### PR TITLE
boards: st: move init code from SYS_INIT to hooks

### DIFF
--- a/boards/st/stm32l496g_disco/Kconfig
+++ b/boards/st/stm32l496g_disco/Kconfig
@@ -1,0 +1,5 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_STM32L496G_DISCO
+	select BOARD_LATE_INIT_HOOK if ADC

--- a/boards/st/stm32l496g_disco/board_adc_vref.c
+++ b/boards/st/stm32l496g_disco/board_adc_vref.c
@@ -8,7 +8,7 @@
 #include <stm32_ll_adc.h>
 #include <zephyr/devicetree.h>
 
-static int enable_adc_reference(void)
+void board_late_init_hook(void)
 {
 	uint8_t init_status;
 	/* VREF+ is not connected to VDDA by default */
@@ -24,8 +24,5 @@ static int enable_adc_reference(void)
 
 	init_status = HAL_SYSCFG_EnableVREFBUF();
 	__ASSERT(init_status == HAL_OK,	"ADC Conversion value may be incorrect");
-
-	return init_status;
+	ARG_UNUSED(init_status);
 }
-
-SYS_INIT(enable_adc_reference, POST_KERNEL, 0);


### PR DESCRIPTION
The STM32L496G Discovery ADC VREFBUF enable ran as a SYS_INIT at
POST_KERNEL. Convert it to the board late init hook, which runs after
all POST_KERNEL device init; the VREF is only used at conversion time,
so there is no init ordering dependency. board_adc_vref.c is only built
when ADC is enabled, so BOARD_LATE_INIT_HOOK is selected under the same
condition. No functional change; this aligns the board with the board
hook convention used across the tree.
