### PR TITLE
net: ethernet: gptp: remove check for GPTP_PORT_END

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -59,7 +59,7 @@ int gptp_set_port_number(struct net_if *iface, uint16_t port)
 		return -ENODEV;
 	}
 
-	if (port < GPTP_PORT_START || port > GPTP_PORT_END) {
+	if (port < GPTP_PORT_START) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
gptp_domain.default_ds.nb_ports is only
increased after gptp_set_port_number, so
we can't use GPTP_PORT_END here because it uses it.

Without this fix, gptp does not work, as the port can not be registered.