### PR TITLE
kernel: timeout: guard arch_spin_relax() behind CONFIG_SMP

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -276,7 +276,7 @@ int z_try_abort_timeout(struct _timeout *to)
 		}
 	}
 
-	if (ret == -EAGAIN) {
+	if (IS_ENABLED(CONFIG_SMP) && ret == -EAGAIN) {
 		arch_spin_relax();
 	}
 


### PR DESCRIPTION
z_try_abort_timeout() can only set ret to -EAGAIN inside a
CONFIG_SMP-gated branch, so the trailing arch_spin_relax() call is
dead code on non-SMP builds. Optimized builds drop it, but a
coverage build (-O0) keeps the call and the linker then fails with
an undefined reference to arch_spin_relax: its weak definition
lives in idle.c, which is only compiled when CONFIG_MULTITHREADING
is set, so a no-multithreading + coverage build has no definition.

Wrap the check with IS_ENABLED(CONFIG_SMP) so the front end folds
the branch (and the arch_spin_relax reference) away even at -O0.
This is behavior-preserving since ret is never -EAGAIN without SMP.

The issue also triggers when building with llvm.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
