### PR TITLE
drivers: mspi: stm32: add memory type and size configuration support

### DIFF
--- a/drivers/mspi/mspi_stm32.h
+++ b/drivers/mspi/mspi_stm32.h
@@ -32,6 +32,46 @@
 #endif
 
 #define MSPI_STM32_WRITE_REG_MAX_TIME          40U
+/*
+ * Memory device geometry, taken at compile time from the controller's
+ * first status "okay" child node. The STM32 MSPI drivers currently
+ * support a single device per controller (MSPI_MAX_DEVICE == 1).
+ *
+ * MSPI_STM32_INST_MEM_ADDR_BITS() expands to the number of address bits
+ * of the memory device (log2 of its size in bytes), derived from the
+ * child's "size" property (in bits). If the
+ * controller has no enabled child, it expands to @p fallback_bits.
+ *
+ * Note that the HAL encodings differ for each IP:
+ *   XSPI  Init.MemorySize = address bits - 1 (raw DCR1 DEVSIZE)
+ *   OSPI  Init.DeviceSize = address bits     (HAL subtracts 1)
+ *   QSPI  Init.FlashSize  = address bits - 1 (raw DCR FSIZE)
+ */
+#define MSPI_STM32_MEM_SIZE_BITS(child)                                        \
+	DT_PROP_OR(child, size, 0)
+
+#define MSPI_STM32_MEM_ADDR_BITS_ENTRY(child)                                  \
+	(LOG2(MSPI_STM32_MEM_SIZE_BITS(child)) - 3),
+
+#define MSPI_STM32_INST_MEM_ADDR_BITS(index, fallback_bits)                    \
+	COND_CODE_0(DT_INST_CHILD_NUM_STATUS_OKAY(index),                      \
+		    (fallback_bits),                                           \
+		    (GET_ARG_N(1, DT_INST_FOREACH_CHILD_STATUS_OKAY(index,     \
+					MSPI_STM32_MEM_ADDR_BITS_ENTRY))))
+
+/*
+ * Memory type token ("st,mem-type" on the child node), upper-cased for
+ * pasting onto the HAL memory type macro prefix. Defaults to MICRON,
+ * the hardware reset value of DCR1 MTYP, when the property is absent.
+ */
+#define MSPI_STM32_MEMTYPE_TOKEN_ENTRY(child)                                  \
+	DT_STRING_UPPER_TOKEN_OR(child, st_mem_type, MICRON),
+
+#define MSPI_STM32_INST_MEMTYPE_TOKEN(index)                                   \
+	COND_CODE_0(DT_INST_CHILD_NUM_STATUS_OKAY(index),                      \
+		    (MICRON),                                                  \
+		    (GET_ARG_N(1, DT_INST_FOREACH_CHILD_STATUS_OKAY(index,     \
+					MSPI_STM32_MEMTYPE_TOKEN_ENTRY))))
 
 typedef void (*irq_config_func_t)(void);
 

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -1475,8 +1475,10 @@ static int mspi_stm32_xspi_pm_action(const struct device *dev, enum pm_device_ac
 				.ChipSelectHighTimeCycle = 1,                                     \
 				.ClockMode = HAL_XSPI_CLOCK_MODE_0,                               \
 				.ChipSelectBoundary = DT_INST_PROP(index, st_csbound),            \
+				.MemorySize = MSPI_STM32_INST_MEM_ADDR_BITS(index, 26) - 1,       \
+				.MemoryType = CONCAT(HAL_XSPI_MEMTYPE_,                           \
+						MSPI_STM32_INST_MEMTYPE_TOKEN(index)),            \
 				.MemoryMode = HAL_XSPI_SINGLE_MEM,                                \
-				.MemorySize = 0x19,                                               \
 				.FreeRunningClock = HAL_XSPI_FREERUNCLK_DISABLE,                  \
 			},                                                                        \
 		},                                                                                \

--- a/dts/bindings/mspi/st,nor-mspi.yaml
+++ b/dts/bindings/mspi/st,nor-mspi.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 EXALT Technologies.
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32 memory device on mspi bus
+
+compatible: "st,nor"
+
+include: jedec,nor-mspi.yaml
+
+properties:
+  st,mem-type:
+    type: string
+    description: |
+      The type of memory to be supported by the controller.
+    enum:
+      - "micron"
+      - "macronix"
+      - "apmem"
+      - "macronix_ram"
+      - "hyperbus"
+      - "apmem_16bits"

--- a/dts/bindings/mspi/st,psram-device-mspi.yaml
+++ b/dts/bindings/mspi/st,psram-device-mspi.yaml
@@ -46,3 +46,15 @@ properties:
 
   write-command:
     required: true
+
+  st,mem-type:
+    type: string
+    description: |
+      The type of memory to be supported by the controller.
+    enum:
+      - "micron"
+      - "macronix"
+      - "apmem"
+      - "macronix_ram"
+      - "hyperbus"
+      - "apmem_16bits"

--- a/samples/drivers/mspi/mspi_flash/boards/stm32h573i_dk.overlay
+++ b/samples/drivers/mspi/mspi_flash/boards/stm32h573i_dk.overlay
@@ -38,7 +38,7 @@
 			dma-names = "tx", "rx";
 
 			mx25lm51245: ospi-nor-flash@0 {
-				compatible = "mxicy,mx25u", "jedec,nor";
+				compatible = "st,nor", "mxicy,mx25u", "jedec,nor";
 				reg = <0>;
 				size = <DT_SIZE_M(512)>; /* 512 Mbits */
 				status = "okay";
@@ -49,6 +49,7 @@
 				mspi-io-mode = "MSPI_IO_MODE_OCTAL";
 				mspi-data-rate = "MSPI_DATA_RATE_DUAL";
 				mspi-hardware-ce-num = <0>;
+				st,mem-type = "macronix";
 				command-length = "INSTR_2_BYTE";
 				jedec-id = [c2 85 3a];
 

--- a/tests/drivers/memc/ram/boards/stm32h7s78_dk_mspi_psram.overlay
+++ b/tests/drivers/memc/ram/boards/stm32h7s78_dk_mspi_psram.overlay
@@ -43,6 +43,7 @@
 				compatible = "st,psram-device", "aps-z8";
 				reg = <0>;
 				size = <DT_SIZE_M(128)>;
+				st,mem-type = "apmem";
 				mspi-max-frequency = <DT_FREQ_M(200)>;
 				mspi-io-mode = "MSPI_IO_MODE_OCTAL";
 				mspi-data-rate = "MSPI_DATA_RATE_S_D_D";


### PR DESCRIPTION
This PR adds support for configuring MSPI memory type and memory size through MSPI device configuration and Devicetree.

**Changes**
- Adds `mem_type` and `mem_size` to MSPI device configuration.
- Introduces the `st,mspi-device`  dts  binding.
- Configures memory type and size in the STM32 XSPI driver.
- Updates MSPI NOR flash and APS z8 PSRAM drivers to provide the new configuration.
- Adds sample and test updates for STM32 MSPI memory devices.