### PR TITLE
boards: st: nucleo_h7xxzi_q: add arduino_spi

### DIFF
--- a/boards/st/nucleo_h745zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h745zi_q/arduino_r3_connector.dtsi
@@ -39,4 +39,6 @@
 
 arduino_i2c: &i2c1 {};
 
+arduino_spi: &spi1 {};
+
 arduino_serial: &lpuart1 {};

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q.dtsi
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q.dtsi
@@ -34,6 +34,12 @@
 	};
 };
 
+&spi1 {
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pb5>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpiod 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+};
+
 &rcc {
 	d1cpre = <1>;
 	hpre = <2>;

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.yaml
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.yaml
@@ -9,6 +9,9 @@ ram: 128
 flash: 1024
 supported:
   - arduino_gpio
+  - arduino_i2c
+  - arduino_serial
+  - arduino_spi
   - gpio
   - netif:eth
   - spi

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.yaml
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.yaml
@@ -10,6 +10,8 @@ flash: 1024
 supported:
   - arduino_gpio
   - arduino_i2c
+  - arduino_serial
+  - arduino_spi
   - uart
   - gpio
   - counter

--- a/boards/st/nucleo_h755zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h755zi_q/arduino_r3_connector.dtsi
@@ -39,4 +39,6 @@
 
 arduino_i2c: &i2c1 {};
 
+arduino_spi: &spi1 {};
+
 arduino_serial: &lpuart1 {};

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q.dtsi
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q.dtsi
@@ -39,6 +39,12 @@
 	};
 };
 
+&spi1 {
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pb5>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpiod 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+};
+
 &rcc {
 	d1cpre = <1>;
 	hpre = <2>;

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m4.yaml
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m4.yaml
@@ -9,6 +9,9 @@ ram: 128
 flash: 1024
 supported:
   - arduino_gpio
+  - arduino_i2c
+  - arduino_serial
+  - arduino_spi
   - gpio
   - netif:eth
 testing:

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.yaml
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.yaml
@@ -10,6 +10,8 @@ flash: 1024
 supported:
   - arduino_gpio
   - arduino_i2c
+  - arduino_serial
+  - arduino_spi
   - uart
   - gpio
   - counter

--- a/boards/st/nucleo_h7a3zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h7a3zi_q/arduino_r3_connector.dtsi
@@ -37,4 +37,6 @@
 	};
 };
 
+arduino_spi: &spi1 {};
+
 arduino_serial: &lpuart1 {};

--- a/boards/st/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
+++ b/boards/st/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
@@ -98,6 +98,12 @@
 	power-supply = "smps-direct";
 };
 
+&spi1 {
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpiod 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+};
+
 &lpuart1 {
 	pinctrl-0 = <&lpuart1_tx_pb6 &lpuart1_rx_pb7>;
 	pinctrl-names = "default";

--- a/boards/st/nucleo_h7a3zi_q/nucleo_h7a3zi_q.yaml
+++ b/boards/st/nucleo_h7a3zi_q/nucleo_h7a3zi_q.yaml
@@ -9,6 +9,8 @@ ram: 256
 flash: 2048
 supported:
   - arduino_gpio
+  - arduino_serial
+  - arduino_spi
   - uart
   - gpio
   - pwm


### PR DESCRIPTION
Add arduino_spi to nucleo_h745zi_q and nucleo_h755zi_q boards.

The information is based on Table 17 and Table 18 in [UM2408 User manual (pdf)](https://www.st.com/resource/en/user_manual/um2408-stm32h7-nucleo144-boards-mb1363-stmicroelectronics.pdf).

<details>
<summary>Table 17. NUCLEO-H745ZI-Q and NUCLEO-H755ZI-Q pin assignments (continued)
</summary>
<img width="709" height="671" alt="image" src="https://github.com/user-attachments/assets/b3becf8f-df1d-42fc-8c37-43b846bf2ace" />
</details>

<details>
<summary>Table 18. NUCLEO-H7A3ZI-Q pin assignments (continued)
</summary>
<img width="714" height="681" alt="image" src="https://github.com/user-attachments/assets/a8541f7e-7a28-42ef-9b76-7c475572d687" />
</details>