### PR TITLE
Bluetooth: AICS: Add bt_aics_mode_to_str

### DIFF
--- a/include/zephyr/bluetooth/audio/aics.h
+++ b/include/zephyr/bluetooth/audio/aics.h
@@ -85,6 +85,29 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief Convert an AICS gain mode to a human-readable string.
+ *
+ * @param mode  The gain mode (BT_AICS_MODE_*) value.
+ *
+ * @return A string representation of the gain mode.
+ */
+static inline const char *bt_aics_mode_to_str(uint8_t mode)
+{
+	switch (mode) {
+	case BT_AICS_MODE_MANUAL_ONLY:
+		return "Manual only";
+	case BT_AICS_MODE_AUTO_ONLY:
+		return "Auto only";
+	case BT_AICS_MODE_MANUAL:
+		return "Manual";
+	case BT_AICS_MODE_AUTO:
+		return "Auto";
+	default:
+		return "Unknown";
+	}
+}
+
+/**
  * @name Audio Input Control Service input types
  * @{
  */

--- a/samples/bluetooth/audio/hap_ha/src/micp_mic_dev.c
+++ b/samples/bluetooth/audio/hap_ha/src/micp_mic_dev.c
@@ -38,8 +38,8 @@ static void micp_mic_dev_aics_state_cb(struct bt_aics *inst, int err, int8_t gai
 	if (err != 0) {
 		printk("AICS state get failed (%d) for inst %p\n", err, inst);
 	} else {
-		printk("AICS inst %p state gain %d, mute %u, mode %u\n",
-		       inst, gain, mute, mode);
+		printk("AICS inst %p state gain %d, mute %u, mode %s (0x%02X)\n", inst, gain, mute,
+		       bt_aics_mode_to_str(mode), mode);
 	}
 
 }

--- a/samples/bluetooth/audio/hap_ha/src/vcp_vol_renderer.c
+++ b/samples/bluetooth/audio/hap_ha/src/vcp_vol_renderer.c
@@ -51,8 +51,8 @@ static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain, uint8_t mu
 	if (err != 0) {
 		printk("AICS state get failed (%d) for inst %p\n", err, inst);
 	} else {
-		printk("AICS inst %p state gain %d, mute %u, mode %u\n",
-		       inst, gain, mute, mode);
+		printk("AICS inst %p state gain %d, mute %u, mode %s (0x%02X)\n", inst, gain, mute,
+		       bt_aics_mode_to_str(mode), mode);
 	}
 }
 

--- a/subsys/bluetooth/audio/aics.c
+++ b/subsys/bluetooth/audio/aics.c
@@ -129,8 +129,9 @@ static ssize_t read_aics_state(struct bt_conn *conn,
 {
 	struct bt_aics *inst = BT_AUDIO_CHRC_USER_DATA(attr);
 
-	LOG_DBG("gain %d, mute %u, gain_mode %u, counter %u", inst->srv.state.gain,
-		inst->srv.state.mute, inst->srv.state.gain_mode, inst->srv.state.change_counter);
+	LOG_DBG("gain %d, mute %u, gain_mode %s (0x%02X), counter %u", inst->srv.state.gain,
+		inst->srv.state.mute, bt_aics_mode_to_str(inst->srv.state.gain_mode),
+		inst->srv.state.gain_mode, inst->srv.state.change_counter);
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &inst->srv.state,
 				 sizeof(inst->srv.state));
@@ -410,8 +411,9 @@ static ssize_t write_aics_control(struct bt_conn *conn, const struct bt_gatt_att
 	if (state_change) {
 		inst->srv.state.change_counter++; /* May overflow which is OK */
 
-		LOG_DBG("New state: gain %d, mute %u, gain_mode %u, counter %u",
-			inst->srv.state.gain, inst->srv.state.mute, inst->srv.state.gain_mode,
+		LOG_DBG("New state: gain %d, mute %u, gain_mode %s (0x%02X), counter %u",
+			inst->srv.state.gain, inst->srv.state.mute,
+			bt_aics_mode_to_str(inst->srv.state.gain_mode), inst->srv.state.gain_mode,
 			inst->srv.state.change_counter);
 
 		value_changed(inst, AICS_NOTIFY_STATE);

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -82,8 +82,10 @@ uint8_t aics_client_notify_handler(struct bt_conn *conn, struct bt_gatt_subscrib
 	if (handle == inst->cli.state_handle) {
 		if (length == sizeof(*state)) {
 			state = (const struct bt_aics_state *)data;
-			LOG_DBG("Inst %p: Gain %d, mute %u, gain_mode %u, counter %u", inst,
-				state->gain, state->mute, state->gain_mode, state->change_counter);
+			LOG_DBG("Inst %p: Gain %d, mute %u, gain_mode %s (0x%02X), counter %u",
+				inst, state->gain, state->mute,
+				bt_aics_mode_to_str(state->gain_mode), state->gain_mode,
+				state->change_counter);
 
 			inst->cli.change_counter = state->change_counter;
 
@@ -152,8 +154,9 @@ static uint8_t aics_client_read_state_cb(struct bt_conn *conn, uint8_t err,
 
 	if (data) {
 		if (length == sizeof(*state)) {
-			LOG_DBG("Gain %d, mute %u, gain_mode %u, counter %u", state->gain,
-				state->mute, state->gain_mode, state->change_counter);
+			LOG_DBG("Gain %d, mute %u, gain_mode %s (0x%02X), counter %u", state->gain,
+				state->mute, bt_aics_mode_to_str(state->gain_mode),
+				state->gain_mode, state->change_counter);
 
 			inst->cli.change_counter = state->change_counter;
 		} else {
@@ -371,8 +374,9 @@ static uint8_t internal_read_state_cb(struct bt_conn *conn, uint8_t err,
 		if (length == sizeof(*state)) {
 			int write_err;
 
-			LOG_DBG("Gain %d, mute %u, gain_mode %u, counter %u", state->gain,
-				state->mute, state->gain_mode, state->change_counter);
+			LOG_DBG("Gain %d, mute %u, gain_mode %s (0x%02X), counter %u", state->gain,
+				state->mute, bt_aics_mode_to_str(state->gain_mode),
+				state->gain_mode, state->change_counter);
 			inst->cli.change_counter = state->change_counter;
 
 			/* clear busy flag to reuse function */

--- a/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_ctlr.c
@@ -138,8 +138,8 @@ static void micp_mic_ctlr_aics_state_cb(struct bt_aics *inst, int err,
 		bt_shell_error("AICS state get failed (%d) for inst %p",
 			       err, inst);
 	} else {
-		bt_shell_print("AICS inst %p state gain %d, mute %u, mode %u",
-			       inst, gain, mute, mode);
+		bt_shell_print("AICS inst %p state gain %d, mute %u, mode %s (0x%02X)", inst, gain,
+			       mute, bt_aics_mode_to_str(mode), mode);
 	}
 }
 

--- a/subsys/bluetooth/audio/shell/micp_mic_dev.c
+++ b/subsys/bluetooth/audio/shell/micp_mic_dev.c
@@ -45,8 +45,8 @@ static void micp_mic_dev_aics_state_cb(struct bt_aics *inst, int err,
 		bt_shell_error("AICS state get failed (%d) for inst %p",
 			       err, inst);
 	} else {
-		bt_shell_print("AICS inst %p state gain %d, mute %u, mode %u",
-			       inst, gain, mute, mode);
+		bt_shell_print("AICS inst %p state gain %d, mute %u, mode %s (0x%02X)", inst, gain,
+			       mute, bt_aics_mode_to_str(mode), mode);
 	}
 }
 static void micp_mic_dev_aics_gain_setting_cb(struct bt_aics *inst, int err,

--- a/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_ctlr.c
@@ -198,8 +198,8 @@ static void vcs_aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 		bt_shell_error("AICS state get failed (%d) for inst %p",
 			       err, inst);
 	} else {
-		bt_shell_print("AICS inst %p state gain %d, mute %u, mode %u",
-			       inst, gain, mute, mode);
+		bt_shell_print("AICS inst %p state gain %d, mute %u, mode %s (0x%02X)", inst, gain,
+			       mute, bt_aics_mode_to_str(mode), mode);
 	}
 }
 

--- a/subsys/bluetooth/audio/shell/vcp_vol_rend.c
+++ b/subsys/bluetooth/audio/shell/vcp_vol_rend.c
@@ -59,8 +59,8 @@ static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 		bt_shell_error("AICS state get failed (%d) for inst %p",
 			       err, inst);
 	} else {
-		bt_shell_print("AICS inst %p state gain %d, mute %u, mode %u",
-			       inst, gain, mute, mode);
+		bt_shell_print("AICS inst %p state gain %d, mute %u, mode %s (0x%02X)", inst, gain,
+			       mute, bt_aics_mode_to_str(mode), mode);
 	}
 }
 


### PR DESCRIPTION
Add function to return a human-readable version of the AICS gain mode.