### PR TITLE
arch: riscv: smp: panic on secondary hartid lookup failure

### DIFF
--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -60,9 +60,23 @@ void arch_secondary_cpu_init(int hartid)
 	for (i = 0; i < CONFIG_MP_MAX_NUM_CPUS; i++) {
 		if (_kernel.cpus[i].arch.hartid == hartid) {
 			cpu_num = i;
+			break;
 		}
 	}
+
 	csr_write(mscratch, &_kernel.cpus[cpu_num]);
+
+	/*
+	 * The no-match check must sit after the mscratch write:
+	 * arch_curr_cpu() reads mscratch, so the fatal path needs the
+	 * per-CPU pointer set first. Note that on the no-match path
+	 * cpu_num is still 0, so the panic is reported against whatever
+	 * CPU 0 is running.
+	 */
+	if (i >= CONFIG_MP_MAX_NUM_CPUS) {
+		k_panic();
+	}
+
 #ifdef CONFIG_SMP
 	_kernel.cpus[cpu_num].arch.online = true;
 #endif


### PR DESCRIPTION
If the loop searching for a matching hartid in `arch_secondary_cpu_init()` exited without a match, `cpu_num` would stay 0 and the secondary hart would initialize itself using CPU 0's per-CPU state, TLS, PMP and startup callback.

This state is currently unreachable: `reset.S` gates each secondary hart until `riscv_cpu_wake_flag` equals its own `mhartid`, and the flag is only ever written from `_kernel.cpus[].arch.hartid` in `arch_cpu_start()`, so a hart whose hartid is absent from the CPU table never reaches this function. Add the check as defensive hardening: break on the first match and call `k_panic()` if the loop completes without one.

The check sits after the `mscratch` write because `arch_curr_cpu()` reads `mscratch`, so the fatal path needs per-CPU state set first.