### PR TITLE
dts: add macros for iterating over cpu nodes

### DIFF
--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -79,7 +79,7 @@ volatile struct boot_params arm_cpu_boot_params = {
 };
 
 const uint32_t cpu_node_list[] = {
-	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))};
+	DT_CPUS_FOREACH_OKAY_SEP(DT_REG_ADDR, (,))};
 
 /* cpu_map saves the mapping of core id and mpid */
 static uint32_t cpu_map[CONFIG_MP_MAX_NUM_CPUS] = {

--- a/arch/arm64/core/macro_priv.inc
+++ b/arch/arm64/core/macro_priv.inc
@@ -25,7 +25,7 @@
  * Get CPU logic id by looking up cpu_node_list
  * returns
  *   xreg0: MPID
- *   xreg1: logic id (0 ~ DT_CHILD_NUM_STATUS_OKAY(DT_PATH(cpus)) - 1)
+ *   xreg1: logic id (0 ~ DT_CPUS_NUM_OKAY - 1)
  * clobbers: xreg0, xreg1, xreg2, xreg3
  */
 .macro get_cpu_logic_id xreg0, xreg1, xreg2, xreg3
@@ -36,7 +36,7 @@
 	cmp	\xreg2, \xreg0
 	beq	2f
 	add	\xreg1, \xreg1, 1
-	cmp	\xreg1, #DT_CHILD_NUM_STATUS_OKAY(DT_PATH(cpus))
+	cmp	\xreg1, #DT_CPUS_NUM_OKAY
 	bne	1b
 	b	.
 2:

--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -164,7 +164,7 @@ resetwait:
 	/* wait */
 	bne	2b
 	add	x5, x5, #1
-	cmp	x5, #DT_CHILD_NUM_STATUS_OKAY(DT_PATH(cpus))
+	cmp	x5, #DT_CPUS_NUM_OKAY
 	bne	2b
 
 

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -36,7 +36,7 @@
 struct boot_params {
 	uint64_t mpid;
 	char *sp;
-	uint8_t voting[DT_CHILD_NUM_STATUS_OKAY(DT_PATH(cpus))];
+	uint8_t voting[DT_CPUS_NUM_OKAY];
 	arch_cpustart_t fn;
 	void *arg;
 	int cpu_num;
@@ -52,10 +52,10 @@ volatile struct boot_params __aligned(L1_CACHE_BYTES) arm64_cpu_boot_params = {
 };
 
 const uint64_t cpu_node_list[] = {
-	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))
+	DT_CPUS_FOREACH_OKAY_SEP(DT_REG_ADDR, (,))
 };
 
-BUILD_ASSERT(ARRAY_SIZE(cpu_node_list) == DT_CHILD_NUM_STATUS_OKAY(DT_PATH(cpus)));
+BUILD_ASSERT(ARRAY_SIZE(cpu_node_list) == DT_CPUS_NUM_OKAY);
 
 /* cpu_map saves the mapping of core id and mpid */
 static uint64_t cpu_map[CONFIG_MP_MAX_NUM_CPUS] = {

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -51,7 +51,7 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 #endif
 #if ((CONFIG_MP_MAX_NUM_CPUS) > 1)
 	unsigned int cpu_node_list[] = {
-		DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))
+		DT_CPUS_FOREACH_OKAY_SEP(DT_REG_ADDR, (,))
 	};
 	unsigned int cpu_num, hart_x;
 

--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -437,6 +437,13 @@ other-macro =/ %s"DT_COMPAT_HAS_OKAY_" dt-name
 other-macro =/ %s"DT_COMPAT_" dt-name %s"_LABEL_" dt-name
 ; Get the node label of the phandle
 other-macro =/ %s"DT_N_NODELABEL_" %s"DT_N" path-id "_IDX_" DIGIT "_C_TOKEN"
+; Total number of cpu nodes
+other-macro = %s"DT_CPUS_NUM_OKAY"
+; These are used to iterate over each cpu node.
+other-macro =/ %s"DT_CPUS_FOREACH_OKAY"
+other-macro =/ %s"DT_CPUS_FOREACH_OKAY_VARGS"
+other-macro =/ %s"DT_CPUS_FOREACH_OKAY_SEP"
+other-macro =/ %s"DT_CPUS_FOREACH_OKAY_SEP_VARGS"
 
 ; --------------------------------------------------------------------
 ; alternate-id: another way to specify a node besides a path-id

--- a/doc/build/kconfig/preprocessor-functions.rst
+++ b/doc/build/kconfig/preprocessor-functions.rst
@@ -45,6 +45,7 @@ while the ``*_hex`` version returns a hexadecimal value starting with ``0x``.
    $(dt_compat_enabled,<compatible string>)
    $(dt_compat_enabled_num,<compatible string>)
    $(dt_compat_on_bus,<compatible string>,<bus>)
+   $(dt_cpus_num)
    $(dt_gpio_hogs_enabled)
    $(dt_has_compat,<compatible string>)
    $(dt_highest_controller_irq_number,<node path>,<cell>)

--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -28,7 +28,7 @@
 #endif
 
 static const uint64_t cpu_mpid_list[] = {
-	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))
+	DT_CPUS_FOREACH_OKAY_SEP(DT_REG_ADDR, (,))
 };
 
 BUILD_ASSERT(ARRAY_SIZE(cpu_mpid_list) >= CONFIG_MP_MAX_NUM_CPUS,

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -924,7 +924,7 @@ SHELL_CMD_REGISTER(plic, &plic_cmds, "PLIC shell commands", NULL);
 
 #define HART_CONTEXTS(i, n) IF_ENABLED(IS_EQ(DT_INST_IRQN_BY_IDX(n, i), DT_INST_IRQN(n)), (i,))
 #define PLIC_HART_CONTEXT_DECLARE(n)                                                               \
-	INTC_PLIC_STATIC const uint32_t plic_hart_contexts_##n[DT_CHILD_NUM(DT_PATH(cpus))] = {    \
+	INTC_PLIC_STATIC const uint32_t plic_hart_contexts_##n[DT_CPUS_NUM_OKAY] = {               \
 		LISTIFY(DT_INST_NUM_IRQS(n), HART_CONTEXTS, (), n)}
 
 #define PLIC_INTC_CONFIG_INIT(n)                                                                   \

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -1247,6 +1247,41 @@ def write_global_macros(edt: edtlib.EDT):
             out_dt_define(f"{bus_id}_DESCENDANT_NUM_ON_BUS_{bus_ident}", count)
             out_dt_define(f"{bus_id}_DESCENDANT_NUM_ON_BUS_{bus_ident}_STATUS_OKAY", count_ok)
 
+    cpu_nodes = list(
+        filter(
+            lambda n: n.path.startswith("/cpus/cpu@")
+            and n.parent.path == "/cpus"
+            and n.status == "okay",
+            edt.nodes,
+        )
+    )
+    ident = "CPUS"
+
+    out_comment('Macros for status "okay" /cpus/cpu* nodes\n')
+
+    out_dt_define(f"{ident}_NUM_OKAY", len(cpu_nodes))
+
+    out_dt_define(
+        f"{ident}_FOREACH_OKAY(fn)", " ".join(f"fn(DT_{node.z_path_id})" for node in cpu_nodes)
+    )
+
+    out_dt_define(
+        f"{ident}_FOREACH_OKAY_VARGS(fn, ...)",
+        " ".join(f"fn(DT_{node.z_path_id}, __VA_ARGS__)" for node in cpu_nodes),
+    )
+
+    out_dt_define(
+        f"{ident}_FOREACH_OKAY_SEP(fn, sep)",
+        " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{node.z_path_id})" for node in cpu_nodes),
+    )
+
+    out_dt_define(
+        f"{ident}_FOREACH_OKAY_SEP_VARGS(fn, sep, ...)",
+        " DT_DEBRACKET_INTERNAL sep ".join(
+            f"fn(DT_{node.z_path_id}, __VA_ARGS__)" for node in cpu_nodes
+        ),
+    )
+
 
 def str2ident(s: str) -> str:
     # Converts 's' to a form suitable for (part of) an identifier

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -922,6 +922,26 @@ def dt_compat_any_not_has_prop(kconf, _, compat, prop):
 
     return "n"
 
+
+def dt_cpus_num(kconf, _):
+    """
+    Return the number of CPU nodes with status "okay".
+    """
+    if doc_mode or edt is None:
+        return "0"
+
+    cpu_nodes = list(
+        filter(
+            lambda n: n.path.startswith("/cpus/cpu@")
+            and n.parent.path == "/cpus"
+            and n.status == "okay",
+            edt.nodes,
+        )
+    )
+
+    return str(len(cpu_nodes))
+
+
 def dt_nodelabel_has_compat(kconf, _, label, compat):
     """
     This function takes a 'label' and looks for an EDT node with that label.
@@ -1280,6 +1300,7 @@ functions = {
         "dt_compat_all_has_prop": (dt_compat_all_has_prop, 2, 3),
         "dt_compat_any_has_prop": (dt_compat_any_has_prop, 2, 3),
         "dt_compat_any_not_has_prop": (dt_compat_any_not_has_prop, 2, 2),
+        "dt_cpus_num": (dt_cpus_num, 0, 0),
         "dt_chosen_label": (dt_chosen_label, 1, 1),
         "dt_chosen_enabled": (dt_chosen_enabled, 1, 1),
         "dt_chosen_path": (dt_chosen_path, 1, 1),

--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -8,7 +8,7 @@
 #include <zephyr/pm/state.h>
 #include <zephyr/toolchain.h>
 
-BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)),
+BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)) && (DT_CPUS_NUM_OKAY > 0),
 	     "cpus node not defined in Devicetree");
 
 #define DEFINE_CPU_STATES(n) \
@@ -16,16 +16,16 @@ BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)),
 		= PM_STATE_INFO_LIST_FROM_DT_CPU(n);
 #define CPU_STATE_REF(n) pmstates_##n
 
-DT_FOREACH_CHILD_STATUS_OKAY(DT_PATH(cpus), DEFINE_CPU_STATES);
+DT_CPUS_FOREACH_OKAY(DEFINE_CPU_STATES);
 
 /** CPU power states information for each CPU */
 static const struct pm_state_info *cpus_states[] = {
-	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), CPU_STATE_REF, (,))
+	DT_CPUS_FOREACH_OKAY_SEP(CPU_STATE_REF, (,))
 };
 
 /** Number of states for each CPU */
 static const uint8_t states_per_cpu[] = {
-	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_NUM_CPU_POWER_STATES, (,))
+	DT_CPUS_FOREACH_OKAY_SEP(DT_NUM_CPU_POWER_STATES, (,))
 };
 
 #define DEFINE_DISABLED_PM_STATE(node) \


### PR DESCRIPTION
As there can be other nodes in /cpus/* then cpus,
add a macros, that only onlude cpus.
As the devicetree specification explicitly states, that the nodes name of the cpus should be
cpu, we can easily filter for it.