### PR TITLE
i2c: stm32: port IRQ flood and error reporting fixes into the RTIO driver

### DIFF
--- a/drivers/i2c/i2c_stm32_v1.c
+++ b/drivers/i2c/i2c_stm32_v1.c
@@ -644,11 +644,10 @@ int i2c_stm32_error(const struct device *dev)
 
 	if (LL_I2C_IsActiveFlag_BERR(i2c)) {
 		LL_I2C_ClearFlag_BERR(i2c);
-		/* STM32 I2C V1 errata: Spurious Bus Error detection in
-		 * controller mode. Multiple errata sheets document this:
-		 *   - ES0182 (STM32F405/407) §2.10.1
-		 *   - ES0305 (STM32F412)     §2.11.1
-		 *   - ES0206 (STM32F2)       §2.10.1
+		/* Address "Spurious Bus Error detection in controller mode"
+		 * erratum, that affects STM32 I2C v1 controller, referenced
+		 * in multiple errata sheets document like:
+		 * - ES0182 (STM32F41x/41x) Rev 18, section 2.10.1
 		 *
 		 * Workaround: clear the BERR flag and let the ongoing
 		 * transfer continue. If a real bus error has occurred,

--- a/drivers/i2c/i2c_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_stm32_v1_rtio.c
@@ -520,6 +520,16 @@ int i2c_stm32_error(const struct device *dev)
 #endif
 	}
 
+	if (LL_I2C_IsActiveFlag_OVR(i2c)) {
+		LL_I2C_ClearFlag_OVR(i2c);
+#if defined(CONFIG_I2C_TARGET)
+		if (error_cb != NULL) {
+			error_cb(data->target_cfg, I2C_ERROR_GENERIC);
+		}
+#endif
+		goto error;
+	}
+
 	return 0;
 error:
 #if defined(CONFIG_I2C_TARGET)

--- a/drivers/i2c/i2c_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_stm32_v1_rtio.c
@@ -503,12 +503,21 @@ int i2c_stm32_error(const struct device *dev)
 
 	if (LL_I2C_IsActiveFlag_BERR(i2c)) {
 		LL_I2C_ClearFlag_BERR(i2c);
+		/* Address "Spurious Bus Error detection in controller mode"
+		 * erratum, that affects STM32 I2C v1 controller, referenced
+		 * in multiple errata sheets document like:
+		 * - ES0182 (STM32F41x/41x) Rev 18, section 2.10.1
+		 *
+		 * Workaround: clear the BERR flag and let the ongoing
+		 * transfer continue. If a real bus error has occurred,
+		 * the transfer will eventually time out.
+		 */
 #if defined(CONFIG_I2C_TARGET)
 		if (error_cb != NULL) {
 			error_cb(data->target_cfg, I2C_ERROR_GENERIC);
 		}
-#endif
 		goto error;
+#endif
 	}
 
 	return 0;

--- a/drivers/i2c/i2c_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_stm32_v1_rtio.c
@@ -181,6 +181,11 @@ static void handle_txe(const struct device *dev)
 		LL_I2C_TransmitData8(i2c, *data->xfer_buf);
 		data->xfer_buf++;
 	} else {
+		/* All bytes sent. Disable the BUF interrupt so the level-triggered
+		 * TXE flag cannot re-fire the ISR while completing the transfer.
+		 */
+		LL_I2C_DisableIT_BUF(i2c);
+
 		if ((data->xfer_flags & I2C_MSG_STOP) != 0) {
 			LL_I2C_GenerateStopCondition(i2c);
 		}

--- a/drivers/i2c/i2c_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_stm32_v1_rtio.c
@@ -161,6 +161,7 @@ static void handle_addr(const struct device *dev)
 		LL_I2C_EnableBitPOS(i2c);
 	}
 	LL_I2C_ClearFlag_ADDR(i2c);
+	LL_I2C_EnableIT_BUF(i2c);
 }
 
 static void handle_txe(const struct device *dev)
@@ -452,10 +453,16 @@ void i2c_stm32_event(const struct device *dev)
 		handle_addr(dev);
 	} else if (LL_I2C_IsActiveFlag_BTF(i2c)) {
 		handle_btf(dev);
-	} else if (LL_I2C_IsActiveFlag_TXE(i2c) && ((data->xfer_flags & I2C_MSG_READ) == 0)) {
-		handle_txe(dev);
-	} else if (LL_I2C_IsActiveFlag_RXNE(i2c) && ((data->xfer_flags & I2C_MSG_READ) != 0)) {
-		handle_rxne(dev);
+	} else {
+		bool is_write = (data->xfer_flags & I2C_MSG_READ) == 0;
+
+		if (LL_I2C_IsActiveFlag_TXE(i2c) && is_write) {
+			handle_txe(dev);
+		} else if (LL_I2C_IsActiveFlag_TXE(i2c) && !is_write) {
+			LL_I2C_DisableIT_BUF(i2c);
+		} else if (LL_I2C_IsActiveFlag_RXNE(i2c) && !is_write) {
+			handle_rxne(dev);
+		}
 	}
 }
 

--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -764,10 +764,14 @@ int i2c_stm32_error(const struct device *dev)
 		goto end;
 	}
 
-	/* Don't end a transaction on bus error in controller mode
-	 * as errata sheet says that spurious false detections
-	 * of BERR can happen which shall be ignored.
-	 * If a real Bus Error occurs, transaction will time out.
+	/* Address "Spurious Bus Error detection in controller mode"
+	 * erratum, that affects STM32 I2C v2 controller, referenced
+	 * in multiple errata sheets document like:
+	 * - ES0392 (STM32H74x/75x), Rev 15, section 2.19.4
+	 *
+	 * Workaround: clear the BERR flag and let the ongoing
+	 * transfer continue. If a real bus error has occurred,
+	 * the transfer will eventually time out.
 	 */
 	if (LL_I2C_IsActiveFlag_BERR(i2c)) {
 		LL_I2C_ClearFlag_BERR(i2c);

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -607,6 +607,27 @@ int i2c_stm32_error(const struct device *dev)
 		ret = -EIO;
 	}
 
+	/* Address "Spurious Bus Error detection in controller mode"
+	 * erratum, that affects STM32 I2C v2 controller, referenced
+	 * in multiple errata sheets document like:
+	 * - ES0392 (STM32H74x/75x), Rev 15, section 2.19.4
+	 *
+	 * Workaround: clear the BERR flag and let the ongoing
+	 * transfer continue. If a real bus error has occurred,
+	 * the transfer will eventually time out.
+	 */
+	if (LL_I2C_IsActiveFlag_BERR(i2c)) {
+		LL_I2C_ClearFlag_BERR(i2c);
+#if defined(CONFIG_I2C_TARGET)
+		if (!data->controller_active) {
+			if (error_cb != NULL) {
+				error_cb(data->target_cfg, I2C_ERROR_GENERIC);
+			}
+			ret = -EIO;
+		}
+#endif
+	}
+
 #if defined(CONFIG_I2C_TARGET)
 	if (data->target_attached && !data->controller_active) {
 		return ret;


### PR DESCRIPTION
This P-R ports recent fixes made in STM32 I2C not-RTIO native drivers into the native RTIO drivers.

* Ports P-R [106888](https://github.com/zephyrproject-rtos/zephyr/pull/106888) related to Issue [106871](https://github.com/zephyrproject-rtos/zephyr/issues/106871) regarding IRQ floods, applicable to **i2c_stm32_v1_rtio.c** only;
* Ports P-R [107883](https://github.com/zephyrproject-rtos/zephyr/pull/107883) and fix BERR reporting in **i2c_stm32_v1_rtio.c** and to add BERR reporting in **i2c_stm32_v2_rtio.c**;
* Add overrun error reporting in **i2c_stm32_v2_rtio.c** that was missing.