### PR TITLE
net: wifi: fix misleading ps_exit_strategy doc comments

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -671,9 +671,14 @@ const char *wifi_ps_wakeup_mode_txt(enum wifi_ps_wakeup_mode ps_wakeup_mode);
  * @brief Wi-Fi power save exit strategy
  */
 enum wifi_ps_exit_strategy {
-	/** PS-Poll frame based */
+	/** Custom algorithm: the driver/firmware decides how to exit power save
+	 *  based on traffic, e.g. by sending a PS-Poll, fully exiting power save,
+	 *  or a mix of both.
+	 */
 	WIFI_PS_EXIT_CUSTOM_ALGO = 0,
-	/** QoS NULL frame based */
+	/** Exit power save on every TIM, typically by sending a QoS NULL (or any
+	 *  data) frame to retrieve the buffered traffic.
+	 */
 	WIFI_PS_EXIT_EVERY_TIM,
 
 /** @cond INTERNAL_HIDDEN */


### PR DESCRIPTION
The doc comments on the wifi_ps_exit_strategy enumerators described the underlying frame mechanism ("PS-Poll frame based" / "QoS NULL frame based") in a way that did not match the enumerator names or the strings returned by wifi_ps_exit_strategy_txt() ("Custom algorithm" / "Every TIM"), which caused confusion about what each value actually selects.

Reword the comments to describe the exit behaviour:

- WIFI_PS_EXIT_CUSTOM_ALGO: the driver/firmware decides how to exit power save based on traffic (PS-Poll, full exit, or a mix), rather than being tied to PS-Poll frames.
- WIFI_PS_EXIT_EVERY_TIM: exit power save on every TIM, typically using a QoS NULL (or any data) frame, rather than being QoS-NULL specific.

No functional change; documentation only.


Assisted-by: Claude:claude-opus-4.8