### PR TITLE
drivers: regulator: stm32_vrefbuf: implement software-loaded trimming

### DIFF
--- a/drivers/regulator/Kconfig.stm32_vrefbuf
+++ b/drivers/regulator/Kconfig.stm32_vrefbuf
@@ -16,4 +16,19 @@ config REGULATOR_STM32_VREFBUF_INIT_PRIORITY
 	help
 	  Init priority for the STM32 VREFBUF regulator driver.
 
+config REGULATOR_STM32_SOFTWARE_TRIM
+	bool "Software copy of trimming data from OTP"
+	default y
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_VREFBUF),nvmem-cells)
+	depends on NVMEM
+	help
+	  Copy trimming data from OTP in software when changing voltage range.
+
+	  On some series (such as STM32WB), trimming data is not automatically
+	  loaded by hardware from OTP when changing voltage range; in this case,
+	  this option should be enabled to ensure correct VREFBUF output voltage.
+
+	  The `VREFBUF trimming` section of the VREFBUF chapter in Reference Manuals
+	  indicates whether or not trimming data is loaded automatically by hardware.
+
 endif # REGULATOR_STM32_VREFBUF

--- a/drivers/regulator/regulator_stm32_vrefbuf.c
+++ b/drivers/regulator/regulator_stm32_vrefbuf.c
@@ -29,13 +29,38 @@ BUILD_ASSERT(UTIL_NOT(DT_ANY_INST_HAS_BOOL_STATUS_OKAY(st_has_active_scale_chang
 #define NEEDS_NASC_SUPPORT 1
 #endif /* DT_ALL_INST_HAS_BOOL_STATUS_OKAY(st_has_active_scale_change) */
 
+/* If the BUILD_ASSERT() at end of file trips, extend this block. */
+#if defined(LL_VREFBUF_VOLTAGE_SCALE3)
+#define MAX_VOLTAGE_SCALES_NUM 4
+#elif defined(LL_VREFBUF_VOLTAGE_SCALE2)
+#define MAX_VOLTAGE_SCALES_NUM 3
+#elif defined(LL_VREFBUF_VOLTAGE_SCALE1)
+#define MAX_VOLTAGE_SCALES_NUM 2
+#else
+#define MAX_VOLTAGE_SCALES_NUM 1
+#endif
+
 struct regulator_stm32_vrefbuf_voltage {
+#if defined(CONFIG_REGULATOR_STM32_SOFTWARE_TRIM)
+	/* trimming data location for this voltage scale */
+	struct nvmem_cell trim;
+#endif /* CONFIG_REGULATOR_STM32_SOFTWARE_TRIM */
 	uint32_t vrs; /* LL_VREFBUF_VOLTAGE_SCALE<X> */
 	int32_t uv;   /* VREFBUF output in uV with this scale */
 };
 
 struct regulator_stm32_vrefbuf_data {
 	struct regulator_common_data common;
+#if defined(CONFIG_REGULATOR_STM32_SOFTWARE_TRIM)
+	/*
+	 * Trimming data read from OTP at runtime.
+	 *
+	 * Given that VREFBUF is usually single-instance, and the trimming
+	 * data is very small, it is more efficient to have a fixed-size
+	 * array in the instance data rather than out-of-band.
+	 */
+	uint8_t trim_data[MAX_VOLTAGE_SCALES_NUM];
+#endif /* CONFIG_REGULATOR_STM32_SOFTWARE_TRIM */
 };
 
 struct regulator_stm32_vrefbuf_config {
@@ -90,8 +115,9 @@ static int regulator_stm32_vrefbuf_set_voltage(const struct device *dev, int32_t
 					       int32_t max_uv)
 {
 	const struct regulator_stm32_vrefbuf_config *config = dev->config;
-	uint32_t best_vrs = 0;
+	__maybe_unused uint8_t best_idx = 0;
 	int32_t best_voltage = INT32_MAX;
+	uint32_t best_vrs = 0;
 	bool regulator_enabled;
 	int res = -EINVAL;
 
@@ -124,10 +150,17 @@ static int regulator_stm32_vrefbuf_set_voltage(const struct device *dev, int32_t
 		    config->ref_voltages[i].uv < best_voltage) {
 			best_voltage = config->ref_voltages[i].uv;
 			best_vrs = config->ref_voltages[i].vrs;
+			best_idx = i;
 		}
 	}
 
 	if (best_voltage != INT32_MAX) {
+#if defined(CONFIG_REGULATOR_STM32_SOFTWARE_TRIM)
+		/* Trim must be applied while the regulator is off */
+		struct regulator_stm32_vrefbuf_data *data = dev->data;
+
+		LL_VREFBUF_SetTrimming(data->trim_data[best_idx]);
+#endif /* CONFIG_REGULATOR_STM32_SOFTWARE_TRIM */
 		LL_VREFBUF_SetVoltageScaling(best_vrs);
 		res = 0;
 	}
@@ -192,6 +225,26 @@ static int regulator_stm32_vrefbuf_init(const struct device *dev)
 		}
 	}
 
+#if defined(CONFIG_REGULATOR_STM32_SOFTWARE_TRIM)
+	/*
+	 * Read all trimming data at once during initialization
+	 * and cache the values for usage later at runtime.
+	 */
+	struct regulator_stm32_vrefbuf_data *data = dev->data;
+
+	for (uint8_t i = 0; i < config->ref_voltage_count; i++) {
+		uint8_t trim_val;
+
+		res = nvmem_cell_read(&config->ref_voltages[i].trim, &trim_val, sizeof(trim_val));
+		if (res != 0) {
+			LOG_ERR("Could not read trimming data for VRS%u: %d", i, res);
+			return res;
+		}
+
+		data->trim_data[i] = trim_val;
+	}
+#endif /* CONFIG_REGULATOR_STM32_SOFTWARE_TRIM */
+
 	if (config->vrefp_output_enable) {
 		LL_VREFBUF_DisableHIZ();
 	} else {
@@ -212,11 +265,20 @@ static DEVICE_API(regulator, api) = {
 
 #define VREFBUF_VOLTAGE_ELEM(node_id, prop, idx)                                                   \
 	{                                                                                          \
+		IF_ENABLED(CONFIG_REGULATOR_STM32_SOFTWARE_TRIM,                                   \
+			(.trim = NVMEM_DT_CELL_BY_IDX(node_id, idx),))                             \
 		.vrs = CONCAT(LL_VREFBUF_VOLTAGE_SCALE, idx),                                      \
 		.uv = DT_PROP_BY_IDX(node_id, prop, idx)                                           \
 	},
 
 #define REGULATOR_STM32_VREFBUF_DEFINE(inst)                                                       \
+	BUILD_ASSERT(DT_INST_PROP_LEN(inst, ref_voltages) <= MAX_VOLTAGE_SCALES_NUM,               \
+		"Too many voltage scales; please increase MAX_VOLTAGE_SCALES_NUM in the driver!"); \
+                                                                                                   \
+	IF_ENABLED(DT_INST_HAS_PROP(inst, nvmem_cells),                                            \
+	(BUILD_ASSERT(DT_INST_PROP_LEN(inst, nvmem_cells) == DT_INST_PROP_LEN(inst, ref_voltages), \
+	 "On node " DT_NODE_FULL_NAME(DT_DRV_INST(inst)) ": the following properties must have "   \
+	 "the same length but do not: `nvmem-cells` and `ref-voltages`");))                        \
                                                                                                    \
 	static struct regulator_stm32_vrefbuf_data data_##inst;                                    \
 	static const struct regulator_stm32_vrefbuf_voltage ref_voltages_##inst[] = {              \

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -181,6 +181,12 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					vref_sc1_otp: vref-sc1@30 {
+						reg = <0x30 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
 					ts_cal1_otp: ts-cal1@a8 {
 						reg = <0xa8 0x2>;
 						#nvmem-cell-cells = <0>;
@@ -195,6 +201,12 @@
 
 					ts_cal2_otp: ts-cal2@ca {
 						reg = <0xca 0x2>;
+						#nvmem-cell-cells = <0>;
+						read-only;
+					};
+
+					vref_sc0_otp: vref-sc0@f0 {
+						reg = <0xf0 0x2>;
 						#nvmem-cell-cells = <0>;
 						read-only;
 					};

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -595,6 +595,7 @@
 			reg = <0x40010030 0xd0>;
 			ref-voltages = <2048000>, <2500000>;
 			st,has-active-scale-change;
+			nvmem-cells = <&vref_sc0_otp>, <&vref_sc1_otp>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/regulator/st,stm32-vrefbuf.yaml
+++ b/dts/bindings/regulator/st,stm32-vrefbuf.yaml
@@ -8,6 +8,7 @@ compatible: "st,stm32-vrefbuf"
 include:
   - name: base.yaml
   - name: reset-device.yaml
+  - name: nvmem-consumer.yaml
   - name: regulator.yaml
     property-allowlist:
       - regulator-name
@@ -26,6 +27,16 @@ properties:
 
   resets:
     description: Optional VREFBUF reset line (present on some STM32 series).
+
+  nvmem-cells:
+    description: |
+      NVMEM cells for VREFBUF trimming data
+
+      Each entry points to the NVMEM cells containing trimming data for the corresponding
+      voltage scale (in the same order as `ref-voltages`; for example, the first entry
+      (index 0) corresponds to trimming data to use when Scale 0 is selected).
+
+      If present, this property must have the same number of entries as `ref-voltages`.
 
   ref-voltages:
     type: array


### PR DESCRIPTION
Based on (and thus loosely depends on) ~~https://github.com/zephyrproject-rtos/zephyr/pull/112693~~ *(merged)* and ~~https://github.com/zephyrproject-rtos/zephyr/pull/112698~~ *(merged)*. ~~Only the last two commits are relevant to this PR.~~

The VREFBUF output voltage is factory-calibrated by ST. On series such as STM32H5 or STM32U5, the VREFBUF loads trimming data automatically when changing voltage scale. However, on series such as STM32WB, the software is responsible for loading the correct trimming data from OTP.

Relevant section in STM32WB Reference Manual (RM0434):
<img width="891" height="492" alt="image" src="https://github.com/user-attachments/assets/abdd34d9-f23c-4541-b2af-a10bef3ade41" />

Same section but in STM32H5 Reference Manual (RM0481):
<img width="1206" height="254" alt="image" src="https://github.com/user-attachments/assets/eadd9fa8-d5a6-4474-acf4-78d89b496c25" />

---

Implement reading of trimming data from OTP and manual application of the proper trimming data by software, gated behind a new Kconfig option for the driver, CONFIG_REGULATOR_STM32_SOFTWARE_TRIM, enabled by default on series without automatic loading by hardware (these series' DTSI are updated to provide the `nvmem-cells` property which gates the option).

For now, the only supported series where this is needed is STM32WB. The proper pattern shall be used directly in future PRs introducing support for other series (no cell if HW-loaded, cells if SW-loaded)