### PR TITLE
samples: Bluetooth: Audio: Fix bad path in CAP handover

### DIFF
--- a/samples/bluetooth/audio/cap_handover/sysbuild.cmake
+++ b/samples/bluetooth/audio/cap_handover/sysbuild.cmake
@@ -14,7 +14,7 @@ if(SB_CONFIG_NET_CORE_IMAGE_HCI_IPC)
   )
 
   set(${NET_APP}_EXTRA_CONF_FILE
-    ${ZEPHYR_BASE}/samples/bluetooth/cap_handover/overlay-bt_ll_sw_split.conf
+    ${ZEPHYR_BASE}/samples/bluetooth/audio/cap_handover/overlay-bt_ll_sw_split.conf
     CACHE INTERNAL ""
   )
 


### PR DESCRIPTION
The sample was moved to the audio subdirectory.