### PR TITLE
drivers: adc: stm32: channel preselection fixes

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1470,7 +1470,11 @@ static void adc_context_on_complete(struct adc_context *ctx, int status)
 #if ANY_ADC_HAS_CHANNEL_PRESELECTION
 	if (config->has_channel_preselection) {
 		/* Reset channel preselection register */
-		LL_ADC_SetChannelPreselection(adc, 0);
+#ifdef STM32H72X_ADC
+		stm32_reg_write(&adc->PCSEL_RES0, 0U);
+#else /* STM32H72X_ADC */
+		stm32_reg_write(&adc->PCSEL, 0U);
+#endif /* STM32H72X_ADC */
 	}
 #endif /* ANY_ADC_HAS_CHANNEL_PRESELECTION */
 #endif /* CONFIG_ADC_STM32_INJECTED_CHANNELS */

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1030,7 +1030,7 @@ static int adc_stm32_preselection_setup(const struct device *dev, uint32_t chann
 #endif /* STM32H72X_ADC */
 
 	if (!config->has_channel_preselection ||
-	    (stm32_reg_read(pcsel_reg) & channel) == channel) {
+	    (stm32_reg_read(pcsel_reg) & BIT(channel_id)) == BIT(channel_id)) {
 		/* Nothing to configure */
 		return 0;
 	}

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -53,6 +53,13 @@
 			sampling-times = <3 7 13 25 48 93 248 641>;
 			st,adc-oversampler = "minimal";
 			st,adc-internal-regulator = "startup-sw-delay";
+
+			/*
+			 * Channel preselection is not available on STM32H72x and STM32H73x
+			 * for ADC3. Since this property is defined in st/h7/stm32h7.dtsi,
+			 * we delete it here.
+			 */
+			/delete-property/ st,adc-has-channel-preselection;
 		};
 
 		dmamux1: dmamux@40020800 {


### PR DESCRIPTION
Couple of fixes for channel preselection code.