### PR TITLE
drivers: esp32: Fix sleep retention

### DIFF
--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -35,7 +35,7 @@
 #endif
 
 #if COUNTER_SLEEP_RETENTION_ENABLED
-#include <hal/timer_periph.h>
+#include "gptimer_priv.h"
 #include <esp_private/sleep_retention.h>
 #endif
 
@@ -104,21 +104,22 @@ static esp_err_t counter_esp32_create_sleep_retention_cb(void *arg)
 	const struct counter_esp32_config *cfg = dev->config;
 
 	return sleep_retention_entries_create(
-		soc_timg_gptimer_retention_infos[cfg->group][cfg->index].regdma_entry_array,
-		soc_timg_gptimer_retention_infos[cfg->group][cfg->index].array_size,
+		gptimer_retention_infos[cfg->group][cfg->index].regdma_entry_array,
+		gptimer_retention_infos[cfg->group][cfg->index].array_size,
 		REGDMA_LINK_PRI_GPTIMER,
-		soc_timg_gptimer_retention_infos[cfg->group][cfg->index].module);
+		gptimer_retention_infos[cfg->group][cfg->index].module);
 }
 
 static void counter_esp32_sleep_retention_init(const struct device *dev)
 {
 	const struct counter_esp32_config *cfg = dev->config;
-	const soc_timg_gptimer_retention_desc_t *info =
-		&soc_timg_gptimer_retention_infos[cfg->group][cfg->index];
+	const gptimer_retention_desc_t *info =
+		&gptimer_retention_infos[cfg->group][cfg->index];
 
 	sleep_retention_module_init_param_t init_param = {
 		.cbs = {.create = {.handle = counter_esp32_create_sleep_retention_cb,
 				   .arg = (void *)dev}},
+		.attribute = SLEEP_RETENTION_MODULE_ATTR_ATTACH,
 		.depends = RETENTION_MODULE_BITMAP_INIT(CLOCK_SYSTEM),
 	};
 
@@ -126,6 +127,9 @@ static void counter_esp32_sleep_retention_init(const struct device *dev)
 
 	if (err == ESP_OK) {
 		err = sleep_retention_module_allocate(info->module);
+	}
+	if (err == ESP_OK) {
+		err = sleep_retention_module_attach(info->module);
 	}
 	if (err != ESP_OK) {
 		LOG_WRN("GPTimer sleep retention init failed (%d) group=%u index=%u", err,

--- a/drivers/dma/dma_esp32_gdma.c
+++ b/drivers/dma/dma_esp32_gdma.c
@@ -39,12 +39,12 @@ LOG_MODULE_REGISTER(dma_esp32_gdma, CONFIG_DMA_LOG_LEVEL);
 #endif
 
 #if GDMA_SLEEP_RETENTION_ENABLED
-#include <hal/gdma_periph.h>
+#include "gdma_priv.h"
 #include <esp_private/sleep_retention.h>
 
 static esp_err_t gdma_create_sleep_retention_cb(void *arg)
 {
-	const gdma_chx_reg_ctx_link_t *ctx = (const gdma_chx_reg_ctx_link_t *)arg;
+	const gdma_retention_desc_t *ctx = (const gdma_retention_desc_t *)arg;
 
 	return sleep_retention_entries_create(ctx->link_list, ctx->link_num,
 					      REGDMA_LINK_PRI_GDMA, ctx->module_id);
@@ -911,8 +911,8 @@ static int dma_esp32_init(const struct device *dev)
 
 #if GDMA_SLEEP_RETENTION_ENABLED
 	for (uint8_t pair = 0; pair < GDMA_LL_PAIRS_PER_INST; pair++) {
-		const gdma_chx_reg_ctx_link_t *ctx =
-			&gdma_chx_regs_retention[hal_config.group_id][pair];
+		const gdma_retention_desc_t *ctx =
+			&gdma_retention_infos[hal_config.group_id][pair];
 		sleep_retention_module_init_param_t init_param = {
 			.cbs = {.create = {.handle = gdma_create_sleep_retention_cb,
 					   .arg = (void *)ctx}},

--- a/drivers/dma/dma_esp32_gdma.c
+++ b/drivers/dma/dma_esp32_gdma.c
@@ -874,6 +874,8 @@ static int dma_esp32_init(const struct device *dev)
 		memset(dma_channel->desc_list, 0, sizeof(dma_channel->desc_list));
 	}
 
+	int group_id;
+
 #if defined(SOC_AXI_GDMA_SUPPORTED)
 	/*
 	 * Dual-bus SoCs have two gdma instances sharing the same compatible, told
@@ -883,21 +885,24 @@ static int dma_esp32_init(const struct device *dev)
 	if ((uint32_t)data->hal.dev == DR_REG_AXI_DMA_BASE) {
 		gdma_ll_enable_bus_clock(1, true);
 		gdma_ll_reset_register(1);
+		group_id = GDMA_LL_AXI_GROUP_START_ID;
 		gdma_hal_config_t hal_config = {
-			.group_id = GDMA_LL_AXI_GROUP_START_ID,
+			.group_id = group_id,
 		};
 		gdma_axi_hal_init(&data->hal, &hal_config);
 		data->is_axi = true;
 	} else {
+		group_id = GDMA_LL_AHB_GROUP_START_ID;
 		gdma_hal_config_t hal_config = {
-			.group_id = GDMA_LL_AHB_GROUP_START_ID,
+			.group_id = group_id,
 		};
 		gdma_ahb_hal_init(&data->hal, &hal_config);
 		data->is_axi = false;
 	}
 #else
+	group_id = GDMA_LL_AHB_GROUP_START_ID;
 	gdma_hal_config_t hal_config = {
-		.group_id = GDMA_LL_AHB_GROUP_START_ID,
+		.group_id = group_id,
 	};
 	gdma_ahb_hal_init(&data->hal, &hal_config);
 #endif
@@ -912,7 +917,7 @@ static int dma_esp32_init(const struct device *dev)
 #if GDMA_SLEEP_RETENTION_ENABLED
 	for (uint8_t pair = 0; pair < GDMA_LL_PAIRS_PER_INST; pair++) {
 		const gdma_retention_desc_t *ctx =
-			&gdma_retention_infos[hal_config.group_id][pair];
+			&gdma_retention_infos[group_id][pair];
 		sleep_retention_module_init_param_t init_param = {
 			.cbs = {.create = {.handle = gdma_create_sleep_retention_cb,
 					   .arg = (void *)ctx}},

--- a/drivers/dma/dma_esp32_gdma.c
+++ b/drivers/dma/dma_esp32_gdma.c
@@ -921,11 +921,16 @@ static int dma_esp32_init(const struct device *dev)
 		sleep_retention_module_init_param_t init_param = {
 			.cbs = {.create = {.handle = gdma_create_sleep_retention_cb,
 					   .arg = (void *)ctx}},
+			.attribute = SLEEP_RETENTION_MODULE_ATTR_ATTACH,
+			.depends = RETENTION_MODULE_BITMAP_INIT(CLOCK_SYSTEM),
 		};
 		esp_err_t err = sleep_retention_module_init(ctx->module_id, &init_param);
 
 		if (err == ESP_OK) {
 			err = sleep_retention_module_allocate(ctx->module_id);
+		}
+		if (err == ESP_OK) {
+			err = sleep_retention_module_attach(ctx->module_id);
 		}
 		if (err != ESP_OK) {
 			LOG_WRN("Failed to init GDMA sleep retention for pair %d", pair);

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -1200,7 +1200,9 @@ static void i2c_esp32_sleep_retention_init(uint32_t port)
 	if (err == ESP_OK) {
 		err = sleep_retention_module_allocate(i2c_regs_retention[port].module_id);
 	}
-
+	if (err == ESP_OK) {
+		err = sleep_retention_module_attach(i2c_regs_retention[port].module_id);
+	}
 	if (err != ESP_OK) {
 		LOG_WRN("I2C%lu sleep retention init failed (%d)", (unsigned long)port, err);
 	}

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -432,12 +432,16 @@ static void pwm_led_esp32_sleep_retention_init(void)
 	sleep_retention_module_t module = ledc_reg_retention_info[0].module_id;
 	sleep_retention_module_init_param_t init_param = {
 		.cbs = {.create = {.handle = pwm_led_esp32_create_sleep_retention_cb, .arg = NULL}},
+		.attribute = SLEEP_RETENTION_MODULE_ATTR_ATTACH,
 		.depends = RETENTION_MODULE_BITMAP_INIT(CLOCK_SYSTEM)};
 
 	esp_err_t err = sleep_retention_module_init(module, &init_param);
 
 	if (err == ESP_OK) {
 		err = sleep_retention_module_allocate(module);
+	}
+	if (err == ESP_OK) {
+		err = sleep_retention_module_attach(module);
 	}
 	if (err != ESP_OK) {
 		LOG_WRN("LEDC sleep retention init failed (%d)", err);

--- a/drivers/pwm/pwm_mc_esp32.c
+++ b/drivers/pwm/pwm_mc_esp32.c
@@ -29,7 +29,7 @@
 #endif
 
 #if MCPWM_SLEEP_RETENTION_ENABLED
-#include <hal/mcpwm_periph.h>
+#include "mcpwm_private.h"
 #include <esp_private/sleep_retention.h>
 #endif
 
@@ -401,9 +401,9 @@ static esp_err_t mcpwm_esp32_create_sleep_retention_cb(void *arg)
 {
 	const struct device *dev = arg;
 	const struct mcpwm_esp32_config *cfg = dev->config;
-	const mcpwm_reg_retention_info_t *info;
+	const mcpwm_retention_desc_t *info;
 
-	info = &mcpwm_reg_retention_info[cfg->index];
+	info = &mcpwm_retention_infos[cfg->index];
 
 	return sleep_retention_entries_create(info->regdma_entry_array, info->array_size,
 					      REGDMA_LINK_PRI_MCPWM, info->retention_module);
@@ -418,17 +418,21 @@ static void mcpwm_esp32_sleep_retention_init(const struct device *dev)
 		return;
 	}
 
-	module = mcpwm_reg_retention_info[cfg->index].retention_module;
+	module = mcpwm_retention_infos[cfg->index].retention_module;
 
 	sleep_retention_module_init_param_t init_param = {
 		.cbs = {.create = {.handle = mcpwm_esp32_create_sleep_retention_cb,
 				   .arg = (void *)dev}},
+		.attribute = SLEEP_RETENTION_MODULE_ATTR_ATTACH,
 		.depends = RETENTION_MODULE_BITMAP_INIT(CLOCK_SYSTEM)};
 
 	esp_err_t err = sleep_retention_module_init(module, &init_param);
 
 	if (err == ESP_OK) {
 		err = sleep_retention_module_allocate(module);
+	}
+	if (err == ESP_OK) {
+		err = sleep_retention_module_attach(module);
 	}
 	if (err != ESP_OK) {
 		LOG_WRN("MCPWM sleep retention init failed (%d)", err);

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -1211,12 +1211,16 @@ static void uart_esp32_sleep_retention_init(int port)
 	sleep_retention_module_init_param_t init_param = {
 		.cbs = {.create = {.handle = uart_create_sleep_retention_cb,
 				   .arg = (void *)(uintptr_t)port}},
+		.attribute = SLEEP_RETENTION_MODULE_ATTR_ATTACH,
 		.depends = RETENTION_MODULE_BITMAP_INIT(CLOCK_SYSTEM)};
 
 	esp_err_t err = sleep_retention_module_init(module, &init_param);
 
 	if (err == ESP_OK) {
 		err = sleep_retention_module_allocate(module);
+	}
+	if (err == ESP_OK) {
+		err = sleep_retention_module_attach(module);
 	}
 	if (err != ESP_OK) {
 		LOG_WRN("UART%d sleep retention init failed (%d)", port, err);

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -623,16 +623,20 @@ static void spi_esp32_sleep_retention_init(const struct device *dev)
 	const struct spi_esp32_config *cfg = dev->config;
 	unsigned int idx = cfg->dma_host;
 
+	sleep_retention_module_t module = spi_reg_retention_info[idx].module_id;
 	sleep_retention_module_init_param_t init_param = {
 		.cbs = {.create = {.handle = spi_esp32_create_sleep_retention_cb,
 				   .arg = (void *)dev}},
+		.attribute = SLEEP_RETENTION_MODULE_ATTR_ATTACH,
 		.depends = RETENTION_MODULE_BITMAP_INIT(CLOCK_SYSTEM)};
 
-	esp_err_t err =
-		sleep_retention_module_init(spi_reg_retention_info[idx].module_id, &init_param);
+	esp_err_t err = sleep_retention_module_init(module, &init_param);
 
 	if (err == ESP_OK) {
-		err = sleep_retention_module_allocate(spi_reg_retention_info[idx].module_id);
+		err = sleep_retention_module_allocate(module);
+	}
+	if (err == ESP_OK) {
+		err = sleep_retention_module_attach(module);
 	}
 	if (err != ESP_OK) {
 		LOG_WRN("SPI sleep retention init failed (%d)", err);

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -159,7 +159,7 @@ static int wdt_esp32_install_timeout(const struct device *dev,
 #if WDT_SLEEP_RETENTION_ENABLED
 static esp_err_t wdt_create_sleep_retention_cb(void *arg)
 {
-	uint32_t group_id = (uint32_t)arg;
+	uint32_t group_id = (uint32_t)(uintptr_t)arg;
 	sleep_retention_module_t module =
 		(group_id == 0) ? SLEEP_RETENTION_MODULE_TG0_WDT : SLEEP_RETENTION_MODULE_TG1_WDT;
 
@@ -175,13 +175,17 @@ static void wdt_esp32_sleep_retention_init(uint32_t group_id)
 
 	sleep_retention_module_init_param_t init_param = {
 		.cbs = {.create = {.handle = wdt_create_sleep_retention_cb,
-				   .arg = (void *)group_id}},
+				   .arg = (void *)(uintptr_t)group_id}},
+		.attribute = SLEEP_RETENTION_MODULE_ATTR_ATTACH,
 		.depends = RETENTION_MODULE_BITMAP_INIT(CLOCK_SYSTEM)};
 
 	esp_err_t err = sleep_retention_module_init(module, &init_param);
 
 	if (err == ESP_OK) {
 		err = sleep_retention_module_allocate(module);
+	}
+	if (err == ESP_OK) {
+		err = sleep_retention_module_attach(module);
 	}
 	if (err != ESP_OK) {
 		LOG_WRN("WDT%d sleep retention init failed (%d)", group_id, err);

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 06d3c9fe735047f5ce390b86888f3b511be2b32d
+      revision: d6a25c8f2a019f7e4d21cf664075f6b94c28eae8
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Recent HAL sync moved sleep-retention definitions out of the HAL periph headers into driver components (esp_driver_dma, esp_driver_gptimer, esp_driver_mcpwm). Update affected drivers to use the new headers and symbol names (gdma_priv.h / gptimer_priv.h / mcpwm_private.h and the corresponding *_retention_infos tables).

Also call sleep_retention_module_attach() (with SLEEP_RETENTION_MODULE_ATTR_ATTACH) so TOP domain power-down can take effect. This lowers light-sleep current when peripheral power-down is enabled.

Drivers: GDMA, UART, SPI, LEDC, MCPWM, WDT, GPTimer/counter, I2C.