### PR TITLE
soc: nxp: imxrt: add ability to disable second core boot

### DIFF
--- a/soc/nxp/imxrt/Kconfig
+++ b/soc/nxp/imxrt/Kconfig
@@ -163,6 +163,15 @@ config SECOND_CORE_MCUX_REMOTE_DIR
 	  Sets the remote directory to include the output image header data
 	  from when launching a second core image
 
+config SOC_IMXRT118X_SECOND_CORE_KICKOFF
+	bool "Second core kickoff on the RT11xx series"
+	default y
+	depends on SECOND_CORE_MCUX && SOC_SERIES_IMXRT118X
+	help
+	  Indicates the second core will be started by the primary core at its system
+	  initialization. Otherwise, secondary core kickoff can be done independently
+	  at application level later.
+
 if SOC_SERIES_IMXRT10XX || SOC_SERIES_IMXRT11XX || SOC_SERIES_IMXRT118X
 
 config PM_MCUX_GPC

--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -875,8 +875,8 @@ void soc_reset_hook(void)
 }
 #endif
 
-#if defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M33)
-
+#if defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_SOC_IMXRT118X_SECOND_CORE_KICKOFF) && \
+	defined(CONFIG_CPU_CORTEX_M33)
 static int second_core_boot(void)
 {
 	/*


### PR DESCRIPTION
On the i.MX RT1180 (IMXRT118X), the CM7 second core is unconditionally kicked off by the CM33 primary core at system initialization. This does not allow use cases where the application needs to control when the second core is started (e.g. deferred boot, conditional launch).

Add a new Kconfig option CONFIG_SECOND_CORE_MCUX_KICKOFF (default y) to gate the automatic CM7 kickoff at SoC init time. When disabled, the second core kickoff can be triggered independently at the application level.

The default value preserves existing behavior for all current users.

Note: Other NXP SoCs with second core support (e.g. IMXRT10XX, IMXRT11XX, MCXN) likely benefit from the same mechanism, but are not included here as they could not be tested.