### PR TITLE
modem: cellular: add operational statistics

### DIFF
--- a/drivers/modem/Kconfig.cellular
+++ b/drivers/modem/Kconfig.cellular
@@ -35,6 +35,14 @@ config MODEM_CELLULAR
 
 if MODEM_CELLULAR
 
+config MODEM_CELLULAR_STATS
+	bool "Operational statistics"
+	help
+	  Maintain cumulative operational counters (outage time, registration
+	  losses, command failures, recoveries, ...) and expose them through
+	  cellular_get_stats(). Adds a small amount of RAM per instance and a
+	  few increments on existing code paths.
+
 config MODEM_CELLULAR_INIT_PRIORITY
 	int "Cellular modem driver initialization priority"
 	default 91

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -452,6 +452,30 @@ static void modem_cellular_clear_registration_status(struct modem_cellular_data 
 	data->registration_status_lte = CELLULAR_REGISTRATION_NOT_REGISTERED;
 }
 
+#if defined(CONFIG_MODEM_CELLULAR_STATS)
+static void modem_cellular_stats_on_reg_transition(struct modem_cellular_data *data,
+						   bool was_registered, bool is_registered)
+{
+	if (was_registered && !is_registered) {
+		data->stats.deregistrations += 1;
+		data->stats_outage_start_ms = k_uptime_get_32();
+	} else if (!was_registered && is_registered && (data->stats_outage_start_ms != 0)) {
+		data->stats.outage_ms += k_uptime_get_32() - data->stats_outage_start_ms;
+		data->stats_outage_start_ms = 0;
+	} else {
+		/* No change in registration state; nothing to record. */
+	}
+}
+
+static void modem_cellular_chat_on_cme_error(struct modem_chat *chat, char **argv, uint16_t argc,
+					     void *user_data)
+{
+	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
+
+	data->stats.command_errors_cme += 1;
+}
+#endif
+
 void modem_cellular_chat_on_cxreg(struct modem_chat *chat, char **argv, uint16_t argc,
 				  void *user_data)
 {
@@ -485,6 +509,9 @@ void modem_cellular_chat_on_cxreg(struct modem_chat *chat, char **argv, uint16_t
 	}
 	LOG_DBG("REG %d AcT %d", registration_status, data->access_tech);
 
+	IF_ENABLED(CONFIG_MODEM_CELLULAR_STATS,
+		   (const bool was_registered = modem_cellular_is_registered(data)));
+
 	if (strcmp(argv[0], "+CREG: ") == 0) {
 		registration_prev = data->registration_status_gsm;
 		data->registration_status_gsm = registration_status;
@@ -495,6 +522,10 @@ void modem_cellular_chat_on_cxreg(struct modem_chat *chat, char **argv, uint16_t
 		registration_prev = data->registration_status_lte;
 		data->registration_status_lte = registration_status;
 	}
+
+	IF_ENABLED(CONFIG_MODEM_CELLULAR_STATS,
+		   (modem_cellular_stats_on_reg_transition(data, was_registered,
+							   modem_cellular_is_registered(data))));
 
 	if (modem_cellular_is_registered(data)) {
 		modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_REGISTERED);
@@ -587,7 +618,10 @@ MODEM_CHAT_MATCH_DEFINE(cgmr_match __maybe_unused, "", "", modem_cellular_chat_o
 
 MODEM_CHAT_MATCHES_DEFINE(abort_matches,
 			  MODEM_CHAT_MATCH("ERROR", "", NULL),
-			  MODEM_CHAT_MATCH("+CME ERROR", "", NULL));
+			  MODEM_CHAT_MATCH("+CME ERROR", "",
+					   COND_CODE_1(CONFIG_MODEM_CELLULAR_STATS,
+						       (modem_cellular_chat_on_cme_error),
+						       (NULL))));
 
 MODEM_CHAT_MATCHES_DEFINE(__maybe_unused dial_abort_matches,
 			  MODEM_CHAT_MATCH("ERROR", "", NULL),
@@ -1029,6 +1063,8 @@ static void modem_cellular_enter_recovery_state(struct modem_cellular_data *data
 {
 	const struct modem_cellular_config *config = data->dev->config;
 
+	IF_ENABLED(CONFIG_MODEM_CELLULAR_STATS, (data->stats.recoveries += 1));
+
 	/* Release CMUX if it was attached, so the UART pipe can be reattached
 	 * cleanly on the next connect attempt. No-op when CMUX is not attached.
 	 */
@@ -1243,6 +1279,7 @@ static void modem_cellular_wait_for_apn_event_handler(struct modem_cellular_data
 static void modem_cellular_script_failed(struct modem_cellular_data *data)
 {
 	data->script_failure_counter++;
+	IF_ENABLED(CONFIG_MODEM_CELLULAR_STATS, (data->stats.command_failures += 1));
 }
 
 static void modem_cellular_script_success(struct modem_cellular_data *data)
@@ -1626,6 +1663,7 @@ static int modem_cellular_on_registered_state_leave(struct modem_cellular_data *
 static int modem_cellular_on_await_ppp_dead_state_enter(struct modem_cellular_data *data)
 {
 	net_if_dormant_on(modem_ppp_get_iface(data->ppp));
+	IF_ENABLED(CONFIG_MODEM_CELLULAR_STATS, (data->stats.link_drops += 1));
 
 	return 0;
 }
@@ -2095,6 +2133,7 @@ static void modem_cellular_cmux_handler(struct modem_cmux *cmux, enum modem_cmux
 		modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_CMUX_CONNECTED);
 		break;
 	case MODEM_CMUX_EVENT_DISCONNECTED:
+		IF_ENABLED(CONFIG_MODEM_CELLULAR_STATS, (data->stats.cmux_disconnects += 1));
 		modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_CMUX_DISCONNECTED);
 		break;
 	default:
@@ -2377,12 +2416,22 @@ int cellular_modem_resume_periodic_script(const struct device *dev)
 	return 0;
 }
 
+#if defined(CONFIG_MODEM_CELLULAR_STATS)
+static const struct cellular_stats *modem_cellular_get_stats(const struct device *dev)
+{
+	struct modem_cellular_data *data = (struct modem_cellular_data *)dev->data;
+
+	return &data->stats;
+}
+#endif
+
 DEVICE_API(cellular, modem_cellular_api) = {
 	.get_signal = modem_cellular_get_signal,
 	.get_modem_info = modem_cellular_get_modem_info,
 	.get_registration_status = modem_cellular_get_registration_status,
 	.set_apn = modem_cellular_set_apn,
 	.set_callback = modem_cellular_set_callback,
+	IF_ENABLED(CONFIG_MODEM_CELLULAR_STATS, (.get_stats = modem_cellular_get_stats,))
 };
 
 int modem_cellular_pm_action(const struct device *dev, enum pm_device_action action)

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -192,6 +192,28 @@ struct cellular_evt_network_status {
 };
 
 /**
+ * @brief Cellular link operational statistics.
+ *
+ * Counters are cumulative since boot.
+ */
+struct cellular_stats {
+	/** Cumulative time the modem was not registered, in milliseconds. */
+	uint32_t outage_ms;
+	/** Registered to not-registered transitions. */
+	uint32_t deregistrations;
+	/** Data-link carrier losses. */
+	uint32_t link_drops;
+	/** Control-channel command failures. */
+	uint32_t command_failures;
+	/** `+CME ERROR` responses. */
+	uint32_t command_errors_cme;
+	/** Recovery transitions entered. */
+	uint32_t recoveries;
+	/** CMUX desync/disconnect events. */
+	uint32_t cmux_disconnects;
+};
+
+/**
  * @brief Prototype for cellular event callbacks.
  *
  * @param dev       Cellular device that generated the event
@@ -243,6 +265,9 @@ typedef int (*cellular_api_set_apn)(const struct device *dev, const char *apn);
 typedef int (*cellular_api_set_callback)(const struct device *dev, cellular_event_mask_t mask,
 					 cellular_event_cb_t cb, void *user_data);
 
+/** API for reading operational statistics */
+typedef const struct cellular_stats *(*cellular_api_get_stats)(const struct device *dev);
+
 /**
  * @driver_ops{Cellular}
  */
@@ -261,6 +286,8 @@ __subsystem struct cellular_driver_api {
 	cellular_api_set_apn set_apn;
 	/** @driver_ops_optional @copybrief cellular_set_callback */
 	cellular_api_set_callback set_callback;
+	/** @driver_ops_optional @copybrief cellular_get_stats */
+	cellular_api_get_stats get_stats;
 };
 
 /** @} */
@@ -441,6 +468,25 @@ static inline int cellular_set_callback(const struct device *dev, cellular_event
 	}
 
 	return api->set_callback(dev, mask, cb, user_data);
+}
+
+/**
+ * @brief Read operational statistics from the cellular device
+ *
+ * @param dev Cellular network device instance.
+ *
+ * @return Pointer to the device's live statistics, or `NULL` if the device does
+ *         not implement the API.
+ */
+static inline const struct cellular_stats *cellular_get_stats(const struct device *dev)
+{
+	const struct cellular_driver_api *api = DEVICE_API_GET(cellular, dev);
+
+	if (api->get_stats == NULL) {
+		return NULL;
+	}
+
+	return api->get_stats(dev);
 }
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -216,6 +216,13 @@ struct modem_cellular_data {
 	atomic_t periodic_paused;
 	/** Set when a TIMEOUT is swallowed while paused; cleared on KICK. */
 	bool periodic_timeout_skipped;
+
+#if defined(CONFIG_MODEM_CELLULAR_STATS)
+	/** Operational statistics, exposed via cellular_get_stats(). */
+	struct cellular_stats stats;
+	/** k_uptime (ms) when registration was last lost; 0 while registered. */
+	uint32_t stats_outage_start_ms;
+#endif
 	/** @endcond */
 };
 

--- a/tests/drivers/build_all/modem/testcase.yaml
+++ b/tests/drivers/build_all/modem/testcase.yaml
@@ -49,6 +49,10 @@ tests:
     extra_args: EXTRA_CONF_FILE=modem_cellular.conf
     extra_configs:
       - CONFIG_UART_ASYNC_API=y
+  drivers.modem.modem_cellular.stats.build:
+    extra_args: EXTRA_CONF_FILE=modem_cellular.conf
+    extra_configs:
+      - CONFIG_MODEM_CELLULAR_STATS=y
   drivers.modem.modem_simcom_sim7080.interrupt_driven.build:
     extra_args: EXTRA_CONF_FILE=modem_simcom_sim7080.conf
     extra_configs:


### PR DESCRIPTION
Adds an optional operational-statistics API to the cellular driver, implemented
in `modem_cellular`, for link-health telemetry on fielded devices.

`cellular_get_stats()` returns a typed `struct cellular_stats` of cumulative
counters (`outage_ms`, `registration_losses`, `link_drops`, `command_failures`,
`command_errors_cme`, `recoveries`, `cmux_errors`). modem_cellular maintains them
at existing hooks (script failure, registration transitions, PPP carrier loss,
CMUX disconnect, recovery), gated on `CONFIG_MODEM_CELLULAR_STATS` (default n).

Shape follows the Ethernet `get_stats()` precedent (optional driver-API op
returning a pointer to the live struct, `NULL` when unsupported)

see the RFC #112442