### PR TITLE
shell: add thread id notice to help description of subcommand 'unwind'

### DIFF
--- a/subsys/shell/modules/kernel_service/thread/unwind.c
+++ b/subsys/shell/modules/kernel_service/thread/unwind.c
@@ -50,4 +50,5 @@ static int cmd_kernel_thread_unwind(const struct shell *sh, size_t argc, char **
 	return 0;
 }
 
-KERNEL_THREAD_CMD_ARG_ADD(unwind, NULL, "Unwind a thread.", cmd_kernel_thread_unwind, 1, 1);
+KERNEL_THREAD_CMD_ARG_ADD(unwind, NULL, "Unwind a thread <thread_id>",
+						cmd_kernel_thread_unwind, 1, 1);


### PR DESCRIPTION
In most usage scenarios, the thread id parameter is useful for unwind subcommand. For example, use the 'kernel thread list' command to locate the <thread id> of the target thread, then check the call trace with 'kernel thread unwind <thread id>'. At least, users should be reminded that this command accepts the <thread id> parameter to check the call trace of any thread.