### PR TITLE
Add support for AMD MicroBlaze V 

### DIFF
--- a/boards/amd/mbv32/Kconfig.defconfig
+++ b/boards/amd/mbv32/Kconfig.defconfig
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if BOARD_MBV32
+
+config 2ND_LVL_INTR_00_OFFSET
+	default 11
+
+config 2ND_LVL_ISR_TBL_OFFSET
+	default 12
+
+config MAX_IRQ_PER_AGGREGATOR
+	default 32
+
+endif # BOARD_MBV32

--- a/boards/amd/mbv32/Kconfig.mbv32
+++ b/boards/amd/mbv32/Kconfig.mbv32
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config BOARD_MBV32
+	select SOC_MBV32

--- a/boards/amd/mbv32/board.cmake
+++ b/boards/amd/mbv32/board.cmake
@@ -1,0 +1,5 @@
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/boards/amd/mbv32/board.cmake
+++ b/boards/amd/mbv32/board.cmake
@@ -3,3 +3,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+
+include(${ZEPHYR_BASE}/boards/common/xsdb.board.cmake)

--- a/boards/amd/mbv32/board.yml
+++ b/boards/amd/mbv32/board.yml
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+board:
+  name: mbv32
+  full_name: AMD MicroBlaze V Board
+  vendor: amd
+  socs:
+    - name: mbv32

--- a/boards/amd/mbv32/doc/index.rst
+++ b/boards/amd/mbv32/doc/index.rst
@@ -1,0 +1,60 @@
+.. mbv32:
+
+AMD mbv32
+#########
+
+Overview
+********
+
+mbv32 board is based on Microblaze V design preset example from AMD Vivado™ Design Suite targeted
+for "AMD Kintex UltraScale FPGA KCU105" evaluation kit. Said design preset example is built
+with realtime configuration (with fast interrupt disabled). Example design system consists of
+following IP blocks:
+
+.. code-block:: console
+
+        AMD MicroBlaze V processsor core FPGA IP
+        AXI INTC FPGA IP
+        AXI Timer FPGA IP
+        AXI I2C FPGA IP
+        AXI UARTLITE FPGA IP
+        AXI GPIO FPGA IP
+        AXI QSPI FPGA IP
+
+Also, it consists of following memory blocks,
+
+.. code-block:: console
+
+        Local BRAM Memory (128 KB)
+        DDR Memory (2 GB)
+
+mbv32 realtime example design
+=============================
+
+Prebuilt mbv32 example design system is available in AMD Vivado™ Design Suite. It can be also found
+at AMD Microblaze RISC-V wiki page. It consist of bitstream file needed for FPGA configuration.
+
+Download Zephyr elf file and run application
+============================================
+
+To download the Zephyr Executable and Linkable Format .elf file, please use following west command.
+
+.. code-block:: console
+
+        west flash --runner xsdb --elf-file mbv32/zephyr/zephyr.elf --bitstream <path>/system.bit
+
+References
+==========
+
+- `AMD MicroBlaze™ V Processor`_
+- `AMD Vivado™ Design Suite`_
+- `AMD Kintex UltraScale FPGA KCU105 Evaluation Kit`_
+
+.. _AMD MicroBlaze™ V Processor:
+   https://www.amd.com/en/products/software/adaptive-socs-and-fpgas/microblaze-v.html
+
+.. _AMD Vivado™ Design Suite:
+   https://www.amd.com/en/products/software/adaptive-socs-and-fpgas/vivado.html
+
+.. _AMD Kintex UltraScale FPGA KCU105 Evaluation Kit:
+   https://www.xilinx.com/products/boards-and-kits/kcu105.html

--- a/boards/amd/mbv32/mbv32.dts
+++ b/boards/amd/mbv32/mbv32.dts
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026, Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	model = "AMD MicroBlaze V 32bit";
+	compatible = "qemu,mbv", "amd,mbv";
+
+	cpus: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		timebase-frequency = <100000000>;
+
+		cpu_0: cpu@0 {
+			compatible = "riscv";
+			device_type = "cpu";
+			reg = <0>;
+			riscv,isa-base = "rv32i";
+			riscv,isa-extensions = "m", "a", "c", "zicsr", "zifencei";
+			clock-frequency = <100000000>;
+
+			cpu0_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+				#interrupt-cells = <1>;
+			};
+		};
+	};
+
+	aliases {
+		serial0 = &uart0;
+	};
+
+	chosen {
+		bootargs = "earlycon=sbi console=ttyUL0,115200";
+		stdout-path = "serial0:115200n8";
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,sram = &ram0;
+	};
+
+	ram0: memory@80000000 {
+		device_type = "memory";
+		reg = <0x80000000 0x80000000>;
+	};
+
+	lmb0: memory@0 {
+		compatible = "mmio-sram";
+		reg = <0 0x20000>;
+	};
+
+	clk100: clk {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <100000000>;
+	};
+
+	axi: soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "simple-bus";
+		ranges;
+		bootph-all;
+
+		axi_intc: interrupt-controller@41200000 {
+			compatible = "xlnx,xps-intc-1.00.a";
+			reg = <0x41200000 0x1000>;
+			interrupt-controller;
+			interrupt-parent = <&cpu0_intc>;
+			#interrupt-cells = <2>;
+			interrupts-extended = <&cpu0_intc 11>;
+			xlnx,has-ivr = <1>;
+			xlnx,has-sie = <1>;
+			xlnx,has-cie = <1>;
+			xlnx,has-ipr = <1>;
+			xlnx,num-intr-inputs = <11>;
+		};
+
+		xlnx_timer0: timer@41c00000 {
+			compatible = "amd,xps-timer-1.00.a";
+			reg = <0x41c00000 0x1000>;
+			interrupt-parent = <&axi_intc>;
+			interrupts = <0 2>;
+			xlnx,one-timer-only = <0>;
+			clocks = <&clk100>;
+		};
+
+		uart0: serial@40600000 {
+			compatible = "xlnx,xps-uartlite-1.00.a";
+			reg = <0x40600000 0x1000>;
+			interrupt-parent = <&axi_intc>;
+			interrupts = <1 2>;
+			clocks = <&clk100>;
+			current-speed = <115200>;
+		};
+
+		axi_gpio: gpio@40010000 {
+			compatible = "xlnx,xps-gpio-1.00.a";
+			reg = <0x40010000 0x10000>;
+			gpio-controller;
+			interrupt-parent = <&axi_intc>;
+			interrupts = <0x4 0x2>;
+			#gpio-cells = <0x2>;
+			xlnx,all-inputs = <0x0>;
+			xlnx,tri-default = <0xffffffff>;
+			xlnx,gpio2-width = <0x20>;
+			xlnx,dout-default-2 = <0x0>;
+			xlnx,all-outputs-2 = <0x0>;
+			xlnx,all-inputs-2 = <0x0>;
+			xlnx,tri-default-2 = <0xffffffff>;
+			xlnx,is-dual = <0x0>;
+			xlnx,dout-default = <0x0>;
+			xlnx,gpio-width = <0x2>;
+			xlnx,all-outputs = <0x0>;
+		};
+	};
+};

--- a/boards/amd/mbv32/mbv32.yaml
+++ b/boards/amd/mbv32/mbv32.yaml
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+identifier: mbv32
+name: MBV32 softcore CPU
+type: mcu
+simulation:
+  - name: qemu
+arch: riscv
+toolchain:
+  - zephyr
+ram: 2097152
+testing:
+  timeout_multiplier: 6
+  ignore_tags:
+    - bluetooth
+    - coredump
+    - crypto
+    - jwt
+    - logging
+    - lwm2m
+    - mcumgr
+    - sensor
+    - shell
+    - smf
+    - tinycrypt
+    - xip
+    - zdsp
+vendor: amd
+supported:
+  - gpio

--- a/boards/amd/mbv32/mbv32_defconfig
+++ b/boards/amd/mbv32/mbv32_defconfig
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_XIP=n
+CONFIG_CONSOLE=y
+CONFIG_SERIAL=y
+CONFIG_UART_CONSOLE=y

--- a/boards/amd/mbv32/support/xsdb.cfg
+++ b/boards/amd/mbv32/support/xsdb.cfg
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+proc load_image args  {
+	set elffile [lindex $args 0]
+	set bit_or_pdi_file [lindex $args 1]
+	if { [info exists ::env(HW_SERVER_URL)] } {
+		connect -url $::env(HW_SERVER_URL)
+	} else {
+		connect
+	}
+	after 2000
+	if {[string match "*.pdi" $bit_or_pdi_file]} {
+		device program $bit_or_pdi_file
+	} else {
+		fpga -f $bit_or_pdi_file -no-revision-check
+	}
+	after 2000
+	targets -set -nocase -filter {name =~ "Hart*" && parent =~ "*USER2*"}
+	after 2000
+	rst -proc
+	dow $elffile
+	con
+	exit
+}
+
+load_image {*}$argv

--- a/soc/xlnx/mbv32/CMakeLists.txt
+++ b/soc/xlnx/mbv32/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+zephyr_sources(
+  ${ZEPHYR_BASE}/soc/common/riscv-privileged/soc_irq.S
+  ${ZEPHYR_BASE}/soc/common/riscv-privileged/vector.S
+)
+
+zephyr_library()
+zephyr_library_sources(soc.c)
+zephyr_library_include_directories(${ZEPHYR_BASE}/arch/common/include)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")

--- a/soc/xlnx/mbv32/Kconfig
+++ b/soc/xlnx/mbv32/Kconfig
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config SOC_MBV32
+	select RISCV
+	select INCLUDE_RESET_VECTOR
+	select CLOCK_CONTROL
+	select CLOCK_CONTROL_FIXED_RATE_CLOCK

--- a/soc/xlnx/mbv32/Kconfig.defconfig
+++ b/soc/xlnx/mbv32/Kconfig.defconfig
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if SOC_MBV32
+
+config NUM_IRQS
+	default 44
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+
+endif # SOC_MBV32

--- a/soc/xlnx/mbv32/Kconfig.soc
+++ b/soc/xlnx/mbv32/Kconfig.soc
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config SOC_MBV32
+	bool
+
+config SOC
+	default "mbv32" if SOC_MBV32

--- a/soc/xlnx/mbv32/soc.c
+++ b/soc/xlnx/mbv32/soc.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief MicroBlaze V interrupt handling support
+ *
+ * Connects the RISC-V interrupt architecture layer with the
+ * Xilinx AXI Interrupt Controller used as a second-level
+ * interrupt controller.
+ */
+
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/riscv/irq.h>
+#include <zephyr/device.h>
+#include <zephyr/irq.h>
+#include <zephyr/irq_multilevel.h>
+#include <zephyr/irq_nextlevel.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include "sw_isr_common.h"
+
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
+
+/**
+ * @brief Enable an interrupt.
+ *
+ * First-level interrupts are enabled through the RISC-V MIE CSR.
+ * Second-level interrupts are enabled through the associated
+ * AXI Interrupt Controller instance.
+ *
+ * @param irq Interrupt number.
+ */
+void arch_irq_enable(unsigned int irq)
+{
+	unsigned int level = irq_get_level(irq);
+
+	if (level == 1U) {
+		/*
+		 * CSR mie register is updated using the atomic CSRRS
+		 * instruction (atomic read and set bits in CSR register).
+		 */
+		(void)csr_read_set(mie, BIT(irq));
+
+	} else if (level == 2U) {
+		const struct device *dev = z_get_sw_isr_device_from_irq(irq);
+		unsigned int line = irq_from_level_2(irq);
+
+		if (dev == NULL) {
+			LOG_ERR("no interrupt controller for irq %u", irq);
+			return;
+		}
+
+		irq_enable_next_level(dev, line);
+	} else {
+		LOG_ERR("unsupported IRQ %u level %u", irq, level);
+	}
+}
+
+/**
+ * @brief Disable an interrupt.
+ *
+ * First-level interrupts are disabled through the RISC-V MIE CSR.
+ * Second-level interrupts are disabled through the associated
+ * AXI Interrupt Controller instance.
+ *
+ * @param irq Interrupt number.
+ */
+void arch_irq_disable(unsigned int irq)
+{
+	unsigned int level = irq_get_level(irq);
+
+	if (level == 1U) {
+		/*
+		 * CSR mie register is updated using the atomic CSRRC
+		 * instruction (atomic read and clear bits in CSR register).
+		 */
+		(void)csr_read_clear(mie, BIT(irq));
+
+	} else if (level == 2U) {
+		const struct device *dev = z_get_sw_isr_device_from_irq(irq);
+		unsigned int line = irq_from_level_2(irq);
+
+		if (dev == NULL) {
+			LOG_ERR("no interrupt controller for irq %u", irq);
+			return;
+		}
+
+		irq_disable_next_level(dev, line);
+	} else {
+		LOG_ERR("unsupported IRQ %u level %u", irq, level);
+	}
+}
+
+/**
+ * @brief Query interrupt enable state.
+ *
+ * First-level interrupts are queried from the RISC-V MIE CSR.
+ * Second-level interrupts are queried from the associated
+ * AXI Interrupt Controller instance.
+ *
+ * @param irq Interrupt number.
+ *
+ * @retval 1 Interrupt is enabled.
+ * @retval 0 Interrupt is disabled.
+ */
+int arch_irq_is_enabled(unsigned int irq)
+{
+	unsigned int level = irq_get_level(irq);
+
+	if (level == 1U) {
+		return (int)((csr_read(mie) & BIT(irq)) != 0U);
+	}
+
+	if (level == 2U) {
+		const struct device *dev = z_get_sw_isr_device_from_irq(irq);
+		unsigned int line = irq_from_level_2(irq);
+
+		if (dev == NULL) {
+			LOG_ERR("no interrupt controller for irq %u", irq);
+			return 0;
+		}
+
+		return (int)irq_line_is_enabled_next_level(dev, line);
+	}
+
+	LOG_ERR("unsupported IRQ %u level %u", irq, level);
+
+	return 0;
+}

--- a/soc/xlnx/mbv32/soc.yml
+++ b/soc/xlnx/mbv32/soc.yml
@@ -1,0 +1,2 @@
+socs:
+- name: mbv32


### PR DESCRIPTION
MicroBlaze V is a new AMD/Xilinx soft-core 32-bit RISC-V processor IP.
It is hardware compatible (from a wiring perspective) with the classic
MicroBlaze processor.

This patchset adds MBV32 SoC and board support for an initial hardware
design containing OCM (128 kB), DDR (2 GB), CPU, Xilinx interrupt
controller, AXI timer, and UARTLite console. Flash support is not yet
available.

Patchset depends on:

- Interrupt controller driver: #113120
- Timer driver: #113123

XSDB flash runner support was contributed by Kedar.

Board documentation was contributed by Mubin.