### PR TITLE
boards: actinius: move init code from SYS_INIT to hooks

### DIFF
--- a/boards/actinius/common/Kconfig
+++ b/boards/actinius/common/Kconfig
@@ -1,12 +1,6 @@
 # Copyright (c) 2022 Actinius
 # SPDX-License-Identifier: Apache-2.0
 
-config ACTINIUS_BOARD_CONTROL_INIT_PRIORITY
-	int "Init priority"
-	default 99
-	help
-	  Sets the init priority for the Board Control module.
-
 module = ACTINIUS_BOARD_CONTROL
 module-str = Board Control
 source "subsys/logging/Kconfig.template.log_config"

--- a/boards/actinius/common/actinius_board_common.c
+++ b/boards/actinius/common/actinius_board_common.c
@@ -65,7 +65,10 @@ static int actinius_board_set_charger_enable(void)
 }
 #endif /* CHARGER_ENABLE */
 
-static int actinius_board_init(void)
+/* Needs to happen after GPIO driver init; the board late init hook runs
+ * after all POST_KERNEL device init.
+ */
+void board_late_init_hook(void)
 {
 
 	int result = 0;
@@ -86,12 +89,7 @@ static int actinius_board_init(void)
 	}
 #endif
 
-	return result;
+	ARG_UNUSED(result);
 }
-
-/* Needs to happen after GPIO driver init */
-SYS_INIT(actinius_board_init,
-		POST_KERNEL,
-		CONFIG_ACTINIUS_BOARD_CONTROL_INIT_PRIORITY);
 
 #endif /* SIM_SELECT || CHARGER_ENABLE */

--- a/boards/actinius/icarus/Kconfig
+++ b/boards/actinius/icarus/Kconfig
@@ -1,0 +1,5 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ACTINIUS_ICARUS
+	select BOARD_LATE_INIT_HOOK

--- a/boards/actinius/icarus_bee/Kconfig
+++ b/boards/actinius/icarus_bee/Kconfig
@@ -1,0 +1,5 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ACTINIUS_ICARUS_BEE
+	select BOARD_LATE_INIT_HOOK

--- a/boards/actinius/icarus_som/Kconfig
+++ b/boards/actinius/icarus_som/Kconfig
@@ -1,0 +1,5 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ACTINIUS_ICARUS_SOM
+	select BOARD_LATE_INIT_HOOK

--- a/boards/actinius/icarus_som_dk/Kconfig
+++ b/boards/actinius/icarus_som_dk/Kconfig
@@ -1,0 +1,5 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ACTINIUS_ICARUS_SOM_DK
+	select BOARD_LATE_INIT_HOOK


### PR DESCRIPTION
The shared Actinius board control init (SIM select and charger enable
GPIO configuration) ran as a SYS_INIT at POST_KERNEL so it would run
after the GPIO driver. Convert it to the board late init hook, which
runs after all POST_KERNEL device init, and select BOARD_LATE_INIT_HOOK
for the Icarus, Icarus Bee, Icarus SoM and Icarus SoM DK boards that
build the common code.

As the hook returns void, the now-unused ACTINIUS_BOARD_CONTROL_INIT_
PRIORITY Kconfig option is removed. No functional change; this aligns
these boards with the board hook convention used across the tree.
