### PR TITLE
drivers: i2c_dw: introduce pm device runtime

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1375,11 +1375,6 @@ static int i2c_dw_initialize(const struct device *dev)
 	struct i2c_dw_dev_config *const dw = dev->data;
 	int ret;
 
-	ret = i2c_dw_prepare(dev);
-	if (ret < 0) {
-		return ret;
-	}
-
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
 	if (rom->pcie) {
 		struct pcie_bar mbar;
@@ -1420,6 +1415,12 @@ static int i2c_dw_initialize(const struct device *dev)
 
 	k_sem_init(&dw->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 	k_sem_init(&dw->bus_sem, 1, 1);
+
+	/* Configure clock, optional reset, and pinctrl */
+	ret = i2c_dw_prepare(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
 	/* Check if the hardware is supported and set the support_hs_mode flag */
 	ret = i2c_dw_probe_hw(dev);

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -21,6 +21,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 #include <zephyr/pm/policy.h>
 #include <zephyr/irq.h>
 #include <string.h>
@@ -129,15 +130,23 @@ int i2c_dw_recovery_bus(const struct device *dev)
 	int ret = 0;
 	struct i2c_dw_dev_config *const dw = dev->data;
 
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
 	/* lock bus */
 	ret = k_sem_take(&dw->bus_sem, K_FOREVER);
 	if (ret != 0) {
+		pm_device_runtime_put(dev);
 		return ret;
 	}
 	/* do bus recovery */
 	ret = i2c_recovery_bus(dev);
 	/* unlock bus */
 	k_sem_give(&dw->bus_sem);
+
+	pm_device_runtime_put(dev);
 
 	return ret;
 }
@@ -846,9 +855,15 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 
 	__ASSERT_NO_MSG(msgs);
 
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
 	/* semaphore to support I2C_CALLBACK */
 	ret = k_sem_take(&dw->bus_sem, K_FOREVER);
 	if (ret != 0) {
+		pm_device_runtime_put(dev);
 		return ret;
 	}
 
@@ -1007,10 +1022,12 @@ error:
 	}
 	k_sem_give(&dw->bus_sem);
 
+	pm_device_runtime_put(dev);
+
 	return ret;
 }
 
-static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
+static int i2c_dw_configure(const struct device *dev, uint32_t config)
 {
 	struct i2c_dw_dev_config *const dw = dev->data;
 	const struct i2c_dw_rom_config *const rom = dev->config;
@@ -1077,6 +1094,22 @@ static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
 	dw->app_config |= I2C_MODE_CONTROLLER;
 
 	return rc;
+}
+
+static int i2c_dw_runtime_configure(const struct device *dev, uint32_t config)
+{
+	int ret;
+
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = i2c_dw_configure(dev, config);
+
+	pm_device_runtime_put(dev);
+
+	return 0;
 }
 
 #ifdef CONFIG_I2C_TARGET
@@ -1160,6 +1193,11 @@ static int i2c_dw_slave_register(const struct device *dev, struct i2c_target_con
 	uint32_t reg_base = get_regs(dev);
 	int ret;
 
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
 	dw->read_in_progress = false;
 	dw->slave_cfg = cfg;
 	ret = i2c_dw_set_slave_mode(dev, cfg->address);
@@ -1178,6 +1216,8 @@ static int i2c_dw_slave_unregister(const struct device *dev, struct i2c_target_c
 
 	dw->state = I2C_DW_STATE_READY;
 	ret = i2c_dw_set_master_mode(dev);
+
+	pm_device_runtime_put(dev);
 
 	return ret;
 }
@@ -1275,7 +1315,7 @@ static int i2c_dw_init_config(const struct device *dev)
 
 	dw->app_config = I2C_MODE_CONTROLLER | i2c_map_dt_bitrate(rom->bitrate);
 
-	if (i2c_dw_runtime_configure(dev, dw->app_config) != 0) {
+	if (i2c_dw_configure(dev, dw->app_config) != 0) {
 		return -EIO;
 	}
 
@@ -1355,6 +1395,63 @@ static int i2c_dw_probe_hw(const struct device *dev)
 
 	return 0;
 }
+static int i2c_dw_turn_on(const struct device *dev)
+{
+	const struct i2c_dw_rom_config *const rom = dev->config;
+	int ret;
+
+	/* Configure clock, optional reset, and pinctrl */
+	ret = i2c_dw_prepare(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Check if the hardware is supported and set the support_hs_mode flag */
+	ret = i2c_dw_probe_hw(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Initialize the controller registers */
+	ret = i2c_dw_init_config(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Configure IRQ*/
+	rom->config_func(dev);
+
+	return 0;
+}
+
+static int i2c_dw_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	__maybe_unused const struct i2c_dw_rom_config *const rom = dev->config;
+	__maybe_unused int ret;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		break;
+	case PM_DEVICE_ACTION_TURN_ON:
+		return i2c_dw_turn_on(dev);
+	case PM_DEVICE_ACTION_TURN_OFF:
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(clocks)
+		if (rom->clk_dev != NULL) {
+			ret = clock_control_off(rom->clk_dev, rom->clk_id);
+			if (ret < 0 && ret != -EALREADY && ret != -ENOSYS) {
+				return ret;
+			}
+		}
+#endif
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
 
 static DEVICE_API(i2c, funcs) = {
 	.configure = i2c_dw_runtime_configure,
@@ -1371,9 +1468,8 @@ static DEVICE_API(i2c, funcs) = {
 
 static int i2c_dw_initialize(const struct device *dev)
 {
-	const struct i2c_dw_rom_config *const rom = dev->config;
+	__maybe_unused const struct i2c_dw_rom_config *const rom = dev->config;
 	struct i2c_dw_dev_config *const dw = dev->data;
-	int ret;
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
 	if (rom->pcie) {
@@ -1416,29 +1512,9 @@ static int i2c_dw_initialize(const struct device *dev)
 	k_sem_init(&dw->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 	k_sem_init(&dw->bus_sem, 1, 1);
 
-	/* Configure clock, optional reset, and pinctrl */
-	ret = i2c_dw_prepare(dev);
-	if (ret < 0) {
-		return ret;
-	}
-
-	/* Check if the hardware is supported and set the support_hs_mode flag */
-	ret = i2c_dw_probe_hw(dev);
-	if (ret < 0) {
-		return ret;
-	}
-
-	/* Initialize the controller registers */
-	ret = i2c_dw_init_config(dev);
-	if (ret < 0) {
-		return ret;
-	}
-
-	rom->config_func(dev);
-
 	LOG_DBG("initialize done");
 
-	return ret;
+	return pm_device_driver_init(dev, i2c_dw_pm_action);
 }
 
 #if I2C_DW_PINCTRL_ENABLED
@@ -1553,9 +1629,10 @@ static int i2c_dw_initialize(const struct device *dev)
 	BUILD_ASSERT(DT_INST_PROP_OR(n, sda_hold_tx, 0) <= 0xffff, "Invalid SDA_HOLD_TX value");   \
 	BUILD_ASSERT(DT_INST_PROP_OR(n, sda_hold_rx, 0) <= 0xff, "Invalid SDA_HOLD_RX value");     \
 	static struct i2c_dw_dev_config i2c_##n##_runtime;                                         \
-	I2C_DEVICE_DT_INST_DEFINE(n, i2c_dw_initialize, NULL, &i2c_##n##_runtime,                  \
-				  &i2c_config_dw_##n, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,       \
-				  &funcs);                                                         \
+	PM_DEVICE_DT_INST_DEFINE(n, i2c_dw_pm_action);                                             \
+	I2C_DEVICE_DT_INST_DEFINE(n, i2c_dw_initialize, PM_DEVICE_DT_INST_GET(n),                  \
+				  &i2c_##n##_runtime, &i2c_config_dw_##n, POST_KERNEL,             \
+				  CONFIG_I2C_INIT_PRIORITY, &funcs);                               \
 	I2C_DW_IRQ_CONFIG(n)
 /* clang-format on */
 

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -1240,36 +1240,66 @@ static void i2c_dw_slave_read_clear_intr_bits(const struct device *dev,
 }
 #endif /* CONFIG_I2C_TARGET */
 
-static DEVICE_API(i2c, funcs) = {
-	.configure = i2c_dw_runtime_configure,
-	.transfer = i2c_dw_transfer,
-#ifdef CONFIG_I2C_TARGET
-	.target_register = i2c_dw_slave_register,
-	.target_unregister = i2c_dw_slave_unregister,
-#endif /* CONFIG_I2C_TARGET */
-#ifdef CONFIG_I2C_RTIO
-	.iodev_submit = i2c_iodev_submit_fallback,
-#endif
-	.recover_bus = i2c_dw_recovery_bus,
-};
-
-static int i2c_dw_initialize(const struct device *dev)
+static int i2c_dw_init_config(const struct device *dev)
 {
 	const struct i2c_dw_rom_config *const rom = dev->config;
 	struct i2c_dw_dev_config *const dw = dev->data;
 	union ic_sdahold_register sda_hold;
-	union ic_con_register ic_con;
-	uint32_t reg_base;
-	int ret = 0;
+	uint32_t reg_base = get_regs(dev);
 #ifdef CONFIG_I2C_DW_EXTENDED_SUPPORT
 	uint32_t sda_timeout = rom->sda_timeout_value * CONFIG_I2C_DW_CLOCK_SPEED * 1000;
 	uint32_t scl_timeout = rom->scl_timeout_value * CONFIG_I2C_DW_CLOCK_SPEED * 1000;
 #endif
 
+	clear_bit_enable_en(reg_base);
+
+	/* Set up SDAHOLD timing register */
+	sda_hold.raw = read_sdahold(reg_base);
+	if (rom->sda_hold_tx != SDA_HOLD_INVALID) {
+		sda_hold.bits.sdahold_tx = rom->sda_hold_tx;
+	}
+	if (rom->sda_hold_rx != SDA_HOLD_INVALID) {
+		sda_hold.bits.sdahold_rx = rom->sda_hold_rx;
+	}
+	write_sdahold(sda_hold.raw, reg_base);
+
+	/*
+	 * depending on the IP configuration, we may have to disable block mode in
+	 * controller mode
+	 */
+	clear_bit_enable_block(reg_base);
+
+	/* Set spike length */
+	write_fs_spklen(rom->fs_spk_len, reg_base);
+	write_hs_spklen(rom->hs_spk_len, reg_base);
+
+	dw->app_config = I2C_MODE_CONTROLLER | i2c_map_dt_bitrate(rom->bitrate);
+
+	if (i2c_dw_runtime_configure(dev, dw->app_config) != 0) {
+		return -EIO;
+	}
+
+	dw->state = I2C_DW_STATE_READY;
+#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
+	dw->need_setup = true;
+#endif
+#ifdef CONFIG_I2C_DW_EXTENDED_SUPPORT
+	write_sdatimeout(sda_timeout, reg_base);
+	write_scltimeout(scl_timeout, reg_base);
+#endif
+
+	return 0;
+}
+
+static int i2c_dw_prepare(const struct device *dev)
+{
+	__maybe_unused const struct i2c_dw_rom_config *const rom = dev->config;
+	__maybe_unused int ret;
+
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(clocks)
 	if (rom->clk_dev != NULL) {
 		ret = clock_control_on(rom->clk_dev, rom->clk_id);
-		if (ret < 0) {
+		if (ret < 0 && ret != -EALREADY && ret != -ENOSYS) {
 			LOG_ERR("Failed to enable the clock");
 			return ret;
 		}
@@ -1293,6 +1323,62 @@ static int i2c_dw_initialize(const struct device *dev)
 		}
 	}
 #endif
+
+	return 0;
+}
+
+static int i2c_dw_probe_hw(const struct device *dev)
+{
+	struct i2c_dw_dev_config *const dw = dev->data;
+	union ic_con_register ic_con;
+	uint32_t reg_base = get_regs(dev);
+
+	if (read_comp_type(reg_base) != I2C_DW_MAGIC_KEY) {
+		LOG_DBG("I2C: DesignWare magic key not found, check base "
+			"address. Stopping initialization");
+		return -EIO;
+	}
+
+	/*
+	 * Grab the default value on initialization. This should be set to the
+	 * IC_MAX_SPEED_MODE in the hardware. If it does support high speed we
+	 * can provide support for it.
+	 */
+	ic_con.raw = read_con(reg_base);
+	if (ic_con.bits.speed == I2C_DW_SPEED_HIGH) {
+		LOG_DBG("I2C: high speed supported");
+		dw->support_hs_mode = true;
+	} else {
+		LOG_DBG("I2C: high speed NOT supported");
+		dw->support_hs_mode = false;
+	}
+
+	return 0;
+}
+
+static DEVICE_API(i2c, funcs) = {
+	.configure = i2c_dw_runtime_configure,
+	.transfer = i2c_dw_transfer,
+#ifdef CONFIG_I2C_TARGET
+	.target_register = i2c_dw_slave_register,
+	.target_unregister = i2c_dw_slave_unregister,
+#endif /* CONFIG_I2C_TARGET */
+#ifdef CONFIG_I2C_RTIO
+	.iodev_submit = i2c_iodev_submit_fallback,
+#endif
+	.recover_bus = i2c_dw_recovery_bus,
+};
+
+static int i2c_dw_initialize(const struct device *dev)
+{
+	const struct i2c_dw_rom_config *const rom = dev->config;
+	struct i2c_dw_dev_config *const dw = dev->data;
+	int ret;
+
+	ret = i2c_dw_prepare(dev);
+	if (ret < 0) {
+		return ret;
+	}
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(pcie)
 	if (rom->pcie) {
@@ -1335,67 +1421,20 @@ static int i2c_dw_initialize(const struct device *dev)
 	k_sem_init(&dw->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 	k_sem_init(&dw->bus_sem, 1, 1);
 
-	reg_base = get_regs(dev);
-	clear_bit_enable_en(reg_base);
-
-	/* Set up SDAHOLD timing register */
-	sda_hold.raw = read_sdahold(reg_base);
-	if (rom->sda_hold_tx != SDA_HOLD_INVALID) {
-		sda_hold.bits.sdahold_tx = rom->sda_hold_tx;
-	}
-	if (rom->sda_hold_rx != SDA_HOLD_INVALID) {
-		sda_hold.bits.sdahold_rx = rom->sda_hold_rx;
-	}
-	write_sdahold(sda_hold.raw, reg_base);
-
-	/*
-	 * depending on the IP configuration, we may have to disable block mode in
-	 * controller mode
-	 */
-	clear_bit_enable_block(reg_base);
-
-	/* verify that we have a valid DesignWare register first */
-	if (read_comp_type(reg_base) != I2C_DW_MAGIC_KEY) {
-		LOG_DBG("I2C: DesignWare magic key not found, check base "
-			"address. Stopping initialization");
-		return -EIO;
+	/* Check if the hardware is supported and set the support_hs_mode flag */
+	ret = i2c_dw_probe_hw(dev);
+	if (ret < 0) {
+		return ret;
 	}
 
-	/*
-	 * grab the default value on initialization.  This should be set to the
-	 * IC_MAX_SPEED_MODE in the hardware.  If it does support high speed we
-	 * can move provide support for it
-	 */
-	ic_con.raw = read_con(reg_base);
-	if (ic_con.bits.speed == I2C_DW_SPEED_HIGH) {
-		LOG_DBG("I2C: high speed supported");
-		dw->support_hs_mode = true;
-	} else {
-		LOG_DBG("I2C: high speed NOT supported");
-		dw->support_hs_mode = false;
+	/* Initialize the controller registers */
+	ret = i2c_dw_init_config(dev);
+	if (ret < 0) {
+		return ret;
 	}
 
 	rom->config_func(dev);
 
-	/* Set spike length */
-	write_fs_spklen(rom->fs_spk_len, reg_base);
-	write_hs_spklen(rom->hs_spk_len, reg_base);
-
-	dw->app_config = I2C_MODE_CONTROLLER | i2c_map_dt_bitrate(rom->bitrate);
-
-	if (i2c_dw_runtime_configure(dev, dw->app_config) != 0) {
-		LOG_DBG("I2C: Cannot set default configuration");
-		return -EIO;
-	}
-
-	dw->state = I2C_DW_STATE_READY;
-#if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
-	dw->need_setup = true;
-#endif
-#ifdef CONFIG_I2C_DW_EXTENDED_SUPPORT
-	write_sdatimeout(sda_timeout, reg_base);
-	write_scltimeout(scl_timeout, reg_base);
-#endif
 	LOG_DBG("initialize done");
 
 	return ret;

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -295,6 +295,8 @@
 			interrupts = <13 0>;
 			interrupt-names = "i2c2";
 			clocks = <&clock0 SIWX91X_CLK_ULP_I2C>;
+			power-domains = <&siwx91x_soc_pd>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 
@@ -306,6 +308,8 @@
 			interrupts = <42 0>;
 			interrupt-names = "i2c0";
 			clocks = <&clock0 SIWX91X_CLK_I2C0>;
+			power-domains = <&siwx91x_soc_pd>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 
@@ -317,6 +321,8 @@
 			interrupts = <61 0>;
 			interrupt-names = "i2c1";
 			clocks = <&clock0 SIWX91X_CLK_I2C1>;
+			power-domains = <&siwx91x_soc_pd>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Add device power management and runtime PM support to the DesignWare I2C driver (i2c_dw), and enable it for the SiWG917 I2C controllers in devicetree.

Driver initialization is refactored into focused helpers so hardware bring-up can be deferred to PM_DEVICE_ACTION_TURN_ON when the parent power domain is not active at boot. pm_device_runtime_get() / put() are added around driver API paths that access controller registers (transfer, recover_bus, configure, and target register/unregister).

All snps,designware-i2c instances now use PM_DEVICE_DT_INST_DEFINE(). On platforms without a power domain or zephyr,pm-device-runtime-auto, behavior is unchanged: pm_device_driver_init() runs TURN_ON at boot and leaves the device active.

**Why ?** 

On SiWx91x, I2C controllers can be unpowered while the SoC is in a low-power state. After power is restored, the controller must be brought up again through the TURN_ON path (clock, optional reset/pinctrl, register programming, and IRQ setup). The same pattern applies to other DesignWare I2C users that adopt power-domains and zephyr,pm-device-runtime-auto in devicetree.

Tested on SiWG917 with I2C sensor transfers before and after runtime idle.

Feedback is welcome, especially around the PCIe, MMIO, and DMA init split. This series assumes that PCIe BAR mapping, MMIO mapping, and LPSS DMA setup do not require the I2C clock or pinctrl to be enabled, and therefore keeps that work in i2c_dw_initialize() while deferring clock/reset/pinctrl and controller register access to i2c_dw_turn_on().