### PR TITLE
Enhance xec dma driver

### DIFF
--- a/drivers/dma/Kconfig.xec
+++ b/drivers/dma/Kconfig.xec
@@ -22,4 +22,24 @@ config DMA_MCHP_XEC_DMAC_MAX_CHANNELS
 	  The number of channels this instance of the DMAC
 	  controller supports.
 
+config DMA_MCHP_XEC_MAX_BLOCKS_PER_CHAN
+	int "Maximum DMA blocks per channel"
+	default 1
+	range 1 16
+	help
+	  Maximum number of dma_block_config entries the driver will
+	  cache from a multi-block dma_config call. The XEC central DMA
+	  hardware programs one block at a time; the driver chains the
+	  remaining blocks in its ISR by ABORTing the channel, rewriting
+	  MSA/MEA/DEVA from the cached block, and re-issuing RUN. Each
+	  cached block costs roughly 16 bytes per channel.
+
+	  Set this to 1 (the default) to preserve historical single-block
+	  behavior bit-for-bit and the lowest RAM footprint. Increase it
+	  when a peripheral driver needs ping-pong or scatter-style
+	  transfers on the same START-to-STOP transaction (for example,
+	  streaming target-mode RX in the I2Cv3-NL driver when the host
+	  may write a payload larger than the per-instance receive
+	  buffer).
+
 endif # DMA_MCHP_XEC

--- a/drivers/dma/dma_mchp_xec.c
+++ b/drivers/dma/dma_mchp_xec.c
@@ -191,6 +191,18 @@ static void xec_dma_chan_clr(mm_reg_t chregs, const struct dma_xec_irq_info *inf
 	soc_ecia_girq_status_clear(info->gid, info->gpos);
 }
 
+static bool xec_dma_chan_is_busy(mm_reg_t chregs)
+{
+	uint32_t ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL);
+
+	if ((ctrl & (BIT(XEC_DMA_CHAN_CTRL_HWFL_RUN_POS) | BIT(XEC_DMA_CHAN_CTRL_SWFL_GO_POS))) &&
+	    (ctrl & BIT(XEC_DMA_CHAN_CTRL_BUSY_POS))) {
+		return true;
+	}
+
+	return false;
+}
+
 static int is_dma_config_valid(const struct device *dev, struct dma_config *config)
 {
 	const struct dma_xec_config * const devcfg = dev->config;
@@ -357,7 +369,7 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	struct dma_xec_channel *chdata = &data->channels[channel];
 
 	/* Do not reconfigure a channel with a transfer in progress */
-	if (sys_test_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_BUSY_POS)) {
+	if (xec_dma_chan_is_busy(chregs)) {
 		return -EBUSY;
 	}
 
@@ -470,7 +482,7 @@ static int dma_xec_reload(const struct device *dev, uint32_t channel,
 	struct dma_xec_channel *chdata = &data->channels[channel];
 	mm_reg_t chregs = xec_chan_regs(regs, channel);
 
-	if (sys_read32(chregs + XEC_DMA_CHAN_CTRL) & BIT(XEC_DMA_CHAN_CTRL_BUSY_POS)) {
+	if (xec_dma_chan_is_busy(chregs)) {
 		return -EBUSY;
 	}
 
@@ -513,7 +525,7 @@ static int dma_xec_start(const struct device *dev, uint32_t channel)
 
 	mm_reg_t chregs = xec_chan_regs(regs, channel);
 
-	if (sys_read32(chregs + XEC_DMA_CHAN_CTRL) & BIT(XEC_DMA_CHAN_CTRL_BUSY_POS)) {
+	if (xec_dma_chan_is_busy(chregs)) {
 		return -EBUSY;
 	}
 

--- a/drivers/dma/dma_mchp_xec.c
+++ b/drivers/dma/dma_mchp_xec.c
@@ -19,7 +19,15 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(dma_mchp_xec, CONFIG_DMA_LOG_LEVEL);
 
-#define XEC_DMA_MAX_CHANS			CONFIG_DMA_MCHP_XEC_DMAC_MAX_CHANNELS
+#define XEC_DMA_MAX_CHANS CONFIG_DMA_MCHP_XEC_DMAC_MAX_CHANNELS
+
+/* Hardware has no buffer address/size or copy alignment restriction */
+#define XEC_DMA_BUF_ADDR_ALIGNMENT 1U
+#define XEC_DMA_BUF_SIZE_ALIGNMENT 1U
+#define XEC_DMA_COPY_ALIGNMENT     1U
+
+/* Hardware and driver support one block transfer per channel */
+#define XEC_DMA_MAX_BLOCK_COUNT 1U
 
 #define XEC_DMA_ABORT_WAIT_LOOPS		32
 
@@ -101,7 +109,6 @@ struct dma_xec_irq_info {
 
 struct dma_xec_config {
 	mm_reg_t regs;
-	uint8_t dma_channels;
 	uint8_t dma_requests;
 	uint16_t enc_pcr;
 	int irq_info_size;
@@ -114,14 +121,12 @@ struct dma_xec_channel {
 	uint32_t mstart;
 	uint32_t mend;
 	uint32_t dstart;
-	uint32_t isr_hw_status;
+	volatile uint32_t isr_hw_status;
 	uint32_t block_count;
 	uint8_t unit_size;
 	uint8_t dir;
 	uint8_t flags;
 	uint8_t rsvd[1];
-	struct dma_block_config *head;
-	struct dma_block_config *curr;
 	dma_callback_t cb;
 	void *user_data;
 	uint32_t total_req_xfr_len;
@@ -195,6 +200,11 @@ static int is_dma_config_valid(const struct device *dev, struct dma_config *conf
 		return 0;
 	}
 
+	if (config->half_complete_callback_en != 0) {
+		LOG_ERR("XEC DMA does not support half-complete callback");
+		return 0;
+	}
+
 	if (config->source_data_size != config->dest_data_size) {
 		LOG_ERR("XEC DMA requires source and dest data size identical");
 		return 0;
@@ -207,7 +217,13 @@ static int is_dma_config_valid(const struct device *dev, struct dma_config *conf
 		return 0;
 	}
 
-	if (!is_dma_data_size_valid(config->source_data_size)) {
+	if (config->source_handshake != config->dest_handshake) {
+		LOG_ERR("Source & Dest. handshake not match");
+		return 0;
+	}
+
+	if (!is_dma_data_size_valid(config->source_data_size) ||
+	    !is_dma_data_size_valid(config->dest_data_size)) {
 		LOG_ERR("XEC DMA requires xfr unit size of 1, 2 or 4 bytes");
 		return 0;
 	}
@@ -239,6 +255,16 @@ static int check_blocks(struct dma_xec_channel *chdata, struct dma_block_config 
 
 		if (!is_data_aligned(block->source_address, block->dest_address, unit_size)) {
 			LOG_ERR("XEC DMA block at index %u violates source/dest unit size", i);
+			return -EINVAL;
+		}
+
+		if (block->block_size == 0u) {
+			LOG_ERR("XEC DMA block at index %u has zero size", i);
+			return -EINVAL;
+		}
+
+		if (block->next_block != NULL) {
+			LOG_ERR("XEC DMA supports a single block; next_block must be NULL");
 			return -EINVAL;
 		}
 
@@ -322,13 +348,18 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	uint32_t ctrl, mstart, mend, dstart, unit_size;
 	int ret;
 
-	if (!config || (channel >= (uint32_t)devcfg->dma_channels)) {
+	if (!config || (channel >= XEC_DMA_MAX_CHANS)) {
 		return -EINVAL;
 	}
 
 	const struct dma_xec_irq_info *info = xec_chan_irq_info(devcfg, channel);
 	mm_reg_t const chregs = xec_chan_regs(regs, channel);
 	struct dma_xec_channel *chdata = &data->channels[channel];
+
+	/* Do not reconfigure a channel with a transfer in progress */
+	if (sys_test_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_BUSY_POS)) {
+		return -EBUSY;
+	}
 
 	chdata->total_req_xfr_len = 0;
 	chdata->total_curr_xfr_len = 0;
@@ -348,8 +379,6 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 
 	unit_size = config->source_data_size;
 	chdata->unit_size = unit_size;
-	chdata->head = block;
-	chdata->curr = block;
 	chdata->block_count = config->block_count;
 	chdata->dir = config->channel_direction;
 
@@ -434,7 +463,7 @@ static int dma_xec_reload(const struct device *dev, uint32_t channel,
 	mm_reg_t const regs = devcfg->regs;
 	uint32_t ctrl;
 
-	if (channel >= (uint32_t)devcfg->dma_channels) {
+	if (channel >= XEC_DMA_MAX_CHANS) {
 		return -EINVAL;
 	}
 
@@ -451,7 +480,8 @@ static int dma_xec_reload(const struct device *dev, uint32_t channel,
 	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
 	sys_write32(0xffu, chregs + XEC_DMA_CHAN_ISTATUS);
 
-	if (ctrl & BIT(XEC_DMA_CHAN_CTRL_M2D_POS)) { /* Memory to Device */
+	if ((ctrl & (BIT(XEC_DMA_CHAN_CTRL_M2D_POS) | BIT(XEC_DMA_CHAN_CTRL_DIS_HWFL_POS)))) {
+		/* memory to memory or memory to peripheral */
 		chdata->mstart = src;
 		chdata->dstart = dst;
 	} else {
@@ -477,7 +507,7 @@ static int dma_xec_start(const struct device *dev, uint32_t channel)
 	mm_reg_t const regs = devcfg->regs;
 	uint32_t chan_ctrl = 0U;
 
-	if (channel >= (uint32_t)devcfg->dma_channels) {
+	if (channel >= XEC_DMA_MAX_CHANS) {
 		return -EINVAL;
 	}
 
@@ -511,11 +541,12 @@ static int dma_xec_stop(const struct device *dev, uint32_t channel)
 	mm_reg_t const regs = devcfg->regs;
 	int wait_loops = XEC_DMA_ABORT_WAIT_LOOPS;
 
-	if (channel >= (uint32_t)devcfg->dma_channels) {
+	if (channel >= XEC_DMA_MAX_CHANS) {
 		return -EINVAL;
 	}
 
 	mm_reg_t chregs = xec_chan_regs(regs, channel);
+	const struct dma_xec_irq_info *info = xec_chan_irq_info(devcfg, channel);
 
 	sys_write32(0, chregs + XEC_DMA_CHAN_IENABLE);
 
@@ -538,6 +569,11 @@ static int dma_xec_stop(const struct device *dev, uint32_t channel)
 	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
 	sys_write32(0xffu, chregs + XEC_DMA_CHAN_ISTATUS);
 	sys_write32(0, chregs + XEC_DMA_CHAN_ACTV);
+
+	/* Clear the aggregated GIRQ source latch so an aborted transfer
+	 * does not leave a spurious pending interrupt.
+	 */
+	soc_ecia_girq_status_clear(info->gid, info->gpos);
 
 	return 0;
 }
@@ -565,7 +601,7 @@ static int dma_xec_get_status(const struct device *dev, uint32_t channel,
 	mm_reg_t const regs = devcfg->regs;
 	uint32_t chan_ctrl = 0U;
 
-	if ((channel >= (uint32_t)devcfg->dma_channels) || (!status)) {
+	if ((channel >= XEC_DMA_MAX_CHANS) || (!status)) {
 		LOG_ERR("unsupported channel");
 		return -EINVAL;
 	}
@@ -598,32 +634,54 @@ static int dma_xec_get_status(const struct device *dev, uint32_t channel,
 
 	status->total_copied = chan_data->total_curr_xfr_len;
 
+	/* Report a latched bus error from the last transfer */
+	if (chan_data->isr_hw_status & BIT(XEC_DMA_CHAN_IES_BERR_POS)) {
+		return -EIO;
+	}
+
 	return 0;
 }
 
 int xec_dma_get_attribute(const struct device *dev, uint32_t type, uint32_t *value)
 {
-	if ((type == DMA_ATTR_MAX_BLOCK_COUNT) && value) {
-		*value = 1;
-		return 0;
+	ARG_UNUSED(dev);
+
+	if (value == NULL) {
+		return -EINVAL;
 	}
 
-	return -EINVAL;
+	switch (type) {
+	case DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT:
+		*value = XEC_DMA_BUF_ADDR_ALIGNMENT;
+		break;
+	case DMA_ATTR_BUFFER_SIZE_ALIGNMENT:
+		*value = XEC_DMA_BUF_SIZE_ALIGNMENT;
+		break;
+	case DMA_ATTR_COPY_ALIGNMENT:
+		*value = XEC_DMA_COPY_ALIGNMENT;
+		break;
+	case DMA_ATTR_MAX_BLOCK_COUNT:
+		*value = XEC_DMA_MAX_BLOCK_COUNT;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
-/* returns true if filter matched otherwise returns false */
 static bool dma_xec_chan_filter(const struct device *dev, int ch, void *filter_param)
 {
-	const struct dma_xec_config * const devcfg = dev->config;
-	uint32_t filter = 0u;
-
-	if (!filter_param && devcfg->dma_channels) {
-		filter = GENMASK(devcfg->dma_channels-1u, 0);
-	} else {
-		filter = *((uint32_t *)filter_param);
+	if ((ch < 0) || (ch >= XEC_DMA_MAX_CHANS)) {
+		return false;
 	}
 
-	return (filter & BIT(ch));
+	if (filter_param == NULL) { /* allow any valid channel */
+		return true;
+	}
+
+	/* Hardware only supports normal channels */
+	return (*((enum dma_channel_filter *)filter_param) == DMA_CHANNEL_NORMAL);
 }
 
 /* API - HW does not stupport suspend/resume */
@@ -676,6 +734,7 @@ static void dma_xec_irq_handler(const struct device *dev, uint32_t channel)
 	mm_reg_t const regs = xec_chan_regs(devcfg->regs, channel);
 	uint32_t sts = sys_read32(regs + XEC_DMA_CHAN_ISTATUS);
 	int cb_status = 0;
+	bool invoke_cb = true;
 
 	LOG_DBG("maddr=0x%08x mend=0x%08x daddr=0x%08x ctrl=0x%08x sts=0x%02x",
 		sys_read32(regs + XEC_DMA_CHAN_MEM_ADDR),
@@ -684,7 +743,7 @@ static void dma_xec_irq_handler(const struct device *dev, uint32_t channel)
 		sys_read32(regs + XEC_DMA_CHAN_CTRL), sts);
 
 	sys_write32(0u, regs + XEC_DMA_CHAN_IENABLE);
-	sys_write32(0xffu, regs + XEC_DMA_CHAN_ISTATUS);
+	sys_write32(sts, regs + XEC_DMA_CHAN_ISTATUS);
 	soc_ecia_girq_status_clear(info[channel].gid, info[channel].gpos);
 
 	chan_data->isr_hw_status = sts;
@@ -692,12 +751,13 @@ static void dma_xec_irq_handler(const struct device *dev, uint32_t channel)
 		(sys_read32(regs + XEC_DMA_CHAN_MEM_ADDR) - chan_data->mstart);
 
 	if (sts & BIT(XEC_DMA_CHAN_IES_BERR_POS)) {/* Bus Error? */
-		if (!(chan_data->flags & BIT(DMA_XEC_CHAN_FLAGS_CB_ERR_DIS_POS))) {
-			cb_status = -EIO;
+		cb_status = -EIO;
+		if (chan_data->flags & BIT(DMA_XEC_CHAN_FLAGS_CB_ERR_DIS_POS)) {
+			invoke_cb = false;
 		}
 	}
 
-	if (chan_data->cb) {
+	if (invoke_cb && chan_data->cb) {
 		chan_data->cb(dev, chan_data->user_data, channel, cb_status);
 	}
 }
@@ -721,7 +781,9 @@ static int dma_xec_init(const struct device *dev)
 	}
 	sys_write32(BIT(XEC_DMA_MAIN_CTRL_EN_POS), regs + XEC_DMA_MAIN_CTRL);
 
-	devcfg->irq_connect(dev);
+	if (devcfg->irq_connect != NULL) {
+		devcfg->irq_connect(dev);
+	}
 
 	return 0;
 }
@@ -761,42 +823,35 @@ static int dma_xec_init(const struct device *dev)
 		DT_INST_FOREACH_PROP_ELEM(inst, interrupt_names, DMA_XEC_IRQ_CONNECT_SUB)          \
 	}
 
-#define DMA_XEC_DEVICE(i)								\
-	BUILD_ASSERT(DT_INST_PROP(i, dma_channels) <= XEC_DMA_MAX_CHANS,		\
-		     "XEC DMA dma-channels exceeds max");				\
-	BUILD_ASSERT(DT_INST_PROP(i, dma_requests) <= XEC_DMA_MAX_CHANS,		\
-		     "XEC DMA dma-requests exceeds max");				\
-											\
-	static struct dma_xec_channel							\
-		dma_xec_ctrl##i##_chans[DT_INST_PROP(i, dma_channels)];			\
-	ATOMIC_DEFINE(dma_xec_atomic##i, DT_INST_PROP(i, dma_channels));		\
-											\
-	static struct dma_xec_data dma_xec_data##i = {					\
-		.ctx.magic = DMA_MAGIC,							\
-		.ctx.dma_channels = DT_INST_PROP(i, dma_channels),			\
-		.ctx.atomic = dma_xec_atomic##i,					\
-		.channels = dma_xec_ctrl##i##_chans,					\
-	};										\
-											\
-	DMA_XEC_IRQ_CONNECT(i)								\
-											\
-	static const struct dma_xec_irq_info dma_xec_irqi##i[] = {			\
-		DT_INST_FOREACH_PROP_ELEM(i, girqs, DMA_XEC_GIRQ_INFO)			\
-	};										\
-	static const struct dma_xec_config dma_xec_cfg##i = {				\
-		.regs = DT_INST_REG_ADDR(i),						\
-		.dma_channels = DT_INST_PROP(i, dma_channels),				\
-		.dma_requests = DT_INST_PROP(i, dma_requests),				\
-		.enc_pcr = DT_INST_PROP(i, pcr_scr),					\
-		.irq_info_size = ARRAY_SIZE(dma_xec_irqi##i),				\
-		.irq_info_list = dma_xec_irqi##i,					\
-		.irq_connect = dma_xec_irq_connect##i,					\
-	};										\
-	PM_DEVICE_DT_DEFINE(i, dmac_xec_pm_action);					\
-	DEVICE_DT_INST_DEFINE(i, dma_xec_init,						\
-		PM_DEVICE_DT_GET(i),							\
-		&dma_xec_data##i, &dma_xec_cfg##i,					\
-		PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,					\
-		&dma_xec_api);
+#define DMA_XEC_DEVICE(i)                                                                          \
+	BUILD_ASSERT(DT_INST_PROP(i, dma_requests) <= XEC_DMA_MAX_CHANS,                           \
+		     "XEC DMA dma-requests exceeds max");                                          \
+                                                                                                   \
+	static struct dma_xec_channel dma_xec_ctrl##i##_chans[DT_INST_PROP(i, dma_channels)];      \
+	ATOMIC_DEFINE(dma_xec_atomic##i, DT_INST_PROP(i, dma_channels));                           \
+                                                                                                   \
+	static struct dma_xec_data dma_xec_data##i = {                                             \
+		.ctx.magic = DMA_MAGIC,                                                            \
+		.ctx.dma_channels = DT_INST_PROP(i, dma_channels),                                 \
+		.ctx.atomic = dma_xec_atomic##i,                                                   \
+		.channels = dma_xec_ctrl##i##_chans,                                               \
+	};                                                                                         \
+                                                                                                   \
+	DMA_XEC_IRQ_CONNECT(i)                                                                     \
+                                                                                                   \
+	static const struct dma_xec_irq_info dma_xec_irqi##i[] = {                                 \
+		DT_INST_FOREACH_PROP_ELEM(i, girqs, DMA_XEC_GIRQ_INFO)};                           \
+	static const struct dma_xec_config dma_xec_cfg##i = {                                      \
+		.regs = DT_INST_REG_ADDR(i),                                                       \
+		.dma_requests = DT_INST_PROP(i, dma_requests),                                     \
+		.enc_pcr = DT_INST_PROP(i, pcr_scr),                                               \
+		.irq_info_size = ARRAY_SIZE(dma_xec_irqi##i),                                      \
+		.irq_info_list = dma_xec_irqi##i,                                                  \
+		.irq_connect = dma_xec_irq_connect##i,                                             \
+	};                                                                                         \
+	PM_DEVICE_DT_DEFINE(i, dmac_xec_pm_action);                                                \
+	DEVICE_DT_INST_DEFINE(i, dma_xec_init, PM_DEVICE_DT_GET(i), &dma_xec_data##i,              \
+			      &dma_xec_cfg##i, PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,             \
+			      &dma_xec_api);
 
 DT_INST_FOREACH_STATUS_OKAY(DMA_XEC_DEVICE)

--- a/drivers/dma/dma_mchp_xec.c
+++ b/drivers/dma/dma_mchp_xec.c
@@ -450,15 +450,11 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 
 	dma_xec_chan_reset(dev, channel);
 
-	sys_clear_bit(chregs + XEC_DMA_CHAN_ACTV, XEC_DMA_CHAN_ACTV_EN_POS);
 	sys_write32(mstart, chregs + XEC_DMA_CHAN_MEM_ADDR);
 	sys_write32(mend, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
 	sys_write32(dstart, chregs + XEC_DMA_CHAN_DEV_ADDR);
 
 	sys_write32(ctrl, chregs + XEC_DMA_CHAN_CTRL);
-	sys_write32(BIT(XEC_DMA_CHAN_IES_BERR_POS) | BIT(XEC_DMA_CHAN_IES_DONE_POS),
-		    chregs + XEC_DMA_CHAN_IENABLE);
-	sys_set_bit(chregs + XEC_DMA_CHAN_ACTV, XEC_DMA_CHAN_ACTV_EN_POS);
 
 	return 0;
 }
@@ -533,8 +529,10 @@ static int dma_xec_start(const struct device *dev, uint32_t channel)
 
 	data->channels[channel].isr_hw_status = 0;
 
-	sys_write32(0u, chregs + XEC_DMA_CHAN_IENABLE);
-	sys_write32(0xffu, chregs + XEC_DMA_CHAN_ISTATUS);
+	sys_set_bit(chregs + XEC_DMA_CHAN_ACTV, XEC_DMA_CHAN_ACTV_EN_POS);
+	sys_write32(XEC_DMA_CHAN_ISTATUS_MSK, chregs + XEC_DMA_CHAN_ISTATUS);
+	sys_write32(BIT(XEC_DMA_CHAN_IES_BERR_POS) | BIT(XEC_DMA_CHAN_IES_DONE_POS),
+		    chregs + XEC_DMA_CHAN_IENABLE);
 	chan_ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL);
 
 	if (chan_ctrl & BIT(XEC_DMA_CHAN_CTRL_DIS_HWFL_POS)) {
@@ -543,10 +541,7 @@ static int dma_xec_start(const struct device *dev, uint32_t channel)
 		chan_ctrl |= BIT(XEC_DMA_CHAN_CTRL_HWFL_RUN_POS);
 	}
 
-	sys_write32(BIT(XEC_DMA_CHAN_IES_BERR_POS) | BIT(XEC_DMA_CHAN_IES_DONE_POS),
-		    chregs + XEC_DMA_CHAN_IENABLE);
 	sys_write32(chan_ctrl, chregs + XEC_DMA_CHAN_CTRL);
-	sys_set_bit(chregs + XEC_DMA_CHAN_ACTV, XEC_DMA_CHAN_ACTV_EN_POS);
 
 	return 0;
 }

--- a/drivers/dma/dma_mchp_xec.c
+++ b/drivers/dma/dma_mchp_xec.c
@@ -96,9 +96,7 @@ LOG_MODULE_REGISTER(dma_mchp_xec, CONFIG_DMA_LOG_LEVEL);
 
 struct dma_xec_irq_info {
 	uint8_t gid;	/* GIRQ id [8, 26] */
-	uint8_t gpos;	/* bit position in GIRQ [0, 31] */
-	uint8_t anid;	/* aggregated external NVIC input */
-	uint8_t dnid;	/* direct NVIC input */
+	uint8_t gpos;   /* bit position in GIRQ [0, 31] */
 };
 
 struct dma_xec_config {
@@ -108,7 +106,7 @@ struct dma_xec_config {
 	uint16_t enc_pcr;
 	int irq_info_size;
 	const struct dma_xec_irq_info *irq_info_list;
-	void (*irq_connect)(void);
+	void (*irq_connect)(const struct device *dev);
 };
 
 struct dma_xec_channel {
@@ -723,7 +721,7 @@ static int dma_xec_init(const struct device *dev)
 	}
 	sys_write32(BIT(XEC_DMA_MAIN_CTRL_EN_POS), regs + XEC_DMA_MAIN_CTRL);
 
-	devcfg->irq_connect();
+	devcfg->irq_connect(dev);
 
 	return 0;
 }
@@ -736,31 +734,31 @@ static int dma_xec_init(const struct device *dev)
 	{									\
 		.gid = DMA_XEC_GID(n, p, i),					\
 		.gpos = DMA_XEC_GPOS(n, p, i),					\
-		.anid = MCHP_XEC_ECIA_NVIC_AGGR(DT_PROP_BY_IDX(n, p, i)),	\
-		.dnid = MCHP_XEC_ECIA_NVIC_DIRECT(DT_PROP_BY_IDX(n, p, i)),	\
 	},
 
-/* n = node-id, p = property, i = index(channel?) */
-#define DMA_XEC_IRQ_DECLARE(node_id, p, i)					\
-	static void dma_xec_chan_##i##_isr(const struct device *dev)		\
-	{									\
-		dma_xec_irq_handler(dev, i);					\
-	}									\
+/* node_id, p = property (interrupt-names), i = interrupt/channel index */
+#define DMA_XEC_IRQ_DECLARE(node_id, p, i)                                                         \
+	static void dma_xec_chan_##i##_isr(const struct device *dev)                               \
+	{                                                                                          \
+		dma_xec_irq_handler(dev, i);                                                       \
+	}
 
-#define DMA_XEC_IRQ_CONNECT_SUB(node_id, p, i)					\
-	IRQ_CONNECT(DT_IRQ_BY_IDX(node_id, i, irq),				\
-		    DT_IRQ_BY_IDX(node_id, i, priority),			\
-		    dma_xec_chan_##i##_isr,					\
-		    DEVICE_DT_GET(node_id), 0);					\
-	irq_enable(DT_IRQ_BY_IDX(node_id, i, irq));				\
-	soc_ecia_girq_ctrl(DMA_XEC_GID(node_id, p, i), DMA_XEC_GPOS(node_id, p, i), 1);
+#define DMA_XEC_IRQ_CONNECT_SUB(node_id, p, i)                                                     \
+	IRQ_CONNECT(DT_IRQ_BY_IDX(node_id, i, irq), DT_IRQ_BY_IDX(node_id, i, priority),           \
+		    dma_xec_chan_##i##_isr, DEVICE_DT_GET(node_id), 0);                            \
+	irq_enable(DT_IRQ_BY_IDX(node_id, i, irq));                                                \
+	soc_ecia_girq_ctrl(devcfg->irq_info_list[i].gid, devcfg->irq_info_list[i].gpos, 1);
 
-/* i = instance number of DMA controller */
-#define DMA_XEC_IRQ_CONNECT(inst)							\
-	DT_INST_FOREACH_PROP_ELEM(inst, girqs, DMA_XEC_IRQ_DECLARE)			\
-	void dma_xec_irq_connect##inst(void)						\
-	{										\
-		DT_INST_FOREACH_PROP_ELEM(inst, girqs, DMA_XEC_IRQ_CONNECT_SUB)		\
+/* i = instance number of DMA controller. The connect loop iterates the
+ * interrupt-names property so the index aligns 1:1 with the interrupts
+ * entries; the GIRQ enable is looked up from the config array by index.
+ */
+#define DMA_XEC_IRQ_CONNECT(inst)                                                                  \
+	DT_INST_FOREACH_PROP_ELEM(inst, interrupt_names, DMA_XEC_IRQ_DECLARE)                      \
+	void dma_xec_irq_connect##inst(const struct device *dev)                                   \
+	{                                                                                          \
+		const struct dma_xec_config *const devcfg = dev->config;                           \
+		DT_INST_FOREACH_PROP_ELEM(inst, interrupt_names, DMA_XEC_IRQ_CONNECT_SUB)          \
 	}
 
 #define DMA_XEC_DEVICE(i)								\

--- a/drivers/dma/dma_mchp_xec.c
+++ b/drivers/dma/dma_mchp_xec.c
@@ -129,8 +129,6 @@ struct dma_xec_channel {
 	uint8_t rsvd[1];
 	dma_callback_t cb;
 	void *user_data;
-	uint32_t total_req_xfr_len;
-	uint32_t total_curr_xfr_len;
 };
 
 #define DMA_XEC_CHAN_FLAGS_CB_EOB_POS		0
@@ -256,8 +254,6 @@ static int check_blocks(struct dma_xec_channel *chdata, struct dma_block_config 
 		return -EINVAL;
 	}
 
-	chdata->total_req_xfr_len = 0;
-
 	for (uint32_t i = 0; i < block_count; i++) {
 		if ((block->source_addr_adj == DMA_ADDR_ADJ_DECREMENT) ||
 		    (block->dest_addr_adj == DMA_ADDR_ADJ_DECREMENT)) {
@@ -279,8 +275,6 @@ static int check_blocks(struct dma_xec_channel *chdata, struct dma_block_config 
 			LOG_ERR("XEC DMA supports a single block; next_block must be NULL");
 			return -EINVAL;
 		}
-
-		chdata->total_req_xfr_len += block->block_size;
 	}
 
 	return 0;
@@ -372,9 +366,6 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	if (xec_dma_chan_is_busy(chregs)) {
 		return -EBUSY;
 	}
-
-	chdata->total_req_xfr_len = 0;
-	chdata->total_curr_xfr_len = 0;
 
 	xec_dma_chan_clr(chregs, info);
 
@@ -502,8 +493,6 @@ static int dma_xec_reload(const struct device *dev, uint32_t channel,
 	}
 
 	chdata->mend = chdata->mstart + size;
-	chdata->total_req_xfr_len = size;
-	chdata->total_curr_xfr_len = 0;
 
 	sys_write32(chdata->mstart, chregs + XEC_DMA_CHAN_MEM_ADDR);
 	sys_write32(chdata->mend, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
@@ -621,19 +610,23 @@ static int dma_xec_get_status(const struct device *dev, uint32_t channel,
 	struct dma_xec_channel *chan_data = &data->channels[channel];
 	mm_reg_t chregs = xec_chan_regs(regs, channel);
 
+	status->busy = false;
+	if (xec_dma_chan_is_busy(chregs)) {
+		status->busy = true;
+	}
+
 	chan_ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL);
 
-	if (chan_ctrl & BIT(XEC_DMA_CHAN_CTRL_BUSY_POS)) {
-		uint32_t rem = sys_read32(chregs + XEC_DMA_CHAN_MEM_ADDR_END) -
-			       sys_read32(chregs + XEC_DMA_CHAN_MEM_ADDR);
+	status->free = 0;
+	status->write_position = 0;
+	status->read_position = 0;
 
-		status->busy = true;
-		/* number of bytes remaining in channel */
-		status->pending_length = chan_data->total_req_xfr_len - rem;
-	} else {
-		status->pending_length = chan_data->total_req_xfr_len -
-						chan_data->total_curr_xfr_len;
-		status->busy = false;
+	uint32_t msa = sys_read32(chregs + XEC_DMA_CHAN_MEM_ADDR);
+	uint32_t mea = sys_read32(chregs + XEC_DMA_CHAN_MEM_ADDR_END);
+
+	status->pending_length = 0;
+	if (mea > msa) {
+		status->pending_length = mea - msa;
 	}
 
 	if (chan_ctrl & BIT(XEC_DMA_CHAN_CTRL_DIS_HWFL_POS)) {
@@ -644,7 +637,7 @@ static int dma_xec_get_status(const struct device *dev, uint32_t channel,
 		status->dir = PERIPHERAL_TO_MEMORY;
 	}
 
-	status->total_copied = chan_data->total_curr_xfr_len;
+	status->total_copied = 0;
 
 	/* Report a latched bus error from the last transfer */
 	if (chan_data->isr_hw_status & BIT(XEC_DMA_CHAN_IES_BERR_POS)) {
@@ -759,8 +752,6 @@ static void dma_xec_irq_handler(const struct device *dev, uint32_t channel)
 	soc_ecia_girq_status_clear(info[channel].gid, info[channel].gpos);
 
 	chan_data->isr_hw_status = sts;
-	chan_data->total_curr_xfr_len +=
-		(sys_read32(regs + XEC_DMA_CHAN_MEM_ADDR) - chan_data->mstart);
 
 	if (sts & BIT(XEC_DMA_CHAN_IES_BERR_POS)) {/* Bus Error? */
 		cb_status = -EIO;

--- a/drivers/dma/dma_mchp_xec.c
+++ b/drivers/dma/dma_mchp_xec.c
@@ -100,6 +100,7 @@ LOG_MODULE_REGISTER(dma_mchp_xec, CONFIG_DMA_LOG_LEVEL);
 #define XEC_DMA_CHAN_CTRL		0x10u
 #define XEC_DMA_CHAN_ISTATUS		0x14u
 #define XEC_DMA_CHAN_IENABLE		0x18u
+#define XEC_DMA_CHAN_ISTATUS_MSK	0x0fu
 #define XEC_DMA_CHAN_FSM		0x1cu
 
 struct dma_xec_irq_info {
@@ -176,19 +177,6 @@ static int is_data_aligned(uint32_t src, uint32_t dest, uint32_t unitsz)
 	return 1;
 }
 
-static void xec_dma_chan_clr(mm_reg_t chregs, const struct dma_xec_irq_info *info)
-{
-	sys_write32(0, chregs + XEC_DMA_CHAN_ACTV);
-	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
-	sys_write32(0, chregs + XEC_DMA_CHAN_MEM_ADDR);
-	sys_write32(0, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
-	sys_write32(0, chregs + XEC_DMA_CHAN_DEV_ADDR);
-	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
-	sys_write32(0, chregs + XEC_DMA_CHAN_IENABLE);
-	sys_write32(0xffu, chregs + XEC_DMA_CHAN_ISTATUS);
-	soc_ecia_girq_status_clear(info->gid, info->gpos);
-}
-
 static bool xec_dma_chan_is_busy(mm_reg_t chregs)
 {
 	uint32_t ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL);
@@ -199,6 +187,32 @@ static bool xec_dma_chan_is_busy(mm_reg_t chregs)
 	}
 
 	return false;
+}
+
+static void dma_xec_chan_reset(const struct device *dev, uint32_t chan)
+{
+	const struct dma_xec_config *devcfg = dev->config;
+	int wait_loops = XEC_DMA_ABORT_WAIT_LOOPS;
+
+	mm_reg_t chregs = xec_chan_regs(devcfg->regs, chan);
+	const struct dma_xec_irq_info *info = xec_chan_irq_info(devcfg, chan);
+
+	sys_set_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_ABORT_POS);
+	/* HW stops on next unit boundary (1, 2, or 4 bytes) */
+	while ((sys_test_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_BUSY_POS) != 0) &&
+	       (wait_loops-- > 0)) {
+	}
+
+	sys_clear_bit(chregs + XEC_DMA_CHAN_ACTV, XEC_DMA_CHAN_ACTV_EN_POS);
+	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
+	/* mem end address before mem start address to ensure msa >= mea */
+	sys_write32(0, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
+	sys_write32(0, chregs + XEC_DMA_CHAN_MEM_ADDR);
+	sys_write32(0, chregs + XEC_DMA_CHAN_DEV_ADDR);
+	sys_write32(0, chregs + XEC_DMA_CHAN_IENABLE);
+	sys_write32(XEC_DMA_CHAN_ISTATUS_MSK, chregs + XEC_DMA_CHAN_ISTATUS);
+
+	soc_ecia_girq_status_clear(info->gid, info->gpos);
 }
 
 static int is_dma_config_valid(const struct device *dev, struct dma_config *config)
@@ -358,7 +372,6 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 		return -EINVAL;
 	}
 
-	const struct dma_xec_irq_info *info = xec_chan_irq_info(devcfg, channel);
 	mm_reg_t const chregs = xec_chan_regs(regs, channel);
 	struct dma_xec_channel *chdata = &data->channels[channel];
 
@@ -366,8 +379,6 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	if (xec_dma_chan_is_busy(chregs)) {
 		return -EBUSY;
 	}
-
-	xec_dma_chan_clr(chregs, info);
 
 	if (!is_dma_config_valid(dev, config)) {
 		return -EINVAL;
@@ -437,6 +448,8 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	chdata->mend = mend;
 	chdata->dstart = dstart;
 
+	dma_xec_chan_reset(dev, channel);
+
 	sys_clear_bit(chregs + XEC_DMA_CHAN_ACTV, XEC_DMA_CHAN_ACTV_EN_POS);
 	sys_write32(mstart, chregs + XEC_DMA_CHAN_MEM_ADDR);
 	sys_write32(mend, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
@@ -477,11 +490,10 @@ static int dma_xec_reload(const struct device *dev, uint32_t channel,
 		return -EBUSY;
 	}
 
-	ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL) & ~(BIT(XEC_DMA_CHAN_CTRL_HWFL_RUN_POS)
-				   | BIT(XEC_DMA_CHAN_CTRL_SWFL_GO_POS));
-	sys_write32(0, chregs + XEC_DMA_CHAN_IENABLE);
-	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
-	sys_write32(0xffu, chregs + XEC_DMA_CHAN_ISTATUS);
+	ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL) &
+	       ~(BIT(XEC_DMA_CHAN_CTRL_HWFL_RUN_POS) | BIT(XEC_DMA_CHAN_CTRL_SWFL_GO_POS));
+
+	dma_xec_chan_reset(dev, channel);
 
 	if ((ctrl & (BIT(XEC_DMA_CHAN_CTRL_M2D_POS) | BIT(XEC_DMA_CHAN_CTRL_DIS_HWFL_POS)))) {
 		/* memory to memory or memory to peripheral */
@@ -505,6 +517,7 @@ static int dma_xec_reload(const struct device *dev, uint32_t channel,
 static int dma_xec_start(const struct device *dev, uint32_t channel)
 {
 	const struct dma_xec_config * const devcfg = dev->config;
+	struct dma_xec_data *const data = dev->data;
 	mm_reg_t const regs = devcfg->regs;
 	uint32_t chan_ctrl = 0U;
 
@@ -517,6 +530,8 @@ static int dma_xec_start(const struct device *dev, uint32_t channel)
 	if (xec_dma_chan_is_busy(chregs)) {
 		return -EBUSY;
 	}
+
+	data->channels[channel].isr_hw_status = 0;
 
 	sys_write32(0u, chregs + XEC_DMA_CHAN_IENABLE);
 	sys_write32(0xffu, chregs + XEC_DMA_CHAN_ISTATUS);
@@ -538,43 +553,11 @@ static int dma_xec_start(const struct device *dev, uint32_t channel)
 
 static int dma_xec_stop(const struct device *dev, uint32_t channel)
 {
-	const struct dma_xec_config * const devcfg = dev->config;
-	mm_reg_t const regs = devcfg->regs;
-	int wait_loops = XEC_DMA_ABORT_WAIT_LOOPS;
-
 	if (channel >= XEC_DMA_MAX_CHANS) {
 		return -EINVAL;
 	}
 
-	mm_reg_t chregs = xec_chan_regs(regs, channel);
-	const struct dma_xec_irq_info *info = xec_chan_irq_info(devcfg, channel);
-
-	sys_write32(0, chregs + XEC_DMA_CHAN_IENABLE);
-
-	if (sys_read32(chregs + XEC_DMA_CHAN_CTRL) & BIT(XEC_DMA_CHAN_CTRL_BUSY_POS)) {
-		sys_write32(0, chregs + XEC_DMA_CHAN_IENABLE);
-		sys_set_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_ABORT_POS);
-		/* HW stops on next unit boundary (1, 2, or 4 bytes) */
-
-		do {
-			if (!(sys_read32(chregs + XEC_DMA_CHAN_CTRL) &
-			      BIT(XEC_DMA_CHAN_CTRL_BUSY_POS))) {
-				break;
-			}
-		} while (wait_loops--);
-	}
-
-	sys_write32(sys_read32(chregs + XEC_DMA_CHAN_MEM_ADDR_END),
-		    chregs + XEC_DMA_CHAN_MEM_ADDR);
-	sys_write32(0, chregs + XEC_DMA_CHAN_FSM); /* delay */
-	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
-	sys_write32(0xffu, chregs + XEC_DMA_CHAN_ISTATUS);
-	sys_write32(0, chregs + XEC_DMA_CHAN_ACTV);
-
-	/* Clear the aggregated GIRQ source latch so an aborted transfer
-	 * does not leave a spurious pending interrupt.
-	 */
-	soc_ecia_girq_status_clear(info->gid, info->gpos);
+	dma_xec_chan_reset(dev, channel);
 
 	return 0;
 }

--- a/drivers/dma/dma_mchp_xec.c
+++ b/drivers/dma/dma_mchp_xec.c
@@ -19,7 +19,17 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(dma_mchp_xec, CONFIG_DMA_LOG_LEVEL);
 
-#define XEC_DMA_MAX_CHANS			CONFIG_DMA_MCHP_XEC_DMAC_MAX_CHANNELS
+#define XEC_DMA_MAX_CHANS CONFIG_DMA_MCHP_XEC_DMAC_MAX_CHANNELS
+
+/* Hardware has no alignment restriction on buffer addresses
+ * other than run time based on byte count.
+ */
+#define XEC_DMA_BUF_ADDR_ALIGNMENT 1U
+#define XEC_DMA_BUF_SIZE_ALIGNMENT 1U
+#define XEC_DMA_COPY_ALIGNMENT     1U
+
+/* Hardware and driver support one block transfer per channel */
+#define XEC_DMA_MAX_BLOCK_COUNT 1U
 
 #define XEC_DMA_ABORT_WAIT_LOOPS		32
 
@@ -101,7 +111,6 @@ struct dma_xec_irq_info {
 
 struct dma_xec_config {
 	mm_reg_t regs;
-	uint8_t dma_channels;
 	uint8_t dma_requests;
 	uint16_t enc_pcr;
 	int irq_info_size;
@@ -114,14 +123,10 @@ struct dma_xec_channel {
 	uint32_t mstart;
 	uint32_t mend;
 	uint32_t dstart;
-	uint32_t isr_hw_status;
+	volatile uint32_t isr_hw_status;
 	uint32_t block_count;
-	uint8_t unit_size;
-	uint8_t dir;
 	uint8_t flags;
 	uint8_t rsvd[1];
-	struct dma_block_config *head;
-	struct dma_block_config *curr;
 	dma_callback_t cb;
 	void *user_data;
 	uint32_t total_req_xfr_len;
@@ -186,12 +191,29 @@ static void xec_dma_chan_clr(mm_reg_t chregs, const struct dma_xec_irq_info *inf
 	soc_ecia_girq_status_clear(info->gid, info->gpos);
 }
 
+static bool xec_dma_chan_is_busy(mm_reg_t chregs)
+{
+	uint32_t ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL);
+
+	if ((ctrl & (BIT(XEC_DMA_CHAN_CTRL_HWFL_RUN_POS) | BIT(XEC_DMA_CHAN_CTRL_SWFL_GO_POS))) &&
+	    (ctrl & BIT(XEC_DMA_CHAN_CTRL_BUSY_POS))) {
+		return true;
+	}
+
+	return false;
+}
+
 static int is_dma_config_valid(const struct device *dev, struct dma_config *config)
 {
 	const struct dma_xec_config * const devcfg = dev->config;
 
 	if (config->dma_slot >= (uint32_t)devcfg->dma_requests) {
 		LOG_ERR("XEC DMA config dma slot > exceeds number of request lines");
+		return 0;
+	}
+
+	if (config->half_complete_callback_en != 0) {
+		LOG_ERR("XEC DMA does not support half-complete callback");
 		return 0;
 	}
 
@@ -207,7 +229,13 @@ static int is_dma_config_valid(const struct device *dev, struct dma_config *conf
 		return 0;
 	}
 
-	if (!is_dma_data_size_valid(config->source_data_size)) {
+	if (config->source_handshake != config->dest_handshake) {
+		LOG_ERR("Source & Dest. handshake not match");
+		return 0;
+	}
+
+	if (!is_dma_data_size_valid(config->source_data_size) ||
+	    !is_dma_data_size_valid(config->dest_data_size)) {
 		LOG_ERR("XEC DMA requires xfr unit size of 1, 2 or 4 bytes");
 		return 0;
 	}
@@ -239,6 +267,11 @@ static int check_blocks(struct dma_xec_channel *chdata, struct dma_block_config 
 
 		if (!is_data_aligned(block->source_address, block->dest_address, unit_size)) {
 			LOG_ERR("XEC DMA block at index %u violates source/dest unit size", i);
+			return -EINVAL;
+		}
+
+		if (block->block_size == 0u) {
+			LOG_ERR("XEC DMA block at index %u has zero size", i);
 			return -EINVAL;
 		}
 
@@ -322,13 +355,18 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	uint32_t ctrl, mstart, mend, dstart, unit_size;
 	int ret;
 
-	if (!config || (channel >= (uint32_t)devcfg->dma_channels)) {
+	if (!config || (channel >= XEC_DMA_MAX_CHANS)) {
 		return -EINVAL;
 	}
 
 	const struct dma_xec_irq_info *info = xec_chan_irq_info(devcfg, channel);
 	mm_reg_t const chregs = xec_chan_regs(regs, channel);
 	struct dma_xec_channel *chdata = &data->channels[channel];
+
+	/* Do not reconfigure a channel with a transfer in progress */
+	if (xec_dma_chan_is_busy(chregs)) {
+		return -EBUSY;
+	}
 
 	chdata->total_req_xfr_len = 0;
 	chdata->total_curr_xfr_len = 0;
@@ -347,11 +385,7 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	}
 
 	unit_size = config->source_data_size;
-	chdata->unit_size = unit_size;
-	chdata->head = block;
-	chdata->curr = block;
 	chdata->block_count = config->block_count;
-	chdata->dir = config->channel_direction;
 
 	chdata->flags = 0;
 	chdata->cb = config->dma_callback;
@@ -434,14 +468,14 @@ static int dma_xec_reload(const struct device *dev, uint32_t channel,
 	mm_reg_t const regs = devcfg->regs;
 	uint32_t ctrl;
 
-	if (channel >= (uint32_t)devcfg->dma_channels) {
+	if (channel >= XEC_DMA_MAX_CHANS) {
 		return -EINVAL;
 	}
 
 	struct dma_xec_channel *chdata = &data->channels[channel];
 	mm_reg_t chregs = xec_chan_regs(regs, channel);
 
-	if (sys_read32(chregs + XEC_DMA_CHAN_CTRL) & BIT(XEC_DMA_CHAN_CTRL_BUSY_POS)) {
+	if (xec_dma_chan_is_busy(chregs)) {
 		return -EBUSY;
 	}
 
@@ -451,7 +485,8 @@ static int dma_xec_reload(const struct device *dev, uint32_t channel,
 	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
 	sys_write32(0xffu, chregs + XEC_DMA_CHAN_ISTATUS);
 
-	if (ctrl & BIT(XEC_DMA_CHAN_CTRL_M2D_POS)) { /* Memory to Device */
+	if ((ctrl & (BIT(XEC_DMA_CHAN_CTRL_M2D_POS) | BIT(XEC_DMA_CHAN_CTRL_DIS_HWFL_POS)))) {
+		/* memory to memory or memory to peripheral */
 		chdata->mstart = src;
 		chdata->dstart = dst;
 	} else {
@@ -477,13 +512,13 @@ static int dma_xec_start(const struct device *dev, uint32_t channel)
 	mm_reg_t const regs = devcfg->regs;
 	uint32_t chan_ctrl = 0U;
 
-	if (channel >= (uint32_t)devcfg->dma_channels) {
+	if (channel >= XEC_DMA_MAX_CHANS) {
 		return -EINVAL;
 	}
 
 	mm_reg_t chregs = xec_chan_regs(regs, channel);
 
-	if (sys_read32(chregs + XEC_DMA_CHAN_CTRL) & BIT(XEC_DMA_CHAN_CTRL_BUSY_POS)) {
+	if (xec_dma_chan_is_busy(chregs)) {
 		return -EBUSY;
 	}
 
@@ -511,11 +546,12 @@ static int dma_xec_stop(const struct device *dev, uint32_t channel)
 	mm_reg_t const regs = devcfg->regs;
 	int wait_loops = XEC_DMA_ABORT_WAIT_LOOPS;
 
-	if (channel >= (uint32_t)devcfg->dma_channels) {
+	if (channel >= XEC_DMA_MAX_CHANS) {
 		return -EINVAL;
 	}
 
 	mm_reg_t chregs = xec_chan_regs(regs, channel);
+	const struct dma_xec_irq_info *info = xec_chan_irq_info(devcfg, channel);
 
 	sys_write32(0, chregs + XEC_DMA_CHAN_IENABLE);
 
@@ -538,6 +574,11 @@ static int dma_xec_stop(const struct device *dev, uint32_t channel)
 	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
 	sys_write32(0xffu, chregs + XEC_DMA_CHAN_ISTATUS);
 	sys_write32(0, chregs + XEC_DMA_CHAN_ACTV);
+
+	/* Clear the aggregated GIRQ source latch so an aborted transfer
+	 * does not leave a spurious pending interrupt.
+	 */
+	soc_ecia_girq_status_clear(info->gid, info->gpos);
 
 	return 0;
 }
@@ -565,7 +606,7 @@ static int dma_xec_get_status(const struct device *dev, uint32_t channel,
 	mm_reg_t const regs = devcfg->regs;
 	uint32_t chan_ctrl = 0U;
 
-	if ((channel >= (uint32_t)devcfg->dma_channels) || (!status)) {
+	if ((channel >= XEC_DMA_MAX_CHANS) || (!status)) {
 		LOG_ERR("unsupported channel");
 		return -EINVAL;
 	}
@@ -598,32 +639,54 @@ static int dma_xec_get_status(const struct device *dev, uint32_t channel,
 
 	status->total_copied = chan_data->total_curr_xfr_len;
 
+	/* Report a latched bus error from the last transfer */
+	if (chan_data->isr_hw_status & BIT(XEC_DMA_CHAN_IES_BERR_POS)) {
+		return -EIO;
+	}
+
 	return 0;
 }
 
 int xec_dma_get_attribute(const struct device *dev, uint32_t type, uint32_t *value)
 {
-	if ((type == DMA_ATTR_MAX_BLOCK_COUNT) && value) {
-		*value = 1;
-		return 0;
+	ARG_UNUSED(dev);
+
+	if (value == NULL) {
+		return -EINVAL;
 	}
 
-	return -EINVAL;
+	switch (type) {
+	case DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT:
+		*value = XEC_DMA_BUF_ADDR_ALIGNMENT;
+		break;
+	case DMA_ATTR_BUFFER_SIZE_ALIGNMENT:
+		*value = XEC_DMA_BUF_SIZE_ALIGNMENT;
+		break;
+	case DMA_ATTR_COPY_ALIGNMENT:
+		*value = XEC_DMA_COPY_ALIGNMENT;
+		break;
+	case DMA_ATTR_MAX_BLOCK_COUNT:
+		*value = XEC_DMA_MAX_BLOCK_COUNT;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
-/* returns true if filter matched otherwise returns false */
 static bool dma_xec_chan_filter(const struct device *dev, int ch, void *filter_param)
 {
-	const struct dma_xec_config * const devcfg = dev->config;
-	uint32_t filter = 0u;
-
-	if (!filter_param && devcfg->dma_channels) {
-		filter = GENMASK(devcfg->dma_channels-1u, 0);
-	} else {
-		filter = *((uint32_t *)filter_param);
+	if ((ch < 0) || (ch >= XEC_DMA_MAX_CHANS)) {
+		return false;
 	}
 
-	return (filter & BIT(ch));
+	if (filter_param == NULL) { /* allow any valid channel */
+		return true;
+	}
+
+	/* Hardware only supports normal channels */
+	return (*((enum dma_channel_filter *)filter_param) == DMA_CHANNEL_NORMAL);
 }
 
 /* API - HW does not stupport suspend/resume */
@@ -676,6 +739,7 @@ static void dma_xec_irq_handler(const struct device *dev, uint32_t channel)
 	mm_reg_t const regs = xec_chan_regs(devcfg->regs, channel);
 	uint32_t sts = sys_read32(regs + XEC_DMA_CHAN_ISTATUS);
 	int cb_status = 0;
+	bool invoke_cb = true;
 
 	LOG_DBG("maddr=0x%08x mend=0x%08x daddr=0x%08x ctrl=0x%08x sts=0x%02x",
 		sys_read32(regs + XEC_DMA_CHAN_MEM_ADDR),
@@ -684,7 +748,7 @@ static void dma_xec_irq_handler(const struct device *dev, uint32_t channel)
 		sys_read32(regs + XEC_DMA_CHAN_CTRL), sts);
 
 	sys_write32(0u, regs + XEC_DMA_CHAN_IENABLE);
-	sys_write32(0xffu, regs + XEC_DMA_CHAN_ISTATUS);
+	sys_write32(sts, regs + XEC_DMA_CHAN_ISTATUS);
 	soc_ecia_girq_status_clear(info[channel].gid, info[channel].gpos);
 
 	chan_data->isr_hw_status = sts;
@@ -692,12 +756,13 @@ static void dma_xec_irq_handler(const struct device *dev, uint32_t channel)
 		(sys_read32(regs + XEC_DMA_CHAN_MEM_ADDR) - chan_data->mstart);
 
 	if (sts & BIT(XEC_DMA_CHAN_IES_BERR_POS)) {/* Bus Error? */
-		if (!(chan_data->flags & BIT(DMA_XEC_CHAN_FLAGS_CB_ERR_DIS_POS))) {
-			cb_status = -EIO;
+		cb_status = -EIO;
+		if (chan_data->flags & BIT(DMA_XEC_CHAN_FLAGS_CB_ERR_DIS_POS)) {
+			invoke_cb = false;
 		}
 	}
 
-	if (chan_data->cb) {
+	if (invoke_cb && chan_data->cb) {
 		chan_data->cb(dev, chan_data->user_data, channel, cb_status);
 	}
 }
@@ -721,7 +786,9 @@ static int dma_xec_init(const struct device *dev)
 	}
 	sys_write32(BIT(XEC_DMA_MAIN_CTRL_EN_POS), regs + XEC_DMA_MAIN_CTRL);
 
-	devcfg->irq_connect(dev);
+	if (devcfg->irq_connect != NULL) {
+		devcfg->irq_connect(dev);
+	}
 
 	return 0;
 }
@@ -761,42 +828,35 @@ static int dma_xec_init(const struct device *dev)
 		DT_INST_FOREACH_PROP_ELEM(inst, interrupt_names, DMA_XEC_IRQ_CONNECT_SUB)          \
 	}
 
-#define DMA_XEC_DEVICE(i)								\
-	BUILD_ASSERT(DT_INST_PROP(i, dma_channels) <= XEC_DMA_MAX_CHANS,		\
-		     "XEC DMA dma-channels exceeds max");				\
-	BUILD_ASSERT(DT_INST_PROP(i, dma_requests) <= XEC_DMA_MAX_CHANS,		\
-		     "XEC DMA dma-requests exceeds max");				\
-											\
-	static struct dma_xec_channel							\
-		dma_xec_ctrl##i##_chans[DT_INST_PROP(i, dma_channels)];			\
-	ATOMIC_DEFINE(dma_xec_atomic##i, DT_INST_PROP(i, dma_channels));		\
-											\
-	static struct dma_xec_data dma_xec_data##i = {					\
-		.ctx.magic = DMA_MAGIC,							\
-		.ctx.dma_channels = DT_INST_PROP(i, dma_channels),			\
-		.ctx.atomic = dma_xec_atomic##i,					\
-		.channels = dma_xec_ctrl##i##_chans,					\
-	};										\
-											\
-	DMA_XEC_IRQ_CONNECT(i)								\
-											\
-	static const struct dma_xec_irq_info dma_xec_irqi##i[] = {			\
-		DT_INST_FOREACH_PROP_ELEM(i, girqs, DMA_XEC_GIRQ_INFO)			\
-	};										\
-	static const struct dma_xec_config dma_xec_cfg##i = {				\
-		.regs = DT_INST_REG_ADDR(i),						\
-		.dma_channels = DT_INST_PROP(i, dma_channels),				\
-		.dma_requests = DT_INST_PROP(i, dma_requests),				\
-		.enc_pcr = DT_INST_PROP(i, pcr_scr),					\
-		.irq_info_size = ARRAY_SIZE(dma_xec_irqi##i),				\
-		.irq_info_list = dma_xec_irqi##i,					\
-		.irq_connect = dma_xec_irq_connect##i,					\
-	};										\
-	PM_DEVICE_DT_DEFINE(i, dmac_xec_pm_action);					\
-	DEVICE_DT_INST_DEFINE(i, dma_xec_init,						\
-		PM_DEVICE_DT_GET(i),							\
-		&dma_xec_data##i, &dma_xec_cfg##i,					\
-		PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,					\
-		&dma_xec_api);
+#define DMA_XEC_DEVICE(i)                                                                          \
+	BUILD_ASSERT(DT_INST_PROP(i, dma_requests) <= XEC_DMA_MAX_CHANS,                           \
+		     "XEC DMA dma-requests exceeds max");                                          \
+                                                                                                   \
+	static struct dma_xec_channel dma_xec_ctrl##i##_chans[DT_INST_PROP(i, dma_channels)];      \
+	ATOMIC_DEFINE(dma_xec_atomic##i, DT_INST_PROP(i, dma_channels));                           \
+                                                                                                   \
+	static struct dma_xec_data dma_xec_data##i = {                                             \
+		.ctx.magic = DMA_MAGIC,                                                            \
+		.ctx.dma_channels = DT_INST_PROP(i, dma_channels),                                 \
+		.ctx.atomic = dma_xec_atomic##i,                                                   \
+		.channels = dma_xec_ctrl##i##_chans,                                               \
+	};                                                                                         \
+                                                                                                   \
+	DMA_XEC_IRQ_CONNECT(i)                                                                     \
+                                                                                                   \
+	static const struct dma_xec_irq_info dma_xec_irqi##i[] = {                                 \
+		DT_INST_FOREACH_PROP_ELEM(i, girqs, DMA_XEC_GIRQ_INFO)};                           \
+	static const struct dma_xec_config dma_xec_cfg##i = {                                      \
+		.regs = DT_INST_REG_ADDR(i),                                                       \
+		.dma_requests = DT_INST_PROP(i, dma_requests),                                     \
+		.enc_pcr = DT_INST_PROP(i, pcr_scr),                                               \
+		.irq_info_size = ARRAY_SIZE(dma_xec_irqi##i),                                      \
+		.irq_info_list = dma_xec_irqi##i,                                                  \
+		.irq_connect = dma_xec_irq_connect##i,                                             \
+	};                                                                                         \
+	PM_DEVICE_DT_DEFINE(i, dmac_xec_pm_action);                                                \
+	DEVICE_DT_INST_DEFINE(i, dma_xec_init, PM_DEVICE_DT_GET(i), &dma_xec_data##i,              \
+			      &dma_xec_cfg##i, PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,             \
+			      &dma_xec_api);
 
 DT_INST_FOREACH_STATUS_OKAY(DMA_XEC_DEVICE)

--- a/drivers/dma/dma_mchp_xec.c
+++ b/drivers/dma/dma_mchp_xec.c
@@ -102,6 +102,7 @@ LOG_MODULE_REGISTER(dma_mchp_xec, CONFIG_DMA_LOG_LEVEL);
 #define XEC_DMA_CHAN_CTRL		0x10u
 #define XEC_DMA_CHAN_ISTATUS		0x14u
 #define XEC_DMA_CHAN_IENABLE		0x18u
+#define XEC_DMA_CHAN_ISTATUS_MSK        0x0fu
 #define XEC_DMA_CHAN_FSM		0x1cu
 
 struct dma_xec_irq_info {
@@ -176,19 +177,6 @@ static int is_data_aligned(uint32_t src, uint32_t dest, uint32_t unitsz)
 	return 1;
 }
 
-static void xec_dma_chan_clr(mm_reg_t chregs, const struct dma_xec_irq_info *info)
-{
-	sys_write32(0, chregs + XEC_DMA_CHAN_ACTV);
-	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
-	sys_write32(0, chregs + XEC_DMA_CHAN_MEM_ADDR);
-	sys_write32(0, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
-	sys_write32(0, chregs + XEC_DMA_CHAN_DEV_ADDR);
-	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
-	sys_write32(0, chregs + XEC_DMA_CHAN_IENABLE);
-	sys_write32(0xffu, chregs + XEC_DMA_CHAN_ISTATUS);
-	soc_ecia_girq_status_clear(info->gid, info->gpos);
-}
-
 static bool xec_dma_chan_is_busy(mm_reg_t chregs)
 {
 	uint32_t ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL);
@@ -199,6 +187,32 @@ static bool xec_dma_chan_is_busy(mm_reg_t chregs)
 	}
 
 	return false;
+}
+
+static void dma_xec_chan_reset(const struct device *dev, uint32_t chan)
+{
+	const struct dma_xec_config *devcfg = dev->config;
+	int wait_loops = XEC_DMA_ABORT_WAIT_LOOPS;
+
+	mm_reg_t chregs = xec_chan_regs(devcfg->regs, chan);
+	const struct dma_xec_irq_info *info = xec_chan_irq_info(devcfg, chan);
+
+	sys_set_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_ABORT_POS);
+	/* HW stops on next unit boundary (1, 2, or 4 bytes) */
+	while ((sys_test_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_BUSY_POS) != 0) &&
+	       (wait_loops-- > 0)) {
+	}
+
+	sys_clear_bit(chregs + XEC_DMA_CHAN_ACTV, XEC_DMA_CHAN_ACTV_EN_POS);
+	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
+	/* mem end address before mem start address to ensure msa >= mea */
+	sys_write32(0, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
+	sys_write32(0, chregs + XEC_DMA_CHAN_MEM_ADDR);
+	sys_write32(0, chregs + XEC_DMA_CHAN_DEV_ADDR);
+	sys_write32(0, chregs + XEC_DMA_CHAN_IENABLE);
+	sys_write32(XEC_DMA_CHAN_ISTATUS_MSK, chregs + XEC_DMA_CHAN_ISTATUS);
+
+	soc_ecia_girq_status_clear(info->gid, info->gpos);
 }
 
 static int is_dma_config_valid(const struct device *dev, struct dma_config *config)
@@ -354,7 +368,6 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 		return -EINVAL;
 	}
 
-	const struct dma_xec_irq_info *info = xec_chan_irq_info(devcfg, channel);
 	mm_reg_t const chregs = xec_chan_regs(regs, channel);
 	struct dma_xec_channel *chdata = &data->channels[channel];
 
@@ -362,8 +375,6 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	if (xec_dma_chan_is_busy(chregs)) {
 		return -EBUSY;
 	}
-
-	xec_dma_chan_clr(chregs, info);
 
 	if (!is_dma_config_valid(dev, config)) {
 		return -EINVAL;
@@ -431,15 +442,13 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	chdata->mend = mend;
 	chdata->dstart = dstart;
 
-	sys_clear_bit(chregs + XEC_DMA_CHAN_ACTV, XEC_DMA_CHAN_ACTV_EN_POS);
+	dma_xec_chan_reset(dev, channel);
+
 	sys_write32(mstart, chregs + XEC_DMA_CHAN_MEM_ADDR);
 	sys_write32(mend, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
 	sys_write32(dstart, chregs + XEC_DMA_CHAN_DEV_ADDR);
 
 	sys_write32(ctrl, chregs + XEC_DMA_CHAN_CTRL);
-	sys_write32(BIT(XEC_DMA_CHAN_IES_BERR_POS) | BIT(XEC_DMA_CHAN_IES_DONE_POS),
-		    chregs + XEC_DMA_CHAN_IENABLE);
-	sys_set_bit(chregs + XEC_DMA_CHAN_ACTV, XEC_DMA_CHAN_ACTV_EN_POS);
 
 	return 0;
 }
@@ -471,11 +480,10 @@ static int dma_xec_reload(const struct device *dev, uint32_t channel,
 		return -EBUSY;
 	}
 
-	ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL) & ~(BIT(XEC_DMA_CHAN_CTRL_HWFL_RUN_POS)
-				   | BIT(XEC_DMA_CHAN_CTRL_SWFL_GO_POS));
-	sys_write32(0, chregs + XEC_DMA_CHAN_IENABLE);
-	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
-	sys_write32(0xffu, chregs + XEC_DMA_CHAN_ISTATUS);
+	ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL) &
+	       ~(BIT(XEC_DMA_CHAN_CTRL_HWFL_RUN_POS) | BIT(XEC_DMA_CHAN_CTRL_SWFL_GO_POS));
+
+	dma_xec_chan_reset(dev, channel);
 
 	if ((ctrl & (BIT(XEC_DMA_CHAN_CTRL_M2D_POS) | BIT(XEC_DMA_CHAN_CTRL_DIS_HWFL_POS)))) {
 		/* memory to memory or memory to peripheral */
@@ -499,6 +507,7 @@ static int dma_xec_reload(const struct device *dev, uint32_t channel,
 static int dma_xec_start(const struct device *dev, uint32_t channel)
 {
 	const struct dma_xec_config * const devcfg = dev->config;
+	struct dma_xec_data *const data = dev->data;
 	mm_reg_t const regs = devcfg->regs;
 	uint32_t chan_ctrl = 0U;
 
@@ -512,8 +521,12 @@ static int dma_xec_start(const struct device *dev, uint32_t channel)
 		return -EBUSY;
 	}
 
-	sys_write32(0u, chregs + XEC_DMA_CHAN_IENABLE);
-	sys_write32(0xffu, chregs + XEC_DMA_CHAN_ISTATUS);
+	data->channels[channel].isr_hw_status = 0;
+
+	sys_set_bit(chregs + XEC_DMA_CHAN_ACTV, XEC_DMA_CHAN_ACTV_EN_POS);
+	sys_write32(XEC_DMA_CHAN_ISTATUS_MSK, chregs + XEC_DMA_CHAN_ISTATUS);
+	sys_write32(BIT(XEC_DMA_CHAN_IES_BERR_POS) | BIT(XEC_DMA_CHAN_IES_DONE_POS),
+		    chregs + XEC_DMA_CHAN_IENABLE);
 	chan_ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL);
 
 	if (chan_ctrl & BIT(XEC_DMA_CHAN_CTRL_DIS_HWFL_POS)) {
@@ -522,53 +535,18 @@ static int dma_xec_start(const struct device *dev, uint32_t channel)
 		chan_ctrl |= BIT(XEC_DMA_CHAN_CTRL_HWFL_RUN_POS);
 	}
 
-	sys_write32(BIT(XEC_DMA_CHAN_IES_BERR_POS) | BIT(XEC_DMA_CHAN_IES_DONE_POS),
-		    chregs + XEC_DMA_CHAN_IENABLE);
 	sys_write32(chan_ctrl, chregs + XEC_DMA_CHAN_CTRL);
-	sys_set_bit(chregs + XEC_DMA_CHAN_ACTV, XEC_DMA_CHAN_ACTV_EN_POS);
 
 	return 0;
 }
 
 static int dma_xec_stop(const struct device *dev, uint32_t channel)
 {
-	const struct dma_xec_config * const devcfg = dev->config;
-	mm_reg_t const regs = devcfg->regs;
-	int wait_loops = XEC_DMA_ABORT_WAIT_LOOPS;
-
 	if (channel >= XEC_DMA_MAX_CHANS) {
 		return -EINVAL;
 	}
 
-	mm_reg_t chregs = xec_chan_regs(regs, channel);
-	const struct dma_xec_irq_info *info = xec_chan_irq_info(devcfg, channel);
-
-	sys_write32(0, chregs + XEC_DMA_CHAN_IENABLE);
-
-	if (sys_read32(chregs + XEC_DMA_CHAN_CTRL) & BIT(XEC_DMA_CHAN_CTRL_BUSY_POS)) {
-		sys_write32(0, chregs + XEC_DMA_CHAN_IENABLE);
-		sys_set_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_ABORT_POS);
-		/* HW stops on next unit boundary (1, 2, or 4 bytes) */
-
-		do {
-			if (!(sys_read32(chregs + XEC_DMA_CHAN_CTRL) &
-			      BIT(XEC_DMA_CHAN_CTRL_BUSY_POS))) {
-				break;
-			}
-		} while (wait_loops--);
-	}
-
-	sys_write32(sys_read32(chregs + XEC_DMA_CHAN_MEM_ADDR_END),
-		    chregs + XEC_DMA_CHAN_MEM_ADDR);
-	sys_write32(0, chregs + XEC_DMA_CHAN_FSM); /* delay */
-	sys_write32(0, chregs + XEC_DMA_CHAN_CTRL);
-	sys_write32(0xffu, chregs + XEC_DMA_CHAN_ISTATUS);
-	sys_write32(0, chregs + XEC_DMA_CHAN_ACTV);
-
-	/* Clear the aggregated GIRQ source latch so an aborted transfer
-	 * does not leave a spurious pending interrupt.
-	 */
-	soc_ecia_girq_status_clear(info->gid, info->gpos);
+	dma_xec_chan_reset(dev, channel);
 
 	return 0;
 }

--- a/drivers/dma/dma_mchp_xec.c
+++ b/drivers/dma/dma_mchp_xec.c
@@ -28,8 +28,14 @@ LOG_MODULE_REGISTER(dma_mchp_xec, CONFIG_DMA_LOG_LEVEL);
 #define XEC_DMA_BUF_SIZE_ALIGNMENT 1U
 #define XEC_DMA_COPY_ALIGNMENT     1U
 
-/* Hardware and driver support one block transfer per channel */
-#define XEC_DMA_MAX_BLOCK_COUNT 1U
+/* Hardware programs one block at a time. The driver caches up to
+ * CONFIG_DMA_MCHP_XEC_MAX_BLOCKS_PER_CHAN block descriptors
+ * per channel from dma_config()'s linked list and chains them in the
+ * channel ISR (ABORT, rewrite MSA/MEA/DEVA + INC bits, set RUN). When
+ * the Kconfig knob is 1 (the historical default) the driver behaves
+ * exactly as the single-block implementation did.
+ */
+#define XEC_DMA_MAX_BLOCK_COUNT CONFIG_DMA_MCHP_XEC_MAX_BLOCKS_PER_CHAN
 
 #define XEC_DMA_ABORT_WAIT_LOOPS		32
 
@@ -119,19 +125,42 @@ struct dma_xec_config {
 	void (*irq_connect)(const struct device *dev);
 };
 
+/* Per-block descriptor cached by the driver at dma_config time. The
+ * channel CR fields that are common to every block in a chain --
+ * direction (M2D), HFC peer/disable, transfer unit -- live in
+ * xec_dchan::ctrl_base; only the address-increment bits vary per block
+ * (different blocks may legitimately come from different sources or go
+ * to different destinations with different adjust modes).
+ */
+struct dma_xec_block {
+	uint32_t mstart;
+	uint32_t dstart;
+	uint32_t nbytes;
+	uint32_t inc_bits;
+};
+
 struct dma_xec_channel {
 	uint32_t control;
-	uint32_t mstart;
-	uint32_t mend;
-	uint32_t dstart;
+	struct dma_xec_block blocks[XEC_DMA_MAX_BLOCK_COUNT];
 	volatile uint32_t isr_hw_status;
-	uint32_t block_count;
+	uint8_t num_blocks;
+	uint8_t cur_block;
+	bool cyclic; /* on last-block DONE wrap to block 0 */
 	uint8_t flags;
-	uint8_t rsvd[1];
 	dma_callback_t cb;
 	void *user_data;
 };
 
+/* DMA callback flags from struct dma_config.
+ * Default behavior is to invoke the user callback once when the entire
+ * transfer list completes, and once on any error along the way.
+ * The caller can request changes in callback behavior:
+ *  - Disable error callback (error_callback_dis).
+ *  - Fire a callback at every block boundary instead of only after
+ *    the last block (complete_callback_en). The block-mid-list
+ *    "halfway" callback flag in dma_config is not supported -- this
+ *    HW has no halfway-through-list interrupt.
+ */
 #define DMA_XEC_CHAN_FLAGS_CB_EOB_POS		0
 #define DMA_XEC_CHAN_FLAGS_CB_ERR_DIS_POS	1
 
@@ -175,6 +204,40 @@ static int is_data_aligned(uint32_t src, uint32_t dest, uint32_t unitsz)
 	}
 
 	return 1;
+}
+
+/* Translate one dma_block_config into the cached per-block descriptor.
+ * The channel-wide CR bits (direction, HFC peer, unit size, DIS_HFC) are
+ * already in ctrl_base; only the per-block INC bits land in blk->inc_bits.
+ */
+static void dma_xec_translate_block(struct dma_xec_block *out, const struct dma_block_config *blk,
+				    uint32_t direction)
+{
+	uint32_t inc = 0;
+
+	out->nbytes = blk->block_size;
+
+	if (direction == PERIPHERAL_TO_MEMORY) {
+		out->mstart = blk->dest_address;
+		out->dstart = blk->source_address;
+		if (blk->source_addr_adj == DMA_ADDR_ADJ_INCREMENT) {
+			inc |= BIT(XEC_DMA_CHAN_CTRL_INCR_DEV_POS);
+		}
+		if (blk->dest_addr_adj == DMA_ADDR_ADJ_INCREMENT) {
+			inc |= BIT(XEC_DMA_CHAN_CTRL_INCR_MEM_POS);
+		}
+	} else {
+		out->mstart = blk->source_address;
+		out->dstart = blk->dest_address;
+		if (blk->source_addr_adj == DMA_ADDR_ADJ_INCREMENT) {
+			inc |= BIT(XEC_DMA_CHAN_CTRL_INCR_MEM_POS);
+		}
+		if (blk->dest_addr_adj == DMA_ADDR_ADJ_INCREMENT) {
+			inc |= BIT(XEC_DMA_CHAN_CTRL_INCR_DEV_POS);
+		}
+	}
+
+	out->inc_bits = inc;
 }
 
 static bool xec_dma_chan_is_busy(mm_reg_t chregs)
@@ -252,8 +315,8 @@ static int is_dma_config_valid(const struct device *dev, struct dma_config *conf
 		return 0;
 	}
 
-	if (config->block_count != 1) {
-		LOG_ERR("XEC DMA block count != 1");
+	if ((config->block_count == 0) || (config->block_count > XEC_DMA_MAX_BLOCK_COUNT)) {
+		LOG_ERR("XEC DMA block count out of range (1..%u)", XEC_DMA_MAX_BLOCK_COUNT);
 		return 0;
 	}
 
@@ -269,6 +332,11 @@ static int check_blocks(struct dma_xec_channel *chdata, struct dma_block_config 
 	}
 
 	for (uint32_t i = 0; i < block_count; i++) {
+		if (!block) {
+			LOG_ERR("XEC DMA block chain shorter than block_count");
+			return -EINVAL;
+		}
+
 		if ((block->source_addr_adj == DMA_ADDR_ADJ_DECREMENT) ||
 		    (block->dest_addr_adj == DMA_ADDR_ADJ_DECREMENT)) {
 			LOG_ERR("XEC DMA HW does not support address decrement. Block index %u", i);
@@ -285,9 +353,36 @@ static int check_blocks(struct dma_xec_channel *chdata, struct dma_block_config 
 			return -EINVAL;
 		}
 
+		block = block->next_block;
+	}
+
+	if (block != NULL) {
+		LOG_ERR("XEC DMA block chain longer than block_count");
+		return -EINVAL;
 	}
 
 	return 0;
+}
+
+/* Reset channel and load mem start address, mem end address, device address,
+ * and control register from the cached block at index `idx`. Does not enable
+ * or program interrupt enables. Used at dma_xec_start time for the first
+ * block of a chain.
+ */
+static void dma_xec_load_chan(const struct device *dev, uint32_t channel, uint32_t idx)
+{
+	const struct dma_xec_config *const devcfg = dev->config;
+	struct dma_xec_data *const data = dev->data;
+	struct dma_xec_channel *chdata = &data->channels[channel];
+	struct dma_xec_block *blk = &chdata->blocks[idx];
+	mm_reg_t chregs = xec_chan_regs(devcfg->regs, channel);
+
+	dma_xec_chan_reset(dev, channel);
+
+	sys_write32(blk->mstart, chregs + XEC_DMA_CHAN_MEM_ADDR);
+	sys_write32(blk->mstart + blk->nbytes, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
+	sys_write32(blk->dstart, chregs + XEC_DMA_CHAN_DEV_ADDR);
+	sys_write32(chdata->control | blk->inc_bits, chregs + XEC_DMA_CHAN_CTRL);
 }
 
 /*
@@ -302,7 +397,8 @@ static int check_blocks(struct dma_xec_channel *chdata, struct dma_block_config 
  * source_chaining_en - Chaining channel together
  * dest_chaining_en - HW does not support channel chaining.
  * linked_channel - HW does not support
- * cyclic - HW does not support cyclic buffer. Would have to emulate with SW.
+ * cyclic - HW does not support cyclic buffer natively; emulated in SW by
+ *	     wrapping back to block 0 from the ISR when block_count > 1.
  * source_data_size - unit size of source data. HW supports 1, 2, or 4 bytes
  * dest_data_size - unit size of dest data. HW requires same as source_data_size
  * source_burst_length - HW does not support
@@ -361,7 +457,7 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	const struct dma_xec_config * const devcfg = dev->config;
 	mm_reg_t const regs = devcfg->regs;
 	struct dma_xec_data * const data = dev->data;
-	uint32_t ctrl, mstart, mend, dstart, unit_size;
+	uint32_t ctrl, unit_size;
 	int ret;
 
 	if (!config || (channel >= XEC_DMA_MAX_CHANS)) {
@@ -388,7 +484,6 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	}
 
 	unit_size = config->source_data_size;
-	chdata->block_count = config->block_count;
 
 	chdata->flags = 0;
 	chdata->cb = config->dma_callback;
@@ -402,10 +497,11 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 		chdata->flags |= BIT(DMA_XEC_CHAN_FLAGS_CB_ERR_DIS_POS);
 	}
 
-	/* Use the control member of struct dma_xec_channel to
-	 * store control register value containing fields invariant
-	 * for all buffers: HW flow control device, direction, unit size, ...
-	 * derived from struct dma_config
+	/* Use the control member of struct dma_xec_channel to store control
+	 * register bits invariant for every block in this channel's chain:
+	 * HW flow control device, direction, unit size. Per-block address
+	 * increment bits live in each dma_xec_block entry instead, since
+	 * they can differ block to block.
 	 */
 	ctrl = XEC_DMA_CHAN_CTRL_UNIT_VAL(unit_size);
 	if (config->channel_direction == MEMORY_TO_MEMORY) {
@@ -413,53 +509,36 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	} else {
 		ctrl |= XEC_DMA_HWFL_DEV_VAL(config->dma_slot);
 	}
-
-	if (config->channel_direction == PERIPHERAL_TO_MEMORY) {
-		mstart = block->dest_address;
-		mend = block->dest_address + block->block_size;
-		dstart = block->source_address;
-		if (block->source_addr_adj == DMA_ADDR_ADJ_INCREMENT) {
-			ctrl |= BIT(XEC_DMA_CHAN_CTRL_INCR_DEV_POS);
-		}
-		if (block->dest_addr_adj == DMA_ADDR_ADJ_INCREMENT) {
-			ctrl |= BIT(XEC_DMA_CHAN_CTRL_INCR_MEM_POS);
-		}
-	} else {
-		mstart = block->source_address;
-		mend = block->source_address + block->block_size;
-		dstart = block->dest_address;
+	if (config->channel_direction != PERIPHERAL_TO_MEMORY) {
 		ctrl |= BIT(XEC_DMA_CHAN_CTRL_M2D_POS);
-		if (block->source_addr_adj == DMA_ADDR_ADJ_INCREMENT) {
-			ctrl |= BIT(XEC_DMA_CHAN_CTRL_INCR_MEM_POS);
-		}
-		if (block->dest_addr_adj == DMA_ADDR_ADJ_INCREMENT) {
-			ctrl |= BIT(XEC_DMA_CHAN_CTRL_INCR_DEV_POS);
-		}
 	}
 
 	chdata->control = ctrl;
-	chdata->mstart = mstart;
-	chdata->mend = mend;
-	chdata->dstart = dstart;
+	chdata->num_blocks = config->block_count;
+	chdata->cur_block = 0;
+	chdata->cyclic = (config->cyclic != 0);
 
-	dma_xec_chan_reset(dev, channel);
+	block = config->head_block;
+	for (uint32_t i = 0; i < config->block_count; i++) {
+		dma_xec_translate_block(&chdata->blocks[i], block, config->channel_direction);
+		block = block->next_block;
+	}
 
-	sys_write32(mstart, chregs + XEC_DMA_CHAN_MEM_ADDR);
-	sys_write32(mend, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
-	sys_write32(dstart, chregs + XEC_DMA_CHAN_DEV_ADDR);
-
-	sys_write32(ctrl, chregs + XEC_DMA_CHAN_CTRL);
+	/* Load HW registers from blocks[0]; do not start. */
+	dma_xec_load_chan(dev, channel, 0);
 
 	return 0;
 }
 
-/* Update previously configured DMA channel with new data source address,
- * data destination address, and size in bytes.
- * src = source address for DMA transfer
- * dst = destination address for DMA transfer
- * size = size of DMA transfer. Assume this is in bytes.
- * We assume the caller will pass src, dst, and size that matches
- * the unit size from the previous configure call.
+/* Reload DMA channel and do not start. Callable from ISR context.
+ * Channel configuration: direction, flow control, etc. are not changed.
+ * We only reprogram the memory start, memory end, and device addresses.
+ *
+ * Reload collapses any multi-block chain previously configured on this
+ * channel into a single block (num_blocks = 1) at cur_block = 0. The
+ * caller's expectation for reload is "replace whatever block was about
+ * to run next", so chains beyond block 0 are not preserved -- callers
+ * needing chain-style behavior re-issue dma_config.
  */
 static int dma_xec_reload(const struct device *dev, uint32_t channel,
 			  uint32_t src, uint32_t dst, size_t size)
@@ -467,7 +546,6 @@ static int dma_xec_reload(const struct device *dev, uint32_t channel,
 	const struct dma_xec_config * const devcfg = dev->config;
 	struct dma_xec_data * const data = dev->data;
 	mm_reg_t const regs = devcfg->regs;
-	uint32_t ctrl;
 
 	if (channel >= XEC_DMA_MAX_CHANS) {
 		return -EINVAL;
@@ -480,30 +558,43 @@ static int dma_xec_reload(const struct device *dev, uint32_t channel,
 		return -EBUSY;
 	}
 
-	ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL) &
-	       ~(BIT(XEC_DMA_CHAN_CTRL_HWFL_RUN_POS) | BIT(XEC_DMA_CHAN_CTRL_SWFL_GO_POS));
-
 	dma_xec_chan_reset(dev, channel);
 
-	if ((ctrl & (BIT(XEC_DMA_CHAN_CTRL_M2D_POS) | BIT(XEC_DMA_CHAN_CTRL_DIS_HWFL_POS)))) {
+	/* reload always re-arms a single buffer; drop any block chain left
+	 * over from a prior multi-block configure() so the ISR's chaining
+	 * logic doesn't reference stale entries.
+	 */
+	chdata->num_blocks = 1;
+	chdata->cur_block = 0;
+	chdata->cyclic = false;
+
+	if ((chdata->control &
+	     (BIT(XEC_DMA_CHAN_CTRL_M2D_POS) | BIT(XEC_DMA_CHAN_CTRL_DIS_HWFL_POS)))) {
 		/* memory to memory or memory to peripheral */
-		chdata->mstart = src;
-		chdata->dstart = dst;
+		chdata->blocks[0].mstart = src;
+		chdata->blocks[0].dstart = dst;
 	} else {
-		chdata->mstart = dst;
-		chdata->dstart = src;
+		chdata->blocks[0].mstart = dst;
+		chdata->blocks[0].dstart = src;
 	}
 
-	chdata->mend = chdata->mstart + size;
+	chdata->blocks[0].nbytes = size;
 
-	sys_write32(chdata->mstart, chregs + XEC_DMA_CHAN_MEM_ADDR);
-	sys_write32(chdata->mend, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
-	sys_write32(chdata->dstart, chregs + XEC_DMA_CHAN_DEV_ADDR);
-	sys_write32(ctrl, chregs + XEC_DMA_CHAN_CTRL);
+	sys_write32(chdata->blocks[0].mstart, chregs + XEC_DMA_CHAN_MEM_ADDR);
+	sys_write32(chdata->blocks[0].mstart + size, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
+	sys_write32(chdata->blocks[0].dstart, chregs + XEC_DMA_CHAN_DEV_ADDR);
+	sys_write32(chdata->control | chdata->blocks[0].inc_bits, chregs + XEC_DMA_CHAN_CTRL);
 
 	return 0;
 }
 
+/* API - start selected channel. Callable from ISR context.
+ * Clears channel status
+ * Enables channel Done and Bus Error interrupts
+ * Starts channel based on current channel control register HW flow control configuration.
+ * If HW flow control is Disabled set SW Flow control Go bit
+ * Else set HW flow control Run bit.
+ */
 static int dma_xec_start(const struct device *dev, uint32_t channel)
 {
 	const struct dma_xec_config * const devcfg = dev->config;
@@ -522,6 +613,11 @@ static int dma_xec_start(const struct device *dev, uint32_t channel)
 	}
 
 	data->channels[channel].isr_hw_status = 0;
+	data->channels[channel].cur_block = 0;
+	/* HW registers were loaded from blocks[0] at dma_xec_configure or
+	 * dma_xec_reload time; nothing to do here besides arm IER+ACTIVATE
+	 * and trip the run bit.
+	 */
 
 	sys_set_bit(chregs + XEC_DMA_CHAN_ACTV, XEC_DMA_CHAN_ACTV_EN_POS);
 	sys_write32(XEC_DMA_CHAN_ISTATUS_MSK, chregs + XEC_DMA_CHAN_ISTATUS);
@@ -540,31 +636,83 @@ static int dma_xec_start(const struct device *dev, uint32_t channel)
 	return 0;
 }
 
+/* Stopping a channel while it is running requires using the CR.ABORT bit and spinning
+ * for the channel to clear read-only CR.BUSY status. Busy will clear when the current
+ * unit (byte, 16-bit half-word, or 32-bit word) completes. When not busy only clear the
+ * abort, HW flow control run, and SW flow control go bits. Do not clear other bits or
+ * registers.
+ */
 static int dma_xec_stop(const struct device *dev, uint32_t channel)
 {
+	const struct dma_xec_config *devcfg = dev->config;
+	int wait_loops = XEC_DMA_ABORT_WAIT_LOOPS;
+
 	if (channel >= XEC_DMA_MAX_CHANS) {
 		return -EINVAL;
 	}
 
-	dma_xec_chan_reset(dev, channel);
+	mm_reg_t chregs = xec_chan_regs(devcfg->regs, channel);
+
+	sys_set_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_ABORT_POS);
+	/* HW stops on next unit boundary (1, 2, or 4 bytes) */
+	while ((sys_test_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_BUSY_POS) != 0) &&
+	       (wait_loops-- > 0)) {
+	}
+
+	sys_clear_bits(chregs + XEC_DMA_CHAN_CTRL,
+		       (BIT(XEC_DMA_CHAN_CTRL_HWFL_RUN_POS) | BIT(XEC_DMA_CHAN_CTRL_SWFL_GO_POS) |
+			BIT(XEC_DMA_CHAN_CTRL_ABORT_POS)));
 
 	return 0;
 }
 
-/* Get DMA transfer status.
- * HW supports: MEMORY_TO_MEMORY, MEMORY_TO_PERIPHERAL, or
- * PERIPHERAL_TO_MEMORY
- * current DMA runtime status structure
+/* Fast-path reprogram used by the channel ISR to chain to the next block
+ * without tearing down the channel state we need to keep (IER, ACTIVATE,
+ * GIRQ enables). The HW design team's guidance for issue SCG_MR_22NM-131
+ * is: a still-pending peripheral request can spontaneously start the new
+ * transfer the instant MSA<MEA becomes true after a reprogram, so we must
+ * use the channel ABORT bit to force HW IDLE before writing the new block.
+ * ABORT at natural DONE settles immediately; mid-transfer it waits at most
+ * one unit-size AHB transfer (~83 ns at 48 MHz worst case for a 4-byte
+ * unit), which is negligible compared to any peripheral byte time we care
+ * about. The DONE latch was W1C-cleared by the caller before we got here
+ * and will not re-latch until the new RUN write below takes effect.
+ */
+static void dma_xec_chan_reprogram(const struct device *dev, uint32_t channel, uint32_t idx)
+{
+	const struct dma_xec_config *const devcfg = dev->config;
+	struct dma_xec_data *const data = dev->data;
+	struct dma_xec_channel *chdata = &data->channels[channel];
+	struct dma_xec_block *blk = &chdata->blocks[idx];
+	mm_reg_t chregs = xec_chan_regs(devcfg->regs, channel);
+	uint32_t ctrl;
+
+	sys_set_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_ABORT_POS);
+	while (sys_test_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_BUSY_POS) != 0) {
+	}
+
+	sys_write32(blk->mstart, chregs + XEC_DMA_CHAN_MEM_ADDR);
+	sys_write32(blk->mstart + blk->nbytes, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
+	sys_write32(blk->dstart, chregs + XEC_DMA_CHAN_DEV_ADDR);
+
+	ctrl = chdata->control | blk->inc_bits;
+	sys_write32(ctrl, chregs + XEC_DMA_CHAN_CTRL);
+
+	if (ctrl & BIT(XEC_DMA_CHAN_CTRL_DIS_HWFL_POS)) {
+		sys_set_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_SWFL_GO_POS);
+	} else {
+		sys_set_bit(chregs + XEC_DMA_CHAN_CTRL, XEC_DMA_CHAN_CTRL_HWFL_RUN_POS);
+	}
+}
+
+/* Microchip XEC central DMA does not support cyclic transfers.
+ * We zero free, write_position, and read_position members.
+ * Hardware does not implement a transferred by count accumlator therefore
+ * we can't provide a total_copied value.
  *
- * busy				- is current DMA transfer busy or idle
- * dir				- DMA transfer direction
- * pending_length		- data length pending to be transferred in bytes
- *					or platform dependent.
- * We don't implement a circular buffer
- * free                         - free buffer space
- * write_position               - write position in a circular dma buffer
- * read_position                - read position in a circular dma buffer
- *
+ * pending_length is the live MEA-MSA of the currently running block plus
+ * the cached block_size of every block that has not started yet. After
+ * the final block's DONE this resolves to zero.
  */
 static int dma_xec_get_status(const struct device *dev, uint32_t channel,
 			      struct dma_status *status)
@@ -572,7 +720,6 @@ static int dma_xec_get_status(const struct device *dev, uint32_t channel,
 	const struct dma_xec_config * const devcfg = dev->config;
 	struct dma_xec_data * const data = dev->data;
 	mm_reg_t const regs = devcfg->regs;
-	uint32_t chan_ctrl = 0U;
 
 	if ((channel >= XEC_DMA_MAX_CHANS) || (!status)) {
 		LOG_ERR("unsupported channel");
@@ -587,8 +734,6 @@ static int dma_xec_get_status(const struct device *dev, uint32_t channel,
 		status->busy = true;
 	}
 
-	chan_ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL);
-
 	status->free = 0;
 	status->write_position = 0;
 	status->read_position = 0;
@@ -601,9 +746,15 @@ static int dma_xec_get_status(const struct device *dev, uint32_t channel,
 		status->pending_length = mea - msa;
 	}
 
-	if (chan_ctrl & BIT(XEC_DMA_CHAN_CTRL_DIS_HWFL_POS)) {
+	if (XEC_DMA_MAX_BLOCK_COUNT > 1) {
+		for (uint32_t i = chan_data->cur_block + 1U; i < chan_data->num_blocks; i++) {
+			status->pending_length += chan_data->blocks[i].nbytes;
+		}
+	}
+
+	if (chan_data->control & BIT(XEC_DMA_CHAN_CTRL_DIS_HWFL_POS)) {
 		status->dir = MEMORY_TO_MEMORY;
-	} else if (chan_ctrl & BIT(XEC_DMA_CHAN_CTRL_M2D_POS)) {
+	} else if (chan_data->control & BIT(XEC_DMA_CHAN_CTRL_M2D_POS)) {
 		status->dir = MEMORY_TO_PERIPHERAL;
 	} else {
 		status->dir = PERIPHERAL_TO_MEMORY;
@@ -702,6 +853,30 @@ static int dmac_xec_pm_action(const struct device *dev,
 }
 #endif /* CONFIG_PM_DEVICE */
 
+/* Called by channel ISR passing the driver device pointer and channel number
+ * NOTE: the callback can call any DMA driver API's for this channel.
+ *
+ * On a successful DONE with more cached blocks remaining, this advances
+ * the chain in-place: the channel is ABORTed back to HW IDLE, the next
+ * block is programmed via dma_xec_chan_reprogram, and RUN is re-issued.
+ * IER and the GIRQ enables are deliberately left armed across the
+ * transition so the next block's DONE re-enters this handler. The
+ * per-block callback fires here only when complete_callback_en was set
+ * on the dma_config (DMA_XEC_CHAN_FLAGS_CB_EOB_POS).
+ *
+ * If the channel was configured cyclic (config->cyclic), DONE on the
+ * final block wraps back to block 0 instead of taking the terminal path:
+ * the per-block callback fires (if enabled), cur_block resets to 0, and
+ * the channel is reprogrammed and restarted. Useful for ping-pong
+ * peripheral-to-memory transfers where the application drains each
+ * chunk during its per-block callback and the channel keeps cycling
+ * until the peripheral signals end-of-transfer (HFC_TERM) or an
+ * external dma_stop call.
+ *
+ * On error, or on DONE of the last block in a non-cyclic chain, the
+ * channel is fully quiesced (IER cleared, status W1C, GIRQ acknowledged)
+ * and the user callback fires once with the appropriate status.
+ */
 static void dma_xec_irq_handler(const struct device *dev, uint32_t channel)
 {
 	const struct dma_xec_config * const devcfg = dev->config;
@@ -719,11 +894,33 @@ static void dma_xec_irq_handler(const struct device *dev, uint32_t channel)
 		sys_read32(regs + XEC_DMA_CHAN_DEV_ADDR),
 		sys_read32(regs + XEC_DMA_CHAN_CTRL), sts);
 
-	sys_write32(0u, regs + XEC_DMA_CHAN_IENABLE);
 	sys_write32(sts, regs + XEC_DMA_CHAN_ISTATUS);
 	soc_ecia_girq_status_clear(info[channel].gid, info[channel].gpos);
 
 	chan_data->isr_hw_status = sts;
+
+	if (!(sts & BIT(XEC_DMA_CHAN_IES_BERR_POS))) {
+		bool last_block = (chan_data->cur_block + 1U) >= chan_data->num_blocks;
+
+		if (!last_block || chan_data->cyclic) {
+			/* Optional per-block callback for the block that just
+			 * completed. Fired BEFORE we advance so the application can
+			 * inspect status, reload state, etc.
+			 */
+			if ((chan_data->flags & BIT(DMA_XEC_CHAN_FLAGS_CB_EOB_POS)) &&
+			    chan_data->cb) {
+				chan_data->cb(dev, chan_data->user_data, channel, DMA_STATUS_BLOCK);
+			}
+
+			chan_data->cur_block =
+				last_block ? 0U : (uint8_t)(chan_data->cur_block + 1U);
+			dma_xec_chan_reprogram(dev, channel, chan_data->cur_block);
+			return;
+		}
+	}
+
+	/* Terminal: error, or DONE of the final block in a non-cyclic chain. */
+	sys_write32(0u, regs + XEC_DMA_CHAN_IENABLE);
 
 	if (sts & BIT(XEC_DMA_CHAN_IES_BERR_POS)) {/* Bus Error? */
 		cb_status = -EIO;

--- a/drivers/dma/dma_mchp_xec.c
+++ b/drivers/dma/dma_mchp_xec.c
@@ -129,8 +129,6 @@ struct dma_xec_channel {
 	uint8_t rsvd[1];
 	dma_callback_t cb;
 	void *user_data;
-	uint32_t total_req_xfr_len;
-	uint32_t total_curr_xfr_len;
 };
 
 #define DMA_XEC_CHAN_FLAGS_CB_EOB_POS		0
@@ -256,8 +254,6 @@ static int check_blocks(struct dma_xec_channel *chdata, struct dma_block_config 
 		return -EINVAL;
 	}
 
-	chdata->total_req_xfr_len = 0;
-
 	for (uint32_t i = 0; i < block_count; i++) {
 		if ((block->source_addr_adj == DMA_ADDR_ADJ_DECREMENT) ||
 		    (block->dest_addr_adj == DMA_ADDR_ADJ_DECREMENT)) {
@@ -275,7 +271,6 @@ static int check_blocks(struct dma_xec_channel *chdata, struct dma_block_config 
 			return -EINVAL;
 		}
 
-		chdata->total_req_xfr_len += block->block_size;
 	}
 
 	return 0;
@@ -367,9 +362,6 @@ static int dma_xec_configure(const struct device *dev, uint32_t channel,
 	if (xec_dma_chan_is_busy(chregs)) {
 		return -EBUSY;
 	}
-
-	chdata->total_req_xfr_len = 0;
-	chdata->total_curr_xfr_len = 0;
 
 	xec_dma_chan_clr(chregs, info);
 
@@ -495,8 +487,6 @@ static int dma_xec_reload(const struct device *dev, uint32_t channel,
 	}
 
 	chdata->mend = chdata->mstart + size;
-	chdata->total_req_xfr_len = size;
-	chdata->total_curr_xfr_len = 0;
 
 	sys_write32(chdata->mstart, chregs + XEC_DMA_CHAN_MEM_ADDR);
 	sys_write32(chdata->mend, chregs + XEC_DMA_CHAN_MEM_ADDR_END);
@@ -614,19 +604,23 @@ static int dma_xec_get_status(const struct device *dev, uint32_t channel,
 	struct dma_xec_channel *chan_data = &data->channels[channel];
 	mm_reg_t chregs = xec_chan_regs(regs, channel);
 
+	status->busy = false;
+	if (xec_dma_chan_is_busy(chregs)) {
+		status->busy = true;
+	}
+
 	chan_ctrl = sys_read32(chregs + XEC_DMA_CHAN_CTRL);
 
-	if (chan_ctrl & BIT(XEC_DMA_CHAN_CTRL_BUSY_POS)) {
-		uint32_t rem = sys_read32(chregs + XEC_DMA_CHAN_MEM_ADDR_END) -
-			       sys_read32(chregs + XEC_DMA_CHAN_MEM_ADDR);
+	status->free = 0;
+	status->write_position = 0;
+	status->read_position = 0;
 
-		status->busy = true;
-		/* number of bytes remaining in channel */
-		status->pending_length = chan_data->total_req_xfr_len - rem;
-	} else {
-		status->pending_length = chan_data->total_req_xfr_len -
-						chan_data->total_curr_xfr_len;
-		status->busy = false;
+	uint32_t msa = sys_read32(chregs + XEC_DMA_CHAN_MEM_ADDR);
+	uint32_t mea = sys_read32(chregs + XEC_DMA_CHAN_MEM_ADDR_END);
+
+	status->pending_length = 0;
+	if (mea > msa) {
+		status->pending_length = mea - msa;
 	}
 
 	if (chan_ctrl & BIT(XEC_DMA_CHAN_CTRL_DIS_HWFL_POS)) {
@@ -637,7 +631,7 @@ static int dma_xec_get_status(const struct device *dev, uint32_t channel,
 		status->dir = PERIPHERAL_TO_MEMORY;
 	}
 
-	status->total_copied = chan_data->total_curr_xfr_len;
+	status->total_copied = 0;
 
 	/* Report a latched bus error from the last transfer */
 	if (chan_data->isr_hw_status & BIT(XEC_DMA_CHAN_IES_BERR_POS)) {
@@ -752,8 +746,6 @@ static void dma_xec_irq_handler(const struct device *dev, uint32_t channel)
 	soc_ecia_girq_status_clear(info[channel].gid, info[channel].gpos);
 
 	chan_data->isr_hw_status = sts;
-	chan_data->total_curr_xfr_len +=
-		(sys_read32(regs + XEC_DMA_CHAN_MEM_ADDR) - chan_data->mstart);
 
 	if (sts & BIT(XEC_DMA_CHAN_IES_BERR_POS)) {/* Bus Error? */
 		cb_status = -EIO;

--- a/dts/arm/microchip/mec/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec/mec172x_common.dtsi
@@ -478,22 +478,18 @@ dmac: dmac@40002400 {
 		     <28 1>, <29 1>, <30 1>, <31 1>,
 		     <32 1>, <33 1>, <34 1>, <35 1>,
 		     <36 1>, <37 1>, <38 1>, <39 1>;
-	girqs = <MCHP_XEC_ECIA(14, 0, 6, 24)
-		 MCHP_XEC_ECIA(14, 1, 6, 25)
-		 MCHP_XEC_ECIA(14, 2, 6, 26)
-		 MCHP_XEC_ECIA(14, 3, 6, 27)
-		 MCHP_XEC_ECIA(14, 4, 6, 28)
-		 MCHP_XEC_ECIA(14, 5, 6, 29)
-		 MCHP_XEC_ECIA(14, 6, 6, 30)
-		 MCHP_XEC_ECIA(14, 7, 6, 31)
-		 MCHP_XEC_ECIA(14, 8, 6, 32)
-		 MCHP_XEC_ECIA(14, 9, 6, 33)
-		 MCHP_XEC_ECIA(14, 10, 6, 34)
-		 MCHP_XEC_ECIA(14, 11, 6, 35)
-		 MCHP_XEC_ECIA(14, 12, 6, 36)
-		 MCHP_XEC_ECIA(14, 13, 6, 37)
-		 MCHP_XEC_ECIA(14, 14, 6, 38)
-		 MCHP_XEC_ECIA(14, 15, 6, 39)>;
+	interrupt-names = "chan0", "chan1", "chan2", "chan3",
+			  "chan4", "chan5", "chan6", "chan7",
+			  "chan8", "chan9", "chan10", "chan11",
+			  "chan12", "chan13", "chan14", "chan15";
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(14, 0) MCHP_XEC_ECIA_GIRQ_ENC(14, 1)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 2) MCHP_XEC_ECIA_GIRQ_ENC(14, 3)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 4) MCHP_XEC_ECIA_GIRQ_ENC(14, 5)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 6) MCHP_XEC_ECIA_GIRQ_ENC(14, 7)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 8) MCHP_XEC_ECIA_GIRQ_ENC(14, 9)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 10) MCHP_XEC_ECIA_GIRQ_ENC(14, 11)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 12) MCHP_XEC_ECIA_GIRQ_ENC(14, 13)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 14) MCHP_XEC_ECIA_GIRQ_ENC(14, 15)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 6)>;
 	#dma-cells = <2>;
 	dma-channels = <16>;

--- a/dts/arm/microchip/mec/mec172x_common.dtsi
+++ b/dts/arm/microchip/mec/mec172x_common.dtsi
@@ -484,22 +484,18 @@ dmac: dmac@40002400 {
 		     <28 1>, <29 1>, <30 1>, <31 1>,
 		     <32 1>, <33 1>, <34 1>, <35 1>,
 		     <36 1>, <37 1>, <38 1>, <39 1>;
-	girqs = <MCHP_XEC_ECIA(14, 0, 6, 24)
-		 MCHP_XEC_ECIA(14, 1, 6, 25)
-		 MCHP_XEC_ECIA(14, 2, 6, 26)
-		 MCHP_XEC_ECIA(14, 3, 6, 27)
-		 MCHP_XEC_ECIA(14, 4, 6, 28)
-		 MCHP_XEC_ECIA(14, 5, 6, 29)
-		 MCHP_XEC_ECIA(14, 6, 6, 30)
-		 MCHP_XEC_ECIA(14, 7, 6, 31)
-		 MCHP_XEC_ECIA(14, 8, 6, 32)
-		 MCHP_XEC_ECIA(14, 9, 6, 33)
-		 MCHP_XEC_ECIA(14, 10, 6, 34)
-		 MCHP_XEC_ECIA(14, 11, 6, 35)
-		 MCHP_XEC_ECIA(14, 12, 6, 36)
-		 MCHP_XEC_ECIA(14, 13, 6, 37)
-		 MCHP_XEC_ECIA(14, 14, 6, 38)
-		 MCHP_XEC_ECIA(14, 15, 6, 39)>;
+	interrupt-names = "chan0", "chan1", "chan2", "chan3",
+			  "chan4", "chan5", "chan6", "chan7",
+			  "chan8", "chan9", "chan10", "chan11",
+			  "chan12", "chan13", "chan14", "chan15";
+	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(14, 0) MCHP_XEC_ECIA_GIRQ_ENC(14, 1)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 2) MCHP_XEC_ECIA_GIRQ_ENC(14, 3)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 4) MCHP_XEC_ECIA_GIRQ_ENC(14, 5)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 6) MCHP_XEC_ECIA_GIRQ_ENC(14, 7)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 8) MCHP_XEC_ECIA_GIRQ_ENC(14, 9)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 10) MCHP_XEC_ECIA_GIRQ_ENC(14, 11)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 12) MCHP_XEC_ECIA_GIRQ_ENC(14, 13)
+		 MCHP_XEC_ECIA_GIRQ_ENC(14, 14) MCHP_XEC_ECIA_GIRQ_ENC(14, 15)>;
 	pcr-scr = <MCHP_XEC_SCR_ENCODE(1, 6)>;
 	#dma-cells = <2>;
 	dma-channels = <16>;

--- a/dts/arm/microchip/mec/mec5/mec5_dma_chan16.dtsi
+++ b/dts/arm/microchip/mec/mec5/mec5_dma_chan16.dtsi
@@ -13,6 +13,10 @@ dmac: dmac@40002400 {
 		     <28 1>, <29 1>, <30 1>, <31 1>,
 		     <32 1>, <33 1>, <34 1>, <35 1>,
 		     <36 1>, <37 1>, <38 1>, <39 1>;
+	interrupt-names = "chan0", "chan1", "chan2", "chan3",
+			  "chan4", "chan5", "chan6", "chan7",
+			  "chan8", "chan9", "chan10", "chan11",
+			  "chan12", "chan13", "chan14", "chan15";
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(14, 0) MCHP_XEC_ECIA_GIRQ_ENC(14, 1)
 		 MCHP_XEC_ECIA_GIRQ_ENC(14, 2) MCHP_XEC_ECIA_GIRQ_ENC(14, 3)
 		 MCHP_XEC_ECIA_GIRQ_ENC(14, 4) MCHP_XEC_ECIA_GIRQ_ENC(14, 5)

--- a/dts/arm/microchip/mec/mec5/mec5_dma_chan20.dtsi
+++ b/dts/arm/microchip/mec/mec5/mec5_dma_chan20.dtsi
@@ -14,6 +14,11 @@ dmac: dmac@40002400 {
 		     <32 1>, <33 1>, <34 1>, <35 1>,
 		     <36 1>, <37 1>, <38 1>, <39 1>,
 		     <194 1>, <195 1>, <196 1>, <197 1>;
+	interrupt-names = "chan0", "chan1", "chan2", "chan3",
+			  "chan4", "chan5", "chan6", "chan7",
+			  "chan8", "chan9", "chan10", "chan11",
+			  "chan12", "chan13", "chan14", "chan15",
+			  "chan16", "chan17", "chan18", "chan19";
 	girqs = <MCHP_XEC_ECIA_GIRQ_ENC(14, 0) MCHP_XEC_ECIA_GIRQ_ENC(14, 1)
 		 MCHP_XEC_ECIA_GIRQ_ENC(14, 2) MCHP_XEC_ECIA_GIRQ_ENC(14, 3)
 		 MCHP_XEC_ECIA_GIRQ_ENC(14, 4) MCHP_XEC_ECIA_GIRQ_ENC(14, 5)

--- a/dts/bindings/dma/microchip,xec-dmac.yaml
+++ b/dts/bindings/dma/microchip,xec-dmac.yaml
@@ -11,6 +11,9 @@ properties:
   interrupts:
     required: true
 
+  interrupt-names:
+    required: true
+
   pcr-scr:
     type: int
     required: true

--- a/include/zephyr/dt-bindings/dma/mchp-xec-dmac.h
+++ b/include/zephyr/dt-bindings/dma/mchp-xec-dmac.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_DMA_MCHP_XEC_DMAC_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_DMA_MCHP_XEC_DMAC_H_
+
+/**
+ * @brief Vendor-specific DMA peripheral triggering sources.
+ *
+ * A valid triggering source should be provided when DMA
+ * is configured for peripheral to peripheral or memory to peripheral
+ * transactions.
+ */
+#define DMA_MCHP_XEC_TRIG_SRC_I2C_SMB0_TARG 0x0
+#define DMA_MCHP_XEC_TRIG_SRC_I2C_SMB0_CTRL 0x1
+#define DMA_MCHP_XEC_TRIG_SRC_I2C_SMB1_TARG 0x2
+#define DMA_MCHP_XEC_TRIG_SRC_I2C_SMB1_CTRL 0x3
+#define DMA_MCHP_XEC_TRIG_SRC_I2C_SMB2_TARG 0x4
+#define DMA_MCHP_XEC_TRIG_SRC_I2C_SMB2_CTRL 0x5
+#define DMA_MCHP_XEC_TRIG_SRC_I2C_SMB3_TARG 0x6
+#define DMA_MCHP_XEC_TRIG_SRC_I2C_SMB3_CTRL 0x7
+#define DMA_MCHP_XEC_TRIG_SRC_I2C_SMB4_TARG 0x8
+#define DMA_MCHP_XEC_TRIG_SRC_I2C_SMB4_CTRL 0x9
+#define DMA_MCHP_XEC_TRIG_SRC_QMSPI0_TX     0xA
+#define DMA_MCHP_XEC_TRIG_SRC_QMSPI0_RX     0xB
+#define DMA_MCHP_XEC_TRIG_SRC_GPSPI0_TX     0xC
+#define DMA_MCHP_XEC_TRIG_SRC_GPSPI0_RX     0xD
+#define DMA_MCHP_XEC_TRIG_SRC_GPSPI1_TX     0xE
+#define DMA_MCHP_XEC_TRIG_SRC_GPSPI1_RX     0xF
+/* Additional channels for MEC175x */
+#define DMA_MCHP_XEC_TRIG_SRC_I3C_HC0_TX    0x10
+#define DMA_MCHP_XEC_TRIG_SRC_I3C_HC0_RX    0x11
+#define DMA_MCHP_XEC_TRIG_SRC_I3C_SC0_TX    0x12
+#define DMA_MCHP_XEC_TRIG_SRC_I3C_SC0_RX    0x13
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_DMA_MCHP_XEC_DMAC_H_ */


### PR DESCRIPTION
Refactors and hardens the Microchip XEC DMA driver: aligns the API callbacks with the Zephyr contract with proper input validation, derives channel status from hardware, and
centralizes channel reset. Also drives IRQ connect from interrupt-names and defers channel activation to start().
Also introduce support to multi block transfer