### PR TITLE
ci: pr_metadata_check: stop the six hour hangs on backport PRs

### DIFF
--- a/.github/workflows/pr_metadata_check.yml
+++ b/.github/workflows/pr_metadata_check.yml
@@ -11,16 +11,20 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  # Key on the PR number: it is globally unique, while github.head_ref is only a
+  # branch name and collides between forks (two PRs from a branch named 'main'
+  # would cancel each other).
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   do-not-merge:
     name: Prevent Merging
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -49,4 +53,5 @@ jobs:
           python -u scripts/ci/do_not_merge.py \
           -p "${{ github.event.pull_request.number }}" \
           -o "${{ github.event.repository.owner.login }}" \
-          -r "${{ github.event.repository.name }}"
+          -r "${{ github.event.repository.name }}" \
+          -a "${{ github.event.action }}"

--- a/scripts/ci/do_not_merge.py
+++ b/scripts/ci/do_not_merge.py
@@ -4,21 +4,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import datetime
 import os
 import sys
 import time
 
 import github
+import urllib3
 
 DNM_LABELS = ["DNM", "DNM (manifest)", "TSC", "Architecture Review", "dev-review"]
 
+# Workflows that label the pull request, and so have to complete before the
+# labels can be trusted. Keyed by workflow file name rather than display name,
+# which is stable across renames.
+WAIT_FOR_WORKFLOWS = ["manifest.yml"]
 
-def print_rate_limit(gh, org):
-    response = gh.get_organization(org)
-    for header, value in response.raw_headers.items():
-        if header.startswith("x-ratelimit"):
-            print(f"{header}: {value}")
+# Events that can be followed by a labelling workflow. A label event carries the
+# final label state already, so there is nothing to wait for.
+WAIT_FOR_ACTIONS = {"opened", "reopened", "synchronize"}
+
+WAIT_POLL_S = 30
+WAIT_TIMEOUT_S = 600
 
 
 def parse_args(argv):
@@ -31,46 +36,94 @@ def parse_args(argv):
     parser.add_argument("-p", "--pull-request", required=True, type=int, help="The PR number")
     parser.add_argument("-o", "--org", default="zephyrproject-rtos", help="Github organization")
     parser.add_argument("-r", "--repo", default="zephyr", help="Github repository")
+    parser.add_argument("-a", "--action", default="", help="The pull_request event action")
+    parser.add_argument(
+        "-t",
+        "--wait-timeout",
+        type=int,
+        default=WAIT_TIMEOUT_S,
+        help="Seconds to wait for the labelling workflows before giving up",
+    )
 
     return parser.parse_args(argv)
 
 
-WAIT_FOR_WORKFLOWS = set({"Manifest"})
-WAIT_FOR_DELAY_S = 60
+def workflow_delay(repo, pr, action, timeout):
+    """Wait for the workflows that label the PR to complete.
 
+    Returns once they are done, or once the timeout expires. Not completing is
+    not fatal: the workflow reruns on 'labeled' and 'unlabeled', so a label
+    applied after this point re-evaluates the check.
+    """
+    if action and action not in WAIT_FOR_ACTIONS:
+        print(f"event action is {action!r}, labels are already settled, not waiting")
+        return
 
-def workflow_delay(repo, pr):
-    print(f"PR is at {pr.head.sha}")
+    sha = pr.head.sha
+    print(f"PR is at {sha}")
 
-    while True:
-        runs = repo.get_workflow_runs(head_sha=pr.head.sha)
+    pending = {}
+    for name in WAIT_FOR_WORKFLOWS:
+        try:
+            pending[name] = repo.get_workflow(name)
+        except github.GithubException as e:
+            # The workflow does not exist on this base branch, so it will never
+            # run and there is nothing to wait for.
+            print(f"{name}: not available on this branch ({e.status}), not waiting")
 
-        completed = set()
-        for run in runs:
-            print(f"{run.name}: {run.status} {run.conclusion} {run.html_url}")
+    deadline = time.monotonic() + timeout
+
+    while pending:
+        for name, workflow in list(pending.items()):
+            runs = workflow.get_runs(head_sha=sha)
+
+            if runs.totalCount == 0:
+                # No run has been created. This is normal for a few seconds
+                # after a push, but permanent for PRs opened by GITHUB_TOKEN
+                # (backport bot), which do not trigger pull_request_target
+                # workflows at all. The timeout below is what bounds this.
+                print(f"{name}: no run for {sha} yet")
+                continue
+
+            run = runs[0]
+            print(f"{name}: {run.status} {run.conclusion} {run.html_url}")
             if run.status == "completed":
-                completed.add(run.name)
+                del pending[name]
 
-        if WAIT_FOR_WORKFLOWS.issubset(completed):
+        if not pending:
             return
 
-        ts = datetime.datetime.now()
-        print(f"wait: {ts} completed={completed}")
-        time.sleep(WAIT_FOR_DELAY_S)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            print(
+                f"timed out after {timeout}s waiting for {sorted(pending)}, "
+                "checking the labels as they are now"
+            )
+            return
+
+        # Re-read the PR: a new push supersedes this run, and the concurrency
+        # group cancels it, but do not keep polling a stale sha in the meantime.
+        pr.update()
+        if pr.head.sha != sha:
+            print(f"PR moved to {pr.head.sha}, this run is superseded")
+            return
+
+        time.sleep(min(WAIT_POLL_S, remaining))
 
 
 def main(argv):
     args = parse_args(argv)
 
     auth = github.Auth.Token(os.environ.get('GITHUB_TOKEN', None))
-    gh = github.Github(auth=auth)
-
-    print_rate_limit(gh, args.org)
+    # Retry on the transient 5xx and on secondary rate limits rather than
+    # failing the check, which is a required check and would block the PR.
+    retry = urllib3.Retry(total=5, backoff_factor=2, status_forcelist=[403, 500, 502, 503, 504])
+    gh = github.Github(auth=auth, retry=retry)
 
     repo = gh.get_repo(f"{args.org}/{args.repo}")
     pr = repo.get_pull(args.pull_request)
 
-    workflow_delay(repo, pr)
+    workflow_delay(repo, pr, args.action, args.wait_timeout)
 
     print(f"pr: {pr.html_url}")
 


### PR DESCRIPTION
We need this in the release branches, but first we need this to land in main.

do_not_merge.py waits for the Manifest workflow to complete on the PR head
sha, with no deadline. Manifest runs on pull_request_target, and GitHub does
not create pull_request_target runs for PRs opened by the default
GITHUB_TOKEN. Backport PRs are opened by the backport action, so they have no
Manifest run and never will: the script spins until GitHub cancels the job at
its six hour ceiling. Release branches carry no timeout-minutes, so nothing
else bounds it either.
