### PR TITLE
Imx952 m7 enable edma

### DIFF
--- a/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7.dts
+++ b/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7.dts
@@ -38,3 +38,11 @@
 &tstmr2 {
 	status = "okay";
 };
+
+&edma1 {
+	status = "okay";
+};
+
+&edma2 {
+	status = "okay";
+};

--- a/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7.dts
+++ b/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7.dts
@@ -42,3 +42,11 @@
 &gpio2 {
 	status = "okay";
 };
+
+&edma1 {
+	status = "okay";
+};
+
+&edma2 {
+	status = "okay";
+};

--- a/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7.yaml
+++ b/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7.yaml
@@ -15,6 +15,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - dma
   - uart
 testing:
   binaries:

--- a/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7.yaml
+++ b/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7.yaml
@@ -15,6 +15,7 @@ toolchain:
   - gnuarmemb
 supported:
   - adc
+  - dma
   - gpio
   - uart
 testing:

--- a/dts/arm/nxp/imx/nxp_imx952_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx952_m7.dtsi
@@ -208,9 +208,27 @@
 			status = "disabled";
 		};
 
-		edma2: dma@42000000 {
+		edma1: dma@44000000 {
 			compatible = "nxp,mcux-edma";
-			reg = <0x42000000 0x4000>;
+			reg = <0x44000000 0x4000>;
+			#dma-cells = <2>;
+			nxp,version = <4>;
+			dma-channels = <32>;
+			dma-requests = <32>;
+			interrupts = <96 0>, <97 0>, <98 0>, <99 0>,
+				     <100 0>, <101 0>, <102 0>, <103 0>,
+				     <104 0>, <105 0>, <106 0>, <107 0>,
+				     <108 0>, <109 0>, <110 0>, <111 0>,
+				     <112 0>, <113 0>, <114 0>, <115 0>,
+				     <116 0>, <117 0>, <118 0>, <119 0>,
+				     <120 0>, <121 0>, <122 0>, <123 0>,
+				     <124 0>, <125 0>, <126 0>, <126 0>;
+			status = "disabled";
+		};
+
+		edma2: dma@42800000 {
+			compatible = "nxp,mcux-edma";
+			reg = <0x42800000 0x4000>;
 			#dma-cells = <2>;
 			nxp,version = <5>;
 			dma-channels = <64>;

--- a/tests/drivers/dma/loop_transfer/boards/imx952_evk_mimx9529_m7.conf
+++ b/tests/drivers/dma/loop_transfer/boards/imx952_evk_mimx9529_m7.conf
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_NOCACHE_MEMORY=y

--- a/tests/drivers/dma/loop_transfer/boards/imx952_evk_mimx9529_m7.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/imx952_evk_mimx9529_m7.overlay
@@ -1,0 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &edma1 {};


### PR DESCRIPTION
This series adds DMA support for the i.MX952 EVK Cortex-M7 core.

Add EDMA1  controller node at base address 0x44000000 with 31 channels and IRQ 96-126 (version 4). Also fix EDMA2  base address from 0x42000000 to 0x42800000
Enable EDMA1 and EDMA2 on the i.MX952 EVK M7 board DTS and add dma to supported features in board YAML.
Add loop_transfer test overlay mapping tst_dma0 to edma1, and board conf with CONFIG_NOCACHE_MEMORY=y required for the M7 D-cache build.
Tested on imx952_evk/mimx9529/m7 with tests/drivers/dma/loop_transfer.