### PR TITLE
drivers: sensor: lis2dh: Add down event int to any motion configuration

### DIFF
--- a/drivers/sensor/st/lis2dh/lis2dh_trigger.c
+++ b/drivers/sensor/st/lis2dh/lis2dh_trigger.c
@@ -121,8 +121,9 @@ static int lis2dh_start_trigger_int1(const struct device *dev)
 					 LIS2DH_EN_DRDY1_INT1);
 }
 
-#define LIS2DH_ANYM_CFG (LIS2DH_INT_CFG_ZHIE_ZUPE | LIS2DH_INT_CFG_YHIE_YUPE |\
-			 LIS2DH_INT_CFG_XHIE_XUPE)
+#define LIS2DH_ANYM_CFG (LIS2DH_INT_CFG_ZHIE_ZUPE | LIS2DH_INT_CFG_ZLIE_ZDOWNE |\
+			LIS2DH_INT_CFG_YHIE_YUPE | LIS2DH_INT_CFG_YLIE_YDOWNE |\
+			LIS2DH_INT_CFG_XHIE_XUPE | LIS2DH_INT_CFG_XLIE_XDOWNE)
 
 static inline void setup_int2(const struct device *dev,
 			      bool enable)


### PR DESCRIPTION
Lis2dh interrupts were only fired for up events. Fixed it by adding down event enable bits to the ANYM_CFG.