### PR TITLE
doc: net: latmon: fix Latmus role in net_latmon_connect description

### DIFF
--- a/include/zephyr/net/latmon.h
+++ b/include/zephyr/net/latmon.h
@@ -39,7 +39,7 @@ typedef int (*net_latmon_measure_t)(uint32_t *delta);
  *
  * @details This function starts the latency monitor, which measures
  * latency using the provided callback function to calculate deltas. Samples
- * are sent to the connected Latmus client.
+ * are sent to the connected Latmus service.
  *
  * @param latmus A valid socket descriptor connected to latmus
  * @param measure_func A callback function to execute the delta calculation.
@@ -47,10 +47,10 @@ typedef int (*net_latmon_measure_t)(uint32_t *delta);
 void net_latmon_start(int latmus, net_latmon_measure_t measure_func);
 
 /**
- * @brief Wait for a connection from a Latmus client.
+ * @brief Wait for a connection from the Latmus service.
  *
- * @details This function blocks until a Latmus client connects to the
- * specified socket. Once connected, the client's IP address is stored
+ * @details This function blocks until the Latmus service connects to the
+ * specified socket. Once connected, the Latmus service's IP address is stored
  * in the provided `ip` structure.
  *
  * @param socket A valid socket descriptor for listening.


### PR DESCRIPTION
The doxygen comments for net_latmon_connect() and net_latmon_start() described the peer that connects to Latmon as a "Latmus client". This contradicts the rest of the documentation: Latmon is the TCP server (net_latmon_get_socket() binds and listens, net_latmon_connect() calls accept()), while Latmus is the service running on the SUT that initiates the connection. The networking API docs and the sample README consistently refer to it as the "Latmus service" (and the Latmon sample itself is the "Latmon Client"), so the header wording was both wrong and confusing.

Align the header with the implementation and the .rst documentation by referring to the connecting peer as the Latmus service.

Assisted-by: Claude:claude-opus-4.8