### PR TITLE
posix: lib: fix 32-bit time_t overflow in time conversions

### DIFF
--- a/lib/os/zvfs/zvfs_select.c
+++ b/lib/os/zvfs/zvfs_select.c
@@ -10,6 +10,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/timeutil.h>
 #include <zephyr/net/socket.h>
 
 /* Get size, in elements, of an array within a struct. */
@@ -140,8 +141,7 @@ int z_impl_zvfs_select(int nfds, struct zvfs_fd_set *ZRESTRICT readfds,
 	if (timeout == NULL) {
 		poll_timeout = K_FOREVER;
 	} else {
-		poll_timeout =
-			K_USEC(timeout->tv_sec * USEC_PER_SEC + timeout->tv_nsec / NSEC_PER_USEC);
+		poll_timeout = timespec_to_timeout(timeout, NULL);
 	}
 
 	res = zvfs_poll_internal(pfds, num_pfds, poll_timeout);

--- a/subsys/portability/posix/options/posix_clock.h
+++ b/subsys/portability/posix/options/posix_clock.h
@@ -24,12 +24,16 @@ extern "C" {
 
 static inline int64_t ts_to_ns(const struct timespec *ts)
 {
-	return ts->tv_sec * NSEC_PER_SEC + ts->tv_nsec;
+	/* Widen tv_sec to 64-bit before scaling: on targets where time_t is a
+	 * 32-bit type the multiplication would otherwise overflow (e.g. tv_sec
+	 * as small as 5 already exceeds UINT32_MAX once scaled to nanoseconds).
+	 */
+	return (int64_t)ts->tv_sec * NSEC_PER_SEC + ts->tv_nsec;
 }
 
 static inline int64_t ts_to_ms(const struct timespec *ts)
 {
-	return ts->tv_sec * MSEC_PER_SEC + ts->tv_nsec / NSEC_PER_MSEC;
+	return (int64_t)ts->tv_sec * MSEC_PER_SEC + ts->tv_nsec / NSEC_PER_MSEC;
 }
 
 static inline void tv_to_ts(const struct timeval *tv, struct timespec *ts)

--- a/tests/net/socket/select/src/main.c
+++ b/tests/net/socket/select/src/main.c
@@ -169,6 +169,68 @@ ZTEST_USER(net_socket_select, test_select)
 	zassert_equal(res, 0, "close failed");
 }
 
+/*
+ * Verify that select() honors a large timeout and does not expire prematurely.
+ *
+ * OVERFLOW_TIMEOUT_SEC (4295) is the smallest whole-second timeout whose
+ * conversion to microseconds (seconds * 1,000,000) exceeds UINT32_MAX. If that
+ * multiplication is done in 32-bit arithmetic, the result wraps to a small
+ * value (~33 ms) instead of the intended >1 hour.
+ *
+ * SENDER_DELAY_MS (200) is when the helper thread makes the socket readable.
+ * That is long enough to outlast a wrongly truncated timeout, but far shorter
+ * than the real timeout, so select() should return 1 (data ready), not 0
+ * (timed out early).
+ */
+#define OVERFLOW_TIMEOUT_SEC 4295
+#define SENDER_DELAY_MS      200
+
+static int overflow_c_sock;
+
+static void overflow_sender(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	k_msleep(SENDER_DELAY_MS);
+	(void)zsock_send(overflow_c_sock, BUF_AND_SIZE(TEST_STR_SMALL), 0);
+}
+
+K_THREAD_STACK_DEFINE(overflow_sender_stack, 1024);
+static struct k_thread overflow_sender_thread;
+
+ZTEST(net_socket_select, test_select_large_timeout_no_overflow)
+{
+	int c_sock;
+	int s_sock;
+	struct net_sockaddr_in6 c_addr;
+	struct net_sockaddr_in6 s_addr;
+	zsock_fd_set readfds;
+	struct timeval tval = {.tv_sec = OVERFLOW_TIMEOUT_SEC, .tv_usec = 0};
+
+	prepare_sock_udp_v6(MY_IPV6_ADDR, CLIENT_PORT, &c_sock, &c_addr);
+	prepare_sock_udp_v6(MY_IPV6_ADDR, SERVER_PORT, &s_sock, &s_addr);
+	zassert_equal(zsock_bind(s_sock, (struct net_sockaddr *)&s_addr, sizeof(s_addr)), 0);
+	zassert_equal(zsock_connect(c_sock, (struct net_sockaddr *)&s_addr, sizeof(s_addr)), 0);
+
+	ZSOCK_FD_ZERO(&readfds);
+	ZSOCK_FD_SET(s_sock, &readfds);
+
+	overflow_c_sock = c_sock;
+	k_thread_create(&overflow_sender_thread, overflow_sender_stack,
+			K_THREAD_STACK_SIZEOF(overflow_sender_stack), overflow_sender, NULL, NULL,
+			NULL, K_PRIO_PREEMPT(10), 0, K_NO_WAIT);
+
+	/* 1 = woken by data; 0 = timed out early (large timeout not honored) */
+	zassert_equal(zsock_select(s_sock + 1, &readfds, NULL, NULL, &tval), 1,
+		      "select timed out before data arrived: large timeout not honored");
+
+	zassert_ok(k_thread_join(&overflow_sender_thread, K_FOREVER));
+	zassert_equal(zsock_close(c_sock), 0);
+	zassert_equal(zsock_close(s_sock), 0);
+}
+
 static void *setup(void)
 {
 	if (IS_ENABLED(CONFIG_NET_TC_THREAD_COOPERATIVE)) {

--- a/tests/subsys/portability/posix/timers/src/timer.c
+++ b/tests/subsys/portability/posix/timers/src/timer.c
@@ -186,7 +186,7 @@ ZTEST(posix_timers, test_TIMER_ABSTIME_reference_clock)
 	zassert_equal(exp_count, 1, "TIMER_ABSTIME fired %d times, expected 1", exp_count);
 }
 
-ZTEST(posix_timers, test_TIMER_ABSTIME_no_uint32_truncation)
+ZTEST(posix_timers, test_TIMER_ABSTIME_large_timeout)
 {
 	struct sigevent sig = {0};
 	struct itimerspec value;
@@ -199,26 +199,36 @@ ZTEST(posix_timers, test_TIMER_ABSTIME_no_uint32_truncation)
 
 	zassert_ok(timer_create(CLOCK_REALTIME, &sig, &timerid));
 
-	/*Set CLOCK_REALTIME to a large value to trigger uint32_t overflow in ts_to_ms()*/
+	/*
+	 * TIMER_ABSTIME at a large CLOCK_REALTIME value with a 5 s offset.
+	 * Guards two timeout conversion bugs on 32-bit time_t toolchains:
+	 * - uint32 truncation: storing absolute milliseconds in a uint32_t
+	 *   instead of the relative wait from timespec_to_timeoutms()
+	 * - time_t overflow: tv_sec * NSEC_PER_SEC wraps in 32-bit math
+	 *   unless widened to int64_t before scaling (needs a multi-second
+	 *   offset; same-second offsets cancel in the subtraction)
+	 * After 2 s the timer must still be pending; after 5.5 s it must
+	 * have fired once.
+	 */
 	zassert_ok(clock_gettime(CLOCK_REALTIME, &orig));
 	ref.tv_sec = 1700000000;
 	ref.tv_nsec = 0;
 	zassert_ok(clock_settime(CLOCK_REALTIME, &ref));
 
-	/*Set TIMER_ABSTIME to ref + 200 ms*/
+	/* Set TIMER_ABSTIME to ref + 5 s */
 	value.it_interval.tv_sec = 0;
 	value.it_interval.tv_nsec = 0;
-	value.it_value.tv_sec = ref.tv_sec;
-	value.it_value.tv_nsec = 200 * NSEC_PER_MSEC;
+	value.it_value.tv_sec = ref.tv_sec + 5;
+	value.it_value.tv_nsec = 0;
 	zassert_ok(timer_settime(timerid, TIMER_ABSTIME, &value, NULL));
 	zassert_ok(clock_settime(CLOCK_REALTIME, &orig));
 
-	/*Verify the timer has not fired before the absolute expiry*/
-	k_sleep(K_MSEC(100));
-	zassert_equal(exp_count, 0, "TIMER_ABSTIME fired too early");
+	/* A broken build fires early; a correct 5 s timeout has not fired yet */
+	k_sleep(K_MSEC(2000));
+	zassert_equal(exp_count, 0, "TIMER_ABSTIME fired too early: tv_sec overflow not widened");
 
-	/*Verify the timer fired after the absolute expiry*/
-	k_sleep(K_MSEC(300));
+	/* A correct build fires exactly once at the 5 s absolute expiry */
+	k_sleep(K_MSEC(3500));
 	zassert_equal(exp_count, 1, "TIMER_ABSTIME fired %d times, expected 1", exp_count);
 }
 


### PR DESCRIPTION
Cast `tv_sec` to `int64_t` before multiplying by `NSEC_PER_SEC` / `MSEC_PER_SEC` / `USEC_PER_SEC` in `posix_clock.h` and `zvfs_select.c`. On 32-bit `time_t` toolchains, the multiplication previously wrapped in 32-bit math, breaking POSIX timed-waits and long `select()` timeouts.
