### PR TITLE
soc: microchip: use diamond include for non-local header files

### DIFF
--- a/soc/microchip/mec/mec15xx/soc.h
+++ b/soc/microchip/mec/mec15xx/soc.h
@@ -11,8 +11,8 @@
 
 #ifndef _ASMLANGUAGE
 
-#include "MEC1501hsz.h"
-#include "regaccess.h"
+#include <MEC1501hsz.h>
+#include <regaccess.h>
 
 /* common peripheral register defines */
 #include <reg/mec_gpio.h>

--- a/soc/microchip/pic32c/pic32ck_sg_gc/pic32ck_gc00/soc.h
+++ b/soc/microchip/pic32c/pic32ck_sg_gc/pic32ck_gc00/soc.h
@@ -12,25 +12,25 @@
 #include <zephyr/types.h>
 
 #if defined(CONFIG_SOC_PIC32CK0512GC00064)
-#include "pic32ck0512gc00064.h"
+#include <pic32ck0512gc00064.h>
 #elif defined(CONFIG_SOC_PIC32CK0512GC00100)
-#include "pic32ck0512gc00100.h"
+#include <pic32ck0512gc00100.h>
 #elif defined(CONFIG_SOC_PIC32CK1012GC00048)
-#include "pic32ck1012gc00048.h"
+#include <pic32ck1012gc00048.h>
 #elif defined(CONFIG_SOC_PIC32CK1012GC00064)
-#include "pic32ck1012gc00064.h"
+#include <pic32ck1012gc00064.h>
 #elif defined(CONFIG_SOC_PIC32CK1012GC00100)
-#include "pic32ck1012gc00100.h"
+#include <pic32ck1012gc00100.h>
 ##elif defined(CONFIG_SOC_PIC32CK1025GC00064)
-#include "pic32ck1025gc00064.h"
+#include <pic32ck1025gc00064.h>
 #elif defined(CONFIG_SOC_PIC32CK1025GC00100)
-#include "pic32ck1025gc00100.h"
+#include <pic32ck1025gc00100.h>
 #elif defined(CONFIG_SOC_PIC32CK2051GC00064)
-#include "pic32ck2051gc00064.h"
+#include <pic32ck2051gc00064.h>
 #elif defined(CONFIG_SOC_PIC32CK2051GC00100)
-#include "pic32ck2051gc00100.h"
+#include <pic32ck2051gc00100.h>
 #elif defined(CONFIG_SOC_PIC32CK2051GC00144)
-#include "pic32ck2051gc00144.h"
+#include <pic32ck2051gc00144.h>
 #else
 #error "Library does not support the specified device."
 #endif

--- a/soc/microchip/pic32c/pic32ck_sg_gc/pic32ck_gc01/soc.h
+++ b/soc/microchip/pic32c/pic32ck_sg_gc/pic32ck_gc01/soc.h
@@ -12,25 +12,25 @@
 #include <zephyr/types.h>
 
 #if defined(CONFIG_SOC_PIC32CK0512GC01064)
-#include "pic32ck0512gc01064.h"
+#include <pic32ck0512gc01064.h>
 #elif defined(CONFIG_SOC_PIC32CK0512GC01100)
-#include "pic32ck0512gc01100.h"
+#include <pic32ck0512gc01100.h>
 #elif defined(CONFIG_SOC_PIC32CK1012GC01048)
-#include "pic32ck1012gc01048.h"
+#include <pic32ck1012gc01048.h>
 #elif defined(CONFIG_SOC_PIC32CK1012GC01064)
-#include "pic32ck1012gc01064.h"
+#include <pic32ck1012gc01064.h>
 #elif defined(CONFIG_SOC_PIC32CK1012GC01100)
-#include "pic32ck1012gc01100.h"
+#include <pic32ck1012gc01100.h>
 #elif defined(CONFIG_SOC_PIC32CK1025GC01064)
-#include "pic32ck1025gc01064.h"
+#include <pic32ck1025gc01064.h>
 #elif defined(CONFIG_SOC_PIC32CK1025GC01100)
-#include "pic32ck1025gc01100.h"
+#include <pic32ck1025gc01100.h>
 #elif defined(CONFIG_SOC_PIC32CK2051GC01064)
-#include "pic32ck2051gc01064.h"
+#include <pic32ck2051gc01064.h>
 #elif defined(CONFIG_SOC_PIC32CK2051GC01100)
-#include "pic32ck2051gc01100.h"
+#include <pic32ck2051gc01100.h>
 #elif defined(CONFIG_SOC_PIC32CK2051GC01144)
-#include "pic32ck2051gc01144.h"
+#include <pic32ck2051gc01144.h>
 #else
 #error "Library does not support the specified device."
 #endif

--- a/soc/microchip/pic32c/pic32cm_jh/pic32cm_jh00/soc.h
+++ b/soc/microchip/pic32c/pic32cm_jh/pic32cm_jh00/soc.h
@@ -31,7 +31,7 @@
 #error "Library does not support the specified device."
 #endif
 
-#include "pic32cm_jh.h"
+#include <pic32cm_jh.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/pic32c/pic32cm_jh/pic32cm_jh01/soc.h
+++ b/soc/microchip/pic32c/pic32cm_jh/pic32cm_jh01/soc.h
@@ -35,7 +35,7 @@
 #error "Library does not support the specified device."
 #endif
 
-#include "pic32cm_jh.h"
+#include <pic32cm_jh.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/pic32c/pic32cm_pl/pic32cm_pl10/soc.h
+++ b/soc/microchip/pic32c/pic32cm_pl/pic32cm_pl10/soc.h
@@ -23,7 +23,7 @@
 #error "Library does not support the specified device."
 #endif
 
-#include "pic32cm_pl.h"
+#include <pic32cm_pl.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/pic32c/pic32cm_sg_gc/pic32cm_gc00/soc.h
+++ b/soc/microchip/pic32c/pic32cm_sg_gc/pic32cm_gc00/soc.h
@@ -12,11 +12,11 @@
 #include <zephyr/types.h>
 
 #if defined(CONFIG_SOC_PIC32CM5112GC00048)
-#include "pic32cm5112gc00048.h"
+#include <pic32cm5112gc00048.h>
 #elif defined(CONFIG_SOC_PIC32CM5112GC00064)
-#include "pic32cm5112gc00064.h"
+#include <pic32cm5112gc00064.h>
 #elif defined(CONFIG_SOC_PIC32CM5112GC00100)
-#include "pic32cm5112gc00100.h"
+#include <pic32cm5112gc00100.h>
 #else
 #error "Library does not support the specified device."
 #endif

--- a/soc/microchip/pic32c/pic32cm_sg_gc/pic32cm_sg00/soc.h
+++ b/soc/microchip/pic32c/pic32cm_sg_gc/pic32cm_sg00/soc.h
@@ -12,11 +12,11 @@
 #include <zephyr/types.h>
 
 #if defined(CONFIG_SOC_PIC32CM5112SG00048)
-#include "pic32cm5112sg00048.h"
+#include <pic32cm5112sg00048.h>
 #elif defined(CONFIG_SOC_PIC32CM5112SG00064)
-#include "pic32cm5112sg00064.h"
+#include <pic32cm5112sg00064.h>
 #elif defined(CONFIG_SOC_PIC32CM5112SG00100)
-#include "pic32cm5112sg00100.h"
+#include <pic32cm5112sg00100.h>
 #else
 #error "Library does not support the specified device."
 #endif

--- a/soc/microchip/pic32c/pic32cx_sg/pic32cx_sg41/soc.h
+++ b/soc/microchip/pic32c/pic32cx_sg/pic32cx_sg41/soc.h
@@ -23,7 +23,7 @@
 #error "Library does not support the specified device."
 #endif
 
-#include "pic32cx_sg.h"
+#include <pic32cx_sg.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/pic32c/pic32cx_sg/pic32cx_sg60/soc.h
+++ b/soc/microchip/pic32c/pic32cx_sg/pic32cx_sg60/soc.h
@@ -19,7 +19,7 @@
 #error "Library does not support the specified device."
 #endif
 
-#include "pic32cx_sg.h"
+#include <pic32cx_sg.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/pic32c/pic32cx_sg/pic32cx_sg61/soc.h
+++ b/soc/microchip/pic32c/pic32cx_sg/pic32cx_sg61/soc.h
@@ -19,7 +19,7 @@
 #error "Library does not support the specified device."
 #endif
 
-#include "pic32cx_sg.h"
+#include <pic32cx_sg.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/pic32c/pic32cz_ca/pic32cz_ca80/soc.h
+++ b/soc/microchip/pic32c/pic32cz_ca/pic32cz_ca80/soc.h
@@ -39,7 +39,7 @@
 #error "Library does not support the specified device."
 #endif
 
-#include "pic32cz_ca.h"
+#include <pic32cz_ca.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/pic32c/pic32cz_ca/pic32cz_ca90/soc.h
+++ b/soc/microchip/pic32c/pic32cz_ca/pic32cz_ca90/soc.h
@@ -39,7 +39,7 @@
 #error "Library does not support the specified device."
 #endif
 
-#include "pic32cz_ca.h"
+#include <pic32cz_ca.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/sam/sam_d5x_e5x/atsamd51/soc.h
+++ b/soc/microchip/sam/sam_d5x_e5x/atsamd51/soc.h
@@ -33,7 +33,7 @@
 #error "Library does not support the specified device."
 #endif
 
-#include "samd5xe5x.h"
+#include <samd5xe5x.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/sam/sam_d5x_e5x/atsame51/soc.h
+++ b/soc/microchip/sam/sam_d5x_e5x/atsame51/soc.h
@@ -29,7 +29,7 @@
 #error "Library does not support the specified device."
 #endif
 
-#include "samd5xe5x.h"
+#include <samd5xe5x.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/sam/sam_d5x_e5x/atsame53/soc.h
+++ b/soc/microchip/sam/sam_d5x_e5x/atsame53/soc.h
@@ -25,7 +25,7 @@
 #error "Library does not support the specified device."
 #endif
 
-#include "samd5xe5x.h"
+#include <samd5xe5x.h>
 
 #endif /* _ASMLANGUAGE */
 

--- a/soc/microchip/sam/sam_d5x_e5x/atsame54/soc.h
+++ b/soc/microchip/sam/sam_d5x_e5x/atsame54/soc.h
@@ -23,7 +23,7 @@
 #error "Library does not support the specified device."
 #endif
 
-#include "samd5xe5x.h"
+#include <samd5xe5x.h>
 
 #endif /* _ASMLANGUAGE */
 


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the #include directive.

This change was made running scripts/check_quoted_includes.py script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with the Linux shell command below and manually selecting the applicable changes:
```
$ find soc/microchip/ -type f -exec \
    ./scripts/check_quoted_includes.py -w {} \;