### PR TITLE
drivers: sdhc: ambiq: convert Zephyr response type enum to HAL bitmask

### DIFF
--- a/drivers/sdhc/sdhc_ambiq.c
+++ b/drivers/sdhc/sdhc_ambiq.c
@@ -468,6 +468,51 @@ static int ambiq_sdio_card_busy(const struct device *dev)
 }
 
 /*
+ * Convert Zephyr SD response type enum to Ambiq HAL response bitmask.
+ */
+static bool ambiq_sdio_resp_type_to_hal(uint32_t type, uint32_t *resp_type)
+{
+	switch (type & SDHC_NATIVE_RESPONSE_MASK) {
+	case SD_RSP_TYPE_NONE:
+		*resp_type = MMC_RSP_NONE;
+		break;
+	case SD_RSP_TYPE_R1:
+		*resp_type = MMC_RSP_R1;
+		break;
+	case SD_RSP_TYPE_R1b:
+		*resp_type = MMC_RSP_R1b;
+		break;
+	case SD_RSP_TYPE_R2:
+		*resp_type = MMC_RSP_R2;
+		break;
+	case SD_RSP_TYPE_R3:
+		*resp_type = MMC_RSP_R3;
+		break;
+	case SD_RSP_TYPE_R4:
+		*resp_type = MMC_RSP_R4;
+		break;
+	case SD_RSP_TYPE_R5:
+		*resp_type = MMC_RSP_R5;
+		break;
+	case SD_RSP_TYPE_R5b:
+		/* SDIO R5b is a 48-bit response with CRC, opcode, and busy. */
+		*resp_type = MMC_RSP_R5 | MMC_RSP_BUSY;
+		break;
+	case SD_RSP_TYPE_R6:
+		*resp_type = MMC_RSP_R6;
+		break;
+	case SD_RSP_TYPE_R7:
+		*resp_type = MMC_RSP_R7;
+		break;
+	default:
+		LOG_ERR("Invalid response type: %d", (int)type);
+		return false;
+	}
+
+	return true;
+}
+
+/*
  * Ambiq SDIO Command and Data Request Function
  */
 static int ambiq_sdio_request(const struct device *dev, struct sdhc_command *cmd,
@@ -483,8 +528,11 @@ static int ambiq_sdio_request(const struct device *dev, struct sdhc_command *cmd
 	if (cmd) {
 		sdio_cmd.ui8Idx = cmd->opcode;
 		sdio_cmd.ui32Arg = cmd->arg;
-		sdio_cmd.ui32RespType = cmd->response_type;
 		sdio_cmd.bASync = false;
+
+		if (!ambiq_sdio_resp_type_to_hal(cmd->response_type, &sdio_cmd.ui32RespType)) {
+			return -EINVAL;
+		}
 	} else {
 		LOG_ERR("Invalid CMD");
 		return -EINVAL;
@@ -514,22 +562,9 @@ static int ambiq_sdio_request(const struct device *dev, struct sdhc_command *cmd
 	LOG_DBG("Send SDIO CMD%d", sdio_cmd.ui8Idx);
 	LOG_DBG("CMD->Arg = 0x%x CMD->RespType = 0x%x", sdio_cmd.ui32Arg, sdio_cmd.ui32RespType);
 
-	if (sdio_cmd.ui8Idx == 1 || sdio_cmd.ui8Idx == 41) {
-		LOG_DBG("Config CMD1 RespType");
-		sdio_cmd.ui32RespType = MMC_RSP_R3;
-	} else if (sdio_cmd.ui8Idx == 3) {
-		LOG_DBG("Config CMD3 RespType");
-		sdio_cmd.ui32RespType = MMC_RSP_R6;
-	} else if ((sdio_cmd.ui8Idx == 52) || (sdio_cmd.ui8Idx == 53)) {
-		LOG_DBG("Config CMD%d RespType", sdio_cmd.ui8Idx);
-		sdio_cmd.ui32RespType = MMC_RSP_R5;
-	} else if (sdio_cmd.ui8Idx == 6 || sdio_cmd.ui8Idx == 38) {
+	if (sdio_cmd.ui8Idx == 6 || sdio_cmd.ui8Idx == 38) {
 		LOG_DBG("Set CheckBusyCmd");
 		sdio_cmd.bCheckBusyCmd = true;
-		sdio_cmd.ui32RespType = MMC_RSP_R1b;
-	} else if (sdio_cmd.ui8Idx == 17 || sdio_cmd.ui8Idx == 18 || sdio_cmd.ui8Idx == 24 ||
-		   sdio_cmd.ui8Idx == 25 || sdio_cmd.ui8Idx == 55) {
-		sdio_cmd.ui32RespType = MMC_RSP_R1;
 	}
 
 #ifdef CONFIG_AMBIQ_SDIO_ASYNC
@@ -584,8 +619,8 @@ static int ambiq_sdio_request(const struct device *dev, struct sdhc_command *cmd
 #endif /* CONFIG_SDHC_AMBIQ_HANDLE_CACHE */
 
 	} else {
-		ui32Status = dev_data->host->ops->execute_cmd(dev_data->host->pHandle,
-							      &sdio_cmd, NULL);
+		ui32Status =
+			dev_data->host->ops->execute_cmd(dev_data->host->pHandle, &sdio_cmd, NULL);
 	}
 	if ((ui32Status & 0xFFFF) != AM_HAL_STATUS_SUCCESS) {
 		if ((ui32Status & 0xFFFF) == AM_HAL_STATUS_TIMEOUT) {


### PR DESCRIPTION
ambiq_sdio_request() assigned cmd->response_type (a Zephyr enum sd_rsp_type value) directly to sdio_cmd.ui32RespType, which the Ambiq HAL expects to be a bitmask of MMC_RSP_* flags.  This caused a semantic mismatch when the field was later tested with MMC_RSP_136 and passed to execute_cmd().

Add ambiq_sdio_resp_type_to_hal() to map enum sd_rsp_type values to the corresponding Ambiq HAL response bitmask.  This ensures ui32RespType is always a HAL bitmask, fixing both the R2 response check and the underlying command configuration.

Fixes zephyrproject-rtos#112220