### PR TITLE
drivers: led: fix max brightness used instead of min brightness

### DIFF
--- a/drivers/led/lp5562.c
+++ b/drivers/led/lp5562.c
@@ -792,7 +792,7 @@ static int lp5562_led_blink(const struct device *dev, uint32_t led,
 	}
 
 	ret = lp5562_program_set_brightness(dev, engine, ++command_index,
-			LED_BRIGHTNESS_MAX);
+			LED_BRIGHTNESS_MIN);
 	if (ret) {
 		return ret;
 	}
@@ -882,7 +882,7 @@ static inline int lp5562_led_off(const struct device *dev, uint32_t led)
 		}
 	}
 
-	return lp5562_led_set_brightness(dev, led, LED_BRIGHTNESS_MAX);
+	return lp5562_led_set_brightness(dev, led, LED_BRIGHTNESS_MIN);
 }
 
 static int lp5562_led_update_current(const struct device *dev)

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -32,6 +32,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief Minimum brightness level, range is 0 to 100.
+ */
+#define LED_BRIGHTNESS_MIN 0u
+
+/**
  * @brief Maximum brightness level, range is 0 to 100.
  */
 #define LED_BRIGHTNESS_MAX 100u


### PR DESCRIPTION
This bug was introduced when replacing min/max brightness stored in the data structures with macro constants in
62c1fb209760976a2c924fe69bf4e2da16a2be00. Occurrences of `min_brightness` were accidentally replaced by `LED_BRIGHTNESS_MAX`.