### PR TITLE
drivers: bluetooth: HCI: Add missing byteorder.h include in silabs driver

### DIFF
--- a/drivers/bluetooth/hci/hci_silabs_efr32.c
+++ b/drivers/bluetooth/hci/hci_silabs_efr32.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/drivers/bluetooth.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/byteorder.h>
 
 #include <sl_btctrl_linklayer.h>
 #include <sl_hci_common_transport.h>


### PR DESCRIPTION
The sys_le16_to_cpu() call added in hci_silabs_efr32.c requires <zephyr/sys/byteorder.h> to be included.