### PR TITLE
tests: drivers: gpio: add FGPIO loopback test for frdm_ke15z

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/frdm_ke15z_fgpio.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/frdm_ke15z_fgpio.overlay
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * FGPIO loopback test wiring (fixture: fgpio_loopback):
+ * Connect a jumper between the Arduino header pins:
+ *     J1-2 (Arduino D0 / PTC8)  <-->  J1-4 (Arduino D1 / PTC9)
+ * out-gpios drives D0 (PTC8) and in-gpios reads it back on D1 (PTC9).
+ * Note: these are FGPIO (IOPORT fast-bus) accesses to the same PTC8/PTC9
+ * pins; they do not conflict with the console (lpuart1 on PTC6/PTC7).
+ */
+
+&fgpioc {
+	status = "okay";
+};
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&fgpioc 8 0>; /* J1-2, Arduino D0, PTC8 */
+		in-gpios = <&fgpioc 9 0>;  /* J1-4, Arduino D1, PTC9 */
+	};
+};

--- a/tests/drivers/gpio/gpio_basic_api/tests.yaml
+++ b/tests/drivers/gpio/gpio_basic_api/tests.yaml
@@ -47,6 +47,14 @@ tests:
     harness_config:
       fixture: fgpio_loopback
 
+  drivers.gpio.2pin_ke15z_fgpio:
+    min_flash: 34
+    platform_allow:
+      - frdm_ke15z
+    extra_args: "DTC_OVERLAY_FILE=boards/frdm_ke15z_fgpio.overlay"
+    harness_config:
+      fixture: fgpio_loopback
+
   drivers.gpio.2pin_arduino:
     min_flash: 34
     depends_on:


### PR DESCRIPTION
## Description

Adds an FGPIO loopback test scenario for the FRDM-KE15Z board, mirroring
the existing `frdm_ke17z` / `frdm_ke17z512` coverage.

The KE1xZ family exposes its GPIO ports through a second, zero-wait-state
IOPORT alias (FGPIO) at `0xf80000xx`, in addition to the standard GPIO
peripheral at `0x400ffxxx`. The FGPIO nodes already exist in the shared
`nxp_ke1xz.dtsi` but were not exercised by any test on `frdm_ke15z`.

This PR:
- Adds `boards/frdm_ke15z_fgpio.overlay`, enabling `&fgpioc` with the
  loopback on PTC8/PTC9 (Arduino D0/D1, header pins J1-2/J1-4).
- Registers a `drivers.gpio.2pin_ke15z_fgpio` scenario in `testcase.yaml`
  with the `fgpio_loopback` fixture.

The FGPIO loopback pins do not conflict with the console (lpuart1 on
PTC6/PTC7).

## Testing

Verified on FRDM-KE15Z hardware with a jumper between J1-2 (PTC8/D0) and
J1-4 (PTC9/D1):
- `gpio_port` suite **PASS** on `gpio@f8000080` (the FGPIO base) —
  `OUT 8 to IN 9 linkage works`
- callback management / variant suites **PASS**
- `PROJECT EXECUTION SUCCESSFUL`
