### PR TITLE
TF-M, MBedTLS and crypto: Diamond include for non-local header files

### DIFF
--- a/modules/trusted-firmware-m/interface/interface.c
+++ b/modules/trusted-firmware-m/interface/interface.c
@@ -88,7 +88,7 @@ uint32_t tfm_ns_interface_init(void)
 
 
 #if defined(TFM_PSA_API)
-#include "psa_manifest/sid.h"
+#include <psa_manifest/sid.h>
 #endif /* TFM_PSA_API */
 
 static int ns_interface_init(void)

--- a/modules/trusted-firmware-m/nordic/src/tfm_hal_platform.c
+++ b/modules/trusted-firmware-m/nordic/src/tfm_hal_platform.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "tfm_hal_defs.h"
-#include "tfm_hal_platform_common.h"
+#include <tfm_hal_defs.h>
+#include <tfm_hal_platform_common.h>
 
 enum tfm_hal_status_t tfm_hal_platform_init(void)
 {

--- a/modules/trusted-firmware-m/nordic/src/tfm_platform_system.c
+++ b/modules/trusted-firmware-m/nordic/src/tfm_platform_system.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "platform/include/tfm_platform_system.h"
-#include "cmsis.h"
-#include "tfm_platform_hal_ioctl.h"
-#include "tfm_ioctl_core_api.h"
+#include <platform/include/tfm_platform_system.h>
+#include <cmsis.h>
+#include <tfm_platform_hal_ioctl.h>
+#include <tfm_ioctl_core_api.h>
 
 void tfm_platform_hal_system_reset(void)
 {

--- a/modules/trusted-firmware-m/src/reboot.c
+++ b/modules/trusted-firmware-m/src/reboot.c
@@ -5,10 +5,10 @@
  */
 #include <zephyr/kernel.h>
 
-#include "tfm_platform_api.h"
+#include <tfm_platform_api.h>
 
 #if defined(TFM_PSA_API)
-#include "psa_manifest/sid.h"
+#include <psa_manifest/sid.h>
 #endif /* TFM_PSA_API */
 
 /**

--- a/samples/tfm_integration/psa_crypto/src/main.c
+++ b/samples/tfm_integration/psa_crypto/src/main.c
@@ -8,7 +8,7 @@
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/logging/log.h>
 
-#include "tfm_ns_interface.h"
+#include <tfm_ns_interface.h>
 #include "psa_attestation.h"
 #include "psa_crypto.h"
 #include "util_app_cfg.h"

--- a/samples/tfm_integration/psa_crypto/src/psa_attestation.c
+++ b/samples/tfm_integration/psa_crypto/src/psa_attestation.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <zephyr/logging/log.h>
 
-#include "psa/initial_attestation.h"
+#include <psa/initial_attestation.h>
 #include "psa_attestation.h"
 #include "util_app_log.h"
 #include "util_sformat.h"

--- a/samples/tfm_integration/psa_crypto/src/psa_attestation.h
+++ b/samples/tfm_integration/psa_crypto/src/psa_attestation.h
@@ -6,7 +6,7 @@
 
 #include <stdarg.h>
 
-#include "psa/error.h"
+#include <psa/error.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/samples/tfm_integration/psa_crypto/src/psa_crypto.c
+++ b/samples/tfm_integration/psa_crypto/src/psa_crypto.c
@@ -11,9 +11,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/data/json.h>
 
-#include "mbedtls/pk.h"
-#include "mbedtls/x509.h"
-#include "mbedtls/x509_csr.h"
+#include <mbedtls/pk.h>
+#include <mbedtls/x509.h>
+#include <mbedtls/x509_csr.h>
 
 #include "psa_crypto.h"
 #include "util_app_log.h"

--- a/samples/tfm_integration/psa_crypto/src/psa_crypto.h
+++ b/samples/tfm_integration/psa_crypto/src/psa_crypto.h
@@ -6,8 +6,8 @@
 
 #include <zephyr/kernel.h>
 
-#include "psa/crypto.h"
-#include "psa/error.h"
+#include <psa/crypto.h>
+#include <psa/error.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/samples/tfm_integration/psa_crypto/src/util_app_cfg.c
+++ b/samples/tfm_integration/psa_crypto/src/util_app_cfg.c
@@ -7,8 +7,8 @@
 #include <string.h>
 #include <zephyr/logging/log.h>
 
-#include "psa/error.h"
-#include "psa/protected_storage.h"
+#include <psa/error.h>
+#include <psa/protected_storage.h>
 #include "util_app_cfg.h"
 #include "util_app_log.h"
 

--- a/samples/tfm_integration/psa_crypto/src/util_app_cfg.h
+++ b/samples/tfm_integration/psa_crypto/src/util_app_cfg.h
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 
-#include "psa/error.h"
+#include <psa/error.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/samples/tfm_integration/psa_crypto/src/util_app_log.c
+++ b/samples/tfm_integration/psa_crypto/src/util_app_log.c
@@ -7,7 +7,7 @@
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/logging/log.h>
 
-#include "psa/crypto.h"
+#include <psa/crypto.h>
 #include "util_app_log.h"
 
 LOG_MODULE_REGISTER(app, CONFIG_LOG_DEFAULT_LEVEL);

--- a/samples/tfm_integration/psa_crypto/src/util_app_log.h
+++ b/samples/tfm_integration/psa_crypto/src/util_app_log.h
@@ -6,9 +6,9 @@
 
 #include <stdarg.h>
 
-#include "psa/error.h"
-#include "psa/initial_attestation.h"
-#include "psa/protected_storage.h"
+#include <psa/error.h>
+#include <psa/initial_attestation.h>
+#include <psa/protected_storage.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/samples/tfm_integration/tfm_ipc/src/main.c
+++ b/samples/tfm_integration/tfm_ipc/src/main.c
@@ -7,10 +7,10 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 
-#include "tfm_ns_interface.h"
+#include <tfm_ns_interface.h>
 #ifdef TFM_PSA_API
-#include "psa_manifest/sid.h"
-#include "psa/crypto.h"
+#include <psa_manifest/sid.h>
+#include <psa/crypto.h>
 #endif
 
 /**

--- a/samples/tfm_integration/tfm_secure_partition/dummy_partition/dummy_partition.c
+++ b/samples/tfm_integration/tfm_secure_partition/dummy_partition/dummy_partition.c
@@ -8,8 +8,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "psa/service.h"
-#include "psa_manifest/tfm_dummy_partition.h"
+#include <psa/service.h>
+#include <psa_manifest/tfm_dummy_partition.h>
 
 #define NUM_SECRETS 5
 

--- a/samples/tfm_integration/tfm_secure_partition/src/dummy_partition.c
+++ b/samples/tfm_integration/tfm_secure_partition/src/dummy_partition.c
@@ -8,8 +8,8 @@
 
 #include "dummy_partition.h"
 
-#include "psa/client.h"
-#include "psa_manifest/sid.h"
+#include <psa/client.h>
+#include <psa_manifest/sid.h>
 
 psa_status_t dp_secret_digest(uint32_t secret_index,
 			void *p_digest,

--- a/tests/crypto/secp256r1/src/main.c
+++ b/tests/crypto/secp256r1/src/main.c
@@ -16,9 +16,9 @@
 #include <zephyr/ztest.h>
 
 #if defined(CONFIG_MBEDTLS_PSA_P256M_DRIVER_RAW)
-#include "p256-m.h"
+#include <p256-m.h>
 #else /* CONFIG_MBEDTLS_PSA_P256M_DRIVER_RAW */
-#include "psa/crypto.h"
+#include <psa/crypto.h>
 #endif /* CONFIG_MBEDTLS_PSA_P256M_DRIVER_RAW */
 
 #if defined(CONFIG_MBEDTLS_PSA_P256M_DRIVER_RAW)

--- a/tests/modules/tf-m/regression/src/main.c
+++ b/tests/modules/tf-m/regression/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include "non_secure_suites.h"
+#include <non_secure_suites.h>
 
 int main(void)
 {


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various TF-M, Mbed TLS and crypto related paths and manually selecting the applicable changes:
```
$ ./scripts/check_quoted_includes.py --apply modules/trusted-firmware-m
