### PR TITLE
drivers: i2c: stm32: Avoid unused variable warning

### DIFF
--- a/drivers/i2c/i2c_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_stm32_v1_rtio.c
@@ -67,13 +67,14 @@ static void i2c_stm32_generate_start_condition(I2C_TypeDef *i2c)
 static void i2c_stm32_controller_mode_end(const struct device *dev, int status)
 {
 	const struct i2c_stm32_config *cfg = dev->config;
-	struct i2c_stm32_data *data = dev->data;
 	I2C_TypeDef *i2c = cfg->i2c;
 	bool disable_i2c = true;
 
 	i2c_stm32_disable_transfer_interrupts(dev);
 
 #if defined(CONFIG_I2C_TARGET)
+	struct i2c_stm32_data *data = dev->data;
+
 	data->controller_active = false;
 	if (data->target_attached) {
 		i2c_stm32_enable_transfer_interrupts(dev);


### PR DESCRIPTION
data is only used if CONFIG_I2C_TARGET is enabled. Let's move its declaration into that ifdef to avoid a compiler warning.

Can be repro'd w
```
cmake -GNinja -DBOARD=nucleo_f401re/stm32f401xe ../samples/sensor/stream_drdy 
ninja
```
https://github.com/zephyrproject-rtos/zephyr/actions/runs/28727711339/job/85187936915#step:14:1818