### PR TITLE
scripts: twister: reset stale Ztest state on device restart

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -962,6 +962,13 @@ class Test(Harness):
     test_case_summary_pattern = re.compile(
         r".*- (PASS|FAIL|SKIP) - \[([^\.]*).(test_)?(\S*)\] duration = (\d*[.,]?\d*) seconds"
     )
+    # The Zephyr boot banner marks the image under test (re)starting. Ztest
+    # markers seen before it belong to a previously-programmed image -- for
+    # example console output captured while the board was still being flashed
+    # (the default flash_before=False opens the serial port before flashing) --
+    # and must not be attributed to this run, or they linger as phantom
+    # 'started' cases that never reach a terminal status.
+    test_boot_banner_pattern = re.compile(r"Booting Zephyr OS")
 
 
     def get_testcase(self, tc_name, phase, ts_name=None):
@@ -1062,6 +1069,28 @@ class Test(Harness):
         testcase_match = None
         if self._match:
             self.testcase_output += line + "\n"
+        if (
+            not getattr(self, "expect_reboot", False)
+            and (self.started_suites or self.started_cases)
+            and re.search(self.test_boot_banner_pattern, line)
+        ):
+            # A fresh boot banner arrived while Ztest state is still pending:
+            # that state is stale output from a previously-programmed image
+            # (e.g. captured while flashing), not this test run. Discard it so
+            # it is not reported as a phantom 'started' case that never ends.
+            logger.debug(
+                f"{self.id}: boot banner with pending Ztest state; discarding "
+                f"stale suites={self.started_suites} cases={self.started_cases}"
+            )
+            for tc in self.instance.testcases:
+                if tc.status == TwisterStatus.STARTED:
+                    tc.status = TwisterStatus.NONE
+            self.started_suites = {}
+            self.started_cases = {}
+            self.detected_suite_names = []
+            self.testcase_output = ""
+            self._match = False
+            self.ztest = False
         if test_suite_start_match := re.search(self.test_suite_start_pattern, line):
             self.start_suite(test_suite_start_match.group("suite_name"))
         elif test_suite_end_match := re.search(self.test_suite_end_pattern, line):

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -1032,6 +1032,10 @@ class Test(Harness):
     test_case_summary_pattern = re.compile(
         r".*- (PASS|FAIL|SKIP) - \[([^\.]*).(test_)?(\S*)\] duration = (\d*[.,]?\d*) seconds"
     )
+    # Secondary restart signal: Ztest prints this at the start of every run
+    # (TC_PRINT_RUNID_START), so it is emitted on every (re)boot and, unlike the
+    # boot banner, is part of the test output rather than an application artifact.
+    test_runid_start_pattern = re.compile(r"RunID started:")
 
 
     def get_testcase(self, tc_name, phase, ts_name=None):
@@ -1068,7 +1072,33 @@ class Test(Harness):
         tc_id = self.instance.testsuite.compose_case_name(tc_name)
         return self.instance.get_case_or_create(tc_id)
 
+    def discard_stale_ztest_state(self, phase, reason):
+        """ Drop Ztest state left pending by an image that has restarted.
+
+            Such state is console output captured from a previously-programmed
+            image -- the default flash_before=False opens the serial port before
+            flashing -- or from a run interrupted by a reboot. Attributing it to
+            this run leaves phantom 'started' cases that never end.
+        """
+        logger.debug(f"{phase}: {reason}; discarding stale Ztest state"
+                     f" suites={self.started_suites} cases={self.started_cases}")
+        for tc in self.instance.testcases:
+            if tc.status == TwisterStatus.STARTED:
+                tc.status = TwisterStatus.NONE
+        self.started_suites = {}
+        self.started_cases = {}
+        self.detected_suite_names = []
+        self.testcase_output = ""
+        self._match = False
+        self.ztest = False
+
     def start_suite(self, suite_name, phase='TS_START'):
+        if self.started_suites.get(suite_name, {}).get('count', 0) > 0 \
+           and not self.expect_reboot:
+            # A suite cannot start while it is already running, so the image
+            # restarted. Ztest emits this marker itself, so the restart evidence
+            # is present with no dependency on any Kconfig.
+            self.discard_stale_ztest_state(phase, f"suite '{suite_name}' already STARTED")
         if suite_name not in self.detected_suite_names:
             self.detected_suite_names.append(suite_name)
         if self.trace and suite_name not in self.instance.testsuite.ztest_suite_names:
@@ -1077,11 +1107,7 @@ class Test(Harness):
             logger.debug(f"{phase}: unexpected Ztest suite '{suite_name}' is "
                          f"not present among: {self.instance.testsuite.ztest_suite_names}")
         if suite_name in self.started_suites:
-            if self.started_suites[suite_name]['count'] > 0 and not self.expect_reboot:
-                # Either the suite restarts itself or unexpected state transition.
-                logger.warning(f"{phase}: already STARTED '{suite_name}':"
-                               f"{self.started_suites[suite_name]}")
-            elif self.trace:
+            if self.trace:
                 logger.debug(f"{phase}: START suite '{suite_name}'")
             self.started_suites[suite_name]['count'] += 1
             self.started_suites[suite_name]['repeat'] += 1
@@ -1106,10 +1132,9 @@ class Test(Harness):
             logger.warning(f"{phase}: END suite '{suite_name}' without START detected")
 
     def start_case(self, tc_name, phase='TC_START'):
+        if self.started_cases.get(tc_name, {}).get('count', 0) > 0 and not self.expect_reboot:
+            self.discard_stale_ztest_state(phase, f"case '{tc_name}' already STARTED")
         if tc_name in self.started_cases:
-            if self.started_cases[tc_name]['count'] > 0 and not self.expect_reboot:
-                logger.warning(f"{phase}: already STARTED case "
-                               f"'{tc_name}':{self.started_cases[tc_name]}")
             self.started_cases[tc_name]['count'] += 1
         else:
             self.started_cases[tc_name] = { 'count': 1 }
@@ -1132,6 +1157,15 @@ class Test(Harness):
         testcase_match = None
         if self._match:
             self.testcase_output += line + "\n"
+        if (
+            not self.expect_reboot
+            and (self.started_suites or self.started_cases)
+            and self.test_runid_start_pattern.search(line)
+        ):
+            # Ztest emits this at the start of every run, so a second one seen
+            # while markers are still pending proves the image restarted. Catches
+            # a restart that never re-emits a marker that is still pending.
+            self.discard_stale_ztest_state('RUNID', 'RunID start marker while Ztest state pending')
         if test_suite_start_match := re.search(self.test_suite_start_pattern, line):
             self.start_suite(test_suite_start_match.group("suite_name"))
         elif test_suite_end_match := re.search(self.test_suite_end_pattern, line):

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -917,6 +917,62 @@ def test_test_handle(
         assert test_obj.instance.testcases[1].status == exp_status
 
 
+def test_test_handle_boot_banner_resets_stale_state(tmp_path):
+    """A boot banner seen while Ztest state is still pending must discard that
+    stale state (e.g. console output captured from a previously-programmed
+    image while flashing), including any phantom 'started' testcase recorded on
+    the instance, unless the suite expects reboots."""
+    mock_platform = mock.Mock()
+    mock_platform.name = "mock_platform"
+    mock_platform.normalized_name = "mock_platform"
+
+    mock_testsuite = mock.Mock(id="dummy.test_id", testcases=[])
+    mock_testsuite.name = "dummy_suite/dummy.test_id"
+    mock_testsuite.harness_config = {}
+    mock_testsuite.ztest_suite_names = []
+    mock_testsuite.detailed_test_id = True
+    mock_testsuite.source_dir_rel = "dummy_suite"
+    mock_testsuite.compose_case_name.return_value = "dummy.test_id.testcase"
+
+    outdir = tmp_path / "ztest_out"
+    with mock.patch('twisterlib.testsuite.TestSuite.get_unique', return_value="dummy_suite"):
+        instance = TestInstance(
+            testsuite=mock_testsuite, platform=mock_platform, toolchain='zephyr', outdir=outdir
+        )
+    instance.handler = mock.Mock(options=mock.Mock(verbose=0), type_str="handler_type")
+
+    test_obj = Test()
+    test_obj.configure(instance)
+    test_obj.id = "dummy.test_id"
+    test_obj.expect_reboot = False
+
+    # Simulate stale pre-flash Ztest state from a previously-programmed image.
+    phantom = instance.get_case_or_create("dummy.test_id.testcase")
+    phantom.status = TwisterStatus.STARTED
+    test_obj.ztest = True
+    test_obj.started_suites = {'suite_name': {'count': 1, 'repeat': 0}}
+    test_obj.started_cases = {'dummy.test_id.testcase': {'count': 1}}
+    test_obj.detected_suite_names = ['suite_name']
+
+    # Act: a fresh boot banner arrives.
+    test_obj.handle("*** Booting Zephyr OS build v4.2.0 ***")
+
+    # Assert: stale state discarded and the phantom case reset to no-result.
+    assert test_obj.started_suites == {}
+    assert test_obj.started_cases == {}
+    assert test_obj.detected_suite_names == []
+    assert test_obj.ztest is False
+    assert phantom.status == TwisterStatus.NONE
+
+    # With expect_reboot set, the banner must NOT clear pending state.
+    test_obj.expect_reboot = True
+    phantom.status = TwisterStatus.STARTED
+    test_obj.started_cases = {'dummy.test_id.testcase': {'count': 1}}
+    test_obj.handle("*** Booting Zephyr OS build v4.2.0 ***")
+    assert test_obj.started_cases == {'dummy.test_id.testcase': {'count': 1}}
+    assert phantom.status == TwisterStatus.STARTED
+
+
 @pytest.fixture
 def gtest(tmp_path):
     mock_platform = mock.Mock()

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -966,6 +966,118 @@ def test_test_handle(
 
 
 @pytest.fixture
+def stale_state_ztest(tmp_path):
+    """A configured Ztest harness carrying stale state from a previous image."""
+    mock_platform = mock.Mock()
+    mock_platform.name = "mock_platform"
+    mock_platform.normalized_name = "mock_platform"
+
+    mock_testsuite = mock.Mock(id="dummy.test_id", testcases=[])
+    mock_testsuite.name = "dummy_suite/dummy.test_id"
+    mock_testsuite.harness_config = {}
+    mock_testsuite.ztest_suite_names = []
+    mock_testsuite.detailed_test_id = True
+    mock_testsuite.source_dir_rel = "dummy_suite"
+    mock_testsuite.compose_case_name.return_value = "dummy.test_id.testcase"
+
+    outdir = tmp_path / "ztest_out"
+    with mock.patch('twisterlib.testsuite.TestSuite.get_unique', return_value="dummy_suite"):
+        instance = TestInstance(
+            testsuite=mock_testsuite, platform=mock_platform, toolchain='zephyr', outdir=outdir
+        )
+    instance.handler = mock.Mock(options=mock.Mock(verbose=0), type_str="handler_type")
+
+    test_obj = Test()
+    test_obj.configure(instance)
+    test_obj.id = "dummy.test_id"
+    test_obj.expect_reboot = False
+
+    phantom = instance.get_case_or_create("dummy.test_id.testcase")
+    phantom.status = TwisterStatus.STARTED
+    test_obj.ztest = True
+    test_obj.started_suites = {'suite_name': {'count': 1, 'repeat': 0}}
+    test_obj.started_cases = {'dummy.test_id.testcase': {'count': 1}}
+    test_obj.detected_suite_names = ['suite_name']
+
+    return test_obj, phantom
+
+
+def test_test_handle_duplicate_suite_marker_resets_stale_state(stale_state_ztest):
+    """A suite that starts again while still running means the image restarted,
+    so the pending state from before it is stale and must be discarded. Ztest
+    always emits this marker, unlike the optional boot banner."""
+    test_obj, phantom = stale_state_ztest
+
+    test_obj.handle("Running TESTSUITE suite_name")
+
+    assert test_obj.started_suites == {'suite_name': {'count': 1, 'repeat': 0}}
+    assert test_obj.started_cases == {}
+    assert phantom.status == TwisterStatus.NONE
+
+
+def test_test_handle_duplicate_case_marker_resets_stale_state(stale_state_ztest):
+    """The same applies to a test case that starts again while still running."""
+    test_obj, phantom = stale_state_ztest
+
+    test_obj.handle("START - test_testcase")
+
+    assert test_obj.started_suites == {}
+    assert test_obj.started_cases == {'dummy.test_id.testcase': {'count': 1}}
+    # handle() re-marks the case as started for the run that is now beginning.
+    assert phantom.status == TwisterStatus.STARTED
+
+
+def test_test_handle_runid_start_marker_resets_stale_state(stale_state_ztest):
+    """The RunID start marker (TC_PRINT_RUNID_START), printed at the start of
+    every run, covers a restart that never re-emits a pending marker, e.g. when
+    the interrupted run had only partially printed one. Unlike the boot banner
+    it is test output, not an application artifact."""
+    test_obj, phantom = stale_state_ztest
+
+    test_obj.handle("RunID started: deadbeefcafe1234")
+
+    assert test_obj.started_suites == {}
+    assert test_obj.started_cases == {}
+    assert test_obj.detected_suite_names == []
+    assert test_obj.ztest is False
+    assert phantom.status == TwisterStatus.NONE
+
+
+@pytest.mark.parametrize(
+    "line",
+    ["Running TESTSUITE suite_name", "START - test_testcase",
+     "RunID started: deadbeefcafe1234"],
+    ids=["suite_marker", "case_marker", "runid_start"],
+)
+def test_test_handle_expect_reboot_keeps_state(stale_state_ztest, line):
+    """A suite that legitimately reboots must keep its pending state."""
+    test_obj, phantom = stale_state_ztest
+    test_obj.expect_reboot = True
+
+    test_obj.handle(line)
+
+    assert test_obj.started_suites['suite_name']['count'] >= 1
+    assert phantom.status == TwisterStatus.STARTED
+
+
+def test_test_handle_repeated_suite_is_not_stale(stale_state_ztest):
+    """A suite that ends before starting again is a legitimate repeat, not a
+    restart, and must not have its state discarded."""
+    test_obj, _ = stale_state_ztest
+    test_obj.started_suites = {}
+    test_obj.started_cases = {}
+    test_obj.detected_suite_names = []
+
+    test_obj.handle("Running TESTSUITE suite_name")
+    test_obj.handle("TESTSUITE suite_name succeeded")
+    test_obj.handle("Running TESTSUITE suite_name")
+
+    assert test_obj.started_suites == {'suite_name': {'count': 1, 'repeat': 1}}
+    assert test_obj.detected_suite_names == ['suite_name']
+    assert test_obj.ztest is True
+
+
+@pytest.fixture
 def gtest(tmp_path):
     mock_platform = mock.Mock()
     mock_platform.name = "mock_platform"


### PR DESCRIPTION
### Description

The twister `Test` harness attributes every Ztest suite/case marker it parses to
the current run. When a device restarts mid-run — because it reboots on its own,
or because console output was captured from a previously-programmed image while
the board was still being flashed (the default `flash_before=False` opens the
serial port before flashing) — the markers seen before the restart are left
pending. They never reach a terminal status, so they surface as phantom
`started` cases and produce spurious `already STARTED` / `None status` warnings
once the real run re-emits the same markers.

This discards that stale state when a restart is detected, via a single shared
`discard_stale_ztest_state()` helper driven by two signals that **Ztest emits
itself** — no dependency on an application artifact:

1. **A start marker for a suite or case that is already running** (primary).
   Ztest emits these itself, so whenever there is stale state to discard the
   evidence of the restart is present by construction, with no dependency on any
   Kconfig. This is exactly the condition that previously only logged an
   `already STARTED` warning, so it turns that warning into a correct recovery.
2. **The `RunID started:` marker** (secondary), printed at the start of every run
   by `TC_PRINT_RUNID_START`. A second one seen while markers are still pending
   proves the image restarted, so it catches a restart that never re-emits a
   still-pending marker. It is part of the test output and does not depend on
   `CONFIG_BOOT_BANNER`.

A suite that *ends* before starting again is a legitimate repeat, not a restart,
and is left alone; so is any suite declaring `expect_reboot`.

The `RunID started:` marker, and its propagation into the application image under
sysbuild, come from #117923, which this depends on. On `kit_pse84_eval/m55` the
marker was confirmed to print on the target console on every boot — including the
double-boot that produces this class of phantom state — bracketing each run
between `RunID started:` … `RunID:`.

An earlier revision used the Zephyr boot banner as the secondary signal. Per
review the banner was dropped: it is an optional application artifact, whereas
the RunID marker is test output.

### Testing

- `scripts/tests/twister/test_harness.py` covers each trigger: a duplicate suite
  marker, a duplicate case marker, and the `RunID started:` marker each discard
  stale state; `expect_reboot` preserves it for all three; and a suite that ends
  before restarting is confirmed *not* to be treated as stale (the main
  false-positive risk). The harness suite passes.
- Replaying 1841 Ztest `handler.log` files captured from real device runs, the
  duplicate-marker trigger eliminates the `already STARTED` warnings (729 → 0).
  The `RunID started:` marker additionally recovers the restarts that re-emit no
  still-pending marker — the class the boot banner previously covered — now
  validated on hardware (`kit_pse84_eval/m55`, RunID marker printed on every
  boot including the double-boot case).
