### PR TITLE
drivers: display: mcux_elcdif: Fix missing variable

### DIFF
--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -54,9 +54,7 @@ struct mcux_elcdif_data {
 	struct k_sem sem;
 	/* Tracks index of next active driver framebuffer */
 	uint8_t next_idx;
-#ifndef CONFIG_MCUX_ELCDIF_START_ON_INIT
 	bool running;
-#endif
 #ifdef CONFIG_MCUX_ELCDIF_PXP
 	/* Given to when PXP completes operation */
 	struct k_sem pxp_done;
@@ -380,6 +378,7 @@ static int mcux_elcdif_init(const struct device *dev)
 	ELCDIF_RgbModeInit(config->base, &dev_data->rgb_mode);
 #ifdef CONFIG_MCUX_ELCDIF_START_ON_INIT
 	ELCDIF_RgbModeStart(config->base);
+	dev_data->running = true;
 #endif
 
 	return 0;


### PR DESCRIPTION
Enable running boolean in data struct to prevent
compilation errors when CONFIG_MCUX_ELCDIF_START_ON_INIT is enabled.