### PR TITLE
include: zephyr: shell: Rename header file guard macros

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -10,8 +10,8 @@
  * @ingroup shell_api
  */
 
-#ifndef SHELL_H__
-#define SHELL_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell_types.h>
@@ -1670,4 +1670,4 @@ int shell_readline(const struct shell *sh, uint8_t *buf, size_t len, k_timeout_t
 #include <zephyr_custom_shell.h>
 #endif
 
-#endif /* SHELL_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_H_ */

--- a/include/zephyr/shell/shell_adsp_memory_window.h
+++ b/include/zephyr/shell/shell_adsp_memory_window.h
@@ -10,8 +10,8 @@
  * @ingroup shell_adsp_memory_window
  */
 
-#ifndef SHELL_ADSP_MEMORY_WINDOW_H__
-#define SHELL_ADSP_MEMORY_WINDOW_H__
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_ADSP_MEMORY_WINDOW_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_ADSP_MEMORY_WINDOW_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
@@ -81,4 +81,4 @@ const struct shell *shell_backend_adsp_memory_window_get_ptr(void);
 }
 #endif
 
-#endif /* SHELL_ADSP_MEMORY_WINDOW_H__ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_ADSP_MEMORY_WINDOW_H_ */

--- a/include/zephyr/shell/shell_backend.h
+++ b/include/zephyr/shell/shell_backend.h
@@ -10,8 +10,8 @@
  * @ingroup shell_backends
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_BACKEND_H_
-#define ZEPHYR_INCLUDE_SHELL_BACKEND_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_BACKEND_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_BACKEND_H_
 
 #include <zephyr/types.h>
 #include <zephyr/shell/shell.h>
@@ -89,4 +89,4 @@ const struct shell *shell_backend_get_by_name(const char *backend_name);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_BACKEND_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_BACKEND_H_ */

--- a/include/zephyr/shell/shell_dummy.h
+++ b/include/zephyr/shell/shell_dummy.h
@@ -12,8 +12,8 @@
  * @ingroup shell_dummy
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_DUMMY_H_
-#define ZEPHYR_INCLUDE_SHELL_DUMMY_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_DUMMY_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_DUMMY_H_
 
 #include <zephyr/shell/shell.h>
 
@@ -125,4 +125,4 @@ void shell_backend_dummy_clear_input(const struct shell *sh);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_DUMMY_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_DUMMY_H_ */

--- a/include/zephyr/shell/shell_fprintf.h
+++ b/include/zephyr/shell/shell_fprintf.h
@@ -9,8 +9,8 @@
  * @brief Header file for the shell formatted output helpers.
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_FPRINTF_H_
-#define ZEPHYR_INCLUDE_SHELL_FPRINTF_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_FPRINTF_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_FPRINTF_H_
 
 #include <zephyr/kernel.h>
 #include <stdbool.h>
@@ -97,4 +97,4 @@ void z_shell_fprintf_buffer_flush(const struct shell_fprintf *sh_fprintf);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_FPRINTF_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_FPRINTF_H_ */

--- a/include/zephyr/shell/shell_history.h
+++ b/include/zephyr/shell/shell_history.h
@@ -9,8 +9,8 @@
  * @brief Header file for the shell command history.
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_HISTORY_H_
-#define ZEPHYR_INCLUDE_SHELL_HISTORY_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_HISTORY_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_HISTORY_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
@@ -104,4 +104,4 @@ static inline bool z_shell_history_active(struct shell_history *history)
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_HISTORY_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_HISTORY_H_ */

--- a/include/zephyr/shell/shell_log_backend.h
+++ b/include/zephyr/shell/shell_log_backend.h
@@ -9,8 +9,8 @@
  * @brief Header file for the shell log backend.
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_LOG_BACKEND_H_
-#define ZEPHYR_INCLUDE_SHELL_LOG_BACKEND_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_LOG_BACKEND_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_LOG_BACKEND_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log_backend.h>
@@ -132,4 +132,4 @@ bool z_shell_log_backend_process(const struct shell_log_backend *backend);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_LOG_BACKEND_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_LOG_BACKEND_H_ */

--- a/include/zephyr/shell/shell_mqtt.h
+++ b/include/zephyr/shell/shell_mqtt.h
@@ -10,8 +10,8 @@
  * @ingroup shell_mqtt
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_MQTT_H_
-#define ZEPHYR_INCLUDE_SHELL_MQTT_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_MQTT_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_MQTT_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
@@ -161,4 +161,4 @@ bool shell_mqtt_get_devid(char *id, int id_max_len);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_MQTT_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_MQTT_H_ */

--- a/include/zephyr/shell/shell_rpmsg.h
+++ b/include/zephyr/shell/shell_rpmsg.h
@@ -10,8 +10,8 @@
  * @ingroup shell_rpmsg
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_RPMSG_H_
-#define ZEPHYR_INCLUDE_SHELL_RPMSG_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_RPMSG_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_RPMSG_H_
 
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
@@ -106,4 +106,4 @@ const struct shell *shell_backend_rpmsg_get_ptr(void);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_RPMSG_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_RPMSG_H_ */

--- a/include/zephyr/shell/shell_rtt.h
+++ b/include/zephyr/shell/shell_rtt.h
@@ -10,8 +10,8 @@
  * @ingroup shell_rtt
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_RTT_H_
-#define ZEPHYR_INCLUDE_SHELL_RTT_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_RTT_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_RTT_H_
 
 #include <zephyr/shell/shell.h>
 
@@ -64,4 +64,4 @@ const struct shell *shell_backend_rtt_get_ptr(void);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_RTT_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_RTT_H_ */

--- a/include/zephyr/shell/shell_ssh.h
+++ b/include/zephyr/shell/shell_ssh.h
@@ -11,8 +11,8 @@
  * @ingroup shell_ssh
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_SSH_H_
-#define ZEPHYR_INCLUDE_SHELL_SSH_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_SSH_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_SSH_H_
 
 #include <zephyr/net/socket.h>
 #include <zephyr/net/ssh/server.h>
@@ -127,4 +127,4 @@ int shell_sshd_transport_event_callback(struct ssh_transport *transport,
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_SSH_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_SSH_H_ */

--- a/include/zephyr/shell/shell_string_conv.h
+++ b/include/zephyr/shell/shell_string_conv.h
@@ -10,8 +10,8 @@
  * @ingroup shell_api
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_STRING_CONV_H_
-#define ZEPHYR_INCLUDE_SHELL_STRING_CONV_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_STRING_CONV_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_STRING_CONV_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -99,4 +99,4 @@ bool shell_strtobool(const char *str, int base, int *err);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_STRING_CONV_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_STRING_CONV_H_ */

--- a/include/zephyr/shell/shell_telnet.h
+++ b/include/zephyr/shell/shell_telnet.h
@@ -10,8 +10,8 @@
  * @ingroup shell_telnet
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_TELNET_H_
-#define ZEPHYR_INCLUDE_SHELL_TELNET_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_TELNET_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_TELNET_H_
 
 #include <zephyr/net/socket.h>
 #include <zephyr/shell/shell.h>
@@ -107,4 +107,4 @@ const struct shell *shell_backend_telnet_get_ptr(void);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_TELNET_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_TELNET_H_ */

--- a/include/zephyr/shell/shell_types.h
+++ b/include/zephyr/shell/shell_types.h
@@ -10,8 +10,8 @@
  * @ingroup shell_api
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_TYPES_H_
-#define ZEPHYR_INCLUDE_SHELL_TYPES_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_TYPES_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_TYPES_H_
 
 
 #ifdef __cplusplus
@@ -72,4 +72,4 @@ struct shell_vt100_ctx {
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_TYPES_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_TYPES_H_ */

--- a/include/zephyr/shell/shell_uart.h
+++ b/include/zephyr/shell/shell_uart.h
@@ -10,8 +10,8 @@
  * @ingroup shell_uart
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_UART_H_
-#define ZEPHYR_INCLUDE_SHELL_UART_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_UART_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_UART_H_
 
 #include <zephyr/drivers/serial/uart_async_rx.h>
 #include <zephyr/mgmt/mcumgr/transport/smp_shell.h>
@@ -132,4 +132,4 @@ struct smp_shell_data *shell_uart_smp_shell_data_get_ptr(void);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_UART_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_UART_H_ */

--- a/include/zephyr/shell/shell_websocket.h
+++ b/include/zephyr/shell/shell_websocket.h
@@ -10,8 +10,8 @@
  * @ingroup shell_websocket
  */
 
-#ifndef ZEPHYR_INCLUDE_SHELL_WEBSOCKET_H_
-#define ZEPHYR_INCLUDE_SHELL_WEBSOCKET_H_
+#ifndef ZEPHYR_INCLUDE_SHELL_SHELL_WEBSOCKET_H_
+#define ZEPHYR_INCLUDE_SHELL_SHELL_WEBSOCKET_H_
 
 #include <zephyr/net/socket.h>
 #include <zephyr/net/http/server.h>
@@ -198,4 +198,4 @@ int shell_websocket_enable(const struct shell *sh);
 }
 #endif
 
-#endif /* ZEPHYR_INCLUDE_SHELL_WEBSOCKET_H_ */
+#endif /* ZEPHYR_INCLUDE_SHELL_SHELL_WEBSOCKET_H_ */


### PR DESCRIPTION
Update header files in **include/zephyr/** to use a `ZEPHYR_INCLUDE_` prefixed header guard macro with the macro name matching the header file path in **include/zephyr/** file tree.

These changes were made using **zephyr_header_guards.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below:
`$ scripts/zephyr_header_guards.py --apply include/zephyr/shell`