### PR TITLE
boards: frdm_mcxa577: add EWM support

### DIFF
--- a/boards/nxp/frdm_mcxa577/board.c
+++ b/boards/nxp/frdm_mcxa577/board.c
@@ -347,6 +347,12 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kFRO_HF_to_FLEXCAN0);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ewm0))
+	RESET_ReleasePeripheralReset(kEWM0_RST_SHIFT_RSTn);
+	CLOCK_SetupFRO16KClocking(kCLKE_16K_SYSTEM | kCLKE_16K_COREMAIN | kCLKE_16K_VBAT);
+	CLOCK_EnableClock(kCLOCK_GateEWM0);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dac0))
 	SPC_EnableActiveModeAnalogModules(SPC0, kSPC_controlDac0);
 	CLOCK_AttachClk(kFRO_LF_DIV_to_DAC0);

--- a/tests/drivers/watchdog/wdt_basic_reset_none/tests.yaml
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/tests.yaml
@@ -25,6 +25,7 @@ tests:
       - frdm_imxrt1186/mimxrt1186/cm7
       - frdm_mcxn947/mcxn947/cpu0
       - frdm_mcxn947/mcxn947/cpu1
+      - frdm_mcxa577
     integration_platforms:
       - frdm_mcxw71
       - frdm_mcxw72


### PR DESCRIPTION
Add EWM (External Watchdog Monitor) support for frdm_mcxa577 by:

- In board_early_init_hook(), release EWM from reset, enable the FRO16K clock for all power domains, and gate the EWM clock, matching the SDK reference hardware init sequence.
- Add frdm_mcxa577 to the platform_allow list in tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml under the drivers.watchdog.reset_none_ewm scenario.

The ewm0 node is already present in nxp_mcxa5x_common.dtsi; the test's shared app_ewm.overlay enables it and sets the watchdog0 alias at test time.

Tested with tests/drivers/watchdog/wdt_basic_reset_none on hardware (frdm_mcxa577, CMSIS-DAP): SUITE PASS, PROJECT EXECUTION SUCCESSFUL (1 pass, 1 expected skip).