### PR TITLE
drivers: sensor: adxl362: fix base_timestamp_ns to first sample time

### DIFF
--- a/drivers/sensor/adi/adxl362/adxl362_decoder.c
+++ b/drivers/sensor/adi/adxl362/adxl362_decoder.c
@@ -87,6 +87,10 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	}
 
 	uint64_t period_ns = accel_period_ns[enc_data->accel_odr];
+	uint16_t total_samples = sample_set_size > 0
+				 ? enc_data->fifo_byte_count / sample_set_size : 0;
+	uint64_t base_ts = enc_data->timestamp -
+			   (total_samples > 0 ? (total_samples - 1) : 0) * period_ns;
 
 	/* Calculate which sample is decoded. */
 	if (*fit >= (uintptr_t)buffer) {
@@ -109,7 +113,7 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 				struct sensor_q31_data *data = (struct sensor_q31_data *)data_out;
 
 				memset(data, 0, sizeof(struct sensor_three_axis_data));
-				data->header.base_timestamp_ns = enc_data->timestamp;
+				data->header.base_timestamp_ns = base_ts;
 				data->header.reading_count = 1;
 				data->shift = 8;
 
@@ -129,7 +133,7 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 					(struct sensor_three_axis_data *)data_out;
 
 			memset(data, 0, sizeof(struct sensor_three_axis_data));
-			data->header.base_timestamp_ns = enc_data->timestamp;
+			data->header.base_timestamp_ns = base_ts;
 			data->header.reading_count = 1;
 			data->shift = range_to_shift[enc_data->selected_range];
 

--- a/drivers/sensor/adi/adxl362/adxl362_decoder.c
+++ b/drivers/sensor/adi/adxl362/adxl362_decoder.c
@@ -87,6 +87,10 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	}
 
 	uint64_t period_ns = accel_period_ns[enc_data->accel_odr];
+	uint16_t total_samples = sample_set_size > 0
+				 ? enc_data->fifo_byte_count / sample_set_size : 0;
+	uint64_t base_ts = enc_data->timestamp -
+			   (total_samples > 0 ? (total_samples - 1) : 0) * period_ns;
 
 	/* Calculate which sample is decoded. */
 	if (*fit >= (uintptr_t)buffer) {
@@ -97,7 +101,7 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 		struct sensor_q31_data *data = (struct sensor_q31_data *)data_out;
 
 		memset(data, 0, sizeof(struct sensor_q31_data));
-		data->header.base_timestamp_ns = enc_data->timestamp;
+		data->header.base_timestamp_ns = base_ts;
 		data->shift = 8;
 
 		while (count < max_count && buffer < buffer_end) {
@@ -130,7 +134,7 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 				(struct sensor_three_axis_data *)data_out;
 
 		memset(data, 0, sizeof(struct sensor_three_axis_data));
-		data->header.base_timestamp_ns = enc_data->timestamp;
+		data->header.base_timestamp_ns = base_ts;
 		data->shift = range_to_shift[enc_data->selected_range];
 
 		while (count < max_count && buffer < buffer_end) {


### PR DESCRIPTION
## Summary

`base_timestamp_ns` was set to the time of the FIFO watermark/full interrupt rather than the time of the first sample in the buffer.

Adjust `base_timestamp_ns` backward from the trigger timestamp by `(N-1)*period` so it reflects the time of the first FIFO sample, matching the `lsm6dsv16x` reference implementation.

Split out of #108718 (per-sensor PR split requested during review).

Fixes: #98720