### PR TITLE
boards: stm32wba: rewrite OTP Read for nucleo boards aligned with DK board

### DIFF
--- a/boards/st/nucleo_wba55cg/CMakeLists.txt
+++ b/boards/st/nucleo_wba55cg/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-zephyr_library_sources(board.c)
+if(CONFIG_BOARD_LATE_INIT_HOOK)
+  zephyr_library()
+  zephyr_library_sources(board.c)
+endif()

--- a/boards/st/nucleo_wba55cg/board.c
+++ b/boards/st/nucleo_wba55cg/board.c
@@ -1,52 +1,45 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2025-2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/init.h>
+#include <zephyr/toolchain.h>
 #include <stm32_ll_rcc.h>
 #include <stddef.h>
-#include <errno.h>
 
-typedef __PACKED_STRUCT
-{
-	uint8_t additional_data[8];	/*!< 64 bits of data to fill OTP slot Ex: MB184510 */
-	uint8_t bd_address[6];		/*!< Bluetooth Device Address*/
-	uint8_t hsetune;		/*!< Load capacitance to be applied on HSE pad */
-	uint8_t index;			/*!< Structure index */
-} OTP_Data_s;
+struct __packed stm32_board_otp_data {
+	uint8_t additional_data[8];	/* 64 bits of data to fill OTP slot Ex: MB184510 */
+	uint8_t bd_address[6];		/* Bluetooth Device Address */
+	uint8_t hsetune;		/* Load capacitance to be applied on HSE pad */
+	uint8_t index;			/* Structure index */
+};
 
 #define DEFAULT_OTP_IDX     0
 
-static HAL_StatusTypeDef OTP_Read(uint8_t index, OTP_Data_s **otp_ptr);
+static struct stm32_board_otp_data *get_otp_ptr(uint8_t index)
+{
+	struct stm32_board_otp_data *otp_ptr =
+		(struct stm32_board_otp_data *)(FLASH_OTP_BASE + FLASH_OTP_SIZE);
 
+	while (--otp_ptr >= (struct stm32_board_otp_data *)FLASH_OTP_BASE) {
+		if (otp_ptr->index == index) {
+			return otp_ptr;
+		}
+	}
+
+	return NULL;
+}
 
 void board_late_init_hook(void)
 {
-	HAL_StatusTypeDef status;
-	OTP_Data_s *otp_ptr = NULL;
+	struct stm32_board_otp_data *otp_ptr = get_otp_ptr(DEFAULT_OTP_IDX);
 
-	status = OTP_Read(DEFAULT_OTP_IDX, &otp_ptr);
-	if (status != HAL_OK) {
+	if (otp_ptr != NULL) {
+		LL_RCC_HSE_SetClockTrimming(otp_ptr->hsetune);
+	} else {
 		/* OTP no present in flash, apply default gain */
 		LL_RCC_HSE_SetClockTrimming(0x0C);
-	} else {
-		LL_RCC_HSE_SetClockTrimming(otp_ptr->hsetune);
 	}
-}
-
-static HAL_StatusTypeDef OTP_Read(uint8_t index, OTP_Data_s **otp_ptr)
-{
-	*otp_ptr = (OTP_Data_s *) (FLASH_OTP_BASE + FLASH_OTP_SIZE - 16);
-
-	while (((*otp_ptr)->index != index) && ((*otp_ptr) != (OTP_Data_s *) FLASH_OTP_BASE)) {
-		(*otp_ptr) -= 1;
-	}
-
-	if ((*otp_ptr)->index != index) {
-		return HAL_ERROR;
-	}
-
-	return HAL_OK;
 }

--- a/boards/st/nucleo_wba55cg/doc/nucleo_wba55cg.rst
+++ b/boards/st/nucleo_wba55cg/doc/nucleo_wba55cg.rst
@@ -149,8 +149,8 @@ Supported Features
 Bluetooth® and IEEE 802.15.4 support
 ------------------------------------
 
-Bluetooth® Low Energy and IEEE 802.15.4 support are enabled on nucleo_wba55cg. To build a zephyr sample
-using this board, you first need to install Bluetooth® and/or IEEE 802.15.4 Controller libraries available
+Bluetooth® Low Energy and IEEE 802.15.4 support are enabled on nucleo_wba55cg. To build a Zephyr sample
+using this board you first need to install Bluetooth® and/or IEEE 802.15.4 Controller libraries available
 in Zephyr as binary blobs.
 
 To fetch Binary Blobs:

--- a/boards/st/nucleo_wba65ri/board.c
+++ b/boards/st/nucleo_wba65ri/board.c
@@ -1,52 +1,45 @@
 /*
- * Copyright (c) 2025 STMicroelectronics
+ * Copyright (c) 2025-2026 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/init.h>
+#include <zephyr/toolchain.h>
 #include <stm32_ll_rcc.h>
 #include <stddef.h>
-#include <errno.h>
 
-typedef __PACKED_STRUCT
-{
-	uint8_t additional_data[8];	/*!< 64 bits of data to fill OTP slot Ex: MB184510 */
-	uint8_t bd_address[6];		/*!< Bluetooth Device Address*/
-	uint8_t hsetune;		/*!< Load capacitance to be applied on HSE pad */
-	uint8_t index;			/*!< Structure index */
-} OTP_Data_s;
+struct __packed stm32_board_otp_data {
+	uint8_t additional_data[8];	/* 64 bits of data to fill OTP slot Ex: MB184510 */
+	uint8_t bd_address[6];		/* Bluetooth Device Address */
+	uint8_t hsetune;		/* Load capacitance to be applied on HSE pad */
+	uint8_t index;			/* Structure index */
+};
 
 #define DEFAULT_OTP_IDX     0
 
-static HAL_StatusTypeDef OTP_Read(uint8_t index, OTP_Data_s **otp_ptr);
+static struct stm32_board_otp_data *get_otp_ptr(uint8_t index)
+{
+	struct stm32_board_otp_data *otp_ptr =
+		(struct stm32_board_otp_data *)(FLASH_OTP_BASE + FLASH_OTP_SIZE);
 
+	while (--otp_ptr >= (struct stm32_board_otp_data *)FLASH_OTP_BASE) {
+		if (otp_ptr->index == index) {
+			return otp_ptr;
+		}
+	}
+
+	return NULL;
+}
 
 void board_late_init_hook(void)
 {
-	HAL_StatusTypeDef status;
-	OTP_Data_s *otp_ptr = NULL;
+	struct stm32_board_otp_data *otp_ptr = get_otp_ptr(DEFAULT_OTP_IDX);
 
-	status = OTP_Read(DEFAULT_OTP_IDX, &otp_ptr);
-	if (status != HAL_OK) {
+	if (otp_ptr != NULL) {
+		LL_RCC_HSE_SetClockTrimming(otp_ptr->hsetune);
+	} else {
 		/* OTP no present in flash, apply default gain */
 		LL_RCC_HSE_SetClockTrimming(0x0C);
-	} else {
-		LL_RCC_HSE_SetClockTrimming(otp_ptr->hsetune);
 	}
-}
-
-static HAL_StatusTypeDef OTP_Read(uint8_t index, OTP_Data_s **otp_ptr)
-{
-	*otp_ptr = (OTP_Data_s *) (FLASH_OTP_BASE + FLASH_OTP_SIZE - 16);
-
-	while (((*otp_ptr)->index != index) && ((*otp_ptr) != (OTP_Data_s *) FLASH_OTP_BASE)) {
-		(*otp_ptr) -= 1;
-	}
-
-	if ((*otp_ptr)->index != index) {
-		return HAL_ERROR;
-	}
-
-	return HAL_OK;
 }

--- a/boards/st/nucleo_wba65ri/doc/index.rst
+++ b/boards/st/nucleo_wba65ri/doc/index.rst
@@ -153,9 +153,9 @@ Supported Features
 Bluetooth® and IEEE 802.15.4 support
 ------------------------------------
 
-Bluetooth® Low Energy and IEEE 802.15.4 support are enabled on nucleo_wba65ri. To build a zephyr sample using this board
-you first need to install Bluetooth® and/or IEEE 802.15.4 Controller libraries available in Zephyr as
-binary blobs.
+Bluetooth® Low Energy and IEEE 802.15.4 support are enabled on nucleo_wba65ri. To build a Zephyr sample
+using this board you first need to install Bluetooth® and/or IEEE 802.15.4 Controller libraries available
+in Zephyr as binary blobs.
 
 To fetch Binary Blobs:
 

--- a/boards/st/stm32wba65i_dk1/board.c
+++ b/boards/st/stm32wba65i_dk1/board.c
@@ -9,20 +9,21 @@
 #include <stm32_ll_rcc.h>
 #include <stddef.h>
 
-typedef struct __packed {
+struct __packed stm32_board_otp_data {
 	uint8_t additional_data[8];	/* 64 bits of data to fill OTP slot Ex: MB184510 */
 	uint8_t bd_address[6];		/* Bluetooth Device Address */
 	uint8_t hsetune;		/* Load capacitance to be applied on HSE pad */
 	uint8_t index;			/* Structure index */
-} board_otp_data;
+};
 
 #define DEFAULT_OTP_IDX     0
 
-static board_otp_data *get_otp_ptr(uint8_t index)
+static struct stm32_board_otp_data *get_otp_ptr(uint8_t index)
 {
-	board_otp_data *otp_ptr = (board_otp_data *)(FLASH_OTP_BASE + FLASH_OTP_SIZE);
+	struct stm32_board_otp_data *otp_ptr =
+		(struct stm32_board_otp_data *)(FLASH_OTP_BASE + FLASH_OTP_SIZE);
 
-	while (--otp_ptr >= (board_otp_data *)FLASH_OTP_BASE) {
+	while (--otp_ptr >= (struct stm32_board_otp_data *)FLASH_OTP_BASE) {
 		if (otp_ptr->index == index) {
 			return otp_ptr;
 		}
@@ -33,7 +34,7 @@ static board_otp_data *get_otp_ptr(uint8_t index)
 
 void board_late_init_hook(void)
 {
-	board_otp_data *otp_ptr = get_otp_ptr(DEFAULT_OTP_IDX);
+	struct stm32_board_otp_data *otp_ptr = get_otp_ptr(DEFAULT_OTP_IDX);
 
 	if (otp_ptr != NULL) {
 		LL_RCC_HSE_SetClockTrimming(otp_ptr->hsetune);


### PR DESCRIPTION
Align the OTP read implementation for the NUCLEO-WBA55CG and NUCLEO-WBA65RI boards with the implementation for the STM32WBAW65I-DK board.

FYI: @asm5878 , @etienne-lms 