### PR TITLE
Fix/cpp minimal new header

### DIFF
--- a/lib/cpp/minimal/cpp_new.cpp
+++ b/lib/cpp/minimal/cpp_new.cpp
@@ -7,6 +7,13 @@
 #include <stdlib.h>
 #include <new>
 
+/*
+ * Define the std::nothrow object referenced by new(std::nothrow) expressions.
+ * Without this, the linker reports: undefined reference to `std::nothrow'.
+ * The standard mandates it be defined in the C++ runtime library.
+ */
+namespace std { const nothrow_t nothrow; }
+
 #if __cplusplus < 201103L
 #define NOEXCEPT
 #else /* >= C++11 */

--- a/lib/cpp/minimal/include/new
+++ b/lib/cpp/minimal/include/new
@@ -25,9 +25,40 @@ namespace std {
 #endif /* __cplusplus */
 	extern const std::nothrow_t nothrow;
 
+#if __cplusplus < 201103L
+#define _CPP_NOEXCEPT
+#else
+#define _CPP_NOEXCEPT noexcept
+#endif
+
 #if __cplusplus >= 201703L
 	enum class align_val_t : std::size_t {};
 #endif /* CONFIG_STD_CPP17 */
 
-}
+} /* namespace std */
+
+/*
+ * Placement new - constructs in already-allocated storage.
+ * new (&buf) T(args) requires operator new(size_t, void*) to be visible.
+ * The standard mandates this overload does nothing but return ptr.
+ */
+inline void* operator new(std::size_t, void* ptr) _CPP_NOEXCEPT { return ptr; }
+inline void* operator new[](std::size_t, void* ptr) _CPP_NOEXCEPT { return ptr; }
+
+/*
+ * Declarations of the nothrow operator new/delete overloads.
+ * The implementations live in lib/cpp/minimal/cpp_new.cpp.
+ * Without these forward declarations, code that uses
+ *   new (std::nothrow) T[n]
+ * fails to compile because the overload is not visible.
+ */
+void* operator new(std::size_t size, const std::nothrow_t&) _CPP_NOEXCEPT;
+void* operator new[](std::size_t size, const std::nothrow_t&) _CPP_NOEXCEPT;
+void  operator delete(void* ptr) _CPP_NOEXCEPT;
+void  operator delete[](void* ptr) _CPP_NOEXCEPT;
+#if __cplusplus >= 201103L
+void  operator delete(void* ptr, std::size_t size) _CPP_NOEXCEPT;
+void  operator delete[](void* ptr, std::size_t size) _CPP_NOEXCEPT;
+#endif
+
 #endif /* ZEPHYR_SUBSYS_CPP_INCLUDE_NEW_ */

--- a/tests/lib/cpp/cxx/src/main.cpp
+++ b/tests/lib/cpp/cxx/src/main.cpp
@@ -9,6 +9,7 @@
  * compile in C++ mode.
  */
 
+#include <new>
 #include <string.h>
 #include <zephyr/types.h>
 #include <stdbool.h>
@@ -135,6 +136,78 @@ ZTEST(cxx_tests, test_new_delete)
 	zassert_equal(test_foo->get_foo(), 10);
 	delete test_foo;
 }
+
+ZTEST(cxx_tests, test_nothrow_new)
+{
+	/*
+	 * new (std::nothrow) must return a valid pointer for a small allocation
+	 * and must not throw on failure (returns nullptr instead).
+	 */
+	foo_class *p = new (std::nothrow) foo_class(42);
+	zassert_not_null(p, "nothrow new returned nullptr unexpectedly");
+	zassert_equal(p->get_foo(), 42);
+	delete p;
+}
+
+ZTEST(cxx_tests, test_nothrow_new_array)
+{
+	/* new (std::nothrow) T[n] - array variant of the nothrow overload. */
+	int *arr = new (std::nothrow) int[8];
+	zassert_not_null(arr, "nothrow new[] returned nullptr unexpectedly");
+	for (int i = 0; i < 8; i++) {
+		arr[i] = i;
+	}
+	zassert_equal(arr[7], 7);
+	delete[] arr;
+}
+
+ZTEST(cxx_tests, test_nothrow_new_oom)
+{
+	/*
+	 * Requesting an impossibly large allocation via new (std::nothrow)
+	 * must return nullptr rather than throwing std::bad_alloc.
+	 */
+	void *p = operator new(SIZE_MAX, std::nothrow);
+
+	zassert_is_null(p, "nothrow new should return nullptr on OOM");
+}
+
+ZTEST(cxx_tests, test_nothrow_new_array_oom)
+{
+	/*
+	 * Array variant: requesting an impossibly large allocation via
+	 * new (std::nothrow) T[n] must return nullptr, not throw.
+	 */
+	int *arr = new (std::nothrow) int[SIZE_MAX / sizeof(int)];
+
+	zassert_is_null(arr, "nothrow new[] should return nullptr on OOM");
+}
+
+ZTEST(cxx_tests, test_placement_new)
+{
+	/*
+	 * placement new must construct the object in the supplied buffer and
+	 * must return exactly the pointer that was passed to it.
+	 */
+	alignas(foo_class) unsigned char buf[sizeof(foo_class)];
+	foo_class *p = new (buf) foo_class(99);
+	zassert_equal_ptr(p, (void *)buf, "placement new returned wrong pointer");
+	zassert_equal(p->get_foo(), 99);
+	p->~foo_class();
+}
+
+ZTEST(cxx_tests, test_placement_new_array)
+{
+	/* placement new[] must return the supplied buffer pointer. */
+	alignas(int) unsigned char buf[sizeof(int) * 4];
+	int *arr = new (buf) int[4];
+	zassert_equal_ptr(arr, (void *)buf, "placement new[] returned wrong pointer");
+	for (int i = 0; i < 4; i++) {
+		arr[i] = i * 2;
+	}
+	zassert_equal(arr[3], 6);
+}
+
 ZTEST_SUITE(cxx_tests, NULL, NULL, NULL, NULL, NULL);
 
 /*


### PR DESCRIPTION
The minimal C++ runtime has three gaps that cause build failures in projects using CONFIG_CPP=y.

First, cpp_new.cpp implements nothrow operator new/delete but never defines std::nothrow. Any code that passes std::nothrow to operator new gets an undefined reference at link time. Fix: add the definition to cpp_new.cpp.

Second, those nothrow overloads exist in cpp_new.cpp but are not declared in include/new. A translation unit that includes <new> and calls new(std::nothrow) T fails to compile. Fix: add forward declarations to include/new along with the _CPP_NOEXCEPT macro already used by the implementation.

Third, placement new (operator new(size_t, void*) and the array form) is required by C++20.10.2 but absent from include/new. Code that constructs objects in pre-allocated buffers fails to compile. Fix: add the two trivial inline definitions (return ptr) to include/new.

Discovered when building for ESP32-S3 with CONFIG_CPP=y. All three errors appeared in sequence and are resolved with these changes. Nothing here is platform-specific.