### PR TITLE
tracing: ctf: keep 64-bit timestamps monotonic on 32-bit counters

### DIFF
--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -52,17 +52,43 @@
 
 #ifdef CONFIG_TRACING_CTF_TIMESTAMP
 #include <zephyr/timing/timing.h>
+#include <zephyr/spinlock.h>
 
+/*
+ * Return a monotonically increasing 64-bit nanosecond timestamp.
+ *
+ * timing_counter_get() may be backed by a counter narrower than 64 bits (e.g. a
+ * 32-bit hardware cycle counter). Converting an instantaneous narrow counter
+ * value to nanoseconds would wrap back to (near) zero every time the counter
+ * rolls over, producing non-monotonic timestamps that crash CTF readers such as
+ * babeltrace2. Instead, accumulate the per-call cycle delta into a 64-bit total
+ * before converting to nanoseconds. timing_cycles_get() resolves a single
+ * counter rollover between two readings, so this stays correct as long as no
+ * more than one rollover happens between consecutive traced events.
+ */
 static inline uint64_t ctf_top_timestamp_get(void)
 {
-	timing_t bigbang = 0;
-	timing_t now;
-	uint64_t now_cycles;
+	static struct k_spinlock lock;
+	static timing_t last;
+	static uint64_t total_cycles;
+	static bool initialized;
+	k_spinlock_key_t key = k_spin_lock(&lock);
+	timing_t now = timing_counter_get();
+	uint64_t ns;
 
-	now = timing_counter_get();
-	now_cycles = timing_cycles_get(&bigbang, &now);
+	if (!initialized) {
+		last = now;
+		initialized = true;
+	}
 
-	return timing_cycles_to_ns(now_cycles);
+	total_cycles += timing_cycles_get(&last, &now);
+	last = now;
+
+	ns = timing_cycles_to_ns(total_cycles);
+
+	k_spin_unlock(&lock, key);
+
+	return ns;
 }
 
 #define CTF_EVENT(...)                                                                             \


### PR DESCRIPTION
The CTF timestamp helper computed the interval from a fixed bigbang of
0, so timing_cycles_get() returned the raw timing counter value. On
boards whose timing counter is narrower than 64 bits (e.g. a 32-bit
hardware cycle counter) that value wraps back to near zero every time
the counter rolls over, which made the 64-bit nanosecond timestamp jump
backwards. Non-monotonic timestamps crash CTF readers such as
babeltrace2 with "timestamp is less than muxer's last returned
timestamp".

Accumulate the per-call cycle delta into a persistent 64-bit total
before converting to nanoseconds. timing_cycles_get() resolves a single
counter rollover between two readings, so the running total stays
monotonic across wraps as long as no more than one rollover happens
between consecutive traced events. A spinlock protects the shared
accumulator, since the CTF_EVENT macro only took irq_lock, which is not
SMP safe.

Fixes #111651

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
