### PR TITLE
tests: counter: move ticks_expected calculation out of measured period

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -889,15 +889,14 @@ static void test_valid_function_without_alarm(const struct device *dev)
 
 	/* counter might not start from 0, use current value as offset */
 	counter_get_value(dev, &tick_current);
+	k_busy_wait(wait_for_us);
+	err = counter_get_value(dev, &ticks);
+
 	if (counter_is_counting_up(dev)) {
 		ticks_expected += tick_current;
 	} else {
 		ticks_expected = tick_current - ticks_expected;
 	}
-
-	k_busy_wait(wait_for_us);
-
-	err = counter_get_value(dev, &ticks);
 
 	zassert_equal(0, err, "%s: could not get counter value", dev->name);
 	zassert_between_inclusive(


### PR DESCRIPTION
The calculation consists of one function call, conditional branch and addition/subtraction operation. When CPU is slow (relatively to the counter frequency), this can take a significant part of the margin, and even cause the test_valid_function_without_alarm() to fail.

This change moves ticks_expected calculation after the real number of ticks is read, i.e. after the second counter_get_value() call.