### PR TITLE
drivers: clock_control: mcxw7x: fix OSC32K load cap and coarse gain

### DIFF
--- a/drivers/clock_control/clock_control_nxp_mcxw7x.c
+++ b/drivers/clock_control/clock_control_nxp_mcxw7x.c
@@ -53,6 +53,8 @@ struct mcxw_clock_control_config {
 	ccm32k_osc_xtal_cap_t xtal_cap;
 	/* OSC32K EXTAL capacitance configuration */
 	ccm32k_osc_extal_cap_t extal_cap;
+	/* OSC32K amplifier coarse gain adjustment */
+	ccm32k_osc_coarse_adjustment_value_t coarse_adjustment;
 
 	/* FIRC mode configuration */
 	uint8_t firc_mode;
@@ -278,7 +280,7 @@ static int nxp_mcxw_clock_control_init(const struct device *dev)
 	/* Init OSC32K */
 	CLOCK_SetRoscMonitorMode(kSCG_RoscMonitorDisable);
 	ccm32k_osc_config_t ccm32k_osc_config = {
-		.coarseAdjustment = kCCM32K_OscCoarseAdjustmentRange0,
+		.coarseAdjustment = config->coarse_adjustment,
 		.enableInternalCapBank = true,
 		.xtalCap = config->xtal_cap,
 		.extalCap = config->extal_cap,
@@ -412,6 +414,7 @@ static struct mcxw_clock_control_config config = {
 	.osc32k_mode = DT_INST_PROP(0, osc32k_mode),
 	.xtal_cap = DT_INST_PROP(0, osc32k_xtal_cap),
 	.extal_cap = DT_INST_PROP(0, osc32k_extal_cap),
+	.coarse_adjustment = DT_INST_PROP(0, osc32k_coarse_adjustment),
 	.firc_mode = DT_INST_PROP(0, firc_mode),
 	.firc_range = DT_INST_PROP(0, firc_range),
 	.enable_sirc_in_lp_mode = DT_INST_PROP(0, enable_sirc_in_lp_mode),

--- a/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw70.dtsi
@@ -443,8 +443,9 @@
 	clk_ctrl: clock-controller {
 		compatible = "nxp,mcxw7x-clock";
 		osc32k-mode = <MCXW_CLK_OSC32K_ENABLE>;
-		osc32k-xtal-cap = <4>;
-		osc32k-extal-cap = <4>;
+		osc32k-xtal-cap = <MCXW_CLK_OSC32K_CAP_16PF>;
+		osc32k-extal-cap = <MCXW_CLK_OSC32K_CAP_16PF>;
+		osc32k-coarse-adjustment = <MCXW_CLK_OSC32K_COARSE_RANGE3>;
 		firc-mode = <MCXW_CLK_FIRC_ENABLE>;
 		firc-range = <MCXW_CLK_FIRC_RANGE_96MHZ>;
 		enable-sirc-in-lp-mode;

--- a/dts/arm/nxp/mcx/nxp_mcxw71.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw71.dtsi
@@ -110,3 +110,7 @@
 	rfmc-xo-cdac = <0x0c>;
 	rfmc-xo-isel = <0x05>;
 };
+
+&clk_ctrl {
+	osc32k-coarse-adjustment = <MCXW_CLK_OSC32K_COARSE_RANGE1>;
+};

--- a/dts/arm/nxp/mcx/nxp_mcxw72.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw72.dtsi
@@ -110,3 +110,7 @@
 	rfmc-xo-cdac = <0x0a>;
 	rfmc-xo-isel = <0x0b>;
 };
+
+&clk_ctrl {
+	osc32k-coarse-adjustment = <MCXW_CLK_OSC32K_COARSE_RANGE3>;
+};

--- a/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxw7x_common.dtsi
@@ -204,8 +204,8 @@
 	clk_ctrl: clock-controller {
 		compatible = "nxp,mcxw7x-clock";
 		osc32k-mode = <MCXW_CLK_OSC32K_ENABLE>;
-		osc32k-xtal-cap = <4>;
-		osc32k-extal-cap = <4>;
+		osc32k-xtal-cap = <MCXW_CLK_OSC32K_CAP_16PF>;
+		osc32k-extal-cap = <MCXW_CLK_OSC32K_CAP_16PF>;
 		firc-mode = <MCXW_CLK_FIRC_ENABLE>;
 		firc-range = <MCXW_CLK_FIRC_RANGE_96MHZ>;
 		enable-sirc-in-lp-mode;

--- a/dts/bindings/clock/nxp,mcxw7x-clock.yaml
+++ b/dts/bindings/clock/nxp,mcxw7x-clock.yaml
@@ -97,6 +97,22 @@ properties:
       - 14
       - 15
 
+  osc32k-coarse-adjustment:
+    type: int
+    default: 0
+    description: |
+      32 kHz crystal oscillator amplifier coarse gain adjustment.
+      Used to match the external crystal ESR range.
+      0: Range0
+      1: Range1
+      2: Range2
+      3: Range3
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+
   firc-mode:
     type: int
     required: true

--- a/include/zephyr/dt-bindings/clock/nxp_mcxw7x_clock.h
+++ b/include/zephyr/dt-bindings/clock/nxp_mcxw7x_clock.h
@@ -22,6 +22,40 @@
 #define MCXW_CLK_OSC32K_BYPASS  3 /**< Bypass 32K oscillator (external clock). */
 /*@}*/
 
+/** @name OSC32K XTAL/EXTAL internal load capacitance
+ * Selects the internal capacitance applied from the OSC32K cap bank.
+ * Value N maps to 2*N pF (0 pF .. 30 pF).
+ */
+/*@{*/
+#define MCXW_CLK_OSC32K_CAP_0PF  0  /**< 0 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_2PF  1  /**< 2 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_4PF  2  /**< 4 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_6PF  3  /**< 6 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_8PF  4  /**< 8 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_10PF 5  /**< 10 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_12PF 6  /**< 12 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_14PF 7  /**< 14 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_16PF 8  /**< 16 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_18PF 9  /**< 18 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_20PF 10 /**< 20 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_22PF 11 /**< 22 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_24PF 12 /**< 24 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_26PF 13 /**< 26 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_28PF 14 /**< 28 pF internal capacitance. */
+#define MCXW_CLK_OSC32K_CAP_30PF 15 /**< 30 pF internal capacitance. */
+/*@}*/
+
+/** @name OSC32K coarse amplifier gain adjustment
+ * Selects the 32 kHz crystal oscillator amplifier coarse gain, used to
+ * match the external crystal ESR range.
+ */
+/*@{*/
+#define MCXW_CLK_OSC32K_COARSE_RANGE0 0 /**< Coarse amplifier gain Range0. */
+#define MCXW_CLK_OSC32K_COARSE_RANGE1 1 /**< Coarse amplifier gain Range1. */
+#define MCXW_CLK_OSC32K_COARSE_RANGE2 2 /**< Coarse amplifier gain Range2. */
+#define MCXW_CLK_OSC32K_COARSE_RANGE3 3 /**< Coarse amplifier gain Range3. */
+/*@}*/
+
 /** @name FIRC Mode */
 /*@{*/
 #define MCXW_CLK_FIRC_DISABLE      0 /**< Disable FIRC. */


### PR DESCRIPTION
The MCXW7x clock controller configured the OSC32K 32 kHz crystal oscillator with an 8 pF internal load capacitance (cap value 4) on both the XTAL and EXTAL pins, and hardcoded the amplifier coarse gain to Range0. This configuration leads to a clock precision issue of around 180 ppm on the 32 kHz clock.

A 16 pF internal load capacitance is the best configuration to achieve the best precision, together with a per-SoC coarse amplifier gain. Fix the default configuration:
- Use a 16 pF internal load capacitance on XTAL and EXTAL.
- Add an osc32k-coarse-adjustment devicetree property so the coarse amplifier gain is configurable (the driver previously forced Range0), and wire it into the CCM32K oscillator config.
- Set the coarse gain per SoC: Range3 on MCXW72, Range1 on MCXW71. MCXW70 is aligned with MCXW72 (Range3).

Also add named dt-bindings macros for the OSC32K load capacitance (MCXW_CLK_OSC32K_CAP_*pF, value N maps to 2*N pF) and coarse gain (MCXW_CLK_OSC32K_COARSE_RANGE*) so the devicetree no longer relies on opaque magic numbers.

Built samples/hello_world for frdm_mcxw70, frdm_mcxw71 and frdm_mcxw72 and verified the generated devicetree resolves to 16 pF caps with coarse gain Range3 (W70/W72) and Range1 (W71).