### PR TITLE
bluetooth: mesh: clamp solicitation PDU length before decryption

### DIFF
--- a/subsys/bluetooth/mesh/solicitation.c
+++ b/subsys/bluetooth/mesh/solicitation.c
@@ -254,6 +254,15 @@ void bt_mesh_sol_recv(struct net_buf_simple *buf, uint8_t uuid_list_len)
 		return;
 	}
 
+	/* Trim any trailing AD structures left attached by the scan callback:
+	 * the encrypted Solicitation PDU has a fixed length of 17 octets.
+	 */
+	if (buf->len < 17) {
+		LOG_DBG("Truncated Solicitation PDU (len %u)", buf->len);
+		return;
+	}
+	buf->len = 17;
+
 	sub = bt_mesh_subnet_find(sol_pdu_decrypt, (void *)buf);
 	if (!sub) {
 		LOG_DBG("Unable to find subnetwork for received solicitation PDU");


### PR DESCRIPTION
The encrypted Solicitation PDU is defined by Mesh Protocol 1.1.1 section 6.9.1 as a fixed 17-octet Network PDU (CTL=1, TTL=0, empty TransportPDU, 8-octet NetMIC).

The mesh scan callback in adv.c restores its snapshot of the advertising buffer before dispatching, so buf->len passed into bt_mesh_sol_recv() may still cover trailing AD structures beyond the Solicitation Service Data.

Trim buf->len to the expected 17 octets after consuming the Solicitation Service Data Identification Type byte, and drop the PDU early if fewer octets remain. This aligns the input handed to sol_pdu_decrypt() with the specification.

Fixes: #113216 