### PR TITLE
soc: infineon: cyw20829: restore CLK_HF0 after BLE controller boot

### DIFF
--- a/modules/hal_infineon/CMakeLists.txt
+++ b/modules/hal_infineon/CMakeLists.txt
@@ -113,6 +113,14 @@ endif()
 ## Add BT assets for AIROC devices
 if(CONFIG_BT_AIROC)
   add_subdirectory(btstack-integration)
+
+  # On CYW20829/CYW89829 B0 silicon the BLE controller boot leaves CLK_HF0 on
+  # the 48 MHz BLE ECO path. The btstack-integration HCI layer restores CLK_HF0
+  # to the 96 MHz FLL path on CY_BT_IPC_BOOT_FULLY_UP, but only when
+  # COMPONENT_CYW20829B0 / COMPONENT_CYW89829B0 is defined. Scope the macro to
+  # this HAL library (not a global define) so the restore is compiled in.
+  zephyr_library_compile_definitions_ifdef(CONFIG_SOC_CYW20829_B0 COMPONENT_CYW20829B0)
+  zephyr_library_compile_definitions_ifdef(CONFIG_SOC_CYW89829_B0 COMPONENT_CYW89829B0)
 endif()
 
 if(CONFIG_BT_PSOC6_BLESS)

--- a/soc/infineon/cat1b/cyw20829/Kconfig.soc
+++ b/soc/infineon/cat1b/cyw20829/Kconfig.soc
@@ -56,6 +56,18 @@ config SOC_CYW89829B1232
 	bool
 	select SOC_SERIES_CYW20829
 
+# Silicon-revision helper symbols. On B0 silicon the BLE controller boot
+# leaves CLK_HF0 on the 48 MHz BLE ECO path; the btstack-integration HCI
+# layer restores it to the 96 MHz FLL path only when COMPONENT_CYW20829B0 /
+# COMPONENT_CYW89829B0 is defined. B1 silicon does not need the restore.
+config SOC_CYW20829_B0
+	bool
+	default y if SOC_CYW20829B0LKML || SOC_CYW20829B0000 || SOC_CYW20829B0010
+
+config SOC_CYW89829_B0
+	bool
+	default y if SOC_CYW89829B0232 || SOC_CYW89829B0062
+
 config SOC
 	default "cyw20829b0lkml" if SOC_CYW20829B0LKML
 	default "cyw89829b0232" if SOC_CYW89829B0232


### PR DESCRIPTION
On CYW20829/CYW89829 B0 silicon the BLE controller boot switches `CLK_HF0`
onto the 48 MHz BLE ECO (ALTHF) path. The btstack-integration HCI layer
already restores `CLK_HF0` to the 96 MHz FLL path on
`CY_BT_IPC_BOOT_FULLY_UP`, but that restore is guarded by
`COMPONENT_CYW20829B0` / `COMPONENT_CYW89829B0`, which the SoC build never
defined. As a result the Cortex-M33 SysTick keeps running at 48 MHz while the
kernel still assumes `CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC` (96 MHz), so every
`k_sleep()`/timeout takes twice as long once Bluetooth is enabled.

This defines `COMPONENT_CYW20829B0` / `COMPONENT_CYW89829B0` for the
B0-silicon MPNs so the existing HAL restore is compiled in. The macro is
referenced in a single place (the `CLK_HF0` restore), so enabling it has no
other effect. B1 silicon is not covered because the HAL has no corresponding
restore path.

### Testing

Verified on CYW920829M2EVK-02. With Bluetooth enabled, a
`k_sleep(K_SECONDS(5))` loop was spaced about 10 s apart (wall clock) before
this change and about 5 s apart after it. Builds with Bluetooth disabled are
unaffected.
