### PR TITLE
net: lwm2m: Fix lwm2m observation single path remove

### DIFF
--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -468,7 +468,9 @@ int boot_write_img_confirmed(void)
 		return -EIO;
 	}
 
-	rc = boot_set_next(fa, true, true);
+	if (boot_set_next(fa, true, true) != 0) {
+		rc = -EIO;
+	}
 
 	flash_area_close(fa);
 

--- a/subsys/net/lib/lwm2m/lwm2m_observation.c
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.c
@@ -788,7 +788,7 @@ static void engine_observe_single_path_id_remove(struct lwm2m_ctx *ctx, struct o
 	sys_snode_t *prev_node = NULL;
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&obs->path_list, o_p, tmp, node) {
-		if (o_p->path.obj_id != obj_id && o_p->path.obj_inst_id) {
+		if (o_p->path.obj_id != obj_id) {
 			prev_node = &o_p->node;
 			continue;
 		}


### PR DESCRIPTION
The previous '&& o_p->path.obj_inst_id' would always return false if the obj_inst_id was 0, which would lead to the deletion of all observations for paths <obj_id>/0/<res_id>.
I noticed this after doing 'lwm2m delete 3421/0' which triggered the deletion of all my objects with instance 0.