### PR TITLE
drivers: sensor: adi: fix reading_count in stream decoders

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345_decoder.c
+++ b/drivers/sensor/adi/adxl345/adxl345_decoder.c
@@ -131,7 +131,6 @@ static int adxl345_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	data->header.base_timestamp_ns =
 		enc_data->timestamp -
 		(total_samples > 0 ? (total_samples - 1) : 0) * period_ns;
-	data->header.reading_count = 1;
 	uint8_t is_full_res = enc_data->is_full_res;
 
 	/* Calculate which sample is decoded. */
@@ -173,6 +172,7 @@ static int adxl345_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 		*fit = (uintptr_t)sample_end;
 		count++;
 	}
+	data->header.reading_count = count;
 	return count;
 }
 

--- a/drivers/sensor/adi/adxl355/adxl355_decoder.c
+++ b/drivers/sensor/adi/adxl355/adxl355_decoder.c
@@ -127,7 +127,6 @@ static int adxl355_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	data->header.base_timestamp_ns =
 		enc_data->timestamp -
 		(total_samples > 0 ? (total_samples - 1) : 0) * period_ns;
-	data->header.reading_count = 1;
 
 	/* Calculate which sample is decoded. */
 	if ((uint8_t *)*fit >= buffer) {
@@ -186,6 +185,7 @@ static int adxl355_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 		buffer = sample_end;
 		*fit = (uintptr_t)sample_end;
 	}
+	data->header.reading_count = count;
 	return count;
 }
 #endif /* CONFIG_ADXL355_STREAM */

--- a/drivers/sensor/adi/adxl362/adxl362_decoder.c
+++ b/drivers/sensor/adi/adxl362/adxl362_decoder.c
@@ -93,50 +93,58 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 		sample_num = (*fit - (uintptr_t)buffer) / sample_set_size;
 	}
 
-	while (count < max_count && buffer < buffer_end) {
-		const uint8_t *sample_end = buffer;
+	if (chan_spec.chan_type == SENSOR_CHAN_DIE_TEMP) {
+		struct sensor_q31_data *data = (struct sensor_q31_data *)data_out;
 
-		sample_end += sample_set_size;
+		memset(data, 0, sizeof(struct sensor_q31_data));
+		data->header.base_timestamp_ns = enc_data->timestamp;
+		data->shift = 8;
 
-		if ((uintptr_t)buffer < *fit) {
-			/* This frame was already decoded, move on to the next frame */
-			buffer = sample_end;
-			continue;
-		}
+		while (count < max_count && buffer < buffer_end) {
+			const uint8_t *sample_end = buffer + sample_set_size;
 
-		if (chan_spec.chan_type == SENSOR_CHAN_DIE_TEMP) {
+			if ((uintptr_t)buffer < *fit) {
+				buffer = sample_end;
+				continue;
+			}
+
 			if (enc_data->has_tmp) {
-				struct sensor_q31_data *data = (struct sensor_q31_data *)data_out;
-
-				memset(data, 0, sizeof(struct sensor_three_axis_data));
-				data->header.base_timestamp_ns = enc_data->timestamp;
-				data->header.reading_count = 1;
-				data->shift = 8;
-
-				data->readings[count].timestamp_delta =
-						period_ns * sample_num;
-
+				data->readings[count].timestamp_delta = period_ns * sample_num;
 				data_in = sys_le16_to_cpu(*((int16_t *)(buffer + 6)));
 
 				/* Check if this sample contains temperature value. */
 				if (ADXL362_FIFO_HDR_CHECK_TEMP(data_in)) {
-					adxl362_temp_convert_q31(&data->readings[count].temperature,
-										data_in);
+					adxl362_temp_convert_q31(
+						&data->readings[count].temperature, data_in);
 				}
 			}
-		} else {
-			struct sensor_three_axis_data *data =
-					(struct sensor_three_axis_data *)data_out;
 
-			memset(data, 0, sizeof(struct sensor_three_axis_data));
-			data->header.base_timestamp_ns = enc_data->timestamp;
-			data->header.reading_count = 1;
-			data->shift = range_to_shift[enc_data->selected_range];
+			buffer = sample_end;
+			*fit = (uintptr_t)sample_end;
+			sample_num++;
+			count++;
+		}
+		data->header.reading_count = count;
+	} else {
+		struct sensor_three_axis_data *data =
+				(struct sensor_three_axis_data *)data_out;
+
+		memset(data, 0, sizeof(struct sensor_three_axis_data));
+		data->header.base_timestamp_ns = enc_data->timestamp;
+		data->shift = range_to_shift[enc_data->selected_range];
+
+		while (count < max_count && buffer < buffer_end) {
+			const uint8_t *sample_end = buffer + sample_set_size;
+
+			if ((uintptr_t)buffer < *fit) {
+				/* This frame was already decoded, move on to the next frame */
+				buffer = sample_end;
+				continue;
+			}
 
 			switch (chan_spec.chan_type) {
 			case SENSOR_CHAN_ACCEL_X:
-				data->readings[count].timestamp_delta = sample_num
-					* period_ns;
+				data->readings[count].timestamp_delta = sample_num * period_ns;
 
 				/* Convert received data into signeg integer. */
 				data_in = sys_le16_to_cpu(*((int16_t *)buffer));
@@ -148,8 +156,7 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 				}
 				break;
 			case SENSOR_CHAN_ACCEL_Y:
-				data->readings[count].timestamp_delta = sample_num
-					* period_ns;
+				data->readings[count].timestamp_delta = sample_num * period_ns;
 
 				/* Convert received data into signeg integer. */
 				data_in = sys_le16_to_cpu(*((int16_t *)(buffer + 2)));
@@ -161,8 +168,7 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 				}
 				break;
 			case SENSOR_CHAN_ACCEL_Z:
-				data->readings[count].timestamp_delta = sample_num
-					* period_ns;
+				data->readings[count].timestamp_delta = sample_num * period_ns;
 				/* Convert received data into signeg integer. */
 				data_in = sys_le16_to_cpu(*((int16_t *)(buffer + 4)));
 
@@ -205,12 +211,15 @@ static int adxl362_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 			default:
 				return -ENOTSUP;
 			}
-		}
 
-		buffer = sample_end;
-		*fit = (uintptr_t)sample_end;
-		count++;
+			buffer = sample_end;
+			*fit = (uintptr_t)sample_end;
+			sample_num++;
+			count++;
+		}
+		data->header.reading_count = count;
 	}
+
 	return count;
 }
 

--- a/drivers/sensor/adi/adxl372/adxl372_decoder.c
+++ b/drivers/sensor/adi/adxl372/adxl372_decoder.c
@@ -64,7 +64,6 @@ static int adxl372_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 	data->header.base_timestamp_ns =
 		enc_data->timestamp -
 		(total_samples > 0 ? (total_samples - 1) : 0) * period_ns;
-	data->header.reading_count = 1;
 
 	/* Calculate which sample is decoded. */
 	if (*fit >= (uintptr_t)buffer) {
@@ -150,6 +149,7 @@ static int adxl372_decode_stream(const uint8_t *buffer, struct sensor_chan_spec 
 		*fit = (uintptr_t)sample_end;
 		count++;
 	}
+	data->header.reading_count = count;
 	return count;
 }
 


### PR DESCRIPTION
adxl345, adxl355, adxl362, and adxl372 all hardcoded reading_count = 1 despite their decode loops being capable of filling multiple readings[] entries up to max_count.

Move header setup (memset, base_timestamp_ns, shift) before the decode loop, and set reading_count to the actual decoded sample count after the loop completes.

For adxl362, the memset and header initialization were also inside the loop body, which zeroed previously decoded readings on each iteration. Fixed by moving setup outside the loop.