### PR TITLE
boards: digilent: move init code from SYS_INIT to hooks

### DIFF
--- a/boards/digilent/arty_a7/Kconfig
+++ b/boards/digilent/arty_a7/Kconfig
@@ -1,13 +1,5 @@
-# Digilent Arty board configuration
-
-# Copyright (c) 2020 Henrik Brix Andersen <henrik@brixandersen.dk>
+# Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-config BOARD_INIT_PRIORITY
-	int "Board initialization priority"
-	default 50
-	depends on BOARD_ARTY_A7_DESIGNSTART_FPGA_CORTEX_M1 || BOARD_ARTY_A7_DESIGNSTART_FPGA_CORTEX_M3
-	depends on "$(dt_nodelabel_enabled,daplink_qspi_mux)"
-	help
-	  Board initialization priority. The board initialization must take
-	  place after the GPIO driver is initialized.
+config BOARD_ARTY_A7
+	select BOARD_LATE_INIT_HOOK if "$(dt_nodelabel_enabled,daplink_qspi_mux)"

--- a/boards/digilent/arty_a7/board.c
+++ b/boards/digilent/arty_a7/board.c
@@ -60,7 +60,10 @@ bool board_daplink_is_fitted(void)
 	return !NVIC_GetPendingIRQ(DT_IRQN(DAPLINK_QSPI_MUX_NODE));
 }
 
-static int board_init(void)
+/* The board init must take place after the GPIO driver is initialized;
+ * the board late init hook runs after all POST_KERNEL device init.
+ */
+void board_late_init_hook(void)
 {
 
 	/*
@@ -72,9 +75,5 @@ static int board_init(void)
 		board_daplink_qspi_mux_select(
 			BOARD_DAPLINK_QSPI_MUX_MODE_NORMAL);
 	}
-
-	return 0;
 }
-
-SYS_INIT(board_init, POST_KERNEL, CONFIG_BOARD_INIT_PRIORITY);
 #endif /* DT_NODE_HAS_STATUS_OKAY(DAPLINK_QSPI_MUX_NODE) */


### PR DESCRIPTION
The Arty A7 DAPLink QSPI mux selection ran as a SYS_INIT at POST_KERNEL
so it would run after the GPIO driver. Convert it to the board late
init hook, which runs after all POST_KERNEL device init. The init code
is only built when the daplink_qspi_mux node is enabled, so
BOARD_LATE_INIT_HOOK is selected under the same condition and the now
unused BOARD_INIT_PRIORITY Kconfig option is removed. No functional
change; this aligns the board with the board hook convention used
across the tree.
