### PR TITLE
drivers: *: stm32: COND_CODE_1() usage cleanup

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -992,11 +992,12 @@ static void set_up_fixed_clock_sources(void)
  * handled by this driver. Pick proper register name:
  */
 #define LSE_DRIVING_SHIFT					\
-	COND_CODE_1(IS_ENABLED(CONFIG_SOC_SERIES_STM32C0X),	\
-		(RCC_CSR1_LSEDRV_Pos),				\
-	(COND_CODE_1(IS_ENABLED(CONFIG_SOC_SERIES_STM32L0X),	\
-		(RCC_CSR_LSEDRV_Pos),				\
-		(RCC_BDCR_LSEDRV_Pos))))
+	COND_CASE_1(						\
+		IS_ENABLED(CONFIG_SOC_SERIES_STM32C0X),		\
+			(RCC_CSR1_LSEDRV_Pos),			\
+		IS_ENABLED(CONFIG_SOC_SERIES_STM32L0X),		\
+			(RCC_CSR_LSEDRV_Pos),			\
+		(RCC_BDCR_LSEDRV_Pos))
 
 		/* Configure driving capability */
 		LL_RCC_LSE_SetDriveCapability(STM32_LSE_DRIVING << LSE_DRIVING_SHIFT);

--- a/drivers/counter/counter_stm32_timer.c
+++ b/drivers/counter/counter_stm32_timer.c
@@ -887,11 +887,12 @@ static void counter_stm32_irq_handler_global(const struct device *dev)
 			(IRQ_CONNECT_AND_ENABLE_BY_NAME(idx, up)))		  \
 		IF_ENABLED(DT_IRQ_HAS_NAME(TIMER(idx), brk_up_trg_com),		  \
 			(IRQ_CONNECT_AND_ENABLE_BY_NAME(idx, brk_up_trg_com)))	  \
-		COND_CODE_1(DT_IRQ_HAS_NAME(TIMER(idx), cc),			  \
-			(IRQ_CONNECT_AND_ENABLE_BY_NAME(idx, cc)),		  \
-		(COND_CODE_1(DT_IRQ_HAS_NAME(TIMER(idx), global),		  \
-			(IRQ_CONNECT_AND_ENABLE_BY_NAME(idx, global)),		  \
-		(BUILD_ASSERT(0, "Timer has no 'cc' or 'global' interrupt!")))))  \
+		COND_CASE_1(							  \
+			DT_IRQ_HAS_NAME(TIMER(idx), cc),			  \
+				(IRQ_CONNECT_AND_ENABLE_BY_NAME(idx, cc)),	  \
+			DT_IRQ_HAS_NAME(TIMER(idx), global),			  \
+				(IRQ_CONNECT_AND_ENABLE_BY_NAME(idx, global)),	  \
+		(BUILD_ASSERT(0, "Timer has no 'cc' or 'global' interrupt!")))	  \
 	}									  \
 										  \
 	static const struct stm32_pclken pclken_##idx[] =			  \

--- a/drivers/mipi_dsi/dsi_stm32.c
+++ b/drivers/mipi_dsi/dsi_stm32.c
@@ -476,7 +476,7 @@ static int mipi_dsi_stm32_init(const struct device *dev)
 #define CHILD_GET_DATA_LANES(child) DT_PROP(child, data_lanes)
 
 #define STM32_MIPI_DSI_DEVICE(inst)								\
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, host_timeouts),					\
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, host_timeouts),					\
 		(static DSI_HOST_TimeoutTypeDef host_timeouts_##inst = {			\
 			.TimeoutCkdiv = DT_INST_PROP_BY_IDX(inst, host_timeouts, 0),		\
 			.HighSpeedTransmissionTimeout =						\
@@ -489,8 +489,8 @@ static int mipi_dsi_stm32_init(const struct device *dev)
 			.HighSpeedWritePrespMode = DT_INST_PROP_BY_IDX(inst, host_timeouts, 6),	\
 			.LowPowerWriteTimeout = DT_INST_PROP_BY_IDX(inst, host_timeouts, 7),	\
 			.BTATimeout = DT_INST_PROP_BY_IDX(inst, host_timeouts, 8)		\
-		}), ());									\
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, phy_timings),					\
+		};))										\
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, phy_timings),					\
 		(static DSI_PHY_TimerTypeDef phy_timings_##inst = {				\
 			.ClockLaneHS2LPTime = DT_INST_PROP_BY_IDX(inst, phy_timings, 0),	\
 			.ClockLaneLP2HSTime = DT_INST_PROP_BY_IDX(inst, phy_timings, 1),	\
@@ -498,7 +498,7 @@ static int mipi_dsi_stm32_init(const struct device *dev)
 			.DataLaneLP2HSTime = DT_INST_PROP_BY_IDX(inst, phy_timings, 3),		\
 			.DataLaneMaxReadTime = DT_INST_PROP_BY_IDX(inst, phy_timings, 4),	\
 			.StopWaitTime = DT_INST_PROP_BY_IDX(inst, phy_timings, 5)		\
-		}), ());									\
+		};))										\
 	/* Only child data-lanes property at index 0 is taken into account */			\
 	static const uint32_t data_lanes_##inst[] = {						\
 		DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(inst, DT_PROP_BY_IDX, (,),		\
@@ -526,13 +526,12 @@ static int mipi_dsi_stm32_init(const struct device *dev)
 					DT_INST_PROP(inst, non_continuous) ?			\
 						DSI_AUTO_CLK_LANE_CTRL_ENABLE :			\
 						DSI_AUTO_CLK_LANE_CTRL_DISABLE,			\
-				COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, phy_freq_range),	\
-					(.PHYFrequencyRange = DT_INST_PROP(inst, phy_freq_range),),\
-					())							\
-				COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, phy_low_power_offset),	\
+				IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, phy_freq_range),		\
+					(.PHYFrequencyRange =					\
+						DT_INST_PROP(inst, phy_freq_range),))		\
+				IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, phy_low_power_offset),	\
 					(.PHYLowPowerOffset =					\
-						DT_INST_PROP(inst, phy_low_power_offset),),	\
-					())							\
+						DT_INST_PROP(inst, phy_low_power_offset),))	\
 			},									\
 		},										\
 		.host_timeouts = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, host_timeouts),	\
@@ -557,16 +556,13 @@ static int mipi_dsi_stm32_init(const struct device *dev)
 			.PLLNDIV = DT_INST_PROP(inst, pll_ndiv),				\
 			.PLLIDF = DT_INST_PROP(inst, pll_idf),					\
 			.PLLODF = DT_INST_PROP(inst, pll_odf),					\
-			COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, pll_vco_range),			\
-					(.PLLVCORange = DT_INST_PROP(inst, pll_vco_range),),	\
-					())							\
-			COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, pll_charge_pump),		\
+			IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pll_vco_range),			\
+					(.PLLVCORange = DT_INST_PROP(inst, pll_vco_range),))	\
+			IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pll_charge_pump),		\
 					(.PLLChargePump =					\
-						DT_INST_PROP(inst, pll_charge_pump),),		\
-					())							\
-			COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, pll_tuning),			\
-					(.PLLTuning = DT_INST_PROP(inst, pll_tuning),),		\
-					())							\
+						DT_INST_PROP(inst, pll_charge_pump),))		\
+			IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pll_tuning),			\
+					(.PLLTuning = DT_INST_PROP(inst, pll_tuning),))		\
 		},										\
 	};											\
 	DEVICE_DT_INST_DEFINE(inst, &mipi_dsi_stm32_init, NULL,					\

--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -42,12 +42,10 @@
  * compile time by BUILD_ASSERT in MSPI_STM32_INIT.
  */
 #define OSPI_INST_NUM(index)                                                           \
-	(COND_CODE_1(DT_NODE_EXISTS(DT_NODELABEL(octospi1)),                               \
-		(DT_SAME_NODE(DT_DRV_INST(index), DT_NODELABEL(octospi1)) ? 1 :),    \
-		())                                                                   \
-	COND_CODE_1(DT_NODE_EXISTS(DT_NODELABEL(octospi2)),                               \
-		(DT_SAME_NODE(DT_DRV_INST(index), DT_NODELABEL(octospi2)) ? 2 :),    \
-		())                                                                   \
+	(IF_ENABLED(DT_NODE_EXISTS(DT_NODELABEL(octospi1)),                            \
+		(DT_SAME_NODE(DT_DRV_INST(index), DT_NODELABEL(octospi1)) ? 1 :))      \
+	IF_ENABLED(DT_NODE_EXISTS(DT_NODELABEL(octospi2)),                             \
+		(DT_SAME_NODE(DT_DRV_INST(index), DT_NODELABEL(octospi2)) ? 2 :))      \
 	0)
 
 /*

--- a/drivers/opamp/opamp_stm32_opamp.c
+++ b/drivers/opamp/opamp_stm32_opamp.c
@@ -652,9 +652,8 @@ static int stm32_opamp_init(const struct device *dev)
 
 /* This assert guarantees a value is always in allowed range at compile time */
 #define STM32_OPAMP_TRIMMING_ASSERT(inst, value)                                                   \
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, value),                                            \
-		    (STM32_OPAMP_TRIMMING_ASSERT_IMPL(inst, value)),                               \
-		    (/* empty */))
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, value),                                            \
+		    (STM32_OPAMP_TRIMMING_ASSERT_IMPL(inst, value)))
 
 #define STM32_OPAMP_DT_PMOS_TRIMMING(inst)                                                         \
 	DT_INST_PROP_OR(inst, st_pmos_trimming_value, STM32_OPAMP_TRIM_VAL_UNDEFINED)

--- a/drivers/sensor/st/stm32_vbat/stm32_vbat.c
+++ b/drivers/sensor/st/stm32_vbat/stm32_vbat.c
@@ -201,16 +201,15 @@ static int stm32_vbat_init(const struct device *dev)
 												\
 	static const struct stm32_vbat_config CONCAT(stm32_vbat_dev_config_, ord) = {		\
 		.ratio = DT_PROP_OR(node_id, ratio, 1),						\
-		COND_CODE_1(DT_NODE_HAS_COMPAT(node_id, st_stm32_vbat), (			\
-			.enable_channel = stm32_vbat_enable_vbatsensor_channel,			\
-			.disable_channel = stm32_vbat_disable_vbatsensor_channel,		\
-		), (COND_CODE_1(DT_NODE_HAS_COMPAT(node_id, st_stm32_vddcore), (		\
-			.enable_channel = stm32_vbat_enable_vddcore_channel,			\
-			.disable_channel = stm32_vbat_disable_vddcore_channel,			\
-		), (										\
-			.enable_channel = NULL,							\
-			.disable_channel = NULL,						\
-		))))										\
+		COND_CASE_1(									\
+			DT_NODE_HAS_COMPAT(node_id, st_stm32_vbat),				\
+				(.enable_channel = stm32_vbat_enable_vbatsensor_channel,	\
+				.disable_channel = stm32_vbat_disable_vbatsensor_channel,),	\
+			DT_NODE_HAS_COMPAT(node_id, st_stm32_vddcore),				\
+				(.enable_channel = stm32_vbat_enable_vddcore_channel,		\
+				.disable_channel = stm32_vbat_disable_vddcore_channel,),	\
+			(.enable_channel = NULL,						\
+			.disable_channel = NULL,))						\
 	};											\
 												\
 	SENSOR_DEVICE_DT_DEFINE(node_id, stm32_vbat_init, NULL,					\

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -109,12 +109,12 @@ typedef PCD_HandleTypeDef		stm32_pcd_handle_t;
  *  - Others ('usb-nop-xceiv') are assumed to be embedded FS PHYs
  */
 #define UDC_STM32_NODE_PHY_ITFACE(usb_node)					\
-	COND_CODE_1(USB_STM32_NODE_PHY_IS_ULPI(usb_node),			\
-		(STM32_PCD_PHY_EXTERNAL_ULPI),					\
-	(COND_CODE_1(USB_STM32_NODE_PHY_IS_EMBEDDED_HS(usb_node),		\
-		(STM32_PCD_PHY_EMBEDDED_HS),					\
-		(STM32_PCD_PHY_EMBEDDED_FS))					\
-	))
+	COND_CASE_1(								\
+		USB_STM32_NODE_PHY_IS_ULPI(usb_node),				\
+			(STM32_PCD_PHY_EXTERNAL_ULPI),				\
+		USB_STM32_NODE_PHY_IS_EMBEDDED_HS(usb_node),			\
+			(STM32_PCD_PHY_EMBEDDED_HS),				\
+		(STM32_PCD_PHY_EMBEDDED_FS))
 
 /*
  * Evaluates to 1 if 'usb_node' uses an embedded FS PHY or has

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -119,13 +119,11 @@ typedef PCD_HandleTypeDef		stm32_pcd_handle_t;
 /*
  * Evaluates to 1 if 'usb_node' uses an embedded FS PHY or has
  * the 'maximum-speed' property set to 'full-speed', 0 otherwise.
- *
- * N.B.: enum index 1 corresponds to 'full-speed'
  */
 #define UDC_STM32_NODE_LIMITED_TO_FS(usb_node)					\
 	UTIL_OR(IS_EQ(UDC_STM32_NODE_PHY_ITFACE(usb_node), PHY_PCD_EMBEDDED),	\
 		UTIL_AND(DT_NODE_HAS_PROP(usb_node, maximum_speed),		\
-			IS_EQ(DT_ENUM_IDX(usb_node, maximum_speed), 1)))
+			DT_ENUM_HAS_VALUE(usb_node, maximum_speed, full_speed)))
 
 /*
  * Returns the 'PCD_Speed' value for 'usb_node', which indicates


### PR DESCRIPTION
Clean up various drivers which use `COND_CODE_1()` in a manner for which another macro is more appropriate. (+ one unrelated cleanup in the UDC driver)