### PR TITLE
twister: vairous fixes and improvements for coverage

### DIFF
--- a/doc/develop/test/coverage.rst
+++ b/doc/develop/test/coverage.rst
@@ -181,6 +181,45 @@ toolchain and require a different board:
 
 which produces a report in the same location as non-unit testing.
 
+Per-test coverage matrix
+========================
+
+By default coverage is aggregated per test scenario. To attribute coverage
+down to individual :ref:`Ztest <test-framework>` test cases -- for example to
+answer "which tests exercised line X of ``foo.c``" -- pass ``--coverage-per-test``:
+
+.. code-block:: console
+
+   $ twister -p mps2/an385 -T tests/kernel --coverage --coverage-tool lcov \
+       --coverage-per-test
+
+This enables :kconfig:option:`CONFIG_ZTEST_COVERAGE_PER_TEST`, which resets the
+gcov counters before each test case and dumps an isolated, test-tagged coverage
+artifact after it. On platforms that support semihosting (ARM, RISC-V and Xtensa
+targets under QEMU, such as ``mps2/an385``) the per-test data is written straight
+to the host filesystem, avoiding the large amount of serial console traffic that
+per-test dumping would otherwise produce; other platforms fall back to the serial
+console transport.
+
+In addition to the usual aggregated coverage report, this produces:
+
+* one ``<scenario>.<test>.info`` tracefile per test under each build's
+  ``coverage/tests/`` directory, and
+* ``twister-out/coverage/test_matrix.json``, a machine-readable matrix with a
+  ``by_line`` view (``{file: {line: [tests]}}``) and a ``by_test`` view
+  (``{test: {file: [lines]}}``).
+
+Per-test attribution is carried by the matrix (and its dashboard), not by the
+aggregated lcov report: each instance's coverage is collapsed to a single
+tracefile before aggregation, so the end-of-run reporting stays proportional to
+the number of instances rather than the total number of test cases.
+
+.. note::
+
+   ``--coverage-per-test`` requires the ``lcov`` coverage tool, because the
+   matrix relies on lcov's per-test ``TN`` tracefile records; ``gcovr`` has no
+   equivalent. It also implies ``--coverage``.
+
 .. _gcovr_symlinks:
    https://github.com/gcovr/gcovr/blob/main/doc/source/guide/filters.rst#filters-for-symlinks
 

--- a/doc/develop/test/coverage.rst
+++ b/doc/develop/test/coverage.rst
@@ -220,6 +220,24 @@ the number of instances rather than the total number of test cases.
    matrix relies on lcov's per-test ``TN`` tracefile records; ``gcovr`` has no
    equivalent. It also implies ``--coverage``.
 
+Visualizing the matrix
+----------------------
+
+``test_matrix.json`` can be turned into a self-contained, interactive HTML
+dashboard with the standalone :zephyr_file:`scripts/gen_test_matrix_dashboard.py`
+script (it has no dependency on Twister and can be run on any previously
+generated matrix):
+
+.. code-block:: console
+
+   $ scripts/gen_test_matrix_dashboard.py -i twister-out/coverage/test_matrix.json
+
+This writes ``twister-out/coverage/test_matrix.html``, which lists -- per test
+-- how many files and lines it covers and how many lines it covers *uniquely*
+(that no other test reaches, useful for spotting redundant or load-bearing
+tests), and lets you drill into the files a test covers or look up which tests
+cover a given file and line.
+
 .. _gcovr_symlinks:
    https://github.com/gcovr/gcovr/blob/main/doc/source/guide/filters.rst#filters-for-symlinks
 

--- a/include/zephyr/debug/gcov.h
+++ b/include/zephyr/debug/gcov.h
@@ -4,15 +4,73 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Public API for dumping GCC gcov code coverage data.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DEBUG_GCOV_H_
 #define ZEPHYR_INCLUDE_DEBUG_GCOV_H_
 
-#ifdef CONFIG_COVERAGE_GCOV
+#if defined(CONFIG_COVERAGE_GCOV) || defined(__DOXYGEN__)
+
+/**
+ * @brief Dump all collected gcov coverage data.
+ *
+ * Retrieve the gcov coverage data for every registered object and send it
+ * over the transport selected by the coverage dump method
+ * (@kconfig{CONFIG_COVERAGE_DUMP} for the console or
+ * @kconfig{CONFIG_COVERAGE_SEMIHOST} for the host filesystem). This is the
+ * untagged form and is equivalent to gcov_coverage_dump_tagged() with a
+ * @c NULL tag.
+ */
 void gcov_coverage_dump(void);
+
+/**
+ * @brief Dump gcov coverage data tagged with a label.
+ *
+ * Retrieve the gcov coverage data and emit it over the configured transport,
+ * associating the dump with @p tag so a consumer can attribute it to a single
+ * producer (for example an individual test case).
+ *
+ * The tag is carried differently depending on the selected dump method:
+ * - Console (@kconfig{CONFIG_COVERAGE_DUMP}): @p tag is appended to the
+ *   @c GCOV_COVERAGE_DUMP_START marker that frames the data.
+ * - Semihosting (@kconfig{CONFIG_COVERAGE_SEMIHOST}): each @c .gcda is written
+ *   to a path formed by appending `@@` and the tag to the file name (for
+ *   example `foo.gcda@@suite.test`) instead of its canonical path, so that
+ *   several isolated dumps can coexist next to the matching @c .gcno without
+ *   overwriting one another.
+ *
+ * When @p tag is not @c NULL, objects that have recorded no coverage are
+ * skipped, keeping tagged (per-producer) dumps small. Passing @c NULL
+ * reproduces the historical, untagged behaviour and dumps every object.
+ *
+ * @param tag Label to attribute the dump to, or @c NULL for an untagged dump.
+ */
+void gcov_coverage_dump_tagged(const char *tag);
+
+/**
+ * @brief Dump all collected gcov coverage data over semihosting.
+ *
+ * Write the gcov coverage data for every registered object to the host
+ * filesystem using semihosting. Available only when the semihosting dump
+ * method (@kconfig{CONFIG_COVERAGE_SEMIHOST}) is selected. This is the
+ * untagged form.
+ */
 void gcov_coverage_semihost(void);
+
+/**
+ * @brief Initialize the gcov runtime.
+ *
+ * Invoke the gcov constructors so that each instrumented object registers its
+ * @c gcov_info with the runtime. Must run before any coverage data is dumped.
+ */
 void gcov_static_init(void);
+
 #else
 static inline void gcov_coverage_dump(void) { }
+static inline void gcov_coverage_dump_tagged(const char *tag) { (void)tag; }
 static inline void gcov_static_init(void) { }
 
 #endif	/* CONFIG_COVERAGE_GCOV */

--- a/scripts/gen_test_matrix_dashboard.py
+++ b/scripts/gen_test_matrix_dashboard.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate a self-contained HTML dashboard from a Twister per-test coverage
+matrix.
+
+Twister's ``--coverage-per-test`` mode writes ``test_matrix.json`` (with
+``by_line`` and ``by_test`` views). This script turns that JSON into a single,
+dependency-free HTML page that shows, per test, how many files and lines it
+covers and how many lines it covers uniquely, and lets you drill into a test's
+files or look up which tests cover a given file and line.
+
+Example:
+
+    scripts/gen_test_matrix_dashboard.py -i twister-out/coverage/test_matrix.json
+"""
+
+import argparse
+import json
+import os
+import sys
+
+# Self-contained dashboard. The matrix is inlined at __MATRIX_DATA__ and all
+# derived metrics are computed in the browser.
+_TEMPLATE = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Per-test coverage matrix</title>
+<style>
+ body{font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+   margin:0;color:#1a1a1a;background:#f6f7f9}
+ header{background:#2c3e50;color:#fff;padding:14px 24px}
+ header h1{margin:0;font-size:18px}
+ .stats{display:flex;flex-wrap:wrap;gap:22px;margin-top:8px;font-size:13px;color:#cfd8e3}
+ .stats b{color:#fff;font-size:15px}
+ main{padding:18px 24px;display:grid;grid-template-columns:1fr 1fr;gap:18px}
+ .card{background:#fff;border:1px solid #e2e6ea;border-radius:6px;padding:14px;min-width:0}
+ .card h2{margin:0 0 10px;font-size:14px;color:#2c3e50}
+ .full{grid-column:1/3}
+ table{border-collapse:collapse;width:100%;font-size:13px}
+ th,td{text-align:left;padding:5px 8px;border-bottom:1px solid #eef1f3;
+   white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:52ch}
+ th{cursor:pointer;user-select:none;background:#f0f2f5;position:sticky;top:0}
+ th.num,td.num{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap}
+ th.sorted::after{content:" \25be";color:#2c3e50}
+ th.asc.sorted::after{content:" \25b4"}
+ tbody tr{cursor:pointer}
+ tbody tr:hover{background:#eef6ff}
+ tr.sel{background:#dcecff}
+ input{width:100%;padding:6px 8px;border:1px solid #cbd2d9;border-radius:4px;
+   margin-bottom:10px;box-sizing:border-box;font-size:13px}
+ .scroll{max-height:62vh;overflow:auto}
+ .uniq{color:#c0392b;font-weight:600}
+ code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px}
+ .muted{color:#7a8794;font-size:12px}
+</style>
+</head>
+<body>
+<header>
+ <h1>Per-test coverage matrix</h1>
+ <div class="stats" id="stats"></div>
+</header>
+<main>
+ <section class="card full">
+   <h2>Coverage per test</h2>
+   <input type="search" id="testFilter" placeholder="Filter tests&#8230;">
+   <div class="scroll"><table id="testTable">
+     <thead><tr>
+       <th data-k="test">Test</th>
+       <th data-k="files" class="num">Files</th>
+       <th data-k="lines" class="num">Lines</th>
+       <th data-k="unique" class="num">Unique</th>
+       <th data-k="uniquePct" class="num">Unique %</th>
+     </tr></thead>
+     <tbody></tbody>
+   </table></div>
+ </section>
+ <section class="card">
+   <h2 id="detailTitle">Test details</h2>
+   <div id="detail" class="muted">Select a test to see the files it covers.</div>
+ </section>
+ <section class="card">
+   <h2>File &#8594; line &#8594; tests</h2>
+   <input type="text" id="fileInput" list="fileList" placeholder="Type a source file&#8230;">
+   <datalist id="fileList"></datalist>
+   <div id="fileView" class="muted">Choose a file to see which tests cover each line.</div>
+ </section>
+</main>
+<script id="data" type="application/json">__MATRIX_DATA__</script>
+<script>
+const DATA = JSON.parse(document.getElementById('data').textContent);
+const byLine = DATA.by_line || {}, byTest = DATA.by_test || {};
+
+const uniqByTest = {};
+let coveredLines = 0, uniqueLines = 0;
+for (const f in byLine) {
+  for (const ln in byLine[f]) {
+    const ts = byLine[f][ln];
+    coveredLines++;
+    if (ts.length === 1) { uniqueLines++; uniqByTest[ts[0]] = (uniqByTest[ts[0]] || 0) + 1; }
+  }
+}
+const rows = Object.keys(byTest).map(t => {
+  const files = Object.keys(byTest[t]).length;
+  const lines = Object.values(byTest[t]).reduce((a, l) => a + l.length, 0);
+  const unique = uniqByTest[t] || 0;
+  return { test: t, files, lines, unique, uniquePct: lines ? unique / lines * 100 : 0 };
+});
+document.getElementById('stats').innerHTML =
+  `<div><b>${rows.length}</b> tests</div>` +
+  `<div><b>${Object.keys(byLine).length}</b> files</div>` +
+  `<div><b>${coveredLines}</b> covered lines</div>` +
+  `<div><b>${uniqueLines}</b> covered by exactly one test</div>`;
+
+const tbody = document.querySelector('#testTable tbody');
+let sortKey = 'unique', sortDir = -1;
+function renderTable() {
+  const q = document.getElementById('testFilter').value.toLowerCase();
+  const rs = rows.filter(r => r.test.toLowerCase().includes(q)).sort((a, b) => {
+    const x = a[sortKey], y = b[sortKey];
+    return (x < y ? -1 : x > y ? 1 : 0) * sortDir;
+  });
+  tbody.innerHTML = rs.map(r =>
+    `<tr data-t="${enc(r.test)}"><td title="${enc(r.test)}"><code>${enc(r.test)}</code></td>` +
+    `<td class="num">${r.files}</td><td class="num">${r.lines}</td>` +
+    `<td class="num uniq">${r.unique}</td><td class="num">${r.uniquePct.toFixed(1)}</td></tr>`
+  ).join('');
+  document.querySelectorAll('#testTable th').forEach(th => {
+    th.classList.toggle('sorted', th.dataset.k === sortKey);
+    th.classList.toggle('asc', th.dataset.k === sortKey && sortDir === 1);
+  });
+}
+function showTest(t) {
+  const files = byTest[t] || {};
+  const list = Object.keys(files).map(f => {
+    let u = 0;
+    for (const ln of files[f]) { if ((byLine[f] && byLine[f][ln] || []).length === 1) u++; }
+    return { f, n: files[f].length, u };
+  }).sort((a, b) => b.n - a.n);
+  document.getElementById('detailTitle').textContent = 'Files covered by ' + t;
+  const total = list.reduce((a, x) => a + x.n, 0);
+  document.getElementById('detail').innerHTML =
+    `<div class="muted">${list.length} files, ${total} lines</div>` +
+    `<div class="scroll"><table><thead><tr><th>File</th><th class="num">Lines</th>` +
+    `<th class="num">Unique</th></tr></thead><tbody>` +
+    list.map(x => `<tr><td title="${enc(x.f)}"><code>${enc(x.f)}</code></td>` +
+      `<td class="num">${x.n}</td><td class="num uniq">${x.u}</td></tr>`).join('') +
+    `</tbody></table></div>`;
+}
+function showFile(f) {
+  const el = document.getElementById('fileView');
+  const lines = byLine[f];
+  if (!lines) {
+    el.className = 'muted';
+    el.textContent = 'No coverage recorded for that file.';
+    return;
+  }
+  el.className = 'scroll';
+  const lns = Object.keys(lines).map(Number).sort((a, b) => a - b);
+  el.innerHTML = `<table><thead><tr><th class="num">Line</th>` +
+    `<th>Covered by</th></tr></thead><tbody>` +
+    lns.map(ln => {
+      const ts = lines[ln];
+      const cell = ts.length === 1
+        ? `<span class="uniq">${enc(ts[0])}</span>`
+        : ts.map(enc).join(', ');
+      return `<tr><td class="num">${ln}</td><td>${cell}</td></tr>`;
+    }).join('') + `</tbody></table>`;
+}
+function enc(s) {
+  return String(s).replace(/[&<>"]/g,
+    c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+}
+
+document.querySelectorAll('#testTable th').forEach(th => th.onclick = () => {
+  const k = th.dataset.k;
+  if (sortKey === k) { sortDir *= -1; } else { sortKey = k; sortDir = k === 'test' ? 1 : -1; }
+  renderTable();
+});
+document.getElementById('testFilter').oninput = renderTable;
+tbody.onclick = e => {
+  const tr = e.target.closest('tr');
+  if (!tr || !tr.dataset.t) return;
+  document.querySelectorAll('#testTable tr.sel').forEach(x => x.classList.remove('sel'));
+  tr.classList.add('sel');
+  showTest(tr.dataset.t);
+};
+document.getElementById('fileList').innerHTML =
+  Object.keys(byLine).sort().map(f => `<option value="${enc(f)}">`).join('');
+document.getElementById('fileInput').oninput = e => showFile(e.target.value);
+renderTable();
+</script>
+</body>
+</html>
+"""
+
+
+def render_dashboard(matrix):
+    """Return the dashboard HTML for a parsed coverage matrix."""
+    payload = json.dumps(matrix, sort_keys=True).replace("</", "<\\/")
+    return _TEMPLATE.replace("__MATRIX_DATA__", payload)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        default="test_matrix.json",
+        help="Path to the test_matrix.json produced by Twister (default: %(default)s).",
+    )
+    parser.add_argument(
+        "-o", "--output", default=None, help="Output HTML file (default: input with .html suffix)."
+    )
+    args = parser.parse_args()
+
+    try:
+        with open(args.input) as fp:
+            matrix = json.load(fp)
+    except OSError as e:
+        sys.exit(f"Unable to read coverage matrix '{args.input}': {e}")
+    except json.JSONDecodeError as e:
+        sys.exit(f"'{args.input}' is not a valid coverage matrix: {e}")
+
+    output = args.output or (os.path.splitext(args.input)[0] + ".html")
+    with open(output, "w") as fp:
+        fp.write(render_dashboard(matrix))
+    print(f"Per-test coverage dashboard written to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -575,34 +575,79 @@ def try_making_symlink(source: str, link: str):
         shutil.copy(source, temp_filename)
         os.replace(temp_filename, link)
 
-def choose_gcov_tool(options, is_system_gcov):
-    gcov_tool = None
-    if not options.gcov_tool:
-        zephyr_sdk_gcov_tool = os.path.join(
-            os.environ.get("ZEPHYR_SDK_INSTALL_DIR", default=""),
-            "gnu/x86_64-zephyr-elf/bin/x86_64-zephyr-elf-gcov")
-        if os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT", "").endswith("/llvm"):
-            llvm_path = os.environ.get("LLVM_TOOLCHAIN_PATH")
-            if llvm_path is not None:
-                llvm_path = os.path.join(llvm_path, "bin")
-            llvm_cov = shutil.which("llvm-cov", path=llvm_path)
-            llvm_cov_ext = pathlib.Path(llvm_cov).suffix
-            gcov_lnk = os.path.join(options.outdir, f"gcov{llvm_cov_ext}")
-            try_making_symlink(llvm_cov, gcov_lnk)
-            gcov_tool = gcov_lnk
-        elif is_system_gcov:
-            gcov_tool = "gcov"
-        elif os.path.exists(zephyr_sdk_gcov_tool):
-            gcov_tool = zephyr_sdk_gcov_tool
-        else:
-            logger.error(
-                "Can't find a suitable gcov tool. Use --gcov-tool or set ZEPHYR_SDK_INSTALL_DIR."
-            )
-            sys.exit(1)
-    else:
-        gcov_tool = str(options.gcov_tool)
+def read_cmake_cache_var(build_dir, var):
+    """ Return the value of a CMake cache variable from build_dir, or None. """
+    cache = os.path.join(build_dir, "CMakeCache.txt")
+    # CMake cache entries look like 'NAME:TYPE=VALUE'.
+    pattern = re.compile(rf"^{re.escape(var)}:[^=]*=(.*)$")
+    try:
+        with open(cache) as f:
+            for line in f:
+                match = pattern.match(line.strip())
+                if match:
+                    return match.group(1).strip()
+    except OSError:
+        return None
 
-    return gcov_tool
+    return None
+
+
+def find_cached_path_in_builds(instances, var):
+    """ Find a CMake cache path variable across the given instances' builds.
+
+    Each Zephyr build resolves the gcov tool matching its toolchain and
+    records it (CMAKE_GCOV) in CMakeCache.txt, so reading it back gives a
+    binary that is guaranteed to match the gcno/gcda data. Returns the first
+    value that exists on disk, or None.
+    """
+    for instance in (instances or {}).values():
+        value = read_cmake_cache_var(instance.build_dir, var)
+        if value and os.path.exists(value):
+            return value
+
+    return None
+
+
+def choose_gcov_tool(options, is_system_gcov, instances=None):
+    if options.gcov_tool:
+        return str(options.gcov_tool)
+
+    if os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT", "").endswith("/llvm"):
+        llvm_path = os.environ.get("LLVM_TOOLCHAIN_PATH")
+        if llvm_path is not None:
+            llvm_path = os.path.join(llvm_path, "bin")
+        llvm_cov = shutil.which("llvm-cov", path=llvm_path)
+        llvm_cov_ext = pathlib.Path(llvm_cov).suffix
+        gcov_lnk = os.path.join(options.outdir, f"gcov{llvm_cov_ext}")
+        try_making_symlink(llvm_cov, gcov_lnk)
+        return gcov_lnk
+
+    if is_system_gcov:
+        return "gcov"
+
+    # Auto-detect the gcov tool used by the builds. Zephyr's CMake toolchain
+    # logic resolves the gcov binary (CMAKE_GCOV) when configuring each build,
+    # which for the Zephyr SDK points at the SDK's cross gcov. Preferring it
+    # avoids depending on ZEPHYR_SDK_INSTALL_DIR being exported and works for
+    # any target architecture.
+    gcov_tool = find_cached_path_in_builds(instances, "CMAKE_GCOV")
+    if gcov_tool:
+        return gcov_tool
+
+    # Fall back to deriving the path from the Zephyr SDK install dir, taken
+    # from the environment or, failing that, from what a build recorded.
+    sdk_dir = os.environ.get("ZEPHYR_SDK_INSTALL_DIR") or \
+        find_cached_path_in_builds(instances, "ZEPHYR_SDK_INSTALL_DIR")
+    if sdk_dir:
+        zephyr_sdk_gcov_tool = os.path.join(
+            sdk_dir, "gnu/x86_64-zephyr-elf/bin/x86_64-zephyr-elf-gcov")
+        if os.path.exists(zephyr_sdk_gcov_tool):
+            return zephyr_sdk_gcov_tool
+
+    logger.error(
+        "Can't find a suitable gcov tool. Use --gcov-tool or set ZEPHYR_SDK_INSTALL_DIR."
+    )
+    sys.exit(1)
 
 
 def run_coverage_tool(options, outdir, is_system_gcov, instances,
@@ -611,7 +656,7 @@ def run_coverage_tool(options, outdir, is_system_gcov, instances,
     if not coverage_tool:
         return False, {}
 
-    coverage_tool.gcov_tool = str(choose_gcov_tool(options, is_system_gcov))
+    coverage_tool.gcov_tool = str(choose_gcov_tool(options, is_system_gcov, instances))
     logger.debug(f"Using gcov tool: {coverage_tool.gcov_tool}")
 
     coverage_tool.instances = instances

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -581,7 +581,7 @@ def choose_gcov_tool(options, is_system_gcov):
         zephyr_sdk_gcov_tool = os.path.join(
             os.environ.get("ZEPHYR_SDK_INSTALL_DIR", default=""),
             "gnu/x86_64-zephyr-elf/bin/x86_64-zephyr-elf-gcov")
-        if os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT").endswith("/llvm"):
+        if os.environ.get("ZEPHYR_TOOLCHAIN_VARIANT", "").endswith("/llvm"):
             llvm_path = os.environ.get("LLVM_TOOLCHAIN_PATH")
             if llvm_path is not None:
                 llvm_path = os.path.join(llvm_path, "bin")

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -202,8 +202,13 @@ class CoverageTool:
                         os.path.join(outdir, "coverage", "coverage.sonarqube.xml")
                     )
                 }
+                # Per-instance reports are generated one per test instance and
+                # would flood the console, so log them at debug level and keep
+                # only the aggregated report at info level.
+                per_instance_report = self.coverage_capture and self.coverage_per_instance
+                log = logger.debug if per_instance_report else logger.info
                 for r in self.output_formats.split(','):
-                    logger.info(report_log[r])
+                    log(report_log[r])
             else:
                 coverage_completed = False
         gcov_process_duration = time.time() - gcov_process_start

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -7,6 +7,7 @@ import collections
 import contextlib
 import filecmp
 import glob
+import json
 import logging
 import os
 import pathlib
@@ -36,6 +37,7 @@ class CoverageTool:
         self.coverage_capture = True
         self.coverage_report = True
         self.coverage_per_instance = False
+        self.coverage_per_test = False
         self.instances = {}
 
     @staticmethod
@@ -173,7 +175,12 @@ class CoverageTool:
         if not coverage_completed or not self.coverage_report:
             return coverage_completed, {}
         build_dirs = None
-        if not self.coverage_capture and self.coverage_report and self.coverage_per_instance:
+        if (not self.coverage_capture and self.coverage_report
+                and (self.coverage_per_instance or self.coverage_per_test)):
+            # Aggregate by merging the per-instance tracefiles. In per-test mode
+            # those already carry every per-test TN record, and no canonical
+            # .gcda exist at the top level to capture from (semihosting writes
+            # tagged files only).
             build_dirs = [instance.build_dir for instance in self.instances.values()]
         reports = {}
         with open(os.path.join(outdir, "coverage.log"), "a") as coveragelog:
@@ -272,7 +279,9 @@ class Lcov(CoverageTool):
 
         cmd_str = " ".join(cmd)
         logger.debug(f"Running {cmd_str}...")
-        return subprocess.call(cmd, stdout=coveragelog)
+        # Send lcov/genhtml diagnostics to the coverage log rather than the
+        # console, where they would otherwise flood a per-test run.
+        return subprocess.call(cmd, stdout=coveragelog, stderr=coveragelog)
 
     def run_lcov(self, args, coveragelog):
         if self.is_lcov_v2:
@@ -363,6 +372,9 @@ class Lcov(CoverageTool):
         cmd = ["genhtml", "--legend", "--branch-coverage",
                "--prefix", self.base_dir,
                "-output-directory", os.path.join(outdir, "coverage")]
+        # Note: per-test mode does not use --show-details; per-test attribution
+        # is provided by test_matrix.json/the dashboard, and --show-details over
+        # thousands of tests would dominate the run time.
         if self.coverage_per_instance:
             cmd.append("--show-details")
         cmd += files
@@ -372,6 +384,124 @@ class Lcov(CoverageTool):
 
         # TODO: Add LCOV summary coverage report.
         return ret, { 'report': coveragefile, 'ztest': ztestfile, 'summary': None }
+
+    def discover_per_test_serial(self, build_dir):
+        """Group tagged per-test gcov dumps from serial handler.log files.
+
+        Returns {tag: {canonical_gcda_path: ("bytes", data)}} for every
+        'GCOV_COVERAGE_DUMP_START <tag>' block, the console transport used on
+        platforms without semihosting.
+        """
+        tags = collections.defaultdict(dict)
+        for log in glob.glob(f"{build_dir}/**/handler.log", recursive=True):
+            for tag, files in retrieve_tagged_gcov_data(log).items():
+                for filename, hexdumps in files.items():
+                    if "kobject_hash" in filename:
+                        continue
+                    tags[tag][filename] = ("bytes", self.merge_hexdumps(hexdumps))
+        return tags
+
+    def capture_per_test(self, build_dir, scenario, coveragelog):
+        """Generate one TN-tagged .info file per Ztest test.
+
+        CONFIG_ZTEST_COVERAGE_PER_TEST makes the target write an isolated set
+        of tagged gcda dumps per test. With the semihosting transport these
+        land on the host as "<canonical>.gcda@@<suite>.<test>"; otherwise they
+        are emitted as tagged blocks on the serial console.
+
+        Each test is captured from its own temporary object tree, containing
+        only that test's gcda files plus symlinks to the shared gcno files.
+        Coverage is extracted by invoking gcov directly (one process per test,
+        far cheaper than a full lcov capture); if that fails, it falls back to
+        lcov over the same tree.
+
+        Returns the list of generated per-test tracefiles.
+        """
+        tags = discover_per_test_semihost(build_dir)
+        if not tags:
+            tags = self.discover_per_test_serial(build_dir)
+        if not tags:
+            return []
+
+        per_test_dir = os.path.join(build_dir, "coverage", "tests")
+        os.makedirs(per_test_dir, exist_ok=True)
+
+        infos = []
+        used_names = set()
+        for tag in sorted(tags):
+            _suite, _, test = tag.rpartition(".")
+            name = f"{scenario}.{test}" if test else f"{scenario}.{tag}"
+            # Fall back to the fully-qualified tag if two suites share a test
+            # name within the same scenario.
+            if name in used_names:
+                name = f"{scenario}.{tag}"
+            used_names.add(name)
+
+            info = os.path.join(per_test_dir, sanitize_coverage_name(name) + ".info")
+            with tempfile.TemporaryDirectory() as objdir:
+                gcda_paths = self._materialize_test_tree(objdir, build_dir, tags[tag])
+                if not self._gcov_capture(objdir, gcda_paths, name, info):
+                    cmd = ["--capture", "--directory", objdir, "--test-name",
+                           re.sub(r"[^A-Za-z0-9_]", "_", name),
+                           "--output-file", info]
+                    self.run_lcov(cmd, coveragelog)
+
+            if os.path.exists(info) and os.path.getsize(info) > 0:
+                infos.append(info)
+            else:
+                logger.error("Per-test coverage capture failed for %s", name)
+
+        return infos
+
+    @staticmethod
+    def _materialize_test_tree(objdir, build_dir, entries):
+        """Populate objdir with a test's gcda plus symlinks to shared gcno.
+
+        Returns the list of materialized gcda paths.
+        """
+        gcda_paths = []
+        for canonical, spec in entries.items():
+            rel = os.path.relpath(canonical, build_dir)
+            if rel.startswith(".."):
+                rel = canonical.lstrip(os.sep)
+            dst_gcda = os.path.join(objdir, rel)
+            materialize_canonical_gcda(dst_gcda, spec)
+            gcda_paths.append(dst_gcda)
+            gcno = canonical[:-len(".gcda")] + ".gcno"
+            if os.path.exists(gcno):
+                with contextlib.suppress(OSError):
+                    os.symlink(gcno, dst_gcda[:-len(".gcda")] + ".gcno")
+        return gcda_paths
+
+    def _gcov_capture(self, objdir, gcda_paths, name, info):
+        """Capture one test's coverage by invoking gcov directly.
+
+        Writes a TN-tagged tracefile to info. Returns True on success, False if
+        gcov is unavailable or produced no usable data (so the caller can fall
+        back to lcov).
+        """
+        if not gcda_paths:
+            return False
+        cmd = [self.gcov_tool, "--stdout", "--json-format",
+               "--branch-probabilities", *gcda_paths]
+        try:
+            proc = subprocess.run(cmd, cwd=objdir, stdout=subprocess.PIPE,
+                                  stderr=subprocess.DEVNULL, check=False)
+        except OSError:
+            return False
+        if proc.returncode != 0 or not proc.stdout:
+            return False
+        try:
+            tracefile = gcov_json_to_tracefile(
+                proc.stdout.decode("utf-8", "replace"), name)
+        except (ValueError, KeyError):
+            logger.exception("Failed to parse gcov output for %s", name)
+            return False
+        if "SF:" not in tracefile:
+            return False
+        with open(info, "w") as fp:
+            fp.write(tracefile)
+        return True
 
 
 class Gcovr(CoverageTool):
@@ -531,6 +661,340 @@ class Gcovr(CoverageTool):
 
         return ret, { 'report': coverage_file, 'ztest': ztest_file, 'summary': coverage_summary }
 
+def sanitize_coverage_name(name):
+    """Make a coverage test name safe to use as a filename component."""
+    return re.sub(r"[^A-Za-z0-9_.]", "_", name)
+
+
+def discover_per_test_semihost(build_dir):
+    """Group tagged per-test gcda dumps written by the semihosting transport.
+
+    Returns {tag: {canonical_gcda_path: ("file", tagged_path)}} for every
+    "<canonical>.gcda@@<tag>" file found under build_dir.
+    """
+    tags = collections.defaultdict(dict)
+    for tagged in glob.glob(f"{build_dir}/**/*@@*", recursive=True):
+        canonical, sep, tag = tagged.rpartition("@@")
+        if not sep or not canonical.endswith(".gcda") or not tag:
+            continue
+        tags[tag][canonical] = ("file", tagged)
+    return tags
+
+
+def retrieve_tagged_gcov_data(input_file):
+    """Parse tagged per-test gcov dumps from a serial handler.log.
+
+    Returns {tag: {filename: [hex_bytes, ...]}} for every
+    'GCOV_COVERAGE_DUMP_START <tag>' block. Untagged blocks (produced by a
+    plain end-of-run dump) are ignored, as they carry no per-test attribution.
+    """
+    tagged = collections.defaultdict(lambda: collections.defaultdict(list))
+    current = None
+    capture = False
+    start_re = re.compile(r"GCOV_COVERAGE_DUMP_START\s*(\S+)?")
+    with open(input_file) as fp:
+        for line in fp:
+            match = start_re.search(line)
+            if match:
+                current = match.group(1)
+                capture = current is not None
+                continue
+            if re.search("GCOV_COVERAGE_DUMP_END", line):
+                capture = False
+                current = None
+                continue
+            if not capture:
+                continue
+            if line.startswith("*"):
+                sp = line.split("<")
+                if len(sp) > 1:
+                    file_name = sp[0][1:]
+                    hex_dump = sp[1].rstrip("\n")
+                    try:
+                        tagged[current][file_name].append(bytes.fromhex(hex_dump))
+                    except ValueError:
+                        logger.exception(
+                            f"Unable to convert hex data for file: {file_name}")
+    return tagged
+
+
+def materialize_canonical_gcda(canonical, spec):
+    """Write a per-test gcda to its canonical path, from a file or raw bytes."""
+    kind, value = spec
+    os.makedirs(os.path.dirname(canonical), exist_ok=True)
+    if kind == "file":
+        shutil.copyfile(value, canonical)
+    else:
+        with open(canonical, "wb") as fp:
+            fp.write(value)
+
+
+def _iter_gcov_json(text):
+    """Yield each JSON object from a possibly concatenated gcov --stdout stream."""
+    decoder = json.JSONDecoder()
+    idx, length = 0, len(text)
+    while idx < length:
+        while idx < length and text[idx].isspace():
+            idx += 1
+        if idx >= length:
+            break
+        obj, idx = decoder.raw_decode(text, idx)
+        yield obj
+
+
+def gcov_json_to_tracefile(text, test_name):
+    """Convert gcov --json-format output into an lcov tracefile string.
+
+    Preserves line and branch coverage under a single per-test TN record, so
+    the result is equivalent to what "lcov --capture --test-name" would produce
+    for the same gcda, but without lcov's per-invocation cost.
+
+    The test name is reduced to lcov's accepted character set to avoid lcov's
+    "invalid characters" warning when the tracefiles are later merged. Function
+    records are intentionally omitted: gcov's per-function execution counts and
+    end lines are reported inconsistently across per-test dumps and would make
+    the tracefiles fail lcov's consistency checks when merged.
+    """
+    files = {}
+    for obj in _iter_gcov_json(text):
+        for entry in obj.get("files", []):
+            path = entry["file"]
+            rec = files.setdefault(path, {"lines": {}, "branches": {}})
+            for line in entry.get("lines", []):
+                num, count = line["line_number"], line.get("count", 0)
+                rec["lines"][num] = max(rec["lines"].get(num, 0), count)
+                branches = line.get("branches", [])
+                if branches:
+                    counts = rec["branches"].setdefault(num, [])
+                    for idx, br in enumerate(branches):
+                        val = br.get("count", 0)
+                        if idx < len(counts):
+                            counts[idx] += val
+                        else:
+                            counts.append(val)
+
+    out = [f"TN:{re.sub(r'[^A-Za-z0-9_]', '_', test_name)}"]
+    for path in sorted(files):
+        rec = files[path]
+        out.append(f"SF:{path}")
+        brf = brh = 0
+        for num in sorted(rec["branches"]):
+            for idx, count in enumerate(rec["branches"][num]):
+                out.append(f"BRDA:{num},0,{idx},{count}")
+                brf += 1
+                brh += count > 0
+        if brf:
+            out.append(f"BRF:{brf}")
+            out.append(f"BRH:{brh}")
+        lf = lh = 0
+        for num in sorted(rec["lines"]):
+            count = rec["lines"][num]
+            out.append(f"DA:{num},{count}")
+            lf += 1
+            lh += count > 0
+        out.append(f"LF:{lf}")
+        out.append(f"LH:{lh}")
+        out.append("end_of_record")
+    return "\n".join(out) + "\n"
+
+
+# Source paths matching these substrings are omitted from the per-test matrix,
+# mirroring the directories excluded from the regular coverage reports.
+_MATRIX_IGNORE_SUBSTRINGS = ("/generated/", "/tests/", "/samples/")
+
+
+
+def build_test_matrix(info_files, out_json, base_dir=None):
+    """Build a test-to-code coverage matrix from TN-tagged lcov tracefiles.
+
+    Produces a JSON document with two views:
+      - "by_line": {source: {line: [tests that covered it]}}
+      - "by_test": {test: {source: [lines it covered]}}
+    """
+    by_line = collections.defaultdict(lambda: collections.defaultdict(set))
+    by_test = collections.defaultdict(lambda: collections.defaultdict(set))
+    for info in info_files:
+        test_name = None
+        source = None
+        ignored = False
+        try:
+            with open(info) as fp:
+                for raw in fp:
+                    line = raw.strip()
+                    if line.startswith("TN:"):
+                        test_name = line[3:] or \
+                            os.path.splitext(os.path.basename(info))[0]
+                    elif line.startswith("SF:"):
+                        source = line[3:]
+                        ignored = any(s in source
+                                      for s in _MATRIX_IGNORE_SUBSTRINGS)
+                        if base_dir:
+                            with contextlib.suppress(ValueError):
+                                source = os.path.relpath(source, base_dir)
+                    elif line.startswith("DA:") and source is not None and not ignored:
+                        fields = line[3:].split(",")
+                        lineno = int(fields[0])
+                        hits = int(fields[1]) if len(fields) > 1 else 0
+                        if hits > 0 and test_name:
+                            by_line[source][lineno].add(test_name)
+                            by_test[test_name][source].add(lineno)
+                    elif line == "end_of_record":
+                        source = None
+                        ignored = False
+        except OSError:
+            logger.error("Unable to read per-test tracefile: %s", info)
+
+    matrix = {
+        "by_line": {
+            src: {str(ln): sorted(tests) for ln, tests in sorted(lines.items())}
+            for src, lines in sorted(by_line.items())
+        },
+        "by_test": {
+            test: {src: sorted(lns) for src, lns in sorted(srcs.items())}
+            for test, srcs in sorted(by_test.items())
+        },
+    }
+    with open(out_json, "w") as fp:
+        json.dump(matrix, fp, indent=2, sort_keys=True)
+    return matrix
+
+
+def merge_test_matrices(matrix_files, out_json):
+    """Union several per-instance coverage matrices into an aggregate one.
+
+    Merging the (already relative-pathed and filtered) per-instance
+    test_matrix.json files avoids re-parsing every per-test tracefile at the
+    end of a run, keeping the aggregate step proportional to the number of
+    instances rather than the number of tests.
+    """
+    by_line = collections.defaultdict(lambda: collections.defaultdict(set))
+    by_test = collections.defaultdict(lambda: collections.defaultdict(set))
+    for matrix_file in matrix_files:
+        try:
+            with open(matrix_file) as fp:
+                matrix = json.load(fp)
+        except (OSError, ValueError):
+            logger.error("Unable to read matrix: %s", matrix_file)
+            continue
+        for src, lines in matrix.get("by_line", {}).items():
+            for lineno, tests in lines.items():
+                by_line[src][int(lineno)].update(tests)
+        for test, srcs in matrix.get("by_test", {}).items():
+            for src, lns in srcs.items():
+                by_test[test][src].update(lns)
+
+    merged = {
+        "by_line": {
+            src: {str(ln): sorted(tests) for ln, tests in sorted(lines.items())}
+            for src, lines in sorted(by_line.items())
+        },
+        "by_test": {
+            test: {src: sorted(lns) for src, lns in sorted(srcs.items())}
+            for test, srcs in sorted(by_test.items())
+        },
+    }
+    with open(out_json, "w") as fp:
+        json.dump(merged, fp, indent=2, sort_keys=True)
+    return merged
+
+
+def write_union_tracefile(info_files, out_info):
+    """Merge per-test tracefiles into a single, untagged union tracefile.
+
+    Per-test attribution is carried by the coverage matrix, not by lcov, so the
+    per-instance report is collapsed to one TN. This keeps the end-of-run
+    aggregation (and genhtml) proportional to the number of instances rather
+    than the number of individual tests, which is what makes large per-test
+    runs tractable.
+    """
+    files = {}
+    for info in info_files:
+        source = None
+        rec = None
+        try:
+            with open(info) as fp:
+                for raw in fp:
+                    line = raw.rstrip("\n")
+                    if line.startswith("SF:"):
+                        source = line[3:]
+                        rec = files.setdefault(source, {"da": {}, "brda": {}})
+                    elif rec is None:
+                        continue
+                    elif line.startswith("DA:"):
+                        num, _, rest = line[3:].partition(",")
+                        count = int(rest.split(",")[0]) if rest else 0
+                        num = int(num)
+                        rec["da"][num] = rec["da"].get(num, 0) + count
+                    elif line.startswith("BRDA:"):
+                        ln, block, branch, taken = line[5:].split(",")
+                        key = (int(ln), block, branch)
+                        val = 0 if taken == "-" else int(taken)
+                        rec["brda"][key] = rec["brda"].get(key, 0) + val
+                    elif line == "end_of_record":
+                        source = None
+                        rec = None
+        except OSError:
+            logger.error("Unable to read tracefile: %s", info)
+
+    out = []
+    for source in sorted(files):
+        rec = files[source]
+        out.append("TN:")
+        out.append(f"SF:{source}")
+        brf = brh = 0
+        for (ln, block, branch) in sorted(rec["brda"]):
+            count = rec["brda"][(ln, block, branch)]
+            out.append(f"BRDA:{ln},{block},{branch},{count}")
+            brf += 1
+            brh += count > 0
+        if brf:
+            out.append(f"BRF:{brf}")
+            out.append(f"BRH:{brh}")
+        lf = lh = 0
+        for num in sorted(rec["da"]):
+            count = rec["da"][num]
+            out.append(f"DA:{num},{count}")
+            lf += 1
+            lh += count > 0
+        out.append(f"LF:{lf}")
+        out.append(f"LH:{lh}")
+        out.append("end_of_record")
+    with open(out_info, "w") as fp:
+        fp.write("\n".join(out) + "\n")
+    return out_info
+
+
+def run_per_test_coverage(options, instance):
+    """Capture per-test coverage for one instance and build its matrix."""
+    coverage_tool = CoverageTool.factory(options.coverage_tool, jobs=options.jobs)
+    if not isinstance(coverage_tool, Lcov):
+        logger.error("Per-test coverage requires the 'lcov' coverage tool.")
+        return
+
+    coverage_tool.gcov_tool = str(choose_gcov_tool(
+        options, has_system_gcov(instance.platform),
+        instances={instance.name: instance}))
+    coverage_tool.base_dir = os.path.abspath(options.coverage_basedir)
+
+    scenario = sanitize_coverage_name(instance.testsuite.name)
+    build_dir = instance.build_dir
+    with open(os.path.join(build_dir, "coverage.log"), "a") as coveragelog:
+        infos = coverage_tool.capture_per_test(build_dir, scenario, coveragelog)
+        if not infos:
+            logger.debug(f"No per-test coverage data for {instance.name}")
+            return
+
+    # Collapse the per-test tracefiles into a single untagged instance report.
+    # Per-test detail lives in the matrix, so the aggregation stays proportional
+    # to the number of instances rather than the number of tests.
+    write_union_tracefile(infos, os.path.join(build_dir, "coverage.info"))
+
+    build_test_matrix(
+        infos, os.path.join(build_dir, "coverage", "test_matrix.json"),
+        base_dir=coverage_tool.base_dir)
+    logger.debug(f"Per-test coverage: {len(infos)} tests for {instance.name}")
+
+
 def try_making_symlink(source: str, link: str):
     """
     Attempts to create a symbolic link from source to link.
@@ -666,6 +1130,7 @@ def run_coverage_tool(options, outdir, is_system_gcov, instances,
 
     coverage_tool.instances = instances
     coverage_tool.coverage_per_instance = options.coverage_per_instance
+    coverage_tool.coverage_per_test = getattr(options, "coverage_per_test", False)
     coverage_tool.coverage_capture = coverage_capture
     coverage_tool.coverage_report = coverage_report
     coverage_tool.base_dir = os.path.abspath(options.coverage_basedir)
@@ -698,17 +1163,40 @@ def run_coverage(options, testplan) -> tuple[bool, dict]:
             is_system_gcov = True
             break
 
-    return run_coverage_tool(options, options.outdir, is_system_gcov,
-                             instances=testplan.instances,
-                             coverage_capture=False,
-                             coverage_report=True)
+    result = run_coverage_tool(options, options.outdir, is_system_gcov,
+                               instances=testplan.instances,
+                               coverage_capture=False,
+                               coverage_report=True)
+
+    if getattr(options, "coverage_per_test", False):
+        matrix_files = [
+            os.path.join(instance.build_dir, "coverage", "test_matrix.json")
+            for instance in testplan.instances.values()
+        ]
+        matrix_files = [m for m in matrix_files if os.path.exists(m)]
+        if matrix_files:
+            matrix_dir = os.path.join(options.outdir, "coverage")
+            os.makedirs(matrix_dir, exist_ok=True)
+            json_path = os.path.join(matrix_dir, "test_matrix.json")
+            merge_test_matrices(matrix_files, json_path)
+            logger.info(f"Per-test coverage matrix generated: {json_path}")
+            logger.info("Render it with "
+                        "scripts/gen_test_matrix_dashboard.py -i "
+                        f"{json_path}")
+
+    return result
 
 
 def run_coverage_instance(options, instance):
     """ Per-instance code coverage called by ProjectBuilder ('coverage' operation).
     """
     is_system_gcov = has_system_gcov(instance.platform)
-    return run_coverage_tool(options, instance.build_dir, is_system_gcov,
-                             instances={instance.name: instance},
-                             coverage_capture=True,
-                             coverage_report=options.coverage_per_instance)
+    result = run_coverage_tool(options, instance.build_dir, is_system_gcov,
+                               instances={instance.name: instance},
+                               coverage_capture=True,
+                               coverage_report=options.coverage_per_instance)
+
+    if getattr(options, "coverage_per_test", False):
+        run_per_test_coverage(options, instance)
+
+    return result

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -517,6 +517,14 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
                         active (`--coverage-per-instance`) to have at least one of these reporting
                         modes. Default: %(default)s""")
 
+    coverage_group.add_argument("--coverage-per-test", action="store_true", default=False,
+                help="""Collect a separate coverage artifact for every individual Ztest
+                        test case, enabling a per-test to source-code coverage matrix.
+                        Requires the 'lcov' coverage tool. Implies --coverage. On platforms
+                        that support semihosting (e.g. mps2/*) the per-test data is written
+                        straight to the host filesystem, avoiding console traffic.
+                        Default: %(default)s""")
+
     parser.add_argument(
         "--test-config",
         action="store",
@@ -922,6 +930,12 @@ def parse_arguments(
 
     if options.aggressive_no_clean:
         options.no_clean = True
+
+    if options.coverage_per_test:
+        options.coverage = True
+        if options.coverage_tool != "lcov":
+            logger.error("--coverage-per-test requires the 'lcov' coverage tool.")
+            sys.exit(1)
 
     if options.coverage:
         options.enable_coverage = True

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -335,13 +335,28 @@ class TestInstance:
 
         return testsuite_runnable and target_ready
 
+    @staticmethod
+    def platform_supports_semihost(platform):
+        """Whether the platform can write coverage data over semihosting.
+
+        Semihosting is implemented for ARM, RISC-V and Xtensa targets and is
+        exercised through QEMU's automatic -semihosting-config switch, so limit
+        the per-test semihost transport to QEMU-simulated targets on those
+        architectures.
+        """
+        return (
+            platform.arch in ("arm", "arm64", "riscv", "riscv32", "riscv64", "xtensa")
+            and platform.simulation == "qemu"
+        )
+
     def create_overlay(
         self,
         platform,
         enable_asan=False,
         enable_ubsan=False,
         enable_coverage=False,
-        coverage_platform=None
+        coverage_platform=None,
+        coverage_per_test=False
     ):
         if coverage_platform is None:
             coverage_platform = []
@@ -392,6 +407,13 @@ class TestInstance:
             for cp in coverage_platform:
                 if cp in platform.aliases:
                     content = content + "\nCONFIG_COVERAGE=y"
+                    if coverage_per_test:
+                        content = content + "\nCONFIG_ZTEST_COVERAGE_PER_TEST=y"
+                        if self.platform_supports_semihost(platform):
+                            # Route the per-test dumps to the host filesystem via
+                            # semihosting instead of the serial console.
+                            content = content + "\nCONFIG_SEMIHOST=y"
+                            content = content + "\nCONFIG_COVERAGE_SEMIHOST=y"
 
         if platform.type == "native":
             if enable_asan:

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -816,7 +816,8 @@ class TestPlan:
                                             self.options.enable_asan,
                                             self.options.enable_ubsan,
                                             self.options.enable_coverage,
-                                            self.options.coverage_platform
+                                            self.options.coverage_platform,
+                                            self.options.coverage_per_test
                                             )
                     instance_list.append(instance)
                 self.add_instances(instance_list)
@@ -1305,7 +1306,8 @@ class TestPlan:
                                 self.options.enable_asan,
                                 self.options.enable_ubsan,
                                 self.options.enable_coverage,
-                                self.options.coverage_platform)
+                                self.options.coverage_platform,
+                                self.options.coverage_per_test)
 
         self.selected_platforms = set(p.platform.name for p in self.instances.values())
 

--- a/scripts/tests/twister/test_coverage.py
+++ b/scripts/tests/twister/test_coverage.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the per-test coverage helpers in twisterlib.coverage
+"""
+
+import json
+import os
+
+from twisterlib.coverage import (
+    build_test_matrix,
+    discover_per_test_semihost,
+    gcov_json_to_tracefile,
+    materialize_canonical_gcda,
+    merge_test_matrices,
+    retrieve_tagged_gcov_data,
+    sanitize_coverage_name,
+    write_union_tracefile,
+)
+
+TESTDATA_SANITIZE = [
+    ("framework_tests.test_empty", "framework_tests.test_empty"),
+    ("scenario/name-with.dots", "scenario_name-with.dots".replace("-", "_")),
+    ("a b\tc", "a_b_c"),
+]
+
+
+def test_sanitize_coverage_name():
+    assert sanitize_coverage_name("keep.dots_1") == "keep.dots_1"
+    # Every character outside [A-Za-z0-9_.] becomes an underscore.
+    assert sanitize_coverage_name("a/b-c d") == "a_b_c_d"
+
+
+def test_discover_per_test_semihost(tmp_path):
+    obj_dir = tmp_path / "CMakeFiles" / "app.dir"
+    obj_dir.mkdir(parents=True)
+    canonical = obj_dir / "main.c.gcda"
+    # Two tags for the same object, plus an unrelated / malformed file.
+    (obj_dir / "main.c.gcda@@suite.test_a").write_bytes(b"a")
+    (obj_dir / "main.c.gcda@@suite.test_b").write_bytes(b"b")
+    (obj_dir / "main.c.gcno").write_bytes(b"x")  # no @@, ignored
+    (obj_dir / "notgcda.txt@@suite.test_a").write_bytes(b"y")  # not .gcda, ignored
+
+    tags = discover_per_test_semihost(str(tmp_path))
+
+    assert set(tags) == {"suite.test_a", "suite.test_b"}
+    assert tags["suite.test_a"][str(canonical)] == (
+        "file",
+        str(obj_dir / "main.c.gcda@@suite.test_a"),
+    )
+    assert list(tags["suite.test_b"]) == [str(canonical)]
+
+
+def test_retrieve_tagged_gcov_data(tmp_path):
+    log = tmp_path / "handler.log"
+    log.write_text(
+        "boot noise\n"
+        "GCOV_COVERAGE_DUMP_START suite.test_a\n"
+        "*/work/foo.gcda<0a0b\n"
+        "GCOV_COVERAGE_DUMP_END\n"
+        # An untagged block must be ignored (no per-test attribution).
+        "GCOV_COVERAGE_DUMP_START\n"
+        "*/work/foo.gcda<ffff\n"
+        "GCOV_COVERAGE_DUMP_END\n"
+        "GCOV_COVERAGE_DUMP_START suite.test_b\n"
+        "*/work/foo.gcda<0c0d\n"
+        "*/work/bar.gcda<0e0f\n"
+        "GCOV_COVERAGE_DUMP_END\n"
+    )
+
+    tags = retrieve_tagged_gcov_data(str(log))
+
+    assert set(tags) == {"suite.test_a", "suite.test_b"}
+    assert tags["suite.test_a"]["/work/foo.gcda"] == [bytes.fromhex("0a0b")]
+    assert tags["suite.test_b"]["/work/bar.gcda"] == [bytes.fromhex("0e0f")]
+
+
+def test_materialize_canonical_gcda(tmp_path):
+    # From raw bytes.
+    dst = tmp_path / "sub" / "out.gcda"
+    materialize_canonical_gcda(str(dst), ("bytes", b"\x01\x02"))
+    assert dst.read_bytes() == b"\x01\x02"
+
+    # From an existing file.
+    src = tmp_path / "src.gcda"
+    src.write_bytes(b"\x03\x04")
+    dst2 = tmp_path / "copy.gcda"
+    materialize_canonical_gcda(str(dst2), ("file", str(src)))
+    assert dst2.read_bytes() == b"\x03\x04"
+
+
+def _write_info(path, tn, records):
+    lines = [f"TN:{tn}"]
+    for sf, das in records.items():
+        lines.append(f"SF:{sf}")
+        lines += [f"DA:{ln},{hits}" for ln, hits in das]
+        lines.append("end_of_record")
+    path.write_text("\n".join(lines) + "\n")
+
+
+def test_build_test_matrix(tmp_path):
+    base = tmp_path / "work"
+    base.mkdir()
+    info_a = tmp_path / "a.info"
+    info_b = tmp_path / "b.info"
+    # test_a hits foo.c:10; foo.c:11 is present but uncovered (0 hits).
+    # bar.c lives under tests/ and must be filtered out of the matrix.
+    _write_info(
+        info_a,
+        "scn.test_a",
+        {
+            str(base / "foo.c"): [(10, 1), (11, 0)],
+            str(base / "tests" / "bar.c"): [(5, 1)],
+        },
+    )
+    _write_info(
+        info_b,
+        "scn.test_b",
+        {
+            str(base / "foo.c"): [(10, 1), (12, 1)],
+        },
+    )
+
+    out = tmp_path / "matrix.json"
+    returned = build_test_matrix([str(info_a), str(info_b)], str(out), base_dir=str(base))
+    matrix = json.loads(out.read_text())
+    # The builder both writes the JSON and returns the matrix for reuse.
+    assert returned == matrix
+
+    by_line = matrix["by_line"]
+    assert set(by_line) == {"foo.c"}  # tests/bar.c filtered out
+    assert by_line["foo.c"]["10"] == ["scn.test_a", "scn.test_b"]
+    assert by_line["foo.c"]["12"] == ["scn.test_b"]
+    assert "11" not in by_line["foo.c"]  # uncovered line excluded
+
+    by_test = matrix["by_test"]
+    assert by_test["scn.test_a"] == {"foo.c": [10]}
+    assert by_test["scn.test_b"] == {"foo.c": [10, 12]}
+    # bar.c under tests/ is absent from every view.
+    assert all("bar.c" not in os.path.basename(k) for k in by_line)
+
+
+def test_write_union_tracefile(tmp_path):
+    # Two per-test tracefiles over the same file; the union sums counts, keeps
+    # a single empty TN, and carries no function records.
+    a = tmp_path / "a.info"
+    a.write_text("TN:t_a\nSF:/w/foo.c\nDA:10,1\nDA:11,0\nBRDA:10,0,0,1\nend_of_record\n")
+    b = tmp_path / "b.info"
+    b.write_text("TN:t_b\nSF:/w/foo.c\nDA:10,2\nDA:12,4\nBRDA:10,0,0,3\nend_of_record\n")
+    out = tmp_path / "union.info"
+    write_union_tracefile([str(a), str(b)], str(out))
+    lines = out.read_text().splitlines()
+
+    assert lines[0] == "TN:"  # single, empty test name
+    assert not any(line.startswith("FN") for line in lines)
+    assert "DA:10,3" in lines  # 1 + 2
+    assert "DA:12,4" in lines
+    assert "DA:11,0" in lines
+    assert "BRDA:10,0,0,4" in lines  # 1 + 3
+    assert "LF:3" in lines and "LH:2" in lines  # 10 and 12 hit, 11 not
+
+
+def test_merge_test_matrices(tmp_path):
+    m1 = tmp_path / "m1.json"
+    m1.write_text(
+        json.dumps(
+            {
+                "by_line": {"foo.c": {"10": ["scnA.t1"]}},
+                "by_test": {"scnA.t1": {"foo.c": [10]}},
+            }
+        )
+    )
+    m2 = tmp_path / "m2.json"
+    m2.write_text(
+        json.dumps(
+            {
+                "by_line": {"foo.c": {"10": ["scnB.t1"], "20": ["scnB.t2"]}},
+                "by_test": {"scnB.t1": {"foo.c": [10]}, "scnB.t2": {"foo.c": [20]}},
+            }
+        )
+    )
+    out = tmp_path / "merged.json"
+    merged = merge_test_matrices([str(m1), str(m2)], str(out))
+
+    # Line 10 covered by tests from both instances; union is sorted+deduped.
+    assert merged["by_line"]["foo.c"]["10"] == ["scnA.t1", "scnB.t1"]
+    assert merged["by_line"]["foo.c"]["20"] == ["scnB.t2"]
+    assert set(merged["by_test"]) == {"scnA.t1", "scnB.t1", "scnB.t2"}
+    assert json.loads(out.read_text()) == merged
+
+
+def test_gcov_json_to_tracefile():
+    # Two concatenated gcov --stdout objects, and a line (11) reported twice
+    # with different counts (its max must win) and with branch data.
+    text = (
+        json.dumps(
+            {
+                "current_working_directory": "/w",
+                "files": [
+                    {
+                        "file": "/w/foo.c",
+                        "lines": [
+                            {"line_number": 10, "count": 3, "branches": []},
+                            {
+                                "line_number": 11,
+                                "count": 0,
+                                "branches": [{"count": 0}, {"count": 2}],
+                            },
+                            {"line_number": 11, "count": 5, "branches": []},
+                        ],
+                    }
+                ],
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "files": [
+                    {
+                        "file": "/w/bar.c",
+                        "lines": [{"line_number": 1, "count": 0, "branches": []}],
+                    }
+                ],
+            }
+        )
+    )
+
+    tf = gcov_json_to_tracefile(text, "scn.test_a")
+    lines = tf.splitlines()
+
+    # Test name is reduced to lcov's accepted character set (no dots).
+    assert lines[0] == "TN:scn_test_a"
+    assert "SF:/w/foo.c" in lines
+    assert "SF:/w/bar.c" in lines
+    # function records are intentionally not emitted
+    assert not any(line.startswith("FN") for line in lines)
+    # line 11 reported twice -> highest count wins
+    assert "DA:11,5" in lines
+    assert "DA:10,3" in lines
+    # branch records from the first line-11 entry
+    assert "BRDA:11,0,0,0" in lines
+    assert "BRDA:11,0,1,2" in lines
+    # foo.c: 2 lines found, both hit
+    foo = tf.split("SF:/w/foo.c", 1)[1]
+    assert "LF:2" in foo and "LH:2" in foo
+    # bar.c: 1 line found, none hit
+    bar = tf.split("SF:/w/bar.c", 1)[1]
+    assert "LF:1" in bar and "LH:0" in bar

--- a/scripts/tests/twister/test_matrix_dashboard.py
+++ b/scripts/tests/twister/test_matrix_dashboard.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the standalone scripts/gen_test_matrix_dashboard.py
+"""
+
+import importlib.util
+import json
+import pathlib
+import re
+import sys
+from unittest import mock
+
+_SCRIPT = pathlib.Path(__file__).parents[3] / "scripts" / "gen_test_matrix_dashboard.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("gen_test_matrix_dashboard", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_render_dashboard_embeds_matrix():
+    mod = _load()
+    matrix = {
+        "by_line": {"foo.c": {"10": ["scn.test_a", "scn.test_b"]}},
+        "by_test": {"scn.test_a": {"foo.c": [10]}, "scn.test_b": {"foo.c": [10]}},
+    }
+    html = mod.render_dashboard(matrix)
+
+    # Placeholder fully substituted and the matrix round-trips through JSON.
+    assert "__MATRIX_DATA__" not in html
+    embedded = re.search(r'application/json">(.*?)</script>', html, re.S).group(1)
+    assert json.loads(embedded.replace("<\\/", "</")) == matrix
+    # Structural anchors the dashboard's JS relies on.
+    for token in ('id="testTable"', 'id="fileView"', "Per-test coverage matrix"):
+        assert token in html
+
+
+def test_main_writes_html(tmp_path):
+    mod = _load()
+    matrix = {"by_line": {}, "by_test": {}}
+    inp = tmp_path / "test_matrix.json"
+    inp.write_text(json.dumps(matrix))
+    out = tmp_path / "dashboard.html"
+
+    with mock.patch.object(sys, "argv", ["prog", "-i", str(inp), "-o", str(out)]):
+        mod.main()
+
+    assert out.exists()
+    assert "Per-test coverage matrix" in out.read_text()
+
+
+def test_main_default_output(tmp_path):
+    mod = _load()
+    inp = tmp_path / "test_matrix.json"
+    inp.write_text(json.dumps({"by_line": {}, "by_test": {}}))
+
+    with mock.patch.object(sys, "argv", ["prog", "-i", str(inp)]):
+        mod.main()
+
+    # Output defaults to the input path with a .html suffix.
+    assert (tmp_path / "test_matrix.html").exists()

--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -269,6 +269,27 @@ void gcov_reset_counts(struct gcov_info *info)
 	}
 }
 
+/*
+ * Returns true if any execution counter of this object is non-zero, i.e. the
+ * object contributed coverage since the last reset. Used to skip all-zero
+ * objects from per-test dumps, which speeds up both the on-target dump and the
+ * host-side processing without changing the resulting coverage.
+ */
+static bool gcov_info_has_data(struct gcov_info *info)
+{
+	for (uint32_t fn = 0U; fn < info->n_functions; fn++) {
+		struct gcov_ctr_info *ctrs = info->functions[fn]->ctrs;
+
+		for (uint32_t vi = 0U; vi < ctrs->num; vi++) {
+			if (ctrs->values[vi] != 0) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 void gcov_reset_all_counts(void)
 {
 	struct gcov_info *gcov_list = NULL;
@@ -311,8 +332,12 @@ void dump_on_console_data(char *ptr, size_t len)
 
 /**
  * Retrieves gcov coverage data and sends it over the given interface.
+ *
+ * When @p tag is not NULL it is appended to the dump start marker so that
+ * consumers can attribute the block to a specific producer (for example a
+ * single test). A NULL tag reproduces the historical, untagged output.
  */
-void gcov_coverage_dump(void)
+void gcov_coverage_dump_tagged(const char *tag)
 {
 	uint8_t *buffer;
 	size_t size;
@@ -326,7 +351,15 @@ void gcov_coverage_dump(void)
 	}
 #endif
 	printk("\nGCOV_COVERAGE_DUMP_START");
+	if (tag != NULL) {
+		printk(" %s", tag);
+	}
 	while (gcov_list) {
+		/* For per-test (tagged) dumps skip objects with no coverage. */
+		if ((tag != NULL) && !gcov_info_has_data(gcov_list)) {
+			goto file_dump_end;
+		}
+
 		if ((strlen(CONFIG_COVERAGE_DUMP_PATH_EXCLUDE) > 0) &&
 		    (fnmatch(CONFIG_COVERAGE_DUMP_PATH_EXCLUDE, gcov_list->filename, 0) == 0)) {
 			/* Don't print a note here, it would be interpreted as dump data */
@@ -369,11 +402,23 @@ coverage_dump_end:
 	return;
 }
 
+void gcov_coverage_dump(void)
+{
+	gcov_coverage_dump_tagged(NULL);
+}
+
 #elif CONFIG_COVERAGE_SEMIHOST
 /**
- * Retrieves gcov coverage data and sends it over the given interface.
+ * Retrieves gcov coverage data and writes it to the host filesystem via
+ * semihosting.
+ *
+ * When @p tag is not NULL each .gcda is written to "<filename>@@<tag>" instead
+ * of its canonical path, so that several isolated dumps (for example one per
+ * test) can coexist next to the matching .gcno without overwriting each other.
+ * A NULL tag reproduces the historical behaviour of writing to the canonical
+ * .gcda path.
  */
-void gcov_coverage_semihost(void)
+void gcov_coverage_dump_tagged(const char *tag)
 {
 	uint8_t *buffer;
 	size_t size;
@@ -398,8 +443,16 @@ void gcov_coverage_semihost(void)
 	}
 #endif
 	while (gcov_list) {
+		const char *path;
+		char *tagged_path = NULL;
+
 		if ((strlen(CONFIG_COVERAGE_DUMP_PATH_EXCLUDE) > 0) &&
 		    (fnmatch(CONFIG_COVERAGE_DUMP_PATH_EXCLUDE, gcov_list->filename, 0) == 0)) {
+			goto file_dump_end;
+		}
+
+		/* For per-test (tagged) dumps skip objects with no coverage. */
+		if ((tag != NULL) && !gcov_info_has_data(gcov_list)) {
 			goto file_dump_end;
 		}
 
@@ -411,9 +464,24 @@ void gcov_coverage_semihost(void)
 		filename = gcov_list->filename;
 #endif /* defined(CONFIG_REBOOT) */
 
-		fd = semihost_open(filename, SEMIHOST_OPEN_WB);
+		path = filename;
+
+		if (tag != NULL) {
+			size_t path_size = strlen(filename) + strlen(tag) + sizeof("@@");
+
+			tagged_path = k_heap_alloc(&gcov_heap, path_size, K_NO_WAIT);
+			if (tagged_path == NULL) {
+				printk("No memory available for tagged path\n");
+				goto coverage_dump_end;
+			}
+			snprintk(tagged_path, path_size, "%s@@%s", filename, tag);
+			path = tagged_path;
+		}
+
+		fd = semihost_open(path, SEMIHOST_OPEN_WB);
 		if (fd < 0) {
-			printk("Failed to open file: %s\n", filename);
+			printk("Failed to open file: %s\n", path);
+			k_heap_free(&gcov_heap, tagged_path);
 			goto coverage_dump_end;
 		}
 
@@ -424,6 +492,7 @@ void gcov_coverage_semihost(void)
 			printk("No memory available to continue dump\n");
 			semihost_close(fd);
 			k_heap_free(&gcov_heap, buffer);
+			k_heap_free(&gcov_heap, tagged_path);
 			goto coverage_dump_end;
 		}
 
@@ -432,20 +501,23 @@ void gcov_coverage_semihost(void)
 			printk("Write Error on buffer\n");
 			semihost_close(fd);
 			k_heap_free(&gcov_heap, buffer);
+			k_heap_free(&gcov_heap, tagged_path);
 			goto coverage_dump_end;
 		}
 
 		int ret = semihost_write(fd, (const void *)buffer, size);
 
 		if (ret < 0) {
-			printk("Failed to write data to file: %s\n", gcov_list->filename);
+			printk("Failed to write data to file: %s\n", path);
 			semihost_close(fd);
 			k_heap_free(&gcov_heap, buffer);
+			k_heap_free(&gcov_heap, tagged_path);
 			goto coverage_dump_end;
 		}
 
-		k_heap_free(&gcov_heap, buffer);
 		semihost_close(fd);
+		k_heap_free(&gcov_heap, buffer);
+		k_heap_free(&gcov_heap, tagged_path);
 file_dump_end:
 		gcov_list = gcov_list->next;
 		if (gcov_list_first == gcov_list) {
@@ -458,6 +530,11 @@ coverage_dump_end:
 		k_sched_unlock();
 	}
 #endif
+}
+
+void gcov_coverage_semihost(void)
+{
+	gcov_coverage_dump_tagged(NULL);
 }
 #endif
 

--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -144,6 +144,26 @@ config ZTEST_COVERAGE_RESET_BEFORE_TESTS
 	  and all the board initialization code and pre-test bootstrap is not counted.
 	  This is useful when, for example, you are testing code that is also executed during bootup.
 
+config ZTEST_COVERAGE_PER_TEST
+	bool "Dump code coverage data per individual test"
+	depends on COVERAGE_GCOV
+	help
+	  Reset the gcov counters before each test and dump a separate,
+	  test-tagged coverage artifact after each test. This enables building a
+	  per-test to source-code coverage matrix. The dump uses whichever
+	  coverage transport is configured (console or semihosting); with
+	  semihosting each artifact is written to "<gcda-path>@@<suite>.<test>"
+	  on the host so the per-test dumps do not overwrite each other.
+
+config ZTEST_COVERAGE_PER_TEST_TAG_SIZE
+	int "Maximum length of a per-test coverage tag"
+	depends on ZTEST_COVERAGE_PER_TEST
+	default 128
+	help
+	  Size of the stack buffer used to compose the "<suite>.<test>" tag
+	  passed to the coverage dump. Test and suite name combinations longer
+	  than this (including the terminating NUL) are truncated.
+
 config ZTEST_SHUFFLE
 	bool "Shuffle the order of tests and suites"
 	select TEST_RANDOM_GENERATOR if !ENTROPY_HAS_DRIVER

--- a/subsys/testsuite/ztest/src/ztest_rules.c
+++ b/subsys/testsuite/ztest/src/ztest_rules.c
@@ -6,6 +6,28 @@
 
 #include <zephyr/ztest.h>
 
+#ifdef CONFIG_ZTEST_COVERAGE_PER_TEST
+#include <coverage.h>
+#include <zephyr/debug/gcov.h>
+
+static void coverage_per_test_before_each(const struct ztest_unit_test *test, void *data)
+{
+	ARG_UNUSED(test);
+	ARG_UNUSED(data);
+	gcov_reset_all_counts();
+}
+static void coverage_per_test_after_each(const struct ztest_unit_test *test, void *data)
+{
+	char tag[CONFIG_ZTEST_COVERAGE_PER_TEST_TAG_SIZE];
+
+	ARG_UNUSED(data);
+
+	snprintk(tag, sizeof(tag), "%s.%s", test->test_suite_name, test->name);
+	gcov_coverage_dump_tagged(tag);
+}
+ZTEST_RULE(coverage_per_test, coverage_per_test_before_each, coverage_per_test_after_each);
+#endif /* CONFIG_ZTEST_COVERAGE_PER_TEST */
+
 #ifdef CONFIG_ZTEST_RULE_1CPU
 static void one_cpu_rule_before_each(const struct ztest_unit_test *test, void *data)
 {


### PR DESCRIPTION
Add the ability to attribute code coverage to individual Ztest
test cases — answering "which tests cover line X of file foo.c" — and ships
the on-target support, the Twister driver, a test↔code matrix, and a
visualization tool. It also folds in several robustness fixes to the coverage
gcov-tool plumbing that the new mode depends on.

Today coverage is aggregated across a whole run, so you can see what is
covered but not by which test. That makes it hard to spot redundant tests
(which add runtime but no unique coverage) or the load-bearing test behind a
given line. This series closes that gap end to end.