### PR TITLE
Bluetooth: BAP: BASE subgroup and metadata fixes

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -928,6 +928,11 @@ Bluetooth Audio
     to ``codec_configured`` and from ``qos_set`` to ``qos_configured`` where the callbacks are
     assigned. (:github:`114835`)
 
+  * :c:func:`bt_bap_scan_delegator_mod_src` no longer treats ``metadata_len = 0`` as "keep existing"
+    and will now set the metadata length to 0 for the subgroup. To keep existing data, the
+    ``metadata_len`` field needs to be set to the existing length and the existing metadata
+    shall be copied.
+
 * CAP
 
   * :c:func:`bt_cap_commander_broadcast_reception_start` now waits for the CAP acceptors to sync to

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -2004,8 +2004,8 @@ int bt_bap_base_get_subgroup_codec_data(const struct bt_bap_base_subgroup *subgr
  * @param[in]  subgroup The subgroup pointer
  * @param[out] meta     Pointer that will point to the resulting codec metadata
  *
+ * @return Length of the metadata on success
  * @retval -EINVAL if arguments are invalid
- * @retval 0 on success
  */
 int bt_bap_base_get_subgroup_codec_meta(const struct bt_bap_base_subgroup *subgroup,
 					uint8_t **meta);

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -2621,12 +2621,7 @@ struct bt_bap_scan_delegator_mod_src_param {
 	/** Number of subgroups */
 	uint8_t num_subgroups;
 
-	/**
-	 * @brief Subgroup specific information
-	 *
-	 * If a subgroup's metadata_len is set to 0, the existing metadata
-	 * for the subgroup will remain unchanged
-	 */
+	/** Subgroup specific information */
 	struct bt_bap_bass_subgroup subgroups[BT_BAP_BASS_MAX_SUBGROUPS];
 };
 

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -149,13 +149,16 @@ static void update_recv_state_big_synced(const struct bt_bap_broadcast_sink *sin
 		mod_src_param.encrypt_state = recv_state->encrypt_state;
 	}
 
-	/* Since the mod_src_param struct is 0-initialized the metadata won't
-	 * be modified by this
-	 */
-
 	/* Copy existing unchanged data */
 	mod_src_param.src_id = recv_state->src_id;
 	mod_src_param.broadcast_id = recv_state->broadcast_id;
+	for (uint8_t i = 0U; i < recv_state->num_subgroups; i++) {
+		struct bt_bap_bass_subgroup *subgroup_param = &mod_src_param.subgroups[i];
+
+		subgroup_param->metadata_len = recv_state->subgroups[i].metadata_len;
+		(void)memcpy(subgroup_param->metadata, recv_state->subgroups[i].metadata,
+			     subgroup_param->metadata_len);
+	}
 
 	err = bt_bap_scan_delegator_mod_src(&mod_src_param);
 	if (err != 0) {
@@ -211,12 +214,17 @@ static void update_recv_state_big_cleared(const struct bt_bap_broadcast_sink *si
 		}
 	}
 
-	/* Since the metadata_len is 0 then the metadata won't be modified by the operation either*/
-
 	/* Copy existing unchanged data */
 	mod_src_param.num_subgroups = recv_state->num_subgroups;
 	mod_src_param.src_id = recv_state->src_id;
 	mod_src_param.broadcast_id = recv_state->broadcast_id;
+	for (uint8_t i = 0U; i < recv_state->num_subgroups; i++) {
+		struct bt_bap_bass_subgroup *subgroup_param = &mod_src_param.subgroups[i];
+
+		subgroup_param->metadata_len = recv_state->subgroups[i].metadata_len;
+		(void)memcpy(subgroup_param->metadata, recv_state->subgroups[i].metadata,
+			     subgroup_param->metadata_len);
+	}
 
 	err = bt_bap_scan_delegator_mod_src(&mod_src_param);
 	if (err != 0) {

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -541,15 +541,30 @@ static bool base_subgroup_meta_cb(const struct bt_bap_base_subgroup *subgroup, v
 
 	ARG_UNUSED(user_data);
 
+	if (mod_src_param.num_subgroups == ARRAY_SIZE(mod_src_param.subgroups)) {
+		return false;
+	}
+
+	subgroup_param = &mod_src_param.subgroups[mod_src_param.num_subgroups];
+
 	ret = bt_bap_base_get_subgroup_codec_meta(subgroup, &meta);
 	if (ret < 0) {
 		return false;
 	}
 
-	subgroup_param = &mod_src_param.subgroups[mod_src_param.num_subgroups];
+	if (ret <= sizeof(subgroup_param->metadata)) {
+		subgroup_param->metadata_len = (uint8_t)ret;
+		(void)memcpy(subgroup_param->metadata, meta, subgroup_param->metadata_len);
+	} else {
+		/* If we cannot store the metadata, we just omit it.
+		 * BASS section 3.2.1.10 Metadata_Length field states
+		 * "the server may write the length of any Metadata
+		 *  parameters for each subgroup to the Metadata_Length field"
+		 */
+		subgroup_param->metadata_len = 0U;
+	}
+
 	mod_src_param.num_subgroups++;
-	subgroup_param->metadata_len = (uint8_t)ret;
-	memcpy(subgroup_param->metadata, meta, subgroup_param->metadata_len);
 
 	return true;
 }
@@ -582,9 +597,11 @@ static void update_recv_state_base(const struct bt_bap_broadcast_sink *sink,
 
 	(void)memset(&mod_src_param, 0, sizeof(mod_src_param));
 
+	/* Will set the mod_src_param.num_subgroups and subgroup-related parameters */
 	err = update_recv_state_base_copy_meta(base);
 	if (err != 0) {
-		LOG_WRN("Failed to modify Receive State for sink %p: %d", sink, err);
+		LOG_WRN("Failed to parse all subgroups from BASE for sink %p: %d (%u != %d)", sink,
+			err, mod_src_param.num_subgroups, bt_bap_base_get_subgroup_count(base));
 		return;
 	}
 
@@ -592,7 +609,7 @@ static void update_recv_state_base(const struct bt_bap_broadcast_sink *sink,
 	mod_src_param.src_id = recv_state->src_id;
 	mod_src_param.encrypt_state = recv_state->encrypt_state;
 	mod_src_param.broadcast_id = recv_state->broadcast_id;
-	mod_src_param.num_subgroups = sink->subgroup_count;
+
 	for (uint8_t i = 0U; i < sink->subgroup_count; i++) {
 		struct bt_bap_bass_subgroup *subgroup_param = &mod_src_param.subgroups[i];
 
@@ -653,8 +670,6 @@ static bool base_decode_subgroup_cb(const struct bt_bap_base_subgroup *subgroup,
 	int ret;
 
 	if (sink->subgroup_count == ARRAY_SIZE(sink->subgroups)) {
-		/* We've parsed as many subgroups as we support */
-		LOG_DBG("Could only store %u subgroups", sink->subgroup_count);
 		return false;
 	}
 
@@ -730,9 +745,18 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 
 		/* Store newest BASE info until we are BIG synced */
 		if (sink->big == NULL) {
+			int err;
+
 			sink->subgroup_count = 0U;
 			sink->valid_indexes_bitfield = 0U;
-			bt_bap_base_foreach_subgroup(base, base_decode_subgroup_cb, sink);
+
+			err = bt_bap_base_foreach_subgroup(base, base_decode_subgroup_cb, sink);
+			if (err != 0) {
+				LOG_WRN("Failed to parse all subgroups for sink %p: %d (%u != %d)",
+					sink, err, sink->subgroup_count,
+					bt_bap_base_get_subgroup_count(base));
+				return false;
+			}
 
 			LOG_DBG("Updating BASE for sink %p with %d subgroups\n", sink,
 				sink->subgroup_count);
@@ -741,6 +765,7 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 			sink->base_size = base_size;
 		}
 
+		/* Metadata may change after syncing, so parse that regardless of `sink->big` */
 		if (atomic_test_bit(sink->flags, BT_BAP_BROADCAST_SINK_FLAG_SRC_ID_VALID)) {
 			update_recv_state_base(sink, base);
 		}

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -600,7 +600,8 @@ static void update_recv_state_base(const struct bt_bap_broadcast_sink *sink,
 	/* Will set the mod_src_param.num_subgroups and subgroup-related parameters */
 	err = update_recv_state_base_copy_meta(base);
 	if (err != 0) {
-		LOG_WRN("Failed to parse all subgroups from BASE for sink %p: %d (%u != %d)", sink,
+		LOG_WRN_RATELIMIT(
+			"Failed to parse all subgroups from BASE for sink %p: %d (%u != %d)", sink,
 			err, mod_src_param.num_subgroups, bt_bap_base_get_subgroup_count(base));
 		return;
 	}
@@ -733,10 +734,11 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 			ret = base_get_bis_count(base);
 
 			if (ret < 0) {
-				LOG_DBG("Invalid BASE: %d", ret);
+				LOG_DBG_RATELIMIT("Invalid BASE: %d", ret);
 				return false;
 			} else if (ret != sink->biginfo.num_bis) {
-				LOG_DBG("BASE contains different amount of BIS (%u) than reported "
+				LOG_DBG_RATELIMIT(
+					"BASE contains different amount of BIS (%u) than reported "
 					"by BIGInfo (%u)",
 					ret, sink->biginfo.num_bis);
 				return false;
@@ -752,7 +754,8 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 
 			err = bt_bap_base_foreach_subgroup(base, base_decode_subgroup_cb, sink);
 			if (err != 0) {
-				LOG_WRN("Failed to parse all subgroups for sink %p: %d (%u != %d)",
+				LOG_WRN_RATELIMIT(
+					"Failed to parse all subgroups for sink %p: %d (%u != %d)",
 					sink, err, sink->subgroup_count,
 					bt_bap_base_get_subgroup_count(base));
 				return false;

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -1816,11 +1816,6 @@ int bt_bap_scan_delegator_mod_src(const struct bt_bap_scan_delegator_mod_src_par
 			state_changed = true;
 		}
 
-		/* If the metadata len is 0, we shall not overwrite the existing metadata */
-		if (param_subgroup->metadata_len == 0U) {
-			continue;
-		}
-
 		if (subgroup->metadata_len != param_subgroup->metadata_len) {
 			subgroup->metadata_len = param_subgroup->metadata_len;
 			state_changed = true;


### PR DESCRIPTION
Adds additional checks when parsing the BASE to avoid accessing invalid memory or to write invalid data to the receive state.

Fixes: #116365