### PR TITLE
dts: arm: silabs: Fix Series 0/1 LF clock frequency

### DIFF
--- a/dts/arm/silabs/efm32hg.dtsi
+++ b/dts/arm/silabs/efm32hg.dtsi
@@ -28,14 +28,14 @@
 		clk_lfxo: clk-lfxo {
 			compatible = "silabs,series0-lfxo";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 
 		clk_lfrco: clk-lfrco {
 			compatible = "silabs,series0-lfrco";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 

--- a/dts/arm/silabs/efm32tg.dtsi
+++ b/dts/arm/silabs/efm32tg.dtsi
@@ -34,14 +34,14 @@
 		clk_lfxo: clk-lfxo {
 			compatible = "silabs,series0-lfxo";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 
 		clk_lfrco: clk-lfrco {
 			compatible = "silabs,series0-lfrco";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -28,14 +28,14 @@
 		clk_lfxo: clk-lfxo {
 			compatible = "silabs,series0-lfxo";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 
 		clk_lfrco: clk-lfrco {
 			compatible = "silabs,series0-lfrco";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 

--- a/dts/arm/silabs/gg11/efm32gg11.dtsi
+++ b/dts/arm/silabs/gg11/efm32gg11.dtsi
@@ -34,14 +34,14 @@
 		clk_lfxo: clk-lfxo {
 			compatible = "silabs,series0-lfxo";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 
 		clk_lfrco: clk-lfrco {
 			compatible = "silabs,series0-lfrco";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 

--- a/dts/arm/silabs/gg12/efm32gg12.dtsi
+++ b/dts/arm/silabs/gg12/efm32gg12.dtsi
@@ -33,14 +33,14 @@
 		clk_lfxo: clk-lfxo {
 			compatible = "silabs,series0-lfxo";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 
 		clk_lfrco: clk-lfrco {
 			compatible = "silabs,series0-lfrco";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 

--- a/dts/arm/silabs/xg1/xg1.dtsi
+++ b/dts/arm/silabs/xg1/xg1.dtsi
@@ -29,14 +29,14 @@
 		clk_lfxo: clk-lfxo {
 			compatible = "silabs,series0-lfxo";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 
 		clk_lfrco: clk-lfrco {
 			compatible = "silabs,series0-lfrco";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 

--- a/dts/arm/silabs/xg12/xg12.dtsi
+++ b/dts/arm/silabs/xg12/xg12.dtsi
@@ -35,14 +35,14 @@
 		clk_lfxo: clk-lfxo {
 			compatible = "silabs,series0-lfxo";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 
 		clk_lfrco: clk-lfrco {
 			compatible = "silabs,series0-lfrco";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 

--- a/dts/arm/silabs/xg13/efr32xg13.dtsi
+++ b/dts/arm/silabs/xg13/efr32xg13.dtsi
@@ -49,14 +49,14 @@
 		clk_lfxo: clk-lfxo {
 			compatible = "silabs,series0-lfxo";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 
 		clk_lfrco: clk-lfrco {
 			compatible = "silabs,series0-lfrco";
 			#clock-cells = <0>;
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Series 0 and 1 have 32768 Hz low-frequency oscillators, while DT_FREQ_K(32) is 32000 Hz.

The HAL hard-codes the known oscillator frequency, while Zephyr uses the Devicetree value. This misconfiguration led to a hang in kernel timer init when using LFXO as it computed `32000/32768=0` and divided by zero.