### PR TITLE
nuvoton: Diamond include for non-local header files

### DIFF
--- a/boards/nuvoton/numaker_gai_m55m1/numaker_gai_m55m1-pinctrl.dtsi
+++ b/boards/nuvoton/numaker_gai_m55m1/numaker_gai_m55m1-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "pinctrl/m55m1h2l-pinctrl.h"
+#include <pinctrl/m55m1h2l-pinctrl.h>
 
 &pinctrl {
 	uart5_default: uart5_default {

--- a/boards/nuvoton/numaker_m031ki/numaker_m031ki-pinctrl.dtsi
+++ b/boards/nuvoton/numaker_m031ki/numaker_m031ki-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "pinctrl/m031-pinctrl.h"
+#include <pinctrl/m031-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki-pinctrl.dtsi
+++ b/boards/nuvoton/numaker_m2l31ki/numaker_m2l31ki-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "pinctrl/m2l31ki-pinctrl.h"
+#include <pinctrl/m2l31ki-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/nuvoton/numaker_m3334ki/numaker_m3334ki-pinctrl.dtsi
+++ b/boards/nuvoton/numaker_m3334ki/numaker_m3334ki-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "pinctrl/m3331-pinctrl.h"
+#include <pinctrl/m3331-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/nuvoton/numaker_m3351ki/numaker_m3351ki-pinctrl.dtsi
+++ b/boards/nuvoton/numaker_m3351ki/numaker_m3351ki-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "pinctrl/m3351-pinctrl.h"
+#include <pinctrl/m3351-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/nuvoton/numaker_m5531/numaker_m5531-pinctrl.dtsi
+++ b/boards/nuvoton/numaker_m5531/numaker_m5531-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "pinctrl/m55m1h2l-pinctrl.h"
+#include <pinctrl/m55m1h2l-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/nuvoton/numaker_m55m1/numaker_m55m1-pinctrl.dtsi
+++ b/boards/nuvoton/numaker_m55m1/numaker_m55m1-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "pinctrl/m55m1h2l-pinctrl.h"
+#include <pinctrl/m55m1h2l-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/nuvoton/numaker_pfm_m467/numaker_pfm_m467-pinctrl.dtsi
+++ b/boards/nuvoton/numaker_pfm_m467/numaker_pfm_m467-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "pinctrl/m467hjhae-pinctrl.h"
+#include <pinctrl/m467hjhae-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/soc/nuvoton/npcx/common/npckn/registers.c
+++ b/soc/nuvoton/npcx/common/npckn/registers.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/device.h>
 #include <soc.h>
-#include "reg_def.h"
+#include <reg_def.h>
 
 /* CDCG register structure check */
 NPCX_REG_SIZE_CHECK(cdcg_reg, 0x116);

--- a/soc/nuvoton/npcx/common/npcxn/registers.c
+++ b/soc/nuvoton/npcx/common/npcxn/registers.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/device.h>
 #include <soc.h>
-#include "reg_def.h"
+#include <reg_def.h>
 
 /* CDCG register structure check */
 NPCX_REG_SIZE_CHECK(cdcg_reg, 0x116);

--- a/soc/nuvoton/npcx/common/soc_pins.h
+++ b/soc/nuvoton/npcx/common/soc_pins.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 
-#include "reg_def.h"
+#include <reg_def.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/nuvoton/npcx/npck3/soc.h
+++ b/soc/nuvoton/npcx/npck3/soc.h
@@ -64,8 +64,8 @@
 /* NPCK3 Clock configuration and limitation */
 #define MAX_OFMCLK 100000000
 
-#include "reg_def.h"
-#include "clock_def.h"
+#include <reg_def.h>
+#include <clock_def.h>
 #include <soc_dt.h>
 #include <soc_espi_taf.h>
 #include <soc_pins.h>

--- a/soc/nuvoton/npcx/npcx4/soc.h
+++ b/soc/nuvoton/npcx/npcx4/soc.h
@@ -53,8 +53,8 @@
 /* NPCX4 Clock Configuration */
 #define MAX_OFMCLK 120000000
 
-#include "reg_def.h"
-#include "clock_def.h"
+#include <reg_def.h>
+#include <clock_def.h>
 #include <soc_dt.h>
 #include <soc_espi_taf.h>
 #include <soc_pins.h>

--- a/soc/nuvoton/npcx/npcx7/soc.h
+++ b/soc/nuvoton/npcx/npcx7/soc.h
@@ -45,8 +45,8 @@
 /* NPCX7 Clock configuration */
 #define MAX_OFMCLK 100000000
 
-#include "reg_def.h"
-#include "clock_def.h"
+#include <reg_def.h>
+#include <clock_def.h>
 #include <soc_dt.h>
 #include <soc_pins.h>
 #include <soc_power.h>

--- a/soc/nuvoton/npcx/npcx9/soc.h
+++ b/soc/nuvoton/npcx/npcx9/soc.h
@@ -50,8 +50,8 @@
 /* NPCX9 Clock configuration and limitation */
 #define MAX_OFMCLK 100000000
 
-#include "reg_def.h"
-#include "clock_def.h"
+#include <reg_def.h>
+#include <clock_def.h>
 #include <soc_dt.h>
 #include <soc_pins.h>
 #include <soc_power.h>


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Nuvoton related paths and manually selecting the applicable changes:
```
$ find soc/nuvoton/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;