### PR TITLE
drivers: memc: sam_smc: Add support to 16-bit width

### DIFF
--- a/drivers/memc/memc_sam_smc.c
+++ b/drivers/memc/memc_sam_smc.c
@@ -75,13 +75,40 @@ static int memc_smc_init(const struct device *dev)
 	SMC_CYCLE_NWE_CYCLE(DT_PROP_BY_IDX(node_id, atmel_smc_cycle_timing, 0))		\
 	| SMC_CYCLE_NRD_CYCLE(DT_PROP_BY_IDX(node_id, atmel_smc_cycle_timing, 1))
 
+#define SMC_DATA_BUS_WIDTH(node_id)                                                                \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, atmel_smc_data_bus_width),                           \
+		((DT_PROP(node_id, atmel_smc_data_bus_width) == 16) ? SMC_MODE_DBW_16_BIT	   \
+		 : 0), (0))
+
+#define SMC_BYTE_ACCESS_TYPE(node_id)                                                              \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, atmel_smc_byte_access_type),                         \
+		(DT_ENUM_IDX(node_id, atmel_smc_byte_access_type) ? SMC_MODE_BAT_BYTE_WRITE	   \
+		 : SMC_MODE_BAT_BYTE_SELECT), (0))
+
+#define SMC_PAGE_SIZE(node_id)                                                                     \
+	((DT_PROP_OR(node_id, atmel_smc_page_size, 4) == 32)                                       \
+		 ? SMC_MODE_PS_32_BYTE                                                             \
+		 : ((DT_PROP_OR(node_id, atmel_smc_page_size, 4) == 16)                            \
+			    ? SMC_MODE_PS_16_BYTE                                                  \
+			    : ((DT_PROP_OR(node_id, atmel_smc_page_size, 4) == 8)                  \
+				       ? SMC_MODE_PS_8_BYTE                                        \
+				       : SMC_MODE_PS_4_BYTE)))
+
+#define SMC_PAGE_MODE(node_id)                                                                     \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, atmel_smc_page_mode),                                \
+		    (DT_PROP_OR(node_id, atmel_smc_page_mode, 0)				   \
+			? (SMC_MODE_PMEN | SMC_PAGE_SIZE(node_id)) : 0), (0))
+
 #define BANK_CONFIG(node_id)								\
 	{										\
 		.cs = DT_REG_ADDR(node_id),						\
 		.mode = COND_CODE_1(DT_ENUM_IDX(node_id, atmel_smc_write_mode),		\
 				    (SMC_MODE_WRITE_MODE), (0))				\
 			| COND_CODE_1(DT_ENUM_IDX(node_id, atmel_smc_read_mode),	\
-				      (SMC_MODE_READ_MODE), (0)),			\
+				      (SMC_MODE_READ_MODE), (0))			\
+			| SMC_DATA_BUS_WIDTH(node_id)					\
+			| SMC_BYTE_ACCESS_TYPE(node_id)					\
+			| SMC_PAGE_MODE(node_id),					\
 		.setup_timing = SETUP_TIMING(node_id),					\
 		.pulse_timing = PULSE_TIMING(node_id),					\
 		.cycle_timing = CYCLE_TIMING(node_id),					\

--- a/dts/bindings/memory-controllers/atmel,sam-smc.yaml
+++ b/dts/bindings/memory-controllers/atmel,sam-smc.yaml
@@ -22,6 +22,7 @@ description: |
     is66wv51216dbll@0 {
       reg = <0>;
 
+      atmel,smc-data-bus-width = <8>;
       atmel,smc-write-mode = "nwe";
       atmel,smc-read-mode = "nrd";
       atmel,smc-setup-timing = <1 1 1 1>;
@@ -30,16 +31,17 @@ description: |
     };
   };
 
-  The above example configures a is66wv51216dbll-55 device. The device is a
-  low power static RAM which uses NWE and NRD signals connected to the WE
-  and OE inputs respectively. Assuming that MCK is 120MHz (cpu at full speed)
-  each MCK cycle will be equivalent to 8ns. Since the memory full cycle is
-  55ns, as per specification, it requires atmel,smc-cycle-timing of at least
-  7 pulses (56ns). The atmel,smc-cycle-timing is composed of three parts:
-  setup, pulse and hold. The setup is used to address the memory. The pulse
-  is the time used to read/write. The hold is used to release memory. For the
-  is66wv51216dbll-55 a minimum setup of 5ns (1 cycle) with at least 45ns
-  (6 cycles) for CPU read/write and no hold time is required.
+  The above example configures an is66wv51216dbll-55 device using the
+  controller's default 8-bit interface. The device is a low power static RAM
+  which uses NWE and NRD signals connected to the WE and OE inputs
+  respectively. Assuming that MCK is 120 MHz (CPU at full speed), each MCK
+  cycle is approximately 8.33 ns. Since the memory full cycle is 55 ns, as per
+  specification, it requires atmel,smc-cycle-timing of at least 7 cycles
+  (approximately 58.33 ns). The atmel,smc-cycle-timing is composed of three
+  parts: setup, pulse and hold. The setup is used to address the memory. The
+  pulse is the time used to read/write. The hold is used to release memory.
+  For the is66wv51216dbll-55 a minimum setup of 5 ns (1 cycle) with at least
+  45 ns (6 cycles) for CPU read/write and no hold time is required.
   Note: Since no hold parameter is available at SMC the atmel,smc-cycle-timing
   should have additional cycles to accommodate for hold values.
 
@@ -48,6 +50,31 @@ description: |
 
     With 3 Hold Times:
     cycle-timing (10) = setup (1) + pulse (6) + hold (3)
+
+  A 16-bit CY62157EV30LL-45BVXI SRAM connected to a SAME70 SMC can be
+  configured as follows:
+
+  &smc {
+    status = "okay";
+    pinctrl-0 = <&smc_default>;
+    pinctrl-names = "default";
+
+    ext_sram_bus: ext-sram@0 {
+      reg = <0>;
+
+      atmel,smc-data-bus-width = <16>;
+      atmel,smc-write-mode = "nwe";
+      atmel,smc-read-mode = "nrd";
+      atmel,smc-setup-timing = <1 1 1 1>;
+      /*
+       * MCK is 300 MHz on SAME70, so one cycle is approximately 3.33 ns.
+       * 14 cycles is the minimum value that meets the 45 ns access time.
+       */
+      atmel,smc-pulse-timing = <14 14 14 14>;
+      atmel,smc-cycle-timing = <15 15>;
+      status = "okay";
+    };
+  };
 
   Finally, in order to make the memory available you will need to define new
   memory device/s in DeviceTree:
@@ -134,7 +161,7 @@ child-binding:
         The pulse value is an array of the signals NWE, NCS_WR, NRD and NCS_RD where
         each value is configured in terms of MCK cycles and a value of 0 is forbidden.
         Each value is encoded in 7 bits where the highest bit adds an offset of 256
-        cycles. The effective value for each element is: 256 x setup[6] + setup[5:0]
+        cycles. The effective value for each element is: 256 x pulse[6] + pulse[5:0]
 
     atmel,smc-cycle-timing:
       type: array
@@ -148,3 +175,34 @@ child-binding:
         is encoded in 9 bits where the two highest bits are multiplied
         with an offset of 256.
         Effective value for each element: 256 x cycle[8:7] + cycle[6:0]
+
+    atmel,smc-data-bus-width:
+      type: int
+      enum:
+        - 8
+        - 16
+      description: |
+        External data bus width used by the connected device.
+
+    atmel,smc-byte-access-type:
+      type: string
+      enum:
+        - "byte-select"
+        - "byte-write"
+      description: |
+        Selects how byte-access cycles are handled by the connected device.
+
+    atmel,smc-page-mode:
+      type: boolean
+      description: |
+        Enable page mode for the connected device when supported.
+
+    atmel,smc-page-size:
+      type: int
+      enum:
+        - 4
+        - 8
+        - 16
+        - 32
+      description: |
+        Page size, in bytes, used when page mode is enabled.


### PR DESCRIPTION
The current driver programs setup, pulse, cycle and basic read/write mode
timings, which is enough for SAM4 SMC users. On SAME70-class devices, however,
SMC_MODE also contains DBW and BAT fields. Without programming DBW, a 16-bit
external SRAM is not configured correctly even if the timing registers are valid.

Add optional devicetree properties for the extended SAME70 SMC mode fields and
program them in the driver when supported. Defaults keep existing SAM4 behavior
unchanged.


```
SAM4 SMC_MODE layout, relevant fields
-------------------------------------
bit  0      READ_MODE
bit  1      WRITE_MODE
bits 5:4    EXNW_MODE
bits 15:8   Reserved
bits 19:16  TDF_CYCLES
bit  20     TDF_MODE
bit  24     PMEN
bits 29:28  PS

Notes:
- No DBW field.
- No BAT field.
- SAM4 SMC data bus is fixed 8-bit.
```


```
SAME70 / S70 / V70 / V71 SMC_MODE layout, relevant fields
---------------------------------------------------------
bit  0      READ_MODE
bit  1      WRITE_MODE
bits 5:4    EXNW_MODE
bit  8      BAT        Byte Access Type
bits 13:12  DBW        Data Bus Width
bits 19:16  TDF_CYCLES
bit  20     TDF_MODE
bit  24     PMEN
bits 29:28  PS         Page Size

Notes:
- DBW selects 8-bit or 16-bit external bus width.
- BAT selects byte access behavior for 16-bit devices.
- PS is only meaningful when page mode is enabled through PMEN.
```

**update**
- adding the official data sheet snippets:

[SAME4](https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/Atmel-11157-32-bit-Cortex-M4-Microcontroller-SAM4E16-SAM4E8_Datasheet.pdf):

<img width="1198" height="492" alt="image" src="https://github.com/user-attachments/assets/d30261ff-3938-43c4-b4ef-f9e2ad5db9fc" />


[SAME7](https://ww1.microchip.com/downloads/aemDocuments/documents/MCU32/ProductDocuments/DataSheets/SAM-E70-S70-V70-V71-Family-Data-Sheet-DS60001527.pdf):

<img width="1164" height="810" alt="image" src="https://github.com/user-attachments/assets/dad914c2-9486-43c2-8519-aeb4e6960cf6" />
