### PR TITLE
[Backport v3.7-branch] net: http: server: re-poll on spurious zsock_poll() return of 0

### DIFF
--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -498,8 +498,15 @@ static int http_server_run(struct http_server_ctx *ctx)
 		}
 
 		if (ret == 0) {
-			/* should not happen because timeout is -1 */
-			break;
+			/* With an infinite timeout zsock_poll() can still return
+			 * 0 when a wake source fired but no fd reported an event.
+			 * Re-poll instead of breaking: the break path skips
+			 * close_all_sockets(), leaking the sockets and leaving
+			 * the client inactivity timers armed, which the caller's
+			 * re-init then memsets - corrupting the kernel timeout
+			 * list.
+			 */
+			continue;
 		}
 
 		if (ret == 1 && ctx->fds[0].revents) {


### PR DESCRIPTION
Backport of the fix from #111239 to `v3.7-branch`.

Fixes: #111238