### PR TITLE
soc: microchip: correct soc family name

### DIFF
--- a/soc/microchip/pic32c/pic32cm_sg_gc/soc.yml
+++ b/soc/microchip/pic32c/pic32cm_sg_gc/soc.yml
@@ -9,7 +9,7 @@ family:
     - name: pic32cm5112gc00048
     - name: pic32cm5112gc00064
     - name: pic32cm5112gc00100
-  - name: pic32ck_sg00
+  - name: pic32cm_sg00
     socs:
     - name: pic32cm5112sg00048
     - name: pic32cm5112sg00064


### PR DESCRIPTION
Correct PIC32CM SG family name in soc.yml