### PR TITLE
kernel: msgq: introduce K_MSGQ_DEFINE_STATIC, K_MSGQ_DEFINE_TYPE macros

### DIFF
--- a/doc/kernel/services/data_passing/message_queues.rst
+++ b/doc/kernel/services/data_passing/message_queues.rst
@@ -90,7 +90,11 @@ that is capable of holding 10 items, each of which is 12 bytes long.
     k_msgq_init(&my_msgq, my_msgq_buffer, sizeof(struct data_item_type), 10);
 
 Alternatively, a message queue can be defined and initialized at compile time
-by calling :c:macro:`K_MSGQ_DEFINE`.
+by calling one of the following macros:
+
+* :c:macro:`K_MSGQ_DEFINE` -- Defines a public message queue.
+* :c:macro:`K_MSGQ_DEFINE_STATIC` -- Defines a private (static scope) message
+  queue.
 
 The following code has the same effect as the code segment above. Observe
 that the macro defines both the message queue and its buffer.

--- a/doc/kernel/services/data_passing/message_queues.rst
+++ b/doc/kernel/services/data_passing/message_queues.rst
@@ -95,6 +95,10 @@ by calling one of the following macros:
 * :c:macro:`K_MSGQ_DEFINE` -- Defines a public message queue.
 * :c:macro:`K_MSGQ_DEFINE_STATIC` -- Defines a private (static scope) message
   queue.
+* :c:macro:`K_MSGQ_DEFINE_TYPE` -- Defines a public message queue for given
+  item type.
+* :c:macro:`K_MSGQ_DEFINE_STATIC_TYPE` -- Defines a private message queue for
+  given item type.
 
 The following code has the same effect as the code segment above. Observe
 that the macro defines both the message queue and its buffer.
@@ -102,6 +106,14 @@ that the macro defines both the message queue and its buffer.
 .. code-block:: c
 
     K_MSGQ_DEFINE(my_msgq, sizeof(struct data_item_type), 10, 1);
+
+The :c:macro:`K_MSGQ_DEFINE_TYPE` shorthand can be used if the queue item type
+is known at compile time. This macro configures the queue item size and
+alignment automatically:
+
+.. code-block:: c
+
+    K_MSGQ_DEFINE_TYPE(my_msgq, struct data_item_type, 10);
 
 Writing to a Message Queue
 ==========================

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -261,6 +261,9 @@ New APIs and options
 
   * :c:func:`k_thread_runtime_stats_is_enabled`
   * :c:func:`atomic_test_and_set_bit_to`
+  * :c:macro:`K_MSGQ_DEFINE_STATIC`
+  * :c:macro:`K_MSGQ_DEFINE_TYPE`
+  * :c:macro:`K_MSGQ_DEFINE_STATIC_TYPE`
 
 * LoRa
 

--- a/drivers/audio/dmic_infineon.c
+++ b/drivers/audio/dmic_infineon.c
@@ -720,7 +720,7 @@ static DEVICE_API(dmic, dmic_ops) = {
 			    DEVICE_DT_INST_GET(index), 0);                                         \
 	}                                                                                          \
                                                                                                    \
-	K_MSGQ_DEFINE(dmic_msgq##index, sizeof(void *), CONFIG_DMIC_INFINEON_QUEUE_SIZE, 1);       \
+	K_MSGQ_DEFINE_STATIC_TYPE(dmic_msgq##index, void *, CONFIG_DMIC_INFINEON_QUEUE_SIZE);      \
                                                                                                    \
 	PINCTRL_DT_INST_DEFINE(index);                                                             \
                                                                                                    \

--- a/drivers/audio/dmic_mcux.c
+++ b/drivers/audio/dmic_mcux.c
@@ -705,8 +705,8 @@ static DEVICE_API(dmic, dmic_ops) = {
 		*pdm_channels##idx[FSL_FEATURE_DMIC_CHANNEL_NUM] = {		\
 			PDM_DMIC_CHANNELS_GET(idx)				\
 	};									\
-	K_MSGQ_DEFINE(dmic_msgq##idx, sizeof(void *),				\
-		      CONFIG_DMIC_MCUX_QUEUE_SIZE, 1);				\
+	K_MSGQ_DEFINE_STATIC_TYPE(dmic_msgq##idx, void *,			\
+		      CONFIG_DMIC_MCUX_QUEUE_SIZE);				\
 	static struct mcux_dmic_drv_data mcux_dmic_data##idx = {		\
 		.pdm_channels = pdm_channels##idx,				\
 		.base_address = (DMIC_Type *) DT_INST_REG_ADDR(idx),		\

--- a/drivers/audio/dmic_nxp_micfil.c
+++ b/drivers/audio/dmic_nxp_micfil.c
@@ -639,8 +639,8 @@ static DEVICE_API(dmic, dmic_ops) = {
 
 #define NXP_MICFIL_DEFINE(inst)								\
 	PINCTRL_DT_INST_DEFINE(inst);							\
-	K_MSGQ_DEFINE(nxp_micfil_msgq##inst, sizeof(void *),				\
-			CONFIG_DMIC_NXP_MICFIL_QUEUE_SIZE, 4);				\
+	K_MSGQ_DEFINE_STATIC_TYPE(nxp_micfil_msgq##inst, void *,			\
+				  CONFIG_DMIC_NXP_MICFIL_QUEUE_SIZE);			\
 											\
 	NXP_MICFIL_IRQ_CONFIG(inst)							\
 											\

--- a/drivers/audio/dmic_stm32_dfsdm.c
+++ b/drivers/audio/dmic_stm32_dfsdm.c
@@ -1028,8 +1028,8 @@ static int dmic_stm32_dfsdm_pm_action(const struct device *dev, enum pm_device_a
                                                                                                    \
 	PINCTRL_DT_DEFINE(flt);                                                                    \
                                                                                                    \
-	K_MSGQ_DEFINE(dmic_stm32_dfsdm_msgq_##flt, sizeof(void *),                                 \
-		      CONFIG_DMIC_STM32_DFSDM_QUEUE_SIZE, 4);                                      \
+	K_MSGQ_DEFINE_STATIC_TYPE(dmic_stm32_dfsdm_msgq_##flt, void *,                             \
+				  CONFIG_DMIC_STM32_DFSDM_QUEUE_SIZE);                             \
                                                                                                    \
 	IF_ENABLED(DT_NODE_HAS_PROP(flt, dmas),                                                    \
 		(static int32_t __aligned(32)                                                      \

--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -493,7 +493,7 @@ static void process_rx(uint8_t packetType, uint8_t *data, uint16_t len)
 
 #if defined(CONFIG_HCI_NXP_RX_THREAD)
 
-K_MSGQ_DEFINE(rx_msgq, sizeof(struct hci_data), CONFIG_HCI_NXP_RX_MSG_QUEUE_SIZE, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(rx_msgq, struct hci_data, CONFIG_HCI_NXP_RX_MSG_QUEUE_SIZE);
 
 static void bt_rx_thread(void *p1, void *p2, void *p3)
 {

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -50,8 +50,8 @@ static const struct can_shell_mode_mapping can_shell_mode_map[] = {
 	/* zephyr-keep-sorted-stop */
 };
 
-K_MSGQ_DEFINE(can_shell_tx_msgq, sizeof(struct can_shell_tx_event),
-	      CONFIG_CAN_SHELL_TX_QUEUE_SIZE, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(can_shell_tx_msgq, struct can_shell_tx_event,
+			  CONFIG_CAN_SHELL_TX_QUEUE_SIZE);
 const struct shell *can_shell_tx_msgq_sh;
 static struct k_work_poll can_shell_tx_msgq_work;
 static struct k_poll_event can_shell_tx_msgq_events[] = {
@@ -60,8 +60,8 @@ static struct k_poll_event can_shell_tx_msgq_events[] = {
 					&can_shell_tx_msgq, 0)
 };
 
-K_MSGQ_DEFINE(can_shell_rx_msgq, sizeof(struct can_shell_rx_event),
-	      CONFIG_CAN_SHELL_RX_QUEUE_SIZE, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(can_shell_rx_msgq, struct can_shell_rx_event,
+			  CONFIG_CAN_SHELL_RX_QUEUE_SIZE);
 const struct shell *can_shell_rx_msgq_sh;
 static struct k_work_poll can_shell_rx_msgq_work;
 static struct k_poll_event can_shell_rx_msgq_events[] = {

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -1394,7 +1394,7 @@ static DEVICE_API(display, sdl_display_api) = {
                                                                                                    \
 	static uint8_t sdl_buf_##n[4 * DT_INST_PROP(n, height) * DT_INST_PROP(n, width)];          \
 	static uint8_t sdl_read_buf_##n[4 * DT_INST_PROP(n, height) * DT_INST_PROP(n, width)];     \
-	K_MSGQ_DEFINE(sdl_task_msgq_##n, sizeof(struct sdl_display_task), 1, 4);                   \
+	K_MSGQ_DEFINE_STATIC_TYPE(sdl_task_msgq_##n, struct sdl_display_task, 1);                  \
 	static struct sdl_display_data sdl_data_##n = {                                            \
 		COND_CODE_1(HAS_COLOR_PALETTE(n),                                                  \
 			    (.color_dither = DISPLAY_COLOR_DITHER_INIT(n),), ())                   \

--- a/drivers/i2s/i2s_max32.c
+++ b/drivers/i2s/i2s_max32.c
@@ -732,8 +732,8 @@ static int i2s_max32_init(const struct device *dev)
 #define MAX32_DT_INST_DMA_CELL(n, name, cell) DT_INST_DMAS_CELL_BY_NAME(n, name, cell)
 
 #define I2S_MAX32_STREAM_DATA_CREATE_AND_INIT(n, dir)                                              \
-	K_MSGQ_DEFINE(i2s_max32_##dir##_q_##n, sizeof(struct i2s_mem_block),                       \
-		      CONFIG_I2S_MAX32_QUEUE_SIZE, 1);                                             \
+	K_MSGQ_DEFINE_STATIC_TYPE(i2s_max32_##dir##_q_##n, struct i2s_mem_block,                   \
+				  CONFIG_I2S_MAX32_QUEUE_SIZE);                                    \
 	static struct i2s_max32_stream_data i2s_max32_##dir##_data_##n = {                         \
 		.state = I2S_STATE_NOT_READY,                                                      \
 		.drain = false,                                                                    \

--- a/drivers/i2s/i2s_stm32.c
+++ b/drivers/i2s/i2s_stm32.c
@@ -1002,10 +1002,10 @@ static const struct device *get_dev_from_tx_dma_channel(uint32_t dma_channel)
 		.ioswp = DT_INST_PROP(index, ioswp),				\
 	};									\
 										\
-	K_MSGQ_DEFINE(rx_##index##_queue, sizeof(struct queue_item),		\
-		      CONFIG_I2S_STM32_RX_BLOCK_COUNT, 4);			\
-	K_MSGQ_DEFINE(tx_##index##_queue, sizeof(struct queue_item),		\
-		      CONFIG_I2S_STM32_TX_BLOCK_COUNT, 4);			\
+	K_MSGQ_DEFINE_STATIC_TYPE(rx_##index##_queue, struct queue_item,	\
+				  CONFIG_I2S_STM32_RX_BLOCK_COUNT);		\
+	K_MSGQ_DEFINE_STATIC_TYPE(tx_##index##_queue, struct queue_item,	\
+				  CONFIG_I2S_STM32_TX_BLOCK_COUNT);		\
 										\
 	static struct i2s_stm32_data i2s_stm32_data_##index = {			\
 		IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, rx),			\

--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -1053,7 +1053,8 @@ static DEVICE_API(i2s, i2s_stm32_sai_api) = {
 	};                                                                                         \
 	DEVICE_DT_DEFINE(node, &sai_sub_init, NULL, &sub_data_##node, &sub_cfg_##node,             \
 			 POST_KERNEL, CONFIG_I2S_INIT_PRIORITY, &i2s_stm32_sai_api);               \
-	K_MSGQ_DEFINE(queue_##node, sizeof(struct queue_item), CONFIG_I2S_STM32_SAI_BLOCK_COUNT, 4);
+	K_MSGQ_DEFINE_STATIC_TYPE(queue_##node, struct queue_item,                                 \
+				  CONFIG_I2S_STM32_SAI_BLOCK_COUNT);
 
 /* Controller Node */
 #define SAI_INIT(inst)                                                                             \

--- a/drivers/ieee802154/ieee802154_esp32.c
+++ b/drivers/ieee802154/ieee802154_esp32.c
@@ -56,8 +56,8 @@ struct ieee802154_esp32_rx_msg {
 
 static struct ieee802154_esp32_data esp32_data;
 
-K_MSGQ_DEFINE(ieee802154_esp32_rx_msgq, sizeof(struct ieee802154_esp32_rx_msg),
-	      CONFIG_IEEE802154_ESP32_RX_BUFFER_SIZE, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(ieee802154_esp32_rx_msgq, struct ieee802154_esp32_rx_msg,
+			  CONFIG_IEEE802154_ESP32_RX_BUFFER_SIZE);
 
 static void ieee802154_esp32_rx_deliver(const struct ieee802154_esp32_rx_msg *rx)
 {

--- a/drivers/mipi_dbi/mipi_dbi_rpi_pico_pio.c
+++ b/drivers/mipi_dbi/mipi_dbi_rpi_pico_pio.c
@@ -662,7 +662,7 @@ static DEVICE_API(mipi_dbi, mipi_dbi_pico_pio_driver_api) = {
 			     DT_INST_PROP(n, pio_clock_div) <= UINT16_MAX,                         \
 		     "pio-clock-div has to be between 1 and 65536");                               \
                                                                                                    \
-	K_MSGQ_DEFINE(msgq_##n, sizeof(int), MIPI_DBI_MAX_SPLITS, 4);                              \
+	K_MSGQ_DEFINE_STATIC_TYPE(msgq_##n, int, MIPI_DBI_MAX_SPLITS);                             \
                                                                                                    \
 	static void inst_##n##_irq_config(void)                                                    \
 	{                                                                                          \

--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -1953,7 +1953,7 @@ static DEVICE_API(sdhc, sdhc_api) = {
                                                                                                    \
 	COND_CODE_1(DT_NUM_PINCTRL_STATES(DT_DRV_INST(n)),                                         \
 			  (PINCTRL_DT_DEFINE(DT_DRV_INST(n));), (EMPTY))                           \
-	K_MSGQ_DEFINE(sdhc##n##_queue, sizeof(struct sdmmc_event), SDMMC_EVENT_QUEUE_LENGTH, 1);   \
+	K_MSGQ_DEFINE_STATIC_TYPE(sdhc##n##_queue, struct sdmmc_event, SDMMC_EVENT_QUEUE_LENGTH);  \
                                                                                                    \
 	static const struct sdhc_esp32_config sdhc_esp32_##n##_config = {                          \
 		.sdio_hw = (const sdmmc_dev_t *)DT_REG_ADDR(DT_INST_PARENT(n)),                    \

--- a/drivers/usb/device/usb_dc_kinetis.c
+++ b/drivers/usb/device/usb_dc_kinetis.c
@@ -137,7 +137,7 @@ struct cb_msg {
 	uint32_t cb;
 };
 
-K_MSGQ_DEFINE(usb_dc_msgq, sizeof(struct cb_msg), 10, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(usb_dc_msgq, struct cb_msg, 10);
 static void usb_kinetis_isr_handler(void);
 
 /*

--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -143,8 +143,8 @@ static struct usb_ep_ctrl_data s_ep_ctrl[NUM_OF_EP_MAX];
 static struct usb_dc_state dev_state;
 
 /* Message queue for the usb thread */
-K_MSGQ_DEFINE(usb_dc_msgq, sizeof(usb_device_callback_message_struct_t),
-	CONFIG_USB_DC_MSG_QUEUE_LEN, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(usb_dc_msgq, usb_device_callback_message_struct_t,
+	CONFIG_USB_DC_MSG_QUEUE_LEN);
 
 #if defined(CONFIG_USB_DC_NXP_EHCI)
 /* EHCI device driver interface */

--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -86,7 +86,7 @@ struct cb_msg {
 	uint8_t ep;
 };
 
-K_MSGQ_DEFINE(usb_dc_msgq, sizeof(struct cb_msg), 10, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(usb_dc_msgq, struct cb_msg, 10);
 
 static struct udc_rpi_ep_state *udc_rpi_get_ep_state(uint8_t ep)
 {

--- a/drivers/usb/udc/udc_ambiq.c
+++ b/drivers/usb/udc/udc_ambiq.c
@@ -36,8 +36,7 @@ struct udc_ambiq_event {
 	uint8_t ep;
 };
 
-K_MSGQ_DEFINE(drv_msgq, sizeof(struct udc_ambiq_event), CONFIG_UDC_AMBIQ_MAX_QMESSAGES,
-	      sizeof(void *));
+K_MSGQ_DEFINE_STATIC_TYPE(drv_msgq, struct udc_ambiq_event, CONFIG_UDC_AMBIQ_MAX_QMESSAGES);
 
 /* USB device controller access from devicetree */
 #define DT_DRV_COMPAT ambiq_usb

--- a/drivers/usb/udc/udc_it82xx2.c
+++ b/drivers/usb/udc/udc_it82xx2.c
@@ -102,8 +102,7 @@ struct it82xx2_ep_event {
 	enum it82xx2_event_type event;
 };
 
-K_MSGQ_DEFINE(evt_msgq, sizeof(struct it82xx2_ep_event),
-	      CONFIG_UDC_IT82xx2_EVENT_COUNT, sizeof(uint32_t));
+K_MSGQ_DEFINE_STATIC_TYPE(evt_msgq, struct it82xx2_ep_event, CONFIG_UDC_IT82xx2_EVENT_COUNT);
 
 struct usb_it8xxx2_wuc {
 	/* WUC control device structure */

--- a/drivers/usb/udc/udc_max32.c
+++ b/drivers/usb/udc/udc_max32.c
@@ -37,8 +37,7 @@ struct udc_max32_evt {
 	struct udc_ep_config *ep_cfg;
 };
 
-K_MSGQ_DEFINE(drv_msgq, sizeof(struct udc_max32_evt), CONFIG_UDC_MAX32_MAX_QMESSAGES,
-	      sizeof(uint32_t));
+K_MSGQ_DEFINE_STATIC_TYPE(drv_msgq, struct udc_max32_evt, CONFIG_UDC_MAX32_MAX_QMESSAGES);
 
 struct udc_max32_config {
 	mxc_usbhs_regs_t *base;

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -3241,8 +3241,8 @@ static const struct udc_api udc_numaker_api = {
 	static struct numaker_usbd_ep                                                              \
 		numaker_usbd_ep_pool_##inst[DT_INST_PROP(inst, num_bidir_endpoints)];              \
                                                                                                    \
-	K_MSGQ_DEFINE(numaker_usbd_msgq_##inst, sizeof(struct numaker_usbd_msg),                   \
-		      CONFIG_UDC_NUMAKER_MSG_QUEUE_SIZE, 4);                                       \
+	K_MSGQ_DEFINE_STATIC_TYPE(numaker_usbd_msgq_##inst, struct numaker_usbd_msg,               \
+		      CONFIG_UDC_NUMAKER_MSG_QUEUE_SIZE);                                          \
                                                                                                    \
 	static struct udc_numaker_data udc_priv_##inst = {                                         \
 		.msgq = &numaker_usbd_msgq_##inst,                                                 \

--- a/drivers/wifi/ameba/ameba_wifi_drv.c
+++ b/drivers/wifi/ameba/ameba_wifi_drv.c
@@ -30,7 +30,7 @@ static struct ameba_wifi_runtime ameba_data[2];
 
 extern void (*p_wifi_join_info_free)(uint8_t iface_type);
 
-K_MSGQ_DEFINE(ameba_wifi_msgq, sizeof(struct ameba_system_event), 10, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(ameba_wifi_msgq, struct ameba_system_event, 10);
 K_THREAD_STACK_DEFINE(ameba_wifi_event_stack, CONFIG_AMEBA_WIFI_EVENT_STACK_SIZE);
 
 static struct k_thread ameba_wifi_event_thread;

--- a/drivers/wifi/infineon/airoc_wifi.c
+++ b/drivers/wifi/infineon/airoc_wifi.c
@@ -139,7 +139,7 @@ struct airoc_wifi_event_t {
 	whd_event_data_t *whd_event_data;
 };
 
-K_MSGQ_DEFINE(airoc_wifi_msgq, sizeof(struct airoc_wifi_event_t), 10, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(airoc_wifi_msgq, struct airoc_wifi_event_t, 10);
 K_THREAD_STACK_DEFINE(airoc_wifi_event_stack, CONFIG_AIROC_WIFI_EVENT_TASK_STACK_SIZE);
 static struct k_thread airoc_wifi_event_thread;
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1364,7 +1364,7 @@ int can_add_rx_filter(const struct device *dev, can_rx_callback_t callback,
  * @param max_frames Maximum number of CAN frames that can be queued.
  */
 #define CAN_MSGQ_DEFINE(name, max_frames) \
-	K_MSGQ_DEFINE(name, sizeof(struct can_frame), max_frames, 4)
+	K_MSGQ_DEFINE_TYPE(name, struct can_frame, max_frames)
 
 /**
  * @brief Simple wrapper function for adding a message queue for a given filter

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5437,6 +5437,42 @@ struct k_msgq_attrs {
 				  (q_msg_size), (q_max_msgs))
 
 /**
+ * @brief Statically define and initialize a message queue for messages of a given type.
+ *
+ * The message queue's ring buffer contains space for @a q_max_msgs messages,
+ * each of which is the size of @a type.
+ *
+ * The message queue can be accessed outside the module where it is defined
+ * using:
+ *
+ * @code extern struct k_msgq <name>; @endcode
+ *
+ * @note This macro cannot be used together with a static keyword.
+ *       If such a use-case is desired, use @ref K_MSGQ_DEFINE_STATIC_TYPE
+ *       instead.
+ *
+ * @param q_name Name of the message queue.
+ * @param q_msg_type Type of each message.
+ * @param q_max_msgs Maximum number of messages that can be queued.
+ */
+#define K_MSGQ_DEFINE_TYPE(q_name, q_msg_type, q_max_msgs) \
+	K_MSGQ_DEFINE(q_name, sizeof(q_msg_type), q_max_msgs, __alignof(q_msg_type))
+
+/**
+ * @brief Statically define and initialize a message queue for messages of a given type in a
+ * private (static) scope.
+ *
+ * The message queue's ring buffer contains space for @a q_max_msgs messages,
+ * each of which is the size of @a type.
+ *
+ * @param q_name Name of the message queue.
+ * @param q_msg_type Type of each message.
+ * @param q_max_msgs Maximum number of messages that can be queued.
+ */
+#define K_MSGQ_DEFINE_STATIC_TYPE(q_name, q_msg_type, q_max_msgs) \
+	K_MSGQ_DEFINE_STATIC(q_name, sizeof(q_msg_type), q_max_msgs, __alignof(q_msg_type))
+
+/**
  * @brief Initialize a message queue.
  *
  * This routine initializes a message queue object, prior to its first use.

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5399,6 +5399,10 @@ struct k_msgq_attrs {
  *
  * @code extern struct k_msgq <name>; @endcode
  *
+ * @note This macro cannot be used together with a static keyword.
+ *       If such a use-case is desired, use @ref K_MSGQ_DEFINE_STATIC
+ *       instead.
+ *
  * @param q_name Name of the message queue.
  * @param q_msg_size Message size (in bytes).
  * @param q_max_msgs Maximum number of messages that can be queued.
@@ -5410,6 +5414,26 @@ struct k_msgq_attrs {
 		_k_fifo_buf_##q_name[(q_max_msgs) * (q_msg_size)];	\
 	STRUCT_SECTION_ITERABLE(k_msgq, q_name) =			\
 	       Z_MSGQ_INITIALIZER(q_name, _k_fifo_buf_##q_name,	\
+				  (q_msg_size), (q_max_msgs))
+
+/**
+ * @brief Statically define and initialize a message queue in a private (static) scope.
+ *
+ * The message queue's ring buffer contains space for @a q_max_msgs messages,
+ * each of which is @a q_msg_size bytes long. Alignment of the message queue's
+ * ring buffer is not necessary, setting @a q_align to 1 is sufficient.
+ *
+ * @param q_name Name of the message queue.
+ * @param q_msg_size Message size (in bytes).
+ * @param q_max_msgs Maximum number of messages that can be queued.
+ * @param q_align Alignment of the message queue's ring buffer (power of 2).
+ *
+ */
+#define K_MSGQ_DEFINE_STATIC(q_name, q_msg_size, q_max_msgs, q_align)	\
+	static char __noinit __aligned(q_align)				\
+		_k_fifo_buf_##q_name[(q_max_msgs) * (q_msg_size)];	\
+	static STRUCT_SECTION_ITERABLE(k_msgq, q_name) =		\
+		Z_MSGQ_INITIALIZER(q_name, _k_fifo_buf_##q_name,	\
 				  (q_msg_size), (q_max_msgs))
 
 /**

--- a/include/zephyr/zbus/proxy_agent/zbus_proxy_agent.h
+++ b/include/zephyr/zbus/proxy_agent/zbus_proxy_agent.h
@@ -164,8 +164,8 @@ int zbus_init_proxy_agent(const struct zbus_proxy_agent *agent);
 	_ZBUS_PROXY_AGENT_BACKEND_CONFIG_DEFINE(_name, _type, _backend_dt_node)                    \
 	K_THREAD_STACK_DEFINE(_name##_thread_stack,                                                \
 			      CONFIG_ZBUS_PROXY_AGENT_WORK_QUEUE_STACK_SIZE);                      \
-	K_MSGQ_DEFINE(_name##_rx_msgq, sizeof(struct zbus_proxy_agent_rx_msg),                     \
-		      CONFIG_ZBUS_PROXY_AGENT_RX_QUEUE_DEPTH, 4);                                  \
+	K_MSGQ_DEFINE_STATIC_TYPE(_name##_rx_msgq, struct zbus_proxy_agent_rx_msg,                 \
+				  CONFIG_ZBUS_PROXY_AGENT_RX_QUEUE_DEPTH);                         \
 	static struct k_thread _name##_thread;                                                     \
 	static k_tid_t _name##_thread_id;                                                          \
 	const struct zbus_proxy_agent _name = {                                                    \

--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -483,9 +483,8 @@ struct zbus_channel_observation {
  * @param[in] _enable The subscriber initial enable state.
  */
 #define ZBUS_SUBSCRIBER_DEFINE_WITH_ENABLE(_name, _queue_size, _enable)       \
-	K_MSGQ_DEFINE(_zbus_observer_queue_##_name,                           \
-		      sizeof(struct zbus_channel *),                          \
-		      _queue_size, sizeof(struct zbus_channel *)              \
+	K_MSGQ_DEFINE_STATIC_TYPE(_zbus_observer_queue_##_name,               \
+				  struct zbus_channel *, _queue_size          \
 	);                                                                    \
 	static struct zbus_observer_data _CONCAT(_zbus_obs_data_, _name) = {  \
 		.enabled = _enable,                                           \

--- a/modules/hal_nordic/nrfs/backends/nrfs_backend_ipc_service.c
+++ b/modules/hal_nordic/nrfs/backends/nrfs_backend_ipc_service.c
@@ -19,8 +19,8 @@ LOG_MODULE_REGISTER(NRFS_BACKEND, CONFIG_NRFS_BACKEND_LOG_LEVEL);
 
 #define MAX_PACKET_DATA_SIZE (CONFIG_NRFS_MAX_BACKEND_PACKET_SIZE)
 
-K_MSGQ_DEFINE(ipc_transmit_msgq, sizeof(struct ipc_data_packet),
-							CONFIG_NRFS_BACKEND_TX_MSG_QUEUE_SIZE, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(ipc_transmit_msgq, struct ipc_data_packet,
+			  CONFIG_NRFS_BACKEND_TX_MSG_QUEUE_SIZE);
 
 static struct k_work backend_send_work;
 

--- a/modules/lvgl/include/lvgl_common_input.h
+++ b/modules/lvgl/include/lvgl_common_input.h
@@ -38,7 +38,7 @@ int lvgl_init_input_devices(void);
 #define LVGL_INPUT_DEFINE(input_device, lvgl_device, identifier, type, msgq_size, process_evt_cb)  \
 	INPUT_CALLBACK_DEFINE_NAMED(input_device, process_evt_cb, (void *)lvgl_device,             \
 				    process_evt_cb_##identifier);                                  \
-	K_MSGQ_DEFINE(lvgl_input_msgq_##type##_##identifier, sizeof(lv_indev_data_t), msgq_size, 4)
+	K_MSGQ_DEFINE_STATIC_TYPE(lvgl_input_msgq_##type##_##identifier, lv_indev_data_t, msgq_size)
 
 #define LVGL_INPUT_INST_DEFINE(inst, type, msgq_size, process_evt_cb)                              \
 	LVGL_INPUT_DEFINE(LVGL_INPUT_DEVICE(inst), DEVICE_DT_INST_GET(inst), inst, type,           \

--- a/modules/lvgl/lvgl_display.c
+++ b/modules/lvgl/lvgl_display.c
@@ -13,7 +13,7 @@
 #ifdef CONFIG_LV_Z_FLUSH_THREAD
 
 /* There can be up to DISPLAY_COUNT flush events at the same time*/
-K_MSGQ_DEFINE(flush_queue, sizeof(struct lvgl_display_flush), DT_ZEPHYR_DISPLAYS_COUNT, 1);
+K_MSGQ_DEFINE_STATIC_TYPE(flush_queue, struct lvgl_display_flush, DT_ZEPHYR_DISPLAYS_COUNT);
 
 void lvgl_flush_thread_entry(void *arg1, void *arg2, void *arg3)
 {

--- a/soc/infineon/edge/pse84/soc_pse84_m33_ns.c
+++ b/soc/infineon/edge/pse84/soc_pse84_m33_ns.c
@@ -107,7 +107,7 @@ static mtb_ipc_semaphore_t pse84_srf_ipc_semaphores[MTB_SRF_IPC_SEMA_COUNT];
 static mtb_ipc_mbox_receiver_t pse84_srf_ipc_receiver;
 
 /* Relay threads */
-K_MSGQ_DEFINE(pse84_srf_request_queue, sizeof(void *), MTB_SRF_POOL_SIZE, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(pse84_srf_request_queue, void *, MTB_SRF_POOL_SIZE);
 K_SEM_DEFINE(pse84_srf_relay_ready_sem, 0, 2);
 K_THREAD_STACK_DEFINE(pse84_srf_receive_stack, SRF_THREAD_STACK_SIZE);
 K_THREAD_STACK_DEFINE(pse84_srf_process_stack, SRF_THREAD_STACK_SIZE);

--- a/subsys/authentication/fido2/fido2_core.c
+++ b/subsys/authentication/fido2/fido2_core.c
@@ -40,7 +40,7 @@ static struct fido2_msg rx_enqueue_msg;
 /* Reused to minimize thread stack usage. */
 static struct fido2_msg rx_dequeue_msg;
 
-K_MSGQ_DEFINE(fido2_msgq, sizeof(struct fido2_msg), 2, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(fido2_msgq, struct fido2_msg, 2);
 
 static K_THREAD_STACK_DEFINE(fido2_stack, CONFIG_FIDO2_THREAD_STACK_SIZE);
 static struct k_thread fido2_thread;

--- a/subsys/authentication/fido2/transport/fido2_transport_usb_hid.c
+++ b/subsys/authentication/fido2/transport/fido2_transport_usb_hid.c
@@ -85,7 +85,7 @@ extern struct fido2_transport usb_hid_transport;
 
 static K_MUTEX_DEFINE(tx_mutex);
 
-K_MSGQ_DEFINE(hid_rx_msgq, CTAPHID_PACKET_SIZE, 8, 4);
+K_MSGQ_DEFINE_STATIC(hid_rx_msgq, CTAPHID_PACKET_SIZE, 8, 4);
 
 static struct k_work_q hid_rx_work_q;
 static K_THREAD_STACK_DEFINE(hid_rx_work_q_stack, FIDO2_HID_RX_WORKQ_STACK_SIZE);

--- a/subsys/input/input.c
+++ b/subsys/input/input.c
@@ -13,8 +13,7 @@ LOG_MODULE_REGISTER(input, CONFIG_INPUT_LOG_LEVEL);
 
 #ifdef CONFIG_INPUT_MODE_THREAD
 
-K_MSGQ_DEFINE(input_msgq, sizeof(struct input_event),
-	      CONFIG_INPUT_QUEUE_MAX_MSGS, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(input_msgq, struct input_event, CONFIG_INPUT_QUEUE_MAX_MSGS);
 
 #endif
 

--- a/subsys/lorawan/native/engine.c
+++ b/subsys/lorawan/native/engine.c
@@ -43,7 +43,7 @@ LOG_MODULE_REGISTER(lorawan_native_engine, CONFIG_LORAWAN_LOG_LEVEL);
 
 #define ENGINE_MSGQ_DEPTH	8
 
-K_MSGQ_DEFINE(engine_msgq, sizeof(struct lwan_req), ENGINE_MSGQ_DEPTH, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(engine_msgq, struct lwan_req, ENGINE_MSGQ_DEPTH);
 
 static K_THREAD_STACK_DEFINE(engine_stack,
 			     CONFIG_LORAWAN_NATIVE_ENGINE_STACK_SIZE);

--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -59,8 +59,7 @@ static void mgmt_run_callbacks(const struct mgmt_event_entry * const mgmt_event)
 static K_MUTEX_DEFINE(net_mgmt_event_lock);
 /* event structure used to prevent increasing the stack usage on the caller thread */
 static struct mgmt_event_entry new_event;
-K_MSGQ_DEFINE(event_msgq, sizeof(struct mgmt_event_entry),
-	      CONFIG_NET_MGMT_EVENT_QUEUE_SIZE, sizeof(uint32_t));
+K_MSGQ_DEFINE_STATIC_TYPE(event_msgq, struct mgmt_event_entry, CONFIG_NET_MGMT_EVENT_QUEUE_SIZE);
 
 static struct k_work_q *mgmt_work_q = COND_CODE_1(CONFIG_NET_MGMT_EVENT_SYSTEM_WORKQUEUE,
 	(&k_sys_work_q), (&mgmt_work_q_obj));

--- a/subsys/net/lib/latmon/latmon.c
+++ b/subsys/net/lib/latmon/latmon.c
@@ -34,7 +34,7 @@ struct latmon_message {
 	int latmus; /* latmus connection */
 };
 
-K_MSGQ_DEFINE(latmon_msgq, sizeof(struct latmon_message), 2, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(latmon_msgq, struct latmon_message, 2);
 
 /*
  * Note: Using a small period (e.g., less than 100 microseconds) may result in
@@ -64,7 +64,7 @@ struct latmon_data {
 };
 
 /* Message queue for sample data transfers */
-K_MSGQ_DEFINE(xfer_msgq, sizeof(struct latmon_data), 10, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(xfer_msgq, struct latmon_data, 10);
 
 /* Network transfer thread: sends data to Latmus  */
 #define XFER_THREAD_STACK_SIZE CONFIG_NET_LATMON_XFER_THREAD_STACK_SIZE

--- a/subsys/net/lib/ocpp/ocpp.c
+++ b/subsys/net/lib/ocpp/ocpp.c
@@ -27,7 +27,8 @@ struct ocpp_msg_table {
 static K_THREAD_STACK_DEFINE(ocpp_int_handler_stack, CONFIG_OCPP_INT_THREAD_STACKSIZE);
 static K_THREAD_STACK_DEFINE(ocpp_wsreader_stack, CONFIG_OCPP_WSREADER_THREAD_STACKSIZE);
 
-K_MSGQ_DEFINE(ocpp_iq, OCPP_INTERNAL_MSG_SIZE, CONFIG_OCPP_INTERNAL_MSGQ_CNT, sizeof(uint32_t));
+K_MSGQ_DEFINE_STATIC(ocpp_iq, OCPP_INTERNAL_MSG_SIZE, CONFIG_OCPP_INTERNAL_MSGQ_CNT,
+		     sizeof(uint32_t));
 
 struct ocpp_info *gctx;
 

--- a/subsys/net/lib/shell/dns.c
+++ b/subsys/net/lib/shell/dns.c
@@ -97,7 +97,7 @@ static void dns_result_cb(enum dns_resolve_status status,
 	PR_WARNING("dns: Unhandled status %d received (errno %d)\n", status, errno);
 }
 
-K_MSGQ_DEFINE(dns_infoq, sizeof(struct dns_addrinfo), CONFIG_NET_SHELL_DNS_RESOLVER_QUEUE_SIZE, 1);
+K_MSGQ_DEFINE_STATIC_TYPE(dns_infoq, struct dns_addrinfo, CONFIG_NET_SHELL_DNS_RESOLVER_QUEUE_SIZE);
 
 static void dns_service_cb(enum dns_resolve_status status,
 			   struct dns_addrinfo *info,

--- a/subsys/net/lib/shell/events.c
+++ b/subsys/net/lib/shell/events.c
@@ -49,8 +49,7 @@ struct event_msg {
 	uint8_t data[MAX_EVENT_INFO_SIZE];
 };
 
-K_MSGQ_DEFINE(event_mon_msgq, sizeof(struct event_msg),
-	      CONFIG_NET_MGMT_EVENT_QUEUE_SIZE, sizeof(intptr_t));
+K_MSGQ_DEFINE_STATIC_TYPE(event_mon_msgq, struct event_msg, CONFIG_NET_MGMT_EVENT_QUEUE_SIZE);
 
 static void event_handler(struct net_mgmt_event_callback *cb,
 			  uint64_t mgmt_event, struct net_if *iface)

--- a/subsys/usb/device_next/class/usbd_msc.c
+++ b/subsys/usb/device_next/class/usbd_msc.c
@@ -79,7 +79,7 @@ struct msc_event {
 };
 
 /* Each instance has 2 endpoints and can receive bulk only reset command */
-K_MSGQ_DEFINE(msc_msgq, sizeof(struct msc_event), MSC_NUM_INSTANCES * 3, 4);
+K_MSGQ_DEFINE_STATIC_TYPE(msc_msgq, struct msc_event, MSC_NUM_INSTANCES * 3);
 
 /* Make supported vendor request visible for the device stack */
 static const struct usbd_cctx_vendor_req msc_bot_vregs =

--- a/subsys/usb/device_next/usbd_core.c
+++ b/subsys/usb/device_next/usbd_core.c
@@ -28,8 +28,7 @@ LOG_MODULE_REGISTER(usbd_core, CONFIG_USBD_LOG_LEVEL);
 static K_KERNEL_STACK_DEFINE(usbd_stack, CONFIG_USBD_THREAD_STACK_SIZE);
 static struct k_thread usbd_thread_data;
 
-K_MSGQ_DEFINE(usbd_msgq, sizeof(struct udc_event),
-	      CONFIG_USBD_MAX_UDC_MSG, sizeof(uint32_t));
+K_MSGQ_DEFINE_STATIC_TYPE(usbd_msgq, struct udc_event, CONFIG_USBD_MAX_UDC_MSG);
 
 static int usbd_event_carrier(const struct device *dev,
 			      const struct udc_event *const event)

--- a/subsys/usb/host/usbh_core.c
+++ b/subsys/usb/host/usbh_core.c
@@ -24,11 +24,8 @@ static struct k_thread usbh_thread_data;
 static K_KERNEL_STACK_DEFINE(usbh_bus_stack, CONFIG_USBH_STACK_SIZE);
 static struct k_thread usbh_bus_thread_data;
 
-K_MSGQ_DEFINE(usbh_msgq, sizeof(struct uhc_event),
-	      CONFIG_USBH_MAX_UHC_MSG, sizeof(uint32_t));
-
-K_MSGQ_DEFINE(usbh_bus_msgq, sizeof(struct uhc_event),
-	      CONFIG_USBH_MAX_UHC_MSG, sizeof(uint32_t));
+K_MSGQ_DEFINE_STATIC_TYPE(usbh_msgq, struct uhc_event, CONFIG_USBH_MAX_UHC_MSG);
+K_MSGQ_DEFINE_STATIC_TYPE(usbh_bus_msgq, struct uhc_event, CONFIG_USBH_MAX_UHC_MSG);
 
 static int usbh_event_carrier(const struct device *dev,
 			      const struct uhc_event *const event)

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_define.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_define.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Cesar Vandevelde
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#include "test_msgq.h"
+
+struct typed_msgq_msg {
+	uint8_t num1;
+	uint64_t num2;
+};
+
+K_MSGQ_DEFINE(kmsgq_public, MSG_SIZE, MSGQ_LEN, 4);
+K_MSGQ_DEFINE_STATIC(kmsgq_static, MSG_SIZE, MSGQ_LEN, 4);
+K_MSGQ_DEFINE_TYPE(kmsgq_type, struct typed_msgq_msg, MSGQ_LEN);
+K_MSGQ_DEFINE_STATIC_TYPE(kmsgq_static_type, struct typed_msgq_msg, MSGQ_LEN);
+
+/**
+ * @brief Test public-scope message queue defined at compile time
+ *
+ * @details
+ * - Verify that the free count is equal to the queue length.
+ * - Verify that the used count equals 0.
+ * - Verify that the message size is correct.
+ *
+ * @see K_MSGQ_DEFINE()
+ */
+ZTEST(msgq_api, test_define_public)
+{
+	zassert_equal(k_msgq_num_free_get(&kmsgq_public), MSGQ_LEN);
+	zassert_equal(k_msgq_num_used_get(&kmsgq_public), 0);
+	zassert_equal(kmsgq_public.msg_size, MSG_SIZE);
+}
+
+/**
+ * @brief Test static-scope message queue defined at compile time
+ *
+ * @details
+ * - Verify that the free count is equal to the queue length.
+ * - Verify that the used count equals 0.
+ * - Verify that the message size is correct.
+ *
+ * @see K_MSGQ_DEFINE_STATIC()
+ */
+ZTEST(msgq_api, test_define_static)
+{
+	zassert_equal(k_msgq_num_free_get(&kmsgq_static), MSGQ_LEN);
+	zassert_equal(k_msgq_num_used_get(&kmsgq_static), 0);
+	zassert_equal(kmsgq_static.msg_size, MSG_SIZE);
+}
+
+/**
+ * @brief Test public-scope, typed message queue defined at compile time
+ *
+ * @details
+ * - Verify that the free count is equal to the queue length.
+ * - Verify that the used count equals 0.
+ * - Verify that the message size is correct.
+ *
+ * @see K_MSGQ_DEFINE_TYPE()
+ */
+ZTEST(msgq_api, test_define_type)
+{
+	zassert_equal(k_msgq_num_free_get(&kmsgq_type), MSGQ_LEN);
+	zassert_equal(k_msgq_num_used_get(&kmsgq_type), 0);
+	zassert_equal(kmsgq_type.msg_size, sizeof(struct typed_msgq_msg));
+}
+
+/**
+ * @brief Test static-scope, typed message queue defined at compile time
+ *
+ * @details
+ * - Verify that the free count is equal to the queue length.
+ * - Verify that the used count equals 0.
+ * - Verify that the message size is correct.
+ *
+ * @see K_MSGQ_DEFINE_STATIC_TYPE()
+ */
+ZTEST(msgq_api, test_define_static_type)
+{
+	zassert_equal(k_msgq_num_free_get(&kmsgq_static_type), MSGQ_LEN);
+	zassert_equal(k_msgq_num_used_get(&kmsgq_static_type), 0);
+	zassert_equal(kmsgq_static_type.msg_size, sizeof(struct typed_msgq_msg));
+}


### PR DESCRIPTION
The `K_MSGQ_DEFINE()` macro defines `struct k_msgq` variables in the global scope. There currently is no way to instantiate static-scope message queues at compile-time. `static K_MSGQ_DEFINE(...)` does not work because the macro defines 2 variables. This means that all in-tree message queues are globally-scoped, leading to namespace collisions in Zephyr and downstream users, especially because users tend to use generic queue names (e.g. `rx_msgq`, `msgq_##n`, ...).

Most in-tree users define a private `k_msgq` with structure messages to buffer data between different execution contexts. This pull request introduces a number of `K_MSGQ_DEFINE_XXX()` macros to accommodate this pattern.

* `K_MSGQ_DEFINE_STATIC()` -- Same as `K_MSGQ_DEFINE()`, but with file-local scope.
* `K_MSGQ_DEFINE_TYPE()` -- Automatically sets message size and alignment, based on given message type.
* `K_MSGQ_DEFINE_STATIC_TYPE()` -- Combines both of the above.

These new macros are patterned after the `K_MEM_SLAB_DEFINE` series of macros. This pull request does several things:

1. Defines the new macros.
2. Adds basic test coverage. The tests only check if compile-time defined instances have the expected size/capacity.
3. Treewide: replace `K_MSGQ_DEFINE()` with `K_MSGQ_DEFINE_STATIC()` or `K_MSGQ_DEFINE_STATIC_TYPE()` where appropriate.