### PR TITLE
Fix remaining legacy syscalls include paths

### DIFF
--- a/drivers/haptics/haptics_handlers.c
+++ b/drivers/haptics/haptics_handlers.c
@@ -57,7 +57,7 @@ static inline int z_vrfy_haptics_select_source(const struct device *dev,
 
 static inline int z_vrfy_haptics_set_level(const struct device *dev, const enum haptics_source src,
 					   const union haptics_config *const cfg,
-					   const uint8_t level)
+					   const uint32_t level)
 {
 	K_OOPS(K_SYSCALL_DRIVER_HAPTICS(dev, set_level));
 

--- a/drivers/haptics/haptics_handlers.c
+++ b/drivers/haptics/haptics_handlers.c
@@ -14,7 +14,7 @@ static inline int z_vrfy_haptics_calibrate(const struct device *dev, const uint3
 	return z_impl_haptics_calibrate(dev, routine);
 }
 
-#include <syscalls/haptics_calibrate_mrsh.c>
+#include <zephyr/syscalls/haptics_calibrate_mrsh.c>
 
 static inline int z_vrfy_haptics_monitor_get(const struct device *dev,
 					     const enum haptics_monitor monitor,
@@ -28,7 +28,7 @@ static inline int z_vrfy_haptics_monitor_get(const struct device *dev,
 	return z_impl_haptics_monitor_get(dev, monitor, type, val);
 }
 
-#include <syscalls/haptics_monitor_get_mrsh.c>
+#include <zephyr/syscalls/haptics_monitor_get_mrsh.c>
 
 static inline int z_vrfy_haptics_monitor_set(const struct device *dev,
 					     const enum haptics_monitor monitor, const bool enable)
@@ -38,7 +38,7 @@ static inline int z_vrfy_haptics_monitor_set(const struct device *dev,
 	return z_impl_haptics_monitor_set(dev, monitor, enable);
 }
 
-#include <syscalls/haptics_monitor_set_mrsh.c>
+#include <zephyr/syscalls/haptics_monitor_set_mrsh.c>
 
 static inline int z_vrfy_haptics_select_source(const struct device *dev,
 					       const enum haptics_source src,
@@ -53,7 +53,7 @@ static inline int z_vrfy_haptics_select_source(const struct device *dev,
 	return z_impl_haptics_select_source(dev, src, cfg);
 }
 
-#include <syscalls/haptics_select_source_mrsh.c>
+#include <zephyr/syscalls/haptics_select_source_mrsh.c>
 
 static inline int z_vrfy_haptics_set_level(const struct device *dev, const enum haptics_source src,
 					   const union haptics_config *const cfg,
@@ -68,7 +68,7 @@ static inline int z_vrfy_haptics_set_level(const struct device *dev, const enum 
 	return z_impl_haptics_set_level(dev, src, cfg, level);
 }
 
-#include <syscalls/haptics_set_level_mrsh.c>
+#include <zephyr/syscalls/haptics_set_level_mrsh.c>
 
 static inline int z_vrfy_haptics_start_output(const struct device *dev)
 {
@@ -77,7 +77,7 @@ static inline int z_vrfy_haptics_start_output(const struct device *dev)
 	return z_impl_haptics_start_output(dev);
 }
 
-#include <syscalls/haptics_start_output_mrsh.c>
+#include <zephyr/syscalls/haptics_start_output_mrsh.c>
 
 static inline int z_vrfy_haptics_stop_output(const struct device *dev)
 {
@@ -86,7 +86,7 @@ static inline int z_vrfy_haptics_stop_output(const struct device *dev)
 	return z_impl_haptics_stop_output(dev);
 }
 
-#include <syscalls/haptics_stop_output_mrsh.c>
+#include <zephyr/syscalls/haptics_stop_output_mrsh.c>
 
 static inline int z_vrfy_haptics_stream_samples(const struct device *dev,
 						const uint8_t *const samples, const size_t len)
@@ -98,4 +98,4 @@ static inline int z_vrfy_haptics_stream_samples(const struct device *dev,
 	return z_impl_haptics_stream_samples(dev, samples, len);
 }
 
-#include <syscalls/haptics_stream_samples_mrsh.c>
+#include <zephyr/syscalls/haptics_stream_samples_mrsh.c>

--- a/include/zephyr/drivers/haptics.h
+++ b/include/zephyr/drivers/haptics.h
@@ -536,6 +536,6 @@ static inline int z_impl_haptics_stream_samples(const struct device *dev,
 }
 #endif /* __cplusplus */
 
-#include <syscalls/haptics.h>
+#include <zephyr/syscalls/haptics.h>
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_HAPTICS_H_ */

--- a/tests/kernel/device/src/abstract_driver.h
+++ b/tests/kernel/device/src/abstract_driver.h
@@ -95,6 +95,6 @@ static inline int z_impl_abstract_sibling_do_other(const struct device *dev, int
 
 __syscall int abstract_sibling_do_other(const struct device *dev, int val);
 
-#include <syscalls/abstract_driver.h>
+#include <zephyr/syscalls/abstract_driver.h>
 
 #endif /* _ABSTRACT_DRIVER_H_ */


### PR DESCRIPTION
#112016 switched `LEGACY_GENERATED_INCLUDE_PATH` off by default, but three in-tree files still use the un-prefixed form, so `tests/kernel/device` now fails to build on every platform (`fatal error: syscalls/abstract_driver.h: No such file or directory`) and the haptics syscall handlers fail the same way under `CONFIG_USERSPACE`. Migrate them to `<zephyr/syscalls/...>`.

Fixing the haptics include exposed a latent mismatch in `z_vrfy_haptics_set_level` — the handler took a `uint8_t level` vs the `uint32_t` in the syscall declaration — fixed in a separate commit.

Build-verified on `qemu_cortex_a53`: `tests/kernel/device`, and `tests/drivers/build_all/haptics` with `CONFIG_USERSPACE=y`.
