### PR TITLE
MAINTAINERS.yml: add maass-hamburg to wifi collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2955,6 +2955,7 @@ Documentation Infrastructure:
     - kludentwo
     - krish2718
     - MaochenWang1
+    - maass-hamburg
   files:
     - drivers/wifi/
     - dts/bindings/wifi/


### PR DESCRIPTION
add maass-hamburg to wifi driver collaborators.
As the wifi drivers use the ethernet api (and I'm the maintainer of the ethernet drivers),
I also like to have a look on the wifi drivers and how they use the ethernet api