### PR TITLE
soc: espressif: defer esp32p4 psram init to pre_kernel_1

### DIFF
--- a/soc/espressif/common/esp_psram.c
+++ b/soc/espressif/common/esp_psram.c
@@ -96,3 +96,25 @@ void esp_init_psram(void)
 	memset(&_ext_ram_bss_start, 0,
 	       (&_ext_ram_bss_end - &_ext_ram_bss_start) * sizeof(_ext_ram_bss_start));
 }
+
+#if CONFIG_ESP_SPIRAM && defined(CONFIG_SOC_SERIES_ESP32P4)
+static int esp32p4_psram_init(void)
+{
+	esp_init_psram();
+
+	if (esp_psram_smh_init()) {
+		printk("Failed to initialize PSRAM shared multi heap\n");
+	}
+
+	return 0;
+}
+
+/*
+ * On ESP32-P4 the PSRAM/MPLL rail is powered by an internal LDO owned by the
+ * devicetree regulator driver, which comes up at PRE_KERNEL_1. Initialize
+ * PSRAM at PRE_KERNEL_1 as well, at the default priority so it runs after the
+ * regulator (lower priority value), and before POST_KERNEL consumers of the
+ * external RAM heap.
+ */
+SYS_INIT(esp32p4_psram_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+#endif

--- a/soc/espressif/esp32p4/soc.c
+++ b/soc/espressif/esp32p4/soc.c
@@ -61,16 +61,6 @@ void IRAM_ATTR __esp_platform_app_start(void)
 
 	esp_efuse_init_virtual();
 
-#if CONFIG_ESP_SPIRAM
-	esp_init_psram();
-
-	int err = esp_psram_smh_init();
-
-	if (err) {
-		printk("Failed to initialize PSRAM shared multi heap (%d)\n", err);
-	}
-#endif
-
 	z_cstart();
 
 	CODE_UNREACHABLE;


### PR DESCRIPTION
On ESP32-P4 the PSRAM and MPLL share an internal LDO rail that is owned by the devicetree regulator driver, which powers it at PRE_KERNEL_1. The PSRAM chip init used to run in the pre-kernel platform entry, before that regulator came up, so the chip was unpowered during detection and failed with "PSRAM chip is not connected" on v3.x silicon.

Move the ESP32-P4 PSRAM init to a PRE_KERNEL_1 SYS_INIT at the default priority, which runs after the regulator has enabled the rail and before any consumer of the external RAM heap. Other Espressif SoCs keep their existing pre-kernel init and are unaffected.