### PR TITLE
net: if: autoconfigure link-local address when DAD is disabled

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1286,6 +1286,69 @@ static void join_mcast_nodes(struct net_if *iface, struct net_in6_addr *addr)
 #define join_mcast_nodes(...)
 #endif /* CONFIG_NET_IPV6_MLD */
 
+/* Generate and add the interface's link-local address. This is run on interface
+ * bring-up regardless of DAD: with DAD it is the address DAD is started for,
+ * without DAD it is the only thing that adds the link-local address. Returns the
+ * added address, or NULL on error. May be called with or without the interface
+ * lock held (the lock is recursive).
+ */
+static struct net_if_addr *iface_ipv6_lladdr_add(struct net_if *iface)
+{
+	struct net_if_ipv6 *ipv6;
+	struct net_in6_addr addr = { };
+	struct net_if_addr *ifaddr = NULL;
+	int ret;
+
+	net_if_lock(iface);
+
+	ret = net_if_config_ipv6_get(iface, &ipv6);
+	if (ret < 0) {
+		if (ret != -ENOTSUP) {
+			NET_WARN("Cannot autoconfigure IPv6, config is not valid.");
+		}
+
+		goto out;
+	}
+
+	if (ipv6 == NULL) {
+		goto out;
+	}
+
+	ret = net_ipv6_addr_generate_iid(iface, NULL,
+					 COND_CODE_1(CONFIG_NET_IPV6_IID_STABLE,
+						     ((uint8_t *)&ipv6->network_counter),
+						     (NULL)),
+					 COND_CODE_1(CONFIG_NET_IPV6_IID_STABLE,
+						     (sizeof(ipv6->network_counter)),
+						     (0U)),
+					 COND_CODE_1(CONFIG_NET_IPV6_IID_STABLE,
+						     (COND_CODE_1(CONFIG_NET_IPV6_DAD,
+								  (ipv6->iid ?
+								   ipv6->iid->dad_count : 0U),
+								  (0U))),
+						     (0U)),
+					 &addr,
+					 net_if_get_link_addr(iface));
+	if (ret < 0) {
+		NET_WARN("IPv6 IID generation issue (%d)", ret);
+		goto out;
+	}
+
+	ifaddr = net_if_ipv6_addr_add(iface, &addr, NET_ADDR_AUTOCONF, 0);
+	if (ifaddr == NULL) {
+		NET_ERR("Cannot add %s address to interface %p",
+			net_sprint_ipv6_addr(&addr), iface);
+		goto out;
+	}
+
+	IF_ENABLED(CONFIG_NET_IPV6_IID_STABLE, (ipv6->iid = ifaddr));
+
+out:
+	net_if_unlock(iface);
+
+	return ifaddr;
+}
+
 #if defined(CONFIG_NET_IPV6_DAD)
 #define DAD_TIMEOUT 100U /* ms */
 
@@ -1392,54 +1455,24 @@ void net_if_ipv6_start_dad(struct net_if *iface,
 
 void net_if_start_dad(struct net_if *iface)
 {
-	struct net_if_addr *ifaddr, *next;
+	struct net_if_addr *ifaddr, *next, *lladdr;
 	struct net_if_ipv6 *ipv6;
 	sys_slist_t dad_needed;
-	struct net_in6_addr addr = { };
-	int ret;
 
 	net_if_lock(iface);
 
 	NET_DBG("Starting DAD for iface %d", net_if_get_by_iface(iface));
 
-	ret = net_if_config_ipv6_get(iface, &ipv6);
-	if (ret < 0) {
-		if (ret != -ENOTSUP) {
-			NET_WARN("Cannot do DAD IPv6 config is not valid.");
-		}
+	/* Add the link-local address. This also configures IPv6 on the
+	 * interface. As the interface is up, the address add starts DAD for it
+	 * directly, so it is skipped in the loop below.
+	 */
+	lladdr = iface_ipv6_lladdr_add(iface);
 
+	ipv6 = iface->config.ip.ipv6;
+	if (ipv6 == NULL) {
 		goto out;
 	}
-
-	if (!ipv6) {
-		goto out;
-	}
-
-	ret = net_ipv6_addr_generate_iid(iface, NULL,
-					 COND_CODE_1(CONFIG_NET_IPV6_IID_STABLE,
-						     ((uint8_t *)&ipv6->network_counter),
-						     (NULL)),
-					 COND_CODE_1(CONFIG_NET_IPV6_IID_STABLE,
-						     (sizeof(ipv6->network_counter)),
-						     (0U)),
-					 COND_CODE_1(CONFIG_NET_IPV6_IID_STABLE,
-						     (ipv6->iid ? ipv6->iid->dad_count : 0U),
-						     (0U)),
-					 &addr,
-					 net_if_get_link_addr(iface));
-	if (ret < 0) {
-		NET_WARN("IPv6 IID generation issue (%d)", ret);
-		goto out;
-	}
-
-	ifaddr = net_if_ipv6_addr_add(iface, &addr, NET_ADDR_AUTOCONF, 0);
-	if (!ifaddr) {
-		NET_ERR("Cannot add %s address to interface %p, DAD fails",
-			net_sprint_ipv6_addr(&addr), iface);
-		goto out;
-	}
-
-	IF_ENABLED(CONFIG_NET_IPV6_IID_STABLE, (ipv6->iid = ifaddr));
 
 	/* Start DAD for all the addresses that were added earlier when
 	 * the interface was down.
@@ -1449,7 +1482,7 @@ void net_if_start_dad(struct net_if *iface)
 	ARRAY_FOR_EACH(ipv6->unicast, i) {
 		if (!ipv6->unicast[i].is_used ||
 		    ipv6->unicast[i].address.family != NET_AF_INET6 ||
-		    &ipv6->unicast[i] == ifaddr ||
+		    &ipv6->unicast[i] == lladdr ||
 		    net_ipv6_is_addr_loopback(
 			    &ipv6->unicast[i].address.in6_addr)) {
 			continue;
@@ -3646,12 +3679,15 @@ static void iface_ipv6_start(struct net_if *iface)
 
 	if (IS_ENABLED(CONFIG_NET_IPV6_DAD)) {
 		net_if_start_dad(iface);
+	} else {
+		/* DAD normally generates the link-local address; do it here
+		 * when DAD is disabled. The address add joins the relevant
+		 * multicast groups (RFC 4291 ch 2.8), and the solicited-node
+		 * groups for any other addresses were already (re)joined by
+		 * rejoin_ipv6_mcast_groups() when the interface came up.
+		 */
+		iface_ipv6_lladdr_add(iface);
 	}
-
-	/* The all-nodes and per-address solicited-node multicast groups are
-	 * (re)joined by rejoin_ipv6_mcast_groups(), which runs just before this
-	 * from notify_iface_up() regardless of DAD. No extra join is needed here.
-	 */
 
 	net_if_start_rs(iface);
 }

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -1243,38 +1243,49 @@ ZTEST(net_iface, test_ipv4_maddr_foreach)
 	zassert_equal(count, 0, "Incorrect number of callback calls");
 }
 
+struct foreach_ipv6_ctx {
+	struct net_if *iface;
+	int count;
+};
+
 static void foreach_ipv6_addr_check(struct net_if *iface,
 				    struct net_if_addr *if_addr,
 				    void *user_data)
 {
-	int *count = (int *)user_data;
+	struct foreach_ipv6_ctx *ctx = user_data;
 
-	(*count)++;
+	ctx->count++;
 
-	zassert_equal_ptr(iface, iface1, "Callback called on wrong interface");
+	zassert_equal_ptr(iface, ctx->iface, "Callback called on wrong interface");
 
 	if (net_ipv6_is_ll_addr(&if_addr->address.in6_addr)) {
-		zassert_mem_equal(&if_addr->address.in6_addr, &ll_addr,
-				  sizeof(struct net_in6_addr), "Wrong IPv6 address");
-	} else {
-		zassert_mem_equal(&if_addr->address.in6_addr, &my_addr1,
-				  sizeof(struct net_in6_addr), "Wrong IPv6 address");
+		/* iface1 has both a manually configured link-local address and
+		 * the one autoconfigured on bring-up; accept any link-local.
+		 */
+		return;
 	}
+
+	zassert_mem_equal(&if_addr->address.in6_addr, &my_addr1,
+			  sizeof(struct net_in6_addr), "Wrong IPv6 address");
 }
 
 ZTEST(net_iface, test_ipv6_addr_foreach)
 {
-	int count = 0;
+	struct foreach_ipv6_ctx ctx;
 
-	/* iface1 has two IPv6 addresses configured */
-	net_if_ipv6_addr_foreach(iface1, foreach_ipv6_addr_check, &count);
-	zassert_equal(count, 2, "Incorrect number of callback calls");
+	/* iface1 has my_addr1, a manually configured link-local address and
+	 * the link-local address autoconfigured on bring-up.
+	 */
+	ctx.iface = iface1;
+	ctx.count = 0;
+	net_if_ipv6_addr_foreach(iface1, foreach_ipv6_addr_check, &ctx);
+	zassert_equal(ctx.count, 3, "Incorrect number of callback calls");
 
-	count = 0;
-
-	/* iface4 has no IPv6 address configured */
-	net_if_ipv6_addr_foreach(iface4, foreach_ipv6_addr_check, &count);
-	zassert_equal(count, 0, "Incorrect number of callback calls");
+	/* iface4 only has the link-local address autoconfigured on bring-up. */
+	ctx.iface = iface4;
+	ctx.count = 0;
+	net_if_ipv6_addr_foreach(iface4, foreach_ipv6_addr_check, &ctx);
+	zassert_equal(ctx.count, 1, "Incorrect number of callback calls");
 }
 
 static void foreach_ipv6_maddr_check(struct net_if *iface,

--- a/tests/net/iface_with_mld/src/main.c
+++ b/tests/net/iface_with_mld/src/main.c
@@ -278,4 +278,28 @@ ZTEST(net_iface_with_mld, test_addr_add_joins_solicited_node)
 	zassert_true(ret, "Cannot remove IPv6 address from dad_iface");
 }
 
+/*
+ * Bringing an interface up must autoconfigure its IPv6 link-local address
+ * regardless of whether DAD is enabled. The address generation used to be a
+ * side effect of starting DAD, so it was skipped entirely when
+ * CONFIG_NET_IPV6_DAD was disabled, leaving the interface with no link-local
+ * address. The no_dad test variant exercises that case.
+ */
+ZTEST(net_iface_with_mld, test_bringup_adds_link_local)
+{
+	const struct net_in6_addr *ll;
+
+	/* Another test in this suite may have brought the interface up
+	 * already; net_if_up() returns -EALREADY in that case.
+	 */
+	if (!net_if_is_up(dad_iface)) {
+		int ret = net_if_up(dad_iface);
+
+		zassert_ok(ret, "Cannot bring dad_iface up");
+	}
+
+	ll = net_if_ipv6_get_ll(dad_iface, NET_ADDR_ANY_STATE);
+	zassert_not_null(ll, "No link-local address configured on interface bring-up");
+}
+
 ZTEST_SUITE(net_iface_with_mld, NULL, iface_with_mld_setup, NULL, NULL, NULL);

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -142,6 +142,13 @@ static void net_test_iface_init(struct net_if *iface)
 	uint8_t *mac = net_test_get_mac(net_if_get_device(iface));
 
 	net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
+
+	/* These tests exercise the IP address helpers with a precisely
+	 * controlled set of addresses, so disable neighbor discovery to keep
+	 * the interface from autoconfiguring its own link-local address on
+	 * bring-up.
+	 */
+	net_if_flag_set(iface, NET_IF_IPV6_NO_ND);
 }
 
 static int tester_send(const struct device *dev, struct net_pkt *pkt)


### PR DESCRIPTION
The interface link-local address is generated as a side effect of `net_if_start_dad()`, which only runs when DAD is enabled. With
`CONFIG_NET_IPV6_DAD` disabled an interface therefore came up without any link-local address, breaking IPv6 on it.

Extract the link-local generation into `iface_ipv6_lladdr_add()` and call it from `net_if_start_dad()` (which no longer duplicates the IID generation) and, when DAD is disabled, from `iface_ipv6_start()`.

Adapt the `net.iface` and `net.ip-addr` tests, which run with DAD disabled and relied on interfaces not autoconfiguring a link-local address.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/112273 and https://github.com/zephyrproject-rtos/zephyr/pull/112292