### PR TITLE
tests: arch: arm: arm_thread_swap_tz: fix timing on fast secure services

### DIFF
--- a/tests/arch/arm/arm_thread_swap_tz/src/main.c
+++ b/tests/arch/arm/arm_thread_swap_tz/src/main.c
@@ -19,7 +19,14 @@ static struct k_work_delayable interrupting_work;
 static volatile bool work_done;
 static char dummy_string[0x1000];
 static char dummy_digest_correct[HASH_LEN];
-static const uint32_t delay_ms = 1;
+/* Delay before the interrupting work preempts the main thread while it is
+ * executing a secure service call. It must be shorter than the duration of the
+ * secure call, otherwise the preemption lands after the call has already
+ * returned to non-secure state (which happens with fast, hardware-accelerated
+ * secure services such as CRACEN crypto on nRF54L). One tick reliably lands the
+ * preemption early inside the secure call, regardless of how fast it executes.
+ */
+static const uint32_t delay_us = 1;
 static volatile const struct k_thread *main_thread;
 
 static void do_hash(char *hash)
@@ -77,7 +84,7 @@ ZTEST(thread_swap_tz, test_thread_swap_tz)
 {
 	int err;
 	char dummy_digest[HASH_LEN];
-	k_timeout_t delay = K_MSEC(delay_ms);
+	k_timeout_t delay = K_USEC(delay_us);
 	k_tid_t curr;
 	psa_status_t status;
 


### PR DESCRIPTION
## Summary

`arch.arm.swap.tz` and `arch.arm.swap.tz_off` schedule a work item to preempt the main thread while it is executing a secure service call (a 4 KB SHA-256) and check the preempted thread's saved `EXC_RETURN` to verify the security state.

The preemption delay was hardcoded to **1 ms**. On targets with a fast, hardware-accelerated secure service the secure call completes in far less than 1 ms (e.g. ~0.5 ms for a 4 KB SHA-256 via CRACEN on the nRF54L), so the preemption always lands *after* the secure call has already returned to non-secure state:

- preemptible variant fails with `EXC_RETURN not secure: 0x...`
- non-preemptible variant fails with `Interrupting work never happened` (the whole call finishes before the work runs)

The TrustZone swap mechanism itself is fine — instrumentation on nRF54L showed the timer preempting the main thread *inside* the secure call ~90% of the time when sampled repeatedly; the one-shot 1 ms delay is simply too long for fast crypto.

The fix shortens the preemption delay to a single tick so it reliably lands early inside the secure call, independently of how fast the secure service executes. On platforms whose tick period is >= 1 ms (e.g. the QEMU `mps2/an521` integration platform at 100 Hz) the delay still rounds up to the same single tick as before, so their behaviour is unchanged; on finer-tick platforms the preemption just fires earlier, still well within the secure call.

## Test plan

Verified on hardware (both `arch.arm.swap.tz` and `arch.arm.swap.tz_off`):

- [x] nRF54Lv10 (`nrf54lv10dk/.../cpuapp/ns`, CRACEN, ~0.5 ms secure call): failed before, passes after
- [x] nRF5340 (`nrf5340dk/nrf5340/cpuapp/ns`, CryptoCell, >1 ms secure call): passed before and after (no regression)
- [x] `mps2/an521` integration platform: effective delay unchanged (1 tick @ 100 Hz)