### PR TITLE
arch: cmake: add directories only when arch is used

### DIFF
--- a/arch/arc/CMakeLists.txt
+++ b/arch/arc/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT COMPILER STREQUAL arcmwdt)
   endif()
 endif()
 
-add_subdirectory(core)
+add_subdirectory_ifdef(CONFIG_ARC core)
 
 if(COMPILER STREQUAL arcmwdt)
   add_subdirectory(arcmwdt)

--- a/arch/arm/CMakeLists.txt
+++ b/arch/arm/CMakeLists.txt
@@ -6,4 +6,4 @@ else()
   set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-littlearm)
 endif()
 
-add_subdirectory(core)
+add_subdirectory_ifdef(CONFIG_ARM core)

--- a/arch/arm64/CMakeLists.txt
+++ b/arch/arm64/CMakeLists.txt
@@ -2,4 +2,4 @@
 
 set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf64-littleaarch64)
 
-add_subdirectory(core)
+add_subdirectory_ifdef(CONFIG_ARM64 core)

--- a/arch/mips/CMakeLists.txt
+++ b/arch/mips/CMakeLists.txt
@@ -12,5 +12,5 @@ else()
   set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT "elf32-littlemips")
 endif()
 
-add_subdirectory(core)
+add_subdirectory_ifdef(CONFIG_MIPS core)
 zephyr_include_directories(include)

--- a/arch/openrisc/CMakeLists.txt
+++ b/arch/openrisc/CMakeLists.txt
@@ -6,5 +6,5 @@
 
 set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT "elf32-or1k")
 
-add_subdirectory(core)
+add_subdirectory_ifdef(CONFIG_OPENRISC core)
 zephyr_include_directories(include)

--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -170,4 +170,4 @@ if(NOT ${LLVM_SANITIZERS_ARG} STREQUAL "")
 endif()
 
 include(natsim_optional.cmake)
-add_subdirectory(core)
+add_subdirectory_ifdef(CONFIG_ARCH_POSIX core)

--- a/arch/riscv/CMakeLists.txt
+++ b/arch/riscv/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(core)
-add_subdirectory(custom)
+add_subdirectory_ifdef(CONFIG_RISCV core)
+add_subdirectory_ifdef(CONFIG_RISCV custom)
 
 zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/arch/riscv/error.h)
 

--- a/arch/rx/CMakeLists.txt
+++ b/arch/rx/CMakeLists.txt
@@ -2,5 +2,5 @@
 # Copyright (c) 2024 Renesas Electronics Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(core)
+add_subdirectory_ifdef(CONFIG_RX core)
 set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-rx-le) # needed for e.g. objcopy

--- a/arch/sparc/CMakeLists.txt
+++ b/arch/sparc/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT "elf32-sparc")
-add_subdirectory(core)
+add_subdirectory_ifdef(CONFIG_SPARC core)

--- a/arch/x86/ia32.cmake
+++ b/arch/x86/ia32.cmake
@@ -117,7 +117,7 @@ add_custom_command(
   )
 
 # Must be last so that soc/ can override default exception handlers
-add_subdirectory(core)
+add_subdirectory_ifdef(CONFIG_X86 core)
 
 get_property(OUTPUT_ARCH   GLOBAL PROPERTY PROPERTY_OUTPUT_ARCH)
 get_property(OUTPUT_FORMAT GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT)

--- a/arch/x86/intel64.cmake
+++ b/arch/x86/intel64.cmake
@@ -45,4 +45,4 @@ if(CONFIG_X86_SSE)
 
 endif()
 
-add_subdirectory(core)
+add_subdirectory_ifdef(CONFIG_X86_64 core)

--- a/arch/xtensa/CMakeLists.txt
+++ b/arch/xtensa/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/arch/xtensa/arch.h)
 set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT elf32-xtensa-le)
-add_subdirectory(core)
+add_subdirectory_ifdef(CONFIG_XTENSA core)
 
 if(CONFIG_XTENSA_INSECURE_USERSPACE)
   message(WARNING "


### PR DESCRIPTION
Only include Arch directories in CMake scripts when the build target is using that Arch.