### PR TITLE
drivers: sensor: icm45686: fix timestamps in FIFO stream

### DIFF
--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -82,6 +82,8 @@ struct icm45686_encoded_header {
 	uint8_t events: 3;
 	uint8_t channels: 7;
 	uint16_t fifo_count;
+	uint8_t accel_odr;
+	uint8_t gyro_odr;
 };
 
 struct icm45686_encoded_data {

--- a/drivers/sensor/tdk/icm45686/icm45686_decoder.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_decoder.c
@@ -18,6 +18,12 @@ LOG_MODULE_REGISTER(ICM45686_DECODER, CONFIG_SENSOR_LOG_LEVEL);
 
 #define DT_DRV_COMPAT invensense_icm45686
 
+/* Hardware timestamp resolution: 16μs per tick (TMST_RESOL=1 in TMST_WOM_CONFIG).
+ * Each 20-byte FIFO packet contains a 16-bit hardware timestamp at this resolution.
+ * The signed int16_t delta handles 16-bit wraparound, valid for batch spans < 524ms.
+ */
+#define ICM45686_HW_TS_NS_PER_TICK UINT32_C(16000) /* 16μs in ns */
+
 static int icm45686_get_shift(enum sensor_channel channel, int accel_fs, int gyro_fs, int8_t *shift)
 {
 	switch (channel) {
@@ -459,6 +465,22 @@ static int icm45686_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec c
 		return 0;
 	}
 
+	uint16_t total = edata->header.fifo_count;
+
+	/*
+	 * Each 20-byte FIFO packet contains a 16-bit hardware timestamp at 16μs resolution.
+	 * The last packet's timestamp correlates with the host IRQ time (edata->header.timestamp).
+	 * Casting the delta to int16_t handles 16-bit counter wraparound — valid for batch
+	 * spans up to ±32767 * 16μs ≈ ±524ms.
+	 *
+	 * base_timestamp_ns = host_irq_time + (ts_first - ts_last) * 16μs
+	 *                   ≈ host time of the first sample in the batch
+	 */
+	uint16_t ts_first = (total > 0) ? frame_begin[0].timestamp : 0;
+	uint16_t ts_last  = (total > 0) ? frame_begin[total - 1].timestamp : 0;
+	int32_t  span_ns  = (int16_t)(ts_first - ts_last) * (int32_t)ICM45686_HW_TS_NS_PER_TICK;
+	uint64_t base_ts  = edata->header.timestamp + (int64_t)span_ns;
+
 	while (count < max_count && (*fit < edata->header.fifo_count)) {
 		struct icm45686_encoded_fifo_payload *fdata = &frame_begin[*fit];
 
@@ -473,6 +495,10 @@ static int icm45686_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec c
 			return -ENOTSUP;
 		}
 
+		/* Per-packet delta from first sample using hardware timestamps */
+		uint32_t hw_delta_ns = (uint32_t)((int16_t)(fdata->timestamp - ts_first) *
+						   (int32_t)ICM45686_HW_TS_NS_PER_TICK);
+
 		switch (chan_spec.chan_type) {
 		case SENSOR_CHAN_ACCEL_XYZ:
 		case SENSOR_CHAN_GYRO_XYZ: {
@@ -482,7 +508,8 @@ static int icm45686_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec c
 			icm45686_get_shift(chan_spec.chan_type, edata->header.accel_fs,
 					   edata->header.gyro_fs, &out->shift);
 
-			out->header.base_timestamp_ns = edata->header.timestamp;
+			out->header.base_timestamp_ns = base_ts;
+			out->readings[count].timestamp_delta = hw_delta_ns;
 
 			err = icm45686_fifo_read_imu_from_packet((uint8_t *)fdata, is_accel, 0,
 								 &out->readings[count].x);
@@ -501,7 +528,8 @@ static int icm45686_fifo_decode(const uint8_t *buffer, struct sensor_chan_spec c
 			icm45686_get_shift(chan_spec.chan_type, edata->header.accel_fs,
 					   edata->header.gyro_fs, &out->shift);
 
-			out->header.base_timestamp_ns = edata->header.timestamp;
+			out->header.base_timestamp_ns = base_ts;
+			out->readings[count].timestamp_delta = hw_delta_ns;
 			out->readings[count].temperature =
 				icm45686_fifo_read_temp_from_packet((uint8_t *)fdata);
 			break;

--- a/drivers/sensor/tdk/icm45686/icm45686_reg.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_reg.h
@@ -66,6 +66,14 @@
 #define REG_FIFO_CONFIG3_FIFO_ACCEL_EN(val) (((val) & BIT_MASK(1)) << 1)
 #define REG_FIFO_CONFIG3_FIFO_EN(val)       ((val) & BIT_MASK(1))
 
+/* FIFO_CONFIG4 (0x22): enable per-packet hardware timestamp insertion */
+#define FIFO_CONFIG4                            0x22
+#define REG_FIFO_CONFIG4_TMST_FSYNC_EN(val)    (((val) & BIT_MASK(1)) << 1)
+
+/* TMST_WOM_CONFIG (0x23): timestamp resolution */
+#define TMST_WOM_CONFIG                         0x23
+#define REG_TMST_WOM_CONFIG_TMST_RESOL(val)    (((val) & BIT_MASK(1)) << 5)
+
 /* Misc. Defines */
 #define WHO_AM_I_ICM45686 0xE9
 

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -148,6 +148,8 @@ static void icm45686_complete_handler(struct rtio *ctx, const struct rtio_sqe *s
 	buf->header.events = REG_INT1_STATUS0_DRDY(data->stream.data.events.drdy) |
 			     REG_INT1_STATUS0_FIFO_THS(data->stream.data.events.fifo_ths) |
 			     REG_INT1_STATUS0_FIFO_FULL(data->stream.data.events.fifo_full);
+	buf->header.accel_odr = cfg->settings.accel.odr;
+	buf->header.gyro_odr = cfg->settings.gyro.odr;
 
 	if (should_flush_fifo(read_cfg, int_status)) {
 		uint8_t write_reg = REG_FIFO_CONFIG2_FIFO_FLUSH(true) |
@@ -501,6 +503,26 @@ void icm45686_stream_submit(const struct device *dev, struct rtio_iodev_sqe *iod
 			err = icm45686_reg_write_rtio(&data->bus, FIFO_CONFIG3, &val, 1);
 			if (err) {
 				LOG_ERR("Failed to enable FIFO: %d", err);
+				icm45686_stream_result(dev, err);
+				return;
+			}
+
+			/* Enable per-packet hardware timestamp insertion (20-byte hires packets).
+			 * Use 16μs resolution so that batches up to ~500ms fit in the signed
+			 * 16-bit delta used for correlation in the decoder.
+			 */
+			val = REG_FIFO_CONFIG4_TMST_FSYNC_EN(true);
+			err = icm45686_reg_write_rtio(&data->bus, FIFO_CONFIG4, &val, 1);
+			if (err) {
+				LOG_ERR("Failed to enable FIFO timestamp: %d", err);
+				icm45686_stream_result(dev, err);
+				return;
+			}
+
+			val = REG_TMST_WOM_CONFIG_TMST_RESOL(1); /* 16μs */
+			err = icm45686_reg_write_rtio(&data->bus, TMST_WOM_CONFIG, &val, 1);
+			if (err) {
+				LOG_ERR("Failed to set timestamp resolution: %d", err);
 				icm45686_stream_result(dev, err);
 				return;
 			}


### PR DESCRIPTION
## Summary

`base_timestamp_ns` was set to the time of the FIFO watermark/full interrupt rather than the time of the first sample in the buffer.

 (`use per-packet hardware timestamps`): enable `FIFO_TMST_FSYNC_EN` in `FIFO_CONFIG4` so the sensor inserts a 16-bit hardware timestamp into every 20-byte FIFO packet. Set `TMST_RESOL=1` (16us/tick) to support batch spans up to ~524ms. In the decoder, anchor the batch to the host IRQ time via the last packet's hardware timestamp, then compute `base_timestamp_ns` and per-sample `timestamp_delta` using the signed 16-bit delta between packet timestamps. This handles wraparound naturally and gives exact inter-sample timing without assuming a uniform ODR, superseding the ODR-based estimate from commit 1.

Split out of #108718 (per-sensor PR split requested during review).

Fixes: #98720