### PR TITLE
modules: lvgl: Fix pixel count variable overflow

### DIFF
--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -158,7 +158,7 @@ static int lvgl_allocate_rendering_buffers(lv_display_t *display)
 {
 	void *buf0 = NULL;
 	void *buf1 = NULL;
-	uint16_t buf_nbr_pixels;
+	uint32_t buf_nbr_pixels;
 	uint32_t buf_size;
 	struct lvgl_disp_data *data = (struct lvgl_disp_data *)lv_display_get_user_data(display);
 	uint16_t hor_res = lv_display_get_horizontal_resolution(display);


### PR DESCRIPTION
For larger resolution displays uint16_t might overflow. Make the type bigger to prevent this.

