### PR TITLE
FRDM-MCXL255: WUU support for CM33

### DIFF
--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
@@ -110,3 +110,7 @@
 &systick {
 	status = "okay";
 };
+
+&wuu {
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
@@ -15,4 +15,5 @@ supported:
   - gpio
   - rtc
   - crc
+  - wuc
 vendor: nxp

--- a/dts/arm/nxp/mcx/nxp_mcxl.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl.dtsi
@@ -193,10 +193,12 @@
 		interrupts = <1 0>;
 	};
 
-	wuu: system-modules@92000 {
-		compatible = "nxp,wuu";
+	wuu: wakeup-controller@92000 {
+		compatible = "nxp,wuc-wuu", "nxp,wuu";
 		reg = <0x92000 0x1000>;
 		interrupts = <18 0>;
+		#wakeup-ctrl-cells = <1>;
+		status = "disabled";
 	};
 
 	mbox_a: mbox@c4000 {


### PR DESCRIPTION
Add WUU support for the FRDM-MCXL255 board target.

This PR describes the MCXL WUU as an NXP Wakeup Controller using the
`nxp,wuc-wuu` compatible, while keeping the legacy `nxp,wuu` compatible.

The WUU instance is enabled for the FRDM-MCXL255 CPU0/CM33 board target
and WUC support is mentioned in the board metadata.

Tested with:
- `samples/hello_world` on `frdm_mcxl255/mcxl255/cpu0`
- `tests/drivers/wuc/wuc_api` on `frdm_mcxl255/mcxl255/cpu0` with a temporary overlay