### PR TITLE
drivers: ethernet: stm32: combine mac addr load

### DIFF
--- a/drivers/ethernet/dwc_mac/eth_stm32_dwc.h
+++ b/drivers/ethernet/dwc_mac/eth_stm32_dwc.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_ETHERNET_DWC_MAC_ETH_STM32_DWC_H_
+#define ZEPHYR_DRIVERS_ETHERNET_DWC_MAC_ETH_STM32_DWC_H_
+
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/sys/crc.h>
+
+#define ST_OUI_B0 0x00
+#define ST_OUI_B1 0x80
+#define ST_OUI_B2 0xE1
+
+static inline int eth_stm32_net_eth_mac_load(const struct net_eth_mac_config *cfg,
+					     uint8_t *mac_addr)
+{
+	int ret;
+
+	ret = net_eth_mac_load(cfg, mac_addr);
+	if (ret == -ENODATA) {
+		uint8_t unique_device_ID_12_bytes[12];
+		uint32_t result_mac_32_bits;
+
+		/**
+		 * Set MAC address locally administered bit (LAA) as this is not assigned by the
+		 * manufacturer
+		 */
+		mac_addr[0] = ST_OUI_B0 | 0x02;
+		mac_addr[1] = ST_OUI_B1;
+		mac_addr[2] = ST_OUI_B2;
+
+		/* Nothing defined by the user, use device id */
+		hwinfo_get_device_id(unique_device_ID_12_bytes, 12);
+		result_mac_32_bits = crc32_ieee((uint8_t *)unique_device_ID_12_bytes, 12);
+		memcpy(&mac_addr[3], &result_mac_32_bits, 3);
+
+		return 0;
+	}
+
+	if (ret < 0) {
+		LOG_ERR("Failed to load MAC address (%d)", ret);
+	}
+
+	return ret;
+}
+
+#endif /* ZEPHYR_DRIVERS_ETHERNET_DWC_MAC_ETH_STM32_DWC_H_ */

--- a/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_1000.c
+++ b/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_1000.c
@@ -18,17 +18,12 @@ LOG_MODULE_REGISTER(dwmac_plat, CONFIG_ETHERNET_LOG_LEVEL);
 #include <ethernet/eth.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
-#include <zephyr/drivers/hwinfo.h>
 #include <zephyr/drivers/pinctrl.h>
-#include <zephyr/sys/crc.h>
 #include <zephyr/irq.h>
 #include <stm32_ll_system.h>
 
 #include "eth_dwmac_priv.h"
-
-#define ST_OUI_B0 0x00
-#define ST_OUI_B1 0x80
-#define ST_OUI_B2 0xE1
+#include "eth_stm32_dwc.h"
 
 /* The DMA bus master interface is 32-bit on this IP */
 #define DATA_BUS_WIDTH 32
@@ -61,7 +56,6 @@ PINCTRL_DT_INST_DEFINE(0);
 static const struct pinctrl_dev_config *eth0_pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0);
 
 static const struct stm32_pclken pclken[] = STM32_DT_INST_CLOCKS(0);
-static struct net_eth_mac_config mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0);
 
 int dwmac_bus_init(const struct device *dev)
 {
@@ -107,8 +101,8 @@ static struct dwmac_dma_desc dwmac_rx_descs[NB_RX_DESCS] __desc_mem;
 
 int dwmac_platform_init(const struct device *dev)
 {
+	const struct net_eth_mac_config mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0);
 	struct dwmac_priv *p = dev->data;
-	int ret;
 
 	p->tx_descs = dwmac_tx_descs;
 	p->rx_descs = dwmac_rx_descs;
@@ -116,31 +110,7 @@ int dwmac_platform_init(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), dwmac_isr, DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 
-	ret = net_eth_mac_load(&mac_cfg, p->mac_addr);
-	if (ret == -ENODATA) {
-		uint8_t unique_device_ID_12_bytes[12];
-		uint32_t result_mac_32_bits;
-
-		p->mac_addr[0] = ST_OUI_B0 | 0x02;
-		p->mac_addr[1] = ST_OUI_B1;
-		p->mac_addr[2] = ST_OUI_B2;
-
-		hwinfo_get_device_id(unique_device_ID_12_bytes, 12);
-		result_mac_32_bits = crc32_ieee((uint8_t *)unique_device_ID_12_bytes, 12);
-		memcpy(&p->mac_addr[3], &result_mac_32_bits, 3);
-
-		ret = 0;
-	}
-
-	if (ret < 0) {
-		LOG_ERR("Failed to load MAC address (%d)", ret);
-		return ret;
-	}
-
-	LOG_DBG("MAC address %02x:%02x:%02x:%02x:%02x:%02x", p->mac_addr[0], p->mac_addr[1],
-		p->mac_addr[2], p->mac_addr[3], p->mac_addr[4], p->mac_addr[5]);
-
-	return 0;
+	return eth_stm32_net_eth_mac_load(&mac_cfg, p->mac_addr);
 }
 
 static const struct dwmac_config dwmac_config = {

--- a/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_qos.c
+++ b/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_qos.c
@@ -23,17 +23,12 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <ethernet/eth.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
-#include <zephyr/drivers/hwinfo.h>
 #include <zephyr/drivers/pinctrl.h>
-#include <zephyr/sys/crc.h>
 #include <zephyr/irq.h>
 #include <stm32_ll_system.h>
 
 #include "eth_dwmac_priv.h"
-
-#define ST_OUI_B0 0x00
-#define ST_OUI_B1 0x80
-#define ST_OUI_B2 0xE1
+#include "eth_stm32_dwc.h"
 
 /* The DMA bus master interface is 32-bit on this IP */
 #define DATA_BUS_WIDTH 32
@@ -89,7 +84,6 @@ static const struct pinctrl_dev_config *eth0_pcfg =
 	PINCTRL_DT_INST_DEV_CONFIG_GET(0);
 
 static const struct stm32_pclken pclken[] = STM32_DT_INST_CLOCKS(0);
-static struct net_eth_mac_config mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0);
 
 int dwmac_bus_init(const struct device *dev)
 {
@@ -135,8 +129,8 @@ static struct dwmac_dma_desc dwmac_rx_descs[NB_RX_DESCS] __desc_mem;
 
 int dwmac_platform_init(const struct device *dev)
 {
+	const struct net_eth_mac_config mac_cfg = NET_ETH_MAC_DT_INST_CONFIG_INIT(0);
 	struct dwmac_priv *p = dev->data;
-	int ret;
 
 	p->tx_descs = dwmac_tx_descs;
 	p->rx_descs = dwmac_rx_descs;
@@ -155,34 +149,7 @@ int dwmac_platform_init(const struct device *dev)
 		    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(DT_INST_IRQN(0));
 
-	/* retrieve MAC address */
-	ret = net_eth_mac_load(&mac_cfg, p->mac_addr);
-	if (ret == -ENODATA) {
-		uint8_t unique_device_ID_12_bytes[12];
-		uint32_t result_mac_32_bits;
-
-		/**
-		 * Set MAC address locally administered bit (LAA) as this is not assigned by the
-		 * manufacturer
-		 */
-		p->mac_addr[0] = ST_OUI_B0 | 0x02;
-		p->mac_addr[1] = ST_OUI_B1;
-		p->mac_addr[2] = ST_OUI_B2;
-
-		/* Nothing defined by the user, use device id */
-		hwinfo_get_device_id(unique_device_ID_12_bytes, 12);
-		result_mac_32_bits = crc32_ieee((uint8_t *)unique_device_ID_12_bytes, 12);
-		memcpy(&p->mac_addr[3], &result_mac_32_bits, 3);
-
-		ret = 0;
-	}
-
-	if (ret < 0) {
-		LOG_ERR("Failed to load MAC address (%d)", ret);
-		return ret;
-	}
-
-	return 0;
+	return eth_stm32_net_eth_mac_load(&mac_cfg, p->mac_addr);
 }
 
 /* Our private device instance */

--- a/drivers/ethernet/eth_stm32_hal2.c
+++ b/drivers/ethernet/eth_stm32_hal2.c
@@ -6,7 +6,6 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
-#include <zephyr/drivers/hwinfo.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
@@ -17,21 +16,18 @@
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/phy.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/crc.h>
 #include <zephyr/sys/util.h>
 #include <soc.h>
 #include "eth.h"
 
 LOG_MODULE_REGISTER(eth_stm32_hal, CONFIG_ETHERNET_LOG_LEVEL);
 
+#include "dwc_mac/eth_stm32_dwc.h"
+
 #define DT_DRV_COMPAT st_stm32_ethernet
 
 #define ETH_STM32_HAL_MTU NET_ETH_MTU
 #define ETH_STM32_HAL_FRAME_SIZE_MAX (ETH_STM32_HAL_MTU + 18)
-
-#define ST_OUI_B0 0x00
-#define ST_OUI_B1 0x80
-#define ST_OUI_B2 0xE1
 
 #define ETH_STM32_RX_BUF_SIZE HAL_ETH_MAX_PACKET_SIZE_BYTE /* full-frame RX DMA buffer */
 #define ETH_STM32_TX_BUF_SIZE HAL_ETH_MAX_PACKET_SIZE_BYTE /* full-frame TX DMA buffer */
@@ -539,29 +535,8 @@ static int eth_initialize(const struct device *dev)
 
 	HAL_ETH_GetConfig(heth, &config_eth);
 
-	ret = net_eth_mac_load(&cfg->mac_config, dev_data->mac_addr);
-	if (ret == -ENODATA) {
-		uint8_t unique_device_ID_12_bytes[12];
-		uint32_t result_mac_32_bits;
-
-		/**
-		 * Set MAC address locally administered bit (LAA) as this is not assigned by the
-		 * manufacturer
-		 */
-		dev_data->mac_addr[0] = ST_OUI_B0 | 0x02;
-		dev_data->mac_addr[1] = ST_OUI_B1;
-		dev_data->mac_addr[2] = ST_OUI_B2;
-
-		/* Nothing defined by the user, use device id */
-		hwinfo_get_device_id(unique_device_ID_12_bytes, 12);
-		result_mac_32_bits = crc32_ieee((uint8_t *)unique_device_ID_12_bytes, 12);
-		memcpy(&dev_data->mac_addr[3], &result_mac_32_bits, 3);
-
-		ret = 0;
-	}
-
+	ret = eth_stm32_net_eth_mac_load(&cfg->mac_config, dev_data->mac_addr);
 	if (ret < 0) {
-		LOG_ERR("Failed to load MAC address (%d)", ret);
 		return ret;
 	}
 

--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -6,7 +6,6 @@
  */
 
 #include <zephyr/device.h>
-#include <zephyr/drivers/hwinfo.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
@@ -15,7 +14,6 @@
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/lldp.h>
 #include <zephyr/net/phy.h>
-#include <zephyr/sys/crc.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/__assert.h>
@@ -29,14 +27,12 @@
 
 LOG_MODULE_REGISTER(eth_stm32_hal, CONFIG_ETHERNET_LOG_LEVEL);
 
+#include "dwc_mac/eth_stm32_dwc.h"
+
 #if defined(CONFIG_ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER) &&                                       \
 	!DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_dtcm))
 #error DTCM for DMA buffer is activated but zephyr,dtcm is not present in dts
 #endif
-
-#define ST_OUI_B0 0x00
-#define ST_OUI_B1 0x80
-#define ST_OUI_B2 0xE1
 
 #define ETH_STM32_HAL_MTU            NET_ETH_MTU
 #define ETH_STM32_HAL_FRAME_SIZE_MAX (ETH_STM32_HAL_MTU + 18)
@@ -121,29 +117,8 @@ static int eth_initialize(const struct device *dev)
 		return ret;
 	}
 
-	ret = net_eth_mac_load(&cfg->mac_cfg, dev_data->mac_addr);
-	if (ret == -ENODATA) {
-		uint8_t unique_device_ID_12_bytes[12];
-		uint32_t result_mac_32_bits;
-
-		/**
-		 * Set MAC address locally administered bit (LAA) as this is not assigned by the
-		 * manufacturer
-		 */
-		dev_data->mac_addr[0] = ST_OUI_B0 | 0x02;
-		dev_data->mac_addr[1] = ST_OUI_B1;
-		dev_data->mac_addr[2] = ST_OUI_B2;
-
-		/* Nothing defined by the user, use device id */
-		hwinfo_get_device_id(unique_device_ID_12_bytes, 12);
-		result_mac_32_bits = crc32_ieee((uint8_t *)unique_device_ID_12_bytes, 12);
-		memcpy(&dev_data->mac_addr[3], &result_mac_32_bits, 3);
-
-		ret = 0;
-	}
-
+	ret = eth_stm32_net_eth_mac_load(&cfg->mac_cfg, dev_data->mac_addr);
 	if (ret < 0) {
-		LOG_ERR("Failed to load MAC address (%d)", ret);
 		return ret;
 	}
 


### PR DESCRIPTION
loading the mac address for stm32 is the same for all 4 stm32 ethernet drivers, combine that into a shared function.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>