### PR TITLE
tests: kernel: pipe: document and namespace pipe tests

### DIFF
--- a/tests/kernel/pipe/pipe_api/src/basic.c
+++ b/tests/kernel/pipe/pipe_api/src/basic.c
@@ -19,7 +19,31 @@ K_PIPE_DEFINE(test_define, 256, 4);
 
 static struct k_pipe pipe;
 
-ZTEST(k_pipe_basic, test_init)
+/**
+ * @brief Pipe (byte stream) API tests
+ * @defgroup tests_kernel_pipe Pipe tests
+ * @ingroup all_tests
+ * @{
+ */
+
+/**
+ * @brief Verify k_pipe_init() opens a pipe for use.
+ *
+ * @details
+ * After k_pipe_init() a pipe must be in the open state, ready for reads and
+ * writes. The test initializes a pipe over a stack buffer and checks the open
+ * flag is set.
+ *
+ * Test steps:
+ * - Initialize a pipe with a backing buffer.
+ * - Verify the pipe's flags indicate it is open.
+ *
+ * Expected result:
+ * - The pipe reports PIPE_FLAG_OPEN.
+ *
+ * @see k_pipe_init()
+ */
+ZTEST(k_pipe_basic, test_pipe_init)
 {
 	uint8_t buffer[10];
 
@@ -27,7 +51,24 @@ ZTEST(k_pipe_basic, test_init)
 	zassert_true(pipe.flags == PIPE_FLAG_OPEN, "Unexpected pipe flags");
 }
 
-ZTEST(k_pipe_basic, test_write_read_one)
+/**
+ * @brief Verify a single byte written to a pipe is read back unchanged.
+ *
+ * @details
+ * The most basic stream round trip: one byte written with k_pipe_write() must be
+ * returned by k_pipe_read() with the same value.
+ *
+ * Test steps:
+ * - Write one byte to an empty pipe (K_NO_WAIT).
+ * - Read one byte back and compare.
+ *
+ * Expected result:
+ * - The byte read equals the byte written.
+ *
+ * @see k_pipe_write()
+ * @see k_pipe_read()
+ */
+ZTEST(k_pipe_basic, test_pipe_write_read_one)
 {
 	uint8_t buffer[10];
 	uint8_t data = 0x55;
@@ -41,7 +82,24 @@ ZTEST(k_pipe_basic, test_write_read_one)
 	zassert_true(read_data == data, "Unexpected data received from pipe");
 }
 
-ZTEST(k_pipe_basic, test_write_read_multiple)
+/**
+ * @brief Verify bytes are read back from a pipe in write (FIFO) order.
+ *
+ * @details
+ * A pipe is a byte stream: multiple bytes written must be read back in the same
+ * order they were written.
+ *
+ * Test steps:
+ * - Write two bytes to the pipe.
+ * - Read two bytes back and verify each matches in order.
+ *
+ * Expected result:
+ * - Bytes are returned in FIFO order.
+ *
+ * @see k_pipe_write()
+ * @see k_pipe_read()
+ */
+ZTEST(k_pipe_basic, test_pipe_write_read_multiple)
 {
 	uint8_t buffer[10];
 	uint8_t data = 0x55;
@@ -56,7 +114,23 @@ ZTEST(k_pipe_basic, test_write_read_multiple)
 	zassert_true(read_data == data, "Unexpected data received from pipe");
 }
 
-ZTEST(k_pipe_basic, test_write_full)
+/**
+ * @brief Verify writing to a full pipe times out with -EAGAIN.
+ *
+ * @details
+ * Once the pipe buffer is full, a write with a finite timeout and no reader must
+ * block for the timeout and then fail with -EAGAIN rather than overrun.
+ *
+ * Test steps:
+ * - Fill the pipe to capacity with a non-blocking write.
+ * - Attempt another write with a finite timeout.
+ *
+ * Expected result:
+ * - The first write stores all bytes; the second returns -EAGAIN.
+ *
+ * @see k_pipe_write()
+ */
+ZTEST(k_pipe_basic, test_pipe_write_full)
 {
 	uint8_t buffer[10];
 	uint8_t data[10];
@@ -68,7 +142,22 @@ ZTEST(k_pipe_basic, test_write_full)
 		"Should not be able to write to full pipe");
 }
 
-ZTEST(k_pipe_basic, test_read_empty)
+/**
+ * @brief Verify reading from an empty pipe times out with -EAGAIN.
+ *
+ * @details
+ * With no data buffered and no writer, a read with a finite timeout must block
+ * for the timeout and then fail with -EAGAIN.
+ *
+ * Test steps:
+ * - Read from an empty pipe with a finite timeout.
+ *
+ * Expected result:
+ * - k_pipe_read() returns -EAGAIN.
+ *
+ * @see k_pipe_read()
+ */
+ZTEST(k_pipe_basic, test_pipe_read_empty)
 {
 	uint8_t buffer[10];
 	uint8_t read_data;
@@ -78,7 +167,24 @@ ZTEST(k_pipe_basic, test_read_empty)
 		"Should not be able to read from empty pipe");
 }
 
-ZTEST(k_pipe_basic, test_read_write_full)
+/**
+ * @brief Verify a full-buffer write/read round trip preserves the data.
+ *
+ * @details
+ * Writing a buffer that exactly fills the pipe and reading it all back must
+ * return the identical byte sequence.
+ *
+ * Test steps:
+ * - Write a buffer of random bytes that fills the pipe.
+ * - Read the same number of bytes back and compare with memcmp.
+ *
+ * Expected result:
+ * - The read buffer is byte-for-byte identical to what was written.
+ *
+ * @see k_pipe_write()
+ * @see k_pipe_read()
+ */
+ZTEST(k_pipe_basic, test_pipe_read_write_full)
 {
 	uint8_t buffer[10];
 	uint8_t input[10];
@@ -94,7 +200,26 @@ ZTEST(k_pipe_basic, test_read_write_full)
 		"Unexpected data received from pipe");
 }
 
-ZTEST(k_pipe_basic, test_read_write_wrapp_around)
+/**
+ * @brief Verify data integrity across a ring-buffer wrap-around.
+ *
+ * @details
+ * The pipe's backing storage is a ring buffer. Partially draining and then
+ * writing more than the remaining contiguous space forces the write/read to wrap
+ * past the end of the buffer; the byte stream must stay correct and in order.
+ *
+ * Test steps:
+ * - Write 8 bytes into a 12-byte pipe and read 5 back.
+ * - Write 8 more bytes (forcing a wrap) and read the remaining 11.
+ * - Verify the byte sequence across the wrap matches what was written.
+ *
+ * Expected result:
+ * - All bytes are returned in order despite the buffer wrap.
+ *
+ * @see k_pipe_write()
+ * @see k_pipe_read()
+ */
+ZTEST(k_pipe_basic, test_pipe_read_write_wrap_around)
 {
 	uint8_t buffer[12];
 	uint8_t input[8];
@@ -119,7 +244,23 @@ ZTEST(k_pipe_basic, test_read_write_wrapp_around)
 		"Unexpected data received from pipe");
 }
 
-ZTEST(k_pipe_basic, test_reset)
+/**
+ * @brief Verify resetting an idle pipe has no side effects.
+ *
+ * @details
+ * k_pipe_reset() on an empty pipe with no waiters must leave the pipe usable;
+ * subsequent writes and reads must still work normally.
+ *
+ * Test steps:
+ * - Reset a freshly initialized, empty pipe.
+ * - Write a byte and read it back.
+ *
+ * Expected result:
+ * - The pipe remains functional after the reset.
+ *
+ * @see k_pipe_reset()
+ */
+ZTEST(k_pipe_basic, test_pipe_reset)
 {
 	uint8_t buffer[10];
 	uint8_t data = 0x55;
@@ -136,7 +277,29 @@ ZTEST(k_pipe_basic, test_reset)
 	zassert_true(read_data == data, "Unexpected data received from pipe");
 }
 
-ZTEST(k_pipe_basic, test_close)
+/**
+ * @brief Verify close blocks writes but lets buffered data drain.
+ *
+ * @details
+ * After k_pipe_close(), new writes must fail with -EPIPE, but data already
+ * buffered must still be readable; once that data is exhausted, reads also
+ * return -EPIPE.
+ *
+ * Test steps:
+ * - Write data into the pipe, then close it.
+ * - Verify a further write returns -EPIPE.
+ * - Read the buffered bytes back (in two reads) and verify their values.
+ * - Verify a read on the now-empty closed pipe returns -EPIPE.
+ *
+ * Expected result:
+ * - Writes fail with -EPIPE; buffered data is drained; empty closed reads
+ *   return -EPIPE.
+ *
+ * @see k_pipe_close()
+ * @see k_pipe_read()
+ * @see k_pipe_write()
+ */
+ZTEST(k_pipe_basic, test_pipe_close)
 {
 	uint8_t buffer[12];
 	uint8_t input[8];
@@ -160,3 +323,7 @@ ZTEST(k_pipe_basic, test_close)
 	zassert_true(k_pipe_read(&pipe, res, 5, K_NO_WAIT) == -EPIPE,
 		"Closed and empty pipe should return -EPIPE");
 }
+
+/**
+ * @}
+ */

--- a/tests/kernel/pipe/pipe_api/src/concurrency.c
+++ b/tests/kernel/pipe/pipe_api/src/concurrency.c
@@ -44,7 +44,30 @@ static void thread_read(void *arg1, void *arg2, void *arg3)
 		K_MSEC(partial_wait_time)) == sizeof(garbage), "Failed to read from pipe");
 }
 
-ZTEST(k_pipe_concurrency, test_close_on_read)
+/**
+ * @addtogroup tests_kernel_pipe
+ * @{
+ */
+
+/**
+ * @brief Verify closing a pipe releases a blocked reader with -EPIPE.
+ *
+ * @details
+ * A reader blocked on an empty pipe must be woken and returned -EPIPE when
+ * another thread closes the pipe, and the pipe must remain closed afterwards.
+ *
+ * Test steps:
+ * - Start a thread that closes the pipe after a short delay.
+ * - Block in k_pipe_read() on the empty pipe.
+ * - Verify the read returns -EPIPE and the open flag is cleared.
+ *
+ * Expected result:
+ * - The blocked read returns -EPIPE and the pipe stays closed.
+ *
+ * @see k_pipe_close()
+ * @see k_pipe_read()
+ */
+ZTEST(k_pipe_concurrency, test_pipe_close_on_read)
 {
 	k_tid_t tid;
 	uint8_t buffer[DUMMY_DATA_SIZE];
@@ -61,7 +84,25 @@ ZTEST(k_pipe_concurrency, test_close_on_read)
 		"Pipe should continue to be closed after all waiters have been released");
 }
 
-ZTEST(k_pipe_concurrency, test_close_on_write)
+/**
+ * @brief Verify closing a pipe releases a blocked writer with -EPIPE.
+ *
+ * @details
+ * A writer blocked on a full pipe must be woken and returned -EPIPE when another
+ * thread closes the pipe, and the pipe must remain closed afterwards.
+ *
+ * Test steps:
+ * - Fill the pipe, then start a thread that closes it after a short delay.
+ * - Block in k_pipe_write() on the full pipe.
+ * - Verify the write returns -EPIPE and the open flag is cleared.
+ *
+ * Expected result:
+ * - The blocked write returns -EPIPE and the pipe stays closed.
+ *
+ * @see k_pipe_close()
+ * @see k_pipe_write()
+ */
+ZTEST(k_pipe_concurrency, test_pipe_close_on_write)
 {
 	k_tid_t tid;
 	uint8_t buffer[DUMMY_DATA_SIZE];
@@ -81,7 +122,26 @@ ZTEST(k_pipe_concurrency, test_close_on_write)
 		"pipe should continue to be closed after all waiters have been released");
 }
 
-ZTEST(k_pipe_concurrency, test_reset_on_read)
+/**
+ * @brief Verify resetting a pipe releases a blocked reader with -ECANCELED.
+ *
+ * @details
+ * Unlike close, k_pipe_reset() cancels in-flight waiters but leaves the pipe
+ * open: a reader blocked on an empty pipe must return -ECANCELED, and afterwards
+ * the reset flag is cleared and the pipe is still open.
+ *
+ * Test steps:
+ * - Start a thread that resets the pipe after a short delay.
+ * - Block in k_pipe_read() on the empty pipe.
+ * - Verify the read returns -ECANCELED and the pipe is still open.
+ *
+ * Expected result:
+ * - The blocked read returns -ECANCELED; the pipe remains open.
+ *
+ * @see k_pipe_reset()
+ * @see k_pipe_read()
+ */
+ZTEST(k_pipe_concurrency, test_pipe_reset_on_read)
 {
 	k_tid_t tid;
 	uint8_t buffer[DUMMY_DATA_SIZE];
@@ -101,7 +161,25 @@ ZTEST(k_pipe_concurrency, test_reset_on_read)
 		"pipe should continue to be open after pipe is reset");
 }
 
-ZTEST(k_pipe_concurrency, test_reset_on_write)
+/**
+ * @brief Verify resetting a pipe releases a blocked writer with -ECANCELED.
+ *
+ * @details
+ * k_pipe_reset() cancels a writer blocked on a full pipe with -ECANCELED while
+ * leaving the pipe open for reuse.
+ *
+ * Test steps:
+ * - Fill the pipe, then start a thread that resets it after a short delay.
+ * - Block in k_pipe_write() on the full pipe.
+ * - Verify the write returns -ECANCELED and the pipe is still open.
+ *
+ * Expected result:
+ * - The blocked write returns -ECANCELED; the pipe remains open.
+ *
+ * @see k_pipe_reset()
+ * @see k_pipe_write()
+ */
+ZTEST(k_pipe_concurrency, test_pipe_reset_on_write)
 {
 	k_tid_t tid;
 	uint8_t buffer[DUMMY_DATA_SIZE];
@@ -123,7 +201,26 @@ ZTEST(k_pipe_concurrency, test_reset_on_write)
 		"pipe should continue to be open after pipe is reset");
 }
 
-ZTEST(k_pipe_concurrency, test_partial_read)
+/**
+ * @brief Verify a reader waiting for more data is satisfied by later writes.
+ *
+ * @details
+ * A reader requesting a full buffer blocks until enough bytes arrive. The test
+ * supplies the data in two partial writes and confirms the reader completes once
+ * the requested amount is available.
+ *
+ * Test steps:
+ * - Start a reader thread requesting DUMMY_DATA_SIZE bytes.
+ * - Write half the bytes, wait, then write the other half.
+ * - Join the reader and confirm it received the full amount.
+ *
+ * Expected result:
+ * - The reader completes after the data is provided across multiple writes.
+ *
+ * @see k_pipe_read()
+ * @see k_pipe_write()
+ */
+ZTEST(k_pipe_concurrency, test_pipe_partial_read)
 {
 	k_tid_t tid;
 	uint8_t buffer[DUMMY_DATA_SIZE];
@@ -142,7 +239,26 @@ ZTEST(k_pipe_concurrency, test_partial_read)
 	k_thread_join(tid, K_FOREVER);
 }
 
-ZTEST(k_pipe_concurrency, test_partial_write)
+/**
+ * @brief Verify a writer waiting for space is satisfied by later reads.
+ *
+ * @details
+ * A writer blocked because the pipe is full must complete once a reader drains
+ * enough space. The test fills the pipe, starts a writer, then frees space with
+ * partial reads and confirms the writer completes.
+ *
+ * Test steps:
+ * - Fill the pipe, then start a writer thread.
+ * - Read half the bytes, wait, then read more to free space.
+ * - Join the writer and confirm it completed.
+ *
+ * Expected result:
+ * - The writer completes once space becomes available.
+ *
+ * @see k_pipe_write()
+ * @see k_pipe_read()
+ */
+ZTEST(k_pipe_concurrency, test_pipe_partial_write)
 {
 	k_tid_t tid;
 	uint8_t buffer[DUMMY_DATA_SIZE];
@@ -182,7 +298,29 @@ static void zero_thread_read_write(void *arg1, void *arg2, void *arg3)
 	      "Failed to write to pipe");
 }
 
-ZTEST(k_pipe_concurrency, test_zero_size_pipe_read_write)
+/**
+ * @brief Verify an unbuffered (zero-size) pipe transfers data thread-to-thread.
+ *
+ * @details
+ * A pipe initialized with no backing buffer has no storage, so a write must
+ * block until a reader is present and copy data directly between threads. The
+ * test wires a worker that reads from one zero-size pipe and writes to another,
+ * and confirms data passes intact in both directions. Skipped when
+ * CONFIG_KERNEL_COHERENCE is set, where unbuffered pipes are unsupported.
+ *
+ * Test steps:
+ * - Initialize two zero-size pipes and start a worker that reads then writes.
+ * - Write into the input pipe and read from the output pipe (both K_FOREVER).
+ * - Verify the data round-trips unchanged and the worker ran both operations.
+ *
+ * Expected result:
+ * - Data is transferred directly between threads and matches end to end.
+ *
+ * @see k_pipe_init()
+ * @see k_pipe_read()
+ * @see k_pipe_write()
+ */
+ZTEST(k_pipe_concurrency, test_pipe_zero_size_read_write)
 {
 	k_tid_t tid;
 	struct k_pipe input_pipe;
@@ -219,3 +357,7 @@ ZTEST(k_pipe_concurrency, test_zero_size_pipe_read_write)
 
 	k_thread_join(tid, K_FOREVER);
 }
+
+/**
+ * @}
+ */

--- a/tests/kernel/pipe/pipe_api/src/stress.c
+++ b/tests/kernel/pipe/pipe_api/src/stress.c
@@ -20,7 +20,29 @@ ZTEST_SUITE(k_pipe_stress, NULL, NULL, NULL, NULL, NULL);
 
 static struct k_pipe pipe;
 
-ZTEST(k_pipe_stress, test_write)
+/**
+ * @addtogroup tests_kernel_pipe
+ * @{
+ */
+
+/**
+ * @brief Stress k_pipe_write() with a large transfer.
+ *
+ * @details
+ * Repeatedly writes until a large payload has been pushed into the pipe,
+ * exercising the write path in bulk and confirming every write makes forward
+ * progress. Elapsed time is logged for reference.
+ *
+ * Test steps:
+ * - Initialize a pipe sized for the payload.
+ * - Write WRITE_LEN bytes, looping until all bytes are accepted.
+ *
+ * Expected result:
+ * - Every write returns a positive count and the full payload is written.
+ *
+ * @see k_pipe_write()
+ */
+ZTEST(k_pipe_stress, test_pipe_write)
 {
 	int rc;
 	const size_t len = WRITE_LEN;
@@ -41,7 +63,24 @@ ZTEST(k_pipe_stress, test_write)
 	LOG_INF("Elapsed cycles: %u\n", end_cycles - start_cycles);
 }
 
-ZTEST(k_pipe_stress, test_read)
+/**
+ * @brief Stress alternating write/read cycles through a pipe.
+ *
+ * @details
+ * Runs many iterations of filling the pipe and draining it, exercising the
+ * read/write paths repeatedly to surface throughput or state-tracking issues.
+ * Elapsed time is logged for reference.
+ *
+ * Test steps:
+ * - For 100 iterations: write READ_LEN bytes (looping) then read them all back.
+ *
+ * Expected result:
+ * - Every read and write makes forward progress across all iterations.
+ *
+ * @see k_pipe_write()
+ * @see k_pipe_read()
+ */
+ZTEST(k_pipe_stress, test_pipe_read)
 {
 	int rc;
 	const size_t len = READ_LEN;
@@ -69,3 +108,7 @@ ZTEST(k_pipe_stress, test_read)
 	end_cycles = k_uptime_get_32();
 	LOG_INF("Elapsed cycles: %u\n", end_cycles - start_cycles);
 }
+
+/**
+ * @}
+ */


### PR DESCRIPTION
The pipe API tests had no documentation - no Doxygen group and no
per-test blocks - and the test names were generic (test_init,
test_write, test_read, test_close, test_reset, test_partial_read, ...),
which is ambiguous in Twister/coverage reports.

Namespace every test with a pipe prefix (test_pipe_*) so the names are
self-describing in reports, and fix the "wrapp" typo while renaming
(test_read_write_wrapp_around -> test_pipe_read_write_wrap_around). The
names are only ZTEST registrations and are referenced nowhere else, so
the rename is self-contained. No test logic changes.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
