### PR TITLE
net: zperf: fix TCP receiver POLLHUP handling

### DIFF
--- a/subsys/net/lib/zperf/zperf_tcp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_tcp_receiver.c
@@ -135,12 +135,9 @@ static int tcp_recv_data(struct net_socket_service_event *pev)
 	}
 
 	if ((pev->event.revents & ZSOCK_POLLERR) ||
-	    (pev->event.revents & ZSOCK_POLLNVAL) ||
-	    (pev->event.revents & ZSOCK_POLLHUP)) {
+	    (pev->event.revents & ZSOCK_POLLNVAL)) {
 		if (pev->event.revents & ZSOCK_POLLNVAL) {
 			default_error = EBADF;
-		} else if (pev->event.revents & ZSOCK_POLLHUP) {
-			default_error = ENOTCONN;
 		}
 
 		(void)zsock_getsockopt(pev->event.fd, ZSOCK_SOL_SOCKET,
@@ -155,6 +152,37 @@ static int tcp_recv_data(struct net_socket_service_event *pev)
 			family == NET_AF_INET ? 4 : 6, sock_error);
 		ret = -sock_error;
 		goto error;
+	}
+
+	/* POLLHUP means the peer closed the connection (TCP FIN). Treat it as
+	 * EOF on the accepted data socket so that zperf can finalize the
+	 * session and report results normally. POLLHUP on a listen socket is
+	 * unexpected and should be ignored here (it will be caught by POLLERR).
+	 * Only handle POLLHUP when POLLIN is not set to avoid duplicate
+	 * processing - when both are set, recv() will return 0 (EOF) naturally.
+	 */
+	if ((pev->event.revents & ZSOCK_POLLHUP) &&
+	    !(pev->event.revents & ZSOCK_POLLIN)) {
+		if (pev->event.fd != fds[SOCK_ID_IPV4_LISTEN].fd &&
+		    pev->event.fd != fds[SOCK_ID_IPV6_LISTEN].fd) {
+			i = SOCK_ID_IPV6_LISTEN + 1;
+			for (; i < SOCK_ID_MAX; i++) {
+				if (fds[i].fd == pev->event.fd) {
+					break;
+				}
+			}
+
+			if (i < SOCK_ID_MAX) {
+				tcp_received(&sock_addr[i], 0);
+				zsock_close(fds[i].fd);
+				fds[i].fd = -1;
+				memset(&sock_addr[i], 0, sizeof(struct net_sockaddr));
+				(void)net_socket_service_register(&svc_tcp, fds,
+								  ARRAY_SIZE(fds),
+								  NULL);
+			}
+		}
+		return 0;
 	}
 
 	if (!(pev->event.revents & ZSOCK_POLLIN)) {

--- a/subsys/net/lib/zperf/zperf_udp_receiver.c
+++ b/subsys/net/lib/zperf/zperf_udp_receiver.c
@@ -331,12 +331,9 @@ static int udp_recv_data(struct net_socket_service_event *pev)
 	}
 
 	if ((pev->event.revents & ZSOCK_POLLERR) ||
-	    (pev->event.revents & ZSOCK_POLLNVAL) ||
-	    (pev->event.revents & ZSOCK_POLLHUP)) {
+	    (pev->event.revents & ZSOCK_POLLNVAL)) {
 		if (pev->event.revents & ZSOCK_POLLNVAL) {
 			default_error = EBADF;
-		} else if (pev->event.revents & ZSOCK_POLLHUP) {
-			default_error = ENOTCONN;
 		}
 
 		(void)zsock_getsockopt(pev->event.fd, ZSOCK_SOL_SOCKET,


### PR DESCRIPTION
In Zephyr, POLLHUP on a TCP socket indicates that the peer closed the connection normally (TCP FIN). It is set via sock_set_eof() in zsock_received_cb() when pkt==NULL, and simultaneously triggers POLLIN so that recv() can be called to consume the EOF (returning 0).

Commit 704c7d30737 incorrectly added POLLHUP to the error condition, causing normal TCP connection close to be reported as socket error (ECONNRESET/128) and losing throughput results. UDP is not connection- oriented and does not use POLLHUP for session termination, so removing POLLHUP from the UDP error condition is sufficient.

For TCP, also add a dedicated POLLHUP handler to cover the case where POLLHUP arrives without POLLIN (recv_q empty at the time of FIN). This ensures session completion even when the two events are not delivered together. When both POLLIN and POLLHUP are set, the existing recv() path handles EOF naturally (recv() returns 0).

Fixes: 704c7d30737 ("net: zperf: handle socket hangup events")