### PR TITLE
MAINTAINERS: cover RISC-V interrupt controller files

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5106,11 +5106,15 @@ RISCV arch:
     - boards/starfive/
     - cmake/compiler/*/target_riscv.cmake
     - doc/hardware/arch/risc-v.rst
+    - drivers/interrupt_controller/Kconfig.riscv_*
     - drivers/interrupt_controller/intc_plic.c
-    - drivers/interrupt_controller/intc_riscv_imsic.c
+    - drivers/interrupt_controller/intc_riscv_*
+    - dts/bindings/interrupt-controller/riscv,*
     - dts/bindings/riscv/
     - dts/riscv/
     - include/zephyr/arch/riscv/
+    - include/zephyr/drivers/interrupt_controller/riscv_*
+    - samples/drivers/interrupt_controller/intc_riscv_aia*/
     - soc/common/riscv-privileged/
     - soc/qemu/virt_riscv/
     - soc/sifive/


### PR DESCRIPTION
Some RISC-V-specific interrupt controller files only matched generic areas such as Interrupt Handling or Samples. That meant PRs touching AIA/APLIC/IMSIC driver, binding, header, or sample files could miss the RISC-V reviewer set.

Scope:
- add RISC-V interrupt-controller Kconfig and driver paths to the RISCV arch area
- add RISC-V interrupt-controller binding and header paths
- add the RISC-V AIA interrupt-controller samples