### PR TITLE
arch/arm: Enable PSCI based SMP support

### DIFF
--- a/arch/arm/core/CMakeLists.txt
+++ b/arch/arm/core/CMakeLists.txt
@@ -24,6 +24,7 @@ zephyr_library_sources_ifdef(CONFIG_ARM_ZIMAGE_HEADER header.S)
 zephyr_library_sources_ifdef(CONFIG_LLEXT elf.c)
 zephyr_library_sources_ifdef(CONFIG_GDBSTUB gdbstub.c)
 zephyr_library_sources_ifdef(CONFIG_ARCH_STACKWALK stacktrace.c)
+zephyr_library_sources_ifdef(CONFIG_HAS_ARM_SMCCC smccc-call.S)
 
 zephyr_cc_option_ifdef(CONFIG_ARCH_STACKWALK -funwind-tables)
 

--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -72,8 +72,15 @@ config CPU_AARCH32_CORTEX_A
 	select ARCH_HAS_GDBSTUB
 	# GDB on ARM needs the extra registers
 	select EXTRA_EXCEPTION_INFO if GDBSTUB
+	select HAS_ARM_SMCCC
 	help
 	  This option signifies the use of a CPU of the Cortex-A family.
+
+config HAS_ARM_SMCCC
+	bool
+	help
+	  Include support for the Secure Monitor Call (SMC) and Hypervisor
+	  Call (HVC) instructions on Armv7 and above architectures.
 
 config GDBSTUB_BUF_SZ
 	# GDB for ARM expects up to 18 4-byte plus 8 12-byte

--- a/arch/arm/core/cortex_a_r/Kconfig
+++ b/arch/arm/core/cortex_a_r/Kconfig
@@ -91,7 +91,7 @@ config AARCH32_ARMV8_A_MONITOR_INIT
 
 config ARMV7_A_NS
 	bool "ARMv7-A Non-Secure state (Non-secure world of TrustZone)"
-	depends on ARMV7_A
+	depends on ARMV7_A || AARCH32_ARMV8_A
 	help
 	  Zephyr is running in ARM TrustZone Non-Secure state on an ARMv7-A core.
 

--- a/arch/arm/core/cortex_a_r/Kconfig
+++ b/arch/arm/core/cortex_a_r/Kconfig
@@ -19,6 +19,7 @@ config CPU_CORTEX_A7
 	select ARMV7_A
 	select CPU_HAS_ICACHE
 	select CPU_HAS_DCACHE
+	select SCHED_IPI_SUPPORTED if SMP
 	help
 	  This option signifies the use of a Cortex-A7 CPU.
 
@@ -37,6 +38,7 @@ config CPU_CORTEX_A32
 	select AARCH32_ARMV8_A
 	select CPU_HAS_ICACHE
 	select CPU_HAS_DCACHE
+	select SCHED_IPI_SUPPORTED if SMP
 	help
 	  This option signifies the use of a Cortex-A32 CPU.
 

--- a/arch/arm/core/cortex_a_r/Kconfig
+++ b/arch/arm/core/cortex_a_r/Kconfig
@@ -297,5 +297,12 @@ config ICACHE_LINE_SIZE
 
 endif # CPU_AARCH32_CORTEX_R
 
+config WAIT_AT_RESET_VECTOR
+	bool "Wait at reset vector"
+	default n
+	help
+	  Spin at reset vector waiting for debugger to attach and resume
+	  execution
+
 config TEST_EXTRA_STACK_SIZE
 	default 1024 if SMP

--- a/arch/arm/core/cortex_a_r/prep_c.c
+++ b/arch/arm/core/cortex_a_r/prep_c.c
@@ -35,7 +35,7 @@
 extern void z_arm_mpu_init(void);
 extern void z_arm_configure_static_mpu_regions(void);
 #elif defined(CONFIG_ARM_AARCH32_MMU)
-extern int z_arm_mmu_init(void);
+extern int z_arm_mmu_init(bool is_primary_core);
 #endif
 
 #if defined(CONFIG_CPU_HAS_FPU)
@@ -122,7 +122,7 @@ FUNC_NORETURN void z_prep_c(void)
 	z_arm_mpu_init();
 	z_arm_configure_static_mpu_regions();
 #elif defined(CONFIG_ARM_AARCH32_MMU)
-	z_arm_mmu_init();
+	z_arm_mmu_init(true);
 #endif
 	z_cstart();
 	CODE_UNREACHABLE;

--- a/arch/arm/core/cortex_a_r/prep_c.c
+++ b/arch/arm/core/cortex_a_r/prep_c.c
@@ -35,7 +35,7 @@
 extern int z_arm_mpu_init(void);
 extern void z_arm_configure_static_mpu_regions(void);
 #elif defined(CONFIG_ARM_AARCH32_MMU)
-extern int z_arm_mmu_init(void);
+extern int z_arm_mmu_init(bool is_primary_core);
 #endif
 
 #if defined(CONFIG_CPU_HAS_FPU)
@@ -122,7 +122,7 @@ FUNC_NORETURN void z_prep_c(void)
 	z_arm_mpu_init();
 	z_arm_configure_static_mpu_regions();
 #elif defined(CONFIG_ARM_AARCH32_MMU)
-	z_arm_mmu_init();
+	z_arm_mmu_init(true);
 #endif
 	z_cstart();
 	CODE_UNREACHABLE;

--- a/arch/arm/core/cortex_a_r/reset.S
+++ b/arch/arm/core/cortex_a_r/reset.S
@@ -66,6 +66,13 @@ __start:
 SECTION_SUBSEC_FUNC(TEXT, _reset_section, z_arm_reset)
 SECTION_SUBSEC_FUNC(TEXT, _reset_section, __start)
 #endif
+
+#ifdef CONFIG_WAIT_AT_RESET_VECTOR
+resetwait:
+    wfe
+    b resetwait
+#endif
+
 #if defined(CONFIG_AARCH32_ARMV8_A_MONITOR_INIT)
     /*
      * ARMv8-A AArch32 Monitor mode (EL3 AArch32) initialization.

--- a/arch/arm/core/cortex_a_r/reset.S
+++ b/arch/arm/core/cortex_a_r/reset.S
@@ -368,6 +368,31 @@ _primary_core:
     msr CPSR_c, #(MODE_SYS | I_BIT | F_BIT)
     mov sp, r10
 
+#ifdef CONFIG_INIT_STACKS
+    /*
+     * Fill this core's SYS mode stack with a known pattern so its high
+     * water mark can be determined later. This must happen here, before
+     * the stack is used, rather than later in C code (e.g.
+     * z_arm_init_stacks()): by the time C code runs on the primary core
+     * it is already executing on this very stack, so filling the whole
+     * slice at that point would clobber live call-stack contents,
+     * including its own return address. Here sp has just been set and
+     * nothing has been pushed yet, so the entire slice can be filled
+     * safely. This also correctly covers every core, since this code
+     * path is shared by both the primary and secondary core boot
+     * sequences above.
+     */
+    ldr r0, =CONFIG_ARMV7_SYS_STACK_SIZE
+    sub r0, r10, r0
+    ldr r1, =0xaaaaaaaa
+stack_init_loop:
+    cmp r0, r10
+    bhs stack_init_done
+    str r1, [r0], #4
+    b stack_init_loop
+stack_init_done:
+#endif
+
 #if defined(CONFIG_SOC_RESET_HOOK)
     /* Execute platform-specific initialisation if applicable */
     bl soc_reset_hook

--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/arch/arm/cortex_a_r/lib_helpers.h>
 #include <zephyr/drivers/interrupt_controller/gic.h>
+#include <zephyr/drivers/pm_cpu_ops.h>
 #include <ipi.h>
 #include "boot.h"
 #include <zephyr/cache.h>
@@ -153,13 +154,21 @@ void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz, arch_cpustart_
 	/* store mpid last as this is our synchronization point */
 	arm_cpu_boot_params.mpid = cpu_mpid;
 
-	sys_cache_data_invd_range(
+	sys_cache_data_flush_range(
 			(void *)&arm_cpu_boot_params,
 			sizeof(arm_cpu_boot_params));
 
-	/*! TODO: Support PSCI
-	 *  \todo Support PSCI
-	 */
+	/* flush and invalidate bootup stack for other CPUs (z_arm_sys_stack) */
+	sys_cache_data_flush_and_invd_range((void *)&z_arm_sys_stack[cpu_num],
+					    sizeof(z_arm_sys_stack[0]));
+
+#ifdef CONFIG_PM_CPU_OPS
+	if (pm_cpu_on(cpu_mpid, (uintptr_t)&__start)) {
+		printk("Failed to boot secondary CPU core %d (MPID:%#x)\n",
+		       cpu_num, cpu_mpid);
+		k_panic();
+	}
+#endif
 
 	/* Wait secondary cores up, see arch_secondary_cpu_init */
 	while (arm_cpu_boot_params.fn) {

--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -96,7 +96,7 @@ static uint32_t cpu_map[CONFIG_MP_MAX_NUM_CPUS] = {
 extern int z_arm_mpu_init(void);
 extern void z_arm_configure_static_mpu_regions(void);
 #elif defined(CONFIG_ARM_AARCH32_MMU)
-extern int z_arm_mmu_init(void);
+extern int z_arm_mmu_init(bool is_primary_core);
 #endif
 
 /* Called from Zephyr initialization */
@@ -200,7 +200,7 @@ void arch_secondary_cpu_init(void)
 	z_arm_mpu_init();
 	z_arm_configure_static_mpu_regions();
 #elif defined(CONFIG_ARM_AARCH32_MMU)
-	z_arm_mmu_init();
+	z_arm_mmu_init(false);
 #endif
 
 #ifdef CONFIG_SMP

--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -242,7 +242,7 @@ static void send_ipi(unsigned int ipi, uint32_t cpu_bitmap)
 		uint32_t target_mpidr = cpu_map[i];
 		uint8_t aff0;
 
-		if (mpidr == target_mpidr || mpidr == INV_MPID) {
+		if (mpidr == target_mpidr || target_mpidr == INV_MPID) {
 			continue;
 		}
 

--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/arch/arm/cortex_a_r/lib_helpers.h>
 #include <zephyr/drivers/interrupt_controller/gic.h>
+#include <zephyr/drivers/pm_cpu_ops.h>
 #include <ipi.h>
 #include "boot.h"
 #include <zephyr/cache.h>
@@ -148,13 +149,17 @@ void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz, arch_cpustart_
 	/* store mpid last as this is our synchronization point */
 	arm_cpu_boot_params.mpid = cpu_mpid;
 
-	sys_cache_data_invd_range(
+	sys_cache_data_flush_range(
 			(void *)&arm_cpu_boot_params,
 			sizeof(arm_cpu_boot_params));
 
-	/*! TODO: Support PSCI
-	 *  \todo Support PSCI
-	 */
+#ifdef CONFIG_PM_CPU_OPS
+	if (pm_cpu_on(cpu_mpid, (uintptr_t)&__start)) {
+		printk("Failed to boot secondary CPU core %d (MPID:%#x)\n",
+		       cpu_num, cpu_mpid);
+		k_panic();
+	}
+#endif
 
 	/* Wait secondary cores up, see arch_secondary_cpu_init */
 	while (arm_cpu_boot_params.fn) {

--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -91,7 +91,7 @@ static uint32_t cpu_map[CONFIG_MP_MAX_NUM_CPUS] = {
 extern void z_arm_mpu_init(void);
 extern void z_arm_configure_static_mpu_regions(void);
 #elif defined(CONFIG_ARM_AARCH32_MMU)
-extern int z_arm_mmu_init(void);
+extern int z_arm_mmu_init(bool is_primary_core);
 #endif
 
 /* Called from Zephyr initialization */
@@ -191,7 +191,7 @@ void arch_secondary_cpu_init(void)
 	z_arm_mpu_init();
 	z_arm_configure_static_mpu_regions();
 #elif defined(CONFIG_ARM_AARCH32_MMU)
-	z_arm_mmu_init();
+	z_arm_mmu_init(false);
 #endif
 
 #ifdef CONFIG_SMP

--- a/arch/arm/core/cortex_a_r/stacks.c
+++ b/arch/arm/core/cortex_a_r/stacks.c
@@ -24,11 +24,14 @@ K_KERNEL_STACK_ARRAY_DEFINE(z_arm_sys_stack, CONFIG_MP_MAX_NUM_CPUS,
 #if defined(CONFIG_INIT_STACKS)
 void z_arm_init_stacks(void)
 {
-	memset(z_arm_fiq_stack, 0xAA, CONFIG_ARMV7_FIQ_STACK_SIZE);
-	memset(z_arm_svc_stack, 0xAA, CONFIG_ARMV7_SVC_STACK_SIZE);
-	memset(z_arm_abort_stack, 0xAA, CONFIG_ARMV7_EXCEPTION_STACK_SIZE);
-	memset(z_arm_undef_stack, 0xAA, CONFIG_ARMV7_EXCEPTION_STACK_SIZE);
-	memset(K_KERNEL_STACK_BUFFER(z_interrupt_stacks[0]), 0xAA,
-	       K_KERNEL_STACK_SIZEOF(z_interrupt_stacks[0]));
+	memset(z_arm_fiq_stack, 0xAA, sizeof(z_arm_fiq_stack));
+	memset(z_arm_svc_stack, 0xAA, sizeof(z_arm_svc_stack));
+	memset(z_arm_abort_stack, 0xAA, sizeof(z_arm_abort_stack));
+	memset(z_arm_undef_stack, 0xAA, sizeof(z_arm_undef_stack));
+
+	for (int i = 0; i < CONFIG_MP_MAX_NUM_CPUS; i++) {
+		memset(K_KERNEL_STACK_BUFFER(z_interrupt_stacks[i]), 0xAA,
+		       K_KERNEL_STACK_SIZEOF(z_interrupt_stacks[i]));
+	}
 }
 #endif

--- a/arch/arm/core/mmu/arm_mmu.c
+++ b/arch/arm/core/mmu/arm_mmu.c
@@ -740,15 +740,16 @@ static void arm_mmu_l2_unmap_page(uint32_t va)
 }
 
 /**
- * @brief MMU boot-time initialization function
- * Initializes the MMU at boot time. Sets up the page tables and
- * applies any specified memory mappings for either the different
- * sections of the Zephyr binary image, or for device memory as
- * specified at the SoC level.
+ * @brief Sets up the L1/L2 page tables for the initial MMU configuration
+ * Maps the image-defined and SoC-defined memory regions into the
+ * page tables.
  *
- * @retval Always 0, errors are handled by assertions.
+ * @retval Attribute flags (MATTR_*) of the memory region which contains
+ * the L1 page table, or 0 if the L1 page table is not located within any
+ * of the image-defined memory regions. These attributes are needed when
+ * writing to the TTBR0 register.
  */
-int z_arm_mmu_init(void)
+static uint32_t setup_page_tables(void)
 {
 	uint32_t mem_range;
 	uint32_t pa;
@@ -756,12 +757,7 @@ int z_arm_mmu_init(void)
 	uint32_t attrs;
 	uint32_t pt_attrs = 0;
 	uint32_t rem_size;
-	uint32_t reg_val = 0;
 	struct arm_mmu_perms_attrs perms_attrs;
-
-	__ASSERT(KB(4) == CONFIG_MMU_PAGE_SIZE,
-		 "MMU_PAGE_SIZE value %u is invalid, only 4 kB pages are supported\n",
-		 CONFIG_MMU_PAGE_SIZE);
 
 	/* Set up the memory regions pre-defined by the image */
 	for (mem_range = 0; mem_range < ARRAY_SIZE(mmu_zephyr_ranges); mem_range++) {
@@ -830,6 +826,33 @@ int z_arm_mmu_init(void)
 				pa += KB(4);
 			}
 		}
+	}
+
+	return pt_attrs;
+}
+
+/**
+ * @brief MMU boot-time initialization function
+ * Initializes the MMU at boot time. Sets up the page tables and
+ * applies any specified memory mappings for either the different
+ * sections of the Zephyr binary image, or for device memory as
+ * specified at the SoC level.
+ *
+ * @param is_primary_core Whether this is the primary (booting) core.
+ *
+ * @retval Always 0, errors are handled by assertions.
+ */
+int z_arm_mmu_init(bool is_primary_core)
+{
+	uint32_t reg_val = 0;
+	static uint32_t pt_attrs;
+
+	__ASSERT(KB(4) == CONFIG_MMU_PAGE_SIZE,
+		 "MMU_PAGE_SIZE value %u is invalid, only 4 kB pages are supported\n",
+		 CONFIG_MMU_PAGE_SIZE);
+
+	if (is_primary_core) {
+		pt_attrs = setup_page_tables();
 	}
 
 	/* Clear TTBR1 */

--- a/arch/arm/core/mmu/arm_mmu.c
+++ b/arch/arm/core/mmu/arm_mmu.c
@@ -21,9 +21,11 @@
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
+#include <zephyr/cache.h>
 
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/spinlock.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel/mm.h>
@@ -60,6 +62,13 @@ static uint32_t arm_mmu_l2_tables_free = CONFIG_ARM_MMU_NUM_L2_TABLES;
 static uint32_t arm_mmu_l2_next_free_table;
 
 /*
+ * Guards all L1/L2 page table content & the L2 table allocation state
+ * above against concurrent access from multiple cores. Must be held
+ * across any read-modify-write sequence touching the page tables.
+ */
+static struct k_spinlock arm_mmu_lock;
+
+/*
  * Static definition of all code & data memory regions of the
  * current Zephyr image. This information must be available &
  * processed upon MMU initialization.
@@ -69,61 +78,69 @@ static const struct arm_mmu_flat_range mmu_zephyr_ranges[] = {
 	 * Mark the zephyr execution regions (data, bss, noinit, etc.)
 	 * cacheable, read / write and non-executable
 	 */
-	{ .name  = "zephyr_data",
-	  .start = (uint32_t)_image_ram_start,
-	  .end   = (uint32_t)_image_ram_end,
-	  .attrs = MT_NORMAL | MATTR_SHARED |
-		   MPERM_R | MPERM_W |
-		   MATTR_CACHE_OUTER_WB_WA | MATTR_CACHE_INNER_WB_WA},
-#if defined(CONFIG_AARCH32_ARMV8_A)
+	{.name = "zephyr_data",
+	 .start = (uint32_t)_image_ram_start,
+	 .end = (uint32_t)_image_ram_end,
+	 .attrs = MT_NORMAL | MATTR_SHARED | MPERM_R | MPERM_W | MATTR_CACHE_OUTER_WB_WA |
+		  MATTR_CACHE_INNER_WB_WA},
+#if defined(CONFIG_AARCH32_ARMV8_A) || defined(CONFIG_CPU_CORTEX_A7)
 	/* The ARMv8-A AArch32 implementation uses VBAR to hold the final vector
 	 * table address (_vector_start); map it here rather than requiring
 	 * each SoC to provide its own entry in mmu_regions.c.
 	 */
-	{ .name  = "vectors",
-	  .start = (uint32_t)_vector_start,
-	  .end   = (uint32_t)_vector_end,
-	  .attrs = MT_NORMAL | MATTR_SHARED |
-		   MPERM_R | MPERM_X |
-		   MATTR_CACHE_OUTER_WB_nWA | MATTR_CACHE_INNER_WB_nWA},
+	{.name = "vectors",
+	 .start = (uint32_t)_vector_start,
+	 .end = (uint32_t)_vector_end,
+	 .attrs = MT_NORMAL | MATTR_SHARED | MPERM_R | MPERM_X | MATTR_CACHE_OUTER_WB_nWA |
+		  MATTR_CACHE_INNER_WB_nWA},
 #endif
 
 	/* Mark text segment cacheable, read only and executable */
-	{ .name  = "zephyr_code",
-	  .start = (uint32_t)__text_region_start,
-	  .end   = (uint32_t)__text_region_end,
-	  .attrs = MT_NORMAL | MATTR_SHARED |
-	  /* The code needs to have write permission in order for
-	   * software breakpoints (which modify instructions) to work
-	   */
+	{.name = "zephyr_code",
+	 .start = (uint32_t)__text_region_start,
+	 .end = (uint32_t)__text_region_end,
+	 .attrs = MT_NORMAL | MATTR_SHARED |
+/* The code needs to have write permission in order for
+ * software breakpoints (which modify instructions) to work
+ */
 #if defined(CONFIG_GDBSTUB)
-		   MPERM_R | MPERM_X | MPERM_W |
+		  MPERM_R | MPERM_X | MPERM_W |
 #else
-		   MPERM_R | MPERM_X |
+		  MPERM_R | MPERM_X |
 #endif
-		   MATTR_CACHE_OUTER_WB_nWA | MATTR_CACHE_INNER_WB_nWA |
-		   MATTR_MAY_MAP_L1_SECTION},
+		  MATTR_CACHE_OUTER_WB_nWA | MATTR_CACHE_INNER_WB_nWA | MATTR_MAY_MAP_L1_SECTION},
 
 	/* Mark rodata segment cacheable, read only and non-executable */
-	{ .name  = "zephyr_rodata",
-	  .start = (uint32_t)__rodata_region_start,
-	  .end   = (uint32_t)__rodata_region_end,
-	  .attrs = MT_NORMAL | MATTR_SHARED |
-		   MPERM_R |
-		   MATTR_CACHE_OUTER_WB_nWA | MATTR_CACHE_INNER_WB_nWA |
-		   MATTR_MAY_MAP_L1_SECTION},
+	{.name = "zephyr_rodata",
+	 .start = (uint32_t)__rodata_region_start,
+	 .end = (uint32_t)__rodata_region_end,
+	 .attrs = MT_NORMAL | MATTR_SHARED | MPERM_R | MATTR_CACHE_OUTER_WB_nWA |
+		  MATTR_CACHE_INNER_WB_nWA | MATTR_MAY_MAP_L1_SECTION},
 #ifdef CONFIG_NOCACHE_MEMORY
 	/* Mark nocache segment read / write and non-executable */
-	{ .name  = "nocache",
-	  .start = (uint32_t)_nocache_ram_start,
-	  .end   = (uint32_t)_nocache_ram_end,
-	  .attrs = MT_STRONGLY_ORDERED |
-		   MPERM_R | MPERM_W},
+	{.name = "nocache",
+	 .start = (uint32_t)_nocache_ram_start,
+	 .end = (uint32_t)_nocache_ram_end,
+	 .attrs = MT_STRONGLY_ORDERED | MPERM_R | MPERM_W},
 #endif
 };
 
 static void arm_mmu_l2_map_page(uint32_t va, uint32_t pa,
 				struct arm_mmu_perms_attrs perms_attrs);
+
+#ifdef CONFIG_SMP
+/*
+ * TLBIALLIS: invalidate entire unified TLB, Inner Shareable.
+ * Not provided by the vendored CMSIS core_ca.h/cmsis_cp15.h (which only
+ * expose the local-only TLBIALL, CRn=8 CRm=7 op2=0). Broadcasting the
+ * invalidation to all cores in the Inner Shareable domain is required
+ * as soon as more than one core walks the same (shared) page tables.
+ */
+static inline void __set_TLBIALLIS(uint32_t value)
+{
+	__set_CP(15, 0, value, 8, 3, 0);
+}
+#endif
 
 /**
  * @brief Invalidates the TLB
@@ -131,10 +148,29 @@ static void arm_mmu_l2_map_page(uint32_t va, uint32_t pa,
  * is performed whenever the MMU is (re-)enabled or changes to the
  * page tables are made at run-time, as the TLB might contain entries
  * which are no longer valid once the changes are applied.
+ * Under CONFIG_SMP, the invalidation is broadcast to all cores in the
+ * Inner Shareable domain, as the page tables are shared between cores
+ * and a change made on one core must not leave stale TLB entries on
+ * another.
  */
 static void invalidate_tlb_all(void)
 {
+	/*
+	 * Ensure that any preceding page table writes have completed and are
+	 * visible to all cores in the (Inner) Shareable domain before the TLB
+	 * invalidate below is issued/broadcast. Without this, a core receiving
+	 * a broadcast invalidate could re-walk the page tables on a subsequent
+	 * TLB miss before the writing core's store has actually propagated,
+	 * observing stale data. Comp. ARM64's "dsb ishst" preceding its TLBI
+	 * in this driver's invalidate_tlb_all().
+	 */
+	barrier_dsync_fence_full();
+
+#ifdef CONFIG_SMP
+	__set_TLBIALLIS(0); /* 0 = opc2 = invalidate entire TLB, inner shareable */
+#else
 	__set_TLBIALL(0); /* 0 = opc2 = invalidate entire TLB */
+#endif
 	barrier_dsync_fence_full();
 	barrier_isync_fence_full();
 }
@@ -482,9 +518,11 @@ static void arm_mmu_remap_l1_section_to_l2_table(uint32_t va,
 	struct arm_mmu_perms_attrs perms_attrs = {0};
 	uint32_t l1_index = (va >> ARM_MMU_PTE_L1_INDEX_PA_SHIFT) &
 			    ARM_MMU_PTE_L1_INDEX_MASK;
-	uint32_t rem_size = MB(1);
-	uint32_t reg_val;
-	int lock_key;
+	union arm_mmu_l1_page_table_entry new_l1_pte = {0};
+	uint32_t l2_page_table_index = ARM_MMU_L2_PT_INDEX(l2_page_table);
+	uint32_t base_va;
+	uint32_t page_va;
+	uint32_t i;
 
 	/*
 	 * Extract the permissions and attributes from the current 1 MB section entry.
@@ -505,52 +543,58 @@ static void arm_mmu_remap_l1_section_to_l2_table(uint32_t va,
 	perms_attrs.exec_never = l1_page_table.entries[l1_index].l1_section_1m.exec_never;
 
 	/*
-	 * Disable interrupts - no interrupts shall occur before the L2 table has
-	 * been set up in place of the former L1 section entry.
+	 * Fully populate all 256 L2 entries for the 1 MB range with attributes
+	 * identical to those of the section entry being replaced, before the
+	 * L2 table is ever linked into the L1 table. The mappings covered by
+	 * a L1 section entry are always identity-mapped (va == pa), see the
+	 * caller-side restriction documented at #arm_mmu_l1_map_section().
 	 */
+	base_va = va & ~(MB(1) - 1);
+	for (i = 0; i < ARM_MMU_PT_L2_NUM_ENTRIES; i++) {
+		page_va = base_va + i * KB(4);
 
-	lock_key = arch_irq_lock();
+		l2_page_table->entries[i].l2_page_4k.id =
+			(ARM_MMU_PTE_ID_SMALL_PAGE & perms_attrs.id_mask);
+		l2_page_table->entries[i].l2_page_4k.id |= perms_attrs.exec_never;
+		l2_page_table->entries[i].l2_page_4k.bufferable = perms_attrs.bufferable;
+		l2_page_table->entries[i].l2_page_4k.cacheable = perms_attrs.cacheable;
+		l2_page_table->entries[i].l2_page_4k.acc_perms10 =
+			((perms_attrs.acc_perms & 0x1) << 1) | 0x1;
+		l2_page_table->entries[i].l2_page_4k.tex = perms_attrs.tex;
+		l2_page_table->entries[i].l2_page_4k.acc_perms2 =
+			((perms_attrs.acc_perms >> 1) & 0x1);
+		l2_page_table->entries[i].l2_page_4k.shared = perms_attrs.shared;
+		l2_page_table->entries[i].l2_page_4k.not_global = perms_attrs.not_global;
+		l2_page_table->entries[i].l2_page_4k.pa_base =
+			((page_va >> ARM_MMU_PTE_L2_SMALL_PAGE_ADDR_SHIFT) &
+			ARM_MMU_PTE_L2_SMALL_PAGE_ADDR_MASK);
+	}
+	l2_page_tables_status[l2_page_table_index].entries = ARM_MMU_PT_L2_NUM_ENTRIES;
 
 	/*
-	 * Disable the MMU. The L1 PTE array and the L2 PT array may actually be
-	 * covered by the L1 PTE we're about to replace, so access to this data
-	 * must remain functional during the entire remap process. Yet, the only
-	 * memory areas for which L1 1 MB section entries are even considered are
-	 * those belonging to the Zephyr image. Those areas are *always* identity
-	 * mapped, so the MMU can be turned off and the relevant data will still
-	 * be available.
+	 * Build the replacement L1 PTE in a local variable, then commit it
+	 * with a single aligned store. l1_page_table.entries[l1_index] never
+	 * observes an invalid or half-built state, so no core (this one or
+	 * any other sharing this page table) can walk into a transient fault
+	 * while the conversion is in progress, and the local MMU does not
+	 * need to be disabled.
 	 */
-
-	reg_val = __get_SCTLR();
-	__set_SCTLR(reg_val & (~ARM_MMU_SCTLR_MMU_ENABLE_BIT));
-
-	/*
-	 * Clear the entire L1 PTE & re-configure it as a L2 PT reference
-	 * -> already sets the correct values for: zero0, zero1, impl_def.
-	 */
-	l1_page_table.entries[l1_index].word = 0;
-
-	l1_page_table.entries[l1_index].l2_page_table_ref.id = ARM_MMU_PTE_ID_L2_PT;
-	l1_page_table.entries[l1_index].l2_page_table_ref.domain = perms_attrs.domain;
-	l1_page_table.entries[l1_index].l2_page_table_ref.non_sec = perms_attrs.non_sec;
-	l1_page_table.entries[l1_index].l2_page_table_ref.l2_page_table_address =
+	new_l1_pte.l2_page_table_ref.id = ARM_MMU_PTE_ID_L2_PT;
+	new_l1_pte.l2_page_table_ref.domain = perms_attrs.domain;
+	new_l1_pte.l2_page_table_ref.non_sec = perms_attrs.non_sec;
+	new_l1_pte.l2_page_table_ref.l2_page_table_address =
 		(((uint32_t)l2_page_table >> ARM_MMU_PT_L2_ADDR_SHIFT) &
 		ARM_MMU_PT_L2_ADDR_MASK);
 
-	/* Align the target VA to the base address of the section we're converting */
-	va &= ~(MB(1) - 1);
-	while (rem_size > 0) {
-		arm_mmu_l2_map_page(va, va, perms_attrs);
-		rem_size -= KB(4);
-		va += KB(4);
-	}
+	l1_page_table.entries[l1_index].word = new_l1_pte.word;
 
-	/* Remap complete, re-enable the MMU, unlock the interrupts. */
-
+	/*
+	 * Make the new L1 PTE and the now-linked L2 table globally visible
+	 * and drop any stale translations for this range from every core's
+	 * TLB before the caller continues to modify the freshly-split-out
+	 * L2 entries.
+	 */
 	invalidate_tlb_all();
-	__set_SCTLR(reg_val);
-
-	arch_irq_unlock(lock_key);
 }
 
 /**
@@ -901,6 +945,19 @@ int z_arm_mmu_init(bool is_primary_core)
 
 	invalidate_tlb_all();
 
+	/*
+	 * The state of the I/D-cache RAMs is architecturally undefined out of
+	 * reset/power-up. Invalidate both caches before turning them on below,
+	 * otherwise stale/undefined tag entries left over in this core's cache
+	 * (e.g. from its power-up state) could spuriously "hit" and be served
+	 * instead of the actual memory contents once the cache is enabled.
+	 */
+	sys_cache_data_invd_all();
+	sys_cache_instr_invd_all();
+
+	/* Ensure these changes are seen before MMU is enabled */
+	barrier_isync_fence_full();
+
 	/* Enable the MMU and Cache in SCTLR */
 	reg_val  = __get_SCTLR();
 	reg_val |= ARM_MMU_SCTLR_AFE_BIT;
@@ -908,6 +965,9 @@ int z_arm_mmu_init(bool is_primary_core)
 	reg_val |= ARM_MMU_SCTLR_DCACHE_ENABLE_BIT;
 	reg_val |= ARM_MMU_SCTLR_MMU_ENABLE_BIT;
 	__set_SCTLR(reg_val);
+
+	/* Ensure the MMU enable takes effect immediately */
+	barrier_isync_fence_full();
 
 	return 0;
 }
@@ -931,7 +991,7 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
 	uint32_t rem_size = (uint32_t)size;
 	uint32_t conv_flags = MPERM_R;
 	struct arm_mmu_perms_attrs perms_attrs;
-	int key;
+	k_spinlock_key_t key;
 
 	if (size == 0) {
 		LOG_ERR("Cannot map physical memory at 0x%08X: invalid "
@@ -977,7 +1037,7 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
 
 	perms_attrs = arm_mmu_convert_attr_flags(conv_flags);
 
-	key = arch_irq_lock();
+	key = k_spin_lock(&arm_mmu_lock);
 
 	while (rem_size > 0) {
 		arm_mmu_l2_map_page(va, pa, perms_attrs);
@@ -986,7 +1046,7 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
 		pa += KB(4);
 	}
 
-	arch_irq_unlock(key);
+	k_spin_unlock(&arm_mmu_lock, key);
 
 	return 0;
 }
@@ -1029,7 +1089,7 @@ static int __arch_mem_unmap(void *addr, size_t size)
 {
 	uint32_t va = (uint32_t)addr;
 	uint32_t rem_size = (uint32_t)size;
-	int key;
+	k_spinlock_key_t key;
 
 	if (addr == NULL) {
 		LOG_ERR("Cannot unmap virtual memory: invalid NULL pointer");
@@ -1042,7 +1102,7 @@ static int __arch_mem_unmap(void *addr, size_t size)
 		return -EINVAL;
 	}
 
-	key = arch_irq_lock();
+	key = k_spin_lock(&arm_mmu_lock);
 
 	while (rem_size > 0) {
 		arm_mmu_l2_unmap_page(va);
@@ -1050,7 +1110,7 @@ static int __arch_mem_unmap(void *addr, size_t size)
 		va += KB(4);
 	}
 
-	arch_irq_unlock(key);
+	k_spin_unlock(&arm_mmu_lock, key);
 
 	return 0;
 }
@@ -1100,9 +1160,9 @@ int arch_page_phys_get(void *virt, uintptr_t *phys)
 	uint32_t l2_pt_resolved;
 
 	int rc = 0;
-	int key;
+	k_spinlock_key_t key;
 
-	key = arch_irq_lock();
+	key = k_spin_lock(&arm_mmu_lock);
 
 	if (l1_page_table.entries[l1_index].undefined.id == ARM_MMU_PTE_ID_SECTION) {
 		/*
@@ -1147,7 +1207,7 @@ int arch_page_phys_get(void *virt, uintptr_t *phys)
 		rc = -EFAULT;
 	}
 
-	arch_irq_unlock(key);
+	k_spin_unlock(&arm_mmu_lock, key);
 
 	if (phys) {
 		*phys = (uintptr_t)pa_resolved;

--- a/arch/arm/core/mmu/arm_mmu.c
+++ b/arch/arm/core/mmu/arm_mmu.c
@@ -740,15 +740,16 @@ static void arm_mmu_l2_unmap_page(uint32_t va)
 }
 
 /**
- * @brief MMU boot-time initialization function
- * Initializes the MMU at boot time. Sets up the page tables and
- * applies any specified memory mappings for either the different
- * sections of the Zephyr binary image, or for device memory as
- * specified at the SoC level.
+ * @brief Sets up the L1/L2 page tables for the initial MMU configuration
+ * Maps the image-defined and SoC-defined memory regions into the
+ * page tables.
  *
- * @retval Always 0, errors are handled by assertions.
+ * @retval Attribute flags (MATTR_*) of the memory region which contains
+ * the L1 page table, or 0 if the L1 page table is not located within any
+ * of the image-defined memory regions. These attributes are needed when
+ * writing to the TTBR0 register.
  */
-int z_arm_mmu_init(void)
+static uint32_t setup_page_tables(void)
 {
 	uint32_t mem_range;
 	uint32_t pa;
@@ -756,12 +757,7 @@ int z_arm_mmu_init(void)
 	uint32_t attrs;
 	uint32_t pt_attrs = 0;
 	uint32_t rem_size;
-	uint32_t reg_val = 0;
 	struct arm_mmu_perms_attrs perms_attrs;
-
-	__ASSERT(KB(4) == CONFIG_MMU_PAGE_SIZE,
-		 "MMU_PAGE_SIZE value %u is invalid, only 4 kB pages are supported\n",
-		 CONFIG_MMU_PAGE_SIZE);
 
 	/* Set up the memory regions pre-defined by the image */
 	for (mem_range = 0; mem_range < ARRAY_SIZE(mmu_zephyr_ranges); mem_range++) {
@@ -814,6 +810,33 @@ int z_arm_mmu_init(void)
 			va += KB(4);
 			pa += KB(4);
 		}
+	}
+
+	return pt_attrs;
+}
+
+/**
+ * @brief MMU boot-time initialization function
+ * Initializes the MMU at boot time. Sets up the page tables and
+ * applies any specified memory mappings for either the different
+ * sections of the Zephyr binary image, or for device memory as
+ * specified at the SoC level.
+ *
+ * @param is_primary_core Whether this is the primary (booting) core.
+ *
+ * @retval Always 0, errors are handled by assertions.
+ */
+int z_arm_mmu_init(bool is_primary_core)
+{
+	uint32_t reg_val = 0;
+	static uint32_t pt_attrs;
+
+	__ASSERT(KB(4) == CONFIG_MMU_PAGE_SIZE,
+		 "MMU_PAGE_SIZE value %u is invalid, only 4 kB pages are supported\n",
+		 CONFIG_MMU_PAGE_SIZE);
+
+	if (is_primary_core) {
+		pt_attrs = setup_page_tables();
 	}
 
 	/* Clear TTBR1 */

--- a/arch/arm/core/mmu/arm_mmu.c
+++ b/arch/arm/core/mmu/arm_mmu.c
@@ -75,7 +75,7 @@ static const struct arm_mmu_flat_range mmu_zephyr_ranges[] = {
 	  .attrs = MT_NORMAL | MATTR_SHARED |
 		   MPERM_R | MPERM_W |
 		   MATTR_CACHE_OUTER_WB_WA | MATTR_CACHE_INNER_WB_WA},
-#if defined(CONFIG_AARCH32_ARMV8_A)
+#if defined(CONFIG_AARCH32_ARMV8_A) || defined(CONFIG_CPU_CORTEX_A7)
 	/* The ARMv8-A AArch32 implementation uses VBAR to hold the final vector
 	 * table address (_vector_start); map it here rather than requiring
 	 * each SoC to provide its own entry in mmu_regions.c.

--- a/arch/arm/core/offsets/offsets_aarch32.c
+++ b/arch/arm/core/offsets/offsets_aarch32.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013-2014 Wind River Systems, Inc.
  * Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -85,6 +86,15 @@ GEN_ABSOLUTE_SYM(___extra_esf_info_t_SIZEOF, sizeof(struct __extra_esf_info));
 #if defined(CONFIG_THREAD_STACK_INFO)
 GEN_OFFSET_SYM(_thread_stack_info_t, start);
 #endif
+
+#if defined(CONFIG_HAS_ARM_SMCCC)
+#include <zephyr/arch/arm/arm-smccc.h>
+
+GEN_OFFSET_SYM(arm_smccc_res_t, a0);
+GEN_OFFSET_SYM(arm_smccc_res_t, a1);
+GEN_OFFSET_SYM(arm_smccc_res_t, a2);
+GEN_OFFSET_SYM(arm_smccc_res_t, a3);
+#endif /* CONFIG_HAS_ARM_SMCCC */
 
 /*
  * CPU context for S2RAM

--- a/arch/arm/core/smccc-call.S
+++ b/arch/arm/core/smccc-call.S
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This file implements the common calling mechanism to be used with the Secure
+ * Monitor Call (SMC) and Hypervisor Call (HVC).
+ *
+ * See https://developer.arm.com/docs/den0028/latest
+ */
+
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
+#include <offsets_short.h>
+
+_ASM_FILE_PROLOGUE
+
+/*
+ * -mcpu=<cpu> restricts the assembler to the instruction encodings that CPU
+ * implements, so on cores without the Security/Virtualization Extensions
+ * (e.g. Cortex-A9) GAS rejects the `smc`/`hvc` opcodes outright. These
+ * directives just unlock the encodings in the assembler; whether the
+ * instruction actually works still depends on the conduit the platform
+ * firmware/hypervisor advertises at runtime.
+ */
+.arch_extension sec
+.arch_extension virt
+
+/*
+ * a0-a3 arrive in r0-r3. a4, a5, a6, a7 and res arrive on the caller's stack,
+ * in that order, at [sp, #0] through [sp, #16] on entry to this macro. The
+ * push below shifts those stack slots down by 20 bytes (5 saved registers).
+ */
+.macro SMCCC instr
+	push    {r4-r7, lr}
+
+	ldr     r4, [sp, #20]
+	ldr     r5, [sp, #24]
+	ldr     r6, [sp, #28]
+	ldr     r7, [sp, #32]
+
+	\instr  #0
+
+	ldr     r4, [sp, #36]
+	str     r0, [r4, #__arm_smccc_res_t_a0_OFFSET]
+	str     r1, [r4, #__arm_smccc_res_t_a1_OFFSET]
+	str     r2, [r4, #__arm_smccc_res_t_a2_OFFSET]
+	str     r3, [r4, #__arm_smccc_res_t_a3_OFFSET]
+
+	pop     {r4-r7, lr}
+	bx      lr
+.endm
+
+/*
+ * The SMC instruction is used to generate a synchronous exception that is
+ * handled by Secure Monitor code running in EL3.
+ */
+GTEXT(arm_smccc_smc)
+SECTION_FUNC(TEXT, arm_smccc_smc)
+	SMCCC	smc
+
+/*
+ * The HVC instruction is used to generate a synchronous exception that is
+ * handled by a hypervisor running in EL2.
+ */
+GTEXT(arm_smccc_hvc)
+SECTION_FUNC(TEXT, arm_smccc_hvc)
+	SMCCC	hvc

--- a/arch/arm/include/cortex_m/kernel_arch_func.h
+++ b/arch/arm/include/cortex_m/kernel_arch_func.h
@@ -38,7 +38,7 @@ extern void z_arm_configure_dynamic_mpu_regions(struct k_thread *thread);
 extern int z_arm_mpu_init(void);
 #endif /* CONFIG_ARM_MPU */
 #ifdef CONFIG_ARM_AARCH32_MMU
-extern int z_arm_mmu_init(void);
+extern int z_arm_mmu_init(bool is_primary_core);
 #endif /* CONFIG_ARM_AARCH32_MMU */
 
 static ALWAYS_INLINE void arch_kernel_init(void)

--- a/boards/qemu/cortex_a7/Kconfig.defconfig
+++ b/boards/qemu/cortex_a7/Kconfig.defconfig
@@ -1,0 +1,19 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_QEMU_CORTEX_A7
+
+config BUILD_OUTPUT_BIN
+	default y
+
+if QEMU_ICOUNT
+
+config QEMU_ICOUNT_SHIFT
+	default 4
+
+config QEMU_ICOUNT_SLEEP
+	default y
+
+endif # QEMU_ICOUNT
+
+endif # BOARD_QEMU_CORTEX_A7

--- a/boards/qemu/cortex_a7/Kconfig.qemu_cortex_a7
+++ b/boards/qemu/cortex_a7/Kconfig.qemu_cortex_a7
@@ -1,0 +1,5 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_QEMU_CORTEX_A7
+	select SOC_QEMU_CORTEX_A7

--- a/boards/qemu/cortex_a7/board.cmake
+++ b/boards/qemu/cortex_a7/board.cmake
@@ -1,0 +1,20 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+set(SUPPORTED_EMU_PLATFORMS qemu)
+set(QEMU_ARCH aarch64)
+
+set(QEMU_CPU_TYPE_${ARCH} cortex-a7)
+
+if(CONFIG_ARMV7_A_NS)
+  set(QEMU_MACH virt,gic-version=2)
+else()
+  set(QEMU_MACH virt,secure=on,gic-version=2)
+endif()
+
+set(QEMU_FLAGS_${ARCH}
+  -cpu ${QEMU_CPU_TYPE_${ARCH}}
+  -machine ${QEMU_MACH}
+  )
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/cortex_a7/board.cmake
+++ b/boards/qemu/cortex_a7/board.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+set(SUPPORTED_EMU_PLATFORMS qemu)
+
+set(QEMU_CPU_TYPE cortex-a7)
+
+if(CONFIG_ARMV7_A_NS)
+  set(QEMU_MACH virt,gic-version=3)
+else()
+  set(QEMU_MACH virt,secure=on,gic-version=3)
+endif()
+
+set(QEMU_BOARD_FLAGS
+  -cpu ${QEMU_CPU_TYPE}
+  -machine ${QEMU_MACH}
+  )
+
+include(${ZEPHYR_BASE}/boards/common/qemu.board.cmake)

--- a/boards/qemu/cortex_a7/board.yml
+++ b/boards/qemu/cortex_a7/board.yml
@@ -1,0 +1,8 @@
+board:
+  name: qemu_cortex_a7
+  full_name: QEMU Emulation for Cortex-A7
+  vendor: qemu
+  socs:
+  - name: qemu_cortex_a7
+    variants:
+    - name: smp

--- a/boards/qemu/cortex_a7/qemu_cortex_a7.dts
+++ b/boards/qemu/cortex_a7/qemu_cortex_a7.dts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <arm/qemu/qemu-virt-a7.dtsi>
+
+/ {
+	model = "QEMU Cortex-A7";
+	compatible = "qemu,arm-cortex-a7";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,flash = &flash0;
+	};
+};
+
+&uart0 {
+	status = "okay";
+	current-speed = <115200>;
+};

--- a/boards/qemu/cortex_a7/qemu_cortex_a7.yaml
+++ b/boards/qemu/cortex_a7/qemu_cortex_a7.yaml
@@ -1,0 +1,17 @@
+identifier: qemu_cortex_a7
+name: QEMU Emulation for Cortex-A7
+type: qemu
+simulation:
+  - name: qemu
+arch: arm
+toolchain:
+  - zephyr
+  - cross-compile
+ram: 131072
+flash: 65536
+testing:
+  default: true
+  ignore_tags:
+    - net
+    - bluetooth
+vendor: qemu

--- a/boards/qemu/cortex_a7/qemu_cortex_a7_defconfig
+++ b/boards/qemu/cortex_a7/qemu_cortex_a7_defconfig
@@ -1,0 +1,22 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ARM_AARCH32_MMU=y
+
+CONFIG_ARM_ARCH_TIMER=y
+
+# Cache management
+CONFIG_CACHE_MANAGEMENT=y
+
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable serial port
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# Avoid timing skew in tests
+CONFIG_QEMU_ICOUNT=y

--- a/boards/qemu/cortex_a7/qemu_cortex_a7_qemu_cortex_a7_smp.dts
+++ b/boards/qemu/cortex_a7/qemu_cortex_a7_qemu_cortex_a7_smp.dts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include "qemu_cortex_a7.dts"

--- a/boards/qemu/cortex_a7/qemu_cortex_a7_qemu_cortex_a7_smp.yaml
+++ b/boards/qemu/cortex_a7/qemu_cortex_a7_qemu_cortex_a7_smp.yaml
@@ -1,0 +1,18 @@
+identifier: qemu_cortex_a7/qemu_cortex_a7/smp
+name: QEMU Emulation for Cortex-A7 SMP
+type: qemu
+simulation:
+  - name: qemu
+arch: arm
+toolchain:
+  - zephyr
+  - cross-compile
+ram: 128
+supported:
+  - smp
+testing:
+  default: true
+  ignore_tags:
+    - net
+    - bluetooth
+vendor: qemu

--- a/boards/qemu/cortex_a7/qemu_cortex_a7_qemu_cortex_a7_smp_defconfig
+++ b/boards/qemu/cortex_a7/qemu_cortex_a7_qemu_cortex_a7_smp_defconfig
@@ -1,0 +1,34 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ARM_AARCH32_MMU=y
+
+CONFIG_ARM_ARCH_TIMER=y
+
+# Cache management
+CONFIG_CACHE_MANAGEMENT=y
+
+# Enable UART driver
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# Enable serial port
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# icount does not work well with SMP
+CONFIG_QEMU_ICOUNT=n
+
+# Run in Non-Secure state so QEMU's own PSCI firmware services CPU_ON
+# (also required for SMP)
+CONFIG_ARMV7_A_NS=y
+
+# PSCI is supported with NS
+CONFIG_PM_CPU_OPS=y
+
+# SMP-related
+CONFIG_USE_SWITCH=y
+CONFIG_SMP=y
+CONFIG_MP_MAX_NUM_CPUS=2

--- a/drivers/pm_cpu_ops/Kconfig
+++ b/drivers/pm_cpu_ops/Kconfig
@@ -21,6 +21,7 @@ config PM_CPU_OPS_PSCI
 	bool "Support for the ARM Power State Coordination Interface (PSCI)"
 	default y
 	depends on DT_HAS_ARM_PSCI_0_2_ENABLED || DT_HAS_ARM_PSCI_1_1_ENABLED
+	depends on HAS_ARM_SMCCC
 	select PM_CPU_OPS_HAS_DRIVER
 	select HAS_POWEROFF
 	help

--- a/dts/arm/qemu/qemu-virt-a7.dtsi
+++ b/dts/arm/qemu/qemu-virt-a7.dtsi
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Derived from DTS extracted with:
+ *
+ *   qemu-system-aarch64 -machine virt,gic-version=3,secure=off -cpu cortex-a7
+ *         -smp 2 -machine dumpdtb=virt.dtb
+ *
+ *   dtc -I dtb -O dts virt.dtb
+ */
+
+#include <mem.h>
+#include <arm/armv7-a.dtsi>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a7";
+			reg = <0>;
+			enable-method = "psci";
+		};
+
+		cpu1: cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a7";
+			reg = <1>;
+			enable-method = "psci";
+		};
+	};
+
+	psci {
+		compatible = "arm,psci-1.0", "arm,psci-0.2", "arm,psci";
+		method = "hvc";
+	};
+
+	timer {
+		compatible = "arm,armv7-timer";
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 14 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 11 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 10 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>;
+	};
+
+	uartclk: apb-pclk {
+		compatible = "fixed-clock";
+		clock-frequency = <24000000>;
+		#clock-cells = <0>;
+	};
+
+	sram0: memory@40000000 {
+		compatible = "mmio-sram";
+		reg = <0x40000000 DT_SIZE_M(128)>;
+	};
+
+	soc {
+		interrupt-parent = <&gic>;
+
+		gic: interrupt-controller@8000000 {
+			compatible = "arm,gic-v3", "arm,gic";
+			reg = <0x8000000 0x010000>,
+			      <0x80a0000 0xf60000>;
+			interrupt-controller;
+			#interrupt-cells = <4>;
+			status = "okay";
+		};
+
+		uart0: uart@9000000 {
+			compatible = "arm,pl011";
+			reg = <0x9000000 0x1000>;
+			status = "disabled";
+			interrupts = <GIC_SPI 1 IRQ_TYPE_LEVEL 0>;
+			interrupt-names = "irq_0";
+			clocks = <&uartclk>;
+		};
+
+		flash0: flash@0 {
+			compatible = "cfi-flash";
+			bank-width = <4>;
+			reg = <0x0 DT_SIZE_M(64)>;
+		};
+	};
+};

--- a/dts/arm/qemu/qemu-virt-a7.dtsi
+++ b/dts/arm/qemu/qemu-virt-a7.dtsi
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Derived from DTS extracted with:
+ *
+ *   qemu-system-aarch64 -machine virt,gic-version=2,secure=off -cpu cortex-a7
+ *         -smp 2 -machine dumpdtb=virt.dtb
+ *
+ *   dtc -I dtb -O dts virt.dtb
+ */
+
+#include <mem.h>
+#include <arm/armv7-a.dtsi>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a7";
+			reg = <0>;
+			enable-method = "psci";
+		};
+
+		cpu1: cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a7";
+			reg = <1>;
+			enable-method = "psci";
+		};
+	};
+
+	psci {
+		compatible = "arm,psci-1.0", "arm,psci-0.2", "arm,psci";
+		method = "hvc";
+	};
+
+	timer {
+		compatible = "arm,armv7-timer";
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 14 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 11 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>,
+			     <GIC_PPI 10 IRQ_TYPE_LEVEL
+			      IRQ_DEFAULT_PRIORITY>;
+	};
+
+	uartclk: apb-pclk {
+		compatible = "fixed-clock";
+		clock-frequency = <24000000>;
+		#clock-cells = <0>;
+	};
+
+	sram0: memory@40000000 {
+		compatible = "mmio-sram";
+		reg = <0x40000000 DT_SIZE_M(128)>;
+	};
+
+	soc {
+		interrupt-parent = <&gic>;
+
+		gic: interrupt-controller@8000000 {
+			compatible = "arm,gic-400", "arm,gic-v2", "arm,gic";
+			reg = <0x8000000 0x10000>,
+			      <0x8010000 0x10000>;
+			interrupt-controller;
+			#interrupt-cells = <4>;
+			status = "okay";
+		};
+
+		uart0: uart@9000000 {
+			compatible = "arm,pl011";
+			reg = <0x9000000 0x1000>;
+			status = "disabled";
+			interrupts = <GIC_SPI 1 IRQ_TYPE_LEVEL 0>;
+			interrupt-names = "irq_0";
+			clocks = <&uartclk>;
+		};
+
+		flash0: flash@0 {
+			compatible = "cfi-flash";
+			bank-width = <4>;
+			reg = <0x0 DT_SIZE_M(64)>;
+		};
+	};
+};

--- a/include/zephyr/arch/arm/arm-smccc.h
+++ b/include/zephyr/arch/arm/arm-smccc.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM_SMCCC_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM_SMCCC_H_
+
+/*
+ * Result from SMC/HVC call
+ * @a0-a3 result values from registers 0 to 3
+ */
+struct arm_smccc_res {
+	unsigned long a0;
+	unsigned long a1;
+	unsigned long a2;
+	unsigned long a3;
+};
+
+typedef struct arm_smccc_res arm_smccc_res_t;
+
+enum arm_smccc_conduit {
+	SMCCC_CONDUIT_NONE,
+	SMCCC_CONDUIT_SMC,
+	SMCCC_CONDUIT_HVC,
+};
+
+/*
+ * @brief Make HVC calls
+ *
+ * @param a0 function identifier
+ * @param a1-a7 parameters registers
+ * @param res results
+ */
+void arm_smccc_hvc(unsigned long a0, unsigned long a1,
+		   unsigned long a2, unsigned long a3,
+		   unsigned long a4, unsigned long a5,
+		   unsigned long a6, unsigned long a7,
+		   struct arm_smccc_res *res);
+
+/*
+ * @brief Make SMC calls
+ *
+ * @param a0 function identifier
+ * @param a1-a7 parameters registers
+ * @param res results
+ */
+void arm_smccc_smc(unsigned long a0, unsigned long a1,
+		   unsigned long a2, unsigned long a3,
+		   unsigned long a4, unsigned long a5,
+		   unsigned long a6, unsigned long a7,
+		   struct arm_smccc_res *res);
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM_SMCCC_H_ */

--- a/include/zephyr/arch/arm/mmu/arm_mmu.h
+++ b/include/zephyr/arch/arm/mmu/arm_mmu.h
@@ -10,6 +10,7 @@
 
 #ifndef _ASMLANGUAGE
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -140,7 +141,7 @@ struct arm_mmu_config {
  */
 extern const struct arm_mmu_config mmu_config;
 
-int z_arm_mmu_init(void);
+int z_arm_mmu_init(bool is_primary_core);
 
 #endif /* _ASMLANGUAGE */
 

--- a/include/zephyr/drivers/pm_cpu_ops/psci.h
+++ b/include/zephyr/drivers/pm_cpu_ops/psci.h
@@ -8,7 +8,13 @@
 #define ZEPHYR_INCLUDE_DRIVERS_PM_CPU_OPS_PSCI_H_
 
 #include <zephyr/types.h>
+
+#if CONFIG_ARM64
 #include <zephyr/arch/arm64/arm-smccc.h>
+#elif CONFIG_ARM
+#include <zephyr/arch/arm/arm-smccc.h>
+#endif
+
 #include <stddef.h>
 #include <zephyr/device.h>
 

--- a/soc/arm/qemu_cortex_a7/CMakeLists.txt
+++ b/soc/arm/qemu_cortex_a7/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_include_directories(.)
+
+zephyr_library_sources_ifdef(CONFIG_ARM_AARCH32_MMU mmu_regions.c)
+zephyr_library_sources(soc.c)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_a_r/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/arm/qemu_cortex_a7/Kconfig
+++ b/soc/arm/qemu_cortex_a7/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_QEMU_CORTEX_A7
+	select ARM
+	select CPU_CORTEX_A7
+	select QEMU_TARGET

--- a/soc/arm/qemu_cortex_a7/Kconfig.defconfig
+++ b/soc/arm/qemu_cortex_a7/Kconfig.defconfig
@@ -1,0 +1,23 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_QEMU_CORTEX_A7
+
+config NUM_IRQS
+	# must be >= the highest interrupt number used
+	# - include the UART interrupts
+	default 220
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 62500000
+
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
+config FLASH_SIZE
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
+
+config FLASH_BASE_ADDRESS
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
+
+endif # SOC_QEMU_CORTEX_A7

--- a/soc/arm/qemu_cortex_a7/Kconfig.soc
+++ b/soc/arm/qemu_cortex_a7/Kconfig.soc
@@ -1,0 +1,9 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_QEMU_CORTEX_A7
+	bool
+	select SOC_FAMILY_ARM
+
+config SOC
+	default "qemu_cortex_a7" if SOC_QEMU_CORTEX_A7

--- a/soc/arm/qemu_cortex_a7/mmu_regions.c
+++ b/soc/arm/qemu_cortex_a7/mmu_regions.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/arm/mmu/arm_mmu.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
+
+static const struct arm_mmu_region mmu_regions[] = {
+
+	MMU_REGION_FLAT_ENTRY("GIC_DIST", DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 0),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 0),
+			      MT_DEVICE | MPERM_R | MPERM_W),
+
+	MMU_REGION_FLAT_ENTRY("GIC_REDIST", DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
+			      MT_DEVICE | MPERM_R | MPERM_W),
+};
+
+const struct arm_mmu_config mmu_config = {
+	.num_regions = ARRAY_SIZE(mmu_regions),
+	.mmu_regions = mmu_regions,
+};

--- a/soc/arm/qemu_cortex_a7/mmu_regions.c
+++ b/soc/arm/qemu_cortex_a7/mmu_regions.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/arm/mmu/arm_mmu.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
+
+static const struct arm_mmu_region mmu_regions[] = {
+
+	MMU_REGION_FLAT_ENTRY("GIC_DIST",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 0),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 0),
+			      MT_DEVICE | MPERM_R | MPERM_W),
+
+	MMU_REGION_FLAT_ENTRY("GIC_CPU",
+			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
+			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
+			      MT_DEVICE | MPERM_R | MPERM_W),
+
+	MMU_REGION_FLAT_ENTRY("UART0",
+			      DT_REG_ADDR(DT_NODELABEL(uart0)),
+			      DT_REG_SIZE(DT_NODELABEL(uart0)),
+			      MT_DEVICE | MPERM_R | MPERM_W),
+};
+
+const struct arm_mmu_config mmu_config = {
+	.num_regions = ARRAY_SIZE(mmu_regions),
+	.mmu_regions = mmu_regions,
+};

--- a/soc/arm/qemu_cortex_a7/soc.c
+++ b/soc/arm/qemu_cortex_a7/soc.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <cmsis_core.h>
+
+#include <zephyr/arch/cpu.h>
+#include <zephyr/linker/linker-defs.h>
+
+void relocate_vector_table(void)
+{
+	uint32_t vector_address = (uint32_t)_vector_start;
+
+	write_sctlr(read_sctlr() & ~HIVECS);
+	write_vbar(vector_address & VBAR_MASK);
+	barrier_isync_fence_full();
+}

--- a/soc/arm/qemu_cortex_a7/soc.h
+++ b/soc/arm/qemu_cortex_a7/soc.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SOC__H_
+#define _SOC__H_
+
+#ifndef _ASMLANGUAGE
+
+/*
+ * The following definition is required for the inclusion of the CMSIS
+ * Common Peripheral Access Layer for aarch32 Cortex-A CPUs:
+ */
+
+#define __CORTEX_A 7U
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* _SOC__H_ */

--- a/soc/arm/soc.yml
+++ b/soc/arm/soc.yml
@@ -30,6 +30,8 @@ family:
     socs:
     - name: designstart_fpga_cortex_m1
     - name: designstart_fpga_cortex_m3
+  socs:
+  - name: qemu_cortex_a7
 - name: arm64
   series:
   - name: fvp_aem

--- a/tests/kernel/multiprocessing/smp_abort/tests.yaml
+++ b/tests/kernel/multiprocessing/smp_abort/tests.yaml
@@ -3,4 +3,4 @@ tests:
     tags:
       - kernel
       - smp
-    filter: (CONFIG_MP_MAX_NUM_CPUS > 1)
+    filter: (CONFIG_MP_MAX_NUM_CPUS > 1) and CONFIG_IRQ_OFFLOAD_NESTED


### PR DESCRIPTION
This patch implements arm_smccc_smc and arm_smccc_hvc for aarch32a arch and calls PSCI based pm_cpu_on to boot the secondary CPUs.