### PR TITLE
Bluetooth: BAP: SD: shell: Fix missing assignment of pa_sync

### DIFF
--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -150,6 +150,7 @@ struct scan_delegator_sync_state *scan_delegator_sync_state_new(void)
 	for (size_t i = 0U; i < ARRAY_SIZE(scan_delegator_sync_states); i++) {
 		if (!scan_delegator_sync_states[i].active) {
 			scan_delegator_sync_states[i].active = true;
+			scan_delegator_sync_states[i].broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 
 			return &scan_delegator_sync_states[i];
 		}
@@ -463,6 +464,14 @@ static void pa_synced_cb(struct bt_le_per_adv_sync *sync,
 				      src_id);
 			return;
 		}
+
+		if (state->pa_sync != NULL) {
+			bt_shell_error(
+				"Unexpected existing PA sync for state %p from source_id 0x%02X",
+				state, src_id);
+		} else {
+			state->pa_sync = sync;
+		}
 	}
 
 	bt_conn_drop(&state->conn);
@@ -520,6 +529,11 @@ static int cmd_bap_scan_delegator_init(const struct shell *sh, size_t argc,
 
 	if (!registered) {
 		int err;
+
+		ARRAY_FOR_EACH_PTR(scan_delegator_sync_states, state) {
+			state->broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
+			/* Remaining fields are 0/NULL initialized */
+		}
 
 		err = bt_bap_scan_delegator_register(&scan_delegator_cb);
 		if (err != 0) {
@@ -626,6 +640,10 @@ static int cmd_bap_scan_delegator_sync_pa(const struct shell *sh, size_t argc,
 		shell_info(sh, "Syncing without PAST");
 		err = pa_sync_no_past(state, state->pa_interval,
 				      &per_adv_syncs[selected_per_adv_sync]);
+
+		if (err == 0) {
+			state->pa_sync = per_adv_syncs[selected_per_adv_sync];
+		}
 	}
 
 	if (err != 0) {
@@ -888,9 +906,19 @@ static int cmd_bap_scan_delegator_add_src_by_pa_sync(const struct shell *sh, siz
 	param.broadcast_id = broadcast_id;
 	param.num_subgroups = 1U;
 
+	/* Shall be assigned before bt_bap_scan_delegator_add_src so that it is available in the
+	 * recv_state_updated_cb callback
+	 */
+	state->pa_sync = pa_sync;
+	state->broadcast_id = broadcast_id;
+
 	err = bt_bap_scan_delegator_add_src(&param);
 	if (err < 0) {
 		shell_error(sh, "Failed to add source: %d", err);
+
+		state->pa_sync = NULL;
+		state->broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
+		state->active = false;
 
 		return -ENOEXEC;
 	}


### PR DESCRIPTION
The state->pa_sync was not properly assigned a few places, causing invalid behavior in the shell.