### PR TITLE
Bluetooth: Audio: Diamond include for non-local header files

### DIFF
--- a/samples/bluetooth/bap_broadcast_source/src/main.c
+++ b/samples/bluetooth/bap_broadcast_source/src/main.c
@@ -92,7 +92,7 @@ static struct bt_bap_lc3_preset preset_active = BT_BAP_LC3_BROADCAST_PRESET_48_2
 #define MAX_NUM_SAMPLES       ((MAX_FRAME_DURATION_US * MAX_SAMPLE_RATE) / USEC_PER_SEC)
 
 #if defined(CONFIG_LIBLC3)
-#include "lc3.h"
+#include <lc3.h>
 
 #if defined(CONFIG_USE_USB_AUDIO_INPUT)
 #include <zephyr/usb/usb_device.h>

--- a/samples/bluetooth/bap_unicast_server/src/main.c
+++ b/samples/bluetooth/bap_unicast_server/src/main.c
@@ -93,7 +93,7 @@ static const struct bt_data ad[] = {
 
 #if defined(CONFIG_LIBLC3)
 
-#include "lc3.h"
+#include <lc3.h>
 
 #define MAX_SAMPLE_RATE         48000U
 #define MAX_FRAME_DURATION_US   10000U

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -32,7 +32,7 @@
 #include <zephyr/types.h>
 
 #include "aics_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 LOG_MODULE_REGISTER(bt_aics_client, CONFIG_BT_AICS_CLIENT_LOG_LEVEL);
 

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -39,8 +39,8 @@
 
 LOG_MODULE_REGISTER(bt_ascs, CONFIG_BT_ASCS_LOG_LEVEL);
 
-#include "common/assert.h"
-#include "common/bt_str.h"
+#include <common/assert.h>
+#include <common/bt_str.h>
 
 #include "../host/att_internal.h"
 

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -46,7 +46,7 @@
 
 LOG_MODULE_REGISTER(bt_bap_broadcast_assistant, CONFIG_BT_BAP_BROADCAST_ASSISTANT_LOG_LEVEL);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "audio_internal.h"
 #include "bap_internal.h"

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -47,7 +47,7 @@
 
 LOG_MODULE_REGISTER(bt_bap_broadcast_sink, CONFIG_BT_BAP_BROADCAST_SINK_LOG_LEVEL);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define BROADCAST_SYNC_MIN_INDEX          (BIT(1U))

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -47,7 +47,7 @@ LOG_MODULE_REGISTER(bt_bap_scan_delegator, CONFIG_BT_BAP_SCAN_DELEGATOR_LOG_LEVE
 	 Use the CONFIG_LOG_MODE_DEFERRED Kconfig option when this feature is enabled.
 #endif
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "audio_internal.h"
 #include "bap_internal.h"

--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -37,7 +37,7 @@
 
 LOG_MODULE_REGISTER(bt_cap_commander, CONFIG_BT_CAP_COMMANDER_LOG_LEVEL);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 static void cap_commander_proc_complete(struct bt_cap_common_proc *active_proc);
 

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -32,7 +32,7 @@
 
 LOG_MODULE_REGISTER(bt_cap_common, CONFIG_BT_CAP_COMMON_LOG_LEVEL);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 static struct bt_cap_common_client bt_cap_common_clients[CONFIG_BT_MAX_CONN];
 static const struct bt_uuid *cas_uuid = BT_UUID_CAS;

--- a/subsys/bluetooth/audio/cap_handover.c
+++ b/subsys/bluetooth/audio/cap_handover.c
@@ -27,7 +27,7 @@
 
 #include "bap_endpoint.h"
 #include "cap_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "csip_internal.h"
 
 LOG_MODULE_REGISTER(bt_cap_handover, CONFIG_BT_CAP_HANDOVER_LOG_LEVEL);

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -43,7 +43,7 @@
 
 LOG_MODULE_REGISTER(bt_cap_initiator, CONFIG_BT_CAP_INITIATOR_LOG_LEVEL);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 static const struct bt_cap_initiator_cb *cap_cb;
 

--- a/subsys/bluetooth/audio/csip_crypto.c
+++ b/subsys/bluetooth/audio/csip_crypto.c
@@ -21,9 +21,9 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "crypto/bt_crypto.h"
+#include <crypto/bt_crypto.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "csip_crypto.h"
 

--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -49,11 +49,11 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "csip_crypto.h"
 #include "csip_internal.h"
-#include "host/conn_internal.h"
-#include "host/keys.h"
+#include <host/conn_internal.h>
+#include <host/keys.h>
 
 LOG_MODULE_REGISTER(bt_csip_set_coordinator, CONFIG_BT_CSIP_SET_COORDINATOR_LOG_LEVEL);
 

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -43,8 +43,8 @@
 #include "../host/keys.h"
 #include "../host/settings.h"
 
-#include "common/bt_settings_commit.h"
-#include "common/bt_str.h"
+#include <common/bt_settings_commit.h>
+#include <common/bt_str.h>
 #include "audio_internal.h"
 #include "csip_internal.h"
 #include "csip_crypto.h"

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -35,10 +35,10 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/toolchain.h>
 
-#include "../bluetooth/host/settings.h"
+#include <../bluetooth/host/settings.h>
 
 #include "audio_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "has_internal.h"
 
 LOG_MODULE_REGISTER(bt_has, CONFIG_BT_HAS_LOG_LEVEL);

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -37,7 +37,7 @@
 #include <zephyr/types.h>
 
 #include "../services/ots/ots_client_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "mcc_internal.h"
 #include "mcs_internal.h"
 

--- a/subsys/bluetooth/audio/mcs.c
+++ b/subsys/bluetooth/audio/mcs.c
@@ -37,7 +37,7 @@
 #include <zephyr/types.h>
 
 #include "audio_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "media_proxy_internal.h"
 #include "mcs_internal.h"
 

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -32,7 +32,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "micp_internal.h"
 
 LOG_MODULE_REGISTER(bt_micp_mic_ctlr, CONFIG_BT_MICP_MIC_CTLR_LOG_LEVEL);

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -38,7 +38,7 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "audio_internal.h"
 #include "bap_unicast_server.h"

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -38,8 +38,8 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/toolchain.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 #define SHELL_PRINT_INDENT_LEVEL_SIZE 2U
 #define MAX_CODEC_FRAMES_PER_SDU      4U
@@ -66,7 +66,7 @@ size_t cap_initiator_pa_data_add(struct bt_data *data_array, const size_t data_a
 #include <zephyr/bluetooth/audio/cap.h>
 
 #if defined(CONFIG_LIBLC3)
-#include "lc3.h"
+#include <lc3.h>
 
 #define USB_SAMPLE_RATE            48000U
 #define LC3_MAX_SAMPLE_RATE        48000U

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -55,8 +55,8 @@
 #include <zephyr/toolchain.h>
 
 #include "audio.h"
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 /* Determines if we can initiate streaming */
 #define IS_BAP_INITIATOR                                                                           \
@@ -292,7 +292,7 @@ uint16_t get_next_seq_num(struct bt_bap_stream *bap_stream)
 NET_BUF_POOL_FIXED_DEFINE(sine_tx_pool, CONFIG_BT_ISO_TX_BUF_COUNT, SINE_TX_POOL_SIZE,
 			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
 
-#include "math.h"
+#include <math.h>
 
 #define AUDIO_VOLUME            (INT16_MAX - 3000) /* codec does clipping above INT16_MAX - 3000 */
 #define AUDIO_TONE_FREQUENCY_HZ   400U

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -38,9 +38,9 @@
 #include <zephyr/types.h>
 
 #include "audio.h"
-#include "common/bt_shell_private.h"
-#include "host/hci_core.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/hci_core.h>
+#include <host/shell/bt.h>
 
 static uint8_t received_base[UINT8_MAX];
 static size_t received_base_size;

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -35,9 +35,9 @@
 
 #include <audio/bap_internal.h>
 #include "audio.h"
-#include "common/bt_shell_private.h"
-#include "common/bt_str.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <common/bt_str.h>
+#include <host/shell/bt.h>
 
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
 #define PA_SYNC_SKIP              5U

--- a/subsys/bluetooth/audio/shell/cap_acceptor.c
+++ b/subsys/bluetooth/audio/shell/cap_acceptor.c
@@ -30,8 +30,8 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 static size_t ad_cap_announcement_data_add(struct bt_data data[], size_t data_size)
 {

--- a/subsys/bluetooth/audio/shell/cap_commander.c
+++ b/subsys/bluetooth/audio/shell/cap_commander.c
@@ -28,8 +28,8 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 #include "audio.h"
 
 static void cap_discover_cb(struct bt_conn *conn, int err,

--- a/subsys/bluetooth/audio/shell/cap_handover.c
+++ b/subsys/bluetooth/audio/shell/cap_handover.c
@@ -35,8 +35,8 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/audio/cap.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 #include "audio.h"
 
 static void unicast_to_broadcast_created_cb(struct bt_cap_broadcast_source *broadcast_source)

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -38,8 +38,8 @@
 #include <zephyr/types.h>
 
 #include "audio.h"
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 #define UNICAST_SINK_SUPPORTED (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0)

--- a/subsys/bluetooth/audio/shell/ccp_call_control_client.c
+++ b/subsys/bluetooth/audio/shell/ccp_call_control_client.c
@@ -21,8 +21,8 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/toolchain.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 static struct bt_ccp_call_control_client *clients[CONFIG_BT_MAX_CONN];
 

--- a/subsys/bluetooth/audio/shell/ccp_call_control_server.c
+++ b/subsys/bluetooth/audio/shell/ccp_call_control_server.c
@@ -20,7 +20,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
-#include "audio/tbs_internal.h"
+#include <audio/tbs_internal.h>
 
 static struct bt_ccp_call_control_server_bearer
 	*bearers[CONFIG_BT_CCP_CALL_CONTROL_SERVER_BEARER_COUNT];

--- a/subsys/bluetooth/audio/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/shell/csip_set_coordinator.c
@@ -31,8 +31,8 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 static uint8_t members_found;
 static struct k_work_delayable discover_members_timer;

--- a/subsys/bluetooth/audio/shell/csip_set_member.c
+++ b/subsys/bluetooth/audio/shell/csip_set_member.c
@@ -32,8 +32,8 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 struct bt_csip_set_member_svc_inst *svc_inst;
 static uint8_t sirk_read_rsp = BT_CSIP_READ_SIRK_REQ_RSP_ACCEPT;

--- a/subsys/bluetooth/audio/shell/gmap.c
+++ b/subsys/bluetooth/audio/shell/gmap.c
@@ -35,8 +35,8 @@
 #include <zephyr/toolchain.h>
 
 #include "audio.h"
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 #define UNICAST_SINK_SUPPORTED (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0)
 #define UNICAST_SRC_SUPPORTED  (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0)

--- a/subsys/bluetooth/audio/shell/has.c
+++ b/subsys/bluetooth/audio/shell/has.c
@@ -22,7 +22,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/toolchain.h>
 
-#include "common/bt_shell_private.h"
+#include <common/bt_shell_private.h>
 
 static int preset_select(uint8_t index, bool sync)
 {

--- a/subsys/bluetooth/audio/shell/has_client.c
+++ b/subsys/bluetooth/audio/shell/has_client.c
@@ -21,8 +21,8 @@
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/toolchain.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static struct bt_has *inst;
 

--- a/subsys/bluetooth/audio/shell/mcc.c
+++ b/subsys/bluetooth/audio/shell/mcc.c
@@ -29,8 +29,8 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 #include "../media_proxy_internal.h"
 

--- a/subsys/bluetooth/audio/shell/media_controller.c
+++ b/subsys/bluetooth/audio/shell/media_controller.c
@@ -29,8 +29,8 @@
 
 #include "../media_proxy_internal.h" /* For MPL_NO_TRACK_ID - TODO: Fix */
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 LOG_MODULE_REGISTER(bt_media_controller_shell, CONFIG_BT_MCS_LOG_LEVEL);
 

--- a/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
@@ -22,8 +22,8 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static struct bt_micp_mic_ctlr *micp_mic_ctlr;
 #if defined(CONFIG_BT_MICP_MIC_CTLR_AICS)

--- a/subsys/bluetooth/audio/shell/micp_mic_dev.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_dev.c
@@ -24,7 +24,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_shell_private.h"
+#include <common/bt_shell_private.h>
 
 static void micp_mic_dev_mute_cb(uint8_t mute)
 {

--- a/subsys/bluetooth/audio/shell/pbp.c
+++ b/subsys/bluetooth/audio/shell/pbp.c
@@ -26,7 +26,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
-#include "common/bt_shell_private.h"
+#include <common/bt_shell_private.h>
 
 #define PBS_DEMO                'P', 'B', 'P'
 

--- a/subsys/bluetooth/audio/shell/tbs.c
+++ b/subsys/bluetooth/audio/shell/tbs.c
@@ -26,7 +26,7 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "host/shell/bt.h"
+#include <host/shell/bt.h>
 
 static struct bt_conn *tbs_authorized_conn;
 

--- a/subsys/bluetooth/audio/shell/tbs_client.c
+++ b/subsys/bluetooth/audio/shell/tbs_client.c
@@ -26,7 +26,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "host/shell/bt.h"
+#include <host/shell/bt.h>
 
 static int cmd_tbs_client_discover(const struct shell *sh, size_t argc,
 				   char *argv[])

--- a/subsys/bluetooth/audio/shell/tmap.c
+++ b/subsys/bluetooth/audio/shell/tmap.c
@@ -21,8 +21,8 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static int cmd_tmap_init(const struct shell *sh, size_t argc, char **argv)
 {

--- a/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
@@ -23,8 +23,8 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static struct bt_vcp_vol_ctlr *vcp_vol_ctlr;
 static struct bt_vcp_included vcp_included;

--- a/subsys/bluetooth/audio/shell/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_rend.c
@@ -25,8 +25,8 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static struct bt_vcp_included vcp_included;
 

--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -39,7 +39,7 @@
 
 #include "audio_internal.h"
 #include "tbs_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 LOG_MODULE_REGISTER(bt_tbs, CONFIG_BT_TBS_LOG_LEVEL);
 

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -33,7 +33,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "tbs_internal.h"
 
 LOG_MODULE_REGISTER(bt_tbs_client, CONFIG_BT_TBS_CLIENT_LOG_LEVEL);

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -33,7 +33,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "vcp_internal.h"
 
 LOG_MODULE_REGISTER(bt_vcp_vol_ctlr, CONFIG_BT_VCP_VOL_CTLR_LOG_LEVEL);

--- a/tests/bluetooth/audio/ascs/include/ascs_expects.h
+++ b/tests/bluetooth/audio/ascs/include/ascs_expects.h
@@ -14,7 +14,7 @@
 #include <zephyr/ztest_assert.h>
 
 #include "ascs.h"
-#include "expects_util.h"
+#include <expects_util.h>
 
 static inline void expect_bt_ascs_cb_config_called(unsigned int expected_count,
 						   struct bt_conn *conns[], struct bt_bap_ep *eps[],

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -34,18 +34,18 @@
 #include <zephyr/ztest_test.h>
 #include <sys/types.h>
 
-#include "assert.h"
-#include "ascs.h"
-#include "audio/ascs_internal.h"
-#include "ascs_expects.h"
-#include "bap_stream.h"
-#include "bap_stream_expects.h"
-#include "conn.h"
-#include "gatt.h"
-#include "gatt_expects.h"
-#include "iso.h"
+#include <assert.h>
+#include <ascs.h>
+#include <audio/ascs_internal.h>
+#include <ascs_expects.h>
+#include <bap_stream.h>
+#include <bap_stream_expects.h>
+#include <conn.h>
+#include <gatt.h>
+#include <gatt_expects.h>
+#include <iso.h>
 
-#include "test_common.h"
+#include <test_common.h>
 
 DEFINE_FFF_GLOBALS;
 

--- a/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_control_params.c
@@ -28,13 +28,13 @@
 #include <zephyr/ztest_test.h>
 #include <sys/types.h>
 
-#include "ascs.h"
-#include "bap_stream.h"
-#include "conn.h"
-#include "gatt_expects.h"
-#include "iso.h"
+#include <ascs.h>
+#include <bap_stream.h>
+#include <conn.h>
+#include <gatt_expects.h>
+#include <iso.h>
 
-#include "test_common.h"
+#include <test_common.h>
 
 struct test_ase_control_params_fixture {
 	struct bt_conn conn;

--- a/tests/bluetooth/audio/ascs/src/test_ase_register.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_register.c
@@ -25,10 +25,10 @@
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
-#include "ascs.h"
-#include "bap_stream.h"
+#include <ascs.h>
+#include <bap_stream.h>
 
-#include "test_common.h"
+#include <test_common.h>
 
 static void ascs_register_test_suite_after(void *f)
 {

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -32,16 +32,16 @@
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
-#include "audio/ascs_internal.h"
+#include <audio/ascs_internal.h>
 
-#include "ascs.h"
-#include "ascs_expects.h"
-#include "bap_stream.h"
-#include "bap_stream_expects.h"
-#include "conn.h"
-#include "iso.h"
+#include <ascs.h>
+#include <ascs_expects.h>
+#include <bap_stream.h>
+#include <bap_stream_expects.h>
+#include <conn.h>
+#include <iso.h>
 
-#include "test_common.h"
+#include <test_common.h>
 
 #define test_sink_ase_state_transition_fixture test_ase_state_transition_fixture
 #define test_source_ase_state_transition_fixture test_ase_state_transition_fixture

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition_invalid.c
@@ -33,13 +33,13 @@
 #include <zephyr/ztest_test.h>
 #include <sys/types.h>
 
-#include "ascs.h"
-#include "audio/ascs_internal.h"
-#include "bap_stream.h"
-#include "conn.h"
-#include "gatt_expects.h"
+#include <ascs.h>
+#include <audio/ascs_internal.h>
+#include <bap_stream.h>
+#include <conn.h>
+#include <gatt_expects.h>
 
-#include "test_common.h"
+#include <test_common.h>
 
 struct test_ase_state_transition_invalid_fixture {
 	const struct bt_gatt_attr *ase_cp;
@@ -569,7 +569,7 @@ static void test_server_disable_expect_error(struct bt_bap_stream *stream)
 }
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
-#include "bap_endpoint.h"
+#include <bap_endpoint.h>
 
 static void test_server_config_qos_expect_error(struct bt_bap_stream *stream)
 {

--- a/tests/bluetooth/audio/ascs/src/test_common.c
+++ b/tests/bluetooth/audio/ascs/src/test_common.c
@@ -28,15 +28,15 @@
 #include <zephyr/ztest_assert.h>
 #include <sys/types.h>
 
-#include "ascs.h"
-#include "audio/ascs_internal.h"
-#include "bap_stream.h"
-#include "conn.h"
-#include "gatt.h"
-#include "iso.h"
-#include "pacs.h"
+#include <ascs.h>
+#include <audio/ascs_internal.h>
+#include <bap_stream.h>
+#include <conn.h>
+#include <gatt.h>
+#include <iso.h>
+#include <pacs.h>
 
-#include "test_common.h"
+#include <test_common.h>
 
 void test_mocks_init(void)
 {

--- a/tests/bluetooth/audio/ascs/uut/ascs.c
+++ b/tests/bluetooth/audio/ascs/uut/ascs.c
@@ -13,7 +13,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/fff.h>
 
-#include "ascs.h"
+#include <ascs.h>
 
 /* List of fakes used by this unit tester */
 #define FFF_FAKES_LIST(FAKE)                                                                       \

--- a/tests/bluetooth/audio/bap_broadcast_source/src/main.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/main.c
@@ -28,10 +28,10 @@
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
-#include "bap_broadcast_source.h"
-#include "bap_stream.h"
-#include "bluetooth.h"
-#include "expects_util.h"
+#include <bap_broadcast_source.h>
+#include <bap_stream.h>
+#include <bluetooth.h>
+#include <expects_util.h>
 
 DEFINE_FFF_GLOBALS;
 

--- a/tests/bluetooth/audio/bap_broadcast_source/src/test_callback_register.c
+++ b/tests/bluetooth/audio/bap_broadcast_source/src/test_callback_register.c
@@ -15,7 +15,7 @@
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
-#include "bap_broadcast_source.h"
+#include <bap_broadcast_source.h>
 
 #define FFF_GLOBALS
 

--- a/tests/bluetooth/audio/cap_commander/src/main.c
+++ b/tests/bluetooth/audio/cap_commander/src/main.c
@@ -18,10 +18,10 @@
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
-#include "cap_commander.h"
-#include "conn.h"
-#include "expects_util.h"
-#include "test_common.h"
+#include <cap_commander.h>
+#include <conn.h>
+#include <expects_util.h>
+#include <test_common.h>
 
 DEFINE_FFF_GLOBALS;
 

--- a/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_broadcast_reception.c
@@ -27,11 +27,11 @@
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
-#include "cap_commander.h"
-#include "conn.h"
-#include "expects_util.h"
-#include "cap_mocks.h"
-#include "test_common.h"
+#include <cap_commander.h>
+#include <conn.h>
+#include <expects_util.h>
+#include <cap_mocks.h>
+#include <test_common.h>
 
 LOG_MODULE_REGISTER(bt_broadcast_reception_test, CONFIG_BT_CAP_COMMANDER_LOG_LEVEL);
 

--- a/tests/bluetooth/audio/cap_commander/src/test_cancel.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_cancel.c
@@ -20,12 +20,12 @@
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
-#include "cap_commander.h"
-#include "conn.h"
-#include "expects_util.h"
-#include "cap_mocks.h"
-#include "test_common.h"
-#include "bap_broadcast_assistant.h"
+#include <cap_commander.h>
+#include <conn.h>
+#include <expects_util.h>
+#include <cap_mocks.h>
+#include <test_common.h>
+#include <bap_broadcast_assistant.h>
 
 #define FFF_GLOBALS
 

--- a/tests/bluetooth/audio/cap_commander/src/test_common.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_common.c
@@ -8,10 +8,10 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "cap_commander.h"
-#include "conn.h"
-#include "cap_mocks.h"
-#include "test_common.h"
+#include <cap_commander.h>
+#include <conn.h>
+#include <cap_mocks.h>
+#include <test_common.h>
 
 void test_mocks_init(void)
 {

--- a/tests/bluetooth/audio/cap_commander/src/test_distribute_broadcast_code.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_distribute_broadcast_code.c
@@ -18,11 +18,11 @@
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
-#include "cap_commander.h"
-#include "conn.h"
-#include "expects_util.h"
-#include "cap_mocks.h"
-#include "test_common.h"
+#include <cap_commander.h>
+#include <conn.h>
+#include <expects_util.h>
+#include <cap_mocks.h>
+#include <test_common.h>
 
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>

--- a/tests/bluetooth/audio/cap_commander/src/test_micp.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_micp.c
@@ -20,11 +20,11 @@
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
-#include "cap_commander.h"
-#include "conn.h"
-#include "expects_util.h"
-#include "cap_mocks.h"
-#include "test_common.h"
+#include <cap_commander.h>
+#include <conn.h>
+#include <expects_util.h>
+#include <cap_mocks.h>
+#include <test_common.h>
 
 #define FFF_GLOBALS
 

--- a/tests/bluetooth/audio/cap_commander/src/test_vcp.c
+++ b/tests/bluetooth/audio/cap_commander/src/test_vcp.c
@@ -20,11 +20,11 @@
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
-#include "cap_commander.h"
-#include "conn.h"
-#include "expects_util.h"
-#include "cap_mocks.h"
-#include "test_common.h"
+#include <cap_commander.h>
+#include <conn.h>
+#include <expects_util.h>
+#include <cap_mocks.h>
+#include <test_common.h>
 
 #define FFF_GLOBALS
 

--- a/tests/bluetooth/audio/cap_commander/uut/bap_broadcast_assistant.c
+++ b/tests/bluetooth/audio/cap_commander/uut/bap_broadcast_assistant.c
@@ -17,8 +17,8 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/ztest_assert.h>
 
-#include "bap_broadcast_assistant.h"
-#include "test_common.h"
+#include <bap_broadcast_assistant.h>
+#include <test_common.h>
 
 static sys_slist_t broadcast_assistant_cbs = SYS_SLIST_STATIC_INIT(&broadcast_assistant_cbs);
 

--- a/tests/bluetooth/audio/cap_commander/uut/cap_commander.c
+++ b/tests/bluetooth/audio/cap_commander/uut/cap_commander.c
@@ -9,7 +9,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/fff.h>
 
-#include "cap_commander.h"
+#include <cap_commander.h>
 
 /* List of fakes used by this unit tester */
 #define FFF_FAKES_LIST(FAKE)                                                                       \

--- a/tests/bluetooth/audio/cap_handover/include/test_common.h
+++ b/tests/bluetooth/audio/cap_handover/include/test_common.h
@@ -13,7 +13,7 @@
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/conn.h>
 
-#include "conn.h"
+#include <conn.h>
 
 void test_mocks_init(void);
 void test_mocks_cleanup(void);

--- a/tests/bluetooth/audio/cap_handover/src/callbacks.c
+++ b/tests/bluetooth/audio/cap_handover/src/callbacks.c
@@ -14,8 +14,8 @@
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
-#include "cap_handover.h"
-#include "test_common.h"
+#include <cap_handover.h>
+#include <test_common.h>
 
 static void cap_handover_callbacks_test_suite_after(void *f)
 {

--- a/tests/bluetooth/audio/cap_handover/src/test_common.c
+++ b/tests/bluetooth/audio/cap_handover/src/test_common.c
@@ -19,12 +19,12 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/ztest_assert.h>
 
-#include "audio/bap_endpoint.h"
-#include "cap_initiator.h"
-#include "cap_handover.h"
-#include "conn.h"
-#include "expects_util.h"
-#include "test_common.h"
+#include <audio/bap_endpoint.h>
+#include <cap_initiator.h>
+#include <cap_handover.h>
+#include <conn.h>
+#include <expects_util.h>
+#include <test_common.h>
 
 DEFINE_FFF_GLOBALS;
 

--- a/tests/bluetooth/audio/cap_handover/src/unicast_to_broadcast.c
+++ b/tests/bluetooth/audio/cap_handover/src/unicast_to_broadcast.c
@@ -29,14 +29,14 @@
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
-#include "audio/bap_endpoint.h"
-#include "audio/bap_iso.h"
-#include "bluetooth.h"
-#include "cap_initiator.h"
-#include "cap_handover.h"
-#include "conn.h"
-#include "expects_util.h"
-#include "test_common.h"
+#include <audio/bap_endpoint.h>
+#include <audio/bap_iso.h>
+#include <bluetooth.h>
+#include <cap_initiator.h>
+#include <cap_handover.h>
+#include <conn.h>
+#include <expects_util.h>
+#include <test_common.h>
 
 static void mock_init_rule_before(const struct ztest_unit_test *test, void *fixture)
 {

--- a/tests/bluetooth/audio/cap_handover/uut/cap_handover.c
+++ b/tests/bluetooth/audio/cap_handover/uut/cap_handover.c
@@ -9,7 +9,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/fff.h>
 
-#include "cap_handover.h"
+#include <cap_handover.h>
 
 /* List of fakes used by this unit tester */
 #define FFF_FAKES_LIST(FAKE) FAKE(mock_unicast_to_broadcast_complete_cb)

--- a/tests/bluetooth/audio/cap_handover/uut/cap_initiator.c
+++ b/tests/bluetooth/audio/cap_handover/uut/cap_initiator.c
@@ -9,7 +9,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/fff.h>
 
-#include "cap_initiator.h"
+#include <cap_initiator.h>
 
 /* List of fakes used by this unit tester */
 #define FFF_FAKES_LIST(FAKE) FAKE(mock_unicast_start_complete_cb)

--- a/tests/bluetooth/audio/cap_initiator/include/test_common.h
+++ b/tests/bluetooth/audio/cap_initiator/include/test_common.h
@@ -13,7 +13,7 @@
 #include <zephyr/bluetooth/audio/cap.h>
 #include <zephyr/bluetooth/conn.h>
 
-#include "conn.h"
+#include <conn.h>
 
 void test_mocks_init(void);
 void test_mocks_cleanup(void);

--- a/tests/bluetooth/audio/cap_initiator/src/main.c
+++ b/tests/bluetooth/audio/cap_initiator/src/main.c
@@ -20,10 +20,10 @@
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_test.h>
 
-#include "cap_initiator.h"
-#include "conn.h"
-#include "expects_util.h"
-#include "test_common.h"
+#include <cap_initiator.h>
+#include <conn.h>
+#include <expects_util.h>
+#include <test_common.h>
 
 static void mock_init_rule_before(const struct ztest_unit_test *test, void *fixture)
 {

--- a/tests/bluetooth/audio/cap_initiator/src/test_common.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_common.c
@@ -19,11 +19,11 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/ztest_assert.h>
 
-#include "audio/bap_endpoint.h"
-#include "cap_initiator.h"
-#include "conn.h"
-#include "expects_util.h"
-#include "test_common.h"
+#include <audio/bap_endpoint.h>
+#include <cap_initiator.h>
+#include <conn.h>
+#include <expects_util.h>
+#include <test_common.h>
 
 DEFINE_FFF_GLOBALS;
 

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
@@ -27,8 +27,8 @@
 #include <zephyr/ztest_test.h>
 #include <sys/errno.h>
 
-#include "audio/bap_endpoint.h"
-#include "test_common.h"
+#include <audio/bap_endpoint.h>
+#include <test_common.h>
 
 struct cap_initiator_test_unicast_group_fixture {
 	struct bt_cap_unicast_group_param *group_param;

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
@@ -31,12 +31,12 @@
 
 #include <sys/errno.h>
 
-#include "audio/bap_endpoint.h"
-#include "audio/bap_iso.h"
-#include "cap_initiator.h"
-#include "conn.h"
-#include "expects_util.h"
-#include "test_common.h"
+#include <audio/bap_endpoint.h>
+#include <audio/bap_iso.h>
+#include <cap_initiator.h>
+#include <conn.h>
+#include <expects_util.h>
+#include <test_common.h>
 
 BUILD_ASSERT(CONFIG_BT_MAX_CONN * (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT +
 				   CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT) >=

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
@@ -29,11 +29,11 @@
 
 #include <sys/errno.h>
 
-#include "audio/bap_endpoint.h"
-#include "cap_initiator.h"
-#include "conn.h"
-#include "expects_util.h"
-#include "test_common.h"
+#include <audio/bap_endpoint.h>
+#include <cap_initiator.h>
+#include <conn.h>
+#include <expects_util.h>
+#include <test_common.h>
 
 BUILD_ASSERT(CONFIG_BT_MAX_CONN * (CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT +
 				   CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT) >=

--- a/tests/bluetooth/audio/cap_initiator/uut/cap_initiator.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/cap_initiator.c
@@ -9,8 +9,8 @@
 #include <zephyr/bluetooth/audio/csip.h>
 #include <zephyr/bluetooth/bluetooth.h>
 
-#include "cap_initiator.h"
-#include "zephyr/fff.h"
+#include <cap_initiator.h>
+#include <zephyr/fff.h>
 
 /* List of fakes used by this unit tester */
 #define FFF_FAKES_LIST(FAKE)                                                                       \

--- a/tests/bluetooth/audio/ccp_call_control_client/src/main.c
+++ b/tests/bluetooth/audio/ccp_call_control_client/src/main.c
@@ -18,9 +18,9 @@
 #include <zephyr/ztest_test.h>
 #include <zephyr/ztest_assert.h>
 
-#include "conn.h"
-#include "expects_util.h"
-#include "test_common.h"
+#include <conn.h>
+#include <expects_util.h>
+#include <test_common.h>
 
 struct ccp_call_control_client_test_suite_fixture {
 	struct bt_ccp_call_control_client_cb client_cbs;

--- a/tests/bluetooth/audio/ccp_call_control_client/src/test_common.c
+++ b/tests/bluetooth/audio/ccp_call_control_client/src/test_common.c
@@ -9,7 +9,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "conn.h"
+#include <conn.h>
 
 void test_conn_init(struct bt_conn *conn)
 {

--- a/tests/bluetooth/audio/ccp_call_control_client/src/test_procedures.c
+++ b/tests/bluetooth/audio/ccp_call_control_client/src/test_procedures.c
@@ -21,8 +21,8 @@
 #include <zephyr/ztest_test.h>
 #include <zephyr/ztest_assert.h>
 
-#include "conn.h"
-#include "test_common.h"
+#include <conn.h>
+#include <test_common.h>
 
 struct ccp_call_control_client_procedures_test_suite_fixture {
 	struct bt_ccp_call_control_client_cb client_cbs;

--- a/tests/bluetooth/audio/mocks/src/adv.c
+++ b/tests/bluetooth/audio/mocks/src/adv.c
@@ -12,7 +12,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/sys/atomic.h>
 
-#include "bluetooth.h"
+#include <bluetooth.h>
 
 int bt_le_ext_adv_get_info(const struct bt_le_ext_adv *adv, struct bt_le_ext_adv_info *info)
 {

--- a/tests/bluetooth/audio/mocks/src/bap_broadcast_source.c
+++ b/tests/bluetooth/audio/mocks/src/bap_broadcast_source.c
@@ -7,8 +7,8 @@
 
 #include <zephyr/bluetooth/audio/bap.h>
 
-#include "bap_broadcast_source.h"
-#include "zephyr/fff.h"
+#include <bap_broadcast_source.h>
+#include <zephyr/fff.h>
 
 /* List of fakes used by this unit tester */
 #define FFF_FAKES_LIST(FAKE)                                                                       \

--- a/tests/bluetooth/audio/mocks/src/bap_stream.c
+++ b/tests/bluetooth/audio/mocks/src/bap_stream.c
@@ -11,7 +11,7 @@
 #include <zephyr/fff.h>
 #include <zephyr/net_buf.h>
 
-#include "bap_stream.h"
+#include <bap_stream.h>
 
 /* List of fakes used by this unit tester */
 #define FFF_FAKES_LIST(FAKE)                                                                       \

--- a/tests/bluetooth/audio/mocks/src/bap_unicast_client.c
+++ b/tests/bluetooth/audio/mocks/src/bap_unicast_client.c
@@ -26,9 +26,9 @@
 #include <zephyr/ztest_assert.h>
 #include <sys/errno.h>
 
-#include "audio/bap_endpoint.h"
-#include "audio/bap_iso.h"
-#include "conn.h"
+#include <audio/bap_endpoint.h>
+#include <audio/bap_iso.h>
+#include <conn.h>
 
 LOG_MODULE_REGISTER(bt_bap_unicast_client, CONFIG_BT_BAP_UNICAST_CLIENT_LOG_LEVEL);
 

--- a/tests/bluetooth/audio/mocks/src/conn.c
+++ b/tests/bluetooth/audio/mocks/src/conn.c
@@ -15,7 +15,7 @@
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/toolchain.h>
 
-#include "conn.h"
+#include <conn.h>
 
 DEFINE_FAKE_VOID_FUNC(bt_conn_foreach, enum bt_conn_type, bt_conn_foreach_cb, void *);
 DEFINE_FAKE_VALUE_FUNC(const bt_addr_le_t *, bt_conn_get_dst, const struct bt_conn *);

--- a/tests/bluetooth/audio/mocks/src/gatt.c
+++ b/tests/bluetooth/audio/mocks/src/gatt.c
@@ -27,9 +27,9 @@
 #include <zephyr/ztest_test.h>
 #include <zephyr/ztest_assert.h>
 
-#include "gatt.h"
-#include "conn.h"
-#include "common/bt_str.h"
+#include <gatt.h>
+#include <conn.h>
+#include <common/bt_str.h>
 
 #define LOG_LEVEL CONFIG_BT_GATT_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/tests/bluetooth/audio/mocks/src/iso.c
+++ b/tests/bluetooth/audio/mocks/src/iso.c
@@ -17,8 +17,8 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/ztest_assert.h>
 
-#include "conn.h"
-#include "iso.h"
+#include <conn.h>
+#include <iso.h>
 
 /* List of fakes used by this unit tester */
 #define FFF_FAKES_LIST(FAKE) FAKE(bt_iso_chan_get_tx_sync)

--- a/tests/bluetooth/audio/mocks/src/pacs.c
+++ b/tests/bluetooth/audio/mocks/src/pacs.c
@@ -16,9 +16,9 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "audio/pacs_internal.h"
+#include <audio/pacs_internal.h>
 
-#include "pacs.h"
+#include <pacs.h>
 
 /* List of fakes used by this unit tester */
 #define PACS_FFF_FAKES_LIST(FAKE) \

--- a/tests/bsim/bluetooth/audio/src/bap_bass_broadcaster_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_bass_broadcaster_test.c
@@ -17,7 +17,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -31,8 +31,8 @@
 #include "../../../../../subsys/bluetooth/host/hci_core.h"
 #include "common.h"
 #include "bap_common.h"
-#include "bstests.h"
-#include "syscalls/kernel.h"
+#include <bstests.h>
+#include <syscalls/kernel.h>
 
 #ifdef CONFIG_BT_BAP_BROADCAST_ASSISTANT
 

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_sink_test.c
@@ -34,7 +34,7 @@
 
 #include "bap_common.h"
 #include "bap_stream_rx.h"
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #if defined(CONFIG_BT_BAP_BROADCAST_SINK)

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_source_test.c
@@ -33,7 +33,7 @@
 
 #include "bap_common.h"
 #include "bap_stream_tx.h"
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #define SUPPORTED_CHAN_COUNTS          BT_AUDIO_CODEC_CAP_CHAN_COUNT_SUPPORT(1, 2)

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -28,7 +28,7 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_BAP_SCAN_DELEGATOR

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -34,7 +34,7 @@
 
 #include "bap_stream_rx.h"
 #include "bap_stream_tx.h"
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 #include "bap_common.h"
 

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -33,7 +33,7 @@
 #include "bap_common.h"
 #include "bap_stream_rx.h"
 #include "bap_stream_tx.h"
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #if defined(CONFIG_BT_BAP_UNICAST_SERVER)

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -39,7 +39,7 @@
 
 #include "bap_stream_rx.h"
 #include "bap_stream_tx.h"
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 #include "bap_common.h"
 

--- a/tests/bsim/bluetooth/audio/src/cap_commander_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_commander_test.c
@@ -35,7 +35,7 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 #include "bap_common.h"
 

--- a/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
@@ -39,7 +39,7 @@
 #include "bap_common.h"
 #include "bap_stream_tx.h"
 #include "bap_stream_rx.h"
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 LOG_MODULE_REGISTER(cap_handover_central, LOG_LEVEL_DBG);

--- a/tests/bsim/bluetooth/audio/src/cap_handover_peripheral_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_handover_peripheral_test.c
@@ -39,7 +39,7 @@
 #include <zephyr/toolchain.h>
 
 #include "bap_stream_rx.h"
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 #include "bap_common.h"
 

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -32,7 +32,7 @@
 
 #include "bap_common.h"
 #include "bap_stream_tx.h"
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #if defined(CONFIG_BT_CAP_INITIATOR) && defined(CONFIG_BT_BAP_BROADCAST_SOURCE)

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -39,7 +39,7 @@
 
 #include "bap_stream_tx.h"
 #include "bap_stream_rx.h"
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 #include "bap_common.h"
 

--- a/tests/bsim/bluetooth/audio/src/ccp_call_control_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/ccp_call_control_client_test.c
@@ -15,7 +15,7 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_CCP_CALL_CONTROL_CLIENT

--- a/tests/bsim/bluetooth/audio/src/ccp_call_control_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/ccp_call_control_server_test.c
@@ -17,7 +17,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/logging/log.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_CCP_CALL_CONTROL_SERVER

--- a/tests/bsim/bluetooth/audio/src/common.c
+++ b/tests/bsim/bluetooth/audio/src/common.c
@@ -30,13 +30,13 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "bs_cmd_line.h"
-#include "bs_dynargs.h"
-#include "bs_pc_backchannel.h"
-#include "posix_native_task.h"
-#include "bs_types.h"
-#include "bsim_args_runner.h"
-#include "bstests.h"
+#include <bs_cmd_line.h>
+#include <bs_dynargs.h>
+#include <bs_pc_backchannel.h>
+#include <posix_native_task.h>
+#include <bs_types.h>
+#include <bsim_args_runner.h>
+#include <bstests.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -32,9 +32,9 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/types.h>
 
-#include "bstests.h"
-#include "bs_types.h"
-#include "bs_tracing.h"
+#include <bstests.h>
+#include <bs_types.h>
+#include <bs_tracing.h>
 
 /* Generate 1 KiB of mock data going 0x00, 0x01, ..., 0xff, 0x00, 0x01, ..., 0xff, etc */
 #define ISO_DATA_GEN(_i, _) ((uint8_t)(_i))

--- a/tests/bsim/bluetooth/audio/src/csip_notify_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_notify_client_test.c
@@ -15,9 +15,9 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 extern enum bst_result_t bst_result;
 

--- a/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_notify_server_test.c
@@ -19,7 +19,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/audio/src/csip_set_coordinator_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_coordinator_test.c
@@ -23,7 +23,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_CSIP_SET_COORDINATOR

--- a/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
@@ -17,8 +17,8 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
+#include <bs_tracing.h>
+#include <bstests.h>
 #include "common.h"
 #ifdef CONFIG_BT_CSIP_SET_MEMBER
 static struct bt_csip_set_member_svc_inst *svc_inst;

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -40,7 +40,7 @@
 
 #include "bap_stream_tx.h"
 #include "bap_stream_rx.h"
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 #include "bap_common.h"
 

--- a/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
@@ -32,7 +32,7 @@
 
 #include "bap_stream_rx.h"
 #include "bap_stream_tx.h"
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 #include "bap_common.h"
 

--- a/tests/bsim/bluetooth/audio/src/has_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/has_client_test.c
@@ -21,9 +21,9 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "../../subsys/bluetooth/audio/has_internal.h"
+#include <../../subsys/bluetooth/audio/has_internal.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 LOG_MODULE_REGISTER(has_client_test, LOG_LEVEL_DBG);

--- a/tests/bsim/bluetooth/audio/src/has_test.c
+++ b/tests/bsim/bluetooth/audio/src/has_test.c
@@ -16,7 +16,7 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 LOG_MODULE_REGISTER(has_test, LOG_LEVEL_DBG);

--- a/tests/bsim/bluetooth/audio/src/ias_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/ias_client_test.c
@@ -13,7 +13,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_IAS_CLIENT

--- a/tests/bsim/bluetooth/audio/src/ias_test.c
+++ b/tests/bsim/bluetooth/audio/src/ias_test.c
@@ -16,7 +16,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/types.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_IAS

--- a/tests/bsim/bluetooth/audio/src/main.c
+++ b/tests/bsim/bluetooth/audio/src/main.c
@@ -6,7 +6,7 @@
 
 #include <stddef.h>
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_vcp_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_vcp_vol_ctlr_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/audio/src/mcc_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcc_test.c
@@ -22,7 +22,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_MCC

--- a/tests/bsim/bluetooth/audio/src/mcs_test.c
+++ b/tests/bsim/bluetooth/audio/src/mcs_test.c
@@ -10,7 +10,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/sys/printk.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_MCS

--- a/tests/bsim/bluetooth/audio/src/media_controller_test.c
+++ b/tests/bsim/bluetooth/audio/src/media_controller_test.c
@@ -17,7 +17,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_MCS

--- a/tests/bsim/bluetooth/audio/src/micp_mic_ctlr_test.c
+++ b/tests/bsim/bluetooth/audio/src/micp_mic_ctlr_test.c
@@ -15,7 +15,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_MICP_MIC_CTLR

--- a/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
+++ b/tests/bsim/bluetooth/audio/src/micp_mic_dev_test.c
@@ -17,7 +17,7 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_MICP_MIC_DEV

--- a/tests/bsim/bluetooth/audio/src/pacs_notify_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/pacs_notify_client_test.c
@@ -19,9 +19,9 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 LOG_MODULE_REGISTER(pacs_notify_client_test, LOG_LEVEL_DBG);
 

--- a/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/pacs_notify_server_test.c
@@ -22,7 +22,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 LOG_MODULE_REGISTER(pacs_notify_server_test, LOG_LEVEL_DBG);

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_sink_test.c
@@ -34,7 +34,7 @@
 
 #include "bap_common.h"
 #include "bap_stream_rx.h"
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #if defined(CONFIG_BT_PBP)

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
@@ -28,7 +28,7 @@
 #include <zephyr/toolchain.h>
 
 #include "bap_stream_tx.h"
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #if defined(CONFIG_BT_PBP)

--- a/tests/bsim/bluetooth/audio/src/tbs_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_client_test.c
@@ -17,7 +17,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_TBS_CLIENT

--- a/tests/bsim/bluetooth/audio/src/tbs_test.c
+++ b/tests/bsim/bluetooth/audio/src/tbs_test.c
@@ -19,7 +19,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_TBS

--- a/tests/bsim/bluetooth/audio/src/tmap_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/tmap_client_test.c
@@ -25,7 +25,7 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_TMAP

--- a/tests/bsim/bluetooth/audio/src/tmap_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/tmap_server_test.c
@@ -18,7 +18,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_TMAP

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_ctlr_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_ctlr_test.c
@@ -17,7 +17,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_VCP_VOL_CTLR

--- a/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
+++ b/tests/bsim/bluetooth/audio/src/vcp_vol_rend_test.c
@@ -20,7 +20,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include "common.h"
 
 #ifdef CONFIG_BT_VCP_VOL_REND

--- a/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/src/broadcast_sink_test.c
+++ b/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/src/broadcast_sink_test.c
@@ -8,10 +8,10 @@
 #include <stdint.h>
 #include <zephyr/toolchain.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "bs_utils.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <bs_utils.h>
+#include <bstests.h>
 
 #define WAIT_TIME 120 /* Seconds */
 

--- a/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/src/test_main.c
+++ b/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/src/test_main.c
@@ -5,7 +5,7 @@
  */
 #include <stddef.h>
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_broadcast_sink_test_install(struct bst_test_list *tests);
 

--- a/tests/bsim/bluetooth/audio_samples/bap_unicast_client/src/test_main.c
+++ b/tests/bsim/bluetooth/audio_samples/bap_unicast_client/src/test_main.c
@@ -5,7 +5,7 @@
  */
 #include <stddef.h>
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_unicast_client_sample_install(struct bst_test_list *tests);
 

--- a/tests/bsim/bluetooth/audio_samples/bap_unicast_client/src/unicast_client_sample_test.c
+++ b/tests/bsim/bluetooth/audio_samples/bap_unicast_client/src/unicast_client_sample_test.c
@@ -9,10 +9,10 @@
 
 #include <zephyr/toolchain.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "bs_utils.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <bs_utils.h>
+#include <bstests.h>
 
 #define WAIT_TIME 20 /* Seconds */
 

--- a/tests/bsim/bluetooth/audio_samples/cap/acceptor/src/cap_acceptor_sample_test.c
+++ b/tests/bsim/bluetooth/audio_samples/cap/acceptor/src/cap_acceptor_sample_test.c
@@ -10,10 +10,10 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "bs_utils.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <bs_utils.h>
+#include <bstests.h>
 
 #define WAIT_TIME 15 /* Seconds */
 

--- a/tests/bsim/bluetooth/audio_samples/cap/acceptor/src/test_main.c
+++ b/tests/bsim/bluetooth/audio_samples/cap/acceptor/src/test_main.c
@@ -5,7 +5,7 @@
  */
 #include <stddef.h>
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_cap_acceptor_sample_install(struct bst_test_list *tests);
 

--- a/tests/bsim/bluetooth/audio_samples/cap/initiator/src/cap_initiator_sample_test.c
+++ b/tests/bsim/bluetooth/audio_samples/cap/initiator/src/cap_initiator_sample_test.c
@@ -10,10 +10,10 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "bs_utils.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <bs_utils.h>
+#include <bstests.h>
 
 #define WAIT_TIME 15 /* Seconds */
 

--- a/tests/bsim/bluetooth/audio_samples/cap/initiator/src/test_main.c
+++ b/tests/bsim/bluetooth/audio_samples/cap/initiator/src/test_main.c
@@ -5,7 +5,7 @@
  */
 #include <stddef.h>
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_cap_initiator_sample_install(struct bst_test_list *tests);
 

--- a/tests/bsim/bluetooth/audio_samples/ccp/call_control_client/src/test_main.c
+++ b/tests/bsim/bluetooth/audio_samples/ccp/call_control_client/src/test_main.c
@@ -7,10 +7,10 @@
 #include <stddef.h>
 #include <zephyr/toolchain.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "bs_utils.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <bs_utils.h>
+#include <bstests.h>
 
 #define WAIT_TIME 10 /* Seconds */
 

--- a/tests/bsim/bluetooth/audio_samples/ccp/call_control_server/src/test_main.c
+++ b/tests/bsim/bluetooth/audio_samples/ccp/call_control_server/src/test_main.c
@@ -7,10 +7,10 @@
 #include <stddef.h>
 #include <zephyr/toolchain.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "bs_utils.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <bs_utils.h>
+#include <bstests.h>
 
 #define WAIT_TIME 10 /* Seconds */
 

--- a/tests/bsim/bluetooth/tester/src/audio/bap_broadcast_sink.c
+++ b/tests/bsim/bluetooth/tester/src/audio/bap_broadcast_sink.c
@@ -15,11 +15,11 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_bap_broadcast_sink, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/bap_broadcast_source.c
+++ b/tests/bsim/bluetooth/tester/src/audio/bap_broadcast_source.c
@@ -19,11 +19,11 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_bap_broadcast_source, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/bap_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/bap_central.c
@@ -19,11 +19,11 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_bap_central, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/bap_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/bap_peripheral.c
@@ -12,11 +12,11 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_bap_peripheral, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/cap_broadcast_sink.c
+++ b/tests/bsim/bluetooth/tester/src/audio/cap_broadcast_sink.c
@@ -15,11 +15,11 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_cap_broadcast_sink, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/cap_broadcast_source.c
+++ b/tests/bsim/bluetooth/tester/src/audio/cap_broadcast_source.c
@@ -19,11 +19,11 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_cap_broadcast_source, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/cap_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/cap_central.c
@@ -19,11 +19,11 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_cap_central, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/cap_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/cap_peripheral.c
@@ -12,11 +12,11 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_cap_peripheral, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/ccp_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/ccp_central.c
@@ -13,11 +13,11 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_ccp_central, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/ccp_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/ccp_peripheral.c
@@ -15,11 +15,11 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_ccp_peripheral, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/csip_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/csip_central.c
@@ -12,11 +12,11 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_csip_central, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/csip_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/csip_peripheral.c
@@ -12,11 +12,11 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_csip_peripheral, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/hap_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/hap_central.c
@@ -12,11 +12,11 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_hap_central, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/hap_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/hap_peripheral.c
@@ -13,11 +13,11 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_hap_peripheral, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/mcp_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/mcp_central.c
@@ -15,11 +15,11 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_mcp_central, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/mcp_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/mcp_peripheral.c
@@ -12,11 +12,11 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_mcp_peripheral, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/micp_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/micp_central.c
@@ -14,11 +14,11 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_micp_central, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/micp_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/micp_peripheral.c
@@ -12,11 +12,11 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_micp_peripheral, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/pbp_sink.c
+++ b/tests/bsim/bluetooth/tester/src/audio/pbp_sink.c
@@ -12,11 +12,11 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_pbp_sink, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/pbp_source.c
+++ b/tests/bsim/bluetooth/tester/src/audio/pbp_source.c
@@ -18,11 +18,11 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_pbp_source, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/tmap_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/tmap_central.c
@@ -12,11 +12,11 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_tmap_central, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/tmap_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/tmap_peripheral.c
@@ -12,11 +12,11 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_tmap_peripheral, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/vcp_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/vcp_central.c
@@ -13,11 +13,11 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_vcp_central, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/tester/src/audio/vcp_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/vcp_peripheral.c
@@ -12,11 +12,11 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bstests.h>
 
-#include "btp/btp.h"
-#include "bsim_btp.h"
+#include <btp/btp.h>
+#include <bsim_btp.h>
 
 LOG_MODULE_REGISTER(bsim_vcp_peripheral, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Bluetooth Audio related paths and manually selecting the applicable changes:
```
$ find subsys/bluetooth/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;
