### PR TITLE
include: zephyr: llext: Rename header file guard macros

### DIFF
--- a/include/zephyr/llext/buf_loader.h
+++ b/include/zephyr/llext/buf_loader.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_LLEXT_BUF_LOADER_H
-#define ZEPHYR_LLEXT_BUF_LOADER_H
+#ifndef ZEPHYR_INCLUDE_LLEXT_BUF_LOADER_H_
+#define ZEPHYR_INCLUDE_LLEXT_BUF_LOADER_H_
 
 #include <zephyr/llext/loader.h>
 
@@ -125,4 +125,4 @@ void *llext_buf_peek(struct llext_loader *ldr, size_t pos);
 }
 #endif
 
-#endif /* ZEPHYR_LLEXT_BUF_LOADER_H */
+#endif /* ZEPHYR_INCLUDE_LLEXT_BUF_LOADER_H_ */

--- a/include/zephyr/llext/elf.h
+++ b/include/zephyr/llext/elf.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  */
-#ifndef ZEPHYR_LLEXT_ELF_H
-#define ZEPHYR_LLEXT_ELF_H
+#ifndef ZEPHYR_INCLUDE_LLEXT_ELF_H_
+#define ZEPHYR_INCLUDE_LLEXT_ELF_H_
 
 #include <stdint.h>
 
@@ -520,4 +520,4 @@ typedef struct elf32_sym elf_sym_t;
  * @}
  */
 
-#endif /* ZEPHYR_LLEXT_ELF_H */
+#endif /* ZEPHYR_INCLUDE_LLEXT_ELF_H_ */

--- a/include/zephyr/llext/fs_loader.h
+++ b/include/zephyr/llext/fs_loader.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_LLEXT_FS_LOADER_H
-#define ZEPHYR_LLEXT_FS_LOADER_H
+#ifndef ZEPHYR_INCLUDE_LLEXT_FS_LOADER_H_
+#define ZEPHYR_INCLUDE_LLEXT_FS_LOADER_H_
 
 #include <zephyr/llext/loader.h>
 #include <zephyr/fs/fs.h>
@@ -71,4 +71,4 @@ void llext_fs_finalize(struct llext_loader *ldr);
 }
 #endif
 
-#endif /* ZEPHYR_LLEXT_FS_LOADER_H */
+#endif /* ZEPHYR_INCLUDE_LLEXT_FS_LOADER_H_ */

--- a/include/zephyr/llext/inspect.h
+++ b/include/zephyr/llext/inspect.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_LLEXT_INSPECT_H
-#define ZEPHYR_LLEXT_INSPECT_H
+#ifndef ZEPHYR_INCLUDE_LLEXT_INSPECT_H_
+#define ZEPHYR_INCLUDE_LLEXT_INSPECT_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -144,4 +144,4 @@ static inline int llext_get_section_info(const struct llext_loader *ldr,
 }
 #endif
 
-#endif /* ZEPHYR_LLEXT_INSPECT_H */
+#endif /* ZEPHYR_INCLUDE_LLEXT_INSPECT_H_ */

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_LLEXT_H
-#define ZEPHYR_LLEXT_H
+#ifndef ZEPHYR_INCLUDE_LLEXT_LLEXT_H_
+#define ZEPHYR_INCLUDE_LLEXT_LLEXT_H_
 
 #include <zephyr/sys/slist.h>
 #include <zephyr/llext/elf.h>
@@ -530,4 +530,4 @@ int llext_restore(struct llext **ext, struct llext_loader **ldr, unsigned int n_
 
 #include <zephyr/syscalls/llext.h>
 
-#endif /* ZEPHYR_LLEXT_H */
+#endif /* ZEPHYR_INCLUDE_LLEXT_LLEXT_H_ */

--- a/include/zephyr/llext/llext_internal.h
+++ b/include/zephyr/llext/llext_internal.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_LLEXT_INTERNAL_H
-#define ZEPHYR_LLEXT_INTERNAL_H
+#ifndef ZEPHYR_INCLUDE_LLEXT_LLEXT_INTERNAL_H_
+#define ZEPHYR_INCLUDE_LLEXT_LLEXT_INTERNAL_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -129,4 +129,4 @@ int arch_elf_relocate_global(struct llext_loader *loader, struct llext *ext, con
 }
 #endif
 
-#endif /* ZEPHYR_LLEXT_INTERNAL_H */
+#endif /* ZEPHYR_INCLUDE_LLEXT_LLEXT_INTERNAL_H_ */

--- a/include/zephyr/llext/loader.h
+++ b/include/zephyr/llext/loader.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_LLEXT_LOADER_H
-#define ZEPHYR_LLEXT_LOADER_H
+#ifndef ZEPHYR_INCLUDE_LLEXT_LOADER_H_
+#define ZEPHYR_INCLUDE_LLEXT_LOADER_H_
 
 #include <zephyr/llext/elf.h>
 #include <stddef.h>
@@ -190,4 +190,4 @@ static inline void llext_finalize(struct llext_loader *l)
 }
 #endif
 
-#endif /* ZEPHYR_LLEXT_LOADER_H */
+#endif /* ZEPHYR_INCLUDE_LLEXT_LOADER_H_ */

--- a/include/zephyr/llext/symbol.h
+++ b/include/zephyr/llext/symbol.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_LLEXT_SYMBOL_H
-#define ZEPHYR_LLEXT_SYMBOL_H
+#ifndef ZEPHYR_INCLUDE_LLEXT_SYMBOL_H_
+#define ZEPHYR_INCLUDE_LLEXT_SYMBOL_H_
 
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys/util_macro.h>
@@ -300,4 +300,4 @@ struct z_llext_discarded_const_symbol {
 #endif
 
 
-#endif /* ZEPHYR_LLEXT_SYMBOL_H */
+#endif /* ZEPHYR_INCLUDE_LLEXT_SYMBOL_H_ */


### PR DESCRIPTION
Update header files in include/zephyr/ to use a `ZEPHYR_INCLUDE_` prefixed header guard macro with the macro name matching the header file path in **include/zephyr/** file tree.

These changes were made using **zephyr_header_guards.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below and manually select changes: 
`$ scripts/zephyr_header_guards.py -v --apply include/zephyr/llext/`