### PR TITLE
modem: cellular: DLCI setup script

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1356,13 +1356,29 @@ static int modem_cellular_on_open_dlci1_state_enter(struct modem_cellular_data *
 static void modem_cellular_open_dlci1_event_handler(struct modem_cellular_data *data,
 						    enum modem_cellular_event evt)
 {
+	const struct modem_cellular_config *config = data->dev->config;
+	const struct modem_chat_script *dlci_script = config->vendor->scripts.dlci_setup;
+
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_DLCI1_OPENED:
-		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_OPEN_DLCI2);
+		if (dlci_script) {
+			modem_chat_attach(&data->chat, data->dlci1_pipe);
+			modem_chat_run_script_async(&data->chat, dlci_script);
+		} else {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_OPEN_DLCI2);
+		}
 		break;
 
 	case MODEM_CELLULAR_EVENT_SUSPEND:
+		modem_chat_release(&data->chat);
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_INIT_POWER_OFF);
+		break;
+
+	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
+	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
+		/* Failure is unlikely to be critical, continue on */
+		modem_chat_release(&data->chat);
+		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_OPEN_DLCI2);
 		break;
 
 	default:
@@ -1406,23 +1422,43 @@ static int modem_cellular_on_open_dlci2_state_enter(struct modem_cellular_data *
 	return modem_pipe_open_async(data->dlci2_pipe);
 }
 
+static void modem_cellular_open_dlci2_next(struct modem_cellular_data *data)
+{
+	data->cmd_pipe = data->dlci2_pipe;
+
+	if (modem_cellular_board_init_script(data->dev) != NULL) {
+		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RUN_BOARD_INIT_SCRIPT);
+	} else {
+		modem_cellular_enter_apn_state(data);
+	}
+}
+
 static void modem_cellular_open_dlci2_event_handler(struct modem_cellular_data *data,
 						    enum modem_cellular_event evt)
 {
+	const struct modem_cellular_config *config = data->dev->config;
+	const struct modem_chat_script *dlci_script = config->vendor->scripts.dlci_setup;
+
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_DLCI2_OPENED:
-		data->cmd_pipe = data->dlci2_pipe;
-
-		if (modem_cellular_board_init_script(data->dev) != NULL) {
-			modem_cellular_enter_state(data,
-						   MODEM_CELLULAR_STATE_RUN_BOARD_INIT_SCRIPT);
+		if (dlci_script) {
+			modem_chat_attach(&data->chat, data->dlci2_pipe);
+			modem_chat_run_script_async(&data->chat, dlci_script);
 		} else {
-			modem_cellular_enter_apn_state(data);
+			modem_cellular_open_dlci2_next(data);
 		}
 		break;
 
 	case MODEM_CELLULAR_EVENT_SUSPEND:
+		modem_chat_release(&data->chat);
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_INIT_POWER_OFF);
+		break;
+
+	case MODEM_CELLULAR_EVENT_SCRIPT_SUCCESS:
+	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
+		/* Failure is unlikely to be critical, continue on */
+		modem_chat_release(&data->chat);
+		modem_cellular_open_dlci2_next(data);
 		break;
 
 	default:

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
@@ -101,6 +101,13 @@ static void nrf93m1_on_bcinfosc(struct modem_chat *chat, char **argv, uint16_t a
 	modem_cellular_emit_network_status(data, &evt);
 }
 
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(nordic_nrf93m1_dlci_setup_chat_script_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match));
+
+MODEM_CHAT_SCRIPT_DEFINE(nordic_nrf93m1_dlci_setup_chat_script,
+			 nordic_nrf93m1_dlci_setup_chat_script_cmds, abort_matches,
+			 modem_cellular_chat_callback_handler, 1);
+
 static const struct modem_cellular_vendor_config nrf93m1_vendor = {
 	/* clang-format off */
 	.scripts = {
@@ -109,6 +116,7 @@ static const struct modem_cellular_vendor_config nrf93m1_vendor = {
 		.dial = &nordic_nrf93m1_dial_chat_script,
 		.periodic = &nordic_nrf93m1_periodic_chat_script,
 		.shutdown = &nordic_nrf93m1_shutdown_chat_script,
+		.dlci_setup = &nordic_nrf93m1_dlci_setup_chat_script,
 	},
 	.unsol_matches = {
 		.matches = nordic_nrf93m1_unsol,

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -249,6 +249,8 @@ struct modem_cellular_config_scripts {
 	const struct modem_chat_script *periodic;
 	/** Optional script that prepares the modem for power-off. */
 	const struct modem_chat_script *shutdown;
+	/** Optional script for configuring DLCI channels after opening */
+	const struct modem_chat_script *dlci_setup;
 };
 
 /**


### PR DESCRIPTION
It is relatively common (at least for nRF93M1, Telit LE910) that channel configuration commands such as `ATE0` that are normally sent during the `init` script are not actually carried over to the DLCI channels opened with CMUX.

Enable vendor implementations to provide a script that should be run after a DLCI channel is opened to re-apply these configurations.

Note that this script is NOT automatically run for user DLCI channels, as the `modem_cellular` is not responsible for opening these pipes.