### PR TITLE
include: usb: Add two missing HID definitions

### DIFF
--- a/include/zephyr/usb/class/hid.h
+++ b/include/zephyr/usb/class/hid.h
@@ -667,6 +667,8 @@ enum hid_kbd_code {
 	HID_KEY_KP_8		= 96,
 	HID_KEY_KP_9		= 97,
 	HID_KEY_KP_0		= 98,
+	HID_KEY_KPDOT		= 99,
+	HID_KEY_MENU		= 101,
 };
 
 /**

--- a/subsys/input/input_hid.c
+++ b/subsys/input/input_hid.c
@@ -104,6 +104,8 @@ static const uint8_t input_to_hid_map[] = {
 	[INPUT_KEY_KP8] = HID_KEY_KP_8,
 	[INPUT_KEY_KP9] = HID_KEY_KP_9,
 	[INPUT_KEY_KP0] = HID_KEY_KP_0,
+	[INPUT_KEY_KPDOT] = HID_KEY_KPDOT,
+	[INPUT_KEY_MENU] = HID_KEY_MENU,
 };
 
 int16_t input_to_hid_code(uint16_t input_code)


### PR DESCRIPTION
This PR adds definitions for the keypad dot and application/menu key[1].

1: https://en.wikipedia.org/wiki/Menu_key