### PR TITLE
drivers: gpio: gpio_mcux: support GPIO_DISCONNECTED in PORT variant

### DIFF
--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -184,6 +184,18 @@ static int gpio_mcux_port_configure(const struct device *dev, gpio_pin_t pin, gp
 		}
 		gpio_base->PDDR |= BIT(pin);
 		break;
+	case GPIO_DISCONNECTED:
+		gpio_base->PDDR &= ~BIT(pin);
+		/* Set the pin MUX to 0 (pin disabled / Alternative 0). This
+		 * disconnects the pin from the GPIO module and disables the
+		 * digital input buffer, so a floating pad draws no current.
+		 */
+		mask = PORT_PCR_MUX_MASK;
+#if defined(FSL_FEATURE_PORT_HAS_INPUT_BUFFER) && FSL_FEATURE_PORT_HAS_INPUT_BUFFER
+		mask |= PORT_PCR_IBE_MASK;
+#endif
+		port_base->PCR[pin] &= ~mask;
+		return 0;
 	default:
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
The PORT-based gpio_mcux_port_configure() rejects any configuration that sets neither GPIO_INPUT nor GPIO_OUTPUT with -ENOTSUP. This makes it impossible to release a pin with gpio_pin_configure(dev, pin, GPIO_DISCONNECTED), which applications such as debug probes and programmers need in order to tri-state shared target pins (SWD, ICSP, UPDI) when a protocol is deactivated.

Handle GPIO_DISCONNECTED by clearing the pin's direction bit in PDDR, turning it into an input. Since no pull flags are present in a disconnect request, the pull resistors are also disabled by the existing PCR logic below, leaving the pin floating (high impedance).

Tested by building samples/subsys/dap for frdm_mcxa156; the change has been shipping as a downstream patch in our probe firmware (MCXA156), where it releases shared programming pins between protocol switches.