### PR TITLE
nordic: Diamond include for non-local header files

### DIFF
--- a/boards/native/nrf_bsim/argparse.c
+++ b/boards/native/nrf_bsim/argparse.c
@@ -6,14 +6,14 @@
  */
 #include <stdbool.h>
 #include <stdlib.h>
-#include "bs_tracing.h"
-#include "bstests.h"
-#include "bs_cmd_line.h"
-#include "bs_dynargs.h"
-#include "posix_native_task.h"
-#include "nsi_tracing.h"
-#include "nsi_main.h"
-#include "nsi_cpu_ctrl.h"
+#include <bs_tracing.h>
+#include <bstests.h>
+#include <bs_cmd_line.h>
+#include <bs_dynargs.h>
+#include <posix_native_task.h>
+#include <nsi_tracing.h>
+#include <nsi_main.h>
+#include <nsi_cpu_ctrl.h>
 
 static const char exe_name[] = "nrf_bsim options:";
 

--- a/boards/native/nrf_bsim/argparse.h
+++ b/boards/native/nrf_bsim/argparse.h
@@ -6,7 +6,7 @@
 #ifndef BSIM_NRF_ARGS_H
 #define BSIM_NRF_ARGS_H
 
-#include "bsim_args_runner.h"
+#include <bsim_args_runner.h>
 
 /* This header is present to avoid breaking backwards compatibility with old bsim tests */
 

--- a/boards/native/nrf_bsim/board_soc.h
+++ b/boards/native/nrf_bsim/board_soc.h
@@ -28,8 +28,8 @@
 #include <stddef.h>
 #include <zephyr/irq.h>
 #include <nrfx.h>
-#include "cmsis.h"
-#include "soc_nrf_common.h"
+#include <cmsis.h>
+#include <soc_nrf_common.h>
 
 /* For offloading interrupts we can use any free interrupt */
 #if defined(CONFIG_BOARD_NRF52_BSIM)

--- a/boards/native/nrf_bsim/common/bsim_args_runner.c
+++ b/boards/native/nrf_bsim/common/bsim_args_runner.c
@@ -16,18 +16,18 @@
 #include <stdbool.h>
 #include <limits.h>
 #include <string.h>
-#include "bs_cmd_line.h"
-#include "bs_cmd_line_typical.h"
-#include "bs_dynargs.h"
-#include "bs_tracing.h"
-#include "bs_dump_files.h"
-#include "bs_rand_main.h"
-#include "nsi_cpu_if.h"
-#include "nsi_tasks.h"
-#include "nsi_main.h"
-#include "nsi_cpu_ctrl.h"
-#include "NRF_HWLowL.h"
-#include "NHW_misc.h"
+#include <bs_cmd_line.h>
+#include <bs_cmd_line_typical.h>
+#include <bs_dynargs.h>
+#include <bs_tracing.h>
+#include <bs_dump_files.h>
+#include <bs_rand_main.h>
+#include <nsi_cpu_if.h>
+#include <nsi_tasks.h>
+#include <nsi_main.h>
+#include <nsi_cpu_ctrl.h>
+#include <NRF_HWLowL.h>
+#include <NHW_misc.h>
 
 static bs_args_struct_t *args_struct;
 /* Direct use of this global is deprecated, use bsim_args_get_global_device_nbr() instead */

--- a/boards/native/nrf_bsim/common/bsim_args_runner.h
+++ b/boards/native/nrf_bsim/common/bsim_args_runner.h
@@ -8,7 +8,7 @@
 #define BOARDS_POSIX_BSIM_COMMON_BSIM_ARGS_RUNNER_H
 
 #include <stdint.h>
-#include "bs_cmd_line.h"
+#include <bs_cmd_line.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/native/nrf_bsim/common/bsim_extra_cpu_if_stubs.c
+++ b/boards/native/nrf_bsim/common/bsim_extra_cpu_if_stubs.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bs_tracing.h"
-#include "nsi_cpu_if.h"
+#include <bs_tracing.h>
+#include <nsi_cpu_if.h>
 
 /*
  * Default (weak) implementation for nsif_cpu<n>_save_test_arg() expected by the argument

--- a/boards/native/nrf_bsim/common/bstests.h
+++ b/boards/native/nrf_bsim/common/bstests.h
@@ -6,7 +6,7 @@
 #ifndef _BSTESTS_ENTRY_H
 #define _BSTESTS_ENTRY_H
 
-#include "bs_types.h"
+#include <bs_types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/native/nrf_bsim/common/bstests_entry.c
+++ b/boards/native/nrf_bsim/common/bstests_entry.c
@@ -6,11 +6,11 @@
 #include <zephyr/init.h>
 #include <stdint.h>
 #include <string.h>
-#include "bs_types.h"
-#include "bs_tracing.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
 #include "bstests.h"
-#include "bs_oswrap.h"
-#include "nsi_host_trampolines.h"
+#include <bs_oswrap.h>
+#include <nsi_host_trampolines.h>
 
 /*
  * Result of the testcase execution.
@@ -251,7 +251,7 @@ uint8_t bst_delete(void)
 }
 
 #if defined(CONFIG_NATIVE_SIMULATOR_MCU_N)
-#include "bstest_ticker.h"
+#include <bstest_ticker.h>
 
 void bst_ticker_set_period(bs_time_t tick_period)
 {

--- a/boards/native/nrf_bsim/common/cmsis/cmsis.c
+++ b/boards/native/nrf_bsim/common/cmsis/cmsis.c
@@ -6,11 +6,11 @@
  */
 
 #include <stdint.h>
-#include "irq_ctrl.h"
-#include "posix_core.h"
-#include "posix_board_if.h"
-#include "board_soc.h"
-#include "bs_tracing.h"
+#include <irq_ctrl.h>
+#include <posix_core.h>
+#include <posix_board_if.h>
+#include <board_soc.h>
+#include <bs_tracing.h>
 
 /*
  *  Replacement for ARMs NVIC functions()

--- a/boards/native/nrf_bsim/common/cmsis/cmsis.h
+++ b/boards/native/nrf_bsim/common/cmsis/cmsis.h
@@ -15,7 +15,7 @@
 #include <stdint.h>
 #include "cmsis_instr.h"
 #if defined(CONFIG_SOC_COMPATIBLE_NRF52833)
-#include "mdk/nrf52833.h"
+#include <mdk/nrf52833.h>
 #endif
 
 #ifdef __cplusplus

--- a/boards/native/nrf_bsim/common/phy_sync_ctrl.c
+++ b/boards/native/nrf_bsim/common/phy_sync_ctrl.c
@@ -7,15 +7,15 @@
 
 #include <stddef.h>
 #include <stdbool.h>
-#include "bs_cmd_line.h"
-#include "bs_dynargs.h"
-#include "bs_utils.h"
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "nsi_tasks.h"
-#include "nsi_hws_models_if.h"
-#include "NRF_HWLowL.h"
-#include "xo_if.h"
+#include <bs_cmd_line.h>
+#include <bs_dynargs.h>
+#include <bs_utils.h>
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <nsi_tasks.h>
+#include <nsi_hws_models_if.h>
+#include <NRF_HWLowL.h>
+#include <xo_if.h>
 #include "bsim_args_runner.h"
 
 /* By default every second we will inform the Phy simulator about our timing */

--- a/boards/native/nrf_bsim/common/phy_sync_ctrl.h
+++ b/boards/native/nrf_bsim/common/phy_sync_ctrl.h
@@ -7,7 +7,7 @@
 #ifndef BOARDS_POSIX_BSIM_COMMON_PHY_SYNC_CTRL_H
 #define BOARDS_POSIX_BSIM_COMMON_PHY_SYNC_CTRL_H
 
-#include "bs_types.h"
+#include <bs_types.h>
 
 #ifdef __cplusplus
 extern "C"{

--- a/boards/native/nrf_bsim/common/posix_arch_if.c
+++ b/boards/native/nrf_bsim/common/posix_arch_if.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "nsi_main.h"
+#include <nsi_main.h>
 
 void posix_exit(int exit_code)
 {

--- a/boards/native/nrf_bsim/common/runner_hooks.c
+++ b/boards/native/nrf_bsim/common/runner_hooks.c
@@ -7,13 +7,13 @@
  * this file should therefore only be built once for all CPUs.
  */
 
-#include "bs_tracing.h"
-#include "bs_dump_files.h"
-#include "bs_pc_backchannel.h"
-#include "nsi_tasks.h"
-#include "nsi_main.h"
-#include "nsi_hw_scheduler.h"
-#include "NRF_HWLowL.h"
+#include <bs_tracing.h>
+#include <bs_dump_files.h>
+#include <bs_pc_backchannel.h>
+#include <nsi_tasks.h>
+#include <nsi_main.h>
+#include <nsi_hw_scheduler.h>
+#include <NRF_HWLowL.h>
 #include "bsim_args_runner.h"
 
 static bool bsim_disconnect_on_exit;

--- a/boards/native/nrf_bsim/common/trace_hook.c
+++ b/boards/native/nrf_bsim/common/trace_hook.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <stdarg.h>
-#include "bs_tracing.h"
+#include <bs_tracing.h>
 
 /*
  * Provide the posix_print_* functions required from all POSIX arch boards

--- a/boards/native/nrf_bsim/cpu_wait.c
+++ b/boards/native/nrf_bsim/cpu_wait.c
@@ -7,11 +7,11 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "fake_timer.h"
+#include <fake_timer.h>
 #include <zephyr/arch/posix/posix_soc_if.h>
 #include <posix_board_if.h>
 #include <posix_soc.h>
-#include "nsi_hw_scheduler.h"
+#include <nsi_hw_scheduler.h>
 
 /**
  * Replacement to the kernel k_busy_wait()

--- a/boards/native/nrf_bsim/gpiote_nrfx_bsim.c
+++ b/boards/native/nrf_bsim/gpiote_nrfx_bsim.c
@@ -5,7 +5,7 @@
 
 #include <zephyr/kernel.h>
 #include <nrfx_gpiote.h>
-#include "gpiote_nrfx.h"
+#include <gpiote_nrfx.h>
 
 #define GPIOTE_NRFX_INST_IDX(idx) DT_CAT3(NRFX_GPIOTE, idx, _INST_IDX)
 #define GPIOTE_INST_IDX(node_id) GPIOTE_NRFX_INST_IDX(DT_PROP(node_id, instance))

--- a/boards/native/nrf_bsim/ipc_backend.c
+++ b/boards/native/nrf_bsim/ipc_backend.c
@@ -15,7 +15,7 @@
  * with the network core image alone, as we would lack this buffer during linking.
  */
 
-#include "nsi_cpu_if.h"
+#include <nsi_cpu_if.h>
 #include <zephyr/device.h>
 
 #define DT_DRV_COMPAT zephyr_ipc_openamp_static_vrings

--- a/boards/native/nrf_bsim/irq_handler.c
+++ b/boards/native/nrf_bsim/irq_handler.c
@@ -9,16 +9,16 @@
 #include <stdint.h>
 #include <zephyr/irq_offload.h>
 #include <zephyr/kernel_structs.h>
-#include "kernel_internal.h"
-#include "kswap.h"
-#include "irq_ctrl.h"
-#include "posix_core.h"
+#include <kernel_internal.h>
+#include <kswap.h>
+#include <irq_ctrl.h>
+#include <posix_core.h>
 #include "board_soc.h"
 #include <zephyr/sw_isr_table.h>
-#include "soc.h"
-#include "bs_tracing.h"
+#include <soc.h>
+#include <bs_tracing.h>
 #include <zephyr/tracing/tracing.h>
-#include "bstests.h"
+#include <bstests.h>
 
 static bool CPU_will_be_awaken_from_WFE;
 

--- a/boards/native/nrf_bsim/native_remap.c
+++ b/boards/native/nrf_bsim/native_remap.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <stdbool.h>
-#include "NHW_misc.h"
+#include <NHW_misc.h>
 
 bool native_emb_addr_remap(void **addr)
 {

--- a/boards/native/nrf_bsim/nsi_if.c
+++ b/boards/native/nrf_bsim/nsi_if.c
@@ -9,12 +9,12 @@
 #include <soc.h>
 #include <posix_native_task.h>
 #include <nsi_cpu_if.h>
-#include "bstests.h"
-#include "bs_tracing.h"
-#include "phy_sync_ctrl.h"
-#include "nsi_hw_scheduler.h"
-#include "nsi_cpu_ctrl.h"
-#include "nsi_host_trampolines.h"
+#include <bstests.h>
+#include <bs_tracing.h>
+#include <phy_sync_ctrl.h>
+#include <nsi_hw_scheduler.h>
+#include <nsi_cpu_ctrl.h>
+#include <nsi_host_trampolines.h>
 
 /*
  * These hooks are to be named nsif_cpu<cpu_number>_<hook_name>, for example nsif_cpu0_boot

--- a/boards/native/nrf_bsim/time_machine.h
+++ b/boards/native/nrf_bsim/time_machine.h
@@ -6,8 +6,8 @@
 #ifndef _BOARD_POSIX_NRF52_BSIM_TIME_MACHINE_H
 #define _BOARD_POSIX_NRF52_BSIM_TIME_MACHINE_H
 
-#include "bs_types.h"
-#include "time_machine_if.h"
+#include <bs_types.h>
+#include <time_machine_if.h>
 #include <zephyr/toolchain.h>
 
 #ifdef __cplusplus

--- a/modules/hal_nordic/nrf_802154/nrf_802154_assert_handler.c
+++ b/modules/hal_nordic/nrf_802154/nrf_802154_assert_handler.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include "nrf_802154_assert_zephyr.h"
+#include <nrf_802154_assert_zephyr.h>
 
 #if defined(CONFIG_NRF_802154_ASSERT_ZEPHYR_MINIMAL)
 

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_init_net.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_init_net.c
@@ -6,8 +6,8 @@
 
 #include <zephyr/init.h>
 
-#include "nrf_802154.h"
-#include "nrf_802154_serialization.h"
+#include <nrf_802154.h>
+#include <nrf_802154_serialization.h>
 
 static int serialization_init(void)
 {

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_serialization_crit_sect.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_serialization_crit_sect.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "nrf_802154_serialization_crit_sect.h"
+#include <nrf_802154_serialization_crit_sect.h>
 
 #ifndef TEST
 #include <zephyr/irq.h>

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
@@ -14,11 +14,11 @@
 #include <hal/nrf_spu.h>
 #endif
 
-#include "nrf_802154.h"
-#include "nrf_802154_spinel_backend_callouts.h"
-#include "nrf_802154_serialization_error.h"
-#include "../../spinel_base/spinel.h"
-#include "../../src/include/nrf_802154_spinel.h"
+#include <nrf_802154.h>
+#include <nrf_802154_spinel_backend_callouts.h>
+#include <nrf_802154_serialization_error.h>
+#include <../../spinel_base/spinel.h>
+#include <../../src/include/nrf_802154_spinel.h>
 
 #define LOG_LEVEL LOG_LEVEL_INFO
 #define LOG_MODULE_NAME spinel_ipc_backend

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_response_notifier.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_response_notifier.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "nrf_802154_spinel_response_notifier.h"
+#include <nrf_802154_spinel_response_notifier.h>
 
 #include <assert.h>
 #include <string.h>
@@ -12,8 +12,8 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/kernel.h>
 
-#include "../spinel_base/spinel.h"
-#include "nrf_802154_spinel_log.h"
+#include <../spinel_base/spinel.h>
+#include <nrf_802154_spinel_log.h>
 
 #define LOG_LEVEL LOG_LEVEL_INFO
 #define LOG_MODULE_NAME spinel_ipc_backend_rsp_ntf

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_temperature_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_temperature_zephyr.c
@@ -11,7 +11,7 @@
  *
  */
 
-#include "platform/nrf_802154_temperature.h"
+#include <platform/nrf_802154_temperature.h>
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>

--- a/modules/hal_nordic/nrfx/nrfx_config.h
+++ b/modules/hal_nordic/nrfx/nrfx_config.h
@@ -25,9 +25,9 @@
 
 /* Include babble-sim configuration. */
 #if defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
-#include "nrfx_config_bsim.h"
+#include <nrfx_config_bsim.h>
 #endif
 
 /* Use defaults for undefined symbols. */
-#include "nrfx_templates_config.h"
+#include <nrfx_templates_config.h>
 #endif // NRFX_CONFIG_H__

--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -314,7 +314,7 @@ void nrfx_busy_wait(uint32_t usec_to_wait);
 void nrfx_isr(const void *irq_handler);
 
 #if defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
-#include "nrfx_glue_bsim.h"
+#include <nrfx_glue_bsim.h>
 #endif
 
 /** @} */

--- a/modules/nrf_wifi/os/shim.c
+++ b/modules/nrf_wifi/os/shim.c
@@ -25,8 +25,8 @@
 #include "shim.h"
 #include "work.h"
 #include "timer.h"
-#include "osal_ops.h"
-#include "common/hal_structs_common.h"
+#include <osal_ops.h>
+#include <common/hal_structs_common.h>
 
 LOG_MODULE_REGISTER(wifi_nrf, CONFIG_WIFI_NRF70_LOG_LEVEL);
 

--- a/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/app_gpio.c
+++ b/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/app_gpio.c
@@ -9,7 +9,7 @@
 #include <zephyr/kernel.h>
 
 #include "app_gpio.h"
-#include "publisher.h"
+#include <publisher.h>
 
 K_WORK_DEFINE(button_work, publish);
 

--- a/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -8,12 +8,12 @@
 #include <zephyr/drivers/gpio.h>
 
 #include "app_gpio.h"
-#include "ble_mesh.h"
-#include "device_composition.h"
-#include "no_transition_work_handler.h"
-#include "state_binding.h"
+#include <ble_mesh.h>
+#include <device_composition.h>
+#include <no_transition_work_handler.h>
+#include <state_binding.h>
 #include "storage.h"
-#include "transition.h"
+#include <transition.h>
 
 static bool reset;
 

--- a/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -6,11 +6,11 @@
  */
 
 #include "ble_mesh.h"
-#include "common.h"
+#include <common.h>
 #include "device_composition.h"
 #include "state_binding.h"
 #include "transition.h"
-#include "storage.h"
+#include <storage.h>
 
 static struct bt_mesh_health_srv health_srv = {
 };

--- a/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/mesh/no_transition_work_handler.c
+++ b/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/mesh/no_transition_work_handler.c
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "common.h"
+#include <common.h>
 #include "ble_mesh.h"
 #include "device_composition.h"
 #include "state_binding.h"
-#include "storage.h"
+#include <storage.h>
 
 static void unsolicitedly_publish_states_work_handler(struct k_work *work)
 {

--- a/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
+++ b/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
@@ -7,7 +7,7 @@
 
 #include <zephyr/drivers/gpio.h>
 
-#include "app_gpio.h"
+#include <app_gpio.h>
 #include "ble_mesh.h"
 #include "device_composition.h"
 #include "publisher.h"

--- a/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
+++ b/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
@@ -10,7 +10,7 @@
 #include "ble_mesh.h"
 #include "device_composition.h"
 #include "state_binding.h"
-#include "storage.h"
+#include <storage.h>
 #include "transition.h"
 
 static int32_t ceiling(float num)

--- a/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
+++ b/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
@@ -6,7 +6,7 @@
  */
 
 #include "ble_mesh.h"
-#include "common.h"
+#include <common.h>
 #include "device_composition.h"
 #include "state_binding.h"
 #include "transition.h"

--- a/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/storage.c
+++ b/samples/boards/nordic/mesh/onoff_level_lighting_vnd_app/src/storage.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "ble_mesh.h"
-#include "device_composition.h"
+#include <ble_mesh.h>
+#include <device_composition.h>
 #include "storage.h"
 
 static uint8_t storage_id;

--- a/samples/boards/nordic/nrf53_sync_rtc/src/main.c
+++ b/samples/boards/nordic/nrf53_sync_rtc/src/main.c
@@ -12,7 +12,7 @@
 LOG_MODULE_REGISTER(main);
 
 #if (CONFIG_SOC_SERIES_BSIM_NRFXX)
-#include "nsi_cpu_if.h"
+#include <nsi_cpu_if.h>
 
 /* For simulation, we can define shared memory variables linkable from
  * other MCUs just by using NATIVE_SIMULATOR_IF

--- a/soc/nordic/common/soc_secure.c
+++ b/soc/nordic/common/soc_secure.c
@@ -7,8 +7,8 @@
 #include <soc_secure.h>
 #include <errno.h>
 
-#include "tfm_platform_api.h"
-#include "tfm_ioctl_api.h"
+#include <tfm_platform_api.h>
+#include <tfm_ioctl_api.h>
 
 #if NRF_GPIO_HAS_SEL
 void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_sel_t mcu)

--- a/tests/bsim/babblekit/include/babblekit/testcase.h
+++ b/tests/bsim/babblekit/include/babblekit/testcase.h
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bs_tracing.h"
-#include "bs_types.h"
-#include "bstests.h"
+#include <bs_tracing.h>
+#include <bs_types.h>
+#include <bstests.h>
 
 extern enum bst_result_t bst_result;
 

--- a/tests/bsim/babblekit/src/device.c
+++ b/tests/bsim/babblekit/src/device.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "argparse.h"
-#include "bs_types.h"
+#include <argparse.h>
+#include <bs_types.h>
 
 unsigned int bk_device_get_number(void)
 {

--- a/tests/bsim/babblekit/src/sync.c
+++ b/tests/bsim/babblekit/src/sync.c
@@ -6,11 +6,11 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
-#include "argparse.h"
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "time_machine.h"
-#include "bs_pc_backchannel.h"
+#include <argparse.h>
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <time_machine.h>
+#include <bs_pc_backchannel.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sync, CONFIG_LOG_DEFAULT_LEVEL);

--- a/tests/bsim/net/sockets/echo_test/src/echo_test.c
+++ b/tests/bsim/net/sockets/echo_test/src/echo_test.c
@@ -5,13 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bs_types.h"
-#include "bs_tracing.h"
-#include "bs_utils.h"
-#include "time_machine.h"
-#include "bstests.h"
+#include <bs_types.h>
+#include <bs_tracing.h>
+#include <bs_utils.h>
+#include <time_machine.h>
+#include <bstests.h>
 
-#include "common.h" /* From echo_client */
+#include <common.h> /* From echo_client */
 
 #if defined(CONFIG_NET_L2_OPENTHREAD)
 /* Open thread takes ~15 seconds to connect in ideal conditions */

--- a/tests/bsim/net/sockets/echo_test/src/test_main.c
+++ b/tests/bsim/net/sockets/echo_test/src/test_main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "bstests.h"
+#include <bstests.h>
 
 extern struct bst_test_list *test_echo_client_install(struct bst_test_list *tests);
 


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Nordic related paths and manually selecting the applicable changes:
```
$ find soc/nordic/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;