### PR TITLE
dts: atmel: sam0: fix samc2x flash ranges for mapped-partition

### DIFF
--- a/dts/arm/atmel/samc2x.dtsi
+++ b/dts/arm/atmel/samc2x.dtsi
@@ -69,6 +69,7 @@
 			interrupts = <6 0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			lock-regions = <16>;
 
@@ -76,6 +77,9 @@
 				compatible = "soc-nv-flash";
 
 				write-block-size = <4>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				/* reg and ranges are specified in samx2xx1x dtsi */
 			};
 		};
 


### PR DESCRIPTION
Commit 5d1241dd172 ("atmel: migrate samd21 to mapped-partition")
added a ranges property to the shared samx2xx1x dtsi files (including
samx2xx18.dtsi, used by samc21n_xpro) but only added the matching
address/size cell declarations to samd2x.dtsi, not samc2x.dtsi.

Without #address-cells/#size-cells on the samc2x flash0 node, the
devicetree tooling falls back to the spec default of #address-cells=2,
so the 3-cell ranges no longer validates against the required 4-cell
layout. This surfaces as a build error on any samc2x board that
declares a partitions child under flash0, e.g. samc21n_xpro:

  'ranges' property in flash@0 has length 12, which is not evenly
  divisible by 16 (= 4*(2 + 1 + 1))

Mirror the samd2x.dtsi fix: add ranges to the nvmctrl node and
samx2xx1x dtsi validates correctly.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
