### PR TITLE
drivers: fuel_gauge: fix FUEL_GAUGE_CYCLE_COUNT to whole cycles

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -302,6 +302,14 @@ Fuel Gauge
   ``FUEL_GAUGE_CURRENT`` (``val.current``) is replaced by
   ``FUEL_GAUGE_CURRENT_UA`` (``val.current_ua``).
 
+* Drivers had inconsistently been reporting full charge/discharge cycles or
+  "1/100ths" of a cycle in the ``FUEL_GAUGE_CYCLE_COUNT`` property.
+  The property now consistently reports full cycles, and drivers that
+  previously reported fractions of a cycle (i.e. ADP5360 and BQ27Z746) have
+  been updated to report full cycles instead.
+  Applications that relied on the old behavior should be updated.
+  (:github:`112276`)
+
 GPIO
 ====
 

--- a/drivers/fuel_gauge/adp5360/fuel_gauge_adp5360.c
+++ b/drivers/fuel_gauge/adp5360/fuel_gauge_adp5360.c
@@ -42,10 +42,10 @@ enum adp5360_fuel_gauge_reg_address {
 	FUEL_GAUGE_ADP5360_REG_PGOOD_STATUS = 0x2Fu,
 };
 
-#define FUEL_GAUGE_ADP5360_SOC_SHIFT  4
-#define FUEL_GAUGE_ADP5360_VBAT_SHIFT 3
-#define FUEL_GAUGE_ADP5360_MV_TO_UV   1000
-#define FUEL_GAUGE_ADP5360_SOC_FULL   100
+#define FUEL_GAUGE_ADP5360_SOCACM_SHIFT 4
+#define FUEL_GAUGE_ADP5360_VBAT_SHIFT   3
+#define FUEL_GAUGE_ADP5360_MV_TO_UV     1000
+#define FUEL_GAUGE_ADP5360_SOC_FULL     100
 
 #define FUEL_GAUGE_ADP5360_V_SOC_MIN_VAL 2500
 #define FUEL_GAUGE_ADP5360_V_SOC_MAX_VAL 4540
@@ -133,18 +133,17 @@ static int fuel_gauge_adp5360_get_cycle_count(const struct device *dev,
 	const struct fuel_gauge_adp5360_config *config = dev->config;
 	const struct device *mfd_dev = config->mfd_adp5360;
 	int ret;
-	uint16_t buf;
+	uint16_t bat_socacm;
 
-	/* Read the cycle count value from the corresponding registers in the ADP5360 MFD */
+	/* Read the accumulated charge state from the corresponding registers in the ADP5360 MFD */
 	ret = mfd_adp5360_reg_burst_read(mfd_dev, FUEL_GAUGE_ADP5360_REG_BAT_SOC_ACM_H,
-					 (uint8_t *)&buf, 2);
+					 (uint8_t *)&bat_socacm, 2);
 	if (ret < 0) {
-		LOG_ERR("Failed to read cycle count from ADP5360 MFD: %d", ret);
+		LOG_ERR("Failed to read accumulated charge state from ADP5360 MFD: %d", ret);
 		return ret;
 	}
 
-	/* Register indicates 1/100ths of cycle count */
-	val->cycle_count = sys_be16_to_cpu(buf) >> FUEL_GAUGE_ADP5360_SOC_SHIFT;
+	val->cycle_count = (sys_be16_to_cpu(bat_socacm) >> FUEL_GAUGE_ADP5360_SOCACM_SHIFT) / 100;
 
 	return 0;
 }
@@ -563,7 +562,7 @@ static int fuel_gauge_adp5360_set_v_soc_probe(const struct device *dev)
 
 	/* Write the v_soc values to the corresponding registers in the ADP5360 MFD */
 	ret = mfd_adp5360_reg_burst_write(mfd_dev, FUEL_GAUGE_ADP5360_REG_V_SOC_0, buf,
-					  ARRAY_SIZE(buf)-1);
+					  ARRAY_SIZE(buf) - 1);
 	if (ret < 0) {
 		LOG_ERR("Failed to write v_soc values to ADP5360 MFD: %d", ret);
 		return ret;

--- a/drivers/fuel_gauge/bq27z746/bq27z746.c
+++ b/drivers/fuel_gauge/bq27z746/bq27z746.c
@@ -131,7 +131,7 @@ static int bq27z746_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		break;
 	case FUEL_GAUGE_CYCLE_COUNT:
 		rc = bq27z746_read16(dev, BQ27Z746_CYCLECOUNT, &tmp_val);
-		val->cycle_count = tmp_val * 100;
+		val->cycle_count = tmp_val;
 		break;
 	case FUEL_GAUGE_CURRENT_UA:
 		rc = bq27z746_read16(dev, BQ27Z746_CURRENT, &tmp_val);

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -55,7 +55,7 @@ enum fuel_gauge_prop_type {
 	FUEL_GAUGE_CURRENT __deprecated = FUEL_GAUGE_CURRENT_UA,
 	/** Whether the battery underlying the fuel-gauge is cut off from charge */
 	FUEL_GAUGE_CHARGE_CUTOFF,
-	/** Cycle count in 1/100ths (number of charge/discharge cycles) */
+	/** Cycle count in charge/discharge cycles */
 	FUEL_GAUGE_CYCLE_COUNT,
 	/** Connect state of battery */
 	FUEL_GAUGE_CONNECT_STATE,

--- a/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
+++ b/tests/drivers/fuel_gauge/bq27z746/src/test_bq27z746.c
@@ -128,7 +128,7 @@ ZTEST_USER_F(bq27z746, test_get_props__returns_ok)
 #if CONFIG_EMUL
 	/* When emulating, check for the fixed values coming from the emulator */
 	zassert_equal(vals[0].avg_current_ua, -2000);
-	zassert_equal(vals[1].cycle_count, 100);
+	zassert_equal(vals[1].cycle_count, 1);
 	zassert_equal(vals[2].current_ua, -2000);
 	zassert_equal(vals[3].full_charge_capacity_uah, 1000);
 	zassert_equal(vals[4].remaining_capacity_uah, 1000);
@@ -147,23 +147,23 @@ ZTEST_USER_F(bq27z746, test_get_props__returns_ok)
 	zassert_equal(vals[17].state_of_health, 1);
 #else
 	/* When having a real device, check for the valid ranges */
-	zassert_between_inclusive(vals[0].avg_current_ua, -32768 * 1000, 32767 * 1000);
-	zassert_between_inclusive(vals[1].cycle_count, 0, 6553500);
-	zassert_between_inclusive(vals[2].current_ua, -32768 * 1000, 32767 * 1000);
-	zassert_between_inclusive(vals[3].full_charge_capacity_uah, 0, 32767 * 1000);
-	zassert_between_inclusive(vals[4].remaining_capacity_uah, 0, 32767 * 1000);
-	zassert_between_inclusive(vals[5].runtime_to_empty_mins, 0, 65535);
-	zassert_between_inclusive(vals[6].runtime_to_full_mins, 0, 65535);
+	zassert_between_inclusive(vals[0].avg_current_ua, INT16_MIN * 1000, INT16_MAX * 1000);
+	zassert_between_inclusive(vals[1].cycle_count, 0, UINT16_MAX);
+	zassert_between_inclusive(vals[2].current_ua, INT16_MIN * 1000, INT16_MAX * 1000);
+	zassert_between_inclusive(vals[3].full_charge_capacity_uah, 0, INT16_MAX * 1000);
+	zassert_between_inclusive(vals[4].remaining_capacity_uah, 0, INT16_MAX * 1000);
+	zassert_between_inclusive(vals[5].runtime_to_empty_mins, 0, UINT16_MAX);
+	zassert_between_inclusive(vals[6].runtime_to_full_mins, 0, UINT16_MAX);
 	/* Not testing props[7]. This is the manufacturer access and has only status bits */
 	zassert_between_inclusive(vals[8].relative_state_of_charge_pct, 0, 100);
-	zassert_between_inclusive(vals[9].temperature_dk, 0, 32767);
-	zassert_between_inclusive(vals[10].voltage_uv, 0, 32767 * 1000);
-	zassert_between_inclusive(vals[11].sbs_at_rate, -32768, 32767);
-	zassert_between_inclusive(vals[12].sbs_at_rate_time_to_empty_mins, 0, 65535);
-	zassert_between_inclusive(vals[13].chg_voltage_uv, 0, 32767);
-	zassert_between_inclusive(vals[14].chg_current_ua, 0, 32767);
+	zassert_between_inclusive(vals[9].temperature_dk, 0, INT16_MAX);
+	zassert_between_inclusive(vals[10].voltage_uv, 0, INT16_MAX * 1000);
+	zassert_between_inclusive(vals[11].sbs_at_rate, INT16_MIN, INT16_MAX);
+	zassert_between_inclusive(vals[12].sbs_at_rate_time_to_empty_mins, 0, UINT16_MAX);
+	zassert_between_inclusive(vals[13].chg_voltage_uv, 0, INT16_MAX);
+	zassert_between_inclusive(vals[14].chg_current_ua, 0, INT16_MAX);
 	/* Not testing props[15]. This property is the status and only has only status bits */
-	zassert_between_inclusive(vals[16].design_cap, 0, 32767);
+	zassert_between_inclusive(vals[16].design_cap, 0, INT16_MAX);
 	zassert_between_inclusive(vals[17].state_of_health, 0, 100);
 #endif
 }


### PR DESCRIPTION
fix #112276:

`FUEL_GAUGE_CYCLE_COUNT` was documented and treated inconsistently: `bq27z746` multiplied the raw register value by 100 (producing 1/100th units), while `adp5360` shifted without the /100 division. Align both drivers so cycle_count carries whole cycle counts, matching the updated API doc. Update the `bq27z746` emulator test expectation accordingly.