### PR TITLE
drivers: otp: implement otp_program for stm32 MCUs

### DIFF
--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -117,6 +117,24 @@ int flash_stm32_wait_flash_idle(const struct device *dev)
 	return 0;
 }
 
+#if defined(CONFIG_OTP_PROGRAM)
+/*
+ * Default (weak) OTP programming implementation. Series whose flash driver
+ * supports programming OTP-in-NVM override this with a strong definition.
+ */
+__weak int flash_stm32_otp_program(const struct device *dev, uint8_t *otp_base, off_t offset,
+				   const void *data, size_t len)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(otp_base);
+	ARG_UNUSED(offset);
+	ARG_UNUSED(data);
+	ARG_UNUSED(len);
+
+	return -ENOSYS;
+}
+#endif
+
 static void flash_stm32_flush_caches(const struct device *dev, off_t offset, size_t len)
 {
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || defined(CONFIG_SOC_SERIES_STM32F3X) ||                  \
@@ -565,5 +583,5 @@ static int stm32_flash_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, stm32_flash_init, NULL, &flash_data, NULL, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, stm32_flash_init, NULL, &flash_data, NULL, PRE_KERNEL_1,
 		      CONFIG_FLASH_INIT_PRIORITY, &flash_stm32_api);

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -565,5 +565,5 @@ static int stm32_flash_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, stm32_flash_init, NULL, &flash_data, NULL, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, stm32_flash_init, NULL, &flash_data, NULL, PRE_KERNEL_1,
 		      CONFIG_FLASH_INIT_PRIORITY, &flash_stm32_api);

--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -357,6 +357,28 @@ int flash_stm32_wait_flash_idle(const struct device *dev);
 
 uint32_t flash_stm32_option_bytes_read(const struct device *dev);
 
+#if defined(CONFIG_OTP_PROGRAM)
+/** @cond INTERNAL_HIDDEN */
+/*
+ * Program half-words into an OTP area located in embedded NVM.
+ *
+ * Called by the STM32 NVM OTP driver (drivers/otp/otp_nvm_stm32.c). The default
+ * implementation in flash_stm32.c returns -ENOSYS; series that support it
+ * provide a strong definition in their flash driver (e.g. flash_stm32l5x.c for
+ * STM32H5). The programming is serialized against regular flash operations
+ * using the flash driver's own lock.
+ *
+ * @param dev      flash controller device (parent of the OTP node)
+ * @param otp_base memory-mapped base address of the OTP area
+ * @param offset   byte offset within the OTP area (half-word aligned)
+ * @param data     source buffer
+ * @param len      number of bytes to program (multiple of a half-word)
+ */
+int flash_stm32_otp_program(const struct device *dev, uint8_t *otp_base, off_t offset,
+			    const void *data, size_t len);
+/** @endcond **/
+#endif /* CONFIG_OTP_PROGRAM */
+
 int flash_stm32_option_bytes_write(const struct device *dev, uint32_t mask,
 				   uint32_t value);
 

--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -357,6 +357,28 @@ int flash_stm32_wait_flash_idle(const struct device *dev);
 
 uint32_t flash_stm32_option_bytes_read(const struct device *dev);
 
+#if defined(CONFIG_OTP_STM32_NVM_PROGRAMMING_SUPPORT)
+/** @cond INTERNAL_HIDDEN */
+/*
+ * Program half-words into an OTP area located in embedded NVM.
+ *
+ * Called by the STM32 NVM OTP driver (drivers/otp/otp_nvm_stm32.c). The default
+ * implementation in flash_stm32.c returns -ENOSYS; series that support it
+ * provide a strong definition in their flash driver (e.g. flash_stm32l5x.c for
+ * STM32H5). The programming is serialized against regular flash operations
+ * using the flash driver's own lock.
+ *
+ * @param dev      flash controller device (parent of the OTP node)
+ * @param otp_base memory-mapped base address of the OTP area
+ * @param offset   byte offset within the OTP area (half-word aligned)
+ * @param data     source buffer
+ * @param len      number of bytes to program (multiple of a half-word)
+ */
+int flash_stm32_otp_program(const struct device *dev, uint8_t *otp_base, off_t offset,
+			    const void *data, size_t len);
+/** @endcond **/
+#endif /* CONFIG_OTP_STM32_NVM_PROGRAMMING_SUPPORT */
+
 int flash_stm32_option_bytes_write(const struct device *dev, uint32_t mask,
 				   uint32_t value);
 

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -958,5 +958,5 @@ static int stm32h7_flash_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, stm32h7_flash_init, NULL, &flash_data, NULL, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, stm32h7_flash_init, NULL, &flash_data, NULL, PRE_KERNEL_1,
 		      CONFIG_FLASH_INIT_PRIORITY, &flash_stm32h7_api);

--- a/drivers/flash/flash_stm32l5x.c
+++ b/drivers/flash/flash_stm32l5x.c
@@ -15,6 +15,8 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <string.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/sys/barrier.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/sys_io.h>
 #include <zephyr/init.h>
 #include <soc.h>
 #include <stm32_ll_icache.h>
@@ -275,6 +277,95 @@ int flash_stm32_write_range(const struct device *dev, unsigned int offset,
 
 	return rc;
 }
+
+#if defined(CONFIG_OTP_PROGRAM) && defined(CONFIG_SOC_SERIES_STM32H5X)
+/* Size in bytes of one OTP block guarded by a single OTPBLR_CUR lock bit. */
+#define STM32H5_OTP_BLOCK_SIZE 64U
+
+static int otp_write_halfwords(const struct device *dev, uint8_t *otp_base, off_t offset,
+			       const void *data, size_t len)
+{
+	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
+	const uint8_t *src = data;
+	size_t written = 0;
+	uint32_t lock_mask;
+	int rc;
+
+	rc = flash_stm32_wait_flash_idle(dev);
+	if (rc < 0) {
+		return rc;
+	}
+
+	/* Refuse to program any OTP block that is already lock-protected. */
+	lock_mask = BIT_MASK(DIV_ROUND_UP(len, STM32H5_OTP_BLOCK_SIZE))
+		    << (offset / STM32H5_OTP_BLOCK_SIZE);
+	if (regs->OTPBLR_CUR & lock_mask) {
+		return -EACCES;
+	}
+
+	/*
+	 * OTP is programmed one half-word at a time using the standard NVM
+	 * half-word programming mode (see RM0481 "FLASH OTP area").
+	 */
+	regs->NSCR |= FLASH_STM32_NSPG;
+	barrier_dsync_fence_full();
+
+	while (written < len) {
+		sys_write16(UNALIGNED_GET((uint16_t *)(src + written)),
+			    (uintptr_t)otp_base + offset + written);
+
+		rc = flash_stm32_wait_flash_idle(dev);
+		if (rc < 0) {
+			break;
+		}
+
+		written += sizeof(uint16_t);
+	}
+
+	regs->NSCR &= ~FLASH_STM32_NSPG;
+
+	return rc;
+}
+
+int flash_stm32_otp_program(const struct device *dev, uint8_t *otp_base, off_t offset,
+			    const void *data, size_t len)
+{
+	bool cache_enabled;
+	int rc, rc2;
+
+	/* OTP is programmed by half-words only. */
+	if ((offset % sizeof(uint16_t)) || (len % sizeof(uint16_t))) {
+		return -EINVAL;
+	}
+
+	flash_stm32_sem_take(dev);
+
+	/*
+	 * As for regular flash writes, the i-cache must be disabled while
+	 * programming or the controller raises the ERRF error flag.
+	 */
+	cache_enabled = LL_ICACHE_IsEnabled();
+	sys_cache_instr_disable();
+
+	rc = flash_stm32_cr_lock(dev, false);
+	if (rc == 0) {
+		rc = otp_write_halfwords(dev, otp_base, offset, data, len);
+	}
+
+	rc2 = flash_stm32_cr_lock(dev, true);
+	if (!rc) {
+		rc = rc2;
+	}
+
+	if (cache_enabled) {
+		sys_cache_instr_enable();
+	}
+
+	flash_stm32_sem_give(dev);
+
+	return rc;
+}
+#endif /* CONFIG_OTP_PROGRAM && CONFIG_SOC_SERIES_STM32H5X */
 
 #if defined(CONFIG_FLASH_STM32_READOUT_PROTECTION)
 

--- a/drivers/flash/flash_stm32l5x.c
+++ b/drivers/flash/flash_stm32l5x.c
@@ -15,6 +15,8 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <string.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/sys/barrier.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/sys_io.h>
 #include <zephyr/init.h>
 #include <soc.h>
 #include <stm32_ll_icache.h>
@@ -275,6 +277,95 @@ int flash_stm32_write_range(const struct device *dev, unsigned int offset,
 
 	return rc;
 }
+
+#if defined(CONFIG_OTP_STM32_NVM_PROGRAMMING_SUPPORT) && defined(CONFIG_SOC_SERIES_STM32H5X)
+/* Size in bytes of one OTP block guarded by a single OTPBLR_CUR lock bit. */
+#define STM32H5_OTP_BLOCK_SIZE 64U
+
+static int otp_write_halfwords(const struct device *dev, uint8_t *otp_base, off_t offset,
+			       const void *data, size_t len)
+{
+	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
+	const uint8_t *src = data;
+	size_t written = 0;
+	uint32_t lock_mask;
+	int rc;
+
+	rc = flash_stm32_wait_flash_idle(dev);
+	if (rc < 0) {
+		return rc;
+	}
+
+	/* Refuse to program any OTP block that is already lock-protected. */
+	lock_mask = BIT_MASK(DIV_ROUND_UP(len, STM32H5_OTP_BLOCK_SIZE))
+		    << (offset / STM32H5_OTP_BLOCK_SIZE);
+	if (regs->OTPBLR_CUR & lock_mask) {
+		return -EACCES;
+	}
+
+	/*
+	 * OTP is programmed one half-word at a time using the standard NVM
+	 * half-word programming mode (see RM0481 "FLASH OTP area").
+	 */
+	regs->NSCR |= FLASH_STM32_NSPG;
+	barrier_dsync_fence_full();
+
+	while (written < len) {
+		sys_write16(UNALIGNED_GET((uint16_t *)(src + written)),
+			    (uintptr_t)otp_base + offset + written);
+
+		rc = flash_stm32_wait_flash_idle(dev);
+		if (rc < 0) {
+			break;
+		}
+
+		written += sizeof(uint16_t);
+	}
+
+	regs->NSCR &= ~FLASH_STM32_NSPG;
+
+	return rc;
+}
+
+int flash_stm32_otp_program(const struct device *dev, uint8_t *otp_base, off_t offset,
+			    const void *data, size_t len)
+{
+	bool cache_enabled;
+	int rc, rc2;
+
+	/* OTP is programmed by half-words only. */
+	if ((offset % sizeof(uint16_t)) || (len % sizeof(uint16_t))) {
+		return -EINVAL;
+	}
+
+	flash_stm32_sem_take(dev);
+
+	/*
+	 * As for regular flash writes, the i-cache must be disabled while
+	 * programming or the controller raises the ERRF error flag.
+	 */
+	cache_enabled = LL_ICACHE_IsEnabled();
+	sys_cache_instr_disable();
+
+	rc = flash_stm32_cr_lock(dev, false);
+	if (rc == 0) {
+		rc = otp_write_halfwords(dev, otp_base, offset, data, len);
+	}
+
+	rc2 = flash_stm32_cr_lock(dev, true);
+	if (!rc) {
+		rc = rc2;
+	}
+
+	if (cache_enabled) {
+		sys_cache_instr_enable();
+	}
+
+	flash_stm32_sem_give(dev);
+
+	return rc;
+}
+#endif /* CONFIG_OTP_STM32_NVM_PROGRAMMING_SUPPORT && CONFIG_SOC_SERIES_STM32H5X */
 
 #if defined(CONFIG_FLASH_STM32_READOUT_PROTECTION)
 

--- a/drivers/flash/flash_stm32wb0x.c
+++ b/drivers/flash/flash_stm32wb0x.c
@@ -470,5 +470,5 @@ int stm32wb0x_flash_init(const struct device *dev)
 static struct flash_wb0x_data wb0x_flash_drv_data;
 
 DEVICE_DT_INST_DEFINE(0, stm32wb0x_flash_init, NULL,
-		    &wb0x_flash_drv_data, NULL, POST_KERNEL,
+		    &wb0x_flash_drv_data, NULL, PRE_KERNEL_1,
 		    CONFIG_FLASH_INIT_PRIORITY, &flash_wb0x_api);

--- a/drivers/flash/flash_stm32wba_fm.c
+++ b/drivers/flash/flash_stm32wba_fm.c
@@ -341,5 +341,5 @@ static int stm32_flash_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DT_INST_DEFINE(0, stm32_flash_init, NULL, &flash_data, NULL, POST_KERNEL,
+DEVICE_DT_INST_DEFINE(0, stm32_flash_init, NULL, &flash_data, NULL, PRE_KERNEL_1,
 		      CONFIG_FLASH_INIT_PRIORITY, &flash_stm32_api);

--- a/drivers/otp/Kconfig.stm32
+++ b/drivers/otp/Kconfig.stm32
@@ -13,8 +13,15 @@ config OTP_STM32_NVM
 	bool "STM32 embedded NVM OTP driver"
 	default y
 	depends on DT_HAS_ST_STM32_NVM_OTP_ENABLED
+	select SOC_FLASH_STM32 if OTP_PROGRAM
 	help
 	  Enable driver for OTP regions inside embedded non-volatile memory
 	  found in STM32 SoCs.
 
-	  N.B.: the "program" operation is currently not supported.
+	  Note: the "program" operation (CONFIG_OTP_PROGRAM) is not implemented
+	  in this driver but in each STM32 series' flash driver instead. This
+	  driver merely acts as a shim redirecting otp_program() to the proper
+	  "backend" driver. It is possible that some series do not provide an
+	  implementation for the program operation: in this case, otp_program()
+	  will return -ENOSYS. Check the appropriate flash driver to determine
+	  if the program operation is implemented or not.

--- a/drivers/otp/Kconfig.stm32
+++ b/drivers/otp/Kconfig.stm32
@@ -17,4 +17,30 @@ config OTP_STM32_NVM
 	  Enable driver for OTP regions inside embedded non-volatile memory
 	  found in STM32 SoCs.
 
-	  N.B.: the "program" operation is currently not supported.
+	  Note: the "program" operation (CONFIG_OTP_PROGRAM) is not implemented
+	  in this driver but in each STM32 series' flash driver instead. This
+	  driver merely acts as a shim redirecting otp_program() to the proper
+	  "backend" driver. It is possible that some series do not provide an
+	  implementation for the program operation: in this case, otp_program()
+	  will return -ENOTSUP. Check the appropriate flash driver to determine
+	  if the program operation is implemented or not.
+
+if OTP_STM32_NVM
+
+config OTP_STM32_NVM_PROGRAMMING_SUPPORT
+	bool "NVM OTP programming"
+	default y
+	depends on OTP_PROGRAM
+	depends on SOC_FLASH_STM32
+	help
+	  Enable programming of the OTP area of STM32 NVM.
+
+	  Note that the OTP programming logic is implemented in series-specific
+	  flash drivers; this driver merely implements otp_program() as a shim
+	  which calls the flash driver's implementation.
+
+	  OTP programming is not supported by all flash drivers yet. Calling
+	  otp_program() when the underlying flash driver does not support the
+	  operation will return -ENOTSUP.
+
+endif # OTP_STM32_NVM

--- a/drivers/otp/otp_nvm_stm32.c
+++ b/drivers/otp/otp_nvm_stm32.c
@@ -1,12 +1,14 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2026 STMicroelectronics
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Metratec GmbH
  * SPDX-License-Identifier: Apache-2.0
  *
  * Driver for one-time programmable areas inside STM32 embedded NVM.
  *
- * "OTP for user data" area programming is not supported yet.
- * It shall be implemented as a dedicated, externally visible function
- * in the flash driver(s) called from this driver.
+ * When CONFIG_OTP_PROGRAM is enabled, "OTP for user data" area programming is
+ * performed by a dedicated, externally visible function in the flash driver(s)
+ * - flash_stm32_otp_program() - which is called from this driver. This keeps
+ * the read path free of any dependency on the flash driver.
  */
 
 #include <string.h>
@@ -17,13 +19,18 @@
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
+#include <flash/flash_stm32.h>
 
 #define DT_DRV_COMPAT st_stm32_nvm_otp
 
 struct otp_stm32_nvm_config {
 	/* Base address and size of OTP area */
-	const uint8_t *base;
+	uint8_t *base;
 	size_t size;
+#if CONFIG_OTP_PROGRAM
+	/* Flash controller (parent) device used to program the OTP area */
+	const struct device *flash_dev;
+#endif
 };
 
 static void slow_otp_readout(void *buf, const uint8_t *src, size_t len)
@@ -117,18 +124,54 @@ static int otp_stm32_nvm_read(const struct device *dev, off_t offset, void *buf,
 	return 0;
 }
 
+#if CONFIG_OTP_PROGRAM
+static int otp_stm32_nvm_program(const struct device *dev, off_t offset, const void *buf,
+				 size_t len)
+{
+	const struct otp_stm32_nvm_config *config = dev->config;
+	const size_t start = (size_t)offset;
+	size_t end;
+
+	/* 16-bit alignment, half-words only. */
+	if ((offset % sizeof(uint16_t)) != 0 || (len % sizeof(uint16_t)) != 0) {
+		return -EINVAL;
+	}
+
+	if (size_add_overflow(start, len, &end) || end > config->size) {
+		return -EINVAL;
+	}
+
+	/*
+	 * The actual programming is done by the flash driver, which serializes
+	 * it against regular flash operations on the shared NVM peripheral.
+	 */
+	return flash_stm32_otp_program(config->flash_dev, config->base, offset, buf, len);
+}
+#endif /* CONFIG_OTP_PROGRAM */
+
 static DEVICE_API(otp, otp_stm32_nvm_api) = {
 	.read = otp_stm32_nvm_read,
+#if CONFIG_OTP_PROGRAM
+	.program = otp_stm32_nvm_program,
+#endif
 };
+
+#if CONFIG_OTP_PROGRAM
+#define OTP_STM32_NVM_FLASH_DEV(inst) .flash_dev = DEVICE_DT_GET(DT_INST_PARENT(inst)),
+#else
+#define OTP_STM32_NVM_FLASH_DEV(inst)
+#endif
 
 #define OTP_STM32_NVM_INIT_INNER(inst, _cfg)							\
 	static const struct otp_stm32_nvm_config _cfg = {					\
 		.base = (void *)DT_INST_REG_ADDR(inst),						\
 		.size = DT_INST_REG_SIZE(inst),							\
+		OTP_STM32_NVM_FLASH_DEV(inst)							\
 	};											\
 												\
 	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, &_cfg,					\
-			      PRE_KERNEL_1, CONFIG_OTP_INIT_PRIORITY, &otp_stm32_nvm_api);
+			      PRE_KERNEL_1, CONFIG_OTP_INIT_PRIORITY,				\
+			      &otp_stm32_nvm_api);
 
 #define OTP_STM32_NVM_INIT(inst)								\
 	OTP_STM32_NVM_INIT_INNER(inst, CONCAT(otp_stm32_nvm_cfg, inst))

--- a/drivers/otp/otp_nvm_stm32.c
+++ b/drivers/otp/otp_nvm_stm32.c
@@ -1,12 +1,14 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2026 STMicroelectronics
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Metratec GmbH
  * SPDX-License-Identifier: Apache-2.0
  *
  * Driver for one-time programmable areas inside STM32 embedded NVM.
  *
- * "OTP for user data" area programming is not supported yet.
- * It shall be implemented as a dedicated, externally visible function
- * in the flash driver(s) called from this driver.
+ * When CONFIG_OTP_PROGRAM is enabled, "OTP for user data" area programming is
+ * performed by a dedicated, externally visible function in the flash driver(s)
+ * - flash_stm32_otp_program() - which is called from this driver. This keeps
+ * the read path free of any dependency on the flash driver.
  */
 
 #include <string.h>
@@ -18,11 +20,14 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 
+/* drivers/flash/flash_stm32.h */
+#include <flash/flash_stm32.h>
+
 #define DT_DRV_COMPAT st_stm32_nvm_otp
 
 struct otp_stm32_nvm_config {
 	/* Base address and size of OTP area */
-	const uint8_t *base;
+	uint8_t *base;
 	size_t size;
 };
 
@@ -117,8 +122,68 @@ static int otp_stm32_nvm_read(const struct device *dev, off_t offset, void *buf,
 	return 0;
 }
 
+#if defined(CONFIG_OTP_STM32_NVM_PROGRAMMING_SUPPORT)
+/*
+ * Default (weak) OTP programming implementation. Series whose flash driver
+ * supports programming OTP-in-NVM override this with a strong definition.
+ */
+__weak int flash_stm32_otp_program(const struct device *dev, uint8_t *otp_base, off_t offset,
+				   const void *data, size_t len)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(otp_base);
+	ARG_UNUSED(offset);
+	ARG_UNUSED(data);
+	ARG_UNUSED(len);
+
+	return -ENOTSUP;
+}
+
+static int otp_stm32_nvm_program(const struct device *dev, off_t offset, const void *buf,
+				 size_t len)
+{
+	const struct otp_stm32_nvm_config *config = dev->config;
+	size_t result;
+
+	/* 16-bit alignment, half-words only. */
+	if ((offset % sizeof(uint16_t)) != 0 || (len % sizeof(uint16_t)) != 0) {
+		return -EINVAL;
+	}
+
+	if (size_add_overflow(offset, len, &result) || result > config->size) {
+		return -EINVAL;
+	}
+
+	/*
+	 * The actual programming is done by the flash driver, which serializes
+	 * it against regular flash operations on the shared NVM peripheral.
+	 */
+	const struct device *flash_dev = DEVICE_DT_GET(DT_INST_PARENT(0));
+	int res = flash_stm32_otp_program(flash_dev, config->base, offset, buf, len);
+
+	if (res == 0) {
+		/* Invalidate D$ lines corresponding to written area */
+		const size_t line_size = sys_cache_data_line_size_get();
+		uint8_t *invd_start;
+		size_t invd_size;
+
+		uint8_t *start = config->base + offset;
+		uint8_t *end = start + len;
+
+		invd_start = (uint8_t *)ROUND_DOWN((uintptr_t)start, line_size);
+		invd_size = (size_t)ROUND_UP((uintptr_t)end - (uintptr_t)invd_start, line_size);
+		sys_cache_data_invd_range(invd_start, invd_size);
+	}
+
+	return res;
+}
+#endif /* CONFIG_OTP_STM32_NVM_PROGRAMMING_SUPPORT */
+
 static DEVICE_API(otp, otp_stm32_nvm_api) = {
 	.read = otp_stm32_nvm_read,
+#if CONFIG_OTP_STM32_NVM_PROGRAMMING_SUPPORT
+	.program = otp_stm32_nvm_program,
+#endif
 };
 
 #define OTP_STM32_NVM_INIT_INNER(inst, _cfg)							\
@@ -127,8 +192,8 @@ static DEVICE_API(otp, otp_stm32_nvm_api) = {
 		.size = DT_INST_REG_SIZE(inst),							\
 	};											\
 												\
-	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, &_cfg,					\
-			      PRE_KERNEL_1, CONFIG_OTP_INIT_PRIORITY, &otp_stm32_nvm_api);
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, &_cfg, PRE_KERNEL_1,			\
+			      CONFIG_OTP_INIT_PRIORITY, &otp_stm32_nvm_api);
 
 #define OTP_STM32_NVM_INIT(inst)								\
 	OTP_STM32_NVM_INIT_INNER(inst, CONCAT(otp_stm32_nvm_cfg, inst))


### PR DESCRIPTION
adds support to program the OTP memory on stm32 MCUs