### PR TITLE
openthread: use diamond include for non-local header files

### DIFF
--- a/modules/openthread/openthread.c
+++ b/modules/openthread/openthread.c
@@ -44,7 +44,7 @@ LOG_MODULE_REGISTER(net_openthread_platform, CONFIG_OPENTHREAD_PLATFORM_LOG_LEVE
 #endif /* CONFIG_OPENTHREAD_NAT64_TRANSLATOR */
 
 #if defined(CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER)
-#include "openthread_border_router.h"
+#include <openthread_border_router.h>
 #endif /* CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER */
 
 #define OT_STACK_SIZE (CONFIG_OPENTHREAD_THREAD_STACK_SIZE)

--- a/modules/openthread/platform/border_agent.c
+++ b/modules/openthread/platform/border_agent.c
@@ -11,8 +11,8 @@
 #include <openthread/thread.h>
 #include <openthread/verhoeff_checksum.h>
 #include <openthread/platform/entropy.h>
-#include "common/code_utils.hpp"
-#include "openthread_border_router.h"
+#include <common/code_utils.hpp>
+#include <openthread_border_router.h>
 #include <zephyr/sys/byteorder.h>
 #include <string.h>
 #include <stdlib.h>

--- a/modules/openthread/platform/dhcp6_pd.c
+++ b/modules/openthread/platform/dhcp6_pd.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "openthread/instance.h"
-#include "openthread/ip6.h"
-#include "openthread_border_router.h"
+#include <openthread/instance.h>
+#include <openthread/ip6.h>
+#include <openthread_border_router.h>
 #include <common/code_utils.hpp>
 #include <openthread/platform/infra_if.h>
 #include <zephyr/posix/sys/socket.h>
 #include <zephyr/net/socket_service.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_ip.h>
-#include "sockets_internal.h"
+#include <sockets_internal.h>
 
 #define DHCPV6_SERVER_PORT 547
 #define DHCPV6_CLIENT_PORT 546

--- a/modules/openthread/platform/diag.c
+++ b/modules/openthread/platform/diag.c
@@ -14,7 +14,7 @@
 #include <openthread/platform/radio.h>
 
 #include "platform-zephyr.h"
-#include "zephyr/sys/util.h"
+#include <zephyr/sys/util.h>
 
 enum {
 	DIAG_TRANSMIT_MODE_IDLE,

--- a/modules/openthread/platform/dns_upstream_resolver.c
+++ b/modules/openthread/platform/dns_upstream_resolver.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "openthread_border_router.h"
+#include <openthread_border_router.h>
 #include <zephyr/net/dns_resolve.h>
 #include <zephyr/sys/slist.h>
-#include "dns_pack.h"
+#include <dns_pack.h>
 #include <common/code_utils.hpp>
 #include <openthread.h>
 #include <openthread/platform/dns.h>

--- a/modules/openthread/platform/hdlc_interface.hpp
+++ b/modules/openthread/platform/hdlc_interface.hpp
@@ -34,10 +34,10 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net/hdlc_rcp_if/hdlc_rcp_if.h>
 
-#include "lib/url/url.hpp"
-#include "lib/hdlc/hdlc.hpp"
-#include "lib/spinel/spinel.h"
-#include "lib/spinel/spinel_interface.hpp"
+#include <lib/url/url.hpp>
+#include <lib/hdlc/hdlc.hpp>
+#include <lib/spinel/spinel.h>
+#include <lib/spinel/spinel_interface.hpp>
 
 namespace ot {
 

--- a/modules/openthread/platform/infra_if.c
+++ b/modules/openthread/platform/infra_if.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "openthread/platform/infra_if.h"
-#include "icmpv6.h"
-#include "ipv6.h"
-#include "route_ipv6.h"
-#include "openthread_border_router.h"
+#include <openthread/platform/infra_if.h>
+#include <icmpv6.h>
+#include <ipv6.h>
+#include <route_ipv6.h>
+#include <openthread_border_router.h>
 #include <common/code_utils.hpp>
 #include <platform-zephyr.h>
 #include <zephyr/kernel.h>

--- a/modules/openthread/platform/mdns_socket.c
+++ b/modules/openthread/platform/mdns_socket.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "openthread/platform/mdns_socket.h"
+#include <openthread/platform/mdns_socket.h>
 #include <openthread/nat64.h>
 #include <openthread/platform/messagepool.h>
-#include "openthread/instance.h"
-#include "openthread_border_router.h"
+#include <openthread/instance.h>
+#include <openthread_border_router.h>
 #include "platform-zephyr.h"
 #include <common/code_utils.hpp>
 #include <zephyr/net/mld.h>
@@ -19,7 +19,7 @@
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/openthread.h>
 #include <zephyr/net/socket_service.h>
-#include "sockets_internal.h"
+#include <sockets_internal.h>
 #include <errno.h>
 
 #define MULTICAST_PORT 5353

--- a/modules/openthread/platform/trel.c
+++ b/modules/openthread/platform/trel.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "openthread/instance.h"
-#include "openthread/ip6.h"
-#include "openthread/trel.h"
-#include "openthread_border_router.h"
+#include <openthread/instance.h>
+#include <openthread/ip6.h>
+#include <openthread/trel.h>
+#include <openthread_border_router.h>
 #include <common/code_utils.hpp>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/socket_service.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_ip.h>
-#include "sockets_internal.h"
+#include <sockets_internal.h>
 #include <platform-zephyr.h>
 
 #define MAX_SERVICES CONFIG_OPENTHREAD_ZEPHYR_BORDER_ROUTER_TREL_SERVICES

--- a/modules/openthread/platform/udp.c
+++ b/modules/openthread/platform/udp.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "openthread/udp.h"
-#include "openthread/ip6.h"
-#include "openthread/platform/udp.h"
-#include "openthread_border_router.h"
-#include "sockets_internal.h"
+#include <openthread/udp.h>
+#include <openthread/ip6.h>
+#include <openthread/platform/udp.h>
+#include <openthread_border_router.h>
+#include <sockets_internal.h>
 #include <assert.h>
 #include <common/code_utils.hpp>
 #include <errno.h>

--- a/modules/openthread/shell.c
+++ b/modules/openthread/shell.c
@@ -15,7 +15,7 @@
 #include <openthread/cli.h>
 #include <openthread/instance.h>
 
-#include "platform-zephyr.h"
+#include <platform-zephyr.h>
 
 #define OT_SHELL_BUFFER_SIZE CONFIG_SHELL_CMD_BUFF_SIZE
 

--- a/tests/subsys/openthread/radio_stub.c
+++ b/tests/subsys/openthread/radio_stub.c
@@ -27,4 +27,4 @@
 #define CONFIG_OPENTHREAD_DEFAULT_TX_POWER 0
 
 /* file itself */
-#include "radio.c"
+#include <radio.c>


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various OpenThread related paths and manually selecting the applicable changes:
```
$ find subsys/openthread/ -type f -exec ./scripts/check_quoted_includes.py -w {} ;