### PR TITLE
arch: arc: fix VPX semaphore array initialization

### DIFF
--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -388,7 +388,7 @@ void arc_vpx_unlock_force(unsigned int id)
 static int arc_vpx_sem_init(void)
 {
 	for (unsigned int i = 0; i < CONFIG_MP_MAX_NUM_CPUS; i++) {
-		k_sem_init(vpx_sem, 1, 1);
+		k_sem_init(&vpx_sem[i], 1, 1);
 	}
 
 	return 0;


### PR DESCRIPTION
arc_vpx_sem_init() initialized vpx_sem[0] once per CPU instead of
initializing each CPU's semaphore: the loop passed the array (decaying
to &vpx_sem[0]) to k_sem_init() rather than the i-th element, leaving
the semaphores of CPUs 1..N-1 uninitialized on multi-core
configurations.
