### PR TITLE
shell: backends: Use atomic_set in tx_disable path

### DIFF
--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -192,7 +192,7 @@ static void uart_tx_handle(const struct device *dev, struct shell_uart_int_drive
 		ARG_UNUSED(err);
 	} else {
 		uart_irq_tx_disable(dev);
-		sh_uart->tx_busy = 0;
+		atomic_set(&sh_uart->tx_busy, 0);
 	}
 
 	sh_uart->common.handler(SHELL_TRANSPORT_EVT_TX_RDY, sh_uart->common.context);


### PR DESCRIPTION
atomic_set is used to access tx_busy in the irq_write function (in order to get atomic exchange behavior) so we should also access it atomically here (even though we don't need atomic exchange behavior here).

This change seems to resolve an infrequent problem we've observed in the shell_uart code when interrupts are being used.  When the problem happens, the shell thread is trying to write to the shell console but is stuck waiting for space to free up in the tx_ringbuf, which is never happening because the UART's TX interrupt is disabled.