### PR TITLE
MAINTAINERS: move alwa-nordic to collaborator for Bluetooth

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -644,8 +644,8 @@ Bluetooth HCI:
   status: maintained
   maintainers:
     - jhedberg
-    - alwa-nordic
   collaborators:
+    - alwa-nordic
     - hermabe
     - Thalley
     - sjanc
@@ -670,8 +670,8 @@ Bluetooth Host:
   status: maintained
   maintainers:
     - jhedberg
-    - alwa-nordic
   collaborators:
+    - alwa-nordic
     - hermabe
     - rugeGerritsen
     - sjanc


### PR DESCRIPTION
I'm moving myself from maintainer to collaborator in the MAINTAINERS file.

I'm stepping down as maintainer for Bluetooth HCI and Bluetooth Host, as per agreement with @jhedberg. This is part of an action to streamline maintainer and collaborator designations to avoid diffusion of responsibility and reflect expected responsiveness and available effort to tend to PRs and reported issues. We both believe clarifying and holding role statuses in high regards will lead to a more cohesive and responsive subsystem community.

I wish to continue as an active collaborator and @jhedberg approves. I remain as deputy chairman in the Zephyr Bluetooth work group. @jhedberg and I treat that as distinct from the maintainer position.