### PR TITLE
doc: build: dts: api: link zephyr,bootloader-info to Retention API page

### DIFF
--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -434,7 +434,7 @@ device.
      - Used for :ref:`boot_mode_api` selection, part of :ref:`retention_api`, which specifies
        what image on a device should be booted.
    * - zephyr,bootloader-info
-     - Selects the retention area used to share information with the bootloader.
+     - Selects the :ref:`retention_api` area used to share information with the bootloader.
    * - zephyr,bt-c2h-uart
      - Selects the UART used for host communication in the
        :zephyr:code-sample:`bluetooth_hci_uart`


### PR DESCRIPTION
The description text for the `zephyr,bootloader-info` mentions that the chosen "selects the retention area used for ..." which isn't very clear about what is a "retention area". Add a direct link to the Retention API documentation page to make it clear.

Per request in: https://github.com/zephyrproject-rtos/zephyr/pull/109055#discussion_r3244368299