### PR TITLE
bluetooth: ISO: Diamond include for non-local header files

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -34,10 +34,10 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/toolchain.h>
 
-#include "common/assert.h"
-#include "host/buf_view.h"
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <common/assert.h>
+#include <host/buf_view.h>
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "iso_internal.h"
 
 LOG_MODULE_REGISTER(bt_iso, CONFIG_BT_ISO_LOG_LEVEL);

--- a/subsys/bluetooth/host/shell/iso.c
+++ b/subsys/bluetooth/host/shell/iso.c
@@ -30,8 +30,8 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #if defined(CONFIG_BT_ISO_TX)
 #define DEFAULT_IO_QOS                                                                             \


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Bluetooth ISO related path and manually selecting the applicable changes:
```
$ find subsys/bluetooth/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;
