### PR TITLE
dts: arm: nuvoton: add uspi nodes for numaker m031x

### DIFF
--- a/drivers/spi/spi_numaker_usci.c
+++ b/drivers/spi/spi_numaker_usci.c
@@ -122,29 +122,33 @@ static int spi_numaker_usci_txrx(const struct device *dev, uint8_t spi_dfs)
 		USPI_WRITE_TX(dev_cfg->uspi, 0x00U);
 	}
 
-	if (spi_context_rx_on(ctx)) {
-		if (!USPI_GET_RX_EMPTY_FLAG(dev_cfg->uspi)) {
-			rx_frame = USPI_READ_RX(dev_cfg->uspi);
-			if (ctx->rx_buf != NULL) {
-				if (spi_dfs > 2) {
-					UNALIGNED_PUT(rx_frame, (uint32_t *)data->ctx.rx_buf);
-				} else if (spi_dfs > 1) {
-					UNALIGNED_PUT(rx_frame, (uint16_t *)data->ctx.rx_buf);
-				} else {
-					UNALIGNED_PUT(rx_frame, (uint8_t *)data->ctx.rx_buf);
-				}
-			}
-			spi_context_update_rx(ctx, spi_dfs, 1);
-			LOG_DBG("%s --> RX [0x%x] done", __func__, rx_frame);
+	/* One TX frame always yields exactly one RX frame. Waiting for
+	 * RX-not-empty keeps TX/RX aligned regardless of the shallow USCI
+	 * buffer depth (unlike the deep-FIFO SPI, we cannot pipeline).
+	 */
+	time_out_cnt = SystemCoreClock;
+	while (USPI_GET_RX_EMPTY_FLAG(dev_cfg->uspi)) {
+		if (--time_out_cnt == 0) {
+			LOG_ERR("Wait for USCI_SPI RX time-out");
+			return -EIO;
 		}
 	}
 
-	time_out_cnt = SystemCoreClock;
-	while (dev_cfg->uspi->PROTSTS & USPI_PROTSTS_BUSY_Msk) {
-		if (--time_out_cnt == 0) {
-			LOG_ERR("Wait for USCI_SPI time-out");
-			return -EIO;
+	rx_frame = USPI_READ_RX(dev_cfg->uspi);
+
+	/* Store received word only if a RX buffer is present */
+	if (spi_context_rx_on(ctx)) {
+		if (ctx->rx_buf != NULL) {
+			if (spi_dfs > 2) {
+				UNALIGNED_PUT(rx_frame, (uint32_t *)data->ctx.rx_buf);
+			} else if (spi_dfs > 1) {
+				UNALIGNED_PUT(rx_frame, (uint16_t *)data->ctx.rx_buf);
+			} else {
+				UNALIGNED_PUT(rx_frame, (uint8_t *)data->ctx.rx_buf);
+			}
 		}
+		spi_context_update_rx(ctx, spi_dfs, 1);
+		LOG_DBG("%s --> RX [0x%x] done", __func__, rx_frame);
 	}
 
 	LOG_DBG("%s --> exit", __func__);
@@ -180,12 +184,6 @@ static int spi_numaker_usci_transceive(const struct device *dev, const struct sp
 		break;
 	case 16:
 		spi_dfs = 2;
-		break;
-	case 24:
-		spi_dfs = 3;
-		break;
-	case 32:
-		spi_dfs = 4;
 		break;
 	default:
 		spi_dfs = 0;

--- a/dts/arm/nuvoton/m031x.dtsi
+++ b/dts/arm/nuvoton/m031x.dtsi
@@ -266,6 +266,28 @@
 			#size-cells = <0>;
 			status = "disabled";
 		};
+
+		uspi0: spi@400d0000 {
+			compatible = "nuvoton,numaker-usci-spi";
+			reg = <0x400d0000 0x1000>;
+			interrupts = <22 0>;
+			resets = <&rst NUMAKER_USCI0_RST>;
+			clocks = <&pcc NUMAKER_USCI0_MODULE 0 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		uspi1: spi@400d1000 {
+			compatible = "nuvoton,numaker-usci-spi";
+			reg = <0x400d1000 0x1000>;
+			interrupts = <22 0>;
+			resets = <&rst NUMAKER_USCI1_RST>;
+			clocks = <&pcc NUMAKER_USCI1_MODULE 0 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
 	};
 };
 


### PR DESCRIPTION
This PR is to add uspi nodes of numaker M031x.
Also fixed  uspi driver without FIFO buffer Rx words.

Pass spi_loopback test as below:
```
===================================================================
TESTSUITE spi_loopback succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [spi_extra_api_features]: pass = 2, fail = 0, skip = 0, total = 2 duration = 0.003 seconds
 - PASS - [spi_extra_api_features.test_spi_hold_on_cs] duration = 0.002 seconds
 - PASS - [spi_extra_api_features.test_spi_lock_release] duration = 0.001 seconds

SUITE PASS - 100.00% [spi_loopback]: pass = 21, fail = 0, skip = 5, total = 26 duration = 0.258 seconds
 - PASS - [spi_loopback.test_nop_nil_bufs] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_large_transfers] duration = 0.179 seconds
 - PASS - [spi_loopback.test_spi_complete_loop_mode_0] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_loop_mode_1] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_loop_mode_2] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_loop_mode_3] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_multiple] duration = 0.002 seconds
 - PASS - [spi_loopback.test_spi_complete_multiple_timed] duration = 0.018 seconds
 - PASS - [spi_loopback.test_spi_concurrent_transfer_different_spec] duration = 0.003 seconds
 - PASS - [spi_loopback.test_spi_concurrent_transfer_same_spec] duration = 0.003 seconds
 - SKIP - [spi_loopback.test_spi_deinit] duration = 0.005 seconds
 - PASS - [spi_loopback.test_spi_null_rx_buf_set] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_null_tx_buf] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_null_tx_buf_set] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_null_tx_rx_buf_set] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_bigger_than_tx] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_every_4] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_half_end] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_half_start] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_same_buf_cmd] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_word_size_16] duration = 0.001 seconds
 - SKIP - [spi_loopback.test_spi_word_size_24] duration = 0.008 seconds
 - SKIP - [spi_loopback.test_spi_word_size_32] duration = 0.008 seconds
 - SKIP - [spi_loopback.test_spi_word_size_7] duration = 0.008 seconds
 - SKIP - [spi_loopback.test_spi_word_size_9] duration = 0.008 seconds
 - PASS - [spi_loopback.test_spi_write_back] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```