### PR TITLE
tests: kernel: use {} to initialize test work_q structs

### DIFF
--- a/tests/kernel/workq/work_queue/src/start_stop.c
+++ b/tests/kernel/workq/work_queue/src/start_stop.c
@@ -25,7 +25,7 @@ ZTEST(workqueue_api, test_k_work_queue_start_stop)
 {
 	size_t i;
 	struct k_work work;
-	struct k_work_q work_q = {0};
+	struct k_work_q work_q = {};
 	struct k_work works[NUM_TEST_ITEMS];
 	struct k_work_queue_config cfg = {
 		.name = "test_work_q",
@@ -58,7 +58,7 @@ ZTEST(workqueue_api, test_k_work_queue_start_stop)
 
 ZTEST(workqueue_api, test_k_work_queue_stop_sys_thread)
 {
-	struct k_work_q work_q = {0};
+	struct k_work_q work_q = {};
 	struct k_work_queue_config cfg = {
 		.name = "test_work_q",
 		.no_yield = true,
@@ -100,7 +100,7 @@ ZTEST(workqueue_api, test_k_work_queue_run_stop)
 	size_t i;
 	struct k_thread thread;
 	struct k_work work;
-	struct k_work_q work_q = {0};
+	struct k_work_q work_q = {};
 	struct k_work works[NUM_TEST_ITEMS];
 	struct k_sem ret_sem;
 
@@ -148,7 +148,7 @@ ZTEST(workqueue_api, test_k_work_queue_run_stop)
  */
 ZTEST(workqueue_api, test_k_work_queue_priority)
 {
-	struct k_work_q work_q = {0};
+	struct k_work_q work_q = {};
 	struct k_work_queue_config cfg = {
 		.name = "prio_work_q",
 	};


### PR DESCRIPTION
LLVM seems to be unhappy with the {0} initialization of structs with a deprecated element. Zero out the struct with memset, seems to make it happier.

Error was:
start_stop.c:28:28: error: 'thread' is deprecated
   28 |         struct k_work_q work_q = {0};

Tested with:

west build -p -b native_sim/native \
	tests/kernel/workq/work_queue/ \
	-DZEPHYR_TOOLCHAIN_VARIANT=host/llvm