### PR TITLE
tracing: add an ivshmem backend

### DIFF
--- a/subsys/tracing/CMakeLists.txt
+++ b/subsys/tracing/CMakeLists.txt
@@ -51,6 +51,12 @@ if(CONFIG_TRACING_CORE)
     CONFIG_TRACING_SHELL
     tracing_shell.c
     )
+
+  zephyr_sources_ifdef(
+    CONFIG_TRACING_BACKEND_IVSHMEM
+    tracing_backend_ivshmem.c
+    )
+
 endif()
 
 zephyr_sources(

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -243,6 +243,15 @@ config TRACING_BACKEND_ADSP_MEMORY_WINDOW
 	help
 	  Use ADSP memory debug memory window to output tracing data
 
+config TRACING_BACKEND_IVSHMEM
+	bool "ivshmem backend"
+	depends on IVSHMEM
+	depends on TRACING_SYNC
+	help
+	  Stream tracing data into an ivshmem-plain shared memory region that a
+	  host tool reads back after the run (for example the twister ivshmem
+	  sidecar). This is useful on QEMU targets without semihosting.
+
 endchoice
 
 config TRACING_BACKEND_NAME
@@ -253,6 +262,7 @@ config TRACING_BACKEND_NAME
 	default "tracing_backend_ram" if TRACING_BACKEND_RAM
 	default "tracing_backend_semihost" if TRACING_BACKEND_SEMIHOST
 	default "tracing_backend_adsp_memory_window" if TRACING_BACKEND_ADSP_MEMORY_WINDOW
+	default "tracing_backend_ivshmem" if TRACING_BACKEND_IVSHMEM
 
 config RAM_TRACING_BUFFER_SIZE
 	int "Ram Tracing buffer size"

--- a/subsys/tracing/tracing_backend_ivshmem.c
+++ b/subsys/tracing/tracing_backend_ivshmem.c
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <string.h>
+
+#include <zephyr/drivers/virtualization/ivshmem.h>
+
+#include <tracing_core.h>
+#include <tracing_buffer.h>
+#include <tracing_backend.h>
+
+/*
+ * Stream the CTF trace into an ivshmem-plain shared memory region so a host
+ * tool can read it back after the run (e.g. the twister ivshmem sidecar),
+ * which is useful on QEMU targets without semihosting.
+ *
+ * Layout written at offset 0 of the region (keep in sync with the host):
+ *
+ *   struct ivshmem_trace_header { magic, version, used, overflow }
+ *
+ * followed by the raw CTF byte stream. "used" is the total number of bytes
+ * written including the header and is updated after every packet; the host
+ * reads it once QEMU has exited, so the region is static by then. "overflow"
+ * is set if the region filled up and trailing trace data was dropped.
+ */
+
+#define IVSHMEM_TRACE_MAGIC   0x4352545aU /* "ZTRC" */
+#define IVSHMEM_TRACE_VERSION 1U
+
+struct ivshmem_trace_header {
+	uint32_t magic;
+	uint32_t version;
+	uint32_t used;
+	uint32_t overflow;
+};
+
+static uint8_t *trace_region;
+static size_t trace_size;
+static uint32_t trace_pos;
+static bool trace_overflow;
+
+static void ivshmem_trace_header_write(uint32_t used, uint32_t overflow)
+{
+	volatile struct ivshmem_trace_header *hdr =
+		(volatile struct ivshmem_trace_header *)trace_region;
+
+	hdr->version = IVSHMEM_TRACE_VERSION;
+	hdr->overflow = overflow;
+	hdr->used = used;
+	/* Write the magic last so the host never keys off a stale header. */
+	hdr->magic = IVSHMEM_TRACE_MAGIC;
+}
+
+static void tracing_backend_ivshmem_output(const struct tracing_backend *backend,
+					   uint8_t *data, uint32_t length)
+{
+	ARG_UNUSED(backend);
+
+	if (trace_region == NULL || trace_overflow) {
+		return;
+	}
+
+	if ((trace_pos + length) > trace_size) {
+		trace_overflow = true;
+		ivshmem_trace_header_write(trace_pos, 1U);
+		return;
+	}
+
+	memcpy(trace_region + trace_pos, data, length);
+	trace_pos += length;
+	ivshmem_trace_header_write(trace_pos, 0U);
+}
+
+static void tracing_backend_ivshmem_init(void)
+{
+	const struct device *ivshmem = DEVICE_DT_GET_ONE(qemu_ivshmem);
+	uintptr_t base;
+	size_t size;
+
+	if (!device_is_ready(ivshmem)) {
+		printk("ivshmem device not ready, tracing backend disabled\n");
+		return;
+	}
+
+	size = ivshmem_get_mem(ivshmem, &base);
+	if (size <= sizeof(struct ivshmem_trace_header) || base == 0) {
+		printk("no ivshmem region available for tracing\n");
+		return;
+	}
+
+	trace_region = (uint8_t *)base;
+	trace_size = size;
+	trace_pos = sizeof(struct ivshmem_trace_header);
+	trace_overflow = false;
+	ivshmem_trace_header_write(trace_pos, 0U);
+}
+
+const struct tracing_backend_api tracing_backend_ivshmem_api = {
+	.init = tracing_backend_ivshmem_init,
+	.output = tracing_backend_ivshmem_output,
+};
+
+TRACING_BACKEND_DEFINE(tracing_backend_ivshmem, tracing_backend_ivshmem_api);


### PR DESCRIPTION
Add a tracing backend that streams the CTF trace into an ivshmem-plain
shared memory region instead of a transport like semihosting or a UART.
The guest writes a small header (magic, version, used length, overflow
flag) followed by the raw CTF byte stream; a host tool reads it back after
the run. This gives QEMU targets without semihosting a low-overhead way to
capture traces.

The backend resolves the qemu,ivshmem device in its init (tracing starts
at APPLICATION level, after the ivshmem PCI device is ready), appends each
packet to the region, and updates the used length. When the region fills
it stops and records the overflow so the host knows the trace was
truncated. Requires TRACING_SYNC, like the other memory-window backends.

