### PR TITLE
MAINTAINERS: move some RISC-V arch area maintainers to collaborator status

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5087,9 +5087,9 @@ RISCV arch:
   status: maintained
   maintainers:
     - fkokosinski
+  collaborators:
     - kgugala
     - tgorochowik
-  collaborators:
     - edersondisouza
     - katsuster
     - mgielda


### PR DESCRIPTION
This PR moves two RISC-V architecture area maintainers (@tgorochowik and @kgugala) to collaborator status.