### PR TITLE
drivers: clock_control: esp32: fix esp32p4 deep-sleep timer wake

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -113,7 +113,7 @@ static int clock_control_esp32_configure(const struct device *dev, clock_control
 
 	switch ((int)sys) {
 	case ESP32_CLOCK_CONTROL_SUBSYS_RTC_FAST:
-		rtc_clk_fast_src_set(new_cfg->rtc.rtc_fast_clock_src);
+		esp32_select_rtc_fast_clk(new_cfg->rtc.rtc_fast_clock_src);
 		break;
 	case ESP32_CLOCK_CONTROL_SUBSYS_RTC_SLOW:
 		ret = esp32_select_rtc_slow_clk(new_cfg->rtc.rtc_slow_clock_src);
@@ -149,7 +149,7 @@ static int clock_control_esp32_init(const struct device *dev)
 		return ret;
 	}
 
-	rtc_clk_fast_src_set(cfg->rtc.rtc_fast_clock_src);
+	esp32_select_rtc_fast_clk(cfg->rtc.rtc_fast_clock_src);
 
 	ret = esp32_select_rtc_slow_clk(cfg->rtc.rtc_slow_clock_src);
 	if (ret) {

--- a/drivers/clock_control/clock_control_esp32_pmu.c
+++ b/drivers/clock_control/clock_control_esp32_pmu.c
@@ -120,6 +120,17 @@ int esp32_select_rtc_slow_clk(uint8_t slow_clk)
 	return 0;
 }
 
+void esp32_select_rtc_fast_clk(uint8_t fast_clk)
+{
+	rtc_clk_fast_src_set(fast_clk);
+
+#if SOC_CLK_LP_FAST_SUPPORT_XTAL
+	if (fast_clk == SOC_RTC_FAST_CLK_SRC_XTAL) {
+		esp_sleep_sub_mode_config(ESP_SLEEP_RTC_FAST_USE_XTAL_MODE, true);
+	}
+#endif
+}
+
 static bool clock_init_done;
 
 static void esp32_cpu_clock_init(const struct esp32_cpu_clock_config *cpu_cfg)
@@ -142,6 +153,10 @@ static void esp32_cpu_clock_init(const struct esp32_cpu_clock_config *cpu_cfg)
 	REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_FORCE_DIG_DREG, 1);
 	REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_XPD_RTC_REG, 0);
 	REGI2C_WRITE_MASK(I2C_DIG_REG, I2C_DIG_REG_XPD_DIG_REG, 0);
+	REGI2C_WRITE_MASK(I2C_BIAS, I2C_BIAS_OR_FORCE_XPD_CK, 0);
+	REGI2C_WRITE_MASK(I2C_BIAS, I2C_BIAS_OR_FORCE_XPD_REF_OUT_BUF, 0);
+	REGI2C_WRITE_MASK(I2C_BIAS, I2C_BIAS_OR_FORCE_XPD_IPH, 0);
+	REGI2C_WRITE_MASK(I2C_BIAS, I2C_BIAS_OR_FORCE_XPD_VGATE_BUF, 0);
 #elif defined(CONFIG_SOC_SERIES_ESP32H2)
 	REGI2C_WRITE_MASK(I2C_PMU, I2C_PMU_OC_SCK_DCAP, rtc_clk_cfg.slow_clk_dcap);
 	REGI2C_WRITE_MASK(I2C_PMU, I2C_PMU_EN_I2C_RTC_DREG, 0);

--- a/drivers/clock_control/clock_control_esp32_priv.h
+++ b/drivers/clock_control/clock_control_esp32_priv.h
@@ -76,6 +76,7 @@
 #include <soc/lp_clkrst_reg.h>
 #include <soc/pmu_reg.h>
 #include <soc/regi2c_dig_reg.h>
+#include <soc/regi2c_bias.h>
 #include <regi2c_ctrl.h>
 #include <esp32p4/rom/rtc.h>
 #include <soc/dport_access.h>
@@ -90,6 +91,7 @@
 #include <esp_cpu.h>
 #include <esp_private/esp_clk.h>
 #include <esp_private/esp_clk_tree_common.h>
+#include <esp_private/esp_sleep_internal.h>
 #include <esp_private/periph_ctrl.h>
 #include <esp_private/rtc_clk.h>
 #include <esp_rom_caps.h>
@@ -113,6 +115,8 @@
  * build, selected from CMakeLists.txt by SoC series.
  */
 int esp32_select_rtc_slow_clk(uint8_t slow_clk);
+
+void esp32_select_rtc_fast_clk(uint8_t fast_clk);
 
 int esp32_cpu_clock_configure(const struct esp32_cpu_clock_config *cpu_cfg);
 

--- a/drivers/clock_control/clock_control_esp32_rtc_cntl.c
+++ b/drivers/clock_control/clock_control_esp32_rtc_cntl.c
@@ -103,6 +103,11 @@ int esp32_select_rtc_slow_clk(uint8_t slow_clk)
 	return 0;
 }
 
+void esp32_select_rtc_fast_clk(uint8_t fast_clk)
+{
+	rtc_clk_fast_src_set(fast_clk);
+}
+
 #undef ESP32_RTC_EXT_SLOW_CLK_SRC
 #undef ESP32_RTC_EXT_CLK_CAL_SRC
 

--- a/samples/boards/espressif/deep_sleep/boards/esp32p4x_function_ev_board_hpcore.overlay
+++ b/samples/boards/espressif/deep_sleep/boards/esp32p4x_function_ev_board_hpcore.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		wakeup-pins = &wakeup_pins;
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+
+		wakeup_pins: wakeup_pins {
+			gpios = <&gpio0 2 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH | GPIO_INT_WAKEUP)>;
+		};
+	};
+};

--- a/soc/espressif/common/poweroff.c
+++ b/soc/espressif/common/poweroff.c
@@ -11,6 +11,10 @@
 #include <hal/pmu_ll.h>
 #endif
 
+#if defined(CONFIG_SOC_SERIES_ESP32P4) && !defined(CONFIG_PM)
+extern esp_err_t sleep_clock_icg_startup_init(void);
+#endif
+
 void z_sys_poweroff(void)
 {
 	/* Forces RTC domain to be always on */
@@ -28,6 +32,15 @@ void z_sys_poweroff(void)
 
 #if CONFIG_PM
 	esp32_sleep_gpio_prepare();
+#endif
+
+#if defined(CONFIG_SOC_SERIES_ESP32P4) && !defined(CONFIG_PM)
+	/*
+	 * Deep-sleep entry needs the REGDMA clock-ICG context. The PM path
+	 * sets it up during sleep retention init; deep-sleep-only builds have
+	 * no such path, so set it up here before entering deep sleep.
+	 */
+	sleep_clock_icg_startup_init();
 #endif
 	esp_deep_sleep_start();
 }

--- a/soc/espressif/esp32c5/hw_init.c
+++ b/soc/espressif/esp32c5/hw_init.c
@@ -70,7 +70,6 @@ int hardware_init(void)
 	esp_cpu_configure_invalid_regions();
 
 	bootloader_clock_configure();
-	esp_clk_tree_initialize();
 
 #ifdef CONFIG_ESP_CONSOLE
 	esp_console_init();

--- a/soc/espressif/esp32c5/mcuboot.ld
+++ b/soc/espressif/esp32c5/mcuboot.ld
@@ -337,6 +337,16 @@ SECTIONS
     _bss_end = ABSOLUTE(.);
   } > dram_seg
 
+  /* Sleep support code links into the bootloader and keeps its state in
+   * RTC-retained sections. The bootloader has no RTC-slow region, so collect
+   * them into the data segment to keep the symbols defined.
+   */
+  .rtc.data (NOLOAD) :
+  {
+    *(.rtc.force_slow .rtc.force_slow.*)
+    *(.rtc.force_fast .rtc.force_fast.*)
+  } > dram_seg
+
   /* linker rel sections*/
   #include <zephyr/linker/rel-sections.ld>
 

--- a/soc/espressif/esp32p4/hw_init.c
+++ b/soc/espressif/esp32p4/hw_init.c
@@ -55,7 +55,6 @@ int hardware_init(void)
 	soc_hw_init();
 	ana_reset_config();
 	super_wdt_auto_feed();
-	esp_clk_tree_initialize();
 	bootloader_clock_configure();
 
 	/* The ROM bootloader leaves PSRAM module clocks gated. Enable them

--- a/soc/espressif/esp32p4/mcuboot.ld
+++ b/soc/espressif/esp32p4/mcuboot.ld
@@ -341,6 +341,16 @@ SECTIONS
     _bss_end = ABSOLUTE(.);
   } > dram_seg
 
+  /* Sleep support code links into the bootloader and keeps its state in
+   * RTC-retained sections. The bootloader has no RTC-slow region, so collect
+   * them into the data segment to keep the symbols defined.
+   */
+  .rtc.data (NOLOAD) :
+  {
+    *(.rtc.force_slow .rtc.force_slow.*)
+    *(.rtc.force_fast .rtc.force_fast.*)
+  } > dram_seg
+
   /* linker rel sections*/
   #include <zephyr/linker/rel-sections.ld>
 


### PR DESCRIPTION
ESP32-P4 did not wake from a timer-based deep sleep. When the RTC_FAST clock is sourced from the XTAL (as selected in the P4 devicetree), the driver set the fast clock source but never enabled the RTC_FAST_USE_XTAL sleep sub-mode. As a result the XTAL was powered down during deep sleep, and since the P4 has no ROM deep-sleep wake stub, the full-reset wake sequence stalled and the chip never came back.

This adds a shared esp32_select_rtc_fast_clk() helper that sets the fast clock source and, on PMU SoCs, enables the XTAL sleep sub-mode when XTAL is the RTC_FAST source. The P4 clock init is also aligned with the expected I2C bias configuration.

A deep_sleep sample overlay is added for the ESP32-P4X function EV board