### PR TITLE
boards: infineon: kit_pse84_eval: disable watchdog on m33/ns

### DIFF
--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns.dts
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns.dts
@@ -43,6 +43,11 @@
 	status = "disabled";
 };
 
+/* watchdog0 is a secure-owned resource; disable it in the non-secure build. */
+&watchdog0 {
+	status = "disabled";
+};
+
 &mcwdt0 {
 	status = "okay";
 };


### PR DESCRIPTION
The SRSS watchdog on the PSE84 is a secure-owned platform resource. On the
`kit_pse84_eval` non-secure M33 target (`m33/ns`) the `watchdog0` node was left
enabled even though the non-secure image is not meant to drive it:

- In the TrustZone-M security model the secure image manages the system
  watchdog (it also gates the `WDT_LOCK`), and a watchdog timeout resets the
  whole SoC.
- On this SoC the SRSS block is mapped secure-only: its non-secure address
  alias does not respond on the bus, and the low-frequency clock the watchdog
  counts on is brought up by the secure world.
- The non-secure side uses the MCWDT (`mcwdt0`) for its timing needs instead.
- This board's non-secure capabilities intentionally do not advertise the
  `watchdog` feature, so the watchdog test suites are already filtered out on
  this target via the devicetree alias / `depends_on` mechanism.

Because the block is secure-only, leaving `watchdog0` enabled on `m33/ns` does
not fail cleanly. Building the watchdog sample with the node forced back on and
running it on hardware reproduces a hang: the non-secure driver's setup path
(`wdt_install_timeout()`) blocks indefinitely when it tries to configure the
timer, with the core spinning in the secure world rather than taking a fault.

Leaving `watchdog0` enabled in the non-secure devicetree is therefore
inconsistent with the board's declared capabilities and would let the driver
bind an instance the non-secure image should not manage. This change disables
the node on `m33/ns` so the devicetree matches the board's non-secure
capabilities; `mcwdt0` stays enabled. The secure M33 and the M55 targets, which
legitimately own the watchdog, are unaffected.
