### PR TITLE
tests: drivers: can: check host interface state

### DIFF
--- a/tests/drivers/can/host/README.rst
+++ b/tests/drivers/can/host/README.rst
@@ -72,7 +72,7 @@ be launched using Twister:
 
 .. code-block:: shell
 
-   west twister -v -p native_sim/native/64 -X can:zcan0 -T tests/drivers/can/host/
+   west twister -v -p native_sim/native/64 -X can --pytest-args=--can-context=zcan0 -T tests/drivers/can/host/
 
 After the test suite has completed, the virtual SocketCAN interface can be removed again:
 

--- a/tests/drivers/can/host/pytest/conftest.py
+++ b/tests/drivers/can/host/pytest/conftest.py
@@ -6,15 +6,95 @@
 Configuration of Zephyr CAN <=> host CAN test suite.
 """
 
+import json
 import logging
 import re
+import subprocess
 
 import pytest
 from can import Bus, BusABC
+from can.exceptions import CanError
+from can.util import load_config
 from can_shell import CanShellBus
 from twister_harness import DeviceAdapter, Shell
 
 logger = logging.getLogger(__name__)
+
+
+def _socketcan_channel(context: str) -> str | None:
+    """Return the SocketCAN channel for a python-can context, if applicable."""
+    try:
+        config = load_config(context=context)
+    except CanError as err:
+        pytest.fail(f'failed to load python-can context "{context}": {err}')
+
+    if config.get('interface') != 'socketcan':
+        logger.info(
+            'skipping SocketCAN link state check for python-can interface "%s"',
+            config.get('interface'),
+        )
+        return None
+
+    channel = config.get('channel')
+    if not channel:
+        pytest.fail(
+            f'python-can context "{context}" uses SocketCAN but does not configure a channel'
+        )
+
+    if not isinstance(channel, str):
+        pytest.fail(
+            f'python-can context "{context}" uses unsupported SocketCAN channel "{channel}"'
+        )
+
+    return channel
+
+
+def _check_socketcan_link(channel: str) -> None:
+    """Fail if a SocketCAN network interface is missing or down."""
+    try:
+        result = subprocess.run(
+            ['ip', '-details', '-json', 'link', 'show', 'dev', channel],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        pytest.fail('ip command not found; install iproute2 to check SocketCAN link state')
+
+    if result.returncode != 0:
+        details = result.stderr.strip() or result.stdout.strip()
+        if 'does not exist' in details:
+            pytest.fail(f'SocketCAN interface "{channel}" not found: {details}')
+
+        pytest.fail(
+            f'failed to query SocketCAN interface "{channel}"' + (f': {details}' if details else '')
+        )
+
+    try:
+        links = json.loads(result.stdout)
+    except json.JSONDecodeError as err:
+        pytest.fail(f'failed to parse "ip" output for SocketCAN interface "{channel}": {err}')
+
+    if not links:
+        pytest.fail(f'SocketCAN interface "{channel}" not found')
+
+    link = links[0]
+    link_type = link.get('link_type')
+    link_kind = link.get('linkinfo', {}).get('info_kind')
+    if link_type != 'can' and link_kind not in ('can', 'vcan'):
+        pytest.fail(
+            f'network interface "{channel}" is not a SocketCAN interface '
+            f'(link_type={link_type}, info_kind={link_kind})'
+        )
+
+    flags = link.get('flags', [])
+    if 'UP' not in flags:
+        pytest.fail(
+            f'SocketCAN interface "{channel}" is down; bring it up with '
+            f'"sudo ip link set up {channel}"'
+        )
+
+    logger.info('SocketCAN interface "%s" is up', channel)
 
 
 def pytest_addoption(parser) -> None:
@@ -58,8 +138,17 @@ def fixture_chosen(shell: Shell) -> str:
     return None
 
 
+@pytest.fixture(name='host_can_ready', scope='session')
+def fixture_host_can_ready(context: str) -> None:
+    """Verify that the configured host CAN interface is ready."""
+    channel = _socketcan_channel(context)
+
+    if channel is not None:
+        _check_socketcan_link(channel)
+
+
 @pytest.fixture
-def can_dut(dut: DeviceAdapter, shell: Shell, chosen: str) -> BusABC:
+def can_dut(dut: DeviceAdapter, shell: Shell, chosen: str, host_can_ready: None) -> BusABC:
     """Return DUT CAN bus."""
     bus = CanShellBus(dut, shell, chosen)
     yield bus
@@ -68,7 +157,7 @@ def can_dut(dut: DeviceAdapter, shell: Shell, chosen: str) -> BusABC:
 
 
 @pytest.fixture
-def can_host(context: str) -> BusABC:
+def can_host(context: str, host_can_ready: None) -> BusABC:
     """Return host CAN bus."""
     bus = Bus(config_context=context)
     yield bus


### PR DESCRIPTION
## Summary
- add a pytest preflight for SocketCAN host interfaces in the CAN host test
- fail early when the configured host SocketCAN interface is missing, down, or invalid
- update the native_sim README command so Twister runs the pytest test with the CAN fixture and passes the python-can context separately

## Motivation
When the host CAN interface is down, the test currently fails later as a DUT/traffic timeout, which makes infrastructure issues harder to diagnose. This reports the host-side setup problem during fixture setup instead.

Fixes #111772.

## Validation
- `west twister -v -p native_sim/native/64 -X can --pytest-args=--can-context=zcan0 -T tests/drivers/can/host/`
  - `drivers.can.host PASSED`
  - `10 of 10 executed test cases passed`
