### PR TITLE
arch: fix dispatch header gaps and stale arch interface code

### DIFF
--- a/arch/xtensa/core/irq_manage.c
+++ b/arch/xtensa/core/irq_manage.c
@@ -41,29 +41,6 @@ void z_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 	 */
 }
 
-#ifdef CONFIG_DYNAMIC_INTERRUPTS
-#ifndef CONFIG_MULTI_LEVEL_INTERRUPTS
-int z_arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
-			       void (*routine)(const void *parameter),
-			       const void *parameter, uint32_t flags)
-{
-	ARG_UNUSED(flags);
-	ARG_UNUSED(priority);
-
-	z_isr_install(irq, routine, parameter);
-	return irq;
-}
-#else /* !CONFIG_MULTI_LEVEL_INTERRUPTS */
-int z_arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
-			       void (*routine)(const void *parameter),
-			       const void *parameter, uint32_t flags)
-{
-	return z_soc_irq_connect_dynamic(irq, priority, routine, parameter,
-					 flags);
-}
-#endif /* !CONFIG_MULTI_LEVEL_INTERRUPTS */
-#endif /* CONFIG_DYNAMIC_INTERRUPTS */
-
 void z_irq_spurious(const void *arg)
 {
 	int irqs, ie;

--- a/doc/hardware/porting/arch.rst
+++ b/doc/hardware/porting/arch.rst
@@ -303,7 +303,7 @@ to happen--the context switch must happen.
 
 .. note::
 
-  On x86 and Nios2, :code:`arch_swap` is generic enough and the architecture
+  On 32-bit x86, :code:`arch_swap` is generic enough and the architecture
   flexible enough that it can be called when exiting an interrupt to provoke
   the context switch. This should not be taken as a rule, since
   neither the ARM Cortex-M nor ARCv2 port do this.
@@ -388,7 +388,7 @@ To enable thread local storage on a new architecture:
    ``struct k_thread`` and put it into an appropriate register (or some
    other variable) for access to the TLS storage area. Refer to toolchain
    and architecture documentation on which registers to use.
-#. In kconfig, add ``select CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE`` to
+#. In kconfig, add ``select ARCH_HAS_THREAD_LOCAL_STORAGE`` to
    kconfig related to the new architecture.
 #. Run the ``tests/kernel/threads/tls`` to make sure the new code works.
 

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -522,7 +522,7 @@ static void gicv3_cpuif_init(void)
 	 * Check if system interface can be enabled.
 	 * 'icc_sre_el3' needs to be configured at 'EL3'
 	 * to allow access to 'icc_sre_el1' at 'EL1'
-	 * eg: z_arch_el3_plat_init can be used by platform.
+	 * eg: z_arm64_el3_plat_init can be used by platform.
 	 */
 	icc_sre = read_sysreg(ICC_SRE_EL1);
 

--- a/include/zephyr/arch/arch_inlines.h
+++ b/include/zephyr/arch/arch_inlines.h
@@ -34,6 +34,8 @@
 #include <zephyr/arch/sparc/arch_inlines.h>
 #elif defined(CONFIG_RX)
 #include <zephyr/arch/rx/arch_inlines.h>
+#elif defined(CONFIG_ARCH_IS_SET)
+#error "The selected architecture is missing from this dispatch header"
 #endif
 
 #endif /* ZEPHYR_INCLUDE_ARCH_ARCH_INLINES_H_ */

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -93,6 +93,14 @@ static inline uint64_t arch_k_cycle_get_64(void);
 
 /**
  * @def ARCH_THREAD_STACK_RESERVED
+ * @brief Reserved space at the beginning of every thread stack object
+ *
+ * Number of bytes reserved at the lowest addresses of a thread stack
+ * object for architecture or platform data, such as an MPU stack guard
+ * region. This space is not usable as thread stack buffer and is not
+ * included in the stack size requested by the user.
+ *
+ * Optional definition, defaults to 0.
  *
  * @see K_THREAD_STACK_RESERVED
  */
@@ -102,19 +110,30 @@ static inline uint64_t arch_k_cycle_get_64(void);
 
 /**
  * @def ARCH_STACK_PTR_ALIGN
+ * @brief Required alignment of the CPU's stack pointer
  *
  * Required alignment of the CPU's stack pointer register value, dictated by
  * hardware constraints and the ABI calling convention.
  *
  * @see Z_STACK_PTR_ALIGN
  */
+#ifdef __DOXYGEN__
+#define ARCH_STACK_PTR_ALIGN
+#endif
 
 /**
  * @def ARCH_THREAD_STACK_OBJ_ALIGN(size)
+ * @brief Required alignment of the lowest address of a stack object
  *
- * Required alignment of the lowest address of a stack object.
+ * Required alignment of the lowest address of a stack object, taking the
+ * requested stack buffer size into account. For example, memory protection
+ * hardware may require a stack object to be aligned to its own size.
  *
- * Optional definition.
+ * Optional definition. If undefined, stack objects are aligned to
+ * ARCH_STACK_PTR_ALIGN.
+ *
+ * @param size Requested size of the stack buffer
+ * @return Required alignment of the stack object
  *
  * @see Z_THREAD_STACK_OBJ_ALIGN
  */
@@ -256,9 +275,9 @@ void arch_pm_state_set_finish(unsigned int key);
 
 /** @} */
 
-
 /**
- * @addtogroup arch-smp
+ * @defgroup arch-smp Architecture-specific SMP APIs
+ * @ingroup arch-interface
  * @{
  */
 
@@ -428,6 +447,19 @@ int arch_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
 
 /**
  * @def ARCH_IRQ_CONNECT(irq, pri, isr, arg, flags)
+ * @brief Arch-specific hook for statically connecting an interrupt
+ *
+ * Statically populate the interrupt tables at build time such that
+ * @p isr is invoked with @p arg as its argument when interrupt @p irq
+ * fires, with interrupt priority @p pri and architecture-specific
+ * configuration @p flags. All arguments must be usable in a constant
+ * expression context.
+ *
+ * @param irq Interrupt line number
+ * @param pri Interrupt priority
+ * @param isr Interrupt service routine
+ * @param arg Argument passed to the ISR
+ * @param flags Arch-specific IRQ configuration flags
  *
  * @see IRQ_CONNECT()
  */
@@ -435,16 +467,40 @@ int arch_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
 #define ARCH_IRQ_CONNECT(irq, pri, isr, arg, flags)
 #endif
 
-#ifdef CONFIG_PCIE
 /**
  * @def ARCH_PCIE_IRQ_CONNECT(bdf, irq, pri, isr, arg, flags)
+ * @brief Arch-specific hook for connecting a PCIe endpoint interrupt
+ *
+ * As for ARCH_IRQ_CONNECT(), but for an interrupt belonging to the PCIe
+ * endpoint identified by @p bdf, so the architecture may resolve the
+ * final interrupt vector from the endpoint at build or run time.
+ *
+ * @param bdf PCIe endpoint bus/device/function identifier
+ * @param irq Interrupt line number
+ * @param pri Interrupt priority
+ * @param isr Interrupt service routine
+ * @param arg Argument passed to the ISR
+ * @param flags Arch-specific IRQ configuration flags
  *
  * @see PCIE_IRQ_CONNECT()
  */
-#endif /* CONFIG_PCIE */
+#ifdef __DOXYGEN__
+#define ARCH_PCIE_IRQ_CONNECT(bdf, irq, pri, isr, arg, flags)
+#endif
 
 /**
  * @def ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p)
+ * @brief Arch-specific hook for statically connecting a direct interrupt
+ *
+ * As for ARCH_IRQ_CONNECT(), but for an ISR declared with
+ * ARCH_ISR_DIRECT_DECLARE() that is installed to bypass the common
+ * software ISR dispatch for minimum latency. Direct ISRs take no
+ * argument.
+ *
+ * @param irq_p Interrupt line number
+ * @param priority_p Interrupt priority
+ * @param isr_p Direct interrupt service routine
+ * @param flags_p Arch-specific IRQ configuration flags
  *
  * @see IRQ_DIRECT_CONNECT()
  */
@@ -454,6 +510,12 @@ int arch_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
 
 /**
  * @def ARCH_ISR_DIRECT_PM()
+ * @brief Arch-specific hook for power management in a direct ISR
+ *
+ * Perform the power management bookkeeping that the common interrupt
+ * dispatch path would otherwise do (such as exiting a low-power idle
+ * state). Direct ISRs that may interrupt the idle loop invoke this
+ * through ISR_DIRECT_PM().
  *
  * @see ISR_DIRECT_PM()
  */
@@ -463,6 +525,12 @@ int arch_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
 
 /**
  * @def ARCH_ISR_DIRECT_HEADER()
+ * @brief Arch-specific bookkeeping on direct interrupt entry
+ *
+ * Perform the interrupt-entry bookkeeping that the common interrupt
+ * dispatch path would otherwise do, such as tracking interrupt nesting
+ * and emitting tracing events. Invoked at the top of every direct ISR
+ * through ISR_DIRECT_HEADER().
  *
  * @see ISR_DIRECT_HEADER()
  */
@@ -472,6 +540,14 @@ int arch_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
 
 /**
  * @def ARCH_ISR_DIRECT_FOOTER(swap)
+ * @brief Arch-specific bookkeeping on direct interrupt exit
+ *
+ * Counterpart to ARCH_ISR_DIRECT_HEADER(): undo the interrupt-entry
+ * bookkeeping and, if @p swap is non-zero, check whether a context
+ * switch is needed on interrupt exit and arrange for it. Invoked at
+ * the end of every direct ISR through ISR_DIRECT_FOOTER().
+ *
+ * @param swap Non-zero if a context switch may be performed on exit
  *
  * @see ISR_DIRECT_FOOTER()
  */
@@ -481,6 +557,16 @@ int arch_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
 
 /**
  * @def ARCH_ISR_DIRECT_DECLARE(name)
+ * @brief Arch-specific hook for declaring a direct interrupt service routine
+ *
+ * Declare a function @p name suitable for installation with
+ * ARCH_IRQ_DIRECT_CONNECT(), wrapping the function body that follows
+ * such that ARCH_ISR_DIRECT_HEADER() and ARCH_ISR_DIRECT_FOOTER() run
+ * around it and any architecture-specific ISR prologue/epilogue (such
+ * as interrupt attributes) is applied. The wrapped body returns
+ * non-zero if a context switch may be performed on interrupt exit.
+ *
+ * @param name Name of the direct interrupt service routine to declare
  *
  * @see ISR_DIRECT_DECLARE()
  */
@@ -568,10 +654,8 @@ void arch_irq_offload_init(void);
 
 /** @} */
 
-
 /**
- * @defgroup arch-smp Architecture-specific SMP APIs
- * @ingroup arch-interface
+ * @addtogroup arch-smp
  * @{
  */
 #ifdef CONFIG_SMP
@@ -1405,10 +1489,7 @@ typedef bool (*stack_trace_callback_fn)(void *cookie, unsigned long addr);
 void arch_stack_walk(stack_trace_callback_fn callback_fn, void *cookie,
 		     const struct k_thread *thread, const struct arch_esf *esf);
 
-/**
- * arch-stackwalk
- * @}
- */
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/arch/arm64/structs.h
+++ b/include/zephyr/arch/arm64/structs.h
@@ -18,6 +18,13 @@ struct _cpu_arch {
 	/* Saved the corrupted stack pointer when stack overflow, else 0 */
 	uint64_t corrupted_sp;
 #endif
+#if !defined(CONFIG_FPU_SHARING) && !defined(CONFIG_ARM64_SAFE_EXCEPTION_STACK) &&                 \
+	defined(__cplusplus)
+	/* This struct will have a size 0 in C which is not allowed in C++ (it'll have a size 1). To
+	 * prevent this, we add a 1 byte dummy variable.
+	 */
+	uint8_t dummy;
+#endif
 };
 
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM64_STRUCTS_H_ */

--- a/include/zephyr/arch/common/addr_types.h
+++ b/include/zephyr/arch/common/addr_types.h
@@ -1,4 +1,4 @@
-/* x86 address types (virtual, physical, etc) definitions */
+/* Address types (virtual, physical, etc) definitions */
 
 /*
  * Copyright (c) 2015 Wind River Systems, Inc.

--- a/include/zephyr/arch/cpu.h
+++ b/include/zephyr/arch/cpu.h
@@ -33,6 +33,8 @@
 #include <zephyr/arch/sparc/arch.h>
 #elif defined(CONFIG_RX)
 #include <zephyr/arch/rx/arch.h>
+#elif defined(CONFIG_ARCH_IS_SET)
+#error "The selected architecture is missing from this dispatch header"
 #endif
 
 #endif /* ZEPHYR_INCLUDE_ARCH_CPU_H_ */

--- a/include/zephyr/arch/exception.h
+++ b/include/zephyr/arch/exception.h
@@ -134,6 +134,8 @@ static inline void arch_exception_call_dump_hook(const char *format, ...)
 #include <zephyr/arch/sparc/exception.h>
 #elif defined(CONFIG_RX)
 #include <zephyr/arch/rx/exception.h>
+#elif defined(CONFIG_ARCH_IS_SET)
+#error "The selected architecture is missing from this dispatch header"
 #endif
 
 #endif /* ZEPHYR_INCLUDE_ARCH_EXCEPTION_H_ */

--- a/include/zephyr/arch/exception.h
+++ b/include/zephyr/arch/exception.h
@@ -126,6 +126,8 @@ static inline void arch_exception_call_dump_hook(const char *format, ...)
 #include <zephyr/arch/xtensa/exception.h>
 #elif defined(CONFIG_MIPS)
 #include <zephyr/arch/mips/exception.h>
+#elif defined(CONFIG_OPENRISC)
+#include <zephyr/arch/openrisc/exception.h>
 #elif defined(CONFIG_ARCH_POSIX)
 #include <zephyr/arch/posix/exception.h>
 #elif defined(CONFIG_SPARC)

--- a/include/zephyr/arch/exception.h
+++ b/include/zephyr/arch/exception.h
@@ -16,7 +16,7 @@
 #include <stdarg.h>
 
 /**
- * @typedef exception_dump_hook_t
+ * @typedef arch_exception_dump_hook_t
  * @brief Exception dump output callback.
  *
  * Called for each exception dump print with printf-style format and
@@ -28,7 +28,7 @@
 typedef void (*arch_exception_dump_hook_t)(const char *format, va_list args);
 
 /**
- * @typedef exception_drain_hook_t
+ * @typedef arch_exception_drain_hook_t
  * @brief Exception dump flush callback.
  *
  * Called when exception dump output should be drained or reset.

--- a/include/zephyr/arch/openrisc/arch.h
+++ b/include/zephyr/arch/openrisc/arch.h
@@ -20,7 +20,7 @@
 
 #include <zephyr/devicetree.h>
 #if !defined(_ASMLANGUAGE) && !defined(__ASSEMBLER__)
-#include <zephyr/arch/openrisc/exception.h>
+#include <zephyr/arch/exception.h>
 #include <zephyr/arch/openrisc/irq.h>
 #include <zephyr/arch/openrisc/thread.h>
 #include <zephyr/arch/common/sys_bitops.h>

--- a/include/zephyr/arch/syscall.h
+++ b/include/zephyr/arch/syscall.h
@@ -23,6 +23,8 @@
 #include <zephyr/arch/riscv/syscall.h>
 #elif defined(CONFIG_XTENSA)
 #include <zephyr/arch/xtensa/syscall.h>
+#elif defined(CONFIG_USERSPACE)
+#error "The selected architecture is missing from this dispatch header"
 #endif
 
 #endif /* ZEPHYR_INCLUDE_ARCH_SYSCALL_H_ */

--- a/include/zephyr/arch/xtensa/irq.h
+++ b/include/zephyr/arch/xtensa/irq.h
@@ -172,12 +172,6 @@ int z_soc_irq_is_enabled(unsigned int irq);
 
 #define arch_irq_is_enabled(irq)	z_soc_irq_is_enabled(irq)
 
-#ifdef CONFIG_DYNAMIC_INTERRUPTS
-extern int z_soc_irq_connect_dynamic(unsigned int irq, unsigned int priority,
-				     void (*routine)(const void *parameter),
-				     const void *parameter, uint32_t flags);
-#endif
-
 #else
 
 #define CONFIG_NUM_IRQS XCHAL_NUM_INTERRUPTS

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
- * @defgroup arch-timing Architecture timing APIs
+ * @addtogroup arch-timing
  * @{
  */
 #ifdef CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT
@@ -249,7 +249,7 @@ int arch_coprocessors_disable(struct k_thread *thread);
  * @return 0 on success
  * @return -EBADF Bad thread object
  * @return -EPERM No permissions on thread object
- * #return -ENOTSUP Forbidden by hardware policy
+ * @return -ENOTSUP Forbidden by hardware policy
  * @return -EINVAL Thread is uninitialized or exited or not a user thread
  * @return -EFAULT Bad memory address for unused_ptr
  */

--- a/soc/intel/intel_adsp/cavs/irq.c
+++ b/soc/intel/intel_adsp/cavs/irq.c
@@ -15,10 +15,6 @@
 #include <adsp_interrupt.h>
 #include "soc.h"
 
-#ifdef CONFIG_DYNAMIC_INTERRUPTS
-#include <zephyr/sw_isr_table.h>
-#endif
-
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 #define CAVS_INTC_NODE(n) DT_INST(n, intel_cavs_intc)
@@ -137,56 +133,3 @@ int z_soc_irq_is_enabled(unsigned int irq)
 out:
 	return ret;
 }
-
-#ifdef CONFIG_DYNAMIC_INTERRUPTS
-int z_soc_irq_connect_dynamic(unsigned int irq, unsigned int priority,
-			      void (*routine)(const void *parameter),
-			      const void *parameter, uint32_t flags)
-{
-	uint32_t table_idx;
-	uint32_t cavs_irq, cavs_idx;
-	int ret;
-
-	ARG_UNUSED(flags);
-	ARG_UNUSED(priority);
-
-	/* extract 2nd level interrupt number */
-	cavs_irq = CAVS_IRQ_NUMBER(irq);
-	ret = irq;
-
-	if (cavs_irq == 0) {
-		/* Not affecting 2nd level interrupts */
-		z_isr_install(irq, routine, parameter);
-		goto irq_connect_out;
-	}
-
-	/* Figure out the base index. */
-	switch (XTENSA_IRQ_NUMBER(irq)) {
-	case DT_IRQN(CAVS_INTC_NODE(0)):
-		cavs_idx = 0;
-		break;
-	case DT_IRQN(CAVS_INTC_NODE(1)):
-		cavs_idx = 1;
-		break;
-	case DT_IRQN(CAVS_INTC_NODE(2)):
-		cavs_idx = 2;
-		break;
-	case DT_IRQN(CAVS_INTC_NODE(3)):
-		cavs_idx = 3;
-		break;
-	default:
-		ret = -EINVAL;
-		goto irq_connect_out;
-	}
-
-	table_idx = CONFIG_CAVS_ISR_TBL_OFFSET +
-		CONFIG_MAX_IRQ_PER_AGGREGATOR * cavs_idx;
-	table_idx += cavs_irq;
-
-	_sw_isr_table[table_idx].arg = parameter;
-	_sw_isr_table[table_idx].isr = routine;
-
-irq_connect_out:
-	return ret;
-}
-#endif


### PR DESCRIPTION
- **arch: add missing OpenRISC entry to exception.h dispatcher**
- **arch: error out when an architecture is missing from dispatch headers**
- **xtensa: remove dead z_arch_irq_connect_dynamic**
- **arm64: structs: guard against empty _cpu_arch struct in C++**
- **arch: fix Doxygen structure of the arch interface headers**
- **doc: porting: arch: drop stale Nios2 reference and fix select syntax**
- **arch: fix stale comments in arch-related headers and gicv3**
