### PR TITLE
[Backport v3.7-branch] arch: arm: Forcibly set K_FP_REGS when FPU enabled

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -939,7 +939,10 @@ config FPU
 
 	  If it is necessary for multiple threads to perform concurrent floating
 	  point operations, the "FPU register sharing" option must be enabled to
-	  preserve the floating point registers across context switches.
+	  preserve the floating point registers across context switches. This is
+	  done automatically if the platform enables an architecture-specific option
+	  enabling the compiler to generate FP instructions for general puprose
+	  integer work.
 
 	  Note that this option cannot be selected for the platforms that do not
 	  include a hardware floating point unit; the floating point support for

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -270,6 +270,9 @@ config ARM_STORE_EXC_RETURN
 	  This is needed when switching between threads that differ in either
 	  FPU usage or security domain.
 
+# Both FP_HARDABI and FP_SOFTABI require FPU sharing support as the compiler
+# may generate code that uses the FPU even if the application does not
+# explicitly use floating point operations.
 choice
 	prompt "Floating point ABI"
 	default FP_HARDABI
@@ -277,6 +280,7 @@ choice
 
 config FP_HARDABI
 	bool "Floating point Hard ABI"
+	select FPU_SHARING
 	help
 	  This option selects the Floating point ABI in which hardware floating
 	  point instructions are generated and uses FPU-specific calling
@@ -284,6 +288,7 @@ config FP_HARDABI
 
 config FP_SOFTABI
 	bool "Floating point Soft ABI"
+	select FPU_SHARING
 	help
 	  This option selects the Floating point ABI in which hardware floating
 	  point instructions are generated but soft-float calling conventions.

--- a/arch/arm/core/cortex_a_r/thread.c
+++ b/arch/arm/core/cortex_a_r/thread.c
@@ -84,6 +84,16 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 {
 	struct __basic_sf *iframe;
 
+#if defined(CONFIG_FP_HARDABI) || defined(CONFIG_FP_SOFTABI)
+	/*
+	 * Both CONFIG_FP_HARDABI and CONFIG_FP_SOFTABI allow the compiler
+	 * to generate FP instructions--even without explicit use of FP types.
+	 * All threads must thus be considered as using FP registers and
+	 * tagged with K_FP_REGS.
+	 */
+	thread->base.user_options |= K_FP_REGS;
+#endif
+
 #ifdef CONFIG_MPU_STACK_GUARD
 #if defined(CONFIG_USERSPACE)
 	if (z_stack_is_user_capable(stack)) {

--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -93,6 +93,16 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 {
 	struct __basic_sf *iframe;
 
+#if defined(CONFIG_FP_HARDABI) || defined(CONFIG_FP_SOFTABI)
+	/*
+	 * Both CONFIG_FP_HARDABI and CONFIG_FP_SOFTABI allow the compiler
+	 * to generate FP instructions--even without explicit use of FP types.
+	 * All threads must thus be considered as using FP registers and
+	 * tagged with K_FP_REGS.
+	 */
+	thread->base.user_options |= K_FP_REGS;
+#endif
+
 #ifdef CONFIG_MPU_STACK_GUARD
 #if defined(CONFIG_USERSPACE)
 	if (z_stack_is_user_capable(stack)) {


### PR DESCRIPTION
Backport of the fix from #110300 to `v3.7-branch`.

Fixes: #108793