### PR TITLE
samples: drivers: can_counter: enlarge thread stack size

### DIFF
--- a/samples/drivers/can/counter/src/main.c
+++ b/samples/drivers/can/counter/src/main.c
@@ -13,7 +13,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/sys/byteorder.h>
 
-#define RX_THREAD_STACK_SIZE 512
+#define RX_THREAD_STACK_SIZE 1024
 #define RX_THREAD_PRIORITY 2
 #define STATE_POLL_THREAD_STACK_SIZE 512
 #define STATE_POLL_THREAD_PRIORITY 2


### PR DESCRIPTION
Enlarge thread stack size to fix panic issue on some ARM64 platforms.

Fixes #113209