### PR TITLE
board: st: stm32h7s78_dk: add support for probe-rs runner

### DIFF
--- a/boards/st/stm32h7s78_dk/board.cmake
+++ b/boards/st/stm32h7s78_dk/board.cmake
@@ -8,6 +8,9 @@ endif()
 
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
+board_runner_args(probe_rs "--chip=STM32H7S7L8")
+board_runner_args(probe_rs "--connect-under-reset")
+
 board_runner_args(pyocd "--target=stm32h7s7l8hxh")
 board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
 board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
@@ -20,6 +23,7 @@ board_runner_args(jlink "--device=STM32H7S7L8" "--speed=4000")
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Allow flashing the STM32H7S78-DK board using the probe-rs runner.
It natively supports both the STM32H7S7L8 chip found on that board,
as well as the external flash chip [1]

[1] https://github.com/probe-rs/probe-rs/blob/v0.31.0/probe-rs/targets/STM32H7RS_Series.yaml#L1539

Signed-off-by: Titouan Christophe <titouan.christophe@mind.be>
