### PR TITLE
watchdog: nxp: mcux_wwdt: enable peripheral clock at init

### DIFF
--- a/drivers/watchdog/wdt_mcux_wwdt.c
+++ b/drivers/watchdog/wdt_mcux_wwdt.c
@@ -283,13 +283,11 @@ static int mcux_wwdt_init(const struct device *dev)
 		return ret;
 	}
 
-#if FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL
 	ret = clock_control_on(config->clock_dev, config->clock_subsys);
 	if (ret) {
 		LOG_ERR("Failed to enable clock: %d", ret);
 		return ret;
 	}
-#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 	/* The rest of the device init is done from the
 	 * PM_DEVICE_ACTION_TURN_ON in the pm callback


### PR DESCRIPTION
 - Removes the compile-time guard so the peripheral clock is always enabled in the driver init path, ensuring the WWDT registers are accessible. Otherwise, at least for MCXA, WWDT register access by mcux_wwdt_config_func()->WWDT_ClearStatusFlags() triggers data bus fault.
 - Tested on frdm-mcxa266.