### PR TITLE
Add RTC driver support for microchip pic32cmjh family

### DIFF
--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
@@ -27,6 +27,7 @@
 		led0 = &led0;
 		sw0 = &button0;
 		pwm-led0 = &pwm_led0;
+		rtc = &rtc;
 	};
 
 	leds {
@@ -249,5 +250,10 @@
 	compatible = "microchip,tcc-g1-counter";
 	max-bit-width = <24>;
 	prescaler = <4>;
+	status = "okay";
+};
+
+&rtc {
+	prescaler = <1024>;
 	status = "okay";
 };

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
@@ -20,6 +20,7 @@ supported:
   - pinctrl
   - pwm
   - reset
+  - rtc
   - uart
   - watchdog
 vendor: microchip

--- a/drivers/rtc/Kconfig.mchp
+++ b/drivers/rtc/Kconfig.mchp
@@ -1,5 +1,5 @@
-#Copyright (c) 2025 Microchip Technology Inc.
-#SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025-2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 config RTC_MCHP_G1
 	bool "Microchip RTC G1 driver"
@@ -22,3 +22,10 @@ config RTC_MCHP_MSS
 	depends on DT_HAS_MICROCHIP_RTC_MSS_ENABLED
 	help
 	  Enable RTC driver for Microchip MSS.
+
+config RTC_MCHP_SUPPORTS_DUAL_ALARM
+	bool
+	default y
+	depends on RTC_MCHP_G1 && !SOC_FAMILY_MICROCHIP_PIC32CM_JH
+	help
+	  RTC supports two alarms. PIC32CM JH only supports one alarm.

--- a/drivers/rtc/rtc_mchp_g1.c
+++ b/drivers/rtc/rtc_mchp_g1.c
@@ -34,7 +34,15 @@ LOG_MODULE_REGISTER(rtc_mchp_g1, CONFIG_RTC_LOG_LEVEL);
 	(RTC_ALARM_TIME_MASK_SECOND | RTC_ALARM_TIME_MASK_MINUTE | RTC_ALARM_TIME_MASK_HOUR |      \
 	 RTC_ALARM_TIME_MASK_MONTHDAY | RTC_ALARM_TIME_MASK_MONTH | RTC_ALARM_TIME_MASK_YEAR)
 
+/*
+ * PIC32CM JH RTC supports only one alarm (ALARM0/MASK0).
+ * Other families (SAM D5x/E5x, PIC32CK GC, PIC32CX SG) support two alarms.
+ */
+#ifdef CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM
 #define RTC_SUPPORTED_ALARM_INT_FLAGS (RTC_MODE2_INTFLAG_ALARM0_Msk | RTC_MODE2_INTFLAG_ALARM1_Msk)
+#else
+#define RTC_SUPPORTED_ALARM_INT_FLAGS (RTC_MODE2_INTFLAG_ALARM0_Msk)
+#endif
 #endif /* CONFIG_RTC_ALARM */
 
 /* Structure defining various time parameters for Microchip RTC driver. */
@@ -196,11 +204,15 @@ static void rtc_set_alarm_mask(rtc_registers_t *regs, uint16_t alarm_id, uint16_
 		regs->MODE2.RTC_MASK0 = (uint8_t)((regs->MODE2.RTC_MASK0 & ~RTC_MODE2_MASK0_Msk) |
 						  RTC_MODE2_MASK0_SEL(set_mask));
 		rtc_sync_busy(regs, RTC_MODE2_SYNCBUSY_MASK0_Msk);
-	} else if (alarm_id == RTC_MCHP_ALARM_2) {
+	}
+#ifdef CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM
+	else if (alarm_id == RTC_MCHP_ALARM_2) {
 		regs->MODE2.RTC_MASK1 = (uint8_t)((regs->MODE2.RTC_MASK1 & ~RTC_MODE2_MASK1_Msk) |
 						  RTC_MODE2_MASK1_SEL(set_mask));
 		rtc_sync_busy(regs, RTC_MODE2_SYNCBUSY_MASK1_Msk);
-	} else {
+	}
+#endif /* CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM */
+	else {
 		LOG_ERR("Invalid alarm_id: %u", alarm_id);
 	}
 }
@@ -212,10 +224,14 @@ static uint16_t rtc_get_alarm_mask(const rtc_registers_t *regs, uint16_t alarm_i
 	if (alarm_id == RTC_MCHP_ALARM_1) {
 		get_mask = (uint16_t)regs->MODE2.RTC_MASK0;
 		rtc_sync_busy(regs, RTC_MODE2_SYNCBUSY_MASK0_Msk);
-	} else if (alarm_id == RTC_MCHP_ALARM_2) {
+	}
+#ifdef CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM
+	else if (alarm_id == RTC_MCHP_ALARM_2) {
 		get_mask = (uint16_t)regs->MODE2.RTC_MASK1;
 		rtc_sync_busy(regs, RTC_MODE2_SYNCBUSY_MASK1_Msk);
-	} else {
+	}
+#endif /* CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM */
+	else {
 		LOG_ERR("Invalid alarm_id: %u", alarm_id);
 	}
 
@@ -225,29 +241,24 @@ static uint16_t rtc_get_alarm_mask(const rtc_registers_t *regs, uint16_t alarm_i
 static void rtc_set_alarm_time(rtc_registers_t *regs, uint16_t alarm_id,
 			       struct rtc_mchp_time *rtc_set_alarm)
 {
+	uint32_t alarm_val =
+		(uint32_t)((((RTC_TM_REFERENCE_YEAR + rtc_set_alarm->year) - RTC_REFERENCE_YEAR)
+			    << RTC_MODE2_CLOCK_YEAR_Pos) |
+			   ((RTC_ADJUST_MONTH(rtc_set_alarm->month)) << RTC_MODE2_CLOCK_MONTH_Pos) |
+			   (rtc_set_alarm->date_of_month << RTC_MODE2_CLOCK_DAY_Pos) |
+			   (rtc_set_alarm->hour << RTC_MODE2_CLOCK_HOUR_Pos) |
+			   (rtc_set_alarm->minute << RTC_MODE2_CLOCK_MINUTE_Pos) |
+			   (rtc_set_alarm->second << RTC_MODE2_CLOCK_SECOND_Pos));
+
 	if (alarm_id == RTC_MCHP_ALARM_1) {
-		regs->MODE2.RTC_ALARM0 =
-			(uint32_t)((((RTC_TM_REFERENCE_YEAR + rtc_set_alarm->year) -
-				     RTC_REFERENCE_YEAR)
-				    << RTC_MODE2_CLOCK_YEAR_Pos) |
-				   ((RTC_ADJUST_MONTH(rtc_set_alarm->month))
-				    << RTC_MODE2_CLOCK_MONTH_Pos) |
-				   (rtc_set_alarm->date_of_month << RTC_MODE2_CLOCK_DAY_Pos) |
-				   (rtc_set_alarm->hour << RTC_MODE2_CLOCK_HOUR_Pos) |
-				   (rtc_set_alarm->minute << RTC_MODE2_CLOCK_MINUTE_Pos) |
-				   (rtc_set_alarm->second << RTC_MODE2_CLOCK_SECOND_Pos));
-	} else if (alarm_id == RTC_MCHP_ALARM_2) {
-		regs->MODE2.RTC_ALARM1 =
-			(uint32_t)((((RTC_TM_REFERENCE_YEAR + rtc_set_alarm->year) -
-				     RTC_REFERENCE_YEAR)
-				    << RTC_MODE2_CLOCK_YEAR_Pos) |
-				   ((RTC_ADJUST_MONTH(rtc_set_alarm->month))
-				    << RTC_MODE2_CLOCK_MONTH_Pos) |
-				   (rtc_set_alarm->date_of_month << RTC_MODE2_CLOCK_DAY_Pos) |
-				   (rtc_set_alarm->hour << RTC_MODE2_CLOCK_HOUR_Pos) |
-				   (rtc_set_alarm->minute << RTC_MODE2_CLOCK_MINUTE_Pos) |
-				   (rtc_set_alarm->second << RTC_MODE2_CLOCK_SECOND_Pos));
-	} else {
+		regs->MODE2.RTC_ALARM0 = alarm_val;
+	}
+#ifdef CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM
+	else if (alarm_id == RTC_MCHP_ALARM_2) {
+		regs->MODE2.RTC_ALARM1 = alarm_val;
+	}
+#endif /* CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM */
+	else {
 		LOG_ERR("Invalid alarm_id: %u", alarm_id);
 	}
 
@@ -264,9 +275,13 @@ static void rtc_get_alarm_time(const rtc_registers_t *regs, uint16_t alarm_id,
 
 	if (alarm_id == RTC_MCHP_ALARM_1) {
 		dataClockCalendar = regs->MODE2.RTC_ALARM0;
-	} else if (alarm_id == RTC_MCHP_ALARM_2) {
+	}
+#ifdef CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM
+	else if (alarm_id == RTC_MCHP_ALARM_2) {
 		dataClockCalendar = regs->MODE2.RTC_ALARM1;
-	} else {
+	}
+#endif /* CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM */
+	else {
 		LOG_ERR("Invalid alarm_id: %u", alarm_id);
 	}
 	rtc_get_time->hour =
@@ -297,9 +312,13 @@ static void rtc_enable_interrupt(rtc_registers_t *regs, uint16_t alarm_id)
 
 	if (alarm_id == RTC_MCHP_ALARM_1) {
 		alarm_int = RTC_MODE2_INTENSET_ALARM0(1);
-	} else if (alarm_id == RTC_MCHP_ALARM_2) {
+	}
+#ifdef CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM
+	else if (alarm_id == RTC_MCHP_ALARM_2) {
 		alarm_int = RTC_MODE2_INTENSET_ALARM1(1);
-	} else {
+	}
+#endif /* CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM */
+	else {
 		LOG_ERR("Invalid alarm_id: %u", alarm_id);
 		return;
 	}
@@ -313,9 +332,13 @@ static void rtc_disable_interrupt(rtc_registers_t *regs, uint16_t alarm_id)
 
 	if (alarm_id == RTC_MCHP_ALARM_1) {
 		alarm_int = RTC_MODE2_INTENCLR_ALARM0(1);
-	} else if (alarm_id == RTC_MCHP_ALARM_2) {
+	}
+#ifdef CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM
+	else if (alarm_id == RTC_MCHP_ALARM_2) {
 		alarm_int = RTC_MODE2_INTENCLR_ALARM1(1);
-	} else {
+	}
+#endif /* CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM */
+	else {
 		LOG_ERR("Invalid alarm_id: %u", alarm_id);
 		return;
 	}
@@ -329,9 +352,13 @@ static uint16_t rtc_get_interrupt_flags(const rtc_registers_t *regs, uint16_t *a
 
 	if ((int_status & RTC_MODE2_INTFLAG_ALARM0_Msk) == RTC_MODE2_INTFLAG_ALARM0_Msk) {
 		*alarm_id = RTC_MCHP_ALARM_1;
-	} else if ((int_status & RTC_MODE2_INTFLAG_ALARM1_Msk) == RTC_MODE2_INTFLAG_ALARM1_Msk) {
+	}
+#ifdef CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM
+	else if ((int_status & RTC_MODE2_INTFLAG_ALARM1_Msk) == RTC_MODE2_INTFLAG_ALARM1_Msk) {
 		*alarm_id = RTC_MCHP_ALARM_2;
-	} else {
+	}
+#endif /* CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM */
+	else {
 		LOG_ERR("Invalid alarm interrupt flag detected");
 	}
 
@@ -340,10 +367,20 @@ static uint16_t rtc_get_interrupt_flags(const rtc_registers_t *regs, uint16_t *a
 
 static void rtc_clear_interrupt_flags(rtc_registers_t *regs, uint16_t alarm_id)
 {
-	uint16_t alarm_status =
-		((alarm_id == RTC_MCHP_ALARM_1)
-			 ? RTC_MODE2_INTFLAG_ALARM0_Msk
-			 : ((alarm_id == RTC_MCHP_ALARM_2) ? RTC_MODE2_INTFLAG_ALARM1_Msk : 0));
+	uint16_t alarm_status = 0;
+
+	if (alarm_id == RTC_MCHP_ALARM_1) {
+		alarm_status = RTC_MODE2_INTFLAG_ALARM0_Msk;
+	}
+#ifdef CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM
+	else if (alarm_id == RTC_MCHP_ALARM_2) {
+		alarm_status = RTC_MODE2_INTFLAG_ALARM1_Msk;
+	}
+#endif /* CONFIG_RTC_MCHP_SUPPORTS_DUAL_ALARM */
+	else {
+		LOG_ERR("Invalid alarm_id: %u", alarm_id);
+		return;
+	}
 
 	regs->MODE2.RTC_INTFLAG = alarm_status;
 }
@@ -356,7 +393,9 @@ static void rtc_clear_interrupt_flags(rtc_registers_t *regs, uint16_t alarm_id)
  */
 static inline uint16_t rtc_supported_alarm_int_flags(const rtc_registers_t *regs)
 {
-	return (RTC_MODE2_INTFLAG_ALARM0_Msk | RTC_MODE2_INTFLAG_ALARM1_Msk);
+	ARG_UNUSED(regs);
+
+	return RTC_SUPPORTED_ALARM_INT_FLAGS;
 }
 
 /*
@@ -532,7 +571,7 @@ static int rtc_mchp_set_alarm_time(const struct device *dev, uint16_t alarm_id, 
 				   const struct rtc_time *timeptr)
 {
 	const struct rtc_mchp_dev_config *const cfg = dev->config;
-	struct rtc_mchp_time rtc_time;
+	struct rtc_mchp_time alarm_time;
 	struct rtc_mchp_dev_data *data = dev->data;
 	uint16_t supported_mask;
 	uint16_t set_mask = 0;
@@ -558,20 +597,6 @@ static int rtc_mchp_set_alarm_time(const struct device *dev, uint16_t alarm_id, 
 		return -EINVAL;
 	}
 
-	/* Validate the provided RTC time */
-	if ((timeptr != NULL) && (rtc_utils_validate_rtc_time(timeptr, supported_mask) == false)) {
-		LOG_ERR("Invalid RTC time provided");
-		return -EINVAL;
-	}
-
-	/* If validation passed, set the RTC ALARM time */
-	rtc_time.second = timeptr->tm_sec;
-	rtc_time.minute = timeptr->tm_min;
-	rtc_time.hour = timeptr->tm_hour;
-	rtc_time.month = timeptr->tm_mon;
-	rtc_time.date_of_month = timeptr->tm_mday;
-	rtc_time.year = timeptr->tm_year;
-
 	/* Lock the semaphore before accessing the RTC. */
 	k_sem_take(&data->lock, K_FOREVER);
 
@@ -582,9 +607,23 @@ static int rtc_mchp_set_alarm_time(const struct device *dev, uint16_t alarm_id, 
 		/* If the alarm mask is zero, turn off the alarm */
 		rtc_set_alarm_mask(cfg->regs, alarm_id, RTC_MCHP_ALARM_MASK_SEL_OFF);
 	} else {
+		/* Validate the provided RTC time */
+		if (rtc_utils_validate_rtc_time(timeptr, supported_mask) == false) {
+			LOG_ERR("Invalid RTC time provided");
+			k_sem_give(&data->lock);
+			return -EINVAL;
+		}
+
+		/* If validation passed, set the RTC ALARM time */
+		alarm_time.second = timeptr->tm_sec;
+		alarm_time.minute = timeptr->tm_min;
+		alarm_time.hour = timeptr->tm_hour;
+		alarm_time.month = timeptr->tm_mon;
+		alarm_time.date_of_month = timeptr->tm_mday;
+		alarm_time.year = timeptr->tm_year;
 
 		/* Set the alarm time */
-		rtc_set_alarm_time(cfg->regs, alarm_id, &rtc_time);
+		rtc_set_alarm_time(cfg->regs, alarm_id, &alarm_time);
 
 		/* Enable the interrupt for the specified alarm ID */
 		set_mask = rtc_alarm_mask(alarm_mask);
@@ -679,7 +718,7 @@ static int rtc_mchp_set_clock_time(const struct device *dev, const struct rtc_ti
 {
 	struct rtc_mchp_dev_data *data = dev->data;
 	const struct rtc_mchp_dev_config *const cfg = dev->config;
-	struct rtc_mchp_time rtc_time;
+	struct rtc_mchp_time clock_time;
 
 	/* Check if rtc_time structure not null */
 	if (timeptr == NULL) {
@@ -696,17 +735,17 @@ static int rtc_mchp_set_clock_time(const struct device *dev, const struct rtc_ti
 #endif /* CONFIG_RTC_ALARM */
 
 		/* If validation passed, set the RTC time */
-		rtc_time.second = timeptr->tm_sec;
-		rtc_time.minute = timeptr->tm_min;
-		rtc_time.hour = timeptr->tm_hour;
-		rtc_time.month = timeptr->tm_mon;
-		rtc_time.date_of_month = timeptr->tm_mday;
-		rtc_time.year = timeptr->tm_year;
+		clock_time.second = timeptr->tm_sec;
+		clock_time.minute = timeptr->tm_min;
+		clock_time.hour = timeptr->tm_hour;
+		clock_time.month = timeptr->tm_mon;
+		clock_time.date_of_month = timeptr->tm_mday;
+		clock_time.year = timeptr->tm_year;
 
 		/* lock the semaphore before setting the RTC. */
 		k_sem_take(&data->lock, K_FOREVER);
 
-		rtc_set_clock_time(cfg->regs, &rtc_time);
+		rtc_set_clock_time(cfg->regs, &clock_time);
 
 		/* Unlock the semaphore before returning. */
 		k_sem_give(&data->lock);

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
@@ -124,6 +124,20 @@
 			status = "disabled";
 		};
 
+		rtc: rtc@40002400 {
+			compatible = "microchip,rtc-g1";
+			reg = <0x40002400 0x48>;
+			interrupts = <2 0>;
+			interrupt-names = "rtc-irq";
+			clocks = <&mclkperiph CLOCK_MCHP_MCLKPERIPH_ID_APBA_RTC>,
+				 <&rtcclock CLOCK_MCHP_RTC_ID>;
+			clock-names = "mclk", "rtcclk";
+			prescaler = <1>;
+			alarms-count = <1>;
+			cal-constant = <1048576>;
+			status = "disabled";
+		};
+
 		eic: interrupt-controller@40002800 {
 			compatible = "microchip,eic-g1-intc";
 			reg = <0x40002800 0x38>;

--- a/dts/bindings/rtc/microchip,rtc-g1.yaml
+++ b/dts/bindings/rtc/microchip,rtc-g1.yaml
@@ -1,4 +1,4 @@
-# Copyright(c) 2025 Microchip Technology Inc.
+# Copyright(c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 title: Microchip G1 RTC driver
@@ -12,14 +12,13 @@ description: |
   Group g1 RTC driver supports following hardware peripherals:
     - module name="RTC" id="U2250" version="2.1.0"
 
-  The node has the 'rtc' node label set in your SoC's devicetree, so you can
-  modify it like this:
-
+examples:
+  - |
     &rtc {
         /* your modifications go here */
     };
 
-    Example:
+  - |
     Correction in ppm = (FREQCORR.VALUE * 1e6 ppm) / (8192 * 128)
 
     &rtc {

--- a/dts/bindings/rtc/microchip,rtc-g1.yaml
+++ b/dts/bindings/rtc/microchip,rtc-g1.yaml
@@ -11,6 +11,7 @@ description: |
 
   Group g1 RTC driver supports following hardware peripherals:
     - module name="RTC" id="U2250" version="2.1.0"
+    - module name="RTC" id="03608" version="3a1"
 
 examples:
   - |

--- a/tests/drivers/rtc/rtc_api/boards/pic32cm_jh01_cpro.conf
+++ b/tests/drivers/rtc/rtc_api/boards/pic32cm_jh01_cpro.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_ALARM=y
+CONFIG_TEST_RTC_ALARM_TIME_MASK=63
+CONFIG_RTC_CALIBRATION=y


### PR DESCRIPTION
- Adds RTC node in dts
- Updates the binding yaml of rtc driver with the supported rtc ip version
- Update RTC G1 driver implementation to support PIC32CM_JH
- Updates the rtc prescaler to 1024 to get 1Hz clock
- Adds alias for rtc for enabling the samples.
- Adds the rtc tag in board.yaml for enabling CI to detect it for tests.
- Adds pic32cm_jh01_cpro.conf file for rtc_api test.