### PR TITLE
modem: cellular: revert baudrate on power-on pulse

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -934,6 +934,11 @@ static int modem_cellular_on_power_on_pulse_state_enter(struct modem_cellular_da
 {
 	const struct modem_cellular_config *config = data->dev->config;
 
+	/* Revert to original baudrate if we have changed it */
+	if (data->original_baudrate) {
+		modem_cellular_baudrate_update(data, data->original_baudrate);
+	}
+
 	gpio_pin_set_dt(&config->power_gpio, 1);
 	modem_cellular_start_timer(data, K_MSEC(config->vendor->power_pulse_duration_ms));
 	return 0;


### PR DESCRIPTION
The power-on pulse re-powers a modem that returns to its default UART rate, since `AT+IPR` is not persisted across a power cycle. When the host UART was switched to `CONFIG_MODEM_CELLULAR_NEW_BAUDRATE` the two ends no longer agree, so re-initialization runs at a mismatched rate and never completes.

Revert the host UART to the original baudrate before pulsing the power pin, mirroring the reset path (0ba20dd96ce). Guarded by `original_baudrate` so it is a no-op for modems that do not switch rate.