### PR TITLE
MAINTAINERS: Clean up Bluetooth Host Collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -688,12 +688,12 @@ Bluetooth Host:
   collaborators:
     - alwa-nordic
     - hermabe
-    - rugeGerritsen
     - sjanc
     - Thalley
     - cvinayak
     - HaavardRei
     - alxelax
+    - lylezhu2012
   files:
     - doc/services/connectivity/bluetooth/
     - include/zephyr/bluetooth/


### PR DESCRIPTION
Remove @rugeGerritsen who hasn't been particularly active, and add @lylezhu2012 who has been active and was interested to become a collaborator.