### PR TITLE
kernel: work: allow submit before starting the workqueue thread

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4031,7 +4031,7 @@ static inline bool k_work_is_pending(const struct k_work *work);
  * * @p queue is draining; or
  * * @p queue is plugged.
  * @retval -EINVAL if @p queue is null and the work item has never been run.
- * @retval -ENODEV if @p queue has not been started.
+ * @retval -ENODEV if @p queue has not been initialized.
  */
 int k_work_submit_to_queue(struct k_work_q *queue,
 			   struct k_work *work);
@@ -4550,6 +4550,8 @@ enum {
 	K_WORK_QUEUE_PLUGGED = BIT(K_WORK_QUEUE_PLUGGED_BIT),
 	K_WORK_QUEUE_STOP_BIT = 4,
 	K_WORK_QUEUE_STOP = BIT(K_WORK_QUEUE_STOP_BIT),
+	K_WORK_QUEUE_INITIALIZED_BIT = 5,
+	K_WORK_QUEUE_INITIALIZED = BIT(K_WORK_QUEUE_INITIALIZED_BIT),
 
 	/* Static work queue flags */
 	K_WORK_QUEUE_NO_YIELD_BIT = 8,

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4083,6 +4083,9 @@ static inline bool k_work_is_pending(const struct k_work *work);
  *
  * @param work pointer to the work item.
  *
+ * If the queue currently has no runner attached, the work will still be queued.
+ * In that case, it will start running after attaching a runner.
+ *
  * @retval 0 if work was already submitted to a queue
  * @retval 1 if work was not submitted and has been queued to @p queue
  * @retval 2 if work was running and has been queued to the queue that was
@@ -4092,7 +4095,6 @@ static inline bool k_work_is_pending(const struct k_work *work);
  * * @p queue is draining; or
  * * @p queue is plugged.
  * @retval -EINVAL if @p queue is null and the work item has never been run.
- * @retval -ENODEV if @p queue has not been started.
  */
 int k_work_submit_to_queue(struct k_work_q *queue,
 			   struct k_work *work);
@@ -4606,8 +4608,6 @@ enum {
 	K_WORK_DELAYABLE = BIT(K_WORK_DELAYABLE_BIT),
 
 	/* Dynamic work queue flags */
-	K_WORK_QUEUE_STARTED_BIT = 0,
-	K_WORK_QUEUE_STARTED = BIT(K_WORK_QUEUE_STARTED_BIT),
 	K_WORK_QUEUE_BUSY_BIT = 1,
 	K_WORK_QUEUE_BUSY = BIT(K_WORK_QUEUE_BUSY_BIT),
 	K_WORK_QUEUE_DRAIN_BIT = 2,

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -276,7 +276,7 @@ static inline int queue_submit_locked(struct k_work_q *queue,
 	 * * -EBUSY if plugged and not draining
 	 * * otherwise OK
 	 */
-	if (!flag_test(&queue->flags, K_WORK_QUEUE_STARTED_BIT)) {
+	if (!flag_test(&queue->flags, K_WORK_QUEUE_INITIALIZED_BIT)) {
 		ret = -ENODEV;
 	} else if (draining && !chained) {
 		ret = -EBUSY;
@@ -725,7 +725,7 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 		} else if (flag_test(&queue->flags, K_WORK_QUEUE_STOP_BIT)) {
 			/* User has requested that the queue stop. Clear the status flags and exit.
 			 */
-			flags_set(&queue->flags, 0);
+			flags_set(&queue->flags, K_WORK_QUEUE_INITIALIZED);
 			k_spin_unlock(&work_lock, key);
 			return;
 		} else {
@@ -807,8 +807,12 @@ void k_work_queue_init(struct k_work_q *queue)
 	__ASSERT_NO_MSG(queue != NULL);
 
 	*queue = (struct k_work_q) {
-		.flags = 0,
+		.flags = K_WORK_QUEUE_INITIALIZED,
 	};
+
+	sys_slist_init(&queue->pending);
+	z_waitq_init(&queue->notifyq);
+	z_waitq_init(&queue->drainq);
 
 	SYS_PORT_TRACING_OBJ_INIT(k_work_queue, queue);
 }
@@ -817,10 +821,13 @@ void k_work_queue_run(struct k_work_q *queue, const struct k_work_queue_config *
 {
 	__ASSERT_NO_MSG(!flag_test(&queue->flags, K_WORK_QUEUE_STARTED_BIT));
 
-	uint32_t flags = K_WORK_QUEUE_STARTED;
+	if (!flag_test(&queue->flags, K_WORK_QUEUE_INITIALIZED_BIT)) {
+		k_work_queue_init(queue);
+		flag_set(&queue->flags, K_WORK_QUEUE_INITIALIZED_BIT);
+	}
 
 	if ((cfg != NULL) && cfg->no_yield) {
-		flags |= K_WORK_QUEUE_NO_YIELD;
+		flag_set(&queue->flags, K_WORK_QUEUE_NO_YIELD_BIT);
 	}
 
 	if ((cfg != NULL) && (cfg->name != NULL)) {
@@ -835,11 +842,8 @@ void k_work_queue_run(struct k_work_q *queue, const struct k_work_queue_config *
 	}
 #endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
 
-	sys_slist_init(&queue->pending);
-	z_waitq_init(&queue->notifyq);
-	z_waitq_init(&queue->drainq);
 	queue->thread_id = _current;
-	flags_set(&queue->flags, flags);
+	flag_set(&queue->flags, K_WORK_QUEUE_STARTED_BIT);
 	work_queue_main(queue, NULL, NULL);
 }
 
@@ -858,23 +862,22 @@ void k_work_queue_start(struct k_work_q *queue,
 	 */
 	TOOLCHAIN_DISABLE_WARNING("-Wdeprecated-declarations");
 
-	uint32_t flags = K_WORK_QUEUE_STARTED;
+	if (!flag_test(&queue->flags, K_WORK_QUEUE_INITIALIZED_BIT)) {
+		k_work_queue_init(queue);
+		flag_set(&queue->flags, K_WORK_QUEUE_INITIALIZED_BIT);
+	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work_queue, start, queue);
 
-	sys_slist_init(&queue->pending);
-	z_waitq_init(&queue->notifyq);
-	z_waitq_init(&queue->drainq);
-
 	if ((cfg != NULL) && cfg->no_yield) {
-		flags |= K_WORK_QUEUE_NO_YIELD;
+		flag_set(&queue->flags, K_WORK_QUEUE_NO_YIELD_BIT);
 	}
 
 	/* It hasn't actually been started yet, but all the state is in place
 	 * so we can submit things and once the thread gets control it's ready
 	 * to roll.
 	 */
-	flags_set(&queue->flags, flags);
+	flag_set(&queue->flags, K_WORK_QUEUE_STARTED_BIT);
 
 	(void)k_thread_create(&queue->thread, stack, stack_size,
 			      work_queue_main, queue, NULL, NULL,

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -896,8 +896,8 @@ void k_work_queue_start(struct k_work_q *queue,
 	}
 #endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
 
-	k_thread_start(&queue->thread);
 	queue->thread_id = &queue->thread;
+	k_thread_start(&queue->thread);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work_queue, start, queue);
 

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -268,24 +268,24 @@ static inline int queue_submit_locked(struct k_work_q *queue,
 	bool chained = (_current == queue->thread_id) && !k_is_in_isr();
 	bool draining = flag_test(&queue->flags, K_WORK_QUEUE_DRAIN_BIT);
 	bool plugged = flag_test(&queue->flags, K_WORK_QUEUE_PLUGGED_BIT);
+	bool was_empty = sys_slist_is_empty(&queue->pending);
 
 	/* Test for acceptability, in priority order:
 	 *
-	 * * -ENODEV if the queue isn't running.
 	 * * -EBUSY if draining and not chained
 	 * * -EBUSY if plugged and not draining
 	 * * otherwise OK
 	 */
-	if (!flag_test(&queue->flags, K_WORK_QUEUE_STARTED_BIT)) {
-		ret = -ENODEV;
-	} else if (draining && !chained) {
+	if (draining && !chained) {
 		ret = -EBUSY;
 	} else if (plugged && !draining) {
 		ret = -EBUSY;
 	} else {
 		sys_slist_append(&queue->pending, &work->node);
 		ret = 1;
-		(void)notify_queue_locked(queue);
+		if (queue->thread_id != NULL && was_empty) {
+			(void)notify_queue_locked(queue);
+		}
 	}
 
 	return ret;
@@ -719,9 +719,9 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 			 */
 			(void)z_sched_wake_all(&queue->drainq, 1, NULL);
 		} else if (flag_test(&queue->flags, K_WORK_QUEUE_STOP_BIT)) {
-			/* User has requested that the queue stop. Clear the status flags and exit.
+			/* User has requested that the queue stop. Clear the thread id and exit.
 			 */
-			flags_set(&queue->flags, 0);
+			queue->thread_id = NULL;
 			k_spin_unlock(&work_lock, key);
 			return;
 		} else {
@@ -798,6 +798,15 @@ static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 	}
 }
 
+static bool k_work_queue_is_initialized(struct k_work_q *queue)
+{
+#ifdef CONFIG_WAITQ_SCALABLE
+	return queue->notifyq.waitq.tree.lessthan_fn != NULL;
+#else
+	return queue->notifyq.waitq.head != NULL;
+#endif
+}
+
 void k_work_queue_init(struct k_work_q *queue)
 {
 	__ASSERT_NO_MSG(queue != NULL);
@@ -806,17 +815,23 @@ void k_work_queue_init(struct k_work_q *queue)
 		.flags = 0,
 	};
 
+	sys_slist_init(&queue->pending);
+	z_waitq_init(&queue->notifyq);
+	z_waitq_init(&queue->drainq);
+
 	SYS_PORT_TRACING_OBJ_INIT(k_work_queue, queue);
 }
 
 void k_work_queue_run(struct k_work_q *queue, const struct k_work_queue_config *cfg)
 {
-	__ASSERT_NO_MSG(!flag_test(&queue->flags, K_WORK_QUEUE_STARTED_BIT));
+	__ASSERT_NO_MSG(queue->thread_id == NULL);
 
-	uint32_t flags = K_WORK_QUEUE_STARTED;
+	if (!k_work_queue_is_initialized(queue)) {
+		k_work_queue_init(queue);
+	}
 
 	if ((cfg != NULL) && cfg->no_yield) {
-		flags |= K_WORK_QUEUE_NO_YIELD;
+		flag_set(&queue->flags, K_WORK_QUEUE_NO_YIELD_BIT);
 	}
 
 	if ((cfg != NULL) && (cfg->name != NULL)) {
@@ -831,11 +846,7 @@ void k_work_queue_run(struct k_work_q *queue, const struct k_work_queue_config *
 	}
 #endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
 
-	sys_slist_init(&queue->pending);
-	z_waitq_init(&queue->notifyq);
-	z_waitq_init(&queue->drainq);
 	queue->thread_id = _current;
-	flags_set(&queue->flags, flags);
 	work_queue_main(queue, NULL, NULL);
 }
 
@@ -847,30 +858,22 @@ void k_work_queue_start(struct k_work_q *queue,
 {
 	__ASSERT_NO_MSG(queue);
 	__ASSERT_NO_MSG(stack);
-	__ASSERT_NO_MSG(!flag_test(&queue->flags, K_WORK_QUEUE_STARTED_BIT));
+	__ASSERT_NO_MSG(queue->thread_id == NULL);
+
+	if (!k_work_queue_is_initialized(queue)) {
+		k_work_queue_init(queue);
+	}
 
 	/* In future, this whole function will be deprecated, but for now, we
 	 * have to use the `thread` field to create a new thread in it.
 	 */
 	TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_DEPRECATED_DECLARATIONS);
 
-	uint32_t flags = K_WORK_QUEUE_STARTED;
-
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work_queue, start, queue);
 
-	sys_slist_init(&queue->pending);
-	z_waitq_init(&queue->notifyq);
-	z_waitq_init(&queue->drainq);
-
 	if ((cfg != NULL) && cfg->no_yield) {
-		flags |= K_WORK_QUEUE_NO_YIELD;
+		flag_set(&queue->flags, K_WORK_QUEUE_NO_YIELD_BIT);
 	}
-
-	/* It hasn't actually been started yet, but all the state is in place
-	 * so we can submit things and once the thread gets control it's ready
-	 * to roll.
-	 */
-	flags_set(&queue->flags, flags);
 
 	(void)k_thread_create(&queue->thread, stack, stack_size,
 			      work_queue_main, queue, NULL, NULL,
@@ -966,7 +969,7 @@ int k_work_queue_stop(struct k_work_q *queue, k_timeout_t timeout)
 
 	k_spinlock_key_t key = k_spin_lock(&work_lock);
 
-	if (!flag_test(&queue->flags, K_WORK_QUEUE_STARTED_BIT)) {
+	if (queue->thread_id == NULL) {
 		k_spin_unlock(&work_lock, key);
 		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work_queue, stop, queue, timeout, -EALREADY);
 		return -EALREADY;

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -892,8 +892,8 @@ void k_work_queue_start(struct k_work_q *queue,
 	}
 #endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
 
-	k_thread_start(&queue->thread);
 	queue->thread_id = &queue->thread;
+	k_thread_start(&queue->thread);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work_queue, start, queue);
 

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -86,9 +86,18 @@ static atomic_t resubmits_left;
 /* k_uptime_get32() on the last invocation of the core handler. */
 static uint32_t volatile last_handle_ms;
 
+static struct k_work_q not_init_queue;
+
+static K_THREAD_STACK_DEFINE(not_start_stack, STACK_SIZE);
+static struct k_work_q not_start_queue;
+static atomic_t not_start_ctr;
+static inline int not_start_counter(void)
+{
+	return atomic_get(&not_start_ctr);
+}
+
 static K_THREAD_STACK_DEFINE(coophi_stack, STACK_SIZE);
 static struct k_work_q coophi_queue;
-static struct k_work_q not_start_queue;
 static atomic_t coophi_ctr;
 static inline int coophi_counter(void)
 {
@@ -138,6 +147,7 @@ static inline void reset_counters(void)
 	atomic_set(&system_ctr, 0);
 	atomic_set(&cooplo_ctr, 0);
 	atomic_set(&preempt_ctr, 0);
+	atomic_set(&not_start_ctr, 0);
 }
 
 static void counter_handler(struct k_work *work)
@@ -151,6 +161,8 @@ static void counter_handler(struct k_work *work)
 		atomic_inc(&cooplo_ctr);
 	} else if (k_current_get() == preempt_queue.thread_id) {
 		atomic_inc(&preempt_ctr);
+	} else if (k_current_get() == not_start_queue.thread_id) {
+		atomic_inc(&not_start_ctr);
 	}
 	if (atomic_dec(&resubmits_left) > 0) {
 		(void)k_work_submit_to_queue(NULL, work);
@@ -211,7 +223,19 @@ static void test_delayable_init(void)
 			  NULL);
 }
 
-/* Check that submission to an unstarted queue is diagnosed. */
+/* Check that submission to an uninitialized queue is diagnosed. */
+ZTEST(work, test_uninitialized)
+{
+	int rc;
+
+	k_work_init(&common_work, counter_handler);
+	zassert_equal(k_work_busy_get(&common_work), 0);
+
+	rc = k_work_submit_to_queue(&not_init_queue, &common_work);
+	zassert_equal(rc, -ENODEV);
+}
+
+/* Check that submission to an unstarted queue is successful. */
 ZTEST(work, test_unstarted)
 {
 	int rc;
@@ -219,8 +243,33 @@ ZTEST(work, test_unstarted)
 	k_work_init(&common_work, counter_handler);
 	zassert_equal(k_work_busy_get(&common_work), 0);
 
+	k_work_queue_init(&not_start_queue);
+
 	rc = k_work_submit_to_queue(&not_start_queue, &common_work);
-	zassert_equal(rc, -ENODEV);
+	zassert_equal(rc, 1);
+	zassert_equal(k_work_busy_get(&common_work), K_WORK_QUEUED);
+	zassert_equal(k_work_is_pending(&common_work), true);
+
+	/* Shouldn't start, yet. */
+	rc = k_sem_take(&sync_sem, K_SECONDS(1));
+	zassert_equal(rc, -EAGAIN);
+	zassert_equal(not_start_counter(), 0);
+	zassert_equal(k_work_busy_get(&common_work), K_WORK_QUEUED);
+
+	k_work_queue_start(&not_start_queue, not_start_stack, STACK_SIZE, PREEMPT_PRIORITY, NULL);
+	zassert_equal(not_start_queue.flags, K_WORK_QUEUE_INITIALIZED | K_WORK_QUEUE_STARTED);
+
+	k_sleep(K_TICKS(1));
+	zassert_equal(not_start_counter(), 1);
+	zassert_equal(k_work_busy_get(&common_work), 0);
+
+	/* Flush the sync state from completion */
+	rc = k_sem_take(&sync_sem, K_FOREVER);
+	zassert_equal(rc, 0);
+
+	/* Make sure the queue is not-started again, in case other tests want to use it. */
+	zassert_true(k_work_queue_drain(&not_start_queue, true) >= 0, "drain failed");
+	zassert_ok(k_work_queue_stop(&not_start_queue, K_FOREVER), "stop failed");
 }
 
 static void cooplo_main(void *workq_ptr, void *p2, void *p3)
@@ -240,14 +289,16 @@ static void cooplo_main(void *workq_ptr, void *p2, void *p3)
 
 static void test_queue_start(void)
 {
+	k_work_queue_init(&not_start_queue);
+
 	struct k_work_queue_config cfg = {
 		.name = "wq.preempt",
 	};
 	k_work_queue_init(&preempt_queue);
-	zassert_equal(preempt_queue.flags, 0);
+	zassert_equal(preempt_queue.flags, K_WORK_QUEUE_INITIALIZED);
 	k_work_queue_start(&preempt_queue, preempt_stack, STACK_SIZE,
 			    PREEMPT_PRIORITY, &cfg);
-	zassert_equal(preempt_queue.flags, K_WORK_QUEUE_STARTED);
+	zassert_equal(preempt_queue.flags, K_WORK_QUEUE_INITIALIZED | K_WORK_QUEUE_STARTED);
 
 	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
 		const char *tn = k_thread_name_get(preempt_queue.thread_id);
@@ -261,7 +312,7 @@ static void test_queue_start(void)
 	zassert_equal(invalid_test_queue.flags, 0);
 	k_work_queue_start(&invalid_test_queue, invalid_test_stack, STACK_SIZE,
 			    PREEMPT_PRIORITY, &cfg);
-	zassert_equal(invalid_test_queue.flags, K_WORK_QUEUE_STARTED);
+	zassert_equal(invalid_test_queue.flags, K_WORK_QUEUE_INITIALIZED | K_WORK_QUEUE_STARTED);
 
 	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
 		const char *tn = k_thread_name_get(invalid_test_queue.thread_id);
@@ -276,7 +327,8 @@ static void test_queue_start(void)
 	k_work_queue_start(&coophi_queue, coophi_stack, STACK_SIZE,
 			    COOPHI_PRIORITY, &cfg);
 	zassert_equal(coophi_queue.flags,
-		      K_WORK_QUEUE_STARTED | K_WORK_QUEUE_NO_YIELD, NULL);
+		      K_WORK_QUEUE_INITIALIZED | K_WORK_QUEUE_STARTED | K_WORK_QUEUE_NO_YIELD,
+		      NULL);
 
 	(void)k_thread_create(&cooplo_thread, cooplo_stack, STACK_SIZE, cooplo_main, &cooplo_queue,
 			      NULL, NULL, COOPLO_PRIORITY, 0, K_FOREVER);
@@ -287,7 +339,8 @@ static void test_queue_start(void)
 	k_msleep(1);
 
 	zassert_equal(cooplo_queue.flags,
-		      K_WORK_QUEUE_STARTED | K_WORK_QUEUE_NO_YIELD, NULL);
+		      K_WORK_QUEUE_INITIALIZED | K_WORK_QUEUE_STARTED | K_WORK_QUEUE_NO_YIELD,
+		      NULL);
 }
 
 /* Check validation of submission without a destination queue. */
@@ -1004,7 +1057,8 @@ ZTEST(work_1cpu, test_1cpu_plugged_drain)
 
 	/* Queue should be plugged */
 	zassert_equal(coophi_queue.flags,
-		      K_WORK_QUEUE_STARTED
+		      K_WORK_QUEUE_INITIALIZED
+		      | K_WORK_QUEUE_STARTED
 		      | K_WORK_QUEUE_PLUGGED
 		      | K_WORK_QUEUE_NO_YIELD,
 		      NULL);
@@ -1024,7 +1078,7 @@ ZTEST(work_1cpu, test_1cpu_plugged_drain)
 	rc = k_work_queue_unplug(&coophi_queue);
 	zassert_equal(rc, -EALREADY);
 	zassert_equal(coophi_queue.flags,
-		      K_WORK_QUEUE_STARTED | K_WORK_QUEUE_NO_YIELD,
+		      K_WORK_QUEUE_INITIALIZED | K_WORK_QUEUE_STARTED | K_WORK_QUEUE_NO_YIELD,
 		      NULL);
 
 	/* Resubmission should succeed and complete */

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -86,9 +86,18 @@ static atomic_t resubmits_left;
 /* k_uptime_get32() on the last invocation of the core handler. */
 static uint32_t volatile last_handle_ms;
 
+static struct k_work_q not_init_queue;
+
+static K_THREAD_STACK_DEFINE(not_start_stack, STACK_SIZE);
+static struct k_work_q not_start_queue;
+static atomic_t not_start_ctr;
+static inline int not_start_counter(void)
+{
+	return atomic_get(&not_start_ctr);
+}
+
 static K_THREAD_STACK_DEFINE(coophi_stack, STACK_SIZE);
 static struct k_work_q coophi_queue;
-static struct k_work_q not_start_queue;
 static atomic_t coophi_ctr;
 static inline int coophi_counter(void)
 {
@@ -151,6 +160,8 @@ static void counter_handler(struct k_work *work)
 		atomic_inc(&cooplo_ctr);
 	} else if (k_current_get() == preempt_queue.thread_id) {
 		atomic_inc(&preempt_ctr);
+	} else if (k_current_get() == not_start_queue.thread_id) {
+		atomic_inc(&not_start_ctr);
 	}
 	if (atomic_dec(&resubmits_left) > 0) {
 		(void)k_work_submit_to_queue(NULL, work);
@@ -211,7 +222,19 @@ static void test_delayable_init(void)
 			  NULL);
 }
 
-/* Check that submission to an unstarted queue is diagnosed. */
+/* Check that submission to an uninitialized queue is successful. */
+ZTEST(work, test_uninitialized)
+{
+	int rc;
+
+	k_work_init(&common_work, counter_handler);
+	zassert_equal(k_work_busy_get(&common_work), 0);
+
+	rc = k_work_submit_to_queue(&not_init_queue, &common_work);
+	zassert_equal(rc, 1);
+}
+
+/* Check that submission to an unstarted queue is successful. */
 ZTEST(work, test_unstarted)
 {
 	int rc;
@@ -220,7 +243,30 @@ ZTEST(work, test_unstarted)
 	zassert_equal(k_work_busy_get(&common_work), 0);
 
 	rc = k_work_submit_to_queue(&not_start_queue, &common_work);
-	zassert_equal(rc, -ENODEV);
+	zassert_equal(rc, 1);
+	zassert_equal(k_work_busy_get(&common_work), K_WORK_QUEUED);
+	zassert_equal(k_work_is_pending(&common_work), true);
+
+	/* Shouldn't start, yet. */
+	rc = k_sem_take(&sync_sem, K_SECONDS(1));
+	zassert_equal(rc, -EAGAIN);
+	zassert_equal(not_start_counter(), 0);
+	zassert_equal(k_work_busy_get(&common_work), K_WORK_QUEUED);
+
+	k_work_queue_start(&not_start_queue, not_start_stack, STACK_SIZE, PREEMPT_PRIORITY, NULL);
+	zassert_equal(not_start_queue.flags, 0);
+
+	k_sleep(K_TICKS(1));
+	zassert_equal(not_start_counter(), 1);
+	zassert_equal(k_work_busy_get(&common_work), 0);
+
+	/* Flush the sync state from completion */
+	rc = k_sem_take(&sync_sem, K_FOREVER);
+	zassert_equal(rc, 0);
+
+	/* Make sure the queue is not-started again, in case other tests want to use it. */
+	zassert_true(k_work_queue_drain(&not_start_queue, true) >= 0, "drain failed");
+	zassert_ok(k_work_queue_stop(&not_start_queue, K_FOREVER), "stop failed");
 }
 
 static void cooplo_main(void *workq_ptr, void *p2, void *p3)
@@ -240,6 +286,8 @@ static void cooplo_main(void *workq_ptr, void *p2, void *p3)
 
 static void test_queue_start(void)
 {
+	k_work_queue_init(&not_start_queue);
+
 	struct k_work_queue_config cfg = {
 		.name = "wq.preempt",
 	};
@@ -247,7 +295,7 @@ static void test_queue_start(void)
 	zassert_equal(preempt_queue.flags, 0);
 	k_work_queue_start(&preempt_queue, preempt_stack, STACK_SIZE,
 			    PREEMPT_PRIORITY, &cfg);
-	zassert_equal(preempt_queue.flags, K_WORK_QUEUE_STARTED);
+	zassert_equal(preempt_queue.flags, 0);
 
 	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
 		const char *tn = k_thread_name_get(preempt_queue.thread_id);
@@ -261,7 +309,7 @@ static void test_queue_start(void)
 	zassert_equal(invalid_test_queue.flags, 0);
 	k_work_queue_start(&invalid_test_queue, invalid_test_stack, STACK_SIZE,
 			    PREEMPT_PRIORITY, &cfg);
-	zassert_equal(invalid_test_queue.flags, K_WORK_QUEUE_STARTED);
+	zassert_equal(invalid_test_queue.flags, 0);
 
 	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
 		const char *tn = k_thread_name_get(invalid_test_queue.thread_id);
@@ -275,8 +323,7 @@ static void test_queue_start(void)
 	cfg.no_yield = true;
 	k_work_queue_start(&coophi_queue, coophi_stack, STACK_SIZE,
 			    COOPHI_PRIORITY, &cfg);
-	zassert_equal(coophi_queue.flags,
-		      K_WORK_QUEUE_STARTED | K_WORK_QUEUE_NO_YIELD, NULL);
+	zassert_equal(coophi_queue.flags, K_WORK_QUEUE_NO_YIELD, NULL);
 
 	(void)k_thread_create(&cooplo_thread, cooplo_stack, STACK_SIZE, cooplo_main, &cooplo_queue,
 			      NULL, NULL, COOPLO_PRIORITY, 0, K_FOREVER);
@@ -286,8 +333,7 @@ static void test_queue_start(void)
 	/* Be sure the cooplo_thread has a chance to start running */
 	k_msleep(1);
 
-	zassert_equal(cooplo_queue.flags,
-		      K_WORK_QUEUE_STARTED | K_WORK_QUEUE_NO_YIELD, NULL);
+	zassert_equal(cooplo_queue.flags, K_WORK_QUEUE_NO_YIELD, NULL);
 }
 
 /* Check validation of submission without a destination queue. */
@@ -1069,11 +1115,7 @@ ZTEST(work_1cpu, test_1cpu_plugged_drain)
 	zassert_equal(coophi_counter(), 1);
 
 	/* Queue should be plugged */
-	zassert_equal(coophi_queue.flags,
-		      K_WORK_QUEUE_STARTED
-		      | K_WORK_QUEUE_PLUGGED
-		      | K_WORK_QUEUE_NO_YIELD,
-		      NULL);
+	zassert_equal(coophi_queue.flags, K_WORK_QUEUE_PLUGGED | K_WORK_QUEUE_NO_YIELD, NULL);
 
 	/* Switch to the non-blocking handler. */
 	k_work_init(&common_work, counter_handler);
@@ -1089,9 +1131,7 @@ ZTEST(work_1cpu, test_1cpu_plugged_drain)
 	/* Unplug the unplugged queue should not affect the queue */
 	rc = k_work_queue_unplug(&coophi_queue);
 	zassert_equal(rc, -EALREADY);
-	zassert_equal(coophi_queue.flags,
-		      K_WORK_QUEUE_STARTED | K_WORK_QUEUE_NO_YIELD,
-		      NULL);
+	zassert_equal(coophi_queue.flags, K_WORK_QUEUE_NO_YIELD, NULL);
 
 	/* Resubmission should succeed and complete */
 	rc = k_work_submit_to_queue(&coophi_queue, &common_work);

--- a/tests/kernel/workq/work_queue/src/start_stop.c
+++ b/tests/kernel/workq/work_queue/src/start_stop.c
@@ -52,8 +52,6 @@ ZTEST(workqueue_api, test_k_work_queue_start_stop)
 	zassert_ok(k_work_queue_stop(&work_q, K_FOREVER), "Failed to stop work queue");
 
 	k_work_init(&work, work_handler);
-	zassert_equal(k_work_submit_to_queue(&work_q, &work), -ENODEV,
-		      "Succeeded to submit work item to non-initialized work queue");
 }
 
 ZTEST(workqueue_api, test_k_work_queue_stop_sys_thread)
@@ -128,8 +126,6 @@ ZTEST(workqueue_api, test_k_work_queue_run_stop)
 	zassert_ok(k_work_queue_stop(&work_q, K_FOREVER), "Failed to stop work queue");
 
 	k_work_init(&work, work_handler);
-	zassert_equal(k_work_submit_to_queue(&work_q, &work), -ENODEV,
-		      "Succeeded to submit work item to non-initialized work queue");
 
 	/* Take the semaphore the other thread released once done running the queue */
 	rc = k_sem_take(&ret_sem, K_MSEC(1));


### PR DESCRIPTION
I don't know, what the original intention was for not allowing this, but
this behavior doesn't seem to match how people use work queues. Almost none
of the code checks the return value of k_work_submit and expects it to
always work. Skipping execution of work might be less of an issue for e.g.
button debouncing, but can be more problematic in other situations.

I've not run into any such issues, but we are about to allow moving the
system work queue to the main thread. That will make it start quite late,
which could cause hard to debug issues without this change.

I've also taken the opportunity to separate k_work_queue_init from
k_work_queue_run/k_work_queue_start more strictly, so the names actually
make sense. My plan is to not add the k_work_queue_start call to the future
implementation of k_work_queue_start_with_thread and expect users to
actually initialize work queues either statically or at runtime before
starting them. Unfortunately we can't do that for k_work_queue_run, because
it would silently break users.

Related: https://github.com/zephyrproject-rtos/zephyr/pull/110610