### PR TITLE
cmake: linker: pass linker-script includes via response file 

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -29,7 +29,14 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     set(linker_script_dep "")
   endif()
 
-  zephyr_get_include_directories_for_lang(C current_includes)
+  # Pass the include directories via a response file to keep this
+  # preprocessing command within the host command-line length limit.
+  # See zephyr_include_directories_response_file() for details.
+  string(MAKE_C_IDENTIFIER "${linker_pass_define}" linker_pass_tag)
+  set(linker_includes_rsp
+    ${PROJECT_BINARY_DIR}/include/generated/linker_includes_${linker_pass_tag}.rsp
+  )
+  zephyr_include_directories_response_file(C "${linker_includes_rsp}" current_includes)
 
   # the command to generate linker file from template
   add_custom_command(
@@ -37,6 +44,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     DEPENDS
     ${LINKER_SCRIPT}
     ${AUTOCONF_H}
+    ${linker_includes_rsp}
     ${extra_dependencies}
     # NB: 'linker_script_dep' will use a keyword that ends 'DEPENDS'
     ${linker_script_dep}

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -55,7 +55,14 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
       set(linker_script_dep "")
     endif()
 
-    zephyr_get_include_directories_for_lang(C current_includes)
+    # Pass the include directories via a response file to keep this
+    # preprocessing command within the host command-line length limit.
+    # See zephyr_include_directories_response_file() for details.
+    string(MAKE_C_IDENTIFIER "${linker_pass_define}" linker_pass_tag)
+    set(linker_includes_rsp
+      ${PROJECT_BINARY_DIR}/include/generated/linker_includes_${linker_pass_tag}.rsp
+    )
+    zephyr_include_directories_response_file(C "${linker_includes_rsp}" current_includes)
     if(DEFINED SOC_LINKER_SCRIPT)
       cmake_path(GET SOC_LINKER_SCRIPT PARENT_PATH soc_linker_script_includes)
       set(soc_linker_script_includes -I${soc_linker_script_includes})
@@ -66,6 +73,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
       DEPENDS
       ${LINKER_SCRIPT}
       ${AUTOCONF_H}
+      ${linker_includes_rsp}
       ${extra_dependencies}
       # NB: 'linker_script_dep' will use a keyword that ends 'DEPENDS'
       ${linker_script_dep}

--- a/cmake/linker/lld/target.cmake
+++ b/cmake/linker/lld/target.cmake
@@ -33,12 +33,20 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     set(linker_script_dep "")
   endif()
 
-  zephyr_get_include_directories_for_lang(C current_includes)
+  # Pass the include directories via a response file to keep this
+  # preprocessing command within the host command-line length limit.
+  # See zephyr_include_directories_response_file() for details.
+  string(MAKE_C_IDENTIFIER "${linker_pass_define}" linker_pass_tag)
+  set(linker_includes_rsp
+    ${PROJECT_BINARY_DIR}/include/generated/linker_includes_${linker_pass_tag}.rsp
+  )
+  zephyr_include_directories_response_file(C "${linker_includes_rsp}" current_includes)
 
   add_custom_command(
     OUTPUT ${linker_script_gen}
     DEPENDS
     ${LINKER_SCRIPT}
+    ${linker_includes_rsp}
     ${extra_dependencies}
     # NB: 'linker_script_dep' will use a keyword that ends 'DEPENDS'
     ${linker_script_dep}

--- a/cmake/linker/xt-ld/target.cmake
+++ b/cmake/linker/xt-ld/target.cmake
@@ -58,13 +58,21 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
       set(linker_script_dep "")
     endif()
 
-    zephyr_get_include_directories_for_lang(C current_includes)
+    # Pass the include directories via a response file to keep this
+    # preprocessing command within the host command-line length limit.
+    # See zephyr_include_directories_response_file() for details.
+    string(MAKE_C_IDENTIFIER "${linker_pass_define}" linker_pass_tag)
+    set(linker_includes_rsp
+      ${PROJECT_BINARY_DIR}/include/generated/linker_includes_${linker_pass_tag}.rsp
+    )
+    zephyr_include_directories_response_file(C "${linker_includes_rsp}" current_includes)
 
     add_custom_command(
       OUTPUT ${linker_script_gen}
       DEPENDS
       ${LINKER_SCRIPT}
       ${AUTOCONF_H}
+      ${linker_includes_rsp}
       ${extra_dependencies}
       # NB: 'linker_script_dep' will use a keyword that ends 'DEPENDS'
       ${linker_script_dep}

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -233,6 +233,44 @@ function(zephyr_get_compile_options_for_lang_as_string lang i)
   set(${i} ${str_of_flags} PARENT_SCOPE)
 endfunction()
 
+# Materialize a (possibly very long, generator-expression) flag string into a
+# GCC/LD '@file' response file and return the "@<path>" token to use on a
+# command line.
+#
+# This exists because CMake/Ninja only auto-spills its *own* compile/link rules
+# into response files; a flag list inlined into an add_custom_command() is not
+# covered and, on hosts with a restrictive command-line length limit, can
+# overflow when the workspace accumulates many long -I include paths.
+#
+# out_var   - variable that receives "@<rsp_path>"
+# rsp_path  - absolute path of the response file to (re)generate
+# content   - flag string, may contain generator expressions; it is expanded at
+#             generate-time via file(GENERATE)
+function(zephyr_flags_response_file out_var rsp_path content)
+  # file(GENERATE) evaluates generator expressions (e.g. the $<JOIN:...> that
+  # zephyr_get_*_for_lang() produces) at the end of the configure stage.
+  file(GENERATE OUTPUT ${rsp_path} CONTENT "${content}\n")
+  set(${out_var} "@${rsp_path}" PARENT_SCOPE)
+endfunction()
+
+# Write all <lang> include directories to the response file <rsp_path> (one -I
+# entry per line) and return the "@<rsp_path>" token in <out_var>.
+#
+# The linker-script preprocessing custom commands use this instead of inlining
+# the include flags, so that the (potentially thousands of characters of) -I
+# paths live in a file and do not overflow the host command-line length limit.
+# One flag per line keeps the file human-diffable.
+#
+# NOTE: callers should add <rsp_path> to their add_custom_command(DEPENDS ...)
+# so the command re-runs when the include set changes (the '@file' token on the
+# command line is invariant, so the generator cannot detect the change itself).
+function(zephyr_include_directories_response_file lang rsp_path out_var)
+  string(ASCII 10 newline)
+  zephyr_get_include_directories_for_lang(${lang} content DELIMITER "${newline}")
+  zephyr_flags_response_file(token "${rsp_path}" "${content}")
+  set(${out_var} "${token}" PARENT_SCOPE)
+endfunction()
+
 function(zephyr_get_include_directories_for_lang lang i)
   zephyr_get_parse_args(args ${ARGN})
   get_property(flags TARGET zephyr_interface PROPERTY INTERFACE_INCLUDE_DIRECTORIES)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -441,7 +441,6 @@ endfunction()
 
 #]=======================================================================]
 function(zephyr_get_include_directories_for_lang lang i)
-function(zephyr_get_include_directories_for_lang lang i)
   zephyr_get_parse_args(args ${ARGN})
   get_property(flags TARGET zephyr_interface PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -390,6 +390,44 @@ function(zephyr_get_compile_options_for_lang_as_string lang i)
   set(${i} ${str_of_flags} PARENT_SCOPE)
 endfunction()
 
+# Materialize a (possibly very long, generator-expression) flag string into a
+# GCC/LD '@file' response file and return the "@<path>" token to use on a
+# command line.
+#
+# This exists because CMake/Ninja only auto-spills its *own* compile/link rules
+# into response files; a flag list inlined into an add_custom_command() is not
+# covered and, on hosts with a restrictive command-line length limit, can
+# overflow when the workspace accumulates many long -I include paths.
+#
+# out_var   - variable that receives "@<rsp_path>"
+# rsp_path  - absolute path of the response file to (re)generate
+# content   - flag string, may contain generator expressions; it is expanded at
+#             generate-time via file(GENERATE)
+function(zephyr_flags_response_file out_var rsp_path content)
+  # file(GENERATE) evaluates generator expressions (e.g. the $<JOIN:...> that
+  # zephyr_get_*_for_lang() produces) at the end of the configure stage.
+  file(GENERATE OUTPUT ${rsp_path} CONTENT "${content}\n")
+  set(${out_var} "@${rsp_path}" PARENT_SCOPE)
+endfunction()
+
+# Write all <lang> include directories to the response file <rsp_path> (one -I
+# entry per line) and return the "@<rsp_path>" token in <out_var>.
+#
+# The linker-script preprocessing custom commands use this instead of inlining
+# the include flags, so that the (potentially thousands of characters of) -I
+# paths live in a file and do not overflow the host command-line length limit.
+# One flag per line keeps the file human-diffable.
+#
+# NOTE: callers should add <rsp_path> to their add_custom_command(DEPENDS ...)
+# so the command re-runs when the include set changes (the '@file' token on the
+# command line is invariant, so the generator cannot detect the change itself).
+function(zephyr_include_directories_response_file lang rsp_path out_var)
+  string(ASCII 10 newline)
+  zephyr_get_include_directories_for_lang(${lang} content DELIMITER "${newline}")
+  zephyr_flags_response_file(token "${rsp_path}" "${content}")
+  set(${out_var} "${token}" PARENT_SCOPE)
+endfunction()
+
 #[=======================================================================[.rst:
 .. cmake:signature:: zephyr_get_include_directories_for_lang(<lang> <var> [STRIP_PREFIX])
 
@@ -402,6 +440,7 @@ endfunction()
    ``STRIP_PREFIX`` can be specified to omit the prefix from the result.
 
 #]=======================================================================]
+function(zephyr_get_include_directories_for_lang lang i)
 function(zephyr_get_include_directories_for_lang lang i)
   zephyr_get_parse_args(args ${ARGN})
   get_property(flags TARGET zephyr_interface PROPERTY INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
## cmake: linker: pass linker-script includes via a response file

### Problem

The linker script is preprocessed by an `add_custom_command()` that inlines every include directory in the build as `-I` flags. Unlike CMake/Ninja's own compile and link rules, an `add_custom_command()` is never spilled into a response file, so this command line grows without bound as more modules are integrated. On Windows it eventually exceeds the `cmd.exe` 8191-character command-line limit and the build aborts with **The system cannot execute the specified program**. The same build succeeds on Linux and macOS, where the command-line limit is far higher.

### Fix

Route the include directories through a response file (`@file`) instead of inlining them, for all four linker backends (`ld`, `lld`, `xt-ld`, `arcmwdt`). Two reusable helpers are added to `cmake/modules/extensions.cmake`:

- `zephyr_flags_response_file()` — writes a flag string to a compiler/linker   `@file` via `file(GENERATE)` (so generator expressions are expanded at generate time) and returns the `@<path>` token.
- `zephyr_include_directories_response_file()` — emits all include directories for a language, one `-I` per line, and returns the `@<path>` token.

The response file is added to the command's `DEPENDS` so the step still re-runs when the include set changes (the invariant `@file` token cannot signal that change on its own). The file name is derived from the pass define with `string(MAKE_C_IDENTIFIER)` so it is always a valid filename. Compared to the previous code, the preprocessor receives exactly the same include paths.

### Before / after

`samples/hello_world`, GNU `ld` backend, measured as the length of the generated Ninja command for the linker-script preprocessing step.

**`frdm_mcxn947/mcxn947/cpu0`**

| Pass       | Before (inlined)       | After (`@rsp`)                     |
|------------|------------------------|------------------------------------|
| PREBUILT   | 3468 chars, 32x `-I`   | 1058 chars, 1x `-I` (31 in `.rsp`) |
| FINAL      | 3417 chars, 32x `-I`   | 1004 chars, 1x `-I` (31 in `.rsp`) |

**`nrf5340dk/nrf5340/cpuapp`**

| Pass       | Before (inlined)       | After (`@rsp`)                     |
|------------|------------------------|------------------------------------|
| PREBUILT   | 2458 chars, 22x `-I`   | 1051 chars, 1x `-I` (21 in `.rsp`) |
| FINAL      | 2407 chars, 22x `-I`   | 997 chars, 1x `-I` (21 in `.rsp`)  |

The single `-I` remaining on the command line is the SoC linker-script directory; all workspace include directories move into the response file. The removed portion scales with the number and length of include paths — exactly the part that overflows on larger builds.

For both boards, on the GNU `ld` backend:

- The generated linker script (`linker.cmd`) is **byte-for-byte identical** to   the inlined version (after normalizing the absolute build-directory prefix):   30808 bytes for `frdm_mcxn947`, 30520 bytes for `nrf5340dk`.
- All code/data ELF sections (`.text`, `.rodata`, `.data`, `.bss`, `.noinit`)   are unchanged.

Builds were run on a Windows host with the Zephyr SDK arm-zephyr-eabi toolchain. The `lld`, `xt-ld` and `arcmwdt` backends receive the same mechanical change but were not built here (no matching toolchain available); they can covered by CI.