### PR TITLE
net: shell: fix alignment of dropped pkts

### DIFF
--- a/subsys/net/lib/shell/stats.c
+++ b/subsys/net/lib/shell/stats.c
@@ -430,14 +430,14 @@ static void print_tc_rx_stats(const struct shell *sh, struct net_if *iface)
 		net_stats_t count = GET_STAT(iface,
 					     tc.recv[i].rx_time.count);
 		if (count == 0) {
-			PR("[%d] %s (%u)\t%u\t%u\t\t%llu\t-\n", i,
+			PR("[%d] %s (%u)\t%u\t\t%u\t\t%llu\t-\n", i,
 			   priority2str(GET_STAT(iface, tc.recv[i].priority)),
 			   GET_STAT(iface, tc.recv[i].priority),
 			   GET_STAT(iface, tc.recv[i].pkts),
 			   GET_STAT(iface, tc.recv[i].dropped),
 			   GET_STAT(iface, tc.recv[i].bytes));
 		} else {
-			PR("[%d] %s (%u)\t%u\t%u\t\t%llu\t%u us%s\n", i,
+			PR("[%d] %s (%u)\t%u\t\t%u\t\t%llu\t%u us%s\n", i,
 			   priority2str(GET_STAT(iface, tc.recv[i].priority)),
 			   GET_STAT(iface, tc.recv[i].priority),
 			   GET_STAT(iface, tc.recv[i].pkts),
@@ -453,7 +453,7 @@ static void print_tc_rx_stats(const struct shell *sh, struct net_if *iface)
 	PR("TC  Priority\tRecv pkts\tDrop pkts\tbytes\n");
 
 	for (i = 0; i < NET_TC_RX_COUNT; i++) {
-		PR("[%d] %s (%u)\t%u\t%u\t\t%llu\n", i,
+		PR("[%d] %s (%u)\t%u\t\t%u\t\t%llu\n", i,
 		   priority2str(GET_STAT(iface, tc.recv[i].priority)),
 		   GET_STAT(iface, tc.recv[i].priority),
 		   GET_STAT(iface, tc.recv[i].pkts),


### PR DESCRIPTION
Fix alignment of dropped packets count for each traffic class in shell stats output. The dropped packets column was not aligned properly with the header, making it harder to read the output.

Before:
```
TX traffic class statistics:
TC  Priority    Sent pkts       bytes
[0] BK (1)      136             24293
[1] NC (7)      5               1415
RX traffic class statistics:
TC  Priority    Recv pkts       Drop pkts       bytes
[0] BE (0)      96      0               7675
[1] NC (7)      0       0               0
```

After:
```
TX traffic class statistics:
TC  Priority    Sent pkts       bytes
[0] BK (1)      1096            285042
[1] NC (7)      14569           700890
RX traffic class statistics:
TC  Priority    Recv pkts       Drop pkts       bytes
[0] BE (0)      657             0               44566
[1] NC (7)      9882            0               592920
```