### PR TITLE
kernel: msgq: fix k_msgq_cleanup doc

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5347,12 +5347,15 @@ __syscall int k_msgq_alloc_init(struct k_msgq *msgq, size_t msg_size,
 /**
  * @brief Release allocated buffer for a queue
  *
- * Releases memory allocated for the ring buffer.
+ * Releases memory allocated for the ring buffer. The buffer is only
+ * freed if it was allocated by k_msgq_alloc_init(); the call succeeds
+ * but frees nothing for a caller-provided buffer. Any messages still
+ * in the queue are discarded with the buffer.
  *
  * @param msgq message queue to cleanup
  *
  * @retval 0 on success
- * @retval -EBUSY Queue not empty
+ * @retval -EBUSY Threads are waiting on the message queue
  */
 int k_msgq_cleanup(struct k_msgq *msgq);
 


### PR DESCRIPTION
The @retval -EBUSY description for k_msgq_cleanup() claimed "Queue not
empty", but the implementation guards on waiting threads, not on
messages: it fails with -EBUSY when z_waitq_head() is non-NULL and
otherwise frees the buffer regardless of content (discarding any
messages still queued). Correct the description and document that only
a k_msgq_alloc_init() buffer is actually freed.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
