### PR TITLE
tests: stream_flash: use write_block_size instead of hardcoded buf_len

### DIFF
--- a/tests/subsys/storage/stream/stream_flash/src/main.c
+++ b/tests/subsys/storage/stream/stream_flash/src/main.c
@@ -319,9 +319,11 @@ ZTEST(lib_stream_flash, test_stream_flash_bytes_buffered)
 ZTEST(lib_stream_flash, test_stream_flash_buf_size_greater_than_page_size)
 {
 	int rc;
+	const struct flash_parameters *fparam = flash_get_parameters(fdev);
 
 	/* To illustrate that other params does not trigger error */
-	rc = stream_flash_init(&ctx, fdev, generic_buf, 0x10, 0, FLASH_AVAILABLE, NULL);
+	rc = stream_flash_init(&ctx, fdev, generic_buf, fparam->write_block_size, 0,
+			       FLASH_AVAILABLE, NULL);
 	zassert_equal(rc, 0, "expected success");
 
 	/* Only change buf_len param */


### PR DESCRIPTION
### Description

`test_stream_flash_buf_size_greater_than_page_size` hardcoded a `buf_len` of `0x10` for the `stream_flash_init()` call that's meant to succeed, assuming that value is always valid regardless of the flash device's actual `write_block_size`. On a device whose `write_block_size` is larger than 16 bytes, `stream_flash_init()` rejects that `buf_len` as invalid, so the test fails with an unrelated error instead of testing what it's meant to test.

Uses `flash_get_parameters(fdev)->write_block_size` instead — the same pattern already used a few lines earlier in this same file (`init_target()`) — so the `buf_len` is always valid for whatever device the test runs on.

Fixes #110948

### Note on prior attempt

This exact fix was previously submitted as #110996, which had `Check Twister Status` / `twister-build` passing on Zephyr's CI, but went without maintainer response for several weeks and was closed by its own author. Re-submitting since the underlying issue (#110948) is still open and unresolved.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.