### PR TITLE
irq: multilevel: avoid bit-field layout dependency

### DIFF
--- a/include/zephyr/irq_multilevel.h
+++ b/include/zephyr/irq_multilevel.h
@@ -96,7 +96,7 @@ static inline unsigned int irq_from_level_2(unsigned int irq)
  *
  * @return 2nd level IRQ number
  */
-#define IRQ_TO_L2(irq) ((irq + 1) << CONFIG_1ST_LEVEL_INTERRUPT_BITS)
+#define IRQ_TO_L2(irq) FIELD_PREP(Z_IRQ_L2_MASK, (irq) + 1U)
 
 /**
  * @brief Converts irq from level 1 to level 2 format
@@ -154,8 +154,7 @@ static inline unsigned int irq_from_level_3(unsigned int irq)
  *
  * @return 3rd level IRQ number
  */
-#define IRQ_TO_L3(irq)                                                                             \
-	((irq + 1) << (CONFIG_1ST_LEVEL_INTERRUPT_BITS + CONFIG_2ND_LEVEL_INTERRUPT_BITS))
+#define IRQ_TO_L3(irq) FIELD_PREP(Z_IRQ_L3_MASK, (irq) + 1U)
 
 /**
  * @brief Converts irq from level 1 to level 3 format

--- a/include/zephyr/irq_multilevel.h
+++ b/include/zephyr/irq_multilevel.h
@@ -13,7 +13,7 @@
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/sys/__assert.h>
-#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 
 #ifdef __cplusplus
@@ -22,70 +22,34 @@ extern "C" {
 
 #if defined(CONFIG_MULTI_LEVEL_INTERRUPTS) || defined(__DOXYGEN__)
 
-typedef union _z_irq {
-	/* Zephyr multilevel-encoded IRQ */
-	uint32_t irq;
+#if defined(CONFIG_2ND_LEVEL_INTERRUPTS)
+BUILD_ASSERT(CONFIG_2ND_LEVEL_INTERRUPT_BITS > 0,
+	     "Second-level IRQ field must contain at least one bit");
+#endif
 
-	/* Interrupt bits */
-	struct {
-		/* First level interrupt bits */
-		uint32_t l1: CONFIG_1ST_LEVEL_INTERRUPT_BITS;
-		/* Second level interrupt bits */
-		uint32_t l2: CONFIG_2ND_LEVEL_INTERRUPT_BITS;
+#if defined(CONFIG_3RD_LEVEL_INTERRUPTS)
+BUILD_ASSERT(CONFIG_3RD_LEVEL_INTERRUPT_BITS > 0,
+	     "Third-level IRQ field must contain at least one bit");
+BUILD_ASSERT(CONFIG_1ST_LEVEL_INTERRUPT_BITS + CONFIG_2ND_LEVEL_INTERRUPT_BITS +
+			     CONFIG_3RD_LEVEL_INTERRUPT_BITS <=
+		     32,
+	     "Multilevel IRQ encoding exceeds 32 bits");
+#elif defined(CONFIG_2ND_LEVEL_INTERRUPTS)
+BUILD_ASSERT(CONFIG_1ST_LEVEL_INTERRUPT_BITS + CONFIG_2ND_LEVEL_INTERRUPT_BITS <= 32,
+	     "Multilevel IRQ encoding exceeds 32 bits");
+#endif
+
+/* Masks for fields in the numeric multilevel IRQ encoding. */
+#define Z_IRQ_L1_MASK ((uint32_t)GENMASK(CONFIG_1ST_LEVEL_INTERRUPT_BITS - 1, 0))
+#define Z_IRQ_L2_MASK                                                                              \
+	((uint32_t)GENMASK(CONFIG_1ST_LEVEL_INTERRUPT_BITS + CONFIG_2ND_LEVEL_INTERRUPT_BITS - 1,  \
+			   CONFIG_1ST_LEVEL_INTERRUPT_BITS))
 #if defined(CONFIG_3RD_LEVEL_INTERRUPTS) || defined(__DOXYGEN__)
-		/* Third level interrupt bits */
-		uint32_t l3: CONFIG_3RD_LEVEL_INTERRUPT_BITS;
+#define Z_IRQ_L3_MASK                                                                              \
+	((uint32_t)GENMASK(CONFIG_1ST_LEVEL_INTERRUPT_BITS + CONFIG_2ND_LEVEL_INTERRUPT_BITS +     \
+				   CONFIG_3RD_LEVEL_INTERRUPT_BITS - 1,                            \
+			   CONFIG_1ST_LEVEL_INTERRUPT_BITS + CONFIG_2ND_LEVEL_INTERRUPT_BITS))
 #endif /* CONFIG_3RD_LEVEL_INTERRUPTS */
-	} bits;
-
-#if defined(CONFIG_3RD_LEVEL_INTERRUPTS) || defined(__DOXYGEN__)
-	/* Third level IRQ's interrupt controller */
-	struct {
-		/* IRQ of the third level interrupt aggregator */
-		uint32_t irq: CONFIG_1ST_LEVEL_INTERRUPT_BITS + CONFIG_2ND_LEVEL_INTERRUPT_BITS;
-	} l3_intc;
-#endif /* CONFIG_3RD_LEVEL_INTERRUPTS */
-
-	/* Second level IRQ's interrupt controller */
-	struct {
-		/* IRQ of the second level interrupt aggregator */
-		uint32_t irq: CONFIG_1ST_LEVEL_INTERRUPT_BITS;
-	} l2_intc;
-} _z_irq_t;
-
-BUILD_ASSERT(sizeof(_z_irq_t) == sizeof(uint32_t), "Size of `_z_irq_t` must equal to `uint32_t`");
-
-static inline uint32_t _z_l1_irq(_z_irq_t irq)
-{
-	return irq.bits.l1;
-}
-
-static inline uint32_t _z_l2_irq(_z_irq_t irq)
-{
-	return irq.bits.l2 - 1;
-}
-
-#ifdef CONFIG_3RD_LEVEL_INTERRUPTS
-static inline uint32_t _z_l3_irq(_z_irq_t irq)
-{
-	return irq.bits.l3 - 1;
-}
-#endif /* CONFIG_3RD_LEVEL_INTERRUPTS */
-
-static inline unsigned int _z_irq_get_level(_z_irq_t z_irq)
-{
-#ifdef CONFIG_3RD_LEVEL_INTERRUPTS
-	if (z_irq.bits.l3 != 0) {
-		return 3;
-	}
-#endif /* CONFIG_3RD_LEVEL_INTERRUPTS */
-
-	if (z_irq.bits.l2 != 0) {
-		return 2;
-	}
-
-	return 1;
-}
 
 /**
  * @brief Return IRQ level
@@ -97,11 +61,17 @@ static inline unsigned int _z_irq_get_level(_z_irq_t z_irq)
  */
 static inline unsigned int irq_get_level(unsigned int irq)
 {
-	_z_irq_t z_irq = {
-		.irq = irq,
-	};
+#ifdef CONFIG_3RD_LEVEL_INTERRUPTS
+	if ((irq & Z_IRQ_L3_MASK) != 0U) {
+		return 3;
+	}
+#endif /* CONFIG_3RD_LEVEL_INTERRUPTS */
 
-	return _z_irq_get_level(z_irq);
+	if ((irq & Z_IRQ_L2_MASK) != 0U) {
+		return 2;
+	}
+
+	return 1;
 }
 
 /**
@@ -116,11 +86,7 @@ static inline unsigned int irq_get_level(unsigned int irq)
  */
 static inline unsigned int irq_from_level_2(unsigned int irq)
 {
-	_z_irq_t z_irq = {
-		.irq = irq,
-	};
-
-	return _z_l2_irq(z_irq);
+	return FIELD_GET(Z_IRQ_L2_MASK, irq) - 1U;
 }
 
 /**
@@ -146,17 +112,7 @@ static inline unsigned int irq_from_level_2(unsigned int irq)
  */
 static inline unsigned int irq_to_level_2(unsigned int irq)
 {
-	_z_irq_t z_irq = {
-		.bits = {
-			.l1 = 0,
-			.l2 = irq + 1,
-#ifdef CONFIG_3RD_LEVEL_INTERRUPTS
-			.l3 = 0,
-#endif /* CONFIG_3RD_LEVEL_INTERRUPTS */
-		},
-	};
-
-	return z_irq.irq;
+	return IRQ_TO_L2(irq);
 }
 
 /**
@@ -171,11 +127,7 @@ static inline unsigned int irq_to_level_2(unsigned int irq)
  */
 static inline unsigned int irq_parent_level_2(unsigned int irq)
 {
-	_z_irq_t z_irq = {
-		.irq = irq,
-	};
-
-	return _z_l1_irq(z_irq);
+	return FIELD_GET(Z_IRQ_L1_MASK, irq);
 }
 
 #if defined(CONFIG_3RD_LEVEL_INTERRUPTS) || defined(__DOXYGEN__)
@@ -192,11 +144,7 @@ static inline unsigned int irq_parent_level_2(unsigned int irq)
  */
 static inline unsigned int irq_from_level_3(unsigned int irq)
 {
-	_z_irq_t z_irq = {
-		.irq = irq,
-	};
-
-	return _z_l3_irq(z_irq);
+	return FIELD_GET(Z_IRQ_L3_MASK, irq) - 1U;
 }
 
 /**
@@ -223,15 +171,7 @@ static inline unsigned int irq_from_level_3(unsigned int irq)
  */
 static inline unsigned int irq_to_level_3(unsigned int irq)
 {
-	_z_irq_t z_irq = {
-		.bits = {
-			.l1 = 0,
-			.l2 = 0,
-			.l3 = irq + 1,
-		},
-	};
-
-	return z_irq.irq;
+	return IRQ_TO_L3(irq);
 }
 
 /**
@@ -246,11 +186,7 @@ static inline unsigned int irq_to_level_3(unsigned int irq)
  */
 static inline unsigned int irq_parent_level_3(unsigned int irq)
 {
-	_z_irq_t z_irq = {
-		.irq = irq,
-	};
-
-	return _z_l2_irq(z_irq);
+	return irq_from_level_2(irq);
 }
 #endif /* CONFIG_3RD_LEVEL_INTERRUPTS */
 
@@ -343,21 +279,18 @@ static inline unsigned int irq_parent_level(unsigned int irq, unsigned int level
 static inline unsigned int irq_get_intc_irq(unsigned int irq)
 {
 	const unsigned int level = irq_get_level(irq);
-	_z_irq_t z_irq = {
-		.irq = irq,
-	};
 
 #ifdef CONFIG_3RD_LEVEL_INTERRUPTS
 	__ASSERT_NO_MSG(level <= 3);
 	if (level == 3) {
-		return z_irq.l3_intc.irq;
+		return irq & (Z_IRQ_L1_MASK | Z_IRQ_L2_MASK);
 	}
 #else
 	__ASSERT_NO_MSG(level <= 2);
 #endif /* CONFIG_3RD_LEVEL_INTERRUPTS */
 
 	if (level == 2) {
-		return z_irq.l2_intc.irq;
+		return irq_parent_level_2(irq);
 	}
 
 	return irq;
@@ -373,23 +306,22 @@ static inline unsigned int irq_get_intc_irq(unsigned int irq)
  */
 static inline unsigned int irq_increment(unsigned int irq, unsigned int val)
 {
-	_z_irq_t z_irq = {
-		.irq = irq,
-	};
+	unsigned int mask;
+	const unsigned int level = irq_get_level(irq);
 
 	if (false) {
 		/* so that it evaluates the next condition */
 #ifdef CONFIG_3RD_LEVEL_INTERRUPTS
-	} else if (z_irq.bits.l3 != 0) {
-		z_irq.bits.l3 += val;
+	} else if (level == 3) {
+		mask = Z_IRQ_L3_MASK;
 #endif /* CONFIG_3RD_LEVEL_INTERRUPTS */
-	} else if (z_irq.bits.l2 != 0) {
-		z_irq.bits.l2 += val;
+	} else if (level == 2) {
+		mask = Z_IRQ_L2_MASK;
 	} else {
-		z_irq.bits.l1 += val;
+		mask = Z_IRQ_L1_MASK;
 	}
 
-	return z_irq.irq;
+	return (irq & ~mask) | FIELD_PREP(mask, FIELD_GET(mask, irq) + val);
 }
 
 #endif /* CONFIG_MULTI_LEVEL_INTERRUPTS */

--- a/tests/arch/common/irq_multilevel/CMakeLists.txt
+++ b/tests/arch/common/irq_multilevel/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(irq_multilevel)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/arch/common/irq_multilevel/prj.conf
+++ b/tests/arch/common/irq_multilevel/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/arch/common/irq_multilevel/src/main.c
+++ b/tests/arch/common/irq_multilevel/src/main.c
@@ -1,0 +1,142 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/irq_multilevel.h>
+#include <zephyr/ztest.h>
+
+#define TEST_L1_IRQ 3U
+#define TEST_L2_IRQ 5U
+
+#define TEST_ENCODED_L2_IRQ (TEST_L1_IRQ | IRQ_TO_L2(TEST_L2_IRQ))
+
+ZTEST(irq_multilevel, test_level_1_increment)
+{
+	const unsigned int irq = TEST_L1_IRQ;
+	const unsigned int expected = TEST_L1_IRQ + 1U;
+	const unsigned int actual = irq_increment(irq, 1U);
+
+	zassert_equal(actual, expected, "irq_increment(%u, 1) returned 0x%x, expected 0x%x", irq,
+		      actual, expected);
+}
+
+ZTEST(irq_multilevel, test_level_2_encoding_matches_macro)
+{
+	const unsigned int expected = IRQ_TO_L2(TEST_L2_IRQ);
+	const unsigned int actual = irq_to_level_2(TEST_L2_IRQ);
+
+	zassert_equal(actual, expected,
+		      "irq_to_level_2(%u) returned 0x%x, "
+		      "but IRQ_TO_L2(%u) returned 0x%x",
+		      TEST_L2_IRQ, actual, TEST_L2_IRQ, expected);
+}
+
+ZTEST(irq_multilevel, test_level_2_get_level)
+{
+	const unsigned int irq = TEST_ENCODED_L2_IRQ;
+	const unsigned int actual = irq_get_level(irq);
+
+	zassert_equal(actual, 2U, "irq_get_level(0x%x) returned %u", irq, actual);
+}
+
+ZTEST(irq_multilevel, test_level_2_decode)
+{
+	const unsigned int irq = TEST_ENCODED_L2_IRQ;
+	const unsigned int actual = irq_from_level_2(irq);
+
+	zassert_equal(actual, TEST_L2_IRQ, "irq_from_level_2(0x%x) returned %u", irq, actual);
+}
+
+ZTEST(irq_multilevel, test_level_2_parent)
+{
+	const unsigned int irq = TEST_ENCODED_L2_IRQ;
+	const unsigned int actual = irq_parent_level_2(irq);
+
+	zassert_equal(actual, TEST_L1_IRQ, "irq_parent_level_2(0x%x) returned %u", irq, actual);
+}
+
+ZTEST(irq_multilevel, test_level_2_intc_irq)
+{
+	const unsigned int irq = TEST_ENCODED_L2_IRQ;
+	const unsigned int actual = irq_get_intc_irq(irq);
+
+	zassert_equal(actual, TEST_L1_IRQ, "irq_get_intc_irq(0x%x) returned 0x%x", irq, actual);
+}
+
+ZTEST(irq_multilevel, test_level_2_increment)
+{
+	const unsigned int irq = TEST_ENCODED_L2_IRQ;
+	const unsigned int expected = TEST_L1_IRQ | IRQ_TO_L2(TEST_L2_IRQ + 1U);
+	const unsigned int actual = irq_increment(irq, 1U);
+
+	zassert_equal(actual, expected, "irq_increment(0x%x, 1) returned 0x%x, expected 0x%x", irq,
+		      actual, expected);
+}
+
+#if defined(CONFIG_3RD_LEVEL_INTERRUPTS)
+#define TEST_L3_IRQ 7U
+
+#define TEST_ENCODED_L3_IRQ (TEST_L1_IRQ | IRQ_TO_L2(TEST_L2_IRQ) | IRQ_TO_L3(TEST_L3_IRQ))
+
+#define TEST_ENCODED_L3_PARENT (TEST_L1_IRQ | IRQ_TO_L2(TEST_L2_IRQ))
+
+ZTEST(irq_multilevel, test_level_3_encoding_matches_macro)
+{
+	const unsigned int expected = IRQ_TO_L3(TEST_L3_IRQ);
+	const unsigned int actual = irq_to_level_3(TEST_L3_IRQ);
+
+	zassert_equal(actual, expected,
+		      "irq_to_level_3(%u) returned 0x%x, "
+		      "but IRQ_TO_L3(%u) returned 0x%x",
+		      TEST_L3_IRQ, actual, TEST_L3_IRQ, expected);
+}
+
+ZTEST(irq_multilevel, test_level_3_get_level)
+{
+	const unsigned int irq = TEST_ENCODED_L3_IRQ;
+	const unsigned int actual = irq_get_level(irq);
+
+	zassert_equal(actual, 3U, "irq_get_level(0x%x) returned %u", irq, actual);
+}
+
+ZTEST(irq_multilevel, test_level_3_decode)
+{
+	const unsigned int irq = TEST_ENCODED_L3_IRQ;
+	const unsigned int actual = irq_from_level_3(irq);
+
+	zassert_equal(actual, TEST_L3_IRQ, "irq_from_level_3(0x%x) returned %u", irq, actual);
+}
+
+ZTEST(irq_multilevel, test_level_3_parent)
+{
+	const unsigned int irq = TEST_ENCODED_L3_IRQ;
+	const unsigned int actual = irq_parent_level_3(irq);
+
+	zassert_equal(actual, TEST_L2_IRQ, "irq_parent_level_3(0x%x) returned %u", irq, actual);
+}
+
+ZTEST(irq_multilevel, test_level_3_intc_irq)
+{
+	const unsigned int irq = TEST_ENCODED_L3_IRQ;
+	const unsigned int actual = irq_get_intc_irq(irq);
+
+	zassert_equal(actual, TEST_ENCODED_L3_PARENT,
+		      "irq_get_intc_irq(0x%x) returned 0x%x, expected 0x%x", irq, actual,
+		      TEST_ENCODED_L3_PARENT);
+}
+
+ZTEST(irq_multilevel, test_level_3_increment)
+{
+	const unsigned int irq = TEST_ENCODED_L3_IRQ;
+	const unsigned int expected =
+		TEST_L1_IRQ | IRQ_TO_L2(TEST_L2_IRQ) | IRQ_TO_L3(TEST_L3_IRQ + 1U);
+	const unsigned int actual = irq_increment(irq, 1U);
+
+	zassert_equal(actual, expected, "irq_increment(0x%x, 1) returned 0x%x, expected 0x%x", irq,
+		      actual, expected);
+}
+
+#endif /* CONFIG_3RD_LEVEL_INTERRUPTS */
+
+ZTEST_SUITE(irq_multilevel, NULL, NULL, NULL, NULL, NULL);

--- a/tests/arch/common/irq_multilevel/tests.yaml
+++ b/tests/arch/common/irq_multilevel/tests.yaml
@@ -1,0 +1,34 @@
+common:
+  tags:
+    - interrupt
+
+tests:
+  arch.irq_multilevel.configured:
+    filter: CONFIG_MULTI_LEVEL_INTERRUPTS
+
+  arch.irq_multilevel.two_level:
+    platform_allow:
+      - qemu_malta/qemu_malta
+      - qemu_malta/qemu_malta/be
+      - qemu_leon3/leon3
+    extra_configs:
+      - CONFIG_MULTI_LEVEL_INTERRUPTS=y
+      - CONFIG_2ND_LEVEL_INTERRUPTS=y
+      - CONFIG_3RD_LEVEL_INTERRUPTS=n
+      - CONFIG_1ST_LEVEL_INTERRUPT_BITS=8
+      - CONFIG_2ND_LEVEL_INTERRUPT_BITS=8
+      - CONFIG_MAX_IRQ_PER_AGGREGATOR=32
+
+  arch.irq_multilevel.three_level:
+    platform_allow:
+      - qemu_malta/qemu_malta
+      - qemu_malta/qemu_malta/be
+      - qemu_leon3/leon3
+    extra_configs:
+      - CONFIG_MULTI_LEVEL_INTERRUPTS=y
+      - CONFIG_2ND_LEVEL_INTERRUPTS=y
+      - CONFIG_3RD_LEVEL_INTERRUPTS=y
+      - CONFIG_1ST_LEVEL_INTERRUPT_BITS=8
+      - CONFIG_2ND_LEVEL_INTERRUPT_BITS=8
+      - CONFIG_3RD_LEVEL_INTERRUPT_BITS=8
+      - CONFIG_MAX_IRQ_PER_AGGREGATOR=32


### PR DESCRIPTION
## Summary

Multilevel IRQ values use a numeric encoding with each interrupt level placed at configuration-defined bit offsets.

The inline helpers in `irq_multilevel.h` currently access those fields through a C bit-field overlay. Since bit-field allocation order is implementation-defined, the helpers can interpret the numeric IRQ value differently from `IRQ_TO_L2()` and `IRQ_TO_L3()`.

This change:

* replaces the bit-field overlay with named masks and the existing `FIELD_GET()` / `FIELD_PREP()` helpers;
* preserves the existing multilevel IRQ encoding and public API;
* adds coverage for encoding, decoding, level detection, parent lookup, interrupt-controller lookup, and increment operations.

Before the fix, the new tests pass on little-endian Malta but fail on big-endian Malta and LEON3.

## Testing

```text
west twister -G -T tests/arch/common/irq_multilevel --inline-logs
```

Results: 12/12 test configurations and 102/102 test cases passed, with no warnings.

Tested on:

```text
qemu_malta/qemu_malta
qemu_malta/qemu_malta/be
qemu_leon3/leon3
```