### PR TITLE
boards: frdm_mcxa577: add RTC support

### DIFF
--- a/boards/nxp/frdm_mcxa577/board.c
+++ b/boards/nxp/frdm_mcxa577/board.c
@@ -354,6 +354,11 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_GateDAC0);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(rtc))
+	/* RTC uses the OSC32K (32.768 kHz) as its clock source */
+	CLOCK_SetupOsc32KClocking(kCLOCK_Osc32kToAll);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 }

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
@@ -20,6 +20,7 @@
 		watchdog0 = &wwdt0;
 		flash-controller = &fmu;
 		die-temp0 = &temp0;
+		rtc = &rtc;
 		ambient-temp0 = &p3t1755;
 	};
 
@@ -256,6 +257,11 @@
 	status = "okay";
 	pinctrl-0 = <&pinmux_flexcan0>;
 	pinctrl-names = "default";
+};
+
+&rtc {
+	status = "okay";
+	clock-src = <1>;
 };
 
 &i3c0 {

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
@@ -29,4 +29,5 @@ supported:
   - edac
   - can
   - dac
+  - rtc
 vendor: nxp


### PR DESCRIPTION
Enable the nxp,irtc RTC peripheral on frdm_mcxa577 with the following changes:

- Add rtc alias and &rtc { status = "okay"; clock-src = <1>; } to frdm_mcxa577.dtsi to enable the node with the OSC32K clock source (32.768 kHz), matching the SDK hardware reference.
- Add rtc to the supported features list in frdm_mcxa577.yaml so the board is selectable for RTC-dependent tests and samples.
- In board_early_init_hook(), call CLOCK_SetupOsc32KClocking() to start the OSC32K oscillator before the RTC driver initialises.

Tested with tests/drivers/rtc/rtc_api on hardware (frdm_mcxa577, CMSIS-DAP): 3/3 tests pass, PROJECT EXECUTION SUCCESSFUL.