### PR TITLE
modem: cellular: bugfixes

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1696,6 +1696,9 @@ static void modem_cellular_await_registered_event_handler(struct modem_cellular_
 		break;
 
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
+		if (config->vendor->scripts.periodic == NULL) {
+			break;
+		}
 		if (atomic_get(&data->periodic_paused)) {
 			data->periodic_timeout_skipped = true;
 			break;
@@ -1784,6 +1787,9 @@ static void modem_cellular_registered_event_handler(struct modem_cellular_data *
 		break;
 
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
+		if (config->vendor->scripts.periodic == NULL) {
+			break;
+		}
 		if (atomic_get(&data->periodic_paused)) {
 			data->periodic_timeout_skipped = true;
 			break;

--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -23,6 +23,7 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/ring_buffer.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/sys/util.h>
 
 #include <zephyr/modem/pipe.h>
 #include <zephyr/modem/stats.h>
@@ -89,10 +90,16 @@ struct modem_cmux_config {
 #define MODEM_CMUX_HEADER_SIZE			6
 #endif
 
+/* Minimum required size for CMUX RX buffers */
+#define MODEM_CMUX_RX_BUFFER_SIZE_MIN		126
 
-/* Total size of the CMUX work buffers */
-#define MODEM_CMUX_WORK_BUFFER_SIZE (CONFIG_MODEM_CMUX_MTU + MODEM_CMUX_HEADER_SIZE + \
-				     CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE_EXTRA)
+/* Total size of the CMUX work buffers from the MTU */
+#define MODEM_CMUX_WORK_BUFFER_FROM_MTU (CONFIG_MODEM_CMUX_MTU + MODEM_CMUX_HEADER_SIZE + \
+					 CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE_EXTRA)
+
+/* Enforce the minimum size required by CMUX */
+#define MODEM_CMUX_WORK_BUFFER_SIZE MAX(MODEM_CMUX_WORK_BUFFER_FROM_MTU, \
+					MODEM_CMUX_RX_BUFFER_SIZE_MIN)
 
 enum modem_cmux_state {
 	MODEM_CMUX_STATE_DISCONNECTED = 0,

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(modem_chat, CONFIG_MODEM_MODULES_LOG_LEVEL);
 #include <string.h>
 
 #include <zephyr/modem/chat.h>
+#include <zephyr/sys/__assert.h>
 
 #include "modem_workqueue.h"
 
@@ -902,6 +903,8 @@ bool modem_chat_is_running(struct modem_chat *chat)
 int modem_chat_run_script_async(struct modem_chat *chat, const struct modem_chat_script *script)
 {
 	bool script_is_running;
+
+	__ASSERT_NO_MSG(script != NULL);
 
 	if (chat->pipe == NULL) {
 		return -EPERM;

--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -2184,7 +2184,7 @@ struct modem_pipe *modem_cmux_dlci_init(struct modem_cmux *cmux, struct modem_cm
 	__ASSERT_NO_MSG(config != NULL);
 	__ASSERT_NO_MSG(config->dlci_address < 64);
 	__ASSERT_NO_MSG(config->receive_buf != NULL);
-	__ASSERT_NO_MSG(config->receive_buf_size >= 126);
+	__ASSERT_NO_MSG(config->receive_buf_size >= MODEM_CMUX_RX_BUFFER_SIZE_MIN);
 
 	memset(dlci, 0x00, sizeof(*dlci));
 	dlci->cmux = cmux;


### PR DESCRIPTION
Ensure that the CMUX buffer sizes instantiated in `modem_cellular.h` meet the minimum size required by the CMUX module.

Don't attempt to run a `NULL` periodic script, and add assertions into `modem_chat` to raise the issue if this does occur.

Increase the default CMUX MTU size for the nRF93M1 from 31 bytes to 127.