### PR TITLE
doc: fix string-array example comment in api-usage

### DIFF
--- a/doc/build/dts/api-usage.rst
+++ b/doc/build/dts/api-usage.rst
@@ -202,7 +202,7 @@ Its properties can be accessed like this:
 
    int a[] = DT_PROP(FOO, a);           /* {1000, 2000, 3000} */
    unsigned char b[] = DT_PROP(FOO, b); /* {0xaa, 0xbb, 0xcc, 0xdd} */
-   char* c[] = DT_PROP(FOO, c);         /* {"foo", "bar"} */
+   char* c[] = DT_PROP(FOO, c);         /* {"bar", "baz"} */
 
 You can use :c:macro:`DT_PROP_LEN()` to get logical array lengths in number of
 elements.


### PR DESCRIPTION
The devicetree fragment
```
foo: foo@1234 {
        a = <1000 2000 3000>; /* array */
        b = [aa bb cc dd];    /* uint8-array */
        c = "bar", "baz";     /* string-array */
};
``` 
defines the string-array property as `c = "bar", "baz";`. However, the corresponding C code example comment incorrectly referenced `{"foo", "bar"}`.

Update the comment to `{"bar", "baz"}` to match the devicetree definition and prevent confusion.