### PR TITLE
boards: mxchip: use pull-up for input buttons

### DIFF
--- a/boards/mxchip/az3166_iotdevkit/az3166_iotdevkit.dts
+++ b/boards/mxchip/az3166_iotdevkit/az3166_iotdevkit.dts
@@ -91,13 +91,13 @@
 		compatible = "gpio-keys";
 
 		button_a: button_a {
-			gpios = <&gpioa 4 (GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)>;
+			gpios = <&gpioa 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			label = "Button A";
 			zephyr,code = <INPUT_KEY_A>;
 		};
 
 		button_b: button_b {
-			gpios = <&gpioa 10 (GPIO_ACTIVE_LOW | GPIO_PULL_DOWN)>;
+			gpios = <&gpioa 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			label = "Button B";
 			zephyr,code = <INPUT_KEY_B>;
 		};


### PR DESCRIPTION
Buttons are active-low so should have pull-up instead of pull-down.

Fixes: zephyrproject-rtos/zephyr#112235