### PR TITLE
pthread: Unwind & execute all cleanup handler where required (but async)

### DIFF
--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -93,7 +93,7 @@ typedef unsigned long timer_t;
 #if !defined(_PTHREAD_ATTR_T_DECLARED) && !defined(__pthread_attr_t_defined)
 typedef struct {
 	void *stack;
-	unsigned int details[2];
+	uint32_t details[2];
 } pthread_attr_t;
 #define _PTHREAD_ATTR_T_DECLARED
 #define __pthread_attr_t_defined

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -802,6 +802,10 @@ static inline void unpend_all(_wait_q_t *wait_q)
 	}
 }
 
+#if defined(CONFIG_POSIX_THREADS)
+extern void posix_thread_kthread_exit(struct k_thread *thread);
+#endif /* CONFIG_POSIX_THREADS */
+
 #ifdef CONFIG_THREAD_ABORT_HOOK
 extern void thread_abort_hook(struct k_thread *thread);
 #endif /* CONFIG_THREAD_ABORT_HOOK */
@@ -882,6 +886,9 @@ static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state
 
 		SYS_PORT_TRACING_FUNC(k_thread, sched_abort, thread);
 
+#ifdef CONFIG_POSIX_THREADS
+		posix_thread_kthread_exit(thread);
+#endif /* CONFIG_POSIX_THREADS */
 		z_thread_monitor_exit(thread);
 #ifdef CONFIG_THREAD_ABORT_HOOK
 		thread_abort_hook(thread);

--- a/subsys/portability/posix/options/posix_internal.h
+++ b/subsys/portability/posix/options/posix_internal.h
@@ -44,15 +44,20 @@ struct posix_thread_attr
 	bool cancelstate: 1;
 	bool canceltype: 1;
 	bool detachstate: 1;
+	bool is_external: 1;
 };
 
 struct posix_thread {
+	/* `struct k_thread` storage for threads created via `pthread_create` */
 	struct k_thread thread;
+
+	/* pointer to related Zephyr thread either `thread` (`pthread_create`) or external. */
+	k_tid_t z_thread;
 
 	/* List nodes for pthread_cleanup_push() / pthread_cleanup_pop() */
 	sys_slist_t cleanup_list;
 
-	/* List node for ready_q, run_q, or done_q */
+	/* List node for ready_q, run_q, done_q or external_q */
 	sys_dnode_t q_node;
 
 	/* List of keys that thread has called pthread_setspecific() on */
@@ -124,6 +129,7 @@ static inline pthread_t mark_pthread_obj_uninitialized(pthread_t obj)
 }
 
 struct posix_thread *to_posix_thread(pthread_t pth);
+k_tid_t pthread_to_zephyr_thread(pthread_t pth);
 
 /* get and possibly initialize a posix_mutex */
 struct k_mutex *to_posix_mutex(pthread_mutex_t *mu);

--- a/subsys/portability/posix/options/posix_internal.h
+++ b/subsys/portability/posix/options/posix_internal.h
@@ -108,17 +108,17 @@ struct pthread_key_data {
 	pthread_thread_data thread_data;
 };
 
-static inline bool is_pthread_obj_initialized(uint32_t obj)
+static inline bool is_pthread_obj_initialized(pthread_t obj)
 {
 	return (obj & PTHREAD_OBJ_MASK_INIT) != 0;
 }
 
-static inline uint32_t mark_pthread_obj_initialized(uint32_t obj)
+static inline pthread_t mark_pthread_obj_initialized(size_t obj)
 {
 	return obj | PTHREAD_OBJ_MASK_INIT;
 }
 
-static inline uint32_t mark_pthread_obj_uninitialized(uint32_t obj)
+static inline pthread_t mark_pthread_obj_uninitialized(pthread_t obj)
 {
 	return obj & ~PTHREAD_OBJ_MASK_INIT;
 }

--- a/subsys/portability/posix/options/pthread.c
+++ b/subsys/portability/posix/options/pthread.c
@@ -505,20 +505,28 @@ void __z_pthread_cleanup_push(void *cleanup[3], void (*routine)(void *arg), void
 	}
 }
 
+static struct __pthread_cleanup *posix_thread_cleanup_pop(sys_slist_t *cleanup_listp)
+{
+	sys_snode_t *node = sys_slist_get(cleanup_listp);
+
+	__ASSERT_NO_MSG(node != NULL);
+	struct __pthread_cleanup *c =
+		CONTAINER_OF(node, struct __pthread_cleanup, node); /* NOSONAR */
+
+	__ASSERT_NO_MSG(c != NULL);
+	__ASSERT_NO_MSG(c->routine != NULL);
+	return c;
+}
+
 void __z_pthread_cleanup_pop(int execute)
 {
-	sys_snode_t *node;
 	struct __pthread_cleanup *c = NULL;
 	struct posix_thread *t = NULL;
 
 	K_SPINLOCK(&pthread_pool_lock) {
 		t = to_posix_thread(posix_thread_self(false));
 		__ASSERT_NO_MSG(t != NULL);
-		node = sys_slist_get(&t->cleanup_list);
-		__ASSERT_NO_MSG(node != NULL);
-		c = CONTAINER_OF(node, struct __pthread_cleanup, node);
-		__ASSERT_NO_MSG(c != NULL);
-		__ASSERT_NO_MSG(c->routine != NULL);
+		c = posix_thread_cleanup_pop(&t->cleanup_list);
 	}
 	if (execute) {
 		c->routine(c->arg);
@@ -716,14 +724,39 @@ static K_WORK_DELAYABLE_DEFINE(posix_thread_recycle_work, posix_thread_recycle_w
 
 extern struct sys_sem pthread_key_lock;
 
-static void posix_thread_finalize(struct posix_thread *t, void *retval)
+static void posix_thread_finalize_cleanuplist(struct posix_thread *t, bool exec_cleanup)
+{
+	if (exec_cleanup) {
+		sys_slist_t cleanup_list = SYS_SLIST_STATIC_INIT(&cleanup_list);
+
+		K_SPINLOCK(&pthread_pool_lock) {
+			while (!sys_slist_is_empty(&t->cleanup_list)) {
+				sys_slist_append(&cleanup_list, sys_slist_get(&t->cleanup_list));
+			}
+		}
+		struct __pthread_cleanup *c;
+
+		while (!sys_slist_is_empty(&cleanup_list)) {
+			c = posix_thread_cleanup_pop(&cleanup_list);
+			c->routine(c->arg);
+		}
+	} else {
+		/* Avoid access to potentially unwound `__pthread_cleanup` stack entries,
+		 * possible via `return`, `goto`, `longjmp`, etc.
+		 */
+		K_SPINLOCK(&pthread_pool_lock) {
+			sys_slist_init(&t->cleanup_list);
+		}
+	}
+}
+
+static void posix_thread_finalize_keyvaluepairs(struct posix_thread *t)
 {
 	sys_snode_t *node_l, *node_s;
 	pthread_key_obj *key_obj;
 	pthread_thread_data *thread_spec_data;
 	sys_snode_t *node_key_data, *node_key_data_s, *node_key_data_prev = NULL;
 	struct pthread_key_data *key_data;
-	k_tid_t z_thread = NULL;
 
 	SYS_SLIST_FOR_EACH_NODE_SAFE(&t->key_list, node_l, node_s) {
 		thread_spec_data = (pthread_thread_data *)node_l;
@@ -753,6 +786,14 @@ static void posix_thread_finalize(struct posix_thread *t, void *retval)
 			}
 		}
 	}
+}
+
+static void posix_thread_finalize(struct posix_thread *t, bool exec_cleanup, void *retval)
+{
+	k_tid_t z_thread = NULL;
+
+	posix_thread_finalize_cleanuplist(t, exec_cleanup);
+	posix_thread_finalize_keyvaluepairs(t);
 
 	/* move thread from run_q to done_q */
 	K_SPINLOCK(&pthread_pool_lock) {
@@ -787,7 +828,8 @@ static void zephyr_thread_wrapper(void *arg1, void *arg2, void *arg3)
 		__ASSERT_NO_MSG(err == 0 || err == PTHREAD_BARRIER_SERIAL_THREAD);
 	}
 
-	posix_thread_finalize(t, fun_ptr(arg1));
+	/* No execution of cleanup-handler on normal return from user-function. */
+	posix_thread_finalize(t, false, fun_ptr(arg1));
 
 	CODE_UNREACHABLE;
 }
@@ -1021,7 +1063,8 @@ int pthread_setcancelstate(int state, int *oldstate)
 
 	if (ret == 0 && state == PTHREAD_CANCEL_ENABLE &&
 	    cancel_type == PTHREAD_CANCEL_ASYNCHRONOUS && cancel_pending) {
-		posix_thread_finalize(t, PTHREAD_CANCELED);
+		/* TODO: execution of cleanup-handler on target-thread for async-cancel */
+		posix_thread_finalize(t, false, PTHREAD_CANCELED);
 	}
 
 	return ret;
@@ -1085,7 +1128,7 @@ void pthread_testcancel(void)
 	}
 
 	if (cancel_pended) {
-		posix_thread_finalize(t, PTHREAD_CANCELED);
+		posix_thread_finalize(t, true, PTHREAD_CANCELED);
 	}
 }
 
@@ -1122,7 +1165,8 @@ int pthread_cancel(pthread_t pthread)
 
 	if (ret == 0 && cancel_state == PTHREAD_CANCEL_ENABLE &&
 	    cancel_type == PTHREAD_CANCEL_ASYNCHRONOUS) {
-		posix_thread_finalize(t, PTHREAD_CANCELED);
+		/* TODO: execution of cleanup-handler on target-thread for async-cancel */
+		posix_thread_finalize(t, false, PTHREAD_CANCELED);
 	}
 
 	return ret;
@@ -1305,7 +1349,7 @@ void pthread_exit(void *retval)
 		CODE_UNREACHABLE;
 	}
 
-	posix_thread_finalize(self, retval);
+	posix_thread_finalize(self, true, retval);
 	CODE_UNREACHABLE;
 }
 

--- a/subsys/portability/posix/options/pthread.c
+++ b/subsys/portability/posix/options/pthread.c
@@ -82,6 +82,9 @@ BUILD_ASSERT((PTHREAD_CANCEL_ENABLE == 0 || PTHREAD_CANCEL_DISABLE == 0) &&
 BUILD_ASSERT(CONFIG_POSIX_PTHREAD_ATTR_STACKSIZE_BITS + CONFIG_POSIX_PTHREAD_ATTR_GUARDSIZE_BITS <=
 	     32);
 
+/* ensure public `pthread_attr_t` covers whole memory requirements of private `struct posix_thread_attr` */
+BUILD_ASSERT(sizeof(struct posix_thread_attr) <= sizeof(pthread_attr_t));
+
 static void posix_thread_recycle(void);
 
 static sys_dlist_t posix_thread_q[] = {

--- a/subsys/portability/posix/options/pthread.c
+++ b/subsys/portability/posix/options/pthread.c
@@ -85,6 +85,10 @@ BUILD_ASSERT(CONFIG_POSIX_PTHREAD_ATTR_STACKSIZE_BITS + CONFIG_POSIX_PTHREAD_ATT
 /* ensure public `pthread_attr_t` covers whole memory requirements of private `struct posix_thread_attr` */
 BUILD_ASSERT(sizeof(struct posix_thread_attr) <= sizeof(pthread_attr_t));
 
+/* ensure public unsigned `pthread_t` type is sufficient as the private `posix_thread_pool` index (size_t). */
+BUILD_ASSERT(CONFIG_POSIX_THREAD_THREADS_MAX <= (pthread_t)~0);
+BUILD_ASSERT(PTHREAD_OBJ_MASK_INIT <= (pthread_t)~0);
+
 static void posix_thread_recycle(void);
 
 static sys_dlist_t posix_thread_q[] = {

--- a/subsys/portability/posix/options/pthread.c
+++ b/subsys/portability/posix/options/pthread.c
@@ -17,9 +17,11 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/posix/pthread.h>
 #include <zephyr/posix/unistd.h>
+#include <zephyr/spinlock.h>
 #include <zephyr/sys/sem.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
+#include <kthread.h>
 
 #define ZEPHYR_TO_POSIX_PRIORITY(_zprio)                                                           \
 	(((_zprio) < 0) ? (-1 * ((_zprio) + 1)) : (CONFIG_NUM_PREEMPT_PRIORITIES - (_zprio)-1))
@@ -40,12 +42,15 @@ LOG_MODULE_REGISTER(pthread, CONFIG_PTHREAD_LOG_LEVEL);
 #ifdef CONFIG_DYNAMIC_THREAD_STACK_SIZE
 #define DYNAMIC_STACK_SIZE CONFIG_DYNAMIC_THREAD_STACK_SIZE
 #else
+/* 0==DYNAMIC_STACK_SIZE renders attribute useless for `pthread_create`.
+ * Keep this use-case for backward-compatibility (ZTests).
+ */
 #define DYNAMIC_STACK_SIZE 0
 #endif
 
 static inline size_t __get_attr_stacksize(const struct posix_thread_attr *attr)
 {
-	return attr->stacksize + 1;
+	return attr->is_external ? 0 : attr->stacksize + 1;
 }
 
 static inline void __set_attr_stacksize(struct posix_thread_attr *attr, size_t stacksize)
@@ -62,10 +67,12 @@ struct __pthread_cleanup {
 enum posix_thread_qid {
 	/* ready to be started via pthread_create() */
 	POSIX_THREAD_READY_Q,
-	/* running */
+	/* running pthread thread */
 	POSIX_THREAD_RUN_Q,
 	/* exited (either joinable or detached) */
 	POSIX_THREAD_DONE_Q,
+	/* running external thread */
+	POSIX_THREAD_EXTERNAL_Q,
 	/* invalid */
 	POSIX_THREAD_INVALID_Q,
 };
@@ -82,24 +89,26 @@ BUILD_ASSERT((PTHREAD_CANCEL_ENABLE == 0 || PTHREAD_CANCEL_DISABLE == 0) &&
 BUILD_ASSERT(CONFIG_POSIX_PTHREAD_ATTR_STACKSIZE_BITS + CONFIG_POSIX_PTHREAD_ATTR_GUARDSIZE_BITS <=
 	     32);
 
-/* ensure public `pthread_attr_t` covers whole memory requirements of private `struct posix_thread_attr` */
+/* ensure `pthread_attr_t` covers memory requirements of private `struct posix_thread_attr` */
 BUILD_ASSERT(sizeof(struct posix_thread_attr) <= sizeof(pthread_attr_t));
 
-/* ensure public unsigned `pthread_t` type is sufficient as the private `posix_thread_pool` index (size_t). */
-BUILD_ASSERT(CONFIG_POSIX_THREAD_THREADS_MAX <= (pthread_t)~0);
+/* ensure unsigned `pthread_t` type is sufficient as the private `posix_thread_pool` index. */
+BUILD_ASSERT(CONFIG_POSIX_THREAD_THREADS_MAX + 1 <= (pthread_t)~0);
 BUILD_ASSERT(PTHREAD_OBJ_MASK_INIT <= (pthread_t)~0);
 
-static void posix_thread_recycle(void);
+static size_t posix_thread_recycle(void);
 
 static sys_dlist_t posix_thread_q[] = {
 	SYS_DLIST_STATIC_INIT(&posix_thread_q[POSIX_THREAD_READY_Q]),
 	SYS_DLIST_STATIC_INIT(&posix_thread_q[POSIX_THREAD_RUN_Q]),
 	SYS_DLIST_STATIC_INIT(&posix_thread_q[POSIX_THREAD_DONE_Q]),
+	SYS_DLIST_STATIC_INIT(&posix_thread_q[POSIX_THREAD_EXTERNAL_Q]),
 };
 
-static struct posix_thread posix_thread_pool[CONFIG_POSIX_THREAD_THREADS_MAX];
+/* entries = CONFIG_POSIX_THREAD_THREADS_MAX + 1 for main-thread */
+static struct posix_thread posix_thread_pool[CONFIG_POSIX_THREAD_THREADS_MAX + 1];
 
-static SYS_SEM_DEFINE(pthread_pool_lock, 1, 1);
+static struct k_spinlock pthread_pool_lock;
 static int pthread_concurrency;
 
 static inline void posix_thread_q_set(struct posix_thread *t, enum posix_thread_qid qid)
@@ -108,6 +117,7 @@ static inline void posix_thread_q_set(struct posix_thread *t, enum posix_thread_
 	case POSIX_THREAD_READY_Q:
 	case POSIX_THREAD_RUN_Q:
 	case POSIX_THREAD_DONE_Q:
+	case POSIX_THREAD_EXTERNAL_Q:
 		sys_dlist_append(&posix_thread_q[qid], &t->q_node);
 		t->qid = qid;
 		break;
@@ -123,6 +133,7 @@ static inline enum posix_thread_qid posix_thread_q_get(struct posix_thread *t)
 	case POSIX_THREAD_READY_Q:
 	case POSIX_THREAD_RUN_Q:
 	case POSIX_THREAD_DONE_Q:
+	case POSIX_THREAD_EXTERNAL_Q:
 		return t->qid;
 	default:
 		__ASSERT(false, "posix thread %p has invalid qid: %d", t, t->qid);
@@ -148,6 +159,19 @@ static inline size_t get_posix_thread_idx(pthread_t pth)
 	return mark_pthread_obj_uninitialized(pth);
 }
 
+/** Return true if given `pth` is inside `posix_thread_pool`, otherwise false. */
+static inline bool is_valid_posix_thread_ptr(struct posix_thread *pth)
+{
+	return posix_thread_to_offset(pth) < ARRAY_SIZE(posix_thread_pool);
+}
+
+/** Converts given `struct posix_thread *` to its public `pthread_t` ID. */
+pthread_t to_pthread_id(struct posix_thread *pth)
+{
+	return mark_pthread_obj_initialized(posix_thread_to_offset(pth));
+}
+
+/* Converts given public `pthread_t` to `struct posix_thread *` only if valid and initialized. */
 struct posix_thread *to_posix_thread(pthread_t pthread)
 {
 	struct posix_thread *t;
@@ -172,9 +196,12 @@ struct posix_thread *to_posix_thread(pthread_t pthread)
 	 * This differs from other posix object allocation strategies because they use
 	 * a bitarray to indicate whether an object has been allocated.
 	 */
-	actually_initialized = !(posix_thread_q_get(t) == POSIX_THREAD_READY_Q ||
-				 (posix_thread_q_get(t) == POSIX_THREAD_DONE_Q &&
-				  t->attr.detachstate == PTHREAD_CREATE_DETACHED));
+	const enum posix_thread_qid qid = posix_thread_q_get(t);
+
+	actually_initialized =
+		qid == POSIX_THREAD_EXTERNAL_Q ||
+		!(qid == POSIX_THREAD_READY_Q ||
+		  (qid == POSIX_THREAD_DONE_Q && t->attr.detachstate == PTHREAD_CREATE_DETACHED));
 
 	if (!actually_initialized) {
 		LOG_DBG("Pthread claims to be initialized (%x)", pthread);
@@ -184,15 +211,267 @@ struct posix_thread *to_posix_thread(pthread_t pthread)
 	return &posix_thread_pool[bit];
 }
 
-pthread_t pthread_self(void)
+/* Converts given public `pthread_t` to Zephyr `k_tid_t`, only if valid and initialized. */
+k_tid_t pthread_to_zephyr_thread(pthread_t pthread)
 {
-	size_t bit;
+	struct posix_thread *th = to_posix_thread(pthread);
+
+	return th ? th->z_thread : NULL;
+}
+
+/** Converts given public `pthread_t` to Zephyr `k_tid_t`, only if valid (maybe uninitialized). */
+static k_tid_t pthread_to_zephyr_thread_any(pthread_t pthread)
+{
+	/* if the provided thread does not claim to be initialized, its invalid */
+	if (!is_pthread_obj_initialized(pthread)) {
+		return NULL;
+	}
+	const size_t idx = get_posix_thread_idx(pthread);
+
+	if (idx >= ARRAY_SIZE(posix_thread_pool)) {
+		return NULL;
+	}
+	return posix_thread_pool[idx].z_thread;
+}
+
+static void posix_thread_init_thread_state(struct posix_thread *t, bool is_external)
+{
+	if (is_external) {
+		posix_thread_q_set(t, POSIX_THREAD_EXTERNAL_Q);
+	} else {
+		posix_thread_q_set(t, POSIX_THREAD_RUN_Q);
+	}
+	sys_slist_init(&t->key_list);
+	sys_slist_init(&t->cleanup_list);
+}
+
+static bool __attr_is_runnable(const struct posix_thread_attr *attr)
+{
+	size_t stacksize;
+
+	if (attr == NULL || (!attr->is_external && attr->stack == NULL)) {
+		LOG_DBG("attr %p is not initialized", attr);
+		return false;
+	}
+
+	if (!attr->is_external) {
+		stacksize = __get_attr_stacksize(attr);
+		if (stacksize < PTHREAD_STACK_MIN) {
+			LOG_DBG("attr %p has stacksize %zu is smaller than " /* NOSONAR */
+				"PTHREAD_STACK_MIN (%zu)",
+				attr, stacksize, (size_t)PTHREAD_STACK_MIN);
+			return false;
+		}
+	}
+
+	/* require a valid scheduler policy */
+	if (!valid_posix_policy(attr->schedpolicy)) {
+		LOG_DBG("Invalid scheduler policy %d", attr->schedpolicy);
+		return false;
+	}
+
+	return true;
+}
+
+static bool __attr_is_initialized(const struct posix_thread_attr *attr)
+{
+	if (IS_ENABLED(CONFIG_DYNAMIC_THREAD)) {
+		return __attr_is_runnable(attr);
+	}
+
+	if (attr == NULL || !attr->initialized) {
+		LOG_DBG("attr %p is not initialized", attr);
+		return false;
+	}
+
+	return true;
+}
+
+static int posix_thread_attr_init(struct posix_thread_attr *const attr, bool is_external)
+{
+	if (attr == NULL) {
+		LOG_DBG("Invalid attr pointer");
+		return ENOMEM;
+	}
+
+	BUILD_ASSERT(DYNAMIC_STACK_SIZE <= PTHREAD_STACK_MAX);
+
+	*attr = (struct posix_thread_attr){0};
+	attr->guardsize = CONFIG_POSIX_PTHREAD_ATTR_GUARDSIZE_DEFAULT;
+	attr->contentionscope = PTHREAD_SCOPE_SYSTEM;
+	attr->inheritsched = PTHREAD_INHERIT_SCHED;
+	if (is_external) {
+		attr->is_external = true;
+		attr->cancelstate = PTHREAD_CANCEL_DISABLE;
+		attr->detachstate = PTHREAD_CREATE_DETACHED;
+	} else if (DYNAMIC_STACK_SIZE > 0) { /* NOSONAR */
+		attr->stack = k_thread_stack_alloc(DYNAMIC_STACK_SIZE + attr->guardsize,
+						   k_is_user_context() ? K_USER : 0);
+		if (attr->stack == NULL) {
+			LOG_DBG("Did not auto-allocate thread stack");
+		} else {
+			__set_attr_stacksize(attr, DYNAMIC_STACK_SIZE);
+			__ASSERT_NO_MSG(__attr_is_initialized(attr));
+			LOG_DBG("Allocated thread stack %zu@%p", __get_attr_stacksize(attr),
+				attr->stack);
+		}
+	}
+
+	/* caller responsible for destroying attr */
+	attr->initialized = true;
+
+	LOG_DBG("Initialized attr %p", attr); /* NOSONAR */
+
+	return 0;
+}
+
+static void posix_thread_move_to_readyq(struct posix_thread *t, bool acquire_lock)
+{
+	if (acquire_lock) {
+		K_SPINLOCK(&pthread_pool_lock) {
+			sys_dlist_remove(&t->q_node);
+			t->z_thread = NULL;
+			posix_thread_q_set(t, POSIX_THREAD_READY_Q);
+		}
+	} else {
+		sys_dlist_remove(&t->q_node);
+		t->z_thread = NULL;
+		posix_thread_q_set(t, POSIX_THREAD_READY_Q);
+	}
+}
+
+static int posix_thread_create_attr(struct posix_thread *t, bool is_external)
+{
+	int err = posix_thread_attr_init(&t->attr, is_external);
+
+	if (err == 0 && !__attr_is_runnable(&t->attr)) {
+		(void)pthread_attr_destroy((pthread_attr_t *)&t->attr);
+		err = EINVAL;
+	}
+	if (err != 0) {
+		/* cannot allocate pthread attributes (e.g. stack) */
+		posix_thread_move_to_readyq(t, !is_external);
+		LOG_ERR("pthread_create_attr: failed (ext %d)", is_external); /* NOSONAR */
+		return err;
+	}
+	/* caller not responsible for destroying attr */
+	t->attr.caller_destroys = false;
+	return err;
+}
+
+static void posix_thread_inherit_sched(int z_prio, struct posix_thread *t)
+{
+	int pol;
+
+	t->attr.priority = zephyr_to_posix_priority(z_prio, &pol);
+	t->attr.schedpolicy = pol;
+}
+
+/**
+ * Add one posix_thread_pool entry for the Zephyr external thread READY -> EXTERNAL
+ * and initialize its attributes w/ states:PTHREAD_CANCEL_DISABLE, PTHREAD_CREATE_DETACHED.
+ *
+ * Caller is required to lock pthread_pool_lock post initialization.
+ *
+ * @return valid added reference or NULL if READY queue is empty
+ */
+static struct posix_thread *posix_thread_add_external(k_tid_t zexternal)
+{
+	struct posix_thread *pexternal = NULL;
+
+	if (!sys_dlist_is_empty(&posix_thread_q[POSIX_THREAD_READY_Q])) {
+		pexternal = CONTAINER_OF(/* NOSONAR */
+					 sys_dlist_get(&posix_thread_q[POSIX_THREAD_READY_Q]),
+					 struct posix_thread, q_node);
+		posix_thread_init_thread_state(pexternal, true);
+	} else {
+		LOG_ERR("pthread_add_external: Empty POSIX_THREAD_READY_Q" /* NOSONAR */
+			" (CONFIG_POSIX_THREAD_THREADS_MAX)");
+		return NULL;
+	}
+	if (posix_thread_create_attr(pexternal, true) != 0) {
+		return NULL;
+	}
+	pexternal->z_thread = zexternal;
+
+	__ASSERT_NO_MSG(pexternal == to_posix_thread(to_pthread_id(pexternal)));
+	__ASSERT_NO_MSG(zexternal == pthread_to_zephyr_thread(to_pthread_id(pexternal)));
+	return pexternal;
+}
+
+static pthread_t posix_thread_self(bool lock)
+{
+#ifdef CONFIG_CURRENT_THREAD_USE_TLS
+	static Z_THREAD_LOCAL struct posix_thread *posix_thread_tls_current =
+		(struct posix_thread *)0;
+#endif
 	struct posix_thread *t;
 
-	t = (struct posix_thread *)CONTAINER_OF(k_current_get(), struct posix_thread, thread);
-	bit = posix_thread_to_offset(t);
+#ifdef CONFIG_CURRENT_THREAD_USE_TLS
+	/* fast path TLS */
+	t = posix_thread_tls_current;
+	if (t && is_valid_posix_thread_ptr(t)) {
+		LOG_DBG("pthread_self: %p (tls, ext %d)", /* NOSONAR */
+			t->z_thread, (int)t->attr.is_external);
+		return to_pthread_id(t);
+	}
+#endif
+	struct k_thread *kself = k_current_get();
 
-	return mark_pthread_obj_initialized(bit);
+	/* existing pthread */
+	t = (struct posix_thread *)CONTAINER_OF(kself, struct posix_thread, thread); /* NOSONAR */
+	if (is_valid_posix_thread_ptr(t)) {
+#ifdef CONFIG_CURRENT_THREAD_USE_TLS
+		posix_thread_tls_current = t;
+#endif
+		LOG_DBG("pthread_self: %p (existing-p, ext %d)", t->z_thread, /* NOSONAR */
+			(int)t->attr.is_external);
+		return to_pthread_id(t);
+	}
+	pthread_t res = 0;
+	k_spinlock_key_t key;
+
+	if (lock) {
+		key = k_spin_lock(&pthread_pool_lock);
+	}
+	/* existing external thread */
+	SYS_DLIST_FOR_EACH_CONTAINER(/* NOSONAR */
+				     &posix_thread_q[POSIX_THREAD_EXTERNAL_Q], t, q_node) {
+		if (t->z_thread == kself) {
+			res = to_pthread_id(t);
+#ifdef CONFIG_CURRENT_THREAD_USE_TLS
+			posix_thread_tls_current = t;
+#endif
+			LOG_DBG("pthread_self: %p (existing-e, ext %d)", /* NOSONAR */
+				t->z_thread, (int)t->attr.is_external);
+			break;
+		}
+	}
+	/* new external thread */
+	if (!res) {
+		t = posix_thread_add_external(kself);
+		if (!t) {
+			LOG_ERR(/* NOSONAR */
+				"pthread_self: Failed to add external thread");
+			k_fatal_halt(K_ERR_KERNEL_OOPS);
+		}
+#ifdef CONFIG_CURRENT_THREAD_USE_TLS
+		posix_thread_tls_current = t;
+#endif
+		posix_thread_inherit_sched(k_thread_priority_get(kself), t);
+		res = to_pthread_id(t);
+		LOG_DBG("pthread_self: %p (new-e, ext %d)", t->z_thread, /* NOSONAR */
+			(int)t->attr.is_external);
+	}
+	if (lock) {
+		k_spin_unlock(&pthread_pool_lock, key);
+	}
+	return res;
+}
+
+pthread_t pthread_self(void)
+{
+	return posix_thread_self(true);
 }
 
 int pthread_equal(pthread_t pt1, pthread_t pt2)
@@ -215,8 +494,8 @@ void __z_pthread_cleanup_push(void *cleanup[3], void (*routine)(void *arg), void
 	struct posix_thread *t = NULL;
 	struct __pthread_cleanup *const c = (struct __pthread_cleanup *)cleanup;
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
-		t = to_posix_thread(pthread_self());
+	K_SPINLOCK(&pthread_pool_lock) {
+		t = to_posix_thread(posix_thread_self(false));
 		BUILD_ASSERT(3 * sizeof(void *) == sizeof(*c));
 		__ASSERT_NO_MSG(t != NULL);
 		__ASSERT_NO_MSG(c != NULL);
@@ -232,8 +511,8 @@ void __z_pthread_cleanup_pop(int execute)
 	struct __pthread_cleanup *c = NULL;
 	struct posix_thread *t = NULL;
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
-		t = to_posix_thread(pthread_self());
+	K_SPINLOCK(&pthread_pool_lock) {
+		t = to_posix_thread(posix_thread_self(false));
 		__ASSERT_NO_MSG(t != NULL);
 		node = sys_slist_get(&t->cleanup_list);
 		__ASSERT_NO_MSG(node != NULL);
@@ -284,45 +563,6 @@ int posix_to_zephyr_priority(int priority, int policy)
 	return POSIX_TO_ZEPHYR_PRIORITY(priority, policy);
 }
 
-static bool __attr_is_runnable(const struct posix_thread_attr *attr)
-{
-	size_t stacksize;
-
-	if (attr == NULL || attr->stack == NULL) {
-		LOG_DBG("attr %p is not initialized", attr);
-		return false;
-	}
-
-	stacksize = __get_attr_stacksize(attr);
-	if (stacksize < PTHREAD_STACK_MIN) {
-		LOG_DBG("attr %p has stacksize %zu is smaller than PTHREAD_STACK_MIN (%zu)", attr,
-			stacksize, (size_t)PTHREAD_STACK_MIN);
-		return false;
-	}
-
-	/* require a valid scheduler policy */
-	if (!valid_posix_policy(attr->schedpolicy)) {
-		LOG_DBG("Invalid scheduler policy %d", attr->schedpolicy);
-		return false;
-	}
-
-	return true;
-}
-
-static bool __attr_is_initialized(const struct posix_thread_attr *attr)
-{
-	if (IS_ENABLED(CONFIG_DYNAMIC_THREAD)) {
-		return __attr_is_runnable(attr);
-	}
-
-	if (attr == NULL || !attr->initialized) {
-		LOG_DBG("attr %p is not initialized", attr);
-		return false;
-	}
-
-	return true;
-}
-
 /**
  * @brief Set scheduling parameter attributes in thread attributes object.
  *
@@ -334,7 +574,7 @@ int pthread_attr_setschedparam(pthread_attr_t *_attr, const struct sched_param *
 
 	if (!__attr_is_initialized(attr) || schedparam == NULL ||
 	    !is_posix_policy_prio_valid(schedparam->sched_priority, attr->schedpolicy)) {
-		LOG_DBG("Invalid pthread_attr_t or sched_param");
+		LOG_DBG("Invalid pthread_attr_t or sched_param"); /* NOSONAR */
 		return EINVAL;
 	}
 
@@ -353,21 +593,25 @@ int pthread_attr_setstack(pthread_attr_t *_attr, void *stackaddr, size_t stacksi
 	struct posix_thread_attr *attr = (struct posix_thread_attr *)_attr;
 
 	if (stackaddr == NULL) {
-		LOG_DBG("NULL stack address");
+		LOG_DBG("NULL stack address"); /* NOSONAR */
 		return EACCES;
 	}
 
-	if (!__attr_is_initialized(attr) || (stacksize == 0) ||
-	    (PTHREAD_STACK_MIN > 0 && stacksize < PTHREAD_STACK_MIN) ||
-	    (stacksize > PTHREAD_STACK_MAX)) {
-		LOG_DBG("Invalid stacksize %zu", stacksize);
+	if (!__attr_is_initialized(attr)) {
+		return EINVAL;
+	} else if (attr->is_external) {
+		LOG_DBG("Not supported on external thread"); /* NOSONAR */
+		return EINVAL;
+	} else if ((stacksize == 0) || (PTHREAD_STACK_MIN > 0 && stacksize < PTHREAD_STACK_MIN) ||
+		   (stacksize > PTHREAD_STACK_MAX)) {
+		LOG_DBG("Invalid stacksize %zu", stacksize); /* NOSONAR */
 		return EINVAL;
 	}
 
 	if (attr->stack != NULL) {
 		ret = k_thread_stack_free(attr->stack);
 		if (ret == 0) {
-			LOG_DBG("Freed attr %p thread stack %zu@%p", _attr,
+			LOG_DBG("Freed attr %p thread stack %zu@%p", _attr, /* NOSONAR */
 				__get_attr_stacksize(attr), attr->stack);
 		}
 	}
@@ -479,6 +723,7 @@ static void posix_thread_finalize(struct posix_thread *t, void *retval)
 	pthread_thread_data *thread_spec_data;
 	sys_snode_t *node_key_data, *node_key_data_s, *node_key_data_prev = NULL;
 	struct pthread_key_data *key_data;
+	k_tid_t z_thread = NULL;
 
 	SYS_SLIST_FOR_EACH_NODE_SAFE(&t->key_list, node_l, node_s) {
 		thread_spec_data = (pthread_thread_data *)node_l;
@@ -510,17 +755,21 @@ static void posix_thread_finalize(struct posix_thread *t, void *retval)
 	}
 
 	/* move thread from run_q to done_q */
-	SYS_SEM_LOCK(&pthread_pool_lock) {
+	K_SPINLOCK(&pthread_pool_lock) {
 		sys_dlist_remove(&t->q_node);
-		posix_thread_q_set(t, POSIX_THREAD_DONE_Q);
 		t->retval = retval;
+		z_thread = t->z_thread;
+		t->z_thread = NULL;
+		posix_thread_q_set(t, POSIX_THREAD_DONE_Q);
 	}
+	__ASSERT_NO_MSG(NULL != z_thread);
 
 	/* trigger recycle work */
 	(void)k_work_schedule(&posix_thread_recycle_work, K_MSEC(CONFIG_PTHREAD_RECYCLER_DELAY_MS));
 
-	/* abort the underlying k_thread */
-	k_thread_abort(&t->thread);
+	/* Note: `z_main_thread` ends up with `k_panic` if `essential`. */
+	LOG_DBG("pthread_finalize: aborting %p", z_thread); /* NOSONAR */
+	k_thread_abort(z_thread);
 }
 
 FUNC_NORETURN
@@ -543,30 +792,69 @@ static void zephyr_thread_wrapper(void *arg1, void *arg2, void *arg3)
 	CODE_UNREACHABLE;
 }
 
-static void posix_thread_recycle(void)
+/* Called by halt_thread (sched.c), in any case of thread-death.
+ * - `_sched_spinlock` is acquired by caller
+ * - if given kthread refers to a registered external thread, it gets recycled immediately
+ */
+void posix_thread_kthread_exit(struct k_thread *kthread)
+{
+	struct posix_thread *t, *res = NULL;
+
+	t = (struct posix_thread *)CONTAINER_OF(/* NOSONAR */
+						kthread, struct posix_thread, thread);
+	if (is_valid_posix_thread_ptr(t)) {
+		return;
+	}
+
+	K_SPINLOCK(&pthread_pool_lock) {
+		/* existing external thread */
+		SYS_DLIST_FOR_EACH_CONTAINER(/* NOSONAR */
+					     &posix_thread_q[POSIX_THREAD_EXTERNAL_Q], t, q_node) {
+			if (t->z_thread == kthread) {
+				res = t;
+				sys_dlist_remove(&t->q_node);
+				LOG_DBG("pthread_kthread_exit: %p (ext %d)", /* NOSONAR */
+					t->z_thread, (int)t->attr.is_external);
+				t->attr = (struct posix_thread_attr){0};
+				t->z_thread = NULL;
+				posix_thread_q_set(t, POSIX_THREAD_READY_Q);
+				break;
+			}
+		}
+	}
+	if (!res) {
+		LOG_DBG("pthread_kthread_exit: Not found %p", kthread); /* NOSONAR */
+	}
+}
+
+static size_t posix_thread_recycle(void)
 {
 	struct posix_thread *t;
 	struct posix_thread *safe_t;
+	size_t count, count_ext = 0;
 	sys_dlist_t recyclables = SYS_DLIST_STATIC_INIT(&recyclables);
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
+	K_SPINLOCK(&pthread_pool_lock) {
 		SYS_DLIST_FOR_EACH_CONTAINER_SAFE(&posix_thread_q[POSIX_THREAD_DONE_Q], t, safe_t,
 						  q_node) {
 			if (t->attr.detachstate == PTHREAD_CREATE_JOINABLE) {
 				/* thread has not been joined yet */
 				continue;
 			}
-
+			if (t->attr.is_external) {
+				++count_ext;
+			}
 			sys_dlist_remove(&t->q_node);
 			sys_dlist_append(&recyclables, &t->q_node);
 		}
 	}
 
 	if (sys_dlist_is_empty(&recyclables)) {
-		return;
+		return 0;
 	}
 
-	LOG_DBG("Recycling %zu threads", sys_dlist_len(&recyclables));
+	count = sys_dlist_len(&recyclables);
+	LOG_DBG("Recycling %zu threads (%zu ext)", count, count_ext); /* NOSONAR */
 
 	SYS_DLIST_FOR_EACH_CONTAINER(&recyclables, t, q_node) {
 		if (t->attr.caller_destroys) {
@@ -576,12 +864,13 @@ static void posix_thread_recycle(void)
 		}
 	}
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
+	K_SPINLOCK(&pthread_pool_lock) {
 		while (!sys_dlist_is_empty(&recyclables)) {
 			t = CONTAINER_OF(sys_dlist_get(&recyclables), struct posix_thread, q_node);
 			posix_thread_q_set(t, POSIX_THREAD_READY_Q);
 		}
 	}
+	return count;
 }
 
 /**
@@ -606,15 +895,12 @@ int pthread_create(pthread_t *th, const pthread_attr_t *_attr, void *(*threadrou
 	/* reclaim resources greedily */
 	posix_thread_recycle();
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
+	K_SPINLOCK(&pthread_pool_lock) {
 		if (!sys_dlist_is_empty(&posix_thread_q[POSIX_THREAD_READY_Q])) {
 			t = CONTAINER_OF(sys_dlist_get(&posix_thread_q[POSIX_THREAD_READY_Q]),
 					 struct posix_thread, q_node);
-
-			/* initialize thread state */
-			posix_thread_q_set(t, POSIX_THREAD_RUN_Q);
-			sys_slist_init(&t->key_list);
-			sys_slist_init(&t->cleanup_list);
+			posix_thread_init_thread_state(t, false);
+			t->z_thread = &t->thread;
 		}
 	}
 
@@ -622,10 +908,7 @@ int pthread_create(pthread_t *th, const pthread_attr_t *_attr, void *(*threadrou
 		err = pthread_barrier_init(&barrier, NULL, 2);
 		if (err != 0) {
 			/* cannot allocate barrier. move thread back to ready_q */
-			SYS_SEM_LOCK(&pthread_pool_lock) {
-				sys_dlist_remove(&t->q_node);
-				posix_thread_q_set(t, POSIX_THREAD_READY_Q);
-			}
+			posix_thread_move_to_readyq(t, true);
 			t = NULL;
 		}
 	}
@@ -637,32 +920,17 @@ int pthread_create(pthread_t *th, const pthread_attr_t *_attr, void *(*threadrou
 	}
 
 	if (_attr == NULL) {
-		err = pthread_attr_init((pthread_attr_t *)&t->attr);
-		if (err == 0 && !__attr_is_runnable(&t->attr)) {
-			(void)pthread_attr_destroy((pthread_attr_t *)&t->attr);
-			err = EINVAL;
-		}
+		err = posix_thread_create_attr(t, false);
 		if (err != 0) {
-			/* cannot allocate pthread attributes (e.g. stack) */
-			SYS_SEM_LOCK(&pthread_pool_lock) {
-				sys_dlist_remove(&t->q_node);
-				posix_thread_q_set(t, POSIX_THREAD_READY_Q);
-			}
 			return err;
 		}
-		/* caller not responsible for destroying attr */
-		t->attr.caller_destroys = false;
 	} else {
 		/* copy user-provided attr into thread, caller must destroy attr at a later time */
 		t->attr = *(struct posix_thread_attr *)_attr;
 	}
 
 	if (t->attr.inheritsched == PTHREAD_INHERIT_SCHED) {
-		int pol;
-
-		t->attr.priority =
-			zephyr_to_posix_priority(k_thread_priority_get(k_current_get()), &pol);
-		t->attr.schedpolicy = pol;
+		posix_thread_inherit_sched(k_thread_priority_get(k_current_get()), t);
 	}
 
 	/* spawn the thread */
@@ -681,7 +949,7 @@ int pthread_create(pthread_t *th, const pthread_attr_t *_attr, void *(*threadrou
 	}
 
 	/* finally provide the initialized thread to the caller */
-	*th = mark_pthread_obj_initialized(posix_thread_to_offset(t));
+	*th = to_pthread_id(t);
 
 	LOG_DBG("Created pthread %p", &t->thread);
 
@@ -692,7 +960,7 @@ int pthread_getconcurrency(void)
 {
 	int ret = 0;
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
+	K_SPINLOCK(&pthread_pool_lock) {
 		ret = pthread_concurrency;
 	}
 
@@ -709,7 +977,7 @@ int pthread_setconcurrency(int new_level)
 		return EAGAIN;
 	}
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
+	K_SPINLOCK(&pthread_pool_lock) {
 		pthread_concurrency = new_level;
 	}
 
@@ -733,11 +1001,11 @@ int pthread_setcancelstate(int state, int *oldstate)
 		return EINVAL;
 	}
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
-		t = to_posix_thread(pthread_self());
-		if (t == NULL) {
+	K_SPINLOCK(&pthread_pool_lock) {
+		t = to_posix_thread(posix_thread_self(false));
+		if (t == NULL || t->attr.is_external) {
 			ret = EINVAL;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		if (oldstate != NULL) {
@@ -774,11 +1042,11 @@ int pthread_setcanceltype(int type, int *oldtype)
 		return EINVAL;
 	}
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
-		t = to_posix_thread(pthread_self());
-		if (t == NULL) {
+	K_SPINLOCK(&pthread_pool_lock) {
+		t = to_posix_thread(posix_thread_self(false));
+		if (t == NULL || t->attr.is_external) {
 			ret = EINVAL;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		if (oldtype != NULL) {
@@ -802,13 +1070,13 @@ void pthread_testcancel(void)
 	bool cancel_pended = false;
 	struct posix_thread *t = NULL;
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
-		t = to_posix_thread(pthread_self());
+	K_SPINLOCK(&pthread_pool_lock) {
+		t = to_posix_thread(posix_thread_self(false));
 		if (t == NULL) {
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 		if (t->attr.cancelstate != PTHREAD_CANCEL_ENABLE) {
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 		if (t->attr.cancelpending) {
 			cancel_pended = true;
@@ -833,17 +1101,17 @@ int pthread_cancel(pthread_t pthread)
 	bool cancel_type = PTHREAD_CANCEL_DEFERRED;
 	struct posix_thread *t = NULL;
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
+	K_SPINLOCK(&pthread_pool_lock) {
 		t = to_posix_thread(pthread);
-		if (t == NULL) {
+		if (t == NULL || t->attr.is_external) {
 			ret = ESRCH;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		if (!__attr_is_initialized(&t->attr)) {
 			/* thread has already terminated */
 			ret = ESRCH;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		ret = 0;
@@ -876,11 +1144,11 @@ int pthread_setschedparam(pthread_t pthread, int policy, const struct sched_para
 		return EINVAL;
 	}
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
+	K_SPINLOCK(&pthread_pool_lock) {
 		t = to_posix_thread(pthread);
-		if (t == NULL) {
+		if (t == NULL || !t->z_thread) {
 			ret = ESRCH;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		ret = 0;
@@ -888,7 +1156,7 @@ int pthread_setschedparam(pthread_t pthread, int policy, const struct sched_para
 	}
 
 	if (ret == 0) {
-		k_thread_priority_set(&t->thread, new_prio);
+		k_thread_priority_set(t->z_thread, new_prio);
 	}
 
 	return ret;
@@ -917,11 +1185,11 @@ int pthread_setschedprio(pthread_t thread, int prio)
 	}
 
 	ret = ESRCH;
-	SYS_SEM_LOCK(&pthread_pool_lock) {
+	K_SPINLOCK(&pthread_pool_lock) {
 		t = to_posix_thread(thread);
-		if (t == NULL) {
+		if (t == NULL || !t->z_thread) {
 			ret = ESRCH;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		ret = 0;
@@ -929,7 +1197,7 @@ int pthread_setschedprio(pthread_t thread, int prio)
 	}
 
 	if (ret == 0) {
-		k_thread_priority_set(&t->thread, new_prio);
+		k_thread_priority_set(t->z_thread, new_prio);
 	}
 
 	return ret;
@@ -942,39 +1210,7 @@ int pthread_setschedprio(pthread_t thread, int prio)
  */
 int pthread_attr_init(pthread_attr_t *_attr)
 {
-	struct posix_thread_attr *const attr = (struct posix_thread_attr *)_attr;
-
-	if (attr == NULL) {
-		LOG_DBG("Invalid attr pointer");
-		return ENOMEM;
-	}
-
-	BUILD_ASSERT(DYNAMIC_STACK_SIZE <= PTHREAD_STACK_MAX);
-
-	*attr = (struct posix_thread_attr){0};
-	attr->guardsize = CONFIG_POSIX_PTHREAD_ATTR_GUARDSIZE_DEFAULT;
-	attr->contentionscope = PTHREAD_SCOPE_SYSTEM;
-	attr->inheritsched = PTHREAD_INHERIT_SCHED;
-
-	if (DYNAMIC_STACK_SIZE > 0) {
-		attr->stack = k_thread_stack_alloc(DYNAMIC_STACK_SIZE + attr->guardsize,
-						   k_is_user_context() ? K_USER : 0);
-		if (attr->stack == NULL) {
-			LOG_DBG("Did not auto-allocate thread stack");
-		} else {
-			__set_attr_stacksize(attr, DYNAMIC_STACK_SIZE);
-			__ASSERT_NO_MSG(__attr_is_initialized(attr));
-			LOG_DBG("Allocated thread stack %zu@%p", __get_attr_stacksize(attr),
-				attr->stack);
-		}
-	}
-
-	/* caller responsible for destroying attr */
-	attr->initialized = true;
-
-	LOG_DBG("Initialized attr %p", _attr);
-
-	return 0;
+	return posix_thread_attr_init((struct posix_thread_attr *)_attr, false);
 }
 
 /**
@@ -991,21 +1227,21 @@ int pthread_getschedparam(pthread_t pthread, int *policy, struct sched_param *pa
 		return EINVAL;
 	}
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
+	K_SPINLOCK(&pthread_pool_lock) {
 		t = to_posix_thread(pthread);
-		if (t == NULL) {
+		if (t == NULL || !t->z_thread) {
 			ret = ESRCH;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		if (!__attr_is_initialized(&t->attr)) {
 			ret = ESRCH;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		ret = 0;
 		param->sched_priority =
-			zephyr_to_posix_priority(k_thread_priority_get(&t->thread), policy);
+			zephyr_to_posix_priority(k_thread_priority_get(t->z_thread), policy);
 	}
 
 	return ret;
@@ -1026,7 +1262,7 @@ int pthread_once(pthread_once_t *once, void (*init_func)(void))
 		return EINVAL;
 	}
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
+	K_SPINLOCK(&pthread_pool_lock) {
 		if (!_once->flag) {
 			run_init_func = true;
 			_once->flag = true;
@@ -1051,10 +1287,10 @@ void pthread_exit(void *retval)
 {
 	struct posix_thread *self = NULL;
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
-		self = to_posix_thread(pthread_self());
+	K_SPINLOCK(&pthread_pool_lock) {
+		self = to_posix_thread(posix_thread_self(false));
 		if (self == NULL) {
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		/* Mark a thread as cancellable before exiting */
@@ -1077,30 +1313,39 @@ static int pthread_timedjoin_internal(pthread_t pthread, void **status, k_timeou
 {
 	int ret = ESRCH;
 	struct posix_thread *t = NULL;
+	k_tid_t z_thread = NULL;
 
 	if (pthread == pthread_self()) {
 		LOG_DBG("Pthread attempted to join itself (%x)", pthread);
 		return EDEADLK;
 	}
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
+	K_SPINLOCK(&pthread_pool_lock) {
 		t = to_posix_thread(pthread);
 		if (t == NULL) {
 			ret = ESRCH;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
-
-		LOG_DBG("Pthread %p joining..", &t->thread);
+		if (t->attr.is_external) {
+			ret = EINVAL;
+			K_SPINLOCK_BREAK;
+		}
+		z_thread = t->z_thread;
+		if (z_thread) {
+			LOG_DBG("Pthread %p joining..", z_thread); /* NOSONAR */
+		} else {
+			LOG_DBG("Pthread skip joining, already terminated.."); /* NOSONAR */
+		}
 
 		if (t->attr.detachstate != PTHREAD_CREATE_JOINABLE) {
 			/* undefined behaviour */
 			ret = EINVAL;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		if (posix_thread_q_get(t) == POSIX_THREAD_READY_Q) {
 			ret = ESRCH;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		/*
@@ -1113,19 +1358,21 @@ static int pthread_timedjoin_internal(pthread_t pthread, void **status, k_timeou
 
 	switch (ret) {
 	case ESRCH:
-		LOG_DBG("Pthread %p has already been joined", &t->thread);
+		LOG_DBG("Pthread %p has already been joined", z_thread); /* NOSONAR */
 		return ret;
 	case EINVAL:
-		LOG_DBG("Pthread %p is not a joinable", &t->thread);
+		LOG_DBG("Pthread %p is not a joinable", z_thread); /* NOSONAR */
 		return ret;
 	case 0:
 		break;
 	}
 
-	ret = k_thread_join(&t->thread, timeout);
+	if (z_thread) {
+		ret = k_thread_join(z_thread, timeout);
+	} /* else: already terminated */
 	if (ret != 0) {
 		/* when joining failed, ensure that the thread can be joined later */
-		SYS_SEM_LOCK(&pthread_pool_lock) {
+		K_SPINLOCK(&pthread_pool_lock) {
 			t->attr.detachstate = PTHREAD_CREATE_JOINABLE;
 		}
 	}
@@ -1137,7 +1384,9 @@ static int pthread_timedjoin_internal(pthread_t pthread, void **status, k_timeou
 	/* Can only be ok or -EDEADLK, which should never occur for pthreads */
 	__ASSERT_NO_MSG(ret == 0);
 
-	LOG_DBG("Joined pthread %p", &t->thread);
+	if (z_thread) {
+		LOG_DBG("Joined pthread %p", z_thread); /* NOSONAR */
+	}
 
 	if (status != NULL) {
 		LOG_DBG("Writing status to %p", status);
@@ -1195,18 +1444,21 @@ int pthread_detach(pthread_t pthread)
 	int ret = ESRCH;
 	struct posix_thread *t = NULL;
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
+	K_SPINLOCK(&pthread_pool_lock) {
 		t = to_posix_thread(pthread);
-		if (t == NULL) {
+		if (t == NULL || !t->z_thread) {
 			ret = ESRCH;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
-
+		if (t->attr.is_external) {
+			ret = EINVAL;
+			K_SPINLOCK_BREAK;
+		}
 		if (posix_thread_q_get(t) == POSIX_THREAD_READY_Q ||
 		    t->attr.detachstate != PTHREAD_CREATE_JOINABLE) {
-			LOG_DBG("Pthread %p cannot be detached", &t->thread);
+			LOG_DBG("Pthread %p cannot be detached", t->z_thread); /* NOSONAR */
 			ret = EINVAL;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		ret = 0;
@@ -1214,7 +1466,7 @@ int pthread_detach(pthread_t pthread)
 	}
 
 	if (ret == 0) {
-		LOG_DBG("Pthread %p detached", &t->thread);
+		LOG_DBG("Pthread %p detached", t->z_thread); /* NOSONAR */
 	}
 
 	return ret;
@@ -1317,9 +1569,14 @@ int pthread_attr_setstacksize(pthread_attr_t *_attr, size_t stacksize)
 	void *new_stack;
 	struct posix_thread_attr *attr = (struct posix_thread_attr *)_attr;
 
-	if (!__attr_is_initialized(attr) || (stacksize == 0) ||
-	    (PTHREAD_STACK_MIN > 0 && stacksize < PTHREAD_STACK_MIN) ||
-	    (stacksize > PTHREAD_STACK_MAX)) {
+	if (!__attr_is_initialized(attr)) {
+		return EINVAL;
+	} else if (attr->is_external) {
+		LOG_DBG("Not supported on external thread"); /* NOSONAR */
+		return EINVAL;
+	} else if ((stacksize == 0) || (PTHREAD_STACK_MIN > 0 && stacksize < PTHREAD_STACK_MIN) ||
+		   (stacksize > PTHREAD_STACK_MAX)) {
+		LOG_DBG("Invalid stacksize %zu", stacksize); /* NOSONAR */
 		return EINVAL;
 	}
 
@@ -1430,10 +1687,12 @@ int pthread_attr_destroy(pthread_attr_t *_attr)
 		return EINVAL;
 	}
 
-	ret = k_thread_stack_free(attr->stack);
-	if (ret == 0) {
-		LOG_DBG("Freed attr %p thread stack %zu@%p", _attr, __get_attr_stacksize(attr),
-			attr->stack);
+	if (!attr->is_external) { /* external thread owns the stack */
+		ret = k_thread_stack_free(attr->stack);
+		if (ret == 0) {
+			LOG_DBG("Freed attr %p thread stack %zu@%p", _attr, /* NOSONAR */
+				__get_attr_stacksize(attr), attr->stack);
+		}
 	}
 
 	*attr = (struct posix_thread_attr){0};
@@ -1444,48 +1703,35 @@ int pthread_attr_destroy(pthread_attr_t *_attr)
 
 int pthread_setname_np(pthread_t thread, const char *name)
 {
-#ifdef CONFIG_THREAD_NAME
-	k_tid_t kthread;
+	k_tid_t kthread = pthread_to_zephyr_thread_any(thread);
 
-	thread = get_posix_thread_idx(thread);
-	if (thread >= ARRAY_SIZE(posix_thread_pool)) {
+	if (!kthread) {
 		return ESRCH;
 	}
-
-	kthread = &posix_thread_pool[thread].thread;
-
 	if (name == NULL) {
 		return EINVAL;
 	}
-
+#ifdef CONFIG_THREAD_NAME
 	return k_thread_name_set(kthread, name);
 #else
-	ARG_UNUSED(thread);
-	ARG_UNUSED(name);
 	return 0;
 #endif
 }
 
 int pthread_getname_np(pthread_t thread, char *name, size_t len)
 {
-#ifdef CONFIG_THREAD_NAME
-	k_tid_t kthread;
+	k_tid_t kthread = pthread_to_zephyr_thread_any(thread);
 
-	thread = get_posix_thread_idx(thread);
-	if (thread >= ARRAY_SIZE(posix_thread_pool)) {
+	if (!kthread) {
 		return ESRCH;
 	}
-
 	if (name == NULL) {
 		return EINVAL;
 	}
-
+#ifdef CONFIG_THREAD_NAME
 	memset(name, '\0', len);
-	kthread = &posix_thread_pool[thread].thread;
 	return k_thread_name_copy(kthread, name, len - 1);
 #else
-	ARG_UNUSED(thread);
-	ARG_UNUSED(name);
 	ARG_UNUSED(len);
 	return 0;
 #endif
@@ -1510,11 +1756,11 @@ int pthread_sigmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT 
 		return EINVAL;
 	}
 
-	SYS_SEM_LOCK(&pthread_pool_lock) {
-		t = to_posix_thread(pthread_self());
+	K_SPINLOCK(&pthread_pool_lock) {
+		t = to_posix_thread(posix_thread_self(false));
 		if (t == NULL) {
 			ret = ESRCH;
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		if (oset != NULL) {
@@ -1523,7 +1769,7 @@ int pthread_sigmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT 
 
 		ret = 0;
 		if (set == NULL) {
-			SYS_SEM_LOCK_BREAK;
+			K_SPINLOCK_BREAK;
 		}
 
 		const unsigned long *const x = (const unsigned long *)set;
@@ -1549,11 +1795,27 @@ int pthread_sigmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT 
 	return ret;
 }
 
+extern struct k_thread z_main_thread;
+
 __boot_func
 static int posix_thread_pool_init(void)
 {
 	ARRAY_FOR_EACH_PTR(posix_thread_pool, th) {
 		posix_thread_q_set(th, POSIX_THREAD_READY_Q);
+	}
+	{
+		/* z_main_thread is not yet initialized, we rely only on its address */
+		struct posix_thread *pmain = posix_thread_add_external(&z_main_thread);
+
+		if (!pmain) {
+			LOG_ERR("pthread_init: Failed to add external main-thread"); /* NOSONAR */
+			k_fatal_halt(K_ERR_KERNEL_OOPS);
+		}
+		__ASSERT_NO_MSG(pmain == &posix_thread_pool[0]);
+		__ASSERT_NO_MSG(0 == posix_thread_to_offset(pmain));
+
+		/* z_main_thread not yet initialized, skip k_thread_priority_get(&z_main_thread) */
+		posix_thread_inherit_sched(CONFIG_MAIN_THREAD_PRIORITY, pmain);
 	}
 
 	return 0;

--- a/tests/subsys/portability/posix/threads_base/src/pthread.c
+++ b/tests/subsys/portability/posix/threads_base/src/pthread.c
@@ -496,7 +496,7 @@ ZTEST(pthread, test_pthread_cleanup)
 static bool testcancel_ignored;
 static bool testcancel_failed;
 
-static void *test_pthread_cancel_fn(void *arg)
+static void *test_pthread_cancel0_self_fn(void *arg)
 {
 	zassert_ok(pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL));
 
@@ -519,17 +519,99 @@ static void *test_pthread_cancel_fn(void *arg)
 	pthread_testcancel();
 
 	testcancel_failed = true;
+	zassert_unreachable();
 
 	return NULL;
 }
 
-ZTEST(pthread, test_pthread_testcancel)
+ZTEST(pthread, test_pthread_testcancel0_self)
 {
 	pthread_t th;
+	void *retval = NULL;
 
-	zassert_ok(pthread_create(&th, NULL, test_pthread_cancel_fn, NULL));
-	zassert_ok(pthread_join(th, NULL));
+	zassert_ok(pthread_create(&th, NULL, test_pthread_cancel0_self_fn, NULL));
+	zassert_ok(pthread_join(th, &retval));
+	zassert_equal_ptr(retval, PTHREAD_CANCELED);
 	zassert_true(testcancel_ignored);
+	zassert_false(testcancel_failed);
+}
+
+static atomic_t test_cancel_flags = ATOMIC_INIT(0);
+#define TEST_CANCEL_ENABLED_BIT 0
+#define TEST_CANCEL_SET_BIT     1
+
+static void *test_pthread_cancel1_ext_fn(void *arg)
+{
+	zassert_ok(pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL));
+
+	testcancel_ignored = false;
+
+	/* this should be ignored */
+	pthread_testcancel();
+
+	testcancel_ignored = true;
+
+	/* enable the thread to be cancelled */
+	zassert_ok(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL));
+	atomic_set_bit(&test_cancel_flags, TEST_CANCEL_ENABLED_BIT);
+	while (!atomic_test_bit(&test_cancel_flags, TEST_CANCEL_SET_BIT)) {
+		k_yield();
+	}
+
+	testcancel_failed = false;
+
+	/* this should terminate the thread */
+	pthread_testcancel();
+
+	testcancel_failed = true;
+	zassert_unreachable();
+
+	return NULL;
+}
+
+ZTEST(pthread, test_pthread_testcancel1_ext)
+{
+	pthread_t th;
+	void *retval = NULL;
+
+	atomic_clear(&test_cancel_flags);
+	zassert_ok(pthread_create(&th, NULL, test_pthread_cancel1_ext_fn, NULL));
+	while (!atomic_test_bit(&test_cancel_flags, TEST_CANCEL_ENABLED_BIT)) {
+		k_yield();
+	}
+	zassert_ok(pthread_cancel(th));
+	atomic_set_bit(&test_cancel_flags, TEST_CANCEL_SET_BIT);
+	zassert_ok(pthread_join(th, &retval));
+	zassert_equal_ptr(retval, PTHREAD_CANCELED);
+	zassert_true(testcancel_ignored);
+	zassert_false(testcancel_failed);
+}
+
+static void *test_pthread_cancel2_ext_fn(void *arg)
+{
+	testcancel_failed = false;
+
+	while (true) {
+		/* this should terminate the thread */
+		pthread_testcancel();
+		k_yield(); /* be more cooperative */
+	}
+
+	testcancel_failed = true;
+	zassert_unreachable();
+
+	return NULL;
+}
+
+ZTEST(pthread, test_pthread_testcancel2_ext)
+{
+	pthread_t th;
+	void *retval = NULL;
+
+	zassert_ok(pthread_create(&th, NULL, test_pthread_cancel2_ext_fn, NULL));
+	zassert_ok(pthread_cancel(th));
+	zassert_ok(pthread_join(th, &retval));
+	zassert_equal_ptr(retval, PTHREAD_CANCELED);
 	zassert_false(testcancel_failed);
 }
 
@@ -557,6 +639,106 @@ ZTEST(pthread, test_pthread_setschedprio)
 
 	zassert_ok(pthread_create(&th, NULL, test_pthread_setschedprio_fn, NULL));
 	zassert_ok(pthread_join(th, NULL));
+}
+
+ZTEST(pthread, test_pthread_setschedprio_main)
+{
+	test_pthread_setschedprio_fn(NULL);
+}
+
+static void *test_pthread_getschedparam_fn(void *arg)
+{
+	int act_policy = 0, res;
+	struct sched_param param;
+	pthread_t self = pthread_self();
+
+	zassert_ok(pthread_getschedparam(self, &act_policy, &param));
+	res = act_policy == SCHED_FIFO || act_policy == SCHED_RR;
+	zassert_true(res);
+
+	return NULL;
+}
+
+ZTEST(pthread, test_pthread_getschedparam)
+{
+	pthread_t th;
+
+	zassert_ok(pthread_create(&th, NULL, test_pthread_getschedparam_fn, NULL));
+	zassert_ok(pthread_join(th, NULL));
+}
+
+ZTEST(pthread, test_pthread_getschedparam_main)
+{
+	test_pthread_getschedparam_fn(NULL);
+}
+
+static char pthread_name_glob_name[80];
+
+static void *test_pthread_name_fn(void *arg)
+{
+	char name[80];
+	int res;
+	pthread_t self = pthread_self();
+
+	pthread_mutex_lock(&lock);
+	pthread_cond_signal(&cvar0);
+	pthread_cond_wait(&cvar1, &lock);
+
+	zassert_ok(pthread_getname_np(self, name, sizeof(name)));
+	res = strncmp("CreateThreadName", name, sizeof(name));
+	zassert_equal(0, res, "Creation Thread-Name (pthread)");
+
+	zassert_ok(pthread_setname_np(self, "ChangdThreadName"));
+	zassert_ok(pthread_getname_np(self, name, sizeof(name)));
+	res = strncmp("ChangdThreadName", name, sizeof(name));
+	zassert_equal(0, res, "Changed Thread-Name (pthread)");
+	strncpy(pthread_name_glob_name, name, sizeof(name));
+
+	pthread_mutex_unlock(&lock);
+
+	return NULL;
+}
+
+ZTEST(pthread, test_pthread_name)
+{
+	char name[80];
+	int res;
+	pthread_t th;
+
+	pthread_mutex_lock(&lock);
+	zassert_ok(pthread_create(&th, NULL, test_pthread_name_fn, NULL));
+	pthread_cond_wait(&cvar0, &lock);
+
+	zassert_ok(pthread_setname_np(th, "CreateThreadName"));
+	zassert_ok(pthread_getname_np(th, name, sizeof(name)));
+	res = strncmp("CreateThreadName", name, sizeof(name));
+	zassert_equal(0, res, "Create Thread-Name (main)");
+	pthread_cond_signal(&cvar1);
+	pthread_mutex_unlock(&lock);
+
+	zassert_ok(pthread_join(th, NULL));
+
+	if (pthread_getname_np(th, name, sizeof(name)) == 0) {
+		res = strncmp("ChangdThreadName", name, sizeof(name));
+		zassert_equal(0, res, "Changed Thread-Name (main)");
+	} /* else thread th could be already dead, OK */
+
+	res = strncmp("ChangdThreadName", pthread_name_glob_name, sizeof(pthread_name_glob_name));
+	zassert_equal(0, res, "Changed Thread-Name (main, global)");
+}
+
+ZTEST(pthread, test_pthread_name_main)
+{
+	char name[80];
+	int res;
+	pthread_t self = pthread_self();
+
+	zassert_not_equal(0, self);
+
+	zassert_ok(pthread_setname_np(self, "MainThreadName"));
+	zassert_ok(pthread_getname_np(self, name, sizeof(name)));
+	res = strncmp("MainThreadName", name, sizeof(name));
+	zassert_equal(0, res, "Main Thread-Name");
 }
 
 static void before(void *arg)

--- a/tests/subsys/portability/posix/threads_base/src/pthread.c
+++ b/tests/subsys/portability/posix/threads_base/src/pthread.c
@@ -463,6 +463,9 @@ ZTEST(pthread, test_pthread_equal)
 	zassert_false(pthread_equal(pthread_self(), (pthread_t)4242));
 }
 
+static atomic_t test_cleanup_flags = ATOMIC_INIT(0);
+#define TEST_CLEANUP_DONE_BIT 0
+
 static void cleanup_handler(void *arg)
 {
 	bool *boolp = (bool *)arg;
@@ -470,27 +473,123 @@ static void cleanup_handler(void *arg)
 	*boolp = true;
 }
 
-static void *test_pthread_cleanup_entry(void *arg)
+static void *test_pthread_cleanup_entry_explicit(void *arg)
 {
-	bool executed[2] = {0};
+	bool executed[2] = {false, false};
 
+	ARG_UNUSED(arg);
 	pthread_cleanup_push(cleanup_handler, &executed[0]);
 	pthread_cleanup_push(cleanup_handler, &executed[1]);
 	pthread_cleanup_pop(false);
 	pthread_cleanup_pop(true);
 
-	zassert_true(executed[0]);
-	zassert_false(executed[1]);
+	zassert_equal(true, executed[0]);
+	zassert_equal(false, executed[1]);
 
 	return NULL;
 }
 
-ZTEST(pthread, test_pthread_cleanup)
+static void *test_pthread_cleanup_entry_pexit(void *arg)
+{
+	bool *executedp = (bool *)arg;
+
+	pthread_cleanup_push(cleanup_handler, executedp + 0); /* NOSONAR */
+	pthread_cleanup_push(cleanup_handler, executedp + 1); /* NOSONAR */
+
+	if (atomic_test_bit(&test_cleanup_flags, TEST_CLEANUP_DONE_BIT)) {
+		/* will exit this user thread-func and execute cleanup-handler */
+		pthread_exit(executedp);
+	}
+
+	pthread_cleanup_pop(false);
+	pthread_cleanup_pop(false);
+	zassert_unreachable();
+	return NULL;
+}
+
+static void *test_pthread_cleanup_entry_cancelsync(void *arg)
+{
+	bool *executedp = (bool *)arg;
+
+	pthread_cleanup_push(cleanup_handler, executedp + 0); /* NOSONAR */
+	pthread_cleanup_push(cleanup_handler, executedp + 1); /* NOSONAR */
+
+	while (true) {
+		/* Will exit this user thread-func and execute cleanup-handler. */
+		pthread_testcancel();
+		k_yield(); /* be more cooperative */
+	}
+
+	pthread_cleanup_pop(false);
+	pthread_cleanup_pop(false);
+	zassert_unreachable();
+	return NULL;
+}
+
+static void *test_pthread_cleanup_entry_return(void *arg)
+{
+	bool *executedp = (bool *)arg;
+
+	pthread_cleanup_push(cleanup_handler, executedp + 0); /* NOSONAR */
+	pthread_cleanup_push(cleanup_handler, executedp + 1); /* NOSONAR */
+	if (atomic_test_bit(&test_cleanup_flags, TEST_CLEANUP_DONE_BIT)) {
+		/* will exit this user thread-func without executing cleanup-handler */
+		return executedp;
+	}
+	pthread_cleanup_pop(true);
+	pthread_cleanup_pop(true);
+	zassert_unreachable();
+	return NULL;
+}
+
+ZTEST(pthread, test_pthread_cleanup0_explicit)
 {
 	pthread_t th;
 
-	zassert_ok(pthread_create(&th, NULL, test_pthread_cleanup_entry, NULL));
+	zassert_ok(pthread_create(&th, NULL, test_pthread_cleanup_entry_explicit, NULL));
 	zassert_ok(pthread_join(th, NULL));
+}
+
+ZTEST(pthread, test_pthread_cleanup1_pexit)
+{
+	pthread_t th;
+	bool executed[2] = {false, false};
+	void *retval = NULL;
+
+	atomic_set_bit(&test_cleanup_flags, TEST_CLEANUP_DONE_BIT);
+	zassert_ok(pthread_create(&th, NULL, test_pthread_cleanup_entry_pexit, executed));
+	zassert_ok(pthread_join(th, &retval));
+	zassert_equal_ptr(retval, executed);
+	zassert_equal(true, executed[0]);
+	zassert_equal(true, executed[1]);
+}
+
+ZTEST(pthread, test_pthread_cleanup2_cancel_sync)
+{
+	pthread_t th;
+	bool executed[2] = {false, false};
+	void *retval = NULL;
+
+	zassert_ok(pthread_create(&th, NULL, test_pthread_cleanup_entry_cancelsync, executed));
+	zassert_ok(pthread_cancel(th));
+	zassert_ok(pthread_join(th, &retval));
+	zassert_equal_ptr(retval, PTHREAD_CANCELED);
+	zassert_equal(true, executed[0]);
+	zassert_equal(true, executed[1]);
+}
+
+ZTEST(pthread, test_pthread_cleanup3_return)
+{
+	pthread_t th;
+	bool executed[2] = {false, false};
+	void *retval = NULL;
+
+	atomic_set_bit(&test_cleanup_flags, TEST_CLEANUP_DONE_BIT);
+	zassert_ok(pthread_create(&th, NULL, test_pthread_cleanup_entry_return, executed));
+	zassert_ok(pthread_join(th, &retval));
+	zassert_equal_ptr(retval, executed);
+	zassert_equal(false, executed[0]);
+	zassert_equal(false, executed[1]);
 }
 
 static bool testcancel_ignored;

--- a/tests/subsys/portability/posix/threads_base/src/pthread_kthread.c
+++ b/tests/subsys/portability/posix/threads_base/src/pthread_kthread.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018-2023 Intel Corporation
+ * Copyright (c) 2026 Göthel Software
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <pthread.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/ztest.h>
+
+extern k_tid_t pthread_to_zephyr_thread(pthread_t pth);
+
+#define STACKSIZE 2000
+static K_THREAD_STACK_DEFINE(kthread__stack, STACKSIZE);
+
+static pthread_t pthread_thread2;
+static struct k_thread *kthread_thread2;
+
+static void *pthread_entry(void *arg)
+{
+	k_tid_t kself = k_current_get();
+
+	ARG_UNUSED(arg);
+	zassert_not_null(kself);
+
+	pthread_t pself = pthread_self();
+
+	zassert_not_equal(0, pself);
+	pthread_thread2 = pself;
+
+	k_tid_t kself2 = pthread_to_zephyr_thread(pself);
+
+	zassert_equal_ptr(kself, kself2);
+	return NULL;
+}
+
+static void kthread_entry(void)
+{
+	k_tid_t kself = k_current_get();
+
+	zassert_not_null(kself);
+	kthread_thread2 = kself;
+
+	pthread_t pself = pthread_self();
+
+	zassert_not_equal(0, pself);
+
+	k_tid_t kself2 = pthread_to_zephyr_thread(pself);
+
+	zassert_equal_ptr(kself, kself2);
+}
+
+ZTEST(pthread_kthread, test_pthread_kthread_self)
+{
+	k_tid_t kself = k_current_get();
+
+	zassert_not_null(kself);
+
+	pthread_t pself = pthread_self();
+
+	zassert_not_equal(0, pself);
+
+	k_tid_t kself2 = pthread_to_zephyr_thread(pself);
+
+	zassert_equal_ptr(kself, kself2);
+}
+
+ZTEST(pthread_kthread, test_pthread_kthread_coop)
+{
+	pthread_t pthread_thread;
+	struct k_thread kthread_thread;
+
+	zassert_ok(pthread_create(&pthread_thread, NULL, &pthread_entry, NULL));
+
+	k_thread_create(&kthread_thread, kthread__stack, STACKSIZE, (k_thread_entry_t)kthread_entry,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+
+	zassert_ok(pthread_join(pthread_thread, NULL));
+	zassert_equal(pthread_thread, pthread_thread2);
+
+	zassert_ok(k_thread_join(&kthread_thread, K_FOREVER));
+	zassert_equal_ptr(&kthread_thread, kthread_thread2);
+}
+
+static void before(void *arg)
+{
+	ARG_UNUSED(arg);
+
+	if (!IS_ENABLED(CONFIG_DYNAMIC_THREAD)) {
+		/* skip redundant testing if there is no thread pool / heap allocation */
+		ztest_test_skip();
+	}
+}
+
+ZTEST_SUITE(pthread_kthread, NULL, NULL, before, NULL, NULL);

--- a/tests/subsys/portability/posix/threads_base/src/pthread_specific.c
+++ b/tests/subsys/portability/posix/threads_base/src/pthread_specific.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018-2023 Intel Corporation
+ * Copyright (c) 2026 Göthel Software
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <pthread.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/ztest.h>
+
+#define STACKSIZE 2000
+static K_THREAD_STACK_DEFINE(kthread__stack, STACKSIZE);
+
+static pthread_key_t key;
+static uint8_t const tagP = 0x11U;
+static uint8_t const tagK = 0x22U;
+static uint8_t const tagM = 0x22U;
+
+static void *pthread_entry(void *arg)
+{
+	pthread_t pself = pthread_self();
+
+	ARG_UNUSED(arg);
+	zassert_not_equal(0, pself);
+
+	uint8_t *val = (uint8_t *)pthread_getspecific(key);
+
+	zassert_is_null(val);
+
+	zassert_ok(pthread_setspecific(key, (void *)&tagP));
+
+	val = (uint8_t *)pthread_getspecific(key);
+	zassert_not_null(val);
+	zassert_equal_ptr(val, &tagP);
+	zassert_equal(*val, tagP);
+	return NULL;
+}
+
+static void kthread_entry(void)
+{
+	pthread_t pself = pthread_self();
+
+	zassert_not_equal(0, pself);
+
+	uint8_t *val = (uint8_t *)pthread_getspecific(key);
+
+	zassert_is_null(val);
+
+	zassert_ok(pthread_setspecific(key, (void *)&tagK));
+
+	val = (uint8_t *)pthread_getspecific(key);
+	zassert_not_null(val);
+	zassert_equal_ptr(val, &tagK);
+	zassert_equal(*val, tagK);
+}
+
+ZTEST(pthread_specific, test_pthread_specific_pkthread)
+{
+	pthread_t pthread_thread;
+	struct k_thread kthread_thread;
+
+	zassert_ok(pthread_key_create(&key, NULL));
+
+	uint8_t *val = (uint8_t *)pthread_getspecific(key);
+
+	zassert_is_null(val);
+
+	zassert_ok(pthread_setspecific(key, (void *)&tagM));
+
+	val = (uint8_t *)pthread_getspecific(key);
+	zassert_not_null(val);
+	zassert_equal_ptr(val, &tagM);
+	zassert_equal(*val, tagM);
+	{
+		zassert_ok(pthread_create(&pthread_thread, NULL, &pthread_entry, NULL));
+
+		k_thread_create(&kthread_thread, kthread__stack, STACKSIZE,
+				(k_thread_entry_t)kthread_entry, NULL, NULL, NULL, K_PRIO_COOP(7),
+				0, K_NO_WAIT);
+
+		zassert_ok(pthread_join(pthread_thread, NULL));
+		zassert_ok(k_thread_join(&kthread_thread, K_FOREVER));
+	}
+}
+
+static void before(void *arg)
+{
+	ARG_UNUSED(arg);
+
+	if (!IS_ENABLED(CONFIG_DYNAMIC_THREAD)) {
+		/* skip redundant testing if there is no thread pool / heap allocation */
+		ztest_test_skip();
+	}
+}
+
+ZTEST_SUITE(pthread_specific, NULL, NULL, before, NULL, NULL);


### PR DESCRIPTION
# pthread: Unwind & execute all cleanup handler where required

This PR furthers compliance with the [POSIX pthread cleanup handler](https://pubs.opengroup.org/onlinepubs/7908799/xsh/pthread_cleanup_push.html) spec.

This PR is build on top of https://github.com/zephyrproject-rtos/zephyr/pull/109291

## Impact
    
### Unwind & execute all cleanup handler on
- `pthread_exit`
- `pthread_testcancel`
    
### TODO: Unwind & execute all cleanup handler on _async-cancel_
- `pthread_cancel`
- `pthread_setcancelstate`

Despite the async cancel nature, the cleanup handler shall be
executed on the user's target-thread. _This may be implemented in a subsequent PR._
    
### Resets `cleanup_list` (no execution of handlers) on
- `return`, i.e. `zephyr_thread_wrapper` end-of-scope
- Above async TODO

The reset avoids an SIGSEGV on potentially unwound `__pthread_cleanup`
stack entries, possible via `return`, `goto`, `longjmp`, etc.

## Implementation    
Implementation uses `posix_thread_finalize` to either unwind-and-execute
or reset the cleanup handler.

The `cleanup_list` is manipulated under the acquired `pthread_pool_lock`,
while execution of the handler is w/o lock.

## Testing
- Passing old and new `tests/subsys/portability/posix` ZTests
  - `qemu_x86/atom` (uni, gcc)
  - `mps2/an385` (uni, gcc, qemu)
  - `qemu_riscv32e/qemu_virt_riscv32e` (uni, llvm)
  - `qemu_x86_64/atom` (smp, gcc)
  - `qemu_riscv64/qemu_virt_riscv64/smp` (smp, gcc)
   