### PR TITLE
doc: security: publish disclosed CVEs, register new advisories

### DIFF
--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -338,12 +338,80 @@ Under embargo until 2026-08-08
 :cve:`2026-9263`
 ----------------
 
-Under embargo until 2026-06-28
+Out-of-bounds read in Bluetooth Controller ISOAL framed RX reassembly leaks adjacent memory into host HCI ISO packets
+
+The Zephyr Bluetooth controller ISO Adaptation Layer
+(``subsys/bluetooth/controller/ll_sw/isoal.c``) fails to validate the length field of a
+framed ISO PDU start segment. Per the Bluetooth specification a start segment (``sc=0``)
+always carries a 3-byte ``time_offset``, so its segment-header ``len`` must be at least
+``PDU_ISO_SEG_TIMEOFFSET_SIZE`` (3). ``isoal_check_seg_header()`` accepted start
+segments with ``len`` < 3 as valid, and ``isoal_rx_framed_consume()`` then computed
+``length = seg_hdr->len - 3`` in a ``uint8_t``, underflowing to 253-255 when ``len`` is
+0-2. That oversized length is passed to ``isoal_rx_append_to_sdu()``, whose copy is
+clamped only against the destination SDU buffer size, not the source PDU length, so up
+to ~255 bytes of controller memory beyond the received PDU are copied (via
+``sink_sdu_write_hci()``/``net_buf_add_mem``) into an HCI ISO data packet and delivered
+to the host. The PDU and its segment headers are entirely attacker-controlled and arrive
+over the air, reachable through both the CIS and BIS-sync HCI data paths
+(``hci_driver.c``) and the vendor data path (``ull_iso.c``), so a remote CIS peer or a
+broadcaster the device is synced to can trigger an out-of-bounds read causing
+information disclosure to the host and potential denial of service (faults or malformed
+oversized HCI ISO packets). The flaw affects all Zephyr releases since framed ISO
+reception was introduced in v3.0.0. The fix rejects ``sc=0`` segments with ``len`` < 3
+in ``isoal_check_seg_header()`` and adds a guard before the subtraction in
+``isoal_rx_framed_consume()``.
+
+- `Zephyr project bug tracker GHSA-6gvp-pmh8-fjh2
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-6gvp-pmh8-fjh2>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 109369 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109369>`_
+
+- `PR 109618 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109618>`_
+
+- `PR 109619 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109619>`_
+
+- `PR 109617 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109617>`_
 
 :cve:`2026-10593`
 -----------------
 
-Under embargo until 2026-06-23
+Remotely triggerable NULL-pointer dereference in Bluetooth LE Audio BAP unicast client QoS-state handling
+
+The Zephyr Bluetooth LE Audio Basic Audio Profile (BAP) unicast client mishandles peer-supplied
+ASE state notifications. In ``unicast_client_ep_qos_state()``
+(``subsys/bluetooth/audio/bap_unicast_client.c``), the handler writes attacker-controlled
+QoS fields (``interval``, ``framing``, ``phy``, ``sdu``, ``rtn``,
+``latency``, ``pd``) through the ``stream->qos`` pointer with only a ``stream != NULL``
+guard. ``stream->qos`` is ``NULL`` for any stream that has been codec-configured via
+``bt_bap_stream_config()`` but not yet added to a unicast group (it is set only by
+``unicast_group_add_stream()``). A malicious or buggy remote ASCS server, to which the
+local device is connected as a BAP unicast client, can send a GATT notification
+announcing the ASE has entered the QoS Configured state while the local endpoint is
+still in the Codec Configured state — a transition the dispatcher explicitly permits —
+during that window, causing a write through a NULL pointer and a crash (denial of
+service). The data written is itself remote-controlled. The defect shipped in v4.3.0 and
+v4.4.0 (and earlier). The fix re-points all BAP QoS storage to the always-valid embedded
+``ep->qos`` struct, eliminating the NULL dereference.
+
+- `Zephyr project bug tracker GHSA-22q8-m94g-2pwh
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-22q8-m94g-2pwh>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 104887 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/104887>`_
+
+- `PR 110777 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110777>`_
+
+- `PR 110779 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110779>`_
 
 :cve:`2026-10634`
 -----------------
@@ -697,62 +765,495 @@ This has been fixed in main for v4.5.0
 :cve:`2026-10642`
 -----------------
 
-Under embargo until 2026-06-17
+Unbounded TX busy-loop DoS in Zephyr PL011 UART driver under CTS hardware flow control
+
+The Zephyr PL011 UART driver (``drivers/serial/uart_pl011.c``) contains an unbounded
+software loop in ``pl011_irq_tx_enable()`` that repeatedly invokes the interrupt-driven
+application callback while the TX interrupt mask bit (``PL011_IMSC_TXIM``) is set, to
+work around the controller's level-transition TX-interrupt behavior. When CTS hardware
+flow control is enabled (devicetree hw-flow-control or runtime
+``UART_CFG_FLOW_CTRL_RTS_CTS``) and the wired serial peer de-asserts CTS, the controller
+stops draining the TX FIFO; ``pl011_fifo_fill()`` then returns 0 on every call while the
+application still has pending data and therefore never disables the TX interrupt. The
+loop condition never clears, so the thread that called ``uart_irq_tx_enable()`` (e.g.
+``h4_send()`` in the Bluetooth HCI H4 driver) spins indefinitely, hanging the executing
+context and stalling the transport — a denial of service (CWE-835). An attacker
+controlling the device attached to the UART's CTS line can trigger the hang by
+withholding CTS during transmission. Impact is availability only; there is no memory-safety,
+confidentiality, or integrity consequence. The vulnerable loop was introduced in
+commit b783bc8448ef (Feb 2025) and shipped in releases v4.1.0 through v4.4.0. The fix
+breaks out of the loop when CTS is blocking and arms the CTS modem-status interrupt to
+resume transmission when CTS re-asserts.
+
+- `Zephyr project bug tracker GHSA-3fgh-73jh-2q5j
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3fgh-73jh-2q5j>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 103684 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/103684>`_
+
+- `PR 110767 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110767>`_
+
+- `PR 110768 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110768>`_
 
 :cve:`2026-10643`
 -----------------
 
-Under embargo until 2026-06-19
+Out-of-bounds heap write in Zephyr ``recvmsg()`` ancillary-data path (``insert_pktinfo`` undersizes the control-buffer capacity check)
+
+Zephyr's IP socket ``recvmsg()`` implementation
+(``subsys/net/lib/sockets/sockets_inet.c``, ``insert_pktinfo()``) validated the user-supplied
+ancillary (``msg_control``) buffer using only the payload length
+(``msg->msg_controllen`` < ``pktinfo_len``) before writing a full control message
+consisting of an aligned cmsg header plus the payload. Because the check omitted the
+cmsg header size, a control buffer whose length falls in the under-checked window (e.g.
+16-27 bytes for IPv4 ``IP_PKTINFO`` on a 64-bit target, where a single element actually
+occupies 28 bytes) passes the guard yet causes a fixed-size out-of-bounds write of up to
+one cmsg header (~12 bytes) past the end of the buffer. Under ``CONFIG_USERSPACE`` the
+``recvmsg`` verifier allocates a kernel-heap copy of the control buffer sized to
+``msg_controllen`` and runs the implementation against it, so the overflow corrupts
+kernel heap memory and is triggerable from an unprivileged userspace thread; in
+supervisor mode it corrupts the caller's buffer. The path is reachable on a UDP/IP
+socket with ``IP_PKTINFO``/``IPV6_RECVPKTINFO`` (or hoplimit/timestamping) enabled when
+the application calls ``recvmsg()`` with an undersized control buffer and a datagram is
+received; part of the overwritten bytes (the destination IP in ``ipi_addr``) is
+influenced by the received packet. The fix makes the capacity check use
+``NET_CMSG_SPACE(pktinfo_len)`` (aligned header + aligned data) and returns ``-ENOMEM``
+when the buffer is too small. Affected: v3.6.0 through v4.4.0.
+
+- `Zephyr project bug tracker GHSA-pvf7-7mrp-35w7
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-pvf7-7mrp-35w7>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 106464 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/106464>`_
+
+- `PR 110670 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110670>`_
+
+- `PR 110669 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110669>`_
+
+- `PR 110668 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110668>`_
 
 :cve:`2026-10644`
 -----------------
 
-Under embargo until 2026-06-20
+Out-of-bounds write in Microchip SERCOM-G1 (PIC32CM-JH) async UART RX with 1-byte buffer
+
+The Microchip SERCOM-G1 UART driver (``drivers/serial/uart_mchp_sercom_g1.c``), used by
+the PIC32CM-JH SoC family, contains an out-of-bounds write in its asynchronous (DMA)
+receive path. When ``uart_rx_enable()`` is invoked with a one-byte receive buffer (``len
+== 1``) and ``CONFIG_UART_MCHP_ASYNC`` is enabled, the RX-complete ISR starts a single-beat
+DMA transfer while a received byte is already pending in the SERCOM DATA register.
+On this SoC the peripheral-triggered DMA start sequencing then writes one byte past the
+end of the caller-supplied buffer (CWE-787). The overflowed byte's value is the UART RX
+data supplied by the connected serial peer (adjacent attacker), while its size and
+location are fixed at one byte immediately after the buffer. Exploitation requires the
+async UART config (not enabled by default on the in-tree PIC32CM-JH boards) and a
+consumer that enables RX with a one-byte buffer; impact is limited single-byte memory
+corruption adjacent to the RX buffer (possible crash / denial of service). The defect
+shipped in v4.4.0. The fix reads the first byte with the CPU and, for one-byte buffers,
+performs no DMA at all; for larger buffers it sizes the DMA for the remaining ``len-1``
+bytes.
+
+- `Zephyr project bug tracker GHSA-xv2x-56j7-6wc3
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-xv2x-56j7-6wc3>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107400 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107400>`_
+
+- `PR 110750 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110750>`_
 
 :cve:`2026-10645`
 -----------------
 
-Under embargo until 2026-06-21
+Out-of-bounds read in Zephyr ext2 directory entry traversal from a crafted filesystem image
+
+The Zephyr ext2 filesystem driver (subsys/fs/ext2) trusted the on-disk directory entry
+fields de_rec_len and de_name_len when walking a directory block. ext2_fetch_direntry()
+guarded only with ``de_name_len > EXT2_MAX_FILE_NAME``, but de_name_len is a uint8_t and
+EXT2_MAX_FILE_NAME is 255, so the check is always false; the function then memcpy'd up
+to 255 name bytes and the lookup/readdir paths advanced traversal by an unvalidated
+de_rec_len. Each directory block is read into a block_size-sized slab buffer, and
+block_off can be driven near the block end by preceding entries' rec_len, so the 8-byte
+header read and the subsequent name memcpy can read up to ~263 bytes past the end of the
+block buffer into adjacent heap/slab memory. On the readdir path those bytes are
+returned to the caller in fs_dirent.name, leaking adjacent kernel heap memory; a
+de_rec_len of 0 also causes a zero-progress infinite loop (denial of service), and the
+unlink path's memmove(de, next, next_reclen) over unvalidated records is an additional
+OOB read/write source. The defect is reached by any path-based operation (open, stat,
+unlink, rename, mkdir) or directory listing on a mounted ext2 volume, so a crafted or
+corrupted ext2 image on attacker-supplied storage (SD card, USB mass storage, or
+otherwise mounted image) triggers it. Affected: Zephyr ext2 from its introduction in
+v3.5.0 through v4.4.0. The fix validates rec_len and name_len in the parser and rejects
+entries whose header does not fit the remaining block or whose rec_len crosses the block
+boundary in every traversal caller.
+
+- `Zephyr project bug tracker GHSA-hwrh-9h3x-vccm
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-hwrh-9h3x-vccm>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108226 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108226>`_
+
+- `PR 110030 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110030>`_
+
+- `PR 110033 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110033>`_
+
+- `PR 110031 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110031>`_
 
 :cve:`2026-10646`
 -----------------
 
-Under embargo until 2026-06-22
+Use-after-return in ``zsock_getaddrinfo()`` when a timed-out DNS query is retried without cancellation
+
+Zephyr's BSD-sockets ``getaddrinfo()`` implementation
+(``subsys/net/lib/sockets/getaddrinfo.c``) passes a pointer to a stack-allocated state
+object (``struct getaddrinfo_state ai_state``) as the ``user_data`` of an asynchronous
+DNS resolver query. The socket layer waits on a semaphore with a timeout deliberately
+set slightly longer than the resolver's own per-query timeout. When that semaphore wait
+nonetheless times out (``-EAGAIN``) - which can occur when the resolver's timeout work
+is delayed by workqueue contention, or in the documented multi-retry configuration where
+``CONFIG_NET_SOCKETS_DNS_TIMEOUT`` exceeds ``CONFIG_NET_SOCKETS_DNS_BACKOFF_INTERVAL`` -
+the pre-fix code retries the query (``goto again``) without cancelling the previous one
+and without resetting the semaphore. The previous query slot remains active in the
+resolver with its callback and the stack pointer as ``user_data``, and
+``ai_state->dns_id`` is overwritten so the stale query can no longer be cancelled. A
+subsequent DNS response delivered over UDP and matched by its 16-bit transaction id (in
+``dispatcher_cb()``/``dns_read()``), or the resolver's own delayed query-timeout work,
+then invokes ``dns_resolve_cb()`` against the now out-of-scope stack frame, writing
+through the stale pointer (``state->status``, ``state->idx``, ``state->ai_arr[]``, and
+``k_sem_give()``). Because the triggering response is network-delivered and its 16-bit
+id is spoofable/replayable by an on- or off-path attacker, this is a network-influenceable
+use-after-return that can corrupt reused stack memory, leading to
+crashes/denial of service or memory corruption. The fix cancels the timed-out query by
+name and type before retrying and resets the local semaphore, eliminating the stale
+callback path. Affected: Zephyr v4.0.0 through v4.4.0.
+
+- `Zephyr project bug tracker GHSA-h752-vhmf-29w6
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-h752-vhmf-29w6>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107609 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107609>`_
+
+- `PR 110773 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110773>`_
+
+- `PR 110774 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110774>`_
 
 :cve:`2026-10647`
 -----------------
 
-Under embargo until 2026-06-23
+Deadlock denial of service in USB CDC-NCM device class on TX enqueue failure
+
+The USB CDC-NCM device class (``subsys/usb/device_next/class/usbd_cdc_ncm.c``) ignores
+the return value of ``usbd_ep_enqueue()`` in its ethernet transmit callback
+``cdc_ncm_send()``. When the enqueue fails, the function still calls
+``k_sem_take(&data->sync_sem, K_FOREVER)``, blocking on a completion semaphore that is
+only ever signaled from the bulk-IN transfer-completion callback. Because nothing was
+enqueued, that callback never fires and the calling thread — a shared network traffic-class
+TX thread — deadlocks permanently while holding the interface TX lock, halting
+transmission until reboot (and leaking the transmit buffer).
+
+The enqueue fails under conditions controlled by the attached USB host:
+``usbd_ep_enqueue()`` returns ``-EPERM`` whenever the bus is suspended (a standard,
+persistent host operation), and the underlying ``udc_ep_enqueue()`` returns
+``-EPERM``/``-ENODEV`` on disconnect, bus reset, or endpoint disable. The
+``cdc_ncm_send()`` guard only checks the ``DATA_IFACE_ENABLED`` and ``IFACE_UP`` flags,
+not the suspended state, so a packet transmitted while the host holds the bus suspended
+reaches the failing enqueue and deadlocks the TX path.
+
+The realistic trigger is a bus suspend that occurs while the exported network interface
+is active and has traffic to send — host sleep, USB selective/auto-suspend, or hub power
+management — after which any device-originated packet deadlocks the path, recoverable
+only by reboot. The impact is a persistent loss of the virtual network connection
+between the host's NCM interface and the Zephyr device; because the deadlocked thread is
+a shared traffic-class TX thread, egress on other network interfaces can stall as well.
+There is no memory corruption or information disclosure.
+
+The defect was introduced with the CDC-NCM driver and shipped in releases through
+v4.4.0; it is fixed by checking the ``usbd_ep_enqueue()`` return value and freeing the
+buffer before the blocking wait.
+
+- `Zephyr project bug tracker GHSA-xcf7-r86m-5q9f
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-xcf7-r86m-5q9f>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107126 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107126>`_
+
+- `PR 110653 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110653>`_
+
+- `PR 110652 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110652>`_
 
 :cve:`2026-10648`
 -----------------
 
-Under embargo until 2026-06-26
+NULL-pointer dereference in MCUmgr serial/console SMP transport on buffer-pool exhaustion
+
+``mcumgr_serial_process_frag()`` in ``subsys/mgmt/mcumgr/transport/src/serial_util.c``
+calls ``net_buf_reset()`` on the result of ``smp_packet_alloc()`` before checking it for
+``NULL``. ``smp_packet_alloc()`` uses ``net_buf_alloc(K_NO_WAIT)`` against the shared
+MCUmgr packet pool (``CONFIG_MCUMGR_TRANSPORT_NETBUF_COUNT``, default 4), which returns
+``NULL`` when the pool is exhausted. In default builds the ``__ASSERT_NO_MSG`` in
+``net_buf_reset`` is a no-op, so ``net_buf_simple_reset`` writes through the ``NULL``
+pointer (``buf->len = 0; buf->data = buf->__buf``), causing a fault/crash. The fragment
+data reaches this code from attacker-controlled bytes on the MCUmgr serial/UART/shell-console
+transports (``smp_uart.c``, ``smp_raw_uart.c``, ``smp_shell.c``), and a fresh
+buffer is allocated at the start of essentially every new packet. An attacker on the
+serial/console link can flood the transport to drive the 4-entry buffer pool to
+exhaustion and induce the ``NULL`` dereference, crashing the device (denial of service).
+The defect was introduced after the original MCUmgr rework and shipped in Zephyr v4.4.0.
+The fix moves the ``NULL`` check ahead of ``net_buf_reset``.
+
+- `Zephyr project bug tracker GHSA-j64f-h3ww-f32c
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-j64f-h3ww-f32c>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107812 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107812>`_
+
+- `PR 108026 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108026>`_
 
 :cve:`2026-10651`
 -----------------
 
-Under embargo until 2026-06-26
+Out-of-bounds read in Bluetooth Classic SDP attribute parsing (``bt_sdp_parse_attribute``)
+
+``bt_sdp_parse_attribute()`` in ``subsys/bluetooth/host/classic/sdp.c`` validated only
+that the SDP record buffer held the type-marker byte plus the 2-byte attribute ID (a
+check of ``buf->len < 3``) but then read a fourth byte, the data-element descriptor
+(``type``), via ``net_buf_simple_pull_u8()``. Because ``net_buf_simple_pull_u8()``
+dereferences ``buf->data[0]`` before its only bounds guard (an ``__ASSERT_NO_MSG`` that
+compiles out when ``CONFIG_ASSERT`` is disabled, the production default), a record of
+exactly three bytes (0x09 followed by a 2-byte attribute ID) causes a one-byte read past
+the end of the logical buffer. The parser is reachable from inbound, remote-controlled
+data: a Bluetooth BR/EDR peer acting as an SDP server returns discovery-response records
+that are stored verbatim in the client receive buffer and parsed via the public
+``bt_sdp_get_attr()``/``bt_sdp_has_attr()``/``bt_sdp_record_parse()`` helpers. The over-read
+is bounded to a single byte that is used only as an internal length selector and is
+never leaked to the attacker; subsequent length checks then reject the malformed record.
+Realistic impact is therefore limited to an edge-case denial of service (a fault only if
+the record ends exactly at a mapped-memory boundary, or a deterministic assert panic
+when ``CONFIG_ASSERT=y``). Affects Zephyr v4.3.0 and v4.4.0; fixed by adding
+``sizeof(type)`` to the length check.
+
+- `Zephyr project bug tracker GHSA-p93g-3r68-cj53
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-p93g-3r68-cj53>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107325 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107325>`_
+
+- `PR 110851 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110851>`_
+
+- `PR 110850 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110850>`_
 
 :cve:`2026-10652`
 -----------------
 
-Under embargo until 2026-06-28
+Out-of-bounds read in Zephyr DNS resolver TXT/SRV record parsing (unvalidated ``rdlength``)
+
+Zephyr's DNS resolver (``subsys/net/lib/dns``) parses resource records from DNS
+responses in ``dns_unpack_answer()``, which validated only the fixed RR header (type,
+class, TTL, ``rdlength``) and accepted any attacker-declared ``rdlength``, including one
+extending past the end of the received datagram. The TXT and SRV consumers in
+``dns_validate_record()`` (``resolve.c``) then read up to ``rdlength`` bytes (clamped
+only to a record-type maximum such as ``DNS_MAX_TEXT_SIZE``, default 64, not to the
+packet) from the receive buffer via ``memcpy`` without their own bounds check, and pass
+the result to the application's resolve callback. A malicious or spoofed DNS server, an
+on-path attacker forging UDP DNS replies, or (with mDNS/LLMNR enabled) any LAN node can
+craft a truncated TXT or SRV response that causes an out-of-bounds read of adjacent
+receive-pool memory; the disclosed stale bytes (residual contents of prior DNS packets /
+uninitialized pool memory) are returned to the application as TXT/SRV record contents,
+an information leak, and may in some configurations cross the allocation boundary and
+fault, causing a denial of service. The read is bounded (~64 bytes for TXT, ~6 for SRV)
+and read-only (no write). The fix rejects any record whose declared rdata extends past
+``dns_msg->msg_size`` at the single chokepoint in ``dns_unpack_answer()``. Affected:
+v4.3.0 and v4.4.0.
+
+- `Zephyr project bug tracker GHSA-3jxq-xx8g-q8j2
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3jxq-xx8g-q8j2>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107977 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107977>`_
+
+- `PR 108845 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108845>`_
+
+- `PR 108843 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108843>`_
+
+- `PR 108844 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108844>`_
 
 :cve:`2026-10653`
 -----------------
 
-Under embargo until 2026-06-29
+Non-atomic ``net_buf`` reference counts cause double-free / free-list corruption under concurrent unref
+
+The Zephyr ``net_buf`` library (``lib/net_buf/buf.c``) manipulated both of its reference
+counts -- the per-header ``buf->ref`` and the per-data-block ``ref_count`` at the start
+of each variable/heap data allocation -- with plain non-atomic C operators
+(``buf->ref++``, ``if (--buf->ref > 0)``, ``if (--(*ref_count))``).
+
+The API is documented as self-synchronizing: callers may share one buffer across threads
+(e.g. via ``k_fifo``) and each holder independently calls ``net_buf_unref()`` with no
+surrounding lock. Under true concurrency (SMP, or single-core preemption between the
+non-atomic load and store while another context unrefs the same buffer), two holders can
+both observe the same prior reference value and both conclude they are the last
+reference.
+
+For heap/variable-data pools (``mem_pool_data_unref``/``heap_data_unref``, used by zbus
+message subscribers, the IP stack RX/TX buffers when
+``CONFIG_NET_BUF_FIXED_DATA_SIZE=n``, capture, wireguard, ISO-TP and usbip) this
+produces a double ``k_heap_free()``/``k_free()`` of the same block -- heap-metadata
+corruption and a use-after-free on the heap-hardening poison pattern.
+
+For the per-header refcount the buffer is returned to the pool free LIFO twice for any
+pool type (including fixed-data pools used by Bluetooth and networking), corrupting the
+free list so a later allocation hands the same buffer to two owners.
+
+The fix converts both refcounts to ``atomic_inc``/``atomic_dec`` (overlaying
+``buf->ref`` in an ``atomic_t``-sized union and changing the data-block refcount from
+``uint8_t`` to ``atomic_t``).
+
+Impact is gated on genuine concurrency and on an application architecture that shares
+one buffer among multiple independent unref'ers; the trigger is a refcount/timing race
+rather than packet content, so an external attacker has at most weak indirect influence
+over the race window. Affects all Zephyr releases through v4.4.0.
+
+- `Zephyr project bug tracker GHSA-284j-5jm9-55hh
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-284j-5jm9-55hh>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108065 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108065>`_
+
+- `PR 110852 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110852>`_
 
 :cve:`2026-10654`
 -----------------
 
-Under embargo until 2026-06-29
+RFCOMM session-disconnect race leaks session/L2CAP and denies further RFCOMM service in Zephyr Bluetooth Classic
+
+A race condition in the Zephyr Bluetooth Classic RFCOMM host stack
+(``subsys/bluetooth/host/classic/rfcomm.c``) mishandles a simultaneous bidirectional
+session disconnect. When the local device has initiated a session teardown (state
+``BT_RFCOMM_STATE_DISCONNECTING``, DISC sent, RTX timer armed) and the connected peer
+concurrently sends its own DISC frame for dlci 0, ``rfcomm_handle_disc()`` invokes
+``rfcomm_session_disconnected()``, which unconditionally forced the session to
+``BT_RFCOMM_STATE_DISCONNECTED`` without ever calling ``bt_l2cap_chan_disconnect()``.
+
+Because the recovery timer was also cancelled and a later UA is ignored in the
+DISCONNECTED state, the session becomes permanently wedged: the underlying L2CAP channel
+is never released and the session slot in the fixed
+``bt_rfcomm_pool[CONFIG_BT_MAX_CONN]`` array is never reclaimed (its ``conn`` pointer
+stays set).
+
+Subsequent ``bt_rfcomm_dlc_connect()`` calls on that connection fail with ``-EINVAL``
+due to the invalid session state, so RFCOMM service is denied for that peer, and
+repeated occurrences can exhaust the session pool. The DISC frame is peer-controlled
+over the air, but exploitation requires the peer's DISC to collide with a local-initiated
+disconnect (a high-complexity timing race). Impact is availability/resource-leak
+only; there is no memory-safety, confidentiality, or integrity consequence. The
+defect shipped in released versions (present in v4.4.0 and earlier).
+
+The fix only transitions to DISCONNECTED when the session is not already in
+DISCONNECTING, preserving the proper L2CAP teardown path.
+
+- `Zephyr project bug tracker GHSA-4m37-wp5x-hq4h
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-4m37-wp5x-hq4h>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108089 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108089>`_
+
+- `PR 110863 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110863>`_
+
+- `PR 110864 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110864>`_
+
+- `PR 110865 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110865>`_
 
 :cve:`2026-10655`
 -----------------
 
-Under embargo until 2026-06-30
+Use-after-free race in SNTP async client when closing the socket while the socket service is still polling it
+
+The asynchronous SNTP client in Zephyr (``subsys/net/lib/sntp/sntp.c``,
+``sntp_close_async``) closed the UDP socket file descriptor directly from the calling
+thread immediately after detaching it from the network socket service, without
+synchronizing with the socket-service poll thread.
+
+The socket service thread polls each socket via ``zvfs_poll``, which (in
+``zsock_poll_prepare_ctx``) registers a ``k_poll_event`` pointing into the socket's
+``net_context`` (``&ctx->recv_q``) and then blocks in ``k_poll`` without holding a
+reference or lock. ``net_context`` objects are allocated from a fixed pool
+(``contexts[CONFIG_NET_MAX_CONTEXTS]``) and reused after close.
+
+When ``sntp_close_async`` is invoked from a different thread than the poll thread (in
+the in-tree consumer ``subsys/net/lib/config/init_clock_sntp.c``, the SNTP timeout
+handler runs on the system workqueue while the socket service thread is blocked in poll
+on the same fd), the close frees and may reuse the ``net_context`` while the poll thread
+still has a poller node linked into the freed object, resulting in a use-after-free /
+object confusion of kernel poll structures.
+
+The SNTP timeout path is the normal no-response failure mode, so a network peer or off-path
+attacker who drops or delays the SNTP/NTP response can drive the racing close
+repeatedly (and periodically with ``NET_CONFIG_SNTP_INIT_RESYNC``). The most likely
+consequence is a crash of the networking thread (denial of service), with potential
+memory corruption when the freed context slot is reallocated.
+
+The fix defers the close to the socket service thread itself via
+``net_socket_service_close`` (``NET_SOCKET_SERVICE_CLOSE_SOCKETS``), so the same thread
+that polls performs the close, eliminating the race. Affected releases: v4.2.0 through
+v4.4.0.
+
+- `Zephyr project bug tracker GHSA-34wr-cg29-c4mw
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-34wr-cg29-c4mw>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108180 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108180>`_
+
+- `PR 110858 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110858>`_
+
+- `PR 110860 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110860>`_
 
 :cve:`2026-10656`
 -----------------
@@ -767,7 +1268,46 @@ Under embargo until 2026-07-05
 :cve:`2026-10658`
 -----------------
 
-Under embargo until 2026-07-07
+Out-of-bounds access in Bluetooth ISO receive (``bt_iso_recv``) due to missing SDU-header length validation
+
+``bt_iso_recv()`` in ``subsys/bluetooth/host/iso.c`` pulled the ISO SDU header (4 bytes)
+or, when the timestamp flag is set, the timestamped SDU header (8 bytes) from the
+inbound HCI ISO Data buffer via ``net_buf_pull_mem()`` without first checking
+``buf->len``. The upstream ``hci_iso()`` handler enforces ``buf->len`` == the
+controller-declared ISO Data_Load length, so a malicious or buggy controller / adjacent
+BLE peer on an established CIS/BIS can present a first-fragment (``BT_ISO_START``) or
+single (``BT_ISO_SINGLE``) PDU shorter than the SDU header. Because
+``net_buf_simple_pull_mem`` only guards length with ``__ASSERT_NO_MSG`` (compiled out
+when ``CONFIG_ASSERT`` is disabled, the production default), the pull underflows
+``buf->len`` (``uint16_t``, e.g. ``0 - 8 = 0xFFF8``) and advances ``buf->data`` past
+valid data: the subsequent reads of ``hdr->slen`` and ``hdr->sn`` are out-of-bounds
+reads of adjacent pool memory. For the multi-fragment (START) case the corrupted buffer
+is retained as ``iso->rx``, and a following CONT/END fragment's ``net_buf_tailroom()``
+guard underflows to a near-``SIZE_MAX`` value, defeating the bounds check and causing
+``net_buf_add_mem()`` to ``memcpy`` attacker-supplied fragment data far past the RX pool
+buffer (out-of-bounds write). The flaw affects ISO receive builds (``CONFIG_BT_ISO_RX``,
+selected by the default-off LE Audio options
+``BT_ISO_PERIPHERAL``/``BT_ISO_CENTRAL``/``BT_ISO_SYNC_RECEIVER``) and has existed since
+the ISO subsystem was introduced (v2.6.0) through v4.4.0. The fix adds explicit
+``buf->len < sizeof(*ts_hdr)`` and ``buf->len < sizeof(*hdr)`` checks that drop the
+buffer before pulling.
+
+- `Zephyr project bug tracker GHSA-26g8-rmpf-j6cw
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-26g8-rmpf-j6cw>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108603 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108603>`_
+
+- `PR 110958 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110958>`_
+
+- `PR 110959 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110959>`_
+
+- `PR 111024 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111024>`_
 
 :cve:`2026-10659`
 -----------------
@@ -1004,10 +1544,91 @@ Under embargo until 2026-08-13
 
 Under embargo until 2026-07-23
 
+:cve:`2026-7656`
+----------------
+
+Broken IPv6 Neighbor Discovery input validation allows spoofed RA/NS/NA acceptance in Zephyr net stack
+
+The IPv6 Neighbor Discovery handlers in ``subsys/net/ip/ipv6_nbr.c``
+(``handle_ra_input``, ``handle_ns_input``, ``handle_na_input``) used an incorrect
+boolean expression that combined the RFC 4861 validity checks with the ICMPv6 code check
+using the wrong operator precedence: the form was '((length/hop/source/target checks) &&
+(icmp_hdr->code != 0))'. Because every legitimate ND message carries ICMPv6 code 0, an
+attacker setting code == 0 (the normal value) caused the entire predicate to evaluate
+false, so the packet was never dropped and all of the other checks were silently
+skipped. The bypassed checks include the mandatory Hop Limit == 255 verification (which
+proves an ND packet originated on-link and was not forwarded) and, for Router
+Advertisements, the requirement that the source be a link-local address, as well as
+multicast-target sanity checks. As a result, an adjacent on-link attacker — and, because
+the Hop-Limit-255 guard is bypassed, potentially a remote/off-link attacker whose
+packets would otherwise be rejected — can have forged Router Advertisement, Neighbor
+Solicitation, and Neighbor Advertisement messages accepted. A forged RA lets the
+attacker reconfigure the victim's default router, on-link prefixes (SLAAC), MTU,
+reachable/retransmit timers, and (with ``CONFIG_NET_IPV6_RA_RDNSS``) DNS servers, while
+forged NS/NA enable neighbor-cache poisoning, enabling man-in-the-middle, traffic
+redirection, and denial of service. The flaw is an input-validation/authentication
+weakness rather than a memory-safety issue: the underlying packet-parsing primitives
+(``net_pkt_get_data``, ``net_pkt_read``, ``net_pkt_skip``) are independently bounds-safe
+and the validated 'length' is the true buffer length, so skipping the length check
+causes no out-of-bounds access. The defect has existed since the logic was introduced in
+2018 and shipped in all releases through v4.4.0; it is fixed by splitting the condition
+so any failing check drops the packet.
+
+- `Zephyr project bug tracker GHSA-cpjw-rvwx-ph9f
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-cpjw-rvwx-ph9f>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107902 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107902>`_
+
+- `PR 108195 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108195>`_
+
+- `PR 108192 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108192>`_
+
+- `PR 108131 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108131>`_
+
 :cve:`2026-8023`
 ----------------
 
-Under embargo until 2026-06-26
+Path traversal in Zephyr HTTP server static-filesystem resource handler allows unauthenticated remote arbitrary file read
+
+Zephyr's HTTP server (``subsys/net/lib/http``) provides a static-filesystem resource
+type (``HTTP_RESOURCE_TYPE_STATIC_FS``, available when ``CONFIG_FILE_SYSTEM`` is
+enabled) that serves files from a configured root directory. Before this fix, both the
+HTTP/1 and HTTP/2 front-ends placed the raw, attacker-controlled request path into
+``client->url_buffer`` (assembled in ``on_url()`` for HTTP/1 and copied verbatim from
+the :path pseudo-header for HTTP/2) without resolving ``.``/``..`` segments. The static-FS
+handler then built the on-disk filename by directly concatenating the configured root
+with that raw URL (``snprintk(fname, ..., "%s%s", static_fs_detail->fs_path,
+client->url_buffer)`` at ``http_server_http1.c:603`` and ``http_server_http2.c:490``)
+and opened it with ``fs_open(fname, FS_O_READ)``. Because the handler is reached via
+wildcard/leading-dir (``fnmatch`` ``FNM_LEADING_DIR``) or fallback resource matching, a
+request such as GET /<prefix>/../../<file> is dispatched to the handler and, after the
+underlying filesystem (e.g. LittleFS/FAT) resolves the ``..`` segments, escapes the
+configured web root, letting an unauthenticated remote client read arbitrary readable
+files on the mounted volume (information disclosure). The HTTP server requires no TLS or
+authentication to reach this path. The fix adds ``http_server_remove_dot_segments()``,
+which canonicalizes the path portion of the URL before resource lookup in both protocol
+handlers, neutralizing the traversal. Affects releases v4.0.0 through v4.4.0 for
+deployments that register a static-filesystem resource.
+
+- `Zephyr project bug tracker GHSA-hch3-53g6-jj3h
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-hch3-53g6-jj3h>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108531 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108531>`_
+
+- `PR 111346 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111346>`_
+
+- `PR 111347 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111347>`_
 
 :cve:`2026-9728`
 ----------------
@@ -1058,3 +1679,118 @@ Under embargo until 2026-08-16
 -----------------
 
 Under embargo until 2026-08-16
+
+:cve:`2026-12629`
+-----------------
+
+Under embargo until 2026-08-16
+
+:cve:`2026-12630`
+-----------------
+
+Under embargo until 2026-08-16
+
+:cve:`2026-12631`
+-----------------
+
+Under embargo until 2026-08-16
+
+:cve:`2026-12632`
+-----------------
+
+Under embargo until 2026-08-16
+
+:cve:`2026-12633`
+-----------------
+
+Under embargo until 2026-08-16
+
+:cve:`2026-12634`
+-----------------
+
+Under embargo until 2026-08-16
+
+:cve:`2026-12999`
+-----------------
+
+Under embargo until 2026-08-22
+
+:cve:`2026-13212`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13213`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13214`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13215`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13216`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13217`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13343`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13478`
+-----------------
+
+Under embargo until 2026-08-25
+
+:cve:`2026-13479`
+-----------------
+
+Under embargo until 2026-08-26
+
+:cve:`2026-13480`
+-----------------
+
+Under embargo until 2026-08-26
+
+:cve:`2026-13481`
+-----------------
+
+Under embargo until 2026-08-26
+
+:cve:`2026-13734`
+-----------------
+
+Under embargo until 2026-08-28
+
+:cve:`2026-13735`
+-----------------
+
+Under embargo until 2026-08-28
+
+:cve:`2026-14366`
+-----------------
+
+Under embargo until 2026-08-30
+
+:cve:`2026-14367`
+-----------------
+
+Under embargo until 2026-08-30
+
+:cve:`2026-14368`
+-----------------
+
+Under embargo until 2026-08-30

--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -330,6 +330,97 @@ This has been fixed in main for v4.4.0
 - `PR 102110 fix for main
   <https://github.com/zephyrproject-rtos/zephyr/pull/102110>`_
 
+:cve:`2026-7007`
+----------------
+
+Under embargo until 2026-07-23
+
+:cve:`2026-7656`
+----------------
+
+Broken IPv6 Neighbor Discovery input validation allows spoofed RA/NS/NA acceptance in Zephyr net stack
+
+The IPv6 Neighbor Discovery handlers in ``subsys/net/ip/ipv6_nbr.c``
+(``handle_ra_input``, ``handle_ns_input``, ``handle_na_input``) used an incorrect
+boolean expression that combined the RFC 4861 validity checks with the ICMPv6 code check
+using the wrong operator precedence: the form was '((length/hop/source/target checks) &&
+(icmp_hdr->code != 0))'. Because every legitimate ND message carries ICMPv6 code 0, an
+attacker setting code == 0 (the normal value) caused the entire predicate to evaluate
+false, so the packet was never dropped and all of the other checks were silently
+skipped. The bypassed checks include the mandatory Hop Limit == 255 verification (which
+proves an ND packet originated on-link and was not forwarded) and, for Router
+Advertisements, the requirement that the source be a link-local address, as well as
+multicast-target sanity checks. As a result, an adjacent on-link attacker — and, because
+the Hop-Limit-255 guard is bypassed, potentially a remote/off-link attacker whose
+packets would otherwise be rejected — can have forged Router Advertisement, Neighbor
+Solicitation, and Neighbor Advertisement messages accepted. A forged RA lets the
+attacker reconfigure the victim's default router, on-link prefixes (SLAAC), MTU,
+reachable/retransmit timers, and (with ``CONFIG_NET_IPV6_RA_RDNSS``) DNS servers, while
+forged NS/NA enable neighbor-cache poisoning, enabling man-in-the-middle, traffic
+redirection, and denial of service. The flaw is an input-validation/authentication
+weakness rather than a memory-safety issue: the underlying packet-parsing primitives
+(``net_pkt_get_data``, ``net_pkt_read``, ``net_pkt_skip``) are independently bounds-safe
+and the validated 'length' is the true buffer length, so skipping the length check
+causes no out-of-bounds access. The defect has existed since the logic was introduced in
+2018 and shipped in all releases through v4.4.0; it is fixed by splitting the condition
+so any failing check drops the packet.
+
+- `Zephyr project bug tracker GHSA-cpjw-rvwx-ph9f
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-cpjw-rvwx-ph9f>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107902 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107902>`_
+
+- `PR 108195 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108195>`_
+
+- `PR 108192 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108192>`_
+
+- `PR 108131 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108131>`_
+
+:cve:`2026-8023`
+----------------
+
+Path traversal in Zephyr HTTP server static-filesystem resource handler allows unauthenticated remote arbitrary file read
+
+Zephyr's HTTP server (``subsys/net/lib/http``) provides a static-filesystem resource
+type (``HTTP_RESOURCE_TYPE_STATIC_FS``, available when ``CONFIG_FILE_SYSTEM`` is
+enabled) that serves files from a configured root directory. Before this fix, both the
+HTTP/1 and HTTP/2 front-ends placed the raw, attacker-controlled request path into
+``client->url_buffer`` (assembled in ``on_url()`` for HTTP/1 and copied verbatim from
+the :path pseudo-header for HTTP/2) without resolving ``.``/``..`` segments. The static-FS
+handler then built the on-disk filename by directly concatenating the configured root
+with that raw URL (``snprintk(fname, ..., "%s%s", static_fs_detail->fs_path,
+client->url_buffer)`` at ``http_server_http1.c:603`` and ``http_server_http2.c:490``)
+and opened it with ``fs_open(fname, FS_O_READ)``. Because the handler is reached via
+wildcard/leading-dir (``fnmatch`` ``FNM_LEADING_DIR``) or fallback resource matching, a
+request such as GET /<prefix>/../../<file> is dispatched to the handler and, after the
+underlying filesystem (e.g. LittleFS/FAT) resolves the ``..`` segments, escapes the
+configured web root, letting an unauthenticated remote client read arbitrary readable
+files on the mounted volume (information disclosure). The HTTP server requires no TLS or
+authentication to reach this path. The fix adds ``http_server_remove_dot_segments()``,
+which canonicalizes the path portion of the URL before resource lookup in both protocol
+handlers, neutralizing the traversal. Affects releases v4.0.0 through v4.4.0 for
+deployments that register a static-filesystem resource.
+
+- `Zephyr project bug tracker GHSA-hch3-53g6-jj3h
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-hch3-53g6-jj3h>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108531 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108531>`_
+
+- `PR 111346 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111346>`_
+
+- `PR 111347 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111347>`_
+
 :cve:`2026-8718`
 ----------------
 
@@ -377,6 +468,16 @@ This has been fixed in main for v4.5.0
 
 - `PR 109617 fix for v4.4
   <https://github.com/zephyrproject-rtos/zephyr/pull/109617>`_
+
+:cve:`2026-9728`
+----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-9771`
+----------------
+
+Under embargo until 2026-08-16
 
 :cve:`2026-10593`
 -----------------
@@ -1538,107 +1639,6 @@ Under embargo until 2026-08-11
 -----------------
 
 Under embargo until 2026-08-13
-
-:cve:`2026-7007`
-----------------
-
-Under embargo until 2026-07-23
-
-:cve:`2026-7656`
-----------------
-
-Broken IPv6 Neighbor Discovery input validation allows spoofed RA/NS/NA acceptance in Zephyr net stack
-
-The IPv6 Neighbor Discovery handlers in ``subsys/net/ip/ipv6_nbr.c``
-(``handle_ra_input``, ``handle_ns_input``, ``handle_na_input``) used an incorrect
-boolean expression that combined the RFC 4861 validity checks with the ICMPv6 code check
-using the wrong operator precedence: the form was '((length/hop/source/target checks) &&
-(icmp_hdr->code != 0))'. Because every legitimate ND message carries ICMPv6 code 0, an
-attacker setting code == 0 (the normal value) caused the entire predicate to evaluate
-false, so the packet was never dropped and all of the other checks were silently
-skipped. The bypassed checks include the mandatory Hop Limit == 255 verification (which
-proves an ND packet originated on-link and was not forwarded) and, for Router
-Advertisements, the requirement that the source be a link-local address, as well as
-multicast-target sanity checks. As a result, an adjacent on-link attacker — and, because
-the Hop-Limit-255 guard is bypassed, potentially a remote/off-link attacker whose
-packets would otherwise be rejected — can have forged Router Advertisement, Neighbor
-Solicitation, and Neighbor Advertisement messages accepted. A forged RA lets the
-attacker reconfigure the victim's default router, on-link prefixes (SLAAC), MTU,
-reachable/retransmit timers, and (with ``CONFIG_NET_IPV6_RA_RDNSS``) DNS servers, while
-forged NS/NA enable neighbor-cache poisoning, enabling man-in-the-middle, traffic
-redirection, and denial of service. The flaw is an input-validation/authentication
-weakness rather than a memory-safety issue: the underlying packet-parsing primitives
-(``net_pkt_get_data``, ``net_pkt_read``, ``net_pkt_skip``) are independently bounds-safe
-and the validated 'length' is the true buffer length, so skipping the length check
-causes no out-of-bounds access. The defect has existed since the logic was introduced in
-2018 and shipped in all releases through v4.4.0; it is fixed by splitting the condition
-so any failing check drops the packet.
-
-- `Zephyr project bug tracker GHSA-cpjw-rvwx-ph9f
-  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-cpjw-rvwx-ph9f>`_
-
-This has been fixed in main for v4.5.0
-
-- `PR 107902 fix for main
-  <https://github.com/zephyrproject-rtos/zephyr/pull/107902>`_
-
-- `PR 108195 fix for v3.7
-  <https://github.com/zephyrproject-rtos/zephyr/pull/108195>`_
-
-- `PR 108192 fix for v4.3
-  <https://github.com/zephyrproject-rtos/zephyr/pull/108192>`_
-
-- `PR 108131 fix for v4.4
-  <https://github.com/zephyrproject-rtos/zephyr/pull/108131>`_
-
-:cve:`2026-8023`
-----------------
-
-Path traversal in Zephyr HTTP server static-filesystem resource handler allows unauthenticated remote arbitrary file read
-
-Zephyr's HTTP server (``subsys/net/lib/http``) provides a static-filesystem resource
-type (``HTTP_RESOURCE_TYPE_STATIC_FS``, available when ``CONFIG_FILE_SYSTEM`` is
-enabled) that serves files from a configured root directory. Before this fix, both the
-HTTP/1 and HTTP/2 front-ends placed the raw, attacker-controlled request path into
-``client->url_buffer`` (assembled in ``on_url()`` for HTTP/1 and copied verbatim from
-the :path pseudo-header for HTTP/2) without resolving ``.``/``..`` segments. The static-FS
-handler then built the on-disk filename by directly concatenating the configured root
-with that raw URL (``snprintk(fname, ..., "%s%s", static_fs_detail->fs_path,
-client->url_buffer)`` at ``http_server_http1.c:603`` and ``http_server_http2.c:490``)
-and opened it with ``fs_open(fname, FS_O_READ)``. Because the handler is reached via
-wildcard/leading-dir (``fnmatch`` ``FNM_LEADING_DIR``) or fallback resource matching, a
-request such as GET /<prefix>/../../<file> is dispatched to the handler and, after the
-underlying filesystem (e.g. LittleFS/FAT) resolves the ``..`` segments, escapes the
-configured web root, letting an unauthenticated remote client read arbitrary readable
-files on the mounted volume (information disclosure). The HTTP server requires no TLS or
-authentication to reach this path. The fix adds ``http_server_remove_dot_segments()``,
-which canonicalizes the path portion of the URL before resource lookup in both protocol
-handlers, neutralizing the traversal. Affects releases v4.0.0 through v4.4.0 for
-deployments that register a static-filesystem resource.
-
-- `Zephyr project bug tracker GHSA-hch3-53g6-jj3h
-  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-hch3-53g6-jj3h>`_
-
-This has been fixed in main for v4.5.0
-
-- `PR 108531 fix for main
-  <https://github.com/zephyrproject-rtos/zephyr/pull/108531>`_
-
-- `PR 111346 fix for v4.3
-  <https://github.com/zephyrproject-rtos/zephyr/pull/111346>`_
-
-- `PR 111347 fix for v4.4
-  <https://github.com/zephyrproject-rtos/zephyr/pull/111347>`_
-
-:cve:`2026-9728`
-----------------
-
-Under embargo until 2026-08-23
-
-:cve:`2026-9771`
-----------------
-
-Under embargo until 2026-08-16
 
 :cve:`2026-12363`
 -----------------


### PR DESCRIPTION
Update the vulnerability registry now that a batch of embargoes has lifted.

- Replace the placeholder "Under embargo" text with full write-ups for 16 CVEs whose embargo has now passed, plus a newly disclosed entry for CVE-2026-7656.
- The disclosed issues span Bluetooth host and controller (ISOAL framed RX, LE Audio BAP QoS state, SDP attribute parsing, RFCOMM disconnect race, ISO receive), the networking stack (recvmsg ancillary data, getaddrinfo use-after-return, DNS TXT/SRV parsing, SNTP async close race, HTTP static-FS path traversal, IPv6 Neighbor Discovery validation), the ext2 filesystem, the PL011 and Microchip SERCOM-G1 UART drivers, USB CDC-NCM, MCUmgr serial transport, and the net_buf refcount library.
- All are fixed in main for v4.5.0 with backports to the affected LTS/release branches.
- Register the next set of assigned-but-embargoed CVEs (2026-12629 through 2026-14368) as placeholders with their embargo dates.