### PR TITLE
boards: qemu: cortex_a53: enable code coverage support

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -870,6 +870,18 @@ static const struct arm_mmu_flat_range mmu_zephyr_ranges[] = {
 	  .end   = _nocache_ram_end,
 	  .attrs = MT_NORMAL_NC | MT_P_RW_U_RW | MT_DEFAULT_SECURE_STATE },
 #endif
+
+#if defined(CONFIG_COVERAGE_GCOV) && defined(CONFIG_USERSPACE)
+	/* GCOV code coverage accounting area. Instrumented code updates the
+	 * counters from user mode too, so the region needs User read-write
+	 * permissions. Placed after "zephyr_data" so it overrides the
+	 * kernel-only mapping for this sub-range.
+	 */
+	{ .name  = "gcov_bss",
+	  .start = __gcov_bss_start,
+	  .end   = __gcov_bss_end,
+	  .attrs = MT_NORMAL | MT_P_RW_U_RW | MT_DEFAULT_SECURE_STATE },
+#endif
 };
 
 static inline void add_arm_mmu_flat_range(struct arm_mmu_ptables *ptables,

--- a/arch/arm64/core/thread.c
+++ b/arch/arm64/core/thread.c
@@ -177,13 +177,21 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 	/* Top of the privileged non-user-accessible part of the stack */
 	stack_el1 = (uintptr_t)(_current->stack_obj + ARCH_THREAD_STACK_RESERVED);
 
+	/* We don't want to be disturbed when playing with SPSR and ELR.
+	 *
+	 * Lock interrupts before pinning the entry point and arguments into
+	 * x0-x3 below. arch_irq_lock() is normally inlined, but when the build
+	 * disables inlining (e.g. code coverage adds -fno-inline) it is emitted
+	 * as a real call. Such a call between the register assignments and the
+	 * eret would clobber those caller-saved registers, so keep it ahead of
+	 * them: no function call must sit between the assignments and the eret.
+	 */
+	arch_irq_lock();
+
 	register void *x0 __asm__("x0") = user_entry;
 	register void *x1 __asm__("x1") = p1;
 	register void *x2 __asm__("x2") = p2;
 	register void *x3 __asm__("x3") = p3;
-
-	/* we don't want to be disturbed when playing with SPSR and ELR */
-	arch_irq_lock();
 
 	/* set up and drop into EL0 */
 	__asm__ volatile (

--- a/boards/qemu/cortex_a53/Kconfig.defconfig
+++ b/boards/qemu/cortex_a53/Kconfig.defconfig
@@ -9,6 +9,11 @@ config BUILD_OUTPUT_BIN
 config MAX_THREAD_BYTES
 	default 3
 
+# The board has plenty of RAM to buffer the gcov coverage data, so coverage
+# reports can be gathered via the custom gcov library (COVERAGE_GCOV).
+config HAS_COVERAGE_SUPPORT
+	default y
+
 if NETWORKING
 
 choice NET_QEMU_NETWORKING

--- a/subsys/testsuite/coverage/coverage_ram.ld
+++ b/subsys/testsuite/coverage/coverage_ram.ld
@@ -9,7 +9,11 @@
 #if defined(CONFIG_ARM) || defined(CONFIG_ARM64)
 SECTION_DATA_PROLOGUE(_GCOV_BSS_SECTION_NAME,(NOLOAD),)
 {
-#ifdef CONFIG_USERSPACE
+/*
+ * ARM64 isolates userspace regions with the MMU and only needs page (region)
+ * alignment; MPU_ALIGN is a Cortex-M/A-R MPU macro and is not defined there.
+ */
+#if defined(CONFIG_USERSPACE) && !defined(CONFIG_ARM64)
 	MPU_ALIGN(__gcov_bss_end - __gcov_bss_start );
 #else  /* CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT && CONFIG_USERSPACE */
 	. = ALIGN(_region_min_align);
@@ -18,7 +22,7 @@ SECTION_DATA_PROLOGUE(_GCOV_BSS_SECTION_NAME,(NOLOAD),)
 	__gcov_bss_start = .;
 	KEEP(*(".bss.__gcov0.*"));
 
-#ifdef CONFIG_USERSPACE
+#if defined(CONFIG_USERSPACE) && !defined(CONFIG_ARM64)
 	MPU_ALIGN(__gcov_bss_end - __gcov_bss_start );
 #else  /* CONFIG_USERSPACE */
 	. = ALIGN(_region_min_align);


### PR DESCRIPTION
- **subsys: testsuite: coverage: fix gcov BSS alignment on arm64**
- **arch: arm64: map gcov coverage area with user access**
- **arch: arm64: keep user entry registers in arch_user_mode_enter**
- **boards: qemu: cortex_a53: enable code coverage support**
