### PR TITLE
drivers: clock_monitor: Support NXP FREQME driver

### DIFF
--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
@@ -291,3 +291,7 @@ zephyr_udc0: &usb {
 &crc {
 	status = "okay";
 };
+
+&freqme0 {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
@@ -292,6 +292,10 @@ zephyr_udc0: &usb {
 	status = "okay";
 };
 
+&inputmux0 {
+	status = "okay";
+};
+
 &freqme0 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
@@ -328,3 +328,7 @@ zephyr_udc0: &usb {
 &crc {
 	status = "okay";
 };
+
+&freqme0 {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
@@ -329,6 +329,10 @@ zephyr_udc0: &usb {
 	status = "okay";
 };
 
+&inputmux0 {
+	status = "okay";
+};
+
 &freqme0 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
+++ b/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
@@ -233,6 +233,10 @@
 	status = "okay";
 };
 
+&freqme0 {
+	status = "okay";
+};
+
 &flexpwm0_pwm0 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_flexpwm0_pwm0>;

--- a/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
+++ b/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
@@ -233,6 +233,10 @@
 	status = "okay";
 };
 
+&inputmux0 {
+	status = "okay";
+};
+
 &freqme0 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
@@ -270,6 +270,10 @@
 	status = "okay";
 };
 
+&freqme0 {
+	status = "okay";
+};
+
 &flexcan0 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_flexcan0>;

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
@@ -270,6 +270,10 @@
 	status = "okay";
 };
 
+&inputmux0 {
+	status = "okay";
+};
+
 &freqme0 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.dts
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.dts
@@ -48,6 +48,10 @@
 	status = "okay";
 };
 
+&freqme0 {
+	status = "okay";
+};
+
 zephyr_udc0: &usb {
 	status = "okay";
 	num-bidir-endpoints = <8>;

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.dts
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.dts
@@ -48,6 +48,10 @@
 	status = "okay";
 };
 
+&inputmux0 {
+	status = "okay";
+};
+
 &freqme0 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.dts
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.dts
@@ -59,6 +59,10 @@
 	status = "okay";
 };
 
+&freqme0 {
+	status = "okay";
+};
+
 zephyr_udc0: &usb {
 	status = "okay";
 	num-bidir-endpoints = <8>;

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.dts
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.dts
@@ -59,6 +59,10 @@
 	status = "okay";
 };
 
+&inputmux0 {
+	status = "okay";
+};
+
 &freqme0 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
@@ -114,6 +114,10 @@
 	pinctrl-names = "default";
 };
 
+&inputmux0 {
+	status = "okay";
+};
+
 &freqme0 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
@@ -114,6 +114,10 @@
 	pinctrl-names = "default";
 };
 
+&freqme0 {
+	status = "okay";
+};
+
 &rtc {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
@@ -483,3 +483,7 @@ dvp_20pin_interface: &video_sdma {};
 &otpc {
 	status = "okay";
 };
+
+&freqme0 {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
@@ -484,6 +484,10 @@ dvp_20pin_interface: &video_sdma {};
 	status = "okay";
 };
 
+&inputmux0 {
+	status = "okay";
+};
+
 &freqme0 {
 	status = "okay";
 };

--- a/boards/nxp/mcx_nx4x_evk/mcx_n5xx_evk_mcxn547_cpu0.dts
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n5xx_evk_mcxn547_cpu0.dts
@@ -12,3 +12,7 @@
 / {
 	model = "NXP MCX-N5XX-EVK board";
 };
+
+&freqme0 {
+	status = "okay";
+};

--- a/boards/nxp/mcx_nx4x_evk/mcx_n5xx_evk_mcxn547_cpu0.dts
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n5xx_evk_mcxn547_cpu0.dts
@@ -13,6 +13,10 @@
 	model = "NXP MCX-N5XX-EVK board";
 };
 
+&inputmux0 {
+	status = "okay";
+};
+
 &freqme0 {
 	status = "okay";
 };

--- a/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0.dts
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0.dts
@@ -11,3 +11,7 @@
 / {
 	model = "NXP MCX-N9XX-EVK board";
 };
+
+&freqme0 {
+	status = "okay";
+};

--- a/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0.dts
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0.dts
@@ -12,6 +12,10 @@
 	model = "NXP MCX-N9XX-EVK board";
 };
 
+&inputmux0 {
+	status = "okay";
+};
+
 &freqme0 {
 	status = "okay";
 };

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -143,6 +143,10 @@
 	status = "okay";
 };
 
+&freqme0 {
+	status = "okay";
+};
+
 /*
  * RT700-EVK board cm33_cpu0 uses OS timer as the kernel timer
  * In case we need to switch to SYSTICK timer, then

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -143,6 +143,10 @@
 	status = "okay";
 };
 
+&inputmux0 {
+	status = "okay";
+};
+
 &freqme0 {
 	status = "okay";
 };

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -136,6 +136,35 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 		CLOCK_EnableClock(kCLOCK_GateQDC1);
 	}
 #endif /* FSL_FEATURE_SOC_EQDC_COUNT > 1 */
+#endif /* CONFIG_EQDC_MCUX */
+
+#if defined(CONFIG_SOC_FAMILY_MCXA) || defined(CONFIG_SOC_FAMILY_MCXN) ||                          \
+	defined(CONFIG_SOC_FAMILY_MCXL) || defined(CONFIG_SOC_SERIES_IMXRT7XX)
+	if ((uint32_t)sub_system == MCUX_FREQME_CLK) {
+#if defined(CONFIG_SOC_FAMILY_MCXA) || defined(CONFIG_SOC_FAMILY_MCXL)
+		CLOCK_EnableClock(kCLOCK_GateFREQME);
+#elif defined(CONFIG_SOC_FAMILY_MCXN)
+		CLOCK_EnableClock(kCLOCK_Freqme);
+#else /* CONFIG_SOC_SERIES_IMXRT7XX */
+		CLOCK_EnableClock(kCLOCK_Freqme0);
+#endif
+	}
+#endif
+
+#if defined(CONFIG_SOC_FAMILY_MCXN)
+	/* Enable the FRO_HF / FRO_12M / external clock outputs via SYSCON
+	 * CLOCK_CTRL when they are turned on (the board clock init does not);
+	 * these feed the Frequency Measure mux among other consumers.
+	 */
+	if ((uint32_t)sub_system == MCUX_FRO_HF_CLK) {
+		CLOCK_SetupClockCtrl(kCLOCK_FRO_HF_ENA);
+	}
+	if ((uint32_t)sub_system == MCUX_FRO_12M_CLK) {
+		CLOCK_SetupClockCtrl(kCLOCK_FRO12MHZ_ENA);
+	}
+	if ((uint32_t)sub_system == MCUX_EXT_CLK) {
+		CLOCK_SetupClockCtrl(kCLOCK_CLKIN_ENA_FM_USBH_LPT);
+	}
 #endif
 
 #if defined(CONFIG_PINCTRL_NXP_PORT)
@@ -452,6 +481,41 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 	uint32_t clock_name = (uint32_t)sub_system;
 
 	switch (clock_name) {
+
+#if defined(CONFIG_SOC_FAMILY_MCXA) || defined(CONFIG_SOC_FAMILY_MCXN) ||                          \
+	defined(CONFIG_SOC_FAMILY_MCXL)
+	case MCUX_FRO_HF_CLK:
+		*rate = CLOCK_GetFreq(kCLOCK_FroHf);
+		break;
+	case MCUX_FRO_12M_CLK:
+		*rate = CLOCK_GetFreq(kCLOCK_Fro12M);
+		break;
+#endif
+#if defined(CONFIG_SOC_FAMILY_MCXA) || defined(CONFIG_SOC_FAMILY_MCXL)
+	case MCUX_FRO_HF_DIV_CLK:
+		*rate = CLOCK_GetFreq(kCLOCK_FroHfDiv);
+		break;
+#endif
+#if defined(CONFIG_SOC_FAMILY_MCXN)
+	case MCUX_CPU_AHB_CLK:
+		*rate = CLOCK_GetFreq(kCLOCK_BusClk);
+		break;
+	case MCUX_EXT_CLK:
+		*rate = CLOCK_GetFreq(kCLOCK_ExtClk);
+		break;
+#endif
+#if defined(CONFIG_SOC_SERIES_IMXRT7XX)
+	/* RT700 clock sources also used by FREQME: FRO1 (192 MHz) as the
+	 * measured target and the system OSC (24 MHz crystal) as the reference
+	 * timebase.
+	 */
+	case MCUX_FRO_HF_CLK:
+		*rate = CLOCK_GetFroClkFreq(1U);
+		break;
+	case MCUX_EXT_CLK:
+		*rate = CLOCK_GetSysOscFreq();
+		break;
+#endif
 
 #if defined(CONFIG_I2C_MCUX_FLEXCOMM) || defined(CONFIG_SPI_MCUX_FLEXCOMM) ||                      \
 	defined(CONFIG_UART_MCUX_FLEXCOMM) || defined(CONFIG_I2S_MCUX_FLEXCOMM)

--- a/drivers/clock_monitor/CMakeLists.txt
+++ b/drivers/clock_monitor/CMakeLists.txt
@@ -10,3 +10,4 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE clock_monitor_handlers.c)
 
 zephyr_library_sources_ifdef(CONFIG_CLOCK_MONITOR_NXP_CMU_FC clock_monitor_nxp_cmu_fc.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_MONITOR_NXP_CMU_FM clock_monitor_nxp_cmu_fm.c)
+zephyr_library_sources_ifdef(CONFIG_CLOCK_MONITOR_NXP_FREQME clock_monitor_nxp_freqme.c)

--- a/drivers/clock_monitor/Kconfig
+++ b/drivers/clock_monitor/Kconfig
@@ -22,5 +22,6 @@ source "subsys/logging/Kconfig.template.log_config"
 
 rsource "Kconfig.nxp_cmu_fc"
 rsource "Kconfig.nxp_cmu_fm"
+rsource "Kconfig.nxp_freqme"
 
 endif # CLOCK_MONITOR

--- a/drivers/clock_monitor/Kconfig.nxp_freqme
+++ b/drivers/clock_monitor/Kconfig.nxp_freqme
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config CLOCK_MONITOR_NXP_FREQME
+	bool "NXP FREQME frequency measurement driver"
+	default y
+	depends on DT_HAS_NXP_FREQME_ENABLED
+	select MUX
+	select MUX_NXP_INPUTMUX
+	help
+	  Zephyr clock_monitor back-end for the NXP FREQME peripheral.
+	  Routes the reference and target clocks through the INPUTMUX mux
+	  subsystem and queries the reference rate from clock_control. Supports
+	  both MEASURE (one-shot) and WINDOW (continuous MIN/MAX threshold)
+	  modes, built on the FREQME frequency-measurement operate mode.

--- a/drivers/clock_monitor/clock_monitor_nxp_freqme.c
+++ b/drivers/clock_monitor/clock_monitor_nxp_freqme.c
@@ -1,0 +1,871 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Zephyr clock_monitor back-end for the NXP FREQME (Frequency Measurement)
+ * module. Built on the FREQME frequency-measurement operate mode, it exposes
+ * both clock_monitor abstraction modes:
+ *
+ *   - MEASURE: one-shot measurement; the result-ready interrupt delivers a
+ *     MEASURE_DONE event and get_rate() returns the measured frequency.
+ *   - WINDOW:  continuous measurement against MIN/MAX thresholds derived from
+ *     the expected frequency and tolerance; the over-/under-range interrupts
+ *     deliver FREQ_HIGH / FREQ_LOW events.
+ *
+ * Reference and target clocks are selected from devicetree-declared source
+ * lists ("reference-sources" / "target-sources"); each source pairs an
+ * INPUTMUX route with a frequency provider (a fixed constant or a
+ * clock_control subsystem). clock_monitor_set_source() switches between the
+ * declared sources at runtime, dropping the device back to the unconfigured
+ * state so the next configure() re-derives the measurement parameters.
+ *
+ * This driver does NOT enable the selected reference/target source clocks:
+ * the caller must ensure both clocks are running before configure()/start().
+ * The source "clocks" phandle is only queried (clock_control_get_rate()) to
+ * derive REF_SCALE and the WINDOW thresholds, never turned on. If a source is
+ * left off the measurement simply counts zero edges and surfaces CLOCK_LOST.
+ * Only the peripheral's own gate clock is enabled here, through clock_control.
+ */
+
+#define DT_DRV_COMPAT nxp_freqme
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_monitor.h>
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
+#include <zephyr/irq.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+#include <fsl_freqme.h>
+
+#include <zephyr/devicetree/mux.h>
+#include <zephyr/drivers/mux.h>
+
+LOG_MODULE_REGISTER(clock_monitor_nxp_freqme, CONFIG_CLOCK_MONITOR_LOG_LEVEL);
+
+/* Measurement result counter is 31 bits; the formula offset is +2. */
+#define FREQME_RESULT_MAX  0x7FFFFFFFU
+/* HW formula offset: Ftarget = (RESULT - 2) * Fref / 2^REF_SCALE, so the target
+ * edge count is RESULT - 2. RESULT <= 2 means zero edges were counted (clock
+ * lost). Fixed by silicon.
+ */
+#define FREQME_RESULT_BIAS 2U
+/* WINDOW guard band (counts) added each side of MIN/MAX to absorb +/-1 LSB
+ * quantization plus nominal truncation, so an in-tolerance clock isn't flagged.
+ */
+#define FREQME_WINDOW_MARGIN 2U
+
+/*
+ * A selectable FREQME clock source: an INPUTMUX route (applied through the
+ * mux subsystem) paired with a frequency provider. The provider is a fixed
+ * constant (has_fixed_hz) or a clock_control subsystem (clk_dev / clk_subsys);
+ * a fixed provider takes precedence when both are declared. Exactly one source
+ * per container is flagged is_default.
+ *
+ * mux_state->state holds the inputmux_connection_t cookie, which also doubles
+ * as the runtime clock_monitor_set_source() selector key.
+ */
+struct nxp_freqme_source {
+	const struct device    *mux_dev;
+	const struct mux_state *mux_state;
+	const struct device    *clk_dev;
+	clock_control_subsys_t  clk_subsys;
+	uint32_t                fixed_hz;
+	bool                    has_fixed_hz;
+	bool                    is_default;
+};
+
+struct nxp_freqme_config {
+	FREQME_Type *base;
+	/* Peripheral gate clock (clocks "ipg"), enabled via clock_control_on(). */
+	const struct device    *gate_clk_dev;
+	clock_control_subsys_t  gate_clk_subsys;
+	/* Selectable reference / target sources; the is_default source is the
+	 * power-on selection.
+	 */
+	const struct nxp_freqme_source *ref_srcs;
+	uint8_t ref_srcs_count;
+	const struct nxp_freqme_source *tar_srcs;
+	uint8_t tar_srcs_count;
+	void (*irq_config_func)(const struct device *dev);
+};
+
+enum nxp_freqme_state {
+	NXP_FREQME_STATE_IDLE = 0,
+	/* configure() is between its lock-free clock query / HAL init and its
+	 * commit; concurrent configure()/start()/set_source() get -EBUSY.
+	 */
+	NXP_FREQME_STATE_CONFIGURING,
+	NXP_FREQME_STATE_CONFIGURED,
+	NXP_FREQME_STATE_RUNNING,
+};
+
+struct nxp_freqme_data {
+	/* Protects the state machine, cfg, source selection and result fields
+	 * against the ISR and against concurrent API calls.
+	 */
+	struct k_spinlock lock;
+	enum nxp_freqme_state state;
+	struct clock_monitor_config cfg;
+	/* Index into config->ref_srcs / tar_srcs for the currently selected
+	 * reference / target source. Only ever written while CONFIGURING (which
+	 * excludes configure()/set_source()) so lock-free reads there are safe.
+	 */
+	uint8_t cur_ref_idx;
+	uint8_t cur_tar_idx;
+	uint32_t ref_hz;     /* cached from the reference source at configure */
+	uint8_t  ref_scale;  /* cached REF_SCALE for ISR formula / re-arm */
+	/* Most recent completed MEASURE result; retained across reads. */
+	uint32_t last_rate_hz;
+	bool has_rate;
+	/* CLOCK_LOST latched since configure(). */
+	bool clock_lost;
+};
+
+/*
+ * Convert a measurement window (ns) into the REF_SCALE power-of-two exponent.
+ * The FREQME window is 2^REF_SCALE reference-clock periods, so this is a
+ * rounded base-2 logarithm of the requested cycle count, clamped to [0, 31].
+ */
+static int freqme_window_to_ref_scale(uint32_t window_ns, uint32_t ref_hz, uint8_t *out)
+{
+	uint64_t cycles = (uint64_t)window_ns * (uint64_t)ref_hz / (uint64_t)NSEC_PER_SEC;
+
+	if (cycles == 0U) {
+		return -ERANGE;
+	}
+
+	uint32_t s = 0U;
+	uint64_t v = cycles;
+
+	while ((v >> 1) != 0U) {
+		v >>= 1;
+		s++;
+	}
+
+	/* Round to the nearer power of two. */
+	if (s < 31U && (cycles - (1ULL << s)) > ((1ULL << (s + 1U)) - cycles)) {
+		s++;
+	}
+	if (s > 31U) {
+		/* REF_SCALE is a 5-bit field (max 31); a window this long cannot
+		 * be represented. Reject rather than silently shorten it.
+		 */
+		return -ERANGE;
+	}
+
+	*out = (uint8_t)s;
+	return 0;
+}
+
+/*
+ * Derive the MIN/MAX result-counter thresholds for WINDOW mode from an already
+ * resolved expected target frequency (caller supplies it from cfg or from the
+ * current target source rate). RESULT = round(f * 2^scale / ref) +
+ * FREQME_RESULT_BIAS, so the nominal count is scaled by (1 +/- tol_ppm) and
+ * biased; a small margin absorbs quantization jitter.
+ *
+ * Returns -ERANGE if the thresholds cannot be represented.
+ */
+static int freqme_compute_thresholds(uint32_t expected_hz, uint32_t tol_ppm,
+				     uint8_t ref_scale, uint32_t ref_hz,
+				     uint32_t *min_val, uint32_t *max_val)
+{
+	uint64_t scale = 1ULL << ref_scale;
+	uint64_t nominal = (uint64_t)expected_hz * scale / (uint64_t)ref_hz;
+
+	uint64_t hi = nominal * (1000000ULL + tol_ppm) / 1000000ULL
+		      + FREQME_RESULT_BIAS + FREQME_WINDOW_MARGIN;
+	uint64_t lo = nominal * (1000000ULL - tol_ppm) / 1000000ULL
+		      + FREQME_RESULT_BIAS;
+
+	if (hi > FREQME_RESULT_MAX) {
+		LOG_ERR("FREQME WINDOW MAX %llu exceeds HW limit (expected_hz=%u, "
+			"tol_ppm=%u, ref_scale=%u, ref_hz=%u)", hi, expected_hz,
+			tol_ppm, ref_scale, ref_hz);
+		return -ERANGE;
+	}
+
+	lo = (lo > FREQME_WINDOW_MARGIN) ? (lo - FREQME_WINDOW_MARGIN) : 0ULL;
+	if (lo < FREQME_RESULT_BIAS) {
+		lo = FREQME_RESULT_BIAS;
+	}
+	if (lo >= hi) {
+		LOG_ERR("FREQME WINDOW thresholds collapse (min=%llu, max=%llu)", lo, hi);
+		return -ERANGE;
+	}
+
+	*min_val = (uint32_t)lo;
+	*max_val = (uint32_t)hi;
+	return 0;
+}
+
+/* Route a source's INPUTMUX connection to its FREQME destination via the
+ * mux subsystem. Returns 0 on success, negative errno on failure.
+ */
+static int nxp_freqme_route(const struct nxp_freqme_source *src)
+{
+	if (!device_is_ready(src->mux_dev)) {
+		LOG_ERR("inputmux device not ready");
+		return -ENODEV;
+	}
+	return mux_state_apply(src->mux_dev, src->mux_state);
+}
+
+/*
+ * Resolve a source's frequency in Hz. A fixed provider is returned verbatim;
+ * otherwise the clock_control rate is queried. The driver does not enable the
+ * source clock - the caller owns that - so this only reads the rate. Returns
+ * -EIO when the provider device is not ready or the rate is unavailable/zero.
+ */
+static int nxp_freqme_src_rate(const struct nxp_freqme_source *src, uint32_t *hz)
+{
+	uint32_t rate = 0U;
+	int ret;
+
+	if (src->has_fixed_hz) {
+		*hz = src->fixed_hz;
+		return 0;
+	}
+	if (src->clk_dev == NULL || !device_is_ready(src->clk_dev)) {
+		return -EIO;
+	}
+
+	ret = clock_control_get_rate(src->clk_dev, src->clk_subsys, &rate);
+	if (ret != 0 || rate == 0U) {
+		return -EIO;
+	}
+	*hz = rate;
+	return 0;
+}
+
+/* Find the source whose INPUTMUX connection cookie equals @p cookie. */
+static int nxp_freqme_find_src(const struct nxp_freqme_source *srcs, uint8_t count,
+			       uint32_t cookie, uint8_t *out_idx)
+{
+	for (uint8_t i = 0U; i < count; i++) {
+		if (srcs[i].mux_state->state == cookie) {
+			*out_idx = i;
+			return 0;
+		}
+	}
+	return -EINVAL;
+}
+
+/* The default (power-on) source index: the child marked default-source. A
+ * BUILD_ASSERT guarantees exactly one exists; 0 is a defensive fallback.
+ */
+static uint8_t nxp_freqme_default_idx(const struct nxp_freqme_source *srcs, uint8_t count)
+{
+	for (uint8_t i = 0U; i < count; i++) {
+		if (srcs[i].is_default) {
+			return i;
+		}
+	}
+	return 0U;
+}
+
+/*
+ * Resolved hardware parameters computed from a clock_monitor_config before
+ * any registers are touched. Passed from freqme_resolve_params() to
+ * freqme_hw_apply() so the two steps can be read and tested independently.
+ */
+struct freqme_cfg_params {
+	uint32_t ref_hz;     /* reference clock rate in Hz                    */
+	uint8_t  ref_scale;  /* REF_SCALE exponent (window = 2^N ref periods) */
+	uint32_t min_val;    /* WINDOW MIN counter threshold (0 in MEASURE)   */
+	uint32_t max_val;    /* WINDOW MAX counter threshold                  */
+	uint32_t int_mask;   /* interrupt-enable bitmask for FREQME_EnableInterrupts */
+};
+
+/*
+ * Resolve hardware parameters from @p cfg and the current source pair
+ * (@p ref, @p tar). Pure computation — no register writes. On success
+ * fills @p out and returns 0; on failure returns a negative errno.
+ *
+ * Called outside the spinlock; the caller must snapshot ref/tar indices
+ * while holding the lock and then pass the resulting source pointers here.
+ */
+static int freqme_resolve_params(const struct clock_monitor_config *cfg,
+				 const struct nxp_freqme_source *ref,
+				 const struct nxp_freqme_source *tar,
+				 struct freqme_cfg_params *out)
+{
+	int ret;
+	uint32_t window_ns;
+
+	/* Query the reference rate — required for REF_SCALE and thresholds. */
+	ret = nxp_freqme_src_rate(ref, &out->ref_hz);
+	if (ret != 0) {
+		return ret;
+	}
+
+	window_ns = (cfg->mode == CLOCK_MONITOR_MODE_MEASURE)
+			    ? cfg->measure.window_ns
+			    : cfg->window.window_ns;
+
+	ret = freqme_window_to_ref_scale(window_ns, out->ref_hz, &out->ref_scale);
+	if (ret != 0) {
+		LOG_ERR("window_ns=%u out of range for ref_hz=%u",
+			window_ns, out->ref_hz);
+		return -EINVAL;
+	}
+
+	if (cfg->mode == CLOCK_MONITOR_MODE_WINDOW) {
+		uint32_t expected_hz = cfg->window.expected_hz;
+
+		if (expected_hz == 0U) {
+			/* Auto-derive the expected frequency from the current
+			 * target source when the caller did not supply one.
+			 */
+			ret = nxp_freqme_src_rate(tar, &expected_hz);
+			if (ret != 0) {
+				return -EINVAL;
+			}
+		}
+
+		ret = freqme_compute_thresholds(expected_hz,
+						cfg->window.tolerance_ppm,
+						out->ref_scale, out->ref_hz,
+						&out->min_val, &out->max_val);
+		if (ret != 0) {
+			return -EINVAL;
+		}
+
+		out->int_mask = (uint32_t)kFREQME_OverflowInterruptEnable |
+				(uint32_t)kFREQME_UnderflowInterruptEnable;
+	} else {
+		out->min_val  = 0U;
+		out->max_val  = FREQME_RESULT_MAX;
+		out->int_mask = (uint32_t)kFREQME_ReadyInterruptEnable;
+	}
+
+	return 0;
+}
+
+/*
+ * Write a resolved parameter set into the FREQME peripheral registers.
+ * Called after freqme_resolve_params() succeeds, still outside the spinlock.
+ * Does not touch driver state — the caller commits data->cfg / data->state
+ * under the spinlock after this returns.
+ */
+static void freqme_hw_apply(FREQME_Type *base,
+			    const struct clock_monitor_config *cfg,
+			    const struct freqme_cfg_params *p)
+{
+	freq_measure_config_t hal_cfg;
+
+	FREQME_GetDefaultConfig(&hal_cfg);
+	hal_cfg.operateMode = kFREQME_FreqMeasurementMode;
+	hal_cfg.operateModeAttribute.refClkScaleFactor = p->ref_scale;
+	hal_cfg.enableContinuousMode = (cfg->mode == CLOCK_MONITOR_MODE_WINDOW);
+	hal_cfg.startMeasurement = false;
+
+	FREQME_Init(base, &hal_cfg);
+	FREQME_SetMinExpectedValue(base, p->min_val);
+	FREQME_SetMaxExpectedValue(base, p->max_val);
+	FREQME_EnableInterrupts(base, p->int_mask);
+}
+
+static int nxp_freqme_configure(const struct device *dev,
+				const struct clock_monitor_config *cfg)
+{
+	const struct nxp_freqme_config *config = dev->config;
+	struct nxp_freqme_data *data = dev->data;
+	struct freqme_cfg_params params;
+	k_spinlock_key_t key;
+	enum nxp_freqme_state prev_state;
+	uint8_t ref_idx;
+	uint8_t tar_idx;
+	int ret;
+
+	/* Input-only validation — no state or hardware needed. */
+	if (cfg->mode != CLOCK_MONITOR_MODE_MEASURE &&
+	    cfg->mode != CLOCK_MONITOR_MODE_WINDOW) {
+		return -ENOTSUP;
+	}
+	if (cfg->mode == CLOCK_MONITOR_MODE_MEASURE) {
+		if (cfg->measure.window_ns == 0U) {
+			return -EINVAL;
+		}
+	} else {
+		if (cfg->window.window_ns == 0U ||
+		    cfg->window.tolerance_ppm >= 1000000U) {
+			return -EINVAL;
+		}
+	}
+
+	/* Claim the configure transaction and snapshot the current source
+	 * indices. CONFIGURING makes concurrent configure()/start()/
+	 * set_source() callers return -EBUSY, so the clock queries and HAL
+	 * writes below run against a stable source pair outside the spinlock.
+	 */
+	key = k_spin_lock(&data->lock);
+	if (data->state == NXP_FREQME_STATE_RUNNING ||
+	    data->state == NXP_FREQME_STATE_CONFIGURING) {
+		k_spin_unlock(&data->lock, key);
+		return -EBUSY;
+	}
+	prev_state = data->state;
+	ref_idx    = data->cur_ref_idx;
+	tar_idx    = data->cur_tar_idx;
+	data->state = NXP_FREQME_STATE_CONFIGURING;
+	k_spin_unlock(&data->lock, key);
+
+	/* Resolve parameters (clock queries + threshold arithmetic) and write
+	 * the results to hardware. Both run outside the spinlock; the caller
+	 * must ensure the selected source clocks are already running.
+	 */
+	ret = freqme_resolve_params(cfg,
+				    &config->ref_srcs[ref_idx],
+				    &config->tar_srcs[tar_idx],
+				    &params);
+	if (ret != 0) {
+		goto restore;
+	}
+
+	freqme_hw_apply(config->base, cfg, &params);
+
+	key = k_spin_lock(&data->lock);
+	data->cfg         = *cfg;
+	data->ref_hz      = params.ref_hz;
+	data->ref_scale   = params.ref_scale;
+	data->last_rate_hz = 0U;
+	data->has_rate    = false;
+	data->clock_lost  = false;
+	data->state       = NXP_FREQME_STATE_CONFIGURED;
+	k_spin_unlock(&data->lock, key);
+	return 0;
+
+restore:
+	/* Hardware untouched: the previous configuration is still valid. */
+	key = k_spin_lock(&data->lock);
+	data->state = prev_state;
+	k_spin_unlock(&data->lock, key);
+	return ret;
+}
+
+static int nxp_freqme_start(const struct device *dev)
+{
+	const struct nxp_freqme_config *config = dev->config;
+	struct nxp_freqme_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&data->lock);
+	if (data->state == NXP_FREQME_STATE_RUNNING ||
+	    data->state == NXP_FREQME_STATE_CONFIGURING) {
+		k_spin_unlock(&data->lock, key);
+		return -EBUSY;
+	}
+	if (data->state != NXP_FREQME_STATE_CONFIGURED) {
+		k_spin_unlock(&data->lock, key);
+		return -EINVAL;
+	}
+
+	/* State transition and HW kick share one critical section so the
+	 * completion ISR can never observe RUNNING hardware with a
+	 * not-yet-RUNNING state machine.
+	 */
+	data->state = NXP_FREQME_STATE_RUNNING;
+	if (data->cfg.mode == CLOCK_MONITOR_MODE_WINDOW) {
+		FREQME_EnableContinuousMode(config->base, true);
+	}
+	FREQME_StartMeasurementCycle(config->base);
+	k_spin_unlock(&data->lock, key);
+	return 0;
+}
+
+static int nxp_freqme_stop(const struct device *dev)
+{
+	const struct nxp_freqme_config *config = dev->config;
+	struct nxp_freqme_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&data->lock);
+	if (data->state == NXP_FREQME_STATE_RUNNING) {
+		if (data->cfg.mode == CLOCK_MONITOR_MODE_WINDOW) {
+			FREQME_EnableContinuousMode(config->base, false);
+		}
+		FREQME_TerminateMeasurementCycle(config->base);
+		data->state = NXP_FREQME_STATE_CONFIGURED;
+	}
+	k_spin_unlock(&data->lock, key);
+	return 0;
+}
+
+static int nxp_freqme_get_rate(const struct device *dev, uint32_t *rate_hz)
+{
+	struct nxp_freqme_data *data = dev->data;
+	k_spinlock_key_t key;
+	int ret;
+
+	key = k_spin_lock(&data->lock);
+	if (data->cfg.mode == CLOCK_MONITOR_MODE_WINDOW) {
+		ret = -EAGAIN;
+	} else if (data->clock_lost) {
+		ret = -EIO;
+	} else if (data->has_rate) {
+		*rate_hz = data->last_rate_hz;
+		ret = 0;
+	} else {
+		ret = -EAGAIN;
+	}
+	k_spin_unlock(&data->lock, key);
+	return ret;
+}
+
+static int nxp_freqme_set_source(const struct device *dev, uint32_t reference, uint32_t target)
+{
+	const struct nxp_freqme_config *config = dev->config;
+	struct nxp_freqme_data *data = dev->data;
+	k_spinlock_key_t key;
+	enum nxp_freqme_state prev_state;
+	uint8_t req_ref_idx = 0U;
+	uint8_t req_tar_idx = 0U;
+	uint8_t new_ref_idx;
+	uint8_t new_tar_idx;
+	bool ref_req = (reference != NXP_FREQME_SOURCE_UNCHANGED);
+	bool tar_req = (target != NXP_FREQME_SOURCE_UNCHANGED);
+	bool ref_changed;
+	bool tar_changed;
+	int ret;
+
+	if (!ref_req && !tar_req) {
+		return -EINVAL;
+	}
+
+	/* Resolve the requested cookies up front. An unknown cookie - including
+	 * one for the wrong axis, which simply isn't in that table - fails with
+	 * -EINVAL without touching hardware or state. -ENOTSUP is reserved by
+	 * the API for back-ends that cannot switch sources at all.
+	 */
+	if (ref_req && nxp_freqme_find_src(config->ref_srcs, config->ref_srcs_count,
+					   reference, &req_ref_idx) != 0) {
+		return -EINVAL;
+	}
+	if (tar_req && nxp_freqme_find_src(config->tar_srcs, config->tar_srcs_count,
+					   target, &req_tar_idx) != 0) {
+		return -EINVAL;
+	}
+
+	/* Claim the transaction against the current selection. */
+	key = k_spin_lock(&data->lock);
+	if (data->state == NXP_FREQME_STATE_RUNNING ||
+	    data->state == NXP_FREQME_STATE_CONFIGURING) {
+		k_spin_unlock(&data->lock, key);
+		return -EBUSY;
+	}
+	new_ref_idx = ref_req ? req_ref_idx : data->cur_ref_idx;
+	new_tar_idx = tar_req ? req_tar_idx : data->cur_tar_idx;
+	ref_changed = (new_ref_idx != data->cur_ref_idx);
+	tar_changed = (new_tar_idx != data->cur_tar_idx);
+	if (!ref_changed && !tar_changed) {
+		/* Resolved no-op: already selected. Leave state and configured
+		 * measurement parameters intact.
+		 */
+		k_spin_unlock(&data->lock, key);
+		return 0;
+	}
+	prev_state = data->state;
+	data->state = NXP_FREQME_STATE_CONFIGURING;
+	k_spin_unlock(&data->lock, key);
+
+	/* Re-route the changed source(s). The driver does not enable source
+	 * clocks - the caller owns that. The previously selected source's clock
+	 * is left running: it may be shared with other consumers and is not the
+	 * driver's to gate off.
+	 */
+	if (ref_changed) {
+		ret = nxp_freqme_route(&config->ref_srcs[new_ref_idx]);
+		if (ret != 0) {
+			goto route_err;
+		}
+	}
+	if (tar_changed) {
+		ret = nxp_freqme_route(&config->tar_srcs[new_tar_idx]);
+		if (ret != 0) {
+			goto route_err;
+		}
+	}
+
+	/* A prior configuration measured the old source(s). Disarm the hardware
+	 * (without FREQME_Deinit) and drop back to IDLE: the reference rate may
+	 * have changed, so the cached REF_SCALE and WINDOW thresholds are stale
+	 * and a fresh configure() must re-derive them.
+	 */
+	if (prev_state == NXP_FREQME_STATE_CONFIGURED) {
+		if (data->cfg.mode == CLOCK_MONITOR_MODE_WINDOW) {
+			FREQME_EnableContinuousMode(config->base, false);
+		}
+		FREQME_TerminateMeasurementCycle(config->base);
+		FREQME_DisableInterrupts(config->base,
+					 (uint32_t)kFREQME_ReadyInterruptEnable |
+					 (uint32_t)kFREQME_OverflowInterruptEnable |
+					 (uint32_t)kFREQME_UnderflowInterruptEnable);
+		FREQME_ClearInterruptStatusFlags(config->base,
+			FREQME_GetInterruptStatusFlags(config->base));
+	}
+
+	key = k_spin_lock(&data->lock);
+	data->cur_ref_idx = new_ref_idx;
+	data->cur_tar_idx = new_tar_idx;
+	data->last_rate_hz = 0U;
+	data->has_rate = false;
+	data->clock_lost = false;
+	data->state = NXP_FREQME_STATE_IDLE;
+	k_spin_unlock(&data->lock, key);
+	return 0;
+
+route_err:
+	/* Routing failed after we claimed the transaction. Drop back to IDLE so
+	 * a subsequent set_source() is not rejected with -EBUSY. The current
+	 * selection is left untouched since the re-route did not complete.
+	 */
+	key = k_spin_lock(&data->lock);
+	data->state = NXP_FREQME_STATE_IDLE;
+	k_spin_unlock(&data->lock, key);
+	return ret;
+}
+
+static void nxp_freqme_isr(const struct device *dev)
+{
+	const struct nxp_freqme_config *config = dev->config;
+	struct nxp_freqme_data *data = dev->data;
+	uint32_t flags = FREQME_GetInterruptStatusFlags(config->base);
+	uint32_t evts = 0U;
+	uint32_t rate = 0U;
+	clock_monitor_callback_t cb = NULL;
+	void *user_data = NULL;
+	k_spinlock_key_t key;
+
+	FREQME_ClearInterruptStatusFlags(config->base, flags);
+
+	key = k_spin_lock(&data->lock);
+
+	/* A pending interrupt may run after stop() (or a fresh configure())
+	 * has already left the RUNNING state; discard it.
+	 */
+	if (data->state != NXP_FREQME_STATE_RUNNING) {
+		k_spin_unlock(&data->lock, key);
+		return;
+	}
+
+	if (data->cfg.mode == CLOCK_MONITOR_MODE_MEASURE) {
+		if ((flags & (uint32_t)kFREQME_ReadyInterruptStatusFlag) != 0U) {
+			uint32_t result = FREQME_GetMeasurementResult(config->base);
+
+			/* target edge count = result - FREQME_RESULT_BIAS, so
+			 * result <= bias means zero edges: clock lost.
+			 */
+			if (result <= FREQME_RESULT_BIAS) {
+				data->clock_lost = true;
+				evts |= CLOCK_MONITOR_EVT_CLOCK_LOST;
+			} else {
+				rate = FREQME_CalculateTargetClkFreq(config->base,
+								     data->ref_hz);
+				data->last_rate_hz = rate;
+				data->has_rate = true;
+				/* A fresh good measurement clears any prior
+				 * CLOCK_LOST so get_rate() reflects the most
+				 * recent completed cycle.
+				 */
+				data->clock_lost = false;
+				evts |= CLOCK_MONITOR_EVT_MEASURE_DONE;
+			}
+			/* Auto-disarm before the callback so it may restart. */
+			data->state = NXP_FREQME_STATE_CONFIGURED;
+		}
+	} else {
+		if ((flags & (uint32_t)kFREQME_OverflowInterruptStatusFlag) != 0U) {
+			evts |= CLOCK_MONITOR_EVT_FREQ_HIGH;
+		}
+		if ((flags & (uint32_t)kFREQME_UnderflowInterruptStatusFlag) != 0U) {
+			evts |= CLOCK_MONITOR_EVT_FREQ_LOW;
+		}
+		/* An out-of-range result auto-clears CONTINUOUS_MODE_EN in
+		 * hardware; re-arm so monitoring continues.
+		 */
+		if (evts != 0U) {
+			FREQME_EnableContinuousMode(config->base, true);
+			FREQME_StartMeasurementCycle(config->base);
+		}
+	}
+
+	if (evts != 0U) {
+		cb = data->cfg.callback;
+		user_data = data->cfg.user_data;
+	}
+	k_spin_unlock(&data->lock, key);
+
+	if (cb != NULL && evts != 0U) {
+		struct clock_monitor_event_data evt = {
+			.events = evts,
+			.measured_hz = rate,
+		};
+		cb(dev, &evt, user_data);
+	}
+}
+
+static int nxp_freqme_init(const struct device *dev)
+{
+	const struct nxp_freqme_config *config = dev->config;
+	struct nxp_freqme_data *data = dev->data;
+	int ret;
+
+	data->state = NXP_FREQME_STATE_IDLE;
+	data->cur_ref_idx = nxp_freqme_default_idx(config->ref_srcs,
+						   config->ref_srcs_count);
+	data->cur_tar_idx = nxp_freqme_default_idx(config->tar_srcs,
+						   config->tar_srcs_count);
+
+	if (!device_is_ready(config->gate_clk_dev)) {
+		LOG_ERR("%s: gate clock device not ready", dev->name);
+		return -ENODEV;
+	}
+
+	ret = clock_control_on(config->gate_clk_dev, config->gate_clk_subsys);
+	if (ret != 0) {
+		LOG_ERR("%s: failed to enable gate clock (%d)", dev->name, ret);
+		return ret;
+	}
+
+	/* Route the default reference/target sources to the FREQME inputs. The
+	 * driver does not enable these source clocks - the caller must have them
+	 * running before configure()/start().
+	 */
+	ret = nxp_freqme_route(&config->ref_srcs[data->cur_ref_idx]);
+	if (ret != 0) {
+		LOG_ERR("%s: failed to route default ref source (%d)", dev->name, ret);
+		return ret;
+	}
+	ret = nxp_freqme_route(&config->tar_srcs[data->cur_tar_idx]);
+	if (ret != 0) {
+		LOG_ERR("%s: failed to route default tar source (%d)", dev->name, ret);
+		return ret;
+	}
+
+	config->irq_config_func(dev);
+	return 0;
+}
+
+static DEVICE_API(clock_monitor, nxp_freqme_api) = {
+	.configure  = nxp_freqme_configure,
+	.start      = nxp_freqme_start,
+	.stop       = nxp_freqme_stop,
+	.get_rate   = nxp_freqme_get_rate,
+	.set_source = nxp_freqme_set_source,
+};
+
+/* Frequency provider: a fixed clock-frequency takes precedence; otherwise a
+ * clocks phandle is used; a source with neither is rejected by BUILD_ASSERT.
+ */
+#define NXP_FREQME_SRC_CLK_DEV(node)                                           \
+	COND_CODE_1(DT_NODE_HAS_PROP(node, clock_frequency), (NULL),           \
+		    (COND_CODE_1(DT_NODE_HAS_PROP(node, clocks),               \
+				 (DEVICE_DT_GET(DT_CLOCKS_CTLR(node))),        \
+				 (NULL))))
+
+#define NXP_FREQME_SRC_CLK_SUBSYS(node)                                        \
+	COND_CODE_1(DT_NODE_HAS_PROP(node, clock_frequency),                   \
+		    ((clock_control_subsys_t)0),                               \
+		    (COND_CODE_1(DT_NODE_HAS_PROP(node, clocks),               \
+				 ((clock_control_subsys_t)(uintptr_t)          \
+					  DT_CLOCKS_CELL(node, name)),         \
+				 ((clock_control_subsys_t)0))))
+
+/* Emit static mux_state storage for one source child node (file scope). */
+#define NXP_FREQME_SRC_MUX_DEFINE(node) MUX_STATE_DT_SPEC_DEFINE(node);
+
+#define NXP_FREQME_SRC_ENTRY(node)                                             \
+	{                                                                      \
+		.mux_dev   = MUX_STATE_DT_DEV_GET(node),                       \
+		.mux_state = MUX_STATE_DT_GET(node),                           \
+		.clk_dev = NXP_FREQME_SRC_CLK_DEV(node),                       \
+		.clk_subsys = NXP_FREQME_SRC_CLK_SUBSYS(node),                 \
+		.fixed_hz = (uint32_t)DT_PROP_OR(node, clock_frequency, 0),    \
+		.has_fixed_hz = DT_NODE_HAS_PROP(node, clock_frequency),       \
+		.is_default = DT_PROP(node, default_source),                   \
+	}
+
+/* Per-source compile-time checks: a usable frequency provider, and a nonzero
+ * fixed frequency when one is given.
+ */
+#define NXP_FREQME_SRC_ASSERT(node)                                            \
+	BUILD_ASSERT(DT_NODE_HAS_PROP(node, clock_frequency) ||                \
+			     DT_NODE_HAS_PROP(node, clocks),                   \
+		     "nxp,freqme source needs clocks or clock-frequency");     \
+	BUILD_ASSERT(!DT_NODE_HAS_PROP(node, clock_frequency) ||               \
+			     DT_PROP_OR(node, clock_frequency, 0) != 0,        \
+		     "nxp,freqme clock-frequency must be nonzero");
+
+/* Target sources may omit a frequency provider (the target rate is measured,
+ * not predicted); only reject a given fixed frequency that is zero.
+ */
+#define NXP_FREQME_TAR_SRC_ASSERT(node) \
+	BUILD_ASSERT(!DT_NODE_HAS_PROP(node, clock_frequency) ||               \
+			     DT_PROP_OR(node, clock_frequency, 0) != 0,        \
+		     "nxp,freqme clock-frequency must be nonzero");
+
+/* Count of default-source children in a container (summed in a BUILD_ASSERT). */
+#define NXP_FREQME_DEFAULT_INC(node) + DT_PROP(node, default_source)
+
+#define NXP_FREQME_REF_NODE(inst) DT_INST_CHILD(inst, reference_sources)
+#define NXP_FREQME_TAR_NODE(inst) DT_INST_CHILD(inst, target_sources)
+
+#define NXP_FREQME_DEVICE_INIT(inst)                                           \
+	BUILD_ASSERT(DT_NODE_EXISTS(NXP_FREQME_REF_NODE(inst)),                \
+		     "nxp,freqme: missing reference-sources node");            \
+	BUILD_ASSERT(DT_NODE_EXISTS(NXP_FREQME_TAR_NODE(inst)),                \
+		     "nxp,freqme: missing target-sources node");               \
+	BUILD_ASSERT(DT_CHILD_NUM(NXP_FREQME_REF_NODE(inst)) >= 1,             \
+		     "nxp,freqme: reference-sources needs >= 1 source");       \
+	BUILD_ASSERT(DT_CHILD_NUM(NXP_FREQME_TAR_NODE(inst)) >= 1,             \
+		     "nxp,freqme: target-sources needs >= 1 source");          \
+	BUILD_ASSERT((0 DT_FOREACH_CHILD(NXP_FREQME_REF_NODE(inst),            \
+					 NXP_FREQME_DEFAULT_INC)) == 1,        \
+		     "nxp,freqme: reference-sources needs exactly one default-source"); \
+	BUILD_ASSERT((0 DT_FOREACH_CHILD(NXP_FREQME_TAR_NODE(inst),            \
+					 NXP_FREQME_DEFAULT_INC)) == 1,        \
+		     "nxp,freqme: target-sources needs exactly one default-source"); \
+	DT_FOREACH_CHILD(NXP_FREQME_REF_NODE(inst), NXP_FREQME_SRC_ASSERT)     \
+	DT_FOREACH_CHILD(NXP_FREQME_TAR_NODE(inst), NXP_FREQME_TAR_SRC_ASSERT)     \
+	DT_FOREACH_CHILD(NXP_FREQME_REF_NODE(inst), NXP_FREQME_SRC_MUX_DEFINE) \
+	DT_FOREACH_CHILD(NXP_FREQME_TAR_NODE(inst), NXP_FREQME_SRC_MUX_DEFINE) \
+	static void nxp_freqme_irq_cfg_##inst(const struct device *dev)        \
+	{                                                                      \
+		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority),   \
+			    nxp_freqme_isr, DEVICE_DT_INST_GET(inst), 0);      \
+		irq_enable(DT_INST_IRQN(inst));                                \
+	}                                                                      \
+	static const struct nxp_freqme_source nxp_freqme_ref_srcs_##inst[] = { \
+		DT_FOREACH_CHILD_SEP(NXP_FREQME_REF_NODE(inst),                \
+				     NXP_FREQME_SRC_ENTRY, (,))                \
+	};                                                                     \
+	static const struct nxp_freqme_source nxp_freqme_tar_srcs_##inst[] = { \
+		DT_FOREACH_CHILD_SEP(NXP_FREQME_TAR_NODE(inst),                \
+				     NXP_FREQME_SRC_ENTRY, (,))                \
+	};                                                                     \
+	static struct nxp_freqme_data nxp_freqme_data_##inst;                  \
+	static const struct nxp_freqme_config nxp_freqme_cfg_##inst = {        \
+		.base = (FREQME_Type *)DT_INST_REG_ADDR(inst),                 \
+		.gate_clk_dev =                                                \
+			DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(inst)), \
+		.gate_clk_subsys = (clock_control_subsys_t)(uintptr_t)         \
+			DT_INST_CLOCKS_CELL(inst, name),          \
+		.ref_srcs = nxp_freqme_ref_srcs_##inst,                        \
+		.ref_srcs_count =                                              \
+			(uint8_t)ARRAY_SIZE(nxp_freqme_ref_srcs_##inst),       \
+		.tar_srcs = nxp_freqme_tar_srcs_##inst,                        \
+		.tar_srcs_count =                                              \
+			(uint8_t)ARRAY_SIZE(nxp_freqme_tar_srcs_##inst),       \
+		.irq_config_func = nxp_freqme_irq_cfg_##inst,                  \
+	};                                                                     \
+	DEVICE_DT_INST_DEFINE(inst, nxp_freqme_init, NULL,                     \
+			      &nxp_freqme_data_##inst, &nxp_freqme_cfg_##inst, \
+			      POST_KERNEL, CONFIG_CLOCK_MONITOR_INIT_PRIORITY, \
+			      &nxp_freqme_api);
+
+DT_INST_FOREACH_STATUS_OKAY(NXP_FREQME_DEVICE_INIT)

--- a/drivers/clock_monitor/clock_monitor_nxp_freqme.c
+++ b/drivers/clock_monitor/clock_monitor_nxp_freqme.c
@@ -270,10 +270,10 @@ static uint8_t nxp_freqme_default_idx(const struct nxp_freqme_source *srcs, uint
 
 /*
  * Resolved hardware parameters computed from a clock_monitor_config before
- * any registers are touched. Passed from freqme_resolve_params() to
+ * any registers are touched. Passed from freqme_derive_hw_params() to
  * freqme_hw_apply() so the two steps can be read and tested independently.
  */
-struct freqme_cfg_params {
+struct freqme_hw_params {
 	uint32_t ref_hz;     /* reference clock rate in Hz                    */
 	uint8_t  ref_scale;  /* REF_SCALE exponent (window = 2^N ref periods) */
 	uint32_t min_val;    /* WINDOW MIN counter threshold (0 in MEASURE)   */
@@ -282,17 +282,21 @@ struct freqme_cfg_params {
 };
 
 /*
- * Resolve hardware parameters from @p cfg and the current source pair
- * (@p ref, @p tar). Pure computation — no register writes. On success
- * fills @p out and returns 0; on failure returns a negative errno.
+ * Translate a clock_monitor_config into FREQME register-level parameters:
+ *   - queries @p ref for the reference clock rate (ref_hz)
+ *   - converts the requested window duration to a REF_SCALE exponent
+ *   - for WINDOW mode: resolves the expected target frequency (from @p tar
+ *     when cfg->window.expected_hz == 0) and computes MIN/MAX result-counter
+ *     thresholds at the given tolerance
+ *   - selects the matching interrupt-enable mask (ready / over- or under-range)
  *
- * Called outside the spinlock; the caller must snapshot ref/tar indices
- * while holding the lock and then pass the resulting source pointers here.
+ * Results are written to @p out. Returns 0 on success, negative errno on
+ * failure (rate unavailable, window out of range, thresholds overflow).
  */
-static int freqme_resolve_params(const struct clock_monitor_config *cfg,
+static int freqme_derive_hw_params(const struct clock_monitor_config *cfg,
 				 const struct nxp_freqme_source *ref,
 				 const struct nxp_freqme_source *tar,
-				 struct freqme_cfg_params *out)
+				 struct freqme_hw_params *out)
 {
 	int ret;
 	uint32_t window_ns;
@@ -347,14 +351,14 @@ static int freqme_resolve_params(const struct clock_monitor_config *cfg,
 }
 
 /*
- * Write a resolved parameter set into the FREQME peripheral registers.
- * Called after freqme_resolve_params() succeeds, still outside the spinlock.
- * Does not touch driver state — the caller commits data->cfg / data->state
- * under the spinlock after this returns.
+ * Program a freqme_hw_params set into the FREQME peripheral: initialises the
+ * HAL config struct (measurement mode, REF_SCALE, continuous-mode flag),
+ * calls FREQME_Init(), then arms the MIN/MAX result-counter thresholds and
+ * enables the appropriate interrupts (ready / over- and under-range).
  */
 static void freqme_hw_apply(FREQME_Type *base,
 			    const struct clock_monitor_config *cfg,
-			    const struct freqme_cfg_params *p)
+			    const struct freqme_hw_params *p)
 {
 	freq_measure_config_t hal_cfg;
 
@@ -375,7 +379,7 @@ static int nxp_freqme_configure(const struct device *dev,
 {
 	const struct nxp_freqme_config *config = dev->config;
 	struct nxp_freqme_data *data = dev->data;
-	struct freqme_cfg_params params;
+	struct freqme_hw_params params;
 	k_spinlock_key_t key;
 	enum nxp_freqme_state prev_state;
 	uint8_t ref_idx;
@@ -419,7 +423,7 @@ static int nxp_freqme_configure(const struct device *dev,
 	 * the results to hardware. Both run outside the spinlock; the caller
 	 * must ensure the selected source clocks are already running.
 	 */
-	ret = freqme_resolve_params(cfg,
+	ret = freqme_derive_hw_params(cfg,
 				    &config->ref_srcs[ref_idx],
 				    &config->tar_srcs[tar_idx],
 				    &params);

--- a/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt7xx_cm33_cpu0.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include "nxp_rt7xx_common.dtsi"
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
 #include <zephyr/dt-bindings/mipi_dsi/mipi_dsi.h>
 #include <zephyr/dt-bindings/misc/nxp_rtxxx_dsp_ctrl.h>
 
@@ -122,6 +123,97 @@
 		interrupts = <136 0>;
 		#wakeup-ctrl-cells = <1>;
 		status = "okay";
+	};
+
+	inputmux0: inputmux@26000 {
+		compatible = "nxp,inputmux";
+		reg = <0x26000 0x1000>;
+		status = "disabled";
+		#mux-control-cells = <1>;
+		#mux-state-cells = <2>;
+	};
+
+	freqme0: freqme@23000 {
+		compatible = "nxp,freqme";
+		reg = <0x23000 0x10>;
+		interrupts = <124 0>;
+		clocks = <&clkctl0 MCUX_FREQME_CLK>;
+		status = "disabled";
+
+		reference-sources {
+			ref-osc {
+				default-source;
+				mux-states = <&inputmux0 0 NXP_FREQME_RT7XX_REF_OSC_CLK>;
+				clocks = <&clkctl0 MCUX_EXT_CLK>;
+			};
+
+			ref-fro1 {
+				mux-states = <&inputmux0 0 NXP_FREQME_RT7XX_REF_FRO1>;
+				clocks = <&clkctl0 MCUX_FRO_HF_CLK>;
+			};
+
+			ref-fro1-div8 {
+				mux-states = <&inputmux0 0 NXP_FREQME_RT7XX_REF_FRO1_DIV8>;
+				clock-frequency = <24000000>;
+			};
+
+			ref-osc32k {
+				mux-states = <&inputmux0 0 NXP_FREQME_RT7XX_REF_OSC32K>;
+				clock-frequency = <32768>;
+			};
+		};
+
+		target-sources {
+			/*
+			 * Targets without a clocks / clock-frequency provider are
+			 * MEASURE only (no WINDOW auto-derive): LPOSC and FRO0 have no
+			 * fixed nominal rate here; GPIO_A / GPIO_B are GPIO clock
+			 * domains.
+			 */
+			tar-fro1 {
+				default-source;
+				mux-states = <&inputmux0 0 NXP_FREQME_RT7XX_TAR_FRO1>;
+				clocks = <&clkctl0 MCUX_FRO_HF_CLK>;
+			};
+
+			tar-osc {
+				mux-states = <&inputmux0 0 NXP_FREQME_RT7XX_TAR_OSC_CLK>;
+				clocks = <&clkctl0 MCUX_EXT_CLK>;
+			};
+
+			tar-fro1-div8 {
+				mux-states = <&inputmux0 0 NXP_FREQME_RT7XX_TAR_FRO1_DIV8>;
+				clock-frequency = <24000000>;
+			};
+
+			tar-lposc {
+				mux-states = <&inputmux0 0 NXP_FREQME_RT7XX_TAR_LPOSC>;
+			};
+
+			tar-osc32k {
+				mux-states = <&inputmux0 0 NXP_FREQME_RT7XX_TAR_OSC32K>;
+				clock-frequency = <32768>;
+			};
+
+			tar-fro0 {
+				mux-states = <&inputmux0 0 NXP_FREQME_RT7XX_TAR_FRO0>;
+			};
+
+			tar-fro2 {
+				mux-states = <&inputmux0 0 NXP_FREQME_RT7XX_TAR_FRO2>;
+				clock-frequency = <300000000>;
+			};
+
+			tar-gpio-a {
+				mux-states = <&inputmux0 0
+					      NXP_FREQME_RT7XX_TAR_GPIO_A_CLK>;
+			};
+
+			tar-gpio-b {
+				mux-states = <&inputmux0 0
+					      NXP_FREQME_RT7XX_TAR_GPIO_B_CLK>;
+			};
+		};
 	};
 
 	ctimer0: timer@28000 {

--- a/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
@@ -8,6 +8,7 @@
 #include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
@@ -271,6 +272,71 @@
 			reg = <0x40001000 0x1000>;
 			#mux-control-cells = <1>;
 			#mux-state-cells = <2>;
+		};
+
+		freqme0: freqme@40009000 {
+			compatible = "nxp,freqme";
+			reg = <0x40009000 0x10>;
+			interrupts = <54 0>;
+			clocks = <&syscon MCUX_FREQME_CLK>;
+			status = "disabled";
+
+			reference-sources {
+				ref-fro-hf-div {
+					default-source;
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_REF_FRO_HF_DIV>;
+					clocks = <&syscon MCUX_FRO_HF_DIV_CLK>;
+				};
+
+				ref-fro-12m {
+					mux-states = <&inputmux0 0 NXP_FREQME_REF_FRO_12M>;
+					clocks = <&syscon MCUX_FRO_12M_CLK>;
+				};
+			};
+
+			target-sources {
+				/*
+				 * Targets without a clocks / clock-frequency provider have an
+				 * unknown or board-specific rate: MEASURE only, no WINDOW
+				 * auto-derive. CLK_IN / CLK_IN0 / CLK_IN1 are external input
+				 * pins; SLOW_CLK is a divided clock whose rate varies.
+				 */
+				tar-fro-12m {
+					default-source;
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_FRO_12M>;
+					clocks = <&syscon MCUX_FRO_12M_CLK>;
+				};
+
+				tar-fro-hf-div {
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_TAR_FRO_HF_DIV>;
+					clocks = <&syscon MCUX_FRO_HF_DIV_CLK>;
+				};
+
+				tar-clk-in {
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN>;
+				};
+
+				tar-clk-16k1 {
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_TAR_CLK_16K1>;
+					clock-frequency = <16384>;
+				};
+
+				tar-slow-clk {
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_TAR_SLOW_CLK>;
+				};
+
+				tar-clk-in0 {
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN0>;
+				};
+
+				tar-clk-in1 {
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN1>;
+				};
+			};
 		};
 
 		i3c0: i3c@40002000 {

--- a/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
@@ -8,6 +8,7 @@
 #include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
@@ -90,6 +91,71 @@
 			reset: reset {
 				compatible = "nxp,mrcc-reset";
 				#reset-cells = <1>;
+			};
+		};
+
+		freqme0: freqme@40009000 {
+			compatible = "nxp,freqme";
+			reg = <0x40009000 0x10>;
+			interrupts = <54 0>;
+			clocks = <&syscon MCUX_FREQME_CLK>;
+			status = "disabled";
+
+			reference-sources {
+				ref-fro-hf-div {
+					default-source;
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_REF_FRO_HF_DIV>;
+					clocks = <&syscon MCUX_FRO_HF_DIV_CLK>;
+				};
+
+				ref-fro-12m {
+					mux-states = <&inputmux0 0 NXP_FREQME_REF_FRO_12M>;
+					clocks = <&syscon MCUX_FRO_12M_CLK>;
+				};
+			};
+
+			target-sources {
+				/*
+				 * Targets without a clocks / clock-frequency provider have an
+				 * unknown or board-specific rate: MEASURE only, no WINDOW
+				 * auto-derive. CLK_IN / CLK_IN0 / CLK_IN1 are external input
+				 * pins; SLOW_CLK is a divided clock whose rate varies.
+				 */
+				tar-fro-12m {
+					default-source;
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_FRO_12M>;
+					clocks = <&syscon MCUX_FRO_12M_CLK>;
+				};
+
+				tar-fro-hf-div {
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_TAR_FRO_HF_DIV>;
+					clocks = <&syscon MCUX_FRO_HF_DIV_CLK>;
+				};
+
+				tar-clk-in {
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN>;
+				};
+
+				tar-clk-16k1 {
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_TAR_CLK_16K1>;
+					clock-frequency = <16384>;
+				};
+
+				tar-slow-clk {
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_TAR_SLOW_CLK>;
+				};
+
+				tar-clk-in0 {
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN0>;
+				};
+
+				tar-clk-in1 {
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN1>;
+				};
 			};
 		};
 

--- a/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
@@ -7,6 +7,7 @@
 #include <mem.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
@@ -180,6 +181,71 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			nxp,kinetis-port = <&porte>;
+		};
+
+		freqme0: freqme@40009000 {
+			compatible = "nxp,freqme";
+			reg = <0x40009000 0x10>;
+			interrupts = <54 0>;
+			clocks = <&syscon MCUX_FREQME_CLK>;
+			status = "disabled";
+
+			reference-sources {
+				ref-fro-hf-div {
+					default-source;
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_REF_FRO_HF_DIV>;
+					clocks = <&syscon MCUX_FRO_HF_DIV_CLK>;
+				};
+
+				ref-fro-12m {
+					mux-states = <&inputmux0 0 NXP_FREQME_REF_FRO_12M>;
+					clocks = <&syscon MCUX_FRO_12M_CLK>;
+				};
+			};
+
+			target-sources {
+				/*
+				 * Targets without a clocks / clock-frequency provider have an
+				 * unknown or board-specific rate: MEASURE only, no WINDOW
+				 * auto-derive. CLK_IN / CLK_IN0 / CLK_IN1 are external input
+				 * pins; SLOW_CLK is a divided clock whose rate varies.
+				 */
+				tar-fro-12m {
+					default-source;
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_FRO_12M>;
+					clocks = <&syscon MCUX_FRO_12M_CLK>;
+				};
+
+				tar-fro-hf-div {
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_TAR_FRO_HF_DIV>;
+					clocks = <&syscon MCUX_FRO_HF_DIV_CLK>;
+				};
+
+				tar-clk-in {
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN>;
+				};
+
+				tar-clk-16k1 {
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_TAR_CLK_16K1>;
+					clock-frequency = <16384>;
+				};
+
+				tar-slow-clk {
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_TAR_SLOW_CLK>;
+				};
+
+				tar-clk-in0 {
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN0>;
+				};
+
+				tar-clk-in1 {
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN1>;
+				};
+			};
 		};
 
 		lpuart0: lpuart@4009f000 {

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -7,6 +7,7 @@
 #include <mem.h>
 #include <freq.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <arm/armv8-m.dtsi>
@@ -143,6 +144,75 @@
 		reset: reset {
 			compatible = "nxp,mrcc-reset";
 			#reset-cells = <1>;
+		};
+	};
+
+	inputmux0: inputmux@1000 {
+		compatible = "nxp,inputmux";
+		reg = <0x1000 0x1000>;
+		status = "disabled";
+		#mux-control-cells = <1>;
+		#mux-state-cells = <2>;
+	};
+
+	freqme0: freqme@9000 {
+		compatible = "nxp,freqme";
+		reg = <0x9000 0x10>;
+		interrupts = <54 0>;
+		clocks = <&syscon MCUX_FREQME_CLK>;
+		status = "disabled";
+
+		reference-sources {
+			ref-fro-hf-div {
+				default-source;
+				mux-states = <&inputmux0 0 NXP_FREQME_REF_FRO_HF_DIV>;
+				clocks = <&syscon MCUX_FRO_HF_DIV_CLK>;
+			};
+
+			ref-fro-12m {
+				mux-states = <&inputmux0 0 NXP_FREQME_REF_FRO_12M>;
+				clocks = <&syscon MCUX_FRO_12M_CLK>;
+			};
+		};
+
+		target-sources {
+			/*
+			 * Targets without a clocks / clock-frequency provider have an
+			 * unknown or board-specific rate: MEASURE only, no WINDOW
+			 * auto-derive. CLK_IN / CLK_IN0 / CLK_IN1 are external input
+			 * pins; SLOW_CLK is a divided clock whose rate varies.
+			 */
+			tar-fro-12m {
+				default-source;
+				mux-states = <&inputmux0 0 NXP_FREQME_TAR_FRO_12M>;
+				clocks = <&syscon MCUX_FRO_12M_CLK>;
+			};
+
+			tar-fro-hf-div {
+				mux-states = <&inputmux0 0 NXP_FREQME_TAR_FRO_HF_DIV>;
+				clocks = <&syscon MCUX_FRO_HF_DIV_CLK>;
+			};
+
+			tar-clk-in {
+				mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN>;
+			};
+
+			tar-clk-16k1 {
+				mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_16K1>;
+				clock-frequency = <16384>;
+			};
+
+			tar-slow-clk {
+				mux-states = <&inputmux0 0 NXP_FREQME_TAR_SLOW_CLK>;
+			};
+
+			tar-clk-in0 {
+				mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN0>;
+			};
+
+			tar-clk-in1 {
+				mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN1>;
+			};
 		};
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -8,6 +8,7 @@
 #include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
@@ -181,6 +182,71 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			nxp,kinetis-port = <&porte>;
+		};
+
+		freqme0: freqme@40009000 {
+			compatible = "nxp,freqme";
+			reg = <0x40009000 0x10>;
+			interrupts = <54 0>;
+			clocks = <&syscon MCUX_FREQME_CLK>;
+			status = "disabled";
+
+			reference-sources {
+				ref-fro-hf-div {
+					default-source;
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_REF_FRO_HF_DIV>;
+					clocks = <&syscon MCUX_FRO_HF_DIV_CLK>;
+				};
+
+				ref-fro-12m {
+					mux-states = <&inputmux0 0 NXP_FREQME_REF_FRO_12M>;
+					clocks = <&syscon MCUX_FRO_12M_CLK>;
+				};
+			};
+
+			target-sources {
+				/*
+				 * Targets without a clocks / clock-frequency provider have an
+				 * unknown or board-specific rate: MEASURE only, no WINDOW
+				 * auto-derive. CLK_IN / CLK_IN0 / CLK_IN1 are external input
+				 * pins; SLOW_CLK is a divided clock whose rate varies.
+				 */
+				tar-fro-12m {
+					default-source;
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_FRO_12M>;
+					clocks = <&syscon MCUX_FRO_12M_CLK>;
+				};
+
+				tar-fro-hf-div {
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_TAR_FRO_HF_DIV>;
+					clocks = <&syscon MCUX_FRO_HF_DIV_CLK>;
+				};
+
+				tar-clk-in {
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN>;
+				};
+
+				tar-clk-16k1 {
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_TAR_CLK_16K1>;
+					clock-frequency = <16384>;
+				};
+
+				tar-slow-clk {
+					mux-states = <&inputmux0 0
+						      NXP_FREQME_TAR_SLOW_CLK>;
+				};
+
+				tar-clk-in0 {
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN0>;
+				};
+
+				tar-clk-in1 {
+					mux-states = <&inputmux0 0 NXP_FREQME_TAR_CLK_IN1>;
+				};
+			};
 		};
 
 		lpuart0: lpuart@4009f000 {

--- a/dts/arm/nxp/mcx/nxp_mcxl.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl.dtsi
@@ -8,6 +8,7 @@
 #include <freq.h>
 #include <arm/armv8-m.dtsi>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
@@ -76,6 +77,81 @@
 		reset: reset {
 			compatible = "nxp,mrcc-reset";
 			#reset-cells = <1>;
+		};
+	};
+
+	inputmux0: inputmux@1000 {
+		compatible = "nxp,inputmux";
+		reg = <0x1000 0x1000>;
+		status = "disabled";
+		#mux-control-cells = <1>;
+		#mux-state-cells = <2>;
+	};
+
+	freqme0: freqme@9000 {
+		compatible = "nxp,freqme";
+		reg = <0x9000 0x10>;
+		interrupts = <54 0>;
+		clocks = <&syscon MCUX_FREQME_CLK>;
+		status = "disabled";
+
+		reference-sources {
+			ref-fro-hf-div {
+				default-source;
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXL_REF_FRO_HF_DIV>;
+				clocks = <&syscon MCUX_FRO_HF_DIV_CLK>;
+			};
+
+			ref-fro-12m {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXL_REF_FRO_12M>;
+				clocks = <&syscon MCUX_FRO_12M_CLK>;
+			};
+
+			ref-xtal32k {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXL_REF_XTAL32K>;
+				clock-frequency = <32768>;
+			};
+		};
+
+		target-sources {
+			/*
+			 * Targets without a clocks / clock-frequency provider are
+			 * MEASURE only (no WINDOW auto-derive): CLK_IN0 / CLK_IN1 are
+			 * external input pins; SLOW_CLK is a divided clock whose rate
+			 * varies.
+			 */
+			tar-fro-12m {
+				default-source;
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXL_TAR_FRO_12M>;
+				clocks = <&syscon MCUX_FRO_12M_CLK>;
+			};
+
+			tar-fro-hf-div {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXL_TAR_FRO_HF_DIV>;
+				clocks = <&syscon MCUX_FRO_HF_DIV_CLK>;
+			};
+
+			tar-xtal32k {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXL_TAR_XTAL32K>;
+				clock-frequency = <32768>;
+			};
+
+			tar-clk-16k0 {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXL_TAR_CLK_16K0>;
+				clock-frequency = <16384>;
+			};
+
+			tar-slow-clk {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXL_TAR_SLOW_CLK>;
+			};
+
+			tar-clk-in0 {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXL_TAR_CLK_IN0>;
+			};
+
+			tar-clk-in1 {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXL_TAR_CLK_IN1>;
+			};
 		};
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
@@ -7,6 +7,7 @@
 #include <mem.h>
 #include <freq.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
@@ -146,6 +147,87 @@
 		reset: reset {
 			compatible = "nxp,lpc-syscon-reset";
 			#reset-cells = <1>;
+		};
+	};
+
+	inputmux0: inputmux@6000 {
+		compatible = "nxp,inputmux";
+		reg = <0x6000 0x1000>;
+		status = "disabled";
+		#mux-control-cells = <1>;
+		#mux-state-cells = <2>;
+	};
+
+	freqme0: freqme@11000 {
+		compatible = "nxp,freqme";
+		reg = <0x11000 0x10>;
+		interrupts = <71 0>;
+		clocks = <&syscon MCUX_FREQME_CLK>;
+		status = "disabled";
+
+		reference-sources {
+			ref-cpu-ahb {
+				default-source;
+				mux-states = <&inputmux0 0
+					      NXP_FREQME_MCXN_REF_CPU_AHB_CLK>;
+				clocks = <&syscon MCUX_CPU_AHB_CLK>;
+			};
+
+			ref-fro-hf {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_REF_FRO_HF>;
+				clocks = <&syscon MCUX_FRO_HF_CLK>;
+			};
+
+			ref-fro-12m {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_REF_FRO_12M>;
+				clocks = <&syscon MCUX_FRO_12M_CLK>;
+			};
+
+			ref-osc32k {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_REF_OSC32K>;
+				clock-frequency = <32768>;
+			};
+		};
+
+		target-sources {
+			/*
+			 * Targets without a clocks / clock-frequency provider are
+			 * MEASURE only (no WINDOW auto-derive): CLK_IN / CLK_IN0 /
+			 * CLK_IN1 are external input pins.
+			 */
+			tar-fro-12m {
+				default-source;
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_TAR_FRO_12M>;
+				clocks = <&syscon MCUX_FRO_12M_CLK>;
+			};
+
+			tar-fro-hf {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_TAR_FRO_HF>;
+				clocks = <&syscon MCUX_FRO_HF_CLK>;
+			};
+
+			tar-clk-in {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_TAR_CLK_IN>;
+			};
+
+			tar-osc32k {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_TAR_OSC32K>;
+				clock-frequency = <32768>;
+			};
+
+			tar-cpu-ahb {
+				mux-states = <&inputmux0 0
+					      NXP_FREQME_MCXN_TAR_CPU_AHB_CLK>;
+				clocks = <&syscon MCUX_CPU_AHB_CLK>;
+			};
+
+			tar-clk-in0 {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_TAR_CLK_IN0>;
+			};
+
+			tar-clk-in1 {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_TAR_CLK_IN1>;
+			};
 		};
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
@@ -7,6 +7,7 @@
 #include <mem.h>
 #include <freq.h>
 #include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
 #include <zephyr/dt-bindings/reset/nxp_syscon_reset_common.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
@@ -139,6 +140,79 @@
 		status = "disabled";
 		#mux-control-cells = <1>;
 		#mux-state-cells = <2>;
+	};
+
+	freqme0: freqme@11000 {
+		compatible = "nxp,freqme";
+		reg = <0x11000 0x10>;
+		interrupts = <71 0>;
+		clocks = <&syscon MCUX_FREQME_CLK>;
+		status = "disabled";
+
+		reference-sources {
+			ref-cpu-ahb {
+				default-source;
+				mux-states = <&inputmux0 0
+					      NXP_FREQME_MCXN_REF_CPU_AHB_CLK>;
+				clocks = <&syscon MCUX_CPU_AHB_CLK>;
+			};
+
+			ref-fro-hf {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_REF_FRO_HF>;
+				clocks = <&syscon MCUX_FRO_HF_CLK>;
+			};
+
+			ref-fro-12m {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_REF_FRO_12M>;
+				clocks = <&syscon MCUX_FRO_12M_CLK>;
+			};
+
+			ref-osc32k {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_REF_OSC32K>;
+				clock-frequency = <32768>;
+			};
+		};
+
+		target-sources {
+			/*
+			 * Targets without a clocks / clock-frequency provider are
+			 * MEASURE only (no WINDOW auto-derive): CLK_IN / CLK_IN0 /
+			 * CLK_IN1 are external input pins.
+			 */
+			tar-fro-12m {
+				default-source;
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_TAR_FRO_12M>;
+				clocks = <&syscon MCUX_FRO_12M_CLK>;
+			};
+
+			tar-fro-hf {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_TAR_FRO_HF>;
+				clocks = <&syscon MCUX_FRO_HF_CLK>;
+			};
+
+			tar-clk-in {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_TAR_CLK_IN>;
+			};
+
+			tar-osc32k {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_TAR_OSC32K>;
+				clock-frequency = <32768>;
+			};
+
+			tar-cpu-ahb {
+				mux-states = <&inputmux0 0
+					      NXP_FREQME_MCXN_TAR_CPU_AHB_CLK>;
+				clocks = <&syscon MCUX_CPU_AHB_CLK>;
+			};
+
+			tar-clk-in0 {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_TAR_CLK_IN0>;
+			};
+
+			tar-clk-in1 {
+				mux-states = <&inputmux0 0 NXP_FREQME_MCXN_TAR_CLK_IN1>;
+			};
+		};
 	};
 
 	porta: pinmux@116000 {

--- a/dts/bindings/clock-monitor/nxp,freqme.yaml
+++ b/dts/bindings/clock-monitor/nxp,freqme.yaml
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  NXP Frequency Measurement (FREQME) module.
+
+  Measures a target clock against a reference clock and returns the result
+  in Hz. The reference and target inputs are routed through the INPUTMUX
+  peripheral. Exposed through the Zephyr clock_monitor API: MEASURE
+  (one-shot) and WINDOW (continuous MIN/MAX threshold) modes are both
+  supported, built on the FREQME frequency measurement operate mode.
+
+  Selectable clock sources are declared with two container child nodes,
+  "reference-sources" and "target-sources". Each container holds one child
+  node per selectable source, pairing an INPUTMUX route with a frequency
+  provider. The child marked "default-source" is the power-on selection.
+  clock_monitor_set_source() switches between the declared sources at
+  runtime, keyed by the INPUTMUX connection cookie (see inputmux-connection).
+
+  A source's frequency provider is either "clock-frequency" (a fixed
+  constant in Hz, used verbatim) or "clocks" (queried through
+  clock_control_get_rate()). When both are present "clock-frequency" wins
+  and "clocks" is ignored. A reference source must resolve to a nonzero
+  frequency; a target source only needs one for WINDOW auto-derive
+  (window.expected_hz == 0).
+
+  The driver does not enable the selected source clocks. The application must
+  ensure the chosen reference and target clocks are running before configure()/start();
+  a source left off simply measures zero edges and is reported as CLOCK_LOST.
+
+  Place NXP_FREQME_REF_* cookies in "reference-sources" and NXP_FREQME_TAR_*
+  cookies in "target-sources"; the axis is not checked at build time. See
+  <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>.
+
+compatible: "nxp,freqme"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+    description: |
+      NVIC interrupt for measurement-ready, over-range, and under-range events.
+
+  clocks:
+    required: true
+    description: |
+      The FREQME peripheral gate clock, enabled by the driver via
+      clock_control_on().
+
+child-binding:
+  description: |
+    Container for a set of selectable FREQME clock sources. Instantiated
+    twice per FREQME node, as "reference-sources" and "target-sources".
+
+  child-binding:
+    description: |
+      One selectable FREQME clock source: an INPUTMUX route paired with a
+      frequency provider. The source's status property is not consulted;
+      every child is a candidate source.
+
+    properties:
+      inputmux-connection:
+        type: phandle-array
+        specifier-space: inputmux
+        required: true
+        description: |
+          INPUTMUX route for this source, given as
+          <&inputmuxN channel connection> where:
+            - &inputmuxN is the INPUTMUX node providing the route
+            - channel is the destination index (0 for FREQME)
+            - connection is an inputmux_connection_t cookie from
+              fsl_inputmux_connections.h. Use the NXP_FREQME_REF_* /
+              NXP_FREQME_TAR_* macros in
+              <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>.
+          This cookie is also the runtime clock_monitor_set_source() selector
+          for this source.
+
+      clocks:
+        type: phandle-array
+        description: |
+          Frequency provider queried through clock_control_get_rate().
+          Ignored when clock-frequency is present.
+
+      clock-frequency:
+        type: int
+        description: |
+          Fixed frequency provider in Hz, used verbatim without querying
+          clock_control. Takes precedence over clocks. Use for sources whose
+          rate the clock_control driver cannot report (e.g. an external
+          crystal).
+
+      default-source:
+        type: boolean
+        description: |
+          Marks this source as the power-on selection for its container.
+          Exactly one child of each container must set it.

--- a/dts/bindings/clock-monitor/nxp,freqme.yaml
+++ b/dts/bindings/clock-monitor/nxp,freqme.yaml
@@ -15,7 +15,7 @@ description: |
   node per selectable source, pairing an INPUTMUX route with a frequency
   provider. The child marked "default-source" is the power-on selection.
   clock_monitor_set_source() switches between the declared sources at
-  runtime, keyed by the INPUTMUX connection cookie (see inputmux-connection).
+  runtime, keyed by the INPUTMUX connection cookie (see mux-states).
 
   A source's frequency provider is either "clock-frequency" (a fixed
   constant in Hz, used verbatim) or "clocks" (queried through
@@ -62,22 +62,23 @@ child-binding:
       frequency provider. The source's status property is not consulted;
       every child is a candidate source.
 
+    include: [mux-consumer.yaml]
+
     properties:
-      inputmux-connection:
-        type: phandle-array
-        specifier-space: inputmux
+      mux-states:
         required: true
         description: |
-          INPUTMUX route for this source, given as
-          <&inputmuxN channel connection> where:
-            - &inputmuxN is the INPUTMUX node providing the route
-            - channel is the destination index (0 for FREQME)
+          INPUTMUX route for this source, given as a single mux-states
+          entry <&inputmuxN index connection> where:
+            - &inputmuxN is the INPUTMUX mux controller providing the route
+            - index is the destination index (0 for FREQME)
             - connection is an inputmux_connection_t cookie from
               fsl_inputmux_connections.h. Use the NXP_FREQME_REF_* /
               NXP_FREQME_TAR_* macros in
               <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>.
-          This cookie is also the runtime clock_monitor_set_source() selector
-          for this source.
+          The route is applied through the mux subsystem (mux_state_apply()).
+          The connection cookie is also the runtime
+          clock_monitor_set_source() selector for this source.
 
       clocks:
         type: phandle-array

--- a/include/zephyr/dt-bindings/clock-monitor/nxp-freqme.h
+++ b/include/zephyr/dt-bindings/clock-monitor/nxp-freqme.h
@@ -1,0 +1,185 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MONITOR_NXP_FREQME_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MONITOR_NXP_FREQME_H_
+
+/**
+ * @file
+ * @brief INPUTMUX connection cookies for NXP FREQME reference / target routing.
+ *
+ * The numeric values mirror the inputmux_connection_t enum in each device's
+ * MCUX HAL header fsl_inputmux_connections.h:
+ *
+ *   cookie = selector + (destination_register << PMUX_SHIFT)
+ *
+ * PMUX_SHIFT is 20 on every FREQME-capable SoC. The destination register and
+ * the per-source selector numbers depend on the SoC family, so the cookies are
+ * grouped by family below and each group lists the devices it applies to. The
+ * device tree and driver simply attach the cookie; the hardware routes it to
+ * the encoded register.
+ */
+
+/** Bit position of the destination mux register within a connection cookie. */
+#define NXP_FREQME_PMUX_SHIFT 20
+
+/**
+ * @brief set_source() sentinel: leave that axis (reference or target) unchanged.
+ *
+ * A real INPUTMUX connection cookie is always nonzero: it always carries a
+ * destination-register field (0x180/0x184 on MCX, 0x700/0x704 on RT7xx) in its
+ * upper bits, so 0 is free to mean "no change" for the NXP FREQME
+ * clock_monitor_set_source() back-end. The public clock_monitor API does not
+ * define a generic sentinel; this constant is FREQME-private.
+ */
+#define NXP_FREQME_SOURCE_UNCHANGED 0U
+
+/*
+ * MCX families with separate FREQMEAS_REF (0x180) / FREQMEAS_TAR (0x184) mux
+ * registers. MCXA, MCXC, MCXN, MCXL and MCXW all share this register layout;
+ * only the per-source selector numbers differ, so each family has its own
+ * cookie set below.
+ */
+
+/** FREQMEAS reference mux register offset (MCXA/MCXC/MCXN/MCXL/MCXW). */
+#define NXP_FREQME_REF_REG 0x180
+/** FREQMEAS target mux register offset (MCXA/MCXC/MCXN/MCXL/MCXW). */
+#define NXP_FREQME_TAR_REG 0x184
+
+/** Build an MCX reference-route cookie from selector @p sel. */
+#define NXP_FREQME_REF(sel) ((sel) + (NXP_FREQME_REF_REG << NXP_FREQME_PMUX_SHIFT))
+/** Build an MCX target-route cookie from selector @p sel. */
+#define NXP_FREQME_TAR(sel) ((sel) + (NXP_FREQME_TAR_REG << NXP_FREQME_PMUX_SHIFT))
+
+/*
+ * MCXA selectors.
+ * Devices: MCXA153, MCXA156, MCXA174, MCXA266, MCXA344, MCXA346, MCXA577 and
+ *          MCXC162 (identical selector numbering).
+ */
+#define NXP_FREQME_REF_CLK_IN      NXP_FREQME_REF(1) /**< MCXA/MCXC reference: CLK_IN. */
+#define NXP_FREQME_REF_FRO_12M     NXP_FREQME_REF(2) /**< MCXA/MCXC reference: 12 MHz FRO. */
+#define NXP_FREQME_REF_FRO_HF_DIV  NXP_FREQME_REF(3) /**< MCXA/MCXC reference: FRO_HF divided. */
+#define NXP_FREQME_REF_CLK_16K1    NXP_FREQME_REF(5) /**< MCXA/MCXC reference: 16 kHz CLK_16K1. */
+#define NXP_FREQME_REF_SLOW_CLK    NXP_FREQME_REF(6) /**< MCXA/MCXC reference: slow clock. */
+#define NXP_FREQME_REF_CLK_IN0     NXP_FREQME_REF(7) /**< MCXA/MCXC reference: CLK_IN0. */
+#define NXP_FREQME_REF_CLK_IN1     NXP_FREQME_REF(8) /**< MCXA/MCXC reference: CLK_IN1. */
+
+#define NXP_FREQME_TAR_CLK_IN      NXP_FREQME_TAR(1) /**< MCXA/MCXC target: CLK_IN. */
+#define NXP_FREQME_TAR_FRO_12M     NXP_FREQME_TAR(2) /**< MCXA/MCXC target: 12 MHz FRO. */
+#define NXP_FREQME_TAR_FRO_HF_DIV  NXP_FREQME_TAR(3) /**< MCXA/MCXC target: FRO_HF divided. */
+#define NXP_FREQME_TAR_CLK_16K1    NXP_FREQME_TAR(5) /**< MCXA/MCXC target: 16 kHz CLK_16K1. */
+#define NXP_FREQME_TAR_SLOW_CLK    NXP_FREQME_TAR(6) /**< MCXA/MCXC target: slow clock. */
+#define NXP_FREQME_TAR_CLK_IN0     NXP_FREQME_TAR(7) /**< MCXA/MCXC target: CLK_IN0. */
+#define NXP_FREQME_TAR_CLK_IN1     NXP_FREQME_TAR(8) /**< MCXA/MCXC target: CLK_IN1. */
+
+/*
+ * MCXN selectors.
+ * Devices: MCXN236, MCXN947.
+ */
+#define NXP_FREQME_MCXN_REF_CLK_IN       NXP_FREQME_REF(0) /**< MCXN reference: CLK_IN. */
+#define NXP_FREQME_MCXN_REF_FRO_12M      NXP_FREQME_REF(1) /**< MCXN reference: 12 MHz FRO. */
+#define NXP_FREQME_MCXN_REF_FRO_HF       NXP_FREQME_REF(2) /**< MCXN reference: FRO_HF. */
+#define NXP_FREQME_MCXN_REF_OSC32K       NXP_FREQME_REF(4) /**< MCXN reference: 32 kHz OSC. */
+#define NXP_FREQME_MCXN_REF_CPU_AHB_CLK  NXP_FREQME_REF(5) /**< MCXN reference: CPU/AHB clock. */
+#define NXP_FREQME_MCXN_REF_CLK_IN0      NXP_FREQME_REF(6) /**< MCXN reference: CLK_IN0. */
+#define NXP_FREQME_MCXN_REF_CLK_IN1      NXP_FREQME_REF(7) /**< MCXN reference: CLK_IN1. */
+
+#define NXP_FREQME_MCXN_TAR_CLK_IN       NXP_FREQME_TAR(0) /**< MCXN target: CLK_IN. */
+#define NXP_FREQME_MCXN_TAR_FRO_12M      NXP_FREQME_TAR(1) /**< MCXN target: 12 MHz FRO. */
+#define NXP_FREQME_MCXN_TAR_FRO_HF       NXP_FREQME_TAR(2) /**< MCXN target: FRO_HF. */
+#define NXP_FREQME_MCXN_TAR_OSC32K       NXP_FREQME_TAR(4) /**< MCXN target: 32 kHz OSC. */
+#define NXP_FREQME_MCXN_TAR_CPU_AHB_CLK  NXP_FREQME_TAR(5) /**< MCXN target: CPU/AHB clock. */
+#define NXP_FREQME_MCXN_TAR_CLK_IN0      NXP_FREQME_TAR(6) /**< MCXN target: CLK_IN0. */
+#define NXP_FREQME_MCXN_TAR_CLK_IN1      NXP_FREQME_TAR(7) /**< MCXN target: CLK_IN1. */
+
+/*
+ * MCXL selectors.
+ * Devices: MCXL255.
+ */
+#define NXP_FREQME_MCXL_REF_FRO_12M     NXP_FREQME_REF(2) /**< MCXL reference: 12 MHz FRO. */
+#define NXP_FREQME_MCXL_REF_FRO_HF_DIV  NXP_FREQME_REF(3) /**< MCXL reference: FRO_HF divided. */
+#define NXP_FREQME_MCXL_REF_XTAL32K     NXP_FREQME_REF(4) /**< MCXL reference: 32 kHz crystal. */
+#define NXP_FREQME_MCXL_REF_CLK_16K0    NXP_FREQME_REF(5) /**< MCXL reference: 16 kHz CLK_16K0. */
+#define NXP_FREQME_MCXL_REF_SLOW_CLK    NXP_FREQME_REF(6) /**< MCXL reference: slow clock. */
+#define NXP_FREQME_MCXL_REF_CLK_IN0     NXP_FREQME_REF(7) /**< MCXL reference: CLK_IN0. */
+#define NXP_FREQME_MCXL_REF_CLK_IN1     NXP_FREQME_REF(8) /**< MCXL reference: CLK_IN1. */
+
+#define NXP_FREQME_MCXL_TAR_FRO_12M     NXP_FREQME_TAR(2) /**< MCXL target: 12 MHz FRO. */
+#define NXP_FREQME_MCXL_TAR_FRO_HF_DIV  NXP_FREQME_TAR(3) /**< MCXL target: FRO_HF divided. */
+#define NXP_FREQME_MCXL_TAR_XTAL32K     NXP_FREQME_TAR(4) /**< MCXL target: 32 kHz crystal. */
+#define NXP_FREQME_MCXL_TAR_CLK_16K0    NXP_FREQME_TAR(5) /**< MCXL target: 16 kHz CLK_16K0. */
+#define NXP_FREQME_MCXL_TAR_SLOW_CLK    NXP_FREQME_TAR(6) /**< MCXL target: slow clock. */
+#define NXP_FREQME_MCXL_TAR_CLK_IN0     NXP_FREQME_TAR(7) /**< MCXL target: CLK_IN0. */
+#define NXP_FREQME_MCXL_TAR_CLK_IN1     NXP_FREQME_TAR(8) /**< MCXL target: CLK_IN1. */
+
+/*
+ * MCXW selectors.
+ * Devices: MCXW236. A completely distinct selector set.
+ */
+#define NXP_FREQME_MCXW_REF_EXTERN_OSC   NXP_FREQME_REF(0)  /**< MCXW reference: external OSC. */
+#define NXP_FREQME_MCXW_REF_FRO_12M      NXP_FREQME_REF(1)  /**< MCXW reference: 12 MHz FRO. */
+#define NXP_FREQME_MCXW_REF_FRO_32M      NXP_FREQME_REF(2)  /**< MCXW reference: 32 MHz FRO. */
+#define NXP_FREQME_MCXW_REF_FRO_1M       NXP_FREQME_REF(3)  /**< MCXW reference: 1 MHz FRO. */
+#define NXP_FREQME_MCXW_REF_OSC32K       NXP_FREQME_REF(4)  /**< MCXW reference: 32 kHz OSC. */
+#define NXP_FREQME_MCXW_REF_MAIN_CLK     NXP_FREQME_REF(5)  /**< MCXW reference: main clock. */
+#define NXP_FREQME_MCXW_REF_SPIFI_CLK    NXP_FREQME_REF(6)  /**< MCXW reference: SPIFI clock. */
+#define NXP_FREQME_MCXW_REF_PORT0_PIN3   NXP_FREQME_REF(7)  /**< MCXW reference: PORT0 pin 3. */
+#define NXP_FREQME_MCXW_REF_PORT0_PIN11  NXP_FREQME_REF(8)  /**< MCXW reference: PORT0 pin 11. */
+#define NXP_FREQME_MCXW_REF_PORT0_PIN12  NXP_FREQME_REF(9)  /**< MCXW reference: PORT0 pin 12. */
+#define NXP_FREQME_MCXW_REF_PORT0_PIN14  NXP_FREQME_REF(10) /**< MCXW reference: PORT0 pin 14. */
+
+#define NXP_FREQME_MCXW_TAR_EXTERN_OSC   NXP_FREQME_TAR(0)  /**< MCXW target: external OSC. */
+#define NXP_FREQME_MCXW_TAR_FRO_12M      NXP_FREQME_TAR(1)  /**< MCXW target: 12 MHz FRO. */
+#define NXP_FREQME_MCXW_TAR_FRO_32M      NXP_FREQME_TAR(2)  /**< MCXW target: 32 MHz FRO. */
+#define NXP_FREQME_MCXW_TAR_FRO_1M       NXP_FREQME_TAR(3)  /**< MCXW target: 1 MHz FRO. */
+#define NXP_FREQME_MCXW_TAR_OSC32K       NXP_FREQME_TAR(4)  /**< MCXW target: 32 kHz OSC. */
+#define NXP_FREQME_MCXW_TAR_MAIN_CLK     NXP_FREQME_TAR(5)  /**< MCXW target: main clock. */
+#define NXP_FREQME_MCXW_TAR_SPIFI_CLK    NXP_FREQME_TAR(6)  /**< MCXW target: SPIFI clock. */
+#define NXP_FREQME_MCXW_TAR_PORT0_PIN3   NXP_FREQME_TAR(7)  /**< MCXW target: PORT0 pin 3. */
+#define NXP_FREQME_MCXW_TAR_PORT0_PIN11  NXP_FREQME_TAR(8)  /**< MCXW target: PORT0 pin 11. */
+#define NXP_FREQME_MCXW_TAR_PORT0_PIN12  NXP_FREQME_TAR(9)  /**< MCXW target: PORT0 pin 12. */
+#define NXP_FREQME_MCXW_TAR_PORT0_PIN14  NXP_FREQME_TAR(10) /**< MCXW target: PORT0 pin 14. */
+
+/*
+ * i.MX RT700 selectors.
+ * Devices: MIMXRT798S (and RT7xx family).
+ *
+ * RT700 places the FREQMEAS reference / target mux registers at 0x700 / 0x704
+ * (not 0x180 / 0x184 like the MCX families), so it needs its own register
+ * constants and helpers.
+ */
+
+/** FREQMEAS reference mux register offset (i.MX RT7xx). */
+#define NXP_FREQME_RT7XX_REF_REG 0x700
+/** FREQMEAS target mux register offset (i.MX RT7xx). */
+#define NXP_FREQME_RT7XX_TAR_REG 0x704
+
+/** Build an RT7xx reference-route cookie from selector @p sel. */
+#define NXP_FREQME_RT7XX_REF(sel) ((sel) + (NXP_FREQME_RT7XX_REF_REG << NXP_FREQME_PMUX_SHIFT))
+/** Build an RT7xx target-route cookie from selector @p sel. */
+#define NXP_FREQME_RT7XX_TAR(sel) ((sel) + (NXP_FREQME_RT7XX_TAR_REG << NXP_FREQME_PMUX_SHIFT))
+
+#define NXP_FREQME_RT7XX_REF_OSC_CLK     NXP_FREQME_RT7XX_REF(0) /**< RT7xx ref: system OSC. */
+#define NXP_FREQME_RT7XX_REF_FRO1_DIV8   NXP_FREQME_RT7XX_REF(1) /**< RT7xx ref: FRO1 / 8. */
+#define NXP_FREQME_RT7XX_REF_FRO1        NXP_FREQME_RT7XX_REF(2) /**< RT7xx ref: FRO1. */
+#define NXP_FREQME_RT7XX_REF_LPOSC       NXP_FREQME_RT7XX_REF(3) /**< RT7xx ref: low-power OSC. */
+#define NXP_FREQME_RT7XX_REF_OSC32K      NXP_FREQME_RT7XX_REF(4) /**< RT7xx ref: 32 kHz OSC. */
+#define NXP_FREQME_RT7XX_REF_FRO0        NXP_FREQME_RT7XX_REF(6) /**< RT7xx ref: FRO0. */
+#define NXP_FREQME_RT7XX_REF_FRO2        NXP_FREQME_RT7XX_REF(7) /**< RT7xx ref: FRO2. */
+#define NXP_FREQME_RT7XX_REF_GPIO_A_CLK  NXP_FREQME_RT7XX_REF(8) /**< RT7xx ref: GPIO A clock. */
+#define NXP_FREQME_RT7XX_REF_GPIO_B_CLK  NXP_FREQME_RT7XX_REF(9) /**< RT7xx ref: GPIO B clock. */
+
+#define NXP_FREQME_RT7XX_TAR_OSC_CLK     NXP_FREQME_RT7XX_TAR(0) /**< RT7xx tar: system OSC. */
+#define NXP_FREQME_RT7XX_TAR_FRO1_DIV8   NXP_FREQME_RT7XX_TAR(1) /**< RT7xx tar: FRO1 / 8. */
+#define NXP_FREQME_RT7XX_TAR_FRO1        NXP_FREQME_RT7XX_TAR(2) /**< RT7xx tar: FRO1. */
+#define NXP_FREQME_RT7XX_TAR_LPOSC       NXP_FREQME_RT7XX_TAR(3) /**< RT7xx tar: low-power OSC. */
+#define NXP_FREQME_RT7XX_TAR_OSC32K      NXP_FREQME_RT7XX_TAR(4) /**< RT7xx tar: 32 kHz OSC. */
+#define NXP_FREQME_RT7XX_TAR_FRO0        NXP_FREQME_RT7XX_TAR(6) /**< RT7xx tar: FRO0. */
+#define NXP_FREQME_RT7XX_TAR_FRO2        NXP_FREQME_RT7XX_TAR(7) /**< RT7xx tar: FRO2. */
+#define NXP_FREQME_RT7XX_TAR_GPIO_A_CLK  NXP_FREQME_RT7XX_TAR(8) /**< RT7xx tar: GPIO A clock. */
+#define NXP_FREQME_RT7XX_TAR_GPIO_B_CLK  NXP_FREQME_RT7XX_TAR(9) /**< RT7xx tar: GPIO B clock. */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MONITOR_NXP_FREQME_H_ */

--- a/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -241,4 +241,22 @@
 /** PowerQuad DSP coprocessor clock identifier. */
 #define MCUX_POWERQUAD_CLK MCUX_LPC_CLK_ID(0x39, 0x00)
 
+/** FRO high-frequency clock (FRO_HF) rate identifier. */
+#define MCUX_FRO_HF_CLK MCUX_LPC_CLK_ID(0x40, 0x00)
+
+/** FRO_HF divided output (FRO_HF_DIV) rate identifier. */
+#define MCUX_FRO_HF_DIV_CLK MCUX_LPC_CLK_ID(0x41, 0x00)
+
+/** FRO 12 MHz clock (FRO_12M) rate identifier. */
+#define MCUX_FRO_12M_CLK MCUX_LPC_CLK_ID(0x42, 0x00)
+
+/** FREQME peripheral gate clock identifier. */
+#define MCUX_FREQME_CLK MCUX_LPC_CLK_ID(0x43, 0x00)
+
+/** CPU / AHB (core system) clock rate identifier. */
+#define MCUX_CPU_AHB_CLK MCUX_LPC_CLK_ID(0x44, 0x00)
+
+/** External (system oscillator / CLK_IN) clock rate identifier. */
+#define MCUX_EXT_CLK MCUX_LPC_CLK_ID(0x45, 0x00)
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MCUX_LPC_SYSCON_H_ */

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -181,6 +181,7 @@ set_variable_ifdef(CONFIG_CRC_DRIVER_NXP        CONFIG_MCUX_COMPONENT_driver.crc
 set_variable_ifdef(CONFIG_CRC_DRIVER_NXP_LPC    CONFIG_MCUX_COMPONENT_driver.lpc_crc)
 set_variable_ifdef(CONFIG_CLOCK_MONITOR_NXP_CMU_FC CONFIG_MCUX_COMPONENT_driver.cmu_fc)
 set_variable_ifdef(CONFIG_CLOCK_MONITOR_NXP_CMU_FM CONFIG_MCUX_COMPONENT_driver.cmu_fm)
+set_variable_ifdef(CONFIG_CLOCK_MONITOR_NXP_FREQME CONFIG_MCUX_COMPONENT_driver.lpc_freqme)
 set_variable_ifdef(CONFIG_PHY_NXP_T1S           CONFIG_MCUX_COMPONENT_driver.tenbaset_phy)
 set_variable_ifdef(CONFIG_AUXDISPLAY_NXP_SLCD CONFIG_MCUX_COMPONENT_driver.slcd)
 

--- a/samples/drivers/clock_monitor/check_freq/CMakeLists.txt
+++ b/samples/drivers/clock_monitor/check_freq/CMakeLists.txt
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.28.0)
+# Shared bindings for the sample-local "clock-monitor-required-clocks" node.
+list(APPEND DTS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(clock_monitor_check_freq)
 

--- a/samples/drivers/clock_monitor/check_freq/boards/frdm_mcxn236.overlay
+++ b/samples/drivers/clock_monitor/check_freq/boards/frdm_mcxn236.overlay
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+
+/ {
+	clock-monitor-required-clocks {
+		compatible = "clock-monitor-required-clocks";
+		clocks = <&syscon MCUX_FRO_12M_CLK>,
+			 <&syscon MCUX_FRO_HF_CLK>;
+	};
+};

--- a/samples/drivers/clock_monitor/check_freq/boards/mcx_n5xx_evk_mcxn547_cpu0.overlay
+++ b/samples/drivers/clock_monitor/check_freq/boards/mcx_n5xx_evk_mcxn547_cpu0.overlay
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+
+/ {
+	clock-monitor-required-clocks {
+		compatible = "clock-monitor-required-clocks";
+		clocks = <&syscon MCUX_FRO_12M_CLK>,
+			 <&syscon MCUX_FRO_HF_CLK>;
+	};
+};

--- a/samples/drivers/clock_monitor/check_freq/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
+++ b/samples/drivers/clock_monitor/check_freq/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+
+/ {
+	clock-monitor-required-clocks {
+		compatible = "clock-monitor-required-clocks";
+		clocks = <&syscon MCUX_FRO_12M_CLK>,
+			 <&syscon MCUX_FRO_HF_CLK>;
+	};
+};

--- a/samples/drivers/clock_monitor/check_freq/src/main.c
+++ b/samples/drivers/clock_monitor/check_freq/src/main.c
@@ -16,6 +16,7 @@
 #include <errno.h>
 
 #include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_monitor.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -24,6 +25,38 @@
 LOG_MODULE_REGISTER(sample, LOG_LEVEL_INF);
 
 #define MONITOR DEVICE_DT_GET(DT_ALIAS(clock_monitor))
+
+/* Enable the clocks a board declares in its clock-monitor-required-clocks node. */
+#if DT_HAS_COMPAT_STATUS_OKAY(clock_monitor_required_clocks)
+
+#define REQUIRED_CLOCK_ON(node_id, prop, idx)                                  \
+	do {                                                                   \
+		const struct device *_clk =                                    \
+			DEVICE_DT_GET(DT_CLOCKS_CTLR_BY_IDX(node_id, idx));    \
+		if (device_is_ready(_clk)) {                                   \
+			(void)clock_control_on(_clk,                           \
+				(clock_control_subsys_t)(uintptr_t)            \
+				DT_CLOCKS_CELL_BY_IDX(node_id, idx, name));    \
+		}                                                              \
+	} while (0)
+
+static void enable_required_clocks(void)
+{
+	DT_FOREACH_PROP_ELEM_SEP(
+		DT_COMPAT_GET_ANY_STATUS_OKAY(clock_monitor_required_clocks),
+		clocks, REQUIRED_CLOCK_ON, (;));
+}
+
+#else
+
+/*
+ * No clock-monitor-required-clocks node on this board, so there are no
+ * source clocks to bring up. Provide an empty stub so the call site in
+ * main() stays unconditional.
+ */
+static void enable_required_clocks(void) {}
+
+#endif
 
 /*
  * Tunable parameters come straight from Kconfig
@@ -55,6 +88,9 @@ int main(void)
 		LOG_ERR("%s is not ready", dev->name);
 		return -ENODEV;
 	}
+
+	/* Ensure any board-declared source clocks are running before configuring. */
+	enable_required_clocks();
 
 	struct clock_monitor_config cfg = {
 		.mode = CLOCK_MONITOR_MODE_WINDOW,

--- a/samples/drivers/clock_monitor/check_freq/tests.yaml
+++ b/samples/drivers/clock_monitor/check_freq/tests.yaml
@@ -9,15 +9,32 @@ sample:
 
     The expected frequency, tolerance and measurement window are all
     Kconfig-tunable (see Kconfig in this sample).
+common:
+  tags:
+    - drivers
+    - clock_monitor
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "heartbeat: clock check running"
 tests:
   sample.drivers.clock_monitor.check_freq:
     platform_allow:
       - frdm_mcxe31b
-    tags:
-      - drivers
-      - clock_monitor
-    harness: console
-    harness_config:
-      type: one_line
-      regex:
-        - "heartbeat: clock check running"
+
+  sample.drivers.clock_monitor.check_freq.freqme:
+    platform_allow:
+      - frdm_mcxa153
+      - frdm_mcxa156
+      - frdm_mcxa344
+      - frdm_mcxa266
+      - frdm_mcxa366
+      - frdm_mcxa577
+      - frdm_mcxn236
+      - mcx_n5xx_evk/mcxn547/cpu0
+      - mcx_n9xx_evk/mcxn947/cpu0
+      - frdm_mcxl255/mcxl255/cpu0
+      - mimxrt700_evk/mimxrt798s/cm33_cpu0
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="../clock_monitor.overlay"

--- a/samples/drivers/clock_monitor/clock_monitor.overlay
+++ b/samples/drivers/clock_monitor/clock_monitor.overlay
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* freqme0 is enabled and fully configured (clocks, INPUTMUX routing) at the
+ * SoC / board devicetree level on every FREQME-capable board; this just
+ * adds the aliases the clock_monitor samples look up. Shared by check_freq
+ * and measure_freq via EXTRA_DTC_OVERLAY_FILE so neither sample duplicates
+ * this overlay.
+ */
+
+/ {
+	aliases {
+		clock-monitor = &freqme0;
+		clock-meter = &freqme0;
+	};
+};

--- a/samples/drivers/clock_monitor/dts/bindings/clock-monitor-required-clocks.yaml
+++ b/samples/drivers/clock_monitor/dts/bindings/clock-monitor-required-clocks.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: Clocks a clock_monitor sample enables at startup.
+
+compatible: "clock-monitor-required-clocks"
+
+properties:
+  clocks:
+    type: phandle-array
+    required: true
+    description: Clocks to enable at startup.

--- a/samples/drivers/clock_monitor/measure_freq/CMakeLists.txt
+++ b/samples/drivers/clock_monitor/measure_freq/CMakeLists.txt
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.28.0)
+# Shared bindings for the sample-local "clock-monitor-required-clocks" node.
+list(APPEND DTS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(clock_monitor_measure_freq)
 

--- a/samples/drivers/clock_monitor/measure_freq/boards/frdm_mcxn236.overlay
+++ b/samples/drivers/clock_monitor/measure_freq/boards/frdm_mcxn236.overlay
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+
+/ {
+	clock-monitor-required-clocks {
+		compatible = "clock-monitor-required-clocks";
+		clocks = <&syscon MCUX_FRO_12M_CLK>,
+			 <&syscon MCUX_FRO_HF_CLK>;
+	};
+};

--- a/samples/drivers/clock_monitor/measure_freq/boards/mcx_n5xx_evk_mcxn547_cpu0.overlay
+++ b/samples/drivers/clock_monitor/measure_freq/boards/mcx_n5xx_evk_mcxn547_cpu0.overlay
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+
+/ {
+	clock-monitor-required-clocks {
+		compatible = "clock-monitor-required-clocks";
+		clocks = <&syscon MCUX_FRO_12M_CLK>,
+			 <&syscon MCUX_FRO_HF_CLK>;
+	};
+};

--- a/samples/drivers/clock_monitor/measure_freq/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
+++ b/samples/drivers/clock_monitor/measure_freq/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+
+/ {
+	clock-monitor-required-clocks {
+		compatible = "clock-monitor-required-clocks";
+		clocks = <&syscon MCUX_FRO_12M_CLK>,
+			 <&syscon MCUX_FRO_HF_CLK>;
+	};
+};

--- a/samples/drivers/clock_monitor/measure_freq/src/main.c
+++ b/samples/drivers/clock_monitor/measure_freq/src/main.c
@@ -21,6 +21,7 @@
 #include <errno.h>
 
 #include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_monitor.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -29,6 +30,38 @@
 LOG_MODULE_REGISTER(sample, LOG_LEVEL_INF);
 
 #define MEASURE_DEV DEVICE_DT_GET(DT_ALIAS(clock_meter))
+
+/* Enable the clocks a board declares in its clock-monitor-required-clocks node. */
+#if DT_HAS_COMPAT_STATUS_OKAY(clock_monitor_required_clocks)
+
+#define REQUIRED_CLOCK_ON(node_id, prop, idx)                                  \
+	do {                                                                   \
+		const struct device *_clk =                                    \
+			DEVICE_DT_GET(DT_CLOCKS_CTLR_BY_IDX(node_id, idx));    \
+		if (device_is_ready(_clk)) {                                   \
+			(void)clock_control_on(_clk,                           \
+				(clock_control_subsys_t)(uintptr_t)            \
+				DT_CLOCKS_CELL_BY_IDX(node_id, idx, name));    \
+		}                                                              \
+	} while (0)
+
+static void enable_required_clocks(void)
+{
+	DT_FOREACH_PROP_ELEM_SEP(
+		DT_COMPAT_GET_ANY_STATUS_OKAY(clock_monitor_required_clocks),
+		clocks, REQUIRED_CLOCK_ON, (;));
+}
+
+#else
+
+/*
+ * No clock-monitor-required-clocks node on this board, so there are no
+ * source clocks to bring up. Provide an empty stub so the call site in
+ * main() stays unconditional.
+ */
+static void enable_required_clocks(void) {}
+
+#endif
 
 static K_SEM_DEFINE(measure_done, 0, 1);
 
@@ -53,6 +86,9 @@ int main(void)
 		LOG_ERR("%s is not ready", dev->name);
 		return -ENODEV;
 	}
+
+	/* Ensure any board-declared source clocks are running before configuring. */
+	enable_required_clocks();
 
 	struct clock_monitor_config cfg = {
 		.mode = CLOCK_MONITOR_MODE_MEASURE,

--- a/samples/drivers/clock_monitor/measure_freq/tests.yaml
+++ b/samples/drivers/clock_monitor/measure_freq/tests.yaml
@@ -6,15 +6,32 @@ sample:
     once, logging the result in Hz. Demonstrates the start -> callback
     -> semaphore wait pattern with application-owned timeout handling.
 
+common:
+  tags:
+    - drivers
+    - clock_monitor
+  harness: console
+  harness_config:
+    type: one_line
+    regex:
+      - "Measured frequency = \\d+ Hz"
 tests:
   sample.drivers.clock_monitor.measure_freq:
     platform_allow:
       - frdm_mcxe31b
-    tags:
-      - drivers
-      - clock_monitor
-    harness: console
-    harness_config:
-      type: one_line
-      regex:
-        - "Measured frequency = \\d+ Hz"
+
+  sample.drivers.clock_monitor.measure_freq.freqme:
+    platform_allow:
+      - frdm_mcxa153
+      - frdm_mcxa156
+      - frdm_mcxa344
+      - frdm_mcxa266
+      - frdm_mcxa366
+      - frdm_mcxa577
+      - frdm_mcxn236
+      - mcx_n5xx_evk/mcxn547/cpu0
+      - mcx_n9xx_evk/mcxn947/cpu0
+      - frdm_mcxl255/mcxl255/cpu0
+      - mimxrt700_evk/mimxrt798s/cm33_cpu0
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="../clock_monitor.overlay"

--- a/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxa153.overlay
+++ b/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxa153.overlay
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* freqme0 is enabled and fully configured (clocks, INPUTMUX routing) at the
+ * SoC / board devicetree level; the test only supplies the fixture node.
+ * freqme0 supports both WINDOW and MEASURE, so it is listed once.
+ */
+
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
+
+/ {
+	clock-monitor-test {
+		compatible = "test-clock-monitor";
+
+		freqme {
+			monitor = <&freqme0>;
+			measure-expected-hz = <12000000>;
+			/* set_source() test: switch reference to FRO_12M (target
+			 * stays FRO_12M, ~12 MHz), then target to FRO_HF_DIV
+			 * (~96 MHz).
+			 */
+			switch-reference = <NXP_FREQME_REF_FRO_12M>;
+			switch-target = <NXP_FREQME_TAR_FRO_HF_DIV>;
+			switch-target-expected-hz = <96000000>;
+		};
+	};
+};

--- a/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxa156.overlay
+++ b/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxa156.overlay
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* freqme0 is enabled and fully configured (clocks, INPUTMUX routing) at the
+ * SoC / board devicetree level; the test only supplies the fixture node.
+ * freqme0 supports both WINDOW and MEASURE, so it is listed once.
+ */
+
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
+
+/ {
+	clock-monitor-test {
+		compatible = "test-clock-monitor";
+
+		freqme {
+			monitor = <&freqme0>;
+			measure-expected-hz = <12000000>;
+			/* set_source() test: switch reference to FRO_12M (target
+			 * stays FRO_12M, ~12 MHz), then target to FRO_HF_DIV
+			 * (96 MHz: FRO_HF 96 MHz / FROHFDIV 1, per board.c).
+			 */
+			switch-reference = <NXP_FREQME_REF_FRO_12M>;
+			switch-target = <NXP_FREQME_TAR_FRO_HF_DIV>;
+			switch-target-expected-hz = <96000000>;
+		};
+	};
+};

--- a/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxa266.overlay
+++ b/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxa266.overlay
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* freqme0 is enabled and fully configured (clocks, INPUTMUX routing) at the
+ * SoC / board devicetree level; the test only supplies the fixture node.
+ * freqme0 supports both WINDOW and MEASURE, so it is listed once.
+ */
+
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
+
+/ {
+	clock-monitor-test {
+		compatible = "test-clock-monitor";
+
+		freqme {
+			monitor = <&freqme0>;
+			measure-expected-hz = <12000000>;
+			/* set_source() test: switch reference to FRO_12M (target
+			 * stays FRO_12M, ~12 MHz), then target to FRO_HF_DIV
+			 * (~180 MHz, measured on this board).
+			 */
+			switch-reference = <NXP_FREQME_REF_FRO_12M>;
+			switch-target = <NXP_FREQME_TAR_FRO_HF_DIV>;
+			switch-target-expected-hz = <180000000>;
+		};
+	};
+};

--- a/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxa344.overlay
+++ b/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxa344.overlay
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* freqme0 is enabled and fully configured (clocks, INPUTMUX routing) at the
+ * SoC / board devicetree level; the test only supplies the fixture node.
+ * freqme0 supports both WINDOW and MEASURE, so it is listed once.
+ */
+
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
+
+/ {
+	clock-monitor-test {
+		compatible = "test-clock-monitor";
+
+		freqme {
+			monitor = <&freqme0>;
+			measure-expected-hz = <12000000>;
+			/* set_source() test: switch reference to FRO_12M (target
+			 * stays FRO_12M, ~12 MHz), then target to FRO_HF_DIV
+			 * (180 MHz: FRO_HF 180 MHz / FROHFDIV 1, per board.c).
+			 */
+			switch-reference = <NXP_FREQME_REF_FRO_12M>;
+			switch-target = <NXP_FREQME_TAR_FRO_HF_DIV>;
+			switch-target-expected-hz = <180000000>;
+		};
+	};
+};

--- a/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxa366.overlay
+++ b/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxa366.overlay
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* freqme0 is enabled and fully configured (clocks, INPUTMUX routing) at the
+ * SoC / board devicetree level; the test only supplies the fixture node.
+ * freqme0 supports both WINDOW and MEASURE, so it is listed once.
+ */
+
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
+
+/ {
+	clock-monitor-test {
+		compatible = "test-clock-monitor";
+
+		freqme {
+			monitor = <&freqme0>;
+			measure-expected-hz = <12000000>;
+			/* set_source() test: switch reference to FRO_12M (target
+			 * stays FRO_12M, ~12 MHz), then target to FRO_HF_DIV
+			 * (~180 MHz, measured on this board).
+			 */
+			switch-reference = <NXP_FREQME_REF_FRO_12M>;
+			switch-target = <NXP_FREQME_TAR_FRO_HF_DIV>;
+			switch-target-expected-hz = <180000000>;
+		};
+	};
+};

--- a/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxa577.overlay
+++ b/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxa577.overlay
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* freqme0 is enabled and fully configured (clocks, INPUTMUX routing) at the
+ * SoC / board devicetree level; the test only supplies the fixture node.
+ * freqme0 supports both WINDOW and MEASURE, so it is listed once.
+ */
+
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
+
+/ {
+	clock-monitor-test {
+		compatible = "test-clock-monitor";
+
+		freqme {
+			monitor = <&freqme0>;
+			measure-expected-hz = <12000000>;
+			/* set_source() test: switch reference to FRO_12M (target
+			 * stays FRO_12M, ~12 MHz), then target to FRO_HF_DIV
+			 * (48 MHz: FRO_HF 192 MHz / FROHFDIV 4, per board.c).
+			 */
+			switch-reference = <NXP_FREQME_REF_FRO_12M>;
+			switch-target = <NXP_FREQME_TAR_FRO_HF_DIV>;
+			switch-target-expected-hz = <48000000>;
+		};
+	};
+};

--- a/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxl255_mcxl255_cpu0.overlay
+++ b/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxl255_mcxl255_cpu0.overlay
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* freqme0 is enabled and fully configured (clocks, INPUTMUX routing) at the
+ * SoC / board devicetree level; the test only supplies the fixture node.
+ * freqme0 supports both WINDOW and MEASURE, so it is listed once.
+ */
+
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
+
+/ {
+	clock-monitor-test {
+		compatible = "test-clock-monitor";
+
+		/*
+		 * Reference = 96 MHz FRO_HF_DIV, target = FRO_12M, so the
+		 * measured value is ~12 MHz.
+		 */
+		freqme {
+			monitor = <&freqme0>;
+			measure-expected-hz = <12000000>;
+			/* set_source() test: switch reference to FRO_12M (target
+			 * stays FRO_12M, ~12 MHz), then target to FRO_HF_DIV
+			 * (~96 MHz).
+			 */
+			switch-reference = <NXP_FREQME_MCXL_REF_FRO_12M>;
+			switch-target = <NXP_FREQME_MCXL_TAR_FRO_HF_DIV>;
+			switch-target-expected-hz = <96000000>;
+		};
+	};
+};

--- a/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxn236.overlay
+++ b/tests/drivers/clock_monitor/clock_monitor_api/boards/frdm_mcxn236.overlay
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* freqme0 is enabled and INPUTMUX-routed at the SoC / board devicetree level;
+ * the test supplies the fixture node. freqme0 supports both WINDOW and MEASURE,
+ * so it is listed once.
+ */
+
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
+
+/ {
+	test-required-clocks {
+		compatible = "test-required-clocks";
+		clocks = <&syscon MCUX_FRO_12M_CLK>,
+			 <&syscon MCUX_FRO_HF_CLK>;
+	};
+
+	clock-monitor-test {
+		compatible = "test-clock-monitor";
+
+		/*
+		 * Reference = 150 MHz CPU/AHB clock, target = FRO_12M, so the
+		 * measured value is ~12 MHz.
+		 */
+		freqme {
+			monitor = <&freqme0>;
+			measure-expected-hz = <12000000>;
+			/* set_source() test: switch reference to FRO_HF (target
+			 * stays FRO_12M, ~12 MHz), then target to FRO_HF
+			 * (48 MHz: FRO_HF, per board.c).
+			 */
+			switch-reference = <NXP_FREQME_MCXN_REF_FRO_HF>;
+			switch-target = <NXP_FREQME_MCXN_TAR_FRO_HF>;
+			switch-target-expected-hz = <48000000>;
+		};
+	};
+};

--- a/tests/drivers/clock_monitor/clock_monitor_api/boards/mcx_n5xx_evk_mcxn547_cpu0.overlay
+++ b/tests/drivers/clock_monitor/clock_monitor_api/boards/mcx_n5xx_evk_mcxn547_cpu0.overlay
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* freqme0 is enabled and INPUTMUX-routed at the SoC / board devicetree level;
+ * the test supplies the fixture node. freqme0 supports both WINDOW and MEASURE,
+ * so it is listed once.
+ */
+
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
+
+/ {
+	test-required-clocks {
+		compatible = "test-required-clocks";
+		clocks = <&syscon MCUX_FRO_12M_CLK>,
+			 <&syscon MCUX_FRO_HF_CLK>;
+	};
+
+	clock-monitor-test {
+		compatible = "test-clock-monitor";
+
+		/*
+		 * Reference = 150 MHz CPU/AHB clock, target = FRO_12M, so the
+		 * measured value is ~12 MHz.
+		 */
+		freqme {
+			monitor = <&freqme0>;
+			measure-expected-hz = <12000000>;
+			/* set_source() test: switch reference to FRO_HF (target
+			 * stays FRO_12M, ~12 MHz), then target to FRO_HF
+			 * (~48 MHz, measured on this board).
+			 */
+			switch-reference = <NXP_FREQME_MCXN_REF_FRO_HF>;
+			switch-target = <NXP_FREQME_MCXN_TAR_FRO_HF>;
+			switch-target-expected-hz = <48000000>;
+		};
+	};
+};

--- a/tests/drivers/clock_monitor/clock_monitor_api/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
+++ b/tests/drivers/clock_monitor/clock_monitor_api/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* freqme0 is enabled and INPUTMUX-routed at the SoC / board devicetree level;
+ * the test supplies the fixture node. freqme0 supports both WINDOW and MEASURE,
+ * so it is listed once.
+ */
+
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
+
+/ {
+	test-required-clocks {
+		compatible = "test-required-clocks";
+		clocks = <&syscon MCUX_FRO_12M_CLK>,
+			 <&syscon MCUX_FRO_HF_CLK>;
+	};
+
+	clock-monitor-test {
+		compatible = "test-clock-monitor";
+
+		/*
+		 * Reference = 150 MHz CPU/AHB clock, target = FRO_12M, so the
+		 * measured value is ~12 MHz.
+		 */
+		freqme {
+			monitor = <&freqme0>;
+			measure-expected-hz = <12000000>;
+			/* set_source() test: switch reference to FRO_HF (target
+			 * stays FRO_12M, ~12 MHz), then target to FRO_HF
+			 * (~48 MHz, measured on this board).
+			 */
+			switch-reference = <NXP_FREQME_MCXN_REF_FRO_HF>;
+			switch-target = <NXP_FREQME_MCXN_TAR_FRO_HF>;
+			switch-target-expected-hz = <48000000>;
+		};
+	};
+};

--- a/tests/drivers/clock_monitor/clock_monitor_api/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
+++ b/tests/drivers/clock_monitor/clock_monitor_api/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* freqme0 is enabled and fully configured (clocks, INPUTMUX routing) at the
+ * SoC / board devicetree level; the test only supplies the fixture node.
+ * freqme0 supports both WINDOW and MEASURE, so it is listed once.
+ */
+
+#include <zephyr/dt-bindings/clock-monitor/nxp-freqme.h>
+
+/ {
+	clock-monitor-test {
+		compatible = "test-clock-monitor";
+
+		/*
+		 * Reference = 24 MHz system OSC, target = FRO1 (~192 MHz), so the
+		 * measured value is ~192 MHz.
+		 */
+		freqme {
+			monitor = <&freqme0>;
+			measure-expected-hz = <192000000>;
+			/* set_source() test: switch reference to FRO1 (target
+			 * stays FRO1, ~192 MHz), then target to the system OSC
+			 * (~24 MHz).
+			 */
+			switch-reference = <NXP_FREQME_RT7XX_REF_FRO1>;
+			switch-target = <NXP_FREQME_RT7XX_TAR_OSC_CLK>;
+			switch-target-expected-hz = <24000000>;
+		};
+	};
+};

--- a/tests/drivers/clock_monitor/clock_monitor_api/dts/bindings/test-clock-monitor.yaml
+++ b/tests/drivers/clock_monitor/clock_monitor_api/dts/bindings/test-clock-monitor.yaml
@@ -44,3 +44,28 @@ child-binding:
       description: |
         Accepted plus/minus deviation of the measured frequency from
         measure-expected-hz, in parts-per-million.
+
+    switch-reference:
+      type: int
+      default: 0
+      description: |
+        Alternate reference-clock cookie (opaque, back-end specific) for the
+        set_source() test. When non-zero, the suite switches the reference to
+        this source, reconfigures, and asserts the same target still measures
+        within tolerance of measure-expected-hz.
+
+    switch-target:
+      type: int
+      default: 0
+      description: |
+        Alternate target-clock cookie for the set_source() test. When non-zero,
+        the suite switches the target to this source, reconfigures, and
+        re-measures - the measured value becomes this target's frequency.
+
+    switch-target-expected-hz:
+      type: int
+      default: 0
+      description: |
+        Expected measured frequency (Hz) after switching the target to
+        switch-target. When non-zero, the measured value must lie within
+        measure-tolerance-ppm of it. 0 only logs the measured value.

--- a/tests/drivers/clock_monitor/clock_monitor_api/dts/bindings/test-required-clocks.yaml
+++ b/tests/drivers/clock_monitor/clock_monitor_api/dts/bindings/test-required-clocks.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: Clocks the clock_monitor API test suite enables during setup.
+
+compatible: "test-required-clocks"
+
+properties:
+  clocks:
+    type: phandle-array
+    required: true
+    description: Clocks to enable during test setup.

--- a/tests/drivers/clock_monitor/clock_monitor_api/src/main.c
+++ b/tests/drivers/clock_monitor/clock_monitor_api/src/main.c
@@ -36,6 +36,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_monitor.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/atomic.h>
@@ -47,6 +48,11 @@ struct clkmon_fixture {
 	/* 0 = no accuracy check for this instance. */
 	uint32_t measure_expected_hz;
 	uint32_t measure_tolerance_ppm;
+	/* Alternate reference cookie for the set_source() test; 0 = skip. */
+	uint32_t switch_reference;
+	/* Alternate target cookie + its expected measured Hz; 0 = skip. */
+	uint32_t switch_target;
+	uint32_t switch_target_expected_hz;
 };
 
 #if DT_HAS_COMPAT_STATUS_OKAY(test_clock_monitor)
@@ -57,6 +63,9 @@ struct clkmon_fixture {
 		.measure_expected_hz = DT_PROP(node_id, measure_expected_hz),  \
 		.measure_tolerance_ppm =                                       \
 			DT_PROP(node_id, measure_tolerance_ppm),               \
+		.switch_reference = DT_PROP(node_id, switch_reference),        \
+		.switch_target = DT_PROP(node_id, switch_target),             \
+		.switch_target_expected_hz = DT_PROP(node_id, switch_target_expected_hz), \
 	},
 
 static const struct clkmon_fixture fixtures[] = {
@@ -71,6 +80,36 @@ static const struct clkmon_fixture fixtures[] = {
 static const struct clkmon_fixture fixtures[] = { {NULL, 0U, 0U} };
 
 #define NUM_CLOCK_DEVICES 0U
+
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(test_required_clocks)
+
+#define REQUIRED_CLOCK_ON(node_id, prop, idx)                                  \
+	do {                                                                   \
+		const struct device *_clk =                                    \
+			DEVICE_DT_GET(DT_CLOCKS_CTLR_BY_IDX(node_id, idx));    \
+		if (device_is_ready(_clk)) {                                   \
+			(void)clock_control_on(_clk,                           \
+				(clock_control_subsys_t)(uintptr_t)            \
+				DT_CLOCKS_CELL_BY_IDX(node_id, idx, name));    \
+		}                                                              \
+	} while (0)
+
+static void enable_required_clocks(void)
+{
+	DT_FOREACH_PROP_ELEM_SEP(DT_COMPAT_GET_ANY_STATUS_OKAY(test_required_clocks),
+				 clocks, REQUIRED_CLOCK_ON, (;));
+}
+
+#else
+
+/*
+ * No test-required-clocks node on this board, so there are no source
+ * clocks to bring up. Provide an empty stub so the call site stays
+ * unconditional.
+ */
+static void enable_required_clocks(void) {}
 
 #endif
 
@@ -221,6 +260,15 @@ static void foreach_device_with_mode(enum clock_monitor_mode mode,
 	}
 }
 
+static void *clkmon_setup(void)
+{
+	/* Enable the board's declared required clocks once, before any test
+	 * configures or starts a measurement.
+	 */
+	enable_required_clocks();
+	return NULL;
+}
+
 static void before_each(void *fixture)
 {
 	ARG_UNUSED(fixture);
@@ -229,7 +277,7 @@ static void before_each(void *fixture)
 	}
 }
 
-ZTEST_SUITE(clock_monitor_api, NULL, NULL, before_each, NULL, NULL);
+ZTEST_SUITE(clock_monitor_api, NULL, clkmon_setup, before_each, NULL, NULL);
 
 /* WINDOW path */
 static void body_window_check_stop(const struct device *dev)
@@ -627,6 +675,129 @@ ZTEST(clock_monitor_api, test_get_rate_enosys_without_measure_hw)
 		zassert_equal(clock_monitor_get_rate(dev, &hz), -ENOSYS,
 			      "get_rate on measurement-less %s must be "
 			      "-ENOSYS", dev->name);
+		ran = true;
+	}
+	if (!ran) {
+		ztest_test_skip();
+	}
+}
+
+static struct cb_capture setsrc_cap;
+
+static void body_set_source_switch_reference(const struct device *dev)
+{
+	const struct clkmon_fixture *fx = fixture_of(dev);
+	struct clock_monitor_config cfg = measure_cfg;
+
+	/* Error contract (no side effects on the current selection). */
+	zassert_equal(clock_monitor_set_source(dev, 0U, 0U), -EINVAL,
+		      "set_source(unchanged, unchanged) must be -EINVAL on %s",
+		      dev->name);
+	zassert_equal(clock_monitor_set_source(dev, 0xFFFFFFFFU, 0U), -EINVAL,
+		      "unknown reference cookie must be -EINVAL on %s", dev->name);
+
+	/* Baseline measurement with the power-on sources. */
+	cb_capture_init(&setsrc_cap, false, 0);
+	cfg.callback = measure_cb;
+	cfg.user_data = &setsrc_cap;
+	zassert_ok(clock_monitor_configure(dev, &cfg),
+		   "baseline configure failed on %s", dev->name);
+	zassert_ok(clock_monitor_start(dev), NULL);
+	zassert_ok(k_sem_take(&setsrc_cap.sem, K_MSEC(100)),
+		   "no baseline measurement on %s", dev->name);
+	zassert_true(setsrc_cap.last_hz > 0U, NULL);
+
+	/* Switch only the reference; the target is left unchanged. */
+	zassert_ok(clock_monitor_set_source(dev, fx->switch_reference, 0U),
+		   "set_source(switch-reference) failed on %s", dev->name);
+
+	/* A source switch drops the device to the unconfigured state: start()
+	 * must fail until a fresh configure().
+	 */
+	zassert_equal(clock_monitor_start(dev), -EINVAL,
+		      "start() after set_source must be -EINVAL on %s", dev->name);
+
+	/* Reconfigure and re-measure the same target: a correctly re-queried
+	 * reference rate leaves the measured value unchanged.
+	 */
+	cb_capture_init(&setsrc_cap, false, 0);
+	zassert_ok(clock_monitor_configure(dev, &cfg),
+		   "reconfigure after switch failed on %s", dev->name);
+	zassert_ok(clock_monitor_start(dev), NULL);
+	zassert_ok(k_sem_take(&setsrc_cap.sem, K_MSEC(100)),
+		   "no measurement after reference switch on %s", dev->name);
+	zassert_true((setsrc_cap.last_events &
+		      CLOCK_MONITOR_EVT_MEASURE_DONE) != 0U, NULL);
+
+	if (fx->measure_expected_hz != 0U) {
+		uint32_t tol = (uint32_t)(((uint64_t)fx->measure_expected_hz *
+			fx->measure_tolerance_ppm) / 1000000U);
+
+		zassert_within(setsrc_cap.last_hz, fx->measure_expected_hz, tol,
+			       "post-switch measured %u Hz outside %u +/- %u Hz "
+			       "on %s", setsrc_cap.last_hz, fx->measure_expected_hz,
+			       tol, dev->name);
+	}
+
+	/* Target switch: change only the target and re-measure. The result is
+	 * the new target's absolute frequency (independent of the reference
+	 * when the back-end is correct), so it differs from the default target
+	 * measured above - proving the target was actually re-routed.
+	 */
+	if (fx->switch_target != 0U) {
+		zassert_ok(clock_monitor_set_source(dev, 0U, fx->switch_target),
+			   "set_source(switch-target) failed on %s", dev->name);
+		zassert_equal(clock_monitor_start(dev), -EINVAL,
+			      "start() after target switch must be -EINVAL on %s",
+			      dev->name);
+
+		cb_capture_init(&setsrc_cap, false, 0);
+		zassert_ok(clock_monitor_configure(dev, &cfg),
+			   "reconfigure after target switch failed on %s", dev->name);
+		zassert_ok(clock_monitor_start(dev), NULL);
+		zassert_ok(k_sem_take(&setsrc_cap.sem, K_MSEC(100)),
+			   "no measurement after target switch on %s", dev->name);
+		TC_PRINT("%s: target-switched measurement = %u Hz\n",
+			 dev->name, setsrc_cap.last_hz);
+		zassert_true(setsrc_cap.last_hz > 0U, NULL);
+
+		if (fx->switch_target_expected_hz != 0U) {
+			uint32_t tol = (uint32_t)(((uint64_t)fx->switch_target_expected_hz *
+				fx->measure_tolerance_ppm) / 1000000U);
+
+			zassert_within(setsrc_cap.last_hz,
+				       fx->switch_target_expected_hz, tol,
+				       "target-switch measured %u Hz outside %u +/- %u "
+				       "Hz on %s", setsrc_cap.last_hz,
+				       fx->switch_target_expected_hz, tol, dev->name);
+		}
+	}
+	(void)clock_monitor_stop(dev);
+}
+
+ZTEST(clock_monitor_api, test_set_source_switch_reference)
+{
+	bool ran = false;
+
+	for (size_t i = 0; i < NUM_CLOCK_DEVICES; i++) {
+		const struct device *dev = fixtures[i].dev;
+
+		zassert_true(device_is_ready(dev), "%s not ready", dev->name);
+
+		/* Probe support: (unchanged, unchanged) returns -ENOSYS when
+		 * set_source is unimplemented, -EINVAL when implemented, and has
+		 * no side effects either way.
+		 */
+		if (clock_monitor_set_source(dev, 0U, 0U) == -ENOSYS) {
+			continue;
+		}
+		/* Needs an alternate reference cookie and MEASURE support. */
+		if (fixtures[i].switch_reference == 0U ||
+		    !dev_supports_mode(dev, CLOCK_MONITOR_MODE_MEASURE)) {
+			continue;
+		}
+		clean_slate(dev);
+		body_set_source_switch_reference(dev);
 		ran = true;
 	}
 	if (!ran) {

--- a/tests/drivers/clock_monitor/clock_monitor_api/tests.yaml
+++ b/tests/drivers/clock_monitor/clock_monitor_api/tests.yaml
@@ -8,3 +8,4 @@ common:
 tests:
   drivers.clock_monitor.api.nxp:
     filter: dt_compat_enabled("nxp,cmu-fc") or dt_compat_enabled("nxp,cmu-fm")
+      or dt_compat_enabled("nxp,freqme")


### PR DESCRIPTION
Add a clock_monitor back-end for the NXP FREQME (Frequency Measurement) peripheral, wrapping the MCUX lpc_freqme HAL. It supports MEASURE (one-shot) and WINDOW (continuous MIN/MAX threshold) modes, routes the
reference and target clocks through INPUTMUX.

Platform enable:
  - frdm_mcxa153
  - frdm_mcxa156
  - frdm_mcxa344
  - frdm_mcxa266
  - frdm_mcxa366
  - frdm_mcxa577
  - frdm_mcxn236
  - mcx_n5xx_evk/mcxn547/cpu0
  - mcx_n9xx_evk/mcxn947/cpu0
  - frdm_mcxl255/mcxl255/cpu0
  - mimxrt700_evk/mimxrt798s/cm33_cpu0
