### PR TITLE
MAINTAINERS: move smbus to odd fixes

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2686,9 +2686,7 @@ Documentation Infrastructure:
     - sample.drivers.sent
 
 "Drivers: SMBus":
-  status: maintained
-  maintainers:
-    - finikorg
+  status: odd fixes
   files:
     - drivers/smbus/
     - dts/bindings/smbus/


### PR DESCRIPTION
Remove inactive maintainer.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
