### PR TITLE
include: zephyr: modem: Rename header file guard macros

### DIFF
--- a/include/zephyr/modem/at/user_pipe.h
+++ b/include/zephyr/modem/at/user_pipe.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_MODEM_AT_USER_PIPE_
-#define ZEPHYR_MODEM_AT_USER_PIPE_
+#ifndef ZEPHYR_INCLUDE_MODEM_AT_USER_PIPE_H_
+#define ZEPHYR_INCLUDE_MODEM_AT_USER_PIPE_H_
 
 #include <zephyr/modem/chat.h>
 
@@ -33,4 +33,4 @@ int modem_at_user_pipe_claim(struct modem_chat *chat, k_timeout_t timeout);
  */
 void modem_at_user_pipe_release(void);
 
-#endif /* ZEPHYR_MODEM_AT_USER_PIPE_ */
+#endif /* ZEPHYR_INCLUDE_MODEM_AT_USER_PIPE_H_ */

--- a/include/zephyr/modem/backend/tty.h
+++ b/include/zephyr/modem/backend/tty.h
@@ -12,8 +12,8 @@
 
 #include <zephyr/modem/pipe.h>
 
-#ifndef ZEPHYR_MODEM_BACKEND_TTY_
-#define ZEPHYR_MODEM_BACKEND_TTY_
+#ifndef ZEPHYR_INCLUDE_MODEM_BACKEND_TTY_H_
+#define ZEPHYR_INCLUDE_MODEM_BACKEND_TTY_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,4 +42,4 @@ struct modem_pipe *modem_backend_tty_init(struct modem_backend_tty *backend,
 }
 #endif
 
-#endif /* ZEPHYR_MODEM_BACKEND_TTY_ */
+#endif /* ZEPHYR_INCLUDE_MODEM_BACKEND_TTY_H_ */

--- a/include/zephyr/modem/backend/uart.h
+++ b/include/zephyr/modem/backend/uart.h
@@ -14,8 +14,8 @@
 #include <zephyr/modem/pipe.h>
 #include <zephyr/modem/stats.h>
 
-#ifndef ZEPHYR_MODEM_BACKEND_UART_
-#define ZEPHYR_MODEM_BACKEND_UART_
+#ifndef ZEPHYR_INCLUDE_MODEM_BACKEND_UART_H_
+#define ZEPHYR_INCLUDE_MODEM_BACKEND_UART_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -101,4 +101,4 @@ struct modem_pipe *modem_backend_uart_init(struct modem_backend_uart *backend,
 }
 #endif
 
-#endif /* ZEPHYR_MODEM_BACKEND_UART_ */
+#endif /* ZEPHYR_INCLUDE_MODEM_BACKEND_UART_H_ */

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -12,8 +12,8 @@
 #include <zephyr/modem/pipe.h>
 #include <zephyr/modem/stats.h>
 
-#ifndef ZEPHYR_MODEM_CHAT_
-#define ZEPHYR_MODEM_CHAT_
+#ifndef ZEPHYR_INCLUDE_MODEM_CHAT_H_
+#define ZEPHYR_INCLUDE_MODEM_CHAT_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -551,4 +551,4 @@ void modem_chat_script_set_timeout(struct modem_chat_script *script, uint32_t ti
 }
 #endif
 
-#endif /* ZEPHYR_MODEM_CHAT_ */
+#endif /* ZEPHYR_INCLUDE_MODEM_CHAT_H_ */

--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -27,8 +27,8 @@
 #include <zephyr/modem/pipe.h>
 #include <zephyr/modem/stats.h>
 
-#ifndef ZEPHYR_MODEM_CMUX_
-#define ZEPHYR_MODEM_CMUX_
+#ifndef ZEPHYR_INCLUDE_MODEM_CMUX_H_
+#define ZEPHYR_INCLUDE_MODEM_CMUX_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -330,4 +330,4 @@ void modem_cmux_release(struct modem_cmux *cmux);
 }
 #endif
 
-#endif /* ZEPHYR_MODEM_CMUX_ */
+#endif /* ZEPHYR_INCLUDE_MODEM_CMUX_H_ */

--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -7,8 +7,8 @@
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 
-#ifndef ZEPHYR_MODEM_PIPE_
-#define ZEPHYR_MODEM_PIPE_
+#ifndef ZEPHYR_INCLUDE_MODEM_PIPE_H_
+#define ZEPHYR_INCLUDE_MODEM_PIPE_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -240,4 +240,4 @@ void modem_pipe_notify_transmit_idle(struct modem_pipe *pipe);
 }
 #endif
 
-#endif /* ZEPHYR_MODEM_PIPE_ */
+#endif /* ZEPHYR_INCLUDE_MODEM_PIPE_H_ */

--- a/include/zephyr/modem/pipelink.h
+++ b/include/zephyr/modem/pipelink.h
@@ -8,8 +8,8 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
 
-#ifndef ZEPHYR_MODEM_PIPELINK_
-#define ZEPHYR_MODEM_PIPELINK_
+#ifndef ZEPHYR_INCLUDE_MODEM_PIPELINK_H_
+#define ZEPHYR_INCLUDE_MODEM_PIPELINK_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -167,4 +167,4 @@ void modem_pipelink_notify_disconnected(struct modem_pipelink *link);
 }
 #endif
 
-#endif /* ZEPHYR_MODEM_PIPELINK_ */
+#endif /* ZEPHYR_INCLUDE_MODEM_PIPELINK_H_ */

--- a/include/zephyr/modem/ppp.h
+++ b/include/zephyr/modem/ppp.h
@@ -15,8 +15,8 @@
 #include <zephyr/modem/pipe.h>
 #include <zephyr/modem/stats.h>
 
-#ifndef ZEPHYR_MODEM_PPP_
-#define ZEPHYR_MODEM_PPP_
+#ifndef ZEPHYR_INCLUDE_MODEM_PPP_H_
+#define ZEPHYR_INCLUDE_MODEM_PPP_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -222,4 +222,4 @@ int modem_ppp_init_internal(const struct device *dev);
 }
 #endif
 
-#endif /* ZEPHYR_MODEM_PPP_ */
+#endif /* ZEPHYR_INCLUDE_MODEM_PPP_H_ */

--- a/include/zephyr/modem/stats.h
+++ b/include/zephyr/modem/stats.h
@@ -7,8 +7,8 @@
 #include <zephyr/types.h>
 #include <zephyr/kernel.h>
 
-#ifndef ZEPHYR_MODEM_STATS_
-#define ZEPHYR_MODEM_STATS_
+#ifndef ZEPHYR_INCLUDE_MODEM_STATS_H_
+#define ZEPHYR_INCLUDE_MODEM_STATS_H_
 
 /**
  * @cond INTERNAL_HIDDEN
@@ -47,4 +47,4 @@ void modem_stats_buffer_init(struct modem_stats_buffer *buffer,
  */
 void modem_stats_buffer_advertise_length(struct modem_stats_buffer *buffer, uint32_t length);
 
-#endif /* ZEPHYR_MODEM_STATS_ */
+#endif /* ZEPHYR_INCLUDE_MODEM_STATS_H_ */

--- a/include/zephyr/modem/ubx.h
+++ b/include/zephyr/modem/ubx.h
@@ -13,8 +13,8 @@
 #include <zephyr/modem/pipe.h>
 #include <zephyr/modem/ubx/protocol.h>
 
-#ifndef ZEPHYR_MODEM_UBX_
-#define ZEPHYR_MODEM_UBX_
+#ifndef ZEPHYR_INCLUDE_MODEM_UBX_H_
+#define ZEPHYR_INCLUDE_MODEM_UBX_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -160,4 +160,4 @@ int modem_ubx_run_script_for_each(struct modem_ubx *ubx, struct modem_ubx_script
 }
 #endif
 
-#endif /* ZEPHYR_MODEM_UBX_ */
+#endif /* ZEPHYR_INCLUDE_MODEM_UBX_H_ */

--- a/include/zephyr/modem/ubx.h
+++ b/include/zephyr/modem/ubx.h
@@ -6,15 +6,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef ZEPHYR_INCLUDE_MODEM_UBX_H_
+#define ZEPHYR_INCLUDE_MODEM_UBX_H_
+
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/atomic.h>
 
 #include <zephyr/modem/pipe.h>
 #include <zephyr/modem/ubx/protocol.h>
-
-#ifndef ZEPHYR_INCLUDE_MODEM_UBX_H_
-#define ZEPHYR_INCLUDE_MODEM_UBX_H_
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/modem/ubx/checksum.h
+++ b/include/zephyr/modem/ubx/checksum.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_MODEM_UBX_CHECKSUM_
-#define ZEPHYR_MODEM_UBX_CHECKSUM_
+#ifndef ZEPHYR_INCLUDE_MODEM_UBX_CHECKSUM_H_
+#define ZEPHYR_INCLUDE_MODEM_UBX_CHECKSUM_H_
 
 /** Macrobatics to compute UBX checksum at compile time */
 
@@ -35,4 +35,4 @@
 
 #define UBX_CSUM(...) UBX_CSUM_A(__VA_ARGS__), UBX_CSUM_B(__VA_ARGS__)
 
-#endif /* ZEPHYR_MODEM_UBX_CHECKSUM_ */
+#endif /* ZEPHYR_INCLUDE_MODEM_UBX_CHECKSUM_H_ */

--- a/include/zephyr/modem/ubx/keys.h
+++ b/include/zephyr/modem/ubx/keys.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_MODEM_UBX_KEYS_
-#define ZEPHYR_MODEM_UBX_KEYS_
+#ifndef ZEPHYR_INCLUDE_MODEM_UBX_KEYS_H_
+#define ZEPHYR_INCLUDE_MODEM_UBX_KEYS_H_
 
 enum ubx_keys_msg_out {
 	UBX_KEY_MSG_OUT_NMEA_GGA_UART1 = 0x209100bb,
@@ -59,4 +59,4 @@ enum ubx_keys_nav_hp_cfg {
 	UBX_KEY_NAV_HP_CFG_GNSS_MODE = 0x20140011,
 };
 
-#endif /* ZEPHYR_MODEM_UBX_KEYS_ */
+#endif /* ZEPHYR_INCLUDE_MODEM_UBX_KEYS_H_ */

--- a/include/zephyr/modem/ubx/protocol.h
+++ b/include/zephyr/modem/ubx/protocol.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_MODEM_UBX_PROTOCOL_
-#define ZEPHYR_MODEM_UBX_PROTOCOL_
+#ifndef ZEPHYR_INCLUDE_MODEM_UBX_PROTOCOL_H_
+#define ZEPHYR_INCLUDE_MODEM_UBX_PROTOCOL_H_
 
 #include <stdint.h>
 #include <zephyr/modem/ubx/checksum.h>
@@ -542,4 +542,4 @@ static inline int ubx_frame_encode(uint8_t class, uint8_t id,
 		},										   \
 	}
 
-#endif /* ZEPHYR_MODEM_UBX_PROTOCOL_ */
+#endif /* ZEPHYR_INCLUDE_MODEM_UBX_PROTOCOL_H_ */


### PR DESCRIPTION
Update header files in include/zephyr/ to use a `ZEPHYR_INCLUDE_` prefixed header guard macro with the macro name matching the header file path in **include/zephyr/** file tree.

These changes were made using **zephyr_header_guards.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below and manually select changes: 
`$ scripts/zephyr_header_guards.py -v --apply include/zephyr/modem/`