### PR TITLE
net: dns: Misc multi-server fixes

### DIFF
--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -364,6 +364,19 @@ int dns_dispatcher_unregister(struct dns_socket_dispatcher *ctx)
 		dispatch_table[sock].ctx = NULL;
 	}
 
+	/* Drop any pairing that referenced this dispatcher so that a
+	 * surviving dispatcher does not delegate to an unregistered context.
+	 * Also clear our own pair so a later re-register does not inherit a
+	 * stale partner.
+	 */
+	SYS_SLIST_FOR_EACH_CONTAINER(&sockets, entry, node) {
+		if (entry->pair == ctx) {
+			entry->pair = NULL;
+		}
+	}
+
+	ctx->pair = NULL;
+
 	SYS_SLIST_FOR_EACH_CONTAINER(&sockets, entry, node) {
 		if (entry->svc == svc) {
 			ret = net_socket_service_register(entry->svc, entry->fds,

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -339,29 +339,34 @@ out:
 
 int dns_dispatcher_unregister(struct dns_socket_dispatcher *ctx)
 {
+	struct dns_socket_dispatcher *entry;
+	const struct net_socket_service_desc *svc;
+	int sock;
 	int ret = 0;
 
 	k_mutex_lock(&lock, K_FOREVER);
 
+	sock = ctx->sock;
+	svc = ctx->svc;
+
 	(void)sys_slist_find_and_remove(&sockets, &ctx->node);
-
-	(void)net_socket_service_unregister(ctx->svc);
-
-	/* Mark the context as unregistered */
 	ctx->sock = -1;
 
-	for (int i = 0; i < ctx->fds_len; i++) {
-		CHECKIF((int)ctx->fds[i].fd >= (int)ARRAY_SIZE(dispatch_table)) {
-			ret = -ERANGE;
+	if (sock >= 0 && sock < (int)ARRAY_SIZE(dispatch_table) &&
+	    dispatch_table[sock].ctx == ctx) {
+		dispatch_table[sock].ctx = NULL;
+	}
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&sockets, entry, node) {
+		if (entry->svc == svc) {
+			ret = net_socket_service_register(entry->svc, entry->fds,
+							  entry->fds_len,
+							  &dispatch_table);
 			goto out;
 		}
-
-		if (ctx->fds[i].fd < 0) {
-			continue;
-		}
-
-		dispatch_table[ctx->fds[i].fd].ctx = NULL;
 	}
+
+	(void)net_socket_service_unregister(svc);
 
 out:
 	k_mutex_unlock(&lock);

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -155,6 +155,14 @@ static int recv_data(struct net_socket_service_event *pev)
 
 	dns_data = net_buf_alloc(&dns_msg_pool, dispatcher->buf_timeout);
 	if (!dns_data) {
+		uint8_t discard;
+
+		/* Flush the pending datagram to release its net_pkt and avoid RX starvation. */
+		if (zsock_recvfrom(pev->event.fd, &discard, sizeof(discard), 0,
+				   NULL, NULL) < 0) {
+			NET_DBG("DNS discard recv failed (%d)", errno);
+		}
+
 		ret = DNS_EAI_MEMORY;
 		goto unlock;
 	}

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -131,6 +131,13 @@ static int recv_data(struct net_socket_service_event *pev)
 	int ret = 0, len;
 
 	dispatcher = table[pev->event.fd].ctx;
+	if (dispatcher == NULL) {
+		/* The dispatch slot was cleared concurrently, for example the
+		 * server socket was just closed while its poll event was still
+		 * in flight. Nothing to dispatch to, so drop the event.
+		 */
+		return 0;
+	}
 
 	k_mutex_lock(&dispatcher->lock, K_FOREVER);
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -400,6 +400,7 @@ static int register_dispatcher(struct dns_resolve_context *ctx,
 	server->dispatcher.sock = server->sock;
 	server->dispatcher.svc = svc;
 	server->dispatcher.resolve_ctx = ctx;
+	server->dispatcher.ifindex = server->if_index;
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
 	    server->dns_server.sa_family == NET_AF_INET6) {

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -2290,9 +2290,19 @@ static int dns_server_close(struct dns_resolve_context *ctx,
 			    int server_idx)
 {
 	struct net_if *iface;
+	int closed_sock;
 
 	if (ctx->servers[server_idx].sock < 0) {
 		return -ENOENT;
+	}
+
+	closed_sock = ctx->servers[server_idx].sock;
+
+	ARRAY_FOR_EACH(ctx->fds, j) {
+		if (ctx->fds[j].fd == closed_sock) {
+			ctx->fds[j].fd = -1;
+			break;
+		}
 	}
 
 	(void)dns_dispatcher_unregister(&ctx->servers[server_idx].dispatcher);
@@ -2315,14 +2325,10 @@ static int dns_server_close(struct dns_resolve_context *ctx,
 		net_mgmt_event_notify(NET_EVENT_DNS_SERVER_DEL, iface);
 	}
 
-	zsock_close(ctx->servers[server_idx].sock);
+	zsock_close(closed_sock);
 
 	ctx->servers[server_idx].sock = -1;
 	ctx->servers[server_idx].dns_server.sa_family = 0;
-
-	ARRAY_FOR_EACH(ctx->fds, j) {
-		ctx->fds[j].fd = -1;
-	}
 
 	return 0;
 }

--- a/tests/net/lib/dns_dispatcher/src/main.c
+++ b/tests/net/lib/dns_dispatcher/src/main.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 #include <zephyr/net/dns_resolve.h>
 #include <zephyr/net/net_event.h>
 #include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/socket.h>
 #include <zephyr/net/socket_service.h>
 
 #define NET_LOG_ENABLED 1
@@ -35,6 +36,24 @@ LOG_MODULE_REGISTER(net_test, CONFIG_DNS_RESOLVER_LOG_LEVEL);
 #else
 #define DBG(fmt, ...)
 #endif
+
+extern void dns_dispatcher_svc_handler(struct net_socket_service_event *pev);
+
+NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(test_pair_svc, dns_dispatcher_svc_handler, 1);
+
+static int test_dispatch_cb(struct dns_socket_dispatcher *ctx, int sock,
+			    struct net_sockaddr *addr, size_t addrlen,
+			    struct net_buf *buf, size_t data_len)
+{
+	ARG_UNUSED(ctx);
+	ARG_UNUSED(sock);
+	ARG_UNUSED(addr);
+	ARG_UNUSED(addrlen);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(data_len);
+
+	return 0;
+}
 
 #define NAME4 "4.zephyr.test"
 #define NAME6 "6.zephyr.test"
@@ -201,6 +220,87 @@ ZTEST(dns_dispatcher, test_dns_dispatcher)
 
 	zassert_equal(ctx->servers[0].dispatcher.fds[sock2].fd, -1, "Socket not closed");
 	zassert_equal(ctx->servers[0].dispatcher.sock, -1, "Dispatcher still registered");
+}
+
+/* Register a responder and a resolver on the same family/port so the
+ * dispatcher pairs them (responder->pair points at the resolver). Closing the
+ * resolver must clear that back-reference, otherwise the surviving responder
+ * would later delegate traffic to an unregistered context.
+ */
+ZTEST(dns_dispatcher, test_dispatcher_pair_cleanup)
+{
+	static struct dns_socket_dispatcher responder;
+	static struct dns_socket_dispatcher resolver;
+	static struct zsock_pollfd responder_fds[1];
+	static struct zsock_pollfd resolver_fds[1];
+	struct net_sockaddr_in local = {
+		.sin_family = NET_AF_INET,
+		.sin_port = net_htons(65123),
+	};
+	int responder_sock, resolver_sock;
+
+	responder_sock = zsock_socket(NET_AF_INET, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
+	zassert_true(responder_sock >= 0, "Cannot create responder socket");
+
+	resolver_sock = zsock_socket(NET_AF_INET, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
+	zassert_true(resolver_sock >= 0, "Cannot create resolver socket");
+
+	responder_fds[0].fd = responder_sock;
+	resolver_fds[0].fd = resolver_sock;
+
+	responder.type = DNS_SOCKET_RESPONDER;
+	responder.cb = test_dispatch_cb;
+	responder.fds = responder_fds;
+	responder.fds_len = 1;
+	responder.sock = responder_sock;
+	responder.svc = &test_pair_svc;
+	memcpy(&responder.local_addr, &local, sizeof(local));
+
+	resolver.type = DNS_SOCKET_RESOLVER;
+	resolver.cb = test_dispatch_cb;
+	resolver.fds = resolver_fds;
+	resolver.fds_len = 1;
+	resolver.sock = resolver_sock;
+	resolver.svc = &test_pair_svc;
+	memcpy(&resolver.local_addr, &local, sizeof(local));
+
+	zassert_ok(dns_dispatcher_register(&responder), "Cannot register responder");
+	zassert_ok(dns_dispatcher_register(&resolver), "Cannot register resolver");
+
+	zassert_equal(responder.pair, &resolver, "Dispatchers were not paired");
+
+	zassert_ok(dns_dispatcher_unregister(&resolver), "Cannot unregister resolver");
+	zassert_is_null(responder.pair, "Pair back-reference was not cleared");
+
+	zassert_ok(dns_dispatcher_unregister(&responder), "Cannot unregister responder");
+
+	(void)zsock_close(responder_sock);
+	(void)zsock_close(resolver_sock);
+}
+
+/* A poll event may still be in flight for a socket whose dispatch slot was
+ * cleared concurrently (e.g. the server was just closed). Emulate that by
+ * handing the handler a dispatch table whose slot is NULL and verify the event
+ * is dropped instead of dereferencing a NULL dispatcher.
+ */
+ZTEST(dns_dispatcher, test_dispatcher_null_slot_dropped)
+{
+	/* dispatch_table entries start with the dispatcher pointer, so a plain
+	 * NULL pointer slot is layout-compatible for index 0.
+	 */
+	struct dns_socket_dispatcher *table[1] = { NULL };
+	struct net_socket_service_event pev = {
+		.event = {
+			.fd = 0,
+			.revents = ZSOCK_POLLIN,
+		},
+		.user_data = table,
+	};
+
+	/* Prior to the NULL guard this dereferenced a NULL dispatcher and
+	 * crashed; reaching the next statement proves the event was dropped.
+	 */
+	dns_dispatcher_svc_handler(&pev);
 }
 
 ZTEST_SUITE(dns_dispatcher, NULL, test_init, NULL, NULL, NULL);


### PR DESCRIPTION
* **Set dispatcher ifindex on resolver registration** — A second DNS server bound to a different interface was treated as a duplicate and never added to the socket service poll list. Late DNS replies on that socket piled up unread, each holding an RX net_pkt until the pool was exhausted.

* **Flush datagram when dispatcher buffer alloc fails** — If the DNS message pool was full, the dispatcher returned without reading the socket. The datagram stayed queued and kept its net_pkt pinned. A discard read on allocation failure releases the buffer even when the packet can't be processed.

* **Keep polling remaining servers on single close** — Removing one DNS server unregistered polling for every resolver socket and cleared dispatch entries for all of them. Servers on other interfaces could still receive traffic but nothing drained their queues, so packets accumulated and starved RX.

Fixes #112939