### PR TITLE
Add mcxa344 opamp support

### DIFF
--- a/boards/nxp/frdm_mcxa344/board.c
+++ b/boards/nxp/frdm_mcxa344/board.c
@@ -224,6 +224,21 @@ void board_early_init_hook(void)
 	CLOCK_SetClockDiv(kCLOCK_DivWWDT0, 1u);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(opamp0))
+	RESET_ReleasePeripheralReset(kOPAMP0_RST_SHIFT_RSTn);
+	SPC_EnableActiveModeAnalogModules(SPC0, kSPC_controlOpamp0);
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(opamp1))
+	RESET_ReleasePeripheralReset(kOPAMP1_RST_SHIFT_RSTn);
+	SPC_EnableActiveModeAnalogModules(SPC0, kSPC_controlOpamp1);
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(opamp2))
+	RESET_ReleasePeripheralReset(kOPAMP2_RST_SHIFT_RSTn);
+	SPC_EnableActiveModeAnalogModules(SPC0, kSPC_controlOpamp2);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 }

--- a/boards/nxp/frdm_mcxa344/frdm_mcxa344-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa344/frdm_mcxa344-pinctrl.dtsi
@@ -99,4 +99,24 @@
 			drive-strength = "low";
 		};
 	};
+
+	pinmux_opamp0: pinmux_opamp0 {
+		group0 {
+			pinmux = <OPAMP0_INP_P2_12>,
+				 <OPAMP0_INN_P2_13>,
+				 <OPAMP0_OUT_P2_15>;
+			drive-strength = "low";
+			slew-rate = "fast";
+		};
+	};
+
+	pinmux_opamp1: pinmux_opamp1 {
+		group0 {
+			pinmux = <OPAMP1_INP_P2_16>,
+				 <OPAMP1_INN_P2_17>,
+				 <OPAMP1_OUT_P2_19>;
+			drive-strength = "low";
+			slew-rate = "fast";
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
+++ b/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
@@ -238,3 +238,10 @@
 	pinctrl-0 = <&pinmux_flexpwm0_pwm0>;
 	pinctrl-names = "default";
 };
+
+/* OPAMP configuration */
+&opamp0 {
+	pinctrl-0 = <&pinmux_opamp0>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/nxp/frdm_mcxa344/frdm_mcxa344.yaml
+++ b/boards/nxp/frdm_mcxa344/frdm_mcxa344.yaml
@@ -26,4 +26,5 @@ supported:
   - watchdog
   - edac
   - pwm
+  - opamp
 vendor: nxp

--- a/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
@@ -614,6 +614,30 @@
 			resets = <&reset NXP_SYSCON_RESET(0, 13)>;
 			status = "disabled";
 		};
+
+		opamp0: opamp@400b7000 {
+			compatible = "nxp,opamp-fast";
+			reg = <0x400b7000 0x1000>;
+			status = "disabled";
+			clocks = <&syscon MCUX_OPAMP0_CLK>;
+			functional-mode = "follower";
+		};
+
+		opamp1: opamp@400b8000 {
+			compatible = "nxp,opamp-fast";
+			reg = <0x400b8000 0x1000>;
+			status = "disabled";
+			clocks = <&syscon MCUX_OPAMP1_CLK>;
+			functional-mode = "follower";
+		};
+
+		opamp2: opamp@400b9000 {
+			compatible = "nxp,opamp-fast";
+			reg = <0x400b9000 0x1000>;
+			status = "disabled";
+			clocks = <&syscon MCUX_OPAMP2_CLK>;
+			functional-mode = "follower";
+		};
 	};
 };
 

--- a/samples/drivers/opamp/output_measure/boards/frdm_mcxa344.overlay
+++ b/samples/drivers/opamp/output_measure/boards/frdm_mcxa344.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/mcux-lpadc.h>
+
+/ {
+	zephyr,user {
+		opamp = <&opamp0>;
+		adc-read-delay-ms = <1>;
+		io-channels = <&lpadc0 0>;
+	};
+};
+
+&opamp0 {
+	functional-mode = "differential";
+};
+
+&lpadc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,vref-mv = <3300>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <16>;
+		/* LPADC0 CH2A is internally connected to the operational amplifier output. */
+		zephyr,input-positive = <MCUX_LPADC_CH2A>;
+	};
+};

--- a/samples/drivers/opamp/output_measure/tests.yaml
+++ b/samples/drivers/opamp/output_measure/tests.yaml
@@ -19,3 +19,4 @@ tests:
       - frdm_mcxn947/mcxn947/cpu0
       - lpcxpresso55s36
       - nucleo_g474re/stm32g474xx
+      - frdm_mcxa344

--- a/tests/drivers/build_all/opamp/boards/frdm_mcxa344.overlay
+++ b/tests/drivers/build_all/opamp/boards/frdm_mcxa344.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&opamp0 {
+	bias-current = <1>;
+	compensation-capcitor = <0>;
+	functional-mode = "differential";
+};

--- a/tests/drivers/build_all/opamp/tests.yaml
+++ b/tests/drivers/build_all/opamp/tests.yaml
@@ -17,6 +17,7 @@ tests:
     platform_allow:
       - frdm_mcxa366
       - frdm_mcxa346
+      - frdm_mcxa344
   drivers.opamp.build.stm32_opamp:
     platform_allow:
       - nucleo_g474re

--- a/tests/drivers/opamp/opamp_api/boards/frdm_mcxa344.overlay
+++ b/tests/drivers/opamp/opamp_api/boards/frdm_mcxa344.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		opamp = <&opamp0>;
+	};
+};
+
+&opamp0 {
+	functional-mode = "differential";
+	compensation-capcitor = <0>;
+};


### PR DESCRIPTION
Add mcxa344 opamp support.

tests/drivers/opamp/opamp_api
```
*** Booting Zephyr OS build v3.7.0-45369-g9a13e820a9da ***
Running TESTSUITE opamp
===================================================================
START - test_init_opamp
 PASS - test_init_opamp in 0.001 seconds
===================================================================
TESTSUITE opamp succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [opamp]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.001 seconds
 - PASS - [opamp.test_init_opamp] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```
samples/drivers/opamp/output_measure
```
*** Booting Zephyr OS build v3.7.0-45372-g8c0991e49a7f ***
OPAMP output (@gain: default) is: 1649(mv)
```