### PR TITLE
soc intel ace: Add missing type in kconfig option

### DIFF
--- a/soc/intel/intel_adsp/ace/Kconfig.soc
+++ b/soc/intel/intel_adsp/ace/Kconfig.soc
@@ -52,6 +52,7 @@ config SOC_SERIES
 	default "intel_adsp_ace" if SOC_SERIES_INTEL_ADSP_ACE
 
 config SOC_TOOLCHAIN_NAME
+	string
 	default "intel_ace15_mtpm" if SOC_ACE15_MTPM
 	default "intel_ace15_mtpm" if SOC_ACE20_LNL
 	default "intel_ace30_ptl" if SOC_ACE30


### PR DESCRIPTION
SOCs kconfig files cannot rely anymore on other SOC kconfig files definitions.
=> Add the missing type.

The issue was revealed by https://github.com/zephyrproject-rtos/zephyr/pull/112386