### PR TITLE
cmake: generate module env files without west

### DIFF
--- a/cmake/modules/zephyr_module.cmake
+++ b/cmake/modules/zephyr_module.cmake
@@ -168,6 +168,10 @@ ${MODULE_NAME_UPPER} is a restricted name for Zephyr modules as it is used for \
   endforeach()
 else()
 
+  file(WRITE ${KCONFIG_BINARY_DIR}/kconfig_module_dirs.env "")
+
+  file(WRITE ${KCONFIG_BINARY_DIR}/kconfig_module_dirs.cmake "")
+
   file(WRITE ${kconfig_modules_file}
     "# No west and no Zephyr modules\n"
     )


### PR DESCRIPTION
## Summary

A standalone Zephyr checkout without a west workspace can reach the no-west
module path in `cmake/modules/zephyr_module.cmake`. That path creates the
empty `Kconfig.modules` and `Kconfig.sysbuild.modules` files, but not the
module environment files consumed by `cmake/modules/kconfig.cmake`.

Generate empty `kconfig_module_dirs.env` and `kconfig_module_dirs.cmake`
files in the no-west path. The CMake fragment initializes `kconfig_env_dirs`
to an empty list, matching the no-module state.

## Background

I hit this while learning Zephyr and building it on macOS from a standalone
checkout. The build reached CMake and failed because
`kconfig_module_dirs.cmake` had not been generated.

After searching upstream issues and pull requests, I found a similar
standalone-checkout failure reported in a comment on PR #109456, where
Twister reached CMake and failed because
`twister-out/.../Kconfig/kconfig_module_dirs.cmake` was not generated.

PR #95771 / commit `f624525f30d4` made `cmake/modules/kconfig.cmake`
include `kconfig_module_dirs.cmake` directly. The normal module discovery
path generates that file, but the no-west path still only generated the
empty Kconfig module files.

## Testing

- `git diff --check upstream/main..HEAD`
- `scripts/checkpatch.pl --no-signoff --git HEAD`
- `.venv/bin/python ./scripts/twister -T samples/hello_world -p qemu_x86 --outdir build/agent/no-west-kconfig-pr/twister-hello`
