### PR TITLE
soc/ite: it8xxx2: Enable SOC_IT8XXX2_RAM_CODE_NOINLINE

### DIFF
--- a/soc/ite/ec/it8xxx2/Kconfig
+++ b/soc/ite/ec/it8xxx2/Kconfig
@@ -245,11 +245,13 @@ config SOC_IT8XXX2_ZEPHYR_IN_RAM
 config SOC_IT8XXX2_RAM_CODE_NOINLINE
 	bool "Force RAM code functions to be non-inlined"
 	depends on LTO
+	default y
 	help
 	  When enabled, functions marked with __soc_ram_code will use the 'noinline'
 	  attribute to ensure they are not inlined by the compiler.
 	  This guarantees the function body stays in the RAM code section rather
-	  than being merged into callers.
+	  than being merged into callers. When LTO is enabled, inlining is more
+	  likely so this option is enabled by default with LTO.
 
 config SOC_IT8XXX2_SHA256_HW_ACCELERATE
 	bool "HW SHA256 calculation"


### PR DESCRIPTION
When LTO is enabled, inlining of functions is more likely.  Enable SOC_IT8XXX2_RAM_CODE_NOINLINE by default when LTO is enabled.

Tested RAM resident flash routines (ramcode_flash_write, etc.) on ITE EC.