### PR TITLE
tests: arch: arm: arm_thread_swap_tz: shorten preemption delay

### DIFF
--- a/tests/arch/arm/arm_thread_swap_tz/src/main.c
+++ b/tests/arch/arm/arm_thread_swap_tz/src/main.c
@@ -19,7 +19,7 @@ static struct k_work_delayable interrupting_work;
 static volatile bool work_done;
 static char dummy_string[0x1000];
 static char dummy_digest_correct[HASH_LEN];
-static const uint32_t delay_ms = 1;
+static const uint32_t delay_ticks = 1;
 static volatile const struct k_thread *main_thread;
 
 static void do_hash(char *hash)
@@ -77,7 +77,7 @@ ZTEST(thread_swap_tz, test_thread_swap_tz)
 {
 	int err;
 	char dummy_digest[HASH_LEN];
-	k_timeout_t delay = K_MSEC(delay_ms);
+	k_timeout_t delay = K_TICKS(delay_ticks);
 	k_tid_t curr;
 	psa_status_t status;
 


### PR DESCRIPTION
The 1 ms delay is longer than a hardware-accelerated secure call (e.g. ~0.5 ms for a 4 KB SHA-256), so the preemption lands after the call returns and the test fails. Use a single tick instead.