### PR TITLE
babblesim bt audio tests: Build and run with twister

### DIFF
--- a/tests/bsim/bluetooth/audio/tests.yaml
+++ b/tests/bsim/bluetooth/audio/tests.yaml
@@ -1,0 +1,23 @@
+common:
+  timeout: 1500
+  tags:
+    - bluetooth
+  depends_on: bsim
+  sysbuild: true
+  harness: bsim
+  harness_config:
+    fixture: bsim_multi_test
+    bsim_exe_name: tests_bsim_bluetooth_audio_prj_conf
+    tests_scripts:
+      - test_scripts
+
+tests:
+  bluetooth.audio:
+    platform_allow:
+      - nrf52_bsim
+      - nrf54l15bsim/nrf54l15/cpuapp
+    extra_args:
+      EXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf
+  bluetooth.audio.nrf5340cpuapp:
+    platform_allow:
+      - nrf5340bsim/nrf5340/cpuapp

--- a/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
@@ -24,7 +24,6 @@ app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-ticker_expire_info.conf sys
 app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_group.conf sysbuild=1 compile
 
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
-run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio/compile.sh
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio_samples/compile.sh
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
@@ -26,7 +26,6 @@ app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-interleaved.conf  compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-ticker_expire_info.conf compile
 
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
-run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio/compile.sh
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio_samples/compile.sh
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/compile.sh
+++ b/tests/bsim/bluetooth/compile.sh
@@ -13,9 +13,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Note: We do not parallelize the call into the build of the host, ll and mesh images as those
 # are already building many images in parallel in themselves, and otherwise we would be
 # launching too many parallel builds which can lead to a too high system load.
-# On the other hand the audio compile script, only builds one image. So we parallelize it with
-# the rest to save a couple of seconds.
-run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio_samples/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/ll/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/mesh/compile.sh

--- a/tests/bsim/bluetooth/tests.nrf52bsim.txt
+++ b/tests/bsim/bluetooth/tests.nrf52bsim.txt
@@ -1,6 +1,5 @@
 # Search paths(s) for tests which will be run in the nrf52bsim
 # This file is used in CI to select which tests are run
-tests/bsim/bluetooth/audio/
 tests/bsim/bluetooth/audio_samples/
 tests/bsim/bluetooth/hci_uart/
 tests/bsim/bluetooth/ll/

--- a/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
@@ -9,5 +9,4 @@ tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
 tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
 tests/bsim/bluetooth/samples/peripheral_gap_svc/
 tests/bsim/bluetooth/audio_samples/
-tests/bsim/bluetooth/audio/
 tests/bsim/bluetooth/tester/

--- a/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
@@ -11,4 +11,3 @@ tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
 tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
 tests/bsim/bluetooth/samples/peripheral_gap_svc/
 tests/bsim/bluetooth/audio_samples/
-tests/bsim/bluetooth/audio/

--- a/tests/bsim/ci.bt.sh
+++ b/tests/bsim/ci.bt.sh
@@ -13,6 +13,8 @@ set -uex
 
 TWISTER_OPTIONS="-vv --fixture bsim_multi_test --no-clean --force-color --inline-logs"
 
+${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/audio/
+
 ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/host/
 
 # nrf52_bsim set:


### PR DESCRIPTION
For background and motivation see https://github.com/zephyrproject-rtos/zephyr/pull/113101

This PR changes the BT audio bsim tests to be both built and *run* using twister.
This means that users which have Babblesim installed can run these tests with twister in a quite comparable way to single device test. For example:
`twister -T tests/bsim/bluetooth/audio/ -vv --fixture bsim_multi_test`

Note these tests can still be run with run_parallel.sh as before. Just now the default test list used by CI does not include them.

Related to:
* https://github.com/zephyrproject-rtos/zephyr/pull/113395
* #113225
* https://github.com/zephyrproject-rtos/zephyr/pull/113101