### PR TITLE
Bluetooth: Controller: Diamond include for non-local header files

### DIFF
--- a/subsys/bluetooth/common/rpa.c
+++ b/subsys/bluetooth/common/rpa.c
@@ -15,7 +15,7 @@
 #include <errno.h>
 #include <string.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include <zephyr/bluetooth/crypto.h>
 

--- a/subsys/bluetooth/controller/coex/coex_ticker.c
+++ b/subsys/bluetooth/controller/coex/coex_ticker.c
@@ -16,10 +16,10 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "controller/hal/ticker.h"
-#include "controller/ticker/ticker.h"
-#include "controller/include/ll.h"
-#include "controller/ll_sw/nordic/hal/nrf5/debug.h"
+#include <controller/hal/ticker.h>
+#include <controller/ticker/ticker.h>
+#include <controller/include/ll.h>
+#include <controller/ll_sw/nordic/hal/nrf5/debug.h>
 
 LOG_MODULE_REGISTER(coex_ticker);
 

--- a/subsys/bluetooth/controller/crypto/crypto.c
+++ b/subsys/bluetooth/controller/crypto/crypto.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "util/memq.h"
+#include <util/memq.h>
 
-#include "hal/ecb.h"
-#include "ll_sw/lll.h"
+#include <hal/ecb.h>
+#include <ll_sw/lll.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/controller/flash/soc_flash_nrf_ticker.c
+++ b/subsys/bluetooth/controller/flash/soc_flash_nrf_ticker.c
@@ -13,11 +13,11 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ticker.h"
-#include "ticker/ticker.h"
-#include "ll.h"
+#include <hal/ticker.h>
+#include <ticker/ticker.h>
+#include <ll.h>
 
-#include "soc_flash_nrf.h"
+#include <soc_flash_nrf.h>
 
 #define FLASH_RADIO_ABORT_DELAY_US 1500
 #define FLASH_RADIO_WORK_DELAY_US  200

--- a/subsys/bluetooth/controller/hal/cntr.h
+++ b/subsys/bluetooth/controller/hal/cntr.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/cntr_vendor_hal.h"
+#include <hal/cntr_vendor_hal.h>
 
 void cntr_init(void);
 uint32_t cntr_start(void);

--- a/subsys/bluetooth/controller/hal/cpu.h
+++ b/subsys/bluetooth/controller/hal/cpu.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/cpu_vendor_hal.h"
+#include <hal/cpu_vendor_hal.h>

--- a/subsys/bluetooth/controller/hal/debug.h
+++ b/subsys/bluetooth/controller/hal/debug.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #if defined(CONFIG_BT_CTLR_ASSERT_HANDLER)
 void bt_ctlr_assert_handle(char *file, uint32_t line);
@@ -101,4 +101,4 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_CPU_CORTEX_M));
 #define LL_ASSERT_OVERHEAD(overhead) ARG_UNUSED(overhead)
 #endif /* !CONFIG_BT_CTLR_ASSERT_OVERHEAD_START */
 
-#include "hal/debug_vendor_hal.h"
+#include <hal/debug_vendor_hal.h>

--- a/subsys/bluetooth/controller/hal/radio.h
+++ b/subsys/bluetooth/controller/hal/radio.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/radio_vendor_hal.h"
+#include <hal/radio_vendor_hal.h>

--- a/subsys/bluetooth/controller/hal/radio_df.h
+++ b/subsys/bluetooth/controller/hal/radio_df.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/radio_df_vendor_hal.h"
+#include <hal/radio_df_vendor_hal.h>

--- a/subsys/bluetooth/controller/hal/swi.h
+++ b/subsys/bluetooth/controller/hal/swi.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/swi_vendor_hal.h"
+#include <hal/swi_vendor_hal.h>

--- a/subsys/bluetooth/controller/hal/ticker.h
+++ b/subsys/bluetooth/controller/hal/ticker.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/ticker_vendor_hal.h"
+#include <hal/ticker_vendor_hal.h>
 
 uint8_t hal_ticker_instance0_caller_id_get(uint8_t user_id);
 void hal_ticker_instance0_sched(uint8_t caller_id, uint8_t callee_id, uint8_t chain,

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -21,78 +21,78 @@
 #include <zephyr/bluetooth/hci_vs.h>
 #include <zephyr/bluetooth/buf.h>
 
-#include "common/hci_common_internal.h"
+#include <common/hci_common_internal.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/dbuf.h>
 
-#include "hal/ecb.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/ecb.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "ll_sw/pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "ll_sw/pdu.h"
+#include <ll_sw/pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <ll_sw/pdu.h>
 
-#include "ll_sw/lll.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
-#include "ll_sw/lll_adv.h"
-#include "lll/lll_adv_pdu.h"
-#include "ll_sw/lll_scan.h"
-#include "lll/lll_df_types.h"
-#include "ll_sw/lll_sync.h"
-#include "ll_sw/lll_sync_iso.h"
-#include "ll_sw/lll_conn.h"
-#include "ll_sw/lll_conn_iso.h"
-#include "ll_sw/lll_iso_tx.h"
+#include <ll_sw/lll.h>
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
+#include <ll_sw/lll_adv.h>
+#include <lll/lll_adv_pdu.h>
+#include <ll_sw/lll_scan.h>
+#include <lll/lll_df_types.h>
+#include <ll_sw/lll_sync.h>
+#include <ll_sw/lll_sync_iso.h>
+#include <ll_sw/lll_conn.h>
+#include <ll_sw/lll_conn_iso.h>
+#include <ll_sw/lll_iso_tx.h>
 
-#include "ll_sw/isoal.h"
+#include <ll_sw/isoal.h>
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
-#include "ll_sw/ull_adv_types.h"
-#include "ll_sw/ull_scan_types.h"
-#include "ll_sw/ull_sync_types.h"
-#include "ll_sw/ull_conn_types.h"
-#include "ll_sw/ull_iso_types.h"
-#include "ll_sw/ull_conn_iso_types.h"
-#include "ll_sw/ull_conn_iso_internal.h"
-#include "ll_sw/ull_df_types.h"
-#include "ll_sw/ull_internal.h"
+#include <ll_sw/ull_adv_types.h>
+#include <ll_sw/ull_scan_types.h>
+#include <ll_sw/ull_sync_types.h>
+#include <ll_sw/ull_conn_types.h>
+#include <ll_sw/ull_iso_types.h>
+#include <ll_sw/ull_conn_iso_types.h>
+#include <ll_sw/ull_conn_iso_internal.h>
+#include <ll_sw/ull_df_types.h>
+#include <ll_sw/ull_internal.h>
 
-#include "ll_sw/ull_adv_internal.h"
-#include "ll_sw/ull_sync_internal.h"
-#include "ll_sw/ull_conn_internal.h"
-#include "ll_sw/ull_sync_iso_internal.h"
-#include "ll_sw/ull_iso_internal.h"
-#include "ll_sw/ull_df_internal.h"
+#include <ll_sw/ull_adv_internal.h>
+#include <ll_sw/ull_sync_internal.h>
+#include <ll_sw/ull_conn_internal.h>
+#include <ll_sw/ull_sync_iso_internal.h>
+#include <ll_sw/ull_iso_internal.h>
+#include <ll_sw/ull_df_internal.h>
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
 #include "hci_internal.h"
-#include "hci_vendor.h"
+#include <hci_vendor.h>
 
 #if defined(CONFIG_BT_HCI_MESH_EXT)
-#include "ll_sw/ll_mesh.h"
+#include <ll_sw/ll_mesh.h>
 #endif /* CONFIG_BT_HCI_MESH_EXT */
 
 #if defined(CONFIG_BT_CTLR_DTM_HCI)
-#include "ll_sw/ll_test.h"
+#include <ll_sw/ll_test.h>
 #endif /* CONFIG_BT_CTLR_DTM_HCI */
 
 #if defined(CONFIG_BT_CTLR_USER_EXT)
 #include "hci_user_ext.h"
 #endif /* CONFIG_BT_CTLR_USER_EXT */
 
-#include "common/bt_str.h"
-#include "hal/debug.h"
+#include <common/bt_str.h>
+#include <hal/debug.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -27,38 +27,38 @@
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #endif /* CONFIG_CLOCK_CONTROL_NRF */
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
 #if defined(CONFIG_SOC_FAMILY_NORDIC_NRF)
-#include "hal/radio.h"
+#include <hal/radio.h>
 #endif /* CONFIG_SOC_FAMILY_NORDIC_NRF */
 
-#include "ll_sw/pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "ll_sw/pdu.h"
+#include <ll_sw/pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <ll_sw/pdu.h>
 
-#include "ll_sw/lll.h"
-#include "lll/lll_df_types.h"
-#include "ll_sw/lll_sync_iso.h"
-#include "ll_sw/lll_conn.h"
-#include "ll_sw/lll_conn_iso.h"
-#include "ll_sw/isoal.h"
+#include <ll_sw/lll.h>
+#include <lll/lll_df_types.h>
+#include <ll_sw/lll_sync_iso.h>
+#include <ll_sw/lll_conn.h>
+#include <ll_sw/lll_conn_iso.h>
+#include <ll_sw/isoal.h>
 
-#include "ll_sw/ull_iso_types.h"
-#include "ll_sw/ull_conn_iso_types.h"
+#include <ll_sw/ull_iso_types.h>
+#include <ll_sw/ull_conn_iso_types.h>
 
-#include "ll_sw/ull_iso_internal.h"
-#include "ll_sw/ull_sync_iso_internal.h"
-#include "ll_sw/ull_conn_internal.h"
-#include "ll_sw/ull_conn_iso_internal.h"
+#include <ll_sw/ull_iso_internal.h>
+#include <ll_sw/ull_sync_iso_internal.h>
+#include <ll_sw/ull_conn_internal.h>
+#include <ll_sw/ull_conn_iso_internal.h>
 
-#include "ll.h"
+#include <ll.h>
 
 #include "hci_internal.h"
 

--- a/subsys/bluetooth/controller/ll_sw/isoal.c
+++ b/subsys/bluetooth/controller/ll_sw/isoal.c
@@ -18,16 +18,16 @@
 
 #include <zephyr/sys/byteorder.h>
 
-#include "util/memq.h"
+#include <util/memq.h>
 
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
+#include <ll.h>
 #include "lll.h"
 #include "lll_conn_iso.h"
 #include "lll_iso_tx.h"
@@ -47,7 +47,7 @@ LOG_MODULE_REGISTER(bt_ctlr_isoal, CONFIG_BT_CTLR_ISOAL_LOG_LEVEL);
 #define ISOAL_LOG_DBGV(...)    (void) 0
 #endif /* CONFIG_BT_CTLR_ISOAL_LOG_DBG_VERBOSE */
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define FSM_TO_STR(s) (s == ISOAL_START ? "START" : \
 	(s == ISOAL_CONTINUE ? "CONTINUE" : \

--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -12,20 +12,20 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/controller.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_scan.h"
 
 #include "ull_adv_types.h"
@@ -33,7 +33,7 @@
 #include "ull_adv_internal.h"
 #include "ull_scan_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
 static uint8_t pub_addr[BDADDR_SIZE];
 static uint8_t rnd_addr[BDADDR_SIZE];

--- a/subsys/bluetooth/controller/ll_sw/ll_feat.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_feat.c
@@ -7,28 +7,28 @@
 
 #include <zephyr/kernel.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 
 #include "ull_conn_internal.h"
 
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll_feat.h>
+#include <ll_settings.h>
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_CTLR_SET_HOST_FEATURE)
 static uint64_t host_features;

--- a/subsys/bluetooth/controller/ll_sw/ll_settings.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_settings.c
@@ -6,13 +6,13 @@
 
 #include <zephyr/settings/settings.h>
 
-#include "ll_settings.h"
+#include <ll_settings.h>
 
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(bt_ctlr_ll_settings, LOG_LEVEL_DBG);
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_CTLR_VERSION_SETTINGS)
 

--- a/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
@@ -10,28 +10,28 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/hci_vs.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
@@ -41,7 +41,7 @@
 #include "ull_scan_internal.h"
 #include "ull_conn_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
 uint8_t ll_tx_pwr_lvl_get(uint8_t handle_type,
 		       uint16_t handle, uint8_t type, int8_t *tx_pwr_lvl)

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -5,7 +5,7 @@
  */
 
 #if defined(CONFIG_BT_CTLR_RX_PDU_META)
-#include "lll_meta.h"
+#include <lll_meta.h>
 #endif /* CONFIG_BT_CTLR_RX_PDU_META */
 
 #define TICKER_INSTANCE_ID_CTLR 0

--- a/subsys/bluetooth/controller/ll_sw/lll_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_chan.c
@@ -7,11 +7,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static uint8_t chan_sel_remap(uint8_t *chan_map, uint8_t chan_index);
 #if defined(CONFIG_BT_CTLR_CHAN_SEL_2)

--- a/subsys/bluetooth/controller/ll_sw/lll_common.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_common.c
@@ -8,12 +8,12 @@
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 
-#include "util/mem.h"
-#include "util/memq.h"
+#include <util/mem.h>
+#include <util/memq.h>
 
 #include "lll.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /**
  * @brief Common entry point for LLL event prepare invocations from ULL.

--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #if defined(CONFIG_BT_CTLR_CONN_META)
-#include "lll_conn_meta.h"
+#include <lll_conn_meta.h>
 #endif /* CONFIG_BT_CTLR_CONN_META */
 
 #define LLL_CONN_RSSI_SAMPLE_COUNT 10

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/cntr_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/cntr_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/cntr.h"
+#include <hal/nrf5/cntr.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/cpu_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/cpu_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/cpu.h"
+#include <hal/nrf5/cpu.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/debug_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/debug_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/debug.h"
+#include <hal/nrf5/debug.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cntr.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cntr.c
@@ -7,9 +7,9 @@
 
 #include <stdint.h>
 
-#include "hal/cntr.h"
+#include <hal/cntr.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if !defined(CONFIG_BT_CTLR_NRF_GRTC)
 #include <hal/nrf_rtc.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
@@ -12,12 +12,12 @@
 
 #include <hal/nrf_ecb.h>
 
-#include "util/mem.h"
+#include <util/mem.h>
 
-#include "hal/cpu.h"
-#include "hal/ecb.h"
+#include <hal/cpu.h>
+#include <hal/ecb.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(NRF_ECB00) /* In some devices NRF_ECB was renamed NRF_ECB00 */
 #define NRF_ECB                   NRF_ECB00

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/mayfly.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/mayfly.c
@@ -7,14 +7,14 @@
 
 #include <soc.h>
 
-#include "hal/nrf5/swi.h"
+#include <hal/nrf5/swi.h>
 
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "ll_sw/lll.h"
+#include <ll_sw/lll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define MAYFLY_CALL_ID_LLL    TICKER_USER_ID_LLL
 #define MAYFLY_CALL_ID_WORKER TICKER_USER_ID_ULL_HIGH

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -14,18 +14,18 @@
 #include <nrfx_gpiote.h>
 #include <gpiote_nrfx.h>
 
-#include "util/mem.h"
+#include <util/mem.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/cntr.h"
-#include "hal/radio.h"
-#include "hal/radio_df.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/cntr.h>
+#include <hal/radio.h>
+#include <hal/radio_df.h>
+#include <hal/ticker.h>
 
-#include "ll_sw/pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "ll_sw/pdu.h"
+#include <ll_sw/pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <ll_sw/pdu.h>
 
 #include "radio_internal.h"
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
@@ -13,9 +13,9 @@
 #include <hal/nrf_gpio.h>
 #include <hal/ccm.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
 #include "radio_nrf5.h"
 #include "radio.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
@@ -79,7 +79,7 @@
 #include "radio_nrf5_fem.h"
 
 /* Include RTC/GRTC Compare Index used to Trigger Radio TXEN/RXEN */
-#include "hal/cntr.h"
+#include <hal/cntr.h>
 
 #if defined(CONFIG_SOC_SERIES_NRF51) || defined(CONFIG_SOC_COMPATIBLE_NRF52X)
 #include <hal/nrf_ppi.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.c
@@ -10,16 +10,16 @@
 
 #include <zephyr/sys/util.h>
 
-#include "hal/cntr.h"
+#include <hal/cntr.h>
 
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "ll_sw/lll.h"
+#include <ll_sw/lll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define TICKER_MAYFLY_CALL_ID_ISR     TICKER_USER_ID_LLL
 #define TICKER_MAYFLY_CALL_ID_TRIGGER TICKER_USER_ID_ULL_HIGH

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/radio_df_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/radio_df_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/radio/radio_df.h"
+#include <hal/nrf5/radio/radio_df.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/radio_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/radio_vendor_hal.h
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/radio/radio.h"
-#include "hal/nrf5/radio/radio_nrf5.h"
-#include "hal/nrf5/radio/radio_nrf5_txp.h"
+#include <hal/nrf5/radio/radio.h>
+#include <hal/nrf5/radio/radio_nrf5.h>
+#include <hal/nrf5/radio/radio_nrf5_txp.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/swi_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/swi_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/swi.h"
+#include <hal/nrf5/swi.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/ticker_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/ticker_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/nrf5/ticker.h"
+#include <hal/nrf5/ticker.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -16,25 +16,25 @@
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/irq.h>
 
-#include "hal/swi.h"
-#include "hal/ccm.h"
-#include "hal/cntr.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/swi.h>
+#include <hal/ccm.h>
+#include <hal/cntr.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
+#include <lll_clock.h>
 #include "lll_internal.h"
 #include "lll_prof_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_CTLR_ZLI)
 #define IRQ_CONNECT_FLAGS IRQ_ZERO_LATENCY

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -11,36 +11,36 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
+#include <lll_clock.h>
 #include "lll_adv_types.h"
-#include "lll_adv.h"
+#include <lll_adv.h>
 #include "lll_adv_pdu.h"
-#include "lll_adv_aux.h"
-#include "lll_adv_sync.h"
+#include <lll_adv_aux.h>
+#include <lll_adv_sync.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_chan.h"
-#include "lll_filter.h"
+#include <lll_conn.h>
+#include <lll_chan.h>
+#include <lll_filter.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
@@ -48,7 +48,7 @@
 #include "lll_prof_internal.h"
 #include "lll_df_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define PDU_FREE_TIMEOUT K_SECONDS(5)
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -11,41 +11,41 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <soc.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_chan.h"
+#include <lll_clock.h>
+#include <lll_chan.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
+#include <lll_conn.h>
 #include "lll_adv_types.h"
-#include "lll_adv.h"
+#include <lll_adv.h>
 #include "lll_adv_pdu.h"
-#include "lll_adv_aux.h"
-#include "lll_adv_sync.h"
-#include "lll_filter.h"
+#include <lll_adv_aux.h>
+#include <lll_adv_sync.h>
+#include <lll_filter.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_adv_internal.h"
 #include "lll_prof_internal.h"
 
-#include "ull_adv_types.h"
+#include <ull_adv_types.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -11,36 +11,36 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_clock.h"
-#include "lll_chan.h"
+#include <lll.h>
+#include <lll_clock.h>
+#include <lll_chan.h>
 #include "lll_vendor.h"
 #include "lll_adv_types.h"
-#include "lll_adv.h"
+#include <lll_adv.h>
 #include "lll_adv_pdu.h"
-#include "lll_adv_iso.h"
-#include "lll_iso_tx.h"
+#include <lll_adv_iso.h>
+#include <lll_iso_tx.h>
 
 #include "lll_internal.h"
 #include "lll_adv_iso_internal.h"
 #include "lll_prof_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define TEST_WITH_DUMMY_PDU 0
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -10,30 +10,30 @@
 
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
-#include "hal/radio_df.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
+#include <hal/radio_df.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_chan.h"
+#include <lll_clock.h>
+#include <lll_chan.h>
 #include "lll_adv_types.h"
-#include "lll_adv.h"
+#include <lll_adv.h>
 #include "lll_adv_pdu.h"
-#include "lll_adv_sync.h"
-#include "lll_adv_iso.h"
+#include <lll_adv_sync.h>
+#include <lll_adv_iso.h>
 #include "lll_df_types.h"
 
 #include "lll_internal.h"
@@ -42,7 +42,7 @@
 #include "lll_prof_internal.h"
 #include "lll_df_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
@@ -12,33 +12,33 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/radio_df.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/radio_df.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
+#include <lll_clock.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_central.h"
-#include "lll_chan.h"
+#include <lll_conn.h>
+#include <lll_central.h>
+#include <lll_chan.h>
 
 #include "lll_internal.h"
 #include "lll_df_internal.h"
 #include "lll_tim_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -8,37 +8,37 @@
 
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_chan.h"
+#include <lll_clock.h>
+#include <lll_chan.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
-#include "lll_central_iso.h"
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
+#include <lll_central_iso.h>
 
-#include "lll_iso_tx.h"
+#include <lll_iso_tx.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -10,7 +10,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* LF (XO, RC) clock setup timeout.
  * LF settling time can vary on the type of the source.

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -13,26 +13,26 @@
 
 #include <zephyr/sys/util.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/radio_df.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/radio_df.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_clock.h"
+#include <lll.h>
+#include <lll_clock.h>
 #include "lll_df_types.h"
-#include "lll_df.h"
-#include "lll_conn.h"
+#include <lll_df.h>
+#include <lll_conn.h>
 
 #include "lll_internal.h"
 #include "lll_df_internal.h"
@@ -41,7 +41,7 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static void isr_done(void *param);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn_iso.c
@@ -10,20 +10,20 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/memq.h"
-#include "util/mem.h"
+#include <util/memq.h>
+#include <util/mem.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll_conn_iso.h>
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 
 int lll_conn_iso_init(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
@@ -8,29 +8,29 @@
 #include <soc.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/dbuf.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio_df.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio_df.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_adv_types.h"
-#include "lll_adv.h"
+#include <lll_adv.h>
 #include "lll_adv_pdu.h"
 #include "lll_df_types.h"
-#include "lll_sync.h"
-#include "lll_df.h"
+#include <lll_sync.h>
+#include <lll_df.h>
 #include "lll_df_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Minimum number of antenna switch patterns required by Direction Finding Extension to be
  * configured in SWTICHPATTER register. The value is set to 2, even though the radio peripheral

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -11,32 +11,32 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
+#include <lll_clock.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_peripheral.h"
-#include "lll_chan.h"
+#include <lll_conn.h>
+#include <lll_peripheral.h>
+#include <lll_chan.h>
 
 #include "lll_internal.h"
 #include "lll_df_internal.h"
 #include "lll_tim_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -8,37 +8,37 @@
 
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_clock.h"
-#include "lll/lll_df_types.h"
-#include "lll_chan.h"
+#include <lll.h>
+#include <lll_clock.h>
+#include <lll/lll_df_types.h>
+#include <lll_chan.h>
 #include "lll_vendor.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
-#include "lll_peripheral_iso.h"
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
+#include <lll_peripheral_iso.h>
 
-#include "lll_iso_tx.h"
+#include <lll_iso_tx.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_prof.c
@@ -10,21 +10,21 @@
 
 #include <zephyr/toolchain.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/memq.h"
+#include <util/memq.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Below profiling measurements using a sample with:
  * 1 connectable legacy advertising or 1 peripheral ACL,

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -11,39 +11,39 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
-#include "util/mayfly.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
+#include <lll_clock.h>
 #include "lll_df_types.h"
-#include "lll_scan.h"
-#include "lll_sync.h"
-#include "lll_conn.h"
-#include "lll_chan.h"
-#include "lll_filter.h"
-#include "lll_sched.h"
+#include <lll_scan.h>
+#include <lll_sync.h>
+#include <lll_conn.h>
+#include <lll_chan.h>
+#include <lll_filter.h>
+#include <lll_sched.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 #include "lll_scan_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Maximum primary Advertising Radio Channels to scan */
 #define ADV_CHAN_MAX 3U

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -11,32 +11,32 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
-#include "hal/radio_df.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
+#include <hal/radio_df.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
-#include "util/mayfly.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
+#include <util/mayfly.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_filter.h"
-#include "lll_scan.h"
-#include "lll_scan_aux.h"
+#include <lll_clock.h>
+#include <lll_filter.h>
+#include <lll_scan.h>
+#include <lll_scan_aux.h>
 #include "lll_df_types.h"
 #include "lll_df_internal.h"
-#include "lll_sync.h"
-#include "lll_sync_iso.h"
-#include "lll_conn.h"
-#include "lll_sched.h"
+#include <lll_sync.h>
+#include <lll_sync_iso.h>
+#include <lll_conn.h>
+#include <lll_sched.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
@@ -44,11 +44,11 @@
 #include "lll_scan_internal.h"
 #include "lll_sync_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
 #include <soc.h>
 #include <ull_scan_types.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -9,41 +9,41 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
-#include "hal/radio_df.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
+#include <hal/radio_df.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_chan.h"
+#include <lll_clock.h>
+#include <lll_chan.h>
 #include "lll_df_types.h"
-#include "lll_scan.h"
-#include "lll_sync.h"
+#include <lll_scan.h>
+#include <lll_sync.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 #include "lll_scan_internal.h"
 
-#include "lll_df.h"
+#include <lll_df.h>
 #include "lll_df_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
 #include <zephyr/bluetooth/hci_types.h>
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int create_prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -12,32 +12,32 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_chan.h"
-#include "lll_sync_iso.h"
+#include <lll_clock.h>
+#include <lll_chan.h>
+#include <lll_sync_iso.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int create_prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -11,40 +11,40 @@
 
 #include <soc.h>
 
-#include "hal/cpu.h"
-#include "hal/cntr.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
-#include "hal/radio.h"
-#include "hal/radio_df.h"
+#include <hal/cpu.h>
+#include <hal/cntr.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
+#include <hal/radio.h>
+#include <hal/radio_df.h>
 
-#include "util/memq.h"
-#include "util/util.h"
-#include "util/dbuf.h"
+#include <util/memq.h>
+#include <util/util.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
+#include <pdu_df.h>
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_clock.h"
+#include <lll.h>
+#include <lll_clock.h>
 #include "lll_internal.h"
 
 #if defined(CONFIG_BT_CTLR_DF)
 #include "lll_df_types.h"
-#include "lll_df.h"
+#include <lll_df.h>
 #endif /* CONFIG_BT_CTLR_DF */
 
-#include "ll_test.h"
+#include <ll_test.h>
 
 #if defined(CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT)
-#include "ull_df_types.h"
-#include "ull_df_internal.h"
+#include <ull_df_types.h>
+#include <ull_df_internal.h>
 #endif /* CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT */
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Define to setup radio start offset by a maximum ISR latency value that is less than inter-frame
  * switching, plus minimum counter compare offset that can be set, plus minimum CPU latency to set

--- a/subsys/bluetooth/controller/ll_sw/nordic/ull/ull_iso_vendor.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/ull/ull_iso_vendor.c
@@ -11,23 +11,23 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "util/util.h"
-#include "util/memq.h"
+#include <util/util.h>
+#include <util/memq.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_conn.h"
+#include <lll.h>
+#include <lll_conn.h>
 
-#include "isoal.h"
+#include <isoal.h>
 
-#include "ull_iso_types.h"
-#include "ull_conn_internal.h"
-#include "ull_internal.h"
+#include <ull_iso_types.h>
+#include <ull_conn_internal.h>
+#include <ull_internal.h>
 
 /* FIXME: Implement vendor specific data path configuration */
 static bool dummy;

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/cntr.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/cntr.c
@@ -10,8 +10,8 @@
 
 #include <zephyr/dt-bindings/interrupt-controller/openisa-intmux.h>
 
-#include "hal/cntr.h"
-#include "hal/debug.h"
+#include <hal/cntr.h>
+#include <hal/debug.h>
 
 #include "ll_irqs.h"
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ecb.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ecb.c
@@ -12,12 +12,12 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ecb.h"
+#include <hal/ecb.h>
 
 #include <zephyr/logging/log.h>
 
-#include "hal/debug.h"
-#include "fsl_cau3_ble.h"
+#include <hal/debug.h>
+#include <fsl_cau3_ble.h>
 
 LOG_MODULE_REGISTER(bt_ctlr_rv32m1_ecb, LOG_LEVEL_DBG);
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/mayfly.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/mayfly.c
@@ -9,15 +9,15 @@
 #include <zephyr/types.h>
 #include <soc.h>
 
-#include "hal/RV32M1/swi.h"
+#include <hal/RV32M1/swi.h>
 
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_LL_SW_SPLIT)
-#include "ll_sw/lll.h"
+#include <ll_sw/lll.h>
 #define MAYFLY_CALL_ID_LLL    TICKER_USER_ID_LLL
 #define MAYFLY_CALL_ID_WORKER TICKER_USER_ID_ULL_HIGH
 #define MAYFLY_CALL_ID_JOB    TICKER_USER_ID_ULL_LOW

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/radio/radio.c
@@ -14,24 +14,24 @@
 #include <zephyr/irq.h>
 #include <errno.h>
 
-#include "util/mem.h"
+#include <util/mem.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
 
-#include "lll/pdu_vendor.h"
-#include "ll_sw/pdu.h"
+#include <lll/pdu_vendor.h>
+#include <ll_sw/pdu.h>
 
-#include "fsl_xcvr.h"
-#include "hal/cntr.h"
-#include "hal/ticker.h"
-#include "hal/swi.h"
-#include "fsl_cau3_ble.h"	/* must be after irq.h */
+#include <fsl_xcvr.h>
+#include <hal/cntr.h>
+#include <hal/ticker.h>
+#include <hal/swi.h>
+#include <fsl_cau3_ble.h>	/* must be after irq.h */
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ticker.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/ticker.c
@@ -8,17 +8,17 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "hal/cntr.h"
+#include <hal/cntr.h>
 
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_LL_SW_SPLIT)
-#include "ll_sw/lll.h"
+#include <ll_sw/lll.h>
 #define TICKER_MAYFLY_CALL_ID_ISR     TICKER_USER_ID_LLL
 #define TICKER_MAYFLY_CALL_ID_TRIGGER TICKER_USER_ID_ULL_HIGH
 #define TICKER_MAYFLY_CALL_ID_WORKER  TICKER_USER_ID_ULL_HIGH

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/cntr_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/cntr_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/RV32M1/cntr.h"
+#include <hal/RV32M1/cntr.h>

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/cpu_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/cpu_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/RV32M1/cpu.h"
+#include <hal/RV32M1/cpu.h>

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/debug_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/debug_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/RV32M1/debug.h"
+#include <hal/RV32M1/debug.h>

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/radio_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/radio_vendor_hal.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/RV32M1/radio/radio.h"
+#include <hal/RV32M1/radio/radio.h>
 
 /* The openisa vendor HAL does not have the GPIO support functions
  * required for handling radio front-end modules with PA/LNAs.

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/swi_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/swi_vendor_hal.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hal/RV32M1/swi.h"
+#include <hal/RV32M1/swi.h>

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/ticker_vendor_hal.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/ticker_vendor_hal.h
@@ -3,4 +3,4 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "hal/RV32M1/ticker.h"
+#include <hal/RV32M1/ticker.h>

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -17,22 +17,22 @@
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/irq.h>
 
-#include "hal/swi.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/swi.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
 #include "lll_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static struct {
 	struct {

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -13,37 +13,37 @@
 #include <zephyr/sys/byteorder.h>
 #include <soc.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
 #include "lll_adv_types.h"
-#include "lll_adv.h"
+#include <lll_adv.h>
 #include "lll_adv_pdu.h"
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_chan.h"
-#include "lll_filter.h"
+#include <lll_conn.h>
+#include <lll_chan.h>
+#include <lll_filter.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_adv_internal.h"
 #include "lll_prof_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *prepare_param);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_central.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_central.c
@@ -10,28 +10,28 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
+#include <util/util.h>
+#include <util/memq.h>
 
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_central.h"
-#include "lll_chan.h"
+#include <lll_conn.h>
+#include <lll_central.h>
+#include <lll_chan.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_clock.c
@@ -9,7 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static uint16_t const sca_ppm_lut[] = {500, 250, 150, 100, 75, 50, 30, 20};
 

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_conn.c
@@ -12,27 +12,27 @@
 #include <soc.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
 
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
+#include <lll_conn.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static void isr_done(void *param);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_peripheral.c
@@ -10,28 +10,28 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
+#include <util/util.h>
+#include <util/memq.h>
 
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_peripheral.h"
-#include "lll_chan.h"
+#include <lll_conn.h>
+#include <lll_peripheral.h>
+#include <lll_chan.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *p);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_prof.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_prof.c
@@ -7,15 +7,15 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
 
-#include "util/memq.h"
+#include <util/memq.h>
 
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 
 static uint8_t latency_min = (uint8_t) -1;
 static uint8_t latency_max;

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_scan.c
@@ -13,34 +13,34 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_vendor.h"
-#include "pdu.h"
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_vendor.h"
-#include "lll_clock.h"
-#include "lll_scan.h"
+#include <lll_clock.h>
+#include <lll_scan.h>
 #include "lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_chan.h"
-#include "lll_filter.h"
+#include <lll_conn.h>
+#include <lll_chan.h>
+#include <lll_filter.h>
 
 #include "lll_internal.h"
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static int prepare_cb(struct lll_prepare_param *prepare_param);

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_test.c
@@ -12,19 +12,19 @@
 #include <soc.h>
 #include <zephyr/drivers/clock_control.h>
 
-#include "hal/cpu.h"
-#include "hal/cntr.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
+#include <hal/cpu.h>
+#include <hal/cntr.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
 
-#include "util/memq.h"
+#include <util/memq.h>
 
-#include "lll.h"
+#include <lll.h>
 #include "lll_internal.h"
 
-#include "ll_test.h"
+#include <ll_test.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define CNTR_MIN_DELTA 3
 

--- a/subsys/bluetooth/controller/ll_sw/shell/ll.c
+++ b/subsys/bluetooth/controller/ll_sw/shell/ll.c
@@ -19,10 +19,10 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "controller/util/memq.h"
-#include "controller/include/ll.h"
+#include <controller/util/memq.h>
+#include <controller/include/ll.h>
 
-#include "host/shell/bt.h"
+#include <host/shell/bt.h>
 
 int cmd_ll_addr_read(const struct shell *sh, size_t argc, char *argv[])
 {
@@ -51,7 +51,7 @@ int cmd_ll_addr_read(const struct shell *sh, size_t argc, char *argv[])
 }
 
 #if defined(CONFIG_BT_CTLR_DTM)
-#include "controller/ll_sw/ll_test.h"
+#include <controller/ll_sw/ll_test.h>
 
 int cmd_test_tx(const struct shell *sh, size_t  argc, char *argv[])
 {
@@ -121,7 +121,7 @@ int cmd_test_end(const struct shell *sh, size_t  argc, char *argv[])
 #endif /* CONFIG_BT_CTLR_DTM */
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-#include "controller/ll_sw/lll.h"
+#include <controller/ll_sw/lll.h>
 
 #if defined(CONFIG_BT_BROADCASTER)
 #define OWN_ADDR_TYPE 1

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -14,33 +14,33 @@
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/cpu.h"
-#include "hal/ecb.h"
-#include "hal/ccm.h"
-#include "hal/cntr.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ecb.h>
+#include <hal/ccm.h>
+#include <hal/cntr.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/mfifo.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/mfifo.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_chan.h"
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_iso_tx.h"
@@ -51,14 +51,14 @@
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
 #include "ull_sync_types.h"
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 #include "ull_conn_types.h"
 #include "ull_filter.h"
 #include "ull_df_types.h"
 #include "ull_df_internal.h"
 
 #if defined(CONFIG_BT_CTLR_USER_EXT)
-#include "ull_vendor.h"
+#include <ull_vendor.h>
 #endif /* CONFIG_BT_CTLR_USER_EXT */
 
 #include "isoal.h"
@@ -81,14 +81,14 @@
 #include "ull_conn_iso_internal.h"
 #include "ull_peripheral_iso_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
+#include <ll.h>
+#include <ll_feat.h>
 #include "ll_test.h"
-#include "ll_settings.h"
+#include <ll_settings.h>
 
-#include "lll/lll_prof_internal.h"
+#include <lll/lll_prof_internal.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define TEST_TICKER_NODES         (TICKER_NODES)
 #define TEST_TICKER_TICKS_SLOT_US 100000U

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -12,37 +12,37 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
-#include "hal/cntr.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
+#include <hal/cntr.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_filter.h"
 #include "lll_conn_iso.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
@@ -54,18 +54,18 @@
 #include "ull_conn_internal.h"
 #include "ull_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
-#include "ll_sw/isoal.h"
-#include "ll_sw/ull_iso_types.h"
-#include "ll_sw/ull_conn_iso_types.h"
+#include <ll_sw/isoal.h>
+#include <ll_sw/ull_iso_types.h>
+#include <ll_sw/ull_conn_iso_types.h>
 
-#include "ll_sw/ull_llcp.h"
+#include <ll_sw/ull_llcp.h>
 
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 inline struct ll_adv_set *ull_adv_set_get(uint8_t handle);
 inline uint16_t ull_adv_handle_get(struct ll_adv_set *adv);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -9,31 +9,31 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 #include "lll_chan.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_adv_aux.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 
 #include "ull_adv_types.h"
@@ -43,9 +43,9 @@
 #include "ull_adv_internal.h"
 #include "ull_sched_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -9,27 +9,27 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
-#include "util/mayfly.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
+#include <util/mayfly.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_adv_iso.h"
 #include "lll_iso_tx.h"
 
@@ -44,12 +44,12 @@
 #include "ull_sched_internal.h"
 #include "ull_iso_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
+#include <ll.h>
+#include <ll_feat.h>
 
-#include "bt_crypto.h"
+#include <bt_crypto.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Controller implementation dependent minimum Pre-Transmission Offset and
  * Pre-Transmission Group Count to use when there is available time space in the

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -9,30 +9,30 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_adv_sync.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_chan.h"
 
@@ -51,9 +51,9 @@
 #include "ull_conn_iso_types.h"
 #include "ull_llcp.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_CTLR_ADV_SYNC_PDU_LINK)
 /* First PDU contains up to PDU_AC_EXT_AD_DATA_LEN_MAX, next ones PDU_AC_EXT_PAYLOAD_SIZE_MAX */

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -9,38 +9,38 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_chan.h"
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_central.h"
 #include "lll_filter.h"
 #include "lll_conn_iso.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
@@ -53,18 +53,18 @@
 #include "ull_conn_internal.h"
 #include "ull_central_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
-#include "ll_sw/isoal.h"
-#include "ll_sw/ull_iso_types.h"
-#include "ll_sw/ull_conn_iso_types.h"
-#include "ll_sw/ull_conn_iso_internal.h"
+#include <ll_sw/isoal.h>
+#include <ll_sw/ull_iso_types.h>
+#include <ll_sw/ull_conn_iso_types.h>
+#include <ll_sw/ull_conn_iso_internal.h>
 
-#include "ll_sw/ull_llcp.h"
+#include <ll_sw/ull_llcp.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static void ticker_op_stop_scan_cb(uint32_t status, void *param);
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_CTLR_PHY_CODED)

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -10,24 +10,24 @@
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/iso.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 #include "lll_clock.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_central_iso.h"
@@ -47,12 +47,12 @@
 #include "ull_conn_internal.h"
 #include "ull_conn_iso_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
+#include <ll.h>
+#include <ll_feat.h>
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define SDU_MAX_DRIFT_PPM 100
 #define SUB_INTERVAL_MIN  400

--- a/subsys/bluetooth/controller/ll_sw/ull_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_chan.c
@@ -11,22 +11,22 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/sys/util.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/dbuf.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_adv_pdu.h>
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 
 #include "ull_adv_types.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -13,32 +13,32 @@
 
 #include <soc.h>
 
-#include "hal/cpu.h"
-#include "hal/ecb.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ecb.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "isoal.h"
 #include "ull_iso_types.h"
@@ -46,7 +46,7 @@
 #include "ull_conn_iso_types.h"
 
 #if defined(CONFIG_BT_CTLR_USER_EXT)
-#include "ull_vendor.h"
+#include <ull_vendor.h>
 #endif /* CONFIG_BT_CTLR_USER_EXT */
 
 #include "ull_internal.h"
@@ -61,7 +61,7 @@
 #include "ull_conn_iso_internal.h"
 #include "ull_central_iso_internal.h"
 #include "ull_peripheral_iso_internal.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
 #include "ull_adv_types.h"
 #include "ull_adv_internal.h"
@@ -72,14 +72,14 @@
 #include "ull_scan_types.h"
 #include "ull_sync_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
-#include "ll_sw/ull_llcp.h"
-#include "ll_sw/ull_llcp_features.h"
+#include <ll_sw/ull_llcp.h>
+#include <ll_sw/ull_llcp_features.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -9,32 +9,32 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 #include "lll_clock.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_central_iso.h"
 #include "lll_peripheral_iso.h"
 #include "lll_iso_tx.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "isoal.h"
 
@@ -50,9 +50,9 @@
 #include "ull_conn_iso_internal.h"
 #include "ull_peripheral_iso_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Used by LISTIFY */
 #define _INIT_MAYFLY_ARRAY(_i, _l, _fp) \

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -10,31 +10,31 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_df.h"
-#include "lll/lll_df_internal.h"
+#include <lll/lll_df_internal.h>
 
 #include "isoal.h"
 #include "ull_scan_types.h"
@@ -53,9 +53,9 @@
 #include "ull_conn_internal.h"
 #include "ull_df_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX) || defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX) || \
 	defined(CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT)

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -11,29 +11,29 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_filter.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
@@ -45,9 +45,9 @@
 #include "ull_scan_internal.h"
 #include "ull_conn_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -60,7 +60,7 @@ LOG_MODULE_REGISTER(bt_ctlr_ull_filter);
 static struct lll_filter fal_filter;
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
-#include "common/rpa.h"
+#include <common/rpa.h>
 
 /* Filter Accept List peer list */
 static struct lll_fal fal[CONFIG_BT_CTLR_FAL_SIZE];

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -12,37 +12,37 @@
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_adv_iso.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_iso_tx.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "isoal.h"
 
@@ -60,10 +60,10 @@
 #include "ull_sync_iso_internal.h"
 #include "ull_conn_iso_internal.h"
 
-#include "ll.h"
-#include "ll_feat.h"
+#include <ll.h>
+#include <ll_feat.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -12,33 +12,33 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
-#include "util/mayfly.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
+#include <util/mayfly.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_scan.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 
 #include "ull_tx_queue.h"
 
@@ -64,7 +64,7 @@
 #include "ull_filter.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define LLCTRL_PDU_SIZE (offsetof(struct pdu_data, llctrl) + sizeof(struct pdu_data_llctrl))
 #define PROC_CTX_BUF_SIZE WB_UP(sizeof(struct proc_ctx))

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -12,24 +12,24 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ecb.h"
-#include "hal/ccm.h"
+#include <hal/ecb.h>
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -51,7 +51,7 @@
 #include "ull_central_iso_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #include <zephyr/bluetooth/iso.h>
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
@@ -12,22 +12,22 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -44,7 +44,7 @@
 #include "ull_conn_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Hardcoded instant delta +6 */
 #define CHMU_INSTANT_DELTA 6U

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -12,32 +12,32 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
-#include "util/mayfly.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
+#include <util/mayfly.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "ll_feat.h"
-#include "lll/lll_df_types.h"
+#include <ll_feat.h>
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_scan.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 
 #include "ull_tx_queue.h"
 
@@ -62,7 +62,7 @@
 #include "ull_llcp_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* LLCP Local Procedure FSM states */
 enum {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -12,23 +12,23 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 
 #include "lll_conn_iso.h"
@@ -44,7 +44,7 @@
 #include "ull_conn_types.h"
 
 #if defined(CONFIG_BT_CTLR_USER_EXT)
-#include "ull_vendor.h"
+#include <ull_vendor.h>
 #endif /* CONFIG_BT_CTLR_USER_EXT */
 
 #include "ull_internal.h"
@@ -53,7 +53,7 @@
 #include "ull_llcp_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Hardcoded instant delta +6 */
 #define CONN_UPDATE_INSTANT_DELTA	6U

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
@@ -11,24 +11,24 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/ecb.h"
-#include "hal/ccm.h"
+#include <hal/ecb.h>
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -47,7 +47,7 @@
 #include "ull_conn_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #if defined(CONFIG_BT_CENTRAL)
 /* LLCP Local Procedure Encryption FSM states */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -12,23 +12,23 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -46,7 +46,7 @@
 #include "ull_conn_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static struct proc_ctx *lr_dequeue(struct ll_conn *conn);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_past.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_past.c
@@ -9,19 +9,19 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
-#include "hal/debug.h"
+#include <hal/ccm.h>
+#include <hal/debug.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_filter.h"
 #include "lll_scan.h"
 #include "lll_sync.h"
@@ -38,8 +38,8 @@
 #include "ull_conn_types.h"
 #include "ull_conn_iso_types.h"
 
-#include "ll_settings.h"
-#include "ll_feat.h"
+#include <ll_settings.h>
+#include <ll_feat.h>
 
 #include "ull_llcp.h"
 #include "ull_llcp_features.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -12,24 +12,24 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_settings.h>
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -40,7 +40,7 @@
 #include "ull_conn_iso_types.h"
 #include "ull_conn_iso_internal.h"
 
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
 #include "ull_adv_types.h"
 #include "lll_sync.h"
@@ -50,10 +50,10 @@
 #include "ull_llcp.h"
 #include "ull_llcp_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /*
  * we need to filter on octet 0; the following mask has 7 octets

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -12,23 +12,23 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_settings.h"
+#include <ll.h>
+#include <ll_settings.h>
 
 #include "lll.h"
-#include "ll_feat.h"
-#include "lll/lll_df_types.h"
+#include <ll_feat.h>
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -47,7 +47,7 @@
 #include "ull_conn_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* LLCP Local Procedure PHY Update FSM states */
 enum {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -12,23 +12,23 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
-#include "ll.h"
-#include "ll_settings.h"
-#include "ll_feat.h"
+#include <ll.h>
+#include <ll_settings.h>
+#include <ll_feat.h>
 
 #include "lll.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
@@ -47,7 +47,7 @@
 #include "ull_llcp_internal.h"
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static struct proc_ctx *rr_dequeue(struct ll_conn *conn);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -9,37 +9,37 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_chan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_peripheral.h"
 #include "lll_filter.h"
 #include "lll_conn_iso.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_conn_types.h"
@@ -50,15 +50,15 @@
 #include "ull_conn_internal.h"
 #include "ull_peripheral_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "ll_sw/isoal.h"
-#include "ll_sw/ull_iso_types.h"
-#include "ll_sw/ull_conn_iso_types.h"
+#include <ll_sw/isoal.h>
+#include <ll_sw/ull_iso_types.h>
+#include <ll_sw/ull_conn_iso_types.h>
 
-#include "ll_sw/ull_llcp.h"
+#include <ll_sw/ull_llcp.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static void invalid_release(struct ull_hdr *hdr, struct lll_conn *lll,
 			    memq_link_t *link, struct node_rx_pdu *rx);

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -12,30 +12,30 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/conn.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_peripheral_iso.h"
 
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_conn_types.h"
 
@@ -50,7 +50,7 @@
 #include "ull_conn_iso_internal.h"
 #include "ull_llcp_internal.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -9,34 +9,34 @@
 #include <soc.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_filter.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_filter.h"
@@ -48,9 +48,9 @@
 #include "ull_scan_internal.h"
 #include "ull_sched_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -9,35 +9,35 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/util.h"
-#include "util/dbuf.h"
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/util.h>
+#include <util/dbuf.h>
 
-#include "hal/ticker.h"
-#include "hal/ccm.h"
+#include <hal/ticker.h>
+#include <hal/ccm.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 #include "lll_scan.h"
 #include "lll_scan_aux.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "isoal.h"
 #include "ull_scan_types.h"
@@ -58,7 +58,7 @@
 #include <zephyr/bluetooth/hci_types.h>
 
 #include <soc.h>
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -9,34 +9,34 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
-#include "util/mem.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
+#include <util/mem.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_adv_sync.h"
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 
-#include "ll_sw/ull_tx_queue.h"
+#include <ll_sw/ull_tx_queue.h>
 
 #include "ull_adv_types.h"
 #include "ull_scan_types.h"
@@ -51,9 +51,9 @@
 #include "ull_conn_internal.h"
 #include "ull_conn_iso_internal.h"
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 
 #if defined(CONFIG_BT_CENTRAL)

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -10,32 +10,32 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_adv_types.h"
+#include <lll/lll_adv_types.h>
 #include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
+#include <lll/lll_adv_pdu.h>
 #include "lll_clock.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 #include "lll_chan.h"
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
 #include "lll_sync.h"
@@ -63,9 +63,9 @@
 #include "ull_df_internal.h"
 
 #include "ull_llcp.h"
-#include "ll.h"
+#include <ll.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Check that timeout_reload member is at safe offset when ll_sync_set is
  * allocated using mem interface. timeout_reload being non-zero is used to

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -8,27 +8,27 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "hal/ccm.h"
-#include "hal/radio.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/radio.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 #include "pdu_df.h"
-#include "lll/pdu_vendor.h"
+#include <lll/pdu_vendor.h>
 #include "pdu.h"
 
 #include "lll.h"
-#include "lll/lll_vendor.h"
+#include <lll/lll_vendor.h>
 #include "lll_clock.h"
 #include "lll_scan.h"
-#include "lll/lll_df_types.h"
+#include <lll/lll_df_types.h>
 #include "lll_sync.h"
 #include "lll_sync_iso.h"
 #include "lll_conn.h"
@@ -52,11 +52,11 @@
 #include "ull_conn_internal.h"
 #include "ull_conn_iso_internal.h"
 
-#include "ll.h"
+#include <ll.h>
 
-#include "bt_crypto.h"
+#include <bt_crypto.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static int init_reset(void);
 static struct ll_sync_iso_set *sync_iso_get(uint8_t handle);

--- a/subsys/bluetooth/controller/ticker/shell/ticker.c
+++ b/subsys/bluetooth/controller/ticker/shell/ticker.c
@@ -16,10 +16,10 @@
 
 #include <zephyr/shell/shell.h>
 
-#include "controller/util/memq.h"
-#include "controller/util/mayfly.h"
-#include "controller/hal/ticker.h"
-#include "controller/ticker/ticker.h"
+#include <controller/util/memq.h>
+#include <controller/util/mayfly.h>
+#include <controller/hal/ticker.h>
+#include <controller/ticker/ticker.h>
 
 #if defined(CONFIG_BT_MAX_CONN)
 #define TICKERS_MAX (CONFIG_BT_MAX_CONN + 2)
@@ -27,7 +27,7 @@
 #define TICKERS_MAX 2
 #endif
 
-#include "host/shell/bt.h"
+#include <host/shell/bt.h>
 
 static void ticker_op_done(uint32_t err, void *context)
 {

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -9,13 +9,13 @@
 #include <zephyr/types.h>
 #include <soc.h>
 
-#include "hal/cntr.h"
-#include "hal/ticker.h"
-#include "hal/cpu.h"
+#include <hal/cntr.h>
+#include <hal/ticker.h>
+#include <hal/cpu.h>
 
 #include "ticker.h"
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /*****************************************************************************
  * Defines

--- a/subsys/bluetooth/controller/util/dbuf.c
+++ b/subsys/bluetooth/controller/util/dbuf.c
@@ -9,9 +9,9 @@
 
 #include <soc.h>
 
-#include "hal/cpu.h"
+#include <hal/cpu.h>
 
-#include "util/util.h"
+#include <util/util.h>
 #include "dbuf.h"
 
 void *dbuf_alloc(struct dbuf_hdr *hdr, uint8_t *idx)

--- a/subsys/bluetooth/controller/util/mayfly.c
+++ b/subsys/bluetooth/controller/util/mayfly.c
@@ -11,7 +11,7 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/printk.h>
 
-#include "hal/cpu.h"
+#include <hal/cpu.h>
 
 #include "memq.h"
 #include "mayfly.h"

--- a/subsys/bluetooth/controller/util/memq.c
+++ b/subsys/bluetooth/controller/util/memq.c
@@ -36,7 +36,7 @@
 
 #include <soc.h>
 
-#include "hal/cpu.h"
+#include <hal/cpu.h>
 
 #include "memq.h"
 

--- a/subsys/bluetooth/controller/util/util.c
+++ b/subsys/bluetooth/controller/util/util.c
@@ -12,13 +12,13 @@
 #include <zephyr/drivers/entropy.h>
 
 #include "util.h"
-#include "util/memq.h"
+#include <util/memq.h>
 
-#include "ll_sw/lll.h"
+#include <ll_sw/lll.h>
 
-#include "ll_sw/pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "ll_sw/pdu.h"
+#include <ll_sw/pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <ll_sw/pdu.h>
 
 /**
  * @brief Population count: Count the number of bits set to 1

--- a/subsys/bluetooth/crypto/bt_crypto.c
+++ b/subsys/bluetooth/crypto/bt_crypto.c
@@ -7,9 +7,9 @@
 
 #include <zephyr/sys/byteorder.h>
 
-#include "psa/crypto.h"
+#include <psa/crypto.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "bt_crypto.h"
 
 #define LOG_LEVEL CONFIG_BT_CRYPTO_LOG_LEVEL

--- a/subsys/bluetooth/crypto/bt_crypto_psa.c
+++ b/subsys/bluetooth/crypto/bt_crypto_psa.c
@@ -7,9 +7,9 @@
 
 #include <zephyr/sys/byteorder.h>
 
-#include "psa/crypto.h"
+#include <psa/crypto.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "bt_crypto.h"
 
 #define LOG_LEVEL CONFIG_BT_CRYPTO_LOG_LEVEL

--- a/tests/bluetooth/controller/common/src/helper_pdu.c
+++ b/tests/bluetooth/controller/common/src/helper_pdu.c
@@ -13,35 +13,35 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
-#include "ll_feat.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
+#include <ll_feat.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn_iso.h>
 
-#include "lll_conn.h"
-#include "ull_tx_queue.h"
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_types.h"
-#include "ull_conn_iso_types.h"
+#include <lll_conn.h>
+#include <ull_tx_queue.h>
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_types.h>
+#include <ull_conn_iso_types.h>
 
-#include "ull_llcp.h"
+#include <ull_llcp.h>
 
-#include "helper_pdu.h"
-#include "helper_features.h"
+#include <helper_pdu.h>
+#include <helper_features.h>
 
 #define PDU_MEM_EQUAL(_f, _s, _p, _t)                                                              \
 	zassert_mem_equal(_s._f, _p->_f, sizeof(_p->_f), _t "\nCalled at %s:%d\n", file, line);

--- a/tests/bluetooth/controller/common/src/helper_util.c
+++ b/tests/bluetooth/controller/common/src/helper_util.c
@@ -13,40 +13,40 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
-#include "ll_feat.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
+#include <ll_feat.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_iso_internal.h"
-#include "ull_conn_types.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_iso_internal.h>
+#include <ull_conn_types.h>
 
-#include "ull_internal.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
-#include "ull_llcp.h"
+#include <ull_internal.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
+#include <ull_llcp.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 static struct ll_conn *emul_conn_pool[CONFIG_BT_MAX_CONN];
 

--- a/tests/bluetooth/controller/ctrl_api/src/main.c
+++ b/tests/bluetooth/controller/ctrl_api/src/main.c
@@ -11,36 +11,36 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
-#include "ll_feat.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
+#include <ll_feat.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_llcp_internal.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 static struct ll_conn conn;
 

--- a/tests/bluetooth/controller/ctrl_chmu/src/main.c
+++ b/tests/bluetooth/controller/ctrl_chmu/src/main.c
@@ -13,36 +13,36 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 static struct ll_conn conn;
 

--- a/tests/bluetooth/controller/ctrl_cis_create/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cis_create/src/main.c
@@ -15,37 +15,37 @@ DEFINE_FFF_GLOBALS;
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn_iso.h"
-#include "lll_conn.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn_iso.h>
+#include <lll_conn.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_iso_internal.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_iso_internal.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 #include <zephyr/bluetooth/iso.h>
 

--- a/tests/bluetooth/controller/ctrl_cis_terminate/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cis_terminate/src/main.c
@@ -11,36 +11,36 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 static struct ll_conn conn;
 

--- a/tests/bluetooth/controller/ctrl_collision/src/main.c
+++ b/tests/bluetooth/controller/ctrl_collision/src/main.c
@@ -13,36 +13,36 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 #define INTVL_MIN 6U /* multiple of 1.25 ms (min 6, max 3200) */
 #define INTVL_MAX 6U /* multiple of 1.25 ms (min 6, max 3200) */

--- a/tests/bluetooth/controller/ctrl_conn_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_conn_update/src/main.c
@@ -13,36 +13,36 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 /* Default connection values */
 #define INTVL_MIN 6U /* multiple of 1.25 ms (min 6, max 3200) */

--- a/tests/bluetooth/controller/ctrl_cte_req/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cte_req/src/main.c
@@ -11,37 +11,37 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "ll_feat.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <ll_feat.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 static struct ll_conn conn;
 

--- a/tests/bluetooth/controller/ctrl_data_length_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_data_length_update/src/main.c
@@ -13,40 +13,40 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_internal.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
-#include "ull_llcp_features.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_internal.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
+#include <ull_llcp_features.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
-#include "helper_features.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
+#include <helper_features.h>
 
 static struct ll_conn conn;
 

--- a/tests/bluetooth/controller/ctrl_encrypt/src/main.c
+++ b/tests/bluetooth/controller/ctrl_encrypt/src/main.c
@@ -15,39 +15,39 @@ DEFINE_FFF_GLOBALS;
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
 
-#include "ull_internal.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <ull_internal.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 /* Tx/Rx pause flag */
 #define RESUMED 0U

--- a/tests/bluetooth/controller/ctrl_feature_exchange/src/main.c
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/src/main.c
@@ -13,41 +13,41 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
 
-#include "ull_internal.h"
-#include "ull_llcp.h"
-#include "ull_llcp_internal.h"
-#include "ull_conn_internal.h"
+#include <ull_internal.h>
+#include <ull_llcp.h>
+#include <ull_llcp_internal.h>
+#include <ull_conn_internal.h>
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
-#include "helper_features.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
+#include <helper_features.h>
 
 static struct ll_conn conn;
 

--- a/tests/bluetooth/controller/ctrl_feature_exchange/src/main_hci.c
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/src/main_hci.c
@@ -13,40 +13,40 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
 
-#include "ull_llcp.h"
-#include "ull_llcp_internal.h"
-#include "ull_conn_internal.h"
+#include <ull_llcp.h>
+#include <ull_llcp_internal.h>
+#include <ull_conn_internal.h>
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
-#include "helper_features.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
+#include <helper_features.h>
 
 static struct ll_conn *conn_from_pool;
 

--- a/tests/bluetooth/controller/ctrl_hci/src/main.c
+++ b/tests/bluetooth/controller/ctrl_hci/src/main.c
@@ -13,40 +13,40 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
 
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "ll_feat.h"
+#include <ll_feat.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
-#include "helper_features.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
+#include <helper_features.h>
 
 static struct ll_conn *conn_from_pool;
 

--- a/tests/bluetooth/controller/ctrl_invalid/src/main.c
+++ b/tests/bluetooth/controller/ctrl_invalid/src/main.c
@@ -11,36 +11,36 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
-#include "ll_feat.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
+#include <ll_feat.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
-#include "ull_tx_queue.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 static struct ll_conn test_conn;
 

--- a/tests/bluetooth/controller/ctrl_isoal/src/isoal_test_common.c
+++ b/tests/bluetooth/controller/ctrl_isoal/src/isoal_test_common.c
@@ -20,22 +20,22 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/cntr.h"
-#include "hal/ticker.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/cntr.h>
+#include <hal/ticker.h>
 
-#include "util/memq.h"
+#include <util/memq.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "ll.h"
-#include "lll.h"
-#include "lll_conn_iso.h"
-#include "lll_iso_tx.h"
-#include "isoal.h"
+#include <ll.h>
+#include <lll.h>
+#include <lll_conn_iso.h>
+#include <lll_iso_tx.h>
+#include <isoal.h>
 
 #include "isoal_test_common.h"
 #include "isoal_test_debug.h"

--- a/tests/bluetooth/controller/ctrl_isoal/src/isoal_test_debug.c
+++ b/tests/bluetooth/controller/ctrl_isoal/src/isoal_test_debug.c
@@ -21,18 +21,18 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
 
-#include "util/memq.h"
+#include <util/memq.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "ll.h"
-#include "lll.h"
-#include "lll_conn_iso.h"
-#include "lll_iso_tx.h"
-#include "isoal.h"
-#include "ull_iso_types.h"
+#include <ll.h>
+#include <lll.h>
+#include <lll_conn_iso.h>
+#include <lll_iso_tx.h>
+#include <isoal.h>
+#include <ull_iso_types.h>
 
 #include "isoal_test_common.h"
 #include "isoal_test_debug.h"

--- a/tests/bluetooth/controller/ctrl_isoal/src/main.c
+++ b/tests/bluetooth/controller/ctrl_isoal/src/main.c
@@ -20,7 +20,7 @@
 DEFINE_FFF_GLOBALS;
 
 /* Include the DUT */
-#include "ll_sw/isoal.c"
+#include <ll_sw/isoal.c>
 
 #include "isoal_test_common.h"
 #include "isoal_test_debug.h"

--- a/tests/bluetooth/controller/ctrl_le_ping/src/main.c
+++ b/tests/bluetooth/controller/ctrl_le_ping/src/main.c
@@ -11,36 +11,36 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 static struct ll_conn conn;
 

--- a/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
@@ -11,36 +11,36 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 static struct ll_conn conn;
 

--- a/tests/bluetooth/controller/ctrl_periodic_sync/src/main.c
+++ b/tests/bluetooth/controller/ctrl_periodic_sync/src/main.c
@@ -14,51 +14,51 @@ DEFINE_FFF_GLOBALS;
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
-#include "ll_feat.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
+#include <ll_feat.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
-#include "lll/lll_adv_types.h"
-#include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
-#include "lll_chan.h"
-#include "lll_scan.h"
-#include "lll_sync.h"
-#include "lll_sync_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
+#include <lll/lll_adv_types.h>
+#include <lll_adv.h>
+#include <lll/lll_adv_pdu.h>
+#include <lll_chan.h>
+#include <lll_scan.h>
+#include <lll_sync.h>
+#include <lll_sync_iso.h>
 
-#include "ull_adv_types.h"
-#include "ull_scan_types.h"
-#include "ull_sync_types.h"
+#include <ull_adv_types.h>
+#include <ull_scan_types.h>
+#include <ull_sync_types.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
 
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_llcp_internal.h"
-#include "ull_sync_internal.h"
-#include "ull_internal.h"
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_llcp_internal.h>
+#include <ull_sync_internal.h>
+#include <ull_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 static struct ll_conn conn;
 static struct ll_sync_set *sync;

--- a/tests/bluetooth/controller/ctrl_phy_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_phy_update/src/main.c
@@ -13,38 +13,38 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
 
-#include "ull_internal.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <ull_internal.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 #define PREFER_S8_CODING 1
 #define PREFER_S2_CODING 0

--- a/tests/bluetooth/controller/ctrl_sca_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_sca_update/src/main.c
@@ -11,38 +11,38 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
-#include "ull_llcp_features.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
+#include <ull_llcp_features.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 static struct ll_conn conn;
 

--- a/tests/bluetooth/controller/ctrl_sw_privacy_unit/src/main.c
+++ b/tests/bluetooth/controller/ctrl_sw_privacy_unit/src/main.c
@@ -20,7 +20,7 @@
 #define CONFIG_BT_CTLR_SW_DEFERRED_PRIVACY 1
 #define CONFIG_BT_LOG_LEVEL 1
 
-#include "ll_sw/ull_filter.c"
+#include <ll_sw/ull_filter.c>
 
 /*
  * Unit test of SW deferred privacy data structure and related methods

--- a/tests/bluetooth/controller/ctrl_terminate/src/main.c
+++ b/tests/bluetooth/controller/ctrl_terminate/src/main.c
@@ -12,37 +12,37 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
 
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 static struct ll_conn conn;
 

--- a/tests/bluetooth/controller/ctrl_tx_buffer_alloc/src/main.c
+++ b/tests/bluetooth/controller/ctrl_tx_buffer_alloc/src/main.c
@@ -13,37 +13,37 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
 
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 
 static struct ll_conn conn[CONFIG_BT_CTLR_LLCP_CONN];

--- a/tests/bluetooth/controller/ctrl_tx_queue/src/main.c
+++ b/tests/bluetooth/controller/ctrl_tx_queue/src/main.c
@@ -11,20 +11,20 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "hal/ccm.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <hal/ccm.h>
 
-#include "pdu.h"
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
+#include <pdu.h>
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
 #define SIZE 10U
 

--- a/tests/bluetooth/controller/ctrl_unsupported/src/main.c
+++ b/tests/bluetooth/controller/ctrl_unsupported/src/main.c
@@ -11,37 +11,37 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
-#include "ll_feat.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
+#include <ll_feat.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_conn_internal.h"
-#include "ull_llcp_internal.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_conn_internal.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 static struct ll_conn test_conn;
 

--- a/tests/bluetooth/controller/ctrl_user_ext/src/hci_user_ext.c
+++ b/tests/bluetooth/controller/ctrl_user_ext/src/hci_user_ext.c
@@ -10,13 +10,13 @@
 #include <zephyr/types.h>
 #include <zephyr/net_buf.h>
 
-#include "util/memq.h"
+#include <util/memq.h>
 
-#include "ll_sw/pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "ll_sw/pdu.h"
-#include "ll_sw/lll.h"
-#include "hci/hci_user_ext.h"
+#include <ll_sw/pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <ll_sw/pdu.h>
+#include <ll_sw/lll.h>
+#include <hci/hci_user_ext.h>
 
 /* The test is made to show that hci.c and other code can compile when
  * certain Kconfig options are set. This includes functions that are

--- a/tests/bluetooth/controller/ctrl_version/src/main.c
+++ b/tests/bluetooth/controller/ctrl_version/src/main.c
@@ -11,37 +11,37 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
-#include "ll_feat.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
+#include <ll_feat.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
 
-#include "ull_conn_types.h"
-#include "ull_llcp.h"
-#include "ull_llcp_internal.h"
+#include <ull_conn_types.h>
+#include <ull_llcp.h>
+#include <ull_llcp_internal.h>
 
-#include "helper_pdu.h"
-#include "helper_util.h"
+#include <helper_pdu.h>
+#include <helper_util.h>
 
 static struct ll_conn conn;
 

--- a/tests/bluetooth/controller/ll_settings/src/main.c
+++ b/tests/bluetooth/controller/ll_settings/src/main.c
@@ -12,7 +12,7 @@
 
 #include <zephyr/settings/settings.h>
 
-#include "ll_settings.h"
+#include <ll_settings.h>
 
 ZTEST_SUITE(test_ll_settings, NULL, NULL, NULL, NULL, NULL);
 

--- a/tests/bluetooth/controller/mock_ctrl/src/assert.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/assert.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
-#include "assert.h"
+#include <assert.h>
 
 void assert_print(const char *fmt, ...)
 {

--- a/tests/bluetooth/controller/mock_ctrl/src/ecb.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ecb.c
@@ -5,7 +5,7 @@
  */
 #include <zephyr/types.h>
 #include <zephyr/ztest.h>
-#include "hal/ecb.h"
+#include <hal/ecb.h>
 
 __attribute__((weak)) void ecb_encrypt(uint8_t const *const key_le,
 				       uint8_t const *const clear_text_le,

--- a/tests/bluetooth/controller/mock_ctrl/src/ll.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ll.c
@@ -13,26 +13,26 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
-#include "ll_feat.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
+#include <ll_feat.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "ull_tx_queue.h"
-#include "ull_conn_types.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <ull_tx_queue.h>
+#include <ull_conn_types.h>
 
-#include "ull_llcp.h"
+#include <ull_llcp.h>
 
 extern sys_slist_t ut_rx_q;

--- a/tests/bluetooth/controller/mock_ctrl/src/lll.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/lll.c
@@ -13,30 +13,30 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_settings.h"
-#include "ll_feat.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_settings.h>
+#include <ll_feat.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
-#include "ull_conn_types.h"
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_iso_types.h"
+#include <ull_tx_queue.h>
+#include <ull_conn_types.h>
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_iso_types.h>
 
 extern sys_slist_t ut_rx_q;
 

--- a/tests/bluetooth/controller/mock_ctrl/src/lll_clock.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/lll_clock.c
@@ -8,7 +8,7 @@
 #include <zephyr/ztest.h>
 #include <soc.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 /* Clock setup timeouts are unlikely, below values are experimental */
 #define LFCLOCK_TIMEOUT_MS 500

--- a/tests/bluetooth/controller/mock_ctrl/src/lll_conn.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/lll_conn.c
@@ -12,27 +12,27 @@
 #include <zephyr/ztest.h>
 #include <zephyr/sys/util.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
-#include "hal/radio.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
+#include <hal/radio.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mfifo.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mfifo.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
 
-#include "lll/lll_internal.h"
-#include "lll/lll_tim_internal.h"
-#include "lll/lll_prof_internal.h"
+#include <lll/lll_internal.h>
+#include <lll/lll_tim_internal.h>
+#include <lll/lll_prof_internal.h>
 
 void lll_conn_flush(uint16_t handle, struct lll_conn *lll)
 {

--- a/tests/bluetooth/controller/mock_ctrl/src/mayfly.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/mayfly.c
@@ -6,8 +6,8 @@
 
 #include <zephyr/types.h>
 #include <zephyr/ztest.h>
-#include "util/memq.h"
-#include "util/mayfly.h"
+#include <util/memq.h>
+#include <util/mayfly.h>
 
 void mayfly_init(void)
 {

--- a/tests/bluetooth/controller/mock_ctrl/src/ticker.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ticker.c
@@ -8,7 +8,7 @@
 #include <zephyr/types.h>
 #include <zephyr/ztest.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
 uint8_t ticker_update(uint8_t instance_index, uint8_t user_id, uint8_t ticker_id,
 		       uint32_t ticks_drift_plus, uint32_t ticks_drift_minus,

--- a/tests/bluetooth/controller/mock_ctrl/src/ull.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull.c
@@ -10,32 +10,32 @@
 
 #include <zephyr/bluetooth/hci.h>
 
-#include "hal/cpu_vendor_hal.h"
-#include "hal/ccm.h"
+#include <hal/cpu_vendor_hal.h>
+#include <hal/ccm.h>
 
-#include "util/mem.h"
-#include "util/mfifo.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
-#include "util.h"
+#include <util/mem.h>
+#include <util/mfifo.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
+#include <util.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "ll.h"
-#include "ll_feat.h"
-#include "ll_settings.h"
-#include "lll.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_adv_types.h"
-#include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
-#include "lll_scan.h"
-#include "lll_sync.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <ll.h>
+#include <ll_feat.h>
+#include <ll_settings.h>
+#include <lll.h>
+#include <lll/lll_vendor.h>
+#include <lll/lll_adv_types.h>
+#include <lll_adv.h>
+#include <lll/lll_adv_pdu.h>
+#include <lll_scan.h>
+#include <lll_sync.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
 
-#include "ull_conn_internal.h"
+#include <ull_conn_internal.h>
 
 #define EVENT_DONE_MAX 3
 /* Backing storage for elements in mfifo_done */

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_adv_sync.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_adv_sync.c
@@ -10,13 +10,13 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "util/mem.h"
-#include "util/memq.h"
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <util/mem.h>
+#include <util/memq.h>
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "lll.h"
+#include <lll.h>
 
 struct ll_adv_sync_set *ull_adv_sync_get(uint8_t handle)
 {

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_central.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_central.c
@@ -6,19 +6,19 @@
 
 #include <zephyr/types.h>
 #include <zephyr/ztest.h>
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "hal/ccm.h"
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
+#include <hal/ccm.h>
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
 
 void ull_central_setup(memq_link_t *link, struct node_rx_pdu *rx, struct node_rx_ftr *ftr,
 		      struct lll_conn *lll)

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_central_iso.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_central_iso.c
@@ -7,16 +7,16 @@
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "util/mem.h"
-#include "util/memq.h"
+#include <util/mem.h>
+#include <util/memq.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "lll.h"
-#include "lll_conn_iso.h"
-#include "ull_conn_iso_types.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <lll.h>
+#include <lll_conn_iso.h>
+#include <ull_conn_iso_types.h>
 
 bool ull_central_iso_all_cises_terminated(struct ll_conn_iso_group *cig)
 {

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_conn_iso.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_conn_iso.c
@@ -9,38 +9,38 @@
 #include <zephyr/kernel.h>
 #include <zephyr/devicetree.h>
 
-#include "hal/ccm.h"
-#include "hal/ticker.h"
-#include "hal/cpu.h"
+#include <hal/ccm.h>
+#include <hal/ticker.h>
+#include <hal/cpu.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
-#include "util/mayfly.h"
-#include "util/mfifo.h"
-#include "ticker/ticker.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
+#include <util/mayfly.h>
+#include <util/mfifo.h>
+#include <ticker/ticker.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
-#include "ull_conn_types.h"
-#include "lll_conn_iso.h"
-#include "ull_conn_iso_types.h"
-#include "ull_conn_internal.h"
-#include "ull_conn_iso_internal.h"
-#include "ull_internal.h"
-#include "lll/lll_vendor.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
+#include <ull_conn_types.h>
+#include <lll_conn_iso.h>
+#include <ull_conn_iso_types.h>
+#include <ull_conn_internal.h>
+#include <ull_conn_iso_internal.h>
+#include <ull_internal.h>
+#include <lll/lll_vendor.h>
 
-#include "hal/debug.h"
+#include <hal/debug.h>
 
 static struct ll_conn_iso_group group = { 0 };
 static struct ll_conn_iso_stream stream = { .established = 1, .group = &group };

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_filter.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_filter.c
@@ -11,14 +11,14 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "util/mem.h"
-#include "util/memq.h"
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <util/mem.h>
+#include <util/memq.h>
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_filter.h"
+#include <lll.h>
+#include <lll_filter.h>
 
 static uint8_t bt_addr[BDADDR_SIZE] = { 0, 0, 0, 0, 0, 0};
 

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_peripheral.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_peripheral.c
@@ -6,21 +6,21 @@
 
 #include <zephyr/types.h>
 #include <zephyr/ztest.h>
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "hal/ccm.h"
-#include "ull_tx_queue.h"
-#include "lll.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "ull_conn_types.h"
+#include <hal/ccm.h>
+#include <ull_tx_queue.h>
+#include <lll.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <ull_conn_types.h>
 
 void ull_periph_setup(memq_link_t *link, struct node_rx_pdu *rx, struct node_rx_ftr *ftr,
 		     struct lll_conn *lll)

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_peripheral_iso.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_peripheral_iso.c
@@ -11,38 +11,38 @@
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/dbuf.h"
-#include "util/mayfly.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/dbuf.h>
+#include <util/mayfly.h>
 
-#include "hal/ccm.h"
-#include "hal/ticker.h"
+#include <hal/ccm.h>
+#include <hal/ticker.h>
 
-#include "ticker/ticker.h"
+#include <ticker/ticker.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll/lll_vendor.h"
-#include "lll/lll_df_types.h"
-#include "lll_conn.h"
-#include "lll_conn_iso.h"
+#include <lll.h>
+#include <lll/lll_vendor.h>
+#include <lll/lll_df_types.h>
+#include <lll_conn.h>
+#include <lll_conn_iso.h>
 
-#include "ull_tx_queue.h"
+#include <ull_tx_queue.h>
 
-#include "isoal.h"
-#include "ull_iso_types.h"
+#include <isoal.h>
+#include <ull_iso_types.h>
 
-#include "ull_conn_types.h"
-#include "ull_conn_iso_types.h"
-#include "ull_internal.h"
+#include <ull_conn_types.h>
+#include <ull_conn_iso_types.h>
+#include <ull_internal.h>
 
-#include "ull_conn_internal.h"
-#include "ull_conn_iso_internal.h"
-#include "lll_peripheral_iso.h"
+#include <ull_conn_internal.h>
+#include <ull_conn_iso_internal.h>
+#include <lll_peripheral_iso.h>
 
 void ull_peripheral_iso_release(uint16_t cis_handle)
 {

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_scan.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_scan.c
@@ -11,17 +11,17 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "util/mem.h"
-#include "util/memq.h"
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <util/mem.h>
+#include <util/memq.h>
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll_scan.h"
+#include <lll.h>
+#include <lll_scan.h>
 
-#include "ull_scan_types.h"
-#include "ull_scan_internal.h"
+#include <ull_scan_types.h>
+#include <ull_scan_internal.h>
 
 #define BT_CTLR_SCAN_MAX 1
 static struct ll_scan_set ll_scan[BT_CTLR_SCAN_MAX];

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_sync.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_sync.c
@@ -10,23 +10,23 @@
 #include <zephyr/ztest.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "hal/cpu.h"
-#include "hal/ccm.h"
+#include <hal/cpu.h>
+#include <hal/ccm.h>
 
-#include "util/util.h"
-#include "util/mem.h"
-#include "util/memq.h"
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <util/util.h>
+#include <util/mem.h>
+#include <util/memq.h>
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "lll.h"
-#include "lll/lll_adv_types.h"
-#include "lll_adv.h"
-#include "ull_adv_types.h"
-#include "lll_sync.h"
-#include "lll_sync_iso.h"
-#include "ull_sync_types.h"
+#include <lll.h>
+#include <lll/lll_adv_types.h>
+#include <lll_adv.h>
+#include <ull_adv_types.h>
+#include <lll_sync.h>
+#include <lll_sync_iso.h>
+#include <ull_sync_types.h>
 
 #define BT_PER_ADV_SYNC_MAX 1
 

--- a/tests/bluetooth/controller/mock_ctrl/src/util.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/util.c
@@ -8,16 +8,16 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/ztest.h>
-#include "util.h"
+#include <util.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "util/mem.h"
-#include "util/memq.h"
-#include "util/mayfly.h"
-#include "lll.h"
+#include <util/mem.h>
+#include <util/memq.h>
+#include <util/mayfly.h>
+#include <lll.h>
 
 /**
  * @brief Population count: Count the number of bits set to 1

--- a/tests/bsim/bluetooth/ll/advx/src/main.c
+++ b/tests/bsim/bluetooth/ll/advx/src/main.c
@@ -16,12 +16,12 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "ll.h"
+#include <ll.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <time_machine.h>
+#include <bstests.h>
 
 #define HANDLE          0x0000
 #define EVT_PROP_SCAN   BIT(1)

--- a/tests/bsim/bluetooth/ll/bis/src/main.c
+++ b/tests/bsim/bluetooth/ll/bis/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 #ifdef CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER
 extern struct bst_test_list *test_past_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/ll/bis/src/test_bis.c
+++ b/tests/bsim/bluetooth/ll/bis/src/test_bis.c
@@ -15,19 +15,19 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/iso.h>
 
-#include "subsys/bluetooth/host/hci_core.h"
-#include "subsys/bluetooth/controller/include/ll.h"
-#include "subsys/bluetooth/controller/util/memq.h"
-#include "subsys/bluetooth/controller/ll_sw/lll.h"
+#include <subsys/bluetooth/host/hci_core.h>
+#include <subsys/bluetooth/controller/include/ll.h>
+#include <subsys/bluetooth/controller/util/memq.h>
+#include <subsys/bluetooth/controller/ll_sw/lll.h>
 
 /* For VS data path */
-#include "subsys/bluetooth/controller/ll_sw/isoal.h"
-#include "subsys/bluetooth/controller/ll_sw/ull_iso_types.h"
+#include <subsys/bluetooth/controller/ll_sw/isoal.h>
+#include <subsys/bluetooth/controller/ll_sw/ull_iso_types.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <time_machine.h>
+#include <bstests.h>
 
 #define FAIL(...)					\
 	do {						\

--- a/tests/bsim/bluetooth/ll/bis/src/test_past.c
+++ b/tests/bsim/bluetooth/ll/bis/src/test_past.c
@@ -20,15 +20,15 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "subsys/bluetooth/host/hci_core.h"
-#include "subsys/bluetooth/controller/include/ll.h"
-#include "subsys/bluetooth/controller/util/memq.h"
-#include "subsys/bluetooth/controller/ll_sw/lll.h"
+#include <subsys/bluetooth/host/hci_core.h>
+#include <subsys/bluetooth/controller/include/ll.h>
+#include <subsys/bluetooth/controller/util/memq.h>
+#include <subsys/bluetooth/controller/ll_sw/lll.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <time_machine.h>
+#include <bstests.h>
 
 static struct bt_conn *default_conn;
 

--- a/tests/bsim/bluetooth/ll/cis/src/main.c
+++ b/tests/bsim/bluetooth/ll/cis/src/main.c
@@ -19,10 +19,10 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys_clock.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <time_machine.h>
+#include <bstests.h>
 
 #define FAIL(...)					\
 	do {						\

--- a/tests/bsim/bluetooth/ll/conn/src/main.c
+++ b/tests/bsim/bluetooth/ll/conn/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_empty_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_connect1_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/ll/conn/src/test_connect1.c
+++ b/tests/bsim/bluetooth/ll/conn/src/test_connect1.c
@@ -6,10 +6,10 @@
  */
 #include <zephyr/kernel.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <time_machine.h>
+#include <bstests.h>
 
 #include <zephyr/types.h>
 #include <stddef.h>

--- a/tests/bsim/bluetooth/ll/conn/src/test_connect2.c
+++ b/tests/bsim/bluetooth/ll/conn/src/test_connect2.c
@@ -6,10 +6,10 @@
  */
 #include <zephyr/kernel.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <time_machine.h>
+#include <bstests.h>
 
 #include <zephyr/types.h>
 #include <stddef.h>

--- a/tests/bsim/bluetooth/ll/conn/src/test_empty.c
+++ b/tests/bsim/bluetooth/ll/conn/src/test_empty.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/kernel.h>
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <time_machine.h>
+#include <bstests.h>
 
 /*
  * This is just a demo of the test framework facilities

--- a/tests/bsim/bluetooth/ll/edtt/common/edtt_driver_bsim.c
+++ b/tests/bsim/bluetooth/ll/edtt/common/edtt_driver_bsim.c
@@ -14,13 +14,13 @@
 
 #include "edtt_driver.h"
 #include <zephyr/kernel.h>
-#include "posix_native_task.h"
+#include <posix_native_task.h>
 
-#include "bs_tracing.h"
-#include "bs_utils.h"
-#include "bs_oswrap.h"
-#include "bs_pc_base_fifo_user.h"
-#include "bsim_args_runner.h"
+#include <bs_tracing.h>
+#include <bs_utils.h>
+#include <bs_oswrap.h>
+#include <bs_pc_base_fifo_user.h>
+#include <bsim_args_runner.h>
 
 /* Recheck if something arrived from the EDTT every 5ms */
 #define EDTT_IF_RECHECK_DELTA 5 /* ms */

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/main.c
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/src/main.c
@@ -22,9 +22,9 @@
 
 #include <gatt/services.h>
 
-#include "edtt_driver.h"
-#include "bs_tracing.h"
-#include "commands.h"
+#include <edtt_driver.h>
+#include <bs_tracing.h>
+#include <commands.h>
 
 #define DEVICE_NAME		CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN		(sizeof(DEVICE_NAME) - 1)

--- a/tests/bsim/bluetooth/ll/edtt/hci_test_app/src/main.c
+++ b/tests/bsim/bluetooth/ll/edtt/hci_test_app/src/main.c
@@ -23,9 +23,9 @@
 #include <zephyr/bluetooth/hci_raw.h>
 #include <zephyr/bluetooth/iso.h>
 
-#include "edtt_driver.h"
-#include "bs_tracing.h"
-#include "commands.h"
+#include <edtt_driver.h>
+#include <bs_tracing.h>
+#include <commands.h>
 
 #if defined(CONFIG_BT_HCI_CORE_LOG_LEVEL_DBG)
 #define LOG_LEVEL LOG_LEVEL_DBG

--- a/tests/bsim/bluetooth/ll/multiple_id/src/main.c
+++ b/tests/bsim/bluetooth/ll/multiple_id/src/main.c
@@ -13,10 +13,10 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <time_machine.h>
+#include <bstests.h>
 
 /* The test case is performing 250 simultaneous connections and managing
  * parallel control procedures utilizing the available/configured minimum

--- a/tests/bsim/bluetooth/ll/throughput/src/main.c
+++ b/tests/bsim/bluetooth/ll/throughput/src/main.c
@@ -11,10 +11,10 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <time_machine.h>
+#include <bstests.h>
 
 /* There are 13 iterations of PHY update every 5 seconds, and based on actual
  * simulation COUNT iterations are sufficient to finish these iterations with


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Bluetooth Controller related paths and manually selecting the applicable changes:
```
$ find subsys/bluetooth/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;