### PR TITLE
ci: stats_merged_prs: fix failing workflow

### DIFF
--- a/.github/workflows/stats_merged_prs.yml
+++ b/.github/workflows/stats_merged_prs.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: |
+            scripts/ci/stats/merged_prs.py
+            scripts/requirements-actions.txt
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -24,6 +29,7 @@ jobs:
           python-version: 3.12
           cache: pip
           cache-dependency-path: scripts/requirements-actions.txt
+
       - name: Install Python packages
         run: |
           pip install -r scripts/requirements-actions.txt --require-hashes


### PR DESCRIPTION
This post merge workflow has been failing for a while due to some
security related changed in how this type of workflow should work.

Pin the sha to the base branch and only clone needed files to satisfy
the security checks.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
