### PR TITLE
net: mqtt_sn: udp: make broadcast optional

### DIFF
--- a/include/zephyr/net/mqtt_sn.h
+++ b/include/zephyr/net/mqtt_sn.h
@@ -239,10 +239,10 @@ struct mqtt_sn_transport_udp {
  * @brief Initialize the UDP transport.
  *
  * @param[in] udp The transport to be initialized
- * @param[in] gwaddr Pre-initialized gateway address
- * @param[in] addrlen Size of the gwaddr structure.
+ * @param[in] gwaddr Broadcast address
+ * @param[in] addrlen Size of the bcaddr structure.
  */
-int mqtt_sn_transport_udp_init(struct mqtt_sn_transport_udp *udp, struct net_sockaddr *gwaddr,
+int mqtt_sn_transport_udp_init(struct mqtt_sn_transport_udp *udp, struct net_sockaddr *bcaddr,
 			       net_socklen_t addrlen);
 #endif
 

--- a/include/zephyr/net/mqtt_sn.h
+++ b/include/zephyr/net/mqtt_sn.h
@@ -228,9 +228,10 @@ struct mqtt_sn_transport_udp {
 	/** Socket FD */
 	int sock;
 
-	/** Address of broadcasts */
-	struct net_sockaddr bcaddr;
-	net_socklen_t bcaddrlen;
+	/** Address of sock */
+	struct net_sockaddr addr;
+	net_socklen_t addrlen;
+	bool use_broadcast;
 };
 
 #define UDP_TRANSPORT(transport) CONTAINER_OF(transport, struct mqtt_sn_transport_udp, tp)

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -2149,6 +2149,49 @@ int net_port_set(struct net_sockaddr *addr, uint16_t port);
 int net_port_get(struct net_sockaddr *addr, uint16_t *port);
 
 /**
+ * @brief Compare socket addresses.
+ *
+ * @param a First address
+ * @param b Second address
+ *
+ * @return true if a and b are equal, false otherwise.
+ */
+static inline bool sockaddr_equal(const struct net_sockaddr *a, const struct net_sockaddr *b)
+{
+	/* FIXME: Should we consider ipv6-mapped ipv4 addresses as equal to
+	 * ipv4 addresses?
+	 */
+	if (a->sa_family != b->sa_family) {
+		return false;
+	}
+
+	if (a->sa_family == NET_AF_INET) {
+		const struct net_sockaddr_in *a4 = net_sin(a);
+		const struct net_sockaddr_in *b4 = net_sin(b);
+
+		if (a4->sin_port != b4->sin_port) {
+			return false;
+		}
+
+		return net_ipv4_addr_cmp(&a4->sin_addr, &b4->sin_addr);
+	}
+
+	if (b->sa_family == NET_AF_INET6) {
+		const struct net_sockaddr_in6 *a6 = net_sin6(a);
+		const struct net_sockaddr_in6 *b6 = net_sin6(b);
+
+		if (a6->sin6_port != b6->sin6_port) {
+			return false;
+		}
+
+		return net_ipv6_addr_cmp(&a6->sin6_addr, &b6->sin6_addr);
+	}
+
+	/* Invalid address family */
+	return false;
+}
+
+/**
  * @brief Compare TCP sequence numbers.
  *
  * @details This function compares TCP sequence numbers,

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -2031,42 +2031,6 @@ bool coap_remove_observer(struct coap_resource *resource,
 	return true;
 }
 
-static bool sockaddr_equal(const struct net_sockaddr *a,
-			   const struct net_sockaddr *b)
-{
-	/* FIXME: Should we consider ipv6-mapped ipv4 addresses as equal to
-	 * ipv4 addresses?
-	 */
-	if (a->sa_family != b->sa_family) {
-		return false;
-	}
-
-	if (a->sa_family == NET_AF_INET) {
-		const struct net_sockaddr_in *a4 = net_sin(a);
-		const struct net_sockaddr_in *b4 = net_sin(b);
-
-		if (a4->sin_port != b4->sin_port) {
-			return false;
-		}
-
-		return net_ipv4_addr_cmp(&a4->sin_addr, &b4->sin_addr);
-	}
-
-	if (b->sa_family == NET_AF_INET6) {
-		const struct net_sockaddr_in6 *a6 = net_sin6(a);
-		const struct net_sockaddr_in6 *b6 = net_sin6(b);
-
-		if (a6->sin6_port != b6->sin6_port) {
-			return false;
-		}
-
-		return net_ipv6_addr_cmp(&a6->sin6_addr, &b6->sin6_addr);
-	}
-
-	/* Invalid address family */
-	return false;
-}
-
 struct coap_observer *coap_find_observer(
 	struct coap_observer *observers, size_t len,
 	const struct net_sockaddr *addr,

--- a/subsys/net/lib/mqtt_sn/Kconfig
+++ b/subsys/net/lib/mqtt_sn/Kconfig
@@ -73,8 +73,6 @@ config MQTT_SN_KEEPALIVE
 config MQTT_SN_TRANSPORT_UDP
 	bool "UDP transport for MQTT-SN"
 	select NET_SOCKETS
-	select NET_IPV4_IGMP if NET_IPV4
-	select NET_IPV6_MLD if NET_IPV6
 
 config MQTT_SN_LIB_N_RETRY
 	int "Number of times to retry messages"

--- a/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn_transport_udp.c
@@ -48,10 +48,10 @@ static char *get_ip_str(const struct net_sockaddr *sa, char *s, size_t maxlen)
 
 static int get_multicast_ttl(struct mqtt_sn_transport_udp *udp, int *ttl, net_socklen_t *ttl_len)
 {
-	if (udp->bcaddr.sa_family == NET_AF_INET && IS_ENABLED(CONFIG_NET_IPV4)) {
+	if (udp->addr.sa_family == NET_AF_INET && IS_ENABLED(CONFIG_NET_IPV4)) {
 		return zsock_getsockopt(udp->sock, NET_IPPROTO_IP, ZSOCK_IP_MULTICAST_TTL, ttl,
 					ttl_len);
-	} else if (udp->bcaddr.sa_family == NET_AF_INET6 && IS_ENABLED(CONFIG_NET_IPV6)) {
+	} else if (udp->addr.sa_family == NET_AF_INET6 && IS_ENABLED(CONFIG_NET_IPV6)) {
 		return zsock_getsockopt(udp->sock, NET_IPPROTO_IPV6, ZSOCK_IPV6_MULTICAST_HOPS, ttl,
 					ttl_len);
 	}
@@ -62,10 +62,10 @@ static int get_multicast_ttl(struct mqtt_sn_transport_udp *udp, int *ttl, net_so
 
 static int set_multicast_ttl(struct mqtt_sn_transport_udp *udp, int *ttl, net_socklen_t ttl_len)
 {
-	if (udp->bcaddr.sa_family == NET_AF_INET && IS_ENABLED(CONFIG_NET_IPV4)) {
+	if (udp->addr.sa_family == NET_AF_INET && IS_ENABLED(CONFIG_NET_IPV4)) {
 		return zsock_setsockopt(udp->sock, NET_IPPROTO_IP, ZSOCK_IP_MULTICAST_TTL, ttl,
 					ttl_len);
-	} else if (udp->bcaddr.sa_family == NET_AF_INET6 && IS_ENABLED(CONFIG_NET_IPV6)) {
+	} else if (udp->addr.sa_family == NET_AF_INET6 && IS_ENABLED(CONFIG_NET_IPV6)) {
 		return zsock_setsockopt(udp->sock, NET_IPPROTO_IPV6, ZSOCK_IPV6_MULTICAST_HOPS, ttl,
 					ttl_len);
 	}
@@ -86,8 +86,11 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 	if (udp->sock >= 0) {
 		return -EALREADY;
 	}
+	if (!udp->use_broadcast) {
+		return 0;
+	}
 
-	udp->sock = zsock_socket(udp->bcaddr.sa_family, NET_SOCK_DGRAM, 0);
+	udp->sock = zsock_socket(udp->addr.sa_family, NET_SOCK_DGRAM, 0);
 	if (udp->sock < 0) {
 		return -errno;
 	}
@@ -105,13 +108,13 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 		char ip[NET_INET6_ADDRSTRLEN], *out;
 		uint16_t port = 0;
 
-		out = get_ip_str((struct net_sockaddr *)&udp->bcaddr, ip, sizeof(ip));
-		switch (udp->bcaddr.sa_family) {
+		out = get_ip_str((struct net_sockaddr *)&udp->addr, ip, sizeof(ip));
+		switch (udp->addr.sa_family) {
 		case NET_AF_INET:
-			port = net_ntohs(((struct net_sockaddr_in *)&udp->bcaddr)->sin_port);
+			port = net_ntohs(((struct net_sockaddr_in *)&udp->addr)->sin_port);
 			break;
 		case NET_AF_INET6:
-			port = net_ntohs(((struct net_sockaddr_in6 *)&udp->bcaddr)->sin6_port);
+			port = net_ntohs(((struct net_sockaddr_in6 *)&udp->addr)->sin6_port);
 			break;
 		default:
 			break;
@@ -122,12 +125,12 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 		}
 	}
 
-	switch (udp->bcaddr.sa_family) {
+	switch (udp->addr.sa_family) {
 	case NET_AF_INET:
 		if (IS_ENABLED(CONFIG_NET_IPV4)) {
 			addrm.sa_family = NET_AF_INET;
 			((struct net_sockaddr_in *)&addrm)->sin_port =
-				((struct net_sockaddr_in *)&udp->bcaddr)->sin_port;
+				((struct net_sockaddr_in *)&udp->addr)->sin_port;
 			((struct net_sockaddr_in *)&addrm)->sin_addr.s_addr = NET_INADDR_ANY;
 		}
 		break;
@@ -135,7 +138,7 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 		if (IS_ENABLED(CONFIG_NET_IPV6)) {
 			addrm.sa_family = NET_AF_INET6;
 			((struct net_sockaddr_in6 *)&addrm)->sin6_port =
-				((struct net_sockaddr_in6 *)&udp->bcaddr)->sin6_port;
+				((struct net_sockaddr_in6 *)&udp->addr)->sin6_port;
 			memcpy(&((struct net_sockaddr_in6 *)&addrm)->sin6_addr, &net_in6addr_any,
 			       sizeof(struct net_in6_addr));
 			break;
@@ -152,12 +155,12 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 		return errno_backup;
 	}
 
-	if (udp->bcaddr.sa_family == NET_AF_INET && IS_ENABLED(CONFIG_NET_IPV4)) {
-		struct net_sockaddr_in *bcaddr_in = (struct net_sockaddr_in *)&udp->bcaddr;
+	if (udp->addr.sa_family == NET_AF_INET && IS_ENABLED(CONFIG_NET_IPV4)) {
+		struct net_sockaddr_in *bcaddr_in = (struct net_sockaddr_in *)&udp->addr;
 		struct net_ip_mreqn mreqn;
 
 		iface = net_if_ipv4_select_src_iface(
-			&((struct net_sockaddr_in *)&udp->bcaddr)->sin_addr);
+			&((struct net_sockaddr_in *)&udp->addr)->sin_addr);
 
 		mreqn = (struct net_ip_mreqn) {
 			.imr_multiaddr = bcaddr_in->sin_addr,
@@ -169,8 +172,8 @@ static int tp_udp_init(struct mqtt_sn_transport *transport)
 		if (err < 0 && errno != EALREADY) {
 			return -errno;
 		}
-	} else if (udp->bcaddr.sa_family == NET_AF_INET6 && IS_ENABLED(CONFIG_NET_IPV6)) {
-		struct net_sockaddr_in6 *bcaddr_in6 = (struct net_sockaddr_in6 *)&udp->bcaddr;
+	} else if (udp->addr.sa_family == NET_AF_INET6 && IS_ENABLED(CONFIG_NET_IPV6)) {
+		struct net_sockaddr_in6 *bcaddr_in6 = (struct net_sockaddr_in6 *)&udp->addr;
 		struct net_ipv6_mreq mreq;
 
 		iface = net_if_ipv6_select_src_iface(
@@ -210,6 +213,45 @@ static void tp_udp_deinit(struct mqtt_sn_transport *transport)
 	}
 }
 
+static int prepare_unicast_socket(struct mqtt_sn_transport_udp *udp,
+				  const struct net_sockaddr *dest_addr, size_t addrlen)
+{
+	int ret;
+
+	if (udp->use_broadcast) {
+		return 0;
+	}
+	if (addrlen > sizeof(udp->addr)) {
+		return -ENOMEM;
+	}
+	if (udp->sock >= 0 && sockaddr_equal(&udp->addr, dest_addr)) {
+		return 0;
+	}
+
+	if (udp->sock >= 0) {
+		zsock_close(udp->sock);
+		udp->sock = -1;
+	}
+
+	udp->sock = zsock_socket(dest_addr->sa_family, NET_SOCK_DGRAM, 0);
+	if (udp->sock < 0) {
+		return -errno;
+	}
+
+	ret = zsock_connect(udp->sock, dest_addr, addrlen);
+	if (ret < 0) {
+		ret = -errno;
+		zsock_close(udp->sock);
+		udp->sock = -1;
+		return ret;
+	}
+
+	memcpy(&udp->addr, dest_addr, addrlen);
+	udp->addrlen = addrlen;
+
+	return 0;
+}
+
 static int tp_udp_sendto(struct mqtt_sn_transport *transport, void *buf, size_t sz,
 			 const void *dest_addr, size_t addrlen)
 {
@@ -219,6 +261,10 @@ static int tp_udp_sendto(struct mqtt_sn_transport *transport, void *buf, size_t 
 	net_socklen_t ttl_len;
 
 	if (dest_addr == NULL) {
+		if (!udp->use_broadcast) {
+			return -ENOTSUP;
+		}
+
 		LOG_HEXDUMP_DBG(buf, sz, "Sending Broadcast UDP packet");
 
 		/* Set ttl if requested value does not match existing*/
@@ -235,8 +281,13 @@ static int tp_udp_sendto(struct mqtt_sn_transport *transport, void *buf, size_t 
 			}
 		}
 
-		rc = zsock_sendto(udp->sock, buf, sz, 0, &udp->bcaddr, udp->bcaddrlen);
+		rc = zsock_sendto(udp->sock, buf, sz, 0, &udp->addr, udp->addrlen);
 	} else {
+		rc = prepare_unicast_socket(udp, dest_addr, addrlen);
+		if (rc < 0) {
+			return rc;
+		}
+
 		LOG_HEXDUMP_DBG(buf, sz, "Sending Addressed UDP packet");
 		rc = zsock_sendto(udp->sock, buf, sz, 0, dest_addr, addrlen);
 	}
@@ -259,6 +310,10 @@ static ssize_t tp_udp_recvfrom(struct mqtt_sn_transport *transport, void *buffer
 	ssize_t ret;
 	int errno_backup;
 	net_socklen_t addrlen_local = *addrlen;
+
+	if (udp->sock < 0) {
+		return 0;
+	}
 
 	ret = zsock_recvfrom(udp->sock, buffer, length, 0, src_addr, &addrlen_local);
 	errno_backup = errno;
@@ -284,6 +339,10 @@ static int tp_udp_poll(struct mqtt_sn_transport *transport)
 		.events = ZSOCK_POLLIN,
 	};
 
+	if (udp->sock < 0) {
+		return 0;
+	}
+
 	rc = zsock_poll(&pollfd, 1, 0);
 	if (rc < 1) {
 		return rc;
@@ -297,7 +356,7 @@ static int tp_udp_poll(struct mqtt_sn_transport *transport)
 int mqtt_sn_transport_udp_init(struct mqtt_sn_transport_udp *udp, struct net_sockaddr *bcaddr,
 			       net_socklen_t addrlen)
 {
-	if (!udp || !bcaddr || !addrlen) {
+	if (!udp) {
 		return -EINVAL;
 	}
 
@@ -311,8 +370,11 @@ int mqtt_sn_transport_udp_init(struct mqtt_sn_transport_udp *udp, struct net_soc
 
 	udp->sock = -1;
 
-	memcpy(&udp->bcaddr, bcaddr, addrlen);
-	udp->bcaddrlen = addrlen;
+	if (bcaddr != NULL) {
+		memcpy(&udp->addr, bcaddr, addrlen);
+		udp->addrlen = addrlen;
+		udp->use_broadcast = true;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Introducing gateway discovery made it impossible to not use that feature.
There are many reasons why one would not want to use it:

- The gateway might be on a different L2 network, and thus can't advertise
  itself without a multicast router. This is usually the case with
  OpenThread.
- Discovery increases the traffic and thus, possibly power consumption.
  Especially during startup.
- Giving anyone on the network the ability to make the client use a certain
  gateway can be seen as a security risk. If that is a concern, you should
  probably use DTLS anyway, but not supporting the feature is an additional
  safeguard.
- Thanks to zsock_connect, we can only receive data from the current
  gateway. The discovery-based code accepts all messages without verifying
  the source address or if the packet was unicast/multicast.