### PR TITLE
bluetooth: classic: l2cap: fix I/S-frame transmission logic

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1106,6 +1106,19 @@ static struct net_buf *l2cap_br_get_next_sdu(struct bt_l2cap_br_chan *br_chan)
 	return NULL;
 }
 
+static bool l2cap_br_retransmit_is_required(struct bt_l2cap_br_chan *br_chan)
+{
+	struct bt_l2cap_br_window *tx_win, *next;
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&br_chan->_pdu_outstanding, tx_win, next, node) {
+		if (tx_win->retransmit) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 static bool l2cap_br_send_i_frame(struct bt_l2cap_br_chan *br_chan, struct net_buf *sdu)
 {
 	if (atomic_test_bit(br_chan->flags, L2CAP_FLAG_REMOTE_BUSY)) {
@@ -1119,11 +1132,13 @@ static bool l2cap_br_send_i_frame(struct bt_l2cap_br_chan *br_chan, struct net_b
 	}
 
 	if (atomic_test_bit(br_chan->flags, L2CAP_FLAG_RET_I_FRAME)) {
-		return true;
+		if (sys_slist_peek_head(&br_chan->_pdu_outstanding) != NULL) {
+			return true;
+		}
 	}
 
 	if (atomic_test_bit(br_chan->flags, L2CAP_FLAG_RET_I_FRAMES)) {
-		return true;
+		return l2cap_br_retransmit_is_required(br_chan);
 	}
 
 	if (atomic_test_bit(br_chan->flags, L2CAP_FLAG_SEND_FRAME_P)) {


### PR DESCRIPTION
when an S-frame needs to be sent, the function
`l2cap_br_ret_fc_data_pull()` calls `l2cap_br_send_i_frame()` to determine whether an I-frame should be sent instead. If an I-frame needs to be sent, the S-frame is not transmitted; instead, the S-frame information is sent within the I-frame.

Currently, when `L2CAP_FLAG_RET_I_FRAME` was set, the code would block a S-frame transmission if any outstanding PDUs existed, and try to perform a retransmission I-frame, regardless of whether they needed retransmission. Similarly, when
`L2CAP_FLAG_RET_I_FRAMES` was set, the S-frame transmission was always blocked without checking if I-frame retransmission was actually needed.

It leads to an issue that no any I-frames or S-frames are performed.

Fix the L2CAP BR/EDR I-frame transmission logic to properly handle retransmission scenarios by checking if retransmission is actually required before blocking new frame transmission.

The change introduces a helper function
`l2cap_br_retransmit_is_required()` that checks if any outstanding PDUs in the transmission window actually need retransmission by examining the retransmit flag.

With the changes, the code checks if the outstanding queue is non-empty for the single frame retransmission case, and uses the new helper to verify if I-frame retransmission is truly required for the multiple frames case. This prevents unnecessary blocking of S-frame transmission when outstanding PDUs don't require retransmission.