### PR TITLE
Bluetooth: Audio: Add missing handling of empty receive states

### DIFF
--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -953,7 +953,11 @@ static void cap_commander_ba_recv_state_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	__ASSERT_NO_MSG(state != NULL);
+	if (state == NULL) {
+		/* Ignore, we use cap_commander_ba_recv_state_removed_cb for removed receive states
+		 */
+		return;
+	}
 
 	cap_commander_handle_recv_state(conn, state->src_id, state);
 }

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -162,6 +162,11 @@ static void bap_broadcast_assistant_recv_state_cb(
 		return;
 	}
 
+	if (state == NULL) {
+		bt_shell_print("Empty BASS recv state");
+		return;
+	}
+
 	bin2hex(state->bad_code, BT_ISO_BROADCAST_CODE_SIZE, bad_code, sizeof(bad_code));
 
 	is_bad_code = state->encrypt_state == BT_BAP_BIG_ENC_STATE_BAD_CODE;


### PR DESCRIPTION
Two places were missing a proper check for empty receive states. 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/116729