### PR TITLE
tests: kernel: sched: fix unused variable error

### DIFF
--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -34,14 +34,14 @@ static int thread_idx;
 
 static void thread_time_slice(void *p1, void *p2, void *p3)
 {
-	uint32_t tick_delta = ticks_delta(&elapsed_slice);
+	__maybe_unused uint32_t tick_delta = ticks_delta(&elapsed_slice);
 	/*
 	 * Thread 0 picks up CPU when the main test thread voluntarily
 	 * yields halfway through its slice, so its elapsed measurement
 	 * spans the busy-wait of half a slice. The remaining threads see
 	 * the previous thread's full slice between successive wakeups.
 	 */
-	uint32_t expected = (thread_idx == 0) ? HALF_SLICE_TICKS : SLICE_TICKS;
+	__maybe_unused uint32_t expected = (thread_idx == 0) ? HALF_SLICE_TICKS : SLICE_TICKS;
 
 #ifdef CONFIG_DEBUG
 	TC_PRINT("thread[%d] elapsed: %u ticks, expected ~%u\n",
@@ -60,8 +60,6 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 	zassert_between_inclusive(tick_delta, expected, expected + 1,
 				  "elapsed %u ticks, expected ~%u",
 				  tick_delta, expected);
-#else
-	(void)tick_delta;
 #endif /* CONFIG_COVERAGE_GCOV */
 
 	/* Keep this thread busy past one slice so the slicer fires and


### PR DESCRIPTION
When CONFIG_DEBUG=n and CONFIG_COVERAGE_GCOV=y, neither tick_delta nor expected are used.

<details>
<summary>Original build error</summary>

```
[31/186] Building C object CMakeFiles/app.dir/src/test_sched_timeslice_reset.c.obj
FAILED: CMakeFiles/app.dir/src/test_sched_timeslice_reset.c.obj 
/home/jonas/zephyr-sdk-1.0.1/gnu/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc -DKERNEL -DK_HEAP_MEM_POOL_SIZE=0 -DPICOLIBC_LONG_LONG_PRINTF_SCANF -DTC_RUNID=0b2a416492b88e9258106ee533f25a88 -D_POSIX_THREAD_SAFE_FUNCTIONS=200809L -D__LINUX_ERRNO_EXTENSIONS__ -D__PROGRAM_START -D__ZEPHYR__=1 -I/home/jonas/projects/ws/zephyr/kernel/include -I/home/jonas/projects/ws/zephyr/arch/arm/include -I/home/jonas/projects/ws/zephyr/include -I/home/jonas/projects/ws/zephyr/twister-out/mps2_an385/zephyr_gnu/tests/kernel/sched/schedule_api/kernel.scheduler.multiq/zephyr/include/generated -I/home/jonas/projects/ws/zephyr/soc/arm -I/home/jonas/projects/ws/zephyr/lib/libc/picolibc/include -I/home/jonas/projects/ws/zephyr/soc/arm/mps2/. -I/home/jonas/projects/ws/zephyr/subsys/portability/posix/c_lib_ext/getopt -I/home/jonas/projects/ws/zephyr/subsys/testsuite/include -I/home/jonas/projects/ws/zephyr/subsys/testsuite/coverage -I/home/jonas/projects/ws/zephyr/subsys/testsuite/ztest/include -I/home/jonas/projects/ws/zephyr/modules/cmsis_6/. -I/home/jonas/projects/ws/modules/hal/cmsis_6/CMSIS/Core/Include -isystem /home/jonas/projects/ws/zephyr/lib/libc/common/include -fno-strict-aliasing -Werror -O0 -imacros /home/jonas/projects/ws/zephyr/twister-out/mps2_an385/zephyr_gnu/tests/kernel/sched/schedule_api/kernel.scheduler.multiq/zephyr/include/generated/zephyr/autoconf.h -fno-printf-return-value -fno-common -g -gdwarf-4 -fdiagnostics-color=always -mcpu=cortex-m3 -mthumb -mabi=aapcs -mfp16-format=ieee -mtp=soft --sysroot=/home/jonas/zephyr-sdk-1.0.1/gnu/arm-zephyr-eabi/arm-zephyr-eabi -imacros /home/jonas/projects/ws/zephyr/include/zephyr/toolchain/zephyr_stdint.h -Wall -Wformat -Wformat-security -Wno-format-zero-length -Wdouble-promotion -Wno-pointer-sign -Wpointer-arith -Wexpansion-to-defined -Wno-unused-but-set-variable -Werror=implicit-int -fno-pic -fno-pie -fno-asynchronous-unwind-tables -ftls-model=local-exec -fno-reorder-functions --param=min-pagesize=0 -fno-defer-pop -fmacro-prefix-map=/home/jonas/projects/ws/zephyr/tests/kernel/sched/schedule_api=CMAKE_SOURCE_DIR -fmacro-prefix-map=/home/jonas/projects/ws/zephyr=ZEPHYR_BASE -fmacro-prefix-map=/home/jonas/projects/ws=WEST_TOPDIR -ffunction-sections -fdata-sections -fprofile-arcs -ftest-coverage -fno-inline -specs=picolibc.specs -std=c17 -MD -MT CMakeFiles/app.dir/src/test_sched_timeslice_reset.c.obj -MF CMakeFiles/app.dir/src/test_sched_timeslice_reset.c.obj.d -o CMakeFiles/app.dir/src/test_sched_timeslice_reset.c.obj -c /home/jonas/projects/ws/zephyr/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
/home/jonas/projects/ws/zephyr/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c: In function 'thread_time_slice':
/home/jonas/projects/ws/zephyr/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c:44:18: error: unused variable 'expected' [-Werror=unused-variable]
   44 |         uint32_t expected = (thread_idx == 0) ? HALF_SLICE_TICKS : SLICE_TICKS;
      |                  ^~~~~~~~
cc1: all warnings being treated as errors
```
</details>