### PR TITLE
drivers: hdlc_rcp_if: spi: add CONFIG_HDLC_RCP_IF_SPI_DEFERRED_INIT

### DIFF
--- a/drivers/hdlc_rcp_if/Kconfig.spi
+++ b/drivers/hdlc_rcp_if/Kconfig.spi
@@ -31,4 +31,17 @@ config HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE
 	  Specify the smallest packet we can receive in a single transaction.
 	  Larger packets will require multiple transactions.
 
+config HDLC_RCP_IF_SPI_DEFERRED_INIT
+	bool "Defer SPI RCP interface start until explicitly requested"
+	depends on HDLC_RCP_IF_SPI
+	help
+	  When enabled, prevents net_if_post_init() from automatically
+	  bringing up the OpenThread interface at boot, and defers SPI
+	  interrupt arming until hdlc_api.deferred_init() is called.
+	  This is required when the RCP firmware is loaded asynchronously
+	  (e.g. IW61X firmware uploaded via BT UART H4 before SPI is active).
+	  hdlc_api.deferred_init() can be called once the firmware is ready.
+	  the SPI IRQ is armed and the network interface is brought up.
+	  When disabled, SPI IRQ is armed during init and the interface
+	  is brought up automatically.
 endif

--- a/drivers/hdlc_rcp_if/hdlc_rcp_if_spi.c
+++ b/drivers/hdlc_rcp_if/hdlc_rcp_if_spi.c
@@ -62,6 +62,7 @@ struct hdlc_rcp_if_spi_data {
 
 	bool tx_ready;
 	bool frame_sent;
+	uint16_t tx_refused_count;
 };
 
 BUILD_ASSERT(CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE <=
@@ -167,6 +168,7 @@ static void hdlc_rcp_if_push_pull_spi(struct k_work *work)
 	uint16_t peer_max_rx;
 	uint16_t fcs;
 	int ret;
+	uint16_t accept_len;
 
 	data->tx_buf[0] = SPI_HEADER_PATTERN_VALUE;
 	if (!data->frame_sent) {
@@ -180,8 +182,9 @@ static void hdlc_rcp_if_push_pull_spi(struct k_work *work)
 		rx_frame.len += data->rx_len;
 		sys_put_le16(data->rx_len, &data->tx_buf[1]);
 	} else {
-		rx_frame.len += CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE;
-		sys_put_le16(CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE, &data->tx_buf[1]);
+		accept_len = MAX(CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE, data->tx_len);
+		rx_frame.len += accept_len;
+		sys_put_le16(accept_len, &data->tx_buf[1]);
 	}
 
 	LOG_HEXDUMP_DBG(data->tx_buf, SPI_HEADER_LEN, "TX Header");
@@ -214,8 +217,18 @@ static void hdlc_rcp_if_push_pull_spi(struct k_work *work)
 	data->rx_len = sys_get_le16(&rx_buf[3]);
 
 	if (data->tx_len > peer_max_rx) {
-		LOG_WRN("Peer not ready to receive our frame (%u > %u)", data->tx_len, peer_max_rx);
+		data->tx_refused_count++;
+		if (data->tx_refused_count == 1) {
+			LOG_WRN("Peer not ready to receive our frame (%u > %u), need to retry",
+				data->tx_len, peer_max_rx);
+		}
+		/* Keep tx_ready to retry the packet on next SPI transaction. */
+		data->tx_ready = true;
+		return;
 	}
+
+	/* TX accepted by peer — reset refused count */
+	data->tx_refused_count = 0;
 
 	LOG_HEXDUMP_DBG(rx_buf, SPI_HEADER_LEN, "RX Header");
 

--- a/drivers/hdlc_rcp_if/hdlc_rcp_if_spi.c
+++ b/drivers/hdlc_rcp_if/hdlc_rcp_if_spi.c
@@ -227,7 +227,7 @@ static void hdlc_rcp_if_push_pull_spi(struct k_work *work)
 		return;
 	}
 
-	/* TX accepted by peer — reset refused count */
+	/* TX accepted by peer, reset refused count */
 	data->tx_refused_count = 0;
 
 	LOG_HEXDUMP_DBG(rx_buf, SPI_HEADER_LEN, "RX Header");
@@ -303,14 +303,31 @@ static void hdlc_rcp_if_spi_isr(const struct device *port, struct gpio_callback 
 
 static void hdlc_iface_init(struct net_if *iface)
 {
-	otExtAddress eui64;
-
 	__ASSERT_NO_MSG(DEVICE_DT_INST_GET(0) == net_if_get_device(iface));
+
+#ifdef CONFIG_HDLC_RCP_IF_SPI_DEFERRED_INIT
+	/* DO NOT call ieee802154_init() here:
+	 * It leads to send Spinel commands to the RCP which is not yet booted.
+	 * RCP firmware is loaded later
+	 */
+
+	/* Set a temporary link address, updated after firmware loads */
+	static uint8_t temp_eui64[8] = {
+		0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+	};
+	net_if_set_link_addr(iface, temp_eui64, 8, NET_LINK_IEEE802154);
+
+	/* Prevent net_if_post_init() from auto-starting the interface */
+	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	LOG_INF("NO_AUTO_START set, waiting for RCP firmware");
+#else
+	otExtAddress eui64;
 
 	ieee802154_init(iface);
 
 	otPlatRadioGetIeeeEui64(openthread_get_default_instance(), eui64.m8);
 	net_if_set_link_addr(iface, eui64.m8, OT_EXT_ADDRESS_SIZE, NET_LINK_IEEE802154);
+#endif /* CONFIG_HDLC_RCP_IF_SPI_DEFERRED_INIT */
 }
 
 static int hdlc_register_rx_cb(hdlc_rx_callback_t hdlc_rx_callback, void *param)
@@ -437,11 +454,13 @@ static int hdlc_rcp_if_spi_init(const struct device *dev)
 		return ret;
 	}
 
+#ifndef CONFIG_HDLC_RCP_IF_SPI_DEFERRED_INIT
 	ret = gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret < 0) {
 		LOG_ERR("Failed to configure interrupt GPIO (%d)", ret);
 		return ret;
 	}
+#endif /* CONFIG_HDLC_RCP_IF_SPI_DEFERRED_INIT */
 
 	gpio_init_callback(&data->int_gpio_cb, hdlc_rcp_if_spi_isr, BIT(cfg->int_gpio.pin));
 
@@ -454,16 +473,46 @@ static int hdlc_rcp_if_spi_init(const struct device *dev)
 	ret = hdlc_rcp_if_spi_reset(dev);
 	if (ret < 0) {
 		LOG_ERR("Failed to reset HDLC SPI device (%d)", ret);
+		return ret;
 	}
 
 	return 0;
 }
+
+#ifdef CONFIG_HDLC_RCP_IF_SPI_DEFERRED_INIT
+static int hdlc_deferred_init(void)
+{
+	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct hdlc_rcp_if_spi_config *cfg = dev->config;
+	struct net_if *iface = net_if_get_first_by_type(&NET_L2_GET_NAME(OPENTHREAD));
+	int ret;
+
+	LOG_INF("Arm SPI INT GPIO");
+
+	ret = gpio_pin_interrupt_configure_dt(&cfg->int_gpio,
+					      GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure interrupt GPIO: %d", ret);
+		return ret;
+	}
+
+	/* Initialize IEEE 802.15.4 */
+	if (iface != NULL) {
+		ieee802154_init(iface);
+	}
+
+	return 0;
+}
+#endif /* CONFIG_HDLC_RCP_IF_SPI_DEFERRED_INIT */
 
 static const struct hdlc_api spi_hdlc_api = {
 	.iface_api.init = hdlc_iface_init,
 	.register_rx_cb = hdlc_register_rx_cb,
 	.send = hdlc_send,
 	.deinit = hdlc_deinit,
+#ifdef CONFIG_HDLC_RCP_IF_SPI_DEFERRED_INIT
+	.deferred_init = hdlc_deferred_init
+#endif
 };
 
 #define L2_CTX_TYPE NET_L2_GET_CTX_TYPE(OPENTHREAD_L2)

--- a/include/zephyr/net/hdlc_rcp_if/hdlc_rcp_if.h
+++ b/include/zephyr/net/hdlc_rcp_if/hdlc_rcp_if.h
@@ -68,6 +68,17 @@ struct hdlc_api {
 	 * @retval -EIO The interface could not be stopped.
 	 */
 	int (*deinit)(void);
+
+	/**
+	 * @brief Optional: complete the RCP interface initialization in deferred init mode.
+	 * If NULL, the interface is started automatically at init.
+	 *
+	 * @param none
+	 *
+	 * @retval 0 The interface was successfully started.
+	 * @retval -EIO The interface could not be started.
+	 */
+	int (*deferred_init)(void);
 };
 
 /* Make sure that the interface API is properly setup inside


### PR DESCRIPTION
Some RCP modules (e.g. IW61X) require an asynchronous firmware load
sequence before the 15.4 SPI interface becomes operational.
The firmware is uploaded via a separate transport (e.g. BT UART H4),

Without this option, Zephyr's net_if_post_init() automatically brings up
the OpenThread interface at boot, before the RCP is ready, causing Spinel
command failures and NULL dereferences.

Add CONFIG_HDLC_RCP_IF_SPI_DEFERRED_INIT (default n, preserves existing
behavior) which:
- hdlc_iface_init(): skip ieee802154_init(), set NET_IF_NO_AUTO_START
  to block net_if_post_init() from starting the interface
  before the RCP is ready.
- hdlc_rcp_if_spi_init(): skip SPI IRQ arming and RCP reset,
- hdlc_deferred_init(): arms the SPI IRQ and clears NET_IF_NO_AUTO_START.

Depends-On: #112476