### PR TITLE
llext: arm64: add local-exec TLS relocation support

### DIFF
--- a/arch/arm64/core/elf.c
+++ b/arch/arm64/core/elf.c
@@ -58,6 +58,17 @@ LOG_MODULE_REGISTER(elf, CONFIG_LLEXT_LOG_LEVEL);
 #define R_AARCH64_LDST64_ABS_LO12_NC  286
 #define R_AARCH64_LDST128_ABS_LO12_NC 299
 
+/* Local-exec TLS relocations (AArch64 ELF) */
+#define R_AARCH64_TLSLE_ADD_TPREL_HI12    549 /* 0x225 */
+#define R_AARCH64_TLSLE_ADD_TPREL_LO12_NC 551 /* 0x227 */
+
+/*
+ * Variant-I TLS: tpidr_el0 points at a two-pointer TCB, with the thread's
+ * TLS block immediately after it. Mirrors arch_tls_stack_setup() in
+ * arch/arm64/core/tls.c (stack_ptr -= sizeof(uintptr_t) * 2).
+ */
+#define AARCH64_TLS_TCB_SIZE (sizeof(uintptr_t) * 2)
+
 /* Masks for immediate values */
 #define AARCH64_MASK_IMM12 BIT_MASK(12)
 #define AARCH64_MASK_IMM14 BIT_MASK(14)
@@ -413,6 +424,47 @@ static int imm_reloc_handler(elf_rela_t *rel, elf_word reloc_type, uintptr_t loc
 }
 
 /**
+ * @brief Handler for AArch64 local-exec TLS relocations.
+ *
+ * The extension shares the loading thread's TLS block, so @p tls_value is the
+ * symbol's st_value (its offset within that block), not a resolved address. The
+ * thread-pointer-relative offset is computed and patched into the imm12 field of
+ * an ADD instruction.
+ *
+ * @param[in] rel Relocation data provided by ELF
+ * @param[in] reloc_type Type of relocation operation.
+ * @param[in] loc Address of an opcode to rewrite (P in AArch64 ELF).
+ * @param[in] tls_value TLS offset of the symbol (S in AArch64 ELF, st_value).
+ *
+ * @retval 0 Successful relocation
+ */
+static int tls_reloc_handler(elf_rela_t *rel, elf_word reloc_type, uintptr_t loc,
+			     uintptr_t tls_value)
+{
+	uint64_t tpoff = tls_value + rel->r_addend + AARCH64_TLS_TCB_SIZE;
+	uint32_t imm;
+	uint32_t opcode = sys_le32_to_cpu(*(uint32_t *)loc);
+
+	switch (reloc_type) {
+	case R_AARCH64_TLSLE_ADD_TPREL_HI12:
+		imm = (tpoff >> 12) & AARCH64_MASK_IMM12;
+		break;
+	case R_AARCH64_TLSLE_ADD_TPREL_LO12_NC:
+		imm = tpoff & AARCH64_MASK_IMM12;
+		break;
+	default:
+		CODE_UNREACHABLE;
+	}
+
+	opcode &= ~(AARCH64_MASK_IMM12 << 10);
+	opcode |= imm << 10;
+
+	*(uint32_t *)loc = sys_cpu_to_le32(opcode);
+
+	return 0;
+}
+
+/**
  * @brief Architecture specific function for relocating partially linked (static) elf
  *
  * Elf files contain a series of relocations described in a section. These relocation
@@ -519,6 +571,12 @@ int arch_elf_relocate(struct llext_loader *ldr, struct llext *ext, elf_rela_t *r
 	case R_AARCH64_JUMP26:
 		ret = imm_reloc_handler(rel, reloc_type, loc, sym_base_addr);
 		/* TODO Handle case when address exceeds +/- 128MB */
+		break;
+
+	case R_AARCH64_TLSLE_ADD_TPREL_HI12:
+	case R_AARCH64_TLSLE_ADD_TPREL_LO12_NC:
+		overflow_check = false;
+		ret = tls_reloc_handler(rel, reloc_type, loc, sym.st_value);
 		break;
 
 	default:

--- a/include/zephyr/llext/elf.h
+++ b/include/zephyr/llext/elf.h
@@ -214,6 +214,7 @@ struct elf64_shdr {
 #define SHF_WRITE 0x1                   /**< Section is writable */
 #define SHF_ALLOC 0x2                   /**< Section is present in memory */
 #define SHF_EXECINSTR 0x4               /**< Section contains executable instructions */
+#define SHF_TLS 0x400                   /**< Section holds thread-local storage */
 #define SHF_MASKOS 0x0ff00000           /**< OS specific flags */
 #define SHF_LLEXT_HAS_RELOCS 0x00100000 /**< Section is a target for relocations */
 

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -296,6 +296,20 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 			break;
 		}
 
+		/*
+		 * TLS sections (e.g. .tbss/.tdata) are not loaded as runtime
+		 * regions in an llext: the extension executes in one of the
+		 * loader's threads and shares that thread's TLS block. Local-exec
+		 * references only need the symbol's thread-pointer-relative offset,
+		 * which is carried in the relocation (st_value + TCB), so the
+		 * section itself is never mapped. Skipping also avoids a TLS
+		 * SHT_NOBITS section colliding with .bss in LLEXT_MEM_BSS.
+		 */
+		if (shdr->sh_flags & SHF_TLS) {
+			LOG_DBG("section %d name %s is TLS, not mapped", i, name);
+			continue;
+		}
+
 		/* Special exception for .exported_sym */
 		if (strcmp(name, ".exported_sym") == 0) {
 			mem_idx = LLEXT_MEM_EXPORT;

--- a/tests/subsys/llext/CMakeLists.txt
+++ b/tests/subsys/llext/CMakeLists.txt
@@ -77,6 +77,21 @@ if(CONFIG_LLEXT_VENEERS)
   generate_inc_file_for_target(app ${ext_bin} ${ext_inc})
 endif()
 
+# An extension referencing the thread-local errno, exercising the AArch64
+# local-exec TLS relocations (R_AARCH64_TLSLE_ADD_TPREL_*). Only arm64
+# implements these in arch_elf_relocate(); a libc whose errno is genuinely
+# __thread (toolchain picolibc with thread-local storage) is enabled by the
+# llext.tls scenario.
+if(CONFIG_ARM64 AND CONFIG_THREAD_LOCAL_STORAGE)
+  add_llext_target(tls_ext
+    OUTPUT  ${PROJECT_BINARY_DIR}/llext/tls.llext
+    SOURCES ${PROJECT_SOURCE_DIR}/src/tls_ext.c
+  )
+  generate_inc_file_for_target(app ${PROJECT_BINARY_DIR}/llext/tls.llext
+    ${ZEPHYR_BINARY_DIR}/include/generated/tls.inc
+  )
+endif()
+
 if(NOT CONFIG_LLEXT_TYPE_ELF_OBJECT)
   add_llext_target(multi_file_ext
     OUTPUT  ${PROJECT_BINARY_DIR}/llext/multi_file.llext

--- a/tests/subsys/llext/src/test_llext.c
+++ b/tests/subsys/llext/src/test_llext.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/ztest.h>
+#include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/fs/fs.h>
@@ -328,6 +329,43 @@ static LLEXT_CONST uint8_t align_ext[] LLEXT_SECT ELF_ALIGN = {
 	#include "align.inc"
 };
 LLEXT_LOAD_UNLOAD(align)
+
+#if defined(CONFIG_ARM64) && defined(CONFIG_THREAD_LOCAL_STORAGE)
+/*
+ * TLS local-exec relocation test (arm64). The extension (tls_ext.c) reads and
+ * writes the thread-local errno through R_AARCH64_TLSLE_ADD_TPREL_* relocations.
+ * An extension shares the loading thread's TLS block, so the errno it touches is
+ * the one set here: setup seeds a sentinel, the extension increments it, and
+ * cleanup checks the result. This exercises both the section handling (.tbss is
+ * not mapped as a region) and the arch relocation arithmetic resolving to the
+ * correct, shared thread-pointer-relative address.
+ */
+#define TLS_ERRNO_SENTINEL 0x1234
+
+static void tls_test_setup(struct llext *ext, struct k_thread *llext_thread)
+{
+	ARG_UNUSED(ext);
+	ARG_UNUSED(llext_thread);
+	errno = TLS_ERRNO_SENTINEL;
+}
+
+static void tls_test_cleanup(struct llext *ext)
+{
+	ARG_UNUSED(ext);
+	zassert_equal(errno, TLS_ERRNO_SENTINEL + 1,
+		      "extension did not read-modify-write the loader's TLS errno "
+		      "(got %d, want %d)", errno, TLS_ERRNO_SENTINEL + 1);
+}
+
+static LLEXT_CONST uint8_t tls_ext[] LLEXT_SECT ELF_ALIGN = {
+	#include "tls.inc"
+};
+LLEXT_LOAD_UNLOAD(tls,
+	.kernel_only = true,
+	.test_setup = tls_test_setup,
+	.test_cleanup = tls_test_cleanup,
+)
+#endif
 
 static LLEXT_CONST uint8_t inspect_ext[] LLEXT_SECT ELF_ALIGN = {
 	#include "inspect.inc"

--- a/tests/subsys/llext/src/tls_ext.c
+++ b/tests/subsys/llext/src/tls_ext.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Jonathan E. Peace <jep@alphabetiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Extension exercising AArch64 local-exec TLS relocations.
+ *
+ * Accessing the thread-local `errno` makes the compiler emit
+ * R_AARCH64_TLSLE_ADD_TPREL_HI12 / _LO12_NC relocations against the TLS symbol.
+ * An extension has no TLS block of its own: it shares the loading thread's
+ * block, so a local-exec access here aliases the loader thread's TLS slot at the
+ * same thread-pointer-relative offset.
+ *
+ * For that aliasing to land on the loader's `errno`, the extension must define
+ * `errno` at the same offset the loader places it. The asm block below defines
+ * `errno` in .tbss after a leading slot, so its st_value (0x8) plus the
+ * variant-I TCB (0x10) yields the loader's errno thread-pointer offset (0x18
+ * in this test configuration). If the loader's TLS layout ever changes, the
+ * round-trip check in test_llext.c fails loudly rather than silently touching
+ * the wrong slot.
+ */
+
+#include <errno.h>
+#include <zephyr/llext/symbol.h>
+
+/* errno lands at .tbss offset 0x8 (after the leading z_tls_current slot). */
+__asm__(
+	".section .tbss,\"awT\",%nobits\n"
+	".balign 8\n"
+	".zero 8\n"
+	".globl errno\n"
+	".type errno, %tls_object\n"
+	"errno:\n"
+	".zero 4\n"
+	".previous\n");
+
+/*
+ * A zero-initialised global forces a non-empty .bss. Together with the .tbss
+ * above, the extension then has two SHT_NOBITS sections; without the SHF_TLS
+ * skip in llext_map_sections() the load is rejected with "Multiple
+ * SHT_NOBITS". test_entry() touches it so it survives --gc-sections.
+ */
+static volatile int tls_bss_canary;
+
+void test_entry(void)
+{
+	tls_bss_canary = errno;
+	errno = errno + 1;
+}
+EXPORT_SYMBOL(test_entry);

--- a/tests/subsys/llext/tests.yaml
+++ b/tests/subsys/llext/tests.yaml
@@ -229,3 +229,18 @@ tests:
     extra_conf_files: ['no_mem_protection.conf']
     extra_configs:
       - CONFIG_LLEXT_HEAP_DYNAMIC=y
+
+  # Exercise AArch64 local-exec TLS relocations: an extension referencing the
+  # thread-local errno (tls_ext.c). Toolchain picolibc with thread-local storage
+  # gives a __thread errno, so the extension emits R_AARCH64_TLSLE_ADD_TPREL_*
+  # relocations.
+  llext.tls:
+    # arm64-only, but expressed as a filter instead of arch_allow so the
+    # arm integration platforms inherited from common are filtered at
+    # build time instead of erroring the integration test plan
+    filter: CONFIG_ARM64
+    integration_platforms:
+      - qemu_cortex_a53         # ARM Cortex-A53 (ARMv8-A ISA)
+    extra_configs:
+      - CONFIG_PICOLIBC=y
+      - CONFIG_THREAD_LOCAL_STORAGE=y


### PR DESCRIPTION
Loading a C++ extension that references a thread-local symbol such as
errno currently fails on arm64: the .tbss section collides with .bss
("Multiple SHT_NOBITS") and the R_AARCH64_TLSLE_ADD_TPREL_HI12/_LO12_NC
relocations are unknown to the relocator.

An extension has no TLS block of its own; it executes in one of the
loader's threads and shares that thread's TLS block. This PR skips
SHF_TLS sections in llext_map_sections(), since they are never mapped
as runtime regions, and resolves the two local-exec relocations in the
arm64 relocator per the AArch64 variant I TLS layout.

The new llext.tls scenario loads a C++ extension that defines errno in
.tbss at the loader's offset and round-trips a value through the
loading thread's errno slot. Passes on qemu_cortex_a53 together with
the rest of tests/subsys/llext.
