### PR TITLE
tcp: recv: improvement on recv queue management 

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2564,6 +2564,23 @@ __syscall void *k_queue_peek_head(struct k_queue *queue);
 __syscall void *k_queue_peek_tail(struct k_queue *queue);
 
 /**
+ * @brief Peek element next to the one provided in the queue
+ *
+ * Return element next to the one provided without removing it.
+ * This operation requires finding the provided element before returning the next one,
+ * hence requiring O(N) time.
+ *
+ * @param queue Address of the queue.
+ * @param data Address of the element which next is being returned.
+ *
+ * @return element next to the one provided
+ * @return NULL if data is NULL
+ * @return NULL if the element provided is not in the list
+ * @return NULL if the element provided has no next
+ */
+__syscall void *k_queue_peek_next(struct k_queue *queue, void *data);
+
+/**
  * @brief Statically define and initialize a queue.
  *
  * The queue can be accessed outside the module where it is defined using:
@@ -3161,6 +3178,29 @@ struct k_fifo {
 	void *fpt_ret = k_queue_peek_tail(&(fifo)->_queue); \
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, peek_tail, fifo, fpt_ret); \
 	fpt_ret; \
+	})
+
+/**
+ * @brief Peek element next to the one provided in the FIFO queue
+ *
+ * Return element next to the one provided without removing it.
+ * This operation requires finding the provided element before returning the next one,
+ * hence requiring O(N) time.
+ *
+ * @param fifo Address of the FIFO queue.
+ * @param data Address of the element which next is being returned.
+ *
+ * @return element next to the one provided
+ * @return NULL if data is NULL
+ * @return NULL if the element provided is not in the list
+ * @return NULL if the element provided has no next
+ */
+#define k_fifo_peek_next(fifo, data)                                                               \
+	({                                                                                         \
+		SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_fifo, peek_next, fifo, data);                    \
+		void *fpt_ret = k_queue_peek_next(&(fifo)->_queue, data);                          \
+		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, peek_next, fifo, data, fpt_ret);            \
+		fpt_ret;                                                                           \
 	})
 
 /**

--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -1099,6 +1099,13 @@
  */
 #define sys_port_trace_k_queue_peek_tail(queue, ret)
 
+/**
+ * @brief Trace Queue peek next
+ * @param queue Queue object
+ * @param ret Return value
+ */
+#define sys_port_trace_k_queue_peek_next(queue, data, ret)
+
 /** @} */ /* end of subsys_tracing_apis_queue */
 
 /**
@@ -1230,6 +1237,19 @@
  * @param ret Return value
  */
 #define sys_port_trace_k_fifo_peek_tail_exit(fifo, ret)
+
+/**
+ * @brief Trace FIFO Queue peek next entry
+ * @param fifo FIFO object
+ */
+#define sys_port_trace_k_fifo_peek_next_enter(fifo)
+
+/**
+ * @brief Trace FIFO Queue peek next exit
+ * @param fifo FIFO object
+ * @param ret Return value
+ */
+#define sys_port_trace_k_fifo_peek_next_exit(fifo, ret)
 
 /** @} */ /* end of subsys_tracing_apis_fifo */
 

--- a/include/zephyr/tracing/tracking.h
+++ b/include/zephyr/tracing/tracking.h
@@ -90,6 +90,7 @@ extern struct k_event *_track_list_k_event;
 	sys_track_k_timer_init(timer)
 #define sys_port_track_k_queue_peek_tail(queue, ret)
 #define sys_port_track_k_queue_peek_head(queue, ret)
+#define sys_port_track_k_queue_peek_next(queue, data, ret)
 #define sys_port_track_k_queue_cancel_wait(queue)
 #define sys_port_track_k_queue_init(queue) \
 	sys_track_k_queue_init(queue)
@@ -150,6 +151,7 @@ void sys_track_socket_init(int sock, int family, int type, int proto);
 #define sys_port_track_k_timer_init(timer)
 #define sys_port_track_k_queue_peek_tail(queue, ret)
 #define sys_port_track_k_queue_peek_head(queue, ret)
+#define sys_port_track_k_queue_peek_next(queue, data, ret)
 #define sys_port_track_k_queue_cancel_wait(queue)
 #define sys_port_track_k_queue_init(queue)
 #define sys_port_track_k_pipe_init(pipe, buffer, buffer_size)

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -416,6 +416,33 @@ void *z_impl_k_queue_peek_tail(struct k_queue *queue)
 	return ret;
 }
 
+void *z_impl_k_queue_peek_next(struct k_queue *queue, void *data)
+{
+	k_spinlock_key_t key = k_spin_lock(&queue->lock);
+	void *ret = NULL;
+	sys_sfnode_t *cur = NULL;
+
+	if (data == NULL) {
+		goto out;
+	}
+
+	SYS_SFLIST_FOR_EACH_NODE(&queue->data_q, cur) {
+		ret = z_queue_node_peek(cur, false);
+		if (ret == data) {
+			break;
+		}
+	}
+
+	ret = z_queue_node_peek(sys_sflist_peek_next(cur), false);
+
+out:
+	k_spin_unlock(&queue->lock, key);
+
+	SYS_PORT_TRACING_OBJ_FUNC(k_queue, peek_next, queue, data, ret);
+
+	return ret;
+}
+
 #ifdef CONFIG_USERSPACE
 static inline void *z_vrfy_k_queue_get(struct k_queue *queue,
 				       k_timeout_t timeout)
@@ -445,6 +472,13 @@ static inline void *z_vrfy_k_queue_peek_tail(struct k_queue *queue)
 	return z_impl_k_queue_peek_tail(queue);
 }
 #include <zephyr/syscalls/k_queue_peek_tail_mrsh.c>
+
+static inline void *z_vrfy_k_queue_peek_next(struct k_queue *queue, void *data)
+{
+	K_OOPS(K_SYSCALL_OBJ(queue, K_OBJ_QUEUE));
+	return z_impl_k_queue_peek_next(queue, data);
+}
+#include <zephyr/syscalls/k_queue_peek_next_mrsh.c>
 
 #endif /* CONFIG_USERSPACE */
 

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1375,26 +1375,15 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 	size_t len;
 	size_t pkt_len;
 	size_t recv_len = 0;
-	struct net_pkt *pkt;
+	struct net_pkt *pkt, *next = NULL;
 	struct net_pkt_cursor backup;
-	struct net_pkt *origin = NULL;
 	const bool do_recv = !(buf == NULL || max_len == NULL);
 	size_t _max_len = (max_len == NULL) ? SIZE_MAX : *max_len;
 	const bool peek = (flags & ZSOCK_MSG_PEEK) == ZSOCK_MSG_PEEK;
-	const struct net_pkt *head = k_fifo_peek_head(&ctx->recv_q);
 
-	while (_max_len > 0) {
-		/* only peek until we know we can dequeue and / or requeue buffer */
-		pkt = k_fifo_peek_head(&ctx->recv_q);
-		if (pkt == NULL || pkt == origin) {
-			break;
-		}
+	pkt = k_fifo_peek_head(&ctx->recv_q);
 
-		if (origin == NULL) {
-			/* mark first pkt to avoid cycles when observing */
-			origin = pkt;
-		}
-
+	while (_max_len > 0 && pkt != NULL) {
 		pkt_len = net_pkt_remaining_data(pkt);
 		len = MIN(_max_len, pkt_len);
 		recv_len += len;
@@ -1414,6 +1403,8 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 			}
 		}
 
+		next = k_fifo_peek_next(&ctx->recv_q, pkt);
+
 		if (do_recv && !peek) {
 			if (len == pkt_len) {
 				/* dequeue empty packets when not observing */
@@ -1429,23 +1420,14 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 
 				net_pkt_unref(pkt);
 			}
-		} else if ((!do_recv || peek) && _max_len > 0) {
-			/* requeue packets when observing, do not requeue if it is the last packet
-			 * as it will be requeued below. This allows to skip requeuing when
-			 * observing only the first packet
-			 */
-			k_fifo_put(&ctx->recv_q, k_fifo_get(&ctx->recv_q, K_NO_WAIT));
 		}
+
+		pkt = next;
 	}
 
 	if (do_recv) {
 		/* convey remaining buffer size back to caller */
 		*max_len = _max_len;
-	}
-
-	/* when observing, the queue should return to the initial state */
-	while ((!do_recv || peek) && k_fifo_peek_head(&ctx->recv_q) != head) {
-		k_fifo_put(&ctx->recv_q, k_fifo_get(&ctx->recv_q, K_NO_WAIT));
 	}
 
 	return recv_len;

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1381,6 +1381,7 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 	const bool do_recv = !(buf == NULL || max_len == NULL);
 	size_t _max_len = (max_len == NULL) ? SIZE_MAX : *max_len;
 	const bool peek = (flags & ZSOCK_MSG_PEEK) == ZSOCK_MSG_PEEK;
+	const struct net_pkt *head = k_fifo_peek_head(&ctx->recv_q);
 
 	while (_max_len > 0) {
 		/* only peek until we know we can dequeue and / or requeue buffer */
@@ -1428,8 +1429,11 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 
 				net_pkt_unref(pkt);
 			}
-		} else if (!do_recv || peek) {
-			/* requeue packets when observing */
+		} else if ((!do_recv || peek) && _max_len > 0) {
+			/* requeue packets when observing, do not requeue if it is the last packet
+			 * as it will be requeued below. This allows to skip requeuing when
+			 * observing only the first packet
+			 */
 			k_fifo_put(&ctx->recv_q, k_fifo_get(&ctx->recv_q, K_NO_WAIT));
 		}
 	}
@@ -1437,6 +1441,11 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 	if (do_recv) {
 		/* convey remaining buffer size back to caller */
 		*max_len = _max_len;
+	}
+
+	/* when observing, the queue should return to the initial state */
+	while ((!do_recv || peek) && k_fifo_peek_head(&ctx->recv_q) != head) {
+		k_fifo_put(&ctx->recv_q, k_fifo_get(&ctx->recv_q, K_NO_WAIT));
 	}
 
 	return recv_len;

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -250,6 +250,7 @@ extern "C" {
 #define sys_port_trace_k_queue_unique_append_exit(queue, ret)
 #define sys_port_trace_k_queue_peek_head(queue, ret)
 #define sys_port_trace_k_queue_peek_tail(queue, ret)
+#define sys_port_trace_k_queue_peek_next(queue, data, ret)
 
 #define sys_port_trace_k_fifo_init_enter(fifo)
 #define sys_port_trace_k_fifo_init_exit(fifo)
@@ -269,6 +270,8 @@ extern "C" {
 #define sys_port_trace_k_fifo_peek_head_exit(fifo, ret)
 #define sys_port_trace_k_fifo_peek_tail_enter(fifo)
 #define sys_port_trace_k_fifo_peek_tail_exit(fifo, ret)
+#define sys_port_trace_k_fifo_peek_next_enter(fifo, data)
+#define sys_port_trace_k_fifo_peek_next_exit(fifo, data, ret)
 
 #define sys_port_trace_k_lifo_init_enter(lifo)
 #define sys_port_trace_k_lifo_init_exit(lifo)

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -421,6 +421,9 @@ void sys_trace_thread_info(struct k_thread *thread);
 #define sys_port_trace_k_queue_peek_tail(queue, ret)                                               \
 	SEGGER_SYSVIEW_RecordU32x2(TID_QUEUE_PEAK_TAIL, (uint32_t)(uintptr_t)queue, (int32_t)ret)
 
+#define sys_port_trace_k_queue_peek_next(queue, data, ret)                                         \
+	SEGGER_SYSVIEW_RecordU32x2(TID_QUEUE_PEAK_NEXT, (uint32_t)(uintptr_t)queue, (int32_t)ret)
+
 #define sys_port_trace_k_fifo_init_enter(fifo)                                                     \
 	SEGGER_SYSVIEW_RecordU32(TID_FIFO_INIT, (uint32_t)(uintptr_t)fifo)
 #define sys_port_trace_k_fifo_init_exit(fifo) SEGGER_SYSVIEW_RecordEndCall(TID_FIFO_INIT)
@@ -471,6 +474,11 @@ void sys_trace_thread_info(struct k_thread *thread);
 	SEGGER_SYSVIEW_RecordU32(TID_FIFO_PEAK_TAIL, (uint32_t)(uintptr_t)fifo)
 #define sys_port_trace_k_fifo_peek_tail_exit(fifo, ret)                                            \
 	SEGGER_SYSVIEW_RecordEndCall(TID_FIFO_PEAK_TAIL)
+
+#define sys_port_trace_k_fifo_peek_next_enter(fifo, data)                                          \
+	SEGGER_SYSVIEW_RecordU32(TID_FIFO_PEAK_NEXT, (uint32_t)(uintptr_t)fifo)
+#define sys_port_trace_k_fifo_peek_next_exit(fifo, data, ret)                                      \
+	SEGGER_SYSVIEW_RecordEndCall(TID_FIFO_PEAK_NEXT)
 
 #define sys_port_trace_k_lifo_init_enter(lifo)                                                     \
 	SEGGER_SYSVIEW_RecordU32(TID_LIFO_INIT, (uint32_t)(uintptr_t)lifo)

--- a/subsys/tracing/sysview/tracing_sysview_ids.h
+++ b/subsys/tracing/sysview/tracing_sysview_ids.h
@@ -41,6 +41,7 @@ extern "C" {
 #define TID_QUEUE_CANCEL_WAIT   (20u + TID_OFFSET)
 #define TID_QUEUE_PEAK_HEAD     (21u + TID_OFFSET)
 #define TID_QUEUE_PEAK_TAIL     (22u + TID_OFFSET)
+#define TID_QUEUE_PEAK_NEXT     (51u + TID_OFFSET)
 
 #define TID_STACK_INIT          (23u + TID_OFFSET)
 #define TID_STACK_PUSH          (24u + TID_OFFSET)
@@ -140,6 +141,7 @@ extern "C" {
 #define TID_FIFO_PUT_SLIST   (114u + TID_OFFSET)
 #define TID_FIFO_PEAK_HEAD   (115u + TID_OFFSET)
 #define TID_FIFO_PEAK_TAIL   (116u + TID_OFFSET)
+#define TID_FIFO_PEAK_NEXT   (137u + TID_OFFSET)
 #define TID_FIFO_PUT         (117u + TID_OFFSET)
 #define TID_FIFO_GET         (118u + TID_OFFSET)
 
@@ -166,7 +168,7 @@ extern "C" {
 #define TID_TIMER_EXPIRY (135u + TID_OFFSET)
 #define TID_TIMER_STOP_EXPIRY (136u + TID_OFFSET)
 
-/* latest ID is 136 */
+/* latest ID is 137 */
 
 #ifdef __cplusplus
 }

--- a/subsys/tracing/test/tracing_string_format_test.c
+++ b/subsys/tracing/test/tracing_string_format_test.c
@@ -485,6 +485,11 @@ void sys_trace_k_queue_peek_tail(struct k_queue *queue, void *ret)
 	TRACING_STRING("%s: %p\n", __func__, queue);
 }
 
+void sys_trace_k_queue_peek_next(struct k_queue *queue, void *data, void *ret)
+{
+	TRACING_STRING("%s: %p\n", __func__, queue);
+}
+
 void sys_trace_k_queue_alloc_append_enter(struct k_queue *queue, void *data)
 {
 	TRACING_STRING("%s: %p\n", __func__, queue);

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -202,6 +202,8 @@
 	sys_trace_k_queue_unique_append_exit(queue, data, ret)
 #define sys_port_trace_k_queue_peek_head(queue, ret) sys_trace_k_queue_peek_head(queue, ret)
 #define sys_port_trace_k_queue_peek_tail(queue, ret) sys_trace_k_queue_peek_tail(queue, ret)
+#define sys_port_trace_k_queue_peek_next(queue, data, ret)                                         \
+	sys_trace_k_queue_peek_next(queue, data, ret)
 
 /* FIFO */
 
@@ -569,6 +571,7 @@ void sys_trace_k_queue_unique_append_enter(struct k_queue *queue, void *data);
 void sys_trace_k_queue_unique_append_exit(struct k_queue *queue, void *data, bool ret);
 void sys_trace_k_queue_peek_head(struct k_queue *queue, void *ret);
 void sys_trace_k_queue_peek_tail(struct k_queue *queue, void *ret);
+void sys_trace_k_queue_peek_next(struct k_queue *queue, void *data, void *ret);
 
 void sys_trace_k_fifo_init_enter(struct k_fifo *fifo);
 void sys_trace_k_fifo_init_exit(struct k_fifo *fifo);
@@ -588,6 +591,8 @@ void sys_trace_k_fifo_peek_head_enter(struct k_fifo *fifo);
 void sys_trace_k_fifo_peek_head_exit(struct k_fifo *fifo, void *ret);
 void sys_trace_k_fifo_peek_tail_enter(struct k_fifo *fifo);
 void sys_trace_k_fifo_peek_tail_exit(struct k_fifo *fifo, void *ret);
+void sys_trace_k_queue_peek_next_enter(struct k_queue *queue, void *data);
+void sys_trace_k_queue_peek_next_exit(struct k_queue *queue, void *data, void *ret);
 
 void sys_trace_k_lifo_init_enter(struct k_lifo *lifo);
 void sys_trace_k_lifo_init_exit(struct k_lifo *lifo);

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -299,6 +299,7 @@ void sys_trace_rtio_chain_next_exit(const struct rtio *r, const struct rtio_iode
 #define sys_port_trace_k_queue_unique_append_exit(queue, ret)
 #define sys_port_trace_k_queue_peek_head(queue, ret)
 #define sys_port_trace_k_queue_peek_tail(queue, ret)
+#define sys_port_trace_k_queue_peek_next(queue, data, ret)
 
 #define sys_port_trace_k_fifo_init_enter(fifo)
 #define sys_port_trace_k_fifo_init_exit(fifo)
@@ -318,6 +319,8 @@ void sys_trace_rtio_chain_next_exit(const struct rtio *r, const struct rtio_iode
 #define sys_port_trace_k_fifo_peek_head_exit(fifo, ret)
 #define sys_port_trace_k_fifo_peek_tail_enter(fifo)
 #define sys_port_trace_k_fifo_peek_tail_exit(fifo, ret)
+#define sys_port_trace_k_fifo_peek_next_enter(fifo, data)
+#define sys_port_trace_k_fifo_peek_next_exit(fifo, data, ret)
 
 #define sys_port_trace_k_lifo_init_enter(lifo)
 #define sys_port_trace_k_lifo_init_exit(lifo)

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -357,6 +357,9 @@ void tcp_server_block_thread(void *vps_sock, void *unused2, void *unused3)
 			chunk_size = remain;
 		}
 
+		/* Validate that peeking doesn't affect the next recv */
+		recved = zsock_recv(new_sock, buffer, 1, ZSOCK_MSG_PEEK);
+
 		recved = zsock_recv(new_sock, buffer, chunk_size, 0);
 
 		zassert(recved > 0, "received bigger then 0",


### PR DESCRIPTION
This PR aims to improve the fix provided here https://github.com/zephyrproject-rtos/zephyr/pull/112061 by means of an additional api for `struct k_queue`. This PR is meant to be merged on top of  https://github.com/zephyrproject-rtos/zephyr/pull/112061