### PR TITLE
include: zephyr: usb: Rename header file guard macros for Common

### DIFF
--- a/include/zephyr/drivers/usb/udc.h
+++ b/include/zephyr/drivers/usb/udc.h
@@ -9,8 +9,8 @@
  * @brief New USB device controller (UDC) driver API
  */
 
-#ifndef ZEPHYR_INCLUDE_UDC_H
-#define ZEPHYR_INCLUDE_UDC_H
+#ifndef ZEPHYR_INCLUDE_DRIVERS_USB_UDC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_USB_UDC_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
@@ -809,4 +809,4 @@ static inline uint16_t udc_mps_ep_size(const struct udc_ep_config *const cfg)
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_UDC_H */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_USB_UDC_H_ */

--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -9,8 +9,8 @@
  * @brief USB host controller (UHC) driver API
  */
 
-#ifndef ZEPHYR_INCLUDE_UHC_H
-#define ZEPHYR_INCLUDE_UHC_H
+#ifndef ZEPHYR_INCLUDE_DRIVERS_USB_UHC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_USB_UHC_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
@@ -620,4 +620,4 @@ static inline const void *uhc_get_event_ctx(const struct device *dev)
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_UHC_H */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_USB_UHC_H_ */

--- a/include/zephyr/drivers/usb/usb_buf.h
+++ b/include/zephyr/drivers/usb/usb_buf.h
@@ -9,8 +9,8 @@
  * @brief Buffers for USB device support
  */
 
-#ifndef ZEPHYR_INCLUDE_USB_BUF_H
-#define ZEPHYR_INCLUDE_USB_BUF_H
+#ifndef ZEPHYR_INCLUDE_DRIVERS_USB_USB_BUF_H_
+#define ZEPHYR_INCLUDE_DRIVERS_USB_USB_BUF_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
@@ -222,4 +222,4 @@ extern const struct net_buf_data_cb net_buf_dma_cb;
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_UDC_BUF_H */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_USB_USB_BUF_H_ */

--- a/include/zephyr/usb/class/usb_audio.h
+++ b/include/zephyr/usb/class/usb_audio.h
@@ -18,8 +18,8 @@
  * - USB Device Class Definition for Terminal Types (termt10.pdf)
  */
 
-#ifndef ZEPHYR_INCLUDE_USB_CLASS_AUDIO_H_
-#define ZEPHYR_INCLUDE_USB_CLASS_AUDIO_H_
+#ifndef ZEPHYR_INCLUDE_USB_CLASS_USB_AUDIO_H_
+#define ZEPHYR_INCLUDE_USB_CLASS_USB_AUDIO_H_
 
 #include <zephyr/usb/usb_ch9.h>
 #include <zephyr/device.h>
@@ -335,4 +335,4 @@ __deprecated void usb_audio_register(const struct device *dev,
 __deprecated int usb_audio_send(const struct device *dev, struct net_buf *buffer,
 		   size_t len);
 
-#endif /* ZEPHYR_INCLUDE_USB_CLASS_AUDIO_H_ */
+#endif /* ZEPHYR_INCLUDE_USB_CLASS_USB_AUDIO_H_ */

--- a/include/zephyr/usb/class/usb_hid.h
+++ b/include/zephyr/usb/class/usb_hid.h
@@ -10,8 +10,8 @@
  * @brief USB HID Class device API header
  */
 
-#ifndef ZEPHYR_INCLUDE_USB_HID_CLASS_DEVICE_H_
-#define ZEPHYR_INCLUDE_USB_HID_CLASS_DEVICE_H_
+#ifndef ZEPHYR_INCLUDE_USB_CLASS_USB_HID_H_
+#define ZEPHYR_INCLUDE_USB_CLASS_USB_HID_H_
 
 #include <zephyr/usb/class/hid.h>
 #include <zephyr/usb/usb_ch9.h>
@@ -147,4 +147,4 @@ __deprecated int usb_hid_init(const struct device *dev);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_USB_HID_CLASS_DEVICE_H_ */
+#endif /* ZEPHYR_INCLUDE_USB_CLASS_USB_HID_H_ */

--- a/include/zephyr/usb/class/usbd_hid.h
+++ b/include/zephyr/usb/class/usbd_hid.h
@@ -9,8 +9,8 @@
  * @brief USBD HID device API header
  */
 
-#ifndef ZEPHYR_INCLUDE_USBD_HID_CLASS_DEVICE_H_
-#define ZEPHYR_INCLUDE_USBD_HID_CLASS_DEVICE_H_
+#ifndef ZEPHYR_INCLUDE_USB_CLASS_USBD_HID_H_
+#define ZEPHYR_INCLUDE_USB_CLASS_USBD_HID_H_
 
 #include <stdint.h>
 #include <zephyr/device.h>
@@ -264,4 +264,4 @@ int hid_device_set_out_polling(const struct device *dev, const unsigned int peri
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_USBD_HID_CLASS_DEVICE_H_ */
+#endif /* ZEPHYR_INCLUDE_USB_CLASS_USBD_HID_H_ */

--- a/include/zephyr/usb/class/usbd_midi2.h
+++ b/include/zephyr/usb/class/usbd_midi2.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_USB_CLASS_USBD_MIDI_H_
-#define ZEPHYR_INCLUDE_USB_CLASS_USBD_MIDI_H_
+#ifndef ZEPHYR_INCLUDE_USB_CLASS_USBD_MIDI2_H_
+#define ZEPHYR_INCLUDE_USB_CLASS_USBD_MIDI2_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,4 +69,4 @@ void usbd_midi_set_ops(const struct device *dev, const struct usbd_midi_ops *ops
 }
 #endif
 
-#endif
+#endif /* ZEPHYR_INCLUDE_USB_CLASS_USBD_MIDI2_H_ */

--- a/include/zephyr/usb/usb_ch9.h
+++ b/include/zephyr/usb/usb_ch9.h
@@ -17,8 +17,8 @@
 #include <zephyr/math/ilog2.h>
 #include <zephyr/usb/class/usb_hub.h>
 
-#ifndef ZEPHYR_INCLUDE_USB_CH9_H_
-#define ZEPHYR_INCLUDE_USB_CH9_H_
+#ifndef ZEPHYR_INCLUDE_USB_USB_CH9_H_
+#define ZEPHYR_INCLUDE_USB_USB_CH9_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -765,4 +765,4 @@ struct usb_association_descriptor {
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_USB_CH9_H_ */
+#endif /* ZEPHYR_INCLUDE_USB_USB_CH9_H_ */

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -11,8 +11,8 @@
  * This file contains the USB device stack APIs and structures.
  */
 
-#ifndef ZEPHYR_INCLUDE_USBD_H_
-#define ZEPHYR_INCLUDE_USBD_H_
+#ifndef ZEPHYR_INCLUDE_USB_USBD_H_
+#define ZEPHYR_INCLUDE_USB_USBD_H_
 
 #include <zephyr/device.h>
 #include <zephyr/usb/bos.h>
@@ -1284,4 +1284,4 @@ int usbd_device_register_vreq(struct usbd_context *const uds_ctx,
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_USBD_H_ */
+#endif /* ZEPHYR_INCLUDE_USB_USBD_H_ */

--- a/include/zephyr/usb/usbd_msg.h
+++ b/include/zephyr/usb/usbd_msg.h
@@ -9,8 +9,8 @@
  * @brief USB support message types and structure
  */
 
-#ifndef ZEPHYR_INCLUDE_USBD_MSG_H_
-#define ZEPHYR_INCLUDE_USBD_MSG_H_
+#ifndef ZEPHYR_INCLUDE_USB_USBD_MSG_H_
+#define ZEPHYR_INCLUDE_USB_USBD_MSG_H_
 
 #include <stdint.h>
 
@@ -119,4 +119,4 @@ static inline const char *usbd_msg_type_string(const enum usbd_msg_type type)
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_USBD_MSG_H_ */
+#endif /* ZEPHYR_INCLUDE_USB_USBD_MSG_H_ */

--- a/include/zephyr/usb/usbh.h
+++ b/include/zephyr/usb/usbh.h
@@ -11,8 +11,8 @@
  * This file contains the USB device stack APIs and structures.
  */
 
-#ifndef ZEPHYR_INCLUDE_USBH_H_
-#define ZEPHYR_INCLUDE_USBH_H_
+#ifndef ZEPHYR_INCLUDE_USB_USBH_H_
+#define ZEPHYR_INCLUDE_USB_USBH_H_
 
 #include <stdint.h>
 #include <zephyr/device.h>
@@ -235,4 +235,4 @@ int usbh_shutdown(struct usbh_context *const uhs_ctx);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_USBH_H_ */
+#endif /* ZEPHYR_INCLUDE_USB_USBH_H_ */


### PR DESCRIPTION
Update header files in include/zephyr/ to use a `ZEPHYR_INCLUDE_` prefixed header guard macro with the macro name matching the header file path in include/zephyr/ file tree.

These changes were made using **zephyr_header_guards.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below and manually select changes: 
```
$ scripts/zephyr_header_guards.py -v --apply \
    `./scripts/get_maintainer.py list "USB"