### PR TITLE
drivers: pinctrl: mchp g1: clear PMUX nibble before setting mux value

### DIFF
--- a/drivers/pinctrl/pinctrl_mchp_port_g1.c
+++ b/drivers/pinctrl/pinctrl_mchp_port_g1.c
@@ -77,9 +77,13 @@ static void pinctrl_pinmux(const pinctrl_soc_pin_t *pin)
 		 * numbered pin in bits 4..7.
 		 */
 		if (is_odd == true) {
-			pRegister->PORT_PMUX[idx] |= PORT_PMUX_PMUXO(pin_mux);
+			pRegister->PORT_PMUX[idx] =
+				(pRegister->PORT_PMUX[idx] & ~PORT_PMUX_PMUXO_Msk) |
+				PORT_PMUX_PMUXO(pin_mux);
 		} else {
-			pRegister->PORT_PMUX[idx] |= PORT_PMUX_PMUXE(pin_mux);
+			pRegister->PORT_PMUX[idx] =
+				(pRegister->PORT_PMUX[idx] & ~PORT_PMUX_PMUXE_Msk) |
+				PORT_PMUX_PMUXE(pin_mux);
 		}
 		pRegister->PORT_PINCFG[pin_num] |= (uint8_t)PORT_PINCFG_PMUXEN_Msk;
 	}


### PR DESCRIPTION
The PMUX register was not being properly cleared before setting the new mux value. This causes incorrect pin configuration when the register contains non-zero initial values. This PR fix clears the PMUX register before writing the new mux value