### PR TITLE
ethernet: dsa: Avoid DSA interface name clashes

### DIFF
--- a/subsys/net/l2/ethernet/dsa/dsa_port.c
+++ b/subsys/net/l2/ethernet/dsa/dsa_port.c
@@ -85,6 +85,8 @@ static void dsa_port_phylink_change(const struct device *phydev, struct phy_link
 
 static void dsa_port_iface_init(struct net_if *iface)
 {
+	static unsigned int dsa_iface_idx;
+
 	const struct device *dev = net_if_get_device(iface);
 	const struct dsa_port_config *cfg = dev->config;
 	char name[INTERFACE_NAME_LEN];
@@ -92,7 +94,8 @@ static void dsa_port_iface_init(struct net_if *iface)
 	int ret;
 
 	/* Set interface name */
-	snprintk(name, sizeof(name), "swp%d", cfg->port_idx);
+	snprintk(name, sizeof(name), "swp%u", dsa_iface_idx);
+	dsa_iface_idx++;
 	net_if_set_name(iface, name);
 
 	ret = net_eth_mac_load(&cfg->mcfg, mac_addr);


### PR DESCRIPTION
I have been playing around with DSA cascading for a project. While I do intend to contribute the changes required to support cascading soonish, I have a few things I would like merged first. This changeset is one of them.

Deriving the `swpX` interface names from the port index works flawlessly so long as only a single switch is connected. Connecting more than one, however, causes interface name clashes, resulting in the interfaces corresponding to the ports of all switches but the one that happens to be initialized first to retain their `ethX` names.  

Address the above issue by using a global counter.