### PR TITLE
tests: drivers: uart: async_api: give kit_pse84_eval DUT own clock divider

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -14,7 +14,7 @@ dut: &scb5 {
 	status = "okay";
 	current-speed = <115200>;
 
-	clocks = <&peri0_group1_16bit_1>;
+	clocks = <&peri0_group1_16bit_2>;
 
 	pinctrl-0 = <&p17_1_scb5_uart_tx &p17_0_scb5_uart_rx>;
 	pinctrl-names = "default";
@@ -31,7 +31,7 @@ dut: &scb5 {
 	input-enable;
 };
 
-&peri0_group1_16bit_1 {
+&peri0_group1_16bit_2 {
 	status = "okay";
 	clock-div = <109>;
 };

--- a/tests/drivers/uart/uart_async_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -14,7 +14,7 @@ dut: &scb5 {
 	status = "okay";
 	current-speed = <115200>;
 
-	clocks = <&peri0_group1_16bit_1>;
+	clocks = <&peri0_group1_16bit_2>;
 
 	pinctrl-0 = <&p17_1_scb5_uart_tx &p17_0_scb5_uart_rx>;
 	pinctrl-names = "default";
@@ -31,7 +31,7 @@ dut: &scb5 {
 	input-enable;
 };
 
-&peri0_group1_16bit_1 {
+&peri0_group1_16bit_2 {
 	status = "okay";
 	clock-div = <109>;
 };


### PR DESCRIPTION
The `uart_async_api` test overlay for `kit_pse84_eval` assigned the DUT
(`&scb5`) the peripheral clock divider `peri0_group1_16bit_1`, which is
also the divider used by the board console (`&scb2`). The `read_abort`
subtest is the only one that reconfigures the DUT baud rate (to 9600), so
`ifx_cat1_uart_set_baud()` reprograms that shared divider. That
simultaneously dropped the console from 115200 to 9600, corrupting all
subsequent console output and making the device appear to hang partway
through the suite.

Point the DUT at a dedicated, otherwise-unused 16-bit divider
(`peri0_group1_16bit_2`) so baud-rate changes on the DUT no longer disturb
the console. The same fix is applied to the m33 and m55 overlays.

### Testing

Ran `drivers.uart.async_api` on `kit_pse84_eval/pse846gps2dbzc4a/m33` with
twister `--device-testing`:

- Before: the suite locked up during `uart_async_read_abort` — the console
  output was truncated and the harness lost the device.
- After: the console stays alive through `read_abort`; the whole suite runs
  to completion and reports results normally.
