### PR TITLE
drivers: sensor: adxl367: fix base_timestamp_ns to first sample time

### DIFF
--- a/drivers/sensor/adi/adxl367/adxl367_decoder.c
+++ b/drivers/sensor/adi/adxl367/adxl367_decoder.c
@@ -421,7 +421,7 @@ static void adxl367_get_12b_temp(const struct adxl367_fifo_data *enc_data,
 
 static int adxl367_decode_12b_stream(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
 				uint32_t *fit, uint16_t max_count, void *data_out,
-				const struct adxl367_fifo_data *enc_data)
+				const struct adxl367_fifo_data *enc_data, uint64_t base_ts)
 {
 	const uint8_t *buffer_end =
 		buffer + sizeof(struct adxl367_fifo_data) + enc_data->fifo_byte_count;
@@ -469,7 +469,7 @@ static int adxl367_decode_12b_stream(const uint8_t *buffer, struct sensor_chan_s
 			struct sensor_q31_data *data = (struct sensor_q31_data *)data_out;
 
 			memset(data, 0, sizeof(struct sensor_three_axis_data));
-			data->header.base_timestamp_ns = enc_data->timestamp;
+			data->header.base_timestamp_ns = base_ts;
 			data->header.reading_count = 1;
 			data->shift = 8;
 
@@ -482,7 +482,7 @@ static int adxl367_decode_12b_stream(const uint8_t *buffer, struct sensor_chan_s
 				(struct sensor_three_axis_data *)data_out;
 
 			memset(data, 0, sizeof(struct sensor_three_axis_data));
-			data->header.base_timestamp_ns = enc_data->timestamp;
+			data->header.base_timestamp_ns = base_ts;
 			data->header.reading_count = 1;
 			data->shift = range_to_shift[enc_data->range];
 
@@ -518,6 +518,11 @@ static int adxl367_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	buffer += sizeof(struct adxl367_fifo_data);
 
 	uint8_t packet_size = enc_data->packet_size;
+
+	if (packet_size == 0) {
+		return -ENODATA;
+	}
+
 	uint64_t period_ns = accel_period_ns[enc_data->accel_odr];
 	uint8_t sample_size = 2;
 
@@ -525,9 +530,13 @@ static int adxl367_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 		sample_size = 1;
 	}
 
+	uint16_t total_samples = enc_data->fifo_byte_count / packet_size;
+	uint64_t base_ts = enc_data->timestamp -
+			   (total_samples > 0 ? (total_samples - 1) : 0) * period_ns;
+
 	if (enc_data->fifo_read_mode == ADXL367_12B) {
 		count = adxl367_decode_12b_stream(buffer, chan_spec, fit, max_count,
-			data_out, enc_data);
+			data_out, enc_data, base_ts);
 	} else {
 		/* Calculate which sample is decoded. */
 		if (*fit >= (uintptr_t)buffer) {
@@ -549,7 +558,7 @@ static int adxl367_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 				struct sensor_q31_data *data = (struct sensor_q31_data *)data_out;
 
 				memset(data, 0, sizeof(struct sensor_three_axis_data));
-				data->header.base_timestamp_ns = enc_data->timestamp;
+				data->header.base_timestamp_ns = base_ts;
 				data->header.reading_count = 1;
 				data->shift = 8;
 
@@ -567,7 +576,7 @@ static int adxl367_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 					(struct sensor_three_axis_data *)data_out;
 
 				memset(data, 0, sizeof(struct sensor_three_axis_data));
-				data->header.base_timestamp_ns = enc_data->timestamp;
+				data->header.base_timestamp_ns = base_ts;
 				data->header.reading_count = 1;
 				data->shift = range_to_shift[enc_data->range];
 


### PR DESCRIPTION
## Summary

`base_timestamp_ns` was set to the time of the FIFO watermark/full interrupt rather than the time of the first sample in the buffer.

Adjust `base_timestamp_ns` backward from the trigger timestamp by `(N-1)*period` so it reflects the time of the first FIFO sample, matching the `lsm6dsv16x` reference implementation.

Split out of #108718 (per-sensor PR split requested during review).

Fixes: #98720