### PR TITLE
drivers: gpio: shell: Delay `GPIO_DT_RESERVED_RANGES_NGPIOS` expansion

### DIFF
--- a/drivers/gpio/gpio_shell.c
+++ b/drivers/gpio/gpio_shell.c
@@ -95,8 +95,14 @@ static void port_pin_get(gpio_port_pins_t reserved_mask, const char **line_names
 
 #define GPIO_DT_RESERVED_RANGES_NGPIOS_SHELL(node_id)                                              \
 	COND_CODE_1(DT_NODE_HAS_PROP(node_id, ngpios),                                             \
-		    (GPIO_DT_RESERVED_RANGES_NGPIOS(node_id, DT_PROP(node_id, ngpios))),           \
-		    (GPIO_MAX_PINS_PER_PORT))
+		    (GPIO_DT_RESERVED_RANGES_NGPIOS_SHELL_HAS),                                    \
+		    (GPIO_DT_RESERVED_RANGES_NGPIOS_SHELL_NO))(node_id)
+
+#define GPIO_DT_RESERVED_RANGES_NGPIOS_SHELL_HAS(node_id)                                          \
+	GPIO_DT_RESERVED_RANGES_NGPIOS(node_id, DT_PROP(node_id, ngpios))
+
+#define GPIO_DT_RESERVED_RANGES_NGPIOS_SHELL_NO(node_id)                                           \
+	GPIO_MAX_PINS_PER_PORT
 
 #define GPIO_CTRL_PIN_GET_FN(node_id)                                                              \
 	static const char *node_id##line_names[] = DT_PROP_OR(node_id, gpio_line_names, {NULL});   \


### PR DESCRIPTION
Currently, compiling gpio_shell.c with a large enough number of devicetree nodes with "okay" (or missing) status results in either compile failures when using clang or considerable memory usage/slow compile times with gcc.

I'm not sure what the exact limit is, but these issues become fairly apparent with 3000+ such nodes.

clang (ATfE clang version 22.1.0) produces errors as below:
```
fatal error: translation unit is too large for Clang to process: ran out \
of source locations
```

This is somewhat of a known limitation of clang (see link below) but even when using gcc (Zephyr SDK v1.0.1) I'm seeing ~5gb memory usage and it takes ~1 minute to compile this file which doesn't seem ideal.

As far as I can tell, this is stemming from
`GPIO_DT_RESERVED_RANGES_NGPIOS_SHELL`. Currently, the compiler has to expand the arguments used in COND_CODE_1, regardless of whether the argument will be used in the end (if `DT_NODE_HAS_PROP(node_id, ngpios)` is true or false). So `GPIO_DT_RESERVED_RANGES_NGPIOS` seems to be expanded by the compiler for each "okay" node rather than just those with the desired property, even though the results might be discarded in the end. `GPIO_DT_RESERVED_RANGES_NGPIOS` seems to expand to a fair bit of code, so this exhausts clang's available source locations or results in high memory usage/slow compile times with gcc.

To alleviate this, we can define helper macros that delay the expansion of these arguments (particularly `GPIO_DT_RESERVED_RANGES_NGPIOS`) so that they're only going to be expand if selected by the `COND_CODE_1`.

With this change and when there are larger numbers of "okay" nodes, clang is able to compile the file and both clang and gcc's memory usage and compile times look more reasonable at ~hundreds of mb and around 1 second, respectively.

Link: https://discourse.llvm.org/t/rfc-an-opt-in-cmake-option-for-64-bit-source-location/87538

Co-authored-by: Eli Friedman <efriedma@qti.qualcomm.com>