### PR TITLE
drivers: wifi: siwx91x: fix TX net_pkt double unref

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -265,7 +265,6 @@ static int siwx91x_send(const struct device *dev, struct net_pkt *pkt)
 		return -EIO;
 	}
 
-	net_pkt_unref(pkt);
 	net_buf_unref(buf);
 
 	return 0;


### PR DESCRIPTION
siwx91x_send() incorrectly unrefs a caller-owned TX net_pkt after transmit. In the TX path, the packet is owned by the networking/L2 stack, while the driver only borrows it long enough to read or copy the frame data.

As a result, the packet may be returned to the pool prematurely while upper layers still consider it valid. Once released, the same memory can be reused for a different allocation, creating a packet lifetime bug similar to a use-after-free condition. This memory reuse can lead to unexpected behavior and explain hangs in the transmit path.

Fixes: #113521