### PR TITLE
manifest: update hostap revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -294,7 +294,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 568e4423c76ec70b2ea9a5ed43085af9a29999ec
+      revision: pull/132/head
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
This PR only updates the manifest revision in Zephyr. The Hostap implementation changes are in the corresponding Hostap branch.