### PR TITLE
tests: kernel: lifo: use K_NO_WAIT for lifo get from ISR

### DIFF
--- a/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
@@ -26,14 +26,14 @@ static void tlifo_put(struct k_lifo *plifo)
 	}
 }
 
-static void tlifo_get(struct k_lifo *plifo)
+static void tlifo_get(struct k_lifo *plifo, k_timeout_t timeout)
 {
 	void *rx_data;
 
 	/*get lifo data*/
 	for (int i = LIST_LEN-1; i >= 0; i--) {
 		/**TESTPOINT: lifo get*/
-		rx_data = k_lifo_get(plifo, K_FOREVER);
+		rx_data = k_lifo_get(plifo, timeout);
 		zassert_equal(rx_data, (void *)&data[i]);
 	}
 }
@@ -46,12 +46,12 @@ static void tIsr_entry_put(const void *p)
 
 static void tIsr_entry_get(const void *p)
 {
-	tlifo_get((struct k_lifo *)p);
+	tlifo_get((struct k_lifo *)p, K_NO_WAIT);
 }
 
 static void tThread_entry(void *p1, void *p2, void *p3)
 {
-	tlifo_get((struct k_lifo *)p1);
+	tlifo_get((struct k_lifo *)p1, K_FOREVER);
 	k_sem_give(&end_sema);
 }
 
@@ -72,7 +72,7 @@ static void tlifo_thread_isr(struct k_lifo *plifo)
 	k_sem_init(&end_sema, 0, 1);
 	/**TESTPOINT: thread-isr data passing via lifo*/
 	irq_offload(tIsr_entry_put, (const void *)plifo);
-	tlifo_get(plifo);
+	tlifo_get(plifo, K_FOREVER);
 }
 
 static void tlifo_isr_thread(struct k_lifo *plifo)

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_loop.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_loop.c
@@ -24,14 +24,14 @@ static void tlifo_put(struct k_lifo *plifo)
 	}
 }
 
-static void tlifo_get(struct k_lifo *plifo)
+static void tlifo_get(struct k_lifo *plifo, k_timeout_t timeout)
 {
 	void *rx_data;
 
 	/*get lifo data*/
 	for (int i = LIST_LEN-1; i >= 0; i--) {
 		/**TESTPOINT: lifo get*/
-		rx_data = k_lifo_get(plifo, K_FOREVER);
+		rx_data = k_lifo_get(plifo, timeout);
 		zassert_equal(rx_data, (void *)&data[i]);
 	}
 }
@@ -40,7 +40,7 @@ static void tlifo_get(struct k_lifo *plifo)
 static void tIsr_entry(const void *p)
 {
 	TC_PRINT("isr lifo get\n");
-	tlifo_get((struct k_lifo *)p);
+	tlifo_get((struct k_lifo *)p, K_NO_WAIT);
 	TC_PRINT("isr lifo put ---> ");
 	tlifo_put((struct k_lifo *)p);
 }
@@ -48,7 +48,7 @@ static void tIsr_entry(const void *p)
 static void tThread_entry(void *p1, void *p2, void *p3)
 {
 	TC_PRINT("thread lifo get\n");
-	tlifo_get((struct k_lifo *)p1);
+	tlifo_get((struct k_lifo *)p1, K_FOREVER);
 	k_sem_give(&end_sema);
 	TC_PRINT("thread lifo put ---> ");
 	tlifo_put((struct k_lifo *)p1);
@@ -71,7 +71,7 @@ static void tlifo_read_write(struct k_lifo *plifo)
 	k_sem_take(&end_sema, K_FOREVER);
 
 	TC_PRINT("main lifo get\n");
-	tlifo_get(plifo);
+	tlifo_get(plifo, K_FOREVER);
 	k_thread_abort(tid);
 	TC_PRINT("\n");
 }


### PR DESCRIPTION
The lifo tests were using `K_FOREVER` from an ISR context, which is a violation of the API contract (no kernel functions that can block should be called from an ISR). This commit fixes the tests to use `K_NO_WAIT` for the ISR calls, while preserving the `K_FOREVER` behavior for the thread and main context calls.