### PR TITLE
boards: shields: add nxp_m2_ieee802154 shield for IW61X IEEE 802.15.4

### DIFF
--- a/boards/shields/nxp_m2_ieee802154/Kconfig.defconfig
+++ b/boards/shields/nxp_m2_ieee802154/Kconfig.defconfig
@@ -1,0 +1,39 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_NXP_M2_2EL_2LL_IEEE802154
+
+config HDLC_RCP_IF
+	default y
+
+config HDLC_RCP_IF_SPI
+	default y
+
+config HDLC_RCP_IF_SPI_NO_AUTO_START
+	default y
+
+config HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE
+	default 48
+
+config HDLC_RCP_IF_SPI_ALIGN_ALLOWANCE
+	default 16
+
+config SPI
+	default y
+
+config I2C
+	default y
+
+config BT
+	default y
+
+config BT_H4
+	default y
+
+config BT_H4_NXP_CTLR
+	default y
+
+config NET_L2_OPENTHREAD
+	default y
+
+endif # SHIELD_NXP_M2_2EL_2LL_IEEE802154

--- a/boards/shields/nxp_m2_ieee802154/Kconfig.shield
+++ b/boards/shields/nxp_m2_ieee802154/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_NXP_M2_2EL_2LL_IEEE802154
+	def_bool $(shields_list_contains,nxp_m2_2el_2ll_ieee802154)

--- a/boards/shields/nxp_m2_ieee802154/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/boards/shields/nxp_m2_ieee802154/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * RT1060 EVKC — NXP M.2 IEEE 802.15.4 SPI RCP
+ */
+
+/* Free GPIO_B0_xx — required for LPSPI4 */
+&lcdif {
+	status = "disabled";
+};
+
+&m2_bt_module {
+	/delete-property/ sdio-reset-gpios;
+	/delete-property/ w-disable-gpios;
+};
+
+&pinctrl {
+	pinmux_lpspi4_ieee802154: pinmux_lpspi4_ieee802154 {
+		group0 {
+			pinmux = <&iomuxc_gpio_b0_01_lpspi4_sdi>,
+				 <&iomuxc_gpio_b0_02_lpspi4_sdo>,
+				 <&iomuxc_gpio_b0_03_lpspi4_sck>;
+			bias-pull-down;
+			drive-strength = "r0-6";
+			slew-rate = "slow";
+			nxp,speed = "100-mhz";
+		};
+		group1 {
+			/* CS GPIO */
+			pinmux = <&iomuxc_gpio_b0_00_gpio2_io00>;
+			bias-pull-up;
+			drive-strength = "r0-6";
+			slew-rate = "slow";
+			nxp,speed = "100-mhz";
+		};
+		group2 {
+			/* SPI INT GPIO — ACTIVE_LOW, pull-up */
+			pinmux = <&iomuxc_gpio_b0_04_gpio2_io04>;
+			bias-pull-up;
+			drive-strength = "r0-6";
+			slew-rate = "slow";
+			nxp,speed = "100-mhz";
+		};
+	};
+};
+
+&lpspi4 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpspi4_ieee802154>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+
+	hdlc_rcp_spi: hdlc_rcp_if_spi@0 {
+		compatible = "spi,hdlc-rcp-if";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+		int-gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
+		reset-assert-time = <30>;
+		reset-delay = <500>;
+		status = "okay";
+	};
+};

--- a/boards/shields/nxp_m2_ieee802154/nxp_m2_2el_2ll_ieee802154.overlay
+++ b/boards/shields/nxp_m2_ieee802154/nxp_m2_2el_2ll_ieee802154.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Generic NXP M.2 IEEE 802.15.4 SPI RCP interface overlay.
+ * Supports IW612 (Murata 2EL) and IW610 (Murata 2LL) M.2 modules.
+ *
+ * Board-specific pinmux and GPIO assignments are in boards/<board>.overlay.
+ * The board overlay must define &lpspi4 with cs-gpios and pinctrl.
+ */
+
+/ {
+	chosen {
+		zephyr,ieee802154 = &hdlc_rcp_spi;
+		zephyr,hdlc-rcp-if = &hdlc_rcp_spi;
+	};
+};

--- a/boards/shields/nxp_m2_ieee802154/pre_dt_shield.cmake
+++ b/boards/shields/nxp_m2_ieee802154/pre_dt_shield.cmake
@@ -1,0 +1,17 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+#
+# The nxp_m2_2el_2ll_ieee802154 shield requires one of the nxp_m2_wifi_bt
+# base shields to be present for BT UART H4 and Wi-Fi SDIO support.
+
+if(NOT (
+    "nxp_m2_2el_wifi_bt" IN_LIST SHIELD_AS_LIST OR
+    "nxp_m2_2ll_wifi_bt" IN_LIST SHIELD_AS_LIST
+))
+  message(FATAL_ERROR
+    "Shield 'nxp_m2_2el_2ll_ieee802154' requires one of the following base shields:\n"
+    "  - nxp_m2_2el_wifi_bt (IW612 Murata 2EL)\n"
+    "  - nxp_m2_2ll_wifi_bt (IW610 Murata 2LL)\n"
+    "Example: --shield \"nxp_m2_2el_wifi_bt nxp_m2_2el_2ll_ieee802154\""
+  )
+endif()

--- a/boards/shields/nxp_m2_ieee802154/shield.yml
+++ b/boards/shields/nxp_m2_ieee802154/shield.yml
@@ -1,0 +1,6 @@
+shields:
+  - name: nxp_m2_2el_2ll_ieee802154
+    full_name: NXP M.2 IW612 IW610 IEEE 802.15.4 SPI RCP Shield
+    vendor: nxp
+    supported_features:
+      - ieee802154

--- a/drivers/hdlc_rcp_if/Kconfig.spi
+++ b/drivers/hdlc_rcp_if/Kconfig.spi
@@ -31,4 +31,18 @@ config HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE
 	  Specify the smallest packet we can receive in a single transaction.
 	  Larger packets will require multiple transactions.
 
+config HDLC_RCP_IF_SPI_NO_AUTO_START
+	bool "Defer SPI RCP interface start until explicitly requested"
+	default n
+	depends on HDLC_RCP_IF_SPI
+	help
+	  When enabled, prevents net_if_post_init() from automatically
+	  bringing up the OpenThread interface at boot, and defers SPI
+	  interrupt arming until hdlc_api.start() is called.
+	  This is required when the RCP firmware is loaded asynchronously
+	  (e.g. IW61X firmware uploaded via BT UART H4 before SPI is active).
+	  hdlc_api.start() can be called once the firmware is ready.
+	  the SPI IRQ is armed and the network interface is brought up.
+	  When disabled, SPI IRQ is armed during init and the interface
+	  is brought up automatically.
 endif

--- a/drivers/hdlc_rcp_if/hdlc_rcp_if_spi.c
+++ b/drivers/hdlc_rcp_if/hdlc_rcp_if_spi.c
@@ -62,6 +62,7 @@ struct hdlc_rcp_if_spi_data {
 
 	bool tx_ready;
 	bool frame_sent;
+	uint16_t tx_refused_count;
 };
 
 BUILD_ASSERT(CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE <=
@@ -167,6 +168,7 @@ static void hdlc_rcp_if_push_pull_spi(struct k_work *work)
 	uint16_t peer_max_rx;
 	uint16_t fcs;
 	int ret;
+	uint16_t accept_len;
 
 	data->tx_buf[0] = SPI_HEADER_PATTERN_VALUE;
 	if (!data->frame_sent) {
@@ -180,8 +182,9 @@ static void hdlc_rcp_if_push_pull_spi(struct k_work *work)
 		rx_frame.len += data->rx_len;
 		sys_put_le16(data->rx_len, &data->tx_buf[1]);
 	} else {
-		rx_frame.len += CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE;
-		sys_put_le16(CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE, &data->tx_buf[1]);
+		accept_len = MAX(CONFIG_HDLC_RCP_IF_SPI_SMALL_PACKET_SIZE, data->tx_len);
+		rx_frame.len += accept_len;
+		sys_put_le16(accept_len, &data->tx_buf[1]);
 	}
 
 	LOG_HEXDUMP_DBG(data->tx_buf, SPI_HEADER_LEN, "TX Header");
@@ -214,8 +217,18 @@ static void hdlc_rcp_if_push_pull_spi(struct k_work *work)
 	data->rx_len = sys_get_le16(&rx_buf[3]);
 
 	if (data->tx_len > peer_max_rx) {
-		LOG_WRN("Peer not ready to receive our frame (%u > %u)", data->tx_len, peer_max_rx);
+		data->tx_refused_count++;
+		if (data->tx_refused_count == 1) {
+			LOG_WRN("Peer not ready to receive our frame (%u > %u), need to retry",
+				data->tx_len, peer_max_rx);
+		}
+		/* Keep tx_ready to retry the packet on next SPI transaction. */
+		data->tx_ready = true;
+		return;
 	}
+
+	/* TX accepted by peer — reset refused count */
+	data->tx_refused_count = 0;
 
 	LOG_HEXDUMP_DBG(rx_buf, SPI_HEADER_LEN, "RX Header");
 

--- a/drivers/hdlc_rcp_if/hdlc_rcp_if_spi.c
+++ b/drivers/hdlc_rcp_if/hdlc_rcp_if_spi.c
@@ -303,14 +303,31 @@ static void hdlc_rcp_if_spi_isr(const struct device *port, struct gpio_callback 
 
 static void hdlc_iface_init(struct net_if *iface)
 {
-	otExtAddress eui64;
-
 	__ASSERT_NO_MSG(DEVICE_DT_INST_GET(0) == net_if_get_device(iface));
+
+#ifdef CONFIG_HDLC_RCP_IF_SPI_NO_AUTO_START
+	/* DO NOT call ieee802154_init() here:
+	 * It leads to send Spinel commands to the RCP which is not yet booted.
+	 * RCP firmware is loaded later
+	 */
+
+	/* Set a temporary link address — updated after firmware loads */
+	static uint8_t temp_eui64[8] = {
+		0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+	};
+	net_if_set_link_addr(iface, temp_eui64, 8, NET_LINK_IEEE802154);
+
+	/* Prevent net_if_post_init() from auto-starting the interface */
+	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
+	LOG_INF("hdlc_iface_init done — NO_AUTO_START set, waiting for RCP firmware");
+#else
+	otExtAddress eui64;
 
 	ieee802154_init(iface);
 
 	otPlatRadioGetIeeeEui64(openthread_get_default_instance(), eui64.m8);
 	net_if_set_link_addr(iface, eui64.m8, OT_EXT_ADDRESS_SIZE, NET_LINK_IEEE802154);
+#endif /* CONFIG_HDLC_RCP_IF_SPI_NO_AUTO_START */
 }
 
 static int hdlc_register_rx_cb(hdlc_rx_callback_t hdlc_rx_callback, void *param)
@@ -437,11 +454,13 @@ static int hdlc_rcp_if_spi_init(const struct device *dev)
 		return ret;
 	}
 
+#ifndef CONFIG_HDLC_RCP_IF_SPI_NO_AUTO_START
 	ret = gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret < 0) {
 		LOG_ERR("Failed to configure interrupt GPIO (%d)", ret);
 		return ret;
 	}
+#endif /* CONFIG_HDLC_RCP_IF_SPI_NO_AUTO_START */
 
 	gpio_init_callback(&data->int_gpio_cb, hdlc_rcp_if_spi_isr, BIT(cfg->int_gpio.pin));
 
@@ -451,19 +470,53 @@ static int hdlc_rcp_if_spi_init(const struct device *dev)
 		return ret;
 	}
 
+#ifndef CONFIG_HDLC_RCP_IF_SPI_NO_AUTO_START
 	ret = hdlc_rcp_if_spi_reset(dev);
 	if (ret < 0) {
 		LOG_ERR("Failed to reset HDLC SPI device (%d)", ret);
+		return ret;
+	}
+#endif /* CONFIG_HDLC_RCP_IF_SPI_NO_AUTO_START */
+
+	return 0;
+}
+
+#ifdef CONFIG_HDLC_RCP_IF_SPI_NO_AUTO_START
+static int hdlc_start(void)
+{
+	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct hdlc_rcp_if_spi_config *cfg = dev->config;
+	int ret;
+
+	LOG_INF("Arm SPI INT GPIO");
+
+	ret = gpio_pin_interrupt_configure_dt(&cfg->int_gpio,
+					      GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret < 0) {
+		LOG_ERR("Failed to configure interrupt GPIO: %d", ret);
+		return ret;
+	}
+
+	/* clear NET_IF_NO_AUTO_START flag to bring up the interface */
+	struct net_if *iface = net_if_get_first_by_type(
+					&NET_L2_GET_NAME(OPENTHREAD));
+	if (iface) {
+		net_if_flag_clear(iface, NET_IF_NO_AUTO_START);
+		LOG_INF("NET_IF_NO_AUTO_START cleared");
 	}
 
 	return 0;
 }
+#endif /* CONFIG_HDLC_RCP_IF_SPI_NO_AUTO_START */
 
 static const struct hdlc_api spi_hdlc_api = {
 	.iface_api.init = hdlc_iface_init,
 	.register_rx_cb = hdlc_register_rx_cb,
 	.send = hdlc_send,
 	.deinit = hdlc_deinit,
+#ifdef CONFIG_HDLC_RCP_IF_SPI_NO_AUTO_START
+	.start = hdlc_start,
+#endif
 };
 
 #define L2_CTX_TYPE NET_L2_GET_CTX_TYPE(OPENTHREAD_L2)

--- a/include/zephyr/net/hdlc_rcp_if/hdlc_rcp_if.h
+++ b/include/zephyr/net/hdlc_rcp_if/hdlc_rcp_if.h
@@ -65,6 +65,12 @@ struct hdlc_api {
 	 * @retval -EIO The interface could not be stopped.
 	 */
 	int (*deinit)(void);
+
+	/**
+	 * @brief Optional: start the RCP interface after deferred init.
+	 * If NULL, the interface is started automatically at init.
+	 */
+	int (*start)(void);
 };
 
 /* Make sure that the interface API is properly setup inside


### PR DESCRIPTION
boards: shields: add nxp_m2_ieee802154 shield for IW61X IEEE 802.15.4
Add the nxp_m2_2el_2ll_ieee802154 shield for NXP IW612 (Murata 2EL) and
IW610 (Murata 2LL) M.2 modules, enabling IEEE 802.15.4 RCP over SPI via
the HDLC RCP interface.

This shield requires one of the nxp_m2_wifi_bt base shields to be present
(nxp_m2_2el_wifi_bt or nxp_m2_2ll_wifi_bt), as BTUART H4 and Wi-Fi SDIO
support are provided by the base shield.
A CMake pre_dt check enforces this dependency at build time.

The shield overlay configures the SPI RCP interface node and the chosen
properties for ieee802154 and hdlc-rcp-if.
Board-specific pinctrl is provided by the board overlay.

Depends-On: [112502](https://github.com/zephyrproject-rtos/zephyr/pull/112502)
