### PR TITLE
Bluetooth: Audio: print location as hex

### DIFF
--- a/samples/bluetooth/audio/hap_ha/src/vcp_vol_renderer.c
+++ b/samples/bluetooth/audio/hap_ha/src/vcp_vol_renderer.c
@@ -107,7 +107,7 @@ static void vocs_location_cb(struct bt_vocs *inst, int err, uint32_t location)
 	if (err != 0) {
 		printk("VOCS location get failed (%d) for inst %p\n", err, inst);
 	} else {
-		printk("VOCS inst %p location %u\n", inst, location);
+		printk("VOCS inst %p location 0x%08X\n", inst, location);
 	}
 }
 

--- a/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
@@ -274,7 +274,7 @@ static void vcs_vocs_location_cb(struct bt_vocs *inst, int err,
 	if (err != 0) {
 		bt_shell_error("VOCS location get failed (%d) for inst %p", err, inst);
 	} else {
-		bt_shell_print("VOCS inst %p location %u", inst, location);
+		bt_shell_print("VOCS inst %p location 0x%08X", inst, location);
 	}
 }
 

--- a/subsys/bluetooth/audio/shell/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_rend.c
@@ -125,7 +125,7 @@ static void vocs_location_cb(struct bt_vocs *inst, int err, uint32_t location)
 	if (err != 0) {
 		bt_shell_error("VOCS location get failed (%d) for inst %p", err, inst);
 	} else {
-		bt_shell_print("VOCS inst %p location %u", inst, location);
+		bt_shell_print("VOCS inst %p location 0x%08X", inst, location);
 	}
 }
 


### PR DESCRIPTION
Modify the print of the location as hex instead of base 10.