### PR TITLE
bluetooth: mesh: dfu distributor self-update

### DIFF
--- a/include/zephyr/bluetooth/mesh/dfu_srv.h
+++ b/include/zephyr/bluetooth/mesh/dfu_srv.h
@@ -183,6 +183,7 @@ struct bt_mesh_dfu_srv {
 	/** Number of updatable images. */
 	size_t img_count;
 
+	/** @cond INTERNAL_HIDDEN */
 	/* Runtime state */
 	const struct bt_mesh_model *mod;
 	struct {
@@ -194,7 +195,9 @@ struct bt_mesh_dfu_srv {
 		uint8_t idx;
 		uint16_t timeout_base;
 		uint16_t meta;
+		bool self_update;
 	} update;
+	/** @endcond */
 };
 
 /** @brief Accept the received DFU transfer.

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -1099,6 +1099,40 @@ static void dfd_srv_reset(const struct bt_mesh_model *mod)
 	bt_mesh_dfu_slot_del_all();
 }
 
+static int dfd_srv_start(const struct bt_mesh_model *mod)
+{
+	struct bt_mesh_dfd_srv *srv = mod->rt->user_data;
+
+	if (srv->phase != BT_MESH_DFD_PHASE_APPLYING_UPDATE) {
+		return 0;
+	}
+
+	/* Resolve the slot pointer deferred from settings_set(). All
+	 * settings are loaded by the time .start fires.
+	 */
+	srv->dfu.xfer.slot = bt_mesh_dfu_slot_at(srv->slot_idx);
+	if (!srv->dfu.xfer.slot) {
+		LOG_WRN("Slot %u lost, failing distribution", srv->slot_idx);
+		dfd_phase_set(srv, BT_MESH_DFD_PHASE_FAILED);
+		return 0;
+	}
+
+	/* Self-update resume: if the local DFU Server is still in APPLYING,
+	 * the reboot means apply succeeded. Transition it to IDLE so it
+	 * responds to Firmware Update Information Get with the new FWID.
+	 */
+	struct bt_mesh_dfu_srv *dfu_srv = self_target_dfu_srv(srv);
+
+	if (dfu_srv && dfu_srv->update.phase == BT_MESH_DFU_PHASE_APPLYING) {
+		bt_mesh_dfu_srv_applied(dfu_srv);
+	}
+
+	/* Resume confirm step to verify targets report new FWID. */
+	(void)bt_mesh_dfu_cli_confirm(&srv->dfu);
+
+	return 0;
+}
+
 static int dfd_srv_settings_set(const struct bt_mesh_model *mod, const char *name,
 				size_t len_rd, settings_read_cb read_cb,
 				void *cb_arg)
@@ -1172,6 +1206,7 @@ static int dfd_srv_settings_set(const struct bt_mesh_model *mod, const char *nam
 
 const struct bt_mesh_model_cb _bt_mesh_dfd_srv_cb = {
 	.init = dfd_srv_init,
+	.start = dfd_srv_start,
 	.settings_set = dfd_srv_settings_set,
 	.reset = dfd_srv_reset,
 };

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -51,10 +51,80 @@ struct slot_search_ctx {
 	bool failed;
 };
 
+struct dfd_srv_persistent_target {
+	uint16_t addr;
+	uint8_t img_idx;
+	uint8_t phase;
+	uint8_t status;
+	uint8_t effect;
+} __packed;
+
+struct dfd_srv_persistent_state {
+	uint16_t target_cnt;
+	uint16_t slot_idx;
+	uint16_t app_idx;
+	uint16_t group;
+	uint16_t timeout_base;
+	uint8_t phase;
+	uint8_t apply;
+	uint8_t ttl;
+	uint8_t xfer_mode;
+	struct dfd_srv_persistent_target targets[CONFIG_BT_MESH_DFD_SRV_TARGETS_MAX];
+} __packed;
+
+static void store_state(struct bt_mesh_dfd_srv *srv)
+{
+	struct dfd_srv_persistent_state state = {
+		.phase = srv->phase,
+		.apply = srv->apply,
+		.target_cnt = srv->target_cnt,
+		.slot_idx = srv->slot_idx,
+		.app_idx = srv->inputs.app_idx,
+		.group = srv->inputs.group,
+		.ttl = srv->inputs.ttl,
+		.timeout_base = srv->inputs.timeout_base,
+		.xfer_mode = srv->dfu.xfer.blob.mode,
+	};
+	uint16_t cnt = MIN(srv->target_cnt, ARRAY_SIZE(state.targets));
+
+	for (int i = 0; i < cnt; i++) {
+		state.targets[i].addr = srv->targets[i].blob.addr;
+		state.targets[i].img_idx = srv->targets[i].img_idx;
+		state.targets[i].phase = srv->targets[i].phase;
+		state.targets[i].status = srv->targets[i].status;
+		state.targets[i].effect = srv->targets[i].effect;
+	}
+
+	bt_mesh_model_data_store(srv->mod, false, NULL, &state,
+				 offsetof(struct dfd_srv_persistent_state, targets) +
+				 cnt * sizeof(struct dfd_srv_persistent_target));
+}
+
+static void erase_state(struct bt_mesh_dfd_srv *srv)
+{
+	bt_mesh_model_data_store(srv->mod, false, NULL, NULL, 0);
+}
+
 static void dfd_phase_set(struct bt_mesh_dfd_srv *srv,
 			  enum bt_mesh_dfd_phase new_phase)
 {
 	srv->phase = new_phase;
+
+	/* Store at Applying Update for self-update resume, erase at
+	 * terminal states to prevent re-triggering after reboot.
+	 */
+	switch (new_phase) {
+	case BT_MESH_DFD_PHASE_IDLE:
+	case BT_MESH_DFD_PHASE_COMPLETED:
+	case BT_MESH_DFD_PHASE_FAILED:
+		erase_state(srv);
+		break;
+	case BT_MESH_DFD_PHASE_APPLYING_UPDATE:
+		store_state(srv);
+		break;
+	default:
+		break;
+	}
 
 	if (srv->cb && srv->cb->phase) {
 		srv->cb->phase(srv, srv->phase);
@@ -968,8 +1038,78 @@ static void dfd_srv_reset(const struct bt_mesh_model *mod)
 	bt_mesh_dfu_slot_del_all();
 }
 
+static int dfd_srv_settings_set(const struct bt_mesh_model *mod, const char *name,
+				size_t len_rd, settings_read_cb read_cb,
+				void *cb_arg)
+{
+	struct bt_mesh_dfd_srv *srv = mod->rt->user_data;
+	struct dfd_srv_persistent_state state;
+	ssize_t len;
+
+	if (len_rd < offsetof(struct dfd_srv_persistent_state, targets)) {
+		return -EINVAL;
+	}
+
+	len = read_cb(cb_arg, &state, sizeof(state));
+	if (len < 0 || len < offsetof(struct dfd_srv_persistent_state, targets)) {
+		return -EINVAL;
+	}
+
+	if (state.target_cnt > ARRAY_SIZE(srv->targets)) {
+		LOG_WRN("Stored target count %u exceeds max %u",
+			state.target_cnt, (uint8_t)ARRAY_SIZE(srv->targets));
+		return -EINVAL;
+	}
+
+	if (len < offsetof(struct dfd_srv_persistent_state, targets) +
+	    state.target_cnt * sizeof(struct dfd_srv_persistent_target)) {
+		LOG_WRN("Stored data too short for %u targets", state.target_cnt);
+		return -EINVAL;
+	}
+
+	if (state.phase != BT_MESH_DFD_PHASE_APPLYING_UPDATE) {
+		LOG_ERR("Unexpected persisted phase %u", state.phase);
+		return -EINVAL;
+	}
+
+	srv->phase = state.phase;
+
+	srv->apply = state.apply;
+	srv->slot_idx = state.slot_idx;
+	srv->inputs.app_idx = state.app_idx;
+	srv->inputs.group = state.group;
+	srv->inputs.ttl = state.ttl;
+	srv->inputs.timeout_base = state.timeout_base;
+	srv->dfu.xfer.blob.mode = state.xfer_mode;
+
+	srv->target_cnt = state.target_cnt;
+	sys_slist_init(&srv->inputs.targets);
+	for (int i = 0; i < srv->target_cnt; i++) {
+		memset(&srv->targets[i], 0, sizeof(struct bt_mesh_dfu_target));
+		memset(&srv->pull_ctxs[i], 0, sizeof(struct bt_mesh_blob_target_pull));
+		srv->targets[i].blob.addr = state.targets[i].addr;
+		srv->targets[i].blob.pull = &srv->pull_ctxs[i];
+		srv->targets[i].img_idx = state.targets[i].img_idx;
+		srv->targets[i].phase = state.targets[i].phase;
+		srv->targets[i].status = state.targets[i].status;
+		srv->targets[i].effect = state.targets[i].effect;
+		sys_slist_append(&srv->inputs.targets,
+				 &srv->targets[i].blob.n);
+	}
+
+	/* Slot pointer is resolved in dfd_srv_start() since the slot
+	 * settings subtree may not be loaded yet at this point.
+	 */
+
+	LOG_DBG("Recovered distribution (phase: %u, targets: %u, slot: %u)",
+		srv->phase, srv->target_cnt, srv->slot_idx);
+
+	return 0;
+}
+
 const struct bt_mesh_model_cb _bt_mesh_dfd_srv_cb = {
 	.init = dfd_srv_init,
+	.settings_set = dfd_srv_settings_set,
 	.reset = dfd_srv_reset,
 };
 

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -13,6 +13,7 @@
 #include "dfd_srv_internal.h"
 #include "net.h"
 #include "transport.h"
+#include "access.h"
 
 #define LOG_LEVEL CONFIG_BT_MESH_DFU_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -870,6 +871,42 @@ static void dfu_suspended(struct bt_mesh_dfu_cli *cli)
 	dfd_phase_set(srv, BT_MESH_DFD_PHASE_TRANSFER_SUSPENDED);
 }
 
+static struct bt_mesh_dfu_srv *self_target_dfu_srv(struct bt_mesh_dfd_srv *srv)
+{
+	/* The spec requires the DFU Server (Target role element Y) to be on
+	 * a different element from the DFD Server (Distributor role element
+	 * X). Find the local DFU Server by looking up the element that owns
+	 * the self-target unicast address stored in the receivers list.
+	 */
+	uint16_t cnt = MIN(srv->target_cnt, ARRAY_SIZE(srv->targets));
+
+	for (int i = 0; i < cnt; i++) {
+		if (bt_mesh_has_addr(srv->targets[i].blob.addr)) {
+			const struct bt_mesh_elem *elem =
+				bt_mesh_elem_find(srv->targets[i].blob.addr);
+			const struct bt_mesh_model *mod =
+				bt_mesh_model_find(elem, BT_MESH_MODEL_ID_DFU_SRV);
+
+			return mod ? mod->rt->user_data : NULL;
+		}
+	}
+
+	return NULL;
+}
+
+static void trigger_self_apply(struct bt_mesh_dfd_srv *srv)
+{
+	struct bt_mesh_dfu_srv *dfu_srv = self_target_dfu_srv(srv);
+
+	/* Trigger self-target apply after distribution completes or fails.
+	 * The DFU Server deferred its apply callback to let the
+	 * Distributor finish the confirm step first.
+	 */
+	if (dfu_srv) {
+		bt_mesh_dfu_srv_apply_deferred(dfu_srv);
+	}
+}
+
 static void dfu_ended(struct bt_mesh_dfu_cli *cli,
 		      enum bt_mesh_dfu_status reason)
 {
@@ -890,6 +927,11 @@ static void dfu_ended(struct bt_mesh_dfu_cli *cli,
 
 	if (reason != BT_MESH_DFU_SUCCESS) {
 		dfd_phase_set(srv, BT_MESH_DFD_PHASE_FAILED);
+		/* Remote targets failed to confirm (e.g. no target
+		 * reported new FWID). Distribution is over, safe to
+		 * apply deferred self-update.
+		 */
+		trigger_self_apply(srv);
 		return;
 	}
 
@@ -933,9 +975,28 @@ static void dfu_confirmed(struct bt_mesh_dfu_cli *cli)
 {
 	struct bt_mesh_dfd_srv *srv =
 		CONTAINER_OF(cli, struct bt_mesh_dfd_srv, dfu);
+	struct bt_mesh_dfu_srv *dfu_srv;
 
 	if (srv->phase != BT_MESH_DFD_PHASE_APPLYING_UPDATE &&
 	    srv->phase != BT_MESH_DFD_PHASE_CANCELING_UPDATE) {
+		return;
+	}
+
+	/* MshDFUv1.0 Section 6.2.2.4 Confirm step requires the DFD Server to
+	 * wait until the Target nodes have applied the new firmware before
+	 * setting Distribution Phase to Completed. In a self-update, the
+	 * distributor is one of those Target nodes, so trigger the deferred
+	 * self-apply first. If the apply callback reboots the device (real
+	 * firmware), execution does not return: the DFD phase stays in
+	 * APPLYING_UPDATE with state persisted, and dfd_srv_start() finishes
+	 * the Confirm step on the next boot. If the self-target is still in
+	 * APPLYING after the callback (async apply or pending reboot), keep
+	 * DFD in APPLYING_UPDATE so state remains persisted for resume.
+	 */
+	trigger_self_apply(srv);
+
+	dfu_srv = self_target_dfu_srv(srv);
+	if (dfu_srv && dfu_srv->update.phase == BT_MESH_DFU_PHASE_APPLYING) {
 		return;
 	}
 

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -1097,6 +1097,8 @@ static int dfd_srv_settings_set(const struct bt_mesh_model *mod, const char *nam
 				 &srv->targets[i].blob.n);
 	}
 
+	bt_mesh_dfu_cli_restore(&srv->dfu, &srv->inputs);
+
 	/* Slot pointer is resolved in dfd_srv_start() since the slot
 	 * settings subtree may not be loaded yet at this point.
 	 */

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -13,6 +13,7 @@
 #include "dfd_srv_internal.h"
 #include "net.h"
 #include "transport.h"
+#include "access.h"
 
 #define LOG_LEVEL CONFIG_BT_MESH_DFU_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -877,6 +878,68 @@ static void dfu_suspended(struct bt_mesh_dfu_cli *cli)
 	dfd_phase_set(srv, BT_MESH_DFD_PHASE_TRANSFER_SUSPENDED);
 }
 
+static struct bt_mesh_dfu_srv *self_target_dfu_srv(struct bt_mesh_dfd_srv *srv)
+{
+	/* The spec requires the DFU Server (Target role element Y) to be on
+	 * a different element from the DFD Server (Distributor role element
+	 * X). Find the local DFU Server by looking up the element that owns
+	 * the self-target unicast address stored in the receivers list.
+	 */
+	for (uint16_t i = 0; i < srv->target_cnt && i < ARRAY_SIZE(srv->targets); i++) {
+		if (bt_mesh_has_addr(srv->targets[i].blob.addr)) {
+			const struct bt_mesh_elem *elem =
+				bt_mesh_elem_find(srv->targets[i].blob.addr);
+			const struct bt_mesh_model *mod =
+				bt_mesh_model_find(elem, BT_MESH_MODEL_ID_DFU_SRV);
+
+			/* A local element without a DFU Server is not the Target
+			 * element; it times out as an ordinary target.
+			 */
+			if (mod) {
+				return mod->rt->user_data;
+			}
+		}
+	}
+
+	return NULL;
+}
+
+static int trigger_self_apply(struct bt_mesh_dfd_srv *srv)
+{
+	struct bt_mesh_dfu_srv *dfu_srv;
+
+	if (!IS_ENABLED(CONFIG_BT_MESH_DFU_SRV)) {
+		return 0;
+	}
+
+	/* Trigger self-target apply after distribution completes or fails.
+	 * The DFU Server deferred its apply callback to let the
+	 * Distributor finish the confirm step first.
+	 */
+	dfu_srv = self_target_dfu_srv(srv);
+	if (!dfu_srv) {
+		return 0;
+	}
+
+	return bt_mesh_dfu_srv_apply_deferred(dfu_srv);
+}
+
+static void cancel_self_apply(struct bt_mesh_dfd_srv *srv)
+{
+	struct bt_mesh_dfu_srv *dfu_srv;
+
+	if (!IS_ENABLED(CONFIG_BT_MESH_DFU_SRV)) {
+		return;
+	}
+
+	dfu_srv = self_target_dfu_srv(srv);
+	if (!dfu_srv) {
+		return;
+	}
+
+	bt_mesh_dfu_srv_apply_cancel(dfu_srv);
+}
+
 static void dfu_ended(struct bt_mesh_dfu_cli *cli,
 		      enum bt_mesh_dfu_status reason)
 {
@@ -897,6 +960,11 @@ static void dfu_ended(struct bt_mesh_dfu_cli *cli,
 
 	if (reason != BT_MESH_DFU_SUCCESS) {
 		dfd_phase_set(srv, BT_MESH_DFD_PHASE_FAILED);
+		/* Remote targets failed to confirm (e.g. no target
+		 * reported new FWID). Distribution is over, safe to
+		 * apply deferred self-update.
+		 */
+		(void)trigger_self_apply(srv);
 		return;
 	}
 
@@ -944,9 +1012,31 @@ static void dfu_confirmed(struct bt_mesh_dfu_cli *cli)
 {
 	struct bt_mesh_dfd_srv *srv =
 		CONTAINER_OF(cli, struct bt_mesh_dfd_srv, dfu);
+	struct bt_mesh_dfu_srv *dfu_srv;
 
 	if (srv->phase != BT_MESH_DFD_PHASE_APPLYING_UPDATE &&
 	    srv->phase != BT_MESH_DFD_PHASE_CANCELING_UPDATE) {
+		return;
+	}
+
+	/* MshDFUv1.0 Section 6.2.2.4 Confirm step requires the DFD Server to
+	 * wait until the Target nodes have applied the new firmware before
+	 * setting Distribution Phase to Completed. In a self-update, the
+	 * distributor is one of those Target nodes, so trigger the deferred
+	 * self-apply first. If the apply callback reboots the device (real
+	 * firmware), execution does not return: the DFD phase stays in
+	 * APPLYING_UPDATE with state persisted, and dfd_srv_start() finishes
+	 * the Confirm step on the next boot. If the self-target is still in
+	 * APPLYING after the callback (async apply or pending reboot), keep
+	 * DFD in APPLYING_UPDATE so state remains persisted for resume.
+	 */
+	if (trigger_self_apply(srv)) {
+		dfd_phase_set(srv, BT_MESH_DFD_PHASE_FAILED);
+		return;
+	}
+
+	dfu_srv = self_target_dfu_srv(srv);
+	if (dfu_srv && dfu_srv->update.phase == BT_MESH_DFU_PHASE_APPLYING) {
 		return;
 	}
 
@@ -1311,8 +1401,16 @@ enum bt_mesh_dfd_status bt_mesh_dfd_srv_cancel(struct bt_mesh_dfd_srv *srv,
 
 	prev_phase = srv->phase;
 	dfd_phase_set(srv, BT_MESH_DFD_PHASE_CANCELING_UPDATE);
+
+	if (prev_phase == BT_MESH_DFD_PHASE_APPLYING_UPDATE) {
+		cancel_self_apply(srv);
+	}
+
 	err = bt_mesh_dfu_cli_cancel(&srv->dfu, NULL);
-	if (err) {
+	/* -EALREADY means the DFU Client has nothing left to cancel, which is
+	 * the case while waiting for a deferred self-apply.
+	 */
+	if (err && err != -EALREADY) {
 		if (ctx != NULL) {
 			status_rsp(srv, ctx, BT_MESH_DFD_ERR_INTERNAL);
 		}

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -904,6 +904,29 @@ static struct bt_mesh_dfu_srv *self_target_dfu_srv(struct bt_mesh_dfd_srv *srv)
 	return NULL;
 }
 
+static void dfd_srv_find_cb(const struct bt_mesh_model *mod,
+			    const struct bt_mesh_elem *elem,
+			    bool vnd, bool primary, void *user_data)
+{
+	struct bt_mesh_dfd_srv **srv = user_data;
+
+	if (!vnd && mod->id == BT_MESH_MODEL_ID_DFD_SRV) {
+		*srv = mod->rt->user_data;
+	}
+}
+
+void bt_mesh_dfd_srv_self_applied(void)
+{
+	struct bt_mesh_dfd_srv *srv = NULL;
+
+	bt_mesh_model_foreach(dfd_srv_find_cb, &srv);
+	if (!srv || srv->phase != BT_MESH_DFD_PHASE_APPLYING_UPDATE) {
+		return;
+	}
+
+	dfd_phase_set(srv, BT_MESH_DFD_PHASE_COMPLETED);
+}
+
 static int trigger_self_apply(struct bt_mesh_dfd_srv *srv)
 {
 	struct bt_mesh_dfu_srv *dfu_srv;
@@ -1028,7 +1051,8 @@ static void dfu_confirmed(struct bt_mesh_dfu_cli *cli)
 	 * APPLYING_UPDATE with state persisted, and dfd_srv_model_start() finishes
 	 * the Confirm step on the next boot. If the self-target is still in
 	 * APPLYING after the callback (async apply or pending reboot), keep
-	 * DFD in APPLYING_UPDATE so state remains persisted for resume.
+	 * DFD in APPLYING_UPDATE so state remains persisted for resume; an
+	 * async apply completes it from bt_mesh_dfd_srv_self_applied().
 	 */
 	if (trigger_self_apply(srv)) {
 		dfd_phase_set(srv, BT_MESH_DFD_PHASE_FAILED);
@@ -1037,6 +1061,11 @@ static void dfu_confirmed(struct bt_mesh_dfu_cli *cli)
 
 	dfu_srv = self_target_dfu_srv(srv);
 	if (dfu_srv && dfu_srv->update.phase == BT_MESH_DFU_PHASE_APPLYING) {
+		return;
+	}
+
+	/* An apply that completed inside the callback has already notified us. */
+	if (srv->phase == BT_MESH_DFD_PHASE_COMPLETED) {
 		return;
 	}
 

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -1025,7 +1025,7 @@ static void dfu_confirmed(struct bt_mesh_dfu_cli *cli)
 	 * distributor is one of those Target nodes, so trigger the deferred
 	 * self-apply first. If the apply callback reboots the device (real
 	 * firmware), execution does not return: the DFD phase stays in
-	 * APPLYING_UPDATE with state persisted, and dfd_srv_start() finishes
+	 * APPLYING_UPDATE with state persisted, and dfd_srv_model_start() finishes
 	 * the Confirm step on the next boot. If the self-target is still in
 	 * APPLYING after the callback (async apply or pending reboot), keep
 	 * DFD in APPLYING_UPDATE so state remains persisted for resume.
@@ -1139,6 +1139,42 @@ static void dfd_srv_reset(const struct bt_mesh_model *mod)
 	bt_mesh_dfu_slot_del_all();
 }
 
+static int dfd_srv_model_start(const struct bt_mesh_model *mod)
+{
+	struct bt_mesh_dfd_srv *srv = mod->rt->user_data;
+
+	if (srv->phase != BT_MESH_DFD_PHASE_APPLYING_UPDATE) {
+		return 0;
+	}
+
+	/* Resolve the slot pointer deferred from settings_set(). All
+	 * settings are loaded by the time .start fires.
+	 */
+	srv->dfu.xfer.slot = bt_mesh_dfu_slot_at(srv->slot_idx);
+	if (!srv->dfu.xfer.slot) {
+		LOG_WRN("Slot %u lost, failing distribution", srv->slot_idx);
+		dfd_phase_set(srv, BT_MESH_DFD_PHASE_FAILED);
+		return 0;
+	}
+
+	/* Self-update resume: if the local DFU Server is still in APPLYING,
+	 * the reboot means apply succeeded. Transition it to IDLE so it
+	 * responds to Firmware Update Information Get with the new FWID.
+	 */
+	if (IS_ENABLED(CONFIG_BT_MESH_DFU_SRV)) {
+		struct bt_mesh_dfu_srv *dfu_srv = self_target_dfu_srv(srv);
+
+		if (dfu_srv && dfu_srv->update.phase == BT_MESH_DFU_PHASE_APPLYING) {
+			bt_mesh_dfu_srv_applied(dfu_srv);
+		}
+	}
+
+	/* Resume confirm step to verify targets report new FWID. */
+	(void)bt_mesh_dfu_cli_confirm(&srv->dfu);
+
+	return 0;
+}
+
 static int dfd_srv_settings_set(const struct bt_mesh_model *mod, const char *name,
 				size_t len_rd, settings_read_cb read_cb,
 				void *cb_arg)
@@ -1200,7 +1236,7 @@ static int dfd_srv_settings_set(const struct bt_mesh_model *mod, const char *nam
 
 	bt_mesh_dfu_cli_restore(&srv->dfu, &srv->inputs);
 
-	/* Slot pointer is resolved in dfd_srv_start() since the slot
+	/* Slot pointer is resolved in dfd_srv_model_start() since the slot
 	 * settings subtree may not be loaded yet at this point.
 	 */
 
@@ -1212,6 +1248,7 @@ static int dfd_srv_settings_set(const struct bt_mesh_model *mod, const char *nam
 
 const struct bt_mesh_model_cb _bt_mesh_dfd_srv_cb = {
 	.init = dfd_srv_init,
+	.start = dfd_srv_model_start,
 	.settings_set = dfd_srv_settings_set,
 	.reset = dfd_srv_reset,
 };

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -51,10 +51,87 @@ struct slot_search_ctx {
 	bool failed;
 };
 
+struct dfd_srv_persistent_target {
+	uint16_t addr;
+	uint8_t img_idx;
+	uint8_t phase;
+	uint8_t status;
+	uint8_t effect;
+} __packed;
+
+struct dfd_srv_persistent_state {
+	uint16_t target_cnt;
+	uint16_t slot_idx;
+	uint16_t app_idx;
+	uint16_t group;
+	uint16_t timeout_base;
+	uint8_t phase;
+	uint8_t apply;
+	uint8_t ttl;
+	uint8_t xfer_mode;
+	struct dfd_srv_persistent_target targets[CONFIG_BT_MESH_DFD_SRV_TARGETS_MAX];
+} __packed;
+
+static int store_state(struct bt_mesh_dfd_srv *srv)
+{
+	struct dfd_srv_persistent_state state = {
+		.phase = srv->phase,
+		.apply = srv->apply,
+		.target_cnt = srv->target_cnt,
+		.slot_idx = srv->slot_idx,
+		.app_idx = srv->inputs.app_idx,
+		.group = srv->inputs.group,
+		.ttl = srv->inputs.ttl,
+		.timeout_base = srv->inputs.timeout_base,
+		.xfer_mode = srv->dfu.xfer.blob.mode,
+	};
+	uint16_t cnt = MIN(srv->target_cnt, ARRAY_SIZE(srv->targets));
+
+	for (uint16_t i = 0; i < srv->target_cnt && i < ARRAY_SIZE(srv->targets); i++) {
+		state.targets[i].addr = srv->targets[i].blob.addr;
+		state.targets[i].img_idx = srv->targets[i].img_idx;
+		state.targets[i].phase = srv->targets[i].phase;
+		state.targets[i].status = srv->targets[i].status;
+		state.targets[i].effect = srv->targets[i].effect;
+	}
+
+	return bt_mesh_model_data_store(srv->mod, false, NULL, &state,
+					offsetof(struct dfd_srv_persistent_state, targets) +
+					cnt * sizeof(struct dfd_srv_persistent_target));
+}
+
+static void erase_state(struct bt_mesh_dfd_srv *srv)
+{
+	bt_mesh_model_data_store(srv->mod, false, NULL, NULL, 0);
+}
+
 static void dfd_phase_set(struct bt_mesh_dfd_srv *srv,
 			  enum bt_mesh_dfd_phase new_phase)
 {
 	srv->phase = new_phase;
+
+	/* Store at Applying Update for self-update resume, erase at
+	 * terminal states to prevent re-triggering after reboot.
+	 */
+	switch (new_phase) {
+	case BT_MESH_DFD_PHASE_IDLE:
+	case BT_MESH_DFD_PHASE_COMPLETED:
+	case BT_MESH_DFD_PHASE_FAILED:
+		erase_state(srv);
+		break;
+	case BT_MESH_DFD_PHASE_APPLYING_UPDATE:
+		if (store_state(srv)) {
+			/* Without persisted state the self-apply reboot would be
+			 * unrecoverable, so fail the distribution instead.
+			 */
+			LOG_ERR("Failed to store DFD state, failing distribution");
+			srv->phase = BT_MESH_DFD_PHASE_FAILED;
+			erase_state(srv);
+		}
+		break;
+	default:
+		break;
+	}
 
 	if (srv->cb && srv->cb->phase) {
 		srv->cb->phase(srv, srv->phase);
@@ -828,7 +905,11 @@ static void dfu_ended(struct bt_mesh_dfu_cli *cli,
 		return;
 	}
 
+	/* dfd_phase_set() downgrades to FAILED if the state cannot be persisted. */
 	dfd_phase_set(srv, BT_MESH_DFD_PHASE_APPLYING_UPDATE);
+	if (srv->phase != BT_MESH_DFD_PHASE_APPLYING_UPDATE) {
+		return;
+	}
 
 	err = bt_mesh_dfu_cli_apply(cli);
 	if (err) {
@@ -968,8 +1049,78 @@ static void dfd_srv_reset(const struct bt_mesh_model *mod)
 	bt_mesh_dfu_slot_del_all();
 }
 
+static int dfd_srv_settings_set(const struct bt_mesh_model *mod, const char *name,
+				size_t len_rd, settings_read_cb read_cb,
+				void *cb_arg)
+{
+	struct bt_mesh_dfd_srv *srv = mod->rt->user_data;
+	struct dfd_srv_persistent_state state;
+	ssize_t len;
+
+	if (len_rd < offsetof(struct dfd_srv_persistent_state, targets)) {
+		return -EINVAL;
+	}
+
+	len = read_cb(cb_arg, &state, sizeof(state));
+	if (len < 0 || len < offsetof(struct dfd_srv_persistent_state, targets)) {
+		return -EINVAL;
+	}
+
+	if (state.target_cnt > ARRAY_SIZE(srv->targets)) {
+		LOG_WRN("Stored target count %u exceeds max %u",
+			state.target_cnt, (uint8_t)ARRAY_SIZE(srv->targets));
+		return -EINVAL;
+	}
+
+	if (len < offsetof(struct dfd_srv_persistent_state, targets) +
+	    state.target_cnt * sizeof(struct dfd_srv_persistent_target)) {
+		LOG_WRN("Stored data too short for %u targets", state.target_cnt);
+		return -EINVAL;
+	}
+
+	if (state.phase != BT_MESH_DFD_PHASE_APPLYING_UPDATE) {
+		LOG_ERR("Unexpected persisted phase %u", state.phase);
+		return -EINVAL;
+	}
+
+	srv->phase = state.phase;
+
+	srv->apply = state.apply;
+	srv->slot_idx = state.slot_idx;
+	srv->inputs.app_idx = state.app_idx;
+	srv->inputs.group = state.group;
+	srv->inputs.ttl = state.ttl;
+	srv->inputs.timeout_base = state.timeout_base;
+	srv->dfu.xfer.blob.mode = state.xfer_mode;
+
+	srv->target_cnt = state.target_cnt;
+	sys_slist_init(&srv->inputs.targets);
+	for (int i = 0; i < srv->target_cnt; i++) {
+		memset(&srv->targets[i], 0, sizeof(struct bt_mesh_dfu_target));
+		memset(&srv->pull_ctxs[i], 0, sizeof(struct bt_mesh_blob_target_pull));
+		srv->targets[i].blob.addr = state.targets[i].addr;
+		srv->targets[i].blob.pull = &srv->pull_ctxs[i];
+		srv->targets[i].img_idx = state.targets[i].img_idx;
+		srv->targets[i].phase = state.targets[i].phase;
+		srv->targets[i].status = state.targets[i].status;
+		srv->targets[i].effect = state.targets[i].effect;
+		sys_slist_append(&srv->inputs.targets,
+				 &srv->targets[i].blob.n);
+	}
+
+	/* Slot pointer is resolved in dfd_srv_start() since the slot
+	 * settings subtree may not be loaded yet at this point.
+	 */
+
+	LOG_DBG("Recovered distribution (phase: %u, targets: %u, slot: %u)",
+		srv->phase, srv->target_cnt, srv->slot_idx);
+
+	return 0;
+}
+
 const struct bt_mesh_model_cb _bt_mesh_dfd_srv_cb = {
 	.init = dfd_srv_init,
+	.settings_set = dfd_srv_settings_set,
 	.reset = dfd_srv_reset,
 };
 
@@ -1210,7 +1361,12 @@ enum bt_mesh_dfd_status bt_mesh_dfd_srv_apply(struct bt_mesh_dfd_srv *srv)
 		return BT_MESH_DFD_ERR_INTERNAL;
 	}
 
+	/* dfd_phase_set() downgrades to FAILED if the state cannot be persisted. */
 	dfd_phase_set(srv, BT_MESH_DFD_PHASE_APPLYING_UPDATE);
+	if (srv->phase != BT_MESH_DFD_PHASE_APPLYING_UPDATE) {
+		return BT_MESH_DFD_ERR_INTERNAL;
+	}
+
 	return BT_MESH_DFD_SUCCESS;
 }
 

--- a/subsys/bluetooth/mesh/dfd_srv.c
+++ b/subsys/bluetooth/mesh/dfd_srv.c
@@ -1108,6 +1108,8 @@ static int dfd_srv_settings_set(const struct bt_mesh_model *mod, const char *nam
 				 &srv->targets[i].blob.n);
 	}
 
+	bt_mesh_dfu_cli_restore(&srv->dfu, &srv->inputs);
+
 	/* Slot pointer is resolved in dfd_srv_start() since the slot
 	 * settings subtree may not be loaded yet at this point.
 	 */

--- a/subsys/bluetooth/mesh/dfd_srv_internal.h
+++ b/subsys/bluetooth/mesh/dfd_srv_internal.h
@@ -40,6 +40,11 @@ enum bt_mesh_dfd_status bt_mesh_dfd_srv_fw_delete(struct bt_mesh_dfd_srv *srv, s
 
 enum bt_mesh_dfd_status bt_mesh_dfd_srv_fw_delete_all(struct bt_mesh_dfd_srv *srv);
 
+/** Notify a co-located Firmware Distribution Server that the local Firmware
+ *  Update Server completed a deferred self-apply.
+ */
+void bt_mesh_dfd_srv_self_applied(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/mesh/dfu.h
+++ b/subsys/bluetooth/mesh/dfu.h
@@ -23,6 +23,8 @@
 void bt_mesh_dfu_cli_restore(struct bt_mesh_dfu_cli *cli,
 			    const struct bt_mesh_blob_cli_inputs *inputs);
 
+void bt_mesh_dfu_srv_apply_deferred(struct bt_mesh_dfu_srv *srv);
+
 static inline uint16_t dfu_metadata_checksum(struct net_buf_simple *buf)
 {
 	/* Simple Fletcher-16 checksum to ensure duplicate start messages don't

--- a/subsys/bluetooth/mesh/dfu.h
+++ b/subsys/bluetooth/mesh/dfu.h
@@ -20,6 +20,9 @@
 					   CONFIG_BT_MESH_DFU_URI_MAXLEN)
 #define DFU_UPDATE_START_MSG_MAXLEN (12 + CONFIG_BT_MESH_DFU_METADATA_MAXLEN)
 
+void bt_mesh_dfu_cli_restore(struct bt_mesh_dfu_cli *cli,
+			    const struct bt_mesh_blob_cli_inputs *inputs);
+
 static inline uint16_t dfu_metadata_checksum(struct net_buf_simple *buf)
 {
 	/* Simple Fletcher-16 checksum to ensure duplicate start messages don't

--- a/subsys/bluetooth/mesh/dfu.h
+++ b/subsys/bluetooth/mesh/dfu.h
@@ -23,6 +23,10 @@
 void bt_mesh_dfu_cli_restore(struct bt_mesh_dfu_cli *cli,
 			    const struct bt_mesh_blob_cli_inputs *inputs);
 
+int bt_mesh_dfu_srv_apply_deferred(struct bt_mesh_dfu_srv *srv);
+
+void bt_mesh_dfu_srv_apply_cancel(struct bt_mesh_dfu_srv *srv);
+
 static inline uint16_t dfu_metadata_checksum(struct net_buf_simple *buf)
 {
 	/* Simple Fletcher-16 checksum to ensure duplicate start messages don't

--- a/subsys/bluetooth/mesh/dfu_cli.c
+++ b/subsys/bluetooth/mesh/dfu_cli.c
@@ -340,6 +340,32 @@ static void send_info_get(struct bt_mesh_blob_cli *b, uint16_t dst)
 	struct bt_mesh_dfu_cli *cli = DFU_CLI(b);
 	struct bt_mesh_msg_ctx ctx = MSG_CTX(cli, dst);
 
+	if (bt_mesh_has_addr(dst)) {
+		const struct bt_mesh_elem *elem = bt_mesh_elem_find(dst);
+		const struct bt_mesh_model *mod =
+			elem ? bt_mesh_model_find(elem, BT_MESH_MODEL_ID_DFU_SRV) : NULL;
+		struct bt_mesh_dfu_srv *dfu_srv = mod ? mod->rt->user_data : NULL;
+
+		if (dfu_srv &&
+		    dfu_srv->update.phase == BT_MESH_DFU_PHASE_APPLYING) {
+			struct bt_mesh_dfu_target *target = target_get(cli, dst);
+
+			/* The local DFU Server defers its apply callback until
+			 * the Confirm step completes (see dfu_confirmed() in
+			 * dfd_srv.c), so it will reject Firmware Update
+			 * Information Get with EBUSY per MshDFUv1.0 Section 7.2.
+			 * Retrying only delays confirmed() from triggering the
+			 * deferred apply. Ack the self-target immediately and
+			 * drive the broadcast state machine forward.
+			 */
+			if (target) {
+				blob_cli_broadcast_rsp(&cli->blob, &target->blob);
+			}
+			blob_cli_broadcast_tx_complete(&cli->blob);
+			return;
+		}
+	}
+
 	cli->req.img_cnt = 0xff;
 
 	info_get(cli, &ctx, 0, cli->req.img_cnt, &send_cb);
@@ -652,6 +678,14 @@ static void confirmed(struct bt_mesh_blob_cli *b)
 			target->phase = BT_MESH_DFU_PHASE_APPLY_FAIL;
 			target_failed(cli, target, BT_MESH_DFU_ERR_INTERNAL);
 		} else if (!target->blob.acked) {
+			if (bt_mesh_has_addr(target->blob.addr)) {
+				/* Self-target deferred apply until distribution
+				 * completes, so it can't confirm yet.
+				 */
+				success = true;
+				continue;
+			}
+
 			LOG_DBG("Target 0x%04x failed to respond", target->blob.addr);
 			target->phase = BT_MESH_DFU_PHASE_APPLY_FAIL;
 			target_failed(cli, target, BT_MESH_DFU_ERR_INTERNAL);

--- a/subsys/bluetooth/mesh/dfu_cli.c
+++ b/subsys/bluetooth/mesh/dfu_cli.c
@@ -801,6 +801,19 @@ static int handle_status(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx
 			blob_cli_broadcast_rsp(&cli->blob, &target->blob);
 			return 0;
 		}
+
+		/* MshDFUv1.0 Section 7.1.2.6: a target that responds with
+		 * status Success and phase Applying Update has accepted the
+		 * Firmware Update Apply message. A target that remains
+		 * provisioned may also respond with phase Idle once the apply
+		 * has already completed. Both responses are terminal for the
+		 * Apply step, and the Firmware Update Apply message is
+		 * idempotent, so further retries cannot change the response.
+		 * Acknowledge the target on the first such response.
+		 */
+		LOG_DBG("Target 0x%04x accepted apply (phase %u)",
+			target->blob.addr, phase);
+		blob_cli_broadcast_rsp(&cli->blob, &target->blob);
 		return 0;
 	} else if (cli->xfer.state == STATE_CONFIRM) {
 		if (phase == BT_MESH_DFU_PHASE_APPLYING) {

--- a/subsys/bluetooth/mesh/dfu_cli.c
+++ b/subsys/bluetooth/mesh/dfu_cli.c
@@ -1281,3 +1281,10 @@ void bt_mesh_dfu_cli_timeout_set(int32_t t)
 {
 	dfu_cli_timeout = t;
 }
+
+void bt_mesh_dfu_cli_restore(struct bt_mesh_dfu_cli *cli,
+			    const struct bt_mesh_blob_cli_inputs *inputs)
+{
+	cli->xfer.state = STATE_APPLIED;
+	cli->blob.inputs = inputs;
+}

--- a/subsys/bluetooth/mesh/dfu_srv.c
+++ b/subsys/bluetooth/mesh/dfu_srv.c
@@ -122,7 +122,7 @@ static void apply_rsp_sent(int err, void *cb_params)
 
 	if (!srv->cb->apply || srv->update.idx == UPDATE_IDX_NONE) {
 		srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
-		store_state(srv);
+		erase_state(srv);
 		LOG_DBG("Prerequisites for apply callback are wrong");
 		return;
 	}
@@ -132,7 +132,7 @@ static void apply_rsp_sent(int err, void *cb_params)
 	err = srv->cb->apply(srv, &srv->imgs[srv->update.idx]);
 	if (err) {
 		srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
-		store_state(srv);
+		erase_state(srv);
 		LOG_DBG("Application apply callback failed (err %d)", err);
 	}
 }
@@ -426,6 +426,7 @@ static int handle_cancel(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx
 
 	bt_mesh_blob_srv_cancel(&srv->blob);
 	srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
+	erase_state(srv);
 	xfer_failed(srv);
 
 rsp:

--- a/subsys/bluetooth/mesh/dfu_srv.c
+++ b/subsys/bluetooth/mesh/dfu_srv.c
@@ -25,10 +25,27 @@ BUILD_ASSERT((DFU_UPDATE_INFO_STATUS_MSG_MINLEN +
 	     "The Firmware Update Info Status message does not fit into the maximum outgoing SDU "
 	     "size.");
 
+struct dfu_srv_persistent_state {
+	uint8_t effect;
+	uint8_t phase;
+	uint8_t ttl;
+	uint8_t idx;
+	uint16_t timeout_base;
+	uint16_t meta;
+} __packed;
+
 static void store_state(struct bt_mesh_dfu_srv *srv)
 {
-	bt_mesh_model_data_store(srv->mod, false, NULL, &srv->update,
-				 sizeof(srv->update));
+	struct dfu_srv_persistent_state state = {
+		.effect = srv->update.effect,
+		.phase = srv->update.phase,
+		.ttl = srv->update.ttl,
+		.idx = srv->update.idx,
+		.timeout_base = srv->update.timeout_base,
+		.meta = srv->update.meta,
+	};
+
+	bt_mesh_model_data_store(srv->mod, false, NULL, &state, sizeof(state));
 }
 
 static void erase_state(struct bt_mesh_dfu_srv *srv)
@@ -494,16 +511,24 @@ static int dfu_srv_settings_set(const struct bt_mesh_model *mod, const char *nam
 				void *cb_arg)
 {
 	struct bt_mesh_dfu_srv *srv = mod->rt->user_data;
+	struct dfu_srv_persistent_state state;
 	ssize_t len;
 
-	if (len_rd < sizeof(srv->update)) {
+	if (len_rd < sizeof(state)) {
 		return -EINVAL;
 	}
 
-	len = read_cb(cb_arg, &srv->update, sizeof(srv->update));
+	len = read_cb(cb_arg, &state, sizeof(state));
 	if (len < 0) {
 		return len;
 	}
+
+	srv->update.effect = state.effect;
+	srv->update.phase = state.phase;
+	srv->update.ttl = state.ttl;
+	srv->update.idx = state.idx;
+	srv->update.timeout_base = state.timeout_base;
+	srv->update.meta = state.meta;
 
 	LOG_DBG("Recovered transfer (phase: %u, idx: %u)", srv->update.phase,
 		srv->update.idx);

--- a/subsys/bluetooth/mesh/dfu_srv.c
+++ b/subsys/bluetooth/mesh/dfu_srv.c
@@ -129,6 +129,11 @@ static void apply_rsp_sent(int err, void *cb_params)
 
 	store_state(srv);
 
+	if (srv->update.self_update) {
+		LOG_DBG("Self-update: deferring apply");
+		return;
+	}
+
 	err = srv->cb->apply(srv, &srv->imgs[srv->update.idx]);
 	if (err) {
 		srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
@@ -371,6 +376,7 @@ static int handle_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 		 * self-update. Skip the transfer phase and proceed to
 		 * verifying update.
 		 */
+		srv->update.self_update = bt_mesh_has_addr(ctx->addr);
 		status = BT_MESH_DFU_SUCCESS;
 		srv->update.idx = idx;
 		srv->blob.state.xfer.id = blob_id;
@@ -658,6 +664,27 @@ bool bt_mesh_dfu_srv_is_busy(const struct bt_mesh_dfu_srv *srv)
 	return srv->update.phase != BT_MESH_DFU_PHASE_IDLE &&
 	       srv->update.phase != BT_MESH_DFU_PHASE_TRANSFER_ERR &&
 	       srv->update.phase != BT_MESH_DFU_PHASE_VERIFY_FAIL;
+}
+
+void bt_mesh_dfu_srv_apply_deferred(struct bt_mesh_dfu_srv *srv)
+{
+	int err;
+
+	if (srv->update.phase != BT_MESH_DFU_PHASE_APPLYING) {
+		return;
+	}
+
+	if (!srv->cb->apply || srv->update.idx == UPDATE_IDX_NONE) {
+		srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
+		erase_state(srv);
+		return;
+	}
+
+	err = srv->cb->apply(srv, &srv->imgs[srv->update.idx]);
+	if (err) {
+		srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
+		erase_state(srv);
+	}
 }
 
 uint8_t bt_mesh_dfu_srv_progress(const struct bt_mesh_dfu_srv *srv)

--- a/subsys/bluetooth/mesh/dfu_srv.c
+++ b/subsys/bluetooth/mesh/dfu_srv.c
@@ -77,10 +77,27 @@ static void apply_rsp_sent(int err, void *cb_params)
 {
 	struct bt_mesh_dfu_srv *srv = cb_params;
 
-	if (err) {
-		/* return phase back to give client one more chance. */
+	if (err == -ETIMEDOUT) {
+		/* The response was transmitted N times without receiving a
+		 * segment ack. A spec-compliant client that received any
+		 * complete copy of the Firmware Update Status message
+		 * containing status Success and phase Applying Update has
+		 * accepted it as terminal for the Apply step (MshDFUv1.0
+		 * Section 7.1.2.6) and will not retry Update Apply. Proceed
+		 * with the apply so our state matches what the client
+		 * believes; if the client did miss the response, its retry
+		 * hits handle_apply's idempotent APPLYING branch.
+		 */
+		LOG_WRN("Apply response ack timeout, applying anyway");
+	} else if (err) {
+		/* Any other end-of-send error (buffer exhaustion, cancellation,
+		 * etc.) means the response was not successfully placed on air.
+		 * Revert the phase so a client retry of Update Apply is
+		 * accepted as a fresh apply request.
+		 */
 		srv->update.phase = BT_MESH_DFU_PHASE_VERIFY_OK;
-		LOG_WRN("Apply response failed, wait for retry (err %d)", err);
+		LOG_WRN("Apply response send failed (err %d), wait for retry",
+			err);
 		return;
 	}
 
@@ -106,6 +123,9 @@ static void apply_rsp_sent(int err, void *cb_params)
 static void apply_rsp_sending(uint16_t duration, int err, void *cb_params)
 {
 	if (err) {
+		/* Start-of-send errors are never -ETIMEDOUT, so this falls
+		 * into apply_rsp_sent's revert-to-VERIFY_OK branch.
+		 */
 		apply_rsp_sent(err, cb_params);
 	}
 }

--- a/subsys/bluetooth/mesh/dfu_srv.c
+++ b/subsys/bluetooth/mesh/dfu_srv.c
@@ -8,6 +8,7 @@
 #include "dfu.h"
 #include "blob.h"
 #include "access.h"
+#include "dfd_srv_internal.h"
 
 #define LOG_LEVEL CONFIG_BT_MESH_DFU_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -657,6 +658,13 @@ void bt_mesh_dfu_srv_applied(struct bt_mesh_dfu_srv *srv)
 
 	srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
 	store_state(srv);
+
+	/* Not set after a reboot, so the Distribution Server's own resume path
+	 * does not complete the distribution before the Confirm step re-runs.
+	 */
+	if (IS_ENABLED(CONFIG_BT_MESH_DFD_SRV) && srv->update.self_update) {
+		bt_mesh_dfd_srv_self_applied();
+	}
 }
 
 bool bt_mesh_dfu_srv_is_busy(const struct bt_mesh_dfu_srv *srv)

--- a/subsys/bluetooth/mesh/dfu_srv.c
+++ b/subsys/bluetooth/mesh/dfu_srv.c
@@ -129,6 +129,11 @@ static void apply_rsp_sent(int err, void *cb_params)
 
 	store_state(srv);
 
+	if (srv->update.self_update) {
+		LOG_DBG("Self-update: deferring apply");
+		return;
+	}
+
 	err = srv->cb->apply(srv, &srv->imgs[srv->update.idx]);
 	if (err) {
 		srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
@@ -363,6 +368,7 @@ static int handle_start(const struct bt_mesh_model *mod, struct bt_mesh_msg_ctx 
 	srv->update.ttl = ttl;
 	srv->update.timeout_base = timeout_base;
 	srv->update.meta = meta_checksum;
+	srv->update.self_update = bt_mesh_has_addr(ctx->addr);
 
 	io = NULL;
 	err = srv->cb->start(srv, &srv->imgs[idx], buf, &io);
@@ -658,6 +664,44 @@ bool bt_mesh_dfu_srv_is_busy(const struct bt_mesh_dfu_srv *srv)
 	return srv->update.phase != BT_MESH_DFU_PHASE_IDLE &&
 	       srv->update.phase != BT_MESH_DFU_PHASE_TRANSFER_ERR &&
 	       srv->update.phase != BT_MESH_DFU_PHASE_VERIFY_FAIL;
+}
+
+int bt_mesh_dfu_srv_apply_deferred(struct bt_mesh_dfu_srv *srv)
+{
+	int err;
+
+	if (srv->update.phase != BT_MESH_DFU_PHASE_APPLYING) {
+		return 0;
+	}
+
+	if (!srv->cb->apply || srv->update.idx == UPDATE_IDX_NONE) {
+		srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
+		erase_state(srv);
+		return -EINVAL;
+	}
+
+	err = srv->cb->apply(srv, &srv->imgs[srv->update.idx]);
+	if (err) {
+		srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
+		erase_state(srv);
+	}
+
+	return err;
+}
+
+void bt_mesh_dfu_srv_apply_cancel(struct bt_mesh_dfu_srv *srv)
+{
+	if (srv->update.phase != BT_MESH_DFU_PHASE_APPLYING) {
+		return;
+	}
+
+	LOG_DBG("");
+
+	/* Equivalent of receiving Firmware Update Cancel, which a self-target
+	 * cannot receive over the mesh from its own Distributor.
+	 */
+	srv->update.phase = BT_MESH_DFU_PHASE_IDLE;
+	erase_state(srv);
 }
 
 uint8_t bt_mesh_dfu_srv_progress(const struct bt_mesh_dfu_srv *srv)

--- a/tests/bsim/bluetooth/mesh/src/dfu_blob_common.c
+++ b/tests/bsim/bluetooth/mesh/src/dfu_blob_common.c
@@ -47,14 +47,39 @@ void common_sar_conf(uint16_t addr)
 {
 	int err;
 
-	/* Reconfigure SAR Transmitter state to change compile-time configuration to default
-	 * configuration.
+	/* Reconfigure SAR Transmitter and Receiver states so BLOB and DFU transfers
+	 * complete without segment retransmission storms in the bsim environment.
+	 *
+	 * Timing invariants that must hold to avoid false -ETIMEDOUT on TX and
+	 * unnecessary retransmit bursts:
+	 *   1. unicast retransmission timeout > max ACK_DELAY, so TX does not
+	 *      retransmit before RX has a chance to send the segment ack.
+	 *   2. unicast_retrans_count > 0 so the transport gets more than one
+	 *      chance to deliver a segmented message; single-attempt delivery
+	 *      is too fragile when multiple Targets respond concurrently to a
+	 *      multicast Firmware Update Apply and their unicast responses
+	 *      collide in bsim's 2.4 GHz airtime model.
+	 *
+	 * With the values below at ttl=1:
+	 *   - RX_SEG_INT_MS      = (0xf + 1) * 10  = 160 ms
+	 *   - max ACK_DELAY      = (0 * 2 + 3) * 160 / 2 = 240 ms
+	 *   - RETRANS_TIMEOUT@1  = (0xf + 1) * 25 = 400 ms
+	 *   - Total TX budget    = (2 + 1) * 400  = 1200 ms
+	 * so the ack always arrives well before the first retransmission fires
+	 * on the ideal path (no storm), but there are two extra attempts in
+	 * reserve when a segment collision drops the initial burst. Only
+	 * unacked segments are retransmitted (see seg_tx_send_unacked in
+	 * transport.c), so the retry cost scales with actual loss, not with
+	 * the retry budget.
+	 * With seg_thresh = 0x1f (max), the RX side does not retransmit acks,
+	 * so lowering ack_delay_inc only shortens ack latency without adding
+	 * airtime.
 	 */
 	struct bt_mesh_sar_tx tx_set = {
 		.seg_int_step = 1,
-		.unicast_retrans_count = 0,
-		.unicast_retrans_without_prog_count = 2,
-		.unicast_retrans_int_step = 7,
+		.unicast_retrans_count = 2,
+		.unicast_retrans_without_prog_count = 3,
+		.unicast_retrans_int_step = 0xf,
 		.unicast_retrans_int_inc = 1,
 		.multicast_retrans_count = 2,
 		.multicast_retrans_int = 3,
@@ -66,12 +91,9 @@ void common_sar_conf(uint16_t addr)
 		FAIL("Failed to configure SAR Transmitter state (err %d)", err);
 	}
 
-	/* Reconfigure SAR Receiver state so that the transport layer doesn't generate SegAcks too
-	 * frequently.
-	 */
 	struct bt_mesh_sar_rx rx_set = {
 		.seg_thresh = 0x1f,
-		.ack_delay_inc = 7,
+		.ack_delay_inc = 0,
 		.discard_timeout = 1,
 		.rx_seg_int_step = 0xf,
 		.ack_retrans_count = 1,

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -1274,10 +1274,15 @@ static void test_cli_stop(void)
 		}
 
 		bt_mesh_dfu_cli_apply(&dfu_cli);
+		/* Per MshDFUv1.0 Section 7.1.2.6, SUCCESS + APPLYING is a terminal
+		 * response to Update Apply. The target sends this response before
+		 * its (test-injected) apply callback stalls, so the client MUST
+		 * accept it and complete the Apply step successfully.
+		 */
 		if (k_sem_take(&dfu_cli_applied_sem, K_SECONDS(SEMAPHORE_TIMEOUT))) {
-			/* This will time out as target will reboot before applying */
+			FAIL("DFU Apply step did not complete");
 		}
-		ASSERT_EQUAL(BT_MESH_DFU_ERR_INTERNAL, dfu_cli_xfer.targets[0].status);
+		ASSERT_EQUAL(BT_MESH_DFU_SUCCESS, dfu_cli_xfer.targets[0].status);
 		ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLYING, dfu_cli_xfer.targets[0].phase);
 		break;
 	case BT_MESH_DFU_PHASE_APPLY_SUCCESS:

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -8,6 +8,7 @@
 #include "mesh/dfu_slot.h"
 #include "mesh/dfu.h"
 #include "mesh/blob.h"
+#include "mesh/access.h"
 #include "argparse.h"
 #include "dfu_blob_common.h"
 
@@ -56,6 +57,15 @@ static bool dfu_fail_confirm;
 static bool recover;
 static bool expect_fail;
 static enum bt_mesh_dfu_phase expected_stop_phase;
+
+/* When true, target_dfu_apply() emulates a device reboot in the middle of a
+ * self-update apply: the new firmware version is "installed" (target_fw_ver_curr
+ * is bumped to the new value) but bt_mesh_dfu_srv_applied() is NOT called, so
+ * the DFU Server's persisted phase stays APPLYING. On the next boot the DFD
+ * Server's start callback is expected to detect this and drive the confirm step
+ * to completion via bt_mesh_dfu_srv_applied() + bt_mesh_dfu_cli_confirm().
+ */
+static bool self_update_reboot_emulation;
 
 static void test_args_parse(int argc, char *argv[])
 {
@@ -253,6 +263,18 @@ static int target_dfu_apply(struct bt_mesh_dfu_srv *srv, const struct bt_mesh_df
 	}
 
 	ASSERT_TRUE(expect_dfu_apply);
+
+	if (self_update_reboot_emulation && srv->update.self_update) {
+		/* Simulate reboot in the middle of self-update apply:
+		 * install the new firmware image (bump the reported FWID) but
+		 * do NOT call bt_mesh_dfu_srv_applied(). The DFU Server's
+		 * persisted phase stays APPLYING; on the next boot the DFD
+		 * Server's start callback drives the resume path.
+		 */
+		target_fw_ver_curr = target_fw_ver_new;
+		k_sem_give(&dfu_ended);
+		return 0;
+	}
 
 	bt_mesh_dfu_srv_applied(srv);
 
@@ -486,7 +508,7 @@ static bool slot_add(const struct bt_mesh_dfu_slot **slot)
 	return true;
 }
 
-static void dist_dfu_start_and_confirm(void)
+static void dist_dfu_start(void)
 {
 	enum bt_mesh_dfd_status status;
 	struct bt_mesh_dfd_start_params start_params = {
@@ -501,13 +523,18 @@ static void dist_dfu_start_and_confirm(void)
 
 	status = bt_mesh_dfd_srv_start(&dfd_srv, &start_params);
 	ASSERT_EQUAL(BT_MESH_DFD_SUCCESS, status);
+}
+
+static void dist_dfu_start_and_confirm(void)
+{
+	enum bt_mesh_dfu_status expected_status;
+	enum bt_mesh_dfu_phase expected_phase;
+
+	dist_dfu_start();
 
 	if (k_sem_take(&dfu_dist_ended, K_SECONDS(DFU_TIMEOUT))) {
 		FAIL("DFU timed out");
 	}
-
-	enum bt_mesh_dfu_status expected_status;
-	enum bt_mesh_dfu_phase expected_phase;
 
 	if (dfu_fail_confirm) {
 		ASSERT_EQUAL(BT_MESH_DFD_PHASE_FAILED, dfd_srv.phase);
@@ -520,21 +547,21 @@ static void dist_dfu_start_and_confirm(void)
 	}
 
 	for (int i = 0; i < dfu_targets_cnt; i++) {
+		enum bt_mesh_dfu_phase target_expected_phase = expected_phase;
+
 		ASSERT_EQUAL(expected_status, dfd_srv.targets[i].status);
 
-		if (dfd_srv.targets[i].effect == BT_MESH_DFU_EFFECT_UNPROV) {
-			/* If device should unprovision itself after the update, the phase won't
-			 * change. If phase changes, DFU failed.
+		if (!dfu_fail_confirm &&
+		    dfd_srv.targets[i].effect == BT_MESH_DFU_EFFECT_UNPROV) {
+			/* If device should unprovision itself after the update, the phase
+			 * does not progress to APPLY_SUCCESS: the target reboots without
+			 * sending a Firmware Update Status with the final phase, so on the
+			 * Distributor it stays in APPLYING.
 			 */
-			if  (dfu_fail_confirm) {
-				ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLY_FAIL,
-					     dfd_srv.targets[i].phase);
-			} else {
-				ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLYING, dfd_srv.targets[i].phase);
-			}
-		} else {
-			ASSERT_EQUAL(expected_phase, dfd_srv.targets[i].phase);
+			target_expected_phase = BT_MESH_DFU_PHASE_APPLYING;
 		}
+
+		ASSERT_EQUAL(target_expected_phase, dfd_srv.targets[i].phase);
 	}
 }
 
@@ -560,11 +587,18 @@ static void test_dist_dfu(void)
 	PASS();
 }
 
-static void test_dist_dfu_self_update(void)
+static void dist_self_update_pre_reboot(void)
 {
 	enum bt_mesh_dfd_status status;
 
-	ASSERT_TRUE(dfu_targets_cnt > 0);
+	/* First run: perform the distribution up to the deferred self-target
+	 * apply and simulate a reboot by returning from target_dfu_apply()
+	 * without calling bt_mesh_dfu_srv_applied(). At that point the DFD
+	 * Server stays in APPLYING_UPDATE with state persisted, and the DFU
+	 * Server stays in APPLYING with state persisted. The next boot must
+	 * resume from that state and drive the distribution to COMPLETED.
+	 */
+	self_update_reboot_emulation = true;
 
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
 	bt_mesh_device_setup(&prov, &dist_comp_self_update);
@@ -581,11 +615,78 @@ static void test_dist_dfu_self_update(void)
 		ASSERT_EQUAL(BT_MESH_DFD_SUCCESS, status);
 	}
 
-	dist_dfu_start_and_confirm();
+	dist_dfu_start();
 
-	/* Check that DFU finished on distributor. */
+	/* Wait for the deferred self-target apply callback to run. It sets
+	 * target_fw_ver_curr = target_fw_ver_new (image "installed") and
+	 * returns without calling bt_mesh_dfu_srv_applied() - emulating a
+	 * reboot that happens before the DFU Server transitions to IDLE.
+	 */
 	if (k_sem_take(&dfu_ended, K_SECONDS(DFU_TIMEOUT))) {
-		FAIL("firmware was not applied");
+		FAIL("deferred apply callback did not fire");
+	}
+
+	/* Pre-reboot invariants that must be persisted for the resume path:
+	 *   - DFD Server is still in APPLYING_UPDATE (dfu_confirmed()
+	 *     intentionally skipped the transition to COMPLETED because the
+	 *     local DFU Server is still in APPLYING).
+	 *   - Local DFU Server is in APPLYING (apply callback returned
+	 *     without calling bt_mesh_dfu_srv_applied()).
+	 */
+	ASSERT_EQUAL(BT_MESH_DFD_PHASE_APPLYING_UPDATE, dfd_srv.phase);
+	ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLYING, dfu_srv.update.phase);
+}
+
+static void dist_self_update_post_reboot(void)
+{
+	/* Second (recover) run: no fresh provisioning or transfer. The DFD
+	 * Server, DFU Client and DFU Server states are all restored from
+	 * persistent storage during bt_mesh_device_setup(). The DFD Server's
+	 * start callback then transitions the local DFU Server out of APPLYING
+	 * (bt_mesh_dfu_srv_applied()) and resumes the confirm step
+	 * (bt_mesh_dfu_cli_confirm()), which polls all targets for their new
+	 * FWID and drives the distribution to BT_MESH_DFD_PHASE_COMPLETED.
+	 *
+	 * Emulate the effect of running the new firmware image on the
+	 * distributor by bumping target_fw_ver_curr to the value that the
+	 * metadata check callback stored in target_fw_ver_new on the previous
+	 * run. It has to be set before bt_mesh_device_setup() so the DFU
+	 * Server reports the new FWID when the resumed confirm step polls it.
+	 */
+	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
+
+	/* The FWID persisted with the DFU slot equals the metadata committed
+	 * by slot_add() on the first run. See slot_add() for the value: 4
+	 * bytes {0xAA, 0xBB, 0xCC, 0xDD} interpreted as a little-endian
+	 * uint32_t.
+	 */
+	target_fw_ver_new = 0xDDCCBBAAU;
+	target_fw_ver_curr = target_fw_ver_new;
+
+	bt_mesh_device_setup(&prov, &dist_comp_self_update);
+
+	/* Wait for the resumed confirm step to reach COMPLETED. */
+	if (k_sem_take(&dfu_dist_ended, K_SECONDS(DFU_TIMEOUT))) {
+		FAIL("Resumed self-update did not complete");
+	}
+
+	ASSERT_EQUAL(BT_MESH_DFD_PHASE_COMPLETED, dfd_srv.phase);
+	ASSERT_EQUAL(BT_MESH_DFU_PHASE_IDLE, dfu_srv.update.phase);
+	for (int i = 0; i < dfu_targets_cnt; i++) {
+		ASSERT_EQUAL(BT_MESH_DFU_SUCCESS, dfd_srv.targets[i].status);
+		ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLY_SUCCESS,
+			     dfd_srv.targets[i].phase);
+	}
+}
+
+static void test_dist_dfu_self_update(void)
+{
+	ASSERT_TRUE(dfu_targets_cnt > 0);
+
+	if (recover) {
+		dist_self_update_post_reboot();
+	} else {
+		dist_self_update_pre_reboot();
 	}
 
 	PASS();
@@ -804,9 +905,33 @@ static void target_test_effect(enum bt_mesh_dfu_effect effect)
 	}
 }
 
+static void target_dfu_no_change_post_reboot(void)
+{
+	/* Recover run of the self-update mult_targets scenario: this device
+	 * is a remote DFU target that already completed its own apply on the
+	 * previous run. On boot it is re-provisioned from settings and merely
+	 * needs to respond to the Firmware Update Information Get poll that
+	 * the distributor sends during the resumed confirm step. Emulate
+	 * having booted the new firmware image by initializing
+	 * target_fw_ver_curr to the FWID the distributor's slot contains
+	 * before bt_mesh_device_setup().
+	 */
+	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
+
+	/* See dist_self_update_post_reboot() for the origin of this constant. */
+	target_fw_ver_new = 0xDDCCBBAAU;
+	target_fw_ver_curr = target_fw_ver_new;
+
+	bt_mesh_device_setup(&prov, &target_comp);
+}
+
 static void test_target_dfu_no_change(void)
 {
-	target_test_effect(BT_MESH_DFU_EFFECT_NONE);
+	if (recover) {
+		target_dfu_no_change_post_reboot();
+	} else {
+		target_test_effect(BT_MESH_DFU_EFFECT_NONE);
+	}
 
 	PASS();
 }

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -166,9 +166,16 @@ static int dist_fw_send(struct bt_mesh_dfd_srv *srv,
 	return 0;
 }
 
+/* Number of times the DFD Server reported Distribution Phase Completed. */
+static int dist_completed_cnt;
+
 static void dist_phase_changed(struct bt_mesh_dfd_srv *srv, enum bt_mesh_dfd_phase phase)
 {
 	static enum bt_mesh_dfd_phase prev_phase;
+
+	if (phase == BT_MESH_DFD_PHASE_COMPLETED) {
+		dist_completed_cnt++;
+	}
 
 	if (phase == BT_MESH_DFD_PHASE_COMPLETED ||
 	    phase == BT_MESH_DFD_PHASE_FAILED) {
@@ -821,6 +828,50 @@ static void test_dist_dfu_self_update_apply_err(void)
 	}
 
 	ASSERT_EQUAL(BT_MESH_DFD_PHASE_FAILED, dfd_srv.phase);
+
+	PASS();
+}
+
+static void test_dist_dfu_self_update_apply_sync(void)
+{
+	ASSERT_TRUE(dfu_targets_cnt > 0);
+
+	/* No emulation flag, so the apply callback calls
+	 * bt_mesh_dfu_srv_applied() and returns. The distribution completes
+	 * while dfu_confirmed() is still on the stack, and must be reported
+	 * once rather than by both the notification and dfu_confirmed().
+	 */
+	dist_self_update_distribute();
+
+	ASSERT_EQUAL(BT_MESH_DFD_PHASE_COMPLETED, dfd_srv.phase);
+	ASSERT_EQUAL(BT_MESH_DFU_PHASE_IDLE, dfu_srv.update.phase);
+	ASSERT_EQUAL(1, dist_completed_cnt);
+
+	PASS();
+}
+
+static void test_dist_dfu_self_update_apply_async(void)
+{
+	ASSERT_TRUE(dfu_targets_cnt > 0);
+
+	/* The apply callback installs the image and returns without calling
+	 * bt_mesh_dfu_srv_applied(), as an application that installs
+	 * asynchronously would. The distribution must stay in APPLYING_UPDATE
+	 * until the application reports completion, and must then reach
+	 * COMPLETED without a reboot.
+	 */
+	self_update_reboot_emulation = true;
+
+	dist_self_update_distribute();
+
+	ASSERT_EQUAL(BT_MESH_DFD_PHASE_APPLYING_UPDATE, dfd_srv.phase);
+	ASSERT_EQUAL(0, dist_completed_cnt);
+
+	bt_mesh_dfu_srv_applied(&dfu_srv);
+
+	ASSERT_EQUAL(BT_MESH_DFD_PHASE_COMPLETED, dfd_srv.phase);
+	ASSERT_EQUAL(BT_MESH_DFU_PHASE_IDLE, dfu_srv.update.phase);
+	ASSERT_EQUAL(1, dist_completed_cnt);
 
 	PASS();
 }
@@ -1964,6 +2015,10 @@ static const struct bst_test_instance test_dfu[] = {
 		  "Distributor self-update reboots before the image is applied"),
 	TEST_CASE(dist, dfu_self_update_apply_err,
 		  "Distributor self-update where the apply callback fails"),
+	TEST_CASE(dist, dfu_self_update_apply_async,
+		  "Distributor self-update applied asynchronously after the callback"),
+	TEST_CASE(dist, dfu_self_update_apply_sync,
+		  "Distributor self-update applied inside the callback"),
 	TEST_CASE(dist, dfu_self_update_remote_fail,
 		  "Distributor self-update completes while a remote target fails"),
 	TEST_CASE(dist, dfu_slot_create, "Distributor creates image slots"),

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -1281,10 +1281,15 @@ static void test_cli_stop(void)
 		}
 
 		bt_mesh_dfu_cli_apply(&dfu_cli);
+		/* Per MshDFUv1.0 Section 7.1.2.6, SUCCESS + APPLYING is a terminal
+		 * response to Update Apply. The target sends this response before
+		 * its (test-injected) apply callback stalls, so the client MUST
+		 * accept it and complete the Apply step successfully.
+		 */
 		if (k_sem_take(&dfu_cli_applied_sem, K_SECONDS(SEMAPHORE_TIMEOUT))) {
-			/* This will time out as target will reboot before applying */
+			FAIL("DFU Apply step did not complete");
 		}
-		ASSERT_EQUAL(BT_MESH_DFU_ERR_INTERNAL, dfu_cli_xfer.targets[0].status);
+		ASSERT_EQUAL(BT_MESH_DFU_SUCCESS, dfu_cli_xfer.targets[0].status);
 		ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLYING, dfu_cli_xfer.targets[0].phase);
 		break;
 	case BT_MESH_DFU_PHASE_APPLY_SUCCESS:

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -8,6 +8,7 @@
 #include "mesh/dfu_slot.h"
 #include "mesh/dfu.h"
 #include "mesh/blob.h"
+#include "mesh/access.h"
 #include "bsim_args_runner.h"
 #include "dfu_blob_common.h"
 
@@ -62,6 +63,25 @@ static void expected_stop_phase_found(char *argv, int offset)
 {
 	expected_stop_phase = (enum bt_mesh_dfu_phase)expected_stop_phase_param;
 }
+
+/* When true, target_dfu_apply() emulates a reboot mid-apply: the new firmware
+ * version is installed but bt_mesh_dfu_srv_applied() is not called, leaving the
+ * persisted phase at APPLYING for the next boot to resume.
+ */
+static bool self_update_reboot_emulation;
+
+/* When true, target_dfu_apply() emulates power loss before the image swap:
+ * the reported FWID is left at the old value and bt_mesh_dfu_srv_applied() is
+ * not called, so the DFU Server's persisted phase stays APPLYING while the
+ * node keeps running the pre-update image. On the next boot the resumed
+ * confirm step must detect the FWID mismatch and fail the distribution.
+ */
+static bool self_update_apply_fail;
+
+/* When true, target_dfu_apply() rejects the self-target image by returning an
+ * error, emulating an application that refuses to install it.
+ */
+static bool self_update_apply_err;
 
 static void test_args_parse(int argc, char *argv[])
 {
@@ -153,7 +173,11 @@ static void dist_phase_changed(struct bt_mesh_dfd_srv *srv, enum bt_mesh_dfd_pha
 	if (phase == BT_MESH_DFD_PHASE_COMPLETED ||
 	    phase == BT_MESH_DFD_PHASE_FAILED) {
 		if (phase == BT_MESH_DFD_PHASE_FAILED) {
-			ASSERT_EQUAL(BT_MESH_DFD_PHASE_APPLYING_UPDATE, prev_phase);
+			/* On a recovery boot the phase history starts fresh,
+			 * so prev_phase has not been observed yet.
+			 */
+			ASSERT_TRUE(prev_phase == BT_MESH_DFD_PHASE_APPLYING_UPDATE ||
+				    (recover && prev_phase == BT_MESH_DFD_PHASE_IDLE));
 		}
 
 		k_sem_give(&dfu_dist_ended);
@@ -260,6 +284,33 @@ static int target_dfu_apply(struct bt_mesh_dfu_srv *srv, const struct bt_mesh_df
 	}
 
 	ASSERT_TRUE(expect_dfu_apply);
+
+	if (self_update_apply_err && srv->update.self_update) {
+		k_sem_give(&dfu_ended);
+		return -EIO;
+	}
+
+	if (self_update_apply_fail && srv->update.self_update) {
+		/* Emulate power loss before the image swap: unlike the
+		 * self_update_reboot_emulation path below, target_fw_ver_curr
+		 * is deliberately NOT bumped, so the node keeps reporting the
+		 * old FWID after the reboot.
+		 */
+		k_sem_give(&dfu_ended);
+		return 0;
+	}
+
+	if (self_update_reboot_emulation && srv->update.self_update) {
+		/* Simulate reboot in the middle of self-update apply:
+		 * install the new firmware image (bump the reported FWID) but
+		 * do NOT call bt_mesh_dfu_srv_applied(). The DFU Server's
+		 * persisted phase stays APPLYING; on the next boot the DFD
+		 * Server's start callback drives the resume path.
+		 */
+		target_fw_ver_curr = target_fw_ver_new;
+		k_sem_give(&dfu_ended);
+		return 0;
+	}
 
 	bt_mesh_dfu_srv_applied(srv);
 
@@ -493,7 +544,7 @@ static bool slot_add(const struct bt_mesh_dfu_slot **slot)
 	return true;
 }
 
-static void dist_dfu_start_and_confirm(void)
+static void dist_dfu_start(void)
 {
 	enum bt_mesh_dfd_status status;
 	struct bt_mesh_dfd_start_params start_params = {
@@ -508,13 +559,18 @@ static void dist_dfu_start_and_confirm(void)
 
 	status = bt_mesh_dfd_srv_start(&dfd_srv, &start_params);
 	ASSERT_EQUAL(BT_MESH_DFD_SUCCESS, status);
+}
+
+static void dist_dfu_start_and_confirm(void)
+{
+	enum bt_mesh_dfu_status expected_status;
+	enum bt_mesh_dfu_phase expected_phase;
+
+	dist_dfu_start();
 
 	if (k_sem_take(&dfu_dist_ended, K_SECONDS(DFU_TIMEOUT))) {
 		FAIL("DFU timed out");
 	}
-
-	enum bt_mesh_dfu_status expected_status;
-	enum bt_mesh_dfu_phase expected_phase;
 
 	if (dfu_fail_confirm) {
 		ASSERT_EQUAL(BT_MESH_DFD_PHASE_FAILED, dfd_srv.phase);
@@ -527,21 +583,21 @@ static void dist_dfu_start_and_confirm(void)
 	}
 
 	for (int i = 0; i < dfu_targets_cnt; i++) {
+		enum bt_mesh_dfu_phase target_expected_phase = expected_phase;
+
 		ASSERT_EQUAL(expected_status, dfd_srv.targets[i].status);
 
-		if (dfd_srv.targets[i].effect == BT_MESH_DFU_EFFECT_UNPROV) {
-			/* If device should unprovision itself after the update, the phase won't
-			 * change. If phase changes, DFU failed.
+		if (!dfu_fail_confirm &&
+		    dfd_srv.targets[i].effect == BT_MESH_DFU_EFFECT_UNPROV) {
+			/* If device should unprovision itself after the update, the phase
+			 * does not progress to APPLY_SUCCESS: the target reboots without
+			 * sending a Firmware Update Status with the final phase, so on the
+			 * Distributor it stays in APPLYING.
 			 */
-			if  (dfu_fail_confirm) {
-				ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLY_FAIL,
-					     dfd_srv.targets[i].phase);
-			} else {
-				ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLYING, dfd_srv.targets[i].phase);
-			}
-		} else {
-			ASSERT_EQUAL(expected_phase, dfd_srv.targets[i].phase);
+			target_expected_phase = BT_MESH_DFU_PHASE_APPLYING;
 		}
+
+		ASSERT_EQUAL(target_expected_phase, dfd_srv.targets[i].phase);
 	}
 }
 
@@ -567,11 +623,16 @@ static void test_dist_dfu(void)
 	PASS();
 }
 
-static void test_dist_dfu_self_update(void)
+/* Shared first-run body for the self-update tests: provision and configure the
+ * two-element distributor, upload a slot, add the co-located Firmware Update
+ * Server (DIST_ADDR + 1) plus any remote targets as Receivers, and run the
+ * distribution until the deferred self-target apply callback fires. The
+ * callback's behavior is selected by the caller through
+ * self_update_reboot_emulation / self_update_apply_fail.
+ */
+static void dist_self_update_distribute(void)
 {
 	enum bt_mesh_dfd_status status;
-
-	ASSERT_TRUE(dfu_targets_cnt > 0);
 
 	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
 	bt_mesh_device_setup(&prov, &dist_comp_self_update);
@@ -588,11 +649,228 @@ static void test_dist_dfu_self_update(void)
 		ASSERT_EQUAL(BT_MESH_DFD_SUCCESS, status);
 	}
 
-	dist_dfu_start_and_confirm();
+	dist_dfu_start();
 
-	/* Check that DFU finished on distributor. */
+	/* Wait for the deferred self-target apply callback to run. */
 	if (k_sem_take(&dfu_ended, K_SECONDS(DFU_TIMEOUT))) {
-		FAIL("firmware was not applied");
+		FAIL("deferred apply callback did not fire");
+	}
+}
+
+static void dist_self_update_pre_reboot(void)
+{
+	/* First run: perform the distribution up to the deferred self-target
+	 * apply and simulate a reboot by returning from target_dfu_apply()
+	 * without calling bt_mesh_dfu_srv_applied(). At that point the DFD
+	 * Server stays in APPLYING_UPDATE with state persisted, and the DFU
+	 * Server stays in APPLYING with state persisted. The next boot must
+	 * resume from that state and drive the distribution to COMPLETED.
+	 */
+	self_update_reboot_emulation = true;
+
+	dist_self_update_distribute();
+
+	/* Pre-reboot invariants that must be persisted for the resume path:
+	 *   - DFD Server is still in APPLYING_UPDATE (dfu_confirmed()
+	 *     intentionally skipped the transition to COMPLETED because the
+	 *     local DFU Server is still in APPLYING).
+	 *   - Local DFU Server is in APPLYING (apply callback returned
+	 *     without calling bt_mesh_dfu_srv_applied()).
+	 */
+	ASSERT_EQUAL(BT_MESH_DFD_PHASE_APPLYING_UPDATE, dfd_srv.phase);
+	ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLYING, dfu_srv.update.phase);
+}
+
+static void dist_self_update_post_reboot(void)
+{
+	/* Second (recover) run: no fresh provisioning or transfer. The DFD
+	 * Server, DFU Client and DFU Server states are all restored from
+	 * persistent storage during bt_mesh_device_setup(). The DFD Server's
+	 * start callback then transitions the local DFU Server out of APPLYING
+	 * (bt_mesh_dfu_srv_applied()) and resumes the confirm step
+	 * (bt_mesh_dfu_cli_confirm()), which polls all targets for their new
+	 * FWID and drives the distribution to BT_MESH_DFD_PHASE_COMPLETED.
+	 *
+	 * Emulate the effect of running the new firmware image on the
+	 * distributor by bumping target_fw_ver_curr to the value that the
+	 * metadata check callback stored in target_fw_ver_new on the previous
+	 * run. It has to be set before bt_mesh_device_setup() so the DFU
+	 * Server reports the new FWID when the resumed confirm step polls it.
+	 */
+	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
+
+	/* The FWID persisted with the DFU slot equals the metadata committed
+	 * by slot_add() on the first run. See slot_add() for the value: 4
+	 * bytes {0xAA, 0xBB, 0xCC, 0xDD} interpreted as a little-endian
+	 * uint32_t.
+	 */
+	target_fw_ver_new = 0xDDCCBBAAU;
+	target_fw_ver_curr = target_fw_ver_new;
+
+	bt_mesh_device_setup(&prov, &dist_comp_self_update);
+
+	/* Wait for the resumed confirm step to reach COMPLETED. */
+	if (k_sem_take(&dfu_dist_ended, K_SECONDS(DFU_TIMEOUT))) {
+		FAIL("Resumed self-update did not complete");
+	}
+
+	ASSERT_EQUAL(BT_MESH_DFD_PHASE_COMPLETED, dfd_srv.phase);
+	ASSERT_EQUAL(BT_MESH_DFU_PHASE_IDLE, dfu_srv.update.phase);
+	for (int i = 0; i < dfu_targets_cnt; i++) {
+		ASSERT_EQUAL(BT_MESH_DFU_SUCCESS, dfd_srv.targets[i].status);
+		ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLY_SUCCESS,
+			     dfd_srv.targets[i].phase);
+	}
+}
+
+static void test_dist_dfu_self_update(void)
+{
+	ASSERT_TRUE(dfu_targets_cnt > 0);
+
+	if (recover) {
+		dist_self_update_post_reboot();
+	} else {
+		dist_self_update_pre_reboot();
+	}
+
+	PASS();
+}
+
+static void dist_self_update_fail_pre_reboot(void)
+{
+	/* First run: identical to dist_self_update_pre_reboot() except that the
+	 * deferred apply callback emulates power loss BEFORE the image swap -
+	 * it neither installs the new image nor calls
+	 * bt_mesh_dfu_srv_applied(). The persisted state is the same in both
+	 * cases; only the firmware the node comes back up with differs, which
+	 * is exactly what the resumed confirm step has to distinguish.
+	 */
+	self_update_apply_fail = true;
+
+	dist_self_update_distribute();
+
+	ASSERT_EQUAL(BT_MESH_DFD_PHASE_APPLYING_UPDATE, dfd_srv.phase);
+	ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLYING, dfu_srv.update.phase);
+}
+
+static void dist_self_update_fail_post_reboot(void)
+{
+	/* Second (recover) run: state is restored from flash and dfd_srv_model_start()
+	 * resumes the confirm step, exactly as in
+	 * dist_self_update_post_reboot(). The difference is that
+	 * target_fw_ver_curr keeps its old value (0xDEADBEEF) instead of being
+	 * bumped to target_fw_ver_new, so the self-target answers Firmware
+	 * Update Information Get with the pre-update FWID.
+	 *
+	 * No image in the Images List then matches the distributed Firmware ID,
+	 * so handle_info_status() takes the confirm-procedure termination path,
+	 * marks the Receiver APPLY_FAIL, and the distribution ends in FAILED
+	 * rather than reporting success against the old image.
+	 */
+	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
+
+	/* Matches the slot metadata committed by slot_add() on the first run;
+	 * see dist_self_update_post_reboot() for the origin of this constant.
+	 */
+	target_fw_ver_new = 0xDDCCBBAAU;
+
+	bt_mesh_device_setup(&prov, &dist_comp_self_update);
+
+	if (k_sem_take(&dfu_dist_ended, K_SECONDS(DFU_TIMEOUT))) {
+		FAIL("Resumed self-update did not end");
+	}
+
+	ASSERT_EQUAL(BT_MESH_DFD_PHASE_FAILED, dfd_srv.phase);
+	ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLY_FAIL, dfd_srv.targets[0].phase);
+}
+
+static void test_dist_dfu_self_update_apply_fail(void)
+{
+	ASSERT_TRUE(dfu_targets_cnt > 0);
+
+	if (recover) {
+		dist_self_update_fail_post_reboot();
+	} else {
+		dist_self_update_fail_pre_reboot();
+	}
+
+	PASS();
+}
+
+static void test_dist_dfu_self_update_apply_err(void)
+{
+	ASSERT_TRUE(dfu_targets_cnt > 0);
+
+	/* The self-target's apply callback returns an error, so the deferred
+	 * apply never installs the image. The DFD Server must report the
+	 * distribution as FAILED rather than COMPLETED: the local Firmware
+	 * Update Server leaves APPLYING for IDLE on a rejected apply
+	 * (MshDFUv1.0 Section 6.1.2.3), which is indistinguishable from a
+	 * successful apply by phase alone.
+	 */
+	self_update_apply_err = true;
+
+	dist_self_update_distribute();
+
+	/* dfu_ended is given from inside the apply callback, before it returns
+	 * the error, so wait for the distribution itself to reach a terminal
+	 * phase before asserting.
+	 */
+	if (k_sem_take(&dfu_dist_ended, K_SECONDS(DFU_TIMEOUT))) {
+		FAIL("Distribution did not end");
+	}
+
+	ASSERT_EQUAL(BT_MESH_DFD_PHASE_FAILED, dfd_srv.phase);
+
+	PASS();
+}
+
+static void dist_self_update_remote_fail_post_reboot(void)
+{
+	/* Second (recover) run, mixed outcome: the co-located Firmware Update
+	 * Server applied the image and reports the new FWID, while the remote
+	 * target was started with fail-confirm=1 and keeps reporting the old
+	 * one.
+	 *
+	 * Per MshDFUv1.0 Section 7.1.2.9 the Confirm Update On Target Nodes
+	 * procedure completes successfully if at least one receiver has
+	 * Retrieved Update Phase equal to Apply Success, so the distribution
+	 * must reach COMPLETED on the strength of the self-target alone. The
+	 * per-receiver entries still have to record the individual outcomes.
+	 */
+	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
+
+	/* See dist_self_update_post_reboot() for the origin of this constant. */
+	target_fw_ver_new = 0xDDCCBBAAU;
+	target_fw_ver_curr = target_fw_ver_new;
+
+	bt_mesh_device_setup(&prov, &dist_comp_self_update);
+
+	if (k_sem_take(&dfu_dist_ended, K_SECONDS(DFU_TIMEOUT))) {
+		FAIL("Resumed self-update did not complete");
+	}
+
+	ASSERT_EQUAL(BT_MESH_DFD_PHASE_COMPLETED, dfd_srv.phase);
+	ASSERT_EQUAL(BT_MESH_DFU_PHASE_IDLE, dfu_srv.update.phase);
+
+	/* Receivers are added self-target first, remote targets after. */
+	ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLY_SUCCESS, dfd_srv.targets[0].phase);
+	ASSERT_EQUAL(BT_MESH_DFU_SUCCESS, dfd_srv.targets[0].status);
+	ASSERT_EQUAL(BT_MESH_DFU_PHASE_APPLY_FAIL, dfd_srv.targets[1].phase);
+}
+
+static void test_dist_dfu_self_update_remote_fail(void)
+{
+	ASSERT_TRUE(dfu_targets_cnt > 1);
+
+	if (recover) {
+		dist_self_update_remote_fail_post_reboot();
+	} else {
+		/* The first run is identical to the plain self-update case;
+		 * only the remote target behaves differently, driven by its
+		 * own fail-confirm argument.
+		 */
+		dist_self_update_pre_reboot();
 	}
 
 	PASS();
@@ -811,9 +1089,39 @@ static void target_test_effect(enum bt_mesh_dfu_effect effect)
 	}
 }
 
+static void target_dfu_no_change_post_reboot(void)
+{
+	/* Recover run of the self-update mult_targets scenario: this device
+	 * is a remote DFU target that already completed its own apply on the
+	 * previous run. On boot it is re-provisioned from settings and merely
+	 * needs to respond to the Firmware Update Information Get poll that
+	 * the distributor sends during the resumed confirm step. Emulate
+	 * having booted the new firmware image by initializing
+	 * target_fw_ver_curr to the FWID the distributor's slot contains
+	 * before bt_mesh_device_setup().
+	 *
+	 * With fail-confirm=1 the old FWID is kept instead, so this target
+	 * fails the resumed confirm step while the distributor's self-target
+	 * succeeds.
+	 */
+	bt_mesh_test_cfg_set(NULL, WAIT_TIME);
+
+	/* See dist_self_update_post_reboot() for the origin of this constant. */
+	target_fw_ver_new = 0xDDCCBBAAU;
+	if (!dfu_fail_confirm) {
+		target_fw_ver_curr = target_fw_ver_new;
+	}
+
+	bt_mesh_device_setup(&prov, &target_comp);
+}
+
 static void test_target_dfu_no_change(void)
 {
-	target_test_effect(BT_MESH_DFU_EFFECT_NONE);
+	if (recover) {
+		target_dfu_no_change_post_reboot();
+	} else {
+		target_test_effect(BT_MESH_DFU_EFFECT_NONE);
+	}
 
 	PASS();
 }
@@ -1652,6 +1960,12 @@ static void test_pre_init(void)
 static const struct bst_test_instance test_dfu[] = {
 	TEST_CASE(dist, dfu, "Distributor performs DFU"),
 	TEST_CASE(dist, dfu_self_update, "Distributor performs DFU with self update"),
+	TEST_CASE(dist, dfu_self_update_apply_fail,
+		  "Distributor self-update reboots before the image is applied"),
+	TEST_CASE(dist, dfu_self_update_apply_err,
+		  "Distributor self-update where the apply callback fails"),
+	TEST_CASE(dist, dfu_self_update_remote_fail,
+		  "Distributor self-update completes while a remote target fails"),
 	TEST_CASE(dist, dfu_slot_create, "Distributor creates image slots"),
 	TEST_CASE(dist, dfu_slot_create_recover,
 		      "Distributor recovers created image slots from persistent storage"),

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update.sh
@@ -4,5 +4,71 @@
 
 source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
+# Test verifies that the Firmware Distribution Server can perform a self-update
+# and survive a reboot in the middle of the local Firmware Update Server's
+# apply callback. Persisted state must be restored on the next boot and drive
+# the distribution procedure to BT_MESH_DFD_PHASE_COMPLETED.
+#
+# Per MshDFUv1.0 Section 2.1.1, the Firmware Update Server (Target role) must
+# reside on a different element than the Firmware Distribution Server
+# (Distributor role) when the two are co-located. The Distributor node
+# therefore has two elements:
+#   - Element 1 (DIST_ADDR):     Config, SAR Config, Firmware Distribution
+#                                Server and the internal Firmware Update
+#                                Client + BLOB Transfer Client that drive
+#                                the transfer.
+#   - Element 2 (DIST_ADDR + 1): Firmware Update Server + BLOB Transfer Server
+#                                (the self-target that receives the image).
+#
+# Test procedure (first run, recover=0):
+# 1. Distributor is provisioned with the self-update composition and configured
+#    (app key bound to the Client models on element 1 and to the Server models
+#    on element 2).
+# 2. Distributor uploads a firmware slot.
+# 3. Distributor adds its own element 2 address (DIST_ADDR + 1) as the sole
+#    Receiver of the distribution.
+# 4. Distribution is started. Transfer and Apply steps run to completion. The
+#    self-target reports APPLYING for the Apply step (deferred apply) and the
+#    DFU Client's confirm step excuses it as expected.
+# 5. Once the confirm step completes, the DFD Server invokes the deferred
+#    self-target apply callback. The test's apply callback emulates a device
+#    reboot by:
+#      - updating the reported FWID (target_fw_ver_curr = target_fw_ver_new),
+#      - releasing the dfu_ended semaphore so the test main can proceed,
+#      - returning without calling bt_mesh_dfu_srv_applied().
+# 6. Test asserts pre-reboot invariants:
+#      - DFD Server phase == BT_MESH_DFD_PHASE_APPLYING_UPDATE (state persisted).
+#      - Local DFU Server phase == BT_MESH_DFU_PHASE_APPLYING (state persisted).
+# 7. Test PASSes and the bsim process exits, flushing persistent state to flash.
+#
+# Test procedure (second run, recover=1):
+# 8. The bsim process starts again with the same flash contents (no
+#    -flash_erase). No fresh provisioning, no receiver adds, no distribution
+#    start.
+# 9. target_fw_ver_curr is set to the new FWID before bt_mesh_device_setup() to
+#    emulate the effect of running the new firmware image.
+# 10. bt_mesh_device_setup() loads persistent state (DFD Server target list and
+#    distribution parameters, DFU Client xfer state, DFU Server update state)
+#    and invokes dfd_srv_start(), which:
+#      - transitions the local DFU Server from APPLYING to IDLE
+#        (bt_mesh_dfu_srv_applied()),
+#      - resumes the confirm step (bt_mesh_dfu_cli_confirm()).
+# 11. The resumed confirm step polls the self-target's Firmware Update
+#    Information Get, which now responds with the new FWID.
+# 12. DFU Client confirms the target, dfu_confirmed() runs, DFD phase
+#    transitions to BT_MESH_DFD_PHASE_COMPLETED, and dfu_dist_ended fires.
+# 13. Test asserts final invariants:
+#      - DFD Server phase == BT_MESH_DFD_PHASE_COMPLETED.
+#      - Local DFU Server phase == BT_MESH_DFU_PHASE_IDLE.
+#      - Self-target's targets[] entry phase == BT_MESH_DFU_PHASE_APPLY_SUCCESS
+#        with status BT_MESH_DFU_SUCCESS.
+
 overlay=overlay_pst_conf
-RunTest dfu_self_update dfu_dist_dfu_self_update -- -argstest targets=1
+RunTestFlash dfu_self_update \
+    dfu_dist_dfu_self_update -flash_erase \
+    -- -argstest targets=1 recover=0
+
+overlay=overlay_pst_conf
+RunTestFlash dfu_self_update \
+    dfu_dist_dfu_self_update -flash_rm \
+    -- -argstest targets=1 recover=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update.sh
@@ -4,5 +4,71 @@
 
 source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
+# Test verifies that the Firmware Distribution Server can perform a self-update
+# and survive a reboot in the middle of the local Firmware Update Server's
+# apply callback. Persisted state must be restored on the next boot and drive
+# the distribution procedure to BT_MESH_DFD_PHASE_COMPLETED.
+#
+# Per MshDFUv1.0 Section 2.1.1, the Firmware Update Server (Target role) must
+# reside on a different element than the Firmware Distribution Server
+# (Distributor role) when the two are co-located. The Distributor node
+# therefore has two elements:
+#   - Element 1 (DIST_ADDR):     Config, SAR Config, Firmware Distribution
+#                                Server and the internal Firmware Update
+#                                Client + BLOB Transfer Client that drive
+#                                the transfer.
+#   - Element 2 (DIST_ADDR + 1): Firmware Update Server + BLOB Transfer Server
+#                                (the self-target that receives the image).
+#
+# Test procedure (first run, recover=0):
+# 1. Distributor is provisioned with the self-update composition and configured
+#    (app key bound to the Client models on element 1 and to the Server models
+#    on element 2).
+# 2. Distributor uploads a firmware slot.
+# 3. Distributor adds its own element 2 address (DIST_ADDR + 1) as the sole
+#    Receiver of the distribution.
+# 4. Distribution is started. Transfer and Apply steps run to completion. The
+#    self-target reports APPLYING for the Apply step (deferred apply) and the
+#    DFU Client's confirm step excuses it as expected.
+# 5. Once the confirm step completes, the DFD Server invokes the deferred
+#    self-target apply callback. The test's apply callback emulates a device
+#    reboot by:
+#      - updating the reported FWID (target_fw_ver_curr = target_fw_ver_new),
+#      - releasing the dfu_ended semaphore so the test main can proceed,
+#      - returning without calling bt_mesh_dfu_srv_applied().
+# 6. Test asserts pre-reboot invariants:
+#      - DFD Server phase == BT_MESH_DFD_PHASE_APPLYING_UPDATE (state persisted).
+#      - Local DFU Server phase == BT_MESH_DFU_PHASE_APPLYING (state persisted).
+# 7. Test PASSes and the bsim process exits, flushing persistent state to flash.
+#
+# Test procedure (second run, recover=1):
+# 8. The bsim process starts again with the same flash contents (no
+#    -flash_erase). No fresh provisioning, no receiver adds, no distribution
+#    start.
+# 9. target_fw_ver_curr is set to the new FWID before bt_mesh_device_setup() to
+#    emulate the effect of running the new firmware image.
+# 10. bt_mesh_device_setup() loads persistent state (DFD Server target list and
+#    distribution parameters, DFU Client xfer state, DFU Server update state)
+#    and invokes dfd_srv_model_start(), which:
+#      - transitions the local DFU Server from APPLYING to IDLE
+#        (bt_mesh_dfu_srv_applied()),
+#      - resumes the confirm step (bt_mesh_dfu_cli_confirm()).
+# 11. The resumed confirm step polls the self-target's Firmware Update
+#    Information Get, which now responds with the new FWID.
+# 12. DFU Client confirms the target, dfu_confirmed() runs, DFD phase
+#    transitions to BT_MESH_DFD_PHASE_COMPLETED, and dfu_dist_ended fires.
+# 13. Test asserts final invariants:
+#      - DFD Server phase == BT_MESH_DFD_PHASE_COMPLETED.
+#      - Local DFU Server phase == BT_MESH_DFU_PHASE_IDLE.
+#      - Self-target's targets[] entry phase == BT_MESH_DFU_PHASE_APPLY_SUCCESS
+#        with status BT_MESH_DFU_SUCCESS.
+
 overlay=overlay_pst_conf
-RunTest dfu_self_update dfu_dist_dfu_self_update -- -argstest targets=1
+RunTestFlash dfu_self_update \
+    dfu_dist_dfu_self_update -flash_erase \
+    -- -argstest targets=1 recover=0
+
+overlay=overlay_pst_conf
+RunTestFlash dfu_self_update \
+    dfu_dist_dfu_self_update -flash_rm \
+    -- -argstest targets=1 recover=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_apply_async.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_apply_async.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test verifies that a self-updating Firmware Distribution Server completes the
+# distribution when its own apply is performed asynchronously.
+#
+# The deferred self-apply callback may reboot the device, call
+# bt_mesh_dfu_srv_applied() before returning, or - as here - install the image
+# and report completion later. In the last case dfu_confirmed() has already
+# returned with the Distribution Phase at Applying Update, so the completion
+# has to be driven from bt_mesh_dfu_srv_applied() through
+# bt_mesh_dfd_srv_self_applied().
+#
+# Node layout (see dfu_dist_self_update.sh for background on the two-element
+# distributor mandated by MshDFUv1.0 Section 2.1.1):
+#   Device 0: Distributor. Element 1 (DIST_ADDR) hosts the Firmware
+#             Distribution Server; element 2 (DIST_ADDR + 1) hosts the Firmware
+#             Update Server that is the sole Receiver of the distribution.
+#
+# Test procedure (single run, no reboot):
+# 1. Distributor is provisioned and configured for self-update, uploads a
+#    firmware slot and adds its own element 2 (DIST_ADDR + 1) as the sole
+#    Receiver.
+# 2. Distribution runs through Transfer and Apply. The self-target reports
+#    APPLYING for the Apply step (deferred apply) and the DFU Client's confirm
+#    step excuses it.
+# 3. The deferred apply callback bumps the reported FWID (image installed) and
+#    returns without calling bt_mesh_dfu_srv_applied().
+# 4. Test asserts the distribution has not completed yet:
+#      - DFD Server phase == BT_MESH_DFD_PHASE_APPLYING_UPDATE.
+#      - No Completed phase notification seen.
+# 5. Test calls bt_mesh_dfu_srv_applied() as the application would once the
+#    install finished, and asserts:
+#      - DFD Server phase == BT_MESH_DFD_PHASE_COMPLETED.
+#      - Local DFU Server phase == BT_MESH_DFU_PHASE_IDLE.
+#      - Exactly one Completed phase notification, so the synchronous path in
+#        dfu_confirmed() does not report it a second time.
+
+overlay=overlay_pst_conf
+RunTest dfu_self_update_apply_async \
+    dfu_dist_dfu_self_update_apply_async \
+    -- -argstest targets=1 recover=0

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_apply_err.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_apply_err.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test verifies that a self-updating Firmware Distribution Server reports a
+# FAILED distribution when its own apply callback rejects the image.
+#
+# The application can refuse to install the new firmware (returning an error
+# from the bt_mesh_dfu_srv_cb.apply callback). Per MshDFUv1.0 Section 6.1.2.3
+# the Firmware Update Server leaves Applying Update for Idle "whether the
+# firmware image is installed successfully or the installation fails", so the
+# phase alone cannot distinguish the two outcomes. The deferred apply result
+# therefore has to be propagated to the DFD Server, otherwise a rejected image
+# is reported as a successful distribution.
+#
+# Node layout (see dfu_dist_self_update.sh for background on the two-element
+# distributor mandated by Section 2.1.1):
+#   Device 0: Distributor. Element 1 (DIST_ADDR) hosts the Firmware
+#             Distribution Server; element 2 (DIST_ADDR + 1) hosts the Firmware
+#             Update Server that is the sole Receiver of the distribution.
+#
+# Test procedure (single run, no reboot):
+# 1. Distributor is provisioned and configured for self-update, uploads a
+#    firmware slot and adds its own element 2 (DIST_ADDR + 1) as the sole
+#    Receiver.
+# 2. Distribution runs through Transfer and Apply. The self-target reports
+#    APPLYING for the Apply step (deferred apply) and the DFU Client's confirm
+#    step excuses it.
+# 3. After the confirm step the DFD Server invokes the deferred self-target
+#    apply callback, which returns -EIO instead of installing the image. The
+#    local Firmware Update Server transitions APPLYING -> IDLE and erases its
+#    persisted state.
+# 4. Test asserts the distribution ended in the failed state:
+#      - DFD Server phase == BT_MESH_DFD_PHASE_FAILED (not COMPLETED).
+
+overlay=overlay_pst_conf
+RunTest dfu_self_update_apply_err \
+    dfu_dist_dfu_self_update_apply_err \
+    -- -argstest targets=1 recover=0

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_apply_fail.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_apply_fail.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test verifies that a self-updating Firmware Distribution Server does not
+# report a successful distribution when the deferred self-target apply never
+# installed the new firmware image.
+#
+# This is the counterpart to dfu_dist_self_update.sh. That test emulates a
+# reboot AFTER the image was installed (the apply callback bumps the reported
+# FWID); this test emulates power loss BEFORE the image was installed, so the
+# node comes back up running the OLD firmware while Update Phase = Applying
+# Update is still on flash.
+#
+# Why the distribution must fail rather than complete, per MshDFUv1.0:
+#   - Applying Update (0x6) is server-sourced and means "the Apply New Firmware
+#     procedure is being executed" only (Section 4.1.2 Table 4.5, Section 4.2.1
+#     Table 4.8). It is not a success indication.
+#   - Apply Success (0x8) is client-sourced (Table 4.8) and is derived by the
+#     Confirm Update On Target Nodes procedure (Section 7.1.2.9), whose
+#     Table 7.3 condition for a node that stays provisioned is that the
+#     distributed Firmware ID matches the Target's Current Firmware ID.
+#   - A node that did not apply must still report the old Firmware ID, because
+#     the Firmware Information List state "changes after the node applies a new
+#     firmware update successfully" (Section 4.1.1).
+# The FWID comparison in the Confirm step is therefore the mechanism that is
+# required to catch this case, and this test pins that behavior.
+#
+# Node layout (see dfu_dist_self_update.sh for background on the two-element
+# distributor mandated by Section 2.1.1):
+#   Device 0: Distributor. Element 1 (DIST_ADDR) hosts the Firmware
+#             Distribution Server; element 2 (DIST_ADDR + 1) hosts the Firmware
+#             Update Server that is the sole Receiver of the distribution.
+#
+# Test procedure (first run, recover=0):
+# 1. Distributor is provisioned and configured for self-update.
+# 2. Distributor uploads a firmware slot and adds its own element 2
+#    (DIST_ADDR + 1) as the sole Receiver.
+# 3. Distribution starts. Transfer and Apply steps run to completion. The
+#    self-target reports APPLYING for the Apply step (deferred apply) and the
+#    DFU Client's confirm step excuses it.
+# 4. After the confirm step, the DFD Server invokes the deferred self-target
+#    apply callback. With self_update_apply_fail set, that callback emulates
+#    power loss before the image swap: it leaves target_fw_ver_curr at the OLD
+#    value, does NOT call bt_mesh_dfu_srv_applied(), gives dfu_ended and
+#    returns.
+# 5. Test asserts the same pre-reboot invariants as dfu_dist_self_update.sh -
+#    DFD Server in APPLYING_UPDATE and local DFU Server in APPLYING, both
+#    persisted. The two runs are indistinguishable on flash at this point;
+#    only the running image differs.
+# 6. Test PASSes and the bsim process exits, flushing persistent state.
+#
+# Test procedure (second run, recover=1):
+# 7. The bsim process starts again with the same flash contents (no
+#    -flash_erase), and target_fw_ver_curr is deliberately left at its old
+#    value (0xDEADBEEF) to emulate still running the pre-update image.
+# 8. bt_mesh_device_setup() loads persistent state and invokes dfd_srv_model_start(),
+#    which transitions the local DFU Server from APPLYING to IDLE and resumes
+#    the confirm step.
+# 9. The resumed confirm step polls the self-target with Firmware Update
+#    Information Get. The self-target answers with the OLD FWID, so no image in
+#    its Images List matches the distributed Firmware ID.
+# 10. handle_info_status() reaches the confirm-procedure termination path,
+#    marks the Receiver BT_MESH_DFU_PHASE_APPLY_FAIL and fails it. confirmed()
+#    then finds no successful Receiver and fails the distribution.
+# 11. Test asserts the distribution ended in the failed state:
+#      - DFD Server phase == BT_MESH_DFD_PHASE_FAILED.
+#      - Self-target's targets[] entry phase == BT_MESH_DFU_PHASE_APPLY_FAIL.
+
+overlay=overlay_pst_conf
+RunTestFlash dfu_self_update_apply_fail \
+    dfu_dist_dfu_self_update_apply_fail -flash_erase \
+    -- -argstest targets=1 recover=0
+
+overlay=overlay_pst_conf
+RunTestFlash dfu_self_update_apply_fail \
+    dfu_dist_dfu_self_update_apply_fail -flash_rm \
+    -- -argstest targets=1 recover=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_apply_sync.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_apply_sync.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test verifies that a self-updating Firmware Distribution Server reports the
+# Completed phase exactly once when its own apply finishes inside the callback.
+#
+# This is the synchronous counterpart to dfu_dist_self_update_apply_async.sh.
+# The apply callback calls bt_mesh_dfu_srv_applied() and returns, so the
+# Firmware Update Server notifies the Distribution Server through
+# bt_mesh_dfd_srv_self_applied() while dfu_confirmed() is still on the stack.
+# dfu_confirmed() must then not report the Completed phase a second time.
+#
+# Node layout (see dfu_dist_self_update.sh for background on the two-element
+# distributor mandated by MshDFUv1.0 Section 2.1.1):
+#   Device 0: Distributor. Element 1 (DIST_ADDR) hosts the Firmware
+#             Distribution Server; element 2 (DIST_ADDR + 1) hosts the Firmware
+#             Update Server that is the sole Receiver of the distribution.
+#
+# Test procedure (single run, no reboot):
+# 1. Distributor is provisioned and configured for self-update, uploads a
+#    firmware slot and adds its own element 2 (DIST_ADDR + 1) as the sole
+#    Receiver.
+# 2. Distribution runs through Transfer and Apply. No emulation flag is set, so
+#    the deferred apply callback takes the ordinary path: it calls
+#    bt_mesh_dfu_srv_applied() and returns 0.
+# 3. Test asserts:
+#      - DFD Server phase == BT_MESH_DFD_PHASE_COMPLETED.
+#      - Local DFU Server phase == BT_MESH_DFU_PHASE_IDLE.
+#      - Exactly one Completed phase notification.
+
+overlay=overlay_pst_conf
+RunTest dfu_self_update_apply_sync \
+    dfu_dist_dfu_self_update_apply_sync \
+    -- -argstest targets=1 recover=0

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_mult_targets.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_mult_targets.sh
@@ -4,6 +4,65 @@
 
 source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
+# Test verifies the Firmware Distribution Server self-update procedure with a
+# mix of Receivers - the co-located self-target plus one remote DFU Target -
+# including a reboot in the middle of the local Firmware Update Server's apply
+# callback. Persisted state on both devices must be restored on the next boot
+# and drive the distribution procedure to BT_MESH_DFD_PHASE_COMPLETED.
+#
+# Node layout (see dfu_dist_self_update.sh for background on the two-element
+# distributor):
+#   Device 0: Distributor (DIST_ADDR / DIST_ADDR + 1).
+#   Device 1: Remote Firmware Update Target (TARGET_ADDR + 1).
+#
+# Test procedure (first run, recover=0):
+# 1. Distributor is provisioned and configured for self-update.
+# 2. Remote target is provisioned and configured as a plain DFU target
+#    (test_target_dfu_no_change / target_test_effect(EFFECT_NONE)).
+# 3. Distributor uploads a firmware slot and adds two Receivers - its own
+#    element 2 (DIST_ADDR + 1) and the remote target (TARGET_ADDR + 1).
+# 4. Distribution starts. Transfer and Apply steps run to completion.
+# 5. The remote target's apply callback runs to completion, updating its
+#    reported FWID and returning after bt_mesh_dfu_srv_applied(). The remote
+#    target PASSes and its bsim process exits after target_test_effect().
+# 6. On the distributor, the self-target reports APPLYING for the Apply step
+#    (deferred apply) and the DFU Client's confirm step excuses it.
+# 7. After the confirm step, the DFD Server invokes the deferred self-target
+#    apply callback. The test's apply callback emulates a device reboot
+#    (updates FWID, gives dfu_ended, returns without applied()).
+# 8. Distributor asserts pre-reboot invariants:
+#      - DFD Server phase == BT_MESH_DFD_PHASE_APPLYING_UPDATE (state persisted).
+#      - Local DFU Server phase == BT_MESH_DFU_PHASE_APPLYING (state persisted).
+# 9. Distributor PASSes; bsim exits and flushes persistent state to flash on
+#    both devices.
+#
+# Test procedure (second run, recover=1):
+# 10. Both bsim processes start again with the same flash contents (no
+#    -flash_erase).
+# 11. Remote target: target_fw_ver_curr is set to the new FWID before
+#    bt_mesh_device_setup() to emulate having booted new firmware. No apply
+#    procedure runs on this side; it merely responds to the Firmware Update
+#    Information Get poll from the distributor.
+# 12. Distributor: target_fw_ver_curr is set to the new FWID before
+#    bt_mesh_device_setup(). bt_mesh_device_setup() loads persistent state and
+#    invokes dfd_srv_start(), which transitions the local DFU Server from
+#    APPLYING to IDLE and resumes the confirm step.
+# 13. The resumed confirm step polls both targets for their new FWID. Both
+#    respond with the new FWID; DFU Client marks them APPLY_SUCCESS.
+# 14. dfu_confirmed() runs, DFD phase transitions to
+#    BT_MESH_DFD_PHASE_COMPLETED, dfu_dist_ended fires.
+# 15. Distributor asserts final invariants for both entries in targets[]:
+#      - phase == BT_MESH_DFU_PHASE_APPLY_SUCCESS.
+#      - status == BT_MESH_DFU_SUCCESS.
+
 overlay=overlay_pst_conf
-RunTest dfu_self_update_no_change \
-    dfu_dist_dfu_self_update dfu_target_dfu_no_change -- -argstest targets=2
+RunTestFlash dfu_self_update_no_change \
+    dfu_dist_dfu_self_update -flash_erase \
+    dfu_target_dfu_no_change -flash_erase \
+    -- -argstest targets=2 recover=0
+
+overlay=overlay_pst_conf
+RunTestFlash dfu_self_update_no_change \
+    dfu_dist_dfu_self_update -flash_rm \
+    dfu_target_dfu_no_change -flash_rm \
+    -- -argstest targets=2 recover=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_mult_targets.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_mult_targets.sh
@@ -4,6 +4,65 @@
 
 source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
+# Test verifies the Firmware Distribution Server self-update procedure with a
+# mix of Receivers - the co-located self-target plus one remote DFU Target -
+# including a reboot in the middle of the local Firmware Update Server's apply
+# callback. Persisted state on both devices must be restored on the next boot
+# and drive the distribution procedure to BT_MESH_DFD_PHASE_COMPLETED.
+#
+# Node layout (see dfu_dist_self_update.sh for background on the two-element
+# distributor):
+#   Device 0: Distributor (DIST_ADDR / DIST_ADDR + 1).
+#   Device 1: Remote Firmware Update Target (TARGET_ADDR + 1).
+#
+# Test procedure (first run, recover=0):
+# 1. Distributor is provisioned and configured for self-update.
+# 2. Remote target is provisioned and configured as a plain DFU target
+#    (test_target_dfu_no_change / target_test_effect(EFFECT_NONE)).
+# 3. Distributor uploads a firmware slot and adds two Receivers - its own
+#    element 2 (DIST_ADDR + 1) and the remote target (TARGET_ADDR + 1).
+# 4. Distribution starts. Transfer and Apply steps run to completion.
+# 5. The remote target's apply callback runs to completion, updating its
+#    reported FWID and returning after bt_mesh_dfu_srv_applied(). The remote
+#    target PASSes and its bsim process exits after target_test_effect().
+# 6. On the distributor, the self-target reports APPLYING for the Apply step
+#    (deferred apply) and the DFU Client's confirm step excuses it.
+# 7. After the confirm step, the DFD Server invokes the deferred self-target
+#    apply callback. The test's apply callback emulates a device reboot
+#    (updates FWID, gives dfu_ended, returns without applied()).
+# 8. Distributor asserts pre-reboot invariants:
+#      - DFD Server phase == BT_MESH_DFD_PHASE_APPLYING_UPDATE (state persisted).
+#      - Local DFU Server phase == BT_MESH_DFU_PHASE_APPLYING (state persisted).
+# 9. Distributor PASSes; bsim exits and flushes persistent state to flash on
+#    both devices.
+#
+# Test procedure (second run, recover=1):
+# 10. Both bsim processes start again with the same flash contents (no
+#    -flash_erase).
+# 11. Remote target: target_fw_ver_curr is set to the new FWID before
+#    bt_mesh_device_setup() to emulate having booted new firmware. No apply
+#    procedure runs on this side; it merely responds to the Firmware Update
+#    Information Get poll from the distributor.
+# 12. Distributor: target_fw_ver_curr is set to the new FWID before
+#    bt_mesh_device_setup(). bt_mesh_device_setup() loads persistent state and
+#    invokes dfd_srv_model_start(), which transitions the local DFU Server from
+#    APPLYING to IDLE and resumes the confirm step.
+# 13. The resumed confirm step polls both targets for their new FWID. Both
+#    respond with the new FWID; DFU Client marks them APPLY_SUCCESS.
+# 14. dfu_confirmed() runs, DFD phase transitions to
+#    BT_MESH_DFD_PHASE_COMPLETED, dfu_dist_ended fires.
+# 15. Distributor asserts final invariants for both entries in targets[]:
+#      - phase == BT_MESH_DFU_PHASE_APPLY_SUCCESS.
+#      - status == BT_MESH_DFU_SUCCESS.
+
 overlay=overlay_pst_conf
-RunTest dfu_self_update_no_change \
-    dfu_dist_dfu_self_update dfu_target_dfu_no_change -- -argstest targets=2
+RunTestFlash dfu_self_update_no_change \
+    dfu_dist_dfu_self_update -flash_erase \
+    dfu_target_dfu_no_change -flash_erase \
+    -- -argstest targets=2 recover=0
+
+overlay=overlay_pst_conf
+RunTestFlash dfu_self_update_no_change \
+    dfu_dist_dfu_self_update -flash_rm \
+    dfu_target_dfu_no_change -flash_rm \
+    -- -argstest targets=2 recover=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_remote_fail.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/dfu/dfu_dist_self_update_remote_fail.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Copyright 2026 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test verifies that a self-updating Firmware Distribution Server still
+# completes its own update when a remote Target fails the Confirm step.
+#
+# This is the mixed-outcome counterpart to dfu_dist_self_update_mult_targets.sh,
+# where both Receivers succeed. Here the remote target is started with
+# fail-confirm=1, so it applies the image but deliberately keeps reporting the
+# old Firmware ID.
+#
+# Per MshDFUv1.0 Section 7.1.2.9, the Confirm Update On Target Nodes procedure
+# "completes successfully" if at least one receiver in the Active Update
+# Receivers state has a Retrieved Update Phase field value equal to Apply
+# Success. The distribution therefore has to reach COMPLETED on the strength of
+# the self-target alone, while the per-receiver entries still record the
+# individual outcomes - the aggregate Distribution Phase is not a per-node
+# result.
+#
+# Node layout (see dfu_dist_self_update.sh for background on the two-element
+# distributor mandated by Section 2.1.1):
+#   Device 0: Distributor (DIST_ADDR / DIST_ADDR + 1).
+#   Device 1: Remote Firmware Update Target (TARGET_ADDR + 1), fail-confirm=1.
+#
+# Note that fail-confirm=1 is passed to every device, but only affects the
+# remote target: on the distributor the self-target returns from
+# target_dfu_apply() through the self_update_reboot_emulation path, which bumps
+# the reported FWID and returns before the dfu_fail_confirm handling.
+#
+# Test procedure (first run, recover=0):
+# 1. Identical to dfu_dist_self_update_mult_targets.sh: both nodes are
+#    provisioned and configured, the distributor uploads a slot and adds its own
+#    element 2 (DIST_ADDR + 1) plus the remote target (TARGET_ADDR + 1) as
+#    Receivers, and the distribution runs to the deferred self-target apply.
+# 2. The remote target applies and, because of fail-confirm=1, leaves
+#    target_fw_ver_curr at the old value.
+# 3. The distributor's deferred apply callback emulates a reboot (bumps its own
+#    FWID, does not call bt_mesh_dfu_srv_applied()) and the run PASSes with the
+#    DFD Server in APPLYING_UPDATE and the local DFU Server in APPLYING.
+#
+# Test procedure (second run, recover=1):
+# 4. Both processes restart with the same flash contents. The distributor loads
+#    persistent state, dfd_srv_model_start() moves the local DFU Server to IDLE
+#    and resumes the Confirm step.
+# 5. The self-target answers Firmware Update Information Get with the new FWID
+#    and is marked APPLY_SUCCESS. The remote target answers with the old FWID,
+#    so handle_info_status() reaches the confirm-procedure termination path and
+#    marks it APPLY_FAIL.
+# 6. confirmed() finds one successful Receiver, so the distribution completes.
+#    Test asserts:
+#      - DFD Server phase == BT_MESH_DFD_PHASE_COMPLETED.
+#      - Local DFU Server phase == BT_MESH_DFU_PHASE_IDLE.
+#      - targets[0] (self)   == BT_MESH_DFU_PHASE_APPLY_SUCCESS / SUCCESS.
+#      - targets[1] (remote) == BT_MESH_DFU_PHASE_APPLY_FAIL.
+
+overlay=overlay_pst_conf
+RunTestFlash dfu_self_update_remote_fail \
+    dfu_dist_dfu_self_update_remote_fail -flash_erase \
+    dfu_target_dfu_no_change -flash_erase \
+    -- -argstest targets=2 recover=0 fail-confirm=1
+
+overlay=overlay_pst_conf
+RunTestFlash dfu_self_update_remote_fail \
+    dfu_dist_dfu_self_update_remote_fail -flash_rm \
+    dfu_target_dfu_no_change -flash_rm \
+    -- -argstest targets=2 recover=1 fail-confirm=1


### PR DESCRIPTION
## Summary

Fixes correctness and resumability issues in Bluetooth Mesh DFU when the
Distributor is also an Update Target (self-update) with no CDP change
— i.e. the Distributor stays provisioned after the update.

## Root causes

1. **Spec mismatch on Apply terminal state.** The DFU Client treated
   `Firmware Update Status { SUCCESS, APPLYING }` as in-progress and kept
   polling. Per MshDFUv1.0 §7.1.2.6 / §7.1.2.8, this response is the
   terminal *keep* condition for the Apply Firmware On Target Nodes
   procedure — Idle verification is handled by Refresh.
2. **Distributor state not persistent.** DFD Server and DFU Client state
   lived only in RAM, so a reboot mid-distribution — unavoidable during
   self-update — left the procedure unrecoverable.
3. **Self-target Apply raced with distribution completion,** losing
   track of remaining targets across the reboot.

## Changes

| # | Commit | What it does |
|---|--------|--------------|
| 1 | `tests: bsim: tune SAR config for DFU and BLOB tests` | Enables retries and tightens ACK timing so segmented unicast survives contention |
| 2 | `dfu_cli, dfu_srv: accept SUCCESS + APPLYING as terminal` | Aligns Apply completion with MshDFUv1.0 §7.1.2.6 |
| 3 | `persist dfd srv state for self-update resume` | Adds settings-backed persistence for DFD Server |
| 4 | `restore dfu client state for self-update resume` | Restores DFU Client procedure state on boot |
| 5 | `decouple dfu srv persisted state from runtime struct` | Splits stored state from live state |
| 6 | `fix dfu srv state persistence on failure paths` | Prevents stale persisted state after errors |
| 7 | `defer self-target apply until distribution completes` | Applies self-image only after all remaining targets are done |
| 8 | `resume self-update confirm step after reboot` | Continues the Apply/Refresh follow-up after Distributor reboots |
| 9 | `tests: cover DFD self-update post-reboot resume` | bsim coverage for the resume path |

## Notes

- No API changes.
- New persisted state uses a new settings subtree; old stored state is
  ignored on first boot (equivalent to no in-progress distribution).
- SAR retuning is scoped to the bsim test config only — no impact on
  production defaults.