### PR TITLE
samples: net: wifi: shell: boards: add .conf file to m33/ns

### DIFF
--- a/samples/net/wifi/shell/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.conf
+++ b/samples/net/wifi/shell/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.conf
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SHELL_STACK_SIZE=6144
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+CONFIG_NET_MGMT_EVENT_STACK_SIZE=4608
+CONFIG_NET_TCP_WORKQ_STACK_SIZE=2048
+CONFIG_IDLE_STACK_SIZE=1024


### PR DESCRIPTION
It causes reboot when doing "wifi scan" becasue CONFIG_NET_MGMT_EVENT_STACK_SIZE is too small.
So copy it from kit_pse84_eval_pse846gps2dbzc4a_m55.conf