### PR TITLE
drivers: modem: hl78xx: allow GNSS timeout updates during active search

### DIFF
--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx.c
@@ -492,6 +492,11 @@ void hl78xx_start_timer(struct hl78xx_data *data, k_timeout_t timeout)
 	k_work_schedule(&data->work.timeout_work, timeout);
 }
 
+void hl78xx_reschedule_timer(struct hl78xx_data *data, k_timeout_t timeout)
+{
+	(void)k_work_reschedule(&data->work.timeout_work, timeout);
+}
+
 void hl78xx_stop_timer(struct hl78xx_data *data)
 {
 	k_work_cancel_delayable(&data->work.timeout_work);
@@ -2645,6 +2650,7 @@ static bool hl78xx_await_registered_resume_should_sleep(struct hl78xx_data *data
 
 static void hl78xx_await_registered_event_handler(struct hl78xx_data *data, enum hl78xx_event evt)
 {
+	LOG_DBG("Await registered event handler: %d", evt);
 	switch (evt) {
 	case MODEM_HL78XX_EVENT_SCRIPT_SUCCESS:
 	case MODEM_HL78XX_EVENT_SCRIPT_FAILED:

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx.h
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx.h
@@ -1266,6 +1266,13 @@ int check_if_any_socket_connected(const struct device *dev);
 void hl78xx_start_timer(struct hl78xx_data *data, k_timeout_t timeout);
 
 /**
+ * @brief Reschedule a pending timeout work item.
+ * @param data pointer to hl78xx_data.
+ * @param timeout the time to wait before submitting the work item.
+ */
+void hl78xx_reschedule_timer(struct hl78xx_data *data, k_timeout_t timeout);
+
+/**
  * @brief Stop the timer.
  * @param data pointer to hl78xx_data.
  */

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_apis.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_apis.c
@@ -1587,19 +1587,35 @@ int hl78xx_gnss_set_search_timeout(const struct device *dev, uint32_t timeout_ms
 {
 	struct hl78xx_gnss_data *data_gnss = NULL;
 	struct hl78xx_data *data_modem = NULL;
+	enum hl78xx_gnss_search_state search_state;
 
 	if (hl78xx_get_gnss_context(dev, &data_gnss, &data_modem) < 0) {
 		return -EINVAL;
 	}
-	ARG_UNUSED(data_modem);
 
-	/* Don't allow changes while GNSS is active */
-	if (hl78xx_gnss_is_active(data_gnss)) {
-		LOG_WRN("Cannot change search timeout while GNSS is active");
-		return -EBUSY;
+	if (data_modem == NULL) {
+		return -EINVAL;
 	}
 
+	search_state = hl78xx_gnss_get_search_state(data_gnss);
 	data_gnss->search_timeout_ms = timeout_ms;
+	data_gnss->search_config.timeout_ms = timeout_ms;
+
+	if ((search_state != HL78XX_GNSS_SEARCH_STATE_SEARCHING) &&
+	    (search_state != HL78XX_GNSS_SEARCH_STATE_STARTING)) {
+		/* Not searching, no need to reschedule timer */
+		return 0;
+	}
+
+	if (timeout_ms == 0U) {
+		LOG_DBG("GNSS search timeout disabled while active");
+		hl78xx_stop_timer(data_modem);
+		return 0;
+	}
+
+	LOG_DBG("GNSS search timeout updated to %u ms while active", timeout_ms);
+	hl78xx_reschedule_timer(data_modem, K_MSEC(timeout_ms));
+
 	return 0;
 }
 

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss.c
@@ -1679,6 +1679,8 @@ int hl78xx_on_gnss_search_started_state_enter(struct hl78xx_data *data)
 
 int hl78xx_on_gnss_search_started_state_leave(struct hl78xx_data *data)
 {
+	hl78xx_stop_timer(data);
+
 	return 0;
 }
 
@@ -1705,6 +1707,12 @@ void hl78xx_gnss_search_started_event_handler(struct hl78xx_data *data, enum hl7
 		break;
 
 	case MODEM_HL78XX_EVENT_TIMEOUT:
+		if (data_gnss->search_state != HL78XX_GNSS_SEARCH_STATE_SEARCHING) {
+			LOG_DBG("GNSS search: ignoring timeout in state=%s",
+				gnss_search_state_str(data_gnss->search_state));
+			break;
+		}
+
 		LOG_WRN("GNSS search: timeout expired - stopping search");
 
 		/* Notify user about timeout */
@@ -1724,6 +1732,7 @@ void hl78xx_gnss_search_started_event_handler(struct hl78xx_data *data, enum hl7
 		break;
 	case MODEM_HL78XX_EVENT_GNSS_STOP_REQUESTED:
 		LOG_INF("GNSS search: stop requested %d", data_gnss->output_port);
+		hl78xx_stop_timer(data);
 		gnss_set_search_state(data_gnss, HL78XX_GNSS_SEARCH_STATE_STOPPING);
 		hl78xx_gnss_clear_search_queue(data_gnss);
 
@@ -1752,6 +1761,7 @@ void hl78xx_gnss_search_started_event_handler(struct hl78xx_data *data, enum hl7
 
 	case MODEM_HL78XX_EVENT_GNSS_STOPPED:
 		LOG_INF("GNSS search: stopped");
+		hl78xx_stop_timer(data);
 		gnss_set_search_state(data_gnss, HL78XX_GNSS_SEARCH_STATE_IDLE);
 		/* Check if GNSS mode exit was requested */
 		if (data_gnss->exit_to_lte_pending) {

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss.h
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_gnss.h
@@ -183,8 +183,8 @@ bool hl78xx_gnss_search_is_queued(struct hl78xx_gnss_data *gnss);
 /**
  * @brief Check if GNSS search is active or pending
  *
- * Returns true if GNSS is in any state other than IDLE, meaning configuration
- * changes should not be allowed.
+ * Returns true if GNSS is in any state other than IDLE, meaning a GNSS
+ * session is active or pending.
  */
 bool hl78xx_gnss_is_active(struct hl78xx_gnss_data *gnss);
 /**

--- a/include/zephyr/drivers/modem/hl78xx_apis.h
+++ b/include/zephyr/drivers/modem/hl78xx_apis.h
@@ -2107,9 +2107,13 @@ int hl78xx_gnss_set_nmea_output(const struct device *dev, enum nmea_output_port 
 /**
  * @brief Set GNSS search timeout
  *
+ * If a GNSS search is already active, the remaining timeout is replaced from
+ * the moment this function is called. Setting @p timeout_ms to 0 disables the
+ * active search timeout.
+ *
  * @param dev Pointer to the GNSS device
  * @param timeout_ms Timeout in milliseconds (0 = no timeout)
- * @return 0 on success, -EBUSY if GNSS search is active, negative errno on failure
+ * @return 0 on success, negative errno on failure
  */
 int hl78xx_gnss_set_search_timeout(const struct device *dev, uint32_t timeout_ms);
 


### PR DESCRIPTION
Allow hl78xx_gnss_set_search_timeout() to update the GNSS search timeout while a search is already in progress.

When GNSS is searching, a new timeout value now reschedules the active timeout work item. Setting the timeout to 0 disables the active search timeout. Additional timer cleanup is performed when leaving the search state and when GNSS stop events are received.

Briefly,the goal is to support adaptive timeout management without requiring the current GNSS session to be stopped and restarted.