### PR TITLE
tests: flash: make buffer and pattern sizes configurable via Kconfig

### DIFF
--- a/tests/drivers/flash/erase_blocks/Kconfig
+++ b/tests/drivers/flash/erase_blocks/Kconfig
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config TEST_FLASH_ERASE_BLOCKS_BUFFER_SIZE
+	int "Flash erase-blocks test buffer size"
+	default 512
+
+source "Kconfig.zephyr"

--- a/tests/drivers/flash/erase_blocks/src/main.c
+++ b/tests/drivers/flash/erase_blocks/src/main.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2023 Bjarki Arge Andreasen
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -39,8 +41,8 @@ LOG_MODULE_REGISTER(test_flash);
 	DT_MTD_FROM_PARTITION(TEST_FLASH_PART_NODE)
 
 static const struct device *flash_controller = DEVICE_DT_GET(TEST_FLASH_CONTROLLER_NODE);
-static uint8_t test_write_block[512];
-static uint8_t test_read_block[512];
+static uint8_t test_write_block[CONFIG_TEST_FLASH_ERASE_BLOCKS_BUFFER_SIZE];
+static uint8_t test_read_block[CONFIG_TEST_FLASH_ERASE_BLOCKS_BUFFER_SIZE];
 
 static void test_flash_fill_test_write_block(void)
 {

--- a/tests/drivers/flash/interface_test/Kconfig
+++ b/tests/drivers/flash/interface_test/Kconfig
@@ -1,8 +1,12 @@
-#
 # Copyright 2025 NXP
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
+
+config TEST_FLASH_PATTERN_SIZE
+	int "Flash interface test pattern size"
+	default 256
 
 config TEST_SEQUENTIAL_READ_PATTERN_AMOUNT
 	int "Perform amount of sequential-read-pattern tests"

--- a/tests/drivers/flash/interface_test/src/main.c
+++ b/tests/drivers/flash/interface_test/src/main.c
@@ -1,5 +1,7 @@
 /*
  * Copyright 2025 NXP
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,7 +22,7 @@
 
 #define TEST_FLASH_CONTROLLER_NODE DT_MTD_FROM_PARTITION(TEST_FLASH_PART_NODE)
 
-#define PATTERN_SIZE 256
+#define PATTERN_SIZE CONFIG_TEST_FLASH_PATTERN_SIZE
 
 static const struct device *flash_controller = DEVICE_DT_GET(TEST_FLASH_CONTROLLER_NODE);
 


### PR DESCRIPTION
This PR replaces hardcoded buffer and pattern sizes in flash tests with
Kconfig options, allowing SoC and board-specific overrides.

Adds CONFIG_FLASH_TEST_WRITE_BLOCK_SIZE (default 512) for erase_blocks test
Adds CONFIG_FLASH_TEST_PATTERN_SIZE (default 256) for interface_test
Preserves existing behavior for all platforms by default

This allows platforms with different flash write-block-size requirements to override these values
without modifying the test source code.