### PR TITLE
STM32 SPI: half duplex peripheral support

### DIFF
--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -749,6 +749,38 @@ static int spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 #else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	uint32_t dir = ll_get_transfer_direction(spi);
 
+#ifdef CONFIG_SPI_STM32_INTERRUPT
+	if (dir == STM32_SPI_FULL_DUPLEX) {
+		/* RXNE-driven: TXE interrupt is not enabled for this path.
+		 * Read the received frame, then queue the next TX frame to keep
+		 * the one-frame pipeline full.
+		 * After the last TX frame, re-enable TXE so the trailing TXE ISR
+		 * provides a guaranteed exit point once BSY has cleared.
+		 */
+		if (ll_rx_is_not_empty(spi) && data->rx_len != 0U) {
+			data->rx_len -= spi_stm32_read_next_frame(spi, data, 0U);
+			if (data->tx_len != 0U) {
+				data->tx_len -= spi_stm32_send_next_frame(spi, data, 0U);
+			} else {
+				/* All TX done; request one trailing TXE interrupt
+				 * to exit cleanly once BSY is cleared.
+				 */
+				ll_enable_int_tx_empty(spi);
+			}
+		}
+	} else {
+		/* Half-duplex: independent TXE/RXNE flag-based handling. */
+		if (dir != STM32_SPI_HALF_DUPLEX_RX && ll_tx_is_not_full(spi) &&
+		    data->tx_len != 0U) {
+			data->tx_len -= spi_stm32_send_next_frame(spi, data, 0U);
+		}
+
+		if (dir != STM32_SPI_HALF_DUPLEX_TX && ll_rx_is_not_empty(spi) &&
+		    data->rx_len != 0U) {
+			data->rx_len -= spi_stm32_read_next_frame(spi, data, 0U);
+		}
+	}
+#else /* CONFIG_SPI_STM32_INTERRUPT */
 	if (dir != STM32_SPI_HALF_DUPLEX_RX && data->tx_len != 0U) {
 		while (!ll_tx_is_not_full(spi)) {
 			/* NOP */
@@ -762,6 +794,7 @@ static int spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 		}
 		data->rx_len -= spi_stm32_read_next_frame(spi, data, 0U);
 	}
+#endif /* CONFIG_SPI_STM32_INTERRUPT */
 
 	return 0;
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
@@ -878,13 +911,30 @@ static void spi_stm32_msg_start(const struct device *dev, bool is_rx_empty)
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	ll_enable_int_errors(spi);
 
-	if (transfer_dir != STM32_SPI_HALF_DUPLEX_TX) {
-		ll_enable_int_rx_not_empty(spi);
-	}
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+	if (transfer_dir == STM32_SPI_FULL_DUPLEX &&
+	    LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
+		struct spi_stm32_data *data = dev->data;
 
-	if (transfer_dir != STM32_SPI_HALF_DUPLEX_RX) {
-		ll_enable_int_tx_empty(spi);
+		/* Non-H7 full-duplex master: seed the TX pipeline with the first
+		 * frame and enable RXNE only. Each RXNE ISR reads one received
+		 * frame then sends the next, keeping exactly one frame in flight.
+		 * This eliminates RX overrun without busy-waiting in ISR context.
+		 */
+		data->tx_len -= spi_stm32_send_next_frame(spi, data, 0U);
+		ll_enable_int_rx_not_empty(spi);
+	} else {
+#endif /* !DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+		if (transfer_dir != STM32_SPI_HALF_DUPLEX_TX) {
+			ll_enable_int_rx_not_empty(spi);
+		}
+
+		if (transfer_dir != STM32_SPI_HALF_DUPLEX_RX) {
+			ll_enable_int_tx_empty(spi);
+		}
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	}
+#endif /* !DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	irq_enable(cfg->irq_line);

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1190,7 +1190,6 @@ static void spi_stm32_complete(const struct device *dev, int status)
 
 #endif /* CONFIG_SPI_STM32_INTERRUPT */
 
-
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo)
 	/* Flush RX buffer */
 	while (ll_rx_is_not_empty(spi)) {
@@ -1306,6 +1305,19 @@ static void spi_stm32_isr(const struct device *dev)
 			return;
 		}
 	}
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo) && !DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+	if (LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER &&
+	    STM32_SPI_HALF_DUPLEX_RX == ll_get_transfer_direction(spi) &&
+	    !spi_context_rx_on(&data->ctx)) {
+		/* In half-duplex RX master mode, disable the SPI as soon as the last byte is
+		 * received to stop the transfer and prevent further reception of dummy bytes.
+		 */
+		ll_disable_spi(spi);
+		spi_stm32_complete(dev, err);
+		return;
+	}
+#endif /* st_stm32_spi_fifo && !st_stm32h7_spi */
 
 	uint32_t transfer_dir = ll_get_transfer_direction(spi);
 

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -711,20 +711,25 @@ static int spi_stm32_shift_fifo(SPI_TypeDef *spi, struct spi_stm32_data *data)
 		 */
 		spi_stm32_read_fifo(spi, data);
 	} else if (transfer_dir != STM32_SPI_HALF_DUPLEX_RX && ll_tx_is_not_full(spi) &&
-		   data->tx_len != 0U && data->tx_len == data->rx_len) {
-		/* First complete data packet can be sent (Tx len == Rx len). After that, use DXP.
+		   data->tx_len != 0U &&
+		   (data->tx_len == data->rx_len || transfer_dir == STM32_SPI_HALF_DUPLEX_TX)) {
+		/* In full-duplex, first complete data packet can be sent (Tx len == Rx len),
+		 * after that, use DXP.
+		 * In half-duplex, send data if FIFO space is available.
 		 * Fill the TxFIFO until threshold is reached or all data for the transfer are sent.
 		 */
 		spi_stm32_send_fifo(spi, data);
 #ifdef CONFIG_SPI_STM32_INTERRUPT
-		/* After first transmit, disable TXP. The goal is to use DXP from then on.
-		 * This keeps Tx and Rx synchronized and avoids overruns.
-		 */
-		LL_SPI_DisableIT_TXP(spi);
+		if (transfer_dir == STM32_SPI_FULL_DUPLEX) {
+			/* After first transmit, disable TXP. The goal is to use DXP from then on.
+			 * This keeps Tx and Rx synchronized and avoids overruns.
+			 */
+			LL_SPI_DisableIT_TXP(spi);
+		}
 #endif /* CONFIG_SPI_STM32_INTERRUPT */
 	}
 
-	if (LL_SPI_IsActiveFlag_EOT(spi)) {
+	if (transfer_dir != STM32_SPI_HALF_DUPLEX_TX && LL_SPI_IsActiveFlag_EOT(spi)) {
 		while (data->rx_len != 0U) {
 			/* Some data may remain in the RxFIFO at the end of transfer if transfer
 			 * size is not a multiple of FIFO threshold. Read them here.
@@ -742,21 +747,19 @@ static int spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	return spi_stm32_shift_fifo(spi, data);
 #else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-	uint32_t transfer_dir = ll_get_transfer_direction(spi);
+	uint32_t dir = ll_get_transfer_direction(spi);
 
-	if (transfer_dir != STM32_SPI_HALF_DUPLEX_RX) {
+	if (dir != STM32_SPI_HALF_DUPLEX_RX && data->tx_len != 0U) {
 		while (!ll_tx_is_not_full(spi)) {
 			/* NOP */
 		}
-
 		data->tx_len -= spi_stm32_send_next_frame(spi, data, 0U);
 	}
 
-	if (transfer_dir != STM32_SPI_HALF_DUPLEX_TX) {
+	if (dir != STM32_SPI_HALF_DUPLEX_TX && data->rx_len != 0U) {
 		while (!ll_rx_is_not_empty(spi)) {
 			/* NOP */
 		}
-
 		data->rx_len -= spi_stm32_read_next_frame(spi, data, 0U);
 	}
 
@@ -770,13 +773,15 @@ static void spi_stm32_shift_s(SPI_TypeDef *spi, struct spi_stm32_data *data)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) && !defined(CONFIG_SPI_RTIO)
 	spi_stm32_shift_fifo(spi, data);
 #else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-	if (ll_tx_is_not_full(spi) && data->tx_len != 0U) {
+	uint32_t dir = ll_get_transfer_direction(spi);
+
+	if (dir != STM32_SPI_HALF_DUPLEX_RX && ll_tx_is_not_full(spi) && data->tx_len != 0U) {
 		data->tx_len -= spi_stm32_send_next_frame(spi, data, 0U);
 	} else {
 		ll_disable_int_tx_empty(spi);
 	}
 
-	if (ll_rx_is_not_empty(spi) && data->rx_len != 0U) {
+	if (dir != STM32_SPI_HALF_DUPLEX_TX && ll_rx_is_not_empty(spi) && data->rx_len != 0U) {
 		data->rx_len -= spi_stm32_read_next_frame(spi, data, 0U);
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
@@ -826,6 +831,7 @@ static void spi_stm32_msg_start(const struct device *dev, bool is_rx_empty)
 {
 	const struct spi_stm32_config *cfg = dev->config;
 	SPI_TypeDef *spi = cfg->spi;
+	__maybe_unused uint32_t transfer_dir = LL_SPI_GetTransferDirection(spi);
 
 	ARG_UNUSED(is_rx_empty);
 
@@ -865,12 +871,20 @@ static void spi_stm32_msg_start(const struct device *dev, bool is_rx_empty)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	if (!IS_ENABLED(CONFIG_SPI_RTIO) || LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
 		LL_SPI_EnableIT_EOT(spi);
-		LL_SPI_EnableIT_DXP(spi);
+		if (transfer_dir == STM32_SPI_FULL_DUPLEX) {
+			LL_SPI_EnableIT_DXP(spi);
+		}
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	ll_enable_int_errors(spi);
-	ll_enable_int_rx_not_empty(spi);
-	ll_enable_int_tx_empty(spi);
+
+	if (transfer_dir != STM32_SPI_HALF_DUPLEX_TX) {
+		ll_enable_int_rx_not_empty(spi);
+	}
+
+	if (transfer_dir != STM32_SPI_HALF_DUPLEX_RX) {
+		ll_enable_int_tx_empty(spi);
+	}
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	irq_enable(cfg->irq_line);
@@ -883,7 +897,7 @@ static void spi_stm32_msg_start(const struct device *dev, bool is_rx_empty)
 static void spi_stm32_iodev_complete(const struct device *dev, int status);
 static int spi_stm32_configure(const struct device *dev,
 			       const struct spi_config *config,
-			       bool write);
+			       bool write, bool read);
 static int32_t spi_stm32_set_transfer_size(const struct device *dev,
 					   const struct spi_config *config,
 					   const struct spi_buf_set *tx_bufs,
@@ -1029,12 +1043,14 @@ static inline int spi_stm32_iodev_prepare_start(const struct device *dev)
 	bool write = (op_code == RTIO_OP_TX) ||
 		     (op_code == RTIO_OP_TINY_TX) ||
 		     (op_code == RTIO_OP_TXRX);
+	bool read = (op_code == RTIO_OP_RX) ||
+		    (op_code == RTIO_OP_TXRX);
 
 #ifdef CONFIG_SPI_SLAVE
 	data->ctx.recv_frames = 0;
 #endif /* CONFIG_SPI_SLAVE */
 
-	return spi_stm32_configure(dev, spi_config, write);
+	return spi_stm32_configure(dev, spi_config, write, read);
 }
 
 static void spi_stm32_iodev_complete(const struct device *dev, int status)
@@ -1077,6 +1093,62 @@ static void spi_stm32_iodev_submit(const struct device *dev, struct rtio_iodev_s
 }
 #endif /* CONFIG_SPI_RTIO */
 
+static int spi_stm32_half_duplex_switch_direction(const struct device *dev)
+{
+	const struct spi_stm32_config *cfg = dev->config;
+	SPI_TypeDef *spi = cfg->spi;
+	struct spi_stm32_data *data = dev->data;
+
+	if (LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER &&
+	    !spi_context_tx_on(&data->ctx) && spi_context_rx_on(&data->ctx)) {
+		LL_SPI_Disable(spi);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+		LL_SPI_SetTransferSize(spi, data->rx_len);
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+
+		ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_RX);
+		LL_SPI_Enable(spi);
+		spi_stm32_cs_control(dev, true);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+		LL_SPI_StartMasterTransfer(spi);
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+
+#ifdef CONFIG_SPI_STM32_INTERRUPT
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+		LL_SPI_EnableIT_EOT(spi);
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+		ll_enable_int_errors(spi);
+		ll_enable_int_rx_not_empty(spi);
+#endif /* CONFIG_SPI_STM32_INTERRUPT */
+	} else if (LL_SPI_GetMode(spi) == LL_SPI_MODE_SLAVE &&
+		   spi_context_tx_on(&data->ctx) && !spi_context_rx_on(&data->ctx)) {
+		LL_SPI_Disable(spi);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+		if (!IS_ENABLED(CONFIG_SPI_RTIO)) {
+			LL_SPI_SetTransferSize(spi, data->tx_len);
+		}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+
+		ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_TX);
+		LL_SPI_Enable(spi);
+
+#ifdef CONFIG_SPI_STM32_INTERRUPT
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+		if (!IS_ENABLED(CONFIG_SPI_RTIO)) {
+			LL_SPI_EnableIT_EOT(spi);
+		}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+		ll_enable_int_errors(spi);
+		ll_enable_int_tx_empty(spi);
+#endif /* CONFIG_SPI_STM32_INTERRUPT */
+	}
+
+	return 0;
+}
+
 static void spi_stm32_complete(const struct device *dev, int status)
 {
 	const struct spi_stm32_config *cfg = dev->config;
@@ -1091,11 +1163,15 @@ static void spi_stm32_complete(const struct device *dev, int status)
 	 */
 	irq_disable(cfg->irq_line);
 #endif /* CONFIG_SPI_STM32_INTERRUPT && CONFIG_SOC_SERIES_STM32H7X */
-	if (data->rtio_ctx->txn_head != NULL) {
+
+	if (data->rtio_ctx->txn_head != NULL &&
+	    ((ll_get_transfer_direction(spi) == STM32_SPI_FULL_DUPLEX) ||
+	     !spi_stm32_transfer_ongoing(data))) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 		LL_SPI_ClearFlag_TXTF(spi);
 		LL_SPI_ClearFlag_OVR(spi);
 		LL_SPI_ClearFlag_EOT(spi);
+		LL_SPI_DisableIT_EOT(spi);
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 		spi_stm32_iodev_complete(dev, status);
 		return;
@@ -1179,7 +1255,12 @@ static void spi_stm32_complete(const struct device *dev, int status)
 #endif /* CONFIG_SPI_STM32_INTERRUPT && CONFIG_SOC_SERIES_STM32H7X */
 	}
 
-	spi_context_complete(&data->ctx, dev, status);
+	if (ll_get_transfer_direction(spi) != STM32_SPI_FULL_DUPLEX &&
+	    spi_stm32_transfer_ongoing(data)) {
+		spi_stm32_half_duplex_switch_direction(dev);
+	} else {
+		spi_context_complete(&data->ctx, dev, status);
+	}
 }
 
 #ifdef CONFIG_SPI_STM32_INTERRUPT
@@ -1205,6 +1286,13 @@ static void spi_stm32_isr(const struct device *dev)
 		return;
 	}
 
+	if (!spi_stm32_transfer_ongoing(data)) {
+		if (ll_rx_is_not_empty(spi)) {
+			(void) LL_SPI_ReceiveData8(spi);
+		}
+		LL_SPI_ClearFlag_OVR(spi);
+	}
+
 	err = spi_stm32_get_err(spi);
 	if (err) {
 		spi_stm32_complete(dev, err);
@@ -1221,18 +1309,50 @@ static void spi_stm32_isr(const struct device *dev)
 
 	uint32_t transfer_dir = ll_get_transfer_direction(spi);
 
-	if (((transfer_dir == STM32_SPI_FULL_DUPLEX) && !spi_stm32_transfer_ongoing(data) &&
-	     !ll_spi_is_busy(spi)) ||
-	    ((transfer_dir == STM32_SPI_HALF_DUPLEX_TX) && !spi_context_tx_on(&data->ctx)) ||
-	    ((transfer_dir == STM32_SPI_HALF_DUPLEX_RX) && !spi_context_rx_on(&data->ctx))) {
+	if (!ll_spi_is_busy(spi) &&
+	    (((transfer_dir == STM32_SPI_FULL_DUPLEX) && !spi_stm32_transfer_ongoing(data)) ||
+	     ((transfer_dir == STM32_SPI_HALF_DUPLEX_TX) && !spi_context_tx_on(&data->ctx)) ||
+	     ((transfer_dir == STM32_SPI_HALF_DUPLEX_RX) && !spi_context_rx_on(&data->ctx)))) {
 		spi_stm32_complete(dev, err);
 	}
 }
 #endif /* CONFIG_SPI_STM32_INTERRUPT */
 
+static void spi_stm32_set_transfer_direction(const struct device *dev,
+					     const struct spi_config *config,
+					     bool write, bool read)
+{
+	const struct spi_stm32_config *cfg = dev->config;
+	SPI_TypeDef *spi = cfg->spi;
+
+	if (config->operation & SPI_HALF_DUPLEX) {
+		/* For half-duplex transfers, if both TX and RX are active:
+		 * For the master, Tx is done first, then Rx.
+		 * For the slave, Rx is done first, then Tx.
+		 * We need to know which direction to start with in each case, hence why we need
+		 * the write and read flags.
+		 */
+		if (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
+			if (write) {
+				ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_TX);
+			} else {
+				ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_RX);
+			}
+		} else {
+			if (read) {
+				ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_RX);
+			} else {
+				ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_TX);
+			}
+		}
+	} else {
+		ll_set_transfer_direction(spi, STM32_SPI_FULL_DUPLEX);
+	}
+}
+
 static int spi_stm32_configure(const struct device *dev,
 			       const struct spi_config *config,
-			       bool write)
+			       bool write, bool read)
 {
 	const struct spi_stm32_config *cfg = dev->config;
 	struct spi_stm32_data *data = dev->data;
@@ -1256,13 +1376,7 @@ static int spi_stm32_configure(const struct device *dev,
 
 #ifndef CONFIG_SPI_RTIO
 	if (spi_context_configured(&data->ctx, config)) {
-		if (config->operation & SPI_HALF_DUPLEX) {
-			if (write) {
-				ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_TX);
-			} else {
-				ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_RX);
-			}
-		}
+		spi_stm32_set_transfer_direction(dev, config, write, read);
 		return 0;
 	}
 #endif /* CONFIG_SPI_RTIO */
@@ -1343,21 +1457,13 @@ static int spi_stm32_configure(const struct device *dev,
 		LL_SPI_SetClockPhase(spi, STM32_SPI_CLOCK_PHASE_1_EDGE);
 	}
 
-	if ((config->operation & SPI_HALF_DUPLEX) != 0U) {
-		if (write) {
-			ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_TX);
-		} else {
-			ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_RX);
-		}
-	} else {
-		ll_set_transfer_direction(spi, STM32_SPI_FULL_DUPLEX);
-	}
-
 	if ((config->operation & SPI_TRANSFER_LSB) != 0) {
 		LL_SPI_SetTransferBitOrder(spi, LL_SPI_LSB_FIRST);
 	} else {
 		LL_SPI_SetTransferBitOrder(spi, LL_SPI_MSB_FIRST);
 	}
+
+	spi_stm32_set_transfer_direction(dev, config, write, read);
 
 	LL_SPI_DisableCRC(spi);
 
@@ -1448,6 +1554,7 @@ static int spi_stm32_release(const struct device *dev, const struct spi_config *
 	return 0;
 }
 
+#ifndef CONFIG_SPI_RTIO
 static int32_t spi_stm32_count_bufset_frames(const struct spi_config *config,
 					     const struct spi_buf_set *bufs)
 {
@@ -1469,12 +1576,9 @@ static int32_t spi_stm32_count_bufset_frames(const struct spi_config *config,
 
 	int frames = num_bytes / dfs;
 
-	if (frames > UINT16_MAX) {
-		return -EMSGSIZE;
-	}
-
 	return frames;
 }
+#endif /* CONFIG_SPI_RTIO */
 
 static int32_t spi_stm32_set_transfer_size(const struct device *dev,
 					   const struct spi_config *config,
@@ -1485,28 +1589,41 @@ static int32_t spi_stm32_set_transfer_size(const struct device *dev,
 	const struct spi_stm32_config *cfg = dev->config;
 	SPI_TypeDef *spi = cfg->spi;
 	uint32_t transfer_dir = ll_get_transfer_direction(spi);
-	int32_t frames;
+	int32_t tx_frames, rx_frames;
+
+#ifdef CONFIG_SPI_RTIO
+	if (transfer_dir == STM32_SPI_FULL_DUPLEX) {
+		tx_frames = spi_context_longest_current_buf(&data->ctx);
+		rx_frames = tx_frames;
+	} else {
+		tx_frames = data->ctx.tx_len;
+		rx_frames = data->ctx.rx_len;
+	}
+#else /* CONFIG_SPI_RTIO */
+	tx_frames = spi_stm32_count_bufset_frames(config, tx_bufs);
+	rx_frames = spi_stm32_count_bufset_frames(config, rx_bufs);
+
+	if (tx_frames < 0) {
+		return tx_frames;
+	}
+
+	if (rx_frames < 0) {
+		return rx_frames;
+	}
 
 	if (transfer_dir == STM32_SPI_FULL_DUPLEX) {
-#ifdef CONFIG_SPI_RTIO
-		frames = spi_context_longest_current_buf(&data->ctx);
-#else /* CONFIG_SPI_RTIO*/
-		frames = MAX(spi_stm32_count_bufset_frames(config, tx_bufs),
-			     spi_stm32_count_bufset_frames(config, rx_bufs));
-#endif /* CONFIG_SPI_RTIO */
-	} else if (transfer_dir == STM32_SPI_HALF_DUPLEX_TX) {
-		frames = spi_stm32_count_bufset_frames(config, tx_bufs);
-	} else {
-		frames = spi_stm32_count_bufset_frames(config, rx_bufs);
-	}
+		uint32_t frames = MAX(tx_frames, rx_frames);
 
-	if (frames < 0) {
-		return frames;
+		tx_frames = frames;
+		rx_frames = frames;
 	}
+#endif /* CONFIG_SPI_RTIO */
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	if (!IS_ENABLED(CONFIG_SPI_RTIO) ||
 	    (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER)) {
+		uint32_t frames = transfer_dir != STM32_SPI_HALF_DUPLEX_RX ? tx_frames : rx_frames;
+
 		if (frames <= cfg->fifo_max_transfer_size) {
 			if (LL_SPI_IsEnabled(spi)) {
 				/* SPI needs to be disabled to set the transfer size */
@@ -1520,86 +1637,11 @@ static int32_t spi_stm32_set_transfer_size(const struct device *dev,
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
-	data->tx_len = data->rx_len = frames;
+	data->tx_len = tx_frames;
+	data->rx_len = rx_frames;
 
 	return 0;
 }
-
-#ifndef CONFIG_SPI_RTIO
-static int spi_stm32_half_duplex_switch_to_receive(const struct spi_stm32_config *cfg,
-						   struct spi_stm32_data *data)
-{
-	SPI_TypeDef *spi = cfg->spi;
-
-	if (!spi_context_tx_on(&data->ctx) && spi_context_rx_on(&data->ctx)) {
-#ifndef CONFIG_SPI_STM32_INTERRUPT
-		while (ll_spi_is_busy(spi)) {
-			/* NOP */
-		}
-		ll_disable_spi(spi);
-#endif /* CONFIG_SPI_STM32_INTERRUPT*/
-
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		const struct spi_config *config = data->ctx.config;
-
-		if (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
-			int num_bytes = spi_context_total_rx_len(&data->ctx);
-			uint8_t dfs = bits2bytes(config->operation);
-
-			if ((num_bytes % dfs) != 0) {
-				return -EINVAL;
-			}
-
-			LL_SPI_SetTransferSize(spi, (uint32_t) num_bytes / dfs);
-		}
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-
-		ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_RX);
-
-		LL_SPI_Enable(spi);
-
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		/* With the STM32MP1, STM32U5 and the STM32H7,
-		 * if the device is the SPI master,
-		 * we need to enable the start of the transfer with
-		 * LL_SPI_StartMasterTransfer(spi).
-		 */
-		if (LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
-			LL_SPI_StartMasterTransfer(spi);
-			while (!LL_SPI_IsActiveMasterTransfer(spi)) {
-				/*
-				 * Check for the race condition where the transfer completes
-				 * before this loop is entered. If EOT is set, the transfer
-				 * is done and we can break.
-				 */
-				if (LL_SPI_IsActiveFlag_EOT(spi)) {
-					break;
-				}
-			}
-		}
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-
-#if CONFIG_SOC_SERIES_STM32H7X
-		/*
-		 * Add a small delay after enabling to prevent transfer stalling at high
-		 * system clock frequency (see errata sheet ES0392).
-		 */
-		k_busy_wait(WAIT_1US);
-#endif
-
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		LL_SPI_EnableIT_EOT(spi);
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-
-		ll_enable_int_errors(spi);
-		ll_enable_int_rx_not_empty(spi);
-#endif /* CONFIG_SPI_STM32_INTERRUPT */
-	}
-
-	return 0;
-}
-#endif /* !CONFIG_SPI_RTIO */
 
 #if defined(CONFIG_SPI_STM32_DMA)
 #if !defined(CONFIG_SPI_RTIO)
@@ -1970,7 +2012,7 @@ static int transceive(const struct device *dev,
 	const struct spi_stm32_config *cfg = dev->config;
 	SPI_TypeDef *spi = cfg->spi;
 
-	ret = spi_stm32_configure(dev, config, tx_bufs != NULL);
+	ret = spi_stm32_configure(dev, config, tx_bufs != NULL, rx_bufs != NULL);
 	if (ret != 0) {
 		goto end;
 	}
@@ -1982,14 +2024,18 @@ static int transceive(const struct device *dev,
 		goto end;
 	}
 
+	/* Flush RX buffer */
+	while (ll_rx_is_not_empty(spi)) {
+		(void) LL_SPI_ReceiveData8(spi);
+	}
+	LL_SPI_ClearFlag_OVR(spi);
+
 #ifdef CONFIG_SPI_STM32_DMA
 	if (use_dma) {
 		ret = transceive_dma(dev, config);
 		goto end;
 	}
 #endif /* CONFIG_SPI_STM32_DMA */
-
-	uint32_t transfer_dir = ll_get_transfer_direction(spi);
 
 	ret = spi_stm32_set_transfer_size(dev, config, tx_bufs, rx_bufs);
 	if (ret != 0) {
@@ -2001,20 +2047,21 @@ static int transceive(const struct device *dev,
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 	do {
 		ret = spi_context_wait_for_completion(&data->ctx);
-
-		if (ret == 0 && transfer_dir == STM32_SPI_HALF_DUPLEX_TX) {
-			ret = spi_stm32_half_duplex_switch_to_receive(cfg, data);
-			transfer_dir = ll_get_transfer_direction(spi);
-		}
-	} while (ret == 0 && spi_stm32_transfer_ongoing(data) &&
-		 transfer_dir != STM32_SPI_FULL_DUPLEX);
+	} while (ret == 0 && spi_stm32_transfer_ongoing(data) && !asynchronous);
 #else /* CONFIG_SPI_STM32_INTERRUPT */
+	uint32_t dir = ll_get_transfer_direction(spi);
+	uint32_t mode = LL_SPI_GetMode(spi);
+
 	while (ret == 0 && spi_stm32_transfer_ongoing(data)) {
 		ret = spi_stm32_shift_frames(spi, data);
 
-		if (ret == 0 && transfer_dir == STM32_SPI_HALF_DUPLEX_TX) {
-			ret = spi_stm32_half_duplex_switch_to_receive(cfg, data);
-			transfer_dir = ll_get_transfer_direction(spi);
+		if (ret == 0 &&
+		    ((dir == STM32_SPI_HALF_DUPLEX_TX && mode == LL_SPI_MODE_MASTER
+		      && data->tx_len == 0) ||
+		     (dir == STM32_SPI_HALF_DUPLEX_RX && mode == LL_SPI_MODE_SLAVE
+		      && data->rx_len == 0))) {
+			ret = spi_stm32_half_duplex_switch_direction(dev);
+			dir = ll_get_transfer_direction(spi);
 		}
 	}
 

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -767,7 +767,7 @@ static int spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 /* Shift a SPI frame as slave. */
 static void spi_stm32_shift_s(SPI_TypeDef *spi, struct spi_stm32_data *data)
 {
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) && !defined(CONFIG_SPI_RTIO)
 	spi_stm32_shift_fifo(spi, data);
 #else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	if (ll_tx_is_not_full(spi) && data->tx_len != 0U) {
@@ -863,8 +863,10 @@ static void spi_stm32_msg_start(const struct device *dev, bool is_rx_empty)
 
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	LL_SPI_EnableIT_EOT(spi);
-	LL_SPI_EnableIT_DXP(spi);
+	if (!IS_ENABLED(CONFIG_SPI_RTIO) || LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
+		LL_SPI_EnableIT_EOT(spi);
+		LL_SPI_EnableIT_DXP(spi);
+	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	ll_enable_int_errors(spi);
 	ll_enable_int_rx_not_empty(spi);
@@ -918,10 +920,6 @@ static void spi_stm32_iodev_msg_start(const struct device *dev, struct spi_confi
 	data->ctx.sync_status = 0;
 	data->ctx.owner = config;
 
-#ifdef CONFIG_SPI_SLAVE
-	ctx->recv_frames = 0;
-#endif /* CONFIG_SPI_SLAVE */
-
 	if (!spi_stm32_transfer_ongoing(data)) {
 		spi_stm32_iodev_complete(dev, 0);
 		return;
@@ -930,13 +928,8 @@ static void spi_stm32_iodev_msg_start(const struct device *dev, struct spi_confi
 	__maybe_unused const struct spi_stm32_config *cfg = dev->config;
 	__maybe_unused SPI_TypeDef *spi = cfg->spi;
 
-	if (LL_SPI_IsEnabled(spi)) {
-		/* SPI needs to be disabled to set the transfer size */
-		ll_disable_spi(spi);
-	}
-
 	if (!use_dma) {
-		if (spi_stm32_set_transfer_size(dev, NULL, NULL, NULL) != 0) {
+		if (spi_stm32_set_transfer_size(dev, config, NULL, NULL) != 0) {
 			spi_stm32_iodev_complete(dev, -EINVAL);
 		}
 	}
@@ -1037,6 +1030,10 @@ static inline int spi_stm32_iodev_prepare_start(const struct device *dev)
 		     (op_code == RTIO_OP_TINY_TX) ||
 		     (op_code == RTIO_OP_TXRX);
 
+#ifdef CONFIG_SPI_SLAVE
+	data->ctx.recv_frames = 0;
+#endif /* CONFIG_SPI_SLAVE */
+
 	return spi_stm32_configure(dev, spi_config, write);
 }
 
@@ -1098,6 +1095,7 @@ static void spi_stm32_complete(const struct device *dev, int status)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 		LL_SPI_ClearFlag_TXTF(spi);
 		LL_SPI_ClearFlag_OVR(spi);
+		LL_SPI_ClearFlag_EOT(spi);
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 		spi_stm32_iodev_complete(dev, status);
 		return;
@@ -1507,17 +1505,18 @@ static int32_t spi_stm32_set_transfer_size(const struct device *dev,
 	}
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	if (frames <= cfg->fifo_max_transfer_size) {
-		if (LL_SPI_IsEnabled(spi)) {
-			/* CFG1 (TSIZE) is write-protected while SPE=1 on H7; disable
-			 * first to ensure the new transfer size takes effect.
-			 */
-			ll_disable_spi(spi);
+	if (!IS_ENABLED(CONFIG_SPI_RTIO) ||
+	    (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER)) {
+		if (frames <= cfg->fifo_max_transfer_size) {
+			if (LL_SPI_IsEnabled(spi)) {
+				/* SPI needs to be disabled to set the transfer size */
+				ll_disable_spi(spi);
+			}
+			LL_SPI_SetTransferSize(spi, (uint32_t)frames);
+		} else {
+			LOG_ERR("Buffer size exceeds maximal supported value");
+			return -EINVAL;
 		}
-		LL_SPI_SetTransferSize(spi, (uint32_t)frames);
-	} else {
-		LOG_ERR("Buffer size exceeds maximal supported value");
-		return -EINVAL;
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
@@ -2021,12 +2020,6 @@ static int transceive(const struct device *dev,
 
 	spi_stm32_complete(dev, ret);
 
-#ifdef CONFIG_SPI_SLAVE
-	if (spi_context_is_slave(&data->ctx) && ret == 0) {
-		ret = data->ctx.recv_frames;
-	}
-#endif /* CONFIG_SPI_SLAVE */
-
 #endif /* CONFIG_SPI_STM32_INTERRUPT */
 
 end:
@@ -2034,6 +2027,12 @@ end:
 	if (ret != 0 || !asynchronous || IS_ENABLED(CONFIG_SPI_RTIO)) {
 		spi_stm32_pm_policy_state_lock_put(dev);
 	}
+
+#ifdef CONFIG_SPI_SLAVE
+	if (spi_context_is_slave(&data->ctx) && ret == 0) {
+		ret = data->ctx.recv_frames;
+	}
+#endif /* CONFIG_SPI_SLAVE */
 
 	spi_context_release(&data->ctx, ret);
 

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -767,7 +767,7 @@ static int spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 /* Shift a SPI frame as peripheral. */
 static void spi_stm32_shift_s(SPI_TypeDef *spi, struct spi_stm32_data *data)
 {
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) && !defined(CONFIG_SPI_RTIO)
 	spi_stm32_shift_fifo(spi, data);
 #else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	if (ll_tx_is_not_full(spi) && data->tx_len != 0U) {
@@ -863,8 +863,10 @@ static void spi_stm32_msg_start(const struct device *dev, bool is_rx_empty)
 
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	LL_SPI_EnableIT_EOT(spi);
-	LL_SPI_EnableIT_DXP(spi);
+	if (!IS_ENABLED(CONFIG_SPI_RTIO) || LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
+		LL_SPI_EnableIT_EOT(spi);
+		LL_SPI_EnableIT_DXP(spi);
+	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	ll_enable_int_errors(spi);
 	ll_enable_int_rx_not_empty(spi);
@@ -918,10 +920,6 @@ static void spi_stm32_iodev_msg_start(const struct device *dev, struct spi_confi
 	data->ctx.sync_status = 0;
 	data->ctx.owner = config;
 
-#ifdef CONFIG_SPI_PERIPHERAL
-	ctx->recv_frames = 0;
-#endif /* CONFIG_SPI_PERIPHERAL */
-
 	if (!spi_stm32_transfer_ongoing(data)) {
 		spi_stm32_iodev_complete(dev, 0);
 		return;
@@ -930,13 +928,8 @@ static void spi_stm32_iodev_msg_start(const struct device *dev, struct spi_confi
 	__maybe_unused const struct spi_stm32_config *cfg = dev->config;
 	__maybe_unused SPI_TypeDef *spi = cfg->spi;
 
-	if (LL_SPI_IsEnabled(spi)) {
-		/* SPI needs to be disabled to set the transfer size */
-		ll_disable_spi(spi);
-	}
-
 	if (!use_dma) {
-		if (spi_stm32_set_transfer_size(dev, NULL, NULL, NULL) != 0) {
+		if (spi_stm32_set_transfer_size(dev, config, NULL, NULL) != 0) {
 			spi_stm32_iodev_complete(dev, -EINVAL);
 		}
 	}
@@ -1037,6 +1030,10 @@ static inline int spi_stm32_iodev_prepare_start(const struct device *dev)
 		     (op_code == RTIO_OP_TINY_TX) ||
 		     (op_code == RTIO_OP_TXRX);
 
+#ifdef CONFIG_SPI_PERIPHERAL
+	data->ctx.recv_frames = 0;
+#endif /* CONFIG_SPI_PERIPHERAL */
+
 	return spi_stm32_configure(dev, spi_config, write);
 }
 
@@ -1098,6 +1095,7 @@ static void spi_stm32_complete(const struct device *dev, int status)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 		LL_SPI_ClearFlag_TXTF(spi);
 		LL_SPI_ClearFlag_OVR(spi);
+		LL_SPI_ClearFlag_EOT(spi);
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 		spi_stm32_iodev_complete(dev, status);
 		return;
@@ -1507,17 +1505,18 @@ static int32_t spi_stm32_set_transfer_size(const struct device *dev,
 	}
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	if (frames <= cfg->fifo_max_transfer_size) {
-		if (LL_SPI_IsEnabled(spi)) {
-			/* CFG1 (TSIZE) is write-protected while SPE=1 on H7; disable
-			 * first to ensure the new transfer size takes effect.
-			 */
-			ll_disable_spi(spi);
+	if (!IS_ENABLED(CONFIG_SPI_RTIO) ||
+	    (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_CONTROLLER)) {
+		if (frames <= cfg->fifo_max_transfer_size) {
+			if (LL_SPI_IsEnabled(spi)) {
+				/* SPI needs to be disabled to set the transfer size */
+				ll_disable_spi(spi);
+			}
+			LL_SPI_SetTransferSize(spi, (uint32_t)frames);
+		} else {
+			LOG_ERR("Buffer size exceeds maximal supported value");
+			return -EINVAL;
 		}
-		LL_SPI_SetTransferSize(spi, (uint32_t)frames);
-	} else {
-		LOG_ERR("Buffer size exceeds maximal supported value");
-		return -EINVAL;
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
@@ -2024,12 +2023,6 @@ static int transceive(const struct device *dev,
 
 	spi_stm32_complete(dev, ret);
 
-#ifdef CONFIG_SPI_PERIPHERAL
-	if (spi_context_is_peripheral(&data->ctx) && ret == 0) {
-		ret = data->ctx.recv_frames;
-	}
-#endif /* CONFIG_SPI_PERIPHERAL */
-
 #endif /* CONFIG_SPI_STM32_INTERRUPT */
 
 end:
@@ -2037,6 +2030,12 @@ end:
 	if (ret != 0 || !asynchronous || IS_ENABLED(CONFIG_SPI_RTIO)) {
 		spi_stm32_pm_policy_state_lock_put(dev);
 	}
+
+#ifdef CONFIG_SPI_PERIPHERAL
+	if (spi_context_is_peripheral(&data->ctx) && ret == 0) {
+		ret = data->ctx.recv_frames;
+	}
+#endif /* CONFIG_SPI_PERIPHERAL */
 
 	spi_context_release(&data->ctx, ret);
 

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -749,6 +749,40 @@ static int spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 #else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	uint32_t dir = ll_get_transfer_direction(spi);
 
+#ifdef CONFIG_SPI_STM32_INTERRUPT
+	if (dir == STM32_SPI_FULL_DUPLEX) {
+		/* RXNE-driven: TXE interrupt is not enabled for this path.
+		 * Read the received frame, then queue the next TX frame to keep
+		 * the one-frame pipeline full.
+		 * After the last TX frame, re-enable TXE so the trailing TXE ISR
+		 * provides a guaranteed exit point once BSY has cleared.
+		 */
+		if (ll_rx_is_not_empty(spi) && data->rx_len != 0U) {
+			data->rx_len -= spi_stm32_read_next_frame(spi, data, 0U);
+			if (data->tx_len != 0U) {
+				data->tx_len -= spi_stm32_send_next_frame(spi, data, 0U);
+			} else {
+				/* All TX done; request one trailing TXE interrupt
+				 * to exit cleanly once BSY is cleared.
+				 */
+				ll_enable_int_tx_empty(spi);
+			}
+		}
+	} else if (dir == STM32_SPI_HALF_DUPLEX_TX) {
+		/* Half-duplex TX: TXE flag-based handling. */
+		if (ll_tx_is_not_full(spi) && data->tx_len != 0U) {
+			data->tx_len -= spi_stm32_send_next_frame(spi, data, 0U);
+		}
+	} else if (dir == STM32_SPI_HALF_DUPLEX_RX) {
+		/* Half-duplex RX: RXNE flag-based handling. */
+		if (ll_rx_is_not_empty(spi) && data->rx_len != 0U) {
+			data->rx_len -= spi_stm32_read_next_frame(spi, data, 0U);
+		}
+	} else {
+		/* Unexpected transfer direction */
+		return -EINVAL;
+	}
+#else /* CONFIG_SPI_STM32_INTERRUPT */
 	if (dir != STM32_SPI_HALF_DUPLEX_RX && data->tx_len != 0U) {
 		while (!ll_tx_is_not_full(spi)) {
 			/* NOP */
@@ -762,6 +796,7 @@ static int spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 		}
 		data->rx_len -= spi_stm32_read_next_frame(spi, data, 0U);
 	}
+#endif /* CONFIG_SPI_STM32_INTERRUPT */
 
 	return 0;
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
@@ -878,13 +913,30 @@ static void spi_stm32_msg_start(const struct device *dev, bool is_rx_empty)
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	ll_enable_int_errors(spi);
 
-	if (transfer_dir != STM32_SPI_HALF_DUPLEX_TX) {
-		ll_enable_int_rx_not_empty(spi);
-	}
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+	if (transfer_dir == STM32_SPI_FULL_DUPLEX &&
+	    LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
+		struct spi_stm32_data *data = dev->data;
 
-	if (transfer_dir != STM32_SPI_HALF_DUPLEX_RX) {
-		ll_enable_int_tx_empty(spi);
+		/* Non-H7 full-duplex controller: seed the TX pipeline with the first
+		 * frame and enable RXNE only. Each RXNE ISR reads one received
+		 * frame then sends the next, keeping exactly one frame in flight.
+		 * This eliminates RX overrun without busy-waiting in ISR context.
+		 */
+		data->tx_len -= spi_stm32_send_next_frame(spi, data, 0U);
+		ll_enable_int_rx_not_empty(spi);
+	} else {
+#endif /* !DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+		if (transfer_dir != STM32_SPI_HALF_DUPLEX_TX) {
+			ll_enable_int_rx_not_empty(spi);
+		}
+
+		if (transfer_dir != STM32_SPI_HALF_DUPLEX_RX) {
+			ll_enable_int_tx_empty(spi);
+		}
+#if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	}
+#endif /* !DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	irq_enable(cfg->irq_line);

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -2045,7 +2045,14 @@ static int transceive(const struct device *dev,
 	bool use_dma = false;
 
 #if defined(CONFIG_SPI_STM32_DMA)
-	use_dma = (data->dma_tx.dma_dev != NULL) && (data->dma_rx.dma_dev != NULL);
+	if ((SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_CONTROLLER) &&
+	    (config->operation & SPI_HALF_DUPLEX) == 0U) {
+		/* DMA can only be used for full-duplex controller mode */
+		use_dma = (data->dma_tx.dma_dev != NULL) && (data->dma_rx.dma_dev != NULL);
+	} else {
+		LOG_ERR("SPI DMA is only supported for full-duplex controller mode");
+		return -ENOTSUP;
+	}
 #endif /* CONFIG_SPI_STM32_DMA */
 
 	if (tx_bufs == NULL && rx_bufs == NULL) {

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1190,7 +1190,6 @@ static void spi_stm32_complete(const struct device *dev, int status)
 
 #endif /* CONFIG_SPI_STM32_INTERRUPT */
 
-
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo)
 	/* Flush RX buffer */
 	while (ll_rx_is_not_empty(spi)) {
@@ -1306,6 +1305,19 @@ static void spi_stm32_isr(const struct device *dev)
 			return;
 		}
 	}
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo) && !DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+	if (LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER &&
+	    STM32_SPI_HALF_DUPLEX_RX == ll_get_transfer_direction(spi) &&
+	    !spi_context_rx_on(&data->ctx)) {
+		/* In half-duplex RX controller mode, disable the SPI as soon as the last byte is
+		 * received to stop the transfer and prevent further reception of dummy bytes.
+		 */
+		ll_disable_spi(spi);
+		spi_stm32_complete(dev, err);
+		return;
+	}
+#endif /* st_stm32_spi_fifo && !st_stm32h7_spi */
 
 	uint32_t transfer_dir = ll_get_transfer_direction(spi);
 

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -711,20 +711,25 @@ static int spi_stm32_shift_fifo(SPI_TypeDef *spi, struct spi_stm32_data *data)
 		 */
 		spi_stm32_read_fifo(spi, data);
 	} else if (transfer_dir != STM32_SPI_HALF_DUPLEX_RX && ll_tx_is_not_full(spi) &&
-		   data->tx_len != 0U && data->tx_len == data->rx_len) {
-		/* First complete data packet can be sent (Tx len == Rx len). After that, use DXP.
+		   data->tx_len != 0U &&
+		   (data->tx_len == data->rx_len || transfer_dir == STM32_SPI_HALF_DUPLEX_TX)) {
+		/* In full-duplex, first complete data packet can be sent (Tx len == Rx len),
+		 * after that, use DXP.
+		 * In half-duplex, send data if FIFO space is available.
 		 * Fill the TxFIFO until threshold is reached or all data for the transfer are sent.
 		 */
 		spi_stm32_send_fifo(spi, data);
 #ifdef CONFIG_SPI_STM32_INTERRUPT
-		/* After first transmit, disable TXP. The goal is to use DXP from then on.
-		 * This keeps Tx and Rx synchronized and avoids overruns.
-		 */
-		LL_SPI_DisableIT_TXP(spi);
+		if (transfer_dir == STM32_SPI_FULL_DUPLEX) {
+			/* After first transmit, disable TXP. The goal is to use DXP from then on.
+			 * This keeps Tx and Rx synchronized and avoids overruns.
+			 */
+			LL_SPI_DisableIT_TXP(spi);
+		}
 #endif /* CONFIG_SPI_STM32_INTERRUPT */
 	}
 
-	if (LL_SPI_IsActiveFlag_EOT(spi)) {
+	if (transfer_dir != STM32_SPI_HALF_DUPLEX_TX && LL_SPI_IsActiveFlag_EOT(spi)) {
 		while (data->rx_len != 0U) {
 			/* Some data may remain in the RxFIFO at the end of transfer if transfer
 			 * size is not a multiple of FIFO threshold. Read them here.
@@ -742,21 +747,19 @@ static int spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	return spi_stm32_shift_fifo(spi, data);
 #else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-	uint32_t transfer_dir = ll_get_transfer_direction(spi);
+	uint32_t dir = ll_get_transfer_direction(spi);
 
-	if (transfer_dir != STM32_SPI_HALF_DUPLEX_RX) {
+	if (dir != STM32_SPI_HALF_DUPLEX_RX && data->tx_len != 0U) {
 		while (!ll_tx_is_not_full(spi)) {
 			/* NOP */
 		}
-
 		data->tx_len -= spi_stm32_send_next_frame(spi, data, 0U);
 	}
 
-	if (transfer_dir != STM32_SPI_HALF_DUPLEX_TX) {
+	if (dir != STM32_SPI_HALF_DUPLEX_TX && data->rx_len != 0U) {
 		while (!ll_rx_is_not_empty(spi)) {
 			/* NOP */
 		}
-
 		data->rx_len -= spi_stm32_read_next_frame(spi, data, 0U);
 	}
 
@@ -770,13 +773,15 @@ static void spi_stm32_shift_s(SPI_TypeDef *spi, struct spi_stm32_data *data)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) && !defined(CONFIG_SPI_RTIO)
 	spi_stm32_shift_fifo(spi, data);
 #else /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-	if (ll_tx_is_not_full(spi) && data->tx_len != 0U) {
+	uint32_t dir = ll_get_transfer_direction(spi);
+
+	if (dir != STM32_SPI_HALF_DUPLEX_RX && ll_tx_is_not_full(spi) && data->tx_len != 0U) {
 		data->tx_len -= spi_stm32_send_next_frame(spi, data, 0U);
 	} else {
 		ll_disable_int_tx_empty(spi);
 	}
 
-	if (ll_rx_is_not_empty(spi) && data->rx_len != 0U) {
+	if (dir != STM32_SPI_HALF_DUPLEX_TX && ll_rx_is_not_empty(spi) && data->rx_len != 0U) {
 		data->rx_len -= spi_stm32_read_next_frame(spi, data, 0U);
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
@@ -826,6 +831,7 @@ static void spi_stm32_msg_start(const struct device *dev, bool is_rx_empty)
 {
 	const struct spi_stm32_config *cfg = dev->config;
 	SPI_TypeDef *spi = cfg->spi;
+	__maybe_unused uint32_t transfer_dir = LL_SPI_GetTransferDirection(spi);
 
 	ARG_UNUSED(is_rx_empty);
 
@@ -865,12 +871,20 @@ static void spi_stm32_msg_start(const struct device *dev, bool is_rx_empty)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	if (!IS_ENABLED(CONFIG_SPI_RTIO) || LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
 		LL_SPI_EnableIT_EOT(spi);
-		LL_SPI_EnableIT_DXP(spi);
+		if (transfer_dir == STM32_SPI_FULL_DUPLEX) {
+			LL_SPI_EnableIT_DXP(spi);
+		}
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 	ll_enable_int_errors(spi);
-	ll_enable_int_rx_not_empty(spi);
-	ll_enable_int_tx_empty(spi);
+
+	if (transfer_dir != STM32_SPI_HALF_DUPLEX_TX) {
+		ll_enable_int_rx_not_empty(spi);
+	}
+
+	if (transfer_dir != STM32_SPI_HALF_DUPLEX_RX) {
+		ll_enable_int_tx_empty(spi);
+	}
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	irq_enable(cfg->irq_line);
@@ -883,7 +897,7 @@ static void spi_stm32_msg_start(const struct device *dev, bool is_rx_empty)
 static void spi_stm32_iodev_complete(const struct device *dev, int status);
 static int spi_stm32_configure(const struct device *dev,
 			       const struct spi_config *config,
-			       bool write);
+			       bool write, bool read);
 static int32_t spi_stm32_set_transfer_size(const struct device *dev,
 					   const struct spi_config *config,
 					   const struct spi_buf_set *tx_bufs,
@@ -1029,12 +1043,14 @@ static inline int spi_stm32_iodev_prepare_start(const struct device *dev)
 	bool write = (op_code == RTIO_OP_TX) ||
 		     (op_code == RTIO_OP_TINY_TX) ||
 		     (op_code == RTIO_OP_TXRX);
+	bool read = (op_code == RTIO_OP_RX) ||
+		    (op_code == RTIO_OP_TXRX);
 
 #ifdef CONFIG_SPI_PERIPHERAL
 	data->ctx.recv_frames = 0;
 #endif /* CONFIG_SPI_PERIPHERAL */
 
-	return spi_stm32_configure(dev, spi_config, write);
+	return spi_stm32_configure(dev, spi_config, write, read);
 }
 
 static void spi_stm32_iodev_complete(const struct device *dev, int status)
@@ -1077,6 +1093,62 @@ static void spi_stm32_iodev_submit(const struct device *dev, struct rtio_iodev_s
 }
 #endif /* CONFIG_SPI_RTIO */
 
+static int spi_stm32_half_duplex_switch_direction(const struct device *dev)
+{
+	const struct spi_stm32_config *cfg = dev->config;
+	SPI_TypeDef *spi = cfg->spi;
+	struct spi_stm32_data *data = dev->data;
+
+	if (LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER &&
+	    !spi_context_tx_on(&data->ctx) && spi_context_rx_on(&data->ctx)) {
+		LL_SPI_Disable(spi);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+		LL_SPI_SetTransferSize(spi, data->rx_len);
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+
+		ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_RX);
+		LL_SPI_Enable(spi);
+		spi_stm32_cs_control(dev, true);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+		LL_SPI_StartMasterTransfer(spi);
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+
+#ifdef CONFIG_SPI_STM32_INTERRUPT
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+		LL_SPI_EnableIT_EOT(spi);
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+		ll_enable_int_errors(spi);
+		ll_enable_int_rx_not_empty(spi);
+#endif /* CONFIG_SPI_STM32_INTERRUPT */
+	} else if (LL_SPI_GetMode(spi) == LL_SPI_MODE_SLAVE &&
+		   spi_context_tx_on(&data->ctx) && !spi_context_rx_on(&data->ctx)) {
+		LL_SPI_Disable(spi);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+		if (!IS_ENABLED(CONFIG_SPI_RTIO)) {
+			LL_SPI_SetTransferSize(spi, data->tx_len);
+		}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+
+		ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_TX);
+		LL_SPI_Enable(spi);
+
+#ifdef CONFIG_SPI_STM32_INTERRUPT
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+		if (!IS_ENABLED(CONFIG_SPI_RTIO)) {
+			LL_SPI_EnableIT_EOT(spi);
+		}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+		ll_enable_int_errors(spi);
+		ll_enable_int_tx_empty(spi);
+#endif /* CONFIG_SPI_STM32_INTERRUPT */
+	}
+
+	return 0;
+}
+
 static void spi_stm32_complete(const struct device *dev, int status)
 {
 	const struct spi_stm32_config *cfg = dev->config;
@@ -1091,11 +1163,15 @@ static void spi_stm32_complete(const struct device *dev, int status)
 	 */
 	irq_disable(cfg->irq_line);
 #endif /* CONFIG_SPI_STM32_INTERRUPT && CONFIG_SOC_SERIES_STM32H7X */
-	if (data->rtio_ctx->txn_head != NULL) {
+
+	if (data->rtio_ctx->txn_head != NULL &&
+	    ((ll_get_transfer_direction(spi) == STM32_SPI_FULL_DUPLEX) ||
+	     !spi_stm32_transfer_ongoing(data))) {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 		LL_SPI_ClearFlag_TXTF(spi);
 		LL_SPI_ClearFlag_OVR(spi);
 		LL_SPI_ClearFlag_EOT(spi);
+		LL_SPI_DisableIT_EOT(spi);
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 		spi_stm32_iodev_complete(dev, status);
 		return;
@@ -1179,7 +1255,12 @@ static void spi_stm32_complete(const struct device *dev, int status)
 #endif /* CONFIG_SPI_STM32_INTERRUPT && CONFIG_SOC_SERIES_STM32H7X */
 	}
 
-	spi_context_complete(&data->ctx, dev, status);
+	if (ll_get_transfer_direction(spi) != STM32_SPI_FULL_DUPLEX &&
+	    spi_stm32_transfer_ongoing(data)) {
+		spi_stm32_half_duplex_switch_direction(dev);
+	} else {
+		spi_context_complete(&data->ctx, dev, status);
+	}
 }
 
 #ifdef CONFIG_SPI_STM32_INTERRUPT
@@ -1205,6 +1286,13 @@ static void spi_stm32_isr(const struct device *dev)
 		return;
 	}
 
+	if (!spi_stm32_transfer_ongoing(data)) {
+		if (ll_rx_is_not_empty(spi)) {
+			(void) LL_SPI_ReceiveData8(spi);
+		}
+		LL_SPI_ClearFlag_OVR(spi);
+	}
+
 	err = spi_stm32_get_err(spi);
 	if (err) {
 		spi_stm32_complete(dev, err);
@@ -1221,18 +1309,50 @@ static void spi_stm32_isr(const struct device *dev)
 
 	uint32_t transfer_dir = ll_get_transfer_direction(spi);
 
-	if (((transfer_dir == STM32_SPI_FULL_DUPLEX) && !spi_stm32_transfer_ongoing(data) &&
-	     !ll_spi_is_busy(spi)) ||
-	    ((transfer_dir == STM32_SPI_HALF_DUPLEX_TX) && !spi_context_tx_on(&data->ctx)) ||
-	    ((transfer_dir == STM32_SPI_HALF_DUPLEX_RX) && !spi_context_rx_on(&data->ctx))) {
+	if (!ll_spi_is_busy(spi) &&
+	    (((transfer_dir == STM32_SPI_FULL_DUPLEX) && !spi_stm32_transfer_ongoing(data)) ||
+	     ((transfer_dir == STM32_SPI_HALF_DUPLEX_TX) && !spi_context_tx_on(&data->ctx)) ||
+	     ((transfer_dir == STM32_SPI_HALF_DUPLEX_RX) && !spi_context_rx_on(&data->ctx)))) {
 		spi_stm32_complete(dev, err);
 	}
 }
 #endif /* CONFIG_SPI_STM32_INTERRUPT */
 
+static void spi_stm32_set_transfer_direction(const struct device *dev,
+					     const struct spi_config *config,
+					     bool write, bool read)
+{
+	const struct spi_stm32_config *cfg = dev->config;
+	SPI_TypeDef *spi = cfg->spi;
+
+	if (config->operation & SPI_HALF_DUPLEX) {
+		/* For half-duplex transfers, if both TX and RX are active:
+		 * For the controller, Tx is done first, then Rx.
+		 * For the peripheral, Rx is done first, then Tx.
+		 * We need to know which direction to start with in each case, hence why we need
+		 * the write and read flags.
+		 */
+		if (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_CONTROLLER) {
+			if (write) {
+				ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_TX);
+			} else {
+				ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_RX);
+			}
+		} else {
+			if (read) {
+				ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_RX);
+			} else {
+				ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_TX);
+			}
+		}
+	} else {
+		ll_set_transfer_direction(spi, STM32_SPI_FULL_DUPLEX);
+	}
+}
+
 static int spi_stm32_configure(const struct device *dev,
 			       const struct spi_config *config,
-			       bool write)
+			       bool write, bool read)
 {
 	const struct spi_stm32_config *cfg = dev->config;
 	struct spi_stm32_data *data = dev->data;
@@ -1256,13 +1376,7 @@ static int spi_stm32_configure(const struct device *dev,
 
 #ifndef CONFIG_SPI_RTIO
 	if (spi_context_configured(&data->ctx, config)) {
-		if (config->operation & SPI_HALF_DUPLEX) {
-			if (write) {
-				ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_TX);
-			} else {
-				ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_RX);
-			}
-		}
+		spi_stm32_set_transfer_direction(dev, config, write, read);
 		return 0;
 	}
 #endif /* CONFIG_SPI_RTIO */
@@ -1343,21 +1457,13 @@ static int spi_stm32_configure(const struct device *dev,
 		LL_SPI_SetClockPhase(spi, STM32_SPI_CLOCK_PHASE_1_EDGE);
 	}
 
-	if ((config->operation & SPI_HALF_DUPLEX) != 0U) {
-		if (write) {
-			ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_TX);
-		} else {
-			ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_RX);
-		}
-	} else {
-		ll_set_transfer_direction(spi, STM32_SPI_FULL_DUPLEX);
-	}
-
 	if ((config->operation & SPI_TRANSFER_LSB) != 0) {
 		LL_SPI_SetTransferBitOrder(spi, LL_SPI_LSB_FIRST);
 	} else {
 		LL_SPI_SetTransferBitOrder(spi, LL_SPI_MSB_FIRST);
 	}
+
+	spi_stm32_set_transfer_direction(dev, config, write, read);
 
 	LL_SPI_DisableCRC(spi);
 
@@ -1448,6 +1554,7 @@ static int spi_stm32_release(const struct device *dev, const struct spi_config *
 	return 0;
 }
 
+#ifndef CONFIG_SPI_RTIO
 static int32_t spi_stm32_count_bufset_frames(const struct spi_config *config,
 					     const struct spi_buf_set *bufs)
 {
@@ -1469,12 +1576,9 @@ static int32_t spi_stm32_count_bufset_frames(const struct spi_config *config,
 
 	int frames = num_bytes / dfs;
 
-	if (frames > UINT16_MAX) {
-		return -EMSGSIZE;
-	}
-
 	return frames;
 }
+#endif /* CONFIG_SPI_RTIO */
 
 static int32_t spi_stm32_set_transfer_size(const struct device *dev,
 					   const struct spi_config *config,
@@ -1485,28 +1589,41 @@ static int32_t spi_stm32_set_transfer_size(const struct device *dev,
 	const struct spi_stm32_config *cfg = dev->config;
 	SPI_TypeDef *spi = cfg->spi;
 	uint32_t transfer_dir = ll_get_transfer_direction(spi);
-	int32_t frames;
+	int32_t tx_frames, rx_frames;
+
+#ifdef CONFIG_SPI_RTIO
+	if (transfer_dir == STM32_SPI_FULL_DUPLEX) {
+		tx_frames = spi_context_longest_current_buf(&data->ctx);
+		rx_frames = tx_frames;
+	} else {
+		tx_frames = data->ctx.tx_len;
+		rx_frames = data->ctx.rx_len;
+	}
+#else /* CONFIG_SPI_RTIO */
+	tx_frames = spi_stm32_count_bufset_frames(config, tx_bufs);
+	rx_frames = spi_stm32_count_bufset_frames(config, rx_bufs);
+
+	if (tx_frames < 0) {
+		return tx_frames;
+	}
+
+	if (rx_frames < 0) {
+		return rx_frames;
+	}
 
 	if (transfer_dir == STM32_SPI_FULL_DUPLEX) {
-#ifdef CONFIG_SPI_RTIO
-		frames = spi_context_longest_current_buf(&data->ctx);
-#else /* CONFIG_SPI_RTIO*/
-		frames = MAX(spi_stm32_count_bufset_frames(config, tx_bufs),
-			     spi_stm32_count_bufset_frames(config, rx_bufs));
-#endif /* CONFIG_SPI_RTIO */
-	} else if (transfer_dir == STM32_SPI_HALF_DUPLEX_TX) {
-		frames = spi_stm32_count_bufset_frames(config, tx_bufs);
-	} else {
-		frames = spi_stm32_count_bufset_frames(config, rx_bufs);
-	}
+		uint32_t frames = MAX(tx_frames, rx_frames);
 
-	if (frames < 0) {
-		return frames;
+		tx_frames = frames;
+		rx_frames = frames;
 	}
+#endif /* CONFIG_SPI_RTIO */
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	if (!IS_ENABLED(CONFIG_SPI_RTIO) ||
 	    (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_CONTROLLER)) {
+		uint32_t frames = transfer_dir != STM32_SPI_HALF_DUPLEX_RX ? tx_frames : rx_frames;
+
 		if (frames <= cfg->fifo_max_transfer_size) {
 			if (LL_SPI_IsEnabled(spi)) {
 				/* SPI needs to be disabled to set the transfer size */
@@ -1520,86 +1637,11 @@ static int32_t spi_stm32_set_transfer_size(const struct device *dev,
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
-	data->tx_len = data->rx_len = frames;
+	data->tx_len = tx_frames;
+	data->rx_len = rx_frames;
 
 	return 0;
 }
-
-#ifndef CONFIG_SPI_RTIO
-static int spi_stm32_half_duplex_switch_to_receive(const struct spi_stm32_config *cfg,
-						   struct spi_stm32_data *data)
-{
-	SPI_TypeDef *spi = cfg->spi;
-
-	if (!spi_context_tx_on(&data->ctx) && spi_context_rx_on(&data->ctx)) {
-#ifndef CONFIG_SPI_STM32_INTERRUPT
-		while (ll_spi_is_busy(spi)) {
-			/* NOP */
-		}
-		ll_disable_spi(spi);
-#endif /* CONFIG_SPI_STM32_INTERRUPT*/
-
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		const struct spi_config *config = data->ctx.config;
-
-		if (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_CONTROLLER) {
-			int num_bytes = spi_context_total_rx_len(&data->ctx);
-			uint8_t dfs = bits2bytes(config->operation);
-
-			if ((num_bytes % dfs) != 0) {
-				return -EINVAL;
-			}
-
-			LL_SPI_SetTransferSize(spi, (uint32_t) num_bytes / dfs);
-		}
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-
-		ll_set_transfer_direction(spi, STM32_SPI_HALF_DUPLEX_RX);
-
-		LL_SPI_Enable(spi);
-
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		/* With the STM32MP1, STM32U5 and the STM32H7,
-		 * if the device is the SPI controller,
-		 * we need to enable the start of the transfer with
-		 * LL_SPI_StartMasterTransfer(spi).
-		 */
-		if (LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
-			LL_SPI_StartMasterTransfer(spi);
-			while (!LL_SPI_IsActiveMasterTransfer(spi)) {
-				/*
-				 * Check for the race condition where the transfer completes
-				 * before this loop is entered. If EOT is set, the transfer
-				 * is done and we can break.
-				 */
-				if (LL_SPI_IsActiveFlag_EOT(spi)) {
-					break;
-				}
-			}
-		}
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-
-#if CONFIG_SOC_SERIES_STM32H7X
-		/*
-		 * Add a small delay after enabling to prevent transfer stalling at high
-		 * system clock frequency (see errata sheet ES0392).
-		 */
-		k_busy_wait(WAIT_1US);
-#endif
-
-#ifdef CONFIG_SPI_STM32_INTERRUPT
-#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-		LL_SPI_EnableIT_EOT(spi);
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
-
-		ll_enable_int_errors(spi);
-		ll_enable_int_rx_not_empty(spi);
-#endif /* CONFIG_SPI_STM32_INTERRUPT */
-	}
-
-	return 0;
-}
-#endif /* !CONFIG_SPI_RTIO */
 
 #if defined(CONFIG_SPI_STM32_DMA)
 #if !defined(CONFIG_SPI_RTIO)
@@ -1970,7 +2012,7 @@ static int transceive(const struct device *dev,
 	const struct spi_stm32_config *cfg = dev->config;
 	SPI_TypeDef *spi = cfg->spi;
 
-	ret = spi_stm32_configure(dev, config, tx_bufs != NULL);
+	ret = spi_stm32_configure(dev, config, tx_bufs != NULL, rx_bufs != NULL);
 	if (ret != 0) {
 		goto end;
 	}
@@ -1985,14 +2027,18 @@ static int transceive(const struct device *dev,
 		goto end;
 	}
 
+	/* Flush RX buffer */
+	while (ll_rx_is_not_empty(spi)) {
+		(void) LL_SPI_ReceiveData8(spi);
+	}
+	LL_SPI_ClearFlag_OVR(spi);
+
 #ifdef CONFIG_SPI_STM32_DMA
 	if (use_dma) {
 		ret = transceive_dma(dev, config);
 		goto end;
 	}
 #endif /* CONFIG_SPI_STM32_DMA */
-
-	uint32_t transfer_dir = ll_get_transfer_direction(spi);
 
 	ret = spi_stm32_set_transfer_size(dev, config, tx_bufs, rx_bufs);
 	if (ret != 0) {
@@ -2004,20 +2050,21 @@ static int transceive(const struct device *dev,
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 	do {
 		ret = spi_context_wait_for_completion(&data->ctx);
-
-		if (ret == 0 && transfer_dir == STM32_SPI_HALF_DUPLEX_TX) {
-			ret = spi_stm32_half_duplex_switch_to_receive(cfg, data);
-			transfer_dir = ll_get_transfer_direction(spi);
-		}
-	} while (ret == 0 && spi_stm32_transfer_ongoing(data) &&
-		 transfer_dir != STM32_SPI_FULL_DUPLEX);
+	} while (ret == 0 && spi_stm32_transfer_ongoing(data) && !asynchronous);
 #else /* CONFIG_SPI_STM32_INTERRUPT */
+	uint32_t dir = ll_get_transfer_direction(spi);
+	uint32_t mode = LL_SPI_GetMode(spi);
+
 	while (ret == 0 && spi_stm32_transfer_ongoing(data)) {
 		ret = spi_stm32_shift_frames(spi, data);
 
-		if (ret == 0 && transfer_dir == STM32_SPI_HALF_DUPLEX_TX) {
-			ret = spi_stm32_half_duplex_switch_to_receive(cfg, data);
-			transfer_dir = ll_get_transfer_direction(spi);
+		if (ret == 0 &&
+		    ((dir == STM32_SPI_HALF_DUPLEX_TX && mode == LL_SPI_MODE_MASTER
+		      && data->tx_len == 0) ||
+		     (dir == STM32_SPI_HALF_DUPLEX_RX && mode == LL_SPI_MODE_SLAVE
+		      && data->rx_len == 0))) {
+			ret = spi_stm32_half_duplex_switch_direction(dev);
+			dir = ll_get_transfer_direction(spi);
 		}
 	}
 

--- a/tests/drivers/spi/spi_controller_peripheral/Kconfig
+++ b/tests/drivers/spi/spi_controller_peripheral/Kconfig
@@ -35,4 +35,11 @@ config SPI_CONTROLLER_PERIPHERAL_WORKQUEUE_PRIORITY
 	help
 	  Priority for the work queue used for async testing
 
+config TEST_SPI_NO_HOLD_ON_CS
+	bool "No hold on CS"
+	help
+	  Setting this option will disable holding the CS line active between transactions.
+	  This can be useful when the SPI instances is expecting a CS transition to start
+	  a transaction.
+
 source "Kconfig.zephyr"

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nucleo_f429zi_half_duplex.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nucleo_f429zi_half_duplex.overlay
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/spi/spi.h>
+
+/* The two SPI instances need to be connected as follows:
+ * CN9:5 (SPI2 MOSI) to CN8:8 (SPI3 MISO)
+ * CN7:7 (SPI2 NSS) to CN7:9 (SPI3 NSS)
+ * CN9:10 (SPI2 SCK) to CN7:15 (SPI3 SCK)
+ */
+
+&spi2 {
+	/* Make controller lower priority than the peripheral */
+	interrupts = <36 1>;
+	pinctrl-0 = <&spi2_mosi_pc3 &spi2_nss_pb12 &spi2_sck_pd3>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+		duplex = <SPI_HALF_DUPLEX>;
+	};
+};
+
+dut_spis: &spi3 {
+	pinctrl-0 = <&spi3_miso_pc11 &spi3_nss_pa15 &spi3_sck_pb3>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nucleo_f429zi_half_duplex.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nucleo_f429zi_half_duplex.overlay
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/spi/spi.h>
+
+/* The two SPI instances need to be connected as follows:
+ * CN9:5 (SPI2 MOSI) to CN8:8 (SPI3 MISO)
+ * CN7:7 (SPI2 NSS) to CN7:9 (SPI3 NSS)
+ * CN9:10 (SPI2 SCK) to CN7:15 (SPI3 SCK)
+ */
+
+&spi2 {
+	/* Make controller lower priority than the peripheral */
+	interrupts = <36 1>;
+	pinctrl-0 = <&spi2_mosi_pc3 &spi2_nss_pb12 &spi2_sck_pd3>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_K(500)>;
+		duplex = <SPI_HALF_DUPLEX>;
+	};
+};
+
+dut_spis: &spi3 {
+	pinctrl-0 = <&spi3_miso_pc11 &spi3_nss_pa15 &spi3_sck_pb3>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nucleo_g474re_half_duplex.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nucleo_g474re_half_duplex.overlay
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/spi/spi.h>
+
+/* The two SPI instances need to be connected as follows:
+ * CN10:14 (SPI2 MOSI) to CN10:27 (SPI3 MISO)
+ * CN10:16 (SPI2 NSS) to CN7:17 (SPI3 NSS)
+ * CN10:30 (SPI2 SCK) to CN7:1 (SPI3 SCK)
+ */
+
+&fdcan1 {
+	/* Disable FDCAN so that PA11 can be used for SPI2 MOSI */
+	status = "disabled";
+};
+
+&pwm3 {
+	/* Disable PWM3 so that PB4 can be used for SPI3 MISO */
+	status = "disabled";
+};
+
+&spi2 {
+	/* Make controller lower priority than the peripheral */
+	interrupts = <36 1>;
+	pinctrl-0 = <&spi2_mosi_pa11 &spi2_nss_pb12 &spi2_sck_pb13>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		spi-max-frequency = <DT_FREQ_M(1)>;
+		reg = <0>;
+		duplex = <SPI_HALF_DUPLEX>;
+	};
+};
+
+dut_spis: &spi3 {
+	pinctrl-0 = <&spi3_miso_pb4 &spi3_nss_pa15 &spi3_sck_pc10>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nucleo_u385rg_q_half_duplex.conf
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nucleo_u385rg_q_half_duplex.conf
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_TEST_SPI_NO_HOLD_ON_CS=y

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nucleo_u385rg_q_half_duplex.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nucleo_u385rg_q_half_duplex.overlay
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/spi/spi.h>
+
+/* The two SPI instances need to be connected as follows:
+ * CN7:36 (SPI2 MOSI) to CN7:2 (SPI3 MISO)
+ * CN10:24 (SPI2 CS) to CN7:17 (SPI3 NSS)
+ * CN10:25 (SPI2 SCK) to CN10:31 (SPI3 SCK)
+ */
+
+&usart3 {
+	/* Disable USART3 to keep PC11 for SPI3 MISO */
+	status = "disabled";
+};
+
+&spi2 {
+	/* Make controller lower priority than the peripheral */
+	interrupts = <60 1>;
+	pinctrl-0 = <&spi2_mosi_pc1 &spi2_sck_pb10>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpiob 1 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+		duplex = <SPI_HALF_DUPLEX>;
+	};
+};
+
+dut_spis: &spi3 {
+	pinctrl-0 = <&spi3_miso_pc11 &spi3_nss_pa15 &spi3_sck_pb3>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_controller_peripheral/src/main.c
+++ b/tests/drivers/spi/spi_controller_peripheral/src/main.c
@@ -33,6 +33,7 @@ static const struct spi_config spis_config = {
 	.frequency = DT_PROP(DT_NODELABEL(dut_spi_dt), spi_max_frequency),
 };
 
+#ifdef CONFIG_SPI_ASYNC
 static struct k_poll_signal async_sig = K_POLL_SIGNAL_INITIALIZER(async_sig);
 static struct k_poll_event async_evt =
 	K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &async_sig);
@@ -40,6 +41,7 @@ static struct k_poll_event async_evt =
 static struct k_poll_signal async_sig_spim = K_POLL_SIGNAL_INITIALIZER(async_sig_spim);
 static struct k_poll_event async_evt_spim =
 	K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &async_sig_spim);
+#endif /* CONFIG_SPI_ASYNC */
 
 #define MEMORY_SECTION(node)                                                                       \
 	COND_CODE_1(IS_ENABLED(CONFIG_PREALLOC_BUFFERS),                                           \
@@ -124,6 +126,7 @@ static void work_handler(struct k_work *work)
 			k_sem_give(&td->sem);
 		}
 	} else {
+#ifdef CONFIG_SPI_ASYNC
 		rv = spi_transceive_signal(spim.bus, &spim.config, td->mtx_set, td->mrx_set,
 				&async_sig_spim);
 		zassert_equal(rv, 0);
@@ -139,6 +142,7 @@ static void work_handler(struct k_work *work)
 		async_evt_spim.state = K_POLL_STATE_NOT_READY;
 
 		k_sem_give(&td->sem);
+#endif /* CONFIG_SPI_ASYNC */
 	}
 }
 
@@ -241,12 +245,13 @@ static void run_test(bool m_same_size, bool s_same_size, bool async)
 	rv = k_work_schedule_for_queue(&spim_spis_work_q, &tdata.test_work, K_MSEC(10));
 	zassert_equal(rv, 1);
 
-	if (!async) {
+	if (!IS_ENABLED(CONFIG_SPI_ASYNC) || !async) {
 		periph_rv = spi_transceive(spis_dev, &spis_config, tdata.stx_set, tdata.srx_set);
 		if (periph_rv == -ENOTSUP) {
 			ztest_test_skip();
 		}
 	} else {
+#ifdef CONFIG_SPI_ASYNC
 		rv = spi_transceive_signal(spis_dev, &spis_config, tdata.stx_set, tdata.srx_set,
 					   &async_sig);
 		if (rv == -ENOTSUP) {
@@ -266,6 +271,7 @@ static void run_test(bool m_same_size, bool s_same_size, bool async)
 		/* Reinitializing for next call */
 		async_evt.signal->signaled = 0U;
 		async_evt.state = K_POLL_STATE_NOT_READY;
+#endif /* CONFIG_SPI_ASYNC */
 	}
 
 	rv = k_sem_take(&tdata.sem, K_MSEC(100));
@@ -310,10 +316,12 @@ ZTEST(spi_controller_peripheral, test_basic)
 	test_basic(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_basic_async)
 {
 	test_basic(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 /** Basic test with zero length buffers.
  */
@@ -361,10 +369,12 @@ ZTEST(spi_controller_peripheral, test_basic_zero_len)
 	test_basic_zero_len(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_basic_zero_len_async)
 {
 	test_basic_zero_len(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 /** Setup a transfer where RX buffer on SPI controller and SPI peripheral are
  *  shorter than TX buffers. RX buffers shall contain beginning of TX data
@@ -401,10 +411,12 @@ ZTEST(spi_controller_peripheral, test_short_rx)
 	test_short_rx(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_short_rx_async)
 {
 	test_short_rx(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 /** Test where only master transmits. */
 static void test_only_tx(bool async)
@@ -435,10 +447,12 @@ ZTEST(spi_controller_peripheral, test_only_tx)
 	test_only_tx(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_only_tx_async)
 {
 	test_only_tx(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 /** Test where only SPI controller transmits and SPI peripheral receives in chunks. */
 static void test_only_tx_in_chunks(bool async)
@@ -472,10 +486,12 @@ ZTEST(spi_controller_peripheral, test_only_tx_in_chunks)
 	test_only_tx_in_chunks(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_only_tx_in_chunks_async)
 {
 	test_only_tx_in_chunks(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 /** Test where only SPI peripheral transmits. */
 static void test_only_rx(bool async)
@@ -506,10 +522,12 @@ ZTEST(spi_controller_peripheral, test_only_rx)
 	test_only_rx(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_only_rx_async)
 {
 	test_only_rx(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 /** Test where only SPI peripheral transmits in chunks. */
 static void test_only_rx_in_chunks(bool async)
@@ -543,10 +561,12 @@ ZTEST(spi_controller_peripheral, test_only_rx_in_chunks)
 	test_only_rx_in_chunks(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_only_rx_in_chunks_async)
 {
 	test_only_rx_in_chunks(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 static void run_half_duplex_test(int len)
 {

--- a/tests/drivers/spi/spi_controller_peripheral/src/main.c
+++ b/tests/drivers/spi/spi_controller_peripheral/src/main.c
@@ -113,7 +113,9 @@ static void work_handler(struct k_work *work)
 #endif
 
 	if (spim.config.operation & SPI_HALF_DUPLEX) {
-		spim.config.operation |= SPI_HOLD_ON_CS;
+		if (!IS_ENABLED(CONFIG_TEST_SPI_NO_HOLD_ON_CS)) {
+			spim.config.operation |= SPI_HOLD_ON_CS;
+		}
 
 		rv = spi_write_dt(&spim, td->mtx_set);
 		spim.config.operation &= ~SPI_HOLD_ON_CS;
@@ -588,7 +590,11 @@ static void run_half_duplex_test(int len)
 		return;
 	}
 
-	spis_half_duplex_config.operation |= (SPI_HOLD_ON_CS | SPI_HALF_DUPLEX);
+	spis_half_duplex_config.operation |= SPI_HALF_DUPLEX;
+
+	if (!IS_ENABLED(CONFIG_TEST_SPI_NO_HOLD_ON_CS)) {
+		spim.config.operation |= SPI_HOLD_ON_CS;
+	}
 
 	tdata.async = false;
 	rv = k_work_schedule_for_queue(&spim_spis_work_q, &tdata.test_work, K_MSEC(10));

--- a/tests/drivers/spi/spi_controller_peripheral/src/main.c
+++ b/tests/drivers/spi/spi_controller_peripheral/src/main.c
@@ -38,6 +38,7 @@ static const struct spi_config spis_config = {
 	.frequency = DT_PROP(DT_NODELABEL(dut_spi_dt), spi_max_frequency),
 };
 
+#ifdef CONFIG_SPI_ASYNC
 static struct k_poll_signal async_sig = K_POLL_SIGNAL_INITIALIZER(async_sig);
 static struct k_poll_event async_evt =
 	K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &async_sig);
@@ -45,6 +46,7 @@ static struct k_poll_event async_evt =
 static struct k_poll_signal async_sig_spim = K_POLL_SIGNAL_INITIALIZER(async_sig_spim);
 static struct k_poll_event async_evt_spim =
 	K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &async_sig_spim);
+#endif /* CONFIG_SPI_ASYNC */
 
 #define MEMORY_SECTION(node)                                                                       \
 	COND_CODE_1(IS_ENABLED(CONFIG_PREALLOC_BUFFERS),                                           \
@@ -133,6 +135,7 @@ static void work_handler(struct k_work *work)
 			k_sem_give(&td->sem);
 		}
 	} else {
+#ifdef CONFIG_SPI_ASYNC
 		rv = spi_transceive_signal(spim.bus, &spim.config, td->mtx_set, td->mrx_set,
 				&async_sig_spim);
 		zassert_equal(rv, 0);
@@ -148,6 +151,7 @@ static void work_handler(struct k_work *work)
 		async_evt_spim.state = K_POLL_STATE_NOT_READY;
 
 		k_sem_give(&td->sem);
+#endif /* CONFIG_SPI_ASYNC */
 	}
 }
 
@@ -250,12 +254,13 @@ static void run_test(bool m_same_size, bool s_same_size, bool async)
 	rv = k_work_schedule_for_queue(&spim_spis_work_q, &tdata.test_work, K_MSEC(10));
 	zassert_equal(rv, 1);
 
-	if (!async) {
+	if (!IS_ENABLED(CONFIG_SPI_ASYNC) || !async) {
 		periph_rv = spi_transceive(spis_dev, &spis_config, tdata.stx_set, tdata.srx_set);
 		if (periph_rv == -ENOTSUP) {
 			ztest_test_skip();
 		}
 	} else {
+#ifdef CONFIG_SPI_ASYNC
 		rv = spi_transceive_signal(spis_dev, &spis_config, tdata.stx_set, tdata.srx_set,
 					   &async_sig);
 		if (rv == -ENOTSUP) {
@@ -275,6 +280,7 @@ static void run_test(bool m_same_size, bool s_same_size, bool async)
 		/* Reinitializing for next call */
 		async_evt.signal->signaled = 0U;
 		async_evt.state = K_POLL_STATE_NOT_READY;
+#endif /* CONFIG_SPI_ASYNC */
 	}
 
 	rv = k_sem_take(&tdata.sem, K_MSEC(100));
@@ -319,10 +325,12 @@ ZTEST(spi_controller_peripheral, test_basic)
 	test_basic(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_basic_async)
 {
 	test_basic(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 /** Basic test with zero length buffers.
  */
@@ -370,10 +378,12 @@ ZTEST(spi_controller_peripheral, test_basic_zero_len)
 	test_basic_zero_len(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_basic_zero_len_async)
 {
 	test_basic_zero_len(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 /** Setup a transfer where RX buffer on SPI controller and SPI peripheral are
  *  shorter than TX buffers. RX buffers shall contain beginning of TX data
@@ -410,10 +420,12 @@ ZTEST(spi_controller_peripheral, test_short_rx)
 	test_short_rx(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_short_rx_async)
 {
 	test_short_rx(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 /** Test where only controller transmits. */
 static void test_only_tx(bool async)
@@ -444,10 +456,12 @@ ZTEST(spi_controller_peripheral, test_only_tx)
 	test_only_tx(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_only_tx_async)
 {
 	test_only_tx(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 /** Test where only SPI controller transmits and SPI peripheral receives in chunks. */
 static void test_only_tx_in_chunks(bool async)
@@ -481,10 +495,12 @@ ZTEST(spi_controller_peripheral, test_only_tx_in_chunks)
 	test_only_tx_in_chunks(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_only_tx_in_chunks_async)
 {
 	test_only_tx_in_chunks(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 /** Test where only SPI peripheral transmits. */
 static void test_only_rx(bool async)
@@ -515,10 +531,12 @@ ZTEST(spi_controller_peripheral, test_only_rx)
 	test_only_rx(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_only_rx_async)
 {
 	test_only_rx(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 /** Test where only SPI peripheral transmits in chunks. */
 static void test_only_rx_in_chunks(bool async)
@@ -552,10 +570,12 @@ ZTEST(spi_controller_peripheral, test_only_rx_in_chunks)
 	test_only_rx_in_chunks(false);
 }
 
+#ifdef CONFIG_SPI_ASYNC
 ZTEST(spi_controller_peripheral, test_only_rx_in_chunks_async)
 {
 	test_only_rx_in_chunks(true);
 }
+#endif /* CONFIG_SPI_ASYNC */
 
 static void run_half_duplex_test(int len)
 {

--- a/tests/drivers/spi/spi_controller_peripheral/tests.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/tests.yaml
@@ -208,3 +208,18 @@ tests:
       - nucleo_u385rg_q/stm32u385xx
     platform_exclude:
       - sam_e54_xpro
+
+  drivers.spi.stm32_interrupt_half_duplex:
+    extra_configs:
+      - CONFIG_SPI_STM32_INTERRUPT=y
+    filter: CONFIG_SOC_FAMILY_STM32
+    extra_args:
+      - platform:nucleo_f429zi/stm32f429xx:DTC_OVERLAY_FILE="boards/nucleo_f429zi_half_duplex.overlay"
+      - platform:nucleo_g474re/stm32g474xx:DTC_OVERLAY_FILE="boards/nucleo_g474re_half_duplex.overlay"
+      - platform:nucleo_u385rg_q/stm32u385xx:DTC_OVERLAY_FILE="boards/nucleo_u385rg_q_half_duplex.overlay"
+    platform_allow:
+      - nucleo_f429zi/stm32f429xx
+      - nucleo_g474re/stm32g474xx
+      - nucleo_u385rg_q/stm32u385xx
+    platform_exclude:
+      - sam_e54_xpro

--- a/tests/drivers/spi/spi_controller_peripheral/tests.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/tests.yaml
@@ -195,3 +195,16 @@ tests:
       - nucleo_u385rg_q/stm32u385xx
     platform_exclude:
       - sam_e54_xpro
+
+  drivers.spi.stm32_rtio_interrupt:
+    extra_configs:
+      - CONFIG_SPI_STM32_INTERRUPT=y
+      - CONFIG_SPI_RTIO=y
+      - CONFIG_SPI_ASYNC=n
+    filter: CONFIG_SOC_FAMILY_STM32
+    platform_allow:
+      - nucleo_f429zi/stm32f429xx
+      - nucleo_g474re/stm32g474xx
+      - nucleo_u385rg_q/stm32u385xx
+    platform_exclude:
+      - sam_e54_xpro

--- a/tests/drivers/spi/spi_controller_peripheral/tests.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/tests.yaml
@@ -231,3 +231,14 @@ tests:
       - nucleo_f429zi/stm32f429xx
       - nucleo_g474re/stm32g474xx
       - nucleo_u385rg_q/stm32u385xx
+
+  drivers.spi.stm32_rtio_interrupt:
+    extra_configs:
+      - CONFIG_SPI_STM32_INTERRUPT=y
+      - CONFIG_SPI_RTIO=y
+      - CONFIG_SPI_ASYNC=n
+    filter: CONFIG_SOC_FAMILY_STM32
+    platform_allow:
+      - nucleo_f429zi/stm32f429xx
+      - nucleo_g474re/stm32g474xx
+      - nucleo_u385rg_q/stm32u385xx

--- a/tests/drivers/spi/spi_controller_peripheral/tests.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/tests.yaml
@@ -242,3 +242,17 @@ tests:
       - nucleo_f429zi/stm32f429xx
       - nucleo_g474re/stm32g474xx
       - nucleo_u385rg_q/stm32u385xx
+
+  drivers.spi.stm32_interrupt_half_duplex:
+    extra_configs:
+      - CONFIG_SPI_STM32_INTERRUPT=y
+    filter: CONFIG_SOC_FAMILY_STM32
+    extra_args:
+      - platform:nucleo_f429zi/stm32f429xx:DTC_OVERLAY_FILE="boards/nucleo_f429zi_half_duplex.overlay"
+      - platform:nucleo_g474re/stm32g474xx:DTC_OVERLAY_FILE="boards/nucleo_g474re_half_duplex.overlay"
+      - platform:nucleo_u385rg_q@D/stm32u385xx:DTC_OVERLAY_FILE="boards/nucleo_u385rg_q_half_duplex.overlay"
+      - platform:nucleo_u385rg_q@D/stm32u385xx:EXTRA_CONF_FILE="boards/nucleo_u385rg_q_half_duplex.conf"
+    platform_allow:
+      - nucleo_f429zi/stm32f429xx
+      - nucleo_g474re/stm32g474xx
+      - nucleo_u385rg_q/stm32u385xx

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wb09ke.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wb09ke.conf
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=13
+CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=14

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wb55rg.conf
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wb55rg.conf
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=29
+CONFIG_SPI_IDEAL_TRANSFER_DURATION_SCALING=30


### PR DESCRIPTION
This PR adds SPI half-duplex peripheral support for STM32 and some related tests.
It also enables peripheral support in RTIO, and an optimization in interrupt mode for non-H7 compatible devices.