### PR TITLE
kernel: remove KERNEL define from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,6 @@ foreach(var AFLAGS CFLAGS CXXFLAGS CPPFLAGS LDFLAGS)
 endforeach()
 
 zephyr_compile_definitions(
-  KERNEL
   __ZEPHYR__=1
 )
 

--- a/subsys/testsuite/ztest/include/zephyr/ztest.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest.h
@@ -22,7 +22,7 @@
 #error "You need to add CONFIG_ZTEST to your config file."
 #endif
 
-#ifndef KERNEL
+#ifdef ZTEST_UNITTEST
 #define ARCH_STACK_PTR_ALIGN 8
 /* FIXME: Properly integrate with Zephyr's arch specific code */
 #ifdef __cplusplus
@@ -32,7 +32,7 @@ struct arch_esf;
 #ifdef __cplusplus
 }
 #endif
-#endif /* KERNEL */
+#endif /* ZTEST_UNITTEST */
 
 #include <zephyr/sys/printk.h>
 #define PRINT printk

--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -184,9 +184,8 @@ static inline __printf_like(6, 7) bool z_zexpect(bool cond, const char *default_
 				  __LINE__, __func__, _msg ? msg : "", ##__VA_ARGS__);             \
 		(void)_msg;                                                                        \
 		if (!_ret) {                                                                       \
-			/* If kernel but without multithreading return. */                         \
-			COND_CODE_1(KERNEL, (COND_CODE_1(CONFIG_MULTITHREADING, (), (return;))),   \
-				    ())                                                            \
+			/* If not multithreading, return from the test function. */                \
+			COND_CODE_1(CONFIG_MULTITHREADING, (), (return;))                          \
 		}                                                                                  \
 	} while (0)
 
@@ -222,9 +221,8 @@ static inline __printf_like(6, 7) bool z_zexpect(bool cond, const char *default_
 				  __LINE__, __func__, _msg ? msg : "", ##__VA_ARGS__);             \
 		(void)_msg;                                                                        \
 		if (!_ret) {                                                                       \
-			/* If kernel but without multithreading return. */                         \
-			COND_CODE_1(KERNEL, (COND_CODE_1(CONFIG_MULTITHREADING, (), (return;))),   \
-				    ())                                                            \
+			/* If not multithreading, return from the test function. */                \
+			COND_CODE_1(CONFIG_MULTITHREADING, (), (return;))                          \
 		}                                                                                  \
 	} while (0)
 
@@ -252,9 +250,8 @@ static inline __printf_like(6, 7) bool z_zexpect(bool cond, const char *default_
 				  __LINE__, __func__, _msg ? msg : "", ##__VA_ARGS__);             \
 		(void)_msg;                                                                        \
 		if (!_ret) {                                                                       \
-			/* If kernel but without multithreading return. */                         \
-			COND_CODE_1(KERNEL, (COND_CODE_1(CONFIG_MULTITHREADING, (), (return;))),   \
-				    ())                                                            \
+			/* If not multithreading, return from the test function. */                \
+			COND_CODE_1(CONFIG_MULTITHREADING, (), (return;))                          \
 		}                                                                                  \
 	} while (0)
 

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -18,7 +18,7 @@
 
 #include <zephyr/sys/barrier.h>
 
-#ifdef KERNEL
+#ifndef ZTEST_UNITTEST
 static struct k_thread ztest_thread;
 #endif
 static bool failed_expectation;
@@ -111,7 +111,7 @@ static int cleanup_test(struct ztest_unit_test *test)
 
 	mock_status = z_cleanup_mock();
 
-#ifdef KERNEL
+#ifndef ZTEST_UNITTEST
 	/* we need to remove the ztest_thread information from the timeout_q.
 	 * Because we reuse the same k_thread structure this would
 	 * causes some problems.
@@ -134,7 +134,7 @@ static int cleanup_test(struct ztest_unit_test *test)
 	return ret;
 }
 
-#ifdef KERNEL
+#ifndef ZTEST_UNITTEST
 
 #if defined(CONFIG_SMP) && (CONFIG_MP_MAX_NUM_CPUS > 1)
 #define MAX_NUM_CPUHOLD  (CONFIG_MP_MAX_NUM_CPUS - 1)
@@ -353,7 +353,7 @@ static void run_test_functions(struct ztest_suite_node *suite, struct ztest_unit
 	test->test(data);
 }
 
-COND_CODE_1(KERNEL, (ZTEST_BMEM), ()) static enum ztest_result test_result;
+COND_CODE_1(ZTEST_UNITTEST, (), (ZTEST_BMEM)) static enum ztest_result test_result;
 
 static int get_final_test_result(const struct ztest_unit_test *test, int ret)
 {
@@ -424,7 +424,7 @@ void ztest_skip_failed_assumption(void)
 	}
 }
 
-#ifndef KERNEL
+#ifdef ZTEST_UNITTEST
 
 /* Static code analysis tool can raise a violation that the standard header
  * <setjmp.h> shall not be used.
@@ -572,7 +572,7 @@ out:
 	return ret;
 }
 
-#else /* KERNEL */
+#else /* !ZTEST_UNITTEST */
 
 /* Zephyr's probably going to cause all tests to fail if one test fails, so
  * skip the rest of tests if one of them fails
@@ -788,7 +788,7 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 	return ret;
 }
 
-#endif /* !KERNEL */
+#endif /* ZTEST_UNITTEST */
 
 static struct ztest_suite_node *ztest_find_test_suite(const char *name)
 {
@@ -973,7 +973,7 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite, bool shuff
 		return -1;
 	}
 
-#ifndef KERNEL
+#ifdef ZTEST_UNITTEST
 	if (setjmp(stack_fail)) {
 		PRINT_DATA("TESTSUITE crashed.\n");
 		test_status = ZTEST_STATUS_CRITICAL_ERROR;
@@ -988,7 +988,7 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite, bool shuff
 	current_test_failed_assumption = false;
 	__ztest_set_test_result(ZTEST_RESULT_PENDING);
 	__ztest_set_test_phase(TEST_PHASE_SETUP);
-#ifndef KERNEL
+#ifdef ZTEST_UNITTEST
 	if (setjmp(test_suite_fail)) {
 		__ztest_set_test_result(ZTEST_RESULT_SUITE_FAIL);
 	}
@@ -1347,7 +1347,7 @@ void __weak test_main(void)
 	ztest_verify_all_test_suites_ran();
 }
 
-#ifndef KERNEL
+#ifdef ZTEST_UNITTEST
 int main(void)
 {
 	z_init_mock();

--- a/subsys/testsuite/ztest/src/ztest_mock.c
+++ b/subsys/testsuite/ztest/src/ztest_mock.c
@@ -17,7 +17,7 @@ struct parameter {
 	uintptr_t value;
 };
 
-#ifndef KERNEL
+#ifdef ZTEST_UNITTEST
 
 #include <stdlib.h>
 #include <stdarg.h>


### PR DESCRIPTION
The KERNEL define polluted namespace it was only really used for the ztest unit test framework. This commit removes the define and updates the ztest code to use the unittest define instead.