### PR TITLE
lib: Add Event-driven State Machine Framework (ESMF) implementation

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5826,6 +5826,7 @@ State machine framework:
     - sambhurst
     - keith-zephyr
     - glenn-andrews
+    - yagoor
   files:
     - doc/services/smf/
     - include/zephyr/smf.h

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -341,6 +341,13 @@ New Samples
 Libraries / Subsystems
 **********************
 
+* ESMF
+
+  * Added a new :ref:`esmf` (ESMF), a table-driven event dispatcher built on
+    top of the :ref:`smf`. It provides guard callbacks, action callbacks, and
+    wildcard event matching via a static transition table. Enable with
+    :kconfig:option:`CONFIG_SMF_ESMF`.
+
 * Crypto
 
   * Added AES CFB and OFB cipher mode support.

--- a/doc/services/esmf/index.rst
+++ b/doc/services/esmf/index.rst
@@ -1,0 +1,117 @@
+.. _esmf:
+
+Event-driven State Machine Framework (ESMF)
+###########################################
+
+.. highlight:: c
+
+Overview
+========
+
+The Event-driven State Machine Framework (ESMF) is a thin, table-driven event
+dispatcher built on top of the :ref:`smf`. It is intended for state machines
+where transitions are driven exclusively by discrete events rather than by a
+periodic run action.
+
+ESMF can be added to any project by enabling the
+:kconfig:option:`CONFIG_SMF_ESMF` option, which implies :kconfig:option:`CONFIG_SMF`.
+
+Transition Table
+================
+
+The core concept in ESMF is a static array of :c:struct:`esmf_transition`
+entries. Each entry describes:
+
+* **from** — the source state, or ``NULL`` to match any current state.
+* **trigger** — the event identifier to match, or :c:macro:`ESMF_TRIGGER_ANY`
+  to match any event.
+* **guard** — an optional :c:type:`esmf_guard_t` callback. If provided, the
+  transition is only taken when the guard returns ``true``.
+* **action** — an optional :c:type:`esmf_action_t` callback executed before
+  the state change.
+* **to** — the destination state, or ``NULL`` for an internal transition that
+  does not change state.
+
+Use the :c:macro:`ESMF_CREATE_TRANSITION` helper macro to populate the table::
+
+   static const struct esmf_transition my_transitions[] = {
+      ESMF_CREATE_TRANSITION(&states[S0], EV_GO, NULL,     NULL,   &states[S1]),
+      ESMF_CREATE_TRANSITION(&states[S1], EV_OK, my_guard, my_act, &states[S2]),
+      ESMF_CREATE_TRANSITION(NULL,        EV_RST, NULL,    NULL,   &states[S0]),
+   };
+
+If explicit priorities are needed, use :c:macro:`ESMF_CREATE_TRANSITION_PRIO`.
+Lower numeric values have higher priority::
+
+   static const struct esmf_transition my_prio_transitions[] = {
+      ESMF_CREATE_TRANSITION_PRIO(&states[S0], EV_WARN, NULL, NULL, &states[S1], 10),
+      ESMF_CREATE_TRANSITION_PRIO(&states[S0], EV_WARN, NULL, NULL, &states[S2],  1),
+   };
+
+Self-transitions
+----------------
+
+When the destination state equals the current state, ESMF calls
+:c:func:`smf_set_state` as normal, so the state's **exit and entry actions are
+re-executed**, matching SMF self-transition semantics. This differs from an
+internal transition (``to = NULL``), where no state change at all is
+performed.
+
+Event Matching and Priority
+===========================
+
+:c:func:`esmf_handle_event` iterates the transition table in order and evaluates
+all matching transitions whose guards (if any) return ``true``. Among those,
+the transition with the lowest priority value is selected. If multiple
+transitions have the same priority, the first one found in table order wins.
+
+If one or more entries matched the current state and trigger but all guards
+rejected the transition, the function returns ``-EACCES``.  If no entry matched
+at all, it returns ``-ENOENT``.
+
+For external transitions (``to != NULL``), SMF entry and exit actions are
+executed according to :c:func:`smf_set_state` semantics.
+
+:c:func:`esmf_handle_event` does not execute SMF run actions. SMF run actions
+should be ``NULL`` for pure event-driven ESMF state machines, or handled
+separately outside ESMF event dispatch.
+
+Initialization and Execution
+=============================
+
+Initialize the ESMF context with :c:func:`esmf_init`, then dispatch events
+using :c:func:`esmf_handle_event`::
+
+   struct my_obj {
+      struct esmf_ctx esmf;
+      bool ready;
+   };
+
+   static struct my_obj obj;
+
+   static bool my_guard(struct esmf_ctx *ctx, uint32_t trigger)
+   {
+      struct my_obj *obj = (struct my_obj *)ctx;
+
+      ARG_UNUSED(trigger);
+      return obj->ready;
+   }
+
+   void app_init(void)
+   {
+      esmf_init(ESMF_CTX(&obj), my_transitions, ARRAY_SIZE(my_transitions));
+      smf_set_initial(SMF_CTX(&obj), &states[S0]);
+   }
+
+   void app_on_event(uint32_t ev)
+   {
+      int rc = esmf_handle_event(ESMF_CTX(&obj), ev);
+      if (rc == -ENOENT) {
+         /* unhandled event */
+      }
+   }
+
+API Reference
+=============
+
+.. doxygengroup:: esmf

--- a/doc/services/index.rst
+++ b/doc/services/index.rst
@@ -36,6 +36,7 @@ OS Services
    profiling/index.rst
    shell/index.rst
    serialization/index.rst
+   esmf/index.rst
    smf/index.rst
    storage/index.rst
    sensing/index.rst

--- a/include/zephyr/esmf.h
+++ b/include/zephyr/esmf.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 Demant A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Event-driven State Machine Framework API built on top of SMF.
+ */
+
+#ifndef ZEPHYR_INCLUDE_ESMF_H_
+#define ZEPHYR_INCLUDE_ESMF_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <zephyr/smf.h>
+
+/**
+ * @brief Event-driven State Machine Framework (ESMF) APIs
+ * @defgroup esmf Event-driven State Machine Framework (ESMF)
+ * @ingroup os_services
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Macro to cast a user-defined object to ESMF context.
+ *
+ * The user-defined object must have :c:struct:`esmf_ctx` as its first member.
+ *
+ * @param o Pointer to user-defined object.
+ */
+#define ESMF_CTX(o) ((struct esmf_ctx *)o)
+
+/**
+ * @brief Macro to create an ESMF transition rule.
+ *
+ * @param _from     Source state or NULL for any state.
+ * @param _trigger Event identifier or @ref ESMF_TRIGGER_ANY.
+ * @param _guard    Guard callback or NULL.
+ * @param _action   Action callback or NULL.
+ * @param _to       Destination state or NULL for an internal transition.
+ */
+/* clang-format off */
+#define ESMF_CREATE_TRANSITION(_from, _trigger, _guard, _action, _to) \
+	ESMF_CREATE_TRANSITION_PRIO(_from, _trigger, _guard, _action, _to, 0)
+/* clang-format on */
+
+/**
+ * @brief Macro to create an ESMF transition rule.
+ *
+ * @param _from     Source state or NULL for any state.
+ * @param _trigger Event identifier or @ref ESMF_TRIGGER_ANY.
+ * @param _guard    Guard callback or NULL.
+ * @param _action   Action callback or NULL.
+ * @param _to       Destination state or NULL for an internal transition.
+ */
+/* clang-format off */
+#define ESMF_CREATE_TRANSITION_PRIO(_from, _trigger, _guard, _action, _to, _prio) \
+{                                                                             \
+	.from = _from,                                                            \
+	.trigger = _trigger,                                                    \
+	.guard = _guard,                                                          \
+	.action = _action,                                                        \
+	.to = _to,                                                                \
+	.priority = _prio,                                                        \
+}
+/* clang-format on */
+
+/**
+ * @brief Wildcard event value that matches any event in a transition rule.
+ */
+#define ESMF_TRIGGER_ANY UINT32_MAX
+
+struct esmf_ctx;
+
+/**
+ * @brief Guard callback signature for event transitions.
+ *
+ * @param ctx      ESMF context.
+ * @param trigger Incoming event identifier.
+ *
+ * @retval true  Transition may be used.
+ * @retval false Transition is rejected.
+ */
+typedef bool (*esmf_guard_t)(struct esmf_ctx *ctx, uint32_t trigger);
+
+/**
+ * @brief Action callback signature for event transitions.
+ *
+ * The action is executed before transitioning to @p to if @p to is non-NULL.
+ *
+ * @param ctx      ESMF context.
+ * @param trigger Incoming event identifier.
+ */
+typedef void (*esmf_action_t)(struct esmf_ctx *ctx, uint32_t trigger);
+
+/**
+ * @brief A single transition rule in the event transition table.
+ */
+struct esmf_transition {
+	/**
+	 * Source state to match.
+	 *
+	 * If NULL, the rule matches from any current state.
+	 */
+	const struct smf_state *from;
+
+	/**
+	 * Event identifier to match, or @ref ESMF_TRIGGER_ANY.
+	 */
+	uint32_t trigger;
+
+	/**
+	 * Optional guard callback. If NULL, the transition is always allowed.
+	 */
+	esmf_guard_t guard;
+
+	/**
+	 * Optional action callback executed before the transition.
+	 */
+	esmf_action_t action;
+
+	/**
+	 * Destination state.
+	 *
+	 * If NULL, no state transition occurs (internal transition).
+	 *
+	 * If equal to the current state (self-transition), :c:func:`smf_set_state`
+	 * is still called, so the state's exit and entry actions are re-executed,
+	 * matching SMF self-transition semantics.
+	 */
+	const struct smf_state *to;
+
+	/**
+	 * Priority of the transition rule.
+	 * Lower values have higher priority. If multiple rules match, the one with
+	 * the highest priority is selected.
+	 */
+	int priority;
+};
+
+/**
+ * @brief ESMF runtime context.
+ */
+struct esmf_ctx {
+	/**
+	 * SMF context controlled by this event table.
+	 *
+	 * This member must be first so :c:macro:`SMF_CTX` and :c:macro:`ESMF_CTX`
+	 * can be used with the same user-defined object.
+	 */
+	struct smf_ctx smf;
+
+	/** Transition table. */
+	const struct esmf_transition *transitions;
+
+	/** Number of entries in @ref transitions. */
+	size_t transition_count;
+};
+
+/**
+ * @brief Initialize an ESMF context.
+ *
+ * @param ctx              ESMF context.
+ * @param transitions      Transition table.
+ * @param transition_count Number of entries in @p transitions.
+ */
+void esmf_init(struct esmf_ctx *ctx, const struct esmf_transition *transitions,
+	       size_t transition_count);
+
+/**
+ * @brief Handle one event against the transition table.
+ *
+ * Among matching and guard-approved rules, lower @ref esmf_transition.priority
+ * values win. Rules with equal priority keep table order (first found wins).
+ *
+ * For external transitions (``to != NULL``), SMF entry/exit actions execute
+ * according to :c:func:`smf_set_state` semantics.
+ *
+ * :c:func:`esmf_handle_event` does not execute SMF run actions. SMF run actions
+ * should be ``NULL`` when using pure event-driven dispatch, or handled
+ * separately outside ESMF event handling.
+ *
+ * @param ctx      ESMF context.
+ * @param trigger Incoming event ID.
+ *
+ * @retval 0       Event handled (with or without state transition).
+ * @retval -EINVAL Invalid arguments.
+ * @retval -ENOENT No matching transition rule was found.
+ * @retval -EACCES At least one rule matched, but all were blocked by guards.
+ */
+int esmf_handle_event(struct esmf_ctx *ctx, uint32_t trigger);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_ESMF_H_ */

--- a/lib/smf/CMakeLists.txt
+++ b/lib/smf/CMakeLists.txt
@@ -7,5 +7,6 @@ target_include_directories(smf INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 zephyr_library()
 
 zephyr_library_sources(smf.c)
+zephyr_library_sources_ifdef(CONFIG_SMF_ESMF esmf.c)
 
 zephyr_library_link_libraries(smf)

--- a/lib/smf/Kconfig
+++ b/lib/smf/Kconfig
@@ -28,4 +28,10 @@ config SMF_INSTRUMENTATION
 	   If y, then the state machine framework includes instrumentation
 	   hooks for observing state transitions
 
+config SMF_ESMF
+	bool "Event-driven State Machine Framework (ESMF)"
+	help
+	  Enable the Event-driven State Machine Framework (ESMF), a transition-table
+	  layer on top of SMF for event-only state machines.
+
 endif # SMF

--- a/lib/smf/esmf.c
+++ b/lib/smf/esmf.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Demant A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/esmf.h>
+
+#include <errno.h>
+
+static bool transition_matches(const struct smf_state *current,
+			       const struct esmf_transition *transition, uint32_t trigger)
+{
+	if (transition->trigger != ESMF_TRIGGER_ANY && transition->trigger != trigger) {
+		return false;
+	}
+
+	if (transition->from == NULL || transition->from == current) {
+		return true;
+	}
+
+#ifdef CONFIG_SMF_ANCESTOR_SUPPORT
+	for (const struct smf_state *state = current->parent; state != NULL;
+	     state = state->parent) {
+		if (state == transition->from) {
+			return true;
+		}
+	}
+#endif
+
+	return false;
+}
+
+void esmf_init(struct esmf_ctx *ctx, const struct esmf_transition *transitions,
+	       size_t transition_count)
+{
+	ctx->transitions = transitions;
+	ctx->transition_count = transition_count;
+}
+
+int esmf_handle_event(struct esmf_ctx *ctx, uint32_t trigger)
+{
+	bool guard_rejected = false;
+	const struct smf_state *current;
+	const struct esmf_transition *selected = NULL;
+
+	if (ctx == NULL || ctx->transitions == NULL || ctx->transition_count == 0U) {
+		return -EINVAL;
+	}
+
+	current = smf_get_current_leaf_state(&ctx->smf);
+
+	if (current == NULL) {
+		return -EINVAL;
+	}
+
+	for (size_t i = 0U; i < ctx->transition_count; i++) {
+		const struct esmf_transition *transition = &ctx->transitions[i];
+
+		if (!transition_matches(current, transition, trigger)) {
+			continue;
+		}
+
+		if (transition->guard != NULL && !transition->guard(ctx, trigger)) {
+			guard_rejected = true;
+			continue;
+		}
+
+		if (selected == NULL || transition->priority < selected->priority) {
+			selected = transition;
+		}
+	}
+
+	if (selected == NULL) {
+		return guard_rejected ? -EACCES : -ENOENT;
+	}
+
+	if (selected->action != NULL) {
+		selected->action(ctx, trigger);
+	}
+
+	if (selected->to != NULL) {
+		smf_set_state(&ctx->smf, selected->to);
+	}
+
+	return 0;
+}

--- a/tests/lib/smf/CMakeLists.txt
+++ b/tests/lib/smf/CMakeLists.txt
@@ -5,12 +5,14 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(smf)
 
 target_sources(app PRIVATE src/main.c)
+target_sources_ifdef(CONFIG_SMF_ESMF app PRIVATE src/test_lib_esmf.c)
 
 if(CONFIG_SMF_INITIAL_TRANSITION)
   target_sources(app PRIVATE src/test_lib_self_transition_smf.c)
 elseif(CONFIG_SMF_ANCESTOR_SUPPORT)
   target_sources(app PRIVATE src/test_lib_hierarchical_smf.c
     src/test_lib_hierarchical_5_ancestor_smf.c)
+  target_sources_ifdef(CONFIG_SMF_ESMF app PRIVATE src/test_lib_hierarchical_esmf.c)
 else()
   target_sources(app PRIVATE src/test_lib_flat_smf.c)
 endif()

--- a/tests/lib/smf/src/test_lib_esmf.c
+++ b/tests/lib/smf/src/test_lib_esmf.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2026 Demant A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/esmf.h>
+#include <zephyr/ztest.h>
+
+enum test_state {
+	STATE_A,
+	STATE_B,
+	STATE_C,
+	STATE_COUNT,
+};
+
+enum test_event {
+	EVENT_TO_B = 1,
+	EVENT_TO_C,
+	EVENT_RESET,
+	EVENT_INTERNAL,
+	EVENT_SELF,
+	EVENT_PRIORITY_LOWEST,
+	EVENT_PRIORITY_TIE,
+};
+
+static const struct smf_state test_states[STATE_COUNT];
+
+struct test_object {
+	struct esmf_ctx esmf;
+	bool allow_to_c;
+	uint32_t action_count;
+	uint32_t entry_count[STATE_COUNT];
+	uint32_t exit_count[STATE_COUNT];
+};
+
+static struct test_object test_obj;
+
+static void state_a_entry(void *obj)
+{
+	struct test_object *o = obj;
+
+	o->entry_count[STATE_A]++;
+}
+
+static void state_a_exit(void *obj)
+{
+	struct test_object *o = obj;
+
+	o->exit_count[STATE_A]++;
+}
+
+static void state_b_entry(void *obj)
+{
+	struct test_object *o = obj;
+
+	o->entry_count[STATE_B]++;
+}
+
+static void state_b_exit(void *obj)
+{
+	struct test_object *o = obj;
+
+	o->exit_count[STATE_B]++;
+}
+
+static void state_c_entry(void *obj)
+{
+	struct test_object *o = obj;
+
+	o->entry_count[STATE_C]++;
+}
+
+static void state_c_exit(void *obj)
+{
+	struct test_object *o = obj;
+
+	o->exit_count[STATE_C]++;
+}
+
+static bool guard_allow_to_c(struct esmf_ctx *ctx, uint32_t trigger)
+{
+	struct test_object *o = (struct test_object *)ctx;
+
+	ARG_UNUSED(trigger);
+
+	return o->allow_to_c;
+}
+
+static void action_increment(struct esmf_ctx *ctx, uint32_t trigger)
+{
+	struct test_object *o = (struct test_object *)ctx;
+
+	ARG_UNUSED(trigger);
+
+	o->action_count++;
+}
+
+/*
+ * Test state machine diagram (PlantUML):
+ *
+ * @startuml
+ * [*] --> A
+ *
+ * A --> B : EVENT_TO_B
+ * B --> C : EVENT_TO_C\n[guard_allow_to_c]\naction_increment
+ * A --> B : EVENT_PRIORITY_LOWEST\nprio=5
+ * A --> C : EVENT_PRIORITY_LOWEST\nprio=1 (selected)
+ * A --> B : EVENT_PRIORITY_TIE\nprio=3 (first found, selected)
+ * A --> C : EVENT_PRIORITY_TIE\nprio=3
+ *
+ * A --> A : EVENT_RESET
+ * B --> A : EVENT_RESET
+ * C --> A : EVENT_RESET
+ *
+ * A : EVENT_INTERNAL / action_increment
+ * B : EVENT_INTERNAL / action_increment
+ * C : EVENT_INTERNAL / action_increment
+ *
+ * B --> B : EVENT_SELF / action_increment
+ * @enduml
+ */
+
+static const struct esmf_transition transitions[] = {
+	ESMF_CREATE_TRANSITION(&test_states[STATE_A], EVENT_TO_B, NULL, NULL,
+			       &test_states[STATE_B]),
+	ESMF_CREATE_TRANSITION(&test_states[STATE_B], EVENT_TO_C, guard_allow_to_c,
+			       action_increment, &test_states[STATE_C]),
+	ESMF_CREATE_TRANSITION(NULL, EVENT_RESET, NULL, NULL, &test_states[STATE_A]),
+	ESMF_CREATE_TRANSITION(NULL, EVENT_INTERNAL, NULL, action_increment, NULL),
+	ESMF_CREATE_TRANSITION(&test_states[STATE_B], EVENT_SELF, NULL, action_increment,
+			       &test_states[STATE_B]),
+	ESMF_CREATE_TRANSITION_PRIO(&test_states[STATE_A], EVENT_PRIORITY_LOWEST, NULL, NULL,
+				    &test_states[STATE_B], 5),
+	ESMF_CREATE_TRANSITION_PRIO(&test_states[STATE_A], EVENT_PRIORITY_LOWEST, NULL, NULL,
+				    &test_states[STATE_C], 1),
+	ESMF_CREATE_TRANSITION_PRIO(&test_states[STATE_A], EVENT_PRIORITY_TIE, NULL, NULL,
+				    &test_states[STATE_B], 3),
+	ESMF_CREATE_TRANSITION_PRIO(&test_states[STATE_A], EVENT_PRIORITY_TIE, NULL, NULL,
+				    &test_states[STATE_C], 3),
+};
+
+/* clang-format off */
+static const struct smf_state test_states[STATE_COUNT] = {
+	[STATE_A] = SMF_CREATE_STATE(state_a_entry, NULL, state_a_exit, NULL, NULL),
+	[STATE_B] = SMF_CREATE_STATE(state_b_entry, NULL, state_b_exit, NULL, NULL),
+	[STATE_C] = SMF_CREATE_STATE(state_c_entry, NULL, state_c_exit, NULL, NULL),
+};
+/* clang-format on */
+
+static void *esmf_setup(void)
+{
+	memset(&test_obj, 0, sizeof(test_obj));
+	esmf_init(ESMF_CTX(&test_obj), transitions, ARRAY_SIZE(transitions));
+
+	return NULL;
+}
+
+static void esmf_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	memset(test_obj.entry_count, 0, sizeof(test_obj.entry_count));
+	memset(test_obj.exit_count, 0, sizeof(test_obj.exit_count));
+	test_obj.allow_to_c = false;
+	test_obj.action_count = 0U;
+	smf_set_initial(SMF_CTX(&test_obj), &test_states[STATE_A]);
+}
+
+ZTEST(esmf_tests, test_transition_and_state_tracking)
+{
+	int rc;
+
+	rc = esmf_handle_event(ESMF_CTX(&test_obj), EVENT_TO_B);
+	zassert_equal(rc, 0, "transition to B should succeed");
+	zassert_equal(smf_get_current_leaf_state(SMF_CTX(&test_obj)), &test_states[STATE_B],
+		      "current state should be B");
+	zassert_equal(test_obj.exit_count[STATE_A], 1, "A exit must run once");
+	zassert_equal(test_obj.entry_count[STATE_B], 1, "B entry must run once");
+}
+
+ZTEST(esmf_tests, test_guard_block_and_then_allow)
+{
+	int rc;
+
+	rc = esmf_handle_event(ESMF_CTX(&test_obj), EVENT_TO_B);
+	zassert_equal(rc, 0, "transition to B should succeed");
+
+	test_obj.allow_to_c = false;
+	rc = esmf_handle_event(ESMF_CTX(&test_obj), EVENT_TO_C);
+	zassert_equal(rc, -EACCES, "guard should block transition");
+	zassert_equal(smf_get_current_leaf_state(SMF_CTX(&test_obj)), &test_states[STATE_B],
+		      "state should remain B");
+
+	test_obj.allow_to_c = true;
+	rc = esmf_handle_event(ESMF_CTX(&test_obj), EVENT_TO_C);
+	zassert_equal(rc, 0, "guard should allow transition");
+	zassert_equal(test_obj.action_count, 1, "action should run once");
+	zassert_equal(smf_get_current_leaf_state(SMF_CTX(&test_obj)), &test_states[STATE_C],
+		      "current state should be C");
+}
+
+ZTEST(esmf_tests, test_wildcard_and_internal_transition)
+{
+	int rc;
+	const struct smf_state *before;
+
+	rc = esmf_handle_event(ESMF_CTX(&test_obj), EVENT_TO_B);
+	zassert_equal(rc, 0, "transition to B should succeed");
+
+	before = smf_get_current_leaf_state(SMF_CTX(&test_obj));
+	rc = esmf_handle_event(ESMF_CTX(&test_obj), EVENT_INTERNAL);
+	zassert_equal(rc, 0, "internal transition event should be handled");
+	zassert_equal(test_obj.action_count, 1, "action should run once");
+	zassert_equal(smf_get_current_leaf_state(SMF_CTX(&test_obj)), before,
+		      "state should not change for internal transition");
+
+	rc = esmf_handle_event(ESMF_CTX(&test_obj), EVENT_RESET);
+	zassert_equal(rc, 0, "wildcard reset should be handled");
+	zassert_equal(smf_get_current_leaf_state(SMF_CTX(&test_obj)), &test_states[STATE_A],
+		      "reset should return to A");
+}
+
+ZTEST(esmf_tests, test_no_match)
+{
+	int rc;
+
+	rc = esmf_handle_event(ESMF_CTX(&test_obj), 999U);
+	zassert_equal(rc, -ENOENT, "unknown event should not match");
+}
+
+ZTEST(esmf_tests, test_self_transition)
+{
+	int rc;
+
+	/* Move to state B first */
+	rc = esmf_handle_event(ESMF_CTX(&test_obj), EVENT_TO_B);
+	zassert_equal(rc, 0, "transition to B should succeed");
+
+	/* Check exit and entry counts */
+	zassert_equal(test_obj.exit_count[STATE_A], 1, "A exit must run once");
+	zassert_equal(test_obj.entry_count[STATE_B], 1, "B entry must run once");
+
+	/* Self-transition: smf_set_state is called, so exit and entry re-run */
+	rc = esmf_handle_event(ESMF_CTX(&test_obj), EVENT_SELF);
+	zassert_equal(rc, 0, "self-transition event should be handled");
+	zassert_equal(smf_get_current_leaf_state(SMF_CTX(&test_obj)), &test_states[STATE_B],
+		      "state should remain B after self-transition");
+	zassert_equal(test_obj.action_count, 1, "action should run once");
+	zassert_equal(test_obj.entry_count[STATE_B], 2, "entry must re-run on self-transition");
+	zassert_equal(test_obj.exit_count[STATE_B], 1, "exit must re-run on self-transition");
+}
+
+ZTEST(esmf_tests, test_priority_lowest_value_wins)
+{
+	int rc;
+
+	rc = esmf_handle_event(ESMF_CTX(&test_obj), EVENT_PRIORITY_LOWEST);
+	zassert_equal(rc, 0, "priority event should be handled");
+	zassert_equal(smf_get_current_leaf_state(SMF_CTX(&test_obj)), &test_states[STATE_C],
+		      "transition with lower priority value should be selected");
+}
+
+ZTEST(esmf_tests, test_priority_tie_keeps_first_found)
+{
+	int rc;
+
+	rc = esmf_handle_event(ESMF_CTX(&test_obj), EVENT_PRIORITY_TIE);
+	zassert_equal(rc, 0, "priority tie event should be handled");
+	zassert_equal(smf_get_current_leaf_state(SMF_CTX(&test_obj)), &test_states[STATE_B],
+		      "first matching transition should win when priorities are equal");
+}
+
+ZTEST_SUITE(esmf_tests, NULL, esmf_setup, esmf_before, NULL, NULL);

--- a/tests/lib/smf/src/test_lib_hierarchical_esmf.c
+++ b/tests/lib/smf/src/test_lib_hierarchical_esmf.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Demant A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/esmf.h>
+#include <zephyr/ztest.h>
+
+enum hier_state {
+	STATE_PARENT,
+	STATE_CHILD_A,
+	STATE_CHILD_B,
+	STATE_ROOT,
+	STATE_COUNT,
+};
+
+enum hier_event {
+	EVENT_TO_CHILD_B = 1,
+	EVENT_TO_ROOT,
+};
+
+static const struct smf_state hier_states[STATE_COUNT];
+
+struct hier_test_object {
+	struct esmf_ctx esmf;
+	bool allow_parent_transition;
+	uint32_t action_count;
+};
+
+static struct hier_test_object hier_test_obj;
+
+static bool guard_parent_to_child_b(struct esmf_ctx *ctx, uint32_t trigger)
+{
+	struct hier_test_object *obj = (struct hier_test_object *)ctx;
+
+	ARG_UNUSED(trigger);
+
+	return obj->allow_parent_transition;
+}
+
+static void action_count_transition(struct esmf_ctx *ctx, uint32_t trigger)
+{
+	struct hier_test_object *obj = (struct hier_test_object *)ctx;
+
+	ARG_UNUSED(trigger);
+
+	obj->action_count++;
+}
+
+/*
+ * Test state machine diagram (PlantUML):
+ *
+ * @startuml
+ * state PARENT {
+ *   [*] --> CHILD_A
+ *   CHILD_A --> CHILD_B : EVENT_TO_CHILD_B\n[allow_parent_transition]\naction_count_transition
+ *   CHILD_B --> [*]
+ * }
+ *
+ * PARENT --> ROOT : EVENT_TO_ROOT\naction_count_transition
+ * @enduml
+ */
+
+static const struct esmf_transition hier_transitions[] = {
+	/*
+	 * Match from parent while current state is CHILD_A.
+	 * This validates ancestor matching in ESMF with SMF ancestor support.
+	 */
+	ESMF_CREATE_TRANSITION(&hier_states[STATE_PARENT], EVENT_TO_CHILD_B,
+			       guard_parent_to_child_b, action_count_transition,
+			       &hier_states[STATE_CHILD_B]),
+	ESMF_CREATE_TRANSITION(&hier_states[STATE_CHILD_B], EVENT_TO_ROOT, NULL,
+			       action_count_transition, &hier_states[STATE_ROOT]),
+};
+
+/* clang-format off */
+static const struct smf_state hier_states[STATE_COUNT] = {
+	[STATE_PARENT]  = SMF_CREATE_STATE(NULL, NULL, NULL, NULL, NULL),
+	[STATE_CHILD_A] = SMF_CREATE_STATE(NULL, NULL, NULL, &hier_states[STATE_PARENT], NULL),
+	[STATE_CHILD_B] = SMF_CREATE_STATE(NULL, NULL, NULL, &hier_states[STATE_PARENT], NULL),
+	[STATE_ROOT]    = SMF_CREATE_STATE(NULL, NULL, NULL, NULL, NULL),
+};
+/* clang-format on */
+
+static void *esmf_hierarchical_setup(void)
+{
+	memset(&hier_test_obj, 0, sizeof(hier_test_obj));
+	esmf_init(ESMF_CTX(&hier_test_obj), hier_transitions, ARRAY_SIZE(hier_transitions));
+
+	return NULL;
+}
+
+static void esmf_hierarchical_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	hier_test_obj.allow_parent_transition = true;
+	hier_test_obj.action_count = 0U;
+	smf_set_initial(SMF_CTX(&hier_test_obj), &hier_states[STATE_CHILD_A]);
+}
+
+ZTEST(esmf_hierarchical_tests, test_ancestor_match_and_transition)
+{
+	int rc;
+
+	rc = esmf_handle_event(ESMF_CTX(&hier_test_obj), EVENT_TO_CHILD_B);
+	zassert_equal(rc, 0, "parent-scope transition should match from child state");
+	zassert_equal(hier_test_obj.action_count, 1, "transition action should run once");
+	zassert_equal(smf_get_current_leaf_state(SMF_CTX(&hier_test_obj)),
+		      &hier_states[STATE_CHILD_B], "current state should be CHILD_B");
+
+	rc = esmf_handle_event(ESMF_CTX(&hier_test_obj), EVENT_TO_ROOT);
+	zassert_equal(rc, 0, "transition from CHILD_B to ROOT should succeed");
+	zassert_equal(hier_test_obj.action_count, 2, "second transition action should run");
+	zassert_equal(smf_get_current_leaf_state(SMF_CTX(&hier_test_obj)), &hier_states[STATE_ROOT],
+		      "current state should be ROOT");
+}
+
+ZTEST(esmf_hierarchical_tests, test_ancestor_guard_reject)
+{
+	int rc;
+
+	hier_test_obj.allow_parent_transition = false;
+
+	rc = esmf_handle_event(ESMF_CTX(&hier_test_obj), EVENT_TO_CHILD_B);
+	zassert_equal(rc, -EACCES, "guard rejection should return -EACCES");
+	zassert_equal(hier_test_obj.action_count, 0, "action must not run when guard rejects");
+	zassert_equal(smf_get_current_leaf_state(SMF_CTX(&hier_test_obj)),
+		      &hier_states[STATE_CHILD_A], "state should remain CHILD_A");
+}
+
+ZTEST_SUITE(esmf_hierarchical_tests, NULL, esmf_hierarchical_setup, esmf_hierarchical_before, NULL,
+	    NULL);

--- a/tests/lib/smf/tests.yaml
+++ b/tests/lib/smf/tests.yaml
@@ -4,6 +4,13 @@ common:
   tags:
     - smf
 tests:
+  libraries.smf.esmf:
+    extra_configs:
+      - CONFIG_SMF_ESMF=y
+  libraries.smf.esmf.hierarchical:
+    extra_configs:
+      - CONFIG_SMF_ESMF=y
+      - CONFIG_SMF_ANCESTOR_SUPPORT=y
   libraries.smf.flat: {}
   libraries.smf.hierarchical:
     extra_configs:


### PR DESCRIPTION
Add a new Event-driven State Machine Framework (ESMF) on top of SMF.

ESMF provides a table-driven event dispatcher for event-only state machines, including a public API for transition tables, guard callbacks, action callbacks, and wildcard event matching. A helper macro is added to define transition entries in a style similar to SMF state definitions.

Wire the new library into the Zephyr build and Kconfig trees, and add a native_sim ztest suite covering state transitions, guard rejection, wildcard reset handling, and action-only events. The test also includes a PlantUML state diagram to document the transition model.

Register ESMF in MAINTAINERS.yml