### PR TITLE
doc: release_process: Mention ssh as a possible tag signing method

### DIFF
--- a/doc/project/release_process.rst
+++ b/doc/project/release_process.rst
@@ -642,8 +642,8 @@ steps:
     interface.  The GitHub release interface does not generate annotated tags (it
     generates 'lightweight' tags regardless of release or pre-release). You should
     also upload your gpg public key to your GitHub account, since the instructions
-    below involve creating signed tags. However, if you do not have a gpg public
-    key you can opt to remove the ``-s`` option from the commands below.
+    below involve creating signed tags. Alternatively, if you don't have a gpg key,
+    you can also use your ssh key for signing.
 
 .. tabs::
 


### PR DESCRIPTION
Since it's strongly recommended that all release tags (also release candidates) are signed, we shouldn't imply in the documentation that this is an optional step. Since git also supports signing using ssh keys, there really shouldn't be a reason to avoid signed tags.