### PR TITLE
drivers: wifi: nrf_wifi: Hold interface dormant until authorized

### DIFF
--- a/drivers/wifi/nrf_wifi/inc/wpa_supp_if.h
+++ b/drivers/wifi/nrf_wifi/inc/wpa_supp_if.h
@@ -37,6 +37,9 @@ int nrf_wifi_wpa_supp_associate(void *if_priv, struct wpa_driver_associate_param
 
 int nrf_wifi_wpa_set_supp_port(void *if_priv, int authorized, char *bssid);
 
+int nrf_wifi_wpa_tx_control_port(void *if_priv, const unsigned char *dest, unsigned short proto,
+				 const unsigned char *buf, size_t len, int no_encrypt);
+
 int nrf_wifi_wpa_supp_signal_poll(void *if_priv, struct wpa_signal_info *si,
 				 unsigned char *bssid);
 

--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -943,6 +943,7 @@ static const struct zep_wpa_supp_dev_ops wpa_supp_ops = {
 	.authenticate = nrf_wifi_wpa_supp_authenticate,
 	.associate = nrf_wifi_wpa_supp_associate,
 	.set_supp_port = nrf_wifi_wpa_set_supp_port,
+	.tx_control_port = nrf_wifi_wpa_tx_control_port,
 	.set_key = nrf_wifi_wpa_supp_set_key,
 	.signal_poll = nrf_wifi_wpa_supp_signal_poll,
 	.send_mlme = nrf_wifi_nl80211_send_mlme,

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -249,7 +249,15 @@ static void nrf_wifi_net_iface_work_handler(struct k_work *work)
 	}
 
 	if (vif_ctx_zep->if_carr_state == NRF_WIFI_FMAC_IF_CARR_STATE_ON) {
-		net_if_dormant_off(vif_ctx_zep->zep_net_if_ctx);
+		/* For STA mode, keep the interface dormant on association and only
+		 * clear it once the controlled port is authorized (see
+		 * nrf_wifi_wpa_set_supp_port). This withholds data TX during the
+		 * 802.1X handshake window while EAPOL still flows out-of-band via
+		 * the control port (nrf_wifi_wpa_tx_control_port).
+		 */
+		if (vif_ctx_zep->if_type != NRF_WIFI_IFTYPE_STATION) {
+			net_if_dormant_off(vif_ctx_zep->zep_net_if_ctx);
+		}
 	} else if (vif_ctx_zep->if_carr_state == NRF_WIFI_FMAC_IF_CARR_STATE_OFF) {
 		net_if_dormant_on(vif_ctx_zep->zep_net_if_ctx);
 	}
@@ -510,6 +518,129 @@ unlock:
 #endif /* CONFIG_NRF70_DATA_TX */
 
 out:
+	return ret;
+}
+
+int nrf_wifi_wpa_tx_control_port(void *if_priv, const unsigned char *dest, unsigned short proto,
+				 const unsigned char *buf, size_t len, int no_encrypt)
+{
+	int ret = -EINVAL;
+#ifdef CONFIG_NRF70_DATA_TX
+	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = if_priv;
+	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
+	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx = NULL;
+	struct rpu_host_stats *host_stats = NULL;
+	struct net_linkaddr *link_addr = NULL;
+	struct net_if *iface = NULL;
+	struct net_eth_hdr eth_hdr;
+	struct net_pkt *pkt = NULL;
+	void *nbuf = NULL;
+	bool locked = false;
+
+	ARG_UNUSED(no_encrypt);
+
+	if (!vif_ctx_zep || !dest || !buf) {
+		LOG_ERR("%s: Invalid params", __func__);
+		goto out;
+	}
+
+	iface = vif_ctx_zep->zep_net_if_ctx;
+	if (!iface) {
+		LOG_ERR("%s: iface is NULL", __func__);
+		goto out;
+	}
+
+	link_addr = net_if_get_link_addr(iface);
+
+	/* Build the Ethernet frame carrying the EAPOL payload and hand it straight
+	 * to the driver TX path. This bypasses the networking stack so that the
+	 * handshake is not gated by the interface operational state (the interface
+	 * is held dormant until the controlled port is authorized).
+	 */
+	pkt = net_pkt_alloc_with_buffer(iface, sizeof(struct net_eth_hdr) + len,
+					NET_AF_UNSPEC, 0, K_MSEC(100));
+	if (!pkt) {
+		LOG_ERR("%s: Failed to allocate net_pkt", __func__);
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	memcpy(eth_hdr.dst.addr, dest, sizeof(eth_hdr.dst.addr));
+	memcpy(eth_hdr.src.addr, link_addr->addr, sizeof(eth_hdr.src.addr));
+	eth_hdr.type = net_htons(proto);
+
+	if (net_pkt_write(pkt, &eth_hdr, sizeof(eth_hdr)) ||
+	    net_pkt_write(pkt, buf, len)) {
+		LOG_ERR("%s: Failed to write EAPOL frame", __func__);
+		net_pkt_unref(pkt);
+		ret = -ENOBUFS;
+		goto out;
+	}
+
+	net_pkt_cursor_init(pkt);
+
+	nbuf = net_pkt_to_nbuf(pkt);
+	net_pkt_unref(pkt);
+	if (!nbuf) {
+		LOG_ERR("%s: nbuf allocation failed", __func__);
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	ret = k_mutex_lock(&vif_ctx_zep->vif_lock, K_FOREVER);
+	if (ret != 0) {
+		LOG_ERR("%s: Failed to lock vif_lock", __func__);
+		goto drop;
+	}
+	locked = true;
+
+	rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;
+	if (!rpu_ctx_zep || !rpu_ctx_zep->rpu_ctx) {
+		ret = -ENODEV;
+		goto drop;
+	}
+
+	sys_dev_ctx = wifi_dev_priv(rpu_ctx_zep->rpu_ctx);
+	host_stats = &sys_dev_ctx->host_stats;
+
+	if (vif_ctx_zep->if_carr_state != NRF_WIFI_FMAC_IF_CARR_STATE_ON) {
+		LOG_DBG("%s: Carrier not ON, dropping EAPOL frame", __func__);
+		ret = -ENETDOWN;
+		goto drop;
+	}
+
+	ret = nrf_wifi_fmac_start_xmit(rpu_ctx_zep->rpu_ctx, vif_ctx_zep->vif_idx, nbuf);
+	/* FMAC owns the nbuf from here on (and frees it on failure) */
+	nbuf = NULL;
+	if (ret == NRF_WIFI_STATUS_FAIL) {
+		host_stats->total_tx_drop_pkts++;
+		ret = -ENOBUFS;
+		goto unlock;
+	}
+
+	ret = 0;
+	goto unlock;
+drop:
+	if (host_stats != NULL) {
+		host_stats->total_tx_drop_pkts++;
+	}
+	if (nbuf != NULL) {
+		nrf_wifi_osal_nbuf_free(nbuf);
+	}
+unlock:
+	if (locked) {
+		k_mutex_unlock(&vif_ctx_zep->vif_lock);
+	}
+out:
+#else
+	ARG_UNUSED(if_priv);
+	ARG_UNUSED(dest);
+	ARG_UNUSED(proto);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(no_encrypt);
+#endif /* CONFIG_NRF70_DATA_TX */
+
 	return ret;
 }
 

--- a/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
+++ b/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
@@ -1122,6 +1122,7 @@ int nrf_wifi_wpa_set_supp_port(void *if_priv, int authorized, char *bssid)
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
 	struct nrf_wifi_sys_fmac_dev_ctx *sys_dev_ctx;
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+	bool update_dormant = false;
 	int ret = -1;
 
 	if (!if_priv || !bssid) {
@@ -1178,11 +1179,25 @@ int nrf_wifi_wpa_set_supp_port(void *if_priv, int authorized, char *bssid)
 
 	if (vif_ctx_zep->if_type == NRF_WIFI_IFTYPE_STATION) {
 		sys_dev_ctx->tx_config.peers[0].authorized = authorized;
+		update_dormant = true;
 	}
 
 	ret = 0;
 out:
 	k_mutex_unlock(&vif_ctx_zep->vif_lock);
+
+	/* Toggle dormant outside vif_lock: bringing the interface operational
+	 * runs net stack callbacks that may queue TX (which takes vif_lock).
+	 * Data TX is withheld until the controlled port is authorized (EAPOL
+	 * uses the control port), avoiding transmits into the closed port.
+	 */
+	if (update_dormant) {
+		if (authorized) {
+			net_if_dormant_off(vif_ctx_zep->zep_net_if_ctx);
+		} else {
+			net_if_dormant_on(vif_ctx_zep->zep_net_if_ctx);
+		}
+	}
 	return ret;
 }
 
@@ -1830,6 +1845,11 @@ int nrf_wifi_supp_get_capa(void *if_priv, struct wpa_driver_capa *capa)
 	capa->flags |= WPA_DRIVER_FLAGS_SME;
 	capa->flags |= WPA_DRIVER_FLAGS_SAE;
 	capa->flags |= WPA_DRIVER_FLAGS_SET_KEYS_AFTER_ASSOC_DONE;
+	/* Route EAPOL TX through the driver control port (tx_control_port op)
+	 * instead of the networking stack, so the handshake is not gated by the
+	 * interface operational state.
+	 */
+	capa->flags |= WPA_DRIVER_FLAGS_CONTROL_PORT;
 	capa->rrm_flags |= WPA_DRIVER_FLAGS_SUPPORT_RRM;
 	capa->rrm_flags |= WPA_DRIVER_FLAGS_SUPPORT_BEACON_REPORT;
 	if (IS_ENABLED(CONFIG_NRF70_AP_MODE)) {

--- a/west.yml
+++ b/west.yml
@@ -294,7 +294,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: e97765d250aad14e0d2495a3fd5d4d9354a408df
+      revision: 568e4423c76ec70b2ea9a5ed43085af9a29999ec
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
In STA mode the interface was brought operational at association, before
the controlled port was authorized, so the IP stack transmitted data
during the 802.1X handshake window which the driver then dropped with
`-EPERM`.

Advertise `WPA_DRIVER_FLAGS_CONTROL_PORT` and implement the `tx_control_port`
op so EAPOL frames are handed to the driver directly instead of going
through the networking stack. With EAPOL off the data path, keep the
interface dormant from association until the controlled port is
authorized, withholding data TX during authorization while the handshake
still completes.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/112520

---

- [x] HW test ~~pending~~ - _Cherry-picked on downstream v4.4 branch_
- [ ] Verify roaming behavior

Simulated/CI testing would have been nice ;)