### PR TITLE
maintainers: Move nordicjm from MCUboot collaborator to maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -7059,9 +7059,9 @@ West:
   status: maintained
   maintainers:
     - d3zd3z
+    - nordicjm
   collaborators:
     - de-nordic
-    - nordicjm
   files:
     - modules/Kconfig.mcuboot
     - tests/boot/


### PR DESCRIPTION
Allows for load distribution on MCUboot update PRs