### PR TITLE
net: lib: coap: client: Wake poll() when a request is scheduled

### DIFF
--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -29,13 +29,22 @@ static struct coap_client *clients[CONFIG_COAP_CLIENT_MAX_INSTANCES];
 static int num_clients;
 static K_SEM_DEFINE(coap_client_recv_sem, 0, 1);
 
-/* Wakeup channel for the recv thread's poll(). coap_client_cancel_requests()
- * writes the eventfd to interrupt poll() immediately (instead of waiting up to
- * COAP_PERIODIC_TIMEOUT for the timeout) and waits on the ack sem until the
- * recv thread has cycled past poll(), so no poll() references a cancelled
- * request when cancel returns. The cancel mutex serialises waiters; the tid
- * lets a cancel issued from the recv thread (a response callback) skip the
- * self-wait.
+/* Wakeup channel for the recv thread's poll(). Writing the eventfd interrupts a
+ * blocked poll() immediately (instead of waiting up to COAP_PERIODIC_TIMEOUT for
+ * the timeout) so the recv loop rebuilds fds[] from current client state. Two
+ * callers use it:
+ *   - coap_client_schedule_poll() writes it when a request is submitted, so a
+ *     response on a newly-added or changed (e.g. reconnected) socket is polled
+ *     without waiting for the periodic timeout.
+ *   - coap_client_cancel_requests() writes it and then waits on the ack sem
+ *     until the recv thread has cycled past poll(), so no poll() references a
+ *     cancelled request when cancel returns. The cancel mutex serialises
+ *     waiters; the tid lets a cancel issued from the recv thread (a response
+ *     callback) skip the self-wait.
+ * handle_poll() drains the eventfd on each wakeup and gives the ack sem; a
+ * schedule-driven wakeup therefore also pulses the ack sem, which is harmless
+ * because coap_client_wait_for_recv_cycle() resets it under the cancel mutex
+ * before waiting.
  */
 static int coap_client_recv_fd = -1;
 static k_tid_t coap_client_recv_tid;
@@ -112,6 +121,15 @@ static void coap_client_schedule_poll(struct coap_client *client, int sock,
 	internal_req->request_ongoing = true;
 
 	k_sem_give(&coap_client_recv_sem);
+
+	/* If the recv thread is already in poll() it holds a stale snapshot of
+	 * client->fd. Wake it so it rebuilds fds[] with the (possibly new) fd
+	 * before blocking again. Without this, a response on a new socket after
+	 * reconnect is invisible to poll() until the timeout fires.
+	 */
+	if (coap_client_recv_fd >= 0) {
+		(void)zvfs_eventfd_write(coap_client_recv_fd, 1);
+	}
 }
 
 static bool exchange_lifetime_exceeded(const struct coap_client_internal_request *internal_req)
@@ -1475,8 +1493,8 @@ void coap_client_recv(void *coap_cl, void *a, void *b)
 	coap_client_recv_tid = k_current_get();
 	coap_client_recv_fd = zvfs_eventfd(0, ZVFS_EFD_NONBLOCK);
 	if (coap_client_recv_fd < 0) {
-		LOG_ERR("Failed to create cancel-wakeup eventfd (%d); "
-			"coap_client_cancel_requests() will fall back to a timeout",
+		LOG_ERR("Failed to create poll-wakeup eventfd (%d); request "
+			"scheduling and cancellation will fall back to a timeout",
 			-errno);
 	}
 


### PR DESCRIPTION
`coap_client_schedule_poll()` only gives the `recv` semaphore, which wakes the `recv` thread when it is idle but does not interrupt a `poll()` that is already blocked. A request submitted mid-poll - in particular one whose socket changed after a reconnect - is then not watched until the current `poll()` returns, up to `COAP_PERIODIC_TIMEOUT` later, so its response is invisible for that window.

Write the recv-thread wakeup `eventfd` from `schedule_poll()` so a blocked `poll()` returns at once and the `recv` loop rebuilds `fds[]` with the current socket set. The `eventfd` is the same channel cancellation already uses; the resulting ack-sem pulse is harmless since the cancel path resets it under the cancel mutex before waiting. Update the eventfd documentation to cover the dual use.