### PR TITLE
tests/samples: audio: dmic: align on alias-based device

### DIFF
--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense.dts
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense.dts
@@ -13,6 +13,10 @@
 	model = "Arduino Nano 33 BLE Sense";
 	compatible = "arduino,arduino_nano_33_ble_sense";
 
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+
 	mic_pwr: mic_pwr {
 		compatible = "regulator-fixed";
 		regulator-name = "mic_pwr";

--- a/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuapp.dts
+++ b/boards/seeed/xiao_nrf54l15/xiao_nrf54l15_nrf54l15_cpuapp.dts
@@ -53,6 +53,7 @@
 	};
 
 	aliases {
+		dmic0 = &dmic_dev;
 		imu0 = &lsm6ds3tr_c;
 	};
 };

--- a/boards/shields/arduino_giga_display_shield/arduino_giga_display_shield.overlay
+++ b/boards/shields/arduino_giga_display_shield/arduino_giga_display_shield.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 &zephyr_mipi_dsi {
 	st7701: st7701@0 {
 		status = "okay";

--- a/boards/st/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/st/stm32l476g_disco/stm32l476g_disco.dts
@@ -18,6 +18,7 @@
 	compatible = "st,stm32l476g-disco";
 
 	aliases {
+		dmic0 = &dmic_dev;
 		i2s-codec-tx = &sai1_a;
 	};
 

--- a/samples/drivers/audio/dmic/boards/apollo510_evb.overlay
+++ b/samples/drivers/audio/dmic/boards/apollo510_evb.overlay
@@ -1,3 +1,9 @@
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 dmic_dev: &pdm0 {
 	pdm-buffer-location = "SRAM_NO_CACHE";
 	pdm-buffer-size = <640>;

--- a/samples/drivers/audio/dmic/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/audio/dmic/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 &pinctrl {
 	pdm20_default_alt: pdm20_default_alt {
 		group1 {

--- a/samples/drivers/audio/dmic/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/audio/dmic/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 &pinctrl {
 	pdm20_default_alt: pdm20_default_alt {
 		group1 {

--- a/samples/drivers/audio/dmic/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/samples/drivers/audio/dmic/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -4,6 +4,12 @@
  * Copyright 2025 NXP
  */
 
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 dmic_dev: &micfil {
 	status = "okay";
 

--- a/samples/drivers/audio/dmic/boards/frdm_mcxn947_mcxn947_cpu1.overlay
+++ b/samples/drivers/audio/dmic/boards/frdm_mcxn947_mcxn947_cpu1.overlay
@@ -4,6 +4,12 @@
  * Copyright 2025 NXP
  */
 
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 dmic_dev: &micfil {
 	status = "okay";
 

--- a/samples/drivers/audio/dmic/boards/kit_pse84_common.overlay
+++ b/samples/drivers/audio/dmic/boards/kit_pse84_common.overlay
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 dmic_dev: &dmic0 {
 	pinctrl-0 = <&p8_5_pdm3_pdm_clk &p8_6_pdm3_pdm_data>;
 	pinctrl-names = "default";

--- a/samples/drivers/audio/dmic/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
+++ b/samples/drivers/audio/dmic/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
@@ -4,6 +4,12 @@
  * Copyright 2025 NXP
  */
 
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 dmic_dev: &micfil {
 	status = "okay";
 

--- a/samples/drivers/audio/dmic/boards/mcx_n9xx_evk_mcxn947_cpu1.overlay
+++ b/samples/drivers/audio/dmic/boards/mcx_n9xx_evk_mcxn947_cpu1.overlay
@@ -4,6 +4,12 @@
  * Copyright 2025 NXP
  */
 
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 dmic_dev: &micfil {
 	status = "okay";
 

--- a/samples/drivers/audio/dmic/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
+++ b/samples/drivers/audio/dmic/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
@@ -1,3 +1,9 @@
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 dmic_dev: &dmic0 {
 	status = "okay";
 };

--- a/samples/drivers/audio/dmic/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/audio/dmic/boards/nrf52840dk_nrf52840.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 &pinctrl {
 	pdm0_default_alt: pdm0_default_alt {
 		group1 {

--- a/samples/drivers/audio/dmic/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/drivers/audio/dmic/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 &clock {
 	hfclkaudio-frequency = <12288000>;
 };

--- a/samples/drivers/audio/dmic/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/audio/dmic/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 &pinctrl {
 	pdm20_default_alt: pdm20_default_alt {
 		group1 {

--- a/samples/drivers/audio/dmic/boards/ophelia4ev_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/audio/dmic/boards/ophelia4ev_nrf54l15_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 &pinctrl {
 	pdm20_default_alt: pdm20_default_alt {
 		group1 {

--- a/samples/drivers/audio/dmic/boards/rd_rw612_bga.overlay
+++ b/samples/drivers/audio/dmic/boards/rd_rw612_bga.overlay
@@ -1,3 +1,9 @@
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 dmic_dev: &dmic0 {
 	status = "okay";
 };

--- a/samples/drivers/audio/dmic/boards/stm32f769i_disco.overlay
+++ b/samples/drivers/audio/dmic/boards/stm32f769i_disco.overlay
@@ -3,4 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
+
 dmic_dev: &pdm0 {};

--- a/samples/drivers/audio/dmic/boards/xiao_ble_nrf52840_sense.overlay
+++ b/samples/drivers/audio/dmic/boards/xiao_ble_nrf52840_sense.overlay
@@ -2,6 +2,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 / {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+
 	msm261d3526hicpm-c-en {
 		regulator-boot-on;
 	};

--- a/samples/drivers/audio/dmic/src/main.c
+++ b/samples/drivers/audio/dmic/src/main.c
@@ -83,7 +83,7 @@ static int do_pdm_transfer(const struct device *dmic_dev,
 
 int main(void)
 {
-	const struct device *const dmic_dev = DEVICE_DT_GET(DT_NODELABEL(dmic_dev));
+	const struct device *const dmic_dev = DEVICE_DT_GET(DT_ALIAS(dmic0));
 	int ret;
 
 	LOG_INF("DMIC sample");

--- a/samples/drivers/i2s/i2s_codec/boards/frdm_mcxn236.overlay
+++ b/samples/drivers/i2s/i2s_codec/boards/frdm_mcxn236.overlay
@@ -10,6 +10,7 @@
 
 / {
 	aliases {
+		dmic0 = &dmic_dev;
 		i2s-codec-tx = &sai1;
 		i2s-tx = &sai1;
 	};

--- a/samples/drivers/i2s/i2s_codec/boards/mcx_n5xx_evk_mcxn547_cpu0.overlay
+++ b/samples/drivers/i2s/i2s_codec/boards/mcx_n5xx_evk_mcxn547_cpu0.overlay
@@ -6,6 +6,7 @@
 
 / {
 	aliases {
+		dmic0 = &dmic_dev;
 		i2s-codec-tx = &sai1;
 		i2s-tx = &sai1;
 	};

--- a/samples/drivers/i2s/i2s_codec/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/samples/drivers/i2s/i2s_codec/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -3,6 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};
 
 &sai1 {
 	mclk-output;

--- a/samples/drivers/i2s/i2s_codec/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
+++ b/samples/drivers/i2s/i2s_codec/boards/mimxrt595_evk_mimxrt595s_cm33.overlay
@@ -6,6 +6,7 @@
 
 / {
 	aliases {
+		dmic0 = &dmic_dev;
 		i2s-codec-rx = &i2s0;
 		i2s-codec-tx = &i2s1;
 	};

--- a/samples/drivers/i2s/i2s_codec/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
+++ b/samples/drivers/i2s/i2s_codec/boards/mimxrt685_evk_mimxrt685s_cm33.overlay
@@ -1,5 +1,6 @@
 / {
 	aliases {
+		dmic0 = &dmic_dev;
 		i2s-codec-rx = &i2s0;
 		i2s-codec-tx = &i2s1;
 	};

--- a/samples/drivers/i2s/i2s_codec/boards/rd_rw612_bga.overlay
+++ b/samples/drivers/i2s/i2s_codec/boards/rd_rw612_bga.overlay
@@ -6,6 +6,7 @@
 
 / {
 	aliases {
+		dmic0 = &dmic_dev;
 		i2s-codec-tx = &flexcomm1;
 	};
 };

--- a/samples/drivers/i2s/i2s_codec/src/main.c
+++ b/samples/drivers/i2s/i2s_codec/src/main.c
@@ -66,7 +66,7 @@ int main(void)
 {
 	const struct device *const i2s_dev_codec = DEVICE_DT_GET(I2S_CODEC_TX);
 #if CONFIG_USE_DMIC
-	const struct device *const dmic_dev = DEVICE_DT_GET(DT_NODELABEL(dmic_dev));
+	const struct device *const dmic_dev = DEVICE_DT_GET(DT_ALIAS(dmic0));
 #endif
 	const struct device *const codec_dev = DEVICE_DT_GET(DT_NODELABEL(audio_codec));
 	struct i2s_config config;


### PR DESCRIPTION
DMIC tests use 'dmic-dev' alias while samples using DMIC look for 'dmic_dev' label.

Align this inconsistency by looking for both in tests and samples. Logic would be: if there is an alias use it. If not, take the label.

This PR is a follow up of #112410.