### PR TITLE
drivers: wifi: siwx91x: fix advanced scan dwell time handling

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
@@ -127,8 +127,10 @@ siwx91x_configure_scan_dwell_time(sl_wifi_scan_type_t scan_type, uint16_t dwell_
 			LOG_DBG("Ignoring per-call dwell times for background scan; "
 				"using CONFIG_WIFI_SILABS_SIWX91X_ADV_*_SCAN_DURATION");
 		}
-		dwell_time_active = CONFIG_WIFI_SILABS_SIWX91X_ADV_ACTIVE_SCAN_DURATION;
-		dwell_time_passive = CONFIG_WIFI_SILABS_SIWX91X_ADV_PASSIVE_SCAN_DURATION;
+		advanced_scan_config->active_channel_time =
+			CONFIG_WIFI_SILABS_SIWX91X_ADV_ACTIVE_SCAN_DURATION;
+		advanced_scan_config->passive_channel_time =
+			CONFIG_WIFI_SILABS_SIWX91X_ADV_PASSIVE_SCAN_DURATION;
 		return 0;
 	default:
 		return 0;


### PR DESCRIPTION
Advanced scan ignored the configured dwell times because the driver only updated local variables instead of the advanced scan configuration structure. Set the active and passive channel times on the advanced scan config directly.