### PR TITLE
drivers: sensor: bmi270: fix any-motion feature-page writes being ignored

### DIFF
--- a/drivers/sensor/bosch/bmi270/bmi270.c
+++ b/drivers/sensor/bosch/bmi270/bmi270.c
@@ -223,7 +223,14 @@ static int set_accel_odr_osr(const struct device *dev, const struct sensor_value
 	}
 
 	if (odr || osr) {
-		ret = bmi270_reg_write(dev, BMI270_REG_ACC_CONF, &acc_conf, 1);
+		/*
+		 * With advanced power save enabled the next write must come
+		 * >=450 us later or it is ignored; the PWR_CTRL write below
+		 * would silently fail to enable the accelerometer.
+		 */
+		ret = bmi270_reg_write_with_delay(dev, BMI270_REG_ACC_CONF,
+						  &acc_conf, 1,
+						  BMI270_INTER_WRITE_DELAY_US);
 		if (ret != 0) {
 			return ret;
 		}

--- a/drivers/sensor/bosch/bmi270/bmi270.c
+++ b/drivers/sensor/bosch/bmi270/bmi270.c
@@ -225,7 +225,14 @@ static int set_accel_odr_osr(const struct device *dev, const struct sensor_value
 	}
 
 	if (odr || osr) {
-		ret = bmi270_reg_write(dev, BMI270_REG_ACC_CONF, &acc_conf, 1);
+		/*
+		 * With advanced power save enabled the next write must come
+		 * >=450 us later or it is ignored; the PWR_CTRL write below
+		 * would silently fail to enable the accelerometer.
+		 */
+		ret = bmi270_reg_write_with_delay(dev, BMI270_REG_ACC_CONF,
+						  &acc_conf, 1,
+						  BMI270_INTER_WRITE_DELAY_US);
 		if (ret != 0) {
 			return ret;
 		}

--- a/drivers/sensor/bosch/bmi270/bmi270_trigger.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_trigger.c
@@ -228,6 +228,12 @@ static int bmi270_anymo_config(const struct device *dev, bool enable)
 	uint16_t anymo_2;
 	int ret;
 
+	if (cfg->feature->anymo_1 == NULL || cfg->feature->anymo_2 == NULL) {
+		LOG_ERR("any-motion not supported by the %s feature set",
+			cfg->feature->name);
+		return -ENOTSUP;
+	}
+
 	if (enable) {
 		ret = bmi270_feature_reg_write(dev, cfg->feature->anymo_1,
 					       data->anymo_1);

--- a/drivers/sensor/bosch/bmi270/bmi270_trigger.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_trigger.c
@@ -226,12 +226,33 @@ static int bmi270_anymo_config(const struct device *dev, bool enable)
 	const struct bmi270_config *cfg = dev->config;
 	struct bmi270_data *data = dev->data;
 	uint16_t anymo_2;
+	uint8_t pwr_conf = 0;
 	int ret;
 
 	if (cfg->feature->anymo_1 == NULL || cfg->feature->anymo_2 == NULL) {
 		LOG_ERR("any-motion not supported by the %s feature set",
 			cfg->feature->name);
 		return -ENOTSUP;
+	}
+
+	/*
+	 * Feature registers are not accessible while advanced power save
+	 * is enabled (see datasheet, PWR_CONF.adv_power_save); the init
+	 * routine leaves it enabled, so park it for the duration.
+	 */
+	ret = bmi270_reg_read(dev, BMI270_REG_PWR_CONF, &pwr_conf, 1);
+	if (ret < 0) {
+		return ret;
+	}
+	if (pwr_conf & BMI270_PWR_CONF_ADV_PWR_SAVE_MSK) {
+		uint8_t aps_off = pwr_conf & ~BMI270_PWR_CONF_ADV_PWR_SAVE_MSK;
+
+		ret = bmi270_reg_write_with_delay(dev, BMI270_REG_PWR_CONF,
+						  &aps_off, 1,
+						  BMI270_INTER_WRITE_DELAY_US);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	if (enable) {
@@ -262,6 +283,16 @@ static int bmi270_anymo_config(const struct device *dev, bool enable)
 	if (ret < 0) {
 		LOG_ERR("failed configuring INT1_MAP_FEAT (%d)", ret);
 		return ret;
+	}
+
+	/* Restore advanced power save if it was enabled on entry */
+	if (pwr_conf & BMI270_PWR_CONF_ADV_PWR_SAVE_MSK) {
+		ret = bmi270_reg_write_with_delay(dev, BMI270_REG_PWR_CONF,
+						  &pwr_conf, 1,
+						  BMI270_INTER_WRITE_DELAY_US);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	return 0;

--- a/drivers/sensor/bosch/bmi270/bmi270_trigger.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_trigger.c
@@ -226,6 +226,7 @@ static int bmi270_anymo_config(const struct device *dev, bool enable)
 	const struct bmi270_config *cfg = dev->config;
 	struct bmi270_data *data = dev->data;
 	uint16_t anymo_2;
+	uint8_t pwr_conf = 0;
 	int ret;
 
 	/* Any-motion registers only exist in feature sets that define them
@@ -236,6 +237,26 @@ static int bmi270_anymo_config(const struct device *dev, bool enable)
 	if (cfg->feature->anymo_1 == NULL || cfg->feature->anymo_2 == NULL) {
 		LOG_ERR("any-motion not supported by the configured feature set");
 		return -ENOTSUP;
+	}
+
+	/*
+	 * Feature registers are not accessible while advanced power save
+	 * is enabled (see datasheet, PWR_CONF.adv_power_save); the init
+	 * routine leaves it enabled, so park it for the duration.
+	 */
+	ret = bmi270_reg_read(dev, BMI270_REG_PWR_CONF, &pwr_conf, 1);
+	if (ret < 0) {
+		return ret;
+	}
+	if (pwr_conf & BMI270_PWR_CONF_ADV_PWR_SAVE_MSK) {
+		uint8_t aps_off = pwr_conf & ~BMI270_PWR_CONF_ADV_PWR_SAVE_MSK;
+
+		ret = bmi270_reg_write_with_delay(dev, BMI270_REG_PWR_CONF,
+						  &aps_off, 1,
+						  BMI270_INTER_WRITE_DELAY_US);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	if (enable) {
@@ -266,6 +287,16 @@ static int bmi270_anymo_config(const struct device *dev, bool enable)
 	if (ret < 0) {
 		LOG_ERR("failed configuring INT1_MAP_FEAT (%d)", ret);
 		return ret;
+	}
+
+	/* Restore advanced power save if it was enabled on entry */
+	if (pwr_conf & BMI270_PWR_CONF_ADV_PWR_SAVE_MSK) {
+		ret = bmi270_reg_write_with_delay(dev, BMI270_REG_PWR_CONF,
+						  &pwr_conf, 1,
+						  BMI270_INTER_WRITE_DELAY_US);
+		if (ret < 0) {
+			return ret;
+		}
 	}
 
 	return 0;

--- a/dts/bindings/sensor/bosch,bmi270.yaml
+++ b/dts/bindings/sensor/bosch,bmi270.yaml
@@ -6,6 +6,13 @@ description: |
     The BMI270 is an inertial measurement unit. See more info at:
     https://www.bosch-sensortec.com/products/motion-sensors/imus/bmi270.html
 
+    By default the driver loads the "max_fifo" feature-set configuration
+    file, which does not support the any-motion feature. To use the
+    any-motion trigger (SENSOR_TRIG_MOTION), select the "base" feature
+    set by listing bosch,bmi270-base before this compatible:
+
+        compatible = "bosch,bmi270-base", "bosch,bmi270";
+
 include: sensor-device.yaml
 
 compatible: "bosch,bmi270"


### PR DESCRIPTION
Follow-up to #114134, which added the -ENOTSUP guard for feature sets without any-motion support (superseding the first commit of this series - now rebased out).

With the guard in place, configuring any-motion with the correct bosch,bmi270-base compatible still does not work: the driver re-enables PWR_CONF.adv_power_save at the end of init, and per the datasheet the feature page is not accessible while it is set. bmi270_anymo_config() therefore writes ANYMO_1/ANYMO_2 with power save enabled and the writes are silently ignored - reading back the feature page after configuration shows both registers still 0x0000. Details and register-level evidence in #112938.

Remaining commits:

- disable adv power save around feature writes: park PWR_CONF.adv_power_save for the duration of bmi270_anymo_config() and restore it afterwards, honouring the inter-write delay
- use delayed write for ACC_CONF: set_accel_odr_osr() issues the ACC_CONF write with only the exact 450 us datasheet minimum before the PWR_CTRL write; on hardware (BMI270 on SPI, nRF54L15) the accelerometer-enable write was observed to be dropped. Use bmi270_reg_write_with_delay() like every other configuration write in the driver
- dts: bindings: document the bosch,bmi270-base compatible, which selects the feature set with any-motion support and is referenced nowhere

Verified on hardware: with these applied, SENSOR_TRIG_MOTION fires and the feature page reads back the written configuration.