### PR TITLE
drivers: memc: is66wv: Assign endianness from DT

### DIFF
--- a/drivers/memc/memc_mspi_is66wv.c
+++ b/drivers/memc/memc_mspi_is66wv.c
@@ -464,7 +464,8 @@ static int memc_mspi_is66wv_init(const struct device *psram)
 		.io_mode                = MSPI_IO_MODE_SINGLE,                                     \
 		.data_rate              = MSPI_DATA_RATE_SINGLE,                                   \
 		.cpp                    = MSPI_CPP_MODE_0,                                         \
-		.endian                 = MSPI_XFER_LITTLE_ENDIAN,                                 \
+		.endian                 = DT_ENUM_IDX_OR(DT_DRV_INST(n), mspi_endian,              \
+							 MSPI_XFER_BIG_ENDIAN),                    \
 		.ce_polarity            = MSPI_CE_ACTIVE_LOW,                                      \
 		.dqs_enable             = false,                                                   \
 		.rx_dummy               = 8,                                                       \


### PR DESCRIPTION
Replace the hardcoded `MSPI_XFER_LITTLE_ENDIAN` value in `MSPI_DEVICE_CONFIG_INIT()` with `DT_ENUM_IDX_OR()`, so the `init_cfg` endian field is driven by the `mspi-endian` property of the device node when present, falling back to big-endian when the property is absent.