### PR TITLE
serial: sam0: Fix UART error assignment flip (framing/parity)

### DIFF
--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -672,11 +672,11 @@ static int uart_sam0_err_check(const struct device *dev)
 	}
 
 	if (regs->STATUS.reg & SERCOM_USART_STATUS_FERR) {
-		err |= UART_ERROR_PARITY;
+		err |= UART_ERROR_FRAMING;
 	}
 
 	if (regs->STATUS.reg & SERCOM_USART_STATUS_PERR) {
-		err |= UART_ERROR_FRAMING;
+		err |= UART_ERROR_PARITY;
 	}
 
 #if (SAM0_SERCOM_HAS_ERROR_FLAGS)


### PR DESCRIPTION
This PR fixes a bug where framing and parity errors are swapped and misreported.