### PR TITLE
drivers: gnss: add ericsson f5521gw gnss driver

### DIFF
--- a/drivers/gnss/CMakeLists.txt
+++ b/drivers/gnss/CMakeLists.txt
@@ -7,6 +7,7 @@ zephyr_library_sources(gnss_publish.c)
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_GNSS_DUMP gnss_dump.c)
 zephyr_library_sources_ifdef(CONFIG_GNSS_EMUL gnss_emul.c)
+zephyr_library_sources_ifdef(CONFIG_GNSS_ERICSSON_F5521GW gnss_ericsson_f5521gw.c)
 zephyr_library_sources_ifdef(CONFIG_GNSS_GLOBALTOP_PA6H gnss_globaltop_pa6h.c)
 zephyr_library_sources_ifdef(CONFIG_GNSS_LUATOS_AIR530Z gnss_luatos_air530z.c)
 zephyr_library_sources_ifdef(CONFIG_GNSS_NMEA0183 gnss_nmea0183.c)

--- a/drivers/gnss/Kconfig
+++ b/drivers/gnss/Kconfig
@@ -86,6 +86,7 @@ source "subsys/logging/Kconfig.template.log_config"
 
 # zephyr-keep-sorted-start
 rsource "Kconfig.emul"
+rsource "Kconfig.ericsson_f5521gw"
 rsource "Kconfig.generic"
 rsource "Kconfig.globaltop_pa6h"
 rsource "Kconfig.luatos_air530z"

--- a/drivers/gnss/Kconfig.ericsson_f5521gw
+++ b/drivers/gnss/Kconfig.ericsson_f5521gw
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Muhammad Waleed Badar
+# SPDX-License-Identifier: Apache-2.0
+
+config GNSS_ERICSSON_F5521GW
+	bool "Ericsson F5521gw GNSS driver"
+	default y
+	depends on GNSS
+	depends on DT_HAS_ERICSSON_F5521GW_ENABLED
+	depends on GNSS_REFERENCE_FRAME_WGS84
+	select MODEM_MODULES
+	select MODEM_BACKEND_UART
+	select MODEM_CHAT
+	select GNSS_PARSE
+	select GNSS_NMEA0183
+	select GNSS_NMEA0183_MATCH
+	help
+	  Ericsson F5521gw (HP HS2340) WWAN module GNSS driver.
+
+if GNSS_ERICSSON_F5521GW
+
+config GNSS_ERICSSON_F5521GW_SATELLITES_COUNT
+	int "Maximum satellite count"
+	depends on GNSS_SATELLITES
+	default 24
+	help
+	  Maximum number of satellite that the driver that can be decoded from
+	  the GNSS device. This does not affect the number of devices that the
+	  device is actually tracking, just how many of those can be reported
+	  in the satellites callback.
+
+endif

--- a/drivers/gnss/gnss_ericsson_f5521gw.c
+++ b/drivers/gnss/gnss_ericsson_f5521gw.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2026 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#define DT_DRV_COMPAT ericsson_f5521gw
+
+#include <zephyr/drivers/gnss.h>
+#include <zephyr/modem/chat.h>
+#include <zephyr/modem/backend/uart.h>
+#include <zephyr/kernel.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+
+#include "gnss_nmea0183.h"
+#include "gnss_nmea0183_match.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(gnss_f5521gw, CONFIG_GNSS_LOG_LEVEL);
+
+#define UART_RX_BUF_SZ    (256 + IS_ENABLED(CONFIG_GNSS_SATELLITES) * 512)
+#define UART_TX_BUF_SZ    64
+#define CHAT_RECV_BUF_SZ  256
+#define CHAT_ARGV_SZ      32
+#define CHAT_DELIMETER_SZ 2
+
+/* clang-format off */
+MODEM_CHAT_MATCH_DEFINE(f5521gw_ok_match, "OK", "", NULL);
+
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(f5521gw_resume_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT*E2GPSCTL=1,1,0", f5521gw_ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT*E2GPSNPD", f5521gw_ok_match),
+);
+
+MODEM_CHAT_SCRIPT_NO_ABORT_DEFINE(f5521gw_resume_script, f5521gw_resume_cmds, NULL, 10000);
+
+#if CONFIG_PM_DEVICE
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(f5521gw_suspend_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT*E2GPSCTL=0", f5521gw_ok_match)
+);
+
+MODEM_CHAT_SCRIPT_NO_ABORT_DEFINE(f5521gw_suspend_script, f5521gw_suspend_cmds, NULL, 10000);
+#endif /* CONFIG_PM_DEVICE */
+
+MODEM_CHAT_MATCHES_DEFINE(unsol_matches,
+	MODEM_CHAT_MATCH_WILDCARD("$??GGA,", ",*", gnss_nmea0183_match_gga_callback),
+	MODEM_CHAT_MATCH_WILDCARD("$??RMC,", ",*", gnss_nmea0183_match_rmc_callback),
+#if CONFIG_GNSS_SATELLITES
+	MODEM_CHAT_MATCH_WILDCARD("$??GSV,", ",*", gnss_nmea0183_match_gsv_callback),
+#endif
+);
+/* clang-format on */
+
+struct f5521gw_config {
+	const struct device *uart;
+};
+
+struct f5521gw_data {
+	struct gnss_nmea0183_match_data match_data;
+#if CONFIG_GNSS_SATELLITES
+	struct gnss_satellite satellites[CONFIG_GNSS_ERICSSON_F5521GW_SATELLITES_COUNT];
+#endif
+
+	struct modem_pipe *uart_pipe;
+	struct modem_backend_uart uart_backend;
+	uint8_t uart_backend_receive_buf[UART_RX_BUF_SZ];
+	uint8_t uart_backend_transmit_buf[UART_TX_BUF_SZ];
+
+	struct modem_chat chat;
+	uint8_t chat_receive_buf[CHAT_RECV_BUF_SZ];
+	uint8_t *chat_argv[CHAT_ARGV_SZ];
+	uint8_t chat_delimiter[CHAT_DELIMETER_SZ];
+};
+
+static int f5521gw_resume(const struct device *dev)
+{
+	struct f5521gw_data *data = dev->data;
+	int ret;
+
+	ret = modem_pipe_open(data->uart_pipe, K_SECONDS(10));
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = modem_chat_attach(&data->chat, data->uart_pipe);
+
+	if (ret == 0) {
+		ret = modem_chat_run_script(&data->chat, &f5521gw_resume_script);
+	}
+
+	if (ret < 0) {
+		modem_pipe_close(data->uart_pipe, K_SECONDS(10));
+	}
+
+	return ret;
+}
+
+#if CONFIG_PM_DEVICE
+static int f5521gw_suspend(const struct device *dev)
+{
+	struct f5521gw_data *data = dev->data;
+	int ret;
+
+	LOG_DBG("Suspending");
+
+	ret = modem_chat_run_script(&data->chat, &f5521gw_suspend_script);
+	if (ret < 0) {
+		LOG_ERR("Failed to suspend GNSS");
+	}
+
+	modem_pipe_close(data->uart_pipe, K_SECONDS(10));
+	return ret;
+}
+
+static int f5521gw_turn_on(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	LOG_DBG("Powered on");
+	return 0;
+}
+
+static int f5521gw_turn_off(const struct device *dev)
+{
+	struct f5521gw_data *data = dev->data;
+
+	LOG_DBG("Powered off");
+	return modem_pipe_close(data->uart_pipe, K_SECONDS(10));
+}
+
+static int f5521gw_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		return f5521gw_resume(dev);
+
+	case PM_DEVICE_ACTION_SUSPEND:
+		return f5521gw_suspend(dev);
+
+	case PM_DEVICE_ACTION_TURN_ON:
+		return f5521gw_turn_on(dev);
+
+	case PM_DEVICE_ACTION_TURN_OFF:
+		return f5521gw_turn_off(dev);
+
+	default:
+		return -ENOTSUP;
+	}
+}
+#endif /* CONFIG_PM_DEVICE */
+
+static int f5521gw_get_fix_rate(const struct device *dev, uint32_t *fix_interval_ms)
+{
+	ARG_UNUSED(dev);
+
+	*fix_interval_ms = 1000;
+	return 0;
+}
+
+static int f5521gw_get_enabled_systems(const struct device *dev, gnss_systems_t *systems)
+{
+	ARG_UNUSED(dev);
+
+	/* F5521gw supports only GPS */
+	*systems = GNSS_SYSTEM_GPS;
+	return 0;
+}
+
+static int f5521gw_get_supported_systems(const struct device *dev, gnss_systems_t *systems)
+{
+	ARG_UNUSED(dev);
+
+	/* F5521gw supports only GPS */
+	*systems = GNSS_SYSTEM_GPS;
+	return 0;
+}
+
+static DEVICE_API(gnss, gnss_api) = {
+	.get_fix_rate = f5521gw_get_fix_rate,
+	.get_enabled_systems = f5521gw_get_enabled_systems,
+	.get_supported_systems = f5521gw_get_supported_systems,
+};
+
+static int f5521gw_init(const struct device *dev)
+{
+	const struct f5521gw_config *cfg = dev->config;
+	struct f5521gw_data *data = dev->data;
+	int ret;
+
+	const struct gnss_nmea0183_match_config match_config = {
+		.gnss = dev,
+#if CONFIG_GNSS_SATELLITES
+		.satellites = data->satellites,
+		.satellites_size = ARRAY_SIZE(data->satellites),
+#endif
+	};
+
+	ret = gnss_nmea0183_match_init(&data->match_data, &match_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+	const struct modem_backend_uart_config uart_config = {
+		.uart = cfg->uart,
+		.receive_buf = data->uart_backend_receive_buf,
+		.receive_buf_size = sizeof(data->uart_backend_receive_buf),
+		.transmit_buf = data->uart_backend_transmit_buf,
+		.transmit_buf_size = sizeof(data->uart_backend_transmit_buf),
+	};
+
+	data->uart_pipe = modem_backend_uart_init(&data->uart_backend, &uart_config);
+
+	const struct modem_chat_config chat_config = {
+		.user_data = data,
+		.receive_buf = data->chat_receive_buf,
+		.receive_buf_size = sizeof(data->chat_receive_buf),
+		.delimiter = data->chat_delimiter,
+		.delimiter_size = ARRAY_SIZE(data->chat_delimiter),
+		.filter = NULL,
+		.filter_size = 0,
+		.argv = data->chat_argv,
+		.argv_size = ARRAY_SIZE(data->chat_argv),
+		.unsol_matches = unsol_matches,
+		.unsol_matches_size = ARRAY_SIZE(unsol_matches),
+	};
+
+	ret = modem_chat_init(&data->chat, &chat_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+#ifdef CONFIG_PM_DEVICE
+	pm_device_init_suspended(dev);
+#else
+	ret = f5521gw_resume(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to start GNSS: %d", ret);
+		return ret;
+	}
+#endif
+
+	return 0;
+}
+
+#define F5521GW_DEFINE(inst)                                                                       \
+	static const struct f5521gw_config f5521gw_cfg_##inst = {                                  \
+		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
+	};                                                                                         \
+                                                                                                   \
+	static struct f5521gw_data f5521gw_data_##inst = {                                         \
+		.chat_delimiter = {'\r', '\n'},                                                    \
+	};                                                                                         \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(inst, f5521gw_pm_action);                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, f5521gw_init, PM_DEVICE_DT_INST_GET(inst),                     \
+			      &f5521gw_data_##inst, &f5521gw_cfg_##inst, POST_KERNEL,              \
+			      CONFIG_GNSS_INIT_PRIORITY, &gnss_api);
+
+DT_INST_FOREACH_STATUS_OKAY(F5521GW_DEFINE)

--- a/dts/bindings/gnss/ericsson,f5521gw.yaml
+++ b/dts/bindings/gnss/ericsson,f5521gw.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 Muhammad Waleed Badar
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Ericsson F5521gw (HP HS2340) WWAN module with integrated GPS
+
+compatible: "ericsson,f5521gw"
+
+include:
+  - uart-device.yaml


### PR DESCRIPTION
Add support for the GNSS receiver integrated in the Ericsson F5521gw (HP HS2340) WWAN module.

The Ericsson F5521gw is a Mini PCIe WWAN module used in many older HP EliteBook and Lenovo ThinkPad laptops. It provides HSPA+ mobile broadband and an integrated GPS/GNSS receiver. The host communicates with the modem using AT commands over one of its USB serial interfaces, which are exposed as virtual serial ports by the operating system.

Datasheet: https://fcc.report/FCC-ID/VV7-MBMF5521GW1/1561482.pdf

# Testing
Tested with native_sim `samples/drivers/gnss`
```

[00:00:00.000,000] <dbg> modem_chat.modem_chat_script_start: running script: f5521gw_resume_script
[00:00:00.000,000] <dbg> modem_chat.modem_chat_script_next: f5521gw_resume_script: step: 0
[00:00:00.000,000] <dbg> modem_chat.modem_chat_script_next: sending: AT*E2GPSCTL=1,1,0
[00:00:00.050,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: *EMRDY: 1
[00:00:00.110,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: AT*E2GPSCTL=1,1,0
[00:00:00.110,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: OK
[00:00:01.010,000] <dbg> modem_chat.modem_chat_script_next: f5521gw_resume_script: step: 1
[00:00:01.010,000] <dbg> modem_chat.modem_chat_script_next: sending: AT*E2GPSNPD
[00:00:01.070,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: AT*E2GPSNPD
[00:00:01.070,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: OK
[00:00:01.910,000] <dbg> modem_chat.modem_chat_log_received_command: $GPGSV, 1 1                  79
[00:00:01.910,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: $GPGLL,,,,,235946.000,V,N*75
[00:00:01.910,000] <dbg> modem_chat.modem_chat_log_received_command: $GPGGA,      0 0   M     1B
[00:00:01.910,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: $GPGSA,A,1,,,,,,,,,,,,,,,*1E
[00:00:01.910,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: $GPGST,235946.000,,,,0,,,*76
[00:00:01.910,000] <dbg> modem_chat.modem_chat_log_received_command: $GPRMC, 235946.000 V          N 42
[00:00:02.020,000] <dbg> modem_chat.modem_chat_script_stop: f5521gw_resume_script: complete
*** Booting Zephyr OS build v4.4.0-6203-g7b9c4176996e ***
GNSS Systems:
	     GNSS_SYSTEM_GPS: Supported: Yes Enabled: Yes
	 GNSS_SYSTEM_GLONASS: Supported:  No Enabled:  No
	 GNSS_SYSTEM_GALILEO: Supported:  No Enabled:  No
	  GNSS_SYSTEM_BEIDOU: Supported:  No Enabled:  No
	    GNSS_SYSTEM_QZSS: Supported:  No Enabled:  No
	   GNSS_SYSTEM_IRNSS: Supported:  No Enabled:  No
	    GNSS_SYSTEM_SBAS: Supported:  No Enabled:  No
	    GNSS_SYSTEM_IMES: Supported:  No Enabled:  No
Fix rate = 1000 ms
[00:00:02.910,000] <dbg> modem_chat.modem_chat_log_received_command: $GPGSV, 1 1                  79
[00:00:02.910,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: $GPGLL,,,,,235947.000,V,N*74
[00:00:02.910,000] <dbg> modem_chat.modem_chat_log_received_command: $GPGGA,      0 0   M     1B
[00:00:02.910,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: $GPGSA,A,1,,,,,,,,,,,,,,,*1E
[00:00:02.910,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: $GPGST,235947.000,,,,0,,,*77
[00:00:02.910,000] <dbg> modem_chat.modem_chat_log_received_command: $GPRMC, 235947.000 V          N 43
[00:00:03.910,000] <dbg> modem_chat.modem_chat_log_received_command: $GPGSV, 1 1                  79
[00:00:03.910,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: $GPGLL,,,,,235948.000,V,N*7B
[00:00:03.910,000] <dbg> modem_chat.modem_chat_log_received_command: $GPGGA,      0 0   M     1B
[00:00:03.910,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: $GPGSA,A,1,,,,,,,,,,,,,,,*1E
[00:00:03.910,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: $GPGST,235948.000,,,,0,,,*78
[00:00:03.910,000] <dbg> modem_chat.modem_chat_log_received_command: $GPRMC, 235948.000 V          N 4C
[00:00:04.930,000] <dbg> modem_chat.modem_chat_log_received_command: $GPGSV, 1 1                  79
[00:00:04.930,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: $GPGLL,,,,,235949.000,V,N*7A
[00:00:04.930,000] <dbg> modem_chat.modem_chat_log_received_command: $GPGGA,      0 0   M     1B
[00:00:04.930,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: $GPGSA,A,1,,,,,,,,,,,,,,,*1E
[00:00:04.930,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: $GPGST,235949.000,,,,0,,,*79
[00:00:04.930,000] <dbg> modem_chat.modem_chat_log_received_command: $GPRMC, 235949.000 V          N 4D
[00:00:05.930,000] <dbg> modem_chat.modem_chat_log_received_command: $GPGSV, 1 1                  79
[00:00:05.930,000] <dbg> modem_chat.modem_chat_on_unknown_command_received: $GPGLL,,,,,235950.000,V,N*72
```
