### PR TITLE
Imx952 m7 gpio systick

### DIFF
--- a/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7.dts
+++ b/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7.dts
@@ -38,3 +38,7 @@
 &tstmr2 {
 	status = "okay";
 };
+
+&gpio2 {
+	status = "okay";
+};

--- a/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7.yaml
+++ b/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7.yaml
@@ -15,6 +15,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - gpio
   - uart
 testing:
   binaries:

--- a/soc/nxp/imx/imx9/imx952/m7/soc.c
+++ b/soc/nxp/imx/imx9/imx952/m7/soc.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/cache.h>
+#include <zephyr/init.h>
 #include <zephyr/pm/pm.h>
 #include <zephyr/drivers/firmware/scmi/nxp/cpu.h>
 #include <zephyr/drivers/firmware/scmi/power.h>
@@ -17,6 +18,33 @@ void soc_early_init_hook(void)
 	sys_cache_instr_enable();
 #endif
 }
+
+static int soc_init(void)
+{
+	int ret = 0;
+
+#if defined(CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS)
+	struct scmi_nxp_cpu_sleep_mode_config cpu_cfg = {0};
+
+	/*
+	 * SLEEP_HOLD_EN is enabled by default, which gates SysTick.
+	 * Set CPU sleep mode to RUN to clear it and allow SysTick to run.
+	 */
+	cpu_cfg.cpu_id = CPU_IDX_M7P;
+	cpu_cfg.sleep_mode = CPU_SLEEP_MODE_RUN;
+
+	ret = scmi_nxp_cpu_sleep_mode_set(&cpu_cfg);
+#endif /* CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS */
+
+	return ret;
+}
+
+/*
+ * Because platform is using ARM SCMI, drivers like scmi, mbox etc. are
+ * initialized during PRE_KERNEL_1. Common init hooks is not able to use.
+ * SoC early init and board early init could be run during PRE_KERNEL_2 instead.
+ */
+SYS_INIT(soc_init, PRE_KERNEL_2, 0);
 
 #ifdef CONFIG_PM
 void pm_state_before(void)


### PR DESCRIPTION
This series adds GPIO support for the i.MX952 EVK Cortex-M7 core.

Enable gpio2 nodes on M7 DTS and add gpio to board YAML supported features
Fix SysTick hang: SLEEP_HOLD_EN is enabled by default and gates SysTick, add soc_init() to set CPU sleep mode to RUN via SCMI at PRE_KERNEL_2, 