### PR TITLE
drivers: spi: stm32: Enable control of SPI pins when peripheral is idle

### DIFF
--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1333,6 +1333,14 @@ static int spi_stm32_configure(const struct device *dev,
 	}
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+	if (cfg->gpio_control) {
+		LL_SPI_EnableGPIOControl(cfg->spi);
+	} else {
+		LL_SPI_DisableGPIOControl(cfg->spi);
+	}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+
 	if (SPI_MODE_GET(config->operation) & SPI_MODE_CPOL) {
 		LL_SPI_SetClockPolarity(spi, STM32_SPI_CLOCK_POLARITY_HIGH);
 	} else {
@@ -2263,6 +2271,11 @@ static int spi_stm32_init(const struct device *dev)
 		(BUILD_ASSERT(DT_INST_PROP(id, st_fifo_threshold) <= DT_INST_PROP(id, fifo_size),\
 		     "FIFO threshold should be less than or equal to FIFO size.")))
 
+/* clang-format off */
+/* TODO This macro seems to be hand aligned. I have not found any way to modify
+ * it and then use 'git clang-format' without breaking the 100-character
+ * line length rule
+ */
 #define STM32_SPI_INIT(id)							\
 	SPI_STM32_CHECK_FIFO(id);						\
 										\
@@ -2286,6 +2299,7 @@ static int spi_stm32_init(const struct device *dev)
 			   (.use_subghzspi_nss =				\
 				DT_INST_PROP_OR(id, use_subghzspi_nss, false),))\
 		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi), (		\
+			.gpio_control =	DT_INST_PROP(id, st_gpio_control),	\
 			.midi_clocks = DT_INST_PROP(id, midi_clock),		\
 			.mssi_clocks = DT_INST_PROP(id, mssi_clock),		\
 			.fifo_size = DT_INST_PROP(id, fifo_size),		\
@@ -2320,5 +2334,6 @@ static int spi_stm32_init(const struct device *dev)
 				  &api_funcs);					\
 										\
 	STM32_SPI_IRQ_HANDLER(id)
+/* clang-format on */
 
 DT_INST_FOREACH_STATUS_OKAY(STM32_SPI_INIT)

--- a/drivers/spi/spi_stm32.c
+++ b/drivers/spi/spi_stm32.c
@@ -1333,6 +1333,14 @@ static int spi_stm32_configure(const struct device *dev,
 	}
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+	if (cfg->gpio_control) {
+		LL_SPI_EnableGPIOControl(cfg->spi);
+	} else {
+		LL_SPI_DisableGPIOControl(cfg->spi);
+	}
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
+
 	if (SPI_MODE_GET(config->operation) & SPI_MODE_CPOL) {
 		LL_SPI_SetClockPolarity(spi, STM32_SPI_CLOCK_POLARITY_HIGH);
 	} else {
@@ -2258,6 +2266,7 @@ static int spi_stm32_init(const struct device *dev)
 		(BUILD_ASSERT(DT_INST_PROP(id, st_fifo_threshold) <= DT_INST_PROP(id, fifo_size),\
 		     "FIFO threshold should be less than or equal to FIFO size.")))
 
+/* clang-format off */
 #define STM32_SPI_INIT(id)							\
 	SPI_STM32_CHECK_FIFO(id);						\
 										\
@@ -2280,6 +2289,7 @@ static int spi_stm32_init(const struct device *dev)
 		IF_ENABLED(DT_INST_NODE_HAS_COMPAT(id, st_stm32_spi_subghz),	\
 			   (.is_subghzspi = true,))				\
 		IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi), (		\
+			.gpio_control =	DT_INST_PROP(id, st_gpio_control),	\
 			.midi_clocks = DT_INST_PROP(id, midi_clock),		\
 			.mssi_clocks = DT_INST_PROP(id, mssi_clock),		\
 			.fifo_size = DT_INST_PROP(id, fifo_size),		\
@@ -2314,5 +2324,6 @@ static int spi_stm32_init(const struct device *dev)
 				  &api_funcs);					\
 										\
 	STM32_SPI_IRQ_HANDLER(id)
+/* clang-format on */
 
 DT_INST_FOREACH_STATUS_OKAY(STM32_SPI_INIT)

--- a/drivers/spi/spi_stm32.h
+++ b/drivers/spi/spi_stm32.h
@@ -37,6 +37,7 @@ struct spi_stm32_config {
 	int mssi_clocks;
 	uint32_t fifo_max_transfer_size;
 	uint8_t fifo_size;
+	bool gpio_control: 1;
 #endif
 	bool ioswp: 1;
 	bool soft_nss: 1;

--- a/dts/bindings/spi/st,stm32h7-spi.yaml
+++ b/dts/bindings/spi/st,stm32h7-spi.yaml
@@ -48,3 +48,11 @@ properties:
       Threshold level for the Tx and Rx FIFOs (in bytes).
       This value defines the maximum number of bytes in a single packet. It is
       recommended that the size of a packet does not exceed half of the FIFO size.
+
+  st,gpio-control:
+    type: boolean
+    description: |
+      When set, the SPI driver will control the SPI GPIOs (e.g. SCK, MOSI, MISO)
+      even when the SPI peripheral is disabled. This can be used to ensure a known
+      state on the SPI lines at all times, which may be required for certain
+      peripherals (e.g. LED strips) that are sensitive to line states during idle.

--- a/dts/bindings/spi/st,stm32h7-spi.yaml
+++ b/dts/bindings/spi/st,stm32h7-spi.yaml
@@ -48,3 +48,11 @@ properties:
       Threshold level for the Tx and Rx FIFOs (in bytes).
       This value defines the maximum number of bytes in a single packet. It is
       recommended that the size of a packet does not exceed half of the FIFO size.
+
+  st,gpio-control:
+    type: boolean
+    description: |
+      When set, the SPI driver will control the SPI GPIOs (e.g. SCK, SDO, SDI)
+      even when the SPI peripheral is disabled. This can be used to ensure a known
+      state on the SPI lines at all times, which may be required for certain
+      peripherals (e.g. LED strips) that are sensitive to line states during idle.


### PR DESCRIPTION
The MOSI of the STM32 SPI controller is floating when the SPI is idle. As we use a pull-up on that pin (it is used as a multi-function pin), this causes an idle-high voltage on the MOSI pin. We use the MOSI pin for control of WS2812 LEDs, and they require an idle-low voltage.

Add a devicetree setting 'st,gpio-control' so the SPI controller keeps control of the MOSI pin also between transmissions. This enables the AFCNTR bit in the STM32 SPI controller, via the LL_SPI_EnableGPIOControl() HAL function.

The functionality is available for SPI in STM32H7, STM32H5, STM32C5 and some other series: all that rely on "st,stm32h7-spi" DT compatible ID.

Tested on STM32H562.