### PR TITLE
twister: samples: task_wdt: fix misleading "Timeout during flashing" failures

### DIFF
--- a/samples/subsys/task_wdt/README.rst
+++ b/samples/subsys/task_wdt/README.rst
@@ -32,8 +32,7 @@ For other boards just replace the board name.
 Sample output
 =============
 
-The following output is printed and continuously repeated (after each
-reset):
+The following output is printed:
 
 .. code-block:: console
 
@@ -47,3 +46,10 @@ reset):
    Main thread still alive...
    Task watchdog channel 1 callback, thread: control
    Resetting device...
+
+The intentional watchdog reset is demonstrated only once per power-on:
+after the device has been reset by the task watchdog, the control thread
+keeps feeding its watchdog channel so that the board stays alive. This
+avoids an endless reset loop, which could otherwise interfere with
+flashing the next application (e.g. in automated device testing). Power
+cycle the board to run the demonstration again.

--- a/samples/subsys/task_wdt/src/main.c
+++ b/samples/subsys/task_wdt/src/main.c
@@ -41,6 +41,16 @@
 #define WDT_NODE DT_INVALID_NODE
 #endif
 
+/*
+ * Reboot-persistent marker so that the intentional watchdog reset is only
+ * demonstrated once per power-on. Without it the sample reboots in an
+ * endless loop, which leaves the board continuously resetting after the
+ * sample has run. That state can make flashing the next application fail
+ * (e.g. during automated device testing).
+ */
+#define DEMO_DONE_MAGIC 0xFEED5AFE
+static __noinit uint32_t demo_done_marker;
+
 static void task_wdt_callback(int channel_id, void *user_data)
 {
 	printk("Task watchdog channel %d callback, thread: %s\n",
@@ -96,8 +106,15 @@ void control_thread(void)
 {
 	int task_wdt_id;
 	int count = 0;
+	bool demo_done = (demo_done_marker == DEMO_DONE_MAGIC);
 
 	printk("Control thread started.\n");
+
+	if (demo_done) {
+		printk("Task watchdog reset already demonstrated, "
+		       "control thread keeps running.\n");
+	}
+	demo_done_marker = DEMO_DONE_MAGIC;
 
 	/*
 	 * Add a new task watchdog channel with custom callback function and
@@ -107,7 +124,7 @@ void control_thread(void)
 		(void *)k_current_get());
 
 	while (true) {
-		if (count == 50) {
+		if (!demo_done && count == 50) {
 			printk("Control thread getting stuck...\n");
 			k_sleep(K_FOREVER);
 		}

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -204,7 +204,12 @@ class Handler:
             elif failure_type == self.FailureType.TIMEOUT:
                 self.instance.reason = "Timeout"
             elif failure_type == self.FailureType.FLASH:
-                self.instance.reason = "Timeout during flashing"
+                # The flash step already recorded a specific status and reason
+                # (e.g. "Device issue (Flash error?)" or "Device issue (Flash
+                # timeout)"); keep them instead of overwriting them with a
+                # misleading generic "Timeout during flashing".
+                self.instance.status = TwisterStatus.ERROR
+                self.instance.reason = self.instance.reason or "Flash failure"
 
             # In case none of the above applies, we set a generic error
             if not self.instance.reason and self.returncode != 0:

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -944,28 +944,36 @@ def test_devicehandler_create_command(
 
 
 TESTDATA_14 = [
-    ('success', Handler.FailureType.NONE, 'success', None, False),
-    (TwisterStatus.FAIL, Handler.FailureType.NONE, TwisterStatus.FAIL,
+    ('success', Handler.FailureType.NONE, None, 'success', None, False),
+    (TwisterStatus.FAIL, Handler.FailureType.NONE, None, TwisterStatus.FAIL,
         "foobar", True),
-    (TwisterStatus.ERROR, Handler.FailureType.NONE, TwisterStatus.ERROR, 'foobar', True),
-    (TwisterStatus.NONE, Handler.FailureType.NONE, TwisterStatus.FAIL, 'Unknown Error', True),
+    (TwisterStatus.ERROR, Handler.FailureType.NONE, None, TwisterStatus.ERROR, 'foobar', True),
+    (TwisterStatus.NONE, Handler.FailureType.NONE, None, TwisterStatus.FAIL,
+        'Unknown Error', True),
+    (TwisterStatus.NONE, Handler.FailureType.FLASH, 'Device issue (Flash timeout)',
+        TwisterStatus.ERROR, 'Device issue (Flash timeout)', True),
+    (TwisterStatus.NONE, Handler.FailureType.FLASH, None, TwisterStatus.ERROR,
+        'Flash failure', True),
 ]
 
 @pytest.mark.parametrize(
-    'harness_status, failure_type,' \
+    'harness_status, failure_type, initial_reason,' \
     ' expected_status, expected_reason, do_add_missing',
     TESTDATA_14,
-    ids=['custom success', 'failed', 'error', 'no status']
+    ids=['custom success', 'failed', 'error', 'no status',
+         'flash error reason kept', 'flash failure fallback']
 )
 def test_devicehandler_update_instance_info(
         mocked_instance,
         harness_status,
         failure_type,
+        initial_reason,
         expected_status,
         expected_reason,
         do_add_missing
         ):
     handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
+    handler.instance.reason = initial_reason
     missing_mock = mock.Mock()
     handler.instance.add_missing_case_status = missing_mock
     mocked_harness = mock.Mock(status=harness_status, reason="foobar")


### PR DESCRIPTION
## Summary

Fixes the two layers behind the `sample.zbus.priority_boost` failure reported in #105705 (`FAILED: Timeout during flashing` on `mimxrt1170_evk@B/mimxrt1176/cm7` while the console still shows *task_wdt* output):

1. **`scripts: twister: handlers: preserve flash failure reason`**
   When the flash command fails, `DeviceHandler` records an accurate status (`ERROR`) and reason (`Device issue (Flash error?)` / `Device issue (Flash timeout)` / `Device issue (Flash error)`). `_update_instance_info()` then overwrote both with `FAIL` + a generic `"Timeout during flashing"`, so **every** flash-stage failure — command error, non-zero exit, or a real timeout — was reported as a flashing timeout and counted as a test failure instead of a device/environment error. Keep the specific status and reason recorded at flash time; fall back to `"Flash failure"` only when none was set.

2. **`samples: task_wdt: demonstrate watchdog reset once per power-on`**
   The task_wdt sample intentionally stops feeding the control-thread channel and lets the task watchdog reset the device — on *every* boot, leaving the board rebooting in an endless ~4.6 s loop after the sample has run. In device testing, the next test's `west flash` then races the reset storm and can hang/time out; the serial monitor meanwhile captures the still-running task_wdt output. That is exactly the log signature in #105705. Record a magic word in `__noinit` RAM so the intentional reset is demonstrated only once per power-on; after the watchdog-triggered reboot the control thread keeps feeding and the board stays alive. First-boot output is unchanged, so the sample's console-harness patterns still match (the final pattern — the second boot banner — still appears).

## Validation

- `scripts/tests/twister/test_handlers.py`: extended `TESTDATA_14` with two `FailureType.FLASH` cases (specific reason kept / fallback); `pytest -k update_instance_info` → 21 passed.
- On-hardware (mimxrt1170_evk@B/mimxrt1176/cm7): a failing flash in `--device-testing` now reports `ERROR Device issue (Flash error?)` instead of `FAILED Timeout during flashing`.
- task_wdt change verified on the same board: first boot runs the unchanged demo sequence through the real `sys_reboot(SYS_REBOOT_COLD)`; the `__noinit` marker (placed in the `noinit` section, verified with objdump) survives the reset; the second boot prints the new notice and keeps feeding — no more reset loop.

## Notes for reviewers

- **Retry semantics**: flash failures now surface as `ERROR` (as the flash-time code always intended) rather than `FAIL`. `--retry-failed` alone retries only failures; CI setups that want device errors retried need `--retry-build-errors` as well.
- **`__noinit` portability**: on platforms where noinit RAM does not survive the watchdog reset, the marker is lost and the sample simply demonstrates again — i.e. the previous behavior, no regression.

Fixes #105705
