### PR TITLE
native: Diamond include for non-local header files

### DIFF
--- a/boards/native/common/sdl/sdl_events.c
+++ b/boards/native/common/sdl/sdl_events.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "posix_board_if.h"
-#include "soc.h"
+#include <posix_board_if.h>
+#include <soc.h>
 #include <zephyr/arch/posix/posix_trace.h>
 #include <zephyr/kernel.h>
 #include "sdl_events_bottom.h"

--- a/boards/native/native_sim/board_soc.h
+++ b/boards/native/native_sim/board_soc.h
@@ -20,7 +20,7 @@
 #ifndef BOARDS_POSIX_NATIVE_SIM_BOARD_SOC_H
 #define BOARDS_POSIX_NATIVE_SIM_BOARD_SOC_H
 
-#include "nsi_cpu0_interrupts.h"
+#include <nsi_cpu0_interrupts.h>
 
 #define NSOS_IRQ 3
 

--- a/boards/native/native_sim/cmdline.c
+++ b/boards/native/native_sim/cmdline.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "nsi_cmdline.h"
+#include <nsi_cmdline.h>
 
 void native_add_command_line_opts(struct args_struct_t *args)
 {

--- a/boards/native/native_sim/cmdline.h
+++ b/boards/native/native_sim/cmdline.h
@@ -8,7 +8,7 @@
 #ifndef BOARDS_POSIX_NATIVE_SIM_CMDLINE_H
 #define BOARDS_POSIX_NATIVE_SIM_CMDLINE_H
 
-#include "nsi_cmdline.h"
+#include <nsi_cmdline.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/native/native_sim/cpu_wait.c
+++ b/boards/native/native_sim/cpu_wait.c
@@ -10,8 +10,8 @@
 #include <zephyr/arch/posix/posix_soc_if.h>
 #include <posix_board_if.h>
 #include <posix_soc.h>
-#include "nsi_hw_scheduler.h"
-#include "nsi_timer_model.h"
+#include <nsi_hw_scheduler.h>
+#include <nsi_timer_model.h>
 
 /**
  * Replacement to the kernel k_busy_wait()

--- a/boards/native/native_sim/irq_handler.c
+++ b/boards/native/native_sim/irq_handler.c
@@ -11,16 +11,16 @@
 #include <stdint.h>
 #include <zephyr/irq_offload.h>
 #include <zephyr/kernel_structs.h>
-#include "kernel_internal.h"
-#include "kswap.h"
-#include "irq_ctrl.h"
-#include "posix_core.h"
+#include <kernel_internal.h>
+#include <kswap.h>
+#include <irq_ctrl.h>
+#include <posix_core.h>
 #include <zephyr/sw_isr_table.h>
-#include "soc.h"
+#include <soc.h>
 #include <zephyr/tracing/tracing.h>
 #include "irq_handler.h"
 #include "board_soc.h"
-#include "nsi_cpu_if.h"
+#include <nsi_cpu_if.h>
 
 typedef void (*normal_irq_f_ptr)(const void *);
 typedef int (*direct_irq_f_ptr)(void);

--- a/boards/native/native_sim/misc.c
+++ b/boards/native/native_sim/misc.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "posix_native_task.h"
-#include "nsi_timer_model.h"
+#include <posix_native_task.h>
+#include <nsi_timer_model.h>
 
 #if defined(CONFIG_NATIVE_SIM_SLOWDOWN_TO_REAL_TIME)
 

--- a/boards/native/native_sim/posix_arch_if.c
+++ b/boards/native/native_sim/posix_arch_if.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
-#include "nsi_cpu_es_if.h"
+#include <nsi_cpu_es_if.h>
 
 /*
  * This file provides the interfaces the POSIX architecture and soc_inf

--- a/boards/native/native_sim/reboot.c
+++ b/boards/native/native_sim/reboot.c
@@ -6,7 +6,7 @@
  */
 
 #include "reboot_bottom.h"
-#include "posix_board_if.h"
+#include <posix_board_if.h>
 
 void sys_arch_reboot(int type)
 {

--- a/scripts/native_simulator/common/src/main.c
+++ b/scripts/native_simulator/common/src/main.c
@@ -15,12 +15,12 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include "nsi_cpun_if.h"
-#include "nsi_tasks.h"
-#include "nsi_cmdline_main_if.h"
-#include "nsi_utils.h"
-#include "nsi_hw_scheduler.h"
+#include <nsi_tasks.h>
+#include <nsi_cmdline_main_if.h>
+#include <nsi_utils.h>
+#include <nsi_hw_scheduler.h>
 #include "nsi_config.h"
-#include "nsi_cpu_ctrl.h"
+#include <nsi_cpu_ctrl.h>
 
 int nsi_exit_inner(int exit_code)
 {

--- a/scripts/native_simulator/common/src/nce.c
+++ b/scripts/native_simulator/common/src/nce.c
@@ -22,8 +22,8 @@
 #include <pthread.h>
 #include <semaphore.h>
 #include <errno.h>
-#include "nsi_utils.h"
-#include "nce_if.h"
+#include <nsi_utils.h>
+#include <nce_if.h>
 #include "nsi_safe_call.h"
 
 struct nce_status_t {

--- a/scripts/native_simulator/common/src/nct.c
+++ b/scripts/native_simulator/common/src/nct.c
@@ -70,8 +70,8 @@
 #include <pthread.h>
 #include <semaphore.h>
 #include <errno.h>
-#include "nsi_utils.h"
-#include "nct_if.h"
+#include <nsi_utils.h>
+#include <nct_if.h>
 #include "nsi_internal.h"
 #include "nsi_safe_call.h"
 

--- a/scripts/native_simulator/common/src/nsi_cpu_ctrl.c
+++ b/scripts/native_simulator/common/src/nsi_cpu_ctrl.c
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include "nsi_config.h"
 #include "nsi_cpun_if.h"
-#include "nsi_tracing.h"
+#include <nsi_tracing.h>
 
 static bool cpu_auto_start[NSI_N_CPUS] = {true}; /* Only the first core starts on its own */
 static bool cpu_booted[NSI_N_CPUS];

--- a/scripts/native_simulator/common/src/nsi_cpun_if.c
+++ b/scripts/native_simulator/common/src/nsi_cpun_if.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "nsi_cpu_if.h"
+#include <nsi_cpu_if.h>
 
 /*
  * These trampolines forward a call from the runner into the corresponding embedded CPU hook

--- a/scripts/native_simulator/common/src/nsi_errno.c
+++ b/scripts/native_simulator/common/src/nsi_errno.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "nsi_errno.h"
-#include "nsi_utils.h"
+#include <nsi_errno.h>
+#include <nsi_utils.h>
 
 struct nsi_errno_mid_map {
 	/** Embedded/host error code */

--- a/scripts/native_simulator/common/src/nsi_hw_scheduler.c
+++ b/scripts/native_simulator/common/src/nsi_hw_scheduler.c
@@ -15,11 +15,11 @@
 #include <signal.h>
 #include <stddef.h>
 #include <inttypes.h>
-#include "nsi_tracing.h"
-#include "nsi_main.h"
+#include <nsi_tracing.h>
+#include <nsi_main.h>
 #include "nsi_safe_call.h"
-#include "nsi_hw_scheduler.h"
-#include "nsi_hws_models_if.h"
+#include <nsi_hw_scheduler.h>
+#include <nsi_hws_models_if.h>
 
 uint64_t nsi_simu_time; /* The actual time as known by the HW models */
 static uint64_t end_of_time = NSI_NEVER; /* When will this device stop */

--- a/scripts/native_simulator/common/src/nsi_internal.h
+++ b/scripts/native_simulator/common/src/nsi_internal.h
@@ -8,7 +8,7 @@
 #define NSI_COMMON_SRC_NSI_INTERNAL_H
 
 #include <stdint.h>
-#include "nsi_utils.h"
+#include <nsi_utils.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/native_simulator/common/src/nsi_safe_call.h
+++ b/scripts/native_simulator/common/src/nsi_safe_call.h
@@ -8,7 +8,7 @@
 #define NSI_COMMON_SRC_NSI_SAFE_CALLL_H
 
 #include <stdbool.h>
-#include "nsi_tracing.h"
+#include <nsi_tracing.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/native_simulator/common/src/nsi_trace_varg.c
+++ b/scripts/native_simulator/common/src/nsi_trace_varg.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdarg.h>
-#include "nsi_tracing.h"
+#include <nsi_tracing.h>
 
 void nsi_print_error_and_exit(const char *format, ...)
 {

--- a/scripts/native_simulator/common/src/nsi_weak_stubs.c
+++ b/scripts/native_simulator/common/src/nsi_weak_stubs.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "nsi_cpu_if.h"
-#include "nsi_tracing.h"
+#include <nsi_cpu_if.h>
+#include <nsi_tracing.h>
 
 /*
  * Stubbed embedded CPU images, which do nothing:

--- a/scripts/native_simulator/native/src/hw_counter.c
+++ b/scripts/native_simulator/native/src/hw_counter.c
@@ -6,10 +6,10 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "nsi_cpu0_interrupts.h"
-#include "irq_ctrl.h"
-#include "nsi_tasks.h"
-#include "nsi_hws_models_if.h"
+#include <nsi_cpu0_interrupts.h>
+#include <irq_ctrl.h>
+#include <nsi_tasks.h>
+#include <nsi_hws_models_if.h>
 
 static uint64_t hw_counter_timer;
 

--- a/scripts/native_simulator/native/src/include/nsi_cmdline.h
+++ b/scripts/native_simulator/native/src/include/nsi_cmdline.h
@@ -19,7 +19,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
-#include "nsi_cmdline_main_if.h"
+#include <nsi_cmdline_main_if.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/native_simulator/native/src/irq_ctrl.c
+++ b/scripts/native_simulator/native/src/irq_ctrl.c
@@ -9,12 +9,12 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "nsi_internal.h"
-#include "nsi_cpu_if.h"
-#include "nsi_cpu0_interrupts.h"
-#include "irq_ctrl.h"
-#include "nsi_tasks.h"
-#include "nsi_hws_models_if.h"
+#include <nsi_internal.h>
+#include <nsi_cpu_if.h>
+#include <nsi_cpu0_interrupts.h>
+#include <irq_ctrl.h>
+#include <nsi_tasks.h>
+#include <nsi_hws_models_if.h>
 
 static uint64_t irq_ctrl_timer = NSI_NEVER;
 

--- a/scripts/native_simulator/native/src/native_rtc.c
+++ b/scripts/native_simulator/native/src/native_rtc.c
@@ -6,10 +6,10 @@
  */
 
 #include <stdint.h>
-#include "nsi_tracing.h"
-#include "native_rtc.h"
-#include "nsi_hw_scheduler.h"
-#include "nsi_timer_model.h"
+#include <nsi_tracing.h>
+#include <native_rtc.h>
+#include <nsi_hw_scheduler.h>
+#include <nsi_timer_model.h>
 
 /**
  * Return the (simulation) time in microseconds

--- a/scripts/native_simulator/native/src/nsi_cmdline.c
+++ b/scripts/native_simulator/native/src/nsi_cmdline.c
@@ -8,12 +8,12 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include "nsi_cmdline.h"
+#include <nsi_cmdline.h>
 #include "nsi_cmdline_internal.h"
-#include "nsi_tracing.h"
-#include "nsi_timer_model.h"
-#include "nsi_hw_scheduler.h"
-#include "nsi_tasks.h"
+#include <nsi_tracing.h>
+#include <nsi_timer_model.h>
+#include <nsi_hw_scheduler.h>
+#include <nsi_tasks.h>
 
 static int s_argc, test_argc;
 static char **s_argv, **test_argv;

--- a/scripts/native_simulator/native/src/nsi_cmdline_common.c
+++ b/scripts/native_simulator/native/src/nsi_cmdline_common.c
@@ -12,10 +12,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
-#include "nsi_tracing.h"
-#include "nsi_cmdline.h"
+#include <nsi_tracing.h>
+#include <nsi_cmdline.h>
 #include "nsi_cmdline_internal.h"
-#include "nsi_cpu_es_if.h"
+#include <nsi_cpu_es_if.h>
 
 /**
  * Check if <arg> is the option <option>

--- a/scripts/native_simulator/native/src/nsi_cmdline_internal.h
+++ b/scripts/native_simulator/native/src/nsi_cmdline_internal.h
@@ -10,7 +10,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
-#include "nsi_cmdline.h"
+#include <nsi_cmdline.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/native_simulator/native/src/nsi_trace.c
+++ b/scripts/native_simulator/native/src/nsi_trace.c
@@ -9,10 +9,10 @@
 #include <stdio.h>  /* for printfs */
 #include <stdarg.h> /* for va args */
 #include <unistd.h>
-#include "nsi_tasks.h"
-#include "nsi_cmdline.h"
-#include "nsi_tracing.h"
-#include "nsi_main.h"
+#include <nsi_tasks.h>
+#include <nsi_cmdline.h>
+#include <nsi_tracing.h>
+#include <nsi_main.h>
 
 /**
  * Are stdout and stderr connected to a tty

--- a/scripts/native_simulator/native/src/timer_model.c
+++ b/scripts/native_simulator/native/src/timer_model.c
@@ -19,13 +19,13 @@
 #include <time.h>
 #include <stdbool.h>
 #include <math.h>
-#include "nsi_utils.h"
-#include "nsi_cmdline.h"
-#include "nsi_tracing.h"
-#include "nsi_cpu0_interrupts.h"
-#include "irq_ctrl.h"
-#include "nsi_tasks.h"
-#include "nsi_hws_models_if.h"
+#include <nsi_utils.h>
+#include <nsi_cmdline.h>
+#include <nsi_tracing.h>
+#include <nsi_cpu0_interrupts.h>
+#include <irq_ctrl.h>
+#include <nsi_tasks.h>
+#include <nsi_hws_models_if.h>
 
 #define DEBUG_NP_TIMER 0
 

--- a/scripts/native_simulator/optional/src/nsi_fcntl.c
+++ b/scripts/native_simulator/optional/src/nsi_fcntl.c
@@ -19,8 +19,8 @@
 #include <stdbool.h>
 #include <fcntl.h>
 
-#include "nsi_errno.h"
-#include "nsi_fcntl.h"
+#include <nsi_errno.h>
+#include <nsi_fcntl.h>
 
 static int nsi_fcntl_to_mid_(int flags, bool strict)
 {

--- a/soc/native/inf_clock/soc.c
+++ b/soc/native/inf_clock/soc.c
@@ -27,11 +27,11 @@
 #include <zephyr/arch/posix/posix_soc_if.h>
 #include "posix_soc.h"
 #include "posix_board_if.h"
-#include "posix_core.h"
-#include "posix_arch_internal.h"
-#include "kernel_internal.h"
+#include <posix_core.h>
+#include <posix_arch_internal.h>
+#include <kernel_internal.h>
 #include "soc.h"
-#include "nce_if.h"
+#include <nce_if.h>
 
 static void *nce_st;
 

--- a/soc/native/inf_clock/soc.h
+++ b/soc/native/inf_clock/soc.h
@@ -9,7 +9,7 @@
 
 #include <stdbool.h>
 #include <zephyr/toolchain.h>
-#include "board_soc.h"
+#include <board_soc.h>
 #include "posix_soc.h"
 #include "posix_native_task.h"
 

--- a/soc/native/inf_clock/soc_irq.h
+++ b/soc/native/inf_clock/soc_irq.h
@@ -7,7 +7,7 @@
 #ifndef _SOC_IRQ_H
 #define _SOC_IRQ_H
 
-#include "board_irq.h"
+#include <board_irq.h>
 
 /*
  * This SOC relies on the boards providing all the IRQ support

--- a/tests/boards/native_sim/cpu_wait/src/main.c
+++ b/tests/boards/native_sim/cpu_wait/src/main.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <zephyr/irq.h>
-#include "board_soc.h"
+#include <board_soc.h>
 
 /**
  * @brief Basic test of the POSIX arch k_busy_wait() and cpu_hold()

--- a/tests/boards/native_sim/native_tasks/src/main.c
+++ b/tests/boards/native_sim/native_tasks/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "soc.h"
+#include <soc.h>
 #include <zephyr/kernel.h>
-#include "posix_board_if.h"
+#include <posix_board_if.h>
 
 /**
  * @brief Test NATIVE_TASK hook for native builds

--- a/tests/boards/native_sim/rtc/src/main.c
+++ b/tests/boards/native_sim/rtc/src/main.c
@@ -14,7 +14,7 @@
 
 #include <nsi_hw_scheduler.h>
 #include <nsi_timer_model.h>
-#include "native_rtc.h"
+#include <native_rtc.h>
 
 
 static char *us_time_to_str(char *dest, uint64_t time)


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running **scripts/check_quoted_includes.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below over various native simlator related paths and manually selecting the applicable changes:
```
$ find soc/native/ -type f -exec ./scripts/check_quoted_includes.py --apply {} ;