### PR TITLE
Bluetooth: BAP: SD: Shell Compare with src_id instead of pointer

### DIFF
--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -83,7 +83,7 @@ sync_state_get_or_new(const struct bt_bap_scan_delegator_recv_state *recv_state)
 			free_state = &scan_delegator_sync_states[i];
 		}
 
-		if (scan_delegator_sync_states[i].recv_state == recv_state) {
+		if (scan_delegator_sync_states[i].src_id == recv_state->src_id) {
 			scan_delegator_sync_states[i].active = true;
 
 			return &scan_delegator_sync_states[i];


### PR DESCRIPTION
In the sync_state_get_or_new we should compare with the src_id instead of the pointer. If the receive state was added locally via cmd_bap_scan_delegator_add_src then the src_id is assigned, but not the pointer. This caused any locally added receive states to be unavailable, and thus causing error prints when using the shell module.