### PR TITLE
Reopen of #105543, which implements the hooks-based approach to hardware-map scripting originally proposed by @nashif in #99918.

### DIFF
--- a/boards/st/nucleo_n657x0_q/doc/index.rst
+++ b/boards/st/nucleo_n657x0_q/doc/index.rst
@@ -324,8 +324,21 @@ To do so, it is advised to use Twister's hardware map feature with the following
 
    - platform: nucleo_n657x0_q/stm32n657xx/sb
      product: BOOT-SERIAL
-     pre_script: <path_to_zephyr>/boards/st/common/scripts/board_power_reset.sh
      runner: stm32cubeprogrammer
+     hooks:
+       - type: pre
+         script: ${ZEPHYR_BASE}/boards/st/common/scripts/board_power_reset.sh
+
+.. note::
+
+   The legacy ``pre_script`` field is still supported for backward compatibility:
+
+   .. code-block:: yaml
+
+      - platform: nucleo_n657x0_q/stm32n657xx/sb
+        product: BOOT-SERIAL
+        pre_script: <path_to_zephyr>/boards/st/common/scripts/board_power_reset.sh
+        runner: stm32cubeprogrammer
 
 .. _NUCLEO-N657X0-Q website:
    https://www.st.com/en/evaluation-tools/nucleo-n657x0-q.html

--- a/boards/st/stm32n6570_dk/doc/index.rst
+++ b/boards/st/stm32n6570_dk/doc/index.rst
@@ -461,8 +461,21 @@ To do so, it is advised to use Twister's hardware map feature with the following
 
    - platform: stm32n6570_dk/stm32n657xx/sb
      product: BOOT-SERIAL
-     pre_script: <path_to_zephyr>/boards/st/common/scripts/board_power_reset.sh
      runner: stm32cubeprogrammer
+     hooks:
+       - type: pre
+         script: ${ZEPHYR_BASE}/boards/st/common/scripts/board_power_reset.sh
+
+.. note::
+
+   The legacy ``pre_script`` field is still supported for backward compatibility:
+
+   .. code-block:: yaml
+
+      - platform: stm32n6570_dk/stm32n657xx/sb
+        product: BOOT-SERIAL
+        pre_script: <path_to_zephyr>/boards/st/common/scripts/board_power_reset.sh
+        runner: stm32cubeprogrammer
 
 .. _STM32N6570_DK website:
    https://www.st.com/en/evaluation-tools/stm32n6570-dk.html

--- a/doc/develop/twister/index.rst
+++ b/doc/develop/twister/index.rst
@@ -1492,6 +1492,115 @@ Would result in calling ``./custom_flash_script.py
 --build-dir <build directory> --board-id <board identification>
 --flag "complex, argument"``.
 
+Hardware Hooks
+--------------
+
+Twister supports running custom scripts at specific points during the
+device test lifecycle. These are called **hooks** and can be defined in the
+hardware map file using the ``hooks`` field. Hooks replace the legacy
+``pre_script``, ``post_script``, ``post_flash_script``, and ``script_param``
+fields, which are still supported for backward compatibility.
+
+The ``hooks`` object uses lifecycle point names as keys. Supported keys are:
+
+- ``pre`` – runs before the serial connection is opened and the device is
+  flashed.
+- ``pre_flash`` – runs immediately before flashing starts.
+- ``post_flash`` – runs immediately after flashing completes.
+- ``post`` – runs after the test finishes and the serial connection is
+  closed.
+
+Each value is an object with the following properties:
+
+- ``script`` *(required)*: Path to the script or executable to run.
+- ``args`` *(optional)*: A list of string arguments passed to the script.
+  Defaults to an empty list.
+- ``timeout`` *(optional)*: Maximum time in seconds to wait for the script
+  to complete. Defaults to 60 seconds. If the timeout is exceeded, the
+  process is killed and an error is logged.
+
+Example hardware map entry with hooks:
+
+.. code-block:: yaml
+
+   - connected: true
+     id: 000683759358
+     platform: nrf52840dk/nrf52840
+     product: J-Link
+     runner: nrfjprog
+     serial: /dev/ttyACM0
+     hooks:
+       pre:
+         script: /path/to/pre_test_setup.sh
+         args:
+           - --reset
+           - --verbose
+         timeout: 30
+       pre_flash:
+         script: /path/to/pre_flash_setup.sh
+         timeout: 10
+       post_flash:
+         script: /path/to/verify_flash.sh
+         timeout: 15
+       post:
+         script: /path/to/cleanup.sh
+
+The hooks are executed in the context of the running test. Environment
+variables from the test environment are passed to the hook scripts. If the
+script exits with a non-zero return code, an error is logged but test
+execution continues.
+
+Legacy Script Fields (Deprecated)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following fields are still supported but are converted internally to the
+``hooks`` format. New configurations should use ``hooks`` instead.
+
+- ``pre_script``: Equivalent to the ``pre`` hook.
+- ``post_script``: Equivalent to the ``post`` hook.
+- ``post_flash_script``: Equivalent to the ``post_flash`` hook.
+- ``script_param``: An object that previously controlled timeouts for the
+  above scripts via ``pre_script_timeout``, ``post_script_timeout``, and
+  ``post_flash_timeout``. These are now specified directly in the hook's
+  ``timeout`` field.
+
+Example using legacy fields (still functional):
+
+.. code-block:: yaml
+
+   - connected: true
+     id: 000683759358
+     platform: stm32n6570_dk/stm32n657xx/sb
+     product: BOOT-SERIAL
+     runner: stm32cubeprogrammer
+     serial: /dev/ttyACM0
+     pre_script: /path/to/board_power_reset.sh
+     post_flash_script: /path/to/verify.sh
+     script_param:
+       pre_script_timeout: 30
+       post_flash_timeout: 15
+
+The equivalent configuration using the new ``hooks`` format:
+
+.. code-block:: yaml
+
+   - connected: true
+     id: 000683759358
+     platform: stm32n6570_dk/stm32n657xx/sb
+     product: BOOT-SERIAL
+     runner: stm32cubeprogrammer
+     serial: /dev/ttyACM0
+     hooks:
+       pre:
+         script: /path/to/board_power_reset.sh
+         timeout: 30
+       post_flash:
+         script: /path/to/verify.sh
+         timeout: 15
+
+If both ``hooks`` and legacy script fields are present in a hardware map
+entry, the ``hooks`` field takes precedence.
+
 .. _twister_fixtures:
 
 Fixtures

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from serial import SerialException
 
 from twister_harness.device.device_adapter import DeviceAdapter
-from twister_harness.device.utils import log_command, terminate_process
+from twister_harness.device.utils import log_command
 from twister_harness.exceptions import (
     TwisterHarnessException,
     TwisterHarnessTimeoutException,
@@ -145,13 +145,13 @@ class HardwareAdapter(DeviceAdapter):
             logger.error(msg)
             raise TwisterHarnessException(msg)
 
-        if self.device_config.pre_script:
-            self._run_custom_script(self.device_config.pre_script, self.base_timeout)
+        self.device_config.dut.run_hook('pre')
 
         if self.device_config.id:
             logger.debug('Flashing device %s', self.device_config.id)
         log_command(logger, 'Flashing command', self.command, level=logging.DEBUG)
 
+        self.device_config.dut.run_hook('pre_flash')
         process = stdout = None
         try:
             process = subprocess.Popen(
@@ -172,8 +172,7 @@ class HardwareAdapter(DeviceAdapter):
                 stdout_decoded = stdout.decode(errors='ignore')
                 with open(self.device_log_path, 'a+') as log_file:
                     log_file.write(stdout_decoded)
-            if self.device_config.post_flash_script:
-                self._run_custom_script(self.device_config.post_flash_script, self.base_timeout)
+            self.device_config.dut.run_hook('post_flash')
             if process is not None and process.returncode == 0:
                 logger.debug('Flashing finished')
             else:
@@ -184,25 +183,5 @@ class HardwareAdapter(DeviceAdapter):
     def _close_device(self) -> None:
         # Run post script only if the reader thread is started to avoid running it
         # multiple times and when in initialization phase
-        if self.is_reader_started() and self.device_config.post_script:
-            self._run_custom_script(self.device_config.post_script, self.base_timeout)
-
-    @staticmethod
-    def _run_custom_script(script_path: str | Path, timeout: float) -> None:
-        with subprocess.Popen(
-            str(script_path), stderr=subprocess.PIPE, stdout=subprocess.PIPE
-        ) as proc:
-            try:
-                stdout, stderr = proc.communicate(timeout=timeout)
-                logger.debug(stdout.decode())
-                if proc.returncode != 0:
-                    msg = f'Custom script failure: \n{stderr.decode(errors="ignore")}'
-                    logger.error(msg)
-                    raise TwisterHarnessException(msg)
-
-            except subprocess.TimeoutExpired as exc:
-                terminate_process(proc)
-                proc.communicate(timeout=timeout)
-                msg = f'Timeout occurred ({timeout}s) during execution custom script: {script_path}'
-                logger.error(msg)
-                raise TwisterHarnessTimeoutException(msg) from exc
+        if self.is_reader_started():
+            self.device_config.dut.run_hook('post')

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -110,21 +110,6 @@ def pytest_addoption(parser: pytest.Parser):
         help='Use a custom flash command for flashing.'
     )
     twister_harness_group.addoption(
-        '--pre-script',
-        metavar='PATH',
-        help='Script executed before flashing and connecting to serial.'
-    )
-    twister_harness_group.addoption(
-        '--post-flash-script',
-        metavar='PATH',
-        help='Script executed after flashing.'
-    )
-    twister_harness_group.addoption(
-        '--post-script',
-        metavar='PATH',
-        help='Script executed after closing serial connection.'
-    )
-    twister_harness_group.addoption(
         '--dut-scope',
         choices=('function', 'class', 'module', 'package', 'session'),
         help='The scope for which `dut` and `shell` fixtures are shared.'
@@ -172,9 +157,6 @@ def _normalize_paths(config: pytest.Config) -> None:
     """Normalize paths provided by user via CLI"""
     config.option.build_dir = _normalize_path(config.option.build_dir)
     config.option.twister_config = _normalize_path(config.option.twister_config)
-    config.option.pre_script = _normalize_path(config.option.pre_script)
-    config.option.post_script = _normalize_path(config.option.post_script)
-    config.option.post_flash_script = _normalize_path(config.option.post_flash_script)
 
 
 def _normalize_path(path: str | None) -> str:

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -28,6 +28,7 @@ class DeviceSerialConfig:
 class DeviceConfig:
     type: str
     build_dir: Path
+    dut: HardwareData = field(default_factory=HardwareData)
     current_build_dir: Path | None = None
     app_build_dir: Path | None = None
     base_timeout: float = 60.0  # [s]
@@ -42,9 +43,6 @@ class DeviceConfig:
     west_flash_extra_args: list[str] = field(default_factory=list, repr=False)
     flash_command: str = ''
     name: str = ''
-    pre_script: Path | None = None
-    post_script: Path | None = None
-    post_flash_script: Path | None = None
     fixtures: list[str] = None
     extra_test_args: str = ''
     west_flash_cmd: str = ''
@@ -133,6 +131,7 @@ class TwisterHarnessConfig:
                 )
 
             device = DeviceConfig(
+                dut=dut,
                 dut_number=dut_number,
                 type=device_type,
                 build_dir=build_dir,
@@ -149,9 +148,6 @@ class TwisterHarnessConfig:
                 west_flash_extra_args=west_flash_extra_args,
                 west_flash_cmd=config.option.west_flash_cmd or test_params.west_flash_cmd or dut.west_flash_cmd,
                 flash_command=flash_command,
-                pre_script=get_path(config.option.pre_script) or get_path(dut.pre_script),
-                post_script=get_path(config.option.post_script) or get_path(dut.post_script),
-                post_flash_script=get_path(config.option.post_flash_script) or get_path(dut.post_flash_script),
                 fixtures=config.option.fixtures or test_params.twister_fixtures or dut.fixtures,
                 extra_test_args=config.option.extra_test_args or test_params.extra_test_args,
             )

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -520,20 +520,6 @@ class DeviceHandler(Handler):
                     ser.close()
                     break
 
-    @staticmethod
-    def run_custom_script(script, timeout):
-        with subprocess.Popen(script, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
-            try:
-                stdout, stderr = proc.communicate(timeout=timeout)
-                logger.debug(stdout.decode())
-                if proc.returncode != 0:
-                    logger.error(f"Custom script failure: {stderr.decode(errors='ignore')}")
-
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.communicate()
-                logger.error(f"{script} timed out")
-
     def _create_flash_command(self, hardware):
         flash_command = next(csv.reader([self.options.flash_command]))
 
@@ -681,7 +667,7 @@ class DeviceHandler(Handler):
         return ser_pty_process
 
     def _handle_robot_test(self, harness, hardware, command, serial_device, serial_pty,
-                            post_flash_script, post_script, script_param, flash_timeout):
+                            flash_timeout):
         """Flash device and run Robot Framework test directly without serial monitoring."""
         start_time = time.time()
         d_log = f"{self.instance.build_dir}/device.log"
@@ -718,11 +704,7 @@ class DeviceHandler(Handler):
             with open(d_log, "w") as dlog_fp:
                 dlog_fp.write(stderr.decode())
 
-        if post_flash_script:
-            timeout = 30
-            if script_param:
-                timeout = script_param.get("post_flash_timeout", timeout)
-            self.run_custom_script(post_flash_script, timeout)
+        hardware.run_hook("post_flash")
 
         self.execution_time = time.time() - start_time
 
@@ -733,25 +715,14 @@ class DeviceHandler(Handler):
                              "--variable", f"BUILD_DIR:{self.build_dir}"]
             harness.run_robot_test(robot_command, self)
 
-        if post_script:
-            timeout = 30
-            if script_param:
-                timeout = script_param.get("post_script_timeout", timeout)
-            self.run_custom_script(post_script, timeout)
+        hardware.run_hook("post")
 
     def handle(self, harness):
         robot_test = getattr(harness, "is_robot_test", False) is True
         hardware: CompoundHardwareData = self.instance.reserved_duts[0]
 
         # Run pre-script BEFORE starting serial PTY to avoid conflicts
-        pre_script = hardware.pre_script
-        script_param = hardware.script_param
-
-        if pre_script:
-            timeout = 30
-            if script_param:
-                timeout = script_param.get("pre_script_timeout", timeout)
-            self.run_custom_script(pre_script, timeout)
+        hardware.run_hook("pre")
 
         runner = hardware.runner or self.options.west_runner
         serial_pty = hardware.serial_pty
@@ -766,9 +737,6 @@ class DeviceHandler(Handler):
 
         command = self._create_command(runner, hardware)
 
-        post_flash_script = hardware.post_flash_script
-        post_script = hardware.post_script
-
         flash_timeout = hardware.flash_timeout
         if hardware.flash_with_test:
             flash_timeout += self.get_test_timeout()
@@ -778,7 +746,7 @@ class DeviceHandler(Handler):
             # directly. Robot Framework will open the serial port itself.
             self._handle_robot_test(
                 harness, hardware, command, serial_device, serial_pty,
-                post_flash_script, post_script, script_param, flash_timeout
+                flash_timeout
             )
             return
 
@@ -808,6 +776,7 @@ class DeviceHandler(Handler):
         t.start()
 
         d_log = f"{self.instance.build_dir}/device.log"
+        hardware.run_hook("pre_flash")
         logger.debug(f'Flash command: {command}', )
         failure_type = Handler.FailureType.NONE
         try:
@@ -842,11 +811,7 @@ class DeviceHandler(Handler):
             self.instance.reason = "Device issue (Flash error)"
             failure_type = Handler.FailureType.FLASH
 
-        if post_flash_script:
-            timeout = 30
-            if script_param:
-                timeout = script_param.get("post_flash_timeout", timeout)
-            self.run_custom_script(post_flash_script, timeout)
+        hardware.run_hook("post_flash")
 
         # Connect to device after flashing it
         if hardware.flash_before:
@@ -919,11 +884,7 @@ class DeviceHandler(Handler):
 
         self._final_handle_actions(harness)
 
-        if post_script:
-            timeout = 30
-            if script_param:
-                timeout = script_param.get("post_script_timeout", timeout)
-            self.run_custom_script(post_script, timeout)
+        hardware.run_hook("post")
 
 
 class QEMUHandler(Handler):

--- a/scripts/pylib/twister/twisterlib/hardwaredata.py
+++ b/scripts/pylib/twister/twisterlib/hardwaredata.py
@@ -4,8 +4,13 @@
 
 from __future__ import annotations
 
+import logging
+import os
+import subprocess
 from dataclasses import asdict, dataclass, field
 from typing import Any
+
+logger = logging.getLogger('twister')
 
 
 @dataclass
@@ -20,10 +25,7 @@ class HardwareData:
     serial_pty: str | None = None
     connected: bool = False
     runner_params: str | None = None
-    pre_script: str | None = None
-    post_script: str | None = None
-    post_flash_script: str | None = None
-    script_param: str | None = None
+    hooks: dict[str, dict[str, Any]] = field(default_factory=dict)
     runner: str | None = None
     flash_timeout: int = 60
     flash_with_test: bool = False
@@ -39,6 +41,36 @@ class HardwareData:
         result = asdict(self)
         # Remove falsy values to keep config file clean
         return {k: v for k, v in result.items() if v}
+
+    def run_hook(self, hook_type):
+        hook = self.hooks.get(hook_type)
+        if hook is None:
+            return
+
+        script = os.path.expandvars(hook.get('script'))
+        args = hook.get('args', [])
+        cmd = [script] + args
+        timeout = hook.get('timeout', 60)
+
+        logger.info(f"Running command {cmd}....")
+        env = os.environ.copy()
+        try:
+            with subprocess.Popen(
+                cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, env=env
+            ) as proc:
+                try:
+                    stdout, stderr = proc.communicate(timeout=timeout)
+                    logger.debug(stdout.decode(errors='ignore'))
+                    if proc.returncode != 0:
+                        logger.error(f"Custom script failure: {stderr.decode(errors='ignore')}")
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.communicate()
+                    logger.error(f"{script} timed out")
+        except FileNotFoundError:
+            logger.error(f"Hook script not found: {script}")
+        except subprocess.SubprocessError as e:
+            logger.error(f"Hook script failed: {e}")
 
 
 @dataclass

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -14,6 +14,7 @@ import re
 from dataclasses import dataclass
 from multiprocessing import Lock, Value
 from pathlib import Path
+from typing import Any
 
 import scl
 import yaml
@@ -230,7 +231,7 @@ class HardwareMap:
         device = DUT(
             platform=platform,
             connected=True,
-            pre_script=pre_script,
+            hooks=self._prepare_hooks_from_scripts(pre_script=pre_script),
             serial_baud=baud,
             flash_timeout=flash_timeout,
             flash_with_test=flash_with_test,
@@ -243,15 +244,56 @@ class HardwareMap:
 
         self.duts.append(device)
 
+    def _prepare_hooks_from_scripts(
+        self,
+        pre_script: str | None = None,
+        post_script: str | None = None,
+        post_flash_script: str | None = None,
+        script_param: dict | None = None,
+    ) -> dict[str, dict[str, Any]]:
+        """Convert script parameters to hooks format for backward compatibility."""
+        hooks: dict[str, dict[str, Any]] = {}
+        if pre_script:
+            hooks['pre'] = {
+                'script': pre_script,
+                'args': [],
+                'timeout': script_param.get('pre_script_timeout', 60) if script_param else 60,
+            }
+        if post_script:
+            hooks['post'] = {
+                'script': post_script,
+                'args': [],
+                'timeout': script_param.get('post_script_timeout', 60) if script_param else 60,
+            }
+        if post_flash_script:
+            hooks['post_flash'] = {
+                'script': post_flash_script,
+                'args': [],
+                'timeout': script_param.get('post_flash_timeout', 60) if script_param else 60,
+            }
+        return hooks
+
     def load(self, map_file):
         hwm_schema = scl.yaml_load(self.schema_path)
         duts = scl.yaml_load_verify(map_file, hwm_schema)
         for dut in duts:
+            # deprecated fields are still supported for backward compatibility
             pre_script = dut.get('pre_script')
             script_param = dut.get('script_param')
             post_script = dut.get('post_script')
             post_flash_script = dut.get('post_flash_script')
+            # prepare hooks dictionary for forward compatibility
+            _hooks = self._prepare_hooks_from_scripts(
+                pre_script=pre_script,
+                post_script=post_script,
+                post_flash_script=post_flash_script,
+                script_param=script_param,
+            )
+            # get hooks from hardware map if available
+            hooks = dut.get('hooks', _hooks)
+
             flash_timeout = dut.get('flash_timeout') or self.options.device_flash_timeout
+
             flash_with_test = dut.get('flash_with_test')
             if flash_with_test is None:
                 flash_with_test = self.options.device_flash_with_test
@@ -287,11 +329,8 @@ class HardwareMap:
                               serial=serial,
                               serial_baud=serial_baud,
                               connected=connected,
-                              pre_script=pre_script,
+                              hooks=hooks,
                               flash_before=flash_before,
-                              post_script=post_script,
-                              post_flash_script=post_flash_script,
-                              script_param=script_param,
                               flash_timeout=flash_timeout,
                               flash_with_test=flash_with_test,
                               west_flash_cmd=west_flash_cmd)

--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -56,6 +56,70 @@ items:
         post_flash_timeout:
           type: integer
       additionalProperties: false
+    hooks:
+      type: object
+      properties:
+        pre:
+          type: object
+          properties:
+            script:
+              type: string
+            args:
+              type: array
+              items:
+                type: string
+            timeout:
+              type: integer
+              minimum: 1
+          required:
+            - script
+          additionalProperties: false
+        post:
+          type: object
+          properties:
+            script:
+              type: string
+            args:
+              type: array
+              items:
+                type: string
+            timeout:
+              type: integer
+              minimum: 1
+          required:
+            - script
+          additionalProperties: false
+        pre_flash:
+          type: object
+          properties:
+            script:
+              type: string
+            args:
+              type: array
+              items:
+                type: string
+            timeout:
+              type: integer
+              minimum: 1
+          required:
+            - script
+          additionalProperties: false
+        post_flash:
+          type: object
+          properties:
+            script:
+              type: string
+            args:
+              type: array
+              items:
+                type: string
+            timeout:
+              type: integer
+              minimum: 1
+          required:
+            - script
+          additionalProperties: false
+      additionalProperties: false
     west_flash_cmd:
       type: string
   required:

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -10,7 +10,6 @@ Tests for handlers.py classes' methods
 import itertools
 import os
 import signal
-import subprocess
 import sys
 from contextlib import nullcontext
 from importlib import reload
@@ -730,56 +729,6 @@ def test_devicehandler_monitor_serial_splitlines(mocked_instance):
     assert harness.handle.call_count == 2
 
 
-TESTDATA_11 = [
-    (mock.Mock(pid=0, returncode=0), False),
-    (mock.Mock(pid=0, returncode=1), False),
-    (mock.Mock(pid=0, returncode=1), True)
-]
-
-@pytest.mark.parametrize(
-    'mock_process, raise_timeout',
-    TESTDATA_11,
-    ids=['proper script', 'error', 'timeout']
-)
-def test_devicehandler_run_custom_script(caplog, mock_process, raise_timeout):
-    def raise_timeout_fn(timeout=-1):
-        if raise_timeout and timeout != -1:
-            raise subprocess.TimeoutExpired(None, timeout)
-        else:
-            return mock.Mock(), mock.Mock()
-
-    def assert_popen(command, *args, **kwargs):
-        return mock.Mock(
-            __enter__=mock.Mock(return_value=mock_process),
-            __exit__=mock.Mock(return_value=None)
-        )
-
-    mock_process.communicate = mock.Mock(side_effect=raise_timeout_fn)
-
-    script = [os.path.join('test','script', 'path'), 'arg']
-    timeout = 60
-
-    with mock.patch('subprocess.Popen', side_effect=assert_popen):
-        DeviceHandler.run_custom_script(script, timeout)
-
-    if raise_timeout:
-        assert all(
-            t in caplog.text.lower() for t in [str(script), 'timed out']
-        )
-        mock_process.assert_has_calls(
-            [
-                mock.call.communicate(timeout=timeout),
-                mock.call.kill(),
-                mock.call.communicate()
-            ]
-        )
-    elif mock_process.returncode == 0:
-        assert not any([r.levelname == 'ERROR' for r in caplog.records])
-    else:
-        assert 'timed out' not in caplog.text.lower()
-        assert 'custom script failure' in caplog.text.lower()
-
-
 TESTDATA_13 = [
     (
         None,
@@ -1182,7 +1131,6 @@ def test_devicehandler_handle(
     )
     handler._start_serial_pty = mock.Mock(side_effect=mock_start_serial_pty)
     handler._create_command = mock.Mock(return_value=['dummy', 'command'])
-    handler.run_custom_script = mock.Mock()
     handler._create_serial_connection = mock.Mock(
         side_effect=mock_create_serial
     )
@@ -1217,23 +1165,50 @@ def test_devicehandler_handle(
     messages = [record.msg for record in caplog.records]
     assert all([msg in messages for msg in expected_logs])
 
-    handler.run_custom_script.assert_has_calls([
-        mock.call('dummy pre script', mock.ANY)
-    ])
-
     if raise_create_serial:
         return
-
-    handler.run_custom_script.assert_has_calls([
-        mock.call('dummy pre script', mock.ANY),
-        mock.call('dummy post flash script', mock.ANY),
-        mock.call('dummy post script', mock.ANY)
-    ])
 
     if expected_reason:
         assert handler.instance.reason == expected_reason
     if expected_status:
         assert handler.instance.status == expected_status
+
+
+def test_devicehandler_handle_robot_test(mocked_instance):
+    """Verify that _handle_robot_test uses hooks instead of legacy scripts."""
+    hardware = mock.Mock(
+        runner='dummy runner',
+        serial_pty=None,
+        serial='dummy serial',
+        serial_baud=115200,
+        flash_timeout=60,
+        flash_with_test=False,
+    )
+
+    handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
+    handler.instance.reserved_duts = [hardware]
+    handler.options = mock.Mock(west_flash=None, west_runner=None, verbose=0)
+    handler._create_command = mock.Mock(return_value=['dummy', 'command'])
+
+    harness = mock.Mock(is_robot_test=True)
+
+    proc_mock = mock.Mock(
+        pid=1,
+        returncode=0,
+        communicate=mock.Mock(return_value=(b'', b'')),
+    )
+    popen_ctx = mock.Mock(
+        __enter__=mock.Mock(return_value=proc_mock),
+        __exit__=mock.Mock(return_value=None),
+    )
+
+    with mock.patch('builtins.open', mock.mock_open()), \
+         mock.patch('subprocess.Popen', return_value=popen_ctx):
+        handler.handle(harness)
+
+    hardware.run_hook.assert_any_call("pre")
+    hardware.run_hook.assert_any_call("post_flash")
+    hardware.run_hook.assert_any_call("post")
 
 
 TESTDATA_18 = [

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -6,6 +6,7 @@
 Tests for hardwaremap.py classes' methods
 """
 
+import subprocess
 import sys
 from pathlib import Path
 from unittest import mock
@@ -49,17 +50,9 @@ TESTDATA_1 = [
             'serial_pty': 'dummy serial pty',
             'connected': True,
             'runner_params': ['dummy', 'runner', 'params'],
-            'pre_script': 'dummy pre script',
-            'post_script': 'dummy post script',
-            'post_flash_script': 'dummy post flash script',
             'runner': 'dummy runner',
             'flash_timeout': 30,
             'flash_with_test': True,
-            'script_param': {
-                'pre_script_timeout' : 30,
-                'post_flash_timeout' : 30,
-                'post_script_timeout' : 30,
-                }
         },
         {
             'id': 'dummy id',
@@ -70,17 +63,9 @@ TESTDATA_1 = [
             'serial_pty': 'dummy serial pty',
             'connected': True,
             'runner_params': ['dummy', 'runner', 'params'],
-            'pre_script': 'dummy pre script',
-            'post_script': 'dummy post script',
-            'post_flash_script': 'dummy post flash script',
             'runner': 'dummy runner',
             'flash_timeout': 30,
             'flash_with_test': True,
-            'script_param': {
-                'pre_script_timeout' : 30,
-                'post_flash_timeout' : 30,
-                'post_script_timeout' : 30,
-                }
         },
         '<dummy platform (dummy product) on dummy serial>'
     ),
@@ -791,3 +776,175 @@ def test_hardwaremap_save_existing_map_disconnect_omits_serial(mocked_hm):
 
     # And ensure nobody writes serial=None
     assert all(d.get('serial') is not None for d in dumped if 'serial' in d)
+
+
+# ── run_hook tests ──────────────────────────────────────────────────────────
+
+@pytest.fixture
+def dut_with_hooks():
+    """Return a DUT with a set of hooks for testing."""
+    hooks = {
+        'pre': {
+            'script': '/usr/bin/pre_script.sh',
+            'args': ['--verbose'],
+            'timeout': 10,
+        },
+        'post': {'script': '/usr/bin/post_script.sh'},
+        'pre_flash': {
+            'script': '/usr/bin/flash.sh',
+            'args': ['-b', '115200'],
+            'timeout': 30,
+        },
+        'post_flash': {
+            'script': '/usr/bin/post_flash.sh',
+            'args': [],
+            'timeout': 5,
+        },
+    }
+    return DUT(platform='test_platform', id='test_id', serial='s0',
+               product='test_product', runner='test_runner',
+               connected=True, hooks=hooks)
+
+
+def test_run_hook_no_matching_hook():
+    """run_hook should return immediately when no hook matches."""
+    dut = DUT(platform='p', id='1', serial='s', product='pr',
+              runner='r', connected=True, hooks={})
+
+    with mock.patch('subprocess.Popen') as popen_mock:
+        dut.run_hook('pre')
+        popen_mock.assert_not_called()
+
+
+def test_run_hook_no_matching_type(dut_with_hooks):
+    """run_hook should return immediately when hook_type is not in hooks list."""
+    with mock.patch('subprocess.Popen') as popen_mock:
+        dut_with_hooks.run_hook('nonexistent')
+        popen_mock.assert_not_called()
+
+
+def test_run_hook_success(dut_with_hooks):
+    """run_hook should execute the script and pass args for a matching hook."""
+    proc_mock = mock.Mock()
+    proc_mock.communicate.return_value = (b'output\n', b'')
+    proc_mock.returncode = 0
+    proc_mock.__enter__ = mock.Mock(return_value=proc_mock)
+    proc_mock.__exit__ = mock.Mock(return_value=False)
+
+    with mock.patch('subprocess.Popen', return_value=proc_mock) as popen_mock:
+        dut_with_hooks.run_hook('pre')
+
+    popen_mock.assert_called_once_with(
+        ['/usr/bin/pre_script.sh', '--verbose'],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        env=mock.ANY,
+    )
+    proc_mock.communicate.assert_called_once_with(timeout=10)
+
+
+def test_run_hook_default_args_and_timeout(dut_with_hooks):
+    """Hook without 'args' or 'timeout' should use defaults ([] and 60)."""
+    proc_mock = mock.Mock()
+    proc_mock.communicate.return_value = (b'', b'')
+    proc_mock.returncode = 0
+    proc_mock.__enter__ = mock.Mock(return_value=proc_mock)
+    proc_mock.__exit__ = mock.Mock(return_value=False)
+
+    with mock.patch('subprocess.Popen', return_value=proc_mock) as popen_mock:
+        # 'post' hook has no args/timeout defined
+        dut_with_hooks.run_hook('post')
+
+    popen_mock.assert_called_once_with(
+        ['/usr/bin/post_script.sh'],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        env=mock.ANY,
+    )
+    proc_mock.communicate.assert_called_once_with(timeout=60)
+
+
+def test_run_hook_nonzero_returncode(caplog, dut_with_hooks):
+    """run_hook should log an error when the script exits with non-zero code."""
+    proc_mock = mock.Mock()
+    proc_mock.communicate.return_value = (b'', b'something went wrong')
+    proc_mock.returncode = 1
+    proc_mock.__enter__ = mock.Mock(return_value=proc_mock)
+    proc_mock.__exit__ = mock.Mock(return_value=False)
+
+    with mock.patch('subprocess.Popen', return_value=proc_mock):
+        dut_with_hooks.run_hook('pre')
+
+    assert 'Custom script failure: something went wrong' in caplog.text
+
+
+def test_run_hook_timeout(caplog, dut_with_hooks):
+    """run_hook should kill the process and log an error on timeout."""
+    proc_mock = mock.Mock()
+    proc_mock.communicate.side_effect = [
+        subprocess.TimeoutExpired(cmd='cmd', timeout=10),
+        (b'', b''),  # second call after kill
+    ]
+    proc_mock.__enter__ = mock.Mock(return_value=proc_mock)
+    proc_mock.__exit__ = mock.Mock(return_value=False)
+
+    with mock.patch('subprocess.Popen', return_value=proc_mock):
+        dut_with_hooks.run_hook('pre')
+
+    proc_mock.kill.assert_called_once()
+    assert '/usr/bin/pre_script.sh timed out' in caplog.text
+
+
+def test_run_hook_uses_os_environ(dut_with_hooks):
+    """run_hook should use os.environ as the subprocess environment."""
+    proc_mock = mock.Mock()
+    proc_mock.communicate.return_value = (b'', b'')
+    proc_mock.returncode = 0
+    proc_mock.__enter__ = mock.Mock(return_value=proc_mock)
+    proc_mock.__exit__ = mock.Mock(return_value=False)
+
+    with mock.patch('subprocess.Popen', return_value=proc_mock) as popen_mock, \
+         mock.patch.dict('os.environ', {'HOST_VAR': 'host_val'}, clear=True):
+        dut_with_hooks.run_hook('pre')
+
+    call_env = popen_mock.call_args.kwargs['env']
+    assert call_env['HOST_VAR'] == 'host_val'
+
+
+def test_run_hook_pre_flash_with_args(dut_with_hooks):
+    """Verify pre_flash hook passes the correct args and timeout."""
+    proc_mock = mock.Mock()
+    proc_mock.communicate.return_value = (b'flashed\n', b'')
+    proc_mock.returncode = 0
+    proc_mock.__enter__ = mock.Mock(return_value=proc_mock)
+    proc_mock.__exit__ = mock.Mock(return_value=False)
+
+    with mock.patch('subprocess.Popen', return_value=proc_mock) as popen_mock:
+        dut_with_hooks.run_hook('pre_flash')
+
+    popen_mock.assert_called_once_with(
+        ['/usr/bin/flash.sh', '-b', '115200'],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        env=mock.ANY,
+    )
+    proc_mock.communicate.assert_called_once_with(timeout=30)
+
+
+def test_run_hook_file_not_found(caplog, dut_with_hooks):
+    """run_hook should log an error when the script is not found."""
+    with mock.patch('subprocess.Popen', side_effect=FileNotFoundError):
+        dut_with_hooks.run_hook('pre')
+
+    assert 'Hook script not found: /usr/bin/pre_script.sh' in caplog.text
+
+
+def test_run_hook_subprocess_error(caplog, dut_with_hooks):
+    """run_hook should log an error on a general subprocess failure."""
+    with mock.patch(
+        'subprocess.Popen',
+        side_effect=subprocess.SubprocessError('unexpected error'),
+    ):
+        dut_with_hooks.run_hook('pre')
+
+    assert 'Hook script failed: unexpected error' in caplog.text


### PR DESCRIPTION
## Summary

This replaces the per-script fields (`pre_script`, `post_flash_script`,
`post_script`) with a unified `hooks` system that supports script path,
arguments, timeout, and hook type in a single structured format — while
maintaining full backward compatibility with existing hardware maps through
automatic translation of legacy fields.

## Why reopen this now

The need for this feature is clearly demonstrated by the ongoing discussion
in #111479, which attempts to solve the same set of problems (script
parameters, execution ordering, `pre_flash` support) by patching the
existing per-script approach. However, that PR has been struggling with
issues that the hooks design inherently avoids:

1. **Code duplication** — #111479 adds `pre_flash_script` as yet another
   individual script field, repeating the same pattern @nashif flagged in
   #98197 ("lots of this code is duplicated and can be done in a generic
   way for all types of scripts"). The hooks approach handles all script
   types through a single `run_hook()` method.

2. **Bugs from scattered logic** — @gchwier's review of #111479 found that
   `post_script` is never run in the robot test path, and `pre_flash_script`
   / `post_flash_script` only execute for `robot_test`, not the normal path.
   These are exactly the class of bugs that a unified hook runner prevents.

3. **Backward compatibility** — @hakehuang raised serious concerns in
   #111479 about breaking CI infrastructure ("I need to change a lot of my
   hwmaps and what's worse is that we cannot backport"). The hooks approach
   solves this with `_prepare_hooks_from_scripts()`, which transparently
   converts legacy `pre_script`/`post_script`/`post_flash_script` fields
   into hooks format — existing hardware maps continue to work unchanged.

4. **Extensibility** — Future hook types (e.g., `pre_flash`, environment
   setup) require only a new `run_hook()` call at the right point, not a
   new field in the schema, new CLI options, new handler code, and new
   pytest plugin options each time.


## Lineage

- #98197 — my original script-args PR; @nashif redirected to hooks approach
- #99918 — @nashif's hooks draft (went stale)
- #105543 — this PR, building on #99918 with review feedback incorporated
- #111479 — alternative approach by @joelguittet, currently opens
