### PR TITLE
drivers: i2c: stm32: reset target ACK on address match

### DIFF
--- a/drivers/i2c/i2c_stm32_v2.c
+++ b/drivers/i2c/i2c_stm32_v2.c
@@ -342,6 +342,11 @@ static void i2c_stm32_target_addr_setup(const struct device *dev,
 		LL_I2C_ClearFlag_ADDR(i2c);
 	}
 
+	/* Do not let a NACK requested by the previous write transfer leak
+	 * into this new target transfer.
+	 */
+	LL_I2C_AcknowledgeNextData(i2c, LL_I2C_ACK);
+
 	dir = LL_I2C_GetTransferDirection(i2c);
 	if (dir == LL_I2C_DIRECTION_WRITE) {
 		if (target_cb->write_requested(target_cfg) < 0) {

--- a/drivers/i2c/i2c_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_stm32_v2_rtio.c
@@ -299,6 +299,11 @@ static void i2c_stm32_target_event(const struct device *dev)
 
 		LL_I2C_ClearFlag_ADDR(i2c);
 
+		/* Do not let a NACK requested by the previous write transfer leak
+		 * into this new target transfer.
+		 */
+		LL_I2C_AcknowledgeNextData(i2c, LL_I2C_ACK);
+
 		dir = LL_I2C_GetTransferDirection(i2c);
 		if (dir == LL_I2C_DIRECTION_WRITE) {
 			if (target_cb->write_requested(target_cfg) < 0) {


### PR DESCRIPTION
A failed target write callback requests a NACK for the next received data byte. On STM32 I2C v2, this state can leak into the next target transfer if it is not cleared when a new address match is handled.

Reset the target ACK state at the start of each new transfer in both the interrupt and RTIO STM32 v2 paths.

Fixes #112538