### PR TITLE
tests: zbus: ipc_backend/proxy_agent: fix fault if CONFIG_KERNEL_COHERENCE=y

### DIFF
--- a/tests/subsys/zbus/proxy_agent/ipc_backend/src/main.c
+++ b/tests/subsys/zbus/proxy_agent/ipc_backend/src/main.c
@@ -119,7 +119,7 @@ ZTEST(ipc_backend, test_set_recv_cb)
 ZTEST(ipc_backend, test_backend_init)
 {
 	int ret;
-	struct zbus_proxy_agent_ipc_data ipc_data = {0};
+	static struct zbus_proxy_agent_ipc_data ipc_data = {0};
 	struct zbus_proxy_agent_ipc_config ipc_config = {
 		.dev = DEVICE_DT_GET(FAKE_IPC_NODE),
 		.ept_name = "test_ept",
@@ -171,7 +171,7 @@ ZTEST(ipc_backend, test_backend_init)
 ZTEST(ipc_backend, test_backend_send)
 {
 	int ret;
-	struct zbus_proxy_agent_ipc_data ipc_data = {0};
+	static struct zbus_proxy_agent_ipc_data ipc_data = {0};
 	struct zbus_proxy_agent_ipc_config ipc_config = {
 		.dev = DEVICE_DT_GET(FAKE_IPC_NODE),
 		.ept_name = "test_ept",
@@ -237,7 +237,7 @@ ZTEST(ipc_backend, test_backend_send)
 /* Test recv */
 ZTEST(ipc_backend, test_backend_recv)
 {
-	struct zbus_proxy_agent_ipc_data ipc_data = {0};
+	static struct zbus_proxy_agent_ipc_data ipc_data = {0};
 	struct zbus_proxy_agent_ipc_config ipc_config = {
 		.dev = DEVICE_DT_GET(FAKE_IPC_NODE),
 		.ept_name = "test_ept",
@@ -289,7 +289,7 @@ ZTEST(ipc_backend, test_backend_recv)
 
 ZTEST(ipc_backend, test_ipc_error)
 {
-	struct zbus_proxy_agent_ipc_data ipc_data = {0};
+	static struct zbus_proxy_agent_ipc_data ipc_data = {0};
 	struct zbus_proxy_agent_ipc_config ipc_config = {
 		.dev = DEVICE_DT_GET(FAKE_IPC_NODE),
 		.ept_name = "test_ept",

--- a/tests/subsys/zbus/proxy_agent/proxy_agent/src/main.c
+++ b/tests/subsys/zbus/proxy_agent/proxy_agent/src/main.c
@@ -189,11 +189,11 @@ ZTEST(zbus_proxy_agent_tests, test_zbus_init_proxy_agent_error_handling)
 		.data = &backend_data,
 		.name = "error_handling_agent",
 	};
-	struct k_thread thread;
-	struct k_msgq msgq;
+	static struct k_thread thread;
+	static struct k_msgq msgq;
 	k_tid_t thread_id = NULL;
-	char msgq_buf[CONFIG_ZBUS_PROXY_AGENT_RX_QUEUE_DEPTH *
-		      sizeof(struct zbus_proxy_agent_rx_msg)];
+	static char msgq_buf[CONFIG_ZBUS_PROXY_AGENT_RX_QUEUE_DEPTH *
+			     sizeof(struct zbus_proxy_agent_rx_msg)];
 	struct zbus_proxy_agent agent = {
 		.name = "error_handling_agent",
 		.backend_config = &backend_config,


### PR DESCRIPTION
Some tests declared their thread and kernel objects as stack locals. With CONFIG_KERNEL_COHERENCE enabled, thread stacks live in cached, non-coherent memory. Thread and kernel objects need to be in coherent memory, or else kernel code will assert on these variables due to sys_cache_is_mem_coherence() returning false.
    
So mark those kernel objects with static so they reside in coherent memory.