### PR TITLE
boards: particle: move init code from SYS_INIT to hooks

### DIFF
--- a/boards/particle/argon/Kconfig
+++ b/boards/particle/argon/Kconfig
@@ -1,0 +1,5 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_PARTICLE_ARGON
+	select BOARD_LATE_INIT_HOOK

--- a/boards/particle/argon/board.c
+++ b/boards/particle/argon/board.c
@@ -28,7 +28,10 @@ static inline void external_antenna(bool on)
 	gpio_pin_configure_dt(&pcb_gpio, (on ? GPIO_OUTPUT_INACTIVE : GPIO_OUTPUT_ACTIVE));
 }
 
-static int board_particle_argon_init(void)
+/* Runs as the board late init hook, after all POST_KERNEL device init,
+ * so the GPIO driver is available.
+ */
+void board_late_init_hook(void)
 {
 
 	/*
@@ -37,11 +40,4 @@ static int board_particle_argon_init(void)
 	 * antenna.
 	 */
 	external_antenna(false);
-
-	return 0;
 }
-
-/* needs to be done after GPIO driver init, which is at
- * POST_KERNEL:KERNEL_INIT_PRIORITY_DEFAULT.
- */
-SYS_INIT(board_particle_argon_init, POST_KERNEL, 99);

--- a/boards/particle/boron/Kconfig
+++ b/boards/particle/boron/Kconfig
@@ -1,0 +1,5 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_PARTICLE_BORON
+	select BOARD_LATE_INIT_HOOK

--- a/boards/particle/boron/board.c
+++ b/boards/particle/boron/board.c
@@ -26,11 +26,10 @@ static inline void external_antenna(bool on)
 	gpio_pin_configure_dt(&ufl_gpio, (on ? GPIO_OUTPUT_ACTIVE : GPIO_OUTPUT_INACTIVE));
 }
 
-static int board_particle_boron_init(void)
+/* Runs as the board late init hook, after all POST_KERNEL device init,
+ * so the GPIO driver is available.
+ */
+void board_late_init_hook(void)
 {
 	external_antenna(false);
-
-	return 0;
 }
-
-SYS_INIT(board_particle_boron_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/boards/particle/xenon/Kconfig
+++ b/boards/particle/xenon/Kconfig
@@ -1,0 +1,5 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_PARTICLE_XENON
+	select BOARD_LATE_INIT_HOOK

--- a/boards/particle/xenon/board.c
+++ b/boards/particle/xenon/board.c
@@ -28,7 +28,10 @@ static inline void external_antenna(bool on)
 	gpio_pin_configure_dt(&pcb_gpio, (on ? GPIO_OUTPUT_INACTIVE : GPIO_OUTPUT_ACTIVE));
 }
 
-static int board_particle_xenon_init(void)
+/* Runs as the board late init hook, after all POST_KERNEL device init,
+ * so the GPIO driver is available.
+ */
+void board_late_init_hook(void)
 {
 
 	/*
@@ -37,11 +40,4 @@ static int board_particle_xenon_init(void)
 	 * antenna.
 	 */
 	external_antenna(false);
-
-	return 0;
 }
-
-/* needs to be done after GPIO driver init, which is at
- * POST_KERNEL:KERNEL_INIT_PRIORITY_DEFAULT.
- */
-SYS_INIT(board_particle_xenon_init, POST_KERNEL, 99);


### PR DESCRIPTION
The Argon, Boron and Xenon antenna-select (SKY13351) GPIO setup ran as
a SYS_INIT at POST_KERNEL so it would run after the GPIO driver.
Convert it to the board late init hook, which runs after all POST_KERNEL
device init, keeping the GPIO-driver dependency satisfied, and select
BOARD_LATE_INIT_HOOK for each board. No functional change; this aligns
these boards with the board hook convention used across the tree.
