### PR TITLE
dts: riscv: ch32v003: Disable I2C1 by default

### DIFF
--- a/dts/riscv/wch/ch32v0/ch32v003.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v003.dtsi
@@ -130,6 +130,7 @@
 			clocks = <&rcc CH32V00X_CLOCK_I2C1>;
 			interrupt-parent = <&pfic>;
 			interrupts = <30>, <31>;
+			status = "disabled";
 		};
 
 		usart1: uart@40013800 {


### PR DESCRIPTION
Disable the I2C1 node in the CH32V003 SoC devicetree.

Boards which use I2C1 should enable it explicitly in their board devicetree or overlay. This keeps the SoC dtsi from enabling unused devices by default.