### PR TITLE
Drivers: UART: STM32: Add zero latency interrupt

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1946,6 +1946,12 @@ static int uart_stm32_async_rx_enable(const struct device *dev,
 		return -ENODEV;
 	}
 
+	/* Prevent driver system calls in case of zero latency interrupt*/
+	if (config->zli) {
+		LOG_ERR("Async API cannot be used with ZLI enabled!");
+		return -EINVAL;
+	}
+
 	if (data->dma_rx.enabled) {
 		LOG_WRN("RX was already enabled");
 		return -EBUSY;
@@ -2596,11 +2602,31 @@ static int uart_stm32_pm_action(const struct device *dev, enum pm_device_action 
 #endif /* CONFIG_UART_ASYNC_API */
 
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) || defined(CONFIG_PM)
+
+#define STM32_UART_ZLI_IRQ_HANDLER_DEFINE(index)				\
+COND_CODE_1(DT_INST_PROP(index, zephyr_zli), (					\
+	ISR_DIRECT_DECLARE(uart_stm32_isr_direct_##index) 			\
+	{									\
+		uart_stm32_isr(DEVICE_DT_INST_GET(index)); 			\
+		return 0;							\
+	}), ());
+
+#define STM32_UART_IRQ_CONNECT(idx)						\
+	COND_CODE_1(DT_INST_PROP(idx, zephyr_zli),				\
+		(IRQ_DIRECT_CONNECT(DT_INST_IRQN(idx),				\
+				    DT_INST_IRQ(idx, priority),			\
+				    uart_stm32_isr_direct_##idx,		\
+				    IRQ_ZERO_LATENCY)),				\
+		(IRQ_CONNECT(DT_INST_IRQN(idx), DT_INST_IRQ(idx, priority),	\
+			    uart_stm32_isr, DEVICE_DT_INST_GET(idx), 0))	\
+	)
+
 #define STM32_UART_IRQ_HANDLER_DEFINE(index)					\
+	STM32_UART_ZLI_IRQ_HANDLER_DEFINE(index)				\
 	static void uart_stm32_irq_config_func_##index(const struct device *dev)\
 	{									\
-		IRQ_CONNECT(DT_INST_IRQN(index), DT_INST_IRQ(index, priority),	\
-			    uart_stm32_isr, DEVICE_DT_INST_GET(index), 0);	\
+		ARG_UNUSED(dev);						\
+		STM32_UART_IRQ_CONNECT(index);					\
 		irq_enable(DT_INST_IRQN(index));				\
 	}
 
@@ -2768,6 +2794,7 @@ static int uart_stm32_pm_action(const struct device *dev, enum pm_device_action 
 		.de_deassert_time = DT_INST_PROP(index, de_deassert_time),	\
 		.de_invert = DT_INST_PROP(index, de_invert),			\
 		.fifo_enable = DT_INST_PROP(index, fifo_enable),		\
+		.zli = DT_INST_PROP(index, zephyr_zli),				\
 		STM32_UART_IRQ_HANDLER_FUNC(index)				\
 		STM32_UART_PM_WAKEUP(index)					\
 	};									\

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -48,6 +48,8 @@ struct uart_stm32_config {
 	bool de_invert;
 	/* enable fifo */
 	bool fifo_enable;
+	/* enable zero latency interrupt */
+	bool zli;
 	/* pin muxing */
 	const struct pinctrl_dev_config *pcfg;
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) || \

--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -108,3 +108,9 @@ properties:
       allows more reliable communication with UART devices sensitive to variation of inter-frames
       delays.
       In RX, FIFO reduces overrun occurrences.
+      
+  zephyr,zli:
+    type: boolean
+    description: |
+      Enable event handler in the ZLI (Zero latency interrupt) context.
+      ATTENTION: Zero latency interrupt handlers must not use OS functions!

--- a/samples/boards/st/uart/zero_latency_interrupt/CMakeLists.txt
+++ b/samples/boards/st/uart/zero_latency_interrupt/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(zero_latency_interrupt)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/boards/st/uart/zero_latency_interrupt/README.rst
+++ b/samples/boards/st/uart/zero_latency_interrupt/README.rst
@@ -1,0 +1,32 @@
+.. zephyr:code-sample:: uart-zero-latency-interrupt
+   :name: UART zero latency interrupt
+   :relevant-api: uart_interface
+
+   Demonstrates how to setup zero latency interrupt for UART.
+
+Overview
+********
+
+This sample demonstrates how to use STM32 UART serial driver with zero latency interrupt.
+
+By default, the UART peripheral that is normally assigned to the Zephyr shell
+is used, hence the majority of boards should be able to run this sample.
+
+Building and Running
+********************
+
+Build and flash the sample as follows, changing ``stm32f3_disco`` for
+your board:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/st/uart/zero_latency_interrupt
+   :board: stm32f3_disco
+   :goals: build flash
+   :compact:
+
+Sample Output
+=============
+
+.. code-block:: console
+
+    ZLI enabled

--- a/samples/boards/st/uart/zero_latency_interrupt/boards/stm32f3_disco.overlay
+++ b/samples/boards/st/uart/zero_latency_interrupt/boards/stm32f3_disco.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 christian.sander85@gmail.com
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&usart2 {
+	zephyr,zli;
+};

--- a/samples/boards/st/uart/zero_latency_interrupt/prj.conf
+++ b/samples/boards/st/uart/zero_latency_interrupt/prj.conf
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SERIAL=y
+CONFIG_CONSOLE=y
+
+CONFIG_ZERO_LATENCY_IRQS=y

--- a/samples/boards/st/uart/zero_latency_interrupt/src/main.c
+++ b/samples/boards/st/uart/zero_latency_interrupt/src/main.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 christian.sander85@gmail.com
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/sys/printk.h>
+
+#define UART_DEVICE_NODE DT_NODELABEL(usart2)
+
+static const struct device *const uart_dev = DEVICE_DT_GET(UART_DEVICE_NODE);
+
+/* uart configuration structure */
+const struct uart_config uart_cfg = {.baudrate = DT_PROP(UART_DEVICE_NODE, current_speed),
+				     .parity = UART_CFG_PARITY_NONE,
+				     .stop_bits = UART_CFG_STOP_BITS_1,
+				     .data_bits = UART_CFG_DATA_BITS_8,
+				     .flow_ctrl = UART_CFG_FLOW_CTRL_NONE};
+
+void uart_cb(const struct device *dev, void *user_data)
+{
+}
+
+int main(void)
+{
+	if (!uart_dev) {
+		printk("Failed to get UART device");
+		return 1;
+	}
+
+	if (!device_is_ready(uart_dev)) {
+		printk("Device not ready");
+		return 1;
+	}
+
+	/* uart configuration parameters */
+	int err = uart_configure(uart_dev, &uart_cfg);
+	if (err != 0) {
+		printk("UART configuration failed: %d", err);
+		return 1;
+	}
+
+	/* Configure uart callback */
+	uart_irq_callback_set(uart_dev, uart_cb);
+
+	/* Enable RX irq */
+	uart_irq_rx_enable(uart_dev);
+
+	printk("ZLI enabled");
+
+	while (1) {
+	}
+
+	return 0;
+}

--- a/samples/boards/st/uart/zero_latency_interrupt/tests.yaml
+++ b/samples/boards/st/uart/zero_latency_interrupt/tests.yaml
@@ -1,0 +1,15 @@
+sample:
+  name: UART driver sample
+tests:
+  sample.boards.stm32.uart.zero_latency_interrupt:
+    integration_platforms:
+      - stm32f3_disco
+    tags:
+      - serial
+      - uart
+    filter: dt_nodelabel_prop_enabled("usart2", "zephyr,zli") and CONFIG_SOC_FAMILY_STM32
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "ZLI enabled"

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -586,8 +586,10 @@ static int enable_shell_uart(void)
 	return 0;
 }
 
-SYS_INIT(enable_shell_uart, POST_KERNEL,
-	 CONFIG_SHELL_BACKEND_SERIAL_INIT_PRIORITY);
+SYS_INIT(enable_shell_uart, POST_KERNEL, CONFIG_SHELL_BACKEND_SERIAL_INIT_PRIORITY);
+
+BUILD_ASSERT(DT_PROP_OR(DT_CHOSEN(zephyr_shell_uart), zephyr_zli, 0) == 0,
+	     "Zero latency interrupt must not be enabled on the uart used as shell backend!");
 
 const struct shell *shell_backend_uart_get_ptr(void)
 {


### PR DESCRIPTION
This PR adds zero latency interrupt functionality to STM32 UART driver in a manner like other drivers by introducing a "zli" boolean in the device tree.

A sample is provided showing basic usage.

Zero latency interrupts can be required for protocols with strict timing requirements, e.g. IOLink.