### PR TITLE
sys: util: add intermediate cast to void* in CONTAINER_OF

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -281,7 +281,7 @@ extern "C" {
 #define CONTAINER_OF(ptr, type, field)                                                             \
 	({                                                                                         \
 		CONTAINER_OF_VALIDATE(ptr, type, field)                                            \
-		((type *)(((char *)(ptr)) - offsetof(type, field)));                               \
+		((type *)(void *)(((char *)(ptr)) - offsetof(type, field)));                       \
 	})
 
 /**


### PR DESCRIPTION
The CONTAINER_OF macro converts a pointer to a member field into a pointer to the containing structure. The direct cast from the original pointer type to `char*` can trigger alignment warnings from static analysis tools such as PC-Lint Plus (warning 2445), because the cast appears to increase alignment requirements.

Insert an intermediate cast to `void*` so the macro explicitly discards the source alignment information before converting to `char*`. This does not change the generated code or runtime behavior because the final cast back to the container type restores the proper alignment.

Fixes #42082

## Verification

- `west twister -T zephyr/tests/kernel/common -p native_sim`
  - Result: 7/7 passed, 485/485 test cases passed
- `west twister -T zephyr/tests/lib/cmsis_dsp -p native_sim`
  - Result: 65/65 passed
- `west build -p -b native_sim zephyr/samples/hello_world`
  - Result: build passed
- `west twister -T zephyr/tests/kernel/common -p native_sim -x EXTRA_CFLAGS="-Werror=cast-align"`
  - Result: 7/7 passed (no new cast-align warnings introduced)

## Note

This change targets static-analysis alignment warnings (PC-Lint Plus / MISRA). It does not resolve `gcc -Wcast-align=strict` warnings, which are triggered independently by the final cast back to the container type.