### PR TITLE
boards: arduino: move init code from SYS_INIT to hooks

### DIFF
--- a/boards/arduino/nano_33_ble/Kconfig
+++ b/boards/arduino/nano_33_ble/Kconfig
@@ -1,0 +1,5 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ARDUINO_NANO_33_BLE
+	select BOARD_LATE_INIT_HOOK

--- a/boards/arduino/nano_33_ble/board.c
+++ b/boards/arduino/nano_33_ble/board.c
@@ -7,29 +7,25 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 
-static int board_init(void)
+void board_late_init_hook(void)
 {
 
-	int res;
 	static const struct gpio_dt_spec pull_up =
 		GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), pull_up_gpios);
 	static const struct gpio_dt_spec user_led =
 		GPIO_DT_SPEC_GET(DT_ALIAS(led4), gpios);
 
 	if (!gpio_is_ready_dt(&pull_up)) {
-		return -ENODEV;
+		return;
 	}
 
 	if (!gpio_is_ready_dt(&user_led)) {
-		return -ENODEV;
+		return;
 	}
 
-	res = gpio_pin_configure_dt(&pull_up, GPIO_OUTPUT_HIGH);
-	if (res) {
-		return res;
+	if (gpio_pin_configure_dt(&pull_up, GPIO_OUTPUT_HIGH)) {
+		return;
 	}
 
-	return gpio_pin_configure_dt(&user_led, GPIO_OUTPUT_HIGH);
+	(void)gpio_pin_configure_dt(&user_led, GPIO_OUTPUT_HIGH);
 }
-
-SYS_INIT(board_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/boards/arduino/opta/Kconfig
+++ b/boards/arduino/opta/Kconfig
@@ -1,0 +1,6 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ARDUINO_OPTA
+	select BOARD_EARLY_INIT_HOOK
+	select BOARD_LATE_INIT_HOOK if FLASH_STM32_QSPI_GENERIC_READ

--- a/boards/arduino/opta/board_gpio_init.c
+++ b/boards/arduino/opta/board_gpio_init.c
@@ -8,12 +8,11 @@
 #include <stm32_ll_bus.h>
 #include <stm32_ll_gpio.h>
 
-static int board_gpio_init(void)
+void board_early_init_hook(void)
 {
 	/* The external oscillator that drives the HSE clock should be enabled
-	 * by setting the GPIOI1 pin. This function is registered at priority
-	 * PRE_KERNEL_1 to be executed before the standard STM clock
-	 * setup code.
+	 * by setting the GPIOI1 pin. This board early init hook is executed
+	 * before the standard STM clock setup code.
 	 *
 	 * Note that the HSE should be turned on by the M7 only because M4
 	 * is not booted by default on Opta and cannot configure the clocks
@@ -45,8 +44,4 @@ static int board_gpio_init(void)
 	}
 	LL_GPIO_SetOutputPin(GPIOJ, LL_GPIO_PIN_15);
 #endif
-
-	return 0;
 }
-
-SYS_INIT(board_gpio_init, PRE_KERNEL_1, 0);

--- a/boards/arduino/opta/board_info.c
+++ b/boards/arduino/opta/board_info.c
@@ -24,7 +24,7 @@ static char serial_number[OPTA_SERIAL_NUMBER_SIZE + 1];
 
 const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(qspi_flash));
 
-static int board_info(void)
+void board_late_init_hook(void)
 {
 	QSPI_CommandTypeDef cmd = {
 		.Instruction = AT25SF128_READ_SECURITY_REGISTERS,
@@ -39,19 +39,11 @@ static int board_info(void)
 	};
 
 	if (!device_is_ready(dev)) {
-		return -ENODEV;
+		return;
 	}
 
-	int ret = flash_ex_op(dev, FLASH_STM32_QSPI_EX_OP_GENERIC_READ, (uintptr_t)&cmd, &info);
-
-	if (ret != 0) {
-		return -EIO;
-	}
-
-	return 0;
+	(void)flash_ex_op(dev, FLASH_STM32_QSPI_EX_OP_GENERIC_READ, (uintptr_t)&cmd, &info);
 }
-
-SYS_INIT(board_info, APPLICATION, 0);
 
 #endif /* CONFIG_FLASH_STM32_QSPI_GENERIC_READ */
 

--- a/boards/arduino/portenta_h7/Kconfig
+++ b/boards/arduino/portenta_h7/Kconfig
@@ -1,0 +1,5 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ARDUINO_PORTENTA_H7
+	select BOARD_LATE_INIT_HOOK if BOARD_ARDUINO_PORTENTA_H7_STM32H747XX_M7

--- a/boards/arduino/portenta_h7/board.c
+++ b/boards/arduino/portenta_h7/board.c
@@ -7,17 +7,15 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 
-static int board_init(void)
+void board_late_init_hook(void)
 {
 
 	/* Set led1 inactive since the Arduino bootloader leaves it active */
 	const struct gpio_dt_spec led1 = GPIO_DT_SPEC_GET(DT_ALIAS(led1), gpios);
 
 	if (!gpio_is_ready_dt(&led1)) {
-		return -ENODEV;
+		return;
 	}
 
-	return gpio_pin_configure_dt(&led1, GPIO_OUTPUT_INACTIVE);
+	(void)gpio_pin_configure_dt(&led1, GPIO_OUTPUT_INACTIVE);
 }
-
-SYS_INIT(board_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);


### PR DESCRIPTION
Convert the Arduino Opta, Nano 33 BLE and Portenta H7 board init from
SYS_INIT to the board init hooks and select the corresponding
BOARD_EARLY_INIT_HOOK / BOARD_LATE_INIT_HOOK symbols:

- Opta: the PRE_KERNEL_1 GPIO/HSE and Ethernet-enable setup becomes the
  early hook; the APPLICATION-level board info read becomes the late
  hook.
- Nano 33 BLE and Portenta H7: the POST_KERNEL GPIO setup becomes the
  late hook, which runs after all POST_KERNEL device init so the GPIO
  driver is available.

As the board hooks return void, the best-effort init helpers no longer
propagate an error code. Portenta H7 board.c is only built for the M7
core, so its hook is selected only for that variant. No functional
change; this aligns these boards with the board hook convention used
across the tree.
