### PR TITLE
boards: st: nucleo_h7s3l8: fix user button configuration

### DIFF
--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8-common.dtsi
@@ -44,7 +44,7 @@
 
 		user_button: button_0 {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioc 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};


### PR DESCRIPTION
There is no external pull-up/pull-down resistor on the pin so an internal one must be enabled. Since the button ties the pin low, enable a pull-up and change the button's polarity to Active-Low.

c.f., board schematic:
<img width="556" height="325" alt="image" src="https://github.com/user-attachments/assets/d9c05263-2be1-429c-9319-baac4b3b2b7d" />

Issue can be observed trivially by running `samples/basic/button` on the board (and fix can be verified in the same manner).