### PR TITLE
net: sockets: Fix incorrect connection drop in zsock_accept()

### DIFF
--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -67,14 +67,8 @@ enum net_context_state {
 /** Remote address set */
 #define NET_CONTEXT_REMOTE_ADDR_SET  BIT(8)
 
-/** Is the socket accepting connections */
-#define NET_CONTEXT_ACCEPTING_SOCK  BIT(9)
-
-/** Is the socket closing / closed */
-#define NET_CONTEXT_CLOSING_SOCK  BIT(10)
-
 /** Context is bound to a specific interface */
-#define NET_CONTEXT_BOUND_TO_IFACE BIT(11)
+#define NET_CONTEXT_BOUND_TO_IFACE BIT(9)
 
 struct net_context;
 
@@ -481,70 +475,6 @@ static inline bool net_context_is_bound_to_iface(struct net_context *context)
 	NET_ASSERT(context);
 
 	return context->flags & NET_CONTEXT_BOUND_TO_IFACE;
-}
-
-/**
- * @brief Is this context is accepting data now.
- *
- * @param context Network context.
- *
- * @return True if the context is accepting connections, False otherwise.
- */
-static inline bool net_context_is_accepting(struct net_context *context)
-{
-	NET_ASSERT(context);
-
-	return context->flags & NET_CONTEXT_ACCEPTING_SOCK;
-}
-
-/**
- * @brief Set this context to accept data now.
- *
- * @param context Network context.
- * @param accepting True if accepting, False if not
- */
-static inline void net_context_set_accepting(struct net_context *context,
-					     bool accepting)
-{
-	NET_ASSERT(context);
-
-	if (accepting) {
-		context->flags |= NET_CONTEXT_ACCEPTING_SOCK;
-	} else {
-		context->flags &= (uint16_t)~NET_CONTEXT_ACCEPTING_SOCK;
-	}
-}
-
-/**
- * @brief Is this context closing.
- *
- * @param context Network context.
- *
- * @return True if the context is closing, False otherwise.
- */
-static inline bool net_context_is_closing(struct net_context *context)
-{
-	NET_ASSERT(context);
-
-	return context->flags & NET_CONTEXT_CLOSING_SOCK;
-}
-
-/**
- * @brief Set this context to closing.
- *
- * @param context Network context.
- * @param closing True if closing, False if not
- */
-static inline void net_context_set_closing(struct net_context *context,
-					   bool closing)
-{
-	NET_ASSERT(context);
-
-	if (closing) {
-		context->flags |= NET_CONTEXT_CLOSING_SOCK;
-	} else {
-		context->flags &= (uint16_t)~NET_CONTEXT_CLOSING_SOCK;
-	}
 }
 
 /** @cond INTERNAL_HIDDEN */

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -509,7 +509,6 @@ int zsock_accept_ctx(struct net_context *parent, struct net_sockaddr *addr,
 		     net_socklen_t *addrlen)
 {
 	struct net_context *ctx;
-	struct net_pkt *last_pkt;
 	int fd, ret;
 
 	if (net_context_get_type(parent) == NET_SOCK_RAW) {
@@ -549,29 +548,6 @@ int zsock_accept_ctx(struct net_context *parent, struct net_sockaddr *addr,
 		net_context_put(ctx);
 		return -1;
 	}
-
-	/* Check if the connection is already disconnected */
-	last_pkt = k_fifo_peek_tail(&ctx->recv_q);
-	if (last_pkt) {
-		if (net_pkt_eof(last_pkt)) {
-			sock_set_eof(ctx);
-			zvfs_free_fd(fd);
-			zsock_flush_queue(ctx);
-			net_context_put(ctx);
-			errno = ECONNABORTED;
-			return -1;
-		}
-	}
-
-	if (net_context_is_closing(ctx)) {
-		errno = ECONNABORTED;
-		zvfs_free_fd(fd);
-		zsock_flush_queue(ctx);
-		net_context_put(ctx);
-		return -1;
-	}
-
-	net_context_set_accepting(ctx, false);
 
 	ret = sock_get_stream_src_addr(ctx, addr, addrlen);
 	if (ret < 0) {

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -680,6 +680,74 @@ ZTEST(net_socket_tcp, test_z_so_linger_timeout)
 	test_context_cleanup();
 }
 
+static void test_accept_after_client_close_common(int af)
+{
+	int c_sock;
+	int s_sock;
+	int new_sock;
+	struct net_sockaddr_in6 c_saddr;
+	struct net_sockaddr_in6 s_saddr;
+	struct net_sockaddr_in6 addr;
+	net_socklen_t addrlen;
+	char rx_buf[sizeof(TEST_STR_SMALL)];
+
+	switch (af) {
+	case NET_AF_INET:
+		prepare_sock_tcp_v4(MY_IPV4_ADDR, ANY_PORT, &c_sock,
+				    (struct net_sockaddr_in *)&c_saddr);
+		prepare_sock_tcp_v4(MY_IPV4_ADDR, SERVER_PORT, &s_sock,
+				    (struct net_sockaddr_in *)&s_saddr);
+		addrlen = sizeof(struct net_sockaddr_in);
+		break;
+	case NET_AF_INET6:
+		prepare_sock_tcp_v6(MY_IPV6_ADDR, ANY_PORT, &c_sock, &c_saddr);
+		prepare_sock_tcp_v6(MY_IPV6_ADDR, SERVER_PORT, &s_sock, &s_saddr);
+		addrlen = sizeof(struct net_sockaddr_in6);
+		break;
+	default:
+		zassert_true(false, "unsupported address family %d", af);
+		return;
+	}
+
+	test_bind(s_sock, (struct net_sockaddr *)&s_saddr, addrlen);
+	test_listen(s_sock);
+
+	test_connect(c_sock, (struct net_sockaddr *)&s_saddr, addrlen);
+	test_send(c_sock, TEST_STR_SMALL, strlen(TEST_STR_SMALL), 0);
+	test_close(c_sock);
+
+	/* Give the stack time to process the close before accept(). */
+	k_msleep(THREAD_SLEEP);
+
+	test_accept(s_sock, &new_sock, (struct net_sockaddr *)&addr, &addrlen);
+	zassert_equal(addrlen, af == NET_AF_INET ? sizeof(struct net_sockaddr_in) :
+		      sizeof(struct net_sockaddr_in6), "wrong addrlen");
+
+	zassert_equal(zsock_recv(new_sock, rx_buf, sizeof(rx_buf), 0),
+		      strlen(TEST_STR_SMALL),
+		      "unexpected received bytes");
+	zassert_equal(strncmp(rx_buf, TEST_STR_SMALL, strlen(TEST_STR_SMALL)),
+		      0,
+		      "unexpected data");
+
+	test_eof(new_sock);
+
+	test_close(new_sock);
+	test_close(s_sock);
+
+	k_sleep(TCP_TEARDOWN_TIMEOUT);
+}
+
+ZTEST_USER(net_socket_tcp, test_v4_accept_after_client_close)
+{
+	test_accept_after_client_close_common(NET_AF_INET);
+}
+
+ZTEST_USER(net_socket_tcp, test_v6_accept_after_client_close)
+{
+	test_accept_after_client_close_common(NET_AF_INET6);
+}
+
 /* Test the stack behavior with a reasonable sized block data, be sure to have multiple packets */
 #define TEST_LARGE_TRANSFER_SIZE 60000
 #define TEST_PRIME 811


### PR DESCRIPTION
zsock_accept() included some obsolete code related to the old TCP stack
behavior, which caused that incoming TCP connections that were already
closed generated an error instead of having FD assigned. This made the
server side unreliable, as it prevented the server from reading out data
received on such connections in case of late accept().

Also the accepted/closed net context flags are not set/checked anywhere
else in the network stack, so there's no need to use them at the socket
layer anymore.

Fixes #112419