### PR TITLE
west.yml: hostap: fix wpa_cli unknown command

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -294,7 +294,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: e97765d250aad14e0d2495a3fd5d4d9354a408df
+      revision: pull/145/head
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
Update hostap revision to fix wpa_cli unknown command for features enabled.