### PR TITLE
drivers: ethernet: eth_stm32_hal_common: Disable MAC filter for DSA

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -182,4 +182,15 @@ config ETH_STM32_MULTICAST_FILTER
 	  other multicast is dropped by the MAC. If disabled then all
 	  multicast is received by the MAC.
 
+config ETH_STM32_HAVE_MACPFR
+	bool "ETH_MACPFR register available"
+	default y
+	depends on SOC_SERIES_STM32H5X \
+		|| SOC_SERIES_STM32H7X \
+		|| SOC_SERIES_STM32H7RSX \
+		|| SOC_SERIES_STM32MP13X \
+		|| SOC_SERIES_STM32N6X
+	help
+	  Set for SoC series with the ETH_MACPFR register available.
+
 endif # ETH_STM32_HAL

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -155,6 +155,13 @@ static int eth_initialize(const struct device *dev)
 		return -EIO;
 	}
 
+#ifdef CONFIG_ETH_STM32_HAVE_MACPFR
+	if (IS_ENABLED(CONFIG_NET_DSA)) {
+		LOG_DBG("Disabling MAC filter");
+		heth->Instance->MACPFR |= ETH_MACPFR_RA;
+	}
+#endif
+
 	LOG_DBG("MAC %02x:%02x:%02x:%02x:%02x:%02x", dev_data->mac_addr[0], dev_data->mac_addr[1],
 		dev_data->mac_addr[2], dev_data->mac_addr[3], dev_data->mac_addr[4],
 		dev_data->mac_addr[5]);


### PR DESCRIPTION
Several STM32 series come with MACs employing built-in, ingress packet filters. By default, these discard packets whose DMAC field does not match the address programmed into the MAC. This causes problems when using DSA on STM32s. More specifically, since each DSA user port receives a unique MAC address whereas the filtering is based only on that of the conduit port, keeping the filtering enabled causes the MAC to drop all user port packets.

While at least a few series allow additional addresses to be added to the packet filter tables, doing so without extending the Ethernet API would be tricky. Instead, simply update the driver s.t. it completely disables MAC address-based packet filtering when CONFIG_NET_DSA is enabled.

Judging by the reference manuals, all STM32 SoC series supported by Zephyr save for the STM32F-based ones provide an ETH_MACPFR register whose most significant bit determines whether or not packet filtering is enabled.