### PR TITLE
TLS 1.3 Session Cache Fix

### DIFF
--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -190,6 +190,12 @@ extern "C" {
 /** Socket option to control TLS session caching on a socket. Accepted values:
  *  - 0 - Disabled.
  *  - 1 - Enabled.
+ *
+ *  For TLS 1.3, sessions are cached when a NewSessionTicket message is
+ *  received, which happens after the handshake completes. The application
+ *  needs to receive from or poll the socket for the ticket to be processed
+ *  and cached. The latest received ticket replaces the cache entry for the
+ *  peer.
  */
 #define ZSOCK_TLS_SESSION_CACHE 12
 /** Write-only socket option to purge session cache immediately.

--- a/modules/mbedtls/Kconfig.mbedtls
+++ b/modules/mbedtls/Kconfig.mbedtls
@@ -152,10 +152,17 @@ config MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
 
 config MBEDTLS_PSK_MAX_LEN
 	int "Max size of TLS pre-shared keys"
+	default 48 if MBEDTLS_SSL_SESSION_TICKETS && PSA_WANT_ALG_SHA_384
 	default 32
 	help
 	  Max size of TLS pre-shared keys, in bytes. It has no effect if no
 	  PSK key exchange is used.
+
+	  TLS 1.3 session tickets derive a resumption PSK that has a length
+	  as long as the hash of the negotiated ciphersuite. Mbed TLS enforces
+	  this limit when the PSK is loaded during a resumption handshake.
+	  When session tickets and SHA-384 based ciphersuites are enabled, the
+	  default therefore needs to be raised to 48.
 
 config MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
 	bool "ECDHE-RSA based ciphersuite modes"

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -915,6 +915,22 @@ exit:
 	mbedtls_ssl_session_free(&session);
 }
 
+static void tls_session_store_current(struct tls_context *context)
+{
+	struct net_sockaddr_storage peer_addr = { 0 };
+	net_socklen_t peer_addrlen = sizeof(peer_addr);
+
+	if (!context->options.cache_enabled) {
+		return;
+	}
+
+	if (zsock_getpeername(context->sock, net_sad(&peer_addr), &peer_addrlen) < 0) {
+		return;
+	}
+
+	tls_session_store(context, net_sad(&peer_addr), peer_addrlen);
+}
+
 static void tls_session_restore(struct tls_context *context,
 				const struct net_sockaddr *addr,
 				net_socklen_t addrlen)
@@ -3102,7 +3118,11 @@ int ztls_connect_ctx(struct tls_context *ctx, const struct net_sockaddr *addr,
 			goto error;
 		}
 
-		tls_session_store(ctx, addr, addrlen);
+		/* TLS 1.3 tickets arrive after the handshake. */
+		if (mbedtls_ssl_get_version_number(&ctx->active_session->ssl) !=
+		    MBEDTLS_SSL_VERSION_TLS1_3) {
+			tls_session_store(ctx, addr, addrlen);
+		}
 	}
 
 	return 0;
@@ -3521,6 +3541,10 @@ static ssize_t recv_tls(struct tls_context *ctx, void *buf,
 		ret = mbedtls_ssl_read(&ctx->active_session->ssl, (uint8_t *)buf + recv_len,
 				       read_len);
 		if (ret < 0) {
+			if (ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
+				tls_session_store_current(ctx);
+			}
+
 			if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
 				/* Peer notified that it's closing the
 				 * connection.
@@ -4037,9 +4061,13 @@ static int tls_data_check(struct tls_context *ctx)
 			return -ENOTCONN;
 		}
 
+		if (ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
+			tls_session_store_current(ctx);
+			return 0;
+		}
+
 		if (ret == MBEDTLS_ERR_SSL_WANT_READ ||
-		    ret == MBEDTLS_ERR_SSL_WANT_WRITE ||
-		    ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET) {
+		    ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
 			return 0;
 		}
 

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -313,6 +313,9 @@ BUILD_ASSERT(CONFIG_NET_SOCKETS_TLS_MAX_SESSION_CONTEXTS >= CONFIG_NET_SOCKETS_T
 
 static struct tls_session_cache client_cache[CONFIG_NET_SOCKETS_TLS_MAX_CLIENT_SESSION_COUNT];
 
+/* A mutex for protecting access to the client session cache. */
+static K_MUTEX_DEFINE(session_cache_lock);
+
 #if defined(MBEDTLS_SSL_CACHE_C)
 static mbedtls_ssl_cache_context server_cache;
 #endif
@@ -341,13 +344,16 @@ static int tls_session_cache_settings_set(const char *key, size_t len, settings_
 		return -ENOENT;
 	}
 
+	k_mutex_lock(&session_cache_lock, K_FOREVER);
+
 	if (strcmp(next, "addr") == 0) {
 		if (len != sizeof(struct net_sockaddr_storage)) {
-			return -EINVAL;
+			rc = -EINVAL;
+			goto out;
 		}
 		rc = read_cb(cb_arg, &client_cache[idx].peer_addr, len);
 		if (rc < 0) {
-			return rc;
+			goto out;
 		}
 		client_cache[idx].timestamp = k_uptime_get();
 	} else if (strcmp(next, "data") == 0) {
@@ -355,12 +361,13 @@ static int tls_session_cache_settings_set(const char *key, size_t len, settings_
 
 		if (buf == NULL) {
 			NET_ERR("TLS session alloc failed for slot %ld", idx);
-			return -ENOMEM;
+			rc = -ENOMEM;
+			goto out;
 		}
 		rc = read_cb(cb_arg, buf, len);
 		if (rc < 0) {
 			mbedtls_free(buf);
-			return rc;
+			goto out;
 		}
 		if (client_cache[idx].session != NULL) {
 			mbedtls_free(client_cache[idx].session);
@@ -369,15 +376,22 @@ static int tls_session_cache_settings_set(const char *key, size_t len, settings_
 		client_cache[idx].session_len = len;
 		NET_DBG("TLS session %ld restored from settings", idx);
 	} else {
-		return -ENOENT;
+		rc = -ENOENT;
+		goto out;
 	}
 
-	return 0;
+	rc = 0;
+
+out:
+	k_mutex_unlock(&session_cache_lock);
+
+	return rc;
 }
 
 SETTINGS_STATIC_HANDLER_DEFINE(tls_session_cache, TLS_SETTINGS_PREFIX, NULL,
 			       tls_session_cache_settings_set, NULL, NULL);
 
+/* Must be called with session_cache_lock held. */
 static void tls_session_cache_settings_save(int idx)
 {
 	char key[32];
@@ -437,6 +451,8 @@ static int tls_mbedtls_reset_session(struct tls_context *context);
 
 static void tls_session_cache_reset(void)
 {
+	k_mutex_lock(&session_cache_lock, K_FOREVER);
+
 	for (int i = 0; i < ARRAY_SIZE(client_cache); i++) {
 		if (client_cache[i].session != NULL) {
 			mbedtls_free(client_cache[i].session);
@@ -444,6 +460,8 @@ static void tls_session_cache_reset(void)
 	}
 
 	(void)memset(client_cache, 0, sizeof(client_cache));
+
+	k_mutex_unlock(&session_cache_lock);
 }
 
 bool net_socket_is_tls(void *obj)
@@ -791,7 +809,9 @@ static int tls_session_save(const struct net_sockaddr *peer_addr,
 {
 	struct tls_session_cache *entry = NULL;
 	size_t session_len;
-	int ret;
+	int ret = 0;
+
+	k_mutex_lock(&session_cache_lock, K_FOREVER);
 
 	for (int i = 0; i < ARRAY_SIZE(client_cache); i++) {
 		if (client_cache[i].session == NULL) {
@@ -827,7 +847,8 @@ static int tls_session_save(const struct net_sockaddr *peer_addr,
 	entry->session = mbedtls_calloc(1, session_len);
 	if (entry->session == NULL) {
 		NET_ERR("Failed to allocate session buffer.");
-		return -ENOMEM;
+		ret = -ENOMEM;
+		goto out;
 	}
 
 	ret = mbedtls_ssl_session_save(session, entry->session, session_len,
@@ -836,7 +857,8 @@ static int tls_session_save(const struct net_sockaddr *peer_addr,
 		NET_ERR("Failed to serialize session, err: -0x%x.", -ret);
 		mbedtls_free(entry->session);
 		entry->session = NULL;
-		return -ENOMEM;
+		ret = -ENOMEM;
+		goto out;
 	}
 
 	entry->session_len = session_len;
@@ -847,14 +869,21 @@ static int tls_session_save(const struct net_sockaddr *peer_addr,
 	tls_session_cache_settings_save(entry - client_cache);
 #endif
 
-	return 0;
+	ret = 0;
+
+out:
+	k_mutex_unlock(&session_cache_lock);
+
+	return ret;
 }
 
 static int tls_session_get(const struct net_sockaddr *peer_addr,
 			   mbedtls_ssl_session *session)
 {
 	struct tls_session_cache *entry = NULL;
-	int ret;
+	int ret = 0;
+
+	k_mutex_lock(&session_cache_lock, K_FOREVER);
 
 	for (int i = 0; i < ARRAY_SIZE(client_cache); i++) {
 		if (client_cache[i].session != NULL &&
@@ -865,7 +894,8 @@ static int tls_session_get(const struct net_sockaddr *peer_addr,
 	}
 
 	if (entry == NULL) {
-		return -ENOENT;
+		ret = -ENOENT;
+		goto out;
 	}
 
 	ret = mbedtls_ssl_session_load(session, entry->session,
@@ -875,10 +905,16 @@ static int tls_session_get(const struct net_sockaddr *peer_addr,
 		mbedtls_free(entry->session);
 		entry->session = NULL;
 		NET_ERR("Failed to load TLS session %d", ret);
-		return -EIO;
+		ret = -EIO;
+		goto out;
 	}
 
-	return 0;
+	ret = 0;
+
+out:
+	k_mutex_unlock(&session_cache_lock);
+
+	return ret;
 }
 
 static void tls_session_store(struct tls_context *context,

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -4793,6 +4793,27 @@ mbedtls_ssl_context *ztls_get_mbedtls_ssl_context(int fd)
 	return &ctx->active_session->ssl;
 }
 
+int ztls_get_cached_session(int fd, mbedtls_ssl_session *session)
+{
+	struct net_sockaddr_storage peer_addr = { 0 };
+	struct tls_context *ctx;
+	net_socklen_t peer_addrlen = sizeof(peer_addr);
+	int ret;
+
+	ctx = zvfs_get_fd_obj(fd, (const struct fd_op_vtable *)&tls_sock_fd_op_vtable,
+			      EBADF);
+	if (ctx == NULL) {
+		return -EBADF;
+	}
+
+	ret = zsock_getpeername(ctx->sock, net_sad(&peer_addr), &peer_addrlen);
+	if (ret < 0) {
+		return -errno;
+	}
+
+	return tls_session_get(net_sad(&peer_addr), session);
+}
+
 uint32_t ztls_get_session_count(void)
 {
 	return k_mem_slab_num_used_get(&tls_session_contexts);

--- a/tests/net/socket/tls_configurations/src/main.c
+++ b/tests/net/socket/tls_configurations/src/main.c
@@ -16,6 +16,12 @@ LOG_MODULE_REGISTER(tls_configuration_sample, LOG_LEVEL_INF);
 #include <zephyr/net/net_if.h>
 #include <zephyr/sys/util.h>
 
+#if defined(CONFIG_NET_TEST)
+#include <mbedtls/ssl.h>
+
+int ztls_get_cached_session(int fd, mbedtls_ssl_session *session);
+#endif
+
 #if defined(CONFIG_MBEDTLS_CIPHERSUITE_TLS_PSK_WITH_AES_256_CBC_SHA384) || \
 	defined(CONFIG_MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED)
 #define USE_PSK_KEY_EXCHANGE
@@ -54,6 +60,25 @@ static struct zsock_pollfd fds[1];
 /* Keep the new line because openssl uses that to start processing the incoming data */
 #define TEST_STRING "hello world\n"
 static uint8_t test_buf[sizeof(TEST_STRING)];
+
+static int check_cached_ticket(void)
+{
+#if defined(CONFIG_NET_TEST)
+	mbedtls_ssl_session session;
+	int ret;
+
+	mbedtls_ssl_session_init(&session);
+	ret = ztls_get_cached_session(socket_fd, &session);
+	if (ret == 0 && session.MBEDTLS_PRIVATE(ticket_len) == 0) {
+		ret = -ENOENT;
+	}
+
+	mbedtls_ssl_session_free(&session);
+	return ret;
+#else
+	return 0;
+#endif
+}
 
 static int wait_for_event(void)
 {
@@ -112,6 +137,17 @@ static int create_socket(void)
 			       sizeof("localhost"));
 	if (ret < 0) {
 		LOG_ERR("Failed to set TLS_HOSTNAME option (%d)", errno);
+		return -errno;
+	}
+#endif
+
+#if defined(CONFIG_NET_TEST)
+	int session_cache = ZSOCK_TLS_SESSION_CACHE_ENABLED;
+
+	ret = zsock_setsockopt(socket_fd, ZSOCK_SOL_TLS, ZSOCK_TLS_SESSION_CACHE,
+			       &session_cache, sizeof(session_cache));
+	if (ret < 0) {
+		LOG_ERR("Failed to enable TLS session cache (%d)", errno);
 		return -errno;
 	}
 #endif
@@ -226,6 +262,12 @@ int main(void)
 			goto exit;
 		}
 		LOG_DBG("Received: %s", test_buf);
+	}
+
+	ret = check_cached_ticket();
+	if (ret < 0) {
+		LOG_ERR("TLS session ticket was not cached (%d)", ret);
+		goto exit;
 	}
 
 	ret = memcmp(TEST_STRING, test_buf, data_len);

--- a/tests/net/socket/tls_configurations/tests.yaml
+++ b/tests/net/socket/tls_configurations/tests.yaml
@@ -47,3 +47,15 @@ tests:
       - CONFIG_SERVER_PORT=4005
     harness_config:
       pytest_args: ["--server-type", "1.3-psk-tickets", "--port", "4005"]
+  net.sockets.tls13.psk_kex.tickets.session_cache:
+    extra_configs:
+      - CONFIG_NET_TEST=y
+      - CONFIG_NET_IPV4=y
+      - CONFIG_MBEDTLS_SSL_SESSION_TICKETS=y
+      - CONFIG_MBEDTLS_CIPHERSUITE_TLS1_3_AES_256_GCM_SHA384=y
+      - CONFIG_MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_ENABLED=y
+      - CONFIG_PSA_WANT_ECC_SECP_R1_256=y # for certificate verification
+      - CONFIG_PSA_WANT_ALG_SHA_256=y # for certificate verification
+      - CONFIG_SERVER_PORT=4006
+    harness_config:
+      pytest_args: ["--server-type", "1.3-psk-tickets", "--port", "4006"]


### PR DESCRIPTION
Fixes TLS session caching (`TLS_SESSION_CACHE` socket option) for TLS 1.3 connections. Additionally adds hardening using a dedicated mutex for the `client_cache` to prevent access by multiple clients.

## Problem

TLS 1.2 delivers session tickets during the handshake, so storing the session at `connect()` time works. TLS 1.3 delivers tickets in post-handshake NewSessionTicket messages, so the connect-time store caches a session without a ticket and resumption never happens.

## Fix

- Store the session when `mbedtls_ssl_read()` returns
  `MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET`, in both the `recv()` path and the
  `poll()` data check.
- Skip the connect-time store for TLS 1.3.
- DTLS paths are unchanged (mbedTLS has no DTLS 1.3).

Each received ticket overwrites the cache entry for the peer, so the freshest ticket is used for resumption.

## Testing

Added a `tls_configurations` scenario that enables the session cache, exchanges data with an OpenSSL TLS 1.3 server that issues tickets, and verifies a ticket-bearing session was cached.

Fixes: #113735