### PR TITLE
dfu: Fix mcuboot image confirmation return check

### DIFF
--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -467,7 +467,9 @@ int boot_write_img_confirmed(void)
 		return -EIO;
 	}
 
-	rc = boot_set_next(fa, true, true);
+	if (boot_set_next(fa, true, true) != 0) {
+		rc = -EIO;
+	}
 
 	flash_area_close(fa);
 


### PR DESCRIPTION
boot_set_next() returns 'non-zero' on error, hardcoded -EIO for all mcuboot internal error codes