### PR TITLE
include: zephyr: net: Rename header file guard macros

### DIFF
--- a/include/zephyr/net/conn_mgr/connectivity_wifi_mgmt.h
+++ b/include/zephyr/net/conn_mgr/connectivity_wifi_mgmt.h
@@ -9,8 +9,8 @@
  * @brief Connectivity implementation for drivers exposing the wifi_mgmt API
  */
 
-#ifndef ZEPHYR_INCLUDE_CONN_MGR_CONNECTIVITY_WIFI_MGMT_H_
-#define ZEPHYR_INCLUDE_CONN_MGR_CONNECTIVITY_WIFI_MGMT_H_
+#ifndef ZEPHYR_INCLUDE_NET_CONN_MGR_CONNECTIVITY_WIFI_MGMT_H_
+#define ZEPHYR_INCLUDE_NET_CONN_MGR_CONNECTIVITY_WIFI_MGMT_H_
 
 #include <zephyr/net/conn_mgr_connectivity_impl.h>
 
@@ -37,4 +37,4 @@ extern "C" {
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_CONN_MGR_CONNECTIVITY_WIFI_MGMT_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_CONN_MGR_CONNECTIVITY_WIFI_MGMT_H_ */

--- a/include/zephyr/net/conn_mgr_connectivity.h
+++ b/include/zephyr/net/conn_mgr_connectivity.h
@@ -10,8 +10,8 @@
  * support it.
  */
 
-#ifndef ZEPHYR_INCLUDE_CONN_MGR_CONNECTIVITY_H_
-#define ZEPHYR_INCLUDE_CONN_MGR_CONNECTIVITY_H_
+#ifndef ZEPHYR_INCLUDE_NET_CONN_MGR_CONNECTIVITY_H_
+#define ZEPHYR_INCLUDE_NET_CONN_MGR_CONNECTIVITY_H_
 
 #include <zephyr/device.h>
 #include <zephyr/net/net_if.h>
@@ -391,4 +391,4 @@ int conn_mgr_all_if_disconnect(bool skip_ignored);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_CONN_MGR_CONNECTIVITY_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_CONN_MGR_CONNECTIVITY_H_ */

--- a/include/zephyr/net/conn_mgr_connectivity_impl.h
+++ b/include/zephyr/net/conn_mgr_connectivity_impl.h
@@ -10,8 +10,8 @@
  * conn_mgr_connectivity).
  */
 
-#ifndef ZEPHYR_INCLUDE_CONN_MGR_CONNECTIVITY_IMPL_H_
-#define ZEPHYR_INCLUDE_CONN_MGR_CONNECTIVITY_IMPL_H_
+#ifndef ZEPHYR_INCLUDE_NET_CONN_MGR_CONNECTIVITY_IMPL_H_
+#define ZEPHYR_INCLUDE_NET_CONN_MGR_CONNECTIVITY_IMPL_H_
 
 #include <zephyr/device.h>
 #include <zephyr/net/net_if.h>
@@ -372,4 +372,4 @@ static inline bool conn_mgr_binding_get_flag(struct conn_mgr_conn_binding *bindi
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_CONN_MGR_CONNECTIVITY_IMPL_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_CONN_MGR_CONNECTIVITY_IMPL_H_ */

--- a/include/zephyr/net/conn_mgr_monitor.h
+++ b/include/zephyr/net/conn_mgr_monitor.h
@@ -9,8 +9,8 @@
  * @brief API for monitoring network connections and interfaces.
  */
 
-#ifndef ZEPHYR_INCLUDE_CONN_MGR_H_
-#define ZEPHYR_INCLUDE_CONN_MGR_H_
+#ifndef ZEPHYR_INCLUDE_NET_CONN_MGR_MONITOR_H_
+#define ZEPHYR_INCLUDE_NET_CONN_MGR_MONITOR_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -109,4 +109,4 @@ void conn_mgr_watch_l2(const struct net_l2 *l2);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_CONN_MGR_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_CONN_MGR_MONITOR_H_ */

--- a/include/zephyr/net/hdlc_rcp_if/hdlc_rcp_if.h
+++ b/include/zephyr/net/hdlc_rcp_if/hdlc_rcp_if.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef ZEPHYR_INCLUDE_NET_HDLC_RCP_IF_HDLC_RCP_IF_H_
+#define ZEPHYR_INCLUDE_NET_HDLC_RCP_IF_HDLC_RCP_IF_H_
+
 /**
  * @file
  * @brief Public APIs of HDLC RCP communication Interface
@@ -75,3 +78,5 @@ BUILD_ASSERT(offsetof(struct hdlc_api, iface_api) == 0);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* ZEPHYR_INCLUDE_NET_HDLC_RCP_IF_HDLC_RCP_IF_H_ */

--- a/include/zephyr/net/http/frame.h
+++ b/include/zephyr/net/http/frame.h
@@ -9,8 +9,8 @@
  * @brief HTTP2 frame information.
  */
 
-#ifndef ZEPHYR_INCLUDE_NET_HTTP_SERVER_FRAME_H_
-#define ZEPHYR_INCLUDE_NET_HTTP_SERVER_FRAME_H_
+#ifndef ZEPHYR_INCLUDE_NET_HTTP_FRAME_H_
+#define ZEPHYR_INCLUDE_NET_HTTP_FRAME_H_
 
 #include <stdint.h>
 
@@ -89,4 +89,4 @@ enum http2_settings {
 }
 #endif
 
-#endif
+#endif /* ZEPHYR_INCLUDE_NET_HTTP_FRAME_H_ */

--- a/include/zephyr/net/http/hpack.h
+++ b/include/zephyr/net/http/hpack.h
@@ -9,8 +9,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_NET_HTTP_SERVER_HPACK_H_
-#define ZEPHYR_INCLUDE_NET_HTTP_SERVER_HPACK_H_
+#ifndef ZEPHYR_INCLUDE_NET_HTTP_HPACK_H_
+#define ZEPHYR_INCLUDE_NET_HTTP_HPACK_H_
 
 #include <stddef.h>
 #include <stdint.h>
@@ -148,4 +148,4 @@ int http_hpack_encode_header(uint8_t *buf, size_t buflen,
  * @}
  */
 
-#endif
+#endif /* ZEPHYR_INCLUDE_NET_HTTP_HPACK_H_ */

--- a/include/zephyr/net/ieee802154_frame.h
+++ b/include/zephyr/net/ieee802154_frame.h
@@ -17,8 +17,8 @@
  * LITTLE ENDIAN, see section 4, especially section 4.3.
  */
 
-#ifndef __IEEE802154_FRAME_H__
-#define __IEEE802154_FRAME_H__
+#ifndef ZEPHYR_INCLUDE_NET_IEEE802154_FRAME_H_
+#define ZEPHYR_INCLUDE_NET_IEEE802154_FRAME_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/net/ieee802154.h>
@@ -1032,4 +1032,4 @@ bool ieee802154_decipher_data_frame(struct net_if *iface, struct net_pkt *pkt,
 
 /** INTERNAL_HIDDEN @endcond */
 
-#endif /* __IEEE802154_FRAME_H__ */
+#endif /* ZEPHYR_INCLUDE_NET_IEEE802154_FRAME_H_ */

--- a/include/zephyr/net/lwm2m_send_scheduler.h
+++ b/include/zephyr/net/lwm2m_send_scheduler.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_NET_LWM2M_SEND_SCHEDULER_H_
-#define ZEPHYR_NET_LWM2M_SEND_SCHEDULER_H_
+#ifndef ZEPHYR_INCLUDE_NET_LWM2M_SEND_SCHEDULER_H_
+#define ZEPHYR_INCLUDE_NET_LWM2M_SEND_SCHEDULER_H_
 
 #include <stdbool.h>
 #include <zephyr/net/lwm2m.h>
@@ -43,4 +43,4 @@ bool lwm2m_send_sched_cache_filter(const struct lwm2m_obj_path *path,
  */
 void lwm2m_send_sched_handle_registration_event(void);
 
-#endif /* ZEPHYR_NET_LWM2M_SEND_SCHEDULER_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_LWM2M_SEND_SCHEDULER_H_ */

--- a/include/zephyr/net/mcp/mcp_server.h
+++ b/include/zephyr/net/mcp/mcp_server.h
@@ -12,8 +12,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_NET_MCP_SERVER_H_
-#define ZEPHYR_INCLUDE_NET_MCP_SERVER_H_
+#ifndef ZEPHYR_INCLUDE_NET_MCP_MCP_SERVER_H_
+#define ZEPHYR_INCLUDE_NET_MCP_MCP_SERVER_H_
 
 /**
  * @file
@@ -200,7 +200,7 @@ int mcp_server_is_execution_canceled(mcp_server_ctx_t server_ctx, const char *ex
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_MCP_SERVER_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_MCP_MCP_SERVER_H_ */
 
 /**
  * @}

--- a/include/zephyr/net/mcp/mcp_server_http.h
+++ b/include/zephyr/net/mcp/mcp_server_http.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_MCP_SERVER_HTTP_H_
-#define ZEPHYR_INCLUDE_MCP_SERVER_HTTP_H_
+#ifndef ZEPHYR_INCLUDE_NET_MCP_MCP_SERVER_HTTP_H_
+#define ZEPHYR_INCLUDE_NET_MCP_MCP_SERVER_HTTP_H_
 
 /**
  * @file
@@ -32,4 +32,4 @@ int mcp_server_http_init(mcp_server_ctx_t server_ctx);
  */
 int mcp_server_http_start(mcp_server_ctx_t server_ctx);
 
-#endif /* ZEPHYR_INCLUDE_MCP_SERVER_HTTP_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_MCP_MCP_SERVER_HTTP_H_ */

--- a/include/zephyr/net/net_pkt_filter.h
+++ b/include/zephyr/net/net_pkt_filter.h
@@ -11,8 +11,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_NET_PKT_FILTER_H_
-#define ZEPHYR_INCLUDE_NET_PKT_FILTER_H_
+#ifndef ZEPHYR_INCLUDE_NET_NET_PKT_FILTER_H_
+#define ZEPHYR_INCLUDE_NET_NET_PKT_FILTER_H_
 
 #include <limits.h>
 #include <stdbool.h>
@@ -767,4 +767,4 @@ const char *npf_test_get_str(struct npf_test *test, char *buf,
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_NET_PKT_FILTER_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_NET_PKT_FILTER_H_ */

--- a/include/zephyr/net/offloaded_netdev.h
+++ b/include/zephyr/net/offloaded_netdev.h
@@ -10,8 +10,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_OFFLOADED_NETDEV_H_
-#define ZEPHYR_INCLUDE_OFFLOADED_NETDEV_H_
+#ifndef ZEPHYR_INCLUDE_NET_OFFLOADED_NETDEV_H_
+#define ZEPHYR_INCLUDE_NET_OFFLOADED_NETDEV_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
@@ -90,4 +90,4 @@ static inline bool net_off_is_wifi_offloaded(struct net_if *iface)
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_OFFLOADED_NETDEV_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_OFFLOADED_NETDEV_H_ */

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -11,8 +11,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef ZEPHYR_INCLUDE_DRIVERS_PHY_H_
-#define ZEPHYR_INCLUDE_DRIVERS_PHY_H_
+#ifndef ZEPHYR_INCLUDE_NET_PHY_H_
+#define ZEPHYR_INCLUDE_NET_PHY_H_
 
 /**
  * @brief Ethernet PHY Interface
@@ -448,4 +448,4 @@ static inline int phy_get_plca_sts(__maybe_unused const struct device *dev,
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_PHY_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_PHY_H_ */

--- a/include/zephyr/net/prometheus/collector.h
+++ b/include/zephyr/net/prometheus/collector.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_PROMETHEUS_COLLECTOR_H_
-#define ZEPHYR_INCLUDE_PROMETHEUS_COLLECTOR_H_
+#ifndef ZEPHYR_INCLUDE_NET_PROMETHEUS_COLLECTOR_H_
+#define ZEPHYR_INCLUDE_NET_PROMETHEUS_COLLECTOR_H_
 
 /**
  * @file
@@ -174,4 +174,4 @@ static inline int prometheus_collector_walk_init(struct prometheus_collector_wal
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_PROMETHEUS_COLLECTOR_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_PROMETHEUS_COLLECTOR_H_ */

--- a/include/zephyr/net/prometheus/counter.h
+++ b/include/zephyr/net/prometheus/counter.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_PROMETHEUS_COUNTER_H_
-#define ZEPHYR_INCLUDE_PROMETHEUS_COUNTER_H_
+#ifndef ZEPHYR_INCLUDE_NET_PROMETHEUS_COUNTER_H_
+#define ZEPHYR_INCLUDE_NET_PROMETHEUS_COUNTER_H_
 
 /**
  * @file
@@ -108,4 +108,4 @@ int prometheus_counter_set(struct prometheus_counter *counter, uint64_t value);
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_PROMETHEUS_COUNTER_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_PROMETHEUS_COUNTER_H_ */

--- a/include/zephyr/net/prometheus/formatter.h
+++ b/include/zephyr/net/prometheus/formatter.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_PROMETHEUS_FORMATTER_H_
-#define ZEPHYR_INCLUDE_PROMETHEUS_FORMATTER_H_
+#ifndef ZEPHYR_INCLUDE_NET_PROMETHEUS_FORMATTER_H_
+#define ZEPHYR_INCLUDE_NET_PROMETHEUS_FORMATTER_H_
 
 /**
  * @file
@@ -53,4 +53,4 @@ int prometheus_format_one_metric(struct prometheus_metric *metric, char *buffer,
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_PROMETHEUS_FORMATTER_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_PROMETHEUS_FORMATTER_H_ */

--- a/include/zephyr/net/prometheus/gauge.h
+++ b/include/zephyr/net/prometheus/gauge.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_PROMETHEUS_GAUGE_H_
-#define ZEPHYR_INCLUDE_PROMETHEUS_GAUGE_H_
+#ifndef ZEPHYR_INCLUDE_NET_PROMETHEUS_GAUGE_H_
+#define ZEPHYR_INCLUDE_NET_PROMETHEUS_GAUGE_H_
 
 /**
  * @file
@@ -87,4 +87,4 @@ int prometheus_gauge_set(struct prometheus_gauge *gauge, double value);
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_PROMETHEUS_GAUGE_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_PROMETHEUS_GAUGE_H_ */

--- a/include/zephyr/net/prometheus/histogram.h
+++ b/include/zephyr/net/prometheus/histogram.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_PROMETHEUS_HISTOGRAM_H_
-#define ZEPHYR_INCLUDE_PROMETHEUS_HISTOGRAM_H_
+#ifndef ZEPHYR_INCLUDE_NET_PROMETHEUS_HISTOGRAM_H_
+#define ZEPHYR_INCLUDE_NET_PROMETHEUS_HISTOGRAM_H_
 
 /**
  * @file
@@ -109,4 +109,4 @@ int prometheus_histogram_observe(struct prometheus_histogram *histogram, double 
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_PROMETHEUS_HISTOGRAM_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_PROMETHEUS_HISTOGRAM_H_ */

--- a/include/zephyr/net/prometheus/label.h
+++ b/include/zephyr/net/prometheus/label.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_PROMETHEUS_LABEL_H_
-#define ZEPHYR_INCLUDE_PROMETHEUS_LABEL_H_
+#ifndef ZEPHYR_INCLUDE_NET_PROMETHEUS_LABEL_H_
+#define ZEPHYR_INCLUDE_NET_PROMETHEUS_LABEL_H_
 
 /**
  * @file
@@ -39,4 +39,4 @@ struct prometheus_label {
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_PROMETHEUS_LABEL_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_PROMETHEUS_LABEL_H_ */

--- a/include/zephyr/net/prometheus/metric.h
+++ b/include/zephyr/net/prometheus/metric.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_PROMETHEUS_METRIC_H_
-#define ZEPHYR_INCLUDE_PROMETHEUS_METRIC_H_
+#ifndef ZEPHYR_INCLUDE_NET_PROMETHEUS_METRIC_H_
+#define ZEPHYR_INCLUDE_NET_PROMETHEUS_METRIC_H_
 
 /**
  * @file
@@ -73,4 +73,4 @@ struct prometheus_metric {
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_PROMETHEUS_METRIC_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_PROMETHEUS_METRIC_H_ */

--- a/include/zephyr/net/prometheus/summary.h
+++ b/include/zephyr/net/prometheus/summary.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_PROMETHEUS_SUMMARY_H_
-#define ZEPHYR_INCLUDE_PROMETHEUS_SUMMARY_H_
+#ifndef ZEPHYR_INCLUDE_NET_PROMETHEUS_SUMMARY_H_
+#define ZEPHYR_INCLUDE_NET_PROMETHEUS_SUMMARY_H_
 
 /**
  * @file
@@ -127,4 +127,4 @@ int prometheus_summary_observe_set(struct prometheus_summary *summary,
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_PROMETHEUS_SUMMARY_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_PROMETHEUS_SUMMARY_H_ */

--- a/include/zephyr/net/wifi_certs.h
+++ b/include/zephyr/net/wifi_certs.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef WIFI_CERTS_H__
-#define WIFI_CERTS_H__
+#ifndef ZEPHYR_INCLUDE_NET_WIFI_CERTS_H_
+#define ZEPHYR_INCLUDE_NET_WIFI_CERTS_H_
 
 #include <stdbool.h>
 #include <zephyr/kernel.h>
@@ -35,4 +35,4 @@ int wifi_set_enterprise_credentials(struct net_if *iface, bool is_ap);
  */
 void wifi_clear_enterprise_credentials(void);
 
-#endif /* WIFI_CERTS_H__ */
+#endif /* ZEPHYR_INCLUDE_NET_WIFI_CERTS_H_ */

--- a/include/zephyr/net/wifi_credentials.h
+++ b/include/zephyr/net/wifi_credentials.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef WIFI_CREDENTIALS_H__
-#define WIFI_CREDENTIALS_H__
+#ifndef ZEPHYR_INCLUDE_NET_WIFI_CREDENTIALS_H_
+#define ZEPHYR_INCLUDE_NET_WIFI_CREDENTIALS_H_
 
 #include <zephyr/types.h>
 #include <zephyr/net/wifi.h>
@@ -269,4 +269,4 @@ void wifi_credentials_for_each_ssid(wifi_credentials_ssid_cb cb, void *cb_arg);
 
 /** @} */
 
-#endif /* WIFI_CREDENTIALS_H__ */
+#endif /* ZEPHYR_INCLUDE_NET_WIFI_CREDENTIALS_H_ */

--- a/include/zephyr/net/wifi_nm.h
+++ b/include/zephyr/net/wifi_nm.h
@@ -11,8 +11,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_ZEPHYR_NET_WIFI_NM_H_
-#define ZEPHYR_INCLUDE_ZEPHYR_NET_WIFI_NM_H_
+#ifndef ZEPHYR_INCLUDE_NET_WIFI_NM_H_
+#define ZEPHYR_INCLUDE_NET_WIFI_NM_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
@@ -164,4 +164,4 @@ int wifi_nm_unregister_mgd_iface(struct wifi_nm_instance *nm, struct net_if *ifa
 #ifdef __cplusplus
 }
 #endif
-#endif /* ZEPHYR_INCLUDE_ZEPHYR_NET_WIFI_NM_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_WIFI_NM_H_ */

--- a/include/zephyr/net/wireguard.h
+++ b/include/zephyr/net/wireguard.h
@@ -10,8 +10,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_NET_WG_H_
-#define ZEPHYR_INCLUDE_NET_WG_H_
+#ifndef ZEPHYR_INCLUDE_NET_WIREGUARD_H_
+#define ZEPHYR_INCLUDE_NET_WIREGUARD_H_
 
 /**
  * @brief Wireguard VPN service
@@ -231,4 +231,4 @@ int wireguard_get_current_time(uint64_t *seconds, uint32_t *nanoseconds);
  * @}
  */
 
-#endif /* ZEPHYR_INCLUDE_NET_WG_H_ */
+#endif /* ZEPHYR_INCLUDE_NET_WIREGUARD_H_ */


### PR DESCRIPTION
Update header files in include/zephyr/ to use a `ZEPHYR_INCLUDE_` prefixed header guard macro with the macro name matching the header file path in **include/zephyr/** file tree.

These changes were made using **zephyr_header_guards.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below:
`$ scripts/zephyr_header_guards.py --apply include/zephyr/net`