### PR TITLE
doc: fix lpcxresso55s69 wrong default runner and on-board probe

### DIFF
--- a/boards/nxp/lpcxpresso55s69/doc/index.rst
+++ b/boards/nxp/lpcxpresso55s69/doc/index.rst
@@ -228,14 +228,14 @@ Configuring a Debug Probe
 
 LinkServer is the default runner for this board.
 A debug probe is used for both flashing and debugging the board. This board is
-configured by default to use the integrated :ref:`mcu-link-onboard-debug-probe`
+configured by default to use the integrated :ref:`lpc-link2-onboard-debug-probe`
 in the CMSIS-DAP mode. To use this probe with Zephyr, you need to install the
 :ref:`linkserver-debug-host-tools` and make sure they are in your search path.
 Refer to the detailed overview about :ref:`application_debugging` for additional
 information.
 
-The integrated MCU-Link hardware can also be used as a J-Link probe with a
-firmware update, as described in :ref:`mcu-link-jlink-onboard-debug-probe`.
+The integrated LPC-Link2 hardware can also be used as a J-Link probe with a
+firmware update, as described in :ref:`lpclink2-jlink-onboard-debug-probe`.
 The :ref:`jlink-debug-host-tools` should be available in this case.
 
 Configuring a Console
@@ -296,7 +296,7 @@ Debugging
 =========
 
 Here is an example for the :zephyr:code-sample:`hello_world` application. This example uses the
-:ref:`jlink-debug-host-tools` as default.
+:ref:`linkserver-debug-host-tools` as default.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world


### PR DESCRIPTION
Fix the docs for lpcxpresso55s69 to correct the on-board probe being Link2 
https://www.nxp.com/design/design-center/software/development-software/mcuxpresso-software-and-tools-/lpcxpresso-boards/lpcxpresso55s69-development-board:LPC55S69-EVK#featuresXsp and the default debug runner being linkserver.