### PR TITLE
treewide: combine OR'd bitmask tests into a single masked check

### DIFF
--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -737,7 +737,7 @@ static int mcp2515_get_state(const struct device *dev, enum can_state *state,
 			*state = CAN_STATE_STOPPED;
 		} else if (eflg & MCP2515_EFLG_TXBO) {
 			*state = CAN_STATE_BUS_OFF;
-		} else if ((eflg & MCP2515_EFLG_RXEP) || (eflg & MCP2515_EFLG_TXEP)) {
+		} else if (eflg & (MCP2515_EFLG_RXEP | MCP2515_EFLG_TXEP)) {
 			*state = CAN_STATE_ERROR_PASSIVE;
 		} else if (eflg & MCP2515_EFLG_EWARN) {
 			*state = CAN_STATE_ERROR_WARNING;

--- a/drivers/ethernet/eth_stm32_hal_v2.c
+++ b/drivers/ethernet/eth_stm32_hal_v2.c
@@ -498,12 +498,10 @@ static void eth_stm32_update_dma_error(struct eth_stm32_hal_dev_data *dev_data, 
 		eth_stats_update_errors_tx(dev_data->iface);
 	}
 #else
-	if ((dma_error & ETH_DMASR_RWTS) || (dma_error & ETH_DMASR_RPSS) ||
-	    (dma_error & ETH_DMASR_RBUS)) {
+	if (dma_error & (ETH_DMASR_RWTS | ETH_DMASR_RPSS | ETH_DMASR_RBUS)) {
 		eth_stats_update_errors_rx(dev_data->iface);
 	}
-	if ((dma_error & ETH_DMASR_ETS) || (dma_error & ETH_DMASR_TPSS) ||
-	    (dma_error & ETH_DMASR_TJTS)) {
+	if (dma_error & (ETH_DMASR_ETS | ETH_DMASR_TPSS | ETH_DMASR_TJTS)) {
 		eth_stats_update_errors_tx(dev_data->iface);
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet) */

--- a/drivers/gpio/gpio_aw9523b.c
+++ b/drivers/gpio/gpio_aw9523b.c
@@ -89,7 +89,7 @@ static int gpio_aw9523b_pin_configure(const struct device *dev, gpio_pin_t pin, 
 		}
 	}
 
-	if ((flags & GPIO_INPUT) && ((flags & GPIO_PULL_UP) || (flags & GPIO_PULL_DOWN))) {
+	if ((flags & GPIO_INPUT) && (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN))) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/gpio/gpio_numicro.c
+++ b/drivers/gpio/gpio_numicro.c
@@ -92,7 +92,7 @@ static int gpio_numicro_configure(const struct device *dev,
 	}
 
 	/* Bias */
-	if ((flags & GPIO_OUTPUT) != 0 || (flags & GPIO_INPUT) != 0) {
+	if ((flags & (GPIO_OUTPUT | GPIO_INPUT)) != 0) {
 		if ((flags & GPIO_PULL_UP) != 0) {
 			bias = GPIO_PUSEL_PULL_UP;
 		} else if ((flags & GPIO_PULL_DOWN) != 0) {

--- a/drivers/gpio/gpio_pca_series.c
+++ b/drivers/gpio/gpio_pca_series.c
@@ -1028,7 +1028,7 @@ static int gpio_pca_series_pin_configure(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	if ((flags & GPIO_PULL_UP) || (flags & GPIO_PULL_DOWN)) {
+	if (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) {
 		if ((cfg->part_cfg->flags & PCA_HAS_PULL) == 0U) {
 			return -ENOTSUP;
 		}
@@ -1073,7 +1073,7 @@ static int gpio_pca_series_pin_configure(const struct device *dev,
 	}
 
 	if ((cfg->part_cfg->flags & PCA_HAS_PULL)) {
-		if ((flags & GPIO_PULL_UP) || (flags & GPIO_PULL_DOWN)) {
+		if (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) {
 			/* configure PCA_REG_TYPE_1B_PULL_SELECT */
 			ret = gpio_pca_series_reg_cache_read(dev,
 				PCA_REG_TYPE_1B_PULL_SELECT, (uint8_t *)&reg_value);
@@ -1100,7 +1100,7 @@ static int gpio_pca_series_pin_configure(const struct device *dev,
 			goto out;
 		}
 		reg_value = sys_le32_to_cpu(reg_value);
-		if ((flags & GPIO_PULL_UP) || (flags & GPIO_PULL_DOWN)) {
+		if (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) {
 			reg_value |= (BIT(pin)); /* set bit to enable pull */
 		} else {
 			reg_value &= (~BIT(pin)); /* clear bit to disable pull */
@@ -1129,7 +1129,7 @@ static int gpio_pca_series_pin_configure(const struct device *dev,
 	}
 
 	/* configure PCA_REG_TYPE_1B_OUTPUT */
-	if ((flags & GPIO_OUTPUT_INIT_HIGH) || (flags & GPIO_OUTPUT_INIT_LOW)) {
+	if (flags & (GPIO_OUTPUT_INIT_HIGH | GPIO_OUTPUT_INIT_LOW)) {
 		uint32_t out_old;
 #ifdef CONFIG_GPIO_PCA_SERIES_CACHE_ALL
 		/* get output register old value from reg cache */

--- a/drivers/gpio/gpio_renesas_rza2m.c
+++ b/drivers/gpio/gpio_renesas_rza2m.c
@@ -319,7 +319,7 @@ static int gpio_rza2m_pin_configure(const struct device *port_dev, gpio_pin_t pi
 		return -EINVAL;
 	}
 
-	if ((flags & GPIO_PULL_UP) || (flags & GPIO_PULL_DOWN)) {
+	if (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/i2c/i2c_bflb.c
+++ b/drivers/i2c/i2c_bflb.c
@@ -407,7 +407,7 @@ static inline bool i2c_bflb_errored(const struct device *dev)
 	const struct i2c_bflb_cfg *config = dev->config;
 	uint32_t tmp = sys_read32(config->base + I2C_INT_STS_OFFSET);
 
-	return (tmp & I2C_ARB_INT) != 0 || (tmp & I2C_FER_INT) != 0;
+	return (tmp & (I2C_ARB_INT | I2C_FER_INT)) != 0;
 }
 
 static int i2c_bflb_write(const struct device *dev, uint8_t *buf, uint8_t len)

--- a/drivers/i2s/i2s_nrf_tdm.c
+++ b/drivers/i2s/i2s_nrf_tdm.c
@@ -549,8 +549,8 @@ static int tdm_nrf_configure(const struct device *dev, enum i2s_dir dir,
 		return -EINVAL;
 	}
 
-	if ((tdm_cfg->format & I2S_FMT_DATA_ORDER_LSB) || (tdm_cfg->format & I2S_FMT_BIT_CLK_INV) ||
-	    (tdm_cfg->format & I2S_FMT_FRAME_CLK_INV)) {
+	if (tdm_cfg->format &
+	    (I2S_FMT_DATA_ORDER_LSB | I2S_FMT_BIT_CLK_INV | I2S_FMT_FRAME_CLK_INV)) {
 		LOG_ERR("Unsupported stream format: 0x%02x", tdm_cfg->format);
 		return -EINVAL;
 	}
@@ -600,7 +600,7 @@ static int tdm_nrf_configure(const struct device *dev, enum i2s_dir dir,
 	 */
 	drv_data->request_clock = (drv_cfg->sck_src != PCLK) || (drv_cfg->mck_src != PCLK);
 
-	if ((tdm_cfg->options & I2S_OPT_LOOPBACK) || (tdm_cfg->options & I2S_OPT_PINGPONG)) {
+	if (tdm_cfg->options & (I2S_OPT_LOOPBACK | I2S_OPT_PINGPONG)) {
 		LOG_ERR("Unsupported options: 0x%02x", tdm_cfg->options);
 		return -EINVAL;
 	}

--- a/drivers/interrupt_controller/intc_ite_it51xxx.c
+++ b/drivers/interrupt_controller/intc_ite_it51xxx.c
@@ -147,14 +147,14 @@ void ite_intc_irq_polarity_set(unsigned int irq, unsigned int flags)
 	i = irq % MAX_REGISR_IRQ_NUM;
 
 	tri = sys_read8(intc_base + INTC_GRPNIPOLR(g));
-	if ((flags & IRQ_TYPE_LEVEL_HIGH) || (flags & IRQ_TYPE_EDGE_RISING)) {
+	if (flags & (IRQ_TYPE_LEVEL_HIGH | IRQ_TYPE_EDGE_RISING)) {
 		sys_write8(tri & ~BIT(i), intc_base + INTC_GRPNIPOLR(g));
 	} else {
 		sys_write8(tri | BIT(i), intc_base + INTC_GRPNIPOLR(g));
 	}
 
 	tri = sys_read8(intc_base + INTC_GRPNIELMR(g));
-	if ((flags & IRQ_TYPE_LEVEL_LOW) || (flags & IRQ_TYPE_LEVEL_HIGH)) {
+	if (flags & (IRQ_TYPE_LEVEL_LOW | IRQ_TYPE_LEVEL_HIGH)) {
 		sys_write8(tri & ~BIT(i), intc_base + INTC_GRPNIELMR(g));
 	} else {
 		sys_write8(tri | BIT(i), intc_base + INTC_GRPNIELMR(g));

--- a/drivers/interrupt_controller/intc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.c
@@ -172,13 +172,13 @@ void ite_intc_irq_polarity_set(unsigned int irq, unsigned int flags)
 	g = irq / MAX_REGISR_IRQ_NUM;
 	i = irq % MAX_REGISR_IRQ_NUM;
 	tri = reg_ipolr[g];
-	if ((flags&IRQ_TYPE_LEVEL_HIGH) || (flags&IRQ_TYPE_EDGE_RISING)) {
+	if (flags & (IRQ_TYPE_LEVEL_HIGH | IRQ_TYPE_EDGE_RISING)) {
 		CLEAR_MASK(*tri, BIT(i));
 	} else {
 		SET_MASK(*tri, BIT(i));
 	}
 	tri = reg_ielmr[g];
-	if ((flags&IRQ_TYPE_LEVEL_LOW) || (flags&IRQ_TYPE_LEVEL_HIGH)) {
+	if (flags & (IRQ_TYPE_LEVEL_LOW | IRQ_TYPE_LEVEL_HIGH)) {
 		CLEAR_MASK(*tri, BIT(i));
 	} else {
 		SET_MASK(*tri, BIT(i));

--- a/drivers/interrupt_controller/intc_ite_it8xxx2_v2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2_v2.c
@@ -148,13 +148,13 @@ void ite_intc_irq_polarity_set(unsigned int irq, unsigned int flags)
 	group = irq / MAX_REGISR_IRQ_NUM;
 	index = irq % MAX_REGISR_IRQ_NUM;
 
-	if ((flags & IRQ_TYPE_LEVEL_HIGH) || (flags & IRQ_TYPE_EDGE_RISING)) {
+	if (flags & (IRQ_TYPE_LEVEL_HIGH | IRQ_TYPE_EDGE_RISING)) {
 		IT8XXX2_INTC_IPOLR(group) &= ~BIT(index);
 	} else {
 		IT8XXX2_INTC_IPOLR(group) |= BIT(index);
 	}
 
-	if ((flags & IRQ_TYPE_LEVEL_LOW) || (flags & IRQ_TYPE_LEVEL_HIGH)) {
+	if (flags & (IRQ_TYPE_LEVEL_LOW | IRQ_TYPE_LEVEL_HIGH)) {
 		IT8XXX2_INTC_IELMR(group) &= ~BIT(index);
 	} else {
 		IT8XXX2_INTC_IELMR(group) |= BIT(index);

--- a/drivers/mfd/mfd_rv3032.c
+++ b/drivers/mfd/mfd_rv3032.c
@@ -186,7 +186,7 @@ static void mfd_rv3032_work_cb(struct k_work *work)
 	}
 
 	/* Temperature Low/High Flags - SENSORS */
-	if ((status & RV3032_STATUS_TLF) || (status & RV3032_STATUS_THF)) {
+	if (status & (RV3032_STATUS_TLF | RV3032_STATUS_THF)) {
 		ret = mfd_rv3032_clear_status(data->dev, RV3032_STATUS_TLF | RV3032_STATUS_THF);
 		mfd_rv3032_fire_child_callback(data, RV3032_DEV_SENSOR);
 		LOG_DBG("(STATUS) Temperature Low/High Flag (%x)\n", status);

--- a/drivers/rtc/rtc_rv8803.c
+++ b/drivers/rtc/rtc_rv8803.c
@@ -510,7 +510,7 @@ static int rv8803_alarm_set_time(const struct device *dev, uint16_t id, uint16_t
 	}
 
 	/* Update WADA bit */
-	if ((mask & RTC_ALARM_TIME_MASK_MONTHDAY) || (mask & RTC_ALARM_TIME_MASK_WEEKDAY)) {
+	if (mask & (RTC_ALARM_TIME_MASK_MONTHDAY | RTC_ALARM_TIME_MASK_WEEKDAY)) {
 		reg_val = (mask & RTC_ALARM_TIME_MASK_MONTHDAY) ? RV8803_EXTENSION_WADA_BIT : 0;
 		err = rv8803_update_reg8(dev, RV8803_EXTENSION_REG, RV8803_EXTENSION_WADA_BIT,
 					 reg_val);

--- a/drivers/sdhc/sdhc_cdns_ll.c
+++ b/drivers/sdhc/sdhc_cdns_ll.c
@@ -735,7 +735,7 @@ static int sdhc_cdns_send_cmd(struct sdmmc_cmd *cmd, struct sdhc_data *data)
 		return -EIO;
 	}
 
-	if ((op & RES_TYPE_SEL_48) || (op & RES_TYPE_SEL_136)) {
+	if (op & (RES_TYPE_SEL_48 | RES_TYPE_SEL_136)) {
 		cmd->resp_data[0] = sys_read32(cdns_params.reg_base + SDHC_CDNS_SRS04);
 		if (op & RES_TYPE_SEL_136) {
 			cmd->resp_data[1] = sys_read32(cdns_params.reg_base + SDHC_CDNS_SRS05);

--- a/drivers/sensor/cht8315/cht8315.c
+++ b/drivers/sensor/cht8315/cht8315.c
@@ -256,13 +256,13 @@ static void cht8315_work_handler(struct k_work *work)
 	}
 
 	if (data->t_cb != NULL && !data->t_triggered
-	    && ((tmp & CHT8315_REG_STATUS_THIGH) != 0 || (tmp & CHT8315_REG_STATUS_TLOW) != 0)) {
+	    && (tmp & (CHT8315_REG_STATUS_THIGH | CHT8315_REG_STATUS_TLOW)) != 0) {
 		data->t_triggered = true;
 		data->t_cb(data->dev, data->t_trig);
 	}
 
 	if (data->rh_cb != NULL && !data->rh_triggered
-	    && ((tmp & CHT8315_REG_STATUS_HHIGH) != 0 || (tmp & CHT8315_REG_STATUS_HLOW) != 0)) {
+	    && (tmp & (CHT8315_REG_STATUS_HHIGH | CHT8315_REG_STATUS_HLOW)) != 0) {
 		data->rh_triggered = true;
 		data->rh_cb(data->dev, data->rh_trig);
 	}

--- a/drivers/watchdog/wdt_bee_core.c
+++ b/drivers/watchdog/wdt_bee_core.c
@@ -74,7 +74,7 @@ static int core_wdt_bee_setup(const struct device *dev, uint8_t options)
 {
 	struct core_wdt_bee_data *data = dev->data;
 
-	if ((options & WDT_OPT_PAUSE_IN_SLEEP) || (options & WDT_OPT_PAUSE_HALTED_BY_DBG)) {
+	if (options & (WDT_OPT_PAUSE_IN_SLEEP | WDT_OPT_PAUSE_HALTED_BY_DBG)) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/watchdog/wdt_counter.c
+++ b/drivers/watchdog/wdt_counter.c
@@ -33,7 +33,7 @@ static int wdt_counter_setup(const struct device *dev, uint8_t options)
 	const struct wdt_counter_config *config = dev->config;
 	const struct device *counter = config->counter;
 
-	if ((options & WDT_OPT_PAUSE_IN_SLEEP) || (options & WDT_OPT_PAUSE_HALTED_BY_DBG)) {
+	if (options & (WDT_OPT_PAUSE_IN_SLEEP | WDT_OPT_PAUSE_HALTED_BY_DBG)) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/watchdog/wdt_m5pm1.c
+++ b/drivers/watchdog/wdt_m5pm1.c
@@ -50,7 +50,7 @@ static int wdt_m5pm1_setup(const struct device *dev, uint8_t options)
 		return -EBUSY;
 	}
 
-	if ((options & WDT_OPT_PAUSE_IN_SLEEP) || (options & WDT_OPT_PAUSE_HALTED_BY_DBG)) {
+	if (options & (WDT_OPT_PAUSE_IN_SLEEP | WDT_OPT_PAUSE_HALTED_BY_DBG)) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/watchdog/wdt_nxp_fs26.c
+++ b/drivers/watchdog/wdt_nxp_fs26.c
@@ -436,7 +436,7 @@ static int wdt_nxp_fs26_setup(const struct device *dev, uint8_t options)
 		return -EINVAL;
 	}
 
-	if ((options & WDT_OPT_PAUSE_IN_SLEEP) || (options & WDT_OPT_PAUSE_HALTED_BY_DBG)) {
+	if (options & (WDT_OPT_PAUSE_IN_SLEEP | WDT_OPT_PAUSE_HALTED_BY_DBG)) {
 		return -ENOTSUP;
 	}
 

--- a/drivers/watchdog/wdt_rts5817.c
+++ b/drivers/watchdog/wdt_rts5817.c
@@ -41,7 +41,7 @@ static int rts_fp_wdt_setup(const struct device *dev, uint8_t options)
 {
 	uint32_t value;
 
-	if ((options & WDT_OPT_PAUSE_IN_SLEEP) || (options & WDT_OPT_PAUSE_HALTED_BY_DBG)) {
+	if (options & (WDT_OPT_PAUSE_IN_SLEEP | WDT_OPT_PAUSE_HALTED_BY_DBG)) {
 		LOG_ERR("Pause in sleep or halted by dbg is not supported");
 		return -ENOTSUP;
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -820,7 +820,7 @@ uint8_t ll_df_set_conn_cte_tx_params(uint16_t handle, uint8_t cte_types, uint8_t
 	}
 
 	/* Check antenna switching pattern only whether CTE TX in AoD mode is allowed */
-	if (((cte_types & BT_HCI_LE_AOD_CTE_RSP_1US) || (cte_types & BT_HCI_LE_AOD_CTE_RSP_2US)) &&
+	if ((cte_types & (BT_HCI_LE_AOD_CTE_RSP_1US | BT_HCI_LE_AOD_CTE_RSP_2US)) &&
 	    (switch_pattern_len < BT_HCI_LE_SWITCH_PATTERN_LEN_MIN ||
 	     switch_pattern_len > BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN || !ant_ids)) {
 		return BT_HCI_ERR_UNSUPP_FEATURE_PARAM_VAL;

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -499,7 +499,7 @@ static int keys_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	 * previous version that did not enforce this requirement.
 	 */
 	if ((keys->flags & BT_KEYS_AUTHENTICATED) &&
-	    !((keys->flags & BT_KEYS_OOB) || (keys->flags & BT_KEYS_SC))) {
+	    !(keys->flags & (BT_KEYS_OOB | BT_KEYS_SC))) {
 		LOG_WRN("The keys for %s are downgraded to unauthenticated as they no longer meet "
 			"authentication requirements",
 			bt_addr_le_str(&addr));


### PR DESCRIPTION
Several places test two or more bits of the *same* value using separate `(x & A) || (x & B)` expressions. Since `(x & A) || (x & B)` is equivalent to `x & (A | B)`, this collapses them into a single masked check.