### PR TITLE
drivers: ethernet: dwc_mac: 1000: make sure last bit is not removed

### DIFF
--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -125,7 +125,7 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 	barrier_dmem_fence_full();
 
 	d = &p->tx_descs[p->tx_desc_head];
-	d->des0 = TDES0_OWN | TDES0_FS | TDES0_FLAGS_DEFAULT;
+	d->des0 |= TDES0_OWN | TDES0_FS;
 
 	barrier_dmem_fence_full();
 	p->tx_desc_head = d_idx;


### PR DESCRIPTION
When enabling CONFIG_NET_L2_ETHERNET_RESERVE_HEADER and increasing CONFIG_NET_BUF_DATA_SIZE a net_pkt can just contain one fragment, for that we need to make sure, that the first and last bit can be set at the same time.