### PR TITLE
MAINTAINERS: bluetooth hci: include sample.bluetooth tests

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -680,6 +680,7 @@ Bluetooth HCI:
     - "area: Bluetooth"
   tests:
     - bluetooth
+    - sample.bluetooth
 
 Bluetooth Host:
   status: maintained


### PR DESCRIPTION
Run sample.bluetooth tests when files under Bluetooth HCI are changed, should catch breakages such as the one in f1027dab160.