### PR TITLE
renesas: Diamond include for non-local header files

### DIFF
--- a/samples/boards/renesas/ctsu_input/src/main.c
+++ b/samples/boards/renesas/ctsu_input/src/main.c
@@ -12,7 +12,7 @@
 #include <zephyr/input/input_renesas_rx_ctsu.h>
 
 #ifdef CONFIG_INPUT_RENESAS_RX_QE_TOUCH_CFG
-#include "qe_touch_config.h"
+#include <qe_touch_config.h>
 #endif /* CONFIG_INPUT_RENESAS_RX_QE_TOUCH_CFG */
 
 static const struct device *const test_touch_dev = DEVICE_DT_GET(DT_NODELABEL(ctsu));

--- a/samples/boards/renesas/ctsu_input/src/qe_generated_files/qe_touch_config.h
+++ b/samples/boards/renesas/ctsu_input/src/qe_generated_files/qe_touch_config.h
@@ -7,8 +7,8 @@
 #ifndef QE_TOUCH_CONFIG_H
 #define QE_TOUCH_CONFIG_H
 
-#include "r_ctsu_qe.h"
-#include "rm_touch_qe.h"
+#include <r_ctsu_qe.h>
+#include <rm_touch_qe.h>
 #include "qe_touch_define.h"
 
 /* Exported global variables */

--- a/soc/renesas/ra/ra4m1/pinctrl_soc.h
+++ b/soc/renesas/ra/ra4m1/pinctrl_soc.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "../common/pinctrl_ra.h"
+#include <../common/pinctrl_ra.h>

--- a/soc/renesas/rx/common/reg_protection.c
+++ b/soc/renesas/rx/common/reg_protection.c
@@ -8,7 +8,7 @@
 #include <zephyr/irq.h>
 #include "reg_protection.h"
 #if CONFIG_HAS_RENESAS_RX_RDP
-#include "r_bsp_cpu.h"
+#include <r_bsp_cpu.h>
 #endif
 
 #define PRCR_KEY    (0xA500)

--- a/soc/renesas/rx/rx130/soc.c
+++ b/soc/renesas/rx/rx130/soc.c
@@ -14,8 +14,8 @@
 #include <zephyr/arch/cpu.h>
 #include <soc.h>
 
-#include "platform.h"
-#include "r_bsp_cpu.h"
+#include <platform.h>
+#include <r_bsp_cpu.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/renesas/rx/rx130/soc.h
+++ b/soc/renesas/rx/rx130/soc.h
@@ -11,7 +11,7 @@
 #ifndef _SOC_H_
 #define _SOC_H_
 
-#include "reg_protection.h"
+#include <reg_protection.h>
 #include <mcu_clocks.h>
 
 #endif /* _SOC_H_ */

--- a/soc/renesas/rx/rx140/soc.c
+++ b/soc/renesas/rx/rx140/soc.c
@@ -14,8 +14,8 @@
 #include <zephyr/arch/cpu.h>
 #include <soc.h>
 
-#include "platform.h"
-#include "r_bsp_cpu.h"
+#include <platform.h>
+#include <r_bsp_cpu.h>
 
 void soc_early_init_hook(void)
 {

--- a/soc/renesas/rx/rx140/soc.h
+++ b/soc/renesas/rx/rx140/soc.h
@@ -11,7 +11,7 @@
 #ifndef _SOC_H_
 #define _SOC_H_
 
-#include "reg_protection.h"
+#include <reg_protection.h>
 #include <mcu_clocks.h>
 
 #endif /* _SOC_H_ */

--- a/soc/renesas/rx/rx14t/soc.c
+++ b/soc/renesas/rx/rx14t/soc.c
@@ -14,8 +14,8 @@
 #include <zephyr/arch/cpu.h>
 #include <soc.h>
 
-#include "platform.h"
-#include "r_bsp_cpu.h"
+#include <platform.h>
+#include <r_bsp_cpu.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/renesas/rx/rx14t/soc.h
+++ b/soc/renesas/rx/rx14t/soc.h
@@ -12,6 +12,6 @@
 #define _SOC_H_
 
 #include <mcu_clocks.h>
-#include "reg_protection.h"
+#include <reg_protection.h>
 
 #endif /* _SOC_H_ */

--- a/soc/renesas/rx/rx261/soc.c
+++ b/soc/renesas/rx/rx261/soc.c
@@ -14,8 +14,8 @@
 #include <zephyr/arch/cpu.h>
 #include <soc.h>
 
-#include "platform.h"
-#include "r_bsp_cpu.h"
+#include <platform.h>
+#include <r_bsp_cpu.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/renesas/rx/rx261/soc.h
+++ b/soc/renesas/rx/rx261/soc.h
@@ -11,7 +11,7 @@
 #ifndef _SOC_H_
 #define _SOC_H_
 
-#include "reg_protection.h"
+#include <reg_protection.h>
 #include <mcu_clocks.h>
 
 #endif /* _SOC_H_ */

--- a/soc/renesas/rx/rx26t/soc.c
+++ b/soc/renesas/rx/rx26t/soc.c
@@ -14,8 +14,8 @@
 #include <zephyr/arch/cpu.h>
 #include <soc.h>
 
-#include "platform.h"
-#include "r_bsp_cpu.h"
+#include <platform.h>
+#include <r_bsp_cpu.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/renesas/rx/rx26t/soc.h
+++ b/soc/renesas/rx/rx26t/soc.h
@@ -12,6 +12,6 @@
 #define _SOC_H_
 
 #include <mcu_clocks.h>
-#include "reg_protection.h"
+#include <reg_protection.h>
 
 #endif /* _SOC_H_ */

--- a/soc/renesas/rx/rx62n/soc.h
+++ b/soc/renesas/rx/rx62n/soc.h
@@ -7,6 +7,6 @@
 #ifndef __RX62N_SOC_H__
 #define __RX62N_SOC_H__
 
-#include "reg_protection.h"
+#include <reg_protection.h>
 
 #endif /* __RX62N_SOC_H__ */

--- a/soc/renesas/rz/common/pinctrl_rza.h
+++ b/soc/renesas/rz/common/pinctrl_rza.h
@@ -8,7 +8,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
-#include "r_ioport.h"
+#include <r_ioport.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/renesas/rz/common/pinctrl_rzg.h
+++ b/soc/renesas/rz/common/pinctrl_rzg.h
@@ -8,7 +8,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
-#include "r_ioport.h"
+#include <r_ioport.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/renesas/rz/common/pinctrl_rzn.h
+++ b/soc/renesas/rz/common/pinctrl_rzn.h
@@ -7,7 +7,7 @@
 
 #include <zephyr/types.h>
 #include <zephyr/devicetree.h>
-#include "r_ioport.h"
+#include <r_ioport.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/renesas/rz/common/pinctrl_rzt.h
+++ b/soc/renesas/rz/common/pinctrl_rzt.h
@@ -7,7 +7,7 @@
 
 #include <zephyr/types.h>
 #include <zephyr/devicetree.h>
-#include "r_ioport.h"
+#include <r_ioport.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/renesas/rz/common/pinctrl_rzv.h
+++ b/soc/renesas/rz/common/pinctrl_rzv.h
@@ -8,7 +8,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
-#include "r_ioport.h"
+#include <r_ioport.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Renesas related paths and manually selecting the applicable changes:
```
$ find soc/renesas/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;