### PR TITLE
drivers: wifi: esp_at: drop local-IP field from UDP server CIPSTART

### DIFF
--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -61,8 +61,6 @@ static int _sock_connect(struct esp_data *dev, struct esp_socket *sock)
 			 sock->link_id, dst_addr_str, net_ntohs(net_sin(&dst)->sin_port));
 	} else {
 		if (src.sa_family == NET_AF_INET && net_sin(&src)->sin_port != 0) {
-			net_addr_ntop(src.sa_family, &net_sin(&src)->sin_addr, src_addr_str,
-				      sizeof(src_addr_str));
 			/* <mode>: In the UDP Wi-Fi passthrough
 			 *
 			 * 0: After UDP data is received, the parameters <"remote host">
@@ -91,10 +89,24 @@ static int _sock_connect(struct esp_data *dev, struct esp_socket *sock)
 				mode = 0;
 			}
 
-			snprintk(connect_msg, sizeof(connect_msg),
-				 "AT+CIPSTART=%d,\"UDP\",\"%s\",%d,%d,%d,\"%s\"", sock->link_id,
-				 dst_addr_str, net_ntohs(net_sin(&dst)->sin_port),
-				 net_ntohs(net_sin(&src)->sin_port), mode, src_addr_str);
+			int bytes_written =
+				snprintk(connect_msg, sizeof(connect_msg),
+					 "AT+CIPSTART=%d,\"UDP\",\"%s\",%d,%d,%d", sock->link_id,
+					 dst_addr_str, net_ntohs(net_sin(&dst)->sin_port),
+					 net_ntohs(net_sin(&src)->sin_port), mode);
+
+			/* The local IP is optional; append it only when a specific
+			 * source address was bound. Emitting it for an unspecified
+			 * (0.0.0.0) address makes the modem reject the command.
+			 */
+			if (!net_ipv4_is_addr_unspecified(&net_sin(&src)->sin_addr)) {
+				net_addr_ntop(src.sa_family, &net_sin(&src)->sin_addr, src_addr_str,
+					      sizeof(src_addr_str));
+				snprintk(connect_msg + bytes_written,
+					 sizeof(connect_msg) - bytes_written, ",\"%s\"",
+					 src_addr_str);
+			}
+
 		} else {
 			snprintk(connect_msg, sizeof(connect_msg),
 				 "AT+CIPSTART=%d,\"UDP\",\"%s\",%d", sock->link_id, dst_addr_str,

--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -20,8 +20,7 @@ LOG_MODULE_REGISTER(wifi_esp_at_offload, CONFIG_WIFI_LOG_LEVEL);
 
 #include "esp.h"
 
-#define TCP_SEND_TIMEOUT                                        \
-	K_MSEC(CONFIG_WIFI_ESP_AT_TCP_SEND_TIMEOUT)
+#define TCP_SEND_TIMEOUT K_MSEC(CONFIG_WIFI_ESP_AT_TCP_SEND_TIMEOUT)
 
 static int esp_listen(struct net_context *context, int backlog)
 {
@@ -31,10 +30,9 @@ static int esp_listen(struct net_context *context, int backlog)
 static int _sock_connect(struct esp_data *dev, struct esp_socket *sock)
 {
 	/* Calculate the largest possible AT command length based on both TCP and UDP variants. */
-	char connect_msg[MAX(sizeof("AT+CIPSTART=000,\"TCP\",\"\",65535,7200") +
-				NET_IPV4_ADDR_LEN,
+	char connect_msg[MAX(sizeof("AT+CIPSTART=000,\"TCP\",\"\",65535,7200") + NET_IPV4_ADDR_LEN,
 			     sizeof("AT+CIPSTART=000,\"UDP\",\"\",65535,65535,0,\"\"") +
-				2 * NET_IPV4_ADDR_LEN)];
+				     2 * NET_IPV4_ADDR_LEN)];
 	char dst_addr_str[NET_IPV4_ADDR_LEN];
 	char src_addr_str[NET_IPV4_ADDR_LEN];
 	struct net_sockaddr src;
@@ -52,23 +50,19 @@ static int _sock_connect(struct esp_data *dev, struct esp_socket *sock)
 	k_mutex_unlock(&sock->lock);
 
 	if (dst.sa_family == NET_AF_INET) {
-		net_addr_ntop(dst.sa_family,
-			      &net_sin(&dst)->sin_addr,
-			      dst_addr_str, sizeof(dst_addr_str));
+		net_addr_ntop(dst.sa_family, &net_sin(&dst)->sin_addr, dst_addr_str,
+			      sizeof(dst_addr_str));
 	} else {
 		strcpy(dst_addr_str, "0.0.0.0");
 	}
 
 	if (esp_socket_ip_proto(sock) == NET_IPPROTO_TCP) {
-		snprintk(connect_msg, sizeof(connect_msg),
-			 "AT+CIPSTART=%d,\"TCP\",\"%s\",%d,7200",
-			 sock->link_id, dst_addr_str,
-			 net_ntohs(net_sin(&dst)->sin_port));
+		snprintk(connect_msg, sizeof(connect_msg), "AT+CIPSTART=%d,\"TCP\",\"%s\",%d,7200",
+			 sock->link_id, dst_addr_str, net_ntohs(net_sin(&dst)->sin_port));
 	} else {
 		if (src.sa_family == NET_AF_INET && net_sin(&src)->sin_port != 0) {
-			net_addr_ntop(src.sa_family,
-				      &net_sin(&src)->sin_addr,
-				      src_addr_str, sizeof(src_addr_str));
+			net_addr_ntop(src.sa_family, &net_sin(&src)->sin_addr, src_addr_str,
+				      sizeof(src_addr_str));
 			/* <mode>: In the UDP Wi-Fi passthrough
 			 *
 			 * 0: After UDP data is received, the parameters <"remote host">
@@ -98,29 +92,24 @@ static int _sock_connect(struct esp_data *dev, struct esp_socket *sock)
 			}
 
 			snprintk(connect_msg, sizeof(connect_msg),
-				 "AT+CIPSTART=%d,\"UDP\",\"%s\",%d,%d,%d,\"%s\"",
-				 sock->link_id, dst_addr_str,
-				 net_ntohs(net_sin(&dst)->sin_port),
-				 net_ntohs(net_sin(&src)->sin_port),
-				 mode, src_addr_str);
+				 "AT+CIPSTART=%d,\"UDP\",\"%s\",%d,%d,%d,\"%s\"", sock->link_id,
+				 dst_addr_str, net_ntohs(net_sin(&dst)->sin_port),
+				 net_ntohs(net_sin(&src)->sin_port), mode, src_addr_str);
 		} else {
 			snprintk(connect_msg, sizeof(connect_msg),
-				 "AT+CIPSTART=%d,\"UDP\",\"%s\",%d",
-				 sock->link_id, dst_addr_str,
+				 "AT+CIPSTART=%d,\"UDP\",\"%s\",%d", sock->link_id, dst_addr_str,
 				 net_ntohs(net_sin(&dst)->sin_port));
 		}
 	}
 
 	LOG_DBG("link %d, ip_proto %s, addr %s", sock->link_id,
-		esp_socket_ip_proto(sock) == NET_IPPROTO_TCP ? "TCP" : "UDP",
-		dst_addr_str);
+		esp_socket_ip_proto(sock) == NET_IPPROTO_TCP ? "TCP" : "UDP", dst_addr_str);
 
 	ret = esp_cmd_send(dev, NULL, 0, connect_msg, ESP_CMD_TIMEOUT);
 	if (ret == 0) {
 		esp_socket_flags_set(sock, ESP_SOCK_CONNECTED);
 		if (esp_socket_type(sock) == NET_SOCK_STREAM) {
-			net_context_set_state(sock->context,
-					      NET_CONTEXT_CONNECTED);
+			net_context_set_state(sock->context, NET_CONTEXT_CONNECTED);
 		}
 	} else if (ret == -ETIMEDOUT) {
 		/* FIXME:
@@ -136,8 +125,7 @@ static int _sock_connect(struct esp_data *dev, struct esp_socket *sock)
 
 void esp_connect_work(struct k_work *work)
 {
-	struct esp_socket *sock = CONTAINER_OF(work, struct esp_socket,
-					       connect_work);
+	struct esp_socket *sock = CONTAINER_OF(work, struct esp_socket, connect_work);
 	struct esp_data *dev = esp_socket_to_dev(sock);
 	int ret;
 
@@ -178,11 +166,8 @@ static int esp_bind(struct net_context *context, const struct net_sockaddr *addr
 	return -EAFNOSUPPORT;
 }
 
-static int esp_connect(struct net_context *context,
-		       const struct net_sockaddr *addr,
-		       net_socklen_t addrlen,
-		       net_context_connect_cb_t cb,
-		       int32_t timeout,
+static int esp_connect(struct net_context *context, const struct net_sockaddr *addr,
+		       net_socklen_t addrlen, net_context_connect_cb_t cb, int32_t timeout,
 		       void *user_data)
 {
 	struct esp_socket *sock;
@@ -222,17 +207,15 @@ static int esp_connect(struct net_context *context,
 	return ret;
 }
 
-static int esp_accept(struct net_context *context,
-			     net_tcp_accept_cb_t cb, int32_t timeout,
-			     void *user_data)
+static int esp_accept(struct net_context *context, net_tcp_accept_cb_t cb, int32_t timeout,
+		      void *user_data)
 {
 	return -ENOTSUP;
 }
 
 MODEM_CMD_DIRECT_DEFINE(on_cmd_tx_ready)
 {
-	struct esp_data *dev = CONTAINER_OF(data, struct esp_data,
-					    cmd_handler_data);
+	struct esp_data *dev = CONTAINER_OF(data, struct esp_data, cmd_handler_data);
 
 	k_sem_give(&dev->sem_tx_ready);
 	return len;
@@ -240,8 +223,7 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_tx_ready)
 
 MODEM_CMD_DEFINE(on_cmd_send_ok)
 {
-	struct esp_data *dev = CONTAINER_OF(data, struct esp_data,
-					    cmd_handler_data);
+	struct esp_data *dev = CONTAINER_OF(data, struct esp_data, cmd_handler_data);
 
 	modem_cmd_handler_set_error(data, 0);
 	k_sem_give(&dev->sem_response);
@@ -251,8 +233,7 @@ MODEM_CMD_DEFINE(on_cmd_send_ok)
 
 MODEM_CMD_DEFINE(on_cmd_send_fail)
 {
-	struct esp_data *dev = CONTAINER_OF(data, struct esp_data,
-					    cmd_handler_data);
+	struct esp_data *dev = CONTAINER_OF(data, struct esp_data, cmd_handler_data);
 
 	modem_cmd_handler_set_error(data, -EIO);
 	k_sem_give(&dev->sem_response);
@@ -264,8 +245,7 @@ static int _sock_send(struct esp_socket *sock, struct net_pkt *pkt)
 {
 	struct esp_data *dev = esp_socket_to_dev(sock);
 	char cmd_buf[sizeof("AT+CIPSEND=0,,\"\",") +
-		     sizeof(STRINGIFY(ESP_MTU)) - 1 +
-		     NET_IPV4_ADDR_LEN + sizeof("65535") - 1];
+		     sizeof(STRINGIFY(ESP_MTU)) - 1 + NET_IPV4_ADDR_LEN + sizeof("65535") - 1];
 	char addr_str[NET_IPV4_ADDR_LEN];
 	int ret, write_len, pkt_len;
 	struct net_buf *frag;
@@ -285,8 +265,7 @@ static int _sock_send(struct esp_socket *sock, struct net_pkt *pkt)
 	LOG_DBG("link %d, len %d", sock->link_id, pkt_len);
 
 	if (esp_socket_ip_proto(sock) == NET_IPPROTO_TCP) {
-		snprintk(cmd_buf, sizeof(cmd_buf),
-			 "AT+CIPSEND=%d,%d", sock->link_id, pkt_len);
+		snprintk(cmd_buf, sizeof(cmd_buf), "AT+CIPSEND=%d,%d", sock->link_id, pkt_len);
 	} else {
 		k_mutex_lock(&sock->lock, K_FOREVER);
 		dst = sock->dst;
@@ -298,21 +277,16 @@ static int _sock_send(struct esp_socket *sock, struct net_pkt *pkt)
 			goto out;
 		}
 
-		net_addr_ntop(dst.sa_family,
-			      &net_sin(&dst)->sin_addr,
-			      addr_str, sizeof(addr_str));
-		snprintk(cmd_buf, sizeof(cmd_buf),
-			 "AT+CIPSEND=%d,%d,\"%s\",%d",
-			 sock->link_id, pkt_len, addr_str,
-			 net_ntohs(net_sin(&dst)->sin_port));
+		net_addr_ntop(dst.sa_family, &net_sin(&dst)->sin_addr, addr_str, sizeof(addr_str));
+		snprintk(cmd_buf, sizeof(cmd_buf), "AT+CIPSEND=%d,%d,\"%s\",%d", sock->link_id,
+			 pkt_len, addr_str, net_ntohs(net_sin(&dst)->sin_port));
 	}
 
 	k_sem_take(&dev->cmd_handler_data.sem_tx_lock, K_FOREVER);
 	k_sem_reset(&dev->sem_tx_ready);
 
-	ret = modem_cmd_send_ext(&dev->mctx.iface, &dev->mctx.cmd_handler,
-				 cmds, ARRAY_SIZE(cmds), cmd_buf,
-				 &dev->sem_response, ESP_CMD_TIMEOUT,
+	ret = modem_cmd_send_ext(&dev->mctx.iface, &dev->mctx.cmd_handler, cmds, ARRAY_SIZE(cmds),
+				 cmd_buf, &dev->sem_response, ESP_CMD_TIMEOUT,
 				 MODEM_NO_TX_LOCK | MODEM_NO_UNSET_CMDS);
 	if (ret < 0) {
 		LOG_DBG("Failed to send command");
@@ -354,8 +328,7 @@ static int _sock_send(struct esp_socket *sock, struct net_pkt *pkt)
 	}
 
 out:
-	(void)modem_cmd_handler_update_cmds(&dev->cmd_handler_data,
-					    NULL, 0U, false);
+	(void)modem_cmd_handler_update_cmds(&dev->cmd_handler_data, NULL, 0U, false);
 	k_sem_give(&dev->cmd_handler_data.sem_tx_lock);
 
 	return ret;
@@ -389,8 +362,7 @@ static int esp_socket_send_one_pkt(struct esp_socket *sock)
 
 	ret = _sock_send(sock, pkt);
 	if (ret < 0) {
-		LOG_ERR("Failed to send data: link %d, ret %d",
-			sock->link_id, ret);
+		LOG_ERR("Failed to send data: link %d, ret %d", sock->link_id, ret);
 
 		/*
 		 * If this is stream data, then we should stop pushing anything
@@ -398,8 +370,7 @@ static int esp_socket_send_one_pkt(struct esp_socket *sock)
 		 * stream, which application layer is not expecting.
 		 */
 		if (esp_socket_type(sock) == NET_SOCK_STREAM) {
-			if (!esp_socket_flags_test_and_set(sock,
-						ESP_SOCK_CLOSE_PENDING)) {
+			if (!esp_socket_flags_test_and_set(sock, ESP_SOCK_CLOSE_PENDING)) {
 				esp_socket_work_submit(sock, &sock->close_work);
 			}
 		}
@@ -415,8 +386,7 @@ pkt_unref:
 
 void esp_send_work(struct k_work *work)
 {
-	struct esp_socket *sock = CONTAINER_OF(work, struct esp_socket,
-					       send_work);
+	struct esp_socket *sock = CONTAINER_OF(work, struct esp_socket, send_work);
 	int err;
 
 	do {
@@ -424,11 +394,8 @@ void esp_send_work(struct k_work *work)
 	} while (err != -ENOMSG);
 }
 
-static int esp_sendto(struct net_pkt *pkt,
-		      const struct net_sockaddr *dst_addr,
-		      net_socklen_t addrlen,
-		      net_context_send_cb_t cb,
-		      int32_t timeout,
+static int esp_sendto(struct net_pkt *pkt, const struct net_sockaddr *dst_addr,
+		      net_socklen_t addrlen, net_context_send_cb_t cb, int32_t timeout,
 		      void *user_data)
 {
 	struct net_context *context;
@@ -449,8 +416,7 @@ static int esp_sendto(struct net_pkt *pkt,
 	if (esp_socket_type(sock) == NET_SOCK_STREAM) {
 		atomic_val_t flags = esp_socket_flags(sock);
 
-		if (!(flags & ESP_SOCK_CONNECTED) ||
-		     (flags & ESP_SOCK_CLOSE_PENDING)) {
+		if (!(flags & ESP_SOCK_CONNECTED) || (flags & ESP_SOCK_CLOSE_PENDING)) {
 			return -ENOTCONN;
 		}
 	} else {
@@ -463,8 +429,8 @@ static int esp_sendto(struct net_pkt *pkt,
 			 * timeout parameter might be different. We want to
 			 * have a valid link id before proceeding.
 			 */
-			ret = esp_connect(context, dst_addr, addrlen, NULL,
-					  (5 * MSEC_PER_SEC), NULL);
+			ret = esp_connect(context, dst_addr, addrlen, NULL, (5 * MSEC_PER_SEC),
+					  NULL);
 			if (ret < 0) {
 				return ret;
 			}
@@ -476,10 +442,7 @@ static int esp_sendto(struct net_pkt *pkt,
 	return esp_socket_queue_tx(sock, pkt);
 }
 
-static int esp_send(struct net_pkt *pkt,
-		    net_context_send_cb_t cb,
-		    int32_t timeout,
-		    void *user_data)
+static int esp_send(struct net_pkt *pkt, net_context_send_cb_t cb, int32_t timeout, void *user_data)
 {
 	return esp_sendto(pkt, NULL, 0, cb, timeout, user_data);
 }
@@ -492,10 +455,8 @@ static int esp_send(struct net_pkt *pkt,
 #define CIPRECVDATA_CMD_MAX_LEN (sizeof("+CIPRECVDATA,LLLL:") - 1)
 #endif
 
-static int cmd_ciprecvdata_parse(struct esp_socket *sock,
-				 struct net_buf *buf, uint16_t len,
-				 int *data_offset, int *data_len, char *ip_str,
-				 int *port)
+static int cmd_ciprecvdata_parse(struct esp_socket *sock, struct net_buf *buf, uint16_t len,
+				 int *data_offset, int *data_len, char *ip_str, int *port)
 {
 	char cmd_buf[CIPRECVDATA_CMD_MAX_LEN + 1];
 	char *endptr;
@@ -507,8 +468,8 @@ static int cmd_ciprecvdata_parse(struct esp_socket *sock,
 		return -EAGAIN;
 	}
 
-	match_len = net_buf_linearize(cmd_buf, CIPRECVDATA_CMD_MAX_LEN,
-				      buf, 0, CIPRECVDATA_CMD_MAX_LEN);
+	match_len = net_buf_linearize(cmd_buf, CIPRECVDATA_CMD_MAX_LEN, buf, 0,
+				      CIPRECVDATA_CMD_MAX_LEN);
 	cmd_buf[match_len] = 0;
 
 	*data_len = strtol(&cmd_buf[len], &endptr, 10);
@@ -529,16 +490,14 @@ static int cmd_ciprecvdata_parse(struct esp_socket *sock,
 	ARG_UNUSED(port);
 #endif
 
-	if (endptr == &cmd_buf[len] ||
-	    (*endptr == 0 && match_len >= CIPRECVDATA_CMD_MAX_LEN) ||
+	if (endptr == &cmd_buf[len] || (*endptr == 0 && match_len >= CIPRECVDATA_CMD_MAX_LEN) ||
 	    *data_len > CIPRECVDATA_MAX_LEN) {
 		LOG_ERR("Invalid cmd: %s", cmd_buf);
 		return -EBADMSG;
 	} else if (*endptr == 0) {
 		return -EAGAIN;
 	} else if (*endptr != _CIPRECVDATA_END) {
-		LOG_ERR("Invalid end of cmd: 0x%02x != 0x%02x", *endptr,
-			_CIPRECVDATA_END);
+		LOG_ERR("Invalid end of cmd: 0x%02x != 0x%02x", *endptr, _CIPRECVDATA_END);
 		return -EBADMSG;
 	}
 
@@ -557,8 +516,7 @@ static int cmd_ciprecvdata_parse(struct esp_socket *sock,
 
 MODEM_CMD_DIRECT_DEFINE(on_cmd_ciprecvdata)
 {
-	struct esp_data *dev = CONTAINER_OF(data, struct esp_data,
-					    cmd_handler_data);
+	struct esp_data *dev = CONTAINER_OF(data, struct esp_data, cmd_handler_data);
 	struct esp_socket *sock;
 	int data_offset, data_len;
 	int err;
@@ -573,11 +531,10 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_ciprecvdata)
 	char raw_remote_ip[NET_INET_ADDRSTRLEN + 3] = {0};
 	int port = 0;
 
-	err = cmd_ciprecvdata_parse(sock, data->rx_buf, len, &data_offset,
-				    &data_len, raw_remote_ip, &port);
+	err = cmd_ciprecvdata_parse(sock, data->rx_buf, len, &data_offset, &data_len, raw_remote_ip,
+				    &port);
 #else
-	err = cmd_ciprecvdata_parse(sock, data->rx_buf, len, &data_offset,
-				    &data_len, NULL, NULL);
+	err = cmd_ciprecvdata_parse(sock, data->rx_buf, len, &data_offset, &data_len, NULL, NULL);
 #endif
 	if (err) {
 		if (err == -EAGAIN) {
@@ -588,8 +545,7 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_ciprecvdata)
 	}
 
 #if defined(CONFIG_WIFI_ESP_AT_CIPDINFO_USE) && !defined(CONFIG_WIFI_ESP_AT_VERSION_1_7)
-	struct net_sockaddr_in *recv_addr =
-			(struct net_sockaddr_in *) &sock->context->remote;
+	struct net_sockaddr_in *recv_addr = (struct net_sockaddr_in *)&sock->context->remote;
 
 	recv_addr->sin_port = net_htons(port);
 	recv_addr->sin_family = NET_AF_INET;
@@ -601,8 +557,7 @@ MODEM_CMD_DIRECT_DEFINE(on_cmd_ciprecvdata)
 	char remote_ip_addr[NET_INET_ADDRSTRLEN];
 	size_t remote_ip_str_len;
 
-	remote_ip_str_len = MIN(sizeof(remote_ip_addr) - 1,
-				strlen(raw_remote_ip) - 2);
+	remote_ip_str_len = MIN(sizeof(remote_ip_addr) - 1, strlen(raw_remote_ip) - 2);
 	strncpy(remote_ip_addr, &raw_remote_ip[1], remote_ip_str_len);
 	remote_ip_addr[remote_ip_str_len] = '\0';
 
@@ -625,10 +580,9 @@ socket_unref:
 
 void esp_recvdata_work(struct k_work *work)
 {
-	struct esp_socket *sock = CONTAINER_OF(work, struct esp_socket,
-					       recvdata_work);
+	struct esp_socket *sock = CONTAINER_OF(work, struct esp_socket, recvdata_work);
 	struct esp_data *data = esp_socket_to_dev(sock);
-	char cmd[sizeof("AT+CIPRECVDATA=000,"STRINGIFY(CIPRECVDATA_MAX_LEN))];
+	char cmd[sizeof("AT+CIPRECVDATA=000," STRINGIFY(CIPRECVDATA_MAX_LEN))];
 	static const struct modem_cmd cmds[] = {
 		MODEM_CMD_DIRECT(_CIPRECVDATA, on_cmd_ciprecvdata),
 	};
@@ -638,27 +592,22 @@ void esp_recvdata_work(struct k_work *work)
 
 	data->rx_sock = sock;
 
-	snprintk(cmd, sizeof(cmd), "AT+CIPRECVDATA=%d,%d", sock->link_id,
-		 CIPRECVDATA_MAX_LEN);
+	snprintk(cmd, sizeof(cmd), "AT+CIPRECVDATA=%d,%d", sock->link_id, CIPRECVDATA_MAX_LEN);
 
 	ret = esp_cmd_send(data, cmds, ARRAY_SIZE(cmds), cmd, ESP_CMD_TIMEOUT);
 	if (ret < 0) {
-		LOG_ERR("Error during rx: link %d, ret %d", sock->link_id,
-			ret);
+		LOG_ERR("Error during rx: link %d, ret %d", sock->link_id, ret);
 	}
 }
 
 void esp_close_work(struct k_work *work)
 {
-	struct esp_socket *sock = CONTAINER_OF(work, struct esp_socket,
-					       close_work);
+	struct esp_socket *sock = CONTAINER_OF(work, struct esp_socket, close_work);
 	atomic_val_t old_flags;
 
-	old_flags = esp_socket_flags_clear(sock,
-				(ESP_SOCK_CONNECTED | ESP_SOCK_CLOSE_PENDING));
+	old_flags = esp_socket_flags_clear(sock, (ESP_SOCK_CONNECTED | ESP_SOCK_CLOSE_PENDING));
 
-	if ((old_flags & ESP_SOCK_CONNECTED) &&
-	    (old_flags & ESP_SOCK_CLOSE_PENDING)) {
+	if ((old_flags & ESP_SOCK_CONNECTED) && (old_flags & ESP_SOCK_CLOSE_PENDING)) {
 		esp_socket_close(sock);
 	}
 
@@ -666,34 +615,28 @@ void esp_close_work(struct k_work *work)
 	if (old_flags & ESP_SOCK_CLOSE_PENDING) {
 		k_mutex_lock(&sock->lock, K_FOREVER);
 		if (sock->recv_cb) {
-			sock->recv_cb(sock->context, NULL, NULL, NULL, 0,
-				      sock->recv_user_data);
+			sock->recv_cb(sock->context, NULL, NULL, NULL, 0, sock->recv_user_data);
 			k_sem_give(&sock->sem_data_ready);
 		}
 		k_mutex_unlock(&sock->lock);
 	}
 }
 
-static int esp_recv(struct net_context *context,
-		    net_context_recv_cb_t cb,
-		    int32_t timeout,
+static int esp_recv(struct net_context *context, net_context_recv_cb_t cb, int32_t timeout,
 		    void *user_data)
 {
 	struct esp_socket *sock = context->offload_context;
 	struct esp_data *dev = esp_socket_to_dev(sock);
 	int ret;
 
-	LOG_DBG("link_id %d, timeout %d, cb %p, data %p",
-		sock->link_id, timeout, cb, user_data);
+	LOG_DBG("link_id %d, timeout %d, cb %p, data %p", sock->link_id, timeout, cb, user_data);
 
 	/*
 	 * UDP "listening" socket needs to be bound using AT+CIPSTART before any
 	 * traffic can be received.
 	 */
-	if (!esp_socket_connected(sock) &&
-	    esp_socket_ip_proto(sock) == NET_IPPROTO_UDP &&
-	    sock->src.sa_family == NET_AF_INET &&
-	    net_sin(&sock->src)->sin_port != 0) {
+	if (!esp_socket_connected(sock) && esp_socket_ip_proto(sock) == NET_IPPROTO_UDP &&
+	    sock->src.sa_family == NET_AF_INET && net_sin(&sock->src)->sin_port != 0) {
 		_sock_connect(dev, sock);
 	}
 
@@ -752,9 +695,7 @@ static int esp_put(struct net_context *context)
 	return 0;
 }
 
-static int esp_get(net_sa_family_t family,
-		   enum net_sock_type type,
-		   enum net_ip_protocol ip_proto,
+static int esp_get(net_sa_family_t family, enum net_sock_type type, enum net_ip_protocol ip_proto,
 		   struct net_context **context)
 {
 	struct esp_socket *sock;
@@ -783,15 +724,15 @@ static int esp_get(net_sa_family_t family,
 }
 
 static struct net_offload esp_offload = {
-	.get	       = esp_get,
-	.bind	       = esp_bind,
-	.listen	       = esp_listen,
-	.connect       = esp_connect,
-	.accept	       = esp_accept,
-	.send	       = esp_send,
-	.sendto	       = esp_sendto,
-	.recv	       = esp_recv,
-	.put	       = esp_put,
+	.get = esp_get,
+	.bind = esp_bind,
+	.listen = esp_listen,
+	.connect = esp_connect,
+	.accept = esp_accept,
+	.send = esp_send,
+	.sendto = esp_sendto,
+	.recv = esp_recv,
+	.put = esp_put,
 };
 
 int esp_offload_init(struct net_if *iface)


### PR DESCRIPTION
The documentation says that when there is no "local-IP" this should be
empty. The current module implementation is sending "" instead of
suppressing it.

This is an possible return that the modem returns an error:
> AT+CIPSTART=1,"UDP","192.168.101.110",1000,,,""

That should be instead:
> AT+CIPSTART=1,"UDP","192.168.101.110",1000,,