### PR TITLE
kernel: tests: document msgq, mbox, lifo, fifo tests

### DIFF
--- a/tests/kernel/fifo/fifo_api/src/main.c
+++ b/tests/kernel/fifo/fifo_api/src/main.c
@@ -7,14 +7,15 @@
 /**
  * @brief Tests for the FIFO kernel object
  *
- * Verify zephyr fifo apis under different context
+ * Verify the Zephyr FIFO APIs across thread and ISR contexts, including data
+ * passing, emptiness queries, cancellation, timeouts and queueing order.
  *
  * - API coverage
- *   -# k_fifo_init K_FIFO_DEFINE
- *   -# k_fifo_put k_fifo_put_list k_fifo_put_slist
- *   -# k_fifo_get *
+ *   -# k_fifo_init() K_FIFO_DEFINE()
+ *   -# k_fifo_put() k_fifo_put_list() k_fifo_put_slist()
+ *   -# k_fifo_get() k_fifo_is_empty() k_fifo_cancel_wait()
  *
- * @defgroup kernel_fifo_tests FIFOs
+ * @defgroup tests_kernel_fifo FIFO tests
  * @ingroup all_tests
  * @{
  * @}

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_cancel.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_cancel.c
@@ -51,15 +51,30 @@ static void tfifo_thread_thread(struct k_fifo *pfifo)
 }
 
 /**
- * @addtogroup kernel_fifo_tests
+ * @addtogroup tests_kernel_fifo
  * @{
  */
 
 /**
- * @brief Test cancel waiting on a FIFO queue.
- * @details This routine causes first thread pending on fifo (if any),
- * to return from k_fifo_get() with NULL value (as if timeout expired).
- * @see k_fifo_init(),k_fifo_get(), k_fifo_cancel_wait()
+ * @brief Verify k_fifo_cancel_wait() wakes a pending getter with NULL.
+ *
+ * @details
+ * A thread blocked in k_fifo_get() with a long timeout must return immediately
+ * with NULL when another thread calls k_fifo_cancel_wait() on that FIFO, rather
+ * than waiting for its own timeout to expire. The test confirms both the NULL
+ * return and that it happened well before the 500 ms get timeout.
+ *
+ * Test steps:
+ * - Start a helper thread that sleeps briefly then calls k_fifo_cancel_wait().
+ * - In the main thread, call k_fifo_get() with a 500 ms timeout and time it.
+ * - Verify the get returned NULL and far sooner than its timeout.
+ * - Repeat for a statically defined FIFO.
+ *
+ * Expected result:
+ * - k_fifo_get() returns NULL promptly due to the cancel, not the timeout.
+ *
+ * @see k_fifo_cancel_wait()
+ * @see k_fifo_get()
  */
 ZTEST(fifo_api_1cpu, test_fifo_cancel_wait)
 {

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
@@ -126,13 +126,34 @@ static void tfifo_is_empty(void *p)
 }
 
 /**
- * @addtogroup kernel_fifo_tests
+ * @addtogroup tests_kernel_fifo
  * @{
  */
 
 /**
- * @brief Test thread to thread data passing via fifo
- * @see k_fifo_init(), k_fifo_put(), k_fifo_get(), k_fifo_put_list()
+ * @brief Verify FIFO data passing between two threads.
+ *
+ * @details
+ * A consumer thread blocks on k_fifo_get() while the main thread enqueues
+ * items via the single, list and slist put APIs. The consumer must receive
+ * every item in FIFO order. The scenario is run against both a k_fifo_init()ed
+ * and a K_FIFO_DEFINE()d FIFO to confirm both initialization paths behave the
+ * same.
+ *
+ * Test steps:
+ * - Create a preemptible consumer thread that drains the FIFO.
+ * - From the main thread, put items using k_fifo_put(), k_fifo_put_list() and
+ *   k_fifo_put_slist().
+ * - Synchronize on a semaphore once the consumer has read all items.
+ * - Repeat for a statically defined FIFO.
+ *
+ * Expected result:
+ * - The consumer dequeues every item in the order it was enqueued.
+ *
+ * @see k_fifo_put()
+ * @see k_fifo_put_list()
+ * @see k_fifo_put_slist()
+ * @see k_fifo_get()
  */
 ZTEST(fifo_api_1cpu, test_fifo_thread2thread)
 {
@@ -145,8 +166,23 @@ ZTEST(fifo_api_1cpu, test_fifo_thread2thread)
 }
 
 /**
- * @brief Test isr to thread data passing via fifo
- * @see k_fifo_init(), k_fifo_put(), k_fifo_get()
+ * @brief Verify FIFO data passing from an ISR to a thread.
+ *
+ * @details
+ * Items are enqueued from interrupt context (via irq_offload()) and dequeued in
+ * thread context, confirming k_fifo_put() is ISR-safe and the thread receives
+ * every item in FIFO order. Run against both an init()ed and a DEFINE()d FIFO.
+ *
+ * Test steps:
+ * - From an ISR, put items into the FIFO and assert it is not empty.
+ * - In thread context, get all items and verify their order.
+ * - Repeat for a statically defined FIFO.
+ *
+ * Expected result:
+ * - The thread dequeues every ISR-enqueued item in order.
+ *
+ * @see k_fifo_put()
+ * @see k_fifo_get()
  */
 ZTEST(fifo_api, test_fifo_thread2isr)
 {
@@ -159,8 +195,23 @@ ZTEST(fifo_api, test_fifo_thread2isr)
 }
 
 /**
- * @brief Test thread to isr data passing via fifo
- * @see k_fifo_init(), k_fifo_put(), k_fifo_get()
+ * @brief Verify FIFO data passing from a thread to an ISR.
+ *
+ * @details
+ * Items are enqueued in thread context and dequeued from interrupt context (via
+ * irq_offload()), confirming k_fifo_get() is ISR-safe and the ISR receives every
+ * item in FIFO order. Run against both an init()ed and a DEFINE()d FIFO.
+ *
+ * Test steps:
+ * - In thread context, put items into the FIFO.
+ * - From an ISR, get all items, verify their order, and assert the FIFO is empty.
+ * - Repeat for a statically defined FIFO.
+ *
+ * Expected result:
+ * - The ISR dequeues every thread-enqueued item in order.
+ *
+ * @see k_fifo_put()
+ * @see k_fifo_get()
  */
 ZTEST(fifo_api, test_fifo_isr2thread)
 {
@@ -173,8 +224,22 @@ ZTEST(fifo_api, test_fifo_isr2thread)
 }
 
 /**
- * @brief Test empty fifo
- * @see k_fifo_init(), k_fifo_is_empty(), k_fifo_put(), k_fifo_get()
+ * @brief Verify k_fifo_is_empty() tracks FIFO contents in thread context.
+ *
+ * @details
+ * k_fifo_is_empty() must report true for a freshly initialized FIFO, false once
+ * items are enqueued, and true again after they are all dequeued. All operations
+ * run in thread context.
+ *
+ * Test steps:
+ * - Initialize a FIFO and assert it is empty.
+ * - Put items and assert it is not empty.
+ * - Get all items and assert it is empty again.
+ *
+ * Expected result:
+ * - k_fifo_is_empty() reflects the presence or absence of queued data.
+ *
+ * @see k_fifo_is_empty()
  */
 ZTEST(fifo_api, test_fifo_is_empty_thread)
 {
@@ -187,8 +252,21 @@ ZTEST(fifo_api, test_fifo_is_empty_thread)
 }
 
 /**
- * @brief Test empty fifo in interrupt context
- * @see k_fifo_init(), fifo_is_empty(), k_fifo_put(), k_fifo_get()
+ * @brief Verify k_fifo_is_empty() tracks FIFO contents in ISR context.
+ *
+ * @details
+ * Same emptiness contract as the thread-context case, but the put/get/is_empty
+ * sequence is executed from interrupt context via irq_offload() to confirm
+ * k_fifo_is_empty() is ISR-safe.
+ *
+ * Test steps:
+ * - Initialize a FIFO and assert it is empty from thread context.
+ * - From an ISR, put items (not empty) then get them all (empty again).
+ *
+ * Expected result:
+ * - k_fifo_is_empty() reports the correct state when called from an ISR.
+ *
+ * @see k_fifo_is_empty()
  */
 ZTEST(fifo_api, test_fifo_is_empty_isr)
 {

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_fail.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_fail.c
@@ -9,15 +9,27 @@
 #define TIMEOUT K_MSEC(100)
 
 /**
- * @addtogroup kernel_fifo_tests
+ * @addtogroup tests_kernel_fifo
  * @{
  */
 
 /**
- * @brief Test FIFO get fail
- * @details test zephyr fifo_get when no data to read,
- * it should returns NULL.
- * @see k_fifo_init(), k_fifo_get()
+ * @brief Verify k_fifo_get() on an empty FIFO returns NULL.
+ *
+ * @details
+ * When no data is queued, k_fifo_get() must return NULL rather than block
+ * indefinitely or return stale data. The contract is checked both with
+ * K_NO_WAIT (immediate) and with a finite timeout that is allowed to expire.
+ *
+ * Test steps:
+ * - Initialize an empty FIFO.
+ * - Call k_fifo_get() with K_NO_WAIT and verify it returns NULL.
+ * - Call k_fifo_get() with a finite timeout and verify it returns NULL.
+ *
+ * Expected result:
+ * - Both k_fifo_get() calls return NULL.
+ *
+ * @see k_fifo_get()
  */
 ZTEST(fifo_api, test_fifo_get_fail)
 {

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_loop.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_loop.c
@@ -77,24 +77,29 @@ static void tfifo_read_write(struct k_fifo *pfifo)
 }
 
 /**
- * @addtogroup kernel_fifo_tests
+ * @addtogroup tests_kernel_fifo
  * @{
  */
 
 /**
- * @brief Verify zephyr fifo continuous read write in loop
+ * @brief Verify FIFO data integrity under repeated cross-context traffic.
  *
  * @details
- * - Test Steps
- *   -# fifo put from main thread
- *   -# fifo read from isr
- *   -# fifo put from isr
- *   -# fifo get from spawn thread
- *   -# loop above steps for LOOPs times
- * - Expected Results
- *   -# fifo data pass correctly and stably across contexts
+ * Stresses the FIFO by cycling data through main-thread, ISR and spawned-thread
+ * contexts many times. Across every iteration the items must be passed without
+ * loss, duplication or reordering, exercising put/get stability when producers
+ * and consumers alternate between thread and interrupt context.
  *
- * @see k_fifo_init(), k_fifo_put(), k_fifo_get()
+ * Test steps:
+ * - For LOOPS iterations: put from the main thread, get then put from an ISR,
+ *   and get from a spawned thread.
+ * - Verify each get returns the expected item.
+ *
+ * Expected result:
+ * - Data passes correctly and in order across all contexts on every iteration.
+ *
+ * @see k_fifo_put()
+ * @see k_fifo_get()
  */
 ZTEST(fifo_api_1cpu, test_fifo_loop)
 {

--- a/tests/kernel/fifo/fifo_timeout/src/main.c
+++ b/tests/kernel/fifo/fifo_timeout/src/main.c
@@ -289,12 +289,26 @@ static void test_thread_timeout_reply_values_wfe(void *p1, void *p2, void *p3)
 }
 
 /**
- * @addtogroup kernel_fifo_tests
+ * @addtogroup tests_kernel_fifo
  * @{
  */
 
 /**
- * @brief Test empty fifo with timeout and K_NO_WAIT
+ * @brief Verify k_fifo_get() timeout behavior on an empty FIFO.
+ *
+ * @details
+ * On an empty FIFO, k_fifo_get() with a finite timeout must block for at least
+ * the requested duration and then return NULL, while K_NO_WAIT must return NULL
+ * immediately. The elapsed time is measured to confirm the full timeout elapsed.
+ *
+ * Test steps:
+ * - Call k_fifo_get() on an empty FIFO with a 10 ms timeout; measure the wait.
+ * - Verify it returned NULL and that at least the timeout elapsed.
+ * - Call k_fifo_get() with K_NO_WAIT and verify it returns NULL.
+ *
+ * Expected result:
+ * - The timed get returns NULL after the timeout; K_NO_WAIT returns NULL at once.
+ *
  * @see k_fifo_get()
  */
 ZTEST(fifo_timeout_1cpu, test_timeout_empty_fifo)
@@ -317,8 +331,22 @@ ZTEST(fifo_timeout_1cpu, test_timeout_empty_fifo)
 }
 
 /**
- * @brief Test non empty fifo with timeout and K_NO_WAIT
- * @see k_fifo_get(), k_fifo_put()
+ * @brief Verify k_fifo_get() returns queued data without waiting.
+ *
+ * @details
+ * When data is already queued, k_fifo_get() must return it immediately
+ * regardless of the timeout argument. The contract is checked with both
+ * K_NO_WAIT and K_FOREVER, neither of which should block when data is present.
+ *
+ * Test steps:
+ * - Put an item, then k_fifo_get() with K_NO_WAIT and verify a non-NULL return.
+ * - Put an item, then k_fifo_get() with K_FOREVER and verify a non-NULL return.
+ *
+ * Expected result:
+ * - Both gets return the queued item without blocking.
+ *
+ * @see k_fifo_get()
+ * @see k_fifo_put()
  */
 ZTEST(fifo_timeout, test_timeout_non_empty_fifo)
 {
@@ -340,14 +368,28 @@ ZTEST(fifo_timeout, test_timeout_non_empty_fifo)
 }
 
 /**
- * @brief Test fifo with timeout and K_NO_WAIT
- * @details In first scenario test fifo with some timeout where child thread
- * puts data on the fifo on time. In second scenario test k_fifo_get with
- * timeout of K_NO_WAIT and the fifo should be filled by the child thread
- * based on the data availability on another fifo. In third scenario test
- * k_fifo_get with timeout of K_FOREVER and the fifo should be filled by
- * the child thread based on the data availability on another fifo.
- * @see k_fifo_get(), k_fifo_put()
+ * @brief Verify k_fifo_get() wakes when a thread supplies data within timeout.
+ *
+ * @details
+ * A getter pending with a timeout must be woken as soon as a producer thread
+ * puts data, returning that data rather than timing out. The test also covers
+ * the K_NO_WAIT and K_FOREVER variants where a child thread conditionally
+ * supplies data based on availability on a second FIFO, exercising the
+ * interaction between blocking gets and producer timing.
+ *
+ * Test steps:
+ * - Pend on k_fifo_get() with a timeout while a child puts data in time; verify
+ *   the data is returned within the timeout window.
+ * - With K_NO_WAIT, verify the child reports no data when the FIFO is empty and
+ *   reports data when it has been pre-filled.
+ * - With K_FOREVER, verify the child retrieves pre-filled data.
+ *
+ * Expected result:
+ * - The getter receives data supplied in time; the reply flags reflect FIFO
+ *   availability for each timeout variant.
+ *
+ * @see k_fifo_get()
+ * @see k_fifo_put()
  */
 ZTEST(fifo_timeout_1cpu, test_timeout_fifo_thread)
 {
@@ -431,10 +473,22 @@ ZTEST(fifo_timeout_1cpu, test_timeout_fifo_thread)
 }
 
 /**
- * @brief Test fifo with different timeouts
- * @details test multiple threads pending on the same fifo with
- * different timeouts
- * @see k_fifo_get(), k_fifo_put()
+ * @brief Verify multiple threads pending on one FIFO time out in timeout order.
+ *
+ * @details
+ * When several threads block on the same FIFO with different timeouts and no
+ * data arrives, each must time out in ascending-timeout order regardless of the
+ * order in which the threads were queued. This validates the timeout queue
+ * ordering for a single FIFO.
+ *
+ * Test steps:
+ * - Spawn several threads that pend on the same FIFO with distinct timeouts.
+ * - Each reports back as it times out; collect the order.
+ *
+ * Expected result:
+ * - Threads time out strictly in increasing-timeout order (within one tick).
+ *
+ * @see k_fifo_get()
  */
 ZTEST(fifo_timeout_1cpu, test_timeout_threads_pend_on_fifo)
 {
@@ -450,10 +504,21 @@ ZTEST(fifo_timeout_1cpu, test_timeout_threads_pend_on_fifo)
 }
 
 /**
- * @brief Test multiple fifos with different timeouts
- * @details test multiple threads pending on different fifos
- * with different timeouts
- * @see k_fifo_get(), k_fifo_put()
+ * @brief Verify threads pending on two FIFOs time out in global timeout order.
+ *
+ * @details
+ * Extends the single-FIFO ordering check to threads distributed across two
+ * FIFOs: timeouts must still fire in ascending-timeout order across the combined
+ * set, confirming the kernel timeout queue is global and not per-FIFO.
+ *
+ * Test steps:
+ * - Spawn threads that pend on two different FIFOs with distinct timeouts.
+ * - Each reports back as it times out; collect the combined order.
+ *
+ * Expected result:
+ * - Threads time out in increasing-timeout order across both FIFOs.
+ *
+ * @see k_fifo_get()
  */
 ZTEST(fifo_timeout_1cpu, test_timeout_threads_pend_on_dual_fifos)
 {
@@ -471,10 +536,25 @@ ZTEST(fifo_timeout_1cpu, test_timeout_threads_pend_on_dual_fifos)
 }
 
 /**
- * @brief Test same fifo with different timeouts
- * @details test multiple threads pending on the same fifo with
- * different timeouts but getting the data in time
- * @see k_fifo_get(), k_fifo_put()
+ * @brief Verify timeout is recomputed when pending getters are satisfied early.
+ *
+ * @details
+ * Several threads pend on the same FIFO with different timeouts; all but the
+ * last receive data in time (their timeouts are aborted), and the last one times
+ * out. This checks that removing satisfied waiters from the timeout queue leaves
+ * the remaining timeout computed correctly, so the final thread still times out
+ * as expected.
+ *
+ * Test steps:
+ * - Spawn threads pending on one FIFO with distinct timeouts.
+ * - Feed data so all but the last get it in queue order; the last gets none.
+ * - Verify each satisfied thread reports in order and the last times out.
+ *
+ * Expected result:
+ * - Satisfied threads report in queue order; the last thread times out cleanly.
+ *
+ * @see k_fifo_get()
+ * @see k_fifo_put()
  */
 ZTEST(fifo_timeout_1cpu, test_timeout_threads_pend_fail_on_fifo)
 {
@@ -491,8 +571,11 @@ ZTEST(fifo_timeout_1cpu, test_timeout_threads_pend_fail_on_fifo)
 }
 
 /**
- * @brief Test fifo init
- * @see k_fifo_init(), k_fifo_put()
+ * @}
+ */
+
+/* Suite setup: initialize the FIFOs used by the tests and pre-fill the scratch
+ * packet pool that the helpers draw from.
  */
 static void *test_timeout_setup(void)
 {
@@ -513,9 +596,6 @@ static void *test_timeout_setup(void)
 
 	return NULL;
 }
-/**
- * @}
- */
 
 ZTEST_SUITE(fifo_timeout, NULL, test_timeout_setup, NULL, NULL, NULL);
 

--- a/tests/kernel/fifo/fifo_usage/src/main.c
+++ b/tests/kernel/fifo/fifo_usage/src/main.c
@@ -128,18 +128,29 @@ static void thread_entry_fn_isr(void *p1, void *p2, void *p3)
 }
 
 /**
- * @addtogroup kernel_fifo_tests
+ * @addtogroup tests_kernel_fifo
  * @{
  */
 
 /**
- * @brief Tests single fifo get and put operation in thread context
- * @details Test Thread enters items into a fifo, starts the Child Thread
- * and waits for a semaphore. Child thread extracts all items from
- * the fifo and enters some items back into the fifo.  Child Thread
- * gives the semaphore for Test Thread to continue.  Once the control
- * is returned back to Test Thread, it extracts all items from the fifo.
- * @see k_fifo_get(), k_fifo_is_empty(), k_fifo_put(), #K_FIFO_DEFINE(x)
+ * @brief Verify producer/consumer exchange over a single FIFO.
+ *
+ * @details
+ * Exercises a hand-off pattern on one FIFO: the main thread fills it, a child
+ * thread drains it and refills it with a second data set, and the main thread
+ * drains that. Confirms items survive a full round trip through both threads in
+ * the correct order.
+ *
+ * Test steps:
+ * - Main thread puts the first data set, then starts the child.
+ * - Child gets all items, puts the second data set, signals via a semaphore.
+ * - Main thread gets all items and verifies they match the second data set.
+ *
+ * Expected result:
+ * - The main thread reads back exactly the items the child enqueued, in order.
+ *
+ * @see k_fifo_put()
+ * @see k_fifo_get()
  */
 ZTEST(fifo_usage, test_single_fifo_play)
 {
@@ -172,13 +183,24 @@ ZTEST(fifo_usage, test_single_fifo_play)
 }
 
 /**
- * @brief Tests dual fifo get and put operation in thread context
- * @details test Thread enters an item into fifo2, starts a Child Thread and
- * extract an item from fifo1 once the item is there.  The Child Thread
- * will extract an item from fifo2 once the item is there and enter
- * an item to fifo1.  The flow of control goes from Test Thread to
- * Child Thread and so forth.
- * @see k_fifo_get(), k_fifo_is_empty(), k_fifo_put(), #K_FIFO_DEFINE(x)
+ * @brief Verify ping-pong synchronization across two FIFOs.
+ *
+ * @details
+ * Two FIFOs are used as a request/response channel: the main thread puts to
+ * fifo2 and blocks getting from fifo1, while the child blocks getting from fifo2
+ * and puts to fifo1. Control alternates between the threads each iteration,
+ * confirming blocking gets correctly serialize the exchange.
+ *
+ * Test steps:
+ * - Start the child, which loops getting from fifo2 and putting to fifo1.
+ * - Main thread loops putting to fifo2 and getting from fifo1.
+ * - Verify each item received on fifo1 matches the expected sequence.
+ *
+ * Expected result:
+ * - The threads alternate correctly and every item is received in order.
+ *
+ * @see k_fifo_put()
+ * @see k_fifo_get()
  */
 ZTEST(fifo_usage, test_dual_fifo_play)
 {
@@ -204,13 +226,24 @@ ZTEST(fifo_usage, test_dual_fifo_play)
 }
 
 /**
- * @brief Tests fifo put and get operation in interrupt context
- * @details Tests the ISR interfaces. Test thread puts items into fifo2
- * and gives control to the Child thread. Child thread gets items from
- * fifo2 and then puts items into fifo1. Child thread gives back control
- * to the Test thread and Test thread gets the items from fifo1.
- * All the Push and Pop operations happen in ISR Context.
- * @see k_fifo_get(), k_fifo_is_empty(), k_fifo_put(), #K_FIFO_DEFINE(x)
+ * @brief Verify producer/consumer exchange with all puts/gets in ISR context.
+ *
+ * @details
+ * Repeats the two-FIFO hand-off pattern but performs every k_fifo_put() and
+ * k_fifo_get() from interrupt context via irq_offload(), confirming the FIFO
+ * operations are ISR-safe end to end when both producer and consumer run in an
+ * ISR.
+ *
+ * Test steps:
+ * - Main thread (from an ISR) puts items into fifo2, then starts the child.
+ * - Child (from ISRs) gets from fifo2 and puts into fifo1, then signals.
+ * - Main thread (from an ISR) gets the items from fifo1.
+ *
+ * Expected result:
+ * - All ISR-context put/get operations succeed and items pass in order.
+ *
+ * @see k_fifo_put()
+ * @see k_fifo_get()
  */
 ZTEST(fifo_usage, test_isr_fifo_play)
 {

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
@@ -84,13 +84,30 @@ static void tlifo_isr_thread(struct k_lifo *plifo)
 }
 
 /**
- * @addtogroup kernel_lifo_tests
+ * @addtogroup tests_kernel_lifo
  * @{
  */
 
 /**
- * @brief test thread to thread data passing via lifo
- * @see k_fifo_init(), k_lifo_put(), k_lifo_get()
+ * @brief Verify LIFO data passing between two threads in LIFO order.
+ *
+ * @details
+ * A consumer thread blocks on k_lifo_get() while the main thread enqueues items,
+ * and must receive them newest-first (LIFO order). Run against both a
+ * k_lifo_init()ed and a K_LIFO_DEFINE()d LIFO to confirm both initialization
+ * paths behave the same.
+ *
+ * Test steps:
+ * - Start a preemptible consumer thread that drains the LIFO.
+ * - From the main thread, put items onto the LIFO.
+ * - Synchronize on a semaphore once the consumer has read all items.
+ * - Repeat for a statically defined LIFO.
+ *
+ * Expected result:
+ * - The consumer dequeues items in reverse insertion order.
+ *
+ * @see k_lifo_put()
+ * @see k_lifo_get()
  */
 ZTEST(lifo_contexts_1cpu, test_lifo_thread2thread)
 {
@@ -103,8 +120,23 @@ ZTEST(lifo_contexts_1cpu, test_lifo_thread2thread)
 }
 
 /**
- * @brief test isr to thread data passing via lifo
- * @see k_fifo_init(), k_lifo_put(), k_lifo_get()
+ * @brief Verify LIFO data passing from an ISR to a thread.
+ *
+ * @details
+ * Items are enqueued from interrupt context (via irq_offload()) and dequeued in
+ * thread context, confirming k_lifo_put() is ISR-safe and the thread receives
+ * the items in LIFO order. Run against both an init()ed and a DEFINE()d LIFO.
+ *
+ * Test steps:
+ * - From an ISR, put items onto the LIFO.
+ * - In thread context, get the items and verify reverse insertion order.
+ * - Repeat for a statically defined LIFO.
+ *
+ * Expected result:
+ * - The thread dequeues every ISR-enqueued item newest-first.
+ *
+ * @see k_lifo_put()
+ * @see k_lifo_get()
  */
 ZTEST(lifo_contexts, test_lifo_thread2isr)
 {
@@ -117,8 +149,23 @@ ZTEST(lifo_contexts, test_lifo_thread2isr)
 }
 
 /**
- * @brief test thread to isr data passing via lifo
- * @see k_fifo_init(), k_lifo_put(), k_lifo_get()
+ * @brief Verify LIFO data passing from a thread to an ISR.
+ *
+ * @details
+ * Items are enqueued in thread context and dequeued from interrupt context (via
+ * irq_offload()), confirming k_lifo_get() is ISR-safe and the ISR receives the
+ * items in LIFO order. Run against both an init()ed and a DEFINE()d LIFO.
+ *
+ * Test steps:
+ * - In thread context, put items onto the LIFO.
+ * - From an ISR, get the items and verify reverse insertion order.
+ * - Repeat for a statically defined LIFO.
+ *
+ * Expected result:
+ * - The ISR dequeues every thread-enqueued item newest-first.
+ *
+ * @see k_lifo_put()
+ * @see k_lifo_get()
  */
 ZTEST(lifo_contexts, test_lifo_isr2thread)
 {

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_fail.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_fail.c
@@ -10,15 +10,27 @@
 
 /*test cases*/
 /**
- * @addtogroup kernel_lifo_tests
+ * @addtogroup tests_kernel_lifo
  * @{
  */
 
 /**
- * @brief Test LIFO get fail
- * @details verify zephyr k_lifo_get, it returns NULL
- * when there is no data to read
- * @see k_lifo_init(), k_lifo_get()
+ * @brief Verify k_lifo_get() on an empty LIFO returns NULL.
+ *
+ * @details
+ * When no data is queued, k_lifo_get() must return NULL rather than block
+ * indefinitely or return stale data. The contract is checked both with
+ * K_NO_WAIT (immediate) and with a finite timeout that is allowed to expire.
+ *
+ * Test steps:
+ * - Initialize an empty LIFO.
+ * - Call k_lifo_get() with K_NO_WAIT and verify it returns NULL.
+ * - Call k_lifo_get() with a finite timeout and verify it returns NULL.
+ *
+ * Expected result:
+ * - Both k_lifo_get() calls return NULL.
+ *
+ * @see k_lifo_get()
  */
 ZTEST(lifo_fail, test_lifo_get_fail)
 {

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_loop.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_loop.c
@@ -77,24 +77,29 @@ static void tlifo_read_write(struct k_lifo *plifo)
 }
 
 /**
- * @addtogroup kernel_lifo_tests
+ * @addtogroup tests_kernel_lifo
  * @{
  */
 
 /**
- * @brief Verify zephyr lifo continuous read write in loop
+ * @brief Verify LIFO data integrity under repeated cross-context traffic.
  *
  * @details
- * - Test Steps
- *   -# lifo put from main thread
- *   -# lifo read from isr
- *   -# lifo put from isr
- *   -# lifo get from spawn thread
- *   -# loop above steps for LOOPs times
- * - Expected Results
- *   -# lifo data pass correctly and stably across contexts
+ * Stresses the LIFO by cycling data through main-thread, ISR and spawned-thread
+ * contexts many times. Across every iteration the items must be passed without
+ * loss, duplication or reordering, exercising put/get stability when producers
+ * and consumers alternate between thread and interrupt context.
  *
- * @see k_lifo_init(), k_fifo_put(), k_fifo_get()
+ * Test steps:
+ * - For LOOPS iterations: put from the main thread, get then put from an ISR,
+ *   and get from a spawned thread.
+ * - Verify each get returns the expected item in LIFO order.
+ *
+ * Expected result:
+ * - Data passes correctly and in LIFO order across all contexts every iteration.
+ *
+ * @see k_lifo_put()
+ * @see k_lifo_get()
  */
 ZTEST(lifo_loop, test_lifo_loop)
 {

--- a/tests/kernel/lifo/lifo_usage/src/main.c
+++ b/tests/kernel/lifo/lifo_usage/src/main.c
@@ -154,24 +154,20 @@ static void thread_entry_wait(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief LIFOs
- * @defgroup kernel_lifo_tests LIFOs
+ * @brief LIFO kernel object tests
+ * @defgroup tests_kernel_lifo LIFO tests
  * @ingroup all_tests
  * @{
  * @}
  */
 
 /**
- * @addtogroup kernel_lifo_tests
+ * @addtogroup tests_kernel_lifo
  * @{
  */
 
-/**
- * @brief try getting data on lifo with special timeout value,
- * return result in lifo
- *
- *
- * @see k_lifo_put()
+/* Helper: get from lifo_timeout[0] with K_NO_WAIT and report whether data was
+ * present back via timeout_order_lifo.
  */
 static void test_thread_timeout_reply_values(void *p1, void *p2, void *p3)
 {
@@ -183,8 +179,8 @@ static void test_thread_timeout_reply_values(void *p1, void *p2, void *p3)
 	k_lifo_put(&timeout_order_lifo, reply_packet);
 }
 
-/**
- * @see k_lifo_put()
+/* Helper: get from lifo_timeout[0] with K_FOREVER and report the result back
+ * via timeout_order_lifo.
  */
 static void test_thread_timeout_reply_values_wfe(void *p1, void *p2, void *p3)
 {
@@ -196,11 +192,7 @@ static void test_thread_timeout_reply_values_wfe(void *p1, void *p2, void *p3)
 	k_lifo_put(&timeout_order_lifo, reply_packet);
 }
 
-/**
- * @brief A thread sleeps then puts data on the lifo
- *
- * @see k_lifo_put()
- */
+/* Helper: sleep for the given timeout then put a packet on the lifo. */
 static void test_thread_put_timeout(void *p1, void *p2, void *p3)
 {
 	uint32_t timeout = *((uint32_t *)p2);
@@ -210,8 +202,22 @@ static void test_thread_put_timeout(void *p1, void *p2, void *p3)
 }
 
 /**
- * @brief Test last in, first out queue using LIFO
- * @see k_sem_init(), k_lifo_put(), k_lifo_get()
+ * @brief Verify k_lifo_get() returns items in last-in first-out order.
+ *
+ * @details
+ * The defining property of a LIFO is that the most recently put item is
+ * retrieved first. Two items are placed on the LIFO around the creation of a
+ * reader thread, which must receive them in reverse insertion order.
+ *
+ * Test steps:
+ * - Put item 0, start a reader thread, then put item 1.
+ * - The reader gets two items and verifies item 1 is returned before item 0.
+ *
+ * Expected result:
+ * - Items are returned newest-first (item 1, then item 0).
+ *
+ * @see k_lifo_put()
+ * @see k_lifo_get()
  */
 ZTEST(lifo_usage, test_lifo_nowait)
 {
@@ -234,8 +240,24 @@ ZTEST(lifo_usage, test_lifo_nowait)
 }
 
 /**
- * @brief Test pending reader in LIFO
- * @see k_lifo_init(), k_lifo_get(), k_lifo_put()
+ * @brief Verify a thread blocked on an empty LIFO is woken by k_lifo_put().
+ *
+ * @details
+ * A reader blocks on an empty LIFO with K_FOREVER. A second thread then puts two
+ * items; the pending reader must be woken with the first item and retrieve the
+ * second on its next get, confirming put correctly hands data to a waiter.
+ *
+ * Test steps:
+ * - Start a thread that puts item 0 then item 1 on the LIFO.
+ * - In the main thread, block in k_lifo_get(K_FOREVER) and verify it returns
+ *   item 0.
+ * - Get again and verify it returns item 1.
+ *
+ * Expected result:
+ * - The pending reader wakes and receives both items in order.
+ *
+ * @see k_lifo_get()
+ * @see k_lifo_put()
  */
 ZTEST(lifo_usage_1cpu, test_lifo_wait)
 {
@@ -262,7 +284,21 @@ ZTEST(lifo_usage_1cpu, test_lifo_wait)
 }
 
 /**
- * @brief Test reading empty LIFO
+ * @brief Verify k_lifo_get() timeout behavior on an empty LIFO.
+ *
+ * @details
+ * On an empty LIFO, k_lifo_get() with a finite timeout must block for at least
+ * the requested duration and then return NULL, while K_NO_WAIT must return NULL
+ * immediately. The elapsed time is measured to confirm the full timeout elapsed.
+ *
+ * Test steps:
+ * - Call k_lifo_get() on an empty LIFO with a 100 ms timeout; measure the wait.
+ * - Verify it returned NULL and that at least the timeout elapsed.
+ * - Call k_lifo_get() with K_NO_WAIT and verify it returns NULL.
+ *
+ * Expected result:
+ * - The timed get returns NULL after the timeout; K_NO_WAIT returns NULL at once.
+ *
  * @see k_lifo_get()
  */
 ZTEST(lifo_usage_1cpu, test_timeout_empty_lifo)
@@ -287,8 +323,22 @@ ZTEST(lifo_usage_1cpu, test_timeout_empty_lifo)
 }
 
 /**
- * @brief Test read and write operation in LIFO with timeout
- * @see k_lifo_put(), k_lifo_get()
+ * @brief Verify k_lifo_get() returns queued data without waiting.
+ *
+ * @details
+ * When an item is already on the LIFO, k_lifo_get() must return it immediately
+ * regardless of the timeout argument. The contract is checked with both
+ * K_NO_WAIT and K_FOREVER, neither of which should block when data is present.
+ *
+ * Test steps:
+ * - Put an item, then k_lifo_get() with K_NO_WAIT and verify a non-NULL return.
+ * - Put an item, then k_lifo_get() with K_FOREVER and verify a non-NULL return.
+ *
+ * Expected result:
+ * - Both gets return the queued item without blocking.
+ *
+ * @see k_lifo_get()
+ * @see k_lifo_put()
  */
 ZTEST(lifo_usage, test_timeout_non_empty_lifo)
 {
@@ -309,8 +359,28 @@ ZTEST(lifo_usage, test_timeout_non_empty_lifo)
 }
 
 /**
- * @brief Test LIFO with timeout
- * @see k_lifo_put(), k_lifo_get()
+ * @brief Verify k_lifo_get() wakes when a thread supplies data within timeout.
+ *
+ * @details
+ * A getter pending with a timeout must be woken as soon as a producer thread
+ * puts data, returning that data rather than timing out. The test also covers
+ * the K_NO_WAIT and K_FOREVER variants where a child thread conditionally
+ * supplies data based on availability on a second LIFO, exercising the
+ * interaction between blocking gets and producer timing.
+ *
+ * Test steps:
+ * - Pend on k_lifo_get() with a timeout while a child puts data in time; verify
+ *   the data is returned within the timeout window.
+ * - With K_NO_WAIT, verify the child reports no data when the LIFO is empty and
+ *   reports data when it has been pre-filled.
+ * - With K_FOREVER, verify the child retrieves pre-filled data.
+ *
+ * Expected result:
+ * - The getter receives data supplied in time; the reply flags reflect LIFO
+ *   availability for each timeout variant.
+ *
+ * @see k_lifo_get()
+ * @see k_lifo_put()
  */
 ZTEST(lifo_usage_1cpu, test_timeout_lifo_thread)
 {
@@ -391,9 +461,8 @@ ZTEST(lifo_usage_1cpu, test_timeout_lifo_thread)
 	put_scratch_packet(scratch_packet);
 }
 
-/**
- * @brief a thread pends on a lifo then times out
- * @see k_lifo_put(), k_lifo_get()
+/* Helper: pend on the thread's lifo with its timeout, confirm it times out with
+ * NULL in range, then report back via timeout_order_lifo.
  */
 void test_thread_pend_and_timeout(void *p1, void *p2, void *p3)
 {
@@ -411,9 +480,21 @@ void test_thread_pend_and_timeout(void *p1, void *p2, void *p3)
 
 
 /**
- * @brief Test multiple pending readers in LIFO
- * @details test multiple threads pending on the same lifo
- * with different timeouts
+ * @brief Verify multiple threads pending on one LIFO time out in timeout order.
+ *
+ * @details
+ * When several threads block on the same LIFO with different timeouts and no
+ * data arrives, each must time out in ascending-timeout order regardless of the
+ * order in which the threads were queued, validating the timeout queue ordering.
+ *
+ * Test steps:
+ * - Spawn several threads that pend on the same LIFO with distinct timeouts.
+ * - Each reports back as it times out; verify the reported order matches the
+ *   ascending-timeout order.
+ *
+ * Expected result:
+ * - Threads time out strictly in increasing-timeout order.
+ *
  * @see k_lifo_get()
  */
 ZTEST(lifo_usage_1cpu, test_timeout_threads_pend_on_lifo)
@@ -430,8 +511,11 @@ ZTEST(lifo_usage_1cpu, test_timeout_threads_pend_on_lifo)
 }
 
 /**
- * @brief Test LIFO initialization with various parameters
- * @see k_lifo_init(), k_lifo_put()
+ * @}
+ */
+
+/* Suite setup helper: initialize the lifos used by the tests, pre-fill the
+ * scratch packet pool, and seed the lifo_data payloads.
  */
 static void test_para_init(void)
 {
@@ -459,11 +543,7 @@ static void test_para_init(void)
 	}
 }
 
-/**
- * @}
- */
-
-/** test case main entry */
+/* Suite setup entry point. */
 void *lifo_usage_setup(void)
 {
 	test_para_init();

--- a/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
+++ b/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
@@ -13,6 +13,8 @@
 #define STACK_SIZE (640 + CONFIG_TEST_EXTRA_STACK_SIZE)
 #endif
 #define MAIL_LEN 64
+/* Receiver buffer smaller than the sent message, to exercise size negotiation. */
+#define TRUNCATED_SIZE 16
 
 /**
  * @brief Tests for the mailbox kernel object
@@ -142,7 +144,19 @@ static void tmbox_put(struct k_mbox *pmbox)
 		k_sem_take(&sync_sema, K_FOREVER);
 		break;
 	case ASYNC_PUT_GET_BLOCK:
-		__fallthrough;
+		/* Offer a full buffer to a receiver that accepts fewer bytes.
+		 * The kernel must truncate the transfer and report the
+		 * negotiated (smaller) size back to the sender.
+		 */
+		mmsg.info = PUT_GET_BUFFER;
+		mmsg.size = sizeof(data[ASYNC_PUT_GET_BLOCK]);
+		mmsg.tx_data = data[ASYNC_PUT_GET_BLOCK];
+		mmsg.tx_target_thread = K_ANY;
+		k_mbox_put(pmbox, &mmsg, K_FOREVER);
+		/**TESTPOINT: sender learns the actually transferred size*/
+		zassert_equal(mmsg.size, TRUNCATED_SIZE,
+			      "sender size not negotiated down: %zu", mmsg.size);
+		break;
 	case INCORRECT_TRANSMIT_TID:
 		mmsg.tx_target_thread = random_tid;
 		zassert_true(k_mbox_put(pmbox,
@@ -285,7 +299,19 @@ static void tmbox_get(struct k_mbox *pmbox)
 			     NULL);
 		break;
 	case ASYNC_PUT_GET_BLOCK:
-		__fallthrough;
+		/* Accept fewer bytes than were sent: the message must be
+		 * truncated to the receiver's size and only that prefix copied.
+		 */
+		mmsg.size = TRUNCATED_SIZE;
+		mmsg.rx_source_thread = K_ANY;
+		zassert_equal(k_mbox_get(pmbox, &mmsg, rxdata, K_FOREVER), 0,
+			      NULL);
+		/**TESTPOINT: message truncated to the receiver's size*/
+		zassert_equal(mmsg.size, TRUNCATED_SIZE,
+			      "receiver size not truncated: %zu", mmsg.size);
+		zassert_true(memcmp(rxdata, data[ASYNC_PUT_GET_BLOCK],
+				    TRUNCATED_SIZE) == 0, NULL);
+		break;
 	case INCORRECT_RECEIVER_TID:
 		mmsg.rx_source_thread = random_tid;
 		zassert_true(k_mbox_get
@@ -612,19 +638,23 @@ ZTEST(mbox_api, test_mbox_async_put_get_buffer)
 }
 
 /**
- * @brief Verify non-matching put and get with K_NO_WAIT return -ENOMSG.
+ * @brief Verify message-size negotiation when the receiver accepts fewer bytes.
  *
  * @details
- * When there is no compatible peer, a non-blocking mailbox operation must fail
- * rather than wait: a put whose target thread is not waiting and a get whose
- * source thread does not match both return -ENOMSG under K_NO_WAIT.
+ * The receiver advertises in rx_msg->size the maximum it will accept. When that
+ * is smaller than the sent message, the kernel must truncate the transfer to the
+ * receiver's size, copy only that prefix, and report the negotiated size back to
+ * both the receiver (rx_msg->size) and the sender (tx_msg->size).
  *
  * Test steps:
- * - Sender puts to a non-waiting target thread with K_NO_WAIT.
- * - Receiver gets from a non-matching source thread with K_NO_WAIT.
+ * - Sender puts a full-length buffer message (MAIL_LEN bytes), K_FOREVER.
+ * - Receiver gets with rx size set to TRUNCATED_SIZE (< MAIL_LEN).
+ * - Check the receiver's size is TRUNCATED_SIZE and the copied prefix matches.
+ * - Check the sender's tx size was updated to TRUNCATED_SIZE after the put.
  *
  * Expected result:
- * - Both operations return -ENOMSG.
+ * - Both sizes are negotiated down to TRUNCATED_SIZE and only that many bytes
+ *   are transferred.
  *
  * @see k_mbox_put()
  * @see k_mbox_get()
@@ -721,6 +751,60 @@ ZTEST(mbox_api, test_mbox_timed_out_mbox_get)
 {
 	info_type = TIMED_OUT_MBOX_GET;
 	tmbox(&mbox);
+}
+
+/* Receiver that performs a single blocking empty get, used to satisfy a
+ * synchronous put within its timeout.
+ */
+static void put_timeout_receiver(void *p1, void *p2, void *p3)
+{
+	struct k_mbox_msg mmsg = {0};
+
+	mmsg.size = 0;
+	mmsg.rx_source_thread = K_ANY;
+	k_mbox_get((struct k_mbox *)p1, &mmsg, NULL, K_FOREVER);
+}
+
+/**
+ * @brief Verify synchronous k_mbox_put() honors its timeout.
+ *
+ * @details
+ * A synchronous put blocks until a receiver takes the message or the timeout
+ * elapses. With no receiver present a finite-timeout put must fail with -EAGAIN;
+ * once a receiver is waiting the same put must succeed.
+ *
+ * Test steps:
+ * - With no receiver, put a message with a finite timeout; expect -EAGAIN.
+ * - Start a receiver thread, then put with a finite timeout; expect success.
+ *
+ * Expected result:
+ * - The put without a receiver returns -EAGAIN; with a receiver it returns 0.
+ *
+ * @see k_mbox_put()
+ */
+ZTEST(mbox_api, test_mbox_put_timeout)
+{
+	struct k_mbox_msg mmsg = {0};
+	k_tid_t rtid;
+
+	/* No receiver waiting: a finite-timeout put must time out. */
+	mmsg.info = PUT_GET_NULL;
+	mmsg.size = 0;
+	mmsg.tx_data = NULL;
+	mmsg.tx_target_thread = K_ANY;
+	zassert_equal(k_mbox_put(&mbox, &mmsg, TIMEOUT), -EAGAIN,
+		      "put with no receiver did not time out");
+
+	/* Receiver waiting: the same finite-timeout put must succeed. */
+	rtid = k_thread_create(&tdata, tstack, STACK_SIZE,
+			       put_timeout_receiver, &mbox, NULL, NULL,
+			       K_PRIO_PREEMPT(0), 0, K_NO_WAIT);
+	mmsg.size = 0;
+	mmsg.tx_data = NULL;
+	mmsg.tx_target_thread = K_ANY;
+	zassert_equal(k_mbox_put(&mbox, &mmsg, TIMEOUT), 0,
+		      "put with a waiting receiver failed");
+	k_thread_abort(rtid);
 }
 
 /**

--- a/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
+++ b/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
@@ -16,7 +16,7 @@
 
 /**
  * @brief Tests for the mailbox kernel object
- * @defgroup kernel_mbox_api Mailbox
+ * @defgroup tests_kernel_mbox Mailbox tests
  * @ingroup all_tests
  * @{
  * @}
@@ -418,13 +418,25 @@ static void tmbox(struct k_mbox *pmbox)
 }
 
 /**
- * @addtogroup kernel_mbox_api
+ * @addtogroup tests_kernel_mbox
  * @{
  */
 
 
 /**
- * @brief Test mailbox initialization
+ * @brief Verify a mailbox can be initialized at runtime.
+ *
+ * @details
+ * k_mbox_init() must prepare a statically allocated k_mbox for use without
+ * error. This is the minimal smoke test that runtime initialization completes.
+ *
+ * Test steps:
+ * - Call k_mbox_init() on a k_mbox instance.
+ *
+ * Expected result:
+ * - The mailbox is initialized and ready for put/get operations.
+ *
+ * @see k_mbox_init()
  */
 ZTEST(mbox_api, test_mbox_kinit)
 {
@@ -433,15 +445,22 @@ ZTEST(mbox_api, test_mbox_kinit)
 }
 
 /**
- * @brief Test mailbox definition
+ * @brief Verify a statically defined mailbox can pass a message.
  *
  * @details
- * - Define a mailbox and verify the mailbox whether as expected
- * - Verify the mailbox can be used
+ * A mailbox created with K_MBOX_DEFINE() must be usable without an explicit
+ * k_mbox_init(). The test exchanges an empty (size 0) message through the
+ * statically defined mailbox between a sender and a receiver thread.
  *
- * @ingroup kernel_mbox_api
+ * Test steps:
+ * - Send and receive an empty message through the K_MBOX_DEFINE()d mailbox.
  *
- * @see k_mbox_init() k_mbox_put() k_mbox_get()
+ * Expected result:
+ * - The message is delivered, confirming the static mailbox is operational.
+ *
+ * @see K_MBOX_DEFINE()
+ * @see k_mbox_put()
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_kdefine)
 {
@@ -452,17 +471,23 @@ ZTEST(mbox_api, test_mbox_kdefine)
 static ZTEST_BMEM char __aligned(4) buffer[8];
 
 /**
- *
- * @brief Test mailbox enhanced capabilities
+ * @brief Verify the same buffer can be sent via a message queue and a mailbox.
  *
  * @details
- * - Define and initialized a message queue and a mailbox
- * - Verify the capability of message queue and mailbox
- * - with same data.
+ * Demonstrates that an identical data buffer can be transported by both kernel
+ * messaging primitives: it is enqueued on a k_msgq and then sent through a
+ * mailbox using the asynchronous buffer path, confirming both accept the data.
  *
- * @ingroup kernel_mbox_api
+ * Test steps:
+ * - Initialize a message queue and put the data buffer on it (K_NO_WAIT).
+ * - Send the same buffer through the mailbox via async put and receive it.
  *
- * @see k_msgq_init() k_msgq_put() k_mbox_async_put() k_mbox_get()
+ * Expected result:
+ * - The message queue put succeeds and the mailbox transfers the same buffer.
+ *
+ * @see k_msgq_put()
+ * @see k_mbox_async_put()
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_enhanced_capabilities)
 {
@@ -480,12 +505,22 @@ ZTEST(mbox_api, test_mbox_enhanced_capabilities)
 }
 
 /**
- * @brief Test that multiple mailboxs can be defined
+ * @brief Verify multiple independent mailboxes can be used.
  *
  * @details
- * - Define multiple mailbox and verify the mailbox whether as
- *   expected
- * - Verify the mailbox can be used
+ * Several mailboxes initialized from the same code must operate independently;
+ * a message sent through each is delivered without interference between them.
+ *
+ * Test steps:
+ * - Initialize three separate mailboxes.
+ * - Send and receive an empty message through each in turn.
+ *
+ * Expected result:
+ * - Each mailbox independently delivers its message.
+ *
+ * @see k_mbox_init()
+ * @see k_mbox_put()
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_define_multi_mbox)
 {
@@ -504,7 +539,22 @@ ZTEST(mbox_api, test_define_multi_mbox)
 }
 
 /**
- * @brief Test case for mailbox put and get operations with null data.
+ * @brief Verify synchronous transfer of an empty mailbox message.
+ *
+ * @details
+ * A zero-length message (no data buffer) must be deliverable: the receiver
+ * observes the message with size 0 and the matching info field, using a
+ * synchronous k_mbox_put() and k_mbox_get().
+ *
+ * Test steps:
+ * - Sender puts a size-0 message targeted at K_ANY.
+ * - Receiver gets from K_ANY and checks the info and that size is 0.
+ *
+ * Expected result:
+ * - The empty message is delivered with size 0 and the expected info value.
+ *
+ * @see k_mbox_put()
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_put_get_null)
 {
@@ -513,8 +563,22 @@ ZTEST(mbox_api, test_mbox_put_get_null)
 }
 
 /**
- * @brief Test case for mailbox put and get operations with buffer.
+ * @brief Verify synchronous transfer of a buffered mailbox message.
  *
+ * @details
+ * A message carrying a data buffer must be delivered intact: the receiver's
+ * info, size and copied payload must match what the sender provided, using
+ * synchronous put/get.
+ *
+ * Test steps:
+ * - Sender puts a buffer message targeted at K_ANY.
+ * - Receiver gets it into a local buffer and compares info, size and contents.
+ *
+ * Expected result:
+ * - The receiver obtains the exact buffer the sender transmitted.
+ *
+ * @see k_mbox_put()
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_put_get_buffer)
 {
@@ -523,8 +587,23 @@ ZTEST(mbox_api, test_mbox_put_get_buffer)
 }
 
 /**
- * @brief Test case for mailbox asynchronous put and get operations with buffer.
+ * @brief Verify asynchronous put delivers a buffered message.
  *
+ * @details
+ * k_mbox_async_put() must hand a buffer message to a receiver without the
+ * sender blocking on delivery; the receiver retrieves the payload with
+ * k_mbox_data_get() and it must match what was sent.
+ *
+ * Test steps:
+ * - Sender async-puts a buffer message and waits on the completion semaphore.
+ * - Receiver gets the message, copies the data via k_mbox_data_get(), compares.
+ *
+ * Expected result:
+ * - The asynchronously sent buffer is received intact.
+ *
+ * @see k_mbox_async_put()
+ * @see k_mbox_data_get()
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_async_put_get_buffer)
 {
@@ -533,8 +612,22 @@ ZTEST(mbox_api, test_mbox_async_put_get_buffer)
 }
 
 /**
- * @brief Test case for mailbox asynchronous put and get operations with block.
+ * @brief Verify non-matching put and get with K_NO_WAIT return -ENOMSG.
  *
+ * @details
+ * When there is no compatible peer, a non-blocking mailbox operation must fail
+ * rather than wait: a put whose target thread is not waiting and a get whose
+ * source thread does not match both return -ENOMSG under K_NO_WAIT.
+ *
+ * Test steps:
+ * - Sender puts to a non-waiting target thread with K_NO_WAIT.
+ * - Receiver gets from a non-matching source thread with K_NO_WAIT.
+ *
+ * Expected result:
+ * - Both operations return -ENOMSG.
+ *
+ * @see k_mbox_put()
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_async_put_get_block)
 {
@@ -543,7 +636,22 @@ ZTEST(mbox_api, test_mbox_async_put_get_block)
 }
 
 /**
- * @brief Test case for mailbox target/source thread buffer operations.
+ * @brief Verify a buffer message directed to a specific thread pair.
+ *
+ * @details
+ * A message may be addressed to a specific target thread and received by
+ * filtering on a specific source thread; the buffer must be delivered on the
+ * matching sender/receiver identities.
+ *
+ * Test steps:
+ * - Sender puts a buffer message with tx_target_thread set to the receiver.
+ * - Receiver gets filtering on rx_source_thread set to the sender.
+ *
+ * Expected result:
+ * - The directed message is delivered and its contents match.
+ *
+ * @see k_mbox_put()
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_target_source_thread_buffer)
 {
@@ -552,7 +660,20 @@ ZTEST(mbox_api, test_mbox_target_source_thread_buffer)
 }
 
 /**
- * @brief Test case for mailbox incorrect receiver thread ID.
+ * @brief Verify a get filtering on a non-matching source returns -ENOMSG.
+ *
+ * @details
+ * A non-blocking get that filters on a specific source thread which has no
+ * pending message must fail with -ENOMSG rather than return another thread's
+ * message.
+ *
+ * Test steps:
+ * - Receiver gets with rx_source_thread set to an unrelated thread, K_NO_WAIT.
+ *
+ * Expected result:
+ * - k_mbox_get() returns -ENOMSG.
+ *
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_incorrect_receiver_tid)
 {
@@ -561,7 +682,19 @@ ZTEST(mbox_api, test_mbox_incorrect_receiver_tid)
 }
 
 /**
- * @brief Test case for mailbox incorrect transmit thread ID.
+ * @brief Verify a put to a non-waiting target returns -ENOMSG.
+ *
+ * @details
+ * A non-blocking put addressed to a specific target thread that is not waiting
+ * to receive must fail with -ENOMSG rather than queue indefinitely.
+ *
+ * Test steps:
+ * - Sender puts with tx_target_thread set to a non-waiting thread, K_NO_WAIT.
+ *
+ * Expected result:
+ * - k_mbox_put() returns -ENOMSG.
+ *
+ * @see k_mbox_put()
  */
 ZTEST(mbox_api, test_mbox_incorrect_transmit_tid)
 {
@@ -570,7 +703,19 @@ ZTEST(mbox_api, test_mbox_incorrect_transmit_tid)
 }
 
 /**
- * @brief Test case for mailbox timed out get operation.
+ * @brief Verify a get with no matching message times out with -EAGAIN.
+ *
+ * @details
+ * A get that filters on a source thread with no pending message and a finite
+ * timeout must block for the timeout and then return -EAGAIN.
+ *
+ * Test steps:
+ * - Receiver gets with a non-matching source thread and a finite timeout.
+ *
+ * Expected result:
+ * - k_mbox_get() returns -EAGAIN after the timeout.
+ *
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_timed_out_mbox_get)
 {
@@ -579,7 +724,22 @@ ZTEST(mbox_api, test_mbox_timed_out_mbox_get)
 }
 
 /**
- * @brief Test case for mailbox message thread ID mismatch.
+ * @brief Verify a message is not delivered to a get with a mismatched tid.
+ *
+ * @details
+ * A message addressed to one thread must not satisfy a get filtering on a
+ * different source thread: the targeted message stays queued (the put times
+ * out) and the mismatched non-blocking get returns -ENOMSG.
+ *
+ * Test steps:
+ * - Sender puts a message targeted at the sender thread with a finite timeout.
+ * - Receiver gets filtering on an unrelated source with K_NO_WAIT.
+ *
+ * Expected result:
+ * - The get returns -ENOMSG; the mismatched message is not delivered.
+ *
+ * @see k_mbox_put()
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_msg_tid_mismatch)
 {
@@ -588,7 +748,20 @@ ZTEST(mbox_api, test_mbox_msg_tid_mismatch)
 }
 
 /**
- * @brief Test case for mailbox dispose size 0 message.
+ * @brief Verify a received message can be disposed by requesting size 0.
+ *
+ * @details
+ * A receiver may discard a message's data by performing a get with a receive
+ * size of 0, which completes the transfer without copying the payload.
+ *
+ * Test steps:
+ * - Sender puts a buffer message.
+ * - Receiver gets it with size 0 to dispose of the data.
+ *
+ * Expected result:
+ * - The get succeeds (returns 0) and the message is consumed without copying.
+ *
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_dispose_size_0_msg)
 {
@@ -597,7 +770,23 @@ ZTEST(mbox_api, test_mbox_dispose_size_0_msg)
 }
 
 /**
- * @brief Test case for mailbox asynchronous put to waiting get operation.
+ * @brief Verify an async put completes a get that is already waiting.
+ *
+ * @details
+ * When a receiver is already blocked in k_mbox_get(), a later
+ * k_mbox_async_put() must wake it and deliver the message. A helper thread
+ * releases the semaphore that gates the async put so it happens after the get
+ * is pending.
+ *
+ * Test steps:
+ * - Receiver blocks in k_mbox_get() (K_FOREVER) for a K_ANY source.
+ * - A helper releases the semaphore so the sender performs an async put.
+ *
+ * Expected result:
+ * - The waiting get completes successfully once the async put runs.
+ *
+ * @see k_mbox_async_put()
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_async_put_to_waiting_get)
 {
@@ -606,7 +795,23 @@ ZTEST(mbox_api, test_mbox_async_put_to_waiting_get)
 }
 
 /**
- * @brief Test case for mailbox get waiting put with incorrect thread ID.
+ * @brief Verify a waiting get is not satisfied by an async put to another tid.
+ *
+ * @details
+ * A get blocked on a specific source thread must not be completed by an async
+ * put addressed to a different thread: the get times out with -EAGAIN, and a
+ * follow-up get for K_ANY then drains the stranded message.
+ *
+ * Test steps:
+ * - Receiver waits in k_mbox_get() filtering on a specific source with a finite
+ *   timeout while an async put targets a different (random) thread.
+ * - Verify the get returns -EAGAIN, then clean up with a K_ANY get.
+ *
+ * Expected result:
+ * - The filtered get times out (-EAGAIN); the message is retrievable via K_ANY.
+ *
+ * @see k_mbox_async_put()
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_get_waiting_put_incorrect_tid)
 {
@@ -615,7 +820,22 @@ ZTEST(mbox_api, test_mbox_get_waiting_put_incorrect_tid)
 }
 
 /**
- * @brief Test case for mailbox asynchronous multiple put operation.
+ * @brief Verify multiple queued async puts are all delivered.
+ *
+ * @details
+ * Several k_mbox_async_put() calls with different target threads queue multiple
+ * messages; the receiver must be able to retrieve them, including selecting a
+ * message by matching source thread.
+ *
+ * Test steps:
+ * - Issue multiple async puts with varying target threads (K_ANY and specific).
+ * - Receiver gets the messages, including one filtered by source thread.
+ *
+ * Expected result:
+ * - All queued messages are retrieved successfully.
+ *
+ * @see k_mbox_async_put()
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_async_multiple_put)
 {
@@ -624,7 +844,23 @@ ZTEST(mbox_api, test_mbox_async_multiple_put)
 }
 
 /**
- * @brief Test case for mailbox multiple waiting get operation.
+ * @brief Verify messages are routed among multiple waiting receivers by tid.
+ *
+ * @details
+ * With several receivers blocked on the same mailbox using different source
+ * filters (K_ANY and specific threads), each put message must be delivered to a
+ * compatible waiting receiver, exercising tid-based routing under contention.
+ *
+ * Test steps:
+ * - Start five threads that each wait in k_mbox_get() with different source
+ *   filters.
+ * - Put several messages targeted at K_ANY and specific threads.
+ *
+ * Expected result:
+ * - Every waiting receiver obtains a message matching its source filter.
+ *
+ * @see k_mbox_put()
+ * @see k_mbox_get()
  */
 ZTEST(mbox_api, test_mbox_multiple_waiting_get)
 {
@@ -637,6 +873,11 @@ ZTEST(mbox_api, test_mbox_multiple_waiting_get)
 	}
 }
 
+/**
+ * @}
+ */
+
+/* Suite setup: create the semaphores and the shared mailbox used by the tests. */
 void *setup_mbox_api(void)
 {
 	k_sem_init(&end_sema, 0, 1);
@@ -645,9 +886,5 @@ void *setup_mbox_api(void)
 
 	return NULL;
 }
-
-/**
- * @}
- */
 
 ZTEST_SUITE(mbox_api, NULL, setup_mbox_api, NULL, NULL, NULL);

--- a/tests/kernel/mbox/mbox_usage/src/main.c
+++ b/tests/kernel/mbox/mbox_usage/src/main.c
@@ -90,7 +90,29 @@ static void test_send(void *p1, void *p2, void *p3)
 	msg_sender((struct k_mbox *)p1, K_NO_WAIT);
 }
 
-/* Receive message from any thread with no wait */
+/**
+ * @addtogroup tests_kernel_mbox
+ * @{
+ */
+
+/**
+ * @brief Verify non-blocking receive fails and a timed receive gets a message.
+ *
+ * @details
+ * A k_mbox_get() with K_NO_WAIT on an empty mailbox must not succeed, while a
+ * get with a finite timeout receives a message that a sender thread provides in
+ * time. Confirms the no-wait versus timed receive semantics in a usage scenario.
+ *
+ * Test steps:
+ * - Receive from K_ANY with K_NO_WAIT on an empty mailbox; expect failure.
+ * - Start a sender thread, then receive with a short timeout.
+ *
+ * Expected result:
+ * - The K_NO_WAIT get fails; the timed get receives the sender's message.
+ *
+ * @see k_mbox_get()
+ * @see k_mbox_put()
+ */
 ZTEST(mbox_usage, test_msg_receiver)
 {
 	static k_tid_t tid;
@@ -112,7 +134,24 @@ static void test_send_un(void *p1, void *p2, void *p3)
 	msg_sender((struct k_mbox *)p1, K_FOREVER);
 }
 
-/* Receive message from thread tid1 */
+/**
+ * @brief Verify a blocking receive from a specific source thread.
+ *
+ * @details
+ * A receiver blocking with K_FOREVER and filtering on a specific sender thread
+ * must receive that thread's message once it is sent, exercising directed,
+ * unbounded-wait delivery.
+ *
+ * Test steps:
+ * - Start a sender thread that puts a message with K_FOREVER.
+ * - Receive filtering on that sender's tid with K_FOREVER.
+ *
+ * Expected result:
+ * - The receiver obtains the message from the specified sender.
+ *
+ * @see k_mbox_get()
+ * @see k_mbox_put()
+ */
 ZTEST(mbox_usage, test_msg_receiver_unlimited)
 {
 	info_type = PUT_GET_NULL;
@@ -160,6 +199,26 @@ static void thread_high_prio(void *p1, void *p2, void *p3)
 	k_sem_give(&sync_sema);
 }
 
+/**
+ * @brief Verify messages are delivered to multiple waiting receiver threads.
+ *
+ * @details
+ * Two receiver threads of different priority block on the same mailbox, then two
+ * messages are put. Each message must be delivered to a waiting receiver, with
+ * the higher-priority thread served first, and the payloads must match.
+ *
+ * Test steps:
+ * - Start a low- and a high-priority receiver, each blocking on the mailbox.
+ * - Put two messages targeted at K_ANY.
+ * - Synchronize on a semaphore after both receivers complete.
+ *
+ * Expected result:
+ * - Both receivers obtain a message; the high-priority thread receives first and
+ *   each payload matches what was sent.
+ *
+ * @see k_mbox_put()
+ * @see k_mbox_get()
+ */
 ZTEST(mbox_usage_1cpu, test_multi_thread_send_get)
 {
 	static k_tid_t low_prio, high_prio;
@@ -192,6 +251,10 @@ ZTEST(mbox_usage_1cpu, test_multi_thread_send_get)
 	k_thread_abort(low_prio);
 	k_thread_abort(high_prio);
 }
+
+/**
+ * @}
+ */
 
 void *setup_mbox_usage(void)
 {

--- a/tests/kernel/msgq/msgq_api/src/main.c
+++ b/tests/kernel/msgq/msgq_api/src/main.c
@@ -5,7 +5,8 @@
  */
 
 /**
- * @defgroup kernel_message_queue_tests Message Queue
+ * @brief Message queue tests
+ * @defgroup tests_kernel_msgq Message queue tests
  * @ingroup all_tests
  * @{
  * @}

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_attrs.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_attrs.c
@@ -37,14 +37,27 @@ static void attrs_get(struct k_msgq *q)
 }
 
 /**
- * @addtogroup kernel_message_queue_tests
+ * @addtogroup tests_kernel_msgq
  * @{
  */
 
 /**
- * @brief Test basic attributes of a message queue
+ * @brief Verify k_msgq_get_attrs() reports the used-message count.
  *
- * @see  k_msgq_get_attrs()
+ * @details
+ * k_msgq_get_attrs() must reflect the live occupancy of the queue. The test
+ * reads the attributes when empty, after filling the queue to capacity, and
+ * again after draining it, confirming used_msgs tracks each transition.
+ *
+ * Test steps:
+ * - Get attributes of an empty queue and verify used_msgs is 0.
+ * - Fill the queue and verify used_msgs equals the queue length.
+ * - Drain the queue and verify used_msgs is 0 again.
+ *
+ * Expected result:
+ * - used_msgs reports 0, full, then 0 as messages are added and removed.
+ *
+ * @see k_msgq_get_attrs()
  */
 ZTEST(msgq_api, test_msgq_attrs_get)
 {
@@ -55,9 +68,22 @@ ZTEST(msgq_api, test_msgq_attrs_get)
 #ifdef CONFIG_USERSPACE
 
 /**
- * @brief Test basic attributes of a message queue
+ * @brief Verify k_msgq_get_attrs() from user mode on an allocated queue.
  *
- * @see  k_msgq_get_attrs()
+ * @details
+ * Same used-message accounting as test_msgq_attrs_get(), but exercised from a
+ * user-mode thread on a queue created with k_msgq_alloc_init(), confirming the
+ * attribute query works under userspace with a dynamically allocated queue.
+ *
+ * Test steps:
+ * - Allocate and alloc-init a message queue as a user thread.
+ * - Verify used_msgs is 0, then full, then 0 across fill/drain.
+ *
+ * Expected result:
+ * - used_msgs is reported correctly from user mode.
+ *
+ * @see k_msgq_get_attrs()
+ * @see k_msgq_alloc_init()
  */
 ZTEST_USER(msgq_api, test_msgq_user_attrs_get)
 {

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
@@ -265,13 +265,29 @@ static void prepend_full_entry(void *p1, void *p2, void *p3)
 }
 
 /**
- * @addtogroup kernel_message_queue_tests
+ * @addtogroup tests_kernel_msgq
  * @{
  */
 
 /**
- * @brief Test thread to thread data passing via message queue
- * @see k_msgq_init(), k_msgq_get(), k_msgq_put(), k_msgq_purge()
+ * @brief Verify FIFO data passing through a message queue between two threads.
+ *
+ * @details
+ * A producer fills the queue and a consumer thread drains it; messages must be
+ * delivered in FIFO order and the occupancy counters (num_free/num_used) and
+ * k_msgq_peek() must track the contents throughout. Run against both a
+ * k_msgq_init()ed and a K_MSGQ_DEFINE()d queue.
+ *
+ * Test steps:
+ * - Producer puts MSGQ_LEN messages, checking peek and free/used counts.
+ * - A consumer thread gets them all and verifies FIFO order.
+ * - Purge the queue and confirm it is empty.
+ *
+ * Expected result:
+ * - All messages are received in order and the counters stay consistent.
+ *
+ * @see k_msgq_put()
+ * @see k_msgq_get()
  */
 ZTEST(msgq_api_1cpu, test_msgq_thread)
 {
@@ -287,8 +303,24 @@ ZTEST(msgq_api_1cpu, test_msgq_thread)
 }
 
 /**
- * @brief Test thread to thread data passing via message queue
- * @see k_msgq_init(), k_msgq_get(), k_msgq_put(), k_msgq_purge()
+ * @brief Verify the ring buffer wraps correctly across put/get cycles.
+ *
+ * @details
+ * After messages have been consumed, new puts must reuse freed slots and the
+ * internal write pointer must advance (wrap) rather than reset to the buffer
+ * start. A blocked consumer and interleaved puts exercise the wrap, and the test
+ * asserts the write pointer did not return to the buffer start.
+ *
+ * Test steps:
+ * - Initialize a length-2 queue and put one message.
+ * - Start a consumer that gets two messages, then put the second message.
+ * - After the exchange, verify the write pointer is not at buffer_start.
+ *
+ * Expected result:
+ * - Messages pass correctly and the write pointer wraps within the ring buffer.
+ *
+ * @see k_msgq_put()
+ * @see k_msgq_get()
  */
 ZTEST(msgq_api, test_msgq_thread_overflow)
 {
@@ -312,8 +344,23 @@ ZTEST(msgq_api, test_msgq_thread_overflow)
 
 #ifdef CONFIG_USERSPACE
 /**
- * @brief Test user thread to kernel thread data passing via message queue
- * @see k_msgq_alloc_init(), k_msgq_get(), k_msgq_put(), k_msgq_purge()
+ * @brief Verify thread-to-thread message passing from user mode.
+ *
+ * @details
+ * Same FIFO data-passing contract as test_msgq_thread(), exercised from a
+ * user-mode thread on a queue created with k_msgq_alloc_init(), confirming the
+ * put/get/purge flow works under userspace.
+ *
+ * Test steps:
+ * - Allocate and alloc-init a queue as a user thread.
+ * - Run the producer/consumer data-passing sequence and purge.
+ *
+ * Expected result:
+ * - Messages pass in order from user mode.
+ *
+ * @see k_msgq_alloc_init()
+ * @see k_msgq_put()
+ * @see k_msgq_get()
  */
 ZTEST_USER(msgq_api, test_msgq_user_thread)
 {
@@ -330,8 +377,23 @@ ZTEST_USER(msgq_api, test_msgq_user_thread)
 }
 
 /**
- * @brief Test thread to thread data passing via message queue
- * @see k_msgq_alloc_init(), k_msgq_get(), k_msgq_put(), k_msgq_purge()
+ * @brief Verify ring-buffer wrap from user mode.
+ *
+ * @details
+ * User-mode counterpart of test_msgq_thread_overflow(): on a length-1 queue
+ * created with k_msgq_alloc_init(), interleaved puts and gets must reuse freed
+ * slots correctly from userspace.
+ *
+ * Test steps:
+ * - Allocate and alloc-init a length-1 queue as a user thread.
+ * - Run the overflow put/get sequence with a blocked consumer.
+ *
+ * Expected result:
+ * - Messages pass correctly with buffer wrap from user mode.
+ *
+ * @see k_msgq_alloc_init()
+ * @see k_msgq_put()
+ * @see k_msgq_get()
  */
 ZTEST_USER(msgq_api, test_msgq_user_thread_overflow)
 {
@@ -349,8 +411,22 @@ ZTEST_USER(msgq_api, test_msgq_user_thread_overflow)
 #endif /* CONFIG_USERSPACE */
 
 /**
- * @brief Test thread to isr data passing via message queue
- * @see k_msgq_init(), k_msgq_get(), k_msgq_put(), k_msgq_purge()
+ * @brief Verify message passing from an ISR to a thread.
+ *
+ * @details
+ * Messages enqueued from interrupt context (via irq_offload()) must be retrieved
+ * in thread context in FIFO order, confirming k_msgq_put() is ISR-safe. Run
+ * against both an init()ed and a K_MSGQ_DEFINE()d queue.
+ *
+ * Test steps:
+ * - From an ISR, put MSGQ_LEN messages into the queue.
+ * - In thread context, get them all and verify FIFO order, then purge.
+ *
+ * Expected result:
+ * - The thread receives every ISR-enqueued message in order.
+ *
+ * @see k_msgq_put()
+ * @see k_msgq_get()
  */
 ZTEST(msgq_api, test_msgq_isr)
 {
@@ -364,8 +440,23 @@ ZTEST(msgq_api, test_msgq_isr)
 }
 
 /**
- * @brief Test pending writer in msgq
- * @see k_msgq_init(), k_msgq_get(), k_msgq_put(), k_msgq_purge()
+ * @brief Verify a writer pending on a full queue is served when space frees.
+ *
+ * @details
+ * On a length-1 queue, a writer that blocks because the queue is full must be
+ * unblocked and complete its put once a reader removes a message, passing the
+ * data through to the reader.
+ *
+ * Test steps:
+ * - Fill a length-1 queue, then start a writer that pends on a put.
+ * - Start a reader that drains the queue.
+ * - Confirm the pending put completes and the data is delivered, then purge.
+ *
+ * Expected result:
+ * - The blocked writer is woken and its message reaches the reader.
+ *
+ * @see k_msgq_put()
+ * @see k_msgq_get()
  */
 ZTEST(msgq_api_1cpu, test_msgq_pend_thread)
 {
@@ -379,10 +470,23 @@ ZTEST(msgq_api_1cpu, test_msgq_pend_thread)
 }
 
 /**
- * @brief Test k_msgq_alloc_init()
- * @details Initialization and buffer allocation for msgq from resource
- * pool with various parameters
- * @see k_msgq_alloc_init(), k_msgq_cleanup()
+ * @brief Verify k_msgq_alloc_init() allocation success and failure paths.
+ *
+ * @details
+ * k_msgq_alloc_init() draws its buffer from the thread's resource pool. It must
+ * succeed for a request the pool can satisfy, return -ENOMEM when the requested
+ * buffer exceeds the pool, and -EINVAL when the message size would overflow.
+ *
+ * Test steps:
+ * - Alloc-init a queue that fits the pool and use it, then clean it up.
+ * - Request a buffer larger than the pool and expect -ENOMEM.
+ * - Request an overflowing message size and expect -EINVAL.
+ *
+ * Expected result:
+ * - Success for a valid request; -ENOMEM and -EINVAL for the failing requests.
+ *
+ * @see k_msgq_alloc_init()
+ * @see k_msgq_cleanup()
  */
 ZTEST(msgq_api, test_msgq_alloc)
 {
@@ -403,15 +507,25 @@ ZTEST(msgq_api, test_msgq_alloc)
 }
 
 /**
- * @brief Get message from an empty queue
+ * @brief Verify get-from-empty timeout behavior and cleanup-while-pending.
  *
  * @details
- * - A thread get message from an empty message queue will get a -ENOMSG if
- *   timeout is set to K_NO_WAIT
- * - A thread get message from an empty message queue will be blocked if timeout
- *   is set to a positive value or K_FOREVER
+ * A get on an empty queue must return -ENOMSG for K_NO_WAIT, -EAGAIN after a
+ * finite timeout, and block under K_FOREVER until a put arrives. While a thread
+ * is pending on the queue, k_msgq_cleanup() must refuse with -EBUSY.
+ *
+ * Test steps:
+ * - Start a thread that gets from an empty queue with K_NO_WAIT (-ENOMSG),
+ *   a finite timeout (-EAGAIN), then blocks on K_FOREVER.
+ * - While it is pending, call k_msgq_cleanup() and expect -EBUSY.
+ * - Put a message to wake the pending getter.
+ *
+ * Expected result:
+ * - The get returns -ENOMSG/-EAGAIN as appropriate, cleanup returns -EBUSY, and
+ *   the K_FOREVER get completes once a message is put.
  *
  * @see k_msgq_get()
+ * @see k_msgq_cleanup()
  */
 ZTEST(msgq_api_1cpu, test_msgq_empty)
 {
@@ -443,13 +557,19 @@ ZTEST(msgq_api_1cpu, test_msgq_empty)
 }
 
 /**
- * @brief Put message to a full queue
+ * @brief Verify put-to-full timeout behavior.
  *
  * @details
- * - A thread put message to a full message queue will get a -ENOMSG if
- *   timeout is set to K_NO_WAIT
- * - A thread put message to a full message queue will be blocked if timeout
- *   is set to a positive value or K_FOREVER
+ * A put on a full queue must return -ENOMSG for K_NO_WAIT, -EAGAIN after a
+ * finite timeout, and block under K_FOREVER until space becomes available.
+ *
+ * Test steps:
+ * - Fill a length-1 queue, then start a thread that puts with K_NO_WAIT
+ *   (-ENOMSG), a finite timeout (-EAGAIN), then blocks on K_FOREVER.
+ * - Confirm the thread is pending after the non-blocking attempts.
+ *
+ * Expected result:
+ * - The put returns -ENOMSG/-EAGAIN as appropriate and blocks under K_FOREVER.
  *
  * @see k_msgq_put()
  */
@@ -475,14 +595,23 @@ ZTEST(msgq_api_1cpu, test_msgq_full)
 }
 
 /**
- * @brief Put a message to a full queue for behavior test
+ * @brief Verify message ordering when a writer pends on a full queue.
  *
  * @details
- * - Thread A put message to a full message queue and go to sleep
- * Thread B put a new message to the queue then pending on it.
- * - Thread A get all messages from message queue and check the behavior.
+ * With a full length-2 queue, a thread attempting another put (or put_front)
+ * blocks; once the main thread drains the queue, the messages must come out in
+ * the expected order, validating that pending writers do not corrupt ordering.
  *
- * @see k_msgq_put(), k_msgq_put_front()
+ * Test steps:
+ * - Fill a length-2 queue (using put and put_front).
+ * - Start a thread that attempts a further prepend/put and pends.
+ * - Drain the queue and verify the messages are returned in the expected order.
+ *
+ * Expected result:
+ * - Messages are dequeued in the correct order despite the pending writer.
+ *
+ * @see k_msgq_put()
+ * @see k_msgq_put_front()
  */
 ZTEST(msgq_api_1cpu, test_msgq_thread_pending)
 {

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
@@ -286,7 +286,12 @@ static void prepend_full_entry(void *p1, void *p2, void *p3)
  * Expected result:
  * - All messages are received in order and the counters stay consistent.
  *
+ * @note The kernel.message_queue.put_front scenario builds this with
+ *       CONFIG_TEST_MSGQ_PUT_FRONT=y, exercising k_msgq_put_front() in place of
+ *       k_msgq_put() and checking the resulting prepend (LIFO) ordering.
+ *
  * @see k_msgq_put()
+ * @see k_msgq_put_front()
  * @see k_msgq_get()
  */
 ZTEST(msgq_api_1cpu, test_msgq_thread)
@@ -425,7 +430,12 @@ ZTEST_USER(msgq_api, test_msgq_user_thread_overflow)
  * Expected result:
  * - The thread receives every ISR-enqueued message in order.
  *
+ * @note The kernel.message_queue.put_front scenario builds this with
+ *       CONFIG_TEST_MSGQ_PUT_FRONT=y, so the ISR enqueues via k_msgq_put_front()
+ *       and the thread checks the prepend (LIFO) ordering.
+ *
  * @see k_msgq_put()
+ * @see k_msgq_put_front()
  * @see k_msgq_get()
  */
 ZTEST(msgq_api, test_msgq_isr)
@@ -455,7 +465,12 @@ ZTEST(msgq_api, test_msgq_isr)
  * Expected result:
  * - The blocked writer is woken and its message reaches the reader.
  *
+ * @note Under the kernel.message_queue.put_front scenario
+ *       (CONFIG_TEST_MSGQ_PUT_FRONT=y) the writer uses k_msgq_put_front(), which
+ *       does not block: on a full queue it returns -ENOMSG instead of pending.
+ *
  * @see k_msgq_put()
+ * @see k_msgq_put_front()
  * @see k_msgq_get()
  */
 ZTEST(msgq_api_1cpu, test_msgq_pend_thread)
@@ -609,6 +624,11 @@ ZTEST(msgq_api_1cpu, test_msgq_full)
  *
  * Expected result:
  * - Messages are dequeued in the correct order despite the pending writer.
+ *
+ * @note The kernel.message_queue.put_front scenario
+ *       (CONFIG_TEST_MSGQ_PUT_FRONT=y) fills the queue and prepends via
+ *       k_msgq_put_front(), checking that a full-queue prepend returns -ENOMSG
+ *       and that the front-inserted message is dequeued first.
  *
  * @see k_msgq_put()
  * @see k_msgq_put_front()

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_fail.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_fail.c
@@ -40,13 +40,25 @@ static void get_fail(struct k_msgq *q)
 }
 
 /**
- * @addtogroup kernel_message_queue_tests
+ * @addtogroup tests_kernel_msgq
  * @{
  */
 
 /**
- * @brief Test returned error code during writing in msgq
- * @see k_msgq_init()
+ * @brief Verify k_msgq_put() error codes when the queue is full.
+ *
+ * @details
+ * Once a queue is full, a non-blocking put must return -ENOMSG and a put with a
+ * finite timeout must return -EAGAIN after the timeout elapses.
+ *
+ * Test steps:
+ * - Fill the queue, then put with K_NO_WAIT and expect -ENOMSG.
+ * - Put with a finite timeout and expect -EAGAIN.
+ *
+ * Expected result:
+ * - k_msgq_put() returns -ENOMSG (no wait) and -EAGAIN (timeout) when full.
+ *
+ * @see k_msgq_put()
  */
 ZTEST(msgq_api_1cpu, test_msgq_put_fail)
 {
@@ -56,7 +68,21 @@ ZTEST(msgq_api_1cpu, test_msgq_put_fail)
 
 #ifdef CONFIG_USERSPACE
 /**
- * @brief Test returned error code during writing in msgq
+ * @brief Verify k_msgq_put() full-queue error codes from user mode.
+ *
+ * @details
+ * User-mode counterpart of test_msgq_put_fail() on a queue created with
+ * k_msgq_alloc_init(): a full-queue put must return -ENOMSG (no wait) and
+ * -EAGAIN (timeout).
+ *
+ * Test steps:
+ * - Allocate and alloc-init a queue as a user thread and fill it.
+ * - Put with K_NO_WAIT (-ENOMSG) and with a finite timeout (-EAGAIN).
+ *
+ * Expected result:
+ * - The error codes match the supervisor case from user mode.
+ *
+ * @see k_msgq_put()
  * @see k_msgq_alloc_init()
  */
 ZTEST_USER(msgq_api, test_msgq_user_put_fail)
@@ -71,8 +97,20 @@ ZTEST_USER(msgq_api, test_msgq_user_put_fail)
 #endif /* CONFIG_USERSPACE */
 
 /**
- * @brief Test returned error code during reading from msgq
- * @see k_msgq_init(), k_msgq_put()
+ * @brief Verify k_msgq_get() error codes when the queue is empty.
+ *
+ * @details
+ * On an empty queue, a non-blocking get must return -ENOMSG and a get with a
+ * finite timeout must return -EAGAIN after the timeout elapses.
+ *
+ * Test steps:
+ * - On an empty queue, get with K_NO_WAIT and expect -ENOMSG.
+ * - Get with a finite timeout and expect -EAGAIN.
+ *
+ * Expected result:
+ * - k_msgq_get() returns -ENOMSG (no wait) and -EAGAIN (timeout) when empty.
+ *
+ * @see k_msgq_get()
  */
 ZTEST(msgq_api_1cpu, test_msgq_get_fail)
 {
@@ -82,8 +120,22 @@ ZTEST(msgq_api_1cpu, test_msgq_get_fail)
 
 #ifdef CONFIG_USERSPACE
 /**
- * @brief Test returned error code during reading from msgq
- * @see k_msgq_alloc_init(), k_msgq_get()
+ * @brief Verify k_msgq_get() empty-queue error codes from user mode.
+ *
+ * @details
+ * User-mode counterpart of test_msgq_get_fail() on a queue created with
+ * k_msgq_alloc_init(): an empty-queue get must return -ENOMSG (no wait) and
+ * -EAGAIN (timeout).
+ *
+ * Test steps:
+ * - Allocate and alloc-init a queue as a user thread.
+ * - Get with K_NO_WAIT (-ENOMSG) and with a finite timeout (-EAGAIN).
+ *
+ * Expected result:
+ * - The error codes match the supervisor case from user mode.
+ *
+ * @see k_msgq_get()
+ * @see k_msgq_alloc_init()
  */
 ZTEST_USER(msgq_api, test_msgq_user_get_fail)
 {

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_purge.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_purge.c
@@ -48,13 +48,29 @@ static void purge_when_put(struct k_msgq *q)
 }
 
 /**
- * @addtogroup kernel_message_queue_tests
+ * @addtogroup tests_kernel_msgq
  * @{
  */
 
 /**
- * @brief Test purge a message queue
- * @see k_msgq_init(), k_msgq_purge(), k_msgq_put()
+ * @brief Verify k_msgq_purge() drops messages and wakes a pending writer.
+ *
+ * @details
+ * Purging a full queue must discard all queued messages and unblock any thread
+ * waiting to put, returning -ENOMSG to that writer. After the purge the queue
+ * must be usable again for new puts.
+ *
+ * Test steps:
+ * - Fill the queue, then start a writer that blocks on a put with a timeout.
+ * - Purge the queue while the writer is pending.
+ * - Verify the writer's put returns -ENOMSG and the queue accepts new messages.
+ *
+ * Expected result:
+ * - Purge empties the queue, the pending writer gets -ENOMSG, and the queue is
+ *   usable afterwards.
+ *
+ * @see k_msgq_purge()
+ * @see k_msgq_put()
  */
 ZTEST(msgq_api_1cpu, test_msgq_purge_when_put)
 {
@@ -65,8 +81,22 @@ ZTEST(msgq_api_1cpu, test_msgq_purge_when_put)
 
 #ifdef CONFIG_USERSPACE
 /**
- * @brief Test purge a message queue
- * @see k_msgq_init(), k_msgq_purge(), k_msgq_put()
+ * @brief Verify k_msgq_purge() with a pending writer from user mode.
+ *
+ * @details
+ * User-mode counterpart of test_msgq_purge_when_put() on a queue created with
+ * k_msgq_alloc_init(): purging while a writer pends must discard messages, wake
+ * the writer with -ENOMSG, and leave the queue usable.
+ *
+ * Test steps:
+ * - Allocate and alloc-init a queue as a user thread and fill it.
+ * - Start a pending writer, purge, and verify recovery.
+ *
+ * Expected result:
+ * - Behavior matches the supervisor case from user mode.
+ *
+ * @see k_msgq_purge()
+ * @see k_msgq_alloc_init()
  */
 ZTEST_USER(msgq_api, test_msgq_user_purge_when_put)
 {

--- a/tests/kernel/msgq/msgq_usage/src/main.c
+++ b/tests/kernel/msgq/msgq_usage/src/main.c
@@ -259,6 +259,35 @@ static void start_client(void)
 				  0, K_NO_WAIT);
 }
 
+/**
+ * @addtogroup tests_kernel_msgq
+ * @{
+ */
+
+/**
+ * @brief Verify message queues coordinate a multi-service registry scenario.
+ *
+ * @details
+ * Exercises message queues as the IPC backbone of a realistic service registry:
+ * a manager thread, two service threads and a client thread each own a queue and
+ * communicate by put/get to register services, query them, issue
+ * request/response calls, and tear services down (with k_msgq_purge() waking
+ * waiters). The flow must complete without loss or deadlock and the client must
+ * observe each service's running response.
+ *
+ * Test steps:
+ * - Start the service manager, two services that register, and a client.
+ * - The client queries the manager, calls each service, and validates replies.
+ * - Tear down each service and join all threads.
+ *
+ * Expected result:
+ * - Services register, the client receives correct responses, and all threads
+ *   complete cleanly.
+ *
+ * @see k_msgq_put()
+ * @see k_msgq_get()
+ * @see k_msgq_purge()
+ */
 ZTEST(msgq_usage, test_msgq_usage)
 {
 	start_service_manager();
@@ -283,5 +312,9 @@ ZTEST(msgq_usage, test_msgq_usage)
 	k_thread_join(tclient, K_FOREVER);
 	k_thread_abort(tservice_manager);
 }
+
+/**
+ * @}
+ */
 
 ZTEST_SUITE(msgq_usage, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
- **tests: kernel: msgq: document msgq_api tests and align group naming**
- **tests: kernel: msgq: document msgq_usage test**
- **tests: kernel: msgq: document the put_front build variant**
- **tests: kernel: mbox: document mbox_api tests and align group naming**
- **tests: kernel: mbox: document mbox_usage tests**
- **tests: kernel: mbox: cover size negotiation and put timeout**
- **tests: kernel: lifo: document lifo_usage tests and align group naming**
- **tests: kernel: lifo: document lifo_api tests**
- **tests: kernel: fifo: document fifo_api tests and align group naming**
- **tests: kernel: fifo: document fifo_timeout tests**
- **tests: kernel: fifo: document fifo_usage tests**
