### PR TITLE
modem: cellular: improve CMUX disconnect handling

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1727,13 +1727,24 @@ static void modem_cellular_init_power_off_event_handler(struct modem_cellular_da
 		data->cmd_pipe = data->uart_pipe;
 		/* CMUX disconnected, notify users */
 		modem_cellular_cmux_cleanup(data);
+		/* Switch the chat instance back to the UART pipe to handle unsolicited events */
+		modem_chat_attach(&data->chat, data->cmd_pipe);
 		/* Assume the same time as reset pulse is enough to return from CMUX to AT mode */
 		modem_cellular_start_timer(data, K_MSEC(config->vendor->reset_pulse_duration_ms));
 		break;
+	case MODEM_CELLULAR_EVENT_MODEM_READY:
+		/* Modem driver indicated it is ready to handle commands after disconnecting CMUX.
+		 * Cancel the timer and proceed as if it has expired.
+		 */
+		modem_cellular_stop_timer(data);
+		__fallthrough;
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
 		if (data->cmd_pipe != data->uart_pipe) {
 			/* No CMUX_DISCONNECTED event occurred, notify users here */
 			modem_cellular_cmux_cleanup(data);
+		} else {
+			/* Release the chat instance attached in CMUX_DISCONNECTED */
+			modem_chat_release(&data->chat);
 		}
 		/* Shutdown script can only be used if cmd_pipe is available, i.e. we are not in
 		 * some intermediary state without a pipe for commands available

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1720,6 +1720,7 @@ static void modem_cellular_init_power_off_event_handler(struct modem_cellular_da
 							enum modem_cellular_event evt)
 {
 	const struct modem_cellular_config *config = data->dev->config;
+	uint16_t disconnect_timeout_ms;
 
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_CMUX_DISCONNECTED:
@@ -1729,8 +1730,14 @@ static void modem_cellular_init_power_off_event_handler(struct modem_cellular_da
 		modem_cellular_cmux_cleanup(data);
 		/* Switch the chat instance back to the UART pipe to handle unsolicited events */
 		modem_chat_attach(&data->chat, data->cmd_pipe);
-		/* Assume the same time as reset pulse is enough to return from CMUX to AT mode */
-		modem_cellular_start_timer(data, K_MSEC(config->vendor->reset_pulse_duration_ms));
+		/* Fallback to `reset_pulse_duration_ms` if `cmux_disconnect_timeout_ms` not
+		 * specified as this was the behaviour before Zephyr v4.5.
+		 */
+		disconnect_timeout_ms = config->vendor->cmux_disconnect_timeout_ms > 0U
+						? config->vendor->cmux_disconnect_timeout_ms
+						: config->vendor->reset_pulse_duration_ms;
+		/* Unless signalled, wait for the modem to return from CMUX to AT mode */
+		modem_cellular_start_timer(data, K_MSEC(disconnect_timeout_ms));
 		break;
 	case MODEM_CELLULAR_EVENT_MODEM_READY:
 		/* Modem driver indicated it is ready to handle commands after disconnecting CMUX.

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1709,6 +1709,13 @@ static int modem_cellular_on_init_power_off_state_enter(struct modem_cellular_da
 	return 0;
 }
 
+static void modem_cellular_cmux_cleanup(struct modem_cellular_data *data)
+{
+	modem_cellular_notify_user_pipes_disconnected(data);
+	modem_chat_release(&data->chat);
+	modem_ppp_release(data->ppp);
+}
+
 static void modem_cellular_init_power_off_event_handler(struct modem_cellular_data *data,
 							enum modem_cellular_event evt)
 {
@@ -1718,10 +1725,16 @@ static void modem_cellular_init_power_off_event_handler(struct modem_cellular_da
 	case MODEM_CELLULAR_EVENT_CMUX_DISCONNECTED:
 		modem_cellular_stop_timer(data);
 		data->cmd_pipe = data->uart_pipe;
+		/* CMUX disconnected, notify users */
+		modem_cellular_cmux_cleanup(data);
 		/* Assume the same time as reset pulse is enough to return from CMUX to AT mode */
 		modem_cellular_start_timer(data, K_MSEC(config->vendor->reset_pulse_duration_ms));
 		break;
 	case MODEM_CELLULAR_EVENT_TIMEOUT:
+		if (data->cmd_pipe != data->uart_pipe) {
+			/* No CMUX_DISCONNECTED event occurred, notify users here */
+			modem_cellular_cmux_cleanup(data);
+		}
 		/* Shutdown script can only be used if cmd_pipe is available, i.e. we are not in
 		 * some intermediary state without a pipe for commands available
 		 */
@@ -1736,14 +1749,6 @@ static void modem_cellular_init_power_off_event_handler(struct modem_cellular_da
 	default:
 		break;
 	}
-}
-
-static int modem_cellular_on_init_power_off_state_leave(struct modem_cellular_data *data)
-{
-	modem_cellular_notify_user_pipes_disconnected(data);
-	modem_chat_release(&data->chat);
-	modem_ppp_release(data->ppp);
-	return 0;
 }
 
 static int modem_cellular_on_run_shutdown_script_state_enter(struct modem_cellular_data *data)
@@ -1976,10 +1981,6 @@ static int modem_cellular_on_state_leave(struct modem_cellular_data *data)
 
 	case MODEM_CELLULAR_STATE_AWAIT_PPP_DEAD:
 		ret = modem_cellular_on_await_ppp_dead_state_leave(data);
-		break;
-
-	case MODEM_CELLULAR_STATE_INIT_POWER_OFF:
-		ret = modem_cellular_on_init_power_off_state_leave(data);
 		break;
 
 	case MODEM_CELLULAR_STATE_RUN_SHUTDOWN_SCRIPT:

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
@@ -58,6 +58,8 @@ static const struct modem_cellular_vendor_config nrf93m1_vendor = {
 	/* clang-format on */
 	.power_pulse_duration_ms = 100,
 	.reset_pulse_duration_ms = 500,
+	/* In practice RDY event short circuits this timeout */
+	.cmux_disconnect_timeout_ms = 3000,
 	.startup_time_ms = 5000,
 	.shutdown_time_ms = 1000,
 };

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -287,6 +287,11 @@ struct modem_cellular_vendor_config {
 	uint16_t power_pulse_duration_ms;
 	/** Duration of the modem reset pulse, in milliseconds. */
 	uint16_t reset_pulse_duration_ms;
+	/** Timeout for the modem to revert from CMUX to AT mode after a CMUX disconnect, in
+	 * milliseconds. Defaults to @c reset_pulse_duration_ms if not specified (value == 0U) for
+	 * legacy compatibility.
+	 */
+	uint16_t cmux_disconnect_timeout_ms;
 	/** Maximum modem startup delay, in milliseconds. */
 	uint16_t startup_time_ms;
 	/** Maximum modem shutdown delay, in milliseconds. */


### PR DESCRIPTION
Notify all CMUX users that the interface has closed immediately upon receiving the `CMUX_DISCONNECTED` event, instead of at some arbitrarily later time point (`reset_pulse_duration_ms` later).

Some modems output a message after a CMUX session disconnects and it is ready to accept commands again on the non-multiplexed interface (nRF93M1 for example outputs `RDY`). Update the `INIT_POWER_OFF` handling to support early exit from this state if a `MODEM_READY` event is received.

Allow modem driver to explicitly set the timeout for the modem to return to AT mode after CMUX disconnects. If not specified, it falls back to the current behaviour (`reset_pulse_duration_ms`).