### PR TITLE
drivers: ethernet: dwc_mac: improve rx and tx path

### DIFF
--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -110,6 +110,14 @@ config DWMAC_NB_RX_DESCS
 	  memory. A smaller number increases the risk of an overflow and
 	  dropped packets.
 
+config ETH_DWMAC_RX_REFILL_IRQ
+	bool "Receive buffer refill in interrupt"
+	depends on ETH_DWC_ETHER_1000_CORE
+	default y
+	help
+	  Refill the receive buffer pool in the rx interrupt, if
+	  possible, otherwise in the refill thread.
+
 config ETH_DWMAC_RX_REFILL_THREAD_PRIORITY
 	int "Receive buffer refill thread priority"
 	default 0

--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -20,7 +20,6 @@ config ETH_DWC_ETHER_1000_CORE
 	bool
 	depends on NET_BUF_FIXED_DATA_SIZE
 	select CACHE_MANAGEMENT if DCACHE
-	select NET_CHECKSUM_OFFLOAD_SUPPORTED if NET_L2_ETHERNET
 	help
 	  This is a driver for the Synopsys DesignWare Ethernet MAC 10/100/1G Universal,
 	  also referred to as "dwc_ether_mac10_100_1000_universal".
@@ -125,21 +124,38 @@ config ETH_DWMAC_RX_REFILL_THREAD_PRIORITY
 	  Priority level of the internal thread which is used to refill
 	  the receive buffer pool.
 
+# Currently only for the 1000 core
+if ETH_DWC_ETHER_1000_CORE
+
 config ETH_DWC_ETHER_TX_HW_CHECKSUM
 	bool "Use TX hardware checksum"
-	depends on NET_CHECKSUM_OFFLOAD
+	select NET_CHECKSUM_OFFLOAD_SUPPORTED if NET_L2_ETHERNET
 	default y
 	help
 	  Enable transmit checksum offload to enhance throughput
 	  performances.
 
+config ETH_DWC_ETHER_TX_HW_CHECKSUM_EN
+	bool
+	depends on ETH_DWC_ETHER_TX_HW_CHECKSUM
+	depends on NET_CHECKSUM_OFFLOAD
+	default y
+
 config ETH_DWC_ETHER_RX_HW_CHECKSUM
 	bool "Use RX hardware checksum"
-	depends on NET_CHECKSUM_OFFLOAD
+	select NET_CHECKSUM_OFFLOAD_SUPPORTED if NET_L2_ETHERNET
 	default y
 	help
 	  Enable receive checksum offload to enhance throughput
 	  performances.
+
+config ETH_DWC_ETHER_RX_HW_CHECKSUM_EN
+	bool
+	depends on ETH_DWC_ETHER_RX_HW_CHECKSUM
+	depends on NET_CHECKSUM_OFFLOAD
+	default y
+
+endif # ETH_DWC_ETHER_1000_CORE
 
 endif # ETH_DWC_ETHER_QOS_CORE || ETH_DWC_ETHER_1000_CORE
 

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -132,7 +132,7 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 
 	barrier_dmem_fence_full();
 	p->tx_desc_head = d_idx;
-	REG_WRITE(DWMAC_DMATPDR, 0);
+	DWMAC_REG_WRITE(DWMAC_DMATPDR, 0);
 
 	return 0;
 
@@ -272,7 +272,7 @@ static void dwmac_rx_refill(const struct device *dev, unsigned int d_idx)
 	d->des0 = RDES0_OWN;
 
 	p->rx_desc_head = INC_WRAP(d_idx, NB_RX_DESCS);
-	REG_WRITE(DWMAC_DMARPDR, 0);
+	DWMAC_REG_WRITE(DWMAC_DMARPDR, 0);
 
 	LOG_DBG("desc sem/head/tail=%d/%d/%d", k_sem_count_get(&p->free_rx_descs), p->rx_desc_head,
 		p->rx_desc_tail);
@@ -297,8 +297,8 @@ void dwmac_isr(const struct device *dev)
 {
 	uint32_t status;
 
-	status = REG_READ(DWMAC_DMASR);
-	REG_WRITE(DWMAC_DMASR, status);
+	status = DWMAC_REG_READ(DWMAC_DMASR);
+	DWMAC_REG_WRITE(DWMAC_DMASR, status);
 
 	LOG_DBG("DMA status 0x%08x", status);
 
@@ -317,8 +317,8 @@ void dwmac_isr(const struct device *dev)
 
 static void dwmac_set_mac_addr(const struct device *dev, const uint8_t *addr)
 {
-	REG_WRITE(DWMAC_MACA0HR, (uint32_t)sys_get_le16(&addr[4]));
-	REG_WRITE(DWMAC_MACA0LR, sys_get_le32(&addr[0]));
+	DWMAC_REG_WRITE(DWMAC_MACA0HR, (uint32_t)sys_get_le16(&addr[4]));
+	DWMAC_REG_WRITE(DWMAC_MACA0LR, sys_get_le32(&addr[0]));
 }
 
 static int dwmac_set_config(const struct device *dev, struct net_if *iface __unused,
@@ -332,13 +332,13 @@ static int dwmac_set_config(const struct device *dev, struct net_if *iface __unu
 		break;
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
-		reg = REG_READ(DWMAC_MACFFR);
+		reg = DWMAC_REG_READ(DWMAC_MACFFR);
 		if (config->promisc_mode) {
 			reg |= DWMAC_MACFFR_PM;
 		} else {
 			reg &= ~DWMAC_MACFFR_PM;
 		}
-		REG_WRITE(DWMAC_MACFFR, reg);
+		DWMAC_REG_WRITE(DWMAC_MACFFR, reg);
 		break;
 #endif
 	default:
@@ -356,7 +356,7 @@ static void phy_link_state_changed(const struct device *phy_dev __unused,
 	uint32_t reg;
 
 	if (state->is_up) {
-		reg = REG_READ(DWMAC_MACCR);
+		reg = DWMAC_REG_READ(DWMAC_MACCR);
 
 		reg &= ~(DWMAC_MACCR_PS | DWMAC_MACCR_FES | DWMAC_MACCR_DM);
 
@@ -372,7 +372,7 @@ static void phy_link_state_changed(const struct device *phy_dev __unused,
 			reg |= DWMAC_MACCR_DM;
 		}
 
-		REG_WRITE(DWMAC_MACCR, reg);
+		DWMAC_REG_WRITE(DWMAC_MACCR, reg);
 	}
 
 	net_eth_carrier_set(p->iface, state->is_up);
@@ -401,7 +401,7 @@ static void dwmac_iface_init(struct net_if *iface)
 	dwmac_set_mac_addr(dev, p->mac_addr);
 
 	/* Pass all multicast frames */
-	REG_WRITE(DWMAC_MACFFR, REG_READ(DWMAC_MACFFR) | DWMAC_MACFFR_PAM);
+	DWMAC_REG_WRITE(DWMAC_MACFFR, DWMAC_REG_READ(DWMAC_MACFFR) | DWMAC_MACFFR_PAM);
 
 	net_if_carrier_off(iface);
 	if (device_is_ready(cfg->phy_dev)) {
@@ -414,12 +414,22 @@ static void dwmac_iface_init(struct net_if *iface)
 			K_ESSENTIAL, K_NO_WAIT);
 	k_thread_name_set(&p->rx_refill_thread, "dwmac_rx_refill");
 
-	REG_WRITE(DWMAC_DMAIER,
-		  DWMAC_DMAIER_NISE | DWMAC_DMAIER_RIE | DWMAC_DMAIER_TIE | DWMAC_DMAIER_AISE);
+	DWMAC_REG_WRITE(DWMAC_DMAIER,
+			DWMAC_DMAIER_NISE |
+			DWMAC_DMAIER_RIE |
+			DWMAC_DMAIER_TIE |
+			DWMAC_DMAIER_AISE);
 
-	REG_WRITE(DWMAC_DMAOMR, REG_READ(DWMAC_DMAOMR) | DWMAC_DMAOMR_SR | DWMAC_DMAOMR_ST);
-	REG_WRITE(DWMAC_MACCR,
-		  REG_READ(DWMAC_MACCR) | DWMAC_MACCR_CSTF | DWMAC_MACCR_TE | DWMAC_MACCR_RE);
+	DWMAC_REG_WRITE(DWMAC_DMAOMR,
+			DWMAC_REG_READ(DWMAC_DMAOMR) |
+			DWMAC_DMAOMR_SR |
+			DWMAC_DMAOMR_ST);
+
+	DWMAC_REG_WRITE(DWMAC_MACCR,
+			DWMAC_REG_READ(DWMAC_MACCR) |
+			DWMAC_MACCR_CSTF |
+			DWMAC_MACCR_TE |
+			DWMAC_MACCR_RE);
 }
 
 int dwmac_probe(const struct device *dev)
@@ -437,21 +447,21 @@ int dwmac_probe(const struct device *dev)
 		return ret;
 	}
 
-	REG_WRITE(DWMAC_DMABMR, REG_READ(DWMAC_DMABMR) | DWMAC_DMABMR_SR);
+	DWMAC_REG_WRITE(DWMAC_DMABMR, DWMAC_REG_READ(DWMAC_DMABMR) | DWMAC_DMABMR_SR);
 
 	timeout = sys_timepoint_calc(K_MSEC(100));
-	while ((REG_READ(DWMAC_DMABMR) & DWMAC_DMABMR_SR) != 0U) {
+	while ((DWMAC_REG_READ(DWMAC_DMABMR) & DWMAC_DMABMR_SR) != 0U) {
 		if (sys_timepoint_expired(timeout)) {
 			LOG_ERR("unable to reset hardware");
 			return -EIO;
 		}
 	}
 
-	reg_val = REG_READ(DWMAC_MACVERR);
+	reg_val = DWMAC_REG_READ(DWMAC_MACVERR);
 	LOG_INF("HW version %u.%u0", (reg_val >> 4) & 0xf, reg_val & 0xf);
 
 	/* get configured hardware features */
-	p->feature0 = REG_READ(DWMAC_HWFR);
+	p->feature0 = DWMAC_REG_READ(DWMAC_HWFR);
 	LOG_DBG("hw_feature: 0x%08x", p->feature0);
 
 	ret = dwmac_platform_init(dev);
@@ -473,15 +483,15 @@ int dwmac_probe(const struct device *dev)
 	}
 
 	if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_1000_CORE_EDFE)) {
-		REG_WRITE(DWMAC_DMABMR, REG_READ(DWMAC_DMABMR) | DWMAC_DMABMR_EDFE);
+		DWMAC_REG_WRITE(DWMAC_DMABMR, DWMAC_REG_READ(DWMAC_DMABMR) | DWMAC_DMABMR_EDFE);
 	}
 
-	REG_WRITE(DWMAC_DMATDLAR, TXDESC_PHYS_L(0));
-	REG_WRITE(DWMAC_DMARDLAR, RXDESC_PHYS_L(0));
-	REG_WRITE(DWMAC_DMAOMR, DWMAC_DMAOMR_TSF | DWMAC_DMAOMR_RSF);
+	DWMAC_REG_WRITE(DWMAC_DMATDLAR, TXDESC_PHYS_L(0));
+	DWMAC_REG_WRITE(DWMAC_DMARDLAR, RXDESC_PHYS_L(0));
+	DWMAC_REG_WRITE(DWMAC_DMAOMR, DWMAC_DMAOMR_TSF | DWMAC_DMAOMR_RSF);
 
 	if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_RX_HW_CHECKSUM)) {
-		REG_WRITE(DWMAC_MACCR, REG_READ(DWMAC_MACCR) | DWMAC_MACCR_IPCO);
+		DWMAC_REG_WRITE(DWMAC_MACCR, DWMAC_REG_READ(DWMAC_MACCR) | DWMAC_MACCR_IPCO);
 	}
 
 	return 0;

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -38,6 +38,7 @@ LOG_MODULE_REGISTER(dwmac_core, CONFIG_ETHERNET_LOG_LEVEL);
 #define TDES0_CIC GENMASK(23, 22)
 
 #define TDES1_TBS1 GENMASK(12, 0)
+#define TDES1_TBS2 GENMASK(28, 16)
 
 #define RDES0_OWN BIT(31)
 #define RDES0_FL  GENMASK(29, 16)
@@ -111,8 +112,16 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 					break;
 				}
 				k_sem_give(&p->free_tx_descs);
+				/* we can put 2 fragments in one descriptor */
+				if (frag1->frags != NULL) {
+					frag1 = frag1->frags;
+				}
 			}
 			return -ENOMEM;
+		}
+		/* we can put 2 fragments in one descriptor */
+		if (frag->frags != NULL) {
+			frag = frag->frags;
 		}
 	}
 
@@ -127,20 +136,28 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 
 		d = &p->tx_descs[d_idx];
 		d->des0 = des0_flags;
-		d->des1 = FIELD_PREP(TDES1_TBS1, frag->len);
-		d->des2 = phys_lo32(frag->data);
-
-		if (!frag->frags) {
-			d->des0 |= TDES0_LS;
-		}
 
 		if (d_idx == NB_TX_DESCS - 1) {
 			d->des0 |= TDES0_TER;
 		}
 
+		d->des1 = FIELD_PREP(TDES1_TBS1, frag->len);
+		d->des2 = phys_lo32(frag->data);
+
+		if (frag->frags != NULL) {
+			frag = frag->frags;
+			d->des1 |= FIELD_PREP(TDES1_TBS2, frag->len);
+			d->des3 = phys_lo32(frag->data);
+			sys_cache_data_flush_range(frag->data, frag->len);
+		}
+
 		des0_flags = TDES0_OWN | TDES0_FLAGS_DEFAULT;
 		INC_WRAP(d_idx, NB_TX_DESCS);
-	};
+
+		if (frag->frags == NULL) {
+			d->des0 |= TDES0_LS;
+		}
+	}
 
 	K_SPINLOCK(&p->spinlock) {
 		net_pkt_ref(pkt);

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -72,10 +72,10 @@ static enum ethernet_hw_caps dwmac_caps(const struct device *dev __unused,
 #ifdef CONFIG_NET_VLAN
 	       | ETHERNET_HW_VLAN
 #endif
-#ifdef CONFIG_ETH_DWC_ETHER_RX_HW_CHECKSUM
+#ifdef CONFIG_ETH_DWC_ETHER_RX_HW_CHECKSUM_EN
 	       | ETHERNET_HW_RX_CHKSUM_OFFLOAD
 #endif
-#ifdef CONFIG_ETH_DWC_ETHER_TX_HW_CHECKSUM
+#ifdef CONFIG_ETH_DWC_ETHER_TX_HW_CHECKSUM_EN
 	       | ETHERNET_HW_TX_CHKSUM_OFFLOAD
 #endif
 		;
@@ -93,7 +93,7 @@ static __maybe_unused unsigned int net_pkt_get_nbfrags(struct net_pkt *pkt)
 }
 
 #define TDES0_FLAGS_DEFAULT (TDES0_IC | \
-	(IS_ENABLED(CONFIG_ETH_DWC_ETHER_TX_HW_CHECKSUM) ? TDES0_CIC : 0U))
+	(IS_ENABLED(CONFIG_ETH_DWC_ETHER_TX_HW_CHECKSUM_EN) ? TDES0_CIC : 0U))
 
 static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 {
@@ -540,7 +540,7 @@ int dwmac_probe(const struct device *dev)
 	DWMAC_REG_WRITE(DWMAC_DMARDLAR, RXDESC_PHYS_L(0));
 	DWMAC_REG_WRITE(DWMAC_DMAOMR, DWMAC_DMAOMR_TSF | DWMAC_DMAOMR_RSF);
 
-	if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_RX_HW_CHECKSUM)) {
+	if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_RX_HW_CHECKSUM_EN)) {
 		DWMAC_REG_WRITE(DWMAC_MACCR, DWMAC_REG_READ(DWMAC_MACCR) | DWMAC_MACCR_IPCO);
 	}
 

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -52,6 +52,8 @@ LOG_MODULE_REGISTER(dwmac_core, CONFIG_ETHERNET_LOG_LEVEL);
 #define TXDESC_PHYS_L(idx) phys_lo32(&p->tx_descs[idx])
 #define RXDESC_PHYS_L(idx) phys_lo32(&p->rx_descs[idx])
 
+static void dwmac_rx_refill(const struct device *dev);
+
 static uint32_t phys_lo32(void *addr)
 {
 	return (uint32_t)(uintptr_t)addr;
@@ -184,9 +186,10 @@ static void dwmac_receive(const struct device *dev)
 	unsigned int d_idx;
 	uint32_t des0;
 	uint16_t bytes_so_far;
+	unsigned int num_frags = 0U;
 
 	for (d_idx = p->rx_desc_tail; d_idx != p->rx_desc_head;
-	     INC_WRAP(d_idx, NB_RX_DESCS), k_sem_give(&p->free_rx_descs)) {
+	     INC_WRAP(d_idx, NB_RX_DESCS), num_frags++) {
 		d = &p->rx_descs[d_idx];
 		des0 = d->des0;
 
@@ -206,12 +209,13 @@ static void dwmac_receive(const struct device *dev)
 			}
 		}
 
-		if (p->rx_pkt == NULL) {
-			continue;
-		}
-
 		frag = p->rx_frags[d_idx];
 		p->rx_frags[d_idx] = NULL;
+
+		if (p->rx_pkt == NULL) {
+			net_buf_unref(frag);
+			continue;
+		}
 
 		sys_cache_data_invd_range(frag->data, frag->size);
 
@@ -242,27 +246,27 @@ static void dwmac_receive(const struct device *dev)
 	}
 
 	p->rx_desc_tail = d_idx;
+
+	for (unsigned int i = 0; i < num_frags; i++) {
+		if (IS_ENABLED(CONFIG_ETH_DWMAC_RX_REFILL_IRQ)) {
+			dwmac_rx_refill(dev);
+		} else {
+			k_sem_give(&p->free_rx_descs);
+		}
+	}
 }
 
-static void dwmac_rx_refill(const struct device *dev, unsigned int d_idx)
+static void dwmac_rx_refill_desc(const struct device *dev, struct net_buf *frag)
 {
 	struct dwmac_priv *p = dev->data;
 	struct dwmac_dma_desc *d;
-	struct net_buf *frag;
+	unsigned int d_idx;
+
+	d_idx = p->rx_desc_head;
+	p->rx_frags[d_idx] = frag;
 
 	d = &p->rx_descs[d_idx];
 	__ASSERT(!(d->des0 & RDES0_OWN), "rx desc still owned");
-
-	frag = p->rx_frags[d_idx];
-	if (frag == NULL) {
-		frag = net_pkt_get_reserve_rx_data(RX_FRAG_SIZE, K_FOREVER);
-		if (frag == NULL) {
-			k_sem_give(&p->free_rx_descs);
-			return;
-		}
-		__ASSERT_NO_MSG(frag->size == RX_FRAG_SIZE);
-		p->rx_frags[d_idx] = frag;
-	}
 
 	d->des1 = FIELD_PREP(RDES1_RBS1, frag->size) | RDES1_RCH;
 	d->des2 = phys_lo32(frag->data);
@@ -274,8 +278,24 @@ static void dwmac_rx_refill(const struct device *dev, unsigned int d_idx)
 	p->rx_desc_head = INC_WRAP(d_idx, NB_RX_DESCS);
 	DWMAC_REG_WRITE(DWMAC_DMARPDR, 0);
 
-	LOG_DBG("desc sem/head/tail=%d/%d/%d", k_sem_count_get(&p->free_rx_descs), p->rx_desc_head,
-		p->rx_desc_tail);
+	LOG_DBG("desc sem/head/tail=%d/%d/%d %s", k_sem_count_get(&p->free_rx_descs),
+		p->rx_desc_head, p->rx_desc_tail, k_is_in_isr() ? "ISR" : "thread");
+}
+
+static void dwmac_rx_refill(const struct device *dev)
+{
+	struct dwmac_priv *p = dev->data;
+	struct net_buf *frag;
+
+	frag = net_pkt_get_reserve_rx_data(RX_FRAG_SIZE, K_FOREVER);
+	if (frag == NULL) {
+		k_sem_give(&p->free_rx_descs);
+		return;
+	}
+
+	K_SPINLOCK(&p->spinlock) {
+		dwmac_rx_refill_desc(dev, frag);
+	}
 }
 
 static void dwmac_rx_refill_thread(void *arg1, void *unused1, void *unused2)
@@ -288,7 +308,7 @@ static void dwmac_rx_refill_thread(void *arg1, void *unused1, void *unused2)
 
 	while (true) {
 		if (k_sem_take(&p->free_rx_descs, K_FOREVER) == 0) {
-			dwmac_rx_refill(dev, p->rx_desc_head);
+			dwmac_rx_refill(dev);
 		}
 	}
 }

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -95,24 +95,33 @@ static __maybe_unused unsigned int net_pkt_get_nbfrags(struct net_pkt *pkt)
 static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 {
 	struct dwmac_priv *p = dev->data;
-	unsigned int d_idx;
+	unsigned int d_idx, first_d_idx;
 	struct dwmac_dma_desc *d;
 	uint32_t des0_flags;
 
 	LOG_DBG("pkt len/frags=%zu/%u", net_pkt_get_len(pkt), net_pkt_get_nbfrags(pkt));
 
-	d_idx = p->tx_desc_head;
-	des0_flags = TDES0_FLAGS_DEFAULT;
-
 	NET_PKT_FRAG_FOR_EACH(pkt, frag) {
 		if (k_sem_take(&p->free_tx_descs, TX_AVAIL_WAIT) != 0) {
 			LOG_DBG("no more free tx descriptors");
-			goto abort;
+			NET_PKT_FRAG_FOR_EACH(pkt, frag1) {
+				if (frag1 == frag) {
+					break;
+				}
+				k_sem_give(&p->free_tx_descs);
+			}
+			return -ENOMEM;
 		}
+	}
 
-		net_pkt_frag_ref(frag);
+	first_d_idx = p->tx_desc_head;
+	d_idx = first_d_idx;
+	des0_flags = TDES0_FLAGS_DEFAULT;
+
+	NET_PKT_FRAG_FOR_EACH(pkt, frag) {
+		LOG_DBG("tx frag %p len=%zu", frag, frag->len);
+
 		sys_cache_data_flush_range(frag->data, frag->len);
-		p->tx_frags[d_idx] = frag;
 
 		d = &p->tx_descs[d_idx];
 		d->des0 = des0_flags;
@@ -127,25 +136,22 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 		INC_WRAP(d_idx, NB_TX_DESCS);
 	};
 
-	barrier_dmem_fence_full();
+	K_SPINLOCK(&p->spinlock) {
+		net_pkt_ref(pkt);
+		k_fifo_put(&p->tx_queue, pkt);
 
-	d = &p->tx_descs[p->tx_desc_head];
-	d->des0 |= TDES0_OWN | TDES0_FS;
+		p->tx_desc_head = d_idx;
 
-	barrier_dmem_fence_full();
-	p->tx_desc_head = d_idx;
-	DWMAC_REG_WRITE(DWMAC_DMATPDR, 0);
+		barrier_dmem_fence_full();
 
-	return 0;
+		d = &p->tx_descs[first_d_idx];
+		d->des0 |= TDES0_OWN | TDES0_FS;
 
-abort:
-	while (d_idx != p->tx_desc_head) {
-		DEC_WRAP(d_idx, NB_TX_DESCS);
-		net_pkt_frag_unref(p->tx_frags[d_idx]);
-		k_sem_give(&p->free_tx_descs);
+		barrier_dmem_fence_full();
+		DWMAC_REG_WRITE(DWMAC_DMATPDR, 0);
 	}
 
-	return -ENOMEM;
+	return 0;
 }
 
 static void dwmac_tx_release(const struct device *dev)
@@ -153,7 +159,6 @@ static void dwmac_tx_release(const struct device *dev)
 	struct dwmac_priv *p = dev->data;
 	unsigned int d_idx;
 	struct dwmac_dma_desc *d;
-	struct net_buf *frag;
 	uint32_t des0;
 
 	for (d_idx = p->tx_desc_tail; d_idx != p->tx_desc_head; INC_WRAP(d_idx, NB_TX_DESCS)) {
@@ -164,12 +169,20 @@ static void dwmac_tx_release(const struct device *dev)
 			break;
 		}
 
-		frag = p->tx_frags[d_idx];
-		net_pkt_frag_unref(frag);
+		if ((des0 & TDES0_LS) != 0U) {
+			struct net_pkt *pkt = k_fifo_get(&p->tx_queue, K_NO_WAIT);
 
-		if ((des0 & TDES0_LS) != 0U && (des0 & TDES0_ES) != 0U) {
-			LOG_ERR("tx error (DES0 = 0x%08x)", des0);
-			eth_stats_update_errors_tx(p->iface);
+			if (pkt != NULL) {
+				LOG_DBG("pkt len/frags=%zu/%u", net_pkt_get_len(pkt),
+					net_pkt_get_nbfrags(pkt));
+			}
+
+			net_pkt_unref(pkt);
+
+			if ((des0 & TDES0_ES) != 0U) {
+				LOG_ERR("tx error (DES0 = 0x%08x)", des0);
+				eth_stats_update_errors_tx(p->iface);
+			}
 		}
 
 		k_sem_give(&p->free_tx_descs);
@@ -416,6 +429,7 @@ static void dwmac_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 	k_sem_init(&p->free_tx_descs, NB_TX_DESCS - 1, NB_TX_DESCS - 1);
 	k_sem_init(&p->free_rx_descs, NB_RX_DESCS - 1, NB_RX_DESCS - 1);
+	k_fifo_init(&p->tx_queue);
 
 	net_if_set_link_addr(iface, p->mac_addr, sizeof(p->mac_addr), NET_LINK_ETHERNET);
 	dwmac_set_mac_addr(dev, p->mac_addr);

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -32,6 +32,7 @@ LOG_MODULE_REGISTER(dwmac_core, CONFIG_ETHERNET_LOG_LEVEL);
 #define TDES0_IC  BIT(30)
 #define TDES0_LS  BIT(29)
 #define TDES0_FS  BIT(28)
+#define TDES0_TER BIT(21)
 #define TDES0_TCH BIT(20)
 #define TDES0_ES  BIT(15)
 #define TDES0_CIC GENMASK(23, 22)
@@ -45,6 +46,7 @@ LOG_MODULE_REGISTER(dwmac_core, CONFIG_ETHERNET_LOG_LEVEL);
 #define RDES0_LS  BIT(8)
 
 #define RDES1_RBS1 GENMASK(12, 0)
+#define RDES1_RER  BIT(15)
 #define RDES1_RCH  BIT(14)
 
 #define RX_LEN_FROM_RDES0(rdes0) (FIELD_GET(RDES0_FL, (rdes0)))
@@ -89,7 +91,7 @@ static __maybe_unused unsigned int net_pkt_get_nbfrags(struct net_pkt *pkt)
 	return nbfrags;
 }
 
-#define TDES0_FLAGS_DEFAULT (TDES0_TCH | TDES0_IC | \
+#define TDES0_FLAGS_DEFAULT (TDES0_IC | \
 	(IS_ENABLED(CONFIG_ETH_DWC_ETHER_TX_HW_CHECKSUM) ? TDES0_CIC : 0U))
 
 static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
@@ -130,6 +132,10 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 
 		if (!frag->frags) {
 			d->des0 |= TDES0_LS;
+		}
+
+		if (d_idx == NB_TX_DESCS - 1) {
+			d->des0 |= TDES0_TER;
 		}
 
 		des0_flags = TDES0_OWN | TDES0_FLAGS_DEFAULT;
@@ -281,7 +287,11 @@ static void dwmac_rx_refill_desc(const struct device *dev, struct net_buf *frag)
 	d = &p->rx_descs[d_idx];
 	__ASSERT(!(d->des0 & RDES0_OWN), "rx desc still owned");
 
-	d->des1 = FIELD_PREP(RDES1_RBS1, frag->size) | RDES1_RCH;
+	d->des1 = FIELD_PREP(RDES1_RBS1, frag->size);
+
+	if (d_idx == NB_RX_DESCS - 1) {
+		d->des1 |= RDES1_RER;
+	}
 	d->des2 = phys_lo32(frag->data);
 
 	barrier_dmem_fence_full();
@@ -471,7 +481,6 @@ int dwmac_probe(const struct device *dev)
 	struct dwmac_priv *p = dev->data;
 	int ret;
 	k_timepoint_t timeout;
-	unsigned int i;
 	uint32_t reg_val;
 
 	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
@@ -505,16 +514,6 @@ int dwmac_probe(const struct device *dev)
 
 	memset(p->tx_descs, 0, NB_TX_DESCS * sizeof(struct dwmac_dma_desc));
 	memset(p->rx_descs, 0, NB_RX_DESCS * sizeof(struct dwmac_dma_desc));
-
-	for (i = 0; i < NB_TX_DESCS; i++) {
-		p->tx_descs[i].des1 = TDES0_TCH;
-		p->tx_descs[i].des3 = TXDESC_PHYS_L((i + 1) % NB_TX_DESCS);
-	}
-
-	for (i = 0; i < NB_RX_DESCS; i++) {
-		p->rx_descs[i].des1 = RDES1_RCH;
-		p->rx_descs[i].des3 = RXDESC_PHYS_L((i + 1) % NB_RX_DESCS);
-	}
 
 	if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_1000_CORE_EDFE)) {
 		DWMAC_REG_WRITE(DWMAC_DMABMR, DWMAC_REG_READ(DWMAC_DMABMR) | DWMAC_DMABMR_EDFE);

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -200,7 +200,7 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 	p->tx_desc_head = d_idx;
 
 	/* lastly notify the hardware */
-	REG_WRITE(DMA_CHn_TXDESC_TAIL_PTR(0), TXDESC_PHYS_L(d_idx));
+	DWMAC_REG_WRITE(DMA_CHn_TXDESC_TAIL_PTR(0), TXDESC_PHYS_L(d_idx));
 
 	return 0;
 
@@ -393,7 +393,7 @@ static void dwmac_rx_refill_thread(void *arg1, void *unused1, void *unused2)
 		p->rx_desc_head = INC_WRAP(d_idx, NB_RX_DESCS);
 
 		/* lastly notify the hardware */
-		REG_WRITE(DMA_CHn_RXDESC_TAIL_PTR(0), RXDESC_PHYS_L(d_idx));
+		DWMAC_REG_WRITE(DMA_CHn_RXDESC_TAIL_PTR(0), RXDESC_PHYS_L(d_idx));
 	}
 }
 
@@ -402,9 +402,9 @@ static void dwmac_dma_irq(const struct device *dev, unsigned int ch)
 	struct dwmac_priv *p = dev->data;
 	uint32_t status;
 
-	status = REG_READ(DMA_CHn_STATUS(ch));
+	status = DWMAC_REG_READ(DMA_CHn_STATUS(ch));
 	LOG_DBG("DMA_CHn_STATUS(%d) = 0x%08x", ch, status);
-	REG_WRITE(DMA_CHn_STATUS(ch), status);
+	DWMAC_REG_WRITE(DMA_CHn_STATUS(ch), status);
 
 	__ASSERT(ch == 0, "only one DMA channel is currently supported");
 
@@ -425,7 +425,7 @@ static void dwmac_mac_irq(const struct device *dev)
 {
 	uint32_t status;
 
-	status = REG_READ(MAC_IRQ_STATUS);
+	status = DWMAC_REG_READ(MAC_IRQ_STATUS);
 	LOG_DBG("MAC_IRQ_STATUS = 0x%08x", status);
 	__ASSERT(false, "unimplemented");
 }
@@ -434,7 +434,7 @@ static void dwmac_mtl_irq(const struct device *dev)
 {
 	uint32_t status;
 
-	status = REG_READ(MTL_IRQ_STATUS);
+	status = DWMAC_REG_READ(MTL_IRQ_STATUS);
 	LOG_DBG("MTL_IRQ_STATUS = 0x%08x", status);
 	__ASSERT(false, "unimplemented");
 }
@@ -444,7 +444,7 @@ void dwmac_isr(const struct device *dev)
 	uint32_t irq_status;
 	unsigned int ch;
 
-	irq_status = REG_READ(DMA_IRQ_STATUS);
+	irq_status = DWMAC_REG_READ(DMA_IRQ_STATUS);
 	LOG_DBG("DMA_IRQ_STATUS = 0x%08x", irq_status);
 
 	while (irq_status & 0xff) {
@@ -467,9 +467,9 @@ static void dwmac_set_mac_addr(const struct device *dev, const uint8_t *addr, in
 	uint32_t reg_val;
 
 	reg_val = (addr[5] << 8) | addr[4];
-	REG_WRITE(MAC_ADDRESS_HIGH(n), reg_val | MAC_ADDRESS_HIGH_AE);
+	DWMAC_REG_WRITE(MAC_ADDRESS_HIGH(n), reg_val | MAC_ADDRESS_HIGH_AE);
 	reg_val = (addr[3] << 24) | (addr[2] << 16) | (addr[1] << 8) | addr[0];
-	REG_WRITE(MAC_ADDRESS_LOW(n), reg_val);
+	DWMAC_REG_WRITE(MAC_ADDRESS_LOW(n), reg_val);
 }
 
 static int dwmac_set_config(const struct device *dev,
@@ -489,15 +489,15 @@ static int dwmac_set_config(const struct device *dev,
 
 #if defined(CONFIG_NET_PROMISCUOUS_MODE)
 	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
-		reg_val = REG_READ(MAC_PKT_FILTER);
+		reg_val = DWMAC_REG_READ(MAC_PKT_FILTER);
 		if (config->promisc_mode &&
 		    !(reg_val & MAC_PKT_FILTER_PR)) {
-			REG_WRITE(MAC_PKT_FILTER,
-				  reg_val | MAC_PKT_FILTER_PR);
+			DWMAC_REG_WRITE(MAC_PKT_FILTER,
+					reg_val | MAC_PKT_FILTER_PR);
 		} else if (!config->promisc_mode &&
 			   (reg_val & MAC_PKT_FILTER_PR)) {
-			REG_WRITE(MAC_PKT_FILTER,
-				  reg_val & ~MAC_PKT_FILTER_PR);
+			DWMAC_REG_WRITE(MAC_PKT_FILTER,
+					reg_val & ~MAC_PKT_FILTER_PR);
 		} else {
 			ret = -EALREADY;
 		}
@@ -523,7 +523,7 @@ static void phy_link_state_changed(const struct device *phy_dev,
 	ARG_UNUSED(phy_dev);
 
 	if (state->is_up) {
-		reg_val = REG_READ(MAC_CONF);
+		reg_val = DWMAC_REG_READ(MAC_CONF);
 
 		switch (state->speed) {
 		case LINK_HALF_10BASE:
@@ -555,7 +555,7 @@ static void phy_link_state_changed(const struct device *phy_dev,
 			reg_val &= ~MAC_CONF_DM;
 		}
 
-		REG_WRITE(MAC_CONF, reg_val);
+		DWMAC_REG_WRITE(MAC_CONF, reg_val);
 	}
 
 	net_eth_carrier_set(p->iface, state->is_up);
@@ -590,7 +590,7 @@ static void dwmac_iface_init(struct net_if *iface)
 	 *   - pass multicast packets
 	 *   - pass broadcast packets
 	 */
-	REG_WRITE(MAC_PKT_FILTER, MAC_PKT_FILTER_PM);
+	DWMAC_REG_WRITE(MAC_PKT_FILTER, MAC_PKT_FILTER_PM);
 
 	if (cfg->phy_dev != NULL) {
 		/* Do not start the interface until PHY link is up */
@@ -622,16 +622,16 @@ static void dwmac_iface_init(struct net_if *iface)
 	k_thread_name_set(&p->rx_refill_thread, "dwmac_rx_refill");
 
 	/* start up TX/RX */
-	reg_val = REG_READ(DMA_CHn_TX_CTRL(0));
-	REG_WRITE(DMA_CHn_TX_CTRL(0), reg_val | DMA_CHn_TX_CTRL_St);
-	reg_val = REG_READ(DMA_CHn_RX_CTRL(0));
-	REG_WRITE(DMA_CHn_RX_CTRL(0), reg_val | DMA_CHn_RX_CTRL_SR);
-	reg_val = REG_READ(MAC_CONF);
+	reg_val = DWMAC_REG_READ(DMA_CHn_TX_CTRL(0));
+	DWMAC_REG_WRITE(DMA_CHn_TX_CTRL(0), reg_val | DMA_CHn_TX_CTRL_St);
+	reg_val = DWMAC_REG_READ(DMA_CHn_RX_CTRL(0));
+	DWMAC_REG_WRITE(DMA_CHn_RX_CTRL(0), reg_val | DMA_CHn_RX_CTRL_SR);
+	reg_val = DWMAC_REG_READ(MAC_CONF);
 	reg_val |= MAC_CONF_CST | MAC_CONF_TE | MAC_CONF_RE;
-	REG_WRITE(MAC_CONF, reg_val);
+	DWMAC_REG_WRITE(MAC_CONF, reg_val);
 
 	/* unmask IRQs */
-	REG_WRITE(DMA_CHn_IRQ_ENABLE(0),
+	DWMAC_REG_WRITE(DMA_CHn_IRQ_ENABLE(0),
 		  DMA_CHn_IRQ_ENABLE_TIE |
 		  DMA_CHn_IRQ_ENABLE_RIE |
 		  DMA_CHn_IRQ_ENABLE_NIE |
@@ -656,15 +656,15 @@ int dwmac_probe(const struct device *dev)
 		return ret;
 	}
 
-	reg_val = REG_READ(MAC_VERSION);
+	reg_val = DWMAC_REG_READ(MAC_VERSION);
 	LOG_INF("HW version %u.%u0", (reg_val >> 4) & 0xf, reg_val & 0xf);
 	__ASSERT(FIELD_GET(MAC_VERSION_SNPSVER, reg_val) >= 0x40,
 		 "This driver expects DWC-ETHERNET version >= 4.00");
 
 	/* resets all of the MAC internal registers and logic */
-	REG_WRITE(DMA_MODE, DMA_MODE_SWR);
+	DWMAC_REG_WRITE(DMA_MODE, DMA_MODE_SWR);
 	timeout = sys_timepoint_calc(K_MSEC(100));
-	while (REG_READ(DMA_MODE) & DMA_MODE_SWR) {
+	while (DWMAC_REG_READ(DMA_MODE) & DMA_MODE_SWR) {
 		if (sys_timepoint_expired(timeout)) {
 			LOG_ERR("unable to reset hardware");
 			return -EIO;
@@ -672,10 +672,10 @@ int dwmac_probe(const struct device *dev)
 	}
 
 	/* get configured hardware features */
-	p->feature0 = REG_READ(MAC_HW_FEATURE0);
-	p->feature1 = REG_READ(MAC_HW_FEATURE1);
-	p->feature2 = REG_READ(MAC_HW_FEATURE2);
-	p->feature3 = REG_READ(MAC_HW_FEATURE3);
+	p->feature0 = DWMAC_REG_READ(MAC_HW_FEATURE0);
+	p->feature1 = DWMAC_REG_READ(MAC_HW_FEATURE1);
+	p->feature2 = DWMAC_REG_READ(MAC_HW_FEATURE2);
+	p->feature3 = DWMAC_REG_READ(MAC_HW_FEATURE3);
 	LOG_DBG("hw_feature: 0x%08x 0x%08x 0x%08x 0x%08x",
 		p->feature0, p->feature1, p->feature2, p->feature3);
 
@@ -688,16 +688,16 @@ int dwmac_probe(const struct device *dev)
 	memset(p->rx_descs, 0, NB_RX_DESCS * sizeof(struct dwmac_dma_desc));
 
 	/* set up DMA */
-	REG_WRITE(DMA_CHn_TX_CTRL(0), 0);
-	REG_WRITE(DMA_CHn_RX_CTRL(0),
-		  FIELD_PREP(DMA_CHn_RX_CTRL_PBL, 32) |
-		  FIELD_PREP(DMA_CHn_RX_CTRL_RBSZ, RX_FRAG_SIZE));
-	REG_WRITE(DMA_CHn_TXDESC_LIST_HADDR(0), TXDESC_PHYS_H(0));
-	REG_WRITE(DMA_CHn_TXDESC_LIST_ADDR(0), TXDESC_PHYS_L(0));
-	REG_WRITE(DMA_CHn_RXDESC_LIST_HADDR(0), RXDESC_PHYS_H(0));
-	REG_WRITE(DMA_CHn_RXDESC_LIST_ADDR(0), RXDESC_PHYS_L(0));
-	REG_WRITE(DMA_CHn_TXDESC_RING_LENGTH(0), NB_TX_DESCS - 1);
-	REG_WRITE(DMA_CHn_RXDESC_RING_LENGTH(0), NB_RX_DESCS - 1);
+	DWMAC_REG_WRITE(DMA_CHn_TX_CTRL(0), 0);
+	DWMAC_REG_WRITE(DMA_CHn_RX_CTRL(0),
+			FIELD_PREP(DMA_CHn_RX_CTRL_PBL, 32) |
+			FIELD_PREP(DMA_CHn_RX_CTRL_RBSZ, RX_FRAG_SIZE));
+	DWMAC_REG_WRITE(DMA_CHn_TXDESC_LIST_HADDR(0), TXDESC_PHYS_H(0));
+	DWMAC_REG_WRITE(DMA_CHn_TXDESC_LIST_ADDR(0), TXDESC_PHYS_L(0));
+	DWMAC_REG_WRITE(DMA_CHn_RXDESC_LIST_HADDR(0), RXDESC_PHYS_H(0));
+	DWMAC_REG_WRITE(DMA_CHn_RXDESC_LIST_ADDR(0), RXDESC_PHYS_L(0));
+	DWMAC_REG_WRITE(DMA_CHn_TXDESC_RING_LENGTH(0), NB_TX_DESCS - 1);
+	DWMAC_REG_WRITE(DMA_CHn_RXDESC_RING_LENGTH(0), NB_RX_DESCS - 1);
 
 	return 0;
 }

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -149,6 +149,20 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 
 	LOG_DBG("pkt len/frags=%u/%u", pkt_len, net_pkt_get_nbfrags(pkt));
 
+	NET_PKT_FRAG_FOR_EACH(pkt, frag) {
+		if (k_sem_take(&p->free_tx_descs, TX_AVAIL_WAIT) < 0) {
+
+			LOG_DBG("no more free tx descriptors");
+			NET_PKT_FRAG_FOR_EACH(pkt, frag1) {
+				if (frag1 == frag) {
+					break;
+				}
+				k_sem_give(&p->free_tx_descs);
+			}
+			return -ENOMEM;
+		}
+	}
+
 	/* initial flag values */
 	des2_flags = 0;
 	des3_flags = TDES3_FD | TDES3_OWN;
@@ -160,17 +174,7 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 			k_sem_count_get(&p->free_tx_descs),
 			p->tx_desc_head, p->tx_desc_tail);
 
-		/* reserve a free descriptor for this fragment */
-		if (k_sem_take(&p->free_tx_descs, TX_AVAIL_WAIT) != 0) {
-			LOG_DBG("no more free tx descriptors");
-			goto abort;
-		}
-
-		/* Take reference for the DMA */
-		net_pkt_frag_ref(frag);
-
 		sys_cache_data_flush_range(frag->data, frag->len);
-		p->tx_frags[d_idx] = frag;
 		LOG_DBG("d[%d]: frag %p len %d", d_idx, (void *)frag->data, frag->len);
 
 		/* if no more fragments after this one: */
@@ -193,6 +197,9 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 		INC_WRAP(d_idx, NB_TX_DESCS);
 	};
 
+	net_pkt_ref(pkt);
+	k_fifo_put(&p->tx_queue, pkt);
+
 	/* make sure all the above made it to memory */
 	barrier_dmem_fence_full();
 
@@ -203,22 +210,12 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 	DWMAC_REG_WRITE(DMA_CHn_TXDESC_TAIL_PTR(0), TXDESC_PHYS_L(d_idx));
 
 	return 0;
-
-abort:
-	while (d_idx != p->tx_desc_head) {
-		/* release already prepared fragments */
-		DEC_WRAP(d_idx, NB_TX_DESCS);
-		net_pkt_frag_unref(p->tx_frags[d_idx]);
-		k_sem_give(&p->free_tx_descs);
-	}
-	return -ENOMEM;
 }
 
 static void dwmac_tx_release(struct dwmac_priv *p)
 {
 	unsigned int d_idx;
 	struct dwmac_dma_desc *d;
-	struct net_buf *frag;
 	uint32_t des3_val;
 
 	for (d_idx = p->tx_desc_tail;
@@ -238,13 +235,17 @@ static void dwmac_tx_release(struct dwmac_priv *p)
 			break;
 		}
 
-		/* release corresponding fragments */
-		frag = p->tx_frags[d_idx];
-		LOG_DBG("unref frag %p", (void *)frag->data);
-		net_pkt_frag_unref(frag);
-
 		/* last packet descriptor: */
 		if (des3_val & TDES3_LD) {
+			struct net_pkt *pkt = k_fifo_get(&p->tx_queue, K_NO_WAIT);
+
+			if (pkt != NULL) {
+				LOG_DBG("pkt len/frags=%zu/%u", net_pkt_get_len(pkt),
+					net_pkt_get_nbfrags(pkt));
+			}
+
+			net_pkt_unref(pkt);
+
 			/* log any errors */
 			if (des3_val & TDES3_ES) {
 				LOG_ERR("tx error (DES3 = 0x%08x)", des3_val);
@@ -612,6 +613,7 @@ static void dwmac_iface_init(struct net_if *iface)
 	 */
 	k_sem_init(&p->free_tx_descs, NB_TX_DESCS - 1, NB_TX_DESCS - 1);
 	k_sem_init(&p->free_rx_descs, NB_RX_DESCS - 1, NB_RX_DESCS - 1);
+	k_fifo_init(&p->tx_queue);
 
 	/* set up RX buffer refill thread */
 	k_thread_create(&p->rx_refill_thread, p->rx_refill_thread_stack,

--- a/drivers/ethernet/dwc_mac/eth_dwmac_mmu.c
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_mmu.c
@@ -70,16 +70,16 @@ int dwmac_platform_init(const struct device *dev)
 	p->rx_descs_phys = desc_phys_addr;
 
 	/* basic configuration for this platform */
-	REG_WRITE(MAC_CONF,
-		  MAC_CONF_PS |
-		  MAC_CONF_FES |
-		  MAC_CONF_DM);
-	REG_WRITE(DMA_SYSBUS_MODE,
-		  DMA_SYSBUS_MODE_AAL |
+	DWMAC_REG_WRITE(MAC_CONF,
+			MAC_CONF_PS |
+			MAC_CONF_FES |
+			MAC_CONF_DM);
+	DWMAC_REG_WRITE(DMA_SYSBUS_MODE,
+			DMA_SYSBUS_MODE_AAL |
 #ifdef CONFIG_64BIT
-		  DMA_SYSBUS_MODE_EAME |
+			DMA_SYSBUS_MODE_EAME |
 #endif
-		  DMA_SYSBUS_MODE_FB);
+			DMA_SYSBUS_MODE_FB);
 
 	/* set up IRQs (still masked for now) */
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), dwmac_isr,

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -128,11 +128,12 @@ struct dwmac_priv {
 	uintptr_t tx_descs_phys, rx_descs_phys;
 #endif
 
-	struct net_buf *tx_frags[NB_TX_DESCS]; /* index shared with tx_descs */
 	struct net_buf *rx_frags[NB_RX_DESCS]; /* index shared with rx_descs */
 
 	struct net_pkt *rx_pkt;
 	uint16_t rx_bytes;
+
+	struct k_fifo tx_queue;
 
 	K_KERNEL_STACK_MEMBER(rx_refill_thread_stack, RX_REFILL_STACK_SIZE);
 	struct k_thread rx_refill_thread;

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -136,6 +136,8 @@ struct dwmac_priv {
 
 	K_KERNEL_STACK_MEMBER(rx_refill_thread_stack, RX_REFILL_STACK_SIZE);
 	struct k_thread rx_refill_thread;
+
+	struct k_spinlock spinlock;
 };
 
 /*

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -142,8 +142,8 @@ struct dwmac_priv {
  * Handy register accessors
  */
 
-#define REG_READ(r) sys_read32(DEVICE_MMIO_GET(dev) + (r))
-#define REG_WRITE(r, v) sys_write32((v), DEVICE_MMIO_GET(dev) + (r))
+#define DWMAC_REG_READ(r) sys_read32(DEVICE_MMIO_GET(dev) + (r))
+#define DWMAC_REG_WRITE(r, v) sys_write32((v), DEVICE_MMIO_GET(dev) + (r))
 
 /*
  * Shared declarations between core and platform glue code

--- a/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_qos.c
+++ b/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_qos.c
@@ -136,13 +136,13 @@ int dwmac_platform_init(const struct device *dev)
 	p->rx_descs = dwmac_rx_descs;
 
 	/* basic configuration for this platform */
-	REG_WRITE(MAC_CONF,
-		  MAC_CONF_PS |
-		  MAC_CONF_FES |
-		  MAC_CONF_DM);
-	REG_WRITE(DMA_SYSBUS_MODE,
-		  DMA_SYSBUS_MODE_AAL |
-		  DMA_SYSBUS_MODE_FB);
+	DWMAC_REG_WRITE(MAC_CONF,
+			MAC_CONF_PS |
+			MAC_CONF_FES |
+			MAC_CONF_DM);
+	DWMAC_REG_WRITE(DMA_SYSBUS_MODE,
+			DMA_SYSBUS_MODE_AAL |
+			DMA_SYSBUS_MODE_FB);
 
 	/* set up IRQs (still masked for now) */
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), dwmac_isr,


### PR DESCRIPTION
improve rx and tx path
- 1000: use ring mode
- 1000: for tx put 2 fragments in one descriptor
- use a fifo for the reference of the tx pkt
- 1000: refill rx descriptors in the irq if possible
- split checksum Kconfigs