### PR TITLE
soc: nxp: imxrt118x: move cm7 init in POST_KERNEL

### DIFF
--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -910,5 +910,5 @@ static int second_core_boot(void)
 	return 0;
 }
 
-SYS_INIT(second_core_boot, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(second_core_boot, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);
 #endif


### PR DESCRIPTION
On i.MX RT1180, the CM7 second core boot is triggered at PRE_KERNEL_2 level. This is too early, as when
CONFIG_MEMC_MCUX_FLEXSPI_INIT_XIP is enabled, the FlexSPI controller has not yet been initialized by the CM33 primary core, causing instruction fetch faults on the CM7 side.

Move the second_core_boot SYS_INIT hook from PRE_KERNEL_2 to POST_KERNEL with CONFIG_APPLICATION_INIT_PRIORITY, ensuring that common peripherals on the primary core are fully initialized before the second core is started.