### PR TITLE
Fixed bug where if link was already up eth_stm32hal would fail with microchip_lan8742

### DIFF
--- a/drivers/ethernet/phy/phy_microchip_lan8742.c
+++ b/drivers/ethernet/phy/phy_microchip_lan8742.c
@@ -409,7 +409,10 @@ static int phy_lan8742_init(const struct device *dev)
 
 	/* Advertise default speeds */
 	ret = phy_lan8742_cfg_link(dev, cfg->default_speeds, 0);
-	if (ret < 0) {
+	if (ret == -EALREADY) {
+		data->autoneg_in_progress = true;
+		data->autoneg_timeout = sys_timepoint_calc(K_MSEC(CONFIG_PHY_AUTONEG_TIMEOUT_MS));
+	} else if (ret < 0) {
 		LOG_ERR("Failed to configure link (%d)", ret);
 		return ret;
 	}


### PR DESCRIPTION
Fixed bug where if link was already up stm32hal would fail

```
[00:00:00.075,000] <inf> microchip_lan8742: PHY (0) ID 0x7C131
[00:00:00.075,000] <err> microchip_lan8742: Failed to configure link (-120)
[00:00:00.082,000] <err> eth_stm32_hal: PHY device not ready
```

Fixes #110260

Used https://github.com/zephyrproject-rtos/zephyr/commit/94c57ba192f61f4159009dc3487ba864f9cf5a9d as example