### PR TITLE
hal_nxp: usb: fix the hal_nxp uhc support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: f7937d3cdb178e29bd29fe97fbe15a3a932f939a
+      revision: 75b5c7fbf918e6905e79b45b7f12acc327a3e1e7
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update the hal_nxp revision to include fixes that enable the USB host controller driver to use the dedicated Zephyr port file.