### PR TITLE
drivers: led_strip: ws2812_gpio: derive GPIO base from devicetree

### DIFF
--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -27,6 +27,7 @@ LOG_MODULE_REGISTER(ws2812_gpio);
 
 struct ws2812_gpio_cfg {
 	struct gpio_dt_spec gpio;
+	uintptr_t gpio_outset_base;
 	uint8_t num_colors;
 	const uint8_t *color_mapping;
 	size_t length;
@@ -76,7 +77,7 @@ struct ws2812_gpio_cfg {
 static int send_buf(const struct device *dev, uint8_t *buf, size_t len)
 {
 	const struct ws2812_gpio_cfg *config = dev->config;
-	volatile uint32_t *base = (uint32_t *)&NRF_GPIO->OUTSET;
+	volatile uint32_t *base = (uint32_t *)config->gpio_outset_base;
 	const uint32_t val = BIT(config->gpio.pin);
 	struct onoff_manager *mgr =
 		z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
@@ -233,6 +234,9 @@ static const uint8_t ws2812_gpio_##idx##_color_mapping[] =		\
 									\
 	static const struct ws2812_gpio_cfg ws2812_gpio_##idx##_cfg = { \
 		.gpio = GPIO_DT_SPEC_INST_GET(idx, gpios),		\
+		.gpio_outset_base =					\
+			DT_REG_ADDR(DT_GPIO_CTLR(DT_DRV_INST(idx), gpios)) + \
+			offsetof(NRF_GPIO_Type, OUTSET),		\
 		.num_colors = WS2812_NUM_COLORS(idx),			\
 		.color_mapping = ws2812_gpio_##idx##_color_mapping,	\
 		.length = DT_INST_PROP(idx, chain_length),		\


### PR DESCRIPTION
send_buf uses NRF_GPIO as the GPIO controller base address. NRF_GPIO is defined as NRF_P0 in sdk-hal_nordic/nrfx/mdk, so with pins not belong to GPIO0,
it causes data to be sent to the wrong pin.
At compile time get the GPIO controller register address from devicetree, and calculate the OUTSET base address with struct NRF_GPIO_Type.
Tested on nRF52833 hardware.