### PR TITLE
timing: add timing_timestamp_get() for monotonic timestamps

### DIFF
--- a/include/zephyr/timing/timing.h
+++ b/include/zephyr/timing/timing.h
@@ -290,6 +290,24 @@ void timing_start(void);
 void timing_stop(void);
 
 /**
+ * @brief Return a monotonic timestamp in nanoseconds.
+ *
+ * Unlike timing_counter_get(), whose backing counter may be narrower than
+ * 64 bits and wrap, this returns a 64-bit nanosecond value that increases
+ * monotonically across counter wraps. It is intended for consumers that need
+ * an absolute time reference (e.g. trace event timestamps) rather than the
+ * duration between two explicit readings.
+ *
+ * The value is always monotonic. It is also accurate as long as the function
+ * is called at least once per wrap period of the underlying counter; if calls
+ * are further apart the value still only increases but may undercount the
+ * true elapsed time.
+ *
+ * @return Monotonic timestamp in nanoseconds.
+ */
+uint64_t timing_timestamp_get(void);
+
+/**
  * @brief Return timing counter.
  *
  * @return Timing counter.

--- a/subsys/instrumentation/timestamp/timestamp.c
+++ b/subsys/instrumentation/timestamp/timestamp.c
@@ -19,12 +19,5 @@ int instr_timestamp_init(void)
 __no_instrumentation__
 uint64_t instr_timestamp_ns(void)
 {
-	timing_t bigbang = 0;
-	timing_t now;
-	uint64_t now_cycles;
-
-	now = timing_counter_get();
-	now_cycles = timing_cycles_get(&bigbang, &now);
-
-	return timing_cycles_to_ns(now_cycles);
+	return timing_timestamp_get();
 }

--- a/subsys/timing/timing.c
+++ b/subsys/timing/timing.c
@@ -6,6 +6,7 @@
 
 #include <stdbool.h>
 #include <zephyr/kernel.h>
+#include <zephyr/spinlock.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/timing/timing.h>
 
@@ -72,4 +73,36 @@ void timing_stop(void)
 #else
 	arch_timing_stop();
 #endif
+}
+
+uint64_t timing_timestamp_get(void)
+{
+	static struct k_spinlock lock;
+	static timing_t last;
+	static uint64_t total_cycles;
+	k_spinlock_key_t key = k_spin_lock(&lock);
+	timing_t now = timing_counter_get();
+
+	/*
+	 * The timing counter may be narrower than 64 bits and wrap. Accumulate
+	 * the interval since the previous reading rather than the raw counter,
+	 * so the returned timestamp stays monotonic across wraps. Each interval
+	 * is a non-negative value, so the total never decreases regardless of
+	 * how often this is called: monotonicity is guaranteed unconditionally.
+	 * timing_cycles_get() resolves only a single wrap though, so if more
+	 * than one wrap happens between two calls the total undercounts the
+	 * elapsed time; the timestamp stays monotonic but loses absolute
+	 * accuracy. The spinlock keeps the shared accumulator consistent on SMP.
+	 *
+	 * The accumulator is deliberately not seeded on the first call, so
+	 * timestamps are offset by the counter value at that point rather than
+	 * starting from zero. That only shifts the origin, not monotonicity, and
+	 * avoids a first-call test on every subsequent call.
+	 */
+	total_cycles += timing_cycles_get(&last, &now);
+	last = now;
+
+	k_spin_unlock(&lock, key);
+
+	return timing_cycles_to_ns(total_cycles);
 }

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -55,14 +55,7 @@
 
 static inline uint64_t ctf_top_timestamp_get(void)
 {
-	timing_t bigbang = 0;
-	timing_t now;
-	uint64_t now_cycles;
-
-	now = timing_counter_get();
-	now_cycles = timing_cycles_get(&bigbang, &now);
-
-	return timing_cycles_to_ns(now_cycles);
+	return timing_timestamp_get();
 }
 
 #define CTF_EVENT(...)                                                                             \


### PR DESCRIPTION
CTF tracing now emits 64-bit nanosecond timestamps (commit 8afa8f1b5ad4). On boards whose timing counter is narrower than 64 bits, the CTF timestamp helper, and the instrumentation timestamp, derived the value from a fixed zero baseline:

```c
timing_t bigbang = 0;
now = timing_counter_get();
now_cycles = timing_cycles_get(&bigbang, &now);
return timing_cycles_to_ns(now_cycles);
```

From a zero baseline `timing_cycles_get()` just returns the raw counter, which wraps back to near zero every period, so the timestamp jumps backwards on each wrap. Non-monotonic timestamps crash CTF readers such as babeltrace2 ("timestamp is less than muxer's last returned timestamp").

Both call sites want an absolute monotonic clock, which is not what the interval API gives from a fixed zero. Add `timing_timestamp_get()` to the timing subsystem: it accumulates the interval since its previous reading into a 64-bit total before converting to nanoseconds. Each interval is non-negative, so the result is monotonic regardless of how often it is called; it is also accurate as long as no more than one wrap occurs between calls, beyond which it undercounts but still only advances. A spinlock keeps the shared accumulator consistent on SMP, where the callers' `irq_lock` does not.

Both consumers now use it. Consumers that measure intervals between two explicit readings (`kernel/usage.c`, `kernel/mmu.c`, `drivers/flash/flash_shell.c`) are unaffected.

Fixes #111651

This is an alternative to #112232. It uses the same accumulate-and-convert approach, but factors it into the timing subsystem so the instrumentation timestamp (which has the identical bug) is fixed too, rather than only the CTF path.
