### PR TITLE
net: if: drop redundant multicast join when DAD is disabled

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3631,14 +3631,12 @@ static void iface_ipv6_start(struct net_if *iface)
 
 	if (IS_ENABLED(CONFIG_NET_IPV6_DAD)) {
 		net_if_start_dad(iface);
-	} else {
-		struct net_if_ipv6 *ipv6 = iface->config.ip.ipv6;
-
-		if (ipv6 != NULL) {
-			join_mcast_nodes(iface,
-					 &ipv6->mcast[0].address.in6_addr);
-		}
 	}
+
+	/* The all-nodes and per-address solicited-node multicast groups are
+	 * (re)joined by rejoin_ipv6_mcast_groups(), which runs just before this
+	 * from notify_iface_up() regardless of DAD. No extra join is needed here.
+	 */
 
 	net_if_start_rs(iface);
 }


### PR DESCRIPTION
When DAD is disabled, `iface_ipv6_start()` called `join_mcast_nodes()` with the first multicast address slot (`mcast[0]`), passing a multicast address where a unicast one is expected to derive the solicited-node group. The join is also redundant: `rejoin_ipv6_mcast_groups()` runs just before this in `notify_iface_up()` and (re)joins the all-nodes and per-address solicited-node groups regardless of DAD.

Remove the bogus join and rely on rejoin_ipv6_mcast_groups().