### PR TITLE
stm32: Diamond include for non-local header files

### DIFF
--- a/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.dts
+++ b/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.dts
@@ -5,8 +5,8 @@
  */
 
 /dts-v1/;
-#include "st/f4/stm32f405Xg.dtsi"
-#include "st/f4/stm32f405vgtx-pinctrl.dtsi"
+#include <st/f4/stm32f405Xg.dtsi>
+#include <st/f4/stm32f405vgtx-pinctrl.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/display/panel.h>
 

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -8,7 +8,7 @@
 #include <st/h7rs/stm32h7s7X8.dtsi>
 #include <st/h7/stm32h7s7l8hxh-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
-#include "zephyr/dt-bindings/display/panel.h"
+#include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 /*

--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -8,7 +8,7 @@
 
 #include <st/mp13/stm32mp135.dtsi>
 #include <st/mp13/stm32mp135faex-pinctrl.dtsi>
-#include "zephyr/dt-bindings/display/panel.h"
+#include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/gpio/raspberrypi-csi-connector.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/video/video-interfaces.h>

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -6,7 +6,7 @@
 
 #include <st/n6/stm32n657X0.dtsi>
 #include <st/n6/stm32n657x0hxq-pinctrl.dtsi>
-#include "zephyr/dt-bindings/display/panel.h"
+#include <zephyr/dt-bindings/display/panel.h>
 #include <zephyr/dt-bindings/flash_controller/xspi.h>
 #include <zephyr/dt-bindings/gpio/raspberrypi-csi-connector.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>

--- a/samples/boards/st/pwm/mastermode/boards/nucleo_f072rb.overlay
+++ b/samples/boards/st/pwm/mastermode/boards/nucleo_f072rb.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "dt-bindings/timer/stm32-timer.h"
+#include <dt-bindings/timer/stm32-timer.h>
 
 / {
 	zephyr,user {

--- a/samples/boards/st/pwm/mastermode/boards/nucleo_g070rb.overlay
+++ b/samples/boards/st/pwm/mastermode/boards/nucleo_g070rb.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "dt-bindings/timer/stm32-timer.h"
+#include <dt-bindings/timer/stm32-timer.h>
 
 / {
 	zephyr,user {

--- a/samples/boards/st/pwm/mastermode/boards/nucleo_g071rb.overlay
+++ b/samples/boards/st/pwm/mastermode/boards/nucleo_g071rb.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "dt-bindings/timer/stm32-timer.h"
+#include <dt-bindings/timer/stm32-timer.h>
 
 / {
 	zephyr,user {

--- a/soc/st/stm32/stm32h7x/soc_m4.c
+++ b/soc/st/stm32/stm32h7x/soc_m4.c
@@ -18,7 +18,7 @@
 #include <stm32_ll_pwr.h>
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_system.h>
-#include "stm32_hsem.h"
+#include <stm32_hsem.h>
 
 #include <cmsis_core.h>
 

--- a/soc/st/stm32/stm32h7x/soc_m7.c
+++ b/soc/st/stm32/stm32h7x/soc_m7.c
@@ -19,7 +19,7 @@
 #include <stm32_ll_pwr.h>
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_system.h>
-#include "stm32_hsem.h"
+#include <stm32_hsem.h>
 
 #include <cmsis_core.h>
 

--- a/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
+++ b/soc/st/stm32/stm32wbax/hci_if/host_stack_if.c
@@ -7,12 +7,12 @@
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 
-#include "app_conf.h"
+#include <app_conf.h>
 #if defined(CONFIG_BT_STM32WBA)
-#include "blestack.h"
-#include "bpka.h"
+#include <blestack.h>
+#include <bpka.h>
 #endif /* CONFIG_BT_STM32WBA */
-#include "ll_intf.h"
+#include <ll_intf.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(host_if);

--- a/soc/st/stm32/stm32wbax/hci_if/ll_sys_if_adapt.c
+++ b/soc/st/stm32/stm32wbax/hci_if/ll_sys_if_adapt.c
@@ -10,8 +10,8 @@
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(ll_sys_if_adapt);
 
-#include "ll_sys.h"
-#include "ll_intf_cmn.h"
+#include <ll_sys.h>
+#include <ll_intf_cmn.h>
 #if defined(CONFIG_BT_STM32WBA_USE_TEMP_BASED_CALIB)
 #include <zephyr/drivers/sensor.h>
 #endif /* defined(CONFIG_BT_STM32WBA_USE_TEMP_BASED_CALIB) */

--- a/soc/st/stm32/stm32wbax/hci_if/stm32_timer.c
+++ b/soc/st/stm32/stm32wbax/hci_if/stm32_timer.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys_clock.h>
 
-#include "stm32_timer.h"
+#include <stm32_timer.h>
 
 #define TICKS_PER_MS (CONFIG_SYS_CLOCK_TICKS_PER_SEC / MSEC_PER_SEC)
 

--- a/soc/st/stm32/stm32wbax/hci_if/sys_wireless_plat.c
+++ b/soc/st/stm32/stm32wbax/hci_if/sys_wireless_plat.c
@@ -12,11 +12,11 @@
 
 #include <stm32_ll_rng.h>
 #if defined(CONFIG_BT_STM32WBA)
-#include "bleplat.h"
-#include "bpka.h"
-#include "baes.h"
+#include <bleplat.h>
+#include <bpka.h>
+#include <baes.h>
 #endif /* CONFIG_BT_STM32WBA */
-#include "linklayer_plat.h"
+#include <linklayer_plat.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(sys_wireless_plat);

--- a/soc/st/stm32/stm32wbax/power.c
+++ b/soc/st/stm32/stm32wbax/power.c
@@ -29,8 +29,8 @@
 
 #if defined(CONFIG_PM) && (defined(CONFIG_BT) || defined(CONFIG_IEEE802154))
 #include <zephyr/pm/policy.h>
-#include "os_wrapper.h"
-#include "ll_sys.h"
+#include <os_wrapper.h>
+#include <ll_sys.h>
 #endif
 
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);

--- a/soc/st/stm32/stm32wbx/power.c
+++ b/soc/st/stm32/stm32wbx/power.c
@@ -15,7 +15,7 @@
 #include <stm32_ll_pwr.h>
 #include <stm32_ll_rcc.h>
 #include <clock_control/clock_stm32_ll_common.h>
-#include "stm32_hsem.h"
+#include <stm32_hsem.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various ST related paths and manually selecting the applicable changes:
```
$ find soc/st/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;