### PR TITLE
Bluetooth: Host: Diamond include for non-local header files

### DIFF
--- a/samples/bluetooth/channel_sounding/src/connected_cs_initiator.c
+++ b/samples/bluetooth/channel_sounding/src/connected_cs_initiator.c
@@ -10,8 +10,8 @@
 #include <zephyr/bluetooth/cs.h>
 #include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/gatt.h>
-#include "distance_estimation.h"
-#include "common.h"
+#include <distance_estimation.h>
+#include <common.h>
 
 #define CS_CONFIG_ID     0
 #define NUM_MODE_0_STEPS 1

--- a/samples/bluetooth/channel_sounding/src/connected_cs_reflector.c
+++ b/samples/bluetooth/channel_sounding/src/connected_cs_reflector.c
@@ -10,7 +10,7 @@
 #include <zephyr/bluetooth/cs.h>
 #include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/gatt.h>
-#include "common.h"
+#include <common.h>
 
 #define CS_CONFIG_ID     0
 #define NUM_MODE_0_STEPS 1

--- a/samples/bluetooth/channel_sounding/src/cs_test_initiator.c
+++ b/samples/bluetooth/channel_sounding/src/cs_test_initiator.c
@@ -11,9 +11,9 @@
 #include <zephyr/bluetooth/cs.h>
 #include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/gatt.h>
-#include "distance_estimation.h"
-#include "common.h"
-#include "cs_test_params.h"
+#include <distance_estimation.h>
+#include <common.h>
+#include <cs_test_params.h>
 
 static K_SEM_DEFINE(sem_results_available, 0, 1);
 static K_SEM_DEFINE(sem_test_complete, 0, 1);

--- a/samples/bluetooth/channel_sounding/src/cs_test_reflector.c
+++ b/samples/bluetooth/channel_sounding/src/cs_test_reflector.c
@@ -11,9 +11,9 @@
 #include <zephyr/bluetooth/cs.h>
 #include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/gatt.h>
-#include "distance_estimation.h"
-#include "common.h"
-#include "cs_test_params.h"
+#include <distance_estimation.h>
+#include <common.h>
+#include <cs_test_params.h>
 
 static K_SEM_DEFINE(sem_results_available, 0, 1);
 static K_SEM_DEFINE(sem_test_complete, 0, 1);

--- a/samples/bluetooth/channel_sounding/src/distance_estimation.c
+++ b/samples/bluetooth/channel_sounding/src/distance_estimation.c
@@ -6,7 +6,7 @@
 
 #include <math.h>
 #include <zephyr/bluetooth/cs.h>
-#include "distance_estimation.h"
+#include <distance_estimation.h>
 
 #define CS_FREQUENCY_MHZ(ch)    (2402u + 1u * (ch))
 #define CS_FREQUENCY_HZ(ch)     (CS_FREQUENCY_MHZ(ch) * 1000000.0f)

--- a/samples/bluetooth/encrypted_advertising/central/src/central_ead.c
+++ b/samples/bluetooth/encrypted_advertising/central/src/central_ead.c
@@ -22,9 +22,9 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/bluetooth.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "common.h"
+#include <common.h>
 
 LOG_MODULE_REGISTER(ead_central_sample, CONFIG_BT_EAD_LOG_LEVEL);
 

--- a/samples/bluetooth/encrypted_advertising/central/src/main.c
+++ b/samples/bluetooth/encrypted_advertising/central/src/main.c
@@ -22,7 +22,7 @@
 
 #include <zephyr/logging/log.h>
 
-#include "common.h"
+#include <common.h>
 
 LOG_MODULE_DECLARE(ead_central_sample, CONFIG_BT_EAD_LOG_LEVEL);
 

--- a/samples/bluetooth/encrypted_advertising/peripheral/src/data.h
+++ b/samples/bluetooth/encrypted_advertising/peripheral/src/data.h
@@ -11,7 +11,7 @@
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/bluetooth.h>
 
-#include "common.h"
+#include <common.h>
 
 #define LF_ID_MSB ((BT_COMP_ID_LF >> 8) & 0xff)
 #define LF_ID_LSB ((BT_COMP_ID_LF) & 0xff)

--- a/samples/bluetooth/encrypted_advertising/peripheral/src/main.c
+++ b/samples/bluetooth/encrypted_advertising/peripheral/src/main.c
@@ -18,7 +18,7 @@
 
 #include <zephyr/logging/log.h>
 
-#include "common.h"
+#include <common.h>
 
 LOG_MODULE_DECLARE(ead_peripheral_sample, CONFIG_BT_EAD_LOG_LEVEL);
 

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -28,7 +28,7 @@
 #include <sys/types.h>
 
 #include "addr_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "conn_internal.h"
 #include "hci_core.h"
 #include "id.h"

--- a/subsys/bluetooth/host/aes_ccm.c
+++ b/subsys/bluetooth/host/aes_ccm.c
@@ -15,7 +15,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
 LOG_MODULE_REGISTER(bt_aes_ccm);

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -37,7 +37,7 @@
 #include <sys/types.h>
 
 #include "att_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "conn_internal.h"
 #include "gatt_internal.h"
 #include "hci_core.h"

--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -23,7 +23,7 @@
 #include <zephyr/sys_clock.h>
 
 #include "buf_view.h"
-#include "common/hci_common_internal.h"
+#include <common/hci_common_internal.h>
 #include "conn_internal.h"
 #include "hci_core.h"
 #include "iso_internal.h"

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -48,8 +48,8 @@
 #include "classic/conn_br_internal.h"
 #include "classic/sco_internal.h"
 #include "classic/ssp.h"
-#include "common/assert.h"
-#include "common/bt_str.h"
+#include <common/assert.h>
+#include <common/bt_str.h>
 #include "conn_internal.h"
 #include "direction_internal.h"
 #include "gatt_gap_svc_validate.h"

--- a/subsys/bluetooth/host/crypto_psa.c
+++ b/subsys/bluetooth/host/crypto_psa.c
@@ -22,7 +22,7 @@
 #include <psa/crypto_types.h>
 #include <psa/crypto_values.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "hci_core.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL

--- a/subsys/bluetooth/host/ecc.c
+++ b/subsys/bluetooth/host/ecc.c
@@ -25,7 +25,7 @@
 #include <psa/crypto_types.h>
 #include <psa/crypto_values.h>
 
-#include "common/long_wq.h"
+#include <common/long_wq.h>
 #include "ecc.h"
 #include "hci_core.h"
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "sys/types.h"
+#include <sys/types.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>
@@ -47,11 +47,11 @@
 
 #include "att_internal.h"
 #include "conn_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "gatt_internal.h"
 #include "hci_core.h"
 #include "keys.h"
-#include "common/long_wq.h"
+#include <common/long_wq.h>
 #include "l2cap_internal.h"
 #include "settings.h"
 #include "smp.h"

--- a/subsys/bluetooth/host/hci_common.c
+++ b/subsys/bluetooth/host/hci_common.c
@@ -14,7 +14,7 @@
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "common/assert.h"
+#include <common/assert.h>
 
 struct net_buf *bt_hci_evt_create(uint8_t evt, uint8_t len)
 {

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -49,10 +49,10 @@
 #include "addr_internal.h"
 #include "adv.h"
 #include "classic/br.h"
-#include "common/hci_common_internal.h"
-#include "common/bt_str.h"
-#include "common/rpa.h"
-#include "common/assert.h"
+#include <common/hci_common_internal.h>
+#include <common/bt_str.h>
+#include <common/rpa.h>
+#include <common/assert.h>
 #include "conn_internal.h"
 #include "crypto.h"
 #include "ecc.h"

--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -29,7 +29,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/toolchain.h>
 
-#include "common/hci_common_internal.h"
+#include <common/hci_common_internal.h>
 #include "hci_raw_internal.h"
 #include "monitor.h"
 

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -32,8 +32,8 @@
 #include <zephyr/toolchain.h>
 
 #include "adv.h"
-#include "common/bt_str.h"
-#include "common/rpa.h"
+#include <common/bt_str.h>
+#include <common/rpa.h>
 #include "conn_internal.h"
 #include "hci_core.h"
 #include "id.h"

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -25,8 +25,8 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util_macro.h>
 
-#include "common/bt_str.h"
-#include "common/rpa.h"
+#include <common/bt_str.h>
+#include <common/rpa.h>
 #include "conn_internal.h"
 #include "gatt_internal.h"
 #include "hci_core.h"
@@ -34,7 +34,7 @@
 #include "keys.h"
 #include "settings.h"
 #include "smp.h"
-#include "sys/types.h"
+#include <sys/types.h>
 
 #define LOG_LEVEL CONFIG_BT_KEYS_LOG_LEVEL
 LOG_MODULE_REGISTER(bt_keys);

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -18,7 +18,7 @@
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys_clock.h>
 
-#include "host/classic/l2cap_br_interface.h"
+#include <host/classic/l2cap_br_interface.h>
 /* TODO: we should include conn_internal.h for bt_conn_tx_cb_t but that causes redefinitions */
 
 enum l2cap_conn_list_action {

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -35,7 +35,7 @@
 #include <sys/types.h>
 
 #include "addr_internal.h"
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 #include "conn_internal.h"
 #include "direction_internal.h"
 #include "hci_core.h"

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -22,12 +22,12 @@
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 
-#include "common/bt_settings_commit.h"
-#include "common/bt_str.h"
+#include <common/bt_settings_commit.h>
+#include <common/bt_str.h>
 #include "classic/br.h"
 #include "hci_core.h"
 #include "settings.h"
-#include "sys/types.h"
+#include <sys/types.h>
 
 #define LOG_LEVEL CONFIG_BT_SETTINGS_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/host/settings.h
+++ b/subsys/bluetooth/host/settings.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/settings/settings.h>
-#include "common/bt_settings_commit.h"
+#include <common/bt_settings_commit.h>
 
 /* Max settings key length (with all components) */
 #define BT_SETTINGS_KEY_MAX 36

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -48,14 +48,14 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
-#include "audio/shell/audio.h"
-#include "common/bt_shell_private.h"
+#include <audio/shell/audio.h>
+#include <common/bt_shell_private.h>
 #if defined(CONFIG_BT_LL_SW_SPLIT)
-#include "controller/ll_sw/shell/ll.h"
+#include <controller/ll_sw/shell/ll.h>
 #endif /* CONFIG_BT_LL_SW_SPLIT */
-#include "host/shell/bt.h"
+#include <host/shell/bt.h>
 #if defined(CONFIG_BT_CLASSIC)
-#include "host/classic/shell/bredr.h"
+#include <host/classic/shell/bredr.h>
 #endif
 
 static bool no_settings_load;

--- a/subsys/bluetooth/host/shell/cs.c
+++ b/subsys/bluetooth/host/shell/cs.c
@@ -27,8 +27,8 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 static int check_cs_sync_antenna_selection_input(uint16_t input)
 {

--- a/subsys/bluetooth/host/shell/gatt.c
+++ b/subsys/bluetooth/host/shell/gatt.c
@@ -31,8 +31,8 @@
 #include <zephyr/sys/util.h>
 #include <sys/types.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 #if defined(CONFIG_BT_GATT_CLIENT) || defined(CONFIG_BT_GATT_DYNAMIC_DB)
 extern uint8_t selected_id;

--- a/subsys/bluetooth/host/shell/l2cap.c
+++ b/subsys/bluetooth/host/shell/l2cap.c
@@ -34,8 +34,8 @@
 #include <zephyr/sys/time_units.h>
 #include <zephyr/sys/util.h>
 
-#include "common/bt_shell_private.h"
-#include "host/shell/bt.h"
+#include <common/bt_shell_private.h>
+#include <host/shell/bt.h>
 
 #define CREDITS			10
 #define DATA_MTU		(23 * CREDITS)

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -38,9 +38,9 @@
 #include <zephyr/toolchain.h>
 
 #include "conn_internal.h"
-#include "common/bt_str.h"
-#include "common/rpa.h"
-#include "crypto/bt_crypto.h"
+#include <common/bt_str.h>
+#include <common/rpa.h>
+#include <crypto/bt_crypto.h>
 #include "ecc.h"
 #include "hci_core.h"
 #include "keys.h"

--- a/subsys/bluetooth/services/ias/shell/ias.c
+++ b/subsys/bluetooth/services/ias/shell/ias.c
@@ -16,8 +16,8 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/services/ias.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static void alert_stop(void)
 {

--- a/subsys/bluetooth/services/ias/shell/ias_client.c
+++ b/subsys/bluetooth/services/ias/shell/ias_client.c
@@ -15,8 +15,8 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/services/ias.h>
 
-#include "host/shell/bt.h"
-#include "common/bt_shell_private.h"
+#include <host/shell/bt.h>
+#include <common/bt_shell_private.h>
 
 static void ias_discover_cb(struct bt_conn *conn, int err)
 {

--- a/tests/bluetooth/at/src/main.c
+++ b/tests/bluetooth/at/src/main.c
@@ -10,7 +10,7 @@
 
 #include <zephyr/net_buf.h>
 
-#include "subsys/bluetooth/host/classic/at.h"
+#include <subsys/bluetooth/host/classic/at.h>
 
 #include <zephyr/ztest.h>
 

--- a/tests/bluetooth/bt_crypto/src/test_bt_crypto.c
+++ b/tests/bluetooth/bt_crypto/src/test_bt_crypto.c
@@ -8,7 +8,7 @@
 #include <string.h>
 
 #include <zephyr/ztest.h>
-#include "bt_crypto.h"
+#include <bt_crypto.h>
 
 ZTEST_SUITE(bt_crypto, NULL, NULL, NULL, NULL, NULL);
 

--- a/tests/bluetooth/bt_crypto_ccm/src/test_bt_crypto_ccm.c
+++ b/tests/bluetooth/bt_crypto_ccm/src/test_bt_crypto_ccm.c
@@ -11,7 +11,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/bluetooth/crypto.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #include "test_vectors.h"
 

--- a/tests/bluetooth/df/common/src/bt_common.c
+++ b/tests/bluetooth/df/common/src/bt_common.c
@@ -12,7 +12,7 @@
 #include <pdu_df.h>
 #include <lll/pdu_vendor.h>
 #include <pdu.h>
-#include "bt_common.h"
+#include <bt_common.h>
 
 void *ut_bt_setup(void)
 {

--- a/tests/bluetooth/df/connectionless_cte_chains/src/common.c
+++ b/tests/bluetooth/df/connectionless_cte_chains/src/common.c
@@ -13,28 +13,28 @@
 #include <zephyr/sys/byteorder.h>
 #include <host/hci_core.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "lll.h"
-#include "lll/lll_adv_types.h"
-#include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
-#include "lll_adv_sync.h"
-#include "lll/lll_df_types.h"
+#include <lll.h>
+#include <lll/lll_adv_types.h>
+#include <lll_adv.h>
+#include <lll/lll_adv_pdu.h>
+#include <lll_adv_sync.h>
+#include <lll/lll_df_types.h>
 
-#include "ull_adv_types.h"
-#include "ull_adv_internal.h"
+#include <ull_adv_types.h>
+#include <ull_adv_internal.h>
 
-#include "ll.h"
+#include <ll.h>
 #include "common.h"
 
 #define PDU_PAULOAD_BUFF_SIZE 100

--- a/tests/bluetooth/df/connectionless_cte_chains/src/test_add_cte_to_chain.c
+++ b/tests/bluetooth/df/connectionless_cte_chains/src/test_add_cte_to_chain.c
@@ -13,29 +13,29 @@
 #include <zephyr/sys/byteorder.h>
 #include <host/hci_core.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "lll.h"
-#include "lll/lll_adv_types.h"
-#include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
-#include "lll/lll_adv_internal.h"
-#include "lll_adv_sync.h"
-#include "lll/lll_df_types.h"
+#include <lll.h>
+#include <lll/lll_adv_types.h>
+#include <lll_adv.h>
+#include <lll/lll_adv_pdu.h>
+#include <lll/lll_adv_internal.h>
+#include <lll_adv_sync.h>
+#include <lll/lll_df_types.h>
 
-#include "ull_adv_types.h"
-#include "ull_adv_internal.h"
+#include <ull_adv_types.h>
+#include <ull_adv_internal.h>
 
-#include "ll.h"
+#include <ll.h>
 #include "common.h"
 
 #define TEST_ADV_SET_HANDLE 0

--- a/tests/bluetooth/df/connectionless_cte_chains/src/test_remove_cte_from_chain.c
+++ b/tests/bluetooth/df/connectionless_cte_chains/src/test_remove_cte_from_chain.c
@@ -13,29 +13,29 @@
 #include <zephyr/sys/byteorder.h>
 #include <host/hci_core.h>
 
-#include "util/util.h"
-#include "util/memq.h"
-#include "util/mem.h"
-#include "util/dbuf.h"
+#include <util/util.h>
+#include <util/memq.h>
+#include <util/mem.h>
+#include <util/dbuf.h>
 
-#include "pdu_df.h"
-#include "lll/pdu_vendor.h"
-#include "pdu.h"
+#include <pdu_df.h>
+#include <lll/pdu_vendor.h>
+#include <pdu.h>
 
-#include "hal/ccm.h"
+#include <hal/ccm.h>
 
-#include "lll.h"
-#include "lll/lll_adv_types.h"
-#include "lll_adv.h"
-#include "lll/lll_adv_pdu.h"
-#include "lll/lll_adv_internal.h"
-#include "lll_adv_sync.h"
-#include "lll/lll_df_types.h"
+#include <lll.h>
+#include <lll/lll_adv_types.h>
+#include <lll_adv.h>
+#include <lll/lll_adv_pdu.h>
+#include <lll/lll_adv_internal.h>
+#include <lll_adv_sync.h>
+#include <lll/lll_df_types.h>
 
-#include "ull_adv_types.h"
-#include "ull_adv_internal.h"
+#include <ull_adv_types.h>
+#include <ull_adv_internal.h>
 
-#include "ll.h"
+#include <ll.h>
 #include "common.h"
 
 #define TEST_ADV_SET_HANDLE 0

--- a/tests/bluetooth/gatt/src/main.c
+++ b/tests/bluetooth/gatt/src/main.c
@@ -14,7 +14,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "gatt_internal.h"
+#include <gatt_internal.h>
 
 /* Custom Service Variables */
 static const struct bt_uuid_128 test_uuid = BT_UUID_INIT_128(

--- a/tests/bluetooth/hci/src/test_hci_driver_ext_adv_report_process.c
+++ b/tests/bluetooth/hci/src/test_hci_driver_ext_adv_report_process.c
@@ -7,7 +7,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/ztest.h>
 
-#include "util_hci_evt.h"
+#include <util_hci_evt.h>
 
 #define DEFAULT_DATA_LEN 100U
 #define DEFAULT_SID      5U

--- a/tests/bluetooth/host/conn/src/main.c
+++ b/tests/bluetooth/host/conn/src/main.c
@@ -11,17 +11,17 @@
 
 #include <host/conn_internal.h>
 
-#include "mocks/addr_internal.h"
-#include "mocks/att_internal.h"
-#include "mocks/buf_view.h"
-#include "mocks/hci_core.h"
-#include "mocks/id.h"
-#include "mocks/kernel.h"
-#include "mocks/l2cap_internal.h"
-#include "mocks/scan.h"
-#include "mocks/smp.h"
-#include "mocks/spinlock.h"
-#include "mocks/sys_clock.h"
+#include <mocks/addr_internal.h>
+#include <mocks/att_internal.h>
+#include <mocks/buf_view.h>
+#include <mocks/hci_core.h>
+#include <mocks/id.h>
+#include <mocks/kernel.h>
+#include <mocks/l2cap_internal.h>
+#include <mocks/scan.h>
+#include <mocks/smp.h>
+#include <mocks/spinlock.h>
+#include <mocks/sys_clock.h>
 
 DEFINE_FFF_GLOBALS;
 

--- a/tests/bluetooth/host/crypto/bt_encrypt_be/src/main.c
+++ b/tests/bluetooth/host/crypto/bt_encrypt_be/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/aes.h"
-#include "mocks/aes_expects.h"
+#include <mocks/aes.h>
+#include <mocks/aes_expects.h>
 
 #include <zephyr/bluetooth/crypto.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/crypto/bt_encrypt_be/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/crypto/bt_encrypt_be/src/test_suite_invalid_inputs.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
-#include "mocks/aes.h"
+#include <host_mocks/assert.h>
+#include <mocks/aes.h>
 
 #include <zephyr/bluetooth/crypto.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/crypto/bt_encrypt_le/src/main.c
+++ b/tests/bluetooth/host/crypto/bt_encrypt_le/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/aes.h"
-#include "mocks/aes_expects.h"
+#include <mocks/aes.h>
+#include <mocks/aes_expects.h>
 
 #include <zephyr/bluetooth/crypto.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/crypto/bt_encrypt_le/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/crypto/bt_encrypt_le/src/test_suite_invalid_inputs.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
-#include "mocks/aes.h"
+#include <host_mocks/assert.h>
+#include <mocks/aes.h>
 
 #include <zephyr/bluetooth/crypto.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/crypto/bt_rand/src/main.c
+++ b/tests/bluetooth/host/crypto/bt_rand/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "mocks/prng.h"
-#include "mocks/prng_expects.h"
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <mocks/prng.h>
+#include <mocks/prng_expects.h>
 
 #include <zephyr/bluetooth/crypto.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/crypto/bt_rand/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/crypto/bt_rand/src/test_suite_invalid_inputs.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "mocks/prng.h"
-#include "mocks/prng_expects.h"
+#include <host_mocks/assert.h>
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <mocks/prng.h>
+#include <mocks/prng_expects.h>
 
 #include <zephyr/bluetooth/crypto.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/crypto/mocks/aes.c
+++ b/tests/bluetooth/host/crypto/mocks/aes.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include "mocks/aes.h"
+#include <mocks/aes.h>
 
 DEFINE_FAKE_VALUE_FUNC(psa_status_t, psa_crypto_init);
 DEFINE_FAKE_VALUE_FUNC(psa_status_t, psa_generate_random, uint8_t *, size_t);

--- a/tests/bluetooth/host/crypto/mocks/aes_expects.c
+++ b/tests/bluetooth/host/crypto/mocks/aes_expects.c
@@ -5,8 +5,8 @@
  */
 
 #include <zephyr/kernel.h>
-#include "mocks/aes.h"
-#include "mocks/aes_expects.h"
+#include <mocks/aes.h>
+#include <mocks/aes_expects.h>
 
 void expect_single_call_psa_cipher_encrypt(uint8_t *out)
 {

--- a/tests/bluetooth/host/crypto/mocks/hci_core.c
+++ b/tests/bluetooth/host/crypto/mocks/hci_core.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/hci.h>
 #include <host/hci_core.h>
-#include "mocks/hci_core.h"
+#include <mocks/hci_core.h>
 
 struct bt_dev bt_dev = {
 	.manufacturer = 0x1234,

--- a/tests/bluetooth/host/crypto/mocks/hci_core_expects.c
+++ b/tests/bluetooth/host/crypto/mocks/hci_core_expects.c
@@ -5,8 +5,8 @@
  */
 
 #include <zephyr/kernel.h>
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
 
 void expect_call_count_bt_hci_le_rand(int call_count, uint8_t args_history[])
 {

--- a/tests/bluetooth/host/crypto/mocks/kernel.c
+++ b/tests/bluetooth/host/crypto/mocks/kernel.c
@@ -5,6 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include "mocks/kernel.h"
+#include <mocks/kernel.h>
 
 DEFINE_FAKE_VALUE_FUNC(int64_t, k_uptime_ticks);

--- a/tests/bluetooth/host/crypto/mocks/prng.c
+++ b/tests/bluetooth/host/crypto/mocks/prng.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include "mocks/prng.h"
+#include <mocks/prng.h>
 
 DEFINE_FAKE_VALUE_FUNC(psa_status_t, psa_crypto_init);
 DEFINE_FAKE_VALUE_FUNC(psa_status_t, psa_generate_random, uint8_t *, size_t);

--- a/tests/bluetooth/host/crypto/mocks/prng_expects.c
+++ b/tests/bluetooth/host/crypto/mocks/prng_expects.c
@@ -5,8 +5,8 @@
  */
 
 #include <zephyr/kernel.h>
-#include "mocks/prng.h"
-#include "mocks/prng_expects.h"
+#include <mocks/prng.h>
+#include <mocks/prng_expects.h>
 
 void expect_single_call_tc_psa_crypto_init(void)
 {

--- a/tests/bluetooth/host/cs/bt_le_cs_step_data_parse/src/main.c
+++ b/tests/bluetooth/host/cs/bt_le_cs_step_data_parse/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/conn.h"
-#include "mocks/hci_core.h"
-#include "mocks/net_buf.h"
+#include <mocks/conn.h>
+#include <mocks/hci_core.h>
+#include <mocks/net_buf.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/cs.h>

--- a/tests/bluetooth/host/cs/mocks/conn.c
+++ b/tests/bluetooth/host/cs/mocks/conn.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/conn.h"
+#include <mocks/conn.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/cs/mocks/hci_core.c
+++ b/tests/bluetooth/host/cs/mocks/hci_core.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/hci_core.h"
+#include <mocks/hci_core.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/cs/mocks/net_buf.c
+++ b/tests/bluetooth/host/cs/mocks/net_buf.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
 
-#include "mocks/net_buf.h"
+#include <mocks/net_buf.h>
 
 const struct net_buf_data_cb net_buf_fixed_cb;
 

--- a/tests/bluetooth/host/host_mocks/assert.c
+++ b/tests/bluetooth/host/host_mocks/assert.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 DEFINE_FAKE_VALUE_FUNC(bool, mock_check_if_assert_expected);
 

--- a/tests/bluetooth/host/id/bt_br_oob_get_local/src/main.c
+++ b/tests/bluetooth/host/id/bt_br_oob_get_local/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "testing_common_defs.h"
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_br_oob_get_local/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_br_oob_get_local/src/test_suite_invalid_inputs.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
-#include "testing_common_defs.h"
+#include <host_mocks/assert.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_add/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_add/src/main.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/adv.h"
-#include "mocks/adv_expects.h"
-#include "mocks/conn.h"
-#include "mocks/conn_expects.h"
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "mocks/net_buf.h"
-#include "mocks/net_buf_expects.h"
-#include "mocks/scan.h"
-#include "mocks/scan_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/adv.h>
+#include <mocks/adv_expects.h>
+#include <mocks/conn.h>
+#include <mocks/conn_expects.h>
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <mocks/net_buf.h>
+#include <mocks/net_buf_expects.h>
+#include <mocks/scan.h>
+#include <mocks/scan_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_id_add/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_add/src/test_suite_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_adv_random_addr_check/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_adv_random_addr_check/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/adv.h"
-#include "mocks/adv_expects.h"
+#include <mocks/adv.h>
+#include <mocks/adv_expects.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_id_adv_random_addr_check/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_adv_random_addr_check/src/test_suite_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_create/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_create/src/main.c
@@ -8,7 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "testing_common_defs.h"
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/hci.h>

--- a/tests/bluetooth/host/id/bt_id_create/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_create/src/test_suite_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "testing_common_defs.h"
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_create/src/test_suite_privacy_enabled.c
+++ b/tests/bluetooth/host/id/bt_id_create/src/test_suite_privacy_enabled.c
@@ -6,9 +6,9 @@
 
 #if defined(CONFIG_BT_PRIVACY)
 
-#include "mocks/crypto.h"
-#include "mocks/crypto_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/crypto.h>
+#include <mocks/crypto_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_del/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_del/src/main.c
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/adv.h"
-#include "mocks/adv_expects.h"
-#include "mocks/conn.h"
-#include "mocks/conn_expects.h"
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "mocks/keys.h"
-#include "mocks/keys_expects.h"
-#include "mocks/net_buf.h"
-#include "mocks/net_buf_expects.h"
-#include "mocks/scan.h"
-#include "mocks/scan_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/adv.h>
+#include <mocks/adv_expects.h>
+#include <mocks/conn.h>
+#include <mocks/conn_expects.h>
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <mocks/keys.h>
+#include <mocks/keys_expects.h>
+#include <mocks/net_buf.h>
+#include <mocks/net_buf_expects.h>
+#include <mocks/scan.h>
+#include <mocks/scan_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_id_del/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_del/src/test_suite_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_delete/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_delete/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/adv.h"
-#include "mocks/hci_core.h"
-#include "mocks/settings.h"
-#include "mocks/settings_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/adv.h>
+#include <mocks/hci_core.h>
+#include <mocks/settings.h>
+#include <mocks/settings_expects.h>
+#include <testing_common_defs.h>
 #include <stdint.h>
 
 #include <zephyr/bluetooth/addr.h>

--- a/tests/bluetooth/host/id/bt_id_delete/src/test_suite_bt_settings.c
+++ b/tests/bluetooth/host/id/bt_id_delete/src/test_suite_bt_settings.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/adv.h"
-#include "mocks/hci_core.h"
-#include "mocks/settings.h"
-#include "mocks/settings_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/adv.h>
+#include <mocks/hci_core.h>
+#include <mocks/settings.h>
+#include <mocks/settings_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_delete/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_delete/src/test_suite_invalid_inputs.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/adv.h"
-#include "mocks/adv_expects.h"
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/adv.h>
+#include <mocks/adv_expects.h>
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_get/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_get/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "testing_common_defs.h"
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_id_init/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_init/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/crypto.h"
-#include "mocks/hci_core.h"
-#include "mocks/kernel.h"
-#include "mocks/kernel_expects.h"
-#include "mocks/smp.h"
-#include "testing_common_defs.h"
+#include <mocks/crypto.h>
+#include <mocks/hci_core.h>
+#include <mocks/kernel.h>
+#include <mocks/kernel_expects.h>
+#include <mocks/smp.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_id_init/src/test_suite_setup_public_identity.c
+++ b/tests/bluetooth/host/id/bt_id_init/src/test_suite_setup_public_identity.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/crypto.h"
-#include "mocks/hci_core.h"
-#include "mocks/kernel.h"
-#include "mocks/kernel_expects.h"
-#include "mocks/smp.h"
-#include "testing_common_defs.h"
+#include <mocks/crypto.h>
+#include <mocks/hci_core.h>
+#include <mocks/kernel.h>
+#include <mocks/kernel_expects.h>
+#include <mocks/smp.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_init/src/test_suite_setup_static_random_identity.c
+++ b/tests/bluetooth/host/id/bt_id_init/src/test_suite_setup_static_random_identity.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/crypto.h"
-#include "mocks/hci_core.h"
-#include "mocks/kernel.h"
-#include "mocks/kernel_expects.h"
-#include "mocks/smp.h"
-#include "testing_common_defs.h"
+#include <mocks/crypto.h>
+#include <mocks/hci_core.h>
+#include <mocks/kernel.h>
+#include <mocks/kernel_expects.h>
+#include <mocks/smp.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_vs.h>

--- a/tests/bluetooth/host/id/bt_id_read_public_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_read_public_addr/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "mocks/net_buf.h"
-#include "mocks/net_buf_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <mocks/net_buf.h>
+#include <mocks/net_buf_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_id_read_public_addr/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_read_public_addr/src/test_suite_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_reset/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_reset/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/addr.h"
-#include "mocks/addr_expects.h"
-#include "mocks/adv.h"
-#include "mocks/hci_core.h"
-#include "testing_common_defs.h"
+#include <mocks/addr.h>
+#include <mocks/addr_expects.h>
+#include <mocks/adv.h>
+#include <mocks/hci_core.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_id_reset/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_reset/src/test_suite_invalid_inputs.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/adv.h"
-#include "mocks/adv_expects.h"
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/adv.h>
+#include <mocks/adv_expects.h>
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_scan_random_addr_check/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_scan_random_addr_check/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/adv.h"
-#include "mocks/adv_expects.h"
+#include <mocks/adv.h>
+#include <mocks/adv_expects.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/crypto.h"
-#include "mocks/scan.h"
-#include "mocks/scan_expects.h"
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "mocks/net_buf.h"
-#include "mocks/net_buf_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/crypto.h>
+#include <mocks/scan.h>
+#include <mocks/scan_expects.h>
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <mocks/net_buf.h>
+#include <mocks/net_buf_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_types.h>

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/src/test_suite_invalid_inputs.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
-#include "mocks/crypto.h"
-#include "testing_common_defs.h"
+#include <host_mocks/assert.h>
+#include <mocks/crypto.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/crypto.h"
-#include "mocks/crypto_expects.h"
-#include "mocks/hci_core.h"
-#include "mocks/rpa.h"
-#include "mocks/rpa_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/crypto.h>
+#include <mocks/crypto_expects.h>
+#include <mocks/hci_core.h>
+#include <mocks/rpa.h>
+#include <mocks/rpa_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/test_suite_invalid_cases.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/test_suite_invalid_cases.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
-#include "mocks/crypto.h"
-#include "mocks/hci_core.h"
-#include "mocks/rpa.h"
-#include "testing_common_defs.h"
+#include <host_mocks/assert.h>
+#include <mocks/crypto.h>
+#include <mocks/hci_core.h>
+#include <mocks/rpa.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "mocks/net_buf.h"
-#include "mocks/net_buf_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <mocks/net_buf.h>
+#include <mocks/net_buf_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/test_suite_invalid_cases.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/test_suite_invalid_cases.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
-#include "mocks/hci_core.h"
-#include "mocks/net_buf.h"
-#include "testing_common_defs.h"
+#include <host_mocks/assert.h>
+#include <mocks/hci_core.h>
+#include <mocks/net_buf.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/hci_core.h"
-#include "mocks/rpa.h"
-#include "testing_common_defs.h"
+#include <mocks/hci_core.h>
+#include <mocks/rpa.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_types.h>

--- a/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/test_suite_invalid_inputs.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
-#include "mocks/hci_core.h"
-#include "mocks/rpa.h"
-#include "mocks/rpa_expects.h"
-#include "testing_common_defs.h"
+#include <host_mocks/assert.h>
+#include <mocks/hci_core.h>
+#include <mocks/rpa.h>
+#include <mocks/rpa_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_set_private_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_private_addr/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/crypto.h"
-#include "mocks/crypto_expects.h"
-#include "mocks/hci_core.h"
-#include "mocks/rpa.h"
-#include "mocks/rpa_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/crypto.h>
+#include <mocks/crypto_expects.h>
+#include <mocks/hci_core.h>
+#include <mocks/rpa.h>
+#include <mocks/rpa_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_id_set_private_addr/src/test_suite_invalid_cases.c
+++ b/tests/bluetooth/host/id/bt_id_set_private_addr/src/test_suite_invalid_cases.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
-#include "mocks/crypto.h"
-#include "mocks/hci_core.h"
-#include "mocks/rpa.h"
-#include "testing_common_defs.h"
+#include <host_mocks/assert.h>
+#include <mocks/crypto.h>
+#include <mocks/hci_core.h>
+#include <mocks/rpa.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/crypto.h"
-#include "mocks/hci_core.h"
-#include "mocks/rpa.h"
-#include "mocks/adv.h"
-#include "mocks/adv_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/crypto.h>
+#include <mocks/hci_core.h>
+#include <mocks/rpa.h>
+#include <mocks/adv.h>
+#include <mocks/adv_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_types.h>

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/test_suite_invalid_inputs.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
-#include "mocks/crypto.h"
-#include "mocks/hci_core.h"
-#include "mocks/rpa.h"
-#include "mocks/rpa_expects.h"
-#include "testing_common_defs.h"
+#include <host_mocks/assert.h>
+#include <mocks/crypto.h>
+#include <mocks/hci_core.h>
+#include <mocks/rpa.h>
+#include <mocks/rpa_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/src/main.c
+++ b/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "testing_common_defs.h"
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_le_ext_adv_oob_get_local/src/test_suite_invalid_inputs.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
-#include "testing_common_defs.h"
+#include <host_mocks/assert.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_le_oob_get_local/src/main.c
+++ b/tests/bluetooth/host/id/bt_le_oob_get_local/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "testing_common_defs.h"
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_le_oob_get_local/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_le_oob_get_local/src/test_suite_invalid_inputs.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
-#include "testing_common_defs.h"
+#include <host_mocks/assert.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_le_oob_get_sc_data/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_le_oob_get_sc_data/src/test_suite_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_le_oob_set_legacy_tk/src/test_suite_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_le_oob_set_sc_data/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_le_oob_set_sc_data/src/test_suite_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_lookup_id_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_lookup_id_addr/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/keys.h"
-#include "mocks/keys_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/keys.h>
+#include <mocks/keys_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_lookup_id_addr/src/test_suite_bt_lookup_id_addr_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_lookup_id_addr/src/test_suite_bt_lookup_id_addr_invalid_inputs.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
-#include "testing_common_defs.h"
+#include <host_mocks/assert.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>

--- a/tests/bluetooth/host/id/bt_setup_public_id_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_setup_public_id_addr/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/id/bt_setup_public_id_addr/src/test_suite_bt_privacy_enabled.c
+++ b/tests/bluetooth/host/id/bt_setup_public_id_addr/src/test_suite_bt_privacy_enabled.c
@@ -6,12 +6,12 @@
 
 #if defined(CONFIG_BT_PRIVACY)
 
-#include "mocks/crypto.h"
-#include "mocks/crypto_expects.h"
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "mocks/smp.h"
-#include "testing_common_defs.h"
+#include <mocks/crypto.h>
+#include <mocks/crypto_expects.h>
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <mocks/smp.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_setup_public_id_addr/src/test_suite_bt_settings_enabled.c
+++ b/tests/bluetooth/host/id/bt_setup_public_id_addr/src/test_suite_bt_settings_enabled.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "mocks/settings.h"
-#include "mocks/settings_expects.h"
-#include "mocks/smp.h"
-#include "testing_common_defs.h"
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <mocks/settings.h>
+#include <mocks/settings_expects.h>
+#include <mocks/smp.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "mocks/net_buf.h"
-#include "mocks/net_buf_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <mocks/net_buf.h>
+#include <mocks/net_buf_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_vs.h>

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_bt_privacy_enabled.c
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_bt_privacy_enabled.c
@@ -6,12 +6,12 @@
 
 #if defined(CONFIG_BT_PRIVACY)
 
-#include "mocks/crypto.h"
-#include "mocks/crypto_expects.h"
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "mocks/smp.h"
-#include "testing_common_defs.h"
+#include <mocks/crypto.h>
+#include <mocks/crypto_expects.h>
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <mocks/smp.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_vs.h>

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_bt_settings_enabled.c
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_bt_settings_enabled.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "mocks/settings.h"
-#include "mocks/settings_expects.h"
-#include "mocks/smp.h"
-#include "testing_common_defs.h"
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <mocks/settings.h>
+#include <mocks/settings_expects.h>
+#include <mocks/smp.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_vs.h>

--- a/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_invalid_cases.c
+++ b/tests/bluetooth/host/id/bt_setup_random_id_addr/src/test_suite_invalid_cases.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
-#include "mocks/net_buf.h"
-#include "mocks/net_buf_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
+#include <mocks/net_buf.h>
+#include <mocks/net_buf_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_vs.h>

--- a/tests/bluetooth/host/id/mocks/addr_expects.c
+++ b/tests/bluetooth/host/id/mocks/addr_expects.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/addr.h"
-#include "mocks/addr_expects.h"
+#include <mocks/addr.h>
+#include <mocks/addr_expects.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/adv.c
+++ b/tests/bluetooth/host/id/mocks/adv.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/adv.h"
+#include <mocks/adv.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/adv_expects.c
+++ b/tests/bluetooth/host/id/mocks/adv_expects.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/adv.h"
-#include "mocks/adv_expects.h"
+#include <mocks/adv.h>
+#include <mocks/adv_expects.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/conn.c
+++ b/tests/bluetooth/host/id/mocks/conn.c
@@ -7,7 +7,7 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/kernel.h>
 
-#include "mocks/conn.h"
+#include <mocks/conn.h>
 
 DEFINE_FAKE_VOID_FUNC(bt_conn_unref, struct bt_conn *);
 DEFINE_FAKE_VALUE_FUNC(int, bt_le_create_conn_cancel);

--- a/tests/bluetooth/host/id/mocks/conn_expects.c
+++ b/tests/bluetooth/host/id/mocks/conn_expects.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/conn.h"
-#include "mocks/conn_expects.h"
+#include <mocks/conn.h>
+#include <mocks/conn_expects.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/crypto_expects.c
+++ b/tests/bluetooth/host/id/mocks/crypto_expects.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/crypto.h"
-#include "mocks/crypto_expects.h"
+#include <mocks/crypto.h>
+#include <mocks/crypto_expects.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/hci_core.c
+++ b/tests/bluetooth/host/id/mocks/hci_core.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/hci_core.h"
+#include <mocks/hci_core.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/mocks/hci_core_expects.c
+++ b/tests/bluetooth/host/id/mocks/hci_core_expects.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
 
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/mocks/kernel.c
+++ b/tests/bluetooth/host/id/mocks/kernel.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/kernel.h"
+#include <mocks/kernel.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/kernel_expects.c
+++ b/tests/bluetooth/host/id/mocks/kernel_expects.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/kernel.h"
-#include "mocks/kernel_expects.h"
+#include <mocks/kernel.h>
+#include <mocks/kernel_expects.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/keys_expects.c
+++ b/tests/bluetooth/host/id/mocks/keys_expects.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/keys.h"
-#include "mocks/keys_expects.h"
+#include <mocks/keys.h>
+#include <mocks/keys_expects.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/net_buf_expects.c
+++ b/tests/bluetooth/host/id/mocks/net_buf_expects.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/net_buf.h"
-#include "mocks/net_buf_expects.h"
+#include <mocks/net_buf.h>
+#include <mocks/net_buf_expects.h>
 
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/id/mocks/rpa.c
+++ b/tests/bluetooth/host/id/mocks/rpa.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/rpa.h"
+#include <mocks/rpa.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/rpa_expects.c
+++ b/tests/bluetooth/host/id/mocks/rpa_expects.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/rpa.h"
-#include "mocks/rpa_expects.h"
+#include <mocks/rpa.h>
+#include <mocks/rpa_expects.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/scan_expects.c
+++ b/tests/bluetooth/host/id/mocks/scan_expects.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/scan.h"
-#include "mocks/scan_expects.h"
+#include <mocks/scan.h>
+#include <mocks/scan_expects.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/settings.c
+++ b/tests/bluetooth/host/id/mocks/settings.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/settings.h"
+#include <mocks/settings.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/settings_expects.c
+++ b/tests/bluetooth/host/id/mocks/settings_expects.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/settings.h"
-#include "mocks/settings_expects.h"
+#include <mocks/settings.h>
+#include <mocks/settings_expects.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/smp.c
+++ b/tests/bluetooth/host/id/mocks/smp.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/smp.h"
+#include <mocks/smp.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/id/mocks/smp_expects.c
+++ b/tests/bluetooth/host/id/mocks/smp_expects.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/smp.h"
-#include "mocks/smp_expects.h"
+#include <mocks/smp.h>
+#include <mocks/smp_expects.h>
 
 #include <zephyr/kernel.h>
 

--- a/tests/bluetooth/host/keys/bt_keys_add_type/src/test_suite_add_type_invalid_inputs.c
+++ b/tests/bluetooth/host/keys/bt_keys_add_type/src/test_suite_add_type_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/keys/bt_keys_clear/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_clear/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/id.h"
-#include "mocks/id_expects.h"
-#include "mocks/keys_help_utils.h"
-#include "testing_common_defs.h"
+#include <mocks/id.h>
+#include <mocks/id_expects.h>
+#include <mocks/keys_help_utils.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/keys/bt_keys_clear/src/test_suite_bt_settings.c
+++ b/tests/bluetooth/host/keys/bt_keys_clear/src/test_suite_bt_settings.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/keys_help_utils.h"
-#include "mocks/settings.h"
-#include "mocks/settings_expects.h"
-#include "mocks/settings_store.h"
-#include "mocks/settings_store_expects.h"
-#include "mocks/util.h"
-#include "mocks/util_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/keys_help_utils.h>
+#include <mocks/settings.h>
+#include <mocks/settings_expects.h>
+#include <mocks/settings_store.h>
+#include <mocks/settings_store_expects.h>
+#include <mocks/util.h>
+#include <mocks/util_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/keys/bt_keys_clear/src/test_suite_clear_invalid_inputs.c
+++ b/tests/bluetooth/host/keys/bt_keys_clear/src/test_suite_clear_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/keys/bt_keys_find/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_find/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/keys_help_utils.h"
-#include "testing_common_defs.h"
+#include <mocks/keys_help_utils.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/keys/bt_keys_find/src/test_suite_find_invalid_inputs.c
+++ b/tests/bluetooth/host/keys/bt_keys_find/src/test_suite_find_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/keys/bt_keys_find_addr/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_find_addr/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/keys_help_utils.h"
-#include "mocks/rpa.h"
-#include "testing_common_defs.h"
+#include <mocks/keys_help_utils.h>
+#include <mocks/rpa.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/keys/bt_keys_find_addr/src/test_suite_find_addr_invalid_inputs.c
+++ b/tests/bluetooth/host/keys/bt_keys_find_addr/src/test_suite_find_addr_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/keys/bt_keys_find_irk/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_find_irk/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/keys_help_utils.h"
-#include "mocks/rpa.h"
-#include "testing_common_defs.h"
+#include <mocks/keys_help_utils.h>
+#include <mocks/rpa.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/keys/bt_keys_find_irk/src/test_suite_find_irk_invalid_inputs.c
+++ b/tests/bluetooth/host/keys/bt_keys_find_irk/src/test_suite_find_irk_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/keys/bt_keys_foreach_bond/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_bond/src/main.c
@@ -9,8 +9,8 @@
 #include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
 #include <zephyr/fff.h>
-#include "mocks/keys_help_utils.h"
-#include "testing_common_defs.h"
+#include <mocks/keys_help_utils.h>
+#include <testing_common_defs.h>
 
 DEFINE_FFF_GLOBALS;
 

--- a/tests/bluetooth/host/keys/bt_keys_foreach_bond/src/test_suite_foreach_bond_invalid_inputs.c
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_bond/src/test_suite_foreach_bond_invalid_inputs.c
@@ -6,8 +6,8 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/bluetooth.h>
-#include "host_mocks/assert.h"
-#include "mocks/keys_help_utils.h"
+#include <host_mocks/assert.h>
+#include <mocks/keys_help_utils.h>
 
 /* This LUT contains different combinations of ID and Address pairs */
 extern const struct id_addr_pair testing_id_addr_pair_lut[CONFIG_BT_MAX_PAIRED];

--- a/tests/bluetooth/host/keys/bt_keys_foreach_type/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_type/src/main.c
@@ -9,8 +9,8 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <host/keys.h>
 #include <zephyr/fff.h>
-#include "mocks/keys_help_utils.h"
-#include "testing_common_defs.h"
+#include <mocks/keys_help_utils.h>
+#include <testing_common_defs.h>
 
 DEFINE_FFF_GLOBALS;
 

--- a/tests/bluetooth/host/keys/bt_keys_foreach_type/src/test_suite_foreach_type_invalid_inputs.c
+++ b/tests/bluetooth/host/keys/bt_keys_foreach_type/src/test_suite_foreach_type_invalid_inputs.c
@@ -7,8 +7,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <host/keys.h>
-#include "host_mocks/assert.h"
-#include "mocks/keys_help_utils.h"
+#include <host_mocks/assert.h>
+#include <mocks/keys_help_utils.h>
 
 /* This LUT contains different combinations of ID, Address and key type.
  * It is defined in main.c.

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/main.c
@@ -8,11 +8,11 @@
 #include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
 #include <zephyr/fff.h>
-#include "mocks/conn.h"
-#include "mocks/hci_core.h"
-#include "mocks/keys_help_utils.h"
-#include "testing_common_defs.h"
-#include "common/bt_str.h"
+#include <mocks/conn.h>
+#include <mocks/hci_core.h>
+#include <mocks/keys_help_utils.h>
+#include <testing_common_defs.h>
+#include <common/bt_str.h>
 
 DEFINE_FFF_GLOBALS;
 

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_invalid_values.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_invalid_values.c
@@ -7,12 +7,12 @@
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
-#include "mocks/conn.h"
-#include "mocks/hci_core.h"
-#include "mocks/keys_help_utils.h"
-#include "mocks/hci_core_expects.h"
-#include "host_mocks/assert.h"
-#include "testing_common_defs.h"
+#include <mocks/conn.h>
+#include <mocks/hci_core.h>
+#include <mocks/keys_help_utils.h>
+#include <mocks/hci_core_expects.h>
+#include <host_mocks/assert.h>
+#include <testing_common_defs.h>
 
 /* This LUT contains different combinations of ID and Address pairs */
 extern const struct id_addr_pair testing_id_addr_pair_lut[CONFIG_BT_MAX_PAIRED];

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_no_overwrite.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_no_overwrite.c
@@ -7,9 +7,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
-#include "mocks/keys_help_utils.h"
-#include "mocks/hci_core_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/keys_help_utils.h>
+#include <mocks/hci_core_expects.h>
+#include <testing_common_defs.h>
 
 /* This LUT contains different combinations of ID and Address pairs */
 extern const struct id_addr_pair testing_id_addr_pair_lut[CONFIG_BT_MAX_PAIRED];

--- a/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_overwrite_oldest.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_addr/src/test_suite_full_list_overwrite_oldest.c
@@ -7,11 +7,11 @@
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/addr.h>
 #include <host/keys.h>
-#include "mocks/conn.h"
-#include "mocks/hci_core.h"
-#include "mocks/keys_help_utils.h"
-#include "mocks/hci_core_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/conn.h>
+#include <mocks/hci_core.h>
+#include <mocks/keys_help_utils.h>
+#include <mocks/hci_core_expects.h>
+#include <testing_common_defs.h>
 
 /* This LUT contains different combinations of ID and Address pairs */
 extern const struct id_addr_pair testing_id_addr_pair_lut[CONFIG_BT_MAX_PAIRED];

--- a/tests/bluetooth/host/keys/bt_keys_get_type/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_type/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "mocks/keys_help_utils.h"
-#include "testing_common_defs.h"
+#include <mocks/keys_help_utils.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/keys/bt_keys_get_type/src/test_suite_get_type_invalid_inputs.c
+++ b/tests/bluetooth/host/keys/bt_keys_get_type/src/test_suite_get_type_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/keys/bt_keys_store/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_store/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/keys_help_utils.h"
-#include "mocks/settings.h"
-#include "mocks/settings_expects.h"
-#include "mocks/settings_store.h"
-#include "mocks/settings_store_expects.h"
-#include "mocks/util.h"
-#include "mocks/util_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/keys_help_utils.h>
+#include <mocks/settings.h>
+#include <mocks/settings_expects.h>
+#include <mocks/settings_store.h>
+#include <mocks/settings_store_expects.h>
+#include <mocks/util.h>
+#include <mocks/util_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/keys/bt_keys_store/src/test_suite_store_invalid_inputs.c
+++ b/tests/bluetooth/host/keys/bt_keys_store/src/test_suite_store_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/keys/bt_keys_update_usage/src/main.c
+++ b/tests/bluetooth/host/keys/bt_keys_update_usage/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/keys_help_utils.h"
-#include "mocks/settings_store_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/keys_help_utils.h>
+#include <mocks/settings_store_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/fff.h>

--- a/tests/bluetooth/host/keys/bt_keys_update_usage/src/test_suite_save_aging_counter.c
+++ b/tests/bluetooth/host/keys/bt_keys_update_usage/src/test_suite_save_aging_counter.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "mocks/keys_help_utils.h"
-#include "mocks/settings_store.h"
-#include "mocks/settings_store_expects.h"
-#include "testing_common_defs.h"
+#include <mocks/keys_help_utils.h>
+#include <mocks/settings_store.h>
+#include <mocks/settings_store_expects.h>
+#include <testing_common_defs.h>
 
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/keys/bt_keys_update_usage/src/test_suite_update_usage_invalid_inputs.c
+++ b/tests/bluetooth/host/keys/bt_keys_update_usage/src/test_suite_update_usage_invalid_inputs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "host_mocks/assert.h"
+#include <host_mocks/assert.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/kernel.h>

--- a/tests/bluetooth/host/keys/mocks/conn.c
+++ b/tests/bluetooth/host/keys/mocks/conn.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include "mocks/conn.h"
+#include <mocks/conn.h>
 
 DEFINE_FAKE_VOID_FUNC(bt_conn_foreach, enum bt_conn_type, bt_conn_foreach_cb, void *);
 DEFINE_FAKE_VALUE_FUNC(const bt_addr_le_t *, bt_conn_get_dst, const struct bt_conn *);

--- a/tests/bluetooth/host/keys/mocks/hci_core.c
+++ b/tests/bluetooth/host/keys/mocks/hci_core.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include "mocks/hci_core.h"
+#include <mocks/hci_core.h>
 
 DEFINE_FAKE_VALUE_FUNC(int, bt_unpair, uint8_t, const bt_addr_le_t *);
 DEFINE_FAKE_VOID_FUNC(bt_id_add, struct bt_keys *);

--- a/tests/bluetooth/host/keys/mocks/hci_core_expects.c
+++ b/tests/bluetooth/host/keys/mocks/hci_core_expects.c
@@ -6,8 +6,8 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/buf.h>
-#include "mocks/hci_core.h"
-#include "mocks/hci_core_expects.h"
+#include <mocks/hci_core.h>
+#include <mocks/hci_core_expects.h>
 
 void expect_single_call_bt_unpair(uint8_t id, const bt_addr_le_t *addr)
 {

--- a/tests/bluetooth/host/keys/mocks/id.c
+++ b/tests/bluetooth/host/keys/mocks/id.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include "mocks/id.h"
+#include <mocks/id.h>
 
 DEFINE_FAKE_VOID_FUNC(bt_id_del, struct bt_keys *);
 DEFINE_FAKE_VOID_FUNC(bt_id_pending_keys_update);

--- a/tests/bluetooth/host/keys/mocks/id_expects.c
+++ b/tests/bluetooth/host/keys/mocks/id_expects.c
@@ -6,8 +6,8 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/buf.h>
-#include "mocks/id.h"
-#include "mocks/id_expects.h"
+#include <mocks/id.h>
+#include <mocks/id_expects.h>
 
 void expect_single_call_bt_id_del(struct bt_keys *keys)
 {

--- a/tests/bluetooth/host/keys/mocks/rpa.c
+++ b/tests/bluetooth/host/keys/mocks/rpa.c
@@ -5,6 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include "mocks/rpa.h"
+#include <mocks/rpa.h>
 
 DEFINE_FAKE_VALUE_FUNC(bool, bt_rpa_irk_matches, const uint8_t *, const bt_addr_t *);

--- a/tests/bluetooth/host/keys/mocks/settings.c
+++ b/tests/bluetooth/host/keys/mocks/settings.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include "mocks/settings.h"
+#include <mocks/settings.h>
 
 DEFINE_FAKE_VOID_FUNC(bt_settings_encode_key, char *, size_t, const char *,
 			    const bt_addr_le_t *, const char *);

--- a/tests/bluetooth/host/keys/mocks/settings_expects.c
+++ b/tests/bluetooth/host/keys/mocks/settings_expects.c
@@ -6,8 +6,8 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/buf.h>
-#include "mocks/settings.h"
-#include "mocks/settings_expects.h"
+#include <mocks/settings.h>
+#include <mocks/settings_expects.h>
 
 void expect_single_call_bt_settings_encode_key_with_not_null_key(const bt_addr_le_t *addr)
 {

--- a/tests/bluetooth/host/keys/mocks/settings_store.c
+++ b/tests/bluetooth/host/keys/mocks/settings_store.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include "mocks/settings_store.h"
+#include <mocks/settings_store.h>
 
 DEFINE_FAKE_VALUE_FUNC(int, bt_settings_store_keys, uint8_t, struct bt_addr_le_t *, const void *,
 		       size_t);

--- a/tests/bluetooth/host/keys/mocks/settings_store_expects.c
+++ b/tests/bluetooth/host/keys/mocks/settings_store_expects.c
@@ -7,8 +7,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/buf.h>
 #include <host/keys.h>
-#include "mocks/settings_store.h"
-#include "mocks/settings_store_expects.h"
+#include <mocks/settings_store.h>
+#include <mocks/settings_store_expects.h>
 
 void expect_single_call_bt_settings_delete_keys(void)
 {

--- a/tests/bluetooth/host/keys/mocks/util.c
+++ b/tests/bluetooth/host/keys/mocks/util.c
@@ -5,6 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include "mocks/util.h"
+#include <mocks/util.h>
 
 DEFINE_FAKE_VALUE_FUNC(uint8_t, u8_to_dec, char *, uint8_t, uint8_t);

--- a/tests/bluetooth/host/keys/mocks/util_expects.c
+++ b/tests/bluetooth/host/keys/mocks/util_expects.c
@@ -6,8 +6,8 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/buf.h>
-#include "mocks/util.h"
-#include "mocks/util_expects.h"
+#include <mocks/util.h>
+#include <mocks/util_expects.h>
 
 void expect_single_call_u8_to_dec(uint8_t value)
 {

--- a/tests/bsim/bluetooth/host/adv/chain/src/main.c
+++ b/tests/bsim/bluetooth/host/adv/chain/src/main.c
@@ -14,7 +14,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 #define NAME_LEN 30
 #define AD_DATA_NAME_SIZE     (sizeof(CONFIG_BT_DEVICE_NAME) - 1U + 2U)

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/central.c
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/central.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 #include "common.h"
 
 extern const struct test_sample_data *sample_data;

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/common.c
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/common.c
@@ -4,7 +4,7 @@
 
 #include "common.h"
 
-#include "bs_cmd_line.h"
+#include <bs_cmd_line.h>
 
 #define SAMPLE_DATA_SET_SIZE 2
 static const struct test_sample_data *sample_data_set[] = {

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/common.h
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/common.h
@@ -9,10 +9,10 @@
 
 #include <zephyr/logging/log.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
+#include <bs_tracing.h>
+#include <bstests.h>
 
 /**
  * @brief Encrypt and authenticate the given advertising data.

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/main.c
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/main.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_bsim_ead_sample_data, CONFIG_BT_EAD_LOG_LEVEL);

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/src/peripheral.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 #include "common.h"
 
 extern const struct test_sample_data *sample_data;

--- a/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/src/main.c
+++ b/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/src/main.c
@@ -12,14 +12,14 @@
 #include <zephyr/bluetooth/ead.h>
 #include <zephyr/bluetooth/conn.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <bstests.h>
 
 #include <zephyr/logging/log.h>
 
-#include "data.h"
-#include "common.h"
+#include <data.h>
+#include <common.h>
 
 LOG_MODULE_REGISTER(bt_bsim_ead_sample, CONFIG_BT_EAD_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_advertiser.c
@@ -5,8 +5,8 @@
  */
 #include <zephyr/kernel.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #include <zephyr/types.h>
 #include <zephyr/sys/printk.h>

--- a/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
+++ b/tests/bsim/bluetooth/host/adv/extended/src/ext_adv_scanner.c
@@ -5,8 +5,8 @@
  */
 #include <zephyr/kernel.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #include <zephyr/types.h>
 #include <zephyr/sys/printk.h>

--- a/tests/bsim/bluetooth/host/adv/long_ad/src/advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/long_ad/src/advertiser.c
@@ -12,7 +12,7 @@
 #include <sys/types.h>
 
 #include "ad.h"
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 LOG_MODULE_REGISTER(advertiser, LOG_LEVEL_INF);
 

--- a/tests/bsim/bluetooth/host/adv/long_ad/src/main.c
+++ b/tests/bsim/bluetooth/host/adv/long_ad/src/main.c
@@ -6,9 +6,9 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
 
 extern void entrypoint_advertiser(void);
 extern void entrypoint_scanner(void);

--- a/tests/bsim/bluetooth/host/adv/long_ad/src/scanner.c
+++ b/tests/bsim/bluetooth/host/adv/long_ad/src/scanner.c
@@ -13,8 +13,8 @@
 
 #include "ad.h"
 
-#include "babblekit/flags.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
 
 LOG_MODULE_REGISTER(scanner, LOG_LEVEL_INF);
 

--- a/tests/bsim/bluetooth/host/adv/periodic/src/main.c
+++ b/tests/bsim/bluetooth/host/adv/periodic/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_per_adv_sync(struct bst_test_list *tests);
 extern struct bst_test_list *test_per_adv_advertiser(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_advertiser.c
+++ b/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_advertiser.c
@@ -15,8 +15,8 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_sync.c
+++ b/tests/bsim/bluetooth/host/adv/periodic/src/per_adv_sync.c
@@ -15,8 +15,8 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/att/eatt/src/common.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/common.c
@@ -6,9 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 #include "common.h"
-#include "argparse.h"
+#include <argparse.h>
 
 struct bt_conn *default_conn;
 

--- a/tests/bsim/bluetooth/host/att/eatt/src/main.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_main_collision_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_main_autoconnect_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/host/att/eatt/src/main_autoconnect.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/main_autoconnect.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 #include "common.h"
 
 static void test_peripheral_main(void)

--- a/tests/bsim/bluetooth/host/att/eatt/src/main_collision.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/main_collision.c
@@ -6,8 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "babblekit/testcase.h"
-#include "babblekit/sync.h"
+#include <babblekit/testcase.h>
+#include <babblekit/sync.h>
 #include "common.h"
 
 static void test_peripheral_main(void)

--- a/tests/bsim/bluetooth/host/att/eatt/src/main_lowres.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/main_lowres.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 #include "common.h"
 
 static void test_peripheral_main(void)

--- a/tests/bsim/bluetooth/host/att/eatt/src/main_reconfigure.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/main_reconfigure.c
@@ -6,9 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
 #include "common.h"
 
 #include <zephyr/bluetooth/gatt.h>

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/client_test.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/client_test.c
@@ -25,9 +25,9 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/att.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
 #include "common.h"
 
 DEFINE_FLAG_STATIC(flag_is_connected);

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/main.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_server_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_client_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/src/server_test.c
@@ -15,9 +15,9 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/att.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
 #include "common.h"
 
 DEFINE_FLAG_STATIC(flag_discover_complete);

--- a/tests/bsim/bluetooth/host/att/long_read/main.c
+++ b/tests/bsim/bluetooth/host/att/long_read/main.c
@@ -10,15 +10,15 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/bluetooth.h>
 
-#include "testlib/adv.h"
-#include "testlib/att_read.h"
-#include "testlib/att_write.h"
+#include <testlib/adv.h>
+#include <testlib/att_read.h>
+#include <testlib/att_write.h>
 #include "bs_macro.h"
 #include "bs_sync.h"
 #include <testlib/conn.h>
-#include "testlib/log_utils.h"
-#include "testlib/scan.h"
-#include "testlib/security.h"
+#include <testlib/log_utils.h>
+#include <testlib/scan.h>
+#include <testlib/security.h>
 
 /* This test uses system asserts to fail tests. */
 BUILD_ASSERT(__ASSERT_ON);

--- a/tests/bsim/bluetooth/host/att/mtu_update/src/main_central.c
+++ b/tests/bsim/bluetooth/host/att/mtu_update/src/main_central.c
@@ -14,8 +14,8 @@
 
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_bsim_mtu_update, LOG_LEVEL_DBG);

--- a/tests/bsim/bluetooth/host/att/mtu_update/src/main_peripheral.c
+++ b/tests/bsim/bluetooth/host/att/mtu_update/src/main_peripheral.c
@@ -12,7 +12,7 @@
 
 #include <zephyr/sys/printk.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_bsim_mtu_update, LOG_LEVEL_DBG);

--- a/tests/bsim/bluetooth/host/att/open_close/src/main.c
+++ b/tests/bsim/bluetooth/host/att/open_close/src/main.c
@@ -10,15 +10,15 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/bluetooth.h>
 
-#include "testlib/adv.h"
-#include "testlib/att_read.h"
-#include "testlib/att_write.h"
+#include <testlib/adv.h>
+#include <testlib/att_read.h>
+#include <testlib/att_write.h>
 #include "bs_macro.h"
 #include "bs_sync.h"
 #include <testlib/conn.h>
-#include "testlib/log_utils.h"
-#include "testlib/scan.h"
-#include "testlib/security.h"
+#include <testlib/log_utils.h>
+#include <testlib/scan.h>
+#include <testlib/security.h>
 
 /* This test uses system asserts to fail tests. */
 BUILD_ASSERT(__ASSERT_ON);

--- a/tests/bsim/bluetooth/host/att/pipeline/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/att/pipeline/dut/src/main.c
@@ -16,11 +16,11 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/conn.h>
 
-#include "testlib/att_read.h"
+#include <testlib/att_read.h>
 
-#include "bsim_args_runner.h"
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <bsim_args_runner.h>
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);

--- a/tests/bsim/bluetooth/host/att/pipeline/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/att/pipeline/tester/src/main.c
@@ -16,14 +16,14 @@
 #include <zephyr/bluetooth/hci_raw.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "common/hci_common_internal.h"
-#include "common/bt_str.h"
+#include <common/hci_common_internal.h>
+#include <common/bt_str.h>
 
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_tinyhost, LOG_LEVEL_INF);

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/client/main.c
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/client/main.c
@@ -15,7 +15,7 @@
 #include <testlib/scan.h>
 #include <testlib/security.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 #include "../common_defs.h"
 
 LOG_MODULE_REGISTER(client, LOG_LEVEL_DBG);

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/server/main.c
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/server/main.c
@@ -10,7 +10,7 @@
 
 #include <testlib/adv.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 #include "../common_defs.h"
 
 LOG_MODULE_REGISTER(server, LOG_LEVEL_DBG);

--- a/tests/bsim/bluetooth/host/att/retry_on_sec_err/client/main.c
+++ b/tests/bsim/bluetooth/host/att/retry_on_sec_err/client/main.c
@@ -13,11 +13,11 @@
 #include "../common_defs.h"
 
 #include <testlib/conn.h>
-#include "testlib/scan.h"
-#include "testlib/security.h"
+#include <testlib/scan.h>
+#include <testlib/security.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 LOG_MODULE_REGISTER(client, LOG_LEVEL_DBG);
 

--- a/tests/bsim/bluetooth/host/att/retry_on_sec_err/server/main.c
+++ b/tests/bsim/bluetooth/host/att/retry_on_sec_err/server/main.c
@@ -9,10 +9,10 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "testlib/adv.h"
-#include "testlib/security.h"
+#include <testlib/adv.h>
+#include <testlib/security.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 #include "../common_defs.h"
 

--- a/tests/bsim/bluetooth/host/att/sequential/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/att/sequential/dut/src/main.c
@@ -16,10 +16,10 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/conn.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
-#include "common_defs.h"
+#include <common_defs.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(dut, LOG_LEVEL_INF);

--- a/tests/bsim/bluetooth/host/att/sequential/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/att/sequential/tester/src/main.c
@@ -16,16 +16,16 @@
 #include <zephyr/bluetooth/hci_raw.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "common/hci_common_internal.h"
-#include "common/bt_str.h"
+#include <common/hci_common_internal.h>
+#include <common/bt_str.h>
 
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
-#include "common_defs.h"
+#include <common_defs.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_tinyhost, LOG_LEVEL_INF);

--- a/tests/bsim/bluetooth/host/att/timeout/main.c
+++ b/tests/bsim/bluetooth/host/att/timeout/main.c
@@ -10,17 +10,17 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/bluetooth.h>
 
-#include "host/att_internal.h"
+#include <host/att_internal.h>
 
-#include "testlib/adv.h"
-#include "testlib/att_read.h"
-#include "testlib/att_write.h"
-#include "bs_macro.h"
-#include "bs_sync.h"
+#include <testlib/adv.h>
+#include <testlib/att_read.h>
+#include <testlib/att_write.h>
+#include <bs_macro.h>
+#include <bs_sync.h>
 #include <testlib/conn.h>
-#include "testlib/log_utils.h"
-#include "testlib/scan.h"
-#include "testlib/security.h"
+#include <testlib/log_utils.h>
+#include <testlib/scan.h>
+#include <testlib/security.h>
 
 /* This test uses system asserts to fail tests. */
 BUILD_ASSERT(__ASSERT_ON);

--- a/tests/bsim/bluetooth/host/central/src/dummy_peripheral.c
+++ b/tests/bsim/bluetooth/host/central/src/dummy_peripheral.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
-#include "babblekit/testcase.h"
+#include <bstests.h>
+#include <babblekit/testcase.h>
 #include <zephyr/bluetooth/conn.h>
 
 static K_SEM_DEFINE(sem_connected, 0, 1);

--- a/tests/bsim/bluetooth/host/central/src/main.c
+++ b/tests/bsim/bluetooth/host/central/src/main.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
-#include "babblekit/testcase.h"
+#include <bstests.h>
+#include <babblekit/testcase.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
 
 /* Include hci_common_internal for the purpose of checking HCI Command counts. */
-#include "common/hci_common_internal.h"
+#include <common/hci_common_internal.h>
 
 /* Include conn_internal for the purpose of checking reference counts. */
-#include "host/conn_internal.h"
+#include <host/conn_internal.h>
 
 struct bst_test_list *test_peripheral_install(struct bst_test_list *tests);
 

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_client_test.c
@@ -15,8 +15,8 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 DEFINE_FLAG_STATIC(flag_is_connected);

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/gatt_server_test.c
@@ -15,8 +15,8 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/gatt/authorization/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/authorization/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_gatt_server_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_gatt_client_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/host/gatt/caching/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/caching/src/gatt_client_test.c
@@ -15,9 +15,9 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
 #include "common.h"
 
 DEFINE_FLAG_STATIC(flag_is_connected);

--- a/tests/bsim/bluetooth/host/gatt/caching/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/caching/src/gatt_server_test.c
@@ -15,9 +15,9 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/gatt/caching/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/caching/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_gatt_server_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_gatt_client_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/src/central.c
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/src/central.c
@@ -19,13 +19,13 @@
 #include <zephyr/settings/settings.h>
 
 #include "common.h"
-#include "settings.h"
+#include <settings.h>
 
-#include "argparse.h"
+#include <argparse.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
 
 #define SERVER_CHAN 0
 

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/src/main.c
@@ -4,7 +4,7 @@
 
 #include <zephyr/kernel.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include <stdlib.h>
 
 #include <zephyr/logging/log.h>

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/src/peripheral.c
@@ -17,12 +17,12 @@
 #include <zephyr/settings/settings.h>
 
 #include "common.h"
-#include "settings.h"
+#include <settings.h>
 
-#include "argparse.h"
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
+#include <argparse.h>
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
 
 #define CLIENT_CHAN 0
 

--- a/tests/bsim/bluetooth/host/gatt/device_name/src/client.c
+++ b/tests/bsim/bluetooth/host/gatt/device_name/src/client.c
@@ -15,15 +15,15 @@
 
 #include <zephyr/logging/log.h>
 
-#include "testlib/adv.h"
-#include "testlib/att.h"
-#include "testlib/att_read.h"
-#include "testlib/att_write.h"
-#include "testlib/conn.h"
+#include <testlib/adv.h>
+#include <testlib/att.h>
+#include <testlib/att_read.h>
+#include <testlib/att_write.h>
+#include <testlib/conn.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
+#include <babblekit/testcase.h>
 
 #include "common.h"
 

--- a/tests/bsim/bluetooth/host/gatt/device_name/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/device_name/src/main.c
@@ -6,10 +6,10 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
-#include "testlib/log_utils.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
+#include <testlib/log_utils.h>
 
 extern void server_procedure(void);
 extern void client_procedure(void);

--- a/tests/bsim/bluetooth/host/gatt/device_name/src/server.c
+++ b/tests/bsim/bluetooth/host/gatt/device_name/src/server.c
@@ -20,12 +20,12 @@
 
 #include <zephyr/sys/util.h>
 
-#include "testlib/conn.h"
-#include "testlib/scan.h"
+#include <testlib/conn.h>
+#include <testlib/scan.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
+#include <babblekit/testcase.h>
 
 #include "common.h"
 

--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_client_test.c
@@ -17,8 +17,8 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 DEFINE_FLAG_STATIC(flag_is_connected);

--- a/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/gatt_server_test.c
@@ -16,8 +16,8 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/gatt/general/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/general/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_gatt_server_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_gatt_client_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/host/gatt/notify/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/gatt_client_test.c
@@ -15,8 +15,8 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 DEFINE_FLAG_STATIC(flag_is_connected);

--- a/tests/bsim/bluetooth/host/gatt/notify/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/gatt_server_test.c
@@ -14,8 +14,8 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/gatt/notify/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/notify/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_gatt_server_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_gatt_client_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_client_test.c
@@ -15,8 +15,8 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #include "common.h"
 

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/src/gatt_server_test.c
@@ -15,8 +15,8 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #include "common.h"
 

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_gatt_server_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_gatt_client_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/host/gatt/notify_stress/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_stress/src/gatt_client_test.c
@@ -15,8 +15,8 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 DEFINE_FLAG_STATIC(flag_is_connected);

--- a/tests/bsim/bluetooth/host/gatt/notify_stress/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_stress/src/gatt_server_test.c
@@ -15,8 +15,8 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/gatt/notify_stress/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/notify_stress/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_gatt_server_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_gatt_client_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/src/bs_bt_utils.h
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/src/bs_bt_utils.h
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
-#include "bs_tracing.h"
+#include <bstests.h>
+#include <bs_tracing.h>
 
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/uuid.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 DECLARE_FLAG(flag_pairing_complete);
 DECLARE_FLAG(flag_bonded);

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/src/central.c
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/src/central.c
@@ -16,8 +16,8 @@
 #include <zephyr/settings/settings.h>
 #include <zephyr/bluetooth/bluetooth.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(test_central, LOG_LEVEL_DBG);

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 #include "bs_bt_utils.h"
 
 extern void central(void);

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/src/peripheral.c
@@ -15,7 +15,7 @@
 #include <zephyr/settings/settings.h>
 #include <zephyr/bluetooth/bluetooth.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(test_peripheral, LOG_LEVEL_DBG);

--- a/tests/bsim/bluetooth/host/gatt/settings/src/client.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/client.c
@@ -16,7 +16,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 void client_round_0(void)
 {

--- a/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
@@ -5,15 +5,15 @@
  */
 
 #include "utils.h"
-#include "argparse.h"
+#include <argparse.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/sys/__assert.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 /* Custom Service Variables */
 static const struct bt_uuid_128 test_svc_uuid = BT_UUID_INIT_128(

--- a/tests/bsim/bluetooth/host/gatt/settings/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/main.c
@@ -7,13 +7,13 @@
 #include <stdlib.h>
 #include "utils.h"
 #include "main.h"
-#include "argparse.h"
-#include "bs_pc_backchannel.h"
-#include "bstests.h"
+#include <argparse.h>
+#include <bs_pc_backchannel.h>
+#include <bstests.h>
 
 #include <zephyr/sys/__assert.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 void server_procedure(void);
 void client_procedure(void);

--- a/tests/bsim/bluetooth/host/gatt/settings/src/server.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/server.c
@@ -17,7 +17,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 void set_public_addr(void)
 {

--- a/tests/bsim/bluetooth/host/gatt/settings/src/settings.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/settings.c
@@ -12,10 +12,10 @@
 #include <zephyr/kernel.h>
 #include <zephyr/settings/settings.h>
 #include <zephyr/types.h>
-#include "errno.h"
-#include "argparse.h"
-#include "posix_native_task.h"
-#include "nsi_host_trampolines.h"
+#include <errno.h>
+#include <argparse.h>
+#include <posix_native_task.h>
+#include <nsi_host_trampolines.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(settings_backend, 3);

--- a/tests/bsim/bluetooth/host/gatt/settings/src/utils.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/utils.c
@@ -8,8 +8,8 @@
 #include "gatt_utils.h"
 #include <zephyr/sys/__assert.h>
 #include <zephyr/bluetooth/hci.h>
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 static struct bt_conn *default_conn;
 

--- a/tests/bsim/bluetooth/host/gatt/settings_clear/src/bt_settings_hook.c
+++ b/tests/bsim/bluetooth/host/gatt/settings_clear/src/bt_settings_hook.c
@@ -11,7 +11,7 @@
 
 #include <zephyr/logging/log.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 LOG_MODULE_REGISTER(bt_settings_hook, LOG_LEVEL_DBG);
 

--- a/tests/bsim/bluetooth/host/gatt/settings_clear/src/client.c
+++ b/tests/bsim/bluetooth/host/gatt/settings_clear/src/client.c
@@ -15,13 +15,13 @@
 
 #include <zephyr/logging/log.h>
 
-#include "testlib/adv.h"
-#include "testlib/att_read.h"
-#include "testlib/conn.h"
+#include <testlib/adv.h>
+#include <testlib/att_read.h>
+#include <testlib/conn.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
+#include <babblekit/testcase.h>
 
 #include "common.h"
 

--- a/tests/bsim/bluetooth/host/gatt/settings_clear/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/settings_clear/src/main.c
@@ -6,10 +6,10 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
-#include "testlib/log_utils.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
+#include <testlib/log_utils.h>
 
 extern void server_procedure(void);
 extern void client_procedure(void);

--- a/tests/bsim/bluetooth/host/gatt/settings_clear/src/server.c
+++ b/tests/bsim/bluetooth/host/gatt/settings_clear/src/server.c
@@ -15,12 +15,12 @@
 
 #include <zephyr/logging/log.h>
 
-#include "testlib/conn.h"
-#include "testlib/scan.h"
+#include <testlib/conn.h>
+#include <testlib/scan.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
+#include <babblekit/testcase.h>
 
 #include "common.h"
 #include "bt_settings_hook.h"

--- a/tests/bsim/bluetooth/host/id/settings/src/dut.c
+++ b/tests/bsim/bluetooth/host/id/settings/src/dut.c
@@ -11,7 +11,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/addr.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 LOG_MODULE_DECLARE(bt_bsim_id_settings, LOG_LEVEL_DBG);
 

--- a/tests/bsim/bluetooth/host/id/settings/src/main.c
+++ b/tests/bsim/bluetooth/host/id/settings/src/main.c
@@ -4,7 +4,7 @@
 
 #include <zephyr/kernel.h>
 
-#include "bstests.h"
+#include <bstests.h>
 #include <string.h>
 
 #include <zephyr/logging/log.h>

--- a/tests/bsim/bluetooth/host/iso/bis/src/bis_broadcaster.c
+++ b/tests/bsim/bluetooth/host/iso/bis/src/bis_broadcaster.c
@@ -21,12 +21,12 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
-#include "babblekit/testcase.h"
-#include "bstests.h"
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
+#include <babblekit/testcase.h>
+#include <bstests.h>
 #include "common.h"
-#include "iso_tx.h"
+#include <iso_tx.h>
 
 LOG_MODULE_REGISTER(bis_broadcaster, LOG_LEVEL_INF);
 

--- a/tests/bsim/bluetooth/host/iso/bis/src/bis_receiver.c
+++ b/tests/bsim/bluetooth/host/iso/bis/src/bis_receiver.c
@@ -15,12 +15,12 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
+#include <babblekit/testcase.h>
 
 #include "common.h"
-#include "iso_tx.h"
+#include <iso_tx.h>
 
 LOG_MODULE_REGISTER(bis_receiver, LOG_LEVEL_INF);
 

--- a/tests/bsim/bluetooth/host/iso/bis/src/common.h
+++ b/tests/bsim/bluetooth/host/iso/bis/src/common.h
@@ -10,7 +10,7 @@
 
 #include <zephyr/sys/clock.h>
 
-#include "bs_types.h"
+#include <bs_types.h>
 
 #define WAIT_TIME (30e6) /* 30 seconds*/
 

--- a/tests/bsim/bluetooth/host/iso/bis/src/main.c
+++ b/tests/bsim/bluetooth/host/iso/bis/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_main_bis_broadcaster_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_main_bis_receiver_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/host/iso/cis/src/cis_central.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/cis_central.c
@@ -21,11 +21,11 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <bstests.h>
 #include "common.h"
-#include "iso_tx.h"
+#include <iso_tx.h>
 
 #define EXPECTED_TX_CNT 100U
 

--- a/tests/bsim/bluetooth/host/iso/cis/src/cis_peripheral.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/cis_peripheral.c
@@ -21,9 +21,9 @@
 
 #include <testlib/conn.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <bstests.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/iso/cis/src/common.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/common.c
@@ -10,8 +10,8 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/iso/cis/src/main.c
+++ b/tests/bsim/bluetooth/host/iso/cis/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_main_cis_peripheral_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_main_cis_central_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/host/iso/common/iso_tx.c
+++ b/tests/bsim/bluetooth/host/iso/common/iso_tx.c
@@ -24,7 +24,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 #include "iso_tx.h"
 

--- a/tests/bsim/bluetooth/host/iso/frag/src/broadcaster.c
+++ b/tests/bsim/bluetooth/host/iso/frag/src/broadcaster.c
@@ -10,8 +10,8 @@
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/logging/log.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
 
 LOG_MODULE_REGISTER(broadcaster, LOG_LEVEL_INF);
 

--- a/tests/bsim/bluetooth/host/iso/frag/src/main.c
+++ b/tests/bsim/bluetooth/host/iso/frag/src/main.c
@@ -6,9 +6,9 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
 
 extern void entrypoint_broadcaster(void);
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/iso/frag_2/src/broadcaster.c
+++ b/tests/bsim/bluetooth/host/iso/frag_2/src/broadcaster.c
@@ -10,8 +10,8 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
 
 LOG_MODULE_REGISTER(broadcaster, LOG_LEVEL_INF);
 

--- a/tests/bsim/bluetooth/host/iso/frag_2/src/main.c
+++ b/tests/bsim/bluetooth/host/iso/frag_2/src/main.c
@@ -6,9 +6,9 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
 
 extern void entrypoint_broadcaster(void);
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits/src/main.c
@@ -16,8 +16,8 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/l2cap.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #define LOG_MODULE_NAME main
 #include <zephyr/logging/log.h>

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/src/main.c
@@ -14,8 +14,8 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/l2cap.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #define LOG_MODULE_NAME main
 #include <zephyr/logging/log.h>

--- a/tests/bsim/bluetooth/host/l2cap/ecred/dut/src/dut.c
+++ b/tests/bsim/bluetooth/host/l2cap/ecred/dut/src/dut.c
@@ -10,11 +10,11 @@
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/logging/log.h>
 
-#include "testlib/conn.h"
-#include "testlib/scan.h"
+#include <testlib/conn.h>
+#include <testlib/scan.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
 
 LOG_MODULE_REGISTER(dut, CONFIG_APP_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/host/l2cap/ecred/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/ecred/dut/src/main.c
@@ -6,9 +6,9 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
 
 extern void entrypoint_dut(void);
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/l2cap/ecred/peer/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/ecred/peer/src/main.c
@@ -6,9 +6,9 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
 
 extern void entrypoint_peer(void);
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/l2cap/ecred/peer/src/peer.c
+++ b/tests/bsim/bluetooth/host/l2cap/ecred/peer/src/peer.c
@@ -11,13 +11,13 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/logging/log.h>
 
-#include "testlib/adv.h"
-#include "testlib/att_read.h"
-#include "testlib/att_write.h"
-#include "testlib/conn.h"
+#include <testlib/adv.h>
+#include <testlib/att_read.h>
+#include <testlib/att_write.h>
+#include <testlib/conn.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
 
 void entrypoint_peer(void)
 {

--- a/tests/bsim/bluetooth/host/l2cap/einprogress/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/einprogress/src/main.c
@@ -4,8 +4,8 @@
 
 #include <zephyr/kernel.h>
 
-#include "bstests.h"
-#include "babblekit/testcase.h"
+#include <bstests.h>
+#include <babblekit/testcase.h>
 
 extern void entrypoint_dut(void);
 extern void entrypoint_tester(void);

--- a/tests/bsim/bluetooth/host/l2cap/general/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/general/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_main_l2cap_ecred_install(struct bst_test_list *tests);
 

--- a/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
+++ b/tests/bsim/bluetooth/host/l2cap/general/src/main_l2cap_ecred.c
@@ -16,9 +16,9 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/l2cap.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
 
 #define LOG_MODULE_NAME main_l2cap_ecred
 #include <zephyr/logging/log.h>

--- a/tests/bsim/bluetooth/host/l2cap/many_conns/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/many_conns/src/main.c
@@ -16,8 +16,8 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/l2cap.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #define LOG_MODULE_NAME main
 #include <zephyr/logging/log.h>

--- a/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/src/central.c
+++ b/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/src/central.c
@@ -11,12 +11,12 @@
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/logging/log.h>
 
-#include "testlib/scan.h"
-#include "testlib/conn.h"
+#include <testlib/scan.h>
+#include <testlib/conn.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
+#include <babblekit/testcase.h>
 
 /* local includes */
 #include "data.h"

--- a/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/src/dut.c
+++ b/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/src/dut.c
@@ -10,8 +10,8 @@
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/logging/log.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
 
 /* local includes */
 #include "data.h"

--- a/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/src/main.c
@@ -6,9 +6,9 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
 
 extern void entrypoint_dut(void);
 extern void entrypoint_central(void);

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/dut/src/dut.c
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/dut/src/dut.c
@@ -10,17 +10,17 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/logging/log.h>
 
-#include "testlib/att_read.h"
-#include "testlib/att_write.h"
-#include "testlib/conn.h"
-#include "testlib/scan.h"
-#include "testlib/log_utils.h"
+#include <testlib/att_read.h>
+#include <testlib/att_write.h>
+#include <testlib/conn.h>
+#include <testlib/scan.h>
+#include <testlib/log_utils.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
 
 /* local includes */
-#include "data.h"
+#include <data.h>
 
 LOG_MODULE_REGISTER(dut, LOG_LEVEL_DBG);
 

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/dut/src/main.c
@@ -6,10 +6,10 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
-#include "testlib/log_utils.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
+#include <testlib/log_utils.h>
 
 extern void entrypoint_dut(void);
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/peer/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/peer/src/main.c
@@ -6,9 +6,9 @@
 
 #include <zephyr/kernel.h>
 
-#include "babblekit/testcase.h"
-#include "bs_tracing.h"
-#include "bstests.h"
+#include <babblekit/testcase.h>
+#include <bs_tracing.h>
+#include <bstests.h>
 
 extern void entrypoint_peer(void);
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/peer/src/peer.c
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/peer/src/peer.c
@@ -16,16 +16,16 @@
 #include <zephyr/bluetooth/hci_raw.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "common/hci_common_internal.h"
-#include "common/bt_str.h"
+#include <common/hci_common_internal.h>
+#include <common/bt_str.h>
 
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
 
-#include "data.h"
+#include <data.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_tinyhost, LOG_LEVEL_INF);

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_main_l2cap_send_on_connect_install(struct bst_test_list *tests);
 

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
@@ -8,10 +8,10 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/l2cap.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "bsim_args_runner.h"
-#include "argparse.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <bsim_args_runner.h>
+#include <argparse.h>
 
 extern enum bst_result_t bst_result;
 

--- a/tests/bsim/bluetooth/host/l2cap/split/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/split/dut/src/main.c
@@ -9,11 +9,11 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/l2cap.h>
 
-#include "host/hci_core.h"
-#include "common.h"
+#include <host/hci_core.h>
+#include <common.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #define LOG_MODULE_NAME main
 #include <zephyr/logging/log.h>

--- a/tests/bsim/bluetooth/host/l2cap/split/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/split/tester/src/main.c
@@ -16,16 +16,16 @@
 #include <zephyr/bluetooth/hci_raw.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "common/hci_common_internal.h"
-#include "common/bt_str.h"
+#include <common/hci_common_internal.h>
+#include <common/bt_str.h>
 
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
 
-#include "common.h"
+#include <common.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_tinyhost, 3);

--- a/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/stress/src/main.c
@@ -15,9 +15,9 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/l2cap.h>
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "bsim_args_runner.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <bsim_args_runner.h>
 
 #define LOG_MODULE_NAME main
 #include <zephyr/logging/log.h>

--- a/tests/bsim/bluetooth/host/l2cap/userdata/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_main_l2cap_ecred_install(struct bst_test_list *tests);
 

--- a/tests/bsim/bluetooth/host/l2cap/userdata/src/main_l2cap_userdata.c
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/src/main_l2cap_userdata.c
@@ -7,8 +7,8 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/l2cap.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 extern enum bst_result_t bst_result;
 

--- a/tests/bsim/bluetooth/host/misc/acl_tx_frag/src/dut.c
+++ b/tests/bsim/bluetooth/host/misc/acl_tx_frag/src/dut.c
@@ -12,15 +12,15 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/logging/log.h>
 
-#include "testlib/conn.h"
-#include "testlib/scan.h"
-#include "testlib/log_utils.h"
+#include <testlib/conn.h>
+#include <testlib/scan.h>
+#include <testlib/log_utils.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
 
 /* For the radio shenanigans */
-#include "hw_testcheat_if.h"
+#include <hw_testcheat_if.h>
 
 /* local includes */
 #include "data.h"

--- a/tests/bsim/bluetooth/host/misc/acl_tx_frag/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/acl_tx_frag/src/main.c
@@ -6,10 +6,10 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
-#include "testlib/log_utils.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
+#include <testlib/log_utils.h>
 
 extern void entrypoint_dut(void);
 extern void entrypoint_peer(void);

--- a/tests/bsim/bluetooth/host/misc/acl_tx_frag/src/peer.c
+++ b/tests/bsim/bluetooth/host/misc/acl_tx_frag/src/peer.c
@@ -11,14 +11,14 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/logging/log.h>
 
-#include "testlib/adv.h"
-#include "testlib/att_read.h"
-#include "testlib/att_write.h"
-#include "testlib/conn.h"
-#include "testlib/log_utils.h"
+#include <testlib/adv.h>
+#include <testlib/att_read.h>
+#include <testlib/att_write.h>
+#include <testlib/conn.h>
+#include <testlib/log_utils.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
 
 /* local includes */
 #include "data.h"

--- a/tests/bsim/bluetooth/host/misc/conn_stress/central/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/central/src/main.c
@@ -24,12 +24,12 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(central, LOG_LEVEL_INF);
 
-#include "bstests.h"
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "bs_pc_backchannel.h"
+#include <bstests.h>
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <bs_pc_backchannel.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 #define DEFAULT_CONN_INTERVAL	   20
 #define PERIPHERAL_DEVICE_NAME	   "Zephyr Peripheral"

--- a/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
@@ -26,13 +26,13 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(peripheral, LOG_LEVEL_INF);
 
-#include "bstests.h"
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "bs_pc_backchannel.h"
-#include "argparse.h"
+#include <bstests.h>
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <bs_pc_backchannel.h>
+#include <argparse.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 #define MIN_NOTIFICATIONS 50
 

--- a/tests/bsim/bluetooth/host/misc/disable/src/gatt_client_test.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/gatt_client_test.c
@@ -14,8 +14,8 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 DEFINE_FLAG_STATIC(flag_is_connected);

--- a/tests/bsim/bluetooth/host/misc/disable/src/gatt_server_test.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/gatt_server_test.c
@@ -14,8 +14,8 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/misc/disable/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_main_disable_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_gatt_server_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/host/misc/disable/src/main_disable.c
+++ b/tests/bsim/bluetooth/host/misc/disable/src/main_disable.c
@@ -12,8 +12,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL_DBG);
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/misc/disconnect/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/disconnect/dut/src/main.c
@@ -16,11 +16,11 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/conn.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
 
-#include "common.h"
+#include <common.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(dut, LOG_LEVEL_INF);

--- a/tests/bsim/bluetooth/host/misc/disconnect/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/disconnect/tester/src/main.c
@@ -17,18 +17,18 @@
 #include <zephyr/bluetooth/hci_raw.h>
 #include <zephyr/bluetooth/hci_types.h>
 
-#include "common/hci_common_internal.h"
-#include "common/bt_str.h"
+#include <common/hci_common_internal.h>
+#include <common/bt_str.h>
 
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
-#include "NRF_HWLowL.h"		/* for hwll_disconnect_phy(); */
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
+#include <NRF_HWLowL.h>		/* for hwll_disconnect_phy(); */
 
-#include "common.h"
+#include <common.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_tinyhost, LOG_LEVEL_INF);

--- a/tests/bsim/bluetooth/host/misc/hfc/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/hfc/src/main.c
@@ -16,11 +16,11 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/conn.h>
 
-#include "testlib/att_read.h"
+#include <testlib/att_read.h>
 
 #include <argparse.h>		/* For get_device_nbr() */
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/dut/src/dut.c
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/dut/src/dut.c
@@ -10,14 +10,14 @@
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/logging/log.h>
 
-#include "testlib/conn.h"
-#include "testlib/scan.h"
+#include <testlib/conn.h>
+#include <testlib/scan.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
 
 /* local includes */
-#include "data.h"
+#include <data.h>
 
 LOG_MODULE_REGISTER(dut, CONFIG_APP_LOG_LEVEL);
 

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/dut/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/dut/src/main.c
@@ -6,9 +6,9 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
 
 extern void entrypoint_dut(void);
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/src/main.c
@@ -6,9 +6,9 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
 
 extern void entrypoint_tester(void);
 extern enum bst_result_t bst_result;

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/src/tester.c
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/src/tester.c
@@ -17,18 +17,18 @@
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/gap.h>
 
-#include "common/hci_common_internal.h"
-#include "common/bt_str.h"
+#include <common/hci_common_internal.h>
+#include <common/bt_str.h>
 
-#include "host/conn_internal.h"
-#include "host/l2cap_internal.h"
+#include <host/conn_internal.h>
+#include <host/l2cap_internal.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/device.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/device.h>
+#include <babblekit/testcase.h>
 
 /* local includes */
-#include "data.h"
+#include <data.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(tester, CONFIG_APP_LOG_LEVEL);

--- a/tests/bsim/bluetooth/host/misc/sample_test/src/dut.c
+++ b/tests/bsim/bluetooth/host/misc/sample_test/src/dut.c
@@ -10,13 +10,13 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/logging/log.h>
 
-#include "testlib/conn.h"
-#include "testlib/scan.h"
-#include "testlib/log_utils.h"
+#include <testlib/conn.h>
+#include <testlib/scan.h>
+#include <testlib/log_utils.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
+#include <babblekit/testcase.h>
 
 /* local includes */
 #include "data.h"

--- a/tests/bsim/bluetooth/host/misc/sample_test/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/sample_test/src/main.c
@@ -6,10 +6,10 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
-#include "testlib/log_utils.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
+#include <testlib/log_utils.h>
 
 extern void entrypoint_dut(void);
 extern void entrypoint_peer(void);

--- a/tests/bsim/bluetooth/host/misc/sample_test/src/peer.c
+++ b/tests/bsim/bluetooth/host/misc/sample_test/src/peer.c
@@ -11,15 +11,15 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/logging/log.h>
 
-#include "testlib/adv.h"
-#include "testlib/att_read.h"
-#include "testlib/att_write.h"
-#include "testlib/conn.h"
-#include "testlib/log_utils.h"
+#include <testlib/adv.h>
+#include <testlib/att_read.h>
+#include <testlib/att_write.h>
+#include <testlib/conn.h>
+#include <testlib/log_utils.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
+#include <babblekit/testcase.h>
 
 /* local includes */
 #include "data.h"

--- a/tests/bsim/bluetooth/host/misc/unregister_conn_cb/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/unregister_conn_cb/src/main.c
@@ -16,8 +16,8 @@
 #include <zephyr/bluetooth/conn.h>
 
 #include <testlib/conn.h>
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 DEFINE_FLAG_STATIC(flag_is_connected);
 

--- a/tests/bsim/bluetooth/host/privacy/central/src/main.c
+++ b/tests/bsim/bluetooth/host/privacy/central/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 void tester_procedure(void);
 void tester_procedure_periph_delayed_start_of_conn_adv(void);

--- a/tests/bsim/bluetooth/host/privacy/central/src/tester.c
+++ b/tests/bsim/bluetooth/host/privacy/central/src/tester.c
@@ -12,9 +12,9 @@
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/toolchain.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
 
 DEFINE_FLAG_STATIC(flag_new_address);
 DEFINE_FLAG_STATIC(flag_connected);

--- a/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_central.c
+++ b/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_central.c
@@ -18,9 +18,9 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(bt_bsim_privacy, LOG_LEVEL_INF);
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "bs_cmd_line.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <bs_cmd_line.h>
 
 DEFINE_FLAG_STATIC(paired);
 DEFINE_FLAG_STATIC(rpa_tested);

--- a/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_main.c
+++ b/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_main.c
@@ -12,7 +12,7 @@
 
 #include <zephyr/sys/printk.h>
 
-#include "bstests.h"
+#include <bstests.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_bsim_privacy, LOG_LEVEL_INF);

--- a/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_peripheral.c
+++ b/tests/bsim/bluetooth/host/privacy/device/src/test_undirected_peripheral.c
@@ -20,9 +20,9 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(bt_bsim_privacy, LOG_LEVEL_INF);
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
-#include "bs_cmd_line.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
+#include <bs_cmd_line.h>
 
 DEFINE_FLAG_STATIC(paired_flag);
 DEFINE_FLAG_STATIC(connected_flag);

--- a/tests/bsim/bluetooth/host/privacy/legacy/src/dut.c
+++ b/tests/bsim/bluetooth/host/privacy/legacy/src/dut.c
@@ -19,8 +19,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/sync.h"
+#include <babblekit/testcase.h>
+#include <babblekit/sync.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(dut, 4);

--- a/tests/bsim/bluetooth/host/privacy/legacy/src/main.c
+++ b/tests/bsim/bluetooth/host/privacy/legacy/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 void tester_procedure(void);
 void dut_procedure(void);

--- a/tests/bsim/bluetooth/host/privacy/legacy/src/tester.c
+++ b/tests/bsim/bluetooth/host/privacy/legacy/src/tester.c
@@ -17,11 +17,11 @@
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/sync.h"
-#include "testlib/addr.h"
+#include <babblekit/testcase.h>
+#include <babblekit/sync.h>
+#include <testlib/addr.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define EXPECTED_NUM_ROTATIONS 5
 

--- a/tests/bsim/bluetooth/host/privacy/peripheral/src/dut_rpa_expired.c
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/src/dut_rpa_expired.c
@@ -20,9 +20,9 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/settings/settings.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define ID_1 1
 #define ID_2 2

--- a/tests/bsim/bluetooth/host/privacy/peripheral/src/dut_rpa_rotation.c
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/src/dut_rpa_rotation.c
@@ -21,9 +21,9 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/settings/settings.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
 #define ID_A_INDEX 1
 #define ID_B_INDEX 2

--- a/tests/bsim/bluetooth/host/privacy/peripheral/src/main.c
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_main_rpa_rotation_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_main_rpa_expired_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/host/privacy/peripheral/src/main_rpa_expired.c
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/src/main_rpa_expired.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 void tester_verify_rpa_procedure(void);
 void dut_rpa_expired_procedure(void);

--- a/tests/bsim/bluetooth/host/privacy/peripheral/src/main_rpa_rotation.c
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/src/main_rpa_rotation.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 void tester_procedure(void);
 void dut_procedure(void);

--- a/tests/bsim/bluetooth/host/privacy/peripheral/src/tester_rpa_expired.c
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/src/tester_rpa_expired.c
@@ -18,8 +18,8 @@
 #include <zephyr/types.h>
 #include <zephyr/settings/settings.h>
 
-#include "babblekit/testcase.h"
-#include "testlib/addr.h"
+#include <babblekit/testcase.h>
+#include <testlib/addr.h>
 
 #define EXPECTED_NUM_ROTATIONS 5
 

--- a/tests/bsim/bluetooth/host/privacy/peripheral/src/tester_rpa_rotation.c
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/src/tester_rpa_rotation.c
@@ -18,8 +18,8 @@
 #include <zephyr/types.h>
 #include <zephyr/settings/settings.h>
 
-#include "babblekit/testcase.h"
-#include "testlib/addr.h"
+#include <babblekit/testcase.h>
+#include <testlib/addr.h>
 
 #define EXPECTED_NUM_ROTATIONS 5
 

--- a/tests/bsim/bluetooth/host/scan/slow/src/dut.c
+++ b/tests/bsim/bluetooth/host/scan/slow/src/dut.c
@@ -10,9 +10,9 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/atomic_builtin.h>
 
-#include "testlib/log_utils.h"
-#include "babblekit/flags.h"
-#include "babblekit/testcase.h"
+#include <testlib/log_utils.h>
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
 
 LOG_MODULE_REGISTER(dut, LOG_LEVEL_DBG);
 

--- a/tests/bsim/bluetooth/host/scan/slow/src/main.c
+++ b/tests/bsim/bluetooth/host/scan/slow/src/main.c
@@ -8,11 +8,11 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_cmd_line.h"
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "babblekit/testcase.h"
-#include "testlib/log_utils.h"
+#include <bs_cmd_line.h>
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <babblekit/testcase.h>
+#include <testlib/log_utils.h>
 
 extern void entrypoint_dut(void);
 extern void entrypoint_peer(void);

--- a/tests/bsim/bluetooth/host/scan/slow/src/peer.c
+++ b/tests/bsim/bluetooth/host/scan/slow/src/peer.c
@@ -11,9 +11,9 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/atomic_builtin.h>
 
-#include "testlib/log_utils.h"
-#include "babblekit/flags.h"
-#include "babblekit/testcase.h"
+#include <testlib/log_utils.h>
+#include <babblekit/flags.h>
+#include <babblekit/testcase.h>
 
 LOG_MODULE_REGISTER(peer, LOG_LEVEL_DBG);
 

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/bs_bt_utils.h
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/bs_bt_utils.h
@@ -6,10 +6,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bs_tracing.h"
-#include "bs_types.h"
-#include "bstests.h"
-#include "time_machine.h"
+#include <bs_tracing.h>
+#include <bs_types.h>
+#include <bstests.h>
+#include <time_machine.h>
 #include <zephyr/sys/__assert.h>
 
 #include <errno.h>
@@ -24,8 +24,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 DECLARE_FLAG(flag_pairing_complete);
 DECLARE_FLAG(flag_pairing_failed);

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/central.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/central.c
@@ -12,8 +12,8 @@
 
 #include <zephyr/bluetooth/bluetooth.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 void central(void)
 {

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/main.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include "bs_bt_utils.h"
-#include "bstests.h"
+#include <bstests.h>
 
 void central(void);
 void peripheral(void);

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/src/peripheral.c
@@ -13,8 +13,8 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 void peripheral(void)
 {

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/bs_bt_utils.h
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/bs_bt_utils.h
@@ -6,10 +6,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bs_tracing.h"
-#include "bs_types.h"
-#include "bstests.h"
-#include "time_machine.h"
+#include <bs_tracing.h>
+#include <bs_types.h>
+#include <bstests.h>
+#include <time_machine.h>
 #include <zephyr/sys/__assert.h>
 
 #include <errno.h>
@@ -24,8 +24,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 DECLARE_FLAG(flag_pairing_complete);
 DECLARE_FLAG(flag_pairing_failed);

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/central.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/central.c
@@ -12,8 +12,8 @@
 
 #include <zephyr/bluetooth/bluetooth.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 void central(void)
 {

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/main.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include "bs_bt_utils.h"
-#include "bstests.h"
+#include <bstests.h>
 
 void central(void);
 void peripheral(void);

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/src/peripheral.c
@@ -13,8 +13,8 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 void peripheral(void)
 {

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/src/bs_bt_utils.h
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/src/bs_bt_utils.h
@@ -6,10 +6,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bs_tracing.h"
-#include "bs_types.h"
-#include "bstests.h"
-#include "time_machine.h"
+#include <bs_tracing.h>
+#include <bs_types.h>
+#include <bstests.h>
+#include <time_machine.h>
 #include <zephyr/sys/__assert.h>
 
 #include <errno.h>
@@ -24,8 +24,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 DECLARE_FLAG(flag_pairing_complete);
 DECLARE_FLAG(flag_bonded);

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/src/central.c
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/src/central.c
@@ -12,8 +12,8 @@
 
 #include <zephyr/bluetooth/bluetooth.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 void central(void)
 {

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/src/main.c
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include "bs_bt_utils.h"
-#include "bstests.h"
+#include <bstests.h>
 
 void central(void);
 void peripheral(void);

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/src/peripheral.c
@@ -13,8 +13,8 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 void peripheral(void)
 {

--- a/tests/bsim/bluetooth/host/security/ccc_update/src/central.c
+++ b/tests/bsim/bluetooth/host/security/ccc_update/src/central.c
@@ -18,13 +18,13 @@
 
 #include <zephyr/settings/settings.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
-#include "settings.h"
+#include <settings.h>
 
-#include "argparse.h"
-#include "bs_pc_backchannel.h"
+#include <argparse.h>
+#include <bs_pc_backchannel.h>
 
 #define CLIENT_CLIENT_CHAN 0
 #define SERVER_CLIENT_CHAN 1

--- a/tests/bsim/bluetooth/host/security/ccc_update/src/common.c
+++ b/tests/bsim/bluetooth/host/security/ccc_update/src/common.c
@@ -6,8 +6,8 @@
 
 #include "common.h"
 
-#include "argparse.h"
-#include "bs_pc_backchannel.h"
+#include <argparse.h>
+#include <bs_pc_backchannel.h>
 
 void backchannel_sync_send(uint channel, uint device_nbr)
 {

--- a/tests/bsim/bluetooth/host/security/ccc_update/src/common.h
+++ b/tests/bsim/bluetooth/host/security/ccc_update/src/common.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/logging/log.h>
 
-#include "bs_tracing.h"
+#include <bs_tracing.h>
 
 LOG_MODULE_DECLARE(bt_bsim_ccc_update, LOG_LEVEL_DBG);
 

--- a/tests/bsim/bluetooth/host/security/ccc_update/src/main.c
+++ b/tests/bsim/bluetooth/host/security/ccc_update/src/main.c
@@ -3,7 +3,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include "bstests.h"
+#include <bstests.h>
 
 #include <zephyr/logging/log.h>
 

--- a/tests/bsim/bluetooth/host/security/ccc_update/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/ccc_update/src/peripheral.c
@@ -16,13 +16,13 @@
 
 #include <zephyr/settings/settings.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 #include "common.h"
-#include "settings.h"
+#include <settings.h>
 
-#include "argparse.h"
-#include "bs_pc_backchannel.h"
+#include <argparse.h>
+#include <bs_pc_backchannel.h>
 
 #define GOOD_CLIENT_CHAN 0
 #define BAD_CLIENT_CHAN 1

--- a/tests/bsim/bluetooth/host/security/id_addr_update/central/src/central.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/central/src/central.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bs_bt_utils.h"
+#include <bs_bt_utils.h>
 #include "utils.h"
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/conn.h>
@@ -13,7 +13,7 @@
 
 #include <zephyr/bluetooth/bluetooth.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(central, LOG_LEVEL_INF);

--- a/tests/bsim/bluetooth/host/security/id_addr_update/central/src/utils.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/central/src/utils.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bs_bt_utils.h"
+#include <bs_bt_utils.h>
 #include "utils.h"
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 BUILD_ASSERT(CONFIG_BT_MAX_PAIRED >= 2, "CONFIG_BT_MAX_PAIRED is too small.");
 BUILD_ASSERT(CONFIG_BT_ID_MAX >= 3, "CONFIG_BT_ID_MAX is too small.");

--- a/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/peripheral.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bs_bt_utils.h"
+#include <bs_bt_utils.h>
 #include "utils.h"
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
@@ -14,7 +14,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(peripheral, LOG_LEVEL_INF);

--- a/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/utils.c
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/src/utils.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bs_bt_utils.h"
+#include <bs_bt_utils.h>
 #include "utils.h"
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 BUILD_ASSERT(CONFIG_BT_MAX_PAIRED >= 2, "CONFIG_BT_MAX_PAIRED is too small.");
 BUILD_ASSERT(CONFIG_BT_ID_MAX >= 3, "CONFIG_BT_ID_MAX is too small.");

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/src/bs_bt_utils.c
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/src/bs_bt_utils.c
@@ -9,8 +9,8 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/settings/settings.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 LOG_MODULE_REGISTER(bs_bt_utils, LOG_LEVEL_DBG);
 

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/src/bs_bt_utils.h
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/src/bs_bt_utils.h
@@ -18,8 +18,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 DECLARE_FLAG(flag_pairing_complete);
 DECLARE_FLAG(flag_bonded);

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/src/central.c
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/src/central.c
@@ -12,8 +12,8 @@
 #include <zephyr/bluetooth/bluetooth.h>
 
 #include "bs_bt_utils.h"
-#include "babblekit/testcase.h"
-#include "babblekit/flags.h"
+#include <babblekit/testcase.h>
+#include <babblekit/flags.h>
 
 LOG_MODULE_REGISTER(test_central, LOG_LEVEL_DBG);
 

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/src/main.c
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include "bs_bt_utils.h"
-#include "bstests.h"
+#include <bstests.h>
 
 void central(void);
 void peripheral_unpair_in_sec_cb(void);

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/src/peripheral.c
@@ -13,7 +13,7 @@
 #include <zephyr/bluetooth/bluetooth.h>
 
 #include "bs_bt_utils.h"
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 LOG_MODULE_REGISTER(test_peripheral, LOG_LEVEL_DBG);
 

--- a/tests/bsim/bluetooth/samples/battery_service/src/central_test.c
+++ b/tests/bsim/bluetooth/samples/battery_service/src/central_test.c
@@ -6,10 +6,10 @@
 
 #include <zephyr/kernel.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <time_machine.h>
+#include <bstests.h>
 #include <argparse.h>
 
 #include <zephyr/types.h>
@@ -24,13 +24,13 @@
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "testlib/conn.h"
-#include "testlib/scan.h"
-#include "testlib/log_utils.h"
+#include <testlib/conn.h>
+#include <testlib/scan.h>
+#include <testlib/log_utils.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
+#include <babblekit/testcase.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_bsim_bas, CONFIG_BT_BAS_LOG_LEVEL);

--- a/tests/bsim/bluetooth/samples/battery_service/src/main.c
+++ b/tests/bsim/bluetooth/samples/battery_service/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_bas_central_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_bas_peripheral_install(struct bst_test_list *tests);

--- a/tests/bsim/bluetooth/samples/battery_service/src/peripheral_test.c
+++ b/tests/bsim/bluetooth/samples/battery_service/src/peripheral_test.c
@@ -5,10 +5,10 @@
  */
 #include <zephyr/kernel.h>
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <time_machine.h>
+#include <bstests.h>
 
 #include <zephyr/types.h>
 #include <stddef.h>
@@ -22,13 +22,13 @@
 #include <zephyr/bluetooth/services/bas.h>
 #include <zephyr/sys/byteorder.h>
 
-#include "testlib/conn.h"
-#include "testlib/scan.h"
-#include "testlib/log_utils.h"
+#include <testlib/conn.h>
+#include <testlib/scan.h>
+#include <testlib/log_utils.h>
 
-#include "babblekit/flags.h"
-#include "babblekit/sync.h"
-#include "babblekit/testcase.h"
+#include <babblekit/flags.h>
+#include <babblekit/sync.h>
+#include <babblekit/testcase.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(bt_bsim_bas, CONFIG_BT_BAS_LOG_LEVEL);

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/src/sample_test.c
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/src/sample_test.c
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "bs_utils.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <bs_utils.h>
+#include <time_machine.h>
+#include <bstests.h>
 
 #define WAIT_TIME 10 /* Seconds */
 

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/src/test_main.c
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/src/test_main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_sample_install(struct bst_test_list *tests);
 

--- a/tests/bsim/bluetooth/samples/peripheral_gap_svc/src/central.c
+++ b/tests/bsim/bluetooth/samples/peripheral_gap_svc/src/central.c
@@ -17,12 +17,12 @@
 
 #include <zephyr/logging/log.h>
 
-#include "testlib/att.h"
-#include "testlib/att_read.h"
-#include "testlib/att_write.h"
-#include "testlib/conn.h"
+#include <testlib/att.h>
+#include <testlib/att_read.h>
+#include <testlib/att_write.h>
+#include <testlib/conn.h>
 
-#include "babblekit/testcase.h"
+#include <babblekit/testcase.h>
 
 LOG_MODULE_REGISTER(central, LOG_LEVEL_DBG);
 

--- a/tests/bsim/bluetooth/samples/peripheral_gap_svc/src/test_main.c
+++ b/tests/bsim/bluetooth/samples/peripheral_gap_svc/src/test_main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_local_gap_svc_central_install(struct bst_test_list *tests);
 


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Bluetooth Host related paths and manually selecting the applicable changes:
```
$ find subsys/bluetooth/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;