### PR TITLE
subsys: ipc_service: make RPMsg shmem reset init priority configurable

### DIFF
--- a/subsys/ipc/ipc_service/backends/Kconfig.rpmsg
+++ b/subsys/ipc/ipc_service/backends/Kconfig.rpmsg
@@ -21,6 +21,14 @@ config IPC_SERVICE_BACKEND_RPMSG_SHMEM_RESET
 	  When this parameter is set to 'y' the status region of the shared
 	  memory is reset on kernel initialization.
 
+config IPC_SERVICE_BACKEND_RPMSG_SHMEM_INIT_PRIORITY
+	int "Shared memory reset init priority"
+	depends on IPC_SERVICE_BACKEND_RPMSG_SHMEM_RESET
+	default 1
+	help
+	  Initialization priority for shared memory reset performed by the
+	  RPMsg static vrings backend.
+
 config IPC_SERVICE_BACKEND_RPMSG_NUM_ENDPOINTS_PER_INSTANCE
 	int "Max number of registered endpoints per instance"
 	default 2

--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -858,5 +858,6 @@ static int shared_memory_prepare(void)
 	return 0;
 }
 
-SYS_INIT(shared_memory_prepare, PRE_KERNEL_1, 1);
+SYS_INIT(shared_memory_prepare, PRE_KERNEL_1,
+	 CONFIG_IPC_SERVICE_BACKEND_RPMSG_SHMEM_INIT_PRIORITY);
 #endif /* CONFIG_IPC_SERVICE_BACKEND_RPMSG_SHMEM_RESET */


### PR DESCRIPTION
The RPMsg static vrings backend currently hard-codes the shared memory reset `SYS_INIT` priority to `1`.

Some platforms need this reset to run later within `PRE_KERNEL_1` because the shared memory region depends on earlier platform initialization. Add a dedicated Kconfig option so platforms can override the priority without modifying the backend code.

The default value remains `1`, so existing behavior is preserved.