### PR TITLE
sockets: tcp: recv: Tcp fifo improved

### DIFF
--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1375,26 +1375,15 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 	size_t len;
 	size_t pkt_len;
 	size_t recv_len = 0;
-	struct net_pkt *pkt;
+	struct net_pkt *pkt, *next = NULL;
 	struct net_pkt_cursor backup;
-	struct net_pkt *origin = NULL;
 	const bool do_recv = !(buf == NULL || max_len == NULL);
 	size_t _max_len = (max_len == NULL) ? SIZE_MAX : *max_len;
 	const bool peek = (flags & ZSOCK_MSG_PEEK) == ZSOCK_MSG_PEEK;
-	const struct net_pkt *head = k_fifo_peek_head(&ctx->recv_q);
 
-	while (_max_len > 0) {
-		/* only peek until we know we can dequeue and / or requeue buffer */
-		pkt = k_fifo_peek_head(&ctx->recv_q);
-		if (pkt == NULL || pkt == origin) {
-			break;
-		}
+	pkt = k_fifo_peek_head(&ctx->recv_q);
 
-		if (origin == NULL) {
-			/* mark first pkt to avoid cycles when observing */
-			origin = pkt;
-		}
-
+	while (_max_len > 0 && pkt != NULL) {
 		pkt_len = net_pkt_remaining_data(pkt);
 		len = MIN(_max_len, pkt_len);
 		recv_len += len;
@@ -1414,6 +1403,8 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 			}
 		}
 
+		next = k_fifo_peek_next(&ctx->recv_q, pkt);
+
 		if (do_recv && !peek) {
 			if (len == pkt_len) {
 				/* dequeue empty packets when not observing */
@@ -1429,23 +1420,14 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 
 				net_pkt_unref(pkt);
 			}
-		} else if ((!do_recv || peek) && _max_len > 0) {
-			/* requeue packets when observing, do not requeue if it is the last packet
-			 * as it will be requeued below. This allows to skip requeuing when
-			 * observing only the first packet
-			 */
-			k_fifo_put(&ctx->recv_q, k_fifo_get(&ctx->recv_q, K_NO_WAIT));
 		}
+
+		pkt = next;
 	}
 
 	if (do_recv) {
 		/* convey remaining buffer size back to caller */
 		*max_len = _max_len;
-	}
-
-	/* when observing, the queue should return to the initial state */
-	while ((!do_recv || peek) && k_fifo_peek_head(&ctx->recv_q) != head) {
-		k_fifo_put(&ctx->recv_q, k_fifo_get(&ctx->recv_q, K_NO_WAIT));
 	}
 
 	return recv_len;

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1381,6 +1381,7 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 	const bool do_recv = !(buf == NULL || max_len == NULL);
 	size_t _max_len = (max_len == NULL) ? SIZE_MAX : *max_len;
 	const bool peek = (flags & ZSOCK_MSG_PEEK) == ZSOCK_MSG_PEEK;
+	const struct net_pkt *head = k_fifo_peek_head(&ctx->recv_q);
 
 	while (_max_len > 0) {
 		/* only peek until we know we can dequeue and / or requeue buffer */
@@ -1428,8 +1429,11 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 
 				net_pkt_unref(pkt);
 			}
-		} else if (!do_recv || peek) {
-			/* requeue packets when observing */
+		} else if ((!do_recv || peek) && _max_len > 0) {
+			/* requeue packets when observing, do not requeue if it is the last packet
+			 * as it will be requeued below. This allows to skip requeuing when
+			 * observing only the first packet
+			 */
 			k_fifo_put(&ctx->recv_q, k_fifo_get(&ctx->recv_q, K_NO_WAIT));
 		}
 	}
@@ -1437,6 +1441,11 @@ static size_t zsock_recv_stream_immediate(struct net_context *ctx, uint8_t **buf
 	if (do_recv) {
 		/* convey remaining buffer size back to caller */
 		*max_len = _max_len;
+	}
+
+	/* when observing, the queue should return to the initial state */
+	while ((!do_recv || peek) && k_fifo_peek_head(&ctx->recv_q) != head) {
+		k_fifo_put(&ctx->recv_q, k_fifo_get(&ctx->recv_q, K_NO_WAIT));
 	}
 
 	return recv_len;

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -716,6 +716,9 @@ void tcp_server_block_thread(void *vps_sock, void *unused2, void *unused3)
 			chunk_size = remain;
 		}
 
+		/* Validate that peeking doesn't affect the next recv */
+		recved = zsock_recv(new_sock, buffer, 1, ZSOCK_MSG_PEEK);
+
 		recved = zsock_recv(new_sock, buffer, chunk_size, 0);
 
 		zassert(recved > 0, "received bigger then 0",


### PR DESCRIPTION
Instead of requeuing packets when peeking, get the next element in the queue.

This PR requires https://github.com/zephyrproject-rtos/zephyr/pull/112681.
This PR is meant to be merged on top of https://github.com/zephyrproject-rtos/zephyr/pull/112061.

if https://github.com/zephyrproject-rtos/zephyr/pull/112061 is not merged c40d20d7affa734ac488cc4933cd31e4bae101d3 and 439a227b0fcc8a1179af76292b3830a44745f3f2 may be squashed together.