### PR TITLE
drivers: sensor: Add arithmetic helper functions to sensor.h

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1429,7 +1429,7 @@ static inline int sensor_value_to_fixed_point(uint32_t *val, struct sensor_value
 
 		*val = (uint32_t)(raw & BIT64_MASK(num_bits));
 	} else {
-		if (!IN_RANGE(raw, 0, BIT64_MASK(num_bits))) {
+		if (!IN_RANGE(raw, 0, (int64_t)BIT64_MASK(num_bits))) {
 			return -ERANGE;
 		}
 

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1687,6 +1687,125 @@ static inline int sensor_value_from_micro(struct sensor_value *val, int64_t micr
 }
 
 /**
+ * @brief Helper function for adding two struct sensor_value.
+ *
+ * @param inp1 The first addend.
+ * @param inp2 The second addend.
+ * @param out Resulting sum.
+ * @return 0 if successful, negative errno code if failure.
+ */
+static inline int sensor_value_add(struct sensor_value *inp1, struct sensor_value *inp2,
+				   struct sensor_value *out)
+{
+	int64_t val1 = (int64_t)inp1->val1 + (int64_t)inp2->val1;
+	int32_t val2 = inp1->val2 + inp2->val2;
+
+	if (val2 >= 1000000LL || (val1 < 0 && val2 > 0)) {
+		val1 += 1;
+		val2 -= 1000000LL;
+	} else if (val2 <= -1000000LL || (val1 > 0 && val2 < 0)) {
+		val1 -= 1;
+		val2 += 1000000LL;
+	}
+
+	if (!IN_RANGE(val1, INT32_MIN, INT32_MAX)) {
+		return -ERANGE;
+	}
+
+	out->val1 = val1;
+	out->val2 = val2;
+
+	return 0;
+}
+
+/**
+ * @brief Helper function for subtracting two struct sensor_value.
+ *
+ * @param inp1 The minuend.
+ * @param inp2 The subtrahend.
+ * @param out Resulting difference.
+ * @return 0 if successful, negative errno code if failure.
+ */
+static inline int sensor_value_subtract(struct sensor_value *inp1, struct sensor_value *inp2,
+					struct sensor_value *out)
+{
+	int64_t val1 = (int64_t)inp1->val1 - (int64_t)inp2->val1;
+	int32_t val2 = inp1->val2 - inp2->val2;
+
+	if (val2 >= 1000000LL || (val1 < 0 && val2 > 0)) {
+		val1 += 1;
+		val2 -= 1000000LL;
+	} else if (val2 <= -1000000LL || (val1 > 0 && val2 < 0)) {
+		val1 -= 1;
+		val2 += 1000000LL;
+	}
+
+	if (!IN_RANGE(val1, INT32_MIN, INT32_MAX)) {
+		return -ERANGE;
+	}
+
+	out->val1 = val1;
+	out->val2 = val2;
+
+	return 0;
+}
+
+/**
+ * @brief Helper function for multiplying two struct sensor_value.
+ *
+ * @param inp1 The first factor.
+ * @param inp2 The second factor.
+ * @param out Resulting product.
+ * @return 0 if successful, negative errno code if failure.
+ */
+static inline int sensor_value_multiply(struct sensor_value *inp1, struct sensor_value *inp2,
+					struct sensor_value *out)
+{
+	int64_t val1 = (int64_t)inp1->val1 * inp2->val1;
+	int64_t val2 = (int64_t)inp1->val1 * inp2->val2 + (int64_t)inp1->val2 * inp2->val1 +
+		       ((int64_t)inp1->val2 * inp2->val2) / 1000000LL;
+
+	val1 += val2 / 1000000LL;
+	val2 %= 1000000LL;
+
+	if (!IN_RANGE(val1, INT32_MIN, INT32_MAX)) {
+		return -ERANGE;
+	}
+
+	out->val1 = val1;
+	out->val2 = val2;
+
+	return 0;
+}
+
+/**
+ * @brief Helper function for scaling a struct sensor_value.
+ *
+ * @param inp A pointer to a sensor_value struct.
+ * @param scalar An integer scalar.
+ * @param out Scaled output.
+ * @return 0 if successful, negative errno code if failure.
+ */
+static inline int sensor_value_scale(struct sensor_value *inp, int32_t scalar,
+				     struct sensor_value *out)
+{
+	int64_t val1 = (int64_t)inp->val1 * scalar;
+	int64_t val2 = (int64_t)inp->val2 * scalar;
+
+	val1 += val2 / 1000000LL;
+	val2 %= 1000000LL;
+
+	if (!IN_RANGE(val1, INT32_MIN, INT32_MAX)) {
+		return -ERANGE;
+	}
+
+	out->val1 = val1;
+	out->val2 = val2;
+
+	return 0;
+}
+
+/**
  * @}
  */
 

--- a/tests/drivers/sensor/generic/src/main.c
+++ b/tests/drivers/sensor/generic/src/main.c
@@ -502,6 +502,107 @@ ZTEST(sensor_api, test_sensor_unit_conversion)
 			"the result does not match");
 	zassert_equal(sensor_value_to_micro(&data), 5432109876543LL,
 			"the result does not match");
+
+	struct sensor_value data2, out;
+
+	/* Testing sensor_value additions */
+	data.val1 = 0;
+	data.val2 = 500000;
+	data2.val1 = 0;
+	data2.val2 = 500000;
+	ret = sensor_value_add(&data, &data2, &out);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(out.val1, 1, "the result does not match");
+	zassert_equal(out.val2, 0, "the result does not match");
+
+	data.val1 = 1;
+	data.val2 = 0;
+	data2.val1 = 0;
+	data2.val2 = -250000;
+	ret = sensor_value_add(&data, &data2, &out);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(out.val1, 0, "the result does not match");
+	zassert_equal(out.val2, 750000, "the result does not match");
+
+	/* Testing sensor_value subtractions */
+	data.val1 = 1;
+	data.val2 = 0;
+	data2.val1 = 0;
+	data2.val2 = 250000;
+	ret = sensor_value_subtract(&data, &data2, &out);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(out.val1, 0, "the result does not match");
+	zassert_equal(out.val2, 750000, "the result does not match");
+
+	data.val1 = 0;
+	data.val2 = -250000;
+	data2.val1 = 1;
+	data2.val2 = 0;
+	ret = sensor_value_subtract(&data, &data2, &out);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(out.val1, -1, "the result does not match");
+	zassert_equal(out.val2, -250000, "the result does not match");
+
+	/* Testing sensor_value multiplications */
+	data.val1 = 1;
+	data.val2 = 500000;
+	data2.val1 = 2;
+	data2.val2 = 0;
+	ret = sensor_value_multiply(&data, &data2, &out);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(out.val1, 3, "the result does not match");
+	zassert_equal(out.val2, 0, "the result does not match");
+
+	data.val1 = 0;
+	data.val2 = 500000;
+	data2.val1 = 0;
+	data2.val2 = -500000;
+	ret = sensor_value_multiply(&data, &data2, &out);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(out.val1, 0, "the result does not match");
+	zassert_equal(out.val2, -250000, "the result does not match");
+
+	/* Testing sensor_value scaling */
+	data.val1 = 0;
+	data.val2 = 750000;
+	ret = sensor_value_scale(&data, 2, &out);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(out.val1, 1, "the result does not match");
+	zassert_equal(out.val2, 500000, "the result does not match");
+
+	data.val1 = -1;
+	data.val2 = -500000;
+	ret = sensor_value_scale(&data, -3, &out);
+	zassert_equal(ret, 0, "success expected");
+	zassert_equal(out.val1, 4, "the result does not match");
+	zassert_equal(out.val2, 500000, "the result does not match");
+
+	/* Testing out-of-range edge cases for sensor_value arithmetic functions */
+	data.val1 = INT32_MAX;
+	data.val2 = 999999;
+	data2.val1 = 0;
+	data2.val2 = 1;
+	ret = sensor_value_add(&data, &data2, &out);
+	zassert_equal(ret, -ERANGE, "range error expected");
+
+	data.val1 = INT32_MIN;
+	data.val2 = -999999;
+	data2.val1 = 0;
+	data2.val2 = 1;
+	ret = sensor_value_subtract(&data, &data2, &out);
+	zassert_equal(ret, -ERANGE, "range error expected");
+
+	data.val1 = INT32_MAX;
+	data.val2 = 0;
+	data2.val1 = 2;
+	data2.val2 = 0;
+	ret = sensor_value_multiply(&data, &data2, &out);
+	zassert_equal(ret, -ERANGE, "range error expected");
+
+	data.val1 = INT32_MAX;
+	data.val2 = 0;
+	ret = sensor_value_scale(&data, 2, &out);
+	zassert_equal(ret, -ERANGE, "range error expected");
 }
 
 ZTEST_SUITE(sensor_api, NULL, NULL, ztest_simple_1cpu_before, ztest_simple_1cpu_after, NULL);


### PR DESCRIPTION
Adds basic arithmetic helper functions for `struct sensor_value` math and adds a test suite to `/tests/drivers/sensor/generic` to verify behavior.

Adding these because I have a need to scale a `struct sensor_value` by an integer scalar, but quickly skimming the in-tree repo shows several instances of one-off add/subtract/multiply/scale implementations. I think it's valuable to provide a uniform and efficient implementation that drivers, subsystems, and applications can just use.

These functions assume that the provided `struct sensor_value` inputs are formatted correctly (i.e., val2 in range [-999999, 999999]), and I've verified `west twister -T tests/drivers/sensor/generic -p qemu_x86` locally. 