### PR TITLE
net: ethernet: bridge: Resolve IPv4 dst before flooding

### DIFF
--- a/subsys/net/l2/ethernet/bridge/CMakeLists.txt
+++ b/subsys/net/l2/ethernet/bridge/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-zephyr_library_include_directories(. ${ZEPHYR_BASE}/subsys/net/ip)
+zephyr_library_include_directories(. .. ${ZEPHYR_BASE}/subsys/net/ip)
 
 zephyr_library_sources(bridge.c)
 zephyr_library_sources(bridge_input.c)

--- a/subsys/net/l2/ethernet/bridge/Kconfig
+++ b/subsys/net/l2/ethernet/bridge/Kconfig
@@ -56,7 +56,24 @@ config NET_ETHERNET_BRIDGE_UNIQUE_MAC
 	  get distinct addresses. Falls back to a random address when no device
 	  ID is available.
 
+config NET_ETHERNET_BRIDGE_PREFIX_MAC
+	bool "Stable MAC address from configured prefix"
+	help
+	  Assign a stable MAC address by appending the bridge index to a
+	  configured five-octet MAC address prefix. The resulting address is the
+	  same across reboots so peers' caches stay valid.
+
 endchoice
+
+config NET_ETHERNET_BRIDGE_MAC_PREFIX
+	string "Bridge MAC address prefix"
+	depends on NET_ETHERNET_BRIDGE_PREFIX_MAC
+	default "02:00:00:00:00"
+	help
+	  Five-octet colon-separated MAC address prefix used for bridge
+	  interfaces. The bridge index is used as the final octet, so bridge0
+	  with prefix "02:00:00:00:00" gets "02:00:00:00:00:00" and bridge1
+	  gets "02:00:00:00:00:01".
 
 config NET_ETHERNET_BRIDGE_TXRX_DEBUG
 	bool "Debug received and sent packets in bridge"

--- a/subsys/net/l2/ethernet/bridge/Kconfig
+++ b/subsys/net/l2/ethernet/bridge/Kconfig
@@ -29,6 +29,35 @@ config NET_ETHERNET_BRIDGE_ETH_INTERFACE_COUNT
 	  How many Ethernet interfaces can be bridged together per each
 	  bridge interface.
 
+choice NET_ETHERNET_BRIDGE_MAC
+	prompt "Bridge interface MAC address source"
+	default NET_ETHERNET_BRIDGE_RANDOM_MAC
+	help
+	  Select how the MAC (link) address of a bridge interface is assigned.
+	  A bridge interface can own an IP address and terminate/originate
+	  traffic of its own, so it needs a MAC address. For a fully custom
+	  address the application can instead call net_if_set_link_addr() on the
+	  bridge interface while it is down (bridge interfaces do not auto-start).
+
+config NET_ETHERNET_BRIDGE_RANDOM_MAC
+	bool "Random MAC address"
+	help
+	  Assign a random locally administered MAC address to each bridge
+	  interface. A new address is generated on every boot, so peers'
+	  ARP/neighbor caches for the bridge become stale across reboots.
+
+config NET_ETHERNET_BRIDGE_UNIQUE_MAC
+	bool "Stable MAC address derived from the device ID"
+	depends on HWINFO
+	help
+	  Derive a stable locally administered MAC address from the hardware
+	  device ID. The same address is used across reboots so peers' caches
+	  stay valid. The bridge index is mixed in so multiple bridge interfaces
+	  get distinct addresses. Falls back to a random address when no device
+	  ID is available.
+
+endchoice
+
 config NET_ETHERNET_BRIDGE_TXRX_DEBUG
 	bool "Debug received and sent packets in bridge"
 	depends on NET_L2_ETHERNET_LOG_LEVEL_DBG

--- a/subsys/net/l2/ethernet/bridge/bridge.c
+++ b/subsys/net/l2/ethernet/bridge/bridge.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(net_eth_bridge, CONFIG_NET_ETHERNET_BRIDGE_LOG_LEVEL);
 #include <zephyr/random/random.h>
 
 #include "net_private.h"
+#include "arp.h"
 
 #if defined(CONFIG_NET_ETHERNET_BRIDGE_TXRX_DEBUG)
 #define DEBUG_TX 1
@@ -343,6 +344,76 @@ static int bridge_iface_stop(const struct device *dev)
 }
 
 /*
+ * Resolve the destination link-layer address of a locally originated packet on
+ * the bridge interface before it is flooded to the member ports.
+ *
+ * A bridge interface can own an IP address and therefore originate traffic of
+ * its own. For IPv6 the neighbor is resolved in net_ipv6_prepare_for_send() on
+ * the interface the packet is sent on, so the destination link address is
+ * already known by the time it reaches this layer. IPv4 is different: its
+ * destination link address is normally resolved later, in the Ethernet L2 send
+ * routine. But the bridge forwards packets to its member ports with the family
+ * reset to AF_UNSPEC (so the already-built header of *forwarded* frames is not
+ * rebuilt), which also disables that ARP step, leaving the destination
+ * unresolved and thus defaulted to broadcast by the Ethernet layer.
+ *
+ * The member ports cannot resolve on the bridge's behalf either: an ARP reply
+ * is addressed to the bridge link address, so a member port would drop it as
+ * "not for me". Resolve here, on the bridge interface, where the ARP cache is
+ * populated and where a request/reply exchange completes correctly.
+ *
+ * Returns the packet to forward to the member ports: the original packet once
+ * the destination is known, an ARP request packet while resolution is pending,
+ * or NULL if nothing should be sent now (packet queued for later or on error).
+ */
+static struct net_pkt *bridge_resolve_local_dst(struct net_if *bridge, struct net_pkt *pkt)
+{
+#if defined(CONFIG_NET_IPV4) && defined(CONFIG_NET_ARP)
+	struct net_pkt *arp_pkt = NULL;
+	int ret;
+
+	/* Only locally originated IPv4 packets need resolving here. Forwarded
+	 * (L2 bridged) frames already carry a complete Ethernet header, ARP
+	 * frames drive their own destination, and packets whose destination is
+	 * already known (broadcast/multicast or a cached neighbor) have a
+	 * non-zero link address.
+	 */
+	if (net_pkt_is_l2_bridged(pkt) ||
+	    net_pkt_ll_proto_type(pkt) != NET_ETH_PTYPE_IP ||
+	    net_pkt_lladdr_dst(pkt)->len > 0) {
+		return pkt;
+	}
+
+	ret = net_arp_prepare(pkt, (struct net_in_addr *)NET_IPV4_HDR(pkt)->dst,
+			      NULL, &arp_pkt);
+	switch (ret) {
+	case NET_ARP_COMPLETE:
+		/* Destination link address is now filled in pkt. */
+		return pkt;
+	case NET_ARP_PKT_REPLACED:
+		/* The original packet was queued inside ARP pending its
+		 * resolution; release our reference and flood the ARP request
+		 * instead so the reply comes back to the bridge.
+		 */
+		net_pkt_unref(pkt);
+		return arp_pkt;
+	case NET_ARP_PKT_QUEUED:
+		/* Appended to an already in-flight request for this address. */
+		net_pkt_unref(pkt);
+		return NULL;
+	default:
+		NET_DBG("DROP: IPv4 ARP prepare failed (%d)", ret);
+		net_pkt_unref(pkt);
+		return NULL;
+	}
+#else
+	ARG_UNUSED(bridge);
+
+	return pkt;
+#endif /* CONFIG_NET_IPV4 && CONFIG_NET_ARP */
+}
+
+/*
  * For direct TX, send pkt to all ifaces.
  * For forward TX (pkt from an original iface), send to all other ifaces.
  */
@@ -351,8 +422,19 @@ static enum net_verdict bridge_iface_send_process(struct net_if *iface,
 {
 	struct eth_bridge_iface_context *ctx = net_if_get_device(iface)->data;
 	struct net_if *orig_iface;
-	struct net_pkt *send_pkt = pkt;
+	struct net_pkt *send_pkt;
 	int fwd_iface_num = 0;
+
+	/* Resolve the destination link address of locally originated IPv4
+	 * traffic before flooding, otherwise the Ethernet layer defaults it to
+	 * broadcast (see bridge_resolve_local_dst).
+	 */
+	pkt = bridge_resolve_local_dst(iface, pkt);
+	if (pkt == NULL) {
+		return NET_OK;
+	}
+
+	send_pkt = pkt;
 
 	lock_bridge(ctx);
 

--- a/subsys/net/l2/ethernet/bridge/bridge.c
+++ b/subsys/net/l2/ethernet/bridge/bridge.c
@@ -20,6 +20,9 @@ LOG_MODULE_REGISTER(net_eth_bridge, CONFIG_NET_ETHERNET_BRIDGE_LOG_LEVEL);
 #endif
 #include <zephyr/sys/slist.h>
 #include <zephyr/random/random.h>
+#if defined(CONFIG_NET_ETHERNET_BRIDGE_UNIQUE_MAC)
+#include <zephyr/drivers/hwinfo.h>
+#endif
 
 #include "net_private.h"
 #include "arp.h"
@@ -245,13 +248,51 @@ int eth_bridge_iface_remove(struct net_if *br, struct net_if *iface)
 	return 0;
 }
 
+static void set_laa_unicast(uint8_t *linkaddr)
+{
+	linkaddr[0] |= 0x02;  /* force LAA (locally administered) bit */
+	linkaddr[0] &= ~0x01; /* clear multicast bit */
+}
+
 static void random_linkaddr(uint8_t *linkaddr, size_t len)
 {
 	sys_rand_get(linkaddr, len);
 
-	linkaddr[0] |= 0x02;  /* force LAA bit */
-	linkaddr[0] &= ~0x01; /* clear multicast bit */
+	set_laa_unicast(linkaddr);
 }
+
+#if defined(CONFIG_NET_ETHERNET_BRIDGE_UNIQUE_MAC)
+/* Derive a stable MAC address from the hardware device ID so that it stays the
+ * same across reboots. The bridge index is mixed in so that multiple bridge
+ * interfaces get distinct addresses. Falls back to a random address if no
+ * device ID is available.
+ */
+static void unique_linkaddr(uint8_t *linkaddr, size_t len, uint8_t id)
+{
+	uint8_t hwid[16];
+	ssize_t ret;
+
+	ret = hwinfo_get_device_id(hwid, sizeof(hwid));
+	if (ret <= 0) {
+		NET_DBG("No device id available (%d), using random link address",
+			(int)ret);
+		random_linkaddr(linkaddr, len);
+		return;
+	}
+
+	/* Fold the device id into the link address so that a device id shorter
+	 * or longer than the link address still contributes all of its bytes.
+	 */
+	(void)memset(linkaddr, 0, len);
+	for (ssize_t i = 0; i < ret; i++) {
+		linkaddr[i % len] ^= hwid[i];
+	}
+
+	linkaddr[len - 1] ^= id;
+
+	set_laa_unicast(linkaddr);
+}
+#endif /* CONFIG_NET_ETHERNET_BRIDGE_UNIQUE_MAC */
 
 static void bridge_iface_init(struct net_if *iface)
 {
@@ -285,7 +326,11 @@ static void bridge_iface_init(struct net_if *iface)
 	 * address would make that comparison fail and the frame be dropped as
 	 * "not for me".
 	 */
+#if defined(CONFIG_NET_ETHERNET_BRIDGE_UNIQUE_MAC)
+	unique_linkaddr(vctx->lladdr.addr, NET_ETH_ADDR_LEN, ctx->id);
+#else
 	random_linkaddr(vctx->lladdr.addr, NET_ETH_ADDR_LEN);
+#endif
 
 	vctx->lladdr.len = NET_ETH_ADDR_LEN;
 	vctx->lladdr.type = NET_LINK_ETHERNET;

--- a/subsys/net/l2/ethernet/bridge/bridge.c
+++ b/subsys/net/l2/ethernet/bridge/bridge.c
@@ -276,11 +276,19 @@ static void bridge_iface_init(struct net_if *iface)
 	/* We need to set the link address here as normally it would be set in
 	 * virtual interface API attach function but we do not use that in
 	 * bridging.
+	 *
+	 * The bridge can own an IP address and terminate/originate traffic of
+	 * its own, so it acts as an Ethernet endpoint. Its link address must be
+	 * a proper 6-byte Ethernet MAC: a locally destined unicast (e.g. an ARP
+	 * reply) is compared against the interface link address with
+	 * net_linkaddr_cmp(), which requires the lengths to match. A longer
+	 * address would make that comparison fail and the frame be dropped as
+	 * "not for me".
 	 */
-	random_linkaddr(vctx->lladdr.addr, sizeof(vctx->lladdr.addr));
+	random_linkaddr(vctx->lladdr.addr, NET_ETH_ADDR_LEN);
 
-	vctx->lladdr.len = sizeof(vctx->lladdr.addr);
-	vctx->lladdr.type = NET_LINK_UNKNOWN;
+	vctx->lladdr.len = NET_ETH_ADDR_LEN;
+	vctx->lladdr.type = NET_LINK_ETHERNET;
 
 	net_if_set_link_addr(iface, vctx->lladdr.addr,
 			     vctx->lladdr.len, vctx->lladdr.type);

--- a/subsys/net/l2/ethernet/bridge/bridge.c
+++ b/subsys/net/l2/ethernet/bridge/bridge.c
@@ -9,6 +9,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_eth_bridge, CONFIG_NET_ETHERNET_BRIDGE_LOG_LEVEL);
 
+#include <ctype.h>
+
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_l2.h>
 #include <zephyr/net/net_log.h>
@@ -261,6 +263,54 @@ static void random_linkaddr(uint8_t *linkaddr, size_t len)
 	set_laa_unicast(linkaddr);
 }
 
+#if defined(CONFIG_NET_ETHERNET_BRIDGE_PREFIX_MAC)
+static bool is_bridge_mac_prefix_valid(const char *prefix)
+{
+	for (size_t i = 0; i < sizeof("xx:xx:xx:xx:xx") - 1; i++) {
+		if ((i % 3) == 2) {
+			if (prefix[i] != ':') {
+				return false;
+			}
+		} else if (!isxdigit((unsigned char)prefix[i])) {
+			return false;
+		}
+	}
+
+	return prefix[sizeof("xx:xx:xx:xx:xx") - 1] == '\0';
+}
+
+static void prefix_linkaddr(uint8_t *linkaddr, size_t len, uint8_t id)
+{
+	int ret;
+
+	(void)memset(linkaddr, 0, len);
+
+	if (!is_bridge_mac_prefix_valid(CONFIG_NET_ETHERNET_BRIDGE_MAC_PREFIX)) {
+		NET_DBG("Invalid bridge MAC prefix \"%s\", using random link address",
+			CONFIG_NET_ETHERNET_BRIDGE_MAC_PREFIX);
+		random_linkaddr(linkaddr, len);
+		return;
+	}
+
+	ret = net_bytes_from_str(linkaddr, NET_ETH_ADDR_LEN - 1,
+				 CONFIG_NET_ETHERNET_BRIDGE_MAC_PREFIX);
+	if (ret < 0) {
+		NET_DBG("Cannot parse bridge MAC prefix \"%s\" (%d), using random link address",
+			CONFIG_NET_ETHERNET_BRIDGE_MAC_PREFIX, ret);
+		random_linkaddr(linkaddr, len);
+		return;
+	}
+
+	linkaddr[NET_ETH_ADDR_LEN - 1] = id;
+
+	/* A bridge MAC address must be unicast. Preserve the configured U/L bit
+	 * so users can provide either a locally administered prefix or their
+	 * assigned OUI.
+	 */
+	linkaddr[0] &= ~0x01;
+}
+#endif /* CONFIG_NET_ETHERNET_BRIDGE_PREFIX_MAC */
+
 #if defined(CONFIG_NET_ETHERNET_BRIDGE_UNIQUE_MAC)
 /* Derive a stable MAC address from the hardware device ID so that it stays the
  * same across reboots. The bridge index is mixed in so that multiple bridge
@@ -328,6 +378,8 @@ static void bridge_iface_init(struct net_if *iface)
 	 */
 #if defined(CONFIG_NET_ETHERNET_BRIDGE_UNIQUE_MAC)
 	unique_linkaddr(vctx->lladdr.addr, NET_ETH_ADDR_LEN, ctx->id);
+#elif defined(CONFIG_NET_ETHERNET_BRIDGE_PREFIX_MAC)
+	prefix_linkaddr(vctx->lladdr.addr, NET_ETH_ADDR_LEN, ctx->id);
 #else
 	random_linkaddr(vctx->lladdr.addr, NET_ETH_ADDR_LEN);
 #endif

--- a/tests/net/bridge/CMakeLists.txt
+++ b/tests/net/bridge/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bridge)
 
-target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)
+target_include_directories(app PRIVATE
+  ${ZEPHYR_BASE}/subsys/net/ip
+  ${ZEPHYR_BASE}/subsys/net/l2/ethernet)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/bridge/src/main.c
+++ b/tests/net/bridge/src/main.c
@@ -20,11 +20,15 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 #include <zephyr/ztest.h>
 
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_pkt.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/ethernet_bridge.h>
 #include <zephyr/net/ethernet_bridge_fdb.h>
 #include <zephyr/net/virtual.h>
 #include <zephyr/net/promiscuous.h>
+
+#include "arp.h"
 
 #if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 #define DBG(fmt, ...) printk(fmt, ##__VA_ARGS__)
@@ -39,6 +43,15 @@ struct eth_fake_context {
 	struct net_pkt *sent_pkt;
 	uint8_t mac_address[6];
 	bool promisc_mode;
+	/* Destination MAC of the last locally originated IPv4 frame seen on
+	 * this interface, used by the local-TX regression test.
+	 */
+	struct net_eth_addr last_ipv4_dst;
+	bool last_ipv4_seen;
+	/* Set when an ARP frame egressed this interface (used by the
+	 * cache-miss variant of the local-TX regression test).
+	 */
+	bool arp_seen;
 };
 
 static void eth_fake_iface_init(struct net_if *iface)
@@ -67,6 +80,23 @@ static int eth_fake_send(const struct device *dev,
 {
 	struct eth_fake_context *ctx = dev->data;
 	struct net_eth_hdr *eth_hdr = NET_ETH_HDR(pkt);
+
+	/*
+	 * Record the destination MAC of locally originated IPv4 frames so the
+	 * local-TX regression test can check it was resolved to a unicast
+	 * address instead of defaulting to broadcast.
+	 */
+	if (eth_hdr->type == net_htons(NET_ETH_PTYPE_IP)) {
+		memcpy(&ctx->last_ipv4_dst, &eth_hdr->dst,
+		       sizeof(ctx->last_ipv4_dst));
+		ctx->last_ipv4_seen = true;
+		return 0;
+	}
+
+	if (eth_hdr->type == net_htons(NET_ETH_PTYPE_ARP)) {
+		ctx->arp_seen = true;
+		return 0;
+	}
 
 	/*
 	 * Ignore packets we don't care about for this test, like
@@ -322,6 +352,167 @@ static void test_setup_bridge(void)
 	zassert_equal(ret, 0, "");
 }
 
+/*
+ * When the bridge interface owns an IPv4 address it can originate traffic of
+ * its own (e.g. a TCP server bound to the bridge). Such locally originated
+ * IPv4 packets used to be flooded to the member ports with an unresolved
+ * destination link address, which the Ethernet layer then defaulted to
+ * broadcast (ff:ff:ff:ff:ff:ff). Verify the destination is resolved to the
+ * neighbor's unicast MAC instead.
+ */
+#if defined(CONFIG_NET_IPV4)
+static const struct net_in_addr bridge_ip = { { { 192, 0, 2, 1 } } };
+
+/* Give the bridge an IPv4 address so a same-subnet peer is considered on-link.
+ * Idempotent: safe to call from more than one test.
+ */
+static void ensure_bridge_ipv4(void)
+{
+	struct net_in_addr netmask = { { { 255, 255, 255, 0 } } };
+
+	zassert_not_null(net_if_ipv4_addr_add(bridge, (struct net_in_addr *)&bridge_ip,
+					      NET_ADDR_MANUAL, 0), "");
+	zassert_true(net_if_ipv4_set_netmask_by_addr(bridge,
+						     (struct net_in_addr *)&bridge_ip,
+						     &netmask), "");
+}
+
+/* Craft a locally originated IPv4 unicast packet for the peer and hand it to
+ * the bridge TX path, mimicking the bridge's own IP stack.
+ */
+static void send_local_ipv4(const struct net_in_addr *peer_ip)
+{
+	struct net_ipv4_hdr ip_hdr = { 0 };
+	static uint8_t payload[] = { 'p', 'i', 'n', 'g' };
+	struct net_pkt *pkt;
+	int i, ret;
+
+	for (i = 0; i < 3; i++) {
+		eth_fake_data[i].last_ipv4_seen = false;
+		eth_fake_data[i].arp_seen = false;
+	}
+
+	pkt = net_pkt_alloc_with_buffer(bridge, sizeof(ip_hdr) + sizeof(payload),
+					NET_AF_INET, NET_IPPROTO_UDP, K_FOREVER);
+	zassert_not_null(pkt, "");
+
+	ip_hdr.vhl = 0x45;
+	ip_hdr.ttl = 64;
+	ip_hdr.proto = NET_IPPROTO_UDP;
+	ip_hdr.len = net_htons(sizeof(ip_hdr) + sizeof(payload));
+	net_ipv4_addr_copy_raw(ip_hdr.src, (uint8_t *)&bridge_ip);
+	net_ipv4_addr_copy_raw(ip_hdr.dst, (uint8_t *)peer_ip);
+
+	ret = net_pkt_write(pkt, &ip_hdr, sizeof(ip_hdr));
+	zassert_equal(ret, 0, "");
+	ret = net_pkt_write(pkt, payload, sizeof(payload));
+	zassert_equal(ret, 0, "");
+
+	net_pkt_cursor_init(pkt);
+	net_pkt_set_family(pkt, NET_AF_INET);
+	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IP);
+
+	net_if_queue_tx(bridge, pkt);
+
+	/* give time to the processing threads to run */
+	k_sleep(K_MSEC(100));
+}
+
+/* Every IPv4 frame that egressed a member port must carry the peer's unicast
+ * MAC, never broadcast. At least one copy must have egressed.
+ */
+static void check_ipv4_unicast(const struct net_eth_addr *peer_mac)
+{
+	bool checked = false;
+	int i;
+
+	for (i = 0; i < 3; i++) {
+		if (!eth_fake_data[i].last_ipv4_seen) {
+			continue;
+		}
+
+		checked = true;
+
+		zassert_false(net_eth_is_addr_broadcast(&eth_fake_data[i].last_ipv4_dst),
+			      "iface %d: IPv4 frame sent to broadcast MAC",
+			      net_if_get_by_iface(eth_fake_data[i].iface));
+		zassert_mem_equal(&eth_fake_data[i].last_ipv4_dst, peer_mac,
+				  sizeof(*peer_mac),
+				  "iface %d: IPv4 frame dst MAC not resolved to peer",
+				  net_if_get_by_iface(eth_fake_data[i].iface));
+	}
+
+	zassert_true(checked, "no IPv4 frame egressed any member port");
+}
+
+/* Cache hit: the neighbor is already in the bridge ARP cache, so the packet is
+ * resolved and flooded to the members straight away.
+ */
+static void test_local_ipv4_tx_unicast(void)
+{
+	struct net_in_addr peer_ip = { { { 192, 0, 2, 2 } } };
+	struct net_eth_addr peer_mac = {
+		.addr = { 0x02, 0x11, 0x22, 0x33, 0x44, 0x55 }
+	};
+
+	ensure_bridge_ipv4();
+
+	/* Seed the bridge ARP cache as if the peer had already been resolved
+	 * (this is what an incoming SYN/ARP from the peer would have done).
+	 */
+	net_arp_update(bridge, &peer_ip, &peer_mac, false, true);
+
+	send_local_ipv4(&peer_ip);
+
+	check_ipv4_unicast(&peer_mac);
+
+	check_free_packet_count();
+}
+
+/* Cache miss: the neighbor is unknown, so the bridge must flood an ARP request
+ * (not the data frame) and hold the packet until the reply resolves it. Once
+ * resolved, the held packet is flushed to the members with the unicast MAC.
+ */
+static void test_local_ipv4_tx_unicast_arp_miss(void)
+{
+	struct net_in_addr peer_ip = { { { 192, 0, 2, 3 } } };
+	struct net_eth_addr peer_mac = {
+		.addr = { 0x02, 0x66, 0x77, 0x88, 0x99, 0xaa }
+	};
+	bool arp_requested = false;
+	int i;
+
+	ensure_bridge_ipv4();
+
+	/* Make sure the peer is not resolved yet. */
+	send_local_ipv4(&peer_ip);
+
+	/* The data frame must not have been sent yet: it is queued pending ARP.
+	 * Instead an ARP request must have been flooded to the member ports.
+	 */
+	for (i = 0; i < 3; i++) {
+		zassert_false(eth_fake_data[i].last_ipv4_seen,
+			      "iface %d: IPv4 frame sent before ARP resolved",
+			      net_if_get_by_iface(eth_fake_data[i].iface));
+		arp_requested |= eth_fake_data[i].arp_seen;
+	}
+
+	zassert_true(arp_requested, "no ARP request flooded on cache miss");
+
+	/* Simulate the peer's ARP reply arriving: this resolves the entry and
+	 * flushes the queued packet back through the bridge TX path.
+	 */
+	net_arp_update(bridge, &peer_ip, &peer_mac, false, false);
+
+	/* give time to the processing threads to run */
+	k_sleep(K_MSEC(100));
+
+	check_ipv4_unicast(&peer_mac);
+
+	check_free_packet_count();
+}
+#endif /* CONFIG_NET_IPV4 */
+
 static void test_recv_with_bridge(void)
 {
 	int i, j;
@@ -461,6 +652,10 @@ ZTEST(net_eth_bridge, test_net_eth_bridge)
 	test_recv_before_bridging();
 	DBG("With bridging\n");
 	test_setup_bridge();
+#if defined(CONFIG_NET_IPV4)
+	test_local_ipv4_tx_unicast();
+	test_local_ipv4_tx_unicast_arp_miss();
+#endif
 	test_recv_with_bridge();
 	test_recv_with_bridge_fdb();
 	DBG("After bridging\n");

--- a/tests/net/bridge/src/main.c
+++ b/tests/net/bridge/src/main.c
@@ -371,13 +371,25 @@ static void test_bridge_link_addr(void)
 		      "bridge link address type is %u, expected NET_LINK_ETHERNET",
 		      lladdr->type);
 
-	/* Whether random or derived from the device id, the address must be a
-	 * locally administered unicast MAC.
+#if defined(CONFIG_NET_ETHERNET_BRIDGE_PREFIX_MAC)
+	{
+		static const uint8_t expected_addr[NET_ETH_ADDR_LEN] = {
+			0x02, 0x34, 0x56, 0x78, 0x9a, 0x00
+		};
+
+		zassert_mem_equal(lladdr->addr, expected_addr, sizeof(expected_addr),
+				  "bridge link address does not use configured prefix");
+	}
+#else
+	/* Random and device-id-derived addresses must be locally administered.
+	 * A configured prefix may use a globally assigned OUI, so it is checked
+	 * separately above.
 	 */
 	zassert_equal(lladdr->addr[0] & 0x01, 0x00,
 		      "bridge link address is not unicast");
 	zassert_equal(lladdr->addr[0] & 0x02, 0x02,
 		      "bridge link address is not locally administered");
+#endif
 }
 
 /*

--- a/tests/net/bridge/src/main.c
+++ b/tests/net/bridge/src/main.c
@@ -370,6 +370,14 @@ static void test_bridge_link_addr(void)
 	zassert_equal(lladdr->type, NET_LINK_ETHERNET,
 		      "bridge link address type is %u, expected NET_LINK_ETHERNET",
 		      lladdr->type);
+
+	/* Whether random or derived from the device id, the address must be a
+	 * locally administered unicast MAC.
+	 */
+	zassert_equal(lladdr->addr[0] & 0x01, 0x00,
+		      "bridge link address is not unicast");
+	zassert_equal(lladdr->addr[0] & 0x02, 0x02,
+		      "bridge link address is not locally administered");
 }
 
 /*

--- a/tests/net/bridge/src/main.c
+++ b/tests/net/bridge/src/main.c
@@ -352,6 +352,26 @@ static void test_setup_bridge(void)
 	zassert_equal(ret, 0, "");
 }
 
+/* The bridge can terminate/originate IP traffic, so it must present a proper
+ * 6-byte Ethernet link address. If the link address max length is larger (e.g.
+ * 8 when another L2 such as IEEE 802.15.4/PPP or a custom length is enabled),
+ * setting the bridge address to that full length makes the Ethernet "for me"
+ * check (net_linkaddr_cmp, which requires equal lengths) reject locally
+ * destined unicast frames like ARP replies, breaking address resolution.
+ */
+static void test_bridge_link_addr(void)
+{
+	struct net_linkaddr *lladdr = net_if_get_link_addr(bridge);
+
+	zassert_not_null(lladdr, "");
+	zassert_equal(lladdr->len, NET_ETH_ADDR_LEN,
+		      "bridge link address length is %u, expected %u",
+		      lladdr->len, NET_ETH_ADDR_LEN);
+	zassert_equal(lladdr->type, NET_LINK_ETHERNET,
+		      "bridge link address type is %u, expected NET_LINK_ETHERNET",
+		      lladdr->type);
+}
+
 /*
  * When the bridge interface owns an IPv4 address it can originate traffic of
  * its own (e.g. a TCP server bound to the bridge). Such locally originated
@@ -511,6 +531,74 @@ static void test_local_ipv4_tx_unicast_arp_miss(void)
 
 	check_free_packet_count();
 }
+
+/* A locally destined unicast frame arriving on a member port must be delivered
+ * to the bridge, not dropped by the Ethernet "for me" check. Inject a unicast
+ * ARP request for the bridge's own IP and verify the bridge answers: the reply
+ * is flooded out the other member ports. If the request were dropped (e.g. due
+ * to a mismatched bridge link address length), no reply would be produced.
+ */
+static void test_local_unicast_delivered_to_bridge(void)
+{
+	struct net_in_addr peer_ip = { { { 192, 0, 2, 9 } } };
+	struct net_eth_addr peer_mac = {
+		.addr = { 0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0xee }
+	};
+	struct net_eth_hdr eth_hdr = { 0 };
+	struct net_arp_hdr arp_hdr = { 0 };
+	struct net_linkaddr *bridge_ll;
+	bool reply_seen = false;
+	struct net_pkt *pkt;
+	int i, ret;
+
+	ensure_bridge_ipv4();
+	bridge_ll = net_if_get_link_addr(bridge);
+
+	for (i = 0; i < 3; i++) {
+		eth_fake_data[i].arp_seen = false;
+	}
+
+	pkt = net_pkt_rx_alloc_with_buffer(fake_iface[1],
+					   sizeof(eth_hdr) + sizeof(arp_hdr),
+					   NET_AF_UNSPEC, 0, K_FOREVER);
+	zassert_not_null(pkt, "");
+
+	/* Unicast Ethernet frame addressed to the bridge's own MAC. */
+	memcpy(&eth_hdr.dst, bridge_ll->addr, sizeof(eth_hdr.dst));
+	memcpy(&eth_hdr.src, peer_mac.addr, sizeof(eth_hdr.src));
+	eth_hdr.type = net_htons(NET_ETH_PTYPE_ARP);
+
+	/* ARP request: who-has <bridge_ip> tell <peer>. */
+	arp_hdr.hwtype = net_htons(NET_ARP_HTYPE_ETH);
+	arp_hdr.protocol = net_htons(NET_ETH_PTYPE_IP);
+	arp_hdr.hwlen = NET_ETH_ADDR_LEN;
+	arp_hdr.protolen = NET_ARP_IPV4_PTYPE_SIZE;
+	arp_hdr.opcode = net_htons(NET_ARP_REQUEST);
+	memcpy(&arp_hdr.src_hwaddr, peer_mac.addr, sizeof(arp_hdr.src_hwaddr));
+	memcpy(arp_hdr.src_ipaddr, &peer_ip, sizeof(arp_hdr.src_ipaddr));
+	memcpy(&arp_hdr.dst_hwaddr, bridge_ll->addr, sizeof(arp_hdr.dst_hwaddr));
+	memcpy(arp_hdr.dst_ipaddr, &bridge_ip, sizeof(arp_hdr.dst_ipaddr));
+
+	ret = net_pkt_write(pkt, &eth_hdr, sizeof(eth_hdr));
+	zassert_equal(ret, 0, "");
+	ret = net_pkt_write(pkt, &arp_hdr, sizeof(arp_hdr));
+	zassert_equal(ret, 0, "");
+
+	ret = net_recv_data(fake_iface[1], pkt);
+	zassert_equal(ret, 0, "");
+
+	/* give time to the processing threads to run */
+	k_sleep(K_MSEC(100));
+
+	for (i = 0; i < 3; i++) {
+		reply_seen |= eth_fake_data[i].arp_seen;
+	}
+
+	zassert_true(reply_seen,
+		     "unicast ARP request to bridge was dropped, no reply sent");
+
+	check_free_packet_count();
+}
 #endif /* CONFIG_NET_IPV4 */
 
 static void test_recv_with_bridge(void)
@@ -652,9 +740,11 @@ ZTEST(net_eth_bridge, test_net_eth_bridge)
 	test_recv_before_bridging();
 	DBG("With bridging\n");
 	test_setup_bridge();
+	test_bridge_link_addr();
 #if defined(CONFIG_NET_IPV4)
 	test_local_ipv4_tx_unicast();
 	test_local_ipv4_tx_unicast_arp_miss();
+	test_local_unicast_delivered_to_bridge();
 #endif
 	test_recv_with_bridge();
 	test_recv_with_bridge_fdb();

--- a/tests/net/bridge/tests.yaml
+++ b/tests/net/bridge/tests.yaml
@@ -27,3 +27,10 @@ tests:
       - CONFIG_NET_IPV4=y
       - CONFIG_NET_IPV6=y
       - CONFIG_NET_LINK_ADDR_CUSTOM_LENGTH=8
+  # Exercise the stable (device-id derived) bridge MAC address option.
+  net.eth_bridge.ip.unique_mac:
+    extra_configs:
+      - CONFIG_NET_IPV4=y
+      - CONFIG_NET_IPV6=y
+      - CONFIG_HWINFO=y
+      - CONFIG_NET_ETHERNET_BRIDGE_UNIQUE_MAC=y

--- a/tests/net/bridge/tests.yaml
+++ b/tests/net/bridge/tests.yaml
@@ -34,3 +34,10 @@ tests:
       - CONFIG_NET_IPV6=y
       - CONFIG_HWINFO=y
       - CONFIG_NET_ETHERNET_BRIDGE_UNIQUE_MAC=y
+  # Exercise the configured bridge MAC prefix option.
+  net.eth_bridge.ip.prefix_mac:
+    extra_configs:
+      - CONFIG_NET_IPV4=y
+      - CONFIG_NET_IPV6=y
+      - CONFIG_NET_ETHERNET_BRIDGE_PREFIX_MAC=y
+      - CONFIG_NET_ETHERNET_BRIDGE_MAC_PREFIX="02:34:56:78:9a"

--- a/tests/net/bridge/tests.yaml
+++ b/tests/net/bridge/tests.yaml
@@ -18,3 +18,12 @@ tests:
     extra_configs:
       - CONFIG_NET_IPV4=y
       - CONFIG_NET_IPV6=y
+  # Exercise the bridge with a link address max length larger than an Ethernet
+  # MAC (as happens when another L2 or a custom length is enabled). This is the
+  # configuration where an over-long bridge link address broke local unicast
+  # RX (e.g. ARP replies) and thus address resolution.
+  net.eth_bridge.ip.custom_lladdr_len:
+    extra_configs:
+      - CONFIG_NET_IPV4=y
+      - CONFIG_NET_IPV6=y
+      - CONFIG_NET_LINK_ADDR_CUSTOM_LENGTH=8


### PR DESCRIPTION
When the bridge interface owns an IPv4 address it can originate traffic of its own (for example a TCP server bound to the bridge). Such locally originated IPv4 packets were flooded to the member ports with the family reset to AF_UNSPEC, which disables the ARP step in the Ethernet L2 send routine. The destination link address was therefore left unresolved and defaulted to broadcast, so e.g. a TCP SYN-ACK went out to ff:ff:ff:ff:ff:ff and RFC-compliant peers dropped it.

The member ports cannot resolve on the bridge's behalf either: an ARP reply is addressed to the bridge link address, so a member port would drop it as "not for me". IPv6 is unaffected as its neighbor is resolved in net_ipv6_prepare_for_send() before the packet reaches this layer.

Resolve the destination on the bridge interface, where the ARP cache is populated, before flooding to the member ports. On a cache miss the ARP request is flooded and the packet held until the reply resolves it. Forwarded (L2 bridged) frames already carry a complete header and are left untouched.

Tested on native_sim with the tests/net/bridge regression tests.

Fixes #112408
