### PR TITLE
drivers: debug: nrf_etr: Add alignment for shell output buffer

### DIFF
--- a/drivers/debug/debug_nrf_etr.c
+++ b/drivers/debug/debug_nrf_etr.c
@@ -1130,7 +1130,7 @@ static struct shell_transport transport = {
 	.ctx = NULL,
 };
 
-static uint8_t shell_out_buffer[CONFIG_SHELL_PRINTF_BUFF_SIZE];
+static uint8_t shell_out_buffer[CONFIG_SHELL_PRINTF_BUFF_SIZE] __aligned(sizeof(uint32_t));
 Z_SHELL_DEFINE(etr_shell, CONFIG_DEBUG_NRF_ETR_SHELL_PROMPT, &transport, shell_out_buffer, NULL,
 	       SHELL_FLAG_OLF_CRLF);
 #endif /* CONFIG_DEBUG_NRF_ETR_SHELL */


### PR DESCRIPTION
This adds word alignment for the shell_out_buffer that may be used in the log_output_func function that can use fast copying for word alignment memory. The fast copying will be allow also for most of shell operations