### PR TITLE
drivers: usb: uhc_dwc2: fix warning on 64-bit platforms

### DIFF
--- a/drivers/usb/uhc/uhc_dwc2.c
+++ b/drivers/usb/uhc/uhc_dwc2.c
@@ -635,14 +635,14 @@ static inline void ch_process_control(struct uhc_dwc2_channel *ch)
 			if (next_dir_is_in) {
 				size = sys_le16_to_cpu(setup->wLength);
 
-				LOG_DBG("Control DATA IN prog=%u, tailroom=%u",
+				LOG_DBG("Control DATA IN prog=%u, tailroom=%zu",
 					size, net_buf_tailroom(xfer->buf));
 
 				dma_addr = net_buf_tail(xfer->buf);
 			} else {
 				size = xfer->buf->len;
 
-				LOG_DBG("Control DATA OUT len=%u, tailroom=%u",
+				LOG_DBG("Control DATA OUT len=%u, tailroom=%zu",
 					xfer->buf->len, net_buf_tailroom(xfer->buf));
 
 				LOG_HEXDUMP_DBG(xfer->buf->data, xfer->buf->len,
@@ -660,7 +660,7 @@ static inline void ch_process_control(struct uhc_dwc2_channel *ch)
 		if (usb_reqtype_is_to_host(setup)) {
 			net_buf_add(xfer->buf, actual_len);
 
-			LOG_DBG("Control DATA IN completed, prog=%u, rem=%u, act=%u, tailroom=%u",
+			LOG_DBG("Control DATA IN completed, prog=%u, rem=%u, act=%u, tailroom=%zu",
 				ch->length,
 				remaining,
 				actual_len,
@@ -1329,7 +1329,7 @@ static int validate_control_xfer(const struct uhc_transfer *xfer)
 		/* Transfer has DATA IN step, so the buffer size should be enough */
 		if ((xfer->buf != NULL) &&
 		     wLength > net_buf_tailroom(xfer->buf)) {
-			LOG_ERR("Control IN buffer is too small: wLength=%u tailroom=%u",
+			LOG_ERR("Control IN buffer is too small: wLength=%u tailroom=%zu",
 			wLength, net_buf_tailroom(xfer->buf));
 			return -EINVAL;
 		}


### PR DESCRIPTION
Use the `%zu` format specifier when printing `size_t` values instead of `%u`. On 64-bit platforms, using an incorrect format specifier is causing compiler warnings due to type mismatches.

```
In file included from /home/walidbadar/workspace/zephyrproject/zephyr/include/zephyr/logging/log.h:11,
                 from /home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c:16:
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c: In function 'ch_process_control':
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c:591:41: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
  591 |                                 LOG_DBG("Control DATA IN prog=%u, tailroom=%u",
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  592 |                                         size, net_buf_tailroom(xfer->buf));
      |                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                               |
      |                                               size_t {aka long unsigned int}
/home/walidbadar/workspace/zephyrproject/zephyr/include/zephyr/logging/log_core.h:336:50: note: in definition of macro 'Z_LOG2'
  336 |                         z_log_printf_arg_checker(__VA_ARGS__);                                     \
      |                                                  ^~~~~~~~~~~
/home/walidbadar/workspace/zephyrproject/zephyr/include/zephyr/logging/log.h:93:22: note: in expansion of macro 'Z_LOG'
   93 | #define LOG_DBG(...) Z_LOG(LOG_LEVEL_DBG, __VA_ARGS__)
      |                      ^~~~~
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c:591:33: note: in expansion of macro 'LOG_DBG'
  591 |                                 LOG_DBG("Control DATA IN prog=%u, tailroom=%u",
      |                                 ^~~~~~~
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c:591:77: note: format string is defined here
  591 |                                 LOG_DBG("Control DATA IN prog=%u, tailroom=%u",
      |                                                                            ~^
      |                                                                             |
      |                                                                             unsigned int
      |                                                                            %lu
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c:599:41: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
  599 |                                 LOG_DBG("Control DATA OUT len=%u, tailroom=%u",
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  600 |                                         xfer->buf->len, net_buf_tailroom(xfer->buf));
      |                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                         |
      |                                                         size_t {aka long unsigned int}
/home/walidbadar/workspace/zephyrproject/zephyr/include/zephyr/logging/log_core.h:336:50: note: in definition of macro 'Z_LOG2'
  336 |                         z_log_printf_arg_checker(__VA_ARGS__);                                     \
      |                                                  ^~~~~~~~~~~
/home/walidbadar/workspace/zephyrproject/zephyr/include/zephyr/logging/log.h:93:22: note: in expansion of macro 'Z_LOG'
   93 | #define LOG_DBG(...) Z_LOG(LOG_LEVEL_DBG, __VA_ARGS__)
      |                      ^~~~~
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c:599:33: note: in expansion of macro 'LOG_DBG'
  599 |                                 LOG_DBG("Control DATA OUT len=%u, tailroom=%u",
      |                                 ^~~~~~~
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c:599:77: note: format string is defined here
  599 |                                 LOG_DBG("Control DATA OUT len=%u, tailroom=%u",
      |                                                                            ~^
      |                                                                             |
      |                                                                             unsigned int
      |                                                                            %lu
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c:618:33: warning: format '%u' expects argument of type 'unsigned int', but argument 5 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
  618 |                         LOG_DBG("Control DATA IN completed, prog=%u, rem=%u, act=%u, tailroom=%u",
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
......
  622 |                                 net_buf_tailroom(xfer->buf));
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                 |
      |                                 size_t {aka long unsigned int}
/home/walidbadar/workspace/zephyrproject/zephyr/include/zephyr/logging/log_core.h:336:50: note: in definition of macro 'Z_LOG2'
  336 |                         z_log_printf_arg_checker(__VA_ARGS__);                                     \
      |                                                  ^~~~~~~~~~~
/home/walidbadar/workspace/zephyrproject/zephyr/include/zephyr/logging/log.h:93:22: note: in expansion of macro 'Z_LOG'
   93 | #define LOG_DBG(...) Z_LOG(LOG_LEVEL_DBG, __VA_ARGS__)
      |                      ^~~~~
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c:618:25: note: in expansion of macro 'LOG_DBG'
  618 |                         LOG_DBG("Control DATA IN completed, prog=%u, rem=%u, act=%u, tailroom=%u",
      |                         ^~~~~~~
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c:618:96: note: format string is defined here
  618 |                         LOG_DBG("Control DATA IN completed, prog=%u, rem=%u, act=%u, tailroom=%u",
      |                                                                                               ~^
      |                                                                                                |
      |                                                                                                unsigned int
      |                                                                                               %lu
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c: In function 'validate_control_xfer':
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c:1295:33: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
 1295 |                         LOG_ERR("Control IN buffer is too small: wLength=%u tailroom=%u",
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1296 |                         wLength, net_buf_tailroom(xfer->buf));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                  |
      |                                  size_t {aka long unsigned int}
/home/walidbadar/workspace/zephyrproject/zephyr/include/zephyr/logging/log_core.h:336:50: note: in definition of macro 'Z_LOG2'
  336 |                         z_log_printf_arg_checker(__VA_ARGS__);                                     \
      |                                                  ^~~~~~~~~~~
/home/walidbadar/workspace/zephyrproject/zephyr/include/zephyr/logging/log.h:62:22: note: in expansion of macro 'Z_LOG'
   62 | #define LOG_ERR(...) Z_LOG(LOG_LEVEL_ERR, __VA_ARGS__)
      |                      ^~~~~
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c:1295:25: note: in expansion of macro 'LOG_ERR'
 1295 |                         LOG_ERR("Control IN buffer is too small: wLength=%u tailroom=%u",
      |                         ^~~~~~~
/home/walidbadar/workspace/zephyrproject/zephyr/drivers/usb/uhc/uhc_dwc2.c:1295:87: note: format string is defined here
 1295 |                         LOG_ERR("Control IN buffer is too small: wLength=%u tailroom=%u",
      |                                                                                      ~^
      |                                                                                       |
      |                                                                                       unsigned int
      |                                                                                      %lu
```