### PR TITLE
include: zephyr: arch: arm: Rename header file guard macros

### DIFF
--- a/include/zephyr/arch/arm/arm-m-switch.h
+++ b/include/zephyr/arch/arm/arm-m-switch.h
@@ -14,8 +14,8 @@
  * ISR tail-fixup logic, and expose a small interface to the scheduler and
  * fault handlers.
  */
-#ifndef _ZEPHYR_ARCH_ARM_M_SWITCH_H
-#define _ZEPHYR_ARCH_ARM_M_SWITCH_H
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_ARM_M_SWITCH_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_ARM_M_SWITCH_H_
 
 #include <stdint.h>
 #include <zephyr/kernel_structs.h>
@@ -355,4 +355,4 @@ static ALWAYS_INLINE void arch_switch(void *switch_to, void **switched_from)
 }
 #endif
 
-#endif /* _ZEPHYR_ARCH_ARM_M_SWITCH_H */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_ARM_M_SWITCH_H_ */

--- a/include/zephyr/arch/arm/barrier.h
+++ b/include/zephyr/arch/arm/barrier.h
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef ZEPHYR_INCLUDE_BARRIER_ARM_H_
-#define ZEPHYR_INCLUDE_BARRIER_ARM_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_BARRIER_H_
 
 #ifndef ZEPHYR_INCLUDE_SYS_BARRIER_H_
 #error Please include <zephyr/sys/barrier.h>
@@ -40,4 +40,4 @@ static ALWAYS_INLINE void z_barrier_isync_fence_full(void)
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_BARRIER_ARM_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_BARRIER_H_ */

--- a/include/zephyr/arch/arm/cortex_a_r/mpu.h
+++ b/include/zephyr/arch/arm/cortex_a_r/mpu.h
@@ -2,8 +2,8 @@
  *
  * Copyright (c) 2019 Lexmark International, Inc.
  */
-#ifndef ARCH_ARM_CORTEX_R_MPU_H
-#define ARCH_ARM_CORTEX_R_MPU_H 1
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_A_R_MPU_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_A_R_MPU_H_
 
 #define MPU_RBAR_ADDR_Msk               (~0x1f)
 #define MPU_RASR_ENABLE_Msk             (1)
@@ -64,4 +64,4 @@
 #define ARM_MPU_REGION_SIZE_2GB         ((uint8_t)0x1eU)
 #define ARM_MPU_REGION_SIZE_4GB         ((uint8_t)0x1fU)
 
-#endif
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_A_R_MPU_H_ */

--- a/include/zephyr/arch/arm/cortex_m/cpu.h
+++ b/include/zephyr/arch/arm/cortex_m/cpu.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _CORTEX_M_CPU_H
-#define _CORTEX_M_CPU_H
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_CPU_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_CPU_H_
 
 #ifdef _ASMLANGUAGE
 
@@ -116,4 +116,4 @@ typedef struct __cpu_context _cpu_context_t;
 
 #endif /* _ASMLANGUAGE */
 
-#endif /* _CORTEX_M_CPU_H */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_CPU_H_ */

--- a/include/zephyr/arch/arm/cortex_m/scb.h
+++ b/include/zephyr/arch/arm/cortex_m/scb.h
@@ -11,8 +11,8 @@
  * System control block context helpers for backup and restore
  */
 
-#ifndef ARM_CORTEX_M_SCB_H_
-#define ARM_CORTEX_M_SCB_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_SCB_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_SCB_H_
 
 #include <stdint.h>
 #include <cmsis_core.h>
@@ -85,4 +85,4 @@ void z_arm_restore_scb_context(const struct scb_context *context);
 
 /** @} */
 
-#endif /* ARM_CORTEX_M_SCB_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_SCB_H_ */

--- a/include/zephyr/arch/arm/gdbstub.h
+++ b/include/zephyr/arch/arm/gdbstub.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_GDBSTUB_H_
-#define ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_GDBSTUB_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_GDBSTUB_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_GDBSTUB_H_
 
 #include <zephyr/arch/exception.h>
 
@@ -68,4 +68,4 @@ void z_gdb_entry(struct arch_esf *esf, unsigned int exc_cause);
 
 #endif
 
-#endif
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_GDBSTUB_H_ */

--- a/include/zephyr/arch/arm/mmu/arm_mem.h
+++ b/include/zephyr/arch/arm/mmu/arm_mem.h
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef ZEPHYR_INCLUDE_ARCH_ARM_ARM_MEM_H_
-#define ZEPHYR_INCLUDE_ARCH_ARM_ARM_MEM_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_MMU_ARM_MEM_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_MMU_ARM_MEM_H_
 
 /*
  * Define ARM specific memory flags used by k_mem_map_phys_bare()
@@ -14,4 +14,4 @@
 /** ARM Specific flags: normal memory with Non-cacheable */
 #define K_MEM_ARM_NORMAL_NC	5
 
-#endif /* ZEPHYR_INCLUDE_ARCH_ARM_ARM_MEM_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_MMU_ARM_MEM_H_ */

--- a/include/zephyr/arch/arm/mmu/arm_mmu.h
+++ b/include/zephyr/arch/arm/mmu/arm_mmu.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ARCH_AARCH32_ARM_MMU_H_
-#define ZEPHYR_INCLUDE_ARCH_AARCH32_ARM_MMU_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_MMU_ARM_MMU_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_MMU_ARM_MMU_H_
 
 #ifndef _ASMLANGUAGE
 
@@ -144,4 +144,4 @@ int z_arm_mmu_init(void);
 
 #endif /* _ASMLANGUAGE */
 
-#endif /* ZEPHYR_INCLUDE_ARCH_AARCH32_ARM_MMU_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_MMU_ARM_MMU_H_ */

--- a/include/zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_mem_cfg.h
@@ -4,8 +4,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef _INCLUDE_ZEPHYR_ARCH_ARM_MPU_MEM_CFG_H_
-#define _INCLUDE_ZEPHYR_ARCH_ARM_MPU_MEM_CFG_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_MPU_ARM_MPU_MEM_CFG_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_MPU_ARM_MPU_MEM_CFG_H_
 
 #include <zephyr/arch/arm/mpu/arm_mpu.h>
 
@@ -127,4 +127,4 @@
 
 #endif /* !ARMV8_M_BASELINE && !ARMV8_M_MAINLINE */
 
-#endif /* _INCLUDE_ZEPHYR_ARCH_ARM_MPU_MEM_CFG_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_MPU_ARM_MPU_MEM_CFG_H_ */

--- a/include/zephyr/arch/arm/mpu/arm_mpu_v7m.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_v7m.h
@@ -5,6 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_MPU_ARM_MPU_V7M_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_MPU_ARM_MPU_V7M_H_
+
 #ifndef _ASMLANGUAGE
 
 #include <cmsis_core.h>
@@ -294,3 +297,5 @@ typedef struct {
 #define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size)                                               \
 	_ARCH_MEM_PARTITION_ALIGN_CHECK_SIZE(size);                                                \
 	_ARCH_MEM_PARTITION_ALIGN_CHECK_START(start, size)
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_MPU_ARM_MPU_V7M_H_ */

--- a/include/zephyr/arch/arm/mpu/arm_mpu_v8.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_v8.h
@@ -6,6 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_MPU_ARM_MPU_V8_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_MPU_ARM_MPU_V8_H_
+
 #ifndef _ASMLANGUAGE
 
 /* Convenience macros to represent the ARMv8-M-specific
@@ -474,3 +477,5 @@ typedef struct {
 		     "The start and size of the partition must align with the minimum MPU "        \
 		     "region size.")
 #endif /* defined(__IAR_SYSTEMS_ICC__) */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_MPU_ARM_MPU_V8_H_ */

--- a/include/zephyr/arch/arm/structs.h
+++ b/include/zephyr/arch/arm/structs.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ARM_STRUCTS_H_
-#define ZEPHYR_INCLUDE_ARM_STRUCTS_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_STRUCTS_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_STRUCTS_H_
 
 #include <zephyr/types.h>
 
@@ -30,4 +30,4 @@ struct _cpu_arch {
 
 #endif
 
-#endif /* ZEPHYR_INCLUDE_ARM_STRUCTS_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_STRUCTS_H_ */


### PR DESCRIPTION
Update header files in include/zephyr/ to use a `ZEPHYR_INCLUDE_` prefixed header guard macro with the macro name matching the header file path in include/zephyr/ file tree.

These changes were made using zephyr_header_guards.py script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below:
`$ scripts/zephyr_header_guards.py --apply include/zephyr/arch/arm`