### PR TITLE
logging: fix -Wcast-qual warnings in log_core.h and log_msg.h

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -175,15 +175,15 @@ extern "C" {
  *
  * It uses the level from the dynamic structure.
  *
- * @param _level Log level.
- * @param _source Data associated with the source.
+ * @param _lvl Log level.
+ * @param _src Data associated with the source.
  *
  * @retval true Continue with log message creation.
  * @retval false Drop that message.
  */
-#define Z_LOG_DYNAMIC_LEVEL_CHECK(_level, _source)                                                 \
+#define Z_LOG_DYNAMIC_LEVEL_CHECK(_lvl, _src)                                                      \
 	(!IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ||                                              \
-	 ((_level) <= Z_LOG_RUNTIME_FILTER(((struct log_source_dynamic_data *)_source)->filters)))
+	 ((_lvl) <= Z_LOG_RUNTIME_FILTER(((const struct log_source_dynamic_data *)_src)->filters)))
 
 /** @brief Check if message shall be created.
  *
@@ -513,9 +513,9 @@ TYPE_SECTION_END_EXTERN(struct log_source_dynamic_data, log_dynamic);
  *
  * @return Source ID.
  */
-static inline uint32_t log_dynamic_source_id(struct log_source_dynamic_data *data)
+static inline uint32_t log_dynamic_source_id(const struct log_source_dynamic_data *data)
 {
-	return ((uint8_t *)data - (uint8_t *)TYPE_SECTION_START(log_dynamic))/
+	return ((const uint8_t *)data - (const uint8_t *)TYPE_SECTION_START(log_dynamic))/
 			sizeof(struct log_source_dynamic_data);
 }
 
@@ -529,7 +529,7 @@ static inline uint32_t log_dynamic_source_id(struct log_source_dynamic_data *dat
 static inline uint32_t log_source_id(const void *source)
 {
 	return IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING) ?
-		log_dynamic_source_id((struct log_source_dynamic_data *)source) :
+		log_dynamic_source_id((const struct log_source_dynamic_data *)source) :
 		log_const_source_id((const struct log_source_const_data *)source);
 }
 

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -360,7 +360,7 @@ do { \
 					   (uint32_t)_plen, _dlen); \
 	LOG_MSG_DBG("creating message on stack: package len: %d, data len: %d\n", \
 			_plen, (int)(_dlen)); \
-	z_log_msg_static_create((void *)(_source), _desc, _msg->data, (_data)); \
+	z_log_msg_static_create((const void *)(_source), _desc, _msg->data, (_data)); \
 } while (false)
 
 #ifdef CONFIG_LOG_SPEED
@@ -381,7 +381,7 @@ do { \
 					Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt), \
 					__VA_ARGS__); \
 	} \
-	z_log_msg_finalize(_msg, (void *)_source, _desc, NULL); \
+	z_log_msg_finalize(_msg, (const void *)_source, _desc, NULL); \
 } while (false)
 #else
 /* Alternative empty macro created to speed up compilation when LOG_SPEED is
@@ -514,8 +514,8 @@ do { \
 			  _level, _data, _dlen, ...) \
 do {\
 	Z_LOG_MSG_STR_VAR(_fmt, ##__VA_ARGS__) \
-	z_log_msg_runtime_create((_domain_id), (void *)(_source), \
-				  (_level), (uint8_t *)(_data), (_dlen),\
+	z_log_msg_runtime_create((_domain_id), (const void *)(_source), \
+				  (_level), (const void *)(_data), (_dlen),\
 				  Z_LOG_MSG_CBPRINTF_FLAGS(_cstr_cnt) | \
 				  (IS_ENABLED(CONFIG_LOG_USE_TAGGED_ARGUMENTS) ? \
 				   CBPRINTF_PACKAGE_ARGS_ARE_TAGGED : 0), \


### PR DESCRIPTION
Add const qualifier to log_dynamic_source_id and dynamic level check casts to prevent discarding const qualifier during pointer conversion. Shorten macro argument names to follow 100 characters per line limit.

Add const qualifier to macros in log_msg.h that call other functions from that file.

This resolves compiler warnings when building Zephyr modules with strict warnings enabled (-Wcast-qual).