### PR TITLE
drivers: sensor: bme280: sign-extend dig_h4/dig_h5 calibration values

### DIFF
--- a/drivers/sensor/bosch/bme280/bme280.c
+++ b/drivers/sensor/bosch/bme280/bme280.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/sys/__assert.h>
 
 #include <zephyr/logging/log.h>
@@ -318,8 +319,15 @@ static int bme280_read_compensation(const struct device *dev)
 
 		data->dig_h2 = (hbuf[1] << 8) | hbuf[0];
 		data->dig_h3 = hbuf[2];
-		data->dig_h4 = (hbuf[3] << 4) | (hbuf[4] & 0x0F);
-		data->dig_h5 = ((hbuf[4] >> 4) & 0x0F) | (hbuf[5] << 4);
+		/*
+		 * dig_h4 and dig_h5 are 12-bit two's complement values (Datasheet
+		 * Table 16, registers 0xE4-0xE6). hbuf[3]/hbuf[5] hold the sign bit
+		 * (bit 11) but are uint8_t, so a plain "<< 4" never sign-extends it
+		 * and negative calibration values silently turn positive. Use
+		 * sign_extend() to reconstruct the signed 12-bit value correctly.
+		 */
+		data->dig_h4 = sign_extend((hbuf[3] << 4) | (hbuf[4] & 0x0F), 11);
+		data->dig_h5 = sign_extend(((hbuf[4] >> 4) & 0x0F) | (hbuf[5] << 4), 11);
 		data->dig_h6 = hbuf[6];
 	}
 


### PR DESCRIPTION
Fixes #112381

## Problem

`bme280_read_compensation()` (drivers/sensor/bosch/bme280/bme280.c) builds the
12-bit two's complement calibration constants `dig_h4`/`dig_h5` (BME280
datasheet Table 16, registers 0xE4-0xE6) like this:

```c
data->dig_h4 = (hbuf[3] << 4) | (hbuf[4] & 0x0F);
data->dig_h5 = ((hbuf[4] >> 4) & 0x0F) | (hbuf[5] << 4);
```

`dig_h4`/`dig_h5` are declared `int16_t` (bme280.h), but `hbuf` is
`uint8_t hbuf[7]`. Under the C integer promotion rules, `hbuf[3]`/`hbuf[5]`
promote to a *non-negative* `int` before the `<<`, so a calibration byte
such as `0xE2` (which is meant to represent a negative 12-bit value once
combined with the low nibble) is promoted to `226`, not `-30` — the shift
never sign-extends it.

Any sensor whose calibration byte has its top bit set (a negative
correction value, which is a normal and frequently-occurring case for
these constants) gets silently reinterpreted as a large positive number.
Both fields feed directly into `bme280_compensate_humidity()`, producing a
wrong `%RH` reading with no indication anything is wrong.

Reported in #112381, where the maintainer (@teburd) confirmed the fix
approach:

> Please propose a PR, you have proposed fix in the issue already. There's
> also a sign extension API in Zephyr, see sign_extend()

## Fix

Use the project's existing `sign_extend()` helper
(`include/zephyr/sys/util.h`) with index `11` (0-based sign-bit position
for a 12-bit value) — the same idiom already used for other 12-bit two's
complement fields elsewhere in the tree, e.g.
`drivers/sensor/als31300/als31300.c`
(`sign_extend(value, ALS31300_12BIT_SIGN_BIT_INDEX)`, where the constant
is `11`) and `drivers/sensor/bosch/bmm350/bmm350.c`.

```c
data->dig_h4 = sign_extend((hbuf[3] << 4) | (hbuf[4] & 0x0F), 11);
data->dig_h5 = sign_extend(((hbuf[4] >> 4) & 0x0F) | (hbuf[5] << 4), 11);
```

`#include <zephyr/sys/util.h>` is added for `sign_extend()`. The change is
scoped to these two lines plus the include and an explanatory comment; no
other file defines or re-implements this parsing (checked
`bme280_async.c`, `bme280_decoder.c`, `bme280_i2c.c`, `bme280_spi.c`).

## Verification

I wrote and ran a standalone C harness that copies the exact parsing
statements and the exact `bme280_compensate_humidity()` formula verbatim
from `bme280.c` (the only stub is the register read itself, replaced with
a fixed test buffer). `sign_extend()` is copied verbatim from
`include/zephyr/sys/util.h`. A third, independent implementation
(`ground_truth_12bit()`, a subtraction-based 12-bit two's-complement
decode that shares no code path with either the buggy or fixed parsing)
is used as the cross-check oracle.

Compiled with `gcc -std=c11 -O0 -Wall -Wextra`, run result: `PASS: 0
mismatch(es)`, exit code 0.

- **Boundary vectors** (`0`, `+2047`, `-2048`, `-1`, `-30`, and the
  issue's own example `0xE2 0x03`): the fixed parsing matches the
  independent ground truth on every vector. The current (buggy) parsing
  *diverges* from ground truth on every vector whose sign bit is set, and
  matches it on every vector whose sign bit is clear — i.e. the bug
  reproduces exactly where expected and nowhere else.
- **Realistic scenario** (`dig_h2=100, dig_h6=0, dig_h3=0, dig_h1=75,
  t_fine=100000, adc_humidity=8000`, chosen to avoid the 0%/100%
  saturation clamps):
  - `dig_h4`: buggy = `3619`, fixed = `-477` (ground truth `-477`)
  - `dig_h5`: buggy = `3616`, fixed = `-480` (ground truth `-480`)
  - Reported humidity: buggy = `50.60%RH`, fixed = `59.31%RH`,
    delta = `-8.71%RH`
- **Regression check**: for a buffer whose sign bits are all clear
  (`hbuf[3..5] = 12 03 34`), buggy and fixed parsing produce identical
  results — the fix does not change behavior for positive calibration
  values.

## Disclosure

Generative AI (Claude, Anthropic) was used to investigate this issue,
implement the fix, and write/run the standalone verification harness
described above. All changes were reviewed by me before submission.

Assisted-by: Claude:claude-sonnet-5
