### PR TITLE
samples: drivers: uart: async_api: fix kit_pse84_eval scb2 clock

### DIFF
--- a/samples/drivers/uart/async_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
+++ b/samples/drivers/uart/async_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33.overlay
@@ -22,3 +22,8 @@
 	dmas = <&dma0 0>, <&dma0 1>;
 	dma-names = "tx", "rx";
 };
+
+&peri0_group1_16bit_0 {
+	status = "okay";
+	clock-div = <109>;
+};

--- a/samples/drivers/uart/async_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/drivers/uart/async_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -22,3 +22,8 @@
 	dmas = <&dma0 0>, <&dma0 1>;
 	dma-names = "tx", "rx";
 };
+
+&peri0_group1_16bit_0 {
+	status = "okay";
+	clock-div = <109>;
+};


### PR DESCRIPTION
The kit_pse84_eval console async_api sample overlays reassign the console
UART (scb2) clock to `peri0_group1_16bit_0` but never enable that
peripheral-divider node. In the merged devicetree the node stays disabled
with the default `clock-div = <1>`, so scb2 receives no valid baud clock and
the UART emits nothing at all (not even the boot banner). The console
harness then never observes the sample output and the scenario fails.

Enable `peri0_group1_16bit_0` and set the 115200 divider, mirroring the
working `uart_async_api` test overlay. With this change the sample boots and
prints the expected `Loop N: Sending ...` / `RX is now enabled|disabled`
sequence on both the m33 and m55 overlays.

Validated on hardware on both cores (m33 and m55): before the change the
sample produced no output; after it, the full expected console sequence.
