### PR TITLE
lora: add energy-detection carrier sense support

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -228,6 +228,8 @@ New APIs and options
 
 * LoRa
 
+  * Added energy-detection carrier sense (Listen Before Talk) to the LoRa API:
+    :c:func:`lora_energy_detect`.
   * :c:func:`lora_recv_duty_cycle`
   * :c:func:`lora_recv_duty_cycle_async`
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -458,6 +458,7 @@ New APIs and options
 
   * :c:func:`lora_recv_duty_cycle`
   * :c:func:`lora_recv_duty_cycle_async`
+  * :c:func:`lora_rssi`
 
 * Management
 

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -458,6 +458,7 @@ New APIs and options
 
   * :c:func:`lora_recv_duty_cycle`
   * :c:func:`lora_recv_duty_cycle_async`
+  * :c:func:`lora_energy_detect`
   * :c:func:`lora_rssi`
 
 * Management

--- a/drivers/lora/CMakeLists.txt
+++ b/drivers/lora/CMakeLists.txt
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_sources(lora_common.c)
 zephyr_sources_ifdef(CONFIG_LORA_SHELL shell.c)
 
 # zephyr-keep-sorted-start

--- a/drivers/lora/Kconfig
+++ b/drivers/lora/Kconfig
@@ -52,6 +52,25 @@ config LORA_SHELL
 	help
 	  Enable LoRa Shell for testing.
 
+config LORA_RSSI_SETTLE_US
+	int "RSSI settling time in microseconds"
+	default 500 if LORA_MODULE_BACKEND_LORAMAC_NODE
+	default 500 if LORA_MODULE_BACKEND_NATIVE
+	default 10000
+	help
+	  Time to wait after entering receive mode before the RSSI is read,
+	  to let the receiver settle. How long a radio needs varies with the
+	  driver: one that sleeps between accesses spends part of this time
+	  in its wake-up calibration, and reads taken too early report the
+	  noise floor. The defaults come from an SX1262: loramac-node and the
+	  native driver are ready in 0.5 ms, the Basics Modem glue needs 7 ms.
+
+config LORA_ENERGY_DETECT_SAMPLE_INTERVAL_US
+	int "Energy detection sample interval in microseconds"
+	default 500
+	help
+	  Time to sleep between two RSSI samples while sensing the channel.
+
 config LORA_INIT_PRIORITY
 	int "LoRa initialization priority"
 	default 90

--- a/drivers/lora/lora-basics-modem/lbm_common.c
+++ b/drivers/lora/lora-basics-modem/lbm_common.c
@@ -653,6 +653,17 @@ int lbm_lora_common_init(const struct device *dev)
 	return 0;
 }
 
+int lbm_lora_rssi(const struct device *dev, int16_t *rssi)
+{
+	const struct lbm_lora_config_common *config = dev->config;
+
+	if (ral_get_rssi_inst(&config->ralf.ral, rssi) != RAL_STATUS_OK) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
 DEVICE_API(lora, lbm_lora_api) = {
 	.config = lbm_lora_config,
 	.airtime = lbm_lora_airtime,
@@ -661,4 +672,5 @@ DEVICE_API(lora, lbm_lora_api) = {
 	.recv = lbm_lora_recv,
 	.recv_async = lbm_lora_recv_async,
 	.test_cw = lbm_lora_test_cw,
+	.rssi = lbm_lora_rssi,
 };

--- a/drivers/lora/lora_common.c
+++ b/drivers/lora/lora_common.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 RAKwireless Technology Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/lora.h>
+#include <zephyr/kernel.h>
+
+static void lora_ed_discard(const struct device *dev, uint8_t *data, uint16_t size, int16_t rssi,
+			    int8_t snr, void *user_data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(data);
+	ARG_UNUSED(size);
+	ARG_UNUSED(rssi);
+	ARG_UNUSED(snr);
+	ARG_UNUSED(user_data);
+}
+
+int lora_energy_detect(const struct device *dev, int16_t rssi_threshold, k_timeout_t duration)
+{
+	k_timepoint_t expiry;
+	bool busy = false;
+	int ret, stop;
+
+	if (K_TIMEOUT_EQ(duration, K_NO_WAIT) || K_TIMEOUT_EQ(duration, K_FOREVER)) {
+		return -EINVAL;
+	}
+
+	ret = lora_recv_async(dev, lora_ed_discard, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+
+	k_sleep(K_USEC(CONFIG_LORA_RSSI_SETTLE_US));
+
+	expiry = sys_timepoint_calc(duration);
+
+	while (!sys_timepoint_expired(expiry)) {
+		int16_t rssi;
+
+		ret = lora_rssi(dev, &rssi);
+		if (ret < 0) {
+			break;
+		}
+
+		if (rssi >= rssi_threshold) {
+			busy = true;
+			break;
+		}
+
+		k_sleep(K_USEC(CONFIG_LORA_ENERGY_DETECT_SAMPLE_INTERVAL_US));
+	}
+
+	stop = lora_recv_async(dev, NULL, NULL);
+	if (stop < 0) {
+		return stop;
+	}
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	return busy ? 1 : 0;
+}

--- a/drivers/lora/loramac-node/sx126x.c
+++ b/drivers/lora/loramac-node/sx126x.c
@@ -471,6 +471,7 @@ static DEVICE_API(lora, sx126x_lora_api) = {
 	.recv = sx12xx_lora_recv,
 	.recv_async = sx12xx_lora_recv_async,
 	.test_cw = sx12xx_lora_test_cw,
+	.energy_detect = sx12xx_lora_energy_detect,
 };
 
 DEVICE_DT_INST_DEFINE(0, &sx126x_lora_init, NULL, &dev_data,

--- a/drivers/lora/loramac-node/sx126x.c
+++ b/drivers/lora/loramac-node/sx126x.c
@@ -118,6 +118,8 @@ static int sx126x_spi_transceive(uint8_t *req_tx, uint8_t *req_rx,
 		.count = ARRAY_SIZE(rx_buf)
 	};
 
+	k_sem_take(&dev_data.bus_lock, K_FOREVER);
+
 	/* Wake the device if necessary */
 	SX126xCheckDeviceReady();
 
@@ -134,6 +136,9 @@ static int sx126x_spi_transceive(uint8_t *req_tx, uint8_t *req_rx,
 	if (req_len >= 1 && req_tx[0] != RADIO_SET_SLEEP) {
 		SX126xWaitOnBusy();
 	}
+
+	k_sem_give(&dev_data.bus_lock);
+
 	return ret;
 }
 
@@ -441,6 +446,7 @@ static int sx126x_lora_init(const struct device *dev)
 		return -EIO;
 	}
 
+	k_sem_init(&dev_data.bus_lock, 1, 1);
 	k_work_init(&dev_data.dio1_irq_work, sx126x_dio1_irq_work_handler);
 
 	ret = sx126x_variant_init(dev);

--- a/drivers/lora/loramac-node/sx126x.c
+++ b/drivers/lora/loramac-node/sx126x.c
@@ -477,6 +477,7 @@ static DEVICE_API(lora, sx126x_lora_api) = {
 	.recv = sx12xx_lora_recv,
 	.recv_async = sx12xx_lora_recv_async,
 	.test_cw = sx12xx_lora_test_cw,
+	.rssi = sx12xx_lora_rssi,
 };
 
 DEVICE_DT_INST_DEFINE(0, &sx126x_lora_init, NULL, &dev_data,

--- a/drivers/lora/loramac-node/sx126x_common.h
+++ b/drivers/lora/loramac-node/sx126x_common.h
@@ -10,6 +10,7 @@
 #define ZEPHYR_DRIVERS_SX126X_COMMON_H_
 
 #include <zephyr/types.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/lora.h>
 #include <zephyr/drivers/spi.h>
@@ -53,6 +54,8 @@ struct sx126x_data {
 	struct k_work dio1_irq_work;
 	DioIrqHandler *radio_dio_irq;
 	RadioOperatingModes_t mode;
+	/* serialises the ready/transfer/busy sequence of one bus access */
+	struct k_sem bus_lock;
 };
 
 void sx126x_reset(struct sx126x_data *dev_data);

--- a/drivers/lora/loramac-node/sx127x.c
+++ b/drivers/lora/loramac-node/sx127x.c
@@ -633,6 +633,7 @@ static DEVICE_API(lora, sx127x_lora_api) = {
 	.recv = sx12xx_lora_recv,
 	.recv_async = sx12xx_lora_recv_async,
 	.test_cw = sx12xx_lora_test_cw,
+	.energy_detect = sx12xx_lora_energy_detect,
 };
 
 DEVICE_DT_INST_DEFINE(0, &sx127x_lora_init, NULL, NULL,

--- a/drivers/lora/loramac-node/sx127x.c
+++ b/drivers/lora/loramac-node/sx127x.c
@@ -633,6 +633,7 @@ static DEVICE_API(lora, sx127x_lora_api) = {
 	.recv = sx12xx_lora_recv,
 	.recv_async = sx12xx_lora_recv_async,
 	.test_cw = sx12xx_lora_test_cw,
+	.rssi = sx12xx_lora_rssi,
 };
 
 DEVICE_DT_INST_DEFINE(0, &sx127x_lora_init, NULL, NULL,

--- a/drivers/lora/loramac-node/sx12xx_common.c
+++ b/drivers/lora/loramac-node/sx12xx_common.c
@@ -434,6 +434,30 @@ int sx12xx_lora_test_cw(const struct device *dev, uint32_t frequency,
 	return 0;
 }
 
+int sx12xx_lora_energy_detect(const struct device *dev, uint32_t bandwidth, int16_t rssi_threshold,
+			      k_timeout_t duration)
+{
+	uint32_t duration_ms =
+		K_TIMEOUT_EQ(duration, K_FOREVER) ? 0 : k_ticks_to_ms_ceil32(duration.ticks);
+	bool channel_free;
+
+	/* Validate that we have a TX configuration */
+	if (!dev_data.tx_cfg.frequency) {
+		return -EINVAL;
+	}
+
+	if (!modem_acquire(&dev_data)) {
+		return -EBUSY;
+	}
+
+	channel_free = Radio.IsChannelFree(dev_data.tx_cfg.frequency, bandwidth, rssi_threshold,
+					   duration_ms);
+
+	modem_release(&dev_data);
+
+	return channel_free ? 0 : 1;
+}
+
 int sx12xx_init(const struct device *dev)
 {
 	atomic_set(&dev_data.modem_usage, 0);

--- a/drivers/lora/loramac-node/sx12xx_common.c
+++ b/drivers/lora/loramac-node/sx12xx_common.c
@@ -434,6 +434,19 @@ int sx12xx_lora_test_cw(const struct device *dev, uint32_t frequency,
 	return 0;
 }
 
+int sx12xx_lora_rssi(const struct device *dev, int16_t *rssi)
+{
+	/*
+	 * Deliberately no modem_acquire(): that claims the radio for one
+	 * exclusive operation, and reading the RSSI is a query on the receive
+	 * already in progress. The bus access itself is serialised one layer
+	 * down.
+	 */
+	*rssi = Radio.Rssi(MODEM_LORA);
+
+	return 0;
+}
+
 int sx12xx_init(const struct device *dev)
 {
 	atomic_set(&dev_data.modem_usage, 0);

--- a/drivers/lora/loramac-node/sx12xx_common.h
+++ b/drivers/lora/loramac-node/sx12xx_common.h
@@ -40,6 +40,9 @@ int sx12xx_lora_test_cw(const struct device *dev, uint32_t frequency,
 			int8_t tx_power,
 			uint16_t duration);
 
+int sx12xx_lora_energy_detect(const struct device *dev, uint32_t bandwidth, int16_t rssi_threshold,
+			      k_timeout_t duration);
+
 int sx12xx_init(const struct device *dev);
 
 #endif /* ZEPHYR_DRIVERS_SX12XX_COMMON_H_ */

--- a/drivers/lora/loramac-node/sx12xx_common.h
+++ b/drivers/lora/loramac-node/sx12xx_common.h
@@ -40,6 +40,8 @@ int sx12xx_lora_test_cw(const struct device *dev, uint32_t frequency,
 			int8_t tx_power,
 			uint16_t duration);
 
+int sx12xx_lora_rssi(const struct device *dev, int16_t *rssi);
+
 int sx12xx_init(const struct device *dev);
 
 #endif /* ZEPHYR_DRIVERS_SX12XX_COMMON_H_ */

--- a/drivers/lora/native/sx126x/sx126x.c
+++ b/drivers/lora/native/sx126x/sx126x.c
@@ -1452,6 +1452,20 @@ static uint32_t sx126x_lora_airtime(const struct device *dev, uint32_t data_len)
 	return (t_preamble_us + t_payload_us + 500) / 1000;
 }
 
+static int sx126x_lora_rssi(const struct device *dev, int16_t *rssi)
+{
+	uint8_t buf[1];
+	int ret;
+
+	ret = sx126x_hal_read_cmd(dev, SX126X_CMD_GET_RSSI_INST, buf, 1);
+	if (ret == 0) {
+		/* RSSI is -value/2 dBm */
+		*rssi = -((int16_t)buf[0] >> 1);
+	}
+
+	return ret;
+}
+
 static int sx126x_lora_test_cw(const struct device *dev, uint32_t frequency,
 			       int8_t tx_power, uint16_t duration)
 {
@@ -1519,6 +1533,7 @@ static DEVICE_API(lora, sx126x_lora_api) = {
 	.recv_duty_cycle_async = sx126x_lora_recv_duty_cycle_async,
 	.airtime = sx126x_lora_airtime,
 	.test_cw = sx126x_lora_test_cw,
+	.rssi = sx126x_lora_rssi,
 };
 
 #ifdef CONFIG_PM_DEVICE

--- a/drivers/lora/shell.c
+++ b/drivers/lora/shell.c
@@ -312,6 +312,35 @@ static int cmd_lora_test_cw(const struct shell *sh,
 	return 0;
 }
 
+static int cmd_lora_energy_detect(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	int ret;
+	long bandwidth, threshold, duration;
+
+	dev = get_modem(sh);
+	if (!dev) {
+		return -ENODEV;
+	}
+
+	if (parse_long_range(&bandwidth, sh, argv[1], "bandwidth", 0, INT32_MAX) < 0 ||
+	    parse_long_range(&threshold, sh, argv[2], "threshold", INT16_MIN, INT16_MAX) < 0 ||
+	    parse_long_range(&duration, sh, argv[3], "duration", 0, INT32_MAX) < 0) {
+		return -EINVAL;
+	}
+
+	ret = lora_energy_detect(dev, (uint32_t)bandwidth, (int16_t)threshold,
+				 K_MSEC((uint32_t)duration));
+	if (ret < 0) {
+		shell_error(sh, "LoRa energy detect failed: %i", ret);
+		return ret;
+	}
+
+	shell_print(sh, "Channel %s", ret == 1 ? "busy" : "clear");
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_lora,
 	SHELL_CMD(config, NULL,
 		  SHELL_HELP("Configure the LoRa radio",
@@ -328,6 +357,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_lora,
 		      SHELL_HELP("Send a continuous wave",
 				 "<freq (Hz)> <power (dBm)> <duration (s)>"),
 		      cmd_lora_test_cw, 4, 0),
+	SHELL_CMD_ARG(energy_detect, NULL,
+		      SHELL_HELP("Energy-detection carrier sense",
+				 "<bandwidth (Hz)> <threshold (dBm)> <duration (ms)>"),
+		      cmd_lora_energy_detect, 4, 0),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 

--- a/drivers/lora/shell.c
+++ b/drivers/lora/shell.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/drivers/lora.h>
+#include <zephyr/kernel.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <zephyr/shell/shell.h>
@@ -316,6 +317,84 @@ static int cmd_lora_test_cw(const struct shell *sh,
 	return 0;
 }
 
+static void lora_shell_discard(const struct device *dev, uint8_t *data, uint16_t size, int16_t rssi,
+			       int8_t snr, void *user_data)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(data);
+	ARG_UNUSED(size);
+	ARG_UNUSED(rssi);
+	ARG_UNUSED(snr);
+	ARG_UNUSED(user_data);
+}
+
+static int cmd_lora_rssi(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	int16_t rssi;
+	int ret, stop;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	dev = get_configured_modem(sh);
+	if (!dev) {
+		return -ENODEV;
+	}
+
+	ret = lora_recv_async(dev, lora_shell_discard, NULL);
+	if (ret < 0) {
+		shell_error(sh, "Failed to enter receive mode: %i", ret);
+		return ret;
+	}
+
+	k_sleep(K_USEC(CONFIG_LORA_RSSI_SETTLE_US));
+
+	ret = lora_rssi(dev, &rssi);
+
+	stop = lora_recv_async(dev, NULL, NULL);
+	if (stop < 0) {
+		shell_error(sh, "Failed to leave receive mode: %i", stop);
+		return stop;
+	}
+
+	if (ret < 0) {
+		shell_error(sh, "LoRa RSSI read failed: %i", ret);
+		return ret;
+	}
+
+	shell_print(sh, "RSSI: %d dBm", rssi);
+
+	return 0;
+}
+
+static int cmd_lora_energy_detect(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	long threshold, duration;
+	int ret;
+
+	dev = get_configured_modem(sh);
+	if (!dev) {
+		return -ENODEV;
+	}
+
+	if (parse_long_range(&threshold, sh, argv[1], "threshold", INT16_MIN, INT16_MAX) < 0 ||
+	    parse_long_range(&duration, sh, argv[2], "duration", 1, INT32_MAX) < 0) {
+		return -EINVAL;
+	}
+
+	ret = lora_energy_detect(dev, (int16_t)threshold, K_MSEC((uint32_t)duration));
+	if (ret < 0) {
+		shell_error(sh, "LoRa energy detect failed: %i", ret);
+		return ret;
+	}
+
+	shell_print(sh, "Channel %s", ret == 1 ? "busy" : "clear");
+
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_lora,
 	SHELL_CMD(config, NULL,
 		  SHELL_HELP("Configure the LoRa radio",
@@ -332,6 +411,13 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_lora,
 		      SHELL_HELP("Send a continuous wave",
 				 "<freq (Hz)> <power (dBm)> <duration (s)>"),
 		      cmd_lora_test_cw, 4, 0),
+	SHELL_CMD_ARG(rssi, NULL,
+		      SHELL_HELP("Read the instantaneous RSSI", "No arguments"),
+		      cmd_lora_rssi, 1, 0),
+	SHELL_CMD_ARG(energy_detect, NULL,
+		      SHELL_HELP("Energy-detection carrier sense",
+				 "<threshold (dBm)> <duration (ms)>"),
+		      cmd_lora_energy_detect, 3, 0),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -297,6 +297,14 @@ typedef int (*lora_api_cad_async)(const struct device *dev, lora_cad_cb cb,
 				  void *user_data);
 
 /**
+ * @brief Callback API for energy-detection carrier sense
+ *
+ * @see lora_energy_detect() for argument descriptions.
+ */
+typedef int (*lora_api_energy_detect)(const struct device *dev, uint32_t bandwidth,
+				      int16_t rssi_threshold, k_timeout_t duration);
+
+/**
  * @typedef lora_api_recv_duty_cycle()
  * @brief Callback API for blocking receive with duty cycling
  *
@@ -348,6 +356,8 @@ __subsystem struct lora_driver_api {
 	lora_api_cad cad;
 	/** @driver_ops_optional @copybrief lora_cad_async */
 	lora_api_cad_async cad_async;
+	/** @driver_ops_optional @copybrief lora_energy_detect */
+	lora_api_energy_detect energy_detect;
 	/** @driver_ops_optional @copybrief lora_recv_duty_cycle_async */
 	lora_api_recv_duty_cycle_async recv_duty_cycle_async;
 	/** @driver_ops_optional @copybrief lora_recv_duty_cycle */
@@ -522,6 +532,43 @@ static inline int lora_cad_async(const struct device *dev, lora_cad_cb cb,
 	}
 
 	return api->cad_async(dev, cb, user_data);
+}
+
+/**
+ * @brief Perform energy-detection carrier sense (Listen Before Talk)
+ *
+ * Puts the radio in RX at @p bandwidth around the frequency previously set by
+ * @ref lora_config and samples the instantaneous RSSI for @p duration. If the
+ * measured energy stays below @p rssi_threshold for the whole window, the
+ * channel is reported clear.
+ *
+ * Unlike @ref lora_cad, this detects any RF energy on the channel, not just
+ * LoRa signals, as required by regulatory Listen Before Talk (e.g. KR920,
+ * AS923 in Japan).
+ *
+ * @note This is a blocking call.
+ *
+ * @param dev            LoRa device
+ * @param bandwidth      Sensing bandwidth in Hz (e.g. 200000)
+ * @param rssi_threshold Threshold in dBm; energy at or above this reads as busy
+ * @param duration       Carrier-sense window
+ * @return 0 if the channel is clear
+ * @return 1 if the channel is busy
+ * @return -EINVAL if the modem has not been configured for transmission
+ * @return -EBUSY if the modem is in use
+ * @return -ENOSYS if the operation is not supported by the driver
+ * @return negative errno on other errors
+ */
+static inline int lora_energy_detect(const struct device *dev, uint32_t bandwidth,
+				     int16_t rssi_threshold, k_timeout_t duration)
+{
+	const struct lora_driver_api *api = DEVICE_API_GET(lora, dev);
+
+	if (api->energy_detect == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->energy_detect(dev, bandwidth, rssi_threshold, duration);
 }
 
 /**

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -298,6 +298,13 @@ typedef int (*lora_api_cad_async)(const struct device *dev, lora_cad_cb cb,
 				  void *user_data);
 
 /**
+ * @brief Callback API for reading the instantaneous RSSI
+ *
+ * @see lora_rssi() for argument descriptions.
+ */
+typedef int (*lora_api_rssi)(const struct device *dev, int16_t *rssi);
+
+/**
  * @typedef lora_api_recv_duty_cycle()
  * @brief Callback API for blocking receive with duty cycling
  *
@@ -349,6 +356,8 @@ __subsystem struct lora_driver_api {
 	lora_api_cad cad;
 	/** @driver_ops_optional @copybrief lora_cad_async */
 	lora_api_cad_async cad_async;
+	/** @driver_ops_optional @copybrief lora_rssi */
+	lora_api_rssi rssi;
 	/** @driver_ops_optional @copybrief lora_recv_duty_cycle_async */
 	lora_api_recv_duty_cycle_async recv_duty_cycle_async;
 	/** @driver_ops_optional @copybrief lora_recv_duty_cycle */
@@ -523,6 +532,34 @@ static inline int lora_cad_async(const struct device *dev, lora_cad_cb cb,
 	}
 
 	return api->cad_async(dev, cb, user_data);
+}
+
+/**
+ * @brief Read the instantaneous RSSI of the current channel
+ *
+ * Samples the receiver's signal strength once, at the bandwidth configured by
+ * @ref lora_config.
+ *
+ * The radio must already be receiving, set up by @ref lora_recv_async. The
+ * value read outside of receive mode is undefined; the driver does not detect
+ * this.
+ *
+ * @param dev  LoRa device
+ * @param rssi Sampled level in dBm
+ * @return 0 on success
+ * @return -EBUSY if the modem is in use
+ * @return -ENOSYS if the operation is not supported by the driver
+ * @return negative on other errors
+ */
+static inline int lora_rssi(const struct device *dev, int16_t *rssi)
+{
+	const struct lora_driver_api *api = DEVICE_API_GET(lora, dev);
+
+	if (api->rssi == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->rssi(dev, rssi);
 }
 
 /**

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -563,6 +563,30 @@ static inline int lora_rssi(const struct device *dev, int16_t *rssi)
 }
 
 /**
+ * @brief Perform energy-detection carrier sense
+ *
+ * Puts the radio into receive mode and samples the RSSI repeatedly for
+ * @p duration. The channel is reported busy as soon as one sample reaches
+ * @p rssi_threshold, and clear if the window elapses without that happening.
+ *
+ * Unlike @ref lora_cad this reacts to any energy on the channel, not only to
+ * a LoRa preamble. Sensing happens at the bandwidth set by @ref lora_config.
+ *
+ * @note This is a blocking call.
+ *
+ * @param dev            LoRa device
+ * @param rssi_threshold Level in dBm at or above which the channel is busy
+ * @param duration       Carrier sense window, neither K_NO_WAIT nor K_FOREVER
+ * @return 0 if the channel is clear
+ * @return 1 if the channel is busy
+ * @return -EINVAL if @p duration is K_NO_WAIT or K_FOREVER
+ * @return -EBUSY if the modem is in use
+ * @return -ENOSYS if the driver supports neither RSSI nor asynchronous receive
+ * @return negative on other errors
+ */
+int lora_energy_detect(const struct device *dev, int16_t rssi_threshold, k_timeout_t duration);
+
+/**
  * @brief Receive data using duty cycling (wake-on-radio)
  *
  * The radio autonomously alternates between sleep and listening for


### PR DESCRIPTION
This PR adds RSSI-based energy-detection carrier sense to the LoRa API.

loramac-node already has `Radio.IsChannelFree()` for this kind of check.
This PR exposes that capability in Zephyr as `lora_energy_detect()`.

Unlike CAD, this checks channel energy by RSSI, so it can detect
non-LoRa activity too, not only LoRa preamble.

- new `lora_energy_detect()` API and optional driver callback
- loramac-node `sx126x` and `sx127x` support
- `lora energy_detect` shell command
- release note update

For future work, some backends may need GFSK RX reconfiguration
to support the exact sensing bandwidth used by regulatory LBT
such as 200 kHz in KR920-related flows.