### PR TITLE
kernel: move USE_SWITCH out of the SMP options menu

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -1019,6 +1019,25 @@ config HW_SHADOW_STACK_ALLOW_REUSE
 endmenu
 
 rsource "userspace/Kconfig"
+
+config USE_SWITCH
+	bool "Use new-style _arch_switch instead of arch_swap"
+	depends on USE_SWITCH_SUPPORTED
+	help
+	  The _arch_switch() API is a lower level context switching
+	  primitive than the original arch_swap mechanism.  It is required
+	  for an SMP-aware scheduler, or if the architecture does not
+	  provide arch_swap.  In uniprocess situations where the
+	  architecture provides both, _arch_switch incurs more somewhat
+	  overhead and may be slower.
+
+config USE_SWITCH_SUPPORTED
+	bool
+	help
+	  Indicates whether _arch_switch() API is supported by the
+	  currently enabled platform. This option should be selected by
+	  platforms that implement it.
+
 rsource "smp/Kconfig"
 
 config TICKLESS_KERNEL

--- a/kernel/smp/Kconfig
+++ b/kernel/smp/Kconfig
@@ -10,24 +10,6 @@ config SMP
 	  When true, kernel will be built with SMP support, allowing
 	  more than one CPU to schedule Zephyr tasks at a time.
 
-config USE_SWITCH
-	bool "Use new-style _arch_switch instead of arch_swap"
-	depends on USE_SWITCH_SUPPORTED
-	help
-	  The _arch_switch() API is a lower level context switching
-	  primitive than the original arch_swap mechanism.  It is required
-	  for an SMP-aware scheduler, or if the architecture does not
-	  provide arch_swap.  In uniprocess situations where the
-	  architecture provides both, _arch_switch incurs more somewhat
-	  overhead and may be slower.
-
-config USE_SWITCH_SUPPORTED
-	bool
-	help
-	  Indicates whether _arch_switch() API is supported by the
-	  currently enabled platform. This option should be selected by
-	  platforms that implement it.
-
 config MP_MAX_NUM_CPUS
 	int "Maximum number of CPUs/cores"
 	default 1


### PR DESCRIPTION
USE_SWITCH and USE_SWITCH_SUPPORTED describe a general context-switch
primitive (_arch_switch) that is usable on uniprocessor systems, not
just SMP configurations. Having them under the "SMP Options" menu in
kernel/smp/Kconfig was misleading.

Move both symbols to kernel/Kconfig proper, just before the SMP menu is
sourced. SMP still depends on USE_SWITCH; the guarding and arch selects
are unchanged.
