### PR TITLE
net: dns: Deprecate LLMNR support

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -884,6 +884,15 @@ Networking
   for embedded Wi-Fi use cases. Users who need the previous behaviour can restore it by enabling
   :kconfig:option:`CONFIG_WIFI_NM_WPA_SUPPLICANT_NW_SEL_THROUGHPUT`.
 
+* LLMNR support has been deprecated. The Kconfig options
+  :kconfig:option:`CONFIG_LLMNR_RESOLVER` and
+  :kconfig:option:`CONFIG_LLMNR_RESPONDER` will be removed in a future release
+  (4.7 at the earliest). LLMNR (RFC 4795) is being retired by Microsoft and is
+  disabled by default on modern Windows. Applications that rely on local name
+  resolution should migrate to mDNS (:kconfig:option:`CONFIG_MDNS_RESOLVER` /
+  :kconfig:option:`CONFIG_MDNS_RESPONDER`).
+
+
 Ethernet
 ========
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -137,6 +137,13 @@ Deprecated APIs and options
     :c:func:`ring_buf_item_get`, :c:func:`ring_buf_item_space_get`) has been deprecated in favor of
     :c:struct:`sys_ringq` (see :ref:`fixed_size_ringq_api`).
 
+* Networking
+
+  * Deprecated LLMNR support (:kconfig:option:`CONFIG_LLMNR_RESOLVER` and
+    :kconfig:option:`CONFIG_LLMNR_RESPONDER`). LLMNR is being phased out; use
+    mDNS (:kconfig:option:`CONFIG_MDNS_RESOLVER` /
+    :kconfig:option:`CONFIG_MDNS_RESPONDER`) instead.
+
 * Networking Link layer
 
   * Deprecated :kconfig:option:`CONFIG_NET_L2_PTP`.

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -26,13 +26,18 @@ config MDNS_RESOLVER
 	  See RFC 6762 for details.
 
 config LLMNR_RESOLVER
-	bool "LLMNR support"
+	bool "LLMNR support [DEPRECATED]"
+	select DEPRECATED
 	help
 	  This option enables link local multicast name resolution client side
 	  support. See RFC 4795 for details. LLMNR is typically used by Windows
 	  hosts. If you enable this option, then the DNS requests are ONLY sent
 	  to LLMNR well known multicast address 224.0.0.252:5355 or
 	  [ff02::1:3]:5355 and other DNS server addresses are ignored.
+
+	  LLMNR is being phased out (Microsoft is retiring it) and this option
+	  is deprecated and will be removed in a future release. Use mDNS
+	  (CONFIG_MDNS_RESOLVER) or unicast DNS instead.
 
 config DNS_RESOLVER_ADDITIONAL_QUERIES
 	int "Additional DNS queries"
@@ -337,7 +342,8 @@ config MDNS_RESOLVER_ADDITIONAL_BUF_CTR
 endif # MDNS_RESPONDER
 
 config LLMNR_RESPONDER
-	bool "LLMNR responder"
+	bool "LLMNR responder [DEPRECATED]"
+	select DEPRECATED
 	select NET_IPV4_IGMP if NET_IPV4
 	select NET_IPV6_MLD if NET_IPV6
 	select NET_MGMT
@@ -355,6 +361,10 @@ config LLMNR_RESPONDER
 	  so there should be NO dot (".") in the name (RFC 4795 ch 3).
 	  Current implementation does not support TCP.
 	  See RFC 4795 for more details about LLMNR.
+
+	  LLMNR is being phased out (Microsoft is retiring it) and this option
+	  is deprecated and will be removed in a future release. Use the mDNS
+	  responder (CONFIG_MDNS_RESPONDER) instead.
 
 if LLMNR_RESPONDER
 


### PR DESCRIPTION
Link-Local Multicast Name Resolution (LLMNR, RFC 4795) is being phased out. Microsoft is retiring the protocol and it is disabled by default on modern Windows for security reasons. mDNS is the modern replacement and Zephyr already provides both an mDNS resolver and responder.

Deprecate the LLMNR resolver and responder Kconfig options by selecting DEPRECATED and marking the prompts with [DEPRECATED]. Enabling either option now emits a deprecation warning when the Kconfig tree is parsed. The feature still works during the deprecation period; per the API lifecycle policy it can be removed after two full releases (5.0 at the earliest).

Document the deprecation in the 4.5 release notes and migration guide, pointing users to mDNS (CONFIG_MDNS_RESOLVER / CONFIG_MDNS_RESPONDER).

Assisted-by: Claude:claude-opus-4-8