### PR TITLE
drivers: spi: nrf_spim[_rtio]: Explicitly point at spim data

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -260,7 +260,7 @@ static int driver_deinit(const struct device *dev)
 		)										\
 	};											\
 												\
-	SPI_NRFX_COMMON_DEFINE(inst, &CONCAT(data, inst));					\
+	SPI_NRFX_COMMON_DEFINE(inst, &CONCAT(data, inst).common.spim);				\
 												\
 	static const struct driver_config CONCAT(config, inst) = {				\
 		.common = SPI_NRFX_COMMON_CONFIG_INIT(						\

--- a/drivers/spi/spi_nrfx_spim_rtio.c
+++ b/drivers/spi/spi_nrfx_spim_rtio.c
@@ -245,7 +245,7 @@ static int driver_deinit(const struct device *dev)
 		.common = SPI_NRFX_COMMON_DATA_INIT(inst),					\
 	};											\
 												\
-	SPI_NRFX_COMMON_DEFINE(inst, &CONCAT(data, inst));					\
+	SPI_NRFX_COMMON_DEFINE(inst, &CONCAT(data, inst).common.spim);				\
 												\
 	SPI_RTIO_DEFINE(									\
 		CONCAT(spi_rtio_ctx, inst),							\


### PR DESCRIPTION
Let's avoid a build warning/error in the spim interrupt handler mapping, by being explicit about passing to it as parameter the address of `nrfx_spim_t spim` data instead of knowing implicitly that it is the first element of `struct driver_data`.

This avoid the following build warnings/errors:
`nrfx_spim.h:472:42: note: expected 'nrfx_spim_t *' but argument is of type 'struct driver_data *'`
`drivers/spi/spi_nrfx_spim_rtio.c:248:38: error: passing argument 1 of 'nrfx_spim_irq_handler' from incompatible pointer type`
`drivers/spi/spi_nrfx_spim.c:263:38: error: passing argument 1 of 'nrfx_spim_irq_handler' from incompatible pointer type`

Issue introduced in:
e4d61fc47218a653e1e1be3bc61086d26f2eba5d
6f2829ea0cc31a2705cc27ad92f9907fc603cc62

Can be reproduced building
tests/arch/arm/arm_irq_vector_table for thingy53/nrf5340/cpuapp (with and without  `CONFIG_SPI_RTIO=y`)