### PR TITLE
Bluetooth: Host: Add lookup functions for advertising sets

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1491,6 +1491,18 @@ int bt_le_ext_adv_delete(struct bt_le_ext_adv *adv);
  */
 uint8_t bt_le_ext_adv_get_index(struct bt_le_ext_adv *adv);
 
+/**
+ * @brief Look up an advertising set by advertiser address and SID.
+ *
+ * @kconfig_dep{CONFIG_BT_EXT_ADV}
+ *
+ * @param addr Advertiser address and type.
+ * @param sid  The advertising set ID.
+ *
+ * @return Pointer to the extended advertising set object or NULL if no matching set was found.
+ */
+struct bt_le_ext_adv *bt_le_ext_adv_lookup_addr(const bt_addr_le_t *addr, uint8_t sid);
+
 /** Advertising states. */
 enum bt_le_ext_adv_state {
 	/** The advertising set has been created but not enabled. */
@@ -1690,6 +1702,19 @@ int bt_le_per_adv_start(struct bt_le_ext_adv *adv);
  * @return         Zero on success or (negative) error code otherwise.
  */
 int bt_le_per_adv_stop(struct bt_le_ext_adv *adv);
+
+/**
+ * @brief Look up a periodic advertising set by advertiser address and SID.
+ *
+ * @kconfig_dep{CONFIG_BT_PER_ADV}
+ *
+ * @param addr Advertiser address.
+ * @param sid  The advertising set ID.
+ *
+ * @return Pointer to the extended advertising set object with periodic advertising configured,
+ *         or NULL if no matching set was found.
+ */
+struct bt_le_ext_adv *bt_le_per_adv_lookup_addr(const bt_addr_le_t *addr, uint8_t sid);
 
 /**
  * @brief Information about the successful synchronization with periodic advertising.

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1493,6 +1493,19 @@ int bt_le_ext_adv_delete(struct bt_le_ext_adv *adv);
  */
 uint8_t bt_le_ext_adv_get_index(struct bt_le_ext_adv *adv);
 
+/**
+ * @brief Look up an advertising set by advertiser address and SID.
+ *
+ * @kconfig_dep{CONFIG_BT_EXT_ADV}
+ *
+ * @param addr Advertiser address and type.
+ * @param sid  The advertising set ID. Shall be @ref BT_GAP_SID_INVALID for advertising sets created
+ *             without @ref BT_LE_ADV_OPT_EXT_ADV.
+ *
+ * @return Pointer to the extended advertising set object or NULL if no matching set was found.
+ */
+struct bt_le_ext_adv *bt_le_ext_adv_lookup_addr(const bt_addr_le_t *addr, uint8_t sid);
+
 /** Advertising states. */
 enum bt_le_ext_adv_state {
 	/** The advertising set has been created but not enabled. */
@@ -1522,7 +1535,12 @@ struct bt_le_ext_adv_info {
 	/** Currently selected Transmit Power in dBm. Range: -127 to +20. */
 	int8_t                     tx_power;
 
-	/** Advertising Set ID */
+	/**
+	 * @brief Advertising Set ID
+	 *
+	 * Will be @ref BT_GAP_SID_INVALID for advertising sets created without
+	 * @ref BT_LE_ADV_OPT_EXT_ADV.
+	 */
 	uint8_t                    sid;
 
 	/** Current local advertising address used. */
@@ -1692,6 +1710,19 @@ int bt_le_per_adv_start(struct bt_le_ext_adv *adv);
  * @return         Zero on success or (negative) error code otherwise.
  */
 int bt_le_per_adv_stop(struct bt_le_ext_adv *adv);
+
+/**
+ * @brief Look up a periodic advertising set by advertiser address and SID.
+ *
+ * @kconfig_dep{CONFIG_BT_PER_ADV}
+ *
+ * @param addr Advertiser address.
+ * @param sid  The advertising set ID.
+ *
+ * @return Pointer to the extended advertising set object with periodic advertising configured,
+ *         or NULL if no matching set was found.
+ */
+struct bt_le_ext_adv *bt_le_per_adv_lookup_addr(const bt_addr_le_t *addr, uint8_t sid);
 
 /**
  * @brief Information about the successful synchronization with periodic advertising.

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -231,6 +231,28 @@ struct bt_le_ext_adv *bt_hci_adv_lookup_handle(uint8_t handle)
 	return NULL;
 }
 #endif /* CONFIG_BT_BROADCASTER */
+
+struct bt_le_ext_adv *bt_le_ext_adv_lookup_addr(const bt_addr_le_t *addr, uint8_t sid)
+{
+	ARRAY_FOR_EACH_PTR(adv_pool, adv) {
+		if (atomic_test_bit(adv->flags, BT_ADV_CREATED) && adv->sid == sid) {
+			const bt_addr_le_t *adv_addr;
+
+			if (atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
+				adv_addr = &bt_dev.id_addr[adv->id];
+			} else {
+				adv_addr = &adv->random_addr;
+			}
+
+			if (bt_addr_le_eq(adv_addr, addr)) {
+				return adv;
+			}
+		}
+	}
+
+	return NULL;
+}
+
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 
 void bt_le_ext_adv_foreach(void (*func)(struct bt_le_ext_adv *adv, void *data),
@@ -1987,6 +2009,17 @@ int bt_le_per_adv_start(struct bt_le_ext_adv *adv)
 int bt_le_per_adv_stop(struct bt_le_ext_adv *adv)
 {
 	return bt_le_per_adv_enable(adv, false);
+}
+
+struct bt_le_ext_adv *bt_le_per_adv_lookup_addr(const bt_addr_le_t *addr, uint8_t sid)
+{
+	struct bt_le_ext_adv *ext_adv = bt_le_ext_adv_lookup_addr(addr, sid);
+
+	if (ext_adv != NULL && atomic_test_bit(ext_adv->flags, BT_PER_ADV_PARAMS_SET)) {
+		return ext_adv;
+	}
+
+	return NULL;
 }
 
 #if defined(CONFIG_BT_PER_ADV_RSP)

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -231,6 +231,28 @@ struct bt_le_ext_adv *bt_hci_adv_lookup_handle(uint8_t handle)
 	return NULL;
 }
 #endif /* CONFIG_BT_BROADCASTER */
+
+struct bt_le_ext_adv *bt_le_ext_adv_lookup_addr(const bt_addr_le_t *addr, uint8_t sid)
+{
+	ARRAY_FOR_EACH_PTR(adv_pool, adv) {
+		if (atomic_test_bit(adv->flags, BT_ADV_CREATED) && adv->sid == sid) {
+			const bt_addr_le_t *adv_addr;
+
+			if (atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
+				adv_addr = &bt_dev.id_addr[adv->id];
+			} else {
+				adv_addr = &adv->random_addr;
+			}
+
+			if (bt_addr_le_eq(adv_addr, addr)) {
+				return adv;
+			}
+		}
+	}
+
+	return NULL;
+}
+
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 
 void bt_le_ext_adv_foreach(void (*func)(struct bt_le_ext_adv *adv, void *data),
@@ -1461,7 +1483,8 @@ int bt_le_ext_adv_create(const struct bt_le_adv_param *param,
 	}
 
 	adv->id = param->id;
-	adv->sid = param->sid;
+	/* Only set SID for extended advertising sets, else set BT_GAP_SID_INVALID for legacy */
+	adv->sid = (param->options & BT_LE_ADV_OPT_EXT_ADV) == 0 ? BT_GAP_SID_INVALID : param->sid;
 	adv->cb = cb;
 
 	err = le_ext_adv_param_set(adv, param, false);
@@ -1507,6 +1530,9 @@ int bt_le_ext_adv_update_param(struct bt_le_ext_adv *adv,
 	if (param->id != adv->id) {
 		atomic_clear_bit(adv->flags, BT_ADV_RPA_VALID);
 	}
+
+	/* Only set SID for extended advertising sets, else set BT_GAP_SID_INVALID for legacy */
+	adv->sid = (param->options & BT_LE_ADV_OPT_EXT_ADV) == 0 ? BT_GAP_SID_INVALID : param->sid;
 
 	return le_ext_adv_param_set(adv, param, false);
 }
@@ -1988,6 +2014,17 @@ int bt_le_per_adv_start(struct bt_le_ext_adv *adv)
 int bt_le_per_adv_stop(struct bt_le_ext_adv *adv)
 {
 	return bt_le_per_adv_enable(adv, false);
+}
+
+struct bt_le_ext_adv *bt_le_per_adv_lookup_addr(const bt_addr_le_t *addr, uint8_t sid)
+{
+	struct bt_le_ext_adv *ext_adv = bt_le_ext_adv_lookup_addr(addr, sid);
+
+	if (ext_adv != NULL && atomic_test_bit(ext_adv->flags, BT_PER_ADV_PARAMS_SET)) {
+		return ext_adv;
+	}
+
+	return NULL;
 }
 
 #if defined(CONFIG_BT_PER_ADV_RSP)


### PR DESCRIPTION
Add functions to lookup advertising sets based on their _current_ advertising address. This can be used for both regular and periodic advertising sets.

See https://github.com/zephyrproject-rtos/zephyr/pull/111786 for how it is used in LE Audio

An alternative to this PR is to expose `bt_le_ext_adv_foreach` in the public API and then application can use that with `bt_le_ext_adv_get_info` to do the lookup themselves (when https://github.com/zephyrproject-rtos/zephyr/issues/112667 has been fixed)