### PR TITLE
modules: hostap: Fix CMake style in CMakeLists.txt

### DIFF
--- a/modules/hostap/CMakeLists.txt
+++ b/modules/hostap/CMakeLists.txt
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-if(CONFIG_WIFI_NM_WPA_SUPPLICANT)
+if(NOT CONFIG_WIFI_NM_WPA_SUPPLICANT)
+  return()
+endif()
 
 zephyr_interface_library_named(hostap)
 
@@ -193,81 +195,81 @@ zephyr_library_sources_ifdef(CONFIG_IEEE80211R
 )
 
 if(CONFIG_WIFI_NM_WPA_SUPPLICANT_AP OR CONFIG_WIFI_NM_HOSTAPD_AP)
-zephyr_library_sources(
-  ${WIFI_NM_WPA_SUPPLICANT_BASE}/ap.c
-  ${HOSTAP_SRC_BASE}/ap/ap_config.c
-  ${HOSTAP_SRC_BASE}/ap/ap_drv_ops.c
-  ${HOSTAP_SRC_BASE}/ap/ap_list.c
-  ${HOSTAP_SRC_BASE}/ap/ap_mlme.c
-  ${HOSTAP_SRC_BASE}/ap/authsrv.c
-  ${HOSTAP_SRC_BASE}/ap/beacon.c
-  ${HOSTAP_SRC_BASE}/ap/bss_load.c
-  ${HOSTAP_SRC_BASE}/ap/dfs.c
-  ${HOSTAP_SRC_BASE}/ap/drv_callbacks.c
-  ${HOSTAP_SRC_BASE}/ap/ctrl_iface_ap.c
-  ${HOSTAP_SRC_BASE}/ap/eap_user_db.c
-  ${HOSTAP_SRC_BASE}/ap/hostapd.c
-  ${HOSTAP_SRC_BASE}/ap/hw_features.c
-  ${HOSTAP_SRC_BASE}/ap/ieee802_11_auth.c
-  ${HOSTAP_SRC_BASE}/ap/ieee802_11.c
-  ${HOSTAP_SRC_BASE}/ap/comeback_token.c
-  ${HOSTAP_SRC_BASE}/ap/ieee802_11_ht.c
-  ${HOSTAP_SRC_BASE}/ap/ieee802_11_shared.c
-  ${HOSTAP_SRC_BASE}/ap/ieee802_1x.c
-  ${HOSTAP_SRC_BASE}/ap/neighbor_db.c
-  ${HOSTAP_SRC_BASE}/ap/p2p_hostapd.c
-  ${HOSTAP_SRC_BASE}/ap/pmksa_cache_auth.c
-  ${HOSTAP_SRC_BASE}/ap/preauth_auth.c
-  ${HOSTAP_SRC_BASE}/ap/rrm.c
-  ${HOSTAP_SRC_BASE}/ap/sta_info.c
-  ${HOSTAP_SRC_BASE}/ap/tkip_countermeasures.c
-  ${HOSTAP_SRC_BASE}/ap/utils.c
-  ${HOSTAP_SRC_BASE}/ap/wmm.c
+  zephyr_library_sources(
+    ${WIFI_NM_WPA_SUPPLICANT_BASE}/ap.c
+    ${HOSTAP_SRC_BASE}/ap/ap_config.c
+    ${HOSTAP_SRC_BASE}/ap/ap_drv_ops.c
+    ${HOSTAP_SRC_BASE}/ap/ap_list.c
+    ${HOSTAP_SRC_BASE}/ap/ap_mlme.c
+    ${HOSTAP_SRC_BASE}/ap/authsrv.c
+    ${HOSTAP_SRC_BASE}/ap/beacon.c
+    ${HOSTAP_SRC_BASE}/ap/bss_load.c
+    ${HOSTAP_SRC_BASE}/ap/dfs.c
+    ${HOSTAP_SRC_BASE}/ap/drv_callbacks.c
+    ${HOSTAP_SRC_BASE}/ap/ctrl_iface_ap.c
+    ${HOSTAP_SRC_BASE}/ap/eap_user_db.c
+    ${HOSTAP_SRC_BASE}/ap/hostapd.c
+    ${HOSTAP_SRC_BASE}/ap/hw_features.c
+    ${HOSTAP_SRC_BASE}/ap/ieee802_11_auth.c
+    ${HOSTAP_SRC_BASE}/ap/ieee802_11.c
+    ${HOSTAP_SRC_BASE}/ap/comeback_token.c
+    ${HOSTAP_SRC_BASE}/ap/ieee802_11_ht.c
+    ${HOSTAP_SRC_BASE}/ap/ieee802_11_shared.c
+    ${HOSTAP_SRC_BASE}/ap/ieee802_1x.c
+    ${HOSTAP_SRC_BASE}/ap/neighbor_db.c
+    ${HOSTAP_SRC_BASE}/ap/p2p_hostapd.c
+    ${HOSTAP_SRC_BASE}/ap/pmksa_cache_auth.c
+    ${HOSTAP_SRC_BASE}/ap/preauth_auth.c
+    ${HOSTAP_SRC_BASE}/ap/rrm.c
+    ${HOSTAP_SRC_BASE}/ap/sta_info.c
+    ${HOSTAP_SRC_BASE}/ap/tkip_countermeasures.c
+    ${HOSTAP_SRC_BASE}/ap/utils.c
+    ${HOSTAP_SRC_BASE}/ap/wmm.c
 
-  ${HOSTAP_SRC_BASE}/ap/wpa_auth.c
-  ${HOSTAP_SRC_BASE}/ap/wpa_auth_ie.c
-  ${HOSTAP_SRC_BASE}/ap/wpa_auth_ft.c
-  ${HOSTAP_SRC_BASE}/ap/wpa_auth_glue.c
+    ${HOSTAP_SRC_BASE}/ap/wpa_auth.c
+    ${HOSTAP_SRC_BASE}/ap/wpa_auth_ie.c
+    ${HOSTAP_SRC_BASE}/ap/wpa_auth_ft.c
+    ${HOSTAP_SRC_BASE}/ap/wpa_auth_glue.c
 
-  ${HOSTAP_SRC_BASE}/eap_common/eap_common.c
-  ${HOSTAP_SRC_BASE}/eap_server/eap_server.c
-  ${HOSTAP_SRC_BASE}/eap_server/eap_server_identity.c
-  ${HOSTAP_SRC_BASE}/eap_server/eap_server_methods.c
-  ${HOSTAP_SRC_BASE}/eapol_auth/eapol_auth_sm.c
-  ${HOSTAP_SRC_BASE}/ap/ctrl_iface_ap.c
-  ${HOSTAP_SRC_BASE}/utils/crc32.c
-  ${HOSTAP_SRC_BASE}/utils/ip_addr.c
-)
+    ${HOSTAP_SRC_BASE}/eap_common/eap_common.c
+    ${HOSTAP_SRC_BASE}/eap_server/eap_server.c
+    ${HOSTAP_SRC_BASE}/eap_server/eap_server_identity.c
+    ${HOSTAP_SRC_BASE}/eap_server/eap_server_methods.c
+    ${HOSTAP_SRC_BASE}/eapol_auth/eapol_auth_sm.c
+    ${HOSTAP_SRC_BASE}/ap/ctrl_iface_ap.c
+    ${HOSTAP_SRC_BASE}/utils/crc32.c
+    ${HOSTAP_SRC_BASE}/utils/ip_addr.c
+  )
 
-zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_11AC
-  ${HOSTAP_SRC_BASE}/ap/ieee802_11_vht.c
-)
+  zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_11AC
+    ${HOSTAP_SRC_BASE}/ap/ieee802_11_vht.c
+  )
 
-if(CONFIG_WIFI_NM_WPA_SUPPLICANT_MBO)
-  zephyr_library_sources(${HOSTAP_SRC_BASE}/ap/mbo_ap.c)
-endif()
+  if(CONFIG_WIFI_NM_WPA_SUPPLICANT_MBO)
+    zephyr_library_sources(${HOSTAP_SRC_BASE}/ap/mbo_ap.c)
+  endif()
 
-zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_11AX
-  ${HOSTAP_SRC_BASE}/ap/ieee802_11_he.c
-)
+  zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_11AX
+    ${HOSTAP_SRC_BASE}/ap/ieee802_11_he.c
+  )
 
-zephyr_library_compile_definitions(
-  CONFIG_AP
-  CONFIG_NO_RADIUS
-  CONFIG_NO_VLAN
-  CONFIG_NO_ACCOUNTING
-  NEED_AP_MLME
-  EAP_SERVER
-  EAP_SERVER_IDENTITY
-)
+  zephyr_library_compile_definitions(
+    CONFIG_AP
+    CONFIG_NO_RADIUS
+    CONFIG_NO_VLAN
+    CONFIG_NO_ACCOUNTING
+    NEED_AP_MLME
+    EAP_SERVER
+    EAP_SERVER_IDENTITY
+  )
 
-zephyr_library_compile_definitions_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_11AC
-  CONFIG_IEEE80211AC
-)
+  zephyr_library_compile_definitions_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_11AC
+    CONFIG_IEEE80211AC
+  )
 
-zephyr_library_compile_definitions_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_11AX
-  CONFIG_IEEE80211AX
-)
+  zephyr_library_compile_definitions_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_11AX
+    CONFIG_IEEE80211AX
+  )
 endif()
 
 zephyr_include_directories_ifdef(CONFIG_WIFI_NM_HOSTAPD_AP
@@ -700,33 +702,33 @@ zephyr_library_compile_definitions_ifdef(CONFIG_EAP_SERVER_TTLS
 )
 
 if(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ALT)
-zephyr_include_directories(
-  ${HOSTAP_BASE}/port/mbedtls
-)
+  zephyr_include_directories(
+    ${HOSTAP_BASE}/port/mbedtls
+  )
 
-zephyr_library_sources(
-  ${HOSTAP_SRC_BASE}/crypto/crypto_mbedtls_alt.c
-)
+  zephyr_library_sources(
+    ${HOSTAP_SRC_BASE}/crypto/crypto_mbedtls_alt.c
+  )
 
-zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_MBEDTLS_PSA
-  ${HOSTAP_BASE}/port/mbedtls/supp_psa_api.c
-)
+  zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_MBEDTLS_PSA
+    ${HOSTAP_BASE}/port/mbedtls/supp_psa_api.c
+  )
 
-zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
-  ${HOSTAP_SRC_BASE}/crypto/ms_funcs.c
-  ${HOSTAP_SRC_BASE}/crypto/aes-eax.c
-  ${HOSTAP_SRC_BASE}/crypto/md4-internal.c
-  ${HOSTAP_SRC_BASE}/crypto/sha1-internal.c
-  ${HOSTAP_SRC_BASE}/crypto/fips_prf_internal.c
-  ${HOSTAP_SRC_BASE}/crypto/milenage.c
-  ${HOSTAP_SRC_BASE}/crypto/tls_mbedtls_alt.c
-)
+  zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
+    ${HOSTAP_SRC_BASE}/crypto/ms_funcs.c
+    ${HOSTAP_SRC_BASE}/crypto/aes-eax.c
+    ${HOSTAP_SRC_BASE}/crypto/md4-internal.c
+    ${HOSTAP_SRC_BASE}/crypto/sha1-internal.c
+    ${HOSTAP_SRC_BASE}/crypto/fips_prf_internal.c
+    ${HOSTAP_SRC_BASE}/crypto/milenage.c
+    ${HOSTAP_SRC_BASE}/crypto/tls_mbedtls_alt.c
+  )
 
-zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_TEST
-  ${HOSTAP_SRC_BASE}/crypto/crypto_module_tests.c
-  ${HOSTAP_SRC_BASE}/crypto/fips_prf_internal.c
-  ${HOSTAP_SRC_BASE}/crypto/sha1-internal.c
-)
+  zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_TEST
+    ${HOSTAP_SRC_BASE}/crypto/crypto_module_tests.c
+    ${HOSTAP_SRC_BASE}/crypto/fips_prf_internal.c
+    ${HOSTAP_SRC_BASE}/crypto/sha1-internal.c
+  )
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT_LEGACY_CRYPTO
@@ -762,6 +764,4 @@ if(CONFIG_SAE_PWE_EARLY_EXIT)
   message(WARNING "CONFIG_SAE_PWE_EARLY_EXIT is enabled, "
   "this is not secure and is a workaround for low resource systems, "
   "please use it carefully and do not use it production.")
-endif()
-
 endif()


### PR DESCRIPTION
Convert the `CONFIG_WIFI_NM_WPA_SUPPLICANT` guard to an early return instead of wrapping the whole file, so the body no longer needs re-indenting, and fix the remaining nested-block indentation.