### PR TITLE
manifest: hal_nxp: upgrade wifi_nxp module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: ab59fc67d61118720e9228c7c75bd4a9d99e317f
+      revision: 02a097059315d7b9a7f7f7d38ee9c97f906867ce
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update hal_nxp revision to pick up wifi_nxp changes:
- Fix legacy roaming after 11kv roaming failure
- Fix network name length check
- Fix CAU TSEN and RFU temperature read back
- Fix WPA3 connection failure with open profile
- Support raw scan result IEs conditionally
- Restrict xtal commands to RW610
- Reduce AMPDU RX window size in SLIM mode
- Fix zero-copy RX deadlock on pool exhaustion
- Pass right rssi and noise to supplicant
- Improve RF test mode xtal feature usage dump

Depends on: https://github.com/zephyrproject-rtos/hal_nxp/pull/766

---
_Generated by WChat AI Agent_