### PR TITLE
drivers: regulator: stm32_vrefbuf: ensure reconfiguration disables VREFBUF if necessary

### DIFF
--- a/drivers/regulator/regulator_stm32_vrefbuf.c
+++ b/drivers/regulator/regulator_stm32_vrefbuf.c
@@ -13,6 +13,22 @@
 
 LOG_MODULE_REGISTER(regulator_stm32_vrefbuf, CONFIG_REGULATOR_LOG_LEVEL);
 
+/*
+ * Do we need to compile support code for VREFBUF without active scale change?
+ * For now, support only configurations where all instances either have it or not.
+ * This can be changed in the future if necessary by saving the property's value
+ * in the device config and replacing compile-time with runtime checks.
+ *
+ * Note: NASC = Non-Active Scale Change
+ */
+#if DT_ALL_INST_HAS_BOOL_STATUS_OKAY(st_has_active_scale_change)
+#define NEEDS_NASC_SUPPORT 0
+#else /* DT_ALL_INST_HAS_BOOL_STATUS_OKAY(st_has_active_scale_change) */
+BUILD_ASSERT(UTIL_NOT(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(st_has_active_scale_change)),
+	     "All instances must have the same value for property st,has-active-scale-change");
+#define NEEDS_NASC_SUPPORT 1
+#endif /* DT_ALL_INST_HAS_BOOL_STATUS_OKAY(st_has_active_scale_change) */
+
 struct regulator_stm32_vrefbuf_voltage {
 	uint32_t vrs; /* LL_VREFBUF_VOLTAGE_SCALE<X> */
 	int32_t uv;   /* VREFBUF output in uV with this scale */
@@ -76,6 +92,27 @@ static int regulator_stm32_vrefbuf_set_voltage(const struct device *dev, int32_t
 	const struct regulator_stm32_vrefbuf_config *config = dev->config;
 	uint32_t best_vrs = 0;
 	int32_t best_voltage = INT32_MAX;
+	bool regulator_enabled;
+	int res = -EINVAL;
+
+	if (NEEDS_NASC_SUPPORT) {
+		/*
+		 * On some series, the regulator must be disabled to change voltage scale.
+		 *
+		 * Enable Hi-Z to switch the regulator in "Hold mode" if the VREF+ output
+		 * is enabled to maintain VREF+ pin voltage while we temporarily disable
+		 * the regulator. Otherwise, the output isn't used (Hi-Z already enabled)
+		 * so disabling the regulator doesn't really matter...
+		 *
+		 * Note that we perform the operations unconditionally to reduce code size
+		 * because they are idempotent (no effect if already in the desired state).
+		 * Also, there is no LL function to check if the regulator is enabled so
+		 * we have to do it using a raw register access.
+		 */
+		regulator_enabled = (VREFBUF->CSR & VREFBUF_CSR_ENVR) != 0U;
+		LL_VREFBUF_EnableHIZ();
+		LL_VREFBUF_Disable();
+	}
 
 	/* Search among supported voltages for the closest one at least equal
 	 * to minimum requested by caller. Note that all configurations must
@@ -90,13 +127,25 @@ static int regulator_stm32_vrefbuf_set_voltage(const struct device *dev, int32_t
 		}
 	}
 
-	if (best_voltage == INT32_MAX) {
-		return -EINVAL;
+	if (best_voltage != INT32_MAX) {
+		LL_VREFBUF_SetVoltageScaling(best_vrs);
+		res = 0;
 	}
 
-	LL_VREFBUF_SetVoltageScaling(best_vrs);
+	if (NEEDS_NASC_SUPPORT) {
+		/*
+		 * Regardless of whether we changed scale,
+		 * undo changes we have done in the prologue.
+		 */
+		if (config->vrefp_output_enable) {
+			LL_VREFBUF_DisableHIZ();
+		}
+		if (regulator_enabled) {
+			LL_VREFBUF_Enable();
+		}
+	}
 
-	return 0;
+	return res;
 }
 
 static int regulator_stm32_vrefbuf_get_voltage(const struct device *dev, int32_t *volt_uv)

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -581,6 +581,7 @@
 			compatible = "st,stm32-vrefbuf";
 			reg = <0x40010030 0xd0>;
 			ref-voltages = <2048000>, <2500000>;
+			st,has-active-scale-change;
 			status = "disabled";
 		};
 

--- a/dts/bindings/regulator/st,stm32-vrefbuf.yaml
+++ b/dts/bindings/regulator/st,stm32-vrefbuf.yaml
@@ -54,3 +54,12 @@ properties:
     description: |
       Enables the VREF+ output pin. VREF+ pin is in high-impedance state
       otherwise.
+
+  st,has-active-scale-change:
+    type: boolean
+    description: |
+      If present, indicates the VREFBUF supports changing voltage scale while enabled.
+
+      Refer to description of bit(s) VRS in the VREFBUF_CSR register in Reference Manual
+      to determine if this feature is supported: if not, the description will indicate
+      "The software can program this bitfield only when the VREFBUF is disabled (ENVR=0)".


### PR DESCRIPTION
On some STM32 series, the VREFBUF must be disabled in order to change the voltage scale. See for example in RM0481 Rev 2 §29.5.1 "VREFBUF control and status register (VREFBUF_CSR)":

<img width="1134" height="387" alt="image" src="https://github.com/user-attachments/assets/f8fbb3fe-3c25-4f7b-be97-191ad1e9acb4" />

Add a new property to the `st,stm32-vrefbuf` binding indicating whether the voltage scale can be reconfigured while the regulator is enabled or not (based on this note's presence in the respective STM32 Reference Manuals) and modify the driver to perform a disable-configure-enable sequence when a call to `regulator_set_voltage()` is done while VREFBUF is enabled.

Thanks to usage of the VREFBUF's *"Hold mode"*, the voltage level on VREF+ should remain relatively stable during the very short reconfiguration time.

<details><summary>Original PR description</summary>
<p>

The VREFBUF must be disabled before changing the voltage scale. Disallow reconfiguration while the regulator is active. See for example in RM0481 Rev 2 §29.5.1 "VREFBUF control and status register (VREFBUF_CSR)":

<img width="1134" height="387" alt="image" src="https://github.com/user-attachments/assets/f8fbb3fe-3c25-4f7b-be97-191ad1e9acb4" />

> [!NOTE]
>
> This restriction is not documented in **all** Reference Manuals for series that have a VREFBUF.
> For example, there is no note indicating this restriction in RM0503 (for STM32U0 series):
> <img width="1261" height="1249" alt="image" src="https://github.com/user-attachments/assets/21a10042-49d9-40f3-9809-a65050927b67" />
>
> However, it is unclear whether this is merely a documentation oversight or if the restriction truly does not exist. For this reason, it seems safest to forbid reconfiguration on all series for now, a restriction which can be relaxed in the future if it turns out to be incorrect.
>
> <details>
> <p>
> 
> Looking at the Reference Manual for all(?) series which contain a VREFBUF:
> - the note is never present on series with 2 scales
>   - on these series, `VRS` = bit 2 of `VREFBUF_CSR`
> - the note is always present on series with 3+ scales
>   - on these series, `VRS[2:0]` = bits 6:4 of `VREFBUF_CSR`
>   - (except on STM32G4 series where VRS is only two bits: `VRS[1:0]` = bits 5:4 of `VREFBUF_CSR`)
>
> </p>
> </details>

### Alternative implementation

Another option is to simply disable the VREFBUF before changing its voltage output. However, it seems that no driver in-tree performs something similar so I'm not sure if this would be allowed. The Regulator API documentation doesn't seem to answer this question either.

If Regulator API maintainers think this would be a better approach, I can change my implementation.


</p>
</details> 