### PR TITLE
drivers: power_domain: resume children force-suspended by the domain

### DIFF
--- a/drivers/power_domain/power_domain_soc_state_change.c
+++ b/drivers/power_domain/power_domain_soc_state_change.c
@@ -36,8 +36,22 @@ static int pd_domain_visitor(const struct device *dev, void *context)
 	if ((visitor_context->action == PM_DEVICE_ACTION_TURN_OFF) &&
 	    (dev->pm_base->state == PM_DEVICE_STATE_ACTIVE)) {
 		(void)pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
+		atomic_set_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_PD_FORCE_SUSPENDED);
 	}
 	(void)pm_device_action_run(dev, visitor_context->action);
+
+	/* Resume devices the domain force-suspended above; the system sweep that
+	 * normally pairs SUSPEND with RESUME never tracked them. Leave the device
+	 * suspended if powering it back up failed.
+	 */
+	if ((visitor_context->action == PM_DEVICE_ACTION_TURN_ON) &&
+	    atomic_test_and_clear_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_PD_FORCE_SUSPENDED)) {
+		if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_TURN_ON_FAILED)) {
+			LOG_WRN("%s: not resuming, power up failed", dev->name);
+		} else {
+			(void)pm_device_action_run(dev, PM_DEVICE_ACTION_RESUME);
+		}
+	}
 	return 0;
 }
 

--- a/drivers/power_domain/power_domain_soc_state_change.c
+++ b/drivers/power_domain/power_domain_soc_state_change.c
@@ -36,8 +36,22 @@ static int pd_domain_visitor(const struct device *dev, void *context)
 	if ((visitor_context->action == PM_DEVICE_ACTION_TURN_OFF) &&
 	    (dev->pm_base->state == PM_DEVICE_STATE_ACTIVE)) {
 		(void)pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
+		atomic_set_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_PD_SUSPENDED);
 	}
 	(void)pm_device_action_run(dev, visitor_context->action);
+
+	/* Resume devices the domain suspended above; the system sweep that
+	 * normally pairs SUSPEND with RESUME never tracked them. Leave the device
+	 * suspended if powering it back up failed.
+	 */
+	if ((visitor_context->action == PM_DEVICE_ACTION_TURN_ON) &&
+	    atomic_test_and_clear_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_PD_SUSPENDED)) {
+		if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_TURN_ON_FAILED)) {
+			LOG_WRN("%s: not resuming, power up failed", dev->name);
+		} else {
+			(void)pm_device_action_run(dev, PM_DEVICE_ACTION_RESUME);
+		}
+	}
 	return 0;
 }
 

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -56,6 +56,8 @@ enum pm_device_flag {
 	PM_DEVICE_FLAG_RUNTIME_AUTO,
 	/** Indicates that device runtime PM supports suspending and resuming from any context. */
 	PM_DEVICE_FLAG_ISR_SAFE,
+	/** Indicates the device was suspended by its power domain, not the PM subsystem. */
+	PM_DEVICE_FLAG_PD_FORCE_SUSPENDED,
 };
 
 /** @endcond */

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -56,6 +56,8 @@ enum pm_device_flag {
 	PM_DEVICE_FLAG_RUNTIME_AUTO,
 	/** Indicates that device runtime PM supports suspending and resuming from any context. */
 	PM_DEVICE_FLAG_ISR_SAFE,
+	/** Indicates the device was suspended by its power domain and must be resumed by it. */
+	PM_DEVICE_FLAG_PD_SUSPENDED,
 };
 
 /** @endcond */

--- a/tests/subsys/pm/power_domain_soc_state_change/src/main.c
+++ b/tests/subsys/pm/power_domain_soc_state_change/src/main.c
@@ -11,6 +11,9 @@
 
 static int testing_domain_on_notitication;
 static int testing_domain_off_notitication;
+static int testing_dev_suspend;
+static int testing_dev_resume;
+static bool testing_dev_fail_turn_on;
 
 void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
@@ -44,17 +47,56 @@ static int dev_pm_action(const struct device *dev, enum pm_device_action pm_acti
 
 	if (pm_action == PM_DEVICE_ACTION_TURN_ON) {
 		testing_domain_on_notitication++;
+		if (testing_dev_fail_turn_on) {
+			return -EIO;
+		}
 	}
 
 	if (pm_action == PM_DEVICE_ACTION_TURN_OFF) {
 		testing_domain_off_notitication++;
 	}
 
+	if (pm_action == PM_DEVICE_ACTION_SUSPEND) {
+		testing_dev_suspend++;
+	}
+
+	if (pm_action == PM_DEVICE_ACTION_RESUME) {
+		testing_dev_resume++;
+	}
+
 	return 0;
 }
 
 PM_DEVICE_DT_DEFINE(TEST_DEV, dev_pm_action);
-DEVICE_DT_DEFINE(TEST_DEV, NULL, PM_DEVICE_DT_GET(TEST_DEV), NULL, NULL, POST_KERNEL, 20, NULL);
+/* Same init priority as the domain: the init-entry ordinal still orders the
+ * child after the domain (its power-domain dependency), while the device list
+ * the suspend sweep walks has no such ordinal, so the domain is reached first
+ * and force-suspends the still-active child, exercising the resume path.
+ */
+DEVICE_DT_DEFINE(TEST_DEV, NULL, PM_DEVICE_DT_GET(TEST_DEV), NULL, NULL, PRE_KERNEL_1,
+		 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+
+static void check_forced_resume(int expected)
+{
+	const struct device *dev = DEVICE_DT_GET(TEST_DEV);
+	enum pm_device_state state;
+
+	zassert_equal(testing_dev_suspend, expected);
+	zassert_equal(testing_dev_resume, expected);
+	zassert_ok(pm_device_state_get(dev, &state));
+	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
+}
+
+static void check_not_resumed(int suspend_expected, int resume_expected)
+{
+	const struct device *dev = DEVICE_DT_GET(TEST_DEV);
+	enum pm_device_state state;
+
+	zassert_equal(testing_dev_suspend, suspend_expected);
+	zassert_equal(testing_dev_resume, resume_expected);
+	zassert_ok(pm_device_state_get(dev, &state));
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
+}
 
 ZTEST(power_domain_soc_state_change_1cpu, test_power_domain_soc_state_change)
 {
@@ -68,6 +110,7 @@ ZTEST(power_domain_soc_state_change_1cpu, test_power_domain_soc_state_change)
 
 	zassert_equal(testing_domain_on_notitication, 1);
 	zassert_equal(testing_domain_off_notitication, 1);
+	check_forced_resume(1);
 
 	state = &cpu_states[1];
 	/* Sleep to transition to STATE: SUSPEND-TO-IDLE */
@@ -75,6 +118,7 @@ ZTEST(power_domain_soc_state_change_1cpu, test_power_domain_soc_state_change)
 
 	zassert_equal(testing_domain_on_notitication, 2);
 	zassert_equal(testing_domain_off_notitication, 2);
+	check_forced_resume(2);
 
 	state = &cpu_states[0];
 	/* Sleep to transition to STATE: RUNTIME-IDLE */
@@ -85,6 +129,21 @@ ZTEST(power_domain_soc_state_change_1cpu, test_power_domain_soc_state_change)
 	 */
 	zassert_equal(testing_domain_on_notitication, 2);
 	zassert_equal(testing_domain_off_notitication, 2);
+	check_forced_resume(2);
+
+	/* A child whose TURN_ON fails is left in SUSPENDED with
+	 * PM_DEVICE_FLAG_TURN_ON_FAILED set, and must not be resumed onto
+	 * hardware that was never powered.
+	 */
+	testing_dev_fail_turn_on = true;
+
+	state = &cpu_states[2];
+	/* Sleep to transition to STATE: STANDBY */
+	k_usleep(state->min_residency_us + state->exit_latency_us);
+
+	zassert_equal(testing_domain_on_notitication, 3);
+	zassert_equal(testing_domain_off_notitication, 3);
+	check_not_resumed(3, 2);
 }
 
 ZTEST_SUITE(power_domain_soc_state_change_1cpu, NULL, NULL, ztest_simple_1cpu_before,

--- a/tests/subsys/pm/power_domain_soc_state_change/src/main.c
+++ b/tests/subsys/pm/power_domain_soc_state_change/src/main.c
@@ -11,6 +11,9 @@
 
 static int testing_domain_on_notitication;
 static int testing_domain_off_notitication;
+static int testing_dev_suspend;
+static int testing_dev_resume;
+static bool testing_dev_fail_turn_on;
 
 void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
@@ -44,17 +47,56 @@ static int dev_pm_action(const struct device *dev, enum pm_device_action pm_acti
 
 	if (pm_action == PM_DEVICE_ACTION_TURN_ON) {
 		testing_domain_on_notitication++;
+		if (testing_dev_fail_turn_on) {
+			return -EIO;
+		}
 	}
 
 	if (pm_action == PM_DEVICE_ACTION_TURN_OFF) {
 		testing_domain_off_notitication++;
 	}
 
+	if (pm_action == PM_DEVICE_ACTION_SUSPEND) {
+		testing_dev_suspend++;
+	}
+
+	if (pm_action == PM_DEVICE_ACTION_RESUME) {
+		testing_dev_resume++;
+	}
+
 	return 0;
 }
 
 PM_DEVICE_DT_DEFINE(TEST_DEV, dev_pm_action);
-DEVICE_DT_DEFINE(TEST_DEV, NULL, PM_DEVICE_DT_GET(TEST_DEV), NULL, NULL, POST_KERNEL, 20, NULL);
+/* Same init priority as the domain: the init-entry ordinal still orders the
+ * child after the domain (its power-domain dependency), while the device list
+ * the suspend sweep walks has no such ordinal, so the domain is reached first
+ * and suspends the still-active child, exercising the resume path.
+ */
+DEVICE_DT_DEFINE(TEST_DEV, NULL, PM_DEVICE_DT_GET(TEST_DEV), NULL, NULL, PRE_KERNEL_1,
+		 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+
+static void check_resumed(int expected)
+{
+	const struct device *dev = DEVICE_DT_GET(TEST_DEV);
+	enum pm_device_state state;
+
+	zassert_equal(testing_dev_suspend, expected);
+	zassert_equal(testing_dev_resume, expected);
+	zassert_ok(pm_device_state_get(dev, &state));
+	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
+}
+
+static void check_not_resumed(int suspend_expected, int resume_expected)
+{
+	const struct device *dev = DEVICE_DT_GET(TEST_DEV);
+	enum pm_device_state state;
+
+	zassert_equal(testing_dev_suspend, suspend_expected);
+	zassert_equal(testing_dev_resume, resume_expected);
+	zassert_ok(pm_device_state_get(dev, &state));
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
+}
 
 ZTEST(power_domain_soc_state_change_1cpu, test_power_domain_soc_state_change)
 {
@@ -68,6 +110,7 @@ ZTEST(power_domain_soc_state_change_1cpu, test_power_domain_soc_state_change)
 
 	zassert_equal(testing_domain_on_notitication, 1);
 	zassert_equal(testing_domain_off_notitication, 1);
+	check_resumed(1);
 
 	state = &cpu_states[1];
 	/* Sleep to transition to STATE: SUSPEND-TO-IDLE */
@@ -75,6 +118,7 @@ ZTEST(power_domain_soc_state_change_1cpu, test_power_domain_soc_state_change)
 
 	zassert_equal(testing_domain_on_notitication, 2);
 	zassert_equal(testing_domain_off_notitication, 2);
+	check_resumed(2);
 
 	state = &cpu_states[0];
 	/* Sleep to transition to STATE: RUNTIME-IDLE */
@@ -85,6 +129,21 @@ ZTEST(power_domain_soc_state_change_1cpu, test_power_domain_soc_state_change)
 	 */
 	zassert_equal(testing_domain_on_notitication, 2);
 	zassert_equal(testing_domain_off_notitication, 2);
+	check_resumed(2);
+
+	/* A child whose TURN_ON fails is left in SUSPENDED with
+	 * PM_DEVICE_FLAG_TURN_ON_FAILED set, and must not be resumed onto
+	 * hardware that was never powered.
+	 */
+	testing_dev_fail_turn_on = true;
+
+	state = &cpu_states[2];
+	/* Sleep to transition to STATE: STANDBY */
+	k_usleep(state->min_residency_us + state->exit_latency_us);
+
+	zassert_equal(testing_domain_on_notitication, 3);
+	zassert_equal(testing_domain_off_notitication, 3);
+	check_not_resumed(3, 2);
 }
 
 ZTEST_SUITE(power_domain_soc_state_change_1cpu, NULL, NULL, ztest_simple_1cpu_before,


### PR DESCRIPTION
When a power-domain-soc-state-change domain powers off, its visitor suspends any ACTIVE child before turning it off. That suspend is issued directly through pm_device_action_run() and is not recorded in the system-managed PM device slots, so pm_resume_devices() never resumes the device: on wake it is powered back only to SUSPENDED via TURN_ON and never returns to ACTIVE.

Track devices the domain force-suspends and resume them symmetrically on TURN_ON, so the actor that suspends a device is the one that restores it.

Fixes #112333