### PR TITLE
tests: arch: cache: don't invalidate all cache on Xtensa

### DIFF
--- a/tests/arch/common/cache/src/test_cache_api.c
+++ b/tests/arch/common/cache/src/test_cache_api.c
@@ -117,11 +117,19 @@ ZTEST(cache_api, test_data_cache_api)
 	ret = sys_cache_data_flush_all();
 	zassert_true((ret == 0) || (ret == -ENOTSUP));
 
+#if !defined(CONFIG_XTENSA)
+	/* Xtensa with Windowed ABI may write to stack due to window
+	 * over-/under-flow. So we cannot invalidate all cache lines here
+	 * or the data written will be lost forever, which will possibly
+	 * result in CPU fault. So skip this test on Xtensa.
+	 */
+
 	/* Flush first so the whole-cache invalidate does not discard dirty
 	 * lines that the test framework still depends on.
 	 */
 	ret = sys_cache_data_invd_all();
 	zassert_true((ret == 0) || (ret == -ENOTSUP));
+#endif /* !CONFIG_XTENSA */
 
 	ret = sys_cache_data_flush_and_invd_all();
 	zassert_true((ret == 0) || (ret == -ENOTSUP));


### PR DESCRIPTION
The test itself cannot invalidate all cache lines as the thread may be running with a cached stack. Any invalidation is going to discard any changes after the flush all call.
On Xtensa with windowed register, a function call may result in window over-/under-flow where registers are being written to stack at function entry/exit. If this happens after the flush all call, the register values are written to stack on entry to the cache all invalidation call. The written values are then lost forever. When the call returns, incorrect register values will be restored from main memory since the modified stack has never been commited to main memory, which will probably result in fault. So skip cache all invalidation test on Xtensa.