### PR TITLE
arch: arm64: remove duplicate privileged stack default

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -156,9 +156,6 @@ config AARCH64_IMAGE_HEADER
 	  This option enables standard ARM64 boot image header used by Linux
 	  and understood by loaders such as u-boot on Xen xl tool.
 
-config PRIVILEGED_STACK_SIZE
-	default 4096
-
 config KOBJECT_TEXT_AREA
 	default 1024 if UBSAN
 	default 512 if TEST


### PR DESCRIPTION
PRIVILEGED_STACK_SIZE already has ARM64 defaults earlier in the same Kconfig file.

The later unconditional default is never reached because the previous unconditional default is the first matching default when FPU_SHARING is disabled.

Remove the duplicate entry to avoid implying that the value is overridden later.

Fixes #113092 