### PR TITLE
gitignore: add KconfigFormat.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ ImageSize.txt
 Kconfig.txt
 KconfigBasic.txt
 KconfigBasicNoModules.txt
+KconfigFormat.txt
 KconfigHWMv2.txt
 KeepSorted.txt
 LicenseAndCopyrightCheck.txt


### PR DESCRIPTION
The kconfig_style.py script generates this file, but it is not meant to ever be commited.