### PR TITLE
Switch to more modern, more safe git commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -866,8 +866,8 @@ else()
     file(WRITE ${syscalls_subdirs_txt} "")
   endif()
 
-  # On other OS'es, using git checkout is reflected on the folder timestamp and hence detected
-  # when using depend on directory level.
+  # On other OS'es, using git checkout (or switch, restore, etc.) is reflected on the folder
+  # timestamp and hence detected when using depend on directory level.
   # Thus CMake only needs to re-run when sub-directories are added / removed, which is indicated
   # by syscalls_subdirs_txt being updated.
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${syscalls_subdirs_txt})

--- a/boards/arduino/due/doc/index.rst
+++ b/boards/arduino/due/doc/index.rst
@@ -132,7 +132,7 @@ To build the bossa tool, follow these steps:
 
    .. code-block:: console
 
-     $ git checkout arduino
+     $ git switch arduino
 
 #. Build the command line version of the bossa tool.
 

--- a/boards/intel/adsp/doc/chromebooks_adsp.rst
+++ b/boards/intel/adsp/doc/chromebooks_adsp.rst
@@ -205,7 +205,7 @@ place it in the home directory here for simplicity:
     dev$ cd $HOME
     dev$ git clone https://chromium.googlesource.com/chromiumos/third_party/kernel
     dev$ cd kernel
-    dev$ git checkout chromeos-5.10
+    dev$ git switch chromeos-5.10
 
 (*Once again, we are typing into a different shell.  We introduce the
 hostname "dev" here to represent the development machine on which you

--- a/boards/intel/common/scripts/build_grub.sh
+++ b/boards/intel/common/scripts/build_grub.sh
@@ -24,7 +24,7 @@ prepare() {
   fi
 
   pushd src
-  git checkout grub-2.12-rc1
+  git switch --detach grub-2.12-rc1
   git clean -fdx
   popd
 }

--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -870,13 +870,13 @@ workflow here:
 #. Create a topic branch (off of ``main``) for your work (if you're addressing
    an issue, we suggest including the issue number in the branch name)::
 
-     git checkout main
-     git checkout -b fix_comment_typo
+     git switch main
+     git switch -c fix_comment_typo
 
    Some Zephyr subsystems do development work on a separate branch from
    ``main`` so you may need to indicate this in your checkout::
 
-     git checkout -b fix_out_of_date_patch origin/net
+     git switch -c fix_out_of_date_patch origin/net
 
 #. Make changes, test locally, change, test, test again, ...  (Check out the
    prior chapter on `twister`_ as well).
@@ -928,8 +928,8 @@ workflow here:
    can create another branch to work on another issue. (Be sure to make your
    new branch off of ``main`` and not the previous branch.)::
 
-     git checkout main
-     git checkout -b fix_another_issue
+     git switch main
+     git switch -c fix_another_issue
 
    and use the same process described above to work on this new topic branch.
 

--- a/doc/develop/manifest/external/executorch.rst
+++ b/doc/develop/manifest/external/executorch.rst
@@ -188,7 +188,7 @@ inference, and CPU-only inference for devices without an NPU.
                .. code-block:: console
 
                   cd FVPs-on-Mac
-                  git checkout 1458860
+                  git switch --detach 1458860
 
                **Step 2:** Build the Docker wrapper:
 

--- a/samples/drivers/ethernet/eth_ivshmem/README.rst
+++ b/samples/drivers/ethernet/eth_ivshmem/README.rst
@@ -21,7 +21,7 @@ some fixes that are not yet on the "master" branch:
 
     git clone https://github.com/siemens/jailhouse-images.git
     cd jailhouse-images
-    git checkout origin/next
+    git switch --detach origin/next
 
 Open the menu, select "QEMU ARM64 virtual target" then "Save & Build"
 (this will take a while):

--- a/scripts/footprint/compare_footprint
+++ b/scripts/footprint/compare_footprint
@@ -100,7 +100,7 @@ def sanity_results_filename(commit=None, cwd=os.environ.get('ZEPHYR_BASE')):
 
     return os.path.join(cwd,'scripts', 'sanity_chk', file_name)
 
-def git_checkout(commit, cwd=os.environ.get('ZEPHYR_BASE')):
+def git_reset(commit, cwd=os.environ.get('ZEPHYR_BASE')):
     proc = subprocess.Popen('git diff --quiet', stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT, cwd=cwd, shell=True)
     if proc.wait() != 0:
@@ -150,7 +150,7 @@ def run_footprint_build(commit=None):
                                 stderr=subprocess.STDOUT,
                                 cwd=tempfile.gettempdir(), shell=True)
         if proc.wait() == 0:
-            if git_checkout(commit, tmp_location):
+            if git_reset(commit, tmp_location):
                 run_sanity_footprint(commit, tmp_location)
         else:
             logger.error(proc.stdout.read())


### PR DESCRIPTION
I think it is better to suggest the usage of the more modern, less data-loss-error-prone commands, i.e. `git switch` instead of `git checkout` where applicable.

Not changing `git checkout .` as default for `checkout-command` in https://github.com/zephyrproject-rtos/zephyr/blob/f1521edd229774b6e3cd4796d1e7300a6d6c1131/scripts/schemas/patch-schema.yml#L110 because there the intention is to actually erase changes, and switching to `git restore .` would just introduce either an inconsistency or a breaking change (renaming `checkout-command`).