### PR TITLE
net: mqtt_sn: stop passing client struct to transport callbacks

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -896,6 +896,12 @@ Networking
   resolution should migrate to mDNS (:kconfig:option:`CONFIG_MDNS_RESOLVER` /
   :kconfig:option:`CONFIG_MDNS_RESPONDER`).
 
+* The following MQTT-SN transport functions now take an :c:struct:`mqtt_sn_transport`
+  instead of an :c:struct:`mqtt_sn_client`:
+
+  * :c:member:`mqtt_sn_transport.recvfrom`
+  * :c:member:`mqtt_sn_transport.poll`
+  * :c:member:`mqtt_sn_transport.sendto`
 
 Ethernet
 ========

--- a/include/zephyr/net/mqtt_sn.h
+++ b/include/zephyr/net/mqtt_sn.h
@@ -193,15 +193,15 @@ struct mqtt_sn_transport {
 	 * @return ENOERR on connection+transmission success, Negative values
 	 *		signal errors.
 	 */
-	int (*sendto)(struct mqtt_sn_client *client, void *buf, size_t sz, const void *dest_addr,
-		      size_t addrlen);
+	int (*sendto)(struct mqtt_sn_transport *transport, void *buf, size_t sz,
+		      const void *dest_addr, size_t addrlen);
 
 	/**
 	 * @brief Will be called by the library when it wants to receive a message.
 	 *
 	 * Implementations should follow recvfrom conventions.
 	 */
-	ssize_t (*recvfrom)(struct mqtt_sn_client *client, void *rx_buf, size_t rx_len,
+	ssize_t (*recvfrom)(struct mqtt_sn_transport *transport, void *rx_buf, size_t rx_len,
 			    void *src_addr, size_t *addrlen);
 
 	/**
@@ -214,7 +214,7 @@ struct mqtt_sn_transport {
 	 * @return Positive number if data is available, or zero if there is none.
 	 * Negative values signal errors.
 	 */
-	int (*poll)(struct mqtt_sn_client *client);
+	int (*poll)(struct mqtt_sn_transport *transport);
 };
 
 #ifdef CONFIG_MQTT_SN_TRANSPORT_UDP

--- a/subsys/net/lib/mqtt_sn/mqtt_sn.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn.c
@@ -127,8 +127,8 @@ static int encode_and_send(struct mqtt_sn_client *client, struct mqtt_sn_param *
 	}
 
 	if (broadcast_radius) {
-		err = client->transport->sendto(client, client->tx.data, client->tx.len, NULL,
-						broadcast_radius);
+		err = client->transport->sendto(client->transport, client->tx.data, client->tx.len,
+						NULL, broadcast_radius);
 	} else {
 		struct mqtt_sn_gateway *gw;
 
@@ -138,8 +138,8 @@ static int encode_and_send(struct mqtt_sn_client *client, struct mqtt_sn_param *
 			err = -ENXIO;
 			goto end;
 		}
-		err = client->transport->sendto(client, client->tx.data, client->tx.len, gw->addr,
-						gw->addr_len);
+		err = client->transport->sendto(client->transport, client->tx.data, client->tx.len,
+						gw->addr, gw->addr_len);
 	}
 
 end:
@@ -1894,7 +1894,7 @@ int mqtt_sn_input(struct mqtt_sn_client *client)
 	}
 
 	if (client->transport->poll) {
-		next_frame_size = client->transport->poll(client);
+		next_frame_size = client->transport->poll(client->transport);
 		if (next_frame_size <= 0) {
 			return next_frame_size;
 		}
@@ -1902,8 +1902,9 @@ int mqtt_sn_input(struct mqtt_sn_client *client)
 
 	net_buf_simple_reset(&client->rx);
 
-	next_frame_size = client->transport->recvfrom(client, client->rx.data, client->rx.size,
-						      (void *)rx_addr.data, &rx_addr.size);
+	next_frame_size =
+		client->transport->recvfrom(client->transport, client->rx.data, client->rx.size,
+					    (void *)rx_addr.data, &rx_addr.size);
 	if (next_frame_size <= 0) {
 		return next_frame_size;
 	}

--- a/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
@@ -210,10 +210,10 @@ static void tp_udp_deinit(struct mqtt_sn_transport *transport)
 	}
 }
 
-static int tp_udp_sendto(struct mqtt_sn_client *client, void *buf, size_t sz, const void *dest_addr,
-			 size_t addrlen)
+static int tp_udp_sendto(struct mqtt_sn_transport *transport, void *buf, size_t sz,
+			 const void *dest_addr, size_t addrlen)
 {
-	struct mqtt_sn_transport_udp *udp = UDP_TRANSPORT(client->transport);
+	struct mqtt_sn_transport_udp *udp = UDP_TRANSPORT(transport);
 	int rc;
 	int ttl;
 	net_socklen_t ttl_len;
@@ -252,10 +252,10 @@ static int tp_udp_sendto(struct mqtt_sn_client *client, void *buf, size_t sz, co
 	return 0;
 }
 
-static ssize_t tp_udp_recvfrom(struct mqtt_sn_client *client, void *buffer, size_t length,
+static ssize_t tp_udp_recvfrom(struct mqtt_sn_transport *transport, void *buffer, size_t length,
 			       void *src_addr, size_t *addrlen)
 {
-	struct mqtt_sn_transport_udp *udp = UDP_TRANSPORT(client->transport);
+	struct mqtt_sn_transport_udp *udp = UDP_TRANSPORT(transport);
 	ssize_t ret;
 	int errno_backup;
 	net_socklen_t addrlen_local = *addrlen;
@@ -274,9 +274,9 @@ static ssize_t tp_udp_recvfrom(struct mqtt_sn_client *client, void *buffer, size
 	return ret;
 }
 
-static int tp_udp_poll(struct mqtt_sn_client *client)
+static int tp_udp_poll(struct mqtt_sn_transport *transport)
 {
-	struct mqtt_sn_transport_udp *udp = UDP_TRANSPORT(client->transport);
+	struct mqtt_sn_transport_udp *udp = UDP_TRANSPORT(transport);
 	int rc;
 
 	struct zsock_pollfd pollfd = {

--- a/tests/net/lib/mqtt_sn_client/src/mqtt_sn_client.c
+++ b/tests/net/lib/mqtt_sn_client/src/mqtt_sn_client.c
@@ -28,7 +28,7 @@ static struct msg_send_data {
 	int ret;
 	const void *dest_addr;
 	size_t addrlen;
-	struct mqtt_sn_client *client;
+	struct mqtt_sn_transport *transport;
 } msg_send_data;
 
 struct k_sem mqtt_sn_tx_sem;
@@ -40,8 +40,8 @@ int mqtt_sn_data_cmp(struct mqtt_sn_data data1, struct mqtt_sn_data data2)
 	return data1.size == data2.size && strncmp(data1.data, data2.data, data1.size);
 }
 
-static int msg_sendto(struct mqtt_sn_client *client, void *buf, size_t sz, const void *dest_addr,
-		      size_t addrlen)
+static int msg_sendto(struct mqtt_sn_transport *transport, void *buf, size_t sz,
+		      const void *dest_addr, size_t addrlen)
 {
 	zassert_not_null(buf);
 	zassert_true(sz <= sizeof(msg_send_data.msg_data),
@@ -49,7 +49,7 @@ static int msg_sendto(struct mqtt_sn_client *client, void *buf, size_t sz, const
 
 	msg_send_data.called++;
 	msg_send_data.msg_sz = sz;
-	msg_send_data.client = client;
+	msg_send_data.transport = transport;
 	msg_send_data.dest_addr = dest_addr;
 	msg_send_data.addrlen = addrlen;
 
@@ -133,7 +133,7 @@ static struct {
 	size_t addrlen;
 } recvfrom_data;
 
-static ssize_t tp_recvfrom(struct mqtt_sn_client *client, void *buffer, size_t length,
+static ssize_t tp_recvfrom(struct mqtt_sn_transport *transport, void *buffer, size_t length,
 			   void *src_addr, size_t *addrlen)
 {
 	if (recvfrom_data.data && recvfrom_data.sz > 0 && length >= recvfrom_data.sz) {
@@ -148,7 +148,7 @@ static ssize_t tp_recvfrom(struct mqtt_sn_client *client, void *buffer, size_t l
 	return recvfrom_data.sz;
 }
 
-int tp_poll(struct mqtt_sn_client *client)
+int tp_poll(struct mqtt_sn_transport *transport)
 {
 	return recvfrom_data.sz;
 }


### PR DESCRIPTION
- This seems like a break of abstractions.
- The UDP transport doesn't need access to it.
- This makes transport tests easier.

Originally, this was part of [a draft PR](https://github.com/zephyrproject-rtos/zephyr/pull/111848), but I think this makes sense by itself.