### PR TITLE
fs: ext2: reject sub-1024 block_size in ext2_format() before it underflows

### DIFF
--- a/subsys/fs/ext2/ext2_format.c
+++ b/subsys/fs/ext2/ext2_format.c
@@ -18,10 +18,19 @@ LOG_MODULE_DECLARE(ext2, LOG_LEVEL_DBG);
 
 FS_EXT2_DECLARE_DEFAULT_CONFIG(ext2_default);
 
-static void validate_config(struct ext2_cfg *cfg)
+static int validate_config(struct ext2_cfg *cfg)
 {
 	if (cfg->block_size == 0) {
 		cfg->block_size = ext2_default.block_size;
+	} else if (cfg->block_size < 1024 ||
+		   (cfg->block_size & (cfg->block_size - 1)) != 0) {
+		/* block_size must be a power of two of at least 1024, otherwise the
+		 * 's_log_block_size' calculation below (log2(block_size) - 11) would
+		 * underflow the unsigned 'block_log_size' and corrupt the superblock.
+		 */
+		LOG_ERR("Unsupported block_size %u (must be 0 or a power of two >= 1024)",
+			cfg->block_size);
+		return -EINVAL;
 	}
 
 	if (cfg->bytes_per_inode == 0) {
@@ -40,6 +49,8 @@ static void validate_config(struct ext2_cfg *cfg)
 		cfg->uuid[6] = (cfg->uuid[6] & 0x0f) | 0x40;
 		cfg->uuid[8] = (cfg->uuid[8] & 0x3f) | 0x80;
 	}
+
+	return 0;
 }
 
 static void set_bitmap_padding(uint8_t *bitmap, uint32_t nelems, struct ext2_cfg *cfg)
@@ -97,7 +108,11 @@ int ext2_format(struct ext2_data *fs, struct ext2_cfg *cfg)
 {
 	int rc, ret = 0;
 
-	validate_config(cfg);
+	ret = validate_config(cfg);
+	if (ret < 0) {
+		return ret;
+	}
+
 	LOG_INF("[Config] blk_sz:%d fs_sz:%d ino_bytes:%d uuid:'%s' vol:'%s'",
 			cfg->block_size, cfg->fs_size, cfg->bytes_per_inode, cfg->uuid,
 			cfg->volume_name);


### PR DESCRIPTION
## Description

`ext2_format()` computes the superblock's `s_log_block_size` field as:

```c
uint8_t block_log_size = find_msb_set(cfg->block_size) - 11;
```

`find_msb_set()` returns `unsigned int` (`include/zephyr/arch/common/ffs.h`), so this
subtraction is unsigned arithmetic. `validate_config()` only substitutes the default
block size when `cfg->block_size == 0` — it never enforces a minimum — so any caller
that passes a `block_size` smaller than 1024 (the sector size 512 is an easy, plausible
mistake to make here) causes `find_msb_set(cfg->block_size) - 11` to underflow, and the
truncated garbage is written straight into the on-disk superblock:

| `block_size` | `find_msb_set()` | `block_log_size` written to disk |
|---|---|---|
| 512 | 10 | 255 |
| 256 | 9 | 254 |
| 100 | 7 | 252 |
| 1 | 1 | 246 |

`ext2_format()` returns success while silently writing a corrupt, unmountable file
system, instead of failing cleanly at format time with a clear error.

This is the root cause flagged by Coverity CID 487768 / issue #84678, and independently
confirmed there by @de-nordic: *"it is possible to set block_size to 512 bytes, even
though it seems that other code expects block_size to be multiply of 1024."*

Note: PR #111241 already added a mount-time bound check (`s_log_block_size > 11U` is
rejected in `ext2_verify_disk_superblock()`), so a superblock corrupted by this bug can
no longer cause Zephyr's own mount path to compute an out-of-bounds shift. That is a
separate, already-fixed concern; it does not address the format-time bug itself, which
still lets `fs_mkfs(FS_EXT2, ...)` silently produce a corrupt, unmountable file system
for any `block_size < 1024`.

## Fix

Extend `validate_config()` to reject any nonzero `block_size` that is not a power of two
`>= 1024`, and propagate that error from `ext2_format()` before the shift-count
calculation is reached. `block_size == 0` still resolves to the documented default, and
every currently-legal value (1024/2048/4096/...) is unaffected — verified with a
standalone reproduction of the exact arithmetic (see Testing).

## Testing

- Reproduced the underflow and validated the fix with a standalone host program that
  copies `find_msb_set()` and the exact expressions verbatim (gcc, `-Wall -Wextra
  -std=c11`): all four bad inputs (512/256/100/1) are rejected with the new check before
  the shift-count is ever computed, and all legal inputs (0/1024/2048/4096) resolve to a
  `block_log_size` byte-identical to what the current code already produces for them.
- Ran `scripts/checkpatch.pl` against the diff: 0 errors, 0 warnings.
- I do not have a Zephyr SDK / `west` toolchain available in this environment, so I was
  not able to run an in-tree `west build` / twister test for `tests/subsys/fs/ext2`
  (that suite currently only exercises `block_size` 2048/4096, never a value below
  1024, so it would not have caught this regardless). Flagging this limitation
  explicitly rather than claiming in-tree verification I didn't do.

Fixes #84678

## Disclosure

Generative AI (Claude) was used to help investigate this issue and implement this fix.
All changes were reviewed by me before submission.
