### PR TITLE
doc twister: script and bsim: Minor improvements

### DIFF
--- a/doc/develop/twister/harness/bsim.rst
+++ b/doc/develop/twister/harness/bsim.rst
@@ -3,7 +3,8 @@
 Bsim
 ####
 
-The ``bsim`` harness extends the ``script`` harness to support BabbleSim tests.
+The ``bsim`` harness extends the :ref:`script harness <twister_script_harness>` to support
+BabbleSim tests.
 During the build phase it copies the final executable (``zephyr.exe``) from
 the build directory to BabbleSim's ``bin`` directory
 (``${BSIM_OUT_PATH}/bin``). During the run phase it executes the test scripts
@@ -14,13 +15,15 @@ replaced by underscores): ``bs_<platform_name>_<test_path>_<test_scenario_name>`
 This name can be overridden with the ``bsim_exe_name`` option in
 ``harness_config`` section.
 
+Additional ``bsim`` harness keys extending the :ref:`script harness <twister_script_harness>`:
+
 bsim_exe_name: <string>
     If provided, the executable filename when copying to BabbleSim's bin
     directory, will be ``bs_<platform_name>_<bsim_exe_name>`` instead of the
     default based on the test path and scenario name.
 
 Example configuration with a multi-images BabbleSim test where the advertiser
-is build-only and the scanner references it via ``required_applications``:
+is build-only and the scanner references it via :ref:`required_applications <required_applications>`:
 
 .. code-block:: yaml
 

--- a/doc/develop/twister/harness/script.rst
+++ b/doc/develop/twister/harness/script.rst
@@ -8,9 +8,9 @@ from the ``tests_scripts`` harness configuration option, runs each script as
 a subprocess, and reports individual pass/fail results based on the script
 exit code.
 
-The ``script`` harness also serves as a base class for the ``bsim``, ``pytest``,
-and ``ctest`` harnesses, providing shared subprocess execution, output
-streaming, and log handling.
+The ``script`` harness also serves as a base class for the :ref:`bsim <twister_bsim_harness>`,
+:ref:`pytest <twister_pytest_harness>`, and :ref:`ctest <twister_ctest_harness>` harnesses,
+providing shared subprocess execution, output streaming, and log handling.
 
 tests_scripts: <list of script paths> (default tests_scripts)
     Specify a list of shell script paths, relative to the test source
@@ -29,5 +29,5 @@ tests_scripts: <list of script paths> (default tests_scripts)
             - ../../test/test_b.sh
             - $ENV_VAR/tests_scripts
 
-Extra arguments following ``--`` on the twister command line are passed to
-every script as additional positional arguments.
+Any extra command-line arguments passed to Twister after ``--`` are forwarded to every script as
+additional positional arguments.


### PR DESCRIPTION
Add cross references between the pages, and clarify a little bit the text so it is clearer, and it is more evident that the bsim harness keys are just extras to the script keys.

Render:
* https://builds.zephyrproject.io/zephyr/pr/113111/docs/develop/twister/harness/bsim.html
* https://builds.zephyrproject.io/zephyr/pr/113111/docs/develop/twister/harness/script.html