### PR TITLE
samples: bluetooth: bound TMAP originate URI

### DIFF
--- a/samples/bluetooth/audio/tmap_peripheral/src/ccp_call_ctrl.c
+++ b/samples/bluetooth/audio/tmap_peripheral/src/ccp_call_ctrl.c
@@ -25,7 +25,7 @@
 #define CALLER_ID "friend"
 
 static uint8_t new_call_index;
-static char remote_uri[CONFIG_BT_TBS_MAX_URI_LENGTH];
+static char remote_uri[CONFIG_BT_TBS_MAX_URI_LENGTH + 1];
 
 static K_SEM_DEFINE(sem_discovery_done, 0U, 1U);
 
@@ -93,7 +93,10 @@ static void terminate_call_cb(struct bt_conn *conn, int err,
 static void read_uri_schemes_string_cb(struct bt_conn *conn, int err,
 				       uint8_t inst_index, const char *value)
 {
-	size_t i;
+	const char *uri_scheme = value;
+	const char *uri_schemes_end = value + strlen(value);
+	const size_t suffix_len = strlen(URI_SEPARATOR) + strlen(CALLER_ID);
+	size_t uri_scheme_len;
 
 	ARG_UNUSED(conn);
 
@@ -109,22 +112,37 @@ static void read_uri_schemes_string_cb(struct bt_conn *conn, int err,
 
 	/* Save first remote URI
 	 *
-	 * First search for the first comma (separator), and use that to determine the end of the
-	 * first (or only) URI. Then use that length to copy the URI to `remote_uri` for later use.
+	 * First search for a URI scheme that can fit with the separator and caller ID.
+	 * Then compose the URI for later use.
 	 */
-	for (i = 0U; i < strlen(value); i++) {
-		if (value[i] == ',') {
+	while (uri_scheme < uri_schemes_end) {
+		uri_scheme_len = 0U;
+		while (uri_scheme[uri_scheme_len] != '\0' &&
+		       uri_scheme[uri_scheme_len] != ',') {
+			uri_scheme_len++;
+		}
+
+		if (uri_scheme_len == 0U) {
+			uri_scheme++;
+			continue;
+		}
+
+		if (uri_scheme_len + suffix_len <= CONFIG_BT_TBS_MAX_URI_LENGTH) {
 			break;
 		}
+
+		uri_scheme += uri_scheme_len + 1U;
 	}
 
-	if (i >= sizeof(remote_uri)) {
-		printk("Cannot store URI of length %zu: %s\n", i, value);
+	if (uri_scheme >= uri_schemes_end) {
+		printk("No URI scheme fits originate URI: %s\n", value);
 		return;
 	}
 
-	strncpy(remote_uri, value, i);
-	remote_uri[i] = '\0';
+	(void)memcpy(remote_uri, uri_scheme, uri_scheme_len);
+	remote_uri[uri_scheme_len] = '\0';
+	(void)strcat(remote_uri, URI_SEPARATOR);
+	(void)strcat(remote_uri, CALLER_ID);
 
 	printk("CCP: Discovered remote URI: %s\n", remote_uri);
 	k_sem_give(&sem_discovery_done);
@@ -160,13 +178,8 @@ int ccp_call_ctrl_init(struct bt_conn *conn)
 int ccp_originate_call(void)
 {
 	int err;
-	char uri[CONFIG_BT_TBS_MAX_URI_LENGTH];
 
-	strcpy(uri, remote_uri);
-	strcat(uri, URI_SEPARATOR);
-	strcat(uri, CALLER_ID);
-
-	err = bt_tbs_client_originate_call(default_conn, BT_TBS_GTBS_INDEX, uri);
+	err = bt_tbs_client_originate_call(default_conn, BT_TBS_GTBS_INDEX, remote_uri);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
 		printk("TBS originate call failed: %d\n", err);
 	}


### PR DESCRIPTION
## Summary

This updates the TMAP peripheral sample to bound the URI used by `ccp_originate_call()`.

The sample reads a list of remote URI schemes and later originates a call to `friend`. `CONFIG_BT_TBS_MAX_URI_LENGTH` is defined as the maximum URI length without the NULL terminator, so the sample needs one byte for termination and must validate the final composed URI length before storing it.

## Changes

- Size the stored remote URI as `CONFIG_BT_TBS_MAX_URI_LENGTH + 1`.
- Walk the URI schemes list and select the first non-empty scheme that can fit `scheme:friend`.
- Build the full originate URI in `read_uri_schemes_string_cb()` after the length check, using `strcat()` only on the validated fixed-size buffer.
- Pass the stored URI directly to `bt_tbs_client_originate_call()`.
- Keep the change limited to the TMAP peripheral sample.

## Testing

- `git fetch origin main`
- `git rebase origin/main`
- `git diff --check origin/main...HEAD -- samples/bluetooth/audio/tmap_peripheral/src/ccp_call_ctrl.c`
- `git show --check --stat --oneline HEAD`
- `rg -n "snprintk|strcat|uri_scheme_len == 0U|remote_uri\[uri_scheme_len\]" samples/bluetooth/audio/tmap_peripheral/src/ccp_call_ctrl.c`

Build not run locally: this Windows checkout does not have `west`, `cmake`, or `ninja` installed, and this sparse checkout does not include Zephyr's `scripts/` directory.
