### PR TITLE
Bluetooth: Mesh: Diamond include for non-local header files

### DIFF
--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -14,7 +14,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "testing.h"
 

--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -15,7 +15,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "net.h"
 #include "foundation.h"

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -14,9 +14,9 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/hci_core.h"
+#include <host/hci_core.h>
 
 #include "net.h"
 #include "proxy.h"

--- a/subsys/bluetooth/mesh/adv_legacy.c
+++ b/subsys/bluetooth/mesh/adv_legacy.c
@@ -15,9 +15,9 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/hci_core.h"
+#include <host/hci_core.h>
 
 #include "net.h"
 #include "foundation.h"

--- a/subsys/bluetooth/mesh/app_keys.c
+++ b/subsys/bluetooth/mesh/app_keys.c
@@ -22,7 +22,7 @@
 #include "foundation.h"
 #include "access.h"
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define LOG_LEVEL CONFIG_BT_MESH_KEYS_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/mesh/beacon.c
+++ b/subsys/bluetooth/mesh/beacon.c
@@ -14,7 +14,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "net.h"
 #include "prov.h"

--- a/subsys/bluetooth/mesh/cdb.c
+++ b/subsys/bluetooth/mesh/cdb.c
@@ -12,7 +12,7 @@
 
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "cdb.h"
 #include "net.h"

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -16,7 +16,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "access.h"
 #include "net.h"

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -16,7 +16,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "testing.h"
 

--- a/subsys/bluetooth/mesh/crypto.c
+++ b/subsys/bluetooth/mesh/crypto.c
@@ -11,7 +11,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "mesh.h"
 #include "crypto.h"

--- a/subsys/bluetooth/mesh/gatt_cli.c
+++ b/subsys/bluetooth/mesh/gatt_cli.c
@@ -15,7 +15,7 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "mesh.h"
 #include "net.h"

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -16,7 +16,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "net.h"
 #include "foundation.h"

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -17,7 +17,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "crypto.h"
 #include "mesh.h"

--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -15,7 +15,7 @@
 #include "beacon.h"
 #include "prov.h"
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define LOG_LEVEL CONFIG_BT_MESH_PROV_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/mesh/pb_gatt.c
+++ b/subsys/bluetooth/mesh/pb_gatt.c
@@ -16,7 +16,7 @@
 
 #include <zephyr/bluetooth/hci.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define LOG_LEVEL CONFIG_BT_MESH_PROV_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -14,7 +14,7 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "mesh.h"
 #include "net.h"

--- a/subsys/bluetooth/mesh/provisionee.c
+++ b/subsys/bluetooth/mesh/provisionee.c
@@ -17,8 +17,8 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/bluetooth/uuid.h>
 
-#include "common/bt_str.h"
-#include "common/long_wq.h"
+#include <common/bt_str.h>
+#include <common/long_wq.h>
 
 #include "crypto.h"
 #include "mesh.h"

--- a/subsys/bluetooth/mesh/provisioner.c
+++ b/subsys/bluetooth/mesh/provisioner.c
@@ -18,8 +18,8 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/bluetooth/uuid.h>
 
-#include "common/bt_str.h"
-#include "common/long_wq.h"
+#include <common/bt_str.h>
+#include <common/long_wq.h>
 
 #include "crypto.h"
 #include "mesh.h"

--- a/subsys/bluetooth/mesh/proxy_msg.c
+++ b/subsys/bluetooth/mesh/proxy_msg.c
@@ -18,7 +18,7 @@
 
 #include <zephyr/bluetooth/hci.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "mesh.h"
 #include "net.h"

--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -17,7 +17,7 @@
 
 #include <zephyr/bluetooth/hci.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "net.h"
 #include "rpl.h"

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -15,7 +15,7 @@
 #include <common/bt_settings_commit.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "host/hci_core.h"
+#include <host/hci_core.h>
 #include "mesh.h"
 #include "subnet.h"
 #include "app_keys.h"

--- a/subsys/bluetooth/mesh/shell/blob.c
+++ b/subsys/bluetooth/mesh/shell/blob.c
@@ -11,7 +11,7 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/bluetooth/mesh/shell.h>
 
-#include "common/bt_shell_private.h"
+#include <common/bt_shell_private.h>
 #include "utils.h"
 
 /***************************************************************************************************

--- a/subsys/bluetooth/mesh/shell/brg_cfg.c
+++ b/subsys/bluetooth/mesh/shell/brg_cfg.c
@@ -9,7 +9,7 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/bluetooth/mesh/shell.h>
 
-#include "mesh/foundation.h"
+#include <mesh/foundation.h>
 #include "utils.h"
 
 static int cmd_subnet_bridge_get(const struct shell *sh, size_t argc, char *argv[])

--- a/subsys/bluetooth/mesh/shell/cfg.c
+++ b/subsys/bluetooth/mesh/shell/cfg.c
@@ -8,8 +8,8 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "mesh/net.h"
-#include "mesh/access.h"
+#include <mesh/net.h>
+#include <mesh/access.h>
 #include "utils.h"
 #include <zephyr/bluetooth/mesh/shell.h>
 

--- a/subsys/bluetooth/mesh/shell/dfu.c
+++ b/subsys/bluetooth/mesh/shell/dfu.c
@@ -16,7 +16,7 @@
 #include <zephyr/dfu/mcuboot.h>
 #include <zephyr/storage/flash_map.h>
 
-#include "common/bt_shell_private.h"
+#include <common/bt_shell_private.h>
 #include "utils.h"
 #include "blob.h"
 #include "../dfu_slot.h"

--- a/subsys/bluetooth/mesh/shell/health.c
+++ b/subsys/bluetooth/mesh/shell/health.c
@@ -8,8 +8,8 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "mesh/net.h"
-#include "mesh/access.h"
+#include <mesh/net.h>
+#include <mesh/access.h>
 #include "utils.h"
 #include <zephyr/bluetooth/mesh/shell.h>
 

--- a/subsys/bluetooth/mesh/shell/large_comp_data.c
+++ b/subsys/bluetooth/mesh/shell/large_comp_data.c
@@ -9,7 +9,7 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/bluetooth/mesh/shell.h>
 
-#include "common/bt_shell_private.h"
+#include <common/bt_shell_private.h>
 #include "utils.h"
 
 static void status_print(int err, char *msg, uint16_t addr, struct bt_mesh_large_comp_data_rsp *rsp)

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -18,15 +18,15 @@
 #include <zephyr/bluetooth/mesh/shell.h>
 
 /* Private includes for raw Network & Transport layer access */
-#include "mesh/mesh.h"
-#include "mesh/net.h"
-#include "mesh/rpl.h"
-#include "mesh/transport.h"
-#include "mesh/foundation.h"
-#include "mesh/settings.h"
-#include "mesh/access.h"
-#include "mesh/prov.h"
-#include "common/bt_shell_private.h"
+#include <mesh/mesh.h>
+#include <mesh/net.h>
+#include <mesh/rpl.h>
+#include <mesh/transport.h>
+#include <mesh/foundation.h>
+#include <mesh/settings.h>
+#include <mesh/access.h>
+#include <mesh/prov.h>
+#include <common/bt_shell_private.h>
 #include "utils.h"
 #include "dfu.h"
 #include "blob.h"

--- a/subsys/bluetooth/mesh/shell/utils.c
+++ b/subsys/bluetooth/mesh/shell/utils.c
@@ -9,8 +9,8 @@
 #include <ctype.h>
 #include <string.h>
 
-#include "mesh/net.h"
-#include "mesh/access.h"
+#include <mesh/net.h>
+#include <mesh/access.h>
 #include "utils.h"
 
 bool bt_mesh_shell_mdl_first_get(uint16_t id, const struct bt_mesh_model **mod)

--- a/subsys/bluetooth/mesh/solicitation.c
+++ b/subsys/bluetooth/mesh/solicitation.c
@@ -19,9 +19,9 @@
 #include "proxy.h"
 #include "settings.h"
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/hci_core.h"
+#include <host/hci_core.h>
 
 #define LOG_LEVEL CONFIG_BT_MESH_MODEL_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -19,7 +19,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "crypto.h"
 #include "net.h"

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -17,7 +17,7 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "crypto.h"
 #include "mesh.h"

--- a/subsys/bluetooth/mesh/va.c
+++ b/subsys/bluetooth/mesh/va.c
@@ -15,7 +15,7 @@
 
 #include <zephyr/bluetooth/mesh.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "va.h"
 #include "foundation.h"

--- a/tests/bluetooth/mesh/blob_io_flash/src/main.c
+++ b/tests/bluetooth/mesh/blob_io_flash/src/main.c
@@ -8,7 +8,7 @@
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "mesh/blob.h"
+#include <mesh/blob.h>
 
 #define SLOT1_PARTITION		slot1_partition
 #define SLOT1_PARTITION_ID	PARTITION_ID(SLOT1_PARTITION)

--- a/tests/bluetooth/mesh/brg/CMakeLists.txt
+++ b/tests/bluetooth/mesh/brg/CMakeLists.txt
@@ -13,7 +13,7 @@ target_sources(app
 
 target_include_directories(app
   PRIVATE
-    ${ZEPHYR_BASE}/subsys/bluetooth/mesh
+    ${ZEPHYR_BASE}/subsys/bluetooth
     ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
     ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/
 )

--- a/tests/bluetooth/mesh/brg/src/main.c
+++ b/tests/bluetooth/mesh/brg/src/main.c
@@ -9,9 +9,9 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <stdlib.h>
 
-#include "settings.h"
-#include "brg_cfg.h"
-#include "foundation.h"
+#include <settings.h>
+#include <brg_cfg.h>
+#include <foundation.h>
 
 #define TEST_VECT_SZ (CONFIG_BT_MESH_BRG_TABLE_ITEMS_MAX + 1)
 

--- a/tests/bluetooth/mesh/brg/src/main.c
+++ b/tests/bluetooth/mesh/brg/src/main.c
@@ -9,9 +9,9 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <stdlib.h>
 
-#include <settings.h>
-#include <brg_cfg.h>
-#include <foundation.h>
+#include <mesh/settings.h>
+#include <mesh/brg_cfg.h>
+#include <mesh/foundation.h>
 
 #define TEST_VECT_SZ (CONFIG_BT_MESH_BRG_TABLE_ITEMS_MAX + 1)
 

--- a/tests/bluetooth/mesh/delayable_msg/CMakeLists.txt
+++ b/tests/bluetooth/mesh/delayable_msg/CMakeLists.txt
@@ -13,7 +13,7 @@ target_sources(app
 
 target_include_directories(app
   PRIVATE
-  ${ZEPHYR_BASE}/subsys/bluetooth/mesh
+  ${ZEPHYR_BASE}/subsys/bluetooth
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/
 )

--- a/tests/bluetooth/mesh/delayable_msg/src/main.c
+++ b/tests/bluetooth/mesh/delayable_msg/src/main.c
@@ -9,9 +9,9 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/random/random.h>
 
-#include <net.h>
-#include <access.h>
-#include <delayable_msg.h>
+#include <mesh/net.h>
+#include <mesh/access.h>
+#include <mesh/delayable_msg.h>
 
 #define SRC_ADDR 0x0002
 #define RX_ADDR  0xc000

--- a/tests/bluetooth/mesh/delayable_msg/src/main.c
+++ b/tests/bluetooth/mesh/delayable_msg/src/main.c
@@ -9,9 +9,9 @@
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/random/random.h>
 
-#include "net.h"
-#include "access.h"
-#include "delayable_msg.h"
+#include <net.h>
+#include <access.h>
+#include <delayable_msg.h>
 
 #define SRC_ADDR 0x0002
 #define RX_ADDR  0xc000

--- a/tests/bluetooth/mesh/net/CMakeLists.txt
+++ b/tests/bluetooth/mesh/net/CMakeLists.txt
@@ -13,7 +13,6 @@ target_sources(app
 
 target_include_directories(app
   PRIVATE
-  ${ZEPHYR_BASE}/subsys/bluetooth/mesh
   ${ZEPHYR_BASE}/subsys/bluetooth
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/

--- a/tests/bluetooth/mesh/net/src/main.c
+++ b/tests/bluetooth/mesh/net/src/main.c
@@ -11,8 +11,8 @@
 #include <zephyr/sys/byteorder.h>
 #include <errno.h>
 #include <string.h>
-#include <crypto.h>
-#include <net.h>
+#include <mesh/crypto.h>
+#include <mesh/net.h>
 
 /**** Mocked functions ****/
 

--- a/tests/bluetooth/mesh/net/src/main.c
+++ b/tests/bluetooth/mesh/net/src/main.c
@@ -11,8 +11,8 @@
 #include <zephyr/sys/byteorder.h>
 #include <errno.h>
 #include <string.h>
-#include "crypto.h"
-#include "net.h"
+#include <crypto.h>
+#include <net.h>
 
 /**** Mocked functions ****/
 

--- a/tests/bluetooth/mesh/rpl/CMakeLists.txt
+++ b/tests/bluetooth/mesh/rpl/CMakeLists.txt
@@ -13,7 +13,7 @@ target_sources(app
 
 target_include_directories(app
   PRIVATE
-  ${ZEPHYR_BASE}/subsys/bluetooth/mesh
+  ${ZEPHYR_BASE}/subsys/bluetooth
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/include
   ${CONFIG_TF_PSA_CRYPTO_MODULE_DIR}/drivers/builtin/include/
 )

--- a/tests/bluetooth/mesh/rpl/src/main.c
+++ b/tests/bluetooth/mesh/rpl/src/main.c
@@ -8,9 +8,9 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include "settings.h"
-#include "net.h"
-#include "rpl.h"
+#include <settings.h>
+#include <net.h>
+#include <rpl.h>
 
 #define EMPTY_ENTRIES_CNT (CONFIG_BT_MESH_CRPL - ARRAY_SIZE(test_vector))
 

--- a/tests/bluetooth/mesh/rpl/src/main.c
+++ b/tests/bluetooth/mesh/rpl/src/main.c
@@ -8,9 +8,9 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/bluetooth/mesh.h>
 
-#include <settings.h>
-#include <net.h>
-#include <rpl.h>
+#include <mesh/settings.h>
+#include <mesh/net.h>
+#include <mesh/rpl.h>
 
 #define EMPTY_ENTRIES_CNT (CONFIG_BT_MESH_CRPL - ARRAY_SIZE(test_vector))
 

--- a/tests/bsim/bluetooth/mesh/src/main.c
+++ b/tests/bsim/bluetooth/mesh/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 #include "mesh_test.h"
 
 #if defined(CONFIG_SETTINGS)

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.c
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "mesh_test.h"
-#include "argparse.h"
+#include <argparse.h>
 #include <bs_pc_backchannel.h>
-#include "mesh/crypto.h"
+#include <mesh/crypto.h>
 #include <zephyr/bluetooth/hci.h>
 
 #define LOG_MODULE_NAME mesh_test
@@ -16,7 +16,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 /* Max number of messages that can be pending on RX at the same time */
 #define RECV_QUEUE_SIZE 32

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.h
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.h
@@ -11,10 +11,10 @@
 #define ZEPHYR_TESTS_BLUETOOTH_BSIM_BT_BSIM_TEST_MESH_MESH_TEST_H_
 #include <zephyr/kernel.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <time_machine.h>
+#include <bstests.h>
 
 #include <zephyr/types.h>
 #include <stddef.h>

--- a/tests/bsim/bluetooth/mesh/src/test_access.c
+++ b/tests/bsim/bluetooth/mesh/src/test_access.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "mesh_test.h"
-#include "mesh/net.h"
-#include "mesh/access.h"
-#include "mesh/foundation.h"
+#include <mesh/net.h>
+#include <mesh/access.h>
+#include <mesh/foundation.h>
 
 #define LOG_MODULE_NAME test_access
 

--- a/tests/bsim/bluetooth/mesh/src/test_advertiser.c
+++ b/tests/bsim/bluetooth/mesh/src/test_advertiser.c
@@ -7,9 +7,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/hci.h>
 #include "mesh_test.h"
-#include "mesh/net.h"
-#include "mesh/mesh.h"
-#include "mesh/foundation.h"
+#include <mesh/net.h>
+#include <mesh/mesh.h>
+#include <mesh/foundation.h>
 #include "gatt_common.h"
 
 #define LOG_MODULE_NAME test_adv

--- a/tests/bsim/bluetooth/mesh/src/test_beacon.c
+++ b/tests/bsim/bluetooth/mesh/src/test_beacon.c
@@ -6,14 +6,14 @@
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/hci.h>
 #include "mesh_test.h"
-#include "mesh/net.h"
-#include "mesh/beacon.h"
-#include "mesh/mesh.h"
-#include "mesh/foundation.h"
-#include "mesh/crypto.h"
-#include "argparse.h"
-#include "mesh/proxy_cli.h"
-#include "mesh/proxy.h"
+#include <mesh/net.h>
+#include <mesh/beacon.h>
+#include <mesh/mesh.h>
+#include <mesh/foundation.h>
+#include <mesh/crypto.h>
+#include <argparse.h>
+#include <mesh/proxy_cli.h>
+#include <mesh/proxy.h>
 
 #define LOG_MODULE_NAME test_beacon
 

--- a/tests/bsim/bluetooth/mesh/src/test_blob.c
+++ b/tests/bsim/bluetooth/mesh/src/test_blob.c
@@ -6,9 +6,9 @@
 #include "mesh_test.h"
 #include "dfu_blob_common.h"
 #include "friendship_common.h"
-#include "mesh/adv.h"
-#include "mesh/blob.h"
-#include "argparse.h"
+#include <mesh/adv.h>
+#include <mesh/blob.h>
+#include <argparse.h>
 
 #define LOG_MODULE_NAME test_blob
 

--- a/tests/bsim/bluetooth/mesh/src/test_brg.c
+++ b/tests/bsim/bluetooth/mesh/src/test_brg.c
@@ -8,11 +8,11 @@
 
 #include "mesh_test.h"
 #include <zephyr/bluetooth/mesh.h>
-#include "mesh/net.h"
-#include "mesh/keys.h"
-#include "mesh/va.h"
-#include "bsim_args_runner.h"
-#include "common/bt_str.h"
+#include <mesh/net.h>
+#include <mesh/keys.h>
+#include <mesh/va.h>
+#include <bsim_args_runner.h>
+#include <common/bt_str.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(test_brg, LOG_LEVEL_INF);

--- a/tests/bsim/bluetooth/mesh/src/test_cdb.c
+++ b/tests/bsim/bluetooth/mesh/src/test_cdb.c
@@ -5,11 +5,11 @@
  */
 
 #include "mesh_test.h"
-#include "mesh/cdb.h"
-#include "mesh/net.h"
-#include "mesh/app_keys.h"
-#include "mesh/settings.h"
-#include "mesh/foundation.h"
+#include <mesh/cdb.h>
+#include <mesh/net.h>
+#include <mesh/app_keys.h>
+#include <mesh/settings.h>
+#include <mesh/foundation.h>
 
 #define LOG_MODULE_NAME test_cdb
 #include <zephyr/logging/log.h>

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "mesh_test.h"
-#include "mesh/dfd_srv_internal.h"
-#include "mesh/dfu_slot.h"
-#include "mesh/dfu.h"
-#include "mesh/blob.h"
-#include "argparse.h"
+#include <mesh/dfd_srv_internal.h>
+#include <mesh/dfu_slot.h>
+#include <mesh/dfu.h>
+#include <mesh/blob.h>
+#include <argparse.h>
 #include "dfu_blob_common.h"
 
 #define LOG_MODULE_NAME test_dfu

--- a/tests/bsim/bluetooth/mesh/src/test_friendship.c
+++ b/tests/bsim/bluetooth/mesh/src/test_friendship.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "mesh_test.h"
-#include "mesh/net.h"
-#include "mesh/lpn.h"
-#include "mesh/transport.h"
-#include "mesh/va.h"
+#include <mesh/net.h>
+#include <mesh/lpn.h>
+#include <mesh/transport.h>
+#include <mesh/va.h>
 #include <zephyr/sys/byteorder.h>
-#include "argparse.h"
+#include <argparse.h>
 
 #include "friendship_common.h"
 

--- a/tests/bsim/bluetooth/mesh/src/test_heartbeat.c
+++ b/tests/bsim/bluetooth/mesh/src/test_heartbeat.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "mesh_test.h"
-#include "argparse.h"
-#include "mesh/net.h"
-#include "mesh/heartbeat.h"
-#include "mesh/lpn.h"
+#include <argparse.h>
+#include <mesh/net.h>
+#include <mesh/heartbeat.h>
+#include <mesh/lpn.h>
 
 #define LOG_MODULE_NAME test_heartbeat
 

--- a/tests/bsim/bluetooth/mesh/src/test_iv_index.c
+++ b/tests/bsim/bluetooth/mesh/src/test_iv_index.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include "mesh_test.h"
-#include "mesh/net.h"
+#include <mesh/net.h>
 
 #define LOG_MODULE_NAME test_ivi
 

--- a/tests/bsim/bluetooth/mesh/src/test_lcd.c
+++ b/tests/bsim/bluetooth/mesh/src/test_lcd.c
@@ -15,7 +15,7 @@
 
 #include <mesh/access.h>
 #include <mesh/net.h>
-#include "argparse.h"
+#include <argparse.h>
 
 LOG_MODULE_REGISTER(test_lcd, LOG_LEVEL_INF);
 

--- a/tests/bsim/bluetooth/mesh/src/test_persistence.c
+++ b/tests/bsim/bluetooth/mesh/src/test_persistence.c
@@ -7,9 +7,9 @@
 #include "mesh_test.h"
 #include <zephyr/bluetooth/mesh.h>
 #include <zephyr/sys/reboot.h>
-#include "mesh/net.h"
-#include "mesh/app_keys.h"
-#include "mesh/keys.h"
+#include <mesh/net.h>
+#include <mesh/app_keys.h>
+#include <mesh/keys.h>
 #include <bs_cmd_line.h>
 
 #include <zephyr/psa/key_ids.h>

--- a/tests/bsim/bluetooth/mesh/src/test_provision.c
+++ b/tests/bsim/bluetooth/mesh/src/test_provision.c
@@ -7,11 +7,11 @@
 #include <stdlib.h>
 
 #include "mesh_test.h"
-#include "mesh/access.h"
-#include "mesh/net.h"
-#include "mesh/crypto.h"
-#include "mesh/prov.h"
-#include "argparse.h"
+#include <mesh/access.h>
+#include <mesh/net.h>
+#include <mesh/crypto.h>
+#include <mesh/prov.h>
+#include <argparse.h>
 #include <bs_pc_backchannel.h>
 #include <time_machine.h>
 
@@ -20,7 +20,7 @@
 #define LOG_MODULE_NAME mesh_prov
 
 #include <zephyr/logging/log.h>
-#include "mesh/rpr.h"
+#include <mesh/rpr.h>
 
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 

--- a/tests/bsim/bluetooth/mesh/src/test_proxy_sol.c
+++ b/tests/bsim/bluetooth/mesh/src/test_proxy_sol.c
@@ -7,11 +7,11 @@
  */
 
 #include "mesh_test.h"
-#include "mesh/access.h"
-#include "mesh/settings.h"
-#include "mesh/net.h"
-#include "mesh/crypto.h"
-#include "mesh/proxy.h"
+#include <mesh/access.h>
+#include <mesh/settings.h>
+#include <mesh/net.h>
+#include <mesh/crypto.h>
+#include <mesh/proxy.h>
 #include <string.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>

--- a/tests/bsim/bluetooth/mesh/src/test_replay_cache.c
+++ b/tests/bsim/bluetooth/mesh/src/test_replay_cache.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "mesh_test.h"
-#include "mesh/mesh.h"
-#include "mesh/net.h"
-#include "mesh/rpl.h"
-#include "mesh/transport.h"
+#include <mesh/mesh.h>
+#include <mesh/net.h>
+#include <mesh/rpl.h>
+#include <mesh/transport.h>
 
 #define LOG_MODULE_NAME test_rpc
 

--- a/tests/bsim/bluetooth/mesh/src/test_scanner.c
+++ b/tests/bsim/bluetooth/mesh/src/test_scanner.c
@@ -5,9 +5,9 @@
  */
 #include <zephyr/kernel.h>
 #include "mesh_test.h"
-#include "mesh/net.h"
-#include "mesh/mesh.h"
-#include "mesh/foundation.h"
+#include <mesh/net.h>
+#include <mesh/mesh.h>
+#include <mesh/foundation.h>
 
 #define LOG_MODULE_NAME test_scanner
 

--- a/tests/bsim/bluetooth/mesh/src/test_transport.c
+++ b/tests/bsim/bluetooth/mesh/src/test_transport.c
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "mesh_test.h"
-#include "mesh/net.h"
-#include "mesh/transport.h"
-#include "mesh/va.h"
+#include <mesh/net.h>
+#include <mesh/transport.h>
+#include <mesh/va.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "mesh/crypto.h"
+#include <mesh/crypto.h>
 
 #define LOG_MODULE_NAME test_transport
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 /*
  * Transport layer tests:


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Bluetooth Mesh related paths and manually selecting the applicable changes:
```
$ find subsys/bluetooth/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;