### PR TITLE
tests: drivers: spi: update sam_e54_xpro platform placement in spi tests

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/tests.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/tests.yaml
@@ -19,7 +19,6 @@ common:
     - nrf54lm20dk/nrf54lm20b/cpuapp
     - nrf7120dk/nrf7120/cpuapp
     - ophelia4ev/nrf54l15/cpuapp
-    - sam_e54_xpro
 
 tests:
   drivers.spi.spi_esp32:
@@ -39,6 +38,8 @@ tests:
     extra_args: EXTRA_DTC_OVERLAY_FILE="250khz.overlay"
     integration_platforms:
       - nrf52840dk/nrf52840
+    platform_allow:
+      - sam_e54_xpro
 
   drivers.spi.spi_mode1:
     extra_configs:
@@ -46,6 +47,8 @@ tests:
     extra_args: EXTRA_DTC_OVERLAY_FILE="500khz.overlay"
     integration_platforms:
       - nrf52840dk/nrf52840
+    platform_allow:
+      - sam_e54_xpro
 
   drivers.spi.spi_mode2:
     extra_configs:
@@ -53,6 +56,8 @@ tests:
     extra_args: EXTRA_DTC_OVERLAY_FILE="1mhz.overlay"
     integration_platforms:
       - nrf52840dk/nrf52840
+    platform_allow:
+      - sam_e54_xpro
 
   drivers.spi.spi_mode3:
     extra_configs:
@@ -60,6 +65,8 @@ tests:
     extra_args: EXTRA_DTC_OVERLAY_FILE="2mhz.overlay"
     integration_platforms:
       - nrf52840dk/nrf52840
+    platform_allow:
+      - sam_e54_xpro
 
   drivers.spi.spi_1M333333Hz:
     extra_configs:
@@ -69,6 +76,8 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf7120dk/nrf7120/cpuapp
+    platform_allow:
+      - sam_e54_xpro
 
   drivers.spi.spi_2M666666Hz:
     extra_configs:
@@ -78,6 +87,8 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf7120dk/nrf7120/cpuapp
+    platform_allow:
+      - sam_e54_xpro
 
   drivers.spi.spi_4MHz:
     extra_configs:
@@ -85,6 +96,8 @@ tests:
     extra_args: EXTRA_DTC_OVERLAY_FILE="4mhz.overlay"
     integration_platforms:
       - nrf52840dk/nrf52840
+    platform_allow:
+      - sam_e54_xpro
 
   drivers.spi.spi_8MHz:
     extra_configs:
@@ -92,6 +105,8 @@ tests:
     extra_args: EXTRA_DTC_OVERLAY_FILE="8mhz.overlay"
     integration_platforms:
       - nrf52840dk/nrf52840
+    platform_allow:
+      - sam_e54_xpro
 
   drivers.spi.spi_half_duplex:
     extra_args: EXTRA_DTC_OVERLAY_FILE="half-duplex.overlay"
@@ -121,7 +136,6 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf7120dk/nrf7120/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
-      - sam_e54_xpro
 
   drivers.spi.spis_fast:
     # SPIS120 instance occupies P6 which is not available on nRF54H20 DK pin headers
@@ -140,15 +154,12 @@ tests:
       - nrf54lm20dk/nrf54lm20b/cpuapp
       - nrf7120dk/nrf7120/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
-      - sam_e54_xpro
 
   drivers.spi.pm_runtime:
     extra_configs:
       - CONFIG_PM_DEVICE=y
       - CONFIG_PM_DEVICE_RUNTIME=y
     filter: CONFIG_SOC_FAMILY_NORDIC_NRF
-    platform_exclude:
-      - sam_e54_xpro
 
   drivers.spi.spi_cross_domain:
     harness_config:
@@ -168,22 +179,17 @@ tests:
       - nrf54h20dk/nrf54h20/cpuppr
       - ophelia4ev/nrf54l15/cpuapp
       - nrf7120dk/nrf7120/cpuapp
-      - sam_e54_xpro
 
   drivers.spi.direct_xfer:
     extra_configs:
       - CONFIG_SPI_NRFX_RAM_BUFFER_SIZE=0
     filter: CONFIG_SOC_FAMILY_NORDIC_NRF
-    platform_exclude:
-      - sam_e54_xpro
 
   drivers.spi.direct_xfer.no_prealloc:
     extra_configs:
       - CONFIG_SPI_NRFX_RAM_BUFFER_SIZE=0
       - CONFIG_PREALLOC_BUFFERS=n
     filter: CONFIG_SOC_FAMILY_NORDIC_NRF
-    platform_exclude:
-      - sam_e54_xpro
 
   drivers.spi.stm32_interrupt:
     extra_configs:
@@ -193,5 +199,3 @@ tests:
       - nucleo_f429zi/stm32f429xx
       - nucleo_g474re/stm32g474xx
       - nucleo_u385rg_q/stm32u385xx
-    platform_exclude:
-      - sam_e54_xpro


### PR DESCRIPTION
This PR addresses the issue reported in #111825.

The issue was caused by `sam_e54_xpro` being added under the common `platform_allow` list in the SPI testcase configuration, which caused it to run unsupported SPI test scenarios.

The fix moves `sam_e54_xpro` to only the SPI test cases supported by the board and removes the unnecessary `platform_exclude` entries.

Fixes #111825