### PR TITLE
MAINTAINERS: Some refocus

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1289,6 +1289,7 @@ Device Driver Model:
   collaborators:
     - dcpleung
     - nashif
+    - edersondisouza
   files:
     - include/zephyr/device.h
     - kernel/device.c

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3611,6 +3611,7 @@ Key-Value Storage Systems:
     - lyakh
     - pillo79
     - laurenmurphyx64
+    - edersondisouza
   files:
     - cmake/llext-edk.cmake
     - samples/subsys/llext/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5090,7 +5090,7 @@ RISCV arch:
   collaborators:
     - kgugala
     - tgorochowik
-    - edersondisouza
+    - dcpleung
     - katsuster
     - mgielda
     - npitre

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4983,10 +4983,10 @@ PMCI:
   status: maintained
   maintainers:
     - teburd
+    - edersondisouza
   collaborators:
     - nashif
     - kehintel
-    - edersondisouza
   files:
     - subsys/pmci/
     - samples/subsys/pmci/
@@ -6996,10 +6996,10 @@ West:
   status: maintained
   maintainers:
     - teburd
+    - edersondisouza
   collaborators:
     - nashif
     - dkalowsk
-    - edersondisouza
   files: []
   labels:
     - "area: MCTP"


### PR DESCRIPTION
Some updates:

* Add `edersondisouza` as a collaborator for both the `Device Driver Model` and `Linkable Loadable Extensions` subsystems.
* Remove `edersondisouza` and add `dcpleung` as a collaborator for the `RISCV arch` subsystem.