### PR TITLE
kernel: Add option to run the system workqueue on the main thread

### DIFF
--- a/doc/kernel/services/threads/workqueue.rst
+++ b/doc/kernel/services/threads/workqueue.rst
@@ -264,6 +264,16 @@ The following API can be used to interact with a workqueue:
 * :c:func:`k_work_queue_unplug()` removes any previous block on submission to
   the queue due to a previous drain operation.
 
+A workqueue can alternatively be run on an existing (caller-supplied) thread
+instead of a dedicated one:
+
+* :c:func:`k_work_queue_run()` turns the calling thread into the workqueue's
+  thread; it does not return until the queue is stopped.
+* :c:func:`k_work_queue_prepare()` marks the queue started and records the calling
+  thread as its thread, but without entering the run loop. This allows work to
+  be submitted (and :c:func:`k_work_queue_thread_get` to be used) before the
+  same thread later calls :c:func:`k_work_queue_run()`.
+
 Submitting a Work Item
 ======================
 

--- a/doc/kernel/services/threads/workqueue.rst
+++ b/doc/kernel/services/threads/workqueue.rst
@@ -215,6 +215,24 @@ use of it.
     for example, if the new work items perform blocking operations that
     would delay other system workqueue processing to an unacceptable degree.
 
+Running the System Workqueue on the Main Thread
+===============================================
+
+By default the system workqueue runs on its own dedicated thread. When
+:kconfig:option:`CONFIG_SYSTEM_WORKQUEUE_ON_MAIN` is enabled, it instead runs on
+the main thread, saving the dedicated thread's stack. This suits applications
+whose ``main()`` returns after boot-time initialization and do not otherwise
+rely on the system workqueue from ``main()``.
+
+With this option:
+
+* The system workqueue is *prepared* (via :c:func:`k_work_queue_prepare`) on the
+  main thread before ``main()`` is entered, so work may be submitted from
+  ``main()`` and :c:func:`k_work_queue_thread_get` returns the main thread.
+* Once ``main()`` returns, the main thread enters the workqueue run loop and
+  does not return. Any work submitted during ``main()`` is preserved and
+  processed then.
+
 How to Use Workqueues
 *********************
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4161,9 +4161,35 @@ void k_work_queue_start(struct k_work_q *queue,
 			k_thread_stack_t *stack, size_t stack_size,
 			int prio, const struct k_work_queue_config *cfg);
 
+/** @brief prepare a work queue for running on the calling thread.
+ *
+ * Puts the work queue into the started state and records the calling thread as
+ * the queue's thread, but does not enter the run loop. This allows work to be
+ * submitted to the queue, and k_work_queue_thread_get() to be used, before the
+ * calling thread later enters the run loop via k_work_queue_run().
+ *
+ * The thread that prepares the queue must be the same thread that subsequently
+ * calls k_work_queue_run().
+ *
+ * Calling k_work_queue_run() without preparing first is still supported; it prepares
+ * the queue implicitly. Use k_work_queue_prepare() only when work must be queued
+ * before the run loop is entered.
+ *
+ * @param queue the queue to prepare
+ *
+ * @param cfg optional additional configuration parameters.  Pass @c
+ * NULL if not required, to use the defaults documented in
+ * k_work_queue_config.
+ */
+void k_work_queue_prepare(struct k_work_q *queue, const struct k_work_queue_config *cfg);
+
 /** @brief Run work queue using calling thread
  *
  * This will run the work queue forever unless stopped by @ref k_work_queue_stop.
+ *
+ * If the queue was previously prepared with k_work_queue_prepare() (by this same
+ * thread), any work submitted in the meantime is preserved and processed once
+ * the run loop starts. Otherwise the queue is prepared implicitly.
  *
  * @param queue the queue to run
  *

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -3460,6 +3460,10 @@ struct k_work;
 struct k_work_q;
 struct k_work_queue_config;
 extern struct k_work_q k_sys_work_q;
+/* Kernel boot-path hook for running the system workqueue on the main thread
+ * (CONFIG_SYSTEM_WORKQUEUE_ON_MAIN). Not intended for application use.
+ */
+void z_sys_work_q_run(void);
 /**
  * INTERNAL_HIDDEN @endcond
  */

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -528,6 +528,17 @@ config SYSTEM_WORKQUEUE_WORK_TIMEOUT_MS
 	  Set to 0 to disable work timeout for system workqueue. Option
 	  has no effect if WORKQUEUE_WORK_TIMEOUT is not enabled.
 
+config SYSTEM_WORKQUEUE_ON_MAIN
+	bool "Run system workqueue on the main thread"
+	help
+	  If enabled, the system workqueue runs on the main thread instead of a
+	  dedicated thread, saving the dedicated system workqueue thread's stack.
+
+	  This is intended for applications whose main() returns after boot-time
+	  initialization and do not otherwise rely on the system workqueue from
+	  main(): once main() returns, the main thread enters the system
+	  workqueue's run loop and does not return.
+
 endmenu
 
 menu "Barrier Operations"

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -52,7 +52,12 @@ atomic_t _cpus_active;
 #endif
 
 /* init/main and idle threads */
-K_THREAD_STACK_DEFINE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
+#if defined(CONFIG_SYSTEM_WORKQUEUE_ON_MAIN)
+#define MAIN_STACK_SIZE MAX(CONFIG_MAIN_STACK_SIZE, CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE)
+#else
+#define MAIN_STACK_SIZE CONFIG_MAIN_STACK_SIZE
+#endif
+K_THREAD_STACK_DEFINE(z_main_stack, MAIN_STACK_SIZE);
 struct k_thread z_main_thread;
 
 #ifdef CONFIG_MULTITHREADING
@@ -347,8 +352,14 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 	(void)main();
 #endif /* CONFIG_BOOTARGS */
 
-	/* Mark non-essential since main() has no more work to do */
-	z_thread_essential_clear(&z_main_thread);
+	if (IS_ENABLED(CONFIG_SYSTEM_WORKQUEUE_ON_MAIN)) {
+		/* main() has returned but the main thread is about to become
+		 * the (essential) system workqueue thread, so keep it essential.
+		 */
+	} else {
+		/* Mark non-essential since main() has no more work to do */
+		z_thread_essential_clear(&z_main_thread);
+	}
 
 #ifdef CONFIG_COVERAGE_DUMP
 	/* Dump coverage data once the main() has exited. */
@@ -356,6 +367,10 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 #elif defined(CONFIG_COVERAGE_SEMIHOST)
 	gcov_coverage_semihost();
 #endif /* CONFIG_COVERAGE_DUMP */
+
+	if (IS_ENABLED(CONFIG_SYSTEM_WORKQUEUE_ON_MAIN)) {
+		z_sys_work_q_run();
+	}
 } /* LCOV_EXCL_LINE ... because we just dumped final coverage data */
 
 #if defined(CONFIG_MULTITHREADING)

--- a/kernel/system_work_q.c
+++ b/kernel/system_work_q.c
@@ -14,25 +14,57 @@
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 
-static K_KERNEL_STACK_DEFINE(sys_work_q_stack,
-			     CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE);
+static const struct k_work_queue_config cfg = {
+	.name = "sysworkq",
+	.no_yield = IS_ENABLED(CONFIG_SYSTEM_WORKQUEUE_NO_YIELD),
+	.essential = true,
+	.work_timeout_ms = CONFIG_SYSTEM_WORKQUEUE_WORK_TIMEOUT_MS,
+};
 
 struct k_work_q k_sys_work_q;
 
+#ifdef CONFIG_SYSTEM_WORKQUEUE_ON_MAIN
+
+void z_sys_work_q_run(void)
+{
+	/* main() has returned and the main thread is about to become the
+	 * system workqueue thread. Switch it from the main thread priority to
+	 * the configured system workqueue priority, matching the dedicated
+	 * thread case (k_work_queue_start() above).
+	 */
+	k_thread_priority_set(_current, CONFIG_SYSTEM_WORKQUEUE_PRIORITY);
+
+	k_work_queue_run(&k_sys_work_q, &cfg);
+}
+
 static void sys_work_q_init(void)
 {
-	static const struct k_work_queue_config cfg = {
-		.name = "sysworkq",
-		.no_yield = IS_ENABLED(CONFIG_SYSTEM_WORKQUEUE_NO_YIELD),
-		.essential = true,
-		.work_timeout_ms = CONFIG_SYSTEM_WORKQUEUE_WORK_TIMEOUT_MS,
-	};
+	k_work_queue_init(&k_sys_work_q);
 
+	/* Arm the queue on the main thread now, before main() runs. This marks
+	 * it started (so work can be submitted during main()), and records the
+	 * main thread as the queue thread, so k_work_queue_thread_get() is
+	 * valid and code running in main() can detect it is in the system
+	 * workqueue's context. The run loop is entered later, once main()
+	 * returns, via z_sys_work_q_run().
+	 */
+	k_work_queue_prepare(&k_sys_work_q, &cfg);
+}
+
+#else /* !CONFIG_SYSTEM_WORKQUEUE_ON_MAIN */
+
+static K_KERNEL_STACK_DEFINE(sys_work_q_stack,
+			     CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE);
+
+static void sys_work_q_init(void)
+{
 	k_work_queue_start(&k_sys_work_q,
 			    sys_work_q_stack,
 			    K_KERNEL_STACK_SIZEOF(sys_work_q_stack),
 			    CONFIG_SYSTEM_WORKQUEUE_PRIORITY, &cfg);
 }
+
+#endif /* CONFIG_SYSTEM_WORKQUEUE_ON_MAIN */
 
 /* Registered into the kernel post-init section. The entry lives in this TU,
  * so it (and this init) is linked only when something references the system

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -813,18 +813,15 @@ void k_work_queue_init(struct k_work_q *queue)
 	SYS_PORT_TRACING_OBJ_INIT(k_work_queue, queue);
 }
 
-void k_work_queue_run(struct k_work_q *queue, const struct k_work_queue_config *cfg)
+void k_work_queue_prepare(struct k_work_q *queue, const struct k_work_queue_config *cfg)
 {
+	__ASSERT_NO_MSG(queue != NULL);
 	__ASSERT_NO_MSG(!flag_test(&queue->flags, K_WORK_QUEUE_STARTED_BIT));
 
 	uint32_t flags = K_WORK_QUEUE_STARTED;
 
 	if ((cfg != NULL) && cfg->no_yield) {
 		flags |= K_WORK_QUEUE_NO_YIELD;
-	}
-
-	if ((cfg != NULL) && (cfg->name != NULL)) {
-		k_thread_name_set(_current, cfg->name);
 	}
 
 #if defined(CONFIG_WORKQUEUE_WORK_TIMEOUT)
@@ -838,8 +835,38 @@ void k_work_queue_run(struct k_work_q *queue, const struct k_work_queue_config *
 	sys_slist_init(&queue->pending);
 	z_waitq_init(&queue->notifyq);
 	z_waitq_init(&queue->drainq);
+
+	/* Record the thread that will run the queue up front, so submissions
+	 * and k_work_queue_thread_get() are valid before k_work_queue_run() is
+	 * entered. This is the same "state is in place, ready to roll" contract
+	 * that k_work_queue_start() provides before its thread gets control.
+	 *
+	 * Note: this is the thread that calls k_work_queue_prepare(). It must be
+	 * the same thread that later calls k_work_queue_run().
+	 */
 	queue->thread_id = _current;
 	flags_set(&queue->flags, flags);
+}
+
+void k_work_queue_run(struct k_work_q *queue, const struct k_work_queue_config *cfg)
+{
+	__ASSERT_NO_MSG(queue != NULL);
+
+	/* Allow the queue to have been prepared ahead of time (so that work could
+	 * be submitted before this run loop is entered). If it has not been
+	 * prepared yet, prepare it now; either way k_work_queue_prepare() has recorded
+	 * the running thread's identity.
+	 */
+	if (!flag_test(&queue->flags, K_WORK_QUEUE_STARTED_BIT)) {
+		k_work_queue_prepare(queue, cfg);
+	}
+
+	__ASSERT_NO_MSG(queue->thread_id == _current);
+
+	if ((cfg != NULL) && (cfg->name != NULL)) {
+		k_thread_name_set(_current, cfg->name);
+	}
+
 	work_queue_main(queue, NULL, NULL);
 }
 

--- a/tests/kernel/workq/work_queue/src/start_stop.c
+++ b/tests/kernel/workq/work_queue/src/start_stop.c
@@ -206,4 +206,86 @@ ZTEST(workqueue_api, test_k_work_delayable_remaining)
 		      "cancelled delayable should report no remaining time");
 }
 
+static K_THREAD_STACK_DEFINE(prepare_stack, STACK_SIZE);
+static atomic_t prepare_work_ran;
+
+static void prepare_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+	atomic_inc(&prepare_work_ran);
+}
+
+static void prepare_q_main(void *workq_ptr, void *sync_ptr, void *submit_ptr)
+{
+	struct k_work_q *queue = (struct k_work_q *)workq_ptr;
+	struct k_sem *prepared = (struct k_sem *)sync_ptr;
+	struct k_sem *submitted = (struct k_sem *)submit_ptr;
+	struct k_work_queue_config cfg = {
+		.name = "wq.prepare_q",
+	};
+
+	/* Prepare without entering the run loop yet, and let the main test thread
+	 * know it can now submit work.
+	 */
+	k_work_queue_prepare(queue, &cfg);
+	k_sem_give(prepared);
+
+	k_sem_take(submitted, K_FOREVER);
+
+	/* Enter the run loop; must process the already-queued work. */
+	k_work_queue_run(queue, &cfg);
+}
+
+/**
+ * @brief Verify a work queue can be prepared before its run loop is entered
+ *
+ * @details prepare a work queue on a helper thread without entering the run loop,
+ * then from another thread verify that (a) k_work_queue_thread_get() already
+ * reports the prepared thread, and (b) work submitted before the run loop is
+ * entered is accepted (not -ENODEV) and later executed once the run loop runs.
+ *
+ * @ingroup kernel_workqueue_tests
+ * @see k_work_queue_prepare(), k_work_queue_run(), k_work_queue_thread_get()
+ */
+ZTEST(workqueue_api, test_k_work_queue_prepare)
+{
+	static struct k_thread thread;
+	static struct k_work_q work_q;
+	struct k_work work;
+	struct k_sem prepared;
+	struct k_sem submitted;
+	k_tid_t tid;
+
+	work_q = (struct k_work_q){};
+	atomic_clear(&prepare_work_ran);
+	k_sem_init(&prepared, 0, 1);
+	k_sem_init(&submitted, 0, 1);
+
+	tid = k_thread_create(&thread, prepare_stack, STACK_SIZE, prepare_q_main, &work_q,
+			      &prepared, &submitted, K_PRIO_COOP(3), 0, K_NO_WAIT);
+
+	/* Wait until the helper thread has prepared the queue. */
+	zassert_ok(k_sem_take(&prepared, K_FOREVER), "queue was never prepared");
+
+	/* Identity is valid after prepare, before the run loop is entered. */
+	zassert_equal(k_work_queue_thread_get(&work_q), tid,
+		      "k_work_queue_thread_get() invalid before run loop");
+
+	/* Submitting before the run loop is entered must be accepted. */
+	k_work_init(&work, prepare_work_handler);
+	zassert_equal(k_work_submit_to_queue(&work_q, &work), 1,
+		      "Failed to submit work to a prepared (not yet running) queue");
+	k_sem_give(&submitted);
+
+	/* The helper thread enters the run loop after CHECK_WAIT and must then
+	 * process the work that was queued while only prepared.
+	 */
+	k_sleep(K_MSEC(CHECK_WAIT));
+	zassert_equal(atomic_get(&prepare_work_ran), 1,
+		      "work queued before the run loop was not processed");
+
+	zassert_true(k_work_queue_drain(&work_q, true) >= 0, "Failed to drain & plug");
+	zassert_ok(k_work_queue_stop(&work_q, K_FOREVER), "Failed to stop work queue");
+}
+
 ZTEST_SUITE(workqueue_api, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Add `CONFIG_SYSTEM_WORKQUEUE_ON_MAIN`, which runs the system workqueue on the
main thread instead of spawning a dedicated thread, reclaiming the dedicated
thread's stack. This targets applications whose `main()` returns after boot-time
initialization and do not otherwise rely on the system workqueue from `main()`
(e.g. memory-constrained targets). On such a build, once `main()` returns the
main thread enters the system workqueue run loop and does not return.

Measured saving: ~1 KB RAM on a basic Bluetooth app.

### Contents

* **kernel: work: allow arming a work queue before its run loop** — add
  `k_work_queue_prepare()`, which marks a queue started and records the calling
  thread as its thread *without* entering the run loop. This lets work be
  submitted (and `k_work_queue_thread_get()` be used) before the same thread
  later calls `k_work_queue_run()`. Previously `k_work_queue_run()` did this
  setup itself, so work submitted beforehand was rejected (`-ENODEV`) and would
  have been discarded by its list re-initialization. `k_work_queue_run()` now
  detects an already-armed queue and skips the setup, so existing callers are
  unaffected.

* **kernel: Add option to run the system workqueue on the main thread** — the
  `CONFIG_SYSTEM_WORKQUEUE_ON_MAIN` option itself. `k_sys_work_q_init()` prepares the
  queue on the main thread before `main()` runs; `k_sys_work_q_run()` enters the
  run loop after `main()` returns. The main thread is kept essential (it becomes
  the essential system workqueue thread).

* **tests: kernel: workq: cover arming a work queue before its run loop** — adds
  `test_k_work_queue_prepare` verifying that the queue thread identity is valid after
  preparing, and that work submitted before the run loop is accepted and later
  processed.

### Notes

* `k_work_queue_prepare()` is generally useful on its own for running a workqueue on
  a caller-supplied thread that must accept submissions before its run loop.