### PR TITLE
soc: st: stm32: add stm32mp133fx config

### DIFF
--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -222,6 +222,7 @@ family:
     - name: stm32mp157cxx
   - name: stm32mp13x
     socs:
+    - name: stm32mp133fxx
     - name: stm32mp135fxx
   - name: stm32mp2x
     socs:

--- a/soc/st/stm32/stm32mp13x/Kconfig.defconfig.stm32mp13_a7
+++ b/soc/st/stm32/stm32mp13x/Kconfig.defconfig.stm32mp13_a7
@@ -3,9 +3,9 @@
 # Copyright (c) 2025 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_STM32MP135FXX
+if SOC_SERIES_STM32MP13X
 
-config NUM_IRQS
+configdefault NUM_IRQS
 	default 181
 
-endif # SOC_STM32MP135FXX
+endif # SOC_SERIES_STM32MP13X

--- a/soc/st/stm32/stm32mp13x/Kconfig.soc
+++ b/soc/st/stm32/stm32mp13x/Kconfig.soc
@@ -10,9 +10,14 @@ config SOC_SERIES_STM32MP13X
 config SOC_SERIES
 	default "stm32mp13x" if SOC_SERIES_STM32MP13X
 
+config SOC_STM32MP133FXX
+	bool
+	select SOC_SERIES_STM32MP13X
+
 config SOC_STM32MP135FXX
 	bool
 	select SOC_SERIES_STM32MP13X
 
 config SOC
+	default "stm32mp133fxx" if SOC_STM32MP133FXX
 	default "stm32mp135fxx" if SOC_STM32MP135FXX


### PR DESCRIPTION
Following commit 4b57150 where stm32mp133.dtsi has been introduced. For compliance purpose, complete SoC configuration consequently.