### PR TITLE
drivers: display: ls0xx: fix releasing SPI bus too soon

### DIFF
--- a/drivers/display/ls0xx.c
+++ b/drivers/display/ls0xx.c
@@ -149,8 +149,8 @@ static void ls0xx_vcom_toggle(void *a, void *b, void *c)
 		}
 		/* Sleep before giving semaphore based on errors in testing */
 		k_sleep(K_TICKS(LS0XX_BUS_RETURN_DELAY_TICKS));
-	    k_sem_give(&ls0xx_bus_sem);
 		spi_release_dt(&config->bus);
+		k_sem_give(&ls0xx_bus_sem);
 		k_msleep(config->serial_vcom_int);
 #endif /* DT_INST_NODE_HAS_PROP(0, extcomin_gpios) */
 	}
@@ -173,8 +173,8 @@ static int ls0xx_clear(const struct device *dev)
 		err = -EBUSY;
 	}
 	k_sleep(K_TICKS(LS0XX_BUS_RETURN_DELAY_TICKS));
-	k_sem_give(&ls0xx_bus_sem);
 	spi_release_dt(&config->bus);
+	k_sem_give(&ls0xx_bus_sem);
 
 	return err;
 }
@@ -230,8 +230,8 @@ static int ls0xx_update_display(const struct device *dev,
 		err = -EBUSY;
 	}
 	k_sleep(K_TICKS(LS0XX_BUS_RETURN_DELAY_TICKS));
-	k_sem_give(&ls0xx_bus_sem);
 	spi_release_dt(&config->bus);
+	k_sem_give(&ls0xx_bus_sem);
 
 	return err;
 }


### PR DESCRIPTION
Moves a semaphore I added in #96396 to lock the SPI bus during VCOM inversion commands down one line in three places, so that we can ensure the bus is ready before allowing display writes to be attempted.

Thanks to @snoyer for reporting this in https://github.com/zmkfirmware/zmk/pull/3400 – I've confirmed this with them (by explaining why my placement was wrong thinking it was theirs) and fixed two other instances of the same issue.

Fixes https://github.com/zmkfirmware/zmk/issues/3392