### PR TITLE
Add mcx_n9xx_evk and mcx_n5xx_evk tsi support

### DIFF
--- a/boards/nxp/mcx_nx4x_evk/mcx_n5xx_evk_mcxn547_cpu0.yaml
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n5xx_evk_mcxn547_cpu0.yaml
@@ -13,4 +13,6 @@ flash: 2048
 toolchain:
   - zephyr
   - gnuarmemb
+supported:
+  - tsi
 vendor: nxp

--- a/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0.yaml
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0.yaml
@@ -35,4 +35,5 @@ supported:
   - watchdog
   - edac
   - crc
+  - tsi
 vendor: nxp

--- a/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk-pinctrl.dtsi
+++ b/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk-pinctrl.dtsi
@@ -299,4 +299,13 @@
 			bias-pull-up;
 		};
 	};
+
+	pinmux_tsi: pinmux_tsi {
+		group0 {
+			pinmux = <TSI0_CH19_PIO1_10>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			bias-pull-up;
+		};
+	};
 };

--- a/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk.dtsi
+++ b/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk.dtsi
@@ -314,3 +314,14 @@ zephyr_mipi_dbi_parallel: &flexio0_lcd {
 &crc {
 	status = "okay";
 };
+
+&tsi0 {
+	pinctrl-0 = <&pinmux_tsi>;
+	pinctrl-names = "default";
+
+	channel-mask = <0x80000>;
+	input-codes = <INPUT_BTN_3>;
+	touch-threshold = <5>;
+	release-threshold = <2>;
+	scan-period-ms = <50>;
+};

--- a/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk_cpu0.dtsi
+++ b/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk_cpu0.dtsi
@@ -299,3 +299,7 @@ zephyr_udc0: &usb1 {
 &erm0 {
 	status = "okay";
 };
+
+&tsi0 {
+	status = "okay";
+};

--- a/dts/arm/nxp/mcx/nxp_mcxn94x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn94x_common.dtsi
@@ -130,14 +130,6 @@
 		status = "disabled";
 	};
 
-	tsi0: tsi@50000 {
-		compatible = "nxp,tsi-input";
-		reg = <0x50000 0x1000>;
-		interrupts = <101 0>;
-		clocks = <&syscon MCUX_TSI_CLK>;
-		status = "disabled";
-	};
-
 	crypto@54000 {
 		compatible = "nxp,els";
 		reg = <0x54000 0x200>;

--- a/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
@@ -1340,6 +1340,14 @@
 		clocks = <&syscon MCUX_CRC_CLK>;
 		status = "disabled";
 	};
+
+	tsi0: tsi@50000 {
+		compatible = "nxp,tsi-input";
+		reg = <0x50000 0x1000>;
+		interrupts = <101 0>;
+		clocks = <&syscon MCUX_TSI_CLK>;
+		status = "disabled";
+	};
 };
 
 &systick {


### PR DESCRIPTION
Support tsi for mcx_n5xx_evk and mcx_n5xx_evk
Verify using samples\subsys\input\input_dump
<img width="668" height="206" alt="image" src="https://github.com/user-attachments/assets/0e0349ea-367c-48a7-8ceb-ba69457d5220" />
