### PR TITLE
drivers: sensor: st: stm32_vbat: add broader support for VDDCORE sensor

### DIFF
--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -96,6 +96,7 @@
 		die-temp0 = &die_temp;
 		volt-sensor0 = &vref;
 		volt-sensor1 = &vbat;
+		volt-sensor2 = &vddcore;
 		spi-flash0 = &mx66uw1g45;
 		rtc = &rtc;
 	};
@@ -375,6 +376,10 @@ st_cam_i2c: &i2c1 {
 };
 
 &vbat {
+	status = "okay";
+};
+
+&vddcore {
 	status = "okay";
 };
 

--- a/drivers/sensor/st/stm32_vbat/stm32_vbat.c
+++ b/drivers/sensor/st/stm32_vbat/stm32_vbat.c
@@ -14,6 +14,12 @@
 
 LOG_MODULE_REGISTER(stm32_vbat, CONFIG_SENSOR_LOG_LEVEL);
 
+#ifdef CONFIG_STM32_HAL2
+#define STM32_ADC_COMMON_INSTANCE	ADC_COMMON_INSTANCE
+#else /* CONFIG_STM32_HAL2 */
+#define STM32_ADC_COMMON_INSTANCE	__LL_ADC_COMMON_INSTANCE
+#endif /* CONFIG_STM32_HAL2 */
+
 struct stm32_vbat_data {
 	const struct device *adc;
 	const struct adc_channel_cfg adc_cfg;
@@ -33,17 +39,17 @@ struct stm32_vbat_config {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_vbat)
 static void stm32_vbat_enable_vbatsensor_channel(ADC_TypeDef *adc)
 {
-	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
+	const uint32_t path = LL_ADC_GetCommonPathInternalCh(STM32_ADC_COMMON_INSTANCE(adc));
 
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
+	LL_ADC_SetCommonPathInternalCh(STM32_ADC_COMMON_INSTANCE(adc),
 					path | LL_ADC_PATH_INTERNAL_VBAT);
 }
 
 static void stm32_vbat_disable_vbatsensor_channel(ADC_TypeDef *adc)
 {
-	const uint32_t path = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc));
+	const uint32_t path = LL_ADC_GetCommonPathInternalCh(STM32_ADC_COMMON_INSTANCE(adc));
 
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
+	LL_ADC_SetCommonPathInternalCh(STM32_ADC_COMMON_INSTANCE(adc),
 					path & ~LL_ADC_PATH_INTERNAL_VBAT);
 }
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_vbat) */
@@ -51,12 +57,20 @@ static void stm32_vbat_disable_vbatsensor_channel(ADC_TypeDef *adc)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_vddcore)
 static void stm32_vbat_enable_vddcore_channel(ADC_TypeDef *adc)
 {
+#if defined(CONFIG_SOC_SERIES_STM32H5X)
 	LL_ADC_EnableChannelVDDcore(adc);
+#else /* CONFIG_SOC_SERIES_STM32H5X */
+	LL_ADC_SetPathInternalChAdd(adc, LL_ADC_PATH_INTERNAL_VDDCORE);
+#endif /* CONFIG_SOC_SERIES_STM32H5X */
 }
 
 static void stm32_vbat_disable_vddcore_channel(ADC_TypeDef *adc)
 {
+#if defined(CONFIG_SOC_SERIES_STM32H5X)
 	LL_ADC_DisableChannelVDDcore(adc);
+#else /* CONFIG_SOC_SERIES_STM32H5X */
+	LL_ADC_SetPathInternalChRem(adc, LL_ADC_PATH_INTERNAL_VDDCORE);
+#endif /* CONFIG_SOC_SERIES_STM32H5X */
 }
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32_vddcore) */
 

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1183,6 +1183,12 @@
 		status = "disabled";
 		io-channels = <&adc1 17>;
 	};
+
+	vddcore: vddcore {
+		compatible = "st,stm32-vddcore";
+		io-channels = <&adc2 17>;
+		status = "disabled";
+	};
 };
 
 &nvic {


### PR DESCRIPTION
Extend the VBAT driver to support VDDCORE channel on more STM32 series:
- STM32H7R/S
- STM32MP2
- STM32N6
- STM32U3

This is achieved by using different LL APIs which seem more portable, `LL_ADC_SetPathInternalChAdd()`/`LL_ADC_SetPathInternalChRem()`, which do a RMW operation on our behalf. (One exception is STM32H5 series on which these APIs are not available - how sad!)

As a demonstration platform, add support for the VDDCORE sensor to STM32H7R/S which already has other internal analog sensors. Other series in the list above seem to lack them - implementation is left as a future effort.

Tested OK on `stm32h7s78_dk` using `samples/sensor/soc_voltage`:
```
*** Booting Zephyr OS build v4.4.0-6833-gecef5940a8b5 ***
Sensor voltage[vref]: 3.29 V
Sensor voltage[vbat]: 3.29 V
Sensor voltage[vddcore]: 1.27 V
```