### PR TITLE
manifest: Update tf-m to enable secure output on RTE_USART21

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -399,7 +399,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: 47b9f07b9ec2c879acc38709e9e7ba3202143a38
+      revision: pull/207/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
nRF7120DK will use uart21 for console output from S domain and so RTE_USART21 must be included for config.