### PR TITLE
scripts: zspdx: normalize discovered include paths

### DIFF
--- a/scripts/pylib/zspdx/getincludes.py
+++ b/scripts/pylib/zspdx/getincludes.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 from subprocess import run
 
 _logger = logging.getLogger(__name__)
@@ -61,7 +62,7 @@ def extract_includes(resp):
             sline = rline.split(" ", maxsplit=1)
             if len(sline) != 2:
                 continue
-            includes.add(sline[1])
+            includes.add(os.path.normpath(sline[1]))
 
     includes_list = list(includes)
     includes_list.sort()


### PR DESCRIPTION
Compiler-reported paths may contain "." or "..", causing the same header to be treated as multiple files. This substantially increases ownership, license, hash, and relationship processing during --analyze-includes.

Normalize paths before deduplication. In a test build pulling in LVGL, this reduced the include set from 50,000+ entries to ~1,200.