### PR TITLE
soc: sensry: move init code from SYS_INIT to hooks

### DIFF
--- a/soc/sensry/ganymed/sy1xx/Kconfig
+++ b/soc/sensry/ganymed/sy1xx/Kconfig
@@ -4,3 +4,4 @@
 config SOC_SERIES_SY1XX
 	select RISCV
 	select RISCV_PRIVILEGED
+	select SOC_EARLY_INIT_HOOK

--- a/soc/sensry/ganymed/sy1xx/common/soc.c
+++ b/soc/sensry/ganymed/sy1xx/common/soc.c
@@ -77,13 +77,8 @@ void soc_interrupt_init(void)
  * @brief Perform basic hardware initialization
  *
  * Initializes the base clocks and LPFLL using helpers provided by the HAL.
- *
- * @return 0
  */
-static int sy1xx_soc_init(void)
+void soc_early_init_hook(void)
 {
 
-	return 0;
 }
-
-SYS_INIT(sy1xx_soc_init, PRE_KERNEL_1, 0);


### PR DESCRIPTION
The sy1xx SoC init ran as a SYS_INIT at PRE_KERNEL_1 priority 0, before
any device initialization. Convert it to the SoC early init hook, which
runs at the same point, and select SOC_EARLY_INIT_HOOK for the series.
No functional change; this aligns the sy1xx series with the SoC hook
convention already used across the tree.
