### PR TITLE
arch: xtensa: fix L2 PTE data loss in region_map_update with cached t…

### DIFF
--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -1140,6 +1140,10 @@ static uint32_t *dup_l2_table(uint32_t *src_l2_table, enum dup_action action)
 		break;
 	}
 
+	if (IS_ENABLED(PAGE_TABLE_IS_CACHED)) {
+		sys_cache_data_flush_range((void *)l2_table, L2_PAGE_TABLE_SIZE);
+	}
+
 	return l2_table;
 }
 
@@ -1266,7 +1270,10 @@ static void dup_l2_table_if_needed(uint32_t *l1_table, uint32_t l1_pos, enum dup
 
 	k_spin_unlock(&xtensa_counter_lock, key);
 
-	sys_cache_data_flush_range((void *)l2_table, L2_PAGE_TABLE_SIZE);
+	if (IS_ENABLED(PAGE_TABLE_IS_CACHED)) {
+		/* L2 was flushed in dup_l2_table(); publish the new L1 pointer. */
+		sys_cache_data_flush_range((void *)&l1_table[l1_pos], sizeof(l1_table[0]));
+	}
 }
 
 int arch_mem_domain_init(struct k_mem_domain *domain)


### PR DESCRIPTION
…ables

When CONFIG_MP_MAX_NUM_CPUS == 1, XTENSA_MMU_PAGE_TABLE_ATTR is set to XTENSA_MMU_CACHED_WB, making PAGE_TABLE_IS_CACHED=1.

In region_map_update(), after dup_l2_table(RESTORE) writes domain L2 entries to the WB data cache, sys_cache_data_invd_range() invalidates the entire 32-byte cache line covering l2[pos..pos+7]. Adjacent entries that are not part of the partition being added are discarded from cache without being written back to memory.

Because page table memory was zero-initialised at boot and the dirty dup_l2_table() writes were never flushed, subsequent TLB refills for those addresses load PTE=0 (illegal). User threads then fault with LoadProhibited or StoreProhibited on first access to those pages (for example BSS or non-identity mapped regions created via arch_mem_map).

This affects systems with CONFIG_USERSPACE and non-identity mapped memory (arch_mem_map with VA != PA), where L2 tables are duplicated by dup_l2_table(RESTORE) and partition pages share a 32-byte cache line with non-partition pages.

Fix by replacing sys_cache_data_invd_range() with
sys_cache_data_flush_and_invd_range() for the L2 entry read. Flushing first commits dirty dup_l2_table() writes to memory before the cache line is invalidated.

The L1 invd_range in the same function is unaffected: the L1 entry for the slot being processed is always re-established by dup_l2_table_if_needed() in the same loop iteration.