### PR TITLE
Allow or deny mDNS responder for each network interface

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -260,6 +260,10 @@ New APIs and options
     :kconfig:option:`CONFIG_MDNS_RESPONDER_IFACE_POLICY_DENYLIST`) together with
     :kconfig:option:`CONFIG_MDNS_RESPONDER_IFACE_LIST` to control on which
     network interfaces the mDNS responder operates.
+  * Add :c:func:`mdns_responder_enable_iface` and
+    :c:func:`mdns_responder_disable_iface`
+    (:kconfig:option:`CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL`) to enable or
+    disable the mDNS responder on a network interface at runtime.
 
 * Ring buffer
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -255,6 +255,11 @@ New APIs and options
   * Add :c:func:`net_eth_set_if_type_wifi` to set the ethernet interface type to Wi-Fi.
   * Add :c:func:`net_dhcpv4_set_reboot_hint` to seed the DHCPv4 client with a
     previously leased address for INIT-REBOOT.
+  * Add an mDNS responder interface policy
+    (:kconfig:option:`CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALLOWLIST`,
+    :kconfig:option:`CONFIG_MDNS_RESPONDER_IFACE_POLICY_DENYLIST`) together with
+    :kconfig:option:`CONFIG_MDNS_RESPONDER_IFACE_LIST` to control on which
+    network interfaces the mDNS responder operates.
 
 * Ring buffer
 

--- a/include/zephyr/net/mdns_responder.h
+++ b/include/zephyr/net/mdns_responder.h
@@ -15,7 +15,9 @@
 #define ZEPHYR_INCLUDE_NET_MDNS_RESPONDER_H_
 
 #include <stddef.h>
+#include <errno.h>
 #include <zephyr/net/dns_sd.h>
+#include <zephyr/net/net_if.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,6 +36,59 @@ extern "C" {
  * @return 0 for OK; -EINVAL for invalid parameters.
  */
 int mdns_responder_set_ext_records(const struct dns_sd_rec *records, size_t count);
+
+#if defined(CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL) || defined(__DOXYGEN__)
+/**
+ * @brief Enable the mDNS responder on a specific network interface at runtime.
+ *
+ * The runtime setting overrides the build-time interface policy
+ * (@kconfig{CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALL} and friends) for the given
+ * interface. The responder listener sockets and multicast group memberships
+ * are reconfigured so that queries arriving on the interface are answered.
+ *
+ * @kconfig_dep{CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL}
+ *
+ * @param iface Network interface to enable the responder on.
+ *
+ * @return 0 for OK; -EINVAL if @p iface is NULL; -ERANGE if the interface
+ *         index is out of range; -ENOTSUP if runtime control is not enabled.
+ */
+int mdns_responder_enable_iface(struct net_if *iface);
+
+/**
+ * @brief Disable the mDNS responder on a specific network interface at runtime.
+ *
+ * The runtime setting overrides the build-time interface policy for the given
+ * interface. The listener socket bound to the interface is closed and its mDNS
+ * multicast group memberships are left, so no further queries are answered on
+ * that interface.
+ *
+ * @kconfig_dep{CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL}
+ *
+ * @param iface Network interface to disable the responder on.
+ *
+ * @return 0 for OK; -EINVAL if @p iface is NULL; -ERANGE if the interface
+ *         index is out of range; -ENOTSUP if runtime control is not enabled.
+ */
+int mdns_responder_disable_iface(struct net_if *iface);
+
+#else /* CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL */
+
+static inline int mdns_responder_enable_iface(struct net_if *iface)
+{
+	ARG_UNUSED(iface);
+
+	return -ENOTSUP;
+}
+
+static inline int mdns_responder_disable_iface(struct net_if *iface)
+{
+	ARG_UNUSED(iface);
+
+	return -ENOTSUP;
+}
+
+#endif /* CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL || __DOXYGEN__ */
 
 #ifdef __cplusplus
 }

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -320,6 +320,16 @@ config MDNS_RESPONDER_IFACE_LIST
 	  names are used instead of interface indexes because the indexes
 	  can change depending on configuration.
 
+config MDNS_RESPONDER_RUNTIME_IFACE_CONTROL
+	bool "Runtime control of the mDNS responder per interface"
+	help
+	  Provide mdns_responder_enable_iface() and
+	  mdns_responder_disable_iface() so that the application can enable or
+	  disable the mDNS responder on a specific network interface at
+	  runtime. The runtime setting overrides the build-time interface
+	  policy for that interface. When this option is not set, the
+	  responder follows the build-time interface policy only.
+
 config MDNS_RESPONDER_PROBE
 	bool "mDNS probing support [EXPERIMENTAL]"
 	select NET_CONNECTION_MANAGER

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -280,6 +280,46 @@ config MDNS_RESPONDER_INIT_PRIO
 	  Note that if NET_CONFIG_AUTO_INIT is enabled, then this value
 	  should be bigger than its value.
 
+choice
+	prompt "mDNS responder interface policy"
+	default MDNS_RESPONDER_IFACE_POLICY_ALL
+	help
+	  Select on which network interfaces the mDNS responder operates.
+	  This allows the responder to be kept off interfaces that do not
+	  need local service discovery, or that have hardware which is not
+	  ready when the responder is initialized.
+
+config MDNS_RESPONDER_IFACE_POLICY_ALL
+	bool "All interfaces"
+	help
+	  The mDNS responder attaches to every network interface. This is
+	  the default and backward compatible behavior.
+
+config MDNS_RESPONDER_IFACE_POLICY_ALLOWLIST
+	bool "Only listed interfaces"
+	select NET_INTERFACE_NAME
+	help
+	  The mDNS responder attaches only to interfaces whose name is
+	  listed in MDNS_RESPONDER_IFACE_LIST.
+
+config MDNS_RESPONDER_IFACE_POLICY_DENYLIST
+	bool "All except listed interfaces"
+	select NET_INTERFACE_NAME
+	help
+	  The mDNS responder attaches to every interface except those whose
+	  name is listed in MDNS_RESPONDER_IFACE_LIST.
+
+endchoice
+
+config MDNS_RESPONDER_IFACE_LIST
+	string "Comma separated list of interface names"
+	depends on MDNS_RESPONDER_IFACE_POLICY_ALLOWLIST || MDNS_RESPONDER_IFACE_POLICY_DENYLIST
+	help
+	  Comma separated list of network interface names (for example
+	  "eth0,wlan0") that the interface policy applies to. Interface
+	  names are used instead of interface indexes because the indexes
+	  can change depending on configuration.
+
 config MDNS_RESPONDER_PROBE
 	bool "mDNS probing support [EXPERIMENTAL]"
 	select NET_CONNECTION_MANAGER

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -54,6 +54,93 @@ extern void dns_dispatcher_svc_handler(struct net_socket_service_event *pev);
 
 #define MDNS_TTL CONFIG_MDNS_RESPONDER_TTL /* In seconds */
 
+#if defined(CONFIG_NET_INTERFACE_NAME_LEN)
+#define INTERFACE_NAME_LEN CONFIG_NET_INTERFACE_NAME_LEN
+#else
+#define INTERFACE_NAME_LEN 0
+#endif
+
+#if defined(CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALL)
+static inline bool mdns_iface_is_enabled(struct net_if *iface)
+{
+	ARG_UNUSED(iface);
+
+	return true;
+}
+#else
+/* Return true if the given interface name is found in the configured comma
+ * separated interface list. Leading and trailing whitespace around each list
+ * entry is ignored.
+ */
+static bool iface_name_in_list(const char *name)
+{
+	const char *p = CONFIG_MDNS_RESPONDER_IFACE_LIST;
+	size_t name_len = strlen(name);
+
+	while (*p != '\0') {
+		const char *start;
+		size_t len;
+
+		/* Skip leading whitespace */
+		while (*p == ' ' || *p == '\t') {
+			p++;
+		}
+
+		start = p;
+
+		/* Find the end of this entry */
+		while (*p != '\0' && *p != ',') {
+			p++;
+		}
+
+		len = p - start;
+
+		/* Trim trailing whitespace */
+		while (len > 0 &&
+		       (start[len - 1] == ' ' || start[len - 1] == '\t')) {
+			len--;
+		}
+
+		if (len == name_len && strncmp(start, name, len) == 0) {
+			return true;
+		}
+
+		/* Skip the comma separator */
+		if (*p == ',') {
+			p++;
+		}
+	}
+
+	return false;
+}
+
+/* Decide whether the mDNS responder should operate on a given interface,
+ * based on the configured interface policy and list.
+ */
+static bool mdns_iface_is_enabled(struct net_if *iface)
+{
+	char name[INTERFACE_NAME_LEN + 1];
+	bool in_list;
+
+	if (iface == NULL) {
+		return false;
+	}
+
+	if (net_if_get_name(iface, name, sizeof(name)) < 0) {
+		in_list = false;
+	} else {
+		in_list = iface_name_in_list(name);
+	}
+
+	if (IS_ENABLED(CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALLOWLIST)) {
+		return in_list;
+	}
+
+	/* CONFIG_MDNS_RESPONDER_IFACE_POLICY_DENYLIST */
+	return !in_list;
+}
+#endif /* CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALL */
+
 /* v4_svc/v6_svc are shared between the per-interface listener dispatch below (needs
  * MDNS_MAX_IPV4/6_IFACE_COUNT fds, one per interface) and, when probing is enabled,
  * send_probe()'s temporary DNS resolve context (needs DNS_RESOLVER_MAX_POLL fds for its
@@ -187,6 +274,10 @@ static void mdns_iface_event_handler(struct net_mgmt_event_callback *cb,
 				     uint64_t mgmt_event, struct net_if *iface)
 
 {
+	if (!mdns_iface_is_enabled(iface)) {
+		return;
+	}
+
 	if (mgmt_event == NET_EVENT_IF_UP) {
 		/* When the interface comes back up (e.g. Ethernet cable was
 		 * reattached), the stack has left the mDNS multicast groups if
@@ -1086,6 +1177,10 @@ static void mdns_addr_event_handler(struct net_mgmt_event_callback *cb,
 	bool probe_started = false;
 	int ret;
 
+	if (!mdns_iface_is_enabled(iface)) {
+		return;
+	}
+
 #if defined(CONFIG_NET_IPV4)
 	if (mgmt_event == NET_EVENT_IPV4_ADDR_ADD) {
 		ARRAY_FOR_EACH(v4_ctx, i) {
@@ -1260,6 +1355,10 @@ static void iface_ipv6_cb(struct net_if *iface, void *user_data)
 		return;
 	}
 
+	if (!mdns_iface_is_enabled(iface)) {
+		return;
+	}
+
 	ret = net_ipv6_mld_join(iface, addr);
 	if (ret < 0) {
 		NET_DBG("Cannot join %s IPv6 multicast group (%d)",
@@ -1282,6 +1381,10 @@ static void iface_ipv4_cb(struct net_if *iface, void *user_data)
 	int ret;
 
 	if (!net_if_flag_is_set(iface, NET_IF_IPV4)) {
+		return;
+	}
+
+	if (!mdns_iface_is_enabled(iface)) {
 		return;
 	}
 
@@ -1314,12 +1417,6 @@ static void setup_ipv4_addr(struct net_sockaddr_in *local_addr)
 	net_if_foreach(iface_ipv4_cb, &local_addr->sin_addr);
 }
 #endif /* CONFIG_NET_IPV4 */
-
-#if defined(CONFIG_NET_INTERFACE_NAME_LEN)
-#define INTERFACE_NAME_LEN CONFIG_NET_INTERFACE_NAME_LEN
-#else
-#define INTERFACE_NAME_LEN 0
-#endif
 
 static int dispatcher_cb(struct dns_socket_dispatcher *ctx, int sock,
 			 struct net_sockaddr *addr, size_t addrlen,
@@ -1397,6 +1494,10 @@ static int pre_init_listener(void)
 			continue;
 		}
 
+		if (!mdns_iface_is_enabled(iface)) {
+			continue;
+		}
+
 		v6_ctx[i].iface = iface;
 		/* Mark the socket as not yet created so that an announce that
 		 * is triggered (e.g. by a DHCP bound event) before the listener
@@ -1422,6 +1523,10 @@ static int pre_init_listener(void)
 	ARRAY_FOR_EACH(v4_ctx, i) {
 		iface = net_if_get_by_index(i + 1);
 		if ((!net_if_flag_is_set(iface, NET_IF_IPV4)) || iface == NULL) {
+			continue;
+		}
+
+		if (!mdns_iface_is_enabled(iface)) {
 			continue;
 		}
 
@@ -1502,9 +1607,14 @@ static int init_listener(void)
 			continue;
 		}
 
+		if (!mdns_iface_is_enabled(iface)) {
+			zsock_close(v6);
+			continue;
+		}
+
 		ifindex = net_if_get_by_iface(iface);
 
-		ret = net_if_get_name(iface, name, INTERFACE_NAME_LEN);
+		ret = net_if_get_name(iface, name, sizeof(name));
 		if (ret < 0) {
 			NET_DBG("Cannot get interface name for %d (%d)",
 				ifindex, ret);
@@ -1599,9 +1709,14 @@ static int init_listener(void)
 			continue;
 		}
 
+		if (!mdns_iface_is_enabled(iface)) {
+			zsock_close(v4);
+			continue;
+		}
+
 		ifindex = net_if_get_by_iface(iface);
 
-		ret = net_if_get_name(iface, name, INTERFACE_NAME_LEN);
+		ret = net_if_get_name(iface, name, sizeof(name));
 		if (ret < 0) {
 			NET_DBG("Cannot get interface name for %d (%d)",
 				ifindex, ret);

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(net_mdns_responder, CONFIG_MDNS_RESPONDER_LOG_LEVEL);
 #include <strings.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <limits.h>
 
 #include <zephyr/random/random.h>
 #include <zephyr/net/mld.h>
@@ -32,6 +33,7 @@ LOG_MODULE_REGISTER(net_mdns_responder, CONFIG_MDNS_RESPONDER_LOG_LEVEL);
 #include <zephyr/net/dns_resolve.h>
 #include <zephyr/net/socket_service.h>
 #include <zephyr/net/igmp.h>
+#include <zephyr/net/mdns_responder.h>
 
 #include "dns_sd.h"
 #include "dns_pack.h"
@@ -60,8 +62,10 @@ extern void dns_dispatcher_svc_handler(struct net_socket_service_event *pev);
 #define INTERFACE_NAME_LEN 0
 #endif
 
+#define MDNS_MAX_IFACE_COUNT MAX(MAX_IPV4_IFACE_COUNT, MAX_IPV6_IFACE_COUNT)
+
 #if defined(CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALL)
-static inline bool mdns_iface_is_enabled(struct net_if *iface)
+static inline bool mdns_iface_policy_allows(struct net_if *iface)
 {
 	ARG_UNUSED(iface);
 
@@ -114,10 +118,10 @@ static bool iface_name_in_list(const char *name)
 	return false;
 }
 
-/* Decide whether the mDNS responder should operate on a given interface,
- * based on the configured interface policy and list.
+/* Decide whether the build-time interface policy allows the mDNS responder to
+ * operate on the given interface.
  */
-static bool mdns_iface_is_enabled(struct net_if *iface)
+static bool mdns_iface_policy_allows(struct net_if *iface)
 {
 	char name[INTERFACE_NAME_LEN + 1];
 	bool in_list;
@@ -140,6 +144,61 @@ static bool mdns_iface_is_enabled(struct net_if *iface)
 	return !in_list;
 }
 #endif /* CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALL */
+
+#if defined(CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL)
+/* Per-interface runtime override of the build-time policy, indexed by
+ * (interface index - 1). Defaults to "follow policy".
+ */
+enum mdns_iface_ctrl {
+	MDNS_IFACE_CTRL_DEFAULT = 0,
+	MDNS_IFACE_CTRL_ENABLED,
+	MDNS_IFACE_CTRL_DISABLED,
+};
+
+static enum mdns_iface_ctrl iface_ctrl[MDNS_MAX_IFACE_COUNT];
+static bool listeners_running;
+
+static void mdns_mark_running(bool running)
+{
+	listeners_running = running;
+}
+
+/* Decide whether the mDNS responder should operate on a given interface. A
+ * runtime override set through mdns_responder_{enable,disable}_iface() takes
+ * precedence over the build-time policy.
+ */
+static bool mdns_iface_is_enabled(struct net_if *iface)
+{
+	int idx;
+
+	if (iface == NULL) {
+		return false;
+	}
+
+	idx = net_if_get_by_iface(iface) - 1;
+	if (idx >= 0 && idx < (int)ARRAY_SIZE(iface_ctrl)) {
+		if (iface_ctrl[idx] == MDNS_IFACE_CTRL_ENABLED) {
+			return true;
+		}
+
+		if (iface_ctrl[idx] == MDNS_IFACE_CTRL_DISABLED) {
+			return false;
+		}
+	}
+
+	return mdns_iface_policy_allows(iface);
+}
+#else
+static inline void mdns_mark_running(bool running)
+{
+	ARG_UNUSED(running);
+}
+
+static inline bool mdns_iface_is_enabled(struct net_if *iface)
+{
+	return mdns_iface_policy_allows(iface);
+}
+#endif /* CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL */
 
 /* v4_svc/v6_svc are shared between the per-interface listener dispatch below (needs
  * MDNS_MAX_IPV4/6_IFACE_COUNT fds, one per interface) and, when probing is enabled,
@@ -1593,6 +1652,14 @@ static int init_listener(void)
 			v6_ctx[i].fds[j].fd = -1;
 		}
 
+		/* Mark the slot closed up front. Skipped slots (no socket,
+		 * disabled or missing interface) must not look "open" to the
+		 * teardown path, otherwise mdns_close_listeners() would act on
+		 * a zero-initialized slot and close(0) an unrelated fd. The
+		 * success path below overwrites this with the real socket.
+		 */
+		v6_ctx[i].sock = -1;
+
 		v6 = get_socket(NET_AF_INET6);
 		if (v6 < 0) {
 			NET_ERR("Cannot get %s socket (%d %s interfaces). Max sockets is %d (%d)",
@@ -1695,6 +1762,14 @@ static int init_listener(void)
 			v4_ctx[i].fds[j].fd = -1;
 		}
 
+		/* Mark the slot closed up front. Skipped slots (no socket,
+		 * disabled or missing interface) must not look "open" to the
+		 * teardown path, otherwise mdns_close_listeners() would act on
+		 * a zero-initialized slot and close(0) an unrelated fd. The
+		 * success path below overwrites this with the real socket.
+		 */
+		v4_ctx[i].sock = -1;
+
 		v4 = get_socket(NET_AF_INET);
 		if (v4 < 0) {
 			NET_ERR("Cannot get %s socket (%d %s interfaces). Max sockets is %d (%d)",
@@ -1780,6 +1855,220 @@ static int init_listener(void)
 
 	return 0;
 }
+
+#if defined(CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL)
+static K_MUTEX_DEFINE(reconfigure_lock);
+
+/* Tear down every listener socket and its dispatcher registration. The sockets
+ * are recreated for the interfaces that remain enabled by init_listener().
+ */
+static void mdns_close_listeners(void)
+{
+#if defined(CONFIG_NET_IPV6)
+	ARRAY_FOR_EACH(v6_ctx, i) {
+		int sock = v6_ctx[i].sock;
+
+		if (sock < 0) {
+			continue;
+		}
+
+		(void)dns_dispatcher_unregister(&v6_ctx[i].dispatcher);
+		(void)zsock_close(sock);
+		v6_ctx[i].sock = -1;
+
+		ARRAY_FOR_EACH(v6_ctx[i].fds, j) {
+			v6_ctx[i].fds[j].fd = -1;
+		}
+	}
+#endif /* CONFIG_NET_IPV6 */
+
+#if defined(CONFIG_NET_IPV4)
+	ARRAY_FOR_EACH(v4_ctx, i) {
+		int sock = v4_ctx[i].sock;
+
+		if (sock < 0) {
+			continue;
+		}
+
+		(void)dns_dispatcher_unregister(&v4_ctx[i].dispatcher);
+		(void)zsock_close(sock);
+		v4_ctx[i].sock = -1;
+
+		ARRAY_FOR_EACH(v4_ctx[i].fds, j) {
+			v4_ctx[i].fds[j].fd = -1;
+		}
+	}
+#endif /* CONFIG_NET_IPV4 */
+}
+
+#if defined(CONFIG_NET_TEST)
+/* Test-only helper. Return the raw socket stored in the given listener slot,
+ * or INT_MIN when the family/slot is out of range. The tests use this to
+ * verify that skipped listener slots are marked closed (-1) rather than left
+ * at a zero-initialized fd, which would make mdns_close_listeners() close an
+ * unrelated descriptor.
+ */
+int mdns_test_get_listener_sock(net_sa_family_t family, unsigned int slot)
+{
+#if defined(CONFIG_NET_IPV6)
+	if (family == NET_AF_INET6) {
+		if (slot >= ARRAY_SIZE(v6_ctx)) {
+			return INT_MIN;
+		}
+
+		return v6_ctx[slot].sock;
+	}
+#endif /* CONFIG_NET_IPV6 */
+
+#if defined(CONFIG_NET_IPV4)
+	if (family == NET_AF_INET) {
+		if (slot >= ARRAY_SIZE(v4_ctx)) {
+			return INT_MIN;
+		}
+
+		return v4_ctx[slot].sock;
+	}
+#endif /* CONFIG_NET_IPV4 */
+
+	return INT_MIN;
+}
+
+/* Test-only helper. Reproduce the boot-time condition where a listener slot
+ * was never opened by injecting a zero-initialized fd into the given slot and
+ * re-running the listener setup. init_listener() must mark a skipped slot
+ * closed (-1); the pre-fix code left it at the injected fd, which later made
+ * mdns_close_listeners() unregister a zeroed dispatcher and close(0) an
+ * unrelated descriptor. Returns 0 on success.
+ */
+int mdns_test_reinit_with_stale_slot(unsigned int slot)
+{
+	/* Start from a clean state (every slot marked closed). */
+	mdns_close_listeners();
+
+#if defined(CONFIG_NET_IPV6)
+	if (slot < ARRAY_SIZE(v6_ctx)) {
+		v6_ctx[slot].sock = 0;
+	}
+#endif /* CONFIG_NET_IPV6 */
+
+#if defined(CONFIG_NET_IPV4)
+	if (slot < ARRAY_SIZE(v4_ctx)) {
+		v4_ctx[slot].sock = 0;
+	}
+#endif /* CONFIG_NET_IPV4 */
+
+	return init_listener();
+}
+#endif /* CONFIG_NET_TEST */
+
+/* Leave the mDNS multicast groups on the given interface. init_listener()
+ * rejoins them on the interfaces that remain enabled.
+ */
+static void mdns_leave_groups_cb(struct net_if *iface, void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+#if defined(CONFIG_NET_IPV4)
+	if (net_if_flag_is_set(iface, NET_IF_IPV4)) {
+		struct net_sockaddr_in addr4;
+
+		create_ipv4_addr(&addr4);
+		(void)net_ipv4_igmp_leave(iface, &addr4.sin_addr);
+	}
+#endif /* CONFIG_NET_IPV4 */
+
+#if defined(CONFIG_NET_IPV6)
+	if (net_if_flag_is_set(iface, NET_IF_IPV6)) {
+		struct net_sockaddr_in6 addr6;
+
+		create_ipv6_addr(&addr6);
+		(void)net_ipv6_mld_leave(iface, &addr6.sin6_addr);
+	}
+#endif /* CONFIG_NET_IPV6 */
+}
+
+/* Rebuild the responder listeners to match the current per-interface state.
+ * Everything is torn down and set up again so that both newly enabled and
+ * newly disabled interfaces are handled by the existing setup path.
+ */
+static void mdns_reconfigure_listeners(void)
+{
+	k_mutex_lock(&reconfigure_lock, K_FOREVER);
+
+	if (!listeners_running) {
+		/* The initial listener setup has not run yet; it will honor the
+		 * current runtime state, so there is nothing to rebuild.
+		 */
+		goto out;
+	}
+
+#if defined(CONFIG_MDNS_RESPONDER_PROBE)
+	/* Stop any in-flight probing before tearing the sockets down. Only the
+	 * contexts that were configured have an initialized probe timer.
+	 */
+#if defined(CONFIG_NET_IPV6)
+	ARRAY_FOR_EACH(v6_ctx, i) {
+		if (v6_ctx[i].iface != NULL) {
+			(void)k_work_cancel_delayable(&v6_ctx[i].probe_timer);
+		}
+	}
+#endif
+#if defined(CONFIG_NET_IPV4)
+	ARRAY_FOR_EACH(v4_ctx, i) {
+		if (v4_ctx[i].iface != NULL) {
+			(void)k_work_cancel_delayable(&v4_ctx[i].probe_timer);
+		}
+	}
+#endif
+#endif /* CONFIG_MDNS_RESPONDER_PROBE */
+
+	mdns_close_listeners();
+
+	net_if_foreach(mdns_leave_groups_cb, NULL);
+
+#if defined(CONFIG_MDNS_RESPONDER_PROBE)
+	(void)pre_init_listener();
+#endif
+	(void)init_listener();
+
+out:
+	k_mutex_unlock(&reconfigure_lock);
+}
+
+static int mdns_set_iface_ctrl(struct net_if *iface, enum mdns_iface_ctrl ctrl)
+{
+	int idx;
+
+	if (iface == NULL) {
+		return -EINVAL;
+	}
+
+	idx = net_if_get_by_iface(iface) - 1;
+	if (idx < 0 || idx >= (int)ARRAY_SIZE(iface_ctrl)) {
+		return -ERANGE;
+	}
+
+	if (iface_ctrl[idx] == ctrl) {
+		return 0;
+	}
+
+	iface_ctrl[idx] = ctrl;
+
+	mdns_reconfigure_listeners();
+
+	return 0;
+}
+
+int mdns_responder_enable_iface(struct net_if *iface)
+{
+	return mdns_set_iface_ctrl(iface, MDNS_IFACE_CTRL_ENABLED);
+}
+
+int mdns_responder_disable_iface(struct net_if *iface)
+{
+	return mdns_set_iface_ctrl(iface, MDNS_IFACE_CTRL_DISABLED);
+}
+#endif /* CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL */
 
 #if defined(CONFIG_MDNS_RESPONDER_PROBE)
 
@@ -2079,6 +2368,11 @@ static void do_init_listener(struct k_work *work)
 			init_listener_done = true;
 		};
 
+		/* Allow runtime enable/disable to rebuild the listeners now
+		 * that the initial setup has run.
+		 */
+		mdns_mark_running(true);
+
 		mark_needs_announce(NULL, true);
 		announce_count = 0;
 		announce_start(work);
@@ -2146,7 +2440,14 @@ static int mdns_responder_init(void)
 
 	return ret;
 #else
-	return init_listener();
+	int ret = init_listener();
+
+	/* Allow runtime enable/disable to rebuild the listeners now that the
+	 * initial setup has run.
+	 */
+	mdns_mark_running(true);
+
+	return ret;
 #endif
 }
 

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -1549,7 +1549,7 @@ static int pre_init_listener(void)
 
 	ARRAY_FOR_EACH(v6_ctx, i) {
 		iface = net_if_get_by_index(i + 1);
-		if ((!net_if_flag_is_set(iface, NET_IF_IPV6)) || iface == NULL) {
+		if (iface == NULL || !net_if_flag_is_set(iface, NET_IF_IPV6)) {
 			continue;
 		}
 
@@ -1581,7 +1581,7 @@ static int pre_init_listener(void)
 
 	ARRAY_FOR_EACH(v4_ctx, i) {
 		iface = net_if_get_by_index(i + 1);
-		if ((!net_if_flag_is_set(iface, NET_IF_IPV4)) || iface == NULL) {
+		if (iface == NULL || !net_if_flag_is_set(iface, NET_IF_IPV4)) {
 			continue;
 		}
 
@@ -1669,7 +1669,7 @@ static int init_listener(void)
 		}
 
 		iface = net_if_get_by_index(i + 1);
-		if ((!net_if_flag_is_set(iface, NET_IF_IPV6)) || iface == NULL) {
+		if (iface == NULL || !net_if_flag_is_set(iface, NET_IF_IPV6)) {
 			zsock_close(v6);
 			continue;
 		}
@@ -1779,7 +1779,7 @@ static int init_listener(void)
 		}
 
 		iface = net_if_get_by_index(i + 1);
-		if ((!net_if_flag_is_set(iface, NET_IF_IPV4)) || iface == NULL) {
+		if (iface == NULL || !net_if_flag_is_set(iface, NET_IF_IPV4)) {
 			zsock_close(v4);
 			continue;
 		}

--- a/tests/net/lib/mdns_responder/src/main.c
+++ b/tests/net/lib/mdns_responder/src/main.c
@@ -985,6 +985,13 @@ ZTEST(test_mdns_responder, test_group_recovery_after_carrier_off_on)
 		     "Responder did not recover after carrier came back");
 }
 
+/* The next two tests verify which interfaces the configured responder policy enables.
+ * iface1 is dummy0 and iface2 is dummy1 (default names for the two dummy interfaces).
+ * The policy test scenarios use allowlist "dummy0" and denylist "dummy1", so in both cases
+ * iface1 runs mDNS while iface2 does not. Under the default ALL policy both
+ * interfaces run mDNS.
+ */
+
 /* Recovery must also work on interfaces other than the first one. The old
  * NET_EVENT_IF_UP handler never rejoined the IPv6 MLD group (ff02::fb) for
  * any interface, so a second interface lost mDNS after a down/up cycle. (Its
@@ -996,11 +1003,13 @@ ZTEST(test_mdns_responder, test_second_iface_group_recovery_after_down_up)
 {
 	struct net_if *iface2 = net_if_get_by_index(2);
 
+	Z_TEST_SKIP_IFNDEF(CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALL);
+
 	zassert_not_null(iface2, "Second interface is NULL");
 
-	zassert_true(ipv4_group_joined(iface2),
+	zexpect_true(ipv4_group_joined(iface2),
 		     "iface2 IPv4 mDNS group not joined before the link went down");
-	zassert_true(ipv6_group_joined(iface2),
+	zexpect_true(ipv6_group_joined(iface2),
 		     "iface2 IPv6 mDNS group not joined before the link went down");
 
 	zassert_ok(net_if_down(iface2), "Cannot bring the second interface down");
@@ -1008,10 +1017,47 @@ ZTEST(test_mdns_responder, test_second_iface_group_recovery_after_down_up)
 
 	k_sleep(K_MSEC(100));
 
-	zassert_true(ipv4_group_joined(iface2),
+	zexpect_true(ipv4_group_joined(iface2),
 		     "iface2 IPv4 mDNS group not rejoined after the interface came back up");
-	zassert_true(ipv6_group_joined(iface2),
+	zexpect_true(ipv6_group_joined(iface2),
 		     "iface2 IPv6 mDNS group not rejoined after the interface came back up");
+}
+
+/* With a non-default interface policy in effect, the responder must operate on
+ * the allowed interface (iface1) and stay off the excluded one (iface2). The
+ * excluded interface must never join the mDNS multicast groups, not even after
+ * a link recovery that would otherwise rejoin them.
+ */
+ZTEST(test_mdns_responder, test_iface_policy_excludes_iface2)
+{
+	struct net_if *iface2 = net_if_get_by_index(2);
+
+	Z_TEST_SKIP_IFDEF(CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALL);
+
+	zassert_not_null(iface2, "Second interface is NULL");
+
+	/* The allowed interface still runs mDNS. */
+	zexpect_true(ipv4_group_joined(iface1),
+		     "policy-allowed iface1 not in the IPv4 mDNS group");
+	zexpect_true(ipv6_group_joined(iface1),
+		     "policy-allowed iface1 not in the IPv6 mDNS group");
+
+	/* The excluded interface must not be a member of either group. */
+	zexpect_false(ipv4_group_joined(iface2),
+		      "policy-excluded iface2 joined the IPv4 mDNS group");
+	zexpect_false(ipv6_group_joined(iface2),
+		      "policy-excluded iface2 joined the IPv6 mDNS group");
+
+	zassert_ok(net_if_down(iface2), "Cannot bring the second interface down");
+	zassert_ok(net_if_up(iface2), "Cannot bring the second interface back up");
+
+	k_sleep(K_MSEC(100));
+
+	/* A recovery cycle must not sneak the excluded interface into the group. */
+	zexpect_false(ipv4_group_joined(iface2),
+		      "policy-excluded iface2 joined the IPv4 mDNS group on recovery");
+	zexpect_false(ipv6_group_joined(iface2),
+		      "policy-excluded iface2 joined the IPv6 mDNS group on recovery");
 }
 
 ZTEST_SUITE(test_mdns_responder, NULL, test_setup, before, cleanup, NULL);

--- a/tests/net/lib/mdns_responder/src/main.c
+++ b/tests/net/lib/mdns_responder/src/main.c
@@ -1060,4 +1060,130 @@ ZTEST(test_mdns_responder, test_iface_policy_excludes_iface2)
 		      "policy-excluded iface2 joined the IPv6 mDNS group on recovery");
 }
 
+/* The runtime control API must be able to take the responder off an interface
+ * that it is currently running on, and put it back. Disabling drops the mDNS
+ * multicast memberships (and closes the listener socket); enabling restores
+ * them so that the responder answers queries again.
+ */
+ZTEST(test_mdns_responder, test_runtime_disable_then_enable_iface)
+{
+	Z_TEST_SKIP_IFNDEF(CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL);
+
+	zexpect_true(ipv4_group_joined(iface1),
+		     "iface1 not in the IPv4 mDNS group at start");
+	zexpect_true(ipv6_group_joined(iface1),
+		     "iface1 not in the IPv6 mDNS group at start");
+
+	zexpect_ok(mdns_responder_disable_iface(iface1),
+		   "Cannot disable the responder on iface1");
+	k_sleep(K_MSEC(100));
+
+	zexpect_false(ipv4_group_joined(iface1),
+		      "iface1 still in the IPv4 mDNS group after disable");
+	zexpect_false(ipv6_group_joined(iface1),
+		      "iface1 still in the IPv6 mDNS group after disable");
+
+	zexpect_ok(mdns_responder_enable_iface(iface1),
+		   "Cannot re-enable the responder on iface1");
+	k_sleep(K_MSEC(100));
+
+	zexpect_true(ipv4_group_joined(iface1),
+		     "iface1 not rejoined the IPv4 mDNS group after enable");
+	zexpect_true(ipv6_group_joined(iface1),
+		     "iface1 not rejoined the IPv6 mDNS group after enable");
+	zexpect_true(responder_answers_query(),
+		     "Responder did not answer after being re-enabled");
+}
+
+/* Argument validation for the runtime control API. */
+ZTEST(test_mdns_responder, test_runtime_iface_control_bad_args)
+{
+	Z_TEST_SKIP_IFNDEF(CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL);
+
+	zexpect_equal(mdns_responder_enable_iface(NULL), -EINVAL,
+		      "enable_iface(NULL) should return -EINVAL");
+	zexpect_equal(mdns_responder_disable_iface(NULL), -EINVAL,
+		      "disable_iface(NULL) should return -EINVAL");
+}
+
+/* A runtime enable must override the build-time policy: an interface excluded
+ * by the policy (iface2 == dummy1) can still be turned on at runtime, and
+ * turned back off again.
+ */
+ZTEST(test_mdns_responder, test_runtime_enable_overrides_policy)
+{
+	struct net_if *iface2 = net_if_get_by_index(2);
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL);
+	Z_TEST_SKIP_IFDEF(CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALL);
+
+	zexpect_not_null(iface2, "Second interface is NULL");
+
+	/* Policy keeps iface2 off. */
+	zexpect_false(ipv4_group_joined(iface2),
+		      "policy-excluded iface2 is in the IPv4 mDNS group");
+	zexpect_false(ipv6_group_joined(iface2),
+		      "policy-excluded iface2 is in the IPv6 mDNS group");
+
+	/* Runtime enable overrides the policy. */
+	zexpect_ok(mdns_responder_enable_iface(iface2),
+		   "Cannot enable the responder on iface2");
+	k_sleep(K_MSEC(100));
+
+	zexpect_true(ipv4_group_joined(iface2),
+		     "iface2 not in the IPv4 mDNS group after runtime enable");
+	zexpect_true(ipv6_group_joined(iface2),
+		     "iface2 not in the IPv6 mDNS group after runtime enable");
+
+	/* Turning it back off must drop the memberships again. Leave iface2 in
+	 * the off state so the rest of the suite sees the policy default.
+	 */
+	zexpect_ok(mdns_responder_disable_iface(iface2),
+		   "Cannot disable the responder on iface2");
+	k_sleep(K_MSEC(100));
+
+	zexpect_false(ipv4_group_joined(iface2),
+		      "iface2 still in the IPv4 mDNS group after runtime disable");
+	zexpect_false(ipv6_group_joined(iface2),
+		      "iface2 still in the IPv6 mDNS group after runtime disable");
+}
+
+/* The test-only hooks are compiled together with runtime interface control
+ * (they call mdns_close_listeners()), which is also the only configuration
+ * where the teardown path this guards against is reachable. That availability
+ * gate stays a compile-time #if; the policy applicability gate below is a
+ * runtime skip.
+ */
+#if defined(CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL)
+extern int mdns_test_get_listener_sock(net_sa_family_t family, unsigned int slot);
+extern int mdns_test_reinit_with_stale_slot(unsigned int slot);
+
+/* A listener slot that the setup skips (here iface2 == dummy1 == slot 1, kept
+ * off by the allowlist policy) must be marked closed (-1), not left at the
+ * zero-initialized fd 0. Otherwise mdns_close_listeners() - run on every
+ * runtime reconfigure - would treat the slot as open, unregister a zeroed
+ * dispatcher and close(0), silently closing an unrelated descriptor.
+ *
+ * Reproduce the boot-time "never opened" condition by injecting fd 0 into the
+ * excluded slot and re-running the setup, then assert the slot was closed.
+ */
+ZTEST(test_mdns_responder, test_excluded_listener_slot_marked_closed)
+{
+	Z_TEST_SKIP_IFNDEF(CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALLOWLIST);
+
+	zexpect_ok(mdns_test_reinit_with_stale_slot(1),
+		   "Cannot re-run mDNS listener setup");
+
+	if (IS_ENABLED(CONFIG_NET_IPV4)) {
+		zexpect_equal(mdns_test_get_listener_sock(NET_AF_INET, 1), -1,
+			      "Excluded IPv4 listener slot left open (stale fd)");
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV6)) {
+		zexpect_equal(mdns_test_get_listener_sock(NET_AF_INET6, 1), -1,
+			      "Excluded IPv6 listener slot left open (stale fd)");
+	}
+}
+#endif /* CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL */
+
 ZTEST_SUITE(test_mdns_responder, NULL, test_setup, before, cleanup, NULL);

--- a/tests/net/lib/mdns_responder/tests.yaml
+++ b/tests/net/lib/mdns_responder/tests.yaml
@@ -7,3 +7,18 @@ tests:
   net.mdns:
     min_ram: 21
     timeout: 600
+  net.mdns.iface_allowlist:
+    min_ram: 21
+    timeout: 600
+    extra_configs:
+      # mDNS responder operates only on the listed interface (dummy0 == iface1).
+      - CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALLOWLIST=y
+      - CONFIG_MDNS_RESPONDER_IFACE_LIST="dummy0"
+  net.mdns.iface_denylist:
+    min_ram: 21
+    timeout: 600
+    extra_configs:
+      # mDNS responder operates on every interface except the listed one
+      # (dummy1 == iface2), so iface1 stays enabled and iface2 is excluded.
+      - CONFIG_MDNS_RESPONDER_IFACE_POLICY_DENYLIST=y
+      - CONFIG_MDNS_RESPONDER_IFACE_LIST="dummy1"

--- a/tests/net/lib/mdns_responder/tests.yaml
+++ b/tests/net/lib/mdns_responder/tests.yaml
@@ -22,3 +22,18 @@ tests:
       # (dummy1 == iface2), so iface1 stays enabled and iface2 is excluded.
       - CONFIG_MDNS_RESPONDER_IFACE_POLICY_DENYLIST=y
       - CONFIG_MDNS_RESPONDER_IFACE_LIST="dummy1"
+  net.mdns.runtime_iface:
+    min_ram: 21
+    timeout: 600
+    extra_configs:
+      # Runtime per-interface control on top of the default (ALL) policy.
+      - CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL=y
+  net.mdns.runtime_iface_allowlist:
+    min_ram: 21
+    timeout: 600
+    extra_configs:
+      # Runtime per-interface control combined with an allowlist policy, so that a
+      # runtime enable can override a policy-excluded interface (dummy1 == iface2).
+      - CONFIG_MDNS_RESPONDER_IFACE_POLICY_ALLOWLIST=y
+      - CONFIG_MDNS_RESPONDER_IFACE_LIST="dummy0"
+      - CONFIG_MDNS_RESPONDER_RUNTIME_IFACE_CONTROL=y


### PR DESCRIPTION
Allow user to select what network interfaces the mDNS responder runs on. Both built time and runtime configuration is implemented. Also add deferred configuration option which delays mDNS responder launch until the network interface is up.

Fixes #110575
