### PR TITLE
manifest: update percepio

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -365,7 +365,7 @@ manifest:
       path: modules/lib/openthread
     - name: percepio
       path: modules/debug/percepio
-      revision: 57358a359d95fa7239d0dccd768f587ffc8f71bb
+      revision: 022c06f76d3e141aad98252fa9211665bf8ca027
       groups:
         - debug
     - name: picolibc


### PR DESCRIPTION
Update the percepio module to use TraceRecorder v4.12.0

Signed-off-by: Erik Tamlin [erik.tamlin@percepio.com](mailto:erik.tamlin@percepio.com)