### PR TITLE
silabs: Diamond include for non-local header files

### DIFF
--- a/boards/silabs/radio_boards/slwrb4321a/board.c
+++ b/boards/silabs/radio_boards/slwrb4321a/board.c
@@ -9,7 +9,7 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/printk.h>
-#include "em_cmu.h"
+#include <em_cmu.h>
 #include "board.h"
 
 static int efm32gg_slwstk6121a_init(void)

--- a/boards/silabs/starter_kits/slstk3701a/board.c
+++ b/boards/silabs/starter_kits/slstk3701a/board.c
@@ -9,7 +9,7 @@
 #include "board.h"
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/printk.h>
-#include "em_cmu.h"
+#include <em_cmu.h>
 
 static int efm32gg_stk3701a_init(void)
 {

--- a/modules/hal_silabs/simplicity_sdk/config/ll/sl_btctrl_scheduler_priority_config.h
+++ b/modules/hal_silabs/simplicity_sdk/config/ll/sl_btctrl_scheduler_priority_config.h
@@ -9,7 +9,7 @@
 
 #ifndef SL_BTCTRL_SCHEDULER_PRIORITY_CONFIG_H
 #define SL_BTCTRL_SCHEDULER_PRIORITY_CONFIG_H
-#include "sl_btctrl_linklayer_defs.h"
+#include <sl_btctrl_linklayer_defs.h>
 
 #define SL_BT_CONTROLLER_SCHEDULER_PRI_SCAN_MIN  191
 #define SL_BT_CONTROLLER_SCHEDULER_PRI_SCAN_MAX  143

--- a/modules/hal_silabs/simplicity_sdk/config/sl_rail_util_pa_config.h
+++ b/modules/hal_silabs/simplicity_sdk/config/sl_rail_util_pa_config.h
@@ -19,7 +19,7 @@
 
 /* Modules still use legacy PA configuration */
 #ifdef CONFIG_SILABS_DEVICE_IS_MODULE
-#include "rail_types.h"
+#include <rail_types.h>
 
 #if DT_NODE_HAS_PROP(DT_NODELABEL(radio), pa_2p4ghz)
 #define SL_RAIL_UTIL_PA_SELECTION_2P4GHZ                                                           \

--- a/modules/hal_silabs/simplicity_sdk/config/sl_rail_util_pa_tables_config.h
+++ b/modules/hal_silabs/simplicity_sdk/config/sl_rail_util_pa_tables_config.h
@@ -16,22 +16,22 @@
 #ifdef CONFIG_SOC_SILABS_XG21
 
 #if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, mp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_0dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_0dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
 #if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 10
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_10_20dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_10_20dbm.h>
 #else
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_10dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_10dbm.h>
 #endif
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
 #if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 10
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h>
 #else
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h>
 #endif
 #else
 #error "Unknown 2.4 GHz PA configuration"
@@ -43,11 +43,11 @@
 
 #if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp) ||                                       \
 	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_6dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_6dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_0dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_0dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_6dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_6dbm.h>
 #else
 #error "Unknown 2.4 GHz PA configuration"
 #endif
@@ -78,22 +78,22 @@
 #ifdef CONFIG_SOC_SILABS_XG24
 
 #if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, mp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_0dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_0dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
 #if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 10
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h>
 #else
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_10dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_10dbm.h>
 #endif
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
 #if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 10
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h>
 #else
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h>
 #endif
 #else
 #error "Unknown 2.4 GHz PA configuration"
@@ -107,11 +107,11 @@
 
 #if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, mp) ||                                       \
 	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_bga_10dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_bga_10dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_bga_0dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_bga_0dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_bga_automode_0_10dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_bga_automode_0_10dbm.h>
 #else
 #error "Unknown 2.4 GHz PA configuration"
 #endif
@@ -119,22 +119,22 @@
 #else /* CONFIG_SOC_EFR32MG26B510F3200IL136 */
 
 #if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, mp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_0dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_0dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
 #if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 10
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h>
 #else
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_10dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_automode_0_10dbm.h>
 #endif
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
 #if DT_PROP(DT_NODELABEL(radio), pa_max_power_dbm) > 10
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_20dbm.h>
 #else
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_10dbm.h>
 #endif
 #else
 #error "Unknown 2.4 GHz PA configuration"
@@ -150,11 +150,11 @@
 
 #if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp) ||                                       \
 	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_8dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_8dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_0dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_0dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_automode_0_8dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_automode_0_8dbm.h>
 #else
 #error "Unknown 2.4 GHz PA configuration"
 #endif
@@ -163,11 +163,11 @@
 
 #if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp) ||                                       \
 	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_csp_4dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_csp_4dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_csp_0dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_csp_0dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_csp_automode_0_4dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_csp_automode_0_4dbm.h>
 #else
 #error "Unknown 2.4 GHz PA configuration"
 #endif
@@ -203,11 +203,11 @@
 
 #if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp) ||                                       \
 	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_8dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_8dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_0dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_0dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_automode_0_8dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_qfn_automode_0_8dbm.h>
 #else
 #error "Unknown 2.4 GHz PA configuration"
 #endif
@@ -216,11 +216,11 @@
 
 #if DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, hp) ||                                       \
 	DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, highest)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_csp_8dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_csp_8dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, lp)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_csp_0dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_csp_0dbm.h>
 #elif DT_ENUM_HAS_VALUE(DT_NODELABEL(radio), pa_2p4ghz, auto)
-#include "sl_rail_util_pa_dbm_powersetting_mapping_table_csp_automode_0_8dbm.h"
+#include <sl_rail_util_pa_dbm_powersetting_mapping_table_csp_automode_0_8dbm.h>
 #else
 #error "Unknown 2.4 GHz PA configuration"
 #endif

--- a/modules/hal_silabs/simplicity_sdk/src/blob_stubs_module.c
+++ b/modules/hal_silabs/simplicity_sdk/src/blob_stubs_module.c
@@ -9,7 +9,7 @@
 #include <stdbool.h>
 
 #include <rail.h>
-#include "pa_curve_types_efr32.h"
+#include <pa_curve_types_efr32.h>
 
 const RAIL_TxPowerCurvesConfigAlt_t RAIL_TxPowerCurvesVbat;
 const RAIL_TxPowerCurvesConfigAlt_t RAIL_TxPowerCurvesDcdc;

--- a/modules/hal_silabs/simplicity_sdk/src/sl_interrupt_manager_shim.c
+++ b/modules/hal_silabs/simplicity_sdk/src/sl_interrupt_manager_shim.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/kernel.h>
 
-#include "sl_interrupt_manager.h"
+#include <sl_interrupt_manager.h>
 
 #define LOCK_KEY_DEFAULT 0xFFFFFFFFU
 

--- a/modules/hal_silabs/simplicity_sdk/src/sl_memory_manager_pool_shim.c
+++ b/modules/hal_silabs/simplicity_sdk/src/sl_memory_manager_pool_shim.c
@@ -11,8 +11,8 @@
 
 #include <zephyr/kernel.h>
 
-#include "sl_memory_manager.h"
-#include "sl_status.h"
+#include <sl_memory_manager.h>
+#include <sl_status.h>
 
 sl_status_t sl_memory_create_pool(size_t block_size, uint32_t block_count,
 				  sl_memory_pool_t *pool_handle)

--- a/modules/hal_silabs/simplicity_sdk/src/sl_memory_manager_shim.c
+++ b/modules/hal_silabs/simplicity_sdk/src/sl_memory_manager_shim.c
@@ -7,7 +7,7 @@
  * will get redirected to the Zephyr sys_heap.
  */
 
-#include "sl_memory_manager.h"
+#include <sl_memory_manager.h>
 #include <stdlib.h>
 
 void *sl_malloc(size_t size)

--- a/soc/silabs/silabs_s0/efm32hg/soc.h
+++ b/soc/silabs/silabs_s0/efm32hg/soc.h
@@ -21,7 +21,7 @@
 #include <zephyr/device.h>
 
 #include "soc_pinmap.h"
-#include "../common/soc_gpio.h"
+#include <../common/soc_gpio.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/silabs/silabs_s0/efm32tg/soc.h
+++ b/soc/silabs/silabs_s0/efm32tg/soc.h
@@ -22,7 +22,7 @@
 
 
 #include "soc_pinmap.h"
-#include "../common/soc_gpio.h"
+#include <../common/soc_gpio.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/silabs/silabs_s0/efm32wg/soc.h
+++ b/soc/silabs/silabs_s0/efm32wg/soc.h
@@ -22,7 +22,7 @@
 
 
 #include "soc_pinmap.h"
-#include "../common/soc_gpio.h"
+#include <../common/soc_gpio.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/silabs/silabs_s1/efm32gg11b/soc.h
+++ b/soc/silabs/silabs_s1/efm32gg11b/soc.h
@@ -27,7 +27,7 @@ extern "C" {
 
 
 #include "soc_pinmap.h"
-#include "../common/soc_gpio.h"
+#include <../common/soc_gpio.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/silabs/silabs_s1/efm32gg12b/soc.h
+++ b/soc/silabs/silabs_s1/efm32gg12b/soc.h
@@ -26,7 +26,7 @@ extern "C" {
 
 
 #include "soc_pinmap.h"
-#include "../common/soc_gpio.h"
+#include <../common/soc_gpio.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/silabs/silabs_s1/efm32jg12b/soc.h
+++ b/soc/silabs/silabs_s1/efm32jg12b/soc.h
@@ -22,7 +22,7 @@
 
 
 #include "soc_pinmap.h"
-#include "../common/soc_gpio.h"
+#include <../common/soc_gpio.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/silabs/silabs_s1/efm32pg12b/soc.h
+++ b/soc/silabs/silabs_s1/efm32pg12b/soc.h
@@ -22,7 +22,7 @@
 
 
 #include "soc_pinmap.h"
-#include "../common/soc_gpio.h"
+#include <../common/soc_gpio.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/silabs/silabs_s1/efm32pg1b/soc.h
+++ b/soc/silabs/silabs_s1/efm32pg1b/soc.h
@@ -22,7 +22,7 @@
 
 
 #include "soc_pinmap.h"
-#include "../common/soc_gpio.h"
+#include <../common/soc_gpio.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/silabs/silabs_s1/efr32bg13p/soc.h
+++ b/soc/silabs/silabs_s1/efr32bg13p/soc.h
@@ -20,7 +20,7 @@
 #include <em_common.h>
 
 #include "soc_pinmap.h"
-#include "../common/soc_gpio.h"
+#include <../common/soc_gpio.h>
 
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/silabs/silabs_s1/efr32fg13p/soc.h
+++ b/soc/silabs/silabs_s1/efr32fg13p/soc.h
@@ -22,7 +22,7 @@
 
 
 #include "soc_pinmap.h"
-#include "../common/soc_gpio.h"
+#include <../common/soc_gpio.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/silabs/silabs_s1/efr32fg1p/soc.h
+++ b/soc/silabs/silabs_s1/efr32fg1p/soc.h
@@ -22,7 +22,7 @@
 
 
 #include "soc_pinmap.h"
-#include "../common/soc_gpio.h"
+#include <../common/soc_gpio.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/silabs/silabs_s1/efr32mg12p/soc.h
+++ b/soc/silabs/silabs_s1/efr32mg12p/soc.h
@@ -21,7 +21,7 @@
 
 
 #include "soc_pinmap.h"
-#include "../common/soc_gpio.h"
+#include <../common/soc_gpio.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/silabs/silabs_s1/efr32mg13p/soc.h
+++ b/soc/silabs/silabs_s1/efr32mg13p/soc.h
@@ -20,7 +20,7 @@
 #include <em_common.h>
 
 #include "soc_pinmap.h"
-#include "../common/soc_gpio.h"
+#include <../common/soc_gpio.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/silabs/silabs_siwx91x/siwg917/power.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/power.c
@@ -8,11 +8,11 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/pm.h>
-#include "sl_si91x_power_manager.h"
-#include "sli_si91x_clock_manager.h"
-#include "sli_siwx917_soc.h"
-#include "sl_rsi_utility.h"
-#include "sl_si91x_m4_ps.h"
+#include <sl_si91x_power_manager.h>
+#include <sli_si91x_clock_manager.h>
+#include <sli_siwx917_soc.h>
+#include <sl_rsi_utility.h>
+#include <sl_si91x_m4_ps.h>
 
 LOG_MODULE_REGISTER(soc_power, CONFIG_SOC_LOG_LEVEL);
 

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_fota_shell.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_fota_shell.c
@@ -15,8 +15,8 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/logging/log.h>
 
-#include "sl_wifi.h"
-#include "firmware_upgradation.h"
+#include <sl_wifi.h>
+#include <firmware_upgradation.h>
 
 LOG_MODULE_REGISTER(siwx91x_ota, LOG_LEVEL_INF);
 

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
@@ -19,14 +19,14 @@
 #include <zephyr/devicetree.h>
 
 #include "siwx91x_nwp.h"
-#include "nwp_fw_version.h"
-#include "sl_wifi_callback_framework.h"
+#include <nwp_fw_version.h>
+#include <sl_wifi_callback_framework.h>
 
-#include "sl_si91x_ble.h"
+#include <sl_si91x_ble.h>
 #ifdef CONFIG_BT_SILABS_SIWX91X
-#include "rsi_ble_common_config.h"
+#include <rsi_ble_common_config.h>
 #endif
-#include "sl_si91x_power_manager.h"
+#include <sl_si91x_power_manager.h>
 
 #define AP_MAX_NUM_STA 4
 #define SL_SI91X_EXT_FEAT_FRONT_END_MSK (BIT(30) | BIT(29))

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.h
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.h
@@ -6,7 +6,7 @@
 #define SIWX91X_NWP_H
 
 #include <zephyr/device.h>
-#include "sl_wifi.h"
+#include <sl_wifi.h>
 
 #define SIWX91X_INTERFACE_MASK (0x03)
 #define DEFAULT_COUNTRY_CODE   "00"

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_version_shell.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_version_shell.c
@@ -4,8 +4,8 @@
  */
 #include <zephyr/shell/shell.h>
 
-#include "nwp_fw_version.h"
-#include "sl_wifi.h"
+#include <nwp_fw_version.h>
+#include <sl_wifi.h>
 
 static int cmd_nwp_version(const struct shell *sh, size_t argc, char **argv)
 {

--- a/soc/silabs/silabs_siwx91x/siwg917/soc.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/soc.c
@@ -9,9 +9,9 @@
 #include <zephyr/device.h>
 #include <zephyr/sw_isr_table.h>
 
-#include "em_device.h"
+#include <em_device.h>
 #include "power.h"
-#include "sl_si91x_hal_soc_soft_reset.h"
+#include <sl_si91x_hal_soc_soft_reset.h>
 
 
 void soc_early_init_hook(void)

--- a/soc/silabs/silabs_siwx91x/siwg917/soc.h
+++ b/soc/silabs/silabs_siwx91x/siwg917/soc.h
@@ -5,7 +5,7 @@
 #ifndef SIWG917_SOC_H
 #define SIWG917_SOC_H
 
-#include "si91x_device.h"
+#include <si91x_device.h>
 
 #define SYSRTC_IRQHandler IRQ022_Handler
 


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Silabs related paths and manually selecting the applicable changes:
```
$ find soc/silabs/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;