### PR TITLE
drivers: timer: cortex_m_systick: fix 32-bit overflow in LPM tick accounting

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -580,7 +580,13 @@ void sys_clock_idle_exit(void)
 	if (timeout_idle) {
 		k_spinlock_key_t key = sys_clock_lock();
 		cycle_t systick_diff, missed_cycles;
-		uint32_t dcycles, dticks;
+		/* dcycles must be 64-bit: after a long low-power sleep the unannounced
+		 * cycle count (cycle_count + elapsed() - announced_cycles) exceeds 2^32
+		 * beyond ~134 s at 32 MHz. Truncating to uint32_t announces far too few
+		 * ticks, so k_sleep() never completes and the MCU appears to never wake.
+		 */
+		uint64_t dcycles;
+		uint32_t dticks;
 		uint64_t systick_us, idle_timer_us;
 
 #if !defined(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)
@@ -625,7 +631,12 @@ void sys_clock_idle_exit(void)
 		/* Announce the passed ticks to the kernel */
 		dcycles = cycle_count + elapsed(NULL) - announced_cycles;
 		dticks = dcycles / CYC_PER_TICK;
-		announced_cycles += dticks * CYC_PER_TICK;
+		/* Cast to cycle_t: dticks * CYC_PER_TICK is otherwise evaluated in
+		 * 32-bit and truncates for a single sleep past ~134 s at 32 MHz
+		 * (dticks > 2^32 / CYC_PER_TICK). That under-counts announced_cycles,
+		 * so the next sleep's dcycles is too large and kernel time runs fast.
+		 */
+		announced_cycles += (cycle_t)dticks * CYC_PER_TICK;
 		last_elapsed = 0U;
 		timeout_idle = false;
 		sys_clock_announce_locked(dticks, key);


### PR DESCRIPTION
When the SysTick LPM counter-companion (CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER) is used to keep time across a low-power state, sys_clock_idle_exit() reconstructs the elapsed time and announces it to the kernel. Two intermediate values were computed in 32 bits, which overflows once a single low-power sleep exceeds 2^32 core cycles (~134 s at 32 MHz):

- dcycles (the unannounced cycle delta) was uint32_t. Truncation makes the announced tick count far too small, so k_sleep() never completes and the MCU appears to never wake from STOP.

- announced_cycles += dticks * CYC_PER_TICK evaluated the product in 32 bits before adding to the 64-bit accumulator. Truncation under-counts announced_cycles by a multiple of 2^32, so each subsequent sleep's dcycles is too large and kernel time runs progressively fast.

Widen dcycles to 64 bits and cast the multiply to cycle_t so both operations are performed in 64 bits. Only affects builds with a 64-bit cycle counter (CONFIG_CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER) using the counter companion; verified on STM32L151 (32 MHz core, LSE RTC companion) with 5- and 9-minute STOP intervals.