### PR TITLE
use zephyr/ prefix for headers (with CONFIG_LEGACY_GENERATED_INCLUDE_PATH gone)

### DIFF
--- a/drivers/haptics/haptics_handlers.c
+++ b/drivers/haptics/haptics_handlers.c
@@ -14,7 +14,7 @@ static inline int z_vrfy_haptics_calibrate(const struct device *dev, const uint3
 	return z_impl_haptics_calibrate(dev, routine);
 }
 
-#include <syscalls/haptics_calibrate_mrsh.c>
+#include <zephyr/syscalls/haptics_calibrate_mrsh.c>
 
 static inline int z_vrfy_haptics_monitor_get(const struct device *dev,
 					     const enum haptics_monitor monitor,
@@ -28,7 +28,7 @@ static inline int z_vrfy_haptics_monitor_get(const struct device *dev,
 	return z_impl_haptics_monitor_get(dev, monitor, type, val);
 }
 
-#include <syscalls/haptics_monitor_get_mrsh.c>
+#include <zephyr/syscalls/haptics_monitor_get_mrsh.c>
 
 static inline int z_vrfy_haptics_monitor_set(const struct device *dev,
 					     const enum haptics_monitor monitor, const bool enable)
@@ -38,7 +38,7 @@ static inline int z_vrfy_haptics_monitor_set(const struct device *dev,
 	return z_impl_haptics_monitor_set(dev, monitor, enable);
 }
 
-#include <syscalls/haptics_monitor_set_mrsh.c>
+#include <zephyr/syscalls/haptics_monitor_set_mrsh.c>
 
 static inline int z_vrfy_haptics_select_source(const struct device *dev,
 					       const enum haptics_source src,
@@ -53,7 +53,7 @@ static inline int z_vrfy_haptics_select_source(const struct device *dev,
 	return z_impl_haptics_select_source(dev, src, cfg);
 }
 
-#include <syscalls/haptics_select_source_mrsh.c>
+#include <zephyr/syscalls/haptics_select_source_mrsh.c>
 
 static inline int z_vrfy_haptics_set_level(const struct device *dev, const enum haptics_source src,
 					   const union haptics_config *const cfg,
@@ -68,7 +68,7 @@ static inline int z_vrfy_haptics_set_level(const struct device *dev, const enum 
 	return z_impl_haptics_set_level(dev, src, cfg, level);
 }
 
-#include <syscalls/haptics_set_level_mrsh.c>
+#include <zephyr/syscalls/haptics_set_level_mrsh.c>
 
 static inline int z_vrfy_haptics_start_output(const struct device *dev)
 {
@@ -77,7 +77,7 @@ static inline int z_vrfy_haptics_start_output(const struct device *dev)
 	return z_impl_haptics_start_output(dev);
 }
 
-#include <syscalls/haptics_start_output_mrsh.c>
+#include <zephyr/syscalls/haptics_start_output_mrsh.c>
 
 static inline int z_vrfy_haptics_stop_output(const struct device *dev)
 {
@@ -86,7 +86,7 @@ static inline int z_vrfy_haptics_stop_output(const struct device *dev)
 	return z_impl_haptics_stop_output(dev);
 }
 
-#include <syscalls/haptics_stop_output_mrsh.c>
+#include <zephyr/syscalls/haptics_stop_output_mrsh.c>
 
 static inline int z_vrfy_haptics_stream_samples(const struct device *dev,
 						const uint8_t *const samples, const size_t len)
@@ -98,4 +98,4 @@ static inline int z_vrfy_haptics_stream_samples(const struct device *dev,
 	return z_impl_haptics_stream_samples(dev, samples, len);
 }
 
-#include <syscalls/haptics_stream_samples_mrsh.c>
+#include <zephyr/syscalls/haptics_stream_samples_mrsh.c>

--- a/drivers/input/input_tsc_keys.c
+++ b/drivers/input/input_tsc_keys.c
@@ -6,7 +6,7 @@
 #include <soc.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>

--- a/include/zephyr/drivers/haptics.h
+++ b/include/zephyr/drivers/haptics.h
@@ -536,6 +536,6 @@ static inline int z_impl_haptics_stream_samples(const struct device *dev,
 }
 #endif /* __cplusplus */
 
-#include <syscalls/haptics.h>
+#include <zephyr/syscalls/haptics.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_HAPTICS_H_ */

--- a/samples/bluetooth/audio/bap_unicast_client/src/stream_tx.c
+++ b/samples/bluetooth/audio/bap_unicast_client/src/stream_tx.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/samples/bluetooth/audio/bap_unicast_server/src/stream_tx.c
+++ b/samples/bluetooth/audio/bap_unicast_server/src/stream_tx.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/samples/bluetooth/audio/cap_acceptor/src/cap_acceptor_unicast.c
+++ b/samples/bluetooth/audio/cap_acceptor/src/cap_acceptor_unicast.c
@@ -7,7 +7,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/samples/bluetooth/audio/cap_acceptor/src/main.c
+++ b/samples/bluetooth/audio/cap_acceptor/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/samples/bluetooth/audio/cap_initiator/src/cap_initiator_unicast.c
+++ b/samples/bluetooth/audio/cap_initiator/src/cap_initiator_unicast.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/samples/bluetooth/audio/cap_initiator/src/main.c
+++ b/samples/bluetooth/audio/cap_initiator/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 #include <stddef.h>
 
 #include <zephyr/bluetooth/bluetooth.h>

--- a/soc/infineon/edge/pse84/linker.ld
+++ b/soc/infineon/edge/pse84/linker.ld
@@ -12,5 +12,5 @@
  * This is the linker script for both standard images and XIP images.
  */
 
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/nxp/imxrt/imxrt6xx/hifi4/include/soc/memory.h
+++ b/soc/nxp/imxrt/imxrt6xx/hifi4/include/soc/memory.h
@@ -8,7 +8,7 @@
 #ifndef __XTENSA_MEMORY_H__
 #define __XTENSA_MEMORY_H__
 
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 
 #define TEXT_BASE (CONFIG_RT685_ADSP_TEXT_MEM_ADDR)
 #define TEXT_SIZE (CONFIG_RT685_ADSP_TEXT_MEM_SIZE)

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -32,7 +32,7 @@
 #include "common.h"
 #include "bap_common.h"
 #include "bstests.h"
-#include "syscalls/kernel.h"
+#include <zephyr/syscalls/kernel.h>
 
 #ifdef CONFIG_BT_BAP_BROADCAST_ASSISTANT
 

--- a/tests/bsim/bluetooth/audio/src/bap_stream_tx.c
+++ b/tests/bsim/bluetooth/audio/src/bap_stream_tx.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/tests/drivers/input/tsc_keys/src/test_stm32_tsc.c
+++ b/tests/drivers/input/tsc_keys/src/test_stm32_tsc.c
@@ -27,7 +27,7 @@
  */
 
 #include <soc.h>
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 #include <inttypes.h>
 #include <zephyr/ztest.h>
 #include <zephyr/device.h>

--- a/tests/kernel/device/src/abstract_driver.h
+++ b/tests/kernel/device/src/abstract_driver.h
@@ -95,6 +95,6 @@ static inline int z_impl_abstract_sibling_do_other(const struct device *dev, int
 
 __syscall int abstract_sibling_do_other(const struct device *dev, int val);
 
-#include <syscalls/abstract_driver.h>
+#include <zephyr/syscalls/abstract_driver.h>
 
 #endif /* _ABSTRACT_DRIVER_H_ */


### PR DESCRIPTION
CONFIG_LEGACY_GENERATED_INCLUDE_PATH is deprecated and no longer
enabled by default, so the un-prefixed <syscalls/abstract_driver.h> and <autoconf.h>
include path is not available anymore and the test fails to build:

  fatal error: syscalls/abstract_driver.h: No such file or directory

Use the zephyr/ prefixed path for the generated syscall header and autoconf.h

