### PR TITLE
Bluetooth: Classic: Diamond include for non-local header files

### DIFF
--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -23,7 +23,7 @@
 #include <zephyr/bluetooth/classic/a2dp_codec_sbc.h>
 #include <zephyr/bluetooth/classic/a2dp.h>
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #define A2DP_SBC_PAYLOAD_TYPE (0x60U)
 
@@ -41,9 +41,9 @@
 #define CTRL_PARAM(_ctrl_param) CONTAINER_OF(_ctrl_param, struct bt_a2dp, ctrl_param)
 #define DELAY_REPORT_REQ(_req)  CONTAINER_OF(_req, struct bt_avdtp_delay_report_params, req)
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
 #include "avdtp_internal.h"
 #include "a2dp_internal.h"
 

--- a/subsys/bluetooth/host/classic/avctp.c
+++ b/subsys/bluetooth/host/classic/avctp.c
@@ -23,8 +23,8 @@
 #include <zephyr/bluetooth/classic/sdp.h>
 
 #include "avctp_internal.h"
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 
 #define LOG_LEVEL CONFIG_BT_AVCTP_LOG_LEVEL

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -20,8 +20,8 @@
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/classic/avdtp.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "avdtp_internal.h"
 

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -22,9 +22,9 @@
 #include <zephyr/bluetooth/classic/sdp.h>
 #include <zephyr/bluetooth/l2cap.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
 #include "avctp_internal.h"
 #include "avrcp_internal.h"
 

--- a/subsys/bluetooth/host/classic/avrcp_cover_art.c
+++ b/subsys/bluetooth/host/classic/avrcp_cover_art.c
@@ -22,9 +22,9 @@
 #include <zephyr/bluetooth/classic/bip.h>
 #include <zephyr/bluetooth/classic/avrcp_cover_art.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
 #include "avctp_internal.h"
 #include "avrcp_internal.h"
 

--- a/subsys/bluetooth/host/classic/bip.c
+++ b/subsys/bluetooth/host/classic/bip.c
@@ -12,14 +12,14 @@
 
 #include <zephyr/bluetooth/conn.h>
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #include <zephyr/bluetooth/classic/sdp.h>
 #include <zephyr/bluetooth/classic/goep.h>
 #include <zephyr/bluetooth/classic/bip.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "obex_internal.h"
 

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -11,11 +11,11 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/buf.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
-#include "host/keys.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
+#include <host/keys.h>
 #include "br.h"
 #include "sco_internal.h"
 

--- a/subsys/bluetooth/host/classic/conn_br.c
+++ b/subsys/bluetooth/host/classic/conn_br.c
@@ -29,13 +29,13 @@
 #include <zephyr/bluetooth/hci_vs.h>
 #include <zephyr/bluetooth/att.h>
 
-#include "common/assert.h"
-#include "common/bt_str.h"
+#include <common/assert.h>
+#include <common/bt_str.h>
 
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
-#include "host/keys.h"
-#include "host/smp.h"
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
+#include <host/keys.h>
+#include <host/smp.h>
 #include "ssp.h"
 #include "sco_internal.h"
 

--- a/subsys/bluetooth/host/classic/goep.c
+++ b/subsys/bluetooth/host/classic/goep.c
@@ -22,7 +22,7 @@
 #include <zephyr/bluetooth/classic/sdp.h>
 #include <zephyr/bluetooth/classic/goep.h>
 
-#include "host/conn_internal.h"
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "rfcomm_internal.h"
 #include "obex_internal.h"

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -13,14 +13,14 @@
 
 #include <zephyr/bluetooth/conn.h>
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #include <zephyr/bluetooth/classic/rfcomm.h>
 #include <zephyr/bluetooth/classic/hfp_ag.h>
 #include <zephyr/bluetooth/classic/sdp.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "rfcomm_internal.h"
 #include "at.h"

--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -14,14 +14,14 @@
 
 #include <zephyr/bluetooth/conn.h>
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #include <zephyr/bluetooth/classic/rfcomm.h>
 #include <zephyr/bluetooth/classic/hfp_hf.h>
 #include <zephyr/bluetooth/classic/sdp.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "rfcomm_internal.h"
 #include "at.h"

--- a/subsys/bluetooth/host/classic/hid_device.c
+++ b/subsys/bluetooth/host/classic/hid_device.c
@@ -11,7 +11,7 @@
 #include <errno.h>
 #include <zephyr/sys/util.h>
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -19,9 +19,9 @@
 #include <zephyr/bluetooth/classic/classic.h>
 #include <zephyr/bluetooth/l2cap.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
 
 #include "hid_internal.h"
 

--- a/subsys/bluetooth/host/classic/keys_br.c
+++ b/subsys/bluetooth/host/classic/keys_br.c
@@ -16,11 +16,11 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/settings/settings.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/hci_core.h"
-#include "host/settings.h"
-#include "host/keys.h"
+#include <host/hci_core.h>
+#include <host/settings.h>
+#include <host/keys.h>
 
 #define LOG_LEVEL CONFIG_BT_KEYS_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -21,10 +21,10 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/classic/l2cap_br.h>
 
-#include "host/buf_view.h"
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
-#include "host/keys.h"
+#include <host/buf_view.h>
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
+#include <host/keys.h>
 #include "l2cap_br_internal.h"
 #include "avdtp_internal.h"
 #include "a2dp_internal.h"

--- a/subsys/bluetooth/host/classic/map.c
+++ b/subsys/bluetooth/host/classic/map.c
@@ -12,14 +12,14 @@
 
 #include <zephyr/bluetooth/conn.h>
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #include <zephyr/bluetooth/classic/sdp.h>
 #include <zephyr/bluetooth/classic/goep.h>
 #include <zephyr/bluetooth/classic/map.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "obex_internal.h"
 

--- a/subsys/bluetooth/host/classic/pbap.c
+++ b/subsys/bluetooth/host/classic/pbap.c
@@ -14,7 +14,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/kernel.h>
 
-#include "psa/crypto.h"
+#include <psa/crypto.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -25,7 +25,7 @@
 #include <zephyr/bluetooth/classic/goep.h>
 #include <zephyr/bluetooth/classic/pbap.h>
 
-#include "host/conn_internal.h"
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "rfcomm_internal.h"
 #include "obex_internal.h"

--- a/subsys/bluetooth/host/classic/pbap.c
+++ b/subsys/bluetooth/host/classic/pbap.c
@@ -14,7 +14,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/kernel.h>
 
-#include "psa/crypto.h"
+#include <psa/crypto.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -27,7 +27,7 @@
 
 #include <mbedtls/constant_time.h>
 
-#include "host/conn_internal.h"
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "rfcomm_internal.h"
 #include "obex_internal.h"

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -23,8 +23,8 @@
 
 #include <zephyr/bluetooth/classic/rfcomm.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "rfcomm_internal.h"
 

--- a/subsys/bluetooth/host/classic/sco.c
+++ b/subsys/bluetooth/host/classic/sco.c
@@ -17,12 +17,12 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/addr_internal.h"
-#include "host/hci_core.h"
+#include <host/addr_internal.h>
+#include <host/hci_core.h>
 #include "br.h"
-#include "host/conn_internal.h"
+#include <host/conn_internal.h>
 #include "sco_internal.h"
 
 #define LOG_LEVEL CONFIG_BT_CONN_LOG_LEVEL

--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -17,11 +17,11 @@
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/classic/sdp.h>
 
-#include "common/bt_str.h"
-#include "common/assert.h"
+#include <common/bt_str.h>
+#include <common/assert.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 #include "sdp_internal.h"
 

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -25,8 +25,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 struct bt_a2dp *default_a2dp;
 static uint8_t a2dp_sink_sdp_registered;

--- a/subsys/bluetooth/host/classic/shell/avrcp.c
+++ b/subsys/bluetooth/host/classic/shell/avrcp.c
@@ -26,8 +26,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 NET_BUF_POOL_DEFINE(avrcp_tx_pool, CONFIG_BT_MAX_CONN,
 		    BT_L2CAP_BUF_SIZE(CONFIG_BT_L2CAP_TX_MTU),

--- a/subsys/bluetooth/host/classic/shell/avrcp_cover_art.c
+++ b/subsys/bluetooth/host/classic/shell/avrcp_cover_art.c
@@ -25,8 +25,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define COVER_ART_MOPL CONFIG_BT_GOEP_L2CAP_MTU
 

--- a/subsys/bluetooth/host/classic/shell/bip.c
+++ b/subsys/bluetooth/host/classic/shell/bip.c
@@ -23,8 +23,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define BIP_MOPL CONFIG_BT_GOEP_RFCOMM_MTU
 

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -32,8 +32,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #if defined(CONFIG_BT_CONN)
 /* Connection context for BR/EDR legacy pairing in sec mode 3 */

--- a/subsys/bluetooth/host/classic/shell/goep.c
+++ b/subsys/bluetooth/host/classic/shell/goep.c
@@ -23,8 +23,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define GOEP_MOPL CONFIG_BT_GOEP_RFCOMM_MTU
 

--- a/subsys/bluetooth/host/classic/shell/hfp.c
+++ b/subsys/bluetooth/host/classic/shell/hfp.c
@@ -23,8 +23,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define HELP_NONE "[none]"
 

--- a/subsys/bluetooth/host/classic/shell/hid_device.c
+++ b/subsys/bluetooth/host/classic/shell/hid_device.c
@@ -22,8 +22,8 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_string_conv.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define BT_HID_DEVICE_VERSION      0x0101
 #define BT_HID_PARSER_VERSION      0x0111

--- a/subsys/bluetooth/host/classic/shell/map.c
+++ b/subsys/bluetooth/host/classic/shell/map.c
@@ -24,8 +24,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define MAP_MOPL                   CONFIG_BT_GOEP_RFCOMM_MTU
 #define MAP_MCE_SUPPORTED_FEATURES 0x0077FFFF

--- a/subsys/bluetooth/host/classic/shell/pbap.c
+++ b/subsys/bluetooth/host/classic/shell/pbap.c
@@ -22,8 +22,8 @@
 #include <zephyr/bluetooth/classic/pbap.h>
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #ifdef CONFIG_ZTEST
 #define STATIC

--- a/subsys/bluetooth/host/classic/shell/spp.c
+++ b/subsys/bluetooth/host/classic/shell/spp.c
@@ -25,9 +25,9 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
-#include "common/bt_str.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
+#include <common/bt_str.h>
 
 #define HELP_NONE "[none]"
 #define SPP_RFCOMM_MTU     CONFIG_BT_RFCOMM_L2CAP_MTU

--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -15,12 +15,12 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/addr.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/keys.h"
+#include <host/keys.h>
 
-#include "host/hci_core.h"
-#include "host/conn_internal.h"
+#include <host/hci_core.h>
+#include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL

--- a/tests/bluetooth/classic/a2dp_sink/src/test_a2dp_sink.c
+++ b/tests/bluetooth/classic/a2dp_sink/src/test_a2dp_sink.c
@@ -24,8 +24,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static struct bt_a2dp *default_a2dp;
 static bool a2dp_initialized;

--- a/tests/bluetooth/classic/a2dp_source/src/test_a2dp_source.c
+++ b/tests/bluetooth/classic/a2dp_source/src/test_a2dp_source.c
@@ -24,8 +24,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static struct bt_a2dp *default_a2dp;
 static bool a2dp_initialized;

--- a/tests/bluetooth/classic/l2cap_c/src/l2cap_test.c
+++ b/tests/bluetooth/classic/l2cap_c/src/l2cap_test.c
@@ -24,8 +24,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static uint16_t data_bredr_mtu = 48;
 #define DATA_POOL_SIZE 200

--- a/tests/bluetooth/classic/l2cap_s/src/l2cap_test.c
+++ b/tests/bluetooth/classic/l2cap_s/src/l2cap_test.c
@@ -24,8 +24,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static uint16_t data_bredr_mtu = 48;
 #define DATA_POOL_SIZE 200

--- a/tests/bluetooth/classic/rfcomm_c/src/rfcomm_c.c
+++ b/tests/bluetooth/classic/rfcomm_c/src/rfcomm_c.c
@@ -21,8 +21,8 @@
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/classic/rfcomm.h>
 #include <zephyr/bluetooth/classic/sdp.h>
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define DATA_MTU CONFIG_BT_RFCOMM_L2CAP_MTU
 

--- a/tests/bluetooth/classic/rfcomm_s/src/rfcomm_s.c
+++ b/tests/bluetooth/classic/rfcomm_s/src/rfcomm_s.c
@@ -22,8 +22,8 @@
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/classic/rfcomm.h>
 #include <zephyr/bluetooth/classic/sdp.h>
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define DATA_MTU 48
 

--- a/tests/bluetooth/classic/smp_bonding/src/smp_br_bonding.c
+++ b/tests/bluetooth/classic/smp_bonding/src/smp_br_bonding.c
@@ -23,8 +23,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define DATA_BREDR_MTU 48
 

--- a/tests/bluetooth/classic/smp_general/src/smp_br_general.c
+++ b/tests/bluetooth/classic/smp_general/src/smp_br_general.c
@@ -25,8 +25,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define DATA_BREDR_MTU          48
 #define SDP_CLIENT_USER_BUF_LEN 4096

--- a/tests/bluetooth/classic/smp_io_cap/src/smp_br_io_cap.c
+++ b/tests/bluetooth/classic/smp_io_cap/src/smp_br_io_cap.c
@@ -23,8 +23,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define DATA_BREDR_MTU 48
 

--- a/tests/bluetooth/classic/smp_key_persist/src/smp_reboot.c
+++ b/tests/bluetooth/classic/smp_key_persist/src/smp_reboot.c
@@ -17,8 +17,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static int cmd_reboot(const struct shell *sh, size_t argc, char *argv[])
 {

--- a/tests/bluetooth/classic/smp_sc_only/src/smp_br_sc_only.c
+++ b/tests/bluetooth/classic/smp_sc_only/src/smp_br_sc_only.c
@@ -23,8 +23,8 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #define DATA_BREDR_MTU 48
 


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Bluetooth Classic related paths and manually selecting the applicable changes:
```
$ find subsys/bluetooth/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;