### PR TITLE
drivers: video: mt9m114: fix uninitialized reg write for 1 byte

### DIFF
--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -238,6 +238,7 @@ static int mt9m114_write_reg(const struct device *dev, uint16_t reg_addr, uint8_
 		val = sys_cpu_to_be32(*(const uint32_t *)value);
 		break;
 	case 1:
+		val = *(const uint8_t *)value;
 		break;
 	default:
 		return -ENOTSUP;


### PR DESCRIPTION
1-byte write in mt9m114_write_reg() was not assigned to `val` variable, which caused uninitialized value to be written to the register, and causing corrupted / invalid byte write.

Introduced from commit e3a7a32334bd85cd579f0677e559c149164780ae

Fixes #110931 