### PR TITLE
drivers: i2c: i2c_emul: write_requested to not refire without stop

### DIFF
--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -124,8 +124,13 @@ static int i2c_emul_send_to_target(const struct device *dev, struct i2c_msg *msg
 		return 0;
 	}
 #endif /* CONFIG_I2C_TARGET_BUFFER_MODE */
+	bool write_requested_invoked = false;
 
 	for (uint8_t i = 0; i < num_msgs; ++i) {
+		if (i2c_is_read_op(&msgs[i]) && write_requested_invoked) {
+			write_requested_invoked = false;
+		}
+
 		LOG_DBG("    msgs[%u].flags? 0x%02x", i, msgs[i].flags);
 		if (i2c_is_read_op(&msgs[i])) {
 			for (uint32_t j = 0; j < msgs[i].len; ++j) {
@@ -150,9 +155,10 @@ static int i2c_emul_send_to_target(const struct device *dev, struct i2c_msg *msg
 			for (uint32_t j = 0; j < msgs[i].len; ++j) {
 				int rc = 0;
 
-				if (j == 0) {
+				if (!write_requested_invoked) {
 					LOG_DBG("    Calling write_requested");
 					rc = callbacks->write_requested(data->target_cfg);
+					write_requested_invoked = true;
 				}
 				if (rc != 0) {
 					return rc;
@@ -166,6 +172,7 @@ static int i2c_emul_send_to_target(const struct device *dev, struct i2c_msg *msg
 			}
 		}
 		if (i2c_is_stop_op(&msgs[i])) {
+			write_requested_invoked = false;
 			int rc = callbacks->stop(data->target_cfg);
 
 			if (rc != 0) {


### PR DESCRIPTION
### Overview:

If we send multiple messages together, the write_requested callback fires on each. Change this so that it only fires on the first, until we get a STOP condition.

### Tests:

We use this for some SMBUS emulation, where we queue up 3 Tx transactions in a row for the cmd, the data, and the optional CRC. Getting three `write_requested` callbacks in this case is unexpected to our SW driver.

### Notes:
Zephyr does not makes a promise about what the behaviour should be. [See the note here.](https://docs.zephyrproject.org/latest/doxygen/html/group__i2c__interface.html#ga2958e6fe92ffb17851052d5c9a5c058e) 

I recognize, while this might help our use case, it might hurt others. Happy to keep this in our fork, if so.