### PR TITLE
MAINTAINERS: add tests to the twister area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6181,6 +6181,11 @@ Twister:
     - scripts/pylib/*-twister-harness/
   labels:
     - "area: Twister"
+  tests:
+    - kernel.common
+    - sample.pytest
+    - sample.harness
+    - sample.twister
 
 USB:
   status: maintained


### PR DESCRIPTION
Add some coverage to the twister area to be able to cover twister
changes in CI.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
