### PR TITLE
doc: gsg: fix typos in west init commands

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -325,7 +325,7 @@ installation.
 
             .. parsed-literal::
 
-               west init ~ -m https://github.com/zephyrproject-rtos/zephyr/zephyrproject --mr v |zephyr-version-ltrim|
+               west init -m https://github.com/zephyrproject-rtos/zephyr ~/zephyrproject --mr v |zephyr-version-ltrim|
                cd ~/zephyrproject
                west update
 
@@ -335,7 +335,7 @@ installation.
 
             .. code-block:: bash
 
-               west init ~ -m https://github.com/zephyrproject-rtos/zephyr/zephyrproject
+               west init -m https://github.com/zephyrproject-rtos/zephyr ~/zephyrproject
                cd ~/zephyrproject
                west update
 
@@ -343,7 +343,7 @@ installation.
 
             .. parsed-literal::
 
-               west init ~ -m https://github.com/zephyrproject-rtos/zephyr/zephyrproject --mr v |zephyr-version-ltrim|
+               west init -m https://github.com/zephyrproject-rtos/zephyr ~/zephyrproject --mr v |zephyr-version-ltrim|
                cd ~/zephyrproject
                west update
 


### PR DESCRIPTION
Fix malformed commands introduced in #110999.