### PR TITLE
modules: hostap: bound P2P value extraction

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -3011,7 +3011,11 @@ static inline void extract_value(const char *src, char *dest, size_t dest_size)
 {
 	size_t i = 0;
 
-	while (src[i] != '\0' && src[i] != '\n' && i < dest_size - 1) {
+	if (dest_size == 0) {
+		return;
+	}
+
+	while (i < dest_size - 1 && src[i] != '\0' && src[i] != '\n') {
 		dest[i] = src[i];
 		i++;
 	}


### PR DESCRIPTION
## Summary
- return early when `extract_value()` receives a zero-length destination buffer
- check the destination bound before reading the current source byte

## Root cause
`extract_value()` used `dest_size - 1` in the loop condition and wrote `dest[i]` after the loop. A zero-length destination underflows the bound and still writes `dest[0]`. The loop also read `src[i]` before confirming that another destination byte could be stored.

## Testing
- `git diff --check`
- `git show --stat --check --format=fuller HEAD`

Build not run locally because this Windows machine does not have `west`, `cmake`, `ninja`, `make`, `gcc`, `clang`, or `cc` installed.