### PR TITLE
drivers: video: ensure to enable GPIO when needed by modules

### DIFF
--- a/drivers/video/Kconfig.gc2145
+++ b/drivers/video/Kconfig.gc2145
@@ -4,6 +4,8 @@
 config VIDEO_GC2145
 	bool "GC2145 CMOS digital image sensor"
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_GALAXYCORE_GC2145),pwdn-gpios) || \
+			$(dt_compat_any_has_prop,$(DT_COMPAT_GALAXYCORE_GC2145),reset-gpios)
 	depends on DT_HAS_GALAXYCORE_GC2145_ENABLED
 	default y
 	help

--- a/drivers/video/Kconfig.hm0360
+++ b/drivers/video/Kconfig.hm0360
@@ -4,6 +4,8 @@
 config VIDEO_HM0360
 	bool "HM0360 CMOS digital image sensor"
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_HIMAX_HM0360),pwdn-gpios) || \
+			$(dt_compat_any_has_prop,$(DT_COMPAT_HIMAX_HM0360),reset-gpios)
 	depends on DT_HAS_HIMAX_HM0360_ENABLED
 	default y
 	help

--- a/drivers/video/Kconfig.imx335
+++ b/drivers/video/Kconfig.imx335
@@ -6,6 +6,7 @@
 config VIDEO_IMX335
 	bool "IMX335 CMOS digital image sensor"
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_SONY_IMX335),reset-gpios)
 	depends on DT_HAS_SONY_IMX335_ENABLED
 	default y
 	help

--- a/drivers/video/Kconfig.ov2640
+++ b/drivers/video/Kconfig.ov2640
@@ -6,6 +6,8 @@
 config VIDEO_OV2640
 	bool "OV2640 CMOS digital image sensor"
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_OVTI_OV2640),pwdn-gpios) || \
+			$(dt_compat_any_has_prop,$(DT_COMPAT_OVTI_OV2640),reset-gpios)
 	depends on DT_HAS_OVTI_OV2640_ENABLED
 	default y
 	help

--- a/drivers/video/Kconfig.ov5640
+++ b/drivers/video/Kconfig.ov5640
@@ -6,6 +6,8 @@
 config VIDEO_OV5640
 	bool "OV5640 CMOS digital image sensor"
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_OVTI_OV5640),powerdown-gpios) || \
+			$(dt_compat_any_has_prop,$(DT_COMPAT_OVTI_OV5640),reset-gpios)
 	depends on DT_HAS_OVTI_OV5640_ENABLED
 	default y
 	help

--- a/drivers/video/Kconfig.ov5642
+++ b/drivers/video/Kconfig.ov5642
@@ -4,6 +4,7 @@
 config VIDEO_OV5642
 	bool "OV5642 CMOS digital image sensor"
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_OVTI_OV5642),powerdown-gpios)
 	depends on DT_HAS_OVTI_OV5642_ENABLED
 	default y
 	help

--- a/drivers/video/Kconfig.ov767x
+++ b/drivers/video/Kconfig.ov767x
@@ -6,6 +6,10 @@
 config VIDEO_OV767X
 	bool "OV767X CMOS digital image sensor"
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_OVTI_OV7670),pwdn-gpios) || \
+			$(dt_compat_any_has_prop,$(DT_COMPAT_OVTI_OV7670),reset-gpios) || \
+			$(dt_compat_any_has_prop,$(DT_COMPAT_OVTI_OV7675),pwdn-gpios) || \
+			$(dt_compat_any_has_prop,$(DT_COMPAT_OVTI_OV7675),reset-gpios)
 	depends on DT_HAS_OVTI_OV7670_ENABLED || DT_HAS_OVTI_OV7675_ENABLED
 	default y
 	help

--- a/drivers/video/Kconfig.ov7725
+++ b/drivers/video/Kconfig.ov7725
@@ -6,6 +6,7 @@
 config VIDEO_OV7725
 	bool "OV7725 CMOS digital image sensor"
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_OVTI_OV7725),reset-gpios)
 	depends on DT_HAS_OVTI_OV7725_ENABLED
 	default y
 	help

--- a/drivers/video/Kconfig.ov9655
+++ b/drivers/video/Kconfig.ov9655
@@ -4,6 +4,8 @@
 config VIDEO_OV9655
 	bool "OV9655 CMOS digital image sensor"
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_OVTI_OV9655),pwdn-gpios) || \
+			$(dt_compat_any_has_prop,$(DT_COMPAT_OVTI_OV9655),reset-gpios)
 	depends on DT_HAS_OVTI_OV9655_ENABLED
 	default y
 	help

--- a/drivers/video/Kconfig.st_mipid02
+++ b/drivers/video/Kconfig.st_mipid02
@@ -4,6 +4,7 @@
 menuconfig VIDEO_ST_MIPID02
 	bool "ST Microelectronics MIPID02 CSI to DVP bridge"
 	select I2C
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_MIPID02),reset-gpios)
 	depends on DT_HAS_ST_MIPID02_ENABLED
 	default y
 	help


### PR DESCRIPTION
Ensure to select GPIO whenever a driver requires a gpios line for reset or powerdown.