### PR TITLE
drivers: clock: syscon: add PowerQuad clock definition

### DIFF
--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -419,6 +419,12 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 	}
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_powerquad)
+	if ((uint32_t)sub_system == MCUX_POWERQUAD_CLK) {
+		CLOCK_EnableClock(kCLOCK_PowerQuad);
+	}
+#endif
+
 	return 0;
 }
 

--- a/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -238,4 +238,7 @@
 /** EQDC1 peripheral clock identifier. */
 #define MCUX_EQDC1_CLK MCUX_LPC_CLK_ID(0x38, 0x01)
 
+/** PowerQuad DSP coprocessor clock identifier. */
+#define MCUX_POWERQUAD_CLK MCUX_LPC_CLK_ID(0x39, 0x00)
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MCUX_LPC_SYSCON_H_ */


### PR DESCRIPTION
Add the MCUX_POWERQUAD_CLK clock identifier to the LPC syscon clock dt-bindings header and add the corresponding clock enable case in the syscon clock control driver. This allows the PowerQuad DSP coprocessor peripheral clock to be managed through the Zephyr clock control API.

This patch is part of this PR: https://github.com/zephyrproject-rtos/zephyr/pull/110745
Because this clock file is changing frequently and results in conflict, so I make it a separate PR here, to avoid unnecessary powerquad PR rebase.