### PR TITLE
net: buf: add NET_BUF_DATA_ALIGNMENT

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -2168,6 +2168,15 @@ MCUmgr
   :ref:`mcumgr_os_application_info` command now always reports the board target as hardware
   platform; the pre-4.3 board and board revision output is no longer available.
 
+Network Buffers
+===============
+
+* :kconfig:option:`CONFIG_NET_BUF_ALIGNMENT` now only aligns the :c:struct:`net_buf` structures
+  themselves. Configurations that used it to align the data buffers, for example for DMA or cache
+  line requirements, must switch to the new :kconfig:option:`CONFIG_NET_BUF_DATA_ALIGNMENT`, which
+  defaults to :kconfig:option:`CONFIG_DCACHE_LINE_SIZE` when that value is non-zero.
+  (:github:`113026`)
+
 POSIX
 =====
 

--- a/drivers/ethernet/Kconfig.bcmgenet
+++ b/drivers/ethernet/Kconfig.bcmgenet
@@ -10,9 +10,6 @@ config ETH_BCMGENET
 
 if ETH_BCMGENET
 
-configdefault NET_BUF_ALIGNMENT
-	default DCACHE_LINE_SIZE if DCACHE
-
 config ETH_BCMGENET_RX_POLLING_INTERVAL_US
 	int "Receive Polling interval in us"
 	default 500

--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -80,9 +80,6 @@ config ETH_DWC_ETHER_1000_CORE_EDFE
 
 if ETH_DWC_ETHER_QOS_CORE || ETH_DWC_ETHER_1000_CORE
 
-configdefault NET_BUF_ALIGNMENT
-	default DCACHE_LINE_SIZE if DCACHE
-
 config DWMAC_NB_TX_DESCS
 	int "Number of entries in the transmit descriptor ring"
 	default 16

--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -129,9 +129,6 @@ config ETH_DWC_ETHER_1000_CORE_EDFE
 
 if ETH_DWC_ETHER_QOS_CORE || ETH_DWC_ETHER_1000_CORE
 
-configdefault NET_BUF_ALIGNMENT
-	default DCACHE_LINE_SIZE if DCACHE
-
 config DWMAC_NB_TX_DESCS
 	int "Number of entries in the transmit descriptor ring"
 	default 16

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -51,17 +51,19 @@
 			 "cache line size"                                                         \
 	);                                                                                         \
 	BUILD_ASSERT(                                                                              \
-		COND_CODE_0(CONFIG_NET_BUF_ALIGNMENT, (sizeof(void *)), (CONFIG_NET_BUF_ALIGNMENT))\
+		COND_CODE_0(CONFIG_NET_BUF_DATA_ALIGNMENT, (sizeof(void *)),                       \
+			(CONFIG_NET_BUF_DATA_ALIGNMENT))                                           \
 		>= MAX(                                                                            \
 			((bus_width) / 8),                                                         \
 			COND_CODE_1(CONFIG_DCACHE, (CONFIG_DCACHE_LINE_SIZE), (0))                 \
-		), "CONFIG_NET_BUF_ALIGNMENT must be at least the data bus width or cache line"    \
-		   "size"                                                                          \
+		), "CONFIG_NET_BUF_DATA_ALIGNMENT must be at least the data bus width or "         \
+		   "cache line size"                                                               \
 	);                                                                                         \
 	IF_ENABLED(CONFIG_DCACHE, (                                                                \
 		BUILD_ASSERT(                                                                      \
-			(CONFIG_NET_BUF_ALIGNMENT) % (CONFIG_DCACHE_LINE_SIZE) == 0,               \
-			"CONFIG_NET_BUF_ALIGNMENT must be a multiple of the data cache line size"  \
+			(CONFIG_NET_BUF_DATA_ALIGNMENT) % (CONFIG_DCACHE_LINE_SIZE) == 0,          \
+			"CONFIG_NET_BUF_DATA_ALIGNMENT must be a multiple of the data cache line " \
+			"size"                                                                     \
 		)                                                                                  \
 	));
 

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -53,17 +53,19 @@
 			 "cache line size"                                                         \
 	);                                                                                         \
 	BUILD_ASSERT(                                                                              \
-		COND_CODE_0(CONFIG_NET_BUF_ALIGNMENT, (sizeof(void *)), (CONFIG_NET_BUF_ALIGNMENT))\
+		COND_CODE_0(CONFIG_NET_BUF_DATA_ALIGNMENT, (sizeof(void *)),                       \
+			(CONFIG_NET_BUF_DATA_ALIGNMENT))                                           \
 		>= MAX(                                                                            \
 			((bus_width) / 8),                                                         \
 			COND_CODE_1(CONFIG_DCACHE, (CONFIG_DCACHE_LINE_SIZE), (0))                 \
-		), "CONFIG_NET_BUF_ALIGNMENT must be at least the data bus width or cache line"    \
-		   "size"                                                                          \
+		), "CONFIG_NET_BUF_DATA_ALIGNMENT must be at least the data bus width or "         \
+		   "cache line size"                                                               \
 	);                                                                                         \
 	IF_ENABLED(CONFIG_DCACHE, (                                                                \
 		BUILD_ASSERT(                                                                      \
-			(CONFIG_NET_BUF_ALIGNMENT) % (CONFIG_DCACHE_LINE_SIZE) == 0,               \
-			"CONFIG_NET_BUF_ALIGNMENT must be a multiple of the data cache line size"  \
+			(CONFIG_NET_BUF_DATA_ALIGNMENT) % (CONFIG_DCACHE_LINE_SIZE) == 0,          \
+			"CONFIG_NET_BUF_DATA_ALIGNMENT must be a multiple of the data cache line " \
+			"size"                                                                     \
 		)                                                                                  \
 	));
 

--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -1478,10 +1478,6 @@ if NXP_WIFI_TX_RX_ZERO_COPY && !NXP_RW610
 configdefault NET_BUF_DATA_SIZE
 	default 2048
 
-# For SDHC zero copy, net buf should be aligned by cache line size
-configdefault NET_BUF_ALIGNMENT
-	default DCACHE_LINE_SIZE
-
 endif # NXP_WIFI_TX_RX_ZERO_COPY && !NXP_RW610
 
 endif # WIFI_NXP

--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -1486,9 +1486,8 @@ configdefault NET_BUF_DATA_SIZE
 
 # For SDHC zero copy, net buf should be aligned by cache line size.
 # On platforms without DCACHE, align to SDHC DMA transfer requirement.
-configdefault NET_BUF_ALIGNMENT
-	default DCACHE_LINE_SIZE if DCACHE
-	default SDHC_BUFFER_ALIGNMENT
+configdefault NET_BUF_DATA_ALIGNMENT
+	default SDHC_BUFFER_ALIGNMENT if !DCACHE
 
 endif # NXP_WIFI_TX_RX_ZERO_COPY && !NXP_RW610
 

--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -36,6 +36,12 @@ extern "C" {
 #define __net_buf_align __aligned(CONFIG_NET_BUF_ALIGNMENT)
 #endif
 
+#if CONFIG_NET_BUF_DATA_ALIGNMENT == 0
+#define __net_buf_data_align __aligned(sizeof(void *))
+#else
+#define __net_buf_data_align __aligned(CONFIG_NET_BUF_DATA_ALIGNMENT)
+#endif
+
 /**
  *  @brief Define a net_buf_simple stack variable.
  *
@@ -1297,7 +1303,7 @@ extern const struct net_buf_data_cb net_buf_fixed_cb;
  */
 #define NET_BUF_POOL_FIXED_DEFINE(_name, _count, _data_size, _ud_size, _destroy) \
 	_NET_BUF_ARRAY_DEFINE(_name, _count, _ud_size);                        \
-	static uint8_t __noinit net_buf_data_##_name[_count][_data_size] __net_buf_align; \
+	static uint8_t __noinit net_buf_data_##_name[_count][_data_size] __net_buf_data_align; \
 	static const struct net_buf_pool_fixed net_buf_fixed_##_name = {       \
 		.data_pool = (uint8_t *)net_buf_data_##_name,                  \
 	};                                                                     \

--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -36,6 +36,12 @@ extern "C" {
 #define __net_buf_align __aligned(CONFIG_NET_BUF_ALIGNMENT)
 #endif
 
+#if CONFIG_NET_BUF_DATA_ALIGNMENT == 0
+#define __net_buf_data_align __aligned(sizeof(void *))
+#else
+#define __net_buf_data_align __aligned(CONFIG_NET_BUF_DATA_ALIGNMENT)
+#endif
+
 /**
  *  @brief Define a net_buf_simple stack variable.
  *
@@ -1330,7 +1336,7 @@ extern const struct net_buf_data_cb net_buf_fixed_cb;
  */
 #define NET_BUF_POOL_FIXED_DEFINE(_name, _count, _data_size, _ud_size, _destroy) \
 	_NET_BUF_ARRAY_DEFINE(_name, _count, _ud_size);                        \
-	static uint8_t __noinit net_buf_data_##_name[_count][_data_size] __net_buf_align; \
+	static uint8_t __noinit net_buf_data_##_name[_count][_data_size] __net_buf_data_align; \
 	static const struct net_buf_pool_fixed net_buf_fixed_##_name = {       \
 		.data_pool = (uint8_t *)net_buf_data_##_name,                  \
 	};                                                                     \

--- a/lib/net_buf/Kconfig
+++ b/lib/net_buf/Kconfig
@@ -53,10 +53,21 @@ config NET_BUF_ALIGNMENT
 	int "Network buffer alignment restriction"
 	default 0
 	help
-	  Alignment restriction for network buffers. This is useful for
+	  Alignment restriction for network buffers. This is just used for
+	  the struct net_buf and not for its data buffer.
+	  Default value of 0 means the alignment will be the size of a void pointer,
+	  any other value will force the alignment of a net buffer in bytes.
+
+config NET_BUF_DATA_ALIGNMENT
+	int "Network buffer data alignment restriction"
+	default DCACHE_LINE_SIZE if (DCACHE_LINE_SIZE > 0)
+	default 0
+	help
+	  Alignment restriction for network buffers data. This is useful for
 	  some hardware IP with DMA that requires the buffers to be aligned
 	  to a certain byte boundary, or dealing with cache line restrictions.
 	  Default value of 0 means the alignment will be the size of a void pointer,
-	  any other value will force the alignment of a net buffer in bytes.
+	  any other value will force the alignment of a net buffers data in bytes.
+	  If the dcache is enabled, we will use the dcache line size by default.
 
 endif # NET_BUF

--- a/lib/net_buf/Kconfig
+++ b/lib/net_buf/Kconfig
@@ -69,10 +69,21 @@ config NET_BUF_ALIGNMENT
 	int "Network buffer alignment restriction"
 	default 0
 	help
-	  Alignment restriction for network buffers. This is useful for
+	  Alignment restriction for network buffers. This is just used for
+	  the struct net_buf and not for its data buffer.
+	  Default value of 0 means the alignment will be the size of a void pointer,
+	  any other value will force the alignment of a net buffer in bytes.
+
+config NET_BUF_DATA_ALIGNMENT
+	int "Network buffer data alignment restriction"
+	default DCACHE_LINE_SIZE if (DCACHE_LINE_SIZE > 0)
+	default 0
+	help
+	  Alignment restriction for network buffers data. This is useful for
 	  some hardware IP with DMA that requires the buffers to be aligned
 	  to a certain byte boundary, or dealing with cache line restrictions.
 	  Default value of 0 means the alignment will be the size of a void pointer,
-	  any other value will force the alignment of a net buffer in bytes.
+	  any other value will force the alignment of a net buffers data in bytes.
+	  If the dcache is enabled, we will use the dcache line size by default.
 
 endif # NET_BUF


### PR DESCRIPTION
add NET_BUF_DATA_ALIGNMENT, that will only
allign the data of the net buf. Also align it by
default by the DCACHE_LINE_SIZE if DACHE is
enabled.