### PR TITLE
include: net_buf: Change size and len to uint32_t

### DIFF
--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -95,10 +95,10 @@ struct net_buf_simple {
 	 *
 	 * To determine the max length, use net_buf_simple_max_len(), not #size!
 	 */
-	uint16_t len;
+	uint32_t len;
 
 	/** Amount of data that net_buf_simple#__buf can store. */
-	uint16_t size;
+	uint32_t size;
 
 	/** Start of the data storage. Not to be accessed directly
 	 *  (the data pointer should be used instead).
@@ -1104,10 +1104,10 @@ struct net_buf {
 			uint8_t *data;
 
 			/** Length of the data behind the data pointer. */
-			uint16_t len;
+			uint32_t len;
 
 			/** Amount of data that this buffer can store. */
-			uint16_t size;
+			uint32_t size;
 
 			/** Start of the data storage. Not to be accessed
 			 *  directly (the data pointer should be used

--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -21,7 +21,7 @@ static inline uint16_t dns_strlen(const char *str)
 	return (uint16_t)strlen(str);
 }
 
-int dns_msg_pack_qname(uint16_t *len, uint8_t *buf, uint16_t size,
+int dns_msg_pack_qname(uint32_t *len, uint8_t *buf, uint32_t size,
 		       const char *domain_name)
 {
 	uint16_t dn_size;
@@ -286,12 +286,12 @@ static int dns_msg_pack_query_header(uint8_t *buf, uint16_t size, uint16_t id)
 	return 0;
 }
 
-int dns_msg_pack_query(uint8_t *buf, uint16_t *len, uint16_t size,
-		       uint8_t *qname, uint16_t qname_len, uint16_t id,
+int dns_msg_pack_query(uint8_t *buf, uint32_t *len, uint32_t size,
+		       uint8_t *qname, uint32_t qname_len, uint16_t id,
 		       enum dns_rr_type qtype)
 {
 	uint16_t msg_size;
-	uint16_t offset;
+	uint32_t offset;
 	int rc;
 
 	msg_size = DNS_MSG_HEADER_SIZE + DNS_QTYPE_LEN + DNS_QCLASS_LEN;
@@ -384,7 +384,7 @@ int dns_unpack_response_query(struct dns_msg_t *dns_msg)
 	return 0;
 }
 
-int dns_copy_qname(uint8_t *buf, uint16_t *len, uint16_t size,
+int dns_copy_qname(uint8_t *buf, uint32_t *len, uint32_t size,
 		   struct dns_msg_t *dns_msg, uint16_t pos)
 {
 	SYS_BITARRAY_DEFINE(visited, DNS_RESOLVER_MAX_BUF_SIZE);

--- a/subsys/net/lib/dns/dns_pack.h
+++ b/subsys/net/lib/dns/dns_pack.h
@@ -347,13 +347,13 @@ static inline int dns_unpack_srv_port(const uint8_t *srv)
  *
  * @param len Bytes used by this function
  * @param buf Buffer
- * @param sizeof Buffer's size
+ * @param size Buffer's size
  * @param domain_name Something like www.example.com
  * @retval 0 on success
  * @retval -ENOMEM if there is no enough space to store the resultant QNAME
  * @retval -EINVAL if an invalid parameter was passed as an argument
  */
-int dns_msg_pack_qname(uint16_t *len, uint8_t *buf, uint16_t size,
+int dns_msg_pack_qname(uint32_t *len, uint8_t *buf, uint32_t size,
 		       const char *domain_name);
 
 /**
@@ -403,8 +403,8 @@ int dns_unpack_response_header(struct dns_msg_t *msg, int src_id);
  * @retval On error, a negative value is returned.
  *         See: dns_msg_pack_query_header and  dns_msg_pack_qname.
  */
-int dns_msg_pack_query(uint8_t *buf, uint16_t *len, uint16_t size,
-		       uint8_t *qname, uint16_t qname_len, uint16_t id,
+int dns_msg_pack_query(uint8_t *buf, uint32_t *len, uint32_t size,
+		       uint8_t *qname, uint32_t qname_len, uint16_t id,
 		       enum dns_rr_type qtype);
 
 /**
@@ -440,7 +440,7 @@ int dns_unpack_response_query(struct dns_msg_t *dns_msg);
  * @retval -EINVAL if an invalid parameter was passed as an argument
  * @retval -ENOMEM if the label's size is corrupted
  */
-int dns_copy_qname(uint8_t *buf, uint16_t *len, uint16_t size,
+int dns_copy_qname(uint8_t *buf, uint32_t *len, uint32_t size,
 		   struct dns_msg_t *dns_msg, uint16_t pos);
 
 /**

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1599,7 +1599,8 @@ static int dns_write(struct dns_resolve_context *ctx,
 	enum dns_query_type query_type;
 	struct net_sockaddr *server;
 	int server_addr_len;
-	uint16_t dns_id, len;
+	uint16_t dns_id;
+	uint32_t len;
 	int ret, sock, family;
 	char *query_name;
 
@@ -1611,7 +1612,7 @@ static int dns_write(struct dns_resolve_context *ctx,
 
 	len = buf_len;
 
-	ret = dns_msg_pack_query(buf, &len, (uint16_t)max_len,
+	ret = dns_msg_pack_query(buf, &len, max_len,
 				 dns_qname->data, dns_qname->len, dns_id,
 				 (enum dns_rr_type)query_type);
 	if (ret < 0) {
@@ -1788,7 +1789,7 @@ int dns_resolve_cancel_with_name(struct dns_resolve_context *ctx,
 
 	if (query_name) {
 		struct net_buf *buf;
-		uint16_t len;
+		uint32_t len;
 		int ret;
 
 		/* Use net_buf as a temporary buffer to store the packed

--- a/tests/net/lib/dns_packet/src/main.c
+++ b/tests/net/lib/dns_packet/src/main.c
@@ -15,10 +15,10 @@
 #define DNS_HEADER_SIZE	12
 
 static uint8_t dns_buf[MAX_BUF_SIZE];
-static uint16_t dns_buf_len;
+static uint32_t dns_buf_len;
 
 static uint8_t qname[MAX_BUF_SIZE];
-static uint16_t qname_len;
+static uint32_t qname_len;
 
 static struct dns_resolve_context dns_ctx;
 
@@ -51,7 +51,7 @@ static uint8_t query_mdns[] = {
 static uint16_t tid1 = 0xda0f;
 
 static int eval_query(const char *dname, uint16_t tid, enum dns_rr_type type,
-		      uint8_t *expected, uint16_t expected_len)
+		      uint8_t *expected, uint32_t expected_len)
 {
 	uint8_t *question;
 	int rc;


### PR DESCRIPTION
Change the size and len fields of struct net_buf_simple and struct net_buf from uint16_t to uint32_t. The previous 16-bit fields limited buffer sizes to 64KB, which is insufficient for subsystems that handle large data payloads such as video frames, audio streams, or bulk data transfers.

With uint32_t, buffers can now address up to 4GB, enabling net_buf to be used as the underlying data transport for multimedia and other data-intensive workloads without requiring custom buffer management.