### PR TITLE
bluetooth: HCI: Diamond include for non-local header files

### DIFF
--- a/drivers/bluetooth/hci/apollox_blue.c
+++ b/drivers/bluetooth/hci/apollox_blue.c
@@ -28,9 +28,9 @@ LOG_MODULE_REGISTER(bt_apollox_driver);
 #include <soc.h>
 #include "apollox_blue.h"
 #if (CONFIG_SOC_SERIES_APOLLO4X)
-#include "am_devices_cooper.h"
+#include <am_devices_cooper.h>
 #elif (CONFIG_SOC_SERIES_APOLLO3X)
-#include "am_apollo3_bt_support.h"
+#include <am_apollo3_bt_support.h>
 #endif /* CONFIG_SOC_SERIES_APOLLO4X */
 
 #define HCI_SPI_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(ambiq_bt_hci_spi)

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -27,7 +27,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_driver);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "../util.h"
 

--- a/drivers/bluetooth/hci/hci_bee.c
+++ b/drivers/bluetooth/hci/hci_bee.c
@@ -11,7 +11,7 @@
 #include <zephyr/drivers/bluetooth.h>
 #include <zephyr/logging/log.h>
 
-#include "rtl_bt_hci.h"
+#include <rtl_bt_hci.h>
 
 LOG_MODULE_REGISTER(bt_driver, CONFIG_BT_HCI_DRIVER_LOG_LEVEL);
 #define DT_DRV_COMPAT realtek_bee_bt_hci

--- a/drivers/bluetooth/hci/hci_infineon_cyw208xx.c
+++ b/drivers/bluetooth/hci/hci_infineon_cyw208xx.c
@@ -69,7 +69,7 @@
 #include <cyabs_rtos.h>
 #include <cybt_result.h>
 
-#include "cyhal_syspm.h"
+#include <cyhal_syspm.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 LOG_MODULE_REGISTER(cyw208xx);

--- a/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_infineon_psoc6_bless.c
@@ -26,8 +26,8 @@
 #define LOG_LEVEL      CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 LOG_MODULE_REGISTER(psoc6_bless);
 
-#include "cy_ble_stack_pvt.h"
-#include "cycfg_ble.h"
+#include <cy_ble_stack_pvt.h>
+#include <cycfg_ble.h>
 
 #define DT_DRV_COMPAT infineon_bless_hci
 

--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -23,9 +23,9 @@
 #include <fwk_platform.h>
 
 #if defined(CONFIG_NXP_SNPS_BLE_CTRL)
-#include "ble_controller.h"
+#include <ble_controller.h>
 #elif defined(CONFIG_NXP_MCXW7X_BLE_CTRL)
-#include "controller_api.h"
+#include <controller_api.h>
 #endif
 
 /* -------------------------------------------------------------------------- */

--- a/drivers/bluetooth/hci/hci_nxp_setup.c
+++ b/drivers/bluetooth/hci/hci_nxp_setup.c
@@ -26,7 +26,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_nxp_ctlr);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define DT_DRV_COMPAT nxp_bt_hci_uart
 

--- a/drivers/bluetooth/hci/hci_rtk_ameba.c
+++ b/drivers/bluetooth/hci/hci_rtk_ameba.c
@@ -6,10 +6,10 @@
 
 #include <stdbool.h>
 
-#include "hci/hci_common.h"
-#include "hci/hci_if_zephyr.h"
-#include "hci/hci_transport.h"
-#include "hci_platform.h"
+#include <hci/hci_common.h>
+#include <hci/hci_if_zephyr.h>
+#include <hci/hci_transport.h>
+#include <hci_platform.h>
 
 #include <zephyr/drivers/bluetooth.h>
 #include <zephyr/logging/log.h>

--- a/drivers/bluetooth/hci/hci_silabs_siwx91x.c
+++ b/drivers/bluetooth/hci/hci_silabs_siwx91x.c
@@ -11,9 +11,9 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_hci_driver_siwg917);
 
-#include "rsi_ble.h"
-#include "rsi_ble_common_config.h"
-#include "siwx91x_nwp.h"
+#include <rsi_ble.h>
+#include <rsi_ble_common_config.h>
+#include <siwx91x_nwp.h>
 
 #define BLE_RF_POWER_INDEX     0x0006
 #define BT_OP_VS_RF_POWER_MODE BT_OP(BT_OGF_VS, BLE_RF_POWER_INDEX)

--- a/drivers/bluetooth/hci/hci_stm32wb0.c
+++ b/drivers/bluetooth/hci/hci_stm32wb0.c
@@ -13,18 +13,18 @@
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/pm/policy.h>
 #include <zephyr/pm/device.h>
-#include "bleplat_cntr.h"
-#include "ble_stack.h"
-#include "stm32wb0x_hal_radio_timer.h"
-#include "miscutil.h"
-#include "pka_manager.h"
-#include "app_conf.h"
-#include "dtm_cmd_db.h"
-#include "dm_alloc.h"
-#include "aci_adv_nwk.h"
-#include "app_common.h"
-#include "hw_aes.h"
-#include "hw_pka.h"
+#include <bleplat_cntr.h>
+#include <ble_stack.h>
+#include <stm32wb0x_hal_radio_timer.h>
+#include <miscutil.h>
+#include <pka_manager.h>
+#include <app_conf.h>
+#include <dtm_cmd_db.h>
+#include <dm_alloc.h>
+#include <aci_adv_nwk.h>
+#include <app_common.h>
+#include <hw_aes.h>
+#include <hw_pka.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/bluetooth/hci/hci_stm32wba.c
+++ b/drivers/bluetooth/hci/hci_stm32wba.c
@@ -17,16 +17,16 @@
 #include <zephyr/pm/policy.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/pm.h>
-#include "linklayer_plat.h"
+#include <linklayer_plat.h>
 #include <linklayer_plat_local.h>
 #include <hci_if.h>
 
 #include <zephyr/sys/byteorder.h>
 
-#include "blestack.h"
-#include "app_conf.h"
-#include "ll_sys.h"
-#include "flash_driver.h"
+#include <blestack.h>
+#include <app_conf.h>
+#include <ll_sys.h>
+#include <flash_driver.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -16,10 +16,10 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/irq.h>
 
-#include "app_conf.h"
-#include "stm32_wpan_common.h"
-#include "shci.h"
-#include "shci_tl.h"
+#include <app_conf.h>
+#include <stm32_wpan_common.h>
+#include <shci.h>
+#include <shci_tl.h>
 
 static const struct stm32_pclken clk_cfg[] = STM32_DT_CLOCKS(DT_DRV_INST(0));
 
@@ -40,7 +40,7 @@ PLACE_IN_SECTION("MB_MEM2") ALIGN(4) static uint8_t
 static void syscmd_status_not(SHCI_TL_CmdStatus_t status);
 static void sysevt_received(void *pdata);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -18,10 +18,10 @@
 #include <stdio.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "nsi_host_trampolines.h"
-#include "nsi_errno.h"
-#include "soc.h"
-#include "cmdline.h" /* native_sim command line options header */
+#include <nsi_host_trampolines.h>
+#include <nsi_errno.h>
+#include <soc.h>
+#include <cmdline.h> /* native_sim command line options header */
 #include "userchan_bottom.h"
 
 #include <zephyr/bluetooth/bluetooth.h>


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with the Linux shell command below and manually selecting the applicable changes:
```
$ find drivers/bluetooth/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;
