### PR TITLE
bluetooth: classic: l2cap: fix retransmit flag race condition

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -5364,13 +5364,17 @@ static void l2cap_br_retransmit_i_frames(struct bt_l2cap_br_chan *br_chan)
 {
 	struct bt_l2cap_br_window *tx_win, *next;
 
-	if (atomic_test_and_set_bit(br_chan->flags, L2CAP_FLAG_RET_I_FRAMES)) {
+	if (atomic_test_bit(br_chan->flags, L2CAP_FLAG_RET_I_FRAMES)) {
 		LOG_WRN("Retransmit-I-frames is ongoing");
 		return;
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&br_chan->_pdu_outstanding, tx_win, next, node) {
 		tx_win->retransmit = true;
+	}
+
+	if (sys_slist_peek_head(&br_chan->_pdu_outstanding) != NULL) {
+		atomic_set_bit(br_chan->flags, L2CAP_FLAG_RET_I_FRAMES);
 	}
 }
 


### PR DESCRIPTION
The `l2cap_br_retransmit_i_frames()` function was using `atomic_test_and_set_bit()` to check and set the
`L2CAP_FLAG_RET_I_FRAMES` flag simultaneously. This caused the flag to be set even when the outstanding PDU queue was empty, leading to a state where the flag remained set without any frames to retransmit.

Fix the issue by only setting the flag `L2CAP_FLAG_RET_I_FRAMES` after marking frames for retransmission, and only if there are actually outstanding PDUs in the queue.