### PR TITLE
Bluetooth: Host: shell: handle invalid args in adv cmds

### DIFF
--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -2632,14 +2632,14 @@ static int cmd_adv_start(const struct shell *sh, size_t argc, char *argv[])
 			}
 
 			timeout = strtoul(argv[argn], NULL, 16);
-		}
-
-		if (!strcmp(arg, "num-events")) {
+		} else if (!strcmp(arg, "num-events")) {
 			if (++argn == argc) {
 				goto fail_show_help;
 			}
 
 			num_events = strtoul(argv[argn], NULL, 16);
+		} else {
+			goto fail_show_help;
 		}
 	}
 
@@ -2657,7 +2657,7 @@ static int cmd_adv_start(const struct shell *sh, size_t argc, char *argv[])
 
 fail_show_help:
 	shell_help(sh);
-	return -ENOEXEC;
+	return SHELL_CMD_HELP_PRINTED;
 }
 
 static int cmd_adv_stop(const struct shell *sh, size_t argc, char *argv[])
@@ -2849,8 +2849,13 @@ static int cmd_per_adv_param(const struct shell *sh, size_t argc,
 		return -EINVAL;
 	}
 
-	if (argc > 3 && !strcmp(argv[3], "tx-power")) {
-		param.options = BT_LE_ADV_OPT_USE_TX_POWER;
+	if (argc > 3) {
+		if (!strcmp(argv[3], "tx-power")) {
+			param.options = BT_LE_ADV_OPT_USE_TX_POWER;
+		} else {
+			shell_help(sh);
+			return SHELL_CMD_HELP_PRINTED;
+		}
 	} else {
 		param.options = 0;
 	}
@@ -4872,6 +4877,9 @@ static int cmd_fal_connect(const struct shell *sh, size_t argc, char *argv[])
 			shell_error(sh, "Auto connect stop failed (err %d)", err);
 		}
 		return err;
+	} else {
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
 	}
 
 	return 0;
@@ -5432,7 +5440,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 #if defined(CONFIG_BT_PER_ADV)
 	SHELL_CMD_ARG(per-adv, NULL, HELP_ONOFF, cmd_per_adv, 2, 0),
 	SHELL_CMD_ARG(per-adv-param, NULL,
-		      "[<interval-min> [<interval-max> [tx_power]]]",
+		      "[<interval-min> [<interval-max> [tx-power]]]",
 		      cmd_per_adv_param, 1, 3),
 	SHELL_CMD_ARG(per-adv-data, NULL, "[data]", cmd_per_adv_data, 1, 1),
 	SHELL_CMD_ARG(per-adv-update-did, NULL, "Update periodic advertising DID",


### PR DESCRIPTION
Three argument parsers in bt.c silently ignored invalid or unknown arguments, allowing the underlying operation to proceed as if no bad input was given.

cmd_adv_start: the two keyword checks ("timeout", "num-events") were written as independent if-blocks. An unknown argument (including "--help") falls through both checks without error and advertising starts. Convert to if/else-if/else and change fail_show_help to return SHELL_CMD_HELP_PRINTED, consistent with the rest of the file.

cmd_per_adv_param: the expression (argc > 3 && !strcmp(argv[3], "tx-power")) silently discards any other value for the fourth argument. Split the condition so that a non-empty argv[3] that is not "tx-power" is rejected with help.

cmd_fal_connect: the if/else-if chain for "on"/"off" had no else branch; an unrecognised action fell through and returned 0 as if it succeeded. Add an else branch that shows help and returns SHELL_CMD_HELP_PRINTED.

Assisted-by: Claude:claude-sonnet-4.6