### PR TITLE
drivers: bluetooth: hci: add BSP wakeup support for NXP BT coex scenario

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.nxp
+++ b/drivers/bluetooth/hci/Kconfig.nxp
@@ -161,3 +161,51 @@ config BT_NXP_IW610
 endchoice # BT_NXP_MODULE
 
 endif # BT_H4_NXP_CTLR
+
+if (BT_NXP_NW612 && NXP_IW61X) || (BT_NXP_IW416 && NXP_IW416) || (BT_NXP_IW610 && NXP_IW610)
+
+config BT_NXP_CTRL_BSP_TRIGGER
+	bool "Trigger to wakeup BSP enabled NXP BT CPU"
+	default y
+	select UART_LINE_CTRL
+	help
+	  Enable Boot-Sleep-Patch (BSP) wakeup trigger for NXP BT
+	  IW416/NW612/IW610 firmware. In Wi-Fi + BT parallel FW download,
+	  if FW is BSP enabled, once Wi-Fi CPU has valid FW loaded (on CPU1),
+	  it puts BT CPU (CPU2) in sleep due to which BT bootloader stops
+	  sending out signature bytes for FW load. To wakeup BT CPU from
+	  sleep, BT HCI UART RTS line needs to be de-asserted (high to low)
+	  before host HCI driver begins FW load procedure on BT CPU.
+
+config BT_NXP_CTRL_BSP_RTS_PULSE_MS
+	int "RTS pulse duration in ms for BSP wakeup trigger"
+	range 1 50
+	default 10
+	depends on BT_NXP_CTRL_BSP_TRIGGER
+	help
+	  Duration in milliseconds for the RTS low pulse used to wake the
+	  BT CPU from boot-sleep state. This value is determined by the
+	  BT CPU bootloader's wakeup detection window.
+
+config BT_NXP_CTRL_HDR_SIG_INTERVAL
+	int "Interval for polling HDR signature on BSP enabled NXP BT CPU"
+	range 501 510
+	default 505
+	depends on BT_NXP_CTRL_BSP_TRIGGER
+	help
+	  Interval in milliseconds for polling HDR signature bytes from
+	  BSP enabled NXP BT CPU. The BT bootloader sends signature
+	  bytes at ~500ms intervals when awake. This value should be slightly
+	  larger than the signature period so that a timeout reliably indicates
+	  the BT CPU has entered BSP sleep.
+
+config BT_NXP_CTRL_BSP_WAIT_TIMEOUT
+	int "Timeout for waiting BT CPU to enter BSP sleep (ms)"
+	range 1000 20000
+	default 10000
+	depends on BT_NXP_CTRL_BSP_TRIGGER
+	help
+	  Maximum time in milliseconds to wait for BT CPU to enter
+	  boot-sleep-patch state before sending the wakeup trigger.
+
+endif # BT_NXP_NW612 || BT_NXP_IW416 || BT_NXP_IW610

--- a/drivers/bluetooth/hci/hci_nxp_setup.c
+++ b/drivers/bluetooth/hci/hci_nxp_setup.c
@@ -260,15 +260,13 @@ struct nxp_ctlr_fw_upload_state {
 
 static struct nxp_ctlr_fw_upload_state fw_upload;
 
-static int fw_upload_read_data(uint8_t *buffer, uint32_t len)
+static int fw_upload_read_data_tmo(uint8_t *buffer, uint32_t len, uint32_t timeout_ms)
 {
 	int err;
 
 	while (len > 0) {
-		err = k_sem_take(&fw_upload.rx.sem,
-				 K_MSEC(CONFIG_BT_H4_NXP_CTLR_WAIT_HDR_SIG_TIMEOUT));
+		err = k_sem_take(&fw_upload.rx.sem, K_MSEC(timeout_ms));
 		if (err < 0) {
-			LOG_ERR("Fail to read data");
 			return err;
 		}
 		*buffer = fw_upload.rx.buffer[fw_upload.rx.tail];
@@ -278,6 +276,12 @@ static int fw_upload_read_data(uint8_t *buffer, uint32_t len)
 		len--;
 	}
 	return 0;
+}
+
+static int fw_upload_read_data(uint8_t *buffer, uint32_t len)
+{
+	return fw_upload_read_data_tmo(buffer, len,
+					   CONFIG_BT_H4_NXP_CTLR_WAIT_HDR_SIG_TIMEOUT);
 }
 
 static void fw_upload_read_to_clear(void)
@@ -1106,6 +1110,47 @@ static int fw_uploading(const uint8_t *fw, uint32_t fw_length)
 	return -EINVAL;
 }
 
+#ifdef CONFIG_BT_NXP_CTRL_BSP_TRIGGER
+static int fw_upload_wake_bt_from_bootsleep(void)
+{
+	int err;
+	uint8_t c;
+	int64_t start = k_uptime_get();
+
+	while ((k_uptime_get() - start) < CONFIG_BT_NXP_CTRL_BSP_WAIT_TIMEOUT) {
+		err = fw_upload_read_data_tmo(&c, 1,
+					    CONFIG_BT_NXP_CTRL_HDR_SIG_INTERVAL);
+		if (err < 0) {
+			/* Timeout: no data received - BT CPU has entered BSP sleep.
+			 * Proceed to send wakeup trigger.
+			 */
+			goto send_bsp_trigger;
+		}
+
+		LOG_DBG("HDR SIG 0x%02X received, BT CPU still awake", c);
+	}
+
+	LOG_WRN("Timeout waiting for BT CPU to enter BSP sleep, sending trigger anyway");
+
+send_bsp_trigger:
+	err = uart_line_ctrl_set(uart_dev, UART_LINE_CTRL_RTS, 0);
+	if (err) {
+		LOG_ERR("Fail to set RTS low, err %d", err);
+		return err;
+	}
+
+	k_sleep(K_MSEC(CONFIG_BT_NXP_CTRL_BSP_RTS_PULSE_MS));
+
+	err = uart_line_ctrl_set(uart_dev, UART_LINE_CTRL_RTS, 1);
+	if (err) {
+		LOG_ERR("Fail to set RTS high, err %d", err);
+		return err;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_BT_NXP_CTRL_BSP_TRIGGER */
+
 static void bt_nxp_ctlr_uart_isr(const struct device *unused, void *user_data)
 {
 	int err = 0;
@@ -1239,6 +1284,16 @@ static int bt_nxp_ctlr_init(void)
 
 	uart_irq_rx_enable(uart_dev);
 
+#ifdef CONFIG_BT_NXP_CTRL_BSP_TRIGGER
+	/* Wait for BT CPU to enter boot-sleep-patch state, then send
+	 * RTS trigger to wake it up for FW download in coex scenario.
+	 */
+	err = fw_upload_wake_bt_from_bootsleep();
+	if (err) {
+		LOG_ERR("Fail to wake BT CPU from boot sleep");
+		return err;
+	}
+#endif /* CONFIG_BT_NXP_CTRL_BSP_TRIGGER */
 	err = fw_uploading(bt_fw_bin, bt_fw_bin_len);
 
 	if (err) {


### PR DESCRIPTION
In Wi-Fi + BT coex scenario on NXP hosted wireless SoCs (IW612/IW416/
    IW610), once Wi-Fi CPU loads valid firmware, it puts BT CPU into sleep
    via Boot-Sleep-Patch (BSP). The BT bootloader stops sending HDR
    signature bytes, blocking BT firmware download.

Add BSP wakeup detection and trigger mechanism:
    - Introduce fw_upload_read_data_tmo() to support custom timeout for
      UART read, refactoring fw_upload_read_data() as a wrapper.
    - Add fw_upload_wake_bt_from_bootsleep() which polls for HDR signature
      bytes with a configurable interval. Absence of signature within the
      polling window indicates BT CPU has entered BSP sleep.
    - Send an RTS low pulse to wake BT CPU before FW download begins.

New Kconfig options:
    - BT_NXP_CTRL_BSP_TRIGGER: enable/disable BSP wakeup feature
    - BT_NXP_CTRL_HDR_SIG_INTERVAL: single poll timeout (default 505ms)
    - BT_NXP_CTRL_BSP_WAIT_TIMEOUT: max total wait time (default 10s)
    - BT_NXP_CTRL_BSP_RTS_PULSE_MS: RTS pulse duration (default 5ms)