### PR TITLE
doc: fix Sparkfun Thing Plus Matter name in index.rst

### DIFF
--- a/boards/sparkfun/thing_plus_matter_mgm240p/doc/index.rst
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/doc/index.rst
@@ -80,10 +80,10 @@ Build the Zephyr kernel and application:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: sparkfun_thing_plus_mgm240p
+   :board: sparkfun_thing_plus_matter_mgm240p
    :goals: build
 
-Connect the sparkfun_thing_plus_mgm240p to your host computer using the USB port and you
+Connect the ``sparkfun_thing_plus_matter_mgm240p`` to your host computer using the USB port and you
 should see a USB connection.
 
 Open a serial terminal (minicom, putty, etc.) with the following settings:

--- a/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
@@ -16,7 +16,7 @@
 
 / {
 	model = "Sparkfun MGM240P (Sparkfun Thing Plus Matter)";
-	compatible = "sparkfun,sparkfun_thing_plus_mgm240p", "silabs,efr32mg24";
+	compatible = "sparkfun,sparkfun_thing_plus_matter_mgm240p", "silabs,efr32mg24";
 
 	chosen {
 		zephyr,bt-hci = &bt_hci_silabs;


### PR DESCRIPTION
minor fix for name inconsistency in the `index.rst` file for the Sparkfun Thing Plus Matter board.

I copied the build command for the `hello_world` sample and was confused as to why it errors out. Turns out the name is mismatched. So just a minor fix so that someone won't encounter the same issue again.