### PR TITLE
drivers: bluetooth: add BL808 on-chip BLE controller support

### DIFF
--- a/boards/sipeed/m1s_dock/m1s.dtsi
+++ b/boards/sipeed/m1s_dock/m1s.dtsi
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <bflb/bl808.dtsi>
+#include <bflb/bl808_em_32kb.dtsi>
 #include "m1s-pinctrl.dtsi"
 
 / {
@@ -19,18 +20,13 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &all_ram;
 		zephyr,console = &uart0;
-		zephyr,log-uart = &log_uarts;
 		zephyr,shell-uart = &uart0;
 		zephyr,entropy = &sec_eng_trng;
+		zephyr,bt-hci = &bt_hci_bflb;
 	};
 
 	aliases {
 		watchdog0 = &wdt0;
-	};
-
-	log_uarts: log_uarts {
-		compatible = "zephyr,log-uart";
-		uarts = <&uart1>;
 	};
 };
 
@@ -143,5 +139,9 @@
 };
 
 &sec_eng_sha {
+	status = "okay";
+};
+
+&bt_hci_bflb {
 	status = "okay";
 };

--- a/drivers/bluetooth/hci/Kconfig.bflb
+++ b/drivers/bluetooth/hci/Kconfig.bflb
@@ -346,3 +346,36 @@ config BFLB_BL61X_BLE_EM_64K
 	  must include bl61x_em_64kb.dtsi instead of bl61x_em_32kb.dtsi.
 
 endif # BT_BFLB_BL61X
+
+config BT_BFLB_BL808
+	bool
+	default y
+	depends on DT_HAS_BFLB_BT_HCI_ENABLED && SOC_SERIES_BL808
+	select BT_BFLB
+	select HAS_BT_CTLR
+	select DYNAMIC_INTERRUPTS
+	select FPU_SHARING
+	select BFLB_AOS_SHIM
+	help
+	  Bouffalo Lab BL808 on-chip BLE controller HCI driver.
+	  Uses precompiled binary blobs from the hal_bouffalolab module.
+
+if BT_BFLB_BL808
+
+config BFLB_BL808_WL_RMEM_SIZE
+	int "PHY/RF retention memory size (bytes)"
+	default 8192
+	help
+	  Size in bytes of the static buffer passed to wl_cfg_get() for
+	  PHY/RF calibration data. The buffer persists for the lifetime
+	  of the application. 8192 matches the Bouffalo SDK default.
+
+# ACL packet count the controller reports in LE Read Buffer Size
+configdefault BT_BUF_ACL_TX_COUNT
+	default 7
+
+# Set to 1 more than BT_BUF_ACL_TX_COUNT
+configdefault BT_BUF_EVT_RX_COUNT
+	default 8
+
+endif # BT_BFLB_BL808

--- a/drivers/bluetooth/hci/hci_bflb.c
+++ b/drivers/bluetooth/hci/hci_bflb.c
@@ -57,6 +57,15 @@
 #define bflb_controller_init(prio)     btble_controller_init(prio)
 #define bflb_controller_deinit()       btble_controller_deinit()
 
+#elif defined(CONFIG_BT_BFLB_BL808)
+
+#include <btble_lib_api.h>
+
+extern void ble_controller_deinit(void);
+
+#define bflb_controller_init(prio) btble_controller_init(prio)
+#define bflb_controller_deinit()   ble_controller_deinit()
+
 #endif
 
 extern int bflb_rf_init(void);

--- a/dts/riscv/bflb/bl808.dtsi
+++ b/dts/riscv/bflb/bl808.dtsi
@@ -22,6 +22,11 @@
 		status = "disabled";
 	};
 
+	bt_hci_bflb: bt-hci {
+		compatible = "bflb,bt-hci";
+		status = "disabled";
+	};
+
 	clocks {
 		clk_rc32m: clk-rc32m {
 			#clock-cells = <0>;

--- a/dts/riscv/bflb/bl808_em_32kb.dtsi
+++ b/dts/riscv/bflb/bl808_em_32kb.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * When BLE is enabled, the hardware reserves 32 KB of
+ * exchange memory (EM) at the top of WRAM
+ * (GLB_EM_SEL=0x0F set in soc_prep_hook), reducing
+ * usable RAM from 224 KB to 192 KB.
+ */
+
+&wram {
+	reg = <0x10000 DT_SIZE_K(128)>;
+	ranges = <0x0 0x10000 DT_SIZE_K(128)>;
+};
+
+&all_ram {
+	reg = <0x62020000 DT_SIZE_K(192)>;
+	ranges = <0x0 0x62020000 DT_SIZE_K(192)>;
+};

--- a/modules/hal_bouffalolab/CMakeLists.txt
+++ b/modules/hal_bouffalolab/CMakeLists.txt
@@ -7,7 +7,7 @@ if(CONFIG_SOC_FAMILY_BFLB)
   zephyr_include_directories(${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include)
   zephyr_include_directories(${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES})
 
-  if(CONFIG_BFLB_FREERTOS_SHIM OR CONFIG_BFLB_BTBLE_PORT_OS_SHIM OR CONFIG_WIFI_BFLB)
+  if(CONFIG_BFLB_FREERTOS_SHIM OR CONFIG_BFLB_BTBLE_PORT_OS_SHIM OR CONFIG_WIFI_BFLB OR CONFIG_BFLB_AOS_SHIM)
     add_subdirectory(shim)
   endif()
 
@@ -15,4 +15,5 @@ if(CONFIG_SOC_FAMILY_BFLB)
   add_subdirectory_ifdef(CONFIG_SOC_SERIES_BL61X src/bl61x)
   add_subdirectory_ifdef(CONFIG_SOC_SERIES_BL70X src/bl70x)
   add_subdirectory_ifdef(CONFIG_SOC_SERIES_BL70XL src/bl70xl)
+  add_subdirectory_ifdef(CONFIG_SOC_SERIES_BL808 src/bl808x)
 endif() # SOC_FAMILY_BFLB

--- a/modules/hal_bouffalolab/Kconfig
+++ b/modules/hal_bouffalolab/Kconfig
@@ -34,10 +34,16 @@ config BFLB_WL80211_SHIM
 	  Provides the wl80211_supplicant_* entry points and OS abstractions
 	  that the MACSW blob requires. Selected by the BL61x WiFi driver.
 
+config BFLB_AOS_SHIM
+	bool
+	help
+	  OS shim for the BL808 on-chip BLE controller blob.
+	  Implements aos_*, bl_irq_*, and platform functions.
+
 config BFLB_SHIM_HEAP_SIZE
 	int "BLE shim heap size"
 	default 8192
-	depends on BFLB_FREERTOS_SHIM || BFLB_BTBLE_PORT_OS_SHIM
+	depends on BFLB_FREERTOS_SHIM || BFLB_BTBLE_PORT_OS_SHIM || BFLB_AOS_SHIM
 	help
 	  Size in bytes of the dedicated memory pool used by the BLE
 	  controller shim layer for threads, stacks, and queues.

--- a/modules/hal_bouffalolab/shim/CMakeLists.txt
+++ b/modules/hal_bouffalolab/shim/CMakeLists.txt
@@ -4,3 +4,4 @@
 zephyr_sources_ifdef(CONFIG_BFLB_FREERTOS_SHIM freertos_shim.c)
 zephyr_sources_ifdef(CONFIG_BFLB_BTBLE_PORT_OS_SHIM btblecontroller_port_os.c)
 add_subdirectory_ifdef(CONFIG_WIFI_BFLB wifi)
+zephyr_sources_ifdef(CONFIG_BFLB_AOS_SHIM aos_shim.c)

--- a/modules/hal_bouffalolab/shim/aos_shim.c
+++ b/modules/hal_bouffalolab/shim/aos_shim.c
@@ -1,0 +1,200 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * OS shim for the BL808 on-chip BLE controller blob. Maps the aos_*
+ * task/queue/heap primitives it expects onto Zephyr kernel APIs.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+static K_HEAP_DEFINE(shim_heap, CONFIG_BFLB_SHIM_HEAP_SIZE);
+
+/* aos_queue_recv wait-forever sentinel (AOS passes ~0 for no timeout) */
+#define AOS_WAIT_FOREVER 0xFFFFFFFFU
+
+/* Cooperative priority for controller tasks, so they interleave with the
+ * (also cooperative) BT host thread without preemption races
+ */
+#define BLE_TASK_COOP_PRIO 8
+
+/*
+ * Queue wrapper: Zephyr k_msgq requires a pre-allocated buffer and struct,
+ * while the AliOS API passes a raw buffer externally.
+ */
+struct aos_queue_wrapper {
+	struct k_msgq msgq;
+};
+
+/*
+ * Thread wrapper: tracks k_thread, stack, and entry point together so
+ * krhino_task_dyn_del can free everything.
+ */
+struct aos_thread {
+	struct k_thread thread;
+	k_thread_stack_t *stack;
+	size_t stack_size;
+	void (*func)(void *arg);
+	void *arg;
+};
+
+/* Trampoline: adapts (void *) entry to Zephyr's (void *, void *, void *) */
+static void task_entry_wrapper(void *p1, void *p2, void *p3)
+{
+	struct aos_thread *t = (struct aos_thread *)p1;
+
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	t->func(t->arg);
+}
+
+/*
+ * AOS memory
+ */
+void *aos_malloc(unsigned int size)
+{
+	void *p = k_heap_alloc(&shim_heap, size, K_NO_WAIT);
+
+	if (p == NULL) {
+		printk("BLE shim: %s(%u) FAILED\n", __func__, size);
+	}
+	return p;
+}
+
+void aos_free(void *mem)
+{
+	k_heap_free(&shim_heap, mem);
+}
+
+/*
+ * AOS queue
+ */
+int aos_queue_new(void *queue_handle, void *buf, unsigned int size, int max_msg)
+{
+	unsigned int item_count;
+	struct aos_queue_wrapper *q;
+
+	if (max_msg == 0) {
+		return -1;
+	}
+
+	item_count = size / (unsigned int)max_msg;
+	if (item_count == 0) {
+		return -1;
+	}
+
+	q = k_heap_alloc(&shim_heap, sizeof(*q), K_NO_WAIT);
+	if (q == NULL) {
+		return -1;
+	}
+
+	k_msgq_init(&q->msgq, (char *)buf, (size_t)max_msg, item_count);
+
+	*(void **)queue_handle = q;
+	return 0;
+}
+
+void aos_queue_free(void *queue_handle)
+{
+	struct aos_queue_wrapper *q = (struct aos_queue_wrapper *)queue_handle;
+
+	if (q != NULL) {
+		k_msgq_purge(&q->msgq);
+		k_heap_free(&shim_heap, q);
+	}
+}
+
+int aos_queue_send(void *queue_handle, void *msg, unsigned int size)
+{
+	/* queue_handle may be &cq (pointer to the handle variable) or the handle itself.
+	 * The blob's rw_main_task_post passes &cq. Dereference to get the wrapper.
+	 */
+	struct aos_queue_wrapper *q = *(struct aos_queue_wrapper **)queue_handle;
+
+	ARG_UNUSED(size);
+
+	return (k_msgq_put(&q->msgq, msg, K_NO_WAIT) == 0) ? 0 : -1;
+}
+
+int aos_queue_recv(void *queue_handle, unsigned int ms, void *msg, unsigned int *size)
+{
+	struct aos_queue_wrapper *q = *(struct aos_queue_wrapper **)queue_handle;
+	k_timeout_t timeout;
+	int ret;
+
+	if (ms == AOS_WAIT_FOREVER) {
+		timeout = K_FOREVER;
+	} else if (ms == 0U) {
+		timeout = K_NO_WAIT;
+	} else {
+		timeout = K_MSEC(ms);
+	}
+
+	ret = k_msgq_get(&q->msgq, msg, timeout);
+	if (ret == 0) {
+		if (size != NULL) {
+			*size = (unsigned int)q->msgq.msg_size;
+		}
+		return 0;
+	}
+
+	return -1;
+}
+
+/*
+ * AOS task
+ */
+int aos_task_new_ext(void *task, const char *name, void (*fn)(void *), void *arg, int stack_size,
+		     int prio)
+{
+	struct aos_thread *t;
+	int zprio;
+
+	ARG_UNUSED(prio);
+
+	t = k_heap_alloc(&shim_heap, sizeof(*t), K_NO_WAIT);
+	if (t == NULL) {
+		return -1;
+	}
+
+	t->stack = k_heap_alloc(&shim_heap, (size_t)stack_size, K_NO_WAIT);
+	if (t->stack == NULL) {
+		k_heap_free(&shim_heap, t);
+		return -1;
+	}
+	t->stack_size = (size_t)stack_size;
+	t->func = fn;
+	t->arg = arg;
+
+	zprio = K_PRIO_COOP(BLE_TASK_COOP_PRIO);
+
+	k_thread_create(&t->thread, t->stack, (size_t)stack_size, task_entry_wrapper, t, NULL, NULL,
+			zprio, 0, K_FOREVER);
+	k_thread_name_set(&t->thread, name);
+
+	if (task != NULL) {
+		*(void **)task = t;
+	}
+
+	k_thread_start(&t->thread);
+
+	return 0;
+}
+
+void krhino_task_dyn_del(void *task)
+{
+	struct aos_thread *t = (struct aos_thread *)task;
+
+	if (t != NULL) {
+		k_thread_abort(&t->thread);
+		k_heap_free(&shim_heap, t->stack);
+		k_heap_free(&shim_heap, t);
+	}
+}

--- a/modules/hal_bouffalolab/src/bl808x/CMakeLists.txt
+++ b/modules/hal_bouffalolab/src/bl808x/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BT_BFLB_BL808)
+  zephyr_include_directories(
+    ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/include/bouffalolab/${SOC_SERIES}/ble)
+
+  set(BLE_BLOBS_DIR ${ZEPHYR_HAL_BOUFFALOLAB_MODULE_DIR}/zephyr/blobs/lib/bl808x)
+
+  message(STATUS "BL808 BLE: on-chip controller blobs")
+
+  if(NOT CONFIG_BUILD_ONLY_NO_BLOBS)
+    zephyr_link_libraries(
+      ${BLE_BLOBS_DIR}/libbl606p_btblecontroller_prebuild.a
+      ${BLE_BLOBS_DIR}/libbl606p_phyrf.a
+    )
+  endif()
+endif()

--- a/soc/bflb/bl808/CMakeLists.txt
+++ b/soc/bflb/bl808/CMakeLists.txt
@@ -6,3 +6,9 @@ zephyr_include_directories(.)
 zephyr_sources(soc.c)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")
+
+if(CONFIG_BT_BFLB_BL808)
+  zephyr_sources(bflb_rf.c)
+  zephyr_sources(ble/btblecontroller_port_hw.c)
+  zephyr_linker_sources(RWDATA bflb_rwdata.ld)
+endif()

--- a/soc/bflb/bl808/bflb_rf.c
+++ b/soc/bflb/bl808/bflb_rf.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * PHY/RF calibration for the BL808 BLE controller, via the BL808-native
+ * phyrf blob. Provides bflb_rf_init(), the common entry point the HCI
+ * driver calls before starting the controller.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/logging/log.h>
+
+#include <wl_api.h>
+
+LOG_MODULE_REGISTER(bflb_rf, LOG_LEVEL_ERR);
+
+#define XTAL_FREQ DT_PROP(DT_NODELABEL(clk_crystal), clock_frequency)
+
+/*
+ * Crystal capcode register access.
+ *
+ * AON_XTAL_CFG register at AON_BASE + 0x884.
+ * CAPCODE_IN: bits [27:22], CAPCODE_OUT: bits [21:16]
+ */
+#define AON_BASE_ADDR       0x2000f000U
+#define AON_XTAL_CFG_OFFSET 0x884U
+#define AON_XTAL_CFG_ADDR   (AON_BASE_ADDR + AON_XTAL_CFG_OFFSET)
+#define CAPCODE_IN_POS      22U
+#define CAPCODE_OUT_POS     16U
+#define CAPCODE_MSK         0x3fU
+
+#define BFLB_EFUSE_DEFAULT_TRIM 0x80U
+
+static uint8_t wl_rmem_buf[CONFIG_BFLB_BL808_WL_RMEM_SIZE] __aligned(4);
+
+static void capcode_get(uint8_t *capcode_in, uint8_t *capcode_out)
+{
+	uint32_t val = sys_read32(AON_XTAL_CFG_ADDR);
+
+	*capcode_in = (val >> CAPCODE_IN_POS) & CAPCODE_MSK;
+	*capcode_out = (val >> CAPCODE_OUT_POS) & CAPCODE_MSK;
+}
+
+static void capcode_set(uint8_t capcode_in, uint8_t capcode_out)
+{
+	uint32_t val = sys_read32(AON_XTAL_CFG_ADDR);
+
+	val &= ~((CAPCODE_MSK << CAPCODE_IN_POS) | (CAPCODE_MSK << CAPCODE_OUT_POS));
+	val |= ((uint32_t)(capcode_in & CAPCODE_MSK) << CAPCODE_IN_POS) |
+	       ((uint32_t)(capcode_out & CAPCODE_MSK) << CAPCODE_OUT_POS);
+	sys_write32(val, AON_XTAL_CFG_ADDR);
+}
+
+int bflb_rf_init(void)
+{
+	struct wl_cfg_t *cfg;
+	int ret;
+
+	cfg = wl_cfg_get(wl_rmem_buf);
+	if (cfg == NULL) {
+		LOG_ERR("wl_cfg_get failed");
+		return -ENOMEM;
+	}
+
+	cfg->mode = WL_API_MODE_BZ;
+	cfg->en_param_load = 0;
+	cfg->en_full_cal = 1;
+	cfg->en_capcode_set = 1;
+	cfg->capcode_get = capcode_get;
+	cfg->capcode_set = capcode_set;
+	cfg->param_load = NULL;
+	cfg->log_level = WL_LOG_LEVEL_NONE;
+	cfg->log_printf = NULL;
+	cfg->param.xtalfreq_hz = XTAL_FREQ;
+	cfg->param.ef.dcdc_vout_trim_aon = BFLB_EFUSE_DEFAULT_TRIM;
+	cfg->param.ef.icx_code = BFLB_EFUSE_DEFAULT_TRIM;
+	cfg->param.ef.iptat_code = BFLB_EFUSE_DEFAULT_TRIM;
+
+	ret = wl_init();
+	if (ret != 0) {
+		LOG_ERR("wl_init failed: %d", ret);
+		return -EIO;
+	}
+
+	return 0;
+}

--- a/soc/bflb/bl808/bflb_rwdata.ld
+++ b/soc/bflb/bl808/bflb_rwdata.ld
@@ -1,0 +1,8 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * BLE vendor blob .tcm_data section.
+ */
+
+*(.tcm_data)

--- a/soc/bflb/bl808/ble/btblecontroller_port_hw.c
+++ b/soc/bflb/bl808/ble/btblecontroller_port_hw.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Hardware port glue for the on-chip BLE controller on BL808.
+ *
+ * The controller reaches the BLE baseband through Exchange Memory (EM) at
+ * bus address 0x28000000. EM_SEL (GLB_SRAM_CFG3[7:0]) repurposes the top
+ * WRAM banks as EM; the CPU accesses that memory through the bridge. CPU
+ * writes to 0x28000000 must be Bufferable — Strongly Ordered writes are
+ * silently dropped by the bridge. EM_SEL is set in soc_prep_hook, before
+ * the controller heap is initialised.
+ *
+ * Provides printf/puts stubs, flash read (XIP), IRQ glue, and efuse MAC.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/drivers/hwinfo.h>
+
+int bl_flash_read(uint32_t addr, uint8_t *dst, int len)
+{
+	memcpy(dst, (const uint8_t *)(0x58000000 + addr), len);
+	return 0;
+}
+
+int bl_flash_erase(uint32_t addr, int len)
+{
+	ARG_UNUSED(addr);
+	ARG_UNUSED(len);
+	return -1;
+}
+
+int bl_flash_write(uint32_t addr, const uint8_t *src, int len)
+{
+	ARG_UNUSED(addr);
+	ARG_UNUSED(src);
+	ARG_UNUSED(len);
+	return -1;
+}
+
+int bl_efuse_read_mac_smart(uint8_t smart, uint8_t mac[6], uint8_t slot)
+{
+	ARG_UNUSED(smart);
+	ARG_UNUSED(slot);
+
+	return (hwinfo_get_device_id(mac, 6) >= 6) ? 0 : -1;
+}
+
+int EF_Ctrl_Read_MAC_Address(uint8_t mac[6])
+{
+	return (hwinfo_get_device_id(mac, 6) >= 6) ? 0 : -1;
+}
+
+void bl_irq_register(int irqnum, void *handler)
+{
+	irq_connect_dynamic(irqnum, 0, (void (*)(const void *))handler, NULL, 0);
+}
+
+void bl_irq_enable(unsigned int source)
+{
+	irq_enable(source);
+}
+
+void bl_irq_disable(unsigned int source)
+{
+	irq_disable(source);
+}
+
+void bl_irq_pending_clear(unsigned int source)
+{
+	ARG_UNUSED(source);
+}

--- a/soc/bflb/bl808/soc.c
+++ b/soc/bflb/bl808/soc.c
@@ -142,16 +142,46 @@ static void system_sysmap_init(void)
 {
 	uintptr_t base = SYSMAP_BASE;
 
+#if defined(CONFIG_BT_BFLB_BL808)
+	/* 0: 0x00000000 ~ 0x28000000: SO (peripherals, uncached OCRAM/WRAM) */
+	sys_write32(0x28000000U >> SYSMAP_BASE_SHIFT, base + SYSMAP_ADDR_OFFSET);
+	sys_write32(SYSMAP_ATTR_STRONG_ORDER, base + SYSMAP_FLAGS_OFFSET);
+	base += SYSMAP_ENTRY_OFFSET;
+
+	/* 0a: 0x28000000 ~ 0x29000000: B (BLE Exchange Memory bus bridge).
+	 * The bus bridge does not support Strongly Ordered writes — they are
+	 * silently dropped, which corrupts EM heap metadata on init. Must be
+	 * Bufferable.
+	 */
+	sys_write32(0x29000000U >> SYSMAP_BASE_SHIFT, base + SYSMAP_ADDR_OFFSET);
+	sys_write32(SYSMAP_ATTR_BUFFER_ABLE, base + SYSMAP_FLAGS_OFFSET);
+	base += SYSMAP_ENTRY_OFFSET;
+
+	/* 0b: 0x29000000 ~ 0x50000000: SO (remaining peripherals) */
+	sys_write32(0x50000000U >> SYSMAP_BASE_SHIFT, base + SYSMAP_ADDR_OFFSET);
+	sys_write32(SYSMAP_ATTR_STRONG_ORDER, base + SYSMAP_FLAGS_OFFSET);
+	base += SYSMAP_ENTRY_OFFSET;
+#else
 	/* 0: 0x00000000 ~ 0x50000000: SO (peripherals, uncached memory) */
 	sys_write32(0x50000000U >> SYSMAP_BASE_SHIFT, base + SYSMAP_ADDR_OFFSET);
 	sys_write32(SYSMAP_ATTR_STRONG_ORDER, base + SYSMAP_FLAGS_OFFSET);
 	base += SYSMAP_ENTRY_OFFSET;
+#endif
 
 	/* 1: 0x50000000 ~ 0x54000000: CB (PSRAM data bus, 64MB window) */
 	sys_write32(0x54000000U >> SYSMAP_BASE_SHIFT, base + SYSMAP_ADDR_OFFSET);
 	sys_write32(SYSMAP_ATTR_CACHE_ABLE | SYSMAP_ATTR_BUFFER_ABLE, base + SYSMAP_FLAGS_OFFSET);
 	base += SYSMAP_ENTRY_OFFSET;
 
+#if defined(CONFIG_BT_BFLB_BL808)
+	/* 2+3 collapsed: 0x54000000 ~ 0x5C000000: C (gap + flash XIP).
+	 * Marking the gap as cacheable is harmless (no real memory) and
+	 * frees a sysmap slot for the BLE EM region above (8 entries max).
+	 */
+	sys_write32(BL808_FLASH2_XIP_BASE >> SYSMAP_BASE_SHIFT, base + SYSMAP_ADDR_OFFSET);
+	sys_write32(SYSMAP_ATTR_CACHE_ABLE, base + SYSMAP_FLAGS_OFFSET);
+	base += SYSMAP_ENTRY_OFFSET;
+#else
 	/* 2: 0x54000000 ~ 0x58000000: SO (gap between PSRAM and flash XIP) */
 	sys_write32(BL808_FLASH_XIP_BASE >> SYSMAP_BASE_SHIFT, base + SYSMAP_ADDR_OFFSET);
 	sys_write32(SYSMAP_ATTR_STRONG_ORDER, base + SYSMAP_FLAGS_OFFSET);
@@ -161,6 +191,7 @@ static void system_sysmap_init(void)
 	sys_write32(BL808_FLASH2_XIP_BASE >> SYSMAP_BASE_SHIFT, base + SYSMAP_ADDR_OFFSET);
 	sys_write32(SYSMAP_ATTR_CACHE_ABLE, base + SYSMAP_FLAGS_OFFSET);
 	base += SYSMAP_ENTRY_OFFSET;
+#endif
 
 	/* 4: 0x5C000000 ~ 0x62020000: SO (flash2 XIP + gap) */
 	sys_write32(BL808_OCRAM_CACHEABLE_BASE >> SYSMAP_BASE_SHIFT,
@@ -174,6 +205,15 @@ static void system_sysmap_init(void)
 	sys_write32(SYSMAP_ATTR_CACHE_ABLE | SYSMAP_ATTR_BUFFER_ABLE, base + SYSMAP_FLAGS_OFFSET);
 	base += SYSMAP_ENTRY_OFFSET;
 
+#if defined(CONFIG_BT_BFLB_BL808)
+	/* 6+7 collapsed: 0x62058000 ~ 0xFFFFF000: SO (gap + DRAM/VRAM/CLIC).
+	 * Both ranges are SO with identical attributes, so collapsing is
+	 * functionally identical and frees a sysmap slot for the BLE EM
+	 * region above (8 entries max).
+	 */
+	sys_write32(0xFFFFF000U >> SYSMAP_BASE_SHIFT, base + SYSMAP_ADDR_OFFSET);
+	sys_write32(SYSMAP_ATTR_STRONG_ORDER, base + SYSMAP_FLAGS_OFFSET);
+#else
 	/* 6: 0x62058000 ~ 0x7EF80000: SO (gap) */
 	sys_write32(BL808_DRAM_CACHEABLE_BASE >> SYSMAP_BASE_SHIFT, base + SYSMAP_ADDR_OFFSET);
 	sys_write32(SYSMAP_ATTR_STRONG_ORDER, base + SYSMAP_FLAGS_OFFSET);
@@ -182,6 +222,7 @@ static void system_sysmap_init(void)
 	/* 7: 0x7EF80000 ~ 0xFFFFF000: SO (DRAM/VRAM, CLIC, sysmap regs) */
 	sys_write32(0xFFFFF000U >> SYSMAP_BASE_SHIFT, base + SYSMAP_ADDR_OFFSET);
 	sys_write32(SYSMAP_ATTR_STRONG_ORDER, base + SYSMAP_FLAGS_OFFSET);
+#endif
 }
 
 /*
@@ -337,9 +378,18 @@ void soc_prep_hook(void)
 	tzc_sec_psram_init();
 	pmp_init();
 
-	/* Set EM to 160KB WRAM / 0KB EM (GLB_WRAM160KB_EM0KB = 0) */
 	tmp = sys_read32(GLB_BASE + GLB_SRAM_CFG3_OFFSET);
 	tmp &= GLB_EM_SEL_UMSK;
+#if defined(CONFIG_BT_BFLB_BL808)
+	/* 32KB EM + 128KB WRAM (GLB_WRAM128KB_EM32KB encoded as 0x0F bitmask
+	 * per SDK GLB_Set_EM_Sel — each bit selects an 8KB WRAM bank as EM).
+	 * BLE blob's btble_ke_mem_init runs before ble_rf_init in rwip_init;
+	 * without EM enabled, ke_mem_init writes garbage heap metadata.
+	 */
+	tmp |= (0x0FU << GLB_EM_SEL_POS);
+#else
+	/* 160KB WRAM / 0KB EM (GLB_WRAM160KB_EM0KB = 0) */
+#endif
 	sys_write32(tmp, GLB_BASE + GLB_SRAM_CFG3_OFFSET);
 }
 
@@ -349,6 +399,15 @@ void soc_early_init_hook(void)
 
 	soc_bl808_halt_secondary_cores();
 	system_sysmap_init();
+
+#if defined(CONFIG_BT_BFLB_BL808)
+	/* WiFi PHY clock gate (shared RF block; BLE depends on it).
+	 * CGEN_CFG0 bit 7 may be TZC-locked once tzc_sec_psram_init runs
+	 * later — set it at the earliest opportunity.
+	 */
+	sys_write32(sys_read32(GLB_BASE + GLB_CGEN_CFG0_OFFSET) | BIT(7),
+		    GLB_BASE + GLB_CGEN_CFG0_OFFSET);
+#endif
 
 	sys_cache_data_flush_all();
 	sys_cache_instr_invd_all();

--- a/west.yml
+++ b/west.yml
@@ -168,7 +168,7 @@ manifest:
         - hal
     - name: hal_bouffalolab
       path: modules/hal/bouffalolab
-      revision: aa6d2207eb479b78c55ed6123d7e2b96617faf9e
+      revision: pull/28/head
       groups:
         - hal
     - name: hal_espressif


### PR DESCRIPTION
## Summary

Adds Bluetooth LE support for the BL808 SoC (tested on the Sipeed M1S Dock) using the on-chip BLE controller and phyrf binary blobs from the hal_bouffalolab module. `samples/bluetooth/peripheral_hr` advertises and is
scannable on hardware.

## Testing

- Built and flash `samples/bluetooth/peripheral_hr` for `m1s_dock/bl808c09q2i`