### PR TITLE
west.yml: Update west to include STM32CubeWB0 v1.5.0 for hal_stm32

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -258,7 +258,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 9b6fb9e0ee432d12a31b6327a3690d243b74d178
+      revision: 729ba54f3c17a3a298d665ce4b86f2b8f9d3726e
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Update west.yml to point to the recent changes for hal_stm32.

Supplementary PR [#390](https://github.com/zephyrproject-rtos/hal_stm32/pull/390)