### PR TITLE
samples: bluetooth: encrypted_advertising: remove k_sleep from callback

### DIFF
--- a/samples/bluetooth/encrypted_advertising/central/src/central_ead.c
+++ b/samples/bluetooth/encrypted_advertising/central/src/central_ead.c
@@ -169,7 +169,7 @@ static int start_scan(bool connect)
 	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, connect ? connect_device_found : device_found);
 	if (err) {
 		LOG_DBG("Scanning failed to start (err %d)", err);
-		return -1;
+		return err;
 	}
 
 	LOG_DBG("Scanning started.");
@@ -222,7 +222,7 @@ static int gatt_read(struct bt_conn *conn, const struct bt_uuid *uuid, size_t re
 	err = bt_gatt_read(conn, &params);
 	if (err) {
 		LOG_DBG("GATT read failed (err %d)", err);
-		return -1;
+		return err;
 	}
 
 	await_signal(&gatt_read_signal);
@@ -242,7 +242,7 @@ static int gatt_read(struct bt_conn *conn, const struct bt_uuid *uuid, size_t re
 		err = bt_gatt_read(conn, &params);
 		if (err) {
 			LOG_DBG("GATT read failed (err %d)", err);
-			return -1;
+			return err;
 		}
 
 		await_signal(&gatt_read_signal);
@@ -285,7 +285,7 @@ static int gatt_discover_primary_service(struct bt_conn *conn, const struct bt_u
 	err = bt_gatt_discover(conn, &params);
 	if (err) {
 		LOG_DBG("Primary service discover failed (err %d)", err);
-		return -1;
+		return err;
 	}
 
 	await_signal(&gatt_disc_signal);
@@ -383,7 +383,7 @@ static int init_bt(void)
 	err = bt_enable(NULL);
 	if (err) {
 		LOG_ERR("Bluetooth init failed (err %d)", err);
-		return -1;
+		return err;
 	}
 
 	LOG_DBG("Bluetooth initialized");
@@ -409,7 +409,7 @@ static int init_bt(void)
 
 	err = bt_conn_auth_cb_register(&central_auth_cb);
 	if (err) {
-		return -1;
+		return err;
 	}
 
 	return 0;
@@ -432,21 +432,21 @@ int run_central_sample(int get_passkey_confirmation(struct bt_conn *conn),
 	/* Initialize Bluetooth and callbacks */
 	err = init_bt();
 	if (err) {
-		return -1;
+		return err;
 	}
 
 	/* Start scan and connect to our peripheral */
 	connect = true;
 	err = start_scan(connect);
 	if (err) {
-		return -2;
+		return err;
 	}
 
 	/* Update connection security level */
 	err = bt_conn_set_security(default_conn, BT_SECURITY_L4);
 	if (err) {
 		LOG_ERR("Failed to set security (err %d)", err);
-		return -3;
+		return err;
 	}
 
 	await_signal(&passkey_enter_signal);
@@ -454,7 +454,7 @@ int run_central_sample(int get_passkey_confirmation(struct bt_conn *conn),
 	err = get_passkey_confirmation(default_conn);
 	if (err) {
 		LOG_ERR("Security update failed");
-		return -4;
+		return err;
 	}
 
 	/* Locate the primary service */
@@ -462,7 +462,7 @@ int run_central_sample(int get_passkey_confirmation(struct bt_conn *conn),
 					    &end_handle);
 	if (err) {
 		LOG_ERR("Service not found (err %d)", err);
-		return -5;
+		return err;
 	}
 
 	/* Read the Key Material characteristic */
@@ -470,7 +470,7 @@ int run_central_sample(int get_passkey_confirmation(struct bt_conn *conn),
 			(uint8_t *)&keymat);
 	if (err) {
 		LOG_ERR("GATT read failed (err %d)", err);
-		return -6;
+		return err;
 	}
 
 	LOG_HEXDUMP_DBG(keymat.session_key, BT_EAD_KEY_SIZE, "Session Key");
@@ -484,13 +484,13 @@ int run_central_sample(int get_passkey_confirmation(struct bt_conn *conn),
 	err = bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 	if (err) {
 		LOG_ERR("Failed to disconnect.");
-		return -7;
+		return err;
 	}
 
 	connect = false;
 	err = start_scan(connect);
 	if (err) {
-		return -2;
+		return err;
 	}
 
 	return 0;

--- a/samples/bluetooth/encrypted_advertising/central/src/main.c
+++ b/samples/bluetooth/encrypted_advertising/central/src/main.c
@@ -2,6 +2,8 @@
 
 /*
  * Copyright (c) 2023 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -45,10 +47,7 @@ static struct k_poll_signal button_pressed_signal;
 static void button_pressed(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
 {
 	LOG_DBG("Button pressed...");
-
 	k_poll_signal_raise(&button_pressed_signal, 0);
-	k_sleep(K_SECONDS(1));
-	k_poll_signal_reset(&button_pressed_signal);
 }
 
 static int get_passkey_confirmation(struct bt_conn *conn)
@@ -63,12 +62,14 @@ static int get_passkey_confirmation(struct bt_conn *conn)
 	err = bt_conn_auth_passkey_confirm(conn);
 	if (err) {
 		LOG_DBG("Failed to confirm passkey.");
-		return -1;
+	} else {
+		printk("Passkey confirmed.\n");
 	}
 
-	printk("Passkey confirmed.\n");
+	k_sleep(K_SECONDS(1));
+	k_poll_signal_reset(&button_pressed_signal);
 
-	return 0;
+	return err ? -1 : 0;
 }
 
 static int setup_btn(void)

--- a/samples/bluetooth/encrypted_advertising/central/src/main.c
+++ b/samples/bluetooth/encrypted_advertising/central/src/main.c
@@ -69,7 +69,7 @@ static int get_passkey_confirmation(struct bt_conn *conn)
 	k_sleep(K_SECONDS(1));
 	k_poll_signal_reset(&button_pressed_signal);
 
-	return err ? -1 : 0;
+	return err;
 }
 
 static int setup_btn(void)
@@ -80,21 +80,21 @@ static int setup_btn(void)
 
 	if (!gpio_is_ready_dt(&button)) {
 		LOG_ERR("Error: button device %s is not ready", button.port->name);
-		return -1;
+		return -ENODEV;
 	}
 
 	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
 	if (ret != 0) {
 		LOG_ERR("Error %d: failed to configure %s pin %d", ret, button.port->name,
 			button.pin);
-		return -1;
+		return ret;
 	}
 
 	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret != 0) {
 		LOG_ERR("Error %d: failed to configure interrupt on %s pin %d", ret,
 			button.port->name, button.pin);
-		return -1;
+		return ret;
 	}
 
 	gpio_init_callback(&button_cb_data, button_pressed, BIT(button.pin));

--- a/samples/bluetooth/encrypted_advertising/peripheral/src/main.c
+++ b/samples/bluetooth/encrypted_advertising/peripheral/src/main.c
@@ -63,7 +63,7 @@ static int get_passkey_confirmation(struct bt_conn *conn)
 	k_sleep(K_SECONDS(1));
 	k_poll_signal_reset(&button_pressed_signal);
 
-	return err ? -1 : 0;
+	return err;
 }
 
 static int setup_btn(void)
@@ -74,21 +74,21 @@ static int setup_btn(void)
 
 	if (!gpio_is_ready_dt(&button)) {
 		LOG_ERR("Error: button device %s is not ready", button.port->name);
-		return -1;
+		return -ENODEV;
 	}
 
 	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
 	if (ret != 0) {
 		LOG_ERR("Error %d: failed to configure %s pin %d", ret, button.port->name,
 			button.pin);
-		return -1;
+		return ret;
 	}
 
 	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret != 0) {
 		LOG_ERR("Error %d: failed to configure interrupt on %s pin %d", ret,
 			button.port->name, button.pin);
-		return -1;
+		return ret;
 	}
 
 	gpio_init_callback(&button_cb_data, button_pressed, BIT(button.pin));

--- a/samples/bluetooth/encrypted_advertising/peripheral/src/main.c
+++ b/samples/bluetooth/encrypted_advertising/peripheral/src/main.c
@@ -2,6 +2,8 @@
 
 /*
  * Copyright (c) 2023 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -39,10 +41,7 @@ static struct k_poll_signal button_pressed_signal;
 static void button_pressed(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
 {
 	LOG_DBG("Button pressed...");
-
 	k_poll_signal_raise(&button_pressed_signal, 0);
-	k_sleep(K_SECONDS(1));
-	k_poll_signal_reset(&button_pressed_signal);
 }
 
 static int get_passkey_confirmation(struct bt_conn *conn)
@@ -57,12 +56,14 @@ static int get_passkey_confirmation(struct bt_conn *conn)
 	err = bt_conn_auth_passkey_confirm(conn);
 	if (err) {
 		LOG_DBG("Failed to confirm passkey.");
-		return -1;
+	} else {
+		printk("Passkey confirmed.\n");
 	}
 
-	printk("Passkey confirmed.\n");
+	k_sleep(K_SECONDS(1));
+	k_poll_signal_reset(&button_pressed_signal);
 
-	return 0;
+	return err ? -1 : 0;
 }
 
 static int setup_btn(void)

--- a/samples/bluetooth/encrypted_advertising/peripheral/src/peripheral_ead.c
+++ b/samples/bluetooth/encrypted_advertising/peripheral/src/peripheral_ead.c
@@ -64,7 +64,7 @@ static int update_ad_data(struct bt_le_ext_adv *adv)
 	err = bt_ead_encrypt(mk.session_key, mk.iv, ad_1, size_ad_1, ead_1);
 	if (err != 0) {
 		LOG_ERR("Error during first encryption");
-		return -1;
+		return err;
 	}
 
 	/* Encrypt ad structures 3 and 4 */
@@ -81,7 +81,7 @@ static int update_ad_data(struct bt_le_ext_adv *adv)
 	err = bt_ead_encrypt(mk.session_key, mk.iv, ad_3_4, size_ad_3_4, ead_2);
 	if (err != 0) {
 		LOG_ERR("Error during second encryption");
-		return -1;
+		return err;
 	}
 
 	/* Concatenate and update the advertising data */
@@ -97,7 +97,7 @@ static int update_ad_data(struct bt_le_ext_adv *adv)
 	err = bt_le_ext_adv_set_data(adv, ad_structs, ARRAY_SIZE(ad_structs), NULL, 0);
 	if (err) {
 		LOG_ERR("Failed to set advertising data (%d)", err);
-		return -1;
+		return err;
 	}
 
 	LOG_DBG("Advertising Data Updated");
@@ -134,7 +134,7 @@ static int create_adv(struct bt_le_ext_adv **adv)
 	err = bt_le_ext_adv_create(BT_LE_EXT_ADV_CONN, &adv_cb, adv);
 	if (err) {
 		LOG_ERR("Failed to create advertiser (%d)", err);
-		return -1;
+		return err;
 	}
 
 	return 0;
@@ -154,7 +154,7 @@ static int start_adv(struct bt_le_ext_adv *adv)
 	err = bt_le_ext_adv_start(adv, &start_params);
 	if (err) {
 		LOG_ERR("Failed to start advertiser (%d)", err);
-		return -1;
+		return err;
 	}
 
 	LOG_DBG("Advertiser started");
@@ -169,13 +169,13 @@ static int stop_and_delete_adv(struct bt_le_ext_adv *adv)
 	err = bt_le_ext_adv_stop(adv);
 	if (err) {
 		LOG_ERR("Failed to stop advertiser (err %d)", err);
-		return -1;
+		return err;
 	}
 
 	err = bt_le_ext_adv_delete(adv);
 	if (err) {
 		LOG_ERR("Failed to delete advertiser (err %d)", err);
-		return -1;
+		return err;
 	}
 
 	return 0;
@@ -247,7 +247,7 @@ static int init_bt(void)
 	err = bt_enable(NULL);
 	if (err) {
 		LOG_ERR("Bluetooth init failed (err %d)", err);
-		return -1;
+		return err;
 	}
 
 	LOG_DBG("Bluetooth initialized");
@@ -273,7 +273,7 @@ static int init_bt(void)
 	err = bt_conn_auth_cb_register(&peripheral_auth_cb);
 	if (err) {
 		LOG_ERR("Failed to register bt_conn_auth_cb (err %d)", err);
-		return -1;
+		return err;
 	}
 
 	return 0;
@@ -286,23 +286,23 @@ int run_peripheral_sample(int get_passkey_confirmation(struct bt_conn *conn))
 
 	err = init_bt();
 	if (err) {
-		return -1;
+		return err;
 	}
 
 	/* Setup advertiser */
 	err = create_adv(&adv);
 	if (err) {
-		return -2;
+		return err;
 	}
 
 	err = start_adv(adv);
 	if (err) {
-		return -3;
+		return err;
 	}
 
 	err = set_ad_data(adv);
 	if (err) {
-		return -4;
+		return err;
 	}
 
 	/* Wait for the peer to update security */
@@ -311,7 +311,7 @@ int run_peripheral_sample(int get_passkey_confirmation(struct bt_conn *conn))
 	err = get_passkey_confirmation(default_conn);
 	if (err) {
 		LOG_ERR("Failure during security update");
-		return -5;
+		return err;
 	}
 
 	/* Wait for the peer to disconnect */
@@ -320,12 +320,12 @@ int run_peripheral_sample(int get_passkey_confirmation(struct bt_conn *conn))
 	/* Restart advertising */
 	err = start_adv(adv);
 	if (err) {
-		return -3;
+		return err;
 	}
 
 	err = set_ad_data(adv);
 	if (err) {
-		return -4;
+		return err;
 	}
 
 	/* Wait 10s before stopping and deleting the advertiser */
@@ -333,7 +333,7 @@ int run_peripheral_sample(int get_passkey_confirmation(struct bt_conn *conn))
 
 	err = stop_and_delete_adv(adv);
 	if (err) {
-		return -6;
+		return err;
 	}
 
 	return 0;


### PR DESCRIPTION
  1. Fix ISR Kernel Panic (Remove  k_sleep )

-  The original code called  k_sleep()  inside the hardware button callback. On standard ARM boards, this callback executes in an Interrupt Service Routine (ISR) context. Sleeping inside an ISR violates Zephyr's kernel rules and causes an immediate kernel panic  (assertion failure). The original author likely tested with assertions disabled ( CONFIG_ASSERT=n ), which masked the issue.
- This commit fixes the architectural flaw by raising a signal ( k_poll_signal_raise ) and deferring all debounce and wait logic to the main application thread. Passkey confirmation prints are also refactored.

Fixes: #112181 
  

 2. Replace Hardcoded Returns with POSIX Errors

-   Returning hardcoded negative numbers (like  -1 ,  -2 , etc.) as error codes is a bad practice in Zephyr. For example,  -1  translates directly to  -EPERM  (Operation Not Permitted), which is misleading. This commit replaces all hardcoded return values across the  encrypted_advertising  samples with proper POSIX error codes (e.g.,  -ENODEV ) or correctly propagates the original error code returned by the failing function.


