### PR TITLE
kernel: Revert intel_adsp_timer

### DIFF
--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -134,12 +134,20 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #ifdef CONFIG_TICKLESS_KERNEL
-	ticks = MIN(ticks, MAX_TICKS);
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	uint64_t curr = count();
 	uint64_t next;
-	uint32_t cyc = ticks * CYC_PER_TICK;
+	uint32_t adj, cyc = ticks * CYC_PER_TICK;
 
+	/* Round up to next tick boundary */
+	adj = (uint32_t)(curr - last_count) + (CYC_PER_TICK - 1);
+	if (cyc <= MAX_CYC - adj) {
+		cyc += adj;
+	} else {
+		cyc = MAX_CYC;
+	}
+	cyc = (cyc / CYC_PER_TICK) * CYC_PER_TICK;
 	next = last_count + cyc;
 
 	if (((uint32_t)next - (uint32_t)curr) < MIN_DELAY) {

--- a/tests/kernel/context/Kconfig
+++ b/tests/kernel/context/Kconfig
@@ -5,6 +5,7 @@ config MAX_IDLE_WAKES
 	int "Maximum number of spurious wakes during k_cpu_idle() test"
 	default 1 if NRF53_SYNC_RTC
 	default 1 if RENESAS_RX_TIMER_CMT
+	default 1 if INTEL_ADSP_SIM
 	default 0
 	help
 	  The platform may have some component running in the background while the k_cpu_idle test is
@@ -12,6 +13,10 @@ config MAX_IDLE_WAKES
 	  for each 10ms idle test, which by default should be 0. The RX CMT driver uses a 16-bit
 	  counter that cannot span more than one tick, so it has to schedule multi-tick timeouts in
 	  stages and delivers an intermediate tick announcement before the requested deadline.
+	  The Intel ADSP simulator may encounter an edge condition (which does not occur
+	  on hardware) that permits it to harmlessly wake 1 tick early, reset the timer,
+	  and then continue normally.
+
 
 # Include Zephyr's Kconfig
 source "Kconfig"


### PR DESCRIPTION
Reverts the "simplification" made tot he intel_adsp_timer. It turns out that the simplification that was made to the timer to resolve a test issue on the simulator did not translate well to actual hardware.

To resolve that original test issue, the test has been modified to allow for a single spurious interrupt that can occur on the simulator (but not on actual hardware).

Note: This revert will conflict with changes proposed in #111022. Depending upon which gets merged first, the other will need to be updated.