### PR TITLE
tests: bluetooth: tester: Fix stack overflow in get_handle_from_uuid

### DIFF
--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -2144,21 +2144,21 @@ static uint8_t get_handle_from_uuid(const void *cmd, uint16_t cmd_len, void *rsp
 {
 	const struct btp_gatt_get_handle_from_uuid_cmd *cp = cmd;
 	struct btp_gatt_get_handle_from_uuid_rp *rp = rsp;
-	struct bt_uuid search_uuid;
+	union uuid search_uuid;
 
-	if (btp2bt_uuid(cp->uuid, cp->uuid_length, &search_uuid)) {
+	if (btp2bt_uuid(cp->uuid, cp->uuid_length, &search_uuid.uuid)) {
 		return BTP_STATUS_FAILED;
 	}
 
 	__maybe_unused char uuid_str[BT_UUID_STR_LEN];
 
-	bt_uuid_to_str(&search_uuid, uuid_str, sizeof(uuid_str));
+	bt_uuid_to_str(&search_uuid.uuid, uuid_str, sizeof(uuid_str));
 
 	LOG_DBG("Searching handle for UUID %s", uuid_str);
 
 	for (int i = 0; i < attr_count; i++) {
 		if (server_db[i].uuid != NULL &&
-		    bt_uuid_cmp(server_db[i].uuid, &search_uuid) == 0) {
+		    bt_uuid_cmp(server_db[i].uuid, &search_uuid.uuid) == 0) {
 			rp->handle = sys_cpu_to_le16(server_db[i].handle);
 			*rsp_len = sizeof(*rp);
 


### PR DESCRIPTION
Initially search_uuid was allocated as struct bt_uuid, which reserved 1 byte of memory. When processing 16-bit UUIDs, btp2bt_uuid wrote past 1-byte limit. Fix this by changing search_uuid type to union uuid.

Fixes GATT/SR/GAW/BI-41-C qualification test case.