### PR TITLE
drivers: dma: dma_stm32: Disable FIFO error interrupt

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -539,11 +539,14 @@ static int dma_stm32_configure(const struct device *dev,
 #if defined(CONFIG_DMA_STM32_V1)
 	if (DMA_InitStruct.FIFOMode == LL_DMA_FIFOMODE_ENABLE) {
 		LL_DMA_EnableFifoMode(dma, dma_stm32_id_to_stream(id));
-		LL_DMA_EnableIT_FE(dma, dma_stm32_id_to_stream(id));
 	} else {
 		LL_DMA_DisableFifoMode(dma, dma_stm32_id_to_stream(id));
-		LL_DMA_DisableIT_FE(dma, dma_stm32_id_to_stream(id));
 	}
+	/* FIFO error can be ignored, since it doesn't imply loss of data,
+	 * and errors caused by a wrong configuration are handled by
+	 * stm32_dma_check_fifo_mburst().
+	 */
+	LL_DMA_DisableIT_FE(dma, dma_stm32_id_to_stream(id));
 #endif
 	return ret;
 }


### PR DESCRIPTION
The FIFO error flag is triggered either by wrong configuration or by overrun/underrun condition. The configuration is handled by `stm32_dma_check_fifo_mburst` function. For overrun/underrun condition, there is no data loss, so it is rather warning and can be ignored.

In case there is actual loss of data due to overrun/underrun, this should be reported by the peripheral itself.

In some cases, the peripheral can suspend/pause itself in order to prevent overrun/underrun (e.g. SPI in master mode). However, this will still trigger DMA FIFO error.
In current implementation, it is not possible to distinguish FIFO error from other DMA errors in the callback. In both cases `-EIO` error code is passed to `dma_callback`.

Maybe the FIFO error could be reported through another API, but I don't see any suitable candidate.
I think there should also be an option to disable this interrupt, since triggering an interrupt when the system is approaching the bandwidth limit is not a good idea.

## Excerpt from reference manual

__FIFO error:__ the FIFO error interrupt flag (FEIFx) is set if:
* a FIFO underrun condition is detected
* a FIFO overrun condition is detected (no detection in memory-to-memory mode
because requests and transfers are internally managed by the DMA)
* the stream is enabled while the FIFO threshold level is not compatible with the
size of the memory burst (refer to Table 116: FIFO threshold configurations)

_Note:
When a FIFO overrun or underrun condition occurs, the data is not lost because the
peripheral request is not acknowledged by the stream until the overrun or underrun
condition is cleared. If this acknowledge takes too much time, the peripheral itself may
detect an overrun or underrun condition of its internal buffer and data might be lost._