### PR TITLE
lsm6dsv16x: stream sensor HUB data in FIFO

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
@@ -232,6 +232,7 @@ int lsm6dsv16x_shub_get_idx(const struct device *dev, enum sensor_channel type);
 int lsm6dsv16x_shub_config(const struct device *dev, enum sensor_channel chan,
 			enum sensor_attribute attr,
 			const struct sensor_value *val);
+enum sensor_channel lsm6dsv16x_shub_type(uint8_t k);
 #endif /* CONFIG_LSM6DSV16X_SENSORHUB */
 
 #ifdef CONFIG_LSM6DSV16X_TRIGGER

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_decoder.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_decoder.c
@@ -60,6 +60,10 @@ static const uint32_t sflp_period_ns[] = {
 	[LSM6DSVXXX_DT_SFLP_ODR_AT_240Hz] = UINT32_C(1000000000) / 240,
 	[LSM6DSVXXX_DT_SFLP_ODR_AT_480Hz] = UINT32_C(1000000000) / 480,
 };
+#if defined(CONFIG_LSM6DSV16X_SENSORHUB)
+static const uint32_t magn_period_ns = UINT32_C(1000000000) / 10;
+static const uint32_t baro_period_ns = UINT32_C(1000000000) / 10;
+#endif
 #endif /* CONFIG_LSM6DSV16X_STREAM */
 
 /*
@@ -74,6 +78,13 @@ static const uint32_t sflp_period_ns[] = {
  */
 #define Q31_SHIFT_MICROVAL(micro_val, range) \
 	(q31_t) ((int64_t)(micro_val) * ((int64_t)1 << (31 - (range))) / 1000000LL)
+
+/*
+ * Expand milli_Pa to q31_t according to its range; this is achieved
+ * multiplying by 2^31/2^range. Then transform it to kPa.
+ */
+#define Q31_SHIFT_KPA_VAL(milli_pa, range) \
+	(q31_t) ((int64_t)(milli_pa) * ((int64_t)1 << (31 - (range))) / 1000000LL)
 
 /* bit range for Accelerometer for a given accel_fs_idx value */
 static const int8_t accel_range[] = {
@@ -106,6 +117,13 @@ static const int8_t temp_range = 9;
 /* transform temperature LSB into micro-Celsius */
 #define SENSOR_TEMP_UCELSIUS(t_lsb) \
 	(int64_t) (25000000LL + (((int64_t)(t_lsb) * 1000000LL) / 256LL))
+
+#endif
+
+#if defined(CONFIG_LSM6DSV16X_SENSORHUB)
+/* transform barometer LSB into milli-Pascal */
+#define SENSOR_PRESS_MPA(p_lsb) \
+	((int64_t)p_lsb * 100000 / 4096.0f)
 
 #endif
 
@@ -146,6 +164,10 @@ static const int32_t gyro_scaler[] = {
 	[LSM6DSV16X_DT_FS_2000DPS] = SENSOR_SCALE_UDPS_TO_URADS(16 * GAIN_UNIT_G),
 	[LSM6DSV16X_DT_FS_4000DPS] = SENSOR_SCALE_UDPS_TO_URADS(32 * GAIN_UNIT_G),
 };
+
+#if defined(CONFIG_LSM6DSV16X_SENSORHUB)
+static const int32_t magn_scaler = 1500; /* uGauss/LSB */
+#endif
 
 static int lsm6dsv16x_decoder_get_frame_count(const uint8_t *buffer,
 					      struct sensor_chan_spec chan_spec,
@@ -193,6 +215,10 @@ static int lsm6dsv16x_decoder_get_frame_count(const uint8_t *buffer,
 	uint8_t fifo_tag;
 	uint8_t tot_accel_fifo_words = 0, tot_gyro_fifo_words = 0;
 	uint8_t tot_sflp_gbias = 0, tot_sflp_gravity = 0, tot_sflp_game_rotation = 0;
+#if defined(CONFIG_LSM6DSV16X_SENSORHUB)
+	uint8_t tot_magn_fifo_words = 0;
+	uint8_t tot_baro_fifo_words = 0;
+#endif /* CONFIG_LSM6DSV16X_SENSORHUB */
 
 #if defined(CONFIG_LSM6DSV16X_ENABLE_TEMP)
 	uint8_t tot_temp_fifo_words = 0;
@@ -226,6 +252,26 @@ static int lsm6dsv16x_decoder_get_frame_count(const uint8_t *buffer,
 		case LSM6DSV16X_SFLP_GAME_ROTATION_VECTOR_TAG:
 			tot_sflp_game_rotation++;
 			break;
+#if defined(CONFIG_LSM6DSV16X_SENSORHUB)
+		case LSM6DSV16X_SENSORHUB_SLAVE1_TAG:
+		case LSM6DSV16X_SENSORHUB_SLAVE2_TAG:
+		case LSM6DSV16X_SENSORHUB_SLAVE3_TAG: {
+			uint8_t k = fifo_tag - LSM6DSV16X_SENSORHUB_SLAVE1_TAG;
+			enum sensor_channel ctype = lsm6dsv16x_shub_type(k);
+
+			switch (ctype) {
+			case SENSOR_CHAN_MAGN_XYZ:
+				tot_magn_fifo_words++;
+				break;
+			case SENSOR_CHAN_PRESS:
+				tot_baro_fifo_words++;
+				break;
+			default:
+				break;
+			}
+			break;
+		}
+#endif /* CONFIG_LSM6DSV16X_SENSORHUB */
 		default:
 			break;
 		}
@@ -262,6 +308,14 @@ static int lsm6dsv16x_decoder_get_frame_count(const uint8_t *buffer,
 	case SENSOR_CHAN_GBIAS_XYZ:
 		*frame_count = tot_sflp_gbias;
 		break;
+#if defined(CONFIG_LSM6DSV16X_SENSORHUB)
+	case SENSOR_CHAN_MAGN_XYZ:
+		*frame_count = tot_magn_fifo_words;
+		break;
+	case SENSOR_CHAN_PRESS:
+		*frame_count = tot_baro_fifo_words;
+		break;
+#endif /* CONFIG_LSM6DSV16X_SENSORHUB */
 	default:
 		*frame_count = 0;
 		break;
@@ -285,6 +339,10 @@ static int lsm6dsv16x_decode_fifo(const uint8_t *buffer, struct sensor_chan_spec
 
 #if defined(CONFIG_LSM6DSV16X_ENABLE_TEMP)
 	uint16_t temp_count = 0;
+#endif
+#if defined(CONFIG_LSM6DSV16X_SENSORHUB)
+	uint16_t magn_count = 0;
+	uint16_t baro_count = 0;
 #endif
 	uint16_t game_rot_count = 0, gravity_count = 0, gbias_count = 0;
 	int ret;
@@ -316,6 +374,14 @@ static int lsm6dsv16x_decode_fifo(const uint8_t *buffer, struct sensor_chan_spec
 		((struct sensor_data_header *)data_out)->base_timestamp_ns =
 			edata->header.timestamp -
 			(tot_chan_fifo_words - 1) * temp_period_ns[edata->temp_batch_odr];
+#endif
+#if defined(CONFIG_LSM6DSV16X_SENSORHUB)
+	} else if (chan_spec.chan_type == SENSOR_CHAN_MAGN_XYZ) {
+		((struct sensor_data_header *)data_out)->base_timestamp_ns =
+			edata->header.timestamp - (tot_chan_fifo_words - 1) * magn_period_ns;
+	} else if (chan_spec.chan_type == SENSOR_CHAN_PRESS) {
+		((struct sensor_data_header *)data_out)->base_timestamp_ns =
+			edata->header.timestamp - (tot_chan_fifo_words - 1) * baro_period_ns;
 #endif
 	} else if (chan_spec.chan_type == SENSOR_CHAN_GRAVITY_VECTOR ||
 		   chan_spec.chan_type == SENSOR_CHAN_GAME_ROTATION_VECTOR ||
@@ -546,6 +612,70 @@ static int lsm6dsv16x_decode_fifo(const uint8_t *buffer, struct sensor_chan_spec
 			out->readings[count].z = Q31_SHIFT_VAL(z, out->shift);
 			break;
 		}
+
+#if defined(CONFIG_LSM6DSV16X_SENSORHUB)
+		case LSM6DSV16X_SENSORHUB_SLAVE1_TAG:
+		case LSM6DSV16X_SENSORHUB_SLAVE2_TAG:
+		case LSM6DSV16X_SENSORHUB_SLAVE3_TAG: {
+			uint8_t k = fifo_tag - LSM6DSV16X_SENSORHUB_SLAVE1_TAG;
+			enum sensor_channel ctype = lsm6dsv16x_shub_type(k);
+
+			if ((uintptr_t)buffer < *fit) {
+				/* This frame was already decoded, move on to the next frame */
+				buffer = frame_end;
+				continue;
+			}
+
+			if (chan_spec.chan_type != ctype) {
+				buffer = frame_end;
+				continue;
+			}
+
+			switch (ctype) {
+			case SENSOR_CHAN_MAGN_XYZ: {
+				struct sensor_three_axis_data *out = data_out;
+				int16_t x, y, z;
+				const int32_t scale = magn_scaler;
+
+				magn_count++;
+				out->readings[count].timestamp_delta =
+					(magn_count - 1) * magn_period_ns;
+
+				x = *(const int16_t *)&buffer[1];
+				y = *(const int16_t *)&buffer[3];
+				z = *(const int16_t *)&buffer[5];
+
+				out->shift = 9;
+
+				out->readings[count].x = Q31_SHIFT_MICROVAL(scale * x, out->shift);
+				out->readings[count].y = Q31_SHIFT_MICROVAL(scale * y, out->shift);
+				out->readings[count].z = Q31_SHIFT_MICROVAL(scale * z, out->shift);
+				break;
+			}
+			case SENSOR_CHAN_PRESS: {
+				struct sensor_q31_data *out = data_out;
+				int32_t baro;
+				int64_t p_mPa;
+
+				baro_count++;
+				out->readings[count].timestamp_delta =
+					(baro_count - 1) * baro_period_ns;
+
+				baro = (int32_t)(buffer[3] << 16) | (buffer[2] << 8) | buffer[1];
+
+				p_mPa = SENSOR_PRESS_MPA(baro);
+
+				out->shift = 8;
+				out->readings[count].pressure =
+					Q31_SHIFT_KPA_VAL(p_mPa, out->shift);
+				break;
+			}
+			default:
+				return -EINVAL;
+			}
+			break;
+		}
+#endif /* CONFIG_LSM6DSV16X_SENSORHUB */
 
 		default:
 			/* skip unhandled FIFO tag */

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
@@ -192,6 +192,20 @@ static void lsm6dsv16x_config_fifo(const struct device *dev, struct trigger_conf
 	lsm6dsv16x_accel_set_odr_raw(dev, lsm6dsv16x->accel_freq);
 	lsm6dsv16x_gyro_set_odr_raw(dev, lsm6dsv16x->gyro_freq);
 
+#if defined(CONFIG_LSM6DSV16X_SENSORHUB)
+	lsm6dsv16x_fifo_sh_batch_slave_set(ctx, 1, PROPERTY_ENABLE);
+	lsm6dsv16x_fifo_sh_batch_slave_set(ctx, 2, PROPERTY_ENABLE);
+
+	/* Configure Sensor Hub data rate */
+	lsm6dsv16x_sh_data_rate_set(ctx, LSM6DSV16X_SH_60Hz);
+
+	/* Configure Sensor Hub to read two slave. */
+	lsm6dsv16x_sh_slave_connected_set(ctx, LSM6DSV16X_SLV_0_1_2);
+
+	/* Enable I2C Master. */
+	lsm6dsv16x_sh_master_set(ctx, PROPERTY_ENABLE);
+#endif /* CONFIG_LSM6DSV16X_SENSORHUB */
+
 	/* Set pin interrupt (fifo_th could be on or off) */
 	if ((config->drdy_pin == 1) || (ON_I3C_BUS(config) && (!I3C_INT_PIN(config)))) {
 		lsm6dsv16x_pin_int1_route_set(ctx, &pin_int);

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_shub.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_shub.c
@@ -594,6 +594,10 @@ static int lsm6dsv16x_shub_read_target_reg(const struct device *dev,
 		return -EIO;
 	}
 
+	/* clean the read numop just to avoid issues when reading from FIFO */
+	trgt_cfg.slv_len = 0;
+	lsm6dsv16x_sh_slv_cfg_read(ctx, 0, &trgt_cfg);
+
 	lsm6dsv16x_shub_enable(dev, 0);
 	return 0;
 }

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_shub.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_shub.c
@@ -492,6 +492,18 @@ static struct lsm6dsv16x_shub_slist {
 #endif /* CONFIG_LSM6DSV16X_EXT_LPS22DF */
 };
 
+enum sensor_channel lsm6dsv16x_shub_type(uint8_t k)
+{
+	struct lsm6dsv16x_shub_slist *sp;
+
+	if (k > LSM6DSV16X_SHUB_MAX_NUM_TARGETS) {
+		return SENSOR_CHAN_COMMON_COUNT;
+	}
+
+	sp = &lsm6dsv16x_shub_slist[k];
+	return sp->type;
+}
+
 static int lsm6dsv16x_shub_wait_completed(stmdev_ctx_t *ctx)
 {
 	lsm6dsv16x_status_master_t status;


### PR DESCRIPTION
lsm6dsv16x sensor driver.
Add Sensor HUB data streaming in FIFO and decode them properly.
Currently two channels are handled:
    
            - SENSOR_CHAN_MAGN_XYZ
            - SENSOR_CHAN_PRESS

Tested on x_nucleo_iks4a1