### PR TITLE
drivers: pwm/soc: espressif: fix ledc update stall and c5 clock tree

### DIFF
--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -88,23 +88,31 @@ static struct pwm_ledc_esp32_channel_config *get_channel_config(const struct dev
 static void pwm_led_esp32_start(struct pwm_ledc_esp32_data *data,
 				struct pwm_ledc_esp32_channel_config *channel)
 {
+	unsigned int key = irq_lock();
+
 	ledc_hal_set_sig_out_en(&data->hal, channel->speed_mode, channel->channel_num, true);
 	ledc_hal_set_duty_start(&data->hal, channel->speed_mode, channel->channel_num);
 
 	if (channel->speed_mode == LEDC_LOW_SPEED_MODE) {
 		ledc_hal_ls_channel_update(&data->hal, channel->speed_mode, channel->channel_num);
 	}
+
+	irq_unlock(key);
 }
 
 static void pwm_led_esp32_stop(struct pwm_ledc_esp32_data *data,
 			       struct pwm_ledc_esp32_channel_config *channel, bool idle_level)
 {
+	unsigned int key = irq_lock();
+
 	ledc_hal_set_idle_level(&data->hal, channel->speed_mode, channel->channel_num, idle_level);
 	ledc_hal_set_sig_out_en(&data->hal, channel->speed_mode, channel->channel_num, false);
 
 	if (channel->speed_mode == LEDC_LOW_SPEED_MODE) {
 		ledc_hal_ls_channel_update(&data->hal, channel->speed_mode, channel->channel_num);
 	}
+
+	irq_unlock(key);
 }
 
 static void pwm_led_esp32_duty_set(const struct device *dev,

--- a/soc/espressif/esp32c5/hw_init.c
+++ b/soc/espressif/esp32c5/hw_init.c
@@ -21,6 +21,7 @@
 #include <bootloader_flash.h>
 #include <esp_flash_internal.h>
 #include <esp_log.h>
+#include <esp_private/esp_clk_tree_common.h>
 
 #include <console_init.h>
 #include <flash_init.h>
@@ -69,6 +70,7 @@ int hardware_init(void)
 	esp_cpu_configure_invalid_regions();
 
 	bootloader_clock_configure();
+	esp_clk_tree_initialize();
 
 #ifdef CONFIG_ESP_CONSOLE
 	esp_console_init();


### PR DESCRIPTION
Lock interrupts around the LEDC start/stop sequences so the low-speed
channel update stays atomic, and initialize the ESP32-C5 clock tree at
boot so peripheral source clocks are actually brought up.