### PR TITLE
Mcuxa lpdac test harness enhancement for second serial console checking with latest multi-dut support in twister-pytest

### DIFF
--- a/tests/drivers/dac/dac_api/pytest/test_dac0_channel0_mcxaxx6.py
+++ b/tests/drivers/dac/dac_api/pytest/test_dac0_channel0_mcxaxx6.py
@@ -1,0 +1,25 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from twister_harness import DeviceAdapter
+
+SUCCESS_LINE = "*PROJECT EXECUTION SUCCESSFUL*"
+ZTEST_LINE = "*START - test_task_write_value*"
+END_PATTERN = r"PROJECT EXECUTION SUCCESSFUL|PROJECT EXECUTION FAILED"
+
+
+def test_dac_aux_output(dut: DeviceAdapter):
+    if len(dut.device_config.serial_configs) < 2:
+        pytest.fail(
+            "AUX UART mapping is missing for this test. "
+            "Expected a second serial connection at connection_index=1."
+        )
+
+    aux_lines = dut.readlines_until(
+        connection_index=1,
+        regex=END_PATTERN,
+        timeout=30.0,
+    )
+
+    pytest.LineMatcher(aux_lines).fnmatch_lines([ZTEST_LINE, SUCCESS_LINE])

--- a/tests/drivers/dac/dac_api/tests.yaml
+++ b/tests/drivers/dac/dac_api/tests.yaml
@@ -71,9 +71,11 @@ tests:
       - frdm_mcxa266
       - frdm_mcxa346
       - frdm_mcxa366
-    harness: ztest
+    harness: pytest
     harness_config:
       fixture: dac_fixture
+      pytest_root:
+        - pytest/test_dac0_channel0_mcxaxx6.py
   drivers.dac.api.dac1_channel1:
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE="dac1-channel1.overlay"


### PR DESCRIPTION
    for mcux lpdac tests, the seconday uart is used, with dut pytest,
    we can unify the test with two instance.

    example usage:

```
    - baud: 115200
      connected: true
      id: "OY2JXE5XLYFEE"
      platform: frdm_mcxa346/mcxa346
      product: NXP
      runner: linkserver
      pre_script: /home/ubuntu/nxp/frdm_mcxa346/erase2.sh
      serial: COM0
      fixtures:
        - dac_fixture
    - connected: true
      id: "OY2JXE5XLYFEE"
      platform: unknown
      product: unknown
      runner: unknown
      serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
      serial_baud: 115200
      notes: "Auxiliary serial port, not flashed"
```

this depends on https://github.com/zephyrproject-rtos/zephyr/pull/91338