### PR TITLE
tests: posix/semaphore: fix fault when CONFIG_KERNEL_COHERENCE=y

### DIFF
--- a/tests/subsys/portability/posix/semaphores/src/main.c
+++ b/tests/subsys/portability/posix/semaphores/src/main.c
@@ -140,7 +140,7 @@ static void semaphore_test(sem_t *sem)
 
 ZTEST(posix_semaphores, test_semaphore)
 {
-	sem_t sema;
+	static sem_t sema;
 
 	/* TESTPOINT: Call sem_post with invalid kobject */
 	zassert_equal(sem_post(NULL), -1,


### PR DESCRIPTION
test_semaphore declared its semaphore as stack local. On platforms with CONFIG_KERNEL_COHERENCE enabled, thread stacks live in cached, non-coherent memory. Kernel objects need to be in coherenet memory, or else kernel code will assert on these variables due to failing the sys_cache_is_mem_coherence() test.

So fix this by declaring the semaphore static so it will reside in coherent memory.