### PR TITLE
nxp: Diamond include for non-local header files

### DIFF
--- a/boards/nxp/frdm_imxrt1186/xip/frdmimxrt1186_flexspi_nor_config.h
+++ b/boards/nxp/frdm_imxrt1186/xip/frdmimxrt1186_flexspi_nor_config.h
@@ -7,7 +7,7 @@
 #ifndef __FRDMIMXRT1186_FLEXSPI_NOR_CONFIG__
 #define __FRDMIMXRT1186_FLEXSPI_NOR_CONFIG__
 
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */
 #define FLEXSPI_CFG_BLK_VERSION (0x56010400UL) /* V1.4.0 */

--- a/boards/nxp/frdm_mcxe31b/boot_header/boot_header.c
+++ b/boards/nxp/frdm_mcxe31b/boot_header/boot_header.c
@@ -5,7 +5,7 @@
  */
 
 #include "boot_header.h"
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /******************************************************************************
  *  External references

--- a/boards/nxp/frdm_mcxe31b/boot_header/boot_header.h
+++ b/boards/nxp/frdm_mcxe31b/boot_header/boot_header.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_BOOT_HEADER_H_
 #define ZEPHYR_INCLUDE_BOOT_HEADER_H_
 
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /******************************************************************************
  * Configuration structure definition                                         *

--- a/boards/nxp/frdm_mcxn236/board.c
+++ b/boards/nxp/frdm_mcxn236/board.c
@@ -9,8 +9,8 @@
 #include <fsl_spc.h>
 #include <soc.h>
 #if CONFIG_USB_DC_NXP_EHCI
-#include "usb_phy.h"
-#include "usb.h"
+#include <usb_phy.h>
+#include <usb.h>
 
 /* USB PHY configuration */
 #define BOARD_USB_PHY_D_CAL     (0x04U)

--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -9,8 +9,8 @@
 #include <fsl_spc.h>
 #include <soc.h>
 #if CONFIG_USB_DC_NXP_EHCI
-#include "usb_phy.h"
-#include "usb.h"
+#include <usb_phy.h>
+#include <usb.h>
 
 /* USB PHY configuration */
 #define BOARD_USB_PHY_D_CAL     (0x04U)

--- a/boards/nxp/frdm_mcxn947/xip/mcxn_flexspi_nor_config.h
+++ b/boards/nxp/frdm_mcxn947/xip/mcxn_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mcx_nx4x_evk/board.c
+++ b/boards/nxp/mcx_nx4x_evk/board.c
@@ -9,8 +9,8 @@
 #include <fsl_spc.h>
 #include <soc.h>
 #if CONFIG_USB_DC_NXP_EHCI
-#include "usb_phy.h"
-#include "usb.h"
+#include <usb_phy.h>
+#include <usb.h>
 
 /* USB PHY configuration */
 #define BOARD_USB_PHY_D_CAL     (0x04U)

--- a/boards/nxp/mcx_nx4x_evk/xip/mcxn_flexspi_nor_config.h
+++ b/boards/nxp/mcx_nx4x_evk/xip/mcxn_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt1010_evk/xip/evkmimxrt1010_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1010_evk/xip/evkmimxrt1010_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt1015_evk/xip/evkmimxrt1015_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1015_evk/xip/evkmimxrt1015_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt1020_evk/xip/evkmimxrt1020_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1020_evk/xip/evkmimxrt1020_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt1024_evk/xip/evkmimxrt1024_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1024_evk/xip/evkmimxrt1024_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt1040_evk/xip/evkmimxrt1040_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1040_evk/xip/evkmimxrt1040_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1050_evk/xip/evkbimxrt1050_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt1060_evk/xip/evkbmimxrt1060_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1060_evk/xip/evkbmimxrt1060_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt1060_evk/xip/evkmimxrt1060_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1060_evk/xip/evkmimxrt1060_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt1064_evk/xip/evkmimxrt1064_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1064_evk/xip/evkmimxrt1064_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt1160_evk/xip/evkmimxrt1160_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1160_evk/xip/evkmimxrt1160_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt1170_evk/xip/evkbmimxrt1170_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1170_evk/xip/evkbmimxrt1170_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt1170_evk/xip/evkmimxrt1170_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1170_evk/xip/evkmimxrt1170_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt1180_evk/xip/evkmimxrt1180_flexspi_nor_config.h
+++ b/boards/nxp/mimxrt1180_evk/xip/evkmimxrt1180_flexspi_nor_config.h
@@ -8,7 +8,7 @@
 #ifndef EVKMIMXRT1180_FLEXSPI_NOR_CONFIG_
 #define EVKMIMXRT1180_FLEXSPI_NOR_CONFIG_
 
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */
 #define FLEXSPI_CFG_BLK_VERSION (0x56010400UL) /* V1.4.0 */

--- a/boards/nxp/mimxrt595_evk/board.c
+++ b/boards/nxp/mimxrt595_evk/board.c
@@ -4,13 +4,13 @@
  */
 
 #include <zephyr/init.h>
-#include "fsl_power.h"
-#include "fsl_inputmux.h"
+#include <fsl_power.h>
+#include <fsl_inputmux.h>
 #include <zephyr/pm/policy.h>
 #include "board.h"
 
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_XIP
-#include "flash_clock_setup.h"
+#include <flash_clock_setup.h>
 #endif
 
 /* OTP fuse index. */

--- a/boards/nxp/mimxrt595_evk/flash_config/flash_config.h
+++ b/boards/nxp/mimxrt595_evk/flash_config/flash_config.h
@@ -9,7 +9,7 @@
 #define FLASH_CONFIG_H_
 
 #include <stdint.h>
-#include "fsl_iap.h"
+#include <fsl_iap.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/mimxrt685_evk/flash_config/flash_config.h
+++ b/boards/nxp/mimxrt685_evk/flash_config/flash_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLASH_CONFIG_BLOCK_TAG     (0x42464346)

--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -4,8 +4,8 @@
  */
 #include <zephyr/init.h>
 #include <zephyr/device.h>
-#include "fsl_power.h"
-#include "fsl_clock.h"
+#include <fsl_power.h>
+#include <fsl_clock.h>
 #include <soc.h>
 #include <fsl_glikey.h>
 

--- a/boards/nxp/mimxrt700_evk/flash_config/flash_config.h
+++ b/boards/nxp/mimxrt700_evk/flash_config/flash_config.h
@@ -7,7 +7,7 @@
 #ifndef FLASH_CONFIG_H_
 #define FLASH_CONFIG_H_
 #include <stdint.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* XSPI memory config block related definitions */
 #define FC_XSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/boards/nxp/vmu_rt1170/xip/evkmimxrt1170_flexspi_nor_config.h
+++ b/boards/nxp/vmu_rt1170/xip/evkmimxrt1170_flexspi_nor_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* FLEXSPI memory config block related definitions */
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL) /* ascii "FCFB" Big Endian */

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/bt_controller/hci_nxp_sco.c
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/bt_controller/hci_nxp_sco.c
@@ -19,10 +19,10 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_nxp_sco);
 
-#include "common/bt_str.h"
+#include <common/bt_str.h>
 
-#include "host/conn_internal.h"
-#include "host/classic/sco_internal.h"
+#include <host/conn_internal.h>
+#include <host/classic/sco_internal.h>
 
 #define NXP_VS_CMD(_opcode, _flags, _data...) \
 	{ \

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/usb_device_config.h
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/usb_device_config.h
@@ -8,7 +8,7 @@
 #define __USB_DEVICE_CONFIG_H__
 
 #include <zephyr/devicetree.h>
-#include "usb.h"
+#include <usb.h>
 
 /******************************************************************************
  * Definitions

--- a/samples/boards/nxp/adsp/number_crunching/src/cmsis_dsp_wrapper.c
+++ b/samples/boards/nxp/adsp/number_crunching/src/cmsis_dsp_wrapper.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <stdio.h>
 
-#include "arm_math.h"
+#include <arm_math.h>
 
 void vec_sum_int16(const int16_t *in_a, const int16_t *in_b, int16_t *out, uint32_t length)
 {

--- a/samples/boards/nxp/adsp/number_crunching/src/main.c
+++ b/samples/boards/nxp/adsp/number_crunching/src/main.c
@@ -12,7 +12,7 @@
 #include <zephyr/kernel.h>
 #include <stdio.h>
 
-#include "math_ops.h"
+#include <math_ops.h>
 
 int main(void)
 {

--- a/samples/boards/nxp/adsp/number_crunching/src/math_ops.c
+++ b/samples/boards/nxp/adsp/number_crunching/src/math_ops.c
@@ -7,8 +7,8 @@
 #include <zephyr/kernel.h>
 #include <stdlib.h>
 
-#include "math_ops.h"
-#include "input.h"
+#include <math_ops.h>
+#include <input.h>
 
 static int start, stop;
 

--- a/samples/boards/nxp/adsp/number_crunching/src/nature_dsp_wrapper.c
+++ b/samples/boards/nxp/adsp/number_crunching/src/nature_dsp_wrapper.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <stdio.h>
 
-#include "NatureDSP_Signal.h"
+#include <NatureDSP_Signal.h>
 
 /**
  * For fft_real32x32, scaling options are:

--- a/samples/boards/nxp/adsp/rtxxx/amp_audio_loopback/src/main.c
+++ b/samples/boards/nxp/adsp/rtxxx/amp_audio_loopback/src/main.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 
-#include "dsp.h"
+#include <dsp.h>
 
 int main(void)
 {

--- a/samples/boards/nxp/adsp/rtxxx/amp_audio_output/src/main.c
+++ b/samples/boards/nxp/adsp/rtxxx/amp_audio_output/src/main.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 
-#include "dsp.h"
+#include <dsp.h>
 
 int main(void)
 {

--- a/samples/boards/nxp/adsp/rtxxx/amp_blinky/src/main.c
+++ b/samples/boards/nxp/adsp/rtxxx/amp_blinky/src/main.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 
-#include "dsp.h"
+#include <dsp.h>
 
 int main(void)
 {

--- a/samples/boards/nxp/adsp/rtxxx/amp_mbox/src/main.c
+++ b/samples/boards/nxp/adsp/rtxxx/amp_mbox/src/main.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/mbox.h>
 
-#include "dsp.h"
+#include <dsp.h>
 
 static const struct device *mbox = DEVICE_DT_GET(DT_ALIAS(mbox));
 static mbox_channel_id_t mbox_ch;

--- a/samples/boards/nxp/adsp/rtxxx/amp_talk/remote_cm33/src/main.c
+++ b/samples/boards/nxp/adsp/rtxxx/amp_talk/remote_cm33/src/main.c
@@ -16,7 +16,7 @@
 
 #include <openamp/open_amp.h>
 
-#include "common.h"
+#include <common.h>
 
 #define APP_TASK_STACK_SIZE (1024)
 K_THREAD_STACK_DEFINE(thread_stack, APP_TASK_STACK_SIZE);

--- a/samples/boards/nxp/adsp/rtxxx/amp_talk/remote_hifi4/src/main.c
+++ b/samples/boards/nxp/adsp/rtxxx/amp_talk/remote_hifi4/src/main.c
@@ -17,7 +17,7 @@
 
 #include <openamp/open_amp.h>
 
-#include "common.h"
+#include <common.h>
 
 #define APP_TASK_STACK_SIZE (4096)
 K_THREAD_STACK_DEFINE(thread_stack, APP_TASK_STACK_SIZE);

--- a/samples/boards/nxp/adsp/rtxxx/amp_talk/src/main.c
+++ b/samples/boards/nxp/adsp/rtxxx/amp_talk/src/main.c
@@ -17,8 +17,8 @@
 
 #include <openamp/open_amp.h>
 
-#include "common.h"
-#include "dsp.h"
+#include <common.h>
+#include <dsp.h>
 
 #define APP_TASK_STACK_SIZE (1024)
 K_THREAD_STACK_DEFINE(thread_stack, APP_TASK_STACK_SIZE);
@@ -55,7 +55,7 @@ static struct virtio_vring_info rvrings_hifi4[2] = {
 		},
 };
 
-#include "fsl_cache.h"
+#include <fsl_cache.h>
 
 static struct virtio_device vdev;
 static struct rpmsg_virtio_device rvdev;

--- a/samples/boards/nxp/tflm_neutron/src/main_functions.cpp
+++ b/samples/boards/nxp/tflm_neutron/src/main_functions.cpp
@@ -8,7 +8,7 @@
  */
 
 #include "main_functions.h"
-#include "model.hpp"
+#include <model.hpp>
 /* Include image data and labels */
 #include "image_data.h"
 #include "labels.h"
@@ -18,7 +18,7 @@
 #include <tensorflow/lite/micro/micro_mutable_op_resolver.h>
 #include <tensorflow/lite/micro/kernels/micro_ops.h>
 #include <tensorflow/lite/schema/schema_generated.h>
-#include "tensorflow/lite/micro/kernels/neutron/neutron.h"
+#include <tensorflow/lite/micro/kernels/neutron/neutron.h>
 
 #include <zephyr/sys/printk.h>
 #include <zephyr/linker/section_tags.h>

--- a/soc/nxp/imx/imx6sx/soc.c
+++ b/soc/nxp/imx/imx6sx/soc.c
@@ -8,7 +8,7 @@
 #include <zephyr/sys/barrier.h>
 #include <soc.h>
 #include <zephyr/dt-bindings/rdc/imx_rdc.h>
-#include "wdog_imx.h"
+#include <wdog_imx.h>
 
 #include <cmsis_core.h>
 

--- a/soc/nxp/imx/imx6sx/soc.h
+++ b/soc/nxp/imx/imx6sx/soc.h
@@ -9,10 +9,10 @@
 
 #ifndef _ASMLANGUAGE
 
-#include "rdc.h"
-#include "rdc_defs_imx6sx.h"
-#include "ccm_imx6sx.h"
-#include "clock_freq.h"
+#include <rdc.h>
+#include <rdc_defs_imx6sx.h>
+#include <ccm_imx6sx.h>
+#include <clock_freq.h>
 #include "soc_clk_freq.h"
 #include <soc_common.h>
 

--- a/soc/nxp/imx/imx6sx/soc_clk_freq.h
+++ b/soc/nxp/imx/imx6sx/soc_clk_freq.h
@@ -7,7 +7,7 @@
 #ifndef __SOC_CLOCK_FREQ_H__
 #define __SOC_CLOCK_FREQ_H__
 
-#include "device_imx.h"
+#include <device_imx.h>
 #include <zephyr/types.h>
 
 #if defined(__cplusplus)

--- a/soc/nxp/imx/imx7d/soc.c
+++ b/soc/nxp/imx/imx7d/soc.c
@@ -8,7 +8,7 @@
 #include <soc.h>
 #include <zephyr/dt-bindings/rdc/imx_rdc.h>
 #include <zephyr/devicetree.h>
-#include "wdog_imx.h"
+#include <wdog_imx.h>
 
 /* Initialize clock. */
 __weak void SOC_ClockInit(void)

--- a/soc/nxp/imx/imx7d/soc.h
+++ b/soc/nxp/imx/imx7d/soc.h
@@ -13,10 +13,10 @@
 
 #ifndef __cplusplus
 
-#include "rdc.h"
-#include "rdc_defs_imx7d.h"
-#include "ccm_imx7d.h"
-#include "clock_freq.h"
+#include <rdc.h>
+#include <rdc_defs_imx7d.h>
+#include <ccm_imx7d.h>
+#include <clock_freq.h>
 #include "soc_clk_freq.h"
 #include <soc_common.h>
 

--- a/soc/nxp/imx/imx7d/soc_clk_freq.h
+++ b/soc/nxp/imx/imx7d/soc_clk_freq.h
@@ -7,7 +7,7 @@
 #ifndef __SOC_CLOCK_FREQ_H__
 #define __SOC_CLOCK_FREQ_H__
 
-#include "device_imx.h"
+#include <device_imx.h>
 #include <zephyr/types.h>
 
 #if defined(__cplusplus)

--- a/soc/nxp/imx/imx8m/a53/pinctrl_soc.h
+++ b/soc/nxp/imx/imx8m/a53/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imx/imx8m/adsp/pinctrl_soc.h
+++ b/soc/nxp/imx/imx8m/adsp/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imx/imx8m/m4_mini/pinctrl_soc.h
+++ b/soc/nxp/imx/imx8m/m4_mini/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imx/imx8m/m4_quad/pinctrl_soc.h
+++ b/soc/nxp/imx/imx8m/m4_quad/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imx/imx8m/m7/pinctrl_soc.h
+++ b/soc/nxp/imx/imx8m/m7/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imx/imx8ulp/pinctrl_soc.h
+++ b/soc/nxp/imx/imx8ulp/pinctrl_soc.h
@@ -8,7 +8,7 @@
 #define ZEPHYR_SOC_NXP_IMX_IMX8ULP_PINCTR_SOC_H_
 
 #include <zephyr/devicetree.h>
-#include "fsl_iomuxc.h"
+#include <fsl_iomuxc.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imx/imx9/imx91/pinctrl_soc.h
+++ b/soc/nxp/imx/imx9/imx91/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imx/imx9/imx93/pinctrl_soc.h
+++ b/soc/nxp/imx/imx9/imx93/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imx/imx9/imx943/pinctrl_soc.h
+++ b/soc/nxp/imx/imx9/imx943/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
-#include "soc.h"
+#include <soc.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imx/imx9/imx95/pinctrl_soc.h
+++ b/soc/nxp/imx/imx9/imx95/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
-#include "soc.h"
+#include <soc.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imx/imx9/imx952/pinctrl_soc.h
+++ b/soc/nxp/imx/imx9/imx952/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
-#include "soc.h"
+#include <soc.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imxrt/flexspi_nor_config.h
+++ b/soc/nxp/imxrt/flexspi_nor_config.h
@@ -10,7 +10,7 @@
 #define FLEXSPI_NOR_CONFIG_
 
 #include <zephyr/types.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 #define FLEXSPI_CFG_BLK_TAG     (0x42464346UL)
 #define FLEXSPI_CFG_BLK_VERSION (0x56010400UL)

--- a/soc/nxp/imxrt/imxrt10xx/pinctrl_soc.h
+++ b/soc/nxp/imxrt/imxrt10xx/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imxrt/imxrt10xx/soc.c
+++ b/soc/nxp/imxrt/imxrt10xx/soc.c
@@ -18,8 +18,8 @@
 #include <zephyr/dt-bindings/clock/imx_ccm.h>
 #include <fsl_iomuxc.h>
 #if CONFIG_USB_DC_NXP_EHCI
-#include "usb_phy.h"
-#include "usb.h"
+#include <usb_phy.h>
+#include <usb.h>
 #endif
 
 #include <zephyr/drivers/misc/flexram/nxp_flexram.h>

--- a/soc/nxp/imxrt/imxrt118x/pinctrl_soc.h
+++ b/soc/nxp/imxrt/imxrt118x/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imxrt/imxrt11xx/pinctrl_soc.h
+++ b/soc/nxp/imxrt/imxrt11xx/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/types.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -34,8 +34,8 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 	       (uint32_t *)(SEGMENT_LMA_ADDRESS_##n), (SEGMENT_SIZE_##n))
 #endif
 #if CONFIG_USB_DC_NXP_EHCI
-#include "usb_phy.h"
-#include "usb.h"
+#include <usb_phy.h>
+#include <usb.h>
 #endif
 #include <zephyr/drivers/misc/flexram/nxp_flexram.h>
 

--- a/soc/nxp/imxrt/imxrt5xx/cm33/flash_clock_setup.c
+++ b/soc/nxp/imxrt/imxrt5xx/cm33/flash_clock_setup.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "fsl_power.h"
+#include <fsl_power.h>
 #include "flash_clock_setup.h"
 
 #define FLEXSPI_DLL_LOCK_RETRY (10)

--- a/soc/nxp/imxrt/imxrt5xx/cm33/flash_clock_setup.h
+++ b/soc/nxp/imxrt/imxrt5xx/cm33/flash_clock_setup.h
@@ -7,7 +7,7 @@
 #ifndef _FLASH_CLOCK_SETUP_H_
 #define _FLASH_CLOCK_SETUP_H_
 
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 void flexspi_clock_safe_config(void);
 void flexspi_setup_clock(FLEXSPI_Type *base, uint32_t src, uint32_t divider);

--- a/soc/nxp/imxrt/imxrt5xx/cm33/power.c
+++ b/soc/nxp/imxrt/imxrt5xx/cm33/power.c
@@ -6,7 +6,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/pm/pm.h>
-#include "fsl_power.h"
+#include <fsl_power.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);

--- a/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt5xx/cm33/soc.c
@@ -17,8 +17,8 @@
 #include <zephyr/linker/sections.h>
 #include <zephyr/logging/log.h>
 #include <soc.h>
-#include "fsl_power.h"
-#include "fsl_clock.h"
+#include <fsl_power.h>
+#include <fsl_clock.h>
 #include <fsl_cache.h>
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
@@ -28,8 +28,8 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 #endif
 
 #if CONFIG_USB_DC_NXP_LPCIP3511 || CONFIG_UDC_NXP_IP3511
-#include "usb_phy.h"
-#include "usb.h"
+#include <usb_phy.h>
+#include <usb.h>
 #endif
 
 /* Board System oscillator settling time in us */

--- a/soc/nxp/imxrt/imxrt6xx/cm33/flash_clock_setup.c
+++ b/soc/nxp/imxrt/imxrt6xx/cm33/flash_clock_setup.c
@@ -9,7 +9,7 @@
  * relocated into internal SRAM.
  */
 
-#include "fsl_power.h"
+#include <fsl_power.h>
 #include "flash_clock_setup.h"
 
 #define FLEXSPI_DLL_LOCK_RETRY (10)

--- a/soc/nxp/imxrt/imxrt6xx/cm33/flash_clock_setup.h
+++ b/soc/nxp/imxrt/imxrt6xx/cm33/flash_clock_setup.h
@@ -7,7 +7,7 @@
 #ifndef _FLASH_CLOCK_SETUP_H_
 #define _FLASH_CLOCK_SETUP_H_
 
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 void flexspi_clock_safe_config(void);
 void flexspi_setup_clock(FLEXSPI_Type *base, uint32_t src, uint32_t divider);

--- a/soc/nxp/imxrt/imxrt6xx/cm33/power.c
+++ b/soc/nxp/imxrt/imxrt6xx/cm33/power.c
@@ -5,7 +5,7 @@
  */
 #include <zephyr/kernel.h>
 #include <zephyr/pm/pm.h>
-#include "fsl_power.h"
+#include <fsl_power.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);

--- a/soc/nxp/imxrt/imxrt6xx/cm33/soc.c
+++ b/soc/nxp/imxrt/imxrt6xx/cm33/soc.c
@@ -34,8 +34,8 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 #endif
 
 #if CONFIG_USB_DC_NXP_LPCIP3511 || CONFIG_UDC_NXP_IP3511
-#include "usb_phy.h"
-#include "usb.h"
+#include <usb_phy.h>
+#include <usb.h>
 #endif
 
 #define SYSTEM_IS_XIP_FLEXSPI()                                                                    \

--- a/soc/nxp/imxrt/imxrt7xx/cm33/display_if.c
+++ b/soc/nxp/imxrt/imxrt7xx/cm33/display_if.c
@@ -6,8 +6,8 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/autoconf.h>
-#include "fsl_power.h"
-#include "fsl_clock.h"
+#include <fsl_power.h>
+#include <fsl_clock.h>
 
 /* Weak so board can override this function */
 void __weak imxrt_pre_init_display_interface(void)

--- a/soc/nxp/imxrt/imxrt7xx/cm33/pmic_int.c
+++ b/soc/nxp/imxrt/imxrt7xx/cm33/pmic_int.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "fsl_power.h"
+#include <fsl_power.h>
 
 /* Weak so board can override this function */
 void __weak imxrt_disable_pmic_interrupt(void)

--- a/soc/nxp/kinetis/ke1xz/soc.c
+++ b/soc/nxp/kinetis/ke1xz/soc.c
@@ -14,7 +14,7 @@
 #include <zephyr/init.h>
 #include <fsl_clock.h>
 #include <cmsis_core.h>
-#include "fsl_smc.h"
+#include <fsl_smc.h>
 
 #define ASSERT_WITHIN_RANGE(val, min, max, str) BUILD_ASSERT(val >= min && val <= max, str)
 

--- a/soc/nxp/lpc/lpc55xxx/soc.c
+++ b/soc/nxp/lpc/lpc55xxx/soc.c
@@ -27,8 +27,8 @@
 #include <fsl_pint.h>
 #endif
 #if CONFIG_USB_DC_NXP_LPCIP3511 || CONFIG_UDC_NXP_IP3511 || CONFIG_UHC_NXP_IP3516HS
-#include "usb_phy.h"
-#include "usb.h"
+#include <usb_phy.h>
+#include <usb.h>
 #endif
 #if defined(CONFIG_SOC_LPC55S36) && (defined(CONFIG_ADC_MCUX_LPADC) \
 	|| defined(CONFIG_DAC_MCUX_LPDAC))

--- a/soc/nxp/mcx/mcxe/mcxe31x/sram_config.c
+++ b/soc/nxp/mcx/mcxe/mcxe31x/sram_config.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 /* Don't access system RAM when configuring PRAM FT_DIS.  */
 void enable_sram_extra_latency(bool en)

--- a/soc/nxp/mcx/mcxw/mcxw2xx/power.c
+++ b/soc/nxp/mcx/mcxw/mcxw2xx/power.c
@@ -13,7 +13,7 @@
 #include <fsl_power.h>
 #include <zephyr/logging/log.h>
 #if defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_HOOKS)
-#include "fsl_ostimer.h"
+#include <fsl_ostimer.h>
 #endif
 
 #if CONFIG_PM_POLICY_CUSTOM

--- a/soc/nxp/rw/flash_config.h
+++ b/soc/nxp/rw/flash_config.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 
 #define FC_BLOCK_TAG     (0x42464346)

--- a/soc/nxp/rw/flexspi_clock_setup.h
+++ b/soc/nxp/rw/flexspi_clock_setup.h
@@ -6,7 +6,7 @@
 #ifndef _FLEXSPI_CLOCK_SETUP_H_
 #define _FLEXSPI_CLOCK_SETUP_H_
 
-#include "fsl_common.h"
+#include <fsl_common.h>
 
 void set_flexspi_clock(FLEXSPI_Type *base, uint32_t src, uint32_t divider);
 

--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -18,7 +18,7 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/drivers/timer/nxp_os_timer.h>
 #include <zephyr/platform/hooks.h>
-#include "fsl_power.h"
+#include <fsl_power.h>
 
 #include <zephyr/logging/log.h>
 

--- a/soc/nxp/rw/soc.c
+++ b/soc/nxp/rw/soc.c
@@ -20,7 +20,7 @@
 #include <fsl_io_mux.h>
 #include "soc.h"
 #include "flexspi_clock_setup.h"
-#include "fsl_ocotp.h"
+#include <fsl_ocotp.h>
 
 #define NON_AON_PINS_START      0
 #define NON_AON_PINS_BREAK      21

--- a/soc/nxp/rw/soc.h
+++ b/soc/nxp/rw/soc.h
@@ -9,7 +9,7 @@
 #ifndef _ASMLANGUAGE
 #include <zephyr/sys/util.h>
 #include <fsl_common.h>
-#include "fsl_power.h"
+#include <fsl_power.h>
 
 /* Add include for DTS generated information */
 #include <zephyr/devicetree.h>


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various NXP related paths and manually selecting the applicable changes:
```
$ find soc/nxp/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;
