### PR TITLE
babblesim net tests: Build and run with twister

### DIFF
--- a/boards/native/nrf_bsim/nrf52_bsim.yaml
+++ b/boards/native/nrf_bsim/nrf52_bsim.yaml
@@ -16,3 +16,4 @@ supported:
   - gpio
   - counter
   - bsim
+  - netif:openthread

--- a/samples/net/sockets/echo_server/tests.yaml
+++ b/samples/net/sockets/echo_server/tests.yaml
@@ -21,11 +21,20 @@ tests:
       - native_sim
     integration_platforms:
       - qemu_x86
-  sample.net.sockets.echo_server.802154:
+  sample.net.sockets.echo_server.802154.qemu:
     extra_args: EXTRA_CONF_FILE="overlay-qemu_802154.conf"
     platform_allow: qemu_x86
     integration_platforms:
       - qemu_x86
+  sample.net.sockets.echo_server.802154.bsim:
+    extra_args: EXTRA_CONF_FILE="overlay-802154.conf"
+    build_only: true
+    depends_on: bsim
+    platform_allow:
+      - nrf52_bsim
+    harness: bsim
+    harness_config:
+      bsim_exe_name: samples_net_sockets_echo_server_prj_conf_overlay-802154_conf
   sample.net.sockets.echo_server.802154.rf2xx.xplained:
     extra_args:
       - SHIELD=atmel_rf2xx_xplained
@@ -96,6 +105,18 @@ tests:
       - nrf52840dk/nrf52840
       - tlsr9518adk80d
     filter: CONFIG_FULL_LIBC_SUPPORTED and not CONFIG_NATIVE_LIBC
+  sample.net.sockets.echo_server.openthread.bsim:
+    extra_args: EXTRA_CONF_FILE="overlay-ot.conf"
+    tags:
+      - net
+      - openthread
+    depends_on: bsim
+    build_only: true
+    platform_allow:
+      - nrf52_bsim
+    harness: bsim
+    harness_config:
+      bsim_exe_name: samples_net_sockets_echo_server_prj_conf_overlay-ot_conf
   sample.net.sockets.echo_server.rw612_openthread_rcp_host:
     build_only: true
     extra_args:

--- a/tests/bsim/ci.net.sh
+++ b/tests/bsim/ci.net.sh
@@ -11,7 +11,5 @@ cd ${ZEPHYR_BASE}
 
 set -uex
 
-WORK_DIR=${ZEPHYR_BASE}/bsim_net nice tests/bsim/net/compile.sh
-BOARD=nrf52_bsim/native \
-RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.net.52.xml \
-SEARCH_PATH=tests/bsim/net/ tests/bsim/run_parallel.sh
+${ZEPHYR_BASE}/scripts/twister -p nrf52_bsim -T tests/bsim/net/ \
+  --force-color --inline-logs -vv --fixture bsim_multi_test

--- a/tests/bsim/net/sockets/echo_test/tests.yaml
+++ b/tests/bsim/net/sockets/echo_test/tests.yaml
@@ -1,0 +1,31 @@
+common:
+  depends_on: bsim
+  harness: bsim
+  harness_config:
+    fixture:
+      - bsim_multi_test
+  platform_allow:
+    - nrf52_bsim/native # This one is sufficient to test the stack, others are also likely to work
+  tags:
+    - net
+    - socket
+
+tests:
+  net.sockets.echo_test.802154:
+    extra_args: EXTRA_CONF_FILE="overlay-802154.conf"
+    harness_config:
+      bsim_exe_name: tests_bsim_net_sockets_echo_test_prj_conf_overlay-802154_conf
+      tests_scripts:
+        - tests_scripts/echo_test_802154.sh
+    required_applications:
+      - application: sample.net.sockets.echo_server.802154.bsim
+        path: $ZEPHYR_BASE/samples/net/sockets/echo_server
+  net.sockets.echo_test.openthread:
+    extra_args: EXTRA_CONF_FILE="overlay-ot.conf"
+    harness_config:
+      bsim_exe_name: tests_bsim_net_sockets_echo_test_prj_conf_overlay-ot_conf
+      tests_scripts:
+        - tests_scripts/echo_test_ot.sh
+    required_applications:
+      - application: sample.net.sockets.echo_server.openthread.bsim
+        path: $ZEPHYR_BASE/samples/net/sockets/echo_server


### PR DESCRIPTION
**Background:**

Following the work in https://github.com/zephyrproject-rtos/zephyr/issues/108293 and its predecessors https://github.com/zephyrproject-rtos/zephyr/issues/62649 , it is now possible to run multi device tests in twister (using Babblesim and its dedicated harness).
Running these tests with twister is not yet the most user friendly, but it is certainly usable, as the main roadblocks and worst annoyances users would face in their day to day should have been addressed.

Originally all multi-device tests were built and run with dedicated shell batching scripts, without twister.
Some time ago the build started to transition to using twister yaml definitions, with some of the images built directly by twister.

Note: By now, tests using the bsim harness, either are set as `build_only: true` or require a fixture `bsim_multi_test` which prevents the tests from being *run* in the normal twister workflow. This is due to twister not yet handling properly mutli-device tests with subsets (which we use to distribute the load to several runners in the normal twister job in CI).

**This PR:**

This PR changes the networking Babblesim tests to be both built and run using twister.
This means that users which have Babablesim installed can run these tests with twister in a quite comparable way to single device test. For example:
`twister -p nrf52_bsim -T tests/bsim/net/ -vv --fixture bsim_multi_test`
Or for a single test
`twister -p nrf52_bsim -T tests/bsim/net/ -s net.sockets.echo_test.802154 --fixture bsim_multi_test`
It is also possible to re-run with only incremental builds (which is what the compile.sh script did by default) by using the [option `--aggressive-no-clean`](https://docs.zephyrproject.org/latest/develop/twister/commandline.html#:~:text=%2D%2Daggressive%2Dno%2Dclean,-Re) or `--no-clean`

**Links**
* https://docs.zephyrproject.org/latest/develop/twister/harness/bsim.html
* https://docs.zephyrproject.org/latest/develop/twister/index.html#tests:~:text=required%5Fapplications
* https://docs.zephyrproject.org/latest/develop/twister/index.html#tests:~:text=build%3A%20%3CTrue%7CFalse%3E

**Annoying quirk to be aware**
When running twister with `--inline-logs` (like we do in CI), for tests that include several tests (with several tests .sh scripts for the bsim harness) and one of them fails, the printed logs will include *both* the logs of the passing and failing tests , and then again the failed one. (This is the same problem as with the pytest harness). So in CI, we are going to see crud logs from passing tests around the failed ones. Hopefully this will be fixed soon.