### PR TITLE
drivers: wifi: nrf_wifi: Support 64-bit TWT interval range

### DIFF
--- a/drivers/wifi/nrf_wifi/src/wifi_mgmt.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_mgmt.c
@@ -238,18 +238,36 @@ out:
 	return ret;
 }
 
-/* TWT interval conversion helpers: User <-> Protocol */
-static struct twt_interval_float nrf_wifi_twt_us_to_float(uint32_t twt_interval)
+/* TWT interval conversion helpers: User <-> Protocol
+ *
+ * Per IEEE 802.11, the TWT interval is encoded as mantissa * 2^exponent
+ * micro-seconds, where the mantissa is a 16-bit field and the exponent a
+ * 5-bit field (max WIFI_MAX_TWT_EXPONENT). Encode directly in micro-seconds
+ * using the full 16-bit mantissa: this supports the complete uint64_t range
+ * the API exposes (no 32-bit truncation) with micro-second resolution.
+ */
+static struct twt_interval_float nrf_wifi_twt_us_to_float(uint64_t twt_interval)
 {
-	double mantissa = 0.0;
-	int exponent = 0;
-	struct twt_interval_float twt_interval_fp;
+	struct twt_interval_float twt_interval_fp = { 0 };
+	uint64_t mantissa = twt_interval;
+	uint8_t exponent = 0;
 
-	double twt_interval_ms = twt_interval / 1000.0;
+	/* Pick the smallest exponent that fits the mantissa in the 16-bit
+	 * field, without exceeding the 5-bit exponent field.
+	 */
+	while (mantissa > UINT16_MAX && exponent < WIFI_MAX_TWT_EXPONENT) {
+		mantissa >>= 1;
+		exponent++;
+	}
 
-	mantissa = frexp(twt_interval_ms, &exponent);
-	/* Ceiling and conversion to milli seconds */
-	twt_interval_fp.mantissa = ceil(mantissa * 1000);
+	/* Saturate if the requested interval exceeds the encodable maximum
+	 * (UINT16_MAX * 2^WIFI_MAX_TWT_EXPONENT us).
+	 */
+	if (mantissa > UINT16_MAX) {
+		mantissa = UINT16_MAX;
+	}
+
+	twt_interval_fp.mantissa = (unsigned short)mantissa;
 	twt_interval_fp.exponent = exponent;
 
 	return twt_interval_fp;
@@ -257,9 +275,8 @@ static struct twt_interval_float nrf_wifi_twt_us_to_float(uint32_t twt_interval)
 
 static uint64_t nrf_wifi_twt_float_to_us(struct twt_interval_float twt_interval_fp)
 {
-	/* Conversion to micro-seconds */
-	return floor(ldexp(twt_interval_fp.mantissa, twt_interval_fp.exponent) / (1000)) *
-			     1000;
+	/* TWT interval = mantissa * 2^exponent (in micro-seconds). */
+	return (uint64_t)twt_interval_fp.mantissa << twt_interval_fp.exponent;
 }
 
 static unsigned char twt_wifi_mgmt_to_rpu_neg_type(enum wifi_twt_negotiation_type neg_type)

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -1070,11 +1070,15 @@ struct wifi_twt_params {
 
 /* Flow ID is only 3 bits */
 #define WIFI_MAX_TWT_FLOWS 8
-#define WIFI_MAX_TWT_INTERVAL_US (LONG_MAX - 1)
+/* The TWT interval is encoded per IEEE 802.11 as mantissa * 2^exponent
+ * micro-seconds, with a 16-bit mantissa and a 5-bit exponent. The maximum
+ * representable interval is therefore UINT16_MAX * 2^WIFI_MAX_TWT_EXPONENT us.
+ */
+#define WIFI_MAX_TWT_EXPONENT 31
+#define WIFI_MAX_TWT_INTERVAL_US ((uint64_t)UINT16_MAX << WIFI_MAX_TWT_EXPONENT)
 /* 256 (u8) * 1TU */
 #define WIFI_MAX_TWT_WAKE_INTERVAL_US 262144
 #define WIFI_MAX_TWT_WAKE_AHEAD_DURATION_US (LONG_MAX - 1)
-#define WIFI_MAX_TWT_EXPONENT 31
 
 /** @endcond */
 

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -213,6 +213,71 @@ static bool parse_number(const struct shell *sh, long *param, char *str,
 	return true;
 }
 
+static bool parse_number_u64(const struct shell *sh, uint64_t *param, char *str,
+			     char *pname, uint64_t min, uint64_t max)
+{
+	char *endptr;
+	char *str_tmp = str;
+	uint64_t num;
+
+	if ((str_tmp[0] == '0') && (str_tmp[1] == 'x')) {
+		/* Hexadecimal numbers take base 0 in strtoull */
+		num = strtoull(str_tmp, &endptr, 0);
+	} else {
+		num = strtoull(str_tmp, &endptr, 10);
+	}
+
+	if (*endptr != '\0') {
+		PR_ERROR("Invalid number: %s\n", str_tmp);
+		return false;
+	}
+
+	if ((num < min) || (num > max)) {
+		if (pname) {
+			PR_WARNING("%s value out of range: %s, (%llu-%llu)\n",
+				   pname, str_tmp, (unsigned long long)min,
+				   (unsigned long long)max);
+		} else {
+			PR_WARNING("Value out of range: %s, (%llu-%llu)\n",
+				   str_tmp, (unsigned long long)min,
+				   (unsigned long long)max);
+		}
+		return false;
+	}
+	*param = num;
+	return true;
+}
+
+/* TWT interval is encoded per IEEE 802.11 as mantissa * 2^exponent us, with a
+ * 16-bit mantissa and a 5-bit exponent (WIFI_MAX_TWT_EXPONENT). Encode directly
+ * in micro-seconds using the full mantissa range so the whole uint64_t interval
+ * range is representable without floating point.
+ */
+static void twt_us_to_mantissa_exp(uint64_t interval_us, uint16_t *mantissa,
+				   uint8_t *exponent)
+{
+	uint64_t m = interval_us;
+	uint8_t e = 0;
+
+	while (m > UINT16_MAX && e < WIFI_MAX_TWT_EXPONENT) {
+		m >>= 1;
+		e++;
+	}
+
+	/* Saturate if the interval exceeds the encodable maximum. */
+	if (m > UINT16_MAX) {
+		m = UINT16_MAX;
+	}
+
+	*mantissa = (uint16_t)m;
+	*exponent = e;
+}
+
+static uint64_t twt_mantissa_exp_to_us(uint16_t mantissa, uint8_t exponent)
+{
+	return (uint64_t)mantissa << exponent;
+}
+
 static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 {
 	const struct wifi_scan_result *entry =
@@ -1948,10 +2013,7 @@ static int cmd_wifi_twt_setup_quick(const struct shell *sh, size_t argc,
 	struct wifi_twt_params params = { 0 };
 	int idx = 1;
 	long value;
-	double twt_mantissa_scale = 0.0;
-	double twt_interval_scale = 0.0;
-	uint16_t scale = 1000;
-	int exponent = 0;
+	uint64_t twt_interval;
 
 	context.sh = sh;
 
@@ -1971,17 +2033,18 @@ static int cmd_wifi_twt_setup_quick(const struct shell *sh, size_t argc,
 	}
 	params.setup.twt_wake_interval = (uint32_t)value;
 
-	if (!parse_number(sh, &value, argv[idx++], NULL, 1, WIFI_MAX_TWT_INTERVAL_US)) {
+	if (!parse_number_u64(sh, &twt_interval, argv[idx++], NULL, 1,
+			      WIFI_MAX_TWT_INTERVAL_US)) {
 		return -EINVAL;
 	}
-	params.setup.twt_interval = (uint64_t)value;
+	params.setup.twt_interval = twt_interval;
 
-	/* control the region of mantissa filed */
-	twt_interval_scale = (double)(params.setup.twt_interval / scale);
-	/* derive mantissa and exponent from interval */
-	twt_mantissa_scale = frexp(twt_interval_scale, &exponent);
-	params.setup.twt_mantissa = ceil(twt_mantissa_scale * scale);
-	params.setup.twt_exponent = exponent;
+	/* Derive mantissa and exponent from the interval for drivers that
+	 * consume the encoded form directly.
+	 */
+	twt_us_to_mantissa_exp(params.setup.twt_interval,
+			       &params.setup.twt_mantissa,
+			       &params.setup.twt_exponent);
 
 	if (net_mgmt(NET_REQUEST_WIFI_TWT, iface, &params, sizeof(params))) {
 		PR_WARNING("%s with %s failed, reason : %s\n",
@@ -2092,10 +2155,6 @@ static int twt_args_to_params(const struct shell *sh, size_t argc, char *argv[],
 	int opt_index = 0;
 	struct sys_getopt_state *state;
 	long value;
-	double twt_mantissa_scale = 0.0;
-	double twt_interval_scale = 0.0;
-	uint16_t scale = 1000;
-	int exponent = 0;
 	static const struct sys_getopt_option long_options[] = {
 		{"negotiation-type", sys_getopt_required_argument, 0, 'n'},
 		{"setup-cmd", sys_getopt_required_argument, 0, 'c'},
@@ -2191,11 +2250,11 @@ static int twt_args_to_params(const struct shell *sh, size_t argc, char *argv[],
 			break;
 
 		case 'p':
-			if (!parse_number(sh, &value, state->optarg, NULL, 1,
-					  WIFI_MAX_TWT_INTERVAL_US)) {
+			if (!parse_number_u64(sh, &params->setup.twt_interval,
+					      state->optarg, NULL, 1,
+					      WIFI_MAX_TWT_INTERVAL_US)) {
 				return -EINVAL;
 			}
-			params->setup.twt_interval = (uint64_t)value;
 			break;
 
 		case 'D':
@@ -2245,16 +2304,17 @@ static int twt_args_to_params(const struct shell *sh, size_t argc, char *argv[],
 	}
 
 	if (params->setup.twt_interval) {
-		/* control the region of mantissa filed */
-		twt_interval_scale = (double)(params->setup.twt_interval / scale);
-		/* derive mantissa and exponent from interval */
-		twt_mantissa_scale = frexp(twt_interval_scale, &exponent);
-		params->setup.twt_mantissa = ceil(twt_mantissa_scale * scale);
-		params->setup.twt_exponent = exponent;
+		/* Derive mantissa and exponent from the interval for drivers
+		 * that consume the encoded form directly.
+		 */
+		twt_us_to_mantissa_exp(params->setup.twt_interval,
+				       &params->setup.twt_mantissa,
+				       &params->setup.twt_exponent);
 	} else if ((params->setup.twt_exponent != 0) ||
 		   (params->setup.twt_mantissa != 0)) {
-		params->setup.twt_interval = floor(ldexp(params->setup.twt_mantissa,
-							 params->setup.twt_exponent));
+		params->setup.twt_interval =
+			twt_mantissa_exp_to_us(params->setup.twt_mantissa,
+					       params->setup.twt_exponent);
 	} else {
 		PR_ERROR("Either TWT interval or (mantissa, exponent) is needed\n");
 		return -EINVAL;


### PR DESCRIPTION
The TWT interval passed by the Wi-Fi management API is a uint64_t, but nrf_wifi_twt_us_to_float() took a uint32_t, silently truncating any interval above UINT32_MAX us (~71.6 min). On top of that, the encoder worked in milliseconds and renormalised the mantissa via frexp(), which pinned it near ~1000 and used only ~10 of the 16 mantissa bits, capping the encodable interval at ~1000 * 2^31 us (~24 days).

Take the interval as uint64_t end to end and encode it directly in micro-seconds using the full 16-bit mantissa and the 5-bit exponent (max WIFI_MAX_TWT_EXPONENT). This removes the truncation and lets the driver represent the complete range the API exposes, up to the IEEE 802.11 maximum of UINT16_MAX * 2^31 us, with exact micro-second resolution. Intervals beyond the encodable maximum are saturated.

The over-the-air value is unchanged (mantissa * 2^exponent us), so the firmware interface is untouched; only the host-side conversion changes.


Assisted-by: Claude:claude-opus-4.8