### PR TITLE
west: runners: minichlink: Add dev-id support

### DIFF
--- a/scripts/west_commands/runners/minichlink.py
+++ b/scripts/west_commands/runners/minichlink.py
@@ -19,6 +19,7 @@ class MiniChLinkBinaryRunner(ZephyrBinaryRunner):
         erase: bool,
         reset: bool,
         terminal: bool,
+        dev_id: str | None,
     ):
         super().__init__(cfg)
 
@@ -26,6 +27,7 @@ class MiniChLinkBinaryRunner(ZephyrBinaryRunner):
         self.erase = erase
         self.reset = reset
         self.terminal = terminal
+        self.dev_id = dev_id
 
     @classmethod
     def name(cls):
@@ -33,7 +35,11 @@ class MiniChLinkBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls) -> RunnerCaps:
-        return RunnerCaps(commands={"flash"}, flash_addr=True, erase=True, reset=True)
+        return RunnerCaps(commands={"flash"}, flash_addr=True, erase=True, reset=True, dev_id=True)
+
+    @classmethod
+    def dev_id_help(cls) -> str:
+        return "serial port or USB VID/PID passed to minichlink's -c option"
 
     @classmethod
     def do_add_parser(cls, parser: argparse.ArgumentParser):
@@ -56,6 +62,7 @@ class MiniChLinkBinaryRunner(ZephyrBinaryRunner):
             erase=args.erase,
             reset=args.reset,
             terminal=args.terminal,
+            dev_id=args.dev_id,
         )
 
     def do_run(self, command: str, **kwargs):
@@ -70,6 +77,9 @@ class MiniChLinkBinaryRunner(ZephyrBinaryRunner):
         self.ensure_output("bin")
 
         cmd = [self.minichlink, "-a"]
+
+        if self.dev_id:
+            cmd.extend(["-c", self.dev_id])
 
         if self.erase:
             cmd.append("-E")


### PR DESCRIPTION
west: runners: minichlink: Add dev-id support

Add support for the common `--dev-id` runner option to the minichlink runner. The value is passed to minichlink with its `-c` option so boards can select a specific serial port or USB VID/PID from board_runner_args().

This allows board.cmake to set a default probe identifier, for example:

    board_runner_args(minichlink "--dev-id=0x1209b803")