### PR TITLE
Bluetooth: shell: Fix audio index bounds checks

### DIFF
--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -603,7 +603,7 @@ static int cmd_select_unicast(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	if (index > ARRAY_SIZE(unicast_streams)) {
+	if (index >= ARRAY_SIZE(unicast_streams)) {
 		shell_error(sh, "Invalid index: %lu", index);
 
 		return -ENOEXEC;
@@ -1138,7 +1138,7 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
-	if (index > ARRAY_SIZE(unicast_streams)) {
+	if (index >= ARRAY_SIZE(unicast_streams)) {
 		shell_error(sh, "Invalid index: %lu", index);
 
 		return -ENOEXEC;
@@ -3230,7 +3230,7 @@ static int cmd_select_broadcast_source(const struct shell *sh, size_t argc,
 		return -ENOEXEC;
 	}
 
-	if (index > ARRAY_SIZE(broadcast_source_streams)) {
+	if (index >= ARRAY_SIZE(broadcast_source_streams)) {
 		shell_error(sh, "Invalid index: %lu", index);
 
 		return -ENOEXEC;

--- a/subsys/bluetooth/audio/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/shell/csip_set_coordinator.c
@@ -299,7 +299,7 @@ static int cmd_csip_set_coordinator_discover(const struct shell *sh,
 			return -ENOEXEC;
 		}
 
-		if (member_index > ARRAY_SIZE(conns)) {
+		if (member_index >= ARRAY_SIZE(conns)) {
 			shell_error(sh, "Invalid member_index: %lu",
 				    member_index);
 
@@ -484,7 +484,7 @@ static int cmd_csip_set_coordinator_lock(const struct shell *sh, size_t argc,
 			return -ENOEXEC;
 		}
 
-		if (member_index > ARRAY_SIZE(set_members)) {
+		if (member_index >= ARRAY_SIZE(set_members)) {
 			shell_error(sh, "Invalid member_index: %lu",
 				    member_index);
 
@@ -523,7 +523,7 @@ static int cmd_csip_set_coordinator_release(const struct shell *sh, size_t argc,
 			return -ENOEXEC;
 		}
 
-		if (member_index > ARRAY_SIZE(set_members)) {
+		if (member_index >= ARRAY_SIZE(set_members)) {
 			shell_error(sh, "Invalid member_index: %lu",
 				    member_index);
 


### PR DESCRIPTION
## Summary
- reject ARRAY_SIZE(...) for Bluetooth audio shell indexes before they are used as array subscripts
- update the matching CSIP set coordinator member index checks

## Verification
- `rg -n "(index|member_index) > ARRAY_SIZE\(" subsys/bluetooth/audio/shell -S` reports no remaining matches
- `git diff --check`
- `git ls-files --eol subsys/bluetooth/audio/shell/bap.c subsys/bluetooth/audio/shell/csip_set_coordinator.c`

I also checked for open duplicate PRs/issues mentioning `index > ARRAY_SIZE`, `Invalid index`, `member_index > ARRAY_SIZE`, and `subsys/bluetooth/audio/shell`, and found no matches.

I did not run a full Zephyr build locally because this Windows environment does not have the Zephyr SDK/toolchain configured.
