### PR TITLE
drivers: ethernet: stm32_hal: fix semaphore init position

### DIFF
--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -399,6 +399,9 @@ static const struct ethernet_api eth_api = {
 				ETH_STM32_HAL_COMMON_CLOCK_SELECTION(n)                            \
 			},                                                                         \
 		},                                                                                 \
+		.rx_int_sem = Z_SEM_INITIALIZER(eth##n##_data.rx_int_sem, 0, K_SEM_MAX_LIMIT),     \
+		IF_ENABLED(CONFIG_ETH_STM32_HAL_API_V2,                                            \
+			(.tx_int_sem = Z_SEM_INITIALIZER(eth##n##_data.tx_int_sem, 0, 1),))        \
 	}
 
 #define ETH_STM32_HAL_COMMON_DT_INST_DEFN(n)                                                       \

--- a/drivers/ethernet/eth_stm32_hal_v1.c
+++ b/drivers/ethernet/eth_stm32_hal_v1.c
@@ -188,9 +188,6 @@ int eth_stm32_hal_init(const struct device *dev)
 		return -EIO;
 	}
 
-	/* Initialize semaphores */
-	k_sem_init(&dev_data->rx_int_sem, 0, K_SEM_MAX_LIMIT);
-
 	if (HAL_ETH_DMATxDescListInit(heth, ETH_STM32_TX_DESC_PTR(cfg),
 				      ETH_STM32_TX_BUF_PTR(cfg), ETH_TXBUFNB) != HAL_OK) {
 		LOG_ERR("HAL_ETH_DMATxDescListInit failed");

--- a/drivers/ethernet/eth_stm32_hal_v2.c
+++ b/drivers/ethernet/eth_stm32_hal_v2.c
@@ -662,10 +662,6 @@ int eth_stm32_hal_init(const struct device *dev)
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet) */
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
-	/* Initialize semaphores */
-	k_sem_init(&dev_data->rx_int_sem, 0, K_SEM_MAX_LIMIT);
-	k_sem_init(&dev_data->tx_int_sem, 0, 1);
-
 	for (uint16_t i = 0; i < ETH_TXBUFNB; ++i) {
 		dev_data->tx_buffer_header[i].tx_buff.buffer = cfg->dma_buf->tx_buf[i];
 	}


### PR DESCRIPTION
Initilization of the semaphores is moved from `eth_stm32_hal_init()` of hal_v1.c/v2.c to a static initialization with `Z_SEM_INITIALIZER` to avoid use of uninitialized semaphores.

The semaphores were used uninitialized when the ethernet node has the `zephyr,deferred-init` property set:
`rx_thread()` uses them after `eth_iface_init()` is called (which in this case happened before the ethernet device was initialized).

https://github.com/zephyrproject-rtos/zephyr/blob/2c47d45300876cbe106c1ea8c39e4c086026ce0a/drivers/ethernet/eth_stm32_hal_common.c#L44-L56