### PR TITLE
sd: sdio: remove duplicate API comments

### DIFF
--- a/subsys/sd/sdio.c
+++ b/subsys/sd/sdio.c
@@ -671,18 +671,6 @@ int sdio_card_init(struct sd_card *card)
 	return ret;
 }
 
-/**
- * @brief Initialize SDIO function.
- *
- * Initializes SDIO card function. The card function will not be enabled,
- * but after this call returns the SDIO function structure can be used to read
- * and write data from the card.
- * @param func: function structure to initialize
- * @param card: SD card to enable function on
- * @param num: function number to initialize
- * @retval 0 function was initialized successfully
- * @retval -EIO: I/O error
- */
 int sdio_init_func(struct sd_card *card, struct sdio_func *func,
 		   enum sdio_func_num num)
 {
@@ -694,18 +682,6 @@ int sdio_init_func(struct sd_card *card, struct sdio_func *func,
 	return sdio_read_cis(func, cis_tuples, ARRAY_SIZE(cis_tuples));
 }
 
-
-
-/**
- * @brief Enable SDIO function
- *
- * Enables SDIO card function. @ref sdio_init_func must be called to
- * initialized the function structure before enabling it in the card.
- * @param func: function to enable
- * @retval 0 function was enabled successfully
- * @retval -ETIMEDOUT: card I/O timed out
- * @retval -EIO: I/O error
- */
 int sdio_enable_func(struct sdio_func *func)
 {
 	int ret;
@@ -743,17 +719,6 @@ int sdio_enable_func(struct sdio_func *func)
 	return -ETIMEDOUT;
 }
 
-/**
- * @brief Set block size of SDIO function
- *
- * Set desired block size for SDIO function, used by block transfers
- * to SDIO registers.
- * @param func: function to set block size for
- * @param bsize: block size
- * @retval 0 block size was set
- * @retval -EINVAL: unsupported/invalid block size
- * @retval -EIO: I/O error
- */
 int sdio_set_block_size(struct sdio_func *func, uint16_t bsize)
 {
 	int ret;
@@ -774,18 +739,6 @@ int sdio_set_block_size(struct sdio_func *func, uint16_t bsize)
 	return 0;
 }
 
-/**
- * @brief Read byte from SDIO register
- *
- * Reads byte from SDIO register
- * @param func: function to read from
- * @param reg: register address to read from
- * @param val: filled with byte value read from register
- * @retval 0 read succeeded
- * @retval -EBUSY: card is busy with another request
- * @retval -ETIMEDOUT: card read timed out
- * @retval -EIO: I/O error
- */
 int sdio_read_byte(struct sdio_func *func, uint32_t reg, uint8_t *val)
 {
 	int ret;
@@ -804,18 +757,6 @@ int sdio_read_byte(struct sdio_func *func, uint32_t reg, uint8_t *val)
 	return ret;
 }
 
-/**
- * @brief Write byte to SDIO register
- *
- * Writes byte to SDIO register
- * @param func: function to write to
- * @param reg: register address to write to
- * @param write_val: value to write to register
- * @retval 0 write succeeded
- * @retval -EBUSY: card is busy with another request
- * @retval -ETIMEDOUT: card write timed out
- * @retval -EIO: I/O error
- */
 int sdio_write_byte(struct sdio_func *func, uint32_t reg, uint8_t write_val)
 {
 	int ret;
@@ -835,19 +776,6 @@ int sdio_write_byte(struct sdio_func *func, uint32_t reg, uint8_t write_val)
 	return ret;
 }
 
-/**
- * @brief Write byte to SDIO register, and read result
- *
- * Writes byte to SDIO register, and reads the register after write
- * @param func: function to write to
- * @param reg: register address to write to
- * @param write_val: value to write to register
- * @param read_val: filled with value read from register
- * @retval 0 write succeeded
- * @retval -EBUSY: card is busy with another request
- * @retval -ETIMEDOUT: card write timed out
- * @retval -EIO: I/O error
- */
 int sdio_rw_byte(struct sdio_func *func, uint32_t reg, uint8_t write_val,
 		 uint8_t *read_val)
 {
@@ -868,20 +796,6 @@ int sdio_rw_byte(struct sdio_func *func, uint32_t reg, uint8_t write_val,
 	return ret;
 }
 
-/**
- * @brief Read bytes from SDIO fifo
- *
- * Reads bytes from SDIO register, treating it as a fifo. Reads will
- * all be done from same address.
- * @param func: function to read from
- * @param reg: register address of fifo
- * @param data: filled with data read from fifo
- * @param len: length of data to read from card
- * @retval 0 read succeeded
- * @retval -EBUSY: card is busy with another request
- * @retval -ETIMEDOUT: card read timed out
- * @retval -EIO: I/O error
- */
 int sdio_read_fifo(struct sdio_func *func, uint32_t reg, uint8_t *data,
 		   uint32_t len)
 {
@@ -902,20 +816,6 @@ int sdio_read_fifo(struct sdio_func *func, uint32_t reg, uint8_t *data,
 	return ret;
 }
 
-/**
- * @brief Write bytes to SDIO fifo
- *
- * Writes bytes to SDIO register, treating it as a fifo. Writes will
- * all be done to same address.
- * @param func: function to write to
- * @param reg: register address of fifo
- * @param data: data to write to fifo
- * @param len: length of data to write to card
- * @retval 0 write succeeded
- * @retval -EBUSY: card is busy with another request
- * @retval -ETIMEDOUT: card write timed out
- * @retval -EIO: I/O error
- */
 int sdio_write_fifo(struct sdio_func *func, uint32_t reg, uint8_t *data,
 		    uint32_t len)
 {
@@ -936,20 +836,6 @@ int sdio_write_fifo(struct sdio_func *func, uint32_t reg, uint8_t *data,
 	return ret;
 }
 
-/**
- * @brief Read blocks from SDIO fifo
- *
- * Reads blocks from SDIO register, treating it as a fifo. Reads will
- * all be done from same address.
- * @param func: function to read from
- * @param reg: register address of fifo
- * @param data: filled with data read from fifo
- * @param blocks: number of blocks to read from fifo
- * @retval 0 read succeeded
- * @retval -EBUSY: card is busy with another request
- * @retval -ETIMEDOUT: card read timed out
- * @retval -EIO: I/O error
- */
 int sdio_read_blocks_fifo(struct sdio_func *func, uint32_t reg, uint8_t *data,
 			  uint32_t blocks)
 {
@@ -970,20 +856,6 @@ int sdio_read_blocks_fifo(struct sdio_func *func, uint32_t reg, uint8_t *data,
 	return ret;
 }
 
-/**
- * @brief Write blocks to SDIO fifo
- *
- * Writes blocks from SDIO register, treating it as a fifo. Writes will
- * all be done to same address.
- * @param func: function to write to
- * @param reg: register address of fifo
- * @param data: data to write to fifo
- * @param blocks: number of blocks to write to fifo
- * @retval 0 write succeeded
- * @retval -EBUSY: card is busy with another request
- * @retval -ETIMEDOUT: card write timed out
- * @retval -EIO: I/O error
- */
 int sdio_write_blocks_fifo(struct sdio_func *func, uint32_t reg, uint8_t *data,
 			   uint32_t blocks)
 {
@@ -1004,19 +876,6 @@ int sdio_write_blocks_fifo(struct sdio_func *func, uint32_t reg, uint8_t *data,
 	return ret;
 }
 
-/**
- * @brief Copy bytes from an SDIO card
- *
- * Copies bytes from an SDIO card, starting from provided address.
- * @param func: function to read from
- * @param reg: register address to start copy at
- * @param data: buffer to copy data into
- * @param len: length of data to read
- * @retval 0 read succeeded
- * @retval -EBUSY: card is busy with another request
- * @retval -ETIMEDOUT: card read timed out
- * @retval -EIO: I/O error
- */
 int sdio_read_addr(struct sdio_func *func, uint32_t reg, uint8_t *data,
 		   uint32_t len)
 {
@@ -1037,20 +896,6 @@ int sdio_read_addr(struct sdio_func *func, uint32_t reg, uint8_t *data,
 	return ret;
 }
 
-/**
- * @brief Copy bytes to an SDIO card
- *
- * Copies bytes to an SDIO card, starting from provided address.
- *
- * @param func: function to write to
- * @param reg: register address to start copy at
- * @param data: buffer to copy data from
- * @param len: length of data to write
- * @retval 0 write succeeded
- * @retval -EBUSY: card is busy with another request
- * @retval -ETIMEDOUT: card write timed out
- * @retval -EIO: I/O error
- */
 int sdio_write_addr(struct sdio_func *func, uint32_t reg, uint8_t *data,
 		    uint32_t len)
 {


### PR DESCRIPTION
SDIO public API documentation already lives in the public header.

Drop duplicate Doxygen blocks from the implementation file.