### PR TITLE
soc: microchip: sama7d6: fix the config of peripheral clock for MCAN

### DIFF
--- a/soc/microchip/sam/sama7/sama7d6/soc.c
+++ b/soc/microchip/sam/sama7/sama7d6/soc.c
@@ -73,7 +73,7 @@ void relocate_vector_table(void)
 #define MCAN_CLK_INIT_DEFN(idx, n)								\
 		IF_ENABLED(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(mcan##n)),			\
 			   (PMC_REGS->PMC_PCR = PMC_PCR_PID(ID_MCAN##n);			\
-			    PMC_REGS->PMC_PCR = PMC_REGS->PMC_PCR | PMC_PCR_CMD_Msk |		\
+			    PMC_REGS->PMC_PCR = PMC_PCR_CMD_Msk |				\
 						PMC_PCR_GCLKEN_Msk | PMC_PCR_EN_Msk |		\
 						PMC_PCR_GCLKDIV(4) | PMC_PCR_GCLKCSS_MCK1 |	\
 						PMC_PCR_PID(ID_MCAN##n);))


### PR DESCRIPTION
Correct the value written to the `PMC_PCR` register when configuring the MCAN peripheral clock. Previously, incorrect `GCLKDIV` or `GCLKCSS` values might be written if the MCAN clocks had already been configured before Zephyr started.

Fixes: e79081f4443c ("soc: microchip: sama7d6: update MMU and config generic clocks for MCAN")