### PR TITLE
scripts: checkpatch: recognize __aligned() in declarations

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -404,6 +404,7 @@ our $Attribute	= qr{
 			____cacheline_aligned|
 			____cacheline_aligned_in_smp|
 			____cacheline_internodealigned_in_smp|
+			__aligned\s*\((?:[^()]*|\([^()]*\))*\)|
 			__weak|
 			__syscall
 		  }x;


### PR DESCRIPTION
checkpatch reported a false-positive LINE_SPACING "Missing a blank line
after declarations" for local variables declared with __aligned(), e.g.:

	uint32_t eicr, embr, eicr_val;
	uint32_t __aligned(4) data32 = 0;

The LINE_SPACING heuristic decides whether a line is a declaration with
a regex that lets the type absorb trailing modifiers/attributes. But
__aligned was missing from the $Attribute list, so the type matched only
"uint32_t", $Ident then matched "__aligned", and the following "(" did
not match the expected [=,;:[] terminator. The line was therefore not
seen as a declaration and a blank line was demanded after the preceding
one.

Add __aligned to $Attribute, consuming its parenthesized argument
(including one level of nesting such as __aligned(sizeof(x))). This is
the root cause: __aligned(N) is now understood as a type attribute
everywhere, not only in the LINE_SPACING check.

Fixes #110417

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
