### PR TITLE
scripts: do not install/recommend vulnerable python packages

### DIFF
--- a/scripts/requirements-actions.in
+++ b/scripts/requirements-actions.in
@@ -7,7 +7,7 @@ elasticsearch<9
 exceptiongroup>=1.0.0rc8
 gcovr==6.0
 gitlint-core>=0.19.1
-gitpython>=3.1.41
+gitpython>=3.1.50
 ijson
 intelhex
 jsonschema

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -21,7 +21,7 @@ patool>=2.0.0
 psutil>=5.6.6
 pylink-square
 pyserial
-requests>=2.32.4
+requests>=2.33.0
 semver
 tqdm>=4.67.1
 reuse>=6.0.0

--- a/scripts/requirements-build-test.txt
+++ b/scripts/requirements-build-test.txt
@@ -14,10 +14,10 @@ gcovr>=6.0
 coverage
 
 # used for west-command testing
-pytest
+pytest>=9.0.3
 mypy
 
 # used for JUnit XML parsing in CTest harness
 junitparser>=3.0.0
 
-python-dotenv
+python-dotenv>=1.2.2

--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -9,7 +9,7 @@ junitparser>=4.0.1
 lxml>=6.1.0
 pykwalify
 pylint>=3
-python-dotenv
+python-dotenv>=1.2.2
 python-magic-bin; sys_platform == "win32"
 python-magic; sys_platform != "win32"
 reuse

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -4,7 +4,7 @@
 anytree
 
 # to use in ./scripts for memory footprint, code coverage, etc.
-gitpython>=3.1.41
+gitpython>=3.1.50
 
 # used by scripts/footprint/plot.py for generating plots of size reports
 plotly
@@ -22,7 +22,7 @@ lpc_checksum
 spsdk >= 3.0.0
 
 # used by scripts/build/gen_cfb_font_header.py - helper script for user
-Pillow>=10.3.0
+Pillow>=12.2.0
 
 # used by scripts/release/bug_bash.py for generating top ten bug squashers
 PyGithub

--- a/tests/kernel/timer/timer_behavior/pytest/requirements-saleae.txt
+++ b/tests/kernel/timer/timer_behavior/pytest/requirements-saleae.txt
@@ -1,4 +1,4 @@
 numpy>=2.2.3
-protobuf>=5.29.5
+protobuf>=5.29.6
 grpcio-tools>=1.66.0
 logic2-automation>=1.0.7


### PR DESCRIPTION
As flagged by https://scorecard.dev/viewer/?uri=github.com/zephyrproject-rtos/zephyr

- requests < 2.33.0 is subject to GHSA-gc5v-m9x4-r6x2
- gitpython < 3.1.47 is subject to GHSA-rpm5-65cw-6hj4
- gitpython < 3.1.47 is subject to GHSA-x2qx-6953-8485
- gitpython < 3.1.48 is subject to GHSA-7545-fcxq-7j24
- gitpython < 3.1.49 is subject to GHSA-v87r-6q3f-2j67
- gitpython < 3.1.50 is subject to GHSA-mv93-w799-cj2w
- Pillow < 12.1.1 is subject to GHSA-cfh3-3jmp-rvhc
- Pillow < 12.2.0 is subject to GHSA-pwv6-vv43-88gr
- Pillow < 12.2.0 is subject to GHSA-r73j-pqj5-w3x7
- Pillow < 12.2.0 is subject to GHSA-whj4-6x5x-4v2j
- Pillow < 12.2.0 is subject to GHSA-wjx4-4jcj-g98j
- protobuf < 5.29.6 is subject to GHSA-7gcm-g887-7qv7
- pytest < 9.0.3 is subject to GHSA-6w46-j5rx-g56g
- python-dotenv < 1.2.2 is subject to GHSA-mf9w-mj56-hr94

pytest and python-dotenv had no minimum version, which OSV-based
scanners treat as being subject to every advisory for the package.
