### PR TITLE
FRDM-MCXL255: MU devicetree support for CM33/CM0+

### DIFF
--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
@@ -110,3 +110,7 @@
 &systick {
 	status = "okay";
 };
+
+&mbox_a {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
@@ -164,3 +164,7 @@
 	pinctrl-0 = <&pinmux_aon_lpi2c0>;
 	pinctrl-names = "default";
 };
+
+&mbox_a {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
@@ -15,4 +15,5 @@ supported:
   - gpio
   - rtc
   - crc
+  - mbox
 vendor: nxp

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
@@ -18,4 +18,5 @@ supported:
   - rtc
   - crc
   - watchdog
+  - mbox
 vendor: nxp

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
@@ -35,3 +35,7 @@
 &systick {
 	status = "okay";
 };
+
+&mbox_b {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.dts
@@ -41,3 +41,7 @@
 	pinctrl-0 = <&pinmux_aon_lpi2c0>;
 	pinctrl-names = "default";
 };
+
+&mbox_b {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
@@ -12,4 +12,5 @@ toolchain:
   - gnuarmemb
 supported:
   - uart
+  - mbox
 vendor: nxp

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu1.yaml
@@ -13,4 +13,5 @@ toolchain:
 supported:
   - uart
   - i2c
+  - mbox
 vendor: nxp

--- a/dts/arm/nxp/mcx/mcxl/nxp_mcxl_aon.dtsi
+++ b/dts/arm/nxp/mcx/mcxl/nxp_mcxl_aon.dtsi
@@ -75,6 +75,15 @@
 		status = "disabled";
 	};
 
+	mbox_b: mbox@84000 {
+		compatible = "nxp,mbox-imx-mu";
+		reg = <0x84000 0x1000>;
+		interrupts = <7 0>, <8 0>, <9 0>;
+		rx-channels = <4>;
+		#mbox-cells = <1>;
+		status = "disabled";
+	};
+
 	aon_qtmr_clock: aon-qtmr-clock {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;

--- a/dts/arm/nxp/mcx/nxp_mcxl_aon.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl_aon.dtsi
@@ -73,4 +73,13 @@
 		alarms-count = <3>;
 		status = "disabled";
 	};
+
+	mbox_b: mbox@84000 {
+		compatible = "nxp,mbox-imx-mu";
+		reg = <0x84000 0x1000>;
+		interrupts = <7 0>, <8 0>, <9 0>;
+		rx-channels = <4>;
+		#mbox-cells = <1>;
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
Add MU devicetree support for FRDM-MCXL255.

This PR adds the AON-domain MUB mailbox node for MCXL devices and enables
the MUA/MUB mailbox instances on FRDM-MCXL255 CPU0 and CPU1.

The existing MUA node is used by the CPU0/CM33 target. The new MUB node is
added for the CPU1/CM0+ AON target.

Full multicore runtime support is left for the multicore team follow-up.

Build-tested:
- `samples/hello_world` on `frdm_mcxl255/mcxl255/cpu0`
- `samples/hello_world` on `frdm_mcxl255/mcxl255/cpu1`