### PR TITLE
DHCPv4 INIT-REBOOT support improvements

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -234,6 +234,8 @@ New APIs and options
 * Network
 
   * Add :c:func:`net_eth_set_if_type_wifi` to set the ethernet interface type to Wi-Fi.
+  * Add :c:func:`net_dhcpv4_set_reboot_hint` to seed the DHCPv4 client with a
+    previously leased address for INIT-REBOOT.
 
 * Ring buffer
 

--- a/include/zephyr/net/dhcpv4.h
+++ b/include/zephyr/net/dhcpv4.h
@@ -69,6 +69,7 @@ enum net_dhcpv4_msg_type {
 };
 
 struct net_dhcpv4_option_callback;
+struct net_in_addr;
 
 /**
  * @typedef net_dhcpv4_option_callback_handler_t
@@ -233,6 +234,28 @@ void net_dhcpv4_stop(struct net_if *iface);
  *  @param iface A valid pointer on an interface
  */
 void net_dhcpv4_restart(struct net_if *iface);
+
+/**
+ * @brief Set the address requested in INIT-REBOOT.
+ *
+ * @details Seed the DHCPv4 client with a previously leased address, for
+ * example one restored from non-volatile storage, so that the next
+ * @ref net_dhcpv4_start begins in INIT-REBOOT state and requests it
+ * directly instead of performing a full discovery. Must be called while
+ * the DHCPv4 client is stopped. Requires
+ * @kconfig{CONFIG_NET_DHCPV4_INIT_REBOOT}.
+ *
+ * @param iface DHCPv4 interface.
+ * @param requested_ip Address to request, or an unspecified address to clear
+ *                     the hint.
+ *
+ * @retval 0 On success.
+ * @retval -EINVAL Invalid argument.
+ * @retval -EBUSY DHCPv4 client is active.
+ * @retval -ENOTSUP INIT-REBOOT support is disabled.
+ */
+int net_dhcpv4_set_reboot_hint(struct net_if *iface,
+			       const struct net_in_addr *requested_ip);
 
 /** @cond INTERNAL_HIDDEN */
 

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -2030,6 +2030,28 @@ void net_dhcpv4_restart(struct net_if *iface)
 	dhcpv4_start_internal(iface, false);
 }
 
+int net_dhcpv4_set_reboot_hint(struct net_if *iface,
+			       const struct net_in_addr *requested_ip)
+{
+	int ret = 0;
+
+	if (!IS_ENABLED(CONFIG_NET_DHCPV4_INIT_REBOOT)) {
+		return -ENOTSUP;
+	}
+
+	k_mutex_lock(&lock, K_FOREVER);
+
+	if (iface->config.dhcpv4.state != NET_DHCPV4_DISABLED) {
+		ret = -EBUSY;
+	} else {
+		iface->config.dhcpv4.requested_ip = *requested_ip;
+	}
+
+	k_mutex_unlock(&lock);
+
+	return ret;
+}
+
 int net_dhcpv4_init(void)
 {
 	uint64_t events =

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1501,9 +1501,13 @@ static void dhcpv4_handle_msg_ack(struct net_if *iface)
 static void dhcpv4_handle_msg_nak(struct net_if *iface)
 {
 	switch (iface->config.dhcpv4.state) {
+	case NET_DHCPV4_INIT_REBOOT:
+		LOG_DBG("NAK during INIT-REBOOT, restart config");
+		dhcpv4_enter_selecting(iface);
+		dhcpv4_immediate_timeout(&iface->config.dhcpv4);
+		break;
 	case NET_DHCPV4_DISABLED:
 	case NET_DHCPV4_INIT:
-	case NET_DHCPV4_INIT_REBOOT:
 	case NET_DHCPV4_SELECTING:
 	case NET_DHCPV4_REQUESTING:
 		if (memcmp(&iface->config.dhcpv4.request_server_addr,

--- a/tests/net/dhcpv4/client/CMakeLists.txt
+++ b/tests/net/dhcpv4/client/CMakeLists.txt
@@ -5,5 +5,6 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dhcpv4_client)
 
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)
+target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/lib)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/dhcpv4/client/src/main.c
+++ b/tests/net/dhcpv4/client/src/main.c
@@ -339,6 +339,7 @@ static uint32_t request_xid;
 static bool strict_dhcp_server;
 static bool discover_req_included_dns;
 static bool init_reboot_req_included_dns;
+static bool init_reboot_request_seen;
 static bool reject_init_reboot;
 
 #define EVT_ADDR_ADD        BIT(0)
@@ -373,6 +374,7 @@ static void dhcp_test_reset_iface(struct net_if *iface)
 	strict_dhcp_server = false;
 	discover_req_included_dns = false;
 	init_reboot_req_included_dns = false;
+	init_reboot_request_seen = false;
 	reject_init_reboot = false;
 }
 
@@ -693,6 +695,7 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 
 		dns_requested = dhcp_msg_req_list_contains(&msg, OPTION_DNS_SERVER);
 		is_init_reboot = msg.has_requested_ip && !msg.has_server_id;
+		init_reboot_request_seen |= is_init_reboot;
 
 		if (strict_dhcp_server && is_init_reboot) {
 			init_reboot_req_included_dns = dns_requested;
@@ -1053,6 +1056,28 @@ ZTEST(dhcpv4_tests, test_dhcp)
 			      EVT_DNS_SERVER3_DEL,
 			      "Missing DHCP stop or deleted address");
 	}
+}
+
+ZTEST(dhcpv4_tests, test_init_reboot_hint)
+{
+	const struct net_in_addr requested_ip = {{{10, 237, 72, 158}}};
+	struct net_if *iface;
+	uint32_t evt;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_DHCPV4_INIT_REBOOT);
+
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
+	zassert_not_null(iface, "Interface not available");
+
+	zassert_ok(net_dhcpv4_set_reboot_hint(iface, &requested_ip));
+
+	net_dhcpv4_start(iface);
+
+	evt = k_event_wait(&events, EVT_DHCP_OFFER | EVT_DHCP_ACK, false, WAIT_TIME);
+	zassert_equal(evt, EVT_DHCP_ACK, "Expected INIT-REBOOT ACK only %08x", evt);
+	zassert_true(init_reboot_request_seen, "INIT-REBOOT REQUEST was not sent");
+
+	net_dhcpv4_stop(iface);
 }
 
 ZTEST(dhcpv4_tests, test_init_reboot_nak_restarts_discovery)

--- a/tests/net/dhcpv4/client/src/main.c
+++ b/tests/net/dhcpv4/client/src/main.c
@@ -31,6 +31,7 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_DHCPV4_LOG_LEVEL);
 
 #include "ipv4.h"
 #include "udp_internal.h"
+#include "dhcpv4/dhcpv4_internal.h"
 
 #include <zephyr/tc_util.h>
 #include <zephyr/ztest.h>
@@ -338,6 +339,7 @@ static uint32_t request_xid;
 static bool strict_dhcp_server;
 static bool discover_req_included_dns;
 static bool init_reboot_req_included_dns;
+static bool reject_init_reboot;
 
 #define EVT_ADDR_ADD        BIT(0)
 #define EVT_ADDR_DEL        BIT(1)
@@ -357,6 +359,7 @@ static bool init_reboot_req_included_dns;
 #define EVT_DNS_SERVER1_DEL BIT(15)
 #define EVT_DNS_SERVER2_DEL BIT(16)
 #define EVT_DNS_SERVER3_DEL BIT(17)
+#define EVT_DHCP_NAK        BIT(18)
 
 static K_EVENT_DEFINE(events);
 
@@ -370,6 +373,7 @@ static void dhcp_test_reset_iface(struct net_if *iface)
 	strict_dhcp_server = false;
 	discover_req_included_dns = false;
 	init_reboot_req_included_dns = false;
+	reject_init_reboot = false;
 }
 
 static void dhcpv4_tests_before(void *fixture)
@@ -508,6 +512,54 @@ fail:
 	return NULL;
 }
 
+static struct net_pkt *prepare_dhcp_nak(struct net_if *iface, uint32_t xid)
+{
+	static const uint8_t cookie[] = { 0x63, 0x82, 0x53, 0x63 };
+	struct dhcp_msg msg = { 0 };
+	uint8_t empty_buf[SIZE_OF_FILE] = { 0 };
+	struct net_pkt *pkt;
+
+	pkt = net_pkt_alloc_with_buffer(iface, DHCPV4_MESSAGE_SIZE, NET_AF_INET,
+					NET_IPPROTO_UDP, K_FOREVER);
+	if (pkt == NULL) {
+		return NULL;
+	}
+
+	net_pkt_set_ipv4_ttl(pkt, 0xFF);
+
+	if (net_ipv4_create(pkt, &server_addr, &client_addr) ||
+	    net_udp_create(pkt, net_htons(SERVER_PORT), net_htons(CLIENT_PORT))) {
+		goto fail;
+	}
+
+	msg.op = DHCPV4_MSG_BOOT_REPLY;
+	msg.htype = HARDWARE_ETHERNET_TYPE;
+	msg.hlen = net_if_get_link_addr(iface)->len;
+	msg.xid = net_htonl(xid);
+	memcpy(msg.chaddr, net_if_get_link_addr(iface)->addr,
+	       net_if_get_link_addr(iface)->len);
+
+	if (net_pkt_write(pkt, &msg, sizeof(msg)) ||
+	    net_pkt_write(pkt, empty_buf, SIZE_OF_SNAME) ||
+	    net_pkt_write(pkt, empty_buf, SIZE_OF_FILE) ||
+	    net_pkt_write(pkt, cookie, sizeof(cookie)) ||
+	    net_pkt_write_u8(pkt, DHCPV4_OPTIONS_MSG_TYPE) ||
+	    net_pkt_write_u8(pkt, 1) ||
+	    net_pkt_write_u8(pkt, NET_DHCPV4_MSG_TYPE_NAK) ||
+	    net_pkt_write_u8(pkt, DHCPV4_OPTIONS_END)) {
+		goto fail;
+	}
+
+	net_pkt_cursor_init(pkt);
+	net_ipv4_finalize(pkt, NET_IPPROTO_UDP);
+
+	return pkt;
+
+fail:
+	net_pkt_unref(pkt);
+	return NULL;
+}
+
 static bool dhcp_msg_req_list_contains(const struct dhcp_client_msg *msg, uint8_t option)
 {
 	for (uint8_t i = 0; i < msg->req_options_cnt; i++) {
@@ -637,6 +689,7 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 		k_event_post(&events, EVT_DHCP_OFFER);
 	} else if (msg.type == REQUEST) {
 		bool include_dns;
+		bool nak_reply;
 
 		dns_requested = dhcp_msg_req_list_contains(&msg, OPTION_DNS_SERVER);
 		is_init_reboot = msg.has_requested_ip && !msg.has_server_id;
@@ -648,12 +701,17 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 			include_dns = true;
 		}
 
-		/* Reply with DHCPv4 ACK */
-		rpkt = prepare_dhcp_ack(net_pkt_iface(pkt), msg.xid, include_dns);
+		nak_reply = reject_init_reboot && is_init_reboot;
+
+		if (nak_reply) {
+			rpkt = prepare_dhcp_nak(net_pkt_iface(pkt), msg.xid);
+		} else {
+			rpkt = prepare_dhcp_ack(net_pkt_iface(pkt), msg.xid, include_dns);
+		}
 		if (!rpkt) {
 			return -EINVAL;
 		}
-		k_event_post(&events, EVT_DHCP_ACK);
+		k_event_post(&events, nak_reply ? EVT_DHCP_NAK : EVT_DHCP_ACK);
 	} else {
 		/* Invalid message type received */
 		return -EINVAL;
@@ -995,6 +1053,32 @@ ZTEST(dhcpv4_tests, test_dhcp)
 			      EVT_DNS_SERVER3_DEL,
 			      "Missing DHCP stop or deleted address");
 	}
+}
+
+ZTEST(dhcpv4_tests, test_init_reboot_nak_restarts_discovery)
+{
+	struct net_if *iface;
+	uint32_t evt;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_DHCPV4_INIT_REBOOT);
+
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
+	zassert_not_null(iface, "Interface not available");
+
+	iface->config.dhcpv4.requested_ip = (struct net_in_addr){{{10, 237, 72, 158}}};
+	iface->config.dhcpv4.request_server_addr.s_addr = NET_INADDR_ANY;
+	reject_init_reboot = true;
+
+	net_dhcpv4_start(iface);
+
+	evt = k_event_wait(&events, EVT_DHCP_NAK, false, WAIT_TIME);
+	zassert_equal(evt, EVT_DHCP_NAK, "Missing INIT-REBOOT NAK %08x", evt);
+
+	evt = k_event_wait_all(&events, EVT_DHCP_OFFER | EVT_DHCP_ACK, false, WAIT_TIME);
+	zassert_equal(evt, EVT_DHCP_OFFER | EVT_DHCP_ACK,
+		      "INIT-REBOOT NAK did not restart discovery %08x", evt);
+
+	net_dhcpv4_stop(iface);
 }
 
 #if IS_ENABLED(CONFIG_NET_DHCPV4_INIT_REBOOT) && \


### PR DESCRIPTION
## NAK handling fix

An INIT-REBOOT REQUEST carries no server identifier (RFC 2131 4.3.2), so `request_server_addr` is never populated in that state. The NAK handler compared it against the NAK source address anyway, so a NAK during INIT-REBOOT was always ignored as coming from a non-requesting server. The client kept retransmitting the REQUEST through the full backoff cycle (roughly 28 seconds) before falling back to discovery.

## New API: `net_dhcpv4_set_reboot_hint()`

INIT-REBOOT currently only triggers from state remembered in RAM, so it never applies after a cold boot. The new API lets an application seed the client with a previously leased address, for example one persisted in non-volatile storage, so the next `net_dhcpv4_start()` requests it directly and skips discovery. This saves a full round trip on every boot for devices trying to save power. The hint can only be set while the client is stopped; an unspecified address clears it. A stale hint is now cheap thanks to the NAK fix above: the server rejects it and the client falls back to discovery immediately.

## Testing

Two new tests in `tests/net/dhcpv4/client`: one where the simulated server NAKs the INIT-REBOOT REQUEST (fails without the fix, client stays stuck retransmitting), and one verifying a seeded hint produces an INIT-REBOOT REQUEST and binds from the ACK without a discovery round.
