### PR TITLE
Bluetooth: Controller: Align PAST sync_offset_us calc with CIS_IND

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -203,7 +203,7 @@ uint8_t ll_sync_create(uint8_t options, uint8_t sid, uint8_t adv_addr_type,
 #if defined(CONFIG_BT_CTLR_SYNC_TRANSFER_RECEIVER)
 void ull_sync_setup_from_sync_transfer(struct ll_conn *conn, uint16_t service_data,
 				       struct ll_sync_set *sync, struct pdu_adv_sync_info *si,
-				       int16_t conn_evt_offset, uint16_t last_pa_event_counter,
+				       uint16_t conn_evt_latency, uint16_t last_pa_event_counter,
 				       uint16_t sync_conn_event_count, uint8_t sender_sca)
 {
 	struct node_rx_past_received *se_past;
@@ -327,18 +327,46 @@ void ull_sync_setup_from_sync_transfer(struct ll_conn *conn, uint16_t service_da
 	/* offs_adjust may be 1 only if sync setup by LL_PERIODIC_SYNC_IND */
 	sync_offset_us += (PDU_ADV_SYNC_INFO_OFFS_ADJUST_GET(si) ? OFFS_ADJUST_US : 0U);
 
-	if (conn_evt_offset) {
-		int64_t conn_offset_us = (int64_t)conn_evt_offset * conn_interval_us;
+	/* Adjust sync_offset_us according to the number of connection events between the
+	 * reference connection event (identified by the Connection Event Counter field in
+	 * LL_PERIODIC_SYNC_IND) and the current connection event when the PDU is being
+	 * processed.
+	 *
+	 * `conn_evt_latency` is computed by the caller in the same way as the CIS_IND
+	 * LLCP procedure computes `instant_latency`, i.e. as an unsigned wrap-safe
+	 * difference `(current_event_counter - reference_event_counter) & 0xFFFF`, so
+	 * that:
+	 *   - Values in the range 0..0x7FFF mean the reference connection event has
+	 *     been reached or passed (i.e. the reference is at the current CE or in
+	 *     the past). In this case the elapsed time since the reference CE must be
+	 *     deducted from sync_offset_us. If the resulting anchor would fall into
+	 *     the past, jump forward by an integer number of periodic advertising
+	 *     intervals and advance the periodic advertising event counter
+	 *     accordingly.
+	 *   - Values in the range 0x8000..0xFFFF mean the reference connection event
+	 *     is still in the future. In this case the remaining time up to the
+	 *     reference CE must be added to sync_offset_us.
+	 */
+	if (conn_evt_latency == 0U) {
+		/* Reference connection event is the current one - no adjustment */
+	} else if (conn_evt_latency <= 0x7FFFU) {
+		/* Reference connection event is in the past - deduct elapsed time */
+		uint32_t elapsed_us = (uint32_t)conn_evt_latency * conn_interval_us;
 
-		if ((int64_t)sync_offset_us + conn_offset_us < 0) {
-			uint32_t total_offset_us = llabs((int64_t)sync_offset_us + conn_offset_us);
+		if (sync_offset_us > elapsed_us) {
+			sync_offset_us -= elapsed_us;
+		} else {
+			uint32_t total_offset_us = elapsed_us - sync_offset_us;
 			uint32_t sync_intervals = DIV_ROUND_UP(total_offset_us, interval_us);
 
 			lll->event_counter += sync_intervals;
 			sync_offset_us = (sync_intervals * interval_us) - total_offset_us;
-		} else {
-			sync_offset_us += conn_offset_us;
 		}
+	} else {
+		/* Reference connection event is in the future - add remaining time */
+		uint16_t remaining_evts = (uint16_t)(0U - conn_evt_latency);
+
+		sync_offset_us += (uint32_t)remaining_evts * conn_interval_us;
 	}
 
 	/* Calculate initial window widening - see Core Spec vol 6, part B, 5.1.13.1 */
@@ -1955,8 +1983,13 @@ void ull_sync_transfer_received(struct ll_conn *conn, uint16_t service_data,
 	/* LLCP should have ensured this holds */
 	LL_ASSERT_DBG(sync_conn_event_count != conn_evt_current);
 
+	/* Compute connection event latency the same way as the CIS_IND LLCP procedure
+	 * computes `instant_latency`: an unsigned wrap-safe difference where values
+	 * in 0..0x7FFF indicate the reference CE has been reached/passed, and values
+	 * in 0x8000..0xFFFF indicate the reference CE is still in the future.
+	 */
 	ull_sync_setup_from_sync_transfer(conn, service_data, sync, si,
-					  conn_event_count - conn_evt_current,
+					  (conn_evt_current - conn_event_count) & 0xFFFFU,
 					  last_pa_event_counter, sync_conn_event_count,
 					  sca);
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -218,6 +218,7 @@ void ull_sync_setup_from_sync_transfer(struct ll_conn *conn, uint16_t service_da
 	uint32_t interval_us;
 	uint32_t slot_us;
 	uint32_t ticks_anchor;
+	uint32_t remainder_us;
 	uint8_t chm_last;
 	uint32_t ret;
 	uint16_t interval;
@@ -433,6 +434,15 @@ void ull_sync_setup_from_sync_transfer(struct ll_conn *conn, uint16_t service_da
 
 	ticks_anchor = conn->llcp.prep.ticks_at_expire;
 
+	/* Fold the ACL prepare fractional remainder into sync_offset_us so that
+	 * sub-tick precision from the connection anchor is preserved on
+	 * platforms where the ticker resolution is coarser than 1 us (e.g. nRF52
+	 * with a 32.768 kHz LFCLK). Mirrors the CIS pattern in cig_offset_calc().
+	 */
+	remainder_us = conn->llcp.prep.remainder;
+	hal_ticker_remove_jitter(&ticks_anchor, &remainder_us);
+	sync_offset_us += remainder_us;
+
 #if defined(CONFIG_BT_PERIPHERAL)
 	if (conn->lll.role == BT_HCI_ROLE_PERIPHERAL) {
 		/* Compensate for window widening */
@@ -440,10 +450,11 @@ void ull_sync_setup_from_sync_transfer(struct ll_conn *conn, uint16_t service_da
 	}
 #endif /* CONFIG_BT_PERIPHERAL */
 
-	ret = ticker_start(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
+	ret = ticker_start_us(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_ULL_HIGH,
 			   (TICKER_ID_SCAN_SYNC_BASE + sync_handle),
 			   ticks_anchor,
 			   HAL_TICKER_US_TO_TICKS(sync_offset_us),
+			   HAL_TICKER_REMAINDER(sync_offset_us),
 			   HAL_TICKER_US_TO_TICKS(interval_us),
 			   HAL_TICKER_REMAINDER(interval_us),
 			   TICKER_NULL_LAZY,


### PR DESCRIPTION
The `ull_sync_setup_from_sync_transfer()` function computed the adjustment to `sync_offset_us` from the `Connection Event Counter` carried by LL_PERIODIC_SYNC_IND using a signed difference (`conn_event_count - conn_evt_current`) narrowed to `int16_t`. The narrowing conversion of an unsigned subtraction result is implementation-defined, and the resulting arithmetic mixed signed and unsigned types.

Refactor the computation to mirror the CIS_IND LLCP procedure handling of `instant_latency` in `rp_cc_check_instant_by_counter()` and `lp_cc_check_instant()`: compute the difference as an unsigned wrap-safe value `(conn_evt_current - conn_event_count) & 0xFFFF` and dispatch on the `<= 0x7FFF` range test.

Also explicitly handle both directions:
- Reference connection event in the past (peripheral processes the LL_PERIODIC_SYNC_IND at a connection event later than the one indicated by the PDU): deduct the elapsed time from `sync_offset_us`; when the resulting anchor would fall into the past, advance the periodic advertising event counter by the required whole number of periodic advertising intervals.
- Reference connection event in the future: add the remaining time to `sync_offset_us`.

The behavior for a valid signed offset in the range supported by the previous implementation is preserved, while the arithmetic is now portable and matches the CIS_IND pattern.

Assisted-by: Claude:claude-sonnet-4.6