### PR TITLE
Add DPLPMTUD over UDP options support

### DIFF
--- a/include/zephyr/net/dplpmtud.h
+++ b/include/zephyr/net/dplpmtud.h
@@ -92,6 +92,25 @@ void net_dplpmtud_set_path_max_plpmtu(struct net_dplpmtud_path *path,
 				      uint16_t max_plpmtu);
 
 /**
+ * @brief Restart the PLPMTU search for a path.
+ *
+ * Resets the search to start again from the base PLPMTU up to the entry's
+ * current ceiling and clears any stale in-flight probe state, so a newly
+ * (re)started prober re-validates the path from scratch.
+ *
+ * The per-destination DPLPMTUD state is shared and outlives an individual
+ * transport/socket. A prior run may have left it in a terminal state that
+ * yields no further probes: either the search completed (validated PLPMTU has
+ * reached the ceiling) or it collapsed after repeated probe loss with no
+ * responder. In both cases a plain re-enable would send no probes, so a
+ * transport that reattaches to a destination should call this when it
+ * re-enables probing.
+ *
+ * @param path Initialized path handle
+ */
+void net_dplpmtud_reopen_path_search(struct net_dplpmtud_path *path);
+
+/**
  * @brief Get the currently validated PLPMTU for a path.
  *
  * The path must have been initialized with net_dplpmtud_init_path(). This

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -31,6 +31,7 @@
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_stats.h>
+#include <zephyr/net/dplpmtud.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -433,6 +434,25 @@ __net_socket struct net_context {
 			uint16_t mds;
 			/** MRDS (Maximum Reassembled Datagram Size), 0 = not set */
 			struct net_udp_opt_mrds mrds;
+#if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+			/** DPLPMTUD (RFC 9869) per-socket state. */
+			struct {
+				/** Generic engine path handle (per destination). */
+				struct net_dplpmtud_path path;
+				/** Probe retransmit / raise timer. */
+				struct k_work_delayable timer;
+				/** Token of the outstanding probe, 0 = none. */
+				uint32_t token;
+				/** Size of the outstanding probe. */
+				uint16_t probe_size;
+				/** DPLPMTUD enabled on this socket. */
+				bool enabled;
+				/** Application echoes RES itself (no auto-echo). */
+				bool app_respond;
+				/** BASE_PLPMTU connectivity has been confirmed. */
+				bool base_confirmed;
+			} dplpmtud;
+#endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
 		} udp_opt;
 #endif
 	} options;
@@ -1404,6 +1424,8 @@ enum net_context_option {
 	NET_OPT_UDP_OPT_UCMP      = 38, /**< UDP options: UNSAFE Compression */
 	NET_OPT_UDP_OPT_UENC      = 39, /**< UDP options: UNSAFE Encryption */
 	NET_OPT_UDP_OPT_UEXP      = 40, /**< UDP options: UNSAFE Experimental */
+	NET_OPT_UDP_OPT_DPLPMTUD  = 41, /**< UDP options: DPLPMTUD enable (RFC 9869) */
+	NET_OPT_UDP_OPT_DPLPMTUD_APP_RESPOND = 42, /**< UDP options: app echoes RES itself */
 };
 
 /**
@@ -1433,6 +1455,30 @@ int net_context_set_option(struct net_context *context,
 int net_context_get_option(struct net_context *context,
 			   enum net_context_option option,
 			   void *value, uint32_t *len);
+
+/**
+ * @brief Enable or disable DPLPMTUD (RFC 9869) on a UDP context.
+ *
+ * When enabled, the stack probes the path MTU using UDP options and answers
+ * incoming probes. Must be a UDP context.
+ *
+ * @param context Network context (proto must be UDP)
+ * @param enable  true to enable DPLPMTUD, false to disable
+ *
+ * @return 0 on success, negative errno otherwise.
+ */
+#if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD) || defined(__DOXYGEN__)
+int net_context_set_udp_dplpmtud(struct net_context *context, bool enable);
+#else
+static inline int net_context_set_udp_dplpmtud(struct net_context *context,
+					       bool enable)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(enable);
+
+	return -ENOTSUP;
+}
+#endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
 
 /**
  * @typedef net_context_cb_t

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -412,6 +412,7 @@ __net_socket struct net_context {
 		/** Enable RX, TX or both timestamps of packets send through sockets. */
 		uint8_t timestamping;
 #endif
+
 #if defined(CONFIG_NET_CONTEXT_LINGER)
 		/** Socket SO_LINGER option. When enabled (l_onoff != 0) with a
 		 * zero timeout (l_linger == 0), close() aborts the connection
@@ -419,6 +420,21 @@ __net_socket struct net_context {
 		 */
 		struct net_linger linger;
 #endif /* CONFIG_NET_CONTEXT_LINGER */
+
+#if defined(CONFIG_NET_UDP_OPTIONS)
+		struct {
+			/** Bitmask of enabled UDP option features (NET_UDP_OPT_F_*) */
+			uint32_t enabled;
+			/** Bitmask of required incoming UDP option features (NET_UDP_OPT_F_*) */
+			uint32_t required;
+			/** true = drop all packets with UDP options on this socket */
+			bool drop_all_opts;
+			/** MDS (Maximum Datagram Size) value to advertise, 0 = not set */
+			uint16_t mds;
+			/** MRDS (Maximum Reassembled Datagram Size), 0 = not set */
+			struct net_udp_opt_mrds mrds;
+		} udp_opt;
+#endif
 	} options;
 
 	/** Protocol (UDP, TCP or IEEE 802.3 protocol value) */
@@ -1374,6 +1390,20 @@ enum net_context_option {
 	NET_OPT_RECV_HOPLIMIT     = 24, /**< Receive hop limit information */
 	NET_OPT_DONT_FRAGMENT     = 25, /**< Disable local IP fragmentation */
 	NET_OPT_LINGER            = 26, /**< Socket linger (SO_LINGER) */
+	NET_OPT_UDP_OPT           = 27, /**< UDP options master enable (RFC 9868) */
+	NET_OPT_UDP_OPT_OCS       = 28, /**< UDP options: Option Checksum */
+	NET_OPT_UDP_OPT_APC       = 29, /**< UDP options: Additional Payload Checksum */
+	NET_OPT_UDP_OPT_FRAG      = 30, /**< UDP options: Fragmentation */
+	NET_OPT_UDP_OPT_MDS       = 31, /**< UDP options: Maximum Datagram Size */
+	NET_OPT_UDP_OPT_MRDS      = 32, /**< UDP options: Maximum Reassembled Datagram Size */
+	NET_OPT_UDP_OPT_REQ       = 33, /**< UDP options: Echo Request */
+	NET_OPT_UDP_OPT_RES       = 34, /**< UDP options: Echo Response */
+	NET_OPT_UDP_OPT_TIME      = 35, /**< UDP options: Timestamp */
+	NET_OPT_UDP_OPT_AUTH      = 36, /**< UDP options: Authentication */
+	NET_OPT_UDP_OPT_EXP       = 37, /**< UDP options: Experimental */
+	NET_OPT_UDP_OPT_UCMP      = 38, /**< UDP options: UNSAFE Compression */
+	NET_OPT_UDP_OPT_UENC      = 39, /**< UDP options: UNSAFE Encryption */
+	NET_OPT_UDP_OPT_UEXP      = 40, /**< UDP options: UNSAFE Experimental */
 };
 
 /**

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -451,6 +451,20 @@ __net_socket struct net_context {
 				bool app_respond;
 				/** BASE_PLPMTU connectivity has been confirmed. */
 				bool base_confirmed;
+				/** Deferred RES-echo work (runs off the RX path). */
+				struct k_work echo_work;
+				/** Peer to send the pending RES to. */
+				struct net_sockaddr_storage echo_peer;
+				/** Length of @ref echo_peer. */
+				net_socklen_t echo_peerlen;
+				/** Token to echo in the pending RES. */
+				uint32_t echo_token;
+				/** A RES echo is queued in @ref echo_work. */
+				bool echo_pending;
+				/** Uptime (ms) of the last auto RES echo; used to
+				 * rate-limit echoes (0 = none sent yet).
+				 */
+				uint32_t echo_last_ms;
 			} dplpmtud;
 #endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
 		} udp_opt;

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -647,6 +647,29 @@ struct net_udp_hdr {
 	uint16_t chksum;
 } __packed;
 
+/** @brief UDP Options Maximum Reassembled Datagram Size (MRDS), RFC 9868.
+ *
+ * Value type for the @c ZSOCK_UDP_OPT_MRDS socket option and the
+ * @c ZSOCK_UDP_OPT_CMSG_MRDS ancillary control message.
+ */
+struct net_udp_opt_mrds {
+	/** Maximum reassembled datagram size in bytes. */
+	uint16_t size;
+	/** Maximum number of fragments, or 0 if unspecified. */
+	uint8_t segs;
+};
+
+/** @brief UDP Options Timestamp (TIME), RFC 9868.
+ *
+ * Value type for the @c ZSOCK_UDP_OPT_CMSG_TIME ancillary control message.
+ */
+struct net_udp_opt_time {
+	/** Timestamp value of the sender. */
+	uint32_t tsval;
+	/** Timestamp echo reply (last @c tsval received from the peer). */
+	uint32_t tsecr;
+};
+
 struct net_tcp_hdr {
 	uint16_t src_port;
 	uint16_t dst_port;

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -143,10 +143,18 @@ struct net_pkt {
 
 	/** @cond ignore */
 
+	/* TCP or UDP are mutually exclusive so they can share the same memory */
+	union {
 #if defined(CONFIG_NET_TCP)
-	/** Allow placing the packet into sys_slist_t */
-	sys_snode_t next;
+		/** Allow placing the packet into sys_slist_t */
+		sys_snode_t next;
 #endif
+#if defined(CONFIG_NET_UDP_OPTIONS)
+		/** Length of the UDP options surplus area (bytes after UDP user data) */
+		uint16_t udp_opt_surplus_len;
+#endif
+	};
+
 #if defined(CONFIG_NET_PKT_ORIG_IFACE)
 	struct net_if *orig_iface; /* Original network interface */
 #endif
@@ -501,6 +509,26 @@ static inline void net_pkt_set_vpn_peer_id(struct net_pkt *pkt,
 	pkt->vpn.peer_id = peer_id;
 }
 #endif /* CONFIG_NET_VPN */
+
+#if defined(CONFIG_NET_UDP_OPTIONS)
+static inline uint16_t net_pkt_udp_opt_surplus_len(struct net_pkt *pkt)
+{
+	return pkt->udp_opt_surplus_len;
+}
+
+static inline void net_pkt_set_udp_opt_surplus_len(struct net_pkt *pkt,
+						   uint16_t len)
+{
+	pkt->udp_opt_surplus_len = len;
+}
+#else
+static inline uint16_t net_pkt_udp_opt_surplus_len(struct net_pkt *pkt)
+{
+	return 0;
+}
+
+#define net_pkt_set_udp_opt_surplus_len(...)
+#endif /* CONFIG_NET_UDP_OPTIONS */
 
 static inline uint8_t net_pkt_family(struct net_pkt *pkt)
 {

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -1007,10 +1007,61 @@ int zsock_sendmsg_all(int sock, const struct net_msghdr *msg, int flags,
 /** @} */
 
 /**
+ * @name UDP level options (NET_IPPROTO_UDP)
+ * @{
+ */
+/* Socket options for NET_IPPROTO_UDP level */
+
+/** Enable/disable all UDP options (int boolean), these are from RFC 9868 */
+#define ZSOCK_UDP_OPT      1
+/** Enable/disable UDP OCS (int boolean) */
+#define ZSOCK_UDP_OPT_OCS  2
+/** Enable/disable UDP APC option (int boolean) */
+#define ZSOCK_UDP_OPT_APC  3
+/** Enable/disable UDP fragmentation option (int boolean) */
+#define ZSOCK_UDP_OPT_FRAG 4
+/** Set/get UDP MDS option value (uint16_t) */
+#define ZSOCK_UDP_OPT_MDS  5
+/** Set/get UDP MRDS option value (struct net_udp_opt_mrds) */
+#define ZSOCK_UDP_OPT_MRDS 6
+/** Enable/disable UDP REQ option (int boolean) */
+#define ZSOCK_UDP_OPT_REQ  7
+/** Enable/disable UDP RES option (int boolean) */
+#define ZSOCK_UDP_OPT_RES  8
+/** Enable/disable UDP TIME option (int boolean) */
+#define ZSOCK_UDP_OPT_TIME 9
+/** Enable/disable UDP AUTH option (int boolean) */
+#define ZSOCK_UDP_OPT_AUTH 10
+/** Enable/disable UDP EXP option (int boolean) */
+#define ZSOCK_UDP_OPT_EXP  11
+/** Enable/disable UDP UCMP option (int boolean) */
+#define ZSOCK_UDP_OPT_UCMP 12
+/** Enable/disable UDP UENC option (int boolean) */
+#define ZSOCK_UDP_OPT_UENC 13
+/** Enable/disable UDP UEXP option (int boolean) */
+#define ZSOCK_UDP_OPT_UEXP 14
+
+/** cmsg types for IPPROTO_UDP level in ancillary data */
+#define ZSOCK_UDP_OPT_CMSG_APC    1  /**< uint32_t CRC32c */
+#define ZSOCK_UDP_OPT_CMSG_MDS    2  /**< uint16_t peer MDS */
+#define ZSOCK_UDP_OPT_CMSG_MRDS   3  /**< struct net_udp_opt_mrds */
+#define ZSOCK_UDP_OPT_CMSG_REQ    4  /**< uint32_t echo request token */
+#define ZSOCK_UDP_OPT_CMSG_RES    5  /**< uint32_t echo response token */
+#define ZSOCK_UDP_OPT_CMSG_TIME   6  /**< struct net_udp_opt_time */
+
+/** @} */
+
+/**
  * @defgroup ipv4_socket_options Socket options for IPv4
  * @ingroup bsd_sockets
  * @{
  */
+
+/**
+ * @name IPv4 level options (NET_IPPROTO_IP)
+ * @{
+ */
+
 /* Socket options for NET_IPPROTO_IP level */
 /** Set or receive the Type-Of-Service value for an outgoing packet. */
 #define ZSOCK_IP_TOS 1
@@ -1064,11 +1115,16 @@ int zsock_sendmsg_all(int sock, const struct net_msghdr *msg, int flags,
 /** Clamp down the global port range for a given socket */
 #define ZSOCK_IP_LOCAL_PORT_RANGE 51
 
-/** @} */
+/** @} */ /* for @name */
+/** @} */ /* for @defgroup */
 
 /**
  * @defgroup ipv6_socket_options Socket options for IPv6
  * @ingroup bsd_sockets
+ * @{
+ */
+/**
+ * @name IPv6 level options (NET_IPPROTO_IPV6)
  * @{
  */
 /* Socket options for NET_IPPROTO_IPV6 level */
@@ -1160,7 +1216,8 @@ int zsock_sendmsg_all(int sock, const struct net_msghdr *msg, int flags,
 
 /** Set or receive the traffic class value for an outgoing packet. */
 #define ZSOCK_IPV6_TCLASS 67
-/** @} */
+/** @} */ /* for @name */
+/** @} */ /* for @defgroup */
 
 /**
  * @name Backlog size for listen()

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -1040,6 +1040,10 @@ int zsock_sendmsg_all(int sock, const struct net_msghdr *msg, int flags,
 #define ZSOCK_UDP_OPT_UENC 13
 /** Enable/disable UDP UEXP option (int boolean) */
 #define ZSOCK_UDP_OPT_UEXP 14
+/** Enable/disable DPLPMTUD over UDP options, RFC 9869 (int boolean) */
+#define ZSOCK_UDP_OPT_DPLPMTUD 15
+/** Let the application echo REQ->RES itself instead of the stack (int boolean) */
+#define ZSOCK_UDP_OPT_DPLPMTUD_APP_RESPOND 16
 
 /** cmsg types for IPPROTO_UDP level in ancillary data */
 #define ZSOCK_UDP_OPT_CMSG_APC    1  /**< uint32_t CRC32c */

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -485,6 +485,52 @@ config NET_UDP_OPTIONS
 	  RFC 9868. This allows sending and receiving UDP options
 	  in the surplus area of IP datagrams.
 
+config NET_UDP_OPTIONS_DPLPMTUD
+	bool "DPLPMTUD over UDP options (RFC 9869) [EXPERIMENTAL]"
+	depends on NET_UDP_OPTIONS
+	depends on NET_PMTU_DPLPMTUD
+	select EXPERIMENTAL
+	help
+	  Enable Datagram Packetization Layer Path MTU Discovery
+	  (RFC 8899) for plain UDP sockets using UDP options (RFC 9869).
+	  When enabled on a socket, the stack probes the path for the
+	  largest usable datagram size using the Request (REQ) and
+	  Response (RES) UDP options and reports the result via
+	  getsockopt(IP_MTU/IPV6_MTU). It also answers incoming probes by
+	  echoing the REQ token back in a RES option.
+
+config NET_UDP_OPTIONS_DPLPMTUD_PROBE_TIMEOUT_MS
+	int "UDP options DPLPMTUD probe timeout (ms)"
+	depends on NET_UDP_OPTIONS_DPLPMTUD
+	default 1000
+	help
+	  Time to wait for a probe Response (RES) before a probe is
+	  declared lost and retransmitted (RFC 8899 PROBE_TIMER). UDP has
+	  no round-trip estimate, so a fixed value is used.
+
+config NET_UDP_OPTIONS_DPLPMTUD_RAISE_TIMEOUT_MS
+	int "UDP options DPLPMTUD raise timer (ms)"
+	depends on NET_UDP_OPTIONS_DPLPMTUD
+	default 600000
+	help
+	  Once the search completes, how long to wait before probing again
+	  to detect a possible increase in the path MTU (RFC 8899
+	  PMTU_RAISE_TIMER). Default is 10 minutes.
+
+config NET_UDP_OPTIONS_DPLPMTUD_ECHO_MIN_INTERVAL_MS
+	int "UDP options DPLPMTUD minimum RES echo interval (ms)"
+	depends on NET_UDP_OPTIONS_DPLPMTUD
+	default 50
+	help
+	  Minimum time between consecutive auto-generated Response (RES)
+	  echoes on a socket acting as a DPLPMTUD responder. The stack
+	  answers a Request (REQ) by sending a RES to the datagram source
+	  address, so an off-path attacker flooding spoofed-source REQs
+	  could otherwise use the socket to reflect traffic (the RES is
+	  never larger than the REQ, so there is no amplification). This
+	  rate limit caps that reflection. Set to 0 to disable the limit,
+	  e.g. on a server that must answer many distinct probers at once.
+
 if NET_UDP
 
 module = NET_UDP

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -476,6 +476,15 @@ config NET_UDP_MISSING_CHECKSUM
 	  for IPv4 and on reception only, since Zephyr will always compute the
 	  UDP checksum in transmission path.
 
+config NET_UDP_OPTIONS
+	bool "UDP transport options (RFC 9868) [EXPERIMENTAL]"
+	depends on NET_UDP
+	select EXPERIMENTAL
+	help
+	  Enable support for UDP transport options as defined in
+	  RFC 9868. This allows sending and receiving UDP options
+	  in the surplus area of IP datagrams.
+
 if NET_UDP
 
 module = NET_UDP

--- a/subsys/net/ip/dplpmtud.c
+++ b/subsys/net/ip/dplpmtud.c
@@ -229,8 +229,12 @@ static inline void sync_search_bounds_locked(struct net_dplpmtud_entry *entry)
 {
 	entry->validated_plpmtu = MIN(entry->validated_plpmtu, entry->max_plpmtu);
 	entry->search_low = entry->validated_plpmtu;
-	entry->search_high = MIN(entry->search_high, entry->max_plpmtu);
-	entry->search_high = MAX(entry->search_high, entry->search_low);
+	/* Track the ceiling both up and down: raising max_plpmtu (e.g. once the
+	 * transport supplies the link capability or the PMTU cache reports a
+	 * larger limit) must reopen the search above the validated size, not
+	 * just clamp it down on PTB-style reductions.
+	 */
+	entry->search_high = MAX(entry->max_plpmtu, entry->search_low);
 
 	if (entry->probe_size <= entry->validated_plpmtu ||
 	    entry->probe_size > entry->search_high) {
@@ -446,11 +450,63 @@ int net_dplpmtud_init_path(struct net_dplpmtud_path *path,
 void net_dplpmtud_set_path_max_plpmtu(struct net_dplpmtud_path *path,
 				      uint16_t max_plpmtu)
 {
+	struct net_dplpmtud_entry *entry;
+
 	if (path == NULL || !path->in_use) {
 		return;
 	}
 
+	k_mutex_lock(&lock, K_FOREVER);
+
 	path->max_plpmtu = normalize_path_max_plpmtu(max_plpmtu);
+
+	/* Raise the shared per-destination ceiling so the search can extend up
+	 * to this path's capability. The entry is created at BASE_PLPMTU and
+	 * get_path_limit() still clamps each probe to this path's own limit, so
+	 * only ever grow the entry here, never shrink it (another path/transport
+	 * to the same destination may support more).
+	 */
+	if (max_plpmtu != 0U) {
+		entry = get_path_entry(path, false, false);
+		if (entry != NULL &&
+		    normalize_max_plpmtu(entry->base_plpmtu, max_plpmtu) >
+			    entry->max_plpmtu) {
+			entry->max_plpmtu =
+				normalize_max_plpmtu(entry->base_plpmtu, max_plpmtu);
+			sync_search_bounds_locked(entry);
+			update_state_locked(entry);
+		}
+	}
+
+	k_mutex_unlock(&lock);
+}
+
+void net_dplpmtud_reopen_path_search(struct net_dplpmtud_path *path)
+{
+	struct net_dplpmtud_entry *entry;
+
+	if (path == NULL || !path->in_use) {
+		return;
+	}
+
+	k_mutex_lock(&lock, K_FOREVER);
+
+	entry = get_path_entry(path, false, false);
+	if (entry != NULL) {
+		/* Restart the search from the base PLPMTU up to the entry's
+		 * current ceiling. A previous run may have left the shared entry
+		 * in a terminal state that yields no further probes: either the
+		 * search completed (validated == max, e.g. a looped-back or
+		 * responsive path) or it collapsed the search range down to the
+		 * validated size (all probes lost with no responder). Both cases
+		 * would make a plain re-enable send nothing, so re-validate the
+		 * path from scratch while keeping the configured base/ceiling.
+		 */
+		init_entry_defaults_locked(entry, entry->base_plpmtu,
+					   entry->max_plpmtu);
+	}
+
+	k_mutex_unlock(&lock);
 }
 
 int net_dplpmtud_get_path_mtu(struct net_dplpmtud_path *path)

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -694,6 +694,17 @@ int net_context_unref(struct net_context *context)
 		return old_rc - 1;
 	}
 
+#if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+	/* Stop any DPLPMTUD prober/responder before the context is released.
+	 * The prober arms a k_work_delayable embedded in the context; if it is
+	 * left running the timer keeps sending probes on a freed context and,
+	 * once the slot is reused, re-initializing the same delayable corrupts
+	 * the kernel timeout queue. net_context_set_udp_dplpmtud() is a no-op
+	 * for non-UDP contexts and for UDP contexts without DPLPMTUD enabled.
+	 */
+	(void)net_context_set_udp_dplpmtud(context, false);
+#endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
+
 	k_mutex_lock(&context->lock, K_FOREVER);
 
 	if (context->conn_handler) {
@@ -2543,35 +2554,90 @@ static inline void context_finalize_udp_options(struct net_context *context, str
 #endif /* CONFIG_NET_UDP_OPTIONS */
 
 #if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+static void udp_dplpmtud_kick(struct net_context *context);
+static void udp_dplpmtud_timer_work(struct k_work *work);
 static void udp_dplpmtud_echo_work(struct k_work *work);
+
+/* Largest PLPMTU (UDP payload size) that the local interface can carry, used
+ * to bound the DPLPMTUD search so probes are never larger than the link MTU.
+ */
+static uint16_t udp_dplpmtud_link_cap(struct net_context *context)
+{
+	struct net_if *iface = net_context_get_iface(context);
+	uint16_t overhead = sizeof(struct net_udp_hdr);
+	int mtu;
+
+	if (iface == NULL) {
+		return NET_DPLPMTUD_BASE_PLPMTU;
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV6) &&
+	    net_context_get_family(context) == NET_AF_INET6) {
+		overhead += sizeof(struct net_ipv6_hdr);
+	} else {
+		overhead += sizeof(struct net_ipv4_hdr);
+	}
+
+	mtu = net_if_get_mtu(iface);
+	if (mtu <= (int)overhead) {
+		return NET_DPLPMTUD_BASE_PLPMTU;
+	}
+
+	return (uint16_t)(mtu - overhead);
+}
 
 int net_context_set_udp_dplpmtud(struct net_context *context, bool enable)
 {
+	int ret = 0;
+
 	if (net_context_get_proto(context) != NET_IPPROTO_UDP) {
 		return -ENOPROTOOPT;
 	}
 
 	k_mutex_lock(&context->lock, K_FOREVER);
 
+	if (enable == context->options.udp_opt.dplpmtud.enabled) {
+		goto out;
+	}
+
 	if (enable) {
+		k_work_init_delayable(&context->options.udp_opt.dplpmtud.timer,
+				      udp_dplpmtud_timer_work);
 		k_work_init(&context->options.udp_opt.dplpmtud.echo_work,
 			    udp_dplpmtud_echo_work);
+		context->options.udp_opt.dplpmtud.token = 0U;
 		context->options.udp_opt.dplpmtud.echo_pending = false;
+		context->options.udp_opt.dplpmtud.enabled = true;
+
+		/* The responder role (echoing REQ as RES) works on any enabled
+		 * socket. Active probing additionally needs a fixed destination,
+		 * so it only starts once a remote address has been set (a
+		 * connect()ed UDP socket).
+		 */
+		if ((context->flags & NET_CONTEXT_REMOTE_ADDR_SET) != 0) {
+			ret = net_dplpmtud_init_path(
+				&context->options.udp_opt.dplpmtud.path,
+				&context->remote,
+				udp_dplpmtud_link_cap(context));
+			if (ret < 0) {
+				context->options.udp_opt.dplpmtud.enabled = false;
+				goto out;
+			}
+
+			udp_dplpmtud_kick(context);
+		}
 	} else {
+		context->options.udp_opt.dplpmtud.enabled = false;
+		context->options.udp_opt.dplpmtud.token = 0U;
 		context->options.udp_opt.dplpmtud.echo_pending = false;
+		(void)k_work_cancel_delayable(&context->options.udp_opt.dplpmtud.timer);
 		(void)k_work_cancel(&context->options.udp_opt.dplpmtud.echo_work);
 	}
 
-	context->options.udp_opt.dplpmtud.enabled = enable;
-
-	/* Path setup, probe-timer arming and the probing/echo state machine
-	 * are wired up in a subsequent step; enabling here records the
-	 * request and gates the responder from echoing REQ options.
-	 */
-
+out:
 	k_mutex_unlock(&context->lock);
 
-	return 0;
+	return ret;
 }
 #endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
 
@@ -3458,6 +3524,189 @@ static bool context_allow_udp_options(struct net_context *context, struct net_pk
 }
 
 #if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+/* Build and send a DPLPMTUD probe: a payload-less UDP datagram to the connected
+ * peer carrying a REQ option with @token, padded through the surplus area to
+ * @size bytes, with the Don't Fragment bit set (RFC 9869).
+ */
+static int udp_dplpmtud_send_probe(struct net_context *context, uint16_t size,
+				   uint32_t token)
+{
+	net_sa_family_t family = net_context_get_family(context);
+	struct net_udp_opt_info opts = {
+		.present = NET_UDP_OPT_F_REQ,
+		.req_token = token,
+		.pad_to_surplus = size,
+	};
+	struct net_pkt *pkt;
+	int ret;
+
+	pkt = context_alloc_pkt(context, family, (size_t)size + 1U, K_NO_WAIT);
+	if (pkt == NULL) {
+		return -ENOMEM;
+	}
+
+	net_pkt_set_dont_fragment(pkt, true);
+
+	if (IS_ENABLED(CONFIG_NET_IPV6) && family == NET_AF_INET6) {
+		ret = context_create_ipv6_new(context, pkt, NULL,
+					      &net_sin6(&context->remote)->sin6_addr,
+					      true);
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && family == NET_AF_INET) {
+		ret = context_create_ipv4_new(context, pkt, NULL,
+					      &net_sin(&context->remote)->sin_addr,
+					      true);
+	} else {
+		ret = -EAFNOSUPPORT;
+	}
+
+	if (ret < 0) {
+		goto fail;
+	}
+
+	ret = bind_default(context);
+	if (ret < 0) {
+		goto fail;
+	}
+
+	ret = net_udp_create(pkt,
+			     net_sin((struct net_sockaddr *)&context->local)->sin_port,
+			     net_sin(&context->remote)->sin_port);
+	if (ret < 0) {
+		goto fail;
+	}
+
+	ret = net_udp_opt_append(pkt, context, &opts);
+	if (ret < 0) {
+		goto fail;
+	}
+
+	context_finalize_packet(context, family, pkt);
+
+	ret = net_send_data(pkt);
+	if (ret < 0) {
+		goto fail;
+	}
+
+	return 0;
+
+fail:
+	net_pkt_unref(pkt);
+	return ret;
+}
+
+/* Decide whether to send the next probe and (re)arm the probe/raise timer.
+ * Must be called with context->lock held.
+ */
+static void udp_dplpmtud_kick(struct net_context *context)
+{
+	struct net_dplpmtud_path *path = &context->options.udp_opt.dplpmtud.path;
+	struct k_work_delayable *timer = &context->options.udp_opt.dplpmtud.timer;
+	uint32_t token;
+	int size;
+	int ret;
+
+	if (!context->options.udp_opt.dplpmtud.enabled) {
+		return;
+	}
+
+	/* A probe of ours is still outstanding; wait for RES or timeout. */
+	if (context->options.udp_opt.dplpmtud.token != 0U) {
+		return;
+	}
+
+	if (net_dplpmtud_path_probe_in_flight(path)) {
+		/* Another transport is probing the shared per-destination entry
+		 * (RFC 9869 coexistence); back off and re-check later.
+		 */
+		(void)k_work_reschedule(timer,
+			K_MSEC(CONFIG_NET_UDP_OPTIONS_DPLPMTUD_PROBE_TIMEOUT_MS));
+		return;
+	}
+
+	size = net_dplpmtud_get_path_probe_size(path);
+	if (size <= 0) {
+		/* Search complete (or nothing to do): schedule a periodic raise
+		 * probe to detect a later PMTU increase.
+		 */
+		(void)k_work_reschedule(timer,
+			K_MSEC(CONFIG_NET_UDP_OPTIONS_DPLPMTUD_RAISE_TIMEOUT_MS));
+		return;
+	}
+
+	ret = net_dplpmtud_on_path_probe_sent(path, (uint16_t)size);
+	if (ret == -EALREADY) {
+		(void)k_work_reschedule(timer,
+			K_MSEC(CONFIG_NET_UDP_OPTIONS_DPLPMTUD_PROBE_TIMEOUT_MS));
+		return;
+	} else if (ret == -EMSGSIZE) {
+		net_dplpmtud_set_path_max_plpmtu(path, (uint16_t)(size - 1));
+		(void)k_work_reschedule(timer, K_NO_WAIT);
+		return;
+	} else if (ret < 0) {
+		return;
+	}
+
+	/* RFC 9869: the probe token must be unpredictable so an off-path
+	 * attacker cannot forge a RES and confirm a bogus PLPMTU. Prefer the
+	 * CSPRNG and fall back to the non-cryptographic RNG only if it is not
+	 * available.
+	 */
+#if defined(CONFIG_CSPRNG_ENABLED)
+	if (sys_csrand_get(&token, sizeof(token)) != 0) {
+		token = sys_rand32_get();
+	}
+#else
+	token = sys_rand32_get();
+#endif
+	if (token == 0U) {
+		token = 1U;
+	}
+
+	ret = udp_dplpmtud_send_probe(context, (uint16_t)size, token);
+	if (ret < 0) {
+		net_dplpmtud_on_path_probe_lost(path, (uint16_t)size);
+		if (ret == -EMSGSIZE) {
+			net_dplpmtud_set_path_max_plpmtu(path, (uint16_t)(size - 1));
+		}
+
+		(void)k_work_reschedule(timer,
+			K_MSEC(CONFIG_NET_UDP_OPTIONS_DPLPMTUD_PROBE_TIMEOUT_MS));
+		return;
+	}
+
+	context->options.udp_opt.dplpmtud.token = token;
+	context->options.udp_opt.dplpmtud.probe_size = (uint16_t)size;
+
+	(void)k_work_reschedule(timer,
+		K_MSEC(CONFIG_NET_UDP_OPTIONS_DPLPMTUD_PROBE_TIMEOUT_MS));
+}
+
+static void udp_dplpmtud_timer_work(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct net_context *context = CONTAINER_OF(dwork, struct net_context,
+					options.udp_opt.dplpmtud.timer);
+
+	k_mutex_lock(&context->lock, K_FOREVER);
+
+	if (!context->options.udp_opt.dplpmtud.enabled) {
+		goto out;
+	}
+
+	if (context->options.udp_opt.dplpmtud.token != 0U) {
+		/* Outstanding probe timed out: declare it lost. */
+		net_dplpmtud_on_path_probe_lost(
+			&context->options.udp_opt.dplpmtud.path,
+			context->options.udp_opt.dplpmtud.probe_size);
+		context->options.udp_opt.dplpmtud.token = 0U;
+	}
+
+	udp_dplpmtud_kick(context);
+
+out:
+	k_mutex_unlock(&context->lock);
+}
+
 /* Send a UDP options Response (RES) datagram echoing @token back to the source
  * of a received Request (REQ), reusing the normal sendmsg path with a synthetic
  * ZSOCK_UDP_OPT_CMSG_RES control message and no user payload.
@@ -3605,6 +3854,28 @@ static void context_udp_dplpmtud_rx(struct net_context *context,
 		return;
 	}
 
+	/* Prober: a returned RES that matches our outstanding probe token
+	 * confirms that probe size; advance the DPLPMTUD state machine and
+	 * launch the next probe.
+	 */
+	if ((info.present & NET_UDP_OPT_F_RES) != 0U &&
+	    context->options.udp_opt.dplpmtud.token != 0U &&
+	    info.res_token == context->options.udp_opt.dplpmtud.token) {
+		net_dplpmtud_on_path_probe_acked(
+			&context->options.udp_opt.dplpmtud.path,
+			context->options.udp_opt.dplpmtud.probe_size);
+		context->options.udp_opt.dplpmtud.token = 0U;
+		/* Launch the next probe from the timer work rather than
+		 * transmitting synchronously in the RX path.
+		 */
+		(void)k_work_reschedule(&context->options.udp_opt.dplpmtud.timer,
+					K_NO_WAIT);
+	}
+
+	/* Responder: echo a received REQ token back as RES, unless the
+	 * application has taken over the echo. The transmit is deferred to a
+	 * work item so it never runs in the RX path or under context->lock.
+	 */
 	if ((info.present & NET_UDP_OPT_F_REQ) != 0U &&
 	    !context->options.udp_opt.dplpmtud.app_respond &&
 	    udp_dplpmtud_echo_allowed(context)) {

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2542,6 +2542,28 @@ static inline void context_finalize_udp_options(struct net_context *context, str
 }
 #endif /* CONFIG_NET_UDP_OPTIONS */
 
+#if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+int net_context_set_udp_dplpmtud(struct net_context *context, bool enable)
+{
+	if (net_context_get_proto(context) != NET_IPPROTO_UDP) {
+		return -ENOPROTOOPT;
+	}
+
+	k_mutex_lock(&context->lock, K_FOREVER);
+
+	context->options.udp_opt.dplpmtud.enabled = enable;
+
+	/* Path setup, probe-timer arming and the probing/echo state machine
+	 * are wired up in a subsequent step; enabling here records the
+	 * request and gates the responder from echoing REQ options.
+	 */
+
+	k_mutex_unlock(&context->lock);
+
+	return 0;
+}
+#endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
+
 static void context_finalize_packet(struct net_context *context,
 				    net_sa_family_t family,
 				    struct net_pkt *pkt)
@@ -4621,6 +4643,58 @@ static int get_context_udp_opt(struct net_context *context,
 
 	return 0;
 }
+
+#if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+static int set_context_udp_opt_dplpmtud(struct net_context *context,
+					enum net_context_option option,
+					const void *value, uint32_t len)
+{
+	int val;
+	int ret;
+
+	ret = udp_opt_read_int(value, len, &val);
+	if (ret < 0) {
+		return ret;
+	}
+
+	switch (option) {
+	case NET_OPT_UDP_OPT_DPLPMTUD:
+		return net_context_set_udp_dplpmtud(context, val != 0);
+	case NET_OPT_UDP_OPT_DPLPMTUD_APP_RESPOND:
+		context->options.udp_opt.dplpmtud.app_respond = (val != 0);
+		return 0;
+	default:
+		return -ENOPROTOOPT;
+	}
+}
+
+static int get_context_udp_opt_dplpmtud(struct net_context *context,
+					enum net_context_option option,
+					void *value, uint32_t *len)
+{
+	int val;
+
+	if (value == NULL || len == NULL || *len < sizeof(int)) {
+		return -EINVAL;
+	}
+
+	switch (option) {
+	case NET_OPT_UDP_OPT_DPLPMTUD:
+		val = context->options.udp_opt.dplpmtud.enabled;
+		break;
+	case NET_OPT_UDP_OPT_DPLPMTUD_APP_RESPOND:
+		val = context->options.udp_opt.dplpmtud.app_respond;
+		break;
+	default:
+		return -ENOPROTOOPT;
+	}
+
+	memcpy(value, &val, sizeof(val));
+	*len = sizeof(val);
+
+	return 0;
+}
+#endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
 #endif /* CONFIG_NET_UDP_OPTIONS */
 
 int net_context_set_option(struct net_context *context,
@@ -4741,6 +4815,12 @@ int net_context_set_option(struct net_context *context,
 	case NET_OPT_UDP_OPT_UEXP:
 		ret = set_context_udp_opt(context, option, value, len);
 		break;
+#if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+	case NET_OPT_UDP_OPT_DPLPMTUD:
+	case NET_OPT_UDP_OPT_DPLPMTUD_APP_RESPOND:
+		ret = set_context_udp_opt_dplpmtud(context, option, value, len);
+		break;
+#endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
 #endif /* CONFIG_NET_UDP_OPTIONS */
 	default:
 		ret = -ENOPROTOOPT;
@@ -4862,6 +4942,12 @@ int net_context_get_option(struct net_context *context,
 	case NET_OPT_UDP_OPT_UEXP:
 		ret = get_context_udp_opt(context, option, value, len);
 		break;
+#if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+	case NET_OPT_UDP_OPT_DPLPMTUD:
+	case NET_OPT_UDP_OPT_DPLPMTUD_APP_RESPOND:
+		ret = get_context_udp_opt_dplpmtud(context, option, value, len);
+		break;
+#endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
 #endif /* CONFIG_NET_UDP_OPTIONS */
 	default:
 		ret = -ENOPROTOOPT;

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2543,6 +2543,8 @@ static inline void context_finalize_udp_options(struct net_context *context, str
 #endif /* CONFIG_NET_UDP_OPTIONS */
 
 #if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+static void udp_dplpmtud_echo_work(struct k_work *work);
+
 int net_context_set_udp_dplpmtud(struct net_context *context, bool enable)
 {
 	if (net_context_get_proto(context) != NET_IPPROTO_UDP) {
@@ -2550,6 +2552,15 @@ int net_context_set_udp_dplpmtud(struct net_context *context, bool enable)
 	}
 
 	k_mutex_lock(&context->lock, K_FOREVER);
+
+	if (enable) {
+		k_work_init(&context->options.udp_opt.dplpmtud.echo_work,
+			    udp_dplpmtud_echo_work);
+		context->options.udp_opt.dplpmtud.echo_pending = false;
+	} else {
+		context->options.udp_opt.dplpmtud.echo_pending = false;
+		(void)k_work_cancel(&context->options.udp_opt.dplpmtud.echo_work);
+	}
 
 	context->options.udp_opt.dplpmtud.enabled = enable;
 
@@ -3446,6 +3457,166 @@ static bool context_allow_udp_options(struct net_context *context, struct net_pk
 #endif /* CONFIG_NET_UDP_OPTIONS */
 }
 
+#if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+/* Send a UDP options Response (RES) datagram echoing @token back to the source
+ * of a received Request (REQ), reusing the normal sendmsg path with a synthetic
+ * ZSOCK_UDP_OPT_CMSG_RES control message and no user payload.
+ */
+/* Record the peer and token of a received REQ so the RES can be echoed from a
+ * work item instead of synchronously in the RX path (see udp_dplpmtud_echo_work).
+ * Must be called with context->lock held.
+ */
+static int udp_dplpmtud_stash_echo(struct net_context *context,
+				   union net_ip_header *ip_hdr,
+				   union net_proto_header *proto_hdr,
+				   uint32_t token)
+{
+	struct net_sockaddr_storage *peer =
+		&context->options.udp_opt.dplpmtud.echo_peer;
+
+	if (proto_hdr->udp == NULL) {
+		return -EINVAL;
+	}
+
+	(void)memset(peer, 0, sizeof(*peer));
+
+	if (IS_ENABLED(CONFIG_NET_IPV6) &&
+	    net_context_get_family(context) == NET_AF_INET6) {
+		struct net_sockaddr_in6 *p = (struct net_sockaddr_in6 *)peer;
+
+		p->sin6_family = NET_AF_INET6;
+		p->sin6_port = proto_hdr->udp->src_port;
+		memcpy(&p->sin6_addr, ip_hdr->ipv6->src, sizeof(struct net_in6_addr));
+		context->options.udp_opt.dplpmtud.echo_peerlen =
+			sizeof(struct net_sockaddr_in6);
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
+		   net_context_get_family(context) == NET_AF_INET) {
+		struct net_sockaddr_in *p = (struct net_sockaddr_in *)peer;
+
+		p->sin_family = NET_AF_INET;
+		p->sin_port = proto_hdr->udp->src_port;
+		memcpy(&p->sin_addr, ip_hdr->ipv4->src, sizeof(struct net_in_addr));
+		context->options.udp_opt.dplpmtud.echo_peerlen =
+			sizeof(struct net_sockaddr_in);
+	} else {
+		return -EAFNOSUPPORT;
+	}
+
+	context->options.udp_opt.dplpmtud.echo_token = token;
+	context->options.udp_opt.dplpmtud.echo_pending = true;
+
+	return 0;
+}
+
+/* Rate-limit auto RES echoes so a flood of (possibly spoofed-source) REQs
+ * cannot turn this socket into a traffic reflector (RFC 9869). The RES is never
+ * larger than the REQ, so there is no amplification; this only bounds the
+ * reflection rate. Returns true (and records the time) when an echo is allowed.
+ * Must be called with context->lock held.
+ */
+static bool udp_dplpmtud_echo_allowed(struct net_context *context)
+{
+#if CONFIG_NET_UDP_OPTIONS_DPLPMTUD_ECHO_MIN_INTERVAL_MS > 0
+	uint32_t now = k_uptime_get_32();
+	uint32_t last = context->options.udp_opt.dplpmtud.echo_last_ms;
+
+	if (last != 0U &&
+	    (now - last) < CONFIG_NET_UDP_OPTIONS_DPLPMTUD_ECHO_MIN_INTERVAL_MS) {
+		return false;
+	}
+
+	/* Avoid the 0 "none sent yet" sentinel when uptime is exactly 0. */
+	context->options.udp_opt.dplpmtud.echo_last_ms = (now == 0U) ? 1U : now;
+#else
+	ARG_UNUSED(context);
+#endif
+	return true;
+}
+
+/* Send the RES datagram stashed by udp_dplpmtud_stash_echo(). Runs on the system
+ * workqueue so the transmit never happens in the RX path or under a held lock.
+ */
+static void udp_dplpmtud_echo_work(struct k_work *work)
+{
+	struct net_context *context = CONTAINER_OF(work, struct net_context,
+					options.udp_opt.dplpmtud.echo_work);
+	struct net_sockaddr_storage peer;
+	net_socklen_t peerlen;
+	uint32_t token;
+	struct net_msghdr msg = { 0 };
+	struct net_cmsghdr *cmsg;
+	union {
+		struct net_cmsghdr hdr;
+		unsigned char buf[NET_CMSG_SPACE(sizeof(uint32_t))];
+	} cmsgbuf;
+	int ret;
+
+	k_mutex_lock(&context->lock, K_FOREVER);
+
+	if (!context->options.udp_opt.dplpmtud.enabled ||
+	    !context->options.udp_opt.dplpmtud.echo_pending) {
+		k_mutex_unlock(&context->lock);
+		return;
+	}
+
+	peer = context->options.udp_opt.dplpmtud.echo_peer;
+	peerlen = context->options.udp_opt.dplpmtud.echo_peerlen;
+	token = context->options.udp_opt.dplpmtud.echo_token;
+	context->options.udp_opt.dplpmtud.echo_pending = false;
+
+	k_mutex_unlock(&context->lock);
+
+	(void)memset(&cmsgbuf, 0, sizeof(cmsgbuf));
+	cmsg = (struct net_cmsghdr *)cmsgbuf.buf;
+	cmsg->cmsg_len = NET_CMSG_LEN(sizeof(token));
+	cmsg->cmsg_level = NET_IPPROTO_UDP;
+	cmsg->cmsg_type = ZSOCK_UDP_OPT_CMSG_RES;
+	memcpy(NET_CMSG_DATA(cmsg), &token, sizeof(token));
+
+	msg.msg_name = &peer;
+	msg.msg_namelen = peerlen;
+	msg.msg_control = cmsgbuf.buf;
+	msg.msg_controllen = sizeof(cmsgbuf.buf);
+
+	ret = net_context_sendmsg(context, &msg, 0, NULL, K_NO_WAIT, NULL);
+	if (ret < 0) {
+		NET_DBG("Failed to send UDP options RES (%d)", ret);
+	}
+}
+
+/* Handle DPLPMTUD-relevant UDP options on a received datagram. Currently this
+ * implements the responder role: echo a received REQ token back as RES unless
+ * the application has taken over the echo. The prober side (matching a returned
+ * RES to an outstanding probe) is wired up together with the probe state
+ * machine in a later commit.
+ */
+static void context_udp_dplpmtud_rx(struct net_context *context,
+				    struct net_pkt *pkt,
+				    union net_ip_header *ip_hdr,
+				    union net_proto_header *proto_hdr)
+{
+	struct net_udp_opt_info info;
+
+	if (net_pkt_udp_opt_surplus_len(pkt) == 0U) {
+		return;
+	}
+
+	if (net_udp_opt_parse(pkt, &info) < 0) {
+		return;
+	}
+
+	if ((info.present & NET_UDP_OPT_F_REQ) != 0U &&
+	    !context->options.udp_opt.dplpmtud.app_respond &&
+	    udp_dplpmtud_echo_allowed(context)) {
+		if (udp_dplpmtud_stash_echo(context, ip_hdr, proto_hdr,
+					    info.req_token) == 0) {
+			(void)k_work_submit(
+				&context->options.udp_opt.dplpmtud.echo_work);
+		}
+	}
+}
+#endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
+
 enum net_verdict net_context_packet_received(struct net_conn *conn,
 					     struct net_pkt *pkt,
 					     union net_ip_header *ip_hdr,
@@ -3469,6 +3640,13 @@ enum net_verdict net_context_packet_received(struct net_conn *conn,
 	if (!context_allow_udp_options(context, pkt)) {
 		goto unlock;
 	}
+
+#if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+	if (net_context_get_proto(context) == NET_IPPROTO_UDP &&
+	    context->options.udp_opt.dplpmtud.enabled) {
+		context_udp_dplpmtud_rx(context, pkt, ip_hdr, proto_hdr);
+	}
+#endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
 
 	if (!context->recv_cb) {
 		goto unlock;

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2624,6 +2624,25 @@ int net_context_set_udp_dplpmtud(struct net_context *context, bool enable)
 				goto out;
 			}
 
+			/* Raise the shared per-destination entry's ceiling to
+			 * the local link capacity so the search can probe above
+			 * BASE_PLPMTU (the entry is created at base). Mirrors the
+			 * QUIC DPLPMTUD driver.
+			 */
+			net_dplpmtud_set_path_max_plpmtu(
+				&context->options.udp_opt.dplpmtud.path,
+				udp_dplpmtud_link_cap(context));
+
+			/* The per-destination DPLPMTUD state is shared and
+			 * outlives the context. A prior prober to the same
+			 * destination may have exhausted the search (all probes
+			 * lost with no responder), collapsing the search range so
+			 * a plain re-enable would send no probes. Reopen it so the
+			 * freshly enabled prober actively probes again.
+			 */
+			net_dplpmtud_reopen_path_search(
+				&context->options.udp_opt.dplpmtud.path);
+
 			udp_dplpmtud_kick(context);
 		}
 	} else {

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2257,6 +2257,129 @@ static int context_write_data(struct net_pkt *pkt, const void *buf,
 	return ret;
 }
 
+#if defined(CONFIG_NET_UDP_OPTIONS)
+static int context_parse_udp_option_cmsgs(const struct net_msghdr *msg,
+					  struct net_udp_opt_info *opts)
+{
+	struct net_cmsghdr *cmsg, *prev;
+
+	if (msg == NULL || opts == NULL || msg->msg_control == NULL ||
+	    msg->msg_controllen == 0U) {
+		return 0;
+	}
+
+	for (prev = NULL, cmsg = NET_CMSG_FIRSTHDR((struct net_msghdr *)msg);
+	     cmsg != NULL && prev != cmsg;
+	     prev = cmsg, cmsg = NET_CMSG_NXTHDR((struct net_msghdr *)msg, cmsg)) {
+		if (cmsg->cmsg_len == 0U) {
+			break;
+		}
+
+		if (cmsg->cmsg_level != NET_IPPROTO_UDP) {
+			continue;
+		}
+
+		switch (cmsg->cmsg_type) {
+		case ZSOCK_UDP_OPT_CMSG_APC:
+			if (cmsg->cmsg_len == NET_CMSG_LEN(sizeof(uint32_t))) {
+				(void)memcpy(&opts->apc_crc, NET_CMSG_DATA(cmsg),
+					     sizeof(opts->apc_crc));
+				opts->present |= NET_UDP_OPT_F_APC;
+				break;
+			}
+
+			return -EINVAL;
+
+		case ZSOCK_UDP_OPT_CMSG_MDS:
+			if (cmsg->cmsg_len == NET_CMSG_LEN(sizeof(uint16_t))) {
+				(void)memcpy(&opts->mds, NET_CMSG_DATA(cmsg),
+					     sizeof(opts->mds));
+				opts->present |= NET_UDP_OPT_F_MDS;
+				break;
+			}
+
+			return -EINVAL;
+
+		case ZSOCK_UDP_OPT_CMSG_MRDS:
+			if (cmsg->cmsg_len == NET_CMSG_LEN(sizeof(struct net_udp_opt_mrds))) {
+				struct net_udp_opt_mrds mrds;
+
+				(void)memcpy(&mrds, NET_CMSG_DATA(cmsg), sizeof(mrds));
+				opts->mrds.size = mrds.size;
+				opts->mrds.segs = mrds.segs;
+				opts->present |= NET_UDP_OPT_F_MRDS;
+				break;
+			}
+
+			return -EINVAL;
+
+		case ZSOCK_UDP_OPT_CMSG_REQ:
+			if (cmsg->cmsg_len == NET_CMSG_LEN(sizeof(uint32_t))) {
+				(void)memcpy(&opts->req_token, NET_CMSG_DATA(cmsg),
+					     sizeof(opts->req_token));
+				opts->present |= NET_UDP_OPT_F_REQ;
+				break;
+			}
+
+			return -EINVAL;
+
+		case ZSOCK_UDP_OPT_CMSG_RES:
+			if (cmsg->cmsg_len == NET_CMSG_LEN(sizeof(uint32_t))) {
+				(void)memcpy(&opts->res_token, NET_CMSG_DATA(cmsg),
+					     sizeof(opts->res_token));
+				opts->present |= NET_UDP_OPT_F_RES;
+				break;
+			}
+
+			return -EINVAL;
+
+		case ZSOCK_UDP_OPT_CMSG_TIME:
+			if (cmsg->cmsg_len == NET_CMSG_LEN(sizeof(struct net_udp_opt_time))) {
+				struct net_udp_opt_time time_val;
+
+				(void)memcpy(&time_val, NET_CMSG_DATA(cmsg), sizeof(time_val));
+				opts->time.tsval = time_val.tsval;
+				opts->time.tsecr = time_val.tsecr;
+				opts->present |= NET_UDP_OPT_F_TIME;
+				break;
+			}
+
+			return -EINVAL;
+		default:
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+static int context_setup_udp_options(struct net_context *context,
+			     struct net_pkt *pkt,
+			     const struct net_msghdr *msg)
+{
+	struct net_udp_opt_info opts = { 0 };
+	int ret;
+
+	ret = context_parse_udp_option_cmsgs(msg, &opts);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return net_udp_opt_append(pkt, context, &opts);
+}
+#else
+static int context_setup_udp_options(struct net_context *context,
+			     struct net_pkt *pkt,
+			     const struct net_msghdr *msg)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(msg);
+
+	return 0;
+}
+#endif /* CONFIG_NET_UDP_OPTIONS */
+
 static int context_setup_udp_packet(struct net_context *context,
 				    net_sa_family_t family,
 				    struct net_pkt *pkt,
@@ -2307,6 +2430,11 @@ static int context_setup_udp_packet(struct net_context *context,
 
 	ret = context_write_data(pkt, buf, len, msg);
 	if (ret) {
+		return ret;
+	}
+
+	ret = context_setup_udp_options(context, pkt, msg);
+	if (ret < 0) {
 		return ret;
 	}
 
@@ -2380,6 +2508,40 @@ static int context_setup_raw_ip_packet(net_sa_family_t family,
 	return 0;
 }
 
+#if defined(CONFIG_NET_UDP_OPTIONS)
+static void context_finalize_udp_options(struct net_context *context, struct net_pkt *pkt)
+{
+	uint16_t surplus_len;
+	uint16_t surplus_offset;
+	int ret;
+
+	if (net_context_get_proto(context) != NET_IPPROTO_UDP) {
+		return;
+	}
+
+	surplus_len = net_pkt_udp_opt_surplus_len(pkt);
+	if (surplus_len == 0U) {
+		return;
+	}
+
+	/* The UDP checksum is computed over the UDP Length bytes only and does
+	 * not cover the surplus area (RFC 9868), so writing the OCS here does
+	 * not require recomputing the UDP checksum.
+	 */
+	surplus_offset = net_pkt_get_len(pkt) - surplus_len;
+	ret = net_udp_opt_finalize_ocs(pkt, surplus_offset, surplus_len);
+	if (ret < 0) {
+		NET_DBG("UDP option OCS finalize failed (%d)", ret);
+	}
+}
+#else
+static inline void context_finalize_udp_options(struct net_context *context, struct net_pkt *pkt)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(pkt);
+}
+#endif /* CONFIG_NET_UDP_OPTIONS */
+
 static void context_finalize_packet(struct net_context *context,
 				    net_sa_family_t family,
 				    struct net_pkt *pkt)
@@ -2395,6 +2557,8 @@ static void context_finalize_packet(struct net_context *context,
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) && family == NET_AF_INET) {
 		net_ipv4_finalize(pkt, net_context_get_proto(context));
 	}
+
+	context_finalize_udp_options(context, pkt);
 }
 
 static int context_validate_dont_fragment_packet(struct net_pkt *pkt)
@@ -2582,8 +2746,13 @@ static int context_sendto(struct net_context *context,
 					 CONFIG_NET_IPV6, (context->options.dont_fragment),
 					 (false));
 	net_sa_family_t family;
+	size_t alloc_len;
 	size_t tmp_len;
 	int ret;
+#if defined(CONFIG_NET_UDP_OPTIONS)
+	struct net_udp_opt_info udp_opts = { 0 };
+	const struct net_udp_opt_info *udp_opts_ptr = NULL;
+#endif
 
 	NET_ASSERT(PART_OF_ARRAY(contexts, context));
 
@@ -2859,6 +3028,26 @@ static int context_sendto(struct net_context *context,
 		}
 	}
 
+	alloc_len = len;
+
+#if defined(CONFIG_NET_UDP_OPTIONS)
+	if (net_context_get_proto(context) == NET_IPPROTO_UDP &&
+	    net_context_get_type(context) == NET_SOCK_DGRAM) {
+		if (msghdr != NULL) {
+			ret = context_parse_udp_option_cmsgs(msghdr, &udp_opts);
+			if (ret < 0) {
+				return ret;
+			}
+
+			if (udp_opts.present != 0U) {
+				udp_opts_ptr = &udp_opts;
+			}
+		}
+
+		alloc_len += net_udp_opt_surplus_len_with_opts(context, len, udp_opts_ptr);
+	}
+#endif /* CONFIG_NET_UDP_OPTIONS */
+
 	iface = net_context_get_iface(context);
 	if (iface && !net_if_is_up(iface)) {
 		return -ENETDOWN;
@@ -2873,7 +3062,7 @@ static int context_sendto(struct net_context *context,
 		goto skip_alloc;
 	}
 
-	pkt = context_alloc_pkt(context, family, len, PKT_WAIT_TIME);
+	pkt = context_alloc_pkt(context, family, alloc_len, PKT_WAIT_TIME);
 	if (!pkt) {
 		NET_ERR("Failed to allocate net_pkt");
 		return -ENOBUFS;
@@ -2881,11 +3070,11 @@ static int context_sendto(struct net_context *context,
 
 	tmp_len = net_pkt_available_payload_buffer(
 				pkt, net_context_get_proto(context));
-	if (tmp_len < len) {
+	if (tmp_len < alloc_len) {
 		if (net_context_get_type(context) == NET_SOCK_DGRAM ||
 		    net_context_get_type(context) == NET_SOCK_RAW) {
 			NET_ERR("Available payload buffer (%zu) is not enough for requested DGRAM (%zu)",
-				tmp_len, len);
+				tmp_len, alloc_len);
 			ret = -ENOMEM;
 			goto fail;
 		}
@@ -3201,6 +3390,40 @@ int net_context_sendto(struct net_context *context,
 	return ret;
 }
 
+static bool context_allow_udp_options(struct net_context *context, struct net_pkt *pkt)
+{
+#if defined(CONFIG_NET_UDP_OPTIONS)
+	struct net_udp_opt_info opt_info;
+
+	if (net_context_get_proto(context) != NET_IPPROTO_UDP) {
+		return true;
+	}
+
+	if (net_pkt_udp_opt_surplus_len(pkt) == 0U) {
+		return context->options.udp_opt.required == 0U;
+	}
+
+	if (context->options.udp_opt.drop_all_opts) {
+		return false;
+	}
+
+	if (context->options.udp_opt.required == 0U) {
+		return true;
+	}
+
+	if (net_udp_opt_parse(pkt, &opt_info) < 0) {
+		return false;
+	}
+
+	return (context->options.udp_opt.required & ~opt_info.present) == 0U;
+#else
+	ARG_UNUSED(context);
+	ARG_UNUSED(pkt);
+
+	return true;
+#endif /* CONFIG_NET_UDP_OPTIONS */
+}
+
 enum net_verdict net_context_packet_received(struct net_conn *conn,
 					     struct net_pkt *pkt,
 					     union net_ip_header *ip_hdr,
@@ -3221,6 +3444,10 @@ enum net_verdict net_context_packet_received(struct net_conn *conn,
 	/* If there is no callback registered, then we can only drop
 	 * the packet.
 	 */
+	if (!context_allow_udp_options(context, pkt)) {
+		goto unlock;
+	}
+
 	if (!context->recv_cb) {
 		goto unlock;
 	}
@@ -4172,6 +4399,230 @@ static int set_context_local_port_range(struct net_context *context,
 #endif
 }
 
+#if defined(CONFIG_NET_UDP_OPTIONS)
+static int udp_opt_read_int(const void *value, uint32_t len, int *out)
+{
+	uint16_t val16;
+
+	if (value == NULL || out == NULL) {
+		return -EINVAL;
+	}
+
+	if (len == sizeof(int)) {
+		memcpy(out, value, sizeof(int));
+		return 0;
+	}
+
+	if (len == sizeof(uint16_t)) {
+		memcpy(&val16, value, sizeof(val16));
+		*out = val16;
+		return 0;
+	}
+
+	return -EINVAL;
+}
+
+static uint32_t udp_opt_flag_from_option(enum net_context_option option)
+{
+	switch (option) {
+	case NET_OPT_UDP_OPT_OCS:
+		return NET_UDP_OPT_F_OCS;
+	case NET_OPT_UDP_OPT_APC:
+		return NET_UDP_OPT_F_APC;
+	case NET_OPT_UDP_OPT_FRAG:
+		return NET_UDP_OPT_F_FRAG;
+	case NET_OPT_UDP_OPT_REQ:
+		return NET_UDP_OPT_F_REQ;
+	case NET_OPT_UDP_OPT_RES:
+		return NET_UDP_OPT_F_RES;
+	case NET_OPT_UDP_OPT_TIME:
+		return NET_UDP_OPT_F_TIME;
+	case NET_OPT_UDP_OPT_AUTH:
+		return NET_UDP_OPT_F_AUTH;
+	case NET_OPT_UDP_OPT_EXP:
+		return NET_UDP_OPT_F_EXP;
+	case NET_OPT_UDP_OPT_UCMP:
+		return NET_UDP_OPT_F_UCMP;
+	case NET_OPT_UDP_OPT_UENC:
+		return NET_UDP_OPT_F_UENC;
+	case NET_OPT_UDP_OPT_UEXP:
+		return NET_UDP_OPT_F_UEXP;
+	default:
+		return 0U;
+	}
+}
+
+static int set_context_udp_opt(struct net_context *context,
+			       enum net_context_option option,
+			       const void *value, uint32_t len)
+{
+	int val;
+	int ret;
+	uint32_t flag;
+
+	switch (option) {
+	case NET_OPT_UDP_OPT:
+		ret = udp_opt_read_int(value, len, &val);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (val != 0) {
+			context->options.udp_opt.enabled = NET_UDP_OPT_F_SUPPORTED;
+		} else {
+			context->options.udp_opt.enabled = 0U;
+			context->options.udp_opt.required = 0U;
+		}
+
+		return 0;
+
+	case NET_OPT_UDP_OPT_MDS:
+		ret = udp_opt_read_int(value, len, &val);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (val < 0 || val > 65535) {
+			return -EINVAL;
+		}
+
+		context->options.udp_opt.mds = (uint16_t)val;
+		if (val != 0) {
+			context->options.udp_opt.enabled |= NET_UDP_OPT_F_MDS;
+		} else {
+			context->options.udp_opt.enabled &= ~NET_UDP_OPT_F_MDS;
+		}
+
+		return 0;
+
+	case NET_OPT_UDP_OPT_MRDS: {
+		struct net_udp_opt_mrds mrds = { 0 };
+		uint16_t size;
+
+		if (value == NULL) {
+			return -EINVAL;
+		}
+
+		if (len == sizeof(struct net_udp_opt_mrds)) {
+			memcpy(&mrds, value, sizeof(mrds));
+		} else if (len == sizeof(uint16_t)) {
+			memcpy(&size, value, sizeof(size));
+			mrds.size = size;
+			mrds.segs = 0U;
+		} else {
+			return -EINVAL;
+		}
+
+		context->options.udp_opt.mrds.size = mrds.size;
+		context->options.udp_opt.mrds.segs = mrds.segs;
+
+		if (mrds.size != 0U) {
+			context->options.udp_opt.enabled |= NET_UDP_OPT_F_MRDS;
+		} else {
+			context->options.udp_opt.enabled &= ~NET_UDP_OPT_F_MRDS;
+		}
+
+		return 0;
+	}
+
+	default:
+		break;
+	}
+
+	/* Remaining options are simple on/off feature flags. */
+	flag = udp_opt_flag_from_option(option);
+	if (flag == 0U) {
+		return -ENOPROTOOPT;
+	}
+
+	ret = udp_opt_read_int(value, len, &val);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (val != 0) {
+		if ((flag & NET_UDP_OPT_F_SUPPORTED) == 0U) {
+			return -ENOTSUP;
+		}
+
+		context->options.udp_opt.enabled |= flag;
+	} else {
+		context->options.udp_opt.enabled &= ~flag;
+	}
+
+	return 0;
+}
+
+static int get_context_udp_opt(struct net_context *context,
+			       enum net_context_option option,
+			       void *value, uint32_t *len)
+{
+	uint32_t flag;
+	int val;
+
+	if (value == NULL || len == NULL) {
+		return -EINVAL;
+	}
+
+	switch (option) {
+	case NET_OPT_UDP_OPT:
+		if (*len < sizeof(int)) {
+			return -EINVAL;
+		}
+
+		val = (context->options.udp_opt.enabled & NET_UDP_OPT_F_SUPPORTED) != 0U;
+		memcpy(value, &val, sizeof(val));
+		*len = sizeof(val);
+
+		return 0;
+
+	case NET_OPT_UDP_OPT_MDS:
+		if (*len < sizeof(uint16_t)) {
+			return -EINVAL;
+		}
+
+		memcpy(value, &context->options.udp_opt.mds, sizeof(uint16_t));
+		*len = sizeof(uint16_t);
+
+		return 0;
+
+	case NET_OPT_UDP_OPT_MRDS: {
+		struct net_udp_opt_mrds mrds = {
+			.size = context->options.udp_opt.mrds.size,
+			.segs = context->options.udp_opt.mrds.segs,
+		};
+
+		if (*len < sizeof(mrds)) {
+			return -EINVAL;
+		}
+
+		memcpy(value, &mrds, sizeof(mrds));
+		*len = sizeof(mrds);
+
+		return 0;
+	}
+
+	default:
+		break;
+	}
+
+	flag = udp_opt_flag_from_option(option);
+	if (flag == 0U) {
+		return -ENOPROTOOPT;
+	}
+
+	if (*len < sizeof(int)) {
+		return -EINVAL;
+	}
+
+	val = (context->options.udp_opt.enabled & flag) != 0U;
+	memcpy(value, &val, sizeof(val));
+	*len = sizeof(val);
+
+	return 0;
+}
+#endif /* CONFIG_NET_UDP_OPTIONS */
+
 int net_context_set_option(struct net_context *context,
 			   enum net_context_option option,
 			   const void *value, uint32_t len)
@@ -4273,6 +4724,27 @@ int net_context_set_option(struct net_context *context,
 	case NET_OPT_LINGER:
 		ret = set_context_linger(context, value, len);
 		break;
+#if defined(CONFIG_NET_UDP_OPTIONS)
+	case NET_OPT_UDP_OPT:
+	case NET_OPT_UDP_OPT_OCS:
+	case NET_OPT_UDP_OPT_APC:
+	case NET_OPT_UDP_OPT_FRAG:
+	case NET_OPT_UDP_OPT_MDS:
+	case NET_OPT_UDP_OPT_MRDS:
+	case NET_OPT_UDP_OPT_REQ:
+	case NET_OPT_UDP_OPT_RES:
+	case NET_OPT_UDP_OPT_TIME:
+	case NET_OPT_UDP_OPT_AUTH:
+	case NET_OPT_UDP_OPT_EXP:
+	case NET_OPT_UDP_OPT_UCMP:
+	case NET_OPT_UDP_OPT_UENC:
+	case NET_OPT_UDP_OPT_UEXP:
+		ret = set_context_udp_opt(context, option, value, len);
+		break;
+#endif /* CONFIG_NET_UDP_OPTIONS */
+	default:
+		ret = -ENOPROTOOPT;
+		break;
 	}
 
 	k_mutex_unlock(&context->lock);
@@ -4372,6 +4844,27 @@ int net_context_get_option(struct net_context *context,
 		break;
 	case NET_OPT_LINGER:
 		ret = get_context_linger(context, value, len);
+		break;
+#if defined(CONFIG_NET_UDP_OPTIONS)
+	case NET_OPT_UDP_OPT:
+	case NET_OPT_UDP_OPT_OCS:
+	case NET_OPT_UDP_OPT_APC:
+	case NET_OPT_UDP_OPT_FRAG:
+	case NET_OPT_UDP_OPT_MDS:
+	case NET_OPT_UDP_OPT_MRDS:
+	case NET_OPT_UDP_OPT_REQ:
+	case NET_OPT_UDP_OPT_RES:
+	case NET_OPT_UDP_OPT_TIME:
+	case NET_OPT_UDP_OPT_AUTH:
+	case NET_OPT_UDP_OPT_EXP:
+	case NET_OPT_UDP_OPT_UCMP:
+	case NET_OPT_UDP_OPT_UENC:
+	case NET_OPT_UDP_OPT_UEXP:
+		ret = get_context_udp_opt(context, option, value, len);
+		break;
+#endif /* CONFIG_NET_UDP_OPTIONS */
+	default:
+		ret = -ENOPROTOOPT;
 		break;
 	}
 

--- a/subsys/net/ip/udp.c
+++ b/subsys/net/ip/udp.c
@@ -52,6 +52,10 @@ int net_udp_finalize(struct net_pkt *pkt, bool force_chksum)
 	length = net_pkt_get_len(pkt) - net_pkt_ip_hdr_len(pkt) -
 		 net_pkt_ip_opts_len(pkt);
 
+	if (IS_ENABLED(CONFIG_NET_UDP_OPTIONS)) {
+		length -= net_pkt_udp_opt_surplus_len(pkt);
+	}
+
 	udp_hdr->len = net_htons(length);
 
 	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), type) || force_chksum) {
@@ -164,8 +168,10 @@ struct net_udp_hdr *net_udp_input(struct net_pkt *pkt,
 				  struct net_pkt_data_access *udp_access)
 {
 	struct net_udp_hdr *udp_hdr;
-	uint16_t chksum = 0;
+	uint16_t ip_payload_len;
+	uint16_t udp_len;
 	int ret;
+	uint16_t chksum = 0;
 	enum net_if_checksum_type type = net_pkt_family(pkt) == NET_AF_INET6 ?
 		NET_IF_CHECKSUM_IPV6_UDP : NET_IF_CHECKSUM_IPV4_UDP;
 
@@ -175,12 +181,54 @@ struct net_udp_hdr *net_udp_input(struct net_pkt *pkt,
 		goto drop;
 	}
 
-	if (net_ntohs(udp_hdr->len) != (net_pkt_get_len(pkt) -
-				    net_pkt_ip_hdr_len(pkt) -
-				    net_pkt_ip_opts_len(pkt))) {
+	udp_len = net_ntohs(udp_hdr->len);
+
+	if (IS_ENABLED(CONFIG_NET_IPV4) && net_pkt_family(pkt) == NET_AF_INET) {
+		uint16_t ipv4_total_len = net_ntohs(NET_IPV4_HDR(pkt)->len);
+		uint16_t ipv4_hdr_len = net_pkt_ip_hdr_len(pkt);
+
+		if (ipv4_total_len < ipv4_hdr_len) {
+			NET_DBG("DROP: Invalid IPv4 total length");
+			goto drop;
+		}
+
+		ip_payload_len = ipv4_total_len - ipv4_hdr_len;
+	} else if (IS_ENABLED(CONFIG_NET_IPV6) && net_pkt_family(pkt) == NET_AF_INET6) {
+		uint16_t ipv6_payload_len = net_ntohs(NET_IPV6_HDR(pkt)->len);
+		uint16_t ipv6_ext_len = net_pkt_ip_opts_len(pkt);
+
+		if (ipv6_payload_len < ipv6_ext_len) {
+			NET_DBG("DROP: Invalid IPv6 payload length");
+			goto drop;
+		}
+
+		ip_payload_len = ipv6_payload_len - ipv6_ext_len;
+	} else {
+		NET_DBG("DROP: Unknown protocol family");
+		goto drop;
+	}
+
+	if (udp_len < NET_UDPH_LEN || udp_len > ip_payload_len) {
 		NET_DBG("DROP: Invalid hdr length");
 		goto drop;
 	}
+
+#if defined(CONFIG_NET_UDP_OPTIONS)
+	net_pkt_set_udp_opt_surplus_len(pkt, 0U);
+
+	if (udp_len < ip_payload_len) {
+		/* A surplus area carrying UDP options (RFC 9868) is present.
+		 * Record its length so it is excluded from the UDP checksum and
+		 * from the payload delivered to the application. Do not validate
+		 * the options here: per RFC 9868 a malformed surplus area or a
+		 * failed OCS MUST NOT cause the datagram to be dropped when the
+		 * UDP checksum (which covers only the UDP Length bytes) is valid.
+		 * Options are parsed and their OCS validated later; the user data
+		 * is delivered regardless.
+		 */
+		net_pkt_set_udp_opt_surplus_len(pkt, ip_payload_len - udp_len);
+	}
+#endif /* CONFIG_NET_UDP_OPTIONS */
 
 	if (IS_ENABLED(CONFIG_NET_UDP_CHECKSUM) &&
 	    (net_if_need_calc_rx_checksum(net_pkt_iface(pkt), type) ||
@@ -206,3 +254,859 @@ drop:
 	net_stats_update_udp_chkerr(net_pkt_iface(pkt));
 	return NULL;
 }
+
+#if defined(CONFIG_NET_UDP_OPTIONS)
+static uint16_t udp_opt_fold_checksum(uint32_t sum)
+{
+	while (sum >> 16) {
+		sum = (sum & 0xffffU) + (sum >> 16);
+	}
+
+	return (uint16_t)sum;
+}
+
+static int udp_opt_get_header_info(struct net_pkt *pkt, uint16_t *udp_len,
+				   uint16_t *udp_chksum)
+{
+	struct net_udp_hdr udp_hdr;
+	struct net_udp_hdr *hdr;
+
+	if (pkt == NULL || udp_len == NULL || udp_chksum == NULL) {
+		return -EINVAL;
+	}
+
+	hdr = net_udp_get_hdr(pkt, &udp_hdr);
+	if (hdr == NULL) {
+		return -EINVAL;
+	}
+
+	*udp_len = net_ntohs(hdr->len);
+	*udp_chksum = hdr->chksum;
+
+	return 0;
+}
+
+static int udp_opt_calc_ocs(struct net_pkt *pkt,
+			    uint16_t surplus_offset,
+			    uint16_t surplus_len,
+			    uint16_t *calc_ocs,
+			    uint16_t *wire_ocs,
+			    bool *pad_ok)
+{
+	uint32_t sum = 0U;
+	size_t abs_val = 0U;
+	size_t idx = 0U;
+	size_t end = (size_t)surplus_offset + surplus_len;
+	uint8_t hi = 0U;
+	uint8_t wire_hi = 0U;
+	uint8_t wire_lo = 0U;
+	bool have_hi = false;
+	uint8_t align_pad;
+
+	if (pkt == NULL || calc_ocs == NULL || surplus_len == 0U) {
+		return -EINVAL;
+	}
+
+	align_pad = surplus_offset & 0x1U;
+	if (surplus_len < (uint16_t)(align_pad + sizeof(uint16_t))) {
+		return -EINVAL;
+	}
+
+	if (end > net_pkt_get_len(pkt)) {
+		return -EINVAL;
+	}
+
+	if (pad_ok != NULL) {
+		*pad_ok = true;
+	}
+
+	NET_PKT_FRAG_FOR_EACH(pkt, frag) {
+		for (size_t i = 0U; i < frag->len; i++) {
+			size_t rel;
+			uint8_t byte;
+
+			if (abs_val < surplus_offset) {
+				abs_val++;
+				continue;
+			}
+
+			if (abs_val >= end) {
+				break;
+			}
+
+			byte = frag->data[i];
+			rel = idx++;
+
+			if (rel < align_pad && byte != 0U && pad_ok != NULL) {
+				*pad_ok = false;
+			}
+
+			if (rel == align_pad) {
+				wire_hi = byte;
+			} else if (rel == (size_t)align_pad + 1U) {
+				wire_lo = byte;
+			}
+
+			if (rel == align_pad || rel == (size_t)align_pad + 1U) {
+				byte = 0U;
+			}
+
+			if (!have_hi) {
+				hi = byte;
+				have_hi = true;
+			} else {
+				sum += ((uint16_t)hi << 8) | byte;
+				sum = (sum & 0xffffU) + (sum >> 16);
+				have_hi = false;
+			}
+
+			abs_val++;
+		}
+
+		if (abs_val >= end) {
+			break;
+		}
+	}
+
+	if (idx != surplus_len) {
+		return -EINVAL;
+	}
+
+	if (have_hi) {
+		sum += ((uint16_t)hi << 8);
+		sum = (sum & 0xffffU) + (sum >> 16);
+	}
+
+	sum += surplus_len;
+	sum = udp_opt_fold_checksum(sum);
+
+	*calc_ocs = (uint16_t)(~sum);
+
+	if (wire_ocs != NULL) {
+		*wire_ocs = ((uint16_t)wire_hi << 8) | wire_lo;
+	}
+
+	return 0;
+}
+
+static int udp_opt_parse_tlvs(struct net_pkt *pkt, uint16_t offset,
+			      uint16_t length,
+			      struct net_udp_opt_info *info)
+{
+	struct net_pkt_cursor backup;
+	uint16_t remaining = length;
+	int ret = 0;
+
+	if (length == 0U) {
+		return 0;
+	}
+
+	net_pkt_cursor_backup(pkt, &backup);
+	net_pkt_cursor_init(pkt);
+
+	ret = net_pkt_skip(pkt, offset);
+	if (ret < 0) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	while (remaining > 0U) {
+		uint8_t kind;
+		uint8_t opt_len;
+		uint16_t opt_payload;
+		uint16_t payload_len;
+
+		ret = net_pkt_read_u8(pkt, &kind);
+		if (ret < 0) {
+			ret = -EINVAL;
+			goto out;
+		}
+
+		remaining--;
+
+		if (kind == NET_UDP_OPT_KIND_EOL) {
+			/* Remaining bytes are expected to be explicit zero padding. */
+			while (remaining > 0U) {
+				uint8_t pad;
+
+				ret = net_pkt_read_u8(pkt, &pad);
+				if (ret < 0 || pad != 0U) {
+					ret = -EINVAL;
+					goto out;
+				}
+
+				remaining--;
+			}
+
+			break;
+		}
+
+		if (kind == NET_UDP_OPT_KIND_NOP) {
+			continue;
+		}
+
+		/* RFC 9868 Section 7: an unsupported option in the UNSAFE range
+		 * (kinds 192-255) signals that the datagram's user data was
+		 * transformed in a way this receiver does not understand. All
+		 * option processing MUST be terminated and every option in the
+		 * datagram discarded. No UNSAFE option is currently supported.
+		 */
+		if (kind >= NET_UDP_OPT_KIND_UCMP) {
+			ret = -EINVAL;
+			goto out;
+		}
+
+		if (remaining < 1U) {
+			ret = -EINVAL;
+			goto out;
+		}
+
+		ret = net_pkt_read_u8(pkt, &opt_len);
+		if (ret < 0) {
+			ret = -EINVAL;
+			goto out;
+		}
+
+		remaining--;
+
+		if (opt_len == 255U) {
+			/* RFC 9868 Section 5: options longer than 254 bytes use
+			 * the extended format (Kind, 0xff, 2-byte Extended
+			 * Length). The Extended Length counts the whole option,
+			 * including the Kind, 0xff and Extended Length bytes, so
+			 * the minimum valid value is 4.
+			 */
+			uint16_t ext_len;
+
+			if (remaining < sizeof(uint16_t)) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			ret = net_pkt_read_be16(pkt, &ext_len);
+			if (ret < 0) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			remaining -= sizeof(uint16_t);
+
+			if (ext_len < 4U) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			opt_payload = ext_len - 4U;
+		} else {
+			if (opt_len < 2U) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			opt_payload = (uint16_t)opt_len - 2U;
+		}
+
+		payload_len = opt_payload;
+		if (payload_len > remaining) {
+			ret = -EINVAL;
+			goto out;
+		}
+
+		/* RFC 9868 Section 7: a known option whose length does not match
+		 * the value defined for its kind is an error and MUST result in
+		 * all options being discarded. Unknown options in the SAFE range
+		 * are ignored (skipped) via the default case.
+		 */
+		switch (kind) {
+		case NET_UDP_OPT_KIND_APC:
+			if (payload_len != sizeof(uint32_t)) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			/* The APC CRC32c is carried to the application as-is; the
+			 * options layer does not verify it (RFC 9868 leaves the
+			 * payload checksum to the endpoints/application).
+			 */
+			ret = net_pkt_read_be32(pkt, &info->apc_crc);
+			if (ret < 0) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			info->present |= NET_UDP_OPT_F_APC;
+			payload_len = 0U;
+			break;
+
+		case NET_UDP_OPT_KIND_MDS:
+			if (payload_len != sizeof(uint16_t)) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			ret = net_pkt_read_be16(pkt, &info->mds);
+			if (ret < 0) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			info->present |= NET_UDP_OPT_F_MDS;
+			payload_len = 0U;
+			break;
+
+		case NET_UDP_OPT_KIND_MRDS:
+			if (payload_len != 3U) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			ret = net_pkt_read_be16(pkt, &info->mrds.size);
+			if (ret < 0) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			ret = net_pkt_read_u8(pkt, &info->mrds.segs);
+			if (ret < 0) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			info->present |= NET_UDP_OPT_F_MRDS;
+			payload_len = 0U;
+			break;
+
+		case NET_UDP_OPT_KIND_REQ:
+			if (payload_len != sizeof(uint32_t)) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			ret = net_pkt_read_be32(pkt, &info->req_token);
+			if (ret < 0) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			info->present |= NET_UDP_OPT_F_REQ;
+			payload_len = 0U;
+			break;
+
+		case NET_UDP_OPT_KIND_RES:
+			if (payload_len != sizeof(uint32_t)) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			ret = net_pkt_read_be32(pkt, &info->res_token);
+			if (ret < 0) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			info->present |= NET_UDP_OPT_F_RES;
+			payload_len = 0U;
+			break;
+
+		case NET_UDP_OPT_KIND_TIME:
+			if (payload_len != (sizeof(uint32_t) * 2U)) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			ret = net_pkt_read_be32(pkt, &info->time.tsval);
+			if (ret < 0) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			ret = net_pkt_read_be32(pkt, &info->time.tsecr);
+			if (ret < 0) {
+				ret = -EINVAL;
+				goto out;
+			}
+
+			info->present |= NET_UDP_OPT_F_TIME;
+			payload_len = 0U;
+			break;
+
+		default:
+			break;
+		}
+
+		if (payload_len > 0U) {
+			ret = net_pkt_skip(pkt, payload_len);
+			if (ret < 0) {
+				ret = -EINVAL;
+				goto out;
+			}
+		}
+
+		remaining -= opt_payload;
+	}
+
+out:
+	net_pkt_cursor_restore(pkt, &backup);
+
+	return ret;
+}
+
+int net_udp_opt_parse(struct net_pkt *pkt, struct net_udp_opt_info *info)
+{
+	uint16_t surplus_len;
+	uint16_t udp_len;
+	uint16_t udp_chksum;
+	uint16_t calc_ocs;
+	uint16_t wire_ocs;
+	uint16_t surplus_offset;
+	uint16_t opt_offset;
+	uint16_t opt_len;
+	bool pad_ok = true;
+	int ret;
+
+	if (pkt == NULL || info == NULL) {
+		return -EINVAL;
+	}
+
+	(void)memset(info, 0, sizeof(*info));
+
+	surplus_len = net_pkt_udp_opt_surplus_len(pkt);
+	if (surplus_len == 0U) {
+		return -ENOENT;
+	}
+
+	ret = udp_opt_get_header_info(pkt, &udp_len, &udp_chksum);
+	if (ret < 0) {
+		return ret;
+	}
+
+	surplus_offset = net_pkt_ip_hdr_len(pkt) + net_pkt_ip_opts_len(pkt) + udp_len;
+
+	ret = udp_opt_calc_ocs(pkt, surplus_offset, surplus_len,
+	&calc_ocs, &wire_ocs, &pad_ok);
+	if (ret < 0) {
+		return ret;
+	}
+
+	info->present |= NET_UDP_OPT_F_OCS;
+
+	if (!pad_ok) {
+		info->ocs_valid = false;
+		return -EINVAL;
+	}
+
+	if (udp_chksum != 0U && wire_ocs == 0U) {
+		/* RFC 9868: when the UDP checksum is non-zero the OCS MUST be
+		 * non-zero. A zero OCS here is invalid; ignore the options.
+		 */
+		info->ocs_valid = false;
+		return -EINVAL;
+	}
+
+	if (wire_ocs == 0U && udp_chksum == 0U) {
+		/* RFC 9868: with a zero UDP checksum the OCS may be unused
+		 * (zero). The options are still parsed and processed.
+		 */
+		info->ocs_valid = true;
+	} else {
+		info->ocs_valid = (wire_ocs == calc_ocs);
+		if (!info->ocs_valid) {
+			return -EINVAL;
+		}
+	}
+
+	opt_offset = surplus_offset + (surplus_offset & 0x1U) + sizeof(uint16_t);
+	opt_len = surplus_len - (uint16_t)((surplus_offset & 0x1U) + sizeof(uint16_t));
+
+	ret = udp_opt_parse_tlvs(pkt, opt_offset, opt_len, info);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int udp_opt_write_tlv_u16(struct net_pkt *pkt, uint8_t kind, uint16_t value)
+{
+	int ret;
+
+	ret = net_pkt_write_u8(pkt, kind);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = net_pkt_write_u8(pkt, 4U);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return net_pkt_write_be16(pkt, value);
+}
+
+static int udp_opt_write_tlv_u32(struct net_pkt *pkt, uint8_t kind, uint32_t value)
+{
+	int ret;
+
+	ret = net_pkt_write_u8(pkt, kind);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = net_pkt_write_u8(pkt, 6U);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return net_pkt_write_be32(pkt, value);
+}
+
+static int udp_opt_write_tlv_time(struct net_pkt *pkt, uint32_t tsval, uint32_t tsecr)
+{
+	int ret;
+
+	ret = net_pkt_write_u8(pkt, NET_UDP_OPT_KIND_TIME);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = net_pkt_write_u8(pkt, 10U);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = net_pkt_write_be32(pkt, tsval);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return net_pkt_write_be32(pkt, tsecr);
+}
+
+static int udp_opt_write_tlv_mrds(struct net_pkt *pkt, uint16_t size, uint8_t segs)
+{
+	int ret;
+
+	ret = net_pkt_write_u8(pkt, NET_UDP_OPT_KIND_MRDS);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = net_pkt_write_u8(pkt, 5U);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = net_pkt_write_be16(pkt, size);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return net_pkt_write_u8(pkt, segs);
+}
+
+static uint16_t udp_opt_tx_tlv_len(uint32_t enabled, uint16_t mds, uint16_t mrds_size)
+{
+	uint16_t len = 0U;
+
+	if ((enabled & NET_UDP_OPT_F_APC) != 0U) {
+		len += 6U;
+	}
+
+	if ((enabled & NET_UDP_OPT_F_MDS) != 0U && mds != 0U) {
+		len += 4U;
+	}
+
+	if ((enabled & NET_UDP_OPT_F_MRDS) != 0U && mrds_size != 0U) {
+		len += 5U;
+	}
+
+	if ((enabled & NET_UDP_OPT_F_REQ) != 0U) {
+		len += 6U;
+	}
+
+	if ((enabled & NET_UDP_OPT_F_RES) != 0U) {
+		len += 6U;
+	}
+
+	if ((enabled & NET_UDP_OPT_F_TIME) != 0U) {
+		len += 10U;
+	}
+
+	return len;
+}
+
+uint16_t net_udp_opt_surplus_len_with_opts(struct net_context *ctx, uint16_t data_len,
+					   const struct net_udp_opt_info *opts)
+{
+	const uint32_t tlv_mask = NET_UDP_OPT_F_APC | NET_UDP_OPT_F_MDS |
+				  NET_UDP_OPT_F_MRDS | NET_UDP_OPT_F_REQ |
+				  NET_UDP_OPT_F_RES | NET_UDP_OPT_F_TIME;
+	uint16_t tlv_len;
+	uint32_t enabled;
+	uint16_t mds;
+	uint16_t mrds_size;
+
+	if (ctx == NULL) {
+		return 0U;
+	}
+
+	enabled = ctx->options.udp_opt.enabled;
+	mds = ctx->options.udp_opt.mds;
+	mrds_size = ctx->options.udp_opt.mrds.size;
+
+	if (opts != NULL) {
+		enabled |= opts->present & tlv_mask;
+
+		if ((opts->present & NET_UDP_OPT_F_MDS) != 0U && opts->mds != 0U) {
+			mds = opts->mds;
+		}
+
+		if ((opts->present & NET_UDP_OPT_F_MRDS) != 0U && opts->mrds.size != 0U) {
+			mrds_size = opts->mrds.size;
+		}
+	}
+
+	if ((enabled & tlv_mask) != 0U) {
+		enabled |= NET_UDP_OPT_F_OCS;
+	}
+
+	if ((enabled & NET_UDP_OPT_F_OCS) == 0U) {
+		return 0U;
+	}
+
+	tlv_len = udp_opt_tx_tlv_len(enabled, mds, mrds_size);
+
+	/* Reserve two bytes for OCS and one alignment pad for odd data lengths. */
+	return ((data_len & 0x1U) != 0U ? 3U : 2U) + tlv_len;
+}
+
+uint16_t net_udp_opt_surplus_len(struct net_context *ctx, uint16_t data_len)
+{
+	return net_udp_opt_surplus_len_with_opts(ctx, data_len, NULL);
+}
+
+int net_udp_opt_append(struct net_pkt *pkt, struct net_context *ctx,
+		       const struct net_udp_opt_info *opts)
+{
+	const uint32_t tlv_mask = NET_UDP_OPT_F_APC | NET_UDP_OPT_F_MDS |
+				  NET_UDP_OPT_F_MRDS | NET_UDP_OPT_F_REQ |
+				  NET_UDP_OPT_F_RES | NET_UDP_OPT_F_TIME;
+	uint32_t enabled;
+	uint16_t tlv_len;
+	uint16_t surplus_offset;
+	uint16_t surplus_len;
+	uint16_t mds;
+	uint16_t mrds_size;
+	uint32_t apc_crc = 0U;
+	uint32_t req_token = 0U;
+	uint32_t res_token = 0U;
+	uint32_t time_tsval = 0U;
+	uint32_t time_tsecr = 0U;
+	uint8_t align_pad;
+	uint8_t mrds_segs;
+	int ret;
+
+	if (pkt == NULL || ctx == NULL) {
+		return -EINVAL;
+	}
+
+	enabled = ctx->options.udp_opt.enabled;
+	mds = ctx->options.udp_opt.mds;
+	mrds_size = ctx->options.udp_opt.mrds.size;
+	mrds_segs = ctx->options.udp_opt.mrds.segs;
+
+	if (opts != NULL) {
+		enabled |= opts->present & tlv_mask;
+
+		if ((opts->present & NET_UDP_OPT_F_APC) != 0U) {
+			apc_crc = opts->apc_crc;
+		}
+
+		if ((opts->present & NET_UDP_OPT_F_REQ) != 0U) {
+			req_token = opts->req_token;
+		}
+
+		if ((opts->present & NET_UDP_OPT_F_RES) != 0U) {
+			res_token = opts->res_token;
+		}
+
+		if ((opts->present & NET_UDP_OPT_F_TIME) != 0U) {
+			time_tsval = opts->time.tsval;
+			time_tsecr = opts->time.tsecr;
+		}
+
+		if ((opts->present & NET_UDP_OPT_F_MDS) != 0U && opts->mds != 0U) {
+			mds = opts->mds;
+		}
+
+		if ((opts->present & NET_UDP_OPT_F_MRDS) != 0U && opts->mrds.size != 0U) {
+			mrds_size = opts->mrds.size;
+			mrds_segs = opts->mrds.segs;
+		}
+	}
+
+	if ((enabled & tlv_mask) != 0U) {
+		enabled |= NET_UDP_OPT_F_OCS;
+	}
+
+	if ((enabled & NET_UDP_OPT_F_OCS) == 0U) {
+		net_pkt_set_udp_opt_surplus_len(pkt, 0U);
+		return 0;
+	}
+
+	tlv_len = udp_opt_tx_tlv_len(enabled, mds, mrds_size);
+	surplus_offset = net_pkt_get_len(pkt);
+	align_pad = surplus_offset & 0x1U;
+	surplus_len = (uint16_t)align_pad + sizeof(uint16_t) + tlv_len;
+
+	if (align_pad != 0U) {
+		ret = net_pkt_write_u8(pkt, 0U);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	ret = net_pkt_write_be16(pkt, 0U);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if ((enabled & NET_UDP_OPT_F_APC) != 0U) {
+		ret = udp_opt_write_tlv_u32(pkt, NET_UDP_OPT_KIND_APC, apc_crc);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if ((enabled & NET_UDP_OPT_F_MDS) != 0U && mds != 0U) {
+		ret = udp_opt_write_tlv_u16(pkt, NET_UDP_OPT_KIND_MDS, mds);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if ((enabled & NET_UDP_OPT_F_MRDS) != 0U && mrds_size != 0U) {
+		ret = udp_opt_write_tlv_mrds(pkt, mrds_size, mrds_segs);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if ((enabled & NET_UDP_OPT_F_REQ) != 0U) {
+		ret = udp_opt_write_tlv_u32(pkt, NET_UDP_OPT_KIND_REQ, req_token);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if ((enabled & NET_UDP_OPT_F_RES) != 0U) {
+		ret = udp_opt_write_tlv_u32(pkt, NET_UDP_OPT_KIND_RES, res_token);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if ((enabled & NET_UDP_OPT_F_TIME) != 0U) {
+		ret = udp_opt_write_tlv_time(pkt, time_tsval, time_tsecr);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	net_pkt_set_udp_opt_surplus_len(pkt, surplus_len);
+
+	return 0;
+}
+
+int net_udp_opt_finalize_ocs(struct net_pkt *pkt,
+			     uint16_t surplus_offset,
+			     uint16_t surplus_len)
+{
+	struct net_pkt_cursor backup;
+	bool overwrite;
+	uint16_t udp_len;
+	uint16_t udp_chksum;
+	uint16_t ocs;
+	uint16_t ocs_offset;
+	uint8_t align_pad;
+	int ret;
+
+	if (pkt == NULL || surplus_len == 0U) {
+		return -EINVAL;
+	}
+
+	ret = udp_opt_get_header_info(pkt, &udp_len, &udp_chksum);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if ((size_t)surplus_offset + surplus_len > net_pkt_get_len(pkt)) {
+		return -EINVAL;
+	}
+
+	ret = udp_opt_calc_ocs(pkt, surplus_offset, surplus_len, &ocs, NULL, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (udp_chksum != 0U && ocs == 0U) {
+		ocs = 0xffffU;
+	}
+
+	align_pad = surplus_offset & 0x1U;
+	ocs_offset = surplus_offset + align_pad;
+
+	overwrite = net_pkt_is_being_overwritten(pkt);
+	net_pkt_set_overwrite(pkt, true);
+
+	net_pkt_cursor_backup(pkt, &backup);
+	net_pkt_cursor_init(pkt);
+
+	ret = net_pkt_skip(pkt, ocs_offset);
+	if (ret == 0) {
+		ret = net_pkt_write_be16(pkt, ocs);
+	}
+
+	net_pkt_cursor_restore(pkt, &backup);
+	net_pkt_set_overwrite(pkt, overwrite);
+
+	return ret;
+}
+#else /* CONFIG_NET_UDP_OPTIONS */
+int net_udp_opt_parse(struct net_pkt *pkt, struct net_udp_opt_info *info)
+{
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(info);
+
+	return -ENOTSUP;
+}
+
+uint16_t net_udp_opt_surplus_len(struct net_context *ctx, uint16_t data_len)
+{
+	ARG_UNUSED(ctx);
+	ARG_UNUSED(data_len);
+
+	return 0U;
+}
+
+int net_udp_opt_append(struct net_pkt *pkt, struct net_context *ctx,
+		       const struct net_udp_opt_info *opts)
+{
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(ctx);
+	ARG_UNUSED(opts);
+
+	return -ENOTSUP;
+}
+
+int net_udp_opt_finalize_ocs(struct net_pkt *pkt,
+			     uint16_t surplus_offset,
+			     uint16_t surplus_len)
+{
+	ARG_UNUSED(pkt);
+	ARG_UNUSED(surplus_offset);
+	ARG_UNUSED(surplus_len);
+
+	return -ENOTSUP;
+}
+#endif /* CONFIG_NET_UDP_OPTIONS */

--- a/subsys/net/ip/udp.c
+++ b/subsys/net/ip/udp.c
@@ -842,6 +842,7 @@ uint16_t net_udp_opt_surplus_len_with_opts(struct net_context *ctx, uint16_t dat
 				  NET_UDP_OPT_F_MRDS | NET_UDP_OPT_F_REQ |
 				  NET_UDP_OPT_F_RES | NET_UDP_OPT_F_TIME;
 	uint16_t tlv_len;
+	uint16_t surplus_len;
 	uint32_t enabled;
 	uint16_t mds;
 	uint16_t mrds_size;
@@ -877,7 +878,14 @@ uint16_t net_udp_opt_surplus_len_with_opts(struct net_context *ctx, uint16_t dat
 	tlv_len = udp_opt_tx_tlv_len(enabled, mds, mrds_size);
 
 	/* Reserve two bytes for OCS and one alignment pad for odd data lengths. */
-	return ((data_len & 0x1U) != 0U ? 3U : 2U) + tlv_len;
+	surplus_len = ((data_len & 0x1U) != 0U ? 3U : 2U) + tlv_len;
+
+	/* A DPLPMTUD probe inflates the surplus area to a target size. */
+	if (opts != NULL && opts->pad_to_surplus > surplus_len) {
+		surplus_len = opts->pad_to_surplus;
+	}
+
+	return surplus_len;
 }
 
 uint16_t net_udp_opt_surplus_len(struct net_context *ctx, uint16_t data_len)
@@ -1011,6 +1019,26 @@ int net_udp_opt_append(struct net_pkt *pkt, struct net_context *ctx,
 		if (ret < 0) {
 			return ret;
 		}
+	}
+
+	/* Pad the surplus area to the requested size for a DPLPMTUD probe
+	 * (RFC 9869). The first zero byte acts as the End of Options List (EOL)
+	 * option and the remainder is zero padding; the OCS finalisation covers
+	 * all of it and the receiver ignores post-EOL zeroes.
+	 */
+	if (opts != NULL && opts->pad_to_surplus > surplus_len) {
+		uint16_t pad = opts->pad_to_surplus - surplus_len;
+
+		while (pad > 0U) {
+			ret = net_pkt_write_u8(pkt, 0U);
+			if (ret < 0) {
+				return ret;
+			}
+
+			pad--;
+		}
+
+		surplus_len = opts->pad_to_surplus;
 	}
 
 	net_pkt_set_udp_opt_surplus_len(pkt, surplus_len);

--- a/subsys/net/ip/udp_internal.h
+++ b/subsys/net/ip/udp_internal.h
@@ -114,6 +114,12 @@ struct net_udp_opt_info {
 		uint16_t frag_offset;
 		bool is_terminal;
 	} frag;
+
+	/** Transmit-only: pad the surplus area with an EOL option and trailing
+	 * zeroes so that it reaches at least this many bytes. Used to inflate a
+	 * DPLPMTUD probe datagram to a target size (RFC 9869). 0 = no padding.
+	 */
+	uint16_t pad_to_surplus;
 };
 
 /**

--- a/subsys/net/ip/udp_internal.h
+++ b/subsys/net/ip/udp_internal.h
@@ -27,6 +27,95 @@
 extern "C" {
 #endif
 
+/** UDP option kind values (RFC 9868 Section 10, Table 1) */
+#define NET_UDP_OPT_KIND_EOL   0   /**< End of Options List */
+#define NET_UDP_OPT_KIND_NOP   1   /**< No Operation */
+#define NET_UDP_OPT_KIND_APC   2   /**< Additional Payload Checksum */
+#define NET_UDP_OPT_KIND_FRAG  3   /**< Fragmentation */
+#define NET_UDP_OPT_KIND_MDS   4   /**< Maximum Datagram Size */
+#define NET_UDP_OPT_KIND_MRDS  5   /**< Maximum Reassembled Datagram Size */
+#define NET_UDP_OPT_KIND_REQ   6   /**< Echo Request */
+#define NET_UDP_OPT_KIND_RES   7   /**< Echo Response */
+#define NET_UDP_OPT_KIND_TIME  8   /**< Timestamp */
+#define NET_UDP_OPT_KIND_AUTH  9   /**< Authentication (RESERVED) */
+#define NET_UDP_OPT_KIND_EXP   127 /**< Experimental */
+#define NET_UDP_OPT_KIND_UCMP  192 /**< UNSAFE Compression */
+#define NET_UDP_OPT_KIND_UENC  193 /**< UNSAFE Encryption */
+#define NET_UDP_OPT_KIND_UEXP  254 /**< UNSAFE Experimental (255 is Reserved) */
+
+/** Status/result bits for each parsed option */
+#define NET_UDP_OPT_STATUS_PRESENT  BIT(0)
+#define NET_UDP_OPT_STATUS_OK       BIT(1)
+#define NET_UDP_OPT_STATUS_FAIL     BIT(2)
+#define NET_UDP_OPT_STATUS_UNKNOWN  BIT(3)
+
+/** Internal UDP option feature bits used in policy/presence bitmasks */
+#define NET_UDP_OPT_F_OCS  BIT(0)
+#define NET_UDP_OPT_F_APC  BIT(1)
+#define NET_UDP_OPT_F_FRAG BIT(2)
+#define NET_UDP_OPT_F_MDS  BIT(3)
+#define NET_UDP_OPT_F_MRDS BIT(4)
+#define NET_UDP_OPT_F_REQ  BIT(5)
+#define NET_UDP_OPT_F_RES  BIT(6)
+#define NET_UDP_OPT_F_TIME BIT(7)
+#define NET_UDP_OPT_F_AUTH BIT(8)
+#define NET_UDP_OPT_F_EXP  BIT(9)
+#define NET_UDP_OPT_F_UCMP BIT(10)
+#define NET_UDP_OPT_F_UENC BIT(11)
+#define NET_UDP_OPT_F_UEXP BIT(12)
+
+#define NET_UDP_OPT_F_ALL (NET_UDP_OPT_F_OCS | NET_UDP_OPT_F_APC | NET_UDP_OPT_F_FRAG | \
+			   NET_UDP_OPT_F_MDS | NET_UDP_OPT_F_MRDS | NET_UDP_OPT_F_REQ | \
+			   NET_UDP_OPT_F_RES | NET_UDP_OPT_F_TIME | NET_UDP_OPT_F_AUTH | \
+			   NET_UDP_OPT_F_EXP | NET_UDP_OPT_F_UCMP | NET_UDP_OPT_F_UENC | \
+			   NET_UDP_OPT_F_UEXP)
+
+/** UDP option features that are actually implemented for sending/receiving */
+#define NET_UDP_OPT_F_SUPPORTED (NET_UDP_OPT_F_OCS | NET_UDP_OPT_F_APC | \
+				 NET_UDP_OPT_F_MDS | NET_UDP_OPT_F_MRDS | \
+				 NET_UDP_OPT_F_REQ | NET_UDP_OPT_F_RES | \
+				 NET_UDP_OPT_F_TIME)
+
+/** Result of parsing UDP options from a received packet */
+struct net_udp_opt_info {
+	/** Bitmask of parsed option features (NET_UDP_OPT_F_*) */
+	uint32_t present;
+
+	/** OCS validation result (true = passed or unused) */
+	bool ocs_valid;
+
+	/** APC (Additional Payload Checksum, RFC 9868) CRC32c value, valid when
+	 * APC is present. The UDP options layer does not compute or verify this
+	 * checksum; it is carried verbatim between the wire and the application,
+	 * which is responsible for computing it on transmit and validating it on
+	 * receive.
+	 */
+	uint32_t apc_crc;
+
+	/** MDS value received from peer */
+	uint16_t mds;
+
+	/** MRDS value received from peer */
+	struct net_udp_opt_mrds mrds;
+
+	/** Echo Request token (if present) */
+	uint32_t req_token;
+
+	/** Echo Response token (if present) */
+	uint32_t res_token;
+
+	/** Timestamp value (if present) */
+	struct net_udp_opt_time time;
+
+	/** FRAG header fields, if present */
+	struct {
+		uint16_t frag_start;
+		uint32_t identification;
+		uint16_t frag_offset;
+		bool is_terminal;
+	} frag;
+};
+
 /**
  * @brief Create UDP packet into net_pkt
  *
@@ -131,6 +220,79 @@ int net_udp_register(uint8_t family,
  * @return Return 0 if the unregistration succeed, <0 otherwise.
  */
 int net_udp_unregister(struct net_conn_handle *handle);
+
+/**
+ * @brief Parse UDP options from the surplus area of a received packet.
+ *
+ * Extracts and validates the OCS and all TLV options from the surplus area
+ * (bytes between UDP Length end and IP payload end).
+ *
+ * @param pkt       Network packet
+ * @param info      [out] Parsed option information
+ *
+ * @return 0 on success (options parsed, results in info)
+ * @return -ENOENT if no surplus area exists (no options)
+ * @return -EINVAL if surplus area is malformed
+ */
+int net_udp_opt_parse(struct net_pkt *pkt, struct net_udp_opt_info *info);
+
+/**
+ * @brief Compute the total size needed for UDP options to be appended.
+ *
+ * @param ctx       Network context (carries per-socket option config)
+ * @param data_len  Length of UDP user data
+ *
+ * @return Number of surplus-area bytes needed (including OCS alignment padding)
+ */
+uint16_t net_udp_opt_surplus_len(struct net_context *ctx, uint16_t data_len);
+
+/**
+ * @brief Compute outgoing UDP options surplus size with optional per-packet overrides.
+ *
+ * This helper mirrors the option merge rules used by net_udp_opt_append():
+ * socket-level options from @p ctx are combined with optional per-packet
+ * overrides from @p opts (typically parsed from sendmsg() cmsgs).
+ *
+ * @param ctx       Network context (socket-level UDP options)
+ * @param data_len  Length of UDP user data
+ * @param opts      Optional per-packet option overrides, or NULL
+ *
+ * @return Number of surplus-area bytes needed (including alignment padding and OCS)
+ */
+uint16_t net_udp_opt_surplus_len_with_opts(struct net_context *ctx, uint16_t data_len,
+					   const struct net_udp_opt_info *opts);
+
+/**
+ * @brief Append UDP options to an outgoing packet's surplus area.
+ *
+ * This writes the alignment padding, OCS, and enabled TLV options after
+ * the UDP user data. The UDP Length in the header is NOT modified (it
+ * must still reflect only header + user data).
+ *
+ * @param pkt       Network packet (cursor should be at end of UDP user data)
+ * @param ctx       Network context (carries per-socket option config)
+ * @param opts      Optional per-packet option overrides (from cmsg), or NULL
+ *
+ * @return 0 on success, negative errno on failure
+ */
+int net_udp_opt_append(struct net_pkt *pkt, struct net_context *ctx,
+		       const struct net_udp_opt_info *opts);
+
+/**
+ * @brief Compute and write the OCS field for the surplus area.
+ *
+ * Called after all options are written. Computes the one's complement
+ * checksum over the surplus area and its length.
+ *
+ * @param pkt           Network packet
+ * @param surplus_offset Byte offset of surplus area start in the packet
+ * @param surplus_len   Total length of surplus area
+ *
+ * @return 0 on success
+ */
+int net_udp_opt_finalize_ocs(struct net_pkt *pkt,
+			     uint16_t surplus_offset,
+			     uint16_t surplus_len);
 
 #ifdef __cplusplus
 }

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -700,7 +700,7 @@ uint16_t calc_chksum(uint16_t sum_in, const uint8_t *data, size_t len)
 }
 
 #if defined(CONFIG_NET_NATIVE_IP)
-static inline uint16_t pkt_calc_chksum(struct net_pkt *pkt, uint16_t sum)
+static inline uint16_t pkt_calc_chksum(struct net_pkt *pkt, uint16_t sum, size_t max_len)
 {
 	struct net_pkt_cursor *cur = &pkt->cursor;
 	size_t len;
@@ -711,8 +711,15 @@ static inline uint16_t pkt_calc_chksum(struct net_pkt *pkt, uint16_t sum)
 
 	len = cur->buf->len - (cur->pos - cur->buf->data);
 
-	while (cur->buf) {
-		sum = calc_chksum(sum, cur->pos, len);
+	while (cur->buf && max_len > 0U) {
+		size_t chunk = MIN(len, max_len);
+
+		sum = calc_chksum(sum, cur->pos, chunk);
+		max_len -= chunk;
+
+		if (max_len == 0U) {
+			break;
+		}
 
 		cur->buf = cur->buf->frags;
 		if (!cur->buf || !cur->buf->len) {
@@ -729,6 +736,7 @@ static inline uint16_t pkt_calc_chksum(struct net_pkt *pkt, uint16_t sum)
 
 			cur->pos++;
 			len = cur->buf->len - 1;
+			max_len--;
 		} else {
 			len = cur->buf->len;
 		}
@@ -759,6 +767,7 @@ int net_calc_chksum(struct net_pkt *pkt, uint8_t proto, uint16_t *out_chksum)
 	struct net_pkt_cursor backup;
 	bool ow;
 	int ret;
+	size_t max_len = SIZE_MAX;
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) &&
 	    net_pkt_family(pkt) == NET_AF_INET) {
@@ -778,6 +787,23 @@ int net_calc_chksum(struct net_pkt *pkt, uint8_t proto, uint16_t *out_chksum)
 		NET_DBG("Unknown protocol family %d", net_pkt_family(pkt));
 		return -EINVAL;
 	}
+
+#if defined(CONFIG_NET_UDP_OPTIONS)
+	/* The UDP checksum covers only the UDP header and user data (the bytes
+	 * counted by the UDP Length field), never the surplus area carrying UDP
+	 * options (RFC 9868 Section 8). Exclude the surplus from both the
+	 * pseudo-header length and the summed transport bytes. At this point
+	 * @sum holds (transport_payload_len + proto).
+	 */
+	if (proto == NET_IPPROTO_UDP) {
+		uint16_t surplus = net_pkt_udp_opt_surplus_len(pkt);
+
+		if (surplus > 0U) {
+			max_len = (size_t)(uint16_t)(sum - proto) - surplus;
+			sum -= surplus;
+		}
+	}
+#endif /* CONFIG_NET_UDP_OPTIONS */
 
 	net_pkt_cursor_backup(pkt, &backup);
 	net_pkt_cursor_init(pkt);
@@ -802,7 +828,7 @@ int net_calc_chksum(struct net_pkt *pkt, uint8_t proto, uint16_t *out_chksum)
 		return ret;
 	}
 
-	sum = pkt_calc_chksum(pkt, sum);
+	sum = pkt_calc_chksum(pkt, sum, max_len);
 
 	sum = (sum == 0U) ? 0xffff : net_htons(sum);
 

--- a/subsys/net/lib/shell/udp.c
+++ b/subsys/net/lib/shell/udp.c
@@ -284,6 +284,126 @@ release_ctx:
 #endif
 }
 
+static int cmd_net_udp_dplpmtud(const struct shell *sh, size_t argc, char *argv[])
+{
+#if !defined(CONFIG_NET_UDP) || !defined(CONFIG_NET_NATIVE_UDP) || \
+	!defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	PR_INFO("Set %s to enable %s support.\n",
+		"CONFIG_NET_UDP_OPTIONS_DPLPMTUD", "DPLPMTUD over UDP options");
+	return -EOPNOTSUPP;
+#else
+	char *host = NULL;
+	char *endptr = NULL;
+	long port_long;
+	uint16_t port;
+	struct net_if *iface;
+	struct net_sockaddr addr;
+	int addrlen;
+	int enable = 1;
+	int ret;
+
+	if (argc < 3) {
+		PR_WARNING("Usage: net udp dplpmtud <host> <port>\n");
+		return -EINVAL;
+	}
+
+	host = argv[1];
+	port_long = strtol(argv[2], &endptr, 0);
+	if (endptr == argv[2] || *endptr != '\0' ||
+	    port_long <= 0 || port_long > 65535) {
+		PR_WARNING("Invalid port number\n");
+		return -EINVAL;
+	}
+
+	port = (uint16_t)port_long;
+
+	if (udp_ctx != NULL && net_context_is_used(udp_ctx)) {
+		PR_WARNING("Network context already in use, run 'net udp close' first\n");
+		return -EALREADY;
+	}
+
+	memset(&addr, 0, sizeof(addr));
+
+	ret = net_ipaddr_parse(host, strlen(host), &addr);
+	if (ret < 0) {
+		PR_WARNING("Cannot parse address \"%s\"\n", host);
+		return -EINVAL;
+	}
+
+	ret = net_context_get(addr.sa_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP,
+			      &udp_ctx);
+	if (ret < 0) {
+		PR_WARNING("Cannot get UDP context (%d)\n", ret);
+		return ret;
+	}
+
+	udp_shell = sh;
+
+	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.sa_family == NET_AF_INET6) {
+		net_sin6(&addr)->sin6_port = net_htons(port);
+		addrlen = sizeof(struct net_sockaddr_in6);
+		iface = net_if_ipv6_select_src_iface(&net_sin6(&addr)->sin6_addr);
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && addr.sa_family == NET_AF_INET) {
+		net_sin(&addr)->sin_port = net_htons(port);
+		addrlen = sizeof(struct net_sockaddr_in);
+		iface = net_if_ipv4_select_src_iface(&net_sin(&addr)->sin_addr);
+	} else {
+		PR_WARNING("IPv6 and IPv4 are disabled, cannot probe.\n");
+		ret = -EAFNOSUPPORT;
+		goto release_ctx;
+	}
+
+	if (iface == NULL) {
+		PR_WARNING("No interface to reach given host\n");
+		ret = -ENETUNREACH;
+		goto release_ctx;
+	}
+
+	net_context_set_iface(udp_ctx, iface);
+
+	/* A connected UDP context gives the prober a fixed destination. */
+	ret = net_context_connect(udp_ctx, &addr, addrlen, NULL, K_NO_WAIT, NULL);
+	if (ret < 0) {
+		PR_WARNING("Cannot connect UDP context (%d)\n", ret);
+		goto release_ctx;
+	}
+
+	/* Receiving is needed so the prober sees the RES echoes. */
+	ret = net_context_recv(udp_ctx, udp_rcvd, K_NO_WAIT, NULL);
+	if (ret < 0) {
+		PR_WARNING("Setting rcv callback failed (%d)\n", ret);
+		goto release_ctx;
+	}
+
+	/* Enabling DPLPMTUD on a connected context makes the prober emit an
+	 * initial BASE_PLPMTU probe (a DF-set, REQ-bearing UDP datagram padded
+	 * via the options surplus area) right away and keep probing upward on
+	 * its timer.
+	 */
+	ret = net_context_set_option(udp_ctx, NET_OPT_UDP_OPT_DPLPMTUD,
+				     &enable, sizeof(enable));
+	if (ret < 0) {
+		PR_WARNING("Cannot enable DPLPMTUD (%d)\n", ret);
+		goto release_ctx;
+	}
+
+	PR("DPLPMTUD probing started to %s port %u.\n", host, port);
+	PR("Use 'net pmtu' to see the discovered MTU, 'net udp close' to stop.\n");
+
+	return 0;
+
+release_ctx:
+	(void)net_context_put(udp_ctx);
+	udp_ctx = NULL;
+
+	return ret;
+#endif
+}
+
 static int cmd_net_udp(const struct shell *sh, size_t argc, char *argv[])
 {
 	ARG_UNUSED(sh);
@@ -304,6 +424,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_udp,
 		  SHELL_HELP("Sends UDP packet to a network host",
 			     "<host> <port> <payload>"),
 		  cmd_net_udp_send),
+	SHELL_CMD(dplpmtud, NULL,
+		  SHELL_HELP("Start DPLPMTUD (RFC 9869) probing to a host "
+			     "using UDP options", "<host> <port>"),
+		  cmd_net_udp_dplpmtud),
 	SHELL_SUBCMD_SET_END
 );
 

--- a/subsys/net/lib/shell/udp.c
+++ b/subsys/net/lib/shell/udp.c
@@ -404,6 +404,126 @@ release_ctx:
 #endif
 }
 
+static int cmd_net_udp_dplpmtud_server(const struct shell *sh, size_t argc,
+				       char *argv[])
+{
+#if !defined(CONFIG_NET_UDP) || !defined(CONFIG_NET_NATIVE_UDP) || \
+	!defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	PR_INFO("Set %s to enable %s support.\n",
+		"CONFIG_NET_UDP_OPTIONS_DPLPMTUD", "DPLPMTUD over UDP options");
+	return -EOPNOTSUPP;
+#else
+	char *addr_str = NULL;
+	char *endptr = NULL;
+	long port_long;
+	uint16_t port;
+	struct net_if *iface;
+	struct net_sockaddr addr;
+	int addrlen;
+	int enable = 1;
+	int ret;
+
+	if (argc < 3) {
+		PR_WARNING("Usage: net udp dplpmtud_server <addr> <port>\n");
+		return -EINVAL;
+	}
+
+	addr_str = argv[1];
+	port_long = strtol(argv[2], &endptr, 0);
+	if (endptr == argv[2] || *endptr != '\0' ||
+	    port_long <= 0 || port_long > 65535) {
+		PR_WARNING("Invalid port number\n");
+		return -EINVAL;
+	}
+
+	port = (uint16_t)port_long;
+
+	if (udp_ctx != NULL && net_context_is_used(udp_ctx)) {
+		PR_WARNING("Network context already in use, run 'net udp close' first\n");
+		return -EALREADY;
+	}
+
+	memset(&addr, 0, sizeof(addr));
+
+	ret = net_ipaddr_parse(addr_str, strlen(addr_str), &addr);
+	if (ret < 0) {
+		PR_WARNING("Cannot parse address \"%s\"\n", addr_str);
+		return -EINVAL;
+	}
+
+	ret = net_context_get(addr.sa_family, NET_SOCK_DGRAM, NET_IPPROTO_UDP,
+			      &udp_ctx);
+	if (ret < 0) {
+		PR_WARNING("Cannot get UDP context (%d)\n", ret);
+		return ret;
+	}
+
+	udp_shell = sh;
+
+	if (IS_ENABLED(CONFIG_NET_IPV6) && addr.sa_family == NET_AF_INET6) {
+		net_sin6(&addr)->sin6_port = net_htons(port);
+		addrlen = sizeof(struct net_sockaddr_in6);
+		iface = net_if_ipv6_select_src_iface(&net_sin6(&addr)->sin6_addr);
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && addr.sa_family == NET_AF_INET) {
+		net_sin(&addr)->sin_port = net_htons(port);
+		addrlen = sizeof(struct net_sockaddr_in);
+		iface = net_if_ipv4_select_src_iface(&net_sin(&addr)->sin_addr);
+	} else {
+		PR_WARNING("IPv6 and IPv4 are disabled, cannot bind.\n");
+		ret = -EAFNOSUPPORT;
+		goto release_ctx;
+	}
+
+	if (iface == NULL) {
+		PR_WARNING("No interface for the given address\n");
+		ret = -ENETUNREACH;
+		goto release_ctx;
+	}
+
+	net_context_set_iface(udp_ctx, iface);
+
+	ret = net_context_bind(udp_ctx, &addr, addrlen);
+	if (ret < 0) {
+		PR_WARNING("Binding to UDP port failed (%d)\n", ret);
+		goto release_ctx;
+	}
+
+	/* Receiving is what lets the responder see incoming REQ options. */
+	ret = net_context_recv(udp_ctx, udp_rcvd, K_NO_WAIT, NULL);
+	if (ret < 0) {
+		PR_WARNING("Setting rcv callback failed (%d)\n", ret);
+		goto release_ctx;
+	}
+
+	/* Enabling DPLPMTUD on an unconnected (bound) socket turns on the
+	 * responder role only: it echoes each received Request (REQ) token
+	 * back in a Response (RES) option. No probing is started because there
+	 * is no fixed destination.
+	 */
+	ret = net_context_set_option(udp_ctx, NET_OPT_UDP_OPT_DPLPMTUD,
+				     &enable, sizeof(enable));
+	if (ret < 0) {
+		PR_WARNING("Cannot enable DPLPMTUD (%d)\n", ret);
+		goto release_ctx;
+	}
+
+	PR("DPLPMTUD responder listening on %s port %u.\n", addr_str, port);
+	PR("Use 'net udp close' to stop.\n");
+
+	return 0;
+
+release_ctx:
+	(void)net_context_put(udp_ctx);
+	udp_ctx = NULL;
+
+	return ret;
+#endif
+}
+
 static int cmd_net_udp(const struct shell *sh, size_t argc, char *argv[])
 {
 	ARG_UNUSED(sh);
@@ -428,6 +548,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_udp,
 		  SHELL_HELP("Start DPLPMTUD (RFC 9869) probing to a host "
 			     "using UDP options", "<host> <port>"),
 		  cmd_net_udp_dplpmtud),
+	SHELL_CMD(dplpmtud_server, NULL,
+		  SHELL_HELP("Bind and act as a DPLPMTUD (RFC 9869) responder, "
+			     "echoing UDP-options probes", "<addr> <port>"),
+		  cmd_net_udp_dplpmtud_server),
 	SHELL_SUBCMD_SET_END
 );
 

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1992,6 +1992,12 @@ static enum net_context_option udp_opt_to_net_opt(int optname)
 		return NET_OPT_UDP_OPT_UENC;
 	case ZSOCK_UDP_OPT_UEXP:
 		return NET_OPT_UDP_OPT_UEXP;
+#if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+	case ZSOCK_UDP_OPT_DPLPMTUD:
+		return NET_OPT_UDP_OPT_DPLPMTUD;
+	case ZSOCK_UDP_OPT_DPLPMTUD_APP_RESPOND:
+		return NET_OPT_UDP_OPT_DPLPMTUD_APP_RESPOND;
+#endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
 	default:
 		return NET_OPT_UDP_OPT;
 	}
@@ -2196,6 +2202,10 @@ int zsock_getsockopt_ctx(struct net_context *ctx, int level, int optname,
 		case ZSOCK_UDP_OPT_UCMP:
 		case ZSOCK_UDP_OPT_UENC:
 		case ZSOCK_UDP_OPT_UEXP:
+#if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+		case ZSOCK_UDP_OPT_DPLPMTUD:
+		case ZSOCK_UDP_OPT_DPLPMTUD_APP_RESPOND:
+#endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
 			ret = net_context_get_option(ctx, udp_opt_to_net_opt(optname),
 						     optval, optlen);
 			if (ret < 0) {
@@ -2909,6 +2919,10 @@ int zsock_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 		case ZSOCK_UDP_OPT_UCMP:
 		case ZSOCK_UDP_OPT_UENC:
 		case ZSOCK_UDP_OPT_UEXP:
+#if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+		case ZSOCK_UDP_OPT_DPLPMTUD:
+		case ZSOCK_UDP_OPT_DPLPMTUD_APP_RESPOND:
+#endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
 			ret = net_context_set_option(ctx, udp_opt_to_net_opt(optname),
 						     optval, optlen);
 			if (ret < 0) {

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -36,6 +36,9 @@ LOG_MODULE_DECLARE(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include "sockets_internal.h"
 #include "../../ip/tcp_internal.h"
 #include "../../ip/net_private.h"
+#if defined(CONFIG_NET_UDP_OPTIONS)
+#include "../../ip/udp_internal.h"
+#endif
 
 #if defined(CONFIG_NET_SOCKETS_INET_RAW)
 BUILD_ASSERT(NET_IPPROTO_IP == 0, "Wildcard IPPROTO_IP must equal 0.");
@@ -1134,6 +1137,84 @@ out:
 	return ret;
 }
 
+#if defined(CONFIG_NET_UDP_OPTIONS)
+static int add_udp_options(struct net_context *ctx,
+			   struct net_pkt *pkt,
+			   struct net_msghdr *msg)
+{
+	struct net_udp_opt_info info;
+	struct net_udp_opt_mrds mrds;
+	struct net_udp_opt_time time_val;
+	int ret;
+
+	if (net_context_get_proto(ctx) != NET_IPPROTO_UDP ||
+	    net_pkt_udp_opt_surplus_len(pkt) == 0U) {
+		return 0;
+	}
+
+	ret = net_udp_opt_parse(pkt, &info);
+	if (ret < 0 || !info.ocs_valid) {
+		return 0;
+	}
+
+	if ((info.present & NET_UDP_OPT_F_APC) != 0U) {
+		ret = insert_pktinfo(msg, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_CMSG_APC,
+				     &info.apc_crc, sizeof(info.apc_crc));
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if ((info.present & NET_UDP_OPT_F_MDS) != 0U) {
+		ret = insert_pktinfo(msg, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_CMSG_MDS,
+				     &info.mds, sizeof(info.mds));
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if ((info.present & NET_UDP_OPT_F_MRDS) != 0U) {
+		mrds.size = info.mrds.size;
+		mrds.segs = info.mrds.segs;
+
+		ret = insert_pktinfo(msg, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_CMSG_MRDS,
+				     &mrds, sizeof(mrds));
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if ((info.present & NET_UDP_OPT_F_REQ) != 0U) {
+		ret = insert_pktinfo(msg, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_CMSG_REQ,
+				     &info.req_token, sizeof(info.req_token));
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if ((info.present & NET_UDP_OPT_F_RES) != 0U) {
+		ret = insert_pktinfo(msg, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_CMSG_RES,
+				     &info.res_token, sizeof(info.res_token));
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if ((info.present & NET_UDP_OPT_F_TIME) != 0U) {
+		time_val.tsval = info.time.tsval;
+		time_val.tsecr = info.time.tsecr;
+
+		ret = insert_pktinfo(msg, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_CMSG_TIME,
+				     &time_val, sizeof(time_val));
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+#endif /* CONFIG_NET_UDP_OPTIONS */
+
 static int update_msg_controllen(struct net_msghdr *msg)
 {
 	struct net_cmsghdr *cmsg;
@@ -1148,6 +1229,24 @@ static int update_msg_controllen(struct net_msghdr *msg)
 	msg->msg_controllen = cmsg_space;
 
 	return 0;
+}
+
+static size_t dgram_pkt_payload_len(struct net_context *ctx, struct net_pkt *pkt)
+{
+	size_t recv_len = net_pkt_remaining_data(pkt);
+
+	if (IS_ENABLED(CONFIG_NET_UDP_OPTIONS) &&
+	    net_context_get_proto(ctx) == NET_IPPROTO_UDP) {
+		uint16_t surplus_len = net_pkt_udp_opt_surplus_len(pkt);
+
+		if (surplus_len >= recv_len) {
+			return 0;
+		}
+
+		recv_len -= surplus_len;
+	}
+
+	return recv_len;
 }
 
 static ssize_t zsock_recv_dgram(struct net_context *ctx,
@@ -1245,7 +1344,7 @@ static ssize_t zsock_recv_dgram(struct net_context *ctx,
 			return -1;
 		}
 
-		recv_len = net_pkt_remaining_data(pkt);
+		recv_len = dgram_pkt_payload_len(ctx, pkt);
 		tmp_read_len = read_len = MIN(recv_len, max_len);
 
 		while (tmp_read_len > 0) {
@@ -1278,7 +1377,7 @@ static ssize_t zsock_recv_dgram(struct net_context *ctx,
 		}
 
 	} else {
-		recv_len = net_pkt_remaining_data(pkt);
+		recv_len = dgram_pkt_payload_len(ctx, pkt);
 		read_len = MIN(recv_len, max_len);
 
 		if (net_pkt_read(pkt, buf, read_len)) {
@@ -1310,6 +1409,12 @@ static ssize_t zsock_recv_dgram(struct net_context *ctx,
 						msg->msg_flags |= ZSOCK_MSG_CTRUNC;
 					}
 				}
+
+#if defined(CONFIG_NET_UDP_OPTIONS)
+				if (add_udp_options(ctx, pkt, msg) < 0) {
+					msg->msg_flags |= ZSOCK_MSG_CTRUNC;
+				}
+#endif /* CONFIG_NET_UDP_OPTIONS */
 
 				/* msg_controllen must be updated to reflect the total length of all
 				 * control messages in the buffer. If there are no control data,
@@ -1855,6 +1960,44 @@ static int ipv4_multicast_if(struct net_context *ctx, const void *optval,
 	return 0;
 }
 
+#if defined(CONFIG_NET_UDP_OPTIONS)
+static enum net_context_option udp_opt_to_net_opt(int optname)
+{
+	switch (optname) {
+	case ZSOCK_UDP_OPT:
+		return NET_OPT_UDP_OPT;
+	case ZSOCK_UDP_OPT_OCS:
+		return NET_OPT_UDP_OPT_OCS;
+	case ZSOCK_UDP_OPT_APC:
+		return NET_OPT_UDP_OPT_APC;
+	case ZSOCK_UDP_OPT_FRAG:
+		return NET_OPT_UDP_OPT_FRAG;
+	case ZSOCK_UDP_OPT_MDS:
+		return NET_OPT_UDP_OPT_MDS;
+	case ZSOCK_UDP_OPT_MRDS:
+		return NET_OPT_UDP_OPT_MRDS;
+	case ZSOCK_UDP_OPT_REQ:
+		return NET_OPT_UDP_OPT_REQ;
+	case ZSOCK_UDP_OPT_RES:
+		return NET_OPT_UDP_OPT_RES;
+	case ZSOCK_UDP_OPT_TIME:
+		return NET_OPT_UDP_OPT_TIME;
+	case ZSOCK_UDP_OPT_AUTH:
+		return NET_OPT_UDP_OPT_AUTH;
+	case ZSOCK_UDP_OPT_EXP:
+		return NET_OPT_UDP_OPT_EXP;
+	case ZSOCK_UDP_OPT_UCMP:
+		return NET_OPT_UDP_OPT_UCMP;
+	case ZSOCK_UDP_OPT_UENC:
+		return NET_OPT_UDP_OPT_UENC;
+	case ZSOCK_UDP_OPT_UEXP:
+		return NET_OPT_UDP_OPT_UEXP;
+	default:
+		return NET_OPT_UDP_OPT;
+	}
+}
+#endif /* CONFIG_NET_UDP_OPTIONS */
+
 int zsock_getsockopt_ctx(struct net_context *ctx, int level, int optname,
 			 void *optval, net_socklen_t *optlen)
 {
@@ -2031,6 +2174,40 @@ int zsock_getsockopt_ctx(struct net_context *ctx, int level, int optname,
 		}
 
 		break;
+
+#if defined(CONFIG_NET_UDP_OPTIONS)
+	case NET_IPPROTO_UDP:
+		if (net_context_get_proto(ctx) != NET_IPPROTO_UDP) {
+			break;
+		}
+
+		switch (optname) {
+		case ZSOCK_UDP_OPT:
+		case ZSOCK_UDP_OPT_OCS:
+		case ZSOCK_UDP_OPT_APC:
+		case ZSOCK_UDP_OPT_FRAG:
+		case ZSOCK_UDP_OPT_MDS:
+		case ZSOCK_UDP_OPT_MRDS:
+		case ZSOCK_UDP_OPT_REQ:
+		case ZSOCK_UDP_OPT_RES:
+		case ZSOCK_UDP_OPT_TIME:
+		case ZSOCK_UDP_OPT_AUTH:
+		case ZSOCK_UDP_OPT_EXP:
+		case ZSOCK_UDP_OPT_UCMP:
+		case ZSOCK_UDP_OPT_UENC:
+		case ZSOCK_UDP_OPT_UEXP:
+			ret = net_context_get_option(ctx, udp_opt_to_net_opt(optname),
+						     optval, optlen);
+			if (ret < 0) {
+				errno = -ret;
+				return -1;
+			}
+
+			return 0;
+		}
+
+		break;
+#endif /* CONFIG_NET_UDP_OPTIONS */
 
 	case NET_IPPROTO_TCP:
 		switch (optname) {
@@ -2710,6 +2887,40 @@ int zsock_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 		}
 
 		break;
+
+#if defined(CONFIG_NET_UDP_OPTIONS)
+	case NET_IPPROTO_UDP:
+		if (net_context_get_proto(ctx) != NET_IPPROTO_UDP) {
+			break;
+		}
+
+		switch (optname) {
+		case ZSOCK_UDP_OPT:
+		case ZSOCK_UDP_OPT_OCS:
+		case ZSOCK_UDP_OPT_APC:
+		case ZSOCK_UDP_OPT_FRAG:
+		case ZSOCK_UDP_OPT_MDS:
+		case ZSOCK_UDP_OPT_MRDS:
+		case ZSOCK_UDP_OPT_REQ:
+		case ZSOCK_UDP_OPT_RES:
+		case ZSOCK_UDP_OPT_TIME:
+		case ZSOCK_UDP_OPT_AUTH:
+		case ZSOCK_UDP_OPT_EXP:
+		case ZSOCK_UDP_OPT_UCMP:
+		case ZSOCK_UDP_OPT_UENC:
+		case ZSOCK_UDP_OPT_UEXP:
+			ret = net_context_set_option(ctx, udp_opt_to_net_opt(optname),
+						     optval, optlen);
+			if (ret < 0) {
+				errno = -ret;
+				return -1;
+			}
+
+			return 0;
+		}
+
+		break;
+#endif /* CONFIG_NET_UDP_OPTIONS */
 
 	case NET_IPPROTO_TCP:
 		switch (optname) {

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -1406,6 +1406,188 @@ ZTEST(net_socket_udp, test_udp_options_sendmsg_cmsg_multi)
 	zassert_equal(rv, 0, "close failed");
 }
 
+#if defined(CONFIG_NET_UDP_OPTIONS_DPLPMTUD)
+ZTEST(net_socket_udp, test_udp_options_dplpmtud_sockopt)
+{
+	struct net_sockaddr_in client_addr;
+	struct net_sockaddr_in server_addr;
+	int client_sock, server_sock;
+	net_socklen_t optlen;
+	int optval;
+	int rv;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_UDP_OPTIONS_DPLPMTUD);
+
+	prepare_sock_udp_v4(MY_IPV4_ADDR, ANY_PORT, &client_sock, &client_addr);
+	prepare_sock_udp_v4(MY_IPV4_ADDR, SERVER_PORT, &server_sock, &server_addr);
+
+	rv = zsock_bind(server_sock, (struct net_sockaddr *)&server_addr, sizeof(server_addr));
+	zassert_equal(rv, 0, "server bind failed");
+	rv = zsock_bind(client_sock, (struct net_sockaddr *)&client_addr, sizeof(client_addr));
+	zassert_equal(rv, 0, "client bind failed");
+
+	/* The responder can be enabled on an unconnected (bound) socket. */
+	optval = 1;
+	rv = zsock_setsockopt(server_sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_DPLPMTUD,
+			      &optval, sizeof(optval));
+	zassert_equal(rv, 0, "server enable DPLPMTUD failed (%d)", errno);
+
+	optlen = sizeof(optval);
+	optval = 0;
+	rv = zsock_getsockopt(server_sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_DPLPMTUD,
+			      &optval, &optlen);
+	zassert_equal(rv, 0, "getsockopt DPLPMTUD failed (%d)", errno);
+	zassert_equal(optval, 1, "DPLPMTUD not reported as enabled");
+
+	/* APP_RESPOND get/set round-trips. */
+	optval = 1;
+	rv = zsock_setsockopt(server_sock, NET_IPPROTO_UDP,
+			      ZSOCK_UDP_OPT_DPLPMTUD_APP_RESPOND, &optval, sizeof(optval));
+	zassert_equal(rv, 0, "set APP_RESPOND failed (%d)", errno);
+
+	optlen = sizeof(optval);
+	optval = 0;
+	rv = zsock_getsockopt(server_sock, NET_IPPROTO_UDP,
+			      ZSOCK_UDP_OPT_DPLPMTUD_APP_RESPOND, &optval, &optlen);
+	zassert_equal(rv, 0, "get APP_RESPOND failed (%d)", errno);
+	zassert_equal(optval, 1, "APP_RESPOND not reported as set");
+
+	/* The prober can be enabled on a connected socket. */
+	rv = zsock_connect(client_sock, (struct net_sockaddr *)&server_addr,
+			   sizeof(server_addr));
+	zassert_equal(rv, 0, "client connect failed (%d)", errno);
+
+	optval = 1;
+	rv = zsock_setsockopt(client_sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_DPLPMTUD,
+			      &optval, sizeof(optval));
+	zassert_equal(rv, 0, "client enable DPLPMTUD failed (%d)", errno);
+
+	/* Disabling clears the enabled state. */
+	optval = 0;
+	rv = zsock_setsockopt(client_sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_DPLPMTUD,
+			      &optval, sizeof(optval));
+	zassert_equal(rv, 0, "disable DPLPMTUD failed (%d)", errno);
+
+	optlen = sizeof(optval);
+	optval = 1;
+	rv = zsock_getsockopt(client_sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_DPLPMTUD,
+			      &optval, &optlen);
+	zassert_equal(rv, 0, "getsockopt DPLPMTUD failed (%d)", errno);
+	zassert_equal(optval, 0, "DPLPMTUD not reported as disabled");
+
+	rv = zsock_close(client_sock);
+	zassert_equal(rv, 0, "close failed");
+	rv = zsock_close(server_sock);
+	zassert_equal(rv, 0, "close failed");
+}
+
+ZTEST(net_socket_udp, test_udp_options_dplpmtud_responder_echo)
+{
+	struct net_sockaddr_in client_addr;
+	struct net_sockaddr_in server_addr;
+	struct net_sockaddr addr;
+	struct net_msghdr msg = { 0 };
+	struct net_msghdr rmsg = { 0 };
+	struct net_iovec io_vector[1];
+	struct net_cmsghdr *cmsg, *prevcmsg;
+	union {
+		struct net_cmsghdr hdr;
+		unsigned char buf[NET_CMSG_SPACE(sizeof(uint32_t))];
+	} cmsgbuf;
+	union {
+		struct net_cmsghdr hdr;
+		unsigned char buf[NET_CMSG_SPACE(sizeof(uint32_t))];
+	} rcmsgbuf;
+	uint32_t req_token = 0xabcd1234U;
+	uint32_t res_token = 0U;
+	net_socklen_t addrlen;
+	int client_sock, server_sock;
+	bool found = false;
+	ssize_t sent, recved;
+	int optval;
+	int rv;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_UDP_OPTIONS_DPLPMTUD);
+
+	prepare_sock_udp_v4(MY_IPV4_ADDR, ANY_PORT, &client_sock, &client_addr);
+	prepare_sock_udp_v4(MY_IPV4_ADDR, SERVER_PORT, &server_sock, &server_addr);
+
+	rv = zsock_bind(server_sock, (struct net_sockaddr *)&server_addr, sizeof(server_addr));
+	zassert_equal(rv, 0, "server bind failed");
+	rv = zsock_bind(client_sock, (struct net_sockaddr *)&client_addr, sizeof(client_addr));
+	zassert_equal(rv, 0, "client bind failed");
+
+	/* Enable the DPLPMTUD responder on the server. */
+	optval = 1;
+	rv = zsock_setsockopt(server_sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_DPLPMTUD,
+			      &optval, sizeof(optval));
+	zassert_equal(rv, 0, "server enable DPLPMTUD failed (%d)", errno);
+
+	/* The client sends a datagram carrying an application-supplied REQ. */
+	io_vector[0].iov_base = TEST_STR_SMALL;
+	io_vector[0].iov_len = STRLEN(TEST_STR_SMALL);
+	memset(&cmsgbuf, 0, sizeof(cmsgbuf));
+	msg.msg_name = &server_addr;
+	msg.msg_namelen = sizeof(server_addr);
+	msg.msg_iov = io_vector;
+	msg.msg_iovlen = 1;
+	msg.msg_control = &cmsgbuf.buf;
+	msg.msg_controllen = sizeof(cmsgbuf.buf);
+
+	cmsg = NET_CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_len = NET_CMSG_LEN(sizeof(req_token));
+	cmsg->cmsg_level = NET_IPPROTO_UDP;
+	cmsg->cmsg_type = ZSOCK_UDP_OPT_CMSG_REQ;
+	memcpy(NET_CMSG_DATA(cmsg), &req_token, sizeof(req_token));
+
+	sent = zsock_sendmsg(client_sock, &msg, 0);
+	zassert_equal(sent, STRLEN(TEST_STR_SMALL), "sendmsg failed (%d)", errno);
+
+	/* Drain the datagram on the server; the RES echo was generated during
+	 * its reception, independently of the application.
+	 */
+	clear_buf(rx_buf);
+	recved = zsock_recv(server_sock, rx_buf, sizeof(rx_buf), 0);
+	zassert_equal(recved, STRLEN(TEST_STR_SMALL), "server recv failed (%zd)", recved);
+
+	/* The client receives the auto-generated RES echo. */
+	io_vector[0].iov_base = rx_buf;
+	io_vector[0].iov_len = sizeof(rx_buf);
+	addrlen = sizeof(addr);
+	memset(&rcmsgbuf, 0, sizeof(rcmsgbuf));
+	rmsg.msg_name = &addr;
+	rmsg.msg_namelen = addrlen;
+	rmsg.msg_iov = io_vector;
+	rmsg.msg_iovlen = 1;
+	rmsg.msg_control = &rcmsgbuf.buf;
+	rmsg.msg_controllen = sizeof(rcmsgbuf.buf);
+
+	clear_buf(rx_buf);
+	recved = zsock_recvmsg(client_sock, &rmsg, 0);
+	zassert_true(recved >= 0, "client recvmsg failed (%d)", errno);
+
+	for (prevcmsg = NULL, cmsg = NET_CMSG_FIRSTHDR(&rmsg);
+	     cmsg != NULL && prevcmsg != cmsg;
+	     prevcmsg = cmsg, cmsg = NET_CMSG_NXTHDR(&rmsg, cmsg)) {
+		if (cmsg->cmsg_level == NET_IPPROTO_UDP &&
+		    cmsg->cmsg_type == ZSOCK_UDP_OPT_CMSG_RES) {
+			memcpy(&res_token, NET_CMSG_DATA(cmsg), sizeof(res_token));
+			found = true;
+			break;
+		}
+	}
+
+	zassert_true(found, "no RES echo received from responder");
+	zassert_equal(res_token, req_token, "echoed RES token mismatch (0x%x != 0x%x)",
+		      res_token, req_token);
+
+	rv = zsock_close(client_sock);
+	zassert_equal(rv, 0, "close failed");
+	rv = zsock_close(server_sock);
+	zassert_equal(rv, 0, "close failed");
+}
+#endif /* CONFIG_NET_UDP_OPTIONS_DPLPMTUD */
+
 static void comm_sendmsg_with_txtime(int client_sock,
 				     struct net_sockaddr *client_addr,
 				     net_socklen_t client_addrlen,

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -996,6 +996,416 @@ ZTEST(net_socket_udp, test_so_protocol)
 	zassert_equal(rv, 0, "close failed");
 }
 
+ZTEST(net_socket_udp, test_udp_options_sockopt_api)
+{
+	struct net_sockaddr_in bind_addr4;
+	struct net_udp_opt_mrds mrds_set = {
+		.size = 1400,
+		.segs = 7,
+	};
+	struct net_udp_opt_mrds mrds_get = { 0 };
+	uint16_t mds = 1234;
+	int sock, rv;
+	int optval;
+	net_socklen_t optlen;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_UDP_OPTIONS);
+
+	prepare_sock_udp_v4(MY_IPV4_ADDR, ANY_PORT, &sock, &bind_addr4);
+
+	rv = zsock_bind(sock, (struct net_sockaddr *)&bind_addr4, sizeof(bind_addr4));
+	zassert_equal(rv, 0, "bind failed");
+
+	optlen = sizeof(optval);
+	rv = zsock_getsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_OCS,
+			      &optval, &optlen);
+	zassert_equal(rv, 0, "getsockopt UDP_OPT_OCS failed (%d)", errno);
+	zassert_equal(optval, 0, "default UDP_OPT_OCS state invalid");
+
+	optval = 1;
+	rv = zsock_setsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_APC,
+			      &optval, sizeof(optval));
+	zassert_equal(rv, 0, "setsockopt UDP_OPT_APC failed (%d)", errno);
+
+	optlen = sizeof(optval);
+	optval = 0;
+	rv = zsock_getsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_APC,
+			      &optval, &optlen);
+	zassert_equal(rv, 0, "getsockopt UDP_OPT_APC failed (%d)", errno);
+	zassert_equal(optval, 1, "UDP_OPT_APC did not enable");
+
+	optval = 0;
+	rv = zsock_setsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_APC,
+			      &optval, sizeof(optval));
+	zassert_equal(rv, 0, "setsockopt UDP_OPT_APC clear failed (%d)", errno);
+
+	optlen = sizeof(optval);
+	optval = 1;
+	rv = zsock_getsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_APC,
+			      &optval, &optlen);
+	zassert_equal(rv, 0, "getsockopt UDP_OPT_APC failed (%d)", errno);
+	zassert_equal(optval, 0, "UDP_OPT_APC did not clear");
+
+	rv = zsock_setsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_MDS,
+			      &mds, sizeof(mds));
+	zassert_equal(rv, 0, "setsockopt UDP_OPT_MDS failed (%d)", errno);
+
+	mds = 0;
+	optlen = sizeof(mds);
+	rv = zsock_getsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_MDS,
+			      &mds, &optlen);
+	zassert_equal(rv, 0, "getsockopt UDP_OPT_MDS failed (%d)", errno);
+	zassert_equal(mds, 1234, "UDP_OPT_MDS mismatch");
+
+	rv = zsock_setsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_MRDS,
+			      &mrds_set, sizeof(mrds_set));
+	zassert_equal(rv, 0, "setsockopt UDP_OPT_MRDS failed (%d)", errno);
+
+	optlen = sizeof(mrds_get);
+	rv = zsock_getsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_MRDS,
+			      &mrds_get, &optlen);
+	zassert_equal(rv, 0, "getsockopt UDP_OPT_MRDS failed (%d)", errno);
+	zassert_equal(mrds_get.size, mrds_set.size, "UDP_OPT_MRDS size mismatch");
+	zassert_equal(mrds_get.segs, mrds_set.segs, "UDP_OPT_MRDS segs mismatch");
+
+	optval = 70000;
+	errno = 0;
+	rv = zsock_setsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_MDS,
+			      &optval, sizeof(optval));
+	zassert_equal(rv, -1, "setsockopt UDP_OPT_MDS unexpectedly succeeded");
+	zassert_equal(errno, EINVAL, "unexpected errno for invalid MDS");
+
+	optval = 0;
+	rv = zsock_setsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT,
+			      &optval, sizeof(optval));
+	zassert_equal(rv, 0, "setsockopt UDP_OPT clear failed (%d)", errno);
+
+	optlen = sizeof(optval);
+	optval = 1;
+	rv = zsock_getsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_OCS,
+			      &optval, &optlen);
+	zassert_equal(rv, 0, "getsockopt UDP_OPT_OCS failed (%d)", errno);
+	zassert_equal(optval, 0, "UDP_OPT clear did not disable OCS");
+
+	optval = 1;
+	rv = zsock_setsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT,
+			      &optval, sizeof(optval));
+	zassert_equal(rv, 0, "setsockopt UDP_OPT enable failed (%d)", errno);
+
+	optlen = sizeof(optval);
+	optval = 0;
+	rv = zsock_getsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT,
+			      &optval, &optlen);
+	zassert_equal(rv, 0, "getsockopt UDP_OPT failed (%d)", errno);
+	zassert_equal(optval, 1, "UDP_OPT enable state mismatch");
+
+	optval = 1;
+	errno = 0;
+	rv = zsock_setsockopt(sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_AUTH,
+			      &optval, sizeof(optval));
+	zassert_equal(rv, -1, "setsockopt UDP_OPT_AUTH unexpectedly succeeded");
+	zassert_true(errno == ENOTSUP || errno == EOPNOTSUPP,
+		     "unexpected errno for unsupported option (%d)", errno);
+
+	rv = zsock_close(sock);
+	zassert_equal(rv, 0, "close failed");
+}
+
+ZTEST(net_socket_udp, test_udp_options_surplus_not_delivered)
+{
+	static const char payload_even[] = "ABCD";
+	static const char payload_odd[] = "ABCDE";
+	struct net_sockaddr_in client_addr;
+	struct net_sockaddr_in server_addr;
+	struct net_sockaddr addr;
+	int client_sock, server_sock;
+	net_socklen_t addrlen;
+	ssize_t recved;
+	int rv;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_UDP_OPTIONS);
+
+	prepare_sock_udp_v4(MY_IPV4_ADDR, ANY_PORT, &client_sock, &client_addr);
+	prepare_sock_udp_v4(MY_IPV4_ADDR, SERVER_PORT, &server_sock, &server_addr);
+
+	rv = zsock_bind(server_sock, (struct net_sockaddr *)&server_addr,
+			sizeof(server_addr));
+	zassert_equal(rv, 0, "bind failed");
+
+	rv = zsock_sendto(client_sock, payload_even, sizeof(payload_even) - 1, 0,
+			  (struct net_sockaddr *)&server_addr, sizeof(server_addr));
+	zassert_equal(rv, sizeof(payload_even) - 1, "sendto even failed (%d)", errno);
+
+	addrlen = sizeof(addr);
+	clear_buf(rx_buf);
+	recved = zsock_recvfrom(server_sock, rx_buf, sizeof(rx_buf),
+				0, &addr, &addrlen);
+	zassert_equal(recved, sizeof(payload_even) - 1, "recv even length mismatch");
+	zassert_mem_equal(rx_buf, payload_even, sizeof(payload_even) - 1,
+			  "recv even data mismatch");
+
+	rv = zsock_sendto(client_sock, payload_odd, sizeof(payload_odd) - 1, 0,
+			  (struct net_sockaddr *)&server_addr, sizeof(server_addr));
+	zassert_equal(rv, sizeof(payload_odd) - 1, "sendto odd failed (%d)", errno);
+
+	addrlen = sizeof(addr);
+	clear_buf(rx_buf);
+	recved = zsock_recvfrom(server_sock, rx_buf, sizeof(rx_buf),
+				0, &addr, &addrlen);
+	zassert_equal(recved, sizeof(payload_odd) - 1, "recv odd length mismatch");
+	zassert_mem_equal(rx_buf, payload_odd, sizeof(payload_odd) - 1,
+			  "recv odd data mismatch");
+
+	rv = zsock_close(client_sock);
+	zassert_equal(rv, 0, "close failed");
+	rv = zsock_close(server_sock);
+	zassert_equal(rv, 0, "close failed");
+}
+
+ZTEST(net_socket_udp, test_udp_options_sendmsg_cmsg_mds)
+{
+	struct net_sockaddr_in client_addr;
+	struct net_sockaddr_in server_addr;
+	struct net_sockaddr addr;
+	struct net_msghdr msg = { 0 };
+	struct net_msghdr server_msg = { 0 };
+	struct net_iovec io_vector[1];
+	struct net_cmsghdr *cmsg, *prevcmsg;
+	union {
+		struct net_cmsghdr hdr;
+		unsigned char buf[NET_CMSG_SPACE(sizeof(uint16_t))];
+	} cmsgbuf;
+	union {
+		struct net_cmsghdr hdr;
+		unsigned char buf[NET_CMSG_SPACE(sizeof(uint16_t))];
+	} server_cmsgbuf;
+	uint16_t mds_tx = 1200U;
+	uint16_t mds_rx = 0U;
+	net_socklen_t addrlen;
+	int client_sock, server_sock;
+	bool found = false;
+	ssize_t sent;
+	ssize_t recved;
+	int rv;
+	int zero = 0;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_UDP_OPTIONS);
+
+	prepare_sock_udp_v4(MY_IPV4_ADDR, ANY_PORT, &client_sock, &client_addr);
+	prepare_sock_udp_v4(MY_IPV4_ADDR, SERVER_PORT, &server_sock, &server_addr);
+
+	rv = zsock_bind(server_sock, (struct net_sockaddr *)&server_addr, sizeof(server_addr));
+	zassert_equal(rv, 0, "server bind failed");
+
+	rv = zsock_bind(client_sock, (struct net_sockaddr *)&client_addr, sizeof(client_addr));
+	zassert_equal(rv, 0, "client bind failed");
+
+	/* Keep socket-level UDP options off so this test exercises only cmsg input. */
+	rv = zsock_setsockopt(client_sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT, &zero, sizeof(zero));
+	zassert_equal(rv, 0, "clear UDP options failed (%d)", errno);
+
+	io_vector[0].iov_base = TEST_STR_SMALL;
+	io_vector[0].iov_len = STRLEN(TEST_STR_SMALL);
+
+	memset(&cmsgbuf, 0, sizeof(cmsgbuf));
+	msg.msg_name = &server_addr;
+	msg.msg_namelen = sizeof(server_addr);
+	msg.msg_iov = io_vector;
+	msg.msg_iovlen = 1;
+	msg.msg_control = &cmsgbuf.buf;
+	msg.msg_controllen = sizeof(cmsgbuf.buf);
+
+	cmsg = NET_CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_len = NET_CMSG_LEN(sizeof(mds_tx));
+	cmsg->cmsg_level = NET_IPPROTO_UDP;
+	cmsg->cmsg_type = ZSOCK_UDP_OPT_CMSG_MDS;
+	memcpy(NET_CMSG_DATA(cmsg), &mds_tx, sizeof(mds_tx));
+
+	sent = zsock_sendmsg(client_sock, &msg, 0);
+	zassert_equal(sent, STRLEN(TEST_STR_SMALL), "sendmsg failed (%d)", errno);
+
+	io_vector[0].iov_base = rx_buf;
+	io_vector[0].iov_len = sizeof(rx_buf);
+	addrlen = sizeof(addr);
+	memset(&server_cmsgbuf, 0, sizeof(server_cmsgbuf));
+	server_msg.msg_name = &addr;
+	server_msg.msg_namelen = addrlen;
+	server_msg.msg_iov = io_vector;
+	server_msg.msg_iovlen = 1;
+	server_msg.msg_control = &server_cmsgbuf.buf;
+	server_msg.msg_controllen = sizeof(server_cmsgbuf.buf);
+
+	clear_buf(rx_buf);
+	recved = zsock_recvmsg(server_sock, &server_msg, 0);
+	zassert_equal(recved, STRLEN(TEST_STR_SMALL), "recvmsg failed (%d)", errno);
+	zassert_mem_equal(rx_buf, TEST_STR_SMALL, STRLEN(TEST_STR_SMALL), "wrong payload");
+
+	for (prevcmsg = NULL, cmsg = NET_CMSG_FIRSTHDR(&server_msg);
+	     cmsg != NULL && prevcmsg != cmsg;
+	     prevcmsg = cmsg, cmsg = NET_CMSG_NXTHDR(&server_msg, cmsg)) {
+		if (cmsg->cmsg_level == NET_IPPROTO_UDP &&
+		    cmsg->cmsg_type == ZSOCK_UDP_OPT_CMSG_MDS) {
+			memcpy(&mds_rx, NET_CMSG_DATA(cmsg), sizeof(mds_rx));
+			found = true;
+			break;
+		}
+	}
+
+	zassert_true(found, "missing UDP MDS control message");
+	zassert_equal(mds_rx, mds_tx, "UDP MDS value mismatch");
+
+	rv = zsock_close(client_sock);
+	zassert_equal(rv, 0, "close failed");
+	rv = zsock_close(server_sock);
+	zassert_equal(rv, 0, "close failed");
+}
+
+ZTEST(net_socket_udp, test_udp_options_sendmsg_cmsg_multi)
+{
+	struct net_sockaddr_in client_addr;
+	struct net_sockaddr_in server_addr;
+	struct net_sockaddr addr;
+	struct net_msghdr msg = { 0 };
+	struct net_msghdr server_msg = { 0 };
+	struct net_iovec io_vector[1];
+	struct net_cmsghdr *cmsg, *prevcmsg;
+	struct net_udp_opt_time time_tx = {
+		.tsval = 0x12345678U,
+		.tsecr = 0x87654321U,
+	};
+	struct net_udp_opt_time time_rx = { 0 };
+	union {
+		struct net_cmsghdr hdr;
+		unsigned char buf[NET_CMSG_SPACE(sizeof(uint16_t)) +
+				  NET_CMSG_SPACE(sizeof(uint32_t)) +
+				  NET_CMSG_SPACE(sizeof(time_tx))];
+	} cmsgbuf;
+	union {
+		struct net_cmsghdr hdr;
+		unsigned char buf[NET_CMSG_SPACE(sizeof(uint16_t)) +
+				  NET_CMSG_SPACE(sizeof(uint32_t)) +
+				  NET_CMSG_SPACE(sizeof(time_tx))];
+	} server_cmsgbuf;
+	uint16_t mds_tx = 1100U, mds_rx = 0U, mds_sock = 0U;
+	uint32_t req_tx = 0x11223344U, req_rx = 0U;
+	net_socklen_t addrlen;
+	net_socklen_t optlen;
+	int client_sock, server_sock;
+	bool found_mds = false;
+	bool found_req = false;
+	bool found_time = false;
+	ssize_t sent;
+	ssize_t recved;
+	int rv;
+	int zero = 0;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_UDP_OPTIONS);
+
+	prepare_sock_udp_v4(MY_IPV4_ADDR, ANY_PORT, &client_sock, &client_addr);
+	prepare_sock_udp_v4(MY_IPV4_ADDR, SERVER_PORT, &server_sock, &server_addr);
+
+	rv = zsock_bind(server_sock, (struct net_sockaddr *)&server_addr,
+			sizeof(server_addr));
+	zassert_equal(rv, 0, "server bind failed");
+
+	rv = zsock_bind(client_sock, (struct net_sockaddr *)&client_addr,
+			sizeof(client_addr));
+	zassert_equal(rv, 0, "client bind failed");
+
+	rv = zsock_setsockopt(client_sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT,
+			      &zero, sizeof(zero));
+	zassert_equal(rv, 0, "clear UDP options failed (%d)", errno);
+
+	io_vector[0].iov_base = TEST_STR_SMALL;
+	io_vector[0].iov_len = STRLEN(TEST_STR_SMALL);
+
+	memset(&cmsgbuf, 0, sizeof(cmsgbuf));
+	msg.msg_name = &server_addr;
+	msg.msg_namelen = sizeof(server_addr);
+	msg.msg_iov = io_vector;
+	msg.msg_iovlen = 1;
+	msg.msg_control = &cmsgbuf.buf;
+	msg.msg_controllen = sizeof(cmsgbuf.buf);
+
+	cmsg = NET_CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_len = NET_CMSG_LEN(sizeof(mds_tx));
+	cmsg->cmsg_level = NET_IPPROTO_UDP;
+	cmsg->cmsg_type = ZSOCK_UDP_OPT_CMSG_MDS;
+	memcpy(NET_CMSG_DATA(cmsg), &mds_tx, sizeof(mds_tx));
+
+	cmsg = NET_CMSG_NXTHDR(&msg, cmsg);
+	zassert_not_null(cmsg, "missing second cmsg slot");
+	cmsg->cmsg_len = NET_CMSG_LEN(sizeof(req_tx));
+	cmsg->cmsg_level = NET_IPPROTO_UDP;
+	cmsg->cmsg_type = ZSOCK_UDP_OPT_CMSG_REQ;
+	memcpy(NET_CMSG_DATA(cmsg), &req_tx, sizeof(req_tx));
+
+	cmsg = NET_CMSG_NXTHDR(&msg, cmsg);
+	zassert_not_null(cmsg, "missing third cmsg slot");
+	cmsg->cmsg_len = NET_CMSG_LEN(sizeof(time_tx));
+	cmsg->cmsg_level = NET_IPPROTO_UDP;
+	cmsg->cmsg_type = ZSOCK_UDP_OPT_CMSG_TIME;
+	memcpy(NET_CMSG_DATA(cmsg), &time_tx, sizeof(time_tx));
+
+	sent = zsock_sendmsg(client_sock, &msg, 0);
+	zassert_equal(sent, STRLEN(TEST_STR_SMALL), "sendmsg failed (%d)", errno);
+
+	io_vector[0].iov_base = rx_buf;
+	io_vector[0].iov_len = sizeof(rx_buf);
+	addrlen = sizeof(addr);
+	memset(&server_cmsgbuf, 0, sizeof(server_cmsgbuf));
+	server_msg.msg_name = &addr;
+	server_msg.msg_namelen = addrlen;
+	server_msg.msg_iov = io_vector;
+	server_msg.msg_iovlen = 1;
+	server_msg.msg_control = &server_cmsgbuf.buf;
+	server_msg.msg_controllen = sizeof(server_cmsgbuf.buf);
+
+	clear_buf(rx_buf);
+	recved = zsock_recvmsg(server_sock, &server_msg, 0);
+	zassert_equal(recved, STRLEN(TEST_STR_SMALL), "recvmsg failed (%d)", errno);
+	zassert_mem_equal(rx_buf, TEST_STR_SMALL, STRLEN(TEST_STR_SMALL),
+			  "wrong payload");
+
+	for (prevcmsg = NULL, cmsg = NET_CMSG_FIRSTHDR(&server_msg);
+	     cmsg != NULL && prevcmsg != cmsg;
+	     prevcmsg = cmsg, cmsg = NET_CMSG_NXTHDR(&server_msg, cmsg)) {
+		if (cmsg->cmsg_level != NET_IPPROTO_UDP) {
+			continue;
+		}
+
+		if (cmsg->cmsg_type == ZSOCK_UDP_OPT_CMSG_MDS) {
+			memcpy(&mds_rx, NET_CMSG_DATA(cmsg), sizeof(mds_rx));
+			found_mds = true;
+		} else if (cmsg->cmsg_type == ZSOCK_UDP_OPT_CMSG_REQ) {
+			memcpy(&req_rx, NET_CMSG_DATA(cmsg), sizeof(req_rx));
+			found_req = true;
+		} else if (cmsg->cmsg_type == ZSOCK_UDP_OPT_CMSG_TIME) {
+			memcpy(&time_rx, NET_CMSG_DATA(cmsg), sizeof(time_rx));
+			found_time = true;
+		}
+	}
+
+	zassert_true(found_mds, "missing UDP MDS control message");
+	zassert_true(found_req, "missing UDP REQ control message");
+	zassert_true(found_time, "missing UDP TIME control message");
+	zassert_equal(mds_rx, mds_tx, "UDP MDS mismatch");
+	zassert_equal(req_rx, req_tx, "UDP REQ mismatch");
+	zassert_equal(time_rx.tsval, time_tx.tsval, "UDP TIME tsval mismatch");
+	zassert_equal(time_rx.tsecr, time_tx.tsecr, "UDP TIME tsecr mismatch");
+
+	optlen = sizeof(mds_sock);
+	rv = zsock_getsockopt(client_sock, NET_IPPROTO_UDP, ZSOCK_UDP_OPT_MDS,
+			      &mds_sock, &optlen);
+	zassert_equal(rv, 0, "getsockopt UDP_OPT_MDS failed (%d)", errno);
+	zassert_equal(mds_sock, 0U, "per-packet MDS leaked into socket option");
+
+	rv = zsock_close(client_sock);
+	zassert_equal(rv, 0, "close failed");
+	rv = zsock_close(server_sock);
+	zassert_equal(rv, 0, "close failed");
+}
+
 static void comm_sendmsg_with_txtime(int client_sock,
 				     struct net_sockaddr *client_addr,
 				     net_socklen_t client_addrlen,

--- a/tests/net/socket/udp/tests.yaml
+++ b/tests/net/socket/udp/tests.yaml
@@ -51,3 +51,11 @@ tests:
   net.socket.udp.udp_options:
     extra_configs:
       - CONFIG_NET_UDP_OPTIONS=y
+  net.socket.udp.dplpmtud:
+    extra_configs:
+      - CONFIG_NET_UDP_OPTIONS=y
+      - CONFIG_NET_IPV4_PMTU=y
+      - CONFIG_NET_IPV4_PMTU_DPLPMTUD=y
+      - CONFIG_NET_IPV6_PMTU=y
+      - CONFIG_NET_IPV6_PMTU_DPLPMTUD=y
+      - CONFIG_NET_UDP_OPTIONS_DPLPMTUD=y

--- a/tests/net/socket/udp/tests.yaml
+++ b/tests/net/socket/udp/tests.yaml
@@ -48,3 +48,6 @@ tests:
   net.socket.udp.v4_mapping_to_v6_enabled:
     extra_configs:
       - CONFIG_NET_IPV4_MAPPING_TO_IPV6=y
+  net.socket.udp.udp_options:
+    extra_configs:
+      - CONFIG_NET_UDP_OPTIONS=y

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -640,4 +640,272 @@ ZTEST(udp_fn_tests, test_udp)
 	zassert_false(test_failed, "udp tests failed");
 }
 
+#if defined(CONFIG_NET_UDP_OPTIONS)
+/* Overwrite the UDP checksum field (offset 6 in the UDP header) so that the
+ * OCS finalization / parsing treats the checksum as present (non-zero).
+ */
+static void set_v4_udp_checksum(struct net_pkt *pkt, uint16_t chksum)
+{
+	struct net_pkt_cursor backup;
+	bool ow = net_pkt_is_being_overwritten(pkt);
+
+	net_pkt_set_overwrite(pkt, true);
+	net_pkt_cursor_backup(pkt, &backup);
+	net_pkt_cursor_init(pkt);
+	zassert_ok(net_pkt_skip(pkt, net_pkt_ip_hdr_len(pkt) + 6U),
+		   "skip to UDP checksum failed");
+	zassert_ok(net_pkt_write_be16(pkt, chksum), "write UDP checksum failed");
+	net_pkt_cursor_restore(pkt, &backup);
+	net_pkt_set_overwrite(pkt, ow);
+}
+
+/* Build an IPv4 UDP packet with four bytes of user data followed by a surplus
+ * area (RFC 9868). The surplus is [OCS(2)][tlvs...] (the four-byte data keeps
+ * the surplus 2-byte aligned so no pad byte is needed). With @valid_ocs a
+ * correct OCS is computed over a non-zero UDP checksum; otherwise the OCS bytes
+ * are left as @ocs_raw.
+ */
+static struct net_pkt *build_v4_udp_opt_pkt(const uint8_t *tlvs, size_t tlv_len,
+					    bool valid_ocs, uint16_t ocs_raw)
+{
+	static const uint8_t data[4] = { 'D', 'A', 'T', 'A' };
+	struct net_in_addr src = { { { 192, 0, 2, 2 } } };
+	struct net_in_addr dst = { { { 192, 0, 2, 1 } } };
+	uint16_t surplus_len = (uint16_t)(sizeof(uint16_t) + tlv_len);
+	uint16_t surplus_offset;
+	uint8_t ocs_bytes[2];
+	struct net_pkt *pkt;
+
+	ocs_bytes[0] = ocs_raw >> 8;
+	ocs_bytes[1] = ocs_raw & 0xffU;
+
+	pkt = net_pkt_alloc_with_buffer(net_if_get_default(),
+					sizeof(data) + surplus_len, NET_AF_INET,
+					NET_IPPROTO_UDP, K_SECONDS(1));
+	zassert_not_null(pkt, "Out of mem");
+
+	zassert_ok(net_ipv4_create(pkt, &src, &dst), "create v4 failed");
+	zassert_ok(net_udp_create(pkt, net_htons(1234), net_htons(4242)), "create udp failed");
+	zassert_ok(net_pkt_write(pkt, data, sizeof(data)), "write data failed");
+	zassert_ok(net_pkt_write(pkt, ocs_bytes, sizeof(ocs_bytes)), "write ocs failed");
+	if (tlv_len > 0U) {
+		zassert_ok(net_pkt_write(pkt, tlvs, tlv_len), "write tlvs failed");
+	}
+
+	net_pkt_set_udp_opt_surplus_len(pkt, surplus_len);
+
+	net_pkt_cursor_init(pkt);
+	net_ipv4_finalize(pkt, NET_IPPROTO_UDP);
+
+	surplus_offset = net_pkt_ip_hdr_len(pkt) + NET_UDPH_LEN + sizeof(data);
+
+	if (valid_ocs) {
+		/* Force a non-zero UDP checksum so the OCS must be validated,
+		 * then compute a correct OCS over the surplus area.
+		 */
+		set_v4_udp_checksum(pkt, 0x1234);
+		zassert_ok(net_udp_opt_finalize_ocs(pkt, surplus_offset, surplus_len),
+			   "finalize ocs failed");
+	} else {
+		/* Deterministic zero UDP checksum for the invalid/unused-OCS
+		 * scenarios (the interface would otherwise compute one).
+		 */
+		set_v4_udp_checksum(pkt, 0);
+	}
+
+	net_pkt_cursor_init(pkt);
+
+	return pkt;
+}
+
+ZTEST(udp_fn_tests, test_udp_opt_bad_ocs_still_delivered)
+{
+	/* RFC 9868: a failed OCS (or otherwise malformed surplus area) MUST NOT
+	 * cause the datagram to be dropped; the user data is delivered and the
+	 * options are ignored.
+	 */
+	static const uint8_t mds_tlv[4] = { NET_UDP_OPT_KIND_MDS, 0x04U, 0x04U, 0xb0U };
+	struct net_in_addr my = { { { 192, 0, 2, 1 } } };
+	struct net_sockaddr_in local = {
+		.sin_family = NET_AF_INET,
+		.sin_port = net_htons(4242),
+	};
+	struct net_if *iface = net_if_get_default();
+	struct net_conn_handle *handle = NULL;
+	struct ud opt_ud = { 0 };
+	struct net_pkt *pkt;
+	int ret;
+
+	net_ipaddr_copy(&local.sin_addr, &my);
+	(void)net_if_ipv4_addr_add(iface, &my, NET_ADDR_MANUAL, 0);
+
+	ret = net_udp_register(NET_AF_INET, NULL, (struct net_sockaddr *)&local,
+			       0, 4242, NULL, test_ok, &opt_ud, &handle);
+	zassert_ok(ret, "register failed (%d)", ret);
+
+	/* Non-zero, deliberately wrong OCS value. */
+	pkt = build_v4_udp_opt_pkt(mds_tlv, sizeof(mds_tlv), false, 0x0001U);
+
+	fail = true;
+	ret = net_recv_data(iface, pkt);
+	zassert_ok(ret, "recv failed (%d)", ret);
+
+	zassert_ok(k_sem_take(&recv_lock, TIMEOUT),
+		   "datagram with a bad OCS was dropped instead of delivered");
+	zassert_false(fail, "handler reported failure");
+
+	(void)net_udp_unregister(handle);
+}
+
+ZTEST(udp_fn_tests, test_udp_opt_parse_known_ok)
+{
+	/* Positive control: a valid MDS option with a correct OCS parses and
+	 * is reported through the option info.
+	 */
+	static const uint8_t mds_tlv[4] = { NET_UDP_OPT_KIND_MDS, 0x04U, 0x04U, 0xb0U };
+	struct net_udp_opt_info info;
+	struct net_pkt *pkt;
+	int ret;
+
+	pkt = build_v4_udp_opt_pkt(mds_tlv, sizeof(mds_tlv), true, 0U);
+	ret = net_udp_opt_parse(pkt, &info);
+	zassert_ok(ret, "valid options rejected (ret %d)", ret);
+	zassert_true((info.present & NET_UDP_OPT_F_MDS) != 0U, "MDS not parsed");
+	zassert_equal(info.mds, 0x04b0U, "MDS value mismatch (%u)", info.mds);
+
+	net_pkt_unref(pkt);
+}
+
+ZTEST(udp_fn_tests, test_udp_opt_unknown_unsafe_discarded)
+{
+	/* RFC 9868 Section 7: an unsupported option in the UNSAFE range
+	 * (192-255) must cause all options to be discarded, i.e. parsing must
+	 * report an error.
+	 */
+	static const uint8_t unsafe_tlv[4] = { NET_UDP_OPT_KIND_UCMP, 0x04U, 0x00U, 0x00U };
+	struct net_udp_opt_info info;
+	struct net_pkt *pkt;
+	int ret;
+
+	pkt = build_v4_udp_opt_pkt(unsafe_tlv, sizeof(unsafe_tlv), true, 0U);
+	ret = net_udp_opt_parse(pkt, &info);
+	zassert_true(ret < 0, "UNSAFE option was not rejected (ret %d)", ret);
+
+	net_pkt_unref(pkt);
+}
+
+ZTEST(udp_fn_tests, test_udp_opt_uexp_kind_is_unsafe)
+{
+	/* RFC 9868: UNSAFE Experimental is kind 254 (255 is Reserved). Both
+	 * fall in the UNSAFE range and must cause all options to be discarded.
+	 */
+	static const uint8_t uexp_tlv[4] = { NET_UDP_OPT_KIND_UEXP, 0x04U, 0x00U, 0x00U };
+	static const uint8_t reserved_tlv[4] = { 255U, 0x04U, 0x00U, 0x00U };
+	struct net_udp_opt_info info;
+	struct net_pkt *pkt;
+
+	zassert_equal(NET_UDP_OPT_KIND_UEXP, 254, "UEXP kind must be 254");
+
+	pkt = build_v4_udp_opt_pkt(uexp_tlv, sizeof(uexp_tlv), true, 0U);
+	zassert_true(net_udp_opt_parse(pkt, &info) < 0, "UEXP (254) not rejected");
+	net_pkt_unref(pkt);
+
+	pkt = build_v4_udp_opt_pkt(reserved_tlv, sizeof(reserved_tlv), true, 0U);
+	zassert_true(net_udp_opt_parse(pkt, &info) < 0, "reserved UNSAFE (255) not rejected");
+	net_pkt_unref(pkt);
+}
+
+ZTEST(udp_fn_tests, test_udp_opt_wrong_length_discarded)
+{
+	/* RFC 9868 Section 7: a known option whose length is not the value
+	 * defined for its kind must cause all options to be discarded. MDS
+	 * (kind 4) has a fixed total length of 4; present it with length 5.
+	 */
+	static const uint8_t bad_mds[5] = { NET_UDP_OPT_KIND_MDS, 0x05U, 0x00U, 0x00U, 0x00U };
+	struct net_udp_opt_info info;
+	struct net_pkt *pkt;
+	int ret;
+
+	pkt = build_v4_udp_opt_pkt(bad_mds, sizeof(bad_mds), true, 0U);
+	ret = net_udp_opt_parse(pkt, &info);
+	zassert_true(ret < 0, "wrong-length option was not rejected (ret %d)", ret);
+
+	net_pkt_unref(pkt);
+}
+
+ZTEST(udp_fn_tests, test_udp_opt_ocs_unused_parsed)
+{
+	/* RFC 9868: with a zero UDP checksum the OCS may be unused (zero);
+	 * the options must still be parsed and processed.
+	 */
+	static const uint8_t mds_tlv[4] = { NET_UDP_OPT_KIND_MDS, 0x04U, 0x04U, 0xb0U };
+	struct net_udp_opt_info info;
+	struct net_pkt *pkt;
+	int ret;
+
+	/* valid_ocs = false leaves the OCS bytes zero and the UDP checksum
+	 * zero (the test disables UDP checksums), exercising the unused-OCS
+	 * path.
+	 */
+	pkt = build_v4_udp_opt_pkt(mds_tlv, sizeof(mds_tlv), false, 0U);
+	ret = net_udp_opt_parse(pkt, &info);
+	zassert_ok(ret, "options not parsed with an unused OCS (ret %d)", ret);
+	zassert_true((info.present & NET_UDP_OPT_F_MDS) != 0U, "MDS not parsed");
+	zassert_true(info.ocs_valid, "ocs_valid should be true when OCS is unused");
+	zassert_equal(info.mds, 0x04b0U, "MDS value mismatch (%u)", info.mds);
+
+	net_pkt_unref(pkt);
+}
+
+ZTEST(udp_fn_tests, test_udp_opt_extended_length)
+{
+	/* RFC 9868 Section 5: an option with Length == 255 uses the extended
+	 * format (Kind, 0xff, 2-byte Extended Length counting the whole
+	 * option). Use an experimental (SAFE, unknown) option in extended form
+	 * followed by a known MDS option, and check the MDS is still parsed -
+	 * proving the extended option was skipped by the correct length.
+	 */
+	static const uint8_t tlvs[] = {
+		/* EXP option, extended format, total length 6 (2 payload bytes) */
+		NET_UDP_OPT_KIND_EXP, 0xffU, 0x00U, 0x06U, 0xaaU, 0xbbU,
+		/* MDS option */
+		NET_UDP_OPT_KIND_MDS, 0x04U, 0x04U, 0xb0U,
+	};
+	struct net_udp_opt_info info;
+	struct net_pkt *pkt;
+	int ret;
+
+	pkt = build_v4_udp_opt_pkt(tlvs, sizeof(tlvs), true, 0U);
+	ret = net_udp_opt_parse(pkt, &info);
+	zassert_ok(ret, "extended-length option not handled (ret %d)", ret);
+	zassert_true((info.present & NET_UDP_OPT_F_MDS) != 0U,
+		     "option after extended-length option not parsed");
+	zassert_equal(info.mds, 0x04b0U, "MDS value mismatch (%u)", info.mds);
+
+	net_pkt_unref(pkt);
+}
+
+ZTEST(udp_fn_tests, test_udp_opt_apc_passthrough)
+{
+	/* APC (RFC 9868) is an application-managed checksum: the CRC32c value
+	 * is carried verbatim to the application, which is responsible for
+	 * validating it. Verify the parsed value is delivered unchanged.
+	 */
+	static const uint8_t apc_tlv[6] = {
+		NET_UDP_OPT_KIND_APC, 0x06U, 0xdeU, 0xadU, 0xbeU, 0xefU,
+	};
+	struct net_udp_opt_info info;
+	struct net_pkt *pkt;
+	int ret;
+
+	pkt = build_v4_udp_opt_pkt(apc_tlv, sizeof(apc_tlv), true, 0U);
+	ret = net_udp_opt_parse(pkt, &info);
+	zassert_ok(ret, "APC option not parsed (ret %d)", ret);
+	zassert_true((info.present & NET_UDP_OPT_F_APC) != 0U, "APC not present");
+	zassert_equal(info.apc_crc, 0xdeadbeefU, "APC CRC mismatch (0x%08x)", info.apc_crc);
+
+	net_pkt_unref(pkt);
+}
+#endif /* CONFIG_NET_UDP_OPTIONS */
+
 ZTEST_SUITE(udp_fn_tests, NULL, NULL, NULL, NULL, NULL);

--- a/tests/net/udp/tests.yaml
+++ b/tests/net/udp/tests.yaml
@@ -9,3 +9,7 @@ tests:
   net.udp.preempt:
     extra_configs:
       - CONFIG_NET_TC_THREAD_PREEMPTIVE=y
+  net.udp.options:
+    extra_configs:
+      - CONFIG_NET_TC_THREAD_COOPERATIVE=y
+      - CONFIG_NET_UDP_OPTIONS=y


### PR DESCRIPTION
This PR implements UDP options (https://datatracker.ietf.org/doc/html/rfc9868) support, and then allow user to use it for Datagram Packetization Layer Path MTU Discovery (DPLPMTUD) (https://datatracker.ietf.org/doc/html/rfc9869)
