### PR TITLE
tests bsim bluetooth ll bis: Remove unused tag

### DIFF
--- a/tests/bsim/bluetooth/ll/bis/tests.yaml
+++ b/tests/bsim/bluetooth/ll/bis/tests.yaml
@@ -2,7 +2,6 @@ common:
   build_only: true
   tags:
     - bluetooth
-    - bsim_multi
   depends_on: bsim
 
 tests:


### PR DESCRIPTION
This tag (bsim_multi) has never been used. Let's remove it.

(It was added intending to be used to separate in CI the babblesim workflow tests from others)