### PR TITLE
drivers: ethernet: sensry: Remove unused variable

### DIFF
--- a/drivers/ethernet/eth_sensry_sy1xx_mac.c
+++ b/drivers/ethernet/eth_sensry_sy1xx_mac.c
@@ -158,7 +158,6 @@ static void sy1xx_mac_set_mac_addr(const struct device *dev)
 {
 	struct sy1xx_mac_dev_config *cfg = (struct sy1xx_mac_dev_config *)dev->config;
 	struct sy1xx_mac_dev_data *data = (struct sy1xx_mac_dev_data *)dev->data;
-	int ret;
 	uint32_t v_low, v_high;
 
 	LOG_INF("%s set link address %02x:%02x:%02x:%02x:%02x:%02x", dev->name, data->mac_addr[0],


### PR DESCRIPTION
The variable ret was not used, and the compiler warned as much. Let's just remove it.

See failures in main: https://github.com/zephyrproject-rtos/zephyr/actions/runs/28727711339/job/85187936912#step:14:5438

Issue can be repro'd with 
```
cmake -GNinja -DBOARD=ganymed_sk/sy120_gen1 ../samples/net/sockets/dumb_http_server 
ninja
```