### PR TITLE
drivers: usb: add DWC2 driver vendor quirks for STM32U5 family and use DWC2 drivers on  nucleo_u5a5zj_q

### DIFF
--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
@@ -80,10 +80,22 @@
 };
 
 zephyr_udc0: &usbotg_hs {
+	compatible = "st,stm32u5-hsotg", "snps,dwc2";
+	/delete-property/ num-bidir-endpoints;
+	/delete-property/ ram-size;
+	/delete-property/ maximum-speed;
+	phys = <&otghs_phy>;
+	num-in-eps = <9>;
+	num-out-eps = <9>;
+	ghwcfg1 = <0x00000000>;
+	ghwcfg2 = <0x228fe052>;
+	ghwcfg4 = <0xe2103e30>;
 	pinctrl-0 = <&usb_otg_hs_dm_pa11 &usb_otg_hs_dp_pa12>;
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+zephyr_uhc0: &usbotg_hs {};
 
 &otghs_phy {
 	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_16MHz";

--- a/drivers/usb/udc/udc_dwc2.h
+++ b/drivers/usb/udc/udc_dwc2.h
@@ -172,6 +172,9 @@ static inline struct usb_dwc2_reg *dwc2_get_base(const struct device *dev)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_fsotg)
 #include "udc_dwc2_stm32f4_fsotg.h"
 #endif
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32u5_hsotg)
+#include "udc_dwc2_stm32u5_hsotg.h"
+#endif
 #if DT_HAS_COMPAT_STATUS_OKAY(syna_sr100_usb)
 #include "udc_dwc2_syna_sr100_usb.h"
 #endif

--- a/drivers/usb/udc/udc_dwc2_stm32u5_hsotg.h
+++ b/drivers/usb/udc/udc_dwc2_stm32u5_hsotg.h
@@ -1,0 +1,195 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_USB_UDC_DWC2_STM32U5_HSOTG_H
+#define ZEPHYR_DRIVERS_USB_UDC_DWC2_STM32U5_HSOTG_H
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+
+/* HAL SYSCFG for the embedded HS PHY, LL PWR for the USB power supply */
+#include <soc.h>
+#include <stm32_ll_pwr.h>
+
+struct udc_dwc2_stm32u5_config {
+	const struct device *clk_dev;
+	const struct stm32_pclken *pclken;
+	const struct stm32_pclken *phy_pclken;
+	size_t phy_pclken_len;
+	uint32_t phy_ref_clk;
+};
+
+/* Enable the USB power supply (mirrors the STM32U5 path in stm32_usb_pwr_enable()) */
+static inline int udc_dwc2_stm32u5_enable_pwr(void)
+{
+	if (LL_PWR_GetRegulVoltageScaling() < LL_PWR_REGU_VOLTAGE_SCALE2) {
+		return -EIO;
+	}
+
+	LL_PWR_EnableVddUSB();
+	LL_PWR_EnableUSBPowerSupply();
+	LL_PWR_EnableUSBEPODBooster();
+	while (LL_PWR_IsActiveFlag_USBBOOST() != 1) {
+		/* Wait for the USB EPOD booster to be ready */
+	}
+
+	return 0;
+}
+
+static inline int udc_dwc2_stm32u5_enable_clk(const struct udc_dwc2_stm32u5_config *const cfg)
+{
+	if (!device_is_ready(cfg->clk_dev)) {
+		return -ENODEV;
+	}
+
+	return clock_control_on(cfg->clk_dev, (void *)&cfg->pclken[0]);
+}
+
+/*
+ * Bring up the embedded High-Speed PHY
+ * (mirrors the drivers/usb/common/stm32/phy_u5otghs.c sequence)
+ */
+static inline int udc_dwc2_stm32u5_enable_phy(const struct udc_dwc2_stm32u5_config *const cfg)
+{
+	int ret;
+
+	/* SYSCFG holds the OTG_HS PHY configuration registers */
+	__HAL_RCC_SYSCFG_CLK_ENABLE();
+
+	/* Select the PHY reference clock frequency */
+	HAL_SYSCFG_SetOTGPHYReferenceClockSelection(cfg->phy_ref_clk);
+
+	/* Deassert the PHY reset */
+	HAL_SYSCFG_EnableOTGPHY(SYSCFG_OTG_HS_PHY_ENABLE);
+
+	if (cfg->phy_pclken_len > 1) {
+		/* Select the PHY clock source */
+		ret = clock_control_configure(cfg->clk_dev, (void *)&cfg->phy_pclken[1], NULL);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	/* Turn on the PHY clock */
+	return clock_control_on(cfg->clk_dev, (void *)&cfg->phy_pclken[0]);
+}
+
+static inline void udc_dwc2_stm32u5_disable_phy(const struct udc_dwc2_stm32u5_config *const cfg)
+{
+	(void)clock_control_off(cfg->clk_dev, (void *)&cfg->phy_pclken[0]);
+}
+
+static inline void udc_dwc2_stm32u5_disable_clk(const struct udc_dwc2_stm32u5_config *const cfg)
+{
+	(void)clock_control_off(cfg->clk_dev, (void *)&cfg->pclken[0]);
+}
+
+static inline void udc_dwc2_stm32u5_disable_pwr(void)
+{
+	LL_PWR_DisableUSBEPODBooster();
+	while (LL_PWR_IsActiveFlag_USBBOOST() != 0) {
+		/* Wait for the USB EPOD booster to turn off */
+	}
+
+	LL_PWR_DisableUSBPowerSupply();
+	LL_PWR_DisableVddUSB();
+}
+
+static inline int udc_dwc2_stm32u5_caps(const struct device *const dev)
+{
+	struct udc_data *const data = dev->data;
+
+	data->caps.hs = true;
+
+	return 0;
+}
+
+/*
+ * Disable the controller's hardware VBUS detection and pulldown resistors and
+ * force the B-session valid override so the device connects.
+ */
+static inline int udc_dwc2_stm32u5_post_enable(const struct device *const dev)
+{
+	struct usb_dwc2_reg *const base = dwc2_get_base(dev);
+	const mem_addr_t ggpio = (mem_addr_t)&base->ggpio;
+
+	sys_clear_bits(ggpio, USB_OTG_GCCFG_PULLDOWNEN | USB_OTG_GCCFG_VBDEN);
+	sys_set_bits(ggpio, USB_OTG_GCCFG_VBVALEXTOEN | USB_OTG_GCCFG_VBVALOVAL);
+
+	return 0;
+}
+
+/*
+ * The PHY node holds the reference clock selection and the PHY clocks. The
+ * SYSCFG_OTG_HS_PHY_CLK_SELECT_<n> values go from 1 to N, whereas DT_ENUM_IDX()
+ * is zero-based, hence the UTIL_INC().
+ */
+#define UDC_DWC2_STM32U5_PHY_NODE(n)	DT_INST_PHANDLE(n, phys)
+
+#define UDC_DWC2_STM32U5_PHY_REF_CLK(n)							\
+	CONCAT(SYSCFG_OTG_HS_PHY_CLK_SELECT_,						\
+	       UTIL_INC(DT_ENUM_IDX(UDC_DWC2_STM32U5_PHY_NODE(n), clock_reference)))
+
+#define QUIRK_STM32U5_HSOTG_DEFINE(n)							\
+	static const struct stm32_pclken pclken_##n[] = STM32_DT_INST_CLOCKS(n);	\
+	static const struct stm32_pclken phy_pclken_##n[] =				\
+		STM32_DT_CLOCKS(UDC_DWC2_STM32U5_PHY_NODE(n));				\
+											\
+	static const struct udc_dwc2_stm32u5_config udc_dwc2_stm32u5_config_##n = {	\
+		.clk_dev = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),			\
+		.pclken = pclken_##n,							\
+		.phy_pclken = phy_pclken_##n,						\
+		.phy_pclken_len = DT_NUM_CLOCKS(UDC_DWC2_STM32U5_PHY_NODE(n)),		\
+		.phy_ref_clk = UDC_DWC2_STM32U5_PHY_REF_CLK(n),				\
+	};										\
+											\
+	static int udc_dwc2_stm32u5_pre_enable_##n(const struct device *dev)		\
+	{										\
+		int ret;								\
+											\
+		ARG_UNUSED(dev);							\
+											\
+		ret = udc_dwc2_stm32u5_enable_pwr();					\
+		if (ret) {								\
+			return ret;							\
+		}									\
+											\
+		ret = udc_dwc2_stm32u5_enable_clk(&udc_dwc2_stm32u5_config_##n);	\
+		if (ret) {								\
+			return ret;							\
+		}									\
+											\
+		return udc_dwc2_stm32u5_enable_phy(&udc_dwc2_stm32u5_config_##n);	\
+	}										\
+											\
+	static int udc_dwc2_stm32u5_shutdown_##n(const struct device *dev)		\
+	{										\
+		ARG_UNUSED(dev);							\
+											\
+		udc_dwc2_stm32u5_disable_phy(&udc_dwc2_stm32u5_config_##n);		\
+		udc_dwc2_stm32u5_disable_clk(&udc_dwc2_stm32u5_config_##n);		\
+		udc_dwc2_stm32u5_disable_pwr();						\
+											\
+		return 0;								\
+	}										\
+											\
+	const struct dwc2_vendor_quirks dwc2_vendor_quirks_##n = {			\
+		.caps = udc_dwc2_stm32u5_caps,						\
+		.pre_enable = udc_dwc2_stm32u5_pre_enable_##n,				\
+		.post_enable = udc_dwc2_stm32u5_post_enable,				\
+		.shutdown = udc_dwc2_stm32u5_shutdown_##n,				\
+	};
+
+/* Define the quirks only for instances that use this compatible */
+#define QUIRK_STM32U5_HSOTG_DEFINE_COMPAT(n)						\
+	IF_ENABLED(DT_NODE_HAS_COMPAT(DT_DRV_INST(n), st_stm32u5_hsotg),		\
+		   (QUIRK_STM32U5_HSOTG_DEFINE(n)))
+
+DT_INST_FOREACH_STATUS_OKAY(QUIRK_STM32U5_HSOTG_DEFINE_COMPAT)
+
+#endif /* ZEPHYR_DRIVERS_USB_UDC_DWC2_STM32U5_HSOTG_H */

--- a/drivers/usb/uhc/uhc_dwc2.c
+++ b/drivers/usb/uhc/uhc_dwc2.c
@@ -288,8 +288,9 @@ static inline int dwc2_core_init_host_gusbcfg(const struct device *dev)
 	uint32_t ghwcfg4 = sys_read32((mem_addr_t)&base->ghwcfg4);
 	const k_timepoint_t timepoint = sys_timepoint_calc(K_MSEC(100));
 
-	/* Enable Host mode */
-	sys_set_bits((mem_addr_t)&base->gusbcfg, USB_DWC2_GUSBCFG_FORCEHSTMODE);
+	/* Force host mode as we do not support mode changes yet */
+	gusbcfg |= USB_DWC2_GUSBCFG_FORCEHSTMODE;
+	sys_write32(gusbcfg, (mem_addr_t)&base->gusbcfg);
 
 	/* Wait until core is in host mode */
 	while ((sys_read32((mem_addr_t)&base->gintsts) & USB_DWC2_GINTSTS_CURMOD) == 0) {
@@ -340,6 +341,7 @@ static inline int dwc2_core_init_host_gusbcfg(const struct device *dev)
 				gusbcfg &= ~USB_DWC2_GUSBCFG_PHYIF_16_BIT;
 			}
 		}
+
 		sys_write32(gusbcfg, (mem_addr_t)&base->gusbcfg);
 	}
 

--- a/drivers/usb/uhc/uhc_dwc2.h
+++ b/drivers/usb/uhc/uhc_dwc2.h
@@ -69,6 +69,9 @@ struct uhc_dwc2_config {
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_usbhs_nrf54l)
 #include "uhc_dwc2_nrf_usbhs_nrf54l.h"
 #endif
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32u5_hsotg)
+#include "uhc_dwc2_stm32u5_hsotg.h"
+#endif
 
 #define UHC_DWC2_VENDOR_QUIRK_GET(n)						\
 	COND_CODE_1(DT_NODE_VENDOR_HAS_IDX(DT_DRV_INST(n), 1),			\

--- a/drivers/usb/uhc/uhc_dwc2_stm32u5_hsotg.h
+++ b/drivers/usb/uhc/uhc_dwc2_stm32u5_hsotg.h
@@ -1,0 +1,253 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_USB_UHC_DWC2_STM32U5_HSOTG_H
+#define ZEPHYR_DRIVERS_USB_UHC_DWC2_STM32U5_HSOTG_H
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+
+#include <usb_dwc2_hw.h>
+
+/* HAL SYSCFG for the embedded HS PHY, LL PWR for the USB power supply */
+#include <soc.h>
+#include <stm32_ll_pwr.h>
+
+/* STM32U5 OTG_HS host quirk configuration */
+struct uhc_dwc2_stm32u5_config {
+	const struct device *clk_dev;
+	const struct stm32_pclken *pclken;
+	const struct stm32_pclken *phy_pclken;
+	size_t phy_pclken_len;
+	uint32_t phy_ref_clk;
+	const struct pinctrl_dev_config *pcfg;
+	/* External VBUS power-switch enable, optional */
+	struct gpio_dt_spec vbus_gpio;
+};
+
+struct uhc_dwc2_stm32u5_data {
+	uint32_t reserved;
+};
+
+static inline int uhc_dwc2_stm32u5_enable_clk(const struct uhc_dwc2_stm32u5_config *const cfg)
+{
+	if (!device_is_ready(cfg->clk_dev)) {
+		return -ENODEV;
+	}
+
+	return clock_control_on(cfg->clk_dev, (void *)&cfg->pclken[0]);
+}
+
+/* Enable the USB power supply (mirrors the STM32U5 path in stm32_usb_pwr_enable()) */
+static inline int uhc_dwc2_stm32u5_enable_pwr(void)
+{
+	if (LL_PWR_GetRegulVoltageScaling() < LL_PWR_REGU_VOLTAGE_SCALE2) {
+		LOG_ERR("Wrong power range to use USB OTG_HS");
+		return -EIO;
+	}
+
+	LL_PWR_EnableVddUSB();
+	LL_PWR_EnableUSBPowerSupply();
+	LL_PWR_EnableUSBEPODBooster();
+	while (LL_PWR_IsActiveFlag_USBBOOST() != 1) {
+		/* Wait for the USB EPOD booster to be ready */
+	}
+
+	return 0;
+}
+
+/*
+ * Bring up the embedded High-Speed PHY
+ * (mirrors the drivers/usb/common/stm32/phy_u5otghs.c sequence)
+ */
+static inline int uhc_dwc2_stm32u5_enable_phy(const struct device *const dev)
+{
+	const struct uhc_dwc2_stm32u5_config *const cfg = UHC_DWC2_QUIRK_CONFIG(dev);
+	int ret;
+
+	/* SYSCFG holds the OTG_HS PHY configuration registers */
+	__HAL_RCC_SYSCFG_CLK_ENABLE();
+
+	/* Select the PHY reference clock frequency */
+	HAL_SYSCFG_SetOTGPHYReferenceClockSelection(cfg->phy_ref_clk);
+
+	/* Deassert the PHY reset */
+	HAL_SYSCFG_EnableOTGPHY(SYSCFG_OTG_HS_PHY_ENABLE);
+
+	if (cfg->phy_pclken_len > 1) {
+		/* Select the PHY kernel clock source */
+		ret = clock_control_configure(cfg->clk_dev, (void *)&cfg->phy_pclken[1], NULL);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	/* Turn on the PHY clock */
+	return clock_control_on(cfg->clk_dev, (void *)&cfg->phy_pclken[0]);
+}
+
+static inline void uhc_dwc2_stm32u5_disable_phy(const struct device *const dev)
+{
+	const struct uhc_dwc2_stm32u5_config *const cfg = UHC_DWC2_QUIRK_CONFIG(dev);
+
+	(void)clock_control_off(cfg->clk_dev, (void *)&cfg->phy_pclken[0]);
+}
+
+static inline void uhc_dwc2_stm32u5_disable_clk(const struct device *const dev)
+{
+	const struct uhc_dwc2_stm32u5_config *const cfg = UHC_DWC2_QUIRK_CONFIG(dev);
+
+	(void)clock_control_off(cfg->clk_dev, (void *)&cfg->pclken[0]);
+}
+
+static inline void uhc_dwc2_stm32u5_disable_pwr(void)
+{
+	LL_PWR_DisableUSBEPODBooster();
+	while (LL_PWR_IsActiveFlag_USBBOOST() != 0) {
+		/* Wait for the USB EPOD booster to turn off */
+	}
+
+	LL_PWR_DisableUSBPowerSupply();
+	LL_PWR_DisableVddUSB();
+}
+
+/*
+ * Enable the USB power supply, the OTG_HS clock and bring up the high-speed PHY.
+ * The DWC2 core soft reset, dwc2_core_soft_reset(), performed later in
+ * uhc_dwc2_init() only completes with a running PHY clock, so the PHY must be
+ * clocked here first.
+ */
+static inline int uhc_dwc2_stm32u5_pre_init(const struct device *const dev)
+{
+	const struct uhc_dwc2_stm32u5_config *const cfg = UHC_DWC2_QUIRK_CONFIG(dev);
+	int ret;
+
+	ret = uhc_dwc2_stm32u5_enable_pwr();
+	if (ret) {
+		return ret;
+	}
+
+	ret = uhc_dwc2_stm32u5_enable_clk(cfg);
+	if (ret) {
+		return ret;
+	}
+
+	if (cfg->pcfg != NULL) {
+		ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	return uhc_dwc2_stm32u5_enable_phy(dev);
+}
+
+static inline int uhc_dwc2_stm32u5_shutdown(const struct device *const dev)
+{
+	uhc_dwc2_stm32u5_disable_phy(dev);
+	uhc_dwc2_stm32u5_disable_clk(dev);
+	uhc_dwc2_stm32u5_disable_pwr();
+
+	return 0;
+}
+
+/*
+ * Enable the PHY pulldown resistors so the root port detects a device
+ * connecting, and clear the device-mode VBUS overrides (as the STM32 HAL
+ * USB_HostInit() does).
+ */
+static inline int uhc_dwc2_stm32u5_pre_enable(const struct device *const dev)
+{
+	const mem_addr_t ggpio = (mem_addr_t)&uhc_dwc2_get_base(dev)->ggpio;
+
+	sys_set_bits(ggpio, USB_OTG_GCCFG_PULLDOWNEN);
+	sys_clear_bits(ggpio, USB_OTG_GCCFG_VBDEN | USB_OTG_GCCFG_VBVALEXTOEN |
+			      USB_OTG_GCCFG_VBVALOVAL);
+
+	return 0;
+}
+
+static inline int uhc_dwc2_stm32u5_post_enable(const struct device *const dev)
+{
+	const struct uhc_dwc2_stm32u5_config *const cfg = UHC_DWC2_QUIRK_CONFIG(dev);
+
+	if (cfg->vbus_gpio.port == NULL) {
+		return 0;
+	}
+
+	if (!gpio_is_ready_dt(&cfg->vbus_gpio)) {
+		LOG_ERR("VBUS enable GPIO not ready");
+		return -ENODEV;
+	}
+
+	return gpio_pin_configure_dt(&cfg->vbus_gpio, GPIO_OUTPUT_ACTIVE);
+}
+
+static inline int uhc_dwc2_stm32u5_disable(const struct device *const dev)
+{
+	const struct uhc_dwc2_stm32u5_config *const cfg = UHC_DWC2_QUIRK_CONFIG(dev);
+
+	if (cfg->vbus_gpio.port != NULL) {
+		(void)gpio_pin_set_dt(&cfg->vbus_gpio, 0);
+	}
+
+	return 0;
+}
+
+/*
+ * The PHY node holds the reference clock selection and the PHY clocks. The
+ * SYSCFG_OTG_HS_PHY_CLK_SELECT_<n> values go from 1 to N, whereas DT_ENUM_IDX()
+ * is zero-based, hence the UTIL_INC().
+ */
+#define UHC_DWC2_STM32U5_PHY_NODE(n)	DT_INST_PHANDLE(n, phys)
+
+#define UHC_DWC2_STM32U5_PHY_REF_CLK(n)							\
+	CONCAT(SYSCFG_OTG_HS_PHY_CLK_SELECT_,						\
+	       UTIL_INC(DT_ENUM_IDX(UHC_DWC2_STM32U5_PHY_NODE(n), clock_reference)))
+
+#define UHC_DWC2_STM32U5_PCFG(n)							\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, pinctrl_0),				\
+		    (PINCTRL_DT_INST_DEV_CONFIG_GET(n)), (NULL))
+
+#define QUIRK_STM32U5_HSOTG_DEFINE(n)							\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, pinctrl_0),				\
+		    (PINCTRL_DT_INST_DEFINE(n);), ())					\
+	static const struct stm32_pclken pclken_##n[] = STM32_DT_INST_CLOCKS(n);	\
+	static const struct stm32_pclken phy_pclken_##n[] =				\
+		STM32_DT_CLOCKS(UHC_DWC2_STM32U5_PHY_NODE(n));				\
+											\
+	static const struct uhc_dwc2_stm32u5_config uhc_dwc2_quirk_config_##n = {	\
+		.clk_dev = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),			\
+		.pclken = pclken_##n,							\
+		.phy_pclken = phy_pclken_##n,						\
+		.phy_pclken_len = DT_NUM_CLOCKS(UHC_DWC2_STM32U5_PHY_NODE(n)),		\
+		.phy_ref_clk = UHC_DWC2_STM32U5_PHY_REF_CLK(n),				\
+		.pcfg = UHC_DWC2_STM32U5_PCFG(n),					\
+		.vbus_gpio = GPIO_DT_SPEC_INST_GET_OR(n, vbus_gpios, {0}),		\
+	};										\
+											\
+	static struct uhc_dwc2_stm32u5_data uhc_dwc2_quirk_data_##n;			\
+											\
+	static const struct uhc_dwc2_vendor_quirks uhc_dwc2_vendor_quirks_##n = {	\
+		.pre_init = uhc_dwc2_stm32u5_pre_init,					\
+		.pre_enable = uhc_dwc2_stm32u5_pre_enable,				\
+		.post_enable = uhc_dwc2_stm32u5_post_enable,				\
+		.disable = uhc_dwc2_stm32u5_disable,					\
+		.shutdown = uhc_dwc2_stm32u5_shutdown,					\
+	};
+
+/* Define the quirks only for instances that use this compatible */
+#define QUIRK_STM32U5_HSOTG_DEFINE_COMPAT(n)						\
+	IF_ENABLED(DT_NODE_HAS_COMPAT(DT_DRV_INST(n), st_stm32u5_hsotg),		\
+		   (QUIRK_STM32U5_HSOTG_DEFINE(n)))
+
+DT_INST_FOREACH_STATUS_OKAY(QUIRK_STM32U5_HSOTG_DEFINE_COMPAT)
+
+#endif /* ZEPHYR_DRIVERS_USB_UHC_DWC2_STM32U5_HSOTG_H */

--- a/dts/bindings/usb/st,stm32u5-hsotg.yaml
+++ b/dts/bindings/usb/st,stm32u5-hsotg.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32U5 OTG_HS DWC2 compatible controller. The high-speed PHY is selected by
+  the "phys" phandle.
+
+compatible: "st,stm32u5-hsotg"
+
+include: ["snps,dwc2.yaml", "pinctrl-device.yaml"]
+
+properties:
+  clocks:
+    required: true
+
+  vbus-gpios:
+    type: phandle-array
+    description: |
+      GPIO controlling the external VBUS power switch in USB host mode.
+      The GPIO, if defined, is used by the vendor quirk, and is active when USB
+      host is enabled.


### PR DESCRIPTION
This PR enables USB host support on STM32U5 family that have the OTG_HS controller
with the embedded high-speed PHY.

It also fixes an issue where STM32U5 OTG_HS based USB devices do not pass testusb tests (TEST13 set/clear halts).

The quirks are tested on NUCLEO-U5A5ZJ-Q. The board flashed with `samples/subsys/usb/testusb` passed all the `testusb` tests.

May or not depend on #112859