### PR TITLE
tests: Bluetooth: bt_crypto_ccm: parameterize RFC vectors with ZTEST_P

### DIFF
--- a/tests/bluetooth/bt_crypto_ccm/src/test_bt_crypto_ccm.c
+++ b/tests/bluetooth/bt_crypto_ccm/src/test_bt_crypto_ccm.c
@@ -9,6 +9,7 @@
 #include <zephyr/ztest_assert.h>
 
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/printk.h>
 #include <zephyr/bluetooth/crypto.h>
 
 #include "common/bt_str.h"
@@ -17,56 +18,71 @@
 
 LOG_MODULE_REGISTER(test_bt_crypto_ccm, LOG_LEVEL_INF);
 
+/* Label each case after its 1-based RFC3610 packet vector number. */
+static const char *ccm_vector_name(size_t index, const void *value)
+{
+	static char buf[16];
+
+	ARG_UNUSED(value);
+	snprintk(buf, sizeof(buf), "packet_%zu", index + 1);
+	return buf;
+}
+
+static const struct ztest_param_values ccm_vals = {
+	.values = input_packets,
+	.count = ARRAY_SIZE(input_packets),
+	.elem_size = sizeof(input_packets[0]),
+	.name_cb = ccm_vector_name,
+};
+
 ZTEST_SUITE(bt_crypto_ccm, NULL, NULL, NULL, NULL, NULL);
 
-ZTEST(bt_crypto_ccm, test_result_rfc_test_vectors)
+ZTEST_P(bt_crypto_ccm, test_result_rfc_test_vectors)
 {
-	for (int i = 0; i < NUMBER_OF_TEST; i++) {
-		LOG_DBG("=============== Packet Vector #%d ==================", i + 1);
-		int err;
-		struct test_data *p = input_packets[i];
+	size_t idx = ztest_get_current_param_index();
+	struct test_data *p = input_packets[idx];
+	size_t vec = idx + 1;
+	int err;
 
-		p->expected_output_len = p->input_len + p->mic_len;
+	LOG_DBG("=============== Packet Vector #%zu ==================", vec);
 
-		const uint8_t *aad = p->input;
+	p->expected_output_len = p->input_len + p->mic_len;
 
-		uint8_t *encrypted_data =
-			(uint8_t *)malloc(p->expected_output_len * sizeof(uint8_t));
+	const uint8_t *aad = p->input;
 
-		memcpy(encrypted_data, p->input, p->input_len);
+	uint8_t *encrypted_data = (uint8_t *)malloc(p->expected_output_len * sizeof(uint8_t));
 
-		err = bt_ccm_encrypt(p->key, p->nonce, &p->input[p->aad_len],
-				     p->input_len - p->aad_len, aad, p->aad_len,
-				     &encrypted_data[p->aad_len], p->mic_len);
-		zassert_true(err == 0, "CCM Encrypt failed for packet vector %d with error %d",
-			     i + 1, err);
+	memcpy(encrypted_data, p->input, p->input_len);
 
-		LOG_DBG("encrypted data %s (len: %d)",
-			bt_hex(encrypted_data, p->expected_output_len), p->expected_output_len);
-		LOG_DBG("expected data  %s (len: %d)",
-			bt_hex(p->expected_output, p->expected_output_len), p->expected_output_len);
+	err = bt_ccm_encrypt(p->key, p->nonce, &p->input[p->aad_len],
+			     p->input_len - p->aad_len, aad,
+			     p->aad_len, &encrypted_data[p->aad_len], p->mic_len);
+	zassert_true(err == 0, "CCM Encrypt failed for packet vector %zu with error %d", vec, err);
 
-		zassert_mem_equal(encrypted_data, p->expected_output, p->expected_output_len,
-				  "Encrypted data are not correct for packet vector %d", i + 1);
+	LOG_DBG("encrypted data %s (len: %d)", bt_hex(encrypted_data, p->expected_output_len),
+		p->expected_output_len);
+	LOG_DBG("expected data  %s (len: %d)", bt_hex(p->expected_output, p->expected_output_len),
+		p->expected_output_len);
 
-		uint8_t *decrypted_data = (uint8_t *)malloc(p->input_len * sizeof(uint8_t));
+	zassert_mem_equal(encrypted_data, p->expected_output, p->expected_output_len,
+			  "Encrypted data are not correct for packet vector %zu", vec);
 
-		memcpy(decrypted_data, encrypted_data, p->aad_len);
+	uint8_t *decrypted_data = (uint8_t *)malloc(p->input_len * sizeof(uint8_t));
 
-		err = bt_ccm_decrypt(p->key, p->nonce, &encrypted_data[p->aad_len],
-				     p->input_len - p->aad_len, aad, p->aad_len,
-				     &decrypted_data[p->aad_len], p->mic_len);
-		zassert_true(err == 0, "CCM Decrypt failed for packet vector %d with error %d",
-			     i + 1, err);
+	memcpy(decrypted_data, encrypted_data, p->aad_len);
 
-		LOG_DBG("decrypted data %s (len: %d)", bt_hex(decrypted_data, p->input_len),
-			p->input_len);
-		LOG_DBG("expected data %s (len: %d)", bt_hex(p->input, p->input_len), p->input_len);
+	err = bt_ccm_decrypt(p->key, p->nonce, &encrypted_data[p->aad_len],
+			     p->input_len - p->aad_len,
+			     aad, p->aad_len, &decrypted_data[p->aad_len], p->mic_len);
+	zassert_true(err == 0, "CCM Decrypt failed for packet vector %zu with error %d", vec, err);
 
-		zassert_mem_equal(decrypted_data, p->input, p->input_len,
-				  "Decrypted data are not correct for packet vector %d", i + 1);
+	LOG_DBG("decrypted data %s (len: %d)", bt_hex(decrypted_data, p->input_len), p->input_len);
+	LOG_DBG("expected data %s (len: %d)", bt_hex(p->input, p->input_len), p->input_len);
 
-		free(encrypted_data);
-		free(decrypted_data);
-	}
+	zassert_mem_equal(decrypted_data, p->input, p->input_len,
+			  "Decrypted data are not correct for packet vector %zu", vec);
+
+	free(encrypted_data);
+	free(decrypted_data);
 }
+ZTEST_INSTANTIATE_TEST_SUITE_P(vectors, bt_crypto_ccm, test_result_rfc_test_vectors, ccm_vals);


### PR DESCRIPTION
test_result_rfc_test_vectors looped over the 24 RFC3610 packet
vectors in input_packets[] inside a single ZTEST body. A failure in
any vector reported as one opaque test, with the offending vector
identifiable only from the printed 1-based index.

Convert the test to ZTEST_P so the framework runs the body once per
vector. The existing input_packets[] table is reused as the
parameter value set and a name_cb labels each case after its
1-based RFC packet-vector number (e.g. packet_7). The current
vector is read from input_packets[] by the parameter index, which
keeps the pointer's type intact (the body mutates p). The
encrypt/decrypt logic and assertions are otherwise unchanged.
