### PR TITLE
usb_c: prl: fix stale TCPC RX data forwarded to the Policy Engine

### DIFF
--- a/drivers/usb_c/tcpc/ucpd_stm32.c
+++ b/drivers/usb_c/tcpc/ucpd_stm32.c
@@ -1183,6 +1183,15 @@ static void ucpd_isr(const struct device *dev_inst[])
 			/* Rx message is complete, but there were bit errors */
 			LOG_ERR("ucpd: rx message error");
 		}
+
+		/*
+		 * UCPD_EVT_RX_MSG is set only for messages passed to the TCPM
+		 * layer. If it is not set, discard the buffer so its stale
+		 * bytes are not reported as a pending message.
+		 */
+		if (!atomic_test_bit(&info->evt, UCPD_EVT_RX_MSG)) {
+			*(uint32_t *)data->ucpd_rx_buffer = 0;
+		}
 	}
 	/* Check for fault conditions */
 	if (sr & UCPD_SR_RXHRSTDET) {

--- a/subsys/usb/usb_c/usbc_prl.c
+++ b/subsys/usb/usb_c/usbc_prl.c
@@ -52,6 +52,8 @@ enum prl_flags {
 	PRL_FLAGS_FIRST_MSG_PENDING = 8,
 	/* Flag to note that PRL requested to set SINK_NG CC state */
 	PRL_FLAGS_SINK_NG = 9,
+	/** Flag to note a message has been received */
+	PRL_FLAGS_RX_COMPLETE = 10,
 };
 
 /**
@@ -326,7 +328,10 @@ void prl_run(const struct device *dev)
 		 */
 		if (prl_hr_get_state(dev) == PRL_HR_WAIT_FOR_REQUEST) {
 			/* Run Protocol Layer Message Reception */
-			prl_rx_wait_for_phy_message(dev);
+			if (atomic_test_and_clear_bit(&data->prl_rx->flags,
+						      PRL_FLAGS_RX_COMPLETE)) {
+				prl_rx_wait_for_phy_message(dev);
+			}
 
 			/* Run Protocol Layer Message Tx state machine */
 			smf_run_state(SMF_CTX(prl_tx));
@@ -367,10 +372,14 @@ static void alert_handler(const struct device *tcpc, void *port_dev, enum tcpc_a
 {
 	const struct device *dev = (const struct device *)port_dev;
 	struct usbc_port_data *data = dev->data;
+	struct protocol_layer_rx_t *prl_rx = data->prl_rx;
 	struct protocol_layer_tx_t *prl_tx = data->prl_tx;
 	struct protocol_hard_reset_t *prl_hr = data->prl_hr;
 
 	switch (alert) {
+	case TCPC_ALERT_MSG_STATUS:
+		atomic_set_bit(&prl_rx->flags, PRL_FLAGS_RX_COMPLETE);
+		break;
 	case TCPC_ALERT_HARD_RESET_RECEIVED:
 		atomic_set_bit(&prl_hr->flags, PRL_FLAGS_PORT_PARTNER_HARD_RESET);
 		break;

--- a/subsys/usb/usb_c/usbc_prl.c
+++ b/subsys/usb/usb_c/usbc_prl.c
@@ -517,7 +517,7 @@ static void prl_hr_send_msg_to_phy(const struct device *dev)
 	 * Policy Engine is informed of the previous transmission. Clear the
 	 * flags so that this message can be sent.
 	 */
-	data->prl_tx->flags = ATOMIC_INIT(0);
+	atomic_clear(&data->prl_tx->flags);
 
 	/* Pass message to PHY Layer */
 	tcpc_transmit_data(tcpc, &prl_tx->emsg);
@@ -546,12 +546,12 @@ static void prl_init(const struct device *dev)
 	tcpc_set_alert_handler_cb(data->tcpc, alert_handler, (void *)dev);
 
 	/* Initialize the PRL_HR state machine */
-	prl_hr->flags = ATOMIC_INIT(0);
+	atomic_clear(&prl_hr->flags);
 	usbc_timer_init(&prl_hr->pd_t_hard_reset_complete, PD_T_HARD_RESET_COMPLETE_MAX_MS);
 	prl_hr_set_state(dev, PRL_HR_WAIT_FOR_REQUEST);
 
 	/* Initialize the PRL_TX state machine */
-	prl_tx->flags = ATOMIC_INIT(0);
+	atomic_clear(&prl_tx->flags);
 	prl_tx->last_xmit_type = PD_PACKET_SOP;
 	for (i = 0; i < NUM_SOP_STAR_TYPES; i++) {
 		prl_tx->msg_id_counter[i] = 0;
@@ -561,7 +561,7 @@ static void prl_init(const struct device *dev)
 	prl_tx_set_state(dev, PRL_TX_PHY_LAYER_RESET);
 
 	/* Initialize the PRL_RX state machine */
-	prl_rx->flags = ATOMIC_INIT(0);
+	atomic_clear(&prl_rx->flags);
 	for (i = 0; i < NUM_SOP_STAR_TYPES; i++) {
 		prl_rx->msg_id[i] = -1;
 	}
@@ -596,7 +596,7 @@ static void prl_tx_wait_for_message_request_entry(void *obj)
 	LOG_INF("PRL_Tx_Wait_for_Message_Request");
 
 	/* Clear outstanding messages */
-	prl_tx->flags = ATOMIC_INIT(0);
+	atomic_clear(&prl_tx->flags);
 }
 
 /**
@@ -979,7 +979,7 @@ static void prl_hr_wait_for_request_entry(void *obj)
 	LOG_INF("PRL_HR_Wait_for_Request");
 
 	/* Reset all Protocol Layer Hard Reset flags */
-	prl_hr->flags = ATOMIC_INIT(0);
+	atomic_clear(&prl_hr->flags);
 }
 
 /**
@@ -1021,9 +1021,9 @@ static void prl_hr_reset_layer_entry(void *obj)
 	LOG_INF("PRL_HR_Reset_Layer");
 
 	/* Reset all Protocol Layer message reception flags */
-	prl_rx->flags = ATOMIC_INIT(0);
+	atomic_clear(&prl_rx->flags);
 	/* Reset all Protocol Layer message transmission flags */
-	prl_tx->flags = ATOMIC_INIT(0);
+	atomic_clear(&prl_tx->flags);
 
 	/* Hard reset resets messageIDCounters for all TX types */
 	for (i = 0; i < NUM_SOP_STAR_TYPES; i++) {


### PR DESCRIPTION
On the USB-C subsystem, the Protocol Layer can deliver a stale or non-deliverable reception to the Policy Engine as if it were a new incoming message, corrupting PE's view of the PD exchange.

This series fixes it at both layers: the TCPC driver and the Protocol Layer as a subsys safeguard.

**Commits**

1. **usb_c: prl: use atomic_clear to reset protocol layer flags**
   The `PRL` flag fields were reset with plain stores (`flags = ATOMIC_INIT(0)`), which expands to a non-atomic store and can race with `atomic_set_bit()` calls issued from `alert_handler()` on the `TCPC` driver's workqueue thread, dropping a concurrently-set bit. Use `atomic_clear()` so the resets are race-safe. This is a pre-existing bug that the next commit makes reachable on `prl_rx->flags`, so it is fixed first.

2. **usb_c: prl: avoid unconditional poll of tcpc rx fifo**
   `prl_run()` polled `prl_rx_wait_for_phy_message()` on every cycle, including wakeups from unrelated alerts such as `TCPC_ALERT_TRANSMIT_MSG_SUCCESS`. Add `PRL_FLAGS_RX_COMPLETE`, set only when `TCPC_ALERT_MSG_STATUS` is received, and gate the RX path on it. This keeps the Policy Engine resilient regardless of a given `TCPC` driver's buffer hygiene.

3. **drivers: usb_c: tcpc: stm32: discard rx buffer for undelivered msgs**
   The STM32 `UCPD` driver cleared `ucpd_rx_buffer` only on consume, so `GoodCRC`, filtered `SOP'`/`SOP''`, `BIST`, and errored receptions left stale bytes that `ucpd_get_rx_pending_msg()` reported as pending. Discard the buffer at the end of the `RXMSGEND` handler when the message was not delivered to the `TCPM` layer. This removes the root cause for this driver.

**Testing**

Verified on `stm32g081b_eval` hardware, built and flashed with:
```
west build -b stm32g081b_eval zephyr/samples/subsys/usb_c/drp/ -p
west flash
```

The driver fix (commit 3) alone resolves the spurious-message delivery on this board. Commits 1 and 2 harden the Protocol Layer so the Policy Engine is protected against any `TCPC` driver that leaves stale RX data.

**Fixes:** #112955 

**Signed-off-by:** Nicholas Cadieux <ncadieux@qti.qualcomm.com>