### PR TITLE
MAINTAINERS: add maintainer for Broadcom Platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -899,11 +899,17 @@ Bouffalolab Platforms:
     - "platform: Bouffalo Lab"
 
 Broadcom Platforms:
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - walidbadar
   files:
     - dts/*/broadcom/
     - soc/brcm/
     - boards/brcm/
+    - boards/raspberrypi/rpi_4b/
+    - boards/raspberrypi/rpi_5/
+  labels:
+    - "platform: Broadcom"
 
 Build Dashboard:
   status: maintained


### PR DESCRIPTION
Add walidbadar as a maintainer on the Broadcom Platforms.

Please see https://github.com/zephyrproject-rtos/zephyr/issues/112703 for list of contributions.