### PR TITLE
drivers: display_renesas_ra: fix Backlight Pin config issue

### DIFF
--- a/drivers/display/display_renesas_ra.c
+++ b/drivers/display/display_renesas_ra.c
@@ -391,10 +391,12 @@ static int display_init(const struct device *dev)
 		return -EIO;
 	}
 
-	err = gpio_pin_configure_dt(&config->backlight_gpio, GPIO_OUTPUT_ACTIVE);
-	if (err) {
-		LOG_ERR("config backlight gpio failed");
-		return err;
+	if (config->backlight_gpio.port != NULL) {
+		err = gpio_pin_configure_dt(&config->backlight_gpio, GPIO_OUTPUT_ACTIVE);
+		if (err) {
+			LOG_ERR("config backlight gpio failed");
+			return err;
+		}
 	}
 
 	config->irq_configure();


### PR DESCRIPTION
`backlight-gpios` is an optional property for Display.
When this property is not defined in the board `dts` or `overlay` file, there is no compilation warning or errors and the device crashes on the boot-up.

Fix:
- Added `NULL` check before configuring backlight pin in `display_init`