### PR TITLE
modem: ubx: wait for transmit idle in modem_ubx_run_script

### DIFF
--- a/include/zephyr/modem/ubx.h
+++ b/include/zephyr/modem/ubx.h
@@ -78,6 +78,7 @@ struct modem_ubx {
 	struct modem_pipe *pipe;
 	struct k_work process_work;
 	struct k_sem script_stopped_sem;
+	struct k_sem script_sent_sem;
 	struct k_sem script_running_sem;
 	struct {
 		const struct modem_ubx_match *array;

--- a/include/zephyr/modem/ubx.h
+++ b/include/zephyr/modem/ubx.h
@@ -78,6 +78,8 @@ struct modem_ubx {
 	struct modem_pipe *pipe;
 	struct k_work process_work;
 	struct k_sem script_stopped_sem;
+	/** Signal that the script has been transmitted */
+	struct k_sem script_sent_sem;
 	struct k_sem script_running_sem;
 	struct {
 		const struct modem_ubx_match *array;

--- a/subsys/modem/modem_ubx.c
+++ b/subsys/modem/modem_ubx.c
@@ -22,6 +22,8 @@ static void modem_ubx_pipe_callback(struct modem_pipe *pipe,
 
 	if (event == MODEM_PIPE_EVENT_RECEIVE_READY) {
 		modem_work_submit(&ubx->process_work);
+	} else if (event == MODEM_PIPE_EVENT_TRANSMIT_IDLE) {
+		k_sem_give(&ubx->script_sent_sem);
 	}
 }
 
@@ -42,12 +44,16 @@ int modem_ubx_run_script(struct modem_ubx *ubx, struct modem_ubx_script *script)
 	int32_t ms_per_attempt = (uint64_t)k_ticks_to_ms_floor64(script->timeout.ticks) / tries;
 
 	do {
+		k_sem_reset(&ubx->script_sent_sem);
+
 		ret = modem_pipe_transmit(ubx->pipe,
 					  (const uint8_t *)ubx->script->request.buf,
 					  ubx->script->request.len);
 
 		if (wait_for_rsp) {
 			ret = k_sem_take(&ubx->script_stopped_sem, K_MSEC(ms_per_attempt));
+		} else if (ret > 0) {
+			ret = k_sem_take(&ubx->script_sent_sem, K_MSEC(ms_per_attempt));
 		}
 		tries--;
 	} while ((tries > 0) && (ret < 0));
@@ -216,6 +222,7 @@ void modem_ubx_release(struct modem_ubx *ubx)
 	modem_pipe_release(ubx->pipe);
 	k_work_cancel_sync(&ubx->process_work, &sync);
 	k_sem_reset(&ubx->script_stopped_sem);
+	k_sem_reset(&ubx->script_sent_sem);
 	k_sem_reset(&ubx->script_running_sem);
 	ubx->pipe = NULL;
 }
@@ -240,6 +247,7 @@ int modem_ubx_init(struct modem_ubx *ubx, const struct modem_ubx_config *config)
 
 	k_work_init(&ubx->process_work, modem_ubx_process_handler);
 	k_sem_init(&ubx->script_stopped_sem, 0, 1);
+	k_sem_init(&ubx->script_sent_sem, 0, 1);
 	k_sem_init(&ubx->script_running_sem, 1, 1);
 
 	return 0;


### PR DESCRIPTION
This was discovered when trying to implement power management for the U-Blox M10.

When sending a request, modem_ubx_run_script blocks until a response has been received or a timeout occurs. However, if no response is expected, the function returns immediately after queuing the request (modem_pipe_transmit is non-blocking). If modem_pipe_close is called shortly after modem_ubx_run_script, the request may not have been transmitted yet and is dropped (this was observed with modem_backend_uart_async).

Make modem_ubx_run_script blocking in every case: Wait for the MODEM_PIPE_EVENT_TRANSMIT_IDLE event to be signaled before returning from modem_ubx_run_script if no response is expected.