### PR TITLE
ci: set_assignees: keep deferred area label on the pr

### DIFF
--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -766,6 +766,7 @@ def process_pr(gh, args, maintainer_file, number: int):
         if _deferred and _non_deferred:
             for _area in _deferred:
                 deferred_reviewers.update(_area.maintainers)
+                labels.update(_area.labels)
                 logger.debug(
                     "  area '%s' defers to other areas for '%s'; "
                     "maintainers %s added as reviewers only",


### PR DESCRIPTION
Collect the deferred area's label when a file is matched by both a deferred file-group and a non-deferred area. The deferral removed the area before labels were gathered, so its area label was silently lost even though its maintainer stayed on as a reviewer.

Follow up of #111946