### PR TITLE
provide compatibility to samples for the heimann board

### DIFF
--- a/boards/heimann/htpa_eval/htpa_eval-common.dtsi
+++ b/boards/heimann/htpa_eval/htpa_eval-common.dtsi
@@ -26,6 +26,7 @@
 		led0 = &led_g;
 		sw0 = &sw0_user_button;
 		watchdog0 = &wdt;
+		eeprom-0 = &eeprom;
 	};
 
 	chosen {
@@ -178,4 +179,20 @@
 
 zephyr_udc0: &usbhs {
 	status = "okay";
+};
+
+&twihs0 {
+	status = "okay";
+
+	pinctrl-0 = <&twihs0_default>;
+	pinctrl-names = "default";
+
+	eeprom: eeprom@50 {
+		compatible = "atmel,at24", "atmel,24mac402";
+		reg = <0x50>;
+		size = <256>;
+		pagesize = <8>;
+		address-width = <8>;
+		timeout = <5>;
+	};
 };

--- a/boards/heimann/htpa_eval/htpa_eval-common.dtsi
+++ b/boards/heimann/htpa_eval/htpa_eval-common.dtsi
@@ -22,6 +22,8 @@
 		cam-led-g = &cam_led_g;
 		cam-led-b = &cam_led_b;
 		cam-on = &cam_on;
+		/* compatibility to sample applications */
+		led0 = &led_g;
 		sw0 = &sw0_user_button;
 		watchdog0 = &wdt;
 	};

--- a/boards/heimann/htpa_eval/htpa_eval-common.dtsi
+++ b/boards/heimann/htpa_eval/htpa_eval-common.dtsi
@@ -175,3 +175,7 @@
 &pioc {
 	status = "okay";
 };
+
+zephyr_udc0: &usbhs {
+	status = "okay";
+};


### PR DESCRIPTION
with this commits we have compatibility to the samples of

- led / button
- usb (cdc, hid, ...)
- eeprom (reboot counter, ... )
- ethernet (was already working before)