### PR TITLE
arch: arm: fix extended frame check compilation for Cortex-A/R

### DIFF
--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -30,7 +30,7 @@ static void esf_dump(const struct arch_esf *esf)
 	EXCEPTION_DUMP(" xpsr:  0x%08x", esf->basic.xpsr);
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	bool extended_frame;
-#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO) && defined(EXC_RETURN_STACK_FRAME_TYPE_Msk)
 	extended_frame = ((esf->extra_info.exc_return & EXC_RETURN_STACK_FRAME_TYPE_Msk) ==
 			  EXC_RETURN_STACK_FRAME_TYPE_EXTENDED);
 #else


### PR DESCRIPTION
Fix a compilation error when CONFIG_EXTRA_EXCEPTION_INFO is enabled on platforms that do not define EXC_RETURN_STACK_FRAME_TYPE_Msk (which is only defined for Cortex-M).

For Cortex-A/R devices we just default to the same code path as before [bce6f0de636fb248bef3f135a2bdc119beb29556](https://github.com/zephyrproject-rtos/zephyr/commit/bce6f0de636fb248bef3f135a2bdc119beb29556?w=1)

Issue introduced in https://github.com/zephyrproject-rtos/zephyr/pull/111949 / bce6f0de636fb248bef3f135a2bdc119beb29556
Can be reproduced with
``
cmake -GNinja -DBOARD=qemu_cortex_a9/xc7z007s ../tests/subsys/debug/gdbstub
ninja
``
Failure in main can be seen here:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/29233319541/job/86763059718#step:12:716
