### PR TITLE
fixes to failing tests with llvm/riscv

### DIFF
--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -247,8 +247,15 @@ void z_riscv_fault(struct arch_esf *esf)
 		reason = K_ERR_STACK_CHK_FAIL;
 	}
 
+	/*
+	 * z_riscv_fatal_error() may return: when the fatal error is handled
+	 * (e.g. an expected fault in test mode aborting the current thread),
+	 * z_fatal_error() returns and the exception exit path in isr.S takes
+	 * care of rescheduling. Do not mark this as unreachable: the compiler
+	 * would place a trapping instruction (or arbitrary code) on the
+	 * return path, causing a fatal error loop.
+	 */
 	z_riscv_fatal_error(reason, esf);
-	CODE_UNREACHABLE;
 }
 
 #ifdef CONFIG_USERSPACE

--- a/include/zephyr/arch/riscv/syscall.h
+++ b/include/zephyr/arch/riscv/syscall.h
@@ -148,12 +148,19 @@ static inline uintptr_t arch_syscall_invoke0(uintptr_t call_id)
 }
 
 #ifdef CONFIG_USERSPACE
-register unsigned long riscv_tp_reg __asm__ ("tp");
-
 static inline bool arch_is_user_context(void)
 {
-	/* don't try accessing TLS variables if tp is not initialized */
-	if (riscv_tp_reg == 0) {
+	/*
+	 * Don't try accessing TLS variables if tp is not initialized.
+	 *
+	 * Note: this deliberately reads the thread pointer via
+	 * __builtin_thread_pointer() rather than declaring a global register
+	 * variable bound to "tp": clang miscompiles unrelated globals that
+	 * happen to share the register's name (e.g. a global variable named
+	 * "tp") when such a declaration is in scope, silently dropping their
+	 * linkage, section attributes and initializers.
+	 */
+	if (__builtin_thread_pointer() == NULL) {
 		return false;
 	}
 

--- a/tests/kernel/common/tests.yaml
+++ b/tests/kernel/common/tests.yaml
@@ -7,16 +7,9 @@ common:
   min_ram: 32
   timeout: 120
 tests:
-  kernel.common.toolchain2:
-    integration_toolchains:
-      - zephyr/llvm
-      - zephyr/gnu
-    platform_allow:
-      - mps2/an385
   kernel.common:
     platform_exclude:
       - native_sim
-      - mps2/an385
   kernel.common.toolchain:
     platform_allow:
       - native_sim


### PR DESCRIPTION
Fix two miscompilation issues exposed by building RISC-V with the LLVM toolchain, both causing kernel.threads.apis to hang forever on qemu_riscv32e (expected-fault tests looped in the fatal error handler).

- z_riscv_fatal_error() may legitimately return when a fatal error is handled (e.g. ztest expected faults), and isr.S already handles that return path. The CODE_UNREACHABLE hint made LLVM emit a trapping unimp instruction on the return path, causing an endless illegal-instruction fatal error loop. GCC builds only worked by chance.

- clang silently miscompiles any global variable named tp while the register ... __asm__("tp") declaration from syscall.h is in scope (loses static linkage, section attribute, and initializer). This broke ZTEST_DMEM placement in the userspace partition, causing PMP faults. Use __builtin_thread_pointer() instead, which gcc and clang both lower to a plain register read.
