### PR TITLE
boards: nucleo_u575zi_q set SPI1 CS to PD14

### DIFF
--- a/boards/st/nucleo_u575zi_q/doc/index.rst
+++ b/boards/st/nucleo_u575zi_q/doc/index.rst
@@ -164,7 +164,7 @@ Default Zephyr Peripheral Mapping:
 - LD3 : PG2
 - LPUART_1_TX : PG7
 - LPUART_1_RX : PG8
-- SPI_1_NSS : PA4
+- SPI_1_CS : PD14
 - SPI_1_SCK : PA5
 - SPI_1_MISO : PA6
 - SPI_1_MOSI : PA7

--- a/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -122,14 +122,13 @@
 };
 
 &spi1 {
-	pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5
-		     &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
 	pinctrl-names = "default";
+	cs-gpios = <&gpiod 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	status = "okay";
 };
 
 &dac1 {
-	/* CAUTION: DAC on PA4 may conflict with SPI1 NSS on same pin */
 	pinctrl-0 = <&dac1_out1_pa4>;
 	pinctrl-names = "default";
 	status = "okay";

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
@@ -124,7 +124,7 @@
 &spi1 {
 	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
 	pinctrl-names = "default";
-	cs-gpios = <&gpiod 14 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpiod 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Set the SPI1 CS pin to PD14 on the ST NUCLEO-U575ZI_Q board.
It aligns this board's config with the very similar NUCLEO-U5A5ZJ-Q (see https://github.com/zephyrproject-rtos/zephyr/commit/8f14c68660bcb64a8e25ddfab7d4fe58ef95e44a) and resolves the conflict with the DAC1 on PA4.
Also add pull-up to SPI1 CS for the NUCLEO-U5A5ZJ_Q board.