### PR TITLE
shell: add unused argument macro to shell_help function

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -1475,6 +1475,7 @@ void shell_help(const struct shell *sh);
 #else
 static inline void shell_help(const struct shell *sh)
 {
+	ARG_UNUSED(sh);
 }
 #endif /* CONFIG_SHELL_HELP */
 


### PR DESCRIPTION
to supress unused-parameter warning