### PR TITLE
ci: coding guidelines: convert to run on schedule

### DIFF
--- a/.github/workflows/coding_guidelines_full.yml
+++ b/.github/workflows/coding_guidelines_full.yml
@@ -1,10 +1,8 @@
 name: Coding Guidelines Scanning
 on:
-  push:
-    branches:
-      - main
-      - v*-branch
-      - collab-*
+  schedule:
+    - cron: '50 20 * * *'
+
 permissions:
   contents: read
 concurrency:


### PR DESCRIPTION
Run on schedule for now..

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
