### PR TITLE
include: zephyr: logging: Rename header file guard macros

### DIFF
--- a/include/zephyr/logging/log_backend_adsp_hda.h
+++ b/include/zephyr/logging/log_backend_adsp_hda.h
@@ -10,8 +10,8 @@
  * @ingroup log_backend_adsp_hda
  */
 
-#ifndef ZEPHYR_LOG_BACKEND_ADSP_HDA_H_
-#define ZEPHYR_LOG_BACKEND_ADSP_HDA_H_
+#ifndef ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_ADSP_HDA_H_
+#define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_ADSP_HDA_H_
 
 /**
  * @brief Intel ADSP HDA log backend API
@@ -44,4 +44,4 @@ void adsp_hda_log_init(adsp_hda_log_hook_t hook, uint32_t channel);
 
 /** @} */
 
-#endif /* ZEPHYR_LOG_BACKEND_ADSP_HDA_H_ */
+#endif /* ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_ADSP_HDA_H_ */

--- a/include/zephyr/logging/log_backend_adsp_mtrace.h
+++ b/include/zephyr/logging/log_backend_adsp_mtrace.h
@@ -10,8 +10,8 @@
  * @ingroup log_backend_adsp_mtrace
  */
 
-#ifndef ZEPHYR_LOG_BACKEND_ADSP_MTRACE_H_
-#define ZEPHYR_LOG_BACKEND_ADSP_MTRACE_H_
+#ifndef ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_ADSP_MTRACE_H_
+#define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_ADSP_MTRACE_H_
 
 /**
  * @brief Intel ADSP mtrace log backend API
@@ -44,4 +44,4 @@ const struct log_backend *log_backend_adsp_mtrace_get(void);
 
 /** @} */
 
-#endif /* ZEPHYR_LOG_BACKEND_ADSP_MTRACE_H_ */
+#endif /* ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_ADSP_MTRACE_H_ */

--- a/include/zephyr/logging/log_backend_ble.h
+++ b/include/zephyr/logging/log_backend_ble.h
@@ -10,8 +10,8 @@
  * @ingroup log_backend_ble
  */
 
-#ifndef ZEPHYR_LOG_BACKEND_BLE_H_
-#define ZEPHYR_LOG_BACKEND_BLE_H_
+#ifndef ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_BLE_H_
+#define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_BLE_H_
 
 /**
  * @brief Bluetooth log backend API
@@ -54,4 +54,4 @@ void logger_backend_ble_set_hook(logger_backend_ble_hook hook, void *ctx);
 
 /** @} */
 
-#endif /* ZEPHYR_LOG_BACKEND_BLE_H_ */
+#endif /* ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_BLE_H_ */

--- a/include/zephyr/logging/log_backend_net.h
+++ b/include/zephyr/logging/log_backend_net.h
@@ -10,8 +10,8 @@
  * @ingroup log_backend_net
  */
 
-#ifndef ZEPHYR_LOG_BACKEND_NET_H_
-#define ZEPHYR_LOG_BACKEND_NET_H_
+#ifndef ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_NET_H_
+#define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_NET_H_
 
 /**
  * @brief Network log backend API
@@ -96,4 +96,4 @@ void log_backend_net_start(void);
 
 /** @} */
 
-#endif /* ZEPHYR_LOG_BACKEND_NET_H_ */
+#endif /* ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_NET_H_ */

--- a/include/zephyr/logging/log_backend_std.h
+++ b/include/zephyr/logging/log_backend_std.h
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef ZEPHYR_LOG_BACKEND_STD_H_
-#define ZEPHYR_LOG_BACKEND_STD_H_
+#ifndef ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_STD_H_
+#define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_STD_H_
 
 #include <zephyr/logging/log_msg.h>
 #include <zephyr/logging/log_output.h>
@@ -94,4 +94,4 @@ log_backend_std_dropped(const struct log_output *const output, uint32_t cnt)
 }
 #endif
 
-#endif /* ZEPHYR_LOG_BACKEND_STD_H_ */
+#endif /* ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_STD_H_ */

--- a/include/zephyr/logging/log_backend_ws.h
+++ b/include/zephyr/logging/log_backend_ws.h
@@ -10,8 +10,8 @@
  * @ingroup log_backend_ws
  */
 
-#ifndef ZEPHYR_LOG_BACKEND_WS_H_
-#define ZEPHYR_LOG_BACKEND_WS_H_
+#ifndef ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_WS_H_
+#define ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_WS_H_
 
 /**
  * @brief Websocket log backend API
@@ -68,4 +68,4 @@ void log_backend_ws_start(void);
 
 /** @} */
 
-#endif /* ZEPHYR_LOG_BACKEND_WS_H_ */
+#endif /* ZEPHYR_INCLUDE_LOGGING_LOG_BACKEND_WS_H_ */

--- a/include/zephyr/logging/log_frontend.h
+++ b/include/zephyr/logging/log_frontend.h
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef LOG_FRONTEND_H_
-#define LOG_FRONTEND_H_
+#ifndef ZEPHYR_INCLUDE_LOGGING_LOG_FRONTEND_H_
+#define ZEPHYR_INCLUDE_LOGGING_LOG_FRONTEND_H_
 
 #include <zephyr/logging/log_core.h>
 
@@ -81,4 +81,4 @@ void log_frontend_simple_2(const void *source, uint32_t level,
 /** @brief Panic state notification. */
 void log_frontend_panic(void);
 
-#endif /* LOG_FRONTEND_H_ */
+#endif /* ZEPHYR_INCLUDE_LOGGING_LOG_FRONTEND_H_ */


### PR DESCRIPTION
Update header files in include/zephyr/ to use a `ZEPHYR_INCLUDE_` prefixed header guard macro with the macro name matching the header file path in include/zephyr/ file tree.

These changes were made using **zephyr_header_guards.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below and manually select changes: 
`$ scripts/zephyr_header_guards.py -v --apply include/zephyr/logging/`