### PR TITLE
drivers: dma/i2s: esp32: dma_stop() returns before the channel stops writing

### DIFF
--- a/drivers/dma/dma_esp32_gdma.c
+++ b/drivers/dma/dma_esp32_gdma.c
@@ -668,6 +668,8 @@ static int dma_esp32_stop(const struct device *dev, uint32_t channel)
 				     GDMA_LL_TX_EVENT_MASK, false);
 		gdma_hal_stop(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX);
 		gdma_hal_stop(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX);
+		gdma_hal_reset(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX);
+		gdma_hal_reset(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX);
 #if CONFIG_PM
 		struct dma_esp32_channel *dma_channel_rx =
 			&config->dma_channel[dma_channel->channel_id * 2];
@@ -679,14 +681,41 @@ static int dma_esp32_stop(const struct device *dev, uint32_t channel)
 #endif
 	}
 
+
+	/*
+	 * Writing the STOP bit only ASKS the channel to stop. The ESP32-S3 TRM makes the
+	 * distinction in the register definitions themselves: GDMA_INLINK_STOP_CHn is
+	 * (R/W/SC), a self-clearing command strobe with no acknowledge, while
+	 * GDMA_INLINK_PARK_CHn is (RO) status. "I asked" and "it happened" are different
+	 * bits, and dma_stop() was only ever writing the first one.
+	 *
+	 * So reset the channel. GDMA_IN_RST_CHn is "used to reset GDMA channel n RX FSM and
+	 * RX FIFO pointer" -- the FIFO is exactly the state the park bit cannot see, and the
+	 * TRM's own programming procedures make this reset step one of every START and
+	 * describe no stop procedure at all. It is the only sanctioned way to put a channel
+	 * into a known state.
+	 *
+	 * Do NOT reach for the park bit instead. It reads idle while the data path is still
+	 * draining, and ESP-IDF never polls it either -- gdma_ll_*_is_desc_fsm_idle() has no
+	 * caller anywhere in that tree.
+	 *
+	 * A reset costs a restarted transfer nothing, and that is documented rather than
+	 * inferred: ESP-IDF's gdma.h says of gdma_reset(), "Resetting a DMA channel won't
+	 * break the connection with the target peripheral." This driver already relies on
+	 * that -- it resets the channel to ARM a transfer, in dma_esp32_config_*() and in
+	 * dma_esp32_reload(), which the I2S driver calls between the chunks of a single
+	 * oversized block while the peripheral is still running.
+	 */
 	if (dma_channel->dir == DMA_RX) {
 		gdma_hal_enable_intr(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX,
 				     GDMA_LL_RX_EVENT_MASK, false);
 		gdma_hal_stop(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX);
+		gdma_hal_reset(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX);
 	} else if (dma_channel->dir == DMA_TX) {
 		gdma_hal_enable_intr(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX,
 				     GDMA_LL_TX_EVENT_MASK, false);
 		gdma_hal_stop(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX);
+		gdma_hal_reset(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX);
 	}
 
 	return 0;

--- a/drivers/dma/dma_esp32_gdma.c
+++ b/drivers/dma/dma_esp32_gdma.c
@@ -464,6 +464,48 @@ static int dma_esp32_config_descriptor(struct dma_esp32_channel *dma_channel,
 	return 0;
 }
 
+static void dma_esp32_channel_reset(struct dma_esp32_data *data, uint32_t channel_id,
+				    gdma_channel_direction_t dir)
+{
+#if defined(SOC_AXI_GDMA_SUPPORTED)
+	if (data->is_axi) {
+		/* An AXI transfer cannot be reset while it is still in flight. */
+		if (dir == GDMA_CHANNEL_DIRECTION_RX) {
+			axi_dma_ll_rx_abort(data->hal.axi_dma_dev, channel_id, true);
+			while (!axi_dma_ll_rx_is_reset_avail(data->hal.axi_dma_dev, channel_id)) {
+			}
+			axi_dma_ll_rx_reset_channel(data->hal.axi_dma_dev, channel_id);
+			axi_dma_ll_rx_abort(data->hal.axi_dma_dev, channel_id, false);
+		} else {
+			axi_dma_ll_tx_abort(data->hal.axi_dma_dev, channel_id, true);
+			while (!axi_dma_ll_tx_is_reset_avail(data->hal.axi_dma_dev, channel_id)) {
+			}
+			axi_dma_ll_tx_reset_channel(data->hal.axi_dma_dev, channel_id);
+			axi_dma_ll_tx_abort(data->hal.axi_dma_dev, channel_id, false);
+		}
+
+		return;
+	}
+#endif /* SOC_AXI_GDMA_SUPPORTED */
+
+	gdma_hal_reset(&data->hal, channel_id, dir);
+}
+
+static void dma_esp32_stop_barrier(struct dma_esp32_data *data, uint32_t channel_id,
+				   gdma_channel_direction_t dir)
+{
+	uint32_t mask = GDMA_LL_TX_EVENT_MASK;
+
+	if (dir == GDMA_CHANNEL_DIRECTION_RX) {
+		mask = GDMA_LL_RX_EVENT_MASK;
+	}
+
+	dma_esp32_channel_reset(data, channel_id, dir);
+
+	/* Reset leaves events the abandoned transfer already latched. */
+	gdma_hal_clear_intr(&data->hal, channel_id, dir, mask);
+}
+
 static int dma_esp32_config_rx(const struct device *dev, struct dma_esp32_channel *dma_channel,
 			       struct dma_config *config_dma)
 {
@@ -472,7 +514,7 @@ static int dma_esp32_config_rx(const struct device *dev, struct dma_esp32_channe
 
 	dma_channel->dir = DMA_RX;
 
-	gdma_hal_reset(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX);
+	dma_esp32_channel_reset(data, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX);
 
 	if (dma_channel->periph_id == SOC_GDMA_TRIG_PERIPH_M2M0) {
 		gdma_hal_connect_mem(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX,
@@ -510,7 +552,7 @@ static int dma_esp32_config_tx(const struct device *dev, struct dma_esp32_channe
 
 	dma_channel->dir = DMA_TX;
 
-	gdma_hal_reset(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX);
+	dma_esp32_channel_reset(data, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX);
 
 	if (dma_channel->periph_id == SOC_GDMA_TRIG_PERIPH_M2M0) {
 		gdma_hal_connect_mem(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX,
@@ -675,6 +717,8 @@ static int dma_esp32_stop(const struct device *dev, uint32_t channel)
 				     GDMA_LL_TX_EVENT_MASK, false);
 		gdma_hal_stop(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX);
 		gdma_hal_stop(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX);
+		dma_esp32_stop_barrier(data, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX);
+		dma_esp32_stop_barrier(data, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX);
 #if CONFIG_PM
 		struct dma_esp32_channel *dma_channel_rx =
 			&config->dma_channel[dma_channel->channel_id * 2];
@@ -685,10 +729,12 @@ static int dma_esp32_stop(const struct device *dev, uint32_t channel)
 		gdma_hal_enable_intr(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX,
 				     GDMA_LL_RX_EVENT_MASK, false);
 		gdma_hal_stop(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX);
+		dma_esp32_stop_barrier(data, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX);
 	} else if (dma_channel->dir == DMA_TX) {
 		gdma_hal_enable_intr(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX,
 				     GDMA_LL_TX_EVENT_MASK, false);
 		gdma_hal_stop(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX);
+		dma_esp32_stop_barrier(data, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX);
 	}
 
 	return 0;
@@ -775,10 +821,10 @@ static int dma_esp32_reload(const struct device *dev, uint32_t channel, uint32_t
 	}
 
 	if (dma_channel->dir == DMA_RX) {
-		gdma_hal_reset(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX);
+		dma_esp32_channel_reset(data, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_RX);
 		buf = dst;
 	} else if (dma_channel->dir == DMA_TX) {
-		gdma_hal_reset(&data->hal, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX);
+		dma_esp32_channel_reset(data, dma_channel->channel_id, GDMA_CHANNEL_DIRECTION_TX);
 		buf = src;
 	} else {
 		return -EINVAL;

--- a/drivers/i2s/i2s_esp32.c
+++ b/drivers/i2s/i2s_esp32.c
@@ -272,6 +272,18 @@ static void IRAM_ATTR i2s_esp32_rx_callback(void *arg, int status)
 		goto rx_disable;
 	}
 
+	/*
+	 * The receive queue owns the block now, and i2s_read() will hand it on to the
+	 * application -- which frees it, either directly or inside i2s_buf_read(). Either
+	 * way it has stopped being the driver's to release, so the driver must stop
+	 * pointing at it. Every path out of this callback that stops the stream ends in
+	 * i2s_esp32_rx_stop_transfer(), which frees whatever mem_block still holds -- and
+	 * on the STOPPING branch immediately below, that would be this block, freed a
+	 * second time while the queue is still holding it.
+	 */
+	stream->data->mem_block = NULL;
+	stream->data->mem_block_len = 0;
+
 	if (dev_data->state == I2S_STATE_STOPPING) {
 		if (dev_data->active_dir == I2S_DIR_RX ||
 		    (dev_data->active_dir == I2S_DIR_BOTH && !dev_cfg->tx.data->transferring)) {
@@ -374,23 +386,85 @@ static void IRAM_ATTR i2s_esp32_rx_stop_transfer(const struct device *dev)
 {
 	const struct i2s_esp32_cfg *dev_cfg = dev->config;
 	const struct i2s_esp32_stream *stream = &dev_cfg->rx;
+	const i2s_hal_context_t *hal = &(dev_cfg->hal);
+	int err;
+
+	/*
+	 * The producer, then the consumer -- and on BOTH paths. This call was missing from
+	 * the stop path entirely; it appears only in rx_start_transfer(). A DMA that is
+	 * told to stop while the I2S unit is still filling the FIFO does not stop writing.
+	 * ESP-IDF's i2s_rx_stop() calls this first, above its own #if/#else.
+	 */
+	i2s_hal_rx_stop(hal);
 
 #if SOC_GDMA_SUPPORTED
-	dma_stop(stream->conf->dma_dev, stream->conf->dma_channel);
+	err = dma_stop(stream->conf->dma_dev, stream->conf->dma_channel);
 #else
-	const i2s_hal_context_t *hal = &(dev_cfg->hal);
-
+	err = 0;
 	esp_intr_disable(stream->data->irq_handle);
 	i2s_hal_rx_stop_link(hal);
 	i2s_hal_rx_disable_intr(hal);
 	i2s_hal_rx_disable_dma(hal);
+	/*
+	 * The non-GDMA analogue of the gdma_reset() this series adds to dma_stop().
+	 * I2S_IN_RST: "Set this bit to reset in DMA FSM." ESP-IDF pairs the two in the same
+	 * #if/#else in its own i2s_rx_reset(). Note that i2s_hal_rx_disable_dma() above is
+	 * NOT a stop -- it writes I2S_DSCR_EN, "enable I2S DMA mode", a mode select that
+	 * promises nothing about a transfer already under way.
+	 */
+	i2s_hal_rx_reset_dma(hal);
 	i2s_hal_clear_intr_status(hal, I2S_INTR_MAX);
 #endif /* SOC_GDMA_SUPPORTED */
 
-	stream->data->mem_block = NULL;
-	stream->data->mem_block_len = 0;
-
+	stream->data->dma_pending = false;
 	stream->data->transferring = false;
+
+	if (err < 0) {
+		/*
+		 * The channel may still be running, so its block is not ours to give away.
+		 * Keeping it leaks one block; handing it back is the free-list corruption
+		 * this patch exists to prevent.
+		 */
+		return;
+	}
+
+#if SOC_GDMA_SUPPORTED
+	if (stream->data->mem_block != NULL) {
+		k_mem_slab_free(stream->data->i2s_cfg.mem_slab, stream->data->mem_block);
+		stream->data->mem_block = NULL;
+	}
+#else
+	/*
+	 * ESP32 and ESP32-S2 STILL LEAK THIS BLOCK, ON PURPOSE.
+	 *
+	 * The stop sequence above now matches -- and exceeds -- what ESP-IDF itself does
+	 * before it frees this same class of buffer: the I2S unit is stopped first, the
+	 * descriptor link is stopped, and the in-DMA FSM is reset. ESP-IDF frees after
+	 * that (i2s_set_clk() -> i2s_stop() -> i2s_realloc_dma_buffer()), which is real
+	 * evidence that it is enough.
+	 *
+	 * It is not enough evidence to free the block here, for three reasons.
+	 *
+	 * The thing that actually owns an in-flight write is the AHB master and its
+	 * command FIFO -- I2S_AHBM_RST and I2S_AHBM_FIFO_RST in I2S_LC_CONF_REG -- and
+	 * neither has any accessor in the HAL. Nothing above touches them. Nothing can.
+	 *
+	 * ESP-IDF's free is separated from its stop by a mutex, a state transition and a
+	 * log line: microseconds. This one lands nanoseconds later, inside an IRAM_ATTR
+	 * function running in ISR context. A window ESP-IDF survives is not a window this
+	 * survives.
+	 *
+	 * And the whole subject of this patch is a stop that looked sufficient and was
+	 * not. On the GDMA path that cost a free list overwritten with captured audio, and
+	 * it was only found because the hardware was on the desk. Repeating the same
+	 * inference on parts nobody in this thread can run would be indefensible. A slow
+	 * leak is strictly safer than heap corruption on hardware nobody can see.
+	 *
+	 * Drop this #if the moment somebody runs it on an ESP32 or an ESP32-S2.
+	 */
+	stream->data->mem_block = NULL;
+#endif /* SOC_GDMA_SUPPORTED */
+	stream->data->mem_block_len = 0;
 }
 
 #endif /* I2S_ESP32_IS_DIR_EN(rx) */
@@ -477,6 +551,8 @@ static void IRAM_ATTR i2s_esp32_tx_callback(void *arg, int status)
 	}
 
 	k_mem_slab_free(stream->data->i2s_cfg.mem_slab, stream->data->mem_block);
+	stream->data->mem_block = NULL;
+	stream->data->mem_block_len = 0;
 
 #if SOC_GDMA_SUPPORTED
 	if (status < 0) {
@@ -577,12 +653,14 @@ static void IRAM_ATTR i2s_esp32_tx_stop_transfer(const struct device *dev)
 {
 	const struct i2s_esp32_cfg *dev_cfg = dev->config;
 	const struct i2s_esp32_stream *stream = &dev_cfg->tx;
+	int err;
 
 #if SOC_GDMA_SUPPORTED
-	dma_stop(stream->conf->dma_dev, stream->conf->dma_channel);
+	err = dma_stop(stream->conf->dma_dev, stream->conf->dma_channel);
 #else
 	const i2s_hal_context_t *hal = &(dev_cfg->hal);
 
+	err = 0;
 	esp_intr_disable(stream->data->irq_handle);
 	i2s_hal_tx_stop_link(hal);
 	i2s_hal_tx_disable_intr(hal);
@@ -590,10 +668,55 @@ static void IRAM_ATTR i2s_esp32_tx_stop_transfer(const struct device *dev)
 	i2s_hal_clear_intr_status(hal, I2S_INTR_MAX);
 #endif /* SOC_GDMA_SUPPORTED */
 
-	stream->data->mem_block = NULL;
-	stream->data->mem_block_len = 0;
-
+	stream->data->dma_pending = false;
 	stream->data->transferring = false;
+
+	if (err < 0) {
+		/*
+		 * The channel may still be running, so its block is not ours to give away.
+		 * Keeping it leaks one block; handing it back is the free-list corruption
+		 * this patch exists to prevent.
+		 */
+		return;
+	}
+
+#if SOC_GDMA_SUPPORTED
+	if (stream->data->mem_block != NULL) {
+		k_mem_slab_free(stream->data->i2s_cfg.mem_slab, stream->data->mem_block);
+		stream->data->mem_block = NULL;
+	}
+#else
+	/*
+	 * ESP32 and ESP32-S2 STILL LEAK THIS BLOCK, ON PURPOSE.
+	 *
+	 * The stop sequence above now matches -- and exceeds -- what ESP-IDF itself does
+	 * before it frees this same class of buffer: the I2S unit is stopped first, the
+	 * descriptor link is stopped, and the in-DMA FSM is reset. ESP-IDF frees after
+	 * that (i2s_set_clk() -> i2s_stop() -> i2s_realloc_dma_buffer()), which is real
+	 * evidence that it is enough.
+	 *
+	 * It is not enough evidence to free the block here, for three reasons.
+	 *
+	 * The thing that actually owns an in-flight write is the AHB master and its
+	 * command FIFO -- I2S_AHBM_RST and I2S_AHBM_FIFO_RST in I2S_LC_CONF_REG -- and
+	 * neither has any accessor in the HAL. Nothing above touches them. Nothing can.
+	 *
+	 * ESP-IDF's free is separated from its stop by a mutex, a state transition and a
+	 * log line: microseconds. This one lands nanoseconds later, inside an IRAM_ATTR
+	 * function running in ISR context. A window ESP-IDF survives is not a window this
+	 * survives.
+	 *
+	 * And the whole subject of this patch is a stop that looked sufficient and was
+	 * not. On the GDMA path that cost a free list overwritten with captured audio, and
+	 * it was only found because the hardware was on the desk. Repeating the same
+	 * inference on parts nobody in this thread can run would be indefensible. A slow
+	 * leak is strictly safer than heap corruption on hardware nobody can see.
+	 *
+	 * Drop this #if the moment somebody runs it on an ESP32 or an ESP32-S2.
+	 */
+	stream->data->mem_block = NULL;
+#endif /* SOC_GDMA_SUPPORTED */
+	stream->data->mem_block_len = 0;
 }
 
 #endif /* I2S_ESP32_IS_DIR_EN(tx) */

--- a/drivers/i2s/i2s_esp32.c
+++ b/drivers/i2s/i2s_esp32.c
@@ -219,13 +219,20 @@ static void IRAM_ATTR i2s_esp32_rx_callback(void *arg, int status)
 
 #if SOC_GDMA_SUPPORTED
 	if (status < 0) {
-#else
-	if (status & I2S_LL_EVENT_RX_DSCR_ERR) {
-#endif /* SOC_GDMA_SUPPORTED */
 		dev_data->state = I2S_STATE_ERROR;
 		LOG_DBG("RX status bad: %d", status);
 		goto rx_disable;
 	}
+#else
+	if (status & I2S_LL_EVENT_RX_DSCR_ERR) {
+		k_mem_slab_free(stream->data->i2s_cfg.mem_slab, stream->data->mem_block);
+		stream->data->mem_block = NULL;
+		stream->data->mem_block_len = 0;
+		dev_data->state = I2S_STATE_ERROR;
+		LOG_DBG("RX status bad: %d", status);
+		goto rx_disable;
+	}
+#endif /* SOC_GDMA_SUPPORTED */
 
 #if SOC_GDMA_SUPPORTED
 	const i2s_hal_context_t *hal = &(dev_cfg->hal);
@@ -280,6 +287,10 @@ static void IRAM_ATTR i2s_esp32_rx_callback(void *arg, int status)
 		dev_data->state = I2S_STATE_ERROR;
 		goto rx_disable;
 	}
+
+	/* Queue owns the block. */
+	stream->data->mem_block = NULL;
+	stream->data->mem_block_len = 0;
 
 	if (dev_data->state == I2S_STATE_STOPPING) {
 		if (dev_data->active_dir == I2S_DIR_RX ||
@@ -383,12 +394,15 @@ static void IRAM_ATTR i2s_esp32_rx_stop_transfer(const struct device *dev)
 {
 	const struct i2s_esp32_cfg *dev_cfg = dev->config;
 	const struct i2s_esp32_stream *stream = &dev_cfg->rx;
+	const i2s_hal_context_t *hal = &(dev_cfg->hal);
+	int err;
 
 #if SOC_GDMA_SUPPORTED
-	dma_stop(stream->conf->dma_dev, stream->conf->dma_channel);
+	/* Stop the I2S unit before the DMA, so nothing keeps filling the FIFO. */
+	i2s_hal_rx_stop(hal);
+	err = dma_stop(stream->conf->dma_dev, stream->conf->dma_channel);
 #else
-	const i2s_hal_context_t *hal = &(dev_cfg->hal);
-
+	err = 0;
 	esp_intr_disable(stream->data->irq_handle);
 	i2s_hal_rx_stop_link(hal);
 	i2s_hal_rx_disable_intr(hal);
@@ -396,10 +410,25 @@ static void IRAM_ATTR i2s_esp32_rx_stop_transfer(const struct device *dev)
 	i2s_hal_clear_intr_status(hal, I2S_INTR_MAX);
 #endif /* SOC_GDMA_SUPPORTED */
 
-	stream->data->mem_block = NULL;
-	stream->data->mem_block_len = 0;
-
+	/* Cleared before the status test: a failed stop must not strand STOPPING. */
+	stream->data->dma_pending = false;
 	stream->data->transferring = false;
+
+	if (err < 0) {
+		/* The channel may still be running, so the block is not ours to release. */
+		return;
+	}
+
+#if SOC_GDMA_SUPPORTED
+	if (stream->data->mem_block != NULL) {
+		k_mem_slab_free(stream->data->i2s_cfg.mem_slab, stream->data->mem_block);
+		stream->data->mem_block = NULL;
+	}
+#else
+	/* Legacy DMA may still own the block; do not return it to the slab. */
+	stream->data->mem_block = NULL;
+#endif /* SOC_GDMA_SUPPORTED */
+	stream->data->mem_block_len = 0;
 }
 
 #endif /* I2S_ESP32_IS_DIR_EN(rx) */
@@ -491,17 +520,25 @@ static void IRAM_ATTR i2s_esp32_tx_callback(void *arg, int status)
 		goto tx_disable;
 	}
 
-	k_mem_slab_free(stream->data->i2s_cfg.mem_slab, stream->data->mem_block);
-
 #if SOC_GDMA_SUPPORTED
 	if (status < 0) {
-#else
-	if (status & I2S_LL_EVENT_TX_DSCR_ERR) {
-#endif /* SOC_GDMA_SUPPORTED */
 		dev_data->state = I2S_STATE_ERROR;
 		LOG_DBG("TX bad status: %d", status);
 		goto tx_disable;
 	}
+#endif /* SOC_GDMA_SUPPORTED */
+
+	k_mem_slab_free(stream->data->i2s_cfg.mem_slab, stream->data->mem_block);
+	stream->data->mem_block = NULL;
+	stream->data->mem_block_len = 0;
+
+#if !SOC_GDMA_SUPPORTED
+	if (status & I2S_LL_EVENT_TX_DSCR_ERR) {
+		dev_data->state = I2S_STATE_ERROR;
+		LOG_DBG("TX bad status: %d", status);
+		goto tx_disable;
+	}
+#endif /* !SOC_GDMA_SUPPORTED */
 
 #if CONFIG_I2S_ESP32_ALLOWED_EMPTY_TX_QUEUE_DEFERRAL_TIME_MS
 	if (k_msgq_num_used_get(&stream->data->queue) == 0 &&
@@ -599,14 +636,16 @@ static void IRAM_ATTR i2s_esp32_tx_stop_transfer(const struct device *dev)
 	const struct i2s_esp32_cfg *dev_cfg = dev->config;
 	const struct i2s_esp32_stream *stream = &dev_cfg->tx;
 	struct i2s_esp32_data *dev_data = dev->data;
+	int err;
 
 	k_timer_stop(&dev_data->tx_deferred_transfer_timer);
 
 #if SOC_GDMA_SUPPORTED
-	dma_stop(stream->conf->dma_dev, stream->conf->dma_channel);
+	err = dma_stop(stream->conf->dma_dev, stream->conf->dma_channel);
 #else
 	const i2s_hal_context_t *hal = &(dev_cfg->hal);
 
+	err = 0;
 	esp_intr_disable(stream->data->irq_handle);
 	i2s_hal_tx_stop_link(hal);
 	i2s_hal_tx_disable_intr(hal);
@@ -614,10 +653,25 @@ static void IRAM_ATTR i2s_esp32_tx_stop_transfer(const struct device *dev)
 	i2s_hal_clear_intr_status(hal, I2S_INTR_MAX);
 #endif /* SOC_GDMA_SUPPORTED */
 
-	stream->data->mem_block = NULL;
-	stream->data->mem_block_len = 0;
-
+	/* Cleared before the status test: a failed stop must not strand STOPPING. */
+	stream->data->dma_pending = false;
 	stream->data->transferring = false;
+
+	if (err < 0) {
+		/* The channel may still be running, so the block is not ours to release. */
+		return;
+	}
+
+#if SOC_GDMA_SUPPORTED
+	if (stream->data->mem_block != NULL) {
+		k_mem_slab_free(stream->data->i2s_cfg.mem_slab, stream->data->mem_block);
+		stream->data->mem_block = NULL;
+	}
+#else
+	/* Legacy DMA may still own the block; do not return it to the slab. */
+	stream->data->mem_block = NULL;
+#endif /* SOC_GDMA_SUPPORTED */
+	stream->data->mem_block_len = 0;
 }
 
 #endif /* I2S_ESP32_IS_DIR_EN(tx) */

--- a/drivers/i2s/i2s_esp32.c
+++ b/drivers/i2s/i2s_esp32.c
@@ -259,6 +259,7 @@ static void IRAM_ATTR i2s_esp32_rx_callback(void *arg, int status)
 		if (err < 0) {
 			LOG_DBG("Failed to reload DMA channel: %" PRIu32,
 				stream->conf->dma_channel);
+			dev_data->state = I2S_STATE_ERROR;
 			goto rx_disable;
 		}
 
@@ -267,6 +268,7 @@ static void IRAM_ATTR i2s_esp32_rx_callback(void *arg, int status)
 		err = dma_start(stream->conf->dma_dev, stream->conf->dma_channel);
 		if (err < 0) {
 			LOG_DBG("Failed to start DMA channel: %" PRIu32, stream->conf->dma_channel);
+			dev_data->state = I2S_STATE_ERROR;
 			goto rx_disable;
 		}
 


### PR DESCRIPTION
`dma_stop()` returns before the GDMA channel has stopped writing, so the I2S stop path frees a block the DMA is still filling. On DROP the block is not returned at all: the mem-slab runs dry and a later `i2s_write()` waits on it forever.

Two commits:

- **dma esp32** resets the channel in `dma_stop()` and clears the events the abandoned transfer latched. `GDMA_INLINK_STOP_CHn` is a command strobe with no acknowledge, so without the reset the stop is not observable. An AXI channel cannot be reset mid-transaction, so every reset site (configure, reload and stop) now goes through one helper that aborts, waits for `axi_dma_ll_*_is_reset_avail()`, resets, then releases the abort. On AHB the helper still calls `gdma_hal_reset()`, so nothing changes there outside `dma_stop()`.
- **i2s esp32** frees the in-flight block once `dma_stop()` has quiesced the channel. RX also stops the I2S unit first, so nothing keeps filling the FIFO the DMA is draining; TX needs no equivalent, since there the DMA is the reader and stopping it is what protects the block.

On ESP32 and ESP32-S2 the stop path deliberately does not free. Those parts have no GDMA reset, and the HAL exposes one bit of the three the TRM prescribes as a group, so a leak is the safer trade until someone can run it there. Their ISR calls the callback only on EOF, though, so the block is already back from the DMA by then, and both callbacks return it before reporting a descriptor error.

Testing:

- ESP32-S3, on hardware: sylvioalves reproduced the leak and confirmed the fix, on the revision before the AXI helper and the ESP32/S2 split went in.
- Build-tested on this revision: `tests/drivers/dma/loop_transfer` on ESP32-P4 and ESP32-S3, `tests/drivers/i2s/i2s_api` on ESP32-S3 and ESP32, and `tests/drivers/spi/spi_loopback` on ESP32-P4 with `socs/esp32p4_hpcore_dma.overlay`, whose effective devicetree binds `spi2` to `dmas = <&dma_axi 0>, <&dma_axi 1>`.
- ESP32-P4: I have no board, so the AXI path is build-tested only.
- ESP32 and ESP32-S2: no board here either. The DROP leak on those two parts is left as it is; this series does not claim to fix it.

Relates to #113310
