### PR TITLE
babblesim bt audio samples tests: Build and run with twister

### DIFF
--- a/samples/bluetooth/audio/bap_broadcast_source/tests.yaml
+++ b/samples/bluetooth/audio/bap_broadcast_source/tests.yaml
@@ -1,6 +1,9 @@
 sample:
   description: Bluetooth Low Energy Broadcast Audio Source sample
   name: Bluetooth Low Energy Broadcast Audio Source sample
+common:
+  tags:
+    - bluetooth
 tests:
   sample.bluetooth.audio.bap_broadcast_source:
     harness: bluetooth
@@ -12,7 +15,6 @@ tests:
     integration_platforms:
       - qemu_x86
       - nrf5340dk/nrf5340/cpuapp
-    tags: bluetooth
     sysbuild: true
   sample.bluetooth.audio.bap_broadcast_source.nrf5340_audio_dk_cpuapp.fem:
     harness: bluetooth
@@ -23,7 +25,6 @@ tests:
     extra_args:
       - DTC_OVERLAY_FILE=boards/nrf5340_audio_dk_nrf5340_cpuapp_nrf21540_ek.overlay
       - hci_ipc_DTC_OVERLAY_FILE=boards/nrf5340_audio_dk_nrf5340_cpunet_nrf21540_ek.overlay
-    tags: bluetooth
     sysbuild: true
   sample.bluetooth.audio.bap_broadcast_source.bt_ll_sw_split:
     harness: bluetooth
@@ -37,4 +38,33 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52840dongle/nrf52840
     extra_args: EXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf
-    tags: bluetooth
+  sample.bluetooth.audio.bap_broadcast_source.sequential.bsim:
+    depends_on: bsim
+    build_only: true
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    sysbuild: true
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-bt_ll_sw_split.conf;overlay-sequential.conf"
+      - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE="overlay-sequential.conf"
+      # Note the last provided EXTRA_CONF_FILE definition will be used by cmake
+    harness: bsim
+    harness_config:
+      bsim_exe_name: samples_bluetooth_audio_bap_broadcast_source_prj_conf_overlay-sequential_conf
+  sample.bluetooth.audio.bap_broadcast_source.interleaved.bsim:
+    depends_on: bsim
+    build_only: true
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    sysbuild: true
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-bt_ll_sw_split.conf;overlay-interleaved.conf"
+      - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE="overlay-interleaved.conf"
+      # Note the last provided EXTRA_CONF_FILE definition will be used by cmake
+    harness: bsim
+    harness_config:
+      bsim_exe_name: samples_bluetooth_audio_bap_broadcast_source_prj_conf_overlay-interleaved_conf

--- a/samples/bluetooth/audio/bap_unicast_server/tests.yaml
+++ b/samples/bluetooth/audio/bap_unicast_server/tests.yaml
@@ -1,26 +1,39 @@
 sample:
   description: Bluetooth Low Energy Audio Unicast Server sample
   name: Bluetooth Low Energy Audio Unicast Server sample
+common:
+  tags:
+    - bluetooth
 tests:
   sample.bluetooth.audio.unicast_server:
     harness: bluetooth
     platform_allow:
       - qemu_cortex_m3
       - qemu_x86
-      - nrf5340bsim/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp
       - native_sim
-    tags: bluetooth
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
     sysbuild: true
   sample.bluetooth.audio.unicast_server.bt_ll_sw_split:
     harness: bluetooth
     platform_allow:
-      - nrf52_bsim
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
     integration_platforms:
       - nrf52dk/nrf52832
     extra_args: EXTRA_CONF_FILE=overlay-bt_ll_sw_split.conf
-    tags: bluetooth
+  sample.bluetooth.audio.unicast_server.bsim:
+    depends_on: bsim
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    build_only: true
+    sysbuild: true
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-bt_ll_sw_split.conf"
+      - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE=""
+    harness: bsim
+    harness_config:
+      bsim_exe_name: samples_bluetooth_audio_bap_unicast_server_prj_conf

--- a/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  tests.bsim.bluetooth.audio_samples.bap_broadcast_sink:
+    timeout: 600
+    tags:
+      - bluetooth
+    depends_on: bsim
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    sysbuild: true
+    extra_args:
+      - CONF_FILE=${ZEPHYR_BASE}/samples/bluetooth/audio/bap_broadcast_sink/prj.conf
+      - EXTRA_CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/audio/bap_broadcast_sink/overlay-bt_ll_sw_split.conf"
+      - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE=""
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_audio_samples_bap_broadcast_sink_prj_conf
+    required_applications:
+      - application: sample.bluetooth.audio.bap_broadcast_source.interleaved.bsim
+        path: ${ZEPHYR_BASE}/samples/bluetooth/audio/bap_broadcast_source/
+      - application: sample.bluetooth.audio.bap_broadcast_source.sequential.bsim
+        path: ${ZEPHYR_BASE}/samples/bluetooth/audio/bap_broadcast_source/

--- a/tests/bsim/bluetooth/audio_samples/bap_unicast_client/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/bap_unicast_client/tests.yaml
@@ -1,0 +1,22 @@
+tests:
+  tests.bsim.bluetooth.audio_samples.bap_unicast_client:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    sysbuild: true
+    extra_args:
+      - CONF_FILE=${ZEPHYR_BASE}/samples/bluetooth/audio/bap_unicast_client/prj.conf
+      - EXTRA_CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/audio/bap_unicast_client/overlay-bt_ll_sw_split.conf"
+      - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/audio/bap_unicast_client/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf"
+      # Note the last provided EXTRA_CONF_FILE definition will be used by cmake
+    harness: bsim
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_audio_samples_bap_unicast_client_prj_conf
+    required_applications:
+      - application: sample.bluetooth.audio.unicast_server.bsim
+        path: ${ZEPHYR_BASE}/samples/bluetooth/audio/bap_unicast_server/

--- a/tests/bsim/bluetooth/audio_samples/cap/acceptor/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/cap/acceptor/tests.yaml
@@ -1,0 +1,28 @@
+common:
+  tags:
+    - bluetooth
+  depends_on: bsim
+  platform_allow:
+    - nrf52_bsim
+    - nrf5340bsim/nrf5340/cpuapp
+    - nrf54l15bsim/nrf54l15/cpuapp
+  sysbuild: true
+  build_only: true
+  harness: bsim
+  extra_args:
+    - CONF_FILE=${ZEPHYR_BASE}/samples/bluetooth/audio/cap_acceptor/prj.conf
+    - EXTRA_CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/audio/cap_acceptor/overlay-bt_ll_sw_split.conf"
+    - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/audio/cap_acceptor/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf"
+    # Note the last provided EXTRA_CONF_FILE definition will be used by cmake
+
+tests:
+  tests.bsim.bluetooth.audio_samples.cap.acceptor.broadcast:
+    extra_configs:
+      - CONFIG_SAMPLE_UNICAST=n
+      - CONFIG_SAMPLE_SCAN_SELF=y
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_audio_samples_cap_acceptor_broadcast_prj_conf
+
+  tests.bsim.bluetooth.audio_samples.cap.acceptor.unicast:
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_audio_samples_cap_acceptor_unicast_prj_conf

--- a/tests/bsim/bluetooth/audio_samples/cap/initiator/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/cap/initiator/tests.yaml
@@ -1,0 +1,27 @@
+common:
+  tags:
+    - bluetooth
+  depends_on: bsim
+  platform_allow:
+    - nrf52_bsim
+    - nrf5340bsim/nrf5340/cpuapp
+    - nrf54l15bsim/nrf54l15/cpuapp
+  sysbuild: true
+  build_only: true
+  harness: bsim
+  extra_args:
+    - CONF_FILE=${ZEPHYR_BASE}/samples/bluetooth/audio/cap_initiator/prj.conf
+    - EXTRA_CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/audio/cap_initiator/overlay-bt_ll_sw_split.conf"
+    - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/audio/cap_initiator/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf"
+    # Note the last provided EXTRA_CONF_FILE definition will be used by cmake
+
+tests:
+  tests.bsim.bluetooth.audio_samples.cap.initiator.broadcast:
+    extra_configs:
+      - CONFIG_SAMPLE_UNICAST=n
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_audio_samples_cap_initiator_broadcast_prj_conf
+
+  tests.bsim.bluetooth.audio_samples.cap.initiator.unicast:
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_audio_samples_cap_initiator_unicast_prj_conf

--- a/tests/bsim/bluetooth/audio_samples/cap/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/cap/tests.yaml
@@ -1,0 +1,33 @@
+common:
+  tags:
+    - bluetooth
+  depends_on: bsim
+  platform_allow:
+    - nrf52_bsim
+    - nrf5340bsim/nrf5340/cpuapp
+    - nrf54l15bsim/nrf54l15/cpuapp
+  harness: bsim
+  build: false
+
+tests:
+  tests.bsim.bluetooth.audio_samples.cap.broadcast:
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/cap_broadcast.sh
+    required_applications:
+      - application: tests.bsim.bluetooth.audio_samples.cap.initiator.broadcast
+        path: initiator
+      - application: tests.bsim.bluetooth.audio_samples.cap.acceptor.broadcast
+        path: acceptor
+
+  tests.bsim.bluetooth.audio_samples.cap.unicast:
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/cap_unicast.sh
+    required_applications:
+      - application: tests.bsim.bluetooth.audio_samples.cap.initiator.unicast
+        path: initiator
+      - application: tests.bsim.bluetooth.audio_samples.cap.acceptor.unicast
+        path: acceptor

--- a/tests/bsim/bluetooth/audio_samples/ccp/call_control_client/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/ccp/call_control_client/tests.yaml
@@ -1,0 +1,19 @@
+tests:
+  tests.bsim.bluetooth.audio_samples.ccp.client:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    sysbuild: true
+    build_only: true
+    harness: bsim
+    extra_args:
+      - CONF_FILE=${ZEPHYR_BASE}/samples/bluetooth/audio/ccp_call_control_client/prj.conf
+      - EXTRA_CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/audio/ccp_call_control_client/overlay-bt_ll_sw_split.conf"
+      - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/audio/ccp_call_control_client/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf"
+      # Note the last provided EXTRA_CONF_FILE definition will be used by cmake
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_audio_samples_ccp_call_control_client_prj_conf

--- a/tests/bsim/bluetooth/audio_samples/ccp/call_control_server/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/ccp/call_control_server/tests.yaml
@@ -1,0 +1,19 @@
+tests:
+  tests.bsim.bluetooth.audio_samples.ccp.server:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    sysbuild: true
+    build_only: true
+    harness: bsim
+    extra_args:
+      - CONF_FILE=${ZEPHYR_BASE}/samples/bluetooth/audio/ccp_call_control_server/prj.conf
+      - EXTRA_CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/audio/ccp_call_control_server/overlay-bt_ll_sw_split.conf"
+      - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE="${ZEPHYR_BASE}/samples/bluetooth/audio/ccp_call_control_server/boards/nrf5340_audio_dk_nrf5340_cpuapp.conf"
+      # Note the last provided EXTRA_CONF_FILE definition will be used by cmake
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_audio_samples_ccp_call_control_server_prj_conf

--- a/tests/bsim/bluetooth/audio_samples/ccp/tests.yaml
+++ b/tests/bsim/bluetooth/audio_samples/ccp/tests.yaml
@@ -1,0 +1,20 @@
+common:
+  tags:
+    - bluetooth
+  depends_on: bsim
+  platform_allow:
+    - nrf52_bsim
+    - nrf5340bsim/nrf5340/cpuapp
+    - nrf54l15bsim/nrf54l15/cpuapp
+  harness: bsim
+  build: false
+
+tests:
+  tests.bsim.bluetooth.audio_samples.ccp:
+    harness_config:
+      fixture: bsim_multi_test
+    required_applications:
+      - application: tests.bsim.bluetooth.audio_samples.ccp.client
+        path: call_control_client
+      - application: tests.bsim.bluetooth.audio_samples.ccp.server
+        path: call_control_server

--- a/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
@@ -24,6 +24,5 @@ app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-ticker_expire_info.conf sys
 app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_group.conf sysbuild=1 compile
 
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
-run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio_samples/compile.sh
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
@@ -26,6 +26,5 @@ app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-interleaved.conf  compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-ticker_expire_info.conf compile
 
 run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
-run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/audio_samples/compile.sh
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/compile.sh
+++ b/tests/bsim/bluetooth/compile.sh
@@ -13,7 +13,6 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # Note: We do not parallelize the call into the build of the host, ll and mesh images as those
 # are already building many images in parallel in themselves, and otherwise we would be
 # launching too many parallel builds which can lead to a too high system load.
-${ZEPHYR_BASE}/tests/bsim/bluetooth/audio_samples/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/ll/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/mesh/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh

--- a/tests/bsim/bluetooth/tests.nrf52bsim.txt
+++ b/tests/bsim/bluetooth/tests.nrf52bsim.txt
@@ -1,6 +1,5 @@
 # Search paths(s) for tests which will be run in the nrf52bsim
 # This file is used in CI to select which tests are run
-tests/bsim/bluetooth/audio_samples/
 tests/bsim/bluetooth/hci_uart/
 tests/bsim/bluetooth/ll/
 tests/bsim/bluetooth/mesh/

--- a/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
@@ -8,5 +8,4 @@ tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_sequential.sh
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
 tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
 tests/bsim/bluetooth/samples/peripheral_gap_svc/
-tests/bsim/bluetooth/audio_samples/
 tests/bsim/bluetooth/tester/

--- a/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
@@ -10,4 +10,3 @@ tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_sequential.sh
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
 tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
 tests/bsim/bluetooth/samples/peripheral_gap_svc/
-tests/bsim/bluetooth/audio_samples/

--- a/tests/bsim/ci.bt.sh
+++ b/tests/bsim/ci.bt.sh
@@ -15,6 +15,8 @@ TWISTER_OPTIONS="-vv --fixture bsim_multi_test --no-clean --force-color --inline
 
 ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/audio/
 
+${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/audio_samples/
+
 ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/host/
 
 # nrf52_bsim set:


### PR DESCRIPTION
For background and motivation see https://github.com/zephyrproject-rtos/zephyr/pull/113101

This PR changes the BT audio samples bsim tests to be both built and run using twister.
This means that users which have Babblesim installed can run these tests with twister in a quite comparable way to single device test. For example:
twister -T tests/bsim/bluetooth/audio_samples/ -vv --fixture bsim_multi_test

Note these tests can still be run with run_parallel.sh as before. Just now the default test list used by CI does not include them.

Related to:
* https://github.com/zephyrproject-rtos/zephyr/pull/113225
* https://github.com/zephyrproject-rtos/zephyr/pull/113244
* https://github.com/zephyrproject-rtos/zephyr/pull/113101