### PR TITLE
boards: nxp: imx952_evk: add M7 DDR board variant

### DIFF
--- a/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7_ddr.dts
+++ b/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7_ddr.dts
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include "imx952_evk_mimx9529_m7.dts"
+
+/ {
+	model = "NXP i.MX952 EVK board DDR variant";
+
+	chosen {
+		zephyr,sram = &ddr;
+		/delete-property/ zephyr,flash;
+	};
+
+	ddr: memory@80000000 {
+		device_type = "memory";
+		reg = <0x80000000 DT_SIZE_M(4)>;
+	};
+};

--- a/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7_ddr.yaml
+++ b/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7_ddr.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: imx952_evk/mimx9529/m7/ddr
+name: NXP i.MX952 EVK DDR variant
+type: mcu
+arch: arm
+ram: 4096
+toolchain:
+  - zephyr
+  - gnuarmemb
+supported:
+  - uart
+vendor: nxp

--- a/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7_ddr_defconfig
+++ b/boards/nxp/imx952_evk/imx952_evk_mimx9529_m7_ddr_defconfig
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright 2026 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# clock-related configurations
+CONFIG_CLOCK_CONTROL=y
+
+# serial interface-related configurations
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+CONFIG_UART_CONSOLE=y
+CONFIG_CONSOLE=y
+
+# SCMI-related configurations
+CONFIG_MBOX=y
+CONFIG_MBOX_INIT_PRIORITY=0
+CONFIG_ARM_SCMI=y
+CONFIG_ARM_SCMI_NXP_VENDOR_EXTENSIONS=y
+
+# kernel-related configurations
+CONFIG_XIP=n


### PR DESCRIPTION
Add DDR variant of the i.MX952 EVK board (M7 core). Using this variant, one can run Zephyr from DDR instead of ITCM/DTCM as it is the case for the M7 base board.