### PR TITLE
[backport v4.4] kernel: timeout: subsystem-level handler-completion synchronization

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2112,6 +2112,18 @@ static inline void *z_impl_k_timer_user_data_get(const struct k_timer *timer)
 	return timer->user_data;
 }
 
+/**
+ * @brief Stop a dynamically allocated timer before free
+ *
+ * If a timer object is dynamically allocated, it needs to be stopped
+ * before associated resources are released.
+ *
+ * @param timer Address of the timer.
+ * @retval 0 on success
+ * @retval -EAGAIN when object is still in use
+ */
+int k_timer_cleanup(struct k_timer *timer);
+
 /** @} */
 
 /**

--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -1948,6 +1948,20 @@
  */
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)
 
+/**
+ * @brief Trace Timer cleanup attempt entry
+ * @param timer Timer object
+ */
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+
+/**
+ * @brief Trace Timer cleanup outcome
+ * @param timer Timer object
+ * @param ret Return value
+ */
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
+
+
 /** @} */ /* end of subsys_tracing_apis_timer */
 
 /**

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -53,7 +53,16 @@ extern struct k_spinlock _sched_spinlock;
 extern struct k_thread _thread_dummy;
 
 void z_sched_init(void);
+
+/**
+ * @brief Unpend thread, do not abort its timeout (if it exists).
+ */
 void z_unpend_thread_no_timeout(struct k_thread *thread);
+
+/**
+ * @brief Unpend thread and abort its timeout (if it exists).
+ */
+void z_unpend_thread(struct k_thread *thread);
 struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q);
 int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
 	       _wait_q_t *wait_q, k_timeout_t timeout);
@@ -61,7 +70,6 @@ void z_pend_thread(struct k_thread *thread, _wait_q_t *wait_q,
 		   k_timeout_t timeout);
 void z_reschedule(struct k_spinlock *lock, k_spinlock_key_t key);
 void z_reschedule_irqlock(uint32_t key);
-void z_unpend_thread(struct k_thread *thread);
 int z_unpend_all(_wait_q_t *wait_q);
 int z_unpend_all_locked(_wait_q_t *wait_q);
 bool z_thread_prio_set(struct k_thread *thread, int prio);

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -41,6 +41,15 @@ k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t tim
 
 int z_abort_timeout(struct _timeout *to);
 
+/* Report whether the given timeout's handler is currently in flight, i.e. it
+ * has been popped from the queue by sys_clock_announce() but its handler has
+ * not yet returned. A canceller that must guarantee the handler is no longer
+ * about to touch the timeout's storage (before freeing or reusing it) can
+ * abort the timeout and then spin on this predicate, dropping the lock the
+ * handler needs so it can run to completion.
+ */
+bool z_timeout_is_inflight(const struct _timeout *to);
+
 /* Determine if the timeout handler should continue.
  *
  * The routine sys_clock_announce() both removes the timeout from the timeout
@@ -105,6 +114,7 @@ k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 #define z_is_aborted_thread_timeout(to) false
 #define z_is_inactive_timeout(to) 1
 #define z_is_aborted_timeout(to) false
+#define z_timeout_is_inflight(to) false
 #define z_get_next_timeout_expiry() ((int32_t) K_TICKS_FOREVER)
 #define z_set_timeout_expiry(ticks, is_idle) do {} while (false)
 

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -643,8 +643,24 @@ static int triggered_work_cancel(struct k_work_poll *work,
 {
 	/* Check if the work waits for event. */
 	if (work->poller.is_polling && work->poller.mode != MODE_NONE) {
-		/* Remove timeout associated with the work. */
+		/* Remove timeout associated with the work. If the handler is
+		 * already in flight this flags it to bail (dticks ABORTED),
+		 * but does not wait for it.
+		 */
 		z_abort_timeout(&work->timeout);
+
+		/* Then wait for any in-flight handler to actually complete
+		 * before we proceed. The handler still has a pending
+		 * dereference of work->timeout / work->poller, so returning
+		 * (and letting the caller free `work`, or re-arming the same
+		 * `work` for a new poll) while it is about to run would race
+		 * that access. Dropping the lock lets the blocked handler take
+		 * it, observe the abort, and return.
+		 */
+		while (z_timeout_is_inflight(&work->timeout)) {
+			k_spin_unlock(&lock, key);
+			key = k_spin_lock(&lock);
+		}
 
 		/*
 		 * Prevent work execution if event arrives while we will be

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -595,18 +595,31 @@ static void triggered_work_handler(struct k_work *work)
 	twork->real_handler(work);
 }
 
+extern int z_work_submit_to_queue(struct k_work_q *queue,
+			 struct k_work *work);
+
 static void triggered_work_expiration_handler(struct _timeout *timeout)
 {
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	if (z_is_timeout_handler_canceled(timeout)) {
+		/*
+		 * The timeout was canceled by a thread on another CPU
+		 * or another ISR. Bail.
+		 */
+		k_spin_unlock(&lock, key);
+		return;
+	}
+
 	struct k_work_poll *twork =
 		CONTAINER_OF(timeout, struct k_work_poll, timeout);
 
 	twork->poller.is_polling = false;
 	twork->poll_result = -EAGAIN;
-	k_work_submit_to_queue(twork->workq, &twork->work);
-}
+	z_work_submit_to_queue(twork->workq, &twork->work);
 
-extern int z_work_submit_to_queue(struct k_work_q *queue,
-			 struct k_work *work);
+	k_spin_unlock(&lock, key);
+}
 
 static int signal_triggered_work(struct k_poll_event *event, uint32_t status)
 {

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -679,12 +679,22 @@ void z_sched_wake_thread_locked(struct k_thread *thread)
 /* Timeout handler for *_thread_timeout() APIs */
 void z_thread_timeout(struct _timeout *timeout)
 {
+	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
+
+	if (z_is_timeout_handler_canceled(timeout)) {
+		/*
+		 * The timeout handler was canceled by a thread on another
+		 * CPU or another ISR. Bail.
+		 */
+		k_spin_unlock(&_sched_spinlock, key);
+		return;
+	}
+
 	struct k_thread *thread = CONTAINER_OF(timeout,
 					       struct k_thread, base.timeout);
 
-	K_SPINLOCK(&_sched_spinlock) {
-		z_sched_wake_thread_locked(thread);
-	}
+	z_sched_wake_thread_locked(thread);
+	k_spin_unlock(&_sched_spinlock, key);
 }
 #endif /* CONFIG_SYS_CLOCK_EXISTS */
 
@@ -727,8 +737,12 @@ struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q)
 
 void z_unpend_thread(struct k_thread *thread)
 {
-	z_unpend_thread_no_timeout(thread);
-	z_abort_thread_timeout(thread);
+	K_SPINLOCK(&_sched_spinlock) {
+		if (thread->base.pended_on != NULL) {
+			unpend_thread_no_timeout(thread);
+		}
+		z_abort_thread_timeout(thread);
+	}
 }
 
 /* Priority set utility that does no rescheduling, it just changes the

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -26,6 +26,20 @@ static struct k_spinlock timeout_lock;
 /* Ticks left to process in the currently-executing sys_clock_announce() */
 static int announce_remaining;
 
+/*
+ * The timeout whose handler is currently executing, or NULL. It is set
+ * under timeout_lock right before sys_clock_announce_locked() drops the lock
+ * to invoke a handler and cleared once the handler returns. The single
+ * announcer invariant (only one CPU runs the dispatch loop at a time) means a
+ * single global pointer is sufficient to track the in-flight handler.
+ *
+ * This lets a canceller detect the window where a timeout has been popped from
+ * the queue but its handler has not yet run (or is running) and wait for it to
+ * complete before freeing or reusing the timeout's storage. See
+ * z_timeout_is_inflight().
+ */
+static struct _timeout *inflight_timeout;
+
 static struct _timeout *first(void)
 {
 	sys_dnode_t *t = sys_dlist_peek_head(&timeout_list);
@@ -166,6 +180,17 @@ int z_abort_timeout(struct _timeout *to)
 	return ret;
 }
 
+bool z_timeout_is_inflight(const struct _timeout *to)
+{
+	bool ret = false;
+
+	K_SPINLOCK(&timeout_lock) {
+		ret = (inflight_timeout == to);
+	}
+
+	return ret;
+}
+
 /* must be locked */
 static k_ticks_t timeout_rem(const struct _timeout *timeout)
 {
@@ -247,10 +272,12 @@ void sys_clock_announce_locked(int32_t ticks, k_spinlock_key_t key)
 		t->dticks = 0;
 		remove_timeout(t);
 		t->dticks = TIMEOUT_DTICKS_ANNOUNCING;
+		inflight_timeout = t;
 
 		k_spin_unlock(&timeout_lock, key);
 		t->fn(t);
 		key = k_spin_lock(&timeout_lock);
+		inflight_timeout = NULL;
 		announce_remaining -= dt;
 	}
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -201,6 +201,19 @@ int k_timer_cleanup(struct k_timer *timer)
 	 */
 	z_abort_timeout(&timer->timeout);
 
+	/* If the expiration handler is in flight on another CPU it may still
+	 * be dereferencing the timer, including running the user expiry_fn
+	 * (z_timer_expiration_handler drops timer.c::lock around it). The
+	 * caller is about to free the timer's storage, so wait for the
+	 * handler to fully complete first. Dropping timer.c::lock lets a
+	 * handler blocked on it run to completion; on uniprocessor nothing is
+	 * in flight (holding the lock disables interrupts) so this is a no-op.
+	 */
+	while (z_timeout_is_inflight(&timer->timeout)) {
+		k_spin_unlock(&lock, key);
+		key = k_spin_lock(&lock);
+	}
+
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, 0);
 
 	k_spin_unlock(&lock, key);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/init.h>
 #include <zephyr/internal/syscall_handler.h>
+#include <zephyr/sys/check.h>
 #include <stdbool.h>
 #include <zephyr/spinlock.h>
 #include <ksched.h>
@@ -178,6 +179,34 @@ void k_timer_init(struct k_timer *timer,
 	z_timer_observer_on_init(timer);
 }
 
+int k_timer_cleanup(struct k_timer *timer)
+{
+	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_timer, cleanup, timer);
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	CHECKIF(z_waitq_head(&timer->wait_q) != NULL) {
+		k_spin_unlock(&lock, key);
+
+		SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, -EAGAIN);
+
+		return -EAGAIN;
+	}
+
+	/* Need to abort the timer so it will not trigger anymore.
+	 * Cannot call k_timer_stop() here as that will call any
+	 * defined callbacks. If we get to this point, we can
+	 * reasonably assume that no one cares about the timer
+	 * anymore, and we simply remove the timeout in queue.
+	 */
+	z_abort_timeout(&timer->timeout);
+
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_timer, cleanup, timer, 0);
+
+	k_spin_unlock(&lock, key);
+
+	return 0;
+}
 
 void z_impl_k_timer_start(struct k_timer *timer, k_timeout_t duration,
 			  k_timeout_t period)

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -685,6 +685,14 @@ static void unref_check(struct k_object *ko, uintptr_t index, bool sched_locked)
 			k_stack_cleanup((struct k_stack *)ko->name);
 		}
 		break;
+	case K_OBJ_TIMER:
+		if ((ko->flags & K_OBJ_FLAG_INITIALIZED) == K_OBJ_FLAG_INITIALIZED) {
+			/* k_timer_cleanup() does not check if timer has been
+			 * initialized. So we need to do it here before calling.
+			 */
+			k_timer_cleanup((struct k_timer *)ko->name);
+		}
+		break;
 	default:
 		/* Nothing to do */
 		break;

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -1117,7 +1117,8 @@ static int schedule_for_queue_locked(struct k_work_q **queuep,
  * @return true if and only if work had been delayed so the timeout
  * was cancelled.
  */
-static inline bool unschedule_locked(struct k_work_delayable *dwork)
+static inline bool unschedule_locked(struct k_work_delayable *dwork,
+				     k_spinlock_key_t *key)
 {
 	bool ret = false;
 	struct k_work *work = &dwork->work;
@@ -1129,6 +1130,23 @@ static inline bool unschedule_locked(struct k_work_delayable *dwork)
 	 */
 	if (flag_test_and_clear(&work->flags, K_WORK_DELAYED_BIT)) {
 		ret = z_abort_timeout(&dwork->timeout) == 0;
+
+		/* Clearing K_WORK_DELAYED_BIT above claims the wake from the
+		 * timeout handler, so a racing in-flight work_timeout() will
+		 * bail. But it may still be about to dereference
+		 * dwork->work.flags: wait for it to complete before we return,
+		 * as callers may free dwork or re-arm the same delayable for a
+		 * new schedule once we return.
+		 *
+		 * Dropping work.c::lock lets the blocked handler take it and
+		 * run to completion. On uniprocessor there is nothing in
+		 * flight (holding the lock disables interrupts) so this is a
+		 * no-op.
+		 */
+		while (z_timeout_is_inflight(&dwork->timeout)) {
+			k_spin_unlock(&lock, *key);
+			*key = k_spin_lock(&lock);
+		}
 	}
 
 	return ret;
@@ -1145,9 +1163,10 @@ static inline bool unschedule_locked(struct k_work_delayable *dwork)
  *
  * @return k_work_busy_get() flags
  */
-static int cancel_delayable_async_locked(struct k_work_delayable *dwork)
+static int cancel_delayable_async_locked(struct k_work_delayable *dwork,
+					 k_spinlock_key_t *key)
 {
-	(void)unschedule_locked(dwork);
+	(void)unschedule_locked(dwork, key);
 
 	return cancel_async_locked(&dwork->work);
 }
@@ -1199,7 +1218,7 @@ int k_work_reschedule_for_queue(struct k_work_q *queue, struct k_work_delayable 
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
 	/* Remove any active scheduling. */
-	(void)unschedule_locked(dwork);
+	(void)unschedule_locked(dwork, &key);
 
 	/* Schedule the work item with the new parameters. */
 	ret = schedule_for_queue_locked(&queue, dwork, delay);
@@ -1229,7 +1248,7 @@ int k_work_cancel_delayable(struct k_work_delayable *dwork)
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_work, cancel_delayable, dwork);
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
-	int ret = cancel_delayable_async_locked(dwork);
+	int ret = cancel_delayable_async_locked(dwork, &key);
 
 	k_spin_unlock(&lock, key);
 
@@ -1256,7 +1275,7 @@ bool k_work_cancel_delayable_sync(struct k_work_delayable *dwork,
 	bool need_wait = false;
 
 	if (pending) {
-		(void)cancel_delayable_async_locked(dwork);
+		(void)cancel_delayable_async_locked(dwork, &key);
 		need_wait = cancel_sync_locked(&dwork->work, canceller);
 	}
 
@@ -1298,7 +1317,7 @@ bool k_work_flush_delayable(struct k_work_delayable *dwork,
 	/* If unscheduling did something then submit it.  Ignore a
 	 * failed submission (e.g. when cancelling).
 	 */
-	if (unschedule_locked(dwork)) {
+	if (unschedule_locked(dwork, &key)) {
 		struct k_work_q *queue = dwork->queue;
 
 		(void)submit_to_queue_locked(work, &queue);

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -204,6 +204,8 @@ extern "C" {
 	sys_trace_k_timer_stop_fn_expiry_enter(timer)
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)                                          \
 	sys_trace_k_timer_stop_fn_expiry_exit(timer)
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
 
 #define sys_port_trace_k_condvar_init(condvar, ret)    sys_trace_k_condvar_init(condvar, ret)
 #define sys_port_trace_k_condvar_signal_enter(condvar) sys_trace_k_condvar_signal_enter(condvar)

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -745,6 +745,9 @@ void sys_trace_thread_info(struct k_thread *thread);
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)                                          \
 	SEGGER_SYSVIEW_RecordEndCall(TID_TIMER_STOP_EXPIRY)
 
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
+
 #define sys_port_trace_syscall_enter(id, name, ...)                                                \
 	SEGGER_SYSVIEW_RecordString(TID_SYSCALL, (const char *)#name)
 

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -437,6 +437,8 @@
 	sys_trace_k_timer_stop_fn_expiry_enter(timer)
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)					   \
 	sys_trace_k_timer_stop_fn_expiry_exit(timer)
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
 
 #define sys_port_trace_k_event_init(event) sys_trace_k_event_init(event)
 #define sys_port_trace_k_event_post_enter(event, events, events_mask)   \

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -418,6 +418,8 @@ void sys_trace_rtio_chain_next_exit(const struct rtio *r, const struct rtio_iode
 					sys_trace_timer_stop_fn_expiry_enter(timer)
 #define sys_port_trace_k_timer_stop_fn_expiry_exit(timer)			\
 					sys_trace_timer_stop_fn_expiry_exit(timer)
+#define sys_port_trace_k_timer_cleanup_enter(timer)
+#define sys_port_trace_k_timer_cleanup_exit(timer, ret)
 
 #define sys_port_trace_k_event_init(event)
 #define sys_port_trace_k_event_post_enter(event, events, events_mask)


### PR DESCRIPTION
Fixes #113143

Backport of the timeout-handler race protection from #109977 to 4.4,
requested by @d3zd3z.

#109977 on main reworked the whole timeout subsystem, replacing the
`dticks`-based in-band cancel mechanism with a new
`z_try_abort_timeout()` interface (roughly 30 files). Bringing that
across verbatim would be far too invasive for a stable branch. Instead
this series provides the equivalent race protection on top of the
mechanism 4.4 already ships, so the change stays small (14 files, ~210
insertions).

Mapping the six races #109977 consolidated against 4.4:

- k_timer re-use in handler (#106654), delayable-work timeout, and the
  workqueue work-timeout gap all landed before the 4.4.0 fork and are
  already present.
- thread timeout (#106653) and poll timeout landed on main after the
  fork. Their original `dticks`-based fixes are cherry-picked here as-is
  (the poll one verbatim, the thread one with a one-line context fixup
  in `ksched.h`).
- the dynamic `k_timer` free UAF (#109426, superseded by #109977) is
  cherry-picked from its original standalone form.

The last four commits close the two pre-existing use-after-free windows
that only #109977's new wait-for-handler machinery addressed
(`k_work_poll_cancel()` and `k_work_cancel_delayable()` returning while
a handler on another CPU is still about to dereference the object, which
a user-space caller may free). Rather than porting `z_try_abort_timeout()`,
a minimal `inflight_timeout` tracker is added to the timeout subsystem
and the cancel paths spin on it until the handler has run to completion.
The same tracker is then used to tighten `k_timer_cleanup()` so the
timer storage is not freed while its expiry handler (including the user
`expiry_fn`) is still running, fully closing the #109426 residual.

On uniprocessor the added waits are no-ops: holding the subsystem lock
disables interrupts, so no handler can be mid-dispatch.

Each `(backported from ...)` / `(cherry picked from ...)` trailer cites
the corresponding upstream main commit.


Fixes: #113143
Fixes: #106653

