### PR TITLE
drivers: sdhc: fix R2 response order in intel_emmc_host and sam_hsmci

### DIFF
--- a/drivers/sdhc/intel_emmc_host.c
+++ b/drivers/sdhc/intel_emmc_host.c
@@ -652,10 +652,10 @@ static void update_cmd_response(const struct device *dev, struct sdhc_command *s
 
 		LOG_DBG("cmd resp: %x %x %x %x", resp0, resp1, resp2, resp3);
 
-		sdhc_cmd->response[0u] = resp3;
-		sdhc_cmd->response[1U] = resp2;
-		sdhc_cmd->response[2U] = resp1;
-		sdhc_cmd->response[3U] = resp0;
+		sdhc_cmd->response[0U] = resp0;
+		sdhc_cmd->response[1U] = resp1;
+		sdhc_cmd->response[2U] = resp2;
+		sdhc_cmd->response[3U] = resp3;
 	} else {
 		LOG_DBG("cmd resp: %x", resp0);
 		sdhc_cmd->response[0u] = resp0;

--- a/drivers/sdhc/sam_hsmci.c
+++ b/drivers/sdhc/sam_hsmci.c
@@ -304,10 +304,10 @@ static int sam_hsmci_send_cmd(Hsmci *hsmci, struct sdhc_command *cmd, uint32_t c
 	}
 
 	/* RSPR is just a FIFO, index is of no consequence */
-	cmd->response[3] = hsmci->HSMCI_RSPR[0];
-	cmd->response[2] = hsmci->HSMCI_RSPR[0];
-	cmd->response[1] = hsmci->HSMCI_RSPR[0];
 	cmd->response[0] = hsmci->HSMCI_RSPR[0];
+	cmd->response[1] = hsmci->HSMCI_RSPR[0];
+	cmd->response[2] = hsmci->HSMCI_RSPR[0];
+	cmd->response[3] = hsmci->HSMCI_RSPR[0];
 	return 0;
 }
 


### PR DESCRIPTION
The Zephyr SD subsystem expects a 136-bit R2 response in sdhc_command::response[4] with response[3] holding the most significant 32 bits and response[0] holding the least significant 32 bits.

intel_emmc_host stored the 32-bit fragments in reverse order, so resp3 (bits 127:96) was placed in response[0] and resp0 (bits 31:0) in response[3]. Reverse the assignments.

sam_hsmci read the HSMCI_RSPR FIFO into response[3..0] in the order the FIFO returns data, but that puts the most significant word in response[0]. Read the FIFO into response[0..3] instead, matching the Zephyr layout.

Fixes #112868