### PR TITLE
include: zephyr: usb_c: Rename header file guard macros for Common

### DIFF
--- a/include/zephyr/drivers/usb_c/tcpci_priv.h
+++ b/include/zephyr/drivers/usb_c/tcpci_priv.h
@@ -12,8 +12,8 @@
  * TCPCI generic functionality and register operations.
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_USBC_TCPCI_PRIV_H_
-#define ZEPHYR_INCLUDE_DRIVERS_USBC_TCPCI_PRIV_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_USB_C_TCPCI_PRIV_H_
+#define ZEPHYR_INCLUDE_DRIVERS_USB_C_TCPCI_PRIV_H_
 
 #include <stdint.h>
 #include <zephyr/drivers/i2c.h>
@@ -326,4 +326,4 @@ int tcpci_tcpm_set_debug_accessory(const struct i2c_dt_spec *bus, bool enable);
  */
 int tcpci_tcpm_set_low_power_mode(const struct i2c_dt_spec *bus, bool enable);
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_USBC_TCPCI_PRIV_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_USB_C_TCPCI_PRIV_H_ */

--- a/include/zephyr/drivers/usb_c/usbc_pd.h
+++ b/include/zephyr/drivers/usb_c/usbc_pd.h
@@ -11,8 +11,8 @@
  * Specification Revision 3.0, Version 2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_PD_H_
-#define ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_PD_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_PD_H_
+#define ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_PD_H_
 
 /**
  * @brief USB Power Delivery
@@ -1056,4 +1056,4 @@ struct pd_msg {
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_PD_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_PD_H_ */

--- a/include/zephyr/drivers/usb_c/usbc_ppc.h
+++ b/include/zephyr/drivers/usb_c/usbc_ppc.h
@@ -9,8 +9,8 @@
  *
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_PPC_H_
-#define ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_PPC_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_PPC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_PPC_H_
 
 /**
  * @brief USB Type-C Power Path Controller
@@ -305,4 +305,4 @@ static inline int ppc_dump_regs(const struct device *dev)
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_PPC_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_PPC_H_ */

--- a/include/zephyr/drivers/usb_c/usbc_tc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tc.h
@@ -13,8 +13,8 @@
  * Cable and Connector Specification Release 2.1
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_TC_H_
-#define ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_TC_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_TC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_TC_H_
 
 /**
  * @brief Support for USB Type-C cables and connectors
@@ -472,4 +472,4 @@ enum tc_cc_states {
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_TC_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_TC_H_ */

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -12,8 +12,8 @@
  * APIs described in this file.
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_TCPC_H_
-#define ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_TCPC_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_TCPC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_TCPC_H_
 
 /**
  * @brief USB Type-C Port Controller API
@@ -1158,4 +1158,4 @@ static inline int tcpc_sop_prime_enable(const struct device *dev, bool enable)
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_TCPC_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_TCPC_H_ */

--- a/include/zephyr/drivers/usb_c/usbc_vbus.h
+++ b/include/zephyr/drivers/usb_c/usbc_vbus.h
@@ -12,8 +12,8 @@
  * implement the APIs described in this file.
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_USBC_VBUS_H_
-#define ZEPHYR_INCLUDE_DRIVERS_USBC_VBUS_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_VBUS_H_
+#define ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_VBUS_H_
 
 /**
  * @brief USB-C VBUS API
@@ -120,4 +120,4 @@ static inline int usbc_vbus_enable(const struct device *dev, bool enable)
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_USBC_VBUS_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_USB_C_USBC_VBUS_H_ */

--- a/include/zephyr/dt-bindings/usb-c/nxp_nx20p3483.h
+++ b/include/zephyr/dt-bindings/usb-c/nxp_nx20p3483.h
@@ -8,8 +8,8 @@
  * @brief Values used to define the sink overvoltage and source overcurrent protections thresholds.
  */
 
-#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_USBC_NXP_NX20P3483_H_
-#define ZEPHYR_INCLUDE_DT_BINDINGS_USBC_NXP_NX20P3483_H_
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_USB_C_NXP_NX20P3483_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_USB_C_NXP_NX20P3483_H_
 
 /** Voltage limit of 6.0V */
 #define NX20P3483_U_THRESHOLD_6_0 0
@@ -59,4 +59,4 @@
 /** Current limit of 3400mA */
 #define NX20P3483_I_THRESHOLD_3_400 15
 
-#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_USBC_NXP_NX20P3483_H_ */
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_USB_C_NXP_NX20P3483_H_ */

--- a/include/zephyr/dt-bindings/usb-c/pd.h
+++ b/include/zephyr/dt-bindings/usb-c/pd.h
@@ -5,8 +5,8 @@
  * This is based on Linux, documentation:
  *   https://github.com/torvalds/linux/blob/v5.19/include/dt-bindings/usb/pd.h
  */
-#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_USBC_PD_H_
-#define ZEPHYR_INCLUDE_DT_BINDINGS_USBC_PD_H_
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_USB_C_PD_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_USB_C_PD_H_
 
 /**
  * @file
@@ -170,4 +170,4 @@
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_USBC_PD_H_ */
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_USB_C_PD_H_ */

--- a/include/zephyr/usb_c/usbc.h
+++ b/include/zephyr/usb_c/usbc.h
@@ -10,8 +10,8 @@
  * This file contains the USB-C Device APIs.
  */
 
-#ifndef ZEPHYR_INCLUDE_USBC_H_
-#define ZEPHYR_INCLUDE_USBC_H_
+#ifndef ZEPHYR_INCLUDE_USB_C_USBC_H_
+#define ZEPHYR_INCLUDE_USB_C_USBC_H_
 
 #include <zephyr/types.h>
 #include <zephyr/device.h>
@@ -540,4 +540,4 @@ void usbc_set_policy_cb_set_port_partner_snk_cap(const struct device *dev,
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_USBC_H_ */
+#endif /* ZEPHYR_INCLUDE_USB_C_USBC_H_ */


### PR DESCRIPTION
Update header files in include/zephyr/ to use a `ZEPHYR_INCLUDE_` prefixed header guard macro with the macro name matching the header file path in include/zephyr/ file tree.

These changes were made using **zephyr_header_guards.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below and manually select changes: 
```
$ scripts/zephyr_header_guards.py -v --apply \
    `./scripts/get_maintainer.py list "USB-C"