### PR TITLE
tests: benchmarks: timeout_mgmt: use z_try_abort_timeout()

### DIFF
--- a/tests/benchmarks/timeout_mgmt/src/main.c
+++ b/tests/benchmarks/timeout_mgmt/src/main.c
@@ -64,7 +64,7 @@ static void test_decreasing_timeouts(unsigned int num_timeouts)
 
 	for (i = 0; i < num_timeouts; i++) {
 		start = timing_counter_get();
-		z_abort_timeout(&timeout[i]);
+		(void)z_try_abort_timeout(&timeout[i]);
 		finish = timing_counter_get();
 		abort_cycles[i] += timing_cycles_get(&start, &finish);
 	}
@@ -95,7 +95,7 @@ static void test_increasing_timeouts(unsigned int num_timeouts)
 
 	for (i = 0; i < num_timeouts; i++) {
 		start = timing_counter_get();
-		z_abort_timeout(&timeout[i]);
+		(void)z_try_abort_timeout(&timeout[i]);
 		finish = timing_counter_get();
 		abort_cycles[i] += timing_cycles_get(&start, &finish);
 	}
@@ -126,7 +126,7 @@ static void test_interleaved_timeouts(unsigned int num_timeouts)
 
 	for (i = 0; i < num_timeouts; i++) {
 		start = timing_counter_get();
-		z_abort_timeout(&timeout[num_timeouts - i - 1]);
+		(void)z_try_abort_timeout(&timeout[num_timeouts - i - 1]);
 		finish = timing_counter_get();
 		abort_cycles[i] += timing_cycles_get(&start, &finish);
 	}


### PR DESCRIPTION
Commits 805b2af18ef and 387b387479e replaced the kernel-internal
z_abort_timeout() with z_try_abort_timeout(), which tracks in-flight
timeouts and returns 0, -EINVAL or -EAGAIN. Every in-tree caller was
migrated except this benchmark, which still called the function that no
longer exists:

  error: implicit declaration of function 'z_abort_timeout'

Update the three call sites. The return value is deliberately discarded:
the benchmark aborts timeouts it has just installed itself and measures
the cost of the operation, not its outcome.
