### PR TITLE
twister: platform: skip default toolchains when board declares its own

### DIFF
--- a/doc/develop/twister/index.rst
+++ b/doc/develop/twister/index.rst
@@ -160,6 +160,13 @@ toolchain:
   Twister filters out any test instance whose toolchain is not in this list, unless
   ``--force-toolchain`` is given. This list says which toolchains *may* build the
   board, it does not select one; see :ref:`twister_toolchain_selection`.
+toolchain_exclusive: [True|False] (default False)
+  When true, Twister will not append the architecture-based default toolchains
+  to the board's ``toolchain`` list. By default, Twister merges a set of
+  toolchains that are common for the board's architecture (for example,
+  ``host`` and ``llvm`` for ``posix``, or ``gnuarmemb`` and ``armclang`` for
+  ``arm``). Set this to true when a board's ``toolchain`` list is the complete
+  set of toolchains it supports and no defaults should be added.
 preferred_toolchain:
   The toolchain Twister should use for this platform when nothing else selects one.
   This is useful for boards that are nominally buildable with several toolchains but

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -150,6 +150,7 @@ class Platform:
         if default_sim:
             self.simulation = default_sim.name
 
+        toolchain_explicit = "toolchain" in variant_data or "toolchain" in data
         self.supported_toolchains = variant_data.get("toolchain", data.get("toolchain", []))
         if self.supported_toolchains is None:
             self.supported_toolchains = []
@@ -176,7 +177,9 @@ class Platform:
           # that is supported on all board targets for xtensa.
         }
 
-        if self.arch in support_toolchain_variants:
+        # Only auto-append arch-based default toolchains when the board YAML
+        # does not explicitly declare a toolchain list.
+        if not toolchain_explicit and self.arch in support_toolchain_variants:
             for toolchain in support_toolchain_variants[self.arch]:
                 if toolchain not in self.supported_toolchains:
                     self.supported_toolchains.append(toolchain)

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -159,6 +159,9 @@ class Platform:
         if self.supported_toolchains is None:
             self.supported_toolchains = []
 
+        toolchain_exclusive = variant_data.get("toolchain_exclusive",
+                                               data.get("toolchain_exclusive", False))
+
         self.preferred_toolchain = variant_data.get("preferred_toolchain",
                                                     data.get("preferred_toolchain",
                                                              None))
@@ -185,7 +188,7 @@ class Platform:
           # that is supported on all board targets for xtensa.
         }
 
-        if self.arch in support_toolchain_variants:
+        if not toolchain_exclusive and self.arch in support_toolchain_variants:
             for toolchain in support_toolchain_variants[self.arch]:
                 if toolchain not in self.supported_toolchains:
                     self.supported_toolchains.append(toolchain)

--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -77,6 +77,8 @@ $defs:
         type: array
         items:
           type: string
+      toolchain_exclusive:
+        type: boolean
       sysbuild:
         type: boolean
       env:


### PR DESCRIPTION
## Problem

When a board YAML explicitly declares its supported `toolchain:` list, twister
still unconditionally appends the arch-based defaults from
`support_toolchain_variants`. This means a RISC-V board that declares only
`toolchain: [cross-compile]` ends up with `[cross-compile, zephyr]` — the
`zephyr` toolchain is silently injected even though the board maintainer
intentionally excluded it.

For most boards this is harmless — the extra toolchains just widen the
candidate set. But for boards where the arch defaults are genuinely
incompatible, there is no way to opt out.

## Solution

Introduce a `toolchain_exclusive` boolean property for board YAML. When set to
`true`, twister skips the arch-based default append loop and treats the board's
`toolchain` list as the complete set of supported toolchains.

The default is `false`, so all existing boards keep getting arch defaults
merged in as before. Boards that need full control set `toolchain_exclusive: true`
and their declared list is respected as-is.

## Impact

- **Default behavior unchanged**: `toolchain_exclusive` defaults to `false`,
  so all existing boards continue working exactly as before.
- **Opt-in override**: boards that need full control over their toolchain list
  set `toolchain_exclusive: true` and their declared list is respected as-is.
- **`preferred_toolchain`**: unaffected; it controls which toolchain twister
  picks for a run, not which toolchains are in the supported list.
- **`integration_toolchains`**: board maintainers that previously had to add
  per-toolchain test scenarios via `integration_toolchains` to work around
  unwanted defaults can now use `toolchain_exclusive` instead.