### PR TITLE
tests: kernel: various doxygen fixes for kernel code / tests

### DIFF
--- a/kernel/compiler_stack_protect.c
+++ b/kernel/compiler_stack_protect.c
@@ -30,7 +30,7 @@
  *
  * This function is invoked when a stack canary error is detected.
  *
- * @return Does not return
+ * @note This function does not return.
  */
 void _StackCheckHandler(void)
 {

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -5,7 +5,8 @@
  */
 
 /**
- * @file event objects library
+ * @file
+ * @brief event objects library
  *
  * Event objects are used to signal one or more threads that a custom set of
  * events has occurred. Threads wait on event objects until another thread or

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -5,7 +5,8 @@
  */
 
 /**
- * @file @brief mutex kernel services
+ * @file
+ * @brief mutex kernel services
  *
  * This module contains routines for handling mutex locking and unlocking.
  *

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -813,6 +813,7 @@ extern void thread_abort_hook(struct k_thread *thread);
  *
  * @param thread Identify the thread to halt
  * @param new_state New thread state (_THREAD_DEAD or _THREAD_SUSPENDED)
+ * @param key Pointer to the scheduler spinlock key held by the caller
  */
 static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state,
 				      k_spinlock_key_t *key)

--- a/kernel/smp/smp.c
+++ b/kernel/smp/smp.c
@@ -39,7 +39,7 @@ static struct cpu_start_cb {
 	 */
 	smp_init_fn fn;
 
-	/** Argument to @ref cpu_start_fn.fn. */
+	/** Argument to @ref cpu_start_cb.fn. */
 	void *arg;
 
 	/** Invoke scheduler after CPU has started if true. */

--- a/tests/kernel/common/src/clock.c
+++ b/tests/kernel/common/src/clock.c
@@ -13,6 +13,7 @@
 			Z_SPIN_DELAY(50);      \
 	} while (0)
 
+/** @cond INTERNAL_HIDDEN */
 struct timer_data {
 	int duration_count;
 	int stop_count;
@@ -20,10 +21,11 @@ struct timer_data {
 static void duration_expire(struct k_timer *timer);
 static void stop_expire(struct k_timer *timer);
 
-/** TESTPOINT: init timer via K_TIMER_DEFINE */
+/* TESTPOINT: init timer via K_TIMER_DEFINE */
 K_TIMER_DEFINE(ktimer, duration_expire, stop_expire);
 
 static ZTEST_BMEM struct timer_data tdata;
+/** @endcond */
 
 #define DURATION 100
 #define LESS_DURATION 70

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -33,6 +33,7 @@
 #define FAKEDRIVER0_NODEID    DT_PATH(fakedriver_e0000000)
 #define FAKEDRIVER0_NODELABEL "fake_driver_label"
 
+/** @cond INTERNAL_HIDDEN */
 /* A device without init call */
 DEVICE_DEFINE(dummy_noinit, DUMMY_NOINIT, NULL, NULL, NULL, NULL,
 	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
@@ -52,6 +53,7 @@ static int fakedeferdriver_init(const struct device *dev);
 
 DEVICE_DT_DEFINE(DT_INST(2, fakedeferdriver), fakedeferdriver_init, NULL, NULL, NULL, POST_KERNEL,
 		 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+/** @endcond */
 
 /**
  * @brief Test cases to verify device objects

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
@@ -284,7 +284,6 @@ ZTEST(fifo_api, test_fifo_is_empty_isr)
  * removing them (a subsequent get still returns both items in order). Peeking an
  * empty FIFO returns NULL.
  *
- * @ingroup kernel_fifo_tests
  * @see k_fifo_peek_head(), k_fifo_peek_tail()
  */
 ZTEST(fifo_api, test_fifo_peek)
@@ -317,7 +316,6 @@ K_HEAP_DEFINE(fifo_alloc_pool, 256);
  * calling thread's resource pool. Verify the call succeeds and that the same
  * data pointer is returned by a subsequent get.
  *
- * @ingroup kernel_fifo_tests
  * @see k_fifo_alloc_put()
  */
 ZTEST(fifo_api, test_fifo_alloc_put)

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
@@ -187,7 +187,6 @@ K_HEAP_DEFINE(lifo_alloc_pool, 256);
  * calling thread's resource pool. Verify the call succeeds and that the same
  * data pointer is returned by a subsequent get.
  *
- * @ingroup kernel_lifo_tests
  * @see k_lifo_alloc_put()
  */
 ZTEST(lifo_contexts, test_lifo_alloc_put)

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
@@ -678,7 +678,6 @@ ZTEST(msgq_api_1cpu, test_msgq_thread_pending)
  * count stays unchanged). Also verify that peeking at an index beyond the
  * number of queued messages returns -ENOMSG.
  *
- * @ingroup kernel_message_queue_tests
  * @see k_msgq_peek_at()
  */
 ZTEST_USER(msgq_api, test_msgq_peek_at)

--- a/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
+++ b/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
@@ -11,11 +11,12 @@
 #define THREAD_MID_PRIORITY 3
 #define THREAD_LOW_PRIORITY 5
 
+/** @cond INTERNAL_HIDDEN */
 /* use to pass case type to threads */
 static ZTEST_DMEM int case_type;
 static ZTEST_DMEM int thread_ret = TC_FAIL;
 
-/**TESTPOINT: init via K_MUTEX_DEFINE*/
+/* TESTPOINT: init via K_MUTEX_DEFINE */
 K_MUTEX_DEFINE(kmutex);
 static struct k_mutex tmutex;
 
@@ -25,6 +26,7 @@ static K_THREAD_STACK_DEFINE(tstack3, STACK_SIZE);
 static struct k_thread tdata;
 static struct k_thread tdata2;
 static struct k_thread tdata3;
+/** @endcond */
 
 
 

--- a/tests/kernel/obj_core/obj_core_stats/src/main.c
+++ b/tests/kernel/obj_core/obj_core_stats/src/main.c
@@ -7,6 +7,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/sys/mem_blocks.h>
 
+/** @cond INTERNAL_HIDDEN */
 SYS_MEM_BLOCKS_DEFINE(mem_block, 32, 4, 16);  /* Four 32 byte blocks */
 
 K_MEM_SLAB_DEFINE(mem_slab, 32, 4, 16);       /* Four 32 byte blocks */
@@ -35,6 +36,7 @@ void busy_thread_entry(void *p1, void *p2, void *p3)
 }
 
 #endif
+/** @endcond */
 
 /***************** SYSTEM (CPUs and KERNEL) ******************/
 

--- a/tests/kernel/poll/src/test_poll.c
+++ b/tests/kernel/poll/src/test_poll.c
@@ -21,6 +21,7 @@ struct fifo_msg {
 #define PIPE_DATA "atad_epip"
 #define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
 
+/** @cond INTERNAL_HIDDEN */
 /* verify k_poll() without waiting */
 static struct k_sem no_wait_sem;
 static struct k_fifo no_wait_fifo;
@@ -39,6 +40,7 @@ K_MSGQ_DEFINE(msgq_high_prio_thread, sizeof(unsigned int), 4, 4);
 static K_THREAD_STACK_DEFINE(high_prio_stack_area, 4096);
 static struct k_thread high_prio_data;
 static volatile bool wake_up_by_poll = true;
+/** @endcond */
 
 /**
  * @brief Test cases to verify poll

--- a/tests/kernel/queue/src/test_queue_user.c
+++ b/tests/kernel/queue/src/test_queue_user.c
@@ -11,9 +11,11 @@
 #define STACK_SIZE (512 + CONFIG_TEST_EXTRA_STACK_SIZE)
 #define LIST_LEN        5
 
+/** @cond INTERNAL_HIDDEN */
 static K_THREAD_STACK_DEFINE(child_stack, STACK_SIZE);
 static struct k_thread child_thread;
 static ZTEST_BMEM struct qdata qdata[LIST_LEN * 2];
+/** @endcond */
 
 /**
  * @brief Tests for queue

--- a/tests/kernel/semaphore/sys_sem/src/main.c
+++ b/tests/kernel/semaphore/sys_sem/src/main.c
@@ -17,6 +17,7 @@
 #define LOW_PRIO 8
 #define HIGH_PRIO 2
 
+/** @cond INTERNAL_HIDDEN */
 static K_THREAD_STACK_ARRAY_DEFINE(multi_stack_give, STACK_NUMS, STACK_SIZE);
 static K_THREAD_STACK_ARRAY_DEFINE(multi_stack_take, STACK_NUMS, STACK_SIZE);
 
@@ -25,6 +26,7 @@ static struct k_thread multi_tid_take[STACK_NUMS];
 static struct k_sem usage_sem, sync_sem, limit_sem, uninit_sem;
 static ZTEST_DMEM int flag;
 static ZTEST_DMEM atomic_t atomic_count;
+/** @endcond */
 
 /**
  * @ingroup all_tests


### PR DESCRIPTION
- **tests: kernel: common: hide clock test fixtures from doxygen**
- **tests: kernel: hide file-scope test fixtures from doxygen**
- **tests: kernel: fix doxygen groups in lifo/fifo/msgq**
- **kernel: fix doxygen warnings exposed by adding kernel/ to docs INPUT**
