### PR TITLE
babblesim bt host tests: Build and run with twister

### DIFF
--- a/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
@@ -12,7 +12,6 @@ export BOARD="${BOARD:-nrf5340bsim/nrf5340/cpuapp}"
 
 source ${ZEPHYR_BASE}/tests/bsim/compile.source
 
-${ZEPHYR_BASE}/tests/bsim/bluetooth/host/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/tester/compile.sh
 
 app=tests/bsim/bluetooth/ll/conn conf_file=prj_split_privacy.conf sysbuild=1  compile

--- a/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpunet.sh
+++ b/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpunet.sh
@@ -13,6 +13,5 @@ export BOARD="${BOARD:-nrf5340bsim/nrf5340/cpunet}"
 source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/ll/compile.sh
-${ZEPHYR_BASE}/tests/bsim/bluetooth/host/compile.sh
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/compile.sh
+++ b/tests/bsim/bluetooth/compile.sh
@@ -17,7 +17,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # the rest to save a couple of seconds.
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio_samples/compile.sh
-${ZEPHYR_BASE}/tests/bsim/bluetooth/host/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/ll/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/mesh/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh

--- a/tests/bsim/bluetooth/host/adv/chain/tests.yaml
+++ b/tests/bsim/bluetooth/host/adv/chain/tests.yaml
@@ -1,11 +1,12 @@
 tests:
   bluetooth.host.adv.chain:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_adv_chain_prj_conf

--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/tests.yaml
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.adv.encrypted.css_sample_data:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_adv_encrypted_css_sample_data_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/tests.yaml
+++ b/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.adv.encrypted.ead_sample:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_adv_encrypted_ead_sample_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/adv/extended/tests.yaml
+++ b/tests/bsim/bluetooth/host/adv/extended/tests.yaml
@@ -1,10 +1,13 @@
 common:
   tags:
     - bluetooth
+  depends_on: bsim
   platform_allow:
     - nrf52_bsim/native
     - nrf5340bsim/nrf5340/cpunet
   harness: bsim
+  harness_config:
+    fixture: bsim_multi_test
 
 tests:
   bluetooth.host.adv.extended.advertiser:
@@ -20,9 +23,6 @@ tests:
     extra_args:
       CONF_FILE=prj_scanner.conf
   bluetooth.host.adv.extended.test:
-    harness_config:
-      fixture:
-        - bsim_multi_test
     build: false
     required_applications:
       - application: bluetooth.host.adv.extended.advertiser

--- a/tests/bsim/bluetooth/host/adv/long_ad/tests.yaml
+++ b/tests/bsim/bluetooth/host/adv/long_ad/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.adv.long_ad:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_adv_long_ad_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/adv/periodic/tests.yaml
+++ b/tests/bsim/bluetooth/host/adv/periodic/tests.yaml
@@ -1,6 +1,7 @@
 common:
   tags:
     - bluetooth
+  depends_on: bsim
   platform_allow:
     - nrf52_bsim/native
     - nrf5340bsim/nrf5340/cpunet
@@ -11,22 +12,21 @@ tests:
     # nrf54l15bsim/nrf54l15/cpuapp not allowed as per_adv_conn_privacy.sh returns with
     # "The advertiser disconnects with reason 61 (BT_HCI_ERR_AUTH_FAIL)"
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_adv_periodic_prj_conf
-      fixture:
-        - bsim_multi_test
       tests_scripts:
         - tests_scripts/per_adv.sh
         - tests_scripts/per_adv_conn.sh
         - tests_scripts/per_adv_conn_privacy.sh
         - tests_scripts/per_adv_app_not_scanning.sh
         - tests_scripts/per_adv_unregister_sync_cb.sh
+        - tests_scripts/per_adv_update_did.sh
   bluetooth.host.adv.periodic.coded:
     platform_allow:
       - nrf54l15bsim/nrf54l15/cpuapp
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_adv_periodic_prj_coded_conf
-      fixture:
-        - bsim_multi_test
       tests_scripts:
         - tests_scripts/per_adv_app_not_scanning_coded.sh
     extra_args:
@@ -35,9 +35,8 @@ tests:
     platform_allow:
       - nrf54l15bsim/nrf54l15/cpuapp
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_adv_periodic_prj_long_data_conf
-      fixture:
-        - bsim_multi_test
       tests_scripts:
         - tests_scripts/per_adv_long_data.sh
     extra_args:

--- a/tests/bsim/bluetooth/host/att/eatt/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/eatt/tests.yaml
@@ -1,27 +1,42 @@
 common:
-  build_only: true
   tags:
     - bluetooth
+  depends_on: bsim
   platform_allow:
     - nrf52_bsim/native
   harness: bsim
 
 tests:
   bluetooth.host.att.eatt.autoconnect:
-    harness_config:
-      bsim_exe_name: tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf
     extra_args:
       EXTRA_CONF_FILE=prj_autoconnect.conf
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_host_att_eatt_prj_autoconnect_conf
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/autoconnect.sh
+        - tests_scripts/reconfigure.sh
   bluetooth.host.adt.eatt.collision:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_att_eatt_prj_collision_conf
+      tests_scripts:
+        - tests_scripts/collision.sh
   bluetooth.host.att.eatt.lowres:
-    harness_config:
-      bsim_exe_name: tests_bsim_bluetooth_host_att_eatt_prj_lowres_conf
     extra_args:
       EXTRA_CONF_FILE=prj_lowres.conf
-  bluetooth.host.att.eatt.multiple_conn:
     harness_config:
-      bsim_exe_name: tests_bsim_bluetooth_host_att_eatt_prj_multiple_conn_conf
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_host_att_eatt_prj_lowres_conf
+      tests_scripts:
+        - tests_scripts/lowres.sh
+    required_applications:
+      - application: bluetooth.host.att.eatt.autoconnect
+  bluetooth.host.att.eatt.multiple_conn:
     extra_args:
       EXTRA_CONF_FILE=prj_multiple_conn.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_host_att_eatt_prj_multiple_conn_conf
+      tests_scripts:
+        - tests_scripts/multiple_conn.sh

--- a/tests/bsim/bluetooth/host/att/eatt_notif/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/eatt_notif/tests.yaml
@@ -1,11 +1,14 @@
 tests:
   bluetooth.host.att.eatt_notif:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_att_eatt_notif_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/att/long_read/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/long_read/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.att.long_read:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_att_long_read_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/att/mtu_update/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/mtu_update/tests.yaml
@@ -1,19 +1,25 @@
 common:
-  build_only: true
   tags:
     - bluetooth
   platform_allow:
     - nrf52_bsim/native
+  depends_on: bsim
   harness: bsim
 
 tests:
   bluetooth.host.att.mtu_update.central:
+    build_only: true
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_att_mtu_update_prj_central_conf
     extra_args:
       CONF_FILE=prj_central.conf
   bluetooth.host.att.mtu_update.peripheral:
-    harness_config:
-      bsim_exe_name: tests_bsim_bluetooth_host_att_mtu_update_prj_peripheral_conf
     extra_args:
       CONF_FILE=prj_peripheral.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_host_att_mtu_update_prj_peripheral_conf
+      tests_scripts:
+        - test_scripts
+    required_applications:
+      - application: bluetooth.host.att.mtu_update.central

--- a/tests/bsim/bluetooth/host/att/open_close/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/open_close/tests.yaml
@@ -1,10 +1,14 @@
 tests:
   bluetooth.host.att.open_close:
-    build_only: true
+    timeout: 600
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_att_open_close_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/att/pipeline/dut/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/pipeline/dut/tests.yaml
@@ -1,4 +1,5 @@
 common:
+  timeout: 600
   build_only: true
   tags:
     - bluetooth

--- a/tests/bsim/bluetooth/host/att/pipeline/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/pipeline/tests.yaml
@@ -1,0 +1,20 @@
+tests:
+  bluetooth.host.att.pipeline:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    build: false
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts
+    required_applications:
+      - application: bluetooth.host.att.pipeline.dut
+        path: dut
+      - application: bluetooth.host.att.pipeline.dut_rx_tx_prio
+        path: dut
+      - application: bluetooth.host.att.pipeline.tester
+        path: tester

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/tests.yaml
@@ -1,0 +1,18 @@
+tests:
+  bluetooth.host.att.read_fill_buf:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    build: false
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts
+    required_applications:
+      - application: bluetooth.host.att.read_fill_buf.client
+        path: client
+      - application: bluetooth.host.att.read_fill_buf.server
+        path: server

--- a/tests/bsim/bluetooth/host/att/retry_on_sec_err/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/retry_on_sec_err/tests.yaml
@@ -1,0 +1,18 @@
+tests:
+  bluetooth.host.att.retry_on_sec_err:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    build: false
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts
+    required_applications:
+      - application: bluetooth.host.att.retry_on_sec_err.client
+        path: client
+      - application: bluetooth.host.att.retry_on_sec_err.server
+        path: server

--- a/tests/bsim/bluetooth/host/att/sequential/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/sequential/tests.yaml
@@ -1,0 +1,18 @@
+tests:
+  bluetooth.host.att.sequential:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    build: false
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts
+    required_applications:
+      - application: bluetooth.host.att.sequential.dut
+        path: dut
+      - application: bluetooth.host.att.sequential.tester
+        path: tester

--- a/tests/bsim/bluetooth/host/att/timeout/tests.yaml
+++ b/tests/bsim/bluetooth/host/att/timeout/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.att.timeout:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_att_timeout_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/central/tests.yaml
+++ b/tests/bsim/bluetooth/host/central/tests.yaml
@@ -1,11 +1,12 @@
 tests:
   bluetooth.host.central:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_central_prj_conf

--- a/tests/bsim/bluetooth/host/gatt/authorization/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/authorization/tests.yaml
@@ -1,11 +1,14 @@
 tests:
   bluetooth.host.gatt.authorization:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_authorization_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/gatt/caching/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/caching/tests.yaml
@@ -1,7 +1,8 @@
 common:
-  build_only: true
+  timeout: 600
   tags:
     - bluetooth
+  depends_on: bsim
   platform_allow:
     - nrf52_bsim/native
     - nrf5340bsim/nrf5340/cpunet
@@ -10,9 +11,20 @@ common:
 tests:
   bluetooth.host.gatt.caching:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_caching_prj_conf
+      tests_scripts:
+        - test_scripts/gatt_caching_db_hash_read_eatt.sh
+        - test_scripts/gatt_caching_retry_reads_no_eatt.sh
+        - test_scripts/gatt_caching_retry_reads_eatt.sh
+        - test_scripts/gatt_caching_db_hash_read_no_eatt.sh
+        - test_scripts/gatt_caching_out_of_sync_eatt.sh
+        - test_scripts/gatt_caching_out_of_sync_no_eatt.sh
   bluetooth.host.gatt.caching_psa_overlay:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_caching_prj_conf_psa_overlay_conf
+      tests_scripts:
+        - test_scripts/gatt_caching_psa_db_hash_read_eatt.sh
     extra_args:
       EXTRA_CONF_FILE=psa_overlay.conf

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/tests.yaml
@@ -1,7 +1,7 @@
 common:
-  build_only: true
   tags:
     - bluetooth
+  depends_on: bsim
   platform_allow:
     - nrf52_bsim/native
   harness: bsim
@@ -9,14 +9,23 @@ common:
 tests:
   bluetooth.host.gatt.ccc_store:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_ccc_store_prj_conf
+      tests_scripts:
+        - test_scripts/ccc_store.sh
   bluetooth.host.gatt.ccc_store_no_store_on_write:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_ccc_store_overlay-no_store_on_write_conf
+      tests_scripts:
+        - test_scripts/ccc_store_no_store_on_write.sh
     extra_args:
       EXTRA_CONF_FILE=overlay-no_store_on_write.conf
   bluetooth.host.gatt.ccc_store_no_long_wq:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_ccc_store_overlay-no_long_wq_conf
+      tests_scripts:
+        - test_scripts/ccc_store_no_long_wq.sh
     extra_args:
       EXTRA_CONF_FILE=overlay-no_long_wq.conf

--- a/tests/bsim/bluetooth/host/gatt/device_name/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/device_name/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.gatt.device_name:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_device_name_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/gatt/general/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/general/tests.yaml
@@ -1,11 +1,14 @@
 tests:
   bluetooth.host.gatt.general:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_general_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/gatt/notify/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/notify/tests.yaml
@@ -1,10 +1,14 @@
 tests:
   bluetooth.host.gatt.notify:
-    build_only: true
+    timeout: 600
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_notify_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.gatt.notify_multiple:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_notify_multiple_prj_conf
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/gatt/notify_stress/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/notify_stress/tests.yaml
@@ -1,12 +1,16 @@
 tests:
   bluetooth.host.gatt.notify_stress:
-    build_only: true
+    timeout: 600
     sysbuild: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpuapp
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_notify_stress_prj_conf
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/tests.yaml
@@ -1,21 +1,23 @@
+common:
+  tags:
+    - bluetooth
+  depends_on: bsim
+  platform_allow:
+    - nrf52_bsim/native
+  harness: bsim
+
 tests:
   bluetooth.host.gatt.sc_indicate:
-    build_only: true
-    tags:
-      - bluetooth
-    platform_allow:
-      - nrf52_bsim/native
-    harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_sc_indicate_prj_conf
+      tests_scripts:
+        - test_scripts/sc_indicate.sh
   bluetooth.host.gatt.sc_indicate_privacy:
-    build_only: true
-    tags:
-      - bluetooth
-    platform_allow:
-      - nrf52_bsim/native
-    harness: bsim
     extra_args:
       - EXTRA_CONF_FILE=overlay-privacy.conf
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_sc_indicate_overlay-privacy_conf
+      tests_scripts:
+        - test_scripts/sc_indicate_privacy.sh

--- a/tests/bsim/bluetooth/host/gatt/settings/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/settings/tests.yaml
@@ -1,7 +1,8 @@
 common:
-  build_only: true
+  timeout: 600
   tags:
     - bluetooth
+  depends_on: bsim
   platform_allow:
     - nrf52_bsim/native
   harness: bsim
@@ -9,9 +10,15 @@ common:
 tests:
   bluetooth.host.gatt.settings:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_settings_prj_conf
+      tests_scripts:
+        - test_scripts/run_gatt_settings.sh
   bluetooth.host.gatt.settings_priv:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_settings_overlay-privacy_conf
+      tests_scripts:
+        - test_scripts/run_gatt_settings_privacy.sh
     extra_args:
       EXTRA_CONF_FILE=overlay-privacy.conf

--- a/tests/bsim/bluetooth/host/gatt/settings_clear/tests.yaml
+++ b/tests/bsim/bluetooth/host/gatt/settings_clear/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.gatt.settings_clear:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_gatt_settings_clear_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/id/settings/tests.yaml
+++ b/tests/bsim/bluetooth/host/id/settings/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.id.settings:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_id_settings_prj_conf
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/iso/bis/tests.yaml
+++ b/tests/bsim/bluetooth/host/iso/bis/tests.yaml
@@ -1,9 +1,11 @@
 common:
-  build_only: true
+  timeout: 600
   tags:
     - bluetooth
+  depends_on: bsim
   harness: bsim
   harness_config:
+    fixture: bsim_multi_test
     bsim_exe_name: tests_bsim_bluetooth_host_iso_bis_prj_conf
 
 tests:
@@ -16,3 +18,8 @@ tests:
     sysbuild: true
     platform_allow:
       - nrf5340bsim/nrf5340/cpuapp
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_host_iso_bis_prj_conf
+      tests_scripts:
+        - tests_scripts/bis.sh

--- a/tests/bsim/bluetooth/host/iso/cis/tests.yaml
+++ b/tests/bsim/bluetooth/host/iso/cis/tests.yaml
@@ -1,11 +1,12 @@
 tests:
   bluetooth.host.iso.cis:
+    timeout: 600
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_iso_cis_prj_conf
-      fixture:
-        - bsim_multi_test
+      fixture: bsim_multi_test

--- a/tests/bsim/bluetooth/host/iso/frag/tests.yaml
+++ b/tests/bsim/bluetooth/host/iso/frag/tests.yaml
@@ -1,10 +1,11 @@
 tests:
   bluetooth.host.iso.frag:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_iso_frag_prj_conf

--- a/tests/bsim/bluetooth/host/iso/frag_2/tests.yaml
+++ b/tests/bsim/bluetooth/host/iso/frag_2/tests.yaml
@@ -1,10 +1,11 @@
 tests:
   bluetooth.host.iso.frag_2:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_iso_frag_2_prj_conf

--- a/tests/bsim/bluetooth/host/l2cap/credits/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/credits/tests.yaml
@@ -1,7 +1,7 @@
 common:
-  build_only: true
   tags:
     - bluetooth
+  depends_on: bsim
   platform_allow:
     - nrf52_bsim/native
   harness: bsim
@@ -9,8 +9,14 @@ common:
 tests:
   bluetooth.host.l2cap.credits:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_credits_prj_conf
+      tests_scripts:
+        - tests_scripts/l2cap_credits.sh
   bluetooth.host.l2cap.credits_ecred:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_credits_prj_conf_overlay-ecred_conf
+      tests_scripts:
+        - tests_scripts/l2cap_credits_ecred.sh
     extra_args: EXTRA_CONF_FILE="overlay-ecred.conf"

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/tests.yaml
@@ -1,7 +1,7 @@
 common:
-  build_only: true
   tags:
     - bluetooth
+  depends_on: bsim
   platform_allow:
     - nrf52_bsim/native
   harness: bsim
@@ -9,8 +9,14 @@ common:
 tests:
   bluetooth.host.l2cap.credits_seg_recv:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_credits_seg_recv_prj_conf
+      tests_scripts:
+        - tests_scripts/l2cap_credits_seg_recv.sh
   bluetooth.host.l2cap.credits_seg_recv_ecred:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_credits_seg_recv_prj_conf_overlay-ecred_conf
+      tests_scripts:
+        - tests_scripts/l2cap_credits_seg_recv_ecred.sh
     extra_args: EXTRA_CONF_FILE="overlay-ecred.conf"

--- a/tests/bsim/bluetooth/host/l2cap/ecred/dut/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/ecred/dut/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim

--- a/tests/bsim/bluetooth/host/l2cap/ecred/peer/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/ecred/peer/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim

--- a/tests/bsim/bluetooth/host/l2cap/ecred/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/ecred/tests.yaml
@@ -1,0 +1,18 @@
+tests:
+  bluetooth.host.l2cap.ecred:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    build: false
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts
+    required_applications:
+      - application: bluetooth.host.l2cap.ecred.dut
+        path: dut
+      - application: bluetooth.host.l2cap.ecred.peer
+        path: peer

--- a/tests/bsim/bluetooth/host/l2cap/einprogress/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/einprogress/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.l2cap.einprogress:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_einprogress_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/l2cap/general/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/general/tests.yaml
@@ -1,10 +1,12 @@
 tests:
   bluetooth.host.l2cap.general:
-    build_only: true
+    timeout: 600
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_general_prj_conf

--- a/tests/bsim/bluetooth/host/l2cap/many_conns/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/many_conns/tests.yaml
@@ -1,10 +1,11 @@
 tests:
   bluetooth.host.l2cap.many_conns:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_many_conns_prj_conf

--- a/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.l2cap.multilink_peripheral:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_multilink_peripheral_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/dut/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/dut/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/peer/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/peer/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/tests.yaml
@@ -1,0 +1,18 @@
+tests:
+  bluetooth.host.l2cap.reassembly:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    build: false
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts
+    required_applications:
+      - application: bluetooth.host.l2cap.reassembly.dut
+        path: dut
+      - application: bluetooth.host.l2cap.reassembly.peer
+        path: peer

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/tests.yaml
@@ -1,7 +1,7 @@
 common:
-  build_only: true
   tags:
     - bluetooth
+  depends_on: bsim
   platform_allow:
     - nrf52_bsim/native
     - nrf5340bsim/nrf5340/cpunet
@@ -10,9 +10,17 @@ common:
 tests:
   bluetooth.host.l2cap.send_on_connect:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_send_on_connect_prj_conf
+      tests_scripts:
+        - tests_scripts/send_on_connect_fixed.sh
   bluetooth.host.l2cap.send_on_connect_ecred:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_send_on_connect_prj_conf_overlay-ecred_conf
+      tests_scripts:
+        - tests_scripts/send_on_connect_dynamic.sh
+    required_applications:
+      - application: bluetooth.host.l2cap.send_on_connect
     extra_args:
       EXTRA_CONF_FILE=overlay-ecred.conf

--- a/tests/bsim/bluetooth/host/l2cap/split/dut/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/split/dut/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim

--- a/tests/bsim/bluetooth/host/l2cap/split/tester/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/split/tester/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim

--- a/tests/bsim/bluetooth/host/l2cap/split/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/split/tests.yaml
@@ -1,0 +1,18 @@
+tests:
+  bluetooth.host.l2cap.split:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    build: false
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts
+    required_applications:
+      - application: bluetooth.host.l2cap.split.dut
+        path: dut
+      - application: bluetooth.host.l2cap.split.tester
+        path: tester

--- a/tests/bsim/bluetooth/host/l2cap/stress/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/stress/tests.yaml
@@ -1,7 +1,8 @@
 common:
-  build_only: true
+  timeout: 600
   tags:
     - bluetooth
+  depends_on: bsim
   platform_allow:
     - nrf52_bsim/native
   harness: bsim
@@ -9,16 +10,28 @@ common:
 tests:
   bluetooth.host.l2cap.stress:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_stress_prj_conf
+      tests_scripts:
+        - tests_scripts/l2cap.sh
   bluetooth.host.l2cap.stress_early_disconnect:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_stress_prj_conf_overlay-early-disc_conf
+      tests_scripts:
+        - tests_scripts/l2cap_early_disconnect.sh
     extra_args: EXTRA_CONF_FILE="overlay-early-disconnect.conf"
   bluetooth.host.l2cap.stress_nofrag:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_stress_prj_conf_overlay-nofrag_conf
+      tests_scripts:
+        - tests_scripts/l2cap_nofrag.sh
     extra_args: EXTRA_CONF_FILE="overlay-nofrag.conf"
   bluetooth.host.l2cap.stress_syswq:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_stress_prj_conf_overlay-syswq_conf
+      tests_scripts:
+        - tests_scripts/l2cap_syswq.sh
     extra_args: EXTRA_CONF_FILE="overlay-syswq.conf"

--- a/tests/bsim/bluetooth/host/l2cap/userdata/tests.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/tests.yaml
@@ -1,10 +1,11 @@
 tests:
   bluetooth.host.l2cap.userdata:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_l2cap_userdata_prj_conf

--- a/tests/bsim/bluetooth/host/misc/acl_tx_frag/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/acl_tx_frag/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.mics.acl_tx_frag:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_misc_acl_tx_frag_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/misc/conn_param_update_reject/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/conn_param_update_reject/tests.yaml
@@ -1,11 +1,12 @@
 tests:
   bluetooth.host.misc.conn_param_update_reject:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_misc_conn_param_update_reject_prj_conf

--- a/tests/bsim/bluetooth/host/misc/conn_stress/central/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/central/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim

--- a/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim

--- a/tests/bsim/bluetooth/host/misc/conn_stress/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/tests.yaml
@@ -1,0 +1,19 @@
+tests:
+  bluetooth.host.misc.conn_stress:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    timeout: 600
+    build: false
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - scripts
+    required_applications:
+      - application: bluetooth.host.misc.conn_stress.peripheral
+        path: peripheral
+      - application: bluetooth.host.misc.conn_stress.central
+        path: central

--- a/tests/bsim/bluetooth/host/misc/disable/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/disable/tests.yaml
@@ -1,11 +1,13 @@
 tests:
   bluetooth.host.mics.disable:
-    build_only: true
+    timeout: 600
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_misc_disable_prj_conf

--- a/tests/bsim/bluetooth/host/misc/disconnect/dut/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/disconnect/dut/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim

--- a/tests/bsim/bluetooth/host/misc/disconnect/tester/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/disconnect/tester/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim

--- a/tests/bsim/bluetooth/host/misc/disconnect/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/disconnect/tests.yaml
@@ -1,0 +1,18 @@
+tests:
+  bluetooth.host.misc.disconnect:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    build: false
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts
+    required_applications:
+      - application: bluetooth.host.misc.disconnect.dut
+        path: dut
+      - application: bluetooth.host.misc.disconnect.tester
+        path: peer

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/dut/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/dut/tests.yaml
@@ -4,6 +4,7 @@ tests:
     sysbuild: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpuapp

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/tests.yaml
@@ -4,6 +4,7 @@ tests:
     sysbuild: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpuapp

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/tests.yaml
@@ -1,16 +1,19 @@
 tests:
-  bluetooth.host.mics.hfc:
-    timeout: 600
-    sysbuild: true
+  bluetooth.host.misc.hfc_multilink:
     tags:
       - bluetooth
     depends_on: bsim
+    build: false
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpuapp
     harness: bsim
     harness_config:
       fixture: bsim_multi_test
-      bsim_exe_name: tests_bsim_bluetooth_host_misc_hfc_prj_conf
       tests_scripts:
         - test_scripts
+    required_applications:
+      - application: bluetooth.host.misc.hfc_multilink.dut
+        path: dut
+      - application: bluetooth.host.misc.hfc_multilink.tester
+        path: tester

--- a/tests/bsim/bluetooth/host/misc/sample_test/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/sample_test/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.mics.sample_test:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_misc_sample_test_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/misc/unregister_conn_cb/tests.yaml
+++ b/tests/bsim/bluetooth/host/misc/unregister_conn_cb/tests.yaml
@@ -1,11 +1,12 @@
 tests:
   bluetooth.host.mics.unregister_conn_cb:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_misc_unregister_conn_cb_prj_conf

--- a/tests/bsim/bluetooth/host/privacy/central/tests.yaml
+++ b/tests/bsim/bluetooth/host/privacy/central/tests.yaml
@@ -1,11 +1,15 @@
 tests:
   bluetooth.host.privacy.central:
-    build_only: true
+    timeout: 600
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_privacy_central_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/privacy/device/tests.yaml
+++ b/tests/bsim/bluetooth/host/privacy/device/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.privacy.device:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_privacy_device_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/privacy/legacy/tests.yaml
+++ b/tests/bsim/bluetooth/host/privacy/legacy/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.privacy.legacy:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_privacy_legacy_prj_conf
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/privacy/peripheral/tests.yaml
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/tests.yaml
@@ -1,8 +1,9 @@
 common:
-  build_only: true
+  timeout: 600
   sysbuild: true
   tags:
     - bluetooth
+  depends_on: bsim
   platform_allow:
     - nrf52_bsim/native
     - nrf5340bsim/nrf5340/cpuapp
@@ -11,19 +12,31 @@ common:
 tests:
   bluetooth.host.privacy.peripheral:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_privacy_peripheral_prj_conf
+      tests_scripts:
+        - test_scripts/run_test.sh
   bluetooth.host.privacy.peripheral_no_snprintk:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_privacy_peripheral_prj_no_snprintk_conf
+      tests_scripts:
+        - test_scripts/run_test_no_snprintk.sh
     extra_args:
       EXTRA_CONF_FILE=prj_no_snprintk.conf
   bluetooth.host.privacy.peripheral_rpa_expired:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_privacy_peripheral_prj_rpa_expired_conf
+      tests_scripts:
+        - test_scripts/run_test_rpa_expired.sh
     extra_args:
       EXTRA_CONF_FILE=prj_rpa_expired.conf
   bluetooth.host.privacy.peripheral_rpa_sharing:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_privacy_peripheral_prj_rpa_sharing_conf
+      tests_scripts:
+        - test_scripts/run_test_rpa_sharing.sh
     extra_args:
       EXTRA_CONF_FILE=prj_rpa_sharing.conf

--- a/tests/bsim/bluetooth/host/scan/slow/tests.yaml
+++ b/tests/bsim/bluetooth/host/scan/slow/tests.yaml
@@ -1,8 +1,9 @@
 common:
-  build_only: true
+  timeout: 600
   sysbuild: true
   tags:
     - bluetooth
+  depends_on: bsim
   platform_allow:
     - nrf52_bsim/native
     - nrf5340bsim/nrf5340/cpuapp
@@ -11,4 +12,7 @@ common:
 tests:
   bluetooth.host.scan.slow:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_scan_slow_prj_conf
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/scan/start_stop/tests.yaml
+++ b/tests/bsim/bluetooth/host/scan/start_stop/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.scan.start_stop:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_scan_start_stop_prj_conf
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.security.bond_overwrite_allowed:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_security_bond_overwrite_allowed_prj_conf
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.security.bond_overwrite_denied:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_security_bond_overwrite_denied_prj_conf
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.security.bond_per_connection:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_security_bond_per_connection_prj_conf
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/host/security/ccc_update/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/ccc_update/tests.yaml
@@ -1,7 +1,7 @@
 common:
-  build_only: true
   tags:
     - bluetooth
+  depends_on: bsim
   platform_allow:
     - nrf52_bsim/native
   harness: bsim
@@ -9,14 +9,23 @@ common:
 tests:
   bluetooth.host.security.ccc_update:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_security_ccc_update_prj_conf
+      tests_scripts:
+        - test_scripts/ccc_update.sh
   bluetooth.host.security.ccc_update_no_lazy_load:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_security_ccc_update_overlay-no_lazy_load_conf
+      tests_scripts:
+        - test_scripts/ccc_update_no_lazy_load.sh
     extra_args:
       EXTRA_CONF_FILE=overlay-no_lazy_load.conf
   bluetooth.host.security.ccc_update_no_long_wq:
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_host_security_ccc_update_overlay-no_long_wq_conf
+      tests_scripts:
+        - test_scripts/ccc_update_no_long_wq.sh
     extra_args:
       EXTRA_CONF_FILE=overlay-no_long_wq.conf

--- a/tests/bsim/bluetooth/host/security/id_addr_update/central/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/central/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim

--- a/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/tests.yaml
@@ -3,6 +3,7 @@ tests:
     build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim

--- a/tests/bsim/bluetooth/host/security/id_addr_update/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/tests.yaml
@@ -1,0 +1,18 @@
+tests:
+  bluetooth.host.security.id_addr_update:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    build: false
+    platform_allow:
+      - nrf52_bsim/native
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts
+    required_applications:
+      - application: bluetooth.host.security.id_addr_update.central
+        path: central
+      - application: bluetooth.host.security.id_addr_update.peripheral
+        path: peripheral

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/tests.yaml
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/tests.yaml
@@ -1,10 +1,13 @@
 tests:
   bluetooth.host.security.security_changed_callback:
-    build_only: true
     tags:
       - bluetooth
+    depends_on: bsim
     platform_allow:
       - nrf52_bsim/native
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_security_security_changed_callback_prj_conf
+      fixture: bsim_multi_test
+      tests_scripts:
+        - test_scripts

--- a/tests/bsim/bluetooth/tests.nrf52bsim.txt
+++ b/tests/bsim/bluetooth/tests.nrf52bsim.txt
@@ -1,3 +1,10 @@
 # Search paths(s) for tests which will be run in the nrf52bsim
 # This file is used in CI to select which tests are run
-tests/bsim/bluetooth/
+tests/bsim/bluetooth/audio/
+tests/bsim/bluetooth/audio_samples/
+tests/bsim/bluetooth/hci_uart/
+tests/bsim/bluetooth/host/
+tests/bsim/bluetooth/ll/
+tests/bsim/bluetooth/mesh/
+tests/bsim/bluetooth/samples/
+tests/bsim/bluetooth/tester/

--- a/tests/bsim/bluetooth/tests.nrf52bsim.txt
+++ b/tests/bsim/bluetooth/tests.nrf52bsim.txt
@@ -3,7 +3,6 @@
 tests/bsim/bluetooth/audio/
 tests/bsim/bluetooth/audio_samples/
 tests/bsim/bluetooth/hci_uart/
-tests/bsim/bluetooth/host/
 tests/bsim/bluetooth/ll/
 tests/bsim/bluetooth/mesh/
 tests/bsim/bluetooth/samples/

--- a/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
@@ -10,9 +10,4 @@ tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
 tests/bsim/bluetooth/samples/peripheral_gap_svc/
 tests/bsim/bluetooth/audio_samples/
 tests/bsim/bluetooth/audio/
-tests/bsim/bluetooth/host/gatt/notify_stress/
-tests/bsim/bluetooth/host/iso/bis/tests_scripts/bis.sh
-tests/bsim/bluetooth/host/misc/hfc/
-tests/bsim/bluetooth/host/misc/hfc_multilink/
-tests/bsim/bluetooth/host/privacy/peripheral
 tests/bsim/bluetooth/tester/

--- a/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpunet.txt
+++ b/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpunet.txt
@@ -2,15 +2,3 @@
 # built in the net core)
 # This file is used in CI to select which tests are run
 tests/bsim/bluetooth/ll/
-tests/bsim/bluetooth/host/att/eatt_notif
-tests/bsim/bluetooth/host/misc/disable
-tests/bsim/bluetooth/host/misc/unregister_conn_cb
-tests/bsim/bluetooth/host/adv/periodic
-tests/bsim/bluetooth/host/adv/extended
-tests/bsim/bluetooth/host/adv/chain
-tests/bsim/bluetooth/host/l2cap/send_on_connect
-tests/bsim/bluetooth/host/central
-tests/bsim/bluetooth/host/privacy/central
-tests/bsim/bluetooth/host/gatt/authorization
-tests/bsim/bluetooth/host/gatt/general
-tests/bsim/bluetooth/host/gatt/caching

--- a/tests/bsim/ci.bt.sh
+++ b/tests/bsim/ci.bt.sh
@@ -11,6 +11,10 @@ cd ${ZEPHYR_BASE}
 
 set -uex
 
+TWISTER_OPTIONS="-vv --fixture bsim_multi_test --no-clean --force-color --inline-logs"
+
+${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/host/
+
 # nrf52_bsim set:
 nice tests/bsim/bluetooth/compile.sh
 


### PR DESCRIPTION
For background and motivation see https://github.com/zephyrproject-rtos/zephyr/pull/113101

This PR changes the BT host bsim tests to be both built and *run* using twister.
This means that users which have Babblesim installed can run these tests with twister in a quite comparable way to single device test. For example:
`twister -T tests/bsim/bluetooth/host/ -vv --fixture bsim_multi_test`

* There is one commit per tests/bsim/bluetooth/host folder  modifying the yaml files so
  * they also can run the tests
  * set appropriately `tests_scripts` where needed
  * set any `required_applications`
  * and ensure all have a `depends_on: bsim` and `fixture: bsim_multi_test`
  * And were needed the twister timeout is set to 600s (instead of 60s) (note this timeout applies to the collection of .sh scripts, not just each..)
* The last commit switches how the BT hosts are run in the script invoked from CI: Instead of with the old .sh scripts by just calling twister.

Note these tests can still be run with run_parallel.sh as before. Just now the default test list used by CI does not include them.