### PR TITLE
[Backport v3.7-branch] Bluetooth: BAP: UC: Add check for stream->group for QoS notification

### DIFF
--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -750,13 +750,18 @@ static void unicast_client_ep_qos_state(struct bt_bap_ep *ep, struct net_buf_sim
 	ep->receiver_ready = false;
 
 	if (buf->len < sizeof(*qos)) {
-		LOG_ERR("QoS status too short");
+		LOG_DBG("QoS status too short");
 		return;
 	}
 
 	stream = ep->stream;
 	if (stream == NULL) {
-		LOG_ERR("No stream active for endpoint");
+		LOG_DBG("No stream active for endpoint");
+		return;
+	}
+
+	if (stream->group == NULL) {
+		LOG_DBG("Stream %p is not configured to a group", stream);
 		return;
 	}
 	ops = stream->ops;


### PR DESCRIPTION
Backport of the fix from #110808 to `v3.7-branch`.

Fixes: #112211