### PR TITLE
drivers: timer: stm32_lptim: use _current_cpu to get CPU ID

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -77,9 +77,6 @@ static struct k_spinlock lock;
 
 #ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
 
-#define CURRENT_CPU \
-	(COND_CODE_1(CONFIG_SMP, (arch_curr_cpu()->id), (_current_cpu->id)))
-
 #define cycle_t uint32_t
 
 /* This local variable indicates that the timeout was set right before
@@ -313,7 +310,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 #ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
 	const struct pm_state_info *next;
 
-	next = pm_policy_next_state(CURRENT_CPU, ticks);
+	next = pm_policy_next_state(_current_cpu->id, ticks);
 
 	/* Check if STANBY or STOP3 is requested */
 	timeout_stdby = false;


### PR DESCRIPTION
The driver used a macro which was effectively a reimplementation of the `_current_cpu` macro, but less safe. Use the real `_current_cpu` macro directly and drop the driver's handrolled version.

I have vague memories that this `CURRENT_CPU` macro was something that was used pervasively in tree a long time ago but was later cleaned up (replaced by `_current_cpu->id`); if my memories are correct, this is probably just a leftover...

Note that `sys_clock_set_timeout()` is called with the `timeout_lock` spinlock held per API specification so the `__ASSERT_NO_MSG(!z_smp_cpu_mobile());` in `_current_cpu` is guaranteed to never be hit:
https://github.com/zephyrproject-rtos/zephyr/blob/91b517fda5c1b9db818a98bd5c8a20ee24137485/include/zephyr/drivers/timer/system_timer.h#L54-L56