### PR TITLE
drivers: sensor: adxl355: fix base_timestamp_ns to first sample time

### DIFF
--- a/drivers/sensor/adi/adxl355/adxl355_decoder.c
+++ b/drivers/sensor/adi/adxl355/adxl355_decoder.c
@@ -116,13 +116,18 @@ static int adxl355_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	struct sensor_three_axis_data *data = (struct sensor_three_axis_data *)data_out;
 
 	memset(data, 0, sizeof(struct sensor_three_axis_sample_data));
-	data->header.base_timestamp_ns = enc_data->timestamp;
-	data->header.reading_count = 1;
 	data->shift = 11;
 
 	buffer += sizeof(struct adxl355_fifo_data);
 	uint8_t sample_set_size = enc_data->sample_set_size * 3;
 	uint64_t period_ns = accel_period_ns[enc_data->accel_odr];
+	uint16_t total_samples = sample_set_size > 0
+				 ? enc_data->fifo_byte_count / sample_set_size : 0;
+
+	data->header.base_timestamp_ns =
+		enc_data->timestamp -
+		(total_samples > 0 ? (total_samples - 1) : 0) * period_ns;
+	data->header.reading_count = 1;
 
 	/* Calculate which sample is decoded. */
 	if ((uint8_t *)*fit >= buffer) {


### PR DESCRIPTION
## Summary

`base_timestamp_ns` was set to the time of the FIFO watermark/full interrupt rather than the time of the first sample in the buffer.

Adjust `base_timestamp_ns` backward from the trigger timestamp by `(N-1)*period` so it reflects the time of the first FIFO sample, matching the `lsm6dsv16x` reference implementation.

Split out of #108718 (per-sensor PR split requested during review).

Fixes: #98720