### PR TITLE
intel: Diamond include for non-local header files

### DIFF
--- a/boards/intel/ish/intel_ish_5_4_1.dts
+++ b/boards/intel/ish/intel_ish_5_4_1.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include "intel/intel_ish5.dtsi"
+#include <intel/intel_ish5.dtsi>
 
 / {
 	model = "intel_ish_5_4_1";

--- a/boards/intel/ish/intel_ish_5_6_0.dts
+++ b/boards/intel/ish/intel_ish_5_6_0.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include "intel/intel_ish5.dtsi"
+#include <intel/intel_ish5.dtsi>
 
 / {
 	model = "intel_ish_5_6_0";

--- a/boards/intel/ish/intel_ish_5_8_0.dts
+++ b/boards/intel/ish/intel_ish_5_8_0.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include "intel/intel_ish5_8.dtsi"
+#include <intel/intel_ish5_8.dtsi>
 
 / {
 	model = "intel_ish_5_8_0";

--- a/boards/intel/socfpga_std/cyclonev_socdk/cyclonev_socdk.dts
+++ b/boards/intel/socfpga_std/cyclonev_socdk/cyclonev_socdk.dts
@@ -6,7 +6,7 @@
  * this file is based on the GSRD DTS for Linux
  */
 
-#include "intel_socfpga_std/socfpga_cyclonev.dtsi"
+#include <intel_socfpga_std/socfpga_cyclonev.dtsi>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {

--- a/soc/intel/common/soc_gpio.c
+++ b/soc/intel/common/soc_gpio.c
@@ -6,7 +6,7 @@
 
 #include <errno.h>
 #include <zephyr/acpi/acpi.h>
-#include "soc.h"
+#include <soc.h>
 #include "soc_gpio.h"
 #include <zephyr/logging/log.h>
 

--- a/soc/intel/intel_adsp/ace/boot.c
+++ b/soc/intel/intel_adsp/ace/boot.c
@@ -14,7 +14,7 @@
 #include <adsp_shim.h>
 #include <adsp_memory.h>
 #include <cpu_init.h>
-#include "manifest.h"
+#include <manifest.h>
 
 #ifdef CONFIG_PM
 #ifdef CONFIG_ADSP_IMR_CONTEXT_SAVE

--- a/soc/intel/intel_adsp/cavs/irq.c
+++ b/soc/intel/intel_adsp/cavs/irq.c
@@ -13,7 +13,7 @@
 #include <adsp_shim.h>
 #include <cavs-idc.h>
 #include <adsp_interrupt.h>
-#include "soc.h"
+#include <soc.h>
 
 #ifdef CONFIG_DYNAMIC_INTERRUPTS
 #include <zephyr/sw_isr_table.h>

--- a/soc/intel/intel_adsp/cavs/power_down_cavs.S
+++ b/soc/intel/intel_adsp/cavs/power_down_cavs.S
@@ -4,7 +4,7 @@
 
 #include "asm_ldo_management.h"
 #include "asm_memory_management.h"
-#include "adsp_memory.h"
+#include <adsp_memory.h>
 
 #define IPC_HOST_BASE		0x00071E00
 #define IPC_DIPCIDD		0x18

--- a/soc/intel/intel_adsp/cavs/sram.c
+++ b/soc/intel/intel_adsp/cavs/sram.c
@@ -11,7 +11,7 @@
 #include <adsp_shim.h>
 #include <adsp_memory.h>
 #include <cpu_init.h>
-#include "manifest.h"
+#include <manifest.h>
 
 #define DELAY_COUNT			256
 #define LPSRAM_MASK(x)		0x00000003

--- a/soc/intel/intel_adsp/common/boot.c
+++ b/soc/intel/intel_adsp/common/boot.c
@@ -15,7 +15,7 @@
 #include <adsp_shim.h>
 #include <adsp_memory.h>
 #include <cpu_init.h>
-#include "manifest.h"
+#include <manifest.h>
 
 #ifdef CONFIG_SOC_SERIES_INTEL_ADSP_ACE
 #include <adsp_boot.h>

--- a/soc/intel/intel_ish/intel_ish5/pm/power.c
+++ b/soc/intel/intel_ish/intel_ish5/pm/power.c
@@ -8,7 +8,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/init.h>
 
-#include "sedi_driver_pm.h"
+#include <sedi_driver_pm.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ish_pm, CONFIG_PM_LOG_LEVEL);

--- a/soc/intel/intel_ish/intel_ish5/soc.c
+++ b/soc/intel/intel_ish/intel_ish5/soc.c
@@ -8,7 +8,7 @@
 #include "soc.h"
 
 #if defined(CONFIG_HPET_TIMER)
-#include "sedi_driver_hpet.h"
+#include <sedi_driver_hpet.h>
 #endif
 
 void soc_early_init_hook(void)

--- a/soc/intel/intel_ish/intel_ish5/soc.h
+++ b/soc/intel/intel_ish/intel_ish5/soc.h
@@ -14,7 +14,7 @@
 #include <zephyr/random/random.h>
 
 #ifdef CONFIG_HPET_TIMER
-#include "sedi_driver_hpet.h"
+#include <sedi_driver_hpet.h>
 
 #define HPET_USE_CUSTOM_REG_ACCESS_FUNCS
 


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various Intel related paths and manually selecting the applicable changes:
```
$ find soc/intel/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;