### PR TITLE
include: audio: move doxygen group under "Device Drivers"

### DIFF
--- a/include/zephyr/audio/dmic.h
+++ b/include/zephyr/audio/dmic.h
@@ -20,6 +20,8 @@
 
 /**
  * @defgroup audio_interface Audio
+ * @ingroup io_interfaces
+ * @brief Interfaces for audio devices.
  * @{
  * @}
  */


### PR DESCRIPTION
Audio interfaces should be folded under "Device Drivers" instead of doxygen "home page" like they were before this commit.