### PR TITLE
boards: 96boards: move init code from SYS_INIT to hooks

### DIFF
--- a/boards/96boards/wistrio/Kconfig
+++ b/boards/96boards/wistrio/Kconfig
@@ -1,0 +1,5 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_96B_WISTRIO
+	select BOARD_LATE_INIT_HOOK

--- a/boards/96boards/wistrio/rf.c
+++ b/boards/96boards/wistrio/rf.c
@@ -7,7 +7,10 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/init.h>
 
-static int rf_init(void)
+/* Runs as the board late init hook, after all POST_KERNEL device init,
+ * so the GPIO driver is available.
+ */
+void board_late_init_hook(void)
 {
 	const struct gpio_dt_spec rf1 =
 		GPIO_DT_SPEC_GET(DT_NODELABEL(rf_switch), rf1_gpios);
@@ -21,15 +24,10 @@ static int rf_init(void)
 	if (!gpio_is_ready_dt(&rf1) ||
 	    !gpio_is_ready_dt(&rf2) ||
 	    !gpio_is_ready_dt(&rf3)) {
-		return -ENODEV;
+		return;
 	}
 
 	(void)gpio_pin_configure_dt(&rf1, GPIO_OUTPUT_HIGH);
 	(void)gpio_pin_configure_dt(&rf2, GPIO_OUTPUT_HIGH);
 	(void)gpio_pin_configure_dt(&rf3, GPIO_OUTPUT_LOW);
-
-	return 0;
 }
-
-/* Need to be initialised after GPIO driver */
-SYS_INIT(rf_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);


### PR DESCRIPTION
The Wistrio RF-switch GPIO setup ran as a SYS_INIT at POST_KERNEL device
priority so it would run after the GPIO driver. Convert it to the board
late init hook, which runs after all POST_KERNEL device init, keeping
the GPIO-driver dependency satisfied, and select BOARD_LATE_INIT_HOOK.
As the hook returns void the best-effort init no longer propagates an
error code. No functional change; this aligns the board with the board
hook convention used across the tree.
