### PR TITLE
drivers: *: stm32: enable GPIO when appropriate

### DIFF
--- a/drivers/flash/Kconfig.stm32_ospi
+++ b/drivers/flash/Kconfig.stm32_ospi
@@ -18,6 +18,7 @@ config FLASH_STM32_OSPI
 	select FLASH_HAS_EXPLICIT_ERASE
 	select PINCTRL
 	select DMA if $(DT_STM32_OCTOSPI_HAS_DMA)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_OSPI_NOR),reset-gpios)
 	select USE_STM32_HAL_DMA if $(DT_STM32_OCTOSPI_HAS_DMA)
 	select USE_STM32_HAL_DMA_EX if SOC_SERIES_STM32U5X && \
 					$(DT_STM32_OCTOSPI_HAS_DMA)

--- a/drivers/flash/Kconfig.stm32_qspi
+++ b/drivers/flash/Kconfig.stm32_qspi
@@ -17,6 +17,7 @@ menuconfig FLASH_STM32_QSPI
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_EXPLICIT_ERASE
 	select PINCTRL
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_QSPI_NOR),reset-gpios)
 	select DMA if $(DT_STM32_QUADSPI_HAS_DMA)
 	select USE_STM32_HAL_DMA if $(DT_STM32_QUADSPI_HAS_DMA)
 	help

--- a/drivers/flash/Kconfig.stm32_xspi
+++ b/drivers/flash/Kconfig.stm32_xspi
@@ -16,6 +16,7 @@ config FLASH_STM32_XSPI
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_EXPLICIT_ERASE
 	select PINCTRL
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_XSPI_NOR),reset-gpios)
 	help
 	  Enable XSPI-NOR support on the STM32 family of processors.
 

--- a/drivers/mipi_dbi/Kconfig.stm32_fmc
+++ b/drivers/mipi_dbi/Kconfig.stm32_fmc
@@ -6,6 +6,8 @@ config MIPI_DBI_STM32_FMC
 	default y
 	depends on DT_HAS_ST_STM32_FMC_MIPI_DBI_ENABLED
 	select MEMC
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_FMC_MIPI_DBI),reset-gpios) \
+		|| $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_FMC_MIPI_DBI),power-gpios)
 	help
 	  Enable support for MIPI DBI driver for controller based on the stm32 FMC.
 

--- a/drivers/mspi/Kconfig.stm32
+++ b/drivers/mspi/Kconfig.stm32
@@ -29,6 +29,7 @@ config MSPI_STM32_OSPI
 	bool "STM32 OSPI Controller driver"
 	depends on DT_HAS_ST_STM32_OSPI_CONTROLLER_ENABLED
 	default y
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_OSPI_CONTROLLER),ce-gpios)
 	select USE_STM32_HAL_OSPI if !SOC_SERIES_STM32H5X
 	select USE_STM32_LL_DLYB if (SOC_SERIES_STM32H5X || SOC_SERIES_STM32U5X)
 	select USE_STM32_HAL_MDMA if SOC_SERIES_STM32H7X
@@ -41,6 +42,7 @@ config MSPI_STM32_QSPI
 	bool "STM32 QSPI Controller driver"
 	depends on DT_HAS_ST_STM32_QSPI_CONTROLLER_ENABLED
 	default y
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_QSPI_CONTROLLER),ce-gpios)
 	select USE_STM32_HAL_QSPI
 	select USE_STM32_HAL_MDMA if SOC_SERIES_STM32H7X
 	select USE_STM32_HAL_DMA
@@ -52,6 +54,7 @@ config MSPI_STM32_XSPI
 	bool "STM32 XSPI Controller driver"
 	depends on DT_HAS_ST_STM32_XSPI_CONTROLLER_ENABLED
 	default y
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_XSPI_CONTROLLER),ce-gpios)
 	select USE_STM32_HAL_XSPI
 	select USE_STM32_LL_DLYB
 	select USE_STM32_HAL_DMA

--- a/drivers/sdhc/Kconfig.stm32
+++ b/drivers/sdhc/Kconfig.stm32
@@ -10,7 +10,8 @@ config SDHC_STM32_SDMMC
 	select USE_STM32_LL_SDMMC
 	select SDHC_SUPPORTS_NATIVE_MODE
 	select PINCTRL
-	select GPIO
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_SDMMC),cd-gpios) \
+		|| $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_SDMMC),pwr-gpios)
 	default y
 	help
 	  Enables support for SD/SDIO devices using SDMMC peripheral on STM32.

--- a/drivers/usb/udc/Kconfig.stm32
+++ b/drivers/usb/udc/Kconfig.stm32
@@ -12,6 +12,9 @@ config UDC_STM32
 	select UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT
 	select STM32_USB_COMMON
 	select PINCTRL
+	imply GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_USB_ULPI_PHY),reset-gpios)
+	# `disconnect-gpios` is supported only on st,stm32-usb
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_USB),disconnect-gpios)
 	default y
 	help
 	  STM32 USB device controller driver.


### PR DESCRIPTION
Modify Kconfig of various STM32 drivers to `select GPIO` if a `*-gpios` property is present on any node associated to the driver, which indicates the GPIO API will have to be used by the driver. 

I believe this is exhaustive except for `drivers/display/Kconfig.stm32_ltdc` which should be handled in #112742.