### PR TITLE
drivers: display: stm32_ltdc: select GPIO as needed

### DIFF
--- a/drivers/display/Kconfig.stm32_ltdc
+++ b/drivers/display/Kconfig.stm32_ltdc
@@ -11,6 +11,8 @@ menuconfig STM32_LTDC
 	select CACHE_MANAGEMENT if DCACHE
 	select PINCTRL
 	select RESET
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_LTDC),disp-on-gpios) || \
+		$(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_LTDC),bl-ctrl-gpios)
 	help
 	  Enable driver for STM32 LCT-TFT display controller periheral.
 


### PR DESCRIPTION
Following #109468, GPIO is now disabled by default on STM32 boards.
On the other hand, the STM32 LTDC driver optionally uses 2 GPIOs to
control the display on/off and backlight, and will configure them
automatically when they are given in the device tree. Consequently,
without any further change, this leads to this kind of error:

    [00:00:00.000,000] <err> stm32_gpioport_mgr:
                       Attempting to use GPIO API without enabling it!
    [00:00:00.000,000] <err> display_stm32_ltdc:
                       Configuration of display on/off control GPIO failed

(as seen with samples/drivers/display on STM32H7S78-DK)

Therefore enable GPIO when the LTDC uses them.