### PR TITLE
drivers,subsys: use min3/max3 instead of nested MIN/MAX

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -36,6 +36,7 @@
 #include <zephyr/sys/sys_io.h>
 
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/minmax.h>
 
 #if defined(CONFIG_I2C_DW_LPSS_DMA)
 #include <zephyr/drivers/dma.h>
@@ -375,7 +376,7 @@ static inline void i2c_dw_data_ask(const struct device *dev)
 
 	/* Figure out how many bytes we can request */
 	cnt = MIN(rx_buffer_depth, dw->request_bytes);
-	cnt = MIN(MIN(tx_empty, rx_empty), cnt);
+	cnt = min3(tx_empty, rx_empty, cnt);
 
 	while (cnt > 0) {
 		/* Tell controller to get another byte */

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -16,6 +16,7 @@
 #include <hal/nrf_uarte.h>
 #include <hal/nrf_timer.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/kernel.h>
 #include <zephyr/cache.h>
 #include <soc.h>
@@ -1109,7 +1110,7 @@ static uint32_t fill_usr_buf(const struct device *dev, uint32_t len)
 	uint8_t *buf = cfg->bounce_buf[cbwt_data->bounce_idx];
 	uint32_t usr_rem = async_rx->buf_len - cbwt_data->usr_wr_off;
 	uint32_t bounce_rem = cbwt_data->bounce_limit - cbwt_data->bounce_off;
-	uint32_t cpy_len = MIN(bounce_rem, MIN(usr_rem, len));
+	uint32_t cpy_len = min3(bounce_rem, usr_rem, len);
 
 	__ASSERT(cpy_len + cbwt_data->bounce_off <= cfg->bounce_buf_len,
 		"Exceeding the buffer cpy_len:%d off:%d limit:%d",

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -16,6 +16,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/usb/udc.h>
@@ -1957,7 +1958,7 @@ static int udc_dwc2_init_controller(const struct device *dev)
 		 * to store reset value. Read the reset value and make sure that
 		 * the programmed value is not greater than what driver sets.
 		 */
-		priv->rxfifo_depth = MIN(MIN(priv->rxfifo_depth, default_depth), max_rxfifo);
+		priv->rxfifo_depth = min3(priv->rxfifo_depth, default_depth, max_rxfifo);
 		sys_write32(usb_dwc2_set_grxfsiz(priv->rxfifo_depth), grxfsiz_reg);
 
 		/* Set TxFIFO 0 depth */

--- a/include/zephyr/net/socketcan_utils.h
+++ b/include/zephyr/net/socketcan_utils.h
@@ -15,6 +15,7 @@
 
 #include <zephyr/drivers/can.h>
 #include <zephyr/net/socketcan.h>
+#include <zephyr/sys/minmax.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,7 +47,7 @@ static inline void socketcan_to_can_frame(const struct socketcan_frame *sframe,
 
 	if ((zframe->flags & CAN_FRAME_RTR) == 0U) {
 		memcpy(zframe->data, sframe->data,
-		       MIN(sframe->len, MIN(sizeof(sframe->data), sizeof(zframe->data))));
+		       min3(sframe->len, sizeof(sframe->data), sizeof(zframe->data)));
 	}
 }
 
@@ -76,7 +77,7 @@ static inline void socketcan_from_can_frame(const struct can_frame *zframe,
 
 	if ((zframe->flags & CAN_FRAME_RTR) == 0U) {
 		memcpy(sframe->data, zframe->data,
-		       MIN(sframe->len, MIN(sizeof(zframe->data), sizeof(sframe->data))));
+		       min3(sframe->len, sizeof(zframe->data), sizeof(sframe->data)));
 	}
 }
 

--- a/subsys/bluetooth/controller/ll_sw/lll_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_chan.c
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <zephyr/sys/minmax.h>
 
 #include "hal/ccm.h"
 #include "hal/radio.h"
@@ -327,7 +328,7 @@ static uint8_t chan_d(uint8_t n)
 	}
 
 	/* Calculate d using the above sub expressions */
-	return MAX(1, MAX(MIN(3, x), MIN(11, y)));
+	return max3(1, min(3, x), min(11, y));
 }
 #endif /* CONFIG_BT_CTLR_ISO */
 

--- a/subsys/fb/cfb.c
+++ b/subsys/fb/cfb.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <zephyr/display/cfb.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/minmax.h>
 
 #define LOG_LEVEL CONFIG_CFB_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -95,8 +96,8 @@ static inline bool is_tofu_border_pixel(const struct cfb_font *fptr, uint8_t px,
 	const uint8_t bottom = fptr->height - margin;
 	const uint8_t max_stroke_x = (right > (left + 1U)) ? (right - left - 1U) / 2U : 1U;
 	const uint8_t max_stroke_y = (bottom > (top + 1U)) ? (bottom - top - 1U) / 2U : 1U;
-	const uint8_t stroke = MIN(MAX(MIN(right - left, bottom - top) / 10U, 1U),
-				       MIN(max_stroke_x, max_stroke_y));
+	const uint8_t stroke = min3(max(min(right - left, bottom - top) / 10U, 1U),
+				    max_stroke_x, max_stroke_y);
 	const bool inside_box = (px >= left) && (px < right) && (py >= top) && (py < bottom);
 	const bool on_left_or_right_edge = (px < (left + stroke)) || (px >= (right - stroke));
 	const bool on_top_or_bottom_edge = (py < (top + stroke)) || (py >= (bottom - stroke));

--- a/subsys/fs/ext2/ext2_impl.c
+++ b/subsys/fs/ext2/ext2_impl.c
@@ -9,6 +9,7 @@
 #include <zephyr/fs/fs.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/sys/byteorder.h>
 
 #include "ext2.h"
@@ -698,7 +699,7 @@ ssize_t ext2_inode_read(struct ext2_inode *inode, void *buf, uint32_t offset, si
 
 		uint32_t left_on_blk = block_size - block_off;
 		uint32_t left_in_file = inode->i_size - offset;
-		size_t to_read = MIN(nbytes_to_read, MIN(left_on_blk, left_in_file));
+		size_t to_read = min3(nbytes_to_read, left_on_blk, left_in_file);
 
 		memcpy((uint8_t *)buf + read, inode_current_block_mem(inode) + block_off, to_read);
 

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -6,6 +6,7 @@
  */
 
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/llext/loader.h>
 #include <zephyr/llext/llext.h>
 #include <zephyr/kernel.h>
@@ -88,7 +89,7 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 				 * to be sized and aligned to the same power of two.
 				 */
 				uintptr_t block_sz =
-					MAX(MAX(region_alloc, region_align), LLEXT_PAGE_SIZE);
+					max3(region_alloc, region_align, LLEXT_PAGE_SIZE);
 
 				block_sz = 1 << LOG2CEIL(block_sz); /* align to next power of two */
 				region_alloc = block_sz;

--- a/subsys/logging/backends/log_backend_ble.c
+++ b/subsys/logging/backends/log_backend_ble.c
@@ -6,6 +6,7 @@
 #include <zephyr/logging/log_backend.h>
 #include <zephyr/logging/log_output.h>
 #include <zephyr/logging/log_backend_ble.h>
+#include <zephyr/sys/minmax.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/logging/log_ctrl.h>
@@ -118,7 +119,7 @@ static int line_out(uint8_t *data, size_t length, void *output_ctx)
 	ARG_UNUSED(output_ctx);
 	const uint16_t mtu_size = bt_gatt_get_mtu(ble_backend_conn);
 	const uint16_t attr_data_len = mtu_size - ATT_NOTIFY_SIZE;
-	const uint16_t notify_len = MIN(length, MIN(attr_data_len, LOG_BACKEND_BLE_BUF_SIZE));
+	const uint16_t notify_len = min3(length, attr_data_len, LOG_BACKEND_BLE_BUF_SIZE);
 
 	struct bt_gatt_notify_params notify_param = {
 		.uuid = NULL,


### PR DESCRIPTION
Replace nested MIN/MAX macro calls with the min3/max3 APIs which are safer (evaluate arguments only once) and cleaner.