### PR TITLE
West link

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -2551,6 +2551,33 @@ class Ruff(ComplianceTest):
                 self.fmtd_failure("error", "Python format error", file, desc=desc)
 
 
+class WestLinkCheck(ComplianceTest):
+    """
+    West link synchronization check
+    """
+
+    name = "WestLink"
+    doc = "Check that west link files are in sync."
+
+    def run(self):
+        cmd = [
+            "west",
+            "ln",
+            "--status",
+            COMMIT_RANGE,
+        ]
+        try:
+            result = subprocess.run(cmd, check=False, capture_output=True, cwd=GIT_TOP)
+        except Exception as ex:
+            self.error(f"Failed to run west ln --status: {ex}")
+        output = result.stdout.decode("utf-8")
+        for line in output.splitlines()[1:]:
+            state, line = line.split(":")
+            if state in ('!', '-', '?'):
+                self.failure(output)
+                break
+
+
 class PythonCompatCheck(ComplianceTest):
     """
     Python Compatibility Check

--- a/scripts/west-commands.yml
+++ b/scripts/west-commands.yml
@@ -107,3 +107,8 @@ west-commands:
       - name: gtags
         class: Gtags
         help: create a GNU global tags file for the current workspace
+  - file: scripts/west_commands/ln.py
+    commands:
+      - name: ln
+        class: Ln
+        help: west link handling

--- a/scripts/west_commands/ln.py
+++ b/scripts/west_commands/ln.py
@@ -1,0 +1,353 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import hashlib
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path, PurePath, PurePosixPath
+
+from west.commands import WestCommand
+
+LINK_DESCRIPTION = '''\
+west ln extension command.
+
+west ln can be used to link files which must be kept in sync.
+When one file is updated then 'west ln --sync' will update all linked files to the same content.
+
+A git pre-commit hook can be installed to automatically sync linked files on commit.
+'''
+
+
+WEST_LN_FILE = PurePath('.westlinks')
+
+
+class Ln(WestCommand):
+    def __init__(self):
+        super().__init__(
+            'ln',
+            # Keep this in sync with the string in west-commands.yml.
+            'west link handling',
+            LINK_DESCRIPTION,
+            accepts_unknown_args=False,
+        )
+
+    def do_add_parser(self, parser_adder):
+        usage = (
+            'west ln ['
+            '--status [<commit>[...<commit>]] | '
+            '--sync | '
+            '--duplicates TARGET | '
+            '[--force] TARGET LINK_NAME]'
+        )
+        parser = parser_adder.add_parser(
+            self.name,
+            help=self.help,
+            usage=usage,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=self.description,
+        )
+
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            '-d', '--delete', action='store_true', help='''Remove link association for LINK_NAME.'''
+        )
+        group.add_argument(
+            '--duplicates', action='store_true', help='''Find duplicate files in current repo.'''
+        )
+        group.add_argument(
+            '--status',
+            nargs='?',
+            default=False,
+            const=True,
+            dest='status',
+            metavar='<commit>[...<commit>]',
+            help='''Show current status of links out of sync.''',
+        )
+        group.add_argument(
+            '--sync',
+            action='store_true',
+            help='''Sync links for targets in git stage area, if TARGET is given only links shared
+                    with TARGET will be synced.''',
+        )
+        group.add_argument(
+            '--hook',
+            action='store_true',
+            help='''Show git pre-commit hook for automatic link syncing.
+                    The hook can easily be installed by redirecting the output to
+                    '.git/hooks/pre-commmit', for example like:
+                      'west ln --hook >> <repo>/.git/hooks/pre-commit'
+                    ''',
+        )
+
+        group = parser.add_argument_group('west ln options')
+        group.add_argument(
+            '-f',
+            '--force',
+            action="store_true",
+            help='''force creating link to target even if link name already exists and points to
+                    other target''',
+        )
+
+        parser.add_argument(
+            'target',
+            metavar='TARGET',
+            nargs='?',
+            help='''link target''',
+        )
+
+        parser.add_argument(
+            'linkname',
+            metavar='LINK_NAME',
+            nargs='?',
+            help='''link name''',
+        )
+
+        return parser
+
+    def _git_run(self, repo, command, args):
+        cp = subprocess.run(
+            ['git', command, *args], capture_output=True, text=True, check=True, cwd=repo
+        )
+        return cp.stdout.splitlines()
+
+    def repo_path(self, file, repo):
+        try:
+            rel_path = file.resolve().relative_to(repo)
+        except ValueError:
+            sys.exit(f"{file} is not inside repository {repo}")
+
+        return PurePosixPath(rel_path)
+
+    def delete(self, args, repo, links):
+        if not args.target:
+            sys.exit("west ln: error: the following arguments is required: LINKNAME")
+
+        # We are working with the link name, but because first position argument to `west ln` is
+        # target, then that's the argument name we fetch in this case.
+        linkname_path = Path(args.target)
+        linkname = str(self.repo_path(linkname_path, repo))
+
+        if linkname not in links:
+            sys.exit(f"Link '{linkname}' not found.")
+        else:
+            del links[linkname]
+
+        with open(repo / WEST_LN_FILE, 'w', encoding="utf-8") as fp:
+            for name, md5 in links.items():
+                fp.write(f"{name} {md5}\n")
+
+    def duplicates(self, args, repo, links):
+        if not args.target:
+            sys.exit("west ln: error: the following arguments is required: TARGET")
+
+        target_path = Path(args.target)
+        target = str(self.repo_path(target_path, repo))
+
+        if not target_path.is_file():
+            sys.exit(f"File {args.target} not found.")
+
+        links_inv = defaultdict(list)
+        for k, v in links.items():
+            links_inv[v].append(k)
+        linked = links_inv[links.get(target)]
+
+        duplicates = []
+        target_id = self._git_run(repo, 'hash-object', [target]).pop()
+        tree_objects = self._git_run(repo, 'ls-tree', ['-r', 'HEAD'])
+
+        for line in tree_objects:
+            meta, filename = line.split("\t", 1)
+            _, _, object_id = meta.split()
+
+            if object_id == target_id:
+                duplicates.append(filename)
+
+        print("Duplicate files, *=linked, -=not linked")
+        for file in duplicates:
+            if file in linked:
+                print(f"* {file}")
+            else:
+                print(f"- {file}")
+
+    def hook(self, args, repo, links):
+        if args.target:
+            sys.exit(f"west ln: error: unexpected arguments: ['{args.target}']")
+
+        file_path = Path(__file__).parent / "west_ln.pre-commit-hook"
+
+        with open(file_path) as file:
+            print(file.read())
+
+    def link(self, args, repo, links):
+        if not args.target or not args.linkname:
+            sys.exit("west ln: error: the following arguments are required: TARGET, LINK_NAME")
+
+        target_path = Path(args.target)
+        linkname_path = Path(args.linkname)
+        target = str(self.repo_path(target_path, repo))
+        linkname = str(self.repo_path(linkname_path, repo))
+
+        if target in links and linkname not in links:
+            links[linkname] = links.get(target)
+            md5 = links.get(linkname)
+        elif linkname in links and not args.force:
+            if target not in links or links.get(target) != links.get(linkname):
+                sys.exit(f"Link '{linkname}' already exists. Use --force to update target.")
+        elif target in links:
+            links[linkname] = links.get(target)
+            md5 = links.get(linkname)
+        else:
+            md5 = hashlib.md5(target.encode("utf-8")).hexdigest()
+            links[linkname] = md5
+            links[target] = md5
+
+        with open(repo / WEST_LN_FILE, 'w', encoding="utf-8") as fp:
+            for name, md5 in links.items():
+                fp.write(f"{name} {md5}\n")
+
+        if not linkname_path.is_file():
+            shutil.copyfile(target_path, linkname_path)
+
+        print(f"Link {linkname} --> {target} created, remember to run 'git add .westlinks'")
+
+    def get_staged_links(self, repo, links):
+        files = self._git_run(repo, 'diff', ['--cached', '--name-only'])
+        return list(set(files) & set(links.keys()))
+
+    def get_committed_links(self, repo, commit_range, links):
+        files = self._git_run(repo, 'diff', [commit_range, '--name-only'])
+        return list(set(files) & set(links.keys()))
+
+    def status(self, args, repo, links):
+        if args.target:
+            sys.exit(f"west ln: error: unexpected arguments: ['{args.target}']")
+
+        if args.status is True:
+            files = self.get_staged_links(repo, links)
+        else:
+            commit_range = args.status
+            files = self.get_committed_links(repo, commit_range, links)
+
+        links_inv = defaultdict(list)
+        for k, v in links.items():
+            links_inv[v].append(k)
+
+        state = {}
+        for file in files:
+            if file in state:
+                continue
+
+            linked = links_inv[links[file]]
+            registered_linked_files = list(set(files) & set(linked))
+            other_linked_files = list(set(files) ^ set(linked))
+
+            result = set(self._git_run(repo, 'hash-object', registered_linked_files))
+            if len(result) > 1:
+                for registered_file in registered_linked_files:
+                    state[registered_file] = '!'
+                for other_file in other_linked_files:
+                    state[other_file] = '?'
+            else:
+                for registered_file in registered_linked_files:
+                    state[registered_file] = '*'
+
+                ref_sha = next(iter(result))
+                result = self._git_run(repo, 'hash-object', other_linked_files)
+                for other_file, sha in zip(other_linked_files, result, strict=True):
+                    state[other_file] = '+' if sha == ref_sha else '-'
+
+        print(
+            f"Linked files status, *=synced ({'staged' if args.status is True else 'committed'}), "
+            "+=synced, -=differ, !=conflicts, ?=undefined"
+        )
+        for file, s in state.items():
+            print(f"{s}: {file}")
+
+    def sync(self, args, repo, links):
+        if args.target:
+            # Not yet supported.
+            sys.exit(f"west ln: error: unexpected arguments: ['{args.target}']")
+
+        if args.linkname:
+            sys.exit(f"west ln: error: unexpected arguments: ['{args.linkname}']")
+
+        files = self.get_staged_links(repo, links)
+
+        links_inv = defaultdict(list)
+        for k, v in links.items():
+            links_inv[v].append(k)
+
+        synced = []
+        for file in files:
+            if file in synced:
+                continue
+
+            linked = links_inv[links[file]]
+            staged_linked_files = list(set(files) & set(linked))
+            other_linked_files = list(set(files) ^ set(linked))
+
+            result = set(self._git_run(repo, 'hash-object', staged_linked_files))
+            if len(result) > 1:
+                sys.exit(f"Sync failed, conflicting files staged: {staged_linked_files}")
+            else:
+                ref_sha = next(iter(result))
+                result = self._git_run(repo, 'hash-object', other_linked_files)
+                for other_file, sha in zip(other_linked_files, result, strict=True):
+                    if sha != ref_sha:
+                        shutil.copyfile(repo / file, repo / other_file)
+
+                self._git_run(repo, 'add', other_linked_files)
+            synced.extend(linked)
+
+    def do_run(self, args, unknown_args):
+        try:
+            cp = subprocess.run(
+                ['git', 'rev-parse', '--show-toplevel'],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+        except subprocess.CalledProcessError as e:
+            print('west ln failed, cannot determine git top-level folder')
+            print("exit code:", e.returncode)
+            print("stderr:", e.stderr)
+        toplevel_path = PurePath(cp.stdout.rstrip())
+
+        links = {}
+        try:
+            linkfile = toplevel_path / WEST_LN_FILE
+            with open(linkfile, encoding="utf-8") as fp:
+                for lineno, fp_line in enumerate(fp, start=1):
+                    line = fp_line.rstrip("\n")
+
+                    if line.lstrip().startswith("#"):
+                        continue
+                    if line == "":
+                        continue
+
+                    try:
+                        name, md5 = line.split()
+                    except ValueError:
+                        sys.exit(f"west ln: error: invalid line {lineno} in {linkfile}, aborting")
+                    links[name] = md5
+        except FileNotFoundError:
+            # Missing file is ok, simply means there are no links created.
+            pass
+
+        if args.delete:
+            self.delete(args, toplevel_path, links)
+        elif args.duplicates:
+            self.duplicates(args, toplevel_path, links)
+        elif args.hook:
+            self.hook(args, toplevel_path, links)
+        elif args.status is not False:
+            self.status(args, toplevel_path, links)
+        elif args.sync:
+            self.sync(args, toplevel_path, links)
+        else:
+            self.link(args, toplevel_path, links)

--- a/scripts/west_commands/west_ln.pre-commit-hook
+++ b/scripts/west_commands/west_ln.pre-commit-hook
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+
+#
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+files=$(git diff --cached --name-only)
+sync_file=.westlinks
+
+for f in $files; do
+  new_object_hash=$(git hash-object $f )
+  link_hash=$(grep "^$f" $sync_file|cut -f2 -d' ')
+  link_files=$(grep $link_hash $sync_file|cut -f1 -d' ')
+  for l_f in $link_files; do
+    link_object_hash=$(git hash-object $l_f)
+    if [ "$new_object_hash" != "$link_object_hash" ]; then
+      if echo "$files" | grep -Eq "(^|[[:space:]])$l_f($|[[:space:]])"; then
+        echo "Linked files '$f' and '$l_f' are both staged for commit but with conflicting content.\nAborting" >&2
+        exit 1
+      fi
+    fi
+  done
+  for l_f in $link_files; do
+    link_object_hash=$(git hash-object $l_f)
+    if [ "$new_object_hash" != "$link_object_hash" ]; then
+      # Update linked file
+      cp $f $l_f
+      git add $l_f
+    fi
+  done
+done


### PR DESCRIPTION
A recurring discussion in development is the balance between duplicated files in a repository, which make it easy for new comers to a project to find and use a given file, and then maintaining and keeping multiple files in sync.

In Linux, Mac, and other systems, this can be handled using soft or hard-links, unfortunately hard links just creates two entries in git, and thus they are not kept in sync when checked out.
Soft-links is possible to use, but its behavior, especially on Windows, depends on git configuration, windows version, and developer mode, and is therefore generally discouraged.
Also there is a risk that the link it self has a risk of pointing to an absolute path, and not a relative path inside the repository.

Git itself is excellent at handling identical files, as n-identical files only consumes the space of a single file.

This PR provides a mechanism of creating a `.westlinks` file to track files that are intended to be identical.

For this purpose a `west ln` command is introduced.

For example, there are several identical overlays with content such as:
```
&wdt31 {
	status = "okay";
};
```

If such files needs an update, then a lot of files needs to be changed, but with `west ln` those files can be linked, and thereby sync'ed if one of the files are updated.

Creation of a link between two files:
```
$ west ln <target> <linkname>
```
For example:
```
$ west ln tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l05_cpuapp.overlay tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
```

To check if files are out of sync between staged files and HEAD:
```
$ west ln --status
Linked files status, *=synced (staged), +=synced, -=differ, !=conflicts, ?=undefined
*: tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
-: tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
```

To sync files (can also happen automatically):
```
# Modify file, and stage the changes
$ git status
HEAD detached from zephyr/main
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	modified:   tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l05_cpuapp.overlay

$ west ln --sync
$ git status
HEAD detached from zephyr/main
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	modified:   tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
	modified:   tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
```

it's also possible to have linked files updated automatically upon commit using a git pre-commit hook.
This hook can be seen using `west ln --hook`

check_compliance has been updated so that if any linked files are out-of-sync, then compliance will fail, like this:
```
$ ./scripts/ci/check_compliance.py -m WestLink -c HEAD~1..
Running WestLink                       tests in /projects/github/ncs/zephyr ...
1 check(s) failed
ERROR   : Test WestLink failed: 
Linked files status, *=synced (committed), +=synced, -=differ, !=conflicts, ?=undefined
*: tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l10_cpuapp.overlay
*: tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l05_cpuapp.overlay
-: tests/drivers/watchdog/wdt_basic_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay

Complete results in compliance.xml
```

Compliance thus helps to ensure that files which are intended to be in sync never drifts apart.
And developers can easily fix this using `west ln --sync` (if they have not installed the pre-commit hook`.