### PR TITLE
Pass dmic_api tests on STM32 boards that support it

### DIFF
--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -26,6 +26,10 @@
 		zephyr,touch = &ft6202;
 	};
 
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+
 	sdram1: sdram@c0000000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		device_type = "memory";
@@ -293,7 +297,7 @@ qsh_030_i2c: &i2c4 {
 	status = "okay";
 };
 
-&pdm0 {
+dmic_dev: &pdm0 {
 	pinctrl-0 = <&dfsdm1_ckout_pd3
 		     &dfsdm1_datin1_pc3>;
 	pinctrl-names = "default";

--- a/boards/st/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/st/stm32l476g_disco/stm32l476g_disco.dts
@@ -20,6 +20,8 @@
 	aliases {
 		dmic0 = &dmic_dev;
 		i2s-codec-tx = &sai1_a;
+		led0 = &green_led_4;
+		sw0 = &joy_center;
 	};
 
 	chosen {
@@ -75,11 +77,6 @@
 			gpios = <&gpioa 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_RIGHT>;
 		};
-	};
-
-	aliases {
-		led0 = &green_led_4;
-		sw0 = &joy_center;
 	};
 };
 


### PR DESCRIPTION
dmic_api test suite needs a `dmic-dev` alias while samples using DMIC uses `dmic_dev` label.  Declare both in order to run tests natively on boards that supports it.

This only solve the symptomatic issue that tests and samples do not acquire the DMIC device the same way.  This could be the leading point to an update. Let me know if this is needed. 