### PR TITLE
drivers: wifi: nxp: fix missing uAP success event when IPv6 is disabled

### DIFF
--- a/drivers/wifi/nxp/src/nxp_wifi_net.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_net.c
@@ -1115,6 +1115,10 @@ int net_configure_address(struct net_ip_config *addr, void *intrfc_handle)
 		 * DAD finished event from zephyr.
 		 */
 		net_if_dormant_off(if_handle->netif);
+#ifndef CONFIG_NXP_WIFI_IPV6
+		(void)wlan_wlcmgr_send_msg(WIFI_EVENT_UAP_NET_ADDR_CONFIG,
+					   WIFI_EVENT_REASON_SUCCESS, NULL);
+#endif
 	}
 #endif
 	else { /* Do Nothing */


### PR DESCRIPTION
When CONFIG_NXP_WIFI_IPV6 is not enabled, the WIFI_EVENT_UAP_NET_ADDR_CONFIG
message is never sent to wlcmgr_task because it relies solely on the
NET_EVENT_IPV6_DAD_SUCCEED callback. This causes WLAN_REASON_UAP_SUCCESS to
never be triggered, leaving applications waiting indefinitely for the
WIFI_STATUS_AP_SUCCESS event.

Send WIFI_EVENT_UAP_NET_ADDR_CONFIG directly in net_configure_address() when
IPv6 is disabled, so the uAP state machine can proceed to CM_UAP_IP_UP and
emit the success event regardless of IPv6 configuration.

Fixes: https://github.com/zephyrproject-rtos/hal_nxp/pull/709

---
_Generated by WChat AI Agent_