### PR TITLE
kernel: Only define z_main_thread if multithreading is enabled

### DIFF
--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -708,9 +708,9 @@ FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(k_thread_entry_t main_
 	extern uintptr_t z_arm_tls_ptr;
 	size_t tls_size;
 
-	tls_size = arch_tls_stack_setup(&z_main_thread, psp);
-	z_arm_tls_ptr = z_main_thread.tls;
+	tls_size = arch_tls_stack_setup(NULL, psp);
 	psp -= tls_size;
+	z_arm_tls_ptr = POINTER_TO_UINT(psp);
 #endif
 
 #if defined(CONFIG_BUILTIN_STACK_GUARD)

--- a/arch/arm/core/tls.c
+++ b/arch/arm/core/tls.c
@@ -46,11 +46,15 @@ size_t arch_tls_stack_setup(struct k_thread *new_thread, char *stack_ptr)
 	stack_ptr -= toolchain_tls_size;
 #endif
 
+#if defined(CONFIG_MULTITHREADING)
 	/*
 	 * Set thread TLS pointer which is used in
 	 * context switch to point to TLS area.
 	 */
 	new_thread->tls = POINTER_TO_UINT(stack_ptr);
+#else
+	ARG_UNUSED(new_thread);
+#endif /* CONFIG_MULTITHREADING */
 
 	return (z_tls_data_size() + toolchain_tls_size);
 }

--- a/arch/arm/core/tls.c
+++ b/arch/arm/core/tls.c
@@ -39,9 +39,11 @@ size_t arch_tls_stack_setup(struct k_thread *new_thread, char *stack_ptr)
 	stack_ptr -= z_tls_data_size();
 	z_tls_copy(stack_ptr);
 
+	size_t toolchain_tls_size = 0;
 #ifndef __IAR_SYSTEMS_ICC__
 	/* Skip two pointers due to toolchain */
-	stack_ptr -= sizeof(uintptr_t) * 2;
+	toolchain_tls_size = sizeof(uintptr_t) * 2;
+	stack_ptr -= toolchain_tls_size;
 #endif
 
 	/*
@@ -50,5 +52,5 @@ size_t arch_tls_stack_setup(struct k_thread *new_thread, char *stack_ptr)
 	 */
 	new_thread->tls = POINTER_TO_UINT(stack_ptr);
 
-	return (z_tls_data_size() + (sizeof(uintptr_t) * 2));
+	return (z_tls_data_size() + toolchain_tls_size);
 }

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -146,7 +146,9 @@ extern void z_early_rand_get(uint8_t *buf, size_t length);
 extern int z_stack_adjust_initialized;
 #endif /* CONFIG_STACK_POINTER_RANDOM */
 
+#ifdef CONFIG_MULTITHREADING
 extern struct k_thread z_main_thread;
+#endif /* CONFIG_MULTITHREADING */
 
 
 K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -53,9 +53,9 @@ atomic_t _cpus_active;
 
 /* init/main and idle threads */
 K_THREAD_STACK_DEFINE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
-struct k_thread z_main_thread;
 
 #ifdef CONFIG_MULTITHREADING
+struct k_thread z_main_thread;
 struct k_thread z_idle_threads[CONFIG_MP_MAX_NUM_CPUS];
 
 static K_KERNEL_STACK_ARRAY_DEFINE(z_idle_stacks,
@@ -347,8 +347,10 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	(void)main();
 #endif /* CONFIG_BOOTARGS */
 
+#ifdef CONFIG_MULTITHREADING
 	/* Mark non-essential since main() has no more work to do */
 	z_thread_essential_clear(&z_main_thread);
+#endif
 
 #ifdef CONFIG_COVERAGE_DUMP
 	/* Dump coverage data once the main() has exited. */

--- a/tests/kernel/threads/no-multithreading/src/main.c
+++ b/tests/kernel/threads/no-multithreading/src/main.c
@@ -118,6 +118,18 @@ ZTEST(no_multithreading, test_cpu_idle)
 				  "Unexpected time passed: %d ms", (int)diff);
 }
 
+/* TODO: Remove CONFIG_ARM check once TLS is supported on all architectures
+ * See https://github.com/zephyrproject-rtos/zephyr/issues/114503
+ */
+#if defined(CONFIG_ARM)
+ZTEST(no_multithreading, test_tls)
+{
+	static volatile Z_THREAD_LOCAL int i = 42;
+
+	zassert_equal(i, 42, "TLS variable was not initialized");
+}
+#endif
+
 #define IDX_PRE_KERNEL_1 0
 #define IDX_PRE_KERNEL_2 1
 #define IDX_POST_KERNEL 2


### PR DESCRIPTION
z_main_thread is only needed if multithreading is enabled, so move its definition inside a multithreading check.