### PR TITLE
drivers: ethernet: phy: add functions to common header

### DIFF
--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -47,9 +47,6 @@ struct phy_mii_dev_data {
 	k_timepoint_t autoneg_timeout;
 };
 
-/* Offset to align capabilities bits of 1000BASE-T Control and Status regs */
-#define MII_1KSTSR_OFFSET 2
-
 #define MII_INVALID_PHY_ID UINT32_MAX
 
 /* How often to poll auto-negotiation status while waiting for it to complete */
@@ -243,82 +240,28 @@ static int check_autonegotiation_completion(const struct device *dev)
 {
 	const struct phy_mii_dev_config *const cfg = dev->config;
 	struct phy_mii_dev_data *const data = dev->data;
+	int ret;
 
-	uint16_t anar_reg = 0;
-	uint16_t bmsr_reg = 0;
-	uint16_t anlpar_reg = 0;
-	uint16_t c1kt_reg = 0;
-	uint16_t s1kt_reg = 0;
-
-	if (phy_mii_reg_read(dev, MII_BMSR, &bmsr_reg) < 0) {
-		return -EIO;
+	ret = phy_mii_check_autoneg(dev);
+	if ((ret == -EINPROGRESS) && sys_timepoint_expired(data->autoneg_timeout)) {
+		LOG_DBG("PHY (%d) auto-negotiate timeout", cfg->phy_addr);
+		return -ETIMEDOUT;
+	}
+	if (ret < 0) {
+		return ret;
 	}
 
-	if (!IS_BIT_SET(bmsr_reg, MII_BMSR_AUTONEG_COMPLETE_BIT)) {
-		if (sys_timepoint_expired(data->autoneg_timeout)) {
-			LOG_DBG("PHY (%d) auto-negotiate timeout", cfg->phy_addr);
-			return -ETIMEDOUT;
-		}
-		return -EINPROGRESS;
+	LOG_DBG("PHY (%d) auto-negotiate sequence completed", cfg->phy_addr);
+
+	ret = phy_mii_get_autoneg_speed(dev, &data->state, data->gigabit_supported);
+	if (ret < 0) {
+		return ret;
 	}
 
-	/* Link status bit is latched low, so read it again to get current status */
-	if (unlikely(!IS_BIT_SET(bmsr_reg, MII_BMSR_LINK_STATUS_BIT))) {
-		/* Second read, clears the latched bits and gives the correct status */
-		if (phy_mii_reg_read(dev, MII_BMSR, &bmsr_reg) < 0) {
-			return -EIO;
-		}
-
-		if (!IS_BIT_SET(bmsr_reg, MII_BMSR_LINK_STATUS_BIT)) {
-			return -EAGAIN;
-		}
-	}
-
-	LOG_DBG("PHY (%d) auto-negotiate sequence completed",
-		cfg->phy_addr);
-
-	/* Read PHY default advertising parameters */
-	if (phy_mii_reg_read(dev, MII_ANAR, &anar_reg) < 0) {
-		return -EIO;
-	}
-
-	/** Read peer device capability */
-	if (phy_mii_reg_read(dev, MII_ANLPAR, &anlpar_reg) < 0) {
-		return -EIO;
-	}
-
-	if (data->gigabit_supported) {
-		if (phy_mii_reg_read(dev, MII_1KTCR, &c1kt_reg) < 0) {
-			return -EIO;
-		}
-		if (phy_mii_reg_read(dev, MII_1KSTSR, &s1kt_reg) < 0) {
-			return -EIO;
-		}
-		s1kt_reg = (uint16_t)(s1kt_reg >> MII_1KSTSR_OFFSET);
-	}
-
-	if (data->gigabit_supported &&
-			((c1kt_reg & s1kt_reg & MII_ADVERTISE_1000_FULL) != 0U)) {
-		data->state.speed = LINK_FULL_1000BASE;
-	} else if (data->gigabit_supported &&
-			((c1kt_reg & s1kt_reg & MII_ADVERTISE_1000_HALF) != 0U)) {
-		data->state.speed = LINK_HALF_1000BASE;
-	} else if ((anar_reg & anlpar_reg & MII_ADVERTISE_100_FULL) != 0U) {
-		data->state.speed = LINK_FULL_100BASE;
-	} else if ((anar_reg & anlpar_reg & MII_ADVERTISE_100_HALF) != 0U) {
-		data->state.speed = LINK_HALF_100BASE;
-	} else if ((anar_reg & anlpar_reg & MII_ADVERTISE_10_FULL) != 0U) {
-		data->state.speed = LINK_FULL_10BASE;
-	} else {
-		data->state.speed = LINK_HALF_10BASE;
-	}
-
-	data->state.is_up = true;
-
-	LOG_INF("PHY (%d) Link speed %s Mb, %s duplex",
+	LOG_INF("PHY (%d) Link speed 10%s Mb, %s duplex",
 		cfg->phy_addr,
-		PHY_LINK_IS_SPEED_1000M(data->state.speed) ? "1000" :
-		(PHY_LINK_IS_SPEED_100M(data->state.speed) ? "100" : "10"),
+		PHY_LINK_IS_SPEED_1000M(data->state.speed) ? "00" :
+		(PHY_LINK_IS_SPEED_100M(data->state.speed) ? "0" : ""),
 		PHY_LINK_IS_FULL_DUPLEX(data->state.speed) ? "full" : "half");
 
 	return 0;

--- a/drivers/ethernet/phy/phy_mii.h
+++ b/drivers/ethernet/phy/phy_mii.h
@@ -11,6 +11,9 @@
 #include <zephyr/net/phy.h>
 #include <zephyr/net/mii.h>
 
+/* Offset to align capabilities bits of 1000BASE-T Control and Status regs */
+#define MII_1KSTSR_OFFSET 2
+
 #define PHY_INST_GENERATE_DEFAULT_SPEEDS(n)							\
 ((DT_INST_ENUM_HAS_VALUE(n, default_speeds, 10base_half_duplex) ? LINK_HALF_10BASE : 0) |	\
 (DT_INST_ENUM_HAS_VALUE(n, default_speeds, 10base_full_duplex) ? LINK_FULL_10BASE : 0) |	\
@@ -180,4 +183,92 @@ static inline enum phy_link_speed phy_mii_get_link_speed_bmcr_reg(const struct d
 
 	return speed;
 }
+
+static inline int phy_mii_check_autoneg(const struct device *dev)
+{
+	uint32_t bmsr_reg = 0;
+
+	if (phy_read(dev, MII_BMSR, &bmsr_reg) < 0) {
+		return -EIO;
+	}
+
+	if (!IS_BIT_SET(bmsr_reg, MII_BMSR_AUTONEG_COMPLETE_BIT)) {
+		return -EINPROGRESS;
+	}
+
+	/* Link status bit is latched low, so read it again to get current status */
+	if (likely(IS_BIT_SET(bmsr_reg, MII_BMSR_LINK_STATUS_BIT))) {
+		return 0;
+	}
+	/* Second read, clears the latched bits and gives the correct status */
+	if (phy_read(dev, MII_BMSR, &bmsr_reg) < 0) {
+		return -EIO;
+	}
+
+	if (!IS_BIT_SET(bmsr_reg, MII_BMSR_LINK_STATUS_BIT)) {
+		return -EAGAIN;
+	}
+
+	return 0;
+}
+
+static inline int phy_mii_get_autoneg_speed(const struct device *dev, struct phy_link_state *state,
+					    bool gigabit_supported)
+{
+	uint32_t anar_reg = 0;
+	uint32_t anlpar_reg = 0;
+	uint16_t mutual_capabilities;
+
+	if (gigabit_supported) {
+		uint32_t c1kt_reg = 0;
+		uint32_t s1kt_reg = 0;
+
+		if (phy_read(dev, MII_1KTCR, &c1kt_reg) < 0) {
+			return -EIO;
+		}
+		if (phy_read(dev, MII_1KSTSR, &s1kt_reg) < 0) {
+			return -EIO;
+		}
+		mutual_capabilities = (uint16_t)(s1kt_reg >> MII_1KSTSR_OFFSET);
+		mutual_capabilities &= (uint16_t)c1kt_reg;
+
+		if (IS_BIT_SET(mutual_capabilities, MII_ADVERTISE_1000_FULL_BIT)) {
+			state->speed = LINK_FULL_1000BASE;
+			state->is_up = true;
+			return 0;
+		}
+		if (IS_BIT_SET(mutual_capabilities, MII_ADVERTISE_1000_HALF_BIT)) {
+			state->speed = LINK_HALF_1000BASE;
+			state->is_up = true;
+			return 0;
+		}
+	}
+
+	/* Read PHY default advertising parameters */
+	if (phy_read(dev, MII_ANAR, &anar_reg) < 0) {
+		return -EIO;
+	}
+
+	/** Read peer device capability */
+	if (phy_read(dev, MII_ANLPAR, &anlpar_reg) < 0) {
+		return -EIO;
+	}
+
+	mutual_capabilities = (uint16_t)(anar_reg & anlpar_reg);
+
+	if (IS_BIT_SET(mutual_capabilities, MII_ADVERTISE_100_FULL_BIT)) {
+		state->speed = LINK_FULL_100BASE;
+	} else if (IS_BIT_SET(mutual_capabilities, MII_ADVERTISE_100_HALF_BIT)) {
+		state->speed = LINK_HALF_100BASE;
+	} else if (IS_BIT_SET(mutual_capabilities, MII_ADVERTISE_10_FULL_BIT)) {
+		state->speed = LINK_FULL_10BASE;
+	} else {
+		state->speed = LINK_HALF_10BASE;
+	}
+
+	state->is_up = true;
+
+	return 0;
+}
+
 #endif /* ZEPHYR_PHY_MII_H_ */


### PR DESCRIPTION
add functions to evaluate the autoneg to the
common phy mii header.