### PR TITLE
kernel: kheap: keep static heap init as a PRE_KERNEL_1 SYS_INIT

### DIFF
--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -5,11 +5,11 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/init.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/sys/iterable_sections.h>
 /* private kernel APIs */
 #include <ksched.h>
-#include <kernel_internal.h>
 #include <wait_q.h>
 
 int k_heap_array_get(struct k_heap **heap)
@@ -32,14 +32,21 @@ void k_heap_init(struct k_heap *heap, void *mem, size_t bytes)
 	SYS_PORT_TRACING_OBJ_INIT(k_heap, heap);
 }
 
-static void statics_init(void)
+static int statics_init(void)
 {
 	STRUCT_SECTION_FOREACH(k_heap, heap) {
 		k_heap_init(heap, heap->heap.init_mem, heap->heap.init_bytes);
 	}
+	return 0;
 }
 
-K_KERNEL_INIT_PRE(statics_init);
+/*
+ * Static heap init must stay a PRE_KERNEL_1 SYS_INIT: the heap KASAN shadow is
+ * registered at (PRE_KERNEL_1, 0) via K_HEAP_KASAN_ENABLE() and must run before
+ * sys_heap_init(). A K_KERNEL_INIT_PRE() hook would run ahead of that, leaving
+ * the shadow unregistered and KASAN tracking disabled.
+ */
+SYS_INIT_NAMED(statics_init_pre, statics_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 
 typedef void * (sys_heap_allocator_t)(struct sys_heap *heap, size_t align, size_t bytes);
 


### PR DESCRIPTION
Static heap init was converted from SYS_INIT(PRE_KERNEL_1, OBJECTS) to a
K_KERNEL_INIT_PRE() hook. Those hooks run before any PRE_KERNEL_1
SYS_INIT, which broke heap KASAN: K_HEAP_KASAN_ENABLE() registers a
heap's shadow at (PRE_KERNEL_1, 0), relying on running before static
heap init. With the hook, sys_heap_init() ran first, heap->kasan_ba
stayed NULL and tracking was silently disabled. On the system heap this
let the tests/lib/heap_kasan overflow cases corrupt real chunk metadata
and panic with "heap corruption (free chunk linkage)".

Revert only the kheap portion of that conversion and keep static heap
init as SYS_INIT(PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS),
restoring the ordering the KASAN shadow registration depends on. The
mem_slab and mailbox conversions in the same series are unaffected and
stay on K_KERNEL_INIT_PRE. A comment records why kheap must remain a
SYS_INIT so it is not reconverted.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
