### PR TITLE
drivers: entropy: gecko_trng: init on read for gecko-sdk as well

### DIFF
--- a/drivers/entropy/entropy_gecko_trng.c
+++ b/drivers/entropy/entropy_gecko_trng.c
@@ -95,9 +95,7 @@ static int entropy_gecko_trng_get_entropy(const struct device *dev,
 
 	ARG_UNUSED(dev);
 
-#ifdef CONFIG_CRYPTO_ACC_GECKO_TRNG
 	entropy_gecko_trng_init(dev);
-#endif
 
 	while (length) {
 #ifndef CONFIG_CRYPTO_ACC_GECKO_TRNG


### PR DESCRIPTION
When the trng peripheral is not enabled, the read becomes an infinite loop for gecko-sdk based SoCs.

I don't have a reliable way to reproduce this and thus don't know what the root cause is. The only thing I found, is that while it's stuck in an infinite loop, the clock is enabled in the CMU register, but the TRNG is disabled in it's control register. So hopefully, this fixes the issue.