### PR TITLE
stm32: tests: drivers: disk_access: enable HWFC for stm32h573i_dk

### DIFF
--- a/tests/drivers/disk/disk_access/boards/stm32h573i_dk.conf
+++ b/tests/drivers/disk/disk_access/boards/stm32h573i_dk.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SDMMC_STM32_HWFC=y


### PR DESCRIPTION
Enable STM32 SDMMC Hardware Flow control in the board configuration to prevent FIFO underrun (error 16 | 0x10) and overrun (error 32 | 0x20) errors during disk_access tests on stm32h573i_dk.

