### PR TITLE
[Backport v4.4-branch] drivers: bluetooth: hci: Fix send() buffer ownership contract

### DIFF
--- a/drivers/bluetooth/hci/hci_bee.c
+++ b/drivers/bluetooth/hci/hci_bee.c
@@ -212,7 +212,6 @@ static void rtl_rx_thread(void *p1, void *p2, void *p3)
 
 static int bt_hci_bee_send(const struct device *dev, struct net_buf *buf)
 {
-	int ret = 0;
 	T_RTL_BT_HCI_BUF hci_buf = {};
 	uint8_t packet_type = net_buf_pull_u8(buf);
 
@@ -224,35 +223,27 @@ static int bt_hci_bee_send(const struct device *dev, struct net_buf *buf)
 
 	default:
 		LOG_ERR("Unknown packet type: 0x%02x", packet_type);
-		ret = -EINVAL;
-		goto done;
+		return -EINVAL;
 	}
 
 	if (rtl_bt_hci_h2c_buf_alloc(&hci_buf, packet_type, buf->len) == false) {
-		ret = -EINVAL;
-		goto done;
+		return -EINVAL;
 	}
 
 	if (rtl_bt_hci_h2c_buf_add(&hci_buf, buf->data, buf->len) == false) {
 		rtl_bt_hci_h2c_buf_rel(hci_buf);
-		ret = -EINVAL;
-		goto done;
+		return -EINVAL;
 	}
 
 	if (rtl_bt_hci_send(hci_buf) == false) {
 		rtl_bt_hci_h2c_buf_rel(hci_buf);
-		ret = -EIO;
+		return -EIO;
 	}
 
-done:
+	LOG_DBG("Sent, type %d, len %u", packet_type, buf->len);
 	net_buf_unref(buf);
-	if (ret != 0) {
-		LOG_ERR("Error, type %d, len %u, ret %d", packet_type, buf->len, ret);
-	} else {
-		LOG_DBG("Sent, type %d, len %u", packet_type, buf->len);
-	}
 
-	return ret;
+	return 0;
 }
 
 static int bt_hci_bee_open(const struct device *dev, bt_hci_recv_t recv)

--- a/drivers/bluetooth/hci/hci_bflb_bl70x.c
+++ b/drivers/bluetooth/hci/hci_bflb_bl70x.c
@@ -223,8 +223,7 @@ static int bt_bflb_send(const struct device *dev, struct net_buf *buf)
 		struct bt_hci_cmd_hdr *chdr;
 
 		if (buf->len < sizeof(*chdr)) {
-			ret = -EINVAL;
-			goto done;
+			return -EINVAL;
 		}
 
 		chdr = (void *)buf->data;
@@ -241,8 +240,7 @@ static int bt_bflb_send(const struct device *dev, struct net_buf *buf)
 		uint16_t connhdl_l2cf;
 
 		if (buf->len < sizeof(*acl)) {
-			ret = -EINVAL;
-			goto done;
+			return -EINVAL;
 		}
 
 		acl = (void *)buf->data;
@@ -258,19 +256,17 @@ static int bt_bflb_send(const struct device *dev, struct net_buf *buf)
 		break;
 	}
 	default:
-		ret = -EINVAL;
-		goto done;
+		return -EINVAL;
 	}
 
 	ret = bt_onchiphci_send(pkt_type, dest_id, &pkt);
 	if (ret != 0) {
 		LOG_ERR("bt_onchiphci_send failed: %d", ret);
-		ret = (ret < 0) ? ret : -EIO;
+		return (ret < 0) ? ret : -EIO;
 	}
 
-done:
 	net_buf_unref(buf);
-	return ret;
+	return 0;
 }
 
 static void bflb_ble_rf_init(void)


### PR DESCRIPTION
Backport of the fix from #110711 to `v4.4-branch`.

Fixes: #112555