### PR TITLE
net/ieee802154: remove -EALREADY in set_channel API

### DIFF
--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -1577,8 +1577,6 @@ struct ieee802154_radio_api {
 	 * @param channel the number of the channel to be set in CPU byte order
 	 *
 	 * @retval 0 channel was successfully set
-	 * @retval -EALREADY The previous channel is the same as the requested
-	 * channel.
 	 * @retval -EINVAL The given channel is not within the range of valid
 	 * channels of the driver's current channel page, see the
 	 * IEEE802154_ATTR_PHY_SUPPORTED_CHANNEL_RANGES driver attribute.


### PR DESCRIPTION
Remove the -EALREADY error return from the set_channel API description because the return value is meaningless.
No driver implements the -EALREADY use case, and implementing it could cause errors in the upper layer.
Therefore, I removed the -EALREADY error return from the description to avoid confusion in the API.