### PR TITLE
tests: drivers: dmic_util: add PSE84 M55 boot delay

### DIFF
--- a/tests/drivers/audio/dmic_util/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.conf
+++ b/tests/drivers/audio/dmic_util/boards/kit_pse84_ai_pse846gps2dbzc4a_m55.conf
@@ -1,0 +1,9 @@
+# Boot delay for PSE84 M55 targets.
+#
+# dmic_util is a pure compile-time devicetree-macro test that completes in
+# ~2 ms from boot. On M55 the two-domain (enable_cm55 + image) OpenOCD flash
+# sequence is slow enough that the test finishes and prints its output before
+# Twister opens its serial-capture window, yielding a status=None result.
+# Delaying the boot past the capture-window open lets Twister observe the
+# PASS output.
+CONFIG_BOOT_DELAY=2000

--- a/tests/drivers/audio/dmic_util/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
+++ b/tests/drivers/audio/dmic_util/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
@@ -1,0 +1,9 @@
+# Boot delay for PSE84 M55 targets.
+#
+# dmic_util is a pure compile-time devicetree-macro test that completes in
+# ~2 ms from boot. On M55 the two-domain (enable_cm55 + image) OpenOCD flash
+# sequence is slow enough that the test finishes and prints its output before
+# Twister opens its serial-capture window, yielding a status=None result.
+# Delaying the boot past the capture-window open lets Twister observe the
+# PASS output.
+CONFIG_BOOT_DELAY=2000


### PR DESCRIPTION
## Description

`dmic_util` is a pure compile-time devicetree-macro test — both test cases only
evaluate DT macros and compare compile-time constants, so the whole suite
completes in ~2 ms from boot.

On the PSE84 M55 targets, flashing programs two domains sequentially
(`enable_cm55` + the test image). That flash sequence is slow enough that the
M55 boots, runs the entire suite, and prints its output **before** the test
harness (twister) opens its serial-capture window for this scenario. As a
result the scenario is reported with no result (status `None`), and its
testcase output is misattributed to whichever suite was previously capturing.
The test itself passes — only the capture timing is wrong.

This adds board Kconfig fragments for both PSE84 M55 targets setting
`CONFIG_BOOT_DELAY=2000`, which delays the test start past the capture-window
open so the harness observes the real result. This mirrors the existing
`CONFIG_BOOT_DELAY` board-conf pattern already used by several in-tree tests
(e.g. `tests/drivers/mbox/mbox_data`, `tests/subsys/ipc/ipc_sessions`).

## Testing

Verified with `twister --device-testing` on
`kit_pse84_eval/pse846gps2dbzc4a/m55`:

- Before: scenario reported status `None` (no captured output).
- After: scenario reports `PASSED` — 2 of 2 test cases passed.

The `kit_pse84_ai` M55 fragment is the identical fix for the sister M55 target.
