### PR TITLE
dap: add lock API to serialize debug port access

### DIFF
--- a/include/zephyr/dap/dap_link.h
+++ b/include/zephyr/dap/dap_link.h
@@ -16,6 +16,7 @@
 #include <stdint.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/swdp.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,6 +38,8 @@ struct dap_link_context {
 	/** @cond INTERNAL_HIDDEN */
 	/* Pointer to SWD or JTAG device. Only SWD is supported yet. */
 	const struct device *dev;
+	/* Serializes debug port access, see dap_link_lock() */
+	struct k_mutex lock;
 	atomic_t state;
 	/* Runtime debug port type */
 	uint8_t debug_port;
@@ -73,6 +76,7 @@ struct dap_link_context {
 #define DAP_LINK_CONTEXT_DEFINE(ctx_name, ctx_dev)				\
 	static struct dap_link_context ctx_name = {				\
 		.dev = ctx_dev,							\
+		.lock = Z_MUTEX_INITIALIZER(ctx_name.lock),			\
 	}
 
 /**
@@ -94,6 +98,37 @@ int dap_link_init(struct dap_link_context *const dap_link_ctx);
  */
 void dap_link_set_pkt_size(struct dap_link_context *const dap_link_ctx,
 			   const uint16_t pkt_size);
+
+/**
+ * @brief Lock the debug port used by a DAP Link context.
+ *
+ * A backend holds this lock while it executes DAP commands via
+ * dap_link_execute_cmd(). An application that accesses the same SWD/JTAG
+ * interface directly (for example to poll a SEGGER RTT control block or to
+ * program target memory) can hold the lock across its own transfer sequence
+ * to prevent interleaving with DAP commands issued by the debug host.
+ *
+ * The lock may be acquired recursively by the same thread.
+ *
+ * @warning Keep hold times short. The USB backend calls
+ * dap_link_execute_cmd() from its transfer completion handler, which runs
+ * in the USB device stack context and blocks on this lock without a
+ * timeout. While an application holds the lock (or a DAP command batch
+ * executes), that context cannot service other transfers — every USB
+ * function on the device stalls, not just DAP. Do not hold the lock
+ * across waits for external events; split long transfer sequences into
+ * short locked sections.
+ *
+ * @param[in] dap_link_ctx Context whose debug port is to be locked.
+ */
+void dap_link_lock(struct dap_link_context *const dap_link_ctx);
+
+/**
+ * @brief Unlock the debug port used by a DAP Link context.
+ *
+ * @param[in] dap_link_ctx Context whose debug port is to be unlocked.
+ */
+void dap_link_unlock(struct dap_link_context *const dap_link_ctx);
 
 /**
  * @brief Initialize the DAP Link USB backend.

--- a/include/zephyr/dap/dap_link.h
+++ b/include/zephyr/dap/dap_link.h
@@ -16,6 +16,7 @@
 #include <stdint.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/swdp.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,6 +38,8 @@ struct dap_link_context {
 	/** @cond INTERNAL_HIDDEN */
 	/* Pointer to SWD or JTAG device. Only SWD is supported yet. */
 	const struct device *dev;
+	/* Serializes debug port access, see dap_link_lock() */
+	struct k_mutex lock;
 	atomic_t state;
 	/* Runtime debug port type */
 	uint8_t debug_port;
@@ -73,6 +76,7 @@ struct dap_link_context {
 #define DAP_LINK_CONTEXT_DEFINE(ctx_name, ctx_dev)				\
 	static struct dap_link_context ctx_name = {				\
 		.dev = ctx_dev,							\
+		.lock = Z_MUTEX_INITIALIZER(ctx_name.lock),			\
 	}
 
 /**
@@ -94,6 +98,32 @@ int dap_link_init(struct dap_link_context *const dap_link_ctx);
  */
 void dap_link_set_pkt_size(struct dap_link_context *const dap_link_ctx,
 			   const uint16_t pkt_size);
+
+/**
+ * @brief Lock the debug port used by a DAP Link context.
+ *
+ * dap_link_execute_cmd() holds this lock for the duration of a command.
+ * An application that drives the same debug port from its own threads can
+ * hold it across a transfer sequence to keep DAP commands from
+ * interleaving with its own.
+ *
+ * The lock is recursive for the owning thread.
+ *
+ * @warning The USB backend executes commands in its transfer completion
+ * handler, so a long hold stalls every USB function on the device, not
+ * just DAP. Keep locked sections short and do not block on external
+ * events under the lock.
+ *
+ * @param[in] dap_link_ctx Context whose debug port is to be locked.
+ */
+void dap_link_lock(struct dap_link_context *const dap_link_ctx);
+
+/**
+ * @brief Unlock the debug port used by a DAP Link context.
+ *
+ * @param[in] dap_link_ctx Context whose debug port is to be unlocked.
+ */
+void dap_link_unlock(struct dap_link_context *const dap_link_ctx);
 
 /**
  * @brief Initialize the DAP Link USB backend.

--- a/subsys/dap/cmsis_dap.c
+++ b/subsys/dap/cmsis_dap.c
@@ -990,6 +990,8 @@ uint32_t dap_link_execute_cmd(struct dap_link_context *const dap_link_ctx,
 	uint16_t n;
 	uint8_t count;
 
+	dap_link_lock(dap_link_ctx);
+
 	if (request[0] == ID_DAP_EXECUTE_COMMANDS) {
 		/* copy command and increment */
 		*response++ = *request++;
@@ -1005,10 +1007,24 @@ uint32_t dap_link_execute_cmd(struct dap_link_context *const dap_link_ctx,
 			request += n;
 			response += n;
 		}
+		dap_link_unlock(dap_link_ctx);
 		return retval;
 	}
 
-	return dap_process_cmd(dap_link_ctx, request, response);
+	retval = dap_process_cmd(dap_link_ctx, request, response);
+	dap_link_unlock(dap_link_ctx);
+
+	return retval;
+}
+
+void dap_link_lock(struct dap_link_context *const dap_link_ctx)
+{
+	k_mutex_lock(&dap_link_ctx->lock, K_FOREVER);
+}
+
+void dap_link_unlock(struct dap_link_context *const dap_link_ctx)
+{
+	k_mutex_unlock(&dap_link_ctx->lock);
 }
 
 void dap_link_set_pkt_size(struct dap_link_context *const dap_link_ctx,


### PR DESCRIPTION
`dap_link_execute_cmd()` runs without locking. An application that also drives the same debug port from its own threads therefore cannot serialize against commands coming from the debug host, and the two interleave on the wire.

This adds a `k_mutex` to `struct dap_link_context`, statically initialized by `DAP_LINK_CONTEXT_DEFINE()` and held across command processing, and exposes `dap_link_lock()` / `dap_link_unlock()` so an application can hold the port across its own transfer sequence. +52/-1, confined to `subsys/dap/` and its header. Existing users are unaffected: the lock is uncontended unless an application takes it.

### What the application is

A USB debug probe running CMSIS-DAP for the host while its own firmware reads a log ring buffer out of the target's RAM over the same SWD interface — "watch the target's console while a debugger is attached to it". The probe's engine is driven by a poll thread; the host's commands execute on the USB device stack thread. Both reach the same DP.

### Why the lock is taken inside `dap_link_execute_cmd()`

Two reasons, and the second is the one that motivates the exported `lock()`/`unlock()` pair:

1. **Granularity.** A `DAP_TransferBlock` writes CSW/TAR once and then issues N DRW accesses. An application transfer landing mid-batch re-points TAR, and the host's remaining reads silently return the wrong data. Serializing at *transfer* granularity — in the DP driver, or in a shim below it — cannot express this; only a hold spanning the whole command can. We built the driver-level shim first and it is structurally short of what correctness needs: it sees operations, not command boundaries.

2. **It is the only interposition point that exists.** `dap_link_execute_cmd()` is declared in `subsys/dap/cmsis_dap.h`, not in a public header, and the USB backend calls it from its own completion handler. An application cannot wrap a DAP command batch through today's public API at all, short of forking `dap_backend_usb.c`. Holding the lock inside the subsystem is what gives the application a state it can make a coherent decision against — in our case, "is a host session live right now", which is armed by `DAP_Connect` from inside that very call.

### Measured

Probe FRDM-MCXA153, target Nucleo-H503RB, pyOCD 0.45.0, ten `pyocd commander` connects with the probe's own engine already polling the target:

| Probe firmware | Clean connects |
|---|---|
| no shared lock | 0 / 10 |
| this lock only | 9 / 16 |
| this lock + application-side deference | 10 / 10 |

Stated plainly: the lock alone is not sufficient — an SW-DP requires IDCODE as the next access after a line reset, which is protocol *phase*, and no lock fixes phase. Our firmware layers a deference rule on top. But the lock is what that layer stands on, and without it the setup does not work at all. Cost of the whole downstream layer on a 24 KB part: +8 bytes.

### Limits

Command execution already happens in the USB backend's transfer completion handler, so a long command stalls every USB function on the device. This patch adds a second source of that stall — an application holding the lock — hence the `@warning`. Moving command execution to a worker would remove the coupling entirely; that is a backend rework, and the lock is correct either way.

### Alternatives

- Lock in the DP driver, or in an application shim below it — wrong granularity (see above); tried, insufficient.
- Application supplies its own DAP backend — the entry point is private, and it means forking ~500 lines off upstream.
- Host-side configuration telling debuggers to drop their register caches — patches only cooperating hosts and fails corrupt rather than safe when absent.

Happy to convert this to a registered callback pair (`lock_ops` on the context, NULL by default) if you would rather no mutex existed for users that do not opt in, or to gate it behind a Kconfig. Also happy to drop the owner-recursive property — nothing in `subsys/dap` re-enters; the recursion only saves our own nesting.

Tested by building `samples/subsys/dap` for `frdm_mcxa156`.
