### PR TITLE
drivers: virtio: zero-initialize virtq struct in virtq_create()

### DIFF
--- a/drivers/virtio/virtqueue.c
+++ b/drivers/virtio/virtqueue.c
@@ -54,6 +54,7 @@ int virtq_create(struct virtq *v, size_t size)
 		return -ENOMEM;
 	}
 
+	memset(v, 0, sizeof(*v));
 	v->num = size;
 	v->desc = (struct virtq_desc *)v_area;
 	v->avail = (struct virtq_avail *)((uint8_t *)v->desc + descriptor_table_size);


### PR DESCRIPTION
virtq_create() received a pointer to a struct virtq allocated by the callers via k_malloc(). k_malloc() does not zero memory, so fields such as lock could contain garbage. When CONFIG_SPIN_VALIDATE is enabled, taking the spinlock then triggers an assertion because lock.thread_cpu is non-zero.

Zero the whole struct at the start of virtq_create() so that all fields are initialized before the descriptor table is set up.

Fixes #112349