### PR TITLE
drivers: timer: fix for cmsdk_apb_timer

### DIFF
--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -29,8 +29,6 @@ BUILD_ASSERT(DT_NODE_HAS_COMPAT(TIMER_NODE, arm_cmsdk_timer),
 	((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec() /                                      \
 		    (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
 #define MAX_CYC UINT32_MAX
-#define MAX_TICKS                                                                                  \
-	(int32_t)MIN((uint64_t)((MAX_CYC - CYC_PER_TICK) / CYC_PER_TICK), (uint64_t)INT32_MAX)
 
 #ifdef CONFIG_CMSDK_APB_TIMER_MIN_DELAY_OVERRIDE
 #define MIN_DELAY_CYCLES CONFIG_CMSDK_APB_TIMER_MIN_DELAY_CYCLES


### PR DESCRIPTION
After recent modifications to the timeout calculation in `cmsdk_apb_timer`, `MAX_TICKS` define is no longer used.
