### PR TITLE
tests: dma: select test DMA controllers via devicetree

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_buffers.c
@@ -8,7 +8,13 @@
 
 #include "test_buffers.h"
 
+#if DT_NODE_HAS_PROP(DT_PATH(zephyr_user), dma_test_devs)
+#define DMA_DATA_ALIGNMENT                                                                         \
+	DT_PROP_OR(DT_PHANDLE_BY_IDX(DT_PATH(zephyr_user), dma_test_devs, 0),                     \
+		   dma_buf_addr_alignment, 32)
+#else
 #define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
+#endif
 
 #if CONFIG_NOCACHE_MEMORY
 __aligned(DMA_DATA_ALIGNMENT) char tx_data[TEST_BUF_SIZE] __used

--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -22,6 +22,28 @@
 
 #include "test_buffers.h"
 
+#define DMA_TEST_NODE      DT_PATH(zephyr_user)
+#define DMA_TEST_DEVS_PROP dma_test_devs
+
+#if DT_NODE_HAS_PROP(DMA_TEST_NODE, DMA_TEST_DEVS_PROP)
+/* Boards list the DMA controllers to test in a zephyr,user dma-test-devs
+ * phandle list.
+ */
+#define DMA_TEST_DEV_COUNT DT_PROP_LEN(DMA_TEST_NODE, DMA_TEST_DEVS_PROP)
+#define DMA_TEST_DEV_GET(idx, _)                                                                   \
+	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DMA_TEST_NODE, DMA_TEST_DEVS_PROP, idx))
+#else
+/* Legacy boards use tst_dmaN devicetree labels and
+ * CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS.
+ */
+#define DMA_TEST_DEV_COUNT CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS
+#define DMA_TEST_DEV_GET(idx, _) DEVICE_DT_GET(DT_NODELABEL(tst_dma##idx))
+#endif
+
+static const struct device *const dma_test_devs[] = {
+	LISTIFY(DMA_TEST_DEV_COUNT, DMA_TEST_DEV_GET, (,))
+};
+
 static K_SEM_DEFINE(transfer_end_sem, 0, 1);
 static int dma_complete_status;
 
@@ -127,58 +149,32 @@ static int test_task(const struct device *dma, uint32_t chan_id, uint32_t blen)
 	return TC_PASS;
 }
 
-#define RUN_DMA_M2M_TEST(dma_label, chan, blen)                                                    \
-	do {                                                                                       \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_label));                 \
-		zassert_true((test_task(dma, chan, blen) == TC_PASS));                             \
-	} while (0)
-
-ZTEST(dma_m2m, test_tst_dma0_m2m_chan0_burst8)
+static void run_dma_m2m_test(uint32_t chan, uint32_t blen)
 {
-	RUN_DMA_M2M_TEST(tst_dma0, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 8);
+	for (size_t i = 0; i < ARRAY_SIZE(dma_test_devs); i++) {
+		zassert_true(test_task(dma_test_devs[i], chan, blen) == TC_PASS,
+			     "%s failed chan %u burst %u", dma_test_devs[i]->name, chan, blen);
+	}
 }
 
-ZTEST(dma_m2m, test_tst_dma0_m2m_chan1_burst8)
+ZTEST(dma_m2m, test_dma_m2m_chan0_burst8)
 {
-	RUN_DMA_M2M_TEST(tst_dma0, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 8);
+	run_dma_m2m_test(CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 8);
 }
 
-#if CONFIG_DMA_TRANSFER_BURST16
-ZTEST(dma_m2m, test_tst_dma0_m2m_chan0_burst16)
+ZTEST(dma_m2m, test_dma_m2m_chan1_burst8)
 {
-	RUN_DMA_M2M_TEST(tst_dma0, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 16);
-}
-
-ZTEST(dma_m2m, test_tst_dma0_m2m_chan1_burst16)
-{
-	RUN_DMA_M2M_TEST(tst_dma0, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 16);
-}
-#endif
-
-#if CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS > 1
-ZTEST(dma_m2m, test_tst_dma1_m2m_chan0_burst8)
-{
-	RUN_DMA_M2M_TEST(tst_dma1, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 8);
-}
-
-ZTEST(dma_m2m, test_tst_dma1_m2m_chan1_burst8)
-{
-	RUN_DMA_M2M_TEST(tst_dma1, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 8);
+	run_dma_m2m_test(CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 8);
 }
 
 #if CONFIG_DMA_TRANSFER_BURST16
-ZTEST(dma_m2m, test_tst_dma1_m2m_chan0_burst16)
+ZTEST(dma_m2m, test_dma_m2m_chan0_burst16)
 {
-	RUN_DMA_M2M_TEST(tst_dma1, CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 16);
+	run_dma_m2m_test(CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 16);
 }
 
-ZTEST(dma_m2m, test_tst_dma1_m2m_chan1_burst16)
+ZTEST(dma_m2m, test_dma_m2m_chan1_burst16)
 {
-	RUN_DMA_M2M_TEST(tst_dma1, CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 16);
+	run_dma_m2m_test(CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 16);
 }
-#endif
-#endif /* CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS > 1 */
-
-#if CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS > 2
-#error "Update test_dma.c to add ZTEST cases for tst_dma2 and beyond."
 #endif

--- a/tests/drivers/dma/chan_link_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_link_transfer/src/test_dma.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 NXP
+ * Copyright (c) 2020, 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,7 +25,30 @@
 #define TEST_DMA_CHANNEL_1 (1)
 #define GUARD_BUFF_SIZE (16)
 #define RX_BUFF_SIZE (48)
-#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
+
+#define DMA_TEST_NODE      DT_PATH(zephyr_user)
+#define DMA_TEST_DEVS_PROP dma_test_devs
+
+#if DT_NODE_HAS_PROP(DMA_TEST_NODE, DMA_TEST_DEVS_PROP)
+/* Boards list the DMA controllers to test in a zephyr,user dma-test-devs
+ * phandle list.
+ */
+#define DMA_TEST_DEV_COUNT DT_PROP_LEN(DMA_TEST_NODE, DMA_TEST_DEVS_PROP)
+#define DMA_TEST_DEV_GET(idx, _)                                                                   \
+	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DMA_TEST_NODE, DMA_TEST_DEVS_PROP, idx))
+#define DMA_TEST_DEV0_NODE DT_PHANDLE_BY_IDX(DMA_TEST_NODE, DMA_TEST_DEVS_PROP, 0)
+#else
+/* Legacy single-controller boards use a tst_dma0 devicetree label. */
+#define DMA_TEST_DEV_COUNT 1
+#define DMA_TEST_DEV_GET(idx, _) DEVICE_DT_GET(DT_NODELABEL(tst_dma0))
+#define DMA_TEST_DEV0_NODE DT_NODELABEL(tst_dma0)
+#endif
+
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DMA_TEST_DEV0_NODE, dma_buf_addr_alignment, 32)
+
+static const struct device *const dma_test_devs[] = {
+	LISTIFY(DMA_TEST_DEV_COUNT, DMA_TEST_DEV_GET, (,))
+};
 
 #ifdef CONFIG_NOCACHE_MEMORY
 static __aligned(DMA_DATA_ALIGNMENT) char tx_data[RX_BUFF_SIZE] __used
@@ -63,11 +86,10 @@ static void test_done(const struct device *dma_dev, void *arg, uint32_t id,
 	}
 }
 
-static int test_task(int minor, int major)
+static int test_task(const struct device *dma, int minor, int major)
 {
 	struct dma_config dma_cfg = { 0 };
 	struct dma_block_config dma_block_cfg = { 0 };
-	const struct device *const dma = DEVICE_DT_GET(DT_NODELABEL(tst_dma0));
 
 	if (!device_is_ready(dma)) {
 		TC_PRINT("dma controller device is not ready\n");
@@ -92,8 +114,8 @@ static int test_task(int minor, int major)
 	dma_cfg.dma_slot = CONFIG_DMA_MCUX_TEST_SLOT_START;
 #endif
 
-	TC_PRINT("Preparing DMA Controller: Chan_ID=%u, BURST_LEN=%u\n",
-		 TEST_DMA_CHANNEL_1, 8 >> 3);
+	TC_PRINT("Preparing DMA Controller: %s, Chan_ID=%u, BURST_LEN=%u\n",
+		 dma->name, TEST_DMA_CHANNEL_1, 8 >> 3);
 
 	TC_PRINT("Starting the transfer\n");
 	(void)memset(rx_data, 0, RX_BUFF_SIZE);
@@ -176,15 +198,24 @@ static int test_task(int minor, int major)
 /* export test cases */
 ZTEST(dma_m2m_link, test_dma_m2m_chan0_1_major_link)
 {
-	zassert_true((test_task(0, 1) == TC_PASS));
+	for (size_t i = 0; i < ARRAY_SIZE(dma_test_devs); i++) {
+		zassert_true(test_task(dma_test_devs[i], 0, 1) == TC_PASS,
+			     "%s failed major link transfer", dma_test_devs[i]->name);
+	}
 }
 
 ZTEST(dma_m2m_link, test_dma_m2m_chan0_1_minor_link)
 {
-	zassert_true((test_task(1, 0) == TC_PASS));
+	for (size_t i = 0; i < ARRAY_SIZE(dma_test_devs); i++) {
+		zassert_true(test_task(dma_test_devs[i], 1, 0) == TC_PASS,
+			     "%s failed minor link transfer", dma_test_devs[i]->name);
+	}
 }
 
 ZTEST(dma_m2m_link, test_dma_m2m_chan0_1_minor_major_link)
 {
-	zassert_true((test_task(1, 1) == TC_PASS));
+	for (size_t i = 0; i < ARRAY_SIZE(dma_test_devs); i++) {
+		zassert_true(test_task(dma_test_devs[i], 1, 1) == TC_PASS,
+			     "%s failed minor major link transfer", dma_test_devs[i]->name);
+	}
 }

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -32,7 +32,32 @@
 #define SLEEPTIME 250
 
 #define TRANSFER_LOOPS (4)
-#define DMA_DATA_ALIGNMENT DT_PROP_OR(DT_NODELABEL(tst_dma0), dma_buf_addr_alignment, 32)
+
+#define DMA_TEST_NODE      DT_PATH(zephyr_user)
+#define DMA_TEST_DEVS_PROP dma_test_devs
+
+#if DT_NODE_HAS_PROP(DMA_TEST_NODE, DMA_TEST_DEVS_PROP)
+/* Boards list the DMA controllers to test in a zephyr,user dma-test-devs
+ * phandle list.
+ */
+#define DMA_TEST_DEV_COUNT DT_PROP_LEN(DMA_TEST_NODE, DMA_TEST_DEVS_PROP)
+#define DMA_TEST_DEV_GET(idx, _)                                                                   \
+	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(DMA_TEST_NODE, DMA_TEST_DEVS_PROP, idx))
+#define DMA_TEST_DEV0_NODE DT_PHANDLE_BY_IDX(DMA_TEST_NODE, DMA_TEST_DEVS_PROP, 0)
+#else
+/* Legacy boards use tst_dmaN devicetree labels and
+ * CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS.
+ */
+#define DMA_TEST_DEV_COUNT CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS
+#define DMA_TEST_DEV_GET(idx, _) DEVICE_DT_GET(DT_NODELABEL(tst_dma##idx))
+#define DMA_TEST_DEV0_NODE DT_NODELABEL(tst_dma0)
+#endif
+
+#define DMA_DATA_ALIGNMENT DT_PROP_OR(DMA_TEST_DEV0_NODE, dma_buf_addr_alignment, 32)
+
+static const struct device *const dma_test_devs[] = {
+	LISTIFY(DMA_TEST_DEV_COUNT, DMA_TEST_DEV_GET, (,))
+};
 
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t tx_data[CONFIG_DMA_LOOP_TRANSFER_SIZE];
 static __aligned(DMA_DATA_ALIGNMENT) uint8_t
@@ -489,32 +514,26 @@ static int test_loop_repeated_start_stop(const struct device *dma)
 	return TC_PASS;
 }
 
-#define DMA_NAME(i, _)	tst_dma ## i
-#define DMA_LIST	LISTIFY(CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS, DMA_NAME, (,))
-
-#define TEST_LOOP(dma_name)                                                                        \
-	ZTEST(dma_m2m_loop, test_ ## dma_name ## _m2m_loop)                                        \
-	{                                                                                          \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
-		zassert_true((test_loop(dma) == TC_PASS));                                         \
+ZTEST(dma_m2m_loop, test_dma_m2m_loop)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(dma_test_devs); i++) {
+		zassert_true(test_loop(dma_test_devs[i]) == TC_PASS,
+			     "%s failed loop transfer", dma_test_devs[i]->name);
 	}
+}
 
-FOR_EACH(TEST_LOOP, (), DMA_LIST);
-
-#define TEST_LOOP_SUSPEND_RESUME(dma_name)                                                         \
-	ZTEST(dma_m2m_loop, test_ ## dma_name ## _m2m_loop_suspend_resume)                         \
-	{                                                                                          \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
-		zassert_true((test_loop_suspend_resume(dma) == TC_PASS));                          \
+ZTEST(dma_m2m_loop, test_dma_m2m_loop_suspend_resume)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(dma_test_devs); i++) {
+		zassert_true(test_loop_suspend_resume(dma_test_devs[i]) == TC_PASS,
+			     "%s failed loop suspend resume", dma_test_devs[i]->name);
 	}
+}
 
-FOR_EACH(TEST_LOOP_SUSPEND_RESUME, (), DMA_LIST);
-
-#define TEST_LOOP_REPEATED_START_STOP(dma_name)                                                    \
-	ZTEST(dma_m2m_loop, test_ ## dma_name ## _m2m_loop_repeated_start_stop)                    \
-	{                                                                                          \
-		const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma_name));                  \
-		zassert_true((test_loop_repeated_start_stop(dma) == TC_PASS));                     \
+ZTEST(dma_m2m_loop, test_dma_m2m_loop_repeated_start_stop)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(dma_test_devs); i++) {
+		zassert_true(test_loop_repeated_start_stop(dma_test_devs[i]) == TC_PASS,
+			     "%s failed repeated start stop", dma_test_devs[i]->name);
 	}
-
-FOR_EACH(TEST_LOOP_REPEATED_START_STOP, (), DMA_LIST);
+}


### PR DESCRIPTION
The three DMA test suites (`chan_blen_transfer`, `loop_transfer`, `chan_link_transfer`) select the controllers to test through hardcoded `tst_dmaN` devicetree labels, with per-instance test cases gated or generated from `CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS`. As raised in the review of #112789, the Kconfig count can get out of sync with the board overlay, the `DMA_LOOP_TRANSFER_*` naming is confusing outside `loop_transfer`, and the pattern does not scale past two instances.

This PR makes devicetree the source of truth, as suggested there: boards list the controllers to test in a `zephyr,user` `dma-test-devs` phandle list, and every test case iterates over the resulting device array:

```dts
/ {
	zephyr,user {
		dma-test-devs = <&edma3>, <&edma4>;
	};
};
```

To avoid churning the ~370 board overlays that already use these suites, the old mechanism keeps working: boards without the property fall back to the existing `tst_dmaN` labels and `CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS`. **No board files are modified.**

Visible change: per-instance case names collapse into one case per scenario that covers all listed controllers, e.g. `test_tst_dma0_m2m_chan0_burst8` / `test_tst_dma1_m2m_chan0_burst8` become `test_dma_m2m_chan0_burst8`. Coverage is unchanged.

## Validation

- `frdm_imxrt1186//cm33` hardware, with a local overlay listing both RT118x eDMA instances (`edma3` per-channel IRQs, `edma4` shared IRQs): `chan_link_transfer` 3/3 PASS, `chan_blen_transfer` 4/4 PASS, `loop_transfer` 2 PASS / 1 SKIP (driver has no suspend support), serial log shows every case exercising both controllers.
- Legacy fallback build-tested: `mimxrt1170_evk//cm7` (chan_link, loop), `mimxrt1064_evk` (chan_blen) for the single-instance path, `frdm_rw612` (chan_blen, loop) for the `CONFIG_DMA_LOOP_TRANSFER_NUMBER_OF_DMAS=2` path.

Follow-up: #112789 will be rebased on top of this to enable the second eDMA instance on `frdm_imxrt1186` via `dma-test-devs`.
