### PR TITLE
tests: kernel: sys_sem: skip basic_sem_test without userspace

### DIFF
--- a/tests/kernel/mem_protect/sys_sem/src/main.c
+++ b/tests/kernel/mem_protect/sys_sem/src/main.c
@@ -154,10 +154,21 @@ static void sem_multiple_threads_wait_helper(void *p1, void *p2, void *p3)
  *
  * @see sys_sem_init()
  */
-#ifdef CONFIG_USERSPACE
 ZTEST(sys_sem, test_basic_sem_test)
 {
 	int32_t ret_value;
+
+	if (!IS_ENABLED(CONFIG_USERSPACE)) {
+		/*
+		 * The argument validation exercised below (returning -EINVAL)
+		 * only exists in the userspace sys_sem_init(). The supervisor
+		 * build is a thin k_sem wrapper that performs no validation, so
+		 * skip rather than compile the case out: keeping it always
+		 * compiled lets twister observe a reported result on
+		 * non-userspace platforms instead of a missing (None) status.
+		 */
+		ztest_test_skip();
+	}
 
 	ret_value = sys_sem_init(NULL, SEM_INIT_VAL, SEM_MAX_VAL);
 	zassert_true(ret_value == -EINVAL,
@@ -179,7 +190,6 @@ ZTEST(sys_sem, test_basic_sem_test)
 	sys_sem_take(&simple_sem, SEM_TIMEOUT);
 	sys_sem_give(&simple_sem);
 }
-#endif
 
 /**
  * @brief Verify sys_sem_give() from an ISR increments the count.


### PR DESCRIPTION
## Summary

`test_basic_sem_test` checks the argument validation performed by the
userspace `sys_sem_init()` (it returns `-EINVAL` for invalid parameters).
The supervisor-mode `sys_sem_init()` is a thin `k_sem` wrapper that performs
no such validation, so the test was guarded with `#ifdef CONFIG_USERSPACE`
and compiled out on non-userspace builds.

Because the case is compiled out, the test image of a non-userspace build
never reports it, while twister still expects it from its source scan of the
test file. The result is a spurious
`WARNING - A None status detected ... sys_sem.basic_sem_test` for that case
on platforms built without userspace.

## Change

Keep the test always compiled and `ztest_test_skip()` at runtime when
`CONFIG_USERSPACE` is not enabled. The case is now reported as *skipped* on
non-userspace builds and runs normally with userspace, so no false None
status remains. This matches the documented intent of `CONFIG_TEST_USERSPACE`
that such tests "should still run on those platforms, just with all threads
in supervisor mode".

## Testing

Run on hardware (`kit_pse84_eval/pse846gps2dbzc4a/m33`):

- Non-userspace scenario `kernel.memory_protection.sys_sem.nouser`:
  14/14 test cases, `basic_sem_test` reported as **skipped**, no
  None-status warning.
- Userspace scenario `kernel.memory_protection.sys_sem`: 14/14 test cases,
  `basic_sem_test` **passed** (behavior unchanged).
