### PR TITLE
drivers: pcie: host: shell: add physical power gating command for pci…

### DIFF
--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -22,6 +22,15 @@ struct pcie_cap_id_to_str {
 	char *str;
 };
 
+/* Standard PCI Power Management Capability ID */
+#define PCI_CAP_ID_PM 0x01U
+
+/* Power Management Control/Status Register (PMCSR) Relative Offsets & Masks */
+ #define PCI_PM_CTRL_STATUS_REG (0x04U / 4U)
+#define PCI_PM_STATE_MASK      0x03U
+#define PCI_PM_STATE_D0        0x00U
+#define PCI_PM_STATE_D3HOT     0x03U
+
 static const struct pcie_cap_id_to_str pcie_cap_list[] = {
 	{ PCI_CAP_ID_PM,     "Power Management" },
 	{ PCI_CAP_ID_AGP,    "Accelerated Graphics Port" },
@@ -391,12 +400,82 @@ static int cmd_pcie_ls(const struct shell *sh, size_t argc, char **argv)
 
 	return 0;
 }
+
+/* Subcommand: pcie device state <bus:dev.func> up|down */
+static int cmd_pcie_device_state(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id;
+	uint32_t pm_offset;
+	uint32_t pmcsr;
+	uint32_t target_state;
+
+	if (argc < 3) {
+		shell_error(sh, "Usage: pcie device state <bus:dev.func> up|down");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF format mapping specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	pm_offset = pcie_get_cap(bdf, PCI_CAP_ID_PM);
+	if (pm_offset == 0) {
+		shell_error(sh, "Target device does not support PCI Power Management.");
+		return -EOPNOTSUPP;
+	}
+
+	if (strcmp(argv[2], "up") == 0) {
+		target_state = PCI_PM_STATE_D0;
+	} else if (strcmp(argv[2], "down") == 0) {
+		target_state = PCI_PM_STATE_D3HOT;
+	} else {
+		shell_error(sh, "Invalid state token. Use 'up' for D0 or 'down' for D3hot.");
+		return -EINVAL;
+	}
+
+	pmcsr = pcie_conf_read(bdf, pm_offset + PCI_PM_CTRL_STATUS_REG);
+	pmcsr &= ~PCI_PM_STATE_MASK;
+	pmcsr |= target_state;
+	pcie_conf_write(bdf, pm_offset + PCI_PM_CTRL_STATUS_REG, pmcsr);
+
+	pmcsr = pcie_conf_read(bdf, pm_offset + PCI_PM_CTRL_STATUS_REG);
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCI HARDWARE TRANSCEIVER ENERGY REGISTRY STATUS: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   Current PMCSR Value Readout  : 0x%08X", pmcsr);
+	shell_print(sh, "   Physical Silicon Transceiver: [%s]",
+		    (pmcsr & PCI_PM_STATE_MASK) == PCI_PM_STATE_D3HOT
+			    ? "POWER GATED - D3hot LOW ENERGY SUSPEND"
+			    : "FULLY OPERATIONAL - D0 MAX PERFORMANCE");
+	shell_print(sh, "====================================================================");
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_device_cmds,
+	SHELL_CMD_ARG(state, NULL, "Power gate physical device state (up = D0, down = D3hot)",
+		      cmd_pcie_device_state, 3, 0),
+	SHELL_SUBCMD_SET_END);
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_pcie_cmds,
-	SHELL_CMD_ARG(ls, NULL,
-		      "List PCIE devices\n"
-		      "Usage: ls [bus:device:function] [dump]",
-		      cmd_pcie_ls, 1, 2),
-	SHELL_SUBCMD_SET_END /* Array terminated. */
-);
+			       SHELL_CMD_ARG(ls, NULL,
+					     "List PCIE devices\n"
+					     "Usage: ls [bus:device:function] [dump]",
+					     cmd_pcie_ls, 1, 2),
+			       SHELL_CMD(device, &sub_pcie_device_cmds,
+					 "Manage pcie physical hardware device states", NULL),
+			       SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(pcie, &sub_pcie_cmds, "PCI(e) device information", cmd_pcie_ls);


### PR DESCRIPTION
 This patch adds a powerful, hardware-level energy-gating subcommand to our central utility tree: `pcie device state <bus:dev.func> up|down`.

While we have software-only filter mechanisms like dynamic device masking to hide malfunctioning controllers during the boot sequence, our shell utilities currently lack any mechanism to manipulate real hardware power states at the silicon level. 

This command directly targets the physical layer. By writing straight to the device's Power Management Control/Status Register (PMCSR), we can dynamically toggle transceivers between fully operational execution states and low-power hardware leakage states. This provides crucial hardware bring-up instrumentation for verifying physical energy-gating loops and power grid states on high-reliability embedded platforms.

### What This Patch Does
* **Traditional Capability Space Traversal:** Scans the base configuration capability list registers to isolate the native PCI Power Management Block (Capability ID `0x01`).
* **Silicon State Mutation:** Implements safe read-modify-write mechanics over the PMCSR, mutating bits `[1:0]` cleanly between `00b` (D0 Max Performance) and `11b` (D3hot Low Energy Suspend).
* **Deterministic Verification Readback:** Performs an immediate hardware status readback right after the bit mutation, verifying the true electrical state of the device transceiver.
* **Shell Parsing Hardening:** Enforces strict argument validation, setting positional constraint matrices tightly to `3, 0` boundaries to prevent execution errors.

### Terminal Output Trace

```text
uart:~\$ pcie device state 0:1.0 up 
====================================================================
   PCI HARDWARE TRANSCEIVER ENERGY REGISTRY STATUS: 0:1.0
====================================================================
   Current PMCSR Value Readout  : 0x00000000
   Physical Silicon Transceiver: [FULLY OPERATIONAL - D0 MAX PERFORMANCE]
====================================================================
uart:~\$ pcie device state 0:1.0 down 
====================================================================
   PCI HARDWARE TRANSCEIVER ENERGY REGISTRY STATUS: 0:1.0
====================================================================
   Current PMCSR Value Readout  : 0x00000003
   Physical Silicon Transceiver: [POWER GATED - D3hot LOW ENERGY SUSPEND]
====================================================================
```
