### PR TITLE
Add GPTIMER counter support for TI MSPM0 L-series (LP-MSPM0L2228)

### DIFF
--- a/boards/ti/lp_mspm0l2228/lp_mspm0l2228.yaml
+++ b/boards/ti/lp_mspm0l2228/lp_mspm0l2228.yaml
@@ -14,4 +14,5 @@ supported:
   - uart
   - spi
   - vref
+  - counter
 vendor: ti

--- a/dts/arm/ti/mspm0/l/mspm0lx22x.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0lx22x.dtsi
@@ -26,6 +26,102 @@
 			reg = <0x4046a000 0x2000>;
 			status = "disabled";
 		};
+
+		timg0: timg0@40084000 {
+			compatible = "ti,mspm0-timer";
+			reg = <0x40084000 0x2000>;
+			clocks = <&ckm MSPM0_CLOCK_ULPCLK>;
+			interrupts = <21 0>;
+			ti,clk-prescaler = <255>;
+			ti,clk-div = <1>;
+			status = "disabled";
+
+			counterg0: counterg0 {
+				compatible = "ti,mspm0-timer-counter";
+				resolution = <16>;
+				status = "disabled";
+			};
+		};
+
+		timg4: timg4@4008c000 {
+			compatible = "ti,mspm0-timer";
+			reg = <0x4008c000 0x2000>;
+			clocks = <&ckm MSPM0_CLOCK_ULPCLK>;
+			interrupts = <22 0>;
+			ti,clk-prescaler = <255>;
+			ti,clk-div = <1>;
+			status = "disabled";
+
+			counterg4: counterg4 {
+				compatible = "ti,mspm0-timer-counter";
+				resolution = <16>;
+				status = "disabled";
+			};
+		};
+
+		timg5: timg5@4008e000 {
+			compatible = "ti,mspm0-timer";
+			reg = <0x4008e000 0x2000>;
+			clocks = <&ckm MSPM0_CLOCK_ULPCLK>;
+			interrupts = <23 0>;
+			ti,clk-prescaler = <255>;
+			ti,clk-div = <1>;
+			status = "disabled";
+
+			counterg5: counterg5 {
+				compatible = "ti,mspm0-timer-counter";
+				resolution = <16>;
+				status = "disabled";
+			};
+		};
+
+		timg8: timg8@40090000 {
+			compatible = "ti,mspm0-timer";
+			reg = <0x40090000 0x2000>;
+			clocks = <&ckm MSPM0_CLOCK_ULPCLK>;
+			interrupts = <20 0>;
+			ti,clk-prescaler = <255>;
+			ti,clk-div = <1>;
+			status = "disabled";
+
+			counterg8: counterg8 {
+				compatible = "ti,mspm0-timer-counter";
+				resolution = <16>;
+				status = "disabled";
+			};
+		};
+
+		timg12: timg12@40870000 {
+			compatible = "ti,mspm0-timer";
+			reg = <0x40870000 0x2000>;
+			clocks = <&ckm MSPM0_CLOCK_ULPCLK>;
+			interrupts = <2 0>;
+			ti,clk-prescaler = <0>; /* No prescaler */
+			ti,clk-div = <1>;
+			status = "disabled";
+
+			counterg12: counterg12 {
+				compatible = "ti,mspm0-timer-counter";
+				resolution = <32>;
+				status = "disabled";
+			};
+		};
+
+		tima0: tima0@40860000 {
+			compatible = "ti,mspm0-timer";
+			reg = <0x40860000 0x2000>;
+			clocks = <&ckm MSPM0_CLOCK_ULPCLK>;
+			interrupts = <18 0>;
+			ti,clk-prescaler = <255>;
+			ti,clk-div = <1>;
+			status = "disabled";
+
+			countera0: countera0 {
+				compatible = "ti,mspm0-timer-counter";
+				resolution = <16>;
+				status = "disabled";
+			};
+		};
 	};
 };
 

--- a/samples/drivers/counter/alarm/boards/lp_mspm0l2228.overlay
+++ b/samples/drivers/counter/alarm/boards/lp_mspm0l2228.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		counter = &counterg12;
+	};
+};
+
+&timg12 {
+	status = "okay";
+
+	counterg12: counterg12 {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/lp_mspm0l2228.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/lp_mspm0l2228.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Texas Instruments
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timg12 {
+	status = "okay";
+
+	counterg12: counterg12 {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -223,6 +223,9 @@ static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_XLNX_TTC
 	DEVS_FOR_DT_COMPAT(xlnx_ttc_counter)
 #endif
+#ifdef CONFIG_COUNTER_MSPM0_TIMER
+	DEVS_FOR_DT_COMPAT(ti_mspm0_timer_counter)
+#endif
 };
 
 static const struct device *const period_devs[] = {
@@ -1293,6 +1296,11 @@ static bool reliable_cancel_capable(const struct device *dev)
 #endif
 #ifdef CONFIG_COUNTER_XLNX_TTC
 	return true;
+#endif
+#ifdef CONFIG_COUNTER_MSPM0_TIMER
+	if (single_channel_alarm_capable(dev)) {
+		return true;
+	}
 #endif
 	return false;
 }


### PR DESCRIPTION
The MSPM0 L-series uses the same GPTIMER peripheral as the G-series but with a different timer topology: all timers reside on PD0 (ULPCLK), including TIMG12 and TIMA0 which are on PD1 (MCLK) in the G-series. 
This series adds timer and counter child nodes for the MSPM0L222x device family and enables counter support on the LP-MSPM0L2228 LaunchPad.

The MSPM0L222x family (L2228, L2227, L1228, L1227) provides six timer instances. All are clocked from ULPCLK on PD0 per datasheet (https://www.ti.com/product/MSPM0L2228)  Table 8-11:

  - TIMG0/4/5/8: 16-bit, 8-bit prescaler, 2 CC channels
  - TIMG12: 32-bit, no prescaler, 2 CC channels
  - TIMA0: 16-bit, advanced timer, 8-bit prescaler, 4 CC channels

  Hardware validation on LP-MSPM0L2228 using TIMG12

counter_basic_api: pass=6, fail=0, skip=4, total=10
counter alarm sample: working correctly (alarm fires at 2s, 4s, 8s... intervals)

The 4 skipped tests (test_late_alarm, test_late_alarm_error, test_multiple_alarms, test_short_relative_alarm) require guard period support and late alarm detection which are not present in the current driver. These will pass once #113204 (drivers: counter: ti: mspm0: Convert to native register access) merges, as shown by the full pass results on G-series hardware with the native driver.