### PR TITLE
MAINTAINERS: Silabs: Add 802.15.4 driver subsection

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5750,6 +5750,12 @@ Silabs Platforms:
     - drivers/*/*/*siwx91x*
     - tests/boards/silabs/
     - snippets/*silabs*/
+  file-groups:
+    - name: Silabs IEEE 802.15.4
+      collaborators:
+        - db00lean
+      files:
+        - drivers/ieee802154/
   labels:
     - "platform: Silabs"
   tests:


### PR DESCRIPTION
Add a file-groups subsection to Silabs Platforms in order to have a dedicated collaborator in the 802.15.4 driver area.