### PR TITLE
espressif: Diamond include for non-local header files

### DIFF
--- a/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.dts
+++ b/boards/espressif/esp32s3_eye/esp32s3_eye_procpu.dts
@@ -5,7 +5,7 @@
  */
 /dts-v1/;
 
-#include "espressif/esp32s3/esp32s3_wroom_n8r8.dtsi"
+#include <espressif/esp32s3/esp32s3_wroom_n8r8.dtsi>
 #include "esp32s3_eye-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/input/esp32-touch-sensor-input.h>

--- a/samples/boards/espressif/ulp/lp_core/debug_ulp/remote/src/main.c
+++ b/samples/boards/espressif/ulp/lp_core/debug_ulp/remote/src/main.c
@@ -5,9 +5,9 @@
  */
 
 #include <stdio.h>
-#include "ulp_lp_core_utils.h"
+#include <ulp_lp_core_utils.h>
 #include <esp_cpu.h>
-#include "riscv/rvruntime-frames.h"
+#include <riscv/rvruntime-frames.h>
 
 /* Override for the ulp_lp_core_panic_handler() so it stops the debugger when abort() is called */
 void ulp_lp_core_panic_handler(RvExcFrame *frame, int exccause)

--- a/samples/boards/espressif/ulp/lp_core/gpio_wakeup/remote/src/main.c
+++ b/samples/boards/espressif/ulp/lp_core/gpio_wakeup/remote/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/drivers/gpio.h>
-#include "ulp_lp_core_utils.h"
+#include <ulp_lp_core_utils.h>
 
 #define WAKEUP_PIN_NODE DT_ALIAS(wakeup_pin)
 

--- a/samples/boards/espressif/ulp/lp_core/interrupt_ulp/remote/src/main.c
+++ b/samples/boards/espressif/ulp/lp_core/interrupt_ulp/remote/src/main.c
@@ -5,8 +5,8 @@
  */
 
 #include <stdio.h>
-#include "ulp_lp_core_utils.h"
-#include "ulp_lp_core_interrupts.h"
+#include <ulp_lp_core_utils.h>
+#include <ulp_lp_core_interrupts.h>
 
 volatile uint32_t lp_core_pmu_intr_count;
 

--- a/samples/boards/espressif/ulp/lp_core/timer_wakeup/remote/src/main.c
+++ b/samples/boards/espressif/ulp/lp_core/timer_wakeup/remote/src/main.c
@@ -5,9 +5,9 @@
  */
 
 #include <stdint.h>
-#include "ulp_lp_core_utils.h"
-#include "ulp_lp_core_memory_shared.h"
-#include "ulp_lp_core_lp_timer_shared.h"
+#include <ulp_lp_core_utils.h>
+#include <ulp_lp_core_memory_shared.h>
+#include <ulp_lp_core_lp_timer_shared.h>
 
 int main(void)
 {

--- a/soc/espressif/common/loader.c
+++ b/soc/espressif/common/loader.c
@@ -56,10 +56,10 @@
 #include <soc/system_reg.h>
 #endif
 
-#include "memory.h"
-#include "hw_init.h"
-#include "soc_init.h"
-#include "soc_random.h"
+#include <memory.h>
+#include <hw_init.h>
+#include <soc_init.h>
+#include <soc_random.h>
 
 #if defined(CONFIG_SOC_ESP32S3_APPCPU) || defined(CONFIG_SOC_ESP32_APPCPU)
 #error "APPCPU does not need this file!"

--- a/soc/espressif/common/start.S
+++ b/soc/espressif/common/start.S
@@ -14,7 +14,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/arch/riscv/csr.h>
 #include <soc/soc_caps.h>
-#include "memory.h"
+#include <memory.h>
 
 #define CSR_MTVT 0x307
 

--- a/soc/espressif/esp32/esp32-mp.c
+++ b/soc/espressif/esp32/esp32-mp.c
@@ -13,10 +13,10 @@
 
 #include <soc.h>
 #include <esp_cpu.h>
-#include "esp_rom_serial_output.h"
+#include <esp_rom_serial_output.h>
 
-#include "esp_mcuboot_image.h"
-#include "esp_memory_utils.h"
+#include <esp_mcuboot_image.h>
+#include <esp_memory_utils.h>
 #include <zephyr/zsr.h>
 
 #ifdef CONFIG_SMP
@@ -323,7 +323,7 @@ void esp_appcpu_start2(void *entry_point)
 /* AMP support */
 #ifdef CONFIG_SOC_ENABLE_APPCPU
 
-#include "bootloader_flash_priv.h"
+#include <bootloader_flash_priv.h>
 
 #define sys_mmap   bootloader_mmap
 #define sys_munmap bootloader_munmap

--- a/soc/espressif/esp32/hw_init.c
+++ b/soc/espressif/esp32/hw_init.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hw_init.h"
+#include <hw_init.h>
 #include <stdint.h>
 #include <esp_cpu.h>
 #include <soc/rtc.h>

--- a/soc/espressif/esp32c2/hw_init.c
+++ b/soc/espressif/esp32c2/hw_init.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hw_init.h"
+#include <hw_init.h>
 #include <stdint.h>
 #include <esp_cpu.h>
 #include <soc/rtc.h>

--- a/soc/espressif/esp32c2/vectors.S
+++ b/soc/espressif/esp32c2/vectors.S
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "soc/soc.h"
-#include "soc/interrupt_reg.h"
-#include "riscv/rvruntime-frames.h"
-#include "soc/soc_caps.h"
+#include <soc/soc.h>
+#include <soc/interrupt_reg.h>
+#include <riscv/rvruntime-frames.h>
+#include <soc/soc_caps.h>
 #include <zephyr/toolchain.h>
 
 /* Imports */

--- a/soc/espressif/esp32c3/hw_init.c
+++ b/soc/espressif/esp32c3/hw_init.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hw_init.h"
+#include <hw_init.h>
 #include <stdint.h>
 #include <esp_cpu.h>
 #include <soc/rtc.h>

--- a/soc/espressif/esp32c3/vectors.S
+++ b/soc/espressif/esp32c3/vectors.S
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "soc/soc.h"
-#include "soc/interrupt_reg.h"
-#include "riscv/rvruntime-frames.h"
-#include "soc/soc_caps.h"
+#include <soc/soc.h>
+#include <soc/interrupt_reg.h>
+#include <riscv/rvruntime-frames.h>
+#include <soc/soc_caps.h>
 #include <zephyr/toolchain.h>
 
 /* Imports */

--- a/soc/espressif/esp32c5/hpcore_init_ulp.c
+++ b/soc/espressif/esp32c5/hpcore_init_ulp.c
@@ -8,9 +8,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/storage/flash_map.h>
 
-#include "bootloader_flash_priv.h"
-#include "ulp_lp_core.h"
-#include "ulp_lp_core_memory_shared.h"
+#include <bootloader_flash_priv.h>
+#include <ulp_lp_core.h>
+#include <ulp_lp_core_memory_shared.h>
 #include <esp_sleep.h>
 
 LOG_MODULE_REGISTER(lp_core_loader, CONFIG_KERNEL_LOG_LEVEL);

--- a/soc/espressif/esp32c5/hw_init.c
+++ b/soc/espressif/esp32c5/hw_init.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hw_init.h"
+#include <hw_init.h>
 #include <stdint.h>
 #include <esp_cpu.h>
 #include <soc/rtc.h>

--- a/soc/espressif/esp32c5/soc_lpcore.c
+++ b/soc/espressif/esp32c5/soc_lpcore.c
@@ -5,11 +5,11 @@
  */
 
 #include <zephyr/toolchain.h>
-#include "soc/soc_caps.h"
-#include "ulp_lp_core_utils.h"
-#include "ulp_lp_core_interrupts.h"
-#include "ulp_lp_core_lp_timer_shared.h"
-#include "ulp_lp_core_memory_shared.h"
+#include <soc/soc_caps.h>
+#include <ulp_lp_core_utils.h>
+#include <ulp_lp_core_interrupts.h>
+#include <ulp_lp_core_lp_timer_shared.h>
+#include <ulp_lp_core_memory_shared.h>
 #include <soc.h>
 
 extern FUNC_NORETURN void z_cstart(void);

--- a/soc/espressif/esp32c5/vectors.S
+++ b/soc/espressif/esp32c5/vectors.S
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "soc/soc.h"
-#include "soc/interrupt_reg.h"
-#include "riscv/rvruntime-frames.h"
-#include "soc/soc_caps.h"
+#include <soc/soc.h>
+#include <soc/interrupt_reg.h>
+#include <riscv/rvruntime-frames.h>
+#include <soc/soc_caps.h>
 #include <zephyr/toolchain.h>
 
 /* Imports */

--- a/soc/espressif/esp32c5/vectors_lpcore.S
+++ b/soc/espressif/esp32c5/vectors_lpcore.S
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "riscv/rvruntime-frames.h"
+#include <riscv/rvruntime-frames.h>
 #include <soc/soc_caps.h>
 
 	.equ SAVE_REGS, 32

--- a/soc/espressif/esp32c6/hpcore_init_ulp.c
+++ b/soc/espressif/esp32c6/hpcore_init_ulp.c
@@ -8,8 +8,8 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/storage/flash_map.h>
 
-#include "bootloader_flash_priv.h"
-#include "ulp_lp_core.h"
+#include <bootloader_flash_priv.h>
+#include <ulp_lp_core.h>
 #include <esp_sleep.h>
 
 LOG_MODULE_REGISTER(lp_core_loader, CONFIG_KERNEL_LOG_LEVEL);

--- a/soc/espressif/esp32c6/hw_init.c
+++ b/soc/espressif/esp32c6/hw_init.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hw_init.h"
+#include <hw_init.h>
 #include <stdint.h>
 #include <esp_cpu.h>
 #include <soc/rtc.h>

--- a/soc/espressif/esp32c6/soc_lpcore.c
+++ b/soc/espressif/esp32c6/soc_lpcore.c
@@ -5,11 +5,11 @@
  */
 
 #include <zephyr/toolchain.h>
-#include "soc/soc_caps.h"
-#include "ulp_lp_core_utils.h"
-#include "ulp_lp_core_interrupts.h"
-#include "ulp_lp_core_lp_timer_shared.h"
-#include "ulp_lp_core_memory_shared.h"
+#include <soc/soc_caps.h>
+#include <ulp_lp_core_utils.h>
+#include <ulp_lp_core_interrupts.h>
+#include <ulp_lp_core_lp_timer_shared.h>
+#include <ulp_lp_core_memory_shared.h>
 #include <soc.h>
 
 extern FUNC_NORETURN void z_cstart(void);

--- a/soc/espressif/esp32c6/vectors.S
+++ b/soc/espressif/esp32c6/vectors.S
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "soc/soc.h"
-#include "soc/interrupt_reg.h"
-#include "riscv/rvruntime-frames.h"
-#include "soc/soc_caps.h"
+#include <soc/soc.h>
+#include <soc/interrupt_reg.h>
+#include <riscv/rvruntime-frames.h>
+#include <soc/soc_caps.h>
 #include <zephyr/toolchain.h>
 
 /* Imports */

--- a/soc/espressif/esp32c6/vectors_lpcore.S
+++ b/soc/espressif/esp32c6/vectors_lpcore.S
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "riscv/rvruntime-frames.h"
+#include <riscv/rvruntime-frames.h>
 #include <soc/soc_caps.h>
 
 	.equ SAVE_REGS, 32

--- a/soc/espressif/esp32h2/hw_init.c
+++ b/soc/espressif/esp32h2/hw_init.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hw_init.h"
+#include <hw_init.h>
 #include <stdint.h>
 #include <esp_cpu.h>
 #include <soc/rtc.h>

--- a/soc/espressif/esp32h2/vectors.S
+++ b/soc/espressif/esp32h2/vectors.S
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "soc/soc.h"
-#include "soc/interrupt_reg.h"
-#include "riscv/rvruntime-frames.h"
-#include "soc/soc_caps.h"
+#include <soc/soc.h>
+#include <soc/interrupt_reg.h>
+#include <riscv/rvruntime-frames.h>
+#include <soc/soc_caps.h>
 #include <zephyr/toolchain.h>
 
 /* Imports */

--- a/soc/espressif/esp32p4/hpcore_init_ulp.c
+++ b/soc/espressif/esp32p4/hpcore_init_ulp.c
@@ -8,9 +8,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/storage/flash_map.h>
 
-#include "bootloader_flash_priv.h"
-#include "ulp_lp_core.h"
-#include "ulp_lp_core_memory_shared.h"
+#include <bootloader_flash_priv.h>
+#include <ulp_lp_core.h>
+#include <ulp_lp_core_memory_shared.h>
 #include <esp_sleep.h>
 #include <hal/lp_core_ll.h>
 

--- a/soc/espressif/esp32p4/hw_init.c
+++ b/soc/espressif/esp32p4/hw_init.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hw_init.h"
+#include <hw_init.h>
 #include <stdint.h>
 #include <esp_cpu.h>
 #include <soc/rtc.h>

--- a/soc/espressif/esp32p4/soc_lpcore.c
+++ b/soc/espressif/esp32p4/soc_lpcore.c
@@ -5,11 +5,11 @@
  */
 
 #include <zephyr/toolchain.h>
-#include "soc/soc_caps.h"
-#include "ulp_lp_core_utils.h"
-#include "ulp_lp_core_interrupts.h"
-#include "ulp_lp_core_lp_timer_shared.h"
-#include "ulp_lp_core_memory_shared.h"
+#include <soc/soc_caps.h>
+#include <ulp_lp_core_utils.h>
+#include <ulp_lp_core_interrupts.h>
+#include <ulp_lp_core_lp_timer_shared.h>
+#include <ulp_lp_core_memory_shared.h>
 #include <soc.h>
 
 extern FUNC_NORETURN void z_cstart(void);

--- a/soc/espressif/esp32p4/vectors.S
+++ b/soc/espressif/esp32p4/vectors.S
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "soc/soc.h"
-#include "soc/interrupt_reg.h"
-#include "riscv/rvruntime-frames.h"
-#include "soc/soc_caps.h"
+#include <soc/soc.h>
+#include <soc/interrupt_reg.h>
+#include <riscv/rvruntime-frames.h>
+#include <soc/soc_caps.h>
 #include <zephyr/toolchain.h>
 
 /* Imports */

--- a/soc/espressif/esp32p4/vectors_lpcore.S
+++ b/soc/espressif/esp32p4/vectors_lpcore.S
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "riscv/rvruntime-frames.h"
+#include <riscv/rvruntime-frames.h>
 #include <soc/soc_caps.h>
 
 	.equ SAVE_REGS, 32

--- a/soc/espressif/esp32s2/hw_init.c
+++ b/soc/espressif/esp32s2/hw_init.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hw_init.h"
+#include <hw_init.h>
 #include <stdint.h>
 #include <esp_cpu.h>
 

--- a/soc/espressif/esp32s3/esp32s3-mp.c
+++ b/soc/espressif/esp32s3/esp32s3-mp.c
@@ -13,18 +13,18 @@
 #include <soc.h>
 #include <esp_log.h>
 #include <esp_cpu.h>
-#include "esp_rom_serial_output.h"
+#include <esp_rom_serial_output.h>
 
-#include "esp_mcuboot_image.h"
-#include "esp_memory_utils.h"
-#include "hw_init.h"
+#include <esp_mcuboot_image.h>
+#include <esp_memory_utils.h>
+#include <hw_init.h>
 
 #define TAG "amp"
 
 /* AMP support */
 #ifdef CONFIG_SOC_ENABLE_APPCPU
 
-#include "bootloader_flash_priv.h"
+#include <bootloader_flash_priv.h>
 
 #define sys_mmap   bootloader_mmap
 #define sys_munmap bootloader_munmap

--- a/soc/espressif/esp32s3/hw_init.c
+++ b/soc/espressif/esp32s3/hw_init.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "hw_init.h"
+#include <hw_init.h>
 #include <stdint.h>
 #include <esp_cpu.h>
 #include <soc/rtc.h>

--- a/soc/espressif/esp32s3/soc_appcpu.c
+++ b/soc/espressif/esp32s3/soc_appcpu.c
@@ -29,7 +29,7 @@
 #include <hal/wdt_hal.h>
 #include <hal/cpu_hal.h>
 #include <soc/gpio_periph.h>
-#include "esp_cpu.h"
+#include <esp_cpu.h>
 #include <esp_err.h>
 #include <esp_timer.h>
 #include <esp_app_format.h>

--- a/tests/boards/espressif/ethernet/src/main.c
+++ b/tests/boards/espressif/ethernet/src/main.c
@@ -17,7 +17,7 @@
 
 LOG_MODULE_REGISTER(ethernet_test, LOG_LEVEL_INF);
 
-#include "net_private.h"
+#include <net_private.h>
 
 #define DHCP_OPTION_NTP (42)
 #define TEST_DATA       "ICMP dummy data"

--- a/tests/boards/espressif/nocache/src/main.c
+++ b/tests/boards/espressif/nocache/src/main.c
@@ -10,8 +10,8 @@
 #include <zephyr/linker/linker-defs.h>
 #include <riscv/csr.h>
 
-#include "soc/soc.h"
-#include "cache.h"
+#include <soc/soc.h>
+#include <cache.h>
 
 #define TEST_PATTERN_A 0xA5A5A5A5U
 

--- a/tests/boards/espressif/wifi/src/main.c
+++ b/tests/boards/espressif/wifi/src/main.c
@@ -13,11 +13,11 @@
 #include <zephyr/net/wifi_nm.h>
 #include <zephyr/net/icmp.h>
 
-#include "icmpv4.h"
+#include <icmpv4.h>
 
 LOG_MODULE_REGISTER(wifi_test, LOG_LEVEL_INF);
 
-#include "net_private.h"
+#include <net_private.h>
 
 K_SEM_DEFINE(wifi_event, 0, 1);
 


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Espressif related paths and manually selecting the applicable changes:
```
$ find soc/espressif/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;
