### PR TITLE
soc: st: stm32: common: put I/O cell-related options in a menu

### DIFF
--- a/soc/st/stm32/common/Kconfig
+++ b/soc/st/stm32/common/Kconfig
@@ -52,7 +52,7 @@ config STM32_BACKUP_PROTECTION
 	  Enabled for SoCs for which access protection to backup domain
 	  resources needs to be explicitly handled.
 
-config STM32_IOCELL
+menuconfig STM32_IOCELL
 	bool "STM32 I/O cell"
 	default y
 	depends on DT_HAS_ST_STM32_IOCELL_ENABLED
@@ -62,14 +62,15 @@ config STM32_IOCELL
 config STM32_IOCELL_PRIORITY
 	int "STM32 I/O cell initialization priority"
 	default 50
+	depends on STM32_IOCELL
 	help
 	  Initialization priority of the routine within the EARLY level.
 
 config STM32_IOCELL_CHECK_ENABLE
 	bool "STM32 I/O cell check"
 	default y
+	depends on STM32_IOCELL
 	depends on LOG
-	depends on DT_HAS_ST_STM32_IOCELL_ENABLED
 	help
 	  Enables logging of I/O cell driver. This can be useful for reporting
 	  discrepancy between device-tree configuration and value stored in


### PR DESCRIPTION
Group all I/O cell-related options in a menu by using menuconfig on option `STM32_IOCELL`. While at it, also fix the driver configuration options which were not gated by `STM32_IOCELL` and could thus leak.