### PR TITLE
drivers: clock_control: guard SIRC calls on MCXW727

### DIFF
--- a/drivers/clock_control/clock_control_nxp_mcxw7x.c
+++ b/drivers/clock_control/clock_control_nxp_mcxw7x.c
@@ -59,8 +59,10 @@ struct mcxw_clock_control_config {
 	/* FIRC frequency range configuration */
 	uint8_t firc_range;
 
+#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
 	/* Enable SIRC in low power mode */
 	bool enable_sirc_in_lp_mode;
+#endif
 
 	/* System clock source selection */
 	uint8_t sys_clk_src;
@@ -154,7 +156,12 @@ static int nxp_mcxw_clock_control_get_rate(const struct device *dev,
 			break;
 		}
 		case MCXW_CLK_IP_MUX_FRO_6M: {
+#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
 			*rate = CLOCK_GetFreq(kCLOCK_ScgSircClk);
+#else
+			/* SIRC not present on this SoC; FRO6M runs at a fixed 6 MHz */
+			*rate = 6000000U;
+#endif
 			break;
 		}
 		default: {
@@ -235,6 +242,13 @@ static int nxp_mcxw_clock_control_pm(const struct device *dev, enum pm_device_ac
 
 static int nxp_mcxw_clock_validate_sys_clk_src(const struct mcxw_clock_control_config *config)
 {
+#if !DT_INST_NODE_HAS_PROP(0, sirc_supported)
+	if (config->sys_clk_src == MCXW_CLK_SYSTEM_CLK_SRC_SIRC) {
+		LOG_ERR("SIRC is not available as system clock source on this SoC");
+		return -EINVAL;
+	}
+#endif
+
 	switch (config->sys_clk_src) {
 	case MCXW_CLK_SYSTEM_CLK_SRC_SOSC:
 		if (!config->enable_sosc) {
@@ -269,7 +283,9 @@ static int nxp_mcxw_clock_control_init(const struct device *dev)
 
 	/* Unlock Reference Clock Status Registers to allow writes */
 	CLOCK_UnlockFircControlStatusReg();
+#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
 	CLOCK_UnlockSircControlStatusReg();
+#endif
 	CLOCK_UnlockRoscControlStatusReg();
 	CLOCK_UnlockSysOscControlStatusReg();
 
@@ -318,12 +334,14 @@ static int nxp_mcxw_clock_control_init(const struct device *dev)
 	/* Initialize FIRC */
 	(void)CLOCK_InitFirc(&scg_firc_config);
 
+#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
 	if (config->enable_sirc_in_lp_mode) {
 		scg_sirc_config_t scg_sirc_config = {
 			.enableMode = kSCG_SircEnableInSleep,
 		};
 		(void)CLOCK_InitSirc(&scg_sirc_config);
 	}
+#endif
 
 	if (config->enable_sosc) {
 		scg_sosc_config_t scg_sosc_config = {
@@ -414,7 +432,9 @@ static struct mcxw_clock_control_config config = {
 	.extal_cap = DT_INST_PROP(0, osc32k_extal_cap),
 	.firc_mode = DT_INST_PROP(0, firc_mode),
 	.firc_range = DT_INST_PROP(0, firc_range),
+#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
 	.enable_sirc_in_lp_mode = DT_INST_PROP(0, enable_sirc_in_lp_mode),
+#endif
 	.sys_clk_src = DT_INST_PROP(0, sys_clk_src),
 #if DT_INST_NODE_HAS_PROP(0, sys_clk_div_plat)
 	.sys_clk_div_plat = DT_INST_PROP(0, sys_clk_div_plat),

--- a/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
@@ -447,6 +447,7 @@
 		osc32k-extal-cap = <4>;
 		firc-mode = <MCXW_CLK_FIRC_ENABLE>;
 		firc-range = <MCXW_CLK_FIRC_RANGE_96MHZ>;
+		sirc-supported;
 		enable-sirc-in-lp-mode;
 		sys-clk-src = <MCXW_CLK_SYSTEM_CLK_SRC_FIRC>;
 		sys-clk-div-plat = <2>;

--- a/dts/arm/nxp/mcx/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw71.dtsi
@@ -106,6 +106,12 @@
 	clock-names = "clksrc0", "clksrc1", "clksrc2", "clksrc3";
 };
 
+&clk_ctrl {
+	/* MCXW71 has SIRC hardware; enable it in low-power mode by default. */
+	sirc-supported;
+	enable-sirc-in-lp-mode;
+};
+
 &nbu {
 	rfmc-xo-cdac = <0x0c>;
 	rfmc-xo-isel = <0x05>;

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -208,7 +208,6 @@
 		osc32k-extal-cap = <4>;
 		firc-mode = <MCXW_CLK_FIRC_ENABLE>;
 		firc-range = <MCXW_CLK_FIRC_RANGE_96MHZ>;
-		enable-sirc-in-lp-mode;
 		sys-clk-src = <MCXW_CLK_SYSTEM_CLK_SRC_FIRC>;
 		sys-clk-div-bus = <1>;
 		sys-clk-div-slow = <4>;

--- a/dts/bindings/clock/nxp,mcxw7x-clock.yaml
+++ b/dts/bindings/clock/nxp,mcxw7x-clock.yaml
@@ -116,10 +116,18 @@ properties:
     description: |
       FIRC frequency range selection.
 
+  sirc-supported:
+    type: boolean
+    description: |
+      Indicates that this SoC variant has a SIRC (Slow Internal RC Clock)
+      hardware block. Present on MCXW70 and MCXW71; absent on MCXW72 variants
+      where the SIRC register block was removed. Used at compile time to
+      conditionally include SIRC-specific SDK types and functions.
+
   enable-sirc-in-lp-mode:
     type: boolean
     description: |
-     Enable/disable SIRC(FRO 6M) in low power mode.
+      Enable SIRC in low-power mode. Only meaningful when sirc-supported is set.
 
   sys-clk-src:
     type: int


### PR DESCRIPTION
mcux-sdk-ng periph3/PERI_SCG.h (MCXW727A/C/D, rev 3.0, 2026-02-11) removed the SIRCCSR register block from SCG. As a result kCLOCK_ScgSircClk, CLOCK_UnlockSircControlStatusReg, scg_sirc_config_t, kSCG_SircEnableInSleep and CLOCK_InitSirc are no longer declared or defined in the MCXW727C SDK headers, breaking the build for frdm_mcxw72.

Guard the three affected sites with
CONFIG_SOC_MCXW70AC || CONFIG_SOC_MCXW716C -- the only two variants in this driver family that still carry SIRC:

- get_rate() watchdog FRO_6M branch: replace CLOCK_GetFreq(kCLOCK_ScgSircClk) with the fixed constant 6000000U on MCXW727, matching the 6 MHz value returned by the SDK's CLOCK_GetIpFreq() for kCLOCK_IpSrcFro6M.
- clock_control_init(): skip CLOCK_UnlockSircControlStatusReg() which has been removed from fsl_clock.c on MCXW727.
- clock_control_init(): skip the SIRC LP-mode init block (scg_sirc_config_t / CLOCK_InitSirc) which relies on types and functions absent from the MCXW727C fsl_clock.h.

Tested: west build -p=always -b frdm_mcxw72 tests/lib/cpp/cxx builds cleanly after this change.