### PR TITLE
drivers: video: Improve video_import_buffer

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1076,3 +1076,11 @@ Architectures
 
 * ``CONFIG_XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK`` is removed, since backtrace is now always
   using :c:macro:`EXCEPTION_DUMP` for output.
+
+Video
+=====
+
+* :c:func:`video_import_buffer` no longer returns the imported buffer index via a
+  ``uint16_t *idx`` output parameter but instead returns a pointer to the imported
+  :c:struct:`video_buffer`, or ``NULL`` on failure. This helps to make the index transparent
+  to the application and also makes the buffer accessible from the application.

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -119,13 +119,13 @@ int video_buffer_release(struct video_buffer *vbuf)
 	return 0;
 }
 
-int video_import_buffer(uint8_t *mem, size_t sz, uint16_t *idx)
+struct video_buffer *video_import_buffer(uint8_t *mem, size_t sz)
 {
 	uint16_t ind;
 
 	if (mem == NULL || sz == 0) {
 		LOG_ERR("Invalid memory address or size");
-		return -EINVAL;
+		return NULL;
 	}
 
 	/* Find the 1st available slot in the video buffer pool */
@@ -136,7 +136,7 @@ int video_import_buffer(uint8_t *mem, size_t sz, uint16_t *idx)
 	}
 
 	if (ind == ARRAY_SIZE(video_buf)) {
-		return -ENOBUFS;
+		return NULL;
 	}
 
 	/* Populate the internal buffer */
@@ -147,10 +147,7 @@ int video_import_buffer(uint8_t *mem, size_t sz, uint16_t *idx)
 	video_buf[ind].bytesused = 0;
 	video_buf[ind].timestamp = 0;
 
-	/* Return the buffer index to the requester */
-	*idx = ind;
-
-	return 0;
+	return &video_buf[ind];
 }
 
 int video_enqueue(const struct device *dev, struct video_buffer *buf)

--- a/include/zephyr/video/video.h
+++ b/include/zephyr/video/video.h
@@ -18,7 +18,7 @@
  * @brief Video public APIs.
  * @defgroup video_api Video APIs
  * @since 4.4
- * @version 0.1.0
+ * @version 0.2.0
  * @ingroup video_interface
  * @{
  */
@@ -37,11 +37,11 @@
  *
  * @param mem Pointer to the external memory
  * @param sz Size of the external memory
- * @param idx Returned index of the imported video buffer in the video buffer pool
  *
- * @retval 0 on success or a negative errno code on failure.
+ * @return Pointer to the imported @ref video_buffer holding the external memory on success,
+ * NULL on failure
  */
-int video_import_buffer(uint8_t *mem, size_t sz, uint16_t *idx);
+struct video_buffer *video_import_buffer(uint8_t *mem, size_t sz);
 
 /**
  * @}


### PR DESCRIPTION
Return the whole video_buffer structure instead of just the index. This helps to make index transparent to application and also **make the buffer accessible from the application**.