### PR TITLE
imx93 hal upgrade in order to align with drivers

### DIFF
--- a/modules/hal_nxp/mcux/mcux-sdk/CMakeLists.txt
+++ b/modules/hal_nxp/mcux/mcux-sdk/CMakeLists.txt
@@ -14,10 +14,12 @@ zephyr_compile_definitions(${MCUX_CPU})
 list(APPEND CMAKE_MODULE_PATH
     ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/mcux-sdk/devices/${MCUX_DEVICE_PATH}
     ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/mcux-sdk/devices/${MCUX_DEVICE_PATH}/drivers
+    ${ZEPHYR_CURRENT_MODULE_DIR}/mcux/mcux-sdk/devices/${MCUX_DEVICE_PATH}/periph
 )
 
 zephyr_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/mcux/mcux-sdk/devices/${MCUX_DEVICE_PATH})
 zephyr_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/mcux/mcux-sdk/devices/${MCUX_DEVICE_PATH}/drivers)
+zephyr_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/mcux/mcux-sdk/devices/${MCUX_DEVICE_PATH}/periph)
 
 if(CONFIG_CPU_CORTEX_A)
     list(APPEND CMAKE_MODULE_PATH

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 53946adb08b54449391c1c0c73cdd094d92a3b6e
+      revision: ba28ac2057aa97c5a18780cecf93e54ccf927fae
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
There are some issues as hal drivers updates in sdk-ng, need to update chipmodel header files to align with driver update.
