### PR TITLE
arch: riscv: fix SBI SRST unsupported return

### DIFF
--- a/arch/riscv/core/sbi.S
+++ b/arch/riscv/core/sbi.S
@@ -172,7 +172,7 @@ m_mode_srst_loop:
 
 m_mode_srst_unsupported:
     li a0, SBI_ERR_NOT_SUPPORTED
-    sr a0, 3 * REGBYTES(sp)
+    sr a0, OFF_A0(sp)
     j m_mode_return
 
 m_mode_handle_interrupt:


### PR DESCRIPTION
  Fix the RISC-V internal SBI handler's unsupported SRST function path.

  The handler loaded `SBI_ERR_NOT_SUPPORTED` into `a0`, but stored it into
  `3 * REGBYTES(sp)`, which is the saved `t2` slot. As a result, S-mode callers
  kept the old `a0` value after `mret`, while `t2` was restored as `-1`.

  Use the existing `OFF_A0` stack offset so the SBI error is returned in `a0`.

  Fixes #113149.