### PR TITLE
drivers: timer: a generic tickless system-timer core

### DIFF
--- a/boards/qemu/cortex_m0/nrf_timer_timer.c
+++ b/boards/qemu/cortex_m0/nrf_timer_timer.c
@@ -162,9 +162,8 @@ void timer0_nrf_isr(void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : (dticks > 0));
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	uint32_t cyc;
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {

--- a/doc/kernel/services/timing/clocks.rst
+++ b/doc/kernel/services/timing/clocks.rst
@@ -265,6 +265,26 @@ comparatively simple API.
   :c:func:`sys_clock_announce`, which the kernel needs to test newly
   arriving timeouts for expiration.
 
+* The driver may optionally provide a :c:func:`sys_clock_unused` call.  The
+  kernel invokes it, in place of :c:func:`sys_clock_set_timeout`, when no
+  timeout is pending and :kconfig:option:`CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE`
+  allows the system uptime to drift.  A driver may use it to halt its counter
+  and stop taking interrupts until the next :c:func:`sys_clock_set_timeout`
+  resumes it.  Unlike :c:func:`sys_clock_disable`, this is a resumable pause,
+  not a teardown; the default implementation is a no-op, so a driver that does
+  nothing here simply stops being reprogrammed and quiesces on its own, and
+  sloppy idle is available to every driver without extra code.
+
+* The driver may optionally provide a :c:func:`sys_clock_idle_enter` call,
+  which the power-management path uses in place of
+  :c:func:`sys_clock_set_timeout` when the CPU is about to enter low-power
+  idle, passing the number of ticks until the next expected wakeup.  A driver
+  that can hand off to a low-power wakeup timer (or otherwise reconfigure for
+  sleep) does so here; recovery happens in :c:func:`sys_clock_idle_exit`.  The
+  default implementation just programs the wakeup through
+  :c:func:`sys_clock_set_timeout`, so a driver with no low-power handling needs
+  no implementation.
+
 Timer Driver Locking
 --------------------
 

--- a/doc/kernel/services/timing/clocks.rst
+++ b/doc/kernel/services/timing/clocks.rst
@@ -329,6 +329,28 @@ counter driver can be trivially implemented also:
   as no more than one tick can be detected as having elapsed (because
   otherwise an interrupt would have been received).
 
+Generic Tickless Core
+---------------------
+
+The per-driver work described above -- the cycle-to-tick conversion, the
+announce baseline, the tick-aligned deadline computation and the counter wrap
+and range handling -- is nearly identical across tickless drivers, and its
+small hand-rolled divergences are a recurring source of timer bugs.
+:zephyr_file:`drivers/timer/system_timer_generic.h` provides that logic once,
+as an implementation header a driver includes after defining a few cycle-domain
+primitives: a counter read plus either an absolute-compare or a relative-reload
+arming function. The header then emits :c:func:`sys_clock_set_timeout`,
+:c:func:`sys_clock_elapsed` and :c:func:`sys_clock_cycle_get_32` /
+:c:func:`sys_clock_cycle_get_64` on the driver's behalf and owns the announce
+baseline, so the driver stays in the cycle domain and never manipulates ticks
+directly. It states its counter width and, only when the counter does not run
+at the system clock rate, its frequency.
+
+New timer drivers that support tickless operation should build on this header
+rather than reimplement the tick accounting; most in-tree drivers already do.
+The header itself documents the exact set of feature macros and primitives a
+driver provides.
+
 
 SMP Details
 -----------

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -655,26 +655,45 @@ Syscon
 Timer
 =====
 
+* Tickless system-timer drivers should no longer carry their own tick handling.
+  The implementation header :file:`drivers/timer/system_timer_generic.h` now
+  owns the accounting that each driver used to reimplement by hand, and got
+  subtly wrong: the cycle-to-tick conversion, the announce baseline, the
+  tick-aligned deadline computation and the counter range clamp (including the
+  wrap handling of a narrow counter). A driver reduces to a few cycle-domain
+  primitives (a cycle-counter read plus an absolute-compare or relative-reload
+  arm) and includes the header once, which emits
+  :c:func:`sys_clock_set_timeout`, :c:func:`sys_clock_elapsed` and
+  :c:func:`sys_clock_cycle_get_32` / :c:func:`sys_clock_cycle_get_64`. Many
+  in-tree tickless drivers have been converted to it, with more to follow;
+  out-of-tree drivers, new or existing, are strongly encouraged to do the same
+  rather than track the kernel interface by hand. A driver built on the core
+  needs no action for the interface changes below, as it no longer defines
+  those entry points itself; those notes apply only to the residual cases
+  where the hardware genuinely cannot be expressed through the core.
+
 * :c:func:`sys_clock_set_timeout`, :c:func:`sys_clock_announce` and
   :c:func:`sys_clock_announce_locked` now take their tick count as an unsigned
-  ``uint32_t`` rather than a signed ``int32_t``. Out-of-tree system timer drivers must
-  update their :c:func:`sys_clock_set_timeout` definition accordingly, otherwise the build
-  fails with a conflicting-types error. The kernel now also caps the requested timeout at
-  ``SYS_CLOCK_MAX_WAIT`` and no longer passes ``K_TICKS_FOREVER`` to the driver, so such
-  drivers no longer need to clamp the request against the :c:func:`sys_clock_announce`
-  range or special-case ``K_TICKS_FOREVER``; only their own hardware cycle-count limits
-  still need enforcing (:github:`111022`).
+  ``uint32_t`` rather than a signed ``int32_t``. An out-of-tree system timer driver
+  that keeps its own :c:func:`sys_clock_set_timeout` must update the definition
+  accordingly, otherwise the build fails with a conflicting-types error. The kernel
+  now also caps the requested timeout at ``SYS_CLOCK_MAX_WAIT`` and no longer passes
+  ``K_TICKS_FOREVER`` to the driver, so such drivers no longer need to clamp the
+  request against the :c:func:`sys_clock_announce` range or special-case
+  ``K_TICKS_FOREVER``; only their own hardware cycle-count limits still need
+  enforcing (:github:`111022`).
 
 * Under ``CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE``, the kernel now calls the new weak
   :c:func:`sys_clock_unused` hook when no timeout is pending, rather than passing
-  ``SYS_CLOCK_MAX_WAIT`` to :c:func:`sys_clock_set_timeout`. An out-of-tree timer driver that
-  stopped its counter on ``ticks == SYS_CLOCK_MAX_WAIT`` must do so in a
-  :c:func:`sys_clock_unused` implementation instead (:github:`112750`).
+  ``SYS_CLOCK_MAX_WAIT`` to :c:func:`sys_clock_set_timeout`. An out-of-tree timer driver
+  with its own implementation that stopped its counter on ``ticks == SYS_CLOCK_MAX_WAIT``
+  must do so in a :c:func:`sys_clock_unused` implementation instead (:github:`112750`).
 
 * :c:func:`sys_clock_set_timeout` no longer takes a ``bool idle`` argument; the low-power
-  idle hint moved to the new weak :c:func:`sys_clock_idle_enter` hook. Out-of-tree timer
-  drivers must drop the parameter from their :c:func:`sys_clock_set_timeout` definition and
-  move any ``idle``-specific handling to :c:func:`sys_clock_idle_enter` (:github:`112750`).
+  idle hint moved to the new weak :c:func:`sys_clock_idle_enter` hook. An out-of-tree timer
+  driver with its own implementation must drop the parameter from its
+  :c:func:`sys_clock_set_timeout` definition and move any ``idle``-specific handling to
+  :c:func:`sys_clock_idle_enter` (:github:`112750`).
 
 USB
 ===

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -665,6 +665,17 @@ Timer
   range or special-case ``K_TICKS_FOREVER``; only their own hardware cycle-count limits
   still need enforcing (:github:`111022`).
 
+* Under ``CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE``, the kernel now calls the new weak
+  :c:func:`sys_clock_unused` hook when no timeout is pending, rather than passing
+  ``SYS_CLOCK_MAX_WAIT`` to :c:func:`sys_clock_set_timeout`. An out-of-tree timer driver that
+  stopped its counter on ``ticks == SYS_CLOCK_MAX_WAIT`` must do so in a
+  :c:func:`sys_clock_unused` implementation instead (:github:`112750`).
+
+* :c:func:`sys_clock_set_timeout` no longer takes a ``bool idle`` argument; the low-power
+  idle hint moved to the new weak :c:func:`sys_clock_idle_enter` hook. Out-of-tree timer
+  drivers must drop the parameter from their :c:func:`sys_clock_set_timeout` definition and
+  move any ``idle``-specific handling to :c:func:`sys_clock_idle_enter` (:github:`112750`).
+
 USB
 ===
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -389,6 +389,17 @@ Other notable changes
     failure.  Use :c:func:`k_thread_cpu_pin` to reassign a thread to a
     different CPU.
 
+* Timer
+
+  * Tickless system-timer drivers can now be built on a shared implementation
+    header, :file:`drivers/timer/system_timer_generic.h`, which owns the tick
+    accounting each driver previously open-coded (and occasionally got wrong):
+    the cycle-to-tick conversion, the announce baseline, the tick-aligned
+    deadline and the counter wrap and range handling. A driver reduces to a few
+    cycle-domain primitives, a cycle-counter read plus an absolute-compare or
+    relative-reload arm. Many in-tree drivers have been converted, with more to
+    follow; see the :ref:`migration guide <migration_4.5>` for how to use it.
+
 * Wi-Fi
 
   * Removed the ``samples/net/wifi/test_certs/rsa2k`` enterprise test

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -44,8 +44,9 @@ config SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE
 config SYSTEM_CLOCK_SLOPPY_IDLE
 	bool "Timer allowed to skew uptime clock during idle"
 	help
-	  When true, the timer driver is not required to maintain a
-	  correct system uptime count when the system enters idle.
+	  When true, the kernel may let the system uptime count drift while
+	  there are no pending timeouts, rather than keep waking the CPU to
+	  maintain it.
 	  Some platforms may take advantage of this to reduce the
 	  overhead from regular interrupts required to handle counter
 	  wraparound conditions.

--- a/drivers/timer/ambiq_stimer.c
+++ b/drivers/timer/ambiq_stimer.c
@@ -137,9 +137,8 @@ void stimer_isr(const void *arg)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -131,9 +131,8 @@ static void isr(const void *arg)
 	sys_clock_announce_locked(delta_ticks, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -46,24 +46,6 @@ BUILD_ASSERT((!IS_ENABLED(CONFIG_APIC_TIMER_TSC) &&
 #define IA32_TSC_DEADLINE_MSR 0x6e0
 #define IA32_TSC_ADJUST_MSR   0x03b
 
-#define CYC_PER_TICK (uint32_t)(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC \
-				/ CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-
-/* the unsigned long cast limits divisors to native CPU register width */
-#define cycle_diff_t unsigned long
-#define CYCLE_DIFF_MAX (~(cycle_diff_t)0)
-
-/*
- * Maximum number of cycles to wait between two sys_clock_announce() reports:
- * the elapsed cycle count must fit in a cycle_diff_t before it is divided down
- * to ticks. Reserve 1/4 of the range as headroom for the unavoidable IRQ
- * servicing latency so a late report still fits, then add the LSB so the value
- * clears a run of low set bits for a nicer literal in the generated assembly.
- */
-#define CYCLES_MAX_1	((uint64_t)CYCLE_DIFF_MAX)
-#define CYCLES_MAX_2	(CYCLES_MAX_1 / 2 + CYCLES_MAX_1 / 4)
-#define CYCLES_MAX	(CYCLES_MAX_2 + LSB_GET(CYCLES_MAX_2))
-
 struct apic_timer_lvt {
 	uint8_t vector   : 8;
 	uint8_t unused0  : 8;
@@ -72,9 +54,6 @@ struct apic_timer_lvt {
 	uint32_t unused2 : 13;
 };
 
-static uint64_t last_cycle;
-static uint64_t last_tick;
-static uint32_t last_elapsed;
 static union { uint32_t val; struct apic_timer_lvt lvt; } lvt_reg;
 
 static ALWAYS_INLINE uint64_t rdtsc(void)
@@ -109,82 +88,32 @@ static void set_trigger(uint64_t deadline)
 	}
 }
 
+/*
+ * Free-running 64-bit TSC plus an absolute deadline (the TSC_DEADLINE MSR, or
+ * the local APIC timer ICR in one-shot mode as a fallback): a COMPARE backend.
+ * The core owns the tick accounting; the driver reads the counter and arms the
+ * deadline.
+ */
+#define TIMER_CORE_BACKEND_COMPARE
+#define TIMER_CORE_64BIT_CYCLES
+
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return rdtsc();
+}
+
+static inline void timer_driver_set_compare(uint64_t cycles)
+{
+	set_trigger(cycles);
+}
+
+#include "system_timer_generic.h"
+
 static void isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	k_spinlock_key_t key = sys_clock_lock();
-	uint64_t curr_cycle = rdtsc();
-	uint64_t delta_cycles = curr_cycle - last_cycle;
-	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
-
-	last_cycle += (cycle_diff_t)delta_ticks * CYC_PER_TICK;
-	last_tick += delta_ticks;
-	last_elapsed = 0;
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		uint64_t next_cycle = last_cycle + CYC_PER_TICK;
-
-		set_trigger(next_cycle);
-	}
-
-	sys_clock_announce_locked(delta_ticks, key);
-}
-
-void sys_clock_set_timeout(uint32_t ticks)
-{
-
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	uint64_t next_cycle;
-
-	next_cycle = (last_tick + last_elapsed + ticks) * CYC_PER_TICK;
-	if ((next_cycle - last_cycle) > CYCLES_MAX) {
-		next_cycle = last_cycle + CYCLES_MAX;
-	}
-
-	/*
-	 * Interpreted strictly, the IA SDM description of the
-	 * TSC_DEADLINE MSR implies that it will trigger an immediate
-	 * interrupt if we try to set an expiration across the 64 bit
-	 * rollover.  Unfortunately there's no way to test that as on
-	 * real hardware it requires more than a century of uptime,
-	 * but this is cheap and safe.
-	 */
-	if (next_cycle < last_cycle) {
-		next_cycle = UINT64_MAX;
-	}
-	set_trigger(next_cycle);
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	uint64_t curr_cycle = rdtsc();
-	uint64_t delta_cycles = curr_cycle - last_cycle;
-	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
-
-	last_elapsed = delta_ticks;
-	return delta_ticks;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	return (uint32_t) rdtsc();
-}
-
-uint64_t sys_clock_cycle_get_64(void)
-{
-	return rdtsc();
+	timer_core_announce();
 }
 
 static inline uint32_t timer_irq(void)
@@ -285,11 +214,8 @@ static int sys_clock_driver_init(void)
 	 */
 	__asm__ volatile("mfence" ::: "memory");
 
-	last_tick = rdtsc() / CYC_PER_TICK;
-	last_cycle = last_tick * CYC_PER_TICK;
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		set_trigger(last_cycle + CYC_PER_TICK);
-	}
+	/* Seed the announce baseline from the TSC and arm the first tick. */
+	timer_core_init();
 	irq_enable(timer_irq());
 
 	return 0;

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -256,26 +256,24 @@ static void timer_int_handler(const void *unused)
 
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_unused(void)
 {
-	/* If the kernel allows us to miss tick announcements in idle,
-	 * then shut off the counter. (Note: we can assume if idle==true
-	 * that interrupts are already disabled)
-	 */
-#if SMP_TIMER_DRIVER
-	/* as 64-bits GFRC is used as wall clock, it's ok to ignore idle
-	 * systick will not be missed.
-	 * However for single core using 32-bits arc timer, idle cannot
-	 * be ignored, as 32-bits timer will overflow in a not-long time.
-	 */
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
-	    ticks == SYS_CLOCK_MAX_WAIT) {
-		timer0_control_register_set(0);
-		timer0_count_register_set(0);
-		timer0_limit_register_set(0);
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
 
+	/* No timeout pending under sloppy idle: shut the counter off. */
+	timer0_control_register_set(0);
+	timer0_count_register_set(0);
+	timer0_limit_register_set(0);
+#if !SMP_TIMER_DRIVER
+	last_load = TIMER_STOPPED;
+#endif
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+#if SMP_TIMER_DRIVER
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint32_t delay;
 	uint32_t key;
@@ -299,15 +297,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	arch_irq_unlock(key);
 #endif
 #else
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
-	    ticks == SYS_CLOCK_MAX_WAIT) {
-		timer0_control_register_set(0);
-		timer0_count_register_set(0);
-		timer0_limit_register_set(0);
-		last_load = TIMER_STOPPED;
-		return;
-	}
-
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint32_t delay;
 	uint32_t unannounced;

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -271,7 +271,7 @@ void sys_clock_unused(void)
 #endif
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 #if SMP_TIMER_DRIVER
 #if defined(CONFIG_TICKLESS_KERNEL)

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -45,11 +45,11 @@
  */
 #define COUNTER_MAX 0x7fffffff
 #define TIMER_STOPPED 0x0
-#define CYC_PER_TICK (sys_clock_hw_cycles_per_sec()	\
+#define TIMER_CORE_CYC_PER_TICK (sys_clock_hw_cycles_per_sec()	\
 		      / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 
-#define MAX_TICKS ((COUNTER_MAX / CYC_PER_TICK) - 1)
-#define MAX_CYCLES (MAX_TICKS * CYC_PER_TICK)
+#define MAX_TICKS ((COUNTER_MAX / TIMER_CORE_CYC_PER_TICK) - 1)
+#define MAX_CYCLES (MAX_TICKS * TIMER_CORE_CYC_PER_TICK)
 
 #define TICKLESS (IS_ENABLED(CONFIG_TICKLESS_KERNEL))
 
@@ -80,13 +80,6 @@ static uint32_t last_load;
  * t = cycle_counter + elapsed();
  */
 static uint32_t cycle_count;
-
-/*
- * This local variable holds the amount of elapsed HW cycles
- * that have been announced to the kernel.
- */
-static uint32_t announced_cycles;
-
 
 /*
  * This local variable holds the amount of elapsed HW cycles due to
@@ -199,6 +192,35 @@ static uint32_t elapsed(void)
 
 	return val + overflow_cycles;
 }
+
+/*
+ * Compare-match-reset up-counter (counts 0..LIMIT, resets on match): a RELOAD
+ * backend. elapsed() is already wrap-aware (it folds a pending overflow in via
+ * the IP bit), so the synthesized count stays monotonic. The generic core owns
+ * the tick accounting, deadline-to-reload conversion, clamp and announce.
+ */
+#define TIMER_CORE_BACKEND_RELOAD
+#define TIMER_CORE_MIN_DELAY MIN_DELAY
+#define TIMER_CORE_CYCLES_MAX MAX_CYCLES
+#define TIMER_CORE_HAVE_CYCLE_GET_32
+
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return cycle_count + elapsed();
+}
+
+static void timer_driver_set_reload(uint32_t rel)
+{
+	cycle_count += elapsed();
+	/* Clear COUNT early to lose as few cycles as possible before the reload. */
+	timer0_count_register_set(0);
+	overflow_cycles = 0U;
+	last_load = rel;
+	timer0_limit_register_set(rel - 1);
+	timer0_control_register_set(_ARC_V2_TMR_CTRL_NH | _ARC_V2_TMR_CTRL_IE);
+}
+
+#include "system_timer_generic.h"
 #endif
 
 /**
@@ -211,9 +233,9 @@ static uint32_t elapsed(void)
 static void timer_int_handler(const void *unused)
 {
 	ARG_UNUSED(unused);
-	uint32_t dticks;
 
 #if defined(CONFIG_SMP) && CONFIG_MP_MAX_NUM_CPUS > 1
+	uint32_t dticks;
 	uint64_t curr_time;
 	k_spinlock_key_t key;
 
@@ -224,24 +246,20 @@ static void timer_int_handler(const void *unused)
 	/* gfrc is the wall clock */
 	curr_time = z_arc_connect_gfrc_read();
 
-	dticks = (curr_time - last_time) / CYC_PER_TICK;
+	dticks = (curr_time - last_time) / TIMER_CORE_CYC_PER_TICK;
 	/* last_time should be aligned to ticks */
-	last_time += dticks * CYC_PER_TICK;
+	last_time += dticks * TIMER_CORE_CYC_PER_TICK;
 
 	k_spin_unlock(&lock, key);
 
 	sys_clock_announce(dticks);
 #else
-	/* timer_int_handler may be triggered by timer irq or
-	 * software helper irq
+	/* timer_int_handler may be triggered by timer irq or software helper
+	 * irq. Commit the wrap that fired it (irq_lock keeps that atomic against
+	 * a higher-priority set_timeout); timer_core_announce() then reads the
+	 * counter and does the tick accounting.
 	 */
-
-	/* irq with higher priority may call sys_clock_set_timeout
-	 * so need a lock here
-	 */
-	uint32_t key;
-
-	key = arch_irq_lock();
+	uint32_t key = arch_irq_lock();
 
 	elapsed();
 	cycle_count += overflow_cycles;
@@ -249,9 +267,7 @@ static void timer_int_handler(const void *unused)
 
 	arch_irq_unlock(key);
 
-	dticks = (cycle_count - announced_cycles) / CYC_PER_TICK;
-	announced_cycles += dticks * CYC_PER_TICK;
-	sys_clock_announce(TICKLESS ? dticks : 1);
+	timer_core_announce();
 #endif
 
 }
@@ -271,9 +287,9 @@ void sys_clock_unused(void)
 #endif
 }
 
+#if SMP_TIMER_DRIVER
 void sys_clock_set_timeout(uint32_t ticks)
 {
-#if SMP_TIMER_DRIVER
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint32_t delay;
 	uint32_t key;
@@ -282,10 +298,10 @@ void sys_clock_set_timeout(uint32_t ticks)
 
 	/* Desired delay in the future
 	 * use MIN_DEALY here can trigger the timer
-	 * irq more soon, no need to go to CYC_PER_TICK
+	 * irq more soon, no need to go to TIMER_CORE_CYC_PER_TICK
 	 * later.
 	 */
-	delay = MAX(ticks * CYC_PER_TICK, MIN_DELAY);
+	delay = MAX(ticks * TIMER_CORE_CYC_PER_TICK, MIN_DELAY);
 
 	key = arch_irq_lock();
 
@@ -296,58 +312,10 @@ void sys_clock_set_timeout(uint32_t ticks)
 
 	arch_irq_unlock(key);
 #endif
-#else
-#if defined(CONFIG_TICKLESS_KERNEL)
-	uint32_t delay;
-	uint32_t unannounced;
-
-	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-
-	cycle_count += elapsed();
-	/* clear counter early to avoid cycle loss as few as possible,
-	 * between cycle_count and clearing 0, few cycles are possible
-	 * to loss
-	 */
-	timer0_count_register_set(0);
-	overflow_cycles = 0U;
-
-
-	/* normal case */
-	unannounced = cycle_count - announced_cycles;
-
-	if ((int32_t)unannounced < 0) {
-		/* We haven't announced for more than half the 32-bit
-		 * wrap duration, because new timeouts keep being set
-		 * before the existing one fires. Force an announce
-		 * to avoid loss of a wrap event, making sure the
-		 * delay is at least the minimum delay possible.
-		 */
-		last_load = MIN_DELAY;
-	} else {
-		/* Desired delay in the future */
-		delay = ticks * CYC_PER_TICK;
-
-		/* Round delay up to next tick boundary */
-		delay += unannounced;
-		delay = DIV_ROUND_UP(delay, CYC_PER_TICK) * CYC_PER_TICK;
-
-		delay -= unannounced;
-		delay = MAX(delay, MIN_DELAY);
-
-		last_load = MIN(delay, MAX_CYCLES);
-	}
-
-	timer0_limit_register_set(last_load - 1);
-	timer0_control_register_set(_ARC_V2_TMR_CTRL_NH | _ARC_V2_TMR_CTRL_IE);
-
-	k_spin_unlock(&lock, key);
-#endif
-#endif
 }
+#endif /* SMP_TIMER_DRIVER (non-SMP sys_clock_set_timeout comes from the core) */
 
+#if SMP_TIMER_DRIVER
 uint32_t sys_clock_elapsed(void)
 {
 	if (!TICKLESS) {
@@ -357,16 +325,13 @@ uint32_t sys_clock_elapsed(void)
 	uint32_t cyc;
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-#if SMP_TIMER_DRIVER
 	cyc = (z_arc_connect_gfrc_read() - last_time);
-#else
-	cyc =  elapsed() + cycle_count - announced_cycles;
-#endif
 
 	k_spin_unlock(&lock, key);
 
-	return cyc / CYC_PER_TICK;
+	return cyc / TIMER_CORE_CYC_PER_TICK;
 }
+#endif /* SMP_TIMER_DRIVER (non-SMP sys_clock_elapsed comes from the core) */
 
 uint32_t sys_clock_cycle_get_32(void)
 {
@@ -400,7 +365,7 @@ void smp_timer_init(void)
  * @brief Initialize and enable the system clock
  *
  * This routine is used to program the ARCv2 timer to deliver interrupts at the
- * rate specified via the CYC_PER_TICK.
+ * rate specified via the TIMER_CORE_CYC_PER_TICK.
  *
  * @return 0
  */
@@ -414,25 +379,38 @@ static int sys_clock_driver_init(void)
 	IRQ_CONNECT(IRQ_TIMER0, CONFIG_ARCV2_TIMER_IRQ_PRIORITY,
 		    timer_int_handler, NULL, 0);
 
-	timer0_limit_register_set(CYC_PER_TICK - 1);
+	timer0_limit_register_set(TIMER_CORE_CYC_PER_TICK - 1);
 	last_time = z_arc_connect_gfrc_read();
 	start_time = last_time;
-#else
-	last_load = CYC_PER_TICK;
-	overflow_cycles = 0;
-	announced_cycles = 0;
-
-	IRQ_CONNECT(IRQ_TIMER0, CONFIG_ARCV2_TIMER_IRQ_PRIORITY,
-		    timer_int_handler, NULL, 0);
-
-	timer0_limit_register_set(last_load - 1);
-#endif
 	timer0_count_register_set(0);
 	timer0_control_register_set(_ARC_V2_TMR_CTRL_NH | _ARC_V2_TMR_CTRL_IE);
 
 	/* everything has been configured: safe to enable the interrupt */
 
 	irq_enable(IRQ_TIMER0);
+#else
+	last_load = TIMER_CORE_CYC_PER_TICK;
+	overflow_cycles = 0;
+
+	IRQ_CONNECT(IRQ_TIMER0, CONFIG_ARCV2_TIMER_IRQ_PRIORITY,
+		    timer_int_handler, NULL, 0);
+
+	/* Seed the core baseline; in tickless mode this also arms the first tick
+	 * (sets LIMIT/COUNT/CTRL).
+	 */
+	timer_core_init();
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/* Timer0 auto-reloads: it resets COUNT to 0 on reaching LIMIT. Set
+		 * it to fire every tick; the core never reprograms it.
+		 */
+		timer0_count_register_set(0);
+		timer0_limit_register_set(TIMER_CORE_CYC_PER_TICK - 1);
+		timer0_control_register_set(_ARC_V2_TMR_CTRL_NH | _ARC_V2_TMR_CTRL_IE);
+	}
+
+	irq_enable(IRQ_TIMER0);
+#endif
 
 	return 0;
 }

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -112,7 +112,7 @@ static void arm_arch_timer_compare_isr(const void *arg)
 	sys_clock_announce_locked(delta_ticks, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -10,48 +10,36 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/arch/cpu.h>
 
-#ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
-/* precompute CYC_PER_TICK at driver init to avoid runtime double divisions */
-static uint32_t cyc_per_tick;
-#define CYC_PER_TICK cyc_per_tick
-#else
-#define CYC_PER_TICK (uint32_t)(sys_clock_hw_cycles_per_sec() \
-				/ CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#endif
-
-#if defined(CONFIG_GDBSTUB)
-/* When interactively debugging, the cycle diff can overflow 32-bit variable */
-#define cycle_diff_t uint64_t
-#else
-/* the unsigned long cast limits divisors to native CPU register width */
-#define cycle_diff_t unsigned long
-#endif
-#define CYCLE_DIFF_MAX (~(cycle_diff_t)0)
-
-/*
- * Maximum number of cycles to wait between two sys_clock_announce() reports:
- * the elapsed cycle count must fit in a cycle_diff_t before it is divided down
- * to ticks. Reserve 1/4 of the range as headroom for the unavoidable IRQ
- * servicing latency so a late report still fits, then add the LSB so the value
- * clears a run of low set bits for a nicer literal in the generated assembly.
- */
-#define CYCLES_MAX_1	((uint64_t)CYCLE_DIFF_MAX)
-#define CYCLES_MAX_2	(CYCLES_MAX_1 / 2 + CYCLES_MAX_1 / 4)
-#define CYCLES_MAX	(CYCLES_MAX_2 + LSB_GET(CYCLES_MAX_2))
-
-static uint64_t last_cycle;
-static uint64_t last_tick;
-static uint32_t last_elapsed;
-
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = ARM_ARCH_TIMER_IRQ;
 #endif
 
+/*
+ * Free-running system counter plus an absolute compare register: a COMPARE
+ * backend. The generic core owns the tick accounting; this driver reads the
+ * counter and arms (and, on ARM, unmasks) the comparator. The system counter
+ * is 64-bit wide.
+ */
+#define TIMER_CORE_BACKEND_COMPARE
+#define TIMER_CORE_64BIT_CYCLES
+#define TIMER_CORE_CYCLES_WIDTH 64
+
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return arm_arch_timer_count();
+}
+
+static inline void timer_driver_set_compare(uint64_t cycles)
+{
+	arm_arch_timer_set_compare(cycles);
+	arm_arch_timer_set_irq_mask(false);
+}
+
+#include "system_timer_generic.h"
+
 static void arm_arch_timer_compare_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
-
-	k_spinlock_key_t key = sys_clock_lock();
 
 #ifdef CONFIG_ARM_ARCH_TIMER_ERRATUM_740657
 	/*
@@ -66,25 +54,16 @@ static void arm_arch_timer_compare_isr(const void *arg)
 		 * DO NOT modify the compare register's value, DO NOT announce
 		 * elapsed ticks!
 		 */
-		sys_clock_unlock(key);
 		return;
 	}
 #endif /* CONFIG_ARM_ARCH_TIMER_ERRATUM_740657 */
 
-	uint64_t curr_cycle = arm_arch_timer_count();
-	uint64_t delta_cycles = curr_cycle - last_cycle;
-	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
-
-	last_cycle += (cycle_diff_t)delta_ticks * CYC_PER_TICK;
-	last_tick += delta_ticks;
-	last_elapsed = 0;
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		uint64_t next_cycle = last_cycle + CYC_PER_TICK;
-
-		arm_arch_timer_set_compare(next_cycle);
-		arm_arch_timer_set_irq_mask(false);
-	} else {
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/*
+		 * The compare stays asserted until it is reprogrammed, so mask
+		 * the interrupt now. timer_driver_set_compare() unmasks it when the
+		 * timer is rearmed after the announce.
+		 */
 		arm_arch_timer_set_irq_mask(true);
 #ifdef CONFIG_ARM_ARCH_TIMER_ERRATUM_740657
 		/*
@@ -95,8 +74,10 @@ static void arm_arch_timer_compare_isr(const void *arg)
 		 * by the handling interrupt controller.
 		 */
 		arm_arch_timer_set_compare(~0ULL);
+#endif /* CONFIG_ARM_ARCH_TIMER_ERRATUM_740657 */
 	}
 
+#ifdef CONFIG_ARM_ARCH_TIMER_ERRATUM_740657
 	/*
 	 * Clear the event flag so that in case the erratum strikes (the timer's
 	 * vector will still be indicated as pending by the GIC's pending register
@@ -105,55 +86,9 @@ static void arm_arch_timer_compare_isr(const void *arg)
 	 * therefore, no actual hardware interrupt has occurred.
 	 */
 	arm_arch_timer_clear_int_status();
-#else
-	}
 #endif /* CONFIG_ARM_ARCH_TIMER_ERRATUM_740657 */
 
-	sys_clock_announce_locked(delta_ticks, key);
-}
-
-void sys_clock_set_timeout(uint32_t ticks)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	uint64_t next_cycle = (last_tick + last_elapsed + ticks) * CYC_PER_TICK;
-
-	if ((next_cycle - last_cycle) > CYCLES_MAX) {
-		next_cycle = last_cycle + CYCLES_MAX;
-	}
-
-	arm_arch_timer_set_compare(next_cycle);
-	arm_arch_timer_set_irq_mask(false);
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	uint64_t curr_cycle = arm_arch_timer_count();
-	uint64_t delta_cycles = curr_cycle - last_cycle;
-	uint32_t delta_ticks = (cycle_diff_t)delta_cycles / CYC_PER_TICK;
-
-	last_elapsed = delta_ticks;
-	return delta_ticks;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	return (uint32_t)arm_arch_timer_count();
-}
-
-uint64_t sys_clock_cycle_get_64(void)
-{
-	return arm_arch_timer_count();
+	timer_core_announce();
 }
 
 #ifdef CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT
@@ -194,10 +129,9 @@ void smp_timer_init(void)
 	/*
 	 * set the initial status of timer0 of each secondary core
 	 */
-	arm_arch_timer_set_compare(last_cycle + CYC_PER_TICK);
+	timer_core_smp_prime();
 	arm_arch_timer_enable(true);
 	irq_enable(ARM_ARCH_TIMER_IRQ);
-	arm_arch_timer_set_irq_mask(false);
 }
 #endif
 
@@ -207,15 +141,9 @@ static int sys_clock_driver_init(void)
 	IRQ_CONNECT(ARM_ARCH_TIMER_IRQ, ARM_ARCH_TIMER_PRIO,
 		    arm_arch_timer_compare_isr, NULL, ARM_ARCH_TIMER_FLAGS);
 	arm_arch_timer_init();
-#ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
-	cyc_per_tick = sys_clock_hw_cycles_per_sec() / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-#endif
-	last_tick = arm_arch_timer_count() / CYC_PER_TICK;
-	last_cycle = last_tick * CYC_PER_TICK;
-	arm_arch_timer_set_compare(last_cycle + CYC_PER_TICK);
+	timer_core_init();
 	arm_arch_timer_enable(true);
 	irq_enable(ARM_ARCH_TIMER_IRQ);
-	arm_arch_timer_set_irq_mask(false);
 
 	return 0;
 }

--- a/drivers/timer/cc13xx_cc26xx_rtc_timer.c
+++ b/drivers/timer/cc13xx_cc26xx_rtc_timer.c
@@ -187,9 +187,8 @@ static void startDevice(void)
 	irq_unlock(key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 #ifdef CONFIG_TICKLESS_KERNEL
 

--- a/drivers/timer/cc23x0_rtc_timer.c
+++ b/drivers/timer/cc23x0_rtc_timer.c
@@ -31,9 +31,8 @@ static uint32_t last_rtc_count;
 
 #define TICK_PERIOD_MICRO_SEC (1000000 / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	/* Get current value as early as possible */
 	uint32_t ticks_now = HWREG(RTC_BASE + RTC_O_TIME8U);

--- a/drivers/timer/cc23x0_systim_timer.c
+++ b/drivers/timer/cc23x0_systim_timer.c
@@ -52,9 +52,8 @@ static int sys_clock_driver_init(void);
 /*
  * Set system clock timeout.
  */
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	/* Get current value as early as possible */
 	uint32_t now_tick = HWREG(SYSTIM_BASE + SYSTIM_O_TIME1U);

--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -70,6 +70,36 @@ static uint32_t elapsed(uint32_t *val_out)
 	return data->load - value;
 }
 
+/* Elapsed cycles since the last reload, including a wrap that fired but has not
+ * yet been accounted by the ISR.
+ *
+ * elapsed() above returns only the in-period offset (load - value). Between a
+ * wrap (the counter reloads) and the ISR crediting that period to cycle_count,
+ * that offset drops back near zero, so cycle_count + elapsed() briefly goes
+ * backwards. It is a race under real time but is hit deterministically under
+ * QEMU icount, and a non-monotonic hardware cycle counter breaks k_busy_wait()
+ * and the tick accounting.
+ *
+ * Detect the pending wrap the way the SysTick driver does: sample the value
+ * either side of the interrupt-status flag and add a full period if the flag is
+ * set or the counter was seen reloading (v1 < v2). This is added to the
+ * returned value only; the ISR commits the period into cycle_count and clears
+ * the flag, so it is never counted twice. Kept separate from elapsed() so
+ * sys_clock_set_timeout()'s reprogramming still works on the raw offset.
+ */
+static uint32_t elapsed_monotonic(void)
+{
+	const struct tmr_cmsdk_apb_cfg *const cfg = &cfg_inst0;
+	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
+
+	uint32_t v1 = cfg->timer->value;
+	uint32_t wrapped = cfg->timer->intstatus & TIMER_CTRL_INT_CLEAR;
+	uint32_t v2 = cfg->timer->value;
+	uint32_t pending = (wrapped || (v1 < v2)) ? data->load : 0;
+
+	return (data->load - v2) + pending;
+}
+
 void sys_clock_unused(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
@@ -151,7 +181,7 @@ uint32_t sys_clock_elapsed(void)
 
 	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
 	uint32_t unannounced = data->cycle_count - data->announced_cycles;
-	uint32_t cycles = elapsed(NULL) + unannounced;
+	uint32_t cycles = elapsed_monotonic() + unannounced;
 	uint32_t ret = cycles / CYC_PER_TICK;
 
 	data->last_elapsed = ret;
@@ -162,7 +192,7 @@ uint32_t sys_clock_cycle_get_32(void)
 {
 	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
 	k_spinlock_key_t key = sys_clock_lock();
-	uint32_t cycles = data->cycle_count + elapsed(NULL);
+	uint32_t cycles = data->cycle_count + elapsed_monotonic();
 
 	sys_clock_unlock(key);
 

--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -70,6 +70,30 @@ static uint32_t elapsed(uint32_t *val_out)
 	return data->load - value;
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	const struct tmr_cmsdk_apb_cfg *const cfg = &cfg_inst0;
+
+	/* No pending timeout: reload the counter with the maximum interval so
+	 * the hardware waits as long as it can before the next interrupt.
+	 *
+	 * This is an auto-reload down-counter, not a free-running compare, so
+	 * it cannot simply stop reprogramming the way the compare timers do:
+	 * that would keep firing at the previous, possibly short, interval.
+	 * Programming the maximum reload matches what non-sloppy idle already
+	 * does via next_timeout(). Stopping the counter here (clearing
+	 * TIMER_CTRL_EN and re-enabling it in sys_clock_set_timeout()) would
+	 * avoid the wakeup entirely; that is left out for now to avoid a
+	 * riskier change to the cycle accounting.
+	 */
+	cfg->timer->reload = MAX_CYC;
+	cfg->timer->value = MAX_CYC;
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
@@ -94,13 +118,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	data->cycle_count += pending_cycles;
 	unannounced_cycles = data->cycle_count - data->announced_cycles;
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * No pending timeout and no future timer interrupt required:
-		 * wait as long as the hardware allows.
-		 */
-		load_to_be_set = MAX_CYC;
-	} else if ((int32_t)unannounced_cycles < 0) {
+	if ((int32_t)unannounced_cycles < 0) {
 		load_to_be_set = MIN_DELAY_CYCLES;
 	} else {
 		int64_t want = ((uint64_t)data->last_elapsed + ticks) * CYC_PER_TICK;

--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -30,11 +30,32 @@ BUILD_ASSERT(DT_NODE_HAS_COMPAT(TIMER_NODE, arm_cmsdk_timer),
 		    (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
 #define MAX_CYC UINT32_MAX
 
+/* Minimum reload the driver will program: the closest-in timeout it can
+ * schedule. It must exceed the longest the timer interrupt can stay masked, or
+ * the counter wraps more than once between elapsed_cyc()'s reads and a period
+ * is lost. That is a wall-clock property, so derive it from a fixed time
+ * (converted to cycles at the counter rate, at init) rather than a fixed cycle
+ * count, which is a different wall-clock time on every clock. The
+ * CMSDK_APB_TIMER_MIN_DELAY_OVERRIDE Kconfig still takes precedence, and a
+ * two-cycle hardware floor keeps the reload from being degenerate on a slow
+ * clock where the time budget rounds below it.
+ */
+#define CMSDK_MIN_DELAY_US 10U
+
+static inline uint32_t cmsdk_min_delay(void)
+{
 #ifdef CONFIG_CMSDK_APB_TIMER_MIN_DELAY_OVERRIDE
-#define MIN_DELAY_CYCLES CONFIG_CMSDK_APB_TIMER_MIN_DELAY_CYCLES
+	uint32_t cyc = CONFIG_CMSDK_APB_TIMER_MIN_DELAY_CYCLES;
 #else
-#define MIN_DELAY_CYCLES MAX(1024U, ((uint32_t)(CYC_PER_TICK / 16U)))
+	uint32_t cyc = k_us_to_cyc_ceil32(CMSDK_MIN_DELAY_US);
 #endif
+	return MAX(2U, cyc);
+}
+
+/* Minimum reload, derived from the cycle rate in sys_clock_driver_init(). See
+ * cmsdk_min_delay().
+ */
+static uint32_t min_delay;
 
 typedef uint32_t cycle_t;
 
@@ -148,12 +169,12 @@ void sys_clock_set_timeout(uint32_t ticks)
 	unannounced_cycles = data->cycle_count - data->announced_cycles;
 
 	if ((int32_t)unannounced_cycles < 0) {
-		load_to_be_set = MIN_DELAY_CYCLES;
+		load_to_be_set = min_delay;
 	} else {
 		int64_t want = ((uint64_t)data->last_elapsed + ticks) * CYC_PER_TICK;
 		int64_t delta_cycles = want - unannounced_cycles;
 
-		load_to_be_set = CLAMP(delta_cycles, (int64_t)MIN_DELAY_CYCLES, (int64_t)MAX_CYC);
+		load_to_be_set = CLAMP(delta_cycles, (int64_t)min_delay, (int64_t)MAX_CYC);
 	}
 
 	data->load = load_to_be_set;
@@ -227,6 +248,7 @@ static int sys_clock_driver_init(void)
 	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
 	const struct tmr_cmsdk_apb_cfg *cfg = &cfg_inst0;
 
+	min_delay = cmsdk_min_delay();
 	data->last_elapsed = 0;
 	data->load = CYC_PER_TICK;
 	cfg->timer->reload = CYC_PER_TICK;

--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -10,8 +10,9 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/init.h>
 #include <zephyr/irq.h>
-#include <zephyr/spinlock.h>
 #include <zephyr/sys_clock.h>
+#include <zephyr/sys/util.h>
+#include <cmsis_core.h>
 #include "timer_cmsdk_apb.h"
 
 #define TIMER_NODE DT_CHOSEN(zephyr_system_timer)
@@ -24,11 +25,6 @@ BUILD_ASSERT(DT_NODE_HAS_COMPAT(TIMER_NODE, arm_cmsdk_timer),
 #define TIMER_IRQ      DT_IRQN(TIMER_NODE)
 #define TIMER_IRQ_PRIO DT_IRQ(TIMER_NODE, priority)
 #define TIMER_BASE     DT_REG_ADDR(TIMER_NODE)
-
-#define CYC_PER_TICK                                                                               \
-	((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec() /                                      \
-		    (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
-#define MAX_CYC UINT32_MAX
 
 /* Minimum reload the driver will program: the closest-in timeout it can
  * schedule. It must exceed the longest the timer interrupt can stay masked, or
@@ -57,69 +53,84 @@ static inline uint32_t cmsdk_min_delay(void)
  */
 static uint32_t min_delay;
 
-typedef uint32_t cycle_t;
+static volatile struct timer_cmsdk_apb *const timer =
+	(volatile struct timer_cmsdk_apb *)TIMER_BASE;
 
-struct tmr_cmsdk_apb_cfg {
-	volatile struct timer_cmsdk_apb *timer;
-};
-
-struct tmr_cmsdk_apb_dev_data {
-	uint32_t load;
-	cycle_t cycle_count;
-	cycle_t announced_cycles;
-	/* ticks last reported via sys_clock_elapsed(), cleared in the ISR */
-	cycle_t last_elapsed;
-};
-
-static const struct tmr_cmsdk_apb_cfg cfg_inst0 = {
-	.timer = ((volatile struct timer_cmsdk_apb *)TIMER_BASE),
-};
-
-static struct tmr_cmsdk_apb_dev_data data_inst0;
-
-static uint32_t elapsed(uint32_t *val_out)
-{
-	const struct tmr_cmsdk_apb_cfg *const cfg = &cfg_inst0;
-	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
-
-	uint32_t value = cfg->timer->value;
-
-	if (val_out != NULL) {
-		*val_out = value;
-	}
-
-	return data->load - value;
-}
-
-/* Elapsed cycles since the last reload, including a wrap that fired but has not
- * yet been accounted by the ISR.
- *
- * elapsed() above returns only the in-period offset (load - value). Between a
- * wrap (the counter reloads) and the ISR crediting that period to cycle_count,
- * that offset drops back near zero, so cycle_count + elapsed() briefly goes
- * backwards. It is a race under real time but is hit deterministically under
- * QEMU icount, and a non-monotonic hardware cycle counter breaks k_busy_wait()
- * and the tick accounting.
- *
- * Detect the pending wrap the way the SysTick driver does: sample the value
- * either side of the interrupt-status flag and add a full period if the flag is
- * set or the counter was seen reloading (v1 < v2). This is added to the
- * returned value only; the ISR commits the period into cycle_count and clears
- * the flag, so it is never counted twice. Kept separate from elapsed() so
- * sys_clock_set_timeout()'s reprogramming still works on the raw offset.
+/* Currently programmed reload value, and the synthesized absolute cycle count
+ * (committed on each wrap and each reprogram). The core owns the announce
+ * baseline and the elapsed report.
  */
-static uint32_t elapsed_monotonic(void)
+static uint32_t load;
+static uint32_t cycle_count;
+
+/* HW cycles counted since the last reload (the counter counts down to zero).
+ *
+ * A wrap that the ISR has not yet accounted for must still be included, or the
+ * synthesized count goes backwards across the (counter-reloaded, ISR-pending)
+ * window. That window is a race under real time but is hit deterministically
+ * under QEMU icount. Detect the wrap the same way SysTick does: read the value
+ * either side of the interrupt-status flag, and add a full period if the flag
+ * is set or the counter was seen reloading (v1 < v2). The ISR commits that
+ * period into cycle_count and clears the flag, so it is never counted twice.
+ */
+static inline uint32_t elapsed_cyc(void)
 {
-	const struct tmr_cmsdk_apb_cfg *const cfg = &cfg_inst0;
-	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
+	uint32_t v1 = timer->value;
+	uint32_t wrapped = timer->intstatus & TIMER_CTRL_INT_CLEAR;
+	uint32_t v2 = timer->value;
+	uint32_t pending = (wrapped || (v1 < v2)) ? load : 0;
 
-	uint32_t v1 = cfg->timer->value;
-	uint32_t wrapped = cfg->timer->intstatus & TIMER_CTRL_INT_CLEAR;
-	uint32_t v2 = cfg->timer->value;
-	uint32_t pending = (wrapped || (v1 < v2)) ? data->load : 0;
-
-	return (data->load - v2) + pending;
+	return (load - v2) + pending;
 }
+
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return cycle_count + elapsed_cyc();
+}
+
+static void timer_driver_set_reload(uint32_t rel)
+{
+	uint32_t last_load = load;
+	uint32_t val1 = timer->value;
+	uint32_t wrapped = timer->intstatus & TIMER_CTRL_INT_CLEAR;
+	uint32_t val2 = timer->value;
+	uint32_t pending = (wrapped || (val1 < val2)) ? last_load : 0;
+
+	/* Commit the cycles counted down on the old reload up to the val2 read,
+	 * plus a full period for a wrap the ISR has not yet committed. As in
+	 * elapsed_cyc(), the pending flag and the val1 < val2 read describe the
+	 * same possible wrap, so at most one period is added: adding them as
+	 * separate terms would double-count a wrap that lands between the reads.
+	 */
+	cycle_count += (last_load - val2) + pending;
+	load = rel;
+
+	timer->reload = rel;
+	timer->value = rel;
+
+	/* The wrap folded in above is now committed; clear the status flag and
+	 * pending IRQ so the ISR does not count it again. The counter has just
+	 * been reloaded with rel (>= MIN_DELAY), so no genuine new wrap can be
+	 * dropped here.
+	 */
+	timer->intclear = TIMER_CTRL_INT_CLEAR;
+	NVIC_ClearPendingIRQ(TIMER_IRQ);
+}
+
+/*
+ * Auto-reload 32-bit down-counter: a RELOAD backend. timer_driver_cycle_get()
+ * synthesizes a monotonic count from the reloads and timer_driver_set_reload()
+ * programs the next interval, recovering any cycles that pass between reading
+ * the counter and rewriting it (the val1/val2 drift compensation) so none are
+ * lost. That synthesized read is non-atomic (cycle_count and elapsed_cyc() are
+ * shared with the ISR and reprogram paths), so TIMER_CORE_CYCLE_GET_NONATOMIC
+ * has the core serialise sys_clock_cycle_get_32() under the clock lock.
+ */
+#define TIMER_CORE_BACKEND_RELOAD
+#define TIMER_CORE_MIN_DELAY min_delay
+#define TIMER_CORE_CYCLE_GET_NONATOMIC
+
+#include "system_timer_generic.h"
 
 void sys_clock_unused(void)
 {
@@ -127,135 +138,49 @@ void sys_clock_unused(void)
 		return;
 	}
 
-	const struct tmr_cmsdk_apb_cfg *const cfg = &cfg_inst0;
-
-	/* No pending timeout: reload the counter with the maximum interval so
-	 * the hardware waits as long as it can before the next interrupt.
-	 *
-	 * This is an auto-reload down-counter, not a free-running compare, so
-	 * it cannot simply stop reprogramming the way the compare timers do:
-	 * that would keep firing at the previous, possibly short, interval.
-	 * Programming the maximum reload matches what non-sloppy idle already
-	 * does via next_timeout(). Stopping the counter here (clearing
-	 * TIMER_CTRL_EN and re-enabling it in sys_clock_set_timeout()) would
-	 * avoid the wakeup entirely; that is left out for now to avoid a
-	 * riskier change to the cycle accounting.
+	/* Nothing is pending and uptime may drift. This is an auto-reload
+	 * down-counter, so it cannot just stop being reprogrammed the way the
+	 * compare timers do (it would keep firing at the previous interval);
+	 * reload the longest safe interval instead so it waits as long as it can.
+	 * Cap it at TIMER_CORE_CYCLES_MAX, not the full counter span: the
+	 * synthesized count is 32-bit, so a full-span period would wrap it and
+	 * alias the wrap announce to a near-zero delta (a whole period of uptime
+	 * lost). TIMER_CORE_CYCLES_MAX keeps that announce unambiguous.
 	 */
-	cfg->timer->reload = MAX_CYC;
-	cfg->timer->value = MAX_CYC;
-}
-
-void sys_clock_set_timeout(uint32_t ticks)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-
-	const struct tmr_cmsdk_apb_cfg *const cfg = &cfg_inst0;
-	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
-	uint32_t last_load = data->load;
-	uint32_t val1;
-	uint32_t val2;
-
-	/* store the current cfg->timer->value in val1 */
-	uint32_t pending_cycles = elapsed(&val1);
-	uint32_t load_to_be_set = 0;
-	uint32_t unannounced_cycles = 0;
-
-	data->cycle_count += pending_cycles;
-	unannounced_cycles = data->cycle_count - data->announced_cycles;
-
-	if ((int32_t)unannounced_cycles < 0) {
-		load_to_be_set = min_delay;
-	} else {
-		int64_t want = ((uint64_t)data->last_elapsed + ticks) * CYC_PER_TICK;
-		int64_t delta_cycles = want - unannounced_cycles;
-
-		load_to_be_set = CLAMP(delta_cycles, (int64_t)min_delay, (int64_t)MAX_CYC);
-	}
-
-	data->load = load_to_be_set;
-
-	val2 = cfg->timer->value;
-
-	cfg->timer->reload = data->load;
-	cfg->timer->value = data->load;
-
-	/* verify if underflow occurred after reading val1 and before reading val2 */
-	if (val1 < val2) {
-		data->cycle_count += (val1 + (last_load - val2));
-	} else {
-		data->cycle_count += (val1 - val2);
-	}
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
-	uint32_t unannounced = data->cycle_count - data->announced_cycles;
-	uint32_t cycles = elapsed_monotonic() + unannounced;
-	uint32_t ret = cycles / CYC_PER_TICK;
-
-	data->last_elapsed = ret;
-	return ret;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
 	k_spinlock_key_t key = sys_clock_lock();
-	uint32_t cycles = data->cycle_count + elapsed_monotonic();
 
+	timer_driver_set_reload(TIMER_CORE_CYCLES_MAX);
 	sys_clock_unlock(key);
-
-	return cycles;
 }
 
 static void cmsdk_apb_timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
-	const struct tmr_cmsdk_apb_cfg *const cfg = &cfg_inst0;
-	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
-	uint32_t ticks = 1;
+
 	k_spinlock_key_t key = sys_clock_lock();
 
-	data->cycle_count += data->load;
+	/* The counter wrapped to fire this interrupt: account that interval. This
+	 * must be atomic with the acknowledge and announce, else a concurrent
+	 * timer_driver_set_reload() (or cycle read) sees a torn cycle_count.
+	 */
+	cycle_count += load;
 
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		uint32_t unannounced_cycles = data->cycle_count - data->announced_cycles;
-
-		ticks = unannounced_cycles / CYC_PER_TICK;
-		data->announced_cycles += ticks * CYC_PER_TICK;
-		data->last_elapsed = 0;
-	}
-
-	cfg->timer->intclear = TIMER_CTRL_INT_CLEAR;
+	timer->intclear = TIMER_CTRL_INT_CLEAR;
 	NVIC_ClearPendingIRQ(TIMER_IRQ);
-	sys_clock_announce_locked(ticks, key);
+
+	timer_core_announce_from(key);
 }
 
 static int sys_clock_driver_init(void)
 {
-	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
-	const struct tmr_cmsdk_apb_cfg *cfg = &cfg_inst0;
-
 	min_delay = cmsdk_min_delay();
-	data->last_elapsed = 0;
-	data->load = CYC_PER_TICK;
-	cfg->timer->reload = CYC_PER_TICK;
-	cfg->timer->value = CYC_PER_TICK;
-	cfg->timer->ctrl = TIMER_CTRL_EN | TIMER_CTRL_IRQ_EN;
+	load = TIMER_CORE_CYC_PER_TICK;
+	timer->reload = TIMER_CORE_CYC_PER_TICK;
+	timer->value = TIMER_CORE_CYC_PER_TICK;
+	timer->ctrl = TIMER_CTRL_EN | TIMER_CTRL_IRQ_EN;
 
 	IRQ_CONNECT(TIMER_IRQ, TIMER_IRQ_PRIO, cmsdk_apb_timer_isr, NULL, 0);
+	timer_core_init();
 	irq_enable(TIMER_IRQ);
 
 	return 0;

--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -94,7 +94,7 @@ void sys_clock_unused(void)
 	cfg->timer->value = MAX_CYC;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -102,7 +102,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	ARG_UNUSED(idle);
 
 	const struct tmr_cmsdk_apb_cfg *const cfg = &cfg_inst0;
 	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -331,53 +331,8 @@ void sys_clock_unused(void)
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
+	ARG_UNUSED(idle);
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-#if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
-	if (idle) {
-		uint64_t timeout_us =
-			((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-		timeout_idle = true;
-
-		/**
-		 * Invoke platform-specific layer to configure LPTIM
-		 * such that system wakes up after timeout elapses.
-		 */
-		z_sys_clock_lpm_enter(timeout_us);
-
-#if !defined(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)
-		/* Store current value of SysTick counter to be able to
-		 * calculate a difference in measurements after exiting
-		 * the low-power state.
-		 */
-		cycle_pre_idle = cycle_count + elapsed();
-#else /* CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
-		/**
-		 * SysTick will be placed under reset once we enter
-		 * low-power mode. Turn it off right now then update
-		 * the cycle counter now, since we won't be able to
-		 * to it after waking up.
-		 */
-		sys_clock_disable();
-		/* Ensure the SysTick interrupt is not pending. This is safe
-		 * as we just did the ISR's job, and MUST be done because
-		 * a pending interrupt could inhibit low-power mode entry.
-		 * Note: On Armv8-M, ICSR.STTNS is R/W, so preserve it while
-		 * writing the write-1-to-clear PENDSTCLR bit.
-		 */
-#ifdef SCB_ICSR_STTNS_Msk
-		SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
-#else
-		SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
-#endif
-
-		cycle_count += elapsed();
-		overflow_cyc = 0;
-#endif /* !CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
-		return;
-	}
-#endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 
 #if defined(CONFIG_TICKLESS_KERNEL)
 	/*
@@ -476,6 +431,56 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		cycle_count += val1 - val2;
 	}
 #endif
+}
+
+void sys_clock_idle_enter(uint32_t ticks)
+{
+#if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
+	uint64_t timeout_us =
+		((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
+	timeout_idle = true;
+
+	/**
+	 * Invoke platform-specific layer to configure LPTIM
+	 * such that system wakes up after timeout elapses.
+	 */
+	z_sys_clock_lpm_enter(timeout_us);
+
+#if !defined(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)
+	/* Store current value of SysTick counter to be able to
+	 * calculate a difference in measurements after exiting
+	 * the low-power state.
+	 */
+	cycle_pre_idle = cycle_count + elapsed();
+#else /* CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
+	/**
+	 * SysTick will be placed under reset once we enter
+	 * low-power mode. Turn it off right now then update
+	 * the cycle counter now, since we won't be able to
+	 * to it after waking up.
+	 */
+	sys_clock_disable();
+	/* Ensure the SysTick interrupt is not pending. This is safe
+	 * as we just did the ISR's job, and MUST be done because
+	 * a pending interrupt could inhibit low-power mode entry.
+	 * Note: On Armv8-M, ICSR.STTNS is R/W, so preserve it while
+	 * writing the write-1-to-clear PENDSTCLR bit.
+	 */
+#ifdef SCB_ICSR_STTNS_Msk
+	SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
+#else
+	SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
+#endif
+
+	cycle_count += elapsed();
+	overflow_cyc = 0;
+#endif /* !CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
+#else /* CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
+	sys_clock_set_timeout(ticks, false);
+#endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 }
 
 uint32_t sys_clock_elapsed(void)

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -20,18 +20,6 @@
 	COND_CODE_1(DT_PROP(DT_NODELABEL(systick), external_clock_source),	\
 		    (0), (SysTick_CTRL_CLKSOURCE_Msk))
 
-#if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME) ||			\
-	defined(CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE)
-extern unsigned int z_clock_hw_cycles_per_sec;
-/* CYC_PER_TICK must be inside of systick capacities (<1Ghz) */
-#define CYC_PER_TICK (z_clock_hw_cycles_per_sec/CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#else
-#define CYC_PER_TICK (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC/CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#if (COUNTER_MAX / CYC_PER_TICK) == 1
-#pragma message("tickless does nothing as CONFIG_SYS_CLOCK_TICKS_PER_SEC too low")
-#endif
-#endif
-
 /* Largest delta we can program into the 24-bit LOAD register. */
 #define MAX_CYCLES ((uint32_t)COUNTER_MAX)
 
@@ -97,45 +85,43 @@ static uint32_t last_load;
  */
 static uint32_t min_delay;
 
+/*
+ * SysTick's LOAD/VAL registers are 24-bit and, in tickless mode, LOAD is
+ * reprogrammed to a different value on every arm, so the raw register is a
+ * variable-period sawtooth, not the free-running monotonic count the core masks
+ * and extends for a plain narrow counter. The driver therefore synthesizes a
+ * monotonic count in software: timer_driver_cycle_get() (below) returns
+ * cycle_count, whole periods accumulated on each wrap and reprogram, plus the
+ * current partial. cycle_t is that accumulator; the core masks announce deltas
+ * to its width via TIMER_CORE_CYCLES_WIDTH, never to the 24-bit hardware size,
+ * so the type and the width are defined together here.
+ *
+ * The default width is the native register (32 bits).
+ * CONFIG_CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER widens it to 64 so a low-power
+ * sleep longer than 2^32 cycles is not truncated to too few announced ticks
+ * (the k_sleep()-never-wakes failure); that also enables the core's
+ * sys_clock_cycle_get_64() through TIMER_CORE_64BIT_CYCLES.
+ */
 #ifdef CONFIG_CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER
 typedef uint64_t cycle_t;
-typedef int64_t cycle_diff_t;
+#define TIMER_CORE_64BIT_CYCLES
+#define TIMER_CORE_CYCLES_WIDTH 64
 #else
 typedef uint32_t cycle_t;
-typedef int32_t cycle_diff_t;
+#define TIMER_CORE_CYCLES_WIDTH 32
 #endif
 
 /*
  * This local variable holds the amount of SysTick HW cycles elapsed
- * and it is updated in sys_clock_isr() and sys_clock_set_timeout().
+ * and it is updated in sys_clock_isr() and timer_driver_set_reload().
  *
  * Note:
  *  At an arbitrary point in time the "current" value of the SysTick
  *  HW timer is calculated as:
  *
- * t = cycle_counter + elapsed();
+ * t = cycle_count + elapsed();
  */
 static cycle_t cycle_count;
-
-/*
- * This local variable holds the amount of elapsed SysTick HW cycles
- * that have been announced to the kernel.
- *
- * Note:
- * Additions/subtractions/comparisons of 64-bits values on 32-bits systems
- * are very cheap. Divisions are not. Make sure the difference between
- * cycle_count and announced_cycles is stored in a 32-bit variable before
- * dividing it by CYC_PER_TICK.
- */
-static cycle_t announced_cycles;
-
-/*
- * Ticks reported to the kernel via sys_clock_elapsed() since the last
- * announce. Reset in sys_clock_isr() / sys_clock_idle_exit() after an
- * announce. Used by sys_clock_set_timeout() to compute a tick-aligned
- * absolute deadline relative to announced_cycles.
- */
-static uint32_t last_elapsed;
 
 /*
  * This local variable holds the amount of elapsed HW cycles due to
@@ -147,68 +133,6 @@ static uint32_t last_elapsed;
  * the overflow_cyc must be reset to zero.
  */
 static volatile uint32_t overflow_cyc;
-
-static uint32_t elapsed(void);
-
-#if defined(CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE)
-void z_sys_clock_hw_cycles_per_sec_update(uint32_t new_hz)
-{
-	uint32_t old_hz = (uint32_t)z_clock_hw_cycles_per_sec;
-
-	if ((old_hz == 0U) || (new_hz == 0U) || (old_hz == new_hz)) {
-		return;
-	}
-
-	k_spinlock_key_t key = sys_clock_lock();
-
-	/* Publish the new frequency. */
-	z_clock_hw_cycles_per_sec = new_hz;
-
-	/* The floor is a wall-clock budget, so re-derive it at the new rate. */
-	min_delay = systick_min_delay();
-
-	uint32_t load_old = last_load;
-
-	if (load_old != TIMER_STOPPED) {
-		cycle_count += elapsed();
-		overflow_cyc = 0U;
-	}
-
-	/* Rescale internal counters from old cycles to new cycles. */
-	cycle_count = (cycle_t)(((uint64_t)cycle_count * (uint64_t)new_hz) / (uint64_t)old_hz);
-	announced_cycles = (cycle_t)(((uint64_t)announced_cycles * (uint64_t)new_hz) /
-				     (uint64_t)old_hz);
-
-	if (load_old != TIMER_STOPPED) {
-		uint32_t new_load;
-
-		if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-			uint32_t val = SysTick->VAL;
-
-			if (val == 0U) {
-				val = load_old;
-			}
-
-			new_load = (uint32_t)(((uint64_t)val * (uint64_t)new_hz) /
-					      (uint64_t)old_hz);
-		} else {
-			new_load = CYC_PER_TICK;
-		}
-
-		new_load = MAX(new_load, min_delay);
-		if (new_load > COUNTER_MAX) {
-			new_load = COUNTER_MAX;
-		}
-
-		last_load = new_load;
-		SysTick->LOAD = new_load - 1U;
-		SysTick->VAL = 0U;
-		SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
-	}
-
-	sys_clock_unlock(key);
-}
-#endif /* CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE */
 
 #if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
 /* This local variable indicates that the timeout was set right before
@@ -229,11 +153,16 @@ static cycle_t cycle_pre_idle;
 /* This internal function calculates the amount of HW cycles that have
  * elapsed since the last time the absolute HW cycles counter has been
  * updated. 'cycle_count' may be updated either by the ISR, or when we
- * re-program the SysTick.LOAD register, in sys_clock_set_timeout().
+ * re-program the SysTick.LOAD register, in timer_driver_set_reload().
  *
  * Additionally, the function updates the 'overflow_cyc' counter, that
  * holds the amount of elapsed HW cycles due to (possibly) multiple
  * timer wraps (overflows).
+ *
+ * @param val_out Optional pointer to store the SysTick->VAL snapshot (val2)
+ *                used in the calculation, so a caller needing that raw value
+ *                gets it with no gap after the measurement (see
+ *                timer_driver_set_reload()).
  *
  * Prerequisites:
  * - reprogramming of SysTick.LOAD must be clearing the SysTick.COUNTER
@@ -244,7 +173,7 @@ static cycle_t cycle_pre_idle;
  *     - and until the current call of the function is completed.
  * - the function is invoked with interrupts disabled.
  */
-static uint32_t elapsed(void)
+static uint32_t elapsed(uint32_t *val_out)
 {
 	uint32_t val1 = SysTick->VAL;	/* A */
 	uint32_t ctrl = SysTick->CTRL;	/* B */
@@ -289,8 +218,89 @@ static uint32_t elapsed(void)
 		(void)SysTick->CTRL;
 	}
 
+	if (val_out != NULL) {
+		*val_out = val2;
+	}
+
 	return (last_load - val2) + overflow_cyc;
 }
+
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return cycle_count + elapsed(NULL);
+}
+
+static void timer_driver_set_reload(uint32_t cycles)
+{
+	/*
+	 * elapsed() returns its own SysTick->VAL snapshot (val2) through val1, so
+	 * the window measured by (val1 - val2) at the bottom abuts the window
+	 * already accounted for by elapsed() with no gap: reading SysTick->VAL
+	 * separately after elapsed() would leave the function-return cycles
+	 * counted by neither, i.e. systematically lost drift. The core has
+	 * already clamped 'cycles' to [MIN_DELAY, MAX_CYCLES].
+	 */
+	uint32_t val1;
+	uint32_t pending = elapsed(&val1);
+	uint32_t old_load = last_load;
+
+	cycle_count += pending;
+	overflow_cyc = 0U;
+
+	/*
+	 * val2 must be sampled while the OLD LOAD is still the reload source: if
+	 * a wrap happened between SysTick->LOAD being reprogrammed and the val2
+	 * read, VAL would reload from the NEW LOAD and the drift-comp formula
+	 * below (which uses old_load for the wrap case) would be wrong. Updating
+	 * last_load (a software shadow) is HW-inert and safe to do before val2.
+	 *
+	 * COUNTFLAG is not checked here: the caller guarantees this runs faster
+	 * than MIN_DELAY cycles, so a wrap cannot be missed.
+	 */
+	last_load = cycles;
+
+	uint32_t val2 = SysTick->VAL;
+
+	SysTick->LOAD = cycles - 1U;
+	SysTick->VAL = 0U;	/* resets counter, clears COUNTFLAG */
+
+	/*
+	 * Clear any pending SysTick exception from the old schedule. Writing
+	 * VAL=0 clears COUNTFLAG in CTRL but not ICSR.PENDSTSET, so without this
+	 * a wrap that fired just before the reprogram would still trigger the
+	 * ISR once interrupts are re-enabled. On Armv8-M, preserve STTNS (R/W)
+	 * while writing the W1C bit.
+	 */
+#ifdef SCB_ICSR_STTNS_Msk
+	SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
+#else
+	SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
+#endif
+
+	if (val1 < val2) {
+		cycle_count += val1 + (old_load - val2);
+	} else {
+		cycle_count += val1 - val2;
+	}
+}
+
+/*
+ * SysTick is an auto-reload down-counter: a RELOAD backend. Its 24-bit LOAD,
+ * too small to serve as the core's counter (hence the synthesized cycle_t
+ * above), instead bounds the arm range: TIMER_CORE_CYCLES_MAX is MAX_CYCLES, the
+ * largest value LOAD can hold, rather than the default half-span.
+ * timer_driver_set_reload() reprograms LOAD with drift compensation, and
+ * MIN_DELAY is the reload floor. The synthesized read is not atomic (cycle_count
+ * and elapsed() are shared with the ISR and reprogram paths), so
+ * TIMER_CORE_CYCLE_GET_NONATOMIC has the core serialise the public cycle getters
+ * under the clock lock.
+ */
+#define TIMER_CORE_BACKEND_RELOAD
+#define TIMER_CORE_MIN_DELAY min_delay
+#define TIMER_CORE_CYCLES_MAX MAX_CYCLES
+#define TIMER_CORE_CYCLE_GET_NONATOMIC
+
+#include "system_timer_generic.h"
 
 /* sys_clock_isr is calling directly from the platform's vectors table.
  * However using ISR_DIRECT_DECLARE() is not so suitable due to possible
@@ -303,17 +313,15 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 	sys_trace_isr_enter();
 #endif /* CONFIG_TRACING_ISR */
 
-	uint32_t dcycles;
-	uint32_t dticks;
-
 	k_spinlock_key_t key = sys_clock_lock();
 
-	/* Update overflow_cyc and clear COUNTFLAG by invoking elapsed() */
-	elapsed();
-
-	/* Increment the amount of HW cycles elapsed (complete counter
-	 * cycles) and announce the progress to the kernel.
+	/* Commit the wrap that fired this interrupt into cycle_count so
+	 * timer_driver_cycle_get() (and therefore the announce) sees it. Done under
+	 * the clock lock, atomically with the announce that follows, so a
+	 * higher-priority interrupt reading the cycle counter never observes a
+	 * half-committed overflow.
 	 */
+	elapsed(NULL);
 	cycle_count += overflow_cyc;
 	overflow_cyc = 0;
 
@@ -332,27 +340,7 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 	}
 #endif /* CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER */
 
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		/* In TICKLESS mode, the SysTick.LOAD is re-programmed
-		 * in sys_clock_set_timeout(), followed by resetting of
-		 * the counter (VAL = 0).
-		 *
-		 * If a timer wrap occurs right when we re-program LOAD,
-		 * the ISR is triggered immediately after sys_clock_set_timeout()
-		 * returns; in that case we shall not increment the cycle_count
-		 * because the value has been updated before LOAD re-program.
-		 *
-		 * We can assess if this is the case by inspecting COUNTFLAG.
-		 */
-
-		dcycles = cycle_count - announced_cycles;
-		dticks = dcycles / CYC_PER_TICK;
-		announced_cycles += dticks * CYC_PER_TICK;
-		last_elapsed = 0U;
-		sys_clock_announce_locked(dticks, key);
-	} else {
-		sys_clock_announce_locked(1, key);
-	}
+	timer_core_announce_from(key);
 
 	ISR_DIRECT_PM();
 
@@ -363,6 +351,76 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 	z_arm_int_exit();
 }
 ARCH_ISR_DIAG_ON
+
+#if defined(CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE)
+void z_sys_clock_hw_cycles_per_sec_update(uint32_t new_hz)
+{
+	extern unsigned int z_clock_hw_cycles_per_sec;
+	uint32_t old_hz = (uint32_t)z_clock_hw_cycles_per_sec;
+
+	if ((old_hz == 0U) || (new_hz == 0U) || (old_hz == new_hz)) {
+		return;
+	}
+
+	k_spinlock_key_t key = sys_clock_lock();
+
+	/* Publish the new frequency. */
+	z_clock_hw_cycles_per_sec = new_hz;
+
+	/* The floor is a wall-clock budget, so re-derive it at the new rate. */
+	min_delay = systick_min_delay();
+
+	uint32_t load_old = last_load;
+
+	if (load_old != TIMER_STOPPED) {
+		cycle_count += elapsed(NULL);
+		overflow_cyc = 0U;
+	}
+
+	/* Rescale the synthesized counter and the core's announce baseline from
+	 * old cycles to new cycles so the tick accounting stays continuous.
+	 */
+	cycle_count = (cycle_t)(((uint64_t)cycle_count * (uint64_t)new_hz) / (uint64_t)old_hz);
+	timer_core_rescale(new_hz, old_hz);
+
+	if (load_old != TIMER_STOPPED) {
+		uint32_t new_load;
+
+		if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+			uint32_t val = SysTick->VAL;
+
+			if (val == 0U) {
+				val = load_old;
+			}
+
+			new_load = (uint32_t)(((uint64_t)val * (uint64_t)new_hz) /
+					      (uint64_t)old_hz);
+		} else {
+			/*
+			 * Tickful: LOAD is one tick and is never otherwise
+			 * reprogrammed, so load_old already holds one tick at
+			 * the old rate. Scale it like the tickless branch; the
+			 * rescale is a pure cycle-domain operation, with no need
+			 * for the cycles-per-tick value.
+			 */
+			new_load = (uint32_t)(((uint64_t)load_old * (uint64_t)new_hz) /
+					      (uint64_t)old_hz);
+		}
+
+		new_load = MAX(new_load, min_delay);
+		if (new_load > COUNTER_MAX) {
+			new_load = COUNTER_MAX;
+		}
+
+		last_load = new_load;
+		SysTick->LOAD = new_load - 1U;
+		SysTick->VAL = 0U;
+		SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
+	}
+
+	sys_clock_unlock(key);
+}
+#endif /* CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE */
 
 void sys_clock_unused(void)
 {
@@ -378,112 +436,9 @@ void sys_clock_unused(void)
 	last_load = TIMER_STOPPED;
 }
 
-void sys_clock_set_timeout(uint32_t ticks)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-#if defined(CONFIG_TICKLESS_KERNEL)
-	/*
-	 * Sync cycle_count with current HW state, capturing any wrap that
-	 * might have occurred since the last sync point. The kernel's
-	 * preceding sys_clock_elapsed() call (or the ISR entry sync)
-	 * usually makes this redundant, but we still need to read CTRL
-	 * here to catch any wrap before writing VAL=0 destroys COUNTFLAG.
-	 *
-	 * val1 must be sampled immediately after elapsed() returns, before
-	 * the cycle_count/overflow_cyc writes below, so the window measured
-	 * by (val1 - val2) at the bottom of this function abuts the window
-	 * already accounted for by elapsed() with no gap in between. Any
-	 * instruction inserted between these two lines would be cycles that
-	 * are neither in elapsed()'s return value nor captured by the
-	 * val1/val2 drift compensation, i.e. systematically lost drift.
-	 */
-	uint32_t pending = elapsed();
-	uint32_t val1 = SysTick->VAL;
-	uint32_t old_load = last_load;
-
-	cycle_count += pending;
-	overflow_cyc = 0U;
-
-	uint32_t cycles;
-
-	cycle_diff_t unannounced = cycle_count - announced_cycles;
-
-	if (unannounced < 0) {
-		/*
-		 * cycle_count has overtaken announced_cycles by more than half
-		 * the cycle_diff_t range. This is reachable when the ISR is
-		 * starved (e.g. a long-running higher-priority IRQ holds the
-		 * CPU) while sys_clock_set_timeout() keeps growing cycle_count
-		 * call after call. Force a near-immediate fire so the ISR can
-		 * drain the backlog before the gap wraps past the unsigned
-		 * range and we start losing cycles permanently. In the 64-bit
-		 * cycle_t configuration this branch is statically unreachable.
-		 */
-		cycles = min_delay;
-	} else {
-		/*
-		 * Compute the number of cycles from 'now' to a tick-aligned
-		 * deadline measured from the last announce. last_elapsed is
-		 * the tick count most recently reported to the kernel via
-		 * sys_clock_elapsed(); the kernel's 'ticks' argument is
-		 * measured from that report. 64-bit math absorbs arbitrarily
-		 * large 'ticks' without overflowing the intermediate product.
-		 */
-		int64_t want = ((uint64_t)last_elapsed + ticks) * CYC_PER_TICK;
-		int64_t delta_64 = want - unannounced;
-
-		/*
-		 * Clamp to [MIN_DELAY, MAX_CYCLES] so the programmed LOAD is
-		 * within SysTick's 24-bit range and leaves enough cycles to
-		 * reliably service the next ISR. A past-deadline request
-		 * (delta_64 <= 0) is pulled up to MIN_DELAY to fire ASAP.
-		 */
-		cycles = CLAMP(delta_64, (int64_t)min_delay, (int64_t)MAX_CYCLES);
-	}
-
-	/*
-	 * val2 must be sampled while the OLD LOAD is still the reload source:
-	 * if a wrap happened between SysTick->LOAD being reprogrammed and the
-	 * val2 read, VAL would reload from the NEW LOAD and the drift-comp
-	 * formula below (which uses old_load for the wrap case) would be
-	 * wrong. Updating last_load (a software shadow) is HW-inert and safe
-	 * to do before val2.
-	 *
-	 * COUNTFLAG is not checked here: the caller guarantees this runs
-	 * faster than MIN_DELAY cycles, so a wrap cannot be missed.
-	 */
-	last_load = cycles;
-
-	uint32_t val2 = SysTick->VAL;
-
-	SysTick->LOAD = cycles - 1U;
-	SysTick->VAL = 0U;	/* resets counter, clears COUNTFLAG */
-
-	/*
-	 * Clear any pending SysTick exception from the old schedule.
-	 * Writing VAL=0 clears COUNTFLAG in CTRL but not ICSR.PENDSTSET,
-	 * so without this a wrap that fired just before the reprogram
-	 * would still trigger the ISR once interrupts are re-enabled.
-	 * On Armv8-M, preserve STTNS (R/W) while writing the W1C bit.
-	 */
-#ifdef SCB_ICSR_STTNS_Msk
-	SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
-#else
-	SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
-#endif
-
-	if (val1 < val2) {
-		cycle_count += val1 + (old_load - val2);
-	} else {
-		cycle_count += val1 - val2;
-	}
-#endif
-}
-
+#if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
 void sys_clock_idle_enter(uint32_t ticks)
 {
-#if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
 	uint64_t timeout_us =
 		((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
 
@@ -502,7 +457,7 @@ void sys_clock_idle_enter(uint32_t ticks)
 	 * calculate a difference in measurements after exiting
 	 * the low-power state.
 	 */
-	cycle_pre_idle = cycle_count + elapsed();
+	cycle_pre_idle = cycle_count + elapsed(NULL);
 #else /* CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
 	/**
 	 * SysTick will be placed under reset once we enter
@@ -523,50 +478,11 @@ void sys_clock_idle_enter(uint32_t ticks)
 	SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
 #endif
 
-	cycle_count += elapsed();
+	cycle_count += elapsed(NULL);
 	overflow_cyc = 0;
 #endif /* !CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
-#else /* CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
-	sys_clock_set_timeout(ticks);
+}
 #endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	uint32_t unannounced = cycle_count - announced_cycles;
-	uint32_t cyc = elapsed() + unannounced;
-	uint32_t dticks = cyc / CYC_PER_TICK;
-
-	last_elapsed = dticks;
-	return dticks;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	k_spinlock_key_t key = sys_clock_lock();
-	uint32_t ret = cycle_count;
-
-	ret += elapsed();
-	sys_clock_unlock(key);
-	return ret;
-}
-
-#ifdef CONFIG_CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER
-uint64_t sys_clock_cycle_get_64(void)
-{
-	k_spinlock_key_t key = sys_clock_lock();
-	uint64_t ret = cycle_count + elapsed();
-
-	sys_clock_unlock(key);
-	return ret;
-}
-#endif
 
 void sys_clock_idle_exit(void)
 {
@@ -574,7 +490,6 @@ void sys_clock_idle_exit(void)
 	if (timeout_idle) {
 		k_spinlock_key_t key = sys_clock_lock();
 		cycle_t systick_diff, missed_cycles;
-		uint32_t dcycles, dticks;
 		uint64_t systick_us, idle_timer_us;
 
 #if !defined(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)
@@ -582,7 +497,7 @@ void sys_clock_idle_exit(void)
 		 * Get current value for SysTick and calculate how
 		 * much time has passed since last measurement.
 		 */
-		systick_diff = cycle_count + elapsed() - cycle_pre_idle;
+		systick_diff = cycle_count + elapsed(NULL) - cycle_pre_idle;
 		systick_us =
 			((uint64_t)systick_diff * USEC_PER_SEC) / sys_clock_hw_cycles_per_sec();
 #else /* CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
@@ -613,16 +528,14 @@ void sys_clock_idle_exit(void)
 					USEC_PER_SEC;
 		}
 
-		/* Update the cycle counter to include the cycles missed in idle */
+		/* Update the cycle counter to include the cycles missed in idle, then
+		 * let the core announce the ticks that implies, still under the lock
+		 * so the accounting stays atomic with a concurrent SysTick interrupt.
+		 */
 		cycle_count += missed_cycles;
-
-		/* Announce the passed ticks to the kernel */
-		dcycles = cycle_count + elapsed() - announced_cycles;
-		dticks = dcycles / CYC_PER_TICK;
-		announced_cycles += dticks * CYC_PER_TICK;
-		last_elapsed = 0U;
 		timeout_idle = false;
-		sys_clock_announce_locked(dticks, key);
+
+		timer_core_announce_from(key);
 	}
 #endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 
@@ -632,7 +545,7 @@ void sys_clock_idle_exit(void)
 		 */
 		k_spinlock_key_t key = sys_clock_lock();
 
-		last_load = CYC_PER_TICK;
+		last_load = TIMER_CORE_CYC_PER_TICK;
 		SysTick->LOAD = last_load - 1;
 		SysTick->VAL = 0; /* resets timer to last_load */
 		if (!IS_ENABLED(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)) {
@@ -658,7 +571,7 @@ static int sys_clock_driver_init(void)
 
 	NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
 	min_delay = systick_min_delay();
-	last_load = CYC_PER_TICK;
+	last_load = TIMER_CORE_CYC_PER_TICK;
 	overflow_cyc = 0U;
 	SysTick->LOAD = last_load - 1;
 	SysTick->VAL = 0; /* resets timer to last_load */
@@ -668,6 +581,8 @@ static int sys_clock_driver_init(void)
 			      SYSTICK_CTRL_CLKSOURCE_MSK_GET();
 
 	SysTick->CTRL = ctrl_flags;
+
+	timer_core_init();
 
 	return 0;
 }

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -35,22 +35,67 @@ extern unsigned int z_clock_hw_cycles_per_sec;
 /* Largest delta we can program into the 24-bit LOAD register. */
 #define MAX_CYCLES ((uint32_t)COUNTER_MAX)
 
-/* Minimum cycles in the future to try to program.  Note that this is
- * NOT simply "enough cycles to get the counter read and reprogrammed
- * reliably" -- it becomes the minimum value of the LOAD register, and
- * thus reflects how much time we can reliably see expire between
- * calls to elapsed() to read the COUNTFLAG bit.  So it needs to be
- * set to be larger than the maximum time the interrupt might be
- * masked.  Choosing a fraction of a tick is probably a good enough
- * default, with an absolute minimum of 1k cyc.
+/* Minimum reload the driver will program, i.e. the closest-in timeout it can
+ * schedule. Two floors apply.
  *
- * The MIN_DELAY can be overridden via device tree property "zephyr,min-timeout-cycles"
- * for boards with low-frequency clock sources (e.g., 32kHz).
+ * Hardware: LOAD is programmed as (cycles - 1), and a LOAD of zero stops the
+ * counter (it reloads to zero and never makes another 1->0 transition, so no
+ * further interrupt), so the smallest usable value is two cycles (LOAD 1).
+ *
+ * Masking: it must also exceed the longest time the SysTick interrupt can stay
+ * masked. elapsed() reconstructs the current cycle count assuming at most one
+ * wrap of the counter has happened since it last ran; it cannot tell one wrap
+ * from several. With a tiny LOAD the counter wraps every few cycles, so if
+ * interrupts are then held off longer than that LOAD (a long critical section,
+ * or a higher-priority ISR that runs for a while) the counter wraps two or
+ * more times before the SysTick ISR can account for it. Each unaccounted wrap
+ * silently drops a full LOAD's worth of cycles: the software clock falls
+ * permanently behind real time and every pending timeout fires late by that
+ * much. A floor above the worst-case masking window guarantees at most one
+ * wrap between reads, which elapsed() does handle.
+ *
+ * That is a wall-clock budget, so express it as a fixed time converted to
+ * cycles at the actual frequency (k_us_to_cyc_ceil32() follows the runtime
+ * rate where the timer reports it), computed at init. A fixed cycle count is a
+ * different wall-clock time on every clock, so it cannot bound a masking
+ * window that is fixed in real time. The tick rate is deliberately not
+ * involved; if the resulting value exceeds one tick on some
+ * clock, sub-tick timeouts are simply unavailable there.
+ *
+ * Keep it as small as correctness allows, not as large as a tick would
+ * permit: this is a floor for safe rescheduling, not a jitter control.
+ * Inflating it does trim the short-period tail, but it eats sub-tick headroom,
+ * and as it approaches CYC_PER_TICK the driver can no longer place a timeout
+ * inside the current tick, so the small per-ISR surplus is carried over and
+ * two ticks get announced at once (a double expiry). 10 us is under a cycle at
+ * 32 kHz, where the two-cycle hardware floor takes over; either way it stays
+ * far below CYC_PER_TICK.
+ *
+ * A device tree "zephyr,min-timeout-cycles" property still overrides the
+ * budget, subject to the same two-cycle hardware floor.
  */
-#define MIN_DELAY DT_PROP_OR(DT_NODELABEL(systick), zephyr_min_timeout_cycles, \
-			MAX(1024U, ((uint32_t)CYC_PER_TICK/16U)))
+#define SYSTICK_MIN_DELAY_US 10U
+
+static inline uint32_t systick_min_delay(void)
+{
+	uint32_t override_cyc =
+		DT_PROP_OR(DT_NODELABEL(systick), zephyr_min_timeout_cycles, 0U);
+	uint32_t cyc = (override_cyc != 0U) ? override_cyc
+					    : k_us_to_cyc_ceil32(SYSTICK_MIN_DELAY_US);
+
+	/* Floor at two cycles: LOAD is programmed as (cycles - 1) and a LOAD
+	 * of zero stops the counter. This is the binding floor on a slow clock
+	 * (e.g. 32 kHz, where the 10 us budget rounds below it).
+	 */
+	return MAX(2U, cyc);
+}
 
 static uint32_t last_load;
+
+/* Minimum LOAD value; derived from the cycle rate in sys_clock_driver_init()
+ * (and refreshed on a runtime frequency change). See systick_min_delay().
+ */
+static uint32_t min_delay;
 
 #ifdef CONFIG_CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER
 typedef uint64_t cycle_t;
@@ -118,6 +163,10 @@ void z_sys_clock_hw_cycles_per_sec_update(uint32_t new_hz)
 
 	/* Publish the new frequency. */
 	z_clock_hw_cycles_per_sec = new_hz;
+
+	/* The floor is a wall-clock budget, so re-derive it at the new rate. */
+	min_delay = systick_min_delay();
+
 	uint32_t load_old = last_load;
 
 	if (load_old != TIMER_STOPPED) {
@@ -146,7 +195,7 @@ void z_sys_clock_hw_cycles_per_sec_update(uint32_t new_hz)
 			new_load = CYC_PER_TICK;
 		}
 
-		new_load = MAX(new_load, MIN_DELAY);
+		new_load = MAX(new_load, min_delay);
 		if (new_load > COUNTER_MAX) {
 			new_load = COUNTER_MAX;
 		}
@@ -371,7 +420,7 @@ void sys_clock_set_timeout(uint32_t ticks)
 		 * range and we start losing cycles permanently. In the 64-bit
 		 * cycle_t configuration this branch is statically unreachable.
 		 */
-		cycles = MIN_DELAY;
+		cycles = min_delay;
 	} else {
 		/*
 		 * Compute the number of cycles from 'now' to a tick-aligned
@@ -390,7 +439,7 @@ void sys_clock_set_timeout(uint32_t ticks)
 		 * reliably service the next ISR. A past-deadline request
 		 * (delta_64 <= 0) is pulled up to MIN_DELAY to fire ASAP.
 		 */
-		cycles = CLAMP(delta_64, (int64_t)MIN_DELAY, (int64_t)MAX_CYCLES);
+		cycles = CLAMP(delta_64, (int64_t)min_delay, (int64_t)MAX_CYCLES);
 	}
 
 	/*
@@ -608,6 +657,7 @@ static int sys_clock_driver_init(void)
 {
 
 	NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
+	min_delay = systick_min_delay();
 	last_load = CYC_PER_TICK;
 	overflow_cyc = 0U;
 	SysTick->LOAD = last_load - 1;

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -329,9 +329,8 @@ void sys_clock_unused(void)
 	last_load = TIMER_STOPPED;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #if defined(CONFIG_TICKLESS_KERNEL)
@@ -479,7 +478,7 @@ void sys_clock_idle_enter(uint32_t ticks)
 	overflow_cyc = 0;
 #endif /* !CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
 #else /* CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
-	sys_clock_set_timeout(ticks, false);
+	sys_clock_set_timeout(ticks);
 #endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 }
 

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -315,21 +315,23 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 }
 ARCH_ISR_DIAG_ON
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* Fast CPUs and a 24 bit counter mean that even idle systems need to
+	 * wake up multiple times per second. With no timeout pending and sloppy
+	 * idle allowing the uptime to drift, shut off the counter entirely.
+	 */
+	SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
+	last_load = TIMER_STOPPED;
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	/* Fast CPUs and a 24 bit counter mean that even idle systems
-	 * need to wake up multiple times per second.  If the kernel
-	 * allows us to miss tick announcements while nothing is pending
-	 * (sloppy idle), then shut off the counter.
-	 */
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
-	    ticks == SYS_CLOCK_MAX_WAIT) {
-		SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
-		last_load = TIMER_STOPPED;
-		return;
-	}
 
 #if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
 	if (idle) {

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -40,7 +40,6 @@ static uint64_t lptim_pre_idle;
 static bool timeout_idle;
 #endif
 
-static struct k_spinlock lock;
 static uint64_t last_count;
 
 /* Systimer HAL layer object */
@@ -79,7 +78,7 @@ static void IRAM_ATTR sys_timer_isr(void *arg)
 	ARG_UNUSED(arg);
 	systimer_ll_clear_alarm_int(systimer_hal.dev, SYSTIMER_ALARM_OS_TICK_CORE0);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 
 	uint64_t now = get_systimer_alarm();
 	uint64_t dticks = sys_timer_elapsed_ticks(now);
@@ -93,12 +92,13 @@ static void IRAM_ATTR sys_timer_isr(void *arg)
 		set_systimer_alarm(next);
 	}
 
-	k_spin_unlock(&lock, key);
-	sys_clock_announce(dticks);
+	sys_clock_announce_locked(dticks, key);
 }
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 #if defined(CONFIG_TICKLESS_KERNEL)
 	if (systimer_hal.dev == NULL) {
 		return;
@@ -106,7 +106,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
 	uint64_t now = get_systimer_alarm();
 	uint32_t adj, cyc = ticks * CYC_PER_TICK;
 
@@ -138,12 +137,13 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	ARG_UNUSED(idle);
 #endif
 
-	k_spin_unlock(&lock, key);
 #endif
 }
 
 uint32_t sys_clock_elapsed(void)
 {
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return 0;
 	}
@@ -152,11 +152,7 @@ uint32_t sys_clock_elapsed(void)
 		return 0;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ret = ((uint32_t)get_systimer_alarm() - (uint32_t)last_count) / CYC_PER_TICK;
-
-	k_spin_unlock(&lock, key);
-	return ret;
+	return ((uint32_t)get_systimer_alarm() - (uint32_t)last_count) / CYC_PER_TICK;
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -189,7 +185,7 @@ void sys_clock_idle_exit(void)
 		return;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key = sys_clock_lock();
 
 	uint64_t lptim_now = esp32_lptim_hook_on_lpm_exit();
 	uint64_t systimer_now = get_systimer_alarm();
@@ -216,10 +212,8 @@ void sys_clock_idle_exit(void)
 
 	timeout_idle = false;
 
-	k_spin_unlock(&lock, key);
-
 	/* Announce OS ticks as systimer remained stalled while in light sleep */
-	sys_clock_announce(dticks);
+	sys_clock_announce_locked(dticks, key);
 }
 #endif
 

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -95,9 +95,8 @@ static void IRAM_ATTR sys_timer_isr(void *arg)
 	sys_clock_announce_locked(dticks, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #if defined(CONFIG_TICKLESS_KERNEL)
@@ -130,7 +129,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 #if defined(CONFIG_PM)
 void sys_clock_idle_enter(uint32_t ticks)
 {
-	sys_clock_set_timeout(ticks, false);
+	sys_clock_set_timeout(ticks);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL) || systimer_hal.dev == NULL) {
 		return;

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -22,25 +22,17 @@
 
 #include "esp32_sys_timer.h"
 
-#define CYC_PER_TICK ((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec()	\
-			      / (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
-#define MAX_CYC 0xffffffffu
-#define MAX_TICKS ((MAX_CYC - CYC_PER_TICK) / CYC_PER_TICK)
 #define MIN_DELAY 1
 
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = DT_IRQN(DT_NODELABEL(systimer0));
 #endif
 
-#define TICKLESS IS_ENABLED(CONFIG_TICKLESS_KERNEL)
-
 #if defined(CONFIG_PM)
 static uint64_t systimer_pre_idle;
 static uint64_t lptim_pre_idle;
 static bool timeout_idle;
 #endif
-
-static uint64_t last_count;
 
 /* Systimer HAL layer object */
 static systimer_hal_context_t systimer_hal;
@@ -64,66 +56,67 @@ static uint64_t get_systimer_alarm(void)
 	return systimer_hal_get_counter_value(&systimer_hal, SYSTIMER_COUNTER_OS_TICK);
 }
 
-static uint64_t sys_timer_elapsed_ticks(uint64_t now)
+/*
+ * Free-running 64-bit systimer counter plus a one-shot alarm: a COMPARE
+ * backend. The core owns the tick accounting; the driver reads the counter and
+ * arms the alarm. timer_driver_set_compare() keeps a target that is too close (or
+ * behind after latency) at least MIN_DELAY ahead so the alarm is not missed.
+ */
+#define TIMER_CORE_BACKEND_COMPARE
+#define TIMER_CORE_64BIT_CYCLES
+/*
+ * The systimer unit counter is 52-bit, read back as a 64-bit value. Declare its
+ * real width: the default native register width would be 32 bits on the RISC-V
+ * parts, masking announce deltas to 32 bits and truncating a light-sleep
+ * compensation longer than 2^32 cycles (~268 s at 16 MHz) in sys_clock_idle_exit();
+ * 52 also keeps the masked delta wrap-correct at the counter's true wrap.
+ */
+#define TIMER_CORE_CYCLES_WIDTH 52
+
+static inline uint64_t timer_driver_cycle_get(void)
 {
-	uint64_t dticks = (uint64_t)((now - last_count) / CYC_PER_TICK);
-
-	last_count += dticks * CYC_PER_TICK;
-
-	return dticks;
+	/* sys_clock_disable() deinitializes the HAL and clears dev; a stray core
+	 * read afterwards must not dereference it.
+	 */
+	if (systimer_hal.dev == NULL) {
+		return 0;
+	}
+	return get_systimer_alarm();
 }
+
+static void timer_driver_set_compare(uint64_t cycles)
+{
+	/* Same post-sys_clock_disable() guard as timer_driver_cycle_get(): once
+	 * the HAL is deinitialized and dev cleared, a stray arm must not
+	 * dereference it.
+	 */
+	if (systimer_hal.dev == NULL) {
+		return;
+	}
+
+	uint64_t curr = get_systimer_alarm();
+
+	if ((int64_t)(cycles - curr) < MIN_DELAY) {
+		cycles = curr + MIN_DELAY;
+	}
+	set_systimer_alarm(cycles);
+}
+
+#include "system_timer_generic.h"
 
 static void IRAM_ATTR sys_timer_isr(void *arg)
 {
 	ARG_UNUSED(arg);
 	systimer_ll_clear_alarm_int(systimer_hal.dev, SYSTIMER_ALARM_OS_TICK_CORE0);
 
-	k_spinlock_key_t key = sys_clock_lock();
-
-	uint64_t now = get_systimer_alarm();
-	uint64_t dticks = sys_timer_elapsed_ticks(now);
-
-	if (!TICKLESS) {
-		uint64_t next = last_count + CYC_PER_TICK;
-
-		if ((int64_t)(next - now) < MIN_DELAY) {
-			next += CYC_PER_TICK;
-		}
-		set_systimer_alarm(next);
-	}
-
-	sys_clock_announce_locked(dticks, key);
+	timer_core_announce();
 }
 
-void sys_clock_set_timeout(uint32_t ticks)
+void sys_clock_disable(void)
 {
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-#if defined(CONFIG_TICKLESS_KERNEL)
-	if (systimer_hal.dev == NULL) {
-		return;
-	}
-
-	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
-
-	uint64_t now = get_systimer_alarm();
-	uint32_t adj, cyc = ticks * CYC_PER_TICK;
-
-	/* Round up to next tick boundary. */
-	adj = (uint32_t)(now - last_count) + (CYC_PER_TICK - 1);
-	if (cyc <= MAX_CYC - adj) {
-		cyc += adj;
-	} else {
-		cyc = MAX_CYC;
-	}
-	cyc = (cyc / CYC_PER_TICK) * CYC_PER_TICK;
-
-	if ((int32_t)(cyc + last_count - now) < MIN_DELAY) {
-		cyc += CYC_PER_TICK;
-	}
-
-	set_systimer_alarm(cyc + last_count);
-#endif
+	systimer_ll_enable_alarm(systimer_hal.dev, SYSTIMER_ALARM_OS_TICK_CORE0, false);
+	systimer_ll_enable_alarm_int(systimer_hal.dev, SYSTIMER_ALARM_OS_TICK_CORE0, false);
+	systimer_hal_deinit(&systimer_hal);
 }
 
 #if defined(CONFIG_PM)
@@ -141,47 +134,7 @@ void sys_clock_idle_enter(uint32_t ticks)
 	systimer_pre_idle = get_systimer_alarm();
 	timeout_idle = true;
 }
-#endif
 
-uint32_t sys_clock_elapsed(void)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	if (systimer_hal.dev == NULL) {
-		return 0;
-	}
-
-	return ((uint32_t)get_systimer_alarm() - (uint32_t)last_count) / CYC_PER_TICK;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	if (systimer_hal.dev == NULL) {
-		return 0;
-	}
-	return (uint32_t)get_systimer_alarm();
-}
-
-uint64_t sys_clock_cycle_get_64(void)
-{
-	if (systimer_hal.dev == NULL) {
-		return 0;
-	}
-	return get_systimer_alarm();
-}
-
-void sys_clock_disable(void)
-{
-	systimer_ll_enable_alarm(systimer_hal.dev, SYSTIMER_ALARM_OS_TICK_CORE0, false);
-	systimer_ll_enable_alarm_int(systimer_hal.dev, SYSTIMER_ALARM_OS_TICK_CORE0, false);
-	systimer_hal_deinit(&systimer_hal);
-}
-
-#if defined(CONFIG_PM)
 void sys_clock_idle_exit(void)
 {
 	if (!timeout_idle) {
@@ -210,13 +163,10 @@ void sys_clock_idle_exit(void)
 	systimer_ll_set_counter_value(systimer_hal.dev, SYSTIMER_COUNTER_OS_TICK, new_value);
 	systimer_ll_apply_counter_value(systimer_hal.dev, SYSTIMER_COUNTER_OS_TICK);
 
-	systimer_now = get_systimer_alarm();
-	uint64_t dticks = sys_timer_elapsed_ticks(systimer_now);
-
 	timeout_idle = false;
 
 	/* Announce OS ticks as systimer remained stalled while in light sleep */
-	sys_clock_announce_locked(dticks, key);
+	timer_core_announce_from(key);
 }
 #endif
 
@@ -244,8 +194,9 @@ static int sys_clock_driver_init(void)
 #if defined(CONFIG_SMP)
 	systimer_hal_counter_can_stall_by_cpu(&systimer_hal, SYSTIMER_COUNTER_OS_TICK, 1, true);
 #endif
-	last_count = get_systimer_alarm();
-	set_systimer_alarm(last_count + CYC_PER_TICK);
+
+	/* Seed the announce baseline from the systimer and arm the first tick. */
+	timer_core_init();
 	return 0;
 }
 

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -97,6 +97,7 @@ static void IRAM_ATTR sys_timer_isr(void *arg)
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
+	ARG_UNUSED(idle);
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #if defined(CONFIG_TICKLESS_KERNEL)
@@ -123,22 +124,25 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	}
 
 	set_systimer_alarm(cyc + last_count);
-
-#if defined(CONFIG_PM)
-	if (idle) {
-		uint64_t timeout_us =
-			((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-		lptim_pre_idle = esp32_lptim_hook_on_lpm_entry(timeout_us);
-		systimer_pre_idle = get_systimer_alarm();
-		timeout_idle = true;
-	}
-#else
-	ARG_UNUSED(idle);
-#endif
-
 #endif
 }
+
+#if defined(CONFIG_PM)
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	sys_clock_set_timeout(ticks, false);
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL) || systimer_hal.dev == NULL) {
+		return;
+	}
+
+	uint64_t timeout_us = ((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+
+	lptim_pre_idle = esp32_lptim_hook_on_lpm_entry(timeout_us);
+	systimer_pre_idle = get_systimer_alarm();
+	timeout_idle = true;
+}
+#endif
 
 uint32_t sys_clock_elapsed(void)
 {

--- a/drivers/timer/gecko_burtc_timer.c
+++ b/drivers/timer/gecko_burtc_timer.c
@@ -109,9 +109,8 @@ static void burtc_isr(const void *arg)
 	sys_clock_announce(unannounced);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -361,9 +361,8 @@ void sys_clock_unused(void)
 	hpet_gconf_set(reg);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -349,6 +349,18 @@ void smp_timer_init(void)
 	 */
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	uint32_t reg = hpet_gconf_get();
+
+	reg &= ~GCONF_ENABLE;
+	hpet_gconf_set(reg);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -356,15 +368,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #if defined(CONFIG_TICKLESS_KERNEL)
-	uint32_t reg;
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		reg = hpet_gconf_get();
-		reg &= ~GCONF_ENABLE;
-		hpet_gconf_set(reg);
-		return;
-	}
-
 	/* The comparator is 64-bit, so the requested timeout needs no clamp. */
 	uint64_t cyc = (last_tick + last_elapsed + ticks) * cyc_per_tick;
 

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -231,17 +231,6 @@ __WARN("HPET_INT_LEVEL_TRIGGER has no effect, DTS setting is used instead")
 #endif
 #endif /* (DT_INST_IRQ_HAS_CELL(0, flags)) */
 
-static uint64_t last_count;
-static uint64_t last_tick;
-static uint32_t last_elapsed;
-
-#ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
-static unsigned int cyc_per_tick;
-#else
-#define cyc_per_tick			\
-	(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#endif /* CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME */
-
 #ifdef HPET_INT_LEVEL_TRIGGER
 /**
  * @brief Write to General Interrupt Status Register
@@ -275,14 +264,35 @@ static inline void hpet_timer_comparator_set_safe(uint64_t next)
 	}
 }
 
+/*
+ * Free-running 64-bit counter plus an equality-match comparator: a COMPARE
+ * backend. The comparator matches only count == cmp, so an already-past target
+ * is rearmed by hpet_timer_comparator_set_safe(), satisfying the core's "must
+ * not miss a past deadline" contract. Under QEMU SMP the shared counter can be
+ * observed reading backwards, handled via TIMER_CORE_COUNTER_NONMONOTONIC.
+ */
+#define TIMER_CORE_BACKEND_COMPARE
+#define TIMER_CORE_64BIT_CYCLES
+#if defined(CONFIG_SMP) && defined(CONFIG_QEMU_TARGET)
+#define TIMER_CORE_COUNTER_NONMONOTONIC
+#endif
+
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return hpet_counter_get();
+}
+
+static inline void timer_driver_set_compare(uint64_t cycles)
+{
+	hpet_timer_comparator_set_safe(cycles);
+}
+
+#include "system_timer_generic.h"
+
 __isr
 static void hpet_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
-
-	k_spinlock_key_t key = sys_clock_lock();
-
-	uint64_t now = hpet_counter_get();
 
 #ifdef HPET_INT_LEVEL_TRIGGER
 	/*
@@ -293,32 +303,7 @@ static void hpet_isr(const void *arg)
 	hpet_int_sts_set(TIMER0_INT_STS);
 #endif
 
-	if (IS_ENABLED(CONFIG_SMP) &&
-	    IS_ENABLED(CONFIG_QEMU_TARGET)) {
-		/* Qemu in SMP mode has observed the clock going
-		 * "backwards" relative to interrupts already received
-		 * on the other CPU, despite the HPET being
-		 * theoretically a global device.
-		 */
-		int64_t diff = (int64_t)(now - last_count);
-
-		if (last_count && diff < 0) {
-			now = last_count;
-		}
-	}
-	uint32_t dticks = (uint32_t)((now - last_count) / cyc_per_tick);
-
-	last_count += (uint64_t)dticks * cyc_per_tick;
-	last_tick += dticks;
-	last_elapsed = 0;
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		uint64_t next = last_count + cyc_per_tick;
-
-		hpet_timer_comparator_set_safe(next);
-	}
-
-	sys_clock_announce_locked(dticks, key);
+	timer_core_announce();
 }
 
 static void config_timer0(unsigned int irq)
@@ -361,44 +346,6 @@ void sys_clock_unused(void)
 	hpet_gconf_set(reg);
 }
 
-void sys_clock_set_timeout(uint32_t ticks)
-{
-
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-#if defined(CONFIG_TICKLESS_KERNEL)
-	/* The comparator is 64-bit, so the requested timeout needs no clamp. */
-	uint64_t cyc = (last_tick + last_elapsed + ticks) * cyc_per_tick;
-
-	hpet_timer_comparator_set_safe(cyc);
-#endif
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL) || cyc_per_tick == 0) {
-		return 0;
-	}
-
-	uint64_t now = hpet_counter_get();
-	uint32_t ret = (uint32_t)((now - last_count) / cyc_per_tick);
-
-	last_elapsed = ret;
-	return ret;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	return (uint32_t)hpet_counter_get();
-}
-
-uint64_t sys_clock_cycle_get_64(void)
-{
-	return hpet_counter_get();
-}
-
 void sys_clock_idle_exit(void)
 {
 	uint32_t reg;
@@ -434,7 +381,6 @@ static int sys_clock_driver_init(void)
 #ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
 	hz = (uint32_t)(HPET_COUNTER_CLK_PERIOD / hpet_counter_clk_period_get());
 	z_clock_hw_cycles_per_sec = hz;
-	cyc_per_tick = hz / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
 #endif
 
 	reg = hpet_gconf_get();
@@ -452,9 +398,7 @@ static int sys_clock_driver_init(void)
 
 	hpet_gconf_set(reg);
 
-	last_tick = hpet_counter_get() / cyc_per_tick;
-	last_count = last_tick * cyc_per_tick;
-	hpet_timer_comparator_set_safe(last_count + cyc_per_tick);
+	timer_core_init();
 
 	return 0;
 }

--- a/drivers/timer/infineon_lp_timer.c
+++ b/drivers/timer/infineon_lp_timer.c
@@ -80,9 +80,8 @@ void sys_clock_unused(void)
 	k_spin_unlock(&lock, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	k_spinlock_key_t key = {0};
 

--- a/drivers/timer/infineon_lp_timer.c
+++ b/drivers/timer/infineon_lp_timer.c
@@ -66,6 +66,20 @@ static void lptimer_interrupt_handler(void *handler_arg, cyhal_lptimer_event_t e
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : (delta_ticks > 0));
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	/* Disable the LPTIMER events */
+	cyhal_lptimer_enable_event(&lptimer_obj, CYHAL_LPTIMER_COMPARE_MATCH,
+				   LPTIMER_INTR_PRIORITY, false);
+	k_spin_unlock(&lock, key);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -73,15 +87,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	k_spinlock_key_t key = {0};
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		key = k_spin_lock(&lock);
-		/* Disable the LPTIMER events */
-		cyhal_lptimer_enable_event(&lptimer_obj, CYHAL_LPTIMER_COMPARE_MATCH,
-					   LPTIMER_INTR_PRIORITY, false);
-		k_spin_unlock(&lock, key);
 		return;
 	}
 

--- a/drivers/timer/infineon_lp_timer_pdl.c
+++ b/drivers/timer/infineon_lp_timer_pdl.c
@@ -92,11 +92,9 @@ static void lptimer_delay(uint32_t cycles)
 	Cy_MCWDT_Enable(lptimer, CY_MCWDT_CTR0 | CY_MCWDT_CTR1, 0);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	uint32_t delay_cycles;
-
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -127,10 +127,8 @@ static void compare_isr(const void *arg)
 	sys_clock_announce_locked(dticks, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
-
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 #ifdef CONFIG_TICKLESS_KERNEL

--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -32,18 +32,11 @@
 #define TIMER_IRQ DSP_WCT_IRQ(COMPARATOR_IDX)
 #endif
 
-#define CYC_PER_TICK	(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC	\
-			/ CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#define MAX_CYC		0xFFFFFFFFUL
-#define MAX_TICKS	((MAX_CYC - CYC_PER_TICK) / CYC_PER_TICK)
 #define MIN_DELAY	(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / 100000)
 
-BUILD_ASSERT(MIN_DELAY < CYC_PER_TICK);
 BUILD_ASSERT(COMPARATOR_IDX >= 0 && COMPARATOR_IDX <= 1);
 
 #define DSP_WCT_CS_TT(x)                     BIT(4 + x)
-
-static uint64_t last_count;
 
 /* Not using current syscon driver due to overhead due to MMU support */
 #define SYSCON_REG_ADDR	DT_REG_ADDR(DT_INST_PHANDLE(0, syscon))
@@ -98,84 +91,54 @@ static uint32_t count32(void)
 	return counter_lo;
 }
 
-static void compare_isr(const void *arg)
+/*
+ * Free-running 64-bit wall clock plus an absolute comparator: a COMPARE
+ * backend. The core owns the tick accounting; the driver reads the counter and
+ * arms the comparator. Arming disarms and rearms the comparator, so
+ * timer_driver_set_compare() keeps a target that latency left too close at least
+ * MIN_DELAY ahead, so the sequence cannot race the counter past it.
+ */
+#define TIMER_CORE_BACKEND_COMPARE
+#define TIMER_CORE_64BIT_CYCLES
+#define TIMER_CORE_HAVE_CYCLE_GET_32
+/* The wall clock is a genuine 64-bit counter on a 32-bit CPU: use its full
+ * range (the native register width would clamp deltas to 32 bits).
+ */
+#define TIMER_CORE_CYCLES_WIDTH 64
+
+static inline uint64_t timer_driver_cycle_get(void)
 {
-	ARG_UNUSED(arg);
-	uint64_t curr;
-	uint64_t dticks;
-
-	k_spinlock_key_t key = sys_clock_lock();
-
-	curr = count();
-	dticks = (curr - last_count) / CYC_PER_TICK;
-
-	/* Clear the triggered bit */
-	sys_write32(sys_read32(DSPWCTCS_ADDR) | DSP_WCT_CS_TT(COMPARATOR_IDX),
-			DSPWCTCS_ADDR);
-
-	last_count += dticks * CYC_PER_TICK;
-
-#ifndef CONFIG_TICKLESS_KERNEL
-	uint64_t next = last_count + CYC_PER_TICK;
-
-	if ((int64_t)(next - curr) < MIN_DELAY) {
-		next += CYC_PER_TICK;
-	}
-	set_compare(next);
-#endif
-
-	sys_clock_announce_locked(dticks, key);
+	return count();
 }
 
-void sys_clock_set_timeout(uint32_t ticks)
+static inline void timer_driver_set_compare(uint64_t cycles)
 {
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-#ifdef CONFIG_TICKLESS_KERNEL
-	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
-
 	uint64_t curr = count();
-	uint64_t next;
-	uint32_t adj, cyc = ticks * CYC_PER_TICK;
 
-	/* Round up to next tick boundary */
-	adj = (uint32_t)(curr - last_count) + (CYC_PER_TICK - 1);
-	if (cyc <= MAX_CYC - adj) {
-		cyc += adj;
-	} else {
-		cyc = MAX_CYC;
+	if ((int64_t)(cycles - curr) < MIN_DELAY) {
+		cycles = curr + MIN_DELAY;
 	}
-	cyc = (cyc / CYC_PER_TICK) * CYC_PER_TICK;
-	next = last_count + cyc;
-
-	if (((uint32_t)next - (uint32_t)curr) < MIN_DELAY) {
-		next += CYC_PER_TICK;
-	}
-
-	set_compare(next);
-#endif
+	set_compare(cycles);
 }
 
-uint32_t sys_clock_elapsed(void)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-	uint64_t ret = (count() - last_count) / CYC_PER_TICK;
-
-	return (uint32_t)ret;
-}
+#include "system_timer_generic.h"
 
 uint32_t sys_clock_cycle_get_32(void)
 {
 	return count32();
 }
 
-uint64_t sys_clock_cycle_get_64(void)
+static void compare_isr(const void *arg)
 {
-	return count();
+	ARG_UNUSED(arg);
+
+	k_spinlock_key_t key = sys_clock_lock();
+
+	/* Clear the triggered bit */
+	sys_write32(sys_read32(DSPWCTCS_ADDR) | DSP_WCT_CS_TT(COMPARATOR_IDX),
+			DSPWCTCS_ADDR);
+
+	timer_core_announce_from(key);
 }
 
 /* Interrupt setup is partially-cpu-local state, so needs to be
@@ -207,11 +170,10 @@ void smp_timer_init(void)
 
 static int sys_clock_driver_init(void)
 {
-	uint64_t curr = count();
-
 	IRQ_CONNECT(TIMER_IRQ, 0, compare_isr, 0, 0);
-	set_compare(curr + CYC_PER_TICK);
-	last_count = curr;
+
+	/* Seed the announce baseline from the wall clock and arm the first tick. */
+	timer_core_init();
 	irq_init();
 	return 0;
 }

--- a/drivers/timer/ite_it51xxx_timer.c
+++ b/drivers/timer/ite_it51xxx_timer.c
@@ -193,6 +193,18 @@ static void free_run_timer_overflow_isr(const void *unused)
 	/* TODO: to increment 32-bit "top half" here for software 64-bit timer emulation. */
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	ext_timer_disable(EVENT_TIMER);
+	k_spin_unlock(&lock, key);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -210,18 +222,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	/* Disable event timer */
 	ext_timer_disable(EVENT_TIMER);
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * The kernel has no pending timeout, which it signals with
-		 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle no future
-		 * timer interrupt is required, so leave the event timer
-		 * disabled and stop waking up. Without sloppy idle we fall
-		 * through and still schedule the (capped) timeout so the
-		 * uptime tick count stays correct.
-		 */
-		k_spin_unlock(&lock, key);
-		return;
-	}
 	/*
 	 * If ticks <= 1 means the kernel wants the tick announced as soon as possible,
 	 * ideally no more than one system tick in the future. So set event timer count

--- a/drivers/timer/ite_it51xxx_timer.c
+++ b/drivers/timer/ite_it51xxx_timer.c
@@ -205,9 +205,8 @@ void sys_clock_unused(void)
 	k_spin_unlock(&lock, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	uint32_t hw_cnt, next_cycs, now, dcycles;
 

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -223,6 +223,18 @@ static void free_run_timer_overflow_isr(const void *unused)
 	 */
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	IT8XXX2_EXT_CTRLX(EVENT_TIMER) &= ~IT8XXX2_EXT_ETXEN;
+	k_spin_unlock(&lock, key);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	uint32_t hw_cnt;
@@ -240,18 +252,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	/* Disable event timer */
 	IT8XXX2_EXT_CTRLX(EVENT_TIMER) &= ~IT8XXX2_EXT_ETXEN;
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * The kernel has no pending timeout, which it signals with
-		 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle no future
-		 * timer interrupt is required, so leave the event timer
-		 * disabled and stop waking up. Without sloppy idle we fall
-		 * through to the else and still schedule the (capped) timeout
-		 * so the uptime tick count stays correct.
-		 */
-		k_spin_unlock(&lock, key);
-		return;
-	} else {
+	{
 		uint32_t next_cycs;
 		uint32_t now;
 		uint32_t dcycles;

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -235,11 +235,10 @@ void sys_clock_unused(void)
 	k_spin_unlock(&lock, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	uint32_t hw_cnt;
 
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Always return for non-tickless kernel system */

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -12,11 +12,10 @@
  * - subtimer 0 is programmed as a one-shot down-counter for the next deadline
  *   in tickless mode, or as a periodic source when CONFIG_TICKLESS_KERNEL=n.
  *
- * GPTIMER has no absolute compare register, so a tick-aligned absolute
- * deadline is computed against the free-running counter and programmed as a
- * relative delay (subtimer 0 reload). The ISR derives the number of elapsed
- * ticks from the free-running counter, so a late or coalesced interrupt
- * announces every elapsed tick rather than dropping it.
+ * GPTIMER has no absolute compare register, only a relative reload, so this is
+ * a RELOAD backend: the free-running subtimer 1 is the cycle source and the
+ * generic core turns a tick-aligned deadline into the relative delay loaded
+ * into subtimer 0.
  */
 
 #define DT_DRV_COMPAT gaisler_gptimer
@@ -33,23 +32,16 @@
  */
 #define PRESCALER 8U
 
-/* Counter cycles per kernel tick (the subtimer clock is HW cycles / PRESCALER).
- * Derived from CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC so it tracks the system clock.
+/* The subtimers run at the system cycle rate divided by the shared prescaler.
+ * That is the rate timer_driver_cycle_get() reports, so the core derives its
+ * cycles-per-tick from it; only the public sys_clock_cycle_get_32() scales back
+ * up to the system cycle rate.
  */
-#define CYC_PER_TICK \
-	(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / PRESCALER / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-
-/* A programmed delay is detected as already-passed via a signed 32-bit delta
- * in sys_clock_set_timeout() and is loaded into a 32-bit reload, so it must
- * stay below 2^31 cycles.
- */
-#define MAX_CYCLES 0x7FFFFFFFU
-#define MAX_TICKS  (MAX_CYCLES / CYC_PER_TICK)
+#define TIMER_CORE_CYCLES_PER_SEC (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / PRESCALER)
 
 /* Smallest delay programmed into subtimer 0. program_subtimer0() writes
  * reload = delay - 1, so delay must be at least 2 to avoid a reload of 0
- * (and the wraparound for delay == 0); a deadline at or before "now" fires
- * as soon as possible and the ISR catches up.
+ * (and the wraparound for delay == 0).
  */
 #define MIN_DELAY_CYC 2U
 
@@ -97,13 +89,10 @@ static int get_timer_irq(void)
 
 static uint32_t gptimer_ctrl_clear_ip;
 
-/* Free-running up-counter (subtimer 1) in cycles. Wraps every 2^32 cycles;
- * unsigned subtraction against the announce baseline stays correct across a
- * single wrap.
+/* Free-running up-counter (subtimer 1) in subtimer cycles. Wraps every 2^32
+ * cycles; the core masks deltas against its baseline so this stays correct
+ * across a single wrap.
  */
-static uint32_t announced_cyc; /* counter value at the last announce (tick-aligned) */
-static uint32_t last_elapsed;  /* ticks reported by the last sys_clock_elapsed() */
-
 static inline uint32_t up_counter(volatile struct gptimer_regs *regs)
 {
 	return 0U - regs->timer[1].counter;
@@ -125,23 +114,39 @@ static void program_subtimer0(volatile struct gptimer_regs *regs, uint32_t delay
 	tmr->ctrl = ctrl;
 }
 
+#define TIMER_CORE_BACKEND_RELOAD
+#define TIMER_CORE_MIN_DELAY MIN_DELAY_CYC
+#define TIMER_CORE_HAVE_CYCLE_GET_32
+
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return up_counter(get_regs());
+}
+
+static void timer_driver_set_reload(uint32_t cycles)
+{
+	program_subtimer0(get_regs(), cycles);
+}
+
+#include "system_timer_generic.h"
+
+uint32_t sys_clock_cycle_get_32(void)
+{
+	/* Scale the subtimer count back up to the system cycle rate the kernel
+	 * expects.
+	 */
+	return up_counter(get_regs()) * PRESCALER;
+}
+
 static void timer_isr(const void *unused)
 {
 	ARG_UNUSED(unused);
 	volatile struct gptimer_regs *regs = get_regs();
 	volatile struct gptimer_timer_regs *tmr = &regs->timer[0];
-	uint32_t dticks;
 
 	if ((tmr->ctrl & GPTIMER_CTRL_IP) == 0) {
 		return; /* interrupt not for us */
 	}
-
-	/* Whole ticks elapsed since the last announce, taken from the
-	 * free-running counter so a late interrupt catches up every tick.
-	 */
-	dticks = (up_counter(regs) - announced_cyc) / CYC_PER_TICK;
-	announced_cyc += dticks * CYC_PER_TICK;
-	last_elapsed = 0;
 
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* One-shot: stop and clear pending; sys_clock_set_timeout()
@@ -154,60 +159,7 @@ static void timer_isr(const void *unused)
 			    GPTIMER_CTRL_EN | gptimer_ctrl_clear_ip;
 	}
 
-	sys_clock_announce(dticks);
-}
-
-void sys_clock_set_timeout(uint32_t ticks)
-{
-	volatile struct gptimer_regs *regs = get_regs();
-	uint32_t target, now;
-	int32_t delay;
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	/* Cap to the cycle-count window: ticks * CYC_PER_TICK must stay below
-	 * 2^31 so the signed delay delta below cannot wrap. The kernel already
-	 * caps the requested tick count (SYS_CLOCK_MAX_WAIT), so this is the
-	 * only limit the driver still has to enforce.
-	 */
-	if (ticks > MAX_TICKS) {
-		ticks = MAX_TICKS;
-	}
-
-	/* Absolute, tick-aligned deadline from the last announce, programmed as
-	 * a relative delay. last_elapsed is the tick count already reported via
-	 * sys_clock_elapsed(), so the fire lands on the requested tick boundary
-	 * regardless of the sub-tick offset of the counter.
-	 */
-	target = announced_cyc + (last_elapsed + ticks) * CYC_PER_TICK;
-	now = up_counter(regs);
-	delay = target - now;
-	if (delay < (int32_t)MIN_DELAY_CYC) {
-		delay = MIN_DELAY_CYC;
-	}
-	program_subtimer0(regs, delay);
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	volatile struct gptimer_regs *regs = get_regs();
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	last_elapsed = (up_counter(regs) - announced_cyc) / CYC_PER_TICK;
-	return last_elapsed;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	volatile struct gptimer_regs *regs = get_regs();
-
-	/* Scale the counter back up to the system cycle rate the kernel expects. */
-	return up_counter(regs) * PRESCALER;
+	timer_core_announce();
 }
 
 static void init_downcounter(volatile struct gptimer_timer_regs *tmr)
@@ -237,19 +189,21 @@ static int sys_clock_driver_init(void)
 		gptimer_ctrl_clear_ip = GPTIMER_CTRL_IP;
 	}
 
-	/* Anchor the announce baseline to "now" so curr_tick == 0 maps to the
-	 * current free-running counter value.
-	 */
-	announced_cyc = up_counter(regs);
-
 	irq_connect_dynamic(timer_interrupt, 0, timer_isr, NULL, 0);
 	irq_enable(timer_interrupt);
 
-	/* Program the first deadline: one tick away. In tickless mode the
-	 * kernel reprograms via sys_clock_set_timeout(); in periodic mode this
-	 * is the recurring tick.
+	/* Seed the announce baseline from the free-running counter. In tickless
+	 * mode this also arms the first deadline (one tick out) and the kernel
+	 * reprograms via sys_clock_set_timeout() thereafter.
 	 */
-	program_subtimer0(regs, CYC_PER_TICK);
+	timer_core_init();
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/* Periodic mode: subtimer 0 auto-restarts (CTRL_RS) every tick and
+		 * the core never reprograms it.
+		 */
+		program_subtimer0(regs, TIMER_CORE_CYC_PER_TICK);
+	}
 
 	return 0;
 }

--- a/drivers/timer/leon_gptimer.c
+++ b/drivers/timer/leon_gptimer.c
@@ -157,9 +157,8 @@ static void timer_isr(const void *unused)
 	sys_clock_announce(dticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	volatile struct gptimer_regs *regs = get_regs();
 	uint32_t target, now;
 	int32_t delay;

--- a/drivers/timer/max32_rv32_sys_timer.c
+++ b/drivers/timer/max32_rv32_sys_timer.c
@@ -122,9 +122,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	uint32_t next_cycle;
 	uint32_t count;
 
-	if (ticks == SYS_CLOCK_MAX_WAIT) {
-		next_cycle = (last_tick * CYC_PER_TICK) + CYCLES_MAX;
-	} else if (ticks == 0) {
+	if (ticks == 0) {
 		next_cycle = MXC_TMR_GetCount(regs) + (CYC_PER_TICK * 3 / 2);
 		next_cycle -= (next_cycle % CYC_PER_TICK);
 	} else {

--- a/drivers/timer/max32_rv32_sys_timer.c
+++ b/drivers/timer/max32_rv32_sys_timer.c
@@ -112,7 +112,7 @@ uint32_t sys_clock_elapsed(void)
 	return delta_ticks;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/max32_wut_timer.c
+++ b/drivers/timer/max32_wut_timer.c
@@ -72,9 +72,8 @@ static void max32_wut_timer_isr(const void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : 1);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/mchp_sam_pit64b_timer.c
+++ b/drivers/timer/mchp_sam_pit64b_timer.c
@@ -79,9 +79,8 @@ static void pit64b_isr(const void *arg)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -182,6 +182,12 @@ static uint32_t last_announcement; /* last time we called sys_clock_announce() *
  * Writing a new value to preload only takes effect once the count
  * register reaches 0.
  */
+void sys_clock_unused(void)
+{
+	sys_write32(0, TIMER_BASE + TIMER_CR_OFS); /* stop timer */
+	cached_icr = TIMER_STOPPED;
+}
+
 void sys_clock_set_timeout(uint32_t n, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -190,16 +196,6 @@ void sys_clock_set_timeout(uint32_t n, bool idle)
 	int full_ticks;          /* number of complete ticks we'll wait */
 	uint32_t full_cycles;    /* full_ticks represented as cycles */
 	uint32_t partial_cycles; /* number of cycles to first tick boundary */
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && (n == SYS_CLOCK_MAX_WAIT)) {
-		/*
-		 * We are not in a locked section. Are writes to two
-		 * global objects safe from pre-emption?
-		 */
-		sys_write32(0, TIMER_BASE + TIMER_CR_OFS); /* stop timer */
-		cached_icr = TIMER_STOPPED;
-		return;
-	}
 
 	if (n < 1) {
 		full_ticks = 0;

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -188,9 +188,8 @@ void sys_clock_unused(void)
 	cached_icr = TIMER_STOPPED;
 }
 
-void sys_clock_set_timeout(uint32_t n, bool idle)
+void sys_clock_set_timeout(uint32_t n)
 {
-	ARG_UNUSED(idle);
 
 	uint32_t ccr, temp;
 	int full_ticks;          /* number of complete ticks we'll wait */

--- a/drivers/timer/mcux_gpt_timer.c
+++ b/drivers/timer/mcux_gpt_timer.c
@@ -130,7 +130,7 @@ void mcux_imx_gpt_isr(const void *arg)
  * Next needed call to sys_clock_announce will not be until the specified number
  * of ticks from the current time have elapsed.
  */
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Not supported on tickful kernels */

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -66,14 +66,14 @@ static inline uint32_t counter_delta(uint32_t now, uint32_t then)
 	return (now - then) & COUNTER_MAX;
 }
 
+void sys_clock_unused(void)
+{
+	LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
-		return;
-	}
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -71,9 +71,8 @@ void sys_clock_unused(void)
 	LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -244,6 +244,26 @@ bool z_nxp_os_timer_ignore_timer_wakeup(void)
 	return (wait_forever || counter_remaining_ticks);
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
+	/* No real wakeup deadline: track it for the counter-overflow wakeup
+	 * bookkeeping, then program the match as far out as the hardware allows.
+	 */
+	wait_forever = true;
+#endif
+	OSTIMER_SetMatchValue(base, MAX_CYC + last_count - cyc_sys_compensated, NULL);
+	counter_remaining_ticks = 0;
+
+	k_spin_unlock(&lock, key);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
@@ -260,10 +280,10 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		 */
 		return;
 	}
-	/* When using a counter for certain low power modes, set this flag when the requested
-	 * delay is forever. This is to keep track of wakeup sources in case of counter overflows.
+	/* A real deadline is being scheduled; the "no deadline" case is handled
+	 * by sys_clock_unused() instead.
 	 */
-	wait_forever = (ticks == SYS_CLOCK_MAX_WAIT);
+	wait_forever = false;
 #else
 	ARG_UNUSED(idle);
 #endif

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -264,7 +264,7 @@ void sys_clock_unused(void)
 	k_spin_unlock(&lock, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_idle_enter(uint32_t ticks)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Only for tickless kernel system */
@@ -273,19 +273,30 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
 	/* We intercept calls from idle with a 0 tick count when PM=y */
-	if (idle && (ticks == 0)) {
+	if (ticks == 0) {
 		mcux_os_timer_set_lp_counter_timeout();
 		/* A low power counter has been started. No need to
 		 * go further, simply return
 		 */
 		return;
 	}
+#endif
+	sys_clock_set_timeout(ticks, false);
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	ARG_UNUSED(idle);
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/* Only for tickless kernel system */
+		return;
+	}
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
 	/* A real deadline is being scheduled; the "no deadline" case is handled
 	 * by sys_clock_unused() instead.
 	 */
 	wait_forever = false;
-#else
-	ARG_UNUSED(idle);
 #endif
 	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -281,12 +281,11 @@ void sys_clock_idle_enter(uint32_t ticks)
 		return;
 	}
 #endif
-	sys_clock_set_timeout(ticks, false);
+	sys_clock_set_timeout(ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Only for tickless kernel system */
 		return;

--- a/drivers/timer/mcux_rtc_jdp_timer.c
+++ b/drivers/timer/mcux_rtc_jdp_timer.c
@@ -128,20 +128,9 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	uint32_t cycles;
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * No pending timeout and no future timer interrupt required:
-		 * wait as long as the hardware allows.
-		 */
-		cycles = cycles_max;
-	} else {
-		uint64_t wait_ticks = (uint64_t)last_elapsed + (uint64_t)ticks;
-		uint64_t wait_cycles = wait_ticks * (uint64_t)cycles_per_tick;
-
-		cycles = (wait_cycles > cycles_max) ? cycles_max : (uint32_t)wait_cycles;
-	}
+	uint64_t wait_ticks = (uint64_t)last_elapsed + (uint64_t)ticks;
+	uint64_t wait_cycles = wait_ticks * (uint64_t)cycles_per_tick;
+	uint32_t cycles = (wait_cycles > cycles_max) ? cycles_max : (uint32_t)wait_cycles;
 
 	rtc_jdp_set_compare(last_count + cycles);
 }

--- a/drivers/timer/mcux_rtc_jdp_timer.c
+++ b/drivers/timer/mcux_rtc_jdp_timer.c
@@ -118,9 +118,8 @@ static void rtc_jdp_set_compare(uint32_t compare)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/mcux_stm_timer.c
+++ b/drivers/timer/mcux_stm_timer.c
@@ -84,9 +84,8 @@ static void mcux_stm_timer_isr(const void *arg)
 	sys_clock_announce_locked(delta_ticks, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/mcux_sysctr_timer.c
+++ b/drivers/timer/mcux_sysctr_timer.c
@@ -167,13 +167,12 @@ void sys_clock_unused(void)
 	SYSCTR_DisableInterrupts(CMP_BASE, TIMER_CMP_INT_MASK);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	uint64_t next_cycle;
 	uint64_t now;
 	uint64_t min;
 
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/mcux_sysctr_timer.c
+++ b/drivers/timer/mcux_sysctr_timer.c
@@ -154,6 +154,19 @@ static void sysctr_timer_isr(const void *arg)
 	sys_clock_announce(delta_ticks);
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* No timeout pending: disable the compare interrupt entirely.
+	 * sys_clock_idle_exit() re-enables it on wake.
+	 */
+	SYSCTR_EnableCompare(CMP_BASE, TIMER_CMP_FRAME, false);
+	SYSCTR_DisableInterrupts(CMP_BASE, TIMER_CMP_INT_MASK);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	uint64_t next_cycle;
@@ -163,17 +176,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * No near deadline to schedule: under sloppy idle, disable the
-		 * compare interrupt entirely. sys_clock_idle_exit() will
-		 * re-enable it when the CPU wakes from an external source.
-		 */
-		SYSCTR_EnableCompare(CMP_BASE, TIMER_CMP_FRAME, false);
-		SYSCTR_DisableInterrupts(CMP_BASE, TIMER_CMP_INT_MASK);
 		return;
 	}
 

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -7,26 +7,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <limits.h>
-
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys_clock.h>
-#include <zephyr/spinlock.h>
 #include <soc.h>
 #include <mips/mipsregs.h>
 
-#define CYC_PER_TICK ((uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec() \
-				 / (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC))
-#define MAX_CYC INT_MAX
-#define MAX_TICKS ((MAX_CYC - CYC_PER_TICK) / CYC_PER_TICK)
 #define MIN_DELAY 1000
-
-#define TICKLESS IS_ENABLED(CONFIG_TICKLESS_KERNEL)
-
-static struct k_spinlock lock;
-static uint32_t last_count;
 
 static ALWAYS_INLINE void set_cp0_compare(uint32_t time)
 {
@@ -38,90 +26,51 @@ static ALWAYS_INLINE uint32_t get_cp0_count(void)
 	return _mips_read_32bit_c0_register(CP0_COUNT);
 }
 
+/*
+ * A free-running 32-bit CP0 Count with an equality-match Compare register: a
+ * COMPARE backend on a 32-bit counter (TIMER_CORE_CYCLES_WIDTH defaults to the native
+ * width, so the core masks deltas at the 2^32 wrap). Because Compare fires only
+ * on Count == Compare, an already-past target is missed until Count wraps, so
+ * timer_driver_set_compare() bumps the target until it is at least MIN_DELAY ahead,
+ * satisfying the core's "must not miss a past deadline" contract. Writing
+ * Compare also clears the pending interrupt.
+ */
+#define TIMER_CORE_BACKEND_COMPARE
+
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return get_cp0_count();
+}
+
+static inline void timer_driver_set_compare(uint64_t cycles)
+{
+	uint32_t next = (uint32_t)cycles;
+
+	set_cp0_compare(next);
+
+	uint32_t now = get_cp0_count();
+
+	while ((int32_t)(next - now) < (int32_t)MIN_DELAY) {
+		next = now + MIN_DELAY;
+		set_cp0_compare(next);
+		now = get_cp0_count();
+	}
+}
+
+#include "system_timer_generic.h"
+
 static void timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t now = get_cp0_count();
-	uint32_t dticks = ((now - last_count) / CYC_PER_TICK);
-
-	last_count = now;
-
-	if (!TICKLESS) {
-		uint32_t next = last_count + CYC_PER_TICK;
-
-		if (next - now < MIN_DELAY) {
-			next += CYC_PER_TICK;
-		}
-		set_cp0_compare(next);
-	}
-
-	k_spin_unlock(&lock, key);
-	sys_clock_announce(TICKLESS ? dticks : 1);
-}
-
-void sys_clock_set_timeout(uint32_t ticks)
-{
-
-	if (!TICKLESS) {
-		return;
-	}
-
-	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t current_count = get_cp0_count();
-	uint32_t delay_wanted = ticks * CYC_PER_TICK;
-
-	/* Round up to next tick boundary. */
-	uint32_t adj = (current_count - last_count) + (CYC_PER_TICK - 1);
-
-	if (delay_wanted <= MAX_CYC - adj) {
-		delay_wanted += adj;
-	} else {
-		delay_wanted = MAX_CYC;
-	}
-	delay_wanted = (delay_wanted / CYC_PER_TICK) * CYC_PER_TICK;
-
-	if ((int32_t)(delay_wanted + last_count - current_count) < MIN_DELAY) {
-		delay_wanted += CYC_PER_TICK;
-	}
-
-	set_cp0_compare(delay_wanted + last_count);
-	k_spin_unlock(&lock, key);
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	if (!TICKLESS) {
-		return 0;
-	}
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint32_t ticks_elapsed = (get_cp0_count() - last_count) / CYC_PER_TICK;
-
-	k_spin_unlock(&lock, key);
-	return ticks_elapsed;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	return get_cp0_count();
+	timer_core_announce();
 }
 
 static int sys_clock_driver_init(void)
 {
 
 	IRQ_CONNECT(MIPS_MACHINE_TIMER_IRQ, 0, timer_isr, NULL, 0);
-	last_count = get_cp0_count();
-
-	/*
-	 * In a tickless system the first tick might possibly be pushed
-	 * much further into the future than is being done here.
-	 */
-	set_cp0_compare(last_count + CYC_PER_TICK);
-
+	timer_core_init();
 	irq_enable(MIPS_MACHINE_TIMER_IRQ);
 
 	return 0;

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -61,9 +61,8 @@ static void timer_isr(const void *arg)
 	sys_clock_announce(TICKLESS ? dticks : 1);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!TICKLESS) {
 		return;

--- a/drivers/timer/mtk_adsp_timer.c
+++ b/drivers/timer/mtk_adsp_timer.c
@@ -135,7 +135,7 @@ uint64_t sys_clock_cycle_get_64(void)
 	return (((uint64_t)h0) << 32) | l;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	/* Compute desired expiration time */
 	uint64_t now = sys_clock_cycle_get_64();
@@ -205,7 +205,7 @@ static void timer_isr(__maybe_unused void *arg)
 	sys_clock_announce(ticks);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		sys_clock_set_timeout(1, false);
+		sys_clock_set_timeout(1);
 	}
 }
 

--- a/drivers/timer/native_sim_timer.c
+++ b/drivers/timer/native_sim_timer.c
@@ -17,23 +17,46 @@
 #include "nsi_timer_model.h"
 #include "soc.h"
 
-static uint64_t tick_period; /* System tick period in microseconds */
-/* Time (microseconds since boot) of the last timer tick interrupt */
-static uint64_t last_tick_time;
+/* The cycle counter is nsi_hws_get_time(), which counts microseconds. */
+#define TIMER_CORE_CYCLES_PER_SEC 1000000
+#define TICK_PERIOD_US (TIMER_CORE_CYCLES_PER_SEC / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 
-/**
- * Return the current HW cycle counter
- * (number of microseconds since boot in 32bits)
+/*
+ * The native simulator has no compare register. Time is the microsecond
+ * counter nsi_hws_get_time(), and the only lever is hwtimer_set_silent_ticks(),
+ * which skips that many periodic tick interrupts before raising the next one.
+ * It still fits the COMPARE model: timer_driver_cycle_get() reads the (64-bit,
+ * non-wrapping) microsecond counter and timer_driver_set_compare() turns an absolute
+ * deadline into the number of ticks to skip. The deadline is a full 64-bit
+ * value (a 32-bit RELOAD reload would cap the fast-forward idle periods the
+ * simulator relies on).
  */
-uint32_t sys_clock_cycle_get_32(void)
+#define TIMER_CORE_CYCLES_WIDTH 64
+#define TIMER_CORE_BACKEND_COMPARE
+#define TIMER_CORE_64BIT_CYCLES
+
+static inline uint64_t timer_driver_cycle_get(void)
 {
 	return nsi_hws_get_time();
 }
 
-uint64_t sys_clock_cycle_get_64(void)
+static void timer_driver_set_compare(uint64_t cycles)
 {
-	return nsi_hws_get_time();
+	uint64_t now = nsi_hws_get_time();
+	uint64_t rel = (cycles > now) ? (cycles - now) : 0U;
+
+	/* The deadline is tick-aligned and the simulator only raises interrupts
+	 * on tick boundaries, so round up to the boundary at or after it (now may
+	 * be mid-tick, e.g. after a busy-wait). set_silent_ticks(n) skips n
+	 * interrupts and raises the (n+1)th, so a deadline n boundaries out skips
+	 * n - 1.
+	 */
+	int64_t ticks = (int64_t)((rel + TICK_PERIOD_US - 1U) / TICK_PERIOD_US);
+
+	hwtimer_set_silent_ticks(ticks > 0 ? ticks - 1 : 0);
 }
+
+#include "system_timer_generic.h"
 
 /**
  * Interrupt handler for the timer interrupt
@@ -43,11 +66,7 @@ static void np_timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	uint64_t now = nsi_hws_get_time();
-	int32_t elapsed_ticks = (now - last_tick_time)/tick_period;
-
-	last_tick_time += elapsed_ticks*tick_period;
-	sys_clock_announce(elapsed_ticks);
+	timer_core_announce();
 }
 
 /**
@@ -56,43 +75,6 @@ static void np_timer_isr(const void *arg)
 void np_timer_isr_test_hook(const void *arg)
 {
 	np_timer_isr(NULL);
-}
-
-/**
- * @brief Set system clock timeout
- *
- * Informs the system clock driver that the next needed call to
- * sys_clock_announce() will not be until the specified number of ticks
- * from the current time have elapsed.
- *
- * See system_timer.h for more information
- *
- * @param ticks Timeout in tick units
- * @param idle Hint to the driver that the system is about to enter
- *        the idle state immediately after setting the timeout
- */
-void sys_clock_set_timeout(uint32_t ticks)
-{
-
-#if defined(CONFIG_TICKLESS_KERNEL)
-	uint64_t silent_ticks;
-
-	silent_ticks = (ticks > 0) ? ticks - 1 : 0;
-	hwtimer_set_silent_ticks(silent_ticks);
-#endif
-}
-
-/**
- * @brief Ticks elapsed since last sys_clock_announce() call
- *
- * Queries the clock driver for the current time elapsed since the
- * last call to sys_clock_announce() was made.  The kernel will call
- * this with appropriate locking, the driver needs only provide an
- * instantaneous answer.
- */
-uint32_t sys_clock_elapsed(void)
-{
-	return (nsi_hws_get_time() - last_tick_time)/tick_period;
 }
 
 /**
@@ -113,14 +95,15 @@ void sys_clock_disable(void)
  */
 static int sys_clock_driver_init(void)
 {
-
-	tick_period = 1000000UL / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-	last_tick_time = nsi_hws_get_time();
-	hwtimer_enable(tick_period);
+	hwtimer_enable(TICK_PERIOD_US);
 
 	IRQ_CONNECT(TIMER_TICK_IRQ, 1, np_timer_isr, 0, 0);
 	irq_enable(TIMER_TICK_IRQ);
+
+	/* Seed the announce baseline from the microsecond counter and arm the
+	 * first tick.
+	 */
+	timer_core_init();
 
 	return 0;
 }

--- a/drivers/timer/native_sim_timer.c
+++ b/drivers/timer/native_sim_timer.c
@@ -71,9 +71,8 @@ void np_timer_isr_test_hook(const void *arg)
  * @param idle Hint to the driver that the system is about to enter
  *        the idle state immediately after setting the timeout
  */
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint64_t silent_ticks;

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -254,9 +254,8 @@ static uint32_t npcx_itim_evt_elapsed_cyc32(void)
 #endif /* CONFIG_PM */
 
 /* System timer api functions */
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* Only for tickless kernel system */

--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -626,9 +626,8 @@ static int grtc_post_init(void)
 #endif
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -682,9 +682,8 @@ void sys_clock_unused(void)
 	sys_busy = false;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	uint64_t target_time;
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -667,6 +667,21 @@ bail:
 	return err;
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* No timeout pending: follow the free-running-compare model and stop
+	 * reprogramming. The last compare still catches the counter wrap and
+	 * the next sys_clock_set_timeout() re-arms us, so sloppy idle needs no
+	 * periodic wakeup here. Only clear the busy flag consumed by the
+	 * overflow trigger path.
+	 */
+	sys_busy = false;
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -676,22 +691,17 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	target_time = last_count +
+		      ((uint64_t)last_elapsed + (uint64_t)ticks) * CYC_PER_TICK;
+	/* Clamp to fit the 24-bit compare register and keep the
+	 * anchor in its valid range (see anchor_update). A resulting
+	 * target in the past is fine: compare_set forces an immediate
+	 * IRQ and the handler catches up in one shot.
+	 */
+	if ((target_time - last_count) > MAX_CYCLES) {
 		target_time = last_count + MAX_CYCLES;
-		sys_busy = false;
-	} else {
-		target_time = last_count +
-			      ((uint64_t)last_elapsed + (uint64_t)ticks) * CYC_PER_TICK;
-		/* Clamp to fit the 24-bit compare register and keep the
-		 * anchor in its valid range (see anchor_update). A resulting
-		 * target in the past is fine: compare_set forces an immediate
-		 * IRQ and the handler catches up in one shot.
-		 */
-		if ((target_time - last_count) > MAX_CYCLES) {
-			target_time = last_count + MAX_CYCLES;
-		}
-		sys_busy = true;
 	}
+	sys_busy = true;
 
 	compare_set(SYS_CLOCK_CH, target_time, sys_clock_timeout_handler, NULL, false);
 }

--- a/drivers/timer/openrisc_tick_timer.c
+++ b/drivers/timer/openrisc_tick_timer.c
@@ -65,7 +65,7 @@ void z_openrisc_timer_isr(void)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 #if defined(CONFIG_TICKLESS_KERNEL)
 	/*
@@ -85,7 +85,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 #else  /* CONFIG_TICKLESS_KERNEL */
 	ARG_UNUSED(ticks);
-	ARG_UNUSED(idle);
 #endif
 }
 

--- a/drivers/timer/openrisc_tick_timer.c
+++ b/drivers/timer/openrisc_tick_timer.c
@@ -7,18 +7,12 @@
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
-#include <zephyr/spinlock.h>
 #include <zephyr/sys_clock.h>
 
 #include <openrisc/openriscregs.h>
 
-#define MAX_CYC SPR_TTMR_TP
-
-static struct k_spinlock lock;
-static uint32_t last_count;
-static uint64_t last_ticks;
-static uint32_t last_elapsed;
-static uint32_t cyc_per_tick;
+#define MAX_CYC   SPR_TTMR_TP
+#define MIN_DELAY 1000
 
 static ALWAYS_INLINE void set_compare(uint32_t time)
 {
@@ -35,91 +29,72 @@ static ALWAYS_INLINE uint32_t get_count(void)
 	return openrisc_read_spr(SPR_TTCR);
 }
 
+/* Signed distance between two counts in the 28-bit compare domain: mask to the
+ * TP field width, then shift the top bit to bit 31 so the arithmetic shift
+ * sign-extends it back.
+ */
+static ALWAYS_INLINE int32_t cyc_diff(uint32_t a, uint32_t b)
+{
+	return (int32_t)(((a - b) & MAX_CYC) << 4) >> 4;
+}
+
+/*
+ * Free-running TTCR count with an equality-match TTMR compare: a COMPARE
+ * backend. The compare (TTMR.TP) is only 28 bits wide while TTCR is 32, so the
+ * counter is treated as 28-bit (TIMER_CORE_CYCLES_WIDTH) and the target is masked to that
+ * width. TTMR matches only TTCR[27:0] == TP, so timer_driver_set_compare() bumps an
+ * already-past target at least MIN_DELAY ahead rather than let it wait for the
+ * 28-bit count to wrap, meeting the core's "must not miss a past deadline"
+ * contract; writing TTMR also clears the pending interrupt.
+ */
+#define TIMER_CORE_CYCLES_WIDTH 28
+#define TIMER_CORE_BACKEND_COMPARE
+
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return get_count();
+}
+
+static inline void timer_driver_set_compare(uint64_t cycles)
+{
+	uint32_t next = (uint32_t)cycles & MAX_CYC;
+
+	set_compare(next);
+
+	uint32_t now = get_count() & MAX_CYC;
+
+	while (cyc_diff(next, now) < (int32_t)MIN_DELAY) {
+		next = (now + MIN_DELAY) & MAX_CYC;
+		set_compare(next);
+		now = get_count() & MAX_CYC;
+	}
+}
+
+#include "system_timer_generic.h"
+
 void z_openrisc_timer_isr(void)
 {
 	if (IS_ENABLED(CONFIG_TRACING_ISR)) {
 		sys_trace_isr_enter();
 	}
 
-	const k_spinlock_key_t key = k_spin_lock(&lock);
-
-	const uint32_t current_count = get_count();
-	const uint32_t delta_count = current_count - last_count;
-	const uint32_t delta_ticks = delta_count / cyc_per_tick;
-
-	last_count += delta_ticks * cyc_per_tick;
-	last_ticks += delta_ticks;
-	last_elapsed = 0;
-
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/* Disarm; the kernel re-arms through sys_clock_set_timeout() after
+		 * the announce. A tickful kernel re-arms in timer_core_announce().
+		 */
 		clear_compare();
-	} else {
-		set_compare((last_count + cyc_per_tick) & MAX_CYC);
 	}
 
-	k_spin_unlock(&lock, key);
-	sys_clock_announce(delta_ticks);
+	timer_core_announce();
 
 	if (IS_ENABLED(CONFIG_TRACING_ISR)) {
 		sys_trace_isr_exit();
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks)
-{
-#if defined(CONFIG_TICKLESS_KERNEL)
-	/*
-	 * Clamp the max period length to a number of cycles that can fit
-	 * in half the range of a cycle_diff_t for native width divisions
-	 * to be usable elsewhere. The half range gives us extra room to cope
-	 * with the unavoidable IRQ servicing latency.
-	 */
-	ticks = MIN(ticks, MAX_CYC / 2 / cyc_per_tick);
-
-	const uint32_t compare =
-		((last_ticks + last_elapsed + (uint32_t)ticks) * cyc_per_tick) & MAX_CYC;
-	const k_spinlock_key_t key = k_spin_lock(&lock);
-
-	set_compare(compare);
-	k_spin_unlock(&lock, key);
-
-#else  /* CONFIG_TICKLESS_KERNEL */
-	ARG_UNUSED(ticks);
-#endif
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	const k_spinlock_key_t key = k_spin_lock(&lock);
-
-	const uint32_t current_count = get_count();
-	const uint32_t delta_count = current_count - last_count;
-	const uint32_t delta_ticks = delta_count / cyc_per_tick;
-
-	last_elapsed = delta_ticks;
-	k_spin_unlock(&lock, key);
-	return delta_ticks;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	return get_count();
-}
-
 static int sys_clock_driver_init(void)
 {
-	cyc_per_tick = (uint32_t)((uint64_t)sys_clock_hw_cycles_per_sec() /
-		(uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC);
-
-	last_ticks = get_count() / cyc_per_tick;
-	last_count = last_ticks * cyc_per_tick;
-	last_elapsed = 0;
-
-	set_compare((last_count + cyc_per_tick) & MAX_CYC);
+	timer_core_init();
 
 	return 0;
 }

--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -104,9 +104,8 @@ void sys_clock_unused(void)
 	previous_cnt = RTMR_TIMER_STOPPED;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	uint32_t cur_cnt, temp;
 	int full_ticks;

--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -98,6 +98,12 @@ static void rtmr_isr(const void *arg)
 	sys_clock_announce(ticks);
 }
 
+void sys_clock_unused(void)
+{
+	RTMR_REG->CTRL = 0U;
+	previous_cnt = RTMR_TIMER_STOPPED;
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -106,12 +112,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	int full_ticks;
 	uint32_t full_cycles;
 	uint32_t partial_cycles;
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && (ticks == SYS_CLOCK_MAX_WAIT)) {
-		RTMR_REG->CTRL = 0U;
-		previous_cnt = RTMR_TIMER_STOPPED;
-		return;
-	}
 
 	if (ticks < 1) {
 		full_ticks = 0;

--- a/drivers/timer/renesas_ra_ulpt_timer.c
+++ b/drivers/timer/renesas_ra_ulpt_timer.c
@@ -91,11 +91,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	/* No timeout change when the kernel has no near deadline to schedule. */
-	if (ticks == SYS_CLOCK_MAX_WAIT) {
-		return;
-	}
-
 	/* Preserve the original behavior even though it looks wrong; to be
 	 * revisited.
 	 */

--- a/drivers/timer/renesas_ra_ulpt_timer.c
+++ b/drivers/timer/renesas_ra_ulpt_timer.c
@@ -82,9 +82,8 @@ static void ra_ulpt_timer_isr(void)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	/* Timeout configuration is unsupported in tickful mode. */
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {

--- a/drivers/timer/renesas_ra_ulpt_timer.c
+++ b/drivers/timer/renesas_ra_ulpt_timer.c
@@ -7,7 +7,6 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/irq.h>
-#include <zephyr/spinlock.h>
 #include <zephyr/sys_clock.h>
 #include <soc.h>
 
@@ -42,96 +41,43 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 2,
 /* Macro to get ELC event for ULPT interrupt based on the channel. */
 #define ELC_EVENT_ULPT_INT(channel) CONCAT(ELC_EVENT_ULPT, channel, _INT)
 
-/* Calculated constants for timer operation. */
-#define CYCLE_PER_TICK ((sys_clock_hw_cycles_per_sec() / CONFIG_SYS_CLOCK_TICKS_PER_SEC))
-#define MAX_TICKS      ((k_ticks_t)(RA_ULPT_RELOAD_MAX / CYCLE_PER_TICK) - 1)
+/*
+ * INST1 free-runs and provides the cycle counter (its down-counter read back
+ * inverted counts up); INST0 is armed with a relative delay and its underflow
+ * announces ticks. That makes this a RELOAD backend whose cycle source is a
+ * genuine free-running counter, so the generic core owns the tick accounting
+ * and the tick-aligned deadline.
+ */
+#define TIMER_CORE_BACKEND_RELOAD
+#define TIMER_CORE_MIN_DELAY (RA_ULPT_RELOAD_MIN + RA_ULPT_RELOAD_DELAY)
 
-/* Static variables for maintaining timer state. */
-static uint32_t cycle_announced;
-static struct k_spinlock lock;
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return ~RA_ULPT_INST1_REG->ULPTCNT;
+}
+
+static void timer_driver_set_reload(uint32_t cycles)
+{
+	/* INST0 counts down 'cycles' then underflows. Account for the fixed
+	 * reload delay of the hardware and the off-by-one of the count register.
+	 */
+	RA_ULPT_INST0_REG->ULPTCNT = (cycles - RA_ULPT_RELOAD_DELAY) - 1U;
+}
+
+#include "system_timer_generic.h"
 
 static void ra_ulpt_timer_isr(void)
 {
-	uint32_t cycles;
-	uint32_t dcycles;
-	uint32_t dticks;
 	IRQn_Type irq = R_FSP_CurrentIrqGet();
 
 	/* Clear pending IRQ to prevent re-triggering. */
 	R_BSP_IrqStatusClear(irq);
 
 	if (RA_ULPT_INST0_REG->ULPTCR_b.TUNDF) {
-		k_spinlock_key_t key = k_spin_lock(&lock);
-
-		if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-			/* Calculate elapsed cycles and ticks. */
-			cycles = ~RA_ULPT_INST1_REG->ULPTCNT;
-			dcycles = cycles - cycle_announced;
-			dticks = dcycles / CYCLE_PER_TICK;
-			cycle_announced += dticks * CYCLE_PER_TICK;
-		} else {
-			/* In tickful mode, announce one tick at a time. */
-			dticks = 1;
-		}
-		/* Clear the underflow flag. */
+		/* Clear the underflow flag and let the core announce. */
 		RA_ULPT_INST0_REG->ULPTCR_b.TUNDF = 0;
-		k_spin_unlock(&lock, key);
-
-		/* Announce the elapsed ticks to the kernel. */
-		sys_clock_announce(dticks);
+		timer_core_announce();
 	}
-}
-
-void sys_clock_set_timeout(uint32_t ticks)
-{
-
-	/* Timeout configuration is unsupported in tickful mode. */
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	/* Preserve the original behavior even though it looks wrong; to be
-	 * revisited.
-	 */
-	if (ticks >= 1) {
-		ticks -= 1;
-	}
-	if (ticks > MAX_TICKS) {
-		ticks = MAX_TICKS;
-	}
-
-	/* Calculate the timer delay in cycles. */
-	uint32_t cycles = ~RA_ULPT_INST1_REG->ULPTCNT;
-	uint32_t unannounced = cycles - cycle_announced;
-	uint32_t delay = ticks * CYCLE_PER_TICK;
-
-	/* Adjust delay to align with tick boundaries. */
-	delay += unannounced;
-	delay = DIV_ROUND_UP(delay, CYCLE_PER_TICK) * CYCLE_PER_TICK;
-	delay -= unannounced;
-	delay = MAX(delay, RA_ULPT_RELOAD_MIN + RA_ULPT_RELOAD_DELAY);
-	delay -= RA_ULPT_RELOAD_DELAY;
-
-	/* Update the timer counter. */
-	RA_ULPT_INST0_REG->ULPTCNT = delay - 1U;
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	/* Elapsed time calculation is unsupported in tickful mode. */
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	/* Calculate and return the number of elapsed cycles. */
-	uint32_t cycles = ~RA_ULPT_INST1_REG->ULPTCNT - cycle_announced;
-
-	return (cycles / CYCLE_PER_TICK);
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	return ~RA_ULPT_INST1_REG->ULPTCNT;
 }
 
 static int sys_clock_driver_init(void)
@@ -169,7 +115,7 @@ static int sys_clock_driver_init(void)
 	RA_ULPT_INST1_REG->ULPTCMSR = 0U;
 
 	/* Initialize timer counters. */
-	RA_ULPT_INST0_REG->ULPTCNT = CYCLE_PER_TICK - 1U;
+	RA_ULPT_INST0_REG->ULPTCNT = TIMER_CORE_CYC_PER_TICK - 1U;
 	RA_ULPT_INST1_REG->ULPTCNT = RA_ULPT_RELOAD_MAX;
 
 	/* Set up interrupts for timer instance 0. */
@@ -187,7 +133,11 @@ static int sys_clock_driver_init(void)
 				   RA_ULPT_INST0_REG->ULPTCR_b.TCSTF);
 	FSP_HARDWARE_REGISTER_WAIT(RA_ULPT_INST1_REG->ULPTCR_b.TSTART,
 				   RA_ULPT_INST1_REG->ULPTCR_b.TCSTF);
-	cycle_announced = 0U;
+
+	/* Seed the core baseline from the free-running counter and arm the first
+	 * tick.
+	 */
+	timer_core_init();
 
 	return 0;
 }

--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -207,7 +207,7 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -213,11 +213,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	/* Nothing to do when the kernel has no near deadline to schedule. */
-	if (ticks == SYS_CLOCK_MAX_WAIT) {
-		return;
-	}
-
 	/* Preserve the original behavior even though it looks wrong; to be
 	 * revisited.
 	 */

--- a/drivers/timer/renesas_rz_gtm_timer.c
+++ b/drivers/timer/renesas_rz_gtm_timer.c
@@ -89,9 +89,8 @@ static void ostm_irq_handler(timer_callback_args_t *arg)
 	sys_clock_announce(delta_ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/renesas_rza2m_os_timer.c
+++ b/drivers/timer/renesas_rza2m_os_timer.c
@@ -103,9 +103,8 @@ static void ostm_irq_handler(const struct device *dev)
 	sys_clock_announce(delta_ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <limits.h>
-
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/timer/system_timer.h>
@@ -18,27 +16,6 @@
 #define MTIME_REG    DT_INST_REG_ADDR_BY_NAME(0, mtime)
 #define MTIMECMP_REG DT_INST_REG_ADDR_BY_NAME(0, mtimecmp)
 #define TIMER_IRQN   DT_INST_IRQN(0)
-
-#define CYC_PER_TICK (uint32_t)(sys_clock_hw_cycles_per_sec() / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-
-/* the unsigned long cast limits divisions to native CPU register width */
-#define cycle_diff_t   unsigned long
-#define CYCLE_DIFF_MAX (~(cycle_diff_t)0)
-
-/*
- * Maximum number of cycles to wait between two sys_clock_announce() reports:
- * the elapsed cycle count must fit in a cycle_diff_t before it is divided down
- * to ticks. Reserve 1/4 of the range as headroom for the unavoidable IRQ
- * servicing latency so a late report still fits, then add the LSB so the value
- * clears a run of low set bits for a nicer literal in the generated assembly.
- */
-#define CYCLES_MAX_1 ((uint64_t)CYCLE_DIFF_MAX)
-#define CYCLES_MAX_2 (CYCLES_MAX_1 / 2 + CYCLES_MAX_1 / 4)
-#define CYCLES_MAX   (CYCLES_MAX_2 + LSB_GET(CYCLES_MAX_2))
-
-static uint64_t last_count;
-static uint64_t last_ticks;
-static uint32_t last_elapsed;
 
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = TIMER_IRQN;
@@ -86,61 +63,33 @@ static uint64_t mtime(void)
 #endif
 }
 
+/*
+ * Free-running mtime counter plus an absolute mtimecmp compare: a COMPARE
+ * backend. The generic core owns the tick accounting; this driver only reads
+ * the counter and arms the comparator. The public cycle counter is the raw
+ * mtime scaled by the DT divider, so it overrides the core's default.
+ */
+#define TIMER_CORE_BACKEND_COMPARE
+#define TIMER_CORE_HAVE_CYCLE_GET_32
+#define TIMER_CORE_HAVE_CYCLE_GET_64
+
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return mtime();
+}
+
+static inline void timer_driver_set_compare(uint64_t cycles)
+{
+	set_mtimecmp(cycles);
+}
+
+#include "system_timer_generic.h"
+
 static void timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	k_spinlock_key_t key = sys_clock_lock();
-
-	uint64_t now = mtime();
-	uint64_t dcycles = now - last_count;
-	uint32_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
-
-	last_count += (cycle_diff_t)dticks * CYC_PER_TICK;
-	last_ticks += dticks;
-	last_elapsed = 0;
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		uint64_t next = last_count + CYC_PER_TICK;
-
-		set_mtimecmp(next);
-	}
-
-	sys_clock_announce_locked(dticks, key);
-}
-
-void sys_clock_set_timeout(uint32_t ticks)
-{
-
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	uint64_t cyc;
-
-	cyc = (last_ticks + last_elapsed + ticks) * CYC_PER_TICK;
-	if ((cyc - last_count) > CYCLES_MAX) {
-		cyc = last_count + CYCLES_MAX;
-	}
-	set_mtimecmp(cyc);
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	uint64_t now = mtime();
-	uint64_t dcycles = now - last_count;
-	uint32_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
-
-	last_elapsed = dticks;
-	return dticks;
+	timer_core_announce();
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -156,9 +105,7 @@ uint64_t sys_clock_cycle_get_64(void)
 static int sys_clock_driver_init(void)
 {
 	IRQ_CONNECT(TIMER_IRQN, 0, timer_isr, NULL, 0);
-	last_ticks = mtime() / CYC_PER_TICK;
-	last_count = last_ticks * CYC_PER_TICK;
-	set_mtimecmp(last_count + CYC_PER_TICK);
+	timer_core_init();
 	irq_enable(TIMER_IRQN);
 	return 0;
 }
@@ -166,7 +113,7 @@ static int sys_clock_driver_init(void)
 #ifdef CONFIG_SMP
 void smp_timer_init(void)
 {
-	set_mtimecmp(last_count + CYC_PER_TICK);
+	timer_core_smp_prime();
 	irq_enable(TIMER_IRQN);
 }
 #endif

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -109,9 +109,8 @@ static void timer_isr(const void *arg)
 	sys_clock_announce_locked(dticks, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 

--- a/drivers/timer/riscv_supervisor_timer.c
+++ b/drivers/timer/riscv_supervisor_timer.c
@@ -98,9 +98,8 @@ static void timer_isr(const void *arg)
 	sys_clock_announce(dticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/riscv_supervisor_timer.c
+++ b/drivers/timer/riscv_supervisor_timer.c
@@ -6,41 +6,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <limits.h>
-
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys_clock.h>
-#include <zephyr/spinlock.h>
 #include <zephyr/irq.h>
 #include <zephyr/arch/riscv/csr.h>
 #include <zephyr/arch/riscv/sbi.h>
 
-#define CYC_PER_TICK (uint32_t)(sys_clock_hw_cycles_per_sec() / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-
-/* the unsigned long cast limits divisions to native CPU register width */
-#define cycle_diff_t   unsigned long
-#define CYCLE_DIFF_MAX (~(cycle_diff_t)0)
-
-/*
- * Maximum number of cycles to wait between two sys_clock_announce() reports:
- * the elapsed cycle count must fit in a cycle_diff_t before it is divided down
- * to ticks. Reserve 1/4 of the range as headroom for the unavoidable IRQ
- * servicing latency so a late report still fits, then add the LSB so the value
- * clears a run of low set bits for a nicer literal in the generated assembly.
- */
-#define CYCLES_MAX_1 ((uint64_t)CYCLE_DIFF_MAX)
-#define CYCLES_MAX_2 (CYCLES_MAX_1 / 2 + CYCLES_MAX_1 / 4)
-#define CYCLES_MAX   (CYCLES_MAX_2 + LSB_GET(CYCLES_MAX_2))
-
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = IRQ_S_TIMER;
 #endif
-
-static struct k_spinlock lock;
-static uint64_t last_count;
-static uint64_t last_ticks;
-static uint32_t last_elapsed;
 
 static void sbi_set_timer(uint64_t deadline)
 {
@@ -74,81 +49,37 @@ static uint64_t stime(void)
 #endif
 }
 
+/*
+ * Free-running "time" counter plus an absolute SBI set-timer deadline: a
+ * COMPARE backend. The generic core owns the tick accounting and the clock
+ * lock; the driver only reads the counter and programs the deadline.
+ */
+#define TIMER_CORE_BACKEND_COMPARE
+#define TIMER_CORE_64BIT_CYCLES
+
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return stime();
+}
+
+static inline void timer_driver_set_compare(uint64_t cycles)
+{
+	sbi_set_timer(cycles);
+}
+
+#include "system_timer_generic.h"
+
 static void timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	uint64_t now = stime();
-	uint64_t dcycles = now - last_count;
-	uint32_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
-
-	last_count += (cycle_diff_t)dticks * CYC_PER_TICK;
-	last_ticks += dticks;
-	last_elapsed = 0;
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		uint64_t next = last_count + CYC_PER_TICK;
-
-		sbi_set_timer(next);
-	}
-
-	k_spin_unlock(&lock, key);
-	sys_clock_announce(dticks);
-}
-
-void sys_clock_set_timeout(uint32_t ticks)
-{
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint64_t cyc;
-
-	cyc = (last_ticks + last_elapsed + ticks) * CYC_PER_TICK;
-	if ((cyc - last_count) > CYCLES_MAX) {
-		cyc = last_count + CYCLES_MAX;
-	}
-	sbi_set_timer(cyc);
-
-	k_spin_unlock(&lock, key);
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-	uint64_t now = stime();
-	uint64_t dcycles = now - last_count;
-	uint32_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
-
-	last_elapsed = dticks;
-	k_spin_unlock(&lock, key);
-	return dticks;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	return (uint32_t)stime();
-}
-
-uint64_t sys_clock_cycle_get_64(void)
-{
-	return stime();
+	timer_core_announce();
 }
 
 static int sys_clock_driver_init(void)
 {
 	IRQ_CONNECT(IRQ_S_TIMER, 0, timer_isr, NULL, 0);
-	last_ticks = stime() / CYC_PER_TICK;
-	last_count = last_ticks * CYC_PER_TICK;
-	sbi_set_timer(last_count + CYC_PER_TICK);
+	timer_core_init();
 	irq_enable(IRQ_S_TIMER);
 	return 0;
 }
@@ -156,7 +87,7 @@ static int sys_clock_driver_init(void)
 #ifdef CONFIG_SMP
 void smp_timer_init(void)
 {
-	sbi_set_timer(last_count + CYC_PER_TICK);
+	timer_core_smp_prime();
 	irq_enable(IRQ_S_TIMER);
 }
 #endif

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -205,12 +205,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 #else /* !CONFIG_TICKLESS_KERNEL */
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/* Disable comparator when the kernel has no pending timeout. */
-		rtc_timeout = rtc_counter;
-		return;
-	}
-
 	if (ticks < 1) {
 		ticks = 1;
 	}

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -181,9 +181,8 @@ static void rtc_isr(const void *arg)
 #endif /* CONFIG_TICKLESS_KERNEL */
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 #ifdef CONFIG_TICKLESS_KERNEL
 

--- a/drivers/timer/silabs_sleeptimer_timer.c
+++ b/drivers/timer/silabs_sleeptimer_timer.c
@@ -98,9 +98,8 @@ static uint32_t sleeptimer_clock_elapsed(struct sleeptimer_timer_data *timer)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	sleeptimer_clock_set_timeout(ticks, &g_sleeptimer_timer_data);
 }

--- a/drivers/timer/smartbond_timer.c
+++ b/drivers/timer/smartbond_timer.c
@@ -107,7 +107,7 @@ static void schedule_next_interrupt(uint32_t ticks)
 	}
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -315,6 +315,18 @@ static inline uint32_t z_clock_lptim_getcounter(void)
 	return lp_time;
 }
 
+void sys_clock_unused(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* No timeout pending: turn the LPTIM off entirely (unclocked, never
+	 * waking up). It is restored by the next sys_clock_set_timeout().
+	 */
+	clock_control_off(clk_ctrl, (clock_control_subsys_t)&lptim_clk[0]);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	/* new LPTIM AutoReload value to set (aligned on Kernel ticks) */
@@ -381,17 +393,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	/*
-	 * The kernel has no pending timeout, which it signals with
-	 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle the LPTIM can be
-	 * turned off entirely (never waking up, not clocked anymore).
-	 * Without sloppy idle we fall through and schedule the (capped)
-	 * timeout so the uptime tick count stays correct.
-	 */
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		clock_control_off(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
-		return;
-	}
 	/*
 	 * When CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE = n, ticks equals to INT_MAX
 	 * is treated as a maximum possible value LPTIM_MAX_TIMEBASE (16bit counter)

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -383,12 +383,11 @@ void sys_clock_idle_enter(uint32_t ticks)
 	}
 #endif /* CONFIG_STM32_LPTIM_STDBY_TIMER */
 
-	sys_clock_set_timeout(ticks, false);
+	sys_clock_set_timeout(ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	/* new LPTIM AutoReload value to set (aligned on Kernel ticks) */
 	uint32_t next_arr = 0;
 	int err;

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -327,14 +327,8 @@ void sys_clock_unused(void)
 	clock_control_off(clk_ctrl, (clock_control_subsys_t)&lptim_clk[0]);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_idle_enter(uint32_t ticks)
 {
-	/* new LPTIM AutoReload value to set (aligned on Kernel ticks) */
-	uint32_t next_arr = 0;
-	int err;
-
-	ARG_UNUSED(idle);
-
 #ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
 	const struct pm_state_info *next;
 
@@ -342,7 +336,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	/* Check if STANBY or STOP3 is requested */
 	timeout_stdby = false;
-	if ((next != NULL) && idle) {
+	if (next != NULL) {
 #ifdef CONFIG_PM_S2RAM
 		if (next->state == PM_STATE_SUSPEND_TO_RAM) {
 			timeout_stdby = true;
@@ -388,6 +382,20 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 #endif /* CONFIG_STM32_LPTIM_STDBY_TIMER */
+
+	sys_clock_set_timeout(ticks, false);
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	ARG_UNUSED(idle);
+	/* new LPTIM AutoReload value to set (aligned on Kernel ticks) */
+	uint32_t next_arr = 0;
+	int err;
+
+#ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
+	timeout_stdby = false;
+#endif
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/stm32wb0_radio_timer.c
+++ b/drivers/timer/stm32wb0_radio_timer.c
@@ -105,9 +105,8 @@ static void radio_timer_txrx_wkup_isr(void *args)
 }
 #endif /* CONFIG_SOC_STM32WB06XX || CONFIG_SOC_STM32WB07XX */
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		uint32_t current_time, delay;

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -18,7 +18,7 @@
 
 /* Weak-linked noop defaults for optional driver interfaces*/
 
-void __weak sys_clock_set_timeout(uint32_t ticks, bool idle)
+void __weak sys_clock_set_timeout(uint32_t ticks)
 {
 }
 
@@ -32,5 +32,5 @@ void __weak sys_clock_unused(void)
 
 void __weak sys_clock_idle_enter(uint32_t ticks)
 {
-	sys_clock_set_timeout(ticks, false);
+	sys_clock_set_timeout(ticks);
 }

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -25,3 +25,7 @@ void __weak sys_clock_set_timeout(uint32_t ticks, bool idle)
 void __weak sys_clock_idle_exit(void)
 {
 }
+
+void __weak sys_clock_unused(void)
+{
+}

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -29,3 +29,8 @@ void __weak sys_clock_idle_exit(void)
 void __weak sys_clock_unused(void)
 {
 }
+
+void __weak sys_clock_idle_enter(uint32_t ticks)
+{
+	sys_clock_set_timeout(ticks, false);
+}

--- a/drivers/timer/system_timer_generic.h
+++ b/drivers/timer/system_timer_generic.h
@@ -1,0 +1,487 @@
+/*
+ * Copyright (c) 2026 BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Generic tickless system-timer core
+ *
+ * This header carries the tick accounting that every tickless system-timer
+ * driver would otherwise reimplement by hand: the cycle-to-tick conversion, the
+ * announce baseline (last_cycle / last_tick / last_elapsed), the deadline
+ * computation and the range clamp. A driver reduces to a few cycle-domain
+ * primitives; the tick contract the kernel calls (sys_clock_set_timeout(),
+ * sys_clock_elapsed(), sys_clock_cycle_get_32/64()) is emitted here.
+ *
+ * The file is an implementation header, not a normal declaration header: it
+ * *defines* the global sys_clock_* entry points, so it must be included exactly
+ * once, by the one chosen system-timer driver, after that driver has provided
+ * its constants and primitives.
+ *
+ * A driver, before the include, provides:
+ *
+ *   - Exactly one backend feature macro:
+ *       TIMER_CORE_BACKEND_COMPARE  free-running counter plus an absolute compare
+ *                                register (arm_arch, riscv, hpet, ...)
+ *       TIMER_CORE_BACKEND_RELOAD   a counter that fires after a relative delay
+ *                                (down-counters, compare-match-reset periodics).
+ *                                Assumed to auto-reload: on a non-tickless
+ *                                kernel it free-runs from the LOAD set at init
+ *                                and is not reprogrammed per tick.
+ *
+ *   - static inline uint64_t timer_driver_cycle_get(void): the hardware cycle count.
+ *     Its rate is TIMER_CORE_CYCLES_PER_SEC (see the knobs below), by default the kernel
+ *     system clock rate. It may wrap at the counter width declared by
+ *     TIMER_CORE_CYCLES_WIDTH (the core masks deltas to that width), so a narrow
+ *     free-running counter is used as-is, without software extension.
+ *
+ *   - the arming primitive for the chosen backend:
+ *       COMPARE: static inline void timer_driver_set_compare(uint32_t/uint64_t cycles)
+ *                Fire an interrupt when the counter reaches @p cycles, a
+ *                full-width cycle count. The argument width is the driver's: a
+ *                64-bit comparator takes uint64_t; a 32-bit one may take uint32_t
+ *                (or mask a uint64_t argument) to drop the value to its
+ *                comparator width. Must not lose the interrupt for an
+ *                already-past target.
+ *       RELOAD:  static inline void timer_driver_set_reload(uint32_t/uint64_t cycles)
+ *                Fire an interrupt after @p cycles more cycles. The core has
+ *                already clamped @p cycles to [TIMER_CORE_MIN_DELAY,
+ *                TIMER_CORE_CYCLES_MAX]. The argument width is the driver's:
+ *                uint32_t suits a counter whose TIMER_CORE_CYCLES_MAX fits 32
+ *                bits (the usual case); a wider counter may take uint64_t and
+ *                raise TIMER_CORE_CYCLES_MAX to match. The core does not narrow
+ *                the value, so the two must be kept coherent.
+ *
+ * Optional knobs (sensible defaults provided):
+ *
+ *   - TIMER_CORE_CYCLES_PER_SEC: rate, in Hz, of the counter timer_driver_cycle_get() reads,
+ *     from which the core derives the cycles per tick. Defaults to the kernel
+ *     system clock rate; a driver whose counter runs at another rate (prescaled,
+ *     or a fixed frequency) overrides it. With a build-time-constant rate the
+ *     derived cycles-per-tick is a constant (the tick math divides by it on the
+ *     announce path); with a run-time rate
+ *     (CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME) the core precomputes it once
+ *     in timer_core_init(), so that path never divides the rate twice. A driver
+ *     that needs cycles-per-tick as a compile-time constant elsewhere may
+ *     instead define TIMER_CORE_CYC_PER_TICK directly.
+ *   - TIMER_CORE_CYCLES_WIDTH: width, in bits, of the cycle counter (1..64). Defaults to
+ *     the native register width, which suits any counter at least that wide;
+ *     a narrower counter, or a wide counter to be treated as narrower, sets its
+ *     own value. The core masks every delta to this width and never arms a
+ *     deadline more than TIMER_CORE_CYCLES_MAX ahead.
+ *   - TIMER_CORE_CYCLES_MAX: furthest deadline armed ahead of the last announce. Defaults
+ *     to half the counter span (the upper half is IRQ-latency headroom), or a
+ *     quarter span when TIMER_CORE_COUNTER_NONMONOTONIC is set.
+ *   - TIMER_CORE_64BIT_CYCLES: define to also emit sys_clock_cycle_get_64().
+ *   - TIMER_CORE_HAVE_CYCLE_GET_32 / _64: define (and provide your own
+ *     sys_clock_cycle_get_32 / _64 before the include) to suppress the core's,
+ *     e.g. when the raw counter needs scaling.
+ *   - TIMER_CORE_CYCLE_GET_NONATOMIC: define when timer_driver_cycle_get() is not a
+ *     single atomic read but a synthesized count (built from a shared software
+ *     accumulator the ISR and reprogram paths also touch). The core then reads
+ *     it under the clock lock in sys_clock_cycle_get_32/64() instead of raw.
+ *   - TIMER_CORE_MIN_DELAY (RELOAD): reload floor, in cycles.
+ *   - TIMER_CORE_COUNTER_NONMONOTONIC: define if the counter may momentarily read
+ *     behind a value already observed (e.g. a global timer under QEMU SMP); the
+ *     core then treats a backwards read as no elapse instead of a huge jump.
+ *
+ * The driver completes with its IRQ handler (a hardware acknowledge, then
+ * timer_core_announce()), its init (connect the IRQ, then timer_core_init()) and,
+ * on SMP, an smp_timer_init() that primes the per-CPU timer via
+ * timer_core_smp_prime().
+ */
+
+#ifndef ZEPHYR_DRIVERS_TIMER_SYSTEM_TIMER_GENERIC_H_
+#define ZEPHYR_DRIVERS_TIMER_SYSTEM_TIMER_GENERIC_H_
+
+#include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/sys/util.h>
+
+#if defined(TIMER_CORE_BACKEND_COMPARE) == defined(TIMER_CORE_BACKEND_RELOAD)
+#error "define exactly one of TIMER_CORE_BACKEND_COMPARE / TIMER_CORE_BACKEND_RELOAD"
+#endif
+
+/*
+ * Cycles per second of the counter that timer_driver_cycle_get() reads. Defaults to
+ * the kernel system clock rate; a driver whose counter runs at another rate (a
+ * prescaled or fixed-frequency source) overrides it.
+ */
+#if !defined(TIMER_CORE_CYCLES_PER_SEC)
+#define TIMER_CORE_CYCLES_PER_SEC sys_clock_hw_cycles_per_sec()
+#endif
+
+/*
+ * Cycles per kernel tick, derived from the rate so a driver normally does not
+ * define it. With a build-time-constant rate the division folds, which matters
+ * because the tick math divides by it on the announce path. When the rate is
+ * only known at run time (CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME) it is
+ * precomputed once in timer_core_init() into a variable, so that path never
+ * divides the rate twice. A driver that needs cycles-per-tick as a compile-time
+ * constant elsewhere (e.g. a preprocessor test) may define it directly instead.
+ */
+#if !defined(TIMER_CORE_CYC_PER_TICK)
+#if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
+static uint32_t timer_core_cyc_per_tick;
+#define TIMER_CORE_CYC_PER_TICK timer_core_cyc_per_tick
+#define TIMER_CORE_PRECOMPUTE_CYC_PER_TICK
+#else
+#define TIMER_CORE_CYC_PER_TICK \
+	((uint32_t)(TIMER_CORE_CYCLES_PER_SEC / CONFIG_SYS_CLOCK_TICKS_PER_SEC))
+/*
+ * The whole tick math divides by this, so a counter rate below the tick rate
+ * (or a mis-set TIMER_CORE_CYCLES_PER_SEC) that rounds it to zero must be caught. When the
+ * default TIMER_CORE_CYCLES_PER_SEC is a build constant, catch it at build time. It is not
+ * a constant with CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE (a runtime
+ * variable that can even change later), so that case, like the runtime-frequency
+ * case above, is checked once in timer_core_init() where the value is known. A
+ * driver that defines its own TIMER_CORE_CYC_PER_TICK owns that check.
+ */
+#if defined(CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE)
+#define TIMER_CORE_CHECK_CYC_PER_TICK_AT_INIT
+#else
+BUILD_ASSERT(TIMER_CORE_CYC_PER_TICK != 0, "timer counter rate is below the tick rate");
+#endif
+#endif
+#endif
+
+/*
+ * Default to the native register width: the masked delta then divides in a
+ * single register, and a counter at least this wide never wraps within the
+ * scheduling range. A narrower counter overrides TIMER_CORE_CYCLES_WIDTH with its width.
+ *
+ * A driver whose counter is genuinely wider than the native register (a 64-bit
+ * counter on a 32-bit CPU) sets TIMER_CORE_CYCLES_WIDTH to that width to use the
+ * counter's full range. It must not be forced wider than the counter really is:
+ * a 64-bit mask on a 32-bit counter underflows once the baseline passes 2^32.
+ */
+#if !defined(TIMER_CORE_CYCLES_WIDTH)
+#define TIMER_CORE_CYCLES_WIDTH __LONG_WIDTH__
+#endif
+
+/* Wrap mask for the counter. */
+#define TIMER_CORE_CYCLES_MASK (UINT64_MAX >> (64 - TIMER_CORE_CYCLES_WIDTH))
+
+/*
+ * Furthest deadline that may be armed ahead of the last announce.
+ *
+ * Half the span by default: the upper half is headroom so a late announce
+ * (IRQ latency on a maximum-length arm) still yields an in-range delta rather
+ * than wrapping.
+ *
+ * With backwards-read detection (TIMER_CORE_COUNTER_NONMONOTONIC) the upper half
+ * is instead the range that flags a backwards read, so it can no longer double
+ * as latency headroom. Arming then reaches only a quarter span ahead, leaving
+ * the second quarter as the headroom: a late announce of a maximum arm stays
+ * below the half-span backwards threshold, while a genuine backwards read still
+ * lands in the upper half. A driver may override TIMER_CORE_CYCLES_MAX.
+ */
+#ifndef TIMER_CORE_CYCLES_MAX
+#ifdef TIMER_CORE_COUNTER_NONMONOTONIC
+#define TIMER_CORE_CYCLES_MAX (TIMER_CORE_CYCLES_MASK >> 2)
+#else
+#define TIMER_CORE_CYCLES_MAX (TIMER_CORE_CYCLES_MASK >> 1)
+#endif
+#endif
+
+/* Reload floor, in cycles (RELOAD only). A driver whose hardware needs a larger
+ * minimum programmable delay overrides it.
+ */
+#ifndef TIMER_CORE_MIN_DELAY
+#define TIMER_CORE_MIN_DELAY 1
+#endif
+
+/*
+ * Announce baseline, private to this translation unit.
+ *
+ * last_cycle is the cycle count of the most recent announce, held tick-aligned
+ * (an exact multiple of TIMER_CORE_CYC_PER_TICK above the init baseline). Its low
+ * TIMER_CORE_CYCLES_WIDTH bits track the hardware counter, so masking a delta against it is
+ * wrap-correct even for a counter narrower than 64 bits. last_elapsed is the
+ * tick count most recently reported to the kernel via sys_clock_elapsed().
+ */
+static uint64_t timer_core_last_cycle;
+static uint64_t timer_core_last_tick;
+static uint32_t timer_core_last_elapsed;
+
+/* Whole ticks elapsed since the last announce, from the current counter. */
+static inline uint32_t timer_core_delta_ticks(void)
+{
+	uint64_t delta =
+		(timer_driver_cycle_get() - timer_core_last_cycle) & TIMER_CORE_CYCLES_MASK;
+
+#ifdef TIMER_CORE_COUNTER_NONMONOTONIC
+	/*
+	 * A counter that can momentarily read behind a value already observed
+	 * (e.g. a global timer seen from another CPU under QEMU SMP) produces a
+	 * near-full-span masked delta. Arming is capped at TIMER_CORE_CYCLES_MAX (a quarter
+	 * span here), so a legitimate delta, even a late one, stays in the lower
+	 * half; a delta in the upper half is therefore a backwards read and is
+	 * reported as no elapse rather than a spurious huge jump.
+	 */
+	if (delta > (TIMER_CORE_CYCLES_MASK >> 1)) {
+		return 0;
+	}
+#endif
+
+#if TIMER_CORE_CYCLES_WIDTH <= 32
+	/* The masked delta fits in a 32-bit register: divide cheaply. */
+	return (uint32_t)delta / TIMER_CORE_CYC_PER_TICK;
+#else
+	return delta / TIMER_CORE_CYC_PER_TICK;
+#endif
+}
+
+/* Program the timer for a tick-aligned deadline `ticks` out from the last
+ * reported elapsed. Called with the system clock lock held.
+ */
+static void timer_core_arm(uint32_t ticks)
+{
+#if defined(TIMER_CORE_BACKEND_COMPARE)
+	/*
+	 * Absolute, tick-aligned deadline. last_cycle is linear (its low
+	 * TIMER_CORE_CYCLES_WIDTH bits track the counter), and a narrow-register driver
+	 * truncates the value to its comparator width when it writes it, so a
+	 * linear deadline is correct for both wide and narrow counters.
+	 */
+	uint64_t deadline = (timer_core_last_tick + timer_core_last_elapsed + ticks) *
+			    TIMER_CORE_CYC_PER_TICK;
+
+	if ((deadline - timer_core_last_cycle) > TIMER_CORE_CYCLES_MAX) {
+		deadline = timer_core_last_cycle + TIMER_CORE_CYCLES_MAX;
+	}
+	timer_driver_set_compare(deadline);
+#else /* TIMER_CORE_BACKEND_RELOAD */
+	/*
+	 * Relative reload: the cycles from the last announce to the tick-aligned
+	 * deadline, minus what has already elapsed since then. Both terms are in
+	 * the counter's cycle domain (the elapsed part masked to TIMER_CORE_CYCLES_WIDTH),
+	 * so this stays correct across a counter wrap, and a starved ISR (elapsed
+	 * past the deadline) yields a non-positive value pulled up to the floor.
+	 */
+	uint64_t want = ((uint64_t)timer_core_last_elapsed + ticks) * TIMER_CORE_CYC_PER_TICK;
+	uint64_t done = (timer_driver_cycle_get() - timer_core_last_cycle) & TIMER_CORE_CYCLES_MASK;
+	int64_t rel = (int64_t)(want - done);
+
+	/*
+	 * Clamp against the budget left before the baseline would be TIMER_CORE_CYCLES_MAX
+	 * behind, not against TIMER_CORE_CYCLES_MAX alone. Re-arming restarts the counter, so
+	 * without accounting `done` a stream of set_timeout() calls with no
+	 * intervening announce would push the fire point out indefinitely and let
+	 * `done` grow past TIMER_CORE_CYCLES_MASK, wrapping the masked delta and silently
+	 * losing the elapsed span. Once `done` reaches TIMER_CORE_CYCLES_MAX the budget goes
+	 * non-positive and the MIN_DELAY floor forces a near-immediate fire, hence
+	 * an announce that resets the baseline. This keeps the same invariant the
+	 * COMPARE path gets from clamping its absolute deadline.
+	 */
+	if (rel > (int64_t)TIMER_CORE_CYCLES_MAX - (int64_t)done) {
+		rel = (int64_t)TIMER_CORE_CYCLES_MAX - (int64_t)done;
+	}
+	if (rel < (int64_t)TIMER_CORE_MIN_DELAY) {
+		rel = TIMER_CORE_MIN_DELAY;
+	}
+	timer_driver_set_reload((uint64_t)rel);
+#endif
+}
+
+void sys_clock_set_timeout(uint32_t ticks)
+{
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+	timer_core_arm(ticks);
+}
+
+uint32_t sys_clock_elapsed(void)
+{
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return 0;
+	}
+
+	timer_core_last_elapsed = timer_core_delta_ticks();
+	return timer_core_last_elapsed;
+}
+
+/* Account the whole ticks elapsed since the last announce, rearm (tickful only;
+ * tickless rearms from the kernel's reprogram after the announce) and announce,
+ * with the clock lock already held. @p key is the key returned by the driver's
+ * sys_clock_lock() and is consumed here. Use this when the driver must do work
+ * that has to be atomic with the announce (e.g. committing a wrap into its cycle
+ * counter) before handing off.
+ */
+static void timer_core_announce_from(k_spinlock_key_t key)
+{
+	uint32_t dticks = timer_core_delta_ticks();
+
+	timer_core_last_cycle += (uint64_t)dticks * TIMER_CORE_CYC_PER_TICK;
+	timer_core_last_tick += dticks;
+	timer_core_last_elapsed = 0;
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+#if defined(TIMER_CORE_BACKEND_COMPARE)
+		/* Re-arm the comparator one tick out. A RELOAD counter reloads
+		 * itself from the LOAD set at init, so it needs nothing here.
+		 */
+		timer_core_arm(1);
+#endif
+	}
+
+	sys_clock_announce_locked(dticks, key);
+}
+
+/* Read the counter, account the whole ticks elapsed since the last announce,
+ * rearm and announce. The driver ISR body reduces to a hardware acknowledge
+ * followed by this call. inline so a driver that instead uses
+ * timer_core_announce_from() directly does not trip -Wunused-function.
+ */
+static inline void timer_core_announce(void)
+{
+	timer_core_announce_from(sys_clock_lock());
+}
+
+/*
+ * Full-width cycle count reconstructed from the announce baseline (which carries
+ * the extended upper bits) plus the masked forward delta, taken under the clock
+ * lock. The lock is needed when either the read cannot be trusted atomically:
+ *
+ *   - timer_driver_cycle_get() is a synthesized count, not a single register read
+ *     (TIMER_CORE_CYCLE_GET_NONATOMIC): the lock serialises it against the ISR and
+ *     reprogram paths that update the same software state; or
+ *   - the full 64-bit baseline is read on a narrower counter (the getter below
+ *     needs all 64 bits, which is not a single load on a 32-bit CPU).
+ *
+ * A narrow counter feeding only the 32-bit getter does NOT need this: that path
+ * reconstructs from the baseline's low word, a single atomic load, so it stays
+ * lock-free (see sys_clock_cycle_get_32()). Keeping the lock out of the 32-bit
+ * getter matters because it is on the thread-usage timestamp hot path.
+ */
+#if defined(TIMER_CORE_CYCLE_GET_NONATOMIC) || \
+	(defined(TIMER_CORE_64BIT_CYCLES) && TIMER_CORE_CYCLES_WIDTH < 64)
+static inline uint64_t timer_core_cycle_extend_locked(void)
+{
+	k_spinlock_key_t key = sys_clock_lock();
+	uint64_t delta =
+		(timer_driver_cycle_get() - timer_core_last_cycle) & TIMER_CORE_CYCLES_MASK;
+	uint64_t ret = timer_core_last_cycle + delta;
+
+	sys_clock_unlock(key);
+	return ret;
+}
+#endif
+
+#if !defined(TIMER_CORE_HAVE_CYCLE_GET_32)
+uint32_t sys_clock_cycle_get_32(void)
+{
+#if defined(TIMER_CORE_CYCLE_GET_NONATOMIC)
+	/* Synthesized read: serialise the get and baseline under the lock. */
+	return (uint32_t)timer_core_cycle_extend_locked();
+#elif TIMER_CORE_CYCLES_WIDTH < 32
+	/* Narrow atomic counter: extend from the baseline's low word. Both reads
+	 * are single loads, and pairing one baseline read with one counter read
+	 * yields the true position regardless of an announce in between, so this
+	 * needs no lock.
+	 */
+	uint32_t base = (uint32_t)timer_core_last_cycle;
+	uint32_t delta = ((uint32_t)timer_driver_cycle_get() - base) &
+			 (uint32_t)TIMER_CORE_CYCLES_MASK;
+
+	return base + delta;
+#else
+	return (uint32_t)timer_driver_cycle_get();
+#endif
+}
+#endif
+
+#if defined(TIMER_CORE_64BIT_CYCLES) && !defined(TIMER_CORE_HAVE_CYCLE_GET_64)
+uint64_t sys_clock_cycle_get_64(void)
+{
+#if defined(TIMER_CORE_CYCLE_GET_NONATOMIC) || TIMER_CORE_CYCLES_WIDTH < 64
+	return timer_core_cycle_extend_locked();
+#else
+	return timer_driver_cycle_get();
+#endif
+}
+#endif
+
+/* Rescale the announce baseline from one cycle rate to another. A driver that
+ * changes the timer frequency at runtime calls this (after rescaling its own
+ * cycle counter) so the tick accounting stays continuous, without touching the
+ * core's private baseline directly. last_tick is a tick count and so is
+ * frequency-independent; only the cycle-domain baseline scales.
+ */
+static inline void timer_core_rescale(uint32_t to_hz, uint32_t from_hz)
+{
+	ARG_UNUSED(from_hz);
+#ifdef TIMER_CORE_PRECOMPUTE_CYC_PER_TICK
+	/* The rate just changed, so the precomputed cycles-per-tick is stale. */
+	timer_core_cyc_per_tick = to_hz / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+#else
+	ARG_UNUSED(to_hz);
+#endif
+	/*
+	 * Re-express the announce baseline in the new cycle domain. Deriving it
+	 * from last_tick (a frequency-independent tick count) keeps it an exact
+	 * multiple of TIMER_CORE_CYC_PER_TICK, the invariant the arm and announce paths rely
+	 * on. Scaling the old cycle value directly would leave it a fraction of a
+	 * tick off and, on the COMPARE arm, could make (deadline - last_cycle)
+	 * underflow. The caller has already rescaled its own cycle counter.
+	 */
+	timer_core_last_cycle = timer_core_last_tick * (uint64_t)TIMER_CORE_CYC_PER_TICK;
+}
+
+/* Prime the calling CPU's timer one tick ahead of the shared baseline. An SMP
+ * driver calls this from smp_timer_init() so it need not touch the core's
+ * private baseline.
+ */
+static inline void timer_core_smp_prime(void)
+{
+#if defined(TIMER_CORE_BACKEND_COMPARE)
+	timer_driver_set_compare(timer_core_last_cycle + TIMER_CORE_CYC_PER_TICK);
+#else
+	timer_driver_set_reload(TIMER_CORE_CYC_PER_TICK);
+#endif
+}
+
+/* Seed the announce baseline from the current counter and arm the first tick.
+ * The driver calls this from its init after connecting the IRQ (and, for a
+ * runtime frequency, after setting TIMER_CORE_CYC_PER_TICK).
+ */
+static inline void timer_core_init(void)
+{
+#ifdef TIMER_CORE_PRECOMPUTE_CYC_PER_TICK
+	/* Rate is known only now (the driver has brought the counter up), so
+	 * fix the cycles-per-tick the tick math will divide by.
+	 */
+	timer_core_cyc_per_tick = TIMER_CORE_CYCLES_PER_SEC / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+#endif
+#if defined(TIMER_CORE_PRECOMPUTE_CYC_PER_TICK) || defined(TIMER_CORE_CHECK_CYC_PER_TICK_AT_INIT)
+	/* Runtime-rate cases: TIMER_CORE_CYC_PER_TICK is not a constant expression, so the
+	 * non-zero check the constant case gets at build time happens here instead.
+	 */
+	__ASSERT(TIMER_CORE_CYC_PER_TICK != 0, "timer counter rate is below the tick rate");
+#endif
+	timer_core_last_tick = timer_driver_cycle_get() / TIMER_CORE_CYC_PER_TICK;
+	timer_core_last_cycle = timer_core_last_tick * TIMER_CORE_CYC_PER_TICK;
+	timer_core_last_elapsed = 0;
+
+#if defined(TIMER_CORE_BACKEND_RELOAD)
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/* A tickful RELOAD driver configures its hardware to auto-reload one
+		 * tick and is never reprogrammed (see timer_core_announce_from()), so the
+		 * driver owns the period. Arming here would instead program it to the
+		 * sub-tick remainder left after seeding the baseline, and that short
+		 * value would stick as the permanent period.
+		 */
+		return;
+	}
+#endif
+	timer_core_arm(1);
+}
+
+#endif /* ZEPHYR_DRIVERS_TIMER_SYSTEM_TIMER_GENERIC_H_ */

--- a/drivers/timer/ti_dmtimer.c
+++ b/drivers/timer/ti_dmtimer.c
@@ -103,9 +103,8 @@ static void ti_dmtimer_isr(void *param)
 	sys_clock_announce(delta_ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 
 	struct ti_dm_timer_data *data = systick_timer_dev->data;
 

--- a/drivers/timer/ti_rti_timer.c
+++ b/drivers/timer/ti_rti_timer.c
@@ -77,9 +77,8 @@ static void ti_rti_timer_isr(void *param)
 	sys_clock_announce(1);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	ARG_UNUSED(ticks);
 	/* This driver doesn't support tickless kernel, return immediately */
 }

--- a/drivers/timer/xlnx_psttc_timer.c
+++ b/drivers/timer/xlnx_psttc_timer.c
@@ -101,7 +101,7 @@ static void ttc_isr(const void *arg)
 	sys_clock_announce(ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
 #ifdef CONFIG_TICKLESS_KERNEL
 	uint32_t cycles;

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -85,7 +85,7 @@ static void ccompare_isr(const void *arg)
 	sys_clock_announce_locked(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+static void set_timeout(uint32_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -125,6 +125,17 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	}
 
 #endif
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	ARG_UNUSED(idle);
+	set_timeout(ticks, false);
+}
+
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	set_timeout(ticks, true);
 }
 
 uint32_t sys_clock_elapsed(void)

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -127,9 +127,8 @@ static void set_timeout(uint32_t ticks, bool idle)
 #endif
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_set_timeout(uint32_t ticks)
 {
-	ARG_UNUSED(idle);
 	set_timeout(ticks, false);
 }
 

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -14,13 +14,7 @@
 #define TIMER_IRQ UTIL_CAT(XCHAL_TIMER,		\
 			   UTIL_CAT(CONFIG_XTENSA_TIMER_ID, _INTERRUPT))
 
-#define CYC_PER_TICK (sys_clock_hw_cycles_per_sec()	\
-		      / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-#define MAX_CYC 0xffffffffu
-#define MAX_TICKS ((MAX_CYC - CYC_PER_TICK) / CYC_PER_TICK)
 #define MIN_DELAY 1000
-
-static unsigned int last_count;
 
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = UTIL_CAT(XCHAL_TIMER,
@@ -28,9 +22,11 @@ const int32_t z_sys_timer_irq_for_test = UTIL_CAT(XCHAL_TIMER,
 #endif
 
 static uint32_t ccount_compensation;
+#ifdef CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK
 static uint32_t ccount_pre_idle;
 static uint64_t lptim_pre_idle;
 static bool timeout_idle;
+#endif
 
 static uint32_t ccount_comp(void)
 {
@@ -55,150 +51,102 @@ static uint32_t ccount(void)
 	return val + ccount_comp();
 }
 
-static uint32_t sys_clock_elapsed_ticks(uint32_t curr)
+/*
+ * Free-running 32-bit CCOUNT plus an equality-match CCOMPARE register: a COMPARE
+ * backend. CCOMPARE fires only on CCOUNT == CCOMPARE, so an already-past target
+ * is missed until CCOUNT wraps; timer_driver_set_compare() bumps the target until it
+ * is at least MIN_DELAY ahead, satisfying the core's "must not miss a past
+ * deadline" contract, and writing CCOMPARE clears the pending interrupt. The
+ * cycle count carries the low-power compensation (ccount_comp), so the raw
+ * register value written is the target minus that offset.
+ */
+#define TIMER_CORE_BACKEND_COMPARE
+
+static inline uint64_t timer_driver_cycle_get(void)
 {
-	uint32_t dticks = (curr - last_count) / CYC_PER_TICK;
-
-	last_count += dticks * CYC_PER_TICK;
-
-	return dticks;
+	return ccount();
 }
+
+static inline void timer_driver_set_compare(uint64_t cycles)
+{
+	uint32_t next = (uint32_t)cycles;
+
+	set_ccompare(next - ccount_comp());
+
+	uint32_t now = ccount();
+
+	while ((int32_t)(next - now) < (int32_t)MIN_DELAY) {
+		next = now + MIN_DELAY;
+		set_ccompare(next - ccount_comp());
+		now = ccount();
+	}
+}
+
+#include "system_timer_generic.h"
 
 static void ccompare_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	k_spinlock_key_t key = sys_clock_lock();
-
-	uint32_t curr = ccount();
-	uint32_t dticks = sys_clock_elapsed_ticks(curr);
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		uint32_t next = last_count + CYC_PER_TICK;
-
-		if ((int32_t)(next - curr) < MIN_DELAY) {
-			next += CYC_PER_TICK;
-		}
-		set_ccompare(next - ccount_comp());
-	}
-
-	sys_clock_announce_locked(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1, key);
-}
-
-static void set_timeout(uint32_t ticks, bool idle)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-#if defined(CONFIG_TICKLESS_KERNEL)
-	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
-
-	uint32_t curr = ccount(), cyc, adj;
-
-	/* Round up to next tick boundary */
-	cyc = ticks * CYC_PER_TICK;
-	adj = (curr - last_count) + (CYC_PER_TICK - 1);
-	if (cyc <= MAX_CYC - adj) {
-		cyc += adj;
-	} else {
-		cyc = MAX_CYC;
-	}
-	cyc = (cyc / CYC_PER_TICK) * CYC_PER_TICK;
-	cyc += last_count;
-
-	if ((cyc - curr) < MIN_DELAY) {
-		cyc += CYC_PER_TICK;
-	}
-
-	set_ccompare(cyc - ccount_comp());
-
-	if (IS_ENABLED(CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK)) {
-		if (idle) {
-			uint64_t timeout_us =
-				((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-			lptim_pre_idle = z_xtensa_lptim_hook_on_lpm_entry(timeout_us);
-			ccount_pre_idle = ccount();
-			timeout_idle = true;
-		}
-	} else {
-		ARG_UNUSED(idle);
-	}
-
-#endif
-}
-
-void sys_clock_set_timeout(uint32_t ticks)
-{
-	set_timeout(ticks, false);
-}
-
-void sys_clock_idle_enter(uint32_t ticks)
-{
-	set_timeout(ticks, true);
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	return (ccount() - last_count) / CYC_PER_TICK;
-}
-
-uint32_t sys_clock_cycle_get_32(void)
-{
-	return ccount();
+	timer_core_announce();
 }
 
 #ifdef CONFIG_SMP
 void smp_timer_init(void)
 {
-	set_ccompare(ccount() + CYC_PER_TICK);
+	timer_core_smp_prime();
 	irq_enable(TIMER_IRQ);
 }
 #endif
 
+#ifdef CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	/* Arm the comparator for the wakeup, then hand off to the low-power
+	 * timer that keeps time while CCOUNT is stalled.
+	 */
+	sys_clock_set_timeout(ticks);
+
+	uint64_t timeout_us =
+		((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+
+	lptim_pre_idle = z_xtensa_lptim_hook_on_lpm_entry(timeout_us);
+	ccount_pre_idle = ccount();
+	timeout_idle = true;
+}
+
 void sys_clock_idle_exit(void)
 {
-	if (IS_ENABLED(CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK)) {
-
-		if (!timeout_idle) {
-			return;
-		}
-
-		k_spinlock_key_t key = sys_clock_lock();
-
-		uint64_t lptim_now = z_xtensa_lptim_hook_on_lpm_exit();
-		uint64_t ccount_now = ccount();
-		uint64_t lptim_diff = lptim_now - lptim_pre_idle;
-		uint32_t ccount_diff = ccount_now - ccount_pre_idle;
-		uint64_t expected_cycles = (lptim_diff * sys_clock_hw_cycles_per_sec()) /
-					   z_xtensa_lptim_hook_get_freq();
-		uint32_t missed_cycles = 0;
-
-		if (expected_cycles > ccount_diff) {
-			missed_cycles = (uint32_t)(expected_cycles - ccount_diff);
-		}
-
-		ccount_compensation += missed_cycles;
-
-		ccount_now = ccount();
-		uint32_t dticks = sys_clock_elapsed_ticks(ccount_now);
-
-		timeout_idle = false;
-
-		/* Announce corrected ticks as CCOUNT remained stalled during LPM */
-		sys_clock_announce_locked(dticks, key);
+	if (!timeout_idle) {
+		return;
 	}
+
+	k_spinlock_key_t key = sys_clock_lock();
+
+	uint64_t lptim_now = z_xtensa_lptim_hook_on_lpm_exit();
+	uint32_t ccount_diff = (uint32_t)ccount() - ccount_pre_idle;
+	uint64_t lptim_diff = lptim_now - lptim_pre_idle;
+	uint64_t expected_cycles =
+		(lptim_diff * sys_clock_hw_cycles_per_sec()) / z_xtensa_lptim_hook_get_freq();
+
+	if (expected_cycles > ccount_diff) {
+		/* CCOUNT stalled during LPM; fold the missed cycles into the
+		 * compensation so the cycle count (and the announced delta) picks
+		 * up the real elapsed time.
+		 */
+		ccount_compensation += (uint32_t)(expected_cycles - ccount_diff);
+	}
+
+	timeout_idle = false;
+
+	timer_core_announce_from(key);
 }
+#endif /* CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK */
 
 static int sys_clock_driver_init(void)
 {
 	IRQ_CONNECT(TIMER_IRQ, 0, ccompare_isr, 0, 0);
-	set_ccompare(ccount() + CYC_PER_TICK);
+	timer_core_init();
 	irq_enable(TIMER_IRQ);
 	return 0;
 }

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -173,11 +173,12 @@ bool sys_clock_is_locked(void);
  * @note This function is called by the kernel with the system clock
  * lock held.
  *
+ * A driver entering low-power idle is notified separately through
+ * sys_clock_idle_enter(); this call carries no idle hint.
+ *
  * @param ticks Timeout in tick units
- * @param idle Hint to the driver that the system is about to enter
- *        the idle state immediately after setting the timeout
  */
-void sys_clock_set_timeout(uint32_t ticks, bool idle);
+void sys_clock_set_timeout(uint32_t ticks);
 
 /**
  * @brief Timer idle exit notification

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -268,6 +268,20 @@ void sys_clock_disable(void);
 void sys_clock_unused(void);
 
 /**
+ * @brief Notify the timer driver that the CPU is entering low-power idle.
+ *
+ * Called by the power-management / idle path when the CPU is about to be put
+ * to sleep, with @p ticks until the next expected wakeup. A driver that can
+ * hand off to a low-power wakeup timer (or otherwise reconfigure for sleep)
+ * does so here. The default implementation just programs the wakeup through
+ * sys_clock_set_timeout(), so a driver with no low-power handling needs no
+ * implementation. Recovery happens in sys_clock_idle_exit().
+ *
+ * @param ticks Ticks until the next expected wakeup.
+ */
+void sys_clock_idle_enter(uint32_t ticks);
+
+/**
  * @brief Hardware cycle counter
  *
  * Timer drivers are generally responsible for the system cycle

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -253,6 +253,21 @@ uint32_t sys_clock_elapsed(void);
 void sys_clock_disable(void);
 
 /**
+ * @brief Notify the timer driver that the system clock is currently unused.
+ *
+ * Called by the kernel when no timeout is pending and
+ * @kconfig{CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE} allows the system uptime to drift.
+ * A driver may use this to halt the counter and stop generating interrupts
+ * until the next sys_clock_set_timeout(), which resumes normal operation.
+ *
+ * Unlike sys_clock_disable(), this is a resumable pause, not a teardown. The
+ * default implementation is a no-op: a driver that does nothing here simply
+ * stops being reprogrammed and quiesces on its own, so sloppy idle is available
+ * to every driver without extra code.
+ */
+void sys_clock_unused(void);
+
+/**
  * @brief Hardware cycle counter
  *
  * Timer drivers are generally responsible for the system cycle

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -138,35 +138,37 @@ static uint32_t next_timeout(uint32_t ticks_elapsed)
 	}
 
 	/*
-	 * With nothing pending under sloppy idle, report SYS_CLOCK_MAX_WAIT
-	 * verbatim (not the budget): it is the "no deadline" value a driver
-	 * looks for to stop the clock entirely, and a skewed uptime is
-	 * acceptable. Without sloppy idle the uptime must stay correct, so
-	 * respect the budget and keep waking up.
+	 * No deadline, or one further out than can be scheduled in a single
+	 * step: wait the capped budget and re-evaluate at the next announce.
+	 * Testing next (which may be 64-bit) against the cap keeps the
+	 * remaining arithmetic in 32 bits. The empty case still returns the
+	 * budget so a driver keeps waking to maintain uptime.
 	 */
-	if (next == K_TICKS_FOREVER) {
-		if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE)) {
-			return SYS_CLOCK_MAX_WAIT;
-		}
+	if (next == K_TICKS_FOREVER || next >= SYS_CLOCK_MAX_WAIT) {
 		return SYS_CLOCK_MAX_WAIT - ticks_elapsed;
-	}
-
-	/*
-	 * A timeout further out than can be scheduled in one step: wait nearly
-	 * the whole budget, but stop one short of SYS_CLOCK_MAX_WAIT so it is
-	 * never mistaken for the "no deadline" value above (which would drop
-	 * the timeout under sloppy idle); an intermediate announce re-evaluates.
-	 * Testing next (which may be 64-bit) against the cap also keeps the
-	 * remaining arithmetic in 32 bits.
-	 */
-	if (next >= SYS_CLOCK_MAX_WAIT) {
-		return SYS_CLOCK_MAX_WAIT - 1 - ticks_elapsed;
 	}
 
 	/* Otherwise wait until the timeout, relative to now (0 if due). */
 	dticks = (uint32_t)next;
 
 	return (dticks > ticks_elapsed) ? (dticks - ticks_elapsed) : 0;
+}
+
+/*
+ * Reprogram the timer for the next pending timeout, or, when nothing is
+ * pending and CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE tolerates a drifting uptime, tell
+ * the driver its clock is unused so it may stop. Only meaningful where the
+ * timeout queue may have just drained (abort, end of announce); the add path
+ * always has a pending timeout and calls sys_clock_set_timeout() directly.
+ */
+static void reprogram_next(uint32_t ticks_elapsed)
+{
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
+	    z_timeout_q_next_expiry() == K_TICKS_FOREVER) {
+		sys_clock_unused();
+	} else {
+		sys_clock_set_timeout(next_timeout(ticks_elapsed), false);
+	}
 }
 
 k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t timeout)
@@ -242,7 +244,7 @@ int z_try_abort_timeout(struct _timeout *to)
 
 			ret = 0;
 			if (was_first) {
-				sys_clock_set_timeout(next_timeout(elapsed()), false);
+				reprogram_next(elapsed());
 			}
 		} else if (IS_ENABLED(CONFIG_SMP) && inflight_ptr() == to &&
 			   !this_cpu_announcing()) {
@@ -396,7 +398,7 @@ void sys_clock_announce_locked(uint32_t ticks, k_spinlock_key_t key)
 
 	announcing_cpu = -1;
 
-	sys_clock_set_timeout(next_timeout(0), false);
+	reprogram_next(0);
 
 	k_spin_unlock(&timeout_lock, key);
 

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -167,7 +167,7 @@ static void reprogram_next(uint32_t ticks_elapsed)
 	    z_timeout_q_next_expiry() == K_TICKS_FOREVER) {
 		sys_clock_unused();
 	} else {
-		sys_clock_set_timeout(next_timeout(ticks_elapsed), false);
+		sys_clock_set_timeout(next_timeout(ticks_elapsed));
 	}
 }
 
@@ -227,7 +227,7 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 				 */
 				ticks_elapsed = elapsed();
 			}
-			sys_clock_set_timeout(next_timeout(ticks_elapsed), false);
+			sys_clock_set_timeout(next_timeout(ticks_elapsed));
 		}
 	}
 

--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -216,7 +216,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		{
 			k_spinlock_key_t key = sys_clock_lock();
 
-			sys_clock_set_timeout(0, true);
+			sys_clock_idle_enter(0);
 			sys_clock_unlock(key);
 		}
 
@@ -237,7 +237,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 				{
 					k_spinlock_key_t key = sys_clock_lock();
 
-					sys_clock_set_timeout(0, true);
+					sys_clock_idle_enter(0);
 					sys_clock_unlock(key);
 				}
 				/* GDET got enabled when exiting PM3, disable it

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -212,7 +212,7 @@ bool pm_system_suspend(int32_t kernel_ticks)
 		 */
 		k_spinlock_key_t key = sys_clock_lock();
 
-		sys_clock_set_timeout(MAX(0, (int64_t)ticks - (int64_t)exit_latency_ticks), true);
+		sys_clock_idle_enter(MAX(0, (int64_t)ticks - (int64_t)exit_latency_ticks));
 		sys_clock_unlock(key);
 	}
 


### PR DESCRIPTION
## Goal

Every tickless system-timer driver re-implements the same tick accounting by
hand: the cycle-to-tick division, the announce baseline
(`last_cycle`/`last_tick`/`last_elapsed`), the tick-aligned deadline
computation and the counter range clamp. Across the free-running-compare
drivers (`arm_arch_timer`, `riscv_machine_timer`, `hpet`, ...) it is copied down
to the same overflow-guard constant; another set (`xtensa_sys_timer`,
`intel_adsp_timer`, `esp32_sys_timer`, ...) instead carries a copied, less
efficient "round up to the next tick boundary" variant that divides and
multiplies by the tick length on every `sys_clock_set_timeout()`. Either way the
small divergences between the copies are a recurring source of timer bugs (wrap
handling, drift, long-sleep truncation).

The goal is to move that accounting into one place so a driver deals only with
its hardware, in the cycle domain, and never re-derives ticks. That both
removes the bug surface and shrinks the drivers: across the conversions here,
`drivers/timer/` is +1112 / -1577 lines (a net ~465 fewer) — and that is *after*
adding the 366-line shared core, so the hand-rolled driver code itself drops by
~830 lines. That is from only 16 of the 59 in-tree system-timer drivers; the
core is a one-time cost, so converting the remaining ~43 should remove several
times more.

## Method

A new implementation header, `drivers/timer/system_timer_generic.h`, carries the
accounting. A driver includes it once, after providing a few cycle-domain
primitives:

- one backend macro: `Z_CLOCK_BACKEND_COMPARE` (free-running counter + absolute
  compare register) or `Z_CLOCK_BACKEND_RELOAD` (relative down-counter);
- `z_clock_cycle_get()` — read the counter;
- the arming primitive — `z_clock_set_compare()` or `z_clock_set_reload()`;
- optionally `CYCLES_WIDTH` (narrow counters), `CYCLES_PER_SEC` (prescaled or
  fixed-rate counters), `CYCLES_MAX`, or `Z_CLOCK_COUNTER_NONMONOTONIC`.

The header then emits the kernel-facing contract (`sys_clock_set_timeout()`,
`sys_clock_elapsed()`, `sys_clock_cycle_get_32/64()`) and owns the baseline
state. Because it is included (not linked) after the driver's constants and
`static inline` primitives, the core inlines and constant-folds against them on
a plain `-Os` build with no LTO: the per-tick divide becomes a multiply-shift
and the unused backend path is eliminated.

The core is complete in its first commit; the driver conversions only use it.

## Builds on

Stacked on #112750 (which builds on the already-merged #111022); it should be
reviewed/merged first. Its 7 commits appear first in this branch, so skip them
when reviewing this PR — this PR's own work starts at
"drivers: timer: add generic tickless system-timer core".

## Drivers converted

This converts a representative sample: both backends across the main
architectures, plus the awkward cases (narrow counters, prescaled and
fixed-rate sources, runtime frequency, low-power stall compensation). To keep
the PR reviewable the remaining timer drivers will be converted in follow-up
PRs.

Runtime-verified on QEMU/sim (`timer_api`, `timer_behavior`, `context`, `sleep`,
`tickless`):

- `riscv_machine_timer`, `arm_arch_timer`, `riscv_supervisor_timer`, `hpet`,
  `mips_cp0_timer`, `cmsdk_apb_timer`, `cortex_m_systick`, `arcv2_timer0`,
  `xtensa_sys_timer`, `openrisc_tick_timer`, `leon_gptimer`, `native_sim_timer`.

Build-only (no in-tree emulation; real targets noted):

- `renesas_ra_ulpt_timer` (RA8), `apic_tsc` (ACRN / x86 hardware),
  `intel_adsp_timer` (ADSP simulator / hardware), `esp32_sys_timer` (ESP32
  RISC-V parts).

## Supersedes

Folded into the `cortex_m_systick` conversion, so they can be closed in favour
of this PR:

- #109574 — SysTick drift-compensation fix.
- #112806 — SysTick 64-bit long-sleep fix.
- #113083 — SysTick min-timeout-from-cycle-rate fix. Its driver commit is
  carried here, just before the `cortex_m_systick` conversion, so the
  conversion can drop the driver's cycles-per-tick entirely (the min timeout
  no longer depends on it).

## Related (not in this PR)

#109735 (`nrf_grtc`) and #110588 (`stm32wb0`) hand-implement the same
tick-aligned-deadline pattern this core provides. They are not converted here;
converting those drivers onto the core is a natural follow-up that would subsume
them.

## Testing

- Full sweep across the 13 QEMU/sim platforms above (`timer_api` +
  `timer_behavior` + `context`) passes, including the runtime-frequency
  precompute path (`arm_arch` on `qemu_cortex_a53`, `hpet` on `qemu_x86*`) and the
  timing-precision suite.
- SysTick verified tickless (default) and tickful, with the 64-bit cycle counter,
  and on the frequency-rescale path.
- Build-only drivers built on their targets, exercising the SMP, low-power-hook
  and runtime-frequency paths where they exist.

