### PR TITLE
sd: sdio: reject zero max_blk_size before byte-I/O loop

### DIFF
--- a/subsys/sd/sdio.c
+++ b/subsys/sd/sdio.c
@@ -196,6 +196,12 @@ static int sdio_io_rw_extended_helper(struct sdio_func *func,
 		}
 	}
 	/* Remaining data must be written using byte I/O */
+	if (func->cis.max_blk_size == 0U) {
+		/* A zero max_blk_size would make MIN(remaining, 0) == 0 and
+		 * the loop below spin forever without making progress.
+		 */
+		return -EIO;
+	}
 	while (remaining > 0) {
 		size = MIN(remaining, func->cis.max_blk_size);
 


### PR DESCRIPTION
sdio_io_rw_byte_extended() used MIN(remaining, func->cis.max_blk_size)
as the per-iteration size. With max_blk_size == 0 the result is always 0,
remaining never decreases, and the function spins forever while holding
the SDIO mutex. Return -EIO when max_blk_size is 0.

Assisted-by: Claude:opus-4.8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>

Fixes: #113729