### PR TITLE
arch: drop inverted PCIE_CONTROLLER guard around IRQ allocation API

### DIFF
--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -488,13 +488,16 @@ int arch_irq_disconnect_dynamic(unsigned int irq, unsigned int priority,
 #define ARCH_ISR_DIRECT_DECLARE(name)
 #endif
 
-#ifndef CONFIG_PCIE_CONTROLLER
 /**
  * @brief Arch-specific hook for allocating IRQs
  *
  * Note: disable/enable IRQ relevantly inside the implementation of such
  * function to avoid concurrency issues. Also, an allocated IRQ is assumed
  * to be used thus a following @see arch_irq_is_used() should return true.
+ *
+ * This API is only used when no PCIe controller driver is enabled
+ * (@kconfig{CONFIG_PCIE_CONTROLLER}); with a controller driver, IRQ
+ * allocation is handled by the controller instead.
  *
  * @return The newly allocated IRQ or UINT_MAX on error.
  */
@@ -518,8 +521,6 @@ void arch_irq_set_used(unsigned int irq);
  * @return true if being, false otherwise
  */
 bool arch_irq_is_used(unsigned int irq);
-
-#endif /* CONFIG_PCIE_CONTROLLER */
 
 /**
  * @def ARCH_EXCEPT(reason_p)


### PR DESCRIPTION
arch_irq_allocate(), arch_irq_set_used() and arch_irq_is_used() were
declared under #ifndef CONFIG_PCIE_CONTROLLER, a negative dependency
on an unrelated subsystem option inside the canonical arch interface
header, unique in the file. The functions themselves are not PCIe
specific; the guard only reflected that platforms with a PCIe
controller driver allocate IRQs through the controller instead.

Declare them unconditionally like every other interface prototype
and document the PCIe controller relationship in the API description
instead. No functional change: prototypes have no code cost and the
callers (drivers/pcie/host, intc_intel_vtd) keep their existing
Kconfig conditions.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
