### PR TITLE
tests: dma: select test DMA controllers via devicetree and cover edma4 on frdm_imxrt1186

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
@@ -4,4 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-tst_dma0: &edma3 {};
+/ {
+	zephyr,user {
+		dma-test-devs = <&edma3>, <&edma4>;
+	};
+};

--- a/tests/drivers/dma/chan_blen_transfer/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
@@ -4,4 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-tst_dma0: &edma3 {};
+/ {
+	zephyr,user {
+		dma-test-devs = <&edma3>, <&edma4>;
+	};
+};

--- a/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024 STMicroelectronics
+ * Copyright 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,7 +9,13 @@
 
 #include "test_buffers.h"
 
+#if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), dma_test_devs)
+#define DMA_DATA_ALIGNMENT                                                                         \
+	DT_PROP_OR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), dma_test_devs, 0),                     \
+		   dma_buf_addr_alignment, 32)
+#else
 #define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
+#endif
 
 #if CONFIG_NOCACHE_MEMORY
 __aligned(DMA_DATA_ALIGNMENT) char tx_data[TEST_BUF_SIZE] __used

--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Intel Corporation
+ * Copyright 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,6 +22,28 @@
 #include <zephyr/ztest.h>
 
 #include "test_buffers.h"
+
+#define DMA_TEST_NODE      DT_PATH(zephyr_user)
+#define DMA_TEST_DEVS_PROP dma_test_devs
+
+#if DT_NODE_HAS_PROP(DMA_TEST_NODE, DMA_TEST_DEVS_PROP)
+/* Boards list the DMA controllers to test in a zephyr,user dma-test-devs
+ * phandle list.
+ */
+#define DMA_TEST_DEV_COUNT DT_PROP_LEN(DMA_TEST_NODE, DMA_TEST_DEVS_PROP)
+#define DMA_TEST_DEV_GET(idx, _)                                                                   \
+	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DMA_TEST_NODE, DMA_TEST_DEVS_PROP, idx))
+#else
+/* Legacy boards use tst_dmaN devicetree labels and
+ * CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS.
+ */
+#define DMA_TEST_DEV_COUNT CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS
+#define DMA_TEST_DEV_GET(idx, _) DEVICE_DT_GET(DT_NODELABEL(tst_dma##idx))
+#endif
+
+static const struct device *const dma_test_devs[] = {
+	LISTIFY(DMA_TEST_DEV_COUNT, DMA_TEST_DEV_GET, (,))
+};
 
 static K_SEM_DEFINE(transfer_end_sem, 0, 1);
 static int dma_complete_status;
@@ -127,58 +150,37 @@ static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 	return TC_PASS;
 }
 
-#define RUN_DMA_M2M_TEST(dma_label, chan, blen)                                                    \
-	do {                                                                                       \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_label));                 \
-		zassert_true((test_task(dma, chan, blen) == TC_PASS));                             \
-	} while (0)
-
-ZTEST(dma_m2m, test_tst_dma0_m2m_chan0_burst8)
+static void run_dma_m2m_test(const struct device *dma, uint32_t chan, uint32_t blen)
 {
-	RUN_DMA_M2M_TEST(tst_dma0, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 8);
+	zassert_true(test_task(dma, chan, blen) == TC_PASS, "%s failed chan %u burst %u", dma->name,
+		     chan, blen);
 }
 
-ZTEST(dma_m2m, test_tst_dma0_m2m_chan1_burst8)
-{
-	RUN_DMA_M2M_TEST(tst_dma0, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 8);
-}
+/* Generate one set of test cases per DMA controller under test so a failure
+ * on one controller does not prevent the remaining controllers from running.
+ */
+#define DEFINE_DMA_M2M_BURST8_TESTS(idx, _)                                                        \
+	ZTEST(dma_m2m, test_dma##idx##_m2m_chan0_burst8)                                           \
+	{                                                                                          \
+		run_dma_m2m_test(dma_test_devs[idx], CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 8);         \
+	}                                                                                          \
+	ZTEST(dma_m2m, test_dma##idx##_m2m_chan1_burst8)                                           \
+	{                                                                                          \
+		run_dma_m2m_test(dma_test_devs[idx], CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 8);         \
+	}
+
+LISTIFY(DMA_TEST_DEV_COUNT, DEFINE_DMA_M2M_BURST8_TESTS, ())
 
 #if CONFIG_DMA_TRANSFER_BURST16
-ZTEST(dma_m2m, test_tst_dma0_m2m_chan0_burst16)
-{
-	RUN_DMA_M2M_TEST(tst_dma0, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 16);
-}
+#define DEFINE_DMA_M2M_BURST16_TESTS(idx, _)                                                       \
+	ZTEST(dma_m2m, test_dma##idx##_m2m_chan0_burst16)                                          \
+	{                                                                                          \
+		run_dma_m2m_test(dma_test_devs[idx], CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 16);        \
+	}                                                                                          \
+	ZTEST(dma_m2m, test_dma##idx##_m2m_chan1_burst16)                                          \
+	{                                                                                          \
+		run_dma_m2m_test(dma_test_devs[idx], CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 16);        \
+	}
 
-ZTEST(dma_m2m, test_tst_dma0_m2m_chan1_burst16)
-{
-	RUN_DMA_M2M_TEST(tst_dma0, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 16);
-}
-#endif
-
-#if CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS > 1
-ZTEST(dma_m2m, test_tst_dma1_m2m_chan0_burst8)
-{
-	RUN_DMA_M2M_TEST(tst_dma1, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 8);
-}
-
-ZTEST(dma_m2m, test_tst_dma1_m2m_chan1_burst8)
-{
-	RUN_DMA_M2M_TEST(tst_dma1, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 8);
-}
-
-#if CONFIG_DMA_TRANSFER_BURST16
-ZTEST(dma_m2m, test_tst_dma1_m2m_chan0_burst16)
-{
-	RUN_DMA_M2M_TEST(tst_dma1, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 16);
-}
-
-ZTEST(dma_m2m, test_tst_dma1_m2m_chan1_burst16)
-{
-	RUN_DMA_M2M_TEST(tst_dma1, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 16);
-}
-#endif
-#endif /* CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS > 1 */
-
-#if CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS > 2
-#error "Update test_dma.c to add ZTEST cases for tst_dma2 and beyond."
+LISTIFY(DMA_TEST_DEV_COUNT, DEFINE_DMA_M2M_BURST16_TESTS, ())
 #endif

--- a/tests/drivers/dma/chan_link_transfer/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
@@ -4,4 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-tst_dma0: &edma3 {};
+/ {
+	zephyr,user {
+		dma-test-devs = <&edma3>, <&edma4>;
+	};
+};

--- a/tests/drivers/dma/chan_link_transfer/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
@@ -4,4 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-tst_dma0: &edma3 {};
+/ {
+	zephyr,user {
+		dma-test-devs = <&edma3>, <&edma4>;
+	};
+};

--- a/tests/drivers/dma/chan_link_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_link_transfer/src/test_dma.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 NXP
+ * Copyright (c) 2020, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,7 +25,30 @@
 #define TEST_DMA_CHANNEL_1 (1)
 #define GUARD_BUFF_SIZE (16)
 #define RX_BUFF_SIZE (48)
-#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
+
+#define DMA_TEST_NODE      DT_PATH(zephyr_user)
+#define DMA_TEST_DEVS_PROP dma_test_devs
+
+#if DT_NODE_HAS_PROP(DMA_TEST_NODE, DMA_TEST_DEVS_PROP)
+/* Boards list the DMA controllers to test in a zephyr,user dma-test-devs
+ * phandle list.
+ */
+#define DMA_TEST_DEV_COUNT DT_PROP_LEN(DMA_TEST_NODE, DMA_TEST_DEVS_PROP)
+#define DMA_TEST_DEV_GET(idx, _)                                                                   \
+	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DMA_TEST_NODE, DMA_TEST_DEVS_PROP, idx))
+#define DMA_TEST_DEV0_NODE DT_PHANDLE_BY_IDX(DMA_TEST_NODE, DMA_TEST_DEVS_PROP, 0)
+#else
+/* Legacy single-controller boards use a tst_dma0 devicetree label. */
+#define DMA_TEST_DEV_COUNT 1
+#define DMA_TEST_DEV_GET(idx, _) DEVICE_DT_GET(DT_NODELABEL(tst_dma0))
+#define DMA_TEST_DEV0_NODE DT_NODELABEL(tst_dma0)
+#endif
+
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DMA_TEST_DEV0_NODE, dma_buf_addr_alignment, 32)
+
+static const struct device *const dma_test_devs[] = {
+	LISTIFY(DMA_TEST_DEV_COUNT, DMA_TEST_DEV_GET, (,))
+};
 
 #ifdef CONFIG_NOCACHE_MEMORY
 static __aligned(DMA_DATA_ALIGNMENT) char tx_data[RX_BUFF_SIZE] __used
@@ -63,11 +86,10 @@ static void test_done(const struct device *dma_dev, void *arg, uint32_t id,
 	}
 }
 
-static int test_task(int minor, int major)
+static int test_task(const struct device *dma, int minor, int major)
 {
 	struct dma_config dma_cfg = { 0 };
 	struct dma_block_config dma_block_cfg = { 0 };
-	const struct device *const dma = DEVICE_DT_GET(DT_NODELABEL(tst_dma0));
 
 	if (!device_is_ready(dma)) {
 		TC_PRINT("dma controller device is not ready\n");
@@ -92,8 +114,8 @@ static int test_task(int minor, int major)
 	dma_cfg.dma_slot = CONFIG_DMA_MCUX_TEST_SLOT_START;
 #endif
 
-	TC_PRINT("Preparing DMA Controller: Chan_ID=%u, BURST_LEN=%u\n",
-		 TEST_DMA_CHANNEL_1, 8 >> 3);
+	TC_PRINT("Preparing DMA Controller: %s, Chan_ID=%u, BURST_LEN=%u\n",
+		 dma->name, TEST_DMA_CHANNEL_1, 8 >> 3);
 
 	TC_PRINT("Starting the transfer\n");
 	(void)memset(rx_data, 0, RX_BUFF_SIZE);
@@ -173,18 +195,25 @@ static int test_task(int minor, int major)
 	return TC_PASS;
 }
 
-/* export test cases */
-ZTEST(dma_m2m_link, test_dma_m2m_chan0_1_major_link)
-{
-	zassert_true((test_task(0, 1) == TC_PASS));
-}
+/* Export test cases: generate one set of test cases per DMA controller under
+ * test so a failure on one controller does not prevent the remaining
+ * controllers from running.
+ */
+#define DEFINE_DMA_M2M_LINK_TESTS(idx, _)                                                          \
+	ZTEST(dma_m2m_link, test_dma##idx##_m2m_chan0_1_major_link)                                \
+	{                                                                                          \
+		zassert_true(test_task(dma_test_devs[idx], 0, 1) == TC_PASS,                       \
+			     "%s failed major link transfer", dma_test_devs[idx]->name);           \
+	}                                                                                          \
+	ZTEST(dma_m2m_link, test_dma##idx##_m2m_chan0_1_minor_link)                                \
+	{                                                                                          \
+		zassert_true(test_task(dma_test_devs[idx], 1, 0) == TC_PASS,                       \
+			     "%s failed minor link transfer", dma_test_devs[idx]->name);           \
+	}                                                                                          \
+	ZTEST(dma_m2m_link, test_dma##idx##_m2m_chan0_1_minor_major_link)                          \
+	{                                                                                          \
+		zassert_true(test_task(dma_test_devs[idx], 1, 1) == TC_PASS,                       \
+			     "%s failed minor major link transfer", dma_test_devs[idx]->name);     \
+	}
 
-ZTEST(dma_m2m_link, test_dma_m2m_chan0_1_minor_link)
-{
-	zassert_true((test_task(1, 0) == TC_PASS));
-}
-
-ZTEST(dma_m2m_link, test_dma_m2m_chan0_1_minor_major_link)
-{
-	zassert_true((test_task(1, 1) == TC_PASS));
-}
+LISTIFY(DMA_TEST_DEV_COUNT, DEFINE_DMA_M2M_LINK_TESTS, ())

--- a/tests/drivers/dma/loop_transfer/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
@@ -4,4 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-tst_dma0: &edma3 {};
+/ {
+	zephyr,user {
+		dma-test-devs = <&edma3>, <&edma4>;
+	};
+};

--- a/tests/drivers/dma/loop_transfer/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/frdm_imxrt1186_mimxrt1186_cm7.overlay
@@ -4,4 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-tst_dma0: &edma3 {};
+/ {
+	zephyr,user {
+		dma-test-devs = <&edma3>, <&edma4>;
+	};
+};

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -3,6 +3,7 @@
 /*
  * Copyright (c) 2016 Intel Corporation.
  * Copyright (c) 2021 Linaro Limited.
+ * Copyright 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -32,7 +33,32 @@
 #define SLEEPTIME 250
 
 #define TRANSFER_LOOPS (4)
-#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
+
+#define DMA_TEST_NODE      DT_PATH(zephyr_user)
+#define DMA_TEST_DEVS_PROP dma_test_devs
+
+#if DT_NODE_HAS_PROP(DMA_TEST_NODE, DMA_TEST_DEVS_PROP)
+/* Boards list the DMA controllers to test in a zephyr,user dma-test-devs
+ * phandle list.
+ */
+#define DMA_TEST_DEV_COUNT DT_PROP_LEN(DMA_TEST_NODE, DMA_TEST_DEVS_PROP)
+#define DMA_TEST_DEV_GET(idx, _)                                                                   \
+	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DMA_TEST_NODE, DMA_TEST_DEVS_PROP, idx))
+#define DMA_TEST_DEV0_NODE DT_PHANDLE_BY_IDX(DMA_TEST_NODE, DMA_TEST_DEVS_PROP, 0)
+#else
+/* Legacy boards use tst_dmaN devicetree labels and
+ * CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS.
+ */
+#define DMA_TEST_DEV_COUNT CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS
+#define DMA_TEST_DEV_GET(idx, _) DEVICE_DT_GET(DT_NODELABEL(tst_dma##idx))
+#define DMA_TEST_DEV0_NODE DT_NODELABEL(tst_dma0)
+#endif
+
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DMA_TEST_DEV0_NODE, dma_buf_addr_alignment, 32)
+
+static const struct device *const dma_test_devs[] = {
+	LISTIFY(DMA_TEST_DEV_COUNT, DMA_TEST_DEV_GET, (,))
+};
 
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_LOOP_TRANSFER_SIZE];
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t
@@ -489,32 +515,25 @@ static int test_loop_repeated_start_stop(const struct device *dma)
 	return TC_PASS;
 }
 
-#define DMA_NAME(i, _)	tst_dma ## i
-#define DMA_LIST	LISTIFY(CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS, DMA_NAME, (,))
-
-#define TEST_LOOP(dma_name)                                                                        \
-	ZTEST(dma_m2m_loop, test_ ## dma_name ## _m2m_loop)                                        \
+/* Generate one set of test cases per DMA controller under test so a failure
+ * or skip on one controller does not prevent the remaining controllers from
+ * running.
+ */
+#define DEFINE_DMA_M2M_LOOP_TESTS(idx, _)                                                          \
+	ZTEST(dma_m2m_loop, test_dma##idx##_m2m_loop)                                              \
 	{                                                                                          \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
-		zassert_true((test_loop(dma) == TC_PASS));                                         \
+		zassert_true(test_loop(dma_test_devs[idx]) == TC_PASS, "%s failed loop transfer",  \
+			     dma_test_devs[idx]->name);                                            \
+	}                                                                                          \
+	ZTEST(dma_m2m_loop, test_dma##idx##_m2m_loop_suspend_resume)                               \
+	{                                                                                          \
+		zassert_true(test_loop_suspend_resume(dma_test_devs[idx]) == TC_PASS,              \
+			     "%s failed loop suspend resume", dma_test_devs[idx]->name);           \
+	}                                                                                          \
+	ZTEST(dma_m2m_loop, test_dma##idx##_m2m_loop_repeated_start_stop)                          \
+	{                                                                                          \
+		zassert_true(test_loop_repeated_start_stop(dma_test_devs[idx]) == TC_PASS,         \
+			     "%s failed repeated start stop", dma_test_devs[idx]->name);           \
 	}
 
-FOR_EACH(TEST_LOOP, (), DMA_LIST);
-
-#define TEST_LOOP_SUSPEND_RESUME(dma_name)                                                         \
-	ZTEST(dma_m2m_loop, test_ ## dma_name ## _m2m_loop_suspend_resume)                         \
-	{                                                                                          \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
-		zassert_true((test_loop_suspend_resume(dma) == TC_PASS));                          \
-	}
-
-FOR_EACH(TEST_LOOP_SUSPEND_RESUME, (), DMA_LIST);
-
-#define TEST_LOOP_REPEATED_START_STOP(dma_name)                                                    \
-	ZTEST(dma_m2m_loop, test_ ## dma_name ## _m2m_loop_repeated_start_stop)                    \
-	{                                                                                          \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
-		zassert_true((test_loop_repeated_start_stop(dma) == TC_PASS));                     \
-	}
-
-FOR_EACH(TEST_LOOP_REPEATED_START_STOP, (), DMA_LIST);
+LISTIFY(DMA_TEST_DEV_COUNT, DEFINE_DMA_M2M_LOOP_TESTS, ())


### PR DESCRIPTION
RT118x has two eDMA instances handled by the unified eDMA driver: `edma3` (per-channel interrupts) and `edma4` (shared channel interrupts via `channels-shared-irq-mask`). The DMA tests on `frdm_imxrt1186` only exercised `edma3`, so the driver's shared-IRQ dispatch path was never covered on this platform.

To enable covering more than one controller cleanly (per the review discussion), this PR first makes devicetree the single source of truth for which DMA controllers a test exercises, then uses that to add `edma4` on `frdm_imxrt1186`.

## Test rework

The three DMA test suites (`chan_blen_transfer`, `loop_transfer`, `chan_link_transfer`) selected controllers through hardcoded `tst_dmaN` devicetree labels, with per-instance cases gated/generated from `CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS`. That count can drift from the overlay, the `DMA_LOOP_TRANSFER_*` naming is confusing outside `loop_transfer`, and it does not scale past two instances.

Boards now list the controllers to test in a `zephyr,user` `dma-test-devs` phandle list, and every test case iterates over the resulting device array:

```dts
/ {
	zephyr,user {
		dma-test-devs = <&edma3>, <&edma4>;
	};
};
```

This is **backward compatible**: boards without the property keep working through the existing `tst_dmaN` labels and `CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS`, so **no existing board overlay is modified** (~370 overlays untouched). Per-instance case names collapse into one case per scenario covering all listed controllers, e.g. `test_tst_dma0_m2m_chan0_burst8` / `test_tst_dma1_m2m_chan0_burst8` become `test_dma_m2m_chan0_burst8`; coverage is unchanged.

## frdm_imxrt1186

The six `frdm_imxrt1186` overlays (cm33 + cm7, all three suites) list both eDMA instances via `dma-test-devs`, so each build exercises `edma3` and `edma4`.

## Validation

All three suites on FRDM-IMXRT1186 hardware, both cores, each case exercising `edma3` (`dma-controller@4000000`) and `edma4` (`dma-controller@2000000`):

| Suite | cm33 | cm7 |
|---|---|---|
| chan_blen_transfer | 4/4 PASS | 4/4 PASS |
| loop_transfer | 2 PASS / 1 SKIP | 2 PASS / 1 SKIP |
| chan_link_transfer | 3/3 PASS | 3/3 PASS |

(`loop_transfer` suspend/resume skips on both cores because the eDMA driver does not implement suspend.)

Legacy fallback (unchanged `tst_dmaN` path) build-tested on `mimxrt1170_evk//cm7` and `mimxrt1064_evk` (single instance) and `frdm_rw612` (`CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS=2` path).
