### PR TITLE
net: route: Make nexthop const

### DIFF
--- a/subsys/net/ip/route_ipv4.c
+++ b/subsys/net/ip/route_ipv4.c
@@ -91,7 +91,7 @@ struct net_route_entry *net_route_ipv4_lookup(struct net_if *iface,
 struct net_route_entry *net_route_ipv4_add(struct net_if *iface,
 					   struct net_in_addr *addr,
 					   uint8_t mask_len,
-					   struct net_in_addr *nexthop,
+					   const struct net_in_addr *nexthop,
 					   uint32_t lifetime,
 					   uint8_t preference)
 {
@@ -124,7 +124,7 @@ int net_route_ipv4_del(struct net_route_entry *route)
 }
 
 int net_route_ipv4_del_by_nexthop(struct net_if *iface,
-				  struct net_in_addr *nexthop)
+				  const struct net_in_addr *nexthop)
 {
 	struct net_addr addr = route_ipv4_addr(nexthop);
 

--- a/subsys/net/ip/route_ipv4.h
+++ b/subsys/net/ip/route_ipv4.h
@@ -64,7 +64,7 @@ static inline struct net_route_entry *net_route_ipv4_lookup(struct net_if *iface
 struct net_route_entry *net_route_ipv4_add(struct net_if *iface,
 					   struct net_in_addr *addr,
 					   uint8_t mask_len,
-					   struct net_in_addr *nexthop,
+					   const struct net_in_addr *nexthop,
 					   uint32_t lifetime,
 					   uint8_t preference);
 
@@ -86,7 +86,7 @@ int net_route_ipv4_del(struct net_route_entry *entry);
  * @return number of routes deleted, <0 if error
  */
 int net_route_ipv4_del_by_nexthop(struct net_if *iface,
-				  struct net_in_addr *nexthop);
+				  const struct net_in_addr *nexthop);
 
 /**
  * @brief Update the route lifetime.

--- a/subsys/net/ip/route_ipv6.c
+++ b/subsys/net/ip/route_ipv6.c
@@ -91,7 +91,7 @@ struct net_route_entry *net_route_ipv6_lookup(struct net_if *iface,
 struct net_route_entry *net_route_ipv6_add(struct net_if *iface,
 					   struct net_in6_addr *addr,
 					   uint8_t prefix_len,
-					   struct net_in6_addr *nexthop,
+					   const struct net_in6_addr *nexthop,
 					   uint32_t lifetime,
 					   uint8_t preference)
 {
@@ -121,7 +121,7 @@ int net_route_ipv6_del(struct net_route_entry *route)
 }
 
 int net_route_ipv6_del_by_nexthop(struct net_if *iface,
-				  struct net_in6_addr *nexthop)
+				  const struct net_in6_addr *nexthop)
 {
 	struct net_addr addr = route_ipv6_addr(nexthop);
 

--- a/subsys/net/ip/route_ipv6.h
+++ b/subsys/net/ip/route_ipv6.h
@@ -62,7 +62,7 @@ static inline struct net_route_entry *net_route_ipv6_lookup(struct net_if *iface
 struct net_route_entry *net_route_ipv6_add(struct net_if *iface,
 					   struct net_in6_addr *addr,
 					   uint8_t prefix_len,
-					   struct net_in6_addr *nexthop,
+					   const struct net_in6_addr *nexthop,
 					   uint32_t lifetime,
 					   uint8_t preference);
 
@@ -84,7 +84,7 @@ int net_route_ipv6_del(struct net_route_entry *entry);
  * @return number of routes deleted, <0 if error
  */
 int net_route_ipv6_del_by_nexthop(struct net_if *iface,
-				  struct net_in6_addr *nexthop);
+				  const struct net_in6_addr *nexthop);
 
 /**
  * @brief Update the route lifetime.


### PR DESCRIPTION
As the IPv4/6 route API function do not modify the nexthop parameter, make it const.