### PR TITLE
logging: Do not enable CONFIG_LOG_PRINTK_STATIC by default

### DIFF
--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -14,7 +14,6 @@ config LOG_PRINTK
 
 config LOG_PRINTK_STATIC
 	bool "Static processing of printk messages"
-	default y
 	depends on LOG_PRINTK
 
 if LOG_MODE_DEFERRED && !LOG_FRONTEND_ONLY


### PR DESCRIPTION
After this option was merged enabled by default, multiple samples and tests failed to build.
Let's leave it disabled by default.

Introduced by https://github.com/zephyrproject-rtos/zephyr/pull/112464

---

llext failure: https://github.com/zephyrproject-rtos/zephyr/actions/runs/28659064360/job/84995263116
macrology failures: https://github.com/zephyrproject-rtos/zephyr/actions/runs/28659064145/job/84995081515
https://github.com/zephyrproject-rtos/zephyr/actions/runs/28659064360/job/84995263171
C++ build failure: https://github.com/zephyrproject-rtos/zephyr/actions/runs/28659064145/job/84995081569