### PR TITLE
drivers: sensor: bmi08x: fix timestamps in FIFO stream

### DIFF
--- a/drivers/sensor/bosch/bmi08x/bmi08x.h
+++ b/drivers/sensor/bosch/bmi08x/bmi08x.h
@@ -632,6 +632,7 @@ struct bmi08x_accel_encoded_data {
 		uint16_t fifo_len;
 		uint8_t sample_count;
 		uint16_t buf_len;
+		uint8_t accel_odr;
 	} header;
 	union {
 		uint16_t payload[3];

--- a/drivers/sensor/bosch/bmi08x/bmi08x.h
+++ b/drivers/sensor/bosch/bmi08x/bmi08x.h
@@ -649,6 +649,7 @@ struct bmi08x_gyro_encoded_data {
 		uint8_t int_status;
 		uint8_t fifo_status;
 		uint8_t sample_count;
+		uint8_t gyro_odr;
 	} header;
 	union {
 		struct bmi08x_gyro_frame frame;

--- a/drivers/sensor/bosch/bmi08x/bmi08x_accel_decoder.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_accel_decoder.c
@@ -42,10 +42,23 @@ struct frame_len {
 	{.header = BMI08X_ACCEL_FIFO_FRAME_EMPTY, .len = 2},
 };
 
+/* Period in ns indexed by BMI08X_ACCEL_ODR_* register value (0x05 = 12.5 Hz .. 0x0C = 1600 Hz) */
+static const uint32_t accel_period_ns[] = {
+	[BMI08X_ACCEL_ODR_12_5_HZ] = UINT32_C(80000000),
+	[BMI08X_ACCEL_ODR_25_HZ]   = UINT32_C(40000000),
+	[BMI08X_ACCEL_ODR_50_HZ]   = UINT32_C(20000000),
+	[BMI08X_ACCEL_ODR_100_HZ]  = UINT32_C(10000000),
+	[BMI08X_ACCEL_ODR_200_HZ]  = UINT32_C(5000000),
+	[BMI08X_ACCEL_ODR_400_HZ]  = UINT32_C(2500000),
+	[BMI08X_ACCEL_ODR_800_HZ]  = UINT32_C(1250000),
+	[BMI08X_ACCEL_ODR_1600_HZ] = UINT32_C(625000),
+};
+
 void bmi08x_accel_encode_header(const struct device *dev, struct bmi08x_accel_encoded_data *edata,
 			       bool is_streaming, uint16_t buf_len)
 {
 	struct bmi08x_accel_data *data = dev->data;
+	const struct bmi08x_accel_config *config = dev->config;
 	uint64_t cycles;
 
 	if (sensor_clock_get_cycles(&cycles) == 0) {
@@ -59,6 +72,7 @@ void bmi08x_accel_encode_header(const struct device *dev, struct bmi08x_accel_en
 	edata->header.is_streaming = is_streaming;
 	edata->header.sample_count = is_streaming ? data->stream.fifo_wm : 1;
 	edata->header.buf_len = buf_len;
+	edata->header.accel_odr = config->accel_hz;
 }
 
 static int bmi08x_decoder_get_frame_count(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
@@ -154,9 +168,15 @@ static inline int bmi08x_decode_fifo(const struct bmi08x_accel_encoded_data *eda
 	 * - 8 - 12 G (78.4 - 117.6 m/s2) = 7 bits.
 	 * - 16 - 24 G (156.8 235.2 m/s2) = 8 bits.
 	 */
+	uint32_t period_ns = (edata->header.accel_odr < ARRAY_SIZE(accel_period_ns))
+			     ? accel_period_ns[edata->header.accel_odr] : 0;
+
 	data_output->shift = 5 + edata->header.range;
 	data_output->header.reading_count = 0;
-	data_output->header.base_timestamp_ns = edata->header.timestamp;
+	data_output->header.base_timestamp_ns =
+		edata->header.timestamp -
+		(uint64_t)(edata->header.sample_count > 0
+			   ? edata->header.sample_count - 1 : 0) * period_ns;
 
 	do {
 		uint8_t header_byte = edata->fifo[*fit] & 0xFC;
@@ -174,6 +194,8 @@ static inline int bmi08x_decode_fifo(const struct bmi08x_accel_encoded_data *eda
 			fixed_point_from_encoded_data(
 				values, data_output->shift, fsr_value_g,
 				data_output->readings[reading_count].values);
+			data_output->readings[reading_count].timestamp_delta =
+				reading_count * period_ns;
 			reading_count++;
 		}
 		*fit += frame_len;

--- a/drivers/sensor/bosch/bmi08x/bmi08x_gyro_decoder.c
+++ b/drivers/sensor/bosch/bmi08x/bmi08x_gyro_decoder.c
@@ -22,10 +22,23 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(BMI08X_GYRO_DECODER, CONFIG_SENSOR_LOG_LEVEL);
 
+/* Period in ns indexed by BMI08X_GYRO_BW_* register value (0x00..0x07) */
+static const uint32_t gyro_period_ns[] = {
+	[0x00] = UINT32_C(500000),    /* 2000 Hz */
+	[0x01] = UINT32_C(500000),    /* 2000 Hz */
+	[0x02] = UINT32_C(1000000),   /* 1000 Hz */
+	[0x03] = UINT32_C(2500000),   /* 400 Hz  */
+	[0x04] = UINT32_C(5000000),   /* 200 Hz  */
+	[0x05] = UINT32_C(10000000),  /* 100 Hz  */
+	[0x06] = UINT32_C(5000000),   /* 200 Hz  */
+	[0x07] = UINT32_C(10000000),  /* 100 Hz  */
+};
+
 void bmi08x_gyro_encode_header(const struct device *dev, struct bmi08x_gyro_encoded_data *edata,
 			       bool is_streaming)
 {
 	struct bmi08x_gyro_data *data = dev->data;
+	const struct bmi08x_gyro_config *config = dev->config;
 	uint64_t cycles;
 
 	if (sensor_clock_get_cycles(&cycles) == 0) {
@@ -37,6 +50,7 @@ void bmi08x_gyro_encode_header(const struct device *dev, struct bmi08x_gyro_enco
 	edata->header.range = data->range;
 	edata->header.is_streaming = is_streaming;
 	edata->header.sample_count = is_streaming ? data->stream.fifo_wm : 1;
+	edata->header.gyro_odr = config->gyro_hz;
 }
 
 static int bmi08x_decoder_get_frame_count(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
@@ -88,6 +102,8 @@ static int bmi08x_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec 
 		return -ENODATA;
 	}
 	uint32_t max_samples = MIN(edata->header.sample_count, edata->header.fifo_status & 0x7F);
+	uint32_t period_ns = (edata->header.gyro_odr < ARRAY_SIZE(gyro_period_ns))
+			     ? gyro_period_ns[edata->header.gyro_odr] : 0;
 
 	/** Bits we need to represent the integer part of FSR in rad/s:
 	 * - 2000 dps (34.91 rad/s) = 6 bits.
@@ -97,17 +113,22 @@ static int bmi08x_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec 
 	 * -  125 dps (2.18 rad/s) = 2 bits.
 	 */
 	data_output->shift = 6 - edata->header.range;
-	data_output->header.base_timestamp_ns = edata->header.timestamp;
+	data_output->header.base_timestamp_ns =
+		edata->header.timestamp -
+		(uint64_t)(max_samples > 0 ? max_samples - 1 : 0) * period_ns;
 
 	do {
+		uint32_t idx = *fit - fit0;
+
 		for (size_t i = 0 ; i < 3 ; i++) {
 			int64_t raw_value;
 
 			raw_value = sign_extend_64(edata->fifo[*fit].payload[i], 15);
 			raw_value = (raw_value * 2000 << (31 - 6 - 15)) * SENSOR_PI / 1000000 / 180;
 
-			data_output->readings[*fit - fit0].values[i] = raw_value;
+			data_output->readings[idx].values[i] = raw_value;
 		}
+		data_output->readings[idx].timestamp_delta = idx * period_ns;
 	} while (++(*fit) < MIN(max_samples, fit0 + max_count));
 
 	data_output->header.reading_count = *fit - fit0;


### PR DESCRIPTION
## Summary

`base_timestamp_ns` was set to the time of the FIFO watermark/full interrupt rather than the time of the first sample in the buffer.

Add `accel_odr`/`gyro_odr` to the encoded header so the decoder knows the sample rate. Fix `base_timestamp_ns` to reflect the time of the first FIFO sample (`trigger_time - (N-1)*period`) and add `timestamp_delta` per sample, matching the `lsm6dsv16x` reference implementation. Both the accel and gyro drivers are fixed here since they share the `bmi08x` driver family.

Split out of #108718

Fixes: #98720