### PR TITLE
dts: ti: am62l: Add wakeup RTC peripheral and counter support 

### DIFF
--- a/boards/ti/am62l_evm/am62l_evm_am62l3_a53.dts
+++ b/boards/ti/am62l_evm/am62l_evm_am62l3_a53.dts
@@ -22,6 +22,7 @@
 	aliases {
 		adc0 = &main_adc0;
 		led0 = &ld9;
+		rtc = &counter_rtc0;
 		watchdog0 = &main_rti0;
 		sdhc0 = &main_sdhci0;
 		sdhc1 = &main_sdhci1;
@@ -207,6 +208,13 @@
 &main_epwm0 {
 	pinctrl-0 = <&main_epwm0_a &main_epwm0_b>;
 	pinctrl-names = "default";
+};
+
+&wkup_rtc0 {
+	status = "okay";
+};
+
+&counter_rtc0 {
 	status = "okay";
 };
 

--- a/dts/arm64/ti/am62l3_a53.dtsi
+++ b/dts/arm64/ti/am62l3_a53.dtsi
@@ -241,3 +241,8 @@
 	interrupts = <GIC_SPI 156 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
 	interrupt-parent = <&gic>;
 };
+
+&wkup_rtc0 {
+	interrupts = <GIC_SPI 28 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+	interrupt-parent = <&gic>;
+};

--- a/dts/vendor/ti/am62l-wakeup.dtsi
+++ b/dts/vendor/ti/am62l-wakeup.dtsi
@@ -53,4 +53,19 @@
 		clock-names = "fck";
 		status = "disabled";
 	};
+
+	wkup_rtc0: rtc@2b1f0000 {
+		compatible = "ti,k3-rtc-counter";
+		reg = <0x2b1f0000 0x64>;
+		clock-frequency = <DT_FREQ_K(32)>;
+		clocks = <&scmi_clk 272>;
+		power-domains = <&wkup_rtc0_pd>;
+		status = "disabled";
+
+		counter_rtc0: counter_rtc {
+			compatible = "zephyr,rtc-counter";
+			alarms-count = <2>;
+			status = "disabled";
+		};
+	};
 };

--- a/dts/vendor/ti/am62l_power_domains.dtsi
+++ b/dts/vendor/ti/am62l_power_domains.dtsi
@@ -181,5 +181,11 @@
 			reg = <24>;
 			#power-domain-cells = <0>;
 		};
+
+		wkup_rtc0_pd: power-domain@3b {
+			compatible = "arm,scmi-power-domain";
+			reg = <59>;
+			#power-domain-cells = <0>;
+		};
 	};
 };

--- a/soc/ti/k3/am62lx/Kconfig.defconfig
+++ b/soc/ti/k3/am62lx/Kconfig.defconfig
@@ -21,4 +21,7 @@ endchoice
 
 endif # SERIAL
 
+configdefault RTC_INIT_PRIORITY
+	default 70 if RTC_COUNTER
+
 endif # SOC_SERIES_AM62LX


### PR DESCRIPTION
Adds device tree support for the wkup_rtc0 RTC peripheral on the TI AM62L SoC and enables it on the am62l_evm board as a Zephyr counter device.