### PR TITLE
net: remove ptp_pkt/lldp_pkt flags

### DIFF
--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -226,10 +226,6 @@ struct net_pkt {
 
 	uint8_t overwrite : 1;	 /* Is packet content being overwritten? */
 	uint8_t eof : 1;	 /* Last packet before EOF */
-	uint8_t ptp_pkt : 1;	 /* For outgoing packet: is this packet
-				  * a L2 PTP packet.
-				  * Used only if defined (CONFIG_NET_L2_PTP_TIMESTAMPING)
-				  */
 	uint8_t forwarding : 1;	 /* Are we forwarding this pkt
 				  * Used only if defined(CONFIG_NET_IPV6_ROUTE)
 				  */
@@ -520,16 +516,6 @@ static inline uint8_t net_pkt_family(struct net_pkt *pkt)
 static inline void net_pkt_set_family(struct net_pkt *pkt, uint8_t family)
 {
 	pkt->family = family;
-}
-
-static inline bool net_pkt_is_ptp(struct net_pkt *pkt)
-{
-	return !!(pkt->ptp_pkt);
-}
-
-static inline void net_pkt_set_ptp(struct net_pkt *pkt, bool is_ptp)
-{
-	pkt->ptp_pkt = is_ptp;
 }
 
 static inline bool net_pkt_is_tx_timestamping(struct net_pkt *pkt)

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -240,12 +240,6 @@ struct net_pkt {
 					* NET_AF_INET.
 					*/
 #endif
-#if defined(CONFIG_NET_LLDP)
-	uint8_t lldp_pkt : 1; /* Is this pkt an LLDP message.
-			       * Note: family needs to be
-			       * NET_AF_UNSPEC.
-			       */
-#endif
 	uint8_t ppp_msg : 1; /* This is a PPP message */
 	uint8_t captured : 1;	  /* Set to 1 if this packet is already being
 				   * captured
@@ -1480,31 +1474,6 @@ static inline void net_pkt_set_ipv4_acd(struct net_pkt *pkt,
 	ARG_UNUSED(is_acd_arp_msg);
 }
 #endif /* CONFIG_NET_IPV4_ACD */
-
-#if defined(CONFIG_NET_LLDP)
-static inline bool net_pkt_is_lldp(struct net_pkt *pkt)
-{
-	return !!(pkt->lldp_pkt);
-}
-
-static inline void net_pkt_set_lldp(struct net_pkt *pkt, bool is_lldp)
-{
-	pkt->lldp_pkt = is_lldp;
-}
-#else
-static inline bool net_pkt_is_lldp(struct net_pkt *pkt)
-{
-	ARG_UNUSED(pkt);
-
-	return false;
-}
-
-static inline void net_pkt_set_lldp(struct net_pkt *pkt, bool is_lldp)
-{
-	ARG_UNUSED(pkt);
-	ARG_UNUSED(is_lldp);
-}
-#endif /* CONFIG_NET_LLDP */
 
 #if defined(CONFIG_NET_L2_PPP)
 static inline bool net_pkt_is_ppp(struct net_pkt *pkt)

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -2138,7 +2138,6 @@ static void clone_pkt_attributes(struct net_pkt *pkt, struct net_pkt *clone_pkt)
 	net_pkt_set_orig_iface(clone_pkt, net_pkt_orig_iface(pkt));
 	net_pkt_set_captured(clone_pkt, net_pkt_is_captured(pkt));
 	net_pkt_set_eof(clone_pkt, net_pkt_eof(pkt));
-	net_pkt_set_ptp(clone_pkt, net_pkt_is_ptp(pkt));
 	net_pkt_set_ppp(clone_pkt, net_pkt_is_ppp(pkt));
 	net_pkt_set_lldp(clone_pkt, net_pkt_is_lldp(pkt));
 	net_pkt_set_ipv4_acd(clone_pkt, net_pkt_ipv4_acd(pkt));

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -2139,7 +2139,6 @@ static void clone_pkt_attributes(struct net_pkt *pkt, struct net_pkt *clone_pkt)
 	net_pkt_set_captured(clone_pkt, net_pkt_is_captured(pkt));
 	net_pkt_set_eof(clone_pkt, net_pkt_eof(pkt));
 	net_pkt_set_ppp(clone_pkt, net_pkt_is_ppp(pkt));
-	net_pkt_set_lldp(clone_pkt, net_pkt_is_lldp(pkt));
 	net_pkt_set_ipv4_acd(clone_pkt, net_pkt_ipv4_acd(pkt));
 	net_pkt_set_tx_timestamping(clone_pkt, net_pkt_is_tx_timestamping(pkt));
 	net_pkt_set_rx_timestamping(clone_pkt, net_pkt_is_rx_timestamping(pkt));

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -171,7 +171,6 @@ static struct net_pkt *setup_gptp_frame(struct net_if *iface,
 	}
 
 	net_buf_add(pkt->buffer, sizeof(struct gptp_hdr) + extra_header);
-	net_pkt_set_ptp(pkt, true);
 	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_PTP);
 
 	(void)net_linkaddr_copy(net_pkt_lladdr_src(pkt),

--- a/subsys/net/l2/ethernet/lldp/lldp.c
+++ b/subsys/net/l2/ethernet/lldp/lldp.c
@@ -72,7 +72,6 @@ static void lldp_send(struct ethernet_lldp *lldp)
 		return;
 	}
 
-	net_pkt_set_lldp(pkt, true);
 	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_LLDP);
 
 	ret = net_pkt_write(pkt, (uint8_t *)lldp->lldpdu,

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -821,7 +821,6 @@ ZTEST(net_pkt_test_suite, test_net_pkt_clone)
 	net_pkt_set_family(pkt, NET_AF_INET6);
 	net_pkt_set_captured(pkt, true);
 	net_pkt_set_eof(pkt, true);
-	net_pkt_set_ptp(pkt, true);
 	net_pkt_set_tx_timestamping(pkt, true);
 	net_pkt_set_rx_timestamping(pkt, true);
 	net_pkt_set_forwarding(pkt, true);
@@ -857,9 +856,6 @@ ZTEST(net_pkt_test_suite, test_net_pkt_clone)
 
 	zassert_true(net_pkt_eof(cloned_pkt),
 		     "Cloned pkt eof flag mismatch");
-
-	zassert_true(net_pkt_is_ptp(cloned_pkt),
-		     "Cloned pkt ptp_pkt flag mismatch");
 
 #if CONFIG_NET_PKT_TIMESTAMP
 	zassert_true(net_pkt_is_tx_timestamping(cloned_pkt),


### PR DESCRIPTION
Remove `ptp_pkt`, `lldp_pkt` flags from `net_pkt` structure.

Follow-up clean-up for #83228.