### PR TITLE
dts: wch: fix the boot by reverting the flash start address change

### DIFF
--- a/dts/riscv/wch/ch32v0/ch32v003.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v003.dtsi
@@ -55,9 +55,9 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			flash0: flash@8000000 {
+			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				reg = <0x8000000 DT_SIZE_K(16)>;
+				reg = <0 DT_SIZE_K(16)>;
 			};
 		};
 

--- a/dts/riscv/wch/ch32v0/ch32v006.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v006.dtsi
@@ -55,9 +55,9 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			flash0: flash@8000000 {
+			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				reg = <0x8000000 DT_SIZE_K(62)>;
+				reg = <0 DT_SIZE_K(62)>;
 			};
 		};
 


### PR DESCRIPTION
script to always use the address from the build configuration. It also updated the ch32v003 and ch32v006 Devicetree to put the flash at the correct location, but this broke the boot as the the startup code also needed to be updated to match.

Mitigate by reverting the Devicetree change. The startup code will be fixed in #111733 and rollback this rollback.

Tested by running `samples/basic/blink` on the ch32v003evt.