### PR TITLE
drivers: display: st7567: fix set_contrast to accept 0-255 range

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -220,6 +220,11 @@ Display
 * The Kconfig options ``CONFIG_ST730X_POWERMODE_LOW`` for ST7305 and ST7306 displays has been
   removed in favour of toggling the low-power-mode property on the device node.
 
+* The ``set_contrast`` function of the ST7567 display driver now expects a contrast value in the
+  range 0-255, instead of 0-63. The driver now scales the value to the 6-bit range expected by the
+  controller. The ``CONFIG_ST7567_DEFAULT_CONTRAST`` Kconfig option has been updated to reflect the
+  new range. (:github:`112528`)
+
 DMA
 ===
 

--- a/drivers/display/Kconfig.st7567
+++ b/drivers/display/Kconfig.st7567
@@ -14,8 +14,8 @@ if ST7567
 
 config ST7567_DEFAULT_CONTRAST
 	int "ST7567 default contrast"
-	default 8
-	range 0 15
+	default 127
+	range 0 255
 	help
 	  ST7567 default contrast.
 

--- a/drivers/display/display_st7567.c
+++ b/drivers/display/display_st7567.c
@@ -359,7 +359,7 @@ static int st7567_set_contrast(const struct device *dev, const uint8_t contrast)
 {
 	uint8_t cmd_buf[] = {
 		ST7567_SET_CONTRAST_CTRL,
-		contrast,
+		contrast >> 2,
 	};
 
 	return st7567_write_cmd_bus(dev, cmd_buf, sizeof(cmd_buf));


### PR DESCRIPTION
Fix for #112528:

The set_contrast function of the ST7567 display driver now expects a contrast value in the range 0-255, instead of 0-63. The driver now scales the value to the 6-bit range expected by the controller.
CONFIG_ST7567_DEFAULT_CONTRAST has been updated.