### PR TITLE
.github: backport_issue_check: scope concurrency per PR

### DIFF
--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -17,7 +17,7 @@ jobs:
   backport:
     name: Backport Issue Check
     concurrency:
-      group: backport-issue-check-${{ github.ref }}
+      group: backport-issue-check-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
     if: github.repository == 'zephyrproject-rtos/zephyr'


### PR DESCRIPTION
The concurrency group keyed the cancel-in-progress behaviour on
github.ref. For pull_request_target events github.ref resolves to the
base branch (refs/heads/v*-branch), which is shared by every PR
targeting that branch. As a result any PR event (opened, edited,
synchronize) cancelled the in-progress backport check of every other
PR in the same group, so the check appeared perpetually cancelled.

Key the group on the pull request number instead so each PR only
cancels its own superseded runs. The PR number is globally unique and
avoids the fork-collision that github.head_ref would still allow.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
