### PR TITLE
include: zephyr: drivers: firmware: Rename header file guard macros

### DIFF
--- a/include/zephyr/drivers/firmware/qemu_fwcfg/qemu_fwcfg.h
+++ b/include/zephyr/drivers/firmware/qemu_fwcfg/qemu_fwcfg.h
@@ -10,8 +10,8 @@
  * @brief Header for the QEMU firmware configuration (fw_cfg) driver
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_QEMU_FWCFG_H_
-#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_QEMU_FWCFG_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_QEMU_FWCFG_QEMU_FWCFG_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_QEMU_FWCFG_QEMU_FWCFG_H_
 
 /**
  * @defgroup qemu_fwcfg_interface QEMU fw_cfg
@@ -110,4 +110,4 @@ bool qemu_fwcfg_dma_supported(const struct device *dev);
 
 /** @} */
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_QEMU_FWCFG_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_QEMU_FWCFG_QEMU_FWCFG_H_ */

--- a/include/zephyr/drivers/firmware/scmi/base.h
+++ b/include/zephyr/drivers/firmware/scmi/base.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef DRIVERS_ARM_SCMI_BASE_H_
-#define DRIVERS_ARM_SCMI_BASE_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_BASE_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_BASE_H_
 
 /**
  * @file
@@ -101,4 +101,4 @@ int scmi_base_reset_agent_cfg(uint32_t agent_id, bool reset_perm);
  * @}
  */
 
-#endif /* DRIVERS_ARM_SCMI_BASE_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_BASE_H_ */

--- a/include/zephyr/drivers/firmware/scmi/clk.h
+++ b/include/zephyr/drivers/firmware/scmi/clk.h
@@ -10,8 +10,8 @@
  * @brief Header file for the SCMI Clock Protocol.
  */
 
-#ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CLK_H_
-#define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CLK_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_CLK_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_CLK_H_
 
 #include <zephyr/drivers/firmware/scmi/protocol.h>
 
@@ -200,4 +200,4 @@ int scmi_clock_get_permissions(struct scmi_protocol *proto, uint32_t clk_id,
  * @}
  */
 
-#endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CLK_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_CLK_H_ */

--- a/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
+++ b/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
@@ -10,8 +10,8 @@
  * @brief Header file for the NXP SCMI CPU Domain Protocol.
  */
 
-#ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CPU_H_
-#define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CPU_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_NXP_CPU_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_NXP_CPU_H_
 
 #include <zephyr/drivers/firmware/scmi/protocol.h>
 #if __has_include("scmi_cpu_soc.h")
@@ -192,4 +192,4 @@ int scmi_nxp_cpu_info_get(uint32_t cpu_id, struct scmi_nxp_cpu_info *cfg);
  * @}
  */
 
-#endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CPU_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_NXP_CPU_H_ */

--- a/include/zephyr/drivers/firmware/scmi/pinctrl.h
+++ b/include/zephyr/drivers/firmware/scmi/pinctrl.h
@@ -10,8 +10,8 @@
  * @brief Header file for the SCMI Pin Control Protocol.
  */
 
-#ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PINCTRL_H_
-#define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PINCTRL_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_PINCTRL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_PINCTRL_H_
 
 #include <zephyr/drivers/firmware/scmi/protocol.h>
 
@@ -143,4 +143,4 @@ int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings);
  * @}
  */
 
-#endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PINCTRL_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_PINCTRL_H_ */

--- a/include/zephyr/drivers/firmware/scmi/power.h
+++ b/include/zephyr/drivers/firmware/scmi/power.h
@@ -10,8 +10,8 @@
  * @brief Header file for the SCMI Power Domain Protocol.
  */
 
-#ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_POWER_H_
-#define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_POWER_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_POWER_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_POWER_H_
 
 #include <zephyr/drivers/firmware/scmi/protocol.h>
 
@@ -101,4 +101,4 @@ int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state);
  * @}
  */
 
-#endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_POWER_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_POWER_H_ */

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -10,8 +10,8 @@
  * @brief Header file for the SCMI (System Control and Management Interface) driver API.
  */
 
-#ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PROTOCOL_H_
-#define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PROTOCOL_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_PROTOCOL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_PROTOCOL_H_
 
 /**
  * @brief Interfaces for ARM System Control and Management Interface (SCMI)
@@ -295,4 +295,4 @@ int scmi_read_message(struct scmi_protocol *proto, struct scmi_message *msg);
  * @ingroup scmi_interface
  */
 
-#endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PROTOCOL_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_PROTOCOL_H_ */

--- a/include/zephyr/drivers/firmware/scmi/reset.h
+++ b/include/zephyr/drivers/firmware/scmi/reset.h
@@ -10,8 +10,8 @@
  * @brief Header file for the SCMI Reset Protocol.
  */
 
-#ifndef DRIVERS_ARM_SCMI_RESET_H_
-#define DRIVERS_ARM_SCMI_RESET_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_RESET_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_RESET_H_
 
 #include <zephyr/drivers/firmware/scmi/protocol.h>
 
@@ -88,4 +88,4 @@ int scmi_reset_domain(struct scmi_protocol *proto, uint32_t id, uint32_t flags,
  * @}
  */
 
-#endif /* DRIVERS_ARM_SCMI_RESET_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_RESET_H_ */

--- a/include/zephyr/drivers/firmware/scmi/shmem.h
+++ b/include/zephyr/drivers/firmware/scmi/shmem.h
@@ -10,8 +10,8 @@
  * @brief Header file for the SCMI Shared Memory.
  */
 
-#ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_SHMEM_H_
-#define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_SHMEM_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_SHMEM_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_SHMEM_H_
 
 #include <zephyr/device.h>
 #include <zephyr/arch/cpu.h>
@@ -151,4 +151,4 @@ void scmi_shmem_mark_channel_free(const struct device *dev);
  * @}
  */
 
-#endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_SHMEM_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_SHMEM_H_ */

--- a/include/zephyr/drivers/firmware/scmi/transport.h
+++ b/include/zephyr/drivers/firmware/scmi/transport.h
@@ -10,8 +10,8 @@
  * @brief Header file for the SCMI Transport Layer.
  */
 
-#ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_TRANSPORT_H_
-#define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_TRANSPORT_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_TRANSPORT_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_TRANSPORT_H_
 
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
@@ -316,4 +316,4 @@ int scmi_core_transport_init(const struct device *transport);
  * @}
  */
 
-#endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_TRANSPORT_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_TRANSPORT_H_ */

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -13,8 +13,8 @@
  * transport "registration".
  */
 
-#ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_UTIL_H_
-#define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_UTIL_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_UTIL_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_UTIL_H_
 
 /**
  * @brief Helper macros and utilities for SCMI drivers
@@ -449,4 +449,4 @@
  * @}
  */
 
-#endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_UTIL_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_SCMI_UTIL_H_ */

--- a/include/zephyr/drivers/firmware/tisci/tisci.h
+++ b/include/zephyr/drivers/firmware/tisci/tisci.h
@@ -10,8 +10,8 @@
  *
  */
 
-#ifndef INCLUDE_ZEPHYR_DRIVERS_TISCI_H_
-#define INCLUDE_ZEPHYR_DRIVERS_TISCI_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_TISCI_TISCI_H_
+#define ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_TISCI_TISCI_H_
 
 #include <zephyr/device.h>
 
@@ -996,4 +996,4 @@ int tisci_cmd_rm_irq_set(const struct device *dev, struct tisci_irq_set_req *req
  * @return 0 if successful, or an error code
  */
 int tisci_cmd_rm_irq_release(const struct device *dev, struct tisci_irq_release_req *req);
-#endif
+#endif /* ZEPHYR_INCLUDE_DRIVERS_FIRMWARE_TISCI_TISCI_H_ */


### PR DESCRIPTION
Update header files in **include/zephyr/** to use a `ZEPHYR_INCLUDE_` prefixed header guard macro with the macro name matching the header file path in **include/zephyr/** file tree.

These changes were made using **zephyr_header_guards.py** script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/111768 with a Linux shell command like the on below:
```
$ scripts/zephyr_header_guards.py --apply \
    include/zephyr/drivers/firmware