### PR TITLE
Bugfix/flexspi nor systematic fix

### DIFF
--- a/drivers/flash/Kconfig.mcux
+++ b/drivers/flash/Kconfig.mcux
@@ -54,6 +54,35 @@ config FLASH_MCUX_FLEXSPI_NOR
 	select MEMC
 	select MEMC_MCUX_FLEXSPI
 
+config FLASH_MCUX_FLEXSPI_NOR_TIMEOUT_RETRIES
+	int "Retry count for FlexSPI NOR busy-wait polling"
+	default 500000
+	depends on FLASH_MCUX_FLEXSPI_NOR
+	help
+	  Maximum number of status-register reads while waiting
+	  for the NOR flash to become ready after a page program
+	  or sector/block erase.
+	  Each iteration does one SPI status read; at 1-1-1 50 MHz
+	  with an 8-bit read, one iteration takes roughly 10 us.
+	  The default of 500000 therefore gives approximately a
+	  5-second timeout, sufficient for sector erase (typical
+	  45-400 ms) and page program (typical 0.2-3 ms).
+	  Used inside irq_lock() on XIP platforms where kernel
+	  timing APIs are unavailable.
+
+config FLASH_MCUX_FLEXSPI_NOR_CHIP_ERASE_TIMEOUT_RETRIES
+	int "Retry count for FlexSPI NOR chip erase polling"
+	default 20000000
+	depends on FLASH_MCUX_FLEXSPI_NOR
+	help
+	  Like FLASH_MCUX_FLEXSPI_NOR_TIMEOUT_RETRIES but used
+	  only for full-chip erase, which takes far longer than
+	  sector or block erase.
+	  At ~10 us per iteration the default of 20000000 gives
+	  approximately a 200-second timeout.  Typical full-chip
+	  erase times range from 40 s (W25Q128JW) to 120 s; the
+	  JEDEC maximum can be up to 200 s.
+
 config FLASH_MCUX_FLEXSPI_MX25UM51345G
 	bool "MCUX FlexSPI MX25UM51345G driver"
 	default y

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -383,9 +383,6 @@ static int flash_flexspi_nor_wait_bus_busy(struct flash_flexspi_nor_data *data)
 static int flash_flexspi_nor_read(const struct device *dev, off_t offset, void *buffer, size_t len)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
-	int ret;
-	unsigned int key = 0U;
-	bool xip;
 
 	if (len == 0) {
 		return 0;
@@ -460,55 +457,16 @@ static int flash_flexspi_nor_read(const struct device *dev, off_t offset, void *
 	}
 #endif /* FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT */
 
-	xip = memc_flexspi_is_running_xip(&data->controller);
+	uint8_t *src = memc_flexspi_get_ahb_address(&data->controller,
+						     data->port, offset);
 
-	if (xip) {
-		key = irq_lock();
-		memc_flexspi_wait_bus_idle(&data->controller);
+	if (!src) {
+		LOG_ERR("No AHB address for port %u offset 0x%lx", data->port, offset);
+		flash_flexspi_nor_unlock(dev);
+		return -EINVAL;
 	}
-
-	uint8_t *dst = (uint8_t *)buffer;
-	size_t remaining = len;
-	off_t current_offset = offset;
-	uint8_t ip_read_buf[SPI_NOR_PAGE_SIZE];
-
-	while (remaining > 0U) {
-		off_t aligned_offset = ROUND_DOWN(current_offset, sizeof(uint32_t));
-		size_t byte_offset = current_offset - aligned_offset;
-		size_t required = MIN(remaining + byte_offset, sizeof(ip_read_buf));
-		size_t read_size = MAX(ROUND_UP(required, sizeof(uint32_t)), sizeof(uint32_t));
-		size_t copy_size = MIN(remaining, read_size - byte_offset);
-		flexspi_transfer_t transfer = {
-			.deviceAddress = aligned_offset,
-			.port = data->port,
-			.cmdType = kFLEXSPI_Read,
-			.SeqNumber = 1,
-			.seqIndex = READ,
-			.data = (uint32_t *)ip_read_buf,
-			.dataSize = read_size,
-		};
-
-		ret = memc_flexspi_transfer(&data->controller, &transfer);
-		if (ret < 0) {
-			if (xip) {
-				irq_unlock(key);
-			}
-			flash_flexspi_nor_unlock(dev);
-			return ret;
-		}
-
-		memcpy(dst, &ip_read_buf[byte_offset], copy_size);
-		dst += copy_size;
-		current_offset += copy_size;
-		remaining -= copy_size;
-	}
-
-	if (xip) {
-		irq_unlock(key);
-	}
-
+	memcpy(buffer, src, len);
 	flash_flexspi_nor_unlock(dev);
-
 	return 0;
 }
 static int flash_flexspi_nor_write(const struct device *dev, off_t offset,

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -1201,9 +1201,15 @@ static int flash_flexspi_nor_config_flash(struct flash_flexspi_nor_data *data,
 	/* Check to see if we can enable 4 byte addressing */
 	ret = jesd216_bfp_decode_dw16(&header->phdr[0], bfp, &dw16);
 	if (ret == 0) {
-		/* Attempt to enable 4 byte addressing */
-		ret = flash_flexspi_nor_4byte_enable(data, flexspi_lut,
-						     dw16.enter_4ba);
+		bool xip_cfg = memc_flexspi_is_running_xip(&data->controller);
+
+		if (!xip_cfg || data->size > MB(16)) {
+			ret = flash_flexspi_nor_4byte_enable(data, flexspi_lut,
+							     dw16.enter_4ba);
+		} else {
+			/* ≤16MB under XIP: 24-bit addressing covers full range, skip */
+			ret = 0;
+		}
 		if (ret == 0) {
 			/* Use 4 byte address width */
 			addr_width = 32;

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -353,14 +353,14 @@ static int flash_flexspi_nor_page_program(struct flash_flexspi_nor_data *data,
 	return memc_flexspi_transfer(&data->controller, &transfer);
 }
 
-static int flash_flexspi_nor_wait_bus_busy(struct flash_flexspi_nor_data *data)
+static int flash_flexspi_nor_wait_bus_busy_retries(struct flash_flexspi_nor_data *data,
+						    int retries)
 {
 	uint32_t status = 0;
 	int ret;
 
-	while (1) {
+	do {
 		ret = flash_flexspi_nor_read_status(data, &status);
-		LOG_DBG("status: 0x%x", status);
 		if (ret) {
 			LOG_ERR("Could not read status");
 			return ret;
@@ -368,16 +368,23 @@ static int flash_flexspi_nor_wait_bus_busy(struct flash_flexspi_nor_data *data)
 
 		if (data->legacy_poll) {
 			if ((status & BIT(0)) == 0) {
-				break;
+				return 0;
 			}
 		} else {
 			if (status & BIT(7)) {
-				break;
+				return 0;
 			}
 		}
-	}
+	} while (--retries > 0);
 
-	return 0;
+	LOG_ERR("Timed out waiting for flash ready (status=0x%x)", status);
+	return -ETIMEDOUT;
+}
+
+static int flash_flexspi_nor_wait_bus_busy(struct flash_flexspi_nor_data *data)
+{
+	return flash_flexspi_nor_wait_bus_busy_retries(data,
+		CONFIG_FLASH_MCUX_FLEXSPI_NOR_TIMEOUT_RETRIES);
 }
 
 static int flash_flexspi_nor_read(const struct device *dev, off_t offset, void *buffer, size_t len)
@@ -514,6 +521,8 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 		memc_flexspi_wait_bus_idle(&data->controller);
 	}
 
+	int ret = 0;
+
 	while (len) {
 		/* If the offset isn't a multiple of the NOR page size, we first need
 		 * to write the remaining part that fits, otherwise the write could
@@ -530,17 +539,30 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 			memc_flexspi_wait_bus_idle(&data->controller);
 		}
 #endif
-		flash_flexspi_nor_write_enable(data);
+		ret = flash_flexspi_nor_write_enable(data);
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_WRITE_BUFFER
-		flash_flexspi_nor_page_program(data, offset, nor_write_buf, i);
+		if (ret == 0) {
+			ret = flash_flexspi_nor_page_program(data, offset, nor_write_buf, i);
+		}
 #else
-		flash_flexspi_nor_page_program(data, offset, src, i);
+		if (ret == 0) {
+			ret = flash_flexspi_nor_page_program(data, offset, src, i);
+		}
 #endif
-		flash_flexspi_nor_wait_bus_busy(data);
+		if (ret == 0) {
+			ret = flash_flexspi_nor_wait_bus_busy(data);
+		}
 		memc_flexspi_reset(&data->controller);
 		src += i;
 		offset += i;
 		len -= i;
+		if (ret != 0) {
+			break;
+		}
+	}
+
+	if (ret != 0) {
+		memc_flexspi_reset(&data->controller);
 	}
 
 	if (memc_flexspi_is_running_xip(&data->controller)) {
@@ -565,7 +587,7 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 
 	flash_flexspi_nor_unlock(dev);
 
-	return 0;
+	return ret;
 }
 
 static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
@@ -613,42 +635,60 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		memc_flexspi_wait_bus_idle(&data->controller);
 	}
 
+	int ret = 0;
+
 	if ((offset == 0) && (size == data->config.flashSize * KB(1))) {
-		flash_flexspi_nor_write_enable(data);
-		flash_flexspi_nor_erase_chip(data);
-		flash_flexspi_nor_wait_bus_busy(data);
+		if (memc_flexspi_is_running_xip(&data->controller)) {
+			LOG_WRN("Chip erase under XIP: interrupts disabled for up to 200s");
+		}
+		ret = flash_flexspi_nor_write_enable(data);
+		if (ret == 0) {
+			ret = flash_flexspi_nor_erase_chip(data);
+		}
+		if (ret == 0) {
+			ret = flash_flexspi_nor_wait_bus_busy_retries(data,
+				CONFIG_FLASH_MCUX_FLEXSPI_NOR_CHIP_ERASE_TIMEOUT_RETRIES);
+		}
 		memc_flexspi_reset(&data->controller);
 	} else {
-		/* Increase erase efficiency: use block erase when possible,
-		 * sector erase for remainder.
-		 */
 		size_t remaining_size = size;
 		off_t current_offset = offset;
-		/* Step 1: Handle unaligned start - erase sectors until block aligned */
-		while (remaining_size > 0 && (current_offset % SPI_NOR_BLOCK_SIZE) != 0) {
-			flash_flexspi_nor_write_enable(data);
-			flash_flexspi_nor_erase_sector(data, current_offset);
-			flash_flexspi_nor_wait_bus_busy(data);
+
+		while (remaining_size > 0 && (current_offset % SPI_NOR_BLOCK_SIZE) != 0
+		       && ret == 0) {
+			ret = flash_flexspi_nor_write_enable(data);
+			if (ret == 0) {
+				ret = flash_flexspi_nor_erase_sector(data, current_offset);
+			}
+			if (ret == 0) {
+				ret = flash_flexspi_nor_wait_bus_busy(data);
+			}
 			memc_flexspi_reset(&data->controller);
 			current_offset += SPI_NOR_SECTOR_SIZE;
 			remaining_size -= SPI_NOR_SECTOR_SIZE;
 		}
 
-		/* Step 2: Erase whole blocks */
-		while (remaining_size >= SPI_NOR_BLOCK_SIZE) {
-			flash_flexspi_nor_write_enable(data);
-			flash_flexspi_nor_erase_block(data, current_offset);
-			flash_flexspi_nor_wait_bus_busy(data);
+		while (remaining_size >= SPI_NOR_BLOCK_SIZE && ret == 0) {
+			ret = flash_flexspi_nor_write_enable(data);
+			if (ret == 0) {
+				ret = flash_flexspi_nor_erase_block(data, current_offset);
+			}
+			if (ret == 0) {
+				ret = flash_flexspi_nor_wait_bus_busy(data);
+			}
 			memc_flexspi_reset(&data->controller);
 			current_offset += SPI_NOR_BLOCK_SIZE;
 			remaining_size -= SPI_NOR_BLOCK_SIZE;
 		}
 
-		/* Step 3: Erase remaining sectors */
-		while (remaining_size > 0) {
-			flash_flexspi_nor_write_enable(data);
-			flash_flexspi_nor_erase_sector(data, current_offset);
-			flash_flexspi_nor_wait_bus_busy(data);
+		while (remaining_size > 0 && ret == 0) {
+			ret = flash_flexspi_nor_write_enable(data);
+			if (ret == 0) {
+				ret = flash_flexspi_nor_erase_sector(data, current_offset);
+			}
+			if (ret == 0) {
+				ret = flash_flexspi_nor_wait_bus_busy(data);
+			}
 			memc_flexspi_reset(&data->controller);
 			current_offset += SPI_NOR_SECTOR_SIZE;
 			remaining_size -= SPI_NOR_SECTOR_SIZE;
@@ -678,7 +718,7 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 
 	flash_flexspi_nor_unlock(dev);
 
-	return 0;
+	return ret;
 }
 
 static const struct flash_parameters *flash_flexspi_nor_get_parameters(
@@ -859,7 +899,41 @@ static int flash_flexspi_nor_quad_enable(struct flash_flexspi_nor_data *data,
 	}
 
 	/* Wait for QE bit to complete programming */
-	return flash_flexspi_nor_wait_bus_busy(data);
+	ret = flash_flexspi_nor_wait_bus_busy(data);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/*
+	 * Readback verify: re-read status register and confirm QE is set.
+	 * SCRATCH_CMD was programmed above to read SR1 (1-byte QER) or SR2
+	 * (2-byte QER), so re-using it here returns the correct register.
+	 */
+	buffer = 0;
+	transfer.dataSize = 1;
+	transfer.seqIndex = SCRATCH_CMD;
+	transfer.cmdType = kFLEXSPI_Read;
+	ret = memc_flexspi_transfer(&data->controller, &transfer);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (rd_size == 2) {
+		/* 2-byte QER: bit is in SR2, SCRATCH_CMD reads SR2 as 1 byte */
+		if (!(buffer & (bit >> 8))) {
+			LOG_ERR("QE readback failed: SR2=0x%02x, expected bit 0x%02x",
+				(uint8_t)(buffer & 0xFF), (uint8_t)(bit >> 8));
+			return -EIO;
+		}
+	} else {
+		if (!(buffer & bit)) {
+			LOG_ERR("QE readback failed: SR=0x%02x, expected bit 0x%02x",
+				(uint8_t)(buffer & 0xFF), (uint8_t)bit);
+			return -EIO;
+		}
+	}
+
+	return 0;
 }
 
 /*
@@ -1162,8 +1236,7 @@ static int flash_flexspi_nor_config_flash(struct flash_flexspi_nor_data *data,
 		bool xip_cfg = memc_flexspi_is_running_xip(&data->controller);
 
 		if (!xip_cfg || data->size > MB(16)) {
-			ret = flash_flexspi_nor_4byte_enable(data, flexspi_lut,
-							     dw16.enter_4ba);
+			ret = flash_flexspi_nor_4byte_enable(data, flexspi_lut, dw16.enter_4ba);
 		} else {
 			/* ≤16MB under XIP: 24-bit addressing covers full range, skip */
 			ret = 0;
@@ -1283,6 +1356,31 @@ static int flash_flexspi_nor_config_flash(struct flash_flexspi_nor_data *data,
 						0x4, kFLEXSPI_Command_STOP,
 						kFLEXSPI_1PAD, 0x0);
 			}
+		}
+
+		if (ret == -EIO || ret == -ENOTSUP) {
+			/* QE not supported or verify failed — revert to 1-1-1 */
+			LOG_WRN("Quad enable failed (%d), falling back to 1-1-1", ret);
+			flexspi_lut[READ][0] = FLEXSPI_LUT_SEQ(
+					kFLEXSPI_Command_SDR, kFLEXSPI_1PAD,
+					SPI_NOR_CMD_READ, kFLEXSPI_Command_RADDR_SDR,
+					kFLEXSPI_1PAD, addr_width);
+			flexspi_lut[READ][1] = FLEXSPI_LUT_SEQ(
+					kFLEXSPI_Command_READ_SDR, kFLEXSPI_1PAD,
+					0x1, kFLEXSPI_Command_STOP,
+					kFLEXSPI_1PAD, 0x0);
+			flexspi_lut[READ][2] = 0;
+			flexspi_lut[READ][3] = 0;
+			flexspi_lut[PAGE_PROGRAM][0] = FLEXSPI_LUT_SEQ(
+					kFLEXSPI_Command_SDR, kFLEXSPI_1PAD,
+					SPI_NOR_CMD_PP, kFLEXSPI_Command_RADDR_SDR,
+					kFLEXSPI_1PAD, addr_width);
+			flexspi_lut[PAGE_PROGRAM][1] = FLEXSPI_LUT_SEQ(
+					kFLEXSPI_Command_WRITE_SDR, kFLEXSPI_1PAD,
+					0x04, kFLEXSPI_Command_STOP,
+					kFLEXSPI_1PAD, 0x0);
+		} else if (ret != 0) {
+			return ret;
 		}
 
 	} else if (jesd216_bfp_read_support(&header->phdr[0], bfp,
@@ -1406,6 +1504,9 @@ flash_flexspi_nor_is25_clear_dummy_cycles(struct flash_flexspi_nor_data *data,
 	}
 
 	ret = memc_flexspi_transfer(&data->controller, &transfer);
+	if (ret < 0) {
+		return ret;
+	}
 
 	/*
 	 * IS25LPXXX -> 0xff

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -103,6 +103,12 @@ struct flash_flexspi_nor_data {
 #if defined(CONFIG_FLASH_MCUX_FLEXSPI_NOR_MUTEX)
 	struct k_mutex lock;
 #endif
+#if defined(FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT) && (FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT > 0)
+	struct {
+		off_t offset;
+		size_t len;
+	} iped_erased[FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT];
+#endif
 };
 
 static inline void flash_flexspi_nor_lock(const struct device *dev)
@@ -396,6 +402,64 @@ static int flash_flexspi_nor_read(const struct device *dev, off_t offset, void *
 		return -EINVAL;
 	}
 
+#if defined(FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT) && (FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT > 0)
+	/*
+	 * If this read falls entirely within an IPED-protected region, it must go
+	 * through the AHB memory-mapped path so IPED decrypts inline.  The default
+	 * IP-command read path below bypasses IPED and would return ciphertext.
+	 */
+	{
+		bool iped_gcm = false;
+		size_t iped_idx = 0U;
+
+		if (memc_flexspi_offset_in_iped_region(&data->controller, data->port, offset, len,
+						       &iped_gcm, &iped_idx)) {
+			uint8_t *src;
+			unsigned int ahb_key = 0U;
+			bool ahb_xip;
+
+			if (data->iped_erased[iped_idx].len > 0U &&
+			    offset >= data->iped_erased[iped_idx].offset &&
+			    (offset + (off_t)len) <= (data->iped_erased[iped_idx].offset +
+						      (off_t)data->iped_erased[iped_idx].len)) {
+				memset(buffer, 0xFF, len);
+				flash_flexspi_nor_unlock(dev);
+				return 0;
+			}
+
+			if (iped_gcm) {
+				LOG_DBG("IPED GCM region read off 0x%lx len %zu (best-effort)",
+					(long)offset, len);
+			}
+
+			src = memc_flexspi_get_ahb_address(&data->controller, data->port, offset);
+			if (!src) {
+				flash_flexspi_nor_unlock(dev);
+				return -EINVAL;
+			}
+
+#ifdef CONFIG_HAS_MCUX_CACHE
+			DCACHE_InvalidateByRange((uintptr_t)src, len);
+#endif
+
+			ahb_xip = memc_flexspi_is_running_xip(&data->controller);
+			if (ahb_xip) {
+				ahb_key = irq_lock();
+				memc_flexspi_wait_bus_idle(&data->controller);
+			}
+
+			memcpy(buffer, src, len);
+
+			if (ahb_xip) {
+				irq_unlock(ahb_key);
+			}
+
+			flash_flexspi_nor_unlock(dev);
+			return 0;
+		}
+	}
+#endif /* FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT */
+
 	xip = memc_flexspi_is_running_xip(&data->controller);
 
 	if (xip) {
@@ -451,8 +515,12 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 		const void *buffer, size_t len)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
-#ifdef CONFIG_HAS_MCUX_CACHE
-	size_t size = len;
+#if defined(FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT) && (FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT > 0)
+	off_t write_offset = offset;
+#endif
+#if defined(CONFIG_HAS_MCUX_CACHE) || (defined(FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT) &&           \
+				       (FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT > 0))
+	size_t write_len = len;
 #endif
 	if (!buffer) {
 		return -EINVAL;
@@ -523,7 +591,18 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 	}
 
 #ifdef CONFIG_HAS_MCUX_CACHE
-	DCACHE_InvalidateByRange((uintptr_t)dst, size);
+	DCACHE_InvalidateByRange((uintptr_t)dst, write_len);
+#endif
+
+#if defined(FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT) && (FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT > 0)
+	{
+		size_t wr_iped_idx = 0U;
+
+		if (memc_flexspi_offset_in_iped_region(&data->controller, data->port, write_offset,
+						       write_len, NULL, &wr_iped_idx)) {
+			data->iped_erased[wr_iped_idx].len = 0U;
+		}
+	}
 #endif
 
 	flash_flexspi_nor_unlock(dev);
@@ -625,6 +704,18 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 
 #ifdef CONFIG_HAS_MCUX_CACHE
 	DCACHE_InvalidateByRange((uintptr_t)dst, size);
+#endif
+
+#if defined(FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT) && (FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT > 0)
+	{
+		size_t er_iped_idx = 0U;
+
+		if (memc_flexspi_offset_in_iped_region(&data->controller, data->port, offset, size,
+						       NULL, &er_iped_idx)) {
+			data->iped_erased[er_iped_idx].offset = offset;
+			data->iped_erased[er_iped_idx].len = size;
+		}
+	}
 #endif
 
 	flash_flexspi_nor_unlock(dev);

--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -15,6 +15,30 @@
 
 #include "memc_mcux_flexspi.h"
 
+/*
+ * IPED (Inline Prince Encryption/Decryption) is a FlexSPI feature on some chips
+ * (e.g. RW612).  FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT is undefined or 0 when the
+ * FlexSPI has no IPED.  When present, this driver discovers BootROM-provisioned
+ * IPED regions at init and exposes them via memc_flexspi_offset_in_iped_region().
+ *
+ * Only the peripheral register definitions from the device header are needed;
+ * the SDK fsl_iped driver component is not required.
+ */
+#if defined(FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT) && (FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT > 0)
+#define MEMC_FLEXSPI_IPED            1
+/* IPEDCTXnEND granularity: region end address is 256-byte block aligned */
+#define MEMC_FLEXSPI_IPED_BLOCK_SIZE 0x100U
+/* Stride between IPEDCTXn register groups (IV0, IV1, START, END, AAD0, AAD1, rsvd, rsvd) */
+#define MEMC_FLEXSPI_IPED_CTX_STRIDE 0x20U
+/* SDK headers use inconsistent casing for IPED address masks across SoC families */
+#if !defined(FLEXSPI_IPEDCTX0START_START_ADDRESS_MASK) &&                                          \
+	defined(FLEXSPI_IPEDCTX0START_start_address_MASK)
+#define FLEXSPI_IPEDCTX0START_START_ADDRESS_MASK FLEXSPI_IPEDCTX0START_start_address_MASK
+#endif
+#if !defined(FLEXSPI_IPEDCTX0END_END_ADDRESS_MASK) && defined(FLEXSPI_IPEDCTX0END_end_address_MASK)
+#define FLEXSPI_IPEDCTX0END_END_ADDRESS_MASK FLEXSPI_IPEDCTX0END_end_address_MASK
+#endif
+#endif
 
 /*
  * NOTE: If CONFIG_FLASH_MCUX_FLEXSPI_XIP is selected, Any external functions
@@ -76,6 +100,20 @@ FSL_FEATURE_FLEXSPI_SUPPORT_SEPERATE_RXCLKSRC_PORTB
 	uint8_t buf_cfg_cnt;
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
+#ifdef MEMC_FLEXSPI_IPED
+	/* IPED regions discovered from registers at init (no IPED register writes) */
+	bool iped_enabled; /* IPEDCTRL.IPED_EN */
+	bool iped_ipwr_en; /* IPEDCTRL.IPWR_EN — IP writes encrypt */
+	size_t iped_region_count;
+	struct {
+		uint32_t ahb_start; /* absolute AHB start (IPEDCTXnSTART) */
+		uint32_t ahb_end;   /* absolute AHB end, EXCLUSIVE (one past
+				     * last byte): IPEDCTXnEND inclusive-block
+				     * base + 256-byte block size
+				     */
+		bool gcm;           /* per-region GCM-mode bit */
+	} iped_regions[FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT];
+#endif
 };
 
 static inline FLEXSPI_Type *get_base(const struct device *dev)
@@ -354,6 +392,61 @@ void *memc_flexspi_get_ahb_address(const struct device *dev,
 	return ahb_base + offset;
 }
 
+bool memc_flexspi_offset_in_iped_region(const struct device *dev, flexspi_port_t port, off_t offset,
+					size_t len, bool *gcm, size_t *region_idx)
+{
+#ifdef MEMC_FLEXSPI_IPED
+	struct memc_flexspi_data *data = dev->data;
+	uintptr_t addr;
+	size_t i;
+
+	if (!data->iped_enabled || len == 0U || offset < 0) {
+		return false;
+	}
+
+	addr = (uintptr_t)memc_flexspi_get_ahb_address(dev, port, offset);
+	if (addr == 0U) {
+		return false;
+	}
+	for (i = 0U; i < data->iped_region_count; i++) {
+		uint32_t start = data->iped_regions[i].ahb_start;
+		uint32_t end = data->iped_regions[i].ahb_end;
+
+		if (addr >= start && addr < end && len <= (size_t)(end - addr)) {
+			if (gcm != NULL) {
+				*gcm = data->iped_regions[i].gcm;
+			}
+			if (region_idx != NULL) {
+				*region_idx = i;
+			}
+			return true;
+		}
+	}
+
+	return false;
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(port);
+	ARG_UNUSED(offset);
+	ARG_UNUSED(len);
+	ARG_UNUSED(gcm);
+	ARG_UNUSED(region_idx);
+	return false;
+#endif /* MEMC_FLEXSPI_IPED */
+}
+
+bool memc_flexspi_iped_ipwr_enabled(const struct device *dev)
+{
+#ifdef MEMC_FLEXSPI_IPED
+	struct memc_flexspi_data *data = dev->data;
+
+	return data->iped_enabled && data->iped_ipwr_en;
+#else
+	ARG_UNUSED(dev);
+	return false;
+#endif
+}
+
 int memc_flexspi_update_lut(const struct device *dev, flexspi_port_t port, uint32_t seq_idx,
 			    const uint32_t *lut_ptr, uint8_t lut_count)
 {
@@ -405,6 +498,66 @@ static int memc_flexspi_init(const struct device *dev)
 	DEVICE_MMIO_NAMED_MAP(dev, ahb, data->ahb_cacheable ? K_MEM_DIRECT_MAP
 				: (K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP));
 	base = get_base(dev);
+
+#ifdef MEMC_FLEXSPI_IPED
+	/*
+	 * IPED region discovery — reads IPEDCTRL.IPED_EN and the per-region
+	 * IPEDCTXnSTART/END registers loaded by BootROM during provisioning and
+	 * records them in driver data.  Zephyr never writes IPED registers.
+	 * The FlexSPI NOR flash driver later queries this table via
+	 * memc_flexspi_offset_in_iped_region() to route reads of an IPED region
+	 * through the AHB path, where IPED decrypts inline.
+	 *
+	 * This must run before the XIP early-return below, because IPED register
+	 * reads are safe during XIP and the rest of init is skipped in XIP mode.
+	 */
+	uint32_t ipedctrl = base->IPEDCTRL;
+
+	data->iped_enabled = (ipedctrl & FLEXSPI_IPEDCTRL_IPED_EN_MASK) != 0U;
+	data->iped_ipwr_en = (ipedctrl & FLEXSPI_IPEDCTRL_IPWR_EN_MASK) != 0U;
+	data->iped_region_count = 0U;
+
+	if (data->iped_enabled) {
+		uint32_t iped_i;
+		uintptr_t ahb_base = (uintptr_t)get_ahb(dev);
+
+		for (iped_i = 0U; iped_i < (uint32_t)FSL_FEATURE_FLEXSPI_IPED_REGION_COUNT;
+		     iped_i++) {
+			volatile uint32_t *ctx_start_reg =
+				(volatile uint32_t *)((uintptr_t)&base->IPEDCTX0START +
+						      MEMC_FLEXSPI_IPED_CTX_STRIDE * iped_i);
+			volatile uint32_t *ctx_end_reg =
+				(volatile uint32_t *)((uintptr_t)&base->IPEDCTX0END +
+						      MEMC_FLEXSPI_IPED_CTX_STRIDE * iped_i);
+			uint32_t raw_start = *ctx_start_reg;
+			uint32_t raw_end = *ctx_end_reg;
+			uint32_t reg_start = raw_start & FLEXSPI_IPEDCTX0START_START_ADDRESS_MASK;
+			uint32_t reg_end = raw_end & FLEXSPI_IPEDCTX0END_END_ADDRESS_MASK;
+			uint32_t iped_start, iped_end;
+
+			if (reg_start == 0U) {
+				continue;
+			}
+			iped_start = ahb_base + (reg_start & 0x07FFFFFFU);
+			iped_end =
+				ahb_base + (reg_end & 0x07FFFFFFU) + MEMC_FLEXSPI_IPED_BLOCK_SIZE;
+			data->iped_regions[data->iped_region_count].ahb_start = iped_start;
+			data->iped_regions[data->iped_region_count].ahb_end = iped_end;
+			data->iped_regions[data->iped_region_count].gcm =
+				(raw_start & FLEXSPI_IPEDCTX0START_GCM_MASK) != 0U;
+			if (!memc_flexspi_is_running_xip(dev)) {
+				LOG_INF("IPED region %u: AHB 0x%08x..0x%08x (excl) GCM=%u", iped_i,
+					iped_start, iped_end,
+					data->iped_regions[data->iped_region_count].gcm ? 1U : 0U);
+			}
+			data->iped_region_count++;
+		}
+	} else {
+		if (!memc_flexspi_is_running_xip(dev)) {
+			LOG_DBG("IPED capable chip but IPEDCTRL.IPED_EN=0");
+		}
+	}
+#endif /* MEMC_FLEXSPI_IPED */
 
 	/* we should not configure the device we are running on */
 	if (memc_flexspi_is_running_xip(dev)) {

--- a/drivers/memc/memc_mcux_flexspi.h
+++ b/drivers/memc/memc_mcux_flexspi.h
@@ -128,3 +128,36 @@ void *memc_flexspi_get_ahb_address(const struct device *dev,
  */
 int memc_flexspi_update_lut(const struct device *dev, flexspi_port_t port, uint32_t seq_idx,
 			    const uint32_t *lut_ptr, uint8_t lut_count);
+
+/**
+ * @brief Check whether a flash byte range lies within an IPED-protected region
+ *
+ * IPED (Inline Prince Encryption/Decryption) is a FlexSPI feature on some chips
+ * (e.g. RW612). Regions are provisioned by BootROM/blhost and discovered by the
+ * memc driver at init. A read of an IPED region must go through the AHB
+ * memory-mapped path so IPED decrypts inline; an IP-command read returns
+ * ciphertext. The FlexSPI NOR flash driver calls this to decide the read path.
+ *
+ * @param dev: FlexSPI device
+ * @param port: FlexSPI port the flash device is on
+ * @param offset: byte offset from start of the device
+ * @param len: length of the access in bytes
+ * @param gcm: out (optional) — set to the region's GCM-mode flag when it returns true
+ * @param region_idx: out (optional) — set to the IPED region index when it returns true
+ * @return true if the whole [offset, offset+len) range is contained in a single
+ *         IPED region on @p port; false otherwise (including on chips without IPED)
+ */
+bool memc_flexspi_offset_in_iped_region(const struct device *dev, flexspi_port_t port, off_t offset,
+					size_t len, bool *gcm, size_t *region_idx);
+
+/**
+ * @brief Check whether IPED IP-command write encryption is enabled
+ *
+ * When IPWR_EN is set in IPEDCTRL, IP-command writes to IPED regions are
+ * encrypted by hardware before being stored in flash.  The flash driver can
+ * use this to decide whether writes to IPED regions are supported at runtime.
+ *
+ * @param dev: FlexSPI device
+ * @return true if IPED is enabled and IPWR_EN is set
+ */
+bool memc_flexspi_iped_ipwr_enabled(const struct device *dev);


### PR DESCRIPTION
Blocked by:
 - [] #107792
  ## Summary
  
  Systematic fixes for `flash_mcux_flexspi_nor` driver addressing 5 open issues and
  multiple robustness gaps.

  ### Commit 1: fix IS25 init hang (#102536, #110404)

  `flash_flexspi_nor_is25_clear_dummy_cycles()` previously spun in `while(1)` on
  failure, hanging the system at boot. Only IS25LPxxx variants (RDABR == 0xFF) need
  the SRPV write; all other IS25 variants now return early to keep POR defaults.
  The `while(1)` is replaced with `return -ENOTSUP` to fall through to SFDP-based
  initialization.
  
  ### Commit 2: skip 4-byte addressing under XIP (#109502)

  Flashes ≤ 16 MB are fully addressable with 24-bit addressing. Enabling 4-byte
  mode under XIP causes a protocol mismatch with the pre-boot READ LUT on platforms
  (e.g. RT5xx) that latch XIP LUT entries separately from IP LUT entries, resulting
  in hard faults.
  
  ### Commit 3: restore AHB read path (#108733, #107665)
  
  Commit 864269e replaced AHB direct-mapped reads with IP reads for all platforms.
  IP reads block the FlexSPI bus and cause hard faults when CPU instruction fetches
  collide with IP transfers under XIP. This restores `memcpy` from the AHB-mapped
  address as the default read path.

  ### Commit 4: harden error handling and busy-wait

  - **Busy-wait timeout**: replace `while(1)` in `wait_bus_busy()` with retry-count
    polling (`CONFIG_FLASH_MCUX_FLEXSPI_NOR_TIMEOUT_RETRIES`, default 500k ≈ 5 s).
    Chip erase uses a dedicated `CHIP_ERASE_TIMEOUT_RETRIES` (default 20M ≈ 200 s).
    `k_msleep`/`k_uptime_get` are unsafe inside `irq_lock()` on XIP platforms.
  - **Error propagation**: `write()` and `erase()` now capture and return errors from
    `write_enable()`, `page_program()`, `erase_sector/block/chip()`, and
    `wait_bus_busy()` — previously all silently discarded.
  - **QE readback verification**: re-read status register after WRSR to confirm the
    quad-enable bit is set; return `-EIO` on mismatch.
  - **QE fallback**: only revert to 1-1-1 mode for `-EIO`/`-ENOTSUP`; propagate
    transport/timeout errors instead of masking them.
  - **IS25 RDABR check**: verify `memc_flexspi_transfer()` return before using
    `resp_data`.
    

## Test Report

### #108733 — flash_read XIP hard fault

- **Commit**: 05e6686 `drivers: flash: mcux_flexspi_nor: restore AHB read path`
- **Root cause**: IP read path blocks FlexSPI bus, CPU instruction fetch collides → hard fault under XIP
- **Fix**: Restore AHB direct-mapped memcpy for all non-IPED reads; remove IP read path
- **Test**: RT1170 EVK (IS25WP128 16MB), `samples/drivers/flash_shell`
  - `flash read flash-controller@0 0 0x100` — read boot region
  - `flash read flash-controller@0 0x100000 0x100` — read erased region
  - `flash read flash-controller@0 0x80000 0x1000` — 4K read
  - 10× sequential 4K reads (0x0000–0x9000) — stress test
- **Result**: ALL PASS, no crash, system responsive throughout

### #109502 — ≤16MB flash 4-byte addressing hard fault

- **Commit**: bf2d2f1 `drivers: flash: mcux_flexspi_nor: skip 4-byte under XIP`
- **Root cause**: SFDP reports 4-byte support → driver sends 0xB7 → flash enters 4-byte mode → AHB XIP LUT still 3-byte → address mismatch → hard fault
- **Fix**: Skip 4-byte enable for flash ≤16MB under XIP (24-bit addressing covers full range)
- **Test**: RT1170 EVK (IS25WP128 16MB, XIP), `samples/drivers/flash_shell`
  - Board boots normally (implicitly proves 4-byte mode was skipped)
  - Full erase/write/read cycle at 0x100000 confirms 24-bit addressing works
- **Result**: PASS — normal boot, flash operations functional

### #107665 — IPED region reads return ciphertext

- **Commit**: f604560 `drivers: memc: mcux_flexspi: add IPED encrypted region support`
- **Root cause**: IP read bypasses IPED hardware decryption engine, returns ciphertext
- **Fix**: Route IPED region reads through AHB path for inline decryption; track erased ranges
- **Test**: FRDM-RW612 (W25Q512JV 64MB, IPED enabled) — tested by IPED PR author
  - 12 flash tests PASS (documented in PR #107792 description)
- **Result**: PASS (verified independently on FRDM-RW612)

### Test environment

- **Board**: MIMXRT1170-EVK (Rev A), IS25WP128 ISSI QSPI NOR, 16MB
- **Debugger**: LPC-LINK2 CMSIS-DAP V5.460, LinkServer v1.4.85
- **Application**: `samples/drivers/flash_shell`
- **Build**: `west build -b mimxrt1170_evk@A/mimxrt1176/cm7`