### PR TITLE
posix: Protect getentropy from missing symbols

### DIFF
--- a/subsys/portability/posix/c_lib_ext/getentropy.c
+++ b/subsys/portability/posix/c_lib_ext/getentropy.c
@@ -12,8 +12,6 @@
 
 int getentropy(void *buffer, size_t length)
 {
-	const struct device *const entropy = entropy_get_default_device();
-
 	if (!buffer) {
 		errno = EFAULT;
 		return -1;
@@ -23,6 +21,9 @@ int getentropy(void *buffer, size_t length)
 		errno = EIO;
 		return -1;
 	}
+
+#if defined(CONFIG_ENTROPY_HAS_DRIVER) || defined(CONFIG_ARCH_HAS_ENTROPY)
+	const struct device *const entropy = entropy_get_default_device();
 
 	if (entropy == NULL || !device_is_ready(entropy)) {
 		errno = EIO;
@@ -40,4 +41,8 @@ int getentropy(void *buffer, size_t length)
 	}
 
 	return 0;
+#else
+	errno = EIO;
+	return -1;
+#endif
 }


### PR DESCRIPTION
When building for native_sim getentropy() would lead to a missing device
node symbol. When the device or architecture do not provide an entropy
device driver then getentropy should shortcircuit out.

Signed-off-by: Tom Burdick <thomas.burdick@infineon.com>

Picked from #110717 
