### PR TITLE
Bluetooth: ISO: Add getter for ISO chan from ISO bt_conn and fix printing in the shell

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -186,6 +186,7 @@ New APIs and options
       to request a specific TX power level per extended advertising set.
     * :c:member:`bt_conn_cb.le_param_update_rejected`
     * :c:func:`bt_iso_get_chan_by_conn`
+    * :c:func:`bt_iso_chan_state_str`
 
   * Mesh
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -185,6 +185,7 @@ New APIs and options
     * :c:member:`bt_le_adv_param.tx_power` and :c:enumerator:`BT_LE_ADV_OPT_TX_POWER`
       to request a specific TX power level per extended advertising set.
     * :c:member:`bt_conn_cb.le_param_update_rejected`
+    * :c:func:`bt_iso_get_chan_by_conn`
 
   * Mesh
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -430,6 +430,7 @@ New APIs and options
 
     * :c:func:`bt_conn_take`
     * :c:func:`bt_conn_drop`
+    * :c:func:`bt_iso_chan_state_str`
     * :c:func:`bt_iso_get_chan_by_conn`
     * :c:func:`bt_le_per_adv_update_did`
     * :c:member:`bt_le_adv_param.tx_power` and :c:enumerator:`BT_LE_ADV_OPT_TX_POWER`

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -430,6 +430,7 @@ New APIs and options
 
     * :c:func:`bt_conn_take`
     * :c:func:`bt_conn_drop`
+    * :c:func:`bt_iso_get_chan_by_conn`
     * :c:func:`bt_le_per_adv_update_did`
     * :c:member:`bt_le_adv_param.tx_power` and :c:enumerator:`BT_LE_ADV_OPT_TX_POWER`
       to request a specific TX power level per extended advertising set.

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -1327,6 +1327,14 @@ int bt_iso_big_terminate(struct bt_iso_big *big);
 int bt_iso_big_sync(struct bt_le_per_adv_sync *sync, struct bt_iso_big_sync_param *param,
 		    struct bt_iso_big **out_big);
 
+/**
+ * @brief Returns a string representation of an ISO channel state
+ *
+ * @param state The state of the channel
+ * @return A string representation, or "unknown" if unknown state.
+ */
+const char *bt_iso_chan_state_str(enum bt_iso_state state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -801,6 +801,16 @@ struct bt_iso_server {
 };
 
 /**
+ * @brief Lookup a bt_iso_chan object by its @ref bt_iso_chan.iso reference
+ *
+ * This is useful to get the corresponding bt_iso_chan object when using e.g. bt_conn_foreach.
+ *
+ * @param iso A connection object with type @ref BT_CONN_TYPE_ISO
+ * @return The corresponding bt_iso_chan object or NULL.
+ */
+struct bt_iso_chan *bt_iso_get_chan_by_conn(const struct bt_conn *iso);
+
+/**
  * @brief Register ISO server.
  *
  * Register ISO server, each new connection is authorized using the accept()

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -1337,6 +1337,14 @@ int bt_iso_big_terminate(struct bt_iso_big *big);
 int bt_iso_big_sync(struct bt_le_per_adv_sync *sync, struct bt_iso_big_sync_param *param,
 		    struct bt_iso_big **out_big);
 
+/**
+ * @brief Returns a string representation of an ISO channel state
+ *
+ * @param state The state of the channel
+ * @return A string representation, or "unknown" if unknown state.
+ */
+const char *bt_iso_chan_state_str(enum bt_iso_state state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -811,6 +811,16 @@ struct bt_iso_server {
 };
 
 /**
+ * @brief Lookup a bt_iso_chan object by its @ref bt_iso_chan.iso reference
+ *
+ * This is useful to get the corresponding bt_iso_chan object when using e.g. bt_conn_foreach.
+ *
+ * @param iso A connection object with type @ref BT_CONN_TYPE_ISO
+ * @return The corresponding bt_iso_chan object or NULL.
+ */
+struct bt_iso_chan *bt_iso_get_chan_by_conn(const struct bt_conn *iso);
+
+/**
  * @brief Register ISO server.
  *
  * Register ISO server, each new connection is authorized using the accept()

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -97,6 +97,21 @@ struct bt_iso_big bigs[CONFIG_BT_ISO_MAX_BIG];
 static struct bt_iso_big *lookup_big_by_handle(uint8_t big_handle);
 #endif /* CONFIG_BT_ISO_BROADCAST */
 
+struct bt_iso_chan *bt_iso_get_chan_by_conn(const struct bt_conn *iso)
+{
+	if (!IS_ARRAY_ELEMENT(iso_conns, iso)) {
+		LOG_DBG("Invalid iso %p pointer", iso);
+		return NULL;
+	}
+
+	if (iso->type != BT_CONN_TYPE_ISO) {
+		LOG_DBG("iso %p not initialized", iso);
+		return NULL;
+	}
+
+	return iso->iso.chan;
+}
+
 static void bt_iso_sent_cb(struct bt_conn *iso, void *user_data, int err)
 {
 #if defined(CONFIG_BT_ISO_TX)

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -559,8 +559,7 @@ void bt_iso_disconnected(struct bt_conn *iso)
 	bt_iso_chan_disconnected(chan, iso->err);
 }
 
-#if defined(CONFIG_BT_ISO_LOG_LEVEL_DBG)
-const char *bt_iso_chan_state_str(uint8_t state)
+const char *bt_iso_chan_state_str(enum bt_iso_state state)
 {
 	switch (state) {
 	case BT_ISO_STATE_DISCONNECTED:
@@ -575,6 +574,8 @@ const char *bt_iso_chan_state_str(uint8_t state)
 		return "unknown";
 	}
 }
+
+#if defined(CONFIG_BT_ISO_LOG_LEVEL_DBG)
 
 void bt_iso_chan_set_state_debug(struct bt_iso_chan *chan, enum bt_iso_state state,
 				 const char *func, int line)

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -564,8 +564,7 @@ void bt_iso_disconnected(struct bt_conn *iso)
 	bt_iso_chan_disconnected(chan, iso->err);
 }
 
-#if defined(CONFIG_BT_ISO_LOG_LEVEL_DBG)
-const char *bt_iso_chan_state_str(uint8_t state)
+const char *bt_iso_chan_state_str(enum bt_iso_state state)
 {
 	switch (state) {
 	case BT_ISO_STATE_DISCONNECTED:
@@ -580,6 +579,8 @@ const char *bt_iso_chan_state_str(uint8_t state)
 		return "unknown";
 	}
 }
+
+#if defined(CONFIG_BT_ISO_LOG_LEVEL_DBG)
 
 void bt_iso_chan_set_state_debug(struct bt_iso_chan *chan, enum bt_iso_state state,
 				 const char *func, int line)

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -4459,11 +4459,12 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 				return;
 			}
 
-			bt_shell_print("%s#%u [ISO][%s]: ISO interval %u us%s%s", selected, info.id,
-				       iso_chan_type_str(iso_info.type),
+			bt_shell_print("%s#%u [ISO][%s]: ISO interval %u us%s%s (%s)", selected,
+				       info.id, iso_chan_type_str(iso_info.type),
 				       BT_GAP_ISO_INTERVAL_TO_US(iso_info.iso_interval),
 				       iso_info.can_send ? " TX" : "",
-				       iso_info.can_recv ? " RX" : "");
+				       iso_info.can_recv ? " RX" : "",
+				       bt_iso_chan_state_str(chan->state));
 		} else {
 			return; /* return to avoid incrementing conn_count */
 		}

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -3930,6 +3930,26 @@ static const char *get_conn_role_str(uint8_t role)
 	}
 }
 
+#if defined(CONFIG_BT_ISO)
+static const char *iso_chan_type_str(enum bt_iso_chan_type type)
+{
+	switch (type) {
+	case BT_ISO_CHAN_TYPE_NONE:
+		return "None";
+	case BT_ISO_CHAN_TYPE_CENTRAL:
+		return "Central";
+	case BT_ISO_CHAN_TYPE_PERIPHERAL:
+		return "Peripheral";
+	case BT_ISO_CHAN_TYPE_BROADCASTER:
+		return "Broadcaster";
+	case BT_ISO_CHAN_TYPE_SYNC_RECEIVER:
+		return "Sync Receiver";
+	default:
+		return "Unknown";
+	}
+}
+#endif /* CONFIG_BT_ISO */
+
 static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_conn *conn = NULL;
@@ -4424,10 +4444,32 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 			       conn_state_to_str(info.state));
 		break;
 #if defined(CONFIG_BT_ISO)
-	case BT_CONN_TYPE_ISO:
-		bt_shell_print(" #%u [ISO][%s] %s (%s)", info.id, role_str, bt_conn_dst_str(conn),
-			       conn_state_to_str(info.state));
+	case BT_CONN_TYPE_ISO: {
+		const struct bt_iso_chan *chan = bt_iso_get_chan_by_conn(conn);
+
+		if (chan != NULL) {
+			struct bt_iso_info iso_info;
+
+			selected = chan == &iso_chan ? "*" : " ";
+
+			err = bt_iso_chan_get_info(chan, &iso_info);
+			if (err != 0) {
+				bt_shell_error("Unable to get ISO info: chan %p (err %d)", chan,
+					       err);
+				return;
+			}
+
+			bt_shell_print("%s#%u [ISO][%s]: ISO interval %u us%s%s", selected, info.id,
+				       iso_chan_type_str(iso_info.type),
+				       BT_GAP_ISO_INTERVAL_TO_US(iso_info.iso_interval),
+				       iso_info.can_send ? " TX" : "",
+				       iso_info.can_recv ? " RX" : "");
+		} else {
+			return; /* return to avoid incrementing conn_count */
+		}
+
 		break;
+	}
 #endif
 	default:
 		break;

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -3955,6 +3955,26 @@ static const char *get_conn_role_str(uint8_t role)
 	}
 }
 
+#if defined(CONFIG_BT_ISO)
+static const char *iso_chan_type_str(enum bt_iso_chan_type type)
+{
+	switch (type) {
+	case BT_ISO_CHAN_TYPE_NONE:
+		return "None";
+	case BT_ISO_CHAN_TYPE_CENTRAL:
+		return "Central";
+	case BT_ISO_CHAN_TYPE_PERIPHERAL:
+		return "Peripheral";
+	case BT_ISO_CHAN_TYPE_BROADCASTER:
+		return "Broadcaster";
+	case BT_ISO_CHAN_TYPE_SYNC_RECEIVER:
+		return "Sync Receiver";
+	default:
+		return "Unknown";
+	}
+}
+#endif /* CONFIG_BT_ISO */
+
 static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 {
 	struct bt_conn *conn = NULL;
@@ -4449,10 +4469,32 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 			       conn_state_to_str(info.state));
 		break;
 #if defined(CONFIG_BT_ISO)
-	case BT_CONN_TYPE_ISO:
-		bt_shell_print(" #%u [ISO][%s] %s (%s)", info.id, role_str, bt_conn_dst_str(conn),
-			       conn_state_to_str(info.state));
+	case BT_CONN_TYPE_ISO: {
+		const struct bt_iso_chan *chan = bt_iso_get_chan_by_conn(conn);
+
+		if (chan != NULL) {
+			struct bt_iso_info iso_info;
+
+			selected = chan == &iso_chan ? "*" : " ";
+
+			err = bt_iso_chan_get_info(chan, &iso_info);
+			if (err != 0) {
+				bt_shell_error("Unable to get ISO info: chan %p (err %d)", chan,
+					       err);
+				return;
+			}
+
+			bt_shell_print("%s#%u [ISO][%s]: ISO interval %u us%s%s", selected, info.id,
+				       iso_chan_type_str(iso_info.type),
+				       BT_GAP_ISO_INTERVAL_TO_US(iso_info.iso_interval),
+				       iso_info.can_send ? " TX" : "",
+				       iso_info.can_recv ? " RX" : "");
+		} else {
+			return; /* return to avoid incrementing conn_count */
+		}
+
 		break;
+	}
 #endif
 	default:
 		break;

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -4484,11 +4484,12 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 				return;
 			}
 
-			bt_shell_print("%s#%u [ISO][%s]: ISO interval %u us%s%s", selected, info.id,
-				       iso_chan_type_str(iso_info.type),
+			bt_shell_print("%s#%u [ISO][%s]: ISO interval %u us%s%s (%s)", selected,
+				       info.id, iso_chan_type_str(iso_info.type),
 				       BT_GAP_ISO_INTERVAL_TO_US(iso_info.iso_interval),
 				       iso_info.can_send ? " TX" : "",
-				       iso_info.can_recv ? " RX" : "");
+				       iso_info.can_recv ? " RX" : "",
+				       bt_iso_chan_state_str(chan->state));
 		} else {
 			return; /* return to avoid incrementing conn_count */
 		}


### PR DESCRIPTION
Add a new getting function that is used by the shell to get information about the ISO connection in a meaningful way. 