### PR TITLE
boards: frdm_mcxa344: add ostimer support

### DIFF
--- a/boards/nxp/frdm_mcxa344/board.c
+++ b/boards/nxp/frdm_mcxa344/board.c
@@ -239,6 +239,10 @@ void board_early_init_hook(void)
 	SPC_EnableActiveModeAnalogModules(SPC0, kSPC_controlOpamp2);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ostimer0))
+	CLOCK_AttachClk(kCLK_1M_to_OSTIMER);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 }

--- a/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
+++ b/boards/nxp/frdm_mcxa344/frdm_mcxa344.dts
@@ -239,6 +239,13 @@
 	pinctrl-names = "default";
 };
 
+/*
+ * Uses OS timer as the kernel timer
+ */
+&ostimer0 {
+	status = "okay";
+};
+
 /* OPAMP configuration */
 &opamp0 {
 	pinctrl-0 = <&pinmux_opamp0>;

--- a/drivers/timer/Kconfig.mcux_os
+++ b/drivers/timer/Kconfig.mcux_os
@@ -24,7 +24,7 @@ config MCUX_OS_TIMER_PM_POWERED_OFF
 
 config MCUX_OS_TIMER_MIN_DELAY
 	int "Minimum delay cycles for OS timer match value"
-	default 1000
+	default 50
 	help
 	  Timer hardware requires a minimum setup time to reliably trigger
 	  interrupts. If a match value is set too close to the current timer


### PR DESCRIPTION
    Enable ostimer as the default kernel timer for frdm_mcxa344,
    which aligns with the SoC design intent and is consistent with
    other MCXA boards (frdm_mcxa153, frdm_mcxa156).

    - Enable ostimer0 in the board DTS
    - Attach 1MHz clock to OSTIMER in board_early_init_hook