### PR TITLE
drivers: timer: stm32_lptim: replace instance selection via `stm32_lp_tick_source` with `zephyr,system-timer`

### DIFF
--- a/boards/antmicro/myra_sip_baseboard/myra_sip_baseboard.dts
+++ b/boards/antmicro/myra_sip_baseboard/myra_sip_baseboard.dts
@@ -19,6 +19,7 @@
 		zephyr,flash = &flash0;
 		zephyr,canbus = &fdcan1;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds: leds {
@@ -133,7 +134,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";

--- a/boards/arduino/uno_q/arduino_uno_q-common.dtsi
+++ b/boards/arduino/uno_q/arduino_uno_q-common.dtsi
@@ -12,6 +12,10 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
+	chosen {
+		zephyr,system-timer = &lptim1;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 
@@ -92,7 +96,7 @@
 	apb3-prescaler = <1>;
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB3, 11)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/canmodule/canbridge_g473/canbridge_g473.dts
+++ b/boards/canmodule/canbridge_g473/canbridge_g473.dts
@@ -15,6 +15,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &fdcan1;
+		zephyr,system-timer = &lptim1;
 	};
 
 	aliases {
@@ -77,7 +78,7 @@
 	apb2-prescaler = <1>;
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/canmodule/usbcanfd_dual/usbcanfd_dual.dts
+++ b/boards/canmodule/usbcanfd_dual/usbcanfd_dual.dts
@@ -15,6 +15,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &fdcan1;
+		zephyr,system-timer = &lptim1;
 	};
 
 	aliases {
@@ -77,7 +78,7 @@
 	apb2-prescaler = <1>;
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/canmodule/usbcanfd_solo/usbcanfd_solo.dts
+++ b/boards/canmodule/usbcanfd_solo/usbcanfd_solo.dts
@@ -15,6 +15,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &fdcan1;
+		zephyr,system-timer = &lptim1;
 	};
 
 	aliases {
@@ -64,7 +65,7 @@
 	apb2-prescaler = <1>;
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/eurovibes/sertest-ng/eurovibes_stm32g431_sertest-ng.dts
+++ b/boards/eurovibes/sertest-ng/eurovibes_stm32g431_sertest-ng.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &fdcan1;
+		zephyr,system-timer = &lptim1;
 	};
 
 	aliases {
@@ -193,7 +194,7 @@
 		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	status = "okay";
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;

--- a/boards/makerbase/mks_canable_v20/mks_canable_v20.dts
+++ b/boards/makerbase/mks_canable_v20/mks_canable_v20.dts
@@ -15,6 +15,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &fdcan1;
+		zephyr,system-timer = &lptim1;
 	};
 
 	aliases {
@@ -66,7 +67,7 @@
 	apb2-prescaler = <1>;
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/olimex/lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
+++ b/boards/olimex/lora_stm32wl_devkit/olimex_lora_stm32wl_devkit.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds {
@@ -47,7 +48,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";

--- a/boards/rakwireless/rak3172/rak3172.dts
+++ b/boards/rakwireless/rak3172/rak3172.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds {
@@ -41,7 +42,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/seeed/lora_e5_dev_board/lora_e5_dev_board.dts
+++ b/boards/seeed/lora_e5_dev_board/lora_e5_dev_board.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds {
@@ -81,7 +82,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	status = "okay";
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;

--- a/boards/seeed/lora_e5_mini/lora_e5_mini.dts
+++ b/boards/seeed/lora_e5_mini/lora_e5_mini.dts
@@ -18,6 +18,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds {
@@ -47,7 +48,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	status = "okay";
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;

--- a/boards/st/b_g474e_dpow1/b_g474e_dpow1.dts
+++ b/boards/st/b_g474e_dpow1/b_g474e_dpow1.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds {
@@ -104,7 +105,7 @@
 	status = "okay";
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -13,6 +13,10 @@
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
 / {
+	chosen {
+		zephyr,system-timer = &lptim1;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 
@@ -85,7 +89,7 @@
 	apb3-prescaler = <1>;
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB3, 11)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/st/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.dts
@@ -23,6 +23,7 @@
 		zephyr,flash-controller = &mx25r6435f;
 		zephyr,bt-c2h-uart = &usart1;
 		zephyr,bt-hci = &hci_spi;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds {
@@ -279,7 +280,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -21,6 +21,7 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram1;
+		zephyr,system-timer = &lptim1;
 		zephyr,flash = &flash0;
 	};
 
@@ -208,7 +209,7 @@
 	status = "okay";
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB3, 11)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(2)>;
 	status = "okay";

--- a/boards/st/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/st/nucleo_g071rb/nucleo_g071rb.dts
@@ -22,6 +22,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds: leds {
@@ -204,7 +205,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";

--- a/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -23,6 +23,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,canbus = &fdcan1;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds: leds {
@@ -236,7 +237,7 @@ zephyr_udc0: &usb {
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";

--- a/boards/st/nucleo_g431kb/nucleo_g431kb.dts
+++ b/boards/st/nucleo_g431kb/nucleo_g431kb.dts
@@ -17,6 +17,7 @@
 		zephyr,shell-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds: leds {
@@ -51,7 +52,7 @@
 	status = "okay";
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";

--- a/boards/st/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/st/nucleo_g431rb/nucleo_g431rb.dts
@@ -21,6 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds: leds {
@@ -154,7 +155,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/st/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/st/nucleo_g474re/nucleo_g474re.dts
@@ -22,6 +22,7 @@
 		zephyr,flash = &flash0;
 		zephyr,canbus = &fdcan1;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds: leds {
@@ -161,7 +162,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";

--- a/boards/st/nucleo_g491re/nucleo_g491re.dts
+++ b/boards/st/nucleo_g491re/nucleo_g491re.dts
@@ -21,6 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds: leds {
@@ -164,7 +165,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -12,6 +12,10 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
+	chosen {
+		zephyr,system-timer = &lptim4;
+	};
+
 	leds: leds {
 		compatible = "gpio-leds";
 
@@ -299,7 +303,7 @@ zephyr_udc0: &usb {
 	status = "okay";
 };
 
-stm32_lp_tick_source: &lptim4 {
+&lptim4 {
 	clocks = <&rcc STM32_CLOCK(APB3, 13)>,
 		 <&rcc STM32_SRC_LSI LPTIM4_SEL(4)>;
 	status = "okay";

--- a/boards/st/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/st/nucleo_l073rz/nucleo_l073rz.dts
@@ -21,6 +21,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds: leds {
@@ -93,7 +94,7 @@
 	apb2-prescaler = <1>;
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	/*
 	 * LSI freq is 37KHz but stm32_lptim driver is using 32000Hz
 	 * resulting in time running 1.13 faster than reality

--- a/boards/st/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/st/nucleo_l476rg/nucleo_l476rg.dts
@@ -20,6 +20,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds: leds {
@@ -78,7 +79,7 @@
 	apb2-prescaler = <1>;
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.dts
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.dts
@@ -19,6 +19,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds: leds {
@@ -147,7 +148,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";

--- a/boards/st/nucleo_u545re_q/nucleo_u545re_q.dts
+++ b/boards/st/nucleo_u545re_q/nucleo_u545re_q.dts
@@ -21,6 +21,7 @@
 		zephyr,flash = &flash0;
 		zephyr,canbus = &fdcan1;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	aliases {
@@ -248,7 +249,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB3, 11)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";

--- a/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -11,6 +11,10 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
+	chosen {
+		zephyr,system-timer = &lptim1;
+	};
+
 	leds: leds {
 		compatible = "gpio-leds";
 
@@ -216,7 +220,7 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB3, 11)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";

--- a/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -22,6 +22,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds: leds {
@@ -202,7 +203,7 @@
 	status = "okay";
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.dts
+++ b/boards/st/nucleo_wba25ce1/nucleo_wba25ce1.dts
@@ -21,6 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	/*
@@ -188,7 +189,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB7, 11)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -22,6 +22,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	/*
@@ -213,7 +214,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB7, 11)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -21,6 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	/*
@@ -174,7 +175,7 @@
 	status = "okay";
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB7, 11)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -21,6 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds: leds {
@@ -82,7 +83,7 @@
 	status = "okay";
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";

--- a/boards/st/sensortile_box_pro/sensortile_box_pro.dts
+++ b/boards/st/sensortile_box_pro/sensortile_box_pro.dts
@@ -18,6 +18,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &hci_spi;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds {
@@ -125,7 +126,7 @@
 	apb3-prescaler = <1>;
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB3, 11)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/st/steval_stwinbx1/steval_stwinbx1.dts
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.dts
@@ -19,6 +19,7 @@
 		zephyr,code-partition = &slot0_partition;
 
 		zephyr,bt-hci = &hci_spi;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds {
@@ -137,7 +138,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB3, 11)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -45,6 +45,7 @@
 
 	chosen {
 		zephyr,bt-hci = &hci_spi;
+		zephyr,system-timer = &lptim1;
 	};
 };
 
@@ -151,7 +152,7 @@
 	apb2-prescaler = <1>;
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.dts
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.dts
@@ -22,6 +22,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim2;
 	};
 
 	leds: leds {
@@ -156,7 +157,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim2 {
+&lptim2 {
 	clocks = <&rcc STM32_CLOCK(APB1, 30)>,
 		 <&rcc STM32_SRC_LSI LPTIM2_SEL(1)>;
 	status = "okay";

--- a/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
+++ b/boards/st/stm32wba65i_dk1/stm32wba65i_dk1.dts
@@ -21,6 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	/*
@@ -189,7 +190,7 @@
 	status = "okay";
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB7, 11)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/we/oceanus1ev/we_oceanus1ev.dts
+++ b/boards/we/oceanus1ev/we_oceanus1ev.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds {
@@ -52,7 +53,7 @@
 	};
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/boards/weact/blackpill_u585ci/blackpill_u585ci.dts
+++ b/boards/weact/blackpill_u585ci/blackpill_u585ci.dts
@@ -21,6 +21,7 @@
 		zephyr,flash = &flash0;
 		zephyr,canbus = &fdcan1;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	aliases {
@@ -257,7 +258,7 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB3, 11)>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";

--- a/boards/weact/stm32g431_core/weact_stm32g431_core.dts
+++ b/boards/weact/stm32g431_core/weact_stm32g431_core.dts
@@ -19,6 +19,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,system-timer = &lptim1;
 	};
 
 	aliases {
@@ -122,7 +123,7 @@
 		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	status = "okay";
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;

--- a/boards/weact/stm32h562_core/weact_stm32h562_core.dts
+++ b/boards/weact/stm32h562_core/weact_stm32h562_core.dts
@@ -19,6 +19,7 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash0;
+		zephyr,system-timer = &lptim4;
 	};
 
 	aliases {
@@ -103,7 +104,7 @@
 	status = "okay";
 };
 
-stm32_lp_tick_source: &lptim4 {
+&lptim4 {
 	clocks = <&rcc STM32_CLOCK(APB3, 13)>,
 		 <&rcc STM32_SRC_LSI LPTIM4_SEL(4)>;
 	status = "okay";

--- a/boards/weact/stm32wb55_core/weact_stm32wb55_core.dts
+++ b/boards/weact/stm32wb55_core/weact_stm32wb55_core.dts
@@ -21,6 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,system-timer = &lptim1;
 	};
 
 	leds: leds {
@@ -165,7 +166,7 @@
 	status = "okay";
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -551,9 +551,15 @@ device.
        available to the Zephyr image, used during linking
    * - zephyr,system-timer
      - Selects the hardware timer instance used as the Zephyr system timer,
-       which is a singleton system-wide function. Use this when devicetree
-       selects which timer instance provides the system timer, even if other
-       identical timer instances are used by other APIs.
+       which is a singleton system-wide function. This chosen is needed when the
+       selected system timer driver corresponds to timer hardware for which multiple
+       instances may exist: it selects one instance as the system timer and allows
+       using the other instances with other APIs. This chosen is ignored when the
+       selected system timer driver corresponds to timer hardware for which only one
+       instance may ever exist, such as the Cortex-M SysTick timer; otherwise, it
+       must corresponds to a node that the selected system timer driver can operate.
+       (Note: the Zephyr system timer *driver* is selected using Kconfig options such
+       as :kconfig:option:`CONFIG_CORTEX_M_SYSTICK` - not Devicetree!)
    * - zephyr,system-timer-companion
      - Selects the device used to keep time while the primary system timer is
        inactive in low-power states. It must implement the :ref:`counter_api` API.

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -619,6 +619,10 @@ STM32
 
 * Renamed Kconfig option ``CONFIG_STM32_MEMMAP`` to :kconfig:option:`CONFIG_FLASH_STM32_NOR_MEMMAP`.
 
+* Using the ``stm32_lp_tick_source`` nodelabel to select an LPTIM as system timer is no longer supported
+  and will trigger a build error. Use the :ref:`generic chosen <devicetree-zephyr-chosen-nodes>`
+  ``zephyr,system-timer`` instead. (:github:`112999`)
+
 Syscon
 ======
 

--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -4,12 +4,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 DT_CHOSEN_STDBY_TIMER := st,lptim-stdby-timer
-DT_STM32_LPTIM_PATH := $(dt_nodelabel_path,stm32_lp_tick_source)
+DT_CHOSEN_Z_SYSTEM_TIMER := zephyr,system-timer
+DT_CHOSEN_Z_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_Z_SYSTEM_TIMER))
+
+# Selecting an LPTIM as system timer by using the `stm32_lp_tick_source` nodelabel
+# is no longer supported since Zephyr v4.5; instead, the selection should be done
+# using the standard `zephyr,system-timer` chosen. Detect the old mechanism and
+# break build if found, with an hopefully helpful error message.
+$(error-if,$(dt_nodelabel_has_compat,stm32_lp_tick_source,$(DT_COMPAT_ST_STM32_LPTIM)),\
+Detected usage of deprecated nodelabel `stm32_lp_tick_source` to select system timer. \
+Please use the `$(DT_CHOSEN_Z_SYSTEM_TIMER)` chosen to select LPTIM instance instead.)
 
 menuconfig STM32_LPTIM_TIMER
 	bool "STM32 Low Power Timer [EXPERIMENTAL]"
 	default y
-	depends on $(dt_nodelabel_exists,stm32_lp_tick_source)
+	depends on $(dt_chosen_has_compat,$(DT_CHOSEN_Z_SYSTEM_TIMER),$(DT_COMPAT_ST_STM32_LPTIM))
+	depends on $(dt_chosen_enabled,$(DT_CHOSEN_Z_SYSTEM_TIMER))
 	depends on DT_HAS_ST_STM32_LPTIM_ENABLED
 	depends on CLOCK_CONTROL && PM
 	select RESET
@@ -24,13 +34,16 @@ if STM32_LPTIM_TIMER
 # Invisible symbols exposing the selected LPTIM source to Kconfig
 # NOTE: the values 2/3 correspond too STM32_SRC_LSE/STM32_SRC_LSI
 # defined in include/zephyr/dt-bindings/clock/stm32_common_clocks.h
+STM32_LPTIM_SYSTIMER_CLK_SRC := \
+	$(dt_node_ph_array_prop_int,$(DT_CHOSEN_Z_SYSTEM_TIMER_PATH),clocks,1,bus)
+
 config STM32_LPTIM_CLOCK_LSI
-	def_bool "$(dt_node_ph_array_prop_int,$(DT_STM32_LPTIM_PATH),clocks,1,bus)" = 3
+	def_bool $(STM32_LPTIM_SYSTIMER_CLK_SRC) = 3
 	help
 	  LSI used as LPTIM clock source
 
 config STM32_LPTIM_CLOCK_LSE
-	def_bool "$(dt_node_ph_array_prop_int,$(DT_STM32_LPTIM_PATH),clocks,1,bus)" = 2
+	def_bool $(STM32_LPTIM_SYSTIMER_CLK_SRC) = 2
 	help
 	  LSE used as LPTIM clock source
 

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -23,17 +23,16 @@
 
 #include <zephyr/spinlock.h>
 
+/* Define for grep-ability, even though this will not be used */
 #define DT_DRV_COMPAT st_stm32_lptim
 
-#if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) > 1
-#error Only one LPTIM instance should be enabled
-#endif
+#define LPTIM_SYSTIMER_NODE DT_CHOSEN(zephyr_system_timer)
 
-#if DT_INST_NUM_CLOCKS(0) <= 1
+#if DT_NUM_CLOCKS(LPTIM_SYSTIMER_NODE) <= 1
 #error "LPTIM source clock must be provided in Device Tree"
 #endif
 
-#define LPTIM (LPTIM_TypeDef *) DT_INST_REG_ADDR(0)
+#define LPTIM ((LPTIM_TypeDef *)DT_REG_ADDR(LPTIM_SYSTIMER_NODE))
 
 #if defined(CONFIG_SOC_SERIES_STM32MP1X)
 #define LL_LPTIM_ClearFlag_ARRM  LL_LPTIM_ClearFLAG_ARRM
@@ -52,11 +51,11 @@
 #define STM32_LPTIM_PRELOAD_ENABLED    LL_LPTIM_UPDATE_MODE_ENDOFPERIOD
 #endif /* CONFIG_STM32_HAL2 */
 
-static const struct stm32_pclken lptim_clk[] = STM32_DT_INST_CLOCKS(0);
+static const struct stm32_pclken lptim_clk[] = STM32_DT_CLOCKS(LPTIM_SYSTIMER_NODE);
 
 static const struct device *const clk_ctrl = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-static const struct reset_dt_spec lptim_reset = RESET_DT_SPEC_INST_GET(0);
+static const struct reset_dt_spec lptim_reset = RESET_DT_SPEC_GET(LPTIM_SYSTIMER_NODE);
 
 /*
  * Assumptions and limitations:
@@ -76,7 +75,7 @@ static const struct reset_dt_spec lptim_reset = RESET_DT_SPEC_INST_GET(0);
 static int32_t lptim_time_base;
 static uint32_t lptim_clock_freq = CONFIG_STM32_LPTIM_CLOCK;
 /* The prescaler given by the DTS and to apply to the lptim_clock_freq */
-static uint32_t lptim_clock_presc = DT_PROP(DT_DRV_INST(0), st_prescaler);
+static uint32_t lptim_clock_presc = DT_PROP(LPTIM_SYSTIMER_NODE, st_prescaler);
 
 /* Minimum nb of clock cycles to have to set autoreload register correctly */
 #define LPTIM_GUARD_VALUE 2
@@ -370,7 +369,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 		LL_LPTIM_DisableIT_ARROK(LPTIM);
 		LL_LPTIM_ClearFlag_ARROK(LPTIM);
-		NVIC_ClearPendingIRQ(DT_INST_IRQN(0));
+		NVIC_ClearPendingIRQ(DT_IRQN(LPTIM_SYSTIMER_NODE));
 		/* Stop clocks for LPTIM, since RTC is used instead */
 		clock_control_off(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
 
@@ -577,8 +576,8 @@ static int sys_clock_driver_init(void)
 	}
 #endif
 
-#if DT_NODE_HAS_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout)
-	uint32_t timeout = DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout);
+#if DT_NODE_HAS_PROP(LPTIM_SYSTIMER_NODE, st_timeout)
+	uint32_t timeout = DT_PROP(LPTIM_SYSTIMER_NODE, st_timeout);
 
 	if (timeout > (lptim_clock_presc * 0xFFFF) / lptim_clock_freq) {
 		__ASSERT(0,
@@ -624,10 +623,10 @@ static int sys_clock_driver_init(void)
 	lptim_clock_freq = lptim_clock_freq / lptim_clock_presc;
 
 	/* Clear the event flag and possible pending interrupt */
-	IRQ_CONNECT(DT_INST_IRQN(0),
-		    DT_INST_IRQ(0, priority),
+	IRQ_CONNECT(DT_IRQN(LPTIM_SYSTIMER_NODE),
+		    DT_IRQ(LPTIM_SYSTIMER_NODE, priority),
 		    lptim_irq_handler, 0, 0);
-	irq_enable(DT_INST_IRQN(0));
+	irq_enable(DT_IRQN(LPTIM_SYSTIMER_NODE));
 
 #ifdef CONFIG_SOC_SERIES_STM32WLX
 	/* Enable the LPTIM wakeup EXTI line */

--- a/dts/bindings/timer/st,stm32-lptim.yaml
+++ b/dts/bindings/timer/st,stm32-lptim.yaml
@@ -53,9 +53,17 @@ properties:
 
 examples:
   - |
-    stm32_lp_tick_source: &lptim1 {
+    /*
+     * Usage of LPTIM as system timer:
+     * (1) enable and configure selected LPTIM instance
+     */
+    &lptim1 {
       status = "okay";
     }
 
-    The lptim node to be used for counting ticks during lowpower modes
-    must be named stm32_lp_tick_source in the DTS.
+    /* (2) select instance as system timer */
+    / {
+      chosen {
+        zephyr,system-timer = &lptim1;
+      };
+    };

--- a/samples/boards/st/power_mgmt/blinky/README.rst
+++ b/samples/boards/st/power_mgmt/blinky/README.rst
@@ -9,12 +9,14 @@ Overview
 This sample is a minimum application to demonstrate basic power management
 behavior in a basic blinking LED set up using the :ref:`GPIO API <gpio_api>` in
 low power context.
-Note that lptim instance selected for the low power timer is named **&stm32_lp_tick_source**
-When setting a prescaler to decrease the lptimer input clock frequency, the system can sleep
-for a longer  timeout value and the CONFIG_SYS_CLOCK_TICKS_PER_SEC is adjusted.
-For example, when clocking the  low power Timer with LSE clock at 32768Hz and adding a
-prescaler of <32>, then the kernel sleep period can reach 65536 * 32/32768 = 64 seconds
-CONFIG_SYS_CLOCK_TICKS_PER_SEC is set to 1024.
+
+The LPTIM instance used as system timer is chosen in Devicetree using the
+:ref:`standardized chosen <devicetree-zephyr-chosen-nodes>` ``zephyr,system-timer``.
+When setting a prescaler to decrease the LPTIM input clock frequency, the system can
+sleep for a longer timeout value and :kconfig:option:`CONFIG_SYS_CLOCK_TICKS_PER_SEC`
+is adjusted. For example, when clocking the LPTIM with LSE clock at 32768Hz and adding
+a prescaler of <32>, then the kernel sleep period can reach 65536 * 32/32768 = 64 seconds,
+and :kconfig:option:`CONFIG_SYS_CLOCK_TICKS_PER_SEC` is set to 1024.
 
 .. _stm32-pm-blinky-sample-requirements:
 

--- a/samples/boards/st/power_mgmt/blinky/boards/arduino_uno_q.overlay
+++ b/samples/boards/st/power_mgmt/blinky/boards/arduino_uno_q.overlay
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&stm32_lp_tick_source {
+&lptim1 {
 	/*
 	 * Default LPTIM period is 2 seconds. This means that application will
 	 * be woken up every 2 seconds to reload its counter.

--- a/samples/boards/st/power_mgmt/blinky/boards/b_u585i_iot02a.overlay
+++ b/samples/boards/st/power_mgmt/blinky/boards/b_u585i_iot02a.overlay
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&stm32_lp_tick_source {
+&lptim1 {
 	/*
 	 * Default LPTIM period is 2 seconds. This means that application will
 	 * be woken up every 2 seconds to reload its counter.

--- a/samples/boards/st/power_mgmt/blinky/boards/nucleo_wb55rg.overlay
+++ b/samples/boards/st/power_mgmt/blinky/boards/nucleo_wb55rg.overlay
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&stm32_lp_tick_source {
+&lptim1 {
 	/*
 	 * Default LPTIM period is 2 seconds. This means that application will
 	 * be woken up every 2 seconds to reload its counter.

--- a/samples/boards/st/power_mgmt/blinky/boards/nucleo_wba55cg.overlay
+++ b/samples/boards/st/power_mgmt/blinky/boards/nucleo_wba55cg.overlay
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&stm32_lp_tick_source {
+&lptim1 {
 	/*
 	 * Default LPTIM period is 2 seconds. This means that application will
 	 * be woken up every 2 seconds to reload its counter.

--- a/samples/boards/st/power_mgmt/blinky/src/main.c
+++ b/samples/boards/st/power_mgmt/blinky/src/main.c
@@ -11,7 +11,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/pm/device_runtime.h>
 
-#if DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout)
+#if DT_NODE_HAS_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout)
 /* st,timeout is set. Application can be woken up exactly on expected tick */
 #define SLEEP_TIME_MS   (DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout) * 1000)
 #else

--- a/samples/boards/st/power_mgmt/blinky/src/main.c
+++ b/samples/boards/st/power_mgmt/blinky/src/main.c
@@ -12,9 +12,9 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/pm/device_runtime.h>
 
-#if DT_NODE_HAS_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout)
+#if DT_NODE_HAS_PROP(DT_CHOSEN(zephyr_system_timer), st_timeout)
 /* st,timeout is set. Application can be woken up exactly on expected tick */
-#define SLEEP_TIME_MS   (DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout) * 1000)
+#define SLEEP_TIME_MS   (DT_PROP(DT_CHOSEN(zephyr_system_timer), st_timeout) * 1000)
 #else
 #define SLEEP_TIME_MS   2000
 #endif

--- a/samples/boards/st/power_mgmt/blinky/src/main.c
+++ b/samples/boards/st/power_mgmt/blinky/src/main.c
@@ -8,6 +8,7 @@
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/clock.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/pm/device_runtime.h>
 
@@ -35,7 +36,7 @@ int main(void)
 	 */
 	DT_FOREACH_STATUS_OKAY(st_stm32_gpio, STM32_GPIO_PM_ENABLE)
 
-	printk("Device ready\n");
+	printk("Blinking every %u seconds\n", SLEEP_TIME_MS / MSEC_PER_SEC);
 
 	while (true) {
 		gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);

--- a/samples/boards/st/power_mgmt/blinky/tests.yaml
+++ b/samples/boards/st/power_mgmt/blinky/tests.yaml
@@ -9,7 +9,7 @@ tests:
     harness_config:
       type: one_line
       regex:
-        - "Device ready"
+        - "Blinking every [0-9]+ seconds\n"
     filter: dt_compat_enabled("zephyr,power-state") and
             dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
             (dt_compat_enabled("st,stm32-lptim") or

--- a/soc/st/stm32/Kconfig.defconfig
+++ b/soc/st/stm32/Kconfig.defconfig
@@ -76,7 +76,11 @@ DT_STM32WB0_RADIO_TIMER_PATH := $(dt_nodelabel_path,radio_timer)
 DT_STM32WB0_TIMER_FREQ := $(dt_node_int_prop_int,$(DT_STM32WB0_RADIO_TIMER_PATH),compensated-timer-freq)
 
 DT_ST_PRESCALER := st,prescaler
-DT_STM32_LPTIM_PATH := $(dt_nodelabel_path,stm32_lp_tick_source)
+DT_CHOSEN_Z_SYSTEM_TIMER := zephyr,system-timer
+DT_CHOSEN_Z_SYSTEM_TIMER_PATH := \
+	$(dt_chosen_path,$(DT_CHOSEN_Z_SYSTEM_TIMER))
+DT_STM32_LPTIM_SYSTIMER_PRESCALER := \
+	$(dt_node_int_prop_int,$(DT_CHOSEN_Z_SYSTEM_TIMER_PATH),$(DT_ST_PRESCALER))
 
 DT_CHOSEN_Z_FLASH := zephyr,flash
 
@@ -107,19 +111,19 @@ config SYS_CLOCK_TICKS_PER_SEC
 # with a minimum value of 4096 for SYS_CLOCK_TICKS_PER_SEC to keep
 # SYS_CLOCK_TICKS_PER_SEC not too high compared to the LPTIM counter clock
 config SYS_CLOCK_TICKS_PER_SEC
-	default 4096 if "$(dt_node_int_prop_int,$(DT_STM32_LPTIM_PATH),$(DT_ST_PRESCALER))" < 16
-	default 2048 if "$(dt_node_int_prop_int,$(DT_STM32_LPTIM_PATH),$(DT_ST_PRESCALER))" = 16
-	default 1024 if "$(dt_node_int_prop_int,$(DT_STM32_LPTIM_PATH),$(DT_ST_PRESCALER))" = 32
-	default  512 if "$(dt_node_int_prop_int,$(DT_STM32_LPTIM_PATH),$(DT_ST_PRESCALER))" = 64
-	default  256 if "$(dt_node_int_prop_int,$(DT_STM32_LPTIM_PATH),$(DT_ST_PRESCALER))" = 128
+	default 4096 if "$(DT_STM32_LPTIM_SYSTIMER_PRESCALER)" < 16
+	default 2048 if "$(DT_STM32_LPTIM_SYSTIMER_PRESCALER)" = 16
+	default 1024 if "$(DT_STM32_LPTIM_SYSTIMER_PRESCALER)" = 32
+	default  512 if "$(DT_STM32_LPTIM_SYSTIMER_PRESCALER)" = 64
+	default  256 if "$(DT_STM32_LPTIM_SYSTIMER_PRESCALER)" = 128
 	depends on STM32_LPTIM_TIMER && STM32_LPTIM_CLOCK_LSE
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 4000 if "$(dt_node_int_prop_int,$(DT_STM32_LPTIM_PATH),$(DT_ST_PRESCALER))" < 16
-	default 2000 if "$(dt_node_int_prop_int,$(DT_STM32_LPTIM_PATH),$(DT_ST_PRESCALER))" = 16
-	default 1000 if "$(dt_node_int_prop_int,$(DT_STM32_LPTIM_PATH),$(DT_ST_PRESCALER))" = 32
-	default  500 if "$(dt_node_int_prop_int,$(DT_STM32_LPTIM_PATH),$(DT_ST_PRESCALER))" = 64
-	default  250 if "$(dt_node_int_prop_int,$(DT_STM32_LPTIM_PATH),$(DT_ST_PRESCALER))" = 128
+	default 4000 if "$(DT_STM32_LPTIM_SYSTIMER_PRESCALER)" < 16
+	default 2000 if "$(DT_STM32_LPTIM_SYSTIMER_PRESCALER)" = 16
+	default 1000 if "$(DT_STM32_LPTIM_SYSTIMER_PRESCALER)" = 32
+	default  500 if "$(DT_STM32_LPTIM_SYSTIMER_PRESCALER)" = 64
+	default  250 if "$(DT_STM32_LPTIM_SYSTIMER_PRESCALER)" = 128
 	depends on STM32_LPTIM_TIMER && STM32_LPTIM_CLOCK_LSI
 
 config CLOCK_CONTROL_INIT_PRIORITY


### PR DESCRIPTION
Nodelabel `stm32_lp_tick_source` was used to select the LPTIM instance to use as system timer on STM32 for historical reasons. Since a generic mechanism is now available for this purpose, replace the old the vendor-specific nodelabel-based mechanism with the new method: chosen `zephyr,system-timer`.

Tested by running `samples/boards/st/power_mgmt/blinky` on boards `b_u585i_iot02a`, `nucleo_wb55rg` and `nucleo_wba55cg`. While at it, I made a small change to this sample to simplify its usage (last commit in patchset).

> [!NOTE]
> For historical reasons, the `zephyr,system-timer` chosen is *not* involved in the selection of the System Timer driver. As a result, SysTick will continue to be the System Timer for boards updated by this PR despite `zephyr,system-timer = &lptimN;` unless the STM32 LPTIM driver is explicitly enabled via Kconfig. (This is identical to the current behavior - this PR does not bring any change on this aspect)
>
> This discrepancy is already present in tree and outside this PR's scope; it should be addressed at a global level instead.