### PR TITLE
Bluetooth: Host: add tx_power field to bt_le_adv_param

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -182,6 +182,8 @@ New APIs and options
     * :c:func:`bt_conn_take`
     * :c:func:`bt_conn_drop`
     * :c:func:`bt_le_per_adv_update_did`
+    * :c:member:`bt_le_adv_param.tx_power` and :c:enumerator:`BT_LE_ADV_OPT_TX_POWER`
+      to request a specific TX power level per extended advertising set.
     * :c:member:`bt_conn_cb.le_param_update_rejected`
 
   * Mesh

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -815,6 +815,19 @@ enum bt_le_adv_opt {
 	 * @kconfig_dep{BT_EXT_ADV_CODING_SELECTION}
 	 */
 	BT_LE_ADV_OPT_REQUIRE_S8_CODING = BIT(21),
+
+	/**
+	 * @brief Request a specific TX power level for the advertising set.
+	 *
+	 * When set, the @ref bt_le_adv_param.tx_power field is passed to the
+	 * controller as the desired TX power. The controller selects the closest
+	 * supported level and reports the actual value via
+	 * @ref bt_le_ext_adv_info.tx_power.
+	 *
+	 * When not set, the controller chooses the TX power freely
+	 * (equivalent to @ref BT_HCI_LE_ADV_TX_POWER_NO_PREF).
+	 */
+	BT_LE_ADV_OPT_TX_POWER = BIT(22),
 };
 
 /** LE Advertising Parameters. */
@@ -850,6 +863,17 @@ struct bt_le_adv_param {
 	 * set as @ref bt_le_adv_param.options.
 	 */
 	uint8_t  secondary_max_skip;
+
+	/**
+	 * @brief Requested TX power in dBm.
+	 *
+	 * Only used when @ref BT_LE_ADV_OPT_TX_POWER is set in @ref options.
+	 * Valid range is @ref BT_HCI_LE_ADV_TX_POWER_MIN to
+	 * @ref BT_HCI_LE_ADV_TX_POWER_MAX.
+	 * The controller selects the closest supported level and reports the
+	 * actual value via @ref bt_le_ext_adv_info.tx_power.
+	 */
+	int8_t tx_power;
 
 	/** @brief Bit-field of advertising options, see the @ref bt_le_adv_opt field. */
 	uint32_t options;
@@ -900,6 +924,23 @@ struct bt_le_adv_param {
 	const bt_addr_le_t *peer;
 };
 
+/**
+ * @brief Set the TX power in an advertising parameter struct.
+ *
+ * Convenience helper that sets @ref bt_le_adv_param.tx_power and enables
+ * @ref BT_LE_ADV_OPT_TX_POWER in @ref bt_le_adv_param.options in a single
+ * call.
+ *
+ * @param param    Advertising parameters to update.
+ * @param tx_power Requested TX power in dBm. Valid range is
+ *                 @ref BT_HCI_LE_ADV_TX_POWER_MIN to
+ *                 @ref BT_HCI_LE_ADV_TX_POWER_MAX.
+ */
+static inline void bt_le_adv_param_set_tx_power(struct bt_le_adv_param *param, int8_t tx_power)
+{
+	param->options |= BT_LE_ADV_OPT_TX_POWER;
+	param->tx_power = tx_power;
+}
 
 /** Periodic Advertising options */
 enum bt_le_per_adv_opt {

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -1756,6 +1756,11 @@ struct bt_hci_cp_le_set_adv_set_random_addr {
 #define BT_HCI_LE_ADV_SCAN_REQ_ENABLE  1
 #define BT_HCI_LE_ADV_SCAN_REQ_DISABLE 0
 
+/** Minimum advertising TX power in dBm (Core Spec Vol 4, Part E, 7.8.53). */
+#define BT_HCI_LE_ADV_TX_POWER_MIN     -127
+/** Maximum advertising TX power in dBm (Core Spec Vol 4, Part E, 7.8.53). */
+#define BT_HCI_LE_ADV_TX_POWER_MAX      20
+/** Advertising TX power: no preference, let the controller choose. */
 #define BT_HCI_LE_ADV_TX_POWER_NO_PREF 0x7F
 
 #define BT_HCI_LE_ADV_HANDLE_MAX       0xEF

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1048,6 +1048,13 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 
 	adv->options = param->options;
 
+	if ((param->options & BT_LE_ADV_OPT_TX_POWER) != 0U) {
+		if (!IN_RANGE(param->tx_power, BT_HCI_LE_ADV_TX_POWER_MIN,
+			      BT_HCI_LE_ADV_TX_POWER_MAX)) {
+			return -EINVAL;
+		}
+	}
+
 	err = bt_id_set_adv_own_addr(adv, param->options, dir_adv,
 				     &own_addr_type);
 	if (err) {
@@ -1083,7 +1090,8 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 	cp->prim_channel_map = get_adv_channel_map(param->options);
 	cp->own_addr_type = own_addr_type;
 	cp->filter_policy = get_filter_policy(param->options);
-	cp->tx_power = BT_HCI_LE_ADV_TX_POWER_NO_PREF;
+	cp->tx_power = (param->options & BT_LE_ADV_OPT_TX_POWER) != 0U ?
+		       param->tx_power : BT_HCI_LE_ADV_TX_POWER_NO_PREF;
 	cp->prim_adv_phy = BT_HCI_LE_PHY_1M;
 
 	if ((param->options & BT_LE_ADV_OPT_EXT_ADV) &&


### PR DESCRIPTION
The HCI Set Extended Advertising Parameters command carries an Advertising_TX_Power field, but Zephyr hardcoded it to BT_HCI_LE_ADV_TX_POWER_NO_PREF, giving applications no way to request a specific TX power per extended advertising set.

Add an `int8_t tx_power` field to `struct bt_le_adv_param` together with a new `BT_LE_ADV_OPT_TX_POWER` options bit. When the bit is set, the `tx_power` value is passed to the controller when the advertising parameters are applied. The controller selects the closest supported level and reports the actual value back via `bt_le_ext_adv_info.tx_power`.

Existing code that does not set `BT_LE_ADV_OPT_TX_POWER` is unaffected.

Assisted-by: Augment:claude-sonnet-4.6