### PR TITLE
debug: intel adsp: add support for breadcrumbs in double and triple faults.

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -127,6 +127,17 @@ endchoice
 
 endif # XTENSA_FATAL_BREADCRUMB
 
+config XTENSA_ADSP_TRIPLE_FAULT_BREADCRUMB
+	bool "Record triple fault breadcrumbs in HP-SRAM window0"
+	depends on SOC_FAMILY_INTEL_ADSP
+	default y
+	help
+	  When a double exception escalates to a triple fault (escaping the
+	  CPU), record the EPC1, double-exception EXCCAUSE, and DEPC into
+	  HP-SRAM window0 via its uncached alias. This is a lightweight
+	  tracing aid that can be enabled in production builds to diagnose
+	  fatal CPU locks and double faults.
+
 menu "Xtensa HiFi Options"
 
 config XTENSA_CPU_HAS_HIFI

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -81,6 +81,52 @@ config XTENSA_EXCEPTION_ENTER_GDB
 	  When an exception like invalid address access or division by zero is
 	  hit, enter the GDB stub.
 
+config XTENSA_FATAL_BREADCRUMB
+	bool "Record fatal exception breadcrumbs in a SoC-specific location"
+	help
+	  When a fatal exception is taken, record the faulting PC, exception
+	  cause and faulting virtual address in an SoC-specific location, so
+	  that crash information remains visible even when no console or
+	  mtrace output is available. The SoC provides the actual storage and
+	  reporting mechanism; enabling this option only opts a fatal exception
+	  into calling it.
+
+	  For example, on Intel ADSP SoCs this records the breadcrumb into
+	  HP-SRAM window0 via its uncached alias: the host SOF driver prints
+	  window0[0] as "Firmware state" and window0[1] as "status/error code"
+	  on an IPC timeout. Only the first fatal exception is latched so the
+	  original fault is preserved across a crash loop. This is a debug aid
+	  and should be left disabled in production builds.
+
+if XTENSA_FATAL_BREADCRUMB
+
+choice XTENSA_FATAL_BREADCRUMB_DATA
+	prompt "Fatal breadcrumb data selection"
+	default XTENSA_FATAL_BREADCRUMB_DATA_CAUSE
+	help
+	  Select which exception diagnostic data an SoC's breadcrumb handler
+	  should treat as the primary "status/error code" value. Not all SoCs
+	  make use of this selection.
+
+config XTENSA_FATAL_BREADCRUMB_DATA_CAUSE
+	bool "Exception cause"
+	help
+	  Record the exception cause as the status/error code.
+
+config XTENSA_FATAL_BREADCRUMB_DATA_VADDR
+	bool "Faulting virtual address (excvaddr)"
+	help
+	  Record the faulting virtual address (excvaddr) as the status/error code.
+
+config XTENSA_FATAL_BREADCRUMB_DATA_A0
+	bool "Caller return address (a0)"
+	help
+	  Record the calling function's return address (a0) as the status/error code.
+
+endchoice
+
+endif # XTENSA_FATAL_BREADCRUMB
+
 menu "Xtensa HiFi Options"
 
 config XTENSA_CPU_HAS_HIFI

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -79,6 +79,15 @@ config XTENSA_EXCEPTION_ENTER_GDB
 	  When an exception like invalid address access or division by zero is
 	  hit, enter the GDB stub.
 
+config XTENSA_FATAL_BREADCRUMB
+	bool "Record fatal exception breadcrumbs"
+	help
+	  When a fatal exception is taken, record the faulting PC, exception
+	  cause and faulting virtual address so that crash information remains
+	  visible even when no console or mtrace output is available. The SoC
+	  provides the actual storage and reporting mechanism; enabling this
+	  option only opts a fatal exception into calling it.
+
 menu "Xtensa HiFi Options"
 
 config XTENSA_CPU_HAS_HIFI

--- a/arch/xtensa/core/CMakeLists.txt
+++ b/arch/xtensa/core/CMakeLists.txt
@@ -30,6 +30,7 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.S syscall_helper.c)
 zephyr_library_sources_ifdef(CONFIG_LLEXT elf.c)
 zephyr_library_sources_ifdef(CONFIG_SMP smp.c)
 zephyr_library_sources_ifdef(CONFIG_XTENSA_HIFI_SHARING xtensa_hifi.S)
+zephyr_library_sources_ifdef(CONFIG_XTENSA_FATAL_BREADCRUMB xtensa_breadcrumb.c)
 
 zephyr_library_sources(instr_mem.c)
 

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -20,6 +20,8 @@
 #include <xtensa_internal.h>
 #include <xtensa_stack.h>
 
+#include <xtensa_breadcrumb.h>
+
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 extern char xtensa_arch_except_epc[];
@@ -686,6 +688,8 @@ void *xtensa_excint1_c(void *esf)
 
 		ps = bsa->ps;
 		pc = (void *)bsa->pc;
+
+		XTENSA_RECORD_FATAL_BREADCRUMB(bsa, cause);
 
 		/* We intentionally use "ill" (illegal instruction) as a trap for custom exceptions.
 		 * So we need to find out if the illegal instruction is legit.

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -19,6 +19,8 @@
 #include <xtensa_internal.h>
 #include <xtensa_stack.h>
 
+#include <xtensa_breadcrumb.h>
+
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 extern char xtensa_arch_except_epc[];
@@ -671,6 +673,8 @@ void *xtensa_excint1_c(void *esf)
 
 		ps = bsa->ps;
 		pc = (void *)bsa->pc;
+
+		XTENSA_RECORD_FATAL_BREADCRUMB(bsa, cause);
 
 		/* We intentionally use "ill" (illegal instruction) as a trap for custom exceptions.
 		 * So we need to find out if the illegal instruction is legit.

--- a/arch/xtensa/core/xtensa_asm2_util.S
+++ b/arch/xtensa/core/xtensa_asm2_util.S
@@ -12,6 +12,19 @@
 #endif
 
 /*
+ * adsp_triple_fault_breadcrumb - record triple fault state for host diagnosis.
+ *
+ * Weak default is a no-op. SoC families that support it (see
+ * soc/intel/intel_adsp/<family>/asm_breadcrumb.S) link in a strong
+ * override, so the shared vector code stays free of per-SoC #ifdefs.
+ * Called via CALL0; may clobber a2/a3/a4.
+ */
+.weak adsp_triple_fault_breadcrumb
+.align 4
+adsp_triple_fault_breadcrumb:
+	ret
+
+/*
  * xtensa_spill_reg_windows
  *
  * Spill all register windows.  Not a C function, enter this via CALL0
@@ -603,6 +616,7 @@ _TripleFault:
 	movi a2, SYS_exit
 	simcall
 #endif
+	call0 adsp_triple_fault_breadcrumb
 1:
 	j	1b
 

--- a/arch/xtensa/core/xtensa_asm2_util.S
+++ b/arch/xtensa/core/xtensa_asm2_util.S
@@ -12,6 +12,18 @@
 #endif
 
 /*
+ * xtensa_triple_fault_breadcrumb - record triple fault state for host diagnosis.
+ *
+ * Weak default is a no-op. SoC families that support it link in a strong
+ * override, so the shared vector code stays free of per-SoC #ifdefs.
+ * Called via CALL0; may clobber a2/a3/a4.
+ */
+.weak xtensa_triple_fault_breadcrumb
+.align 4
+xtensa_triple_fault_breadcrumb:
+	ret
+
+/*
  * xtensa_spill_reg_windows
  *
  * Spill all register windows.  Not a C function, enter this via CALL0
@@ -632,6 +644,7 @@ _TripleFault:
 	movi a2, SYS_exit
 	simcall
 #endif
+	call0 xtensa_triple_fault_breadcrumb
 1:
 	j	1b
 

--- a/arch/xtensa/core/xtensa_breadcrumb.c
+++ b/arch/xtensa/core/xtensa_breadcrumb.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <xtensa_breadcrumb.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+
+/* No-op default, overridden by SoCs that support fatal breadcrumbs. */
+void __weak xtensa_fatal_breadcrumb(const _xtensa_irq_bsa_t *bsa, int cause)
+{
+	ARG_UNUSED(bsa);
+	ARG_UNUSED(cause);
+}

--- a/arch/xtensa/include/xtensa_breadcrumb.h
+++ b/arch/xtensa/include/xtensa_breadcrumb.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_BREADCRUMB_H_
+#define ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_BREADCRUMB_H_
+
+#ifndef _ASMLANGUAGE
+
+#include <xtensa_asm2_context.h>
+
+#if defined(CONFIG_XTENSA_FATAL_BREADCRUMB)
+
+/**
+ * xtensa_fatal_breadcrumb() - record a fatal exception breadcrumb.
+ * @bsa:   pointer to the _xtensa_irq_bsa_t base save area
+ * @cause: EXCCAUSE code for the exception
+ *
+ * Weakly defined with a no-op default; an SoC that supports
+ * CONFIG_XTENSA_FATAL_BREADCRUMB provides a strong override that records
+ * the breadcrumb into its own SoC-specific storage.
+ */
+void xtensa_fatal_breadcrumb(const _xtensa_irq_bsa_t *bsa, int cause);
+
+#define XTENSA_RECORD_FATAL_BREADCRUMB(bsa, cause) xtensa_fatal_breadcrumb(bsa, cause)
+
+#else
+
+#define XTENSA_RECORD_FATAL_BREADCRUMB(bsa, cause) do { } while (0)
+
+#endif /* CONFIG_XTENSA_FATAL_BREADCRUMB */
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_BREADCRUMB_H_ */

--- a/arch/xtensa/include/xtensa_breadcrumb.h
+++ b/arch/xtensa/include/xtensa_breadcrumb.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_BREADCRUMB_H_
+#define ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_BREADCRUMB_H_
+
+#ifndef _ASMLANGUAGE
+
+#include <xtensa_asm2_context.h>
+
+#if defined(CONFIG_XTENSA_FATAL_BREADCRUMB) || defined(__DOXYGEN__)
+
+/**
+ * @brief Record a fatal exception breadcrumb.
+ *
+ * Weakly defined with a no-op default; an SoC that supports
+ * CONFIG_XTENSA_FATAL_BREADCRUMB provides a strong override that records
+ * the breadcrumb into its own SoC-specific storage.
+ *
+ * @param bsa Pointer to the _xtensa_irq_bsa_t base save area.
+ * @param cause EXCCAUSE code for the exception.
+ */
+void xtensa_fatal_breadcrumb(const _xtensa_irq_bsa_t *bsa, int cause);
+
+#define XTENSA_RECORD_FATAL_BREADCRUMB(bsa, cause) xtensa_fatal_breadcrumb(bsa, cause)
+
+#else
+
+#define XTENSA_RECORD_FATAL_BREADCRUMB(bsa, cause) do { } while (0)
+
+#endif /* CONFIG_XTENSA_FATAL_BREADCRUMB || __DOXYGEN__ */
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_BREADCRUMB_H_ */

--- a/soc/intel/intel_adsp/Kconfig
+++ b/soc/intel/intel_adsp/Kconfig
@@ -176,4 +176,14 @@ config INTEL_ADSP_UNCACHED_REGION
 	  As for INTEL_ADSP_CACHED_REGION, this specifies which 512M
 	  region (0-7) contains the "uncached" mapping.
 
+config SOC_FAMILY_INTEL_ADSP_TRIPLE_FAULT_BREADCRUMB
+	bool "Record triple fault breadcrumbs in HP-SRAM window0"
+	default y
+	help
+	  When a double exception escalates to a triple fault (escaping the
+	  CPU), record the EPC1, double-exception EXCCAUSE, and DEPC into
+	  HP-SRAM window0 via its uncached alias. This is a lightweight
+	  tracing aid that can be enabled in production builds to diagnose
+	  fatal CPU locks and double faults.
+
 endif # SOC_FAMILY_INTEL_ADSP

--- a/soc/intel/intel_adsp/ace/CMakeLists.txt
+++ b/soc/intel/intel_adsp/ace/CMakeLists.txt
@@ -30,6 +30,7 @@ zephyr_library_sources_ifdef(
   CONFIG_SOC_SERIES_INTEL_ADSP_ACE_CUSTOM_MORE_SPIN_RELAX_NOPS
   spin_relax.c
 )
+zephyr_library_sources_ifdef(CONFIG_XTENSA_ADSP_TRIPLE_FAULT_BREADCRUMB asm_breadcrumb.S)
 
 if(CONFIG_XTENSA_MMU)
   zephyr_library_sources_ifdef(CONFIG_SOC_ACE30 mmu_ace30.c)

--- a/soc/intel/intel_adsp/ace/CMakeLists.txt
+++ b/soc/intel/intel_adsp/ace/CMakeLists.txt
@@ -30,6 +30,7 @@ zephyr_library_sources_ifdef(
   CONFIG_SOC_SERIES_INTEL_ADSP_ACE_CUSTOM_MORE_SPIN_RELAX_NOPS
   spin_relax.c
 )
+zephyr_library_sources_ifdef(CONFIG_SOC_FAMILY_INTEL_ADSP_TRIPLE_FAULT_BREADCRUMB asm_breadcrumb.S)
 
 if(CONFIG_XTENSA_MMU)
   zephyr_library_sources_ifdef(CONFIG_SOC_ACE30 mmu_ace30.c)

--- a/soc/intel/intel_adsp/ace/asm_breadcrumb.S
+++ b/soc/intel/intel_adsp/ace/asm_breadcrumb.S
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * adsp_triple_fault_breadcrumb - record triple fault state into HP-SRAM window0.
+ *
+ * Strong override of the weak default in arch/xtensa/core/xtensa_asm2_util.S,
+ * linked in only for the ACE SoC family (see CMakeLists.txt). Called via
+ * CALL0 from the shared triple-fault handler.
+ *
+ * Writes EPC1, EXCCAUSE|0xdb1e0000 and DEPC to the HP-SRAM window0 uncached
+ * alias so the host SOF driver can diagnose a triple fault from dmesg.
+ * Constructs the base address using shifts to avoid literal generation under
+ * Clang's Integrated Assembler. Clobbers a2/a3/a4.
+ */
+.global adsp_triple_fault_breadcrumb
+.align 4
+adsp_triple_fault_breadcrumb:
+	/* Construct window0 uncached base without literals/l32r (Clang IAS safe) */
+	movi a3, 1
+	slli a3, a3, 30
+	movi a4, 0x240
+	slli a4, a4, 8
+	add a3, a3, a4
+	rsr.epc1 a2
+	s32i a2, a3, 0
+	/* Construct 0xdb1e0000 without literals/l32r */
+	movi a2, 0xdb
+	slli a2, a2, 8
+	movi a4, 0x1e
+	add a2, a2, a4
+	slli a2, a2, 16
+	rsr.exccause a4
+	or a2, a2, a4
+	s32i a2, a3, 4
+	rsr.depc a2
+	s32i a2, a3, 8
+	memw
+	ret

--- a/soc/intel/intel_adsp/ace/asm_breadcrumb.S
+++ b/soc/intel/intel_adsp/ace/asm_breadcrumb.S
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * xtensa_triple_fault_breadcrumb - record triple fault state into HP-SRAM window0.
+ *
+ * Strong override of the weak default in arch/xtensa/core/xtensa_asm2_util.S,
+ * linked in only for the ACE SoC family (see CMakeLists.txt). Called via
+ * CALL0 from the shared triple-fault handler.
+ *
+ * Writes EPC1, EXCCAUSE|0xdb1e0000 and DEPC to the HP-SRAM window0 uncached
+ * alias so the host SOF driver can diagnose a triple fault from dmesg.
+ * Constructs the base address using shifts to avoid literal generation under
+ * Clang's Integrated Assembler. Clobbers a2/a3/a4.
+ */
+.global xtensa_triple_fault_breadcrumb
+.align 4
+xtensa_triple_fault_breadcrumb:
+	/* Construct window0 uncached base without literals/l32r (Clang IAS safe) */
+	movi a3, 1
+	slli a3, a3, 30
+	movi a4, 0x240
+	slli a4, a4, 8
+	add a3, a3, a4
+	rsr.epc1 a2
+	s32i a2, a3, 0
+	/* Construct 0xdb1e0000 without literals/l32r */
+	movi a2, 0xdb
+	slli a2, a2, 8
+	movi a4, 0x1e
+	add a2, a2, a4
+	slli a2, a2, 16
+	rsr.exccause a4
+	or a2, a2, a4
+	s32i a2, a3, 4
+	rsr.depc a2
+	s32i a2, a3, 8
+	memw
+	ret

--- a/soc/intel/intel_adsp/cavs/CMakeLists.txt
+++ b/soc/intel/intel_adsp/cavs/CMakeLists.txt
@@ -23,4 +23,6 @@ endif()
 
 zephyr_library_sources_ifdef(CONFIG_CAVS_ICTL irq.c)
 
+zephyr_library_sources_ifdef(CONFIG_XTENSA_ADSP_TRIPLE_FAULT_BREADCRUMB asm_breadcrumb.S)
+
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/include/xtensa-cavs-linker.ld CACHE INTERNAL "")

--- a/soc/intel/intel_adsp/cavs/CMakeLists.txt
+++ b/soc/intel/intel_adsp/cavs/CMakeLists.txt
@@ -23,4 +23,6 @@ endif()
 
 zephyr_library_sources_ifdef(CONFIG_CAVS_ICTL irq.c)
 
+zephyr_library_sources_ifdef(CONFIG_SOC_FAMILY_INTEL_ADSP_TRIPLE_FAULT_BREADCRUMB asm_breadcrumb.S)
+
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/include/xtensa-cavs-linker.ld CACHE INTERNAL "")

--- a/soc/intel/intel_adsp/cavs/asm_breadcrumb.S
+++ b/soc/intel/intel_adsp/cavs/asm_breadcrumb.S
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * adsp_triple_fault_breadcrumb - record triple fault state into HP-SRAM window0.
+ *
+ * Strong override of the weak default in arch/xtensa/core/xtensa_asm2_util.S,
+ * linked in only for the cAVS SoC family (see CMakeLists.txt). Called via
+ * CALL0 from the shared triple-fault handler.
+ *
+ * Writes EPC1, EXCCAUSE|0xdb1e0000 and DEPC to the HP-SRAM window0 uncached
+ * alias so the host SOF driver can diagnose a triple fault from dmesg.
+ * Constructs the base address using shifts to avoid literal generation under
+ * Clang's Integrated Assembler. Clobbers a2/a3/a4.
+ */
+.global adsp_triple_fault_breadcrumb
+.align 4
+adsp_triple_fault_breadcrumb:
+	/* Construct window0 uncached base without literals/l32r (Clang IAS safe) */
+	movi a3, 0x5e
+	slli a3, a3, 24
+	movi a4, 0x240
+	slli a4, a4, 8
+	add a3, a3, a4
+	rsr.epc1 a2
+	s32i a2, a3, 0
+	/* Construct 0xdb1e0000 without literals/l32r */
+	movi a2, 0xdb
+	slli a2, a2, 8
+	movi a4, 0x1e
+	add a2, a2, a4
+	slli a2, a2, 16
+	rsr.exccause a4
+	or a2, a2, a4
+	s32i a2, a3, 4
+	rsr.depc a2
+	s32i a2, a3, 8
+	memw
+	ret

--- a/soc/intel/intel_adsp/cavs/asm_breadcrumb.S
+++ b/soc/intel/intel_adsp/cavs/asm_breadcrumb.S
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * xtensa_triple_fault_breadcrumb - record triple fault state into HP-SRAM window0.
+ *
+ * Strong override of the weak default in arch/xtensa/core/xtensa_asm2_util.S,
+ * linked in only for the cAVS SoC family (see CMakeLists.txt). Called via
+ * CALL0 from the shared triple-fault handler.
+ *
+ * Writes EPC1, EXCCAUSE|0xdb1e0000 and DEPC to the HP-SRAM window0 uncached
+ * alias so the host SOF driver can diagnose a triple fault from dmesg.
+ * Constructs the base address using shifts to avoid literal generation under
+ * Clang's Integrated Assembler. Clobbers a2/a3/a4.
+ */
+.global xtensa_triple_fault_breadcrumb
+.align 4
+xtensa_triple_fault_breadcrumb:
+	/* Construct window0 uncached base without literals/l32r (Clang IAS safe) */
+	movi a3, 0x5e
+	slli a3, a3, 24
+	movi a4, 0x240
+	slli a4, a4, 8
+	add a3, a3, a4
+	rsr.epc1 a2
+	s32i a2, a3, 0
+	/* Construct 0xdb1e0000 without literals/l32r */
+	movi a2, 0xdb
+	slli a2, a2, 8
+	movi a4, 0x1e
+	add a2, a2, a4
+	slli a2, a2, 16
+	rsr.exccause a4
+	or a2, a2, a4
+	s32i a2, a3, 4
+	rsr.depc a2
+	s32i a2, a3, 8
+	memw
+	ret

--- a/soc/intel/intel_adsp/common/CMakeLists.txt
+++ b/soc/intel/intel_adsp/common/CMakeLists.txt
@@ -25,6 +25,8 @@ zephyr_library_sources(
 
 zephyr_library_sources_ifdef(CONFIG_ADSP_CLOCK clk.c)
 
+zephyr_library_sources_ifdef(CONFIG_XTENSA_FATAL_BREADCRUMB xtensa_breadcrumb.c)
+
 zephyr_library_sources_ifdef(CONFIG_INTEL_ADSP_DEBUG_SLOT_MANAGER
     debug_window.c
     )

--- a/soc/intel/intel_adsp/common/include/mem_window.h
+++ b/soc/intel/intel_adsp/common/include/mem_window.h
@@ -8,6 +8,8 @@
 #ifndef _ADSP_MEMORY_WINDOW_H_
 #define _ADSP_MEMORY_WINDOW_H_
 
+#include <adsp_memory.h>
+
 #define WIN_SIZE(N) (CONFIG_MEMORY_WIN_##N##_SIZE)
 
 #define MEM_WINDOW_NODE(n) DT_NODELABEL(mem_window##n)

--- a/soc/intel/intel_adsp/common/xtensa_breadcrumb.c
+++ b/soc/intel/intel_adsp/common/xtensa_breadcrumb.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <xtensa_breadcrumb.h>
+#include <adsp_memory.h>
+#include <mem_window.h>
+#include <zephyr/cache.h>
+
+/* Select diagnostic data written to win0[1] (host "status/error code") */
+#if defined(CONFIG_XTENSA_FATAL_BREADCRUMB_DATA_VADDR)
+#define BC_DATA1(bsa, cause)	((uint32_t)(bsa)->excvaddr)
+#elif defined(CONFIG_XTENSA_FATAL_BREADCRUMB_DATA_A0)
+#define BC_DATA1(bsa, cause)	((uint32_t)(bsa)->a0)
+#else
+#define BC_DATA1(bsa, cause)	(0xe0000000U | ((uint32_t)(cause) & 0xffU))
+#endif
+
+/*
+ * Record a fatal exception into HP-SRAM window0. Only the first fatal
+ * exception is latched; win0[3] counts all.
+ */
+void xtensa_fatal_breadcrumb(const _xtensa_irq_bsa_t *bsa, int cause)
+{
+	volatile uint32_t *win0 =
+		(volatile uint32_t *)sys_cache_uncached_ptr_get((void *)HP_SRAM_WIN0_BASE);
+
+	if (win0[0] == 0U) {
+		win0[0] = (uint32_t)bsa->pc;
+		win0[1] = BC_DATA1(bsa, cause);
+		win0[2] = (uint32_t)bsa->excvaddr;
+		win0[4] = *(volatile uint32_t *)((uint32_t)bsa->pc & ~3U);
+	}
+	win0[3]++;
+}

--- a/soc/intel/intel_adsp/common/xtensa_breadcrumb.c
+++ b/soc/intel/intel_adsp/common/xtensa_breadcrumb.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <xtensa_breadcrumb.h>
+#include <adsp_memory.h>
+#include <mem_window.h>
+#include <zephyr/cache.h>
+
+/*
+ * Record a fatal exception into HP-SRAM window0. Only the first fatal
+ * exception is latched; win0[3] counts all.
+ */
+void xtensa_fatal_breadcrumb(const _xtensa_irq_bsa_t *bsa, int cause)
+{
+	volatile uint32_t *win0 =
+		(volatile uint32_t *)sys_cache_uncached_ptr_get((void *)HP_SRAM_WIN0_BASE);
+
+	if (win0[0] == 0U) {
+		win0[0] = (uint32_t)bsa->pc;
+		win0[1] = 0xe0000000U | ((uint32_t)cause & 0xffU);
+		win0[2] = (uint32_t)bsa->excvaddr;
+		win0[4] = *(volatile uint32_t *)((uint32_t)bsa->pc & ~3U);
+	}
+	win0[3]++;
+}


### PR DESCRIPTION
Very useful for agentic flows, particularly when stack is unavailable to Linux driver.  Linux always logs 2 "registers" to kernel logs in a shared HP-SRAM memory Window during FW hangs. Regular stack/register dumps are not showing in many cases (possibly due to corrupt stack/register data) hence the need for this, in particular for IPC timeouts.

```XTENSA_ADSP_TRIPLE_FAULT_BREADCRUMB``` should be available in production configurations.

@nashif @dcpleung draft atm as I think we could additionally put some assembly to dump more data here, we have the window space, but obviously cant call the C based stack dump infra as our stack is likely toast (and that's why we end up here).  This is not to replace the regular stack dump on adsp, but an additional source of knowledge especially for triple fault which is a black hole on adsp socs today. 