### PR TITLE
Imx9 fix tstmr

### DIFF
--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.dts
@@ -96,10 +96,6 @@
 	status = "okay";
 };
 
-&tstmr1 {
-	status = "okay";
-};
-
 &tstmr2 {
 	status = "okay";
 };

--- a/dts/arm/nxp/imx/nxp_imx93_m33.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx93_m33.dtsi
@@ -203,14 +203,14 @@
 		tstmr1: timer@442c0000 {
 			compatible = "nxp,tstmr";
 			reg = <0x442c0000 0x8>;
-			clock-frequency = <DT_FREQ_M(1)>;
+			clock-frequency = <DT_FREQ_M(24)>;
 			status = "disabled";
 		};
 
 		tstmr2: timer@42480000 {
 			compatible = "nxp,tstmr";
 			reg = <0x42480000 0x8>;
-			clock-frequency = <DT_FREQ_M(1)>;
+			clock-frequency = <DT_FREQ_M(24)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/imx/nxp_imx94x.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx94x.dtsi
@@ -665,14 +665,14 @@
 		tstmr1: timer@442c0000 {
 			compatible = "nxp,tstmr";
 			reg = <0x442c0000 0x8>;
-			clock-frequency = <DT_FREQ_M(1)>;
+			clock-frequency = <DT_FREQ_M(24)>;
 			status = "disabled";
 		};
 
 		tstmr2: timer@42480000 {
 			compatible = "nxp,tstmr";
 			reg = <0x42480000 0x8>;
-			clock-frequency = <DT_FREQ_M(1)>;
+			clock-frequency = <DT_FREQ_M(24)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/imx/nxp_imx952_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx952_m7.dtsi
@@ -653,14 +653,14 @@
 		tstmr1: timer@442c0000 {
 			compatible = "nxp,tstmr";
 			reg = <0x442c0000 0x8>;
-			clock-frequency = <DT_FREQ_M(1)>;
+			clock-frequency = <DT_FREQ_M(24)>;
 			status = "disabled";
 		};
 
 		tstmr2: timer@420a0000 {
 			compatible = "nxp,tstmr";
 			reg = <0x420a0000 0x8>;
-			clock-frequency = <DT_FREQ_M(1)>;
+			clock-frequency = <DT_FREQ_M(24)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -695,14 +695,14 @@
 		tstmr1: timer@442c0000 {
 			compatible = "nxp,tstmr";
 			reg = <0x442c0000 0x8>;
-			clock-frequency = <DT_FREQ_M(1)>;
+			clock-frequency = <DT_FREQ_M(24)>;
 			status = "disabled";
 		};
 
 		tstmr2: timer@42480000 {
 			compatible = "nxp,tstmr";
 			reg = <0x42480000 0x8>;
-			clock-frequency = <DT_FREQ_M(1)>;
+			clock-frequency = <DT_FREQ_M(24)>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Fix TSTMR issues on NXP i.MX93/943/95/952
1. boards: nxp: imx943_evk: disable tstmr1 on M33

On i.MX943, tstmr1 is owned by the System Manager (secure core) and is not accessible from either the M7 or M33 cores. The previous board file for imx943_evk_mimx94398_m33.dts incorrectly enabled tstmr1. This commit removes that enable, leaving only tstmr2 (which is accessible to the M33) enabled.

2. dts: nxp: fix TSTMR clock-frequency to 24 MHz on i.MX93/943/95/952

The TSTMR on i.MX93, i.MX943, i.MX95, and i.MX952 is clocked from the 24 MHz OSC, not 1 MHz as previously set. This commit corrects the clock-frequency property in the following dtsi files:

dts/arm/nxp/imx/nxp_imx93_m33.dtsi
dts/arm/nxp/imx/nxp_imx94x.dtsi
dts/arm/nxp/imx/nxp_imx95_m7.dtsi
dts/arm/nxp/imx/nxp_imx952_m7.dtsi