### PR TITLE
infineon: Diamond include for non-local header files

### DIFF
--- a/boards/infineon/cyw920829m2evk_02/config/qspi_memslot.h
+++ b/boards/infineon/cyw920829m2evk_02/config/qspi_memslot.h
@@ -8,7 +8,7 @@
 #ifndef QSPI_MEMSLOT_H
 #define QSPI_MEMSLOT_H
 
-#include "cy_smif_memslot.h"
+#include <cy_smif_memslot.h>
 
 /* Slave Select Pin */
 #define QSPI_SLAVE_SELECT (P2_0)

--- a/soc/infineon/cat1a/psoc6_legacy/soc.c
+++ b/soc/infineon/cat1a/psoc6_legacy/soc.c
@@ -9,11 +9,11 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/irq.h>
 
-#include "cy_syslib.h"
-#include "cy_gpio.h"
-#include "cy_scb_uart.h"
-#include "cy_syspm.h"
-#include "cy_sysclk.h"
+#include <cy_syslib.h>
+#include <cy_gpio.h>
+#include <cy_scb_uart.h>
+#include <cy_syspm.h>
+#include <cy_sysclk.h>
 
 #define CY_CFG_SYSCLK_CLKFAST_ENABLED 1
 #define CY_CFG_SYSCLK_FLL_ENABLED 1

--- a/soc/infineon/cat1b/cyw20829/smif_pm.c
+++ b/soc/infineon/cat1b/cyw20829/smif_pm.c
@@ -15,8 +15,8 @@
  */
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
-#include "cyhal.h"
-#include "qspi_memslot.h"
+#include <cyhal.h>
+#include <qspi_memslot.h>
 #include "smif_pm.h"
 
 

--- a/soc/infineon/cat1b/cyw20829/soc.c
+++ b/soc/infineon/cat1b/cyw20829/soc.c
@@ -14,7 +14,7 @@
 
 #include <cy_sysint.h>
 #include <system_cat1b.h>
-#include "cy_pdl.h"
+#include <cy_pdl.h>
 
 /* Power profiles definition */
 #define CY_CFG_PWR_MODE_POWER_PROFILE_0  0 /* LP MCU + Radio ON */

--- a/soc/infineon/edge/pse84/mtb_ipc_config.h
+++ b/soc/infineon/edge/pse84/mtb_ipc_config.h
@@ -28,7 +28,7 @@
 #ifndef SOC_INFINEON_EDGE_PSE84_MTB_IPC_CONFIG_H_
 #define SOC_INFINEON_EDGE_PSE84_MTB_IPC_CONFIG_H_
 
-#include "mtb_ipc.h"
+#include <mtb_ipc.h>
 
 
 /** Define the channel used to set up the IPC instance set up for SRF operations*/

--- a/soc/infineon/edge/pse84/mtb_srf_config.h
+++ b/soc/infineon/edge/pse84/mtb_srf_config.h
@@ -23,7 +23,7 @@
 #ifndef SOC_INFINEON_EDGE_PSE84_MTB_SRF_CONFIG_H_
 #define SOC_INFINEON_EDGE_PSE84_MTB_SRF_CONFIG_H_
 
-#include "mtb_srf_iovec.h"
+#include <mtb_srf_iovec.h>
 
 /** Maximum input argument count in bytes, adjusting the default BSP-generated pool */
 #define MTB_SRF_MAX_ARG_IN_SIZE                 (5U * sizeof(uint32_t))

--- a/soc/infineon/edge/pse84/security_config/pse84_boot.h
+++ b/soc/infineon/edge/pse84/security_config/pse84_boot.h
@@ -11,10 +11,10 @@
 #include <cy_sysint.h>
 #include <system_edge.h>
 #include "pse84_s_sau.h"
-#include "cy_pdl.h"
+#include <cy_pdl.h>
 
 #if defined(CONFIG_SOC_PSE84_M55_ENABLE)
-#include "partition_ARMCM33.h"
+#include <partition_ARMCM33.h>
 #include <zephyr/drivers/timer/system_timer.h>
 
 #include "pse84_s_system.h"

--- a/soc/infineon/edge/pse84/security_config/pse84_s_mpc.h
+++ b/soc/infineon/edge/pse84/security_config/pse84_s_mpc.h
@@ -11,8 +11,8 @@
 #include <stdint.h>
 
 #include <infineon_kconfig.h>
-#include "cy_device.h"
-#include "cy_mpc.h"
+#include <cy_device.h>
+#include <cy_mpc.h>
 
 cy_rslt_t cy_mpc_init(void);
 

--- a/soc/infineon/edge/pse84/security_config/pse84_s_protection.h
+++ b/soc/infineon/edge/pse84/security_config/pse84_s_protection.h
@@ -9,10 +9,10 @@
 #define pse84_s_protection_h
 
 #include <infineon_kconfig.h>
-#include "cy_mpc.h"
+#include <cy_mpc.h>
 #include "pse84_s_system.h"
 #include "pse84_s_mpc.h"
-#include "cy_ppc.h"
+#include <cy_ppc.h>
 
 #include "pse84_s_sau.h"
 

--- a/soc/infineon/edge/pse84/security_config/pse84_s_sau.h
+++ b/soc/infineon/edge/pse84/security_config/pse84_s_sau.h
@@ -9,8 +9,8 @@
 #define pse84_s_sau_h
 
 #include <infineon_kconfig.h>
-#include "cmsis_compiler.h"
-#include "cy_device.h"
+#include <cmsis_compiler.h>
+#include <cy_device.h>
 
 #define CY_SAU_REGION_CNT     (3U)
 #define CY_SAU_MAX_REGION_CNT (8U)

--- a/soc/infineon/edge/pse84/security_config/pse84_s_system.h
+++ b/soc/infineon/edge/pse84/security_config/pse84_s_system.h
@@ -9,10 +9,10 @@
 #define pse84_s_system_h
 
 #include <infineon_kconfig.h>
-#include "cy_syspm.h"
-#include "system_edge.h"
-#include "cy_sysclk.h"
-#include "cy_syspm_pdcm.h"
+#include <cy_syspm.h>
+#include <system_edge.h>
+#include <cy_sysclk.h>
+#include <cy_syspm_pdcm.h>
 #include "pse84_s_mpc.h"
 
 #define CY_CFG_PWR_MODE_LP            0x01UL

--- a/soc/infineon/edge/pse84/soc_pse84_m33_ns.c
+++ b/soc/infineon/edge/pse84/soc_pse84_m33_ns.c
@@ -14,20 +14,20 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 
-#include "cy_pdl.h"
+#include <cy_pdl.h>
 #include <system_edge.h>
 
 #if defined(CONFIG_BUILD_WITH_TFM)
-#include "cy_syslib.h"
-#include "mtb_srf_pool_init.h"
+#include <cy_syslib.h>
+#include <mtb_srf_pool_init.h>
 #endif
 
 #if defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
-#include "cyabs_rtos.h"
-#include "mtb_ipc.h"
+#include <cyabs_rtos.h>
+#include <mtb_ipc.h>
 #include "mtb_ipc_config.h"
-#include "mtb_srf_ipc.h"
-#include "mtb_srf_ipc_init.h"
+#include <mtb_srf_ipc.h>
+#include <mtb_srf_ipc_init.h>
 #endif
 
 #define PSE84_CPU_FREQ_HZ DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)

--- a/soc/infineon/edge/pse84/soc_pse84_m33_s.c
+++ b/soc/infineon/edge/pse84/soc_pse84_m33_s.c
@@ -16,9 +16,9 @@
 #include "soc.h"
 #include <cy_sysint.h>
 #include <system_edge.h>
-#include "cy_pdl.h"
+#include <cy_pdl.h>
 
-#include "pse84_boot.h"
+#include <pse84_boot.h>
 
 static void systeminit_enable_clocks(void)
 {

--- a/soc/infineon/edge/pse84/soc_pse84_m55.c
+++ b/soc/infineon/edge/pse84/soc_pse84_m55.c
@@ -14,17 +14,17 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 
-#include "cy_pdl.h"
+#include <cy_pdl.h>
 #include "soc.h"
 #include <cy_sysint.h>
 #include <system_edge.h>
 
 #if defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
-#include "cy_syslib.h"
+#include <cy_syslib.h>
 #include "mtb_ipc_config.h"
-#include "mtb_srf.h"
-#include "mtb_srf_ipc_init.h"
-#include "mtb_srf_pool_init.h"
+#include <mtb_srf.h>
+#include <mtb_srf_ipc_init.h>
+#include <mtb_srf_pool_init.h>
 #else
 #include <ifx_cycfg_init.h>
 #endif

--- a/soc/infineon/psoc4/psoc4100smax/soc.c
+++ b/soc/infineon/psoc4/psoc4100smax/soc.c
@@ -11,7 +11,7 @@
 
 #include <cy_sysint.h>
 #include <system_cat2.h> /* PSoC4 system init header from PDL */
-#include "cy_pdl.h"
+#include <cy_pdl.h>
 
 /* Minimal early initialization for PSoC 4100S Max */
 void soc_early_init_hook(void)

--- a/soc/infineon/psoc4/psoc4100tp/soc.c
+++ b/soc/infineon/psoc4/psoc4100tp/soc.c
@@ -11,7 +11,7 @@
 
 #include <cy_sysint.h>
 #include <system_cat2.h>/* PSoC4 system init header from PDL */
-#include "cy_pdl.h"
+#include <cy_pdl.h>
 
 /* Minimal early initialization for PSOC4100tp */
 void soc_early_init_hook(void)


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Infineon related paths and manually selecting the applicable changes:
```
$ find soc/infineon/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;