### PR TITLE
scripts: zspdx: scanner: fully leverage REUSE for license and copyright scan, including modules

### DIFF
--- a/scripts/pylib/zspdx/scanner.py
+++ b/scripts/pylib/zspdx/scanner.py
@@ -31,57 +31,12 @@ class ScannerConfig:
     # each File's license, based on its detected license(s)?
     should_conclude_file_licenses: bool = True
 
-    # number of lines to scan for SPDX-License-Identifier (0 = all)
-    # defaults to 20
-    num_lines_scanned: int = 20
-
     # should we calculate SHA256 hashes for each Component's Files?
     # note that SHA1 hashes are mandatory, per SPDX 2.3
     do_sha256: bool = True
 
     # should we calculate MD5 hashes for each Component's Files?
     do_md5: bool = False
-
-
-def parse_line_for_expression(line):
-    """Return parsed SPDX expression if tag found in line, or None otherwise."""
-    p = line.partition("SPDX-License-Identifier:")
-    if p[2] == "":
-        return None
-    # strip away trailing comment marks and whitespace, if any
-    expression = p[2].strip()
-    expression = expression.rstrip("/*")
-    expression = expression.strip()
-    return expression
-
-
-def get_expression_data(file_path, num_lines):
-    """
-    Scans the specified file for the first SPDX-License-Identifier:
-    tag in the file.
-
-    Arguments:
-        - file_path: path to file to scan.
-        - num_lines: number of lines to scan for an expression before
-                    giving up. If 0, will scan the entire file.
-    Returns: parsed expression if found; None if not found.
-    """
-    _logger.debug("  - getting licenses for %s", file_path)
-
-    with open(file_path) as f:
-        try:
-            for lineno, line in enumerate(f, start=1):
-                if lineno > num_lines > 0:
-                    break
-                expression = parse_line_for_expression(line)
-                if expression is not None:
-                    return expression
-        except UnicodeDecodeError:
-            # invalid UTF-8 content
-            return None
-
-    # if we get here, we didn't find an expression
-    return None
 
 
 def split_expression(expression):
@@ -237,25 +192,16 @@ def scan_sbom_graph(cfg, sbom_graph):
                 f.hashes["MD5"] = h_md5
 
             # get licenses for file
-            expression = get_expression_data(f.path, cfg.num_lines_scanned)
             reuse_licenses, copyrights = get_reuse_info(reuse_project, f.path)
 
-            if expression:
-                # in-file SPDX-License-Identifier tag takes priority
+            if reuse_licenses:
                 if cfg.should_conclude_file_licenses:
-                    f.concluded_license = expression
-                f.license_info_in_file = split_expression(expression)
-            elif reuse_licenses:
-                # fall back to REUSE.toml / .reuse/dep5 bulk annotation
-                combined = " AND ".join(
-                    f"({e})" if " " in e else e for e in reuse_licenses
+                    f.concluded_license = " AND ".join(
+                        f"({e})" if " " in e else e for e in reuse_licenses
+                    )
+                f.license_info_in_file = sorted(
+                    {lic for expr in reuse_licenses for lic in split_expression(expr)}
                 )
-                if cfg.should_conclude_file_licenses:
-                    f.concluded_license = combined
-                f.license_info_in_file = []
-                for lic_expr in reuse_licenses:
-                    f.license_info_in_file.extend(split_expression(lic_expr))
-                f.license_info_in_file = sorted(set(f.license_info_in_file))
 
             if copyrights:
                 f.copyright_text = "<text>\n" + "\n".join(copyrights) + "\n</text>"

--- a/scripts/pylib/zspdx/scanner.py
+++ b/scripts/pylib/zspdx/scanner.py
@@ -14,6 +14,10 @@ from .util import get_hashes
 
 _logger = logging.getLogger(__name__)
 
+# Quiet the reuse library's own logger as it may warn about REUSE-compliance
+# issues (e.g. malformed LICENSES/ file names).
+logging.getLogger("reuse").setLevel(logging.ERROR)
+
 
 # ScannerConfig contains settings used to configure how the SBOM
 # scanning should occur.
@@ -159,30 +163,38 @@ def normalize_expression(lics_concluded):
     return " AND ".join(revised)
 
 
-def get_copyright_info(file_path):
+def get_reuse_info(project, file_path):
     """
-    Scans the specified file for copyright information using REUSE tools.
+    Retrieve SPDX license expressions and copyright notices for a file using
+    the REUSE library.
 
     Arguments:
+        - project: reuse.project.Project for the file's component, rooted at
+          the component's base_dir so that REUSE.toml are found; may be None
         - file_path: path to file to scan
 
-    Returns: list of copyright statements if found; empty list if not found
+    Returns: (list of license expression strings, list of copyright strings)
     """
-    _logger.debug("  - getting copyright info for %s", file_path)
+    if project is None:
+        return [], []
+
+    _logger.debug("  - getting REUSE info for %s", file_path)
 
     try:
-        project = Project(os.path.dirname(file_path))
         infos = project.reuse_info_of(file_path)
+        licenses = []
         copyrights = []
 
         for info in infos:
+            for expr in info.spdx_expressions:
+                licenses.append(str(expr))
             for notice in info.copyright_notices:
-                copyrights.extend([notice.original])
+                copyrights.append(str(notice))
 
-        return copyrights
+        return licenses, copyrights
     except Exception:
-        _logger.warning("Error getting copyright info for %s", file_path, exc_info=True)
-        return []
+        _logger.warning("Error getting REUSE info for %s", file_path, exc_info=True)
+        return [], []
 
 
 def scan_sbom_graph(cfg, sbom_graph):
@@ -196,6 +208,16 @@ def scan_sbom_graph(cfg, sbom_graph):
     """
     for component in sbom_graph.components.values():
         _logger.info("scanning files in component %s", component.name)
+
+        # build the REUSE project once per component, rooted at the
+        # component's own base_dir, and reuse it for all of its files
+        try:
+            reuse_project = Project.from_directory(str(component.base_dir))
+        except Exception:
+            _logger.warning(
+                "Error building REUSE project for %s", component.base_dir, exc_info=True
+            )
+            reuse_project = None
 
         # first, gather File data for this component
         for f in component.files.values():
@@ -216,12 +238,26 @@ def scan_sbom_graph(cfg, sbom_graph):
 
             # get licenses for file
             expression = get_expression_data(f.path, cfg.num_lines_scanned)
+            reuse_licenses, copyrights = get_reuse_info(reuse_project, f.path)
+
             if expression:
+                # in-file SPDX-License-Identifier tag takes priority
                 if cfg.should_conclude_file_licenses:
                     f.concluded_license = expression
                 f.license_info_in_file = split_expression(expression)
+            elif reuse_licenses:
+                # fall back to REUSE.toml / .reuse/dep5 bulk annotation
+                combined = " AND ".join(
+                    f"({e})" if " " in e else e for e in reuse_licenses
+                )
+                if cfg.should_conclude_file_licenses:
+                    f.concluded_license = combined
+                f.license_info_in_file = []
+                for lic_expr in reuse_licenses:
+                    f.license_info_in_file.extend(split_expression(lic_expr))
+                f.license_info_in_file = sorted(set(f.license_info_in_file))
 
-            if copyrights := get_copyright_info(f.path):
+            if copyrights:
                 f.copyright_text = "<text>\n" + "\n".join(copyrights) + "\n</text>"
 
             # check if any custom license IDs should be flagged for SBOM

--- a/scripts/pylib/zspdx/walker.py
+++ b/scripts/pylib/zspdx/walker.py
@@ -869,19 +869,21 @@ class Walker:
         ):
             return self.component_sdk
 
-        # Check app
-        if self.component_app and self._is_within(src_abspath, self.component_app.base_dir):
-            return self.component_app
-
-        # Check zephyr sources and module sources. A module path is nested under
-        # the zephyr west topdir, so prefer the deepest matching base_dir to attribute
-        # a file to its owning module rather than to the top-level zephyr component.
-        zephyr_candidates = list(self.component_zephyr_modules.values())
+        # Check app sources, zephyr sources and module sources together,
+        # preferring the deepest (most specific) matching base_dir. A module can
+        # be nested under the application's source directory or under the zephyr
+        # west topdir, so an ordered check that returned the app (or the
+        # top-level zephyr) component first would misattribute a module's files.
+        # Selecting the deepest base_dir instead assigns each file to its true
+        # owner.
+        candidates = list(self.component_zephyr_modules.values())
         if self.component_zephyr:
-            zephyr_candidates.append(self.component_zephyr)
+            candidates.append(self.component_zephyr)
+        if self.component_app:
+            candidates.append(self.component_app)
 
         best_match = None
-        for component in zephyr_candidates:
+        for component in candidates:
             if self._is_within(src_abspath, component.base_dir) and (
                 best_match is None or len(component.base_dir) > len(best_match.base_dir)
             ):

--- a/tests/application_development/software_bill_of_materials/CMakeLists.txt
+++ b/tests/application_development/software_bill_of_materials/CMakeLists.txt
@@ -2,6 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
+
+# Pull two extra Zephyr modules into the build that we fully control so they are reflected in the
+# generated SBOM and we can verify various properties (license detection, source presence, etc.).
+# One of them (sbom_used_module) has code that is actually compiled and called from the application,
+# so its source is analyzed; the other (sbom_unused_module) is declared but builds nothing, so it
+# appears only as an empty source package and a dependency entry. Both modules live in-tree under
+# this application directory; 'west spdx' still attributes their sources to the owning module.
+list(APPEND EXTRA_ZEPHYR_MODULES
+  "${CMAKE_CURRENT_SOURCE_DIR}/used_module"
+  "${CMAKE_CURRENT_SOURCE_DIR}/unused_module"
+)
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(sbom_spdx)

--- a/tests/application_development/software_bill_of_materials/src/main.c
+++ b/tests/application_development/software_bill_of_materials/src/main.c
@@ -7,7 +7,10 @@
 
 #include <zephyr/kernel.h>
 
+#include <answer.h>
+
 int main(void)
 {
-	return 0;
+	/* Reference the "used" module so its code is linked into the image. */
+	return sbom_used_module_answer() == 42 ? 0 : 1;
 }

--- a/tests/application_development/software_bill_of_materials/unused_module/CMakeLists.txt
+++ b/tests/application_development/software_bill_of_materials/unused_module/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_SBOM_UNUSED_MODULE)
+  zephyr_library()
+  zephyr_library_sources(src/unused.c)
+  zephyr_include_directories(include)
+endif()

--- a/tests/application_development/software_bill_of_materials/unused_module/Kconfig
+++ b/tests/application_development/software_bill_of_materials/unused_module/Kconfig
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config SBOM_UNUSED_MODULE
+	bool "Build the sbom_unused_module sources"
+	help
+	  When enabled, compiles sources from sbom_unused_module. It is left disabled for this test
+	  so the source stays out of the build.

--- a/tests/application_development/software_bill_of_materials/unused_module/include/sbom_unused_module.h
+++ b/tests/application_development/software_bill_of_materials/unused_module/include/sbom_unused_module.h
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SBOM_UNUSED_MODULE_H_
+#define SBOM_UNUSED_MODULE_H_
+
+/**
+ * @brief A helper that ships with the module but is never compiled or called.
+ *
+ * src/unused.c is gated behind CONFIG_SBOM_UNUSED_MODULE, which is disabled for
+ * this test, so this file must not appear anywhere in the generated SBOM.
+ */
+int sbom_unused_module_noop(void);
+
+#endif /* SBOM_UNUSED_MODULE_H_ */

--- a/tests/application_development/software_bill_of_materials/unused_module/src/unused.c
+++ b/tests/application_development/software_bill_of_materials/unused_module/src/unused.c
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sbom_unused_module.h>
+
+int sbom_unused_module_noop(void)
+{
+	return 0;
+}

--- a/tests/application_development/software_bill_of_materials/unused_module/zephyr/module.yml
+++ b/tests/application_development/software_bill_of_materials/unused_module/zephyr/module.yml
@@ -1,0 +1,5 @@
+name: sbom_unused_module
+
+build:
+  cmake: ./
+  kconfig: ./Kconfig

--- a/tests/application_development/software_bill_of_materials/used_module/CMakeLists.txt
+++ b/tests/application_development/software_bill_of_materials/used_module/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(src/answer.c)
+# no_header.c has no SPDX tags of its own; its license/copyright come from
+# REUSE.toml. Compiling it lets the SBOM tests verify REUSE.toml support.
+zephyr_library_sources(src/no_header.c)
+zephyr_include_directories(include)

--- a/tests/application_development/software_bill_of_materials/used_module/REUSE.toml
+++ b/tests/application_development/software_bill_of_materials/used_module/REUSE.toml
@@ -1,0 +1,6 @@
+version = 1
+
+[[annotations]]
+path = "src/*"
+SPDX-License-Identifier = "Apache-2.0"
+SPDX-FileCopyrightText = "Copyright The Zephyr Project Contributors"

--- a/tests/application_development/software_bill_of_materials/used_module/include/answer.h
+++ b/tests/application_development/software_bill_of_materials/used_module/include/answer.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SBOM_USED_MODULE_ANSWER_H_
+#define SBOM_USED_MODULE_ANSWER_H_
+
+/**
+ * @brief Return the answer computed by the "used" SBOM demo module.
+ *
+ * The application calls this from main() so that the module's compiled code is
+ * pulled into the final image and its source appears in the generated SBOM.
+ *
+ * @return The answer to the ultimate question of life, the universe, and everything.
+ */
+int sbom_used_module_answer(void);
+
+/**
+ * @brief A helper whose source file carries no license/copyright header.
+ *
+ * src/no_header.c has no SPDX tags of its own; its license and copyright are
+ * supplied by the module's REUSE.toml. It exists to prove that 'west spdx'
+ * honours REUSE.toml annotations when analyzing a source file.
+ *
+ * @return An arbitrary value.
+ */
+int sbom_used_module_from_reuse_toml(void);
+
+#endif /* SBOM_USED_MODULE_ANSWER_H_ */

--- a/tests/application_development/software_bill_of_materials/used_module/src/answer.c
+++ b/tests/application_development/software_bill_of_materials/used_module/src/answer.c
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <answer.h>
+
+int sbom_used_module_answer(void)
+{
+	return 42;
+}

--- a/tests/application_development/software_bill_of_materials/used_module/src/no_header.c
+++ b/tests/application_development/software_bill_of_materials/used_module/src/no_header.c
@@ -1,0 +1,12 @@
+/*
+ * This file intentionally carries no SPDX-License-Identifier or
+ * SPDX-FileCopyrightText tag. Its license and copyright are provided by the
+ * module's REUSE.toml, which 'west spdx' must honour when analyzing it.
+ */
+
+#include <answer.h>
+
+int sbom_used_module_from_reuse_toml(void)
+{
+	return 7;
+}

--- a/tests/application_development/software_bill_of_materials/used_module/zephyr/module.yml
+++ b/tests/application_development/software_bill_of_materials/used_module/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: sbom_used_module
+
+build:
+  cmake: ./

--- a/tests/application_development/software_bill_of_materials/verify_spdx_content.py
+++ b/tests/application_development/software_bill_of_materials/verify_spdx_content.py
@@ -237,7 +237,7 @@ class TestAppDocument:
         copyright_text = str(main_c_spdx.copyright_text)
         expected = [
             "Copyright The Zephyr Project Contributors",
-            "Copyright (c) 2026 The Linux Foundation",
+            "Copyright (C) 2026 The Linux Foundation",
         ]
         for s in expected:
             assert s in copyright_text, f"main.c copyright missing '{s}', got '{copyright_text}'"

--- a/tests/application_development/software_bill_of_materials/verify_spdx_content.py
+++ b/tests/application_development/software_bill_of_materials/verify_spdx_content.py
@@ -28,11 +28,34 @@ FILE_LIBKERNEL_A = "./zephyr/kernel/libkernel.a"
 FILE_LIBZEPHYR_A = "./zephyr/libzephyr.a"
 FILE_ZEPHYR_ELF = "./zephyr/zephyr.elf"
 
+PKG_USED_MODULE_SOURCES = "sbom_used_module-sources"
+PKG_UNUSED_MODULE_SOURCES = "sbom_unused_module-sources"
+PKG_USED_MODULE_DEPS = "sbom_used_module-deps"
+PKG_UNUSED_MODULE_DEPS = "sbom_unused_module-deps"
+
+FILE_USED_MODULE_C = "./src/answer.c"
+FILE_UNUSED_MODULE_C = "unused.c"
+FILE_REUSE_TOML_C = "./src/no_header.c"
+
+# Common license and copyright strings as they appear in the SBOM.
+LICENSE_APACHE = "Apache-2.0"
+COPYRIGHT_ZEPHYR = "Copyright The Zephyr Project Contributors"
+COPYRIGHT_LINUX_FOUNDATION = "Copyright (C) 2026 The Linux Foundation"
+
+# answer.c declares its copyright with the SPDX tag, and the scanner stores each
+# notice canonically between newlines, so this is the exact value in the SBOM.
+EXPECTED_USED_MODULE_COPYRIGHT = f"\nSPDX-FileCopyrightText: {COPYRIGHT_ZEPHYR}\n"
+
 
 def find_file_by_name(doc, name):
     """Find a file in a document by exact name."""
 
     return next((f for f in doc.files if f.name == name), None)
+
+
+def file_license_ids(spdx_file):
+    """Return the list of license identifiers detected inside a file."""
+    return [str(lic) for lic in spdx_file.license_info_in_file]
 
 
 def find_package_by_name(doc, name):
@@ -224,8 +247,10 @@ class TestAppDocument:
         assert main_c_spdx.license_info_in_file, "app.spdx: main.c has no license_info_in_file"
 
         license_strs = [str(lic) for lic in main_c_spdx.license_info_in_file]
-        has_apache = any("Apache-2.0" in lic for lic in license_strs)
-        assert has_apache, f"app.spdx: main.c license should be Apache-2.0, got {license_strs}"
+        has_apache = any(LICENSE_APACHE in lic for lic in license_strs)
+        assert has_apache, (
+            f"app.spdx: main.c license should be {LICENSE_APACHE}, got {license_strs}"
+        )
 
     def test_main_c_copyright_correct(self, app_doc):
         """Test that main.c has correct copyright text."""
@@ -235,10 +260,8 @@ class TestAppDocument:
         assert main_c_spdx.copyright_text, "app.spdx: main.c has no copyright_text"
 
         copyright_text = str(main_c_spdx.copyright_text)
-        expected = [
-            "Copyright The Zephyr Project Contributors",
-            "Copyright (C) 2026 The Linux Foundation",
-        ]
+        # REUSE canonicalizes notices (e.g. "(c)" -> "(C)"), so match that form.
+        expected = [COPYRIGHT_ZEPHYR, COPYRIGHT_LINUX_FOUNDATION]
         for s in expected:
             assert s in copyright_text, f"main.c copyright missing '{s}', got '{copyright_text}'"
 
@@ -290,9 +313,11 @@ class TestZephyrDocument:
             f
             for f in zephyr_doc.files
             if f.license_info_in_file
-            and any("Apache-2.0" in str(lic) for lic in f.license_info_in_file)
+            and any(LICENSE_APACHE in str(lic) for lic in f.license_info_in_file)
         ]
-        assert len(files_with_apache) > 0, "zephyr.spdx: no files have Apache-2.0 license info"
+        assert len(files_with_apache) > 0, (
+            f"zephyr.spdx: no files have {LICENSE_APACHE} license info"
+        )
 
     def test_verification_code(self, zephyr_doc):
         """Test that verification code is present when files are analyzed."""
@@ -613,3 +638,193 @@ class TestBuildTraceability:
         source_names = [str(r.related_spdx_element_id) for r in generated_from_rels]
         found = any(expected_source in name for name in source_names)
         assert found, f"build.spdx: {FILE_LIBKERNEL_A} should be GENERATED_FROM {expected_source}"
+
+
+class TestExtraModules:
+    """Tests for the two extra Zephyr modules pulled into the SBOM.
+
+    The build adds two modules via EXTRA_ZEPHYR_MODULES:
+      * ``sbom_used_module``   compiled and called from main.c, so its Apache-2.0 source is analyzed
+      * ``sbom_unused_module`` declared but builds nothing, so it is present only as an empty source
+                               package and a dependency entry.
+
+    Both must surface as source packages in zephyr.spdx and as dependency packages in
+    modules-deps.spdx.
+    Only the compiled module contributes an analyzed, licensed source file; the declared-only module
+    should stay empty.
+    """
+
+    @pytest.mark.parametrize(
+        "pkg_name",
+        [PKG_USED_MODULE_SOURCES, PKG_UNUSED_MODULE_SOURCES],
+    )
+    def test_module_source_package_exists(self, zephyr_doc, pkg_name):
+        """Both module source packages must exist in zephyr.spdx."""
+        pkg = find_package_by_name(zephyr_doc, pkg_name)
+        pkg_names = [p.name for p in zephyr_doc.packages]
+        assert pkg is not None, f"zephyr.spdx: expected '{pkg_name}' package, got {pkg_names}"
+
+    @pytest.mark.parametrize(
+        "pkg_name",
+        [PKG_USED_MODULE_SOURCES, PKG_UNUSED_MODULE_SOURCES],
+    )
+    def test_module_source_package_spdx_id(self, zephyr_doc, pkg_name):
+        """Module source packages must have a valid, normalized SPDX ID."""
+        pkg = find_package_by_name(zephyr_doc, pkg_name)
+        assert pkg is not None, f"zephyr.spdx: '{pkg_name}' package not found"
+        expected_id = "SPDXRef-" + pkg_name.replace("_", "-")
+        assert pkg.spdx_id == expected_id, (
+            f"zephyr.spdx: {pkg_name} spdx_id is '{pkg.spdx_id}', expected '{expected_id}'"
+        )
+
+    def test_used_module_file_present(self, zephyr_doc):
+        """The used module contributes its source file to zephyr.spdx."""
+        f = find_file_by_name(zephyr_doc, FILE_USED_MODULE_C)
+        assert f is not None, f"zephyr.spdx: {FILE_USED_MODULE_C} not found"
+
+    def test_used_module_file_has_sha1(self, zephyr_doc):
+        """The used module's source file must carry a SHA1 checksum."""
+        f = find_file_by_name(zephyr_doc, FILE_USED_MODULE_C)
+        assert f is not None, f"zephyr.spdx: {FILE_USED_MODULE_C} not found"
+        sha1s = [c for c in f.checksums if c.algorithm == ChecksumAlgorithm.SHA1]
+        assert len(sha1s) > 0, f"zephyr.spdx: {FILE_USED_MODULE_C} has no SHA1 checksum"
+
+    def test_used_module_license_is_apache(self, zephyr_doc):
+        """The used module's file must be analyzed as Apache-2.0."""
+        f = find_file_by_name(zephyr_doc, FILE_USED_MODULE_C)
+        assert f is not None, f"zephyr.spdx: {FILE_USED_MODULE_C} not found"
+        licenses = file_license_ids(f)
+        assert any(LICENSE_APACHE in lic for lic in licenses), (
+            f"zephyr.spdx: {FILE_USED_MODULE_C} license should be {LICENSE_APACHE}, got {licenses}"
+        )
+
+    def test_used_module_files_analyzed(self, zephyr_doc):
+        """The used module package must be marked as having analyzed files."""
+        pkg = find_package_by_name(zephyr_doc, PKG_USED_MODULE_SOURCES)
+        assert pkg is not None, f"zephyr.spdx: '{PKG_USED_MODULE_SOURCES}' package not found"
+        assert pkg.files_analyzed, (
+            f"zephyr.spdx: {PKG_USED_MODULE_SOURCES} should have files_analyzed=True"
+        )
+
+    # --- REUSE.toml supplies license/copyright for a header-less source ---
+
+    def test_reuse_toml_file_present(self, zephyr_doc):
+        """The header-less source compiled by the used module is analyzed."""
+        f = find_file_by_name(zephyr_doc, FILE_REUSE_TOML_C)
+        assert f is not None, f"zephyr.spdx: {FILE_REUSE_TOML_C} not found"
+
+    def test_reuse_toml_license_applied(self, zephyr_doc):
+        """A file with no SPDX tag must get its license from REUSE.toml."""
+        f = find_file_by_name(zephyr_doc, FILE_REUSE_TOML_C)
+        assert f is not None, f"zephyr.spdx: {FILE_REUSE_TOML_C} not found"
+        licenses = file_license_ids(f)
+        assert any(LICENSE_APACHE in lic for lic in licenses), (
+            f"zephyr.spdx: {FILE_REUSE_TOML_C} license should be {LICENSE_APACHE} "
+            f"(from REUSE.toml), got {licenses}"
+        )
+
+    def test_reuse_toml_copyright_applied(self, zephyr_doc):
+        """A file with no SPDX tag must get its copyright from REUSE.toml."""
+        f = find_file_by_name(zephyr_doc, FILE_REUSE_TOML_C)
+        assert f is not None, f"zephyr.spdx: {FILE_REUSE_TOML_C} not found"
+        assert COPYRIGHT_ZEPHYR in str(f.copyright_text), (
+            f"zephyr.spdx: {FILE_REUSE_TOML_C} copyright should come from REUSE.toml "
+            f"('{COPYRIGHT_ZEPHYR}'), got '{f.copyright_text}'"
+        )
+
+    def test_reuse_toml_file_in_used_module_package(self, zephyr_doc):
+        """The header-less source must be attributed to the used module package."""
+        pkg = find_package_by_name(zephyr_doc, PKG_USED_MODULE_SOURCES)
+        assert pkg is not None, f"zephyr.spdx: '{PKG_USED_MODULE_SOURCES}' package not found"
+        f = find_file_by_name(zephyr_doc, FILE_REUSE_TOML_C)
+        assert f is not None, f"zephyr.spdx: {FILE_REUSE_TOML_C} not found"
+        contained = {
+            str(r.related_spdx_element_id)
+            for r in get_relationships_for_element(
+                zephyr_doc, pkg.spdx_id, RelationshipType.CONTAINS
+            )
+        }
+        assert f.spdx_id in contained, (
+            f"zephyr.spdx: {PKG_USED_MODULE_SOURCES} does not CONTAIN {FILE_REUSE_TOML_C}"
+        )
+
+    def test_unused_module_has_no_files(self, zephyr_doc):
+        """The unused module is declared but compiles nothing, its source package must therefore
+        exist yet stay empty.
+        """
+        pkg = find_package_by_name(zephyr_doc, PKG_UNUSED_MODULE_SOURCES)
+        assert pkg is not None, f"zephyr.spdx: '{PKG_UNUSED_MODULE_SOURCES}' package not found"
+        assert not pkg.files_analyzed, (
+            f"zephyr.spdx: {PKG_UNUSED_MODULE_SOURCES} should have files_analyzed=False"
+        )
+        contains = get_relationships_for_element(zephyr_doc, pkg.spdx_id, RelationshipType.CONTAINS)
+        assert len(contains) == 0, (
+            f"zephyr.spdx: {PKG_UNUSED_MODULE_SOURCES} should contain no files, got {len(contains)}"
+        )
+
+    def test_unused_module_source_absent_from_sbom(
+        self, app_doc, zephyr_doc, build_doc, modules_doc
+    ):
+        """A module's source file that is never compiled must not leak into the SBOM."""
+        docs = {
+            "app.spdx": app_doc,
+            "zephyr.spdx": zephyr_doc,
+            "build.spdx": build_doc,
+            "modules-deps.spdx": modules_doc,
+        }
+        for doc_name, doc in docs.items():
+            offenders = [
+                f.name for f in doc.files if os.path.basename(f.name) == FILE_UNUSED_MODULE_C
+            ]
+            assert not offenders, (
+                f"{doc_name}: lists un-compiled source(s) that should be absent: {offenders}"
+            )
+
+    def test_used_module_copyright(self, zephyr_doc):
+        """The used module file must expose exactly its copyright text."""
+        f = find_file_by_name(zephyr_doc, FILE_USED_MODULE_C)
+        assert f is not None, f"zephyr.spdx: {FILE_USED_MODULE_C} not found"
+        assert str(f.copyright_text) == EXPECTED_USED_MODULE_COPYRIGHT, (
+            f"zephyr.spdx: {FILE_USED_MODULE_C} copyright is '{f.copyright_text}', "
+            f"expected '{EXPECTED_USED_MODULE_COPYRIGHT}'"
+        )
+
+    def test_used_module_package_contains_its_file(self, zephyr_doc):
+        """The used module package must CONTAIN its source file."""
+        pkg = find_package_by_name(zephyr_doc, PKG_USED_MODULE_SOURCES)
+        assert pkg is not None, f"zephyr.spdx: '{PKG_USED_MODULE_SOURCES}' package not found"
+        f = find_file_by_name(zephyr_doc, FILE_USED_MODULE_C)
+        assert f is not None, f"zephyr.spdx: {FILE_USED_MODULE_C} not found"
+
+        contained = {
+            str(r.related_spdx_element_id)
+            for r in get_relationships_for_element(
+                zephyr_doc, pkg.spdx_id, RelationshipType.CONTAINS
+            )
+        }
+        assert f.spdx_id in contained, (
+            f"zephyr.spdx: {PKG_USED_MODULE_SOURCES} does not CONTAIN {FILE_USED_MODULE_C}"
+        )
+
+    @pytest.mark.parametrize(
+        "pkg_name",
+        [PKG_USED_MODULE_DEPS, PKG_UNUSED_MODULE_DEPS],
+    )
+    def test_module_deps_package_exists(self, modules_doc, pkg_name):
+        """Both modules must be listed as dependency packages in modules-deps.spdx."""
+        pkg = find_package_by_name(modules_doc, pkg_name)
+        pkg_names = [p.name for p in modules_doc.packages]
+        assert pkg is not None, f"modules-deps.spdx: expected '{pkg_name}' package, got {pkg_names}"
+
+    @pytest.mark.parametrize(
+        "pkg_name",
+        [PKG_USED_MODULE_DEPS, PKG_UNUSED_MODULE_DEPS],
+    )
+    def test_module_deps_depend_on_zephyr(self, modules_doc, pkg_name):
+        """Each module dependency must be a DEPENDENCY_OF the zephyr dependency."""
+        pkg = find_package_by_name(modules_doc, pkg_name)
+        assert pkg is not None, f"modules-deps.spdx: '{pkg_name}' package not found"
+        dep_rels = get_relationships_for_element(
+            modules_doc, pkg.spdx_id, RelationshipType.DEPENDENCY_OF
+        )
+        assert len(dep_rels) > 0, f"modules-deps.spdx: {pkg_name} has no DEPENDENCY_OF relationship"

--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 40b720b80ab8f399263998dfc9a0e8a2bfc7a729
+      revision: e0897095c27423aafd59e0d2c79f11fb4ff894b0
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
- Updated `hal_stm32` to comply with REUSE spec that should be parse-able with new spdx 3.0 SBOM geneation command.
- Drop custom license extraction code to fully rely on `reuse-tool` instead
- Ensure reuse-tool sees each module as a project so that any reuse.toml file it may contain is properly read

Assisted-by: GitHub Copilot (Claude Sonnet 4.6)
Assisted-by: Claude:sonnet-5