### PR TITLE
kernel: queue: Add peek_next accessor

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2562,6 +2562,23 @@ __syscall void *k_queue_peek_head(struct k_queue *queue);
 __syscall void *k_queue_peek_tail(struct k_queue *queue);
 
 /**
+ * @brief Peek element next to the one provided in the queue
+ *
+ * Return element next to the one provided without removing it.
+ * This operation requires finding the provided element before returning the next one,
+ * hence requiring O(N) time.
+ *
+ * @param queue Address of the queue.
+ * @param data Address of the element which next is being returned.
+ *
+ * @return element next to the one provided
+ * @return NULL if data is NULL
+ * @return NULL if the element provided is not in the list
+ * @return NULL if the element provided has no next
+ */
+__syscall void *k_queue_peek_next(struct k_queue *queue, void *data);
+
+/**
  * @brief Statically define and initialize a queue.
  *
  * The queue can be accessed outside the module where it is defined using:
@@ -3160,6 +3177,27 @@ struct k_fifo {
 	void *fpt_ret = k_queue_peek_tail(&(fifo)->_queue); \
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, peek_tail, fifo, fpt_ret); \
 	fpt_ret; \
+	})
+
+/**
+ * @brief Peek element next to the one provided in the FIFO queue
+ *
+ * Return element next to the one provided without removing it.
+ * This operation requires finding the provided element before returning the next one,
+ * hence requiring O(N) time.
+ *
+ * @param fifo Address of the FIFO queue.
+ * @param data Address of the element which next is being returned.
+ *
+ * @return element next to the one provided
+ * @return NULL if data is NULL
+ * @return NULL if the element provided is not in the list
+ * @return NULL if the element provided has no next
+ */
+#define k_fifo_peek_next(fifo, data)                                                               \
+	({                                                                                         \
+		void *fpt_ret = k_queue_peek_next(&(fifo)->_queue, data);                          \
+		fpt_ret;                                                                           \
 	})
 
 /**

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -3196,7 +3196,9 @@ struct k_fifo {
  */
 #define k_fifo_peek_next(fifo, data)                                                               \
 	({                                                                                         \
+		SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_fifo, peek_next, fifo, data);                    \
 		void *fpt_ret = k_queue_peek_next(&(fifo)->_queue, data);                          \
+		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, peek_next, fifo, data, fpt_ret);            \
 		fpt_ret;                                                                           \
 	})
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2596,6 +2596,23 @@ __syscall void *k_queue_peek_head(struct k_queue *queue);
 __syscall void *k_queue_peek_tail(struct k_queue *queue);
 
 /**
+ * @brief Peek element next to the one provided in the queue
+ *
+ * Return element next to the one provided without removing it.
+ * This operation requires finding the provided element before returning the next one,
+ * hence requiring O(N) time.
+ *
+ * @param queue Address of the queue.
+ * @param data Address of the element which next is being returned.
+ *
+ * @return element next to the one provided
+ * @return NULL if data is NULL
+ * @return NULL if the element provided is not in the list
+ * @return NULL if the element provided has no next
+ */
+__syscall void *k_queue_peek_next(struct k_queue *queue, void *data);
+
+/**
  * @brief Statically define and initialize a queue.
  *
  * The queue can be accessed outside the module where it is defined using:
@@ -3207,6 +3224,27 @@ struct k_fifo {
 	void *fpt_ret = k_queue_peek_tail(&(fifo)->_queue); \
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, peek_tail, fifo, fpt_ret); \
 	fpt_ret; \
+	})
+
+/**
+ * @brief Peek element next to the one provided in the FIFO queue
+ *
+ * Return element next to the one provided without removing it.
+ * This operation requires finding the provided element before returning the next one,
+ * hence requiring O(N) time.
+ *
+ * @param fifo Address of the FIFO queue.
+ * @param data Address of the element which next is being returned.
+ *
+ * @return element next to the one provided
+ * @return NULL if data is NULL
+ * @return NULL if the element provided is not in the list
+ * @return NULL if the element provided has no next
+ */
+#define k_fifo_peek_next(fifo, data)                                                               \
+	({                                                                                         \
+		void *fpt_ret = k_queue_peek_next(&(fifo)->_queue, data);                          \
+		fpt_ret;                                                                           \
 	})
 
 /**

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2599,8 +2599,10 @@ __syscall void *k_queue_peek_tail(struct k_queue *queue);
  * @brief Peek element next to the one provided in the queue
  *
  * Return element next to the one provided without removing it.
- * This operation requires finding the provided element before returning the next one,
- * hence requiring O(N) time.
+ * This operation requires finding the provided element before returning the next one.
+ * The lookup is performed with a payload pointer, for this reason, if the same pointer is equeued
+ * multiple times with k_queue_alloc_append() the first occurrencee will be returned.
+ * This operation requires O(N) time.
  *
  * @param queue Address of the queue.
  * @param data Address of the element which next is being returned.
@@ -3243,8 +3245,11 @@ struct k_fifo {
  */
 #define k_fifo_peek_next(fifo, data)                                                               \
 	({                                                                                         \
-		void *fpt_ret = k_queue_peek_next(&(fifo)->_queue, data);                          \
-		fpt_ret;                                                                           \
+		void *_data = data;                                                                \
+		SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_fifo, peek_next, fifo, _data);                   \
+		void *fpn_ret = k_queue_peek_next(&(fifo)->_queue, _data);                         \
+		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_fifo, peek_next, fifo, _data, fpn_ret);           \
+		fpn_ret;                                                                           \
 	})
 
 /**

--- a/include/zephyr/tracing/tracing_hooks.h
+++ b/include/zephyr/tracing/tracing_hooks.h
@@ -1369,6 +1369,16 @@
 #define sys_port_trace_k_queue_peek_tail(queue, ret)
 #endif
 
+/**
+ * @brief Trace Queue peek next
+ * @param queue Queue object
+ * @param data data pointer
+ * @param ret Return value
+ */
+#ifndef sys_port_trace_k_queue_peek_next
+#define sys_port_trace_k_queue_peek_next(queue, data, ret)
+#endif
+
 /** @} */ /* end of subsys_tracing_apis_queue */
 
 /**
@@ -1535,6 +1545,25 @@
  */
 #ifndef sys_port_trace_k_fifo_peek_tail_exit
 #define sys_port_trace_k_fifo_peek_tail_exit(fifo, ret)
+#endif
+
+/**
+ * @brief Trace FIFO Queue peek next entry
+ * @param fifo FIFO object
+ * @param data data pointer
+ */
+#ifndef sys_port_trace_k_fifo_peek_next_enter
+#define sys_port_trace_k_fifo_peek_next_enter(fifo, data)
+#endif
+
+/**
+ * @brief Trace FIFO Queue peek next exit
+ * @param fifo FIFO object
+ * @param ret Return value
+ * @param data data pointer
+ */
+#ifndef sys_port_trace_k_fifo_peek_next_exit
+#define sys_port_trace_k_fifo_peek_next_exit(fifo, data, ret)
 #endif
 
 /** @} */ /* end of subsys_tracing_apis_fifo */

--- a/include/zephyr/tracing/tracing_hooks.h
+++ b/include/zephyr/tracing/tracing_hooks.h
@@ -1347,6 +1347,16 @@
 #define sys_port_trace_k_queue_peek_tail(queue, ret)
 #endif
 
+/**
+ * @brief Trace Queue peek next
+ * @param queue Queue object
+ * @param data data pointer
+ * @param ret Return value
+ */
+#ifndef sys_port_trace_k_queue_peek_next
+#define sys_port_trace_k_queue_peek_next(queue, data, ret)
+#endif
+
 /** @} */ /* end of subsys_tracing_apis_queue */
 
 /**
@@ -1514,6 +1524,25 @@
  */
 #ifndef sys_port_trace_k_fifo_peek_tail_exit
 #define sys_port_trace_k_fifo_peek_tail_exit(fifo, ret)
+#endif
+
+/**
+ * @brief Trace FIFO Queue peek next entry
+ * @param fifo FIFO object
+ * @param data data pointer
+ */
+#ifndef sys_port_trace_k_fifo_peek_next_enter
+#define sys_port_trace_k_fifo_peek_next_enter(fifo, data)
+#endif
+
+/**
+ * @brief Trace FIFO Queue peek next exit
+ * @param fifo FIFO object
+ * @param ret Return value
+ * @param data data pointer
+ */
+#ifndef sys_port_trace_k_fifo_peek_next_exit
+#define sys_port_trace_k_fifo_peek_next_exit(fifo, data, ret)
 #endif
 
 /** @} */ /* end of subsys_tracing_apis_fifo */

--- a/include/zephyr/tracing/tracking.h
+++ b/include/zephyr/tracing/tracking.h
@@ -90,6 +90,7 @@ extern struct k_event *_track_list_k_event;
 	sys_track_k_timer_init(timer)
 #define sys_port_track_k_queue_peek_tail(queue, ret)
 #define sys_port_track_k_queue_peek_head(queue, ret)
+#define sys_port_track_k_queue_peek_next(queue, data, ret)
 #define sys_port_track_k_queue_cancel_wait(queue)
 #define sys_port_track_k_queue_init(queue) \
 	sys_track_k_queue_init(queue)
@@ -150,6 +151,7 @@ void sys_track_socket_init(int sock, int family, int type, int proto);
 #define sys_port_track_k_timer_init(timer)
 #define sys_port_track_k_queue_peek_tail(queue, ret)
 #define sys_port_track_k_queue_peek_head(queue, ret)
+#define sys_port_track_k_queue_peek_next(queue, data, ret)
 #define sys_port_track_k_queue_cancel_wait(queue)
 #define sys_port_track_k_queue_init(queue)
 #define sys_port_track_k_pipe_init(pipe, buffer, buffer_size)

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -416,6 +416,31 @@ void *z_impl_k_queue_peek_tail(struct k_queue *queue)
 	return ret;
 }
 
+void *z_impl_k_queue_peek_next(struct k_queue *queue, void *data)
+{
+	k_spinlock_key_t key = k_spin_lock(&queue->lock);
+	void *ret = NULL;
+	sys_sfnode_t *cur = NULL;
+
+	if (data == NULL) {
+		goto out;
+	}
+
+	SYS_SFLIST_FOR_EACH_NODE(&queue->data_q, cur) {
+		ret = z_queue_node_peek(cur, false);
+		if (ret == data) {
+			break;
+		}
+	}
+
+	ret = z_queue_node_peek(sys_sflist_peek_next(cur), false);
+
+out:
+	k_spin_unlock(&queue->lock, key);
+
+	return ret;
+}
+
 #ifdef CONFIG_USERSPACE
 static inline void *z_vrfy_k_queue_get(struct k_queue *queue,
 				       k_timeout_t timeout)
@@ -445,6 +470,12 @@ static inline void *z_vrfy_k_queue_peek_tail(struct k_queue *queue)
 	return z_impl_k_queue_peek_tail(queue);
 }
 #include <zephyr/syscalls/k_queue_peek_tail_mrsh.c>
+
+static inline void *z_vrfy_k_queue_peek_next(struct k_queue *queue, void *data)
+{
+	return z_impl_k_queue_peek_next(queue, data);
+}
+#include <zephyr/syscalls/k_queue_peek_next_mrsh.c>
 
 #endif /* CONFIG_USERSPACE */
 

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -438,6 +438,8 @@ void *z_impl_k_queue_peek_next(struct k_queue *queue, void *data)
 out:
 	k_spin_unlock(&queue->lock, key);
 
+	SYS_PORT_TRACING_OBJ_FUNC(k_queue, peek_next, queue, data, ret);
+
 	return ret;
 }
 
@@ -473,6 +475,7 @@ static inline void *z_vrfy_k_queue_peek_tail(struct k_queue *queue)
 
 static inline void *z_vrfy_k_queue_peek_next(struct k_queue *queue, void *data)
 {
+	K_OOPS(K_SYSCALL_OBJ(queue, K_OBJ_QUEUE));
 	return z_impl_k_queue_peek_next(queue, data);
 }
 #include <zephyr/syscalls/k_queue_peek_next_mrsh.c>

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -454,6 +454,8 @@ void *z_impl_k_queue_peek_next(struct k_queue *queue, void *data)
 out:
 	k_spin_unlock(&queue->lock, key);
 
+	SYS_PORT_TRACING_OBJ_FUNC(k_queue, peek_next, queue, data, ret);
+
 	return ret;
 }
 
@@ -489,6 +491,7 @@ static inline void *z_vrfy_k_queue_peek_tail(struct k_queue *queue)
 
 static inline void *z_vrfy_k_queue_peek_next(struct k_queue *queue, void *data)
 {
+	K_OOPS(K_SYSCALL_OBJ(queue, K_OBJ_QUEUE));
 	return z_impl_k_queue_peek_next(queue, data);
 }
 #include <zephyr/syscalls/k_queue_peek_next_mrsh.c>

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -434,6 +434,29 @@ void *z_impl_k_queue_peek_tail(struct k_queue *queue)
 	return ret;
 }
 
+void *z_impl_k_queue_peek_next(struct k_queue *queue, void *data)
+{
+	k_spinlock_key_t key = k_spin_lock(&queue->lock);
+	void *ret = NULL;
+	sys_sfnode_t *cur = NULL;
+
+	if (data == NULL) {
+		goto out;
+	}
+
+	SYS_SFLIST_FOR_EACH_NODE(&queue->data_q, cur) {
+		if (z_queue_node_peek(cur, false) == data) {
+			ret = z_queue_node_peek(sys_sflist_peek_next_no_check(cur), false);
+			break;
+		}
+	}
+
+out:
+	k_spin_unlock(&queue->lock, key);
+
+	return ret;
+}
+
 #ifdef CONFIG_USERSPACE
 static inline void *z_vrfy_k_queue_get(struct k_queue *queue,
 				       k_timeout_t timeout)
@@ -463,6 +486,12 @@ static inline void *z_vrfy_k_queue_peek_tail(struct k_queue *queue)
 	return z_impl_k_queue_peek_tail(queue);
 }
 #include <zephyr/syscalls/k_queue_peek_tail_mrsh.c>
+
+static inline void *z_vrfy_k_queue_peek_next(struct k_queue *queue, void *data)
+{
+	return z_impl_k_queue_peek_next(queue, data);
+}
+#include <zephyr/syscalls/k_queue_peek_next_mrsh.c>
 
 #endif /* CONFIG_USERSPACE */
 

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -379,6 +379,9 @@ void sys_trace_thread_info(struct k_thread *thread);
 #define sys_port_trace_k_queue_peek_tail(queue, ret)                                               \
 	SEGGER_SYSVIEW_RecordU32x2(TID_QUEUE_PEAK_TAIL, (uint32_t)(uintptr_t)queue, (int32_t)ret)
 
+#define sys_port_trace_k_queue_peek_next(queue, data, ret)                                         \
+	SEGGER_SYSVIEW_RecordU32x2(TID_QUEUE_PEAK_NEXT, (uint32_t)(uintptr_t)queue, (int32_t)ret)
+
 #define sys_port_trace_k_fifo_init_enter(fifo)                                                     \
 	SEGGER_SYSVIEW_RecordU32(TID_FIFO_INIT, (uint32_t)(uintptr_t)fifo)
 #define sys_port_trace_k_fifo_init_exit(fifo) SEGGER_SYSVIEW_RecordEndCall(TID_FIFO_INIT)
@@ -429,6 +432,11 @@ void sys_trace_thread_info(struct k_thread *thread);
 	SEGGER_SYSVIEW_RecordU32(TID_FIFO_PEAK_TAIL, (uint32_t)(uintptr_t)fifo)
 #define sys_port_trace_k_fifo_peek_tail_exit(fifo, ret)                                            \
 	SEGGER_SYSVIEW_RecordEndCall(TID_FIFO_PEAK_TAIL)
+
+#define sys_port_trace_k_fifo_peek_next_enter(fifo, data)                                          \
+	SEGGER_SYSVIEW_RecordU32(TID_FIFO_PEAK_NEXT, (uint32_t)(uintptr_t)fifo)
+#define sys_port_trace_k_fifo_peek_next_exit(fifo, data, ret)                                      \
+	SEGGER_SYSVIEW_RecordEndCall(TID_FIFO_PEAK_NEXT)
 
 #define sys_port_trace_k_lifo_init_enter(lifo)                                                     \
 	SEGGER_SYSVIEW_RecordU32(TID_LIFO_INIT, (uint32_t)(uintptr_t)lifo)

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -368,6 +368,9 @@ void sys_trace_thread_info(struct k_thread *thread);
 #define sys_port_trace_k_queue_peek_tail(queue, ret)                                               \
 	SEGGER_SYSVIEW_RecordU32x2(TID_QUEUE_PEAK_TAIL, (uint32_t)(uintptr_t)queue, (int32_t)ret)
 
+#define sys_port_trace_k_queue_peek_next(queue, data, ret)                                         \
+	SEGGER_SYSVIEW_RecordU32x2(TID_QUEUE_PEAK_NEXT, (uint32_t)(uintptr_t)queue, (int32_t)ret)
+
 #define sys_port_trace_k_fifo_init_enter(fifo)                                                     \
 	SEGGER_SYSVIEW_RecordU32(TID_FIFO_INIT, (uint32_t)(uintptr_t)fifo)
 #define sys_port_trace_k_fifo_init_exit(fifo) SEGGER_SYSVIEW_RecordEndCall(TID_FIFO_INIT)
@@ -418,6 +421,11 @@ void sys_trace_thread_info(struct k_thread *thread);
 	SEGGER_SYSVIEW_RecordU32(TID_FIFO_PEAK_TAIL, (uint32_t)(uintptr_t)fifo)
 #define sys_port_trace_k_fifo_peek_tail_exit(fifo, ret)                                            \
 	SEGGER_SYSVIEW_RecordEndCall(TID_FIFO_PEAK_TAIL)
+
+#define sys_port_trace_k_fifo_peek_next_enter(fifo, data)                                          \
+	SEGGER_SYSVIEW_RecordU32(TID_FIFO_PEAK_NEXT, (uint32_t)(uintptr_t)fifo)
+#define sys_port_trace_k_fifo_peek_next_exit(fifo, data, ret)                                      \
+	SEGGER_SYSVIEW_RecordEndCall(TID_FIFO_PEAK_NEXT)
 
 #define sys_port_trace_k_lifo_init_enter(lifo)                                                     \
 	SEGGER_SYSVIEW_RecordU32(TID_LIFO_INIT, (uint32_t)(uintptr_t)lifo)

--- a/subsys/tracing/sysview/tracing_sysview_ids.h
+++ b/subsys/tracing/sysview/tracing_sysview_ids.h
@@ -41,6 +41,7 @@ extern "C" {
 #define TID_QUEUE_CANCEL_WAIT   (20u + TID_OFFSET)
 #define TID_QUEUE_PEAK_HEAD     (21u + TID_OFFSET)
 #define TID_QUEUE_PEAK_TAIL     (22u + TID_OFFSET)
+#define TID_QUEUE_PEAK_NEXT     (51u + TID_OFFSET)
 
 #define TID_STACK_INIT          (23u + TID_OFFSET)
 #define TID_STACK_PUSH          (24u + TID_OFFSET)
@@ -140,6 +141,7 @@ extern "C" {
 #define TID_FIFO_PUT_SLIST   (114u + TID_OFFSET)
 #define TID_FIFO_PEAK_HEAD   (115u + TID_OFFSET)
 #define TID_FIFO_PEAK_TAIL   (116u + TID_OFFSET)
+#define TID_FIFO_PEAK_NEXT   (137u + TID_OFFSET)
 #define TID_FIFO_PUT         (117u + TID_OFFSET)
 #define TID_FIFO_GET         (118u + TID_OFFSET)
 
@@ -166,7 +168,7 @@ extern "C" {
 #define TID_TIMER_EXPIRY (135u + TID_OFFSET)
 #define TID_TIMER_STOP_EXPIRY (136u + TID_OFFSET)
 
-/* latest ID is 136 */
+/* latest ID is 137 */
 
 #ifdef __cplusplus
 }

--- a/subsys/tracing/sysview/tracing_sysview_ids.h
+++ b/subsys/tracing/sysview/tracing_sysview_ids.h
@@ -41,6 +41,7 @@ extern "C" {
 #define TID_QUEUE_CANCEL_WAIT   (20u + TID_OFFSET)
 #define TID_QUEUE_PEAK_HEAD     (21u + TID_OFFSET)
 #define TID_QUEUE_PEAK_TAIL     (22u + TID_OFFSET)
+#define TID_QUEUE_PEAK_NEXT     (51u + TID_OFFSET)
 
 #define TID_STACK_INIT          (23u + TID_OFFSET)
 #define TID_STACK_PUSH          (24u + TID_OFFSET)
@@ -141,6 +142,7 @@ extern "C" {
 #define TID_FIFO_PUT_SLIST   (114u + TID_OFFSET)
 #define TID_FIFO_PEAK_HEAD   (115u + TID_OFFSET)
 #define TID_FIFO_PEAK_TAIL   (116u + TID_OFFSET)
+#define TID_FIFO_PEAK_NEXT   (138u + TID_OFFSET)
 #define TID_FIFO_PUT         (117u + TID_OFFSET)
 #define TID_FIFO_GET         (118u + TID_OFFSET)
 
@@ -169,7 +171,7 @@ extern "C" {
 
 #define TID_SLEEP_TICKS (137u + TID_OFFSET)
 
-/* latest ID is 136 */
+/* latest ID is 138 */
 
 #ifdef __cplusplus
 }

--- a/subsys/tracing/test/tracing_string_format_test.c
+++ b/subsys/tracing/test/tracing_string_format_test.c
@@ -485,6 +485,11 @@ void sys_trace_k_queue_peek_tail(struct k_queue *queue, void *ret)
 	TRACING_STRING("%s: %p\n", __func__, queue);
 }
 
+void sys_trace_k_queue_peek_next(struct k_queue *queue, void *data, void *ret)
+{
+	TRACING_STRING("%s: %p\n", __func__, queue);
+}
+
 void sys_trace_k_queue_alloc_append_enter(struct k_queue *queue, void *data)
 {
 	TRACING_STRING("%s: %p\n", __func__, queue);
@@ -548,6 +553,16 @@ void sys_trace_k_fifo_get_enter(struct k_fifo *fifo, k_timeout_t timeout)
 }
 
 void sys_trace_k_fifo_get_exit(struct k_fifo *fifo, k_timeout_t timeout, void *ret)
+{
+	TRACING_STRING("%s: %p\n", __func__, fifo);
+}
+
+void sys_trace_k_fifo_peek_next_enter(struct k_fifo *fifo, void *data)
+{
+	TRACING_STRING("%s: %p\n", __func__, fifo);
+}
+
+void sys_trace_k_fifo_peek_next_exit(struct k_fifo *fifo, void *data, void *ret)
 {
 	TRACING_STRING("%s: %p\n", __func__, fifo);
 }

--- a/subsys/tracing/test/tracing_string_format_test.c
+++ b/subsys/tracing/test/tracing_string_format_test.c
@@ -475,6 +475,11 @@ void sys_trace_k_queue_peek_tail(struct k_queue *queue, void *ret)
 	TRACING_STRING("%s: %p\n", __func__, queue);
 }
 
+void sys_trace_k_queue_peek_next(struct k_queue *queue, void *data, void *ret)
+{
+	TRACING_STRING("%s: %p\n", __func__, queue);
+}
+
 void sys_trace_k_queue_alloc_append_enter(struct k_queue *queue, void *data)
 {
 	TRACING_STRING("%s: %p\n", __func__, queue);
@@ -538,6 +543,16 @@ void sys_trace_k_fifo_get_enter(struct k_fifo *fifo, k_timeout_t timeout)
 }
 
 void sys_trace_k_fifo_get_exit(struct k_fifo *fifo, k_timeout_t timeout, void *ret)
+{
+	TRACING_STRING("%s: %p\n", __func__, fifo);
+}
+
+void sys_trace_k_fifo_peek_next_enter(struct k_fifo *fifo, void *data)
+{
+	TRACING_STRING("%s: %p\n", __func__, fifo);
+}
+
+void sys_trace_k_fifo_peek_next_exit(struct k_fifo *fifo, void *data, void *ret)
 {
 	TRACING_STRING("%s: %p\n", __func__, fifo);
 }

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -137,6 +137,8 @@
 	sys_trace_k_queue_unique_append_exit(queue, data, ret)
 #define sys_port_trace_k_queue_peek_head(queue, ret) sys_trace_k_queue_peek_head(queue, ret)
 #define sys_port_trace_k_queue_peek_tail(queue, ret) sys_trace_k_queue_peek_tail(queue, ret)
+#define sys_port_trace_k_queue_peek_next(queue, data, ret)                                         \
+	sys_trace_k_queue_peek_next(queue, data, ret)
 
 /* FIFO */
 
@@ -484,6 +486,7 @@ void sys_trace_k_queue_unique_append_enter(struct k_queue *queue, void *data);
 void sys_trace_k_queue_unique_append_exit(struct k_queue *queue, void *data, bool ret);
 void sys_trace_k_queue_peek_head(struct k_queue *queue, void *ret);
 void sys_trace_k_queue_peek_tail(struct k_queue *queue, void *ret);
+void sys_trace_k_queue_peek_next(struct k_queue *queue, void *data, void *ret);
 
 void sys_trace_k_fifo_init_enter(struct k_fifo *fifo);
 void sys_trace_k_fifo_init_exit(struct k_fifo *fifo);
@@ -503,6 +506,8 @@ void sys_trace_k_fifo_peek_head_enter(struct k_fifo *fifo);
 void sys_trace_k_fifo_peek_head_exit(struct k_fifo *fifo, void *ret);
 void sys_trace_k_fifo_peek_tail_enter(struct k_fifo *fifo);
 void sys_trace_k_fifo_peek_tail_exit(struct k_fifo *fifo, void *ret);
+void sys_trace_k_fifo_peek_next_enter(struct k_fifo *fifo, void *data);
+void sys_trace_k_fifo_peek_next_exit(struct k_fifo *fifo, void *data, void *ret);
 
 void sys_trace_k_lifo_init_enter(struct k_lifo *lifo);
 void sys_trace_k_lifo_init_exit(struct k_lifo *lifo);

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -135,6 +135,8 @@
 	sys_trace_k_queue_unique_append_exit(queue, data, ret)
 #define sys_port_trace_k_queue_peek_head(queue, ret) sys_trace_k_queue_peek_head(queue, ret)
 #define sys_port_trace_k_queue_peek_tail(queue, ret) sys_trace_k_queue_peek_tail(queue, ret)
+#define sys_port_trace_k_queue_peek_next(queue, data, ret)                                         \
+	sys_trace_k_queue_peek_next(queue, data, ret)
 
 /* FIFO */
 
@@ -179,6 +181,10 @@
 #define sys_port_trace_k_fifo_peek_tail_enter(fifo) sys_trace_k_fifo_peek_tail_enter(fifo)
 
 #define sys_port_trace_k_fifo_peek_tail_exit(fifo, ret) sys_trace_k_fifo_peek_tail_exit(fifo, ret)
+
+#define sys_port_trace_k_fifo_peek_next_enter(fifo, data) sys_trace_k_fifo_peek_next_enter(fifo, data)
+
+#define sys_port_trace_k_fifo_peek_next_exit(fifo, data, ret) sys_trace_k_fifo_peek_next_exit(fifo, data, ret)
 
 /* LIFO */
 #define sys_port_trace_k_lifo_init_enter(lifo) sys_trace_k_lifo_init_enter(lifo)
@@ -478,6 +484,7 @@ void sys_trace_k_queue_unique_append_enter(struct k_queue *queue, void *data);
 void sys_trace_k_queue_unique_append_exit(struct k_queue *queue, void *data, bool ret);
 void sys_trace_k_queue_peek_head(struct k_queue *queue, void *ret);
 void sys_trace_k_queue_peek_tail(struct k_queue *queue, void *ret);
+void sys_trace_k_queue_peek_next(struct k_queue *queue, void *data, void *ret);
 
 void sys_trace_k_fifo_init_enter(struct k_fifo *fifo);
 void sys_trace_k_fifo_init_exit(struct k_fifo *fifo);
@@ -497,6 +504,8 @@ void sys_trace_k_fifo_peek_head_enter(struct k_fifo *fifo);
 void sys_trace_k_fifo_peek_head_exit(struct k_fifo *fifo, void *ret);
 void sys_trace_k_fifo_peek_tail_enter(struct k_fifo *fifo);
 void sys_trace_k_fifo_peek_tail_exit(struct k_fifo *fifo, void *ret);
+void sys_trace_k_fifo_peek_next_enter(struct k_fifo *fifo, void *data);
+void sys_trace_k_fifo_peek_next_exit(struct k_fifo *fifo, void *data, void *ret);
 
 void sys_trace_k_lifo_init_enter(struct k_lifo *lifo);
 void sys_trace_k_lifo_init_exit(struct k_lifo *lifo);

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
@@ -276,15 +276,14 @@ ZTEST(fifo_api, test_fifo_is_empty_isr)
 }
 
 /**
- * @brief Test peeking at the front and back items of a FIFO
+ * @brief Test peeking at the front, back and next items of a FIFO
  *
- * @details Enqueue two data items, then use k_fifo_peek_head() and
- * k_fifo_peek_tail() to inspect the items at the front and back of the FIFO and
- * verify the returned pointers match the first and last enqueued items without
- * removing them (a subsequent get still returns both items in order). Peeking an
- * empty FIFO returns NULL.
+ * @details Enqueue two data items, then use k_fifo_peek_head(), k_fifo_peek_tail() and
+ * k_fifo_peek_next() to inspect the items inside of the FIFO and verify the returned
+ * pointers match he expected items without removing them (a subsequent get still
+ * returns both items in order). Peeking an empty FIFO returns NULL.
  *
- * @see k_fifo_peek_head(), k_fifo_peek_tail()
+ * @see k_fifo_peek_head(), k_fifo_peek_tail(), k_fifo_peek_next()
  */
 ZTEST(fifo_api, test_fifo_peek)
 {
@@ -297,6 +296,15 @@ ZTEST(fifo_api, test_fifo_peek)
 	zassert_equal(k_fifo_peek_head(&fifo), (void *)&data[0]);
 	zassert_equal(k_fifo_peek_tail(&fifo), (void *)&data[1]);
 
+	/**TESTPOINT: peek next of the first element is the second*/
+	zassert_equal(k_fifo_peek_next(&fifo, (void *)&data[0]), (void *)&data[1]);
+
+	/**TESTPOINT: peek next of the last element is NULL*/
+	zassert_is_null(k_fifo_peek_next(&fifo, (void *)&data[1]));
+
+	/**TESTPOINT: peek next of a NULL element is NULL*/
+	zassert_is_null(k_fifo_peek_next(&fifo, NULL));
+
 	/* Peeking does not dequeue: both items are still retrievable in order. */
 	zassert_equal(k_fifo_get(&fifo, K_NO_WAIT), (void *)&data[0]);
 	zassert_equal(k_fifo_get(&fifo, K_NO_WAIT), (void *)&data[1]);
@@ -304,6 +312,9 @@ ZTEST(fifo_api, test_fifo_peek)
 	/**TESTPOINT: peek of an empty fifo returns NULL*/
 	zassert_is_null(k_fifo_peek_head(&fifo));
 	zassert_is_null(k_fifo_peek_tail(&fifo));
+
+	/**TESTPOINT: peek next of an empty fifo returns NULL*/
+	zassert_is_null(k_fifo_peek_next(&fifo, (void *)&data[0]));
 }
 
 K_HEAP_DEFINE(fifo_alloc_pool, 256);

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
@@ -390,15 +390,14 @@ ZTEST(fifo_api, test_fifo_is_empty_isr)
 }
 
 /**
- * @brief Test peeking at the front and back items of a FIFO
+ * @brief Test peeking at the front, back and next items of a FIFO
  *
- * @details Enqueue two data items, then use k_fifo_peek_head() and
- * k_fifo_peek_tail() to inspect the items at the front and back of the FIFO and
- * verify the returned pointers match the first and last enqueued items without
- * removing them (a subsequent get still returns both items in order). Peeking an
- * empty FIFO returns NULL.
+ * @details Enqueue two data items, then use k_fifo_peek_head(), k_fifo_peek_tail() and
+ * k_fifo_peek_next() to inspect the items inside of the FIFO and verify the returned
+ * pointers match he expected items without removing them (a subsequent get still
+ * returns both items in order). Peeking an empty FIFO returns NULL.
  *
- * @see k_fifo_peek_head(), k_fifo_peek_tail()
+ * @see k_fifo_peek_head(), k_fifo_peek_tail(), k_fifo_peek_next()
  */
 ZTEST(fifo_api, test_fifo_peek)
 {
@@ -411,6 +410,15 @@ ZTEST(fifo_api, test_fifo_peek)
 	zassert_equal(k_fifo_peek_head(&fifo), (void *)&data[0]);
 	zassert_equal(k_fifo_peek_tail(&fifo), (void *)&data[1]);
 
+	/**TESTPOINT: peek next of the first element is the second*/
+	zassert_equal(k_fifo_peek_next(&fifo, (void *)&data[0]), (void *)&data[1]);
+
+	/**TESTPOINT: peek next of the last element is NULL*/
+	zassert_is_null(k_fifo_peek_next(&fifo, (void *)&data[1]));
+
+	/**TESTPOINT: peek next of a NULL element is NULL*/
+	zassert_is_null(k_fifo_peek_next(&fifo, NULL));
+
 	/* Peeking does not dequeue: both items are still retrievable in order. */
 	zassert_equal(k_fifo_get(&fifo, K_NO_WAIT), (void *)&data[0]);
 	zassert_equal(k_fifo_get(&fifo, K_NO_WAIT), (void *)&data[1]);
@@ -418,6 +426,9 @@ ZTEST(fifo_api, test_fifo_peek)
 	/**TESTPOINT: peek of an empty fifo returns NULL*/
 	zassert_is_null(k_fifo_peek_head(&fifo));
 	zassert_is_null(k_fifo_peek_tail(&fifo));
+
+	/**TESTPOINT: peek next of an empty fifo returns NULL*/
+	zassert_is_null(k_fifo_peek_next(&fifo, (void *)&data[0]));
 }
 
 K_HEAP_DEFINE(fifo_alloc_pool, 256);

--- a/tests/kernel/queue/src/test_queue_contexts.c
+++ b/tests/kernel/queue/src/test_queue_contexts.c
@@ -657,3 +657,45 @@ ZTEST(queue_api, test_queue_unique_append)
 	ret = k_queue_unique_append(&queue, (void *)&data[1]);
 	zassert_true(ret, "queue unique append failed");
 }
+
+/**
+ * @brief Test peeking at the front, back and next items of a queue
+ *
+ * @details Enqueue two data items, then use k_queue_peek_head(), k_queue_peek_tail() and
+ * k_queue_peek_next() to inspect the items inside of the queue and verify the returned
+ * pointers match he expected items without removing them (a subsequent get still
+ * returns both items in order). Peeking an empty queue returns NULL.
+ *
+ * @see k_queue_peek_head(), k_queue_peek_tail(), k_queue_peek_next()
+ */
+ZTEST(queue_api, test_queue_peek)
+{
+	k_queue_init(&queue);
+
+	k_queue_append(&queue, (void *)&data[0]);
+	k_queue_append(&queue, (void *)&data[1]);
+
+	/**TESTPOINT: peek front and back without removing*/
+	zassert_equal(k_queue_peek_head(&queue), (void *)&data[0]);
+	zassert_equal(k_queue_peek_tail(&queue), (void *)&data[1]);
+
+	/**TESTPOINT: peek next of the first element is the second*/
+	zassert_equal(k_queue_peek_next(&queue, (void *)&data[0]), (void *)&data[1]);
+
+	/**TESTPOINT: peek next of the last element is NULL*/
+	zassert_is_null(k_queue_peek_next(&queue, (void *)&data[1]));
+
+	/**TESTPOINT: peek next of a NULL element is NULL*/
+	zassert_is_null(k_queue_peek_next(&queue, NULL));
+
+	/* Peeking does not dequeue: both items are still retrievable in order. */
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data[0]);
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data[1]);
+
+	/**TESTPOINT: peek of an empty queue returns NULL*/
+	zassert_is_null(k_queue_peek_head(&queue));
+	zassert_is_null(k_queue_peek_tail(&queue));
+
+	/**TESTPOINT: peek next of an empty queue returns NULL*/
+	zassert_is_null(k_queue_peek_next(&queue, (void *)&data[0]));
+}

--- a/tests/kernel/queue/src/test_queue_contexts.c
+++ b/tests/kernel/queue/src/test_queue_contexts.c
@@ -984,3 +984,45 @@ ZTEST(queue_api, test_queue_unique_append)
 	ret = k_queue_unique_append(&queue, (void *)&data[1]);
 	zassert_true(ret, "queue unique append failed");
 }
+
+/**
+ * @brief Test peeking at the front, back and next items of a queue
+ *
+ * @details Enqueue two data items, then use k_queue_peek_head(), k_queue_peek_tail() and
+ * k_queue_peek_next() to inspect the items inside of the queue and verify the returned
+ * pointers match he expected items without removing them (a subsequent get still
+ * returns both items in order). Peeking an empty queue returns NULL.
+ *
+ * @see k_queue_peek_head(), k_queue_peek_tail(), k_queue_peek_next()
+ */
+ZTEST(queue_api, test_queue_peek)
+{
+	k_queue_init(&queue);
+
+	k_queue_append(&queue, (void *)&data[0]);
+	k_queue_append(&queue, (void *)&data[1]);
+
+	/**TESTPOINT: peek front and back without removing*/
+	zassert_equal(k_queue_peek_head(&queue), (void *)&data[0]);
+	zassert_equal(k_queue_peek_tail(&queue), (void *)&data[1]);
+
+	/**TESTPOINT: peek next of the first element is the second*/
+	zassert_equal(k_queue_peek_next(&queue, (void *)&data[0]), (void *)&data[1]);
+
+	/**TESTPOINT: peek next of the last element is NULL*/
+	zassert_is_null(k_queue_peek_next(&queue, (void *)&data[1]));
+
+	/**TESTPOINT: peek next of a NULL element is NULL*/
+	zassert_is_null(k_queue_peek_next(&queue, NULL));
+
+	/* Peeking does not dequeue: both items are still retrievable in order. */
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data[0]);
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data[1]);
+
+	/**TESTPOINT: peek of an empty queue returns NULL*/
+	zassert_is_null(k_queue_peek_head(&queue));
+	zassert_is_null(k_queue_peek_tail(&queue));
+
+	/**TESTPOINT: peek next of an empty queue returns NULL*/
+	zassert_is_null(k_queue_peek_next(&queue, (void *)&data[0]));
+}

--- a/tests/kernel/queue/src/test_queue_fail.c
+++ b/tests/kernel/queue/src/test_queue_fail.c
@@ -258,6 +258,22 @@ ZTEST_USER(queue_api, test_queue_peek_tail_null)
 }
 
 /**
+ * @brief Test k_queue_peek_next() failure scenario
+ *
+ * @details Verify that the parameter of the API is
+ * NULL, what will happen.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_peek_next()
+ */
+ZTEST_USER(queue_api, test_queue_peek_next_null)
+{
+	ztest_set_fault_valid(true);
+	k_queue_peek_next(NULL, NULL);
+}
+
+/**
  * @brief Test k_queue_merge_slist() failure scenario
  *
  * @details Verify that the parameter of the API is


### PR DESCRIPTION
Add the possibility of peeking the next element in the queue to the one provided as parameter without removing it. The aim for this PR is to add the possibility of observing a queue without modifying the internal structure of the queue itself. 

@nashif @Mattemagikern 