### PR TITLE
net: ethernet: remove ETHERNET_PTP from caps

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -336,6 +336,11 @@ Ethernet
   extra headroom for transmit packets must now select
   :kconfig:option:`CONFIG_NET_L2_ETHERNET_EXTRA_TX_PKT_HEADROOM`. (:github:`112924`)
 
+* ``ETHERNET_PTP`` flag has been removed from :c:enum:`ethernet_hw_caps`.
+  Use :c:func:`net_eth_get_ptp_clock` to check if the ethernet interface has a PTP clock.
+  Out-of-tree drivers must remove any references to these flags from their
+  :c:struct:`ethernet_api` ``get_capabilities`` implementation. (:github:`112788`)
+
 Flash
 =====
 * :dtcompatible:`jedec,spi-nand` now requires a ``plane-bytes`` property, which indicates the size

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -80,9 +80,6 @@ static enum ethernet_hw_caps e1000_caps(const struct device *dev, struct net_if 
 #if defined(CONFIG_NET_VLAN)
 		ETHERNET_HW_VLAN |
 #endif
-#if defined(CONFIG_ETH_E1000_PTP_CLOCK)
-		ETHERNET_PTP |
-#endif
 		ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE |
 		ETHERNET_LINK_1000BASE |
 		/* The driver does not really support TXTIME atm but mark

--- a/drivers/ethernet/eth_native_tap.c
+++ b/drivers/ethernet/eth_native_tap.c
@@ -456,9 +456,6 @@ static enum ethernet_hw_caps eth_native_tap_get_capabilities(const struct device
 #if defined(CONFIG_ETH_NATIVE_TAP_VLAN_TAG_STRIP)
 		| ETHERNET_HW_VLAN_TAG_STRIP
 #endif
-#if defined(CONFIG_PTP_CLOCK_NATIVE)
-		| ETHERNET_PTP
-#endif
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 		| ETHERNET_PROMISC_MODE
 #endif

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -254,9 +254,6 @@ static enum ethernet_hw_caps eth_nxp_enet_get_capabilities(const struct device *
 #if defined(CONFIG_NET_VLAN)
 		ETHERNET_HW_VLAN |
 #endif
-#if defined(CONFIG_PTP_CLOCK_NXP_ENET)
-		ETHERNET_PTP |
-#endif
 #if defined(CONFIG_ETH_NXP_ENET_HW_ACCELERATION)
 		ETHERNET_HW_TX_CHKSUM_OFFLOAD |
 		ETHERNET_HW_RX_CHKSUM_OFFLOAD |

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -270,9 +270,6 @@ static enum ethernet_hw_caps eth_nxp_enet_qos_get_capabilities(const struct devi
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 	caps |= ETHERNET_PROMISC_MODE;
 #endif
-#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
-	caps |= ETHERNET_PTP;
-#endif
 	return caps;
 }
 

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1812,9 +1812,6 @@ static enum ethernet_hw_caps eth_sam_gmac_get_capabilities(const struct device *
 #if defined(CONFIG_NET_VLAN)
 		ETHERNET_HW_VLAN |
 #endif
-#if defined(CONFIG_PTP_CLOCK_SAM_GMAC)
-		ETHERNET_PTP |
-#endif
 		ETHERNET_PRIORITY_QUEUES |
 #if GMAC_ACTIVE_PRIORITY_QUEUE_NUM >= 1
 		ETHERNET_QAV |

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -258,9 +258,6 @@ static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device 
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 	       | ETHERNET_PROMISC_MODE
 #endif
-#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
-	       | ETHERNET_PTP
-#endif
 #if defined(CONFIG_NET_LLDP)
 	       | ETHERNET_LLDP
 #endif

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -1113,10 +1113,6 @@ static enum ethernet_hw_caps eth_xmc4xxx_capabilities(const struct device *dev _
 	enum ethernet_hw_caps caps = ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE |
 				     ETHERNET_HW_TX_CHKSUM_OFFLOAD | ETHERNET_HW_RX_CHKSUM_OFFLOAD;
 
-#if defined(CONFIG_PTP_CLOCK_XMC4XXX)
-	caps |= ETHERNET_PTP;
-#endif
-
 #if defined(CONFIG_NET_VLAN)
 	caps |= ETHERNET_HW_VLAN;
 #endif

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -576,11 +576,6 @@ enum ethernet_hw_caps netc_eth_get_capabilities(const struct device *dev __maybe
 #endif
 	);
 
-#if defined(CONFIG_PTP_CLOCK_NXP_NETC)
-	if (netc_eth_get_ptp_clock(dev, iface) != NULL) {
-		caps |= ETHERNET_PTP;
-	}
-#endif
 	return caps;
 }
 

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -167,9 +167,6 @@ enum ethernet_hw_caps {
 	/** 5 Gbits link supported */
 	ETHERNET_LINK_5000BASE		= BIT(7),
 
-	/** IEEE 802.1AS (gPTP) clock supported */
-	ETHERNET_PTP			= BIT(8),
-
 	/** IEEE 802.1Qav (credit-based shaping) supported */
 	ETHERNET_QAV			= BIT(9),
 

--- a/samples/net/sockets/txtime/src/main.c
+++ b/samples/net/sockets/txtime/src/main.c
@@ -582,11 +582,6 @@ int main(void)
 	if_index = net_if_get_by_iface(iface);
 
 	caps = net_eth_get_hw_capabilities(iface);
-	if (!(caps & ETHERNET_PTP)) {
-		LOG_ERR("Interface %p does not support %s", iface, "PTP");
-		return 0;
-	}
-
 	if (!(caps & ETHERNET_TXTIME)) {
 		LOG_ERR("Interface %p does not support %s", iface, "TXTIME");
 		return 0;

--- a/subsys/net/l2/ethernet/dsa/dsa_port.c
+++ b/subsys/net/l2/ethernet/dsa/dsa_port.c
@@ -150,23 +150,16 @@ const struct device *dsa_port_get_ptp_clock(const struct device *dev,
 }
 #endif
 
-enum ethernet_hw_caps dsa_port_get_capabilities(const struct device *dev,
-						struct net_if *iface __maybe_unused)
+static enum ethernet_hw_caps dsa_port_get_capabilities(const struct device *dev,
+						       struct net_if *iface __unused)
 {
 	struct dsa_switch_context *dsa_switch_ctx = dev->data;
-	uint32_t caps = 0;
 
-#ifdef CONFIG_NET_L2_PTP_TIMESTAMPING
-	if (dsa_port_get_ptp_clock(dev, iface) != NULL) {
-		caps |= ETHERNET_PTP;
-	}
-#endif
-
-	if (dsa_switch_ctx->dapi->get_capabilities) {
-		caps |= dsa_switch_ctx->dapi->get_capabilities(dev);
+	if (dsa_switch_ctx->dapi->get_capabilities == NULL) {
+		return (enum ethernet_hw_caps)0;
 	}
 
-	return caps;
+	return dsa_switch_ctx->dapi->get_capabilities(dev);
 }
 
 static int dsa_set_config(const struct device *dev,

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -924,10 +924,6 @@ const struct device *net_eth_get_ptp_clock(struct net_if *iface)
 		return NULL;
 	}
 
-	if (!(net_eth_get_hw_capabilities(iface) & ETHERNET_PTP)) {
-		return NULL;
-	}
-
 	if (!api->get_ptp_clock) {
 		return NULL;
 	}

--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -53,9 +53,6 @@ static struct ethernet_capabilities eth_hw_caps[] = {
 	EC(ETHERNET_LINK_1000BASE,        "1 Gbits"),
 	EC(ETHERNET_LINK_2500BASE,        "2.5 Gbits"),
 	EC(ETHERNET_LINK_5000BASE,        "5 Gbits"),
-#ifdef CONFIG_PTP_CLOCK
-	EC(ETHERNET_PTP,                  "IEEE 802.1AS gPTP clock"),
-#endif
 	EC(ETHERNET_QAV,                  "IEEE 802.1Qav (credit shaping)"),
 	EC(ETHERNET_QBV,                  "IEEE 802.1Qbv (scheduled traffic)"),
 	EC(ETHERNET_QBU,                  "IEEE 802.1Qbu (frame preemption)"),
@@ -82,6 +79,12 @@ static void print_supported_ethernet_capabilities(
 			PR("\t%s\n", eth_hw_caps[i].description);
 		}
 	}
+
+#ifdef CONFIG_PTP_CLOCK
+	if (net_eth_get_ptp_clock(iface) != NULL) {
+		PR("\t%s\n", "IEEE 802.1AS gPTP clock");
+	}
+#endif
 }
 #endif /* CONFIG_NET_L2_ETHERNET */
 

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -119,12 +119,6 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static enum ethernet_hw_caps eth_capabilities(const struct device *dev __unused,
-					      struct net_if *iface __unused)
-{
-	return ETHERNET_PTP;
-}
-
 static const struct device *eth_get_ptp_clock(const struct device *dev,
 					      struct net_if *iface __unused)
 {
@@ -136,7 +130,6 @@ static const struct device *eth_get_ptp_clock(const struct device *dev,
 static struct ethernet_api api_funcs = {
 	.iface_api.init = eth_iface_init,
 
-	.get_capabilities = eth_capabilities,
 	.get_ptp_clock = eth_get_ptp_clock,
 	.send = eth_tx,
 };


### PR DESCRIPTION
net_eth_get_ptp_clock can be used instead to
check if ptp is supported, so remove ETHERNET_PTP.