### PR TITLE
MAINTAINERS.yml: add myself to devicetree area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1309,6 +1309,7 @@ Devicetree:
     - mbolivar
     - rruuaanng
     - kylebonnici
+    - maass-hamburg
   files-regex:
     - ^dts/bindings/.*zephyr.*
     - ^dts/bindings/[^,]+$


### PR DESCRIPTION
Add myself as a collaborator to
devicetree area. That area recently lost a
collaborator and got downgraded to odd fixes.
So I am willing to help in that area.

related PRs
- #89212
- #91818
- #97540
- #102521
- #104003
- #108015
- #108585
- #108587
- #108892 (this will allow allow childs refering its parents without having cyclic dependencies)