### PR TITLE
realtek: Diamond include for non-local header files

### DIFF
--- a/modules/hal_realtek/ameba/os_wrapper/os_wrapper_critical.c
+++ b/modules/hal_realtek/ameba/os_wrapper/os_wrapper_critical.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "os_wrapper.h"
+#include <os_wrapper.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(os_if_critical);
 

--- a/modules/hal_realtek/ameba/os_wrapper/os_wrapper_memory.c
+++ b/modules/hal_realtek/ameba/os_wrapper/os_wrapper_memory.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "os_wrapper.h"
+#include <os_wrapper.h>
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(os_if_memory);

--- a/modules/hal_realtek/ameba/os_wrapper/os_wrapper_mutex.c
+++ b/modules/hal_realtek/ameba/os_wrapper/os_wrapper_mutex.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include "os_wrapper.h"
+#include <os_wrapper.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(os_if_mutex);
 

--- a/modules/hal_realtek/ameba/os_wrapper/os_wrapper_queue.c
+++ b/modules/hal_realtek/ameba/os_wrapper/os_wrapper_queue.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include "os_wrapper.h"
+#include <os_wrapper.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(os_if_queue);
 

--- a/modules/hal_realtek/ameba/os_wrapper/os_wrapper_semaphore.c
+++ b/modules/hal_realtek/ameba/os_wrapper/os_wrapper_semaphore.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include "os_wrapper.h"
+#include <os_wrapper.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(os_if_sema);
 

--- a/modules/hal_realtek/ameba/os_wrapper/os_wrapper_task.c
+++ b/modules/hal_realtek/ameba/os_wrapper/os_wrapper_task.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "os_wrapper.h"
+#include <os_wrapper.h>
 #include <zephyr/kernel_structs.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(os_if_task);

--- a/modules/hal_realtek/ameba/os_wrapper/os_wrapper_time.c
+++ b/modules/hal_realtek/ameba/os_wrapper/os_wrapper_time.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "os_wrapper.h"
+#include <os_wrapper.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(os_if_time);
 

--- a/modules/hal_realtek/ameba/os_wrapper/os_wrapper_timer.c
+++ b/modules/hal_realtek/ameba/os_wrapper/os_wrapper_timer.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "os_wrapper.h"
+#include <os_wrapper.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(os_if_timer);
 

--- a/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.c
+++ b/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.c
@@ -18,7 +18,7 @@
 #include <zephyr/logging/log.h>
 
 #include "osif_zephyr_impl.h"
-#include "mem_types.h"
+#include <mem_types.h>
 
 LOG_MODULE_REGISTER(osif);
 

--- a/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.h
+++ b/modules/hal_realtek/bee/osif/common/osif_zephyr_impl.h
@@ -13,7 +13,7 @@
 #define OSIF_ZEPHYR_IMPL_H
 
 #include <zephyr/kernel.h>
-#include "mem_types.h"
+#include <mem_types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/hal_realtek/bee/osif/rtl8752h/osif_zephyr_patch.c
+++ b/modules/hal_realtek/bee/osif/rtl8752h/osif_zephyr_patch.c
@@ -23,10 +23,10 @@
 
 #include <zephyr/devicetree.h>
 
-#include "osif_zephyr.h"
-#include "osif_zephyr_impl.h"
-#include "mem_types.h"
-#include "os_patch.h"
+#include <osif_zephyr.h>
+#include <osif_zephyr_impl.h>
+#include <mem_types.h>
+#include <os_patch.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(osif);

--- a/modules/hal_realtek/bee/osif/rtl87x2g/osif_zephyr_patch.c
+++ b/modules/hal_realtek/bee/osif/rtl87x2g/osif_zephyr_patch.c
@@ -15,17 +15,17 @@
 #include <zephyr/kernel.h>
 #include <zephyr/devicetree.h>
 
-#include "os_queue.h"
-#include "os_msg.h"
-#include "os_mem.h"
-#include "os_sched.h"
-#include "os_sync.h"
-#include "os_timer.h"
-#include "os_task.h"
-#include "mem_types.h"
+#include <os_queue.h>
+#include <os_msg.h>
+#include <os_mem.h>
+#include <os_sched.h>
+#include <os_sync.h>
+#include <os_timer.h>
+#include <os_task.h>
+#include <mem_types.h>
 
-#include "osif_zephyr.h"
-#include "osif_zephyr_impl.h"
+#include <osif_zephyr.h>
+#include <osif_zephyr_impl.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(osif);

--- a/soc/realtek/ameba/amebad/soc.c
+++ b/soc/realtek/ameba/amebad/soc.c
@@ -9,7 +9,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/cache.h>
-#include "ameba_system.h"
+#include <ameba_system.h>
 
 void z_arm_reset(void);
 

--- a/soc/realtek/ameba/amebad/soc.h
+++ b/soc/realtek/ameba/amebad/soc.h
@@ -10,7 +10,7 @@
 #ifndef _ASMLANGUAGE
 
 #include <zephyr/sys/util.h>
-#include "cmsis_cpu.h"
+#include <cmsis_cpu.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/realtek/ameba/amebadplus/soc.h
+++ b/soc/realtek/ameba/amebadplus/soc.h
@@ -10,7 +10,7 @@
 #ifndef _ASMLANGUAGE
 
 #include <zephyr/sys/util.h>
-#include "cmsis_cpu.h"
+#include <cmsis_cpu.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/realtek/ameba/amebag2/soc.h
+++ b/soc/realtek/ameba/amebag2/soc.h
@@ -10,7 +10,7 @@
 #ifndef _ASMLANGUAGE
 
 #include <zephyr/sys/util.h>
-#include "cmsis_cpu.h"
+#include <cmsis_cpu.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -9,14 +9,14 @@
 #include <zephyr/logging/log.h>
 #include <soc.h>
 
-#include "clock_manager.h"
-#include "image_header.h"
-#include "osif_zephyr.h"
-#include "rom_uuid.h"
-#include "rtl_boot_record.h"
-#include "system_rtl876x.h"
-#include "vector_table.h"
-#include "rtl876x_aon_reg.h"
+#include <clock_manager.h>
+#include <image_header.h>
+#include <osif_zephyr.h>
+#include <rom_uuid.h>
+#include <rtl_boot_record.h>
+#include <system_rtl876x.h>
+#include <vector_table.h>
+#include <rtl876x_aon_reg.h>
 
 extern void _isr_wrapper(void);
 

--- a/soc/realtek/bee/rtl87x2g/soc.c
+++ b/soc/realtek/bee/rtl87x2g/soc.c
@@ -13,16 +13,16 @@
 #include <zephyr/logging/log.h>
 #include <soc.h>
 
-#include "system_init_ns.h"
-#include "utils.h"
-#include "sys_reset.h"
-#include "osif_zephyr.h"
-#include "clock_manager.h"
-#include "vector_table.h"
-#include "image_info.h"
-#include "image_check.h"
-#include "rom_uuid.h"
-#include "aon_reg.h"
+#include <system_init_ns.h>
+#include <utils.h>
+#include <sys_reset.h>
+#include <osif_zephyr.h>
+#include <clock_manager.h>
+#include <vector_table.h>
+#include <image_info.h>
+#include <image_check.h>
+#include <rom_uuid.h>
+#include <aon_reg.h>
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various RealTek related paths and manually selecting the applicable changes:
```
$ find soc/realtek/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;
