### PR TITLE
drivers: rtc: mspm0: Use proper compatible

### DIFF
--- a/drivers/rtc/Kconfig.ti_mspm0
+++ b/drivers/rtc/Kconfig.ti_mspm0
@@ -4,6 +4,7 @@
 config RTC_TI_MSPM0
 	bool "Texas Instruments MSPM0 RTC driver"
 	default y
-	depends on DT_HAS_TI_MSPM0_RTC_ENABLED
+	depends on DT_HAS_TI_MSPM0_RTC_ENABLED || DT_HAS_TI_MSPM0_RTC_A_ENABLED || \
+		DT_HAS_TI_MSPM0_RTC_B_ENABLED
 	help
 	  Texas Instruments Real-Time Clock (RTC) driver used on MSPM0 SoC series.

--- a/drivers/rtc/rtc_ti_mspm0.c
+++ b/drivers/rtc/rtc_ti_mspm0.c
@@ -5,8 +5,6 @@
  *
  */
 
-#define DT_DRV_COMPAT ti_mspm0_rtc
-
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/rtc.h>
@@ -437,26 +435,34 @@ static DEVICE_API(rtc, rtc_ti_mspm0_driver_api) = {
 #endif /* CONFIG_RTC_ALARM */
 };
 
-#define RTC_TI_MSPM0_DEVICE_INIT(n)						\
+#define RTC_TI_MSPM0_DEVICE_INIT(n, is_rtc_x)                                                      \
 	IF_ENABLED(CONFIG_RTC_ALARM,						\
 	(static void ti_mspm0_config_irq_##n(void)				\
 	{									\
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),		\
 			    rtc_ti_mspm0_isr, DEVICE_DT_INST_GET(n), 0);	\
 		irq_enable(DT_INST_IRQN(n));					\
-	}))									\
-										\
-	static struct rtc_ti_mspm0_data rtc_data_##n;				\
-										\
-	static struct rtc_ti_mspm0_config rtc_config_##n = {			\
-		.regs		 = (RTC_Regs *)DT_INST_REG_ADDR(n),		\
-		.rtc_x		 = DT_INST_PROP(n, ti_rtc_x),			\
+	}))                                                        \
+                                                                                                   \
+	static struct rtc_ti_mspm0_data rtc_data_##n;                                              \
+                                                                                                   \
+	static struct rtc_ti_mspm0_config rtc_config_##n = {                                       \
+		.regs = (RTC_Regs *)DT_INST_REG_ADDR(n),                                           \
+		.rtc_x = is_rtc_x,                                                                 \
 		IF_ENABLED(CONFIG_RTC_ALARM,					\
-		(.irq_config_func = ti_mspm0_config_irq_##n,))			\
-	};									\
-										\
-DEVICE_DT_INST_DEFINE(n, &rtc_ti_mspm0_init, NULL, &rtc_data_##n,		\
-		      &rtc_config_##n, PRE_KERNEL_1,				\
-		      CONFIG_RTC_INIT_PRIORITY, &rtc_ti_mspm0_driver_api);
+		(.irq_config_func = ti_mspm0_config_irq_##n,)) };        \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, &rtc_ti_mspm0_init, NULL, &rtc_data_##n, &rtc_config_##n,         \
+			      PRE_KERNEL_1, CONFIG_RTC_INIT_PRIORITY, &rtc_ti_mspm0_driver_api);
 
-DT_INST_FOREACH_STATUS_OKAY(RTC_TI_MSPM0_DEVICE_INIT);
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT ti_mspm0_rtc
+DT_INST_FOREACH_STATUS_OKAY_VARGS(RTC_TI_MSPM0_DEVICE_INIT, false)
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT ti_mspm0_rtc_a
+DT_INST_FOREACH_STATUS_OKAY_VARGS(RTC_TI_MSPM0_DEVICE_INIT, true);
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT ti_mspm0_rtc_b
+DT_INST_FOREACH_STATUS_OKAY_VARGS(RTC_TI_MSPM0_DEVICE_INIT, true);

--- a/drivers/rtc/rtc_ti_mspm0.c
+++ b/drivers/rtc/rtc_ti_mspm0.c
@@ -5,8 +5,6 @@
  *
  */
 
-#define DT_DRV_COMPAT ti_mspm0_rtc
-
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/rtc.h>
@@ -437,26 +435,27 @@ static DEVICE_API(rtc, rtc_ti_mspm0_driver_api) = {
 #endif /* CONFIG_RTC_ALARM */
 };
 
-#define RTC_TI_MSPM0_DEVICE_INIT(n)						\
+#define RTC_TI_MSPM0_DEVICE_INIT(n, is_rtc_x)                                                      \
 	IF_ENABLED(CONFIG_RTC_ALARM,						\
 	(static void ti_mspm0_config_irq_##n(void)				\
 	{									\
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),		\
 			    rtc_ti_mspm0_isr, DEVICE_DT_INST_GET(n), 0);	\
 		irq_enable(DT_INST_IRQN(n));					\
-	}))									\
-										\
-	static struct rtc_ti_mspm0_data rtc_data_##n;				\
-										\
-	static struct rtc_ti_mspm0_config rtc_config_##n = {			\
-		.regs		 = (RTC_Regs *)DT_INST_REG_ADDR(n),		\
-		.rtc_x		 = DT_INST_PROP(n, ti_rtc_x),			\
+	}))                                                        \
+                                                                                                   \
+	static struct rtc_ti_mspm0_data rtc_data_##n;                                              \
+                                                                                                   \
+	static struct rtc_ti_mspm0_config rtc_config_##n = {                                       \
+		.regs = (RTC_Regs *)DT_INST_REG_ADDR(n),                                           \
+		.rtc_x = is_rtc_x,                                                                 \
 		IF_ENABLED(CONFIG_RTC_ALARM,					\
-		(.irq_config_func = ti_mspm0_config_irq_##n,))			\
-	};									\
-										\
-DEVICE_DT_INST_DEFINE(n, &rtc_ti_mspm0_init, NULL, &rtc_data_##n,		\
-		      &rtc_config_##n, PRE_KERNEL_1,				\
-		      CONFIG_RTC_INIT_PRIORITY, &rtc_ti_mspm0_driver_api);
+		(.irq_config_func = ti_mspm0_config_irq_##n,)) };        \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, &rtc_ti_mspm0_init, NULL, &rtc_data_##n, &rtc_config_##n,         \
+			      PRE_KERNEL_1, CONFIG_RTC_INIT_PRIORITY, &rtc_ti_mspm0_driver_api);
 
-DT_INST_FOREACH_STATUS_OKAY(RTC_TI_MSPM0_DEVICE_INIT);
+/* Third argument = !has power enable register */
+DT_FOREACH_STATUS_OKAY_VARGS(ti_mspm0_rtc, RTC_TI_MSPM0_DEVICE_INIT, false)
+DT_FOREACH_STATUS_OKAY_VARGS(ti_mspm0_rtc_a, RTC_TI_MSPM0_DEVICE_INIT, true);
+DT_FOREACH_STATUS_OKAY_VARGS(ti_mspm0_rtc_b, RTC_TI_MSPM0_DEVICE_INIT, true);

--- a/dts/bindings/rtc/ti,mspm0-rtc-a.yaml
+++ b/dts/bindings/rtc/ti,mspm0-rtc-a.yaml
@@ -1,9 +1,8 @@
-# Copyright 2025 Linumiz GmbH
 # Copyright 2026 BeagleBoard.org Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Texas Instruments MSPM0 RTC
+description: Texas Instruments MSPM0 RTC A
 
-compatible: "ti,mspm0-rtc"
+compatible: "ti,mspm0-rtc-a"
 
 include: ti,mspm0-rtc-base.yaml

--- a/dts/bindings/rtc/ti,mspm0-rtc-b.yaml
+++ b/dts/bindings/rtc/ti,mspm0-rtc-b.yaml
@@ -1,9 +1,8 @@
-# Copyright 2025 Linumiz GmbH
 # Copyright 2026 BeagleBoard.org Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-description: Texas Instruments MSPM0 RTC
+description: Texas Instruments MSPM0 RTC B
 
-compatible: "ti,mspm0-rtc"
+compatible: "ti,mspm0-rtc-b"
 
 include: ti,mspm0-rtc-base.yaml

--- a/dts/bindings/rtc/ti,mspm0-rtc-base.yaml
+++ b/dts/bindings/rtc/ti,mspm0-rtc-base.yaml
@@ -1,9 +1,10 @@
 # Copyright 2025 Linumiz GmbH
-# Copyright 2026 BeagleBoard.org Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 description: Texas Instruments MSPM0 RTC
 
-compatible: "ti,mspm0-rtc"
+include: rtc-device.yaml
 
-include: ti,mspm0-rtc-base.yaml
+properties:
+  reg:
+    required: true


### PR DESCRIPTION
Instead of a bool field in dts, use seperate compatible for mspm0-rtc, mspm0-rtc-a and mspm0-rtc-b.
cc @glneo 