### PR TITLE
net: if: add public net_if_ipv4_route_add()

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2687,6 +2687,22 @@ struct net_if_router *net_if_ipv4_router_add(struct net_if *iface,
 bool net_if_ipv4_router_rm(struct net_if_router *router);
 
 /**
+ * @brief Add an IPv4 route to the system routing table.
+ *
+ * @param iface Network interface this route is tied to.
+ * @param addr Destination IPv4 address of the route.
+ * @param mask_len Destination netmask length.
+ * @param nexthop IPv4 address of the next hop, or NULL for an on-link
+ *                (directly connected) route.
+ * @param lifetime Route lifetime in seconds (UINT32_MAX for a route that
+ *                 never expires).
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+int net_if_ipv4_route_add(struct net_if *iface, const struct net_in_addr *addr, uint8_t mask_len,
+			  const struct net_in_addr *nexthop, uint32_t lifetime);
+
+/**
  * @brief Check if the given IPv4 address belongs to local subnet.
  *
  * @param iface Interface to use. Must be a valid pointer to an interface.

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -5364,6 +5364,26 @@ bool net_if_ipv4_router_rm(struct net_if_router *router)
 	return iface_router_rm(router);
 }
 
+int net_if_ipv4_route_add(struct net_if *iface, const struct net_in_addr *addr, uint8_t mask_len,
+			  const struct net_in_addr *nexthop, uint32_t lifetime)
+{
+#if defined(CONFIG_NET_IPV4_ROUTE)
+	struct net_route_entry *route;
+
+	route = net_route_ipv4_add(iface, (struct net_in_addr *)addr, mask_len,
+				   (struct net_in_addr *)nexthop, lifetime, 0);
+
+	return route == NULL ? -ENOMEM : 0;
+#else
+	ARG_UNUSED(iface);
+	ARG_UNUSED(addr);
+	ARG_UNUSED(mask_len);
+	ARG_UNUSED(nexthop);
+	ARG_UNUSED(lifetime);
+
+	return -ENOTSUP;
+#endif
+}
 
 static void iface_ipv4_init(int if_count)
 {


### PR DESCRIPTION
Add a public wrapper for net_route_ipv4_add() so a route can be installed without including the private route_ipv4.h header. It mirrors the public net_if_ipv4_router_add() and returns an errno.