### PR TITLE
FRDM-MCXL255: OSTIMER support for CM33

### DIFF
--- a/boards/nxp/frdm_mcxl255/board.c
+++ b/boards/nxp/frdm_mcxl255/board.c
@@ -127,6 +127,11 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_GateAonUART);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ostimer0))
+	/* Select 1 MHz clock source for OSTIMER0. */
+	CLOCK_AttachClk(kCLK_1M_to_OSTIMER0);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(rtc))
 	if (!CLOCK_IsRoscInitialized()) {
 		rosc_init_config_t rosc_init_config;

--- a/boards/nxp/frdm_mcxl255/board.c
+++ b/boards/nxp/frdm_mcxl255/board.c
@@ -184,6 +184,11 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_GatePERIPH_GROUP1);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ostimer0))
+	/* Select 1 MHz clock source for OSTIMER0. */
+	CLOCK_AttachClk(kCLK_1M_to_OSTIMER0);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(rtc))
 	if (!CLOCK_IsRoscInitialized()) {
 		rosc_init_config_t rosc_init_config;

--- a/dts/arm/nxp/mcx/mcxl/nxp_mcxl.dtsi
+++ b/dts/arm/nxp/mcx/mcxl/nxp_mcxl.dtsi
@@ -291,4 +291,17 @@
 		resets = <&reset NXP_SYSCON_RESET(0, 9)>;
 		status = "disabled";
 	};
+
+	ostimer0: timers@ad000 {
+		compatible = "nxp,os-timer";
+		reg = <0xad000 0x1000>;
+		interrupts = <57 0>;
+		status = "disabled";
+	};
+
+	ostimer0_clk: clock-ostimer0 {
+		compatible = "fixed-clock";
+		clock-frequency = <DT_FREQ_M(1)>;
+		#clock-cells = <0>;
+	};
 };

--- a/dts/arm/nxp/mcx/nxp_mcxl.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl.dtsi
@@ -215,4 +215,17 @@
 		resets = <&reset NXP_SYSCON_RESET(0, 9)>;
 		status = "disabled";
 	};
+
+	ostimer0: timers@ad000 {
+		compatible = "nxp,os-timer";
+		reg = <0xad000 0x1000>;
+		interrupts = <57 0>;
+		status = "disabled";
+	};
+
+	ostimer0_clk: clock-ostimer0 {
+		compatible = "fixed-clock";
+		clock-frequency = <DT_FREQ_M(1)>;
+		#clock-cells = <0>;
+	};
 };

--- a/soc/nxp/mcx/mcxl/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxl/Kconfig.defconfig
@@ -10,12 +10,15 @@ config MCUX_CORE_SUFFIX
 		SOC_MCXL253_CPU1
 
 config CORTEX_M_SYSTICK
+	default n if MCUX_OS_TIMER
 	default y
 
 config NUM_IRQS
 	default 161
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,$(dt_nodelabel_path,ostimer0_clk),clock-frequency) if \
+		MCUX_OS_TIMER
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if \
 		SOC_MCXL255_CPU0 || SOC_MCXL254_CPU0 || SOC_MCXL253_CPU0
 	default $(dt_node_int_prop_int,/cpus/cpu@1,clock-frequency) if \

--- a/soc/nxp/mcx/mcxl/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxl/Kconfig.defconfig
@@ -10,6 +10,7 @@ config MCUX_CORE_SUFFIX
 		SOC_MCXL253_CPU1
 
 config CORTEX_M_SYSTICK
+	default n if MCUX_OS_TIMER
 	default y
 
 config NUM_IRQS
@@ -17,6 +18,8 @@ config NUM_IRQS
 	default 161 if SOC_MCXL255_CPU0 || SOC_MCXL254_CPU0 || SOC_MCXL253_CPU0
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,$(dt_nodelabel_path,ostimer0_clk),clock-frequency) if \
+		MCUX_OS_TIMER
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if \
 		SOC_MCXL255_CPU0 || SOC_MCXL254_CPU0 || SOC_MCXL253_CPU0
 	default $(dt_node_int_prop_int,/cpus/cpu@1,clock-frequency) if \


### PR DESCRIPTION
Add OSTIMER support for MCXL25x CPU0/CM33.

This PR adds the MCXL OSTIMER0 devicetree node and allows the existing NXP
`nxp,os-timer` driver to be selected for MCXL25x CPU0.

OSTIMER0 is kept disabled by default and FRDM-MCXL255 continues to use
SysTick as the default timer. The board early initialization selects
the 1 MHz OSTIMER0 clock source when the OSTIMER node is enabled.

Tested with:
- `samples/hello_world` on `frdm_mcxl255/mcxl255/cpu0`
- custom temporary OSTIMER test application on `frdm_mcxl255/mcxl255/cpu0`