### PR TITLE
Add mcxn236 qdc support

### DIFF
--- a/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
@@ -1212,6 +1212,28 @@
 			status = "disabled";
 		};
 	};
+
+	inputmux0: inputmux@6000 {
+		compatible = "nxp,inputmux";
+		reg = <0x6000 0x1000>;
+		status = "disabled";
+		#mux-control-cells = <1>;
+		#mux-state-cells = <2>;
+	};
+
+	qdc0: qdc@cf000 {
+		compatible = "nxp,mcux-qdc";
+		reg = <0xcf000 0x1000>;
+		interrupts = <124 0>, <125 0>, <126 0>, <127 0>;
+		status = "disabled";
+	};
+
+	qdc1: qdc@d1000 {
+		compatible = "nxp,mcux-qdc";
+		reg = <0xd1000 0x1000>;
+		interrupts = <128 0>, <129 0>, <130 0>, <131 0>;
+		status = "disabled";
+	};
 };
 
 &systick {

--- a/samples/sensor/qdec/boards/frdm_mcxa153.conf
+++ b/samples/sensor/qdec/boards/frdm_mcxa153.conf
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2026 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-# Enable EQDC overflow-trigger support so the qdec sample exercises the
-# SENSOR_TRIG_OVERFLOW path on the revolution channel.
-CONFIG_EQDC_MCUX_TRIGGER=y

--- a/samples/sensor/qdec/boards/frdm_mcxa156.conf
+++ b/samples/sensor/qdec/boards/frdm_mcxa156.conf
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2026 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-# Enable EQDC overflow-trigger support so the qdec sample exercises the
-# SENSOR_TRIG_OVERFLOW path on the revolution channel.
-CONFIG_EQDC_MCUX_TRIGGER=y

--- a/samples/sensor/qdec/boards/frdm_mcxa266.conf
+++ b/samples/sensor/qdec/boards/frdm_mcxa266.conf
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2026 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-# Enable EQDC overflow-trigger support so the qdec sample exercises the
-# SENSOR_TRIG_OVERFLOW path on the revolution channel.
-CONFIG_EQDC_MCUX_TRIGGER=y

--- a/samples/sensor/qdec/boards/frdm_mcxa344.conf
+++ b/samples/sensor/qdec/boards/frdm_mcxa344.conf
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2026 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-# Enable EQDC overflow-trigger support so the qdec sample exercises the
-# SENSOR_TRIG_OVERFLOW path on the revolution channel.
-CONFIG_EQDC_MCUX_TRIGGER=y

--- a/samples/sensor/qdec/boards/frdm_mcxa346.conf
+++ b/samples/sensor/qdec/boards/frdm_mcxa346.conf
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2026 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-# Enable EQDC overflow-trigger support so the qdec sample exercises the
-# SENSOR_TRIG_OVERFLOW path on the revolution channel.
-CONFIG_EQDC_MCUX_TRIGGER=y

--- a/samples/sensor/qdec/boards/frdm_mcxa366.conf
+++ b/samples/sensor/qdec/boards/frdm_mcxa366.conf
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2026 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-# Enable EQDC overflow-trigger support so the qdec sample exercises the
-# SENSOR_TRIG_OVERFLOW path on the revolution channel.
-CONFIG_EQDC_MCUX_TRIGGER=y

--- a/samples/sensor/qdec/boards/frdm_mcxn236.overlay
+++ b/samples/sensor/qdec/boards/frdm_mcxn236.overlay
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		qdec0 = &qdc0;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	encoder-emulate {
+		compatible = "gpio-leds";
+
+		phase_a: phase_a {
+			gpios = <&gpio3 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		phase_b: phase_b {
+			gpios = <&gpio3 17 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&inputmux0 {
+	status = "okay";
+};
+
+/* Connect J3-5 -> J3-1, J3-7 -> J3-3 */
+&pinctrl {
+	qdc0_default: qdc0_default {
+		group0 {
+			pinmux = <TRIG_IN9_PIO4_21>,
+				 <TRIG_IN8_PIO4_13>;
+			drive-strength = "low";
+			slew-rate = "fast";
+			input-enable;
+		};
+	};
+};
+
+&qdc0 {
+	status = "okay";
+	counts-per-revolution = <480>;
+	mux-states = <&inputmux0 0 0x37000033>,
+		     <&inputmux0 0 0x36c00032>;
+	pinctrl-0 = <&qdc0_default>;
+	pinctrl-names = "default";
+};

--- a/samples/sensor/qdec/tests.yaml
+++ b/samples/sensor/qdec/tests.yaml
@@ -19,19 +19,19 @@ tests:
         - "Position = (.*) degrees"
 
   sample.sensor.eqdc_trigger:
-    platform_allow:
-      - frdm_mcxa153
-      - frdm_mcxa156
-      - frdm_mcxa266
-      - frdm_mcxa344
-      - frdm_mcxa346
-      - frdm_mcxa366
+    filter: >
+      dt_alias_exists("qdec0") and dt_alias_exists("qenca")
+      and dt_alias_exists("qencb") and CONFIG_EQDC_MCUX
     integration_platforms:
       - frdm_mcxa153
+    extra_configs:
+      - CONFIG_EQDC_MCUX_TRIGGER=y
     depends_on: gpio
     harness_config:
       type: multi_line
       ordered: true
+      fixture:
+        - qdec_gpio
       regex:
         - "Quadrature decoder sensor test"
         - "Quadrature encoder emulator enabled with (.*) ms period"


### PR DESCRIPTION
1. Support qdc0 and qdc1 nodes for mcxn23x dtsi file
2. Enables samples/sensor/qdec for frdm_mcxn236