### PR TITLE
drivers: wuc: add NXP WKPU wakeup controller driver

### DIFF
--- a/drivers/wuc/CMakeLists.txt
+++ b/drivers/wuc/CMakeLists.txt
@@ -5,5 +5,6 @@ zephyr_library()
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_WUC_MCUX_LLWU wuc_nxp_llwu.c)
+zephyr_library_sources_ifdef(CONFIG_WUC_MCUX_WKPU wuc_nxp_wkpu.c)
 zephyr_library_sources_ifdef(CONFIG_WUC_MCUX_WUU wuc_nxp_wuu.c)
 # zephyr-keep-sorted-stop

--- a/drivers/wuc/Kconfig.mcux_wuc
+++ b/drivers/wuc/Kconfig.mcux_wuc
@@ -8,6 +8,13 @@ config WUC_MCUX_LLWU
 	help
 	  Enable support for NXP LLWU(Low Leakage Wakeup Unit) wakeup controller driver.
 
+config WUC_MCUX_WKPU
+	bool "NXP WKPU wakeup control"
+	default y
+	depends on DT_HAS_NXP_WUC_WKPU_ENABLED
+	help
+	  Enable support for NXP WKPU (Wake-up Unit) wakeup controller driver.
+
 config WUC_MCUX_WUU
 	bool "NXP WUU wakeup control"
 	default y

--- a/drivers/wuc/wuc_nxp_wkpu.c
+++ b/drivers/wuc/wuc_nxp_wkpu.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_wuc_wkpu
+
+#include <zephyr/init.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/logging/log.h>
+
+#include <fsl_wkpu.h>
+#include <zephyr/drivers/wuc.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wkpu.h>
+
+LOG_MODULE_REGISTER(mcux_wkpu, CONFIG_WUC_LOG_LEVEL);
+
+struct mcux_wkpu_config {
+	WKPU_Type *base;
+	uint32_t irqn;
+};
+
+struct mcux_wkpu_data {
+	uint64_t triggered_sources;
+	struct k_spinlock lock;
+};
+
+static void mcux_wkpu_isr(const struct device *dev)
+{
+	const struct mcux_wkpu_config *config = dev->config;
+	struct mcux_wkpu_data *data = dev->data;
+	uint64_t triggered;
+
+	triggered = WKPU_GetExternalWakeUpSourceFlag(config->base);
+	WKPU_ClearExternalWakeUpSourceFlag(config->base, triggered);
+
+	K_SPINLOCK(&data->lock) {
+		data->triggered_sources |= triggered;
+	}
+}
+
+static int mcux_wkpu_enable_wakeup_source(const struct device *dev, uint32_t source)
+{
+	const struct mcux_wkpu_config *config = dev->config;
+	uint8_t index = NXP_WKPU_WAKEUP_SOURCE_DECODE_INDEX(source);
+	uint8_t edge = NXP_WKPU_WAKEUP_SOURCE_DECODE_EDGE(source);
+	uint8_t event = NXP_WKPU_WAKEUP_SOURCE_DECODE_EVENT(source);
+	wkpu_external_wakeup_source_config_t cfg = {
+		.event = (event == NXP_WKPU_EVENT_INT_WAKEUP) ? kWKPU_InterruptAndWakeUp
+							      : kWKPU_Interrupt,
+		.edge = (wkpu_pin_edge_detection_t)edge,
+		.enableFilter = false,
+	};
+
+	WKPU_SetExternalWakeUpSourceConfig(config->base, (uint64_t)1ULL << index, &cfg);
+
+	/* A source delivering an interrupt event needs the controller IRQ. */
+	irq_enable(config->irqn);
+
+	LOG_DBG("WKPU source %u enabled (edge %u, event %u)", index, edge, event);
+
+	return 0;
+}
+
+static int mcux_wkpu_disable_wakeup_source(const struct device *dev, uint32_t source)
+{
+	const struct mcux_wkpu_config *config = dev->config;
+	uint8_t index = NXP_WKPU_WAKEUP_SOURCE_DECODE_INDEX(source);
+
+	WKPU_ClearExternalWakeupSourceConfig(config->base, (uint64_t)1ULL << index);
+
+	/* Disable the controller IRQ once no source requests an interrupt. */
+	if ((config->base->IRER == 0U) && (config->base->IRER_64 == 0U)) {
+		irq_disable(config->irqn);
+	}
+
+	LOG_DBG("WKPU source %u disabled", index);
+
+	return 0;
+}
+
+static int mcux_wkpu_check_wakeup_source_triggered(const struct device *dev, uint32_t source)
+{
+	struct mcux_wkpu_data *data = dev->data;
+	uint8_t index = NXP_WKPU_WAKEUP_SOURCE_DECODE_INDEX(source);
+	int ret;
+
+	K_SPINLOCK(&data->lock) {
+		ret = (data->triggered_sources & ((uint64_t)1ULL << index)) ? 1 : 0;
+	}
+
+	return ret;
+}
+
+static int mcux_wkpu_clear_wakeup_source_triggered(const struct device *dev, uint32_t source)
+{
+	struct mcux_wkpu_data *data = dev->data;
+	uint8_t index = NXP_WKPU_WAKEUP_SOURCE_DECODE_INDEX(source);
+
+	K_SPINLOCK(&data->lock) {
+		data->triggered_sources &= ~((uint64_t)1ULL << index);
+	}
+
+	return 0;
+}
+
+static int mcux_wkpu_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(action);
+
+	return 0;
+}
+
+static int mcux_wkpu_init(const struct device *dev)
+{
+	struct mcux_wkpu_data *data = dev->data;
+
+	IRQ_CONNECT(DT_IRQN(DT_DRV_INST(0)), DT_IRQ(DT_DRV_INST(0), priority), mcux_wkpu_isr,
+		    DEVICE_DT_INST_GET(0), 0);
+
+	data->triggered_sources = 0;
+
+	return pm_device_driver_init(dev, mcux_wkpu_pm_action);
+}
+
+static const struct mcux_wkpu_config wkpu_config = {
+	.base = (WKPU_Type *)DT_REG_ADDR(DT_DRV_INST(0)),
+	.irqn = DT_IRQN(DT_DRV_INST(0)),
+};
+
+static struct mcux_wkpu_data wkpu_data;
+
+static const DEVICE_API(wuc, wkpu_api) = {
+	.enable = mcux_wkpu_enable_wakeup_source,
+	.disable = mcux_wkpu_disable_wakeup_source,
+	.triggered = mcux_wkpu_check_wakeup_source_triggered,
+	.clear = mcux_wkpu_clear_wakeup_source_triggered,
+};
+
+DEVICE_DT_INST_DEFINE(0, mcux_wkpu_init, NULL, &wkpu_data, &wkpu_config, PRE_KERNEL_1,
+		      WUC_INIT_PRIORITY, &wkpu_api);

--- a/dts/arm/nxp/mcx/nxp_mcxe31x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxe31x_common.dtsi
@@ -1229,9 +1229,10 @@
 	};
 
 	wkpu: wkpu@2b4000 {
-		compatible = "nxp,wkpu";
+		compatible = "nxp,wuc-wkpu";
 		reg = <0x2b4000 0x90>;
 		interrupts = <83 0>;
+		#wakeup-ctrl-cells = <1>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/wuc/nxp,wuc-wkpu.yaml
+++ b/dts/bindings/wuc/nxp,wuc-wkpu.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  NXP Wake-up Unit (WKPU) acting as a Wakeup Controller (WUC).
+
+  This binding is used by SoCs that consume the WKPU through the WUC
+  subsystem (i.e. via "wakeup-ctrls" properties), and therefore must
+  declare the "#wakeup-ctrl-cells" property required by wuc-controller.
+
+  The WKPU exposes up to 64 wakeup sources: sources 0-3 are internal
+  peripheral events (SWT/RTC-API, RTC timeout, LPCMP round-robin, RTI)
+  and sources 4..63 are external pins. Use the helpers in
+  <zephyr/dt-bindings/wuc/wuc_nxp_wkpu.h> to build wakeup-source ids.
+
+compatible: "nxp,wuc-wkpu"
+
+include: [base.yaml, wuc-controller.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  '#wakeup-ctrl-cells':
+    type: int
+    const: 1
+    description: |
+      Number of cells in wakeup-ctrls property.
+
+wakeup-ctrl-cells:
+  - id

--- a/include/zephyr/dt-bindings/wuc/wuc_nxp_wkpu.h
+++ b/include/zephyr/dt-bindings/wuc/wuc_nxp_wkpu.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief NXP WKPU (Wake-up Unit) wakeup-source encoding helpers.
+ *
+ * Encodes a WKPU wakeup source as a single 32-bit value, plus helper macros to
+ * build and decode such values for use with the NXP WKPU WUC driver and
+ * devicetree "wakeup-ctrls" properties.
+ *
+ * The WKPU exposes a flat set of up to 64 wakeup sources. Sources 0-3 are
+ * internal peripheral events and sources 4..63 are the external pins
+ * WKPU[0]..WKPU[59]; all of them are configured through the same registers, so
+ * a single encoding (index + edge + event) covers every source.
+ *
+ * Wakeup source encoding:
+ *   Bits [23:16] - Index (WKPU source number, 0..63)
+ *   Bits [15:8]  - Edge type (1=RISING, 2=FALLING, 3=ANY)
+ *   Bits [7:0]   - Event type (0=INT, 1=INT_WAKEUP)
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_WUC_NXP_WKPU_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_WUC_NXP_WKPU_H_
+
+/** Bit position of the index field (WKPU source number). */
+#define NXP_WKPU_SOURCE_INDEX_POS 16
+/** Bit position of the edge-type field. */
+#define NXP_WKPU_SOURCE_EDGE_POS  8
+/** Bit position of the event-type field. */
+#define NXP_WKPU_SOURCE_EVENT_POS 0
+
+/** Mask covering one 8-bit field of the encoded wakeup source. */
+#define NXP_WKPU_SOURCE_MASK 0xFF
+
+/** Edge-type value: trigger on rising edge. */
+#define NXP_WKPU_EDGE_RISING  1
+/** Edge-type value: trigger on falling edge. */
+#define NXP_WKPU_EDGE_FALLING 2
+/** Edge-type value: trigger on any edge. */
+#define NXP_WKPU_EDGE_ANY     3
+
+/** Event-type value: generate a core interrupt only. */
+#define NXP_WKPU_EVENT_INT        0
+/** Event-type value: generate a core interrupt and a system wakeup. */
+#define NXP_WKPU_EVENT_INT_WAKEUP 1
+
+/**
+ * @brief Encode a WKPU wakeup source into a single 32-bit value.
+ *
+ * @param index WKPU source number (0..63).
+ * @param edge  Edge type (NXP_WKPU_EDGE_*).
+ * @param event Event type (NXP_WKPU_EVENT_*).
+ */
+#define NXP_WKPU_WAKEUP_SOURCE_ENCODE(index, edge, event)                                          \
+	(((index) << NXP_WKPU_SOURCE_INDEX_POS) | ((edge) << NXP_WKPU_SOURCE_EDGE_POS) |           \
+	 ((event) << NXP_WKPU_SOURCE_EVENT_POS))
+
+/**
+ * @brief Extract one 8-bit field from an encoded wakeup source.
+ *
+ * @param source Encoded wakeup source value.
+ * @param pos    Bit position of the field (one of NXP_WKPU_SOURCE_*_POS).
+ */
+#define NXP_WKPU_WAKEUP_SOURCE_DECODE(source, pos) (((source) >> (pos)) & NXP_WKPU_SOURCE_MASK)
+
+/** @brief Decode the index field (WKPU source number). */
+#define NXP_WKPU_WAKEUP_SOURCE_DECODE_INDEX(source)                                                \
+	NXP_WKPU_WAKEUP_SOURCE_DECODE(source, NXP_WKPU_SOURCE_INDEX_POS)
+
+/** @brief Decode the edge-type field. */
+#define NXP_WKPU_WAKEUP_SOURCE_DECODE_EDGE(source)                                                 \
+	NXP_WKPU_WAKEUP_SOURCE_DECODE(source, NXP_WKPU_SOURCE_EDGE_POS)
+
+/** @brief Decode the event-type field. */
+#define NXP_WKPU_WAKEUP_SOURCE_DECODE_EVENT(source)                                                \
+	NXP_WKPU_WAKEUP_SOURCE_DECODE(source, NXP_WKPU_SOURCE_EVENT_POS)
+
+/** @brief Encode an external WKPU pin (WKPU[n] == source index 4 + n). */
+#define NXP_WKPU_PIN(n, edge, event) NXP_WKPU_WAKEUP_SOURCE_ENCODE((4 + (n)), edge, event)
+
+/*
+ * Internal WKPU wakeup sources (indices 0-3). See the chip reference manual,
+ * "WKPU wake-up source connectivity".
+ */
+
+/** Source 0: SWT_0 timeout / RTC-API API wakeup. */
+#define NXP_WKPU_SWT0_RTC_API(edge, event) NXP_WKPU_WAKEUP_SOURCE_ENCODE(0, edge, event)
+/** Source 1: RTC timeout. */
+#define NXP_WKPU_RTC_TIMEOUT(edge, event)  NXP_WKPU_WAKEUP_SOURCE_ENCODE(1, edge, event)
+/** Source 2: LPCMP_0/1/2 round-robin. */
+#define NXP_WKPU_LPCMP_RR(edge, event)     NXP_WKPU_WAKEUP_SOURCE_ENCODE(2, edge, event)
+/** Source 3: RTI (PIT0-RTI). */
+#define NXP_WKPU_RTI(edge, event)          NXP_WKPU_WAKEUP_SOURCE_ENCODE(3, edge, event)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_WUC_NXP_WKPU_H_ */

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -121,6 +121,7 @@ set_variable_ifdef(CONFIG_UART_MCUX_IUART       CONFIG_MCUX_COMPONENT_driver.iua
 set_variable_ifdef(CONFIG_ADC_MCUX_12B1MSPS_SAR CONFIG_MCUX_COMPONENT_driver.adc_12b1msps_sar)
 set_variable_ifdef(CONFIG_HWINFO_MCUX_SRC       CONFIG_MCUX_COMPONENT_driver.src)
 set_variable_ifdef(CONFIG_DT_HAS_NXP_WUU_ENABLED CONFIG_MCUX_COMPONENT_driver.wuu)
+set_variable_ifdef(CONFIG_WUC_MCUX_WKPU         CONFIG_MCUX_COMPONENT_driver.wkpu)
 set_variable_ifdef(CONFIG_HWINFO_MCUX_SIM       CONFIG_MCUX_COMPONENT_driver.sim)
 set_variable_ifdef(CONFIG_HWINFO_MCUX_RCM       CONFIG_MCUX_COMPONENT_driver.rcm)
 set_variable_ifdef(CONFIG_IPM_MCUX              CONFIG_MCUX_COMPONENT_driver.mailbox)

--- a/tests/drivers/wuc/wkpu/CMakeLists.txt
+++ b/tests/drivers/wuc/wkpu/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(wuc_nxp_wkpu)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/drivers/wuc/wkpu/boards/frdm_mcxe31b.overlay
+++ b/tests/drivers/wuc/wkpu/boards/frdm_mcxe31b.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Enable the WKPU wakeup controller. The RTC counter (the internal stimulus) is
+ * already enabled in the board devicetree.
+ */
+&wkpu {
+	status = "okay";
+};

--- a/tests/drivers/wuc/wkpu/prj.conf
+++ b/tests/drivers/wuc/wkpu/prj.conf
@@ -1,0 +1,6 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_WUC=y
+CONFIG_COUNTER=y

--- a/tests/drivers/wuc/wkpu/src/main.c
+++ b/tests/drivers/wuc/wkpu/src/main.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Functional test for the NXP WKPU (Wake-up Unit) wakeup-controller (WUC)
+ * driver on MCXE31x. It exercises the driver through an internal wakeup source
+ * so that no external pin stimulus / loopback jumper is required.
+ *
+ * Per the MCXE31x Reference Manual ("WKPU wake-up source connectivity"), the RTC
+ * timeout is WKPU wakeup source 1. The test enables that source through the WUC
+ * API, programs an RTC counter alarm, and polls the WUC "triggered" status,
+ * which the WKPU ISR latches when the RTC timeout fires.
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/wuc.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wkpu.h>
+
+/* counter_mcux_rtc_jdp: channel 0 == RTCVAL (the RTC timeout compare). */
+#define RTC_ALARM_CHANNEL 0U
+
+/* WKPU source 1 (RTC timeout), rising edge, interrupt event. */
+#define WKPU_RTC_SOURCE NXP_WKPU_RTC_TIMEOUT(NXP_WKPU_EDGE_RISING, NXP_WKPU_EVENT_INT)
+
+static const struct device *const wkpu = DEVICE_DT_GET(DT_NODELABEL(wkpu));
+static const struct device *const rtc = DEVICE_DT_GET(DT_NODELABEL(rtc));
+
+static void rtc_alarm_callback(const struct device *dev, uint8_t chan_id, uint32_t ticks,
+			       void *user_data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(chan_id);
+	ARG_UNUSED(ticks);
+	ARG_UNUSED(user_data);
+}
+
+ZTEST(wuc_nxp_wkpu, test_rtc_timeout_wakeup_source)
+{
+	struct counter_alarm_cfg alarm_cfg;
+	bool triggered = false;
+	int err;
+
+	zassert_true(device_is_ready(wkpu), "WKPU WUC device not ready");
+	zassert_true(device_is_ready(rtc), "RTC counter device not ready");
+
+	err = wuc_enable_wakeup_source(wkpu, WKPU_RTC_SOURCE);
+	zassert_ok(err, "wuc_enable_wakeup_source() failed: %d", err);
+
+	/* Drop any stale latched status from a previous run. */
+	(void)wuc_clear_wakeup_source_triggered(wkpu, WKPU_RTC_SOURCE);
+
+	alarm_cfg.callback = rtc_alarm_callback;
+	alarm_cfg.ticks = counter_us_to_ticks(rtc, 3000000U); /* ~3 s */
+	alarm_cfg.flags = 0U;
+	alarm_cfg.user_data = NULL;
+
+	err = counter_set_channel_alarm(rtc, RTC_ALARM_CHANNEL, &alarm_cfg);
+	zassert_ok(err, "counter_set_channel_alarm() failed: %d", err);
+
+	/* The RTC timeout drives WKPU source 1 -> WKPU ISR -> latched triggered. */
+	for (int i = 0; i < 100; i++) {
+		if (wuc_check_wakeup_source_triggered(wkpu, WKPU_RTC_SOURCE) == 1) {
+			triggered = true;
+			break;
+		}
+		k_msleep(100);
+	}
+
+	(void)counter_cancel_channel_alarm(rtc, RTC_ALARM_CHANNEL);
+	(void)wuc_clear_wakeup_source_triggered(wkpu, WKPU_RTC_SOURCE);
+	(void)wuc_disable_wakeup_source(wkpu, WKPU_RTC_SOURCE);
+
+	zassert_true(triggered, "WKPU RTC-timeout wakeup source did not trigger within 10 s");
+}
+
+ZTEST_SUITE(wuc_nxp_wkpu, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/wuc/wkpu/testcase.yaml
+++ b/tests/drivers/wuc/wkpu/testcase.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+common:
+  tags:
+    - drivers
+    - wuc
+    - wkpu
+  harness: ztest
+tests:
+  drivers.wuc.nxp_wkpu:
+    # Exercises the WKPU WUC driver through the RTC-timeout internal wakeup
+    # source (no external pin stimulus required).
+    platform_allow:
+      - frdm_mcxe31b
+    integration_platforms:
+      - frdm_mcxe31b


### PR DESCRIPTION
Adds a Wakeup Controller (WUC) driver for the NXP Wake-up Unit (WKPU), implementing the existing `wuc_driver_api` (enable / disable / triggered / clear) on top of the `fsl_wkpu` HAL. **No WUC API change is introduced** — only a new driver, binding, and dt-bindings header, alongside the existing WUU and LLWU WUC drivers.

This is an alternative to #111824, which enables WKPU on MCXE31x via the existing `nxp,s32-wkpu` interrupt-controller driver. This PR instead brings WKPU into the WUC subsystem, consistent with WUU/LLWU. Posting both so maintainers can choose the preferred direction.

## Design

- The WKPU exposes up to 64 wakeup sources: indices 0-3 are internal peripheral events (SWT/RTC-API, RTC timeout, LPCMP round-robin, RTI) and 4..63 are external pins. A source is encoded as index + edge + event via `<zephyr/dt-bindings/wuc/wuc_nxp_wkpu.h>`.
- The driver owns the WKPU IRQ, latches triggered sources in its ISR, and reports them through the WUC poll API — same shape as the existing `wuc_nxp_wuu` driver.
- Enabled on MCXE31x by giving the shared SoC WKPU node the `nxp,wuc-wkpu` compatible (previously a placeholder with no driver behind it).

## Scope

MCXE31x only. On MCXE31x the SIUL2 GPIO WKPU path is not built (`CONFIG_NXP_S32_WKPU` is off), so routing the WKPU through the WUC subsystem does not disturb it. S32K3 keeps using the `nxp,s32-wkpu` interrupt-controller driver, whose run-mode GPIO interrupt delivery (consumed by `gpio_nxp_siul2`) is outside the WUC poll model.

## Testing

`frdm_mcxe31b` hardware — `tests/drivers/wuc/wkpu`:

```
Running TESTSUITE wuc_nxp_wkpu
START - test_rtc_timeout_wakeup_source
 PASS - test_rtc_timeout_wakeup_source in 3.604 seconds
SUITE PASS - 100.00% [wuc_nxp_wkpu]: pass = 1, fail = 0, skip = 0
PROJECT EXECUTION SUCCESSFUL
```

The test drives the WKPU through the RTC-timeout internal wakeup source (WKPU source 1), so it needs no external pin stimulus or jumper.
