### PR TITLE
arch: arm: (cortex-m) add memory clobber to arch_switch_to_main_thread

### DIFF
--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -579,7 +579,8 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
 	"bl z_thread_entry\n\t"	/* z_thread_entry(_main, 0, 0, 0); */
 	:
 	: "r" (_main), "r" (stack_ptr)
-	: "r0" /* not to be overwritten by msr PSP, %1 */
+	: "r0", /* not to be overwritten by msr PSP, %1 */
+	  "memory" /* ensure _current is written before enabling IRQs */
 	);
 
 	CODE_UNREACHABLE;


### PR DESCRIPTION
GCC 14 optimizes away the write to the global `_current` thread pointer (`_current = main_thread`) in `arch_switch_to_main_thread` because the subsequent inline assembly block does not declare a "memory" clobber. The compiler assumes the write is a dead store since the function ends with `CODE_UNREACHABLE` and the assembly block is not marked as accessing memory.

While the assembly code itself does not access memory, it enables interrupts, allowing context switches which will require writes earlier in the function to be visible to other code. Adding the "memory" clobber forces the compiler to treat the block as a barrier and commit the write to memory before the assembly executes.

Without this change, with GCC 14.2.1 at `-Os`, `-O2` or `-O3`, the global `_current` is left pointing to the temporary `dummy_thread` on the stack from `z_cstart`.