### PR TITLE
include: zephyr: input: Rename header file guard macros

### DIFF
--- a/include/zephyr/input/input.h
+++ b/include/zephyr/input/input.h
@@ -10,8 +10,8 @@
  * @ingroup input_interface
  */
 
-#ifndef ZEPHYR_INCLUDE_INPUT_H_
-#define ZEPHYR_INCLUDE_INPUT_H_
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_H_
 
 /**
  * @brief Interfaces for input devices.
@@ -175,4 +175,4 @@ struct input_callback {
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_INPUT_H_ */
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_H_ */

--- a/include/zephyr/input/input_analog_axis.h
+++ b/include/zephyr/input/input_analog_axis.h
@@ -10,8 +10,8 @@
  * @brief Main header file for interacting with analog axis input devices.
  */
 
-#ifndef ZEPHYR_INCLUDE_INPUT_ANALOG_AXIS_H_
-#define ZEPHYR_INCLUDE_INPUT_ANALOG_AXIS_H_
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_ANALOG_AXIS_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_ANALOG_AXIS_H_
 
 #include <stdint.h>
 #include <zephyr/device.h>
@@ -100,4 +100,4 @@ int analog_axis_calibration_set(const struct device *dev,
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_INPUT_ANALOG_AXIS_H_ */
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_ANALOG_AXIS_H_ */

--- a/include/zephyr/input/input_analog_axis_settings.h
+++ b/include/zephyr/input/input_analog_axis_settings.h
@@ -10,8 +10,8 @@
  * @ingroup input_analog_axis
  */
 
-#ifndef ZEPHYR_INCLUDE_INPUT_ANALOG_AXIS_SETTINGS_H_
-#define ZEPHYR_INCLUDE_INPUT_ANALOG_AXIS_SETTINGS_H_
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_ANALOG_AXIS_SETTINGS_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_ANALOG_AXIS_SETTINGS_H_
 
 #include <stdint.h>
 #include <zephyr/device.h>
@@ -36,4 +36,4 @@ int analog_axis_calibration_save(const struct device *dev);
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_INPUT_ANALOG_AXIS_SETTINGS_H_ */
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_ANALOG_AXIS_SETTINGS_H_ */

--- a/include/zephyr/input/input_crsf.h
+++ b/include/zephyr/input/input_crsf.h
@@ -19,8 +19,8 @@
  * @{
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_INPUT_INPUT_CRSF_H_
-#define ZEPHYR_INCLUDE_DRIVERS_INPUT_INPUT_CRSF_H_
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_CRSF_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_CRSF_H_
 
 #include <zephyr/types.h>
 
@@ -215,4 +215,4 @@ struct crsf_link_stats input_crsf_get_link_stats(const struct device *dev);
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_INPUT_INPUT_CRSF_H_ */
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_CRSF_H_ */

--- a/include/zephyr/input/input_hid.h
+++ b/include/zephyr/input/input_hid.h
@@ -10,8 +10,8 @@
  * @ingroup input_interface
  */
 
-#ifndef ZEPHYR_INCLUDE_INPUT_HID_H_
-#define ZEPHYR_INCLUDE_INPUT_HID_H_
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_HID_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_HID_H_
 
 /**
  * @addtogroup input_interface
@@ -45,4 +45,4 @@ uint8_t input_to_hid_modifier(uint16_t input_code);
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_INPUT_HID_H_ */
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_HID_H_ */

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -10,8 +10,8 @@
  * @brief Main header file for keyboard matrix input devices.
  */
 
-#ifndef ZEPHYR_INCLUDE_INPUT_KBD_MATRIX_H_
-#define ZEPHYR_INCLUDE_INPUT_KBD_MATRIX_H_
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_KBD_MATRIX_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_KBD_MATRIX_H_
 
 /**
  * @defgroup input_kbd_matrix Keyboard Matrix
@@ -369,4 +369,4 @@ bool input_kbd_matrix_active(const struct device *dev);
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_INPUT_KBD_MATRIX_H_ */
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_KBD_MATRIX_H_ */

--- a/include/zephyr/input/input_nunchuk.h
+++ b/include/zephyr/input/input_nunchuk.h
@@ -9,8 +9,8 @@
  * @ingroup nunchuk_interface
  */
 
-#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_NUNCHUCK_H_
-#define ZEPHYR_INCLUDE_INPUT_INPUT_NUNCHUCK_H_
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_NUNCHUK_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_NUNCHUK_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,4 +68,4 @@ int nunchuk_read(const struct device *dev);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_NUNCHUCK_H_ */
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_NUNCHUK_H_ */

--- a/include/zephyr/input/input_pat912x.h
+++ b/include/zephyr/input/input_pat912x.h
@@ -10,8 +10,8 @@
  * @ingroup pat912x_interface
  */
 
-#ifndef ZEPHYR_INCLUDE_INPUT_PAT912X_H_
-#define ZEPHYR_INCLUDE_INPUT_PAT912X_H_
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_PAT912X_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_PAT912X_H_
 
 /**
  * @defgroup pat912x_interface PAT912x
@@ -34,4 +34,4 @@ int pat912x_set_resolution(const struct device *dev,
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_INPUT_PAT912X_H_ */
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_PAT912X_H_ */

--- a/include/zephyr/input/input_paw32xx.h
+++ b/include/zephyr/input/input_paw32xx.h
@@ -10,8 +10,8 @@
  * @ingroup paw32xx_interface
  */
 
-#ifndef ZEPHYR_INCLUDE_INPUT_PAW32XX_H_
-#define ZEPHYR_INCLUDE_INPUT_PAW32XX_H_
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_PAW32XX_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_PAW32XX_H_
 
 /**
  * @defgroup paw32xx_interface PAW32xx
@@ -38,4 +38,4 @@ int paw32xx_force_awake(const struct device *dev, bool enable);
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_INPUT_PAW32XX_H_ */
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_PAW32XX_H_ */

--- a/include/zephyr/input/input_pmw3610.h
+++ b/include/zephyr/input/input_pmw3610.h
@@ -10,8 +10,8 @@
  * @ingroup pmw3610_interface
  */
 
-#ifndef ZEPHYR_INCLUDE_INPUT_PMW3610_H_
-#define ZEPHYR_INCLUDE_INPUT_PMW3610_H_
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_PMW3610_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_PMW3610_H_
 
 /**
  * @defgroup pmw3610_interface PMW3610
@@ -44,4 +44,4 @@ int pmw3610_force_awake(const struct device *dev, bool enable);
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_INPUT_PMW3610_H_ */
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_PMW3610_H_ */

--- a/include/zephyr/input/input_renesas_ra_ctsu.h
+++ b/include/zephyr/input/input_renesas_ra_ctsu.h
@@ -10,8 +10,8 @@
  * @ingroup renesas_ra_ctsu_interface
  */
 
-#ifndef ZEPHYR_INCLUDE_ZEPHYR_INPUT_INPUT_RENESAS_RA_CTSU_H_
-#define ZEPHYR_INCLUDE_ZEPHYR_INPUT_INPUT_RENESAS_RA_CTSU_H_
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_RENESAS_RA_CTSU_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_RENESAS_RA_CTSU_H_
 
 /**
  * @defgroup renesas_ra_ctsu_interface Renesas RA CTSU
@@ -56,4 +56,4 @@ __syscall int renesas_ra_ctsu_group_configure(const struct device *dev,
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_ZEPHYR_INPUT_INPUT_RENESAS_RA_CTSU_H_ */
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_RENESAS_RA_CTSU_H_ */

--- a/include/zephyr/input/input_renesas_rx_ctsu.h
+++ b/include/zephyr/input/input_renesas_rx_ctsu.h
@@ -10,8 +10,8 @@
  * @ingroup renesas_rx_ctsu_interface
  */
 
-#ifndef ZEPHYR_INCLUDE_ZEPHYR_INPUT_INPUT_RENESAS_RX_CTSU_H_
-#define ZEPHYR_INCLUDE_ZEPHYR_INPUT_INPUT_RENESAS_RX_CTSU_H_
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_RENESAS_RX_CTSU_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_RENESAS_RX_CTSU_H_
 
 /**
  * @defgroup renesas_rx_ctsu_interface Renesas RX CTSU
@@ -56,4 +56,4 @@ __syscall int renesas_rx_ctsu_group_configure(const struct device *dev,
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_ZEPHYR_INPUT_INPUT_RENESAS_RX_CTSU_H_ */
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_RENESAS_RX_CTSU_H_ */

--- a/include/zephyr/input/input_touch.h
+++ b/include/zephyr/input/input_touch.h
@@ -10,8 +10,8 @@
  * @ingroup touch_events
  */
 
-#ifndef ZEPHYR_INCLUDE_INPUT_TOUCH_H_
-#define ZEPHYR_INCLUDE_INPUT_TOUCH_H_
+#ifndef ZEPHYR_INCLUDE_INPUT_INPUT_TOUCH_H_
+#define ZEPHYR_INCLUDE_INPUT_INPUT_TOUCH_H_
 
 /**
  * @defgroup touch_events Touchscreen Events
@@ -96,4 +96,4 @@ void input_touchscreen_report_pos(const struct device *dev,
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_INPUT_TOUCH_H_ */
+#endif /* ZEPHYR_INCLUDE_INPUT_INPUT_TOUCH_H_ */


### PR DESCRIPTION
Update header files in include/zephyr/ to use a ZEPHYR_`I`NCLUDE_ prefixed header guard macro with the macro name matching the header file path in include/zephyr/ file tree.

These changes were made using **zephyr_header_guards.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below and manually select changes: 
`$ scripts/zephyr_header_guards.py -v --apply include/zephyr/input/`