### PR TITLE
drivers: sensor: bmi270: convert RTIO path to fully async with SQE chaining

### DIFF
--- a/drivers/sensor/bosch/bmi270/CMakeLists.txt
+++ b/drivers/sensor/bosch/bmi270/CMakeLists.txt
@@ -8,6 +8,8 @@
 zephyr_library()
 
 zephyr_library_sources(bmi270.c)
+zephyr_library_sources(bmi270_decoder.c)
 zephyr_library_sources_ifdef(CONFIG_BMI270_BUS_I2C bmi270_i2c.c)
 zephyr_library_sources_ifdef(CONFIG_BMI270_BUS_SPI bmi270_spi.c)
 zephyr_library_sources_ifdef(CONFIG_BMI270_TRIGGER bmi270_trigger.c)
+zephyr_library_sources_ifdef(CONFIG_BMI270_STREAM bmi270_stream.c)

--- a/drivers/sensor/bosch/bmi270/Kconfig
+++ b/drivers/sensor/bosch/bmi270/Kconfig
@@ -64,4 +64,100 @@ config BMI270_THREAD_STACK_SIZE
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 
+config BMI270_LOW_POWER_MODE
+	bool "Force low-power (power-optimized) filter mode at all ODRs"
+	default n
+	help
+	  When set, the accelerometer and gyroscope always use the
+	  power-optimized filter mode (acc_filter_perf=0, gyr_filter_perf=0,
+	  gyr_noise_perf=0) regardless of ODR. By default the driver switches
+	  to performance mode at ODR >= 100 Hz. Enabling this saves power at
+	  the cost of higher noise (no digital filtering / OSR).
+
+config BMI270_STREAM
+	bool "FIFO streaming via sensor_stream()"
+	depends on BMI270_TRIGGER
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_BOSCH_BMI270),irq-gpios)
+	select SENSOR_ASYNC_API
+	help
+	  Enable FIFO watermark/full streaming using the standard Zephyr
+	  sensor_stream() API and SENSOR_TRIG_FIFO_WATERMARK trigger.
+
+config BMI270_FIFO_ON_INT2
+	bool "Route FIFO watermark/full interrupt to INT2 instead of INT1"
+	depends on BMI270_STREAM
+	default n
+	help
+	  By default, FIFO watermark and full interrupts are mapped to INT1
+	  and the single irq-gpios pin is assigned to INT1. Enable this only
+	  if your board routes the FIFO interrupt to the sensor's INT2 pin.
+
+config BMI270_FIFO_POLL_FALLBACK
+	bool "Poll-based FIFO fallback alongside GPIO interrupt"
+	depends on BMI270_STREAM
+	default n
+	help
+	  When set, a periodic poll checks the FIFO fill level via SPI/I2C
+	  and triggers a read when the watermark is reached, as a fallback
+	  for hardware where the GPIO interrupt line is not connected.
+	  The poll period is set by BMI270_FIFO_POLL_PERIOD_MS.
+
+config BMI270_FIFO_POLL_PERIOD_MS
+	int "FIFO poll fallback period (ms)"
+	depends on BMI270_FIFO_POLL_FALLBACK
+	default 100
+	range 10 1000
+	help
+	  How often (in milliseconds) the poll fallback checks the FIFO fill
+	  level. Lower values reduce latency but increase SPI/I2C bus traffic.
+
+config BMI270_FIFO_WORKQ_STACK_SIZE
+	int "Stack size for FIFO handler work queue thread"
+	depends on BMI270_STREAM
+	default 4096
+	help
+	  The FIFO watermark handler runs in a dedicated work queue thread to avoid
+	  stack overflow in the trigger thread. Increase if you see crashes when
+	  the interrupt fires.
+
+config BMI270_FIFO_HEADERLESS
+	bool "Use FIFO headerless mode (no per-frame headers)"
+	depends on BMI270_STREAM
+	default n
+	help
+	  When set, FIFO is configured with FIFO_CONFIG_1.fifo_header_en=0.
+	  Requires identical ODR for accelerometer and gyroscope.
+	  Only regular frames are stored (no skip/sensortime/config);
+	  watermark = WATERMARK_SAMPLES*12 gives exactly that many samples per interrupt.
+
+config BMI270_FIFO_WATERMARK_SAMPLES
+	int "FIFO watermark in number of samples (acc+gyr frames)"
+	depends on BMI270_STREAM
+	default 10
+	help
+	  Desired number of accelerometer and gyroscope data samples per watermark interrupt.
+	  In headerless mode the byte watermark is SAMPLES*12 (exact).
+
+config BMI270_FIFO_WATERMARK_CONTROL_MARGIN
+	int "Extra bytes added to FIFO byte-watermark for control frames"
+	depends on BMI270_STREAM && !BMI270_FIFO_HEADERLESS
+	default 0
+	help
+	  In header mode the FIFO may insert control/skip frames between data
+	  frames. This margin is added to (WATERMARK_SAMPLES * frame_bytes) when
+	  programming the hardware watermark register, so the interrupt fires
+	  after at least WATERMARK_SAMPLES data frames. Set to 0 if you do not
+	  need extra headroom for control frames.
+
+config BMI270_FIFO_STREAM_BLOCK_SIZE
+	int "Stream RTIO mempool block size (bytes)"
+	depends on BMI270_STREAM
+	default 384
+	help
+	  Must match the block size used in RTIO_DEFINE_WITH_MEMPOOL for the
+	  sensor stream. Each FIFO read is capped to fit in one block (minus
+	  encoded header). Size needed: WATERMARK_SAMPLES*13 + CONTROL_MARGIN
+	  + ~32 bytes encoded header. Default 384 supports 10 samples in
+	  header mode (10*13+40+32=202) with headroom.
+
 endif # BMI270

--- a/drivers/sensor/bosch/bmi270/Kconfig
+++ b/drivers/sensor/bosch/bmi270/Kconfig
@@ -9,7 +9,9 @@ menuconfig BMI270
 	default y
 	depends on DT_HAS_BOSCH_BMI270_ENABLED
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMI270),i2c)
+	select I2C_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMI270),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMI270),spi)
+	select SPI_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMI270),spi)
 	help
 	  Enable driver for BMI270 I2C-based imu sensor
 
@@ -110,15 +112,6 @@ config BMI270_FIFO_POLL_PERIOD_MS
 	help
 	  How often (in milliseconds) the poll fallback checks the FIFO fill
 	  level. Lower values reduce latency but increase SPI/I2C bus traffic.
-
-config BMI270_FIFO_WORKQ_STACK_SIZE
-	int "Stack size for FIFO handler work queue thread"
-	depends on BMI270_STREAM
-	default 4096
-	help
-	  The FIFO watermark handler runs in a dedicated work queue thread to avoid
-	  stack overflow in the trigger thread. Increase if you see crashes when
-	  the interrupt fires.
 
 config BMI270_FIFO_HEADERLESS
 	bool "Use FIFO headerless mode (no per-frame headers)"

--- a/drivers/sensor/bosch/bmi270/bmi270.c
+++ b/drivers/sensor/bosch/bmi270/bmi270.c
@@ -16,6 +16,7 @@
 
 #include "bmi270.h"
 #include "bmi270_config_file.h"
+#include "bmi270_decoder.h"
 
 LOG_MODULE_REGISTER(bmi270, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -61,6 +62,22 @@ int bmi270_reg_write_with_delay(const struct device *dev,
 		k_usleep(delay_us);
 	}
 	return ret;
+}
+
+int bmi270_adv_power_save_enable(const struct device *dev)
+{
+	uint8_t pwr = BMI270_PWR_CONF_ADV_PWR_SAVE_EN;
+
+	return bmi270_reg_write_with_delay(dev, BMI270_REG_PWR_CONF, &pwr, 1,
+					   BMI270_TRANSC_DELAY_SUSPEND);
+}
+
+int bmi270_adv_power_save_disable(const struct device *dev)
+{
+	uint8_t pwr = BMI270_PWR_CONF_ADV_PWR_SAVE_DIS;
+
+	return bmi270_reg_write_with_delay(dev, BMI270_REG_PWR_CONF, &pwr, 1,
+					   BMI270_TRANSC_DELAY_SUSPEND);
 }
 
 static void channel_accel_convert(struct sensor_value *val, int64_t raw_val,
@@ -152,23 +169,20 @@ static int set_accel_odr_osr(const struct device *dev, const struct sensor_value
 			pwr_ctrl &= ~BMI270_PWR_CTRL_ACC_EN;
 		}
 
-		/* If the Sampling frequency (odr) >= 100Hz, enter performance
-		 * mode else, power optimized. This also has a consequence
-		 * for the OSR
-		 */
-		if (odr_bits >= BMI270_ACC_ODR_100_HZ) {
-			acc_conf = BMI270_SET_BITS(acc_conf, BMI270_ACC_FILT,
-						   BMI270_ACC_FILT_PERF_OPT);
+		if (IS_ENABLED(CONFIG_BMI270_LOW_POWER_MODE) || odr_bits < BMI270_ACC_ODR_100_HZ) {
+			acc_conf =
+				BMI270_SET_BITS(acc_conf, BMI270_ACC_FILT, BMI270_ACC_FILT_PWR_OPT);
 		} else {
 			acc_conf = BMI270_SET_BITS(acc_conf, BMI270_ACC_FILT,
-						   BMI270_ACC_FILT_PWR_OPT);
+						   BMI270_ACC_FILT_PERF_OPT);
 		}
 
 		data->acc_odr = odr_bits;
 	}
 
 	if (osr) {
-		if (data->acc_odr >= BMI270_ACC_ODR_100_HZ) {
+		if (!IS_ENABLED(CONFIG_BMI270_LOW_POWER_MODE) &&
+		    data->acc_odr >= BMI270_ACC_ODR_100_HZ) {
 			/* Performance mode */
 			/* osr->val2 should be unused */
 			switch (osr->val1) {
@@ -340,24 +354,16 @@ static int set_gyro_odr_osr(const struct device *dev, const struct sensor_value 
 			pwr_ctrl &= ~BMI270_PWR_CTRL_GYR_EN;
 		}
 
-		/* If the Sampling frequency (odr) >= 100Hz, enter performance
-		 * mode else, power optimized. This also has a consequence for
-		 * the OSR
-		 */
-		if (odr_bits >= BMI270_GYR_ODR_100_HZ) {
-			gyr_conf = BMI270_SET_BITS(gyr_conf,
-						   BMI270_GYR_FILT,
-						   BMI270_GYR_FILT_PERF_OPT);
-			gyr_conf = BMI270_SET_BITS(gyr_conf,
-						   BMI270_GYR_FILT_NOISE,
-						   BMI270_GYR_FILT_NOISE_PERF);
-		} else {
-			gyr_conf = BMI270_SET_BITS(gyr_conf,
-						   BMI270_GYR_FILT,
-						   BMI270_GYR_FILT_PWR_OPT);
-			gyr_conf = BMI270_SET_BITS(gyr_conf,
-						   BMI270_GYR_FILT_NOISE,
+		if (IS_ENABLED(CONFIG_BMI270_LOW_POWER_MODE) || odr_bits < BMI270_GYR_ODR_100_HZ) {
+			gyr_conf =
+				BMI270_SET_BITS(gyr_conf, BMI270_GYR_FILT, BMI270_GYR_FILT_PWR_OPT);
+			gyr_conf = BMI270_SET_BITS(gyr_conf, BMI270_GYR_FILT_NOISE,
 						   BMI270_GYR_FILT_NOISE_PWR);
+		} else {
+			gyr_conf = BMI270_SET_BITS(gyr_conf, BMI270_GYR_FILT,
+						   BMI270_GYR_FILT_PERF_OPT);
+			gyr_conf = BMI270_SET_BITS(gyr_conf, BMI270_GYR_FILT_NOISE,
+						   BMI270_GYR_FILT_NOISE_PERF);
 		}
 
 		data->gyr_odr = odr_bits;
@@ -443,10 +449,10 @@ static int set_gyro_range(const struct device *dev, const struct sensor_value *r
 	return ret;
 }
 
-static int8_t write_config_file(const struct device *dev)
+static int write_config_file(const struct device *dev)
 {
 	const struct bmi270_config *cfg = dev->config;
-	int8_t ret = 0;
+	int ret = 0;
 	uint16_t index = 0;
 	uint8_t addr_array[2] = { 0 };
 
@@ -649,7 +655,7 @@ static int bmi270_init(const struct device *dev)
 
 	ret = bmi270_bus_check(dev);
 	if (ret < 0) {
-		LOG_ERR("Could not initialize bus");
+		LOG_ERR("Bus check failed: %d", ret);
 		return ret;
 	}
 
@@ -667,24 +673,25 @@ static int bmi270_init(const struct device *dev)
 
 	ret = bmi270_bus_init(dev);
 	if (ret != 0) {
-		LOG_ERR("Could not initiate bus communication");
+		LOG_ERR("Bus init failed: %d", ret);
 		return ret;
 	}
 
 	ret = bmi270_reg_read(dev, BMI270_REG_CHIP_ID, &chip_id, 1);
 	if (ret != 0) {
+		LOG_ERR("CHIP_ID read failed: %d", ret);
 		return ret;
 	}
 
 	if (chip_id != BMI270_CHIP_ID) {
-		LOG_ERR("Unexpected chip id (%x). Expected (%x)",
-			chip_id, BMI270_CHIP_ID);
+		LOG_ERR("Unexpected chip id (0x%02x). Expected (0x%02x)", chip_id, BMI270_CHIP_ID);
 		return -EIO;
 	}
 
 	soft_reset_cmd = BMI270_CMD_SOFT_RESET;
 	ret = bmi270_reg_write(dev, BMI270_REG_CMD, &soft_reset_cmd, 1);
 	if (ret != 0) {
+		LOG_ERR("Soft reset write failed: %d", ret);
 		return ret;
 	}
 
@@ -699,6 +706,7 @@ static int bmi270_init(const struct device *dev)
 
 	ret = bmi270_reg_read(dev, BMI270_REG_PWR_CONF, &adv_pwr_save, 1);
 	if (ret != 0) {
+		LOG_ERR("PWR_CONF read failed: %d", ret);
 		return ret;
 	}
 
@@ -715,18 +723,20 @@ static int bmi270_init(const struct device *dev)
 	init_ctrl = BMI270_PREPARE_CONFIG_LOAD;
 	ret = bmi270_reg_write(dev, BMI270_REG_INIT_CTRL, &init_ctrl, 1);
 	if (ret != 0) {
+		LOG_ERR("INIT_CTRL prepare failed: %d", ret);
 		return ret;
 	}
 
 	ret = write_config_file(dev);
-
 	if (ret != 0) {
+		LOG_ERR("Config file write failed: %d", ret);
 		return ret;
 	}
 
 	init_ctrl = BMI270_COMPLETE_CONFIG_LOAD;
 	ret = bmi270_reg_write(dev, BMI270_REG_INIT_CTRL, &init_ctrl, 1);
 	if (ret != 0) {
+		LOG_ERR("INIT_CTRL complete failed: %d", ret);
 		return ret;
 	}
 
@@ -738,6 +748,7 @@ static int bmi270_init(const struct device *dev)
 	for (tries = 0; tries <= BMI270_CONFIG_FILE_RETRIES; tries++) {
 		ret = bmi270_reg_read(dev, BMI270_REG_INTERNAL_STATUS, &msg, 1);
 		if (ret != 0) {
+			LOG_ERR("INTERNAL_STATUS read failed: %d", ret);
 			return ret;
 		}
 
@@ -750,6 +761,7 @@ static int bmi270_init(const struct device *dev)
 	}
 
 	if (tries > BMI270_CONFIG_FILE_RETRIES) {
+		LOG_ERR("Config load timeout (INTERNAL_STATUS not INIT_OK)");
 		return -EIO;
 	}
 
@@ -775,8 +787,12 @@ static DEVICE_API(sensor, bmi270_driver_api) = {
 	.sample_fetch = bmi270_sample_fetch,
 	.channel_get = bmi270_channel_get,
 	.attr_set = bmi270_attr_set,
+	.get_decoder = bmi270_get_decoder,
 #if defined(CONFIG_BMI270_TRIGGER)
 	.trigger_set = bmi270_trigger_set,
+#endif
+#if defined(CONFIG_BMI270_STREAM)
+	.submit = bmi270_submit_stream,
 #endif
 };
 
@@ -800,9 +816,33 @@ static const struct bmi270_feature_config bmi270_feature_base = {
 		&bmi270_feature_max_fifo)
 
 #if CONFIG_BMI270_TRIGGER
-#define BMI270_CONFIG_INT(inst) \
-	.int1 = GPIO_DT_SPEC_INST_GET_BY_IDX_OR(inst, irq_gpios, 0, {}),\
-	.int2 = GPIO_DT_SPEC_INST_GET_BY_IDX_OR(inst, irq_gpios, 1, {}),
+/*
+ * One irq-gpio: INT1 by default, INT2 when CONFIG_BMI270_FIFO_ON_INT2.
+ * Two irq-gpios: INT1=first, INT2=second.
+ *
+ * When FIFO_ON_INT2 is set with a single irq-gpio, INT1 is unavailable
+ * and SENSOR_TRIG_MOTION will return -ENOTSUP at runtime.
+ */
+#if defined(CONFIG_BMI270_FIFO_ON_INT2)
+#define BMI270_SINGLE_IRQ_INT1(inst)                                                               \
+	{                                                                                          \
+	}
+#define BMI270_SINGLE_IRQ_INT2(inst) GPIO_DT_SPEC_INST_GET_BY_IDX(inst, irq_gpios, 0)
+#else
+#define BMI270_SINGLE_IRQ_INT1(inst) GPIO_DT_SPEC_INST_GET_BY_IDX(inst, irq_gpios, 0)
+#define BMI270_SINGLE_IRQ_INT2(inst)                                                               \
+	{                                                                                          \
+	}
+#endif
+
+#define BMI270_CONFIG_INT_1(inst)                                                                  \
+	.int1 = BMI270_SINGLE_IRQ_INT1(inst), .int2 = BMI270_SINGLE_IRQ_INT2(inst),
+#define BMI270_CONFIG_INT_2(inst)                                                                  \
+	.int1 = GPIO_DT_SPEC_INST_GET_BY_IDX(inst, irq_gpios, 0),                                  \
+	.int2 = GPIO_DT_SPEC_INST_GET_BY_IDX(inst, irq_gpios, 1),
+#define BMI270_CONFIG_INT(inst)                                                                    \
+	COND_CODE_1(DT_INST_PROP_HAS_IDX(inst, irq_gpios, 1),                                      \
+		    (BMI270_CONFIG_INT_2(inst)), (BMI270_CONFIG_INT_1(inst)))
 #else
 #define BMI270_CONFIG_INT(inst)
 #endif

--- a/drivers/sensor/bosch/bmi270/bmi270.c
+++ b/drivers/sensor/bosch/bmi270/bmi270.c
@@ -68,7 +68,7 @@ int bmi270_reg_write_with_delay(const struct device *dev,
 int bmi270_prep_reg_read_async(const struct device *dev, uint8_t reg, uint8_t *buf, size_t len,
 			       uint8_t flags)
 {
-#if CONFIG_BMI270_BUS_SPI
+#if defined(CONFIG_BMI270_BUS_SPI)
 	const struct bmi270_config *cfg = dev->config;
 
 	if (cfg->bus_io == &bmi270_bus_io_spi) {
@@ -76,7 +76,7 @@ int bmi270_prep_reg_read_async(const struct device *dev, uint8_t reg, uint8_t *b
 	}
 #endif
 
-#if CONFIG_BMI270_BUS_I2C
+#if defined(CONFIG_BMI270_BUS_I2C)
 	return bmi270_i2c_prep_reg_read_async(dev, reg, buf, len, flags);
 #else
 	return -ENOTSUP;
@@ -86,7 +86,7 @@ int bmi270_prep_reg_read_async(const struct device *dev, uint8_t reg, uint8_t *b
 int bmi270_prep_reg_write_async(const struct device *dev, uint8_t reg, const uint8_t *buf,
 				size_t len, uint8_t flags)
 {
-#if CONFIG_BMI270_BUS_SPI
+#if defined(CONFIG_BMI270_BUS_SPI)
 	const struct bmi270_config *cfg = dev->config;
 
 	if (cfg->bus_io == &bmi270_bus_io_spi) {
@@ -94,7 +94,7 @@ int bmi270_prep_reg_write_async(const struct device *dev, uint8_t reg, const uin
 	}
 #endif
 
-#if CONFIG_BMI270_BUS_I2C
+#if defined(CONFIG_BMI270_BUS_I2C)
 	return bmi270_i2c_prep_reg_write_async(dev, reg, buf, len, flags);
 #else
 	return -ENOTSUP;

--- a/drivers/sensor/bosch/bmi270/bmi270.c
+++ b/drivers/sensor/bosch/bmi270/bmi270.c
@@ -64,6 +64,44 @@ int bmi270_reg_write_with_delay(const struct device *dev,
 	return ret;
 }
 
+#if defined(CONFIG_BMI270_STREAM)
+int bmi270_prep_reg_read_async(const struct device *dev, uint8_t reg, uint8_t *buf, size_t len,
+			       uint8_t flags)
+{
+#if CONFIG_BMI270_BUS_SPI
+	const struct bmi270_config *cfg = dev->config;
+
+	if (cfg->bus_io == &bmi270_bus_io_spi) {
+		return bmi270_spi_prep_reg_read_async(dev, reg, buf, len, flags);
+	}
+#endif
+
+#if CONFIG_BMI270_BUS_I2C
+	return bmi270_i2c_prep_reg_read_async(dev, reg, buf, len, flags);
+#else
+	return -ENOTSUP;
+#endif
+}
+
+int bmi270_prep_reg_write_async(const struct device *dev, uint8_t reg, const uint8_t *buf,
+				size_t len, uint8_t flags)
+{
+#if CONFIG_BMI270_BUS_SPI
+	const struct bmi270_config *cfg = dev->config;
+
+	if (cfg->bus_io == &bmi270_bus_io_spi) {
+		return bmi270_spi_prep_reg_write_async(dev, reg, buf, len, flags);
+	}
+#endif
+
+#if CONFIG_BMI270_BUS_I2C
+	return bmi270_i2c_prep_reg_write_async(dev, reg, buf, len, flags);
+#else
+	return -ENOTSUP;
+#endif
+}
+#endif
+
 int bmi270_adv_power_save_enable(const struct device *dev)
 {
 	uint8_t pwr = BMI270_PWR_CONF_ADV_PWR_SAVE_EN;
@@ -669,6 +707,11 @@ static int bmi270_init(const struct device *dev)
 	data->gyr_odr = BMI270_GYR_ODR_200_HZ;
 	data->gyr_range = 2000;
 
+#if defined(CONFIG_BMI270_STREAM)
+	mpsc_init(&data->fifo_jobs);
+	bmi270_stream_init(dev);
+#endif
+
 	k_usleep(BMI270_POWER_ON_TIME);
 
 	ret = bmi270_bus_init(dev);
@@ -858,9 +901,35 @@ static const struct bmi270_feature_config bmi270_feature_base = {
 	.bus.i2c = I2C_DT_SPEC_INST_GET(inst),		\
 	.bus_io = &bmi270_bus_io_i2c,
 
+#if defined(CONFIG_BMI270_STREAM)
+#define BMI270_RTIO_SPI_DEFINE(inst)					\
+	SPI_DT_IODEV_DEFINE(bmi270_iodev_##inst, DT_DRV_INST(inst),	\
+			    BMI270_SPI_OPERATION);			\
+	RTIO_DEFINE(bmi270_rtio_ctx_##inst, 8, 8);
+
+#define BMI270_RTIO_I2C_DEFINE(inst)					\
+	I2C_DT_IODEV_DEFINE(bmi270_iodev_##inst, DT_DRV_INST(inst));	\
+	RTIO_DEFINE(bmi270_rtio_ctx_##inst, 8, 8);
+
+#define BMI270_RTIO_DEFINE(inst)					\
+	COND_CODE_1(DT_INST_ON_BUS(inst, spi),				\
+		    (BMI270_RTIO_SPI_DEFINE(inst)),			\
+		    (BMI270_RTIO_I2C_DEFINE(inst)))
+#define BMI270_RTIO_DATA_INIT(inst)					\
+	.rtio_ctx = &bmi270_rtio_ctx_##inst,				\
+	.iodev = &bmi270_iodev_##inst,
+#else
+#define BMI270_RTIO_DEFINE(inst)
+#define BMI270_RTIO_DATA_INIT(inst)
+#endif
+
 #define BMI270_CREATE_INST(inst)					\
 									\
-	static struct bmi270_data bmi270_drv_##inst;			\
+	BMI270_RTIO_DEFINE(inst)					\
+									\
+	static struct bmi270_data bmi270_drv_##inst = {			\
+		BMI270_RTIO_DATA_INIT(inst)				\
+	};								\
 									\
 	static const struct bmi270_config bmi270_config_##inst = {	\
 		COND_CODE_1(DT_INST_ON_BUS(inst, spi),			\

--- a/drivers/sensor/bosch/bmi270/bmi270.h
+++ b/drivers/sensor/bosch/bmi270/bmi270.h
@@ -24,6 +24,20 @@
 #define BMI270_CONFIG_FILE_POLL_PERIOD_US       10000
 #define BMI270_INTER_WRITE_DELAY_US             1000
 
+#if defined(CONFIG_BMI270_STREAM)
+#include <zephyr/rtio/rtio.h>
+#endif
+
+int bmi270_adv_power_save_enable(const struct device *dev);
+int bmi270_adv_power_save_disable(const struct device *dev);
+
+#if defined(CONFIG_BMI270_STREAM)
+void bmi270_stream_handle_fifo(const struct device *dev);
+void bmi270_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
+void bmi270_submit_fifo_work(const struct device *dev);
+struct k_work_q *bmi270_get_fifo_work_q(void);
+#endif
+
 #define BMI270_REG_CHIP_ID         0x00
 #define BMI270_REG_ERROR           0x02
 #define BMI270_REG_STATUS          0x03
@@ -33,6 +47,7 @@
 #define BMI270_REG_SENSORTIME_0    0x18
 #define BMI270_REG_EVENT           0x1B
 #define BMI270_REG_INT_STATUS_0    0x1C
+#define BMI270_REG_INT_STATUS_1    0x1D
 #define BMI270_REG_SC_OUT_0        0x1E
 #define BMI270_REG_WR_GEST_ACT     0x20
 #define BMI270_REG_INTERNAL_STATUS 0x21
@@ -48,7 +63,9 @@
 #define BMI270_REG_AUX_CONF        0x44
 #define BMI270_REG_FIFO_DOWNS      0x45
 #define BMI270_REG_FIFO_WTM_0      0x46
+#define BMI270_REG_FIFO_WTM_1      0x47
 #define BMI270_REG_FIFO_CONFIG_0   0x48
+#define BMI270_REG_FIFO_CONFIG_1   0x49
 #define BMI270_REG_SATURATION      0x4A
 #define BMI270_REG_AUX_DEV_ID      0x4B
 #define BMI270_REG_AUX_IF_CONF     0x4C
@@ -110,6 +127,9 @@
 #define BMI270_INT_IO_CTRL_OUTPUT_EN	BIT(3) /* Output enabled */
 #define BMI270_INT_IO_CTRL_INPUT_EN	BIT(4) /* Input enabled */
 
+#define BMI270_INT_LATCH_NONE      0x00
+#define BMI270_INT_LATCH_PERMANENT 0x01
+
 /* Applies to INT1_MAP_FEAT, INT2_MAP_FEAT, INT_STATUS_0 */
 #define BMI270_INT_MAP_SIG_MOTION        BIT(0)
 #define BMI270_INT_MAP_STEP_COUNTER      BIT(1)
@@ -130,12 +150,45 @@
 
 #define BMI270_INT_STATUS_ANY_MOTION		BIT(6)
 
+/* INT_STATUS_1 */
+#define BMI270_INT_STATUS_1_FFULL_INT    BIT(0)
+#define BMI270_INT_STATUS_1_FWM_INT      BIT(1)
+#define BMI270_INT_STATUS_1_ERR_INT      BIT(2)
+#define BMI270_INT_STATUS_1_ACC_DRDY_INT BIT(7)
+#define BMI270_INT_STATUS_1_GYR_DRDY_INT BIT(6)
+#define BMI270_INT_STATUS_1_AUX_DRDY_INT BIT(5)
+
+/* FIFO header mode (fh_mode<1:0>) - type of frame (regular or control)*/
+#define BMI270_FIFO_HEADER_REGULAR 0x02
+#define BMI270_FIFO_HEADER_CONTROL 0x01
+
+/* FIFO header parameters (fh_parm<3:0>) - sensors in the payload or control opcode */
+#define BMI270_FIFO_FHPARM_ACC BIT(0)
+#define BMI270_FIFO_FHPARM_GYR BIT(1)
+#define BMI270_FIFO_FHPARM_AUX BIT(2)
+
+/* Regular frame payload: acc+gyr only = 6 + 6 bytes */
+#define BMI270_FIFO_FRAME_PAYLOAD_ACC_GYR_BYTES 12
+#define BMI270_FIFO_HEADER_BYTES                1
+#define BMI270_FIFO_FRAME_ACC_GYR_BYTES                                                            \
+	(BMI270_FIFO_HEADER_BYTES + BMI270_FIFO_FRAME_PAYLOAD_ACC_GYR_BYTES)
+
+/* FIFO_CONFIG_0 (register 0x48) */
+#define BMI270_FIFO_CONFIG_0_STOP_ON_FULL_MSK BIT(0)
+#define BMI270_FIFO_CONFIG_0_FIFO_TIME_EN_MSK BIT(1)
+
+/* FIFO_CONFIG_1 (register 0x49) */
+#define BMI270_FIFO_CONFIG_1_FIFO_HEADER_EN_MSK BIT(4)
+#define BMI270_FIFO_CONFIG_1_FIFO_AUX_EN_MSK    BIT(5)
+#define BMI270_FIFO_CONFIG_1_FIFO_ACC_EN_MSK    BIT(6)
+#define BMI270_FIFO_CONFIG_1_FIFO_GYR_EN_MSK    BIT(7)
+
 #define BMI270_CHIP_ID 0x24
 
 #define BMI270_CMD_G_TRIGGER  0x02
 #define BMI270_CMD_USR_GAIN   0x03
 #define BMI270_CMD_NVM_PROG   0xA0
-#define BMI270_CMD_FIFO_FLUSH OxB0
+#define BMI270_CMD_FIFO_FLUSH 0xB0
 #define BMI270_CMD_SOFT_RESET 0xB6
 
 #define BMI270_POWER_ON_TIME                500
@@ -290,6 +343,14 @@ struct bmi270_data {
 	struct k_work trig_work;
 #endif
 #endif /* CONFIG_BMI270_TRIGGER */
+
+#if defined(CONFIG_BMI270_STREAM)
+	struct rtio_iodev_sqe *streaming_sqe;
+	uint16_t fifo_watermark_bytes;
+	uint8_t int_status_1;
+	uint64_t timestamp;
+	struct k_work fifo_work;
+#endif /* CONFIG_BMI270_STREAM */
 };
 
 struct bmi270_feature_reg {

--- a/drivers/sensor/bosch/bmi270/bmi270.h
+++ b/drivers/sensor/bosch/bmi270/bmi270.h
@@ -18,6 +18,8 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/sys/mpsc_lockfree.h>
 
 #define BMI270_WR_LEN                           32
 #define BMI270_CONFIG_FILE_RETRIES              15
@@ -32,10 +34,10 @@ int bmi270_adv_power_save_enable(const struct device *dev);
 int bmi270_adv_power_save_disable(const struct device *dev);
 
 #if defined(CONFIG_BMI270_STREAM)
+void bmi270_stream_init(const struct device *dev);
 void bmi270_stream_handle_fifo(const struct device *dev);
+void bmi270_stream_submit_fifo_job(const struct device *dev);
 void bmi270_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
-void bmi270_submit_fifo_work(const struct device *dev);
-struct k_work_q *bmi270_get_fifo_work_q(void);
 #endif
 
 #define BMI270_REG_CHIP_ID         0x00
@@ -54,6 +56,8 @@ struct k_work_q *bmi270_get_fifo_work_q(void);
 #define BMI270_REG_TEMPERATURE_0   0x22
 #define BMI270_REG_FIFO_LENGTH_0   0x24
 #define BMI270_REG_FIFO_DATA       0x26
+
+#define BMI270_FIFO_DRAIN_CHUNK_SIZE 64
 #define BMI270_REG_FEAT_PAGE       0x2F
 #define BMI270_REG_FEATURES_0      0x30
 #define BMI270_REG_ACC_CONF        0x40
@@ -345,11 +349,26 @@ struct bmi270_data {
 #endif /* CONFIG_BMI270_TRIGGER */
 
 #if defined(CONFIG_BMI270_STREAM)
+	struct rtio *rtio_ctx;
+	struct rtio_iodev *iodev;
 	struct rtio_iodev_sqe *streaming_sqe;
 	uint16_t fifo_watermark_bytes;
+	uint16_t fifo_len;
+	uint16_t fifo_drain_len;
 	uint8_t int_status_1;
+	uint8_t fifo_status[2];
+	uint8_t *fifo_data_buf;
+	uint8_t fifo_discard_buf[BMI270_FIFO_DRAIN_CHUNK_SIZE];
+	uint8_t spi_dummy_byte;
 	uint64_t timestamp;
-	struct k_work fifo_work;
+	struct mpsc fifo_jobs;
+	struct mpsc_node fifo_job;
+	struct k_work fifo_job_work;
+	struct k_spinlock fifo_job_lock;
+	uint16_t fifo_job_pending;
+	uint8_t fifo_job_phase;
+	bool fifo_job_queued;
+	bool fifo_job_processing;
 #endif /* CONFIG_BMI270_STREAM */
 };
 
@@ -412,6 +431,25 @@ extern const struct bmi270_bus_io bmi270_bus_io_spi;
 
 #if CONFIG_BMI270_BUS_I2C
 extern const struct bmi270_bus_io bmi270_bus_io_i2c;
+#endif
+
+#if defined(CONFIG_BMI270_STREAM)
+int bmi270_prep_reg_read_async(const struct device *dev, uint8_t reg, uint8_t *buf, size_t len,
+			       uint8_t flags);
+int bmi270_prep_reg_write_async(const struct device *dev, uint8_t reg, const uint8_t *buf,
+				size_t len, uint8_t flags);
+#if CONFIG_BMI270_BUS_SPI
+int bmi270_spi_prep_reg_read_async(const struct device *dev, uint8_t reg, uint8_t *buf,
+				   size_t len, uint8_t flags);
+int bmi270_spi_prep_reg_write_async(const struct device *dev, uint8_t reg, const uint8_t *buf,
+				    size_t len, uint8_t flags);
+#endif
+#if CONFIG_BMI270_BUS_I2C
+int bmi270_i2c_prep_reg_read_async(const struct device *dev, uint8_t reg, uint8_t *buf,
+				   size_t len, uint8_t flags);
+int bmi270_i2c_prep_reg_write_async(const struct device *dev, uint8_t reg, const uint8_t *buf,
+				    size_t len, uint8_t flags);
+#endif
 #endif
 
 int bmi270_reg_read(const struct device *dev, uint8_t reg, uint8_t *data, uint16_t length);

--- a/drivers/sensor/bosch/bmi270/bmi270.h
+++ b/drivers/sensor/bosch/bmi270/bmi270.h
@@ -56,8 +56,6 @@ void bmi270_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev
 #define BMI270_REG_TEMPERATURE_0   0x22
 #define BMI270_REG_FIFO_LENGTH_0   0x24
 #define BMI270_REG_FIFO_DATA       0x26
-
-#define BMI270_FIFO_DRAIN_CHUNK_SIZE 64
 #define BMI270_REG_FEAT_PAGE       0x2F
 #define BMI270_REG_FEATURES_0      0x30
 #define BMI270_REG_ACC_CONF        0x40
@@ -176,6 +174,9 @@ void bmi270_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev
 #define BMI270_FIFO_HEADER_BYTES                1
 #define BMI270_FIFO_FRAME_ACC_GYR_BYTES                                                            \
 	(BMI270_FIFO_HEADER_BYTES + BMI270_FIFO_FRAME_PAYLOAD_ACC_GYR_BYTES)
+
+/* Chunk size used when draining leftover FIFO bytes that exceed a stream block */
+#define BMI270_FIFO_DRAIN_CHUNK_SIZE 64
 
 /* FIFO_CONFIG_0 (register 0x48) */
 #define BMI270_FIFO_CONFIG_0_STOP_ON_FULL_MSK BIT(0)
@@ -369,6 +370,7 @@ struct bmi270_data {
 	uint8_t fifo_job_phase;
 	bool fifo_job_queued;
 	bool fifo_job_processing;
+	bool fifo_configured;
 #endif /* CONFIG_BMI270_STREAM */
 };
 
@@ -438,13 +440,13 @@ int bmi270_prep_reg_read_async(const struct device *dev, uint8_t reg, uint8_t *b
 			       uint8_t flags);
 int bmi270_prep_reg_write_async(const struct device *dev, uint8_t reg, const uint8_t *buf,
 				size_t len, uint8_t flags);
-#if CONFIG_BMI270_BUS_SPI
+#if defined(CONFIG_BMI270_BUS_SPI)
 int bmi270_spi_prep_reg_read_async(const struct device *dev, uint8_t reg, uint8_t *buf,
 				   size_t len, uint8_t flags);
 int bmi270_spi_prep_reg_write_async(const struct device *dev, uint8_t reg, const uint8_t *buf,
 				    size_t len, uint8_t flags);
 #endif
-#if CONFIG_BMI270_BUS_I2C
+#if defined(CONFIG_BMI270_BUS_I2C)
 int bmi270_i2c_prep_reg_read_async(const struct device *dev, uint8_t reg, uint8_t *buf,
 				   size_t len, uint8_t flags);
 int bmi270_i2c_prep_reg_write_async(const struct device *dev, uint8_t reg, const uint8_t *buf,

--- a/drivers/sensor/bosch/bmi270/bmi270_decoder.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_decoder.c
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT bosch_bmi270
+
+#include <errno.h>
+#include <stddef.h>
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/logging/log.h>
+
+#include "bmi270_decoder.h"
+
+LOG_MODULE_REGISTER(bmi270_decoder, CONFIG_SENSOR_LOG_LEVEL);
+
+/*
+ * BMI270 FIFO header byte layout
+ *   Bits [7:6] = fh_mode  (10 = regular, 01 = control)
+ *   Bits [5:2] = fh_parm  (sensor presence for regular; opcode for control)
+ *   Bits [1:0] = fh_ext   (INT tag bits)
+ *
+ * fh_parm for regular frames:
+ *   bit 0 = ACC, bit 1 = GYR, bit 2 = AUX, bit 3 = reserved
+ */
+#define BMI270_FIFO_HDR_MODE(h)             (((h) >> 6) & 0x03)
+#define BMI270_FIFO_HDR_PARM(h)             (((h) >> 2) & 0x0F)
+#define BMI270_FIFO_MODE_REGULAR            0x02
+#define BMI270_FIFO_MODE_CONTROL            0x01
+#define BMI270_FIFO_PARM_ACC                BIT(0)
+#define BMI270_FIFO_PARM_GYR                BIT(1)
+#define BMI270_FIFO_CTRL_PARM_SKIP_FRAME    0x00
+#define BMI270_FIFO_CTRL_PARM_SENSORTIME    0x01
+#define BMI270_FIFO_CTRL_PARM_CONFIG_CHANGE 0x02
+
+#define BMI270_FIFO_SENSOR_BYTES           6
+#define BMI270_FIFO_PAYLOAD_ACC_GYR        12
+#define BMI270_FIFO_CTRL_LEN_SKIP_FRAME    2
+#define BMI270_FIFO_CTRL_LEN_SENSORTIME    4
+#define BMI270_FIFO_CTRL_LEN_CONFIG_CHANGE 5
+
+#define BMI270_ACC_SHIFT_BASE 5
+#define BMI270_GYR_SHIFT_BASE 6
+
+static inline uint8_t bmi270_fifo_control_frame_size(uint8_t parm)
+{
+	switch (parm) {
+	case BMI270_FIFO_CTRL_PARM_SKIP_FRAME:
+		return BMI270_FIFO_CTRL_LEN_SKIP_FRAME;
+	case BMI270_FIFO_CTRL_PARM_SENSORTIME:
+		return BMI270_FIFO_CTRL_LEN_SENSORTIME;
+	case BMI270_FIFO_CTRL_PARM_CONFIG_CHANGE:
+		return BMI270_FIFO_CTRL_LEN_CONFIG_CHANGE;
+	default:
+		return BMI270_FIFO_CTRL_LEN_SKIP_FRAME;
+	}
+}
+
+static inline uint32_t bmi270_sample_period_ns(const struct bmi270_decoder_header *header,
+					       enum sensor_channel chan)
+{
+	const uint16_t odr_hz =
+		(chan == SENSOR_CHAN_ACCEL_XYZ) ? header->acc_odr_hz : header->gyr_odr_hz;
+
+	return (uint32_t)(1000000000ULL / odr_hz);
+}
+
+/* Advance past one FIFO frame; increment *count if frame has a sample for the requested channel. */
+static const uint8_t *bmi270_fifo_advance_frame(const uint8_t *p, bool want_acc, uint16_t *count)
+{
+	uint8_t h = *p;
+	uint8_t mode = BMI270_FIFO_HDR_MODE(h);
+	uint8_t parm = BMI270_FIFO_HDR_PARM(h);
+
+	if (mode == BMI270_FIFO_MODE_REGULAR) {
+		if (parm == 0) {
+			return p + 2;
+		}
+		uint8_t payload = (parm & BMI270_FIFO_PARM_ACC ? BMI270_FIFO_SENSOR_BYTES : 0) +
+				  (parm & BMI270_FIFO_PARM_GYR ? BMI270_FIFO_SENSOR_BYTES : 0);
+		if (payload == 0) {
+			return p + 1;
+		}
+		if ((want_acc && (parm & BMI270_FIFO_PARM_ACC)) ||
+		    (!want_acc && (parm & BMI270_FIFO_PARM_GYR))) {
+			(*count)++;
+		}
+		return p + 1 + payload;
+	}
+	if (mode == BMI270_FIFO_MODE_CONTROL) {
+		return p + bmi270_fifo_control_frame_size(parm);
+	}
+	return p + 1;
+}
+
+static int bmi270_decoder_get_frame_count(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
+					  uint16_t *frame_count)
+{
+	const struct bmi270_fifo_encoded_data *edata =
+		(const struct bmi270_fifo_encoded_data *)buffer;
+
+	if (chan_spec.chan_idx != 0) {
+		return -EINVAL;
+	}
+
+	if (!edata->header.is_fifo) {
+		return -ENODATA;
+	}
+
+	if (chan_spec.chan_type != SENSOR_CHAN_ACCEL_XYZ &&
+	    chan_spec.chan_type != SENSOR_CHAN_GYRO_XYZ) {
+		return -ENOTSUP;
+	}
+
+	if (edata->header.is_headerless) {
+		*frame_count = edata->fifo_byte_count / BMI270_FIFO_PAYLOAD_ACC_GYR;
+		return 0;
+	}
+
+	uint16_t count = 0;
+	const uint8_t *p = edata->fifo_data;
+	const uint8_t *end = p + edata->fifo_byte_count;
+	bool want_acc = (chan_spec.chan_type == SENSOR_CHAN_ACCEL_XYZ);
+
+	while (p < end) {
+		p = bmi270_fifo_advance_frame(p, want_acc, &count);
+	}
+
+	*frame_count = count;
+	return 0;
+}
+
+static int bmi270_decoder_get_size_info(struct sensor_chan_spec chan_spec, size_t *base_size,
+					size_t *frame_size)
+{
+	if (chan_spec.chan_idx != 0) {
+		return -EINVAL;
+	}
+
+	switch (chan_spec.chan_type) {
+	case SENSOR_CHAN_ACCEL_XYZ:
+	case SENSOR_CHAN_GYRO_XYZ:
+		*base_size = sizeof(struct sensor_three_axis_data);
+		*frame_size = sizeof(struct sensor_three_axis_sample_data);
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+/* Accel: raw -> m/s^2 in Q31 with shift. range in G (2,4,8,16) */
+static void decode_accel_frame(const uint8_t *payload, uint8_t range_g, int8_t shift,
+			       struct sensor_three_axis_sample_data *out)
+{
+	int16_t x = (int16_t)sys_get_le16(&payload[0]);
+	int16_t y = (int16_t)sys_get_le16(&payload[2]);
+	int16_t z = (int16_t)sys_get_le16(&payload[4]);
+
+	int64_t scale = (int64_t)SENSOR_G * range_g * (1LL << (31 - shift)) / INT16_MAX;
+
+	out->timestamp_delta = 0;
+	out->x = (q31_t)((x * scale) / 1000000LL);
+	out->y = (q31_t)((y * scale) / 1000000LL);
+	out->z = (q31_t)((z * scale) / 1000000LL);
+}
+
+/* Gyro: raw -> rad/s in Q31 with shift. range_dps in degrees/s */
+static void decode_gyro_frame(const uint8_t *payload, uint16_t range_dps, int8_t shift,
+			      struct sensor_three_axis_sample_data *out)
+{
+	int16_t x = (int16_t)sys_get_le16(&payload[0]);
+	int16_t y = (int16_t)sys_get_le16(&payload[2]);
+	int16_t z = (int16_t)sys_get_le16(&payload[4]);
+
+	int64_t scale =
+		(int64_t)range_dps * SENSOR_PI * (1LL << (31 - shift)) / (180LL * INT16_MAX);
+
+	out->timestamp_delta = 0;
+	out->x = (q31_t)((x * scale) / 1000000LL);
+	out->y = (q31_t)((y * scale) / 1000000LL);
+	out->z = (q31_t)((z * scale) / 1000000LL);
+}
+
+/* Accel range register value to G (2,4,8,16) */
+static uint8_t acc_range_reg_to_g(uint8_t reg)
+{
+	static const uint8_t g[] = {2, 4, 8, 16};
+
+	return reg < ARRAY_SIZE(g) ? g[reg] : 2;
+}
+
+/* Gyro range register index to dps (2000,1000,500,250,125) */
+static uint16_t gyr_range_idx_to_dps(uint8_t idx)
+{
+	static const uint16_t dps[] = {2000, 1000, 500, 250, 125};
+
+	return idx < ARRAY_SIZE(dps) ? dps[idx] : 2000;
+}
+
+/* Per-invocation decode state (one buffer, one channel) shared by FIFO decode helpers. */
+struct bmi270_fifo_decode_ctx {
+	struct sensor_three_axis_data *out;
+	uint32_t fit_base;
+	uint32_t sample_period_ns;
+	uint16_t chan_type;
+	uint8_t acc_g;
+	uint16_t gyr_dps;
+	int8_t acc_shift;
+	int8_t gyr_shift;
+};
+
+/* Headerless: fixed 12-byte frames, payload order GYR then ACC (same as header mode). */
+static uint16_t decode_fifo_headerless(const uint8_t *p, const uint8_t *end, uint16_t max_count,
+				       const struct bmi270_fifo_decode_ctx *ctx)
+{
+	uint32_t skip = ctx->fit_base;
+	uint16_t decoded = 0;
+
+	while (p + BMI270_FIFO_PAYLOAD_ACC_GYR <= end && decoded < max_count) {
+		if (skip > 0) {
+			skip--;
+			p += BMI270_FIFO_PAYLOAD_ACC_GYR;
+			continue;
+		}
+		if (ctx->chan_type == SENSOR_CHAN_ACCEL_XYZ) {
+			decode_accel_frame(&p[6], ctx->acc_g, ctx->acc_shift,
+					   &ctx->out->readings[decoded]);
+		} else {
+			decode_gyro_frame(p, ctx->gyr_dps, ctx->gyr_shift,
+					  &ctx->out->readings[decoded]);
+		}
+		ctx->out->readings[decoded].timestamp_delta =
+			(uint32_t)(ctx->fit_base + decoded) * ctx->sample_period_ns;
+		decoded++;
+		p += BMI270_FIFO_PAYLOAD_ACC_GYR;
+	}
+
+	return decoded;
+}
+
+/*
+ * One REGULAR FIFO frame at p: advance pointer; optionally decode into *decoded if it matches
+ * chan_type and skip count is satisfied.
+ */
+static const uint8_t *fifo_decode_regular_frame(const uint8_t *p, const uint8_t *end,
+						uint32_t *skip, uint16_t *decoded,
+						const struct bmi270_fifo_decode_ctx *ctx)
+{
+	uint8_t parm = BMI270_FIFO_HDR_PARM(*p);
+
+	if (parm == 0) {
+		return p + 2;
+	}
+
+	bool has_gyr = (parm & BMI270_FIFO_PARM_GYR) != 0;
+	bool has_acc = (parm & BMI270_FIFO_PARM_ACC) != 0;
+	int payload =
+		(has_gyr ? BMI270_FIFO_SENSOR_BYTES : 0) + (has_acc ? BMI270_FIFO_SENSOR_BYTES : 0);
+
+	if (payload == 0 || p + 1 + payload > end) {
+		return p + 1;
+	}
+
+	bool want_this = (ctx->chan_type == SENSOR_CHAN_ACCEL_XYZ) ? has_acc : has_gyr;
+
+	if (!want_this) {
+		return p + 1 + payload;
+	}
+	if (*skip > 0) {
+		(*skip)--;
+		return p + 1 + payload;
+	}
+
+	/*
+	 * Payload order (datasheet): GYR (6B if present) then ACC (6B if present).
+	 * ACC offset = 0 when GYR absent, 6 when GYR present.
+	 */
+	const uint8_t *frame = p + 1;
+
+	if (ctx->chan_type == SENSOR_CHAN_ACCEL_XYZ) {
+		int acc_off = has_gyr ? BMI270_FIFO_SENSOR_BYTES : 0;
+
+		decode_accel_frame(&frame[acc_off], ctx->acc_g, ctx->acc_shift,
+				   &ctx->out->readings[*decoded]);
+	} else {
+		decode_gyro_frame(frame, ctx->gyr_dps, ctx->gyr_shift,
+				  &ctx->out->readings[*decoded]);
+	}
+	ctx->out->readings[*decoded].timestamp_delta =
+		(uint32_t)(ctx->fit_base + *decoded) * ctx->sample_period_ns;
+	(*decoded)++;
+	return p + 1 + payload;
+}
+
+static uint16_t decode_fifo_header_mode(const uint8_t *p, const uint8_t *end, uint16_t max_count,
+					const struct bmi270_fifo_decode_ctx *ctx)
+{
+	uint32_t skip = ctx->fit_base;
+	uint16_t decoded = 0;
+
+	while (p < end && decoded < max_count) {
+		uint8_t mode = BMI270_FIFO_HDR_MODE(*p);
+
+		if (mode == BMI270_FIFO_MODE_REGULAR) {
+			p = fifo_decode_regular_frame(p, end, &skip, &decoded, ctx);
+		} else if (mode == BMI270_FIFO_MODE_CONTROL) {
+			p += bmi270_fifo_control_frame_size(BMI270_FIFO_HDR_PARM(*p));
+		} else {
+			p++;
+		}
+	}
+
+	return decoded;
+}
+
+static int bmi270_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec chan_spec,
+				 uint32_t *fit, uint16_t max_count, void *data_out)
+{
+	const struct bmi270_fifo_encoded_data *edata =
+		(const struct bmi270_fifo_encoded_data *)buffer;
+	struct sensor_three_axis_data *out = data_out;
+	const uint8_t *p = edata->fifo_data;
+	const uint8_t *end = p + edata->fifo_byte_count;
+	uint16_t decoded;
+	struct bmi270_fifo_decode_ctx ctx;
+
+	if (!edata->header.is_fifo || chan_spec.chan_idx != 0) {
+		return -EINVAL;
+	}
+
+	if (chan_spec.chan_type != SENSOR_CHAN_ACCEL_XYZ &&
+	    chan_spec.chan_type != SENSOR_CHAN_GYRO_XYZ) {
+		return -ENOTSUP;
+	}
+
+	out->header.base_timestamp_ns = edata->header.timestamp;
+	out->header.reading_count = 0;
+
+	ctx.out = out;
+	ctx.fit_base = *fit;
+	ctx.sample_period_ns = bmi270_sample_period_ns(&edata->header, chan_spec.chan_type);
+	ctx.chan_type = chan_spec.chan_type;
+	ctx.acc_g = acc_range_reg_to_g(edata->header.acc_range);
+	ctx.gyr_dps = gyr_range_idx_to_dps(edata->header.gyr_range_idx);
+	ctx.acc_shift =
+		BMI270_ACC_SHIFT_BASE + (edata->header.acc_range > 0 ? edata->header.acc_range : 0);
+	ctx.gyr_shift = BMI270_GYR_SHIFT_BASE;
+
+	if (edata->header.is_headerless) {
+		decoded = decode_fifo_headerless(p, end, max_count, &ctx);
+	} else {
+		decoded = decode_fifo_header_mode(p, end, max_count, &ctx);
+	}
+
+	*fit += decoded;
+	out->shift = (chan_spec.chan_type == SENSOR_CHAN_ACCEL_XYZ) ? ctx.acc_shift : ctx.gyr_shift;
+	out->header.reading_count = decoded;
+	return (int)decoded;
+}
+
+static bool bmi270_decoder_has_trigger(const uint8_t *buffer, enum sensor_trigger_type trigger)
+{
+	ARG_UNUSED(buffer);
+	ARG_UNUSED(trigger);
+	return false;
+}
+
+static const struct sensor_decoder_api bmi270_decoder_api = {
+	.get_frame_count = bmi270_decoder_get_frame_count,
+	.get_size_info = bmi270_decoder_get_size_info,
+	.decode = bmi270_decoder_decode,
+	.has_trigger = bmi270_decoder_has_trigger,
+};
+
+int bmi270_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder)
+{
+	ARG_UNUSED(dev);
+	*decoder = &bmi270_decoder_api;
+	return 0;
+}

--- a/drivers/sensor/bosch/bmi270/bmi270_decoder.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_decoder.c
@@ -46,6 +46,9 @@ LOG_MODULE_REGISTER(bmi270_decoder, CONFIG_SENSOR_LOG_LEVEL);
 #define BMI270_ACC_SHIFT_BASE 5
 #define BMI270_GYR_SHIFT_BASE 6
 
+/* SENSOR_G/SENSOR_PI are in micro units; divide this back out once per scale. */
+#define BMI270_MICRO_UNIT_SCALE 1000000LL
+
 static inline uint8_t bmi270_fifo_control_frame_size(uint8_t parm)
 {
 	switch (parm) {
@@ -152,37 +155,46 @@ static int bmi270_decoder_get_size_info(struct sensor_chan_spec chan_spec, size_
 	}
 }
 
-/* Accel: raw -> m/s^2 in Q31 with shift. range in G (2,4,8,16) */
-static void decode_accel_frame(const uint8_t *payload, uint8_t range_g, int8_t shift,
+/* Precompute the accel raw-to-Q31 scale once per buffer instead of per frame. */
+static int64_t bmi270_accel_scale(uint8_t range_g, int8_t shift)
+{
+	return (int64_t)SENSOR_G * range_g * (1LL << (31 - shift)) / INT16_MAX /
+	       BMI270_MICRO_UNIT_SCALE;
+}
+
+/* Precompute the gyro raw-to-Q31 scale for a given range/shift; see bmi270_accel_scale(). */
+static int64_t bmi270_gyro_scale(uint16_t range_dps, int8_t shift)
+{
+	return (int64_t)range_dps * SENSOR_PI * (1LL << (31 - shift)) /
+	       (180LL * INT16_MAX) / BMI270_MICRO_UNIT_SCALE;
+}
+
+/* Accel: raw -> m/s^2 in Q31, using a scale precomputed once per buffer by bmi270_accel_scale(). */
+static void decode_accel_frame(const uint8_t *payload, int64_t scale,
 			       struct sensor_three_axis_sample_data *out)
 {
 	int16_t x = (int16_t)sys_get_le16(&payload[0]);
 	int16_t y = (int16_t)sys_get_le16(&payload[2]);
 	int16_t z = (int16_t)sys_get_le16(&payload[4]);
 
-	int64_t scale = (int64_t)SENSOR_G * range_g * (1LL << (31 - shift)) / INT16_MAX;
-
 	out->timestamp_delta = 0;
-	out->x = (q31_t)((x * scale) / 1000000LL);
-	out->y = (q31_t)((y * scale) / 1000000LL);
-	out->z = (q31_t)((z * scale) / 1000000LL);
+	out->x = (q31_t)(x * scale);
+	out->y = (q31_t)(y * scale);
+	out->z = (q31_t)(z * scale);
 }
 
-/* Gyro: raw -> rad/s in Q31 with shift. range_dps in degrees/s */
-static void decode_gyro_frame(const uint8_t *payload, uint16_t range_dps, int8_t shift,
+/* Gyro: raw -> rad/s in Q31, using a scale precomputed once per buffer by bmi270_gyro_scale(). */
+static void decode_gyro_frame(const uint8_t *payload, int64_t scale,
 			      struct sensor_three_axis_sample_data *out)
 {
 	int16_t x = (int16_t)sys_get_le16(&payload[0]);
 	int16_t y = (int16_t)sys_get_le16(&payload[2]);
 	int16_t z = (int16_t)sys_get_le16(&payload[4]);
 
-	int64_t scale =
-		(int64_t)range_dps * SENSOR_PI * (1LL << (31 - shift)) / (180LL * INT16_MAX);
-
 	out->timestamp_delta = 0;
-	out->x = (q31_t)((x * scale) / 1000000LL);
-	out->y = (q31_t)((y * scale) / 1000000LL);
-	out->z = (q31_t)((z * scale) / 1000000LL);
+	out->x = (q31_t)(x * scale);
+	out->y = (q31_t)(y * scale);
+	out->z = (q31_t)(z * scale);
 }
 
 /* Accel range register value to G (2,4,8,16) */
@@ -207,10 +219,10 @@ struct bmi270_fifo_decode_ctx {
 	uint32_t fit_base;
 	uint32_t sample_period_ns;
 	uint16_t chan_type;
-	uint8_t acc_g;
-	uint16_t gyr_dps;
 	int8_t acc_shift;
 	int8_t gyr_shift;
+	int64_t acc_scale;
+	int64_t gyr_scale;
 };
 
 /* Headerless: fixed 12-byte frames, payload order GYR then ACC (same as header mode). */
@@ -227,11 +239,9 @@ static uint16_t decode_fifo_headerless(const uint8_t *p, const uint8_t *end, uin
 			continue;
 		}
 		if (ctx->chan_type == SENSOR_CHAN_ACCEL_XYZ) {
-			decode_accel_frame(&p[6], ctx->acc_g, ctx->acc_shift,
-					   &ctx->out->readings[decoded]);
+			decode_accel_frame(&p[6], ctx->acc_scale, &ctx->out->readings[decoded]);
 		} else {
-			decode_gyro_frame(p, ctx->gyr_dps, ctx->gyr_shift,
-					  &ctx->out->readings[decoded]);
+			decode_gyro_frame(p, ctx->gyr_scale, &ctx->out->readings[decoded]);
 		}
 		ctx->out->readings[decoded].timestamp_delta =
 			(uint32_t)(ctx->fit_base + decoded) * ctx->sample_period_ns;
@@ -284,11 +294,9 @@ static const uint8_t *fifo_decode_regular_frame(const uint8_t *p, const uint8_t 
 	if (ctx->chan_type == SENSOR_CHAN_ACCEL_XYZ) {
 		int acc_off = has_gyr ? BMI270_FIFO_SENSOR_BYTES : 0;
 
-		decode_accel_frame(&frame[acc_off], ctx->acc_g, ctx->acc_shift,
-				   &ctx->out->readings[*decoded]);
+		decode_accel_frame(&frame[acc_off], ctx->acc_scale, &ctx->out->readings[*decoded]);
 	} else {
-		decode_gyro_frame(frame, ctx->gyr_dps, ctx->gyr_shift,
-				  &ctx->out->readings[*decoded]);
+		decode_gyro_frame(frame, ctx->gyr_scale, &ctx->out->readings[*decoded]);
 	}
 	ctx->out->readings[*decoded].timestamp_delta =
 		(uint32_t)(ctx->fit_base + *decoded) * ctx->sample_period_ns;
@@ -342,13 +350,16 @@ static int bmi270_decoder_decode(const uint8_t *buffer, struct sensor_chan_spec 
 
 	ctx.out = out;
 	ctx.fit_base = *fit;
-	ctx.sample_period_ns = bmi270_sample_period_ns(&edata->header, chan_spec.chan_type);
 	ctx.chan_type = chan_spec.chan_type;
-	ctx.acc_g = acc_range_reg_to_g(edata->header.acc_range);
-	ctx.gyr_dps = gyr_range_idx_to_dps(edata->header.gyr_range_idx);
 	ctx.acc_shift =
 		BMI270_ACC_SHIFT_BASE + (edata->header.acc_range > 0 ? edata->header.acc_range : 0);
 	ctx.gyr_shift = BMI270_GYR_SHIFT_BASE;
+
+	ctx.sample_period_ns = bmi270_sample_period_ns(&edata->header, chan_spec.chan_type);
+	ctx.acc_scale =
+		bmi270_accel_scale(acc_range_reg_to_g(edata->header.acc_range), ctx.acc_shift);
+	ctx.gyr_scale =
+		bmi270_gyro_scale(gyr_range_idx_to_dps(edata->header.gyr_range_idx), ctx.gyr_shift);
 
 	if (edata->header.is_headerless) {
 		decoded = decode_fifo_headerless(p, end, max_count, &ctx);

--- a/drivers/sensor/bosch/bmi270/bmi270_decoder.h
+++ b/drivers/sensor/bosch/bmi270/bmi270_decoder.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_BMI270_BMI270_DECODER_H_
+#define ZEPHYR_DRIVERS_SENSOR_BMI270_BMI270_DECODER_H_
+
+#include <stdint.h>
+#include <zephyr/drivers/sensor.h>
+
+/** Encoded FIFO buffer header for BMI270 */
+struct bmi270_decoder_header {
+	uint64_t timestamp;
+	uint8_t is_fifo: 1;
+	uint8_t is_headerless: 1; /* 1 = FIFO had no per-frame headers; fixed 12 B/frame */
+	uint8_t acc_range: 2;     /* 0=2G, 1=4G, 2=8G, 3=16G */
+	uint8_t gyr_range_idx: 3; /* 0=2000dps .. 4=125dps */
+	uint8_t reserved: 1;
+	uint16_t acc_odr_hz;
+	uint16_t gyr_odr_hz;
+} __attribute__((__packed__));
+
+/** Encoded FIFO read result: header + raw FIFO bytes */
+struct bmi270_fifo_encoded_data {
+	struct bmi270_decoder_header header;
+	uint16_t fifo_byte_count;
+	uint8_t fifo_data[];
+} __attribute__((__packed__));
+
+int bmi270_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_BMI270_BMI270_DECODER_H_ */

--- a/drivers/sensor/bosch/bmi270/bmi270_i2c.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_i2c.c
@@ -57,3 +57,55 @@ const struct bmi270_bus_io bmi270_bus_io_i2c = {
 	.write = bmi270_reg_write_i2c,
 	.init = bmi270_bus_init_i2c,
 };
+
+#if defined(CONFIG_BMI270_STREAM)
+int bmi270_i2c_prep_reg_read_async(const struct device *dev, uint8_t reg, uint8_t *buf,
+				   size_t len, uint8_t flags)
+{
+	struct bmi270_data *data = dev->data;
+	struct rtio_sqe *sqes[2];
+	struct rtio_sqe *write_reg_sqe;
+	struct rtio_sqe *read_buf_sqe;
+
+	if (rtio_sqe_acquire_array(data->rtio_ctx, ARRAY_SIZE(sqes), sqes) != 0) {
+		return -ENOMEM;
+	}
+
+	write_reg_sqe = sqes[0];
+	read_buf_sqe = sqes[1];
+
+	rtio_sqe_prep_tiny_write(write_reg_sqe, data->iodev, RTIO_PRIO_HIGH, &reg, 1, NULL);
+	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+	rtio_sqe_prep_read(read_buf_sqe, data->iodev, RTIO_PRIO_HIGH, buf, len, NULL);
+	read_buf_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	read_buf_sqe->flags |= flags;
+
+	return 2;
+}
+
+int bmi270_i2c_prep_reg_write_async(const struct device *dev, uint8_t reg, const uint8_t *buf,
+				    size_t len, uint8_t flags)
+{
+	struct bmi270_data *data = dev->data;
+	struct rtio_sqe *sqes[2];
+	struct rtio_sqe *write_reg_sqe;
+	struct rtio_sqe *write_buf_sqe;
+
+	if (rtio_sqe_acquire_array(data->rtio_ctx, ARRAY_SIZE(sqes), sqes) != 0) {
+		return -ENOMEM;
+	}
+
+	write_reg_sqe = sqes[0];
+	write_buf_sqe = sqes[1];
+
+	rtio_sqe_prep_tiny_write(write_reg_sqe, data->iodev, RTIO_PRIO_HIGH, &reg, 1, NULL);
+	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+	rtio_sqe_prep_write(write_buf_sqe, data->iodev, RTIO_PRIO_HIGH, buf, len, NULL);
+	write_buf_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP;
+	write_buf_sqe->flags |= flags;
+
+	return 2;
+}
+#endif

--- a/drivers/sensor/bosch/bmi270/bmi270_spi.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_spi.c
@@ -16,7 +16,11 @@ LOG_MODULE_DECLARE(bmi270, CONFIG_SENSOR_LOG_LEVEL);
 
 static int bmi270_bus_check_spi(const union bmi270_bus *bus)
 {
-	return spi_is_ready_dt(&bus->spi) ? 0 : -ENODEV;
+	if (!spi_is_ready_dt(&bus->spi)) {
+		LOG_ERR("SPI device not ready");
+		return -ENODEV;
+	}
+	return 0;
 }
 
 static int bmi270_reg_read_spi(const union bmi270_bus *bus,

--- a/drivers/sensor/bosch/bmi270/bmi270_spi.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_spi.c
@@ -102,3 +102,61 @@ const struct bmi270_bus_io bmi270_bus_io_spi = {
 	.write = bmi270_reg_write_spi,
 	.init = bmi270_bus_init_spi,
 };
+
+#if defined(CONFIG_BMI270_STREAM)
+int bmi270_spi_prep_reg_read_async(const struct device *dev, uint8_t reg, uint8_t *buf,
+				   size_t len, uint8_t flags)
+{
+	struct bmi270_data *data = dev->data;
+	struct rtio_sqe *sqes[3];
+	struct rtio_sqe *write_reg_sqe;
+	struct rtio_sqe *dummy_sqe;
+	struct rtio_sqe *read_buf_sqe;
+	uint8_t addr = reg | 0x80;
+
+	if (rtio_sqe_acquire_array(data->rtio_ctx, ARRAY_SIZE(sqes), sqes) != 0) {
+		return -ENOMEM;
+	}
+
+	write_reg_sqe = sqes[0];
+	dummy_sqe = sqes[1];
+	read_buf_sqe = sqes[2];
+
+	rtio_sqe_prep_tiny_write(write_reg_sqe, data->iodev, RTIO_PRIO_HIGH, &addr, 1, NULL);
+	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+	rtio_sqe_prep_read(dummy_sqe, data->iodev, RTIO_PRIO_HIGH, &data->spi_dummy_byte, 1,
+			   NULL);
+	/* Keep the dummy byte in the same SPI transaction; the payload read carries chaining. */
+	dummy_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+	rtio_sqe_prep_read(read_buf_sqe, data->iodev, RTIO_PRIO_HIGH, buf, len, NULL);
+	read_buf_sqe->flags |= flags;
+
+	return 3;
+}
+
+int bmi270_spi_prep_reg_write_async(const struct device *dev, uint8_t reg, const uint8_t *buf,
+				    size_t len, uint8_t flags)
+{
+	struct bmi270_data *data = dev->data;
+	struct rtio_sqe *sqes[2];
+	struct rtio_sqe *write_reg_sqe;
+	struct rtio_sqe *write_buf_sqe;
+
+	if (rtio_sqe_acquire_array(data->rtio_ctx, ARRAY_SIZE(sqes), sqes) != 0) {
+		return -ENOMEM;
+	}
+
+	write_reg_sqe = sqes[0];
+	write_buf_sqe = sqes[1];
+
+	rtio_sqe_prep_tiny_write(write_reg_sqe, data->iodev, RTIO_PRIO_HIGH, &reg, 1, NULL);
+	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
+
+	rtio_sqe_prep_write(write_buf_sqe, data->iodev, RTIO_PRIO_HIGH, buf, len, NULL);
+	write_buf_sqe->flags |= flags;
+
+	return 2;
+}
+#endif

--- a/drivers/sensor/bosch/bmi270/bmi270_spi.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_spi.c
@@ -143,6 +143,7 @@ int bmi270_spi_prep_reg_write_async(const struct device *dev, uint8_t reg, const
 	struct rtio_sqe *sqes[2];
 	struct rtio_sqe *write_reg_sqe;
 	struct rtio_sqe *write_buf_sqe;
+	uint8_t addr = reg & BMI270_REG_MASK;
 
 	if (rtio_sqe_acquire_array(data->rtio_ctx, ARRAY_SIZE(sqes), sqes) != 0) {
 		return -ENOMEM;
@@ -151,7 +152,7 @@ int bmi270_spi_prep_reg_write_async(const struct device *dev, uint8_t reg, const
 	write_reg_sqe = sqes[0];
 	write_buf_sqe = sqes[1];
 
-	rtio_sqe_prep_tiny_write(write_reg_sqe, data->iodev, RTIO_PRIO_HIGH, &reg, 1, NULL);
+	rtio_sqe_prep_tiny_write(write_reg_sqe, data->iodev, RTIO_PRIO_HIGH, &addr, 1, NULL);
 	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
 
 	rtio_sqe_prep_write(write_buf_sqe, data->iodev, RTIO_PRIO_HIGH, buf, len, NULL);

--- a/drivers/sensor/bosch/bmi270/bmi270_stream.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_stream.c
@@ -1,0 +1,483 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT bosch_bmi270
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor_clock.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+
+#include "bmi270.h"
+#include "bmi270_decoder.h"
+
+#if defined(CONFIG_BMI270_STREAM)
+
+LOG_MODULE_DECLARE(bmi270, CONFIG_SENSOR_LOG_LEVEL);
+
+static inline const struct gpio_dt_spec *fifo_pin(const struct bmi270_config *config)
+{
+	return IS_ENABLED(CONFIG_BMI270_FIFO_ON_INT2) ? &config->int2 : &config->int1;
+}
+
+static inline uint8_t fifo_fwm_map_bit(void)
+{
+	return IS_ENABLED(CONFIG_BMI270_FIFO_ON_INT2) ? BMI270_INT_MAP_DATA_FWM_INT2
+						      : BMI270_INT_MAP_DATA_FWM_INT1;
+}
+
+static inline uint8_t fifo_ffull_map_bit(void)
+{
+	return IS_ENABLED(CONFIG_BMI270_FIFO_ON_INT2) ? BMI270_INT_MAP_DATA_FFULL_INT2
+						      : BMI270_INT_MAP_DATA_FFULL_INT1;
+}
+
+static inline uint8_t fifo_io_ctrl_reg(void)
+{
+	return IS_ENABLED(CONFIG_BMI270_FIFO_ON_INT2) ? BMI270_REG_INT2_IO_CTRL
+						      : BMI270_REG_INT1_IO_CTRL;
+}
+
+static inline uint16_t fifo_watermark_bytes(void)
+{
+#if defined(CONFIG_BMI270_FIFO_HEADERLESS)
+	return CONFIG_BMI270_FIFO_WATERMARK_SAMPLES * BMI270_FIFO_FRAME_PAYLOAD_ACC_GYR_BYTES;
+#else
+	return CONFIG_BMI270_FIFO_WATERMARK_SAMPLES * BMI270_FIFO_FRAME_ACC_GYR_BYTES +
+	       CONFIG_BMI270_FIFO_WATERMARK_CONTROL_MARGIN;
+#endif
+}
+
+static inline uint16_t acc_odr_reg_to_hz(uint8_t odr_reg)
+{
+	switch (odr_reg) {
+	case BMI270_ACC_ODR_25_HZ:
+		return 25;
+	case BMI270_ACC_ODR_50_HZ:
+		return 50;
+	case BMI270_ACC_ODR_100_HZ:
+		return 100;
+	case BMI270_ACC_ODR_200_HZ:
+		return 200;
+	case BMI270_ACC_ODR_400_HZ:
+		return 400;
+	case BMI270_ACC_ODR_800_HZ:
+		return 800;
+	case BMI270_ACC_ODR_1600_HZ:
+		return 1600;
+	default:
+		return 0;
+	}
+}
+
+/* Full-scale G (2, 4, 8, 16) to bmi270_decoder_header.acc_range field 0..3 */
+static inline uint8_t acc_fullscale_g_to_decoder_idx(uint8_t fs_g)
+{
+	switch (fs_g) {
+	case 2:
+		return 0U;
+	case 4:
+		return 1U;
+	case 8:
+		return 2U;
+	default:
+		return 3U;
+	}
+}
+
+/* Gyro full-scale (dps) to bmi270_decoder_header.gyr_range_idx field 0..4 */
+static inline uint8_t gyr_fullscale_dps_to_decoder_idx(uint16_t range_dps)
+{
+	switch (range_dps) {
+	case 2000:
+		return 0U;
+	case 1000:
+		return 1U;
+	case 500:
+		return 2U;
+	case 250:
+		return 3U;
+	case 125:
+		return 4U;
+	default:
+		return 0U;
+	}
+}
+
+static inline uint16_t gyr_odr_reg_to_hz(uint8_t odr_reg)
+{
+	switch (odr_reg) {
+	case BMI270_GYR_ODR_25_HZ:
+		return 25;
+	case BMI270_GYR_ODR_50_HZ:
+		return 50;
+	case BMI270_GYR_ODR_100_HZ:
+		return 100;
+	case BMI270_GYR_ODR_200_HZ:
+		return 200;
+	case BMI270_GYR_ODR_400_HZ:
+		return 400;
+	case BMI270_GYR_ODR_800_HZ:
+		return 800;
+	case BMI270_GYR_ODR_1600_HZ:
+		return 1600;
+	case BMI270_GYR_ODR_3200_HZ:
+		return 3200;
+	default:
+		return 0;
+	}
+}
+
+static inline void stream_error(const struct device *dev, struct bmi270_data *data,
+				struct rtio_iodev_sqe *iodev_sqe, int err)
+{
+	int ps_ret = bmi270_adv_power_save_enable(dev);
+
+	if (ps_ret) {
+		LOG_ERR("adv_power_save_enable failed: %d", ps_ret);
+	}
+	rtio_iodev_sqe_err(iodev_sqe, err);
+	data->streaming_sqe = NULL;
+}
+
+static struct sensor_stream_trigger *get_read_config_trigger(const struct sensor_read_config *cfg,
+							     enum sensor_trigger_type trig)
+{
+	for (size_t i = 0; i < cfg->count; i++) {
+		if (cfg->triggers[i].trigger == trig) {
+			return (struct sensor_stream_trigger *)&cfg->triggers[i];
+		}
+	}
+	return NULL;
+}
+
+static int configure_fifo(const struct device *dev, bool enable, uint16_t watermark_bytes)
+{
+	uint8_t val;
+	int ret;
+
+	if (!enable) {
+		val = 0;
+		ret = bmi270_reg_write(dev, BMI270_REG_FIFO_CONFIG_1, &val, 1);
+		if (ret < 0) {
+			return ret;
+		}
+		return 0;
+	}
+
+	/* FIFO_CONFIG_0: stop_on_full=0, fifo_time_en=0 (streaming, no sensortime) */
+	val = 0;
+	ret = bmi270_reg_write(dev, BMI270_REG_FIFO_CONFIG_0, &val, 1);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* FIFO_CONFIG_1: acc+gyr in FIFO; header bit depends on mode */
+	val = BMI270_FIFO_CONFIG_1_FIFO_ACC_EN_MSK | BMI270_FIFO_CONFIG_1_FIFO_GYR_EN_MSK;
+#if !defined(CONFIG_BMI270_FIFO_HEADERLESS)
+	val |= BMI270_FIFO_CONFIG_1_FIFO_HEADER_EN_MSK;
+#endif
+	ret = bmi270_reg_write(dev, BMI270_REG_FIFO_CONFIG_1, &val, 1);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Watermark in bytes */
+	uint8_t wtm[2] = {
+		watermark_bytes & 0xFF,
+		(watermark_bytes >> 8) & 0x1F,
+	};
+	ret = bmi270_reg_write(dev, BMI270_REG_FIFO_WTM_0, wtm, 2);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int map_fifo_int(const struct device *dev, bool watermark, bool full)
+{
+	uint8_t int_map = 0;
+
+	if (watermark) {
+		int_map |= fifo_fwm_map_bit();
+	}
+	if (full) {
+		int_map |= fifo_ffull_map_bit();
+	}
+	return bmi270_reg_write(dev, BMI270_REG_INT_MAP_DATA, &int_map, 1);
+}
+
+#if defined(CONFIG_BMI270_FIFO_POLL_FALLBACK)
+
+#define FIFO_POLL_MS CONFIG_BMI270_FIFO_POLL_PERIOD_MS
+
+static const struct device *poll_dev;
+static struct k_work_delayable poll_work;
+static bool poll_work_inited;
+
+static void poll_work_fn(struct k_work *work)
+{
+	const struct device *dev = poll_dev;
+	struct bmi270_data *data;
+	uint16_t fifo_len;
+
+	if (dev == NULL) {
+		return;
+	}
+	data = dev->data;
+	if (data->streaming_sqe == NULL) {
+		return;
+	}
+	bmi270_reg_read(dev, BMI270_REG_FIFO_LENGTH_0, (uint8_t *)&fifo_len, 2);
+	fifo_len = sys_get_le16((uint8_t *)&fifo_len) & 0x3FFF;
+	if (fifo_len >= data->fifo_watermark_bytes) {
+		bmi270_submit_fifo_work(dev);
+	}
+	k_work_schedule(&poll_work, K_MSEC(FIFO_POLL_MS));
+}
+#endif /* CONFIG_BMI270_FIFO_POLL_FALLBACK */
+
+static void adv_power_save_enable_log_failure(const struct device *dev)
+{
+	int ret = bmi270_adv_power_save_enable(dev);
+
+	if (ret != 0) {
+		LOG_ERR("adv_power_save_enable failed: %d", ret);
+	}
+}
+
+static void fifo_fill_encoded_header(struct bmi270_fifo_encoded_data *edata,
+				     struct bmi270_data *data, uint16_t fifo_len)
+{
+	edata->header.is_fifo = true;
+#if defined(CONFIG_BMI270_FIFO_HEADERLESS)
+	edata->header.is_headerless = true;
+#else
+	edata->header.is_headerless = false;
+#endif
+	edata->header.timestamp = data->timestamp;
+	edata->header.acc_range = acc_fullscale_g_to_decoder_idx(data->acc_range);
+	edata->header.acc_odr_hz = acc_odr_reg_to_hz(data->acc_odr);
+	edata->header.gyr_odr_hz = gyr_odr_reg_to_hz(data->gyr_odr);
+	edata->header.gyr_range_idx = gyr_fullscale_dps_to_decoder_idx(data->gyr_range);
+	edata->fifo_byte_count = fifo_len;
+}
+
+static void fifo_drain_bytes(const struct device *dev, uint16_t remain)
+{
+	uint8_t discard[64];
+
+	while (remain > 0) {
+		size_t chunk = remain > sizeof(discard) ? sizeof(discard) : (size_t)remain;
+
+		bmi270_reg_read(dev, BMI270_REG_FIFO_DATA, discard, chunk);
+		remain -= (uint16_t)chunk;
+	}
+}
+
+void bmi270_stream_handle_fifo(const struct device *dev)
+{
+	struct bmi270_data *data = dev->data;
+	struct rtio_iodev_sqe *iodev_sqe = data->streaming_sqe;
+	uint8_t int_status_1;
+	uint16_t fifo_len;
+	uint64_t cycles;
+	uint8_t *buf;
+	uint32_t buf_len;
+	struct bmi270_fifo_encoded_data *edata;
+	int ret;
+
+	if (iodev_sqe == NULL) {
+		return;
+	}
+
+	LOG_DBG("FIFO INT: handling watermark");
+
+	if (sensor_clock_get_cycles(&cycles) == 0) {
+		data->timestamp = sensor_clock_cycles_to_ns(cycles);
+	}
+
+	ret = bmi270_reg_read(dev, BMI270_REG_INT_STATUS_1, &int_status_1, 1);
+	if (ret < 0) {
+		stream_error(dev, data, iodev_sqe, ret);
+		return;
+	}
+
+	data->int_status_1 = int_status_1;
+
+	if (!(int_status_1 & (BMI270_INT_STATUS_1_FWM_INT | BMI270_INT_STATUS_1_FFULL_INT))) {
+		adv_power_save_enable_log_failure(dev);
+		return;
+	}
+
+	/* Read FIFO length (14-bit, LSB then MSB) */
+	ret = bmi270_reg_read(dev, BMI270_REG_FIFO_LENGTH_0, (uint8_t *)&fifo_len, 2);
+	if (ret < 0) {
+		stream_error(dev, data, iodev_sqe, ret);
+		return;
+	}
+
+	fifo_len = sys_get_le16((uint8_t *)&fifo_len) & 0x3FFF;
+	if (fifo_len == 0) {
+		adv_power_save_enable_log_failure(dev);
+		data->streaming_sqe = NULL;
+		rtio_iodev_sqe_ok(iodev_sqe, 0);
+		return;
+	}
+
+	size_t max_fifo =
+		CONFIG_BMI270_FIFO_STREAM_BLOCK_SIZE - sizeof(struct bmi270_fifo_encoded_data);
+	uint16_t fifo_len_orig = fifo_len;
+
+	if (fifo_len > max_fifo) {
+		LOG_WRN("FIFO len %u > max %zu, capping and draining remainder", fifo_len,
+			max_fifo);
+		fifo_len = (uint16_t)max_fifo;
+	}
+
+	size_t min_len = sizeof(struct bmi270_fifo_encoded_data) + fifo_len;
+
+	ret = rtio_sqe_rx_buf(iodev_sqe, min_len, min_len, &buf, &buf_len);
+	if (ret != 0 || buf_len < min_len) {
+		stream_error(dev, data, iodev_sqe, -ENOMEM);
+		return;
+	}
+
+	edata = (struct bmi270_fifo_encoded_data *)buf;
+	fifo_fill_encoded_header(edata, data, fifo_len);
+
+	/* Burst read from FIFO_DATA (address does not auto-increment; burst read does) */
+	ret = bmi270_reg_read(dev, BMI270_REG_FIFO_DATA, edata->fifo_data, fifo_len);
+	if (ret < 0) {
+		stream_error(dev, data, iodev_sqe, ret);
+		return;
+	}
+
+	/* If we capped, drain remainder so FIFO is empty for next watermark */
+	if (fifo_len_orig > fifo_len) {
+		fifo_drain_bytes(dev, fifo_len_orig - fifo_len);
+	}
+
+	/*
+	 * Clear the FWM/FFULL latch now that the FIFO is drained below
+	 * watermark.  Latched interrupts only clear when INT_STATUS is read
+	 * AND fill level is below the threshold, so this must come AFTER drain.
+	 */
+	bmi270_reg_read(dev, BMI270_REG_INT_STATUS_1, &int_status_1, 1);
+
+	adv_power_save_enable_log_failure(dev);
+
+	data->streaming_sqe = NULL;
+	rtio_iodev_sqe_ok(iodev_sqe, (int)min_len);
+}
+
+void bmi270_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+	struct bmi270_data *data = dev->data;
+	const struct bmi270_config *config = dev->config;
+	struct sensor_stream_trigger *fifo_wm =
+		get_read_config_trigger(cfg, SENSOR_TRIG_FIFO_WATERMARK);
+	struct sensor_stream_trigger *fifo_full =
+		get_read_config_trigger(cfg, SENSOR_TRIG_FIFO_FULL);
+	bool use_wm = (fifo_wm != NULL);
+	bool use_full = (fifo_full != NULL);
+	const struct gpio_dt_spec *fifo_pin_submit = fifo_pin(config);
+	uint8_t flush_cmd, stat1;
+	uint64_t cycles;
+	int ret;
+
+	if (!fifo_pin_submit->port) {
+		LOG_ERR("FIFO stream requires %s (irq-gpios)",
+			IS_ENABLED(CONFIG_BMI270_FIFO_ON_INT2) ? "INT2" : "INT1");
+		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+		return;
+	}
+
+	if (!use_wm && !use_full) {
+		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+		return;
+	}
+
+	if (sensor_clock_get_cycles(&cycles) == 0) {
+		data->timestamp = sensor_clock_cycles_to_ns(cycles);
+	} else {
+		data->timestamp = 0;
+	}
+
+	/*
+	 * Disable adv_power_save before the register burst. In suspend mode
+	 * the BMI270 requires 450 µs between SPI transactions; normal mode
+	 * only needs 2 µs. Re-enabled in bmi270_stream_handle_fifo() after
+	 * all SPI work is done.
+	 */
+	ret = bmi270_adv_power_save_disable(dev);
+	if (ret < 0) {
+		LOG_ERR("adv_power_save_disable failed: %d", ret);
+		rtio_iodev_sqe_err(iodev_sqe, ret);
+		return;
+	}
+
+	data->fifo_watermark_bytes = fifo_watermark_bytes();
+
+	ret = configure_fifo(dev, true, data->fifo_watermark_bytes);
+	if (ret < 0) {
+		LOG_ERR("FIFO config failed: %d", ret);
+		rtio_iodev_sqe_err(iodev_sqe, ret);
+		return;
+	}
+
+	ret = map_fifo_int(dev, use_wm, use_full);
+	if (ret < 0) {
+		rtio_iodev_sqe_err(iodev_sqe, ret);
+		return;
+	}
+
+	/* Flush FIFO so first interrupt starts from a clean state */
+	flush_cmd = BMI270_CMD_FIFO_FLUSH;
+	ret = bmi270_reg_write(dev, BMI270_REG_CMD, &flush_cmd, 1);
+	if (ret < 0) {
+		rtio_iodev_sqe_err(iodev_sqe, ret);
+		return;
+	}
+
+	/*
+	 * FIFO was just flushed so fill level is 0 (below watermark).
+	 * Reading INT_STATUS_1 clears the FWM/FFULL latch, which deasserts
+	 * the INT pin so the GPIO sees a clean LOW before arming.
+	 */
+	bmi270_reg_read(dev, BMI270_REG_INT_STATUS_1, &stat1, 1);
+
+	ret = gpio_pin_interrupt_configure_dt(fifo_pin_submit, GPIO_INT_DISABLE);
+	if (ret != 0) {
+		rtio_iodev_sqe_err(iodev_sqe, ret);
+		return;
+	}
+
+	data->streaming_sqe = iodev_sqe;
+	ret = gpio_pin_interrupt_configure_dt(fifo_pin_submit, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret != 0) {
+		data->streaming_sqe = NULL;
+		rtio_iodev_sqe_err(iodev_sqe, ret);
+		return;
+	}
+
+	LOG_DBG("Stream submitted (wm %u bytes, pin=%d)", data->fifo_watermark_bytes,
+		gpio_pin_get_dt(fifo_pin_submit));
+
+#if defined(CONFIG_BMI270_FIFO_POLL_FALLBACK)
+	if (!poll_work_inited) {
+		k_work_init_delayable(&poll_work, poll_work_fn);
+		poll_work_inited = true;
+	}
+	poll_dev = dev;
+	k_work_schedule(&poll_work, K_MSEC(FIFO_POLL_MS));
+#endif
+}
+
+#endif /* CONFIG_BMI270_STREAM */

--- a/drivers/sensor/bosch/bmi270/bmi270_stream.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_stream.c
@@ -230,15 +230,16 @@ static void poll_work_fn(struct k_work *work)
 	if (dev == NULL) {
 		return;
 	}
+
 	data = dev->data;
-	if (data->streaming_sqe == NULL) {
-		return;
+	if (data->streaming_sqe != NULL) {
+		bmi270_reg_read(dev, BMI270_REG_FIFO_LENGTH_0, (uint8_t *)&fifo_len, 2);
+		fifo_len = sys_get_le16((uint8_t *)&fifo_len) & 0x3FFF;
+		if (fifo_len >= data->fifo_watermark_bytes) {
+			bmi270_stream_submit_fifo_job(dev);
+		}
 	}
-	bmi270_reg_read(dev, BMI270_REG_FIFO_LENGTH_0, (uint8_t *)&fifo_len, 2);
-	fifo_len = sys_get_le16((uint8_t *)&fifo_len) & 0x3FFF;
-	if (fifo_len >= data->fifo_watermark_bytes) {
-		bmi270_stream_submit_fifo_job(dev);
-	}
+
 	k_work_schedule(&poll_work, K_MSEC(FIFO_POLL_MS));
 }
 #endif /* CONFIG_BMI270_FIFO_POLL_FALLBACK */
@@ -378,6 +379,9 @@ static void bmi270_fifo_job_abort(const struct device *dev)
 	data->fifo_job_queued = false;
 	data->fifo_job_processing = false;
 	k_spin_unlock(&data->fifo_job_lock, key);
+
+	/* Force a full re-arm on the next submit_stream(), state may be stale after an abort. */
+	data->fifo_configured = false;
 }
 
 static int bmi270_prep_fifo_drain_async(const struct device *dev, size_t max_reads,
@@ -795,42 +799,55 @@ void bmi270_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev
 		return;
 	}
 
-	data->fifo_watermark_bytes = fifo_watermark_bytes();
-
-	ret = configure_fifo(dev, true, data->fifo_watermark_bytes);
-	if (ret < 0) {
-		LOG_ERR("FIFO config failed: %d", ret);
-		rtio_iodev_sqe_err(iodev_sqe, ret);
-		return;
-	}
-
-	ret = map_fifo_int(dev, use_wm, use_full);
-	if (ret < 0) {
-		rtio_iodev_sqe_err(iodev_sqe, ret);
-		return;
-	}
-
-	/* Flush FIFO so first interrupt starts from a clean state */
-	flush_cmd = BMI270_CMD_FIFO_FLUSH;
-	ret = bmi270_reg_write(dev, BMI270_REG_CMD, &flush_cmd, 1);
-	if (ret < 0) {
-		rtio_iodev_sqe_err(iodev_sqe, ret);
-		return;
-	}
-
 	/*
-	 * FIFO was just flushed so fill level is 0 (below watermark).
-	 * Reading INT_STATUS_1 clears the FWM/FFULL latch, which deasserts
-	 * the INT pin so the GPIO sees a clean LOW before arming.
+	 * RTIO_SQE_MULTISHOT re-invokes this submit() on every FIFO cycle, not just at
+	 * stream start, so only run the one-time FIFO/INT-map/flush setup once.
 	 */
-	bmi270_reg_read(dev, BMI270_REG_INT_STATUS_1, &stat1, 1);
+	if (!data->fifo_configured) {
+		data->fifo_watermark_bytes = fifo_watermark_bytes();
 
-	ret = gpio_pin_interrupt_configure_dt(fifo_pin_submit, GPIO_INT_DISABLE);
-	if (ret != 0) {
-		rtio_iodev_sqe_err(iodev_sqe, ret);
-		return;
+		ret = configure_fifo(dev, true, data->fifo_watermark_bytes);
+		if (ret < 0) {
+			LOG_ERR("FIFO config failed: %d", ret);
+			rtio_iodev_sqe_err(iodev_sqe, ret);
+			return;
+		}
+
+		ret = map_fifo_int(dev, use_wm, use_full);
+		if (ret < 0) {
+			rtio_iodev_sqe_err(iodev_sqe, ret);
+			return;
+		}
+
+		/* Flush FIFO so first interrupt starts from a clean state */
+		flush_cmd = BMI270_CMD_FIFO_FLUSH;
+		ret = bmi270_reg_write(dev, BMI270_REG_CMD, &flush_cmd, 1);
+		if (ret < 0) {
+			rtio_iodev_sqe_err(iodev_sqe, ret);
+			return;
+		}
+
+		/*
+		 * FIFO was just flushed so fill level is 0 (below watermark).
+		 * Reading INT_STATUS_1 clears the FWM/FFULL latch, which
+		 * deasserts the INT pin so the GPIO sees a clean LOW before
+		 * arming.
+		 */
+		bmi270_reg_read(dev, BMI270_REG_INT_STATUS_1, &stat1, 1);
+
+		ret = gpio_pin_interrupt_configure_dt(fifo_pin_submit, GPIO_INT_DISABLE);
+		if (ret != 0) {
+			rtio_iodev_sqe_err(iodev_sqe, ret);
+			return;
+		}
+
+		data->fifo_configured = true;
+
+		LOG_DBG("Stream submitted (wm %u bytes, pin=%d)", data->fifo_watermark_bytes,
+			gpio_pin_get_dt(fifo_pin_submit));
 	}
 
+	/* Re-arm on every call: bmi270_try_submit_fifo_irq() disables this on every IRQ. */
 	data->streaming_sqe = iodev_sqe;
 	ret = gpio_pin_interrupt_configure_dt(fifo_pin_submit, GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret != 0) {
@@ -838,9 +855,6 @@ void bmi270_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev
 		rtio_iodev_sqe_err(iodev_sqe, ret);
 		return;
 	}
-
-	LOG_DBG("Stream submitted (wm %u bytes, pin=%d)", data->fifo_watermark_bytes,
-		gpio_pin_get_dt(fifo_pin_submit));
 
 #if defined(CONFIG_BMI270_FIFO_POLL_FALLBACK)
 	if (!poll_work_inited) {

--- a/drivers/sensor/bosch/bmi270/bmi270_stream.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_stream.c
@@ -11,6 +11,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 
 #include "bmi270.h"
 #include "bmi270_decoder.h"
@@ -236,7 +237,7 @@ static void poll_work_fn(struct k_work *work)
 	bmi270_reg_read(dev, BMI270_REG_FIFO_LENGTH_0, (uint8_t *)&fifo_len, 2);
 	fifo_len = sys_get_le16((uint8_t *)&fifo_len) & 0x3FFF;
 	if (fifo_len >= data->fifo_watermark_bytes) {
-		bmi270_submit_fifo_work(dev);
+		bmi270_stream_submit_fifo_job(dev);
 	}
 	k_work_schedule(&poll_work, K_MSEC(FIFO_POLL_MS));
 }
@@ -268,31 +269,449 @@ static void fifo_fill_encoded_header(struct bmi270_fifo_encoded_data *edata,
 	edata->fifo_byte_count = fifo_len;
 }
 
-static void fifo_drain_bytes(const struct device *dev, uint16_t remain)
+static int bmi270_rtio_drain_cq(struct rtio *r, int result)
 {
-	uint8_t discard[64];
+	struct rtio_cqe *cqe;
 
-	while (remain > 0) {
-		size_t chunk = remain > sizeof(discard) ? sizeof(discard) : (size_t)remain;
+	do {
+		cqe = rtio_cqe_consume(r);
+		if (cqe != NULL) {
+			if (result >= 0) {
+				result = cqe->result;
+			}
+			rtio_cqe_release(r, cqe);
+		}
+	} while (cqe != NULL);
 
-		bmi270_reg_read(dev, BMI270_REG_FIFO_DATA, discard, chunk);
-		remain -= (uint16_t)chunk;
+	return result;
+}
+
+enum bmi270_fifo_job_phase {
+	BMI270_FIFO_JOB_STATUS,
+	BMI270_FIFO_JOB_DATA,
+	BMI270_FIFO_JOB_DRAIN,
+	BMI270_FIFO_JOB_CLEAR_STATUS,
+};
+
+/* SPI register reads use 3 SQEs, so keep each drain submission within the 8-SQE pool. */
+#define BMI270_FIFO_DATA_JOB_DRAIN_READS 1
+#define BMI270_FIFO_DRAIN_JOB_DRAIN_READS 2
+
+static void bmi270_fifo_job_work_handler(struct k_work *work)
+{
+	struct bmi270_data *data = CONTAINER_OF(work, struct bmi270_data, fifo_job_work);
+
+	bmi270_stream_handle_fifo(data->dev);
+}
+
+void bmi270_stream_init(const struct device *dev)
+{
+	struct bmi270_data *data = dev->data;
+
+	k_work_init(&data->fifo_job_work, bmi270_fifo_job_work_handler);
+}
+
+void bmi270_stream_submit_fifo_job(const struct device *dev)
+{
+	struct bmi270_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&data->fifo_job_lock);
+	data->fifo_job_pending++;
+	if (!data->fifo_job_queued && !data->fifo_job_processing) {
+		data->fifo_job_pending--;
+		data->fifo_job_queued = true;
+		data->fifo_job_phase = BMI270_FIFO_JOB_STATUS;
+		mpsc_push(&data->fifo_jobs, &data->fifo_job);
 	}
+	k_spin_unlock(&data->fifo_job_lock, key);
+
+	k_work_submit(&data->fifo_job_work);
+}
+
+static void bmi270_requeue_fifo_job_work(const struct device *dev,
+					 enum bmi270_fifo_job_phase phase)
+{
+	struct bmi270_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&data->fifo_job_lock);
+	data->fifo_job_phase = phase;
+	data->fifo_job_queued = true;
+	data->fifo_job_processing = false;
+	mpsc_push(&data->fifo_jobs, &data->fifo_job);
+	k_spin_unlock(&data->fifo_job_lock, key);
+	k_work_submit(&data->fifo_job_work);
+}
+
+static void bmi270_fifo_job_complete(const struct device *dev)
+{
+	struct bmi270_data *data = dev->data;
+	k_spinlock_key_t key;
+	bool submit = false;
+
+	key = k_spin_lock(&data->fifo_job_lock);
+	data->fifo_job_processing = false;
+	if (data->fifo_job_pending > 0U) {
+		data->fifo_job_pending--;
+		data->fifo_job_queued = true;
+		data->fifo_job_phase = BMI270_FIFO_JOB_STATUS;
+		mpsc_push(&data->fifo_jobs, &data->fifo_job);
+		submit = true;
+	} else {
+		data->fifo_job_queued = false;
+	}
+	k_spin_unlock(&data->fifo_job_lock, key);
+
+	if (submit) {
+		k_work_submit(&data->fifo_job_work);
+	}
+}
+
+static void bmi270_fifo_job_abort(const struct device *dev)
+{
+	struct bmi270_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&data->fifo_job_lock);
+	data->fifo_job_pending = 0U;
+	data->fifo_job_queued = false;
+	data->fifo_job_processing = false;
+	k_spin_unlock(&data->fifo_job_lock, key);
+}
+
+static int bmi270_prep_fifo_drain_async(const struct device *dev, size_t max_reads,
+					uint16_t *drained)
+{
+	struct bmi270_data *data = dev->data;
+	int ret;
+
+	*drained = 0U;
+
+	while (data->fifo_drain_len > *drained && max_reads > 0) {
+		uint16_t remaining = data->fifo_drain_len - *drained;
+		size_t chunk = MIN((size_t)remaining, sizeof(data->fifo_discard_buf));
+
+		ret = bmi270_prep_reg_read_async(dev, BMI270_REG_FIFO_DATA, data->fifo_discard_buf,
+						 chunk, RTIO_SQE_CHAINED);
+		if (ret < 0) {
+			return ret;
+		}
+
+		*drained += (uint16_t)chunk;
+		max_reads--;
+	}
+
+	return 0;
+}
+
+static void bmi270_fifo_drain_done_cb(struct rtio *r, const struct rtio_sqe *sqe, int result,
+				      void *arg)
+{
+	ARG_UNUSED(sqe);
+
+	const struct device *dev = arg;
+	struct bmi270_data *data = dev->data;
+	struct rtio_iodev_sqe *iodev_sqe = data->streaming_sqe;
+
+	result = bmi270_rtio_drain_cq(r, result);
+
+	if (result < 0 || iodev_sqe == NULL) {
+		if (iodev_sqe != NULL) {
+			stream_error(dev, data, iodev_sqe, result);
+		}
+		data->fifo_drain_len = 0U;
+		bmi270_fifo_job_abort(dev);
+		return;
+	}
+
+	if (data->fifo_drain_len > 0U) {
+		bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_DRAIN);
+	} else {
+		bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_CLEAR_STATUS);
+	}
+}
+
+static void bmi270_fifo_read_done_cb(struct rtio *r, const struct rtio_sqe *sqe, int result,
+				     void *arg)
+{
+	ARG_UNUSED(sqe);
+
+	const struct device *dev = arg;
+	struct bmi270_data *data = dev->data;
+	struct rtio_iodev_sqe *iodev_sqe = data->streaming_sqe;
+
+	result = bmi270_rtio_drain_cq(r, result);
+
+	if (result < 0 || iodev_sqe == NULL) {
+		if (iodev_sqe != NULL) {
+			stream_error(dev, data, iodev_sqe, result);
+		}
+		bmi270_fifo_job_abort(dev);
+		return;
+	}
+
+	adv_power_save_enable_log_failure(dev);
+
+	data->streaming_sqe = NULL;
+	rtio_iodev_sqe_ok(iodev_sqe,
+			  sizeof(struct bmi270_fifo_encoded_data) + data->fifo_len);
+	bmi270_fifo_job_complete(dev);
+}
+
+static void bmi270_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, int result,
+				void *arg)
+{
+	ARG_UNUSED(sqe);
+
+	const struct device *dev = arg;
+	struct bmi270_data *data = dev->data;
+	struct rtio_iodev_sqe *iodev_sqe = data->streaming_sqe;
+	uint16_t fifo_len;
+	uint16_t fifo_len_orig;
+	uint8_t *buf;
+	uint32_t buf_len;
+	struct bmi270_fifo_encoded_data *edata;
+	size_t max_fifo;
+	size_t min_len;
+	int ret;
+
+	if (result < 0 || iodev_sqe == NULL) {
+		result = bmi270_rtio_drain_cq(r, result);
+		if (iodev_sqe != NULL) {
+			stream_error(dev, data, iodev_sqe, result);
+		}
+		bmi270_fifo_job_abort(dev);
+		return;
+	}
+
+	result = bmi270_rtio_drain_cq(r, result);
+	if (result < 0) {
+		stream_error(dev, data, iodev_sqe, result);
+		bmi270_fifo_job_abort(dev);
+		return;
+	}
+
+	if (!(data->int_status_1 & (BMI270_INT_STATUS_1_FWM_INT | BMI270_INT_STATUS_1_FFULL_INT))) {
+		adv_power_save_enable_log_failure(dev);
+		data->streaming_sqe = NULL;
+		rtio_iodev_sqe_ok(iodev_sqe, 0);
+		bmi270_fifo_job_complete(dev);
+		return;
+	}
+
+	fifo_len = sys_get_le16(data->fifo_status) & 0x3FFF;
+	if (fifo_len == 0) {
+		adv_power_save_enable_log_failure(dev);
+		data->streaming_sqe = NULL;
+		rtio_iodev_sqe_ok(iodev_sqe, 0);
+		bmi270_fifo_job_complete(dev);
+		return;
+	}
+
+	max_fifo = CONFIG_BMI270_FIFO_STREAM_BLOCK_SIZE - sizeof(struct bmi270_fifo_encoded_data);
+	fifo_len_orig = fifo_len;
+	data->fifo_drain_len = 0U;
+
+	if (fifo_len > max_fifo) {
+		LOG_WRN("FIFO len %u > max %zu, capping and draining remainder", fifo_len,
+			max_fifo);
+		fifo_len = (uint16_t)max_fifo;
+		data->fifo_drain_len = fifo_len_orig - fifo_len;
+	}
+
+	data->fifo_len = fifo_len;
+	min_len = sizeof(struct bmi270_fifo_encoded_data) + fifo_len;
+
+	ret = rtio_sqe_rx_buf(iodev_sqe, min_len, min_len, &buf, &buf_len);
+	if (ret != 0 || buf_len < min_len) {
+		stream_error(dev, data, iodev_sqe, -ENOMEM);
+		bmi270_fifo_job_abort(dev);
+		return;
+	}
+
+	edata = (struct bmi270_fifo_encoded_data *)buf;
+	fifo_fill_encoded_header(edata, data, fifo_len);
+	data->fifo_data_buf = edata->fifo_data;
+
+	bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_DATA);
+}
+
+static void bmi270_submit_fifo_data_job(const struct device *dev)
+{
+	struct bmi270_data *data = dev->data;
+	struct rtio_iodev_sqe *iodev_sqe = data->streaming_sqe;
+	struct rtio_sqe *cb_sqe;
+	uint16_t drained;
+	int ret;
+
+	if (iodev_sqe == NULL) {
+		bmi270_fifo_job_abort(dev);
+		return;
+	}
+
+	ret = bmi270_prep_reg_read_async(dev, BMI270_REG_FIFO_DATA, data->fifo_data_buf,
+					 data->fifo_len, RTIO_SQE_CHAINED);
+	if (ret < 0) {
+		rtio_sqe_drop_all(data->rtio_ctx);
+		bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_DATA);
+		return;
+	}
+
+	if (data->fifo_drain_len > 0U) {
+		ret = bmi270_prep_fifo_drain_async(dev, BMI270_FIFO_DATA_JOB_DRAIN_READS,
+						   &drained);
+		if (ret < 0) {
+			rtio_sqe_drop_all(data->rtio_ctx);
+			bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_DATA);
+			return;
+		}
+
+		cb_sqe = rtio_sqe_acquire(data->rtio_ctx);
+		if (cb_sqe == NULL) {
+			rtio_sqe_drop_all(data->rtio_ctx);
+			bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_DATA);
+			return;
+		}
+		rtio_sqe_prep_callback_no_cqe(cb_sqe, bmi270_fifo_drain_done_cb, (void *)dev,
+					      NULL);
+		data->fifo_drain_len -= drained;
+
+		rtio_submit(data->rtio_ctx, 0);
+		return;
+	}
+
+	ret = bmi270_prep_reg_read_async(dev, BMI270_REG_INT_STATUS_1, &data->int_status_1, 1,
+					 RTIO_SQE_CHAINED);
+	if (ret < 0) {
+		rtio_sqe_drop_all(data->rtio_ctx);
+		bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_DATA);
+		return;
+	}
+
+	cb_sqe = rtio_sqe_acquire(data->rtio_ctx);
+	if (cb_sqe == NULL) {
+		rtio_sqe_drop_all(data->rtio_ctx);
+		bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_DATA);
+		return;
+	}
+	rtio_sqe_prep_callback_no_cqe(cb_sqe, bmi270_fifo_read_done_cb, (void *)dev, NULL);
+
+	rtio_submit(data->rtio_ctx, 0);
+}
+
+static void bmi270_submit_fifo_drain_job(const struct device *dev)
+{
+	struct bmi270_data *data = dev->data;
+	struct rtio_iodev_sqe *iodev_sqe = data->streaming_sqe;
+	struct rtio_sqe *cb_sqe;
+	uint16_t drained;
+	int ret;
+
+	if (iodev_sqe == NULL) {
+		bmi270_fifo_job_abort(dev);
+		return;
+	}
+
+	if (data->fifo_drain_len == 0U) {
+		bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_CLEAR_STATUS);
+		return;
+	}
+
+	ret = bmi270_prep_fifo_drain_async(dev, BMI270_FIFO_DRAIN_JOB_DRAIN_READS, &drained);
+	if (ret < 0) {
+		rtio_sqe_drop_all(data->rtio_ctx);
+		bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_DRAIN);
+		return;
+	}
+
+	cb_sqe = rtio_sqe_acquire(data->rtio_ctx);
+	if (cb_sqe == NULL) {
+		rtio_sqe_drop_all(data->rtio_ctx);
+		bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_DRAIN);
+		return;
+	}
+	rtio_sqe_prep_callback_no_cqe(cb_sqe, bmi270_fifo_drain_done_cb, (void *)dev, NULL);
+	data->fifo_drain_len -= drained;
+
+	rtio_submit(data->rtio_ctx, 0);
+}
+
+static void bmi270_submit_fifo_clear_status_job(const struct device *dev)
+{
+	struct bmi270_data *data = dev->data;
+	struct rtio_iodev_sqe *iodev_sqe = data->streaming_sqe;
+	struct rtio_sqe *cb_sqe;
+	int ret;
+
+	if (iodev_sqe == NULL) {
+		bmi270_fifo_job_abort(dev);
+		return;
+	}
+
+	ret = bmi270_prep_reg_read_async(dev, BMI270_REG_INT_STATUS_1, &data->int_status_1, 1,
+					 RTIO_SQE_CHAINED);
+	if (ret < 0) {
+		rtio_sqe_drop_all(data->rtio_ctx);
+		bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_CLEAR_STATUS);
+		return;
+	}
+
+	cb_sqe = rtio_sqe_acquire(data->rtio_ctx);
+	if (cb_sqe == NULL) {
+		rtio_sqe_drop_all(data->rtio_ctx);
+		bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_CLEAR_STATUS);
+		return;
+	}
+	rtio_sqe_prep_callback_no_cqe(cb_sqe, bmi270_fifo_read_done_cb, (void *)dev, NULL);
+
+	rtio_submit(data->rtio_ctx, 0);
 }
 
 void bmi270_stream_handle_fifo(const struct device *dev)
 {
 	struct bmi270_data *data = dev->data;
-	struct rtio_iodev_sqe *iodev_sqe = data->streaming_sqe;
-	uint8_t int_status_1;
-	uint16_t fifo_len;
+	struct rtio_iodev_sqe *iodev_sqe;
+	struct rtio_sqe *cb_sqe;
+	struct mpsc_node *job;
+	k_spinlock_key_t key;
 	uint64_t cycles;
-	uint8_t *buf;
-	uint32_t buf_len;
-	struct bmi270_fifo_encoded_data *edata;
 	int ret;
 
+	key = k_spin_lock(&data->fifo_job_lock);
+	if (data->fifo_job_processing) {
+		k_spin_unlock(&data->fifo_job_lock, key);
+		return;
+	}
+
+	job = mpsc_pop(&data->fifo_jobs);
+	if (job == NULL) {
+		data->fifo_job_queued = false;
+		k_spin_unlock(&data->fifo_job_lock, key);
+		return;
+	}
+	data->fifo_job_queued = false;
+	data->fifo_job_processing = true;
+	k_spin_unlock(&data->fifo_job_lock, key);
+
+	iodev_sqe = data->streaming_sqe;
 	if (iodev_sqe == NULL) {
+		bmi270_fifo_job_abort(dev);
+		return;
+	}
+
+	if (data->fifo_job_phase == BMI270_FIFO_JOB_DATA) {
+		bmi270_submit_fifo_data_job(dev);
+		return;
+	}
+
+	if (data->fifo_job_phase == BMI270_FIFO_JOB_DRAIN) {
+		bmi270_submit_fifo_drain_job(dev);
+		return;
+	}
+
+	if (data->fifo_job_phase == BMI270_FIFO_JOB_CLEAR_STATUS) {
+		bmi270_submit_fifo_clear_status_job(dev);
 		return;
 	}
 
@@ -302,78 +721,31 @@ void bmi270_stream_handle_fifo(const struct device *dev)
 		data->timestamp = sensor_clock_cycles_to_ns(cycles);
 	}
 
-	ret = bmi270_reg_read(dev, BMI270_REG_INT_STATUS_1, &int_status_1, 1);
+	ret = bmi270_prep_reg_read_async(dev, BMI270_REG_INT_STATUS_1, &data->int_status_1, 1,
+					 RTIO_SQE_CHAINED);
 	if (ret < 0) {
-		stream_error(dev, data, iodev_sqe, ret);
+		rtio_sqe_drop_all(data->rtio_ctx);
+		bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_STATUS);
 		return;
 	}
 
-	data->int_status_1 = int_status_1;
-
-	if (!(int_status_1 & (BMI270_INT_STATUS_1_FWM_INT | BMI270_INT_STATUS_1_FFULL_INT))) {
-		adv_power_save_enable_log_failure(dev);
-		return;
-	}
-
-	/* Read FIFO length (14-bit, LSB then MSB) */
-	ret = bmi270_reg_read(dev, BMI270_REG_FIFO_LENGTH_0, (uint8_t *)&fifo_len, 2);
+	ret = bmi270_prep_reg_read_async(dev, BMI270_REG_FIFO_LENGTH_0, data->fifo_status, 2,
+					 RTIO_SQE_CHAINED);
 	if (ret < 0) {
-		stream_error(dev, data, iodev_sqe, ret);
+		rtio_sqe_drop_all(data->rtio_ctx);
+		bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_STATUS);
 		return;
 	}
 
-	fifo_len = sys_get_le16((uint8_t *)&fifo_len) & 0x3FFF;
-	if (fifo_len == 0) {
-		adv_power_save_enable_log_failure(dev);
-		data->streaming_sqe = NULL;
-		rtio_iodev_sqe_ok(iodev_sqe, 0);
+	cb_sqe = rtio_sqe_acquire(data->rtio_ctx);
+	if (cb_sqe == NULL) {
+		rtio_sqe_drop_all(data->rtio_ctx);
+		bmi270_requeue_fifo_job_work(dev, BMI270_FIFO_JOB_STATUS);
 		return;
 	}
+	rtio_sqe_prep_callback_no_cqe(cb_sqe, bmi270_read_fifo_cb, (void *)dev, NULL);
 
-	size_t max_fifo =
-		CONFIG_BMI270_FIFO_STREAM_BLOCK_SIZE - sizeof(struct bmi270_fifo_encoded_data);
-	uint16_t fifo_len_orig = fifo_len;
-
-	if (fifo_len > max_fifo) {
-		LOG_WRN("FIFO len %u > max %zu, capping and draining remainder", fifo_len,
-			max_fifo);
-		fifo_len = (uint16_t)max_fifo;
-	}
-
-	size_t min_len = sizeof(struct bmi270_fifo_encoded_data) + fifo_len;
-
-	ret = rtio_sqe_rx_buf(iodev_sqe, min_len, min_len, &buf, &buf_len);
-	if (ret != 0 || buf_len < min_len) {
-		stream_error(dev, data, iodev_sqe, -ENOMEM);
-		return;
-	}
-
-	edata = (struct bmi270_fifo_encoded_data *)buf;
-	fifo_fill_encoded_header(edata, data, fifo_len);
-
-	/* Burst read from FIFO_DATA (address does not auto-increment; burst read does) */
-	ret = bmi270_reg_read(dev, BMI270_REG_FIFO_DATA, edata->fifo_data, fifo_len);
-	if (ret < 0) {
-		stream_error(dev, data, iodev_sqe, ret);
-		return;
-	}
-
-	/* If we capped, drain remainder so FIFO is empty for next watermark */
-	if (fifo_len_orig > fifo_len) {
-		fifo_drain_bytes(dev, fifo_len_orig - fifo_len);
-	}
-
-	/*
-	 * Clear the FWM/FFULL latch now that the FIFO is drained below
-	 * watermark.  Latched interrupts only clear when INT_STATUS is read
-	 * AND fill level is below the threshold, so this must come AFTER drain.
-	 */
-	bmi270_reg_read(dev, BMI270_REG_INT_STATUS_1, &int_status_1, 1);
-
-	adv_power_save_enable_log_failure(dev);
-
-	data->streaming_sqe = NULL;
-	rtio_iodev_sqe_ok(iodev_sqe, (int)min_len);
+	rtio_submit(data->rtio_ctx, 0);
 }
 
 void bmi270_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)

--- a/drivers/sensor/bosch/bmi270/bmi270_trigger.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_trigger.c
@@ -5,10 +5,64 @@
  */
 
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(bmi270);
 
 #include "bmi270.h"
+
+#if defined(CONFIG_BMI270_STREAM)
+/* Dedicated work queue so FIFO handler runs on a thread with large stack (SPI + RTIO). */
+static K_KERNEL_STACK_DEFINE(bmi270_fifo_work_stack, CONFIG_BMI270_FIFO_WORKQ_STACK_SIZE);
+static struct k_work_q bmi270_fifo_work_q;
+static bool bmi270_fifo_work_q_initialized;
+
+static inline const struct gpio_dt_spec *bmi270_fifo_irq_pin(const struct bmi270_config *cfg)
+{
+#if defined(CONFIG_BMI270_FIFO_ON_INT2)
+	return &cfg->int2;
+#else
+	return &cfg->int1;
+#endif
+}
+
+static void bmi270_fifo_work_handler(struct k_work *work)
+{
+	struct bmi270_data *data = CONTAINER_OF(work, struct bmi270_data, fifo_work);
+
+	bmi270_stream_handle_fifo(data->dev);
+}
+
+void bmi270_submit_fifo_work(const struct device *dev)
+{
+	struct bmi270_data *data = dev->data;
+
+	k_work_submit_to_queue(&bmi270_fifo_work_q, &data->fifo_work);
+}
+
+struct k_work_q *bmi270_get_fifo_work_q(void)
+{
+	return &bmi270_fifo_work_q;
+}
+
+static bool bmi270_try_submit_fifo_irq(const struct device *dev, const struct gpio_dt_spec *irq_pin,
+				       const char *label)
+{
+	struct bmi270_data *data = dev->data;
+
+	if (data->streaming_sqe == NULL) {
+		return false;
+	}
+
+	if (irq_pin->port) {
+		gpio_pin_interrupt_configure_dt(irq_pin, GPIO_INT_DISABLE);
+	}
+
+	LOG_DBG("%s: submit FIFO work", label);
+	k_work_submit_to_queue(&bmi270_fifo_work_q, &data->fifo_work);
+	return true;
+}
+#endif
 
 enum {
 	INT_FLAGS_INT1,
@@ -33,6 +87,7 @@ static void bmi270_int1_callback(const struct device *dev,
 {
 	struct bmi270_data *data =
 		CONTAINER_OF(cb, struct bmi270_data, int1_cb);
+
 	bmi270_raise_int_flag(data->dev, INT_FLAGS_INT1);
 }
 
@@ -44,14 +99,20 @@ static void bmi270_int2_callback(const struct device *dev,
 	bmi270_raise_int_flag(data->dev, INT_FLAGS_INT2);
 }
 
-
 static void bmi270_thread_cb(const struct device *dev)
 {
 	struct bmi270_data *data = dev->data;
 	int ret;
 
-	/* INT1 is used for feature interrupts */
+	/* INT1: FIFO by default, feature (motion) interrupts when using INT2 for FIFO */
 	if (atomic_test_and_clear_bit(&data->int_flags, INT_FLAGS_INT1)) {
+#if defined(CONFIG_BMI270_STREAM) && !defined(CONFIG_BMI270_FIFO_ON_INT2)
+		const struct bmi270_config *cfg = dev->config;
+
+		if (bmi270_try_submit_fifo_irq(dev, bmi270_fifo_irq_pin(cfg), "INT1")) {
+			return;
+		}
+#endif
 		uint16_t int_status;
 
 		ret = bmi270_reg_read(dev, BMI270_REG_INT_STATUS_0,
@@ -72,8 +133,15 @@ static void bmi270_thread_cb(const struct device *dev)
 		k_mutex_unlock(&data->trigger_mutex);
 	}
 
-	/* INT2 is used for data ready interrupts */
+	/* INT2: FIFO when CONFIG_BMI270_FIFO_ON_INT2, else data ready only */
 	if (atomic_test_and_clear_bit(&data->int_flags, INT_FLAGS_INT2)) {
+#if defined(CONFIG_BMI270_STREAM) && defined(CONFIG_BMI270_FIFO_ON_INT2)
+		const struct bmi270_config *cfg = dev->config;
+
+		if (bmi270_try_submit_fifo_irq(dev, bmi270_fifo_irq_pin(cfg), "INT2")) {
+			return;
+		}
+#endif
 		k_mutex_lock(&data->trigger_mutex, K_FOREVER);
 
 		if (data->drdy_handler != NULL) {
@@ -168,6 +236,24 @@ static int bmi270_init_int_pin(const struct gpio_dt_spec *pin,
 	return 0;
 }
 
+static int bmi270_configure_int_io_ctrl(const struct device *dev, const struct gpio_dt_spec *pin,
+					uint8_t reg, const char *name)
+{
+	int ret;
+	uint8_t io_ctrl = BMI270_INT_IO_CTRL_OUTPUT_EN | BMI270_INT_IO_CTRL_LVL;
+
+	if (!pin->port) {
+		return 0;
+	}
+
+	ret = bmi270_reg_write(dev, reg, &io_ctrl, 1);
+	if (ret < 0) {
+		LOG_ERR("failed configuring %s_IO_CTRL (%d)", name, ret);
+		return ret;
+	}
+
+	return 0;
+}
 
 int bmi270_init_interrupts(const struct device *dev)
 {
@@ -194,29 +280,53 @@ int bmi270_init_interrupts(const struct device *dev)
 	ret = bmi270_init_int_pin(&cfg->int2, &data->int2_cb,
 				  bmi270_int2_callback);
 	if (ret) {
-		LOG_ERR("Failed to initialize INT2");
+		LOG_ERR("Failed to initialize INT2 (required for FIFO and data ready)");
 		return -EINVAL;
 	}
 
-	if (cfg->int1.port) {
-		uint8_t int1_io_ctrl = BMI270_INT_IO_CTRL_OUTPUT_EN;
+#if defined(CONFIG_BMI270_STREAM)
+	if (!bmi270_fifo_work_q_initialized) {
+		k_work_queue_init(&bmi270_fifo_work_q);
+		k_work_queue_start(&bmi270_fifo_work_q, bmi270_fifo_work_stack,
+				   K_THREAD_STACK_SIZEOF(bmi270_fifo_work_stack),
+				   CONFIG_BMI270_THREAD_PRIORITY - 1, NULL);
+		bmi270_fifo_work_q_initialized = true;
+	}
+	k_work_init(&data->fifo_work, bmi270_fifo_work_handler);
+#endif
 
-		ret = bmi270_reg_write(dev, BMI270_REG_INT1_IO_CTRL, &int1_io_ctrl, 1);
-		if (ret < 0) {
-			LOG_ERR("failed configuring INT1_IO_CTRL (%d)", ret);
-			return ret;
-		}
+	ret = bmi270_configure_int_io_ctrl(dev, &cfg->int1, BMI270_REG_INT1_IO_CTRL, "INT1");
+	if (ret < 0) {
+		return ret;
 	}
 
-	if (cfg->int2.port) {
-		uint8_t int2_io_ctrl = BMI270_INT_IO_CTRL_OUTPUT_EN;
-
-		ret = bmi270_reg_write(dev, BMI270_REG_INT2_IO_CTRL, &int2_io_ctrl, 1);
-		if (ret < 0) {
-			LOG_ERR("failed configuring INT2_IO_CTRL (%d)", ret);
-			return ret;
-		}
+	ret = bmi270_configure_int_io_ctrl(dev, &cfg->int2, BMI270_REG_INT2_IO_CTRL, "INT2");
+	if (ret < 0) {
+		return ret;
 	}
+
+	/*
+	 * Permanent latched: pin stays HIGH until INT_STATUS is read AND the
+	 * interrupt condition is no longer active.  Non-latched mode leaves
+	 * INT1 permanently HIGH on this hardware even with no mapped sources.
+	 * With latched mode the pin deasserts after the handler drains the
+	 * FIFO and reads INT_STATUS_1, giving the nRF GPIO a clean edge.
+	 */
+	uint8_t int_latch = BMI270_INT_LATCH_PERMANENT;
+
+	ret = bmi270_reg_write(dev, BMI270_REG_INT_LATCH, &int_latch, 1);
+	if (ret < 0) {
+		LOG_ERR("failed configuring INT_LATCH (%d)", ret);
+		return ret;
+	}
+
+	/*
+	 * Clear any stale latched status so INT pins deassert before the
+	 * GPIO edge interrupt is armed.
+	 */
+	uint8_t dummy[2];
+
+	bmi270_reg_read(dev, BMI270_REG_INT_STATUS_0, dummy, 2);
 
 	return 0;
 }
@@ -264,7 +374,6 @@ static int bmi270_anymo_config(const struct device *dev, bool enable)
 static int bmi270_drdy_config(const struct device *dev, bool enable)
 {
 	int ret;
-
 	uint8_t int_map_data = 0;
 
 	if (enable) {

--- a/drivers/sensor/bosch/bmi270/bmi270_trigger.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_trigger.c
@@ -12,11 +12,6 @@ LOG_MODULE_DECLARE(bmi270);
 #include "bmi270.h"
 
 #if defined(CONFIG_BMI270_STREAM)
-/* Dedicated work queue so FIFO handler runs on a thread with large stack (SPI + RTIO). */
-static K_KERNEL_STACK_DEFINE(bmi270_fifo_work_stack, CONFIG_BMI270_FIFO_WORKQ_STACK_SIZE);
-static struct k_work_q bmi270_fifo_work_q;
-static bool bmi270_fifo_work_q_initialized;
-
 static inline const struct gpio_dt_spec *bmi270_fifo_irq_pin(const struct bmi270_config *cfg)
 {
 #if defined(CONFIG_BMI270_FIFO_ON_INT2)
@@ -24,25 +19,6 @@ static inline const struct gpio_dt_spec *bmi270_fifo_irq_pin(const struct bmi270
 #else
 	return &cfg->int1;
 #endif
-}
-
-static void bmi270_fifo_work_handler(struct k_work *work)
-{
-	struct bmi270_data *data = CONTAINER_OF(work, struct bmi270_data, fifo_work);
-
-	bmi270_stream_handle_fifo(data->dev);
-}
-
-void bmi270_submit_fifo_work(const struct device *dev)
-{
-	struct bmi270_data *data = dev->data;
-
-	k_work_submit_to_queue(&bmi270_fifo_work_q, &data->fifo_work);
-}
-
-struct k_work_q *bmi270_get_fifo_work_q(void)
-{
-	return &bmi270_fifo_work_q;
 }
 
 static bool bmi270_try_submit_fifo_irq(const struct device *dev, const struct gpio_dt_spec *irq_pin,
@@ -58,8 +34,8 @@ static bool bmi270_try_submit_fifo_irq(const struct device *dev, const struct gp
 		gpio_pin_interrupt_configure_dt(irq_pin, GPIO_INT_DISABLE);
 	}
 
-	LOG_DBG("%s: submit FIFO work", label);
-	k_work_submit_to_queue(&bmi270_fifo_work_q, &data->fifo_work);
+	LOG_DBG("%s: handle FIFO stream", label);
+	bmi270_stream_submit_fifo_job(dev);
 	return true;
 }
 #endif
@@ -283,17 +259,6 @@ int bmi270_init_interrupts(const struct device *dev)
 		LOG_ERR("Failed to initialize INT2 (required for FIFO and data ready)");
 		return -EINVAL;
 	}
-
-#if defined(CONFIG_BMI270_STREAM)
-	if (!bmi270_fifo_work_q_initialized) {
-		k_work_queue_init(&bmi270_fifo_work_q);
-		k_work_queue_start(&bmi270_fifo_work_q, bmi270_fifo_work_stack,
-				   K_THREAD_STACK_SIZEOF(bmi270_fifo_work_stack),
-				   CONFIG_BMI270_THREAD_PRIORITY - 1, NULL);
-		bmi270_fifo_work_q_initialized = true;
-	}
-	k_work_init(&data->fifo_work, bmi270_fifo_work_handler);
-#endif
 
 	ret = bmi270_configure_int_io_ctrl(dev, &cfg->int1, BMI270_REG_INT1_IO_CTRL, "INT1");
 	if (ret < 0) {


### PR DESCRIPTION
## Overview

Reworks the BMI270 RTIO data path to be fully asynchronous, using SQE chaining instead of a work queue, and adds FIFO streaming support via `sensor_stream()`.

The original async RTIO rework and FIFO streaming work was authored by @sudiiyengar-en based on #105828. This PR carries it forward, rebased onto current `main`, with the review feedback from that PR addressed and two additional fixes found during hardware validation.

Since #105828 was closed as stale, this reopens the same work rebased onto current `main`, with the review feedback from that PR addressed:

- FIFO decode now converts each raw sample to Q31 with a single multiply, using a scale precomputed once per buffer instead of per frame.
- The `1000000LL` unit-conversion divisor is now a named macro (`BMI270_MICRO_UNIT_SCALE`) with a short comment explaining it.
- `bmi270_decoder_decode()` groups plain field assignments separately from ones requiring a function call.
- `write_config_file()` correctly keeps `int` (not `int8_t`), since it forwards the return of `bmi270_reg_write_with_delay()`, which is `int`.

On top of that, this adds two fixes found while validating FIFO streaming end to end on hardware:

- `bmi270_submit_stream()` was re-running its full one-time setup (FIFO config, INT map, flush, GPIO disable) on every `RTIO_SQE_MULTISHOT` cycle instead of once at stream start. It's now gated behind a `fifo_configured` flag, re-armed only after a stream abort.
- The FIFO poll fallback (`CONFIG_BMI270_FIFO_POLL_FALLBACK`) stopped rescheduling itself permanently if it ran while `streaming_sqe` was momentarily `NULL` between cycles.

## Testing

Built and run on hardware with BMI270 over SPI, using the `gesture_recognition` application from `nrfconnect/sdk-edge-ai`. FIFO streaming, IMU sampling, and the application pipeline ran continuously without stalling.