### PR TITLE
kernel.h: various doc fixes / cleanups / enhancements

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -3388,7 +3388,8 @@ void k_stack_init(struct k_stack *stack,
  * @param stack Address of the stack.
  * @param num_entries Maximum number of values that can be stacked.
  *
- * @return -ENOMEM if memory couldn't be allocated
+ * @retval 0 on success
+ * @retval -ENOMEM if memory couldn't be allocated
  */
 
 __syscall int32_t k_stack_alloc_init(struct k_stack *stack,

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -526,8 +526,9 @@ static inline void k_thread_heap_assign(struct k_thread *thread,
  * @return 0 on success
  * @return -EBADF Bad thread object (user mode only)
  * @return -EPERM No permissions on thread object (user mode only)
- * #return -ENOTSUP Forbidden by hardware policy
- * @return -EINVAL Thread is uninitialized or exited (user mode only)
+ * @return -ENOTSUP Forbidden by hardware policy
+ * @return -EINVAL Thread is uninitialized or exited (user mode only), or the
+ *	stack is not mapped when @kconfig{CONFIG_THREAD_STACK_MEM_MAPPED} is set
  * @return -EFAULT Bad memory address for unused_ptr (user mode only)
  */
 __syscall int k_thread_stack_space_get(const struct k_thread *thread,

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1508,10 +1508,13 @@ __syscall void *k_thread_custom_data_get(void);
  *
  * @param thread Thread to set name, or NULL to set the current thread
  * @param str Name string
+ * @note A name longer than CONFIG_THREAD_MAX_NAME_LEN is silently truncated,
+ * this is not reported as an error.
+ *
  * @retval 0 on success
  * @retval -EFAULT Memory access error with supplied string
  * @retval -ENOSYS Thread name configuration option not enabled
- * @retval -EINVAL Thread name too long
+ * @retval -EINVAL Invalid thread object (user mode only)
  */
 __syscall int k_thread_name_set(k_tid_t thread, const char *str);
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2643,7 +2643,7 @@ struct z_futex_data {
  *		   will not wait on it.
  * @param timeout Waiting period on the futex, or one of the special values
  *                K_NO_WAIT or K_FOREVER.
- * @retval -EACCES Caller does not have read access to futex address.
+ * @retval -EACCES Caller does not have write access to futex address.
  * @retval -EAGAIN If the futex value did not match the expected parameter.
  * @retval -EINVAL Futex parameter address not recognized by the kernel.
  * @retval -ETIMEDOUT Thread woke up due to timeout and not a futex wakeup.

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4229,14 +4229,18 @@ int k_work_queue_unplug(struct k_work_q *queue);
  * This call is blocking and guarantees that the work queue thread has terminated
  * cleanly if successful, no work will be processed past this point.
  *
+ * The queue must have been drained and plugged first (for example via
+ * k_work_queue_drain() with the @p plug option enabled); otherwise the call
+ * returns -EBUSY.
+ *
  * @param queue Pointer to the queue structure.
  * @param timeout Maximum time to wait for the work queue to stop.
  *
  * @retval 0 if the work queue was stopped
  * @retval -EALREADY if the work queue was not started (or already stopped)
- * @retval -EBUSY if the work queue is actively processing work items
+ * @retval -EBUSY if the work queue has not been plugged
  * @retval -ETIMEDOUT if the work queue did not stop within the stipulated timeout
- * @retval -ENOSUP if the work queue is essential
+ * @retval -ENOTSUP if the work queue is essential
  */
 int k_work_queue_stop(struct k_work_q *queue, k_timeout_t timeout);
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -7055,7 +7055,7 @@ __syscall int k_float_disable(struct k_thread *thread);
  *
  * @warning
  * This routine should only be used to enable floating point support for
- * a thread that currently has such support enabled.
+ * a thread that does not currently have such support enabled.
  *
  * @param thread  ID of thread.
  * @param options architecture dependent options

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1114,9 +1114,9 @@ __syscall void k_thread_priority_set(k_tid_t thread, int prio);
  * above this call, which is simply input to the priority selection
  * logic.
  *
- * @note The relative deadline is silently clamped to a maximum of
- * INT32_MAX / 2 (2^30 cycles) to preserve the scheduler's modular
- * comparison invariants.
+ * @note The relative deadline is silently clamped to the range
+ * [0, INT32_MAX / 2] (2^30 cycles) to preserve the scheduler's modular
+ * comparison invariants; negative values are clamped up to 0.
  *
  * @kconfig_dep{CONFIG_SCHED_DEADLINE}
  *

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2746,7 +2746,8 @@ __syscall void k_event_init(struct k_event *event);
  * @param event Address of the event object
  * @param events Set of events to post to @a event
  *
- * @return Previous value of the events in @a event
+ * @return Previous value of the events that are being posted, i.e. the bits
+ *         of @a events that were already set in @a event before this call
  */
 __syscall uint32_t k_event_post(struct k_event *event, uint32_t events);
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1534,10 +1534,11 @@ const char *k_thread_name_get(k_tid_t thread);
  * @param thread Thread to obtain name information
  * @param buf Destination buffer
  * @param size Destination buffer size
- * @retval -ENOSPC Destination buffer too small
- * @retval -EFAULT Memory access error
- * @retval -ENOSYS Thread name feature not enabled
  * @retval 0 Success
+ * @retval -ENOSYS Thread name feature not enabled
+ * @retval -EINVAL Invalid thread object (user mode only)
+ * @retval -ENOSPC Destination buffer too small (user mode only)
+ * @retval -EFAULT Memory access error (user mode only)
  */
 __syscall int k_thread_name_copy(k_tid_t thread, char *buf,
 				 size_t size);

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2052,7 +2052,8 @@ __syscall uint32_t k_timer_status_sync(struct k_timer *timer);
  *
  * This routine returns the future system uptime reached at the next
  * time of expiration of the timer, in units of system ticks.  If the
- * timer is not running, current system time is returned.
+ * timer is not running, the last announced tick count is returned (which
+ * may lag the true current uptime by the elapsed sub-tick amount).
  *
  * @param timer The timer object
  * @return Uptime of expiration, in ticks

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -6074,7 +6074,6 @@ int k_mem_slab_init(struct k_mem_slab *slab, void *buffer,
  *         is set to the starting address of the memory block.
  * @retval -ENOMEM Returned without waiting.
  * @retval -EAGAIN Waiting period timed out.
- * @retval -EINVAL Invalid data supplied
  */
 int k_mem_slab_alloc(struct k_mem_slab *slab, void **mem,
 			    k_timeout_t timeout);

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -6856,15 +6856,14 @@ __syscall void k_poll_signal_check(struct k_poll_signal *sig,
  * passed again to k_poll() or k_poll() will consider it being signaled, and
  * will return immediately.
  *
- * @note The result is stored and the 'signaled' field is set even if
- * this function returns an error indicating that an expiring poll was
- * not notified.  The next k_poll() will detect the missed raise.
+ * @note The result is stored and the 'signaled' field is set even when the
+ * polling thread's timeout is already expiring and the poll is therefore not
+ * notified directly.  The next k_poll() will detect the missed raise.
  *
  * @param sig A poll signal.
  * @param result The value to store in the result field of the signal.
  *
  * @retval 0 The signal was delivered successfully.
- * @retval -EAGAIN The polling thread's timeout is in the process of expiring.
  */
 
 __syscall int k_poll_signal_raise(struct k_poll_signal *sig, int result);

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2243,7 +2243,7 @@ static inline uint32_t k_uptime_seconds(void)
  * @param reftime Pointer to a reference time, which is updated to the current
  *                uptime upon return.
  *
- * @return Elapsed time.
+ * @return Elapsed time, in milliseconds.
  */
 static inline int64_t k_uptime_delta(int64_t *reftime)
 {

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -3066,6 +3066,9 @@ struct k_fifo {
  * @param fifo Address of the FIFO queue.
  * @param head Pointer to first node in singly-linked list.
  * @param tail Pointer to last node in singly-linked list.
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on invalid supplied data
  */
 #define k_fifo_put_list(fifo, head, tail) \
 	({ \
@@ -3086,6 +3089,9 @@ struct k_fifo {
  *
  * @param fifo Address of the FIFO queue.
  * @param list Pointer to sys_slist_t object.
+ *
+ * @retval 0 on success
+ * @retval -EINVAL on invalid supplied data
  */
 #define k_fifo_put_slist(fifo, list) \
 	({ \

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1234,6 +1234,8 @@ int k_thread_cpu_mask_enable_all(k_tid_t thread);
  *
  * @note You should enable @kconfig{CONFIG_SCHED_CPU_MASK} in your project
  * configuration.
+ * @note If @kconfig{CONFIG_SCHED_CPU_MASK_PIN_ONLY} is enabled the mask must
+ * contain exactly one CPU, so enabling a second CPU is not supported.
  *
  * @param thread Thread to operate upon
  * @param cpu CPU index

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -686,6 +686,8 @@ __syscall int k_thread_join(struct k_thread *thread, k_timeout_t timeout);
  * sleep rounded up to the nearest millisecond (e.g. if the thread was
  * awoken by the \ref k_wakeup call).  Will be clamped to INT_MAX in
  * the case where the remaining time is unrepresentable in an int32_t.
+ * If @a timeout is K_FOREVER and the thread is woken early via
+ * k_wakeup(), -1 is returned.
  */
 __syscall int32_t k_sleep(k_timeout_t timeout);
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -6244,7 +6244,8 @@ void k_heap_init(struct k_heap *h, void *mem,
  * @param align Alignment in bytes, must be a power of two
  * @param bytes Number of bytes requested
  * @param timeout How long to wait, or K_NO_WAIT
- * @return Pointer to memory the caller can now use
+ * @return Pointer to memory the caller can now use, or NULL if the allocation
+ *         could not be satisfied within the timeout
  */
 void *k_heap_aligned_alloc(struct k_heap *h, size_t align, size_t bytes,
 			k_timeout_t timeout) __attribute_nonnull(1);

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2274,6 +2274,9 @@ static inline uint32_t k_cycle_get_32(void)
  * This routine returns the current time in 64-bits, as measured by the
  * system's hardware clock, if available.
  *
+ * @note Requires @kconfig{CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER}. When that
+ * option is not enabled this routine asserts and returns 0.
+ *
  * @see CONFIG_TIMER_HAS_64BIT_CYCLE_COUNTER
  *
  * @return Current hardware clock up-counter (in cycles).


### PR DESCRIPTION
- **kernel: thread: fix k_thread_stack_space_get return docs**
- **kernel: work: fix k_work_queue_stop return docs**
- **kernel: thread: fix k_thread_name_set return docs**
- **kernel: thread: fix k_thread_name_copy return docs**
- **kernel: float: fix contradictory k_float_enable warning**
- **kernel: events: clarify k_event_post return value**
- **kernel: futex: fix k_futex_wait access requirement doc**
- **kernel: mem_slab: drop bogus k_mem_slab_alloc -EINVAL doc**
- **kernel: poll: drop unreachable k_poll_signal_raise -EAGAIN doc**
- **kernel: sleep: document k_sleep(K_FOREVER) early-wake return**
- **kernel: thread: note PIN_ONLY caveat on k_thread_cpu_mask_enable**
- **kernel: clock: document k_cycle_get_64 fallback behaviour**
- **kernel: stack: document k_stack_alloc_init success return**
- **kernel: heap: document k_heap_aligned_alloc NULL return**
- **kernel: fifo: document k_fifo_put_list/put_slist return values**
- **kernel: deadline: document negative clamp in k_thread_deadline_set**
- **kernel: timer: clarify k_timer_expires_ticks inactive return**
- **kernel: clock: state k_uptime_delta return unit**
