### PR TITLE
drivers: wifi: nrf_wifi: lower default RAM footprint for nrf70 Series

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -470,11 +470,11 @@ config NRF70_RX_NUM_BUFS
 	int "Number of RX buffers"
 	range 3 256
 	default 6 if !NRF70_DATA_TX
-	default 48
+	default 16
 
 config NRF70_MAX_TX_AGGREGATION
 	int "Maximum number of TX packets to aggregate"
-	default 12
+	default 4
 
 config NRF70_MAX_TX_TOKENS
 	int "Maximum number of TX tokens"
@@ -628,7 +628,8 @@ config NRF_WIFI_DATA_HEAP_SIZE
 	default 0 if NRF70_RADIO_TEST || NRF70_OFFLOADED_RAW_TX
 	default 8000 if NRF70_SCAN_ONLY
 	default 110000 if !SOC_FAMILY_NORDIC_NRF
-	default 130000
+	default 65536
+
 endif
 
 if NETWORKING


### PR DESCRIPTION
Adjust defaults on nRF70 Series for a lower RAM footprint. A 130 kB heap is too large for many applications, and many samples need to override these defaults in order to just fit.

The PR saves about 64 KB while remaining suitable for most IoT applications.