### PR TITLE
dts: st: l4 fix sai dma slot

### DIFF
--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -483,7 +483,7 @@
 
 			sai1_a: sai1a@4 {
 				reg = <0x4 0x20>;
-				dmas = <&dma2 1 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				dmas = <&dma2 1 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
@@ -491,7 +491,7 @@
 
 			sai1_b: sai1b@24 {
 				reg = <0x24 0x20>;
-				dmas = <&dma2 2 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+				dmas = <&dma2 2 38 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -72,5 +72,16 @@
 				status = "disabled";
 			};
 		};
+
+		sai1: sai1@40015400 {
+			/* L4R/S SAI DMA Request differs from L4P/Q */
+			sai1_a: sai1a@4 {
+				dmas = <&dma2 1 36 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+			};
+
+			sai1_b: sai1b@24 {
+				dmas = <&dma2 2 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+			};
+		};
 	};
 };


### PR DESCRIPTION
These changes match the SAI DMA Slot to DMAMUX Request

[RM432](https://www.st.com/resource/en/reference_manual/rm0432-stm32l4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf):
STM32L4Rx & STM32L4Sx -> Req 36 / 37
STM32L4Px & STM32L4Qx -> Req 37 / 38

closes: #111985

