### PR TITLE
drivers: i2c: esp32: Fix recover and NACK detection

### DIFF
--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -273,6 +273,9 @@ static void IRAM_ATTR i2c_hw_fsm_reset(const struct device *dev)
 #else
 	i2c_ll_master_fsm_rst(data->hal.dev);
 	i2c_master_clear_bus(dev);
+	i2c_hal_master_init(&data->hal);
+	i2c_ll_disable_intr_mask(data->hal.dev, I2C_LL_INTR_MASK);
+	i2c_ll_clear_intr_mask(data->hal.dev, I2C_LL_INTR_MASK);
 #endif
 	i2c_ll_update(data->hal.dev);
 }
@@ -418,7 +421,7 @@ static int IRAM_ATTR i2c_esp32_transmit(const struct device *dev)
 		i2c_hw_fsm_reset(dev);
 		ret = -ETIMEDOUT;
 	} else if (data->status == I2C_STATUS_ACK_ERROR) {
-		ret = -EFAULT;
+		ret = -EIO;
 	}
 
 	return ret;


### PR DESCRIPTION
Call i2c HAL init after HW FSM reset so i2c_recover_bus() leaves the controller ready for the next transfer on C5/C6/H2/P4. Return -EIO on master ACK errors per Zephyr I2C API.

Fixes testcase errors on `tests/drivers/i2c/i2c_at24` for the above mentioned devices.