### PR TITLE
dts: broadcom: fix CTS pin in uart0_ctsrts_gpio32

### DIFF
--- a/dts/arm/broadcom/bcm283x-pinctrl.dtsi
+++ b/dts/arm/broadcom/bcm283x-pinctrl.dtsi
@@ -43,7 +43,7 @@
 		};
 
 		group2 {
-			pinmux = <UART0_RTS_GPIO31>,
+			pinmux = <UART0_CTS_GPIO30>,
 				 <UART0_RX_GPIO33>;
 			bias-pull-up;
 		};


### PR DESCRIPTION
uart0_ctsrts_gpio32 muxed UART0_RTS_GPIO31 in both group1 and group2 and never muxed UART0_CTS_GPIO30, so CTS/RTS flow control was broken for any board using this group.

Verified on a Pi Zero 2 W where these pins (GPIO 30-33 at ALT3) route uart0 to the onboard CYW43436 BT HCI with flow control enabled.