### PR TITLE
llext: remove limit on number of init/fini functions

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -78,6 +78,10 @@ Removed APIs and options
 
     * ``CONFIG_COUNTER_MAXIM_DS3231``
 
+* LLEXT
+
+    * ``llext_get_fn_table``, replaced by ``llext_get_fn_table_entry``
+
 * Networking
 
     * ``CONFIG_NET_TC_SKIP_FOR_HIGH_PRIO``

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -327,24 +327,24 @@ int llext_teardown(struct llext *ext);
 void llext_bootstrap(struct llext *ext, llext_entry_fn_t entry_fn, void *user_data);
 
 /**
- * @brief Get pointers to setup or cleanup functions for an extension.
+ * @brief Get a pointer to a setup or cleanup function for an extension.
  *
- * This syscall can be used to get the addresses of all the functions that
- * have to be called for full extension setup or cleanup.
+ * This syscall can be used to get the addresses of every function that
+ * has to be called for full extension setup or cleanup.
  *
  * @see llext_bootstrap
  *
  * @param[in]    ext Extension to initialize.
  * @param[in]    is_init `true` to get functions to be called at setup time,
  *                       `false` to get the cleanup ones.
- * @param[inout] buf Buffer to store the function pointers in. Can be `NULL`
- *                   to only get the minimum required size.
- * @param[in]    size Allocated size of the buffer in bytes.
- * @returns the size used by the array in bytes, or a negative error code.
+ * @param[inout] ptr Address of pointer to store the function pointer in.
+ *                   Can be `NULL` to retrieve the number of defined functions.
+ * @param[in]    idx Index of the function to retrieve. Ignored if @a ptr is `NULL`.
+ * @returns the number of functions if ptr is NULL, 0 or a negative error code otherwise.
  * @retval -EFAULT A relocation issue was detected
  * @retval -ENOMEM Array does not fit in the allocated buffer
  */
-__syscall ssize_t llext_get_fn_table(struct llext *ext, bool is_init, void *buf, size_t size);
+__syscall ssize_t llext_get_fn_table_entry(struct llext *ext, bool is_init, void **ptr, size_t idx);
 
 /**
  * @brief Find the address for an arbitrary symbol.

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -237,16 +237,6 @@ config LLEXT_VENEERS
 	  Disable only if all external symbol calls are known to be in range
 	  or if -mlong-calls is used.
 
-config LLEXT_MAX_INIT_FINI_FUNCTION_TABLE_ENTRIES
-	int "Maximum number of entries in init / fini function pointer table"
-	default 8
-	help
-	  A function pointer table is used to hold preinitialization /
-	  initialization function pointers during bringup and finalization
-	  function pointers during teardown. This option sets the maximum number
-	  of entries in that table. If the number of function pointers for
-	  bringup or teardown exceeds this value, bringup or teardown will fail.
-
 config LLEXT_EXPERIMENTAL
 	bool "LLEXT experimental functionality"
 	help

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -341,7 +341,7 @@ static int call_fn_table(struct llext *ext, bool is_init)
 {
 	ssize_t ret;
 
-	ret = llext_get_fn_table(ext, is_init, NULL, 0);
+	ret = llext_get_fn_table_entry(ext, is_init, NULL, 0);
 	if (ret < 0) {
 		LOG_ERR("Failed to get table size: %d", (int)ret);
 		return ret;
@@ -349,29 +349,21 @@ static int call_fn_table(struct llext *ext, bool is_init)
 
 	typedef void (*elf_void_fn_t)(void);
 
-	int fn_count = ret / sizeof(elf_void_fn_t);
-
-	if (fn_count == 0) {
-		return 0;
-	} else if (fn_count > CONFIG_LLEXT_MAX_INIT_FINI_FUNCTION_TABLE_ENTRIES) {
-		LOG_ERR("%s function table too large: %d entries (max %d)",
-			is_init ? "Bringup" : "Teardown", fn_count,
-			CONFIG_LLEXT_MAX_INIT_FINI_FUNCTION_TABLE_ENTRIES);
-		return -ENOEXEC;
-	}
-
-	elf_void_fn_t fn_table[CONFIG_LLEXT_MAX_INIT_FINI_FUNCTION_TABLE_ENTRIES];
-
-	ret = llext_get_fn_table(ext, is_init, &fn_table, sizeof(fn_table));
-	if (ret < 0) {
-		LOG_ERR("Failed to get function table: %d", (int)ret);
-		return ret;
-	}
+	int fn_count = ret;
 
 	for (int i = 0; i < fn_count; i++) {
+		elf_void_fn_t fn;
+
+		ret = llext_get_fn_table_entry(ext, is_init, (void **)&fn, i);
+		if (ret < 0) {
+			LOG_ERR("Failed to get %s function %d: %d",
+				is_init ? "bringup" : "teardown", i, (int)ret);
+			return ret;
+		}
+
 		LOG_DBG("calling %s function %p()",
-			is_init ? "bringup" : "teardown", (void *)fn_table[i]);
-		fn_table[i]();
+			is_init ? "bringup" : "teardown", (void *)fn);
+		fn();
 	}
 
 	return 0;

--- a/subsys/llext/llext_handlers.c
+++ b/subsys/llext/llext_handlers.c
@@ -15,9 +15,10 @@ LOG_MODULE_DECLARE(llext, CONFIG_LLEXT_LOG_LEVEL);
 
 #include "llext_priv.h"
 
-ssize_t z_impl_llext_get_fn_table(struct llext *ext, bool is_init, void *buf, size_t buf_size)
+ssize_t z_impl_llext_get_fn_table_entry(struct llext *ext, bool is_init, void **ptr, size_t idx)
 {
 	size_t table_size;
+	size_t offset = idx * sizeof(void *);
 
 	if (!ext) {
 		return -EINVAL;
@@ -30,45 +31,44 @@ ssize_t z_impl_llext_get_fn_table(struct llext *ext, bool is_init, void *buf, si
 		table_size = ext->mem_size[LLEXT_MEM_FINI];
 	}
 
-	if (buf) {
-		char *byte_ptr = buf;
-
-		if (buf_size < table_size) {
-			return -ENOMEM;
-		}
-
-		if (is_init) {
-			/* setup functions from preinit_array and init_array */
-			memcpy(byte_ptr,
-			       ext->mem[LLEXT_MEM_PREINIT], ext->mem_size[LLEXT_MEM_PREINIT]);
-			memcpy(byte_ptr + ext->mem_size[LLEXT_MEM_PREINIT],
-			       ext->mem[LLEXT_MEM_INIT], ext->mem_size[LLEXT_MEM_INIT]);
-		} else {
-			/* cleanup functions from fini_array */
-			memcpy(byte_ptr,
-			       ext->mem[LLEXT_MEM_FINI], ext->mem_size[LLEXT_MEM_FINI]);
-		}
-
-		/* Sanity check: pointers in this table must map inside the
-		 * text region of the extension. If this fails, something went
-		 * wrong during the relocation process.
-		 * Using "char *" for these simplifies pointer arithmetic.
-		 */
-		const char *text_start = ext->mem[LLEXT_MEM_TEXT];
-		const char *text_end = text_start + ext->mem_size[LLEXT_MEM_TEXT];
-		const char **fn_ptrs = buf;
-
-		for (int i = 0; i < table_size / sizeof(void *); i++) {
-			if (fn_ptrs[i] < text_start || fn_ptrs[i] >= text_end) {
-				LOG_ERR("%s function %i (%p) outside text region",
-					is_init ? "bringup" : "teardown",
-					i, fn_ptrs[i]);
-				return -EFAULT;
-			}
-		}
+	if (!ptr) {
+		return table_size / sizeof(void *);
 	}
 
-	return table_size;
+	if (offset >= table_size) {
+		return -EINVAL;
+	}
+
+	if (is_init) {
+		/* setup functions from preinit_array and init_array */
+		if (offset < ext->mem_size[LLEXT_MEM_PREINIT]) {
+			*ptr = *(void **)((char *)ext->mem[LLEXT_MEM_PREINIT] + offset);
+		} else {
+			offset -= ext->mem_size[LLEXT_MEM_PREINIT];
+			*ptr = *(void **)((char *)ext->mem[LLEXT_MEM_INIT] + offset);
+		}
+	} else {
+		/* cleanup functions from fini_array */
+		*ptr = *(void **)((char *)ext->mem[LLEXT_MEM_FINI] + offset);
+	}
+
+	/*
+	 * Safety check: returned pointer must map inside the text region of the extension.
+	 * If this fails, something went wrong during the relocation process.
+	 * Using "char *" for these simplifies pointer arithmetic.
+	 */
+	const char *text_start = ext->mem[LLEXT_MEM_TEXT];
+	const char *text_end = text_start + ext->mem_size[LLEXT_MEM_TEXT];
+	const char *ptr_char = (const char *)*ptr;
+
+	if (ptr_char < text_start || ptr_char >= text_end) {
+		LOG_ERR("%s function %zu (%p) outside text region",
+			is_init ? "bringup" : "teardown",
+			idx, *ptr);
+		return -EFAULT;
+	}
+
+	return 0;
 }
 
 #ifdef CONFIG_USERSPACE
@@ -78,19 +78,20 @@ static int ext_is_valid(struct llext *ext, void *arg)
 	return ext == arg;
 }
 
-static inline ssize_t z_vrfy_llext_get_fn_table(struct llext *ext, bool is_init,
-						void *buf, size_t size)
+static inline ssize_t z_vrfy_llext_get_fn_table_entry(struct llext *ext,
+						      bool is_init,
+						      void **ptr, size_t idx)
 {
 	/* Test that ext matches a loaded extension */
 	K_OOPS(llext_iterate(ext_is_valid, ext) == 0);
 
-	if (buf) {
+	if (ptr) {
 		/* Test that buf is a valid user-accessible pointer */
-		K_OOPS(K_SYSCALL_MEMORY_WRITE(buf, size));
+		K_OOPS(K_SYSCALL_MEMORY_WRITE(ptr, sizeof(void *)));
 	}
 
-	return z_impl_llext_get_fn_table(ext, is_init, buf, size);
+	return z_impl_llext_get_fn_table_entry(ext, is_init, ptr, idx);
 }
-#include <zephyr/syscalls/llext_get_fn_table_mrsh.c>
+#include <zephyr/syscalls/llext_get_fn_table_entry_mrsh.c>
 
 #endif /* CONFIG_USERSPACE */

--- a/tests/subsys/llext/src/init_fini_ext.c
+++ b/tests/subsys/llext/src/init_fini_ext.c
@@ -6,8 +6,8 @@
 
 /*
  * This test checks for proper support of ELF init arrays. This processing is
- * performed by llext_bootstrap(), which gets the array of function pointers
- * from LLEXT via the llext_get_fn_table() syscall.
+ * performed by llext_bootstrap(), which gets the function pointers from LLEXT
+ * via the llext_get_fn_table_entry() syscall.
  *
  * Each function in this test shifts the number left by 4 bits and sets the
  * lower 4 bits to a specific value. The proper init sequence (preinit_fn_1,


### PR DESCRIPTION
In some contexts, the number of init/fini functions may not be known at compile time. Allocating a function table is not even needed since it is only ever used to call the functions in order.

Replace the `llext_get_fn_table()` syscall with `llext_get_fn_table_entry()`, which returns a single function pointer at a time. This allows the caller to iterate over the functions without needing to allocate a table, and removes the limit on the number of init/fini functions that can be defined by an extension. The added overhead is negligible as the number of functions is typically small and only executed once at load/unload time.

> [!NOTE]
>  This replaces an existing syscall with no deprecation process. However,
>   1. LLEXT is currently still "experimental", so there's no official need for it; but most importantly 
>   1. that syscall was designed to be used internally by `llext_bootstrap`, which keeps a stable API, and it was documented as such. 

Also remove the `CONFIG_LLEXT_MAX_INIT_FINI_FUNCTION_TABLE_ENTRIES` Kconfig option, since it is no longer needed. It was recently added by #109875 (after 4.4) so no action is required there. 

