### PR TITLE
tests: mem_protect/syscalls: use CONFIG_INTEL_ADSP_SIM instead..

### DIFF
--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -15,10 +15,7 @@
 
 #if defined(CONFIG_BOARD_FVP_BASE_REVC_2XAEM)
 #define SLEEP_MS_LONG	30000
-#elif defined(CONFIG_BOARD_INTEL_ADSP_ACE30_PTL_SIM) ||                                            \
-	defined(CONFIG_BOARD_INTEL_ADSP_ACE40_NVL_SIM)
-#define SLEEP_MS_LONG	300
-#elif defined(CONFIG_WHISPER_TARGET)
+#elif defined(CONFIG_WHISPER_TARGET) || defined(CONFIG_INTEL_ADSP_SIM)
 #define SLEEP_MS_LONG	300
 #elif defined(CONFIG_QEMU_TARGET)
 /* Emulators are much slower than real hardware, especially in the kyield


### PR DESCRIPTION
... of individual CONFIG_BOARD_INTEL_ADSP_*_SIM. These boards are all using the same base simulator so they are having similar long running issue. So just use the blanket Kconfig instead of needing to add them one by one when new boards come in.