### PR TITLE
arch: riscv: Bump privileged stack size

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -583,6 +583,9 @@ config MAIN_STACK_SIZE
 	default 4096 if 64BIT
 	default 2048 if PMP_STACK_GUARD
 
+config PRIVILEGED_STACK_SIZE
+	default 2048 if 64BIT && ASSERT
+
 config TEST_EXTRA_STACK_SIZE
 	default 4096 if CPP_EXCEPTIONS
 	default 1536


### PR DESCRIPTION
Since 5528dee556e1 (`device: Add asserts to DEVICE_API_GET`), the following tests fail with a privileged-stack overflow during the `log_panic()` syscall:

```
west twister -p hifive_unmatched/fu740/u74 -s logging.log_user
west twister -p hifive_unleashed/fu540/u54 -s logging.log_user
```

`qemu_riscv64` passes only because its defconfig sets `CONFIG_PRIVILEGED_STACK_SIZE=2048`, lowering it to `1024` reproduces the failure in a similar way.

The bad commit makes stack frames bigger along the `log_panic()` flush chain. Peak privileged-stack usage goes from just-under to just-over 1024 bytes.