### PR TITLE
Tag all bsim tests with bsim_CI and exclude them from twitster workflow

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -179,7 +179,7 @@ jobs:
       BSIM_COMPONENTS_PATH: /opt/bsim/components
       TWISTER_COMMON: ' --test-config tests/test_config_ci.yaml --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 --post-build-checks '
       WEEKLY_OPTIONS: ' -M --build-only --all --show-footprint --report-filtered -j 32'
-      PR_OPTIONS: ' --clobber-output --integration -j 16'
+      PR_OPTIONS: ' --clobber-output --integration -j 16 -e bsim_CI'
       PUSH_OPTIONS: ' --clobber-output -M --show-footprint --report-filtered -j 16'
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}

--- a/tests/bsim/bluetooth/host/adv/chain/tests.yaml
+++ b/tests/bsim/bluetooth/host/adv/chain/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.adv.chain:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/tests.yaml
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.adv.encrypted.css_sample_data:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/tests.yaml
+++ b/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.adv.encrypted.ead_sample:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/adv/extended/tests.yaml
+++ b/tests/bsim/bluetooth/host/adv/extended/tests.yaml
@@ -1,5 +1,6 @@
 common:
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/adv/long_ad/tests.yaml
+++ b/tests/bsim/bluetooth/host/adv/long_ad/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.adv.long_ad:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/adv/periodic/tests.yaml
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests.yaml
@@ -1,5 +1,6 @@
 common:
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/eatt/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/eatt/tests.yaml
@@ -1,6 +1,7 @@
 common:
   build_only: true
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/eatt_notif/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.att.eatt_notif:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/long_read/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/long_read/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.att.long_read:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/mtu_update/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/mtu_update/tests.yaml
@@ -1,6 +1,7 @@
 common:
   build_only: true
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/open_close/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/open_close/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.att.open_close:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/pipeline/dut/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/pipeline/dut/tests.yaml
@@ -1,6 +1,7 @@
 common:
   build_only: true
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/pipeline/tester/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/pipeline/tester/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.att.pipeline.tester:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/client/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/client/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.att.read_fill_buf.client:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/server/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/server/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.att.read_fill_buf.server:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/retry_on_sec_err/client/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/retry_on_sec_err/client/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.att.retry_on_sec_err.client:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/retry_on_sec_err/server/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/retry_on_sec_err/server/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.att.retry_on_sec_err.server:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/sequential/dut/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/sequential/dut/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.att.sequential.dut:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/sequential/tester/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/sequential/tester/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.att.sequential.tester:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/att/timeout/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/timeout/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.att.timeout:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/central/tests.yaml
+++ b/tests/bsim/bluetooth/host/central/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.central:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/gatt/authorization/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/authorization/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.gatt.authorization:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/gatt/caching/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/caching/tests.yaml
@@ -1,6 +1,7 @@
 common:
   build_only: true
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/tests.yaml
@@ -1,6 +1,7 @@
 common:
   build_only: true
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/gatt/device_name/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/device_name/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.gatt.device_name:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/gatt/general/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/general/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.gatt.general:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/gatt/notify/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/notify/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.gatt.notify:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.gatt.notify_multiple:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/gatt/notify_stress/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/notify_stress/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     sysbuild: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.gatt.sc_indicate:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native
@@ -11,6 +12,7 @@ tests:
   bluetooth.host.gatt.sc_indicate_privacy:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/gatt/settings/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/settings/tests.yaml
@@ -1,6 +1,7 @@
 common:
   build_only: true
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/gatt/settings_clear/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/settings_clear/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.gatt.settings_clear:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/id/settings/tests.yaml
+++ b/tests/bsim/bluetooth/host/id/settings/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.id.settings:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/iso/bis/tests.yaml
+++ b/tests/bsim/bluetooth/host/iso/bis/tests.yaml
@@ -1,6 +1,7 @@
 common:
   build_only: true
   tags:
+    - bsim_CI
     - bluetooth
   harness: bsim
   harness_config:

--- a/tests/bsim/bluetooth/host/iso/cis/tests.yaml
+++ b/tests/bsim/bluetooth/host/iso/cis/tests.yaml
@@ -1,6 +1,7 @@
 tests:
   bluetooth.host.iso.cis:
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/iso/frag/tests.yaml
+++ b/tests/bsim/bluetooth/host/iso/frag/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.iso.frag:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/iso/frag_2/tests.yaml
+++ b/tests/bsim/bluetooth/host/iso/frag_2/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.iso.frag_2:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/credits/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/credits/tests.yaml
@@ -1,6 +1,7 @@
 common:
   build_only: true
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests.yaml
@@ -1,6 +1,7 @@
 common:
   build_only: true
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/ecred/dut/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/ecred/dut/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.l2cap.ecred.dut:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/ecred/peer/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/ecred/peer/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.l2cap.ecred.peer:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/einprogress/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/einprogress/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.l2cap.einprogress:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/general/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/general/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.l2cap.general:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/many_conns/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/many_conns/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.l2cap.many_conns:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.l2cap.multilink_peripheral:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/dut/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/dut/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.l2cap.reassembly.dut:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/peer/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/peer/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.l2cap.reassembly.peer:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests.yaml
@@ -1,6 +1,7 @@
 common:
   build_only: true
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/split/dut/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/split/dut/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.l2cap.split.dut:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/split/tester/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/split/tester/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.l2cap.split.tester:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/stress/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/stress/tests.yaml
@@ -1,6 +1,7 @@
 common:
   build_only: true
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/l2cap/userdata/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.l2cap.userdata:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/misc/acl_tx_frag/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/acl_tx_frag/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.mics.acl_tx_frag:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/misc/conn_param_update_reject/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/conn_param_update_reject/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.misc.conn_param_update_reject:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/misc/conn_stress/central/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/central/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.misc.conn_stress.central:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.misc.conn_stress.peripheral:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/misc/disable/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/disable/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.mics.disable:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/misc/disconnect/dut/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/disconnect/dut/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.misc.disconnect.dut:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/misc/disconnect/tester/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/disconnect/tester/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.misc.disconnect.tester:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/misc/hfc/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/hfc/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     sysbuild: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/dut/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/dut/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     sysbuild: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     sysbuild: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/misc/sample_test/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/sample_test/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.mics.sample_test:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/misc/unregister_conn_cb/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/unregister_conn_cb/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.mics.unregister_conn_cb:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/privacy/central/tests.yaml
+++ b/tests/bsim/bluetooth/host/privacy/central/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.privacy.central:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/privacy/device/tests.yaml
+++ b/tests/bsim/bluetooth/host/privacy/device/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.privacy.device:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/privacy/legacy/tests.yaml
+++ b/tests/bsim/bluetooth/host/privacy/legacy/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.privacy.legacy:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/privacy/peripheral/tests.yaml
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/tests.yaml
@@ -2,6 +2,7 @@ common:
   build_only: true
   sysbuild: true
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/scan/slow/tests.yaml
+++ b/tests/bsim/bluetooth/host/scan/slow/tests.yaml
@@ -2,6 +2,7 @@ common:
   build_only: true
   sysbuild: true
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/scan/start_stop/tests.yaml
+++ b/tests/bsim/bluetooth/host/scan/start_stop/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.scan.start_stop:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.security.bond_overwrite_allowed:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.security.bond_overwrite_denied:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.security.bond_per_connection:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/security/ccc_update/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/ccc_update/tests.yaml
@@ -1,6 +1,7 @@
 common:
   build_only: true
   tags:
+    - bsim_CI
     - bluetooth
   platform_allow:
     - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/security/id_addr_update/central/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/central/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.security.id_addr_update.central:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.security.id_addr_update.peripheral:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.host.security.security_changed_callback:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     platform_allow:
       - nrf52_bsim/native

--- a/tests/bsim/bluetooth/ll/bis/tests.yaml
+++ b/tests/bsim/bluetooth/ll/bis/tests.yaml
@@ -1,8 +1,8 @@
 common:
   build_only: true
   tags:
+    - bsim_CI
     - bluetooth
-    - bsim_multi
   depends_on: bsim
 
 tests:

--- a/tests/bsim/bluetooth/tester/tests.yaml
+++ b/tests/bsim/bluetooth/tester/tests.yaml
@@ -2,6 +2,7 @@ tests:
   bluetooth.tester_bsim:
     build_only: true
     tags:
+      - bsim_CI
       - bluetooth
     harness: bsim
     harness_config:


### PR DESCRIPTION
These tests are already built & run by the babblesim workflow, so there is no need to also build them in the twister workflow on PRs.

This change will just save CI time, specially as we transition the bsim tests (and its workflow) to use twister and test.yaml definitions for all tests.

The change was done with a plain search and replace.
The removed `bsim_multi` tag, was a leftover which was meant to have the same purpose but was actually never used for anything.