### PR TITLE
include: zephyr: arch: Rename header file guard macros for Common

### DIFF
--- a/include/zephyr/arch/arch_inlines.h
+++ b/include/zephyr/arch/arch_inlines.h
@@ -9,8 +9,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ARCH_INLINES_H_
-#define ZEPHYR_INCLUDE_ARCH_INLINES_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_ARCH_INLINES_H_
+#define ZEPHYR_INCLUDE_ARCH_ARCH_INLINES_H_
 
 #if defined(CONFIG_X86)
 #include <zephyr/arch/x86/arch_inlines.h>
@@ -36,4 +36,4 @@
 #include <zephyr/arch/rx/arch_inlines.h>
 #endif
 
-#endif /* ZEPHYR_INCLUDE_ARCH_INLINES_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_ARCH_INLINES_H_ */

--- a/include/zephyr/arch/cfi.h
+++ b/include/zephyr/arch/cfi.h
@@ -8,8 +8,8 @@
  * DWARF Control Flow Integrity (CFI) support for architectures.
  */
 
-#ifndef ZEPHYR_INCLUDE_CFI_H_
-#define ZEPHYR_INCLUDE_CFI_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_CFI_H_
+#define ZEPHYR_INCLUDE_ARCH_CFI_H_
 
 #include <zephyr/arch/arch_interface.h>
 
@@ -38,4 +38,4 @@
 #define ARCH_CFI_UNDEFINED_RETURN_ADDRESS()
 #endif
 
-#endif /* ZEPHYR_INCLUDE_CFI_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_CFI_H_ */

--- a/include/zephyr/arch/common/addr_types.h
+++ b/include/zephyr/arch/common/addr_types.h
@@ -6,12 +6,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ARCH_X86_ADDR_TYPES_H_
-#define ZEPHYR_INCLUDE_ARCH_X86_ADDR_TYPES_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_COMMON_ADDR_TYPES_H_
+#define ZEPHYR_INCLUDE_ARCH_COMMON_ADDR_TYPES_H_
 
 #ifndef _ASMLANGUAGE
 typedef uintptr_t paddr_t;
 typedef void *vaddr_t;
 #endif
 
-#endif /* ZEPHYR_INCLUDE_ARCH_X86_ADDR_TYPES_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_COMMON_ADDR_TYPES_H_ */

--- a/include/zephyr/arch/common/exc_handle.h
+++ b/include/zephyr/arch/common/exc_handle.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_EXC_HANDLE_H_
-#define ZEPHYR_INCLUDE_EXC_HANDLE_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_COMMON_EXC_HANDLE_H_
+#define ZEPHYR_INCLUDE_ARCH_COMMON_EXC_HANDLE_H_
 
 /*
  * This is used by some architectures to define code ranges which may
@@ -42,4 +42,4 @@ struct z_exc_handle {
 	void name ## _fault_end(void);   \
 	void name ## _fixup(void)
 
-#endif /* ZEPHYR_INCLUDE_EXC_HANDLE_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_COMMON_EXC_HANDLE_H_ */

--- a/include/zephyr/arch/common/init.h
+++ b/include/zephyr/arch/common/init.h
@@ -3,8 +3,8 @@
  * Copyright The Zephyr Project Contributors
  */
 
-#ifndef ZEPHYR_ARCH_COMMON_INIT_H_
-#define ZEPHYR_ARCH_COMMON_INIT_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_COMMON_INIT_H_
+#define ZEPHYR_INCLUDE_ARCH_COMMON_INIT_H_
 
 FUNC_NORETURN void z_cstart(void);
 
@@ -23,4 +23,4 @@ static inline void arch_bss_zero_boot(void)
 }
 #endif /* CONFIG_LINKER_USE_BOOT_SECTION */
 
-#endif /* ZEPHYR_ARCH_COMMON_INIT_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_COMMON_INIT_H_ */

--- a/include/zephyr/arch/common/xip.h
+++ b/include/zephyr/arch/common/xip.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_ARCH_INCLUDE_XIP_H_
-#define ZEPHYR_ARCH_INCLUDE_XIP_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_COMMON_XIP_H_
+#define ZEPHYR_INCLUDE_ARCH_COMMON_XIP_H_
 
 #ifndef _ASMLANGUAGE
 #ifdef __cplusplus
@@ -24,4 +24,4 @@ static inline void arch_data_copy(void)
 #endif
 
 #endif	/* _ASMLANGUAGE */
-#endif /* ZEPHYR_ARCH_INCLUDE_XIP_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_COMMON_XIP_H_ */

--- a/include/zephyr/arch/openrisc/irq.h
+++ b/include/zephyr/arch/openrisc/irq.h
@@ -9,8 +9,8 @@
  * @brief OpenRISC public interrupt handling
  */
 
-#ifndef ZEPHYR_INCLUDE_ARCH_OR1K_IRQ_H_
-#define ZEPHYR_INCLUDE_ARCH_OR1K_IRQ_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_OPENRISC_IRQ_H_
+#define ZEPHYR_INCLUDE_ARCH_OPENRISC_IRQ_H_
 
 #include <openrisc/openriscregs.h>
 
@@ -122,4 +122,4 @@ static ALWAYS_INLINE int arch_irq_is_enabled(unsigned int irq)
 	return (openrisc_read_spr(SPR_PICMR) & BIT(irq)) != 0;
 }
 
-#endif /* ZEPHYR_INCLUDE_ARCH_OR1K_IRQ_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_OPENRISC_IRQ_H_ */

--- a/include/zephyr/arch/riscv/csr.h
+++ b/include/zephyr/arch/riscv/csr.h
@@ -6,8 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef CSR_H_
-#define CSR_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_RISCV_CSR_H_
+#define ZEPHYR_INCLUDE_ARCH_RISCV_CSR_H_
 
 #define MSTATUS_UIE	0x00000001
 #define MSTATUS_SIE	0x00000002
@@ -299,4 +299,4 @@
 
 #endif /* !_ASMLANGUAGE */
 
-#endif /* CSR_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_RISCV_CSR_H_ */

--- a/include/zephyr/arch/riscv/elf.h
+++ b/include/zephyr/arch/riscv/elf.h
@@ -10,8 +10,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef ZEPHYR_ARCH_RISCV_ELF_H
-#define ZEPHYR_ARCH_RISCV_ELF_H
+#ifndef ZEPHYR_INCLUDE_ARCH_RISCV_ELF_H_
+#define ZEPHYR_INCLUDE_ARCH_RISCV_ELF_H_
 
 #include <stdint.h>
 #include <zephyr/sys/util_macro.h>
@@ -295,4 +295,4 @@ typedef uint32_t r_riscv_wordclass_t;
 }
 #endif
 
-#endif /* ZEPHYR_ARCH_RISCV_ELF_H */
+#endif /* ZEPHYR_INCLUDE_ARCH_RISCV_ELF_H_ */

--- a/include/zephyr/arch/riscv/pmp.h
+++ b/include/zephyr/arch/riscv/pmp.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_RISCV_PMP_H_
-#define ZEPHYR_INCLUDE_RISCV_PMP_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_RISCV_PMP_H_
+#define ZEPHYR_INCLUDE_ARCH_RISCV_PMP_H_
 
 #include <zephyr/arch/riscv/arch.h>
 #include <zephyr/sys/iterable_sections.h>
@@ -89,4 +89,4 @@ int z_riscv_pmp_change_permissions(size_t region_idx, uint8_t perm);
  */
 void z_riscv_pmp_clear_all(void);
 
-#endif /* ZEPHYR_INCLUDE_RISCV_PMP_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_RISCV_PMP_H_ */

--- a/include/zephyr/arch/riscv/sbi.h
+++ b/include/zephyr/arch/riscv/sbi.h
@@ -18,8 +18,8 @@
  * (https://github.com/riscv-non-isa/riscv-sbi-doc)
  */
 
-#ifndef ZEPHYR_ARCH_RISCV_INCLUDE_SBI_H_
-#define ZEPHYR_ARCH_RISCV_INCLUDE_SBI_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_RISCV_SBI_H_
+#define ZEPHYR_INCLUDE_ARCH_RISCV_SBI_H_
 
 /** @brief SBI extension ID for the Timer extension (TIME) */
 #define SBI_EXT_TIME			0x54494D45
@@ -48,4 +48,4 @@
 /** @brief SBI return code: requested extension/function is not available */
 #define SBI_ERR_NOT_SUPPORTED		-1
 
-#endif /* ZEPHYR_ARCH_RISCV_INCLUDE_SBI_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_RISCV_SBI_H_ */

--- a/include/zephyr/arch/riscv/structs.h
+++ b/include/zephyr/arch/riscv/structs.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_RISCV_STRUCTS_H_
-#define ZEPHYR_INCLUDE_RISCV_STRUCTS_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_RISCV_STRUCTS_H_
+#define ZEPHYR_INCLUDE_ARCH_RISCV_STRUCTS_H_
 
 /* Per CPU architecture specifics */
 struct _cpu_arch {
@@ -33,4 +33,4 @@ struct _cpu_arch {
 BUILD_ASSERT(sizeof(struct _cpu_arch) >= 1);
 #endif
 
-#endif /* ZEPHYR_INCLUDE_RISCV_STRUCTS_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_RISCV_STRUCTS_H_ */

--- a/include/zephyr/arch/rx/arch_inlines.h
+++ b/include/zephyr/arch/rx/arch_inlines.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ARCH_RX_INLINES_H
-#define ZEPHYR_INCLUDE_ARCH_RX_INLINES_H
+#ifndef ZEPHYR_INCLUDE_ARCH_RX_ARCH_INLINES_H_
+#define ZEPHYR_INCLUDE_ARCH_RX_ARCH_INLINES_H_
 
 #include <zephyr/kernel_structs.h>
 
@@ -14,4 +14,4 @@ static ALWAYS_INLINE unsigned int arch_num_cpus(void)
 	return CONFIG_MP_MAX_NUM_CPUS;
 }
 
-#endif /* ZEPHYR_INCLUDE_ARCH_RX_INLINES_H */
+#endif /* ZEPHYR_INCLUDE_ARCH_RX_ARCH_INLINES_H_ */

--- a/include/zephyr/arch/rx/exception.h
+++ b/include/zephyr/arch/rx/exception.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ARCH_RX_INLINES_H_
-#define ZEPHYR_INCLUDE_ARCH_RX_INLINES_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_RX_EXCEPTION_H_
+#define ZEPHYR_INCLUDE_ARCH_RX_EXCEPTION_H_
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/types.h>
@@ -42,4 +42,4 @@ struct arch_esf {
 
 #endif /* _ASMLANGUAGE */
 
-#endif /* ZEPHYR_INCLUDE_ARCH_RX_INLINES_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_RX_EXCEPTION_H_ */

--- a/include/zephyr/arch/x86/efi.h
+++ b/include/zephyr/arch/x86/efi.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_ARCH_X86_INCLUDE_EFI_H_
-#define ZEPHYR_ARCH_X86_INCLUDE_EFI_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_X86_EFI_H_
+#define ZEPHYR_INCLUDE_ARCH_X86_EFI_H_
 
 /* Boot type value (see prep_c.c) */
 #define EFI_BOOT_TYPE 2
@@ -41,4 +41,4 @@ void *efi_get_acpi_rsdp(void);
 
 #endif /* _ASMLANGUAGE */
 
-#endif /* ZEPHYR_ARCH_X86_INCLUDE_EFI_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_X86_EFI_H_ */

--- a/include/zephyr/arch/x86/ia32/gdbstub.h
+++ b/include/zephyr/arch/x86/ia32/gdbstub.h
@@ -9,8 +9,8 @@
  * @brief IA-32 specific gdbstub interface header
  */
 
-#ifndef ZEPHYR_INCLUDE_ARCH_X86_GDBSTUB_SYS_H_
-#define ZEPHYR_INCLUDE_ARCH_X86_GDBSTUB_SYS_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_X86_IA32_GDBSTUB_H_
+#define ZEPHYR_INCLUDE_ARCH_X86_IA32_GDBSTUB_H_
 
 #ifndef _ASMLANGUAGE
 
@@ -82,4 +82,4 @@ struct gdb_ctx {
 
 #endif /* _ASMLANGUAGE */
 
-#endif /* ZEPHYR_INCLUDE_ARCH_X86_GDBSTUB_SYS_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_X86_IA32_GDBSTUB_H_ */

--- a/include/zephyr/arch/x86/ia32/structs.h
+++ b/include/zephyr/arch/x86/ia32/structs.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_X86_STRUCTS_H_
-#define ZEPHYR_INCLUDE_X86_STRUCTS_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_X86_IA32_STRUCTS_H_
+#define ZEPHYR_INCLUDE_ARCH_X86_IA32_STRUCTS_H_
 
 #include <stdint.h>
 
@@ -37,4 +37,4 @@ struct _cpu_arch {
 #endif
 };
 
-#endif /* ZEPHYR_INCLUDE_X86_STRUCTS_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_X86_IA32_STRUCTS_H_ */

--- a/include/zephyr/arch/x86/legacy_bios.h
+++ b/include/zephyr/arch/x86/legacy_bios.h
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_ARCH_X86_INCLUDE_LEGACY_BIOS_H_
-#define ZEPHYR_ARCH_X86_INCLUDE_LEGACY_BIOS_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_X86_LEGACY_BIOS_H_
+#define ZEPHYR_INCLUDE_ARCH_X86_LEGACY_BIOS_H_
 
 void *bios_acpi_rsdp_get(void);
 
-#endif /* ZEPHYR_ARCH_X86_INCLUDE_LEGACY_BIOS_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_X86_LEGACY_BIOS_H_ */

--- a/include/zephyr/arch/x86/mmustructs.h
+++ b/include/zephyr/arch/x86/mmustructs.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ARCH_X86_MMU_H
-#define ZEPHYR_INCLUDE_ARCH_X86_MMU_H
+#ifndef ZEPHYR_INCLUDE_ARCH_X86_MMUSTRUCTS_H_
+#define ZEPHYR_INCLUDE_ARCH_X86_MMUSTRUCTS_H_
 
 #include <zephyr/sys/util.h>
 
@@ -96,4 +96,4 @@ struct arch_mem_domain {
 };
 #endif /* CONFIG_X86_PAE */
 #endif /* _ASMLANGUAGE */
-#endif /* ZEPHYR_INCLUDE_ARCH_X86_MMU_H */
+#endif /* ZEPHYR_INCLUDE_ARCH_X86_MMUSTRUCTS_H_ */

--- a/include/zephyr/arch/x86/x86_acpi.h
+++ b/include/zephyr/arch/x86/x86_acpi.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef ZEPHYR_INCLUDE_ARCH_X86_X86_ACPI_H_
+#define ZEPHYR_INCLUDE_ARCH_X86_X86_ACPI_H_
+
 /**
  * @brief Encode interrupt flag for x86 architecture.
  *
@@ -12,3 +15,5 @@
  * @return return encoded interrupt flag
  */
 uint32_t arch_acpi_encode_irq_flags(uint8_t polarity, uint8_t trigger);
+
+#endif /* ZEPHYR_INCLUDE_ARCH_X86_X86_ACPI_H_ */

--- a/include/zephyr/arch/x86/x86_acpi_osal.h
+++ b/include/zephyr/arch/x86/x86_acpi_osal.h
@@ -6,8 +6,8 @@
 #include <zephyr/arch/x86/efi.h>
 #include <zephyr/arch/x86/legacy_bios.h>
 
-#ifndef ZEPHYR_ARCH_X86_INCLUDE_X86_ACPI_H_
-#define ZEPHYR_ARCH_X86_INCLUDE_X86_ACPI_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_X86_X86_ACPI_OSAL_H_
+#define ZEPHYR_INCLUDE_ARCH_X86_X86_ACPI_OSAL_H_
 
 #if defined(CONFIG_X86_EFI)
 static inline void *acpi_rsdp_get(void)
@@ -31,4 +31,4 @@ static inline uint64_t acpi_timer_get(void)
 {
 	return z_tsc_read();
 }
-#endif /* ZEPHYR_ARCH_X86_INCLUDE_X86_ACPI_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_X86_X86_ACPI_OSAL_H_ */

--- a/include/zephyr/arch/xtensa/atomic_xtensa.h
+++ b/include/zephyr/arch/xtensa/atomic_xtensa.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ATOMIC_XTENSA_H_
-#define ZEPHYR_INCLUDE_ATOMIC_XTENSA_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_XTENSA_ATOMIC_XTENSA_H_
+#define ZEPHYR_INCLUDE_ARCH_XTENSA_ATOMIC_XTENSA_H_
 
 /* Included from <zephyr/sys/atomic.h> */
 
@@ -221,4 +221,4 @@ static ALWAYS_INLINE void *atomic_ptr_clear(atomic_ptr_t *target)
 	return (void *) atomic_set((atomic_t *) target, 0);
 }
 
-#endif /* ZEPHYR_INCLUDE_ATOMIC_XTENSA_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_ATOMIC_XTENSA_H_ */

--- a/include/zephyr/arch/xtensa/gdbstub.h
+++ b/include/zephyr/arch/xtensa/gdbstub.h
@@ -6,8 +6,8 @@
 
 #include <inttypes.h>
 
-#ifndef ZEPHYR_INCLUDE_ARCH_XTENSA_GDBSTUB_SYS_H_
-#define ZEPHYR_INCLUDE_ARCH_XTENSA_GDBSTUB_SYS_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_XTENSA_GDBSTUB_H_
+#define ZEPHYR_INCLUDE_ARCH_XTENSA_GDBSTUB_H_
 
 #ifdef CONFIG_GDBSTUB
 
@@ -171,4 +171,4 @@ static inline bool gdb_xtensa_is_user_reg(struct xtensa_register *reg)
 
 #endif /* CONFIG_GDBSTUB */
 
-#endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_GDBSTUB_SYS_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_GDBSTUB_H_ */

--- a/include/zephyr/arch/xtensa/irq.h
+++ b/include/zephyr/arch/xtensa/irq.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ARCH_XTENSA_XTENSA_IRQ_H_
-#define ZEPHYR_INCLUDE_ARCH_XTENSA_XTENSA_IRQ_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_XTENSA_IRQ_H_
+#define ZEPHYR_INCLUDE_ARCH_XTENSA_IRQ_H_
 
 #include <stdint.h>
 
@@ -303,4 +303,4 @@ int xtensa_irq_is_enabled(unsigned int irq);
 
 #include <zephyr/irq.h>
 
-#endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_XTENSA_IRQ_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_IRQ_H_ */

--- a/include/zephyr/arch/xtensa/mpu.h
+++ b/include/zephyr/arch/xtensa/mpu.h
@@ -11,8 +11,8 @@
 
 #include <xtensa/config/core-isa.h>
 
-#ifndef ZEPHYR_INCLUDE_ARCH_XTENSA_XTENSA_MPU_H
-#define ZEPHYR_INCLUDE_ARCH_XTENSA_XTENSA_MPU_H
+#ifndef ZEPHYR_INCLUDE_ARCH_XTENSA_MPU_H_
+#define ZEPHYR_INCLUDE_ARCH_XTENSA_MPU_H_
 
 /**
  * @defgroup xtensa_mpu_apis Xtensa Memory Protection Unit (MPU) APIs
@@ -347,4 +347,4 @@ void xtensa_mpu_init(void);
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_XTENSA_MPU_H */
+#endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_MPU_H_ */

--- a/include/zephyr/arch/xtensa/structs.h
+++ b/include/zephyr/arch/xtensa/structs.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_XTENSA_STRUCTS_H_
-#define ZEPHYR_INCLUDE_XTENSA_STRUCTS_H_
+#ifndef ZEPHYR_INCLUDE_ARCH_XTENSA_STRUCTS_H_
+#define ZEPHYR_INCLUDE_ARCH_XTENSA_STRUCTS_H_
 
 /* Per CPU architecture specifics */
 struct _cpu_arch {
@@ -20,4 +20,4 @@ struct _cpu_arch {
 #endif
 };
 
-#endif /* ZEPHYR_INCLUDE_XTENSA_STRUCTS_H_ */
+#endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_STRUCTS_H_ */


### PR DESCRIPTION
Update header files in include/zephyr/ to use a `ZEPHYR_INCLUDE_` prefixed header guard macro with the macro name matching the header file path in include/zephyr/ file tree.

These changes were made using **zephyr_header_guards.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below and manually select changes: 
```
$ scripts/zephyr_header_guard-SAVEs.py -v --apply \
    `./scripts/get_maintainer.py list "Common Architecture Interface"