### PR TITLE
fs: FatFs CVE-2026-668x security fixes (module bump + POSIX readdir bound)

### DIFF
--- a/subsys/portability/posix/options/fs.c
+++ b/subsys/portability/posix/options/fs.c
@@ -106,8 +106,17 @@ struct dirent *readdir(DIR *dirp)
 		return NULL;
 	}
 
-	rc = strlen(fdirent.name);
-	rc = (rc < MAX_FILE_NAME) ? rc : (MAX_FILE_NAME - 1);
+	/*
+	 * Bound the copy by both buffers: fdirent.name is MAX_FILE_NAME + 1
+	 * bytes and d_name is NAME_MAX + 1, and either may be the smaller.
+	 * With FAT long file names MAX_FILE_NAME (CONFIG_FS_FATFS_MAX_LFN, up
+	 * to 255) exceeds NAME_MAX, so a long directory entry name would
+	 * overrun d_name; with 8.3 short names it is only 12, so the source is
+	 * the shorter one. strnlen() keeps the read inside fdirent.name even
+	 * if the filesystem left the name unterminated.
+	 */
+	rc = (int)strnlen(fdirent.name,
+			  MIN(sizeof(pdirent.d_name), sizeof(fdirent.name)) - 1);
 	(void)memcpy(pdirent.d_name, fdirent.name, rc);
 
 	/* Make sure the name is NULL terminated */

--- a/tests/subsys/fs/fat_fs_api/CMakeLists.txt
+++ b/tests/subsys/fs/fat_fs_api/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(app PRIVATE
   src/test_fat_rename.c
   src/test_fat_rd_only_mount.c
   src/test_fat_file.c
+  src/test_fat_cve.c
   ../common/test_fs_open_flags.c
 )
 if(CONFIG_FILE_SYSTEM_MKFS)

--- a/tests/subsys/fs/fat_fs_api/src/main.c
+++ b/tests/subsys/fs/fat_fs_api/src/main.c
@@ -34,6 +34,7 @@ static void *fat_fs_basic_setup(void)
 	test_fat_dir();
 	test_fat_fs();
 	test_fat_rename();
+	test_fat_cve();
 	test_fs_open_flags();
 #ifdef CONFIG_FS_FATFS_REENTRANT
 	test_fat_file_reentrant();

--- a/tests/subsys/fs/fat_fs_api/src/test_fat.h
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat.h
@@ -47,6 +47,7 @@ void test_fat_file(void);
 void test_fat_dir(void);
 void test_fat_fs(void);
 void test_fat_rename(void);
+void test_fat_cve(void);
 #ifdef CONFIG_FS_FATFS_REENTRANT
 void test_fat_file_reentrant(void);
 #endif /* CONFIG_FS_FATFS_REENTRANT */

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_cve.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_cve.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Regression tests for vendored FatFs (ff.c) security fixes that are only
+ * reachable through the FatFs API directly. The Zephyr fs_* layer clamps
+ * fs_seek() to the current file size and zero-fills fs_truncate() growth, so
+ * those wrappers cannot reach the underlying bug; these tests therefore drive
+ * ff.c's f_lseek() extend path directly on the already-mounted volume.
+ */
+
+#include "test_fat.h"
+#include <string.h>
+
+#define CVE_FILE DISK_NAME ":/cve6686.bin"
+
+/*
+ * CVE-2026-6686 (GHSA-h94p-vjqx-v7rr): extending a file past end-of-file with
+ * f_lseek() must not expose residual on-disk data. The newly in-file range has
+ * to read back as zeros, covering both freshly allocated clusters and the
+ * unused tail (slack) of an already-allocated cluster.
+ */
+static int test_cve_2026_6686(void)
+{
+	static FIL fp;
+	static uint8_t buf[512];
+	int res;
+	unsigned int bw, br;
+
+	TC_PRINT("\nCVE-2026-6686 (f_lseek past-EOF zeroing):\n");
+
+	/* Scenario 1: extend an empty file; the whole range must read zeroed. */
+	res = f_open(&fp, CVE_FILE, FA_CREATE_ALWAYS | FA_WRITE | FA_READ);
+	if (res != FR_OK) {
+		TC_PRINT("f_open failed [%d]\n", res);
+		return TC_FAIL;
+	}
+	res = f_lseek(&fp, 400);
+	if (res != FR_OK || f_size(&fp) != 400) {
+		TC_PRINT("f_lseek extend failed [%d]\n", res);
+		f_close(&fp);
+		return TC_FAIL;
+	}
+	f_lseek(&fp, 0);
+	memset(buf, 0xAA, sizeof(buf));
+	res = f_read(&fp, buf, 400, &br);
+	if (res != FR_OK || br != 400) {
+		TC_PRINT("f_read failed [%d] (%u)\n", res, br);
+		f_close(&fp);
+		return TC_FAIL;
+	}
+	for (int i = 0; i < 400; i++) {
+		if (buf[i] != 0) {
+			TC_PRINT("empty-extend leaked residual at %d (0x%02x)\n", i, buf[i]);
+			f_close(&fp);
+			return TC_FAIL;
+		}
+	}
+	f_close(&fp);
+
+	/*
+	 * Scenario 2 (partial-cluster / straddle): write real data, truncate so
+	 * its tail becomes unused slack that stays on disk, then re-extend within
+	 * the same cluster. The re-exposed slack must read zeroed while the kept
+	 * byte survives. This is the case whole-cluster zeroing alone would miss.
+	 */
+	res = f_open(&fp, CVE_FILE, FA_CREATE_ALWAYS | FA_WRITE | FA_READ);
+	if (res != FR_OK) {
+		TC_PRINT("f_open(2) failed [%d]\n", res);
+		return TC_FAIL;
+	}
+	memset(buf, 0xCC, 400);
+	res = f_write(&fp, buf, 400, &bw);
+	if (res != FR_OK || bw != 400) {
+		TC_PRINT("f_write failed [%d] (%u)\n", res, bw);
+		f_close(&fp);
+		return TC_FAIL;
+	}
+	f_lseek(&fp, 1);
+	res = f_truncate(&fp);		/* objsize == 1, [1, 400) slack still on disk */
+	if (res != FR_OK) {
+		TC_PRINT("f_truncate failed [%d]\n", res);
+		f_close(&fp);
+		return TC_FAIL;
+	}
+	res = f_lseek(&fp, 300);		/* re-extend within the same cluster */
+	if (res != FR_OK) {
+		TC_PRINT("f_lseek re-extend failed [%d]\n", res);
+		f_close(&fp);
+		return TC_FAIL;
+	}
+	f_lseek(&fp, 0);
+	memset(buf, 0xAA, sizeof(buf));
+	res = f_read(&fp, buf, 300, &br);
+	if (res != FR_OK || br != 300) {
+		TC_PRINT("f_read(2) failed [%d] (%u)\n", res, br);
+		f_close(&fp);
+		return TC_FAIL;
+	}
+	f_close(&fp);
+	(void)f_unlink(CVE_FILE);
+
+	if (buf[0] != 0xCC) {
+		TC_PRINT("straddle kept byte clobbered (0x%02x)\n", buf[0]);
+		return TC_FAIL;
+	}
+	for (int i = 1; i < 300; i++) {
+		if (buf[i] != 0) {
+			TC_PRINT("straddle leaked slack at %d (0x%02x)\n", i, buf[i]);
+			return TC_FAIL;
+		}
+	}
+
+	TC_PRINT("CVE-2026-6686: PASS\n");
+	return TC_PASS;
+}
+
+void test_fat_cve(void)
+{
+	zassert_true(test_cve_2026_6686() == TC_PASS);
+}

--- a/west.yml
+++ b/west.yml
@@ -142,7 +142,7 @@ manifest:
       groups:
         - tools
     - name: fatfs
-      revision: f4ead3bf4a6dab3a07d7b5f5315795c073db568d
+      revision: refs/pull/23/head
       path: modules/fs/fatfs
       groups:
         - fs


### PR DESCRIPTION
## Summary

Integrate the vendored FatFs fixes for the 2026 runZero FatFs disclosure
(CVE-2026-6682 … CVE-2026-6688) into Zephyr, and fix the one Zephyr-side
caller that shares the disclosure.

Two commits:

1. **`portability: posix: bound readdir() name copy to the dirent buffer`** —
   the POSIX `readdir()` shim copied the FatFs long file name into
   `struct dirent.d_name[NAME_MAX + 1]` clamped only to `MAX_FILE_NAME`. Those
   limits are independent: with FAT LFN, `MAX_FILE_NAME` follows
   `CONFIG_FS_FATFS_MAX_LFN` (default 255) while `NAME_MAX` is the POSIX minimum
   (14), so a long directory entry name overran the static `d_name` buffer.
   This is the caller-side FatFs long-name overflow of **CVE-2026-6688**
   (GHSA-8vm2-mjff-2gg2); the in-tree `fs_readdir()` path was already bounded by
   the CVE-2020-13598 fix. The copy is now clamped to the destination buffer.

2. **`manifest: update fatfs with FatFs security fixes`** — bump the `fatfs`
   module to the revision carrying the five `ff.c` fixes:

   | CVE | GHSA | Fix |
   |---|---|---|
   | CVE-2026-6682 | GHSA-c25x-vcg6-4ccx | FAT32 mount FAT-area size overflow |
   | CVE-2026-6685 | GHSA-rggj-rv54-4gvx | dirty sector-cache subtraction underflow |
   | CVE-2026-6686 | GHSA-h94p-vjqx-v7rr | `f_lseek()` past-EOF stale-data disclosure |
   | CVE-2026-6683 | GHSA-74cg-p8q3-4c3q | exFAT `sync_fs()` divide-by-zero |
   | CVE-2026-6687 | GHSA-wghw-hg6m-7rh3 | exFAT `f_getlabel()` volume-label overflow |

   The corresponding module PR is **zephyrproject-rtos/fatfs#23** (per-fix
   commits + advisory links). CVE-2026-6684 (GPT loop) is already bounded in
   R0.16 and not affected.

## Not mergeable as-is — for review + CI

The manifest points `fatfs` at `refs/pull/23/head` so CI exercises the module
PR while it is under review; the manifest checker will (correctly) flag that
as unmergeable. Once fatfs#23 merges, the manifest will be repinned to the
merged revision. Please review it as the real fatfs update.

## Testing

The `ff.c` fixes were validated against a standalone host harness compiling the
patched `ff.c` under ASan/UBSan over a RAM-disk `diskio`, with crafted-image /
API reproductions that flip FAIL→PASS across the fix (FAT32 mount overflow;
`f_lseek()` extend past EOF incl. the partial-cluster/straddle case), across the
Zephyr default (tiny), non-tiny, and exFAT configurations. A follow-up will port
these into `tests/subsys/fs/fat_fs_api` so they run on `native_sim` under Zephyr
CI.
