### PR TITLE
zbus: Fix message subscribers net buf isolated pools usage

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -368,6 +368,11 @@ Libraries / Subsystems
 
   * Introducing a video subsystem that inherits all the function names previously in
     video drivers.
+* ZBus
+
+  * :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION` now works without requiring
+    a dedicated pool on every channel (channels fall back to the shared pool until
+    :c:func:`zbus_chan_set_msg_sub_pool` is called)
 
 Devicetree
 **********

--- a/doc/services/zbus/index.rst
+++ b/doc/services/zbus/index.rst
@@ -1143,7 +1143,8 @@ Related configuration options:
 * :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_SIZE` the available number of message
   buffers to be used simultaneously;
 * :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION` enables the developer to isolate
-  a pool for the message subscriber for a set of channels;
+  a pool for the message subscriber for a set of channels; a channel only switches to a dedicated pool once
+  :c:func:`zbus_chan_set_msg_sub_pool` has been called for it;
 * :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_STATIC_DATA_SIZE` the biggest message of zbus
   channels to be transported into a message buffer;
 * :kconfig:option:`CONFIG_HEAP_MEM_POOL_ADD_SIZE_ZBUS` the reserved heap size for ZBus in a whole

--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -313,9 +313,11 @@ struct zbus_channel_observation {
 		.sem = Z_SEM_INITIALIZER(_CONCAT(_zbus_chan_data_, _name).sem, 1, 1),              \
 		IF_ENABLED(CONFIG_ZBUS_PRIORITY_BOOST,                                             \
 			   (.highest_observer_priority = ZBUS_MIN_THREAD_PRIORITY,))               \
-		 IF_ENABLED(CONFIG_ZBUS_RUNTIME_OBSERVERS,                                         \
+		IF_ENABLED(CONFIG_ZBUS_RUNTIME_OBSERVERS,                                          \
 			   (.observers = SYS_SLIST_STATIC_INIT(                                    \
 				&_CONCAT(_zbus_chan_data_, _name).observers),))                    \
+		IF_ENABLED(CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION,                      \
+			   (.msg_subscriber_pool = NULL,))                                         \
 	};                                                                                         \
 	_ZBUS_CPP_EXTERN const STRUCT_SECTION_ITERABLE(zbus_channel, _name) = {                    \
 		ZBUS_CHANNEL_NAME_INIT(_name) /* Maybe removed */                                  \
@@ -325,8 +327,6 @@ struct zbus_channel_observation {
 		.user_data = _user_data,                                                           \
 		.validator = _validator,                                                           \
 		.data = &_CONCAT(_zbus_chan_data_, _name),                                         \
-		IF_ENABLED(ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION,                             \
-			   (.msg_subscriber_pool = &_zbus_msg_subscribers_pool,))                  \
 	}
 /* clang-format on */
 

--- a/samples/subsys/zbus/msg_subscriber/Kconfig
+++ b/samples/subsys/zbus/msg_subscriber/Kconfig
@@ -12,4 +12,9 @@ config ZBUS_MSG_SUBSCRIBER_SAMPLE_ISOLATED_BUF_POOL_SIZE
 	default 32
 	depends on ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION
 
+config ZBUS_MSG_SUBSCRIBER_SAMPLE_ISOLATED_BUF_POOL_USE_DEFAULT
+	bool "Use default size for isolated pool"
+	default y
+	depends on ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION
+
 source "Kconfig.zephyr"

--- a/samples/subsys/zbus/msg_subscriber/src/main.c
+++ b/samples/subsys/zbus/msg_subscriber/src/main.c
@@ -188,7 +188,12 @@ int main(void)
 
 	total_allocated = 0;
 #if defined(CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION)
-	zbus_chan_set_msg_sub_pool(&acc_data_chan, &isolated_pool);
+	if (IS_ENABLED(CONFIG_ZBUS_MSG_SUBSCRIBER_SAMPLE_ISOLATED_BUF_POOL_USE_DEFAULT)) {
+		LOG_INF("Using the default msg buf pool for acc_data_chan");
+	} else {
+		LOG_INF("Using an isolated msg buf pool for channel acc_data_chan");
+		zbus_chan_set_msg_sub_pool(&acc_data_chan, &isolated_pool);
+	}
 #endif
 
 #if defined(CONFIG_ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC)

--- a/samples/subsys/zbus/msg_subscriber/tests.yaml
+++ b/samples/subsys/zbus/msg_subscriber/tests.yaml
@@ -191,9 +191,102 @@ tests:
       type: multi_line
       ordered: false
       regex:
+        - "^.*?I: Using the default msg buf pool for acc_data_chan"
         - "^.*?I: ----> Publishing to acc_data_chan channel"
         - "^.*?I:  AL Memory allocated \\d{1,3} bytes. Total allocated \\d{1,3} bytes$"
         - "^.*?I:  FR Memory freed \\d{1,3} bytes. Total allocated 0 bytes$"
+        - "^.*?D:  0 -> bar_sub1"
+        - "^.*?D:  1 -> bar_msg_sub1"
+        - "^.*?D:  2 -> bar_msg_sub2"
+        - "^.*?D:  3 -> bar_msg_sub3"
+        - "^.*?D:  4 -> bar_msg_sub4"
+        - "^.*?D:  5 -> bar_msg_sub5"
+        - "^.*?D:  6 -> bar_msg_sub6"
+        - "^.*?D:  7 -> bar_msg_sub7"
+        - "^.*?D:  8 -> bar_msg_sub8"
+        - "^.*?D:  9 -> bar_msg_sub9"
+        - "^.*?D:  10 -> foo_lis"
+        - "^.*?D:  11 -> bar_msg_sub10"
+        - "^.*?D:  12 -> bar_msg_sub11"
+        - "^.*?D:  13 -> bar_msg_sub12"
+        - "^.*?D:  14 -> bar_msg_sub13"
+        - "^.*?D:  15 -> bar_msg_sub14"
+        - "^.*?D:  16 -> bar_msg_sub15"
+        - "^.*?D:  17 -> bar_msg_sub16"
+        - "^.*?D:  18 -> bar_sub2"
+        - "^.*?I: From listener foo_lis -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub1 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub2 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub3 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub4 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub5 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub6 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub7 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub8 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub9 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub10 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub11 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub12 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub13 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub14 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub15 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub16 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From subscriber bar_sub1 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From subscriber bar_sub2 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From listener foo_lis -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub1 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub2 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub3 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub4 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub5 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub6 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub7 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub8 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub9 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub10 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub11 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub12 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub13 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub14 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub15 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub16 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From subscriber bar_sub1 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From subscriber bar_sub2 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From listener foo_lis -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub1 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub2 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub3 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub4 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub5 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub6 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub7 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub8 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub9 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub10 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub11 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub12 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub13 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub14 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub15 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub16 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From subscriber bar_sub1 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From subscriber bar_sub2 -> Acc x=3, y=30, z=300"
+    tags: zbus
+    integration_platforms:
+      - qemu_x86
+  sample.zbus.msg_subscriber_dynamic_isolated_too_small_use_default:
+    filter: not CONFIG_SMP
+    harness: console
+    extra_configs:
+      - CONFIG_ZBUS_LOG_LEVEL_DBG=y
+      - CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION=y
+      - CONFIG_ZBUS_MSG_SUBSCRIBER_SAMPLE_ISOLATED_BUF_POOL_SIZE=2
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "^.*?I: Using the default msg buf pool for acc_data_chan"
+        - "^.*?I: ----> Publishing to acc_data_chan channel"
         - "^.*?D:  0 -> bar_sub1"
         - "^.*?D:  1 -> bar_msg_sub1"
         - "^.*?D:  2 -> bar_msg_sub2"
@@ -280,10 +373,12 @@ tests:
       - CONFIG_ZBUS_LOG_LEVEL_DBG=y
       - CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION=y
       - CONFIG_ZBUS_MSG_SUBSCRIBER_SAMPLE_ISOLATED_BUF_POOL_SIZE=2
+      - CONFIG_ZBUS_MSG_SUBSCRIBER_SAMPLE_ISOLATED_BUF_POOL_USE_DEFAULT=n
     harness_config:
       type: multi_line
       ordered: false
       regex:
+        - "^.*?I: Using an isolated msg buf pool for channel acc_data_chan"
         - "^.*?I: ----> Publishing to acc_data_chan channel"
         - "^.*?I:  AL Memory allocated \\d{1,3} bytes. Total allocated \\d{1,3} bytes$"
         - "^.*?I:  FR Memory freed \\d{1,3} bytes. Total allocated 0 bytes$"
@@ -301,10 +396,106 @@ tests:
       - CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_STATIC_DATA_SIZE=16
       - CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION=y
       - CONFIG_ZBUS_MSG_SUBSCRIBER_SAMPLE_ISOLATED_BUF_POOL_SIZE=32
+      - CONFIG_ZBUS_MSG_SUBSCRIBER_SAMPLE_ISOLATED_BUF_POOL_USE_DEFAULT=n
     harness_config:
       type: multi_line
       ordered: false
       regex:
+        - "^.*?I: Using an isolated msg buf pool for channel acc_data_chan"
+        - "^.*?I: ----> Publishing to acc_data_chan channel"
+        - "^.*?D:  0 -> bar_sub1"
+        - "^.*?D:  1 -> bar_msg_sub1"
+        - "^.*?D:  2 -> bar_msg_sub2"
+        - "^.*?D:  3 -> bar_msg_sub3"
+        - "^.*?D:  4 -> bar_msg_sub4"
+        - "^.*?D:  5 -> bar_msg_sub5"
+        - "^.*?D:  6 -> bar_msg_sub6"
+        - "^.*?D:  7 -> bar_msg_sub7"
+        - "^.*?D:  8 -> bar_msg_sub8"
+        - "^.*?D:  9 -> bar_msg_sub9"
+        - "^.*?D:  10 -> foo_lis"
+        - "^.*?D:  11 -> bar_msg_sub10"
+        - "^.*?D:  12 -> bar_msg_sub11"
+        - "^.*?D:  13 -> bar_msg_sub12"
+        - "^.*?D:  14 -> bar_msg_sub13"
+        - "^.*?D:  15 -> bar_msg_sub14"
+        - "^.*?D:  16 -> bar_msg_sub15"
+        - "^.*?D:  17 -> bar_msg_sub16"
+        - "^.*?D:  18 -> bar_sub2"
+        - "^.*?I: From listener foo_lis -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub1 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub2 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub3 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub4 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub5 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub6 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub7 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub8 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub9 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub10 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub11 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub12 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub13 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub14 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub15 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From msg subscriber bar_msg_sub16 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From subscriber bar_sub1 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From subscriber bar_sub2 -> Acc x=1, y=10, z=100"
+        - "^.*?I: From listener foo_lis -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub1 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub2 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub3 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub4 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub5 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub6 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub7 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub8 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub9 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub10 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub11 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub12 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub13 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub14 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub15 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From msg subscriber bar_msg_sub16 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From subscriber bar_sub1 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From subscriber bar_sub2 -> Acc x=2, y=20, z=200"
+        - "^.*?I: From listener foo_lis -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub1 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub2 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub3 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub4 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub5 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub6 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub7 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub8 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub9 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub10 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub11 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub12 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub13 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub14 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub15 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From msg subscriber bar_msg_sub16 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From subscriber bar_sub1 -> Acc x=3, y=30, z=300"
+        - "^.*?I: From subscriber bar_sub2 -> Acc x=3, y=30, z=300"
+    tags: zbus
+    integration_platforms:
+      - qemu_x86
+  sample.zbus.msg_subscriber_static_isolated_too_small_use_default:
+    filter: not CONFIG_SMP
+    harness: console
+    extra_configs:
+      - CONFIG_ZBUS_LOG_LEVEL_DBG=y
+      - CONFIG_ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_STATIC=y
+      - CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_STATIC_DATA_SIZE=16
+      - CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION=y
+      - CONFIG_ZBUS_MSG_SUBSCRIBER_SAMPLE_ISOLATED_BUF_POOL_SIZE=2
+    harness_config:
+      type: multi_line
+      ordered: false
+      regex:
+        - "^.*?I: Using the default msg buf pool for acc_data_chan"
         - "^.*?I: ----> Publishing to acc_data_chan channel"
         - "^.*?D:  0 -> bar_sub1"
         - "^.*?D:  1 -> bar_msg_sub1"
@@ -394,10 +585,12 @@ tests:
       - CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_STATIC_DATA_SIZE=16
       - CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION=y
       - CONFIG_ZBUS_MSG_SUBSCRIBER_SAMPLE_ISOLATED_BUF_POOL_SIZE=2
+      - CONFIG_ZBUS_MSG_SUBSCRIBER_SAMPLE_ISOLATED_BUF_POOL_USE_DEFAULT=n
     harness_config:
       type: multi_line
       ordered: false
       regex:
+        - "^.*?I: Using an isolated msg buf pool for channel acc_data_chan"
         - "^.*?I: ----> Publishing to acc_data_chan channel"
         - "^.*?D:  0 -> bar_sub1"
         - "^.*?D:  1 -> bar_msg_sub1"

--- a/subsys/zbus/zbus.c
+++ b/subsys/zbus/zbus.c
@@ -397,9 +397,15 @@ static inline int _zbus_vded_exec(const struct zbus_channel *chan, k_timepoint_t
 	struct zbus_channel_observation_mask *observation_mask;
 
 #if defined(CONFIG_ZBUS_MSG_SUBSCRIBER)
-	struct net_buf_pool *pool =
-		COND_CODE_1(CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION,
-			    (chan->data->msg_subscriber_pool), (&_zbus_msg_subscribers_pool));
+	/* Always the common subscriber pool */
+	struct net_buf_pool *pool = &_zbus_msg_subscribers_pool;
+
+#if defined(CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION)
+	/* Channel specific pool if set, otherwise common pool */
+	if (chan->data->msg_subscriber_pool != NULL) {
+		pool = chan->data->msg_subscriber_pool;
+	}
+#endif
 
 	buf = _zbus_create_net_buf(pool, zbus_chan_msg_size(chan), sys_timepoint_timeout(end_time));
 


### PR DESCRIPTION
The net buf isolated pools feature definition inside the channel was wrong. That was causing a false sensation that the feature was set up correctly, but it was never set. It was forcing the developer to set an isolated pool to all the msg subscribers, which is a wrong behavior.

This commit fixes that by adjusting the configuration usage, adding the `CONFIG_` prefix, and placing the initialization in the proper place (the `zbus_channel_data`, instead of the `zbus_channel` directly). It also adapts the test to capture the issue and avoid regressions.

It addresses the issue mentioned in #107533 PR. The direction the PR was taking would take more time to converge than opening another one.  

Please @MarkoSagadin, review this one and check if it solves what you were meant to solve.