### PR TITLE
soc: intel_adsp: include DATA_SECTIONS linker snippet

### DIFF
--- a/soc/intel/intel_adsp/ace/include/linker/ace-link-mirrored.ld
+++ b/soc/intel/intel_adsp/ace/include/linker/ace-link-mirrored.ld
@@ -352,6 +352,12 @@ SECTIONS {
 
 #include <zephyr/linker/common-ram.ld>
 #include <zephyr/linker/kobject-data.ld>
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources(DATA_SECTIONS ...) CMake function.
+ */
+#include <snippets-data-sections.ld>
+
   __common_ram_region_end = .;
 
   .tm_clone_table : {

--- a/soc/intel/intel_adsp/cavs/include/xtensa-cavs-linker.ld
+++ b/soc/intel/intel_adsp/cavs/include/xtensa-cavs-linker.ld
@@ -231,6 +231,11 @@ SECTIONS {
 
 #include <zephyr/linker/common-ram.ld>
 
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources(DATA_SECTIONS ...) CMake function.
+ */
+#include <snippets-data-sections.ld>
+
   .tm_clone_table : {
     *(.tm_clone_table)
   } >RAM


### PR DESCRIPTION
The ACE and CAVS Xtensa linker scripts never included the generated
snippets-data-sections.ld file, so any section registered through
zephyr_linker_sources(DATA_SECTIONS ...) was silently dropped. The new
ztest benchmark framework registers its iterable RAM sections this way,
which made benchmark tests fail to link with undefined references to
_ztest_benchmark_*_list_start/end on these SoCs.
