### PR TITLE
secure_storage: make the nonce provider thread-safe

### DIFF
--- a/subsys/secure_storage/Kconfig.its_transform
+++ b/subsys/secure_storage/Kconfig.its_transform
@@ -78,6 +78,7 @@ config SECURE_STORAGE_ITS_TRANSFORM_AEAD_KEY_PROVIDER_DEVICE_ID_HASH
 
 config SECURE_STORAGE_ITS_TRANSFORM_AEAD_KEY_PROVIDER_ENTRY_UID_HASH
 	bool "Hash of the ITS entry UID (not secure)"
+	select NOT_SECURE
 	select PSA_WANT_ALG_SHA_256
 	help
 	  This key provider generates keys by hashing the UID of the ITS entry for which it is

--- a/subsys/secure_storage/src/its/transform/aead_get.c
+++ b/subsys/secure_storage/src/its/transform/aead_get.c
@@ -4,6 +4,7 @@
 #include <zephyr/secure_storage/its/transform/aead_get.h>
 #include <zephyr/drivers/hwinfo.h>
 #include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <psa/crypto.h>
 #include <string.h>
@@ -123,14 +124,17 @@ SYS_INIT(warn_insecure_key, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
 psa_status_t secure_storage_its_transform_aead_get_nonce(
 		uint8_t nonce[static CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_NONCE_SIZE])
 {
-	psa_status_t ret;
+	psa_status_t ret = PSA_SUCCESS;
 	static uint8_t s_nonce[CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_NONCE_SIZE];
 	static bool s_nonce_initialized;
+	static K_MUTEX_DEFINE(s_nonce_mutex);
+
+	k_mutex_lock(&s_nonce_mutex, K_FOREVER);
 
 	if (!s_nonce_initialized) {
 		ret = psa_generate_random(s_nonce, sizeof(s_nonce));
 		if (ret != PSA_SUCCESS) {
-			return ret;
+			goto exit;
 		}
 		s_nonce_initialized = true;
 	} else {
@@ -141,8 +145,10 @@ psa_status_t secure_storage_its_transform_aead_get_nonce(
 			}
 		}
 	}
-
 	memcpy(nonce, &s_nonce, sizeof(s_nonce));
-	return PSA_SUCCESS;
+
+exit:
+	k_mutex_unlock(&s_nonce_mutex);
+	return ret;
 }
 #endif /* CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_NONCE_PROVIDER_DEFAULT */


### PR DESCRIPTION
The nonce is stored in a static variable, so multiple threads generating a nonce at the same time could potentially interfere with one another and the final nonce values used.

Fixes #113464