### PR TITLE
wifi: nxp: Enable Kconfig REG ACCESS by default

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -1067,6 +1067,7 @@ config NXP_WIFI_MEM_ACCESS
 
 config NXP_WIFI_REG_ACCESS
 	bool
+	default y
 	help
 	  This option enables register access cmd in the Wi-Fi driver.
 


### PR DESCRIPTION
Enable CONFIG_NXP_WIFI_REG_ACCESS by default in Kconfig.nxp