### PR TITLE
arch: arm: zimage_header: fix incorrect image size calculation

### DIFF
--- a/arch/arm/core/zimage_header.ld
+++ b/arch/arm/core/zimage_header.ld
@@ -7,5 +7,12 @@
 #if defined(CONFIG_ARM_ZIMAGE_HEADER)
 KEEP(*(.image_header))
 KEEP(*(.".image_header.*"))
-__end = .;
+/*
+ * The zImage header at offset 0x2c must hold the end-of-image LMA so that
+ * (end - start) equals the file size of the produced binary, matching the
+ * Linux ARM zImage convention.  '.' here is only just past the 48-byte
+ * header (rom_start is one of the first sections emitted), so use the
+ * .last_section LMA which the linker resolves lazily at final link time.
+ */
+__end = LOADADDR(.last_section) + SIZEOF(.last_section);
 #endif


### PR DESCRIPTION
Fix incorrect zImage header size calculation for ARM Cortex-R/A
builds when CONFIG_ARM_ZIMAGE_HEADER is enabled.

Currently, the zImage header reports an incorrect size of 48 bytes,
since __end is set immediately after the .image_header section.
Consumers such as the Xen ARM loader rely on this field to determine
how much data to load, resulting in only a partial image being loaded
and causing runtime failures.

This change fixes the calculation of __end to use the end of the
final output section, ensuring the full image size is correctly
reflected in the header.