### PR TITLE
bluetooth: classic: pbap: add security warnings to MD5 auth APIs

### DIFF
--- a/include/zephyr/bluetooth/classic/pbap.h
+++ b/include/zephyr/bluetooth/classic/pbap.h
@@ -967,6 +967,9 @@ int bt_pbap_pse_abort_rsp(struct bt_pbap_pse *pbap_pse, uint8_t rsp_code, struct
  *               (@ref BT_OBEX_CHALLENGE_TAG_NONCE_LEN bytes).
  *
  *  @return 0 on success, negative error code on failure.
+ *
+ *  @warning PBAP v1.x uses MD5 for authentication, which is cryptographically weak.
+ *           PBAP authentication provides limited security.
  */
 int bt_pbap_calculate_nonce(const uint8_t *pwd, uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN]);
 
@@ -983,6 +986,9 @@ int bt_pbap_calculate_nonce(const uint8_t *pwd, uint8_t nonce[BT_OBEX_CHALLENGE_
  *                    (@ref BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN bytes).
  *
  *  @return 0 on success, negative error code on failure.
+ *
+ *  @warning PBAP v1.x uses MD5 for authentication, which is cryptographically weak.
+ *           PBAP authentication provides limited security.
  */
 int bt_pbap_calculate_rsp_digest(const uint8_t *pwd,
 				 const uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN],
@@ -1001,6 +1007,9 @@ int bt_pbap_calculate_rsp_digest(const uint8_t *pwd,
  *  @param pwd Password string used for authentication (null-terminated).
  *
  *  @return 0 if authentication is successful, negative error code on failure.
+ *
+ *  @warning PBAP v1.x uses MD5 for authentication, which is cryptographically weak.
+ *           PBAP authentication provides limited security.
  */
 int bt_pbap_verify_authentication(uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN],
 				  uint8_t rsp_digest[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN],

--- a/subsys/bluetooth/host/classic/CMakeLists.txt
+++ b/subsys/bluetooth/host/classic/CMakeLists.txt
@@ -55,4 +55,9 @@ zephyr_library_sources_ifdef(
   pbap.c
   )
 
+if(CONFIG_BT_PBAP)
+  message(WARNING "CONFIG_BT_PBAP: PBAP v1.x uses MD5 for authentication, which is "
+                  "cryptographically weak.")
+endif()
+
 zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedtls_iface)

--- a/subsys/bluetooth/host/classic/pbap.c
+++ b/subsys/bluetooth/host/classic/pbap.c
@@ -841,6 +841,8 @@ int bt_pbap_calculate_nonce(const uint8_t *pwd, uint8_t nonce[BT_OBEX_CHALLENGE_
 		return -EINVAL;
 	}
 
+	LOG_WRN("PBAP authentication relies on legacy MD5-based OBEX authentication");
+
 	memcpy(hash_input, &timestamp, sizeof(timestamp));
 	hash_input[sizeof(timestamp)] = ':';
 	memcpy(hash_input + sizeof(timestamp) + 1U, pwd, pwd_len);
@@ -883,6 +885,8 @@ int bt_pbap_calculate_rsp_digest(const uint8_t *pwd,
 		LOG_ERR("Password is invalid");
 		return -EINVAL;
 	}
+
+	LOG_WRN("PBAP authentication relies on legacy MD5-based OBEX authentication");
 
 	memcpy(hash_input, nonce, BT_OBEX_CHALLENGE_TAG_NONCE_LEN);
 	hash_input[BT_OBEX_CHALLENGE_TAG_NONCE_LEN] = ':';


### PR DESCRIPTION
Add doxygen warnings to PBAP authentication helper functions to inform users that PBAP v1.x uses MD5 for authentication, which is cryptographically weak and provides limited security.

Add the log warnings to the function. The warning Log message will be printed when the function is being called in the running time mode.

Also add a building warning if the `CONFIG_BT_PBAP` is enabled.