### PR TITLE
tests: kernel: usage: compare peak stats in the tick domain

### DIFF
--- a/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
+++ b/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
@@ -8,21 +8,6 @@
 
 #define HELPER_STACK_SIZE 500
 
-/**
- * @brief Verify @a va1 and @a val2 are within @a pcnt % of each other
- */
-#define TEST_WITHIN_X_PERCENT(val1, val2, pcnt)                       \
-	((((val1) * 100) < ((val2) * (100 + (pcnt)))) &&              \
-	 (((val1) * 100) > ((val2) * (100 - (pcnt))))) ? true : false
-
-#if defined(CONFIG_RISCV)
-#define IDLE_EVENT_STATS_PRECISION 7
-#elif defined(CONFIG_QEMU_TARGET)
-#define IDLE_EVENT_STATS_PRECISION 3
-#else
-#define IDLE_EVENT_STATS_PRECISION 1
-#endif
-
 static struct k_thread helper_thread;
 static K_THREAD_STACK_DEFINE(helper_stack, HELPER_STACK_SIZE);
 
@@ -87,11 +72,7 @@ ZTEST(usage_api, test_all_stats_usage)
 
 	k_thread_runtime_stats_all_get(&stats2);
 
-#if defined(CONFIG_RISCV)
-	k_sleep(K_TICKS(3));  /* Helper runs for 3 ticks - on slower platforms */
-#else
-	k_sleep(K_TICKS(2));  /* Helper runs for 2 ticks */
-#endif
+	k_sleep(K_TICKS(3));  /* Helper runs for 3 ticks */
 
 	k_thread_runtime_stats_all_get(&stats3);
 
@@ -181,8 +162,13 @@ ZTEST(usage_api, test_all_stats_usage)
 	zassert_true(stats4.current_cycles <= stats1.current_cycles);
 	zassert_true(stats5.current_cycles > stats4.current_cycles);
 
-	zassert_true(TEST_WITHIN_X_PERCENT(stats4.peak_cycles,
-					   stats3.peak_cycles, IDLE_EVENT_STATS_PRECISION), NULL);
+	/* The peak busy stretch is the same one before and after it closed; it
+	 * only grew by the sub-tick measurement tail between the stats3 sample
+	 * and the idle event. Scheduling here is tick aligned, so comparing in
+	 * the tick domain makes that tail vanish, no percentage tolerance needed.
+	 */
+	zassert_equal(k_cyc_to_ticks_near64(stats4.peak_cycles),
+		      k_cyc_to_ticks_near64(stats3.peak_cycles), NULL);
 	zassert_true(stats4.peak_cycles == stats5.peak_cycles);
 
 	zassert_true(stats4.average_cycles > 0);


### PR DESCRIPTION
test_all_stats_usage checked that peak_cycles is stable across the idle
event by comparing two samples of the same busy stretch (before and after
it closed) with a percentage tolerance. That tolerance was hand-tuned per
platform: 1% by default, 3% under QEMU, 7% on RISC-V, and #112974 proposes
adding 7% for the Realtek Bee 32 kHz SysTick SoCs.

The two samples only differ by a short sub-tick tail (the stats-get and
abort syscalls that run between the stats3 sample and the idle event). As
a fraction of the stretch that tail is negligible on fast clocks but
several percent on a coarse clock, which is what forces the per-platform
values, and it does not generalize (every new coarse clock needs another
exception).

Scheduling in this test is tick aligned: the stretch is a whole number of
ticks plus that sub-tick tail. Comparing the two peaks in the tick domain
with k_cyc_to_ticks_near64() makes the tail round away and both samples
land on the same tick, so no tolerance and no per-platform value are
needed. TEST_WITHIN_X_PERCENT and IDLE_EVENT_STATS_PRECISION are dropped,
which also removes the pre-existing RISC-V and QEMU special cases, not
just the Bee one #112974 would add.

The same commit drops the CONFIG_RISCV special case that slept 3 ticks
instead of 2 for "slower platforms": keying slowness off an architecture
is a poor proxy and 3 ticks is harmless everywhere, so it sleeps 3
unconditionally.

Verified on qemu_x86, qemu_riscv32, mps2/an385 and qemu_cortex_a9.

Supersedes the thread_runtime_stats change in #112974.