### PR TITLE
tests: timer_behavior: compute drift and jitter bounds from the clock

### DIFF
--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -34,10 +34,6 @@ config TIMER_TEST_MAX_STDDEV
 	default 33 if ITE_IT8XXX2_TIMER
 	default 10
 
-config TIMER_TEST_MAX_DRIFT
-	int "Maximum drift in microseconds allowed (should be about 1 period allowance)"
-	default 1000
-
 config TIMER_EXTERNAL_TEST
 	bool "Perform test using an external tool"
 	help

--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -28,12 +28,6 @@ config TIMER_TEST_PERIOD
 	int "The number of microseconds to for the timer period"
 	default 1000
 
-config TIMER_TEST_MAX_STDDEV
-	int "Maximum standard deviation in microseconds allowed"
-	default 33 if NPCX_ITIM_TIMER
-	default 33 if ITE_IT8XXX2_TIMER
-	default 10
-
 config TIMER_EXTERNAL_TEST
 	bool "Perform test using an external tool"
 	help

--- a/tests/kernel/timer/timer_behavior/Kconfig
+++ b/tests/kernel/timer/timer_behavior/Kconfig
@@ -38,23 +38,6 @@ config TIMER_TEST_MAX_DRIFT
 	int "Maximum drift in microseconds allowed (should be about 1 period allowance)"
 	default 1000
 
-config TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT
-	int "Maximum drift percentage for the timer period"
-	# Use 13% on nRF platforms using the RTC timer because one tick there is
-	# ~122 us (see SYS_CLOCK_TICKS_PER_SEC configuration above) and one tick
-	# difference in the test period is nothing unusual (it can happen for
-	# example if a new tick elapses right after the kernel gets the number
-	# of elapsed ticks when scheduling a new timeout but before the timer
-	# driver sets up that timeout).
-	default 13 if NRF_RTC_TIMER && TICKLESS_KERNEL
-	# Use 13% on Infineon platforms using the MCWDT timer because it takes
-	# a variable amount of time to reprogram the timer compare for a delay
-	# which may result in slightly higher maximum delay times.
-	default 13 if INFINEON_LP_TIMER_PDL
-	default 10
-	help
-	  A value of 10 means 10%.
-
 config TIMER_EXTERNAL_TEST
 	bool "Perform test using an external tool"
 	help

--- a/tests/kernel/timer/timer_behavior/README
+++ b/tests/kernel/timer/timer_behavior/README
@@ -68,8 +68,8 @@ the board under test and one at the external tool (Zephyr implementation of
 the timer also plays a role, and it's the real target of the test, but it
 depends on the board's clock). Different clocks run at different speeds, so
 they tend to drift. To be able to account for this drift, the external test
-doesn't reuse CONFIG_TIMER_TEST_MAX_DRIFT and
-CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT, instead introducing
+doesn't reuse CONFIG_TIMER_TEST_MAX_DRIFT or the built-in test's computed
+per-period drift bound, instead introducing
 CONFIG_TIMER_EXTERNAL_TEST_MAX_DRIFT_PPM and
 CONFIG_TIMER_EXTERNAL_TEST_PERIOD_MAX_DRIFT_PPM, that can be more finely tuned
 for the hardware in question.

--- a/tests/kernel/timer/timer_behavior/README
+++ b/tests/kernel/timer/timer_behavior/README
@@ -68,8 +68,7 @@ the board under test and one at the external tool (Zephyr implementation of
 the timer also plays a role, and it's the real target of the test, but it
 depends on the board's clock). Different clocks run at different speeds, so
 they tend to drift. To be able to account for this drift, the external test
-doesn't reuse CONFIG_TIMER_TEST_MAX_DRIFT or the built-in test's computed
-per-period drift bound, instead introducing
+doesn't reuse the built-in test's computed drift bounds, instead introducing
 CONFIG_TIMER_EXTERNAL_TEST_MAX_DRIFT_PPM and
 CONFIG_TIMER_EXTERNAL_TEST_PERIOD_MAX_DRIFT_PPM, that can be more finely tuned
 for the hardware in question.

--- a/tests/kernel/timer/timer_behavior/pytest/test_timer.py
+++ b/tests/kernel/timer/timer_behavior/pytest/test_timer.py
@@ -38,9 +38,9 @@ def do_analysis(test, stats, stats_count, config, sys_clock_hw_cycles_per_sec):
                  expected_period_drift) / 1_000_000
 
     min_cyc = 1. / sys_clock_hw_cycles_per_sec
-    max_stddev = int(config['TIMER_TEST_MAX_STDDEV']) / 1_000_000
-    # Max STDDEV cannot be lower than clock single cycle
-    max_stddev = max(min_cyc, max_stddev)
+    # Allowed jitter is one tick (the scheduling quantum), computed from the
+    # clock; never below a single cycle.
+    max_stddev = max(min_cyc, 1. / ticks_per_sec)
 
     max_drift_ppm = int(config['TIMER_EXTERNAL_TEST_MAX_DRIFT_PPM'])
     time_diff = stats['total_time'] - seconds - expected_total_drift

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -237,8 +237,10 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		- expected_time_drift_us;
 	double time_diff_us_abs = time_diff_us >= 0.0 ? time_diff_us : -time_diff_us;
 
-	/* If max stddev is lower than a single clock tick then round it up. */
-	uint32_t max_stddev = MAX(k_ticks_to_us_ceil32(1), CONFIG_TIMER_TEST_MAX_STDDEV);
+	/* Allowed jitter is one tick, the scheduling quantum, computed from the
+	 * clock rather than a tuning value.
+	 */
+	uint32_t max_stddev = k_ticks_to_us_ceil32(1);
 
 	TC_PRINT("timer clock rate %u, kernel tick rate %d\n",
 		 sys_clock_hw_cycles_per_sec(), CONFIG_SYS_CLOCK_TICKS_PER_SEC);

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -363,9 +363,14 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 	zassert_true(stddev_us < (double)max_stddev,
 		     "Standard deviation (in microseconds) outside expected bound");
 
-	/* Validate the timer drift (accuracy over time) is within a configurable bound */
-	zassert_true(time_diff_us_abs < CONFIG_TIMER_TEST_MAX_DRIFT,
-		     "Drift (in microseconds) outside expected bound");
+	/* Validate the timer accuracy over time: the total measured time must
+	 * not drift from the model by as much as a whole period. That "within
+	 * one period" allowance is the test period itself, so no separate tuning
+	 * value is needed.
+	 */
+	zassert_true(time_diff_us_abs < test_period,
+		     "Total drift %f us exceeds one period (%f us)",
+		     time_diff_us_abs, test_period);
 }
 
 ZTEST(timer_jitter_drift, test_jitter_drift_timer_period)

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -311,22 +311,51 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		 max_stddev
 		 );
 
-	/* Validate the maximum/minimum timer period is off by no more than 10% */
+	/* Validate the maximum/minimum timer period is within the allowed drift.
+	 *
+	 * The bound is an absolute time, one tick, computed from the clock rather
+	 * than a percentage of the period. A periodic timer is rescheduled in
+	 * whole ticks, so a single period can land up to one tick from nominal;
+	 * one tick also covers the measurement slop at any realistic tick rate.
+	 * It scales with the cycle-to-tick ratio, so a coarse clock (e.g. a
+	 * 32 kHz SysTick, where a tick is a large fraction of the period) widens
+	 * the bound automatically and needs no per-platform value.
+	 */
 	double test_period = (double)CONFIG_TIMER_TEST_PERIOD;
-	double period_max_drift_percentage =
-		(double)CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT / 100;
-	double min_us_bound = test_period - period_max_drift_percentage * test_period
-		+ expected_period_drift;
-	double max_us_bound = test_period + period_max_drift_percentage * test_period
-		+ expected_period_drift;
+	double allowed_drift_us = (double)k_ticks_to_us_ceil32(1);
+	double nominal_us = test_period + expected_period_drift;
 
-	zassert_true(min_us >= min_us_bound,
-		"Shortest timer period too short (off by more than expected %d%%)",
-		CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT);
-	zassert_true(max_us <= max_us_bound,
-		"Longest timer period too long (off by more than expected %d%%)",
-		CONFIG_TIMER_TEST_PERIOD_MAX_DRIFT_PERCENT);
+	/* Report the measured drift as a percentage for readability; the
+	 * pass/fail decision below is on the absolute allowed_drift_us bound.
+	 */
+	TC_PRINT("period drift allowed +/-%f us (%.3g%%); measured min %f us (%.3g%%), "
+		 "max %f us (%.3g%%)\n",
+		 allowed_drift_us, allowed_drift_us / test_period * 100,
+		 nominal_us - min_us, (nominal_us - min_us) / test_period * 100,
+		 max_us - nominal_us, (max_us - nominal_us) / test_period * 100);
 
+	zassert_true(max_us <= nominal_us + allowed_drift_us,
+		"Longest timer period %f us too long: drift %f us (%.3g%%) exceeds allowed %f us",
+		max_us, max_us - nominal_us, (max_us - nominal_us) / test_period * 100,
+		allowed_drift_us);
+
+	/* The low-side bound (nominal - one tick) only carries information while
+	 * the nominal period stays above one tick. A period can never be
+	 * negative, so once the period is within a tick of zero, "one tick short"
+	 * permits an arbitrarily short period and the assertion can no longer
+	 * fail. Skip it there rather than run a check that always passes; at that
+	 * resolution the short side is constrained by the jitter (stddev) and
+	 * total-drift checks below.
+	 */
+	if (nominal_us > allowed_drift_us) {
+		zassert_true(min_us >= nominal_us - allowed_drift_us,
+			"Shortest timer period %f us too short: drift %f us (%.3g%%) exceeds allowed %f us",
+			min_us, nominal_us - min_us, (nominal_us - min_us) / test_period * 100,
+			allowed_drift_us);
+	} else {
+		TC_PRINT("nominal period (%f us) is within one tick; short-side bound "
+			 "not applicable, see stddev and total drift\n", nominal_us);
+	}
 
 	/* Validate the timer deviation (precision/jitter of the timer) is within a configurable
 	 * bound


### PR DESCRIPTION
The timer_behavior jitter and drift checks used hand-tuned tolerances with
per-platform exceptions:

* a per-period drift percentage (10%, bumped to 13% for the nRF RTC),
* an absolute total-drift limit (1000 us), and
* a jitter/stddev limit (10 us, bumped to 33 us for the NPCX and ITE EC timers).

These do not generalize. A new coarse clock such as the 32 kHz SysTick on the
Realtek Bee SoCs needs yet another exception (see #112974), because at that
resolution one tick is already a large fraction of the 1 ms test period.

Each of these bounds is really a fixed multiple of a clock quantity, so this
series derives them from the clock instead of tuning them:

* period drift -> one tick. A periodic timer is rescheduled in whole ticks, so
  a single period can land up to one tick from nominal. This reproduces the old
  nRF value (one 122 us tick over a 1 ms period is 12.2%) and scales with the
  cycle-to-tick ratio, so coarse clocks widen automatically. Once the period is
  itself within one tick (as on the 32 kHz Bee), `nominal - one tick` is zero or
  negative and a period cannot be shorter than zero, so the short-side check is
  skipped there rather than run as a vacuous always-pass; the stddev and
  total-drift checks still constrain that case.
* total drift -> one period. The accumulated drift over the run must stay under
  a full period, and that allowance is the period itself.
* jitter (stddev) -> one tick. The check already floored at one tick, and one
  tick exceeds the old 10/33 us values on every platform here (244 us on ITE,
  1000 us on NPCX, 122 us on nRF), so the configured values were dead.

Three Kconfig symbols and all their per-platform exceptions are removed, and
coarse-clock platforms need no new ones. The measured drift is still printed as
a percentage for readability; pass/fail is on the computed absolute bound.

Behavior is preserved on existing platforms: the computed bound matches or
exceeds what the removed values provided. Verified on mps2/an385 across tick
rates. The external logic-analyzer path's jitter bound is only widened.

Relationship to #112974: this replaces that PR's period-drift exception (the
19% proposed for Realtek Bee) with the computed bound, so no per-platform
percentage is needed. Its driver-side min-timeout-cycles tuning is superseded by
#113083, which derives the SysTick minimum timeout from the cycle rate; that is
where the underlying double-fire is fixed. This PR is the test-side counterpart.
