### PR TITLE
drivers: haptics: Propagate haptics API changes to CS40L26/27 driver

### DIFF
--- a/drivers/haptics/cirrus/cs40l26-firmware.c
+++ b/drivers/haptics/cirrus/cs40l26-firmware.c
@@ -123,6 +123,26 @@ int cs40l26_firmware_read(const struct device *const dev, const uint32_t firmwar
 	return cs40lxx_read(&config->io_bus, firmware_address, rx);
 }
 
+int cs40l26_firmware_read_offset(const struct device *const dev, const uint32_t firmware_control,
+				 uint32_t *const rx, const off_t offset)
+{
+	const struct cs40l26_config *const config = dev->config;
+	uint32_t firmware_address;
+	int ret;
+
+	ret = cs40l26_get_firmware_address(dev, firmware_control, &firmware_address);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (!IN_RANGE((int64_t)offset, -(int64_t)firmware_address,
+		      (int64_t)(UINT32_MAX - firmware_address))) {
+		return -EINVAL;
+	}
+
+	return cs40lxx_read(&config->io_bus, firmware_address + offset, rx);
+}
+
 int cs40l26_firmware_burst_write(const struct device *const dev, const uint32_t firmware_control,
 				 uint32_t *const tx, const uint32_t len)
 {

--- a/drivers/haptics/cirrus/cs40l26.c
+++ b/drivers/haptics/cirrus/cs40l26.c
@@ -113,6 +113,18 @@ LOG_MODULE_REGISTER(CS40L26, CONFIG_HAPTICS_LOG_LEVEL);
 #define CS40L26_NUM_BUZ_EFFECTS     1
 #define CS40L26_FLASH_MEMORY_ERASED 0xFFFFFFFF
 
+enum cs40l26_monitor {
+	CS40L26_MONITOR_BEMF,
+	CS40L26_MONITOR_VBST,
+	CS40L26_MONITOR_VOUT,
+};
+
+static const struct cs40l26_sensor cs40l26_sensors[] = {
+	[HAPTICS_MONITOR_BEMF] = {.is_signed = true, .n = 23, .m = 0, .full_scale = 24},
+	[HAPTICS_MONITOR_VBST] = {.is_signed = false, .n = 24, .m = 0, .full_scale = 14},
+	[HAPTICS_MONITOR_VOUT] = {.is_signed = true, .n = 23, .m = 0, .full_scale = 24},
+};
+
 static const struct cs40lxx_multi_write cs40l26_irq_clear[] = {
 	{.addr = CS40L26_REG_IRQ1_EINT_1,
 	 CS40LXX_MULTI_WRITE_BE32(0xFFFFFFFFU, 0xFFFFFFFFU, 0xFFFFFFFFU, 0xFFFFFFFFU, 0xFFFFFFFFU)},
@@ -1035,6 +1047,102 @@ error_pm:
 	return ret;
 }
 
+static int cs40l26_monitor_get(const struct device *dev, const enum haptics_monitor monitor,
+			       const enum haptics_monitor_type type, struct sensor_value *const val)
+{
+	__maybe_unused const struct cs40l26_config *const config = dev->config;
+	struct cs40l26_data *const data = dev->data;
+	uint32_t reading;
+	int offset, ret;
+
+	if (type >= HAPTICS_MONITOR_TYPE_SINGLE) {
+		LOG_INST_DBG(config->log, "unsupported haptics monitor type %d", type);
+		return -ENOTSUP;
+	}
+
+	offset = type * CS40L26_LOGGER_TYPE_STEP;
+
+	switch (monitor) {
+	case HAPTICS_MONITOR_BEMF:
+		offset += (CS40L26_MONITOR_BEMF * CS40L26_LOGGER_SRC_STEP);
+		break;
+	case HAPTICS_MONITOR_VBST:
+		offset += (CS40L26_MONITOR_VBST * CS40L26_LOGGER_SRC_STEP);
+		break;
+	case HAPTICS_MONITOR_VOUT:
+		offset += (CS40L26_MONITOR_VOUT * CS40L26_LOGGER_SRC_STEP);
+		break;
+	default:
+		LOG_INST_DBG(config->log, "unsupported haptics monitor %d", monitor);
+		return -ENOTSUP;
+	}
+
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = k_mutex_lock(&data->lock, CS40L26_T_WAIT);
+	if (ret < 0) {
+		LOG_INST_DBG(config->log, "timed out waiting for lock (%d)", ret);
+		goto error_pm;
+	}
+
+	ret = cs40l26_firmware_read_offset(dev, CS40L26_REG_LOGGER_DATA, &reading, offset);
+
+	(void)k_mutex_unlock(&data->lock);
+
+error_pm:
+	(void)pm_device_runtime_put(dev);
+
+	if (ret >= 0) {
+		ret = sensor_value_from_fixed_point(val, reading, cs40l26_sensors[monitor].m,
+						    cs40l26_sensors[monitor].n,
+						    cs40l26_sensors[monitor].is_signed);
+		if (ret < 0) {
+			LOG_INST_DBG(config->log, "failed fixed-point conversion (%d)", ret);
+			return ret;
+		}
+
+		ret = sensor_value_scale(val, cs40l26_sensors[monitor].full_scale, val);
+	}
+
+	return ret;
+}
+
+static int cs40l26_monitor_set(const struct device *dev, const enum haptics_monitor monitor,
+			       const bool enable)
+{
+	__maybe_unused const struct cs40l26_config *const config = dev->config;
+	struct cs40l26_data *const data = dev->data;
+	int ret;
+
+	if (monitor != HAPTICS_MONITOR_ALL) {
+		LOG_INST_DBG(config->log, "unsupported haptics monitor %d", monitor);
+		return -ENOTSUP;
+	}
+
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = k_mutex_lock(&data->lock, CS40L26_T_WAIT);
+	if (ret < 0) {
+		LOG_INST_DBG(config->log, "timed out waiting for lock (%d)", ret);
+		goto error_pm;
+	}
+
+	ret = cs40l26_firmware_write(dev, CS40L26_REG_LOGGER_ENABLE, (uint32_t)enable);
+
+	(void)k_mutex_unlock(&data->lock);
+
+error_pm:
+	(void)pm_device_runtime_put(dev);
+
+	return ret;
+}
+
 static int cs40l26_register_error_callback(const struct device *dev, haptics_error_callback_t cb,
 					   void *const user_data)
 {
@@ -1172,6 +1280,8 @@ static int cs40l26_stop_output(const struct device *const dev)
 
 static DEVICE_API(haptics, cs40l26_driver_api) = {
 	.calibrate = &cs40l26_calibrate,
+	.monitor_get = &cs40l26_monitor_get,
+	.monitor_set = &cs40l26_monitor_set,
 	.register_error_callback = &cs40l26_register_error_callback,
 	.select_source = &cs40l26_select_source,
 	.set_level = &cs40l26_set_level,

--- a/drivers/haptics/cirrus/cs40l26.c
+++ b/drivers/haptics/cirrus/cs40l26.c
@@ -131,19 +131,6 @@ static const struct cs40lxx_multi_write cs40l26_pseq[] = {
 				  0x00FFFFFFU)},
 };
 
-/* Source attenuation in decibels (dB) stored in signed Q21.2 format */
-static const uint8_t cs40l26_attenuation[] = {
-	0xFF, /* mute */
-	0xA0, 0x88, 0x7A, 0x70, 0x68, 0x62, 0x5C, 0x58, 0x54, 0x50, 0x4D, 0x4A, 0x47,
-	0x44, 0x42, 0x40, 0x3E, 0x3C, 0x3A, 0x38, 0x36, 0x35, 0x33, 0x32, 0x30, /* 25% */
-	0x2F, 0x2D, 0x2C, 0x2B, 0x2A, 0x29, 0x28, 0x27, 0x25, 0x24, 0x23, 0x23, 0x22,
-	0x21, 0x20, 0x1F, 0x1E, 0x1D, 0x1D, 0x1C, 0x1B, 0x1A, 0x1A, 0x19, 0x18, /* 50% */
-	0x17, 0x17, 0x16, 0x15, 0x15, 0x14, 0x14, 0x13, 0x12, 0x12, 0x11, 0x11, 0x10,
-	0x10, 0x0F, 0x0E, 0x0E, 0x0D, 0x0D, 0x0C, 0x0C, 0x0B, 0x0B, 0x0A, 0x0A, /* 75% */
-	0x0A, 0x09, 0x09, 0x08, 0x08, 0x07, 0x07, 0x06, 0x06, 0x06, 0x05, 0x05, 0x04,
-	0x04, 0x04, 0x03, 0x03, 0x03, 0x02, 0x02, 0x01, 0x01, 0x01, 0x00, 0x00 /* 100% */
-};
-
 static int cs40l26_poll(const struct device *const dev, const uint32_t addr, const uint32_t val,
 			const k_timeout_t timeout)
 {
@@ -172,14 +159,14 @@ static int cs40l26_poll(const struct device *const dev, const uint32_t addr, con
 }
 
 static inline bool cs40l26_valid_wavetable_source(const struct device *const dev,
-						  const enum cs40l26_bank bank,
-						  const uint16_t index)
+						  const enum haptics_source src,
+						  const union haptics_config *const cfg)
 {
-	switch (bank) {
-	case CS40L26_ROM_BANK:
-		return index < CS40L26_NUM_ROM_EFFECTS;
-	case CS40L26_BUZ_BANK:
-		return index < CS40L26_NUM_BUZ_EFFECTS;
+	switch ((int)src) {
+	case HAPTICS_SOURCE_ROM:
+		return cfg->idx < CS40L26_NUM_ROM_EFFECTS;
+	case CS40L26_SOURCE_BUZ:
+		return cfg->idx < CS40L26_NUM_BUZ_EFFECTS;
 	default:
 		return false;
 	}
@@ -948,15 +935,17 @@ static int cs40l26_teardown(const struct device *const dev)
 }
 #endif /* CONFIG_PM_DEVICE */
 
-int cs40l26_calibrate(const struct device *const dev)
+static int cs40l26_calibrate(const struct device *dev, const uint32_t routine)
 {
 	const struct cs40l26_config *const config = dev->config;
 	struct cs40l26_data *const data = dev->data;
 	uint32_t f0 = 0, redc = 0;
 	int ret;
 
+	ARG_UNUSED(routine);
+
 	if (!IS_ENABLED(CONFIG_HAPTICS_CS40L26_CALIBRATION)) {
-		LOG_INST_ERR(config->log, "calibration is disabled (%d)", -EPERM);
+		LOG_INST_DBG(config->log, "calibration is disabled");
 		return -EPERM;
 	}
 
@@ -1057,29 +1046,37 @@ static int cs40l26_register_error_callback(const struct device *dev, haptics_err
 	return 0;
 }
 
-int cs40l26_select_output(const struct device *const dev, const enum cs40l26_bank bank,
-			  const uint16_t index)
+static int cs40l26_select_source(const struct device *dev, const enum haptics_source src,
+				 const union haptics_config *const cfg)
 {
 	__maybe_unused const struct cs40l26_config *const config = dev->config;
 	struct cs40l26_data *const data = dev->data;
 	uint32_t output;
 	int ret;
 
-	if (!cs40l26_valid_wavetable_source(dev, bank, index)) {
-		LOG_INST_ERR(config->log, "invalid wavetable selection (%d)", -EINVAL);
-		return -EINVAL;
-	}
-
-	switch (bank) {
-	case CS40L26_ROM_BANK:
-		output = index | CS40L26_ROM_BANK_CMD;
+	switch ((int)src) {
+	case HAPTICS_SOURCE_ROM:
+		output = CS40L26_ROM_BANK_CMD;
 		break;
-	case CS40L26_BUZ_BANK:
+	case CS40L26_SOURCE_BUZ:
 		output = CS40L26_BUZ_BANK_CMD;
 		break;
 	default:
+		LOG_INST_DBG(config->log, "unsupported haptics source %d", src);
+		return -ENOTSUP;
+	}
+
+	if (cfg == NULL) {
+		LOG_INST_DBG(config->log, "idx required for supported haptic sources");
 		return -EINVAL;
 	}
+
+	if (!cs40l26_valid_wavetable_source(dev, src, cfg)) {
+		LOG_INST_DBG(config->log, "invalid wavetable selection");
+		return -EINVAL;
+	}
+
+	output |= cfg->idx;
 
 	ret = k_mutex_lock(&data->lock, CS40L26_T_WAIT);
 	if (ret < 0) {
@@ -1094,16 +1091,18 @@ int cs40l26_select_output(const struct device *const dev, const enum cs40l26_ban
 	return ret;
 }
 
-int cs40l26_set_gain(const struct device *const dev, const uint8_t gain)
+static int cs40l26_set_level(const struct device *dev, const enum haptics_source src,
+			     const union haptics_config *const cfg, const uint32_t level)
 {
 	__maybe_unused const struct cs40l26_config *const config = dev->config;
 	struct cs40l26_data *const data = dev->data;
-	uint32_t attenuation;
 	int ret;
 
-	if (gain > CS40L26_MAX_GAIN) {
-		LOG_INST_ERR(config->log, "invalid gain, %u >= %u", gain, CS40L26_MAX_GAIN);
-		return -EINVAL;
+	ARG_UNUSED(cfg);
+
+	if (src != HAPTICS_SOURCE_ALL) {
+		LOG_INST_DBG(config->log, "unsupported haptics source %d", src);
+		return -ENOTSUP;
 	}
 
 	ret = pm_device_runtime_get(dev);
@@ -1117,13 +1116,7 @@ int cs40l26_set_gain(const struct device *const dev, const uint8_t gain)
 		goto error_pm;
 	}
 
-	if (gain == 0) {
-		attenuation = CS40L26_MAX_ATTENUATION;
-	} else {
-		attenuation = (uint32_t)cs40l26_attenuation[gain];
-	}
-
-	ret = cs40l26_firmware_write(data->dev, CS40L26_REG_SOURCE_ATTENUATION, attenuation);
+	ret = cs40l26_firmware_write(dev, CS40L26_REG_SOURCE_ATTENUATION, level);
 
 	(void)k_mutex_unlock(&data->lock);
 
@@ -1177,17 +1170,13 @@ static int cs40l26_stop_output(const struct device *const dev)
 	return ret;
 }
 
-static int cs40l26_select_source(const struct device *dev, const enum haptics_source src,
-				 const union haptics_config *const cfg)
-{
-	return -ENOTSUP;
-}
-
 static DEVICE_API(haptics, cs40l26_driver_api) = {
+	.calibrate = &cs40l26_calibrate,
+	.register_error_callback = &cs40l26_register_error_callback,
 	.select_source = &cs40l26_select_source,
+	.set_level = &cs40l26_set_level,
 	.start_output = &cs40l26_start_output,
 	.stop_output = &cs40l26_stop_output,
-	.register_error_callback = &cs40l26_register_error_callback,
 };
 
 static int cs40l26_pm_resume(const struct device *const dev)

--- a/drivers/haptics/cirrus/cs40l26.h
+++ b/drivers/haptics/cirrus/cs40l26.h
@@ -57,6 +57,13 @@ struct cs40l26_calibration {
 	uint32_t f0;
 };
 
+struct cs40l26_sensor {
+	bool is_signed;
+	uint8_t n;
+	uint8_t m;
+	int8_t full_scale;
+};
+
 struct cs40l26_config {
 	LOG_INSTANCE_PTR_DECLARE(log);
 	/* Log instance declaration requires blank line. */
@@ -84,6 +91,8 @@ struct cs40l26_data {
 
 int cs40l26_firmware_read(const struct device *const dev, const uint32_t firmware_control,
 			  uint32_t *const rx);
+int cs40l26_firmware_read_offset(const struct device *const dev, const uint32_t firmware_control,
+				 uint32_t *const rx, const off_t offset);
 int cs40l26_firmware_write(const struct device *const dev, const uint32_t firmware_control,
 			   uint32_t val);
 int cs40l26_firmware_burst_write(const struct device *const dev, const uint32_t firmware_control,

--- a/include/zephyr/drivers/haptics/cs40l26.h
+++ b/include/zephyr/drivers/haptics/cs40l26.h
@@ -12,6 +12,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_HAPTICS_CS40L26_H_
 #define ZEPHYR_INCLUDE_DRIVERS_HAPTICS_CS40L26_H_
 
+#include <zephyr/drivers/haptics.h>
 #include <zephyr/kernel.h>
 
 #ifdef __cplusplus
@@ -27,24 +28,10 @@ extern "C" {
 
 /**
  * @brief Wavetable sources for effects
- *
- * @details Provide to @ref cs40l26_select_output().
  */
-enum cs40l26_bank {
-	CS40L26_ROM_BANK, /**< Playback from the pre-programmed ROM library */
-	CS40L26_BUZ_BANK, /**< Playback from buzz source programmed at runtime */
-	CS40L26_NO_BANK,  /**< Reserved for driver error handling */
+enum cs40l26_source {
+	CS40L26_SOURCE_BUZ = HAPTICS_SOURCE_PRIV_START, /**< Playback from the buzz library */
 };
-
-/**
- * @brief Run calibration to derive ReDC and F0 values and apply results for click compensation
- *
- * @param[in] dev Pointer to the device structure for haptic device instance
- *
- * @retval 0 if success
- * @retval <0 if failed
- */
-int cs40l26_calibrate(const struct device *const dev);
 
 /**
  * @brief Configure ROM buzz for haptic playback
@@ -61,32 +48,6 @@ int cs40l26_calibrate(const struct device *const dev);
  */
 int cs40l26_configure_buzz(const struct device *const dev, const uint32_t frequency,
 			   const uint8_t level, const uint32_t duration);
-
-/**
- * @brief Select haptic effect triggered via @ref haptics_start_output()
- *
- * @param[in] dev Pointer to the device structure for haptic device instance
- * @param[in] bank Refer to @ref cs40l26_bank
- * @param[in] index Wavetable index for desired haptic effect
- *
- * @retval 0 if successful
- * @retval <0 if failed
- */
-int cs40l26_select_output(const struct device *const dev, const enum cs40l26_bank bank,
-			  const uint16_t index);
-
-/**
- * @brief Configure gain for haptic effects triggered via @ref haptics_start_output()
- *
- * @param[in] dev Pointer to the device structure for haptic device instance
- * @param[in] gain Gain setting (valid values between 0 and 100)
- *
- * @retval 0 if successful
- * @retval <0 if failed
- */
-int cs40l26_set_gain(const struct device *const dev, const uint8_t gain);
-
-/** @} */
 
 #ifdef __cplusplus
 }

--- a/samples/drivers/haptics/cs40l26/prj.conf
+++ b/samples/drivers/haptics/cs40l26/prj.conf
@@ -7,6 +7,7 @@ CONFIG_PM_DEVICE_RUNTIME=y
 
 # Enable custom shell sample for demonstration
 CONFIG_SHELL=y
+CONFIG_HAPTICS_SHELL=y
 
 # All CS40L26 Kconfig options and their defaults
 CONFIG_HAPTICS_CS40L26_CALIBRATION=y

--- a/samples/drivers/haptics/cs40l26/src/main.c
+++ b/samples/drivers/haptics/cs40l26/src/main.c
@@ -25,17 +25,7 @@ const struct device *cs40l26 = DEVICE_DT_GET(DT_ALIAS(haptic0));
 
 #if CONFIG_SHELL
 #define CS40L26_HELP                SHELL_HELP("CS40L26 haptics commands", NULL)
-#define CS40L26_CALIBRATE_HELP      SHELL_HELP("Run calibration routine", NULL)
 #define CS40L26_CONFIGURE_BUZZ_HELP SHELL_HELP("Configure buzz output", "<freq> <level> <dur>")
-#define CS40L26_GAIN_HELP           SHELL_HELP("Update gain", "<gain %%>")
-#define CS40L26_SELECT_HELP         SHELL_HELP("Select haptic effect", "<bank> <index>")
-#define CS40L26_START_HELP          SHELL_HELP("Start haptic playback", NULL)
-#define CS40L26_STOP_HELP           SHELL_HELP("Stop haptic playback", NULL)
-
-static int cmd_calibrate(const struct shell *sh, size_t argc, char **argv)
-{
-	return cs40l26_calibrate(cs40l26);
-}
 
 static int cmd_configure_buzz(const struct shell *sh, size_t argc, char **argv)
 {
@@ -53,56 +43,11 @@ static int cmd_configure_buzz(const struct shell *sh, size_t argc, char **argv)
 	return cs40l26_configure_buzz(cs40l26, frequency, (uint8_t)level, duration);
 }
 
-static int cmd_gain(const struct shell *sh, size_t argc, char **argv)
-{
-	uint32_t gain;
-
-	gain = strtoul(argv[1], NULL, 10);
-
-	if (gain > 100) {
-		shell_error(sh, "Gain must be between 0 and 100%%");
-		return -EINVAL;
-	}
-
-	return cs40l26_set_gain(cs40l26, (uint8_t)gain);
-}
-
-static int cmd_select(const struct shell *sh, size_t argc, char **argv)
-{
-	enum cs40l26_bank bank;
-	uint8_t index;
-
-	if (strcmp(argv[1], "ROM") == 0) {
-		bank = CS40L26_ROM_BANK;
-	} else if (strcmp(argv[1], "BUZ") == 0) {
-		bank = CS40L26_BUZ_BANK;
-	} else {
-		shell_error(sh, "Bank must be 'ROM' or 'BUZ'");
-		return -EINVAL;
-	}
-
-	index = strtoul(argv[2], NULL, 10);
-
-	return cs40l26_select_output(cs40l26, bank, index);
-}
-
-static int cmd_start(const struct shell *sh, size_t argc, char **argv)
-{
-	return haptics_start_output(cs40l26);
-}
-
-static int cmd_stop(const struct shell *sh, size_t argc, char **argv)
-{
-	return haptics_stop_output(cs40l26);
-}
-
-SHELL_STATIC_SUBCMD_SET_CREATE(
-	cs40l26_cmds, SHELL_CMD_ARG(calibrate, NULL, CS40L26_CALIBRATE_HELP, cmd_calibrate, 1, 0),
+/* clang-format off */
+SHELL_STATIC_SUBCMD_SET_CREATE(cs40l26_cmds,
 	SHELL_CMD_ARG(configure_buzz, NULL, CS40L26_CONFIGURE_BUZZ_HELP, cmd_configure_buzz, 4, 0),
-	SHELL_CMD_ARG(gain, NULL, CS40L26_GAIN_HELP, cmd_gain, 2, 0),
-	SHELL_CMD_ARG(select, NULL, CS40L26_SELECT_HELP, cmd_select, 3, 0),
-	SHELL_CMD_ARG(start, NULL, CS40L26_START_HELP, cmd_start, 1, 0),
-	SHELL_CMD_ARG(stop, NULL, CS40L26_STOP_HELP, cmd_stop, 1, 0), SHELL_SUBCMD_SET_END);
+	SHELL_SUBCMD_SET_END);
+/* clang-format on */
 
 SHELL_CMD_REGISTER(cs40l26, &cs40l26_cmds, "CS40L26 shell commands", NULL);
 #endif /* CONFIG_SHELL */
@@ -115,6 +60,7 @@ static void cs40l26_dummy_callback(const struct device *const dev, const uint32_
 
 int main(void)
 {
+	const union haptics_config cfg = {.idx = 0};
 	int ret;
 
 	if (!cs40l26 || !device_is_ready(cs40l26)) {
@@ -132,7 +78,7 @@ int main(void)
 
 	/* Basic demonstration if not using the custom shell interface. */
 	if (!IS_ENABLED(CONFIG_SHELL)) {
-		ret = cs40l26_calibrate(cs40l26);
+		ret = haptics_calibrate(cs40l26, 0);
 		if (ret < 0) {
 			return ret;
 		}
@@ -145,7 +91,7 @@ int main(void)
 			return ret;
 		}
 
-		ret = cs40l26_select_output(cs40l26, CS40L26_BUZ_BANK, 0);
+		ret = haptics_select_source(cs40l26, (enum haptics_source)CS40L26_SOURCE_BUZ, &cfg);
 		if (ret < 0) {
 			return ret;
 		}


### PR DESCRIPTION
Since #109442, #112130, and #113077 have been merged, this PR updates the CS40L26/27 driver to implement the haptics API instead of a driver-specific API and propagates changes to the CS40L26/27 sample application. Also implements `haptics_monitor_get()` and `haptics_monitor_set()` functions.