### PR TITLE
boards: nxp: frdm_mcxaxx6: add RTC support

### DIFF
--- a/boards/nxp/frdm_mcxaxx6/board.c
+++ b/boards/nxp/frdm_mcxaxx6/board.c
@@ -299,6 +299,13 @@ void board_early_init_hook(void)
 
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(rtc))
+	/* OSC32k is not available on this device; the RTC is clocked from the
+	 * FRO16K in the VBAT domain.
+	 */
+	CLOCK_SetupFRO16KClocking(kCLKE_16K_SYSTEM | kCLKE_16K_COREMAIN);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexio0))
 	CLOCK_SetClockDiv(kCLOCK_DivFLEXIO0, 2u);
 	CLOCK_AttachClk(kFRO_HF_to_FLEXIO0);

--- a/boards/nxp/frdm_mcxaxx6/board_common.dtsi
+++ b/boards/nxp/frdm_mcxaxx6/board_common.dtsi
@@ -18,6 +18,7 @@
 		sw1 = &user_button_3;
 		watchdog0 = &wwdt0;
 		die-temp0 = &temp0;
+		rtc = &counter_rtc;
 	};
 
 	chosen {
@@ -237,6 +238,14 @@
 };
 
 &lptmr0 {
+	status = "okay";
+};
+
+&rtc {
+	status = "okay";
+};
+
+&counter_rtc {
 	status = "okay";
 };
 

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.yaml
@@ -30,4 +30,5 @@ supported:
   - usbd
   - edac
   - pwm
+  - rtc
 vendor: nxp

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa346.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa346.yaml
@@ -28,4 +28,5 @@ supported:
   - arduino_gpio
   - edac
   - pwm
+  - rtc
 vendor: nxp

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.yaml
@@ -31,4 +31,5 @@ supported:
   - usbd
   - edac
   - pwm
+  - rtc
 vendor: nxp

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -230,6 +230,24 @@
 			status = "disabled";
 		};
 
+		rtc: rtc@400ee000 {
+			compatible = "nxp,rtc";
+			reg = <0x400ee000 0x1000>;
+			interrupts = <119 0>, <120 0>;
+			interrupt-names = "alarm", "seconds";
+			clock-frequency = <32768>;
+			prescaler = <32768>;
+			/* OSC32k is not available on this device */
+			clock-source = "LPO";
+			status = "disabled";
+
+			counter_rtc: counter_rtc {
+				compatible = "zephyr,rtc-counter";
+				alarms-count = <1>;
+				status = "disabled";
+			};
+		};
+
 		ctimer0: ctimer@40004000 {
 			compatible = "nxp,lpc-ctimer";
 			reg = <0x40004000 0x1000>;


### PR DESCRIPTION
Add RTC support for the mcxaxx6 SoC family and the corresponding board variants.

OSC32k is not available on these devices. The RTC is clocked from the 16.384 kHz FRO16K in the VBAT domain (CR[LPOS]=1, clock-source = "LPO"), which the prescaler divides to ~1 Hz for the seconds counter.

Tested on frdm_mcxa366 with tests/drivers/rtc/rtc_api (rtc_counter scenario): PASS 3/3 (test_set_get_time, test_time_counting, test_y2k).
