### PR TITLE
maintainers: espressif: own esp_at and esp_hosted wifi paths

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3119,6 +3119,8 @@ Espressif Platforms:
     - samples/boards/espressif/
     - tests/boards/espressif/
     - drivers/*/*esp32*/
+    - drivers/wifi/esp_hosted/
+    - drivers/wifi/esp_at/
   file-groups:
     - name: Espressif hosted Wi-Fi driver
       files:


### PR DESCRIPTION
Add the Espressif Wi-Fi driver folders to the area's main files list so the Espressif maintainer is a real assignment candidate. They previously lived only under file-groups, which inherits from the parent area and carries no maintainer, so those entries never matched and PRs touching them were assigned to the generic Wi-Fi area instead.

The file-groups entries are kept so the per-driver labels and collaborator scoping still apply, matching how other vendors list their wifi folders in both files and file-groups.