### PR TITLE
Align nrf7120 tests with dk

### DIFF
--- a/tests/boards/nrf/i2c/i2c_slave/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/boards/nrf/i2c/i2c_slave/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -10,17 +10,17 @@
 };
 
 &pinctrl {
-	i2c21_default_alt: i2c21_default_alt {
+	i2c23_default_alt: i2c23_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 8)>,
-				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 5)>,
+				<NRF_PSEL(TWIM_SCL, 1, 6)>;
 		};
 	};
 
-	i2c21_sleep_alt: i2c21_sleep_alt {
+	i2c23_sleep_alt: i2c23_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 8)>,
-				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 5)>,
+				<NRF_PSEL(TWIM_SCL, 1, 6)>;
 			low-power-enable;
 		};
 	};
@@ -30,26 +30,26 @@
 			/* Temporary workaround as it is currently not possible
 			 * to configure pins for TWIS with pinctrl.
 			 */
-			psels = <NRF_PSEL(TWIM_SDA, 1, 9)>,
-				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 14)>,
+				<NRF_PSEL(TWIM_SCL, 1, 4)>;
 			bias-pull-up;
 		};
 	};
 
 	i2c22_sleep_alt: i2c22_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 9)>,
-				<NRF_PSEL(TWIM_SCL, 1, 3)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 14)>,
+				<NRF_PSEL(TWIM_SCL, 1, 4)>;
 			low-power-enable;
 		};
 	};
 };
 
-dut_twim: &i2c21 {
+dut_twim: &i2c23 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
-	pinctrl-0 = <&i2c21_default_alt>;
-	pinctrl-1 = <&i2c21_sleep_alt>;
+	pinctrl-0 = <&i2c23_default_alt>;
+	pinctrl-1 = <&i2c23_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 

--- a/tests/boards/nrf/qdec/boards/nrf7120dk_nrf7120_common.dtsi
+++ b/tests/boards/nrf/qdec/boards/nrf7120dk_nrf7120_common.dtsi
@@ -5,10 +5,10 @@
  */
 
 /* Required loopbacks
- * P1.11 <-> P1.12
+ * P1.07 <-> P1.12
  * P1.13 <-> P1.15
- * P1.02 <-> P1.3
- * P1.00 <-> P1.14
+ * P1.06 <-> P1.04
+ * P1.05 <-> P1.14
  */
 
 / {
@@ -16,7 +16,7 @@
 		compatible = "gpio-leds";
 
 		phase_a0: phase_a0 {
-			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
 		};
 
 		phase_b0: phase_b0 {
@@ -24,11 +24,11 @@
 		};
 
 		phase_a1: phase_a1 {
-			gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
 		};
 
 		phase_b1: phase_b1 {
-			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
 		};
 	};
 
@@ -65,14 +65,14 @@
 
 	qdec_21_pinctrl: qdec_21_pinctrl {
 		group1 {
-			psels = <NRF_PSEL(QDEC_A, 1, 3)>,
+			psels = <NRF_PSEL(QDEC_A, 1, 4)>,
 				<NRF_PSEL(QDEC_B, 1, 14)>;
 		};
 	};
 
 	qdec_21_sleep_pinctrl: qdec_21_sleep_pinctrl {
 		group1 {
-			psels = <NRF_PSEL(QDEC_A, 1, 3)>,
+			psels = <NRF_PSEL(QDEC_A, 1, 4)>,
 				<NRF_PSEL(QDEC_B, 1, 14)>;
 			low-power-enable;
 		};

--- a/tests/drivers/audio/dmic_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/audio/dmic_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -5,7 +5,7 @@
  */
 
 /* Test requires loopbacks:
- * - between P1.14 and P1.0,
+ * - between P1.12 and P1.07,
  * For best performance, PDM_CLK shall be on 'Clock pin'.
  */
 
@@ -18,8 +18,8 @@
 &pinctrl {
 	pdm20_default_test: pdm20_default_test {
 		group1 {
-			psels = <NRF_PSEL(PDM_CLK, 1, 14)>,
-				<NRF_PSEL(PDM_DIN, 1, 0)>;
+			psels = <NRF_PSEL(PDM_CLK, 1, 7)>,
+				<NRF_PSEL(PDM_DIN, 1, 12)>;
 		};
 	};
 };

--- a/tests/drivers/gpio/gpio_basic_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -8,7 +8,7 @@
 	resources {
 		compatible = "test-gpio-basic-api";
 		out-gpios = <&gpio1 12 0>;
-		in-gpios = <&gpio1 11 0>;
+		in-gpios = <&gpio1 7 0>;
 	};
 };
 

--- a/tests/drivers/i2c/i2c_nrfx_twim/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/i2c/i2c_nrfx_twim/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -5,55 +5,55 @@
  */
 
 /*
- * SDA = P1.8 and P1.9
- * SCL = P1.2 and P1.3
+ * SDA = P1.05 and P1.14
+ * SCL = P1.06 and P1.04
  */
 
 / {
 	aliases {
-		i2c-controller = &i2c21;
+		i2c-controller = &i2c23;
 		i2c-controller-target = &i2c22;
 	};
 };
 
 &pinctrl {
-	i2c21_default: i2c21_default {
+	i2c23_default: i2c23_default {
 		group1 {
-			psels = <NRF_PSEL(TWIS_SDA, 1, 8)>,
-				<NRF_PSEL(TWIS_SCL, 1, 2)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 5)>,
+				<NRF_PSEL(TWIS_SCL, 1, 6)>;
 			bias-pull-up;
 		};
 	};
 
-	i2c21_sleep: i2c21_sleep {
+	i2c23_sleep: i2c23_sleep {
 		group1 {
-			psels = <NRF_PSEL(TWIS_SDA, 1, 8)>,
-				<NRF_PSEL(TWIS_SCL, 1, 2)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 5)>,
+				<NRF_PSEL(TWIS_SCL, 1, 6)>;
 			low-power-enable;
 		};
 	};
 
 	i2c22_default: i2c22_default {
 		group1 {
-			psels = <NRF_PSEL(TWIS_SDA, 1, 9)>,
-				<NRF_PSEL(TWIS_SCL, 1, 3)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 14)>,
+				<NRF_PSEL(TWIS_SCL, 1, 4)>;
 			bias-pull-up;
 		};
 	};
 
 	i2c22_sleep: i2c22_sleep {
 		group1 {
-			psels = <NRF_PSEL(TWIS_SDA, 1, 9)>,
-				<NRF_PSEL(TWIS_SCL, 1, 3)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 14)>,
+				<NRF_PSEL(TWIS_SCL, 1, 4)>;
 			low-power-enable;
 		};
 	};
 };
 
-&i2c21 {
+&i2c23 {
 	compatible = "nordic,nrf-twim";
-	pinctrl-0 = <&i2c21_default>;
-	pinctrl-1 = <&i2c21_sleep>;
+	pinctrl-0 = <&i2c23_default>;
+	pinctrl-1 = <&i2c23_sleep>;
 	pinctrl-names = "default", "sleep";
 	zephyr,concat-buf-size = <256>;
 	status = "okay";

--- a/tests/drivers/i2c/i2c_target_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -5,47 +5,47 @@
  */
 
 /*
- * SDA = P1.8 and P1.9
- * SCL = P1.2 and P1.3
+ * SDA = P1.05 and P1.14
+ * SCL = P1.06 and P1.04
  */
 
 &pinctrl {
-	i2c21_default: i2c21_default {
+	i2c23_default: i2c23_default {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 8)>,
-				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 5)>,
+				<NRF_PSEL(TWIS_SCL, 1, 6)>;
 			bias-pull-up;
 		};
 	};
 
-	i2c21_sleep: i2c21_sleep {
+	i2c23_sleep: i2c23_sleep {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 1, 8)>,
-				<NRF_PSEL(TWIM_SCL, 1, 2)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 5)>,
+				<NRF_PSEL(TWIS_SCL, 1, 6)>;
 			low-power-enable;
 		};
 	};
 
 	i2c22_default: i2c22_default {
 		group1 {
-			psels = <NRF_PSEL(TWIS_SDA, 1, 9)>,
-				<NRF_PSEL(TWIS_SCL, 1, 3)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 14)>,
+				<NRF_PSEL(TWIS_SCL, 1, 4)>;
 			bias-pull-up;
 		};
 	};
 
 	i2c22_sleep: i2c22_sleep {
 		group1 {
-			psels = <NRF_PSEL(TWIS_SDA, 1, 9)>,
-				<NRF_PSEL(TWIS_SCL, 1, 3)>;
+			psels = <NRF_PSEL(TWIS_SDA, 1, 14)>,
+				<NRF_PSEL(TWIS_SCL, 1, 4)>;
 			low-power-enable;
 		};
 	};
 };
 
-&i2c21 {
-	pinctrl-0 = <&i2c21_default>;
-	pinctrl-1 = <&i2c21_sleep>;
+&i2c23 {
+	pinctrl-0 = <&i2c23_default>;
+	pinctrl-1 = <&i2c23_sleep>;
 	pinctrl-names = "default", "sleep";
 	zephyr,concat-buf-size = <256>;
 	status = "okay";

--- a/tests/drivers/i2s/i2s_additional/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/i2s/i2s_additional/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -17,7 +17,7 @@
 		group1 {
 			psels = <NRF_PSEL(TDM_SCK_M, 1, 13)>,
 				<NRF_PSEL(TDM_FSYNC_M, 1, 14)>,
-				<NRF_PSEL(TDM_SDOUT, 1, 11)>,  /* TDM_SDOUT shorted to TDM_SDIN */
+				<NRF_PSEL(TDM_SDOUT, 1, 7)>,  /* TDM_SDOUT shorted to TDM_SDIN */
 				<NRF_PSEL(TDM_SDIN, 1, 12)>;
 		};
 	};

--- a/tests/drivers/i2s/i2s_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/i2s/i2s_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -15,8 +15,8 @@
 &pinctrl {
 	tdm_default_alt: tdm_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TDM_SCK_M, 1, 13)>,
-				<NRF_PSEL(TDM_FSYNC_M, 1, 14)>,
+			psels = <NRF_PSEL(TDM_SCK_M, 1, 6)>,
+				<NRF_PSEL(TDM_FSYNC_M, 1, 4)>,
 				<NRF_PSEL(TDM_SDOUT, 1, 4)>,  /* TDM_SDOUT shorted to TDM_SDIN */
 				<NRF_PSEL(TDM_SDIN, 1, 5)>;
 		};

--- a/tests/drivers/i2s/i2s_speed/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -17,7 +17,7 @@
 		group1 {
 			psels = <NRF_PSEL(TDM_SCK_M, 1, 13)>,
 				<NRF_PSEL(TDM_FSYNC_M, 1, 14)>,
-				<NRF_PSEL(TDM_SDOUT, 1, 11)>,  /* TDM_SDOUT shorted to TDM_SDIN */
+				<NRF_PSEL(TDM_SDOUT, 1, 7)>,  /* TDM_SDOUT shorted to TDM_SDIN */
 				<NRF_PSEL(TDM_SDIN, 1, 12)>;
 		};
 	};

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -5,8 +5,8 @@
  */
 
 /* Test requires wire connection between:
- *  - PWM22 OUT[0] at P1.14 <-> GPIO input at P1.00
- *  - PWM22 OUT[1] at P1.02 <-> GPIO input at P1.03
+ *  - PWM22 OUT[0] at P1.14 <-> GPIO input at P1.05
+ *  - PWM22 OUT[1] at P1.06 <-> GPIO input at P1.04
  */
 
 / {
@@ -14,8 +14,8 @@
 		pwms = <&pwm22 0 1600000 PWM_POLARITY_NORMAL>,
 		       <&pwm22 1 1600000 PWM_POLARITY_NORMAL>;
 
-		gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>,
-			<&gpio1 3 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>,
+			<&gpio1 4 GPIO_ACTIVE_HIGH>;
 	};
 };
 
@@ -23,14 +23,14 @@
 	pwm22_alt: pwm22_alt {
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 1, 14)>,
-				<NRF_PSEL(PWM_OUT1, 1, 2)>;
+				<NRF_PSEL(PWM_OUT1, 1, 6)>;
 		};
 	};
 
 	pwm22_alt_sleep: pwm22_alt_sleep {
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 1, 14)>,
-				<NRF_PSEL(PWM_OUT1, 1, 2)>;
+				<NRF_PSEL(PWM_OUT1, 1, 6)>;
 			low-power-enable;
 		};
 	};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -7,17 +7,17 @@
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 11)>,
-				<NRF_PSEL(SPIM_MISO, 1, 0)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 8)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 7)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
 		};
 	};
 
 	spi22_sleep_alt: spi22_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 11)>,
-				<NRF_PSEL(SPIM_MISO, 1, 0)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 8)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 7)>,
+				<NRF_PSEL(SPIM_MISO, 1, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 6)>;
 			low-power-enable;
 		};
 	};
@@ -26,7 +26,7 @@
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 12)>,
 				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 9)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 4)>,
 				<NRF_PSEL(SPIS_CSN, 1, 13)>;
 		};
 	};
@@ -35,7 +35,7 @@
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 12)>,
 				<NRF_PSEL(SPIS_MISO, 1, 14)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 9)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 4)>,
 				<NRF_PSEL(SPIS_CSN, 1, 13)>;
 			low-power-enable;
 		};

--- a/tests/drivers/spi/spi_error_cases/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/spi/spi_error_cases/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -8,16 +8,16 @@
 	spi22_default_alt: spi22_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
-				<NRF_PSEL(SPIM_MISO, 1, 11)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 9)>;
+				<NRF_PSEL(SPIM_MISO, 1, 7)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 4)>;
 		};
 	};
 
 	spi22_sleep_alt: spi22_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
-				<NRF_PSEL(SPIM_MISO, 1, 11)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 9)>;
+				<NRF_PSEL(SPIM_MISO, 1, 7)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 4)>;
 			low-power-enable;
 		};
 	};
@@ -25,8 +25,8 @@
 	spi21_default_alt: spi21_default_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 12)>,
-				<NRF_PSEL(SPIS_MISO, 1, 10)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 15)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 6)>,
 				<NRF_PSEL(SPIS_CSN, 1, 14)>;
 		};
 	};
@@ -34,8 +34,8 @@
 	spi21_sleep_alt: spi21_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 12)>,
-				<NRF_PSEL(SPIS_MISO, 1, 10)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 8)>,
+				<NRF_PSEL(SPIS_MISO, 1, 15)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 6)>,
 				<NRF_PSEL(SPIS_CSN, 1, 14)>;
 			low-power-enable;
 		};

--- a/tests/drivers/spi/spi_loopback/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -6,14 +6,14 @@
 
 /*
  * Test requires following loopback:
- * P1.11 - P1.12
+ * P1.07 - P1.12
  */
 
 / {
 	zephyr,user {
-		miso-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		miso-gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
 		mosi-gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
-		cs-loopback-gpios = <&gpio1 0 0>;
+		cs-loopback-gpios = <&gpio1 5 0>;
 	};
 };
 
@@ -21,7 +21,7 @@
 	spi21_default: spi21_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
-				<NRF_PSEL(SPIM_MISO, 1, 11)>,
+				<NRF_PSEL(SPIM_MISO, 1, 7)>,
 				<NRF_PSEL(SPIM_MOSI, 1, 12)>;
 			low-power-enable;
 		};
@@ -30,7 +30,7 @@
 	spi21_sleep: spi21_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
-				<NRF_PSEL(SPIM_MISO, 1, 11)>,
+				<NRF_PSEL(SPIM_MISO, 1, 7)>,
 				<NRF_PSEL(SPIM_MOSI, 1, 12)>;
 			low-power-enable;
 		};

--- a/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_common_dual_uart.dtsi
+++ b/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_common_dual_uart.dtsi
@@ -5,25 +5,25 @@
  */
 
 &pinctrl {
-	uart21_default: uart21_default {
+	uart21_default_alt: uart21_default_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
-				<NRF_PSEL(UART_RX, 1, 8)>;
+				<NRF_PSEL(UART_RX, 1, 6)>;
 			bias-pull-up;
 		};
 	};
 
-	uart21_sleep: uart21_sleep {
+	uart21_sleep_alt: uart21_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
-				<NRF_PSEL(UART_RX, 1, 8)>;
+				<NRF_PSEL(UART_RX, 1, 6)>;
 			low-power-enable;
 		};
 	};
 
 	uart22_default: uart22_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 9)>,
+			psels = <NRF_PSEL(UART_TX, 1, 4)>,
 				<NRF_PSEL(UART_RX, 1, 15)>;
 			bias-pull-up;
 		};
@@ -31,7 +31,7 @@
 
 	uart22_sleep: uart22_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 9)>,
+			psels = <NRF_PSEL(UART_TX, 1, 4)>,
 				<NRF_PSEL(UART_RX, 1, 15)>;
 			low-power-enable;
 		};
@@ -41,8 +41,8 @@
 dut: &uart21 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart21_default>;
-	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-0 = <&uart21_default_alt>;
+	pinctrl-1 = <&uart21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 };
 

--- a/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -5,21 +5,21 @@
  */
 
 &pinctrl {
-	uart21_default: uart21_default {
+	uart21_default_alt: uart21_default_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>,
-				<NRF_PSEL(UART_RTS, 1, 02)>,
-				<NRF_PSEL(UART_CTS, 1, 03)>;
+				<NRF_PSEL(UART_RTS, 1, 06)>,
+				<NRF_PSEL(UART_CTS, 1, 04)>;
 		};
 	};
 
-	uart21_sleep: uart21_sleep {
+	uart21_sleep_alt: uart21_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>,
-				<NRF_PSEL(UART_RTS, 1, 02)>,
-				<NRF_PSEL(UART_CTS, 1, 03)>;
+				<NRF_PSEL(UART_RTS, 1, 06)>,
+				<NRF_PSEL(UART_CTS, 1, 04)>;
 			low-power-enable;
 		};
 	};
@@ -28,8 +28,8 @@
 dut: &uart21 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart21_default>;
-	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-0 = <&uart21_default_alt>;
+	pinctrl-1 = <&uart21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	hw-flow-control;
 };

--- a/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_cpuapp_cross_domain.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_cpuapp_cross_domain.overlay
@@ -5,7 +5,7 @@
  */
 
 &pinctrl {
-	uart21_default: uart21_default {
+	uart21_default_alt: uart21_default_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 2, 8)>,
 				<NRF_PSEL(UART_RX, 2, 7)>,
@@ -14,7 +14,7 @@
 		};
 	};
 
-	uart21_sleep: uart21_sleep {
+	uart21_sleep_alt: uart21_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 2, 8)>,
 				<NRF_PSEL(UART_RX, 2, 7)>,
@@ -28,8 +28,8 @@
 dut: &uart21 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart21_default>;
-	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-0 = <&uart21_default_alt>;
+	pinctrl-1 = <&uart21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	hw-flow-control;
 };

--- a/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_cpuflpr.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_cpuflpr.overlay
@@ -5,21 +5,21 @@
  */
 
 &pinctrl {
-	uart21_default: uart21_default {
+	uart21_default_alt: uart21_default_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>,
-				<NRF_PSEL(UART_RTS, 1, 02)>,
-				<NRF_PSEL(UART_CTS, 1, 03)>;
+				<NRF_PSEL(UART_RTS, 1, 06)>,
+				<NRF_PSEL(UART_CTS, 1, 04)>;
 		};
 	};
 
-	uart21_sleep: uart21_sleep {
+	uart21_sleep_alt: uart21_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>,
-				<NRF_PSEL(UART_RTS, 1, 02)>,
-				<NRF_PSEL(UART_CTS, 1, 03)>;
+				<NRF_PSEL(UART_RTS, 1, 06)>,
+				<NRF_PSEL(UART_CTS, 1, 04)>;
 			low-power-enable;
 		};
 	};
@@ -28,8 +28,8 @@
 dut: &uart21 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart21_default>;
-	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-0 = <&uart21_default_alt>;
+	pinctrl-1 = <&uart21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	hw-flow-control;
 };

--- a/tests/drivers/uart/uart_errors/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/uart/uart_errors/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -5,17 +5,17 @@
  */
 
 &pinctrl {
-	uart21_default: uart21_default {
+	uart21_default_alt: uart21_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 1, 8)>,
+			psels = <NRF_PSEL(UART_RX, 1, 6)>,
 				<NRF_PSEL(UART_RTS, 1, 13)>;
 			bias-pull-up;
 		};
 	};
 
-	uart21_sleep: uart21_sleep {
+	uart21_sleep_alt: uart21_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 1, 8)>,
+			psels = <NRF_PSEL(UART_RX, 1, 6)>,
 				<NRF_PSEL(UART_RTS, 1, 13)>;
 			low-power-enable;
 		};
@@ -28,13 +28,13 @@
 		};
 
 		group2 {
-			psels = <NRF_PSEL(UART_TX, 1, 9)>;
+			psels = <NRF_PSEL(UART_TX, 1, 4)>;
 		};
 	};
 
 	uart22_sleep: uart22_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 1, 9)>,
+			psels = <NRF_PSEL(UART_TX, 1, 4)>,
 				<NRF_PSEL(UART_CTS, 1, 15)>;
 			low-power-enable;
 		};
@@ -44,8 +44,8 @@
 dut: &uart21 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart21_default>;
-	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-0 = <&uart21_default_alt>;
+	pinctrl-1 = <&uart21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 };
 

--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -5,20 +5,20 @@
  */
 
 &pinctrl {
-	uart21_default: uart21_default {
+	uart21_default_alt: uart21_default_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>,
-				<NRF_PSEL(UART_RTS, 1, 11)>,
+				<NRF_PSEL(UART_RTS, 1, 7)>,
 				<NRF_PSEL(UART_CTS, 1, 12)>;
 		};
 	};
 
-	uart21_sleep: uart21_sleep {
+	uart21_sleep_alt: uart21_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>,
-				<NRF_PSEL(UART_RTS, 1, 11)>,
+				<NRF_PSEL(UART_RTS, 1, 7)>,
 				<NRF_PSEL(UART_CTS, 1, 12)>;
 			low-power-enable;
 		};
@@ -28,8 +28,8 @@
 dut: &uart21 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart21_default>;
-	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-0 = <&uart21_default_alt>;
+	pinctrl-1 = <&uart21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	hw-flow-control;
 };

--- a/tests/drivers/uart/uart_pm/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/uart/uart_pm/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -5,14 +5,14 @@
  */
 
 &pinctrl {
-	uart21_default: uart21_default {
+	uart21_default_alt: uart21_default_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>;
 		};
 	};
 
-	uart21_sleep: uart21_sleep {
+	uart21_sleep_alt: uart21_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>;
@@ -24,7 +24,7 @@
 dut: &uart21 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart21_default>;
-	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-0 = <&uart21_default_alt>;
+	pinctrl-1 = <&uart21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 };


### PR DESCRIPTION
Align tests such that pins now being used for uart are not used in loopback testing