### PR TITLE
net: stats: align periodic stats output with 'net stats' command

### DIFF
--- a/subsys/net/ip/net_stats.c
+++ b/subsys/net/ip/net_stats.c
@@ -198,6 +198,22 @@ static inline void stats(struct net_if *iface)
 			 GET_STAT(iface, dns.drop));
 #endif /* CONFIG_NET_STATISTICS_DNS */
 
+#if defined(CONFIG_NET_STATISTICS_PKT_FILTER)
+		NET_INFO("Filter drop rx %u"
+			 IF_ENABLED(CONFIG_NET_PKT_FILTER_IPV4_HOOK, ("\tIPv4\t%u"))
+			 IF_ENABLED(CONFIG_NET_PKT_FILTER_IPV6_HOOK, ("\tIPv6\t%u"))
+			 IF_ENABLED(CONFIG_NET_PKT_FILTER_LOCAL_IN_HOOK, ("\tlocal\t%u"))
+			 "\ttx\t%u",
+			 GET_STAT(iface, pkt_filter.rx.drop),
+			 IF_ENABLED(CONFIG_NET_PKT_FILTER_IPV4_HOOK,
+				    (GET_STAT(iface, pkt_filter.rx.ipv4_drop),))
+			 IF_ENABLED(CONFIG_NET_PKT_FILTER_IPV6_HOOK,
+				    (GET_STAT(iface, pkt_filter.rx.ipv6_drop),))
+			 IF_ENABLED(CONFIG_NET_PKT_FILTER_LOCAL_IN_HOOK,
+				    (GET_STAT(iface, pkt_filter.rx.local_drop),))
+			 GET_STAT(iface, pkt_filter.tx.drop));
+#endif /* CONFIG_NET_STATISTICS_PKT_FILTER */
+
 		NET_INFO("Bytes received %llu", GET_STAT(iface, bytes.received));
 		NET_INFO("Bytes sent     %llu", GET_STAT(iface, bytes.sent));
 		NET_INFO("Processing err %u",

--- a/subsys/net/ip/net_stats.c
+++ b/subsys/net/ip/net_stats.c
@@ -205,14 +205,15 @@ static inline void stats(struct net_if *iface)
 
 #if NET_TC_RX_COUNT > 1
 		NET_INFO("RX traffic class statistics:");
-		NET_INFO("TC  Priority\tRecv pkts\tbytes");
+		NET_INFO("TC  Priority\tRecv pkts\tDrop pkts\tbytes");
 
 		for (i = 0; i < NET_TC_RX_COUNT; i++) {
-			NET_INFO("[%d] %s (%u)\t%u\t\t%llu", i,
+			NET_INFO("[%d] %s (%u)\t%u\t\t%u\t\t%llu", i,
 				 priority2str(GET_STAT(iface,
 						       tc.recv[i].priority)),
 				 GET_STAT(iface, tc.recv[i].priority),
 				 GET_STAT(iface, tc.recv[i].pkts),
+				 GET_STAT(iface, tc.recv[i].dropped),
 				 GET_STAT(iface, tc.recv[i].bytes));
 		}
 #endif

--- a/subsys/net/ip/net_stats.c
+++ b/subsys/net/ip/net_stats.c
@@ -191,6 +191,13 @@ static inline void stats(struct net_if *iface)
 		NET_INFO("TCP pkt drop   %u", GET_STAT(iface, tcp.drop));
 #endif
 
+#if defined(CONFIG_NET_STATISTICS_DNS)
+		NET_INFO("DNS recv       %u\tsent\t%u\tdrop\t%u",
+			 GET_STAT(iface, dns.recv),
+			 GET_STAT(iface, dns.sent),
+			 GET_STAT(iface, dns.drop));
+#endif /* CONFIG_NET_STATISTICS_DNS */
+
 		NET_INFO("Bytes received %llu", GET_STAT(iface, bytes.received));
 		NET_INFO("Bytes sent     %llu", GET_STAT(iface, bytes.sent));
 		NET_INFO("Processing err %u",

--- a/subsys/net/ip/net_stats.c
+++ b/subsys/net/ip/net_stats.c
@@ -163,24 +163,25 @@ static inline void stats(struct net_if *iface)
 #endif
 
 #if defined(CONFIG_NET_STATISTICS_TCP)
-		NET_INFO("TCP bytes recv %llu\tsent\t%llu",
+		NET_INFO("TCP bytes recv %llu\tsent\t%llu\tresent\t%u",
 			 GET_STAT(iface, tcp.bytes.received),
-			 GET_STAT(iface, tcp.bytes.sent));
+			 GET_STAT(iface, tcp.bytes.sent),
+			 GET_STAT(iface, tcp.resent));
 		NET_INFO("TCP seg recv   %u\tsent\t%u\tdrop\t%u",
 			 GET_STAT(iface, tcp.recv),
 			 GET_STAT(iface, tcp.sent),
-			 GET_STAT(iface, tcp.drop));
+			 GET_STAT(iface, tcp.seg_drop));
 		NET_INFO("TCP seg resent %u\tchkerr\t%u\tackerr\t%u",
-			 GET_STAT(iface, tcp.resent),
+			 GET_STAT(iface, tcp.rexmit),
 			 GET_STAT(iface, tcp.chkerr),
 			 GET_STAT(iface, tcp.ackerr));
-		NET_INFO("TCP seg rsterr %u\trst\t%u\tre-xmit\t%u",
+		NET_INFO("TCP seg rsterr %u\trst\t%u",
 			 GET_STAT(iface, tcp.rsterr),
-			 GET_STAT(iface, tcp.rst),
-			 GET_STAT(iface, tcp.rexmit));
+			 GET_STAT(iface, tcp.rst));
 		NET_INFO("TCP conn drop  %u\tconnrst\t%u",
 			 GET_STAT(iface, tcp.conndrop),
 			 GET_STAT(iface, tcp.connrst));
+		NET_INFO("TCP pkt drop   %u", GET_STAT(iface, tcp.drop));
 #endif
 
 		NET_INFO("Bytes received %llu", GET_STAT(iface, bytes.received));

--- a/subsys/net/ip/net_stats.c
+++ b/subsys/net/ip/net_stats.c
@@ -143,6 +143,13 @@ static inline void stats(struct net_if *iface)
 			 GET_STAT(iface, icmp.typeerr),
 			 GET_STAT(iface, icmp.chkerr));
 
+#if defined(CONFIG_NET_STATISTICS_IGMP)
+		NET_INFO("IGMP recv      %u\tsent\t%u\tdrop\t%u",
+			 GET_STAT(iface, ipv4_igmp.recv),
+			 GET_STAT(iface, ipv4_igmp.sent),
+			 GET_STAT(iface, ipv4_igmp.drop));
+#endif /* CONFIG_NET_STATISTICS_IGMP */
+
 #if defined(CONFIG_NET_STATISTICS_UDP)
 		NET_INFO("UDP recv       %u\tsent\t%u\tdrop\t%u",
 			 GET_STAT(iface, udp.recv),


### PR DESCRIPTION
Align periodic statistics outputs to match statistics output with `net stats`.

For details, see individual commits.