### PR TITLE
drivers: xen: dom0: add CPU hotplug sysctl 

### DIFF
--- a/arch/arm64/core/xen/Kconfig
+++ b/arch/arm64/core/xen/Kconfig
@@ -48,7 +48,7 @@ config XEN_DOMCTL_INTERFACE_VERSION
 config XEN_SYSCTL_INTERFACE_VERSION
 	hex "Xen Sysctl interface version"
 	default 0x15
-	range 0x15 0x15
+	range 0x15 0x16
 	depends on XEN
 	help
 	  Xen Sysctl interface version to use. This is the version of the

--- a/arch/arm64/core/xen/Kconfig
+++ b/arch/arm64/core/xen/Kconfig
@@ -37,7 +37,7 @@ config XEN_INTERFACE_VERSION
 config XEN_DOMCTL_INTERFACE_VERSION
 	hex "Xen Domctl interface version"
 	default 0x17
-	range 0x15 0x17
+	range 0x15 0x18
 	depends on XEN
 	help
 	  Xen Domctl interface version to use. This is the version of the

--- a/drivers/xen/dom0/sysctl.c
+++ b/drivers/xen/dom0/sysctl.c
@@ -57,3 +57,17 @@ int xen_sysctl_getdomaininfo(struct xen_domctl_getdomaininfo *domaininfo,
 
 	return sysctl.u.getdomaininfolist.num_domains;
 }
+
+int xen_sysctl_cpu_hotplug(uint32_t cpu, bool enable)
+{
+	int ret;
+	xen_sysctl_t sysctl = {
+		.cmd = XEN_SYSCTL_cpu_hotplug,
+		.u.cpu_hotplug.cpu = cpu,
+		.u.cpu_hotplug.op = enable ? XEN_SYSCTL_CPU_HOTPLUG_ONLINE
+					   : XEN_SYSCTL_CPU_HOTPLUG_OFFLINE,
+	};
+
+	ret = do_sysctl(&sysctl);
+	return ret;
+}

--- a/include/zephyr/xen/dom0/sysctl.h
+++ b/include/zephyr/xen/dom0/sysctl.h
@@ -58,6 +58,17 @@ int xen_sysctl_physinfo(struct xen_sysctl_physinfo *info);
 int xen_sysctl_getdomaininfo(struct xen_domctl_getdomaininfo *domaininfo,
 			     uint16_t first, uint16_t num);
 
+/**
+ * @brief Enable/disable physical CPUs.
+ *
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ * @param cpu ID of the CPU being turned on or off.
+ * @param enable Flag indicating whether the CPU should be turned on or off.
+ *
+ * @return 0 on success, negative errno value on failure.
+ */
+int xen_sysctl_cpu_hotplug(uint32_t cpu, bool enable);
+
 /** @} */
 
 #endif /* __XEN_DOM0_SYSCTL_H__ */

--- a/include/zephyr/xen/public/arch-arm.h
+++ b/include/zephyr/xen/public/arch-arm.h
@@ -338,6 +338,15 @@ struct xen_arch_domainconfig {
 	 *
 	 */
 	uint32_t clock_frequency;
+#if CONFIG_XEN_DOMCTL_INTERFACE_VERSION >= 0x00000017
+	/* IN */
+	uint8_t arm_sci_type;
+#endif /* CONFIG_XEN_DOMCTL_INTERFACE_VERSION */
+#if CONFIG_XEN_DOMCTL_INTERFACE_VERSION >= 0x00000018
+	/* IN */
+	uint8_t v8r_el1_msa;
+	uint16_t pad;
+#endif /* CONFIG_XEN_DOMCTL_INTERFACE_VERSION */
 };
 #endif /* CONFIG_XEN_DOM0 */
 

--- a/include/zephyr/xen/public/sysctl.h
+++ b/include/zephyr/xen/public/sysctl.h
@@ -101,6 +101,41 @@ struct xen_sysctl_getcpuinfo {
 	uint32_t nr_cpus;
 };
 
+/**
+ * @brief CPU hotplug data
+ * XEN_SYSCTL_cpu_hotplug
+ */
+struct xen_sysctl_cpu_hotplug {
+	/** Physical cpu. */
+	uint32_t cpu;
+
+	/** Single CPU enable. */
+#define XEN_SYSCTL_CPU_HOTPLUG_ONLINE  0
+	/** Single CPU disable. */
+#define XEN_SYSCTL_CPU_HOTPLUG_OFFLINE 1
+
+	/*
+	 * SMT enable/disable.
+	 *
+	 * These two ops loop over all present CPUs, and either online or offline
+	 * every non-primary sibling thread (those with a thread id which is not
+	 * 0).  This behaviour is chosen to simplify the implementation.
+	 *
+	 * They are intended as a shorthand for identifying and feeding the cpu
+	 * numbers individually to HOTPLUG_{ON,OFF}LINE.
+	 *
+	 * These are not expected to be used in conjunction with debugging options
+	 * such as `maxcpus=` or when other manual configuration of offline cpus
+	 * is in use.
+	 */
+	/** SMT enable */
+#define XEN_SYSCTL_CPU_HOTPLUG_SMT_ENABLE  2
+	/** SMT disable */
+#define XEN_SYSCTL_CPU_HOTPLUG_SMT_DISABLE 3
+	/** hotplug opcode */
+	uint32_t op;
+};
+
 struct xen_sysctl {
 	uint32_t cmd;
 #define XEN_SYSCTL_readconsole                    1
@@ -136,6 +171,8 @@ struct xen_sysctl {
 		struct xen_sysctl_physinfo          physinfo;
 		struct xen_sysctl_getdomaininfolist getdomaininfolist;
 		struct xen_sysctl_getcpuinfo        getcpuinfo;
+		/** XEN_SYSCTL_cpu_hotplug input */
+		struct xen_sysctl_cpu_hotplug       cpu_hotplug;
 		uint8_t                             pad[128];
 	} u;
 };


### PR DESCRIPTION
This sysctl can be used to turn physical CPUs on or off at runtime.

Increase the range of XEN_SYSCTL_INTERFACE_VERSION to 0x15 - 0x16 to allow for using sysctls with newer versions of Xen.

Increase the range of XEN_DOMCTL_INTERFACE_VERSION to 0x15 - 0x18 to allow for using domctls with newer versions of Xen.