### PR TITLE
cmake: llext: don't force -mthumb on ARMv6-A extensions

### DIFF
--- a/cmake/compiler/gcc/target_arm.cmake
+++ b/cmake/compiler/gcc/target_arm.cmake
@@ -25,7 +25,7 @@ if(CONFIG_FPU)
     set(FORCE_FP_HARDABI TRUE)
   endif()
 
-  if    (CONFIG_FP_HARDABI OR FORCE_FP_HARDABI)
+  if(CONFIG_FP_HARDABI OR FORCE_FP_HARDABI)
     list(APPEND ARM_C_FLAGS   -mfloat-abi=hard)
   elseif(CONFIG_FP_SOFTABI)
     list(APPEND ARM_C_FLAGS   -mfloat-abi=softfp)
@@ -33,7 +33,7 @@ if(CONFIG_FPU)
 endif()
 
 if(CONFIG_FP16)
-  if    (CONFIG_FP16_IEEE)
+  if(CONFIG_FP16_IEEE)
     list(APPEND ARM_C_FLAGS   -mfp16-format=ieee)
   elseif(CONFIG_FP16_ALT)
     list(APPEND ARM_C_FLAGS   -mfp16-format=alternative)
@@ -57,11 +57,21 @@ set(LLEXT_REMOVE_FLAGS
   -Os
 )
 
-# Flags to be added to llext code compilation
-set(LLEXT_APPEND_FLAGS
-  -mlong-calls
-  -mthumb
-)
+# Flags to be added to llext code compilation. -mthumb must not be forced
+# on ARMv6-A (ARM1176), where the kernel runs in ARM mode and Thumb
+# extensions break the interworking the linker emits. -mlong-calls stays
+# on all targets so extensions can call kernel functions outside their
+# code section's PC-relative branch range.
+if(CONFIG_CPU_AARCH32_ARMV6)
+  set(LLEXT_APPEND_FLAGS
+    -mlong-calls
+  )
+else()
+  set(LLEXT_APPEND_FLAGS
+    -mlong-calls
+    -mthumb
+  )
+endif()
 
 list(APPEND LLEXT_EDK_REMOVE_FLAGS
     --sysroot=.*


### PR DESCRIPTION
LLEXT_APPEND_FLAGS is "-mlong-calls -mthumb" for every GCC ARM target.
That is right on Cortex-M, which is Thumb-only, but wrong on ARMv6-A
where the kernel and the llext loader run in ARM mode: forcing
extensions to Thumb breaks the interworking the linker emits, and
inline-asm long-call trampolines loading a target address with
movw/movt fail to assemble on -mcpu=arm1176jzf-s.

Split the flag list so CPU_AARCH32_ARMV6 gets only -mlong-calls. Other
targets keep the existing behaviour (built tests/subsys/llext for
mps2/an385 to confirm the Cortex-M path still emits -mthumb).

Verified on Raspberry Pi Zero W (BCM2835, ARM1176JZF-S): ARMv6-A
extensions build, load and run.

Also removes two stray spaces before if( parens in the same file,
flagged by CMakeStyle.

Depends on #112663, which introduces CONFIG_CPU_AARCH32_ARMV6.
