### PR TITLE
fs: virtiofs: validate READ response length before returning

### DIFF
--- a/subsys/fs/virtiofs/virtiofs.c
+++ b/subsys/fs/virtiofs/virtiofs.c
@@ -365,6 +365,17 @@ int virtiofs_read(
 		return valid_ret;
 	}
 
+	/* out_header.len is host-controlled; guard against underflow (smaller
+	 * than the header) and against returning more bytes than the read
+	 * buffer can hold.
+	 */
+	if (req.out_header.len < sizeof(req.out_header) ||
+	    (req.out_header.len - sizeof(req.out_header)) > size) {
+		LOG_ERR("FUSE_READ response length 0x%x invalid for buffer %u",
+			req.out_header.len, size);
+		return -EIO;
+	}
+
 	return req.out_header.len - sizeof(req.out_header);
 }
 


### PR DESCRIPTION
virtiofs_read() validated only error/used_len but passed expected_len=-1
to virtiofs_validate_response(), skipping the length check. The host-
supplied out_header.len was then used to compute the return value; a
value smaller than sizeof(out_header) underflowed, and a value larger
than the read buffer would misrepresent the bytes read.

Guard against both cases before returning.
