### PR TITLE
Bluetooth: Classic: MAP: Add missing error code and remove _transport_type

### DIFF
--- a/include/zephyr/bluetooth/classic/map.h
+++ b/include/zephyr/bluetooth/classic/map.h
@@ -869,9 +869,6 @@ struct bt_map_mce_mas {
 	/** @internal Callbacks */
 	const struct bt_map_mce_mas_cb *_cb;
 
-	/** @internal Transport type */
-	uint8_t _transport_type;
-
 	/** @internal Transport state (atomic) */
 	atomic_t _transport_state;
 
@@ -1386,9 +1383,6 @@ struct bt_map_mce_mns {
 	/** @internal Callbacks */
 	const struct bt_map_mce_mns_cb *_cb;
 
-	/** @internal Transport type */
-	uint8_t _transport_type;
-
 	/** @internal Transport state (atomic) */
 	atomic_t _transport_state;
 
@@ -1845,9 +1839,6 @@ struct bt_map_mse_mas {
 
 	/** @internal Callbacks */
 	const struct bt_map_mse_mas_cb *_cb;
-
-	/** @internal Transport type */
-	uint8_t _transport_type;
 
 	/** @internal Transport state (atomic) */
 	atomic_t _transport_state;
@@ -2317,9 +2308,6 @@ struct bt_map_mse_mns {
 
 	/** @internal Callbacks */
 	const struct bt_map_mse_mns_cb *_cb;
-
-	/** @internal Transport type */
-	uint8_t _transport_type;
 
 	/** @internal Transport state (atomic) */
 	atomic_t _transport_state;

--- a/subsys/bluetooth/host/classic/map.c
+++ b/subsys/bluetooth/host/classic/map.c
@@ -1008,6 +1008,7 @@ static int mce_mas_get_or_put(struct bt_map_mce_mas *mce_mas, bool is_get, const
 
 	if (!is_get && final && !bt_obex_has_header(buf, BT_OBEX_HEADER_ID_END_BODY)) {
 		LOG_ERR("OBEX header (End of Body) is missing");
+		err = -ENODATA;
 		goto failed;
 	}
 
@@ -2818,6 +2819,7 @@ static int mse_mns_get_or_put(struct bt_map_mse_mns *mse_mns, bool is_get, const
 
 	if (!is_get && final && !bt_obex_has_header(buf, BT_OBEX_HEADER_ID_END_BODY)) {
 		LOG_ERR("OBEX header (End of Body) is missing");
+		err = -ENODATA;
 		goto failed;
 	}
 

--- a/subsys/bluetooth/host/classic/map.c
+++ b/subsys/bluetooth/host/classic/map.c
@@ -385,7 +385,7 @@ static void mce_mas_transport_connected(struct bt_conn *conn, struct bt_goep *go
 	LOG_DBG("MCE MAS transport connected");
 	atomic_set(&mce_mas->_transport_state, BT_MAP_TRANSPORT_STATE_CONNECTED);
 
-	if (mce_mas->_transport_type == MAP_TRANSPORT_TYPE_L2CAP) {
+	if (mce_mas->goep.v2 != NULL) {
 		if (mce_mas->_cb != NULL && mce_mas->_cb->l2cap_connected != NULL) {
 			mce_mas->_cb->l2cap_connected(conn, mce_mas);
 		}
@@ -405,7 +405,7 @@ static void mce_mas_transport_disconnected(struct bt_goep *goep)
 	atomic_set(&mce_mas->_state, BT_MAP_STATE_DISCONNECTED);
 	mce_mas_clear_pending_request(mce_mas);
 
-	if (mce_mas->_transport_type == MAP_TRANSPORT_TYPE_L2CAP) {
+	if (mce_mas->goep.v2 != NULL) {
 		if (mce_mas->_cb != NULL && mce_mas->_cb->l2cap_disconnected != NULL) {
 			mce_mas->_cb->l2cap_disconnected(mce_mas);
 		}
@@ -436,7 +436,6 @@ static int mce_mas_transport_connect(struct bt_conn *conn, struct bt_map_mce_mas
 	}
 
 	LOG_DBG("MCE MAS transport connecting, type %u", type);
-	mce_mas->_transport_type = type;
 	mce_mas->goep.transport_ops = &mce_mas_transport_ops;
 	atomic_set(&mce_mas->_transport_state, BT_MAP_TRANSPORT_STATE_CONNECTING);
 
@@ -531,7 +530,9 @@ static void mce_mas_connect(struct bt_obex_client *client, uint8_t rsp_code, uin
 		err = bt_obex_get_header_conn_id(buf, &c->_conn_id);
 		if (err != 0) {
 			LOG_ERR("Failed to get connection ID: %d", err);
-			mce_mas_transport_disconnect(c, c->_transport_type);
+			mce_mas_transport_disconnect(c, c->goep.v2 != NULL
+								? MAP_TRANSPORT_TYPE_L2CAP
+								: MAP_TRANSPORT_TYPE_RFCOMM);
 		} else {
 			LOG_DBG("Connection ID: %u", c->_conn_id);
 		}
@@ -1081,7 +1082,7 @@ static void mce_mns_transport_connected(struct bt_conn *conn, struct bt_goep *go
 	LOG_DBG("MCE MNS transport connected");
 	atomic_set(&mce_mns->_transport_state, BT_MAP_TRANSPORT_STATE_CONNECTED);
 
-	if (mce_mns->_transport_type == MAP_TRANSPORT_TYPE_L2CAP) {
+	if (mce_mns->goep.v2 != NULL) {
 		if (mce_mns->_cb != NULL && mce_mns->_cb->l2cap_connected != NULL) {
 			mce_mns->_cb->l2cap_connected(conn, mce_mns);
 		}
@@ -1107,7 +1108,7 @@ static void mce_mns_transport_disconnected(struct bt_goep *goep)
 		LOG_ERR("Failed to unregister obex server: %d", err);
 	}
 
-	if (mce_mns->_transport_type == MAP_TRANSPORT_TYPE_L2CAP) {
+	if (mce_mns->goep.v2 != NULL) {
 		if (mce_mns->_cb != NULL && mce_mns->_cb->l2cap_disconnected != NULL) {
 			mce_mns->_cb->l2cap_disconnected(mce_mns);
 		}
@@ -1350,7 +1351,6 @@ static int mce_mns_accept(struct bt_conn *conn, void *server, uint8_t type, stru
 		return -EINVAL;
 	}
 
-	mce_mns->_transport_type = type;
 	mce_mns->goep.transport_ops = &mce_mns_transport_ops;
 	if (type == MAP_TRANSPORT_TYPE_RFCOMM) {
 		BT_GOEP_INIT_V1(&mce_mns->goep, &mce_mns->goep_transport.v1);
@@ -1637,7 +1637,7 @@ static void mse_mas_transport_connected(struct bt_conn *conn, struct bt_goep *go
 	LOG_DBG("MSE MAS transport connected");
 	atomic_set(&mse_mas->_transport_state, BT_MAP_TRANSPORT_STATE_CONNECTED);
 
-	if (mse_mas->_transport_type == MAP_TRANSPORT_TYPE_L2CAP) {
+	if (mse_mas->goep.v2 != NULL) {
 		if (mse_mas->_cb != NULL && mse_mas->_cb->l2cap_connected != NULL) {
 			mse_mas->_cb->l2cap_connected(conn, mse_mas);
 		}
@@ -1663,7 +1663,7 @@ static void mse_mas_transport_disconnected(struct bt_goep *goep)
 		LOG_ERR("Failed to unregister obex server: %d", err);
 	}
 
-	if (mse_mas->_transport_type == MAP_TRANSPORT_TYPE_L2CAP) {
+	if (mse_mas->goep.v2 != NULL) {
 		if (mse_mas->_cb != NULL && mse_mas->_cb->l2cap_disconnected != NULL) {
 			mse_mas->_cb->l2cap_disconnected(mse_mas);
 		}
@@ -1959,7 +1959,6 @@ static int mse_mas_accept(struct bt_conn *conn, void *server, uint8_t type, stru
 		return -EINVAL;
 	}
 
-	mse_mas->_transport_type = type;
 	mse_mas->goep.transport_ops = &mse_mas_transport_ops;
 	if (type == MAP_TRANSPORT_TYPE_RFCOMM) {
 		BT_GOEP_INIT_V1(&mse_mas->goep, &mse_mas->goep_transport.v1);
@@ -2289,7 +2288,7 @@ static void mse_mns_transport_connected(struct bt_conn *conn, struct bt_goep *go
 	LOG_DBG("MSE MNS transport connected");
 	atomic_set(&mse_mns->_transport_state, BT_MAP_TRANSPORT_STATE_CONNECTED);
 
-	if (mse_mns->_transport_type == MAP_TRANSPORT_TYPE_L2CAP) {
+	if (mse_mns->goep.v2 != NULL) {
 		if (mse_mns->_cb != NULL && mse_mns->_cb->l2cap_connected != NULL) {
 			mse_mns->_cb->l2cap_connected(conn, mse_mns);
 		}
@@ -2309,7 +2308,7 @@ static void mse_mns_transport_disconnected(struct bt_goep *goep)
 	atomic_set(&mse_mns->_state, BT_MAP_STATE_DISCONNECTED);
 	mse_mns_clear_pending_request(mse_mns);
 
-	if (mse_mns->_transport_type == MAP_TRANSPORT_TYPE_L2CAP) {
+	if (mse_mns->goep.v2 != NULL) {
 		if (mse_mns->_cb != NULL && mse_mns->_cb->l2cap_disconnected != NULL) {
 			mse_mns->_cb->l2cap_disconnected(mse_mns);
 		}
@@ -2340,7 +2339,6 @@ static int mse_mns_transport_connect(struct bt_conn *conn, struct bt_map_mse_mns
 	}
 
 	LOG_DBG("MSE MNS transport connecting, type %u", type);
-	mse_mns->_transport_type = type;
 	mse_mns->goep.transport_ops = &mse_mns_transport_ops;
 	atomic_set(&mse_mns->_transport_state, BT_MAP_TRANSPORT_STATE_CONNECTING);
 
@@ -2435,7 +2433,9 @@ static void mse_mns_connect(struct bt_obex_client *client, uint8_t rsp_code, uin
 		err = bt_obex_get_header_conn_id(buf, &c->_conn_id);
 		if (err != 0) {
 			LOG_ERR("Failed to get connection ID: %d", err);
-			mse_mns_transport_disconnect(c, c->_transport_type);
+			mse_mns_transport_disconnect(c, c->goep.v2 != NULL
+								? MAP_TRANSPORT_TYPE_L2CAP
+								: MAP_TRANSPORT_TYPE_RFCOMM);
 		} else {
 			LOG_DBG("Connection ID: %u", c->_conn_id);
 		}


### PR DESCRIPTION
Previously, the code did not return an error when End of Body was absent, which could cause the caller to treat the message as valid. Fix this by returning `-ENODATA` in this case.

Remove the `_transport_type` field from `bt_map_mce_mas`, `bt_map_mce_mns`, `bt_map_mse_mas`, and `bt_map_mse_mns` structures.

Instead, replace all usages of `_transport_type` with `goep.v2` to determine whether the active transport is L2CAP (v2) or RFCOMM (v1), since this information is already encoded in the GOEP instance after BT_GOEP_INIT_V1/V2.
