### PR TITLE
usb: host: uhc: Start using the existing uhc mutex lock helpers

### DIFF
--- a/drivers/usb/uhc/uhc_max3421e.c
+++ b/drivers/usb/uhc/uhc_max3421e.c
@@ -152,16 +152,12 @@ static int max3421e_write(const struct device *dev,
 
 static int max3421e_lock(const struct device *dev)
 {
-	struct uhc_data *data = dev->data;
-
-	return k_mutex_lock(&data->mutex, K_FOREVER);
+	return uhc_lock_internal(dev, K_FOREVER);
 }
 
 static int max3421e_unlock(const struct device *dev)
 {
-	struct uhc_data *data = dev->data;
-
-	return k_mutex_unlock(&data->mutex);
+	return uhc_unlock_internal(dev);
 }
 
 /* Disable Host Interrupt */


### PR DESCRIPTION
Previously, the max3421e driver locked and unlocked `uhc_data` mutex by using `k_mutex_lock()` and `k_mutex_unlock()` instead the already existing uhc helpers: `uhc_lock_internal()` and `uhc_unlock_internal()`.