### PR TITLE
arch: arm: mpu: Cortex-M7 speculative access hardening

### DIFF
--- a/arch/arm/core/mpu/Kconfig
+++ b/arch/arm/core/mpu/Kconfig
@@ -51,6 +51,29 @@ config MPU_DISABLE_BACKGROUND_MAP
 	  Enable this to turn off the default background MPU address map. Your
 	  SoC definition should likely provide its own custom MPU regions.
 
+config ARM_MPU_CM7_UNMAPPED_REGION
+	bool "Catch-all no-access MPU region for unmapped addresses"
+	depends on CPU_CORTEX_M7
+	select MPU_DISABLE_BACKGROUND_MAP
+	help
+	  Program the lowest-priority MPU region (region 0) as a 4GB
+	  Strongly-ordered, no-access, Execute-Never region covering the
+	  whole address space. Explicitly configured MPU regions use higher
+	  region numbers and therefore take precedence.
+
+	  Cortex-M7 can speculatively access any address that is not mapped
+	  Execute-Never (see the Arm Cortex-M7 TRM, "Memory system -
+	  Speculative accesses"), and a PLD instruction may perform a cache
+	  linefill even to an address whose load would fault (Arm Cortex-M7
+	  erratum 1013783, SDEN-1068427, present in all M7 revisions). This
+	  catch-all region implements the recommended workaround by removing
+	  all unmapped holes from the MPU map.
+
+	  Warning: with this region programmed the PRIVDEFENA background map
+	  never applies, so the static MPU region table of the board or SoC
+	  must explicitly cover every address range the firmware accesses,
+	  including code, RAM and peripherals.
+
 config CUSTOM_SECTION_ALIGN
 	bool "Custom Section Align"
 	help

--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -61,6 +61,23 @@ BUILD_ASSERT((DT_FOREACH_STATUS_OKAY_NODE_VARGS(
  */
 static uint8_t static_regions_num;
 
+#if defined(CONFIG_ARM_MPU_CM7_UNMAPPED_REGION)
+/* Lowest-priority catch-all region covering the entire 4GB address space:
+ * Strongly-ordered, no access, Execute-Never. It removes all unmapped holes
+ * from the MPU map, so that Cortex-M7 speculative accesses (Arm Cortex-M7
+ * TRM, "Memory system - Speculative accesses") and PLD linefills to
+ * faulting addresses (Arm Cortex-M7 erratum 1013783) cannot reach unmapped
+ * memory. Explicitly configured regions use higher region numbers and take
+ * precedence.
+ */
+static const struct arm_mpu_region unmapped_region =
+	MPU_REGION_ENTRY("UNMAPPED", 0U, {REGION_4G | MPU_RASR_XN_Msk | P_NA_U_NA_Msk});
+#define MPU_UNMAPPED_REGION_IDX  0U
+#define MPU_UNMAPPED_REGIONS_NUM 1U
+#else
+#define MPU_UNMAPPED_REGIONS_NUM 0U
+#endif /* CONFIG_ARM_MPU_CM7_UNMAPPED_REGION */
+
 /* Include architecture-specific internal headers. */
 #if defined(CONFIG_CPU_CORTEX_M0PLUS) || \
 	defined(CONFIG_CPU_CORTEX_M3) || \
@@ -504,18 +521,15 @@ int z_arm_mpu_init(void)
 {
 	uint32_t r_index;
 
-	if (mpu_config.num_regions > get_num_regions()) {
+	if (mpu_config.num_regions + MPU_UNMAPPED_REGIONS_NUM > get_num_regions()) {
 		/* Attempt to configure more MPU regions than
 		 * what is supported by hardware. As this operation
 		 * is executed during system (pre-kernel) initialization,
 		 * we want to ensure we can detect an attempt to
 		 * perform invalid configuration.
 		 */
-		__ASSERT(0,
-			"Request to configure: %u regions (supported: %u)\n",
-			mpu_config.num_regions,
-			get_num_regions()
-		);
+		__ASSERT(0, "Request to configure: %u regions (supported: %u)\n",
+			 mpu_config.num_regions + MPU_UNMAPPED_REGIONS_NUM, get_num_regions());
 		return -1;
 	}
 
@@ -564,13 +578,20 @@ int z_arm_mpu_init(void)
 	/* Architecture-specific configuration */
 	mpu_init();
 
+#if defined(CONFIG_ARM_MPU_CM7_UNMAPPED_REGION)
+	/* Program the catch-all region first, so that it gets the lowest
+	 * priority region number and all other regions override it.
+	 */
+	region_init(MPU_UNMAPPED_REGION_IDX, &unmapped_region);
+#endif
+
 	/* Program fixed regions configured at SOC definition. */
 	for (r_index = 0U; r_index < mpu_config.num_regions; r_index++) {
-		region_init(r_index, &mpu_config.mpu_regions[r_index]);
+		region_init(r_index + MPU_UNMAPPED_REGIONS_NUM, &mpu_config.mpu_regions[r_index]);
 	}
 
 	/* Update the number of programmed MPU regions. */
-	static_regions_num = mpu_config.num_regions;
+	static_regions_num = mpu_config.num_regions + MPU_UNMAPPED_REGIONS_NUM;
 #ifdef CONFIG_MEM_ATTR
 	/* DT-defined MPU regions. */
 	if (mpu_configure_regions_from_dt(&static_regions_num) == -EINVAL) {

--- a/boards/nxp/frdm_imxrt1186/Kconfig.defconfig
+++ b/boards/nxp/frdm_imxrt1186/Kconfig.defconfig
@@ -12,6 +12,11 @@ config EXTERNAL_MEM_CONFIG_DATA
 config NXP_IMX_EXTERNAL_HYPERRAM
 	default y if CPU_CORTEX_M33
 
+# The cm7 MPU region table fully covers all memory the firmware uses,
+# so enable the catch-all unmapped region (Cortex-M7 erratum 1013783).
+config ARM_MPU_CM7_UNMAPPED_REGION
+	default y if CPU_CORTEX_M7
+
 if SECOND_CORE_MCUX && BOARD_FRDM_IMXRT1186_MIMXRT1186_CM7
 
 # Workaround for not being able to have commas in macro arguments

--- a/boards/nxp/frdm_imxrt1186/cm7/mpu_regions.c
+++ b/boards/nxp/frdm_imxrt1186/cm7/mpu_regions.c
@@ -46,14 +46,11 @@
 			REGION_CUSTOMED_MEMORY_SIZE(MEMORY_REGION_SIZE_KB(PERIPHERAL_SIZE))
 
 static const struct arm_mpu_region mpu_regions[] = {
-	/*
-	 * Add "UNMAPPED" region to deny access to whole address space to
-	 * workaround speculative prefetch.
-	 * Refer to Arm errata 1013783-B for more details.
-	 */
-	MPU_REGION_ENTRY("UNMAPPED", 0,
-			{REGION_4G | MPU_RASR_XN_Msk | P_NA_U_NA_Msk}),
-
+/*
+ * The catch-all no-access region for unmapped addresses (Arm
+ * Cortex-M7 erratum 1013783) is programmed by the MPU driver,
+ * see CONFIG_ARM_MPU_CM7_UNMAPPED_REGION.
+ */
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(itcm))
 	MPU_REGION_ENTRY("ITCM", REGION_ITCM_BASE_ADDRESS,
 			 REGION_FLASH_ATTR(REGION_ITCM_SIZE)),

--- a/boards/nxp/mimxrt1180_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1180_evk/Kconfig.defconfig
@@ -12,6 +12,11 @@ config EXTERNAL_MEM_CONFIG_DATA
 config NXP_IMX_EXTERNAL_HYPERRAM
 	default y if CPU_CORTEX_M33
 
+# The cm7 MPU region table fully covers all memory the firmware uses,
+# so enable the catch-all unmapped region (Cortex-M7 erratum 1013783).
+config ARM_MPU_CM7_UNMAPPED_REGION
+	default y if CPU_CORTEX_M7
+
 if SECOND_CORE_MCUX && BOARD_MIMXRT1180_EVK_MIMXRT1189_CM7
 
 # Workaround for not being able to have commas in macro arguments

--- a/boards/nxp/mimxrt1180_evk/cm7/mpu_regions.c
+++ b/boards/nxp/mimxrt1180_evk/cm7/mpu_regions.c
@@ -46,14 +46,11 @@
 			REGION_CUSTOMED_MEMORY_SIZE(MEMORY_REGION_SIZE_KB(PERIPHERAL_SIZE))
 
 static const struct arm_mpu_region mpu_regions[] = {
-	/*
-	 * Add "UNMAPPED" region to deny access to whole address space to
-	 * workaround speculative prefetch.
-	 * Refer to Arm errata 1013783-B for more details.
-	 */
-	MPU_REGION_ENTRY("UNMAPPED", 0,
-			{REGION_4G | MPU_RASR_XN_Msk | P_NA_U_NA_Msk}),
-
+/*
+ * The catch-all no-access region for unmapped addresses (Arm
+ * Cortex-M7 erratum 1013783) is programmed by the MPU driver,
+ * see CONFIG_ARM_MPU_CM7_UNMAPPED_REGION.
+ */
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(itcm))
 	MPU_REGION_ENTRY("ITCM", REGION_ITCM_BASE_ADDRESS,
 			 REGION_FLASH_ATTR(REGION_ITCM_SIZE)),

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1298,6 +1298,17 @@ Architectures
   Out-of-tree boards that nevertheless execute from a region mapped with these
   attributes must define a custom attribute instead.
 
+* The new :kconfig:option:`CONFIG_ARM_MPU_CM7_UNMAPPED_REGION` option makes the Arm
+  MPU driver program the lowest-priority MPU region (region 0) as a 4GB
+  Strongly-ordered, no-access, Execute-Never catch-all, implementing the workaround
+  for Arm Cortex-M7 erratum 1013783 (SDEN-1068427) and preventing Cortex-M7
+  speculative accesses to unmapped addresses. Cortex-M7 boards or SoCs whose static
+  MPU region table explicitly covers all memory the firmware uses can enable it; the
+  static regions are then programmed starting from MPU region 1. The
+  ``mimxrt1180_evk`` and ``frdm_imxrt1186`` cm7 targets enable it by default,
+  replacing their previous hand-rolled ``UNMAPPED`` MPU region table entry with
+  identical runtime behavior.
+
 Video
 =====
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1288,6 +1288,16 @@ Architectures
 * SoCs using :kconfig:option:`CONFIG_XTENSA_BACKTRACE` are now expected to implement
   :c:func:`xtensa_soc_stack_ptr_is_sane` and :c:func:`xtensa_soc_ptr_executable`.
 
+* The ARMv7-M MPU device-type region attributes ``REGION_PPB_ATTR``, ``REGION_IO_ATTR``
+  and ``REGION_EXTMEM_ATTR`` now set Execute-Never (``XN=1``) on all ARMv7-M cores.
+  Executing from Device/Strongly-ordered memory is architecturally UNPREDICTABLE on
+  ARMv7-M, so no valid use case is affected. On Cortex-M7 the XN attribute additionally
+  prevents speculative instruction fetches into these regions, which can cause bus hangs
+  or read side effects in peripheral space (Arm Cortex-M7 TRM, "Speculative accesses -
+  Considerations for system design"); the memory type alone does not prevent them.
+  Out-of-tree boards that nevertheless execute from a region mapped with these
+  attributes must define a custom attribute instead.
+
 Video
 =====
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -182,6 +182,11 @@ New APIs and options
 
 .. zephyr-keep-sorted-start re(^\* \w) ignorecase
 
+* Architectures
+
+  * :kconfig:option:`CONFIG_ARM_MPU_CM7_UNMAPPED_REGION` (Arm Cortex-M7 catch-all MPU region
+    for unmapped addresses, erratum 1013783 workaround)
+
 * Audio
 
   * :c:member:`pcm_stream_cfg.gain_db`

--- a/include/zephyr/arch/arm/mpu/arm_mpu_v7m.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_v7m.h
@@ -133,9 +133,16 @@
 #define REGION_FLASH_ATTR(size)                                                                    \
 	{(NORMAL_OUTER_INNER_WRITE_THROUGH_NON_SHAREABLE | size | P_RO_U_RO_Msk)}
 #endif
-#define REGION_PPB_ATTR(size)    {(STRONGLY_ORDERED_SHAREABLE | size | P_RW_U_NA_Msk)}
-#define REGION_IO_ATTR(size)     {(DEVICE_NON_SHAREABLE | size | P_RW_U_NA_Msk)}
-#define REGION_EXTMEM_ATTR(size) {(STRONGLY_ORDERED_SHAREABLE | size | NO_ACCESS_Msk)}
+/* Executing from Device or Strongly-ordered memory is architecturally
+ * UNPREDICTABLE on ARMv7-M, so device-type regions are always mapped
+ * Execute-Never. On Cortex-M7 the XN attribute is also what prevents the core
+ * from speculatively fetching instructions from these regions; the memory type
+ * alone does not. See the Arm Cortex-M7 TRM (DDI0489), "Memory system -
+ * Speculative accesses - Considerations for system design".
+ */
+#define REGION_PPB_ATTR(size)    {(STRONGLY_ORDERED_SHAREABLE | NOT_EXEC | size | P_RW_U_NA_Msk)}
+#define REGION_IO_ATTR(size)     {(DEVICE_NON_SHAREABLE | NOT_EXEC | size | P_RW_U_NA_Msk)}
+#define REGION_EXTMEM_ATTR(size) {(STRONGLY_ORDERED_SHAREABLE | NOT_EXEC | size | NO_ACCESS_Msk)}
 
 struct arm_mpu_region_attr {
 	/* Attributes belonging to RASR (including the encoded region size) */


### PR DESCRIPTION
## Description

On Cortex-M7 the core can issue **speculative instruction fetches** into any region that is not mapped Execute-Never. Per the Arm Cortex-M7 TRM (DDI0489), *Memory system → Speculative accesses → Considerations for system design*, regions that must not be speculatively accessed have to be **Strongly-ordered/Device AND Execute Never (XN)** — the memory type alone is not sufficient. In addition, a `PLD` instruction may perform a D-cache linefill to an address whose load would generate a MemManage fault (Arm Cortex-M7 erratum 1013783, [SDEN-1068427](https://developer.arm.com/documentation/SDEN1068427/latest/), present in all M7 revisions).

Both issues let the core emit bus reads that should never happen; if such a read hits a register with read side effects or a bus slave that never responds, the result is data corruption or a bus hang. A customer hit the instruction-side case on RT1180, where the PERIPHERAL MPU region (`0x40000000-0x7FFFFFFF`) was mapped executable. This affects **all Cortex-M7 based platforms**, not just RT1180.

## Changes

Per review feedback, fixed at the existing abstraction level instead of adding a parallel helper:

1. `arch: arm: mpu:` — the device-type region attributes `REGION_PPB_ATTR`, `REGION_IO_ATTR` and `REGION_EXTMEM_ATTR` now set `XN=1` unconditionally on all ARMv7-M cores. Executing from Device/Strongly-ordered memory is architecturally UNPREDICTABLE on ARMv7-M, so no valid use case can rely on these regions being executable, and the ARMv8-M `REGION_IO_ATTR` already sets XN. On Cortex-M7 the XN attribute is additionally what closes the speculative-fetch window. All in-tree users of these attributes (i.MX RT, S32K3/K5, STM32H7/H7RS) map peripheral space or data-only regions — including the RT118x PERIPHERAL region, which stays on `REGION_PPB_ATTR` and picks up `XN` automatically.
2. `arch: arm: mpu:` — new opt-in `CONFIG_ARM_MPU_CM7_UNMAPPED_REGION`: the MPU driver programs the lowest-priority MPU region (region 0) as a 4GB Strongly-ordered, no-access, Execute-Never catch-all — exactly the field values recommended by the erratum 1013783 workaround — closing the unmapped holes that remain reachable through the `PRIVDEFENA` background map. Board/SoC static regions are programmed from region 1 up and take precedence.
3. `boards: nxp: imxrt118x:` — the two RT118x cm7 targets enable the new option, replacing their hand-rolled `UNMAPPED` MPU table entry with identical runtime behavior. The board default is guarded with `if CPU_CORTEX_M7` so it does not leak to the cm33 targets.

Docs: release notes (new Kconfig option) and migration guide (device-type attribute behavior change + catch-all adoption guidance).

## Scope

The catch-all option is **opt-in** because it bypasses the `PRIVDEFENA` background map: a platform can only enable it once its static MPU region table explicitly covers all memory the firmware uses. Enabling it blindly would break every M7 board that relies on the background map for uncovered ranges. Other Cortex-M7 platforms (e.g. S32K344, RT10xx/11xx, STM32H7) can adopt it after auditing their region coverage.

## Related

Supersedes #112375.
