### PR TITLE
babblesim bt tester: Build and run with twister

### DIFF
--- a/tests/bluetooth/tester/tests.yaml
+++ b/tests/bluetooth/tester/tests.yaml
@@ -12,13 +12,15 @@ tests:
     tags: bluetooth
     harness: bluetooth
   bluetooth.general.tester_bsim:
+    sysbuild: true
     platform_allow:
       - nrf52_bsim/native
+      - nrf5340bsim/nrf5340/cpuapp
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bluetooth_tester_prj_conf
     extra_args:
-      - EXTRA_CONF_FILE="overlay-bt_ll_sw_split.conf"
+      - platform:nrf52_bsim/native:EXTRA_CONF_FILE="overlay-bt_ll_sw_split.conf"
   bluetooth.general.tester.nxp:
     # Disabling monolithic since CI environment doesn't use blobs
     build_only: true
@@ -39,13 +41,6 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     tags: bluetooth
     sysbuild: true
-  bluetooth.general.tester_hci_ipc_bsim:
-    platform_allow:
-      - nrf5340bsim/nrf5340/cpuapp
-    harness: bsim
-    harness_config:
-      bsim_exe_name: tests_bluetooth_tester_prj_conf
-    sysbuild: true
   bluetooth.audio.tester:
     build_only: true
     platform_allow:
@@ -63,23 +58,16 @@ tests:
     sysbuild: true
   bluetooth.audio.tester_bsim:
     build_only: true
+    sysbuild: true
     platform_allow:
       - nrf52_bsim/native
-    extra_args:
-      - EXTRA_CONF_FILE="overlay-le-audio.conf;overlay-bt_ll_sw_split.conf"
-    harness: bsim
-    harness_config:
-      bsim_exe_name: tests_bluetooth_tester_le_audio_prj_conf
-  bluetooth.audio.tester_hci_ipc_bsim:
-    build_only: true
-    platform_allow:
       - nrf5340bsim/nrf5340/cpuapp
     extra_args:
-      - EXTRA_CONF_FILE="overlay-le-audio.conf"
+      - platform:nrf52_bsim/native:EXTRA_CONF_FILE="overlay-le-audio.conf;overlay-bt_ll_sw_split.conf"
+      - platform:nrf5340bsim/nrf5340/cpuapp:EXTRA_CONF_FILE="overlay-le-audio.conf"
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bluetooth_tester_le_audio_prj_conf
-    sysbuild: true
   bluetooth.general.tester_mesh:
     build_only: true
     platform_allow:

--- a/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
@@ -12,8 +12,6 @@ export BOARD="${BOARD:-nrf5340bsim/nrf5340/cpuapp}"
 
 source ${ZEPHYR_BASE}/tests/bsim/compile.source
 
-${ZEPHYR_BASE}/tests/bsim/bluetooth/tester/compile.sh
-
 app=tests/bsim/bluetooth/ll/conn conf_file=prj_split_privacy.conf sysbuild=1  compile
 app=tests/bsim/bluetooth/ll/throughput sysbuild=1 compile
 app=tests/bsim/bluetooth/ll/throughput conf_overlay=overlay-no_phy_update.conf sysbuild=1 compile

--- a/tests/bsim/bluetooth/compile.sh
+++ b/tests/bsim/bluetooth/compile.sh
@@ -19,6 +19,5 @@ ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
 if [ ${BOARD} == "nrf52_bsim/native" ]; then
 	${ZEPHYR_BASE}/tests/bsim/bluetooth/hci_uart/compile.sh
 fi
-${ZEPHYR_BASE}/tests/bsim/bluetooth/tester/compile.sh
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/tester/tests.yaml
+++ b/tests/bsim/bluetooth/tester/tests.yaml
@@ -1,10 +1,33 @@
+common:
+  tags:
+    - bluetooth
+  harness: bsim
+  depends_on: bsim
+
 tests:
-  bluetooth.tester_bsim:
+  bluetooth.tests.bsim.tester.image:
     build_only: true
-    tags:
-      - bluetooth
-    harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_tester_prj_conf
     platform_allow:
       - nrf52_bsim/native
+
+  bluetooth.tests.bsim.tester:
+    timeout: 1200
+    build: false
+    platform_allow:
+      - nrf52_bsim/native
+      - nrf5340bsim/nrf5340/cpuapp
+    harness_config:
+      fixture: bsim_multi_test
+    required_applications:
+      - application: bluetooth.general.tester_bsim
+        path: ${ZEPHYR_BASE}/tests/bluetooth/tester/
+      - application: bluetooth.audio.tester_bsim
+        path: ${ZEPHYR_BASE}/tests/bluetooth/tester/
+      - application: bluetooth.tests.bsim.tester.image
+        platform: nrf52_bsim/native
+        # We only want to build the tests/bsim/bluetooth/tester/ application for the
+        # nrf52_bsim/native board as we do not gain anything from running this application for the
+        # nrf5340bsim_nrf5340_cpuapp and it is not worth the added complexity to run it with
+        # anything but nrf52_bsim/native

--- a/tests/bsim/bluetooth/tests.nrf52bsim.txt
+++ b/tests/bsim/bluetooth/tests.nrf52bsim.txt
@@ -4,4 +4,3 @@ tests/bsim/bluetooth/hci_uart/
 tests/bsim/bluetooth/ll/
 tests/bsim/bluetooth/mesh/
 tests/bsim/bluetooth/samples/
-tests/bsim/bluetooth/tester/

--- a/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
@@ -8,4 +8,3 @@ tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_sequential.sh
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
 tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
 tests/bsim/bluetooth/samples/peripheral_gap_svc/
-tests/bsim/bluetooth/tester/

--- a/tests/bsim/ci.bt.sh
+++ b/tests/bsim/ci.bt.sh
@@ -19,6 +19,8 @@ ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/audio_
 
 ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/host/
 
+${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/tester/
+
 # nrf52_bsim set:
 nice tests/bsim/bluetooth/compile.sh
 


### PR DESCRIPTION
For background and motivation see https://github.com/zephyrproject-rtos/zephyr/pull/113101

This PR changes the BT tester bsim tests to be both built and run using twister.
This means that users which have Babblesim installed can run these tests with twister in a quite comparable way to single device test. For example:
twister -T tests/bsim/bluetooth/tester/ -vv --fixture bsim_multi_test

Note these tests can still be run with run_parallel.sh as before. Just now the default test list used by CI does not include them.

Related to:
* https://github.com/zephyrproject-rtos/zephyr/pull/113395
* https://github.com/zephyrproject-rtos/zephyr/pull/113225
* https://github.com/zephyrproject-rtos/zephyr/pull/113244
* https://github.com/zephyrproject-rtos/zephyr/pull/113101