### PR TITLE
kernel: timer: round k_timer_remaining_get() up, and check the right invariant

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2088,7 +2088,7 @@ static inline k_ticks_t z_impl_k_timer_remaining_ticks(
  */
 static inline uint32_t k_timer_remaining_get(struct k_timer *timer)
 {
-	return k_ticks_to_ms_floor32(k_timer_remaining_ticks(timer));
+	return k_ticks_to_ms_ceil32(k_timer_remaining_ticks(timer));
 }
 
 #endif /* CONFIG_SYS_CLOCK_EXISTS */

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -717,8 +717,12 @@ ZTEST_USER(timer_api, test_timer_remaining)
 	 * the k_timer api is limited by the system tick abstraction. As result
 	 * the value obtained through k_timer_remaining_get() could be larger
 	 * than actual remaining time with maximum error equal to one tick.
+	 * That one tick of error has to be converted to ms by rounding up:
+	 * a tick shorter than a millisecond would otherwise round down to a
+	 * zero tolerance and the legitimate one-tick overshoot would trip the
+	 * check on high tick rate platforms.
 	 */
-	zassert_true(rem_ms <= (DURATION / 2) + k_ticks_to_ms_floor64(1),
+	zassert_true(rem_ms <= (DURATION / 2) + k_ticks_to_ms_ceil64(1),
 		     NULL);
 
 	/* Half the value of DURATION in ticks may not be the value of

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -683,7 +683,6 @@ ZTEST_USER(timer_api, test_timer_user_data)
 
 ZTEST_USER(timer_api, test_timer_remaining)
 {
-	uint32_t dur_ticks = k_ms_to_ticks_ceil32(DURATION);
 	uint32_t target_rem_ticks = k_ms_to_ticks_ceil32(DURATION / 2);
 	uint32_t rem_ms, rem_ticks, exp_ticks;
 	uint32_t latency_ticks;
@@ -725,11 +724,14 @@ ZTEST_USER(timer_api, test_timer_remaining)
 	zassert_true(rem_ms <= (DURATION / 2) + k_ticks_to_ms_ceil64(1),
 		     NULL);
 
-	/* Half the value of DURATION in ticks may not be the value of
-	 * half DURATION in ticks, when DURATION/2 is not an integer
-	 * multiple of ticks, so target_rem_ticks is used rather than
-	 * dur_ticks/2.  Also set a threshold based on expected clock
-	 * skew.
+	/* We stopped half way through the wait, so the remaining ticks
+	 * should match the half duration converted to ticks. That is
+	 * target_rem_ticks, k_ms_to_ticks_ceil32(DURATION / 2). Halving
+	 * the full duration in ticks would not do: it truncates when
+	 * DURATION / 2 is not a whole number of ticks (at a 2048 Hz tick
+	 * rate the full duration rounds to 205 ticks, half of which floors
+	 * to 102 while ceil(50 ms) is 103). Allow the larger of the
+	 * busy-wait clock skew and the read latency.
 	 */
 	delta_ticks = (int32_t)(rem_ticks - target_rem_ticks);
 	slew_ticks = BUSY_SLEW_THRESHOLD_TICKS(DURATION * USEC_PER_MSEC / 2U);
@@ -737,17 +739,19 @@ ZTEST_USER(timer_api, test_timer_remaining)
 		     "tick/busy slew %d larger than test threshold %u",
 		     delta_ticks, slew_ticks);
 
-	/* Note +1 tick precision: even though we're calculating in
-	 * ticks, we're waiting in k_busy_wait(), not for a timer
-	 * interrupt, so it's possible for that to take 1 tick longer
-	 * than expected on systems where the requested microsecond
-	 * delay cannot be exactly represented as an integer number of
-	 * ticks.
-	 * As above, use higher tolerance on platforms where the clock used
-	 * by the kernel timer and the one used for busy-waiting may be skewed.
+	/* k_timer_expires_ticks() returns the absolute expiry tick, so
+	 * "now" plus the remaining ticks must land on it. This checks the
+	 * three queries agree; it is not another half-way check, so neither
+	 * the duration nor the busy-wait slew enter into it.
+	 *
+	 * rem_ticks, now and exp_ticks are read in three separate syscalls.
+	 * exp_ticks is invariant over time, but "now" can only have advanced
+	 * past the rem_ticks sample, so (exp_ticks - now) is at most rem_ticks
+	 * and falls short of it by at most the read latency.
 	 */
-	zassert_true(((int64_t)exp_ticks - (int64_t)now)
-		     <= (dur_ticks / 2) + 1 + slew_ticks, NULL);
+	zassert_between_inclusive((int64_t)rem_ticks -
+				  ((int64_t)exp_ticks - (int64_t)now),
+				  0, latency_ticks, NULL);
 }
 
 ZTEST_USER(timer_api, test_timeout_abs)


### PR DESCRIPTION
The `kernel.timer` regression in #111885 is two separate issues exposed
by commit 1296dc85e332, which stopped cancelling `z_add_timeout()`'s one
tick round-up. Both reproduce on plain `qemu_x86` with only
`CONFIG_SYS_CLOCK_TICKS_PER_SEC=2048`, so this is not Intel specific: a
2048 Hz tick makes a 100 ms duration round to an odd 205 ticks, which
the old code happened to paper over.

First commit fixes `k_timer_remaining_get()`, which floored its tick to
millisecond conversion. `k_timer_remaining_ticks()` already returns an
upper bound on the time to fire, so flooring under-reports the remaining
time, disagreeing with the tick API and waking "wait it out" callers too
early. It now rounds up. See the commit log for the full rationale.

Second commit reworks the `test_timer_remaining` assertion that actually
fails. It compared `exp_ticks - now` against `dur_ticks / 2`, a third
mid point check that also truncated for odd `dur_ticks`. That query
should instead verify the three APIs agree: the absolute expiry tick
equals the current uptime plus the remaining ticks, an identity that is
exact bar the read latency between the separate syscalls.

Fixes #111885