### PR TITLE
driver/ieee802154: ieee802154_silabs_efr32 potential blocking issue

### DIFF
--- a/drivers/ieee802154/ieee802154_silabs_efr32.c
+++ b/drivers/ieee802154/ieee802154_silabs_efr32.c
@@ -1206,6 +1206,10 @@ static sl_rail_status_t sl_802154_handle_data_request_command(struct sl_802154_d
 
 static void sl_802154_handle_tx_failed(struct sl_802154_data *data)
 {
+	if (data->tx_mhr.fs->fc.ar) {
+		k_sem_give(&data->ack_wait);
+	}
+
 	sl_802154_state_clear_tx_data_and_wait_for_ack(&data->radio_data.state);
 	sl_802154_yield_radio(data->radio_data.rail_handle);
 }
@@ -1214,8 +1218,7 @@ static void sl_802154_handle_ack_timeout(struct sl_802154_data *data)
 {
 	__ASSERT_NO_MSG(sl_802154_state_is_tx_data_ongoing(&data->radio_data.state));
 	__ASSERT_NO_MSG(sl_802154_state_is_waiting_for_ack(&data->radio_data.state));
-	sl_802154_state_set_tx_data_ongoing(&data->radio_data.state, false);
-	sl_802154_state_set_waiting_for_ack(&data->radio_data.state, false);
+	sl_802154_state_clear_tx_data_and_wait_for_ack(&data->radio_data.state);
 	data->ack_errno = -ENOMSG;
 	k_sem_give(&data->ack_wait);
 	sl_802154_yield_radio(data->radio_data.rail_handle);


### PR DESCRIPTION
Modification:
- Give the ack wait semaphore in `sl_802154_handle_tx_failed`
- Use `sl_802154_state_clear_tx_data_and_wait_for_ack` in `sl_802154_handle_ack_timeout`

Reason:
- The driver could be blocked in this scenarios:
  1. Start TX return no error
  2. Block with tx wait
  3. Block with ack wait
  4. Radio performs transmision but failed, `SL_RAIL_EVENT_TX_PACKET_SENT` never fires (another tx error occurs like `SL_RAIL_EVENT_TX_CHANNEL_BUSY`) so that ACK timeout timer can't start and `SL_RAIL_EVENT_RX_ACK_TIMEOUT` never reach, but now we are already blocked by ack wait
- set both clear action in one operation since we already func to do it