### PR TITLE
MAINTAINERS.yml: drivers: ethernet: remove decsny

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1935,7 +1935,6 @@ Documentation Infrastructure:
   maintainers:
     - maass-hamburg
   collaborators:
-    - decsny
     - lmajewski
     - pdgendt
     - ClaCodes


### PR DESCRIPTION
decsny has not reviewed a ethernet driver PR
since beginning of this year, therefore remove him from the ethernet drivers area. If he is comming back, he is welcome to add himself again.