### PR TITLE
Internal: Trigger CI twister run on vanilla Zephyr

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -25,6 +25,8 @@
 #include <run_q.h>
 #include <timeslicing.h>
 
+/* Trigger CI twister run 01 */
+
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 /* pending_current is owned by timeslicing.c; sleep.c also accesses it */


### PR DESCRIPTION
Compare CI twister results w/ https://github.com/zephyrproject-rtos/zephyr/pull/109291

+++

See SMP related build/tests issue https://github.com/zephyrproject-rtos/zephyr/issues/112765 , 1st reported here https://github.com/zephyrproject-rtos/zephyr/pull/109291#issuecomment-4886244922

+++

See `qemu_riscv32e/qemu_virt_riscv32e` issues here
- https://github.com/zephyrproject-rtos/zephyr/issues/112764
- https://github.com/zephyrproject-rtos/zephyr/issues/112767

first reported here https://github.com/zephyrproject-rtos/zephyr/pull/109291#issuecomment-4887033214