### PR TITLE
bluetooth: BAP: fix BAP broaadcast BIS stream setup

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -319,13 +319,101 @@ static void remote_broadcaster_free(struct btp_bap_broadcast_remote_source *broa
 	}
 }
 
+static int stream_chan_alloc_get(enum bt_audio_location chan_alloc, size_t stream_idx,
+				 enum bt_audio_location *stream_chan_alloc)
+{
+	uint32_t chan_alloc_bits = (uint32_t)chan_alloc;
+
+	if (stream_chan_alloc == NULL) {
+		return -EINVAL;
+	}
+
+	/* Mono itself can be used with multiple BISes, but this helper derives a
+	 * single-channel allocation for a specific BIS index. For mono there is no
+	 * index-based split, so only stream_idx 0 can be derived here.
+	 */
+	if (chan_alloc == BT_AUDIO_LOCATION_MONO_AUDIO) {
+		if (stream_idx != 0U) {
+			return -EINVAL;
+		}
+
+		*stream_chan_alloc = BT_AUDIO_LOCATION_MONO_AUDIO;
+		return 0;
+	}
+
+	/* When there is a 1:1 mapping between channel bits and BISes, each set bit
+	 * in chan_alloc belongs to one lower-indexed stream. Clear one least
+	 * significant set bit per lower-indexed stream, then return the next one.
+	 * This selects the Nth set bit without scanning all 32 possible positions.
+	 */
+	for (size_t i = 0U; i < stream_idx; i++) {
+		/* clear LSB from lower indexed streams */
+		chan_alloc_bits ^= LSB_GET(chan_alloc_bits);
+	}
+
+	/* All set bits were consumed before reaching stream_idx, so there is no
+	 * channel allocation that can be derived for this BIS index.
+	 */
+	if (chan_alloc_bits == 0U) {
+		return -EINVAL;
+	}
+
+	*stream_chan_alloc = (enum bt_audio_location)LSB_GET(chan_alloc_bits);
+	return 0;
+}
+
+static int stream_bis_codec_data_set(bool set_bis_chan_alloc, bool derive_bis_chan_alloc,
+				     enum bt_audio_location chan_alloc, size_t bis_idx,
+				     uint8_t *codec_data,
+				     struct bt_bap_broadcast_source_stream_param *stream_param)
+{
+	enum bt_audio_location bis_chan_alloc = chan_alloc;
+	int err;
+
+	/* Leave the per-BIS codec data empty when no channel allocation shall be
+	 * exposed in the BIS-specific codec configuration.
+	 */
+	if (!set_bis_chan_alloc) {
+		stream_param->data = NULL;
+		stream_param->data_len = 0U;
+
+		return 0;
+	}
+
+	/* Reuse the subgroup channel allocation unless there is an unambiguous
+	 * 1:1 mapping between channel bits and BISes and we can derive a unique
+	 * channel allocation for this BIS index.
+	 */
+	if (derive_bis_chan_alloc) {
+		err = stream_chan_alloc_get(chan_alloc, bis_idx, &bis_chan_alloc);
+		if (err != 0) {
+			LOG_DBG("Failed to derive BIS channel allocation (%zu): %d", bis_idx, err);
+			return err;
+		}
+	}
+
+	/* Encode a single BT_AUDIO_CODEC_CFG_CHAN_ALLOC LTV for this BIS. */
+	codec_data[0] = sizeof(uint8_t) /* type */ + sizeof(uint32_t) /* value */;
+	codec_data[1] = BT_AUDIO_CODEC_CFG_CHAN_ALLOC;
+	sys_put_le32((uint32_t)bis_chan_alloc, &codec_data[2]);
+
+	stream_param->data = codec_data;
+	stream_param->data_len = sizeof(uint8_t) + sizeof(uint8_t) + sizeof(uint32_t);
+
+	return 0;
+}
+
 static int setup_broadcast_source(uint8_t streams_per_subgroup, uint8_t subgroups,
 				  struct btp_bap_broadcast_local_source *source,
 				  struct bt_audio_codec_cfg *codec_cfg)
 {
 	int err;
+	enum bt_audio_location chan_alloc;
+	bool derive_bis_chan_alloc = false;
+	bool set_bis_chan_alloc = false;
 	struct bt_bap_broadcast_source_stream_param
 		stream_params[CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT];
+	uint8_t stream_codec_data[CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT][6];
 	struct bt_bap_broadcast_source_subgroup_param
 		subgroup_param[CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT];
 	struct bt_bap_broadcast_source_param create_param;
@@ -340,22 +428,48 @@ static int setup_broadcast_source(uint8_t streams_per_subgroup, uint8_t subgroup
 	 */
 	memcpy(&source->streams[0].codec_cfg, codec_cfg, sizeof(*codec_cfg));
 
+	err = bt_audio_codec_cfg_get_chan_allocation(codec_cfg, &chan_alloc, false);
+	if (err == 0 && streams_per_subgroup > 1U) {
+		size_t chan_alloc_count = sys_count_bits(&chan_alloc, sizeof(chan_alloc));
+
+		/* Always set BIS channel allocation when source allocation is
+		 * present. Only derive a unique per-BIS allocation when there is an
+		 * unambiguous 1:1 mapping between channel bits and BISes.
+		 */
+		if ((chan_alloc != BT_AUDIO_LOCATION_MONO_AUDIO) &&
+		    (chan_alloc_count == streams_per_subgroup)) {
+			derive_bis_chan_alloc = true;
+		}
+
+		set_bis_chan_alloc = true;
+	} else if (err == 0) {
+		set_bis_chan_alloc = true;
+	}
+
 	for (size_t i = 0U; i < subgroups; i++) {
 		subgroup_param[i].params_count = streams_per_subgroup;
 		subgroup_param[i].params = stream_params + i * streams_per_subgroup;
 		subgroup_param[i].codec_cfg = &source->streams[0].codec_cfg;
-	}
+		for (size_t j = 0U; j < streams_per_subgroup; j++) {
+			const size_t stream_idx = i * streams_per_subgroup + j;
+			struct bt_bap_stream *stream =
+				stream_broadcast_to_bap(&source->streams[stream_idx]);
 
-	for (size_t j = 0U; j < streams_per_subgroup; j++) {
-		struct btp_bap_broadcast_stream *b_stream = &source->streams[j];
-		struct bt_bap_stream *stream = stream_broadcast_to_bap(b_stream);
+			stream_params[stream_idx].stream = stream;
+			bt_bap_stream_cb_register(stream, &stream_ops);
 
-		stream_params[j].stream = stream;
-		bt_bap_stream_cb_register(stream, &stream_ops);
-
-		/* BIS Codec Specific Configuration specified on subgroup level */
-		stream_params[j].data = NULL;
-		stream_params[j].data_len = 0U;
+			/* stream_bis_codec_data_set() fills the BIS-specific codec data for
+			 * this stream, reusing or deriving channel allocation as needed.
+			 */
+			err = stream_bis_codec_data_set(set_bis_chan_alloc,
+							derive_bis_chan_alloc,
+							chan_alloc, j,
+							stream_codec_data[stream_idx],
+							&stream_params[stream_idx]);
+			if (err != 0) {
+				return err;
+			}
+		}
 	}
 
 	create_param.params_count = subgroups;


### PR DESCRIPTION
Initialize all broadcast stream parameters across
subgroups and attach per-BIS channel allocation
codec data. This fixes PTS reporting of audio
channel count/BIS count as zero in broadcast
source streaming.

The following conformance tests now pass:
BAP/BSRC/STR/BV-35-C
BAP/BSRC/STR/BV-36-C
BAP/BSRC/STR/BV-37-C
BAP/BSRC/STR/BV-38-C
BAP/BSRC/STR/BV-39-C
BAP/BSRC/STR/BV-40-C
BAP/BSRC/STR/BV-41-C
BAP/BSRC/STR/BV-42-C
BAP/BSRC/STR/BV-43-C
BAP/BSRC/STR/BV-44-C
BAP/BSRC/STR/BV-45-C
BAP/BSRC/STR/BV-46-C
BAP/BSRC/STR/BV-47-C
BAP/BSRC/STR/BV-48-C
BAP/BSRC/STR/BV-49-C
BAP/BSRC/STR/BV-50-C

Testing
nRF5340 Audio DK
nRF54L15 DK