### PR TITLE
drivers: i2c: eeprom_target: fix buffer over-read on buffered read

### DIFF
--- a/drivers/i2c/target/eeprom_target.c
+++ b/drivers/i2c/target/eeprom_target.c
@@ -231,7 +231,7 @@ static int eeprom_target_buf_read_requested(struct i2c_target_config *config,
 						config);
 
 	*ptr = &data->buffer[data->buffer_idx];
-	*len = data->buffer_size;
+	*len = data->buffer_size - data->buffer_idx;
 
 	return 0;
 }


### PR DESCRIPTION
## Summary

Fixes #110548. `eeprom_target_buf_read_requested()` (`drivers/i2c/target/eeprom_target.c`, used under `CONFIG_I2C_TARGET_BUFFER_MODE`) returns a pointer into the buffer starting at `buffer_idx`:

```c
*ptr = &data->buffer[data->buffer_idx];
*len = data->buffer_size;
```

but reports the *full* `buffer_size` as the available length, rather than the remaining bytes from that offset to the end of the buffer (`buffer_size - buffer_idx`). When `buffer_idx` is non-zero, this tells the calling I2C controller driver it can read `buffer_size` bytes starting at `&buffer[buffer_idx]` — which runs `buffer_idx` bytes past the actual end of the underlying buffer.

## Fix

Report `buffer_size - buffer_idx` instead, matching the pointer that's actually returned. `buffer_idx` is always kept in `[0, buffer_size)` elsewhere in this file (e.g. via `% data->buffer_size`), so this is always non-negative.

## Testing

This function doesn't depend on a real I2C bus, so I verified the arithmetic directly: a standalone host-C snippet with `buffer_size = 32`, `buffer_idx = 10`, computing the last offset the reported `(ptr, len)` pair would let a caller read.

- **Before fix**: reports `len = 32` from offset 10, i.e. readable up to offset 41 — 10 bytes past the 32-byte buffer's last valid index (31).
- **After fix**: reports `len = 22`, readable up to offset 31 — exactly the buffer's last valid index.

## Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.