### PR TITLE
arch: arm: cortex_a_r: keep IRQs disabled during interrupt exit

### DIFF
--- a/arch/arm/core/cortex_a_r/isr_wrapper.S
+++ b/arch/arm/core/cortex_a_r/isr_wrapper.S
@@ -183,18 +183,6 @@ _idle_state_cleared:
 #endif /* !CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER */
 	push {r0, r1}
 
-	/*
-	 * Enable interrupts to allow nesting.
-	 *
-	 * Note that interrupts are disabled up to this point on the ARM
-	 * architecture variants other than the Cortex-M. It is also important
-	 * to note that most interrupt controllers require that the nested
-	 * interrupts are handled after the active interrupt is acknowledged;
-	 * this is be done through the `get_active` interrupt controller
-	 * interface function.
-	 */
-	cpsie i
-
 #if CONFIG_GIC_VER >= 3
 	/*
 	 * Ignore GIC special INTIDs (1020-1023), which do not represent
@@ -225,7 +213,21 @@ oob:
 			 * in thumb mode */
 
 	ldm r1!,{r0,r3}	/* arg in r0, ISR in r3 */
+
+	/*
+	 * Enable interrupts only while the registered ISR runs to allow
+	 * nesting. Keep EOI and interrupt exit non-reentrant.
+	 *
+	 * Note that interrupts are disabled up to this point on the ARM
+	 * architecture variants other than the Cortex-M. It is also important
+	 * to note that most interrupt controllers require that the nested
+	 * interrupts are handled after the active interrupt is acknowledged;
+	 * this is done through the `get_active` interrupt controller
+	 * interface function.
+	 */
+	cpsie i
 	blx r3		/* call ISR */
+	cpsid i
 
 spurious_continue:
 	/* Signal end-of-interrupt */


### PR DESCRIPTION
The Cortex-A/R interrupt wrapper enables IRQs to support nested interrupt handling while running the registered ISR.

Move cpsie i after the spurious IRQ check so only valid ISR calls run with IRQs enabled, and add cpsid i after the ISR returns. This prevents EOI and z_arm_int_exit() from running with IRQs enabled.

Issue: https://github.com/zephyrproject-rtos/zephyr/issues/109768