### PR TITLE
include: zephyr: sys: Rename header file guard macros

### DIFF
--- a/include/zephyr/sys/hash_map_api.h
+++ b/include/zephyr/sys/hash_map_api.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_SYS_HASHMAP_API_H_
-#define ZEPHYR_INCLUDE_SYS_HASHMAP_API_H_
+#ifndef ZEPHYR_INCLUDE_SYS_HASH_MAP_API_H_
+#define ZEPHYR_INCLUDE_SYS_HASH_MAP_API_H_
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -237,4 +237,4 @@ struct sys_hashmap_data {
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SYS_HASHMAP_API_H_ */
+#endif /* ZEPHYR_INCLUDE_SYS_HASH_MAP_API_H_ */

--- a/include/zephyr/sys/iterable_sections.h
+++ b/include/zephyr/sys/iterable_sections.h
@@ -10,8 +10,8 @@
  * @ingroup iterable_section_apis
  */
 
-#ifndef INCLUDE_ZEPHYR_SYS_ITERABLE_SECTIONS_H_
-#define INCLUDE_ZEPHYR_SYS_ITERABLE_SECTIONS_H_
+#ifndef ZEPHYR_INCLUDE_SYS_ITERABLE_SECTIONS_H_
+#define ZEPHYR_INCLUDE_SYS_ITERABLE_SECTIONS_H_
 
 #include <zephyr/sys/__assert.h>
 #include <zephyr/toolchain.h>
@@ -354,4 +354,4 @@ extern "C" {
 }
 #endif
 
-#endif /* INCLUDE_ZEPHYR_SYS_ITERABLE_SECTIONS_H_ */
+#endif /* ZEPHYR_INCLUDE_SYS_ITERABLE_SECTIONS_H_ */

--- a/include/zephyr/sys/linear_range.h
+++ b/include/zephyr/sys/linear_range.h
@@ -9,8 +9,8 @@
  * @ingroup linear_range
  */
 
-#ifndef INCLUDE_ZEPHYR_SYS_LINEAR_RANGE_H_
-#define INCLUDE_ZEPHYR_SYS_LINEAR_RANGE_H_
+#ifndef ZEPHYR_INCLUDE_SYS_LINEAR_RANGE_H_
+#define ZEPHYR_INCLUDE_SYS_LINEAR_RANGE_H_
 
 #include <errno.h>
 #include <stdint.h>
@@ -344,4 +344,4 @@ static inline int linear_range_group_get_win_index(const struct linear_range *r,
 }
 #endif
 
-#endif /* INCLUDE_ZEPHYR_SYS_LINEAR_RANGE_H_ */
+#endif /* ZEPHYR_INCLUDE_SYS_LINEAR_RANGE_H_ */

--- a/include/zephyr/sys/math_extras_impl.h
+++ b/include/zephyr/sys/math_extras_impl.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef ZEPHYR_INCLUDE_SYS_MATH_EXTRAS_IMPL_H_
+#define ZEPHYR_INCLUDE_SYS_MATH_EXTRAS_IMPL_H_
+
 /**
  * @file
  * @brief Inline implementation of functions declared in math_extras.h.
@@ -318,3 +321,5 @@ static inline void i128_multiply_i64_i64(int64_t a, int64_t b, int128_t *result)
 #undef use_builtin
 
 /** @endcond */
+
+#endif /* ZEPHYR_INCLUDE_SYS_MATH_EXTRAS_IMPL_H_ */

--- a/include/zephyr/sys/mpsc_lockfree.h
+++ b/include/zephyr/sys/mpsc_lockfree.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_SYS_MPSC_LOCKFREE_H_
-#define ZEPHYR_SYS_MPSC_LOCKFREE_H_
+#ifndef ZEPHYR_INCLUDE_SYS_MPSC_LOCKFREE_H_
+#define ZEPHYR_INCLUDE_SYS_MPSC_LOCKFREE_H_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -194,4 +194,4 @@ static inline struct mpsc_node *mpsc_pop(struct mpsc *q)
 }
 #endif
 
-#endif /* ZEPHYR_SYS_MPSC_LOCKFREE_H_ */
+#endif /* ZEPHYR_INCLUDE_SYS_MPSC_LOCKFREE_H_ */

--- a/include/zephyr/sys/speculation.h
+++ b/include/zephyr/sys/speculation.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_MISC_SPECULATION_H
-#define ZEPHYR_MISC_SPECULATION_H
+#ifndef ZEPHYR_INCLUDE_SYS_SPECULATION_H_
+#define ZEPHYR_INCLUDE_SYS_SPECULATION_H_
 
 #include <zephyr/types.h>
 
@@ -52,4 +52,4 @@ static inline uint32_t k_array_index_sanitize(uint32_t index, uint32_t array_siz
 	return index;
 #endif /* CONFIG_BOUNDS_CHECK_BYPASS_MITIGATION */
 }
-#endif /* ZEPHYR_MISC_SPECULATION_H */
+#endif /* ZEPHYR_INCLUDE_SYS_SPECULATION_H_ */

--- a/include/zephyr/sys/spsc_lockfree.h
+++ b/include/zephyr/sys/spsc_lockfree.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_SYS_SPSC_LOCKFREE_H_
-#define ZEPHYR_SYS_SPSC_LOCKFREE_H_
+#ifndef ZEPHYR_INCLUDE_SYS_SPSC_LOCKFREE_H_
+#define ZEPHYR_INCLUDE_SYS_SPSC_LOCKFREE_H_
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -330,4 +330,4 @@ struct spsc {
  * @}
  */
 
-#endif /* ZEPHYR_SYS_SPSC_LOCKFREE_H_ */
+#endif /* ZEPHYR_INCLUDE_SYS_SPSC_LOCKFREE_H_ */

--- a/include/zephyr/sys/sys_getopt.h
+++ b/include/zephyr/sys/sys_getopt.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_SYS_GETOPT_H_
-#define ZEPHYR_INCLUDE_SYS_GETOPT_H_
+#ifndef ZEPHYR_INCLUDE_SYS_SYS_GETOPT_H_
+#define ZEPHYR_INCLUDE_SYS_SYS_GETOPT_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -127,4 +127,4 @@ int sys_getopt_long_only(int nargc, char *const *nargv, const char *options,
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SYS_GETOPT_H_ */
+#endif /* ZEPHYR_INCLUDE_SYS_SYS_GETOPT_H_ */

--- a/include/zephyr/sys/time_units.h
+++ b/include/zephyr/sys/time_units.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_TIME_UNITS_H_
-#define ZEPHYR_INCLUDE_TIME_UNITS_H_
+#ifndef ZEPHYR_INCLUDE_SYS_TIME_UNITS_H_
+#define ZEPHYR_INCLUDE_SYS_TIME_UNITS_H_
 
 #include <zephyr/toolchain.h>
 #include <zephyr/sys/util.h>
@@ -2101,4 +2101,4 @@ static inline unsigned int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
 } /* extern "C" */
 #endif
 
-#endif /* ZEPHYR_INCLUDE_TIME_UNITS_H_ */
+#endif /* ZEPHYR_INCLUDE_SYS_TIME_UNITS_H_ */

--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -14,8 +14,8 @@
  * should be include instead <sys/util_internal.h>
  */
 
-#ifndef ZEPHYR_INCLUDE_SYS_UTIL_MACROS_H_
-#define ZEPHYR_INCLUDE_SYS_UTIL_MACROS_H_
+#ifndef ZEPHYR_INCLUDE_SYS_UTIL_MACRO_H_
+#define ZEPHYR_INCLUDE_SYS_UTIL_MACRO_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -770,4 +770,4 @@ extern "C" {
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SYS_UTIL_MACROS_H_ */
+#endif /* ZEPHYR_INCLUDE_SYS_UTIL_MACRO_H_ */

--- a/include/zephyr/sys/util_utf8.h
+++ b/include/zephyr/sys/util_utf8.h
@@ -11,8 +11,8 @@
  * Misc UTF-8 utilities.
  */
 
-#ifndef ZEPHYR_INCLUDE_SYS_UTIL_UFT8_H_
-#define ZEPHYR_INCLUDE_SYS_UTIL_UFT8_H_
+#ifndef ZEPHYR_INCLUDE_SYS_UTIL_UTF8_H_
+#define ZEPHYR_INCLUDE_SYS_UTIL_UTF8_H_
 
 #include <stddef.h>
 
@@ -90,4 +90,4 @@ int utf8_count_chars(const char *s);
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_SYS_UTIL_UFT8_H_ */
+#endif /* ZEPHYR_INCLUDE_SYS_UTIL_UTF8_H_ */

--- a/include/zephyr/sys/word_granular_access.h
+++ b/include/zephyr/sys/word_granular_access.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_SYS_WORD_GRANULAR_H_
-#define ZEPHYR_INCLUDE_SYS_WORD_GRANULAR_H_
+#ifndef ZEPHYR_INCLUDE_SYS_WORD_GRANULAR_ACCESS_H_
+#define ZEPHYR_INCLUDE_SYS_WORD_GRANULAR_ACCESS_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -105,4 +105,4 @@ void *sys_memcpy_from_word_granular_access(void *d, const void *s, size_t n);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SYS_WORD_GRANULAR_H_ */
+#endif /* ZEPHYR_INCLUDE_SYS_WORD_GRANULAR_ACCESS_H_ */

--- a/include/zephyr/zvfs/eventfd.h
+++ b/include/zephyr/zvfs/eventfd.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ZEPHYR_ZVFS_EVENTFD_H_
-#define ZEPHYR_INCLUDE_ZEPHYR_ZVFS_EVENTFD_H_
+#ifndef ZEPHYR_INCLUDE_ZVFS_EVENTFD_H_
+#define ZEPHYR_INCLUDE_ZVFS_EVENTFD_H_
 
 #include <stdint.h>
 
@@ -63,4 +63,4 @@ int zvfs_eventfd_write(int fd, zvfs_eventfd_t value);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_ZEPHYR_ZVFS_EVENTFD_H_ */
+#endif /* ZEPHYR_INCLUDE_ZVFS_EVENTFD_H_ */


### PR DESCRIPTION
Update header files in include/zephyr/ to use a `ZEPHYR_INCLUDE_` prefixed header guard macro with the macro name matching the header file path in **include/zephyr/** file tree.

These changes were made using **zephyr_header_guards.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below:
```
$ scripts/zephyr_header_guards.py --apply \
    `./scripts/get_maintainer.py list "Base OS"`