### PR TITLE
soc: stm32: xspim: Prevent running xpim configuration from nor xip app

### DIFF
--- a/soc/st/stm32/common/Kconfig
+++ b/soc/st/stm32/common/Kconfig
@@ -78,9 +78,11 @@ config STM32_IOCELL_CHECK_ENABLE
 config STM32_XSPIM
 	bool "STM32 XSPI Manager"
 	select USE_STM32_HAL_XSPI
+	depends on !STM32_APP_IN_EXT_FLASH
 	default y if DT_HAS_ST_STM32_XSPIM_ENABLED
 	help
-	  Enables support for XSPI Manager.
+	  Enables support for XSPI Manager. Shouldn't be used by applications
+	  running from external flash as it reinitializes the serial bus controllers.
 
 if STM32_XSPIM
 


### PR DESCRIPTION
When application is running in xip from the nor flash controlled by the xspi manager, prevent controller full re-initialization.

Tested with
west build samples/hello_world
   -b stm32h7s78_dk/stm32h7s7xx/ext_flash_app
   --sysbuild -p