### PR TITLE
modem: cellular: bound the recovery loop

### DIFF
--- a/drivers/modem/Kconfig.cellular
+++ b/drivers/modem/Kconfig.cellular
@@ -100,6 +100,15 @@ config MODEM_CELLULAR_RESET_POWER_ON_DELAY_MS
 	int "Delay between de-asserting the reset pin and pulsing the power pin"
 	default 500
 
+config MODEM_CELLULAR_MAX_SCRIPT_FAILURES
+	int "Maximum consecutive script failures before suspending"
+	range 0 255
+	default 3
+	help
+	  Number of consecutive chat-script failures tolerated before the driver
+	  gives up on the current attempt and suspends to idle. A value of 0 gives
+	  up on the first failure.
+
 config MODEM_CELLULAR_MAX_RECOVERIES
 	int "Maximum consecutive recovery attempts before suspending"
 	range 0 255

--- a/drivers/modem/Kconfig.cellular
+++ b/drivers/modem/Kconfig.cellular
@@ -100,6 +100,32 @@ config MODEM_CELLULAR_RESET_POWER_ON_DELAY_MS
 	int "Delay between de-asserting the reset pin and pulsing the power pin"
 	default 500
 
+config MODEM_CELLULAR_MAX_RECOVERIES
+	int "Maximum consecutive recovery attempts before suspending"
+	range 0 255
+	default 10
+	help
+	  After this many consecutive init or CMUX-connect recovery attempts without
+	  restored service, the driver suspends to idle instead of resetting the modem
+	  indefinitely. The counter resets once CMUX reconnects. Set to 0 to retry
+	  without a limit.
+
+config MODEM_CELLULAR_RECOVERY_BACKOFF_MS
+	int "Recovery backoff step in milliseconds"
+	range 0 3600000
+	default 2000
+	help
+	  Delay before each recovery reset, multiplied by the attempt count, so
+	  repeated failures back off instead of resetting the modem back-to-back.
+
+config MODEM_CELLULAR_RECOVERY_BACKOFF_MAX_MS
+	int "Maximum recovery backoff in milliseconds"
+	range 0 3600000
+	default 60000
+	help
+	  Upper bound on the per-attempt recovery backoff, so a large attempt budget
+	  cannot produce an unbounded delay before a reset.
+
 config MODEM_CELLULAR_SHELL
 	bool "Cellular modem driver shell commands"
 	depends on !MODEM_SHELL

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -32,7 +32,6 @@ LOG_MODULE_REGISTER(modem_cellular, CONFIG_MODEM_LOG_LEVEL);
 	K_MSEC(CONFIG_MODEM_CELLULAR_PERIODIC_SCRIPT_MS)
 
 /* Magic constants */
-#define MODEM_CELLULAR_MAX_SCRIPT_FAILURES   (3)
 #define CSQ_RSSI_UNKNOWN		     (99)
 #define CESQ_RSRP_UNKNOWN		     (255)
 #define CESQ_RSRQ_UNKNOWN		     (255)
@@ -1352,7 +1351,7 @@ static void modem_cellular_script_success(struct modem_cellular_data *data)
 
 static bool modem_cellular_is_script_retry_exceeded(struct modem_cellular_data *data)
 {
-	if (data->script_failure_counter >= MODEM_CELLULAR_MAX_SCRIPT_FAILURES) {
+	if (data->script_failure_counter >= CONFIG_MODEM_CELLULAR_MAX_SCRIPT_FAILURES) {
 		data->script_failure_counter = 0;
 		return true;
 	}

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -61,6 +61,8 @@ static const char *modem_cellular_state_str(enum modem_cellular_state state)
 	switch (state) {
 	case MODEM_CELLULAR_STATE_IDLE:
 		return "idle";
+	case MODEM_CELLULAR_STATE_RECOVERY:
+		return "recovery";
 	case MODEM_CELLULAR_STATE_RESET_PULSE:
 		return "reset pulse";
 	case MODEM_CELLULAR_STATE_AWAIT_RESET:
@@ -1059,24 +1061,80 @@ static int modem_cellular_on_run_init_script_state_enter(struct modem_cellular_d
 	return modem_pipe_open_async(data->uart_pipe);
 }
 
-static void modem_cellular_enter_recovery_state(struct modem_cellular_data *data)
+static int modem_cellular_on_recovery_state_enter(struct modem_cellular_data *data)
+{
+	/* Back off before resetting. Growing the delay with the attempt count keeps a
+	 * persistent fault from resetting the modem back-to-back, and gives a modem
+	 * that is merely slow to respond some time to settle. Clamp it so a large
+	 * attempt budget cannot produce an unbounded delay.
+	 */
+	uint32_t backoff_ms = MIN(CONFIG_MODEM_CELLULAR_RECOVERY_BACKOFF_MS * data->recovery_count,
+				  CONFIG_MODEM_CELLULAR_RECOVERY_BACKOFF_MAX_MS);
+
+	LOG_DBG("recovery attempt %u, backoff %u ms", data->recovery_count, backoff_ms);
+	modem_cellular_start_timer(data, K_MSEC(backoff_ms));
+	return 0;
+}
+
+static void modem_cellular_recovery_event_handler(struct modem_cellular_data *data,
+						  enum modem_cellular_event evt)
 {
 	const struct modem_cellular_config *config = data->dev->config;
 
+	switch (evt) {
+	case MODEM_CELLULAR_EVENT_TIMEOUT:
+		/* Release CMUX if attached so the UART pipe reattaches cleanly on the
+		 * next connect attempt. No-op when CMUX is not attached.
+		 */
+		modem_cmux_release(&data->cmux);
+
+		if (modem_cellular_gpio_is_enabled(&config->reset_gpio) &&
+		    config->reset_on_recovery) {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RESET_PULSE);
+		} else if (modem_cellular_gpio_is_enabled(&config->power_gpio)) {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_POWER_ON_PULSE);
+		} else {
+			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_IDLE);
+		}
+		break;
+
+	case MODEM_CELLULAR_EVENT_SUSPEND:
+		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_IDLE);
+		break;
+
+	default:
+		break;
+	}
+}
+
+static int modem_cellular_on_recovery_state_leave(struct modem_cellular_data *data)
+{
+	modem_cellular_stop_timer(data);
+	return 0;
+}
+
+static void modem_cellular_enter_recovery_state(struct modem_cellular_data *data)
+{
 	IF_ENABLED(CONFIG_MODEM_CELLULAR_STATS, (data->stats.recoveries += 1));
 
-	/* Release CMUX if it was attached, so the UART pipe can be reattached
-	 * cleanly on the next connect attempt. No-op when CMUX is not attached.
+	/* Bound the recovery loop: a persistent fault parks in IDLE once the
+	 * attempt budget is spent, instead of resetting forever. A zero budget
+	 * disables the cap.
 	 */
-	modem_cmux_release(&data->cmux);
-
-	if (modem_cellular_gpio_is_enabled(&config->reset_gpio) && config->reset_on_recovery) {
-		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RESET_PULSE);
-	} else if (modem_cellular_gpio_is_enabled(&config->power_gpio)) {
-		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_POWER_ON_PULSE);
-	} else {
-		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_IDLE);
+	if (CONFIG_MODEM_CELLULAR_MAX_RECOVERIES != 0 &&
+	    data->recovery_count >= CONFIG_MODEM_CELLULAR_MAX_RECOVERIES) {
+		LOG_WRN("Recovery attempts exhausted (%u), suspending", data->recovery_count);
+		data->recovery_count = 0;
+		modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_SUSPEND);
+		return;
 	}
+
+	/* Saturate rather than wrap so the backoff stays monotonic in unlimited mode. */
+	if (data->recovery_count < UINT8_MAX) {
+		data->recovery_count++;
+	}
+
+	modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_RECOVERY);
 }
 
 static void modem_cellular_run_init_script_event_handler(struct modem_cellular_data *data,
@@ -1153,6 +1211,11 @@ static void modem_cellular_connect_cmux_event_handler(struct modem_cellular_data
 		break;
 
 	case MODEM_CELLULAR_EVENT_CMUX_CONNECTED:
+		/* CMUX connected: the init/CMUX-connect fault that drives recovery has
+		 * cleared, so reset the attempt count. A sustained connect/drop flap is
+		 * not bounded by this alone; that would need a stability timer.
+		 */
+		data->recovery_count = 0;
 		modem_cellular_notify_user_pipes_connected(data);
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_OPEN_DLCI1);
 		break;
@@ -1853,6 +1916,10 @@ static int modem_cellular_on_state_enter(struct modem_cellular_data *data)
 		ret = modem_cellular_on_await_reset_state_enter(data);
 		break;
 
+	case MODEM_CELLULAR_STATE_RECOVERY:
+		ret = modem_cellular_on_recovery_state_enter(data);
+		break;
+
 	case MODEM_CELLULAR_STATE_POWER_ON_PULSE:
 		ret = modem_cellular_on_power_on_pulse_state_enter(data);
 		break;
@@ -1950,6 +2017,10 @@ static int modem_cellular_on_state_leave(struct modem_cellular_data *data)
 		ret = modem_cellular_on_await_reset_state_leave(data);
 		break;
 
+	case MODEM_CELLULAR_STATE_RECOVERY:
+		ret = modem_cellular_on_recovery_state_leave(data);
+		break;
+
 	case MODEM_CELLULAR_STATE_POWER_ON_PULSE:
 		ret = modem_cellular_on_power_on_pulse_state_leave(data);
 		break;
@@ -2039,6 +2110,10 @@ static void modem_cellular_event_handler(struct modem_cellular_data *data,
 
 	case MODEM_CELLULAR_STATE_AWAIT_RESET:
 		modem_cellular_await_reset_event_handler(data, evt);
+		break;
+
+	case MODEM_CELLULAR_STATE_RECOVERY:
+		modem_cellular_recovery_event_handler(data, evt);
 		break;
 
 	case MODEM_CELLULAR_STATE_POWER_ON_PULSE:

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -56,6 +56,7 @@ extern "C" {
  */
 enum modem_cellular_state {
 	MODEM_CELLULAR_STATE_IDLE = 0,
+	MODEM_CELLULAR_STATE_RECOVERY,
 	MODEM_CELLULAR_STATE_RESET_PULSE,
 	MODEM_CELLULAR_STATE_AWAIT_RESET,
 	MODEM_CELLULAR_STATE_POWER_ON_PULSE,
@@ -162,6 +163,7 @@ struct modem_cellular_data {
 	/** @cond INTERNAL_HIDDEN */
 	uint8_t *chat_argv[32];
 	uint8_t script_failure_counter;
+	uint8_t recovery_count;
 
 	/* Status */
 	enum cellular_registration_status registration_status_gsm;


### PR DESCRIPTION
init-script and CMUX-connect failures both enter a recovery that resets or power-cycles the modem and re-runs the full bring-up, with no attempt cap and no delay between attempts, so a persistently failing modem loops through hardware resets indefinitely, thrashing the power rails, while the per-script failure path already caps and suspends.

Adds a recovery state that backs off before resetting (delay grows per attempt, up to a ceiling) and caps consecutive attempts, suspending to idle once exhausted, matching the script-failure behavior; the counter resets when CMUX reconnects. Second commit moves the pre-existing script-failure limit to Kconfig alongside the new recovery tunables.