### PR TITLE
boards: cirrus: Remove unnecessary defconfigs from board directories

### DIFF
--- a/boards/cirrus/crd40l26/crd40l26_defconfig
+++ b/boards/cirrus/crd40l26/crd40l26_defconfig
@@ -1,4 +1,0 @@
-# Copyright (c) 2026 Cirrus Logic, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_GPIO=y

--- a/boards/cirrus/crd40l50/Kconfig.defconfig
+++ b/boards/cirrus/crd40l50/Kconfig.defconfig
@@ -5,8 +5,7 @@
 
 if BOARD_CRD40L50
 
-config SPI_STM32_INTERRUPT
+configdefault SPI_STM32_INTERRUPT
 	default y
-	depends on SPI
 
 endif # BOARD_CRD40L50

--- a/boards/cirrus/crd40l50/crd40l50.dts
+++ b/boards/cirrus/crd40l50/crd40l50.dts
@@ -38,6 +38,7 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &rtt0;
 		zephyr,flash = &flash0;
+		zephyr,flash-controller = &flash_1;
 		zephyr,sram = &sram0;
 	};
 

--- a/boards/cirrus/crd40l50/crd40l50_defconfig
+++ b/boards/cirrus/crd40l50/crd40l50_defconfig
@@ -1,4 +1,0 @@
-# Copyright (c) 2026 Cirrus Logic, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_GPIO=y

--- a/drivers/haptics/cirrus/Kconfig.cs40l26
+++ b/drivers/haptics/cirrus/Kconfig.cs40l26
@@ -22,14 +22,17 @@ config HAPTICS_CS40L27_B2
 config HAPTICS_CS40L26_RESET
 	def_bool $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L26),reset-gpios) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L27),reset-gpios)
+	select GPIO
 
 config HAPTICS_CS40L26_INTERRUPT
 	def_bool $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L26),int-gpios) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L27),int-gpios)
+	select GPIO
 
 config HAPTICS_CS40L26_FLASH
 	def_bool $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L26),flash-storage) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L27),flash-storage)
+	select FLASH
 
 config HAPTICS_CS40L26_CALIBRATION
 	bool "Calibration"

--- a/drivers/haptics/cirrus/Kconfig.cs40l5x
+++ b/drivers/haptics/cirrus/Kconfig.cs40l5x
@@ -18,24 +18,28 @@ config HAPTICS_CS40L5X_RESET
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L51),reset-gpios) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L52),reset-gpios) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L53),reset-gpios)
+	select GPIO
 
 config HAPTICS_CS40L5X_INTERRUPT
 	def_bool $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L50),int-gpios) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L51),int-gpios) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L52),int-gpios) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L53),int-gpios)
+	select GPIO
 
 config HAPTICS_CS40L5X_TRIGGER
 	def_bool $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L50),trigger-gpios) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L51),trigger-gpios) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L52),trigger-gpios) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L53),trigger-gpios)
+	select GPIO
 
 config HAPTICS_CS40L5X_EXTERNAL_BOOST
 	def_bool $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L50),external-boost) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L51),external-boost) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L52),external-boost) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L53),external-boost)
+	select REGULATOR
 
 config HAPTICS_CS40L5X_INTERNAL_BOOST
 	def_bool !$(dt_compat_all_has_prop,$(DT_COMPAT_CIRRUS_CS40L50),external-boost) && \
@@ -48,6 +52,7 @@ config HAPTICS_CS40L5X_FLASH
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L51),flash-storage) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L52),flash-storage) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L53),flash-storage)
+	select FLASH
 
 config HAPTICS_CS40L5X_CALIBRATION
 	bool "Calibration"

--- a/samples/drivers/haptics/cs40l26/prj.conf
+++ b/samples/drivers/haptics/cs40l26/prj.conf
@@ -1,7 +1,4 @@
-CONFIG_FLASH=y
-CONFIG_GPIO=y
 CONFIG_HAPTICS=y
-CONFIG_I2C=y
 CONFIG_LOG=y
 
 # Demonstrate PM runtime features

--- a/samples/drivers/haptics/cs40l5x/prj.conf
+++ b/samples/drivers/haptics/cs40l5x/prj.conf
@@ -1,7 +1,4 @@
-CONFIG_FLASH=y
-CONFIG_GPIO=y
 CONFIG_HAPTICS=y
-CONFIG_I2C=y
 CONFIG_LOG=y
 
 # Demonstrate PM runtime features


### PR DESCRIPTION
Similarly to #110259, this PR drops Kconfig symbols from CRD40L26 and CRD40L50 defconfigs and instead selects required symbols in driver-specific Kconfig files. Propagates this change to CS40L26/27 and CS40L5x samples. Finally, this PR adds two additional minor fixes to CRD40L50 (ccdbe0ec32cd4c0e7bb6f70e8af9f6a40d3278dc), which were identified in #109871.