### PR TITLE
logging: Add option to process printk using static macros

### DIFF
--- a/include/zephyr/sys/printk.h
+++ b/include/zephyr/sys/printk.h
@@ -13,6 +13,10 @@
 #include <stdarg.h>
 #include <inttypes.h>
 
+#ifdef CONFIG_LOG_PRINTK_STATIC
+#include <zephyr/logging/log_core.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -44,7 +48,16 @@ extern "C" {
  */
 #ifdef CONFIG_PRINTK
 
+#ifdef CONFIG_LOG_PRINTK_STATIC
+/* If printk is redirected to the logging use the macro which allow build time
+ * logging message creation which is faster and allows format string stripping in
+ * case of dictionary based logging.
+ */
+#define printk(...) Z_LOG_PRINTK(0, __VA_ARGS__)
+#else
 __printf_like(1, 2) void printk(const char *fmt, ...);
+#endif /* CONFIG_LOG_PRINTK_STATIC */
+
 __printf_like(1, 0) void vprintk(const char *fmt, va_list ap);
 
 #else

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -189,6 +189,7 @@ static inline void z_vrfy_k_str_out(char *c, size_t n)
  * @param fmt formatted string to output
  */
 
+#ifndef CONFIG_LOG_PRINTK_STATIC
 void printk(const char *fmt, ...)
 {
 	va_list ap;
@@ -200,6 +201,8 @@ void printk(const char *fmt, ...)
 	va_end(ap);
 }
 EXPORT_SYMBOL(printk);
+#endif
+
 #endif /* defined(CONFIG_PRINTK) */
 
 #ifndef CONFIG_PICOLIBC

--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -12,6 +12,11 @@ config LOG_PRINTK
 	  If enabled, printk messages are redirected to the logging subsystem.
 	  The messages are formatted in place and logged unconditionally.
 
+config LOG_PRINTK_STATIC
+	bool "Static processing of printk messages"
+	default y
+	depends on LOG_PRINTK
+
 if LOG_MODE_DEFERRED && !LOG_FRONTEND_ONLY
 
 config LOG_MODE_OVERFLOW


### PR DESCRIPTION
Added option CONFIG_LOG_PRINTK_STATIC which redirects printk's to logging macro which creates message during compilation by examining argument types using _Generic keyword. When this option is enabled printk format string is not accessed in runtime so it can be removed  (e.g. in dictionary based logging). When this option is enabled printk is much faster. 

The only condition that must be met to use build time message creation macros is that format string is a string literal and not a variable. That is the case for printk because it is using __printf_like gcc extension to validate that.

Using this approach reduces need for string formatting functions if only logging or printk is used. It saves ~1.5k of flash in that case.

It was already once proposed #68230 but then PR to sof seemed to block the issue and now sof is no longer part of Zephyr.
