### PR TITLE
Bluetooth: BAP: SD: Shell: Add handling of pending PAST for term req

### DIFF
--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -277,6 +277,15 @@ static int pa_sync_term(struct scan_delegator_sync_state *state)
 
 	(void)k_work_cancel_delayable(&state->pa_timer);
 
+	/* If we are waiting for PAST, we just clear the data, as we won't have a PA sync object to
+	 * remove
+	 */
+	if (state->recv_state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ) {
+		state->pa_syncing = false;
+
+		return 0;
+	}
+
 	if (state->pa_sync == NULL) {
 		bt_shell_warn("PA state %p not synced", state);
 		return -1;

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -278,6 +278,15 @@ static int pa_sync_term(struct scan_delegator_sync_state *state)
 
 	(void)k_work_cancel_delayable(&state->pa_timer);
 
+	/* If we are waiting for PAST, we just clear the data, as we won't have a PA sync object to
+	 * remove
+	 */
+	if (state->recv_state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ) {
+		state->pa_syncing = false;
+
+		return 0;
+	}
+
 	if (state->pa_sync == NULL) {
 		bt_shell_warn("PA state %p not synced", state);
 		return -1;


### PR DESCRIPTION
If we are pending PAST, we do not have a pa_sync object to delete, but we should not rejec the request to stop the sync, as that indicates that we should just stop waiting.