### PR TITLE
kernel: dynamic: combine thread state checks in stack free

### DIFF
--- a/kernel/dynamic.c
+++ b/kernel/dynamic.c
@@ -121,8 +121,7 @@ int z_impl_k_thread_stack_free(k_thread_stack_t *stack)
 	k_thread_foreach(dyn_cb, &data);
 
 	if (data.tid != NULL) {
-		if (!(z_is_thread_state_set(data.tid, _THREAD_DUMMY) ||
-		      z_is_thread_state_set(data.tid, _THREAD_DEAD))) {
+		if (!z_is_thread_state_set(data.tid, _THREAD_DUMMY | _THREAD_DEAD)) {
 			LOG_ERR("tid %p is in use!", data.tid);
 			return -EBUSY;
 		}


### PR DESCRIPTION
z_impl_k_thread_stack_free() tested _THREAD_DUMMY and _THREAD_DEAD
with two separate z_is_thread_state_set() calls combined with a
logical OR. z_is_thread_state_set() returns (thread_state & state)
!= 0, so the two calls are equivalent to a single call with both
bits ORed into the mask. Collapse them into one call; this is
smaller and clearer with no change in behavior.

