### PR TITLE
beagleconnect_zepto: Enable counter

### DIFF
--- a/boards/beagle/beagleconnect_zepto/beagleconnect_zepto.dts
+++ b/boards/beagle/beagleconnect_zepto/beagleconnect_zepto.dts
@@ -20,6 +20,7 @@
 		led0 = &led0;
 		sw0 = &button0;
 		watchdog0 = &wdt0;
+		counter = &counterg0;
 	};
 
 	chosen {
@@ -82,5 +83,13 @@
 };
 
 &trng {
+	status = "okay";
+};
+
+&timg0 {
+	status = "okay";
+};
+
+&counterg0 {
 	status = "okay";
 };

--- a/boards/beagle/beagleconnect_zepto/beagleconnect_zepto.yaml
+++ b/boards/beagle/beagleconnect_zepto/beagleconnect_zepto.yaml
@@ -19,3 +19,4 @@ supported:
   - pinctrl
   - uart
   - watchdog
+  - counter

--- a/dts/arm/ti/mspm0/l/mspm0l111x.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l111x.dtsi
@@ -21,5 +21,53 @@
 			ti,clk-div = <2>;
 			status = "disabled";
 		};
+
+		timg0: timg0@40084000 {
+			compatible = "ti,mspm0-timer";
+			reg = <0x40084000 0x2000>;
+			clocks = <&ckm MSPM0_CLOCK_LFCLK>;
+			interrupts = <16 0>;
+			ti,clk-prescaler = <255>;
+			ti,clk-div = <1>;
+			status = "disabled";
+
+			counterg0: counterg0 {
+				compatible = "ti,mspm0-timer-counter";
+				resolution = <16>;
+				status = "disabled";
+			};
+		};
+
+		timg1: timg1@40486000 {
+			compatible = "ti,mspm0-timer";
+			reg = <0x40486000 0x2000>;
+			clocks = <&ckm MSPM0_CLOCK_LFCLK>;
+			interrupts = <22 0>;
+			ti,clk-prescaler = <255>;
+			ti,clk-div = <1>;
+			status = "disabled";
+
+			counterg1: counterg1 {
+				compatible = "ti,mspm0-timer-counter";
+				resolution = <16>;
+				status = "disabled";
+			};
+		};
+
+		timg8: timg8@40090000 {
+			compatible = "ti,mspm0-timer";
+			reg = <0x40090000 0x2000>;
+			clocks = <&ckm MSPM0_CLOCK_LFCLK>;
+			interrupts = <2 0>;
+			ti,clk-prescaler = <255>;
+			ti,clk-div = <1>;
+			status = "disabled";
+
+			counterg8: counterg8 {
+				compatible = "ti,mspm0-timer-counter";
+				resolution = <16>;
+				status = "disabled";
+			};
+		};
 	};
 };


### PR DESCRIPTION
- Using counterg0 as the default counter.
- Testing using samples/drivers/counter/alarm