### PR TITLE
devicetree: fix incorrect doc reference

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -3560,7 +3560,7 @@
  *            this is required to enable providing a comma as separator.
  * @param ... variable number of arguments to pass to @p fn
  *
- * @see DT_FOREACH_CHILD_SEP_STATUS_OKAY
+ * @see DT_FOREACH_CHILD_STATUS_OKAY_SEP
  */
 #define DT_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(node_id, fn, sep, ...) \
 	DT_CAT(node_id, _FOREACH_CHILD_STATUS_OKAY_SEP_VARGS)(fn, sep, __VA_ARGS__)


### PR DESCRIPTION
`DT_FOREACH_CHILD_SEP_STATUS_OKAY` was never the correct name, even back when the comment was first introduced in fff9ecbc.