### PR TITLE
include: zephyr: xen: Rename header file guard macros

### DIFF
--- a/include/zephyr/xen/console.h
+++ b/include/zephyr/xen/console.h
@@ -10,8 +10,8 @@
  * @ingroup xen_console_driver
  */
 
-#ifndef __XEN_CONSOLE_H__
-#define __XEN_CONSOLE_H__
+#ifndef ZEPHYR_INCLUDE_XEN_CONSOLE_H_
+#define ZEPHYR_INCLUDE_XEN_CONSOLE_H_
 
 #include <zephyr/init.h>
 #include <zephyr/device.h>
@@ -53,4 +53,4 @@ int xen_console_init(const struct device *dev);
 
 /** @} */
 
-#endif /* __XEN_CONSOLE_H__ */
+#endif /* ZEPHYR_INCLUDE_XEN_CONSOLE_H_ */

--- a/include/zephyr/xen/dmop.h
+++ b/include/zephyr/xen/dmop.h
@@ -10,8 +10,8 @@
  * @ingroup xen_device_model
  */
 
-#ifndef ZEPHYR_XEN_DMOP_H_
-#define ZEPHYR_XEN_DMOP_H_
+#ifndef ZEPHYR_INCLUDE_XEN_DMOP_H_
+#define ZEPHYR_INCLUDE_XEN_DMOP_H_
 
 #include <xen/public/hvm/dm_op.h>
 
@@ -142,4 +142,4 @@ int dmop_set_irq_level(domid_t domid, uint32_t irq, uint8_t level);
 
 /** @} */
 
-#endif /* ZEPHYR_XEN_DMOP_H_ */
+#endif /* ZEPHYR_INCLUDE_XEN_DMOP_H_ */

--- a/include/zephyr/xen/dom0/domctl.h
+++ b/include/zephyr/xen/dom0/domctl.h
@@ -10,8 +10,8 @@
  * @ingroup xen_dom0_domain_control
  */
 
-#ifndef __XEN_DOM0_DOMCTL_H__
-#define __XEN_DOM0_DOMCTL_H__
+#ifndef ZEPHYR_INCLUDE_XEN_DOM0_DOMCTL_H_
+#define ZEPHYR_INCLUDE_XEN_DOM0_DOMCTL_H_
 
 #include <xen/public/xen.h>
 #include <xen/public/domctl.h>
@@ -354,4 +354,4 @@ int xen_domctl_getvcpu(int domid, uint32_t vcpu, struct xen_domctl_getvcpuinfo *
 
 /** @} */
 
-#endif /* __XEN_DOM0_DOMCTL_H__ */
+#endif /* ZEPHYR_INCLUDE_XEN_DOM0_DOMCTL_H_ */

--- a/include/zephyr/xen/dom0/domctl.h
+++ b/include/zephyr/xen/dom0/domctl.h
@@ -10,8 +10,8 @@
  * @ingroup xen_dom0_domain_control
  */
 
-#ifndef __XEN_DOM0_DOMCTL_H__
-#define __XEN_DOM0_DOMCTL_H__
+#ifndef ZEPHYR_INCLUDE_XEN_DOM0_DOMCTL_H_
+#define ZEPHYR_INCLUDE_XEN_DOM0_DOMCTL_H_
 
 #include <xen/public/xen.h>
 #include <xen/public/domctl.h>
@@ -318,4 +318,4 @@ int xen_domctl_getvcpu(int domid, uint32_t vcpu, struct xen_domctl_getvcpuinfo *
 
 /** @} */
 
-#endif /* __XEN_DOM0_DOMCTL_H__ */
+#endif /* ZEPHYR_INCLUDE_XEN_DOM0_DOMCTL_H_ */

--- a/include/zephyr/xen/dom0/sysctl.h
+++ b/include/zephyr/xen/dom0/sysctl.h
@@ -10,8 +10,8 @@
  * @ingroup xen_dom0_sysctl
  */
 
-#ifndef __XEN_DOM0_SYSCTL_H__
-#define __XEN_DOM0_SYSCTL_H__
+#ifndef ZEPHYR_INCLUDE_XEN_DOM0_SYSCTL_H_
+#define ZEPHYR_INCLUDE_XEN_DOM0_SYSCTL_H_
 
 #include <xen/public/xen.h>
 #include <xen/public/sysctl.h>
@@ -83,4 +83,4 @@ int xen_sysctl_cpu_hotplug(uint32_t cpu, bool enable);
 
 /** @} */
 
-#endif /* __XEN_DOM0_SYSCTL_H__ */
+#endif /* ZEPHYR_INCLUDE_XEN_DOM0_SYSCTL_H_ */

--- a/include/zephyr/xen/dom0/sysctl.h
+++ b/include/zephyr/xen/dom0/sysctl.h
@@ -10,8 +10,8 @@
  * @ingroup xen_dom0_sysctl
  */
 
-#ifndef __XEN_DOM0_SYSCTL_H__
-#define __XEN_DOM0_SYSCTL_H__
+#ifndef ZEPHYR_INCLUDE_XEN_DOM0_SYSCTL_H_
+#define ZEPHYR_INCLUDE_XEN_DOM0_SYSCTL_H_
 
 #include <xen/public/xen.h>
 #include <xen/public/sysctl.h>
@@ -72,4 +72,4 @@ int xen_sysctl_cpu_hotplug(uint32_t cpu, bool enable);
 
 /** @} */
 
-#endif /* __XEN_DOM0_SYSCTL_H__ */
+#endif /* ZEPHYR_INCLUDE_XEN_DOM0_SYSCTL_H_ */

--- a/include/zephyr/xen/events.h
+++ b/include/zephyr/xen/events.h
@@ -11,8 +11,8 @@
  * @ingroup xen_event_channels
  */
 
-#ifndef __XEN_EVENTS_H__
-#define __XEN_EVENTS_H__
+#ifndef ZEPHYR_INCLUDE_XEN_EVENTS_H_
+#define ZEPHYR_INCLUDE_XEN_EVENTS_H_
 
 #include <xen/public/event_channel.h>
 
@@ -214,4 +214,4 @@ int xen_events_init(void);
 
 /** @} */
 
-#endif /* __XEN_EVENTS_H__ */
+#endif /* ZEPHYR_INCLUDE_XEN_EVENTS_H_ */

--- a/include/zephyr/xen/generic.h
+++ b/include/zephyr/xen/generic.h
@@ -10,8 +10,8 @@
  * @ingroup xen_internal
  */
 
-#ifndef __XEN_GENERIC_H__
-#define __XEN_GENERIC_H__
+#ifndef ZEPHYR_INCLUDE_XEN_GENERIC_H_
+#define ZEPHYR_INCLUDE_XEN_GENERIC_H_
 
 #include <xen/public/xen.h>
 
@@ -52,4 +52,4 @@
 
 /** @} */
 
-#endif /* __XEN_GENERIC_H__ */
+#endif /* ZEPHYR_INCLUDE_XEN_GENERIC_H_ */

--- a/include/zephyr/xen/gnttab.h
+++ b/include/zephyr/xen/gnttab.h
@@ -10,8 +10,8 @@
  * @ingroup xen_grant_tables
  */
 
-#ifndef __XEN_GNTTAB_H__
-#define __XEN_GNTTAB_H__
+#ifndef ZEPHYR_INCLUDE_XEN_GNTTAB_H_
+#define ZEPHYR_INCLUDE_XEN_GNTTAB_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -148,4 +148,4 @@ const char *gnttabop_error(int16_t status);
 
 /** @} */
 
-#endif /* __XEN_GNTTAB_H__ */
+#endif /* ZEPHYR_INCLUDE_XEN_GNTTAB_H_ */

--- a/include/zephyr/xen/gnttab.h
+++ b/include/zephyr/xen/gnttab.h
@@ -10,8 +10,8 @@
  * @ingroup xen_grant_tables
  */
 
-#ifndef __XEN_GNTTAB_H__
-#define __XEN_GNTTAB_H__
+#ifndef ZEPHYR_INCLUDE_XEN_GNTTAB_H_
+#define ZEPHYR_INCLUDE_XEN_GNTTAB_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -164,4 +164,4 @@ const char *gnttabop_error(int16_t status);
 
 /** @} */
 
-#endif /* __XEN_GNTTAB_H__ */
+#endif /* ZEPHYR_INCLUDE_XEN_GNTTAB_H_ */

--- a/include/zephyr/xen/hvm.h
+++ b/include/zephyr/xen/hvm.h
@@ -10,8 +10,8 @@
  * @ingroup xen_hvm
  */
 
-#ifndef __XEN_HVM_H__
-#define __XEN_HVM_H__
+#ifndef ZEPHYR_INCLUDE_XEN_HVM_H_
+#define ZEPHYR_INCLUDE_XEN_HVM_H_
 
 #include <xen/public/hvm/hvm_op.h>
 #include <xen/public/hvm/params.h>
@@ -49,4 +49,4 @@ int hvm_get_parameter(int idx, int domid, uint64_t *value);
 
 /** @} */
 
-#endif /* __XEN_HVM_H__ */
+#endif /* ZEPHYR_INCLUDE_XEN_HVM_H_ */

--- a/include/zephyr/xen/memory.h
+++ b/include/zephyr/xen/memory.h
@@ -9,8 +9,8 @@
  * @ingroup xen_memory_management
  */
 
-#ifndef ZEPHYR_XEN_MEMORY_H_
-#define ZEPHYR_XEN_MEMORY_H_
+#ifndef ZEPHYR_INCLUDE_XEN_MEMORY_H_
+#define ZEPHYR_INCLUDE_XEN_MEMORY_H_
 
 #include <xen/public/xen.h>
 #include <xen/public/memory.h>
@@ -150,4 +150,4 @@ int xendom_acquire_resource(domid_t domid, uint16_t type, uint32_t id, uint64_t 
 
 /** @} */
 
-#endif /* ZEPHYR_XEN_MEMORY_H_ */
+#endif /* ZEPHYR_INCLUDE_XEN_MEMORY_H_ */

--- a/include/zephyr/xen/memory.h
+++ b/include/zephyr/xen/memory.h
@@ -9,8 +9,8 @@
  * @ingroup xen_memory_management
  */
 
-#ifndef ZEPHYR_XEN_MEMORY_H_
-#define ZEPHYR_XEN_MEMORY_H_
+#ifndef ZEPHYR_INCLUDE_XEN_MEMORY_H_
+#define ZEPHYR_INCLUDE_XEN_MEMORY_H_
 
 #include <xen/public/xen.h>
 #include <xen/public/memory.h>
@@ -109,4 +109,4 @@ int xendom_acquire_resource(domid_t domid, uint16_t type, uint32_t id, uint64_t 
 
 /** @} */
 
-#endif /* ZEPHYR_XEN_MEMORY_H_ */
+#endif /* ZEPHYR_INCLUDE_XEN_MEMORY_H_ */

--- a/include/zephyr/xen/version.h
+++ b/include/zephyr/xen/version.h
@@ -10,8 +10,8 @@
  * @ingroup xen_version_queries
  */
 
-#ifndef __XEN_VERSION_H__
-#define __XEN_VERSION_H__
+#ifndef ZEPHYR_INCLUDE_XEN_VERSION_H_
+#define ZEPHYR_INCLUDE_XEN_VERSION_H_
 
 #include <zephyr/xen/generic.h>
 #include <xen/public/version.h>
@@ -50,4 +50,4 @@ int xen_version_extraversion(char *extra, int len);
 
 /** @} */
 
-#endif /* __XEN_VERSION_H__ */
+#endif /* ZEPHYR_INCLUDE_XEN_VERSION_H_ */


### PR DESCRIPTION
Update header files in include/zephyr/ to use a `ZEPHYR_INCLUDE_` prefixed header guard macro with the macro name matching the header file path in **include/zephyr/** file tree.

These changes were made using **zephyr_header_guards.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below:
`$ scripts/zephyr_header_guards.py --apply include/zephyr/xen`