### PR TITLE
drivers: hdlc_rcp_if: spi: fix Spinel SPI framing protocol handling issues

### DIFF
--- a/drivers/hdlc_rcp_if/hdlc_rcp_if_spi.c
+++ b/drivers/hdlc_rcp_if/hdlc_rcp_if_spi.c
@@ -62,6 +62,7 @@ struct hdlc_rcp_if_spi_data {
 
 	bool tx_ready;
 	bool frame_sent;
+	uint16_t tx_refused_count;
 };
 
 BUILD_ASSERT(CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE <=
@@ -167,6 +168,7 @@ static void hdlc_rcp_if_push_pull_spi(struct k_work *work)
 	uint16_t peer_max_rx;
 	uint16_t fcs;
 	int ret;
+	uint16_t accept_len;
 
 	data->tx_buf[0] = SPI_HEADER_PATTERN_VALUE;
 	if (!data->frame_sent) {
@@ -180,8 +182,9 @@ static void hdlc_rcp_if_push_pull_spi(struct k_work *work)
 		rx_frame.len += data->rx_len;
 		sys_put_le16(data->rx_len, &data->tx_buf[1]);
 	} else {
-		rx_frame.len += CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE;
-		sys_put_le16(CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE, &data->tx_buf[1]);
+		accept_len = MAX(CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE, data->tx_len);
+		rx_frame.len += accept_len;
+		sys_put_le16(accept_len, &data->tx_buf[1]);
 	}
 
 	LOG_HEXDUMP_DBG(data->tx_buf, SPI_HEADER_LEN, "TX Header");
@@ -214,8 +217,18 @@ static void hdlc_rcp_if_push_pull_spi(struct k_work *work)
 	data->rx_len = sys_get_le16(&rx_buf[3]);
 
 	if (data->tx_len > peer_max_rx) {
-		LOG_WRN("Peer not ready to receive our frame (%u > %u)", data->tx_len, peer_max_rx);
+		data->tx_refused_count++;
+		if (data->tx_refused_count == 1) {
+			LOG_WRN("Peer not ready to receive our frame (%u > %u), need to retry",
+				data->tx_len, peer_max_rx);
+		}
+		/* Keep tx_ready to retry the packet on next SPI transaction. */
+		data->tx_ready = true;
+		return;
 	}
+
+	/* TX accepted by peer — reset refused count */
+	data->tx_refused_count = 0;
 
 	LOG_HEXDUMP_DBG(rx_buf, SPI_HEADER_LEN, "RX Header");
 


### PR DESCRIPTION
In hdlc_rcp_if_push_pull_spi(), two cases cause OpenThread Tx timeouts and RCP resets on the host side.

- RECV_LEN undersized when data->rx_len == 0

When the host sends a frame and no RX is pending, RECV_LEN was unconditionally set to CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE. As RECV_LEN is less than tx_len, the RCP does not answer and the host goes into Tx timeout.

Fix: set RECV_LEN to max(CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE, tx_len), matching the OpenThread POSIX reference implementation

- No retry when RCP RECV_LEN < tx_len

When peer_max_rx (slave RECV_LEN) < tx_len, the outgoing frame was silently dropped after logging a warning.

Fix: The host must keep tx_len and retry on the next SPI transaction.