### PR TITLE
twister: Colorize console log output

### DIFF
--- a/scripts/pylib/twister/twisterlib/log_helper.py
+++ b/scripts/pylib/twister/twisterlib/log_helper.py
@@ -10,6 +10,8 @@ import os
 import platform
 import shlex
 
+from colorlog import ColoredFormatter
+
 _WINDOWS = platform.system() == 'Windows'
 
 
@@ -32,6 +34,7 @@ def log_command(logger, msg, args):
     else:
         logger.debug(msg, shlex.join(args))
 
+
 def setup_logging(outdir, log_file, log_level, timestamps):
     logger = logging.getLogger("twister")
     logger.setLevel(logging.DEBUG)
@@ -50,9 +53,11 @@ def setup_logging(outdir, log_file, log_level, timestamps):
 
     # create formatter and add it to the handlers
     if timestamps:
-        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        formatter = ColoredFormatter(
+            "%(asctime)s - %(log_color)s%(levelname)s%(reset)s - %(message)s"
+        )
     else:
-        formatter = logging.Formatter("%(levelname)-7s - %(message)s")
+        formatter = ColoredFormatter("%(log_color)s%(levelname)-7s%(reset)s - %(message)s")
 
     formatter_file = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/scripts/requirements-actions.in
+++ b/scripts/requirements-actions.in
@@ -3,6 +3,7 @@ anytree
 awscli
 canopen
 clang-format>=15.0.0
+colorlog
 elasticsearch<9
 exceptiongroup>=1.0.0rc8
 gcovr==6.0

--- a/scripts/requirements-actions.txt
+++ b/scripts/requirements-actions.txt
@@ -338,6 +338,7 @@ colorama==0.4.6 \
     # via
     #   awscli
     #   click
+    #   colorlog
     #   halo
     #   log-symbols
     #   pylint
@@ -345,6 +346,10 @@ colorama==0.4.6 \
     #   tox
     #   tqdm
     #   west
+colorlog==6.10.1 \
+    --hash=sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c \
+    --hash=sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321
+    # via -r requirements-actions.in
 cryptography==49.0.0 \
     --hash=sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001 \
     --hash=sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122 \

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -10,6 +10,9 @@ pyelftools>=0.29
 # twister to parse YAMLs, by west, zephyr_module,...
 PyYAML>=6.0
 
+# used by twister
+colorlog
+
 # YAML validation. Used by zephyr_module.
 pykwalify
 jsonschema


### PR DESCRIPTION
Use colorlog's `ColoredFormatter` for Twister's console formatter in both timestamped and non-timestamped modes to improve readability without changing file log formatting.

Example run:
<img width="1393" height="467" alt="image" src="https://github.com/user-attachments/assets/7192f9ea-3019-4e43-b0ab-fcadda9ee185" />

With DEBUG level:
<img width="1393" height="467" alt="image" src="https://github.com/user-attachments/assets/2cc17d0d-bf8d-4a44-a1ec-5d9bb1671c9a" />

*Note:*
line: `INFO    - Total complete:    1/   1  100%  built (not run):    0, filtered:    0, failed:    0, error:    0` is just `sys.stdout.write` so it is not colorized. 
<img width="1620" height="158" alt="image" src="https://github.com/user-attachments/assets/e32e7ce8-e7ca-4831-b7d5-b4ada34b03fd" />
