### PR TITLE
drivers: watchdog: wdt_xilinx_wwdt: cleanup, firmware-owned reset, DEVICE_MMIO, zero-window fix

### DIFF
--- a/drivers/watchdog/Kconfig.xilinx_wwdt
+++ b/drivers/watchdog/Kconfig.xilinx_wwdt
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 config XILINX_WINDOW_WATCHDOG
@@ -14,3 +14,25 @@ config XILINX_WINDOW_WATCHDOG
 	  late. The WWDT has to be restarted within the open window time.
 	  If software tries to restart WWDT outside of the open window
 	  time period, it generates a SOC reset.
+
+if XILINX_WINDOW_WATCHDOG
+
+choice
+	prompt "Watchdog mode"
+	default XILINX_VERSAL_WDT_WINDOW_MODE
+	help
+	  Select which watchdog engine of the IP the driver operates.
+
+config XILINX_VERSAL_WDT_WINDOW_MODE
+	bool "Window watchdog mode"
+	help
+	  Enable the window watchdog.
+
+config XILINX_VERSAL_WDT_GENERIC_MODE
+	bool "Generic watchdog (GWDT) mode"
+	help
+	  Enable the generic watchdog.
+
+endchoice
+
+endif # XILINX_WINDOW_WATCHDOG

--- a/drivers/watchdog/wdt_xilinx_wwdt.c
+++ b/drivers/watchdog/wdt_xilinx_wwdt.c
@@ -9,7 +9,6 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
-#include <zephyr/drivers/hwinfo.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>

--- a/drivers/watchdog/wdt_xilinx_wwdt.c
+++ b/drivers/watchdog/wdt_xilinx_wwdt.c
@@ -40,11 +40,12 @@ LOG_MODULE_REGISTER(xilinx_wwdt, CONFIG_WDT_LOG_LEVEL);
 #define XWWDT_MAX_COUNT_WINDOW_COMBINED	GENMASK64(32, 1)
 
 struct xilinx_wwdt_config {
+	DEVICE_MMIO_ROM;
 	uint32_t wdt_clock_freq;
-	mem_addr_t base;
 };
 
 struct xilinx_wwdt_data {
+	DEVICE_MMIO_RAM;
 	struct k_spinlock lock;
 	bool timeout_active;
 	bool wdt_started;
@@ -52,8 +53,8 @@ struct xilinx_wwdt_data {
 
 static int wdt_xilinx_wwdt_setup(const struct device *dev, uint8_t options)
 {
-	const struct xilinx_wwdt_config *config = dev->config;
 	struct xilinx_wwdt_data *data = dev->data;
+	mm_reg_t reg = DEVICE_MMIO_GET(dev);
 	uint32_t reg_value;
 	int ret = 0;
 
@@ -75,10 +76,10 @@ static int wdt_xilinx_wwdt_setup(const struct device *dev, uint8_t options)
 	 */
 
 	/* Read enable status register and update WEN bit */
-	reg_value = sys_read32(config->base + XWWDT_ESR_OFFSET) | XWWDT_ESR_WEN_MASK;
+	reg_value = sys_read32(reg + XWWDT_ESR_OFFSET) | XWWDT_ESR_WEN_MASK;
 
 	/* Write enable status register with updated WEN value */
-	sys_write32(reg_value, config->base + XWWDT_ESR_OFFSET);
+	sys_write32(reg_value, reg + XWWDT_ESR_OFFSET);
 	data->wdt_started = true;
 out:
 	k_spin_unlock(&data->lock, key);
@@ -90,6 +91,7 @@ static int wdt_xilinx_wwdt_install_timeout(const struct device *dev,
 {
 	const struct xilinx_wwdt_config *config = dev->config;
 	struct xilinx_wwdt_data *data = dev->data;
+	mm_reg_t reg = DEVICE_MMIO_GET(dev);
 	uint64_t closed_window_ms_count;
 	uint64_t open_window_ms_count;
 	uint64_t max_hw_timeout_ms;
@@ -138,10 +140,10 @@ static int wdt_xilinx_wwdt_install_timeout(const struct device *dev,
 		goto out;
 	}
 
-	sys_write32(XWWDT_MWR_MASK, config->base + XWWDT_MWR_OFFSET);
-	sys_write32(~(uint32_t)XWWDT_ESR_WEN_MASK, config->base + XWWDT_ESR_OFFSET);
-	sys_write32(closed_window_ms_count, config->base + XWWDT_FWR_OFFSET);
-	sys_write32(open_window_ms_count, config->base + XWWDT_SWR_OFFSET);
+	sys_write32(XWWDT_MWR_MASK, reg + XWWDT_MWR_OFFSET);
+	sys_write32(~(uint32_t)XWWDT_ESR_WEN_MASK, reg + XWWDT_ESR_OFFSET);
+	sys_write32(closed_window_ms_count, reg + XWWDT_FWR_OFFSET);
+	sys_write32(open_window_ms_count, reg + XWWDT_SWR_OFFSET);
 
 	data->timeout_active = true;
 out:
@@ -151,8 +153,8 @@ out:
 
 static int wdt_xilinx_wwdt_feed(const struct device *dev, int channel_id)
 {
-	const struct xilinx_wwdt_config *config = dev->config;
 	struct xilinx_wwdt_data *data = dev->data;
+	mm_reg_t reg = DEVICE_MMIO_GET(dev);
 	uint32_t control_status_reg;
 	uint32_t is_sec_window;
 	int ret = 0;
@@ -165,10 +167,10 @@ static int wdt_xilinx_wwdt_feed(const struct device *dev, int channel_id)
 	}
 
 	/* Enable write access control bit for the WWDT. */
-	sys_write32(XWWDT_MWR_MASK, config->base + XWWDT_MWR_OFFSET);
+	sys_write32(XWWDT_MWR_MASK, reg + XWWDT_MWR_OFFSET);
 
 	/* Trigger restart kick to WWDT. */
-	control_status_reg = sys_read32(config->base + XWWDT_ESR_OFFSET);
+	control_status_reg = sys_read32(reg + XWWDT_ESR_OFFSET);
 
 	/* Check if WWDT is in Second window. */
 	is_sec_window = (control_status_reg & (uint32_t)XWWDT_ESR_WSW_MASK) >> XWWDT_ESR_WSW_SHIFT;
@@ -180,7 +182,7 @@ static int wdt_xilinx_wwdt_feed(const struct device *dev, int channel_id)
 	}
 
 	control_status_reg |= (uint32_t)XWWDT_ESR_WSW_MASK;
-	sys_write32(control_status_reg, config->base + XWWDT_ESR_OFFSET);
+	sys_write32(control_status_reg, reg + XWWDT_ESR_OFFSET);
 out:
 	k_spin_unlock(&data->lock, key);
 	return ret;
@@ -188,8 +190,8 @@ out:
 
 static int wdt_xilinx_wwdt_disable(const struct device *dev)
 {
-	const struct xilinx_wwdt_config *config = dev->config;
 	struct xilinx_wwdt_data *data = dev->data;
+	mm_reg_t reg = DEVICE_MMIO_GET(dev);
 	uint32_t is_wwdt_enable;
 	uint32_t is_sec_window;
 	uint32_t reg_value;
@@ -197,7 +199,7 @@ static int wdt_xilinx_wwdt_disable(const struct device *dev)
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	is_wwdt_enable = sys_read32(config->base + XWWDT_ESR_OFFSET) & XWWDT_ESR_WEN_MASK;
+	is_wwdt_enable = sys_read32(reg + XWWDT_ESR_OFFSET) & XWWDT_ESR_WEN_MASK;
 
 	if (is_wwdt_enable == 0) {
 		ret = -EFAULT;
@@ -205,7 +207,7 @@ static int wdt_xilinx_wwdt_disable(const struct device *dev)
 	}
 
 	/* Read enable status register and check if WWDT is in open window. */
-	is_sec_window = (sys_read32(config->base + XWWDT_ESR_OFFSET) & XWWDT_ESR_WSW_MASK) >>
+	is_sec_window = (sys_read32(reg + XWWDT_ESR_OFFSET) & XWWDT_ESR_WSW_MASK) >>
 				   XWWDT_ESR_WSW_SHIFT;
 
 	if (is_sec_window != 1)	{
@@ -215,10 +217,10 @@ static int wdt_xilinx_wwdt_disable(const struct device *dev)
 	}
 
 	/* Read enable status register and update WEN bit. */
-	reg_value = sys_read32(config->base + XWWDT_ESR_OFFSET) & (~XWWDT_ESR_WEN_MASK);
+	reg_value = sys_read32(reg + XWWDT_ESR_OFFSET) & (~XWWDT_ESR_WEN_MASK);
 
 	/* Write enable status register with updated WEN and WSW value. */
-	sys_write32(reg_value, config->base + XWWDT_ESR_OFFSET);
+	sys_write32(reg_value, reg + XWWDT_ESR_OFFSET);
 
 	data->wdt_started = false;
 out:
@@ -235,6 +237,7 @@ static int wdt_xilinx_wwdt_init(const struct device *dev)
 		return -EINVAL;
 	}
 
+	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 	return ret;
 }
 
@@ -249,7 +252,7 @@ static DEVICE_API(wdt, wdt_xilinx_wwdt_api) = {
 	static struct xilinx_wwdt_data wdt_xilinx_wwdt_##inst##_dev_data;			\
 												\
 	static const struct xilinx_wwdt_config wdt_xilinx_wwdt_##inst##_cfg = {			\
-		.base = DT_INST_REG_ADDR(inst),							\
+		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(inst)),					\
 		.wdt_clock_freq = DT_INST_PROP_BY_PHANDLE(inst, clocks, clock_frequency),	\
 	};											\
 												\

--- a/drivers/watchdog/wdt_xilinx_wwdt.c
+++ b/drivers/watchdog/wdt_xilinx_wwdt.c
@@ -105,9 +105,10 @@ static int wdt_xilinx_wwdt_install_timeout(const struct device *dev,
 		goto out;
 	}
 
-	if (cfg->flags != WDT_FLAG_RESET_SOC) {
-		ret = -ENOTSUP;
-		goto out;
+	/* Reset action is owned by platform firmware (PLM/CDO); cfg->flags is only a hint. */
+	if (cfg->flags != WDT_FLAG_RESET_NONE) {
+		LOG_WRN("WDT_FLAG_RESET_* not honored; "
+			"reset action is owned by firmware (PLM/CDO)");
 	}
 
 	timeout_ms = cfg->window.max;

--- a/drivers/watchdog/wdt_xilinx_wwdt.c
+++ b/drivers/watchdog/wdt_xilinx_wwdt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/watchdog.h>
+#include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 
@@ -30,6 +31,13 @@ LOG_MODULE_REGISTER(xilinx_wwdt, CONFIG_WDT_LOG_LEVEL);
 #define XWWDT_ESR_WSW_MASK	BIT(8)
 #define XWWDT_ESR_WEN_MASK	BIT(0)
 
+/* Function Control Register Masks (second window interrupt assertion point) */
+#define XWWDT_FCR_SBC_MASK GENMASK(15, 8)
+#define XWWDT_FCR_BSS_MASK GENMASK(7, 6)
+
+/* Byte Segment Selection: compare SBC against SW[31:24] (top byte) */
+#define XWWDT_FCR_BSS_BYTE3 3U
+
 /* Watchdog Second Window Shift */
 #define XWWDT_ESR_WSW_SHIFT	8U
 
@@ -42,6 +50,8 @@ LOG_MODULE_REGISTER(xilinx_wwdt, CONFIG_WDT_LOG_LEVEL);
 struct xilinx_wwdt_config {
 	DEVICE_MMIO_ROM;
 	uint32_t wdt_clock_freq;
+	void (*irq_config)(void);
+	unsigned int irq;
 };
 
 struct xilinx_wwdt_data {
@@ -49,10 +59,12 @@ struct xilinx_wwdt_data {
 	struct k_spinlock lock;
 	bool timeout_active;
 	bool wdt_started;
+	wdt_callback_t callback;
 };
 
 static int wdt_xilinx_wwdt_setup(const struct device *dev, uint8_t options)
 {
+	const struct xilinx_wwdt_config *config = dev->config;
 	struct xilinx_wwdt_data *data = dev->data;
 	mm_reg_t reg = DEVICE_MMIO_GET(dev);
 	uint32_t reg_value;
@@ -81,6 +93,15 @@ static int wdt_xilinx_wwdt_setup(const struct device *dev, uint8_t options)
 	/* Write enable status register with updated WEN value */
 	sys_write32(reg_value, reg + XWWDT_ESR_OFFSET);
 	data->wdt_started = true;
+
+	/*
+	 * The interrupt source is enabled by default in the IP (Interrupt_Mask
+	 * reset state), so delivery is gated only at the interrupt controller:
+	 * unmask it only when a warning callback is installed.
+	 */
+	if (data->callback != NULL) {
+		irq_enable(config->irq);
+	}
 out:
 	k_spin_unlock(&data->lock, key);
 	return ret;
@@ -111,6 +132,12 @@ static int wdt_xilinx_wwdt_install_timeout(const struct device *dev,
 	if (cfg->flags != WDT_FLAG_RESET_NONE) {
 		LOG_WRN("WDT_FLAG_RESET_* not honored; "
 			"reset action is owned by firmware (PLM/CDO)");
+	}
+
+	/* A callback requires the WINT interrupt to be wired in DT. */
+	if (cfg->callback != NULL && config->irq_config == NULL) {
+		ret = -ENOTSUP;
+		goto out;
 	}
 
 	timeout_ms = cfg->window.max;
@@ -151,6 +178,21 @@ static int wdt_xilinx_wwdt_install_timeout(const struct device *dev,
 	sys_write32(closed_window_ms_count, reg + XWWDT_FWR_OFFSET);
 	sys_write32(open_window_ms_count, reg + XWWDT_SWR_OFFSET);
 
+	if (cfg->callback != NULL) {
+		/*
+		 * Assert WINT at the start of the open (second) window: with
+		 * BSS=3 the SBC byte is compared against SW[31:24], which equals
+		 * the top byte of the open window count at the instant the
+		 * second window is entered. This fires exactly once per window
+		 * because the down-counting SW never returns to that byte value.
+		 */
+		sys_write32(XWWDT_MWR_MASK, reg + XWWDT_MWR_OFFSET);
+		sys_write32(
+			FIELD_PREP(XWWDT_FCR_BSS_MASK, XWWDT_FCR_BSS_BYTE3) |
+				FIELD_PREP(XWWDT_FCR_SBC_MASK, (open_window_ms_count >> 24) & 0xFF),
+			reg + XWWDT_FCR_OFFSET);
+	}
+	data->callback = cfg->callback;
 	data->timeout_active = true;
 out:
 	k_spin_unlock(&data->lock, key);
@@ -196,6 +238,7 @@ out:
 
 static int wdt_xilinx_wwdt_disable(const struct device *dev)
 {
+	const struct xilinx_wwdt_config *config = dev->config;
 	struct xilinx_wwdt_data *data = dev->data;
 	mm_reg_t reg = DEVICE_MMIO_GET(dev);
 	uint32_t is_wwdt_enable;
@@ -213,10 +256,10 @@ static int wdt_xilinx_wwdt_disable(const struct device *dev)
 	}
 
 	/* Read enable status register and check if WWDT is in open window. */
-	is_sec_window = (sys_read32(reg + XWWDT_ESR_OFFSET) & XWWDT_ESR_WSW_MASK) >>
-				   XWWDT_ESR_WSW_SHIFT;
+	is_sec_window =
+		(sys_read32(reg + XWWDT_ESR_OFFSET) & XWWDT_ESR_WSW_MASK) >> XWWDT_ESR_WSW_SHIFT;
 
-	if (is_sec_window != 1)	{
+	if (is_sec_window != 1) {
 		LOG_ERR("Disabling WWDT in closed window is not allowed.");
 		ret = -EPERM;
 		goto out;
@@ -229,10 +272,49 @@ static int wdt_xilinx_wwdt_disable(const struct device *dev)
 	sys_write32(reg_value, reg + XWWDT_ESR_OFFSET);
 
 	data->wdt_started = false;
+
+	if (data->callback != NULL) {
+		irq_disable(config->irq);
+	}
 out:
 	k_spin_unlock(&data->lock, key);
 	return ret;
 }
+
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(interrupts)
+__maybe_unused static void wdt_xilinx_wwdt_isr(const struct device *dev)
+{
+	struct xilinx_wwdt_data *data = dev->data;
+	mm_reg_t reg = DEVICE_MMIO_GET(dev);
+	wdt_callback_t callback;
+	uint32_t reg_value;
+
+	k_spinlock_key_t key = k_spin_lock(&data->lock);
+
+	reg_value = sys_read32(reg + XWWDT_ESR_OFFSET);
+	if ((reg_value & XWWDT_ESR_WINT_MASK) == 0U) {
+		k_spin_unlock(&data->lock, key);
+		return;
+	}
+
+	/*
+	 * Clear the interrupt (WINT is write-1-to-clear) with WSW masked out
+	 * of the written value so the clear does not issue a restart kick.
+	 * The lock is released before invoking the callback so a wdt_feed()
+	 * from the callback can take it (the spinlock is not recursive).
+	 */
+	reg_value |= XWWDT_ESR_WINT_MASK;
+	reg_value &= ~XWWDT_ESR_WSW_MASK;
+	sys_write32(XWWDT_MWR_MASK, reg + XWWDT_MWR_OFFSET);
+	sys_write32(reg_value, reg + XWWDT_ESR_OFFSET);
+	callback = data->callback;
+	k_spin_unlock(&data->lock, key);
+
+	if (callback != NULL) {
+		callback(dev, 0);
+	}
+}
+#endif
 
 static int wdt_xilinx_wwdt_init(const struct device *dev)
 {
@@ -244,6 +326,11 @@ static int wdt_xilinx_wwdt_init(const struct device *dev)
 	}
 
 	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
+
+	if (config->irq_config != NULL) {
+		config->irq_config();
+	}
+
 	return ret;
 }
 
@@ -254,17 +341,49 @@ static DEVICE_API(wdt, wdt_xilinx_wwdt_api) = {
 	.disable = wdt_xilinx_wwdt_disable,
 };
 
-#define WDT_XILINX_WWDT_INIT(inst)								\
-	static struct xilinx_wwdt_data wdt_xilinx_wwdt_##inst##_dev_data;			\
-												\
-	static const struct xilinx_wwdt_config wdt_xilinx_wwdt_##inst##_cfg = {			\
-		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(inst)),					\
-		.wdt_clock_freq = DT_INST_PROP_BY_PHANDLE(inst, clocks, clock_frequency),	\
-	};											\
-												\
-	DEVICE_DT_INST_DEFINE(inst, &wdt_xilinx_wwdt_init, NULL,				\
-				&wdt_xilinx_wwdt_##inst##_dev_data,				\
-				&wdt_xilinx_wwdt_##inst##_cfg, PRE_KERNEL_1,			\
-				CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &wdt_xilinx_wwdt_api);
+#define WDT_XILINX_WWDT_IRQ_CONFIG_FUNC(inst)                                                      \
+	static void wdt_xilinx_wwdt_irq_config_##inst(void)                                        \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, wdt, irq),                                   \
+			    DT_INST_IRQ_BY_NAME(inst, wdt, priority), wdt_xilinx_wwdt_isr,         \
+			    DEVICE_DT_INST_GET(inst), 0);                                          \
+	}
+
+/*
+ * The interrupts block is optional, but when present the window interrupt
+ * (WINT) must be named "wdt" so the driver can select it from the other
+ * interrupt lines the node may expose.
+ */
+#define WDT_XILINX_WWDT_CHECK_IRQ_NAME(inst)                                                       \
+	BUILD_ASSERT(!DT_INST_IRQ_HAS_IDX(inst, 0) || DT_INST_IRQ_HAS_NAME(inst, wdt),             \
+		     "xlnx,versal-wwdt: 'interrupts' requires interrupt-names = \"wdt\"");
+
+#define WDT_XILINX_WWDT_IRQ_CFG_GET(inst)                                                          \
+	COND_CODE_1(DT_INST_IRQ_HAS_NAME(inst, wdt),						\
+		    (wdt_xilinx_wwdt_irq_config_##inst), (NULL))
+
+#define WDT_XILINX_WWDT_IRQ_GET(inst)                                                              \
+	COND_CODE_1(DT_INST_IRQ_HAS_NAME(inst, wdt), (DT_INST_IRQ_BY_NAME(inst, wdt, irq)), (0))
+
+#define WDT_XILINX_WWDT_IRQ_CONFIG_DEFINE(inst)                                                    \
+	COND_CODE_1(DT_INST_IRQ_HAS_NAME(inst, wdt), (WDT_XILINX_WWDT_IRQ_CONFIG_FUNC(inst)), ())
+
+#define WDT_XILINX_WWDT_INIT(inst)                                                                 \
+	WDT_XILINX_WWDT_CHECK_IRQ_NAME(inst)                                                       \
+	WDT_XILINX_WWDT_IRQ_CONFIG_DEFINE(inst)                                                    \
+                                                                                                   \
+	static struct xilinx_wwdt_data wdt_xilinx_wwdt_##inst##_dev_data;                          \
+                                                                                                   \
+	static const struct xilinx_wwdt_config wdt_xilinx_wwdt_##inst##_cfg = {                    \
+		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(inst)),                                           \
+		.wdt_clock_freq = DT_INST_PROP_BY_PHANDLE(inst, clocks, clock_frequency),          \
+		.irq_config = WDT_XILINX_WWDT_IRQ_CFG_GET(inst),                                   \
+		.irq = WDT_XILINX_WWDT_IRQ_GET(inst),                                              \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, &wdt_xilinx_wwdt_init, NULL,                                   \
+			      &wdt_xilinx_wwdt_##inst##_dev_data, &wdt_xilinx_wwdt_##inst##_cfg,   \
+			      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                    \
+			      &wdt_xilinx_wwdt_api);
 
 DT_INST_FOREACH_STATUS_OKAY(WDT_XILINX_WWDT_INIT)

--- a/drivers/watchdog/wdt_xilinx_wwdt.c
+++ b/drivers/watchdog/wdt_xilinx_wwdt.c
@@ -114,6 +114,12 @@ static int wdt_xilinx_wwdt_install_timeout(const struct device *dev,
 	}
 
 	timeout_ms = cfg->window.max;
+
+	if (timeout_ms == 0) {
+		ret = -EINVAL;
+		goto out;
+	}
+
 	max_hw_timeout_ms = (XWWDT_MAX_COUNT_WINDOW_COMBINED * 1000) / config->wdt_clock_freq;
 
 	/* Timeout greater than the maximum hardware timeout is invalid. */

--- a/drivers/watchdog/wdt_xilinx_wwdt.c
+++ b/drivers/watchdog/wdt_xilinx_wwdt.c
@@ -16,6 +16,13 @@
 
 LOG_MODULE_REGISTER(xilinx_wwdt, CONFIG_WDT_LOG_LEVEL);
 
+/* interrupt-names entry used by the active mode: "wdt" (window), "gwdt" (generic). */
+#if defined(CONFIG_XILINX_VERSAL_WDT_WINDOW_MODE)
+#define XWWDT_IRQ_NAME wdt
+#elif defined(CONFIG_XILINX_VERSAL_WDT_GENERIC_MODE)
+#define XWWDT_IRQ_NAME gwdt
+#endif
+
 /* Register offsets for the WWDT device */
 #define XWWDT_MWR_OFFSET	0x00
 #define XWWDT_ESR_OFFSET	0x04
@@ -47,6 +54,19 @@ LOG_MODULE_REGISTER(xilinx_wwdt, CONFIG_WDT_LOG_LEVEL);
 /* Maximum count value of closed and open window combined */
 #define XWWDT_MAX_COUNT_WINDOW_COMBINED	GENMASK64(32, 1)
 
+/* Generic Watchdog (GWDT) register offsets (absolute from MMIO base) */
+#define XGWDT_GWRR_OFFSET  0x1000 /* Refresh register */
+#define XGWDT_GWCSR_OFFSET 0x2000 /* Control and status register */
+#define XGWDT_GWOR_OFFSET  0x2008 /* Offset (first-window period) register */
+#define XGWDT_GW_WR_OFFSET 0x2fd0 /* Warm reset register */
+
+/* Generic Watchdog Control and Status Register masks */
+#define XGWDT_GWCSR_GWEN_MASK BIT(0) /* Generic watchdog enable */
+#define XGWDT_GWCSR_GWS1_MASK BIT(1) /* Stage-1 (interrupt) status */
+
+#define XGWDT_GWRR_MASK  BIT(0) /* Generic watchdog refresh */
+#define XGWDT_GW_WR_MASK BIT(0) /* Generic watchdog warm reset enable */
+
 struct xilinx_wwdt_config {
 	DEVICE_MMIO_ROM;
 	uint32_t wdt_clock_freq;
@@ -67,7 +87,6 @@ static int wdt_xilinx_wwdt_setup(const struct device *dev, uint8_t options)
 	const struct xilinx_wwdt_config *config = dev->config;
 	struct xilinx_wwdt_data *data = dev->data;
 	mm_reg_t reg = DEVICE_MMIO_GET(dev);
-	uint32_t reg_value;
 	int ret = 0;
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
@@ -87,11 +106,18 @@ static int wdt_xilinx_wwdt_setup(const struct device *dev, uint8_t options)
 	 * or when halted by debugger. Hence there is no check for the options.
 	 */
 
-	/* Read enable status register and update WEN bit */
-	reg_value = sys_read32(reg + XWWDT_ESR_OFFSET) | XWWDT_ESR_WEN_MASK;
+	if (IS_ENABLED(CONFIG_XILINX_VERSAL_WDT_WINDOW_MODE)) {
+		uint32_t reg_value;
 
-	/* Write enable status register with updated WEN value */
-	sys_write32(reg_value, reg + XWWDT_ESR_OFFSET);
+		/* Read enable status register and update WEN bit */
+		reg_value = sys_read32(reg + XWWDT_ESR_OFFSET) | XWWDT_ESR_WEN_MASK;
+
+		/* Write enable status register with updated WEN value */
+		sys_write32(reg_value, reg + XWWDT_ESR_OFFSET);
+	} else if (IS_ENABLED(CONFIG_XILINX_VERSAL_WDT_GENERIC_MODE)) {
+		/* Set the GWEN bit to enable the generic watchdog. */
+		sys_write32(XGWDT_GWCSR_GWEN_MASK, reg + XGWDT_GWCSR_OFFSET);
+	}
 	data->wdt_started = true;
 
 	/*
@@ -113,8 +139,6 @@ static int wdt_xilinx_wwdt_install_timeout(const struct device *dev,
 	const struct xilinx_wwdt_config *config = dev->config;
 	struct xilinx_wwdt_data *data = dev->data;
 	mm_reg_t reg = DEVICE_MMIO_GET(dev);
-	uint64_t closed_window_ms_count;
-	uint64_t open_window_ms_count;
 	uint64_t max_hw_timeout_ms;
 	uint64_t timeout_ms_count;
 	uint32_t timeout_ms;
@@ -134,64 +158,88 @@ static int wdt_xilinx_wwdt_install_timeout(const struct device *dev,
 			"reset action is owned by firmware (PLM/CDO)");
 	}
 
-	/* A callback requires the WINT interrupt to be wired in DT. */
+	/* A callback requires the mode's interrupt to be wired in DT. */
 	if (cfg->callback != NULL && config->irq_config == NULL) {
 		ret = -ENOTSUP;
 		goto out;
 	}
 
+	/* Ticks for the requested timeout, shared by both modes. */
+	ms_count = config->wdt_clock_freq / 1000;
 	timeout_ms = cfg->window.max;
 
+	/* A zero (open) window is invalid for both engines. */
 	if (timeout_ms == 0) {
 		ret = -EINVAL;
 		goto out;
 	}
 
-	max_hw_timeout_ms = (XWWDT_MAX_COUNT_WINDOW_COMBINED * 1000) / config->wdt_clock_freq;
-
-	/* Timeout greater than the maximum hardware timeout is invalid. */
-	if (timeout_ms > max_hw_timeout_ms) {
-		ret = -EINVAL;
-		goto out;
-	}
-
-	/* Calculate ticks for 1 milli-second */
-	ms_count = (config->wdt_clock_freq) / 1000;
 	timeout_ms_count = timeout_ms * ms_count;
 
-	closed_window_ms_count = cfg->window.min * ms_count;
-	if (closed_window_ms_count > XWWDT_MAX_COUNT_WINDOW) {
-		LOG_ERR("The closed window timeout is invalid.");
-		ret = -EINVAL;
-		goto out;
-	}
+	if (IS_ENABLED(CONFIG_XILINX_VERSAL_WDT_WINDOW_MODE)) {
+		uint64_t closed_window_ms_count;
+		uint64_t open_window_ms_count;
 
-	open_window_ms_count = timeout_ms_count - closed_window_ms_count;
-	if (open_window_ms_count > XWWDT_MAX_COUNT_WINDOW) {
-		LOG_ERR("The open window timeout is invalid.");
-		ret = -EINVAL;
-		goto out;
-	}
+		max_hw_timeout_ms =
+			(XWWDT_MAX_COUNT_WINDOW_COMBINED * 1000) / config->wdt_clock_freq;
 
-	sys_write32(XWWDT_MWR_MASK, reg + XWWDT_MWR_OFFSET);
-	sys_write32(~(uint32_t)XWWDT_ESR_WEN_MASK, reg + XWWDT_ESR_OFFSET);
-	sys_write32(closed_window_ms_count, reg + XWWDT_FWR_OFFSET);
-	sys_write32(open_window_ms_count, reg + XWWDT_SWR_OFFSET);
+		/* Timeout greater than the maximum hardware timeout is invalid. */
+		if (timeout_ms > max_hw_timeout_ms) {
+			ret = -EINVAL;
+			goto out;
+		}
 
-	if (cfg->callback != NULL) {
-		/*
-		 * Assert WINT at the start of the open (second) window: with
-		 * BSS=3 the SBC byte is compared against SW[31:24], which equals
-		 * the top byte of the open window count at the instant the
-		 * second window is entered. This fires exactly once per window
-		 * because the down-counting SW never returns to that byte value.
-		 */
+		closed_window_ms_count = cfg->window.min * ms_count;
+		if (closed_window_ms_count > XWWDT_MAX_COUNT_WINDOW) {
+			LOG_ERR("The closed window timeout is invalid.");
+			ret = -EINVAL;
+			goto out;
+		}
+
+		open_window_ms_count = timeout_ms_count - closed_window_ms_count;
+		if (open_window_ms_count > XWWDT_MAX_COUNT_WINDOW) {
+			LOG_ERR("The open window timeout is invalid.");
+			ret = -EINVAL;
+			goto out;
+		}
+
 		sys_write32(XWWDT_MWR_MASK, reg + XWWDT_MWR_OFFSET);
-		sys_write32(
-			FIELD_PREP(XWWDT_FCR_BSS_MASK, XWWDT_FCR_BSS_BYTE3) |
-				FIELD_PREP(XWWDT_FCR_SBC_MASK, (open_window_ms_count >> 24) & 0xFF),
-			reg + XWWDT_FCR_OFFSET);
+		sys_write32(~(uint32_t)XWWDT_ESR_WEN_MASK, reg + XWWDT_ESR_OFFSET);
+		sys_write32(closed_window_ms_count, reg + XWWDT_FWR_OFFSET);
+		sys_write32(open_window_ms_count, reg + XWWDT_SWR_OFFSET);
+
+		if (cfg->callback != NULL) {
+			/*
+			 * Assert WINT at the start of the open (second) window: with
+			 * BSS=3 the SBC byte is compared against SW[31:24], which equals
+			 * the top byte of the open window count at the instant the
+			 * second window is entered. This fires exactly once per window
+			 * because the down-counting SW never returns to that byte value.
+			 */
+			sys_write32(XWWDT_MWR_MASK, reg + XWWDT_MWR_OFFSET);
+			sys_write32(FIELD_PREP(XWWDT_FCR_BSS_MASK, XWWDT_FCR_BSS_BYTE3) |
+					    FIELD_PREP(XWWDT_FCR_SBC_MASK,
+						       (open_window_ms_count >> 24) & 0xFF),
+				    reg + XWWDT_FCR_OFFSET);
+		}
+	} else if (IS_ENABLED(CONFIG_XILINX_VERSAL_WDT_GENERIC_MODE)) {
+		/* The generic watchdog has a single window; a closed window is invalid. */
+		if (cfg->window.min != 0) {
+			ret = -EINVAL;
+			goto out;
+		}
+
+		max_hw_timeout_ms =
+			((uint64_t)XWWDT_MAX_COUNT_WINDOW * 1000) / config->wdt_clock_freq;
+		if (timeout_ms > max_hw_timeout_ms) {
+			ret = -EINVAL;
+			goto out;
+		}
+
+		/* Program the first-window period (registers warm-reset at init). */
+		sys_write32((uint32_t)timeout_ms_count, reg + XGWDT_GWOR_OFFSET);
 	}
+
 	data->callback = cfg->callback;
 	data->timeout_active = true;
 out:
@@ -203,8 +251,6 @@ static int wdt_xilinx_wwdt_feed(const struct device *dev, int channel_id)
 {
 	struct xilinx_wwdt_data *data = dev->data;
 	mm_reg_t reg = DEVICE_MMIO_GET(dev);
-	uint32_t control_status_reg;
-	uint32_t is_sec_window;
 	int ret = 0;
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
@@ -214,23 +260,45 @@ static int wdt_xilinx_wwdt_feed(const struct device *dev, int channel_id)
 		goto out;
 	}
 
-	/* Enable write access control bit for the WWDT. */
-	sys_write32(XWWDT_MWR_MASK, reg + XWWDT_MWR_OFFSET);
+	if (IS_ENABLED(CONFIG_XILINX_VERSAL_WDT_WINDOW_MODE)) {
+		uint32_t control_status_reg;
+		uint32_t is_sec_window;
 
-	/* Trigger restart kick to WWDT. */
-	control_status_reg = sys_read32(reg + XWWDT_ESR_OFFSET);
+		/* Enable write access control bit for the WWDT. */
+		sys_write32(XWWDT_MWR_MASK, reg + XWWDT_MWR_OFFSET);
 
-	/* Check if WWDT is in Second window. */
-	is_sec_window = (control_status_reg & (uint32_t)XWWDT_ESR_WSW_MASK) >> XWWDT_ESR_WSW_SHIFT;
+		/* Trigger restart kick to WWDT. */
+		control_status_reg = sys_read32(reg + XWWDT_ESR_OFFSET);
 
-	if (is_sec_window != 1) {
-		LOG_ERR("Feed in Closed window is not supported.");
-		ret = -ENOTSUP;
-		goto out;
+		/* Check if WWDT is in Second window. */
+		is_sec_window =
+			(control_status_reg & (uint32_t)XWWDT_ESR_WSW_MASK) >> XWWDT_ESR_WSW_SHIFT;
+
+		if (is_sec_window != 1) {
+			LOG_ERR("Feed in Closed window is not supported.");
+			ret = -ENOTSUP;
+			goto out;
+		}
+
+		control_status_reg |= (uint32_t)XWWDT_ESR_WSW_MASK;
+		sys_write32(control_status_reg, reg + XWWDT_ESR_OFFSET);
+	} else if (IS_ENABLED(CONFIG_XILINX_VERSAL_WDT_GENERIC_MODE)) {
+		const struct xilinx_wwdt_config *config = dev->config;
+
+		/* Refresh the generic watchdog to restart the first window. */
+		sys_write32(XGWDT_GWRR_MASK, reg + XGWDT_GWRR_OFFSET);
+
+		/*
+		 * The refresh clears GWS1, so re-arm the warning interrupt that the
+		 * ISR masked to acknowledge the previous stage-1 event. The source
+		 * is now deasserted, so unmasking the (level) line is race-free.
+		 * This is a no-op on a normal feed where the interrupt is already
+		 * enabled.
+		 */
+		if (data->callback != NULL) {
+			irq_enable(config->irq);
+		}
 	}
-
-	control_status_reg |= (uint32_t)XWWDT_ESR_WSW_MASK;
-	sys_write32(control_status_reg, reg + XWWDT_ESR_OFFSET);
 out:
 	k_spin_unlock(&data->lock, key);
 	return ret;
@@ -241,35 +309,51 @@ static int wdt_xilinx_wwdt_disable(const struct device *dev)
 	const struct xilinx_wwdt_config *config = dev->config;
 	struct xilinx_wwdt_data *data = dev->data;
 	mm_reg_t reg = DEVICE_MMIO_GET(dev);
-	uint32_t is_wwdt_enable;
-	uint32_t is_sec_window;
 	uint32_t reg_value;
 	int ret = 0;
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	is_wwdt_enable = sys_read32(reg + XWWDT_ESR_OFFSET) & XWWDT_ESR_WEN_MASK;
+	if (IS_ENABLED(CONFIG_XILINX_VERSAL_WDT_WINDOW_MODE)) {
+		uint32_t is_wwdt_enable;
+		uint32_t is_sec_window;
 
-	if (is_wwdt_enable == 0) {
-		ret = -EFAULT;
-		goto out;
+		is_wwdt_enable = sys_read32(reg + XWWDT_ESR_OFFSET) & XWWDT_ESR_WEN_MASK;
+
+		if (is_wwdt_enable == 0) {
+			ret = -EFAULT;
+			goto out;
+		}
+
+		/* Read enable status register and check if WWDT is in open window. */
+		is_sec_window = (sys_read32(reg + XWWDT_ESR_OFFSET) & XWWDT_ESR_WSW_MASK) >>
+				XWWDT_ESR_WSW_SHIFT;
+
+		if (is_sec_window != 1) {
+			LOG_ERR("Disabling WWDT in closed window is not allowed.");
+			ret = -EPERM;
+			goto out;
+		}
+
+		/* Read enable status register and update WEN bit. */
+		reg_value = sys_read32(reg + XWWDT_ESR_OFFSET) & (~XWWDT_ESR_WEN_MASK);
+
+		/* Write enable status register with updated WEN and WSW value. */
+		sys_write32(reg_value, reg + XWWDT_ESR_OFFSET);
+	} else if (IS_ENABLED(CONFIG_XILINX_VERSAL_WDT_GENERIC_MODE)) {
+		reg_value = sys_read32(reg + XGWDT_GWCSR_OFFSET);
+
+		if ((reg_value & XGWDT_GWCSR_GWEN_MASK) == 0) {
+			ret = -EFAULT;
+			goto out;
+		}
+
+		/* Clear the GWEN bit. */
+		reg_value &= ~XGWDT_GWCSR_GWEN_MASK;
+
+		/* Write control status register to disable the generic watchdog. */
+		sys_write32(reg_value, reg + XGWDT_GWCSR_OFFSET);
 	}
-
-	/* Read enable status register and check if WWDT is in open window. */
-	is_sec_window =
-		(sys_read32(reg + XWWDT_ESR_OFFSET) & XWWDT_ESR_WSW_MASK) >> XWWDT_ESR_WSW_SHIFT;
-
-	if (is_sec_window != 1) {
-		LOG_ERR("Disabling WWDT in closed window is not allowed.");
-		ret = -EPERM;
-		goto out;
-	}
-
-	/* Read enable status register and update WEN bit. */
-	reg_value = sys_read32(reg + XWWDT_ESR_OFFSET) & (~XWWDT_ESR_WEN_MASK);
-
-	/* Write enable status register with updated WEN and WSW value. */
-	sys_write32(reg_value, reg + XWWDT_ESR_OFFSET);
 
 	data->wdt_started = false;
 
@@ -291,22 +375,46 @@ __maybe_unused static void wdt_xilinx_wwdt_isr(const struct device *dev)
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	reg_value = sys_read32(reg + XWWDT_ESR_OFFSET);
-	if ((reg_value & XWWDT_ESR_WINT_MASK) == 0U) {
-		k_spin_unlock(&data->lock, key);
-		return;
+	if (IS_ENABLED(CONFIG_XILINX_VERSAL_WDT_WINDOW_MODE)) {
+		reg_value = sys_read32(reg + XWWDT_ESR_OFFSET);
+		if ((reg_value & XWWDT_ESR_WINT_MASK) == 0U) {
+			k_spin_unlock(&data->lock, key);
+			return;
+		}
+
+		/*
+		 * Clear the interrupt (WINT is write-1-to-clear) with WSW masked
+		 * out of the written value so the clear does not issue a restart
+		 * kick.
+		 */
+		reg_value |= XWWDT_ESR_WINT_MASK;
+		reg_value &= ~XWWDT_ESR_WSW_MASK;
+		sys_write32(XWWDT_MWR_MASK, reg + XWWDT_MWR_OFFSET);
+		sys_write32(reg_value, reg + XWWDT_ESR_OFFSET);
+	} else if (IS_ENABLED(CONFIG_XILINX_VERSAL_WDT_GENERIC_MODE)) {
+		const struct xilinx_wwdt_config *config = dev->config;
+
+		reg_value = sys_read32(reg + XGWDT_GWCSR_OFFSET);
+		if ((reg_value & XGWDT_GWCSR_GWS1_MASK) == 0U) {
+			k_spin_unlock(&data->lock, key);
+			return;
+		}
+
+		/*
+		 * The stage-1 status (GWS1) is cleared only by a watchdog refresh,
+		 * which would also restart the timer and prevent the stage-2 reset.
+		 * To acknowledge the interrupt without restarting, mask it at the
+		 * interrupt controller; the callback decides whether to feed (via
+		 * wdt_feed(), which clears GWS1 and re-enables this interrupt) to
+		 * continue, or let the stage-2 reset proceed.
+		 */
+		irq_disable(config->irq);
 	}
 
 	/*
-	 * Clear the interrupt (WINT is write-1-to-clear) with WSW masked out
-	 * of the written value so the clear does not issue a restart kick.
 	 * The lock is released before invoking the callback so a wdt_feed()
 	 * from the callback can take it (the spinlock is not recursive).
 	 */
-	reg_value |= XWWDT_ESR_WINT_MASK;
-	reg_value &= ~XWWDT_ESR_WSW_MASK;
-	sys_write32(XWWDT_MWR_MASK, reg + XWWDT_MWR_OFFSET);
-	sys_write32(reg_value, reg + XWWDT_ESR_OFFSET);
 	callback = data->callback;
 	k_spin_unlock(&data->lock, key);
 
@@ -327,6 +435,11 @@ static int wdt_xilinx_wwdt_init(const struct device *dev)
 
 	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 
+	if (IS_ENABLED(CONFIG_XILINX_VERSAL_WDT_GENERIC_MODE)) {
+		/* Warm-reset the generic watchdog registers to a known state once. */
+		sys_write32(XGWDT_GW_WR_MASK, DEVICE_MMIO_GET(dev) + XGWDT_GW_WR_OFFSET);
+	}
+
 	if (config->irq_config != NULL) {
 		config->irq_config();
 	}
@@ -344,29 +457,33 @@ static DEVICE_API(wdt, wdt_xilinx_wwdt_api) = {
 #define WDT_XILINX_WWDT_IRQ_CONFIG_FUNC(inst)                                                      \
 	static void wdt_xilinx_wwdt_irq_config_##inst(void)                                        \
 	{                                                                                          \
-		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, wdt, irq),                                   \
-			    DT_INST_IRQ_BY_NAME(inst, wdt, priority), wdt_xilinx_wwdt_isr,         \
-			    DEVICE_DT_INST_GET(inst), 0);                                          \
+		IRQ_CONNECT(DT_INST_IRQ_BY_NAME(inst, XWWDT_IRQ_NAME, irq),                        \
+			    DT_INST_IRQ_BY_NAME(inst, XWWDT_IRQ_NAME, priority),                   \
+			    wdt_xilinx_wwdt_isr, DEVICE_DT_INST_GET(inst), 0);                     \
 	}
 
 /*
- * The interrupts block is optional, but when present the window interrupt
- * (WINT) must be named "wdt" so the driver can select it from the other
- * interrupt lines the node may expose.
+ * The interrupts block is optional, but when present the active mode's
+ * interrupt must be named so the driver can select it from the other
+ * interrupt lines the node may expose ("wdt" for the window engine's WINT,
+ * "gwdt" for the generic engine's stage-1 interrupt).
  */
 #define WDT_XILINX_WWDT_CHECK_IRQ_NAME(inst)                                                       \
-	BUILD_ASSERT(!DT_INST_IRQ_HAS_IDX(inst, 0) || DT_INST_IRQ_HAS_NAME(inst, wdt),             \
-		     "xlnx,versal-wwdt: 'interrupts' requires interrupt-names = \"wdt\"");
+	BUILD_ASSERT(                                                                              \
+		!DT_INST_IRQ_HAS_IDX(inst, 0) || DT_INST_IRQ_HAS_NAME(inst, XWWDT_IRQ_NAME),       \
+		"versal-wwdt: interrupt-names must include \"" STRINGIFY(XWWDT_IRQ_NAME) "\"");
 
 #define WDT_XILINX_WWDT_IRQ_CFG_GET(inst)                                                          \
-	COND_CODE_1(DT_INST_IRQ_HAS_NAME(inst, wdt),						\
+	COND_CODE_1(DT_INST_IRQ_HAS_NAME(inst, XWWDT_IRQ_NAME),					\
 		    (wdt_xilinx_wwdt_irq_config_##inst), (NULL))
 
 #define WDT_XILINX_WWDT_IRQ_GET(inst)                                                              \
-	COND_CODE_1(DT_INST_IRQ_HAS_NAME(inst, wdt), (DT_INST_IRQ_BY_NAME(inst, wdt, irq)), (0))
+	COND_CODE_1(DT_INST_IRQ_HAS_NAME(inst, XWWDT_IRQ_NAME),					\
+		    (DT_INST_IRQ_BY_NAME(inst, XWWDT_IRQ_NAME, irq)), (0))
 
 #define WDT_XILINX_WWDT_IRQ_CONFIG_DEFINE(inst)                                                    \
-	COND_CODE_1(DT_INST_IRQ_HAS_NAME(inst, wdt), (WDT_XILINX_WWDT_IRQ_CONFIG_FUNC(inst)), ())
+	COND_CODE_1(DT_INST_IRQ_HAS_NAME(inst, XWWDT_IRQ_NAME),					\
+		    (WDT_XILINX_WWDT_IRQ_CONFIG_FUNC(inst)), ())
 
 #define WDT_XILINX_WWDT_INIT(inst)                                                                 \
 	WDT_XILINX_WWDT_CHECK_IRQ_NAME(inst)                                                       \

--- a/drivers/watchdog/wdt_xilinx_wwdt.c
+++ b/drivers/watchdog/wdt_xilinx_wwdt.c
@@ -118,6 +118,12 @@ static int wdt_xilinx_wwdt_install_timeout(const struct device *dev,
 		"reset action is owned by firmware (PLM/CDO)");
 
 	timeout_ms = cfg->window.max;
+
+	if (timeout_ms == 0) {
+		ret = -EINVAL;
+		goto out;
+	}
+
 	max_hw_timeout_ms = (XWWDT_MAX_COUNT_WINDOW_COMBINED * 1000) / config->wdt_clock_freq;
 
 	/* Timeout greater than the maximum hardware timeout is invalid. */

--- a/drivers/watchdog/wdt_xilinx_wwdt.c
+++ b/drivers/watchdog/wdt_xilinx_wwdt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,7 +9,6 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
-#include <zephyr/drivers/hwinfo.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>

--- a/drivers/watchdog/wdt_xilinx_wwdt.c
+++ b/drivers/watchdog/wdt_xilinx_wwdt.c
@@ -40,11 +40,12 @@ LOG_MODULE_REGISTER(xilinx_wwdt, CONFIG_WDT_LOG_LEVEL);
 #define XWWDT_MAX_COUNT_WINDOW_COMBINED	GENMASK64(32, 1)
 
 struct xilinx_wwdt_config {
+	DEVICE_MMIO_ROM;
 	uint32_t wdt_clock_freq;
-	mem_addr_t base;
 };
 
 struct xilinx_wwdt_data {
+	DEVICE_MMIO_RAM;
 	struct k_spinlock lock;
 	bool timeout_active;
 	bool wdt_started;
@@ -52,8 +53,8 @@ struct xilinx_wwdt_data {
 
 static int wdt_xilinx_wwdt_setup(const struct device *dev, uint8_t options)
 {
-	const struct xilinx_wwdt_config *config = dev->config;
 	struct xilinx_wwdt_data *data = dev->data;
+	mm_reg_t reg = DEVICE_MMIO_GET(dev);
 	uint32_t reg_value;
 	int ret = 0;
 
@@ -75,10 +76,10 @@ static int wdt_xilinx_wwdt_setup(const struct device *dev, uint8_t options)
 	 */
 
 	/* Read enable status register and update WEN bit */
-	reg_value = sys_read32(config->base + XWWDT_ESR_OFFSET) | XWWDT_ESR_WEN_MASK;
+	reg_value = sys_read32(reg + XWWDT_ESR_OFFSET) | XWWDT_ESR_WEN_MASK;
 
 	/* Write enable status register with updated WEN value */
-	sys_write32(reg_value, config->base + XWWDT_ESR_OFFSET);
+	sys_write32(reg_value, reg + XWWDT_ESR_OFFSET);
 	data->wdt_started = true;
 out:
 	k_spin_unlock(&data->lock, key);
@@ -90,6 +91,7 @@ static int wdt_xilinx_wwdt_install_timeout(const struct device *dev,
 {
 	const struct xilinx_wwdt_config *config = dev->config;
 	struct xilinx_wwdt_data *data = dev->data;
+	mm_reg_t reg = DEVICE_MMIO_GET(dev);
 	uint64_t closed_window_ms_count;
 	uint64_t open_window_ms_count;
 	uint64_t max_hw_timeout_ms;
@@ -142,10 +144,10 @@ static int wdt_xilinx_wwdt_install_timeout(const struct device *dev,
 		goto out;
 	}
 
-	sys_write32(XWWDT_MWR_MASK, config->base + XWWDT_MWR_OFFSET);
-	sys_write32(~(uint32_t)XWWDT_ESR_WEN_MASK, config->base + XWWDT_ESR_OFFSET);
-	sys_write32(closed_window_ms_count, config->base + XWWDT_FWR_OFFSET);
-	sys_write32(open_window_ms_count, config->base + XWWDT_SWR_OFFSET);
+	sys_write32(XWWDT_MWR_MASK, reg + XWWDT_MWR_OFFSET);
+	sys_write32(~(uint32_t)XWWDT_ESR_WEN_MASK, reg + XWWDT_ESR_OFFSET);
+	sys_write32(closed_window_ms_count, reg + XWWDT_FWR_OFFSET);
+	sys_write32(open_window_ms_count, reg + XWWDT_SWR_OFFSET);
 
 	data->timeout_active = true;
 out:
@@ -155,8 +157,8 @@ out:
 
 static int wdt_xilinx_wwdt_feed(const struct device *dev, int channel_id)
 {
-	const struct xilinx_wwdt_config *config = dev->config;
 	struct xilinx_wwdt_data *data = dev->data;
+	mm_reg_t reg = DEVICE_MMIO_GET(dev);
 	uint32_t control_status_reg;
 	uint32_t is_sec_window;
 	int ret = 0;
@@ -169,10 +171,10 @@ static int wdt_xilinx_wwdt_feed(const struct device *dev, int channel_id)
 	}
 
 	/* Enable write access control bit for the WWDT. */
-	sys_write32(XWWDT_MWR_MASK, config->base + XWWDT_MWR_OFFSET);
+	sys_write32(XWWDT_MWR_MASK, reg + XWWDT_MWR_OFFSET);
 
 	/* Trigger restart kick to WWDT. */
-	control_status_reg = sys_read32(config->base + XWWDT_ESR_OFFSET);
+	control_status_reg = sys_read32(reg + XWWDT_ESR_OFFSET);
 
 	/* Check if WWDT is in Second window. */
 	is_sec_window = (control_status_reg & (uint32_t)XWWDT_ESR_WSW_MASK) >> XWWDT_ESR_WSW_SHIFT;
@@ -184,7 +186,7 @@ static int wdt_xilinx_wwdt_feed(const struct device *dev, int channel_id)
 	}
 
 	control_status_reg |= (uint32_t)XWWDT_ESR_WSW_MASK;
-	sys_write32(control_status_reg, config->base + XWWDT_ESR_OFFSET);
+	sys_write32(control_status_reg, reg + XWWDT_ESR_OFFSET);
 out:
 	k_spin_unlock(&data->lock, key);
 	return ret;
@@ -192,8 +194,8 @@ out:
 
 static int wdt_xilinx_wwdt_disable(const struct device *dev)
 {
-	const struct xilinx_wwdt_config *config = dev->config;
 	struct xilinx_wwdt_data *data = dev->data;
+	mm_reg_t reg = DEVICE_MMIO_GET(dev);
 	uint32_t is_wwdt_enable;
 	uint32_t is_sec_window;
 	uint32_t reg_value;
@@ -201,7 +203,7 @@ static int wdt_xilinx_wwdt_disable(const struct device *dev)
 
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
-	is_wwdt_enable = sys_read32(config->base + XWWDT_ESR_OFFSET) & XWWDT_ESR_WEN_MASK;
+	is_wwdt_enable = sys_read32(reg + XWWDT_ESR_OFFSET) & XWWDT_ESR_WEN_MASK;
 
 	if (is_wwdt_enable == 0) {
 		ret = -EFAULT;
@@ -209,7 +211,7 @@ static int wdt_xilinx_wwdt_disable(const struct device *dev)
 	}
 
 	/* Read enable status register and check if WWDT is in open window. */
-	is_sec_window = (sys_read32(config->base + XWWDT_ESR_OFFSET) & XWWDT_ESR_WSW_MASK) >>
+	is_sec_window = (sys_read32(reg + XWWDT_ESR_OFFSET) & XWWDT_ESR_WSW_MASK) >>
 				   XWWDT_ESR_WSW_SHIFT;
 
 	if (is_sec_window != 1)	{
@@ -219,10 +221,10 @@ static int wdt_xilinx_wwdt_disable(const struct device *dev)
 	}
 
 	/* Read enable status register and update WEN bit. */
-	reg_value = sys_read32(config->base + XWWDT_ESR_OFFSET) & (~XWWDT_ESR_WEN_MASK);
+	reg_value = sys_read32(reg + XWWDT_ESR_OFFSET) & (~XWWDT_ESR_WEN_MASK);
 
 	/* Write enable status register with updated WEN and WSW value. */
-	sys_write32(reg_value, config->base + XWWDT_ESR_OFFSET);
+	sys_write32(reg_value, reg + XWWDT_ESR_OFFSET);
 
 	data->wdt_started = false;
 out:
@@ -239,6 +241,7 @@ static int wdt_xilinx_wwdt_init(const struct device *dev)
 		return -EINVAL;
 	}
 
+	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
 	return ret;
 }
 
@@ -253,7 +256,7 @@ static DEVICE_API(wdt, wdt_xilinx_wwdt_api) = {
 	static struct xilinx_wwdt_data wdt_xilinx_wwdt_##inst##_dev_data;			\
 												\
 	static const struct xilinx_wwdt_config wdt_xilinx_wwdt_##inst##_cfg = {			\
-		.base = DT_INST_REG_ADDR(inst),							\
+		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(inst)),					\
 		.wdt_clock_freq = DT_INST_PROP_BY_PHANDLE(inst, clocks, clock_frequency),	\
 	};											\
 												\

--- a/drivers/watchdog/wdt_xilinx_wwdt.c
+++ b/drivers/watchdog/wdt_xilinx_wwdt.c
@@ -105,10 +105,15 @@ static int wdt_xilinx_wwdt_install_timeout(const struct device *dev,
 		goto out;
 	}
 
-	if (cfg->flags != WDT_FLAG_RESET_SOC) {
-		ret = -ENOTSUP;
-		goto out;
-	}
+	/*
+	 * The expiry/reset action is owned by platform firmware (PLM/CDO) and is
+	 * routed through the Error Aggregation Module; the driver never issues a
+	 * reset itself and cannot honor any WDT_FLAG_RESET_* value (including
+	 * WDT_FLAG_RESET_NONE). Accept the timeout regardless and warn that the
+	 * flag has no effect.
+	 */
+	LOG_WRN("WDT_FLAG_RESET_* has no effect; "
+		"reset action is owned by firmware (PLM/CDO)");
 
 	timeout_ms = cfg->window.max;
 	max_hw_timeout_ms = (XWWDT_MAX_COUNT_WINDOW_COMBINED * 1000) / config->wdt_clock_freq;

--- a/dts/bindings/watchdog/xlnx,versal-wwdt.yaml
+++ b/dts/bindings/watchdog/xlnx,versal-wwdt.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
@@ -26,3 +26,21 @@ properties:
   clocks:
     required: true
     description: Reference to clock for window watchdog core.
+
+  interrupts:
+    description: |
+      Window watchdog interrupt lines. The node may expose more than one
+      interrupt (for example the window interrupt and a reset-pending
+      line); the driver uses only the window interrupt (WINT), which must
+      be named "wdt" in interrupt-names. WINT is asserted when the second
+      (open) window is entered, i.e. as soon as the watchdog may be
+      serviced, so the timeout can be handled from the installed callback.
+      This property is optional; when present, interrupt-names must
+      include "wdt".
+
+  interrupt-names:
+    description: |
+      Names for the interrupts specified in the "interrupts" property. The
+      window watchdog interrupt (WINT) used by the driver must be named
+      "wdt". Other interrupt lines exposed by the node may be listed but
+      are not used by the driver.

--- a/dts/bindings/watchdog/xlnx,versal-wwdt.yaml
+++ b/dts/bindings/watchdog/xlnx,versal-wwdt.yaml
@@ -1,7 +1,19 @@
 # Copyright (c) 2025 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Xilinx window watchdog
+description: |
+  Xilinx window watchdog
+  The WWDT implements a two-window (closed + open) watchdog. It must be
+  fed only during the open window. A feed in the closed window, or a
+  missed feed by the end of the open window, is treated as a watchdog
+  failure.
+  The action taken on a failure (no reset, CPU/subsystem reset, or SoC
+  reset) is routed through the platform Error Aggregation Module and
+  configured by firmware (PLM) via the boot-time CDO. Zephyr running on
+  the APU/RPU cannot observe or change this routing, so the driver does
+  not honor the WDT_FLAG_RESET_* flags (including WDT_FLAG_RESET_NONE)
+  passed to wdt_install_timeout(); the reset behavior is defined entirely
+  by platform firmware.
 
 compatible: "xlnx,versal-wwdt"
 

--- a/dts/bindings/watchdog/xlnx,versal-wwdt.yaml
+++ b/dts/bindings/watchdog/xlnx,versal-wwdt.yaml
@@ -14,6 +14,11 @@ description: |
   not honor the WDT_FLAG_RESET_* flags (including WDT_FLAG_RESET_NONE)
   passed to wdt_install_timeout(); the reset behavior is defined entirely
   by platform firmware.
+  The same IP also contains an independent generic watchdog (GWDT): a
+  two-stage timer whose stage-1 timeout raises an interrupt and, if the
+  watchdog is not refreshed, firmware issues the stage-2 reset. The window
+  and generic engines are separate counters with their own enable bits and
+  interrupt lines.
 
 compatible: "xlnx,versal-wwdt"
 
@@ -25,22 +30,20 @@ properties:
 
   clocks:
     required: true
-    description: Reference to clock for window watchdog core.
+    description: Reference to the clock that drives the watchdog counters.
 
   interrupts:
     description: |
-      Window watchdog interrupt lines. The node may expose more than one
-      interrupt (for example the window interrupt and a reset-pending
-      line); the driver uses only the window interrupt (WINT), which must
-      be named "wdt" in interrupt-names. WINT is asserted when the second
-      (open) window is entered, i.e. as soon as the watchdog may be
-      serviced, so the timeout can be handled from the installed callback.
-      This property is optional; when present, interrupt-names must
-      include "wdt".
+      Watchdog interrupt lines. The node may expose more than one interrupt.
+      The window interrupt (WINT) is asserted when the second (open) window
+      is entered, i.e. as soon as the watchdog may be serviced, so the
+      timeout can be handled from the installed callback. The generic
+      watchdog also provides a stage-1 timeout interrupt. This property is
+      optional; the names required for each line are documented under
+      interrupt-names.
 
   interrupt-names:
     description: |
       Names for the interrupts specified in the "interrupts" property. The
-      window watchdog interrupt (WINT) used by the driver must be named
-      "wdt". Other interrupt lines exposed by the node may be listed but
-      are not used by the driver.
+      window watchdog interrupt (WINT) must be named "wdt" and the generic
+      watchdog stage-1 interrupt must be named "gwdt".

--- a/dts/bindings/watchdog/xlnx,versal-wwdt.yaml
+++ b/dts/bindings/watchdog/xlnx,versal-wwdt.yaml
@@ -1,7 +1,19 @@
-# Copyright (c) 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Xilinx window watchdog
+description: |
+  Xilinx window watchdog
+  The WWDT implements a two-window (closed + open) watchdog. It must be
+  fed only during the open window. A feed in the closed window, or a
+  missed feed by the end of the open window, is treated as a watchdog
+  failure.
+  The action taken on a failure (no reset, CPU/subsystem reset, or SoC
+  reset) is routed through the platform Error Aggregation Module and
+  configured by firmware (PLM) via the boot-time CDO. Zephyr running on
+  the APU/RPU cannot observe or change this routing, so the driver does
+  not honor the WDT_FLAG_RESET_* flags (including WDT_FLAG_RESET_NONE)
+  passed to wdt_install_timeout(); the reset behavior is defined entirely
+  by platform firmware.
 
 compatible: "xlnx,versal-wwdt"
 


### PR DESCRIPTION
### Summary
This series cleans up the Xilinx Versal Window Watchdog (WWDT) driver: drops an unused include, corrects reset-flag handling to reflect the platform's firmware-owned reset model, converts register access to the `DEVICE_MMIO` API, and fixes a zero-max-window validation gap. The changes are backward compatible: existing device tree nodes that provide `reg`/`clocks` continue to work unchanged, and there is no new required property or Kconfig option.

### Commits
1. **drop unused hwinfo include** — the driver never used the hwinfo API; remove the stray include.
2. **do not gate install on reset flags** — the expiry/reset action (no reset, CPU/subsystem reset, or SoC reset) is routed through the Error Aggregation Module and configured by the PLM via the boot-time CDO. Zephyr on the APU/RPU can neither observe nor change that routing, so the driver cannot honor any `WDT_FLAG_RESET_*` value (including
`WDT_FLAG_RESET_NONE`). Stop rejecting non-`WDT_FLAG_RESET_SOC` flags; accept the timeout regardless and warn at install time that the flag has no effect. The firmware-owned reset behavior is documented in the binding.
3. **use DEVICE_MMIO for register access** — store the register region with the `DEVICE_MMIO` ROM/RAM helpers and access it via `DEVICE_MMIO_GET()`. On MMU targets (aarch64 APU) the region is mapped dynamically via `device_map()`; on non-MMU targets (R52 RPU) it reduces to direct physical access, so behavior is unchanged there.
4. **reject zero max window** — `wdt_install_timeout()` accepted `window.max == 0`, programming a zero timeout and returning success; reject it with `-EINVAL`.
