### PR TITLE
drivers: mbox: renesas: rcar: mfis: fix format specifier for size_t

### DIFF
--- a/drivers/mbox/mbox_renesas_rcar_mfis.c
+++ b/drivers/mbox/mbox_renesas_rcar_mfis.c
@@ -256,7 +256,7 @@ static int rcar_mfis_send(const struct device *dev, uint32_t channel,
 
 	/* Data transfer mode */
 	if (msg->size > RCAR_MFIS_MBOX_SIZE) {
-		LOG_ERR("Invalid data size (val = %u, max = %u)",
+		LOG_ERR("Invalid data size (val = %zu, max = %zu)",
 			msg->size, RCAR_MFIS_MBOX_SIZE);
 		return -EMSGSIZE;
 	} else if (msg->size > 0 && msg->data == NULL) {


### PR DESCRIPTION
Hi everybody,

I would like to summit fix a compiler warning in the Renesas R-Car MFIS mailbox driver by using %zu instead of %u for size_t arguments in a LOG_ERR call.
Thank you for your review and feedback.