### PR TITLE
cmake: gcc: fix GCC emitting double-precision FP instructions on single-precision Cortex-M55

### DIFF
--- a/cmake/compiler/gcc/target_arm.cmake
+++ b/cmake/compiler/gcc/target_arm.cmake
@@ -16,7 +16,16 @@ if(CONFIG_BIG_ENDIAN)
 endif()
 
 if(CONFIG_FPU)
-  list(APPEND ARM_C_FLAGS   -mfpu=${GCC_M_FPU})
+  if("${GCC_M_FPU}" STREQUAL "auto" AND NOT CONFIG_CPU_HAS_FPU_DOUBLE_PRECISION)
+    # GCC derives MVE capability from -mcpu, so -mfpu=fpv5-sp-d16 does not
+    # disable mve.fp (unlike clang).  When the SoC has only a single-precision
+    # FPU but GCC_M_FPU resolved to "auto", gcc would otherwise assume the
+    # full double-precision FPU implied by the CPU default.  Override it
+    # explicitly so that double-precision FP instructions are not emitted.
+    list(APPEND ARM_C_FLAGS   -mfpu=fpv5-sp-d16)
+  else()
+    list(APPEND ARM_C_FLAGS   -mfpu=${GCC_M_FPU})
+  endif()
 
   if(CONFIG_DCLS AND NOT CONFIG_FP_HARDABI)
     # If the processor is equipped with VFP and configured in DCLS topology,


### PR DESCRIPTION
 ## Problem

  The Realtek RTL87x2G (Cortex-M55) is an unusual configuration:
  it has **full MVE** (both integer MVE and MVE with float, i.e.
  `ARMV8_1_M_MVEI` + `ARMV8_1_M_MVEF`) and **DSP**, but only a
  **single-precision FPU** — double-precision instructions are not
  implemented in hardware.

  Because both MVE variants are present, `gcc-m-cpu.cmake` resolves
  `GCC_M_CPU` to the bare `cortex-m55` (the first branch, no `+nomve.*`
  suffix).  This means `gcc-m-fpu.cmake` looks up `FPU_FOR_cortex-m55`,
  and whatever value that holds is what GCC receives for `-mfpu=`.

  ### Timeline of regressions

  1. **Before commit 6612580** — `FPU_FOR_cortex-m55` was `auto`.
     GCC inferred double-precision from `-mcpu=cortex-m55`, so
     double-precision FP instructions could be emitted on a chip that
     does not support them.

  2. **commit 6612580** (`cmake: gcc-m-fpu: Support Cortex-M55 with
     single-precision FPU`) — changed `FPU_FOR_cortex-m55` to
     `fpv5-${PRECISION_TOKEN}d16`.  With `CPU_HAS_FPU_DOUBLE_PRECISION`
     unset, `PRECISION_TOKEN = "sp-"`, so GCC received `-mfpu=fpv5-sp-d16`.
     **This correctly prevented double-precision codegen on RTL87x2G.**

  3. **commit 570ef09** (`cmake: clang: fix MVE FP disabled on Cortex-M55
     with -mfpu=fpv5-sp-d16`) — reverted `FPU_FOR_cortex-m55` back to
     `auto` in the shared `gcc-m-fpu.cmake` to fix a clang regression
     (clang treats `-mfpu=` as an explicit capability override, so
     `-mfpu=fpv5-sp-d16` silently disables `mve.fp`).  The clang fix was
     correct, but editing the shared file also reverted the GCC behaviour.
     **Double-precision instructions can be emitted on RTL87x2G again.**

  ## Fix

  GCC and clang have different semantics for `-mfpu=`:

  - **GCC**: MVE capability comes from `-mcpu`/`-march` only; `-mfpu=`
    controls scalar FP precision and does not affect MVE.  Passing
    `-mfpu=fpv5-sp-d16` is safe and correct.
  - **clang**: `-mfpu=` is a full capability override; any feature not
    listed is disabled, so `fpv5-sp-d16` removes `mve.fp`.

  The right fix is therefore toolchain-specific.  This PR adds a guard
  in the **GCC-only** `cmake/compiler/gcc/target_arm.cmake`: when
  `GCC_M_FPU` is `"auto"` and `CPU_HAS_FPU_DOUBLE_PRECISION` is not set,
  explicitly pass `-mfpu=fpv5-sp-d16` to prevent GCC from assuming
  double-precision.

  The clang and armclang paths already skip `-mfpu=` entirely for `"auto"`
  (via guards added in commits 570ef09 and f30235f respectively) and are
  not changed.

  ## Impact

  No behaviour change for:
  - Any platform where `CPU_HAS_FPU_DOUBLE_PRECISION` is set
  - Any platform where `GCC_M_FPU != "auto"` (e.g. `cortex-m55+nomve.fp`)
  - clang or armclang builds

  Fixes double-precision FP codegen for any GCC build targeting a
  Cortex-M55 (or similarly resolved `auto` CPU) with a single-precision
  FPU only.

Assisted By Claude