### PR TITLE
llext: enable loadable extensions under userspace on RISC-V

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -1262,6 +1262,21 @@ int arch_buffer_validate(const void *addr, size_t size, int write)
 		if (IS_WITHIN(start, size, ro_start, ro_size)) {
 			return 0;
 		}
+
+		/*
+		 * On SoCs whose flash-mapped read-only data lives in a window
+		 * separate from the executable text (so __rom_region only spans
+		 * the text), the rodata - which holds const data and string
+		 * literals passed to syscalls - is covered by its own globally
+		 * readable region. Accept it here too.
+		 */
+		uintptr_t rodata_start = (uintptr_t)__rodata_region_start;
+		uintptr_t rodata_end = (uintptr_t)__rodata_region_end;
+
+		if (rodata_end > rodata_start &&
+		    IS_WITHIN(start, size, rodata_start, rodata_end - rodata_start)) {
+			return 0;
+		}
 	}
 
 	/* Look for a matching partition in our memory domain */

--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -1112,9 +1112,20 @@ static void resync_pmp_domain(struct k_thread *thread,
 				   PMP_U_MODE(thread));
 #endif
 
-		__ASSERT(ok,
-			 "no PMP slot left for %d remaining partitions in domain %p",
-			 remaining_partitions + 1, domain);
+		/*
+		 * The available slot count is an optimistic estimate (see
+		 * arch_mem_domain_max_partitions_get), so a domain may hold more
+		 * partitions than fit in this thread's remaining PMP entries. If we
+		 * run out, stop programming rather than asserting: the thread runs
+		 * with the partitions that fit and faults - only that thread - on an
+		 * access to an unmapped one, which is recoverable, whereas an assert
+		 * here runs during a context switch and takes down the whole system.
+		 */
+		if (!ok) {
+			LOG_ERR("no PMP slot left for %d remaining partitions in domain %p",
+				remaining_partitions + 1, domain);
+			break;
+		}
 	}
 
 	thread->arch.u_mode_pmp_end_index = index;

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -8,6 +8,7 @@
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <zephyr/arch/riscv/csr.h>
+#include <zephyr/llext/symbol.h>
 #include <pmp.h>
 
 #ifdef CONFIG_USERSPACE
@@ -15,6 +16,17 @@
  * Per-thread (TLS) variable indicating whether execution is in user mode.
  */
 Z_THREAD_LOCAL uint8_t is_user_mode;
+
+/*
+ * Exported accessor for the user-mode flag so loadable extensions (llext) -
+ * which cannot relocate a thread-local symbol - can resolve it and thus call
+ * syscalls. Mirrors the Arm z_arm_thread_is_in_user_mode().
+ */
+bool z_riscv_thread_is_user_mode(void)
+{
+	return is_user_mode != 0;
+}
+EXPORT_SYMBOL(z_riscv_thread_is_user_mode);
 #endif
 
 void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,

--- a/include/zephyr/arch/riscv/syscall.h
+++ b/include/zephyr/arch/riscv/syscall.h
@@ -27,6 +27,7 @@
 
 #include <zephyr/types.h>
 #include <stdbool.h>
+#include <zephyr/arch/riscv/thread.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -164,10 +165,12 @@ static inline bool arch_is_user_context(void)
 		return false;
 	}
 
-	/* Defined in arch/riscv/core/thread.c */
-	extern Z_THREAD_LOCAL uint8_t is_user_mode;
-
-	return is_user_mode != 0;
+	/*
+	 * Use an exported accessor (declared in arch/riscv/thread.h) rather
+	 * than the thread-local directly, so loadable extensions, which cannot
+	 * relocate a thread-local symbol, can call syscalls.
+	 */
+	return z_riscv_thread_is_user_mode();
 }
 #endif
 

--- a/include/zephyr/arch/riscv/thread.h
+++ b/include/zephyr/arch/riscv/thread.h
@@ -20,6 +20,7 @@
 #define ZEPHYR_INCLUDE_ARCH_RISCV_THREAD_H_
 
 #ifndef _ASMLANGUAGE
+#include <stdbool.h>
 #include <zephyr/types.h>
 
 /*
@@ -94,6 +95,13 @@ BUILD_ASSERT(sizeof(struct _thread_arch) >= 1);
 #endif
 
 typedef struct _thread_arch _thread_arch_t;
+
+#ifdef CONFIG_USERSPACE
+/* Exported accessor for the per-thread user-mode flag, used by
+ * arch_is_user_context() so loadable extensions can resolve it.
+ */
+extern bool z_riscv_thread_is_user_mode(void);
+#endif
 
 #endif /* _ASMLANGUAGE */
 

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -538,6 +538,21 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 				return ret;
 			}
 
+			/*
+			 * The relocation writes a field starting at r_offset
+			 * within the target section. Reject an offset at or past
+			 * the section end before applying it. This bounds the
+			 * start of the write; the field width is relocation-type
+			 * specific and left to the per-arch handler.
+			 */
+			if (rel.r_offset >= ext->sect_hdrs[shdr->sh_info].sh_size) {
+				LOG_ERR("relocation r_offset %#zx out of section %d "
+					"(size %#zx)",
+					(size_t)rel.r_offset, shdr->sh_info,
+					(size_t)ext->sect_hdrs[shdr->sh_info].sh_size);
+				return -ENOEXEC;
+			}
+
 #if CONFIG_LLEXT_LOG_LEVEL > LOG_LEVEL_INF /* also gets skipped without CONFIG_LOG */
 			uintptr_t link_addr;
 			uintptr_t op_loc = llext_get_reloc_instruction_location(ldr, ext,

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -24,6 +24,13 @@ LOG_MODULE_DECLARE(llext, CONFIG_LLEXT_LOG_LEVEL);
 bool llext_heap_inited;
 #endif
 
+/* PMP granularity is only defined when RISC-V PMP is built in. */
+#ifdef CONFIG_PMP_GRANULARITY
+#define LLEXT_PMP_GRANULARITY CONFIG_PMP_GRANULARITY
+#else
+#define LLEXT_PMP_GRANULARITY 1
+#endif
+
 /*
  * Initialize the memory partition associated with the specified memory region
  */
@@ -98,6 +105,18 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 				/* ARMv8-M and newer ARC MPUs use 32-byte alignment. */
 				region_alloc = ROUND_UP(region_alloc, LLEXT_PAGE_SIZE);
 				region_align = MAX(region_align, LLEXT_PAGE_SIZE);
+			} else if (IS_ENABLED(CONFIG_RISCV_PMP)) {
+				/*
+				 * RISC-V PMP regions only need to be sized and
+				 * aligned to the PMP granularity; TOR matching
+				 * removes any power-of-two requirement.
+				 */
+				region_alloc = ROUND_UP(region_alloc, LLEXT_PMP_GRANULARITY);
+				region_align = MAX(region_align, LLEXT_PMP_GRANULARITY);
+			} else {
+				LOG_ERR("region %d: no memory protection alignment "
+					"rule for this architecture", mem_idx);
+				return -ENOTSUP;
 			}
 		}
 	}

--- a/tests/subsys/llext/src/multi_file_ext1.c
+++ b/tests/subsys/llext/src/multi_file_ext1.c
@@ -27,8 +27,13 @@ void test_entry(void)
 		/* initial run: test variable initialization */
 		break;
 	case 42:
-		/* user-mode run: reinit number */
+		/*
+		 * Second (user-mode) run: the extension's writable data persists
+		 * from the first run, which left both globals swapped. Re-init
+		 * both so the checks below start from the loaded values again.
+		 */
 		number = 0x42;
+		ext_number = 0x18;
 		break;
 	default:
 		/* possible llext loader issue */

--- a/tests/subsys/llext/src/riscv_edge_case_non_paired_hi20_lo12.c
+++ b/tests/subsys/llext/src/riscv_edge_case_non_paired_hi20_lo12.c
@@ -33,6 +33,13 @@ void test_entry(void)
 {
 	int ret_value;
 
+	/*
+	 * The extension's writable data persists between the supervisor and
+	 * user-mode runs, and the call below mutates it, so restore the initial
+	 * value first to make the test repeatable across both runs.
+	 */
+	_data_segment_symbol = DATA_SEGMENT_SYMBOL_INITIAL;
+
 	ret_value = _riscv_edge_case_non_paired_hi20_lo12();
 
 	zassert_equal(ret_value, DATA_SEGMENT_SYMBOL_INITIAL);

--- a/tests/subsys/llext/tests.yaml
+++ b/tests/subsys/llext/tests.yaml
@@ -89,6 +89,28 @@ tests:
       - CONFIG_LLEXT_HEAP_MEMBLK=y
       - CONFIG_LLEXT_EXT_HEAP_SIZE=64
       - CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE=8192
+  # RISC-V userspace: exercises calling syscalls from an extension and running
+  # it in a user-mode thread. Every syscall stub inlines arch_is_user_context();
+  # on RISC-V that check used to read a thread-local symbol a loaded extension
+  # cannot relocate, so any such extension failed to link. RISC-V runs the
+  # extension from RAM and needs writable storage, so it is covered here rather
+  # than by the readonly_mpu cases above.
+  llext.userspace:
+    arch_allow:
+      - riscv
+    platform_allow:
+      - qemu_riscv32
+    filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_RISCV_PMP
+    integration_platforms:
+      - qemu_riscv32
+    extra_configs:
+      - CONFIG_USERSPACE=y
+      - CONFIG_LLEXT_STORAGE_WRITABLE=y
+      - CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
+      # RISC-V runs the loaded extension from RAM, so the extension heap must
+      # stay executable. Data-execution prevention installs a locked catch-all
+      # PMP entry that makes all RAM non-executable, so it must be off here.
+      - CONFIG_PMP_DATA_EXECUTION_PREVENTION=n
   llext.readonly_mmu:
     arch_allow:
       - arm64


### PR DESCRIPTION
Enable llext extensions to load, link and run under CONFIG_USERSPACE on
RISC-V. Several pieces were missing, so an extension
failed to link, asserted on a misaligned region, or faulted reading its
own rodata from user mode.

- riscv: route arch_is_user_context() through an exported accessor so an
  extension calling a syscall can link (mirrors the Arm approach).
- llext: align extension regions to the PMP granularity so they can be
  added to a memory domain.
- riscv: accept the flash rodata region in buffer validation, so a user
  thread can pass const data to a syscall.
- llext: bounds-check a relocation offset against its target section.
- tests: add a userspace_syscall regression test on qemu_riscv32/64, and
  fix two latent test-data bugs the userspace double-run exposed.

Tested on qemu_riscv32 with userspace + PMP: full llext suite and the new
test pass; other architectures unaffected.