### PR TITLE
arch: arm: core: cortex_m: disallow unsafe D-cache invalidate

### DIFF
--- a/arch/arm/core/cortex_m/cache.c
+++ b/arch/arm/core/cortex_m/cache.c
@@ -34,9 +34,17 @@ int arch_dcache_flush_all(void)
 
 int arch_dcache_invd_all(void)
 {
-	SCB_InvalidateDCache();
-
-	return 0;
+	/*
+	 * CMSIS provides SCB_InvalidateDCache() to invalidate the entire
+	 * D-cache. However, using it while the system is running can also
+	 * invalidate dirty cache lines belonging to the current stack or other
+	 * runtime state, resulting in data loss or corruption. Since it is
+	 * difficult for this backend to provide a correct runtime
+	 * implementation of arch_dcache_invd_all(), report the operation as
+	 * -ENOTSUP instead. The whole-cache clean and clean-invalidate paths
+	 * remain available for callers that need safe maintenance.
+	 */
+	return -ENOTSUP;
 }
 
 int arch_dcache_flush_and_invd_all(void)


### PR DESCRIPTION
The Cortex-M arch cache backend exposed sys_cache_data_invd_all() through SCB_InvalidateDCache(). Invalidating the whole D-cache while Zephyr is running can drop dirty stack, kernel, or ztest state, which hangs the cache API test on i.MX RT Cortex-M7 platforms.

Report the operation as unsupported instead. The cache API permits -ENOTSUP for unsupported operations, and the whole-cache clean and clean-invalidate paths remain available for callers that need safe maintenance.

Tested on mimxrt1064_evk/mimxrt1064 with tests/arch/common/cache using J-Link and COM42; all cache_api tests passed and PROJECT EXECUTION SUCCESSFUL was captured. Also built the same test for mimxrt1170_evk/mimxrt1176/cm7.

This fixes https://github.com/zephyrproject-rtos/zephyr/issues/112982