### PR TITLE
mgmt: mcumgr: fix heap leak on settings access hook rejection

### DIFF
--- a/subsys/mgmt/mcumgr/grp/settings_mgmt/src/settings_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/settings_mgmt/src/settings_mgmt.c
@@ -107,6 +107,10 @@ static int settings_mgmt_read(struct smp_streamer *ctxt)
 
 		if (status != MGMT_CB_OK) {
 			if (status == MGMT_CB_ERROR_RC) {
+#ifdef CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_HEAP
+				k_free(key_name);
+				k_free(data);
+#endif
 				return ret_rc;
 			}
 
@@ -220,6 +224,9 @@ static int settings_mgmt_write(struct smp_streamer *ctxt)
 
 		if (status != MGMT_CB_OK) {
 			if (status == MGMT_CB_ERROR_RC) {
+#ifdef CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_HEAP
+				k_free(key_name);
+#endif
 				return ret_rc;
 			}
 
@@ -319,6 +326,9 @@ static int settings_mgmt_delete(struct smp_streamer *ctxt)
 
 		if (status != MGMT_CB_OK) {
 			if (status == MGMT_CB_ERROR_RC) {
+#ifdef CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_HEAP
+				k_free(key_name);
+#endif
 				return ret_rc;
 			}
 


### PR DESCRIPTION
## Summary

Fixes #112782. `settings_mgmt_read()`/`settings_mgmt_write()`/`settings_mgmt_delete()` (`subsys/mgmt/mcumgr/grp/settings_mgmt/src/settings_mgmt.c`) each allocate `key_name` (and `data`, for read) from the heap when `CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_HEAP` is enabled, then optionally call an application access hook via `mgmt_callback_notify()`. When that hook returns `MGMT_CB_ERROR_RC`, the handler does `return ret_rc;` directly, bypassing the `end:` label where these buffers would otherwise be freed. Every other status/return path in these functions does go through `end:` (or frees explicitly) and is unaffected.

## Fix

Free the heap-allocated buffers immediately before returning on this specific path, matching what `end:` already does for every other path in the same three functions.

## Testing

I don't have a working Zephyr build environment set up right now to run the existing `tests/subsys/mgmt/mcumgr/settings_mgmt` test suite on `native_sim`, so I can't provide a real test-suite pass. What I did instead: traced all three functions to confirm this is the only path in each that skips the free, and wrote a standalone host-C reproduction of just the control flow (mock `k_malloc`/`k_free` that count calls):

- **Before fix**: 2 mocked allocations, 0 freed, when the access hook returns `MGMT_CB_ERROR_RC`.
- **After fix**: 2 allocations, 2 frees.

Happy to add a case to the existing `tests/subsys/mgmt/mcumgr/settings_mgmt` test suite (registering an access hook that always returns `MGMT_CB_ERROR_RC` and checking heap usage before/after, per the existing test patterns there) if that's wanted before merge — I saw @nordicjm and @teburd already said to go ahead and submit a fix on the issue.

## Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.