### PR TITLE
drivers: i2s: nrfx: do not stop again after error

### DIFF
--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -774,7 +774,7 @@ static int i2s_nrfx_trigger(const struct device *dev,
 		return 0;
 
 	case I2S_TRIGGER_DROP:
-		if (drv_data->state != I2S_STATE_READY) {
+		if (drv_data->state != I2S_STATE_READY && drv_data->state != I2S_STATE_ERROR) {
 			drv_data->discard_rx = true;
 			nrfx_i2s_stop(&drv_data->i2s);
 		}

--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -818,7 +818,7 @@ static int i2s_nrfx_trigger(const struct device *dev,
 		return 0;
 
 	case I2S_TRIGGER_DROP:
-		if (drv_data->state != I2S_STATE_READY) {
+		if (drv_data->state != I2S_STATE_READY && drv_data->state != I2S_STATE_ERROR) {
 			drv_data->discard_rx = true;
 			nrfx_i2s_stop(&drv_data->i2s);
 		}


### PR DESCRIPTION
If the current state is I2S_STATE_ERROR, the peripheral has already been stopped through nrfx_i2s_stop. Do not try to stop it again when i2s_nrfx_trigger is called with I2S_TRIGGER_DROP, as this may cause the hal to assert on p_cb->state != NRFX_DRV_STATE_UNINITIALIZED.