### PR TITLE
drivers: sensor: adxl345: fix base_timestamp_ns to first sample time

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345_decoder.c
+++ b/drivers/sensor/adi/adxl345/adxl345_decoder.c
@@ -115,14 +115,23 @@ static int adxl345_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	struct sensor_three_axis_data *data = (struct sensor_three_axis_data *)data_out;
 
 	memset(data, 0, sizeof(struct sensor_three_axis_data));
-	data->header.base_timestamp_ns = enc_data->timestamp;
-	data->header.reading_count = 1;
 	data->shift = range_to_shift[enc_data->selected_range];
 
 	buffer += sizeof(struct adxl345_fifo_data);
 
 	uint8_t sample_set_size = enc_data->sample_set_size;
+
+	if (sample_set_size == 0) {
+		return -ENODATA;
+	}
+
 	uint64_t period_ns = accel_period_ns[enc_data->accel_odr];
+	uint16_t total_samples = enc_data->fifo_byte_count / sample_set_size;
+
+	data->header.base_timestamp_ns =
+		enc_data->timestamp -
+		(total_samples > 0 ? (total_samples - 1) : 0) * period_ns;
+	data->header.reading_count = 1;
 	uint8_t is_full_res = enc_data->is_full_res;
 
 	/* Calculate which sample is decoded. */


### PR DESCRIPTION
## Summary

`base_timestamp_ns` was set to the time of the FIFO watermark/full interrupt rather than the time of the first sample in the buffer.

Adjust `base_timestamp_ns` backward from the trigger timestamp by `(N-1)*period` so it reflects the time of the first FIFO sample, matching the `lsm6dsv16x` reference implementation.

Split out of #108718 (per-sensor PR split requested during review).

Fixes: #98720