### PR TITLE
bluetooth: classic: pbap: use constant-time digest comparison

### DIFF
--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -725,6 +725,7 @@ config BT_PBAP
 	bool
 	select BT_GOEP
 	select PSA_WANT_ALG_MD5
+	select MBEDTLS
 	help
 	  This option enables the PBAP profile
 

--- a/subsys/bluetooth/host/classic/pbap.c
+++ b/subsys/bluetooth/host/classic/pbap.c
@@ -25,6 +25,8 @@
 #include <zephyr/bluetooth/classic/goep.h>
 #include <zephyr/bluetooth/classic/pbap.h>
 
+#include <mbedtls/constant_time.h>
+
 #include "host/conn_internal.h"
 #include "l2cap_br_internal.h"
 #include "rfcomm_internal.h"
@@ -906,15 +908,18 @@ int bt_pbap_verify_authentication(uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN]
 	int err;
 
 	err = bt_pbap_calculate_rsp_digest(pwd, nonce, result);
-	if (err == 0) {
-		err = memcmp(result, rsp_digest, BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN);
-		if (err != 0) {
-			LOG_ERR("rsp_digest is invalid");
-			return -EINVAL;
-		}
+	if (err != 0) {
+		LOG_ERR("Failed to calculate response digest %d", err);
+		return err;
 	}
 
-	return err;
+	err = mbedtls_ct_memcmp(result, rsp_digest, BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN);
+	if (err != 0) {
+		LOG_ERR("rsp_digest is invalid");
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
 #if defined(CONFIG_BT_PBAP_PSE)


### PR DESCRIPTION
Replace memcmp() with mbedtls_ct_memcmp() when verifying authentication response digests to prevent timing attacks. The standard memcmp() function may leak information about the digest through timing side channels, allowing attackers to potentially recover the digest byte-by-byte.