### PR TITLE
[RFC] doc: contribute: style: header guards, local/non-local includes

### DIFF
--- a/doc/contribute/style/code.rst
+++ b/doc/contribute/style/code.rst
@@ -43,6 +43,8 @@ exceptions and clarifications:
   * For header files located ``drivers/``, the header guard name should
     reflects the path of the header file in the Zephyr source tree but
      using ``ZEPHYR_DRIVERS_`` prefix (instead of plain ``DRIVERS_``).
+* Be strict in using ``#include <>`` to include a non-local header file
+  and ``#include ""`` only for local header files.
 
 .. _Linux kernel coding style:
    https://kernel.org/doc/html/latest/process/coding-style.html

--- a/doc/contribute/style/code.rst
+++ b/doc/contribute/style/code.rst
@@ -31,6 +31,18 @@ exceptions and clarifications:
   clarity, avoid emojis in any case.
 * Use proper capitalization of nouns in code comments (e.g. ``UART`` and not
   ``uart``, ``CMake`` and not ``cmake``).
+* All header file shall have a header guard using ``#ifndef <GUARD_NAME>``,
+  followed ``#define <GUARD_NAME>`` at file entry and ``#endif`` (preferrably
+  ``#endif /* <GUARD_NAME> */`` at file end.
+  * For header files located ``include/zephyr/`` the guard macro name shall
+    reflects the path of the header file in the Zephyr source tree but
+    unsing ``ZEPHYR_INCLUDE_`` prefix (instead of ``INCLUDE_ZEPHYR_``).
+    Expection can be tolerated (e.g. leads to > 100 char/line) in which case
+    guard ``#ifndef <GUARD_MACRO>`` shall be preceeded by an inline comment
+    ``/* CUSTOM_GUARD_NAME: <brief reason> */`` including a brief explanation.
+  * For header files located ``drivers/``, the header guard name should
+    reflects the path of the header file in the Zephyr source tree but
+     using ``ZEPHYR_DRIVERS_`` prefix (instead of plain ``DRIVERS_``).
 
 .. _Linux kernel coding style:
    https://kernel.org/doc/html/latest/process/coding-style.html

--- a/doc/contribute/style/devicetree.rst
+++ b/doc/contribute/style/devicetree.rst
@@ -22,6 +22,8 @@ Devicetree Style Guidelines
     value on the same line as the opening bracket (``<`` or ``[``). Place the
     closing bracket and semicolon (``>;`` or ``];``) on the same line after
     the final value of the property.
+  * Be strict in using ``#include <>`` to include a non-local DTSI file
+    and ``#include ""`` only for DTSI header files.
 
 Examples:
 


### PR DESCRIPTION
Add entries in the coding style documentation about header files regarding header guards.
(related to https://github.com/zephyrproject-rtos/zephyr/pull/111768)

Add entries in the coding style documentation about use of `#include <>` and `#include ""` for inclusion local and non-local files in source and DTS/DTSI files.
(related to https://github.com/zephyrproject-rtos/zephyr/pull/112135)
