### PR TITLE
boards: mcx_nx4x_evk: enable ewm for mcx_n9xx_evk and mcx_n5xx_evk

### DIFF
--- a/boards/nxp/mcx_nx4x_evk/board.c
+++ b/boards/nxp/mcx_nx4x_evk/board.c
@@ -464,6 +464,12 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_Micfil);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ewm0))
+	CLOCK_SetupOsc32KClocking(kCLOCK_Osc32kToWake);
+	CLOCK_AttachClk(kXTAL32K2_to_EWM0);
+	CLOCK_EnableClock(kCLOCK_Ewm0);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 }

--- a/tests/drivers/watchdog/wdt_basic_reset_none/tests.yaml
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/tests.yaml
@@ -25,6 +25,8 @@ tests:
       - frdm_imxrt1186/mimxrt1186/cm7
       - frdm_mcxn947/mcxn947/cpu0
       - frdm_mcxn947/mcxn947/cpu1
+      - mcx_n9xx_evk/mcxn947/cpu0
+      - mcx_n5xx_evk/mcxn547/cpu0
       - frdm_mcxa577
     integration_platforms:
       - frdm_mcxw71


### PR DESCRIPTION
Support ewm for mcx_n9xx_evk and mcx_n5xx_evk
Verify using tests/drivers/watchdog/wdt_basic_reset_none