### PR TITLE
include: devicetree: Exclude non "cpu" nodes when iterating through "cpus"

### DIFF
--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -79,7 +79,7 @@ volatile struct boot_params arm_cpu_boot_params = {
 };
 
 const uint32_t cpu_node_list[] = {
-	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))};
+	DT_FOREACH_CPU_STATUS_OKAY_SEP(DT_REG_ADDR, (,))};
 
 /* cpu_map saves the mapping of core id and mpid */
 static uint32_t cpu_map[CONFIG_MP_MAX_NUM_CPUS] = {

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -52,7 +52,7 @@ volatile struct boot_params __aligned(L1_CACHE_BYTES) arm64_cpu_boot_params = {
 };
 
 const uint64_t cpu_node_list[] = {
-	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))
+	DT_FOREACH_CPU_STATUS_OKAY_SEP(DT_REG_ADDR, (,))
 };
 
 BUILD_ASSERT(ARRAY_SIZE(cpu_node_list) == DT_CHILD_NUM_STATUS_OKAY(DT_PATH(cpus)));

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -51,7 +51,7 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 #endif
 #if ((CONFIG_MP_MAX_NUM_CPUS) > 1)
 	unsigned int cpu_node_list[] = {
-		DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))
+		DT_FOREACH_CPU_STATUS_OKAY_SEP(DT_REG_ADDR, (,))
 	};
 	unsigned int cpu_num, hart_x;
 

--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -28,7 +28,7 @@
 #endif
 
 static const uint64_t cpu_mpid_list[] = {
-	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))
+	DT_FOREACH_CPU_STATUS_OKAY_SEP(DT_REG_ADDR, (,))
 };
 
 BUILD_ASSERT(ARRAY_SIZE(cpu_mpid_list) >= CONFIG_MP_MAX_NUM_CPUS,

--- a/dts/bindings/cpu/cpu.yaml
+++ b/dts/bindings/cpu/cpu.yaml
@@ -6,6 +6,13 @@
 include: base.yaml
 
 properties:
+  device_type:
+    type: string
+    default: "cpu"
+    description: |
+      Standard device_type identifying this node as a cpu. Required to maintain compatibility
+      with the IEEE 1275 standard as well as for DT_FOREACH_CPU family of devicetree macros to
+      identify cpu nodes within the "/cpus" parent node
   clock-frequency:
     type: int
     description: Clock frequency in Hz

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -6064,5 +6064,6 @@
 #include <zephyr/devicetree/mapped-partition.h>
 #include <zephyr/devicetree/partitions.h>
 #include <zephyr/devicetree/sram.h>
+#include <zephyr/devicetree/cpu.h>
 
 #endif /* ZEPHYR_INCLUDE_DEVICETREE_H_ */

--- a/include/zephyr/devicetree/cpu.h
+++ b/include/zephyr/devicetree/cpu.h
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief CPU devicetree macro public API header file.
+ */
+#ifndef ZEPHYR_INCLUDE_DEVICETREE_CPU_H_
+#define ZEPHYR_INCLUDE_DEVICETREE_CPU_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util_macro.h>
+
+/**
+ * @defgroup devicetree-cpu Devicetree Interrupt CPU API
+ * @ingroup devicetree
+ * @{
+ */
+
+/**
+ * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
+ *        device_type is "cpu"
+ *
+ * The macro @p fn must take one parameter, which will be the node
+ * identifier of a "/cpus" child node with device_type = "cpu". Children of
+ * "/cpus" that do not have device_type = "cpu" are skipped.
+ *
+ * Example devicetree fragment:
+ *
+ * @code{.dts}
+ *     cpus {
+ *             cpu0: cpu@0 {
+ *                     device_type = "cpu";
+ *                     reg = <0>;
+ *             };
+ *             cpu1: cpu@1 {
+ *                     device_type = "cpu";
+ *                     reg = <1>;
+ *             };
+ *             power-states {
+ *                     idle: idle { ... };
+ *             };
+ *     };
+ * @endcode
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     #define REG_AND_COMMA(node_id) DT_REG_ADDR(node_id),
+ *
+ *     const uint32_t cpu_regs[] = {
+ *         DT_FOREACH_CPU(REG_AND_COMMA)
+ *     };
+ * @endcode
+ *
+ * This expands to:
+ *
+ * @code{.c}
+ *     const uint32_t cpu_regs[] = {
+ *         0, 1,
+ *     };
+ * @endcode
+ *
+ * Notice that "power-states" is skipped, since its device_type is not "cpu".
+ *
+ * @param fn macro to invoke
+ */
+#define DT_FOREACH_CPU(fn) DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_INTERNAL, fn)
+
+/**
+ * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
+ *        device_type is "cpu", with a separator
+ *
+ * The macro @p fn must take one parameter, which will be the node
+ * identifier of a "/cpus" child node with device_type = "cpu". Children of
+ * "/cpus" that do not have device_type = "cpu" are skipped.
+ *
+ * @p sep is placed after each invocation of @p fn, not between invocations.
+ * This means the expansion has a trailing @p sep, which is convenient for
+ * initializers since a trailing comma is legal.
+ *
+ * Example usage:
+ *
+ * @code{.c}
+ *     const uint32_t cpu_regs[] = {
+ *         DT_FOREACH_CPU_SEP(DT_REG_ADDR, (,))
+ *     };
+ * @endcode
+ *
+ * @param fn macro to invoke
+ * @param sep Separator (e.g. comma or semicolon) placed after each
+ *            invocation of @p fn. Must be in parentheses; this is required
+ *            to enable providing a comma as separator.
+ *
+ * @see DT_FOREACH_CPU
+ */
+#define DT_FOREACH_CPU_SEP(fn, sep)                                                                \
+	DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_SEP_INTERNAL, fn, sep)
+
+/**
+ * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
+ *        device_type is "cpu", with multiple arguments
+ *
+ * The macro @p fn takes multiple arguments. The first should be the node
+ * identifier for the "/cpus" child node. The remaining are passed-in by the
+ * caller.
+ *
+ * @param fn macro to invoke
+ * @param ... variable number of arguments to pass to @p fn
+ *
+ * @see DT_FOREACH_CPU
+ */
+#define DT_FOREACH_CPU_VARGS(fn, ...)                                                              \
+	DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_VARGS_INTERNAL, fn, __VA_ARGS__)
+
+/**
+ * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
+ *        device_type is "cpu", with a separator and multiple arguments
+ *
+ * The macro @p fn takes multiple arguments. The remaining are passed-in by the caller.
+ *
+ * @param fn macro to invoke
+ * @param sep Separator (e.g. comma or semicolon) placed after each
+ *            invocation of @p fn. Must be in parentheses; this is required
+ *            to enable providing a comma as separator.
+ * @param ... variable number of arguments to pass to @p fn
+ *
+ * @see DT_FOREACH_CPU_SEP
+ */
+#define DT_FOREACH_CPU_SEP_VARGS(fn, sep, ...)                                                     \
+	DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_SEP_VARGS_INTERNAL, fn, sep,          \
+			       __VA_ARGS__)
+
+/**
+ * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
+ *        device_type is "cpu" and status is "okay"
+ *
+ * This macro iterates through children of the "/cpus" node in the same order
+ * as they appear in the final devicetree, but children whose status is not `okay`
+ * are also skipped.
+ *
+ * @param fn macro to invoke
+ *
+ * @see DT_FOREACH_CPU
+ */
+#define DT_FOREACH_CPU_STATUS_OKAY(fn)                                                             \
+	DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_STATUS_OKAY_INTERNAL, fn)
+
+/**
+ * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
+ *        device_type is "cpu" and status is "okay", with a separator
+ *
+ * This macro iterates through children of the "/cpus" node in the same order
+ * as they appear in the final devicetree, but children whose status is not `okay`
+ * are also skipped.
+ *
+ * @param fn macro to invoke
+ * @param sep Separator (e.g. comma or semicolon) placed after each
+ *            invocation of @p fn. Must be in parentheses; this is required
+ *            to enable providing a comma as separator.
+ *
+ * @see DT_FOREACH_CPU_SEP
+ */
+#define DT_FOREACH_CPU_STATUS_OKAY_SEP(fn, sep)                                                    \
+	DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_STATUS_OKAY_SEP_INTERNAL, fn, sep)
+
+/**
+ * @brief Invokes @p fn for each child of the devicetree's "/cpus" node whose
+ *        device_type is "cpu" and status is "okay", with a separator and
+ *        multiple arguments
+ *
+ * This macro iterates through children of the "/cpus" node in the same order
+ * as they appear in the final devicetree, but children whose status is not `okay`
+ * are also skipped.
+ *
+ * @param fn macro to invoke
+ * @param sep Separator (e.g. comma or semicolon) placed after each
+ *            invocation of @p fn. Must be in parentheses; this is required
+ *            to enable providing a comma as separator.
+ * @param ... variable number of arguments to pass to @p fn
+ *
+ * @see DT_FOREACH_CPU_STATUS_OKAY_SEP
+ */
+#define DT_FOREACH_CPU_STATUS_OKAY_SEP_VARGS(fn, sep, ...)                                         \
+	DT_FOREACH_CHILD_VARGS(DT_PATH(cpus), DT_FOREACH_CPU_STATUS_OKAY_SEP_VARGS_INTERNAL, fn,   \
+			       sep, __VA_ARGS__)
+
+/** @cond INTERNAL_HIDDEN */
+#define DT_FOREACH_CPU_INTERNAL(node_id, fn)                                                       \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), (fn(node_id)), ())
+
+#define DT_FOREACH_CPU_VARGS_INTERNAL(node_id, fn, ...)                                            \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), \
+		    (fn(node_id, __VA_ARGS__)), ())
+
+#define DT_FOREACH_CPU_SEP_INTERNAL(node_id, fn, sep)                                              \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), \
+		    (fn(node_id) DT_DEBRACKET_INTERNAL sep), ())
+
+#define DT_FOREACH_CPU_SEP_VARGS_INTERNAL(node_id, fn, sep, ...)                                   \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), \
+		    (fn(node_id, __VA_ARGS__) DT_DEBRACKET_INTERNAL sep), ())
+
+#define DT_FOREACH_CPU_STATUS_OKAY_INTERNAL(node_id, fn)                                           \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), \
+		    (COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(node_id), (fn(node_id)), ())), ())
+
+#define DT_FOREACH_CPU_STATUS_OKAY_SEP_INTERNAL(node_id, fn, sep)                                  \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), \
+		    (COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(node_id), \
+				  (fn(node_id) DT_DEBRACKET_INTERNAL sep), ())), \
+		    ())
+
+#define DT_FOREACH_CPU_STATUS_OKAY_SEP_VARGS_INTERNAL(node_id, fn, sep, ...)                       \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, device_type), \
+		    (COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(node_id), \
+				  (fn(node_id, __VA_ARGS__) DT_DEBRACKET_INTERNAL sep), ())), \
+		    ())
+/** @endcond */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DEVICETREE_CPU_H_ */

--- a/scripts/bindings_properties_allowlist.yaml
+++ b/scripts/bindings_properties_allowlist.yaml
@@ -9,3 +9,4 @@
 
 - mmc-hs200-1_8v
 - mmc-hs400-1_8v
+- device_type

--- a/tests/lib/devicetree/cpu/CMakeLists.txt
+++ b/tests/lib/devicetree/cpu/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(devicetree_cpu)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/lib/devicetree/cpu/app.overlay
+++ b/tests/lib/devicetree/cpu/app.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Application overlay for testing the DT_FOREACH_CPU family of
+ * devicetree macros.
+ *
+ * Defines 8 CPUs and adds a "power-states" sibling node under
+ * "/cpus" to verify that non-cpu children are skipped when iterating.
+ */
+
+&{/cpus/cpu@0} {
+	device_type = "cpu";
+	status = "okay";
+};
+
+&{/cpus} {
+	power-states {
+		idle: idle {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			min-residency-us = <1000000>;
+		};
+	};
+};

--- a/tests/lib/devicetree/cpu/prj.conf
+++ b/tests/lib/devicetree/cpu/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/lib/devicetree/cpu/src/main.c
+++ b/tests/lib/devicetree/cpu/src/main.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+#include <zephyr/devicetree.h>
+
+static const uint32_t cpu_regs[] = {
+	DT_FOREACH_CPU_STATUS_OKAY_SEP(DT_REG_ADDR, (,))
+};
+
+ZTEST_SUITE(devicetree_cpu, NULL, NULL, NULL, NULL, NULL);
+
+ZTEST(devicetree_cpu, test_foreach_cpu_status_okay_sep_skips_non_cpu)
+{
+	/*
+	 * "/cpus" has two types of children:
+	 * (1) At least 1 "cpu@#" node with (device_type = "cpu")
+	 * (2) "power-states" (no device_type)
+	 *
+	 * Only cpu nodes should be counted
+	 */
+	printf("Number of cpu entries found: %d\n", ARRAY_SIZE(cpu_regs));
+
+	zassert_true(ARRAY_SIZE(cpu_regs) >= 1, "Expected at least 1 cpu entry");
+	zassert_equal(cpu_regs[0], DT_REG_ADDR(DT_PATH(cpus, cpu_0)), "");
+}

--- a/tests/lib/devicetree/cpu/tests.yaml
+++ b/tests/lib/devicetree/cpu/tests.yaml
@@ -1,0 +1,9 @@
+tests:
+  libraries.devicetree.cpu:
+    tags: devicetree
+    # We only need this to run on one platform so use native_sim as it
+    # will mostly likely be the fastest.
+    integration_platforms:
+      - native_sim
+    platform_allow:
+      - native_sim


### PR DESCRIPTION
Currently, with SMP enabled, the arch_kernel_init function for RISCV blindly iterates through all items in the "cpus" node, which could include nodes blindly / incorrectly. The loop should check for the `device_type` property to ensure only "cpu" children nodes are chosen.

**Detailed Analysis**

In Linux upstream there is an `idle-states` node that is "a direct child of the cpus node" (https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/cpu/idle-states.yaml#L237-L238). Zephyr uses a similar procedure with their `power-states` node and adds their `power-states` node within `cpus` to align with this practice (see https://github.com/zephyrproject-rtos/zephyr/commit/e4c43e4cc98cba02470e654db9fd29065e5c4ff1).

On RISCV with SMP enabled `power-states` is blindly included when evaluating each child of `cpus` and will fail to compile due to no `reg` property being present. Rather than break Linux convention and move `power-states` out of `cpus` it would be more robust to identify CPUs based on the `device_type` property before adding them to the cpu list. 