### PR TITLE
bluetooth: classic: l2cap: add state validation in receive path

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1692,6 +1692,7 @@ static void connect_fixed_channel(struct bt_l2cap_br_chan *chan)
 		return;
 	}
 
+	bt_l2cap_br_chan_set_state(&chan->chan, BT_L2CAP_CONNECTED);
 	if (chan->chan.ops && chan->chan.ops->connected) {
 		chan->chan.ops->connected(&chan->chan);
 	}

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1938,6 +1938,8 @@ void bt_l2cap_br_connected(struct bt_conn *conn)
 			return;
 		}
 
+		bt_l2cap_br_chan_set_state(chan, BT_L2CAP_CONNECTING);
+
 		/*
 		 * other fixed channels will be connected after Information
 		 * Response is received
@@ -6239,7 +6241,8 @@ int bt_l2cap_br_chan_recv_complete(struct bt_l2cap_chan *chan)
 
 static int l2cap_br_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
-	int i;
+	struct bt_l2cap_br *l2cap;
+	uint8_t index;
 	static const struct bt_l2cap_chan_ops ops = {
 		.connected = l2cap_br_connected,
 		.disconnected = l2cap_br_disconnected,
@@ -6248,22 +6251,20 @@ static int l2cap_br_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 
 	LOG_DBG("conn %p handle %u", conn, conn->handle);
 
-	for (i = 0; i < ARRAY_SIZE(bt_l2cap_br_pool); i++) {
-		struct bt_l2cap_br *l2cap = &bt_l2cap_br_pool[i];
+	index = bt_conn_index(conn);
+	__ASSERT(index < ARRAY_SIZE(bt_l2cap_br_pool), "Invalid ACL conn index");
 
-		if (l2cap->chan.chan.conn) {
-			continue;
-		}
+	l2cap = &bt_l2cap_br_pool[index];
 
-		l2cap->chan.chan.ops = &ops;
-		*chan = &l2cap->chan.chan;
-		atomic_set(l2cap->chan.flags, 0);
-		return 0;
+	if (l2cap->chan.state != BT_L2CAP_DISCONNECTED) {
+		LOG_ERR("Signal chan %p is not idle (state %u)", &l2cap->chan, l2cap->chan.state);
+		return -EBUSY;
 	}
 
-	LOG_ERR("No available L2CAP context for conn %p", conn);
-
-	return -ENOMEM;
+	l2cap->chan.chan.ops = &ops;
+	*chan = &l2cap->chan.chan;
+	atomic_set(l2cap->chan.flags, 0);
+	return 0;
 }
 
 BT_L2CAP_BR_CHANNEL_DEFINE(br_fixed_chan, BT_L2CAP_CID_BR_SIG, l2cap_br_accept);
@@ -6600,9 +6601,14 @@ static int l2cap_br_connless_accept(struct bt_conn *conn, struct bt_l2cap_chan *
 	LOG_DBG("conn %p handle %u", conn, conn->handle);
 
 	index = bt_conn_index(conn);
-	__ASSERT(index < ARRAY_SIZE(bt_l2cap_br_pool), "Invalid ACL conn index");
+	__ASSERT(index < ARRAY_SIZE(bt_l2cap_br_connless_pool), "Invalid ACL conn index");
 
 	br_chan = &bt_l2cap_br_connless_pool[index];
+
+	if (br_chan->state != BT_L2CAP_DISCONNECTED) {
+		LOG_ERR("Connectionless chan %p is not idle (state %u)", br_chan, br_chan->state);
+		return -EBUSY;
+	}
 
 	br_chan->chan.ops = &ops;
 	br_chan->rx.mtu = BT_L2CAP_RX_MTU - BT_L2CAP_CONNLESS_SDU_HDR_SIZE;

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -6156,8 +6156,7 @@ void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf)
 
 	if (buf->len < sizeof(*hdr)) {
 		LOG_ERR("Too small L2CAP PDU received");
-		net_buf_unref(buf);
-		return;
+		goto done;
 	}
 
 	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
@@ -6166,8 +6165,7 @@ void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf)
 	chan = bt_l2cap_br_lookup_rx_cid(conn, cid);
 	if (!chan) {
 		LOG_WRN("Ignoring data for unknown channel ID 0x%04x", cid);
-		net_buf_unref(buf);
-		return;
+		goto done;
 	}
 
 	/*
@@ -6175,6 +6173,11 @@ void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf)
 	 * Response we connect channel here.
 	 */
 	check_fixed_channel(chan);
+
+	if (BR_CHAN(chan)->state < BT_L2CAP_CONNECTED) {
+		LOG_ERR("Chan %p in invalid state %u, ignoring data", chan, BR_CHAN(chan)->state);
+		goto done;
+	}
 
 #if defined(CONFIG_BT_L2CAP_RET_FC)
 	if (BR_CHAN(chan)->rx.mode != BT_L2CAP_BR_LINK_MODE_BASIC) {
@@ -6187,6 +6190,8 @@ void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf)
 #if defined(CONFIG_BT_L2CAP_RET_FC)
 	}
 #endif /* CONFIG_BT_L2CAP_RET_FC */
+
+done:
 	net_buf_unref(buf);
 }
 

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1753,40 +1753,39 @@ static bool br_sc_supported(void)
 
 static int bt_smp_br_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
+	struct bt_smp_br *smp;
+	uint8_t index;
 	static const struct bt_l2cap_chan_ops ops = {
 		.connected = bt_smp_br_connected,
 		.disconnected = bt_smp_br_disconnected,
 		.recv = bt_smp_br_recv,
 	};
-	int i;
 
 	/* Check BR/EDR SC is supported */
 	if (!br_sc_supported()) {
 		return -ENOTSUP;
 	}
 
+	index = bt_conn_index(conn);
+	__ASSERT(index < ARRAY_SIZE(bt_smp_br_pool), "Invalid ACL conn index");
+
 	LOG_DBG("conn %p handle %u", conn, conn->handle);
 
-	for (i = 0; i < ARRAY_SIZE(bt_smp_pool); i++) {
-		struct bt_smp_br *smp = &bt_smp_br_pool[i];
+	smp = &bt_smp_br_pool[index];
 
-		if (smp->chan.chan.conn) {
-			continue;
-		}
-
-		smp->chan.chan.ops = &ops;
-
-		*chan = &smp->chan.chan;
-
-		k_work_init_delayable(&smp->work, smp_br_timeout);
-		smp_br_reset(smp);
-
-		return 0;
+	if (smp->chan.state != BT_L2CAP_DISCONNECTED) {
+		LOG_ERR("SMP BR chan %p is not idle (state %u)", &smp->chan, smp->chan.state);
+		return -EBUSY;
 	}
 
-	LOG_ERR("No available SMP context for conn %p", conn);
+	smp->chan.chan.ops = &ops;
 
-	return -ENOMEM;
+	*chan = &smp->chan.chan;
+
+	k_work_init_delayable(&smp->work, smp_br_timeout);
+	smp_br_reset(smp);
+
+	return 0;
 }
 
 static struct bt_smp_br *smp_br_chan_get(struct bt_conn *conn)


### PR DESCRIPTION
* bluetooth: classic: l2cap: add state transition for fixed channel

Add proper state management to Bluetooth Classic L2CAP fixed channel connection by setting the channel state to `CONNECTED` before invoking the connected callback.

The change ensures that fixed channels follow the same state transition pattern as other L2CAP channel types. When a fixed channel is connected, the state is now explicitly set to `BT_L2CAP_CONNECTED` before calling the channel's connected callback.

The changes ensure the channel state accurately reflects its lifecycle status.

* bluetooth: classic: l2cap: use chan state to manage fixed channel

Refactor the fixed channel accept functions to use channel state for direct check if the channel is available instead of checking `conn` field of channel. And also refactor the fixed channel accept functions to use connection index for direct lookup instead of iterating through the pool arrays.

The changes affect the L2CAP BR signaling channel, connectionless channel, and SMP BR channel accept functions.

The functions now check if the channel is in the `DISCONNECTED` state before accepting a new connection, returning `-EBUSY` if the channel is not idle. This ensures proper channel state validation and prevents reuse of channels that are still in use.

Additionally, instead of searching through the entire pool to find an available channel context, the code now uses `bt_conn_index()` to directly access the corresponding entry in the pool array.

The L2CAP BR fixed channel connection now also sets the channel state to CONNECTING, ensuring proper state transitions.

* bluetooth: classic: l2cap: add state validation in receive path

Add state validation check in the L2CAP BR/EDR receive path to ensure channels are in a valid connected state before processing incoming data.

The change adds a check after the fixed channel validation to verify that the channel state is at least BT_L2CAP_CONNECTED before proceeding with data reception. If the channel is in an earlier state (CONNECTING or DISCONNECTED), an error is logged and the packet is dropped.

This prevents potential issues from processing data on channels that are not yet fully established or are in the process of being torn down, improving the robustness of the L2CAP receive path.

Fixes: #113698