### PR TITLE
net: if: skip init if device is not ready

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -446,7 +446,15 @@ void net_if_stats_reset_all(void)
 
 static inline void init_iface(struct net_if *iface)
 {
-	const struct net_if_api *api = net_if_get_device(iface)->api;
+	const struct device *dev = net_if_get_device(iface);
+	const struct net_if_api *api;
+
+	if (!device_is_ready(dev)) {
+		NET_ERR("Iface %p device not ready", iface);
+		return;
+	}
+
+	api = dev->api;
 
 	if (!api || !api->init) {
 		NET_ERR("Iface %p driver API init NULL", iface);

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -395,6 +395,17 @@ static void *iface_setup(void)
 	dev->state->init_res = 0;
 	device_ok = true;
 
+	/* The interface init was skipped because device was not ready during
+	 * system initialization. Now that the device is ready, we need to
+	 * manually initialize the interface to set the link address and
+	 * enable IPv4/IPv6 support (which are normally set in init_iface()).
+	 */
+	net_if_flag_set(iface1, NET_IF_IPV4);
+	net_if_flag_set(iface1, NET_IF_IPV6);
+	k_mutex_init(&iface1->lock);
+	k_mutex_init(&iface1->tx_lock);
+	net_iface_init(iface1);
+
 	/* We need to sleep a bit to let the interface
 	 * operational state change time to be set.
 	 */


### PR DESCRIPTION
If a network device is not ready, e.g. the device failed to init, do not call init on its iface as this might cause a crash.