### PR TITLE
drivers: rtc: ti_mspm0: Add delay after writing to calendar regs

### DIFF
--- a/drivers/rtc/rtc_ti_mspm0.c
+++ b/drivers/rtc/rtc_ti_mspm0.c
@@ -18,6 +18,10 @@
 #include "rtc_utils.h"
 #include <ti/driverlib/dl_rtc_common.h>
 
+#define RTCCLK_FREQ (32768)
+/* Writes take ~ 3 RTCCLK cycles (32 kHz) to take effect. Approximate delay of 92us */
+#define WRITE_DELAY ((3 * USEC_PER_SEC) / RTCCLK_FREQ)
+
 #if defined(CONFIG_RTC_ALARM)
 #define RTC_TI_ALARM_1		0
 #define RTC_TI_ALARM_2		1
@@ -80,6 +84,7 @@ static int rtc_ti_mspm0_set_time(const struct device *dev,
 				    RTC_DAY_DOW_MASK | RTC_DAY_DOMBIN_MASK);
 		DL_RTC_Common_setCalendarMonthBinary(cfg->regs, mon);
 		DL_RTC_Common_setCalendarYearBinary(cfg->regs, year);
+		k_busy_wait(WRITE_DELAY);
 	}
 
 	return 0;


### PR DESCRIPTION
- The writes take 2-3 RTCCLK cyles to take effect. Reading the regs before this gives invalid values. So just wait for around 3 cycles here.
- RTCCLK can be sourced either from LFOSC or LFXT. Both are 32.768KHz.
- Tested using `tests/drivers/rtc/rtc_api` on mspm0l1117. Without this patch, both test_time_counting and test_set_get_time fail (most of the times. They do succeed some times).