### PR TITLE
drivers: sensor: bma4xx: fix base_timestamp_ns to first sample time

### DIFF
--- a/drivers/sensor/bosch/bma4xx/bma4xx_decoder.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_decoder.c
@@ -314,7 +314,16 @@ static int bma4xx_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec ch,
 		return -ENOTSUP;
 	}
 
-	((struct sensor_data_header *)data_out)->base_timestamp_ns = edata->header.timestamp;
+	uint16_t total_accel_frames = 0;
+	struct sensor_chan_spec accel_ch = {.chan_type = SENSOR_CHAN_ACCEL_XYZ, .chan_idx = 0};
+
+	bma4xx_decoder_get_frame_count(buffer, accel_ch, &total_accel_frames);
+
+	uint64_t period_ns = accel_period_ns[edata->accel_odr];
+
+	((struct sensor_data_header *)data_out)->base_timestamp_ns =
+		edata->header.timestamp -
+		(total_accel_frames > 0 ? (total_accel_frames - 1) : 0) * period_ns;
 
 	buffer += sizeof(struct bma4xx_fifo_data);
 
@@ -352,8 +361,6 @@ static int bma4xx_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec ch,
 		if (has_accel) {
 			struct sensor_three_axis_data *data =
 				(struct sensor_three_axis_data *)data_out;
-
-			uint64_t period_ns = accel_period_ns[edata->accel_odr];
 
 			bma4xx_get_shift(
 				(struct sensor_chan_spec){.chan_type = SENSOR_CHAN_ACCEL_XYZ,


### PR DESCRIPTION
## Summary

`base_timestamp_ns` was set to the time of the FIFO watermark/full interrupt rather than the time of the first sample in the buffer, which makes every decoded sample appear to have occurred at or after the IRQ instead of before it.

Record `base_timestamp_ns` as the time of the first sample in the FIFO by adjusting backward from the trigger timestamp using the total frame count and ODR period, matching the `lsm6dsv16x` reference implementation.

Split out of #108718 (per-sensor PR split requested during review).

Fixes: #98720