### PR TITLE
doc: clarify board port smoke build checks

### DIFF
--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -624,6 +624,28 @@ For ``west flash`` to work, see :ref:`flash-and-debug-support` below. You can
 also just flash :file:`build/zephyr/zephyr.elf`, :file:`zephyr.hex`, or
 :file:`zephyr.bin` with any other tools you prefer.
 
+Before submitting a board upstream, verify that every board target you add can
+build at least one simple application using only code from the mainline Zephyr
+repository and its modules. For example:
+
+.. code-block:: console
+
+   west build -p always -b plank samples/hello_world
+
+For boards with multiple SoCs, CPU clusters, variants, or revisions, repeat the
+smoke build for each new board target, for example:
+
+.. code-block:: console
+
+   west build -p always -b plank/soc1/foo samples/hello_world
+   west build -p always -b plank@1.0.0/soc1/foo samples/hello_world
+
+Use :ref:`sysbuild` if the board target requires it. If ``hello_world`` is not a
+reasonable smoke test for the hardware, use an equivalent simple sample and
+explain the choice in the pull request. When using board testing metadata,
+such as ``testing: only_tags`` in the board target YAML file, make sure the
+new target still has at least one smoke build in local testing or CI.
+
 .. _porting-general-recommendations:
 
 General recommendations

--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -625,26 +625,31 @@ also just flash :file:`build/zephyr/zephyr.elf`, :file:`zephyr.hex`, or
 :file:`zephyr.bin` with any other tools you prefer.
 
 Before submitting a board upstream, verify that every board target you add can
-build at least one simple application using only code from the mainline Zephyr
-repository and its modules. For example:
+pass the project's minimum open source test suite using only code from the
+mainline Zephyr repository and its modules. The suite currently consists of:
+
+- :file:`samples/philosophers`
+- :file:`tests/kernel`
+
+For example, build the suite for a board target with:
 
 .. code-block:: console
 
-   west build -p always -b plank samples/hello_world
+   west twister -p plank -T samples/philosophers -T tests/kernel
 
 For boards with multiple SoCs, CPU clusters, variants, or revisions, repeat the
-smoke build for each new board target, for example:
+test suite for each new board target. A :zephyr:code-sample:`hello_world` build
+is also recommended as a quick smoke check, for example:
 
 .. code-block:: console
 
    west build -p always -b plank/soc1/foo samples/hello_world
    west build -p always -b plank@1.0.0/soc1/foo samples/hello_world
 
-Use :ref:`sysbuild` if the board target requires it. If ``hello_world`` is not a
-reasonable smoke test for the hardware, use an equivalent simple sample and
-explain the choice in the pull request. When using board testing metadata,
-such as ``testing: only_tags`` in the board target YAML file, make sure the
-new target still has at least one smoke build in local testing or CI.
+Use :ref:`sysbuild` if the board target requires it. When using board testing
+metadata, such as ``testing: only_tags`` in the board target YAML file, make
+sure the target is still validated against the minimum test suite in local
+testing or CI.
 
 .. _porting-general-recommendations:
 


### PR DESCRIPTION
## Summary

- Document the minimum open source test suite required for every upstream board target.
- Require `samples/philosophers` and `tests/kernel` for every target, qualifier, and revision.
- Keep `samples/hello_world` as a recommended quick smoke check.
- Clarify that restricted board testing metadata must not bypass the minimum suite.

Refs #95398

## Testing

- `git diff --check $(git merge-base upstream/main HEAD)..HEAD`
- `scripts/checkpatch.pl --git $(git merge-base upstream/main HEAD)..HEAD`
- `sphinx-lint doc/hardware/porting/board_porting.rst`