### PR TITLE
include: zephyr: arch: arm64: Rename header file guard macros

### DIFF
--- a/include/zephyr/arch/arm64/arm-smccc.h
+++ b/include/zephyr/arch/arm64/arm-smccc.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ARCH_ARM64_SMCCC_H_
-#define ZEPHYR_INCLUDE_ARCH_ARM64_SMCCC_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM64_ARM_SMCCC_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM64_ARM_SMCCC_H_
 
 /*
  * Result from SMC/HVC call
@@ -56,4 +56,4 @@ void arm_smccc_smc(unsigned long a0, unsigned long a1,
 		   unsigned long a6, unsigned long a7,
 		   struct arm_smccc_res *res);
 
-#endif /* ZEPHYR_INCLUDE_ARCH_ARM64_SMCCC_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM64_ARM_SMCCC_H_ */

--- a/include/zephyr/arch/arm64/barrier.h
+++ b/include/zephyr/arch/arm64/barrier.h
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef ZEPHYR_INCLUDE_BARRIER_ARM64_H_
-#define ZEPHYR_INCLUDE_BARRIER_ARM64_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM64_BARRIER_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM64_BARRIER_H_
 
 #ifndef ZEPHYR_INCLUDE_SYS_BARRIER_H_
 #error Please include <zephyr/sys/barrier.h>
@@ -40,4 +40,4 @@ static ALWAYS_INLINE void z_barrier_isync_fence_full(void)
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_BARRIER_ARM64_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM64_BARRIER_H_ */

--- a/include/zephyr/arch/arm64/cortex_r/arm_mpu.h
+++ b/include/zephyr/arch/arm64/cortex_r/arm_mpu.h
@@ -5,8 +5,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef ZEPHYR_INCLUDE_ARCH_ARM64_CORTEX_R_MPU_ARM_MPU_H_
-#define ZEPHYR_INCLUDE_ARCH_ARM64_CORTEX_R_MPU_ARM_MPU_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM64_CORTEX_R_ARM_MPU_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM64_CORTEX_R_ARM_MPU_H_
 
 /*
  * Convenience macros to represent the ARMv8-R64-specific configuration
@@ -261,4 +261,4 @@ struct dynamic_region_info {
 
 #endif	/* _ASMLANGUAGE */
 
-#endif	/* ZEPHYR_INCLUDE_ARCH_ARM64_CORTEX_R_MPU_ARM_MPU_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM64_CORTEX_R_ARM_MPU_H_ */

--- a/include/zephyr/arch/arm64/structs.h
+++ b/include/zephyr/arch/arm64/structs.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ARM64_STRUCTS_H_
-#define ZEPHYR_INCLUDE_ARM64_STRUCTS_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM64_STRUCTS_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM64_STRUCTS_H_
 
 /* Per CPU architecture specifics */
 struct _cpu_arch {
@@ -20,4 +20,4 @@ struct _cpu_arch {
 #endif
 };
 
-#endif /* ZEPHYR_INCLUDE_ARM64_STRUCTS_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM64_STRUCTS_H_ */


### PR DESCRIPTION
Update header files in include/zephyr/ to use a `ZEPHYR_INCLUDE_` prefixed header guard macro with the macro name matching the header file path in include/zephyr/ file tree.

These changes were made using zephyr_header_guards.py script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below:
`$ scripts/zephyr_header_guards.py --apply include/zephyr/arch/arm64`