### PR TITLE
hostap: enforce PMF for SAE connections in AP mode

### DIFF
--- a/modules/hostap/src/hapd_main.c
+++ b/modules/hostap/src/hapd_main.c
@@ -373,6 +373,7 @@ struct hostapd_config *hostapd_config_read2(const char *fname)
 	conf->ht_capab |= HT_CAP_INFO_SHORT_GI20MHZ;
 	bss->auth_algs = 1;
 	bss->okc = 1;
+	bss->sae_require_mfp = 1;
 	conf->no_pri_sec_switch = 1;
 	conf->ht_op_mode_fixed  = 1;
 #if CONFIG_WIFI_NM_WPA_SUPPLICANT_11AC


### PR DESCRIPTION
Per WPA3 specification, stations connecting via SAE
authentication must have PMF (Protected Management Frames)
capability enabled. Set sae_require_mfp to 1 in hostapd AP
configuration (hostapd_config_read2) so that in WPA3-Personal
Transition mode (ieee80211w=1), the AP rejects SAE stations
that do not advertise MFPC in their RSN capabilities. This
allows legacy PSK stations to connect without PMF while
enforcing PMF for all SAE connections.

---
_Generated by WChat AI Agent_