### PR TITLE
dts: infineon: pse84: Resolve warning avoid_unnecessary_addr_size

### DIFF
--- a/dts/arm/infineon/edge/pse84/pse84.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.dtsi
@@ -297,8 +297,6 @@
 			reg = <0x42880000 0x10000>;
 			status = "disabled";
 			wakeup-source;
-			#address-cells = <1>;
-			#size-cells = <1>;
 
 			lpcomp0_0: lpcomp0-0 {
 				compatible = "infineon,lp-comp-channel";

--- a/dts/arm/infineon/edge/pse84/pse84_s.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84_s.dtsi
@@ -310,8 +310,6 @@
 			reg = <0x52880000 0x10000>;
 			status = "disabled";
 			wakeup-source;
-			#address-cells = <1>;
-			#size-cells = <1>;
 
 			lpcomp0_0: lpcomp0-0 {
 				compatible = "infineon,lp-comp-channel";


### PR DESCRIPTION
The comparator nodes had  address-cells and size-cells without ranges or a child reg property causing warnings at build time. Removed them as they are unnecessary.