### PR TITLE
soc: espressif: fix undefined kconfig references

### DIFF
--- a/drivers/clock_control/clock_control_esp32_pmu.c
+++ b/drivers/clock_control/clock_control_esp32_pmu.c
@@ -162,7 +162,7 @@ static void esp32_cpu_clock_init(const struct esp32_cpu_clock_config *cpu_cfg)
 	 * at sleep entry to read stale values (0) and write an invalid
 	 * regulator bias which brown-outs the core.
 	 */
-#if !defined(CONFIG_ESP_ENABLE_PVT)
+#if !defined(CONFIG_SOC_ESP32_ENABLE_PVT)
 	uint32_t hp_cali_dbias = get_act_hp_dbias();
 	uint32_t lp_cali_dbias = get_act_lp_dbias();
 
@@ -176,7 +176,7 @@ static void esp32_cpu_clock_init(const struct esp32_cpu_clock_config *cpu_cfg)
 			  hp_cali_dbias, PMU_HP_MODEM_HP_REGULATOR_DBIAS_S);
 	SET_PERI_REG_BITS(PMU_HP_SLEEP_LP_REGULATOR0_REG, PMU_HP_SLEEP_LP_REGULATOR_DBIAS,
 			  lp_cali_dbias, PMU_HP_SLEEP_LP_REGULATOR_DBIAS_S);
-#endif /* !CONFIG_ESP_ENABLE_PVT */
+#endif /* !CONFIG_SOC_ESP32_ENABLE_PVT */
 
 #if !defined(CONFIG_SOC_SERIES_ESP32P4)
 	clk_ll_rc_fast_tick_conf();

--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -36,8 +36,15 @@ LOG_MODULE_REGISTER(entropy, CONFIG_ENTROPY_LOG_LEVEL);
 /* Same reasoning as for ESP32C6, but the CPU frequency on ESP32H2 is 96MHz instead of 160 MHz */
 #define APB_CYCLE_WAIT_NUM (96 * 16)
 #elif defined CONFIG_SOC_SERIES_ESP32P4
-/* On ESP32P4 (ECO5+), the RNG has been tested at around 75 KHz reading frequency */
-#define APB_CYCLE_WAIT_NUM (CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ * 14)
+/* On ESP32P4 (ECO5+), the RNG has been tested at around 75 KHz reading
+ * frequency. Scaled by the default CPU frequency, which is 360 MHz on
+ * rev 1.3 and 400 MHz on rev 3.x.
+ */
+#if defined(CONFIG_SOC_ESP32P4_REV_1_3)
+#define APB_CYCLE_WAIT_NUM (360 * 14)
+#else
+#define APB_CYCLE_WAIT_NUM (400 * 14)
+#endif
 #else
 #define APB_CYCLE_WAIT_NUM (16)
 #endif

--- a/soc/espressif/Kconfig
+++ b/soc/espressif/Kconfig
@@ -45,6 +45,17 @@ config RESERVE_RTC_MEM
 	help
 	  This option reserves an area in RTC FAST memory.
 
+config SOC_ESP32_ENABLE_PVT
+	bool "Auto adjust hp & lp voltage using pvt function"
+	depends on SOC_SERIES_ESP32C5 || SOC_SERIES_ESP32C6 || SOC_SERIES_ESP32P4
+	default n if SOC_SERIES_ESP32C6
+	default y
+	help
+	  If enabled, hp & lp voltage can be auto adjusted by the PVT
+	  characteristic. Otherwise, internal voltage is set to a fixed
+	  dbias. This is required for stable mass production; disable for
+	  debugging only.
+
 rsource "Kconfig.ulp"
 
 endif # SOC_FAMILY_ESPRESSIF_ESP32

--- a/soc/espressif/common/Kconfig.flash
+++ b/soc/espressif/common/Kconfig.flash
@@ -156,4 +156,15 @@ config ESP32_SLEEP_WAIT_FLASH_READY_EXTRA_DELAY
 	  minus 900us. Increase it if you see "flash read err, 1000" after deep
 	  sleep or an RTC_WDT/LP_WDT trigger after light sleep wakeup.
 
+config SOC_ESP32_SLEEP_DCM_VSET_VAL_IN_SLEEP
+	int "DCDC voltage parameter during sleep"
+	depends on SOC_SERIES_ESP32P4
+	default 14
+	range 0 31
+	help
+	  Voltage of the DCDC converter during sleep. The same parameter value may
+	  correspond to different voltages on different DCDC models, so adjust it
+	  according to the external DCDC selected in your hardware.
+	  Recommended value for TI TLV62569/TLV62569P: 14.
+
 endif # SOC_FAMILY_ESPRESSIF_ESP32

--- a/soc/espressif/common/Kconfig.pm
+++ b/soc/espressif/common/Kconfig.pm
@@ -135,17 +135,6 @@ config ESP32_SLEEP_SPI_FLASH_EXIT_DPD_MODE_DELAY
 	help
 	  Time CS must stay high after the exit-DPD command (tRES1 in datasheets).
 
-config ESP32_SLEEP_DCM_VSET_VAL_IN_SLEEP
-	int "DCDC voltage parameter during sleep"
-	depends on SOC_SERIES_ESP32P4
-	default 14
-	range 0 31
-	help
-	  Voltage of the DCDC converter during sleep. The same parameter value may
-	  correspond to different voltages on different DCDC models, so adjust it
-	  according to the external DCDC selected in your hardware.
-	  Recommended value for TI TLV62569/TLV62569P: 14.
-
 endmenu # Espressif PM Config
 
 endif # SOC_FAMILY_ESPRESSIF_ESP32

--- a/soc/espressif/common/esp_etm_alloc.c
+++ b/soc/espressif/common/esp_etm_alloc.c
@@ -11,7 +11,7 @@
 #include <soc/soc_caps.h>
 #include <hal/etm_ll.h>
 
-#if defined(CONFIG_SOC_GPIO_SUPPORT_ETM)
+#if defined(SOC_GPIO_SUPPORT_ETM)
 #include <hal/gpio_etm_ll.h>
 #include <hal/gpio_caps.h>
 #define ETM_GPIO_NUM_EVENTS _GPIO_ETM_EVENT_CHANNELS_PER_GROUP
@@ -24,7 +24,7 @@ static struct k_spinlock etm_lock;
 static uint32_t etm_chan_mask[DIV_ROUND_UP(ETM_NUM_CHANS, 32)];
 static bool etm_initialized;
 
-#if defined(CONFIG_SOC_GPIO_SUPPORT_ETM)
+#if defined(SOC_GPIO_SUPPORT_ETM)
 static uint32_t etm_gpio_evt_mask;
 #endif
 
@@ -128,7 +128,7 @@ int esp_etm_channel_free(esp_etm_chan_t chan)
 	return 0;
 }
 
-#if defined(CONFIG_SOC_GPIO_SUPPORT_ETM)
+#if defined(SOC_GPIO_SUPPORT_ETM)
 int esp_etm_gpio_event_alloc(uint32_t gpio_num, enum esp_etm_gpio_edge edge,
 			     esp_etm_chan_t *out_chan, uint32_t *out_event_id)
 {
@@ -195,4 +195,4 @@ int esp_etm_gpio_event_free(esp_etm_chan_t chan)
 
 	return 0;
 }
-#endif /* CONFIG_SOC_GPIO_SUPPORT_ETM */
+#endif /* SOC_GPIO_SUPPORT_ETM */

--- a/soc/espressif/common/power.c
+++ b/soc/espressif/common/power.c
@@ -289,7 +289,7 @@ uint64_t esp32_lptim_hook_get_freq(void)
 {
 #if defined(SOC_SYSTIMER_SUPPORTED)
 	return systimer_us_to_ticks(1) * 1000000ULL;
-#elif defined(CONFIG_ESP_TIMER_IMPL_TG0_LAC)
+#elif defined(CONFIG_SOC_SERIES_ESP32)
 	return LACT_TICKS_PER_US * 1000000ULL;
 #endif
 }

--- a/soc/espressif/esp32p4/Kconfig
+++ b/soc/espressif/esp32p4/Kconfig
@@ -78,4 +78,16 @@ config ESP32P4_EMAC
 	  this driver. This option allows enabling MDIO
 	  independently of Ethernet.
 
+config SOC_ESP32P4_REV_MIN_FULL
+	int
+	default 103 if SOC_ESP32P4_REV_1_3
+	default 300 if SOC_ESP32P4_REV_3_0
+	default 301 if SOC_ESP32P4_REV_3_1
+	default 301
+	help
+	  Minimum supported ESP32-P4 chip revision in major * 100 + minor
+	  format, matching what efuse_hal_chip_revision() returns at runtime.
+	  Derived from the SOC_ESP32P4_REV_* symbol the board selects; defaults
+	  to v3.1 (301), the floor of the v3.x family, when none is selected.
+
 endif # SOC_SERIES_ESP32P4

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: aa20ec213be90548a9318d3cd678bb608ce427af
+      revision: 563219d8db677b70e92f1493e4e46b018bf41120
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Zephyr driver and soc code referenced five CONFIG symbols that were only declared in the hal module, so a compliance run without the module in place flagged them as undefined.