### PR TITLE
drivers: bluetooth: HCI: fix unaligned access in extended adv report

### DIFF
--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -365,10 +365,10 @@ static bool is_hci_event_discardable(const uint8_t *evt_data)
 		case BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT: {
 			const struct bt_hci_evt_le_ext_advertising_report *ext_adv =
 				(void *)&evt_data[3];
+			uint16_t adv_evt_type = sys_le16_to_cpu(ext_adv->adv_info[0].evt_type);
 
 			return (ext_adv->num_reports == 1) &&
-			       ((ext_adv->adv_info[0].evt_type & BT_HCI_LE_ADV_EVT_TYPE_LEGACY) !=
-				0);
+			       ((adv_evt_type & BT_HCI_LE_ADV_EVT_TYPE_LEGACY) != 0);
 		}
 #endif
 		default:

--- a/drivers/bluetooth/hci/hci_silabs_efr32.c
+++ b/drivers/bluetooth/hci/hci_silabs_efr32.c
@@ -79,11 +79,13 @@ static bool slz_is_evt_discardable(const struct bt_hci_evt_hdr *hdr, const uint8
 				return false;
 			}
 
+			uint16_t adv_evt_type = sys_le16_to_cpu(evt->adv_info[0].evt_type);
+
 			/* Never discard if the event could be part of a multi-part report event,
 			 * because the missing part could confuse the BT host.
 			 */
 			return (evt->num_reports == 1) &&
-			       ((evt->adv_info[0].evt_type & BT_HCI_LE_ADV_EVT_TYPE_LEGACY) != 0);
+			       ((adv_evt_type & BT_HCI_LE_ADV_EVT_TYPE_LEGACY) != 0);
 		}
 		default:
 			return false;

--- a/drivers/bluetooth/hci/ipc.c
+++ b/drivers/bluetooth/hci/ipc.c
@@ -70,10 +70,10 @@ static bool is_hci_event_discardable(const uint8_t *evt_data)
 		{
 			const struct bt_hci_evt_le_ext_advertising_report *ext_adv =
 				(void *)&evt_data[3];
+			uint16_t adv_evt_type = sys_le16_to_cpu(ext_adv->adv_info[0].evt_type);
 
 			return (ext_adv->num_reports == 1) &&
-				   ((ext_adv->adv_info[0].evt_type &
-					 BT_HCI_LE_ADV_EVT_TYPE_LEGACY) != 0);
+			       ((adv_evt_type & BT_HCI_LE_ADV_EVT_TYPE_LEGACY) != 0);
 		}
 #endif
 		default:

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -77,10 +77,10 @@ static bool is_hci_event_discardable(const struct bt_hci_evt_hdr *evt)
 		case BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT: {
 			const struct bt_hci_evt_le_ext_advertising_report *ext_adv =
 				(const void *)meta_evt->data;
+			uint16_t adv_evt_type = sys_le16_to_cpu(ext_adv->adv_info[0].evt_type);
 
 			return (ext_adv->num_reports == 1) &&
-			       ((ext_adv->adv_info[0].evt_type & BT_HCI_LE_ADV_EVT_TYPE_LEGACY) !=
-				0);
+			       ((adv_evt_type & BT_HCI_LE_ADV_EVT_TYPE_LEGACY) != 0);
 		}
 #endif
 		default:


### PR DESCRIPTION
When processing LE Extended Advertising Report events in is_hci_event_discardable(), the evt_type field of adv_info[0] may reside at an unaligned address. This occurs because evt_data can point to shared memory (e.g., IMU buffer) at an odd address, and the evt_type (uint16_t) ends up at an odd offset after the packed struct layout.

On Cortex-M33 with UNALIGN_TRP enabled, this causes a HardFault.

Use sys_le16_to_cpu() to read the evt_type field, which ensures the compiler generates byte-level access (LDRB) for the packed struct member, avoiding the unaligned LDRH instruction.