### PR TITLE
net: ptp: fix 32-bit overflow in foreign clock record time window

### DIFF
--- a/subsys/net/lib/ptp/port.c
+++ b/subsys/net/lib/ptp/port.c
@@ -791,10 +791,10 @@ static void foreign_clock_cleanup(struct ptp_foreign_tt_clock *foreign)
 		} else if (msg->header.log_msg_interval >= 31) {
 			timeout = INT64_MAX;
 		} else if (msg->header.log_msg_interval > 0) {
-			timeout = FOREIGN_TIME_TRANSMITTER_TIME_WINDOW_MUL *
+			timeout = (int64_t)FOREIGN_TIME_TRANSMITTER_TIME_WINDOW_MUL *
 				  (1 << msg->header.log_msg_interval) * NSEC_PER_SEC;
 		} else {
-			timeout = FOREIGN_TIME_TRANSMITTER_TIME_WINDOW_MUL * NSEC_PER_SEC /
+			timeout = (int64_t)FOREIGN_TIME_TRANSMITTER_TIME_WINDOW_MUL * NSEC_PER_SEC /
 				  (1 << (-msg->header.log_msg_interval));
 		}
 

--- a/tests/net/ptp/foreign_master/src/main.c
+++ b/tests/net/ptp/foreign_master/src/main.c
@@ -528,4 +528,31 @@ ZTEST(ptp_foreign_master, test_best_foreign_cleanup_uses_local_uptime)
 	zassert_true(k_fifo_is_empty(&foreign->messages), "foreign message queue should be empty");
 }
 
+ZTEST(ptp_foreign_master, test_best_foreign_cleanup_keeps_scaled_time_window)
+{
+	struct ptp_foreign_tt_clock *foreign;
+
+	/* log_msg_interval = 1 gives a 4 * 2^1 = 8 second time window.
+	 * Records aged 5 seconds must survive the cleanup. With 32-bit
+	 * arithmetic the window wraps to about 3.7 seconds and they are
+	 * dropped prematurely.
+	 */
+	init_announce_msg_ext(&msg1, 0x69, 1, 120, 128, 0, 1);
+	init_announce_msg_ext(&msg2, 0x69, 1, 120, 128, 0, 1);
+
+	zassert_equal(ptp_port_add_foreign_tt(&port, &msg1), 0, "first add failed");
+	zassert_equal(ptp_port_add_foreign_tt(&port, &msg2), 1, "second add failed");
+
+	msg1.local_uptime_ms = k_uptime_get() - (5 * MSEC_PER_SEC);
+	msg2.local_uptime_ms = k_uptime_get() - (5 * MSEC_PER_SEC);
+
+	zassert_not_null(ptp_port_best_foreign(&port),
+			 "records within the time window should produce best");
+
+	foreign = find_foreign_clock(&port, 0x69, 1);
+	zassert_not_null(foreign, "foreign clock missing");
+	zassert_equal(foreign->messages_count, FOREIGN_TIME_TRANSMITTER_THRESHOLD,
+		      "records within the time window should be kept");
+}
+
 ZTEST_SUITE(ptp_foreign_master, NULL, NULL, foreign_master_before, foreign_master_after, NULL);


### PR DESCRIPTION
`foreign_clock_cleanup()` computes the announce record aging timeout in
32-bit arithmetic before storing it into an `int64_t`. For positive
`log_msg_interval` values the product `4 * 2^log * NSEC_PER_SEC` wraps
around: with `log_msg_interval = 1` the 8 s window becomes ~3.7 s, so
announce messages still inside the window are aged out prematurely and
the port can wrongly lose its foreign time transmitter records
(Coverity CID 487738, OVERFLOW_BEFORE_WIDEN / CWE-190).

- The first commit casts the first factor to `int64_t` in both branches
  so the expression is evaluated in 64-bit arithmetic.
- The second commit adds a `foreign_master` regression test pinning the
  scaled window behavior: it fails without the fix (records dropped,
  `ptp_port_best_foreign()` returns `NULL`) and passes with it.

**Testing:** `west twister -T tests/net/ptp -p native_sim/native/64` —
all suites pass; the new test was verified to fail with the fix
reverted. `./scripts/ci/check_compliance.py` clean locally.

Fixes #84696
