### PR TITLE
tests: kernel: condvar: fix coherence fault on intel_adsp

### DIFF
--- a/tests/kernel/condvar/condvar_api/src/main.c
+++ b/tests/kernel/condvar/condvar_api/src/main.c
@@ -923,8 +923,15 @@ static void *condvar_tests_setup(void)
  */
 ZTEST(condvar_tests, test_condvar_wait_timeout_relocks_mutex)
 {
-	struct k_condvar local_cv;
-	struct k_mutex local_mtx;
+	/*
+	 * Keep these off the thread stack: on CONFIG_KERNEL_COHERENCE
+	 * platforms (e.g. intel_adsp) stacks are cached/non-coherent, but a
+	 * pended-on wait_q must be memory-coherent (see the assert in
+	 * pend_locked() at kernel/sched.c). static places them in coherent
+	 * .bss, matching every other kernel object in this file.
+	 */
+	static struct k_condvar local_cv;
+	static struct k_mutex local_mtx;
 	int ret;
 
 	zassert_ok(k_condvar_init(&local_cv));


### PR DESCRIPTION
test_condvar_wait_timeout_relocks_mutex declared its k_condvar and
k_mutex as stack locals. On CONFIG_KERNEL_COHERENCE platforms (Xtensa
SMP DSP targets such as intel_adsp/ace20_lnl and ace30/ptl) thread
stacks live in cached, non-coherent memory, while a wait_q a thread
pends on must be memory-coherent -- it can be manipulated from another
CPU under _sched_spinlock.

When k_condvar_wait() timed out and pended the current thread on the
stack-resident condvar wait_q, the assert in pend_locked()

  __ASSERT_NO_MSG(wait_q == NULL || sys_cache_is_mem_coherent(wait_q));

fired, producing an EXCCAUSE 63 fatal exception and CPU panic. This was
the only test in the suite using stack-local kernel objects; every other
object here is file-scope and therefore already coherent.

Make the two objects static so they land in coherent .bss. The test is
single-shot and single-threaded, so static is safe.

Fixes #112846

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
