### PR TITLE
shell: remote: Append read-only strings by default

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -441,7 +441,6 @@ if SHELL_REMOTE_CLI
 
 config SHELL_REMOTE_CLI_SKIP_RO_STRINGS
 	bool "Skip read-only strings in remote message"
-	default y
 	help
 	  When enabled, read-only strings are not included in the remote message.
 	  This can save some memory (for example, stack space) and reduces the size of


### PR DESCRIPTION
Read-only strings can only be skipped if shell main core has access to the read only memory of the remote core. By default assume that it has not access.

Fixes #112252.