### PR TITLE
[DNM] soc: espressif: add esp32p4 nocache memory support

### DIFF
--- a/soc/espressif/esp32p4/Kconfig
+++ b/soc/espressif/esp32p4/Kconfig
@@ -11,6 +11,8 @@ config SOC_SERIES_ESP32P4
 	select CPU_HAS_DCACHE if SOC_ESP32P4_HPCORE
 	select HAS_PM
 	select HAS_POWEROFF
+	select ARCH_HAS_NOCACHE_MEMORY_SUPPORT
+	select NOCACHE_MEMORY
 
 if SOC_SERIES_ESP32P4
 
@@ -71,6 +73,7 @@ rsource "Kconfig.caps"
 config ESP32P4_EMAC
 	bool
 	default y if ETH_ESP32
+	default y if ETH_ESP32_DWC_ETHER_1000
 	default y if MDIO_ESP32
 	help
 	  Hidden option to enable the ESP32-P4 Ethernet

--- a/soc/espressif/esp32p4/default.ld
+++ b/soc/espressif/esp32p4/default.ld
@@ -47,7 +47,13 @@ user_sram_size = (user_sram_end - user_sram_org);
 	#endif
 #else
 	#define MPU_MIN_SIZE_ALIGN
-	#define MPU_ALIGN(region_size) . = ALIGN(4)
+	/* The nocache region is carved out with a dedicated PMA entry and must
+	 * start and end on an L2 cache line boundary so it does not share a line
+	 * with cacheable data. The line size is 64 bytes on the 128KB/256KB
+	 * caches and 128 bytes on the 512KB cache, so align to the configured
+	 * value regardless of the silicon revision.
+	 */
+	#define MPU_ALIGN(region_size) . = ALIGN(CONFIG_ESP32_CACHE_L2_LINE_SIZE)
 #endif
 
 #undef GROUP_DATA_LINK_IN

--- a/soc/espressif/esp32p4/soc.c
+++ b/soc/espressif/esp32p4/soc.c
@@ -5,6 +5,7 @@
  */
 
 #include <soc.h>
+#include <soc/soc.h>
 #include <soc_init.h>
 #include <flash_init.h>
 #include <esp_err.h>
@@ -13,16 +14,20 @@
 #include <esp_timer.h>
 #include <efuse_virtual.h>
 #include <esp_rom_serial_output.h>
+#include <stdint.h>
 #include <zephyr/init.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32.h>
+#include <zephyr/linker/linker-defs.h>
 #include <zephyr/kernel_structs.h>
 #include <zephyr/arch/common/init.h>
 #include <zephyr/arch/riscv/arch.h>
+#include <riscv/csr.h>
 #include <hal/interrupt_clic_ll.h>
 #include <riscv/interrupt.h>
 #include <soc/interrupts.h>
 #include <psram.h>
 #include <zephyr/sys/printk.h>
+#include <zephyr/cache.h>
 
 extern void esp_reset_reason_init(void);
 extern FUNC_NORETURN void z_cstart(void);
@@ -37,6 +42,38 @@ static void core_intr_matrix_clear(void)
 		esprv_int_set_vectored(i, true);
 	}
 }
+
+#if defined(CONFIG_NOCACHE_MEMORY)
+/*
+ * The nocache region is carved out of internal SRAM using PMA entries. The
+ * region boundaries come from the linker symbols, so they automatically track
+ * the usable SRAM window for the target silicon revision: on rev v1.3 the L2
+ * cache sits at the top of SRAM, while on rev v3.x it sits at the bottom, but
+ * in both cases the linker places the nocache section within the valid RAM and
+ * these entries follow it. The chain covers cacheable RAM below the region
+ * (entry 0), the noncacheable window itself (entry 1), and the remaining
+ * cacheable space up to the peripheral range (entry 2).
+ */
+static void configure_nocache_region(void)
+{
+	const uintptr_t nocache_start = (uintptr_t)_nocache_ram_start;
+	const uintptr_t nocache_end = (uintptr_t)_nocache_ram_end;
+
+	/* The region is aligned to the L2 cache line size by the linker, so any
+	 * cached copies of it can be dropped a whole line at a time.
+	 */
+	sys_cache_data_flush_and_invd_range(_nocache_ram_start, (size_t)_nocache_ram_size);
+
+	PMA_RESET_AND_ENTRY_SET_TOR(0, nocache_start, PMA_L | PMA_EN | PMA_TOR | PMA_R | PMA_W | PMA_X);
+	PMA_RESET_AND_ENTRY_SET_TOR(1, nocache_end,
+				    PMA_L | PMA_TOR | PMA_EN | PMA_R | PMA_W | PMA_X | PMA_NONCACHEABLE | PMA_WRITETHROUGH | PMA_WRITEMISSNOALLOC | PMA_READMISSNOALLOC);
+	PMA_RESET_AND_ENTRY_SET_TOR(2, SOC_PERIPHERAL_LOW,
+				    PMA_L | PMA_TOR | PMA_EN | PMA_R | PMA_W | PMA_X);
+
+	/* Reset PMA entries that were set by the rom */
+	PMA_ENTRY_CFG_RESET(15);
+}
+#endif
 
 void IRAM_ATTR __esp_platform_app_start(void)
 {
@@ -69,6 +106,10 @@ void IRAM_ATTR __esp_platform_app_start(void)
 	if (err) {
 		printk("Failed to initialize PSRAM shared multi heap (%d)\n", err);
 	}
+#endif
+
+#if defined(CONFIG_NOCACHE_MEMORY)
+	configure_nocache_region();
 #endif
 
 	z_cstart();


### PR DESCRIPTION
Enable non-cacheable memory support on the esp32p4 by selecting NOCACHE_MEMORY and configuring PMA entries so the nocache region is mapped as noncacheable at startup.

Align the nocache region to the configured L2 cache line size so the boundaries are correct on both rev v1.3 and rev v3.x silicon, whose cache and SRAM layouts differ. The PMA entries follow the linker symbols, so they track the usable SRAM window per revision.