### PR TITLE
manifest: bump Mbed TLS to v4.1.1 and TF-PSA-Crypto to v1.1.1

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1178,6 +1178,12 @@ Mbed TLS
   as an alias to the latter for backward compatibility, but it will be removed in future
   releases.
 
+* Mbed TLS was updated to version 4.1.1. Release notes can be found
+  `here <https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-4.1.1>`_.
+
+* TF-PSA-Crypto was updated to version 1.1.1. Release notes can be found
+  `here <https://github.com/Mbed-TLS/TF-PSA-Crypto/releases/tag/tf-psa-crypto-1.1.1>`_.
+
 Trusted Firmware-M
 ==================
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -345,6 +345,12 @@ Libraries / Subsystems
 
   * Added AES CFB and OFB cipher mode support.
 
+  * Mbed TLS was updated to version 4.1.1. Release notes can be found
+    `here <https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-4.1.1>`_.
+
+  * TF-PSA-Crypto was updated to version 1.1.1. Release notes can be found
+    `here <https://github.com/Mbed-TLS/TF-PSA-Crypto/releases/tag/tf-psa-crypto-1.1.1>`_.
+
 * DFU
 
   * Added :kconfig:option:`CONFIG_IMG_CUSTOM_SECTOR_SIZE` to allow MCUboot to use a different

--- a/west.yml
+++ b/west.yml
@@ -324,7 +324,7 @@ manifest:
       revision: bbedf2656086a93a8468a1c98168a6b36631ce9a
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: c53cc657cedbd17c009cb676a17bffb28b6650a3
+      revision: 098e120afb51877ed814bdc04443890ae12e0642
       path: modules/crypto/mbedtls
       groups:
         - crypto
@@ -389,7 +389,7 @@ manifest:
         - testing
         - tee
     - name: tf-psa-crypto
-      revision: 2d881593696aec687ca2246c53de207c2b9bf782
+      revision: fa92349590a54959ee2efc21b668e5afdb144726
       path: modules/crypto/tf-psa-crypto
       groups:
         - crypto


### PR DESCRIPTION
Bump:
- Mbed TLS from 4.1.0 to 4.1.1
- TF-PSA-Crypto from 1.1.0 to 1.1.1

CVEs are still missing because they have not been published yet form upstream project.