### PR TITLE
Bluetooth: Audio: Fix comment typo

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -90,9 +90,9 @@ struct bt_audio_codec_octets_per_codec_frame {
  * @name Unicast Announcement Type
  * @{
  */
-/** Unicast Server is connectable and is requesting a connection. */
+/** Unicast Server is connectable and is not requesting a connection. */
 #define BT_AUDIO_UNICAST_ANNOUNCEMENT_GENERAL    0x00U
-/** Unicast Server is connectable but is not requesting a connection. */
+/** Unicast Server is connectable but is requesting a connection. */
 #define BT_AUDIO_UNICAST_ANNOUNCEMENT_TARGETED   0x01U
 /** @} */
 

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -108,7 +108,7 @@ extern "C" {
 /**
  * @brief Recommended connection parameters for coexistence of ACL and ISO
  *
- * Defined by Table 8.3 in BAP 1.0.2
+ * Defined by Table 8.4 in BAP 1.0.2
  */
 #define BT_BAP_CONN_PARAM_RELAXED                                                                  \
 	BT_LE_CONN_PARAM(BT_GAP_MS_TO_CONN_INTERVAL(50), BT_GAP_MS_TO_CONN_INTERVAL(70), 0,        \


### PR DESCRIPTION
Refers to BAP v1.0.2:
* Table 3.7: Unicast Server AD format when connectable and available to receive or transmit audio data
* Table 8.4: Recommended range for relaxed connection interval values