### PR TITLE
net: mqtt_sn: allow small publish buffer size

### DIFF
--- a/subsys/net/lib/mqtt_sn/Kconfig
+++ b/subsys/net/lib/mqtt_sn/Kconfig
@@ -14,7 +14,7 @@ if MQTT_SN_LIB
 config MQTT_SN_LIB_MAX_PAYLOAD_SIZE
 	int "Maximum payload size of an MQTT-SN message"
 	default $(UINT8_MAX)
-	range $(UINT8_MAX) $(UINT16_MAX)
+	range 1 $(UINT16_MAX)
 
 config MQTT_SN_LIB_MAX_MSGS
 	int "Number of preallocated messages"


### PR DESCRIPTION
I assume, that this is a copy&paste mistake, because I see no reason why publish buffers should be at least 255 bytes in size.