### PR TITLE
boards: nxp: imxrt118x: set M7 PERIPHERAL MPU region execute-never

### DIFF
--- a/boards/nxp/frdm_imxrt1186/cm7/mpu_regions.c
+++ b/boards/nxp/frdm_imxrt1186/cm7/mpu_regions.c
@@ -84,8 +84,13 @@ static const struct arm_mpu_region mpu_regions[] = {
 			 REGION_FLASH_ATTR(REGION_QSPI_FLASH_SIZE)),
 #endif
 
+	/*
+	 * PERIPHERAL region must be Execute-Never (XN=1) to prevent Cortex-M7
+	 * speculative instruction fetches into peripheral space.
+	 */
 	MPU_REGION_ENTRY("PERIPHERAL", REGION_PERIPHERAL_BASE_ADDRESS,
-			 REGION_PPB_ATTR(REGION_PERIPHERAL_SIZE)),
+			 {STRONGLY_ORDERED_SHAREABLE | MPU_RASR_XN_Msk |
+			  REGION_PERIPHERAL_SIZE | P_RW_U_NA_Msk}),
 };
 
 const struct arm_mpu_config mpu_config = {

--- a/boards/nxp/mimxrt1180_evk/cm7/mpu_regions.c
+++ b/boards/nxp/mimxrt1180_evk/cm7/mpu_regions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 NXP
+ * Copyright 2025-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -84,8 +84,13 @@ static const struct arm_mpu_region mpu_regions[] = {
 			 REGION_FLASH_ATTR(REGION_QSPI_FLASH_SIZE)),
 #endif
 
+	/*
+	 * PERIPHERAL region must be Execute-Never (XN=1) to prevent Cortex-M7
+	 * speculative instruction fetches into peripheral space.
+	 */
 	MPU_REGION_ENTRY("PERIPHERAL", REGION_PERIPHERAL_BASE_ADDRESS,
-			 REGION_PPB_ATTR(REGION_PERIPHERAL_SIZE)),
+			 {STRONGLY_ORDERED_SHAREABLE | MPU_RASR_XN_Msk |
+			  REGION_PERIPHERAL_SIZE | P_RW_U_NA_Msk}),
 };
 
 const struct arm_mpu_config mpu_config = {


### PR DESCRIPTION
## Description

The Cortex-M7 performs speculative instruction fetches into the PERIPHERAL region (`0x40000000-0x7FFFFFFF`). Per ARM, the only way to prevent speculative fetches into a region on Cortex-M7 is to mark it Execute-Never (`XN=1`).

The PERIPHERAL MPU entry for the affected RT118x M7 boards used `REGION_PPB_ATTR()`, which leaves `XN=0`, so the region was executable. This sets `XN=1` on the PERIPHERAL region by adding `MPU_RASR_XN_Msk` to its attributes; all other attributes are unchanged.

Boards updated:
- `mimxrt1180_evk/cm7`
- `frdm_imxrt1186/cm7`

## Testing

Built `samples/hello_world` for both targets; both link cleanly:
- `mimxrt1180_evk/mimxrt1189/cm7`
- `frdm_imxrt1186/mimxrt1186/cm7`

