### PR TITLE
arch/x86: intel64: ensure x2APIC mode before reading AP APIC ID

### DIFF
--- a/arch/x86/core/intel64/locore.S
+++ b/arch/x86/core/intel64/locore.S
@@ -152,9 +152,15 @@ x86_ap_start:
 	 */
 
 #ifdef CONFIG_X2APIC
-	/* In x2APIC mode the MMIO registers are inaccessible; read the
-	 * 32-bit x2APIC ID from MSR 0x802 instead.
+	/*
+	 * x2APIC: read the ID from the MSR (MMIO is inaccessible). An AP may
+	 * still be in xAPIC mode, where that MSR faults, so enable x2APIC
+	 * first -- faults can't be handled this early.
 	 */
+	movl $X86_APIC_BASE_MSR, %ecx
+	rdmsr
+	orl $X86_APIC_BASE_MSR_X2APIC, %eax
+	wrmsr
 	movl $(X86_X2APIC_BASE_MSR + (LOAPIC_ID >> 4)), %ecx
 	rdmsr
 #else


### PR DESCRIPTION
The `CONFIG_X2APIC` help text frames the option as safe to enable on any APIC that supports x2APIC mode. This is not accurate: with `CONFIG_X2APIC=y`, an AP reads its local APIC ID from the x2APIC ID MSR unconditionally, even when the AP has not been switched into x2APIC mode earlier in the bootflow. The MSR access then faults, and the fault cannot be handled this early in SMP bring-up, so the AP hangs.
