### PR TITLE
tracing: Add existed object check in SYS_TRACK_LIST_PREPEND

### DIFF
--- a/subsys/tracing/tracing_tracking.c
+++ b/subsys/tracing/tracing_tracking.c
@@ -42,12 +42,24 @@ struct k_event *_track_list_k_event;
 struct k_spinlock _track_list_k_event_lock;
 #endif
 
-#define SYS_TRACK_LIST_PREPEND(list, obj) \
-	do { \
-		k_spinlock_key_t key = k_spin_lock(&list ## _lock); \
-		obj->_obj_track_next = list; \
-		list = obj; \
-		k_spin_unlock(&list ## _lock, key); \
+/* Iterates in the tracking list and prepends an object only when it doesn't exist */
+#define SYS_TRACK_LIST_PREPEND(list, obj)                                                          \
+	do {                                                                                       \
+		k_spinlock_key_t key = k_spin_lock(&list##_lock);                                  \
+		if ((obj) != (list)) {                                                             \
+			__typeof__(list) _cur = (list);                                            \
+			while (_cur != NULL) {                                                     \
+				if (_cur == (obj)) {                                               \
+					break;                                                     \
+				}                                                                  \
+				_cur = _cur->_obj_track_next;                                      \
+			}                                                                          \
+			if (_cur == NULL) {                                                        \
+				(obj)->_obj_track_next = (list);                                   \
+				(list) = (obj);                                                    \
+			}                                                                          \
+		}                                                                                  \
+		k_spin_unlock(&list##_lock, key);                                                  \
 	} while (false)
 
 #define SYS_TRACK_STATIC_INIT(type, ...) \

--- a/tests/kernel/obj_tracking/src/main.c
+++ b/tests/kernel/obj_tracking/src/main.c
@@ -21,6 +21,7 @@ K_MBOX_DEFINE(mbox_s);
 K_PIPE_DEFINE(pipe_s, 64, 4);
 K_QUEUE_DEFINE(queue_s);
 K_EVENT_DEFINE(event_s);
+K_EVENT_DEFINE(double_init_event_s);
 
 unsigned char __aligned(4) pipe_buffer[64];
 char __aligned(4) slab_buffer[8 * 4];
@@ -152,7 +153,27 @@ ZTEST(obj_tracking, test_obj_tracking_coherence)
 	}
 	zassert_equal(count, 2, "Wrong number of event objects");
 
+	/* Count all the events in the list */
+	list = _track_list_k_event;
+	count = 0;
+	while (list != NULL) {
+		count++;
+		list = SYS_PORT_TRACK_NEXT((struct k_event *)list);
+	}
 
+	/* Initialize the statically initialized event dynamically to test if it corrupts the list
+	 */
+	k_event_init(&double_init_event_s);
+	list = _track_list_k_event;
+	while (list != NULL) {
+		list = SYS_PORT_TRACK_NEXT((struct k_event *)list);
+
+		if (count == 0) {
+			break;
+		}
+		count--;
+	}
+	zassert_equal(list, NULL, "List of event objects has circles");
 }
 
 ZTEST_SUITE(obj_tracking, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
The SYS_TRACK_LIST_PREPEND unconditionally prepends an object in the list without checking if the object is already in the list.

This is problematic and will corrupt the list if an object is initiallized multiple times.

For example if you define an event with the macro: K_EVENT_DEFINE(my_event)

and then you also initialize the object in code:
k_event_init(&my_event)

This will corrupt the list. Even though you don't need to run the k_event_init after you statically define the event it is not explicitely forbitten either so it should not corrupt anything.

To fix that I updated the SYS_TRACK_LIST_PREPEND to check if an object is already in the list and only prepend it if it does not exist.


If you want to test this I also created a minimal sample that I run with native_sim 64 that show cases the problem.
If you run this sample without my PR the list will get corrupted immediately after the first call to the k_event_init.
[obj_tracking_event_poc.zip](https://github.com/user-attachments/files/29597418/obj_tracking_event_poc.zip)
