### PR TITLE
drivers: dac: microchip: fix G1 DAC Kconfig defaults

### DIFF
--- a/drivers/dac/Kconfig.mchp
+++ b/drivers/dac/Kconfig.mchp
@@ -19,18 +19,21 @@ config DAC_MCHP_G1_DIFFERENTIAL
 config DAC_MCHP_G1_REFRESH
 	bool "Refresh Period"
 	depends on SOC_FAMILY_MICROCHIP_SAM_D5X_E5X
+	default y
 	help
 	  Enable refresh period support for G1 DAC
 
 config DAC_MCHP_G1_EXTERNAL_FILTER
 	bool "External Filter"
 	depends on SOC_FAMILY_MICROCHIP_SAM_D5X_E5X
+	default y
 	help
 	  Enable External Filter support for G1 DAC
 
 config DAC_MCHP_G1_OVERSAMPLING_RATIO
 	bool "Oversampling Ratio"
 	depends on SOC_FAMILY_MICROCHIP_SAM_D5X_E5X
+	default y
 	help
 	  Enable Oversampling Ratio support for G1 DAC
 


### PR DESCRIPTION
Enable the following G1 DAC Kconfig options by default for Microchip SAM D5x/E5x devices:
- DAC_MCHP_G1_REFRESH
- DAC_MCHP_G1_EXTERNAL_FILTER
- DAC_MCHP_G1_OVERSAMPLING_RATIO

These Kconfig symbols were introduced during the addition of DAC driver support for PIC32CX SG family devices, but the default enablement for SAM D5x/E5x devices was missed.