### PR TITLE
twister: expand module directory variables in path fields

### DIFF
--- a/doc/develop/twister/harness/pytest.rst
+++ b/doc/develop/twister/harness/pytest.rst
@@ -13,6 +13,8 @@ pytest_root: <list of pytest testpaths> (default pytest)
     executed when a test scenario begins to run. The default pytest directory is
     ``pytest``. After the pytest run is finished, Twister will check if
     the test scenario passed or failed according to the pytest report.
+    Environment variables and Zephyr module directory variables are expanded
+    (see :ref:`twister_module_dir_vars`).
     As an example, a list of valid pytest roots is presented below:
 
     .. code-block:: yaml
@@ -24,6 +26,7 @@ pytest_root: <list of pytest testpaths> (default pytest)
             - "/tmp/test_shell.py"
             - "~/tmp/test_shell.py"
             - "$ZEPHYR_BASE/samples/subsys/testsuite/pytest/shell/pytest/test_shell.py"
+            - "$ZEPHYR_HAL_NORDIC_MODULE_DIR/tests/pytest/test_hal.py"  # path inside a module
             - "pytest/test_shell_help.py::test_shell2_sample"  # select pytest subtest
             - "pytest/test_shell_help.py::test_shell2_sample[param_a]"  # select pytest parametrized subtest
 
@@ -100,8 +103,10 @@ required_devices: <list of required device entries> (default empty)
         Directory path where Twister should search for the application
         specified in ``application``. Can be an absolute path or a path
         relative to the directory containing the test's YAML file.
-        Environment variables are expanded. If not specified, Twister
-        searches in the same directory as the referring test's YAML file.
+        Environment variables and Zephyr module directory variables are
+        expanded (see :ref:`twister_module_dir_vars`). If not specified,
+        Twister searches in the same directory as the referring test's
+        YAML file.
 
     fixture: <list of fixture names> (optional, defaults to empty)
         List of fixture names that must be present on the reserved device.

--- a/doc/develop/twister/index.rst
+++ b/doc/develop/twister/index.rst
@@ -801,7 +801,8 @@ required_applications: <list of required applications> (default empty)
     - ``platform``: Target platform (optional, defaults to current test's platform)
     - ``path``: Directory path where Twister should search for the application
       (optional). Can be an absolute path or a path relative to the directory
-      containing the test's YAML file. Environment variables are expanded.
+      containing the test's YAML file. Environment variables and Zephyr module
+      directory variables are expanded (see :ref:`twister_module_dir_vars`).
       If not specified, Twister searches in the same directory as the referring
       test's YAML file.
 
@@ -908,6 +909,23 @@ To load arguments from a file, add ``+`` before the file name, e.g.,
 line break instead of white spaces.
 
 Most everyday users will run with no arguments.
+
+.. _twister_module_dir_vars:
+
+Expanding paths with module directory variables
+===============================================
+
+Path options in the test scenario file (e.g. ``required_applications``,
+``harness_config: pytest_root``) are expanded before use. In addition to
+environment variables, Twister expands Zephyr module directory
+variables, which mirror the CMake variables defined for every module:
+
+* ``ZEPHYR_<MODULE>_MODULE_DIR`` - absolute path to the module's root.
+* ``ZEPHYR_<MODULE>_MODULE_NAME`` - the module's name.
+
+``<MODULE>`` is upper-cased with non-alphanumeric characters replaced by ``_``,
+exactly as CMake does (for example ``$ZEPHYR_HAL_NORDIC_MODULE_DIR`` for the
+``hal_nordic`` module). Unknown references are left unchanged.
 
 Managing tests timeouts
 =======================

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -28,6 +28,7 @@ from twisterlib.environment import PYTEST_PLUGIN_INSTALLED, ZEPHYR_BASE
 from twisterlib.error import ConfigurationError, StatusAttributeError
 from twisterlib.handlers import DeviceHandler, Handler, terminate_process
 from twisterlib.harnessconfig import TWISTER_PYTEST_CONFIG_FILE, HarnessPytestConfig
+from twisterlib.modulevars import expand_zephyr_vars
 from twisterlib.reports import ReportStatus
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
@@ -590,7 +591,10 @@ class Pytest(Script):
         command.extend(
             [
                 os.path.normpath(
-                    os.path.join(self.source_dir, os.path.expanduser(os.path.expandvars(src)))
+                    os.path.join(
+                        self.source_dir,
+                        expand_zephyr_vars(os.path.expanduser(os.path.expandvars(src))),
+                    )
                 )
                 for src in config.pytest_root
             ]

--- a/scripts/pylib/twister/twisterlib/modulevars.py
+++ b/scripts/pylib/twister/twisterlib/modulevars.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Expansion of Zephyr module directory / name variables in path strings.
+
+These mirror the CMake variables that the build system defines for every
+Zephyr module, so the same ${ZEPHYR_<MODULE>_MODULE_DIR} spelling can be used
+in both CMake and Twister test configuration contexts.
+"""
+
+import os
+import re
+from functools import cache
+
+import zephyr_module
+from twisterlib.constants import ZEPHYR_BASE
+
+# Matches ${NAME} or $NAME references used when expanding path variables.
+_VAR_REF_RE = re.compile(r'\$\{(?P<braced>\w+)\}|\$(?P<bare>\w+)')
+
+
+@cache
+def get_module_dir_vars() -> dict[str, str]:
+    """Return a mapping of Zephyr module directory / name variables.
+
+    For every discovered Zephyr module this provides the
+    ZEPHYR_<MODULE>_MODULE_DIR and ZEPHYR_<MODULE>_MODULE_NAME entries,
+    mirroring the CMake variables defined for each module in
+    cmake/modules/zephyr_module.cmake. The module name is sanitized and
+    upper-cased exactly as the build system does, so the same
+    ${ZEPHYR_<MODULE>_MODULE_DIR} spelling works in both CMake and
+    Twister contexts.
+    """
+    module_vars = {}
+    for module in zephyr_module.parse_modules(ZEPHYR_BASE):
+        name_upper = module.meta['name-sanitized'].upper()
+        module_vars[f'ZEPHYR_{name_upper}_MODULE_DIR'] = os.path.normpath(module.project)
+        module_vars[f'ZEPHYR_{name_upper}_MODULE_NAME'] = module.meta['name']
+    return module_vars
+
+
+def expand_zephyr_vars(path: str) -> str:
+    """Expand Zephyr module directory / name variables in a path.
+
+    Substitutes ZEPHYR_<MODULE>_MODULE_DIR and ZEPHYR_<MODULE>_MODULE_NAME,
+    which are CMake variables not present in the process environment and are
+    therefore not handled by os.path.expandvars. Unknown references are left
+    untouched. Environment variables should be expanded with os.path.expandvars
+    before calling this function.
+    """
+    if '$' not in path:
+        return path
+
+    module_vars = get_module_dir_vars()
+
+    def replace(match: re.Match) -> str:
+        name = match.group('braced') or match.group('bare')
+        return module_vars.get(name, match.group(0))
+
+    return _VAR_REF_RE.sub(replace, path)

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -38,6 +38,7 @@ from twisterlib.config_parser import TwisterConfigParser
 from twisterlib.environment import TwisterEnv
 from twisterlib.error import TwisterRuntimeError
 from twisterlib.hardwaremap import HardwareMap
+from twisterlib.modulevars import expand_zephyr_vars
 from twisterlib.platform import Platform, generate_platforms
 from twisterlib.quarantine import Quarantine
 from twisterlib.statuses import TwisterStatus
@@ -679,7 +680,7 @@ class TestPlan:
                 if req_app.application not in self.testsuites:
                     required_apps.add(req_app.application)
                     if req_app.path:
-                        req_app_path = os.path.expandvars(req_app.path)
+                        req_app_path = expand_zephyr_vars(os.path.expandvars(req_app.path))
                         if os.path.isabs(req_app_path):
                             testroots.add(req_app_path)
                         else:


### PR DESCRIPTION
Twister resolves filesystem paths from test YAML through
`os.path.expandvars()`, which only substitutes process environment
variables. The most useful pointer to a module's root,
`ZEPHYR_<MODULE>_MODULE_DIR`, is a CMake build-system variable and is
not available at test-discovery time.

Add a helper that expands `ZEPHYR_<MODULE>_MODULE_DIR` and
`ZEPHYR_<MODULE>_MODULE_NAME`, mirroring the CMake variables defined for
every module, with the name sanitized and upper-cased exactly as the
build system does. Apply it when resolving `required_applications` and
`required_devices` paths and `pytest_root`, so the same spelling works in
both CMake and Twister contexts. Document the behavior in the Twister
guide.