### PR TITLE
[Backport v4.4-branch] net: ocpp: add mixed array support for ocpp1.6 JSON messages

### DIFF
--- a/subsys/net/lib/ocpp/ocpp_j.c
+++ b/subsys/net/lib/ocpp/ocpp_j.c
@@ -9,44 +9,6 @@
 #include <zephyr/data/json.h>
 #include <zephyr/random/random.h>
 
-static int extract_string_field(char *out_buf, int outlen, char *token)
-{
-	char *end;
-
-	if (out_buf == NULL || token == NULL) {
-		return -EINVAL;
-	}
-
-	strncpy(out_buf, token + 1, outlen - 1);
-	end = strchr(out_buf, '"');
-	if (end != NULL) {
-		*end = '\0';
-	}
-
-	return 0;
-}
-
-static int extract_payload(char *msg, int msglen)
-{
-	size_t len;
-	char *start = strchr(msg, '{');
-	char *end = strrchr(msg, '}');
-
-	if (start == NULL || end == NULL || end < start) {
-		return -EINVAL;
-	}
-
-	len = end - start + 1;
-	if (len >= msglen) {
-		return -ENOMEM;
-	}
-
-	memmove(msg, start, len);
-	msg[len] = '\0';
-
-	return 0;
-}
-
 static int frame_rpc_call_req(char *rpcbuf, int len, int pdu,
 			      uint32_t ses, char *pdumsg)
 {
@@ -475,64 +437,78 @@ static int frame_status_resp_msg(char *buf, int len, char *res, char *uid)
 int parse_rpc_msg(char *msg, int msglen, char *uid, int uidlen,
 		  int *pdu, bool *is_rsp)
 {
-	int ret;
-	char local_buf[JSON_MSG_BUF_512];
-	char action[JSON_MSG_BUF_128];
-	char *token;
-	char *saveptr = NULL;
-	int rpc_id = -1;
+	struct json_ocpp_call_res_msg call_res_msg = { 0 };
+	struct json_ocpp_call_req_msg call_req_msg = { 0 };
+	int ret = 0;
 
-	if (msg == NULL || uid == NULL || pdu == NULL || is_rsp == NULL) {
+	if (msg == NULL || uid == NULL || pdu == NULL || is_rsp == NULL || msglen < 2) {
 		return -EINVAL;
 	}
 
-	memcpy(local_buf, msg + 1, sizeof(local_buf) - 1);
-	local_buf[sizeof(local_buf) - 1] = '\0';
+	switch (msg[1]) {
+	case OCPP_WAMP_RPC_REQ: {
+		call_req_msg.count = 4;
+		struct json_mixed_arr_descr call_req_descr[] = {
+			JSON_MIXED_ARR_DESCR_PRIM(struct json_ocpp_call_req_msg,
+						  call_req, JSON_TOK_INT, count),
+			JSON_MIXED_ARR_DESCR_PRIM(struct json_ocpp_call_req_msg,
+						  uid, JSON_TOK_STRING, count),
+			JSON_MIXED_ARR_DESCR_PRIM(struct json_ocpp_call_req_msg,
+						  action, JSON_TOK_STRING, count),
+			JSON_MIXED_ARR_DESCR_PRIM(struct json_ocpp_call_req_msg,
+						  payload, JSON_TOK_ENCODED_OBJ, count),
+		};
 
-	token = strtok_r(local_buf, ",", &saveptr);
-	if (token == NULL) {
-		return -EINVAL;
-	}
-
-	rpc_id = *token - '0';
-
-	token = strtok_r(NULL, ",", &saveptr);
-	if (token == NULL) {
-		return -EINVAL;
-	}
-
-	ret = extract_string_field(uid, uidlen, token);
-	if (ret < 0) {
-		return ret;
-	}
-
-	switch (rpc_id + '0') {
-	case OCPP_WAMP_RPC_REQ:
-		token = strtok_r(NULL, ",", &saveptr);
-		if (token == NULL) {
-			return -EINVAL;
-		}
-
-		ret = extract_string_field(action, sizeof(action), token);
-		if (ret < 0) {
+		ret = json_mixed_arr_parse(msg, msglen, call_req_descr,
+					   ARRAY_SIZE(call_req_descr), &call_req_msg);
+		if (ret != ARRAY_SIZE(call_req_descr)) {
 			return ret;
 		}
-		*pdu = ocpp_find_pdu_from_literal(action);
-		__fallthrough;
 
-	case OCPP_WAMP_RPC_RESP:
-		*is_rsp = rpc_id - 2;
-		ret = extract_payload(msg, msglen);
-		if (ret < 0) {
-			return ret;
-		}
+		*is_rsp = false;
+		*pdu = ocpp_find_pdu_from_literal(call_req_msg.action);
+		strncpy(uid, call_req_msg.uid, uidlen - 1);
+		uid[uidlen - 1] = '\0';
+
+		memmove(msg, call_req_msg.payload, strlen(call_req_msg.payload) + 1);
+		memset(msg + strlen(msg) + 1, 0, msglen - strlen(msg) - 1);
 		break;
+	}
 
-	case OCPP_WAMP_RPC_ERR:
+	case OCPP_WAMP_RPC_RESP: {
+		call_res_msg.count = 3;
+		struct json_mixed_arr_descr call_res_descr[] = {
+			JSON_MIXED_ARR_DESCR_PRIM(struct json_ocpp_call_res_msg,
+						  call_res, JSON_TOK_INT, count),
+			JSON_MIXED_ARR_DESCR_PRIM(struct json_ocpp_call_res_msg,
+						  uid, JSON_TOK_STRING, count),
+			JSON_MIXED_ARR_DESCR_PRIM(struct json_ocpp_call_res_msg,
+						  payload, JSON_TOK_ENCODED_OBJ, count),
+		};
+
+		ret = json_mixed_arr_parse(msg, msglen, call_res_descr,
+					   ARRAY_SIZE(call_res_descr), &call_res_msg);
+		if (ret != ARRAY_SIZE(call_res_descr)) {
+			return ret;
+		}
+
+		*is_rsp = true;
+		*pdu = -1;
+		strncpy(uid, call_res_msg.uid, uidlen - 1);
+		uid[uidlen - 1] = '\0';
+
+		memmove(msg, call_res_msg.payload, strlen(call_res_msg.payload) + 1);
+		memset(msg + strlen(msg) + 1, 0, msglen - strlen(msg) - 1);
+		break;
+	}
+
+	case OCPP_WAMP_RPC_ERR: {
 		__fallthrough;
+	}
 
-	default:
+	default: {
 		return -EINVAL;
+	}
 	}
 
 	return 0;

--- a/subsys/net/lib/ocpp/ocpp_j.h
+++ b/subsys/net/lib/ocpp/ocpp_j.h
@@ -25,6 +25,21 @@
 #define SAMPLED_VALUE_MIN_FIELDS 2
 #define SAMPLED_VALUE_MAX_FIELDS 3
 
+struct json_ocpp_call_req_msg {
+	char *uid;
+	const char *action;
+	char *payload;
+	size_t count;
+	uint8_t call_req;
+};
+
+struct json_ocpp_call_res_msg {
+	char *uid;
+	char *payload;
+	size_t count;
+	uint8_t call_res;
+};
+
 struct json_common_payload_field {
 	int val1;
 	char *val2;


### PR DESCRIPTION
Backport of the fix from #95399 to `v4.4-branch`.

Fixes: #112424