### PR TITLE
P2P Persistent fix

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -1796,6 +1796,8 @@ struct wifi_p2p_params {
 		int freq;
 		/** Persistent group ID (-1 = not persistent) */
 		int persistent;
+		/** Add persistent group */
+		bool persistent_set;
 		/** Enable HT40 */
 		bool ht40;
 		/** Enable VHT */

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -1789,6 +1789,8 @@ struct wifi_p2p_params {
 		unsigned int freq;
 		/** Join an existing group (as a client) instead of starting GO negotiation */
 		bool join;
+		/** Add persistent group */
+		bool persistent_set;
 	} connect;
 	/** Group add specific parameters */
 	struct {

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -1731,6 +1731,8 @@ enum wifi_p2p_op {
 	WIFI_P2P_INVITE,
 	/** P2P power save */
 	WIFI_P2P_POWER_SAVE,
+	/** P2P list stored persistent networks */
+	WIFI_P2P_LIST_NETWORKS,
 };
 
 /** Wi-Fi P2P discovery type */
@@ -1755,6 +1757,7 @@ enum wifi_p2p_connection_method {
 
 /** Maximum number of P2P peers that can be returned in a single query */
 #define WIFI_P2P_MAX_PEERS CONFIG_WIFI_P2P_MAX_PEERS
+#define WIFI_P2P_LIST_NETWORKS_BUF_SIZE 2048
 
 /** Wi-Fi P2P parameters */
 struct wifi_p2p_params {
@@ -1838,6 +1841,13 @@ struct wifi_p2p_params {
 		/** GO device address length */
 		uint8_t go_dev_addr_length;
 	} invite;
+	/** List networks specific parameters */
+	struct {
+		/** Buffer to hold the LIST_NETWORKS response. */
+		char *buf;
+		/** Size of the allocated buffer in bytes */
+		size_t buf_size;
+	} list_networks;
 };
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_P2P */
 

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -1733,6 +1733,8 @@ enum wifi_p2p_op {
 	WIFI_P2P_POWER_SAVE,
 	/** P2P list stored persistent networks */
 	WIFI_P2P_LIST_NETWORKS,
+	/** P2P remove persistent network(s) */
+	WIFI_P2P_PERSISTENT_REMOVE,
 };
 
 /** Wi-Fi P2P discovery type */
@@ -1848,6 +1850,14 @@ struct wifi_p2p_params {
 		/** Size of the allocated buffer in bytes */
 		size_t buf_size;
 	} list_networks;
+	/** Persistent network remove specific parameters */
+	struct {
+		/** Network ID to remove.
+		 *  >= 0 : remove the specific network with this ID.
+		 *  -1   : remove ALL saved networks.
+		 */
+		int id;
+	} persistent_remove;
 };
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_P2P */
 

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -3525,6 +3525,28 @@ int supplicant_p2p_oper(const struct device *dev __unused, struct net_if *iface,
 		}
 		ret = 0;
 		break;
+	case WIFI_P2P_LIST_NETWORKS: {
+		if (params->list_networks.buf == NULL ||
+		    params->list_networks.buf_size == 0) {
+			wpa_printf(MSG_ERROR,
+				   "P2P list_networks: buffer not provided");
+			return -EINVAL;
+		}
+
+		ret = zephyr_wpa_cli_cmd_resp_noprint(wpa_s->ctrl_conn,
+						      "LIST_NETWORKS",
+						      params->list_networks.buf);
+		if (ret < 0) {
+			wpa_printf(MSG_ERROR, "LIST_NETWORKS command failed");
+			return -EIO;
+		}
+		if (strncmp(params->list_networks.buf, "FAIL", 4) == 0) {
+			wpa_printf(MSG_ERROR, "LIST_NETWORKS returned FAIL");
+			return -EIO;
+		}
+		ret = 0;
+		break;
+	}
 
 	default:
 		wpa_printf(MSG_ERROR, "Unknown P2P operation: %d", params->oper);

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -3339,6 +3339,15 @@ int supplicant_p2p_oper(const struct device *dev __unused, struct net_if *iface,
 			return -EINVAL;
 		}
 
+		if ((params->group_add.persistent_set)) {
+			ret = zephyr_wpa_cli_cmd_resp_noprint(wpa_s->ctrl_conn,
+					"SET persistent_reconnect 1",
+					resp_buf);
+			if (ret < 0) {
+				wpa_printf(MSG_WARNING, "Failed to set persistent_reconnect");
+			}
+		}
+
 		len = snprintk(cmd_buf, sizeof(cmd_buf), "P2P_GROUP_ADD");
 
 		if (params->group_add.freq > 0) {
@@ -3346,9 +3355,25 @@ int supplicant_p2p_oper(const struct device *dev __unused, struct net_if *iface,
 					params->group_add.freq);
 		}
 
-		if (params->group_add.persistent >= 0) {
-			len += snprintk(cmd_buf + len, sizeof(cmd_buf) - len, " persistent=%d",
-					params->group_add.persistent);
+		if (params->group_add.persistent_set == true) {
+			len += snprintk(cmd_buf + len, sizeof(cmd_buf) - len, " persistent");
+		} else if (params->group_add.persistent >= 0) {
+			/* Sanity check: verify the network exists before proceeding. */
+			char check_cmd[64];
+
+			snprintk(check_cmd, sizeof(check_cmd), "GET_NETWORK %d ssid",
+				 params->group_add.persistent);
+			ret = zephyr_wpa_cli_cmd_resp_noprint(wpa_s->ctrl_conn,
+							      check_cmd, resp_buf);
+			if (ret < 0 || strncmp(resp_buf, "FAIL", 4) == 0) {
+				wpa_printf(MSG_ERROR,
+					   "P2P persistent group %d does not exist",
+					   params->group_add.persistent);
+				return -ENOENT;
+			}
+
+			len += snprintk(cmd_buf + len, sizeof(cmd_buf) - len,
+					" persistent=%d", params->group_add.persistent);
 		}
 
 		if (params->group_add.ht40 != 0) {

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -3248,10 +3248,19 @@ int supplicant_p2p_oper(const struct device *dev __unused, struct net_if *iface,
 		const char *method_str = "";
 		char freq_str[32] = "";
 		const char *join_str = "";
+		char persistent_str[32] = "";
 
 		if (params == NULL) {
 			wpa_printf(MSG_ERROR, "P2P connect params are NULL");
 			return -EINVAL;
+		}
+
+		if ((params->connect.persistent_set)) {
+			ret = zephyr_wpa_cli_cmd_resp_noprint(wpa_s->ctrl_conn,
+					"SET persistent_reconnect 1", resp_buf);
+			if (ret < 0) {
+				wpa_printf(MSG_WARNING, "Failed to set persistent_reconnect");
+			}
 		}
 
 		snprintk(addr_str, sizeof(addr_str), "%02x:%02x:%02x:%02x:%02x:%02x",
@@ -3268,27 +3277,33 @@ int supplicant_p2p_oper(const struct device *dev __unused, struct net_if *iface,
 			join_str = " join";
 		}
 
+		/* Add persistent parameter if specified */
+		if (params->connect.persistent_set == true) {
+			/* persistent without specific ID — wpa_supplicant picks the group */
+			snprintk(persistent_str, sizeof(persistent_str), " persistent");
+		}
+
 		switch (params->connect.method) {
 		case WIFI_P2P_METHOD_PBC:
 			method_str = "pbc";
-			snprintk(cmd_buf, sizeof(cmd_buf), "P2P_CONNECT %s %s go_intent=%d%s%s",
+			snprintk(cmd_buf, sizeof(cmd_buf), "P2P_CONNECT %s %s go_intent=%d%s%s%s",
 				 addr_str, method_str, params->connect.go_intent, freq_str,
-				 join_str);
+				 join_str, persistent_str);
 			break;
 		case WIFI_P2P_METHOD_DISPLAY:
 			method_str = "pin";
-			snprintk(cmd_buf, sizeof(cmd_buf), "P2P_CONNECT %s %s go_intent=%d%s%s",
+			snprintk(cmd_buf, sizeof(cmd_buf), "P2P_CONNECT %s %s go_intent=%d%s%s%s",
 				 addr_str, method_str, params->connect.go_intent, freq_str,
-				 join_str);
+				 join_str, persistent_str);
 			break;
 		case WIFI_P2P_METHOD_KEYPAD:
 			if (params->connect.pin[0] == '\0') {
 				wpa_printf(MSG_ERROR, "PIN required for keypad method");
 				return -EINVAL;
 			}
-			snprintk(cmd_buf, sizeof(cmd_buf), "P2P_CONNECT %s %s go_intent=%d%s%s",
+			snprintk(cmd_buf, sizeof(cmd_buf), "P2P_CONNECT %s %s go_intent=%d%s%s%s",
 				 addr_str, params->connect.pin,
-				 params->connect.go_intent, freq_str, join_str);
+				 params->connect.go_intent, freq_str, join_str, persistent_str);
 			break;
 		default:
 			wpa_printf(MSG_ERROR, "Unknown P2P connection method: %d",

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -3525,6 +3525,7 @@ int supplicant_p2p_oper(const struct device *dev __unused, struct net_if *iface,
 		}
 		ret = 0;
 		break;
+
 	case WIFI_P2P_LIST_NETWORKS: {
 		if (params->list_networks.buf == NULL ||
 		    params->list_networks.buf_size == 0) {
@@ -3543,6 +3544,72 @@ int supplicant_p2p_oper(const struct device *dev __unused, struct net_if *iface,
 		if (strncmp(params->list_networks.buf, "FAIL", 4) == 0) {
 			wpa_printf(MSG_ERROR, "LIST_NETWORKS returned FAIL");
 			return -EIO;
+		}
+		ret = 0;
+		break;
+	}
+
+	case WIFI_P2P_PERSISTENT_REMOVE: {
+		if (params->persistent_remove.id == -1) {
+			/* Remove ALL saved networks */
+			snprintk(cmd_buf, sizeof(cmd_buf), "REMOVE_NETWORK all");
+			ret = zephyr_wpa_cli_cmd_resp_noprint(wpa_s->ctrl_conn,
+							      cmd_buf, resp_buf);
+			if (ret < 0) {
+				wpa_printf(MSG_ERROR,
+					   "REMOVE_NETWORK all command failed: %d", ret);
+				return -EIO;
+			}
+			if (strncmp(resp_buf, "FAIL", 4) == 0) {
+				wpa_printf(MSG_ERROR,
+					   "REMOVE_NETWORK all returned FAIL");
+				return -EIO;
+			}
+		} else if (params->persistent_remove.id >= 0) {
+			/*
+			 * Sanity check: use GET_NETWORK <id> ssid to verify
+			 * the network exists before attempting removal.
+			 * wpa_supplicant returns "FAIL" if the ID is unknown.
+			 */
+			snprintk(cmd_buf, sizeof(cmd_buf), "GET_NETWORK %d ssid",
+				 params->persistent_remove.id);
+			ret = zephyr_wpa_cli_cmd_resp_noprint(wpa_s->ctrl_conn,
+							      cmd_buf, resp_buf);
+			if (ret < 0) {
+				wpa_printf(MSG_ERROR,
+					   "GET_NETWORK %d ssid command failed: %d",
+					   params->persistent_remove.id, ret);
+				return -EIO;
+			}
+			if (strncmp(resp_buf, "FAIL", 4) == 0) {
+				wpa_printf(MSG_ERROR,
+					   "P2P persistent_remove: network ID %d not found",
+					   params->persistent_remove.id);
+				return -ENOENT;
+			}
+
+			/* Network exists, proceed with removal */
+			snprintk(cmd_buf, sizeof(cmd_buf), "REMOVE_NETWORK %d",
+				 params->persistent_remove.id);
+			ret = zephyr_wpa_cli_cmd_resp_noprint(wpa_s->ctrl_conn,
+							      cmd_buf, resp_buf);
+			if (ret < 0) {
+				wpa_printf(MSG_ERROR,
+					   "REMOVE_NETWORK %d command failed: %d",
+					   params->persistent_remove.id, ret);
+				return -EIO;
+			}
+			if (strncmp(resp_buf, "FAIL", 4) == 0) {
+				wpa_printf(MSG_ERROR,
+					   "REMOVE_NETWORK %d returned FAIL",
+					   params->persistent_remove.id);
+				return -EIO;
+			}
+		} else {
+			wpa_printf(MSG_ERROR,
+				   "P2P persistent_remove: invalid id %d",
+				   params->persistent_remove.id);
+			return -EINVAL;
 		}
 		ret = 0;
 		break;

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -3513,7 +3513,7 @@ int supplicant_p2p_oper(const struct device *dev __unused, struct net_if *iface,
 	}
 
 	case WIFI_P2P_POWER_SAVE:
-		snprintk(cmd_buf, sizeof(cmd_buf), "p2p_set ps %d", params->power_save ? 1 : 0);
+		snprintk(cmd_buf, sizeof(cmd_buf), "P2P_SET ps %d", params->power_save ? 1 : 0);
 		ret = zephyr_wpa_cli_cmd_resp_noprint(wpa_s->ctrl_conn, cmd_buf, resp_buf);
 		if (ret < 0) {
 			wpa_printf(MSG_ERROR, "p2p_set ps command failed: %d", ret);

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -4525,6 +4525,58 @@ static int cmd_wifi_p2p_list_networks(const struct shell *sh, size_t argc, char 
 	k_free(buf);
 	return 0;
 }
+
+static int cmd_wifi_p2p_persistent_remove(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = get_iface(IFACE_TYPE_STA, argc, argv);
+	struct wifi_p2p_params params = {0};
+	int idx = 1;
+	long val;
+	char *endptr;
+
+	context.sh = sh;
+
+	if (argc < 2) {
+		PR_ERROR("Usage: wifi p2p persistent_remove <network_id|-1>\n"
+			 "  <network_id> : remove a single persistent network by ID (>= 0)\n"
+			 "  all          : remove all saved persistent networks\n");
+		return -EINVAL;
+	}
+
+	params.oper = WIFI_P2P_PERSISTENT_REMOVE;
+
+	/* Accept all (remove all) or >= 0 (remove by ID) */
+	if (strcmp(argv[idx], "all") == 0) {
+		val = -1;
+	} else {
+		val = strtol(argv[idx], &endptr, 10);
+		if (*endptr != '\0' || val < 0) {
+			PR_ERROR("Invalid network_id '%s': must be >= 0\n",
+				 argv[idx]);
+			return -EINVAL;
+		}
+	}
+
+	params.persistent_remove.id = (int)val;
+
+	if (net_mgmt(NET_REQUEST_WIFI_P2P_OPER, iface, &params, sizeof(params))) {
+		if (params.persistent_remove.id == -1) {
+			PR_WARNING("P2P remove all networks request failed\n");
+		} else {
+			PR_WARNING("P2P persistent_remove network %d failed "
+				   "(network may not exist)\n",
+				   params.persistent_remove.id);
+		}
+		return -ENOEXEC;
+	}
+
+	if (params.persistent_remove.id == -1) {
+		PR("All P2P persistent networks removed\n");
+	} else {
+		PR("P2P persistent network %d removed\n", params.persistent_remove.id);
+	}
+	return 0;
+}
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_P2P */
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN
@@ -5683,6 +5735,16 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      SHELL_HELP("List stored persistent P2P networks",
 				 "[-i, --iface=<interface index>]"),
 		      cmd_wifi_p2p_list_networks, 1, 2),
+	SHELL_CMD_ARG(persistent_remove, NULL,
+		      SHELL_HELP("Remove P2P persistent network(s)",
+				 "[-i, --iface=<interface index>]\n"
+				 "<network_id|all>\n"
+				 "  <network_id> : Remove a single persistent network by ID (>= 0).\n"
+				 "  all           : Remove all saved persistent networks.\n"
+				 "Examples:\n"
+				 "  wifi p2p persistent_remove 0\n"
+				 "  wifi p2p persistent_remove all"),
+		      cmd_wifi_p2p_persistent_remove, 2, 3),
 	SHELL_SUBCMD_SET_END
 );
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -4196,6 +4196,7 @@ static int cmd_wifi_p2p_group_add(const struct shell *sh, size_t argc, char *arg
 	static const struct sys_getopt_option long_options[] = {
 		{"freq", sys_getopt_required_argument, 0, 'f'},
 		{"persistent", sys_getopt_required_argument, 0, 'p'},
+		{"persistent_set", sys_getopt_no_argument, 0, 'a'},
 		{"ht40", sys_getopt_no_argument, 0, 'h'},
 		{"vht", sys_getopt_no_argument, 0, 'v'},
 		{"he", sys_getopt_no_argument, 0, 'H'},
@@ -4212,6 +4213,7 @@ static int cmd_wifi_p2p_group_add(const struct shell *sh, size_t argc, char *arg
 
 	params.oper = WIFI_P2P_GROUP_ADD;
 	params.group_add.freq = 0;
+	params.group_add.persistent_set = false;
 	params.group_add.persistent = -1;
 	params.group_add.ht40 = false;
 	params.group_add.vht = false;
@@ -4219,7 +4221,7 @@ static int cmd_wifi_p2p_group_add(const struct shell *sh, size_t argc, char *arg
 	params.group_add.edmg = false;
 	params.group_add.go_bssid_length = 0;
 
-	while ((opt = sys_getopt_long(argc, argv, "f:p:hvHeb:i:?", long_options,
+	while ((opt = sys_getopt_long(argc, argv, "f:ap:hvHeb:i:?", long_options,
 				      &opt_index)) != -1) {
 		state = sys_getopt_state_get();
 		switch (opt) {
@@ -4228,6 +4230,9 @@ static int cmd_wifi_p2p_group_add(const struct shell *sh, size_t argc, char *arg
 				return -EINVAL;
 			}
 			params.group_add.freq = (int)val;
+			break;
+		case 'a':
+			params.group_add.persistent_set = true;
 			break;
 		case 'p':
 			if (!parse_number(sh, &val, state->optarg, "persistent", -1, 255)) {
@@ -4268,6 +4273,11 @@ static int cmd_wifi_p2p_group_add(const struct shell *sh, size_t argc, char *arg
 			PR_ERROR("Invalid option %c\n", state->optopt);
 			return -EINVAL;
 		}
+	}
+
+	if (params.group_add.persistent_set == true) {
+		PR_WARNING("The persistent_set is indicated and parameter -p will be ignored\n");
+		params.group_add.persistent = -1;
 	}
 
 	if (net_mgmt(NET_REQUEST_WIFI_P2P_OPER, iface, &params, sizeof(params))) {
@@ -5590,6 +5600,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 				 "[-f, --freq=<MHz>]: Frequency in MHz (0 = auto)\n"
 				 "[-p, --persistent=<id>]: Persistent group ID "
 				 "(-1 = not persistent)\n"
+				 "[-a, --persistent_set]: Add persistent group\n"
 				 "[-h, --ht40]: Enable HT40\n"
 				 "[-v, --vht]: Enable VHT (also enables HT40)\n"
 				 "[-H, --he]: Enable HE\n"

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -4093,6 +4093,7 @@ static int cmd_wifi_p2p_connect(const struct shell *sh, size_t argc, char *argv[
 		{"go-intent", sys_getopt_required_argument, 0, 'g'},
 		{"freq", sys_getopt_required_argument, 0, 'f'},
 		{"join", sys_getopt_no_argument, 0, 'j'},
+		{"persistent_set", sys_getopt_no_argument, 0, 'a'},
 		{"iface", sys_getopt_required_argument, 0, 'i'},
 		{"help", sys_getopt_no_argument, 0, 'h'},
 		{0, 0, 0, 0}
@@ -4103,7 +4104,8 @@ static int cmd_wifi_p2p_connect(const struct shell *sh, size_t argc, char *argv[
 
 	if (argc < 3) {
 		PR_ERROR("Usage: wifi p2p connect <MAC address> <pbc|pin> [PIN] "
-			 "[--go-intent=<0-15>] [--freq=<frequency>] [--join]\n");
+			 "[--go-intent=<0-15>] [--freq=<frequency>] [--join] "
+			 "[--persistent_set]\n");
 		return -EINVAL;
 	}
 
@@ -4139,8 +4141,10 @@ static int cmd_wifi_p2p_connect(const struct shell *sh, size_t argc, char *argv[
 	params.connect.freq = 0;
 	/* Set default join to false */
 	params.connect.join = false;
+	/* Set default persistent_set to false */
+	params.connect.persistent_set = false;
 
-	while ((opt = sys_getopt_long(argc, argv, "g:f:ji:h", long_options, &opt_index)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, "g:f:jai:h", long_options, &opt_index)) != -1) {
 		state = sys_getopt_state_get();
 		switch (opt) {
 		case 'g':
@@ -4157,6 +4161,9 @@ static int cmd_wifi_p2p_connect(const struct shell *sh, size_t argc, char *argv[
 			break;
 		case 'j':
 			params.connect.join = true;
+			break;
+		case 'a':
+			params.connect.persistent_set = true;
 			break;
 		case 'i':
 			/* Unused, but parsing to avoid unknown option error */
@@ -5584,6 +5591,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 				 "[PIN]: 8-digit PIN (optional, generates if omitted)\n"
 				 "[-g, --go-intent=<0-15>]: GO intent "
 				 "(0=client, 15=GO, default: 0)\n"
+				 "[-a, --persistent_set]: Add persistent group\n"
 				 "[-f, --freq=<frequency>]: Frequency in MHz (default: 2462)\n"
 				 "[-j, --join]: Join an existing group (as a client) "
 				 "instead of starting GO negotiation\n"
@@ -5593,7 +5601,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 				 "(uses PIN)\n"
 				 "wifi p2p connect f4:ce:36:01:00:38 pbc --join  "
 				 "(join existing group)"),
-		      cmd_wifi_p2p_connect, 3, 6),
+		      cmd_wifi_p2p_connect, 3, 7),
 	SHELL_CMD_ARG(group_add, NULL,
 		      SHELL_HELP("Add a P2P group (start as GO)",
 				 "[-i, --iface=<interface index>]\n"

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -4486,6 +4486,45 @@ static int cmd_wifi_p2p_power_save(const struct shell *sh, size_t argc, char *ar
 	PR("P2P power save %s\n", power_save_enable ? "enabled" : "disabled");
 	return 0;
 }
+
+static int cmd_wifi_p2p_list_networks(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = get_iface(IFACE_TYPE_STA, argc, argv);
+	struct wifi_p2p_params params = {0};
+	char *buf;
+	int ret;
+
+	context.sh = sh;
+
+	/* Dynamically allocate response buffer to avoid large stack usage */
+	buf = k_malloc(WIFI_P2P_LIST_NETWORKS_BUF_SIZE);
+	if (buf == NULL) {
+		PR_ERROR("Failed to allocate buffer for list_networks\n");
+		return -ENOMEM;
+	}
+	memset(buf, 0, WIFI_P2P_LIST_NETWORKS_BUF_SIZE);
+
+	params.oper = WIFI_P2P_LIST_NETWORKS;
+	params.list_networks.buf = buf;
+	params.list_networks.buf_size = WIFI_P2P_LIST_NETWORKS_BUF_SIZE;
+
+	ret = net_mgmt(NET_REQUEST_WIFI_P2P_OPER, iface, &params, sizeof(params));
+	if (ret) {
+		PR_WARNING("P2P list_networks request failed\n");
+		k_free(buf);
+		return -ENOEXEC;
+	}
+
+	if (buf[0] == '\0') {
+		PR("No persistent P2P networks stored\n");
+	} else {
+		PR("Stored P2P networks:\n");
+		PR("%s\n", buf);
+	}
+
+	k_free(buf);
+	return 0;
+}
 #endif /* CONFIG_WIFI_NM_WPA_SUPPLICANT_P2P */
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_NAN
@@ -5640,6 +5679,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 				 "<on>: Enable P2P power save\n"
 				 "<off>: Disable P2P power save"),
 		      cmd_wifi_p2p_power_save, 2, 3),
+	SHELL_CMD_ARG(list_networks, NULL,
+		      SHELL_HELP("List stored persistent P2P networks",
+				 "[-i, --iface=<interface index>]"),
+		      cmd_wifi_p2p_list_networks, 1, 2),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
The P2P persistent feature is not complete. 
1. Allow user to add P2P persistent group in wifi p2p group_add command.
2. Add persistent support in wifi p2p connect command.
3. Add new command wifi p2p list_networks to show stored persistent groups.