### PR TITLE
ethernet: dwc_mac: collect ethernet stats

### DIFF
--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -484,10 +484,22 @@ int dwmac_probe(const struct device *dev)
 	return 0;
 }
 
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+static struct net_stats_eth *dwmac_stats(const struct device *dev, struct net_if *iface __unused)
+{
+	struct dwmac_priv *p = dev->data;
+
+	return &p->stats;
+}
+#endif
+
 const struct ethernet_api dwmac_api = {
 	.iface_api.init = dwmac_iface_init,
 	.get_capabilities = dwmac_caps,
 	.set_config = dwmac_set_config,
 	.get_phy = dwmac_get_phy,
 	.send = dwmac_send,
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+	.get_stats = dwmac_stats,
+#endif
 };

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -690,10 +690,22 @@ int dwmac_probe(const struct device *dev)
 	return 0;
 }
 
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+static struct net_stats_eth *dwmac_stats(const struct device *dev, struct net_if *iface __unused)
+{
+	struct dwmac_priv *p = dev->data;
+
+	return &p->stats;
+}
+#endif
+
 const struct ethernet_api dwmac_api = {
 	.iface_api.init		= dwmac_iface_init,
 	.get_capabilities	= dwmac_caps,
 	.set_config		= dwmac_set_config,
 	.get_phy		= dwmac_get_phy,
 	.send			= dwmac_send,
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+	.get_stats		= dwmac_stats,
+#endif
 };

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -115,6 +115,10 @@ struct dwmac_priv {
 	uint32_t feature3;
 #endif
 
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+	struct net_stats_eth stats;
+#endif
+
 	struct dwmac_dma_desc *tx_descs, *rx_descs;
 	struct k_sem free_tx_descs, free_rx_descs;
 	unsigned int tx_desc_head, tx_desc_tail;


### PR DESCRIPTION
Support collection of the most common ethernet statistics. This currently does not utilize any hardware statistics counters, but rather collects the stats in software.

`eth_stats_update_*` calls were already in-place for statistics collection.