### PR TITLE
doc: multiple 404 dead links fixes

### DIFF
--- a/boards/adafruit/trinket_m0/doc/index.rst
+++ b/boards/adafruit/trinket_m0/doc/index.rst
@@ -131,7 +131,7 @@ References
     https://learn.adafruit.com/adafruit-trinket-m0-circuitpython-arduino
 
 .. _pinouts:
-    https://learn.adafruit.com/assets/49778
+    https://learn.adafruit.com/adafruit-trinket-m0-circuitpython-arduino/pinouts
 
 .. _schematic:
     https://learn.adafruit.com/assets/45723

--- a/boards/beagle/beagleconnect_zepto/doc/index.rst
+++ b/boards/beagle/beagleconnect_zepto/doc/index.rst
@@ -75,4 +75,4 @@ References
 .. _BeagleY-AI:
    https://www.beagleboard.org/boards/beagley-ai
 .. _BeagleBoard Imaging Utility:
-   https://beagleboard.github.io/bb-imager-rs/bb-imager/1.0.8/install-gui.html
+   https://beagleboard.github.io/bb-imager-rs/

--- a/boards/blues/cygnet/doc/index.rst
+++ b/boards/blues/cygnet/doc/index.rst
@@ -192,7 +192,7 @@ References
    https://www.blues.dev/
 
 .. _Blues Cygnet User Manual:
-   https://dev.blues.io/feather-mcus/cygnet/cygnet-introduction/
+   https://dev.blues.io/feather-mcus/cygnet/
 
 .. _STM32L433CC on www.st.com:
    https://www.st.com/en/microcontrollers-microprocessors/stm32l433cc.html

--- a/boards/circuitdojo/feather/doc/index.rst
+++ b/boards/circuitdojo/feather/doc/index.rst
@@ -155,5 +155,5 @@ References
 **Side note** This page was based on the documentation for the nRF9160 DK. Thanks to Nordic for
 developing a great platform!
 
-.. _nRF9160 Feather Documentation: https://docs.jaredwolff.com/nrf9160-introduction.html
+.. _nRF9160 Feather Documentation: https://docs.circuitdojo.com/nrf9160-feather/overview.html
 .. _Getting Started: https://docs.jaredwolff.com/nrf9160-getting-started.html

--- a/boards/doiting/dt_bl10_devkit/doc/index.rst
+++ b/boards/doiting/dt_bl10_devkit/doc/index.rst
@@ -103,7 +103,7 @@ Congratulations, you have ``dt_bl10_devkit`` configured and running Zephyr.
 
 
 .. _Bouffalo Lab BL602 MCU Website:
-	https://www.bouffalolab.com/bl602
+	https://en.bouffalolab.com/product/?type=detail&id=1
 
 .. _Bouffalo Lab BL602 MCU Datasheet:
 	https://github.com/bouffalolab/bl_docs/tree/main/BL602_DS/en

--- a/boards/dragino/lsn50/doc/index.rst
+++ b/boards/dragino/lsn50/doc/index.rst
@@ -162,7 +162,7 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _Dragino LSN50 website:
-   https://www.dragino.com/products/lora-lorawan-end-node/item/128-lsn50.html
+   https://www.dragino.com/products/lora-lorawan-end-node/item/lsn50.html
 
 .. _STM32L072CZ on www.st.com:
    https://www.st.com/en/microcontrollers/stm32l072cz.html

--- a/boards/espressif/esp32s2_devkitc/doc/index.rst
+++ b/boards/espressif/esp32s2_devkitc/doc/index.rst
@@ -61,4 +61,4 @@ References
 
 .. target-notes::
 
-.. _`ESP32-S2-DevKitC`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html
+.. _`ESP32-S2-DevKitC`: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-s2-devkitc-1.html

--- a/boards/gardena/sgrm/doc/index.rst
+++ b/boards/gardena/sgrm/doc/index.rst
@@ -18,7 +18,7 @@ Hardware
 - UART is connected to the Linux SoC. Usually it's used for PPP, but it can also be used for
   debugging when PPP is not active.
 
-.. _SiM3U167-B-GM: https://www.silabs.com/mcu/32-bit-microcontrollers/precision32-sim3u1xx/device.SiM3U167-B-GQ?tab=specs
+.. _SiM3U167-B-GM: https://www.silabs.com/products/mcu/32-bit/precision32-sim3u1xx/device.sim3u167-b-gm
 .. _Si4467: https://www.silabs.com/wireless/proprietary/ezradiopro-sub-ghz-ics/device.si4467?tab=specs
 
 Supported Features

--- a/boards/gd/gd32e507v_start/doc/index.rst
+++ b/boards/gd/gd32e507v_start/doc/index.rst
@@ -104,7 +104,7 @@ the JP1 header.
       :compact:
 
 .. _GigaDevice Cortex-M33 High Performance SoC Website:
-   https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m33/high-performance-line/
+   https://www.gigadevice.com/product/mcu/high-performance-mcus/gd32e5xx-series
 
 .. _GD32E507X Datasheet:
    https://gd32mcu.com/download/down/document_id/252/path_type/1

--- a/boards/gd/gd32e507z_eval/doc/index.rst
+++ b/boards/gd/gd32e507z_eval/doc/index.rst
@@ -114,7 +114,7 @@ the JP2 header.
       :compact:
 
 .. _GigaDevice Cortex-M33 High Performance SoC Website:
-   https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m33/high-performance-line/
+   https://www.gigadevice.com/product/mcu/high-performance-mcus/gd32e5xx-series
 
 .. _GD32E507X Datasheet:
    https://gd32mcu.com/download/down/document_id/252/path_type/1

--- a/boards/gd/gd32f450i_eval/doc/index.rst
+++ b/boards/gd/gd32f450i_eval/doc/index.rst
@@ -115,10 +115,10 @@ allows flash programming and debugging over USB. There is also a JTAG header
    https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m4/stretch-performance-line/
 
 .. _GD32F450xx Datasheet:
-	https://gd32mcu.21ic.com/data/documents/shujushouce/GD32F450xx_Datasheet_Rev1.1.pdf
+	https://www.gd32mcu.com/data/documents/datasheet/GD32F450xx_Datasheet_Rev2.3.pdf
 
 .. _GD32F4xx User Manual:
-	https://www.gigadevice.com/manual/gd32f450xxxx-user-manual/
+	https://www.gd32mcu.com/data/documents/userManual/GD32F4xx_User_Manual_Rev3.0.pdf
 
 .. _GD32F450I-EVAL User Manual:
 	http://www.gd32mcu.com/download/down/document_id/120/path_type/1

--- a/boards/gd/gd32f450v_start/doc/index.rst
+++ b/boards/gd/gd32f450v_start/doc/index.rst
@@ -105,7 +105,7 @@ allows flash programming and debugging over USB. There is also a SWD header
    https://gd32mcu.com/data/documents/datasheet/GD32F450xx_Datasheet_Rev2.3.pdf
 
 .. _GD32F4xx User Manual:
-   https://www.gigadevice.com/manual/gd32f450xxxx-user-manual/
+   https://www.gd32mcu.com/data/documents/userManual/GD32F4xx_User_Manual_Rev3.0.pdf
 
 .. _GD32F450V-START User Manual:
    https://gd32mcu.com/data/documents/evaluationBoard/GD32F4xx_Demo_Suites_V2.6.1.rar

--- a/boards/gd/gd32f450z_eval/doc/index.rst
+++ b/boards/gd/gd32f450z_eval/doc/index.rst
@@ -113,10 +113,10 @@ allows flash programming and debugging over USB. There is also a JTAG header
    https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m4/stretch-performance-line/
 
 .. _GD32F450xx Datasheet:
-	https://gd32mcu.21ic.com/data/documents/shujushouce/GD32F450xx_Datasheet_Rev1.1.pdf
+	https://www.gd32mcu.com/data/documents/datasheet/GD32F450xx_Datasheet_Rev2.3.pdf
 
 .. _GD32F4xx User Manual:
-	https://www.gigadevice.com/manual/gd32f450xxxx-user-manual/
+	https://www.gd32mcu.com/data/documents/userManual/GD32F4xx_User_Manual_Rev3.0.pdf
 
 .. _GD32F450Z-EVAL User Manual:
   http://www.gd32mcu.com/download/down/document_id/118/path_type/1

--- a/boards/gd/gd32f470i_eval/doc/index.rst
+++ b/boards/gd/gd32f470i_eval/doc/index.rst
@@ -111,10 +111,10 @@ allows flash programming and debugging over USB. There is also a JTAG header
 
 
 .. _GigaDevice Cortex-M4F Stretch Performance SoC Website:
-   https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m4/stretch-performance-line/gd32f470-series/
+   https://www.gigadevice.com/product/mcu/high-performance-mcus/gd32f4xx-series/gd32f470
 
 .. _GD32F470IKH6 Specifications:
-   https://www.gigadevice.com/microcontroller/gd32f470ikh6/
+   https://www.gigadevice.com/product/mcu/mcus-product-selector/gd32f470ikh6
 
 .. _GD32F470xx Datasheet:
    https://gd32mcu.com/data/documents/datasheet/GD32F470xx_Datasheet_Rev1.3.pdf

--- a/boards/intel/adsp/doc/chromebooks_adsp.rst
+++ b/boards/intel/adsp/doc/chromebooks_adsp.rst
@@ -412,4 +412,4 @@ https://www.chromium.org/chromium-os/developer-library/reference/device/disk-for
 
 This is great too, with an eye toward booting things other than ChromeOS:
 
-https://www.chromium.org/chromium-os/developer-information-for-chrome-os-devices/custom-firmware
+https://www.chromium.org/chromium-os/developer-library/reference/development/developer-information-for-chrome-os-devices/custom-firmware/

--- a/boards/ite/it51xxx_evb/doc/index.rst
+++ b/boards/ite/it51xxx_evb/doc/index.rst
@@ -93,7 +93,7 @@ Building
 ========
 
 #. Build :zephyr:code-sample:`hello_world` application as you would normally do
-   (see :`Zephyr Getting Started Guide`_):.
+   (see :ref:`Zephyr Getting Started Guide <getting_started>`):.
 
    .. zephyr-app-commands::
       :board: it51xxx_evb/it51526aw
@@ -161,5 +161,4 @@ References
 .. target-notes::
 
 .. _ITE's website: https://www.ite.com.tw/en
-.. _Zephyr Getting Started Guide: https://docs.zephyrproject.org/latest/getting_started/index.html
 .. _Flashing steps: https://docs.zephyrproject.org/latest/boards/ite/it82xx2_evb/doc/index.html#flashing

--- a/boards/ite/it82xx2_evb/doc/index.rst
+++ b/boards/ite/it82xx2_evb/doc/index.rst
@@ -94,7 +94,7 @@ Building
 ========
 
 #. Build :zephyr:code-sample:`hello_world` application as you would normally do
-   (see :`Zephyr Getting Started Guide`_):.
+   (see :ref:`Zephyr Getting Started Guide <getting_started>`):.
 
    .. zephyr-app-commands::
       :board: it82xx2_evb
@@ -186,4 +186,3 @@ References
 .. target-notes::
 
 .. _ITE's website: https://www.ite.com.tw/zh-tw/product/view?mid=169
-.. _Zephyr Getting Started Guide: https://docs.zephyrproject.org/latest/getting_started/index.html

--- a/boards/ite/it8xxx2_evb/doc/index.rst
+++ b/boards/ite/it8xxx2_evb/doc/index.rst
@@ -97,7 +97,7 @@ Building
 ========
 
 #. Build :zephyr:code-sample:`hello_world` application as you would normally do
-   (see :`Zephyr Getting Started Guide`_):.
+   (see :ref:`Zephyr Getting Started Guide <getting_started>`):.
 
    .. zephyr-app-commands::
       :board: it8xxx2_evb
@@ -188,4 +188,3 @@ References
 .. target-notes::
 
 .. _ITE's website: https://www.ite.com.tw/en/product/cate2/IT81202
-.. _Zephyr Getting Started Guide: https://docs.zephyrproject.org/latest/getting_started/index.html

--- a/boards/khadas/edgev/doc/index.rst
+++ b/boards/khadas/edgev/doc/index.rst
@@ -8,7 +8,7 @@ See <https://www.khadas.com/edge-v>
 Hardware
 ********
 
-See <https://docs.khadas.com/linux/edge/Hardware.html#Edge-V-1>
+See <https://docs.khadas.com/products/sbc/edge1/hardware/start>
 
 Supported Features
 ==================
@@ -64,4 +64,4 @@ EMMC, QSPI Flash or downloaded from network in uboot.
 References
 ==========
 
-`Documentation: <https://docs.khadas.com/linux/edge/>`_
+`Documentation: <https://docs.khadas.com/products/sbc/edge1/start>`_

--- a/boards/lowrisc/opentitan_earlgrey/doc/index.rst
+++ b/boards/lowrisc/opentitan_earlgrey/doc/index.rst
@@ -77,4 +77,4 @@ References
 
 .. _OpenTitan GitHub: https://github.com/lowRISC/opentitan
 
-.. _OpenTitan Verilator Setup: https://opentitan.org/guides/getting_started/setup_verilator.html
+.. _OpenTitan Verilator Setup: https://opentitan.org/book/doc/getting_started/setup_verilator.html

--- a/boards/nuvoton/numaker_m3334ki/doc/index.rst
+++ b/boards/nuvoton/numaker_m3334ki/doc/index.rst
@@ -85,4 +85,4 @@ References
 .. _NuMaker M3334KI User Manual:
    https://www.nuvoton.com/products/microcontrollers/arm-cortex-m33-mcus/m3331-series/
 .. _M3331 TRM:
-   https://www.nuvoton.com/products/microcontrollers/arm-cortex-m33-mcus/m3331-series/
+   https://www.nuvoton.com/export/resource-files/en-us--TRM_M3331_Series_EN_Rev1.00.pdf

--- a/boards/nuvoton/numaker_pfm_m467/doc/index.rst
+++ b/boards/nuvoton/numaker_pfm_m467/doc/index.rst
@@ -88,4 +88,4 @@ References
 .. _PFM M467 User Manual:
    https://www.nuvoton.com/export/resource-files/UM_NuMaker-PFM-M467_User_Manual_EN_Rev1.01.pdf
 .. _M460 TRM:
-   https://www.nuvoton.com/export/resource-files/TRM_M460_Series_EN_Rev1.01.pdf
+   https://www.nuvoton.com/export/resource-files/en-us--TRM_M460_Series_EN_Rev1.03.pdf

--- a/boards/nxp/mimxrt1024_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1024_evk/doc/index.rst
@@ -247,7 +247,7 @@ should see the following message in the terminal:
    https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/i-mx-rt-crossover-mcus/i-mx-rt1024-crossover-processor-with-arm-cortex-m7-core:i.MX-RT1024
 
 .. _i.MX RT1024 Datasheet:
-   https://www.nxp.com.cn/docs/en/data-sheet/IMXRT1024CEC.pdf
+   https://www.nxp.com/docs/en/data-sheet/IMXRT1024CEC.pdf
 
 .. _i.MX RT1024 Reference Manual:
    https://www.nxp.com/webapp/Download?colCode=IMXRT1024RM

--- a/boards/nxp/mimxrt1062_fmurt6/doc/index.rst
+++ b/boards/nxp/mimxrt1062_fmurt6/doc/index.rst
@@ -303,7 +303,7 @@ connected to the FMURT6 properly.
    https://www.nxp.com/part/RDDRONE-FMURT6#
 
 .. _MIMXRT1062-FMURT6 User Guide:
-   https://docs.px4.io/master/en/
+   https://docs.px4.io/main/en/
 
 .. _MIMXRT1062-FMURT6 Schematics:
    https://github.com/NXPHoverGames/NXP-FMUMRT6

--- a/boards/others/esp32c3_supermini/doc/index.rst
+++ b/boards/others/esp32c3_supermini/doc/index.rst
@@ -47,4 +47,4 @@ References
 
 .. target-notes::
 
-.. _`ESP32-C3-SUPERMINI`: https://www.nologo.tech/product/esp32/esp32c3SuperMini/esp32C3SuperMini.html
+.. _`ESP32-C3-SUPERMINI`: https://www.nologo.tech/en/product/esp32/esp32c3SuperMini/esp32C3SuperMini.html

--- a/boards/panasonic/pan1770_evb/doc/index.rst
+++ b/boards/panasonic/pan1770_evb/doc/index.rst
@@ -48,7 +48,7 @@ Please use the ``pan1770_evb`` board configuration when
 :ref:`build_an_application` and :ref:`application_run`.
 
 .. target-notes::
-.. _product website: https://industry.panasonic.eu/products/devices/wireless-connectivity/bluetooth-low-energy-modules/pan1770-nrf52840
+.. _product website: https://pideu.panasonic.de/development-hub/pan1770/
 .. _Panasonic Wireless Connectivity Development Hub: https://pideu.panasonic.de/development-hub/
 .. _user guide: https://pideu.panasonic.de/development-hub/pan1770/evaluation_board/user_guide/
 .. _download section: https://pideu.panasonic.de/development-hub/pan1770/downloads/

--- a/boards/panasonic/pan1780_evb/doc/index.rst
+++ b/boards/panasonic/pan1780_evb/doc/index.rst
@@ -47,7 +47,7 @@ Please use the ``pan1780_evb`` board configuration when
 :ref:`build_an_application` and :ref:`application_run`.
 
 .. target-notes::
-.. _product website: https://industry.panasonic.eu/products/devices/wireless-connectivity/bluetooth-low-energy-modules/pan1780-nrf52840
+.. _product website: https://pideu.panasonic.de/development-hub/pan1780/
 .. _Panasonic Wireless Connectivity Development Hub: https://pideu.panasonic.de/development-hub/
 .. _user guide: https://pideu.panasonic.de/development-hub/pan1780/evaluation_board/user_guide/
 .. _download section: https://pideu.panasonic.de/development-hub/pan1780/downloads/

--- a/boards/panasonic/pan1783/doc/index.rst
+++ b/boards/panasonic/pan1783/doc/index.rst
@@ -58,7 +58,7 @@ Please use the ``pan1783_evb_cpuapp``, ``pan1783a_evb_cpuapp`` or
 for network core when :ref:`build_an_application` and :ref:`application_run`.
 
 .. target-notes::
-.. _product website: https://industry.panasonic.eu/products/devices/wireless-connectivity/bluetooth-low-energy-modules
+.. _product website: https://pideu.panasonic.de/development-hub/pan1783/
 .. _Panasonic Wireless Connectivity Development Hub: https://pideu.panasonic.de/development-hub/
 .. _pan1783_evb user guide: https://pideu.panasonic.de/development-hub/pan1783/evaluation_board/user_guide/
 .. _pan1783a_evb user guide: https://pideu.panasonic.de/development-hub/pan1783a/evaluation_board/user_guide/

--- a/boards/panasonic/panb611evb/doc/index.rst
+++ b/boards/panasonic/panb611evb/doc/index.rst
@@ -40,7 +40,7 @@ be built, flashed, and debugged in the usual way. See
 building and running.
 
 .. target-notes::
-.. _product website: https://industry.panasonic.eu/products/devices/wireless-connectivity/bluetooth-low-energy-modules
+.. _product website: https://pideu.panasonic.de/development-hub/panb611/
 .. _Panasonic Wireless Connectivity Development Hub: https://pideu.panasonic.de/development-hub/
 .. _panb611evb user guide: https://pideu.panasonic.de/development-hub/panb611/evaluation_board/user_guide/
 .. _download section PANB611: https://pideu.panasonic.de/development-hub/panb611/downloads/

--- a/boards/phytec/phyboard_nash/doc/index.rst
+++ b/boards/phytec/phyboard_nash/doc/index.rst
@@ -141,4 +141,4 @@ For more information refer to the `PHYTEC website`_.
 .. _PHYTEC website:
    https://www.phytec.eu/en/produkte/development-kits/phyboard-nash/
 .. _phyCORE-i.MX93 BSP Manual:
-   https://phytec.github.io/doc-bsp-yocto/bsp/imx9/imx93/imx93.html
+   https://phytec.github.io/doc-bsp-yocto/bsp/imx9/imx9.html

--- a/boards/rakwireless/rak11720/doc/index.rst
+++ b/boards/rakwireless/rak11720/doc/index.rst
@@ -80,10 +80,10 @@ the following message:
    Hello World! rak11720/apollo3_blue
 
 .. _WisDuo RAK11720 Website:
-   https://docs.rakwireless.com/Product-Categories/WisDuo/RAK11720-Module/Overview/#product-description
+   https://docs.rakwireless.com/product-categories/wisduo/rak11720-module/overview/
 
 .. _WisBlock RAK11722 Website:
-   https://docs.rakwireless.com/Product-Categories/WisBlock/RAK11722/Overview/#product-description
+   https://docs.rakwireless.com/product-categories/wisblock/rak11722/overview/
 
 .. _SEGGER J-Link software:
    https://www.segger.com/downloads/jlink

--- a/boards/rakwireless/rak3112/doc/index.rst
+++ b/boards/rakwireless/rak3112/doc/index.rst
@@ -75,5 +75,5 @@ References
 
 .. target-notes::
 
-.. _`WisDuo RAK3112 Website`: https://docs.rakwireless.com/Product-Categories/WisDuo/RAK3112-Module/Overview/
+.. _`WisDuo RAK3112 Website`: https://docs.rakwireless.com/product-categories/wisduo/rak3112-module/overview/
 .. _`Espressif ESP32-S3 Website`: https://www.espressif.com/en/products/socs/esp32-s3

--- a/boards/rakwireless/rak3172/doc/index.rst
+++ b/boards/rakwireless/rak3172/doc/index.rst
@@ -84,7 +84,7 @@ References
 .. target-notes::
 
 .. _WisDuo RAK3172 Website:
-   https://docs.rakwireless.com/Product-Categories/WisDuo/RAK3172-Module/Overview/#product-description
+   https://docs.rakwireless.com/product-categories/wisduo/rak3172-module/overview/
 
 .. _STM32WLE5CC on www.st.com:
    https://www.st.com/en/microcontrollers-microprocessors/stm32wle5cc.html

--- a/boards/rakwireless/rak4631/doc/index.rst
+++ b/boards/rakwireless/rak4631/doc/index.rst
@@ -105,7 +105,7 @@ References
 .. target-notes::
 
 .. _RAK4631 Product Description:
-    https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/Datasheet/#overview
+    https://docs.rakwireless.com/product-categories/wisblock/rak4631/datasheet/
 
 .. _JLink Downloads Page:
     https://www.segger.com/downloads/jlink

--- a/boards/realtek/rtl872xd_evb/doc/index.rst
+++ b/boards/realtek/rtl872xd_evb/doc/index.rst
@@ -87,4 +87,4 @@ References
 
 .. _`RTL872XD-EVB`: https://www.realmcu.com/en/Home/Products/RTL872xCS-RTL872xD-Series#
 .. _`RTL872xCS/D Series`: https://www.realmcu.com
-.. _`AmebaImageTool`: https://github.com/Ameba-AIoT/ameba-rtos/tree/master/tools/ameba/ImageTool_Legacy/AmebaImageTool.exe
+.. _`AmebaImageTool`: https://github.com/Ameba-AIoT/ameba-rtos/blob/master/tools/ameba/ImageTool/AmebaImageTool.exe

--- a/boards/renesas/rcar_salvator_x/doc/index.rst
+++ b/boards/renesas/rcar_salvator_x/doc/index.rst
@@ -148,6 +148,3 @@ References
 
 .. _eLinux H3 Salvator-X page:
 	https://elinux.org/R-Car/Boards/Salvator-X
-
-.. _Install a toolchain:
-	https://docs.zephyrproject.org/latest/getting_started/index.html#install-a-toolchain

--- a/boards/ronoth/lodev/doc/index.rst
+++ b/boards/ronoth/lodev/doc/index.rst
@@ -140,7 +140,7 @@ References
 
 .. _Ronoth: https://ronoth.com/
 
-.. _LoDev: https://ronoth.com/products/lodev-s76s-lora-soc-development-board?variant=31608819417220
+.. _LoDev: https://www.crowdsupply.com/ronoth/lodev
 
 .. _AcSIP: http://www.acsip.com.tw
 

--- a/boards/ruuvi/ruuvitag/doc/index.rst
+++ b/boards/ruuvi/ruuvitag/doc/index.rst
@@ -144,4 +144,4 @@ References
 
 .. _ruuvitag website: https://ruuvi.com
 .. _ruuvitag datasheet: https://ruuvi.com/files/ruuvitag-tech-spec-2019-7.pdf
-.. _ruuvitag devkit: https://lab.ruuvi.com/devshield/
+.. _ruuvitag devkit: https://lab.ruuvi.com/devshield

--- a/boards/seeed/xiao_nrf54l15/doc/index.rst
+++ b/boards/seeed/xiao_nrf54l15/doc/index.rst
@@ -91,7 +91,7 @@ Reset the board and you should see the following message in the terminal:
 
 
 .. _Seeed Studio XIAO nRF54L15:
-   https://www.seeedstudio.com/XIAO-nRF54L15-Sense-p-6494
+   https://www.seeedstudio.com/XIAO-nRF54L15-Sense-p-6494.html
 
 .. _XIAO nRF54L15 Wiki:
    https://wiki.seeedstudio.com/xiao_nrf54l15_sense_getting_started

--- a/boards/shields/canis_canpico/doc/index.rst
+++ b/boards/shields/canis_canpico/doc/index.rst
@@ -147,7 +147,7 @@ in your Zephyr application. For example:
    https://canislabs.com/
 
 .. _CANPico CAN Bus Shield:
-   https://canislabs.com/canpico/
+   https://kentindell.github.io/canpico
 
 .. _MCP2517FD:
    https://www.microchip.com/en-us/product/MCP2518FD

--- a/boards/shields/mikroe_wifi_bt_click/doc/index.rst
+++ b/boards/shields/mikroe_wifi_bt_click/doc/index.rst
@@ -113,7 +113,7 @@ References
 .. target-notes::
 
 .. _ESP32 AT Bin:
-   https://docs.espressif.com/projects/esp-at/en/latest/esp32/AT_Binary_Lists/ESP32_AT_binaries.html
+   https://docs.espressif.com/projects/esp-at/en/latest/esp32/AT_Binary_Lists/index.html
 
 .. _WIFI BT Click Shield website:
    https://www.mikroe.com/

--- a/boards/solderedelectronics/inkplate_6color/doc/index.rst
+++ b/boards/solderedelectronics/inkplate_6color/doc/index.rst
@@ -113,5 +113,5 @@ References
 
 .. target-notes::
 
-.. _`Inkplate 6Color`: https://soldered.com/product/inkplate-6color/
+.. _`Inkplate 6Color`: https://soldered.com/products/inkplate-6color-e-paper-display
 .. _`Soldered Electronics`: https://soldered.com/

--- a/boards/u-blox/ubx_evk_iris_w1/doc/index.rst
+++ b/boards/u-blox/ubx_evk_iris_w1/doc/index.rst
@@ -145,7 +145,7 @@ board target ``ubx_evk_iris_w1//ethernet``.
    Pin conflicts between the Ethernet PHY and the external oscillator require hardware modifications on the board.
    Refer to the following documents for the required hardware changes:
 
-   - `EVK-IRIS-W1 User Guide <https://content.u-blox.com/sites/default/files/documents/EVK-IRIS-W1_UserGuide_UBX-23007837.pdf>`_
+   - `EVK-IRIS-W1 User Guide <https://www.u-blox.com/docs/UBX-23007837>`_
    - `IRIS-W10 SIM <https://content.u-blox.com/sites/default/files/documents/IRIS-W10_SIM_UBX-23003263.pdf>`_
 
 Resources
@@ -153,5 +153,5 @@ Resources
 
 - `EVK-IRIS-W1 Website <https://www.u-blox.com/en/product/evk-iris-w1>`_
 - `EVK-IRIS-W1 GitHub <https://github.com/u-blox/u-blox-sho-OpenCPU/tree/master/MCUXpresso/IRIS-W1>`_
-- `EVK-IRIS-W1 User Guide <https://content.u-blox.com/sites/default/files/documents/EVK-IRIS-W1_UserGuide_UBX-23007837.pdf>`_
+- `EVK-IRIS-W1 User Guide <https://www.u-blox.com/docs/UBX-23007837>`_
 - `IRIS-W10 SIM <https://content.u-blox.com/sites/default/files/documents/IRIS-W10_SIM_UBX-23003263.pdf>`_

--- a/boards/xunlong/opi_zero/doc/index.rst
+++ b/boards/xunlong/opi_zero/doc/index.rst
@@ -68,7 +68,7 @@ You should see the following output on the serial console:
    Hello World! opi_zero/sun8i_h3
 
 .. _Orange Pi Zero:
-   http://www.orangepi.org/orangepiwiki/index.php/Orange_Pi_Zero/
+   http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-Zero.html
 
 .. _Das U-Boot Website:
    https://docs.u-boot.org/en/latest/

--- a/doc/_extensions/zephyr/api_overview.py
+++ b/doc/_extensions/zephyr/api_overview.py
@@ -97,10 +97,11 @@ class ApiOverview(SphinxDirective):
                 version = sect.get_para()[0].get_valueOf_()
 
         if since:
+            # Some @since values already carry a patch component (e.g. "1.14.0");
+            # normalize to a "major.minor.0" release tag to avoid "v1.14.0.0".
+            release = ".".join(since.strip().split(".")[:2]) + ".0"
             since_url = nodes.inline()
-            reference = nodes.reference(
-                text=f"v{since.strip()}.0", refuri=f"{github_uri}/v{since.strip()}.0"
-            )
+            reference = nodes.reference(text=f"v{release}", refuri=f"{github_uri}v{release}")
             reference.attributes["internal"] = True
             since_url += reference
         else:

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -71,7 +71,7 @@ binding indicates it is a PCIe bus node, as defined in the
 `PCI Bus Binding to: IEEE Std 1275-1994 Standard for Boot (Initialization Configuration) Firmware`_
 
 .. _PCI Bus Binding to\: IEEE Std 1275-1994 Standard for Boot (Initialization Configuration) Firmware:
-    https://www.openfirmware.info/data/docs/bus.pci.pdf
+    https://www.devicetree.org/open-firmware/bindings/pci/pci2_1.pdf
 
 .. doxygengroup:: devicetree-ranges-prop
 

--- a/doc/contribute/coding_guidelines/index.rst
+++ b/doc/contribute/coding_guidelines/index.rst
@@ -1094,7 +1094,7 @@ Status
   .. _Inclusive Language Label: https://github.com/zephyrproject-rtos/zephyr/issues?q=label%3A%22Inclusive+Language%22
   .. _I2C Specification: https://www.nxp.com/docs/en/user-guide/UM10204.pdf
   .. _Bluetooth Appropriate Language Mapping Tables: https://specificationrefs.bluetooth.com/language-mapping/Appropriate_Language_Mapping_Table.pdf
-  .. _OSHWA Resolution to Redefine SPI Signal Names: https://www.oshwa.org/a-resolution-to-redefine-spi-signal-names/
+  .. _OSHWA Resolution to Redefine SPI Signal Names: https://oshwa.org/resources/a-resolution-to-redefine-spi-signal-names/
   .. _CAN in Automation Inclusive Language news post: https://www.can-cia.org/news/archive/view/?tx_news_pi1%5Bnews%5D=699&tx_news_pi1%5Bday%5D=6&tx_news_pi1%5Bmonth%5D=12&tx_news_pi1%5Byear%5D=2020&cHash=784e79eb438141179386cf7c29ed9438
   .. _CAN in Automation Inclusive Language: https://can-newsletter.org/canopen/categories/
   .. _eSPI Specification: https://downloadmirror.intel.com/27055/327432%20espi_base_specification%20R1-5.pdf

--- a/doc/develop/flash_debug/nordic_segger.rst
+++ b/doc/develop/flash_debug/nordic_segger.rst
@@ -238,7 +238,7 @@ References
 
 .. _nRF5x Command-Line Tools: https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Command-Line-Tools
 
-.. _Segger SAM3U Wiki: https://wiki.segger.com/index.php?title=J-Link-OB_SAM3U
+.. _Segger SAM3U Wiki: https://wiki.segger.com/J-Link-OB_SAM3U
 .. _Real-Time Tracing (RTT): https://www.segger.com/jlink-rtt.html
 .. _pyrtt-viewer: https://github.com/thomasstenersen/pyrtt-viewer
 .. _Segger Ozone: https://www.segger.com/ozone.html

--- a/doc/develop/flash_debug/probes.rst
+++ b/doc/develop/flash_debug/probes.rst
@@ -577,4 +577,4 @@ See `Black Magic Debug supported hardware`_.
    https://black-magic.org/index.html
 
 .. _Black Magic Debug supported hardware:
-   https://black-magic.org/hardware.html
+   https://black-magic.org/index.html#other-hardware-supported-by-black-magic-debug

--- a/doc/develop/manifest/external/zephelin.rst
+++ b/doc/develop/manifest/external/zephelin.rst
@@ -76,4 +76,4 @@ References
    https://ai.google.dev/edge/litert
 
 .. _microTVM:
-   https://tvm.apache.org/docs/v0.9.0/topic/microtvm/index.html
+   https://tvm.apache.org/docs/

--- a/doc/develop/tools/kapa_ai.rst
+++ b/doc/develop/tools/kapa_ai.rst
@@ -119,10 +119,10 @@ synchronized at the indicated frequencies:
        Markdown, Python, and text files
      - Hourly
    * - API reference
-     - https://docs.zephyrproject.org/latest/doxygen/
+     - https://docs.zephyrproject.org/latest/doxygen/html/index.html
      - Daily
    * - Devicetree bindings
-     - https://docs.zephyrproject.org/latest/build/dts/api/
+     - https://docs.zephyrproject.org/latest/build/dts/api/bindings.html
      - Daily
    * - Main documentation
      - https://docs.zephyrproject.org/latest/ (excluding the API reference and Devicetree bindings

--- a/doc/services/connectivity/bluetooth/autopts/autopts-win10.rst
+++ b/doc/services/connectivity/bluetooth/autopts/autopts-win10.rst
@@ -70,7 +70,7 @@ drivers from installation directory
 Setup Zephyr project for Windows
 =================================
 
-Perform Windows setup from `Getting Started Guide <https://docs.zephyrproject.org/latest/getting_started/index.html>`_.
+Perform Windows setup from :ref:`Getting Started Guide <getting_started>`.
 
 Install nrftools
 =================

--- a/samples/boards/quicklogic/qomu/README.rst
+++ b/samples/boards/quicklogic/qomu/README.rst
@@ -9,7 +9,7 @@ usbserial driver.
 Requirements
 ************
 * Zephyr RTOS with printk enabled
-* `QuickLogic Qomu board <https://www.quicklogic.com/products/eos-s3/quickfeather-development-kit/>`_
+* `QuickLogic Qomu board <https://www.quicklogic.com/products/eos-s3/quickfeather/>`_
 
 Building
 ********

--- a/samples/modules/tflite-micro/magic_wand/README.rst
+++ b/samples/modules/tflite-micro/magic_wand/README.rst
@@ -54,7 +54,7 @@ start the emulator:
     https://github.com/renode/renode/releases/
 
 .. _Renode GitHub README:
-    https://github.com/renode/renode/blob/master/README.rst
+    https://github.com/renode/renode/blob/master/README.md
 
 Sample Output
 =============

--- a/samples/sensor/bmi270/README.rst
+++ b/samples/sensor/bmi270/README.rst
@@ -16,7 +16,7 @@ with the compatible string :dtcompatible:`bosch,bmi270`.
 References
 **********
 
- - BMI270: https://www.bosch-sensortec.com/products/motion-sensors/imus/bmi270.html
+ - BMI270: https://www.bosch-sensortec.com/products/motion-sensors/imus/bmi270/
 
 Building and Running
 ********************

--- a/samples/sensor/sgp40_sht4x/README.rst
+++ b/samples/sensor/sgp40_sht4x/README.rst
@@ -24,8 +24,8 @@ To make use of the heater have a look at the Kconfig options for this applicatio
 References
 **********
 
- - `SHT4X sensor <https://www.sensirion.com/en/environmental-sensors/humidity-sensors/humidity-sensor-sht4x/>`_
- - `SGP40 sensor <https://www.sensirion.com/en/environmental-sensors/gas-sensors/sgp40/>`_
+ - `SHT4X sensor <https://sensirion.com/products/catalog/SHT40>`_
+ - `SGP40 sensor <https://sensirion.com/products/catalog/SGP40>`_
 
 Wiring
 ******

--- a/samples/sensor/sht3xd/README.rst
+++ b/samples/sensor/sht3xd/README.rst
@@ -14,7 +14,7 @@ Optionally, it also shows how to use the upper threshold triggers.
 References
 **********
 
- - `SHT3X-DIS sensor <https://www.sensirion.com/en/environmental-sensors/humidity-sensors/digital-humidity-sensors-for-various-applications/>`_
+ - `SHT3X-DIS sensor <https://sensirion.com/products/catalog/SHT31-DIS-B>`_
 
 Wiring
 *******


### PR DESCRIPTION
Fixes a batch of broken external links across board, sample and subsystem
documentation, found by running `make linkcheck` on the docs.

Fixed with the help of Claude, each fixed link manually verified to be actually correct replacement.