### PR TITLE
lib: utils: json: add top-level object member walker

### DIFF
--- a/include/zephyr/data/json.h
+++ b/include/zephyr/data/json.h
@@ -75,6 +75,22 @@ struct json_obj {
 	struct json_lexer lex;
 };
 
+/**
+ * @brief A single top-level "key": value member of a JSON object.
+ *
+ * Returned by @ref json_obj_next_key_value. Both the key and the value are raw
+ * spans into the parsed payload; the value is returned verbatim (its type is
+ * given by @c value.type) and is not decoded.
+ */
+struct json_obj_key_value {
+	/** Member key text (not NUL-terminated), or NULL at the end of the object. */
+	const char *key;
+	/** Length of the key text in bytes. */
+	size_t key_len;
+	/** Member value, returned as a raw token span. */
+	struct json_token value;
+};
+
 struct json_obj_token {
 	char *start;
 	size_t length;
@@ -715,6 +731,52 @@ int json_arr_separate_object_parse_init(struct json_obj *json, char *payload, si
  */
 int json_arr_separate_parse_object(struct json_obj *json, const struct json_obj_descr *descr,
 				   size_t descr_len, void *val);
+
+/**
+ * @brief Initialize incremental parsing of a JSON object's members.
+ *
+ * JSON-encoded object data is going to be walked one top-level member at a time.
+ * Data is provided by @a payload with the size of @a len bytes.
+ *
+ * Validates that a JSON object start is detected and initializes @a json for
+ * member-by-member parsing with @ref json_obj_next_key_value. Unlike
+ * json_obj_parse(), no descriptor is required up front, which suits callers that
+ * dispatch each member to a handler chosen at run time.
+ *
+ * @param json Provide storage for parser state. To be used when walking the object.
+ * @param payload Pointer to JSON-encoded object to be parsed
+ * @param len Length of JSON-encoded object
+ *
+ * @return 0 if object start is detected and initialization is successful, or a
+ * negative error code in case of failure.
+ */
+int json_obj_separate_parse_init(struct json_obj *json, char *payload, size_t len);
+
+/**
+ * @brief Return the next top-level member of a JSON object.
+ *
+ * Walks one "key": value member of the object initialized by
+ * @ref json_obj_separate_parse_init. The value is returned as a raw, undecoded
+ * span in @a kv->value, leaving the caller to route it by key. A scalar spans the
+ * value text; an object or array spans the whole balanced @c {...} / @c [...]
+ * (its @c type is @ref JSON_TOK_OBJECT_START / @ref JSON_TOK_ARRAY_START). The
+ * value span can therefore be handed straight to a decoder such as
+ * json_obj_parse() or json_arr_parse(), per @a kv->value.type.
+ *
+ * @note @a kv->key and @a kv->value point into the @a payload buffer passed to
+ * @ref json_obj_separate_parse_init; they are borrowed and stay valid only as
+ * long as that buffer does. Copy the span out if a stable or mutable copy is
+ * needed (e.g. before parsing it in place).
+ *
+ * @param json Pointer to JSON-object parser state
+ * @param kv Pointer to storage for the returned key and value
+ *
+ * @return 0 on success with @a kv->key pointing at the member key and
+ * @a kv->value holding the raw value span; 0 at the end of the object with
+ * @a kv->key set to NULL; a negative error code on malformed input or on
+ * container nesting deeper than 64 levels.
+ */
+int json_obj_next_key_value(struct json_obj *json, struct json_obj_key_value *kv);
 
 /**
  * @brief Escapes the string so it can be used to encode JSON objects

--- a/lib/utils/json.c
+++ b/lib/utils/json.c
@@ -18,12 +18,6 @@
 
 #include <zephyr/data/json.h>
 
-struct json_obj_key_value {
-	const char *key;
-	size_t key_len;
-	struct json_token value;
-};
-
 static bool lexer_consume(struct json_lexer *lex, struct json_token *tok,
 			  enum json_tokens empty_token)
 {
@@ -1315,6 +1309,78 @@ int json_arr_separate_parse_object(struct json_obj *json, const struct json_obj_
 	}
 
 	return obj_parse(json, descr, descr_len, val);
+}
+
+int json_obj_separate_parse_init(struct json_obj *json, char *payload, size_t len)
+{
+	return obj_init(json, payload, len);
+}
+
+int json_obj_next_key_value(struct json_obj *json, struct json_obj_key_value *kv)
+{
+	int ret = obj_next(json, kv);
+
+	if (ret < 0 || kv->key == NULL) {
+		return ret;
+	}
+
+	/*
+	 * obj_next() returns a container value as its start token only. Walk the
+	 * token stream to the matching close so the caller receives the full
+	 * balanced {...} / [...] span and the walk resyncs to the next member.
+	 * Strings are single lexer tokens, so braces inside a string value do not
+	 * affect the walk.
+	 */
+	if (kv->value.type == JSON_TOK_OBJECT_START || kv->value.type == JSON_TOK_ARRAY_START) {
+		enum json_tokens type = kv->value.type;
+		char *start = kv->value.start;
+		struct json_token tok;
+		uint64_t kinds = (type == JSON_TOK_ARRAY_START) ? 1U : 0U;
+		int depth = 1;
+
+		do {
+			if (!lexer_next(&json->lex, &tok)) {
+				return -EINVAL;
+			}
+
+			switch (tok.type) {
+			case JSON_TOK_OBJECT_START:
+			case JSON_TOK_ARRAY_START:
+				if (depth >= 64) {
+					return -EINVAL;
+				}
+				if (tok.type == JSON_TOK_ARRAY_START) {
+					kinds |= ((uint64_t)1 << depth);
+				} else {
+					kinds &= ~((uint64_t)1 << depth);
+				}
+				depth++;
+				break;
+			case JSON_TOK_OBJECT_END:
+			case JSON_TOK_ARRAY_END: {
+				bool closed_array = (tok.type == JSON_TOK_ARRAY_END);
+				bool opened_array;
+
+				depth--;
+				opened_array = ((kinds >> depth) & 1U) != 0U;
+				if (closed_array != opened_array) {
+					return -EINVAL;
+				}
+				break;
+			}
+			case JSON_TOK_ERROR:
+				return -EINVAL;
+			default:
+				break;
+			}
+		} while (depth > 0);
+
+		kv->value.type = type;
+		kv->value.start = start;
+		kv->value.end = tok.end;
+	}
+
+	return ret;
 }
 
 static char escape_as(char chr)

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -3147,4 +3147,316 @@ ZTEST(lib_json_test, test_json_polymorphic_complex_type_error_handling)
 	zassert_true(ret < 0, "Parsing should fail immediately for invalid object, got %d", ret);
 }
 
+/*
+ * Tests for the top-level object-member walker
+ * (json_obj_separate_parse_init / json_obj_next_key_value).
+ */
+
+static bool jkv_key_eq(const struct json_obj_key_value *kv, const char *key)
+{
+	return kv->key != NULL && kv->key_len == strlen(key) &&
+	       memcmp(kv->key, key, kv->key_len) == 0;
+}
+
+static bool jtok_span_eq(const struct json_token *tok, const char *text)
+{
+	size_t len = (size_t)(tok->end - tok->start);
+
+	return len == strlen(text) && memcmp(tok->start, text, len) == 0;
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_empty)
+{
+	char payload[] = "{}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_is_null(kv.key, "empty object must report end of object");
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_single)
+{
+	char payload[] = "{\"a\":1}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "a"), "key mismatch");
+	zassert_equal(kv.value.type, JSON_TOK_NUMBER, "value type mismatch");
+	zassert_true(jtok_span_eq(&kv.value, "1"), "value span mismatch");
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_is_null(kv.key, "expected end of object");
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_multiple)
+{
+	char payload[] = "{\"a\":1,\"b\":\"xy\",\"c\":true}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "a"));
+	zassert_equal(kv.value.type, JSON_TOK_NUMBER);
+	zassert_true(jtok_span_eq(&kv.value, "1"));
+
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "b"));
+	zassert_equal(kv.value.type, JSON_TOK_STRING);
+	zassert_true(jtok_span_eq(&kv.value, "xy"));
+
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "c"));
+	zassert_equal(kv.value.type, JSON_TOK_TRUE);
+
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_is_null(kv.key);
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_nested_object_span)
+{
+	char payload[] = "{\"o\":{\"x\":1}}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "o"));
+	zassert_equal(kv.value.type, JSON_TOK_OBJECT_START);
+	zassert_true(jtok_span_eq(&kv.value, "{\"x\":1}"),
+		     "object value must be the full balanced span");
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_is_null(kv.key, "walk must resync to object end after a container");
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_nested_array_span)
+{
+	char payload[] = "{\"a\":[1,2,3]}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "a"));
+	zassert_equal(kv.value.type, JSON_TOK_ARRAY_START);
+	zassert_true(jtok_span_eq(&kv.value, "[1,2,3]"),
+		     "array value must be the full balanced span");
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_is_null(kv.key);
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_deep_nesting_span)
+{
+	char payload[] = "{\"d\":{\"a\":[{\"n\":1}]},\"e\":9}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "d"));
+	zassert_equal(kv.value.type, JSON_TOK_OBJECT_START);
+	zassert_true(jtok_span_eq(&kv.value, "{\"a\":[{\"n\":1}]}"),
+		     "arbitrarily nested value must span the whole balanced container");
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "e"), "walk must resync after deep container");
+	zassert_true(jtok_span_eq(&kv.value, "9"));
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_braces_in_string_value)
+{
+	/* A brace/bracket inside a string value must not close the container early. */
+	char payload[] = "{\"o\":{\"k\":\"}]\"},\"b\":1}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "o"));
+	zassert_true(jtok_span_eq(&kv.value, "{\"k\":\"}]\"}"),
+		     "string braces must not truncate the container span");
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "b"));
+	zassert_true(jtok_span_eq(&kv.value, "1"));
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_container_not_last_object)
+{
+	char payload[] = "{\"a\":{\"x\":1},\"b\":2}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "a"));
+	zassert_true(jtok_span_eq(&kv.value, "{\"x\":1}"));
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "b"), "must resync to the member after the object");
+	zassert_true(jtok_span_eq(&kv.value, "2"));
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_is_null(kv.key);
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_container_not_last_array)
+{
+	char payload[] = "{\"a\":[1,2],\"b\":3}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "a"));
+	zassert_true(jtok_span_eq(&kv.value, "[1,2]"));
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "b"), "must resync to the member after the array");
+	zassert_true(jtok_span_eq(&kv.value, "3"));
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_is_null(kv.key);
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_empty_containers)
+{
+	char obj_payload[] = "{\"a\":{}}";
+	char arr_payload[] = "{\"a\":[]}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, obj_payload, strlen(obj_payload)), 0);
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "a"));
+	zassert_true(jtok_span_eq(&kv.value, "{}"), "empty object span must be exactly {}");
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_is_null(kv.key);
+
+	zassert_equal(json_obj_separate_parse_init(&obj, arr_payload, strlen(arr_payload)), 0);
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "a"));
+	zassert_true(jtok_span_eq(&kv.value, "[]"), "empty array span must be exactly []");
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_is_null(kv.key);
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_unbalanced_container)
+{
+	/* Container value with no matching close must fail on the same call. */
+	char payload[] = "{\"o\":{\"x\":1";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_true(json_obj_next_key_value(&obj, &kv) < 0,
+		     "unbalanced container value must fail");
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_string_escapes)
+{
+	char payload[] = "{\"k\":\"a\\\"b\\n\"}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "k"));
+	zassert_equal(kv.value.type, JSON_TOK_STRING);
+	/* Raw span: escape sequences are not processed by the walker. */
+	zassert_true(jtok_span_eq(&kv.value, "a\\\"b\\n"), "escaped string span mismatch");
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_whitespace)
+{
+	char payload[] = "  {  \"a\" : 1 , \"b\" : 2 }  ";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "a"));
+	zassert_true(jtok_span_eq(&kv.value, "1"));
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "b"));
+	zassert_true(jtok_span_eq(&kv.value, "2"));
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_is_null(kv.key);
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_init_not_object)
+{
+	char payload[] = "[1,2]";
+	struct json_obj obj;
+
+	zassert_true(json_obj_separate_parse_init(&obj, payload, strlen(payload)) < 0,
+		     "init must reject a non-object payload");
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_missing_colon)
+{
+	char payload[] = "{\"a\" 1}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_true(json_obj_next_key_value(&obj, &kv) < 0, "missing colon must fail");
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_unterminated_string)
+{
+	char payload[] = "{\"a\":\"x}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_true(json_obj_next_key_value(&obj, &kv) < 0, "unterminated string must fail");
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_unbalanced_braces)
+{
+	char payload[] = "{\"a\":1";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_equal(json_obj_next_key_value(&obj, &kv), 0);
+	zassert_true(jkv_key_eq(&kv, "a"));
+	zassert_true(json_obj_next_key_value(&obj, &kv) < 0, "missing '}' must fail");
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_mismatched_object_close)
+{
+	/* Object value closed by a bracket: depth is balanced but the pair is not. */
+	char payload[] = "{\"a\":{]}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_true(json_obj_next_key_value(&obj, &kv) < 0, "'{]' must fail");
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_mismatched_array_close)
+{
+	/* Array value closed by a brace: depth is balanced but the pair is not. */
+	char payload[] = "{\"a\":[}}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_true(json_obj_next_key_value(&obj, &kv) < 0, "'[}' must fail");
+}
+
+ZTEST(lib_json_test, test_json_obj_walk_interleaved_mismatch)
+{
+	/* Array holding an open object closed by the array's bracket. Depth returns
+	 * to zero and neither brace nor bracket count goes negative, so only a
+	 * type-matched scan rejects it.
+	 */
+	char payload[] = "{\"a\":[{]}}";
+	struct json_obj obj;
+	struct json_obj_key_value kv;
+
+	zassert_equal(json_obj_separate_parse_init(&obj, payload, strlen(payload)), 0);
+	zassert_true(json_obj_next_key_value(&obj, &kv) < 0, "'[{]}' must fail");
+}
+
 ZTEST_SUITE(lib_json_test, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
`json_obj_parse()` needs a fixed `json_obj_descr` describing every field up front and reports only a top-level present bitmap. This doesn't fit a caller that dispatches each top-level member to a handler chosen at runtime (e.g. handlers registered across like iterable_sections and so on), where no single descriptor for the whole object exists. Such a caller has to hand-roll a lexer to split the object into "key":value members and route each raw value to the handler that owns the key.

Adding two public functions that walk an object's top-level members over the existing object lexer with no descriptor required:

- `json_obj_separate_parse_init()`: validate the object start and init the walk.
- `json_obj_next_key_value()`: return the next "key":value member.

Each value is returned as a raw, undecoded span into the payload: a scalar spans its text, an object or array spans the whole balanced {...} / [...], so it can be handed straight to `json_obj_parse()` for example. The span aliases the input buffer (borrowed; copy it if you need a stable/mutable copy). Existing functions are unchanged.

Tests cover empty/single/multiple members, arbitrary nesting depth, braces inside string values, resync to the next member after a container, empty containers, and malformed input (non-object, missing colon, unterminated string, truncated container).