### PR TITLE
drivers: modem: hl78xx: split GNSS parsers and harden modem helpers

### DIFF
--- a/drivers/modem/vendor_standalone/hl78xx/CMakeLists.txt
+++ b/drivers/modem/vendor_standalone/hl78xx/CMakeLists.txt
@@ -32,6 +32,7 @@ zephyr_library_sources_ifdef(
     CONFIG_HL78XX_GNSS
     hl78xx_gnss.c
     hl78xx_gnssloc.c
+    hl78xx_gnss_aux_parse.c
     hl78xx_gnss_parsers.c
 )
 

--- a/drivers/modem/vendor_standalone/hl78xx/CMakeLists.txt
+++ b/drivers/modem/vendor_standalone/hl78xx/CMakeLists.txt
@@ -31,6 +31,7 @@ zephyr_library_sources_ifdef(
 zephyr_library_sources_ifdef(
     CONFIG_HL78XX_GNSS
     hl78xx_gnss.c
+    hl78xx_gnssloc.c
     hl78xx_gnss_parsers.c
 )
 

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx.c
@@ -610,7 +610,7 @@ void hl78xx_on_cxreg(struct modem_chat *chat, char **argv, uint16_t argc, void *
 	struct hl78xx_evt event = {.type = HL78XX_LTE_REGISTRATION_STAT_UPDATE};
 	enum hl78xx_cell_rat_mode rat_mode = HL78XX_RAT_MODE_NONE;
 	struct hl78xx_evt rat_event = {.type = HL78XX_LTE_RAT_UPDATE};
-	bool is_urc_message;
+	bool has_n_param;
 	bool rat_mode_updated = false;
 
 	ARG_UNUSED(chat);
@@ -620,10 +620,18 @@ void hl78xx_on_cxreg(struct modem_chat *chat, char **argv, uint16_t argc, void *
 	}
 
 	LOG_DBG("Received %s URC with argc: %d", argv[0], argc);
+	/*
+	 * Query responses include <n> before <stat>:
+	 *   +CEREG: <n>,<stat>,...
+	 *
+	 * URCs do not include <n>:
+	 *   +CEREG: <stat>,...
+	 *
+	 * The parser expects has_n_param=true when argv[1] is <n> and argv[2] is <stat>.
+	 */
+	has_n_param = (argc > 2 && strlen(argv[1]) == 1 && strlen(argv[2]) == 1);
 
-	is_urc_message = (argc > 2 && strlen(argv[1]) == 1 && strlen(argv[2]) == 1);
-
-	hl78xx_parse_cereg_info(data, argv, argc, is_urc_message);
+	hl78xx_parse_cereg_info(data, argv, argc, has_n_param);
 	rat_mode_updated = data->status.cxreg.has_rat_mode;
 	rat_mode = data->status.cxreg.rat_mode;
 	registration_status = data->status.cxreg.reg_status;

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_apis.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_apis.c
@@ -17,6 +17,7 @@
 #include "hl78xx_gnss.h"
 #endif /* CONFIG_HL78XX_GNSS */
 #include "hl78xx_cfg.h"
+#include <zephyr/modem/chat.h>
 #include <zephyr/drivers/modem/hl78xx_apis.h>
 
 LOG_MODULE_REGISTER(hl78xx_apis, CONFIG_MODEM_LOG_LEVEL);

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.c
@@ -1669,7 +1669,7 @@ static bool hl78xx_copy_cereg_timer_field(const char *src, char *dst, size_t dst
 	return true;
 }
 
-void hl78xx_parse_cereg_info(struct hl78xx_data *data, char **argv, uint16_t argc, bool is_urc)
+void hl78xx_parse_cereg_info(struct hl78xx_data *data, char **argv, uint16_t argc, bool has_n_param)
 {
 	struct hl78xx_cxreg_status *cxreg;
 	int status_idx;
@@ -1697,7 +1697,7 @@ void hl78xx_parse_cereg_info(struct hl78xx_data *data, char **argv, uint16_t arg
 	cxreg->has_tau = false;
 	cxreg->tau[0] = '\0';
 
-	status_idx = is_urc ? 2 : 1;
+	status_idx = has_n_param ? 2 : 1;
 	tac_idx = status_idx + 1;
 	cell_idx = status_idx + 2;
 	act_idx = status_idx + 3;

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.c
@@ -1984,8 +1984,7 @@ int hl78xx_switch_baudrate(struct hl78xx_data *data, uint32_t target_baudrate)
 }
 #endif /* CONFIG_MODEM_HL78XX_AUTO_BAUDRATE */
 
-#ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
-/* Convert 8-character binary string to byte (0–255) */
+/* Convert 8-character binary string to byte (0-255) */
 int binary_str_to_byte(const char *bin_str)
 {
 	if (strlen(bin_str) != 8) {
@@ -2019,4 +2018,3 @@ void byte_to_binary_str(uint8_t byte, char *output)
 	}
 	output[8] = '\0';
 }
-#endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.c
@@ -1440,7 +1440,7 @@ static bool hl78xx_parse_quoted_hex_field(const char *src, uint32_t *value)
 	return true;
 }
 
-static void hl78xx_ctzeu_normalize_value(char *str)
+static void hl78xx_ctzeu_trim_whitespace(char *str)
 {
 	char *start;
 	char *end;
@@ -1453,16 +1453,7 @@ static void hl78xx_ctzeu_normalize_value(char *str)
 	while (isspace((unsigned char)*start)) {
 		start++;
 	}
-	if (start != str) {
-		memmove(str, start, strlen(start) + 1U);
-	}
 
-	hl78xx_trim_surrounding_quotes(str);
-
-	start = str;
-	while (isspace((unsigned char)*start)) {
-		start++;
-	}
 	if (start != str) {
 		memmove(str, start, strlen(start) + 1U);
 	}
@@ -1471,7 +1462,44 @@ static void hl78xx_ctzeu_normalize_value(char *str)
 	while ((end > str) && isspace((unsigned char)end[-1])) {
 		end--;
 	}
+
 	*end = '\0';
+}
+
+static void hl78xx_ctzeu_normalize_value(char *str)
+{
+	if (str == NULL) {
+		return;
+	}
+
+	/*
+	 * First trim whitespace so values such as:
+	 *
+	 *   " \"8\" "
+	 *
+	 * become:
+	 *
+	 *   "\"8\""
+	 *
+	 * before quote removal is attempted.
+	 */
+	hl78xx_ctzeu_trim_whitespace(str);
+
+	/*
+	 * Remove one pair of surrounding quotes, if present.
+	 */
+	hl78xx_trim_surrounding_quotes(str);
+
+	/*
+	 * Trim again so quoted values with internal padding such as:
+	 *
+	 *   "\" 8 \""
+	 *
+	 * normalize to:
+	 *
+	 *   "8"
+	 */
+	hl78xx_ctzeu_trim_whitespace(str);
 }
 
 static int hl78xx_ctzeu_parse_numeric_arg(const char *src, int min_value, int max_value, int *value)
@@ -1734,8 +1762,11 @@ bool hl78xx_parse_plmn(const char *operator, uint16_t *mcc, uint16_t *mnc)
 		return false;
 	}
 
-	while ((*operator != '\0') && (len < (sizeof(digits) - 1U))) {
+	while (*operator != '\0') {
 		if ((*operator >= '0') && (*operator <= '9')) {
+			if (len >= (sizeof(digits) - 1U)) {
+				return false;
+			}
 			digits[len++] = *operator;
 		}
 		operator++;

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.c
@@ -1657,15 +1657,24 @@ int hl78xx_ctzeu_parse_urc(char **argv, uint16_t argc, struct hl78xx_ctzeu_updat
 
 static bool hl78xx_copy_cereg_timer_field(const char *src, char *dst, size_t dst_size)
 {
+	char timer[11];
+
 	if ((src == NULL) || (dst == NULL) || (dst_size == 0U)) {
 		return false;
 	}
 
-	if (strlen(src) >= dst_size) {
+	safe_strncpy(timer, src, sizeof(timer));
+	hl78xx_trim_surrounding_quotes(timer);
+
+	if (strlen(timer) != 8U) {
 		return false;
 	}
 
-	safe_strncpy(dst, src, dst_size);
+	if (binary_str_to_byte(timer) < 0) {
+		return false;
+	}
+
+	safe_strncpy(dst, timer, dst_size);
 	return true;
 }
 

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.h
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.h
@@ -79,9 +79,10 @@ int hl78xx_ctzeu_parse_urc(char **argv, uint16_t argc, struct hl78xx_ctzeu_updat
  * @param data HL78XX data structure.
  * @param argv Tokenized URC arguments from modem chat.
  * @param argc Number of tokens in argv.
- * @param is_urc Indicates if the message is a URC.
+ * @param has_n_param Indicates if argv includes the query response <n> field.
  */
-void hl78xx_parse_cereg_info(struct hl78xx_data *data, char **argv, uint16_t argc, bool is_urc);
+void hl78xx_parse_cereg_info(struct hl78xx_data *data, char **argv, uint16_t argc,
+			     bool has_n_param);
 
 /**
  * @brief Set network operator format.

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.h
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.h
@@ -193,9 +193,9 @@ uint32_t hl78xx_edrx_idle_get_remaining_timetosleep(struct hl78xx_data *data);
 void hl78xx_psmev_init(struct hl78xx_data *data);
 #endif /* CONFIG_MODEM_HL78XX_PSM */
 
-int binary_str_to_byte(const char *bin_str);
-void byte_to_binary_str(uint8_t byte, char *output);
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+void byte_to_binary_str(uint8_t byte, char *output);
+int binary_str_to_byte(const char *bin_str);
 
 bool hl78xx_is_rsrp_value_valid(int16_t rsrp);
 bool hl78xx_is_rsrq_value_valid(int16_t rsrq);

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss.h
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_DRIVERS_MODEM_HL78XX_HL78XX_GNSS_H_
 #define ZEPHYR_DRIVERS_MODEM_HL78XX_HL78XX_GNSS_H_
 
+#include <stddef.h>
+
 #include <zephyr/types.h>
 
 #include <zephyr/drivers/gnss.h>
@@ -70,8 +72,11 @@ struct hl78xx_gnss_config {
 };
 
 struct hl78xx_gnss_data {
-	const struct device *dev;
+	/* Must stay first: generic gnss_nmea0183_match_* callbacks cast user_data
+	 * directly to struct gnss_nmea0183_match_data.
+	 */
 	struct gnss_nmea0183_match_data match_data;
+	const struct device *dev;
 #if defined(CONFIG_GNSS_SATELLITES) && defined(CONFIG_HL78XX_GNSS_SOURCE_NMEA)
 	struct gnss_satellite satellites[CONFIG_HL78XX_GNSS_SATELLITES_COUNT];
 #endif
@@ -120,6 +125,9 @@ struct hl78xx_gnss_data {
 	struct k_sem lock;
 	k_timepoint_t pm_deadline;
 };
+
+_Static_assert(offsetof(struct hl78xx_gnss_data, match_data) == 0,
+	       "hl78xx_gnss_data.match_data must be the first member");
 
 /**
  * @brief Set the GNSS search state

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss_aux_parse.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss_aux_parse.c
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Netfeasa Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stdint.h>
+
+#include "hl78xx_gnss_aux_parse.h"
+#include "../../../gnss/gnss_parse.h"
+
+/*
+ * @brief Parse a mandatory NMEA UTC field to milliseconds.
+ *
+ * @param argv NMEA argument vector.
+ * @param argc Number of arguments in argv.
+ * @param utc Destination UTC value in milliseconds.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL on invalid input.
+ */
+static int hl78xx_gnss_parse_utc(char **argv, uint16_t argc, uint32_t *utc)
+{
+	int64_t i64;
+
+	if (argv == NULL || utc == NULL || argc < 2 || argv[1] == NULL) {
+		return -EINVAL;
+	}
+
+	if ((gnss_parse_dec_to_milli(argv[1], &i64) < 0) || i64 < 0 || i64 > UINT32_MAX) {
+		return -EINVAL;
+	}
+
+	*utc = (uint32_t)i64;
+	return 0;
+}
+
+/*
+ * @brief Parse an optional decimal field as milli-units.
+ *
+ * Missing, empty, or invalid optional fields are converted to zero.
+ *
+ * @param str Decimal string.
+ * @param value Destination parsed value.
+ */
+static void hl78xx_gnss_parse_optional_milli(const char *str, int64_t *value)
+{
+	if (value == NULL) {
+		return;
+	}
+
+	if (str == NULL || str[0] == '\0') {
+		*value = 0;
+		return;
+	}
+
+	if (gnss_parse_dec_to_milli(str, value) < 0) {
+		*value = 0;
+	}
+}
+
+int hl78xx_gnss_parse_gsa(char **argv, uint16_t argc, struct hl78xx_gnss_nmea_aux_data *aux_data)
+{
+	if (argv == NULL || aux_data == NULL || argc < 18) {
+		return -EINVAL;
+	}
+
+	if (argv[2] == NULL) {
+		return -EINVAL;
+	}
+
+	if (gnss_parse_atoi(argv[2], 10, &aux_data->gsa.fix_type) < 0) {
+		return -EINVAL;
+	}
+
+	hl78xx_gnss_parse_optional_milli(argv[15], &aux_data->gsa.pdop);
+	hl78xx_gnss_parse_optional_milli(argv[16], &aux_data->gsa.hdop);
+	hl78xx_gnss_parse_optional_milli(argv[17], &aux_data->gsa.vdop);
+
+	return 0;
+}
+
+int hl78xx_gnss_parse_gst(char **argv, uint16_t argc, struct hl78xx_gnss_nmea_aux_data *aux_data)
+{
+	if (argv == NULL || aux_data == NULL || argc < 9) {
+		return -EINVAL;
+	}
+
+	if (hl78xx_gnss_parse_utc(argv, argc, &aux_data->gst.gst_utc) < 0) {
+		return -EINVAL;
+	}
+
+	hl78xx_gnss_parse_optional_milli(argv[2], &aux_data->gst.rms);
+	hl78xx_gnss_parse_optional_milli(argv[6], &aux_data->gst.lat_err);
+	hl78xx_gnss_parse_optional_milli(argv[7], &aux_data->gst.lon_err);
+	hl78xx_gnss_parse_optional_milli(argv[8], &aux_data->gst.alt_err);
+
+	return 0;
+}
+
+int hl78xx_gnss_parse_epu(char **argv, uint16_t argc, struct hl78xx_gnss_nmea_aux_data *aux_data)
+{
+	if (argv == NULL || aux_data == NULL || argc < 12) {
+		return -EINVAL;
+	}
+
+	hl78xx_gnss_parse_optional_milli(argv[1], &aux_data->epu.pos_3d);
+	hl78xx_gnss_parse_optional_milli(argv[2], &aux_data->epu.pos_2d);
+	hl78xx_gnss_parse_optional_milli(argv[3], &aux_data->epu.pos_lat);
+	hl78xx_gnss_parse_optional_milli(argv[4], &aux_data->epu.pos_lon);
+	hl78xx_gnss_parse_optional_milli(argv[5], &aux_data->epu.pos_alt);
+	hl78xx_gnss_parse_optional_milli(argv[6], &aux_data->epu.vel_3d);
+	hl78xx_gnss_parse_optional_milli(argv[7], &aux_data->epu.vel_2d);
+	hl78xx_gnss_parse_optional_milli(argv[8], &aux_data->epu.vel_hdg);
+	hl78xx_gnss_parse_optional_milli(argv[9], &aux_data->epu.vel_east);
+	hl78xx_gnss_parse_optional_milli(argv[10], &aux_data->epu.vel_north);
+	hl78xx_gnss_parse_optional_milli(argv[11], &aux_data->epu.vel_up);
+
+	return 0;
+}

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss_aux_parse.h
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss_aux_parse.h
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Netfeasa Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_MODEM_HL78XX_GNSS_AUX_PARSE_H_
+#define ZEPHYR_DRIVERS_MODEM_HL78XX_GNSS_AUX_PARSE_H_
+
+#include <zephyr/types.h>
+#include <zephyr/drivers/modem/hl78xx_apis.h>
+
+/**
+ * @brief Parse a GSA NMEA argument list into HL78XX auxiliary GNSS data.
+ *
+ * Expected argument layout:
+ * argv[0]: $xxGSA
+ * argv[1]: mode
+ * argv[2]: fix type
+ * argv[3-14]: satellite IDs
+ * argv[15]: PDOP
+ * argv[16]: HDOP
+ * argv[17]: VDOP
+ *
+ * @param argv NMEA argument vector.
+ * @param argc Number of arguments in argv.
+ * @param aux_data Destination auxiliary GNSS data.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL if mandatory input is invalid.
+ */
+int hl78xx_gnss_parse_gsa(char **argv, uint16_t argc, struct hl78xx_gnss_nmea_aux_data *aux_data);
+
+/**
+ * @brief Parse a GST NMEA argument list into HL78XX auxiliary GNSS data.
+ *
+ * Expected argument layout:
+ * argv[0]: $xxGST
+ * argv[1]: UTC time
+ * argv[2]: RMS error
+ * argv[3]: semi-major error
+ * argv[4]: semi-minor error
+ * argv[5]: orientation
+ * argv[6]: latitude error
+ * argv[7]: longitude error
+ * argv[8]: altitude error
+ *
+ * Optional numeric fields are defaulted to zero when empty or invalid.
+ * The UTC field is mandatory.
+ *
+ * @param argv NMEA argument vector.
+ * @param argc Number of arguments in argv.
+ * @param aux_data Destination auxiliary GNSS data.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL if mandatory input is invalid.
+ */
+int hl78xx_gnss_parse_gst(char **argv, uint16_t argc, struct hl78xx_gnss_nmea_aux_data *aux_data);
+
+/**
+ * @brief Parse a PSEPU NMEA argument list into HL78XX auxiliary GNSS data.
+ *
+ * Expected argument layout:
+ * argv[0]: $PSEPU
+ * argv[1]: position 3D uncertainty
+ * argv[2]: position 2D uncertainty
+ * argv[3]: position latitude uncertainty
+ * argv[4]: position longitude uncertainty
+ * argv[5]: position altitude uncertainty
+ * argv[6]: velocity 3D uncertainty
+ * argv[7]: velocity 2D uncertainty
+ * argv[8]: velocity heading uncertainty
+ * argv[9]: velocity east uncertainty
+ * argv[10]: velocity north uncertainty
+ * argv[11]: velocity up uncertainty
+ *
+ * Empty or invalid optional numeric fields are defaulted to zero. This allows
+ * an empty PSEPU sentence to still act as an end-of-aux-frame marker.
+ *
+ * @param argv NMEA argument vector.
+ * @param argc Number of arguments in argv.
+ * @param aux_data Destination auxiliary GNSS data.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL if mandatory input is invalid or too few fields are present.
+ */
+int hl78xx_gnss_parse_epu(char **argv, uint16_t argc, struct hl78xx_gnss_nmea_aux_data *aux_data);
+
+#endif /* ZEPHYR_DRIVERS_MODEM_HL78XX_GNSS_AUX_PARSE_H_ */

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss_parsers.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss_parsers.c
@@ -24,237 +24,18 @@
 #include <stdlib.h>
 #include "hl78xx_gnss_parsers.h"
 #include "hl78xx_gnss.h"
+#include "hl78xx_gnssloc.h"
 #include "../../../gnss/gnss_parse.h"
 
 LOG_MODULE_DECLARE(hl78xx_gnss);
 
+enum hl78xx_gnss_aux_sentence {
+	HL78XX_GNSS_AUX_SENTENCE_GSA,
+	HL78XX_GNSS_AUX_SENTENCE_GST,
+	HL78XX_GNSS_AUX_SENTENCE_EPU,
+};
+
 static K_SEM_DEFINE(semlock, 1, 1);
-
-/* -------------------------------------------------------------------------
- * GNSSLOC Parser Helper Functions
- * -------------------------------------------------------------------------
- */
-
-int gnssloc_dms_to_ndeg(const char *str, int64_t *ndeg)
-{
-	int64_t degrees = 0;
-	int64_t minutes = 0;
-	int64_t seconds_nano = 0;
-	int64_t result;
-	char direction = '\0';
-	char *ptr = (char *)str;
-	char *end;
-	char sec_buf[16];
-	size_t sec_len;
-
-	if (str == NULL || ndeg == NULL) {
-		return -EINVAL;
-	}
-
-	/* Skip leading spaces */
-	while (*ptr == ' ') {
-		ptr++;
-	}
-
-	/* Parse degrees */
-	degrees = strtol(ptr, &end, 10);
-	if (ptr == end || degrees < 0 || degrees > 180) {
-		return -EINVAL;
-	}
-	ptr = end;
-
-	/* Skip to "Deg" and past it */
-	while (*ptr && strncmp(ptr, "Deg", 3) != 0) {
-		ptr++;
-	}
-	if (*ptr) {
-		ptr += 3; /* Skip "Deg" */
-	} else {
-		return -EINVAL;
-	}
-
-	/* Skip spaces */
-	while (*ptr == ' ') {
-		ptr++;
-	}
-
-	/* Parse minutes */
-	minutes = strtol(ptr, &end, 10);
-	if (ptr == end || minutes < 0 || minutes > 59) {
-		return -EINVAL;
-	}
-	ptr = end;
-
-	/* Skip to "Min" and past it */
-	while (*ptr && strncmp(ptr, "Min", 3) != 0) {
-		ptr++;
-	}
-	if (*ptr) {
-		ptr += 3; /* Skip "Min" */
-	} else {
-		return -EINVAL;
-	}
-
-	/* Skip spaces */
-	while (*ptr == ' ') {
-		ptr++;
-	}
-
-	/* Extract seconds value into a clean buffer for gnss_parse_dec_to_nano()
-	 * The string looks like "13.61 Sec N" - we need just "13.61"
-	 */
-	sec_len = 0;
-	while (ptr[sec_len] &&
-	       (ptr[sec_len] == '.' || (ptr[sec_len] >= '0' && ptr[sec_len] <= '9') ||
-		ptr[sec_len] == '-')) {
-		if (sec_len >= sizeof(sec_buf) - 1) {
-			return -EINVAL;
-		}
-		sec_buf[sec_len] = ptr[sec_len];
-		sec_len++;
-	}
-	sec_buf[sec_len] = '\0';
-
-	if (sec_len == 0) {
-		return -EINVAL;
-	}
-
-	/* Parse seconds (can be decimal like "14.43") as nano-seconds */
-	if (gnss_parse_dec_to_nano(sec_buf, &seconds_nano) < 0) {
-		return -EINVAL;
-	}
-	if (seconds_nano < 0 || seconds_nano > 60000000000LL) {
-		return -EINVAL;
-	}
-
-	/* Advance past the number */
-	ptr += sec_len;
-
-	/* Skip to "Sec" and past it */
-	while (*ptr && strncmp(ptr, "Sec", 3) != 0) {
-		ptr++;
-	}
-	if (*ptr) {
-		ptr += 3; /* Skip "Sec" */
-	} else {
-		return -EINVAL;
-	}
-
-	/* Skip spaces and find direction (N/S/E/W) */
-	while (*ptr) {
-		if (*ptr == 'N' || *ptr == 'S' || *ptr == 'E' || *ptr == 'W') {
-			direction = *ptr;
-			break;
-		}
-		ptr++;
-	}
-
-	if (direction == '\0') {
-		return -EINVAL;
-	}
-
-	/* Convert to nanodegrees:
-	 * 1 degree = 1,000,000,000 nanodegrees
-	 * 1 minute = 1/60 degree
-	 * 1 second = 1/3600 degree
-	 */
-	result = degrees * 1000000000LL;           /* Degrees to nanodegrees */
-	result += (minutes * 1000000000LL) / 60LL; /* Minutes to nanodegrees */
-	result += seconds_nano / 3600LL;           /* Seconds (in nano) to nanodegrees */
-
-	/* Apply sign based on direction */
-	if (direction == 'S' || direction == 'W') {
-		result = -result;
-	}
-
-	*ndeg = result;
-	return 0;
-}
-
-int gnssloc_parse_value_with_unit(const char *str, int64_t *milli)
-{
-	int ret;
-	char value_buf[32];
-	char *ptr;
-	size_t len;
-
-	if (str == NULL || milli == NULL) {
-		return -EINVAL;
-	}
-
-	/* Copy the string and find where the unit starts */
-	len = strlen(str);
-	if (len >= sizeof(value_buf)) {
-		len = sizeof(value_buf) - 1;
-	}
-	memcpy(value_buf, str, len);
-	value_buf[len] = '\0';
-
-	/* Find and truncate at unit (space before 'm', 'k', etc.) */
-	ptr = value_buf;
-	while (*ptr) {
-		if (*ptr == ' ' && (*(ptr + 1) == 'm' || *(ptr + 1) == 'k')) {
-			*ptr = '\0';
-			break;
-		}
-		ptr++;
-	}
-
-	/* Parse the numeric part as milli using Zephyr's gnss_parse_dec_to_milli */
-	ret = gnss_parse_dec_to_milli(value_buf, milli);
-	return ret;
-}
-
-int gnssloc_parse_speed_to_mms(const char *str, uint32_t *mms)
-{
-	int64_t milli;
-	int ret;
-
-	if (str == NULL || mms == NULL) {
-		return -EINVAL;
-	}
-
-	ret = gnssloc_parse_value_with_unit(str, &milli);
-	if (ret < 0) {
-		return ret;
-	}
-
-	if (milli < 0 || milli > UINT32_MAX) {
-		return -ERANGE;
-	}
-
-	*mms = (uint32_t)milli;
-	return 0;
-}
-
-int gnssloc_parse_gpstime(const char *str, struct gnss_time *utc)
-{
-	int year, month, day, hour, minute, second;
-
-	if (str == NULL || utc == NULL) {
-		return -EINVAL;
-	}
-
-	/* Parse format: "2026 1 25 23:15:56" */
-	if (sscanf(str, "%d %d %d %d:%d:%d", &year, &month, &day, &hour, &minute, &second) != 6) {
-		return -EINVAL;
-	}
-
-	/* Validate ranges */
-	if (year < 2000 || year > 2099 || month < 1 || month > 12 || day < 1 || day > 31 ||
-	    hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 59) {
-		return -ERANGE;
-	}
-
-	utc->century_year = (uint8_t)(year % 100);
-	utc->month = (uint8_t)month;
-	utc->month_day = (uint8_t)day;
-	utc->hour = (uint8_t)hour;
-	utc->minute = (uint8_t)minute;
-	utc->millisecond = (uint16_t)(second * 1000);
-
-	return 0;
-}
 
 /* -------------------------------------------------------------------------
  * NMEA Sentence Parser Callbacks
@@ -262,9 +43,27 @@ int gnssloc_parse_gpstime(const char *str, struct gnss_time *utc)
  */
 
 #ifdef CONFIG_HL78XX_GNSS_AUX_DATA_PARSER
+
+static bool hl78xx_gnss_aux_should_publish(enum hl78xx_gnss_aux_sentence sentence)
+{
+	if (IS_ENABLED(CONFIG_HL78XX_GNSS_NMEA_PEPU)) {
+		return sentence == HL78XX_GNSS_AUX_SENTENCE_EPU;
+	}
+
+	if (IS_ENABLED(CONFIG_HL78XX_GNSS_NMEA_GST)) {
+		return sentence == HL78XX_GNSS_AUX_SENTENCE_GST;
+	}
+
+	return sentence == HL78XX_GNSS_AUX_SENTENCE_GSA;
+}
+
 static int gnss_nmea0183_match_parse_utc(char **argv, uint16_t argc, uint32_t *utc)
 {
 	int64_t i64;
+
+	if (argv == NULL || utc == NULL || argc < 2 || argv[1] == NULL) {
+		return -EINVAL;
+	}
 
 	if ((gnss_parse_dec_to_milli(argv[1], &i64) < 0) || (i64 < 0) || (i64 > UINT32_MAX)) {
 		return -EINVAL;
@@ -274,93 +73,130 @@ static int gnss_nmea0183_match_parse_utc(char **argv, uint16_t argc, uint32_t *u
 	return 0;
 }
 
+static void hl78xx_gnss_parse_optional_milli(const char *str, int64_t *value)
+{
+	if (str == NULL || value == NULL || str[0] == '\0') {
+		if (value != NULL) {
+			*value = 0;
+		}
+
+		return;
+	}
+
+	if (gnss_parse_dec_to_milli(str, value) < 0) {
+		*value = 0;
+	}
+}
+
+int hl78xx_gnss_parse_gsa(char **argv, uint16_t argc, struct hl78xx_gnss_nmea_aux_data *aux_data)
+{
+	/* GSA message should have at least 17 fields:
+	 * 0: $xxGSA, 1: mode, 2: fix_type, 3-14: sat_ids, 15: pdop, 16: hdop, 17: vdop
+	 */
+	if (argv == NULL || aux_data == NULL || argc < 18) {
+		return -EINVAL;
+	}
+
+	/* Parse fix type (1=no fix, 2=2D, 3=3D) */
+	if (gnss_parse_atoi(argv[2], 10, &aux_data->gsa.fix_type) < 0) {
+		return -EINVAL;
+	}
+
+	/* Parse PDOP (Position Dilution of Precision) */
+	if (gnss_parse_dec_to_milli(argv[15], &aux_data->gsa.pdop) < 0) {
+		aux_data->gsa.pdop = 0;
+	}
+
+	/* Parse HDOP (Horizontal Dilution of Precision) */
+	if (gnss_parse_dec_to_milli(argv[16], &aux_data->gsa.hdop) < 0) {
+		aux_data->gsa.hdop = 0;
+	}
+
+	/* Parse VDOP (Vertical Dilution of Precision) */
+	if (gnss_parse_dec_to_milli(argv[17], &aux_data->gsa.vdop) < 0) {
+		aux_data->gsa.vdop = 0;
+	}
+
+	return 0;
+}
+
 void gnss_nmea0183_match_gsa_callback(struct modem_chat *chat, char **argv, uint16_t argc,
 				      void *user_data)
 {
 	struct hl78xx_gnss_data *data = (struct hl78xx_gnss_data *)user_data;
+	int ret;
 
-	/* GSA message should have at least 17 fields:
-	 * 0: $xxGSA, 1: mode, 2: fix_type, 3-14: sat_ids, 15: pdop, 16: hdop, 17: vdop
-	 */
-	if (argc < 18) {
-		LOG_DBG("GSA: insufficient fields (argc=%u)", argc);
+	ARG_UNUSED(chat);
+
+	if (data == NULL) {
 		return;
 	}
-
 	/* Parse fix type (1=no fix, 2=2D, 3=3D) */
-	if (gnss_parse_atoi(argv[2], 10, &data->aux_data.gsa.fix_type) < 0) {
-		LOG_WRN("GSA: failed to parse fix_type");
+	ret = hl78xx_gnss_parse_gsa(argv, argc, &data->aux_data);
+	if (ret < 0) {
+		LOG_WRN("GSA: failed to parse GSA data");
 		return;
-	}
-
-	/* Parse PDOP (Position Dilution of Precision) */
-	if (gnss_parse_dec_to_milli(argv[15], &data->aux_data.gsa.pdop) < 0) {
-		LOG_DBG("GSA: failed to parse PDOP");
-		data->aux_data.gsa.pdop = 0;
-	}
-
-	/* Parse HDOP (Horizontal Dilution of Precision) */
-	if (gnss_parse_dec_to_milli(argv[16], &data->aux_data.gsa.hdop) < 0) {
-		LOG_DBG("GSA: failed to parse HDOP");
-		data->aux_data.gsa.hdop = 0;
-	}
-
-	/* Parse VDOP (Vertical Dilution of Precision) */
-	if (gnss_parse_dec_to_milli(argv[17], &data->aux_data.gsa.vdop) < 0) {
-		LOG_DBG("GSA: failed to parse VDOP");
-		data->aux_data.gsa.vdop = 0;
 	}
 
 	/* Note: DOP values could be stored in user_data if extended
 	 * gnss_data structure is needed
 	 */
+	if (hl78xx_gnss_aux_should_publish(HL78XX_GNSS_AUX_SENTENCE_GSA)) {
+		gnss_publish_aux_data((const struct device *)data->dev, &data->aux_data,
+				      sizeof(data->aux_data));
+	}
+}
+
+int hl78xx_gnss_parse_gst(char **argv, uint16_t argc, struct hl78xx_gnss_nmea_aux_data *aux_data)
+{
+	/* GST message should have at least 9 fields:
+	 * 0: $xxGST, 1: time, 2: rms, 3: smajor, 4: sminor,
+	 * 5: orient, 6: lat_err, 7: lon_err, 8: alt_err
+	 */
+	if (argv == NULL || aux_data == NULL || argc < 9) {
+		return -EINVAL;
+	}
+
+	if (gnss_nmea0183_match_parse_utc(argv, argc, &aux_data->gst.gst_utc) < 0) {
+		return -EINVAL;
+	}
+	/* Parse RMS error (meters) */
+	hl78xx_gnss_parse_optional_milli(argv[2], &aux_data->gst.rms);
+	/* Parse latitude error (meters) */
+	hl78xx_gnss_parse_optional_milli(argv[6], &aux_data->gst.lat_err);
+	/* Parse longitude error (meters) */
+	hl78xx_gnss_parse_optional_milli(argv[7], &aux_data->gst.lon_err);
+	/* Parse altitude error (meters) */
+	hl78xx_gnss_parse_optional_milli(argv[8], &aux_data->gst.alt_err);
+
+	return 0;
 }
 
 void gnss_nmea0183_match_gst_callback(struct modem_chat *chat, char **argv, uint16_t argc,
 				      void *user_data)
 {
 	struct hl78xx_gnss_data *data = (struct hl78xx_gnss_data *)user_data;
+	int ret;
 
-	/* GST message should have at least 9 fields:
-	 * 0: $xxGST, 1: time, 2: rms, 3: smajor, 4: sminor,
-	 * 5: orient, 6: lat_err, 7: lon_err, 8: alt_err
-	 */
-	if (argc < 9) {
-		LOG_DBG("GST: insufficient fields (argc=%u)", argc);
+	ARG_UNUSED(chat);
+
+	if (data == NULL) {
 		return;
 	}
-	if (gnss_nmea0183_match_parse_utc(argv, argc, &data->aux_data.gst.gst_utc) < 0) {
+
+	ret = hl78xx_gnss_parse_gst(argv, argc, &data->aux_data);
+	if (ret < 0) {
 		return;
 	}
-	/* Parse RMS error (meters) */
-	if (gnss_parse_dec_to_milli(argv[2], &data->aux_data.gst.rms) < 0) {
-		LOG_DBG("GST: failed to parse RMS");
-		data->aux_data.gst.rms = 0;
-	}
 
-	/* Parse latitude error (meters) */
-	if (gnss_parse_dec_to_milli(argv[6], &data->aux_data.gst.lat_err) < 0) {
-		LOG_DBG("GST: failed to parse lat_err");
-		data->aux_data.gst.lat_err = 0;
-	}
-
-	/* Parse longitude error (meters) */
-	if (gnss_parse_dec_to_milli(argv[7], &data->aux_data.gst.lon_err) < 0) {
-		LOG_DBG("GST: failed to parse lon_err");
-		data->aux_data.gst.lon_err = 0;
-	}
-
-	/* Parse altitude error (meters) */
-	if (gnss_parse_dec_to_milli(argv[8], &data->aux_data.gst.alt_err) < 0) {
-		LOG_DBG("GST: failed to parse alt_err");
-		data->aux_data.gst.alt_err = 0;
+	if (hl78xx_gnss_aux_should_publish(HL78XX_GNSS_AUX_SENTENCE_GST)) {
+		gnss_publish_aux_data((const struct device *)data->dev, &data->aux_data,
+				      sizeof(data->aux_data));
 	}
 }
-void gnss_nmea0183_match_epu_callback(struct modem_chat *chat, char **argv, uint16_t argc,
-				      void *user_data)
-{
-	struct hl78xx_gnss_data *data = (struct hl78xx_gnss_data *)user_data;
 
+int hl78xx_gnss_parse_epu(char **argv, uint16_t argc, struct hl78xx_gnss_nmea_aux_data *aux_data)
+{
 	/* PSEPU message format: $PSEPU,x.x,x.x,x.x,x.x,x.x,x.xx,x.xx,x.x,x.xx,x.xx,x.xx*hh
 	 * 0: $PSEPU
 	 * 1: position 3D uncertainty (0.0 to 999.9)
@@ -376,61 +212,52 @@ void gnss_nmea0183_match_epu_callback(struct modem_chat *chat, char **argv, uint
 	 * 11: velocity Up uncertainty (0.00 to 500.00)
 	 * All units in meters (except heading in degrees)
 	 */
-	if (argc < 12) {
-		LOG_DBG("PSEPU: insufficient fields (argc=%u)", argc);
+
+	if (argv == NULL || aux_data == NULL || argc < 12) {
+		return -EINVAL;
+	}
+
+	/*
+	 * Empty EPU fields are accepted and converted to zero. A PSEPU
+	 * sentence with empty fields is still useful as an end-of-frame marker.
+	 */
+
+	hl78xx_gnss_parse_optional_milli(argv[1], &aux_data->epu.pos_3d);
+	hl78xx_gnss_parse_optional_milli(argv[2], &aux_data->epu.pos_2d);
+	hl78xx_gnss_parse_optional_milli(argv[3], &aux_data->epu.pos_lat);
+	hl78xx_gnss_parse_optional_milli(argv[4], &aux_data->epu.pos_lon);
+	hl78xx_gnss_parse_optional_milli(argv[5], &aux_data->epu.pos_alt);
+	hl78xx_gnss_parse_optional_milli(argv[6], &aux_data->epu.vel_3d);
+	hl78xx_gnss_parse_optional_milli(argv[7], &aux_data->epu.vel_2d);
+	hl78xx_gnss_parse_optional_milli(argv[8], &aux_data->epu.vel_hdg);
+	hl78xx_gnss_parse_optional_milli(argv[9], &aux_data->epu.vel_east);
+	hl78xx_gnss_parse_optional_milli(argv[10], &aux_data->epu.vel_north);
+	hl78xx_gnss_parse_optional_milli(argv[11], &aux_data->epu.vel_up);
+
+	return 0;
+}
+
+void gnss_nmea0183_match_epu_callback(struct modem_chat *chat, char **argv, uint16_t argc,
+				      void *user_data)
+{
+	struct hl78xx_gnss_data *data = (struct hl78xx_gnss_data *)user_data;
+	int ret;
+
+	ARG_UNUSED(chat);
+
+	if (data == NULL) {
 		return;
 	}
 
-	/* Parse position uncertainties */
-	if (gnss_parse_dec_to_milli(argv[1], &data->aux_data.epu.pos_3d) < 0) {
-		LOG_DBG("PSEPU: failed to parse pos_3d");
-		data->aux_data.epu.pos_3d = 0;
-	}
-	if (gnss_parse_dec_to_milli(argv[2], &data->aux_data.epu.pos_2d) < 0) {
-		LOG_DBG("PSEPU: failed to parse pos_2d");
-		data->aux_data.epu.pos_2d = 0;
-	}
-	if (gnss_parse_dec_to_milli(argv[3], &data->aux_data.epu.pos_lat) < 0) {
-		LOG_DBG("PSEPU: failed to parse pos_lat");
-		data->aux_data.epu.pos_lat = 0;
-	}
-	if (gnss_parse_dec_to_milli(argv[4], &data->aux_data.epu.pos_lon) < 0) {
-		LOG_DBG("PSEPU: failed to parse pos_lon");
-		data->aux_data.epu.pos_lon = 0;
-	}
-	if (gnss_parse_dec_to_milli(argv[5], &data->aux_data.epu.pos_alt) < 0) {
-		LOG_DBG("PSEPU: failed to parse pos_alt");
-		data->aux_data.epu.pos_alt = 0;
+	ret = hl78xx_gnss_parse_epu(argv, argc, &data->aux_data);
+	if (ret < 0) {
+		return;
 	}
 
-	/* Parse velocity uncertainties */
-	if (gnss_parse_dec_to_milli(argv[6], &data->aux_data.epu.vel_3d) < 0) {
-		LOG_DBG("PSEPU: failed to parse vel_3d");
-		data->aux_data.epu.vel_3d = 0;
+	if (hl78xx_gnss_aux_should_publish(HL78XX_GNSS_AUX_SENTENCE_EPU)) {
+		gnss_publish_aux_data((const struct device *)data->dev, &data->aux_data,
+				      sizeof(data->aux_data));
 	}
-	if (gnss_parse_dec_to_milli(argv[7], &data->aux_data.epu.vel_2d) < 0) {
-		LOG_DBG("PSEPU: failed to parse vel_2d");
-		data->aux_data.epu.vel_2d = 0;
-	}
-	if (gnss_parse_dec_to_milli(argv[8], &data->aux_data.epu.vel_hdg) < 0) {
-		LOG_DBG("PSEPU: failed to parse vel_hdg");
-		data->aux_data.epu.vel_hdg = 0;
-	}
-	if (gnss_parse_dec_to_milli(argv[9], &data->aux_data.epu.vel_east) < 0) {
-		LOG_DBG("PSEPU: failed to parse vel_east");
-		data->aux_data.epu.vel_east = 0;
-	}
-	if (gnss_parse_dec_to_milli(argv[10], &data->aux_data.epu.vel_north) < 0) {
-		LOG_DBG("PSEPU: failed to parse vel_north");
-		data->aux_data.epu.vel_north = 0;
-	}
-	if (gnss_parse_dec_to_milli(argv[11], &data->aux_data.epu.vel_up) < 0) {
-		LOG_DBG("PSEPU: failed to parse vel_up");
-		data->aux_data.epu.vel_up = 0;
-	}
-
-	gnss_publish_aux_data((const struct device *)data->dev, &data->aux_data,
-			      sizeof(data->aux_data));
 }
 
 void gnss_publish_aux_data(const struct device *dev,

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss_parsers.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss_parsers.c
@@ -26,6 +26,7 @@
 #include "hl78xx_gnss.h"
 #include "hl78xx_gnssloc.h"
 #include "../../../gnss/gnss_parse.h"
+#include "hl78xx_gnss_aux_parse.h"
 
 LOG_MODULE_DECLARE(hl78xx_gnss);
 
@@ -57,69 +58,6 @@ static bool hl78xx_gnss_aux_should_publish(enum hl78xx_gnss_aux_sentence sentenc
 	return sentence == HL78XX_GNSS_AUX_SENTENCE_GSA;
 }
 
-static int gnss_nmea0183_match_parse_utc(char **argv, uint16_t argc, uint32_t *utc)
-{
-	int64_t i64;
-
-	if (argv == NULL || utc == NULL || argc < 2 || argv[1] == NULL) {
-		return -EINVAL;
-	}
-
-	if ((gnss_parse_dec_to_milli(argv[1], &i64) < 0) || (i64 < 0) || (i64 > UINT32_MAX)) {
-		return -EINVAL;
-	}
-
-	*utc = (uint32_t)i64;
-	return 0;
-}
-
-static void hl78xx_gnss_parse_optional_milli(const char *str, int64_t *value)
-{
-	if (str == NULL || value == NULL || str[0] == '\0') {
-		if (value != NULL) {
-			*value = 0;
-		}
-
-		return;
-	}
-
-	if (gnss_parse_dec_to_milli(str, value) < 0) {
-		*value = 0;
-	}
-}
-
-int hl78xx_gnss_parse_gsa(char **argv, uint16_t argc, struct hl78xx_gnss_nmea_aux_data *aux_data)
-{
-	/* GSA message should have at least 17 fields:
-	 * 0: $xxGSA, 1: mode, 2: fix_type, 3-14: sat_ids, 15: pdop, 16: hdop, 17: vdop
-	 */
-	if (argv == NULL || aux_data == NULL || argc < 18) {
-		return -EINVAL;
-	}
-
-	/* Parse fix type (1=no fix, 2=2D, 3=3D) */
-	if (gnss_parse_atoi(argv[2], 10, &aux_data->gsa.fix_type) < 0) {
-		return -EINVAL;
-	}
-
-	/* Parse PDOP (Position Dilution of Precision) */
-	if (gnss_parse_dec_to_milli(argv[15], &aux_data->gsa.pdop) < 0) {
-		aux_data->gsa.pdop = 0;
-	}
-
-	/* Parse HDOP (Horizontal Dilution of Precision) */
-	if (gnss_parse_dec_to_milli(argv[16], &aux_data->gsa.hdop) < 0) {
-		aux_data->gsa.hdop = 0;
-	}
-
-	/* Parse VDOP (Vertical Dilution of Precision) */
-	if (gnss_parse_dec_to_milli(argv[17], &aux_data->gsa.vdop) < 0) {
-		aux_data->gsa.vdop = 0;
-	}
-
-	return 0;
-}
-
 void gnss_nmea0183_match_gsa_callback(struct modem_chat *chat, char **argv, uint16_t argc,
 				      void *user_data)
 {
@@ -147,31 +85,6 @@ void gnss_nmea0183_match_gsa_callback(struct modem_chat *chat, char **argv, uint
 	}
 }
 
-int hl78xx_gnss_parse_gst(char **argv, uint16_t argc, struct hl78xx_gnss_nmea_aux_data *aux_data)
-{
-	/* GST message should have at least 9 fields:
-	 * 0: $xxGST, 1: time, 2: rms, 3: smajor, 4: sminor,
-	 * 5: orient, 6: lat_err, 7: lon_err, 8: alt_err
-	 */
-	if (argv == NULL || aux_data == NULL || argc < 9) {
-		return -EINVAL;
-	}
-
-	if (gnss_nmea0183_match_parse_utc(argv, argc, &aux_data->gst.gst_utc) < 0) {
-		return -EINVAL;
-	}
-	/* Parse RMS error (meters) */
-	hl78xx_gnss_parse_optional_milli(argv[2], &aux_data->gst.rms);
-	/* Parse latitude error (meters) */
-	hl78xx_gnss_parse_optional_milli(argv[6], &aux_data->gst.lat_err);
-	/* Parse longitude error (meters) */
-	hl78xx_gnss_parse_optional_milli(argv[7], &aux_data->gst.lon_err);
-	/* Parse altitude error (meters) */
-	hl78xx_gnss_parse_optional_milli(argv[8], &aux_data->gst.alt_err);
-
-	return 0;
-}
-
 void gnss_nmea0183_match_gst_callback(struct modem_chat *chat, char **argv, uint16_t argc,
 				      void *user_data)
 {
@@ -195,47 +108,6 @@ void gnss_nmea0183_match_gst_callback(struct modem_chat *chat, char **argv, uint
 	}
 }
 
-int hl78xx_gnss_parse_epu(char **argv, uint16_t argc, struct hl78xx_gnss_nmea_aux_data *aux_data)
-{
-	/* PSEPU message format: $PSEPU,x.x,x.x,x.x,x.x,x.x,x.xx,x.xx,x.x,x.xx,x.xx,x.xx*hh
-	 * 0: $PSEPU
-	 * 1: position 3D uncertainty (0.0 to 999.9)
-	 * 2: position 2D uncertainty (0.0 to 999.9)
-	 * 3: position Latitude uncertainty (0.0 to 999.9)
-	 * 4: position Longitude uncertainty (0.0 to 999.9)
-	 * 5: position Altitude uncertainty (0.0 to 999.9)
-	 * 6: velocity 3D uncertainty (0.00 to 500.00)
-	 * 7: velocity 2D uncertainty (0.00 to 500.00)
-	 * 8: velocity Heading uncertainty (0.0 to 180.0)
-	 * 9: velocity East uncertainty (0.00 to 500.00)
-	 * 10: velocity North uncertainty (0.00 to 500.00)
-	 * 11: velocity Up uncertainty (0.00 to 500.00)
-	 * All units in meters (except heading in degrees)
-	 */
-
-	if (argv == NULL || aux_data == NULL || argc < 12) {
-		return -EINVAL;
-	}
-
-	/*
-	 * Empty EPU fields are accepted and converted to zero. A PSEPU
-	 * sentence with empty fields is still useful as an end-of-frame marker.
-	 */
-
-	hl78xx_gnss_parse_optional_milli(argv[1], &aux_data->epu.pos_3d);
-	hl78xx_gnss_parse_optional_milli(argv[2], &aux_data->epu.pos_2d);
-	hl78xx_gnss_parse_optional_milli(argv[3], &aux_data->epu.pos_lat);
-	hl78xx_gnss_parse_optional_milli(argv[4], &aux_data->epu.pos_lon);
-	hl78xx_gnss_parse_optional_milli(argv[5], &aux_data->epu.pos_alt);
-	hl78xx_gnss_parse_optional_milli(argv[6], &aux_data->epu.vel_3d);
-	hl78xx_gnss_parse_optional_milli(argv[7], &aux_data->epu.vel_2d);
-	hl78xx_gnss_parse_optional_milli(argv[8], &aux_data->epu.vel_hdg);
-	hl78xx_gnss_parse_optional_milli(argv[9], &aux_data->epu.vel_east);
-	hl78xx_gnss_parse_optional_milli(argv[10], &aux_data->epu.vel_north);
-	hl78xx_gnss_parse_optional_milli(argv[11], &aux_data->epu.vel_up);
-
-	return 0;
-}
 
 void gnss_nmea0183_match_epu_callback(struct modem_chat *chat, char **argv, uint16_t argc,
 				      void *user_data)

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnssloc.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnssloc.c
@@ -1,0 +1,210 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Netfeasa Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hl78xx_gnssloc.h"
+#include "../../../gnss/gnss_parse.h"
+
+int gnssloc_dms_to_ndeg(const char *str, int64_t *ndeg)
+{
+	int64_t degrees = 0;
+	int64_t minutes = 0;
+	int64_t seconds_nano = 0;
+	int64_t result;
+	char direction = '\0';
+	const char *ptr = str;
+	char *end;
+	char sec_buf[16];
+	size_t sec_len;
+
+	if (str == NULL || ndeg == NULL) {
+		return -EINVAL;
+	}
+
+	while (*ptr == ' ') {
+		ptr++;
+	}
+
+	degrees = strtol(ptr, &end, 10);
+	if (ptr == end || degrees < 0 || degrees > 180) {
+		return -EINVAL;
+	}
+	ptr = end;
+
+	ptr = strstr(ptr, "Deg");
+	if (ptr == NULL) {
+		return -EINVAL;
+	}
+	ptr += 3;
+
+	while (*ptr == ' ') {
+		ptr++;
+	}
+
+	minutes = strtol(ptr, &end, 10);
+	if (ptr == end || minutes < 0 || minutes > 59) {
+		return -EINVAL;
+	}
+	ptr = end;
+
+	ptr = strstr(ptr, "Min");
+	if (ptr == NULL) {
+		return -EINVAL;
+	}
+	ptr += 3;
+
+	while (*ptr == ' ') {
+		ptr++;
+	}
+
+	sec_len = 0;
+	while (ptr[sec_len] &&
+	       (ptr[sec_len] == '.' || (ptr[sec_len] >= '0' && ptr[sec_len] <= '9') ||
+		ptr[sec_len] == '-')) {
+		if (sec_len >= sizeof(sec_buf) - 1) {
+			return -EINVAL;
+		}
+
+		sec_buf[sec_len] = ptr[sec_len];
+		sec_len++;
+	}
+	sec_buf[sec_len] = '\0';
+
+	if (sec_len == 0) {
+		return -EINVAL;
+	}
+
+	if (gnss_parse_dec_to_nano(sec_buf, &seconds_nano) < 0) {
+		return -EINVAL;
+	}
+
+	if (seconds_nano < 0 || seconds_nano >= 60000000000LL) {
+		return -EINVAL;
+	}
+
+	ptr += sec_len;
+
+	ptr = strstr(ptr, "Sec");
+	if (ptr == NULL) {
+		return -EINVAL;
+	}
+	ptr += 3;
+
+	while (*ptr) {
+		if (*ptr == 'N' || *ptr == 'S' || *ptr == 'E' || *ptr == 'W') {
+			direction = *ptr;
+			break;
+		}
+		ptr++;
+	}
+
+	if (direction == '\0') {
+		return -EINVAL;
+	}
+
+	if ((direction == 'N' || direction == 'S') && degrees > 90) {
+		return -EINVAL;
+	}
+
+	result = degrees * 1000000000LL;
+	result += (minutes * 1000000000LL) / 60LL;
+	result += seconds_nano / 3600LL;
+
+	if (direction == 'S' || direction == 'W') {
+		result = -result;
+	}
+
+	*ndeg = result;
+	return 0;
+}
+
+int gnssloc_parse_value_with_unit(const char *str, int64_t *milli)
+{
+	int ret;
+	char value_buf[32];
+	const char *unit;
+	size_t value_len;
+
+	if (str == NULL || milli == NULL) {
+		return -EINVAL;
+	}
+
+	unit = str;
+
+	while (*unit) {
+		if (*unit == ' ' && (*(unit + 1) == 'm' || *(unit + 1) == 'k')) {
+			break;
+		}
+
+		unit++;
+	}
+
+	value_len = unit - str;
+
+	if (value_len == 0 || value_len >= sizeof(value_buf)) {
+		return -EINVAL;
+	}
+
+	memcpy(value_buf, str, value_len);
+	value_buf[value_len] = '\0';
+
+	ret = gnss_parse_dec_to_milli(value_buf, milli);
+	return ret;
+}
+
+int gnssloc_parse_speed_to_mms(const char *str, uint32_t *mms)
+{
+	int64_t milli;
+	int ret;
+
+	if (str == NULL || mms == NULL) {
+		return -EINVAL;
+	}
+
+	ret = gnssloc_parse_value_with_unit(str, &milli);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (milli < 0 || milli > UINT32_MAX) {
+		return -ERANGE;
+	}
+
+	*mms = (uint32_t)milli;
+	return 0;
+}
+
+int gnssloc_parse_gpstime(const char *str, struct gnss_time *utc)
+{
+	int year, month, day, hour, minute, second;
+
+	if (str == NULL || utc == NULL) {
+		return -EINVAL;
+	}
+
+	if (sscanf(str, "%d %d %d %d:%d:%d", &year, &month, &day, &hour, &minute, &second) != 6) {
+		return -EINVAL;
+	}
+
+	if (year < 2000 || year > 2099 || month < 1 || month > 12 || day < 1 || day > 31 ||
+	    hour < 0 || hour > 23 || minute < 0 || minute > 59 || second < 0 || second > 59) {
+		return -ERANGE;
+	}
+
+	utc->century_year = (uint8_t)(year % 100);
+	utc->month = (uint8_t)month;
+	utc->month_day = (uint8_t)day;
+	utc->hour = (uint8_t)hour;
+	utc->minute = (uint8_t)minute;
+	utc->millisecond = (uint16_t)(second * 1000);
+
+	return 0;
+}

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnssloc.h
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnssloc.h
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Netfeasa Ltd.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_MODEM_HL78XX_GNSSLOC_H_
+#define ZEPHYR_DRIVERS_MODEM_HL78XX_GNSSLOC_H_
+
+#include <stdint.h>
+#include <zephyr/drivers/gnss.h>
+
+/**
+ * @brief Convert a GNSSLOC DMS coordinate string to nanodegrees.
+ *
+ * Expected format example:
+ * "52 Deg 15 Min 13.61 Sec N"
+ *
+ * @param str Coordinate string.
+ * @param ndeg Output coordinate in nanodegrees.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL on invalid input.
+ */
+int gnssloc_dms_to_ndeg(const char *str, int64_t *ndeg);
+
+/**
+ * @brief Parse a decimal value with a textual unit suffix to milli-units.
+ *
+ * Expected format example:
+ * "123.456 m"
+ *
+ * @param str Value string.
+ * @param milli Output value in milli-units.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL on invalid input.
+ */
+int gnssloc_parse_value_with_unit(const char *str, int64_t *milli);
+
+/**
+ * @brief Parse speed string to millimeters per second.
+ *
+ * Expected format example:
+ * "4.250 m/s"
+ *
+ * @param str Speed string.
+ * @param mms Output speed in millimeters per second.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL on invalid input.
+ * @retval -ERANGE on negative or too large value.
+ */
+int gnssloc_parse_speed_to_mms(const char *str, uint32_t *mms);
+
+/**
+ * @brief Parse GNSSLOC GPS time string.
+ *
+ * Expected format example:
+ * "2026 1 25 23:15:56"
+ *
+ * @param str Time string.
+ * @param utc Output GNSS time.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL on malformed input.
+ * @retval -ERANGE on out-of-range date/time fields.
+ */
+int gnssloc_parse_gpstime(const char *str, struct gnss_time *utc);
+
+#endif /* ZEPHYR_DRIVERS_MODEM_HL78XX_GNSSLOC_H_ */

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_sockets.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_sockets.c
@@ -458,9 +458,6 @@ static bool hl78xx_apply_pending_tcp_socket_error_if_drained(struct hl78xx_socke
  * compact. When moving functions into groups, add any new prototypes
  * here first.
  */
-/* Parser helpers */
-static bool split_ipv4_and_subnet(const char *combined, char *ip_out, size_t ip_out_len,
-				  char *subnet_out, size_t subnet_out_len);
 static int hl78xx_socket_get_network_context(struct hl78xx_data *data);
 static bool parse_ip(bool is_ipv4, const char *ip_str, void *out_addr);
 static bool update_dns(struct hl78xx_socket_data *socket_data, bool is_ipv4, const char *dns_str);
@@ -477,18 +474,12 @@ static bool modem_chat_match_matches_received(struct hl78xx_socket_data *socket_
 					      const char *match, uint16_t match_size);
 
 /* Receive / parser entrypoints */
-static void socket_process_bytes(struct hl78xx_socket_data *socket_data, char byte);
-static int modem_process_handler(struct hl78xx_data *data);
 static void modem_pipe_callback(struct modem_pipe *pipe, enum modem_pipe_event event,
 				void *user_data);
 
 /* Socket I/O helpers */
-static int on_cmd_sockread_common(int socket_id, uint16_t socket_data_length, uint16_t len,
-				  void *user_data);
 static ssize_t offload_recvfrom(void *obj, void *buf, size_t len, int flags,
 				struct net_sockaddr *from, net_socklen_t *fromlen);
-static int prepare_send_cmd(const struct modem_socket *sock, const struct net_sockaddr *dst_addr,
-			    size_t buf_len, char *cmd_buf, size_t cmd_buf_size);
 static int send_data_buffer(struct hl78xx_socket_data *socket_data, const char *buf,
 			    const size_t buf_len, int *sock_written);
 
@@ -497,7 +488,6 @@ static int create_socket(struct modem_socket *sock, const struct net_sockaddr *a
 			 struct hl78xx_socket_data *data);
 static int socket_close(struct hl78xx_socket_data *socket_data, struct modem_socket *sock);
 static int socket_delete(struct hl78xx_socket_data *socket_data, struct modem_socket *sock);
-static void socket_notify_data(int socket_id, int new_total, void *user_data);
 static void check_tcp_state_if_needed(struct hl78xx_socket_data *socket_data,
 				      struct modem_socket *sock);
 /* ===== TLS prototypes (conditional) ==================================
@@ -612,6 +602,62 @@ static int hl78xx_socket_wait_data_timeout(struct hl78xx_socket_data *socket_dat
 
 	return ret;
 }
+#ifdef CONFIG_NET_IPV4
+
+static bool split_ipv4_and_subnet(const char *combined, char *ip_out, size_t ip_out_len,
+				  char *subnet_out, size_t subnet_out_len)
+{
+	int dot_count = 0;
+	const char *ptr = combined;
+	const char *split = NULL;
+	size_t ip_len;
+	size_t subnet_len;
+
+	if (!combined || !ip_out || !subnet_out || ip_out_len == 0 || subnet_out_len == 0) {
+		return false;
+	}
+
+	while (*ptr && dot_count < 4) {
+		if (*ptr == '.') {
+			dot_count++;
+			if (dot_count == 4) {
+				split = ptr;
+				break;
+			}
+		}
+
+		ptr++;
+	}
+
+	if (!split) {
+		LOG_ERR("Invalid IPv4 + subnet format: %s", combined);
+		return false;
+	}
+
+	ip_len = split - combined;
+	subnet_len = strlen(split + 1);
+
+	if ((ip_len == 0) || (subnet_len == 0)) {
+		LOG_ERR("Invalid IPv4 + subnet format: %s", combined);
+		return false;
+	}
+
+	if ((ip_len >= ip_out_len) || (subnet_len >= subnet_out_len)) {
+		LOG_ERR("IPv4 + subnet output buffer too small: %s", combined);
+		return false;
+	}
+
+	memcpy(ip_out, combined, ip_len);
+	ip_out[ip_len] = '\0';
+
+	memcpy(subnet_out, split + 1, subnet_len);
+	subnet_out[subnet_len] = '\0';
+
+	LOG_DBG("Extracted IP: %s, Subnet: %s", ip_out, subnet_out);
+
+	return true;
+}
+#endif /* CONFIG_NET_IPV4 */
 
 #ifdef CONFIG_MODEM_HL78XX_LOW_POWER_MODE
 void hl78xx_release_socket_comms(struct hl78xx_data *data)
@@ -746,6 +792,41 @@ static int hl78xx_ensure_modem_awake(struct hl78xx_socket_data *socket_data)
 	errno = EAGAIN;
 	return -1;
 }
+
+static void socket_notify_data(int socket_id, int new_total, void *user_data)
+{
+	int ret = 0;
+	struct modem_socket *sock;
+	struct hl78xx_data *data = (struct hl78xx_data *)user_data;
+	struct hl78xx_socket_data *socket_data;
+
+	if ((data == NULL) || (data->devices.offload == NULL) ||
+	    (data->devices.offload->data == NULL)) {
+		LOG_ERR("%s: invalid user_data", __func__);
+		return;
+	}
+
+	socket_data = (struct hl78xx_socket_data *)data->devices.offload->data;
+
+	sock = modem_socket_from_id(&socket_data->control.socket_config, socket_id);
+	if (!sock) {
+		LOG_ERR("%s: invalid socket_id", __func__);
+		return;
+	}
+	/* Update the packet size */
+	ret = modem_socket_packet_size_update(&socket_data->control.socket_config, sock, new_total);
+	if (ret < 0) {
+		LOG_ERR("socket_id:%d left_bytes:%d err: %d", socket_id, new_total, ret);
+	}
+	LOG_DBG("id=%d new_total=%d update_ret=%d", socket_id, new_total, ret);
+	if (new_total > 0) {
+		modem_socket_data_ready(&socket_data->control.socket_config, sock);
+	} else {
+		(void)hl78xx_apply_pending_tcp_socket_error_if_drained(socket_data, socket_id);
+	}
+	/* Duplicate/chat callback block removed; grouped versions live earlier */
+}
+
 /* ===== Chat callbacks (grouped) =====================================
  * Group all chat/URC handlers together to make the socket TU easier to
  * scan. These handlers are registered via hl78xx_chat getters in
@@ -758,7 +839,7 @@ void hl78xx_on_socknotifydata(struct modem_chat *chat, char **argv, uint16_t arg
 
 	ARG_UNUSED(chat);
 
-	if (argc < 2) {
+	if (argc < 3) {
 		return;
 	}
 
@@ -797,8 +878,7 @@ void hl78xx_on_ktcpstat(struct modem_chat *chat, char **argv, uint16_t argc, voi
 void hl78xx_on_ktcpnotif(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
 {
 	struct hl78xx_data *data = (struct hl78xx_data *)user_data;
-	struct hl78xx_socket_data *socket_data =
-		(struct hl78xx_socket_data *)data->devices.offload->data;
+	struct hl78xx_socket_data *socket_data;
 	struct modem_socket *sock = NULL;
 	enum hl78xx_tcp_notif tcp_notif_received;
 	int socket_id = -1;
@@ -808,13 +888,18 @@ void hl78xx_on_ktcpnotif(struct modem_chat *chat, char **argv, uint16_t argc, vo
 	bool receive_in_progress = false;
 	bool defer_disconnect = false;
 
-	if (!data || !socket_data) {
+	if ((data == NULL) || (data->devices.offload == NULL) ||
+	    (data->devices.offload->data == NULL)) {
 		LOG_ERR("%s: invalid user_data", __func__);
 		return;
 	}
+
+	socket_data = (struct hl78xx_socket_data *)data->devices.offload->data;
+
 	if (argc < 3) {
 		return;
 	}
+
 	socket_id = ATOI(argv[1], -1, "socket_id");
 	tcp_notif = ATOI(argv[2], -1, "tcp_notif");
 	if ((socket_id <= 0) || (tcp_notif < 0)) {
@@ -1065,7 +1150,10 @@ void hl78xx_on_udprcv(struct modem_chat *chat, char **argv, uint16_t argc, void 
 	HL78XX_LOG_DBG("%d %d [%s] [%s] [%s]", __LINE__, argc, argv[0], argv[1], argv[2]);
 }
 #endif
-/* Handler for +CGCONTRDP: <cid>,<bearer>,<apn>,<addr>,<dcomp>,<hcomp>,<dns1>[,<dns2>]
+/* Handler for +CGCONTRDP:
+ * <cid>,<bearer_id>,<apn>,<local_addr and subnet_mask>,<gw_addr>,
+ * <DNS_prim_addr>[,<DNS_sec_addr>...]
+ *
  * This function is invoked by the chat layer when a CGCONTRDP URC is matched.
  * It extracts the PDP context address, gateway and DNS servers and updates the
  * per-instance socket_data DNS fields so dns_work_cb() can apply them.
@@ -1293,41 +1381,6 @@ static void set_iface(struct hl78xx_socket_data *socket_data, bool is_ipv4)
 		(void)net_if_up(socket_data->network.net_iface);
 	}
 #endif /* CONFIG_NET_IPV6 */
-}
-
-static bool split_ipv4_and_subnet(const char *combined, char *ip_out, size_t ip_out_len,
-				  char *subnet_out, size_t subnet_out_len)
-{
-	int dot_count = 0;
-	const char *ptr = combined;
-	const char *split = NULL;
-	size_t ip_len = 0;
-
-	while (*ptr && dot_count < 4) {
-		if (*ptr == '.') {
-			dot_count++;
-			if (dot_count == 4) {
-				split = ptr;
-				break;
-			}
-		}
-		ptr++;
-	}
-	if (!split) {
-		LOG_ERR("Invalid IPv4 + subnet format: %s", combined);
-		return false;
-	}
-
-	ip_len = split - combined;
-	if (ip_len >= ip_out_len) {
-		ip_len = ip_out_len - 1;
-	}
-	strncpy(ip_out, combined, ip_len);
-	ip_out[ip_len] = '\0';
-	strncpy(subnet_out, split + 1, subnet_out_len);
-	subnet_out[subnet_out_len - 1] = '\0';
-	LOG_DBG("Extracted IP: %s, Subnet: %s", ip_out, subnet_out);
-	return true;
 }
 
 static int hl78xx_socket_get_network_context(struct hl78xx_data *data)
@@ -1732,11 +1785,17 @@ static bool socket_transfer_complete(struct hl78xx_socket_data *socket_data)
  */
 static int modem_process_handler(struct hl78xx_data *data)
 {
-	struct hl78xx_socket_data *socket_data =
-		(struct hl78xx_socket_data *)data->devices.offload->data;
+	struct hl78xx_socket_data *socket_data;
 	char work_buf_local[HL78XX_UART_PIPE_WORK_SOCKET_BUFFER_SIZE] = {0};
 	int recv_len = 0;
 	int work_len = 0;
+
+	if ((data == NULL) || (data->devices.offload == NULL) ||
+	    (data->devices.offload->data == NULL)) {
+		return -EINVAL;
+	}
+
+	socket_data = (struct hl78xx_socket_data *)data->devices.offload->data;
 
 	if (socket_data->rx.expected_buf_len == 0U) {
 		LOG_DBG("No more data expected");
@@ -2973,6 +3032,14 @@ static int prepare_send_cmd(const struct modem_socket *sock, const struct net_so
 {
 	int ret = 0;
 
+	if (!sock || !cmd_buf || cmd_buf_size == 0) {
+		return -EINVAL;
+	}
+
+	if (sock->ip_proto == NET_IPPROTO_UDP && dst_addr == NULL) {
+		return -EINVAL;
+	}
+
 	if (sock->ip_proto == NET_IPPROTO_UDP) {
 		char ip_str[NET_IPV6_ADDR_LEN];
 		uint16_t dst_port = 0;
@@ -2982,18 +3049,20 @@ static int prepare_send_cmd(const struct modem_socket *sock, const struct net_so
 			LOG_ERR("Error formatting IP string %d", ret);
 			return ret;
 		}
+
 		ret = modem_context_get_addr_port(dst_addr, &dst_port);
 		if (ret < 0) {
 			LOG_ERR("Error getting port from IP address %d", ret);
 			return ret;
 		}
+
 		snprintk(cmd_buf, cmd_buf_size, "AT+KUDPSND=%d,\"%s\",%u,%zu", sock->id, ip_str,
 			 dst_port, buf_len);
 		return 0;
 	}
 
-	/* Default to TCP-style send command */
 	snprintk(cmd_buf, cmd_buf_size, "AT+KTCPSND=%d,%zu", sock->id, buf_len);
+
 	return 0;
 }
 
@@ -3507,35 +3576,6 @@ static int hl78xx_init_sockets(const struct device *dev)
 	return 0;
 error:
 	return ret;
-}
-static void socket_notify_data(int socket_id, int new_total, void *user_data)
-{
-	int ret = 0;
-	struct modem_socket *sock;
-	struct hl78xx_data *data = (struct hl78xx_data *)user_data;
-	struct hl78xx_socket_data *socket_data =
-		(struct hl78xx_socket_data *)data->devices.offload->data;
-
-	if (!data || !socket_data) {
-		LOG_ERR("%s: invalid user_data", __func__);
-		return;
-	}
-	sock = modem_socket_from_id(&socket_data->control.socket_config, socket_id);
-	if (!sock) {
-		return;
-	}
-	/* Update the packet size */
-	ret = modem_socket_packet_size_update(&socket_data->control.socket_config, sock, new_total);
-	if (ret < 0) {
-		LOG_ERR("socket_id:%d left_bytes:%d err: %d", socket_id, new_total, ret);
-	}
-	LOG_DBG("id=%d new_total=%d update_ret=%d", socket_id, new_total, ret);
-	if (new_total > 0) {
-		modem_socket_data_ready(&socket_data->control.socket_config, sock);
-	} else {
-		(void)hl78xx_apply_pending_tcp_socket_error_if_drained(socket_data, socket_id);
-	}
-	/* Duplicate/chat callback block removed; grouped versions live earlier */
 }
 
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS) && defined(CONFIG_MODEM_HL78XX_SOCKETS_SOCKOPT_TLS)

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_sockets.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_sockets.c
@@ -3100,6 +3100,8 @@ static int send_data_buffer(struct hl78xx_socket_data *socket_data, const char *
 static int validate_and_prepare(struct modem_socket *sock, const struct net_sockaddr **dst_addr,
 				size_t *buf_len, char *cmd_buf, size_t cmd_buf_len)
 {
+	int ret;
+
 	/* Validate args and prepare send command */
 	if (!sock) {
 		errno = EINVAL;
@@ -3120,7 +3122,13 @@ static int validate_and_prepare(struct modem_socket *sock, const struct net_sock
 		*buf_len = MDM_MAX_DATA_LENGTH;
 	}
 	/* Consolidated send command helper handles UDP vs TCP formatting */
-	return prepare_send_cmd(sock, *dst_addr, *buf_len, cmd_buf, cmd_buf_len);
+	ret = prepare_send_cmd(sock, *dst_addr, *buf_len, cmd_buf, cmd_buf_len);
+	if (ret < 0) {
+		hl78xx_set_errno_from_code(ret);
+		return -1;
+	}
+
+	return 0;
 }
 
 static int transmit_regular_data(struct hl78xx_socket_data *socket_data, const char *buf,

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_sockets.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_sockets.c
@@ -441,10 +441,14 @@ static bool hl78xx_apply_pending_tcp_socket_error_if_drained(struct hl78xx_socke
 	if (modem_socket_next_packet_size(&socket_data->control.socket_config, sock) > 0U) {
 		return false;
 	}
+	/*
+	 * Wake the waiter while the modem_socket is still considered connected.
+	 * Some modem_socket_data_ready() implementations do not signal disconnected sockets.
+	 */
+	modem_socket_data_ready(&socket_data->control.socket_config, sock);
 
 	hl78xx_mark_tcp_socket_error(socket_data, socket_id, err_code);
 	socket_data->conn.tcp_pending_err_code[slot] = 0;
-	modem_socket_data_ready(&socket_data->control.socket_config, sock);
 
 	return true;
 }

--- a/include/zephyr/drivers/modem/hl78xx_apis.h
+++ b/include/zephyr/drivers/modem/hl78xx_apis.h
@@ -20,7 +20,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <time.h>
-#include <zephyr/modem/chat.h>
 #include <zephyr/drivers/cellular.h>
 #include <zephyr/sys/util_macro.h>
 #ifdef __cplusplus
@@ -876,7 +875,6 @@ struct hl78xx_evt {
 	} content;
 };
 
-#if defined(CONFIG_HL78XX_GNSS_AUX_DATA_PARSER) || defined(__DOXYGEN__)
 /**
  * @brief Parsed GSA sentence data (GNSS DOP and Active Satellites)
  *
@@ -969,6 +967,20 @@ struct hl78xx_gnss_nmea_aux_data {
 };
 
 /**
+ * @brief Forward declaration for modem chat response match descriptors.
+ *
+ * This declaration is intentionally used instead of including
+ * <zephyr/modem/chat.h> from this public API header. The API only needs to
+ * expose pointers to struct modem_chat_match, so the full structure definition
+ * is not required here.
+ *
+ * Source files that dereference struct modem_chat_match members, allocate
+ * instances, or otherwise need the complete type definition must include
+ * <zephyr/modem/chat.h> directly.
+ */
+struct modem_chat_match;
+
+/**
  * @brief GNSS auxiliary data callback function type
  *
  * @param dev Pointer to the GNSS device
@@ -1016,22 +1028,7 @@ struct hl78xx_gnss_aux_data_callback {
 		.dev = DEVICE_DT_GET(_node_id),                                                    \
 		.callback = _callback,                                                             \
 	}
-#else
-/**
- * @brief Register a callback structure for GNSS auxiliary data published
- *
- * @param _dev Device pointer
- * @param _callback The callback function
- */
-#define GNSS_AUX_DATA_CALLBACK_DEFINE(_dev, _callback)
-/**
- * @brief Register a callback structure for GNSS auxiliary data published
- *
- * @param _node_id Device tree node identifier
- * @param _callback The callback function
- */
-#define GNSS_DT_AUX_DATA_CALLBACK_DEFINE(_node_id, _callback)
-#endif
+
 /**
  * @brief API function pointer for configuring networks
  *


### PR DESCRIPTION
Refactor and harden HL78xx modem driver parsing and socket helper paths.

This splits GNSSLOC and auxiliary GNSS parsing into dedicated helper files, reduces public API dependency on modem chat internals, and improves CEREG/PLMN parser robustness. It also hardens socket helper handling around deferred errors.

 **Key changes**

- Split GNSSLOC parser helpers.
- Split auxiliary GNSS parser helpers.
- Reject overlong PLMN values.
- Accept quoted CEREG timer fields.
- Clarify CEREG parser argument handling.
- Avoid modem chat include in public API.
- Expose binary string conversion helper.
- Wake sockets before applying deferred errors.
- Harden socket helper paths.

Fixes: #113702