### PR TITLE
Ameba/kconfig decouple zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
         - hal
     - name: hal_realtek
       path: modules/hal/realtek
-      revision: a00cf493fa200df303f617d609538d33088c2654
+      revision: b106aa7cbbb78cee74c0d8063f19eecc575a80b2
       groups:
         - hal
     - name: hal_renesas


### PR DESCRIPTION
Required by PR #112386, which narrows Kconfig loading to the active SoC
and expects HAL Kconfigs to be free of Zephyr symbol references. This is
the companion PR to the hal_realtek change (https://github.com/zephyrproject-rtos/hal_realtek/pull/38)

- Add WiFi-related selects to amebad/amebadplus Kconfig.soc; 
- Add BT_COEXIST and EXT_PTA_PIN_* per-SoC defaults to Kconfig.defconfig files; 
- Add ZEPHYR_MBEDTLS_MODULE, SHARED_INTERRUPTS and REALTEK_AMEBA_ZEPHYR_BT 
- selects to BT_AMEBA in drivers/bluetooth/hci/Kconfig; 
- Add new Kconfig.ameba for BT subsystem defaults.
- 