### PR TITLE
MAINTAINERS: add yangbolu1991 as collaborator for Networking gPTP

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4790,6 +4790,8 @@ Networking:
   status: maintained
   maintainers:
     - jukkar
+  collaborators:
+    - yangbolu1991
   files:
     - doc/services/connectivity/networking/api/gptp.rst
     - include/zephyr/net/gptp.h


### PR DESCRIPTION
I'm experienced on IEEE 1588/802.1AS protocols, ETH PTP clock driver and gPTP stacks.
I'd like to help on code review and feature/issue tasks for Networking gPTP area.
So, propose myself as collaborator.

My contribution related.
- Introduced PI servo in gPTP to optimize performance to nanosecond level.
- Some bug-fixes and PR review on gPTP.
- Ethernet driver support and gPTP enablement for NXP platforms.

Thanks a lot.