### PR TITLE
fixes for 2 build issues in main

### DIFF
--- a/modules/trusted-firmware-m/nordic/include/RTE_Device.h
+++ b/modules/trusted-firmware-m/nordic/include/RTE_Device.h
@@ -44,7 +44,7 @@
 	) \
 }
 
-#elif DT_PINCTRL_HAS_NAME(DT_NODELABEL(uart21), default)
+#elif DT_PINCTRL_HAS_NAME(DT_NODELABEL(uart21), default) && (NRF_SECURE_UART_INSTANCE == 21)
 
 #define RTE_USART21 1
 

--- a/soc/silabs/common/CMakeLists.txt
+++ b/soc/silabs/common/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 if((CONFIG_SOC_FAMILY_SILABS_S1 AND CONFIG_SILABS_GECKO_POWER_MANAGER) OR CONFIG_SOC_FAMILY_SILABS_S2)
   zephyr_sources_ifdef(CONFIG_PM soc_power_pmgr.c)
-else()
+elseif(CONFIG_SOC_FAMILY_SILABS_S0 OR CONFIG_SOC_FAMILY_SILABS_S1)
   zephyr_sources_ifdef(CONFIG_PM soc_power.c)
 endif()
 


### PR DESCRIPTION
- **modules: tfm: nordic: gate RTE_USART21 on secure UART instance**
- **soc: silabs: don't build Gecko soc_power.c for non-Gecko families**
