### PR TITLE
manifest: hal_nxp: update revision for FW blob update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 75b5c7fbf918e6905e79b45b7f12acc327a3e1e7
+      revision: ab59fc67d61118720e9228c7c75bd4a9d99e317f
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Point hal_nxp to pull/764/head for pre-merge CI validation.

hal_nxp PR: https://github.com/zephyrproject-rtos/hal_nxp/pull/764

Updates firmware blobs to nxp-v4.4.1:
- RW612: FW version 8.p79
- IW610: FW version 8.p79
- IW612 (NW61x): FW version 18.99.8.p79
- IW416: FW version 16.92.21.p161

Fix https://github.com/zephyrproject-rtos/zephyr/issues/107390