### PR TITLE
subsys: pm: remove unused includes

### DIFF
--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -6,7 +6,6 @@
 
 #include <zephyr/device.h>
 #include <zephyr/pm/device.h>
-#include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/iterable_sections.h>
 
 #include <zephyr/logging/log.h>

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -6,11 +6,8 @@
 
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
-#include <zephyr/init.h>
-#include <string.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/pm/device.h>
-#include <zephyr/pm/device_runtime.h>
 #include <zephyr/pm/pm.h>
 #include <zephyr/pm/state.h>
 #include <zephyr/pm/policy.h>

--- a/subsys/pm/pm_shell.c
+++ b/subsys/pm/pm_shell.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdio.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>

--- a/subsys/pm/policy/policy_device_lock.c
+++ b/subsys/pm/policy/policy_device_lock.c
@@ -9,7 +9,6 @@
 #include <zephyr/pm/policy.h>
 #include <zephyr/pm/state.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/pm/device.h>
 
 struct pm_state_device_constraint {
 	const char *const dev;


### PR DESCRIPTION
Remove headers that are not needed across power management subsystem.