### PR TITLE
dts: bindings: dma: stm32-bdma: fix dma-cells count

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1155,7 +1155,7 @@
 
 		bdma1: bdma@58025400 {
 			compatible = "st,stm32-bdma";
-			#dma-cells = <4>;
+			#dma-cells = <3>;
 			reg = <0x58025400 0x400>;
 			interrupts = <129 0>, <130 0>, <131 0>, <132 0>, <133 0>, <134 0>,
 				     <135 0>, <136 0>;

--- a/dts/bindings/dma/st,stm32-bdma.yaml
+++ b/dts/bindings/dma/st,stm32-bdma.yaml
@@ -86,7 +86,7 @@ properties:
       plus the nb of dma channels of the 1st dma instance, etc.
 
   "#dma-cells":
-    const: 4
+    const: 3
 
 # Parameter syntax of stm32 follows the dma client dts syntax
 # in the Linux kernel declared in


### PR DESCRIPTION
There are three DMA cells but the binding sets the `dma-cells` property to `const: 4`. Fix the value in the binding and update DTSI accordingly so that `dma-cells` matches the number of DMA cells.