### PR TITLE
twister: use suite id as testsuites registry key

### DIFF
--- a/doc/develop/twister/index.rst
+++ b/doc/develop/twister/index.rst
@@ -277,12 +277,7 @@ Test Scenario, Test Suite, and Test Case names must follow to these basic rules:
    subsection names delimited with a dot (``.``). For example, a test scenario
    that covers semaphores in the kernel shall start with ``kernel.semaphore``.
 
-#. All Test Scenario identifiers within a Test Configuration (``testcase.yaml`` file)
-   need to be unique.
-   For example a ``testcase.yaml`` file covering semaphores in the kernel can have:
-
-   * ``kernel.semaphore``: For general semaphore tests
-   * ``kernel.semaphore.stress``: Stress testing semaphores in the kernel.
+#. All Test Scenario names must be unique for the Twister execution scope.
 
 #. The full canonical name of a Test Suite is:
    ``<Test Application Project path>/<Test Scenario identifier>``
@@ -299,15 +294,6 @@ Test Scenario, Test Suite, and Test Case names must follow to these basic rules:
      a Test Scenario identifier from the corresponding ``tests.yaml`` file where
      the last section signifies the standalone
      Test Case name, for example: ``debug.coredump.logging_backend``.
-
-
-The ``--no-detailed-test-id`` command line option modifies the above rules in this way:
-
-#. A Test Suite name has only ``<Test Scenario identifier>`` component.
-   Its Application Project path can be found in ``twister.json`` report as ``path:`` property.
-
-#. With short Test Suite names in this mode, all corresponding Test Scenario names
-   must be unique for the Twister execution scope.
 
 
 The following is an example test configuration with a few options that are

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -522,19 +522,19 @@ class TestPlan:
 
     def _register_testsuite(self, suite: TestSuite) -> None:
         """Add a suite to testsuites, raising on duplicate from a different file."""
-        if suite.name in self.testsuites:
+        if suite.id in self.testsuites:
             msg = (
                 f"test suite '{suite.name}' in '{suite.yamlfile}' is already added"
             )
-            if suite.yamlfile == self.testsuites[suite.name].yamlfile:
+            if suite.yamlfile == self.testsuites[suite.id].yamlfile:
                 logger.debug(f"Skip - {msg}")
             else:
                 msg = (
-                    f"Duplicate {msg} from '{self.testsuites[suite.name].yamlfile}'"
+                    f"Duplicate {msg} from '{self.testsuites[suite.id].yamlfile}'"
                 )
                 raise TwisterRuntimeError(msg)
         else:
-            self.testsuites[suite.name] = suite
+            self.testsuites[suite.id] = suite
 
     def _is_testsuite_selected(self, suite: TestSuite, testsuite_filter, testsuite_patterns_r):
         """Check if the testsuite is selected by the user."""
@@ -751,8 +751,9 @@ class TestPlan:
                         )
                     if filter_platform and platform.name not in filter_platform:
                         continue
+                    testsuite_id = testsuite.rsplit('/', 1)[-1]
                     instance = TestInstance(
-                        self.testsuites[testsuite], platform, toolchain, self.env.outdir
+                        self.testsuites[testsuite_id], platform, toolchain, self.env.outdir
                     )
                     if ts.get("run_id"):
                         instance.run_id = ts.get("run_id")

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -51,8 +51,7 @@ def test_check_build_or_run(
     Scenario 2: Test if build_only is enabled when the OS is Windows"""
 
     class_testplan.testsuites = all_testsuites_dict
-    testsuite = class_testplan.testsuites.get('scripts/tests/twister/test_data/testsuites/tests/'
-                                              'test_a/test_a.check_1')
+    testsuite = class_testplan.testsuites.get('test_a.check_1')
     print(testsuite)
 
     class_testplan.platforms = platforms_list
@@ -135,8 +134,7 @@ def test_create_overlay(
 ):
     """Test correct content is written to testcase_extra.conf based on if conditions."""
     class_testplan.testsuites = all_testsuites_dict
-    testcase = class_testplan.testsuites.get('scripts/tests/twister/test_data/testsuites/samples/'
-                                             'test_app/sample_test.app')
+    testcase = class_testplan.testsuites.get('sample_test.app')
 
     if extra_configs:
         testcase.extra_configs = extra_configs
@@ -151,8 +149,7 @@ def test_create_overlay(
 def test_calculate_sizes(class_testplan, all_testsuites_dict, platforms_list):
     """ Test Calculate sizes method for zephyr elf"""
     class_testplan.testsuites = all_testsuites_dict
-    testcase = class_testplan.testsuites.get('scripts/tests/twister/test_data/testsuites/samples/'
-                                             'test_app/sample_test.app')
+    testcase = class_testplan.testsuites.get('sample_test.app')
     class_testplan.platforms = platforms_list
     platform = class_testplan.get_platform("demo_board_2")
     testinstance = TestInstance(testcase, platform, 'zephyr', class_testplan.env.outdir)
@@ -199,14 +196,15 @@ def test_which_filter_stages(filter_expr, expected_stages):
 
 @pytest.fixture(name='testinstance')
 def sample_testinstance(all_testsuites_dict, class_testplan, platforms_list, request):
-    testsuite_path = 'scripts/tests/twister/test_data/testsuites'
     if request.param['testsuite_kind']  == 'sample':
-        testsuite_path += '/samples/test_app/sample_test.app'
+        testsuite_id = 'sample_test.app'
     elif request.param['testsuite_kind'] == 'tests':
-        testsuite_path += '/tests/test_a/test_a.check_1'
+        testsuite_id = 'test_a.check_1'
+    else:
+        raise ValueError(f"Unknown testsuite_kind: {request.param['testsuite_kind']}")
 
     class_testplan.testsuites = all_testsuites_dict
-    testsuite = class_testplan.testsuites.get(testsuite_path)
+    testsuite = class_testplan.testsuites.get(testsuite_id)
     class_testplan.platforms = platforms_list
     platform = class_testplan.get_platform(request.param.get('board_name', 'demo_board_2'))
 
@@ -221,9 +219,9 @@ TESTDATA_1 = [
 
 @pytest.mark.parametrize('detailed_test_id', TESTDATA_1)
 def test_testinstance_init(all_testsuites_dict, class_testplan, platforms_list, detailed_test_id):
-    testsuite_path = 'scripts/tests/twister/test_data/testsuites/samples/test_app/sample_test.app'
+    testsuite_id = 'sample_test.app'
     class_testplan.testsuites = all_testsuites_dict
-    testsuite = class_testplan.testsuites.get(testsuite_path)
+    testsuite = class_testplan.testsuites.get(testsuite_id)
     testsuite.detailed_test_id = detailed_test_id
     class_testplan.platforms = platforms_list
     platform = class_testplan.get_platform("demo_board_2/unit_testing")
@@ -231,7 +229,7 @@ def test_testinstance_init(all_testsuites_dict, class_testplan, platforms_list, 
     testinstance = TestInstance(testsuite, platform, 'zephyr', class_testplan.env.outdir)
 
     if detailed_test_id:
-        assert testinstance.build_dir == os.path.join(class_testplan.env.outdir, platform.normalized_name, 'zephyr', testsuite_path)
+        assert testinstance.build_dir == os.path.join(class_testplan.env.outdir, platform.normalized_name, 'zephyr', testsuite.name)
     else:
         assert testinstance.build_dir == os.path.join(class_testplan.env.outdir, platform.normalized_name, 'zephyr', testsuite.source_dir_rel, testsuite.name)
 
@@ -281,9 +279,9 @@ def test_testinstance_add_filter(testinstance):
 
 
 def test_testinstance_init_cases(all_testsuites_dict, class_testplan, platforms_list):
-    testsuite_path = 'scripts/tests/twister/test_data/testsuites/tests/test_a/test_a.check_1'
+    testsuite_id = 'test_a.check_1'
     class_testplan.testsuites = all_testsuites_dict
-    testsuite = class_testplan.testsuites.get(testsuite_path)
+    testsuite = class_testplan.testsuites.get(testsuite_id)
     class_testplan.platforms = platforms_list
     platform = class_testplan.get_platform("demo_board_2")
 
@@ -335,9 +333,9 @@ def test_testinstance_add_missing_case_status(testinstance, reason, expected_rea
 
 
 def test_testinstance_dunders(all_testsuites_dict, class_testplan, platforms_list):
-    testsuite_path = 'scripts/tests/twister/test_data/testsuites/samples/test_app/sample_test.app'
+    testsuite_id = 'sample_test.app'
     class_testplan.testsuites = all_testsuites_dict
-    testsuite = class_testplan.testsuites.get(testsuite_path)
+    testsuite = class_testplan.testsuites.get(testsuite_id)
     class_testplan.platforms = platforms_list
     platform = class_testplan.get_platform("demo_board_2")
 
@@ -359,7 +357,7 @@ def test_testinstance_dunders(all_testsuites_dict, class_testplan, platforms_lis
     assert not testinstance < testinstance_copy
     assert not testinstance_copy < testinstance
 
-    assert testinstance.__repr__() == f'<TestSuite {testsuite_path} on demo_board_2/unit_testing>'
+    assert testinstance.__repr__() == f'<TestSuite {testsuite.name} on demo_board_2/unit_testing>'
 
 
 @pytest.mark.parametrize('testinstance', [{'testsuite_kind': 'tests'}], indirect=True)
@@ -648,9 +646,9 @@ TESTDATA_9 = [
 
 @pytest.mark.parametrize('harness_config, expected_content', TESTDATA_9)
 def test_create_overlay_with_harness_config(class_testplan, all_testsuites_dict, platforms_list, harness_config, expected_content):
-    testsuite_path = 'scripts/tests/twister/test_data/testsuites/samples/test_app/sample_test.app'
+    testsuite_id = 'sample_test.app'
     class_testplan.testsuites = all_testsuites_dict
-    testsuite = class_testplan.testsuites.get(testsuite_path)
+    testsuite = class_testplan.testsuites.get(testsuite_id)
     testsuite.harness_config = harness_config
     class_testplan.platforms = platforms_list
     platform = class_testplan.get_platform("demo_board_2")

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -59,7 +59,7 @@ def test_testplan_add_testsuites_short(class_testplan):
     assert sorted(testsuite_list) == sorted(expected_testsuites)
 
     # Test 2 : Assert Testcase name is expected & all testsuites values are testcase class objects
-    suite = class_testplan.testsuites.get(tests_rel_dir + 'test_a/test_a.check_1')
+    suite = class_testplan.testsuites.get('test_a.check_1')
     assert suite.name == tests_rel_dir + 'test_a/test_a.check_1'
     assert all(isinstance(n, TestSuite) for n in class_testplan.testsuites.values())
 
@@ -427,7 +427,7 @@ def test_add_instances_short(tmp_path, class_env, all_testsuites_dict, platforms
         instance_list.append(instance)
     plan.add_instances(instance_list)
     assert list(plan.instances.keys()) == \
-		   [platform.name + '/zephyr/' + s for s in list(all_testsuites_dict.keys())]
+		   [platform.name + '/zephyr/' + s.name for s in all_testsuites_dict.values()]
     assert all(isinstance(n, TestInstance) for n in list(plan.instances.values()))
     assert list(plan.instances.values()) == instance_list
 
@@ -512,16 +512,16 @@ def test_quarantine_short(class_testplan, platforms_list, test_data,
 
 
 TESTDATA_PART4 = [
-    (os.path.join('test_d', 'test_d.check_1'), ['dummy'],
+    ('test_d.check_1', ['dummy'],
      None, 'Snippet not supported'),
-    (os.path.join('test_c', 'test_c.check_1'), ['cdc-acm-console'],
+    ('test_c.check_1', ['cdc-acm-console'],
      0, None),
-    (os.path.join('test_d', 'test_d.check_1'), ['dummy', 'cdc-acm-console'],
+    ('test_d.check_1', ['dummy', 'cdc-acm-console'],
      2, 'Snippet not supported'),
 ]
 
 @pytest.mark.parametrize(
-    'testpath, required_snippets, expected_filtered_len, expected_filtered_reason',
+    'testsuite_id, required_snippets, expected_filtered_len, expected_filtered_reason',
     TESTDATA_PART4,
     ids=['app', 'global', 'multiple']
 )
@@ -529,19 +529,17 @@ def test_required_snippets_short(
     class_testplan,
     all_testsuites_dict,
     platforms_list,
-    testpath,
+    testsuite_id,
     required_snippets,
     expected_filtered_len,
     expected_filtered_reason
 ):
     """ Testing required_snippets function of TestPlan class in Twister """
     plan = class_testplan
-    testpath = os.path.join('scripts', 'tests', 'twister', 'test_data',
-                            'testsuites', 'tests', testpath)
-    testsuite = class_testplan.testsuites.get(testpath)
+    testsuite = all_testsuites_dict.get(testsuite_id)
     plan.platforms = platforms_list
     plan.platform_names = [p.name for p in platforms_list]
-    plan.testsuites = {testpath: testsuite}
+    plan.testsuites = {testsuite_id: testsuite}
 
     for _, testcase in plan.testsuites.items():
         testcase.exclude_platform = []
@@ -1341,14 +1339,14 @@ def test_testplan_get_all_tests():
 
 
 TESTDATA_9 = [
-    ([], False, True, 11, 1),
+    ([], False, True, 7, 2),
     ([], False, False, 7, 2),
     ([], True, False, 9, 1),
     ([], True, True, 9, 1),
     ([], True, False, 9, 1),
     (['good_test/dummy.common.1', 'good_test/dummy.common.2', 'good_test/dummy.common.3'], False, True, 3, 1),
     (['good_test/dummy.common.1', 'good_test/dummy.common.2',
-      'duplicate_test/dummy.common.1', 'duplicate_test/dummy.common.2'], False, True, 4, 1),
+      'duplicate_test/dummy.common.1', 'duplicate_test/dummy.common.2'], False, True, 2, 2),
     (['dummy.common.1', 'dummy.common.2'], False, False, 2, 2),
     (['good_test/dummy.common.1', 'good_test/dummy.common.2', 'good_test/dummy.common.3'], True, True, 0, 1),
 ]
@@ -1363,7 +1361,7 @@ TESTDATA_9 = [
         'no filter, alt root, detailed id',
         'no filter, alt root, short id',
         'testsuite filter',
-        'testsuite filter and valid duplicate',
+        'testsuite filter and duplicate',
         'testsuite filter, short id and duplicate',
         'testsuite filter, alt root',
     ]
@@ -1433,9 +1431,8 @@ tests:
 
     tmp_duplicate_test_dir = tmp_test_root_dir / 'duplicate_test'
     tmp_duplicate_test_dir.mkdir()
-    # The duplicate needs to have the same number of tests as these configurations
-    # can be read either with duplicate_test first, or good_test first, so number
-    # of selected tests needs to be the same in both situations.
+    # duplicated testcases should be detected and reported as an error,
+    # no matter if --detailed-test-id is used or not
     testcase_yaml_4 = """\
 tests:
   dummy.common.1:


### PR DESCRIPTION
Use suite id instead of name as the key in the testsuites registry.
With `--detailed-test-id` enabled, the suite name includes the path, which caused a false duplicate error when a
required application was passed via `-T` on the command line and was also listed in the `required_application` section of another test.

Duplicated scenarios will be reported as an error regardless of whether `--detailed-test-id` is used.

Update the twister unit tests.

---
reproduce with a command:
`west twister --no-clean -vv -ll debug -T samples/hello_world -T tests/subsys/testsuite/no_self_build  --list-tests --detailed-test-id`
received (on main branch):
```
DEBUG   - Skip - test suite 'samples/hello_world/sample.basic.helloworld' in 'zephyrproject/zephyr/samples/hello_world' is already added
DEBUG   - Required application sample.basic.helloworld not found among test suites.
```
The test then fails, because the required application is not added.
When running a downstream test (with a path outside of `ZEPHYR_BASE`), a duplicate error is received instead.
