### PR TITLE
soc: qingke_v3a: incude <zephyr/offsets.h>

### DIFF
--- a/soc/wch/ch32v/qingke_v3a/soc_irq.S
+++ b/soc/wch/ch32v/qingke_v3a/soc_irq.S
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <offsets.h>
+#include <zephyr/offsets.h>
 #include <zephyr/toolchain.h>
 
 /* Exports */


### PR DESCRIPTION
Fix include, offsets.h alont is now not enough, we need
<zephyr/offsets.h>.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
