### PR TITLE
tests: kernel: condvar: bump MAX_THREAD_BYTES for SMP & USERSPACE

### DIFF
--- a/tests/kernel/condvar/condvar_api/Kconfig
+++ b/tests/kernel/condvar/condvar_api/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config MAX_THREAD_BYTES
+	default 3 if USERSPACE && SMP
+
+# Include Zephyr's Kconfig.
+source "Kconfig.zephyr"


### PR DESCRIPTION
Any userspace test that spawns a handful of threads then overflows this
limit during kobject metadata generation, e.g. now fails with:

    Too many thread objects (19)
    Increase CONFIG_MAX_THREAD_BYTES to 3

Default CONFIG_MAX_THREAD_BYTES to 3 under USERSPACE

Fixes #112137

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
