### PR TITLE
openisa: Diamond include for non-local header files

### DIFF
--- a/boards/openisa/rv32m1_vega/rv32m1_vega_openisa_rv32m1_ri5cy.dts
+++ b/boards/openisa/rv32m1_vega/rv32m1_vega_openisa_rv32m1_ri5cy.dts
@@ -5,7 +5,7 @@
 
 /dts-v1/;
 
-#include "openisa/rv32m1_ri5cy.dtsi"
+#include <openisa/rv32m1_ri5cy.dtsi>
 #include "rv32m1_vega_openisa_rv32m1.dtsi"
 
 / {

--- a/boards/openisa/rv32m1_vega/rv32m1_vega_openisa_rv32m1_zero_riscy.dts
+++ b/boards/openisa/rv32m1_vega/rv32m1_vega_openisa_rv32m1_zero_riscy.dts
@@ -5,7 +5,7 @@
 
 /dts-v1/;
 
-#include "openisa/rv32m1_zero_riscy.dtsi"
+#include <openisa/rv32m1_zero_riscy.dtsi>
 #include "rv32m1_vega_openisa_rv32m1.dtsi"
 
 / {

--- a/soc/openisa/rv32m1/soc.h
+++ b/soc/openisa/rv32m1/soc.h
@@ -9,7 +9,7 @@
 
 #ifndef _ASMLANGUAGE
 
-#include "fsl_device_registers.h"
+#include <fsl_device_registers.h>
 #include <zephyr/types.h>
 
 /*


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various OpenISA related paths and manually selecting the applicable changes:
```
$ find soc/openisa/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;