### PR TITLE
tests: drivers: spi: spi_controller_peripheral: Incorrect SCK

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/Kconfig
+++ b/tests/drivers/spi/spi_controller_peripheral/Kconfig
@@ -5,29 +5,34 @@ config TESTED_SPI_MODE
 	int "SPI mode"
 	default 0
 	help
-		SPI mode value (clock polarity and phase) used in the test.
-		0: CPOL 0 (Active high), CPHA 0 (leading)
-		1: CPOL 0 (Active high), CPHA 1 (trailing)
-		2: CPOL 1 (Active low), CPHA 0 (leading)
-		3: CPOL 1 (Active low), CPHA 1 (trailing)
+	  SPI mode value (clock polarity and phase) used in the test.
+	  0: CPOL 0 (Active high), CPHA 0 (leading)
+	  1: CPOL 0 (Active high), CPHA 1 (trailing)
+	  2: CPOL 1 (Active low), CPHA 0 (leading)
+	  3: CPOL 1 (Active low), CPHA 1 (trailing)
+
+config TEST_INCORRECT_SCK_STATE
+	bool "Incorrect SCK state"
+	help
+	  Setting this option will set SCK to the opposite state than CPOL just before transceive.
 
 config PREALLOC_BUFFERS
 	bool "Preallocate buffers"
 	default y
 	help
-		Preallocate buffers used for transaction
-		using `memory-region` property.
+	  Preallocate buffers used for transaction
+	  using `memory-region` property.
 
 config SPI_CONTROLLER_PERIPHERAL_WORKQUEUE_STACK_SIZE
 	int "Test workqueue stack size"
 	default 1024
 	help
-	    Stack size for thread used to perform async API checks
+	  Stack size for thread used to perform async API checks
 
 config SPI_CONTROLLER_PERIPHERAL_WORKQUEUE_PRIORITY
 	int "Test workqueue priority"
 	default 10
 	help
-	    Priority for the work queue used for async testing
+	  Priority for the work queue used for async testing
 
 source "Kconfig.zephyr"

--- a/tests/drivers/spi/spi_controller_peripheral/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi3_default_alt: spi3_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi2_default_alt: spi2_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi130_default_alt: spi130_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio7 2 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi121_default_alt: spi121_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast_spis.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast_spis.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio7 3 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spis120_default_alt: spis120_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -11,6 +11,12 @@
  * CS:   P1.03 - P1.04
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -11,6 +11,12 @@
  * CS:   P1.03 - P1.04
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ophelia4ev_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ophelia4ev_nrf54l15_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	zephyr,user {
+		sck-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi22_default_alt: spi22_default_alt {
 		group1 {

--- a/tests/drivers/spi/spi_controller_peripheral/src/main.c
+++ b/tests/drivers/spi/spi_controller_peripheral/src/main.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <string.h>
 #include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/ztest.h>
@@ -24,6 +25,10 @@
 
 #define SPIM_OP	 (SPI_OP_MODE_MASTER | SPI_MODE)
 #define SPIS_OP	 (SPI_OP_MODE_SLAVE | SPI_MODE)
+
+#if CONFIG_TEST_INCORRECT_SCK_STATE && DT_NODE_HAS_PROP(DT_PATH(zephyr_user), sck_gpios)
+static const struct gpio_dt_spec sck = GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), sck_gpios);
+#endif
 
 static struct spi_dt_spec spim = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPIM_OP);
 static const struct device *spis_dev = DEVICE_DT_GET(DT_NODELABEL(dut_spis));
@@ -100,6 +105,10 @@ static void work_handler(struct k_work *work)
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct test_data *td = CONTAINER_OF(dwork, struct test_data, test_work);
 	int rv;
+
+#if CONFIG_TEST_INCORRECT_SCK_STATE && DT_NODE_HAS_PROP(DT_PATH(zephyr_user), sck_gpios)
+	gpio_pin_set_dt(&sck, CONFIG_TESTED_SPI_MODE > 1 ? 0 : 1);
+#endif
 
 	if (spim.config.operation & SPI_HALF_DUPLEX) {
 		spim.config.operation |= SPI_HOLD_ON_CS;
@@ -703,6 +712,10 @@ ZTEST(spi_controller_peripheral, test_half_duplex_split_peripheral_rx_buffers)
 static void before(void *not_used)
 {
 	ARG_UNUSED(not_used);
+
+#if CONFIG_TEST_INCORRECT_SCK_STATE && !DT_NODE_HAS_PROP(DT_PATH(zephyr_user), sck_gpios)
+	ztest_test_skip();
+#endif
 
 	memset(&tdata, 0, sizeof(tdata));
 	for (size_t i = 0; i < sizeof(spim_buffer); i++) {

--- a/tests/drivers/spi/spi_controller_peripheral/tests.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/tests.yaml
@@ -61,6 +61,38 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
 
+  drivers.spi.spi_mode0.incorrect_sck_state:
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=0
+      - CONFIG_TEST_INCORRECT_SCK_STATE=y
+    extra_args: EXTRA_DTC_OVERLAY_FILE="250khz.overlay"
+    integration_platforms:
+      - nrf52840dk/nrf52840
+
+  drivers.spi.spi_mode1.incorrect_sck_state:
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=1
+      - CONFIG_TEST_INCORRECT_SCK_STATE=y
+    extra_args: EXTRA_DTC_OVERLAY_FILE="500khz.overlay"
+    integration_platforms:
+      - nrf52840dk/nrf52840
+
+  drivers.spi.spi_mode2.incorrect_sck_state:
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=2
+      - CONFIG_TEST_INCORRECT_SCK_STATE=y
+    extra_args: EXTRA_DTC_OVERLAY_FILE="1mhz.overlay"
+    integration_platforms:
+      - nrf52840dk/nrf52840
+
+  drivers.spi.spi_mode3.incorrect_sck_state:
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=3
+      - CONFIG_TEST_INCORRECT_SCK_STATE=y
+    extra_args: EXTRA_DTC_OVERLAY_FILE="2mhz.overlay"
+    integration_platforms:
+      - nrf52840dk/nrf52840
+
   drivers.spi.spi_1M333333Hz:
     extra_configs:
       - CONFIG_TESTED_SPI_MODE=0


### PR DESCRIPTION
Added a set of test cases to verify the SPI controller's behavior when the SCK line is in an incorrect state (the opposite of the CPOL setting) just before transmission. These tests will be skipped if the GPIO SCK is not defined in the device tree.