### PR TITLE
samples: drivers: audio: dmic: add dmic0 alias for lm20

### DIFF
--- a/samples/drivers/audio/dmic/boards/nrf54lm20dk_nrf54lm20_common.dtsi
+++ b/samples/drivers/audio/dmic/boards/nrf54lm20dk_nrf54lm20_common.dtsi
@@ -23,3 +23,9 @@ dmic_dev: &pdm20 {
 	pinctrl-names = "default";
 	clock-source = "PCLK32M";
 };
+
+/ {
+	aliases {
+		dmic0 = &dmic_dev;
+	};
+};


### PR DESCRIPTION
Missing after switch from dmic-dev.