### PR TITLE
Add frdm mcxa577 i3c

### DIFF
--- a/boards/nxp/frdm_mcxa577/board.c
+++ b/boards/nxp/frdm_mcxa577/board.c
@@ -236,6 +236,12 @@ void board_early_init_hook(void)
 #endif
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(i3c0))
+	CLOCK_AttachClk(kFRO_LF_DIV_to_I3C0FCLK);
+	CLOCK_SetClockDiv(kCLOCK_DivI3C0_FCLK, 1U);
+	RESET_ReleasePeripheralReset(kI3C0_RST_SHIFT_RSTn);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpcmp0))
 	CLOCK_AttachClk(kFRO_LF_DIV_to_CMP0);
 	CLOCK_SetClockDiv(kCLOCK_DivCMP0_FUNC, 1U);

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
@@ -139,4 +139,22 @@
 			slew-rate = "fast";
 		};
 	};
+
+	pinmux_i3c0: pinmux_i3c0 {
+		group0 {
+			pinmux = <I3C0_SDA_P0_20>,
+				 <I3C0_SCL_P0_21>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+			bias-pull-up;
+		};
+
+		group1 {
+			pinmux = <I3C0_PUR_P0_2>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
@@ -20,6 +20,7 @@
 		watchdog0 = &wwdt0;
 		flash-controller = &fmu;
 		die-temp0 = &temp0;
+		ambient-temp0 = &p3t1755;
 	};
 
 	leds {
@@ -255,4 +256,20 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_flexcan0>;
 	pinctrl-names = "default";
+};
+
+&i3c0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_i3c0>;
+	pinctrl-names = "default";
+
+	i2c-scl-hz = <DT_FREQ_K(400)>;
+	i3c-scl-hz = <DT_FREQ_M(4)>;
+	i3c-od-scl-hz = <DT_FREQ_K(1500)>;
+
+	p3t1755: p3t1755@4800000236152a0090 {
+		compatible = "nxp,p3t1755";
+		reg = <0x48 0x0236 0x152a0090>;
+		status = "okay";
+	};
 };

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
@@ -20,6 +20,7 @@ supported:
   - counter
   - adc
   - i2c
+  - i3c
   - spi
   - dma
   - watchdog

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -644,21 +644,43 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 	case MCUX_I3C_CLK:
 #if CONFIG_SOC_FAMILY_MCXN
 		*rate = CLOCK_GetI3cClkFreq(0);
+#elif CONFIG_SOC_SERIES_MCXAXX7
+		*rate = CLOCK_GetI3CFClkFreq(0);
 #elif CONFIG_SOC_FAMILY_MCXA
 		*rate = CLOCK_GetI3CFClkFreq();
 #else
 		*rate = CLOCK_GetI3cClkFreq();
 #endif
 		break;
-#if (FSL_FEATURE_SOC_I3C_COUNT == 2)
+#if (FSL_FEATURE_SOC_I3C_COUNT >= 2)
 	case MCUX_I3C2_CLK:
 #if CONFIG_SOC_FAMILY_MCXN
 		*rate = CLOCK_GetI3cClkFreq(1);
+#elif CONFIG_SOC_SERIES_MCXAXX7
+		*rate = CLOCK_GetI3CFClkFreq(1);
 #else
 		*rate = CLOCK_GetI3cClkFreq();
 #endif
 		break;
-#endif /* (FSL_FEATURE_SOC_I3C_COUNT == 2) */
+#endif /* (FSL_FEATURE_SOC_I3C_COUNT >= 2) */
+#if (FSL_FEATURE_SOC_I3C_COUNT >= 3)
+	case MCUX_I3C3_CLK:
+#if CONFIG_SOC_SERIES_MCXAXX7
+		*rate = CLOCK_GetI3CFClkFreq(2);
+#else
+		*rate = CLOCK_GetI3cClkFreq(2);
+#endif
+		break;
+#endif /* (FSL_FEATURE_SOC_I3C_COUNT >= 3) */
+#if (FSL_FEATURE_SOC_I3C_COUNT >= 4)
+	case MCUX_I3C4_CLK:
+#if CONFIG_SOC_SERIES_MCXAXX7
+		*rate = CLOCK_GetI3CFClkFreq(3);
+#else
+		*rate = CLOCK_GetI3cClkFreq(3);
+#endif
+		break;
+#endif /* (FSL_FEATURE_SOC_I3C_COUNT >= 4) */
 
 #endif /* CONFIG_I3C_MCUX */
 

--- a/samples/sensor/thermometer/sample.yaml
+++ b/samples/sensor/thermometer/sample.yaml
@@ -36,6 +36,7 @@ tests:
     integration_platforms:
       - frdm_mcxn947/mcxn947/cpu0 # p3t1755
       - frdm_mcxa153              # p3t1755
+      - frdm_mcxa577              # p3t1755
     depends_on:
       - i3c
     filter: dt_alias_exists("ambient-temp0")


### PR DESCRIPTION
Enable I3C0 on the FRDM-MCXA577 board and register the on-board
    NXP P3T1755 temperature sensor as an I3C device. The clock is
    sourced from FRO_LF_DIV with divider 1 (per the board SDK
    hardware_init reference). Pins P0_20 (SDA), P0_21 (SCL), and
    P0_2 (PUR) are configured via a new pinmux_i3c0 group (verified
    against the SDK BOARD_InitI3CPins implementation).

    Add the ambient-temp0 alias required by the thermometer sample,
    list i3c in the board's supported features, and add frdm_mcxa577
    to the sample.sensor.thermometer_i3c integration platforms.

    Tested by building samples/sensor/thermometer