### PR TITLE
manifest: mbedtls: pull update of CPE vendor to 'trustedfirmware'

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -324,7 +324,7 @@ manifest:
       revision: bbedf2656086a93a8468a1c98168a6b36631ce9a
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 554163f6f7b2ec71fed9b423e81f2217a8615d29
+      revision: c53cc657cedbd17c009cb676a17bffb28b6650a3
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
Pick up change from arm to trustedfirmware, matching NIST's current mbed_tls CPE vendor.