### PR TITLE
kernel: timeout: centralise sloppy idle and drop the sys_clock_set_timeout() idle argument

### DIFF
--- a/boards/qemu/cortex_m0/nrf_timer_timer.c
+++ b/boards/qemu/cortex_m0/nrf_timer_timer.c
@@ -162,9 +162,8 @@ void timer0_nrf_isr(void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : (dticks > 0));
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	uint32_t cyc;
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {

--- a/doc/kernel/services/timing/clocks.rst
+++ b/doc/kernel/services/timing/clocks.rst
@@ -265,6 +265,26 @@ comparatively simple API.
   :c:func:`sys_clock_announce`, which the kernel needs to test newly
   arriving timeouts for expiration.
 
+* The driver may optionally provide a :c:func:`sys_clock_unused` call.  The
+  kernel invokes it, in place of :c:func:`sys_clock_set_timeout`, when no
+  timeout is pending and :kconfig:option:`CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE`
+  allows the system uptime to drift.  A driver may use it to halt its counter
+  and stop taking interrupts until the next :c:func:`sys_clock_set_timeout`
+  resumes it.  Unlike :c:func:`sys_clock_disable`, this is a resumable pause,
+  not a teardown; the default implementation is a no-op, so a driver that does
+  nothing here simply stops being reprogrammed and quiesces on its own, and
+  sloppy idle is available to every driver without extra code.
+
+* The driver may optionally provide a :c:func:`sys_clock_idle_enter` call,
+  which the power-management path uses in place of
+  :c:func:`sys_clock_set_timeout` when the CPU is about to enter low-power
+  idle, passing the number of ticks until the next expected wakeup.  A driver
+  that can hand off to a low-power wakeup timer (or otherwise reconfigure for
+  sleep) does so here; recovery happens in :c:func:`sys_clock_idle_exit`.  The
+  default implementation just programs the wakeup through
+  :c:func:`sys_clock_set_timeout`, so a driver with no low-power handling needs
+  no implementation.
+
 Timer Driver Locking
 --------------------
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -665,6 +665,17 @@ Timer
   range or special-case ``K_TICKS_FOREVER``; only their own hardware cycle-count limits
   still need enforcing (:github:`111022`).
 
+* Under ``CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE``, the kernel now calls the new weak
+  :c:func:`sys_clock_unused` hook when no timeout is pending, rather than passing
+  ``SYS_CLOCK_MAX_WAIT`` to :c:func:`sys_clock_set_timeout`. An out-of-tree timer driver that
+  stopped its counter on ``ticks == SYS_CLOCK_MAX_WAIT`` must do so in a
+  :c:func:`sys_clock_unused` implementation instead (:github:`112750`).
+
+* :c:func:`sys_clock_set_timeout` no longer takes a ``bool idle`` argument; the low-power
+  idle hint moved to the new weak :c:func:`sys_clock_idle_enter` hook. Out-of-tree timer
+  drivers must drop the parameter from their :c:func:`sys_clock_set_timeout` definition and
+  move any ``idle``-specific handling to :c:func:`sys_clock_idle_enter` (:github:`112750`).
+
 USB
 ===
 

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -44,8 +44,9 @@ config SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE
 config SYSTEM_CLOCK_SLOPPY_IDLE
 	bool "Timer allowed to skew uptime clock during idle"
 	help
-	  When true, the timer driver is not required to maintain a
-	  correct system uptime count when the system enters idle.
+	  When true, the kernel may let the system uptime count drift while
+	  there are no pending timeouts, rather than keep waking the CPU to
+	  maintain it.
 	  Some platforms may take advantage of this to reduce the
 	  overhead from regular interrupts required to handle counter
 	  wraparound conditions.

--- a/drivers/timer/ambiq_stimer.c
+++ b/drivers/timer/ambiq_stimer.c
@@ -137,9 +137,8 @@ void stimer_isr(const void *arg)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -131,9 +131,8 @@ static void isr(const void *arg)
 	sys_clock_announce_locked(delta_ticks, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -256,26 +256,24 @@ static void timer_int_handler(const void *unused)
 
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_unused(void)
 {
-	/* If the kernel allows us to miss tick announcements in idle,
-	 * then shut off the counter. (Note: we can assume if idle==true
-	 * that interrupts are already disabled)
-	 */
-#if SMP_TIMER_DRIVER
-	/* as 64-bits GFRC is used as wall clock, it's ok to ignore idle
-	 * systick will not be missed.
-	 * However for single core using 32-bits arc timer, idle cannot
-	 * be ignored, as 32-bits timer will overflow in a not-long time.
-	 */
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
-	    ticks == SYS_CLOCK_MAX_WAIT) {
-		timer0_control_register_set(0);
-		timer0_count_register_set(0);
-		timer0_limit_register_set(0);
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
 
+	/* No timeout pending under sloppy idle: shut the counter off. */
+	timer0_control_register_set(0);
+	timer0_count_register_set(0);
+	timer0_limit_register_set(0);
+#if !SMP_TIMER_DRIVER
+	last_load = TIMER_STOPPED;
+#endif
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+#if SMP_TIMER_DRIVER
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint32_t delay;
 	uint32_t key;
@@ -299,15 +297,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	arch_irq_unlock(key);
 #endif
 #else
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
-	    ticks == SYS_CLOCK_MAX_WAIT) {
-		timer0_control_register_set(0);
-		timer0_count_register_set(0);
-		timer0_limit_register_set(0);
-		last_load = TIMER_STOPPED;
-		return;
-	}
-
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint32_t delay;
 	uint32_t unannounced;

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -271,7 +271,7 @@ void sys_clock_unused(void)
 #endif
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 #if SMP_TIMER_DRIVER
 #if defined(CONFIG_TICKLESS_KERNEL)

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -112,7 +112,7 @@ static void arm_arch_timer_compare_isr(const void *arg)
 	sys_clock_announce_locked(delta_ticks, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/cc13xx_cc26xx_rtc_timer.c
+++ b/drivers/timer/cc13xx_cc26xx_rtc_timer.c
@@ -187,9 +187,8 @@ static void startDevice(void)
 	irq_unlock(key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 #ifdef CONFIG_TICKLESS_KERNEL
 

--- a/drivers/timer/cc23x0_rtc_timer.c
+++ b/drivers/timer/cc23x0_rtc_timer.c
@@ -31,9 +31,8 @@ static uint32_t last_rtc_count;
 
 #define TICK_PERIOD_MICRO_SEC (1000000 / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	/* Get current value as early as possible */
 	uint32_t ticks_now = HWREG(RTC_BASE + RTC_O_TIME8U);

--- a/drivers/timer/cc23x0_systim_timer.c
+++ b/drivers/timer/cc23x0_systim_timer.c
@@ -52,9 +52,8 @@ static int sys_clock_driver_init(void);
 /*
  * Set system clock timeout.
  */
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	/* Get current value as early as possible */
 	uint32_t now_tick = HWREG(SYSTIM_BASE + SYSTIM_O_TIME1U);

--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -70,6 +70,30 @@ static uint32_t elapsed(uint32_t *val_out)
 	return data->load - value;
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	const struct tmr_cmsdk_apb_cfg *const cfg = &cfg_inst0;
+
+	/* No pending timeout: reload the counter with the maximum interval so
+	 * the hardware waits as long as it can before the next interrupt.
+	 *
+	 * This is an auto-reload down-counter, not a free-running compare, so
+	 * it cannot simply stop reprogramming the way the compare timers do:
+	 * that would keep firing at the previous, possibly short, interval.
+	 * Programming the maximum reload matches what non-sloppy idle already
+	 * does via next_timeout(). Stopping the counter here (clearing
+	 * TIMER_CTRL_EN and re-enabling it in sys_clock_set_timeout()) would
+	 * avoid the wakeup entirely; that is left out for now to avoid a
+	 * riskier change to the cycle accounting.
+	 */
+	cfg->timer->reload = MAX_CYC;
+	cfg->timer->value = MAX_CYC;
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
@@ -94,13 +118,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	data->cycle_count += pending_cycles;
 	unannounced_cycles = data->cycle_count - data->announced_cycles;
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * No pending timeout and no future timer interrupt required:
-		 * wait as long as the hardware allows.
-		 */
-		load_to_be_set = MAX_CYC;
-	} else if ((int32_t)unannounced_cycles < 0) {
+	if ((int32_t)unannounced_cycles < 0) {
 		load_to_be_set = MIN_DELAY_CYCLES;
 	} else {
 		int64_t want = ((uint64_t)data->last_elapsed + ticks) * CYC_PER_TICK;

--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -94,7 +94,7 @@ void sys_clock_unused(void)
 	cfg->timer->value = MAX_CYC;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -102,7 +102,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	ARG_UNUSED(idle);
 
 	const struct tmr_cmsdk_apb_cfg *const cfg = &cfg_inst0;
 	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -331,53 +331,8 @@ void sys_clock_unused(void)
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
+	ARG_UNUSED(idle);
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-#if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
-	if (idle) {
-		uint64_t timeout_us =
-			((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-		timeout_idle = true;
-
-		/**
-		 * Invoke platform-specific layer to configure LPTIM
-		 * such that system wakes up after timeout elapses.
-		 */
-		z_sys_clock_lpm_enter(timeout_us);
-
-#if !defined(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)
-		/* Store current value of SysTick counter to be able to
-		 * calculate a difference in measurements after exiting
-		 * the low-power state.
-		 */
-		cycle_pre_idle = cycle_count + elapsed();
-#else /* CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
-		/**
-		 * SysTick will be placed under reset once we enter
-		 * low-power mode. Turn it off right now then update
-		 * the cycle counter now, since we won't be able to
-		 * to it after waking up.
-		 */
-		sys_clock_disable();
-		/* Ensure the SysTick interrupt is not pending. This is safe
-		 * as we just did the ISR's job, and MUST be done because
-		 * a pending interrupt could inhibit low-power mode entry.
-		 * Note: On Armv8-M, ICSR.STTNS is R/W, so preserve it while
-		 * writing the write-1-to-clear PENDSTCLR bit.
-		 */
-#ifdef SCB_ICSR_STTNS_Msk
-		SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
-#else
-		SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
-#endif
-
-		cycle_count += elapsed();
-		overflow_cyc = 0;
-#endif /* !CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
-		return;
-	}
-#endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 
 #if defined(CONFIG_TICKLESS_KERNEL)
 	/*
@@ -476,6 +431,56 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		cycle_count += val1 - val2;
 	}
 #endif
+}
+
+void sys_clock_idle_enter(uint32_t ticks)
+{
+#if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
+	uint64_t timeout_us =
+		((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
+	timeout_idle = true;
+
+	/**
+	 * Invoke platform-specific layer to configure LPTIM
+	 * such that system wakes up after timeout elapses.
+	 */
+	z_sys_clock_lpm_enter(timeout_us);
+
+#if !defined(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)
+	/* Store current value of SysTick counter to be able to
+	 * calculate a difference in measurements after exiting
+	 * the low-power state.
+	 */
+	cycle_pre_idle = cycle_count + elapsed();
+#else /* CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
+	/**
+	 * SysTick will be placed under reset once we enter
+	 * low-power mode. Turn it off right now then update
+	 * the cycle counter now, since we won't be able to
+	 * to it after waking up.
+	 */
+	sys_clock_disable();
+	/* Ensure the SysTick interrupt is not pending. This is safe
+	 * as we just did the ISR's job, and MUST be done because
+	 * a pending interrupt could inhibit low-power mode entry.
+	 * Note: On Armv8-M, ICSR.STTNS is R/W, so preserve it while
+	 * writing the write-1-to-clear PENDSTCLR bit.
+	 */
+#ifdef SCB_ICSR_STTNS_Msk
+	SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
+#else
+	SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
+#endif
+
+	cycle_count += elapsed();
+	overflow_cyc = 0;
+#endif /* !CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
+#else /* CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
+	sys_clock_set_timeout(ticks, false);
+#endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 }
 
 uint32_t sys_clock_elapsed(void)

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -329,9 +329,8 @@ void sys_clock_unused(void)
 	last_load = TIMER_STOPPED;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #if defined(CONFIG_TICKLESS_KERNEL)
@@ -479,7 +478,7 @@ void sys_clock_idle_enter(uint32_t ticks)
 	overflow_cyc = 0;
 #endif /* !CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
 #else /* CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
-	sys_clock_set_timeout(ticks, false);
+	sys_clock_set_timeout(ticks);
 #endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 }
 

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -315,21 +315,23 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 }
 ARCH_ISR_DIAG_ON
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* Fast CPUs and a 24 bit counter mean that even idle systems need to
+	 * wake up multiple times per second. With no timeout pending and sloppy
+	 * idle allowing the uptime to drift, shut off the counter entirely.
+	 */
+	SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
+	last_load = TIMER_STOPPED;
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	/* Fast CPUs and a 24 bit counter mean that even idle systems
-	 * need to wake up multiple times per second.  If the kernel
-	 * allows us to miss tick announcements while nothing is pending
-	 * (sloppy idle), then shut off the counter.
-	 */
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
-	    ticks == SYS_CLOCK_MAX_WAIT) {
-		SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
-		last_load = TIMER_STOPPED;
-		return;
-	}
 
 #if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
 	if (idle) {

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -40,7 +40,6 @@ static uint64_t lptim_pre_idle;
 static bool timeout_idle;
 #endif
 
-static struct k_spinlock lock;
 static uint64_t last_count;
 
 /* Systimer HAL layer object */
@@ -79,7 +78,7 @@ static void IRAM_ATTR sys_timer_isr(void *arg)
 	ARG_UNUSED(arg);
 	systimer_ll_clear_alarm_int(systimer_hal.dev, SYSTIMER_ALARM_OS_TICK_CORE0);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 
 	uint64_t now = get_systimer_alarm();
 	uint64_t dticks = sys_timer_elapsed_ticks(now);
@@ -93,12 +92,13 @@ static void IRAM_ATTR sys_timer_isr(void *arg)
 		set_systimer_alarm(next);
 	}
 
-	k_spin_unlock(&lock, key);
-	sys_clock_announce(dticks);
+	sys_clock_announce_locked(dticks, key);
 }
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 #if defined(CONFIG_TICKLESS_KERNEL)
 	if (systimer_hal.dev == NULL) {
 		return;
@@ -106,7 +106,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t now = get_systimer_alarm();
 	uint32_t adj, cyc = ticks * CYC_PER_TICK;
 
@@ -138,12 +137,13 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	ARG_UNUSED(idle);
 #endif
 
-	k_spin_unlock(&lock, key);
 #endif
 }
 
 uint32_t sys_clock_elapsed(void)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
 	}
@@ -152,11 +152,7 @@ uint32_t sys_clock_elapsed(void)
 		return 0;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ret = ((uint32_t)get_systimer_alarm() - (uint32_t)last_count) / CYC_PER_TICK;
-
-	k_spin_unlock(&lock, key);
-	return ret;
+	return ((uint32_t)get_systimer_alarm() - (uint32_t)last_count) / CYC_PER_TICK;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -189,7 +185,7 @@ void sys_clock_idle_exit(void)
 		return;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 
 	uint64_t lptim_now = esp32_lptim_hook_on_lpm_exit();
 	uint64_t systimer_now = get_systimer_alarm();
@@ -216,10 +212,8 @@ void sys_clock_idle_exit(void)
 
 	timeout_idle = false;
 
-	k_spin_unlock(&lock, key);
-
 	/* Announce OS ticks as systimer remained stalled while in light sleep */
-	sys_clock_announce(dticks);
+	sys_clock_announce_locked(dticks, key);
 }
 #endif
 

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -95,9 +95,8 @@ static void IRAM_ATTR sys_timer_isr(void *arg)
 	sys_clock_announce_locked(dticks, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #if defined(CONFIG_TICKLESS_KERNEL)
@@ -130,7 +129,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 #if defined(CONFIG_PM)
 void sys_clock_idle_enter(uint32_t ticks)
 {
-	sys_clock_set_timeout(ticks, false);
+	sys_clock_set_timeout(ticks);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL) || systimer_hal.dev == NULL) {
 		return;

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -97,6 +97,7 @@ static void IRAM_ATTR sys_timer_isr(void *arg)
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
+	ARG_UNUSED(idle);
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #if defined(CONFIG_TICKLESS_KERNEL)
@@ -123,22 +124,25 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	}
 
 	set_systimer_alarm(cyc + last_count);
-
-#if defined(CONFIG_PM)
-	if (idle) {
-		uint64_t timeout_us =
-			((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-		lptim_pre_idle = esp32_lptim_hook_on_lpm_entry(timeout_us);
-		systimer_pre_idle = get_systimer_alarm();
-		timeout_idle = true;
-	}
-#else
-	ARG_UNUSED(idle);
-#endif
-
 #endif
 }
+
+#if defined(CONFIG_PM)
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	sys_clock_set_timeout(ticks, false);
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL) || systimer_hal.dev == NULL) {
+		return;
+	}
+
+	uint64_t timeout_us = ((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+
+	lptim_pre_idle = esp32_lptim_hook_on_lpm_entry(timeout_us);
+	systimer_pre_idle = get_systimer_alarm();
+	timeout_idle = true;
+}
+#endif
 
 uint32_t sys_clock_elapsed(void)
 {

--- a/drivers/timer/gecko_burtc_timer.c
+++ b/drivers/timer/gecko_burtc_timer.c
@@ -109,9 +109,8 @@ static void burtc_isr(const void *arg)
 	sys_clock_announce(unannounced);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -361,9 +361,8 @@ void sys_clock_unused(void)
 	hpet_gconf_set(reg);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -349,6 +349,18 @@ void smp_timer_init(void)
 	 */
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	uint32_t reg = hpet_gconf_get();
+
+	reg &= ~GCONF_ENABLE;
+	hpet_gconf_set(reg);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -356,15 +368,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #if defined(CONFIG_TICKLESS_KERNEL)
-	uint32_t reg;
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		reg = hpet_gconf_get();
-		reg &= ~GCONF_ENABLE;
-		hpet_gconf_set(reg);
-		return;
-	}
-
 	/* The comparator is 64-bit, so the requested timeout needs no clamp. */
 	uint64_t cyc = (last_tick + last_elapsed + ticks) * cyc_per_tick;
 

--- a/drivers/timer/infineon_lp_timer.c
+++ b/drivers/timer/infineon_lp_timer.c
@@ -80,9 +80,8 @@ void sys_clock_unused(void)
 	k_spin_unlock(&lock, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	k_spinlock_key_t key = {0};
 

--- a/drivers/timer/infineon_lp_timer.c
+++ b/drivers/timer/infineon_lp_timer.c
@@ -66,6 +66,20 @@ static void lptimer_interrupt_handler(void *handler_arg, cyhal_lptimer_event_t e
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : (delta_ticks > 0));
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	/* Disable the LPTIMER events */
+	cyhal_lptimer_enable_event(&lptimer_obj, CYHAL_LPTIMER_COMPARE_MATCH,
+				   LPTIMER_INTR_PRIORITY, false);
+	k_spin_unlock(&lock, key);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -73,15 +87,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	k_spinlock_key_t key = {0};
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		key = k_spin_lock(&lock);
-		/* Disable the LPTIMER events */
-		cyhal_lptimer_enable_event(&lptimer_obj, CYHAL_LPTIMER_COMPARE_MATCH,
-					   LPTIMER_INTR_PRIORITY, false);
-		k_spin_unlock(&lock, key);
 		return;
 	}
 

--- a/drivers/timer/infineon_lp_timer_pdl.c
+++ b/drivers/timer/infineon_lp_timer_pdl.c
@@ -92,11 +92,9 @@ static void lptimer_delay(uint32_t cycles)
 	Cy_MCWDT_Enable(lptimer, CY_MCWDT_CTR0 | CY_MCWDT_CTR1, 0);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	uint32_t delay_cycles;
-
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -127,10 +127,8 @@ static void compare_isr(const void *arg)
 	sys_clock_announce_locked(dticks, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
-
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #ifdef CONFIG_TICKLESS_KERNEL

--- a/drivers/timer/ite_it51xxx_timer.c
+++ b/drivers/timer/ite_it51xxx_timer.c
@@ -193,6 +193,18 @@ static void free_run_timer_overflow_isr(const void *unused)
 	/* TODO: to increment 32-bit "top half" here for software 64-bit timer emulation. */
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	ext_timer_disable(EVENT_TIMER);
+	k_spin_unlock(&lock, key);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -210,18 +222,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	/* Disable event timer */
 	ext_timer_disable(EVENT_TIMER);
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * The kernel has no pending timeout, which it signals with
-		 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle no future
-		 * timer interrupt is required, so leave the event timer
-		 * disabled and stop waking up. Without sloppy idle we fall
-		 * through and still schedule the (capped) timeout so the
-		 * uptime tick count stays correct.
-		 */
-		k_spin_unlock(&lock, key);
-		return;
-	}
 	/*
 	 * If ticks <= 1 means the kernel wants the tick announced as soon as possible,
 	 * ideally no more than one system tick in the future. So set event timer count

--- a/drivers/timer/ite_it51xxx_timer.c
+++ b/drivers/timer/ite_it51xxx_timer.c
@@ -205,9 +205,8 @@ void sys_clock_unused(void)
 	k_spin_unlock(&lock, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	uint32_t hw_cnt, next_cycs, now, dcycles;
 

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -223,6 +223,18 @@ static void free_run_timer_overflow_isr(const void *unused)
 	 */
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	IT8XXX2_EXT_CTRLX(EVENT_TIMER) &= ~IT8XXX2_EXT_ETXEN;
+	k_spin_unlock(&lock, key);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	uint32_t hw_cnt;
@@ -240,18 +252,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	/* Disable event timer */
 	IT8XXX2_EXT_CTRLX(EVENT_TIMER) &= ~IT8XXX2_EXT_ETXEN;
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * The kernel has no pending timeout, which it signals with
-		 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle no future
-		 * timer interrupt is required, so leave the event timer
-		 * disabled and stop waking up. Without sloppy idle we fall
-		 * through to the else and still schedule the (capped) timeout
-		 * so the uptime tick count stays correct.
-		 */
-		k_spin_unlock(&lock, key);
-		return;
-	} else {
+	{
 		uint32_t next_cycs;
 		uint32_t now;
 		uint32_t dcycles;

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -235,11 +235,10 @@ void sys_clock_unused(void)
 	k_spin_unlock(&lock, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	uint32_t hw_cnt;
 
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Always return for non-tickless kernel system */

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -157,9 +157,8 @@ static void timer_isr(const void *unused)
 	sys_clock_announce(dticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	volatile struct gptimer_regs *regs = get_regs();
 	uint32_t target, now;
 	int32_t delay;

--- a/drivers/timer/max32_rv32_sys_timer.c
+++ b/drivers/timer/max32_rv32_sys_timer.c
@@ -122,9 +122,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	uint32_t next_cycle;
 	uint32_t count;
 
-	if (ticks == SYS_CLOCK_MAX_WAIT) {
-		next_cycle = (last_tick * CYC_PER_TICK) + CYCLES_MAX;
-	} else if (ticks == 0) {
+	if (ticks == 0) {
 		next_cycle = MXC_TMR_GetCount(regs) + (CYC_PER_TICK * 3 / 2);
 		next_cycle -= (next_cycle % CYC_PER_TICK);
 	} else {

--- a/drivers/timer/max32_rv32_sys_timer.c
+++ b/drivers/timer/max32_rv32_sys_timer.c
@@ -112,7 +112,7 @@ uint32_t sys_clock_elapsed(void)
 	return delta_ticks;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/max32_wut_timer.c
+++ b/drivers/timer/max32_wut_timer.c
@@ -72,9 +72,8 @@ static void max32_wut_timer_isr(const void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : 1);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/mchp_sam_pit64b_timer.c
+++ b/drivers/timer/mchp_sam_pit64b_timer.c
@@ -79,9 +79,8 @@ static void pit64b_isr(const void *arg)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -182,6 +182,12 @@ static uint32_t last_announcement; /* last time we called sys_clock_announce() *
  * Writing a new value to preload only takes effect once the count
  * register reaches 0.
  */
+void sys_clock_unused(void)
+{
+	sys_write32(0, TIMER_BASE + TIMER_CR_OFS); /* stop timer */
+	cached_icr = TIMER_STOPPED;
+}
+
 void sys_clock_set_timeout(uint32_t n, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -190,16 +196,6 @@ void sys_clock_set_timeout(uint32_t n, bool idle)
 	int full_ticks;          /* number of complete ticks we'll wait */
 	uint32_t full_cycles;    /* full_ticks represented as cycles */
 	uint32_t partial_cycles; /* number of cycles to first tick boundary */
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && (n == SYS_CLOCK_MAX_WAIT)) {
-		/*
-		 * We are not in a locked section. Are writes to two
-		 * global objects safe from pre-emption?
-		 */
-		sys_write32(0, TIMER_BASE + TIMER_CR_OFS); /* stop timer */
-		cached_icr = TIMER_STOPPED;
-		return;
-	}
 
 	if (n < 1) {
 		full_ticks = 0;

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -188,9 +188,8 @@ void sys_clock_unused(void)
 	cached_icr = TIMER_STOPPED;
 }
 
-void sys_clock_set_timeout(uint32_t n, bool idle)
+void sys_clock_set_timeout(uint32_t n)
 {
-	ARG_UNUSED(idle);
 
 	uint32_t ccr, temp;
 	int full_ticks;          /* number of complete ticks we'll wait */

--- a/drivers/timer/mcux_gpt_timer.c
+++ b/drivers/timer/mcux_gpt_timer.c
@@ -130,7 +130,7 @@ void mcux_imx_gpt_isr(const void *arg)
  * Next needed call to sys_clock_announce will not be until the specified number
  * of ticks from the current time have elapsed.
  */
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Not supported on tickful kernels */

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -66,14 +66,14 @@ static inline uint32_t counter_delta(uint32_t now, uint32_t then)
 	return (now - then) & COUNTER_MAX;
 }
 
+void sys_clock_unused(void)
+{
+	LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
-		return;
-	}
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -71,9 +71,8 @@ void sys_clock_unused(void)
 	LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -244,6 +244,26 @@ bool z_nxp_os_timer_ignore_timer_wakeup(void)
 	return (wait_forever || counter_remaining_ticks);
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
+	/* No real wakeup deadline: track it for the counter-overflow wakeup
+	 * bookkeeping, then program the match as far out as the hardware allows.
+	 */
+	wait_forever = true;
+#endif
+	OSTIMER_SetMatchValue(base, MAX_CYC + last_count - cyc_sys_compensated, NULL);
+	counter_remaining_ticks = 0;
+
+	k_spin_unlock(&lock, key);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
@@ -260,10 +280,10 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		 */
 		return;
 	}
-	/* When using a counter for certain low power modes, set this flag when the requested
-	 * delay is forever. This is to keep track of wakeup sources in case of counter overflows.
+	/* A real deadline is being scheduled; the "no deadline" case is handled
+	 * by sys_clock_unused() instead.
 	 */
-	wait_forever = (ticks == SYS_CLOCK_MAX_WAIT);
+	wait_forever = false;
 #else
 	ARG_UNUSED(idle);
 #endif

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -264,7 +264,7 @@ void sys_clock_unused(void)
 	k_spin_unlock(&lock, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_idle_enter(uint32_t ticks)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Only for tickless kernel system */
@@ -273,19 +273,30 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
 	/* We intercept calls from idle with a 0 tick count when PM=y */
-	if (idle && (ticks == 0)) {
+	if (ticks == 0) {
 		mcux_os_timer_set_lp_counter_timeout();
 		/* A low power counter has been started. No need to
 		 * go further, simply return
 		 */
 		return;
 	}
+#endif
+	sys_clock_set_timeout(ticks, false);
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	ARG_UNUSED(idle);
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/* Only for tickless kernel system */
+		return;
+	}
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
 	/* A real deadline is being scheduled; the "no deadline" case is handled
 	 * by sys_clock_unused() instead.
 	 */
 	wait_forever = false;
-#else
-	ARG_UNUSED(idle);
 #endif
 	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -281,12 +281,11 @@ void sys_clock_idle_enter(uint32_t ticks)
 		return;
 	}
 #endif
-	sys_clock_set_timeout(ticks, false);
+	sys_clock_set_timeout(ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Only for tickless kernel system */
 		return;

--- a/drivers/timer/mcux_rtc_jdp_timer.c
+++ b/drivers/timer/mcux_rtc_jdp_timer.c
@@ -128,20 +128,9 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	uint32_t cycles;
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * No pending timeout and no future timer interrupt required:
-		 * wait as long as the hardware allows.
-		 */
-		cycles = cycles_max;
-	} else {
-		uint64_t wait_ticks = (uint64_t)last_elapsed + (uint64_t)ticks;
-		uint64_t wait_cycles = wait_ticks * (uint64_t)cycles_per_tick;
-
-		cycles = (wait_cycles > cycles_max) ? cycles_max : (uint32_t)wait_cycles;
-	}
+	uint64_t wait_ticks = (uint64_t)last_elapsed + (uint64_t)ticks;
+	uint64_t wait_cycles = wait_ticks * (uint64_t)cycles_per_tick;
+	uint32_t cycles = (wait_cycles > cycles_max) ? cycles_max : (uint32_t)wait_cycles;
 
 	rtc_jdp_set_compare(last_count + cycles);
 }

--- a/drivers/timer/mcux_rtc_jdp_timer.c
+++ b/drivers/timer/mcux_rtc_jdp_timer.c
@@ -118,9 +118,8 @@ static void rtc_jdp_set_compare(uint32_t compare)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/mcux_stm_timer.c
+++ b/drivers/timer/mcux_stm_timer.c
@@ -84,9 +84,8 @@ static void mcux_stm_timer_isr(const void *arg)
 	sys_clock_announce_locked(delta_ticks, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/mcux_sysctr_timer.c
+++ b/drivers/timer/mcux_sysctr_timer.c
@@ -167,13 +167,12 @@ void sys_clock_unused(void)
 	SYSCTR_DisableInterrupts(CMP_BASE, TIMER_CMP_INT_MASK);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	uint64_t next_cycle;
 	uint64_t now;
 	uint64_t min;
 
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/mcux_sysctr_timer.c
+++ b/drivers/timer/mcux_sysctr_timer.c
@@ -154,6 +154,19 @@ static void sysctr_timer_isr(const void *arg)
 	sys_clock_announce(delta_ticks);
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* No timeout pending: disable the compare interrupt entirely.
+	 * sys_clock_idle_exit() re-enables it on wake.
+	 */
+	SYSCTR_EnableCompare(CMP_BASE, TIMER_CMP_FRAME, false);
+	SYSCTR_DisableInterrupts(CMP_BASE, TIMER_CMP_INT_MASK);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	uint64_t next_cycle;
@@ -163,17 +176,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * No near deadline to schedule: under sloppy idle, disable the
-		 * compare interrupt entirely. sys_clock_idle_exit() will
-		 * re-enable it when the CPU wakes from an external source.
-		 */
-		SYSCTR_EnableCompare(CMP_BASE, TIMER_CMP_FRAME, false);
-		SYSCTR_DisableInterrupts(CMP_BASE, TIMER_CMP_INT_MASK);
 		return;
 	}
 

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -61,9 +61,8 @@ static void timer_isr(const void *arg)
 	sys_clock_announce(TICKLESS ? dticks : 1);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!TICKLESS) {
 		return;

--- a/drivers/timer/mtk_adsp_timer.c
+++ b/drivers/timer/mtk_adsp_timer.c
@@ -135,7 +135,7 @@ uint64_t sys_clock_cycle_get_64(void)
 	return (((uint64_t)h0) << 32) | l;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	/* Compute desired expiration time */
 	uint64_t now = sys_clock_cycle_get_64();
@@ -205,7 +205,7 @@ static void timer_isr(__maybe_unused void *arg)
 	sys_clock_announce(ticks);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		sys_clock_set_timeout(1, false);
+		sys_clock_set_timeout(1);
 	}
 }
 

--- a/drivers/timer/native_sim_timer.c
+++ b/drivers/timer/native_sim_timer.c
@@ -71,9 +71,8 @@ void np_timer_isr_test_hook(const void *arg)
  * @param idle Hint to the driver that the system is about to enter
  *        the idle state immediately after setting the timeout
  */
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint64_t silent_ticks;

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -254,9 +254,8 @@ static uint32_t npcx_itim_evt_elapsed_cyc32(void)
 #endif /* CONFIG_PM */
 
 /* System timer api functions */
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Only for tickless kernel system */

--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -626,9 +626,8 @@ static int grtc_post_init(void)
 #endif
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -682,9 +682,8 @@ void sys_clock_unused(void)
 	sys_busy = false;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	uint64_t target_time;
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -667,6 +667,21 @@ bail:
 	return err;
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* No timeout pending: follow the free-running-compare model and stop
+	 * reprogramming. The last compare still catches the counter wrap and
+	 * the next sys_clock_set_timeout() re-arms us, so sloppy idle needs no
+	 * periodic wakeup here. Only clear the busy flag consumed by the
+	 * overflow trigger path.
+	 */
+	sys_busy = false;
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -676,22 +691,17 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	target_time = last_count +
+		      ((uint64_t)last_elapsed + (uint64_t)ticks) * CYC_PER_TICK;
+	/* Clamp to fit the 24-bit compare register and keep the
+	 * anchor in its valid range (see anchor_update). A resulting
+	 * target in the past is fine: compare_set forces an immediate
+	 * IRQ and the handler catches up in one shot.
+	 */
+	if ((target_time - last_count) > MAX_CYCLES) {
 		target_time = last_count + MAX_CYCLES;
-		sys_busy = false;
-	} else {
-		target_time = last_count +
-			      ((uint64_t)last_elapsed + (uint64_t)ticks) * CYC_PER_TICK;
-		/* Clamp to fit the 24-bit compare register and keep the
-		 * anchor in its valid range (see anchor_update). A resulting
-		 * target in the past is fine: compare_set forces an immediate
-		 * IRQ and the handler catches up in one shot.
-		 */
-		if ((target_time - last_count) > MAX_CYCLES) {
-			target_time = last_count + MAX_CYCLES;
-		}
-		sys_busy = true;
 	}
+	sys_busy = true;
 
 	compare_set(SYS_CLOCK_CH, target_time, sys_clock_timeout_handler, NULL, false);
 }

--- a/drivers/timer/openrisc_tick_timer.c
+++ b/drivers/timer/openrisc_tick_timer.c
@@ -65,7 +65,7 @@ void z_openrisc_timer_isr(void)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 #if defined(CONFIG_TICKLESS_KERNEL)
 	/*
@@ -85,7 +85,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 #else  /* CONFIG_TICKLESS_KERNEL */
 	ARG_UNUSED(ticks);
-	ARG_UNUSED(idle);
 #endif
 }
 

--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -104,9 +104,8 @@ void sys_clock_unused(void)
 	previous_cnt = RTMR_TIMER_STOPPED;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	uint32_t cur_cnt, temp;
 	int full_ticks;

--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -98,6 +98,12 @@ static void rtmr_isr(const void *arg)
 	sys_clock_announce(ticks);
 }
 
+void sys_clock_unused(void)
+{
+	RTMR_REG->CTRL = 0U;
+	previous_cnt = RTMR_TIMER_STOPPED;
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -106,12 +112,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	int full_ticks;
 	uint32_t full_cycles;
 	uint32_t partial_cycles;
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && (ticks == SYS_CLOCK_MAX_WAIT)) {
-		RTMR_REG->CTRL = 0U;
-		previous_cnt = RTMR_TIMER_STOPPED;
-		return;
-	}
 
 	if (ticks < 1) {
 		full_ticks = 0;

--- a/drivers/timer/renesas_ra_ulpt_timer.c
+++ b/drivers/timer/renesas_ra_ulpt_timer.c
@@ -91,11 +91,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	/* No timeout change when the kernel has no near deadline to schedule. */
-	if (ticks == SYS_CLOCK_MAX_WAIT) {
-		return;
-	}
-
 	/* Preserve the original behavior even though it looks wrong; to be
 	 * revisited.
 	 */

--- a/drivers/timer/renesas_ra_ulpt_timer.c
+++ b/drivers/timer/renesas_ra_ulpt_timer.c
@@ -82,9 +82,8 @@ static void ra_ulpt_timer_isr(void)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	/* Timeout configuration is unsupported in tickful mode. */
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {

--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -207,7 +207,7 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -213,11 +213,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	/* Nothing to do when the kernel has no near deadline to schedule. */
-	if (ticks == SYS_CLOCK_MAX_WAIT) {
-		return;
-	}
-
 	/* Preserve the original behavior even though it looks wrong; to be
 	 * revisited.
 	 */

--- a/drivers/timer/renesas_rz_gtm_timer.c
+++ b/drivers/timer/renesas_rz_gtm_timer.c
@@ -89,9 +89,8 @@ static void ostm_irq_handler(timer_callback_args_t *arg)
 	sys_clock_announce(delta_ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/renesas_rza2m_os_timer.c
+++ b/drivers/timer/renesas_rza2m_os_timer.c
@@ -103,9 +103,8 @@ static void ostm_irq_handler(const struct device *dev)
 	sys_clock_announce(delta_ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -109,9 +109,8 @@ static void timer_isr(const void *arg)
 	sys_clock_announce_locked(dticks, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/riscv_supervisor_timer.c
+++ b/drivers/timer/riscv_supervisor_timer.c
@@ -98,9 +98,8 @@ static void timer_isr(const void *arg)
 	sys_clock_announce(dticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -205,12 +205,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 #else /* !CONFIG_TICKLESS_KERNEL */
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/* Disable comparator when the kernel has no pending timeout. */
-		rtc_timeout = rtc_counter;
-		return;
-	}
-
 	if (ticks < 1) {
 		ticks = 1;
 	}

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -181,9 +181,8 @@ static void rtc_isr(const void *arg)
 #endif /* CONFIG_TICKLESS_KERNEL */
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 #ifdef CONFIG_TICKLESS_KERNEL
 

--- a/drivers/timer/silabs_sleeptimer_timer.c
+++ b/drivers/timer/silabs_sleeptimer_timer.c
@@ -98,9 +98,8 @@ static uint32_t sleeptimer_clock_elapsed(struct sleeptimer_timer_data *timer)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	sleeptimer_clock_set_timeout(ticks, &g_sleeptimer_timer_data);
 }

--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -107,7 +107,7 @@ static void schedule_next_interrupt(uint32_t ticks)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -315,6 +315,18 @@ static inline uint32_t z_clock_lptim_getcounter(void)
 	return lp_time;
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* No timeout pending: turn the LPTIM off entirely (unclocked, never
+	 * waking up). It is restored by the next sys_clock_set_timeout().
+	 */
+	clock_control_off(clk_ctrl, (clock_control_subsys_t)&lptim_clk[0]);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	/* new LPTIM AutoReload value to set (aligned on Kernel ticks) */
@@ -381,17 +393,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	/*
-	 * The kernel has no pending timeout, which it signals with
-	 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle the LPTIM can be
-	 * turned off entirely (never waking up, not clocked anymore).
-	 * Without sloppy idle we fall through and schedule the (capped)
-	 * timeout so the uptime tick count stays correct.
-	 */
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		clock_control_off(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
-		return;
-	}
 	/*
 	 * When CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE = n, ticks equals to INT_MAX
 	 * is treated as a maximum possible value LPTIM_MAX_TIMEBASE (16bit counter)

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -383,12 +383,11 @@ void sys_clock_idle_enter(uint32_t ticks)
 	}
 #endif /* CONFIG_STM32_LPTIM_STDBY_TIMER */
 
-	sys_clock_set_timeout(ticks, false);
+	sys_clock_set_timeout(ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	/* new LPTIM AutoReload value to set (aligned on Kernel ticks) */
 	uint32_t next_arr = 0;
 	int err;

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -327,14 +327,8 @@ void sys_clock_unused(void)
 	clock_control_off(clk_ctrl, (clock_control_subsys_t)&lptim_clk[0]);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_idle_enter(uint32_t ticks)
 {
-	/* new LPTIM AutoReload value to set (aligned on Kernel ticks) */
-	uint32_t next_arr = 0;
-	int err;
-
-	ARG_UNUSED(idle);
-
 #ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
 	const struct pm_state_info *next;
 
@@ -342,7 +336,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	/* Check if STANBY or STOP3 is requested */
 	timeout_stdby = false;
-	if ((next != NULL) && idle) {
+	if (next != NULL) {
 #ifdef CONFIG_PM_S2RAM
 		if (next->state == PM_STATE_SUSPEND_TO_RAM) {
 			timeout_stdby = true;
@@ -388,6 +382,20 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 #endif /* CONFIG_STM32_LPTIM_STDBY_TIMER */
+
+	sys_clock_set_timeout(ticks, false);
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	ARG_UNUSED(idle);
+	/* new LPTIM AutoReload value to set (aligned on Kernel ticks) */
+	uint32_t next_arr = 0;
+	int err;
+
+#ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
+	timeout_stdby = false;
+#endif
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/stm32wb0_radio_timer.c
+++ b/drivers/timer/stm32wb0_radio_timer.c
@@ -105,9 +105,8 @@ static void radio_timer_txrx_wkup_isr(void *args)
 }
 #endif /* CONFIG_SOC_STM32WB06XX || CONFIG_SOC_STM32WB07XX */
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		uint32_t current_time, delay;

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -18,7 +18,7 @@
 
 /* Weak-linked noop defaults for optional driver interfaces*/
 
-void __weak sys_clock_set_timeout(uint32_t ticks, bool idle)
+void __weak sys_clock_set_timeout(uint32_t ticks)
 {
 }
 
@@ -32,5 +32,5 @@ void __weak sys_clock_unused(void)
 
 void __weak sys_clock_idle_enter(uint32_t ticks)
 {
-	sys_clock_set_timeout(ticks, false);
+	sys_clock_set_timeout(ticks);
 }

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -25,3 +25,7 @@ void __weak sys_clock_set_timeout(uint32_t ticks, bool idle)
 void __weak sys_clock_idle_exit(void)
 {
 }
+
+void __weak sys_clock_unused(void)
+{
+}

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -29,3 +29,8 @@ void __weak sys_clock_idle_exit(void)
 void __weak sys_clock_unused(void)
 {
 }
+
+void __weak sys_clock_idle_enter(uint32_t ticks)
+{
+	sys_clock_set_timeout(ticks, false);
+}

--- a/drivers/timer/ti_dmtimer.c
+++ b/drivers/timer/ti_dmtimer.c
@@ -103,9 +103,8 @@ static void ti_dmtimer_isr(void *param)
 	sys_clock_announce(delta_ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	struct ti_dm_timer_data *data = systick_timer_dev->data;
 

--- a/drivers/timer/ti_rti_timer.c
+++ b/drivers/timer/ti_rti_timer.c
@@ -77,9 +77,8 @@ static void ti_rti_timer_isr(void *param)
 	sys_clock_announce(1);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	ARG_UNUSED(ticks);
 	/* This driver doesn't support tickless kernel, return immediately */
 }

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -101,7 +101,7 @@ static void ttc_isr(const void *arg)
 	sys_clock_announce(ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 #ifdef CONFIG_TICKLESS_KERNEL
 	uint32_t cycles;

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -85,7 +85,7 @@ static void ccompare_isr(const void *arg)
 	sys_clock_announce_locked(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+static void set_timeout(uint32_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -125,6 +125,17 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	}
 
 #endif
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	ARG_UNUSED(idle);
+	set_timeout(ticks, false);
+}
+
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	set_timeout(ticks, true);
 }
 
 uint32_t sys_clock_elapsed(void)

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -127,9 +127,8 @@ static void set_timeout(uint32_t ticks, bool idle)
 #endif
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	set_timeout(ticks, false);
 }
 

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -173,11 +173,12 @@ bool sys_clock_is_locked(void);
  * @note This function is called by the kernel with the system clock
  * lock held.
  *
+ * A driver entering low-power idle is notified separately through
+ * sys_clock_idle_enter(); this call carries no idle hint.
+ *
  * @param ticks Timeout in tick units
- * @param idle Hint to the driver that the system is about to enter
- *        the idle state immediately after setting the timeout
  */
-void sys_clock_set_timeout(uint32_t ticks, bool idle);
+void sys_clock_set_timeout(uint32_t ticks);
 
 /**
  * @brief Timer idle exit notification

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -268,6 +268,20 @@ void sys_clock_disable(void);
 void sys_clock_unused(void);
 
 /**
+ * @brief Notify the timer driver that the CPU is entering low-power idle.
+ *
+ * Called by the power-management / idle path when the CPU is about to be put
+ * to sleep, with @p ticks until the next expected wakeup. A driver that can
+ * hand off to a low-power wakeup timer (or otherwise reconfigure for sleep)
+ * does so here. The default implementation just programs the wakeup through
+ * sys_clock_set_timeout(), so a driver with no low-power handling needs no
+ * implementation. Recovery happens in sys_clock_idle_exit().
+ *
+ * @param ticks Ticks until the next expected wakeup.
+ */
+void sys_clock_idle_enter(uint32_t ticks);
+
+/**
  * @brief Hardware cycle counter
  *
  * Timer drivers are generally responsible for the system cycle

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -253,6 +253,21 @@ uint32_t sys_clock_elapsed(void);
 void sys_clock_disable(void);
 
 /**
+ * @brief Notify the timer driver that the system clock is currently unused.
+ *
+ * Called by the kernel when no timeout is pending and
+ * @kconfig{CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE} allows the system uptime to drift.
+ * A driver may use this to halt the counter and stop generating interrupts
+ * until the next sys_clock_set_timeout(), which resumes normal operation.
+ *
+ * Unlike sys_clock_disable(), this is a resumable pause, not a teardown. The
+ * default implementation is a no-op: a driver that does nothing here simply
+ * stops being reprogrammed and quiesces on its own, so sloppy idle is available
+ * to every driver without extra code.
+ */
+void sys_clock_unused(void);
+
+/**
  * @brief Hardware cycle counter
  *
  * Timer drivers are generally responsible for the system cycle

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -138,35 +138,37 @@ static uint32_t next_timeout(uint32_t ticks_elapsed)
 	}
 
 	/*
-	 * With nothing pending under sloppy idle, report SYS_CLOCK_MAX_WAIT
-	 * verbatim (not the budget): it is the "no deadline" value a driver
-	 * looks for to stop the clock entirely, and a skewed uptime is
-	 * acceptable. Without sloppy idle the uptime must stay correct, so
-	 * respect the budget and keep waking up.
+	 * No deadline, or one further out than can be scheduled in a single
+	 * step: wait the capped budget and re-evaluate at the next announce.
+	 * Testing next (which may be 64-bit) against the cap keeps the
+	 * remaining arithmetic in 32 bits. The empty case still returns the
+	 * budget so a driver keeps waking to maintain uptime.
 	 */
-	if (next == K_TICKS_FOREVER) {
-		if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE)) {
-			return SYS_CLOCK_MAX_WAIT;
-		}
+	if (next == K_TICKS_FOREVER || next >= SYS_CLOCK_MAX_WAIT) {
 		return SYS_CLOCK_MAX_WAIT - ticks_elapsed;
-	}
-
-	/*
-	 * A timeout further out than can be scheduled in one step: wait nearly
-	 * the whole budget, but stop one short of SYS_CLOCK_MAX_WAIT so it is
-	 * never mistaken for the "no deadline" value above (which would drop
-	 * the timeout under sloppy idle); an intermediate announce re-evaluates.
-	 * Testing next (which may be 64-bit) against the cap also keeps the
-	 * remaining arithmetic in 32 bits.
-	 */
-	if (next >= SYS_CLOCK_MAX_WAIT) {
-		return SYS_CLOCK_MAX_WAIT - 1 - ticks_elapsed;
 	}
 
 	/* Otherwise wait until the timeout, relative to now (0 if due). */
 	dticks = (uint32_t)next;
 
 	return (dticks > ticks_elapsed) ? (dticks - ticks_elapsed) : 0;
+}
+
+/*
+ * Reprogram the timer for the next pending timeout, or, when nothing is
+ * pending and CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE tolerates a drifting uptime, tell
+ * the driver its clock is unused so it may stop. Only meaningful where the
+ * timeout queue may have just drained (abort, end of announce); the add path
+ * always has a pending timeout and calls sys_clock_set_timeout() directly.
+ */
+static void reprogram_next(uint32_t ticks_elapsed)
+{
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
+	    z_timeout_q_next_expiry() == K_TICKS_FOREVER) {
+		sys_clock_unused();
+	} else {
+		sys_clock_set_timeout(next_timeout(ticks_elapsed), false);
+	}
 }
 
 k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t timeout)
@@ -242,7 +244,7 @@ int z_try_abort_timeout(struct _timeout *to)
 
 			ret = 0;
 			if (was_first) {
-				sys_clock_set_timeout(next_timeout(elapsed()), false);
+				reprogram_next(elapsed());
 			}
 		} else if (IS_ENABLED(CONFIG_SMP) && inflight_ptr() == to &&
 			   !this_cpu_announcing()) {
@@ -396,7 +398,7 @@ void sys_clock_announce_locked(uint32_t ticks, k_spinlock_key_t key)
 
 	announcing_cpu = -1;
 
-	sys_clock_set_timeout(next_timeout(0), false);
+	reprogram_next(0);
 
 	k_spin_unlock(&timeout_lock, key);
 

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -167,7 +167,7 @@ static void reprogram_next(uint32_t ticks_elapsed)
 	    z_timeout_q_next_expiry() == K_TICKS_FOREVER) {
 		sys_clock_unused();
 	} else {
-		sys_clock_set_timeout(next_timeout(ticks_elapsed), false);
+		sys_clock_set_timeout(next_timeout(ticks_elapsed));
 	}
 }
 
@@ -227,7 +227,7 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 				 */
 				ticks_elapsed = elapsed();
 			}
-			sys_clock_set_timeout(next_timeout(ticks_elapsed), false);
+			sys_clock_set_timeout(next_timeout(ticks_elapsed));
 		}
 	}
 

--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -216,7 +216,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		{
 			k_spinlock_key_t key = sys_clock_lock();
 
-			sys_clock_set_timeout(0, true);
+			sys_clock_idle_enter(0);
 			sys_clock_unlock(key);
 		}
 
@@ -237,7 +237,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 				{
 					k_spinlock_key_t key = sys_clock_lock();
 
-					sys_clock_set_timeout(0, true);
+					sys_clock_idle_enter(0);
 					sys_clock_unlock(key);
 				}
 				/* GDET got enabled when exiting PM3, disable it

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -212,7 +212,7 @@ bool pm_system_suspend(int32_t kernel_ticks)
 		 */
 		k_spinlock_key_t key = sys_clock_lock();
 
-		sys_clock_set_timeout(MAX(0, (int64_t)ticks - (int64_t)exit_latency_ticks), true);
+		sys_clock_idle_enter(MAX(0, (int64_t)ticks - (int64_t)exit_latency_ticks));
 		sys_clock_unlock(key);
 	}
 


### PR DESCRIPTION
The system timer interface carried two pieces of implicit protocol that every driver had to reimplement by hand. This series turns both into explicit, optional hooks and simplifies the drivers accordingly.

**1. Sloppy idle becomes a core decision, not a magic value.**
Under `CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE`, "no timeout pending, uptime may drift" was signalled by `next_timeout()` handing the driver `SYS_CLOCK_MAX_WAIT` as a sentinel that every driver then had to recognise. The kernel now makes that decision itself and calls a new weak `sys_clock_unused()` hook instead, so `SYS_CLOCK_MAX_WAIT` goes back to meaning nothing more than the largest tick count the kernel will request. A driver overrides `sys_clock_unused()` if it wants to halt its counter; one that does not simply stops being reprogrammed and quiesces on its own.

**2. The low-power idle hint gets its own hook.**
`sys_clock_set_timeout(ticks, idle)` overloaded a power signal onto the scheduling call: `idle == true` meant "the CPU is entering low-power idle, here is its wakeup", and only the PM and SoC power paths ever produced it. That moves to a dedicated weak `sys_clock_idle_enter(ticks)` hook (the counterpart to the existing `sys_clock_idle_exit()`). With nobody passing it any more, the argument is dropped, and `sys_clock_set_timeout(uint32_t ticks)` now means exactly "program the next tick, N ticks out".

**Commits (each builds on its own):**
1. `esp32_sys_timer: adopt the sys_clock_lock() scheme` moves the driver off its private spinlock onto the kernel timer lock, so the later idle handling needs no locking of its own.
2. `add sys_clock_unused() and decide sloppy idle centrally`: the hook plus the core decision.
3. `stop the clock via sys_clock_unused()` converts the drivers that acted on the old sentinel.
4. `mcux_os: track the no-deadline state in sys_clock_unused()`.
5. `add sys_clock_idle_enter() for low-power idle handoff` introduces the idle hook and moves each driver's idle handling into it.
6. `drop the idle argument of sys_clock_set_timeout()` removes the now-dead parameter tree-wide.
7. `doc: releases: migration: document the sys_clock timeout API changes`.

**Behaviour.** The interface rework is behaviour-preserving, including on non-tickless kernels (the sloppy stop stays gated where each driver gated it before, just in the driver rather than the core). The one intended refinement: the free-running-compare timers no longer arm a redundant maximum-length wake under sloppy idle, since their counter wrap already covers it.

**Out-of-tree drivers.** Two source changes may be needed, both described in the 4.5 migration guide: drop the `idle` parameter from the `sys_clock_set_timeout()` definition (the build breaks otherwise, with a conflicting-types error), and, if the driver stopped its counter on the `SYS_CLOCK_MAX_WAIT` sentinel under sloppy idle, move that into a `sys_clock_unused()` implementation. Drivers with no low-power handling need nothing: both new hooks have weak defaults.
