### PR TITLE
tests: kernel: sched: time slices with the real cycles per tick

### DIFF
--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -101,8 +101,13 @@ ZTEST(threads_scheduling, test_slice_reset)
 	/* disable timeslice */
 	k_sched_time_slice_set(0, K_PRIO_PREEMPT(0));
 
-	/* Cycle-domain length of half a slice for the busy-wait below. */
-	uint32_t half_slice_cyc = k_ticks_to_cyc_ceil32(HALF_SLICE_TICKS);
+	/* Size the busy-wait as a whole number of ticks using the driver's
+	 * real cycles per tick, floor(HW/ticks). Converting the half-slice
+	 * with the fractional ratio (k_ticks_to_cyc_ceil32()) would skew the
+	 * measured ticks where a tick isn't a whole number of cycles.
+	 */
+	uint32_t cyc_per_tick = k_ticks_to_cyc_floor32(1);
+	uint32_t half_slice_cyc = HALF_SLICE_TICKS * cyc_per_tick;
 
 	for (int j = 0; j < 2; j++) {
 		k_sem_reset(&sema);
@@ -127,7 +132,9 @@ ZTEST(threads_scheduling, test_slice_reset)
 		/* initialize reference timestamp */
 		ticks_delta(&elapsed_slice);
 
-		/* current thread (ztest native) consumed a half timeslice */
+		/* consume half a timeslice, timed on the free-running cycle
+		 * counter (independent of the tick interrupt)
+		 */
 		t32 = k_cycle_get_32();
 		while (k_cycle_get_32() - t32 < half_slice_cyc) {
 			Z_SPIN_DELAY(50);

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -87,8 +87,13 @@ static void slice_expired(struct k_thread *thread, void *data)
 {
 	zassert_equal(thread, data, "wrong callback data pointer");
 
+	/* Convert with the driver's real cycles per tick, floor(HW/ticks), not
+	 * the fractional ratio k_cyc_to_ticks_near32() uses (which skews where a
+	 * tick isn't a whole number of cycles). Round, don't truncate, to absorb
+	 * the sub-tick offset between the reference and this reading.
+	 */
 	uint32_t now = k_cycle_get_32();
-	uint32_t dt = k_cyc_to_ticks_near32(now - last_cyc);
+	uint32_t dt = DIV_ROUND_CLOSEST(now - last_cyc, k_ticks_to_cyc_floor32(1));
 
 	zassert_true(perthread_running, "thread didn't start");
 	/* Slice fire lands on either the configured tick boundary or


### PR DESCRIPTION
The scheduler time-slice tests convert between the free-running cycle
counter and ticks through the fractional HW/ticks ratio, while the driver
advances k_uptime_ticks() once per floor(HW/ticks) cycles. On a platform
whose clock is not a whole multiple of the tick rate that skews a slice
past its [N, N+1] bound, which is what broke on the 32768 Hz parts once
the suite was pinned to a 1 ms tick (097d7bd9afdc). Both sites now convert
with the real cycles per tick instead. Full derivation in the commit log.

Reproduced locally on native_sim at non-dividing tick rates (6000 for
test_slice_reset, 19000 for test_slice_perthread); both fail before and
pass after.

Fixes #111973