### PR TITLE
drivers: rtc: stm32: don't allow WEEKDAY + MONTHDAY alarms

### DIFF
--- a/drivers/rtc/rtc_stm32.c
+++ b/drivers/rtc/rtc_stm32.c
@@ -925,6 +925,13 @@ static int rtc_stm32_alarm_set_time(const struct device *dev, uint16_t id, uint1
 		goto unlock;
 	}
 
+	if ((mask & RTC_ALARM_TIME_MASK_WEEKDAY) && (mask & RTC_ALARM_TIME_MASK_MONTHDAY)) {
+		/* STM32 RTC can match weekday OR monthday but not both at the same time */
+		LOG_ERR("alarm %d cannot match weekday and monthday simultaneously", id);
+		err = -EINVAL;
+		goto unlock;
+	}
+
 	if (timeptr == NULL) {
 		LOG_ERR("timeptr is invalid");
 		err = -EINVAL;


### PR DESCRIPTION
The RTC API does not seem to disallow an alarm matching both a specific day of the month **and** a specific day of the week at the same time. However, the STM32 RTC hardware only supports ONE of these two criteria at a time. Add a check in the STM32 RTC driver to reject attempts to configure an alarm matching both criteria at the same time.