### PR TITLE
drivers: ethernet: dwc_mac: add multicast filtering

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -445,6 +445,11 @@ Ethernet
   :kconfig:option:`CONFIG_ETH_NXP_ENET_QOS_UNIQUE_MAC_ADDRESS`. Configurations setting the old
   name must be updated to use the new one. (:github:`115952`)
 
+* The Synopsys DesignWare MAC driver now filters multicast by default
+  (:kconfig:option:`CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER`), so only multicast for the addresses
+  the network stack has joined is received. Disable this option to receive all multicast, as
+  before. (:github:`113235`)
+
 Flash
 =====
 * :dtcompatible:`jedec,spi-nand` now requires a ``plane-bytes`` property, which indicates the size

--- a/drivers/ethernet/dwc_mac/CMakeLists.txt
+++ b/drivers/ethernet/dwc_mac/CMakeLists.txt
@@ -6,6 +6,11 @@ zephyr_library_sources_ifdef(CONFIG_ETH_DWC_ETHER_1000_CORE eth_dwc_ether_1000_c
 zephyr_library_sources_ifdef(CONFIG_ETH_DWC_ETHER_QOS_CORE eth_dwc_ether_qos_core.c)
 # zephyr-keep-sorted-stop
 
+# Common parts shared between cores
+# zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER_HASH eth_dwc_ether_multicast_filter_hash.c)
+# zephyr-keep-sorted-stop
+
 # Platform specific drivers
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_ETH_DWMAC_MMU eth_dwmac_mmu.c)

--- a/drivers/ethernet/dwc_mac/CMakeLists.txt
+++ b/drivers/ethernet/dwc_mac/CMakeLists.txt
@@ -6,6 +6,12 @@ zephyr_library_sources_ifdef(CONFIG_ETH_DWC_ETHER_1000_CORE eth_dwc_ether_1000_c
 zephyr_library_sources_ifdef(CONFIG_ETH_DWC_ETHER_QOS_CORE eth_dwc_ether_qos_core.c)
 # zephyr-keep-sorted-stop
 
+# Common parts shared between cores
+# zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER_HASH eth_dwc_ether_multicast_filter_hash.c)
+zephyr_library_sources_ifdef(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER_PERFECT eth_dwc_ether_multicast_filter_perfect.c)
+# zephyr-keep-sorted-stop
+
 # Platform specific drivers
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_ETH_DWMAC_MMU eth_dwmac_mmu.c)

--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -124,6 +124,19 @@ config ETH_DWMAC_RX_REFILL_THREAD_PRIORITY
 	  Priority level of the internal thread which is used to refill
 	  the receive buffer pool.
 
+config ETH_DWC_ETHER_MULTICAST_FILTER_HASH
+	bool "Multicast hash filter support"
+	select CRC
+	default y
+	help
+	  Enable support for multicast hash filtering in the MAC.
+	  Once enabled the ethernet MAC performs imperfect filtering
+	  based on a computed hash of the destination MAC address of
+	  the multicast address. Only multicast with the computed
+	  hash set in the multicast table will be received and all
+	  other multicast is dropped by the MAC. If disabled then all
+	  multicast is received by the MAC.
+
 # Currently only for the 1000 core
 if ETH_DWC_ETHER_1000_CORE
 

--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -136,6 +136,8 @@ config ETH_DWMAC_RX_REFILL_THREAD_PRIORITY
 	  Priority level of the internal thread which is used to refill
 	  the receive buffer pool.
 
+rsource "Kconfig.mcast"
+
 config ETH_DWC_ETHER_TX_HW_CHECKSUM
 	bool "Use TX hardware checksum"
 	select NET_CHECKSUM_OFFLOAD_SUPPORTED if NET_L2_ETHERNET

--- a/drivers/ethernet/dwc_mac/Kconfig.mcast
+++ b/drivers/ethernet/dwc_mac/Kconfig.mcast
@@ -1,0 +1,57 @@
+# Synopsys DesignWare MAC multicast filter configuration options
+
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+DT_PROP_SNPS_MULTICAST_FILTER_BINS := snps,multicast-filter-bins
+DT_PROP_SNPS_PERFECT_FILTER_ENTRIES := snps,perfect-filter-entries
+
+config ETH_DWC_ETHER_MULTICAST_FILTER_HASH_SUPPORTED
+	def_bool $(dt_compat_any_has_prop,$(DT_COMPAT_SNPS_DWMAC),$(DT_PROP_SNPS_MULTICAST_FILTER_BINS))
+	help
+	  The hardware can hash multicast addresses, which the devicetree
+	  property snps,multicast-filter-bins indicates.
+
+config ETH_DWC_ETHER_MULTICAST_FILTER_PERFECT_SUPPORTED
+	def_bool !$(dt_compat_all_has_prop,$(DT_COMPAT_SNPS_DWMAC),$(DT_PROP_SNPS_PERFECT_FILTER_ENTRIES),1)
+	help
+	  The hardware has spare MAC address entries to perfect filter
+	  multicast addresses with, meaning the devicetree property
+	  snps,perfect-filter-entries is larger than 1, as entry 0 holds
+	  the station address.
+
+config ETH_DWC_ETHER_MULTICAST_FILTER
+	bool "Multicast filter support"
+	depends on ETH_DWC_ETHER_MULTICAST_FILTER_HASH_SUPPORTED || \
+		ETH_DWC_ETHER_MULTICAST_FILTER_PERFECT_SUPPORTED
+	depends on NET_L2_ETHERNET
+	default y
+	help
+	  Enable support for multicast filtering in the MAC, so only
+	  multicast for the addresses the stack listens to is received.
+	  If disabled, or if the hardware cannot filter at all, then all
+	  multicast is received by the MAC.
+
+choice ETH_DWC_ETHER_MULTICAST_FILTER_MODE
+	prompt "Multicast filter mode"
+	depends on ETH_DWC_ETHER_MULTICAST_FILTER
+	default ETH_DWC_ETHER_MULTICAST_FILTER_HASH if ETH_DWC_ETHER_MULTICAST_FILTER_HASH_SUPPORTED
+	default ETH_DWC_ETHER_MULTICAST_FILTER_PERFECT
+
+config ETH_DWC_ETHER_MULTICAST_FILTER_HASH
+	bool "Hash filtering"
+	depends on ETH_DWC_ETHER_MULTICAST_FILTER_HASH_SUPPORTED
+	select CRC
+	help
+	  Imperfect multicast filtering based on a computed hash of the
+	  destination MAC address.
+
+config ETH_DWC_ETHER_MULTICAST_FILTER_PERFECT
+	bool "Perfect filtering"
+	depends on ETH_DWC_ETHER_MULTICAST_FILTER_PERFECT_SUPPORTED
+	help
+	  Perfect multicast filtering against the spare MAC address entries
+	  of the hardware. Should the addresses ever not fit into the spare
+	  entries, all multicast is received instead.
+
+endchoice

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -78,6 +78,9 @@ static enum ethernet_hw_caps dwmac_caps(const struct device *dev __unused,
 #ifdef CONFIG_ETH_DWC_ETHER_TX_HW_CHECKSUM_EN
 	       | ETHERNET_HW_TX_CHKSUM_OFFLOAD
 #endif
+#ifdef CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER_HASH
+	       | ETHERNET_HW_FILTERING
+#endif
 		;
 }
 
@@ -401,6 +404,11 @@ static int dwmac_set_config(const struct device *dev, struct net_if *iface __unu
 		DWMAC_REG_WRITE(DWMAC_MACFFR, reg);
 		break;
 #endif
+#if defined(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER_HASH)
+	case ETHERNET_CONFIG_TYPE_FILTER:
+		dwmac_setup_multicast_filter(dev, &config->filter);
+		break;
+#endif
 	default:
 		return -ENOTSUP;
 	}
@@ -461,8 +469,12 @@ static void dwmac_iface_init(struct net_if *iface)
 	net_if_set_link_addr(iface, p->mac_addr, sizeof(p->mac_addr), NET_LINK_ETHERNET);
 	dwmac_set_mac_addr(dev, p->mac_addr);
 
-	/* Pass all multicast frames */
-	DWMAC_REG_WRITE(DWMAC_MACFFR, DWMAC_REG_READ(DWMAC_MACFFR) | DWMAC_MACFFR_PAM);
+	if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER_HASH)) {
+		DWMAC_REG_WRITE(DWMAC_MACFFR, DWMAC_REG_READ(DWMAC_MACFFR) | DWMAC_MACFFR_HM);
+	} else {
+		/* Pass all multicast frames */
+		DWMAC_REG_WRITE(DWMAC_MACFFR, DWMAC_REG_READ(DWMAC_MACFFR) | DWMAC_MACFFR_PAM);
+	}
 
 	net_if_carrier_off(iface);
 	if (device_is_ready(cfg->phy_dev)) {

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -81,6 +81,9 @@ static enum ethernet_hw_caps dwmac_caps(const struct device *dev __unused,
 #ifdef CONFIG_ETH_DWC_ETHER_TX_HW_CHECKSUM_EN
 	       | ETHERNET_HW_TX_CHKSUM_OFFLOAD
 #endif
+#ifdef CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER
+	       | ETHERNET_HW_FILTERING
+#endif
 		;
 }
 
@@ -453,6 +456,11 @@ static int dwmac_set_config(const struct device *dev, struct net_if *iface __unu
 		DWMAC_REG_WRITE(DWMAC_MACFFR, reg);
 		break;
 #endif
+#if defined(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER)
+	case ETHERNET_CONFIG_TYPE_FILTER:
+		dwmac_setup_multicast_filter(dev, &config->filter);
+		break;
+#endif
 	default:
 		return -ENOTSUP;
 	}
@@ -513,8 +521,16 @@ static void dwmac_iface_init(struct net_if *iface)
 	net_if_set_link_addr(iface, p->mac_addr, sizeof(p->mac_addr), NET_LINK_ETHERNET);
 	dwmac_set_mac_addr(dev, p->mac_addr);
 
-	/* Pass all multicast frames */
-	DWMAC_REG_WRITE(DWMAC_MACFFR, DWMAC_REG_READ(DWMAC_MACFFR) | DWMAC_MACFFR_PAM);
+	if (!IS_ENABLED(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER)) {
+		/* Pass all multicast frames */
+		DWMAC_REG_WRITE(DWMAC_MACFFR, DWMAC_REG_READ(DWMAC_MACFFR) | DWMAC_MACFFR_PAM);
+	} else if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER_HASH)) {
+		DWMAC_REG_WRITE(DWMAC_MACFFR, DWMAC_REG_READ(DWMAC_MACFFR) | DWMAC_MACFFR_HM);
+	} else {
+		/* multicast is perfect filtered against the MAC address entries,
+		 * which is the default filter mode
+		 */
+	}
 
 	net_if_carrier_off(iface);
 	if (device_is_ready(cfg->phy_dev)) {

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_multicast_filter_hash.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_multicast_filter_hash.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(dwmac_core, CONFIG_ETHERNET_LOG_LEVEL);
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/bit_rev.h>
+#include <zephyr/sys/crc.h>
+#include <zephyr/sys/device_mmio.h>
+
+#include "eth_dwmac_priv.h"
+
+#ifdef CONFIG_ETH_DWC_ETHER_1000_CORE
+#define DWMAC_MULTICAST_FILTER_HASH_TABLE_HIGH DWMAC_MACHTHR
+#define DWMAC_MULTICAST_FILTER_HASH_TABLE_LOW  DWMAC_MACHTLR
+#endif
+#ifdef CONFIG_ETH_DWC_ETHER_QOS_CORE
+#define DWMAC_MULTICAST_FILTER_HASH_TABLE_HIGH MAC_HASH_TABLE(1)
+#define DWMAC_MULTICAST_FILTER_HASH_TABLE_LOW  MAC_HASH_TABLE(0)
+#endif
+
+void dwmac_setup_multicast_filter(const struct device *dev, const struct ethernet_filter *filter)
+{
+	struct dwmac_priv *p = dev->data;
+	uint32_t crc;
+	uint32_t hash_table[2];
+	uint32_t hash_index;
+
+	crc = sys_bit_rev32(crc32_ieee(filter->mac_address.addr, sizeof(struct net_eth_addr)));
+	hash_index = (crc >> 26) & 0x3f;
+
+	__ASSERT_NO_MSG(hash_index < ARRAY_SIZE(p->hash_index_cnt));
+
+	hash_table[0] = DWMAC_REG_READ(DWMAC_MULTICAST_FILTER_HASH_TABLE_LOW);
+	hash_table[1] = DWMAC_REG_READ(DWMAC_MULTICAST_FILTER_HASH_TABLE_HIGH);
+
+	if (filter->set) {
+		p->hash_index_cnt[hash_index]++;
+		hash_table[hash_index / 32] |= (1 << (hash_index % 32));
+	} else {
+		if (p->hash_index_cnt[hash_index] == 0) {
+			return; /* No hash at index to remove */
+		}
+
+		p->hash_index_cnt[hash_index]--;
+		if (p->hash_index_cnt[hash_index] == 0) {
+			hash_table[hash_index / 32] &= ~(1 << (hash_index % 32));
+		}
+	}
+
+	DWMAC_REG_WRITE(DWMAC_MULTICAST_FILTER_HASH_TABLE_LOW, hash_table[0]);
+	DWMAC_REG_WRITE(DWMAC_MULTICAST_FILTER_HASH_TABLE_HIGH, hash_table[1]);
+}

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_multicast_filter_hash.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_multicast_filter_hash.c
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(dwmac_core, CONFIG_ETHERNET_LOG_LEVEL);
+
+#include <zephyr/kernel.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/sys/bit_rev.h>
+#include <zephyr/sys/crc.h>
+#include <zephyr/sys/device_mmio.h>
+#include <zephyr/sys/util.h>
+
+#include "eth_dwmac_priv.h"
+
+#ifdef CONFIG_ETH_DWC_ETHER_1000_CORE
+#define DWMAC_MCAST_HASH_TABLE_REG(i) ((i) == 0 ? DWMAC_MACHTLR : DWMAC_MACHTHR)
+
+BUILD_ASSERT(DWMAC_MULTICAST_FILTER_BINS == 64, "this core only supports 64 multicast hash bins");
+#endif
+#ifdef CONFIG_ETH_DWC_ETHER_QOS_CORE
+#define DWMAC_MCAST_HASH_TABLE_REG(i) MAC_HASH_TABLE(i)
+#endif
+
+#define DWMAC_MCAST_HASH_WORDS (DWMAC_MULTICAST_FILTER_BINS / 32)
+
+static void dwmac_mcast_hash_cb(struct net_if *iface, const struct net_eth_mcast_addr *mcast_addr,
+				void *user_data)
+{
+	uint32_t *hash_table = user_data;
+	uint32_t crc;
+	uint32_t index;
+
+	ARG_UNUSED(iface);
+
+	crc = sys_bit_rev32(crc32_ieee(mcast_addr->addr.addr, sizeof(mcast_addr->addr.addr)));
+	index = crc >> (32 - LOG2(DWMAC_MULTICAST_FILTER_BINS));
+
+	hash_table[index / 32] |= BIT(index % 32);
+}
+
+void dwmac_setup_multicast_filter(const struct device *dev, const struct ethernet_filter *filter)
+{
+	struct dwmac_priv *p = dev->data;
+	uint32_t hash_table[DWMAC_MCAST_HASH_WORDS] = {0};
+
+	ARG_UNUSED(filter);
+
+	net_eth_mcast_addr_foreach(p->iface, dwmac_mcast_hash_cb, hash_table);
+
+	for (unsigned int i = 0; i < DWMAC_MCAST_HASH_WORDS; i++) {
+		DWMAC_REG_WRITE(DWMAC_MCAST_HASH_TABLE_REG(i), hash_table[i]);
+	}
+}

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_multicast_filter_perfect.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_multicast_filter_perfect.c
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(dwmac_core, CONFIG_ETHERNET_LOG_LEVEL);
+
+#include <zephyr/kernel.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/device_mmio.h>
+#include <zephyr/sys/util.h>
+
+#include "eth_dwmac_priv.h"
+
+#ifdef CONFIG_ETH_DWC_ETHER_1000_CORE
+#define DWMAC_MCAST_ADDR_HIGH(n)	DWMAC_MACAHR(n)
+#define DWMAC_MCAST_ADDR_LOW(n)		DWMAC_MACALR(n)
+#define DWMAC_MCAST_ADDR_HIGH_AE	DWMAC_MACAHR_AE
+#define DWMAC_PASS_ALL_MCAST_REG	DWMAC_MACFFR
+#define DWMAC_PASS_ALL_MCAST_BIT	DWMAC_MACFFR_PAM
+
+BUILD_ASSERT(DWMAC_PERFECT_FILTER_ENTRIES <= 16,
+	     "this driver only supports the first 16 MAC address entries");
+#endif
+#ifdef CONFIG_ETH_DWC_ETHER_QOS_CORE
+#define DWMAC_MCAST_ADDR_HIGH(n)	MAC_ADDRESS_HIGH(n)
+#define DWMAC_MCAST_ADDR_LOW(n)		MAC_ADDRESS_LOW(n)
+#define DWMAC_MCAST_ADDR_HIGH_AE	MAC_ADDRESS_HIGH_AE
+#define DWMAC_PASS_ALL_MCAST_REG	MAC_PKT_FILTER
+#define DWMAC_PASS_ALL_MCAST_BIT	MAC_PKT_FILTER_PM
+
+BUILD_ASSERT(DWMAC_PERFECT_FILTER_ENTRIES <= 128,
+	     "this core supports at most 128 MAC address entries");
+#endif
+
+static void dwmac_mcast_perfect_cb(struct net_if *iface,
+				   const struct net_eth_mcast_addr *mcast_addr, void *user_data)
+{
+	const struct device *dev = net_if_get_device(iface);
+	unsigned int *count = user_data;
+
+	(*count)++;
+	if (*count > DWMAC_MULTICAST_PERFECT_SLOTS) {
+		return;
+	}
+
+	/* MAC address entry 0 holds the station address, so start at entry 1 */
+	DWMAC_REG_WRITE(DWMAC_MCAST_ADDR_HIGH(*count),
+			sys_get_le16(&mcast_addr->addr.addr[4]) | DWMAC_MCAST_ADDR_HIGH_AE);
+	DWMAC_REG_WRITE(DWMAC_MCAST_ADDR_LOW(*count), sys_get_le32(mcast_addr->addr.addr));
+}
+
+void dwmac_setup_multicast_filter(const struct device *dev, const struct ethernet_filter *filter)
+{
+	struct dwmac_priv *p = dev->data;
+	unsigned int count = 0;
+
+	ARG_UNUSED(filter);
+
+	net_eth_mcast_addr_foreach(p->iface, dwmac_mcast_perfect_cb, &count);
+
+	if (NET_ETH_MCAST_FILTER_COUNT > DWMAC_MULTICAST_PERFECT_SLOTS) {
+		uint32_t reg_val = DWMAC_REG_READ(DWMAC_PASS_ALL_MCAST_REG);
+
+		if (count > DWMAC_MULTICAST_PERFECT_SLOTS) {
+			/* the addresses do not fit into the entries, accept all multicast */
+			DWMAC_REG_WRITE(DWMAC_PASS_ALL_MCAST_REG,
+					reg_val | DWMAC_PASS_ALL_MCAST_BIT);
+		} else {
+			DWMAC_REG_WRITE(DWMAC_PASS_ALL_MCAST_REG,
+					reg_val & ~DWMAC_PASS_ALL_MCAST_BIT);
+		}
+	}
+
+	/* disable the now unused entries */
+	for (unsigned int i = MIN(count, DWMAC_MULTICAST_PERFECT_SLOTS) + 1;
+	     i <= DWMAC_MULTICAST_PERFECT_SLOTS; i++) {
+		DWMAC_REG_WRITE(DWMAC_MCAST_ADDR_HIGH(i), 0);
+	}
+}

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -123,6 +123,9 @@ static enum ethernet_hw_caps dwmac_caps(const struct device *dev, struct net_if 
 #ifdef CONFIG_NET_VLAN
 	caps |= ETHERNET_HW_VLAN;
 #endif
+#ifdef CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER_HASH
+	caps |= ETHERNET_HW_FILTERING;
+#endif
 
 	return caps;
 }
@@ -504,7 +507,11 @@ static int dwmac_set_config(const struct device *dev,
 		}
 		break;
 #endif
-
+#if defined(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER_HASH)
+	case ETHERNET_CONFIG_TYPE_FILTER:
+		dwmac_setup_multicast_filter(dev, &config->filter);
+		break;
+#endif
 	default:
 		ret = -ENOTSUP;
 		break;
@@ -591,7 +598,11 @@ static void dwmac_iface_init(struct net_if *iface)
 	 *   - pass multicast packets
 	 *   - pass broadcast packets
 	 */
-	DWMAC_REG_WRITE(MAC_PKT_FILTER, MAC_PKT_FILTER_PM);
+	if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER_HASH)) {
+		DWMAC_REG_WRITE(MAC_PKT_FILTER, MAC_PKT_FILTER_HMC);
+	} else {
+		DWMAC_REG_WRITE(MAC_PKT_FILTER, MAC_PKT_FILTER_PM);
+	}
 
 	if (cfg->phy_dev != NULL) {
 		/* Do not start the interface until PHY link is up */

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -110,6 +110,9 @@ static enum ethernet_hw_caps dwmac_caps(const struct device *dev, struct net_if 
 #ifdef CONFIG_NET_VLAN
 	caps |= ETHERNET_HW_VLAN;
 #endif
+#ifdef CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER
+	caps |= ETHERNET_HW_FILTERING;
+#endif
 
 #ifdef CONFIG_ETH_DWC_ETHER_RX_HW_CHECKSUM_EN
 	caps |= ETHERNET_HW_RX_CHKSUM_OFFLOAD;
@@ -579,7 +582,11 @@ static int dwmac_set_config(const struct device *dev,
 		}
 		break;
 #endif
-
+#if defined(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER)
+	case ETHERNET_CONFIG_TYPE_FILTER:
+		dwmac_setup_multicast_filter(dev, &config->filter);
+		break;
+#endif
 	default:
 		ret = -ENOTSUP;
 		break;
@@ -663,10 +670,18 @@ static void dwmac_iface_init(struct net_if *iface)
 	/*
 	 * Configure MAC address filter to
 	 *   - pass unicast packets with our MAC address
-	 *   - pass multicast packets
+	 *   - pass multicast packets matching the multicast filter,
+	 *     or all multicast packets if there is no filter
 	 *   - pass broadcast packets
 	 */
-	DWMAC_REG_WRITE(MAC_PKT_FILTER, MAC_PKT_FILTER_PM);
+	if (!IS_ENABLED(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER)) {
+		DWMAC_REG_WRITE(MAC_PKT_FILTER, MAC_PKT_FILTER_PM);
+	} else if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER_HASH)) {
+		DWMAC_REG_WRITE(MAC_PKT_FILTER, MAC_PKT_FILTER_HMC);
+	} else {
+		/* multicast is perfect filtered against the MAC address entries */
+		DWMAC_REG_WRITE(MAC_PKT_FILTER, 0);
+	}
 
 	if (cfg->phy_dev != NULL) {
 		/* Do not start the interface until PHY link is up */

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -15,6 +15,7 @@
 #define ZEPHYR_DRIVERS_ETHERNET_ETH_DWMAC_PRIV_H_
 
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/net/ethernet.h>
 #include <zephyr/sys/device_mmio.h>
 
 /*
@@ -135,6 +136,10 @@ struct dwmac_priv {
 
 	struct k_fifo tx_queue;
 
+#ifdef CONFIG_ETH_DWC_ETHER_MULTICAST_FILTER_HASH
+	uint8_t hash_index_cnt[64];
+#endif
+
 	K_KERNEL_STACK_MEMBER(rx_refill_thread_stack, RX_REFILL_STACK_SIZE);
 	struct k_thread rx_refill_thread;
 
@@ -155,6 +160,7 @@ struct dwmac_priv {
 int dwmac_probe(const struct device *dev);
 int dwmac_bus_init(const struct device *dev);
 int dwmac_platform_init(const struct device *dev);
+void dwmac_setup_multicast_filter(const struct device *dev, const struct ethernet_filter *filter);
 void dwmac_isr(const struct device *ddev);
 extern const struct ethernet_api dwmac_api;
 
@@ -1283,6 +1289,8 @@ extern const struct ethernet_api dwmac_api;
 /* GMAC register map */
 #define DWMAC_MACCR      0x0000
 #define DWMAC_MACFFR     0x0004
+#define DWMAC_MACHTHR    0x0008
+#define DWMAC_MACHTLR    0x000C
 #define DWMAC_MACVERR    0x0020
 #define DWMAC_MACA0HR    0x0040
 #define DWMAC_MACA0LR    0x0044
@@ -1308,6 +1316,7 @@ extern const struct ethernet_api dwmac_api;
 
 /* MAC frame filter bits */
 #define DWMAC_MACFFR_PM    BIT(0)
+#define DWMAC_MACFFR_HM    BIT(2)
 #define DWMAC_MACFFR_PAM   BIT(4)
 
 /* DMA status bits */

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -14,6 +14,7 @@
 #ifndef ZEPHYR_DRIVERS_ETHERNET_ETH_DWMAC_PRIV_H_
 #define ZEPHYR_DRIVERS_ETHERNET_ETH_DWMAC_PRIV_H_
 
+#include <zephyr/devicetree.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/sys/device_mmio.h>
@@ -73,6 +74,22 @@
 /* number of hardware descriptors in uncached memory */
 #define NB_TX_DESCS		CONFIG_DWMAC_NB_TX_DESCS
 #define NB_RX_DESCS		CONFIG_DWMAC_NB_RX_DESCS
+
+/*
+ * The devicetree node of the first MAC instance. The snps,dwmac properties
+ * are assumed to be the same for all instances.
+ */
+
+BUILD_ASSERT(DT_HAS_COMPAT_STATUS_OKAY(snps_dwmac),
+	     "No device tree node with compatible \"snps,dwmac\" found");
+
+#define DWMAC_DT_NODE DT_INST(0, snps_dwmac)
+
+/* multicast filter capabilities of the hardware */
+#define DWMAC_MULTICAST_FILTER_BINS	DT_PROP_OR(DWMAC_DT_NODE, snps_multicast_filter_bins, 0)
+#define DWMAC_PERFECT_FILTER_ENTRIES	DT_PROP(DWMAC_DT_NODE, snps_perfect_filter_entries)
+/* MAC address entry 0 holds the station address */
+#define DWMAC_MULTICAST_PERFECT_SLOTS	(DWMAC_PERFECT_FILTER_ENTRIES - 1)
 
 /* stack size for RX refill thread */
 #define RX_REFILL_STACK_SIZE	1024
@@ -211,6 +228,7 @@ struct dwmac_priv {
 int dwmac_probe(const struct device *dev);
 int dwmac_bus_init(const struct device *dev);
 int dwmac_platform_init(const struct device *dev);
+void dwmac_setup_multicast_filter(const struct device *dev, const struct ethernet_filter *filter);
 void dwmac_isr(const struct device *ddev);
 #if defined(CONFIG_PTP_CLOCK_DWC_MAC)
 const struct device *dwmac_get_ptp_clock(const struct device *dev, struct net_if *iface);
@@ -1394,9 +1412,16 @@ extern const struct ethernet_api dwmac_api;
 /* GMAC register map */
 #define DWMAC_MACCR      (DWMAC_MAC_OFFSET + 0x0000)
 #define DWMAC_MACFFR     (DWMAC_MAC_OFFSET + 0x0004)
+#define DWMAC_MACHTHR    (DWMAC_MAC_OFFSET + 0x0008)
+#define DWMAC_MACHTLR    (DWMAC_MAC_OFFSET + 0x000C)
 #define DWMAC_MACVERR    (DWMAC_MAC_OFFSET + 0x0020)
-#define DWMAC_MACA0HR    (DWMAC_MAC_OFFSET + 0x0040)
-#define DWMAC_MACA0LR    (DWMAC_MAC_OFFSET + 0x0044)
+#define DWMAC_MACAHR(n)  (DWMAC_MAC_OFFSET + 0x0040 + 8 * (n))
+#define DWMAC_MACALR(n)  (DWMAC_MAC_OFFSET + 0x0044 + 8 * (n))
+#define DWMAC_MACA0HR    DWMAC_MACAHR(0)
+#define DWMAC_MACA0LR    DWMAC_MACALR(0)
+
+/* MAC address high register bits (entries 1 and up) */
+#define DWMAC_MACAHR_AE  BIT(31)
 
 #define DWMAC_DMABMR       (DWMAC_DMA_OFFSET + 0x0000)
 #define DWMAC_DMATPDR      (DWMAC_DMA_OFFSET + 0x0004)
@@ -1420,6 +1445,7 @@ extern const struct ethernet_api dwmac_api;
 
 /* MAC frame filter bits */
 #define DWMAC_MACFFR_PM    BIT(0)
+#define DWMAC_MACFFR_HM    BIT(2)
 #define DWMAC_MACFFR_PAM   BIT(4)
 
 /* DMA status bits */

--- a/dts/arm/infineon/cat3/xmc/xmc4xxx.dtsi
+++ b/dts/arm/infineon/cat3/xmc/xmc4xxx.dtsi
@@ -253,6 +253,8 @@
 			compatible = "infineon,xmc4xxx-ethernet", "snps,dwmac";
 			reg = <0x5000c000 0x3fff>;
 			interrupts = <108 1>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio: mdio {

--- a/dts/arm/intel_socfpga_std/socfpga.dtsi
+++ b/dts/arm/intel_socfpga_std/socfpga.dtsi
@@ -143,6 +143,8 @@
 			reg = <0xff700000 0x2000>;
 			interrupts = <0 115 4 IRQ_DEFAULT_PRIORITY>;
 			emac-index = <0>;
+			snps,multicast-filter-bins = <256>;
+			snps,perfect-filter-entries = <128>;
 			status = "disabled";
 		};
 
@@ -151,6 +153,8 @@
 			reg = <0xff702000 0x2000>;
 			interrupts = <0 120 4 IRQ_DEFAULT_PRIORITY>;
 			emac-index = <1>;
+			snps,multicast-filter-bins = <256>;
+			snps,perfect-filter-entries = <128>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nuvoton/m46x.dtsi
+++ b/dts/arm/nuvoton/m46x.dtsi
@@ -504,6 +504,8 @@
 			resets = <&rst NUMAKER_EMAC0_RST>;
 			phy-addr = <1>;
 			clocks = <&pcc NUMAKER_EMAC0_MODULE 0 0>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <16>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nuvoton/m55m1x.dtsi
+++ b/dts/arm/nuvoton/m55m1x.dtsi
@@ -374,6 +374,8 @@
 			resets = <&rst NUMAKER_SYS_EMAC0RST>;
 			phy-addr = <0>;
 			clocks = <&pcc NUMAKER_EMAC0_MODULE 0 0>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <16>;
 			status = "disabled";
 		};
 

--- a/dts/arm/nxp/mcx/mcxa/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/mcxa/nxp_mcxa5x_common.dtsi
@@ -858,6 +858,7 @@
 		clocks = <&syscon MCUX_ENET_QOS_CLK>;
 		interrupts = <90 0>, <91 0>;
 		interrupt-names = "mac", "power";
+		snps,perfect-filter-entries = <1>;
 		status = "disabled";
 
 		enet_mdio: mdio {

--- a/dts/arm/nxp/mcx/mcxe/nxp_mcxe31x_common.dtsi
+++ b/dts/arm/nxp/mcx/mcxe/nxp_mcxe31x_common.dtsi
@@ -295,6 +295,8 @@
 		compatible = "nxp,emac", "snps,dwmac";
 		reg = <0x480000 0x120c>;
 		interrupts = <105 0>;
+		snps,multicast-filter-bins = <64>;
+		snps,perfect-filter-entries = <3>;
 		status = "disabled";
 	};
 

--- a/dts/arm/nxp/mcx/mcxn/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/mcxn/nxp_mcxnx4x_common.dtsi
@@ -961,6 +961,7 @@
 		clock-names = "mac", "ptp";
 		interrupts = <139 0>, <140 0>, <141 0>;
 		interrupt-names = "mac", "power", "lpi";
+		snps,perfect-filter-entries = <1>;
 		status = "disabled";
 
 		enet_ptp_clock: ptp_clock {

--- a/dts/arm/nxp/s32/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/s32/nxp_s32k344_m7.dtsi
@@ -653,6 +653,8 @@
 			compatible = "nxp,s32-gmac", "snps,dwmac";
 			interrupts = <105 0>, <106 0>, <107 0>, <108 0>;
 			interrupt-names = "common", "tx", "rx", "safety";
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <3>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -193,6 +193,8 @@
 				 <&rcc STM32_SRC_HSE ETH1CLKDIV_SEL(0)>,
 				 <&rcc STM32_SRC_HSE ETH1REFCLK_SEL(0)>;
 			interrupts = <94 0>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio: mdio {

--- a/dts/arm/st/f1/stm32f107.dtsi
+++ b/dts/arm/st/f1/stm32f107.dtsi
@@ -27,6 +27,8 @@
 				 <&rcc STM32_CLOCK(AHB1, 15)>,
 				 <&rcc STM32_CLOCK(AHB1, 16)>;
 			interrupts = <61 0>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio: mdio {

--- a/dts/arm/st/f2/stm32f207.dtsi
+++ b/dts/arm/st/f2/stm32f207.dtsi
@@ -19,6 +19,8 @@
 				 <&rcc STM32_CLOCK(AHB1, 27)>,
 				 <&rcc STM32_CLOCK(AHB1, 28)>;
 			interrupts = <61 0>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio: mdio {

--- a/dts/arm/st/f4/stm32f407.dtsi
+++ b/dts/arm/st/f4/stm32f407.dtsi
@@ -19,6 +19,8 @@
 				 <&rcc STM32_CLOCK(AHB1, 27)>,
 				 <&rcc STM32_CLOCK(AHB1, 28)>;
 			interrupts = <61 0>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio: mdio {

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -85,6 +85,8 @@
 				 <&rcc STM32_CLOCK(AHB1, 27)>,
 				 <&rcc STM32_CLOCK(AHB1, 28)>;
 			interrupts = <61 0>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio: mdio {

--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -130,6 +130,8 @@
 				 <&rcc STM32_CLOCK(AHB1, 27)>,
 				 <&rcc STM32_CLOCK(AHB1, 28)>;
 			interrupts = <61 0>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio: mdio {

--- a/dts/arm/st/h5/stm32h563.dtsi
+++ b/dts/arm/st/h5/stm32h563.dtsi
@@ -30,6 +30,8 @@
 				 <&rcc STM32_CLOCK(AHB1, 21)>,
 				 <&rcc STM32_SRC_PLL1_Q NO_SEL>;
 			interrupts = <106 0>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio: mdio {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1236,6 +1236,8 @@
 				 <&rcc STM32_CLOCK(AHB1, 16)>,
 				 <&rcc STM32_CLOCK(AHB1, 17)>;
 			interrupts = <61 0>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			memory-regions = <&sram2>;
 			status = "disabled";
 

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1008,6 +1008,8 @@
 				 <&rcc STM32_CLOCK(AHB1, 16)>,
 				 <&rcc STM32_CLOCK(AHB1, 17)>;
 			interrupts = <92 0>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			memory-regions = <&sram2>;
 			status = "disabled";
 

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -690,6 +690,8 @@
 				 <&rcc STM32_SRC_PLL4_Q ETH1_SEL(0)>;
 			interrupts = <GIC_SPI 62 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 63 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio0: mdio {

--- a/dts/arm/st/mp13/stm32mp133.dtsi
+++ b/dts/arm/st/mp13/stm32mp133.dtsi
@@ -22,6 +22,8 @@
 				 <&rcc STM32_SRC_PLL4_P ETH2_SEL(0)>;
 			interrupts = <GIC_SPI 97 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 				     <GIC_SPI 98 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio1: mdio {

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -976,6 +976,8 @@
 					 <&rcc STM32_CLOCK(AHB5, 23)>,
 					 <&rcc STM32_CLOCK(AHB5, 24)>;
 				interrupts = <179 0>;
+				snps,multicast-filter-bins = <64>;
+				snps,perfect-filter-entries = <4>;
 				status = "disabled";
 
 				mdio: mdio {

--- a/dts/bindings/ethernet/snps,dwmac.yaml
+++ b/dts/bindings/ethernet/snps,dwmac.yaml
@@ -19,3 +19,20 @@ properties:
       Value programmed into the MAC MDIO Address CR field.
       When present, this fixed value is used directly instead of deriving
       the MDIO clock range from the MAC clock rate.
+
+  snps,multicast-filter-bins:
+    type: int
+    enum: [64, 128, 256]
+    description: |
+      Number of multicast hash filter bins the hardware was configured
+      with. The absence of this property means the hardware cannot hash
+      multicast addresses.
+
+  snps,perfect-filter-entries:
+    type: int
+    default: 1
+    min: 1
+    description: |
+      Number of MAC address (perfect) filter entries the hardware was
+      configured with, including entry 0 which holds the station address.
+      The default corresponds to the minimal hardware configuration.

--- a/dts/riscv/espressif/esp32p4/esp32p4_common.dtsi
+++ b/dts/riscv/espressif/esp32p4/esp32p4_common.dtsi
@@ -682,6 +682,7 @@
 			clocks = <&clock ESP32_EMAC_MODULE>,
 				 <&clock ESP32_EMAC_PTP_MODULE>;
 			clock-names = "mac", "ptp";
+			snps,perfect-filter-entries = <9>;
 			status = "disabled";
 
 			mdio: mdio {

--- a/dts/riscv/wch/ch32v307/ch32v307.dtsi
+++ b/dts/riscv/wch/ch32v307/ch32v307.dtsi
@@ -20,6 +20,8 @@
 			interrupts = <77>, <78>;
 			internal-phy-pllmul = "15";
 			internal-phy-prediv = "2";
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio: mdio {

--- a/dts/riscv/wch/ch32v317/ch32v317.dtsi
+++ b/dts/riscv/wch/ch32v317/ch32v317.dtsi
@@ -20,6 +20,8 @@
 			interrupts = <77>, <78>;
 			internal-phy-pllmul = "15";
 			internal-phy-prediv = "2";
+			snps,multicast-filter-bins = <64>;
+			snps,perfect-filter-entries = <4>;
 			status = "disabled";
 
 			mdio: mdio {

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -584,6 +584,7 @@
 			interrupts = <ETH_MAC_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			clocks = <&clock ESP32_EMAC_MODULE>;
+			snps,perfect-filter-entries = <9>;
 			status = "disabled";
 
 			mdio: mdio {

--- a/include/zephyr/sys/bit_rev.h
+++ b/include/zephyr/sys/bit_rev.h
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_SYS_BIT_REV_H_
+#define ZEPHYR_INCLUDE_SYS_BIT_REV_H_
+
+#include <zephyr/types.h>
+#include <zephyr/sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file
+ * @brief Header file for bit reverse operations.
+ *
+ * @{
+ */
+
+/**
+ * @brief Reverse the bits in a 32-bit value.
+ *
+ * @param x Value to reverse
+ *
+ * @return reversed value
+ */
+static inline uint32_t sys_bit_rev32(uint32_t x)
+{
+#if defined(__clang__)
+	return __builtin_bitreverse32(x);
+#elif defined(CONFIG_ARM)
+	__asm__("rbit %0, %1" : "=r"(x) : "r"(x));
+	return x;
+#elif defined(CONFIG_ARM64)
+	__asm__("rbit %w0, %w1" : "=r"(x) : "r"(x));
+	return x;
+#elif defined(CONFIG_RISCV_ISA_EXT_ZBKB)
+	unsigned long x_rev;
+
+	__asm__("rev8 %0, %1\n"
+		"brev8 %0, %0\n"
+		: "=r"(x_rev)
+		: "r"(x));
+
+	return x_rev >> (__riscv_xlen - 32);
+#else
+	/* Fallback implementation for other architectures */
+	uint32_t x_rev = 0;
+
+	for (uint8_t i = 0; i < 32; i++) {
+		if (IS_BIT_SET(x, i)) {
+			x_rev |= BIT(32 - 1 - i);
+		}
+	}
+
+	return x_rev;
+#endif
+}
+
+/**
+ * @brief Reverse the bits in a 16-bit value.
+ *
+ * @param x Value to reverse
+ *
+ * @return reversed value
+ */
+static inline uint16_t sys_bit_rev16(uint16_t x)
+{
+#if defined(__clang__)
+	return __builtin_bitreverse16(x);
+#elif defined(CONFIG_ARM) || defined(CONFIG_ARM64) || defined(CONFIG_RISCV_ISA_EXT_ZBKB)
+	return sys_bit_rev32(x) >> 16;
+#else
+	/* Fallback implementation for other architectures */
+	uint16_t x_rev = 0;
+
+	for (uint8_t i = 0; i < 16; i++) {
+		if (IS_BIT_SET(x, i)) {
+			x_rev |= BIT(16 - 1 - i);
+		}
+	}
+
+	return x_rev;
+#endif
+}
+
+/**
+ * @brief Reverse the bits in an 8-bit value.
+ *
+ * @param x Value to reverse
+ *
+ * @return reversed value
+ */
+static inline uint8_t sys_bit_rev8(uint8_t x)
+{
+#if defined(__clang__)
+	return __builtin_bitreverse8(x);
+#elif defined(CONFIG_ARM) || defined(CONFIG_ARM64)
+	return sys_bit_rev32(x) >> 24;
+#elif defined(CONFIG_RISCV_ISA_EXT_ZBKB)
+	__asm__("rev8 %0, %1\n" : "=r"(x) : "r"(x));
+	return x;
+#else
+	/* Fallback implementation for other architectures */
+	uint8_t x_rev = 0;
+
+	for (uint8_t i = 0; i < 8; i++) {
+		if (IS_BIT_SET(x, i)) {
+			x_rev |= BIT(8 - 1 - i);
+		}
+	}
+
+	return x_rev;
+#endif
+}
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_SYS_BIT_REV_H_ */

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include <zephyr/ztest.h>
+#include <zephyr/sys/bit_rev.h>
 #include <zephyr/sys/minmax.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_utf8.h>
@@ -1001,6 +1002,72 @@ ZTEST(util, test_sys_count_bits)
 
 	zassert_equal(sys_count_bits(u8_arr, sizeof(u8_arr)), 128);
 	zassert_equal(sys_count_bits(&u8_arr[1], sizeof(u8_arr) - sizeof(u8_arr[0])), 124);
+}
+
+ZTEST(util, test_sys_bit_rev32)
+{
+	static const struct {
+		uint32_t input;
+		uint32_t expected;
+	} cases[] = {
+		{ 0x00000000U, 0x00000000U },
+		{ 0x00000001U, 0x80000000U },
+		{ 0x80000000U, 0x00000001U },
+		{ 0xAAAAAAAAU, 0x55555555U },
+		{ 0x12345678U, 0x1E6A2C48U },
+		{ 0x0F0F00FFU, 0xFF00F0F0U },
+	};
+
+	for (size_t i = 0U; i < ARRAY_SIZE(cases); i++) {
+		zassert_equal(sys_bit_rev32(cases[i].input), cases[i].expected,
+			      "Unexpected 32-bit reversal at index %zu", i);
+		zassert_equal(sys_bit_rev32(cases[i].expected), cases[i].input,
+			      "32-bit reversal should be symmetric at index %zu", i);
+	}
+}
+
+ZTEST(util, test_sys_bit_rev16)
+{
+	static const struct {
+		uint16_t input;
+		uint16_t expected;
+	} cases[] = {
+		{ 0x0000U, 0x0000U },
+		{ 0x0001U, 0x8000U },
+		{ 0x8000U, 0x0001U },
+		{ 0x55AAU, 0x55AAU },
+		{ 0x1234U, 0x2C48U },
+		{ 0x00F1U, 0x8F00U },
+	};
+
+	for (size_t i = 0U; i < ARRAY_SIZE(cases); i++) {
+		zassert_equal(sys_bit_rev16(cases[i].input), cases[i].expected,
+			      "Unexpected 16-bit reversal at index %zu", i);
+		zassert_equal(sys_bit_rev16(cases[i].expected), cases[i].input,
+			      "16-bit reversal should be symmetric at index %zu", i);
+	}
+}
+
+ZTEST(util, test_sys_bit_rev8)
+{
+	static const struct {
+		uint8_t input;
+		uint8_t expected;
+	} cases[] = {
+		{ 0x00U, 0x00U },
+		{ 0x01U, 0x80U },
+		{ 0x80U, 0x01U },
+		{ 0x55U, 0xAAU },
+		{ 0x3CU, 0x3CU },
+		{ 0x96U, 0x69U },
+	};
+
+	for (size_t i = 0U; i < ARRAY_SIZE(cases); i++) {
+		zassert_equal(sys_bit_rev8(cases[i].input), cases[i].expected,
+			      "Unexpected 8-bit reversal at index %zu", i);
+		zassert_equal(sys_bit_rev8(cases[i].expected), cases[i].input,
+			      "8-bit reversal should be symmetric at index %zu", i);
+	}
 }
 
 ZTEST(util, test_CONCAT)


### PR DESCRIPTION
add multicast filtering to both cores.

With this we have all features currently supported in the ETH_STM32_HAL_API_V1 stm32f1 and stm32f2 hal based driver also supported in this native driver.