### PR TITLE
Bluetooth: BAP: Shell: Print qos_pref when stream configured

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -315,6 +315,14 @@ static inline void print_qos(const struct bt_bap_qos_cfg *qos)
 #endif /* CONFIG_BT_BAP_BROADCAST_SOURCE || CONFIG_BT_BAP_UNICAST */
 }
 
+static inline void print_qos_pref(const struct bt_bap_qos_cfg_pref *pref)
+{
+	bt_shell_print("QoS Preference: unframed %ssupported, PHY 0x%02x RTN %u latency %u (ms), "
+		       "pd_min %u (us), pd_max %u (us), pref_pd_min %u (us), pref_pd_max %u (us)",
+		       pref->unframed_supported ? "" : "not ", pref->phy, pref->rtn, pref->latency,
+		       pref->pd_min, pref->pd_max, pref->pref_pd_min, pref->pref_pd_max);
+}
+
 struct print_ltv_info {
 	size_t indent;
 	size_t cnt;

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3145,9 +3145,9 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 static void stream_configured_cb(struct bt_bap_stream *stream,
 				 const struct bt_bap_qos_cfg_pref *pref)
 {
-	ARG_UNUSED(pref);
-
 	bt_shell_print("Stream %p configured", stream);
+
+	print_qos_pref(pref);
 }
 
 static void stream_released_cb(struct bt_bap_stream *stream)

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3145,9 +3145,9 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 static void stream_codec_configured_cb(struct bt_bap_stream *stream,
 				       const struct bt_bap_qos_cfg_pref *pref)
 {
-	ARG_UNUSED(pref);
-
 	bt_shell_print("Stream %p configured", stream);
+
+	print_qos_pref(pref);
 }
 
 static void stream_released_cb(struct bt_bap_stream *stream)


### PR DESCRIPTION
Add function to print the QoS preferences.