### PR TITLE
address documentation gaps / enhance kernel docs

### DIFF
--- a/doc/kernel/memory_management/demand_paging.rst
+++ b/doc/kernel/memory_management/demand_paging.rst
@@ -69,6 +69,16 @@ a considerable amount of time. This frees up page frames so that the next
 page in can be executed faster as the paging code does not need to invoke
 the eviction algorithm.
 
+A data region can also be **pinned** in physical memory using
+:c:func:`k_mem_pin()`. This pages the region in if necessary and marks its page
+frames so that the eviction algorithm will never select them, guaranteeing that
+the region remains resident and that accesses to it never fault. This is a
+stronger form of :c:func:`k_mem_page_in()` and is appropriate for latency- or
+safety-critical data that must always be available. A pinned region is later
+released with :c:func:`k_mem_unpin()`, which marks the page frames as evictable
+again; unpinning does not itself evict the region, so it may be followed by
+:c:func:`k_mem_page_out()` if immediate eviction is desired.
+
 Terminology
 ***********
 

--- a/doc/kernel/memory_management/heap.rst
+++ b/doc/kernel/memory_management/heap.rst
@@ -34,6 +34,15 @@ until memory is available.  The final argument is a
 sleep before returning, or else one of the constant timeout values
 :c:macro:`K_NO_WAIT` or :c:macro:`K_FOREVER`.
 
+When a block with a specific alignment is required, :c:func:`k_heap_aligned_alloc`
+allocates a block whose start address is a multiple of a caller-supplied power-of-two
+alignment.  :c:func:`k_heap_calloc` allocates and zero-initializes an array.
+
+The size of an existing allocation can be changed with :c:func:`k_heap_realloc`,
+which returns a block of the requested size while preserving the contents up to
+the smaller of the old and new sizes.  As with the standard C ``realloc()``, the
+returned pointer may differ from the original.
+
 Releasing Memory
 ================
 
@@ -42,6 +51,16 @@ Memory allocated with :c:func:`k_heap_alloc` must be released using
 provided must be either a ``NULL`` value or a pointer previously
 returned by :c:func:`k_heap_alloc` for the same heap.  Freeing a
 ``NULL`` value is defined to have no effect.
+
+Enumerating Heaps
+=================
+
+All heaps defined statically with :c:macro:`K_HEAP_DEFINE` are placed in a
+dedicated linker section, which allows them to be enumerated at run time.
+:c:func:`k_heap_array_get` returns the address of the array of statically
+defined heaps and the number of entries it contains.  This is primarily useful
+for instrumentation and diagnostics that need to inspect every heap in the
+system.
 
 Low Level Heap Allocator
 ************************

--- a/doc/kernel/memory_management/slabs.rst
+++ b/doc/kernel/memory_management/slabs.rst
@@ -135,6 +135,18 @@ then releases it once it is no longer needed.
     ... /* use memory block pointed at by block_ptr */
     k_mem_slab_free(&my_slab, (void *)block_ptr);
 
+Querying Slab Usage
+===================
+
+The current utilization of a memory slab can be queried at run time.
+:c:func:`k_mem_slab_num_used_get` returns the number of blocks currently
+allocated, and :c:func:`k_mem_slab_num_free_get` returns the number of blocks
+still available. When :kconfig:option:`CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION`
+is enabled, :c:func:`k_mem_slab_max_used_get` reports the peak number of blocks
+that have been allocated simultaneously, and
+:c:func:`k_mem_slab_runtime_stats_get` returns these figures together in a
+:c:struct:`sys_memory_stats` structure.
+
 Suggested Uses
 **************
 

--- a/doc/kernel/services/data_passing/queues.rst
+++ b/doc/kernel/services/data_passing/queues.rst
@@ -9,6 +9,18 @@ to a FIFO and serves as the underlying implementation for both :ref:`k_fifo
 <fifos_v2>` and :ref:`k_lifo <lifos_v2>`. For more information on usage see
 :ref:`k_fifo <fifos_v2>`.
 
+Cancelling a Wait
+*****************
+
+A thread that is blocked waiting to retrieve an item from a queue can be released
+without an item by calling :c:func:`k_queue_cancel_wait` from another thread or
+an ISR. The first thread pending on the queue returns from its
+:c:func:`k_queue_get` call with a ``NULL`` value, exactly as if its timeout had
+expired. If the queue is instead being waited on through :c:func:`k_poll`, that
+call returns ``-EINTR`` with the poll event in the cancelled state.
+
+This mechanism is also available to the queue-based primitives through
+:c:macro:`k_fifo_cancel_wait` and :c:macro:`k_lifo_cancel_wait`.
 
 Configuration Options
 *********************

--- a/doc/kernel/services/other/fatal.rst
+++ b/doc/kernel/services/other/fatal.rst
@@ -234,6 +234,19 @@ that the entire stack buffer has overflowed, but instead that the current
 function stack frame has been corrupted. See the compiler documentation for
 more details.
 
+By default a single canary value, generated at boot, is shared by all threads.
+When :kconfig:option:`CONFIG_STACK_CANARIES_TLS` is enabled, the canary is
+instead stored in :ref:`thread-local storage <thread_local_storage>` so that
+each thread has its own value, making the canary location and value harder to
+predict at the cost of additional per-thread setup.
+
+As a complementary hardening measure, :kconfig:option:`CONFIG_STACK_POINTER_RANDOM`
+applies a randomized offset to each thread's initial stack pointer when the
+thread is created. This is a limited form of address space layout randomization
+that makes the location of any given stack frame non-deterministic, hindering
+some classes of security attack, at the cost of consuming up to the configured
+number of bytes from each thread's stack region.
+
 Other Exceptions
 ================
 

--- a/doc/kernel/services/other/float.rst
+++ b/doc/kernel/services/other/float.rst
@@ -27,6 +27,14 @@ required by an application. Three modes of operation are supported,
 which are described below. In addition, the kernel's support for the SSE
 registers can be included or omitted, as desired.
 
+A thread's participation in floating point context preservation can also be
+managed at run time. :c:func:`k_float_enable` enables preservation for a thread
+and accepts options -- such as :c:macro:`K_FP_REGS` and :c:macro:`K_SSE_REGS` --
+that select which register sets are preserved, while :c:func:`k_float_disable`
+turns preservation off again. On targets that do not implement floating point
+context management these routines return ``-ENOTSUP``, and they return
+``-EINVAL`` if the request is otherwise invalid and cannot be performed.
+
 No FP registers mode
 ====================
 

--- a/doc/kernel/services/scheduling/index.rst
+++ b/doc/kernel/services/scheduling/index.rst
@@ -200,6 +200,22 @@ only when dealing with lower priority threads that are less time-sensitive.
    execute. However, the algorithm *does* ensure that a thread never executes
    for longer than a single time slice without being required to yield.
 
+Per-Thread Time Slicing
+=======================
+
+The time slice configured with :c:func:`k_sched_time_slice_set` applies globally
+to every preemptible thread at or below a given priority. When
+:kconfig:option:`CONFIG_TIMESLICE_PER_THREAD` is enabled, an individual thread
+can instead be given its own time slice with :c:func:`k_thread_time_slice_set`.
+A per-thread slice takes precedence over the global value, and is applied even to
+threads whose priority is above the global time-slicing limit.
+
+In addition to a slice duration (expressed in ticks), a per-thread slice
+registers a callback that the kernel invokes when the slice expires. This
+callback runs in interrupt context while the affected thread is still the current
+thread, and may, for example, adjust the thread's priority or slice for its next
+execution, or suspend it.
+
 Scheduler Locking
 =================
 
@@ -251,6 +267,32 @@ that delays its processing for a specified time period
 A busy wait is typically used instead of thread sleeping
 when the required delay is too short to warrant having the scheduler
 context switch from the current thread to another thread and then back again.
+
+Forcing a Scheduling Decision
+=============================
+
+A thread can force the scheduler to make an immediate scheduling decision on the
+current CPU by calling :c:func:`k_reschedule`. When invoked from a thread (with
+interrupts unlocked) the scheduler runs immediately; when invoked from an ISR the
+decision is deferred until the ISR exits.
+
+Unlike :c:func:`k_yield`, this routine does not guarantee a switch to a thread of
+equal or higher priority -- it simply asks the kernel to re-evaluate which thread
+should run next given the current state. Most applications never need this
+routine.
+
+Querying Preemptibility
+=======================
+
+Code whose behavior depends on whether it can be preempted can query the current
+context with :c:func:`k_is_preempt_thread`. This returns a non-zero value only
+when the caller is a thread (not an ISR), the thread's priority is in the
+preemptible range, and the thread has not locked the scheduler.
+
+The related :c:func:`k_can_yield` routine reports whether the current context is
+able to yield or invoke blocking APIs at all. It returns false in contexts such
+as ISRs, the pre-kernel initialization phase, or the idle thread, where yielding
+is not possible.
 
 Suggested Uses
 **************

--- a/doc/kernel/services/smp/smp.rst
+++ b/doc/kernel/services/smp/smp.rst
@@ -72,6 +72,13 @@ recursive semantics above, spinlocks in single-CPU contexts produce
 identical code to legacy IRQ locks.  In fact the entirety of the
 Zephyr core kernel has now been ported to use spinlocks exclusively.
 
+The default spinlock implementation is built on a single atomic variable and
+does not guarantee fairness between contending CPUs: it is possible for one CPU
+to repeatedly win the contention, in pathological cases starving the others.
+Where this matters, enabling :kconfig:option:`CONFIG_TICKET_SPINLOCKS` switches
+to a ticket-based implementation that grants a contended lock to requesting CPUs
+in first-come, first-served order, at the cost of a slightly larger lock object.
+
 Legacy irq_lock() emulation
 ===========================
 
@@ -92,6 +99,23 @@ impact, however.  Unlike uniprocessor apps, SMP apps using
 instruction) interrupt masking operation.  That, and the fact that the
 IRQ lock is global, means that code expecting to be run in an SMP
 context should be using the spinlock API wherever possible.
+
+Memory Coherence
+================
+
+Some multiprocessor architectures are *cache-incoherent*: the per-CPU caches are
+not automatically kept consistent with each other, so data written by one CPU may
+not be visible to another until it is flushed from the cache. On such systems,
+shared kernel data structures must reside in memory that all CPUs observe
+consistently.
+
+When :kconfig:option:`CONFIG_KERNEL_COHERENCE` is enabled, the kernel places all
+shared data into multiprocessor-coherent (generally uncached) memory. Thread
+stacks remain cached, as does application memory explicitly declared with
+``__incoherent``. This mode is intended only for SMP kernels running on
+cache-incoherent architectures, and it carries an implicit API contract: any
+memory passed to the kernel is assumed to be cache-coherent, so kernel data
+structures must not be created in uncached regions.
 
 .. _smp_cpu_mask:
 
@@ -176,6 +200,15 @@ API.
    Example SMP initialization process, showing a configuration with
    two CPUs and two app threads which begin operating simultaneously.
 
+By default the kernel brings up every available CPU during this start-up
+sequence. When :kconfig:option:`CONFIG_SMP_BOOT_DELAY` is enabled the kernel
+skips bringing up the secondary CPUs at initialization, leaving them disabled so
+that architecture, SoC, board, or application code can start them later at run
+time. A deferred CPU is started with :c:func:`k_smp_cpu_start`, which performs
+full per-CPU initialization; :c:func:`k_smp_cpu_resume` is the counterpart used
+to bring a previously stopped CPU back online without repeating one-time
+initialization.
+
 Interprocessor Interrupts
 *************************
 
@@ -208,6 +241,11 @@ scheduler will get invoked on those CPUs. The expectation is that these
 APIs will evolve over time to encompass more functionality (e.g. cross-CPU
 calls), and that the scheduler-specific calls here will be implemented in
 terms of a more general framework.
+
+When directed IPIs are available, the scheduler signals only those CPUs that
+actually need to reschedule when a thread becomes ready, rather than broadcasting
+to every other CPU. This avoids disturbing CPUs whose currently running thread
+does not need to be preempted, reducing the overall interrupt load.
 
 Note that not all SMP architectures will have a usable IPI mechanism
 (either missing, or just undocumented/unimplemented).  In those cases

--- a/doc/kernel/services/synchronization/condvar.rst
+++ b/doc/kernel/services/synchronization/condvar.rst
@@ -35,6 +35,11 @@ the condition using :c:func:`k_condvar_signal` or
 #. Re-acquires the mutex previously released.
 #. Returns from :c:func:`k_condvar_wait`.
 
+Regardless of why the wait completes -- whether the thread was signaled, the
+supplied timeout elapsed, or the wait was requested without blocking --
+:c:func:`k_condvar_wait` always returns with the associated mutex re-locked by
+the calling thread.
+
 A condition variable must be initialized before it can be used.
 
 

--- a/doc/kernel/services/threads/index.rst
+++ b/doc/kernel/services/threads/index.rst
@@ -74,6 +74,18 @@ executing. A cancellation request has no effect if the thread has already
 started. A thread whose delayed start was successfully canceled must be
 re-spawned before it can be used.
 
+Starting a Thread
+=================
+
+A thread that is created with :c:macro:`K_FOREVER` as its start delay is not
+added to the scheduler's ready queue and does not begin executing until it is
+explicitly started. The :c:func:`k_thread_start` function starts such an
+inactive thread, making it eligible for scheduling. Starting a thread that has
+already started has no effect.
+
+This is useful when a thread object must be created at one point in time but its
+execution deferred until the application has completed additional setup.
+
 Thread Termination
 ===================
 
@@ -228,7 +240,7 @@ have an identical effect to the ``K_KERNEL_STACK`` macros.
 .. _thread_priorities:
 
 Thread Priorities
-******************
+*****************
 
 A thread's priority is an integer value, and can be either negative or
 non-negative.
@@ -414,6 +426,79 @@ each thread calls a specific routine.
 Use thread custom data to allow a routine to access thread-specific information,
 by using the custom data as a pointer to a data structure owned by the thread.
 
+.. _thread_name_v2:
+
+Thread Name
+***********
+
+When :kconfig:option:`CONFIG_THREAD_NAME` is enabled, a human-readable name can
+be associated with each thread. Names are primarily an aid for debugging,
+logging, and shell introspection; the kernel does not use them for scheduling.
+
+A thread name may be assigned in one of two ways:
+
+* Statically, by passing a name to :c:macro:`K_THREAD_DEFINE`.
+* At run time, using :c:func:`k_thread_name_set`. The supplied string must
+  remain valid for the lifetime of the thread, as only a pointer to it is
+  retained.
+
+A thread's name can be retrieved with :c:func:`k_thread_name_get`, which returns
+a pointer to the name string, or with :c:func:`k_thread_name_copy`, which copies
+the name into a caller-supplied buffer. The copying variant is the safe choice
+from user mode, where the calling thread may not have access to the memory
+backing another thread's name.
+
+If :kconfig:option:`CONFIG_THREAD_NAME` is not enabled,
+:c:func:`k_thread_name_set` returns an error and :c:func:`k_thread_name_get`
+returns ``NULL``.
+
+Thread Introspection
+********************
+
+The kernel provides several interfaces for inspecting threads at run time.
+
+**Identifying the current thread**
+    :c:func:`k_current_get` returns the thread id (:c:type:`k_tid_t`) of the
+    thread that is currently executing. This id can be passed to the other
+    thread APIs to operate on the calling thread.
+
+**Reading a thread's priority**
+    :c:func:`k_thread_priority_get` returns the current scheduling priority of a
+    thread. This reflects any changes made since the thread was created, for
+    example by :c:func:`k_thread_priority_set`.
+
+**Obtaining a thread's state**
+    :c:func:`k_thread_state_str` writes a human-readable representation of a
+    thread's current state (for example ``pending``, ``suspended``, or
+    ``ready``) into a caller-supplied buffer. This is intended for diagnostic
+    output and should not be parsed programmatically.
+
+**Iterating over all threads**
+    When :kconfig:option:`CONFIG_THREAD_MONITOR` is enabled,
+    :c:func:`k_thread_foreach` invokes a caller-supplied callback once for each
+    thread in the system. It holds an internal lock that blocks thread creation
+    and termination for the duration of the iteration, which guarantees a
+    consistent snapshot of the thread list but can introduce latency
+    proportional to the number of threads. :c:func:`k_thread_foreach_unlocked`
+    is a lower-latency variant that releases the lock around each callback at the
+    cost of a less strictly consistent view.
+
+**Querying stack usage**
+    When :kconfig:option:`CONFIG_INIT_STACKS` and
+    :kconfig:option:`CONFIG_THREAD_STACK_INFO` are enabled,
+    :c:func:`k_thread_stack_space_get` reports the number of unused bytes
+    remaining in a thread's stack, computed by scanning the stack for its unused
+    (still-initialized) region. This complements the build-time stack analysis
+    tools and the runtime stack safety feature described below.
+
+**Querying a pending timeout**
+    A thread that is blocked on a timed operation (such as :c:func:`k_sleep` or
+    a kernel object operation with a timeout) has a pending timeout. Its
+    remaining duration can be queried in ticks with
+    :c:func:`k_thread_timeout_remaining_ticks`, and the absolute system tick at
+    which it will expire with :c:func:`k_thread_timeout_expires_ticks`. Both
+    return zero if the thread has no pending timeout.
+
 Implementation
 **************
 
@@ -586,6 +671,19 @@ Here is an example:
    k_thread_runtime_stats_get(k_current_get(), &rt_stats_thread);
 
    printk("Cycles: %llu\n", rt_stats_thread.execution_cycles);
+
+The combined statistics for every thread in the system can be retrieved with
+:c:func:`k_thread_runtime_stats_all_get`, which reports the aggregate runtime
+usage across all threads (including the idle thread). This is useful for
+computing overall CPU utilization.
+
+When :kconfig:option:`CONFIG_SCHED_THREAD_USAGE` is enabled, statistics
+collection can be toggled at run time on a per-thread basis with
+:c:func:`k_thread_runtime_stats_enable` and
+:c:func:`k_thread_runtime_stats_disable`. Whether collection is currently active
+for a thread can be checked with :c:func:`k_thread_runtime_stats_is_enabled`.
+Disabling collection for threads that do not need to be measured reduces the
+bookkeeping overhead incurred on each context switch.
 
 Runtime Stack Safety
 ********************

--- a/doc/kernel/services/timing/timers.rst
+++ b/doc/kernel/services/timing/timers.rst
@@ -105,6 +105,22 @@ returns the timer's status and resets it to zero.
     with a given timer. ISRs are not permitted to synchronize with timers,
     since ISRs are not allowed to block.
 
+Timer Observers
+***************
+
+When :kconfig:option:`CONFIG_TIMER_OBSERVER` is enabled, code can register
+:dfn:`timer observers` that are notified of timer lifecycle events across all
+timers in the system. An observer is a set of optional callbacks invoked when a
+timer is initialized, started, stopped, or expires. This allows external modules
+-- for example tracing, profiling, or power-management code -- to react to timer
+activity without modifying kernel internals or the individual timers.
+
+An observer is defined statically with :c:macro:`K_TIMER_OBSERVER_DEFINE`, which
+takes pointers to the ``on_init``, ``on_start``, ``on_stop``, and ``on_expiry``
+callbacks; any callback that is not needed may be passed as ``NULL``. Because the
+expiry callback runs in interrupt context, it must be kept short and
+non-blocking.
+
 Implementation
 **************
 

--- a/doc/kernel/usermode/syscalls.rst
+++ b/doc/kernel/usermode/syscalls.rst
@@ -383,6 +383,13 @@ the copy and not the original data sent by the user. The
 :c:func:`k_usermode_to_copy()` and :c:func:`k_usermode_from_copy()` APIs exist for
 this purpose.
 
+C strings passed from user mode need similar care, since their length is not
+known in advance and the terminating ``NUL`` must be located without reading
+past memory the caller can access. The :c:func:`k_usermode_string_copy()` and
+:c:func:`k_usermode_string_alloc_copy()` helpers safely validate and copy a
+user-supplied string into kernel-controlled memory before it is used by the
+implementation function.
+
 There is one exception in place, with respect to large data buffers which are
 only used to provide a memory area that is either only written to, or whose
 contents are never used for any validation or control flow. Further


### PR DESCRIPTION
- **doc: kernel: document demand paging memory pinning**
- **doc: kernel: document additional heap APIs**
- **doc: kernel: document memory slab usage queries**
- **doc: kernel: document cancelling a queue wait**
- **doc: kernel: document stack canary TLS and pointer randomization**
- **doc: kernel: document runtime floating point enable/disable**
- **doc: kernel: clarify condvar mutex re-lock on wait return**
- **doc: kernel: document timer observers**
- **doc: kernel: document user mode string copy helpers**
- **doc: kernel: document additional scheduling APIs**
- **doc: kernel: document additional SMP features**
- **doc: kernel: document additional thread APIs**
