### PR TITLE
boards: silabs: xg24: enable netif:openthread for supported boards

### DIFF
--- a/boards/silabs/radio_boards/xg24/xg24_rb4186c.yaml
+++ b/boards/silabs/radio_boards/xg24/xg24_rb4186c.yaml
@@ -20,4 +20,5 @@ supported:
   - spi
   - uart
   - watchdog
+  - netif:openthread
 vendor: silabs

--- a/boards/silabs/radio_boards/xg24/xg24_rb4187c.yaml
+++ b/boards/silabs/radio_boards/xg24/xg24_rb4187c.yaml
@@ -21,4 +21,5 @@ supported:
   - spi
   - uart
   - watchdog
+  - netif:openthread
 vendor: silabs

--- a/modules/hal_silabs/simplicity_sdk/src/blob_stubs.c
+++ b/modules/hal_silabs/simplicity_sdk/src/blob_stubs.c
@@ -11,7 +11,15 @@
 
 #include <sl_rail.h>
 #include <sl_status.h>
-#include <sl_rail.h>
+
+#if defined(CONFIG_IEEE802154_SILABS_EFR32)
+#include <sl_rail_ieee802154.h>
+#endif
+
+const uint16_t sl_rail_builtin_rx_packet_queue_entries;
+const uint16_t sl_rail_builtin_rx_fifo_bytes;
+sl_rail_packet_queue_entry_t *const sl_rail_builtin_rx_packet_queue_ptr;
+sl_rail_fifo_buffer_align_t *const sl_rail_builtin_rx_fifo_ptr;
 
 sl_rail_status_t sl_rail_verify_tx_power_conversion(const struct sl_rail_tx_power_table_config *cfg)
 {
@@ -22,13 +30,163 @@ void sl_rail_enable_pa_cal(sl_rail_handle_t rail_handle, bool enable)
 {
 }
 
+sl_rail_status_t sl_rail_set_tx_pa_voltage(sl_rail_handle_t rail_handle, uint16_t voltage_mv)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_set_tx_pa_ramp_time(sl_rail_handle_t rail_handle, uint16_t ramp_time_us)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
 sl_rail_status_t sl_rail_config_sleep(sl_rail_handle_t handle,
 				      const sl_rail_timer_sync_config_t *config)
 {
 	return SL_RAIL_STATUS_NO_ERROR;
 }
 
+sl_rail_status_t sl_rail_config_events(sl_rail_handle_t rail_handle, sl_rail_events_t mask,
+				       sl_rail_events_t events)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_config_rx_options(sl_rail_handle_t rail_handle,
+					   sl_rail_rx_options_t rx_options_mask,
+					   sl_rail_rx_options_t rx_options)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_config_cal(sl_rail_handle_t rail_handle,
+				    sl_rail_cal_mask_t cal_enable_mask)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+const sl_rail_config_t *sl_rail_get_config(sl_rail_handle_t rail_handle)
+{
+	return NULL;
+}
+
+sl_rail_status_t sl_rail_init(sl_rail_handle_t *p_rail_handle,
+			      const sl_rail_config_t *p_rail_config,
+			      sl_rail_init_complete_callback_t init_complete_callback)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
 sl_rail_status_t sl_rail_init_power_manager(void)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_set_tx_power_dbm(sl_rail_handle_t rail_handle,
+					  sl_rail_tx_power_t power_ddbm)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_set_pti_protocol(sl_rail_handle_t rail_handle,
+					  sl_rail_pti_protocol_t protocol)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+uint32_t sl_rail_get_symbol_rate(sl_rail_handle_t rail_handle)
+{
+	return 0;
+}
+
+int16_t sl_rail_get_rssi(sl_rail_handle_t rail_handle, sl_rail_time_t wait_timeout_us)
+{
+	return 0;
+}
+
+sl_rail_radio_state_t sl_rail_get_radio_state(sl_rail_handle_t rail_handle)
+{
+	return SL_RAIL_RF_STATE_INACTIVE;
+}
+
+sl_rail_status_t sl_rail_start_tx(sl_rail_handle_t rail_handle, uint16_t channel,
+				  sl_rail_tx_options_t tx_options,
+				  const sl_rail_scheduler_info_t *p_scheduler_info)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_start_rx(sl_rail_handle_t rail_handle, uint16_t channel,
+				  const sl_rail_scheduler_info_t *p_scheduler_info)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+uint16_t sl_rail_write_tx_fifo(sl_rail_handle_t rail_handle, const uint8_t *p_data,
+			       uint16_t write_bytes, bool reset)
+{
+	return 0;
+}
+
+sl_rail_status_t sl_rail_start_cca_csma_tx(sl_rail_handle_t rail_handle, uint16_t channel,
+					   sl_rail_tx_options_t tx_options,
+					   const sl_rail_csma_config_t *p_csma_config,
+					   const sl_rail_scheduler_info_t *p_scheduler_info)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_rx_packet_handle_t sl_rail_get_rx_packet_info(sl_rail_handle_t rail_handle,
+						      sl_rail_rx_packet_handle_t packet_handle,
+						      sl_rail_rx_packet_info_t *p_packet_info)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_get_rx_time_sync_word_end(sl_rail_handle_t rail_handle,
+						   sl_rail_rx_packet_details_t *p_packet_details)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_get_rx_incoming_packet_info(sl_rail_handle_t rail_handle,
+						     sl_rail_rx_packet_info_t *p_packet_info)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_get_rx_packet_details(sl_rail_handle_t rail_handle,
+					       sl_rail_rx_packet_handle_t packet_handle,
+					       sl_rail_rx_packet_details_t *p_packet_details)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_copy_rx_packet(sl_rail_handle_t rail_handle, uint8_t *p_dest,
+					const sl_rail_rx_packet_info_t *p_packet_info)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_get_scheduler_status(sl_rail_handle_t rail_handle,
+					      sl_rail_scheduler_status_t *p_scheduler_status,
+					      sl_rail_status_t *p_rail_status)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_calibrate(sl_rail_handle_t rail_handle, sl_rail_cal_values_t *p_cal_values,
+				   sl_rail_cal_mask_t cal_force_mask)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_idle(sl_rail_handle_t rail_handle, sl_rail_idle_mode_t mode, bool wait)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_yield_radio(sl_rail_handle_t rail_handle)
 {
 	return SL_RAIL_STATUS_NO_ERROR;
 }
@@ -111,12 +269,9 @@ sl_rail_time_t sl_rail_get_time(sl_rail_handle_t rail_handle)
 	return 0U;
 }
 
-sl_rail_status_t sl_rail_set_multi_timer(sl_rail_handle_t rail_handle,
-					 sl_rail_multi_timer_t *timer,
-					 sl_rail_time_t expiration_time,
-					 sl_rail_time_mode_t mode,
-					 sl_rail_multi_timer_callback_t callback,
-					 void *user_data)
+sl_rail_status_t sl_rail_set_multi_timer(sl_rail_handle_t rail_handle, sl_rail_multi_timer_t *timer,
+					 sl_rail_time_t expiration_time, sl_rail_time_mode_t mode,
+					 sl_rail_multi_timer_callback_t callback, void *user_data)
 {
 	return SL_RAIL_STATUS_NO_ERROR;
 }
@@ -127,15 +282,109 @@ sl_rail_status_t sl_rail_cancel_multi_timer(sl_rail_handle_t rail_handle,
 	return SL_RAIL_STATUS_NO_ERROR;
 }
 
-bool sl_rail_is_multi_timer_running(sl_rail_handle_t rail_handle,
-				    sl_rail_multi_timer_t *timer)
+bool sl_rail_is_multi_timer_running(sl_rail_handle_t rail_handle, sl_rail_multi_timer_t *timer)
 {
 	return false;
+}
+
+sl_rail_status_t sl_rail_config_multi_timer(sl_rail_handle_t rail_handle, bool enable)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
 }
 
 #if defined(CONFIG_IEEE802154_SILABS_EFR32)
 void sl_openthread_init(void)
 {
 	/* Stub for the OpenThread PAL blob; declared in ieee802154_silabs_efr32.h. */
+}
+
+sl_rail_status_t sl_rail_ieee802154_enable_early_frame_pending(sl_rail_handle_t rail_handle,
+							       bool enable)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_ieee802154_enable_data_frame_pending(sl_rail_handle_t rail_handle,
+							      bool enable)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_ieee802154_init(sl_rail_handle_t rail_handle,
+					 const sl_rail_ieee802154_config_t *p_config)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_ieee802154_config_2p4_ghz_radio(sl_rail_handle_t rail_handle)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_ieee802154_config_e_options(sl_rail_handle_t rail_handle,
+						     sl_rail_ieee802154_e_options_t mask,
+						     sl_rail_ieee802154_e_options_t options)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t
+sl_rail_ieee802154_set_rx_to_enh_ack_tx(sl_rail_handle_t rail_handle,
+					sl_rail_transition_time_t *p_rx_to_enh_ack_tx)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_ieee802154_config_cca_mode(sl_rail_handle_t rail_handle,
+						    sl_rail_ieee802154_cca_mode_t cca_mode)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_ieee802154_set_promiscuous_mode(sl_rail_handle_t rail_handle, bool enable)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_ieee802154_set_pan_coordinator(sl_rail_handle_t rail_handle,
+							bool is_pan_coordinator)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_ieee802154_set_pan_id(sl_rail_handle_t rail_handle, uint16_t pan_id,
+					       uint8_t index)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_ieee802154_set_short_address(sl_rail_handle_t rail_handle,
+						      uint16_t short_addr, uint8_t index)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_ieee802154_set_long_address(sl_rail_handle_t rail_handle,
+						     const uint8_t *p_long_addr, uint8_t index)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_ieee802154_write_enh_ack(sl_rail_handle_t rail_handle,
+						  const uint8_t *p_ack_data,
+						  uint16_t ack_data_bytes)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_ieee802154_get_address(sl_rail_handle_t rail_handle,
+						sl_rail_ieee802154_address_t *p_address)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
+}
+
+sl_rail_status_t sl_rail_ieee802154_toggle_frame_pending(sl_rail_handle_t rail_handle)
+{
+	return SL_RAIL_STATUS_NO_ERROR;
 }
 #endif


### PR DESCRIPTION
This allows compiling the build tests in
samples/net/openthread/shell/tests.yaml. Before this commit, the silabs ieee802154 driver was never compiled in CI.

The CI run in this PR still didn't compile this sample, because it was filtered out. Will these at least run on the weekly CI run?