### PR TITLE
boards: st: *: fix duplicate scl-gpios/sca-gpios properties

### DIFF
--- a/boards/st/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/st/nucleo_f303re/nucleo_f303re.dts
@@ -101,13 +101,11 @@
 
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
-	status = "okay";
 	pinctrl-names = "default";
-	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
-	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
+	status = "okay";
 };
 
 &spi1 {

--- a/boards/st/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/st/nucleo_f446re/nucleo_f446re.dts
@@ -101,30 +101,28 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
-	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb3>;
 	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
 	scl-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 	status = "okay";
-	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pb4>;
 	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
 	scl-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
 	status = "okay";
-	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi1 {

--- a/boards/st/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/st/nucleo_g474re/nucleo_g474re.dts
@@ -116,8 +116,6 @@
 	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	status = "okay";
-	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
-	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 };
 
 &spi1 {

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -147,12 +147,10 @@ zephyr_udc0: &usbotg_fs {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
-	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
+	status = "okay";
 };
 
 &timers12 {

--- a/boards/st/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/st/nucleo_l476rg/nucleo_l476rg.dts
@@ -107,12 +107,10 @@ stm32_lp_tick_source: &lptim1 {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
-	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	scl-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
+	status = "okay";
 };
 
 &i2c3 {


### PR DESCRIPTION
Due to a conflict between two PRs (#110161 and #110459), the properties have been added twice to the same I2C nodes of some ST boards. Remove the duplicate entries to silence a CI compliance check failure (seen in #112999).

While at it, also reorder properties such that `status = "okay"` is always the last property set in the nodes.