### PR TITLE
scripts: zspdx: SPDX NTIA compliance improvements

### DIFF
--- a/scripts/pylib/zspdx/model.py
+++ b/scripts/pylib/zspdx/model.py
@@ -39,6 +39,7 @@ class RelationshipType(StrEnum):
     GENERATED_FROM = "GENERATED_FROM"
     HAS_PREREQUISITE = "HAS_PREREQUISITE"
     STATIC_LINK = "STATIC_LINK"
+    VARIANT_OF = "VARIANT_OF"
 
     @classmethod
     def from_value(cls, value: RelationshipType | str) -> RelationshipType:

--- a/scripts/pylib/zspdx/model.py
+++ b/scripts/pylib/zspdx/model.py
@@ -152,6 +152,7 @@ class SBOMComponent:
         copyright_text: Copyright text for the component.
         external_references: Structured external references such as CPEs and package URLs.
         supplier: Supplier or vendor name.
+        comment: Free-form note describing the component's role in the SBOM.
         target_build_file: Main build artifact when the component represents a build target.
         metadata: Additional data not represented by the common model fields.
     """
@@ -170,6 +171,7 @@ class SBOMComponent:
     copyright_text: str = NOASSERTION
     external_references: list[ExternalReference] = field(default_factory=list)
     supplier: str = ""
+    comment: str = ""
     target_build_file: SBOMFile | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 

--- a/scripts/pylib/zspdx/serializers/spdx2/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx2/serializer.py
@@ -158,15 +158,38 @@ class SPDX2Serializer:
             created = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
             self.document_created_timestamps[doc.name] = created
 
+        creators = "".join(f"Creator: {creator}\n" for creator in self._creators())
+
         f.write(f"""SPDXVersion: SPDX-{self.spdx_version}
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: {normalized_name}
 DocumentNamespace: {namespace}
-Creator: Tool: Zephyr SPDX builder
-Created: {created}
+{creators}Created: {created}
 
 """)
+
+    def _creators(self):
+        """Build the SPDX Creator values: an organization author and the tool.
+
+        An ``Organization`` creator gives the SBOM a declared author, and the
+        ``Tool`` creator carries a version suffix so downstream tooling can
+        identify which generator produced the document.
+        """
+        metadata = self.sbom_graph.metadata
+        creators = []
+
+        organization = metadata.get("creator_organization")
+        if organization:
+            creators.append(f"Organization: {organization}")
+
+        tool_name = metadata.get("tool_name") or "Zephyr SPDX builder"
+        tool_version = metadata.get("tool_version")
+        if tool_version:
+            tool_name = f"{tool_name}-{tool_version}"
+        creators.append(f"Tool: {tool_name}")
+
+        return creators
 
     def _write_external_document_refs(self, f, doc: SBOMDocument):
         """Write external document references."""

--- a/scripts/pylib/zspdx/serializers/spdx2/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx2/serializer.py
@@ -127,10 +127,9 @@ class SPDX2Serializer:
         try:
             # Write the updated document
             with open(output_path, "w", encoding="utf-8") as f:
-                # Write header
+                # Write header (external document refs are emitted within the
+                # creation-info section by _write_document_header)
                 self._write_document_header(f, doc)
-                # Write external document refs (now we have all hashes)
-                self._write_external_document_refs(f, doc)
                 # Write the rest (relationships, packages, licenses)
                 self._write_document_relationships(f, doc)
                 self._write_packages(f, doc)
@@ -165,9 +164,12 @@ DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: {normalized_name}
 DocumentNamespace: {namespace}
-{creators}Created: {created}
-
 """)
+        # ExternalDocumentRef is part of the Document Creation Information section and
+        # must precede Creator/Created; strict tag-value parsers reject it if it appears
+        # after the section (e.g. once Created has been seen).
+        self._write_external_document_refs(f, doc)
+        f.write(f"{creators}Created: {created}\n\n")
 
     def _creators(self):
         """Build the SPDX Creator values: an organization author and the tool.
@@ -213,7 +215,6 @@ DocumentNamespace: {namespace}
                     ext_doc.namespace or f"{self.sbom_graph.namespace_prefix}/{ext_doc.name}"
                 )
                 f.write(f"ExternalDocumentRef: {doc_ref_id} {namespace} SHA1: {doc_hash}\n")
-            f.write("\n")
 
     def _write_document_relationships(self, f, doc: SBOMDocument):
         """Write document-level relationships (DESCRIBES) for the document's primary subjects."""

--- a/scripts/pylib/zspdx/serializers/spdx2/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx2/serializer.py
@@ -267,7 +267,7 @@ DocumentNamespace: {namespace}
     def _write_files_analyzed(self, f, component):
         """Write the FilesAnalyzed section and verification code for a component."""
         if not component.files:
-            f.write("FilesAnalyzed: false\nPackageComment: Utility target; no files\n\n")
+            f.write("FilesAnalyzed: false\n\n")
             return
 
         if component.license_info_from_files:
@@ -326,6 +326,10 @@ PackageCopyrightText: {component.copyright_text}
                 f.write(f"ExternalRef: PACKAGE-MANAGER purl {ref.locator}\n")
             else:
                 _logger.warning(f"Unknown external reference ({ref.locator})")
+
+        # Comment describing the package's role
+        if component.comment:
+            f.write(f"PackageComment: <text>{component.comment}</text>\n")
 
         # Files analyzed and verification code
         self._write_files_analyzed(f, component)

--- a/scripts/pylib/zspdx/serializers/spdx3/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx3/serializer.py
@@ -568,6 +568,10 @@ class SPDX3Serializer:
         elif component.revision:
             package.software_packageVersion = component.revision
 
+        supplier_agent = self._get_organization(component.supplier)
+        if supplier_agent:
+            package.suppliedBy = supplier_agent._id
+
         # Download location
         if component.url:
             package.software_downloadLocation = generate_download_url(
@@ -877,6 +881,10 @@ class SPDX3Serializer:
             element_ids.add(self.creator_agent._id)
         if self.author_agent:
             element_ids.add(self.author_agent._id)
+        for component in components:
+            supplier_agent = self.organizations.get(component.supplier)
+            if supplier_agent:
+                element_ids.add(supplier_agent._id)
         data_license = self._create_license_expression("CC0-1.0")
         if data_license:
             element_ids.add(data_license._id)

--- a/scripts/pylib/zspdx/serializers/spdx3/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx3/serializer.py
@@ -561,6 +561,8 @@ class SPDX3Serializer:
         package.name = component.name
         package.creationInfo = self.creation_info._id
         package.software_primaryPurpose = self._purpose_to_spdx3(component.purpose)
+        if component.comment:
+            package.comment = component.comment
 
         # Version
         if component.version:

--- a/scripts/pylib/zspdx/serializers/spdx3/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx3/serializer.py
@@ -666,6 +666,7 @@ class SPDX3Serializer:
             "BUILD_TOOL_OF": (spdx.RelationshipType.usesTool, True),
             "DEV_TOOL_OF": (spdx.RelationshipType.usesTool, True),
             "TEST_TOOL_OF": (spdx.RelationshipType.usesTool, True),
+            "VARIANT_OF": (spdx.RelationshipType.hasVariant, True),
             "OTHER": (spdx.RelationshipType.other, False),
         }
         return type_map.get(rel_type, (spdx.RelationshipType.other, False))

--- a/scripts/pylib/zspdx/serializers/spdx3/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx3/serializer.py
@@ -68,6 +68,8 @@ class SPDX3Serializer:
         # Shared objects
         self.tool = None  # Tool element for createdUsing
         self.creator_agent = None  # SoftwareAgent for createdBy
+        self.author_agent = None  # Organization for createdBy (the SBOM author)
+        self.organizations = {}  # organization name -> shared Organization element
         self.creation_info = None
         self.documents = {}  # doc_name -> SpdxDocument
 
@@ -148,7 +150,15 @@ class SPDX3Serializer:
             # Create the tool (for createdUsing)
             self.tool = spdx.Tool()
             self.tool._id = self._shorten_id(f"{namespace}/tools/west-spdx")
-            self.tool.name = "West SPDX Tool"
+            self.tool.name = self.sbom_data.metadata.get("tool_name") or "West SPDX Tool"
+            # SPDX 3.0 has no Tool version field; record it as a packageUrl external
+            # identifier, mirroring how the Build profile tools carry their version.
+            tool_version = self.sbom_data.metadata.get("tool_version")
+            if tool_version:
+                ext_id = spdx.ExternalIdentifier()
+                ext_id.externalIdentifierType = spdx.ExternalIdentifierType.packageUrl
+                ext_id.identifier = f"pkg:generic/zephyr-spdx-builder@{tool_version}"
+                self.tool.externalIdentifier.append(ext_id)
             self.elements.append(self.tool)
 
         if self.creation_info is None:
@@ -166,9 +176,38 @@ class SPDX3Serializer:
             self.tool.creationInfo = self.creation_info._id
             self.creator_agent.creationInfo = self.creation_info._id
 
+            # Credit the organization author alongside the automated agent, so the
+            # SBOM declares a real author. Reuses the shared Organization element,
+            # which package suppliers also reference.
+            organization = self.sbom_data.metadata.get("creator_organization")
+            self.author_agent = self._get_organization(organization)
+            if self.author_agent:
+                self.creation_info.createdBy.append(self.author_agent._id)
+
         # Build profile elements; no-ops when no build information was collected.
         self._create_build_tools()
         self._create_build_object()
+
+    def _get_organization(self, name: str):
+        """Return a shared Organization element for ``name``, creating it once.
+
+        Organizations are deduplicated by name so a supplier that is also the SBOM
+        author (or supplies many packages) is emitted as a single Agent that every
+        reference points at. Returns ``None`` when ``name`` is empty.
+        """
+        if not name:
+            return None
+        agent = self.organizations.get(name)
+        if agent is None:
+            namespace = self.sbom_data.namespace_prefix.rstrip("/")
+            slug = normalize_spdx_name(name).lower().replace(" ", "-")
+            agent = spdx.Organization()
+            agent._id = self._shorten_id(f"{namespace}/agents/{slug}")
+            agent.name = name
+            agent.creationInfo = self.creation_info._id
+            self.elements.append(agent)
+            self.organizations[name] = agent
+        return agent
 
     # ---- SPDX 3.0 Build profile -------------------------------------------------
 
@@ -836,6 +875,8 @@ class SPDX3Serializer:
             element_ids.add(self.tool._id)
         if self.creator_agent:
             element_ids.add(self.creator_agent._id)
+        if self.author_agent:
+            element_ids.add(self.author_agent._id)
         data_license = self._create_license_expression("CC0-1.0")
         if data_license:
             element_ids.add(data_license._id)

--- a/scripts/pylib/zspdx/serializers/spdx3/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx3/serializer.py
@@ -662,6 +662,7 @@ class SPDX3Serializer:
             "CONTAINS": (spdx.RelationshipType.contains, False),
             "DESCRIBES": (spdx.RelationshipType.describes, False),
             "DEPENDS_ON": (spdx.RelationshipType.dependsOn, False),
+            "DEPENDENCY_OF": (spdx.RelationshipType.dependsOn, True),
             "DYNAMIC_LINK": (spdx.RelationshipType.hasDynamicLink, False),
             "BUILD_TOOL_OF": (spdx.RelationshipType.usesTool, True),
             "DEV_TOOL_OF": (spdx.RelationshipType.usesTool, True),

--- a/scripts/pylib/zspdx/walker.py
+++ b/scripts/pylib/zspdx/walker.py
@@ -674,6 +674,12 @@ class Walker:
 
         self.sbom_graph.add_component(component, "modules-deps")
         self.doc_modules_deps.add_described_component(component)
+
+        # link this dependency package to the Zephyr source package (same relation
+        # the module dependency packages have with their -sources counterparts)
+        self.pending_relationships.append(
+            ("component", "zephyr-sources", "component", component.name, "VARIANT_OF")
+        )
         return component
 
     def setup_modules_deps_component(self, modules, zephyr=None):
@@ -712,6 +718,18 @@ class Walker:
 
             self.sbom_graph.add_component(component, "modules-deps")
             self.component_modules_deps[module_name] = component
+
+            # link this dependency package to the module's source package: the
+            # checked-out sources are Zephyr's variant of the upstream dependency
+            self.pending_relationships.append(
+                (
+                    "component",
+                    module_name + "-sources",
+                    "component",
+                    component.name,
+                    "VARIANT_OF",
+                )
+            )
 
             # each module is a dependency of the zephyr dependency component
             if zephyr_deps is not None:

--- a/scripts/pylib/zspdx/walker.py
+++ b/scripts/pylib/zspdx/walker.py
@@ -39,6 +39,25 @@ SPDX_TOOL_NAME = "Zephyr SPDX builder"
 # GitHub namespace under which Zephyr mirrors its modules.
 ZEPHYR_GITHUB_NAMESPACE = "zephyrproject-rtos"
 
+# Free-form notes emitted as package comments to clarify each package's role. The
+# "-sources" and "-deps" packages are systematically emitted for every module, so
+# the distinction (and why unused modules still appear) is spelled out here.
+SOURCES_COMMENT = (
+    "Source package: this component's source tree as checked out in the west "
+    "workspace. Files that were compiled into the build are listed here; a "
+    "component contributing no compiled files appears with no files."
+)
+DEPS_COMMENT = (
+    "Reference-only dependency package: identifies an upstream Zephyr module "
+    "(download location, and PURL/CPE where known) for supply-chain and "
+    "vulnerability tracking. One is emitted for every module in the west "
+    "manifest, whether or not its code is built, and it carries no files."
+)
+ZEPHYR_DEPS_COMMENT = (
+    "Reference-only package for the Zephyr RTOS itself, the common dependency "
+    "shared by every module dependency package; it carries no files."
+)
+
 # Matches a git repository URL of the form '<protocol><host>/<namespace>/<package>',
 # capturing the host type (e.g. "github"), the namespace and the package name.
 COMMON_GIT_URL_REGEX = (
@@ -528,6 +547,7 @@ class Walker:
 
         # Zephyr itself is always supplied by the Zephyr Project.
         component.supplier = ZEPHYR_ORGANIZATION
+        component.comment = SOURCES_COMMENT
 
         zephyr_url = zephyr.get("remote") or zephyr.get("url", "")
         if zephyr_url:
@@ -582,6 +602,7 @@ class Walker:
                 name=module_name + "-sources",
                 purpose=ComponentPurpose.SOURCE,
                 base_dir=module_path,
+                comment=SOURCES_COMMENT,
             )
 
             if module_revision:
@@ -619,7 +640,7 @@ class Walker:
             return None
 
         # no PrimaryPackagePurpose: this is a reference-only dependency package with no files
-        component = SBOMComponent(name="zephyr-deps")
+        component = SBOMComponent(name="zephyr-deps", comment=ZEPHYR_DEPS_COMMENT)
         component.supplier = ZEPHYR_ORGANIZATION
         component.url = zephyr.get("remote") or zephyr.get("url", "")
         component.revision = zephyr.get("revision", "")
@@ -675,7 +696,7 @@ class Walker:
                 module_ext_ref = module_security.get("external-references", [])
 
             # set up module deps component (reference-only, no files; no purpose)
-            component = SBOMComponent(name=module_name + "-deps")
+            component = SBOMComponent(name=module_name + "-deps", comment=DEPS_COMMENT)
 
             if module_url:
                 component.url = module_url

--- a/scripts/pylib/zspdx/walker.py
+++ b/scripts/pylib/zspdx/walker.py
@@ -27,6 +27,13 @@ from zspdx.model import (
 
 _logger = logging.getLogger(__name__)
 
+# Organization credited as the SBOM author and as the supplier of Zephyr and its
+# upstream-mirrored modules (all hosted under github.com/zephyrproject-rtos).
+ZEPHYR_ORGANIZATION = "The Zephyr Project"
+
+# Name of the tool recorded in the SPDX Creator field.
+SPDX_TOOL_NAME = "Zephyr SPDX builder"
+
 
 def get_tool_version(tool_path):
     """Get a tool's version by running it with ``--version``.
@@ -160,6 +167,52 @@ class Walker:
             purl += f'@{version}'
 
         return purl
+
+    @staticmethod
+    def _read_zephyr_version(zephyr_path):
+        """Read the Zephyr version (e.g. "4.4.99") from the repo VERSION file.
+
+        Returns "" when the path is missing or the file cannot be parsed.
+        """
+        if not zephyr_path:
+            return ""
+        version_file = os.path.join(zephyr_path, "VERSION")
+        values = {}
+        try:
+            with open(version_file) as f:
+                for line in f:
+                    key, sep, val = line.partition("=")
+                    if sep:
+                        values[key.strip()] = val.strip()
+        except OSError:
+            return ""
+
+        try:
+            version = (
+                f"{int(values['VERSION_MAJOR'])}"
+                f".{int(values['VERSION_MINOR'])}"
+                f".{int(values['PATCHLEVEL'])}"
+            )
+        except (KeyError, ValueError):
+            return ""
+
+        extra = values.get("EXTRAVERSION", "")
+        if extra:
+            version += f"-{extra}"
+        return version
+
+    def _set_creation_metadata(self, zephyr):
+        """Record SBOM creator provenance (author organization and tool version).
+
+        Serializers read these from the graph metadata to emit the SPDX Creator
+        fields, so the SBOM advertises a human/organization author alongside the
+        versioned generation tool.
+        """
+        self.sbom_graph.metadata["creator_organization"] = ZEPHYR_ORGANIZATION
+        self.sbom_graph.metadata["tool_name"] = SPDX_TOOL_NAME
+        self.sbom_graph.metadata["tool_version"] = self._read_zephyr_version(
+            (zephyr or {}).get("path", "")
+        )
 
     # primary entry point
     def collect_sbom_graph(self):
@@ -372,6 +425,7 @@ class Walker:
         try:
             with open(self.meta_file) as file:
                 content = yaml.load(file.read(), yaml.SafeLoader)
+                self._set_creation_metadata(content.get("zephyr"))
                 if not self.setup_zephyr_component(content["zephyr"], content["modules"]):
                     return False
         except (FileNotFoundError, yaml.YAMLError):

--- a/scripts/pylib/zspdx/walker.py
+++ b/scripts/pylib/zspdx/walker.py
@@ -17,6 +17,7 @@ from zspdx.getincludes import get_c_includes
 from zspdx.model import (
     BuildInfo,
     ComponentPurpose,
+    ExternalReferenceType,
     RelationshipType,
     SBOMBuild,
     SBOMComponent,
@@ -33,6 +34,16 @@ ZEPHYR_ORGANIZATION = "The Zephyr Project"
 
 # Name of the tool recorded in the SPDX Creator field.
 SPDX_TOOL_NAME = "Zephyr SPDX builder"
+
+# GitHub namespace under which Zephyr mirrors its modules.
+ZEPHYR_GITHUB_NAMESPACE = "zephyrproject-rtos"
+
+# Matches a git repository URL of the form '<protocol><host>/<namespace>/<package>',
+# capturing the host type (e.g. "github"), the namespace and the package name.
+COMMON_GIT_URL_REGEX = (
+    r'((git@|http(s)?:\/\/)(?P<type>[\w\.@]+)(\.\w+)(\/|:))'
+    r'(?P<namespace>[\w,\-,\_\/]+)\/(?P<package>[\w,\-,\_]+)(.git){0,1}((\/){0,1})$'
+)
 
 
 def get_tool_version(tool_path):
@@ -147,26 +158,68 @@ class Walker:
         # Meta file path
         self.meta_file = ""
 
-    def _build_purl(self, url, version=None):
+    @staticmethod
+    def _parse_git_url(url):
+        """Parse a git repository URL into (host_type, namespace, package).
+
+        Returns ``None`` when the URL does not match the common
+        '<protocol><host>/<namespace>/<package>' pattern.
+        """
         if not url:
             return None
-
-        purl = None
-        # This is designed to match repository with the following url pattern:
-        # '<protocol><type>/<namespace>/<package>
-        COMMON_GIT_URL_REGEX = (
-            r'((git@|http(s)?:\/\/)(?P<type>[\w\.@]+)(\.\w+)(\/|:))'
-            r'(?P<namespace>[\w,\-,\_\/]+)\/(?P<package>[\w,\-,\_]+)(.git){0,1}((\/){0,1})$'
-        )
-
         match = re.fullmatch(COMMON_GIT_URL_REGEX, url)
-        if match:
-            purl = f'pkg:{match.group("type")}/{match.group("namespace")}/{match.group("package")}'
+        if not match:
+            return None
+        return match.group("type"), match.group("namespace"), match.group("package")
 
-        if purl and version:
+    def _build_purl(self, url, version=None):
+        parsed = self._parse_git_url(url)
+        if not parsed:
+            return None
+
+        host_type, namespace, package = parsed
+        purl = f'pkg:{host_type}/{namespace}/{package}'
+        if version:
             purl += f'@{version}'
 
         return purl
+
+    def _supplier_from_url(self, url):
+        """Derive an SPDX supplier organization name from a git repository URL.
+
+        Modules mirrored under github.com/zephyrproject-rtos are supplied by the
+        Zephyr Project; for any other host namespace the namespace itself is used.
+        Returns "" when no supplier can be derived.
+        """
+        parsed = self._parse_git_url(url)
+        if not parsed:
+            return ""
+        _host_type, namespace, _package = parsed
+        if namespace == ZEPHYR_GITHUB_NAMESPACE:
+            return ZEPHYR_ORGANIZATION
+        return namespace
+
+    def _apply_scm_identity(self, component, url, revision):
+        """Attach supplier and a package URL derived from a module's SCM location.
+
+        Sets ``component.supplier`` from the repository namespace when not already
+        set, and adds a revision-pinned purl unless the component already carries
+        one (e.g. a curated purl from the module's security metadata).
+        """
+        if not url:
+            return
+        if not component.supplier:
+            supplier = self._supplier_from_url(url)
+            if supplier:
+                component.supplier = supplier
+        has_purl = any(
+            ref.reference_type == ExternalReferenceType.PURL
+            for ref in component.external_references
+        )
+        if not has_purl:
+            purl = self._build_purl(url, revision)
+            if purl:
+                component.add_external_reference(purl)
 
     @staticmethod
     def _read_zephyr_version(zephyr_path):
@@ -472,7 +525,10 @@ class Walker:
             base_dir=relative_base_dir,
         )
 
-        zephyr_url = zephyr.get("remote", "")
+        # Zephyr itself is always supplied by the Zephyr Project.
+        component.supplier = ZEPHYR_ORGANIZATION
+
+        zephyr_url = zephyr.get("remote") or zephyr.get("url", "")
         if zephyr_url:
             component.url = zephyr_url
 
@@ -494,6 +550,13 @@ class Walker:
                 if component.version == "" and version:
                     component.version = version.group('version')
 
+        # Fall back to a revision-pinned package URL when no release tag is known,
+        # so the component still carries a purl for vulnerability matching.
+        if purl is None and zephyr_url:
+            purl = self._build_purl(zephyr_url, component.revision)
+            if purl:
+                component.add_external_reference(purl)
+
         if len(component.version) > 0:
             cpe = f'cpe:2.3:o:zephyrproject:zephyr:{component.version}:-:*:*:*:*:*:*'
             component.add_external_reference(cpe)
@@ -506,7 +569,8 @@ class Walker:
         for module in modules:
             module_name = module.get("name", None)
             module_path = module.get("path", None)
-            module_url = module.get("remote", None)
+            # west may record the module remote as either "remote" or "url"
+            module_url = module.get("remote") or module.get("url")
             module_revision = module.get("revision", None)
 
             if not module_name:
@@ -524,6 +588,7 @@ class Walker:
 
             if module_url:
                 module_component.url = module_url
+                self._apply_scm_identity(module_component, module_url, module_revision)
 
             self.sbom_graph.add_component(module_component, "zephyr")
             self.doc_zephyr.add_described_component(module_component)
@@ -554,7 +619,8 @@ class Walker:
 
         # no PrimaryPackagePurpose: this is a reference-only dependency package with no files
         component = SBOMComponent(name="zephyr-deps")
-        component.url = zephyr.get("remote", "")
+        component.supplier = ZEPHYR_ORGANIZATION
+        component.url = zephyr.get("remote") or zephyr.get("url", "")
         component.revision = zephyr.get("revision", "")
 
         purl = None
@@ -596,6 +662,8 @@ class Walker:
         for module in modules:
             module_name = module.get("name", None)
             module_security = module.get("security", None)
+            module_url = module.get("remote") or module.get("url")
+            module_revision = module.get("revision", None)
 
             if not module_name:
                 _logger.error("cannot find module name in meta file; bailing")
@@ -608,8 +676,17 @@ class Walker:
             # set up module deps component (reference-only, no files; no purpose)
             component = SBOMComponent(name=module_name + "-deps")
 
+            if module_url:
+                component.url = module_url
+            if module_revision:
+                component.revision = module_revision
+
+            # curated security references (CPE/purl) take precedence; the SCM
+            # identity then fills in a supplier and a purl when none was provided.
             for ref in module_ext_ref:
                 component.add_external_reference(ref)
+            if module_url:
+                self._apply_scm_identity(component, module_url, module_revision)
 
             self.sbom_graph.add_component(component, "modules-deps")
             self.component_modules_deps[module_name] = component

--- a/scripts/pylib/zspdx/walker.py
+++ b/scripts/pylib/zspdx/walker.py
@@ -12,6 +12,7 @@ import yaml
 from west.util import WestNotFound, west_topdir
 
 from zspdx.cmakecache import parse_cmake_cache_file
+from zspdx.cmakefileapi import TargetType
 from zspdx.cmakefileapijson import parse_reply, parse_toolchains_and_info
 from zspdx.getincludes import get_c_includes
 from zspdx.model import (
@@ -706,6 +707,16 @@ class Walker:
         # assuming just one configuration; consider whether this is incorrect
         cfg_targets = self.cm.configurations[0].config_targets
         for cfg_target in cfg_targets:
+            # Skip CMake UTILITY targets (menuconfig, ram_report, run/flash/debug,
+            # code-generation helpers, ...). These are phony build-system convenience
+            # targets, not software components: they produce no build artifacts and
+            # only add noise to the SBOM. Generated sources that end up in the
+            # firmware are still captured via the artifact-producing targets that
+            # compile them, so nothing of value is lost by dropping them.
+            if cfg_target.target.type == TargetType.UTILITY:
+                _logger.debug(f"  - skipping UTILITY target {cfg_target.name}")
+                continue
+
             # build the Component for this target
             component = self.init_config_target_component(cfg_target)
 

--- a/tests/application_development/software_bill_of_materials/conftest.py
+++ b/tests/application_development/software_bill_of_materials/conftest.py
@@ -96,3 +96,31 @@ def build_doc(spdx_dir):
 def modules_doc(spdx_dir):
     """Fixture providing the parsed modules-deps.spdx document."""
     return parse_file(os.path.join(spdx_dir, "modules-deps.spdx"))
+
+
+@pytest.fixture(scope="session")
+def zephyr_version():
+    """Fixture providing the Zephyr version from the VERSION file."""
+    zephyr_base = os.environ.get("ZEPHYR_BASE")
+    if not zephyr_base:
+        pytest.skip("ZEPHYR_BASE not set")
+
+    version_file = os.path.join(zephyr_base, "VERSION")
+    values = {}
+    try:
+        with open(version_file) as f:
+            for line in f:
+                key, sep, val = line.partition("=")
+                if sep:
+                    values[key.strip()] = val.strip()
+    except OSError:
+        pytest.skip(f"Cannot read {version_file}")
+
+    try:
+        return (
+            f"{int(values['VERSION_MAJOR'])}"
+            f".{int(values['VERSION_MINOR'])}"
+            f".{int(values['PATCHLEVEL'])}"
+        )
+    except (KeyError, ValueError):
+        pytest.skip(f"Cannot parse version from {version_file}")

--- a/tests/application_development/software_bill_of_materials/conftest.py
+++ b/tests/application_development/software_bill_of_materials/conftest.py
@@ -6,6 +6,7 @@
 import os
 
 import pytest
+import yaml
 from packaging import version
 from spdx_tools.spdx.parser.parse_anything import parse_file
 
@@ -124,3 +125,17 @@ def zephyr_version():
         )
     except (KeyError, ValueError):
         pytest.skip(f"Cannot parse version from {version_file}")
+
+
+@pytest.fixture(scope="session")
+def zephyr_meta_remote(build_dir):
+    """Fixture providing the zephyr SCM URL from zephyr.meta, if any."""
+    meta_path = os.path.join(build_dir, "zephyr", "zephyr.meta")
+    try:
+        with open(meta_path) as f:
+            content = yaml.safe_load(f)
+    except OSError:
+        return None
+
+    zephyr = content.get("zephyr", {}) if content else {}
+    return zephyr.get("remote") or zephyr.get("url")

--- a/tests/application_development/software_bill_of_materials/verify_spdx_content.py
+++ b/tests/application_development/software_bill_of_materials/verify_spdx_content.py
@@ -21,6 +21,9 @@ from spdx_tools.spdx.model.checksum import ChecksumAlgorithm
 from spdx_tools.spdx.model.package import PackagePurpose
 from spdx_tools.spdx.model.relationship import RelationshipType
 
+ZEPHYR_ORGANIZATION = "The Zephyr Project"
+SPDX_TOOL_PREFIX = "Zephyr SPDX builder"
+
 # File name constants (as they appear in SPDX documents)
 FILE_MAIN_C = "./src/main.c"
 FILE_LIBAPP_A = "./app/libapp.a"
@@ -103,10 +106,26 @@ class TestCommonValidation:
         doc, doc_name = doc_with_name
         assert doc.creation_info.document_namespace, f"{doc_name}: document_namespace is empty"
 
-    def test_creators(self, doc_with_name):
-        """Test that creators list is not empty."""
+    def test_creators(self, doc_with_name, zephyr_version):
+        """Test that creators include the Zephyr organization and versioned tool."""
         doc, doc_name = doc_with_name
-        assert len(doc.creation_info.creators) > 0, f"{doc_name}: no creators found"
+        creators = [str(c) for c in doc.creation_info.creators]
+
+        org_creators = [c for c in creators if c.startswith("Organization:")]
+        assert any(ZEPHYR_ORGANIZATION in c for c in org_creators), (
+            f"{doc_name}: expected Organization creator '{ZEPHYR_ORGANIZATION}', got {creators}"
+        )
+
+        expected_tool = f"{SPDX_TOOL_PREFIX}-{zephyr_version}"
+        tool_creators = [c for c in creators if c.startswith("Tool:")]
+        assert tool_creators, f"{doc_name}: no Tool creator found in {creators}"
+        tool_names = [c.removeprefix("Tool: ") for c in tool_creators]
+        assert any(name.startswith(SPDX_TOOL_PREFIX) for name in tool_names), (
+            f"{doc_name}: Tool creator should start with '{SPDX_TOOL_PREFIX}', got {tool_creators}"
+        )
+        assert expected_tool in tool_names, (
+            f"{doc_name}: expected Tool creator '{expected_tool}', got {tool_creators}"
+        )
 
     def test_document_name(self, doc_with_name):
         """Test that document name is not empty."""

--- a/tests/application_development/software_bill_of_materials/verify_spdx_content.py
+++ b/tests/application_development/software_bill_of_materials/verify_spdx_content.py
@@ -17,12 +17,14 @@ import hashlib
 import os
 
 import pytest
+from spdx_tools.spdx.model import ExternalPackageRefCategory
 from spdx_tools.spdx.model.checksum import ChecksumAlgorithm
 from spdx_tools.spdx.model.package import PackagePurpose
 from spdx_tools.spdx.model.relationship import RelationshipType
 
 ZEPHYR_ORGANIZATION = "The Zephyr Project"
 SPDX_TOOL_PREFIX = "Zephyr SPDX builder"
+PURL_ZEPHYR_PREFIX = "pkg:github/zephyrproject-rtos/zephyr@"
 
 # File name constants (as they appear in SPDX documents)
 FILE_MAIN_C = "./src/main.c"
@@ -68,6 +70,35 @@ def file_sha1(path):
     """Calculate the SHA1 hash of a file."""
     with open(path, "rb") as f:
         return hashlib.sha1(f.read(), usedforsecurity=False).hexdigest()
+
+
+def get_purl_refs(package):
+    """Collect purl external references from a package."""
+    return [
+        ref.locator
+        for ref in package.external_references
+        if ref.category == ExternalPackageRefCategory.PACKAGE_MANAGER
+        and ref.reference_type == "purl"
+    ]
+
+
+def get_supplier_name(package):
+    """Return the package supplier as a string, or None if unset."""
+    if package.supplier is None:
+        return None
+    return str(package.supplier)
+
+
+def first_module_deps_package(modules_doc):
+    """Return the first module *-deps package, excluding zephyr-deps."""
+    return next(
+        (
+            pkg
+            for pkg in modules_doc.packages
+            if pkg.name.endswith("-deps") and pkg.name != "zephyr-deps"
+        ),
+        None,
+    )
 
 
 class TestCommonValidation:
@@ -388,6 +419,55 @@ class TestModulesDocument:
             assert pkg.spdx_id.startswith("SPDXRef-"), (
                 f"modules-deps.spdx: package '{pkg.name}' has invalid spdx_id '{pkg.spdx_id}'"
             )
+
+
+class TestPackageProvenance:
+    """Tests for package supplier and purl metadata."""
+
+    def test_zephyr_sources_supplier_and_purl(self, zephyr_doc, zephyr_meta_remote):
+        """Test zephyr-sources supplier and purl reference."""
+        pkg = find_package_by_name(zephyr_doc, "zephyr-sources")
+        assert pkg is not None, "zephyr.spdx: zephyr-sources package not found"
+        assert get_supplier_name(pkg) == f"Organization: {ZEPHYR_ORGANIZATION}", (
+            f"zephyr.spdx: zephyr-sources supplier is '{get_supplier_name(pkg)}'"
+        )
+        if not zephyr_meta_remote:
+            pytest.skip("zephyr.meta has no remote URL for zephyr")
+        purls = get_purl_refs(pkg)
+        assert any(p.startswith(PURL_ZEPHYR_PREFIX) for p in purls), (
+            f"zephyr.spdx: zephyr-sources missing purl prefix '{PURL_ZEPHYR_PREFIX}', got {purls}"
+        )
+
+    def test_zephyr_deps_supplier_and_purl(self, modules_doc, zephyr_meta_remote):
+        """Test zephyr-deps supplier and purl reference."""
+        if len(modules_doc.packages) == 0:
+            pytest.skip("No packages in modules-deps.spdx")
+        pkg = find_package_by_name(modules_doc, "zephyr-deps")
+        assert pkg is not None, "modules-deps.spdx: zephyr-deps package not found"
+        assert get_supplier_name(pkg) == f"Organization: {ZEPHYR_ORGANIZATION}", (
+            f"modules-deps.spdx: zephyr-deps supplier is '{get_supplier_name(pkg)}'"
+        )
+        if not zephyr_meta_remote:
+            pytest.skip("zephyr.meta has no remote URL for zephyr")
+        purls = get_purl_refs(pkg)
+        assert any(p.startswith(PURL_ZEPHYR_PREFIX) for p in purls), (
+            f"modules-deps.spdx: zephyr-deps missing purl prefix '{PURL_ZEPHYR_PREFIX}', "
+            f"got {purls}"
+        )
+
+    def test_module_deps_supplier_and_purl(self, modules_doc):
+        """Test first module-deps supplier and purl reference."""
+        pkg = first_module_deps_package(modules_doc)
+        if pkg is None:
+            pytest.skip("No module-deps packages in modules-deps.spdx")
+        assert get_supplier_name(pkg) == f"Organization: {ZEPHYR_ORGANIZATION}", (
+            f"modules-deps.spdx: {pkg.name} supplier is '{get_supplier_name(pkg)}'"
+        )
+        purls = get_purl_refs(pkg)
+        assert purls, f"modules-deps.spdx: {pkg.name} has no purl references"
+        assert any("@" in p for p in purls), (
+            f"modules-deps.spdx: {pkg.name} purl should include revision suffix, got {purls}"
+        )
 
 
 class TestCrossReferences:

--- a/tests/application_development/software_bill_of_materials/verify_spdx_content.py
+++ b/tests/application_development/software_bill_of_materials/verify_spdx_content.py
@@ -25,6 +25,16 @@ from spdx_tools.spdx.model.relationship import RelationshipType
 ZEPHYR_ORGANIZATION = "The Zephyr Project"
 SPDX_TOOL_PREFIX = "Zephyr SPDX builder"
 PURL_ZEPHYR_PREFIX = "pkg:github/zephyrproject-rtos/zephyr@"
+UTILITY_TARGETS = {
+    "run",
+    "flash",
+    "debug",
+    "debugserver",
+    "menuconfig",
+    "guiconfig",
+    "ram_report",
+    "rom_report",
+}
 
 # File name constants (as they appear in SPDX documents)
 FILE_MAIN_C = "./src/main.c"
@@ -397,6 +407,12 @@ class TestBuildDocument:
         assert app_files == [FILE_LIBAPP_A], (
             f"build.spdx: app package should contain only {FILE_LIBAPP_A}, got {app_files}"
         )
+
+    def test_utility_targets_excluded(self, build_doc):
+        """Test that CMake UTILITY targets are not emitted as packages."""
+        package_names = {pkg.name for pkg in build_doc.packages}
+        found = package_names & UTILITY_TARGETS
+        assert not found, f"build.spdx: UTILITY targets should be excluded, found {sorted(found)}"
 
 
 class TestModulesDocument:

--- a/tests/application_development/software_bill_of_materials/verify_spdx_content.py
+++ b/tests/application_development/software_bill_of_materials/verify_spdx_content.py
@@ -111,6 +111,18 @@ def first_module_deps_package(modules_doc):
     )
 
 
+def first_module_sources_package(zephyr_doc):
+    """Return the first module *-sources package, excluding zephyr-sources."""
+    return next(
+        (
+            pkg
+            for pkg in zephyr_doc.packages
+            if pkg.name.endswith("-sources") and pkg.name != "zephyr-sources"
+        ),
+        None,
+    )
+
+
 class TestCommonValidation:
     """Tests for common SPDX document validation."""
 
@@ -484,6 +496,61 @@ class TestPackageProvenance:
         assert any("@" in p for p in purls), (
             f"modules-deps.spdx: {pkg.name} purl should include revision suffix, got {purls}"
         )
+
+
+class TestPackageComments:
+    """Tests for package role comments."""
+
+    def test_zephyr_sources_comment(self, zephyr_doc):
+        """Test zephyr-sources comment describes a source package."""
+        pkg = find_package_by_name(zephyr_doc, "zephyr-sources")
+        assert pkg is not None, "zephyr.spdx: zephyr-sources package not found"
+        assert pkg.comment and "Source package" in str(pkg.comment), (
+            f"zephyr.spdx: zephyr-sources comment should mention 'Source package', "
+            f"got '{pkg.comment}'"
+        )
+
+    def test_zephyr_deps_comment(self, modules_doc):
+        """Test zephyr-deps comment describes a reference-only package."""
+        if len(modules_doc.packages) == 0:
+            pytest.skip("No packages in modules-deps.spdx")
+        pkg = find_package_by_name(modules_doc, "zephyr-deps")
+        assert pkg is not None, "modules-deps.spdx: zephyr-deps package not found"
+        assert pkg.comment and "Reference-only" in str(pkg.comment), (
+            f"modules-deps.spdx: zephyr-deps comment should mention 'Reference-only', "
+            f"got '{pkg.comment}'"
+        )
+
+    def test_module_sources_comment(self, zephyr_doc):
+        """Test first module-sources comment describes a source package."""
+        pkg = first_module_sources_package(zephyr_doc)
+        if pkg is None:
+            pytest.skip("No module-sources packages in zephyr.spdx")
+        assert pkg.comment and "Source package" in str(pkg.comment), (
+            f"zephyr.spdx: {pkg.name} comment should mention 'Source package', got '{pkg.comment}'"
+        )
+
+    def test_module_deps_comment(self, modules_doc):
+        """Test first module-deps comment describes a reference-only package."""
+        pkg = first_module_deps_package(modules_doc)
+        if pkg is None:
+            pytest.skip("No module-deps packages in modules-deps.spdx")
+        assert pkg.comment and "Reference-only" in str(pkg.comment), (
+            f"modules-deps.spdx: {pkg.name} comment should mention 'Reference-only', "
+            f"got '{pkg.comment}'"
+        )
+
+    def test_no_utility_target_comments(self, app_doc, zephyr_doc, build_doc, modules_doc):
+        """Test that no package carries the old UTILITY target comment."""
+        for doc_name, doc in [
+            ("app.spdx", app_doc),
+            ("zephyr.spdx", zephyr_doc),
+            ("build.spdx", build_doc),
+            ("modules-deps.spdx", modules_doc),
+        ]:
+            for pkg in doc.packages:
+                if pkg.comment and str(pkg.comment) == "Utility target; no files":
+                    pytest.fail(f"{doc_name}: package '{pkg.name}' has UTILITY target comment")
 
 
 class TestCrossReferences:

--- a/tests/application_development/software_bill_of_materials/verify_spdx_content.py
+++ b/tests/application_development/software_bill_of_materials/verify_spdx_content.py
@@ -99,6 +99,18 @@ def get_supplier_name(package):
     return str(package.supplier)
 
 
+def has_relationship(doc, spdx_element_id, rel_type, related_id):
+    """Return True if doc has a relationship of rel_type to related_id."""
+    for rel in doc.relationships:
+        if rel.spdx_element_id != spdx_element_id:
+            continue
+        if rel_type not in str(rel.relationship_type):
+            continue
+        if str(rel.related_spdx_element_id) == related_id:
+            return True
+    return False
+
+
 def first_module_deps_package(modules_doc):
     """Return the first module *-deps package, excluding zephyr-deps."""
     return next(
@@ -551,6 +563,52 @@ class TestPackageComments:
             for pkg in doc.packages:
                 if pkg.comment and str(pkg.comment) == "Utility target; no files":
                     pytest.fail(f"{doc_name}: package '{pkg.name}' has UTILITY target comment")
+
+
+class TestModuleRelationships:
+    """Tests for VARIANT_OF and DEPENDENCY_OF module relationships."""
+
+    def test_zephyr_sources_variant_of_zephyr_deps(self, zephyr_doc, modules_doc):
+        """Test zephyr-sources VARIANT_OF zephyr-deps across documents."""
+        if len(modules_doc.packages) == 0:
+            pytest.skip("No packages in modules-deps.spdx")
+        zephyr_sources = find_package_by_name(zephyr_doc, "zephyr-sources")
+        assert zephyr_sources is not None, "zephyr.spdx: zephyr-sources package not found"
+
+        modules_ref = find_doc_ref_id(zephyr_doc, modules_doc.creation_info.document_namespace)
+        assert modules_ref is not None, "zephyr.spdx: no external reference to modules-deps.spdx"
+        target = f"{modules_ref}:SPDXRef-zephyr-deps"
+        assert has_relationship(zephyr_doc, zephyr_sources.spdx_id, "VARIANT_OF", target), (
+            f"zephyr.spdx: expected {zephyr_sources.spdx_id} VARIANT_OF {target}"
+        )
+
+    def test_module_sources_variant_of_module_deps(self, zephyr_doc, modules_doc):
+        """Test module-sources VARIANT_OF module-deps across documents."""
+        module_deps = first_module_deps_package(modules_doc)
+        if module_deps is None:
+            pytest.skip("No module-deps packages in modules-deps.spdx")
+        module_name = module_deps.name.removesuffix("-deps")
+        module_sources = find_package_by_name(zephyr_doc, f"{module_name}-sources")
+        if module_sources is None:
+            pytest.skip(f"No {module_name}-sources package in zephyr.spdx")
+
+        modules_ref = find_doc_ref_id(zephyr_doc, modules_doc.creation_info.document_namespace)
+        assert modules_ref is not None, "zephyr.spdx: no external reference to modules-deps.spdx"
+        target = f"{modules_ref}:{module_deps.spdx_id}"
+        assert has_relationship(zephyr_doc, module_sources.spdx_id, "VARIANT_OF", target), (
+            f"zephyr.spdx: expected {module_sources.spdx_id} VARIANT_OF {target}"
+        )
+
+    def test_module_deps_dependency_of_zephyr_deps(self, modules_doc):
+        """Test module-deps DEPENDENCY_OF zephyr-deps in modules-deps.spdx."""
+        module_deps = first_module_deps_package(modules_doc)
+        if module_deps is None:
+            pytest.skip("No module-deps packages in modules-deps.spdx")
+        zephyr_deps = find_package_by_name(modules_doc, "zephyr-deps")
+        assert zephyr_deps is not None, "modules-deps.spdx: zephyr-deps package not found"
+        assert has_relationship(
+            modules_doc, module_deps.spdx_id, "DEPENDENCY_OF", zephyr_deps.spdx_id
+        ), f"modules-deps.spdx: expected {module_deps.spdx_id} DEPENDENCY_OF {zephyr_deps.spdx_id}"
 
 
 class TestCrossReferences:


### PR DESCRIPTION
When running SBOMs generated through `sbomqs score`, a few easy-to-fix compliance issues get flagged, which this series of commits address:

- Missing SBOM author and tool version in SPDX Creator fields
- Missing package supplier and revision-pinned PURL on Zephyr and module packages
- Source and dependency packages lacking descriptive comments explaining their role since it's not obvious what all these xxx-deps and xxx-sources packages are and what's the difference between them...

Also, although not necessarily an NTIA compliance issue, CMake UTILITY targets (`run`, `flash`, `menuconfig`, …) were unnecessarily polluting the build SBOM so they've been dropped.