### PR TITLE
drivers: pcie: host: shell: implement unified advanced telemetry and …

### DIFF
--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -376,6 +376,18 @@ static bool scan_flag(const struct pcie_scan_opt *opt, uint32_t flag)
 /* Forward declaration needed since scanning a device may reveal a bridge */
 static bool scan_bus(uint8_t bus, const struct pcie_scan_opt *opt);
 
+static inline bool should_skip_masked_bdf(pcie_bdf_t bdf, uint8_t func,
+					  const struct pcie_scan_opt *opt)
+{
+	ARG_UNUSED(func);
+
+	if (opt != NULL && opt->scan_masking_fn != NULL) {
+		return opt->scan_masking_fn(bdf);
+	}
+
+	return false;
+}
+
 static bool scan_dev(uint8_t bus, uint8_t dev, const struct pcie_scan_opt *opt)
 {
 	for (uint8_t func = 0; func <= PCIE_MAX_FUNC; func++) {
@@ -383,6 +395,14 @@ static bool scan_dev(uint8_t bus, uint8_t dev, const struct pcie_scan_opt *opt)
 		uint32_t secondary = 0;
 		uint32_t id, type;
 		bool do_cb;
+
+		/* Skip the scan loops if this BDF is registered in the mask */
+		if (should_skip_masked_bdf(bdf, func, opt)) {
+			if (func == 0) {
+				break;
+			}
+			continue;
+		}
 
 		id = pcie_conf_read(bdf, PCIE_CONF_ID);
 		if (!PCIE_ID_IS_VALID(id)) {

--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -376,6 +376,18 @@ static bool scan_flag(const struct pcie_scan_opt *opt, uint32_t flag)
 /* Forward declaration needed since scanning a device may reveal a bridge */
 static bool scan_bus(uint8_t bus, const struct pcie_scan_opt *opt);
 
+static inline bool should_skip_masked_bdf(pcie_bdf_t bdf, uint8_t func,
+					  const struct pcie_scan_opt *opt)
+{
+	ARG_UNUSED(func);
+
+	if (opt != NULL && opt->scan_masking_fn != NULL) {
+		return opt->scan_masking_fn(bdf);
+	}
+
+	return false;
+}
+
 static bool scan_dev(uint8_t bus, uint8_t dev, const struct pcie_scan_opt *opt)
 {
 	for (uint8_t func = 0; func <= PCIE_MAX_FUNC; func++) {
@@ -383,6 +395,11 @@ static bool scan_dev(uint8_t bus, uint8_t dev, const struct pcie_scan_opt *opt)
 		uint32_t secondary = 0;
 		uint32_t id, type;
 		bool do_cb;
+
+		/* Skip the scan loops if this BDF is registered in the mask */
+		if (should_skip_masked_bdf(bdf, func, opt)) {
+			continue;
+		}
 
 		id = pcie_conf_read(bdf, PCIE_CONF_ID);
 		if (!PCIE_ID_IS_VALID(id)) {

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -1243,6 +1243,84 @@ static int cmd_pcie_device_state(const struct shell *sh, size_t argc, char **arg
 	return 0;
 }
 
+/* Subcommand: pcie link speed <bus:dev.func> */
+static int cmd_pcie_link_speed(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id;
+	uint32_t exp_offset;
+	uint32_t lnkcap_val;
+	uint32_t lnksta_val;
+	uint8_t raw_max_width;
+	uint8_t raw_curr_width;
+	uint8_t max_speed, curr_speed;
+	uint8_t max_width, curr_width;
+
+	/* Shell parsing gate checked */
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie link speed <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	exp_offset = pcie_get_cap(bdf, PCI_CAP_ID_EXP);
+	if (exp_offset == 0) {
+		shell_error(sh, "Target device does not support native PCIe Capabilities.");
+		return -EOPNOTSUPP;
+	}
+
+	lnkcap_val = pcie_conf_read(bdf, exp_offset + 3U);
+	max_speed = (uint8_t)(lnkcap_val & 0x0FU);
+
+	raw_max_width = (uint8_t)((lnkcap_val >> 4) & 0x3FU);
+	max_width = (raw_max_width != 0U) ? raw_max_width : 1U;
+
+	lnksta_val = pcie_conf_read(bdf, exp_offset + 4U) >> 16;
+	curr_speed = (uint8_t)(lnksta_val & 0x0FU);
+
+	raw_curr_width = (uint8_t)((lnksta_val >> 4) & 0x3FU);
+	curr_width = (raw_curr_width != 0U) ? raw_curr_width : 1U;
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCIe HARDWARE LINK BANDWIDTH CAPABILITY TRACKER: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   Silicon Design Limits (Maximum Capabilities):");
+	shell_print(sh, "      Max Link Speed : PCIe Gen %u", (unsigned int)max_speed);
+	shell_print(sh, "      Max Link Width : x%u Lanes", (unsigned int)max_width);
+	shell_print(sh, "   ----------------------------------------------------");
+	shell_print(sh, "   Real-Time Operational Link Status:");
+	shell_print(sh, "      Current Speed  : PCIe Gen %u",
+		    curr_speed == 0U ? max_speed : curr_speed);
+	shell_print(sh, "      Current Width  : x%u Lanes",
+		    (unsigned int)(curr_width == 0U ? max_width : curr_width));
+	shell_print(sh, "   ----------------------------------------------------");
+
+	if ((curr_speed < max_speed && curr_speed != 0U) ||
+	    (curr_width < max_width && curr_width != 0U)) {
+		shell_print(sh, "   [CRITICAL] -> Link Bandwidth Degradation Detected!");
+		shell_print(sh, "                 Hardware has autonomously downgraded its lane "
+				"configurations.");
+	} else {
+		shell_print(
+			sh,
+			"   -> Link Negotiation Status: Healthy [Maximum Bus Throughput Achieved]");
+	}
+	shell_print(sh, "====================================================================");
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -1265,6 +1343,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      cmd_pcie_link_set_speed, 3, 0),
 	SHELL_CMD_ARG(margin, NULL, "Trace SerDes physical layer receiver lane margining caps",
 		      cmd_pcie_link_margin, 2, 0),
+	SHELL_CMD_ARG(speed, NULL, "Trace link capabilities and real-time speed negotiation status",
+		      cmd_pcie_link_speed, 2, 0),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -479,6 +479,12 @@ static int cmd_pcie_mask_ignore(const struct shell *sh, size_t argc, char **argv
 	}
 
 	pcie_bdf_t bdf = get_bdf(argv[1]);
+
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
 	bdf = PCIE_BDF(PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), 0);
 
 	if (is_bdf_masked(bdf)) {
@@ -491,6 +497,39 @@ static int cmd_pcie_mask_ignore(const struct shell *sh, size_t argc, char **argv
 	shell_print(sh, "Successfully masked BDF %u:%x.%u. Bus scans will ignore this slot.",
 		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
 
+	return 0;
+}
+
+/* Subcommand: pcie mask clear */
+static int cmd_pcie_mask_clear(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	masked_count = 0;
+	pcie_scan_override_hook = NULL;
+	shell_print(sh, "Software PCIe mask tracking array successfully cleared.");
+	return 0;
+}
+
+/* Subcommand: pcie mask show */
+static int cmd_pcie_mask_show(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	shell_print(sh, "--- Active PCIe Software Mask Registry Matrix ---");
+	if (masked_count == 0) {
+		shell_print(sh, " No devices currently masked.");
+		return 0;
+	}
+
+	for (uint32_t i = 0; i < masked_count; i++) {
+		pcie_bdf_t bdf = masked_bdfs[i];
+
+		shell_print(sh, " [%u] Ignored BDF Slot -> %u:%x.%u", i, PCIE_BDF_TO_BUS(bdf),
+			    PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	}
 	return 0;
 }
 
@@ -711,6 +750,7 @@ static int cmd_pcie_link_set_speed(const struct shell *sh, size_t argc, char **a
 		shell_error(sh, "No responsive endpoint found at target BDF.");
 		return -ENODEV;
 	}
+
 	pcie_cap_offset = pcie_get_cap(bdf, PCI_CAP_ID_EXP);
 	if (pcie_cap_offset == 0) {
 		shell_error(sh, "Target device does not support native "
@@ -752,7 +792,7 @@ static int cmd_pcie_link_set_speed(const struct shell *sh, size_t argc, char **a
 	link_ctrl2_reg = pcie_cap_offset + (0x30U / 4U);
 	link_ctrl2 = pcie_conf_read(bdf, link_ctrl2_reg);
 
-	link_ctrl2 &= ~0x0FU;
+	link_ctrl2 &= ~0x0FU; /* Clear Target Link Speed bitfield (Bits 3:0) */
 	link_ctrl2 |= target_speed;
 	pcie_conf_write(bdf, link_ctrl2_reg, link_ctrl2);
 
@@ -785,6 +825,114 @@ static int cmd_pcie_link_set_speed(const struct shell *sh, size_t argc, char **a
 	return 0;
 }
 
+/* Subcommand: pcie irq status <bus:dev.func> */
+static int cmd_pcie_irq_status(const struct shell *sh, size_t argc, char **argv)
+{
+	uint32_t intr;
+	uint8_t int_pin;
+	uint8_t int_line;
+	uint32_t msi_offset;
+	uint32_t msix_offset;
+	pcie_bdf_t bdf;
+	uint32_t id;
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie irq status <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (!PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCIe INTERRUPT LINE DIAGNOSTIC MATRIX: %u:%x.%u", PCIE_BDF_TO_BUS(bdf),
+		    PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+
+	intr = pcie_conf_read(bdf, PCIE_CONF_INTR);
+	int_pin = (intr >> 8) & 0xFFU;
+	int_line = intr & 0xFFU;
+
+	shell_print(sh, "Legacy INTx Parameters:");
+	shell_print(sh, "   -> Interrupt Pin  : INT%c", int_pin ? ('A' + int_pin - 1) : '-');
+
+	if (int_line == PCIE_CONF_INTR_IRQ_NONE) {
+		shell_print(sh, "   -> Interrupt Line : NOT ROUTED");
+	} else {
+		shell_print(sh, "   -> Interrupt Line : IRQ %u", (unsigned int)int_line);
+	}
+
+	shell_print(sh, "----------------------------------------------------");
+
+	msi_offset = pcie_get_cap(bdf, PCI_CAP_ID_MSI);
+	if (msi_offset != 0) {
+		uint32_t msg_ctrl = pcie_conf_read(bdf, msi_offset);
+		bool msi_en = (msg_ctrl & (1U << 16)) != 0;
+		uint32_t multi_msg = (msg_ctrl >> 17) & 0x07U;
+		uint32_t multi_en = (msg_ctrl >> 20) & 0x07U;
+		bool is_64bit = (msg_ctrl & (1U << 23)) != 0;
+		uint32_t addr_lo = pcie_conf_read(bdf, msi_offset + 1);
+
+		shell_print(sh, "Message Signaled Interrupts (MSI) Capability [Offset 0x%02X]:",
+			    msi_offset * 4);
+		shell_print(sh, "   -> Active Status  : %s", msi_en ? "ENABLED" : "DISABLED");
+		shell_print(sh, "   -> Capabilities   : Multiple Message Capable: %u vectors",
+			    1U << multi_msg);
+		shell_print(sh, "   -> Allocated      : Multiple Message Enabled: %u vectors",
+			    1U << multi_en);
+
+		if (is_64bit) {
+			uint32_t addr_hi = pcie_conf_read(bdf, msi_offset + 2);
+			uint32_t msg_data = pcie_conf_read(bdf, msi_offset + 3) & 0xFFFFU;
+
+			shell_print(sh, "   -> Target Address : 0x%08X%08X", addr_hi, addr_lo);
+			shell_print(sh, "   -> Message Data   : 0x%04X", msg_data);
+		} else {
+			uint32_t msg_data = pcie_conf_read(bdf, msi_offset + 2) & 0xFFFFU;
+
+			shell_print(sh, "   -> Target Address : 0x%08X", addr_lo);
+			shell_print(sh, "   -> Message Data   : 0x%04X", msg_data);
+		}
+	} else {
+		shell_print(sh, "MSI Capability [ID 0x05]     : NOT SUPPORTED");
+	}
+	shell_print(sh, "----------------------------------------------------");
+
+	msix_offset = pcie_get_cap(bdf, PCI_CAP_ID_MSIX);
+	if (msix_offset != 0) {
+		uint32_t msg_ctrl = pcie_conf_read(bdf, msix_offset);
+		bool msix_en = (msg_ctrl & (1U << 31)) != 0;
+		bool msix_mask = (msg_ctrl & (1U << 30)) != 0;
+		uint32_t table_size = ((msg_ctrl >> 16) & 0x07FFU) + 1;
+		uint32_t table_bir = pcie_conf_read(bdf, msix_offset + 1);
+		uint8_t bir = table_bir & 0x07U;
+		uint32_t offset = table_bir & ~0x07U;
+
+		shell_print(sh,
+			    "Extended MSI (MSI-X) Capability [Offset 0x%02X]:", msix_offset * 4);
+		shell_print(sh, "   -> Active Status  : %s", msix_en ? "ENABLED" : "DISABLED");
+		shell_print(sh, "   -> Global Mask    : %s",
+			    msix_mask ? "TRUE (All Vectors Blocked)" : "FALSE");
+		shell_print(sh, "   -> Table Size     : %u distinct vectors", table_size);
+		shell_print(sh, "   -> Vector Table   : Located in BAR %u at base offset + 0x%08X",
+			    bir, offset);
+	} else {
+		shell_print(sh, "MSI-X Capability [ID 0x11]   : NOT SUPPORTED");
+	}
+	shell_print(sh, "====================================================================");
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -808,6 +956,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_irq_cmds,
+	SHELL_CMD_ARG(status, NULL, "Trace legacy and MSI/MSI-X vector configuration statuses",
+		      cmd_pcie_irq_status, 2, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
 		      "List PCIE devices\n"
@@ -822,6 +976,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		  NULL),
 	SHELL_CMD(link, &sub_pcie_link_cmds,
 		  "Manage PCIe hardware link performance and power metrics", NULL),
+	SHELL_CMD(irq, &sub_pcie_irq_cmds, "Trace legacy and vector interrupt message allocations",
+		  NULL),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(pcie, &sub_pcie_cmds, "PCI(e) device information", cmd_pcie_ls);

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -45,6 +45,15 @@ struct pcie_cap_id_to_str {
 #define PCIE_MARGIN_CAP_MAX_T_STEPS(val)     (((val) >> 15) & 0x3FU)
 #define PCIE_MARGIN_CAP_MAX_T_STEPS_BIT(val) (((val) >> 21) & 0x1U)
 
+/* Standard PCI Power Management Capability ID */
+#define PCI_CAP_ID_PM 0x01U
+
+/* Power Management Control/Status Register (PMCSR) Relative Offsets & Masks */
+#define PCI_PM_CTRL_STATUS_REG (0x04U / 4U)
+#define PCI_PM_STATE_MASK      0x03U
+#define PCI_PM_STATE_D0        0x00U
+#define PCI_PM_STATE_D3HOT     0x03U
+
 static const struct pcie_cap_id_to_str pcie_cap_list[] = {
 	{ PCI_CAP_ID_PM,     "Power Management" },
 	{ PCI_CAP_ID_AGP,    "Accelerated Graphics Port" },
@@ -1172,6 +1181,68 @@ static int cmd_pcie_link_margin(const struct shell *sh, size_t argc, char **argv
 	return 0;
 }
 
+/* Subcommand: pcie device state <bus:dev.func> up|down */
+static int cmd_pcie_device_state(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id;
+	uint32_t pm_offset;
+	uint32_t pmcsr;
+	uint32_t target_state;
+
+	if (argc < 3) {
+		shell_error(sh, "Usage: pcie device state <bus:dev.func> up|down");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF format mapping specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	pm_offset = pcie_get_cap(bdf, PCI_CAP_ID_PM);
+	if (pm_offset == 0) {
+		shell_error(sh, "Target device does not support PCI Power Management.");
+		return -EOPNOTSUPP;
+	}
+
+	if (strcmp(argv[2], "up") == 0) {
+		target_state = PCI_PM_STATE_D0;
+	} else if (strcmp(argv[2], "down") == 0) {
+		target_state = PCI_PM_STATE_D3HOT;
+	} else {
+		shell_error(sh, "Invalid state token. Use 'up' for D0 or 'down' for D3hot.");
+		return -EINVAL;
+	}
+
+	pmcsr = pcie_conf_read(bdf, pm_offset + PCI_PM_CTRL_STATUS_REG);
+	pmcsr &= ~PCI_PM_STATE_MASK;
+	pmcsr |= target_state;
+	pcie_conf_write(bdf, pm_offset + PCI_PM_CTRL_STATUS_REG, pmcsr);
+
+	pmcsr = pcie_conf_read(bdf, pm_offset + PCI_PM_CTRL_STATUS_REG);
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCI HARDWARE TRANSCEIVER ENERGY REGISTRY STATUS: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   Current PMCSR Value Readout  : 0x%08X", pmcsr);
+	shell_print(sh, "   Physical Silicon Transceiver: [%s]",
+		    (pmcsr & PCI_PM_STATE_MASK) == PCI_PM_STATE_D3HOT
+			    ? "POWER GATED - D3hot LOW ENERGY SUSPEND"
+			    : "FULLY OPERATIONAL - D0 MAX PERFORMANCE");
+	shell_print(sh, "====================================================================");
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -1209,6 +1280,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_device_cmds,
+	SHELL_CMD_ARG(state, NULL, "Power gate physical device state (up = D0, down = D3hot)",
+		      cmd_pcie_device_state, 3, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
 		      "List PCIE devices\n"
@@ -1226,6 +1303,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(irq, &sub_pcie_irq_cmds, "Trace legacy and vector interrupt message allocations",
 		  NULL),
 	SHELL_CMD(aer, &sub_pcie_aer_cmds, "Interact with PCIe Advanced Error Reporting metrics",
+		  NULL),
+	SHELL_CMD(device, &sub_pcie_device_cmds, "Manage pcie physical hardware device states",
 		  NULL),
 	SHELL_SUBCMD_SET_END);
 

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -592,6 +592,7 @@ static int cmd_pcie_resource_show(const struct shell *sh, size_t argc, char **ar
 		shell_error(sh, "Invalid BDF layout format specification.");
 		return -EINVAL;
 	}
+
 	id = pcie_conf_read(bdf, PCIE_CONF_ID);
 	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
 		shell_error(sh, "No responsive endpoint found at target BDF.");
@@ -674,6 +675,116 @@ static int cmd_pcie_mask_show(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+/* Subcommand: pcie link set_speed <bus:dev.func> <gen1|gen2|gen3|gen4> */
+static int cmd_pcie_link_set_speed(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id;
+	uint32_t pcie_cap_offset;
+	uint32_t target_speed;
+	uint32_t pcie_cap;
+	uint32_t pcie_cap_ver;
+	uint32_t lnkcap2_reg;
+	uint32_t lnkcap2;
+	uint32_t supported_speeds;
+	uint32_t link_ctrl2_reg;
+	uint32_t link_ctrl2;
+	uint32_t link_ctrl_reg;
+	uint32_t link_ctrl;
+	uint32_t link_status;
+	uint32_t negotiated_speed;
+
+	if (argc < 3) {
+		shell_error(sh, "Usage: pcie link set_speed <bus:dev.func> "
+				"<gen1|gen2|gen3|gen4>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+	pcie_cap_offset = pcie_get_cap(bdf, PCI_CAP_ID_EXP);
+	if (pcie_cap_offset == 0) {
+		shell_error(sh, "Target device does not support native "
+				"PCIe Capability structures.");
+		return -EOPNOTSUPP;
+	}
+
+	if (strcmp(argv[2], "gen1") == 0) {
+		target_speed = 0x1;
+	} else if (strcmp(argv[2], "gen2") == 0) {
+		target_speed = 0x2;
+	} else if (strcmp(argv[2], "gen3") == 0) {
+		target_speed = 0x3;
+	} else if (strcmp(argv[2], "gen4") == 0) {
+		target_speed = 0x4;
+	} else {
+		shell_error(sh, "Invalid speed argument. Supported values: "
+				"gen1, gen2, gen3, gen4");
+		return -EINVAL;
+	}
+
+	pcie_cap = pcie_conf_read(bdf, pcie_cap_offset);
+	pcie_cap_ver = (pcie_cap >> 16) & 0xFU;
+
+	if (pcie_cap_ver < 2U) {
+		shell_error(sh, "PCIe cap v%u does not support Link Control 2.", pcie_cap_ver);
+		return -EOPNOTSUPP;
+	}
+
+	lnkcap2_reg = pcie_cap_offset + (0x2CU / 4U);
+	lnkcap2 = pcie_conf_read(bdf, lnkcap2_reg);
+	supported_speeds = lnkcap2 & 0x0FU;
+
+	if ((supported_speeds & (1U << (target_speed - 1U))) == 0U) {
+		shell_error(sh, "Target speed %s is not supported by this link.", argv[2]);
+		return -EINVAL;
+	}
+
+	link_ctrl2_reg = pcie_cap_offset + (0x30U / 4U);
+	link_ctrl2 = pcie_conf_read(bdf, link_ctrl2_reg);
+
+	link_ctrl2 &= ~0x0FU;
+	link_ctrl2 |= target_speed;
+	pcie_conf_write(bdf, link_ctrl2_reg, link_ctrl2);
+
+	shell_print(sh,
+		    "Target speed configured to %s (Value: 0x%X) inside "
+		    "Link Control 2.",
+		    argv[2], target_speed);
+
+	link_ctrl_reg = pcie_cap_offset + (0x10U / 4U);
+	link_ctrl = pcie_conf_read(bdf, link_ctrl_reg);
+
+	shell_print(sh, "Issuing Retrain Link command (Setting Bit 5)...");
+	link_ctrl |= (1U << 5);
+	pcie_conf_write(bdf, link_ctrl_reg, link_ctrl);
+
+	/* Poll Link Status until retraining completes (Link Training bit clears) */
+	link_status = 0U;
+	for (int i = 0; i < 1000; i++) {
+		link_status = pcie_conf_read(bdf, link_ctrl_reg);
+		if (((link_status >> 27) & 0x1U) == 0U) {
+			break;
+		}
+	}
+
+	negotiated_speed = (link_status >> 16) & 0x0FU;
+
+	shell_print(sh, "Active Negotiated Link Speed reported by hardware: Gen%u",
+		    negotiated_speed);
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -691,6 +802,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_link_cmds,
+	SHELL_CMD_ARG(set_speed, NULL, "Scale the target PCIe bus lane speed dynamically",
+		      cmd_pcie_link_set_speed, 3, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
 		      "List PCIE devices\n"
@@ -703,6 +820,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(mask, &sub_pcie_mask_cmds, "Manage PCIe device scanning parameters", NULL),
 	SHELL_CMD(resource, &sub_pcie_resource_cmds, "PCI(e) memory mapping and resource metrics",
 		  NULL),
+	SHELL_CMD(link, &sub_pcie_link_cmds,
+		  "Manage PCIe hardware link performance and power metrics", NULL),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(pcie, &sub_pcie_cmds, "PCI(e) device information", cmd_pcie_ls);

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -22,6 +22,16 @@ struct pcie_cap_id_to_str {
 	char *str;
 };
 
+/* PCI Express Extended Capability Constants */
+#define PCIE_EXT_CAP_AER_ID 0x0001U
+
+/* AER Register Offsets (Relative to the AER Capability Base Offset) */
+#define PCIE_AER_UNCORR_STATUS_REG (0x04U / 4U)
+#define PCIE_AER_UNCORR_MASK_REG   (0x08U / 4U)
+#define PCIE_AER_CORR_STATUS_REG   (0x10U / 4U)
+#define PCIE_AER_CORR_MASK_REG     (0x14U / 4U)
+#define PCIE_AER_HEADER_LOG_REG    (0x1CU / 4U)
+
 static const struct pcie_cap_id_to_str pcie_cap_list[] = {
 	{ PCI_CAP_ID_PM,     "Power Management" },
 	{ PCI_CAP_ID_AGP,    "Accelerated Graphics Port" },
@@ -933,6 +943,123 @@ static int cmd_pcie_irq_status(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static inline void log_pcie_aer_uncorr(const struct shell *sh, uint32_t status)
+{
+	if (status == 0U) {
+		shell_print(sh, "   -> No uncorrectable fatal hardware fractures logged.");
+		return;
+	}
+
+	if ((status & (1U << 0)) != 0U) {
+		shell_print(sh, "   [CRITICAL] -> Link Training Error (LTSSM Failure)");
+	}
+	if ((status & (1U << 4)) != 0U) {
+		shell_print(sh, "   [CRITICAL] -> Data Link Protocol Error Detected");
+	}
+	if ((status & (1U << 12)) != 0U) {
+		shell_print(sh, "   [CRITICAL] -> Poisoned TLP Execution Blocked");
+	}
+	if ((status & (1U << 13)) != 0U) {
+		shell_print(sh, "   [CRITICAL] -> Flow Control Protocol Error (FCPE)");
+	}
+	if ((status & (1U << 16)) != 0U) {
+		shell_print(sh, "   [CRITICAL] -> Unexpected Completion Trap");
+	}
+	if ((status & (1U << 20)) != 0U) {
+		shell_print(sh, "   [CRITICAL] -> Unsupported Request (UR) Abort");
+	}
+}
+
+static inline void log_pcie_aer_corr(const struct shell *sh, uint32_t status)
+{
+	if (status == 0U) {
+		shell_print(sh, "   -> No physical signal degradation deviations reported.");
+		return;
+	}
+
+	if ((status & (1U << 0)) != 0U) {
+		shell_print(sh, "   [WARNING]  -> Receiver Physical Layer Error");
+	}
+	if ((status & (1U << 6)) != 0U) {
+		shell_print(sh, "   [WARNING]  -> Bad TLP Frame CRC Detected");
+	}
+	if ((status & (1U << 7)) != 0U) {
+		shell_print(sh, "   [WARNING]  -> Bad DLLP Frame Checksum Detected");
+	}
+	if ((status & (1U << 8)) != 0U) {
+		shell_print(sh, "   [WARNING]  -> REPLAY_NUM Rollover/Timer Timeout");
+	}
+}
+
+/* Subcommand: pcie aer status <bus:dev.func> */
+static int cmd_pcie_aer_status(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id;
+	uint32_t aer_offset;
+	uint32_t uncorr_status;
+	uint32_t uncorr_mask;
+	uint32_t corr_status;
+	uint32_t corr_mask;
+	uint32_t header_log[4];
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie aer status <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	aer_offset = pcie_get_ext_cap(bdf, PCIE_EXT_CAP_AER_ID);
+	if (aer_offset == 0) {
+		shell_error(sh, "Target device does not support native "
+				"Advanced Error Reporting (AER).");
+		return -EOPNOTSUPP;
+	}
+
+	uncorr_status = pcie_conf_read(bdf, aer_offset + PCIE_AER_UNCORR_STATUS_REG);
+	uncorr_mask = pcie_conf_read(bdf, aer_offset + PCIE_AER_UNCORR_MASK_REG);
+	corr_status = pcie_conf_read(bdf, aer_offset + PCIE_AER_CORR_STATUS_REG);
+	corr_mask = pcie_conf_read(bdf, aer_offset + PCIE_AER_CORR_MASK_REG);
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCIe ADVANCED ERROR REPORTING (AER) STATUS MATRIX: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+
+	shell_print(sh, "Uncorrectable Errors Status: 0x%08X [Mask: 0x%08X]", uncorr_status,
+		    uncorr_mask);
+	log_pcie_aer_uncorr(sh, uncorr_status);
+
+	shell_print(sh, "----------------------------------------------------");
+
+	shell_print(sh, "Correctable Errors Status:   0x%08X [Mask: 0x%08X]", corr_status,
+		    corr_mask);
+	log_pcie_aer_corr(sh, corr_status);
+
+	shell_print(sh, "----------------------------------------------------");
+
+	shell_print(sh, "Transaction Layer Packet (TLP) Header Log Matrix:");
+	for (uint32_t i = 0U; i < 4U; i++) {
+		header_log[i] = pcie_conf_read(bdf, aer_offset + PCIE_AER_HEADER_LOG_REG + i);
+	}
+	shell_print(sh, "   [DW0-DW1] : 0x%08X 0x%08X", header_log[0], header_log[1]);
+	shell_print(sh, "   [DW2-DW3] : 0x%08X 0x%08X", header_log[2], header_log[3]);
+	shell_print(sh, "====================================================================");
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -962,6 +1089,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_aer_cmds,
+	SHELL_CMD_ARG(status, NULL, "Trace correctable and uncorrectable hardware error states",
+		      cmd_pcie_aer_status, 2, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
 		      "List PCIE devices\n"
@@ -977,6 +1110,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(link, &sub_pcie_link_cmds,
 		  "Manage PCIe hardware link performance and power metrics", NULL),
 	SHELL_CMD(irq, &sub_pcie_irq_cmds, "Trace legacy and vector interrupt message allocations",
+		  NULL),
+	SHELL_CMD(aer, &sub_pcie_aer_cmds, "Interact with PCIe Advanced Error Reporting metrics",
 		  NULL),
 	SHELL_SUBCMD_SET_END);
 

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -350,6 +350,20 @@ static bool scan_cb(pcie_bdf_t bdf, pcie_id_t id, void *cb_data)
 	return true;
 }
 
+#define MAX_MASKED_DEVICES 8U
+static pcie_bdf_t masked_bdfs[MAX_MASKED_DEVICES];
+static uint32_t masked_count;
+
+static bool is_bdf_masked(pcie_bdf_t bdf)
+{
+	for (uint32_t i = 0; i < masked_count; i++) {
+		if (masked_bdfs[i] == bdf) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static int cmd_pcie_ls(const struct shell *sh, size_t argc, char **argv)
 {
 	pcie_bdf_t bdf = PCIE_BDF_NONE;
@@ -361,6 +375,7 @@ static int cmd_pcie_ls(const struct shell *sh, size_t argc, char **argv)
 		.cb = scan_cb,
 		.cb_data = &data,
 		.flags = (PCIE_SCAN_RECURSIVE | PCIE_SCAN_CB_ALL),
+		.scan_masking_fn = is_bdf_masked,
 	};
 
 	for (int i = 1; i < argc; i++) {
@@ -450,6 +465,84 @@ static int cmd_pcie_write(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+/* Subcommand: pcie mask ignore <bus:dev.func> */
+static int cmd_pcie_mask_ignore(const struct shell *sh, size_t argc, char **argv)
+{
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie mask ignore <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	if (masked_count >= MAX_MASKED_DEVICES) {
+		shell_error(sh, "Mask table allocation full (Max %u).", MAX_MASKED_DEVICES);
+		return -ENOMEM;
+	}
+
+	pcie_bdf_t bdf = get_bdf(argv[1]);
+
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	bdf = PCIE_BDF(PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), 0);
+
+	if (is_bdf_masked(bdf)) {
+		shell_warn(sh, "Target BDF is already registered in the mask array.");
+		return 0;
+	}
+
+	masked_bdfs[masked_count++] = bdf;
+
+	shell_print(sh, "Successfully masked BDF %u:%x.%u. Bus scans will ignore this slot.",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+
+	return 0;
+}
+
+/* Subcommand: pcie mask clear */
+static int cmd_pcie_mask_clear(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	masked_count = 0;
+
+	shell_print(sh, "Software PCIe mask tracking array successfully cleared.");
+	return 0;
+}
+
+/* Subcommand: pcie mask show */
+static int cmd_pcie_mask_show(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	shell_print(sh, "--- Active PCIe Software Mask Registry Matrix ---");
+	if (masked_count == 0) {
+		shell_print(sh, " No devices currently masked.");
+		return 0;
+	}
+
+	for (uint32_t i = 0; i < masked_count; i++) {
+		pcie_bdf_t bdf = masked_bdfs[i];
+
+		shell_print(sh, " [%u] Ignored BDF Slot -> %u:%x.%u", i, PCIE_BDF_TO_BUS(bdf),
+			    PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	}
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_mask_cmds,
+	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
+		      cmd_pcie_mask_ignore, 2, 0),
+	SHELL_CMD_ARG(show, NULL, "Display all blacklisted BDF slots currently active",
+		      cmd_pcie_mask_show, 1, 0),
+	SHELL_CMD_ARG(clear, NULL, "Flush the mask configuration tracking registers",
+		      cmd_pcie_mask_clear, 1, 0),
+	SHELL_SUBCMD_SET_END);
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
@@ -460,6 +553,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "Write a 32-bit word directly to a device register.\n"
 		      "Usage: write <bus:device.function> <reg_offset> <32bit_hex>",
 		      cmd_pcie_write, 4, 0),
+	SHELL_CMD(mask, &sub_pcie_mask_cmds, "Manage PCIe device scanning parameters", NULL),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(pcie, &sub_pcie_cmds, "PCI(e) device information", cmd_pcie_ls);

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -32,6 +32,19 @@ struct pcie_cap_id_to_str {
 #define PCIE_AER_CORR_MASK_REG     (0x14U / 4U)
 #define PCIE_AER_HEADER_LOG_REG    (0x1CU / 4U)
 
+/* PCI EXPRESS RECEIVER LANE MARGINING (SERDES) SUBSYSTEM DIAGNOSTICS */
+#define PCIE_EXT_CAP_MARGIN_ID 0x001AU
+
+#define PCIE_MARGIN_PORT_CAP_REG    0x04U
+#define PCIE_MARGIN_PORT_CTL_REG    0x06U
+#define PCIE_MARGIN_LANE_STATUS_REG 0x08U
+
+#define PCIE_MARGIN_CAP_IND_PARAMS(val)      (((val) >> 0) & 0x1U)
+#define PCIE_MARGIN_CAP_NUM_LANES(val)       (((val) >> 4) & 0xFU)
+#define PCIE_MARGIN_CAP_MAX_V_STEPS(val)     (((val) >> 8) & 0x7FU)
+#define PCIE_MARGIN_CAP_MAX_T_STEPS(val)     (((val) >> 15) & 0x3FU)
+#define PCIE_MARGIN_CAP_MAX_T_STEPS_BIT(val) (((val) >> 21) & 0x1U)
+
 static const struct pcie_cap_id_to_str pcie_cap_list[] = {
 	{ PCI_CAP_ID_PM,     "Power Management" },
 	{ PCI_CAP_ID_AGP,    "Accelerated Graphics Port" },
@@ -1060,6 +1073,105 @@ static int cmd_pcie_aer_status(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static inline void log_pcie_margin_caps(const struct shell *sh, uint16_t caps, uint16_t ctls)
+{
+	uint8_t num_lanes = (uint8_t)PCIE_MARGIN_CAP_NUM_LANES(caps);
+	uint8_t max_t_steps = (PCIE_MARGIN_CAP_MAX_T_STEPS_BIT(caps) != 0U) ? 63U : 31U;
+
+	shell_print(sh, "Port Capabilities Register: 0x%04X [Control: 0x%04X]", (unsigned int)caps,
+		    (unsigned int)ctls);
+	shell_print(sh, "   -> Link Width Tracked       : x%u Physical Lanes",
+		    (num_lanes == 0U ? 1U : num_lanes));
+	shell_print(sh, "   -> Max Voltage Step Margins : %u Steps",
+		    PCIE_MARGIN_CAP_MAX_V_STEPS(caps));
+	shell_print(sh, "   -> Max Timing Step Margins  : %u Steps", max_t_steps);
+
+	if (PCIE_MARGIN_CAP_IND_PARAMS(caps) != 0U) {
+		shell_print(
+			sh,
+			"   -> Software Margining Matrix: Deployed [Independent Per-Lane Control]");
+	} else {
+		shell_print(
+			sh,
+			"   -> Software Margining Matrix: Bound [Unified Link Parameter Control]");
+	}
+}
+
+static inline void log_pcie_margin_status(const struct shell *sh, uint32_t status)
+{
+	shell_print(sh, "Receiver Physical Signal Integrity Status (Lane 0 Baseline):");
+	shell_print(sh, "   Raw Lane Status Register  : 0x%08X", status);
+
+	if ((status & (1U << 0)) != 0U) {
+		shell_print(sh, "   [ALERT] -> Hardware Margining Engine Currently Active");
+	} else {
+		shell_print(
+			sh,
+			"   -> SerDes Sample Point Architecture: Safe [Stable Locked Tracking]");
+	}
+
+	if ((status & (1U << 1)) != 0U) {
+		shell_print(sh, "   [ALERT] -> Timing/Voltage Step Limit Threshold Reached");
+	}
+}
+
+/* Subcommand: pcie link margin <bus:dev.func> */
+static int cmd_pcie_link_margin(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id;
+	uint32_t margin_offset;
+	uint32_t port_caps_ctl;
+	uint32_t lane_status;
+	uint32_t port_caps;
+	uint32_t port_ctls;
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie link margin <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	margin_offset = pcie_get_ext_cap(bdf, PCIE_EXT_CAP_ID_LMR);
+	if (margin_offset == 0) {
+		shell_error(sh, "Target device does not implement native "
+				"Lane Margining at Receiver (Cap ID 0x0027).");
+		return -EOPNOTSUPP;
+	}
+
+	port_caps_ctl = pcie_conf_read(bdf, margin_offset + 1U);
+	port_caps = port_caps_ctl;
+	port_ctls = (port_caps_ctl >> 16) & 0xFFFFU;
+
+	lane_status = pcie_conf_read(bdf, margin_offset + 2U);
+
+	shell_print(sh, "====================================================");
+	shell_print(sh, "   PCIe SerDes LANE MARGINING METRICS MATRIX: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================");
+
+	log_pcie_margin_caps(sh, port_caps, port_ctls);
+
+	shell_print(sh, "----------------------------------------------------");
+
+	log_pcie_margin_status(sh, lane_status);
+
+	shell_print(sh, "====================================================");
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -1080,6 +1192,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_link_cmds,
 	SHELL_CMD_ARG(set_speed, NULL, "Scale the target PCIe bus lane speed dynamically",
 		      cmd_pcie_link_set_speed, 3, 0),
+	SHELL_CMD_ARG(margin, NULL, "Trace SerDes physical layer receiver lane margining caps",
+		      cmd_pcie_link_margin, 2, 0),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -59,6 +59,10 @@ struct pcie_cap_id_to_str {
 #define PCI_EXP_DEVCAP2_SRIOV_MASK   0x00000010U /* Bit 4: Single Root I/O Virt */
 #define PCI_EXP_DEVCAP2_NVME_OFFLOAD 0x000000C0U /* Memory-mapped offload markers */
 
+/* MSI-X Redirection Table Definition Layouts */
+#define PCI_MSIX_TABLE_OFFSET_MASK 0xFFFFFFF8U
+#define PCI_MSIX_TABLE_BIR_MASK    0x00000007U
+
 static const struct pcie_cap_id_to_str pcie_cap_list[] = {
 	{ PCI_CAP_ID_PM,     "Power Management" },
 	{ PCI_CAP_ID_AGP,    "Accelerated Graphics Port" },
@@ -534,39 +538,6 @@ static int cmd_pcie_mask_ignore(const struct shell *sh, size_t argc, char **argv
 	shell_print(sh, "Successfully masked BDF %u:%x.%u. Bus scans will ignore this slot.",
 		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
 
-	return 0;
-}
-
-/* Subcommand: pcie mask clear */
-static int cmd_pcie_mask_clear(const struct shell *sh, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	masked_count = 0;
-	pcie_scan_override_hook = NULL;
-	shell_print(sh, "Software PCIe mask tracking array successfully cleared.");
-	return 0;
-}
-
-/* Subcommand: pcie mask show */
-static int cmd_pcie_mask_show(const struct shell *sh, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	shell_print(sh, "--- Active PCIe Software Mask Registry Matrix ---");
-	if (masked_count == 0) {
-		shell_print(sh, " No devices currently masked.");
-		return 0;
-	}
-
-	for (uint32_t i = 0; i < masked_count; i++) {
-		pcie_bdf_t bdf = masked_bdfs[i];
-
-		shell_print(sh, " [%u] Ignored BDF Slot -> %u:%x.%u", i, PCIE_BDF_TO_BUS(bdf),
-			    PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
-	}
 	return 0;
 }
 
@@ -1373,6 +1344,65 @@ static int cmd_pcie_offload_capabilities(const struct shell *sh, size_t argc, ch
 	return 0;
 }
 
+static int cmd_pcie_irq_affinity(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id, msix_offset, msg_ctrl, table_val, table_offset, table_bir;
+	uint16_t vector_count;
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie irq affinity <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	msix_offset = pcie_get_cap(bdf, PCI_CAP_ID_MSIX);
+	if (msix_offset == 0U) {
+		shell_error(sh, "Target device does not support MSI-X affinity mapping.");
+		return -EOPNOTSUPP;
+	}
+
+	msg_ctrl = pcie_conf_read(bdf, msix_offset) >> 16;
+	vector_count = (uint16_t)((msg_ctrl & 0x07FFU) + 1U);
+
+	table_val = pcie_conf_read(bdf, msix_offset + 1U);
+	table_offset = table_val & PCI_MSIX_TABLE_OFFSET_MASK;
+	table_bir = table_val & PCI_MSIX_TABLE_BIR_MASK;
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCIe MULTI-VECTOR REDIRECTION TABLE AFFINITY MATRIX: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   Hardware Redirection Profile:");
+	shell_print(sh, "      MSI-X Execution Status : [%s]",
+		    (msg_ctrl & (1U << 15)) ? "ENABLED / ROUTING ACTIVE" : "MASKED / SUSPENDED");
+	shell_print(sh, "      MSI-X Table Size       : %u vectors", (unsigned int)vector_count);
+	shell_print(sh, "   ----------------------------------------------------");
+	shell_print(sh,
+		    "   Physical Core Steering Line Memory Map (BAR %u Offset 0x%08X):", table_bir,
+		    table_offset);
+
+	if ((msg_ctrl & (1U << 15)) != 0U) {
+		shell_print(sh, "      -> [STATUS] MSI-X is active.");
+	} else {
+		shell_print(sh, "      -> [STATUS] MSI-X is inactive. All rings routing through "
+				"Legacy IRQ line.");
+	}
+	shell_print(sh, "====================================================================");
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -1403,6 +1433,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_irq_cmds,
 	SHELL_CMD_ARG(status, NULL, "Trace legacy and MSI/MSI-X vector configuration statuses",
 		      cmd_pcie_irq_status, 2, 0),
+	SHELL_CMD_ARG(affinity, NULL, "Inspect PCIe interrupt affinity steering parameters",
+		      cmd_pcie_irq_affinity, 2, 0),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -54,6 +54,11 @@ struct pcie_cap_id_to_str {
 #define PCI_PM_STATE_D0        0x00U
 #define PCI_PM_STATE_D3HOT     0x03U
 
+/* Device Capabilities 2 Register Decoding Masks */
+#define PCI_EXP_DEVCAP2_ARI_MASK     0x00000020U /* Bit 5: Alternative Routing-ID */
+#define PCI_EXP_DEVCAP2_SRIOV_MASK   0x00000010U /* Bit 4: Single Root I/O Virt */
+#define PCI_EXP_DEVCAP2_NVME_OFFLOAD 0x000000C0U /* Memory-mapped offload markers */
+
 static const struct pcie_cap_id_to_str pcie_cap_list[] = {
 	{ PCI_CAP_ID_PM,     "Power Management" },
 	{ PCI_CAP_ID_AGP,    "Accelerated Graphics Port" },
@@ -1321,6 +1326,53 @@ static int cmd_pcie_link_speed(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static int cmd_pcie_offload_capabilities(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id, exp_offset, devcap2;
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie offload <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	exp_offset = pcie_get_cap(bdf, PCI_CAP_ID_EXP);
+	if (exp_offset == 0U) {
+		shell_error(sh, "Target device does not support native PCIe Capabilities.");
+		return -EOPNOTSUPP;
+	}
+
+	devcap2 = pcie_conf_read(bdf, exp_offset + 9U);
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   SILICON HARDWARE TRANSPORT OVERLAY DECODER MATRIX: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   Raw DEVCAP2 Value: 0x%08X", devcap2);
+	shell_print(sh, "   ----------------------------------------------------");
+	shell_print(sh, "   Supported Physical Transaction Offloads:");
+	shell_print(sh, "      Alternative Routing-ID (ARI) : [%s]",
+		    (devcap2 & PCI_EXP_DEVCAP2_ARI_MASK) ? "SUPPORTED" : "UNAVAILABLE");
+	shell_print(sh, "      Single-Root I/O Virt (SR-IOV): [%s]",
+		    (devcap2 & PCI_EXP_DEVCAP2_SRIOV_MASK) ? "SUPPORTED" : "UNAVAILABLE");
+	shell_print(sh, "      NVMe MMIO Transport Offloads : [%s]",
+		    (devcap2 & PCI_EXP_DEVCAP2_NVME_OFFLOAD) ? "DEPLOYED" : "UNAVAILABLE");
+	shell_print(sh, "====================================================================");
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -1386,6 +1438,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		  NULL),
 	SHELL_CMD(device, &sub_pcie_device_cmds, "Manage pcie physical hardware device states",
 		  NULL),
+	SHELL_CMD_ARG(offload, NULL,
+		      "Probe dynamic vector routing capabilities\n"
+		      "Usage: offload <bus:device.function>",
+		      cmd_pcie_offload_capabilities, 2, 0),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(pcie, &sub_pcie_cmds, "PCI(e) device information", cmd_pcie_ls);

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -479,12 +479,6 @@ static int cmd_pcie_mask_ignore(const struct shell *sh, size_t argc, char **argv
 	}
 
 	pcie_bdf_t bdf = get_bdf(argv[1]);
-
-	if (bdf == PCIE_BDF_NONE) {
-		shell_error(sh, "Invalid BDF layout format specification.");
-		return -EINVAL;
-	}
-
 	bdf = PCIE_BDF(PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), 0);
 
 	if (is_bdf_masked(bdf)) {
@@ -496,6 +490,152 @@ static int cmd_pcie_mask_ignore(const struct shell *sh, size_t argc, char **argv
 
 	shell_print(sh, "Successfully masked BDF %u:%x.%u. Bus scans will ignore this slot.",
 		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+
+	return 0;
+}
+
+static uint64_t probe_bar_size_mask(pcie_bdf_t bdf, unsigned int reg, unsigned int bar_idx,
+				    bool is_64bit, uint32_t raw_bar)
+{
+	uint32_t cmd_backup = pcie_conf_read(bdf, PCIE_CONF_CMDSTAT);
+	uint32_t size_mask_lo;
+	uint64_t mask;
+
+	pcie_conf_write(bdf, PCIE_CONF_CMDSTAT,
+			cmd_backup & (~(PCIE_CONF_CMDSTAT_IO | PCIE_CONF_CMDSTAT_MEM)));
+
+	pcie_conf_write(bdf, reg, 0xFFFFFFFFU);
+	size_mask_lo = pcie_conf_read(bdf, reg);
+	pcie_conf_write(bdf, reg, raw_bar);
+
+	if (is_64bit && bar_idx < 5) {
+		uint32_t raw_bar_hi = pcie_conf_read(bdf, reg + 1);
+		uint32_t size_mask_hi;
+
+		pcie_conf_write(bdf, reg + 1, 0xFFFFFFFFU);
+		size_mask_hi = pcie_conf_read(bdf, reg + 1);
+		pcie_conf_write(bdf, reg + 1, raw_bar_hi);
+
+		mask = ((uint64_t)size_mask_hi << 32) | (uint64_t)size_mask_lo;
+	} else {
+		mask = (uint64_t)(uint32_t)size_mask_lo;
+	}
+
+	pcie_conf_write(bdf, PCIE_CONF_CMDSTAT, cmd_backup);
+	return mask;
+}
+
+static void show_mem_bar_info(const struct shell *sh, pcie_bdf_t bdf, unsigned int reg,
+			      unsigned int *bar_idx, uint64_t size_mask64, uint32_t raw_bar,
+			      bool is_64bit)
+{
+	uint64_t mem_size;
+	uint64_t base_addr = (uint64_t)(raw_bar & 0xFFFFFFF0U);
+	bool prefetch = ((raw_bar & 0x8U) != 0);
+
+	if (is_64bit && *bar_idx < 5) {
+		mem_size = ~(size_mask64 & 0xFFFFFFFFFFFFFFF0U) + 1ULL;
+	} else {
+		mem_size = (~(size_mask64 & 0xFFFFFFF0U) + 1ULL) & 0xFFFFFFFFULL;
+	}
+
+	shell_print(sh, "   -> Type       : MEMORY Space (%s)",
+		    is_64bit ? "64-bit Aperture" : "32-bit Aperture");
+	shell_print(sh, "   -> Attributes : Prefetchable: %s", prefetch ? "TRUE" : "FALSE");
+	shell_print(sh, "   -> Sizing     : Requested Size: %llu KB (Mask: 0x%016llX)",
+		    (unsigned long long)(mem_size / 1024U), (unsigned long long)size_mask64);
+
+	if (is_64bit && *bar_idx < 5) {
+		uint32_t raw_bar_hi = pcie_conf_read(bdf, reg + 1);
+		uint64_t base_addr64 = ((uint64_t)raw_bar_hi << 32) | base_addr;
+		uint64_t end_addr64 = base_addr64 + (mem_size - 1ULL);
+
+		shell_print(sh, "   -> Map Window : 0x%016llX - 0x%016llX",
+			    (unsigned long long)base_addr64, (unsigned long long)end_addr64);
+		*bar_idx += 2;
+	} else {
+		uint64_t end_addr32 = (base_addr + (mem_size - 1ULL)) & 0xFFFFFFFFULL;
+
+		shell_print(sh, "   -> Map Window : 0x%016llX - 0x%016llX",
+			    (unsigned long long)base_addr, (unsigned long long)end_addr32);
+		*bar_idx += 1;
+	}
+}
+
+static void show_io_bar_info(const struct shell *sh, uint64_t size_mask64, uint32_t raw_bar,
+			     unsigned int *bar_idx)
+{
+	uint32_t io_size = ~((uint32_t)size_mask64 & 0xFFFFFFFCU) + 1;
+	uint32_t base_io = raw_bar & 0xFFFFFFFCU;
+
+	shell_print(sh, "   -> Type       : I/O Space");
+	shell_print(sh, "   -> Sizing     : Requested Size: %u Bytes (Mask: 0x%016llX)", io_size,
+		    (unsigned long long)size_mask64);
+	shell_print(sh, "   -> Map Window : Port Range: 0x%08X - 0x%08X", base_io,
+		    base_io + (io_size - 1U));
+	*bar_idx += 1;
+}
+
+static int cmd_pcie_resource_show(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id;
+	unsigned int bar_idx;
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie resource show <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCIe BAR RESOURCE DECODER DIAGNOSTIC GRID: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+
+	bar_idx = 0;
+	while (bar_idx < 6) {
+		unsigned int reg = PCIE_CONF_BAR0 + bar_idx;
+		uint32_t raw_bar = pcie_conf_read(bdf, reg);
+		uint64_t size_mask64;
+		bool is_mem;
+		bool is_64bit;
+
+		if (PCIE_CONF_BAR_INVAL_FLAGS(raw_bar)) {
+			bar_idx++;
+			continue;
+		}
+
+		is_mem = ((raw_bar & 0x1U) == 0);
+		is_64bit = (is_mem && ((raw_bar & 0x6U) == 0x4U));
+
+		size_mask64 = probe_bar_size_mask(bdf, reg, bar_idx, is_64bit, raw_bar);
+
+		if (size_mask64 == 0 || size_mask64 == 0xFFFFFFFFFFFFFFFFU ||
+		    (is_64bit && size_mask64 == 0xFFFFFFFF00000000U)) {
+			bar_idx += (is_64bit && bar_idx < 5) ? 2 : 1;
+			continue;
+		}
+
+		shell_print(sh, "BAR %u [Reg Offset: 0x%02X]:", bar_idx, reg * 4);
+
+		if (is_mem) {
+			show_mem_bar_info(sh, bdf, reg, &bar_idx, size_mask64, raw_bar, is_64bit);
+		} else {
+			show_io_bar_info(sh, size_mask64, raw_bar, &bar_idx);
+		}
+		shell_print(sh, "----------------------------------------------------");
+	}
 
 	return 0;
 }
@@ -530,6 +670,7 @@ static int cmd_pcie_mask_show(const struct shell *sh, size_t argc, char **argv)
 		shell_print(sh, " [%u] Ignored BDF Slot -> %u:%x.%u", i, PCIE_BDF_TO_BUS(bdf),
 			    PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
 	}
+
 	return 0;
 }
 
@@ -544,6 +685,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_resource_cmds,
+	SHELL_CMD_ARG(show, NULL, "Decode and map all active Base Address Registers (BARs)",
+		      cmd_pcie_resource_show, 2, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
 		      "List PCIE devices\n"
@@ -554,6 +701,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "Usage: write <bus:device.function> <reg_offset> <32bit_hex>",
 		      cmd_pcie_write, 4, 0),
 	SHELL_CMD(mask, &sub_pcie_mask_cmds, "Manage PCIe device scanning parameters", NULL),
+	SHELL_CMD(resource, &sub_pcie_resource_cmds, "PCI(e) memory mapping and resource metrics",
+		  NULL),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(pcie, &sub_pcie_cmds, "PCI(e) device information", cmd_pcie_ls);

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -391,12 +391,75 @@ static int cmd_pcie_ls(const struct shell *sh, size_t argc, char **argv)
 
 	return 0;
 }
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_pcie_cmds,
+
+/* Interactive PCIe Configuration Space Write Utility */
+static int cmd_pcie_write(const struct shell *sh, size_t argc, char **argv)
+{
+	if (argc < 4) {
+		shell_error(sh, "Usage: pcie write <bus:dev.func> "
+				"<register_word_offset> <32bit_hex_data>");
+		return -EINVAL;
+	}
+
+	pcie_bdf_t bdf = get_bdf(argv[1]);
+
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	int err = 0;
+	unsigned int reg = (unsigned int)shell_strtoul(argv[2], 0, &err);
+
+	if (err != 0) {
+		shell_error(sh, "Invalid argument: %s", argv[2]);
+		return err;
+	}
+
+	if (reg >= (4096U / sizeof(uint32_t))) {
+		shell_error(sh, "Register word offset out of range: %u", reg);
+		return -EINVAL;
+	}
+
+	uint32_t data = (uint32_t)shell_strtoul(argv[3], 0, &err);
+
+	if (err != 0) {
+		shell_error(sh, "Invalid argument: %s", argv[3]);
+		return err;
+	}
+
+	uint32_t id = pcie_conf_read(bdf, PCIE_CONF_ID);
+
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	uint32_t current_val = pcie_conf_read(bdf, reg);
+
+	shell_print(sh, "Writing 0x%08x to %u:%x.%u reg %u (prev: 0x%08x)...", data,
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf), reg,
+		    current_val);
+
+	pcie_conf_write(bdf, reg, data);
+
+	uint32_t read_back = pcie_conf_read(bdf, reg);
+
+	shell_print(sh, "Read-back Verification Value: 0x%08X", read_back);
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
 		      "List PCIE devices\n"
 		      "Usage: ls [bus:device:function] [dump]",
 		      cmd_pcie_ls, 1, 2),
-	SHELL_SUBCMD_SET_END /* Array terminated. */
-);
+	SHELL_CMD_ARG(write, NULL,
+		      "Write a 32-bit word directly to a device register.\n"
+		      "Usage: write <bus:device.function> <reg_offset> <32bit_hex>",
+		      cmd_pcie_write, 4, 0),
+	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(pcie, &sub_pcie_cmds, "PCI(e) device information", cmd_pcie_ls);

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -350,6 +350,20 @@ static bool scan_cb(pcie_bdf_t bdf, pcie_id_t id, void *cb_data)
 	return true;
 }
 
+#define MAX_MASKED_DEVICES 8U
+static pcie_bdf_t masked_bdfs[MAX_MASKED_DEVICES];
+static uint32_t masked_count;
+
+static bool is_bdf_masked(pcie_bdf_t bdf)
+{
+	for (uint32_t i = 0; i < masked_count; i++) {
+		if (masked_bdfs[i] == bdf) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static int cmd_pcie_ls(const struct shell *sh, size_t argc, char **argv)
 {
 	pcie_bdf_t bdf = PCIE_BDF_NONE;
@@ -361,6 +375,7 @@ static int cmd_pcie_ls(const struct shell *sh, size_t argc, char **argv)
 		.cb = scan_cb,
 		.cb_data = &data,
 		.flags = (PCIE_SCAN_RECURSIVE | PCIE_SCAN_CB_ALL),
+		.scan_masking_fn = is_bdf_masked,
 	};
 
 	for (int i = 1; i < argc; i++) {
@@ -458,7 +473,86 @@ static int cmd_pcie_write(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_pcie_cmds,
+/* Subcommand: pcie mask ignore <bus:dev.func> */
+static int cmd_pcie_mask_ignore(const struct shell *sh, size_t argc, char **argv)
+{
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie mask ignore <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	if (masked_count >= MAX_MASKED_DEVICES) {
+		shell_error(sh, "Mask table allocation full (Max %u).", MAX_MASKED_DEVICES);
+		return -ENOMEM;
+	}
+
+	pcie_bdf_t bdf = get_bdf(argv[1]);
+
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	bdf = PCIE_BDF(PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+
+	if (is_bdf_masked(bdf)) {
+		shell_warn(sh, "Target BDF is already registered in the mask array.");
+		return 0;
+	}
+
+	masked_bdfs[masked_count++] = bdf;
+
+	shell_print(sh, "Successfully masked BDF %u:%x.%u. Bus scans will ignore this slot.",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+
+	return 0;
+}
+
+/* Subcommand: pcie mask clear */
+static int cmd_pcie_mask_clear(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	masked_count = 0;
+
+	shell_print(sh, "Software PCIe mask tracking array successfully cleared.");
+	return 0;
+}
+
+/* Subcommand: pcie mask show */
+static int cmd_pcie_mask_show(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	shell_print(sh, "--- Active PCIe Software Mask Registry Matrix ---");
+	if (masked_count == 0) {
+		shell_print(sh, " No devices currently masked.");
+		return 0;
+	}
+
+	for (uint32_t i = 0; i < masked_count; i++) {
+		pcie_bdf_t bdf = masked_bdfs[i];
+
+		shell_print(sh, " [%u] Ignored BDF Slot -> %u:%x.%u", i, PCIE_BDF_TO_BUS(bdf),
+			    PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	}
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_mask_cmds,
+	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
+		      cmd_pcie_mask_ignore, 2, 0),
+	SHELL_CMD_ARG(show, NULL, "Display all blacklisted BDF slots currently active",
+		      cmd_pcie_mask_show, 1, 0),
+	SHELL_CMD_ARG(clear, NULL, "Flush the mask configuration tracking registers",
+		      cmd_pcie_mask_clear, 1, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
 		      "List PCIE devices\n"
 		      "Usage: ls [bus:device:function] [dump]",
@@ -467,6 +561,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_pcie_cmds,
 		      "Write a 32-bit word directly to a device register.\n"
 		      "Usage: write <bus:device.function> <reg_offset> <32bit_hex>",
 		      cmd_pcie_write, 4, 0),
+	SHELL_CMD(mask, &sub_pcie_mask_cmds, "Manage PCIe device scanning parameters", NULL),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -22,6 +22,16 @@ struct pcie_cap_id_to_str {
 	char *str;
 };
 
+/* PCI Express Extended Capability Constants */
+#define PCIE_EXT_CAP_AER_ID 0x0001U
+
+/* AER Register Offsets (Relative to the AER Capability Base Offset) */
+#define PCIE_AER_UNCORR_STATUS_REG (0x04U / 4U)
+#define PCIE_AER_UNCORR_MASK_REG   (0x08U / 4U)
+#define PCIE_AER_CORR_STATUS_REG   (0x10U / 4U)
+#define PCIE_AER_CORR_MASK_REG     (0x14U / 4U)
+#define PCIE_AER_HEADER_LOG_REG    (0x1CU / 4U)
+
 static const struct pcie_cap_id_to_str pcie_cap_list[] = {
 	{ PCI_CAP_ID_PM,     "Power Management" },
 	{ PCI_CAP_ID_AGP,    "Accelerated Graphics Port" },
@@ -916,6 +926,123 @@ static int cmd_pcie_irq_status(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static inline void log_pcie_aer_uncorr(const struct shell *sh, uint32_t status)
+{
+	if (status == 0U) {
+		shell_print(sh, "   -> No uncorrectable fatal hardware fractures logged.");
+		return;
+	}
+
+	if ((status & (1U << 0)) != 0U) {
+		shell_print(sh, "   [CRITICAL] -> Link Training Error (LTSSM Failure)");
+	}
+	if ((status & (1U << 4)) != 0U) {
+		shell_print(sh, "   [CRITICAL] -> Data Link Protocol Error Detected");
+	}
+	if ((status & (1U << 12)) != 0U) {
+		shell_print(sh, "   [CRITICAL] -> Poisoned TLP Execution Blocked");
+	}
+	if ((status & (1U << 13)) != 0U) {
+		shell_print(sh, "   [CRITICAL] -> Flow Control Protocol Error (FCPE)");
+	}
+	if ((status & (1U << 16)) != 0U) {
+		shell_print(sh, "   [CRITICAL] -> Unexpected Completion Trap");
+	}
+	if ((status & (1U << 20)) != 0U) {
+		shell_print(sh, "   [CRITICAL] -> Unsupported Request (UR) Abort");
+	}
+}
+
+static inline void log_pcie_aer_corr(const struct shell *sh, uint32_t status)
+{
+	if (status == 0U) {
+		shell_print(sh, "   -> No physical signal degradation deviations reported.");
+		return;
+	}
+
+	if ((status & (1U << 0)) != 0U) {
+		shell_print(sh, "   [WARNING]  -> Receiver Physical Layer Error");
+	}
+	if ((status & (1U << 6)) != 0U) {
+		shell_print(sh, "   [WARNING]  -> Bad TLP Frame CRC Detected");
+	}
+	if ((status & (1U << 7)) != 0U) {
+		shell_print(sh, "   [WARNING]  -> Bad DLLP Frame Checksum Detected");
+	}
+	if ((status & (1U << 8)) != 0U) {
+		shell_print(sh, "   [WARNING]  -> REPLAY_NUM Rollover/Timer Timeout");
+	}
+}
+
+/* Subcommand: pcie aer status <bus:dev.func> */
+static int cmd_pcie_aer_status(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id;
+	uint32_t aer_offset;
+	uint32_t uncorr_status;
+	uint32_t uncorr_mask;
+	uint32_t corr_status;
+	uint32_t corr_mask;
+	uint32_t header_log[4];
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie aer status <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	aer_offset = pcie_get_ext_cap(bdf, PCIE_EXT_CAP_AER_ID);
+	if (aer_offset == 0) {
+		shell_error(sh, "Target device does not support native "
+				"Advanced Error Reporting (AER).");
+		return -EOPNOTSUPP;
+	}
+
+	uncorr_status = pcie_conf_read(bdf, aer_offset + PCIE_AER_UNCORR_STATUS_REG);
+	uncorr_mask = pcie_conf_read(bdf, aer_offset + PCIE_AER_UNCORR_MASK_REG);
+	corr_status = pcie_conf_read(bdf, aer_offset + PCIE_AER_CORR_STATUS_REG);
+	corr_mask = pcie_conf_read(bdf, aer_offset + PCIE_AER_CORR_MASK_REG);
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCIe ADVANCED ERROR REPORTING (AER) STATUS MATRIX: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+
+	shell_print(sh, "Uncorrectable Errors Status: 0x%08X [Mask: 0x%08X]", uncorr_status,
+		    uncorr_mask);
+	log_pcie_aer_uncorr(sh, uncorr_status);
+
+	shell_print(sh, "----------------------------------------------------");
+
+	shell_print(sh, "Correctable Errors Status:   0x%08X [Mask: 0x%08X]", corr_status,
+		    corr_mask);
+	log_pcie_aer_corr(sh, corr_status);
+
+	shell_print(sh, "----------------------------------------------------");
+
+	shell_print(sh, "Transaction Layer Packet (TLP) Header Log Matrix:");
+	for (uint32_t i = 0U; i < 4U; i++) {
+		header_log[i] = pcie_conf_read(bdf, aer_offset + PCIE_AER_HEADER_LOG_REG + i);
+	}
+	shell_print(sh, "   [DW0-DW1] : 0x%08X 0x%08X", header_log[0], header_log[1]);
+	shell_print(sh, "   [DW2-DW3] : 0x%08X 0x%08X", header_log[2], header_log[3]);
+	shell_print(sh, "====================================================================");
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -945,6 +1072,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_aer_cmds,
+	SHELL_CMD_ARG(status, NULL, "Trace correctable and uncorrectable hardware error states",
+		      cmd_pcie_aer_status, 2, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
 		      "List PCIE devices\n"
@@ -960,6 +1093,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(link, &sub_pcie_link_cmds,
 		  "Manage PCIe hardware link performance and power metrics", NULL),
 	SHELL_CMD(irq, &sub_pcie_irq_cmds, "Trace legacy and vector interrupt message allocations",
+		  NULL),
+	SHELL_CMD(aer, &sub_pcie_aer_cmds, "Interact with PCIe Advanced Error Reporting metrics",
 		  NULL),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -32,6 +32,19 @@ struct pcie_cap_id_to_str {
 #define PCIE_AER_CORR_MASK_REG     (0x14U / 4U)
 #define PCIE_AER_HEADER_LOG_REG    (0x1CU / 4U)
 
+/* PCI EXPRESS RECEIVER LANE MARGINING (SERDES) SUBSYSTEM DIAGNOSTICS */
+#define PCIE_EXT_CAP_MARGIN_ID 0x001AU
+
+#define PCIE_MARGIN_PORT_CAP_REG    0x04U
+#define PCIE_MARGIN_PORT_CTL_REG    0x06U
+#define PCIE_MARGIN_LANE_STATUS_REG 0x08U
+
+#define PCIE_MARGIN_CAP_IND_PARAMS(val)      (((val) >> 0) & 0x1U)
+#define PCIE_MARGIN_CAP_NUM_LANES(val)       (((val) >> 4) & 0xFU)
+#define PCIE_MARGIN_CAP_MAX_V_STEPS(val)     (((val) >> 8) & 0x7FU)
+#define PCIE_MARGIN_CAP_MAX_T_STEPS(val)     (((val) >> 15) & 0x3FU)
+#define PCIE_MARGIN_CAP_MAX_T_STEPS_BIT(val) (((val) >> 21) & 0x1U)
+
 static const struct pcie_cap_id_to_str pcie_cap_list[] = {
 	{ PCI_CAP_ID_PM,     "Power Management" },
 	{ PCI_CAP_ID_AGP,    "Accelerated Graphics Port" },
@@ -1043,6 +1056,105 @@ static int cmd_pcie_aer_status(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static inline void log_pcie_margin_caps(const struct shell *sh, uint16_t caps, uint16_t ctls)
+{
+	uint8_t num_lanes = (uint8_t)PCIE_MARGIN_CAP_NUM_LANES(caps);
+	uint8_t max_t_steps = (PCIE_MARGIN_CAP_MAX_T_STEPS_BIT(caps) != 0U) ? 63U : 31U;
+
+	shell_print(sh, "Port Capabilities Register: 0x%04X [Control: 0x%04X]", (unsigned int)caps,
+		    (unsigned int)ctls);
+	shell_print(sh, "   -> Link Width Tracked       : x%u Physical Lanes",
+		    (num_lanes == 0U ? 1U : num_lanes));
+	shell_print(sh, "   -> Max Voltage Step Margins : %u Steps",
+		    PCIE_MARGIN_CAP_MAX_V_STEPS(caps));
+	shell_print(sh, "   -> Max Timing Step Margins  : %u Steps", max_t_steps);
+
+	if (PCIE_MARGIN_CAP_IND_PARAMS(caps) != 0U) {
+		shell_print(
+			sh,
+			"   -> Software Margining Matrix: Deployed [Independent Per-Lane Control]");
+	} else {
+		shell_print(
+			sh,
+			"   -> Software Margining Matrix: Bound [Unified Link Parameter Control]");
+	}
+}
+
+static inline void log_pcie_margin_status(const struct shell *sh, uint32_t status)
+{
+	shell_print(sh, "Receiver Physical Signal Integrity Status (Lane 0 Baseline):");
+	shell_print(sh, "   Raw Lane Status Register  : 0x%08X", status);
+
+	if ((status & (1U << 0)) != 0U) {
+		shell_print(sh, "   [ALERT] -> Hardware Margining Engine Currently Active");
+	} else {
+		shell_print(
+			sh,
+			"   -> SerDes Sample Point Architecture: Safe [Stable Locked Tracking]");
+	}
+
+	if ((status & (1U << 1)) != 0U) {
+		shell_print(sh, "   [ALERT] -> Timing/Voltage Step Limit Threshold Reached");
+	}
+}
+
+/* Subcommand: pcie link margin <bus:dev.func> */
+static int cmd_pcie_link_margin(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id;
+	uint32_t margin_offset;
+	uint32_t port_caps_ctl;
+	uint32_t lane_status;
+	uint32_t port_caps;
+	uint32_t port_ctls;
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie link margin <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	margin_offset = pcie_get_ext_cap(bdf, PCIE_EXT_CAP_ID_LMR);
+	if (margin_offset == 0) {
+		shell_error(sh, "Target device does not implement native "
+				"Lane Margining at Receiver (Cap ID 0x0027).");
+		return -EOPNOTSUPP;
+	}
+
+	port_caps_ctl = pcie_conf_read(bdf, margin_offset + 1U);
+	port_caps = port_caps_ctl;
+	port_ctls = (port_caps_ctl >> 16) & 0xFFFFU;
+
+	lane_status = pcie_conf_read(bdf, margin_offset + 2U);
+
+	shell_print(sh, "====================================================");
+	shell_print(sh, "   PCIe SerDes LANE MARGINING METRICS MATRIX: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================");
+
+	log_pcie_margin_caps(sh, port_caps, port_ctls);
+
+	shell_print(sh, "----------------------------------------------------");
+
+	log_pcie_margin_status(sh, lane_status);
+
+	shell_print(sh, "====================================================");
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -1063,6 +1175,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_link_cmds,
 	SHELL_CMD_ARG(set_speed, NULL, "Scale the target PCIe bus lane speed dynamically",
 		      cmd_pcie_link_set_speed, 3, 0),
+	SHELL_CMD_ARG(margin, NULL, "Trace SerDes physical layer receiver lane margining caps",
+		      cmd_pcie_link_margin, 2, 0),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -391,11 +391,82 @@ static int cmd_pcie_ls(const struct shell *sh, size_t argc, char **argv)
 
 	return 0;
 }
+
+/* Interactive PCIe Configuration Space Write Utility */
+static int cmd_pcie_write(const struct shell *sh, size_t argc, char **argv)
+{
+	if (argc < 4) {
+		shell_error(sh, "Usage: pcie write <bus:dev.func> "
+				"<register_word_offset> <32bit_hex_data>");
+		return -EINVAL;
+	}
+
+	pcie_bdf_t bdf = get_bdf(argv[1]);
+
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	int err = 0;
+	unsigned long reg_arg = shell_strtoul(argv[2], 0, &err);
+
+	if (err != 0) {
+		shell_error(sh, "Invalid argument: %s", argv[2]);
+		return err;
+	}
+
+	if (reg_arg >= (4096U / sizeof(uint32_t))) {
+		shell_error(sh, "Register word offset out of range: %lu", reg_arg);
+		return -EINVAL;
+	}
+
+	unsigned int reg = (unsigned int)reg_arg;
+
+	unsigned long data_arg = shell_strtoul(argv[3], 0, &err);
+
+	if (err != 0) {
+		shell_error(sh, "Invalid argument: %s", argv[3]);
+		return err;
+	}
+
+	if (data_arg > UINT32_MAX) {
+		shell_error(sh, "32-bit data out of range: %s", argv[3]);
+		return -ERANGE;
+	}
+	uint32_t data = (uint32_t)data_arg;
+
+	uint32_t id = pcie_conf_read(bdf, PCIE_CONF_ID);
+
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	uint32_t current_val = pcie_conf_read(bdf, reg);
+
+	shell_print(sh, "Writing 0x%08x to %u:%x.%u reg %u (prev: 0x%08x)...", data,
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf), reg,
+		    current_val);
+
+	pcie_conf_write(bdf, reg, data);
+
+	uint32_t read_back = pcie_conf_read(bdf, reg);
+
+	shell_print(sh, "Read-back Verification Value: 0x%08X", read_back);
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
 		      "List PCIE devices\n"
 		      "Usage: ls [bus:device:function] [dump]",
 		      cmd_pcie_ls, 1, 2),
+	SHELL_CMD_ARG(write, NULL,
+		      "Write a 32-bit word directly to a device register.\n"
+		      "Usage: write <bus:device.function> <reg_offset> <32bit_hex>",
+		      cmd_pcie_write, 4, 0),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -1226,6 +1226,84 @@ static int cmd_pcie_device_state(const struct shell *sh, size_t argc, char **arg
 	return 0;
 }
 
+/* Subcommand: pcie link speed <bus:dev.func> */
+static int cmd_pcie_link_speed(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id;
+	uint32_t exp_offset;
+	uint32_t lnkcap_val;
+	uint32_t lnksta_val;
+	uint8_t raw_max_width;
+	uint8_t raw_curr_width;
+	uint8_t max_speed, curr_speed;
+	uint8_t max_width, curr_width;
+
+	/* Shell parsing gate checked */
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie link speed <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	exp_offset = pcie_get_cap(bdf, PCI_CAP_ID_EXP);
+	if (exp_offset == 0) {
+		shell_error(sh, "Target device does not support native PCIe Capabilities.");
+		return -EOPNOTSUPP;
+	}
+
+	lnkcap_val = pcie_conf_read(bdf, exp_offset + 3U);
+	max_speed = (uint8_t)(lnkcap_val & 0x0FU);
+
+	raw_max_width = (uint8_t)((lnkcap_val >> 4) & 0x3FU);
+	max_width = (raw_max_width != 0U) ? raw_max_width : 1U;
+
+	lnksta_val = pcie_conf_read(bdf, exp_offset + 4U) >> 16;
+	curr_speed = (uint8_t)(lnksta_val & 0x0FU);
+
+	raw_curr_width = (uint8_t)((lnksta_val >> 4) & 0x3FU);
+	curr_width = (raw_curr_width != 0U) ? raw_curr_width : 1U;
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCIe HARDWARE LINK BANDWIDTH CAPABILITY TRACKER: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   Silicon Design Limits (Maximum Capabilities):");
+	shell_print(sh, "      Max Link Speed : PCIe Gen %u", (unsigned int)max_speed);
+	shell_print(sh, "      Max Link Width : x%u Lanes", (unsigned int)max_width);
+	shell_print(sh, "   ----------------------------------------------------");
+	shell_print(sh, "   Real-Time Operational Link Status:");
+	shell_print(sh, "      Current Speed  : PCIe Gen %u",
+		    curr_speed == 0U ? max_speed : curr_speed);
+	shell_print(sh, "      Current Width  : x%u Lanes",
+		    (unsigned int)(curr_width == 0U ? max_width : curr_width));
+	shell_print(sh, "   ----------------------------------------------------");
+
+	if ((curr_speed < max_speed && curr_speed != 0U) ||
+	    (curr_width < max_width && curr_width != 0U)) {
+		shell_print(sh, "   [CRITICAL] -> Link Bandwidth Degradation Detected!");
+		shell_print(sh, "                 Hardware has autonomously downgraded its lane "
+				"configurations.");
+	} else {
+		shell_print(
+			sh,
+			"   -> Link Negotiation Status: Healthy [Maximum Bus Throughput Achieved]");
+	}
+	shell_print(sh, "====================================================================");
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -1248,6 +1326,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      cmd_pcie_link_set_speed, 3, 0),
 	SHELL_CMD_ARG(margin, NULL, "Trace SerDes physical layer receiver lane margining caps",
 		      cmd_pcie_link_margin, 2, 0),
+	SHELL_CMD_ARG(speed, NULL, "Trace link capabilities and real-time speed negotiation status",
+		      cmd_pcie_link_speed, 2, 0),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -59,6 +59,10 @@ struct pcie_cap_id_to_str {
 #define PCI_EXP_DEVCAP2_SRIOV_MASK   0x00000010U /* Bit 4: Single Root I/O Virt */
 #define PCI_EXP_DEVCAP2_NVME_OFFLOAD 0x000000C0U /* Memory-mapped offload markers */
 
+/* MSI-X Redirection Table Definition Layouts */
+#define PCI_MSIX_TABLE_OFFSET_MASK 0xFFFFFFF8U
+#define PCI_MSIX_TABLE_BIR_MASK    0x00000007U
+
 static const struct pcie_cap_id_to_str pcie_cap_list[] = {
 	{ PCI_CAP_ID_PM,     "Power Management" },
 	{ PCI_CAP_ID_AGP,    "Accelerated Graphics Port" },
@@ -1357,6 +1361,65 @@ static int cmd_pcie_offload_capabilities(const struct shell *sh, size_t argc, ch
 	return 0;
 }
 
+static int cmd_pcie_irq_affinity(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id, msix_offset, msg_ctrl, table_val, table_offset, table_bir;
+	uint16_t vector_count;
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie irq affinity <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	msix_offset = pcie_get_cap(bdf, PCI_CAP_ID_MSIX);
+	if (msix_offset == 0U) {
+		shell_error(sh, "Target device does not support MSI-X affinity mapping.");
+		return -EOPNOTSUPP;
+	}
+
+	msg_ctrl = pcie_conf_read(bdf, msix_offset) >> 16;
+	vector_count = (uint16_t)((msg_ctrl & 0x07FFU) + 1U);
+
+	table_val = pcie_conf_read(bdf, msix_offset + 1U);
+	table_offset = table_val & PCI_MSIX_TABLE_OFFSET_MASK;
+	table_bir = table_val & PCI_MSIX_TABLE_BIR_MASK;
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCIe MULTI-VECTOR REDIRECTION TABLE AFFINITY MATRIX: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   Hardware Redirection Profile:");
+	shell_print(sh, "      MSI-X Execution Status : [%s]",
+		    (msg_ctrl & (1U << 15)) ? "ENABLED / ROUTING ACTIVE" : "MASKED / SUSPENDED");
+	shell_print(sh, "      MSI-X Table Size       : %u vectors", (unsigned int)vector_count);
+	shell_print(sh, "   ----------------------------------------------------");
+	shell_print(sh,
+		    "   Physical Core Steering Line Memory Map (BAR %u Offset 0x%08X):", table_bir,
+		    table_offset);
+
+	if ((msg_ctrl & (1U << 15)) != 0U) {
+		shell_print(sh, "      -> [STATUS] MSI-X is active.");
+	} else {
+		shell_print(sh, "      -> [STATUS] MSI-X is inactive. All rings routing through "
+				"Legacy IRQ line.");
+	}
+	shell_print(sh, "====================================================================");
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -1387,6 +1450,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_irq_cmds,
 	SHELL_CMD_ARG(status, NULL, "Trace legacy and MSI/MSI-X vector configuration statuses",
 		      cmd_pcie_irq_status, 2, 0),
+	SHELL_CMD_ARG(affinity, NULL, "Inspect PCIe interrupt affinity steering parameters",
+		      cmd_pcie_irq_affinity, 2, 0),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -733,6 +733,7 @@ static int cmd_pcie_link_set_speed(const struct shell *sh, size_t argc, char **a
 		shell_error(sh, "No responsive endpoint found at target BDF.");
 		return -ENODEV;
 	}
+
 	pcie_cap_offset = pcie_get_cap(bdf, PCI_CAP_ID_EXP);
 	if (pcie_cap_offset == 0) {
 		shell_error(sh, "Target device does not support native "
@@ -774,7 +775,7 @@ static int cmd_pcie_link_set_speed(const struct shell *sh, size_t argc, char **a
 	link_ctrl2_reg = pcie_cap_offset + (0x30U / 4U);
 	link_ctrl2 = pcie_conf_read(bdf, link_ctrl2_reg);
 
-	link_ctrl2 &= ~0x0FU;
+	link_ctrl2 &= ~0x0FU; /* Clear Target Link Speed bitfield (Bits 3:0) */
 	link_ctrl2 |= target_speed;
 	pcie_conf_write(bdf, link_ctrl2_reg, link_ctrl2);
 
@@ -807,6 +808,114 @@ static int cmd_pcie_link_set_speed(const struct shell *sh, size_t argc, char **a
 	return 0;
 }
 
+/* Subcommand: pcie irq status <bus:dev.func> */
+static int cmd_pcie_irq_status(const struct shell *sh, size_t argc, char **argv)
+{
+	uint32_t intr;
+	uint8_t int_pin;
+	uint8_t int_line;
+	uint32_t msi_offset;
+	uint32_t msix_offset;
+	pcie_bdf_t bdf;
+	uint32_t id;
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie irq status <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (!PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCIe INTERRUPT LINE DIAGNOSTIC MATRIX: %u:%x.%u", PCIE_BDF_TO_BUS(bdf),
+		    PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+
+	intr = pcie_conf_read(bdf, PCIE_CONF_INTR);
+	int_pin = (intr >> 8) & 0xFFU;
+	int_line = intr & 0xFFU;
+
+	shell_print(sh, "Legacy INTx Parameters:");
+	shell_print(sh, "   -> Interrupt Pin  : INT%c", int_pin ? ('A' + int_pin - 1) : '-');
+
+	if (int_line == PCIE_CONF_INTR_IRQ_NONE) {
+		shell_print(sh, "   -> Interrupt Line : NOT ROUTED");
+	} else {
+		shell_print(sh, "   -> Interrupt Line : IRQ %u", (unsigned int)int_line);
+	}
+
+	shell_print(sh, "----------------------------------------------------");
+
+	msi_offset = pcie_get_cap(bdf, PCI_CAP_ID_MSI);
+	if (msi_offset != 0) {
+		uint32_t msg_ctrl = pcie_conf_read(bdf, msi_offset);
+		bool msi_en = (msg_ctrl & (1U << 16)) != 0;
+		uint32_t multi_msg = (msg_ctrl >> 17) & 0x07U;
+		uint32_t multi_en = (msg_ctrl >> 20) & 0x07U;
+		bool is_64bit = (msg_ctrl & (1U << 23)) != 0;
+		uint32_t addr_lo = pcie_conf_read(bdf, msi_offset + 1);
+
+		shell_print(sh, "Message Signaled Interrupts (MSI) Capability [Offset 0x%02X]:",
+			    msi_offset * 4);
+		shell_print(sh, "   -> Active Status  : %s", msi_en ? "ENABLED" : "DISABLED");
+		shell_print(sh, "   -> Capabilities   : Multiple Message Capable: %u vectors",
+			    1U << multi_msg);
+		shell_print(sh, "   -> Allocated      : Multiple Message Enabled: %u vectors",
+			    1U << multi_en);
+
+		if (is_64bit) {
+			uint32_t addr_hi = pcie_conf_read(bdf, msi_offset + 2);
+			uint32_t msg_data = pcie_conf_read(bdf, msi_offset + 3) & 0xFFFFU;
+
+			shell_print(sh, "   -> Target Address : 0x%08X%08X", addr_hi, addr_lo);
+			shell_print(sh, "   -> Message Data   : 0x%04X", msg_data);
+		} else {
+			uint32_t msg_data = pcie_conf_read(bdf, msi_offset + 2) & 0xFFFFU;
+
+			shell_print(sh, "   -> Target Address : 0x%08X", addr_lo);
+			shell_print(sh, "   -> Message Data   : 0x%04X", msg_data);
+		}
+	} else {
+		shell_print(sh, "MSI Capability [ID 0x05]     : NOT SUPPORTED");
+	}
+	shell_print(sh, "----------------------------------------------------");
+
+	msix_offset = pcie_get_cap(bdf, PCI_CAP_ID_MSIX);
+	if (msix_offset != 0) {
+		uint32_t msg_ctrl = pcie_conf_read(bdf, msix_offset);
+		bool msix_en = (msg_ctrl & (1U << 31)) != 0;
+		bool msix_mask = (msg_ctrl & (1U << 30)) != 0;
+		uint32_t table_size = ((msg_ctrl >> 16) & 0x07FFU) + 1;
+		uint32_t table_bir = pcie_conf_read(bdf, msix_offset + 1);
+		uint8_t bir = table_bir & 0x07U;
+		uint32_t offset = table_bir & ~0x07U;
+
+		shell_print(sh,
+			    "Extended MSI (MSI-X) Capability [Offset 0x%02X]:", msix_offset * 4);
+		shell_print(sh, "   -> Active Status  : %s", msix_en ? "ENABLED" : "DISABLED");
+		shell_print(sh, "   -> Global Mask    : %s",
+			    msix_mask ? "TRUE (All Vectors Blocked)" : "FALSE");
+		shell_print(sh, "   -> Table Size     : %u distinct vectors", table_size);
+		shell_print(sh, "   -> Vector Table   : Located in BAR %u at base offset + 0x%08X",
+			    bir, offset);
+	} else {
+		shell_print(sh, "MSI-X Capability [ID 0x11]   : NOT SUPPORTED");
+	}
+	shell_print(sh, "====================================================================");
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -830,6 +939,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_irq_cmds,
+	SHELL_CMD_ARG(status, NULL, "Trace legacy and MSI/MSI-X vector configuration statuses",
+		      cmd_pcie_irq_status, 2, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
 		      "List PCIE devices\n"
@@ -844,6 +959,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		  NULL),
 	SHELL_CMD(link, &sub_pcie_link_cmds,
 		  "Manage PCIe hardware link performance and power metrics", NULL),
+	SHELL_CMD(irq, &sub_pcie_irq_cmds, "Trace legacy and vector interrupt message allocations",
+		  NULL),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -45,6 +45,15 @@ struct pcie_cap_id_to_str {
 #define PCIE_MARGIN_CAP_MAX_T_STEPS(val)     (((val) >> 15) & 0x3FU)
 #define PCIE_MARGIN_CAP_MAX_T_STEPS_BIT(val) (((val) >> 21) & 0x1U)
 
+/* Standard PCI Power Management Capability ID */
+#define PCI_CAP_ID_PM 0x01U
+
+/* Power Management Control/Status Register (PMCSR) Relative Offsets & Masks */
+#define PCI_PM_CTRL_STATUS_REG (0x04U / 4U)
+#define PCI_PM_STATE_MASK      0x03U
+#define PCI_PM_STATE_D0        0x00U
+#define PCI_PM_STATE_D3HOT     0x03U
+
 static const struct pcie_cap_id_to_str pcie_cap_list[] = {
 	{ PCI_CAP_ID_PM,     "Power Management" },
 	{ PCI_CAP_ID_AGP,    "Accelerated Graphics Port" },
@@ -1155,6 +1164,68 @@ static int cmd_pcie_link_margin(const struct shell *sh, size_t argc, char **argv
 	return 0;
 }
 
+/* Subcommand: pcie device state <bus:dev.func> up|down */
+static int cmd_pcie_device_state(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id;
+	uint32_t pm_offset;
+	uint32_t pmcsr;
+	uint32_t target_state;
+
+	if (argc < 3) {
+		shell_error(sh, "Usage: pcie device state <bus:dev.func> up|down");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF format mapping specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	pm_offset = pcie_get_cap(bdf, PCI_CAP_ID_PM);
+	if (pm_offset == 0) {
+		shell_error(sh, "Target device does not support PCI Power Management.");
+		return -EOPNOTSUPP;
+	}
+
+	if (strcmp(argv[2], "up") == 0) {
+		target_state = PCI_PM_STATE_D0;
+	} else if (strcmp(argv[2], "down") == 0) {
+		target_state = PCI_PM_STATE_D3HOT;
+	} else {
+		shell_error(sh, "Invalid state token. Use 'up' for D0 or 'down' for D3hot.");
+		return -EINVAL;
+	}
+
+	pmcsr = pcie_conf_read(bdf, pm_offset + PCI_PM_CTRL_STATUS_REG);
+	pmcsr &= ~PCI_PM_STATE_MASK;
+	pmcsr |= target_state;
+	pcie_conf_write(bdf, pm_offset + PCI_PM_CTRL_STATUS_REG, pmcsr);
+
+	pmcsr = pcie_conf_read(bdf, pm_offset + PCI_PM_CTRL_STATUS_REG);
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCI HARDWARE TRANSCEIVER ENERGY REGISTRY STATUS: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   Current PMCSR Value Readout  : 0x%08X", pmcsr);
+	shell_print(sh, "   Physical Silicon Transceiver: [%s]",
+		    (pmcsr & PCI_PM_STATE_MASK) == PCI_PM_STATE_D3HOT
+			    ? "POWER GATED - D3hot LOW ENERGY SUSPEND"
+			    : "FULLY OPERATIONAL - D0 MAX PERFORMANCE");
+	shell_print(sh, "====================================================================");
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -1192,6 +1263,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_device_cmds,
+	SHELL_CMD_ARG(state, NULL, "Power gate physical device state (up = D0, down = D3hot)",
+		      cmd_pcie_device_state, 3, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
 		      "List PCIE devices\n"
@@ -1209,6 +1286,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(irq, &sub_pcie_irq_cmds, "Trace legacy and vector interrupt message allocations",
 		  NULL),
 	SHELL_CMD(aer, &sub_pcie_aer_cmds, "Interact with PCIe Advanced Error Reporting metrics",
+		  NULL),
+	SHELL_CMD(device, &sub_pcie_device_cmds, "Manage pcie physical hardware device states",
 		  NULL),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -697,6 +697,116 @@ static int cmd_pcie_mask_show(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+/* Subcommand: pcie link set_speed <bus:dev.func> <gen1|gen2|gen3|gen4> */
+static int cmd_pcie_link_set_speed(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id;
+	uint32_t pcie_cap_offset;
+	uint32_t target_speed;
+	uint32_t pcie_cap;
+	uint32_t pcie_cap_ver;
+	uint32_t lnkcap2_reg;
+	uint32_t lnkcap2;
+	uint32_t supported_speeds;
+	uint32_t link_ctrl2_reg;
+	uint32_t link_ctrl2;
+	uint32_t link_ctrl_reg;
+	uint32_t link_ctrl;
+	uint32_t link_status;
+	uint32_t negotiated_speed;
+
+	if (argc < 3) {
+		shell_error(sh, "Usage: pcie link set_speed <bus:dev.func> "
+				"<gen1|gen2|gen3|gen4>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+	pcie_cap_offset = pcie_get_cap(bdf, PCI_CAP_ID_EXP);
+	if (pcie_cap_offset == 0) {
+		shell_error(sh, "Target device does not support native "
+				"PCIe Capability structures.");
+		return -EOPNOTSUPP;
+	}
+
+	if (strcmp(argv[2], "gen1") == 0) {
+		target_speed = 0x1;
+	} else if (strcmp(argv[2], "gen2") == 0) {
+		target_speed = 0x2;
+	} else if (strcmp(argv[2], "gen3") == 0) {
+		target_speed = 0x3;
+	} else if (strcmp(argv[2], "gen4") == 0) {
+		target_speed = 0x4;
+	} else {
+		shell_error(sh, "Invalid speed argument. Supported values: "
+				"gen1, gen2, gen3, gen4");
+		return -EINVAL;
+	}
+
+	pcie_cap = pcie_conf_read(bdf, pcie_cap_offset);
+	pcie_cap_ver = (pcie_cap >> 16) & 0xFU;
+
+	if (pcie_cap_ver < 2U) {
+		shell_error(sh, "PCIe cap v%u does not support Link Control 2.", pcie_cap_ver);
+		return -EOPNOTSUPP;
+	}
+
+	lnkcap2_reg = pcie_cap_offset + (0x2CU / 4U);
+	lnkcap2 = pcie_conf_read(bdf, lnkcap2_reg);
+	supported_speeds = lnkcap2 & 0x0FU;
+
+	if ((supported_speeds & (1U << (target_speed - 1U))) == 0U) {
+		shell_error(sh, "Target speed %s is not supported by this link.", argv[2]);
+		return -EINVAL;
+	}
+
+	link_ctrl2_reg = pcie_cap_offset + (0x30U / 4U);
+	link_ctrl2 = pcie_conf_read(bdf, link_ctrl2_reg);
+
+	link_ctrl2 &= ~0x0FU;
+	link_ctrl2 |= target_speed;
+	pcie_conf_write(bdf, link_ctrl2_reg, link_ctrl2);
+
+	shell_print(sh,
+		    "Target speed configured to %s (Value: 0x%X) inside "
+		    "Link Control 2.",
+		    argv[2], target_speed);
+
+	link_ctrl_reg = pcie_cap_offset + (0x10U / 4U);
+	link_ctrl = pcie_conf_read(bdf, link_ctrl_reg);
+
+	shell_print(sh, "Issuing Retrain Link command (Setting Bit 5)...");
+	link_ctrl |= (1U << 5);
+	pcie_conf_write(bdf, link_ctrl_reg, link_ctrl);
+
+	/* Poll Link Status until retraining completes (Link Training bit clears) */
+	link_status = 0U;
+	for (int i = 0; i < 1000; i++) {
+		link_status = pcie_conf_read(bdf, link_ctrl_reg);
+		if (((link_status >> 27) & 0x1U) == 0U) {
+			break;
+		}
+	}
+
+	negotiated_speed = (link_status >> 16) & 0x0FU;
+
+	shell_print(sh, "Active Negotiated Link Speed reported by hardware: Gen%u",
+		    negotiated_speed);
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -714,6 +824,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_link_cmds,
+	SHELL_CMD_ARG(set_speed, NULL, "Scale the target PCIe bus lane speed dynamically",
+		      cmd_pcie_link_set_speed, 3, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
 		      "List PCIE devices\n"
@@ -726,6 +842,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(mask, &sub_pcie_mask_cmds, "Manage PCIe device scanning parameters", NULL),
 	SHELL_CMD(resource, &sub_pcie_resource_cmds, "PCI(e) memory mapping and resource metrics",
 		  NULL),
+	SHELL_CMD(link, &sub_pcie_link_cmds,
+		  "Manage PCIe hardware link performance and power metrics", NULL),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -508,6 +508,162 @@ static int cmd_pcie_mask_ignore(const struct shell *sh, size_t argc, char **argv
 	return 0;
 }
 
+static void show_mem_bar_info(const struct shell *sh, pcie_bdf_t bdf, unsigned int reg,
+			      unsigned int *bar_idx, uint64_t size_mask64, uint32_t raw_bar,
+			      bool is_64bit)
+{
+	uint64_t mem_size;
+	uint64_t base_addr = (uint64_t)(raw_bar & 0xFFFFFFF0U);
+	bool prefetch = ((raw_bar & 0x8U) != 0);
+
+	if (is_64bit && *bar_idx < 5) {
+		mem_size = ~(size_mask64 & 0xFFFFFFFFFFFFFFF0U) + 1ULL;
+	} else {
+		mem_size = (~(size_mask64 & 0xFFFFFFF0U) + 1ULL) & 0xFFFFFFFFULL;
+	}
+
+	shell_print(sh, "   -> Type       : MEMORY Space (%s)",
+		    is_64bit ? "64-bit Aperture" : "32-bit Aperture");
+	shell_print(sh, "   -> Attributes : Prefetchable: %s", prefetch ? "TRUE" : "FALSE");
+	shell_print(sh, "   -> Sizing     : Requested Size: %llu KB (Mask: 0x%016llX)",
+		    (unsigned long long)(mem_size / 1024U), (unsigned long long)size_mask64);
+
+	if (is_64bit && *bar_idx < 5) {
+		uint32_t raw_bar_hi = pcie_conf_read(bdf, reg + 1);
+		uint64_t base_addr64 = ((uint64_t)raw_bar_hi << 32) | base_addr;
+		uint64_t end_addr64 = base_addr64 + (mem_size - 1ULL);
+
+		shell_print(sh, "   -> Map Window : 0x%016llX - 0x%016llX",
+			    (unsigned long long)base_addr64, (unsigned long long)end_addr64);
+		*bar_idx += 2;
+	} else {
+		uint64_t end_addr32 = (base_addr + (mem_size - 1ULL)) & 0xFFFFFFFFULL;
+
+		shell_print(sh, "   -> Map Window : 0x%016llX - 0x%016llX",
+			    (unsigned long long)base_addr, (unsigned long long)end_addr32);
+		*bar_idx += 1;
+	}
+}
+
+static void show_io_bar_info(const struct shell *sh, uint64_t size_mask64, uint32_t raw_bar,
+			     unsigned int *bar_idx)
+{
+	uint32_t io_size = ~((uint32_t)size_mask64 & 0xFFFFFFFCU) + 1;
+	uint32_t base_io = raw_bar & 0xFFFFFFFCU;
+
+	shell_print(sh, "   -> Type       : I/O Space");
+	shell_print(sh, "   -> Sizing     : Requested Size: %u Bytes (Mask: 0x%016llX)", io_size,
+		    (unsigned long long)size_mask64);
+	shell_print(sh, "   -> Map Window : Port Range: 0x%08X - 0x%08X", base_io,
+		    base_io + (io_size - 1U));
+	*bar_idx += 1;
+}
+
+static uint64_t probe_bar_size_mask(pcie_bdf_t bdf, unsigned int reg, unsigned int bar_idx,
+				    bool is_64bit, uint32_t raw_bar)
+{
+	uint32_t cmd_backup = pcie_conf_read(bdf, PCIE_CONF_CMDSTAT);
+	uint32_t size_mask_lo;
+	uint64_t mask;
+
+	pcie_conf_write(bdf, PCIE_CONF_CMDSTAT,
+			cmd_backup & (~(PCIE_CONF_CMDSTAT_IO | PCIE_CONF_CMDSTAT_MEM)));
+
+	pcie_conf_write(bdf, reg, 0xFFFFFFFFU);
+	size_mask_lo = pcie_conf_read(bdf, reg);
+	pcie_conf_write(bdf, reg, raw_bar);
+
+	if (is_64bit && bar_idx < 5) {
+		uint32_t raw_bar_hi = pcie_conf_read(bdf, reg + 1);
+		uint32_t size_mask_hi;
+
+		pcie_conf_write(bdf, reg + 1, 0xFFFFFFFFU);
+		size_mask_hi = pcie_conf_read(bdf, reg + 1);
+		pcie_conf_write(bdf, reg + 1, raw_bar_hi);
+
+		mask = ((uint64_t)size_mask_hi << 32) | (uint64_t)size_mask_lo;
+	} else {
+		mask = (uint64_t)(uint32_t)size_mask_lo;
+	}
+
+	pcie_conf_write(bdf, PCIE_CONF_CMDSTAT, cmd_backup);
+	return mask;
+}
+
+static int cmd_pcie_resource_show(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id;
+	unsigned int bar_idx;
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie resource show <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF layout format specification.");
+		return -EINVAL;
+	}
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCIe BAR RESOURCE DECODER DIAGNOSTIC GRID: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+
+	uint32_t header_type = PCIE_CONF_TYPE_GET(pcie_conf_read(bdf, PCIE_CONF_TYPE));
+	unsigned int bar_count = 0U;
+
+	if (header_type == PCIE_CONF_TYPE_STANDARD) {
+		bar_count = 6U;
+	} else if (header_type == PCIE_CONF_TYPE_PCI_BRIDGE) {
+		bar_count = 2U;
+	} else if (header_type == PCIE_CONF_TYPE_CARDBUS_BRIDGE) {
+		bar_count = 1U;
+	}
+	bar_idx = 0U;
+	while (bar_idx < bar_count) {
+		unsigned int reg = PCIE_CONF_BAR0 + bar_idx;
+		uint32_t raw_bar = pcie_conf_read(bdf, reg);
+		uint64_t size_mask64;
+		bool is_mem;
+		bool is_64bit;
+
+		if (PCIE_CONF_BAR_INVAL_FLAGS(raw_bar)) {
+			bar_idx++;
+			continue;
+		}
+
+		is_mem = ((raw_bar & 0x1U) == 0);
+		is_64bit = (is_mem && ((raw_bar & 0x6U) == 0x4U));
+
+		size_mask64 = probe_bar_size_mask(bdf, reg, bar_idx, is_64bit, raw_bar);
+
+		if (size_mask64 == 0 || size_mask64 == 0xFFFFFFFFFFFFFFFFU ||
+		    (is_64bit && size_mask64 == 0xFFFFFFFF00000000U)) {
+			bar_idx += (is_64bit && bar_idx < 5) ? 2 : 1;
+			continue;
+		}
+
+		shell_print(sh, "BAR %u [Reg Offset: 0x%02X]:", bar_idx, reg * 4);
+
+		if (is_mem) {
+			show_mem_bar_info(sh, bdf, reg, &bar_idx, size_mask64, raw_bar, is_64bit);
+		} else {
+			show_io_bar_info(sh, size_mask64, raw_bar, &bar_idx);
+		}
+		shell_print(sh, "----------------------------------------------------");
+	}
+
+	return 0;
+}
+
 /* Subcommand: pcie mask clear */
 static int cmd_pcie_mask_clear(const struct shell *sh, size_t argc, char **argv)
 {
@@ -552,6 +708,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_pcie_resource_cmds,
+	SHELL_CMD_ARG(show, NULL, "Decode and map all active Base Address Registers (BARs)",
+		      cmd_pcie_resource_show, 2, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_cmds,
 	SHELL_CMD_ARG(ls, NULL,
 		      "List PCIE devices\n"
@@ -562,6 +724,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "Usage: write <bus:device.function> <reg_offset> <32bit_hex>",
 		      cmd_pcie_write, 4, 0),
 	SHELL_CMD(mask, &sub_pcie_mask_cmds, "Manage PCIe device scanning parameters", NULL),
+	SHELL_CMD(resource, &sub_pcie_resource_cmds, "PCI(e) memory mapping and resource metrics",
+		  NULL),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 

--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -54,6 +54,11 @@ struct pcie_cap_id_to_str {
 #define PCI_PM_STATE_D0        0x00U
 #define PCI_PM_STATE_D3HOT     0x03U
 
+/* Device Capabilities 2 Register Decoding Masks */
+#define PCI_EXP_DEVCAP2_ARI_MASK     0x00000020U /* Bit 5: Alternative Routing-ID */
+#define PCI_EXP_DEVCAP2_SRIOV_MASK   0x00000010U /* Bit 4: Single Root I/O Virt */
+#define PCI_EXP_DEVCAP2_NVME_OFFLOAD 0x000000C0U /* Memory-mapped offload markers */
+
 static const struct pcie_cap_id_to_str pcie_cap_list[] = {
 	{ PCI_CAP_ID_PM,     "Power Management" },
 	{ PCI_CAP_ID_AGP,    "Accelerated Graphics Port" },
@@ -1304,6 +1309,54 @@ static int cmd_pcie_link_speed(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static int cmd_pcie_offload_capabilities(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id, exp_offset, devcap2, ext_sriov_offset;
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie offload <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	exp_offset = pcie_get_cap(bdf, PCI_CAP_ID_EXP);
+	if (exp_offset == 0U) {
+		shell_error(sh, "Target device does not support native PCIe Capabilities.");
+		return -EOPNOTSUPP;
+	}
+
+	devcap2 = pcie_conf_read(bdf, (exp_offset + 0x24U) >> 2);
+	ext_sriov_offset = pcie_get_ext_cap(bdf, PCIE_EXT_CAP_ID_SRIOV);
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   SILICON HARDWARE TRANSPORT OVERLAY DECODER MATRIX: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   Raw DEVCAP2 Value: 0x%08X", devcap2);
+	shell_print(sh, "   ----------------------------------------------------");
+	shell_print(sh, "   Supported Physical Transaction Offloads:");
+	shell_print(sh, "      Alternative Routing-ID (ARI) : [%s]",
+		    (devcap2 & (1U << 5)) ? "SUPPORTED" : "UNAVAILABLE");
+	shell_print(sh, "      Single-Root I/O Virt (SR-IOV): [%s]",
+		    (ext_sriov_offset != 0U) ? "SUPPORTED" : "UNAVAILABLE");
+	shell_print(sh, "      Completion Timeout Disable   : [%s]",
+		    (devcap2 & (1U << 4)) ? "SUPPORTED" : "UNAVAILABLE");
+	shell_print(sh, "====================================================================");
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pcie_mask_cmds,
 	SHELL_CMD_ARG(ignore, NULL, "Register a coordinate slot to be ignored by bus scans",
@@ -1358,6 +1411,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "Write a 32-bit word directly to a device register.\n"
 		      "Usage: write <bus:device.function> <reg_offset> <32bit_hex>",
 		      cmd_pcie_write, 4, 0),
+	SHELL_CMD_ARG(offload, NULL,
+		      "Probe dynamic vector routing capabilities\n"
+		      "Usage: offload <bus:device.function>",
+		      cmd_pcie_offload_capabilities, 2, 0),
 	SHELL_CMD(mask, &sub_pcie_mask_cmds, "Manage PCIe device scanning parameters", NULL),
 	SHELL_CMD(resource, &sub_pcie_resource_cmds, "PCI(e) memory mapping and resource metrics",
 		  NULL),

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -214,6 +214,9 @@ struct pcie_scan_opt {
 
 	/** Scan flags */
 	uint32_t flags;
+
+	/** Function to call to determine if a BDF is masked */
+	bool (*scan_masking_fn)(pcie_bdf_t bdf);
 };
 
 /** Scan for PCIe devices.

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -220,6 +220,9 @@ struct pcie_scan_opt {
 
 	/** Scan flags */
 	uint32_t flags;
+
+	/** Function to call to determine if a BDF is masked */
+	bool (*scan_masking_fn)(pcie_bdf_t bdf);
 };
 
 /** Scan for PCIe devices.


### PR DESCRIPTION
This comprehensive pull request unifies our entire low-level PCIe diagnostics and hardware instrumentation sprint into a single, cohesive subsystem release: the PCIe Runtime Telemetry & Bring-up Suite. 

By grouping these subcommands and cross-module tracking layers into a linear, single-commit architecture, we prevent tracking drift, eliminate downstream rebasing churn, and deliver a clean, modular diagnostic interface to the core shell utility tree.

### Development History & Patch Breakdown
To facilitate granular code reviews, the atomic development history can be traced through the following individual tracking branches:
* 🔗 **[Patch 01: Configuration Space Write Utility]** -> [View Branch Feature/pcie-shell-write](https://github.com/zephyrproject-rtos/zephyr/pull/112783)
* 🔗 **[Patch 02: Dynamic Scan Masking]** -> [View Branch Feature/pcie-dynamic-masking](https://github.com/zephyrproject-rtos/zephyr/pull/112873)
* 🔗 **[Patch 03: BAR Address Decoder]** -> [View Branch Feature/pcie-bar-decoder](https://github.com/zephyrproject-rtos/zephyr/pull/112878)
*  🔗 **[Patch 04: Interactive Link Speed Control Command]** -> [View Branch Feature/pcie-link-control](https://github.com/zephyrproject-rtos/zephyr/pull/112888)
* 🔗 **[Patch 05: Interrupt Line Diagnostic Utility]** -> [View Branch Feature/pcie-irq-diagnostics](https://github.com/zephyrproject-rtos/zephyr/pull/112891)
* 🔗 **[Patch 06: AER Diagnostic Subsystem]** -> [View Branch Feature/pcie-aer-diagnostics](https://github.com/zephyrproject-rtos/zephyr/pull/113108)
* 🔗 **[Patch 07: SerDes Signal Margin]** -> [View Branch Feature/pcie-link-margining](https://github.com/zephyrproject-rtos/zephyr/pull/113122)
* 🔗 **[Patch 08: Silicon Power Gating]** -> [View Branch Feature/pcie-power-gating](https://github.com/zephyrproject-rtos/zephyr/pull/113128)
* 🔗 **[Patch 09: Link Speed and Bandwidth Tracking Command]** -> [View Branch feature/pcie-link-speed-telemetry](https://github.com/zephyrproject-rtos/zephyr/pull/113141)
* 🔗 **[Patch 10: Transport Overlay Decoder]** -> [View Transport Overlay Decode](https://github.com/zephyrproject-rtos/zephyr/pull/113453)
* 🔗 **[Patch 11: Dynamic Vector Routing]** -> [View  Dynamic Vector Routing](https://github.com/zephyrproject-rtos/zephyr/pull/113454)


### Rationale & Industrial Problem Framing
When bringing up custom silicon, evaluating multi-layer high-speed PCB trace designs, or triaging fault signatures on safety-critical real-time platforms, firmware engineers cannot rely on heavy, non-deterministic high-level OS abstractions. 

Hardware bring-up, pre-silicon fast-model simulations, and first-silicon validation teams require immediate, register-accurate, and low-latency terminal instrumentation to evaluate link parameters, manipulate physical power rails, map interrupt lines, and decode hardware faults at runtime directly over low-latency serial interfaces without necessitating external physical probes.

### Proposed Subcommand Architecture Map
This patch suite implements 9 runtime diagnostic subcommands organized into a nested shell topology, backed by a cross-module kernel visibility layer:

1. **`pcie write <bdf> <offset> <value>` (configuration space write utility):** Exposes a protected, direct-access register overwrite channel for rapid hardware verification loops.
2.  **`pcie mask <ignore|show|clear> <bdf>` (dynamic device scanning mask subsystem):** Implements a cross-module software-level kernel filtering mechanism (`should_skip_masked_bdf`) inside `pcie.c` to dynamically bypass and isolate malfunctioning or unconfigured peripherals during early bus scans.
3.  **`pcie resource show <bdf>` (BAR Decoder):** Parses base configuration registers to decode and print exact Base Address Register (BAR) dimensions, distinguishing between 32-bit/64-bit bounds, I/O spaces, and assigned memory address block windows.
4.  **`pcie link set_speed <bdf> <gen>` (Directed Frequency Control):** Mutates the Link Control 2 register to manipulate target speeds and force an immediate LTSSM directed retraining clock cycle.
5. **`pcie irq status <bdf>` (interrupt line diagnostic utility):** Decodes legacy INTx pins/lines and high-density MSI-X capability tables, extracting raw Table Memory Offsets and vector control bits to reveal physical processor core steering lines.
6.  **`pcie aer status <bdf>` (AER Decoding):** Traverses Extended Configuration Space (offsets ≥ `0x100`) to poll and unpack the native Advanced Error Reporting structure, translating raw bitfields into explicit fatal/non-fatal hardware breakdown metrics and dumping TLP Header logs.
7.  **`pcie link margin <bdf>` (SerDes Signal Margining):** Traverses Extended Capability block ID to audit L1 physical receiver voltage and timing tolerances defensively.
8. **`pcie device state <bdf> up|down` (Silicon Power Gating):** Add  physical power gating command for pci devices which manipulates the standard Power Management Control/Status Register (PMCSR) to physically toggle hardware transceivers between `D0` operational and `D3hot` low-power suspend states.
9.  **`pcie link speed <bdf>` (Bandwidth Status Monitor):** Evaluates Link Capabilities against active Link Status fields, dynamically throwing an explicit `[CRITICAL]` warning flag if lane or throughput degradation is captured.
10. **`pcie offload <bdf>` (Transport Overlay):** Decodes word-scaled DEVCAP2 registers to intercept physical transaction layer support for Alternative Routing-ID (ARI) and Single-Root I/O Virt (SR-IOV) transaction offloads.
11. **`pcie irq affinity <bdf>` (Vector Routing):** Interrogates live MSI-X redirection tables dynamically to decode active ring vector pool allocations and memory-mapped affinity vectors.

### PCIe Terminal Output 

#### 1. Dynamic Scanning Masking Filter (`pcie mask`) Loop
```text
uart:~\$ pcie mask ignore 1:0.0
Successfully masked BDF 1:0.0. Bus scans will ignore this slot.
uart:~\$ pcie ls
0:0.0 ID 1b36:8 class 6 subclass 0 prog i/f 0 rev 0
    wired interrupt on IRQ 0
0:1.0 ID 1b36:c class 6 subclass 4 prog i/f 0 rev 0 [bridge]
```

#### 2. Base Address Register Resource Mapping (`pcie resource show`)
```text
uart:~\$ pcie resource show 0:1.0 
====================================================================
   PCIe BAR RESOURCE DECODER DIAGNOSTIC GRID: 0:1.0
====================================================================
BAR 0 [Reg Offset: 0x10]:
   -> Type       : MEMORY Space (32-bit Aperture)
   -> Attributes : Prefetchable: FALSE
   -> Sizing     : Requested Size: 4 KB (Mask: 0x00000000FFFFF000)
   -> Map Window : 0x0000000010000000 - 0x0000000010000FFF
```

#### 3. Interrupt Redirection & MSI-X Vector Profiling (`pcie irq status`)
```text
uart:~\$ pcie irq status 1:0.0
====================================================================
   PCIe INTERRUPT LINE DIAGNOSTIC MATRIX: 1:0.0
====================================================================
Extended MSI (MSI-X) Capability [Offset 0x40]:
   -> Active Status  : DISABLED
   -> Global Mask    : FALSE
   -> Table Size     : 65 distinct vectors
   -> Vector Table   : Located in BAR 0 at base offset + 0x00002000
```

#### 4. Transceiver Silicon Power Rails Gating (`pcie device state`)
```text
uart:~\$ pcie device state 1:0.0 down 
====================================================================
   PCI HARDWARE TRANSCEIVER ENERGY REGISTRY STATUS: 1:0.0
====================================================================
   Current PMCSR Value Readout  : 0x00000003
   Physical Silicon Transceiver: [POWER GATED - D3hot LOW ENERGY SUSPEND]
====================================================================
```

#### 5. DWord-Aligned Bandwidth Status Tracking (`pcie link speed`)
```text
uart:~\$ pcie link speed 1:0.0
====================================================================
   PCIe HARDWARE LINK BANDWIDTH CAPABILITY TRACKER: 1:0.0
====================================================================
   Silicon Design Limits (Maximum Capabilities):
      Max Link Speed : PCIe Gen 1
      Max Link Width : x1 Lanes
   ----------------------------------------------------
   Real-Time Operational Link Status:
      Current Speed  : PCIe Gen 1
      Current Width  : x1 Lanes
   ----------------------------------------------------
   -> Link Negotiation Status: Healthy [Maximum Bus Throughput Achieved]
====================================================================
```
#### 4.  AER Diagnostic Subsystem (`pcie aer status`)
```text
uart:~$ pcie aer status 0:1.0 
====================================================================
   PCIe ADVANCED ERROR REPORTING (AER) STATUS MATRIX: 0:1.0
====================================================================
Uncorrectable Errors Status: 0x00000000 [Mask: 0x02400000]
   -> No uncorrectable fatal hardware fractures logged.
----------------------------------------------------
Correctable Errors Status:   0x00000000 [Mask: 0x0000E000]
   -> No physical signal degradation deviations reported.
----------------------------------------------------
Transaction Layer Packet (TLP) Header Log Matrix:
   [DW0-DW1] : 0x00000000 0x00000000
   [DW2-DW3] : 0x00000000 0x00000000
====================================================================
uart:~$ pcie aer status 0:1.0
====================================================================
   PCIe ADVANCED ERROR REPORTING (AER) STATUS MATRIX: 0:1.0
====================================================================
Uncorrectable Errors Status: 0x00100000 [Mask: 0x02400000]
   [CRITICAL] -> Unsupported Request (UR) Abort
----------------------------------------------------
Correctable Errors Status:   0x00000000 [Mask: 0x0000E000]
   -> No physical signal degradation deviations reported.
----------------------------------------------------
Transaction Layer Packet (TLP) Header Log Matrix:
   [DW0-DW1] : 0x11111111 0x22222222
   [DW2-DW3] : 0x33333333 0x44444444
====================================================================

```
