### PR TITLE
kernel: smp: ipi: do not drain self bit in signal_pending_ipi()

### DIFF
--- a/kernel/smp/ipi.c
+++ b/kernel/smp/ipi.c
@@ -71,22 +71,28 @@ atomic_val_t ipi_mask_create(struct k_thread *thread)
 
 void signal_pending_ipi(void)
 {
-	/* Note: with directed IPIs, arch_sched_directed_ipi() skips the
-	 * calling CPU, so if a CPU consumes its own pending bit the IPI
-	 * is silently dropped. When rescheduling, callers must ensure
-	 * that signal_pending_ipi() is invoked while the scheduler lock is
-	 * still held. Holding the lock ensures the scheduling decision and
-	 * IPI dispatch are atomic: either a concurrent flag_ipi() lands
-	 * before the lock is acquired (and the CPU sees the new thread),
-	 * or it lands after the lock is released (and the other CPU
-	 * dispatches the IPI).
+	/* Drain only the bits for other CPUs. Clearing our own bit here
+	 * would silently drop an IPI destined for us, because
+	 * arch_sched_directed_ipi() skips the calling CPU. Our own bit
+	 * is left set so the next interrupt entry on this CPU will see
+	 * it and run the scheduler.
+	 *
+	 * When rescheduling, callers must ensure that signal_pending_ipi()
+	 * is invoked while the scheduler lock is still held. Holding the
+	 * lock ensures the scheduling decision and IPI dispatch are atomic:
+	 * either a concurrent flag_ipi() lands before the lock is acquired
+	 * (and the CPU sees the new thread), or it lands after the lock is
+	 * released (and the other CPU dispatches the IPI).
 	 */
 
 #if defined(CONFIG_SCHED_IPI_SUPPORTED)
 	if (arch_num_cpus() > 1) {
-		uint32_t  cpu_bitmap;
+		uint32_t self_bit = BIT(_current_cpu->id);
+		uint32_t cpu_bitmap;
 
-		cpu_bitmap = (uint32_t)atomic_clear(&_kernel.pending_ipi);
+		cpu_bitmap = (uint32_t)atomic_and(&_kernel.pending_ipi,
+						  (atomic_val_t)self_bit);
+		cpu_bitmap &= ~self_bit;
 		if (cpu_bitmap != 0) {
 #ifdef CONFIG_ARCH_HAS_DIRECTED_IPIS
 			arch_sched_directed_ipi(cpu_bitmap);


### PR DESCRIPTION
signal_pending_ipi() used atomic_clear() on _kernel.pending_ipi, which
also drained the calling CPU's own pending bit. With directed IPIs,
arch_sched_directed_ipi() skips the calling CPU, so any IPI that had
been raised for self by another CPU was silently dropped. The lost
wakeup left the target CPU stuck until something else nudged the
scheduler.

This was latent for the existing call site in ipi_work_process(), but
became reachable on every no-swap path through do_swap() once
signal_pending_ipi() was added there, producing intermittent CPU1
starvation on SMP. tests/kernel/spinlock/spinlock_api test_trylock
(and test_spinlock_bounce on cortex_a53) reproduced it reliably on
qemu_riscv32/smp, qemu_riscv64/smp, and qemu_cortex_a53/smp: CPU0's
loop would acquire bounce_lock 10000 times in a row without CPU1
ever winning a single acquisition.

Switch to atomic_and() with the self bit as the mask, which preserves
our own pending bit (so the next interrupt entry on this CPU still
sees it and runs the scheduler) while atomically draining the bits
for the other CPUs we are about to dispatch IPIs to.

Assisted-by: Claude:claude-opus-4.7
Signed-off-by: Tom Burdick <thomas.burdick@infineon.com>

Picked out of #110717 
