### PR TITLE
samples: drivers: mspi: stm32 running on octospi2 of the b_u585  board

### DIFF
--- a/samples/drivers/mspi/mspi_flash/boards/b_u585i_iot02a.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/b_u585i_iot02a.overlay
@@ -35,6 +35,7 @@
 			pinctrl-names = "default";
 			dmas = <&gpdma1 12 41 0x10480>; /* request 41 for OCTOSPI2 */
 			dma-names = "tx_rx";
+			st,dqs-port = <2>;
 			status = "okay";
 
 			mx25lm51245: ospi-nor-flash@0 {


### PR DESCRIPTION
The property "st,dqs-port = <2>;" is required for the b_u585i_io02a target because the NOR flash is mounted on the octospi2 instance. which is not the case with other targat boards (default value)


Running the samples/drivers/mspi/mspi_flash/ on the b_u585i_iot02a  : 
```
ospi-nor-flash@0 SPI flash testing
==========================

Perform test on single sector
Test 1: Flash erase
[00:00:00.000,000] <inf> ospi_stm32: OSPI with DMA Transfer
[00:00:00.000,000] <inf> ospi_stm32: MSPI config result: success
*** Booting Zephyr OS build v4.4.0-7069-gb316d4749864 ***
Flash erase succeeded!

Test 2: Flash write
Attempting to write 4 bytes
Data read matches data written. Good!!

Perform test on multiple consecutive sectors
Test 1: Flash erase
Flash erase succeeded!

Test 2: Flash write
Attempting to write 4 bytes at offset 0xff000
Data read matches data written. Good!!
Attempting to write 4 bytes at offset 0x100000
Data read matches data written. Good!!
==========================
```

