### PR TITLE
drivers: spi: stm32: add Kconfig help for SPI_STM32_BUSY_FLAG_TIMEOUT

### DIFF
--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -44,6 +44,15 @@ if SPI_STM32_ERRATA_BUSY
 config SPI_STM32_BUSY_FLAG_TIMEOUT
 	int "timeout in us for the STM32 busy flag workaround"
 	default 10000
+	help
+	  Maximum time in microseconds to wait for the SPI BSY (busy) flag
+	  to clear after a DMA transfer, as a workaround for the errata on
+	  STM32F7 and STM32L4 devices where BSY may remain set after the
+	  last byte is transmitted in slave mode.
+	  The driver polls the BSY and TXE flags using k_yield() between
+	  iterations. If the flag does not clear within this time the
+	  driver continues regardless; increase this value on heavily
+	  loaded systems or when operating at low SPI clock rates.
 
 endif # SPI_STM32_ERRATA_BUSY
 


### PR DESCRIPTION
## Description
SPI_STM32_BUSY_FLAG_TIMEOUT is a user-configurable int option that
appears in menuconfig when building for STM32F7 or STM32L4 targets, but
had no help text. Without it, a developer browsing the config has no
way to know what the value affects, what units it uses, or what the
trade-offs are when changing it.
Add a help block that explains:
- The option sets the maximum polling time in microseconds for the SPI
  BSY flag to clear after a DMA transfer.
- It is a workaround for the errata where BSY may stay high at the end
  of a transfer in slave mode (STM32F7 and STM32L4 families).
- The driver polls using k_yield() between iterations and continues
  regardless if the timeout expires.
- Larger values help on heavily loaded systems or at low SPI clock rates.
## Testing
The fix is Kconfig-only (no compiled code changed). Verified the
resulting help text is visible in menuconfig when building with
CONFIG_SOC_SERIES_STM32F7X or CONFIG_SOC_SERIES_STM32L4X.