### PR TITLE
samples: net: latmon: update Latmus benchmark links

### DIFF
--- a/samples/net/latmon/README.rst
+++ b/samples/net/latmon/README.rst
@@ -21,7 +21,7 @@ GPIO events using:
   and generate histogram data.
 
 This project is part of the open-source initiative
-`EVL Project - Latmus GPIO Response Time <https://evlproject.org/core/benchmarks/#latmus-gpio-response-time>`_.
+`EVL Project - Latmus GPIO Response Time <https://v4.xenomai.org/core/benchmarks/#latmus-gpio-response-time>`_.
 
 The main program is designed to monitor latency using GPIO pins on a Zephyr-based system. It generates a
 pulse signal on a GPIO pin and measures the time it takes for the SUT (executing Latmus) to respond to
@@ -100,7 +100,7 @@ Setup and Usage
 
 - **Run Latmus on the SUT**
 
-  Request the appropriate options with `Latmus <https://evlproject.org/core/testing/#latmus-program>`_. Users
+  Request the appropriate options with `Latmus <https://v4.xenomai.org/core/testing/#latmus-program>`_. Users
   can for example modify the sampling period with the ``-p`` option or generate histogram data for
   postprocessing with the ``-g`` option,
 


### PR DESCRIPTION
The latmon sample README referenced the Latmus GPIO response time benchmark and the latmus program on evlproject.org. The EVL project is the development effort that became Xenomai 4, and its documentation was rebranded onto the v4.xenomai.org domain (alongside v3.xenomai.org for Xenomai 3) around September 2023 - the earliest archived snapshot of v4.xenomai.org dates to 2023-09-24, with the rebrand landing in the website repository across August-September 2023.

While evlproject.org still mirrors the same content, v4.xenomai.org is now the canonical location. Update both references in the latmon sample README accordingly:

- core/benchmarks/#latmus-gpio-response-time
- core/testing/#latmus-program

Assisted-by: Claude:claude-opus-4.8