### PR TITLE
scripts: twister: openocd: removed deprecated cmsis_dap_serial argument

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -100,10 +100,9 @@ class HardwareAdapter(DeviceAdapter):
             ]:
                 extra_args.append('--cmd-pre-init')
                 extra_args.append(f'hla_serial {board_id}')
-            elif runner == 'openocd' and self.device_config.product == 'EDBG CMSIS-DAP':
-                extra_args.append('--cmd-pre-init')
-                extra_args.append(f'cmsis_dap_serial {board_id}')
-            elif runner == "openocd" and self.device_config.product == "LPC-LINK2 CMSIS-DAP":
+            elif runner == "openocd" and (
+                self.device_config.product in ('EDBG CMSIS-DAP', 'LPC-LINK2 CMSIS-DAP')
+            ):
                 extra_args.append("--cmd-pre-init")
                 extra_args.append(f'adapter serial {board_id}')
             elif runner == 'jlink' or (

--- a/scripts/pylib/pytest-twister-harness/tests/device/hardware_adapter_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/device/hardware_adapter_test.py
@@ -90,7 +90,7 @@ def test_if_get_command_returns_proper_string_5(patched_which, device: HardwareA
     assert isinstance(device.command, list)
     assert device.command == [
         'west', 'flash', '--no-rebuild', '--build-dir', 'build', '--runner', 'openocd',
-        '--', '--cmd-pre-init', 'cmsis_dap_serial p_id'
+        '--', '--cmd-pre-init', 'adapter serial p_id'
     ]
 
 

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -568,10 +568,7 @@ class DeviceHandler(Handler):
                 ):
                     command_extra_args.append("--cmd-pre-init")
                     command_extra_args.append(f"hla_serial {board_id}")
-                elif runner == "openocd" and product == "EDBG CMSIS-DAP":
-                    command_extra_args.append("--cmd-pre-init")
-                    command_extra_args.append(f"cmsis_dap_serial {board_id}")
-                elif runner == "openocd" and product == "LPC-LINK2 CMSIS-DAP":
+                elif runner == "openocd" and (product in ("EDBG CMSIS-DAP", "LPC-LINK2 CMSIS-DAP")):
                     command_extra_args.append("--cmd-pre-init")
                     command_extra_args.append(f"adapter serial {board_id}")
                 elif runner == "jlink":

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -863,7 +863,7 @@ TESTDATA_13 = [
         None,
         ['west', 'flash', '--no-rebuild', '-d', '$build_dir',
          '--runner', 'openocd', 'param1', 'param2',
-         '--', '--cmd-pre-init', 'cmsis_dap_serial 12345']
+         '--', '--cmd-pre-init', 'adapter serial 12345']
     ),
     (
         None,


### PR DESCRIPTION
Clean up Twister OpenOCD runner by removing
deprecated cmsis_dap_serial argument.