### PR TITLE
timing: rename timing_ns_get() to avoid a benchmark syscall clash

### DIFF
--- a/include/zephyr/timing/timing.h
+++ b/include/zephyr/timing/timing.h
@@ -305,7 +305,7 @@ void timing_stop(void);
  *
  * @return Monotonic timestamp in nanoseconds.
  */
-uint64_t timing_timestamp_get(void);
+uint64_t timing_ns_get(void);
 
 /**
  * @brief Return timing counter.

--- a/subsys/instrumentation/timestamp/timestamp.c
+++ b/subsys/instrumentation/timestamp/timestamp.c
@@ -19,5 +19,5 @@ int instr_timestamp_init(void)
 __no_instrumentation__
 uint64_t instr_timestamp_ns(void)
 {
-	return timing_timestamp_get();
+	return timing_ns_get();
 }

--- a/subsys/timing/timing.c
+++ b/subsys/timing/timing.c
@@ -75,7 +75,7 @@ void timing_stop(void)
 #endif
 }
 
-uint64_t timing_timestamp_get(void)
+uint64_t timing_ns_get(void)
 {
 	static struct k_spinlock lock;
 	static timing_t last;

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -55,7 +55,7 @@
 
 static inline uint64_t ctf_top_timestamp_get(void)
 {
-	return timing_timestamp_get();
+	return timing_ns_get();
 }
 
 #define CTF_EVENT(...)                                                                             \


### PR DESCRIPTION
`timing_timestamp_get()` was added to the public timing API in #112448 (commit ca3d07f70e7e). The `app_kernel` and `latency_measure` benchmarks already define a local userspace syscall of the same name to read the raw timing counter from user threads, and they include `<zephyr/timing/timing.h>`, so the declarations now collide:

```
error: static declaration of 'timing_timestamp_get' follows non-static declaration
```

This breaks those benchmark builds on `main`.

Rename the newly added API to `timing_ns_get()`. Besides resolving the clash, the name better reflects that it returns a monotonic nanosecond value rather than the raw `timing_t` counter that the benchmarks' helper returns. The benchmark syscalls are left as they are.

Reported by @nashif. Build-verified for both benchmarks (qemu_arc_hs5x) and the CTF/instrumentation consumers.
