### PR TITLE
drivers: haptics: Simplify and add trigger GPIOs

### DIFF
--- a/drivers/haptics/cirrus/Kconfig.cs40l26
+++ b/drivers/haptics/cirrus/Kconfig.cs40l26
@@ -29,6 +29,11 @@ config HAPTICS_CS40L26_INTERRUPT
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L27),int-gpios)
 	select GPIO
 
+config HAPTICS_CS40L26_TRIGGER
+	def_bool $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L26),trigger-gpios) || \
+		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L27),trigger-gpios)
+	select GPIO
+
 config HAPTICS_CS40L26_FLASH
 	def_bool $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L26),flash-storage) || \
 		 $(dt_compat_any_has_prop,$(DT_COMPAT_CIRRUS_CS40L27),flash-storage)

--- a/drivers/haptics/cirrus/cs40l26-firmware.c
+++ b/drivers/haptics/cirrus/cs40l26-firmware.c
@@ -42,6 +42,7 @@ static const uint16_t *const cs40l26_firmware[CS40L26_NUM_DEVICES] = {
 		[CS40L26_REG_F0_EST] = 0x6504U,
 		[CS40L26_REG_LOGGER_ENABLE] = 0x6CE0U,
 		[CS40L26_REG_LOGGER_DATA] = 0x6D38U,
+		[CS40L26_REG_GPIO_EVENT_BASE] = 0x6FC4U,
 		[CS40L26_REG_BUZZ_FREQ] = 0x7008U,
 		[CS40L26_REG_BUZZ_LEVEL] = 0x700CU,
 		[CS40L26_REG_BUZZ_DURATION] = 0x7010U,
@@ -70,6 +71,7 @@ static const uint16_t *const cs40l26_firmware[CS40L26_NUM_DEVICES] = {
 		[CS40L26_REG_BUZZ_FREQ] = 0x6D28U,
 		[CS40L26_REG_BUZZ_LEVEL] = 0x6D2CU,
 		[CS40L26_REG_BUZZ_DURATION] = 0x6D30U,
+		[CS40L26_REG_GPIO_EVENT_BASE] = 0x6FB0U,
 		[CS40L26_REG_F0_EST_REDC] = 0x720CU,
 		[CS40L26_REG_F0_EST] = 0x7214U,
 		[CS40L26_REG_MAILBOX_QUEUE_WT] = 0x74A0U,
@@ -142,6 +144,25 @@ int cs40l26_firmware_write(const struct device *const dev, const uint32_t firmwa
 			   uint32_t val)
 {
 	return cs40l26_firmware_burst_write(dev, firmware_control, &val, 1);
+}
+
+int cs40l26_firmware_write_offset(const struct device *const dev, const uint32_t firmware_control,
+				  uint32_t val, const off_t offset)
+{
+	const struct cs40l26_config *const config = dev->config;
+	uint32_t addr;
+	int ret;
+
+	ret = cs40l26_get_firmware_address(dev, firmware_control, &addr);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (!IN_RANGE(offset, -(int64_t)addr, UINT32_MAX - addr)) {
+		return -EINVAL;
+	}
+
+	return cs40lxx_write(&config->io_bus, addr + offset, val);
 }
 
 int cs40l26_firmware_raw_write(const struct device *const dev, const uint32_t firmware_control,

--- a/drivers/haptics/cirrus/cs40l26.c
+++ b/drivers/haptics/cirrus/cs40l26.c
@@ -43,6 +43,7 @@ LOG_MODULE_REGISTER(CS40L26, CONFIG_HAPTICS_LOG_LEVEL);
 /* Masks */
 #define CS40L26_MASK_F0_ENABLE   BIT(0)
 #define CS40L26_MASK_REDC_ENABLE BIT(1)
+#define CS40L26_MASK_ATTENUATION GENMASK(11, 9)
 
 /* Unmasked interrupts */
 #define CS40L26_DSP_VIRTUAL2_MBOX_WR_MASK1 BIT(31)
@@ -112,6 +113,20 @@ LOG_MODULE_REGISTER(CS40L26, CONFIG_HAPTICS_LOG_LEVEL);
 #define CS40L26_NUM_ROM_EFFECTS     39
 #define CS40L26_NUM_BUZ_EFFECTS     1
 #define CS40L26_FLASH_MEMORY_ERASED 0xFFFFFFFF
+
+enum cs40l26_gpios {
+	CS40L26_GPIO1,
+	CS40L26_GPIO2,
+	CS40L26_GPIO3,
+	CS40L26_GPIO4,
+};
+
+static const uint8_t cs40l26_trigger_offsets[] = {
+	[CS40L26_GPIO1] = 0x00,
+	[CS40L26_GPIO2] = 0x08,
+	[CS40L26_GPIO3] = 0x10,
+	[CS40L26_GPIO4] = 0x18,
+};
 
 static const struct cs40lxx_multi_write cs40l26_irq_clear[] = {
 	{.addr = CS40L26_REG_IRQ1_EINT_1,
@@ -246,6 +261,42 @@ static int cs40l26_reset_mailbox(const struct device *const dev)
 	}
 
 	return cs40l26_firmware_write(dev, CS40L26_REG_MAILBOX_QUEUE_RD, mbox_ptr);
+}
+
+static int cs40l26_get_trigger_gpio(const struct device *const dev,
+				    const struct gpio_dt_spec *const gpio, uint8_t *const index)
+{
+	const struct cs40l26_config *const config = dev->config;
+	uint8_t i;
+
+	if (gpio == NULL) {
+		return -EINVAL;
+	}
+
+	for (i = 0; i < config->num_triggers; i++) {
+		if (gpio->port == config->trigger_gpios[i].port &&
+		    gpio->pin == config->trigger_gpios[i].pin) {
+			*index = config->trigger_mapping[i];
+			return 0;
+		}
+	}
+
+	return -EINVAL;
+}
+
+static int cs40l26_trigger_config(const struct device *const dev)
+{
+	const struct cs40l26_config *const config = dev->config;
+	int ret;
+
+	for (int i = 0; i < config->num_triggers; i++) {
+		ret = gpio_pin_configure_dt(&config->trigger_gpios[i], GPIO_OUTPUT);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	return 0;
 }
 
 static void cs40l26_error_callback(const struct device *const dev, const uint32_t error_bitmask)
@@ -899,6 +950,14 @@ static int cs40l26_bringup(const struct device *const dev)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_HAPTICS_CS40L26_TRIGGER) && config->trigger_gpios != NULL) {
+		ret = cs40l26_trigger_config(dev);
+		if (ret < 0) {
+			LOG_INST_DBG(config->log, "failed trigger configuration (%d)", ret);
+			return ret;
+		}
+	}
+
 	return cs40l26_dsp_config(dev);
 }
 
@@ -1038,6 +1097,68 @@ int cs40l26_configure_buzz(const struct device *const dev, const uint32_t freque
 	ret = cs40l26_firmware_write(dev, CS40L26_REG_BUZZ_DURATION, duration);
 
 error_mutex:
+	(void)k_mutex_unlock(&data->lock);
+
+error_pm:
+	(void)pm_device_runtime_put(dev);
+
+	return ret;
+}
+
+int cs40l26_configure_trigger(const struct device *const dev, const struct gpio_dt_spec *const gpio,
+			      const enum haptics_source src, const union haptics_config *const cfg,
+			      const int8_t attenuation, const enum cs40l26_trigger_edge edge)
+{
+	const struct cs40l26_config *const config = dev->config;
+	struct cs40l26_data *const data = dev->data;
+	uint8_t i, offset;
+	uint32_t playback;
+	int ret;
+
+	if (!IS_ENABLED(CONFIG_HAPTICS_CS40L26_TRIGGER) || config->trigger_gpios == NULL) {
+		LOG_INST_DBG(config->log, "no trigger GPIOs provided (%d)", -EINVAL);
+		return -EINVAL;
+	}
+
+	if (!cs40l26_valid_wavetable_source(dev, src, cfg)) {
+		LOG_INST_ERR(config->log, "invalid wavetable selection (%d)", -EINVAL);
+		return -EINVAL;
+	}
+
+	ret = cs40l26_get_trigger_gpio(dev, gpio, &i);
+	if (ret < 0) {
+		LOG_INST_ERR(config->log, "failed to retrieve trigger GPIO (%d)", ret);
+		return ret;
+	}
+
+	offset = cs40l26_trigger_offsets[i] + ((edge == CS40L26_FALLING_EDGE) ? 4 : 0);
+
+	playback = FIELD_PREP(CS40L26_MASK_ATTENUATION, abs(attenuation)) | cfg->idx;
+
+	switch ((int)src) {
+	case HAPTICS_SOURCE_ROM:
+		break;
+	case CS40L26_SOURCE_BUZ:
+		playback |= CS40L5X_MASK_BUZ_BANK;
+		break;
+	default:
+		LOG_INST_DBG(config->log, "invalid source for trigger effects (%d)", -EINVAL);
+		return -EINVAL;
+	}
+
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = k_mutex_lock(&data->lock, CS40L26_T_WAIT);
+	if (ret < 0) {
+		LOG_INST_DBG(config->log, "timed out waiting for lock (%d)", ret);
+		goto error_pm;
+	}
+
+	ret = cs40l26_firmware_write_offset(dev, CS40L26_REG_GPIO_EVENT_BASE, playback, offset);
+
 	(void)k_mutex_unlock(&data->lock);
 
 error_pm:
@@ -1375,6 +1496,18 @@ __maybe_unused static int cs40l26_deinit(const struct device *dev)
 							 .error_callback = NULL,                   \
 							 .output = CS40L26_ROM_BANK_CMD}
 
+#define HAPTICS_CS40L26_GET_GPIO(inst, prop, idx) GPIO_DT_SPEC_GET_BY_IDX(inst, prop, idx),
+
+#define HAPTICS_CS40L26_TRIGGER_GPIOS(inst)                                                        \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, trigger_gpios),					   \
+		((struct gpio_dt_spec[]){DT_INST_FOREACH_PROP_ELEM(inst, trigger_gpios,		   \
+								       HAPTICS_CS40L26_GET_GPIO)}),\
+		    (NULL))
+
+#define HAPTICS_CS40L26_TRIGGER_MAPPING(inst)                                                      \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, trigger_mapping),				   \
+		    ((int[])DT_INST_PROP(inst, trigger_mapping)), (NULL))
+
 #define HAPTICS_CS40L26_BUS(inst)                                                                  \
 	COND_CODE_1(DT_INST_ON_BUS(inst, i2c),	\
 		(.io_bus.bus.i2c = I2C_DT_SPEC_INST_GET(inst), .io_bus.io = &cs40lxx_io_i2c,),	   \
@@ -1403,6 +1536,9 @@ __maybe_unused static int cs40l26_deinit(const struct device *dev)
 		.dev_id = id,                                                                      \
 		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {0}),                    \
 		.interrupt_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, {0}),                  \
+		.trigger_gpios = HAPTICS_CS40L26_TRIGGER_GPIOS(inst),                              \
+		.trigger_mapping = HAPTICS_CS40L26_TRIGGER_MAPPING(inst),                          \
+		.num_triggers = DT_INST_PROP_LEN_OR(inst, trigger_gpios, 0),                       \
 		LOG_INSTANCE_PTR_INIT(log, DT_NODE_FULL_NAME_TOKEN(DT_DRV_INST(inst)), inst)       \
 			HAPTICS_CS40L26_BUS(inst) HAPTICS_CS40L26_FLASH(inst)}
 

--- a/drivers/haptics/cirrus/cs40l26.h
+++ b/drivers/haptics/cirrus/cs40l26.h
@@ -49,6 +49,7 @@ extern "C" {
 #define CS40L26_REG_MAILBOX_QUEUE_RD            18
 #define CS40L26_REG_MAILBOX_STATUS              19
 #define CS40L26_REG_SOURCE_ATTENUATION          20
+#define CS40L26_REG_GPIO_EVENT_BASE             21
 
 struct cs40l26_calibration {
 	/* Coil DC resistance in signed Q6.17 format (Ohms * (24 / 2.9)) */
@@ -65,6 +66,9 @@ struct cs40l26_config {
 	const struct cs40lxx_io_bus io_bus;
 	const struct gpio_dt_spec reset_gpio;
 	const struct gpio_dt_spec interrupt_gpio;
+	const struct gpio_dt_spec *const trigger_gpios;
+	const int *const trigger_mapping;
+	const uint8_t num_triggers;
 	const struct device *flash;
 	const off_t flash_offset;
 };
@@ -86,6 +90,8 @@ int cs40l26_firmware_read(const struct device *const dev, const uint32_t firmwar
 			  uint32_t *const rx);
 int cs40l26_firmware_write(const struct device *const dev, const uint32_t firmware_control,
 			   uint32_t val);
+int cs40l26_firmware_write_offset(const struct device *const dev, const uint32_t firmware_control,
+				  uint32_t val, const off_t offset);
 int cs40l26_firmware_burst_write(const struct device *const dev, const uint32_t firmware_control,
 				 uint32_t *const tx, const uint32_t len);
 int cs40l26_firmware_raw_write(const struct device *const dev, const uint32_t firmware_control,

--- a/drivers/haptics/cirrus/cs40l5x.c
+++ b/drivers/haptics/cirrus/cs40l5x.c
@@ -214,6 +214,23 @@ enum cs40l5x_irq {
 	CS40L5X_INT22,
 };
 
+enum cs40l5x_gpios {
+	CS40L5X_GPIO3 = 3,
+	CS40L5X_GPIO4,
+	CS40L5X_GPIO5,
+	CS40L5X_GPIO6,
+	CS40L5X_GPIO10 = 10,
+	CS40L5X_GPIO11,
+	CS40L5X_GPIO12,
+	CS40L5X_GPIO13,
+};
+
+static const uint8_t cs40l5x_trigger_offsets[] = {
+	[CS40L5X_GPIO3] = 0x00,  [CS40L5X_GPIO4] = 0x08,  [CS40L5X_GPIO5] = 0x10,
+	[CS40L5X_GPIO6] = 0x18,  [CS40L5X_GPIO10] = 0x20, [CS40L5X_GPIO11] = 0x28,
+	[CS40L5X_GPIO12] = 0x30, [CS40L5X_GPIO13] = 0x38,
+};
+
 static const struct cs40lxx_multi_write cs40l5x_b0_internal_boost[] = {
 	{.addr = 0x00002018U, CS40LXX_MULTI_WRITE_BE32(0x00003321U, 0x04000010U)},
 };
@@ -429,41 +446,33 @@ static int cs40l5x_get_trigger_gpio(const struct device *const dev,
 				    const struct gpio_dt_spec *const gpio, uint8_t *const index)
 {
 	const struct cs40l5x_config *const config = dev->config;
-	const struct cs40l5x_trigger_gpios *const gpios = &config->trigger_gpios;
+	uint8_t i;
 
 	if (gpio == NULL) {
 		return -EINVAL;
 	}
 
-	for (*index = 0; *index < gpios->num_gpio; (*index)++) {
-		if ((gpio->pin == gpios->gpio[*index].pin) &&
-		    (strcmp(gpio->port->name, gpios->gpio[*index].port->name) == 0)) {
-			break;
+	for (i = 0; i < config->num_triggers; i++) {
+		if (gpio->port == config->trigger_gpios[i].port &&
+		    gpio->pin == config->trigger_gpios[i].pin) {
+			*index = config->trigger_mapping[i];
+			return 0;
 		}
 	}
 
-	if (*index == gpios->num_gpio) {
-		return -EINVAL;
-	}
-
-	return 0;
+	return -EINVAL;
 }
 
 static int cs40l5x_trigger_config(const struct device *const dev)
 {
 	const struct cs40l5x_config *const config = dev->config;
-	const struct cs40l5x_trigger_gpios *const gpios = &config->trigger_gpios;
 	int ret;
 
-	for (int i = 0; i < gpios->num_gpio; i++) {
-		ret = gpio_pin_configure_dt(&gpios->gpio[i], GPIO_OUTPUT);
+	for (int i = 0; i < config->num_triggers; i++) {
+		ret = gpio_pin_configure_dt(&config->trigger_gpios[i], GPIO_OUTPUT);
 		if (ret < 0) {
-			LOG_INST_DBG(config->log, "skipped %s (%d)", gpios->gpio[i].port->name,
-				     ret);
-			continue;
+			return ret;
 		}
-
-		gpios->ready[i] = true;
 	}
 
 	return 0;
@@ -1152,7 +1161,7 @@ static int cs40l5x_bringup(const struct device *const dev)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_HAPTICS_CS40L5X_TRIGGER) && config->trigger_gpios.num_gpio > 0) {
+	if (IS_ENABLED(CONFIG_HAPTICS_CS40L5X_TRIGGER) && config->trigger_gpios != NULL) {
 		ret = cs40l5x_trigger_config(dev);
 		if (ret < 0) {
 			LOG_INST_DBG(config->log, "failed trigger configuration (%d)", ret);
@@ -1395,23 +1404,21 @@ error_pm:
 }
 
 int cs40l5x_configure_trigger(const struct device *const dev, const struct gpio_dt_spec *const gpio,
-			      const enum cs40l5x_bank bank, const uint8_t index,
-			      const enum cs40l5x_attenuation attenuation,
-			      const enum cs40l5x_trigger_edge edge)
+			      const enum haptics_source src, const union haptics_config *const cfg,
+			      const int8_t attenuation, const enum cs40l5x_trigger_edge edge)
 {
 	const struct cs40l5x_config *const config = dev->config;
-	const struct cs40l5x_trigger_gpios *const gpios = &config->trigger_gpios;
 	struct cs40l5x_data *const data = dev->data;
-	uint8_t *address, i;
+	uint8_t i, offset;
 	uint32_t playback;
 	int ret;
 
-	if (!IS_ENABLED(CONFIG_HAPTICS_CS40L5X_TRIGGER) || gpios->num_gpio == 0) {
+	if (!IS_ENABLED(CONFIG_HAPTICS_CS40L5X_TRIGGER) || config->trigger_gpios == NULL) {
 		LOG_INST_DBG(config->log, "no trigger GPIOs provided (%d)", -EINVAL);
 		return -EINVAL;
 	}
 
-	if (!cs40l5x_valid_wavetable_source(dev, bank, index)) {
+	if (!cs40l5x_valid_wavetable_source(dev, src, cfg)) {
 		LOG_INST_ERR(config->log, "invalid wavetable selection (%d)", -EINVAL);
 		return -EINVAL;
 	}
@@ -1422,13 +1429,18 @@ int cs40l5x_configure_trigger(const struct device *const dev, const struct gpio_
 		return ret;
 	}
 
-	playback = FIELD_PREP(CS40L5X_MASK_ATTENUATION, abs(attenuation)) | index;
+	offset = cs40l5x_trigger_offsets[i] + ((edge == CS40L5X_FALLING_EDGE) ? 4 : 0);
 
-	switch (bank) {
-	case CS40L5X_ROM_BANK:
+	playback = FIELD_PREP(CS40L5X_MASK_ATTENUATION, abs(attenuation)) | cfg->idx;
+
+	switch ((int)src) {
+	case HAPTICS_SOURCE_ROM:
 		break;
-	case CS40L5X_CUSTOM_BANK:
-		playback |= CS40L5X_MASK_CUSTOM_PLAYBACK;
+	case CS40L5X_SOURCE_BUZ:
+		playback |= CS40L5X_MASK_BUZ_BANK;
+		break;
+	case CS40L5X_SOURCE_RTH:
+		playback |= CS40L5X_MASK_RTH_PLAYBACK;
 		break;
 	default:
 		LOG_INST_ERR(config->log, "invalid source for trigger effects (%d)", -EINVAL);
@@ -1446,10 +1458,7 @@ int cs40l5x_configure_trigger(const struct device *const dev, const struct gpio_
 		goto error_pm;
 	}
 
-	address = (edge == CS40L5X_RISING_EDGE) ? gpios->rising_edge : gpios->falling_edge;
-
-	ret = cs40lxx_write(&config->io_bus, CS40L5X_REG_GPIO_EVENT_BASE | (uint32_t)address[i],
-			    playback);
+	ret = cs40lxx_write(&config->io_bus, CS40L5X_REG_GPIO_EVENT_BASE + offset, playback);
 
 	(void)k_mutex_unlock(&data->lock);
 
@@ -2088,10 +2097,10 @@ static int cs40l5x_init(const struct device *dev)
 	}
 
 	if (IS_ENABLED(CONFIG_HAPTICS_CS40L5X_TRIGGER)) {
-		for (int i = 0; i < config->trigger_gpios.num_gpio; i++) {
-			if (!gpio_is_ready_dt(&config->trigger_gpios.gpio[i])) {
+		for (int i = 0; i < config->num_triggers; i++) {
+			if (!gpio_is_ready_dt(&config->trigger_gpios[i])) {
 				LOG_INST_DBG(config->log, "trigger GPIO is not ready (%s)",
-					     config->trigger_gpios.gpio[i].port->name);
+					     config->trigger_gpios[i].port->name);
 			}
 		}
 	}
@@ -2130,68 +2139,23 @@ __maybe_unused static int cs40l5x_deinit(const struct device *dev)
 	.dev = DEVICE_DT_INST_GET(inst), .error_callback = NULL, .output = CS40L5X_ROM_BANK_CMD,   \
 	.custom_effects = {false, false}, .calibration = {.f0 = 0, .redc = 0},
 
-#define HAPTICS_CS40L5X_FALLING_DEFAULT(inst, prop, idx)                                           \
-	COND_CODE_1(IS_EQ(3, DT_PROP_BY_IDX(inst, prop, idx)), (0x38,),	(EMPTY))		   \
-	COND_CODE_1(IS_EQ(4, DT_PROP_BY_IDX(inst, prop, idx)), (0x40,),	(EMPTY))		   \
-	COND_CODE_1(IS_EQ(5, DT_PROP_BY_IDX(inst, prop, idx)), (0x48,),	(EMPTY))		   \
-	COND_CODE_1(IS_EQ(6, DT_PROP_BY_IDX(inst, prop, idx)), (0x50,),	(EMPTY))		   \
-	COND_CODE_1(IS_EQ(10, DT_PROP_BY_IDX(inst, prop, idx)),	(0x58,), (EMPTY))		   \
-	COND_CODE_1(IS_EQ(11, DT_PROP_BY_IDX(inst, prop, idx)),	(0x60,), (EMPTY))		   \
-	COND_CODE_1(IS_EQ(12, DT_PROP_BY_IDX(inst, prop, idx)),	(0x68,), (EMPTY))		   \
-	COND_CODE_1(IS_EQ(13, DT_PROP_BY_IDX(inst, prop, idx)), (0x70,), (EMPTY))
-
-#define HAPTICS_CS40L5X_RISING_DEFAULT(inst, prop, idx)                                            \
-	COND_CODE_1(IS_EQ(3, DT_PROP_BY_IDX(inst, prop, idx)), (0x3C,), (EMPTY))		   \
-	COND_CODE_1(IS_EQ(4, DT_PROP_BY_IDX(inst, prop, idx)), (0x44,),	(EMPTY))		   \
-	COND_CODE_1(IS_EQ(5, DT_PROP_BY_IDX(inst, prop, idx)), (0x4C,),	(EMPTY))		   \
-	COND_CODE_1(IS_EQ(6, DT_PROP_BY_IDX(inst, prop, idx)), (0x54,),	(EMPTY))		   \
-	COND_CODE_1(IS_EQ(10, DT_PROP_BY_IDX(inst, prop, idx)),	(0x5C,), (EMPTY))		   \
-	COND_CODE_1(IS_EQ(11, DT_PROP_BY_IDX(inst, prop, idx)),	(0x64,), (EMPTY))		   \
-	COND_CODE_1(IS_EQ(12, DT_PROP_BY_IDX(inst, prop, idx)),	(0x6C,), (EMPTY))		   \
-	COND_CODE_1(IS_EQ(13, DT_PROP_BY_IDX(inst, prop, idx)),	(0x74,), (EMPTY))
-
-#define HAPTICS_CS40L5X_FALLING_DEFAULTS(inst)                                                     \
-	(uint8_t[DT_INST_PROP_LEN(inst, trigger_mapping)])                                         \
-	{                                                                                          \
-		DT_INST_FOREACH_PROP_ELEM(inst, trigger_mapping, HAPTICS_CS40L5X_FALLING_DEFAULT)  \
-	}
-
-#define HAPTICS_CS40L5X_RISING_DEFAULTS(inst)                                                      \
-	(uint8_t[DT_INST_PROP_LEN(inst, trigger_mapping)])                                         \
-	{                                                                                          \
-		DT_INST_FOREACH_PROP_ELEM(inst, trigger_mapping, HAPTICS_CS40L5X_RISING_DEFAULT)   \
-	}
-
-#define HAPTICS_CS40L5X_TRIGGER_GPIO_(inst, prop, idx)                                             \
-	GPIO_DT_SPEC_GET_BY_IDX(inst, trigger_gpios, idx),
-
-#define HAPTICS_CS40L5X_TRIGGER_GPIO(inst)                                                         \
-	(struct gpio_dt_spec[])                                                                    \
-	{                                                                                          \
-		DT_INST_FOREACH_PROP_ELEM(inst, trigger_gpios, HAPTICS_CS40L5X_TRIGGER_GPIO_)      \
-	}
+#define HAPTICS_CS40L5X_GET_GPIO(inst, prop, idx) GPIO_DT_SPEC_GET_BY_IDX(inst, prop, idx),
 
 #define HAPTICS_CS40L5X_TRIGGER_GPIOS(inst)                                                        \
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, trigger_gpios),					   \
-		(.trigger_gpios = {								   \
-			.gpio = HAPTICS_CS40L5X_TRIGGER_GPIO(inst),				   \
-			.num_gpio = DT_INST_PROP_LEN(inst, trigger_gpios),			   \
-			.rising_edge = HAPTICS_CS40L5X_RISING_DEFAULTS(inst),			   \
-			.falling_edge = HAPTICS_CS40L5X_FALLING_DEFAULTS(inst),			   \
-			.ready = (bool[DT_INST_PROP_LEN(inst, trigger_gpios)]) {0}},),		   \
-		(.trigger_gpios = {								   \
-			.gpio = NULL,								   \
-			.num_gpio = 0,								   \
-			.rising_edge = NULL,							   \
-			.falling_edge = NULL,							   \
-			.ready = NULL},)							   \
-	)
+		((struct gpio_dt_spec[]){DT_INST_FOREACH_PROP_ELEM(inst, trigger_gpios,		   \
+								       HAPTICS_CS40L5X_GET_GPIO)}),\
+		    (NULL))
+
+#define HAPTICS_CS40L5X_TRIGGER_MAPPING(inst)                                                      \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, trigger_mapping),				   \
+		    ((int[])DT_INST_PROP(inst, trigger_mapping)), (NULL))
 
 #define HAPTICS_CS40L5X_FLASH_DEVICE(inst)                                                         \
 	DEVICE_DT_GET_OR_NULL(DT_MTD_FROM_PARTITION(DT_INST_PHANDLE(inst, flash_storage)))
 
 #define HAPTICS_CS40L5X_FLASH_OFFSET(inst)                                                         \
-	PARTITION_NODE_OFFSET(DT_INST_PHANDLE(inst, flash_storage)) +                        \
+	PARTITION_NODE_OFFSET(DT_INST_PHANDLE(inst, flash_storage)) +                              \
 		DT_INST_PROP_OR(inst, flash_offset, 0)
 
 #define HAPTICS_CS40L5X_FLASH(inst)                                                                \
@@ -2213,10 +2177,12 @@ __maybe_unused static int cs40l5x_deinit(const struct device *dev)
 	.dev = DEVICE_DT_INST_GET(inst), .dev_id = id,                                             \
 	.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {0}),                            \
 	.interrupt_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, {0}),                          \
+	.trigger_gpios = HAPTICS_CS40L5X_TRIGGER_GPIOS(inst),                                      \
+	.trigger_mapping = HAPTICS_CS40L5X_TRIGGER_MAPPING(inst),                                  \
+	.num_triggers = DT_INST_PROP_LEN_OR(inst, trigger_gpios, 0),                               \
 	.external_boost = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, external_boost)),            \
 	LOG_INSTANCE_PTR_INIT(log, DT_NODE_FULL_NAME_TOKEN(DT_DRV_INST(inst)), inst)               \
-		HAPTICS_CS40L5X_BUS(inst) HAPTICS_CS40L5X_TRIGGER_GPIOS(inst)                      \
-			HAPTICS_CS40L5X_FLASH(inst)
+		HAPTICS_CS40L5X_BUS(inst) HAPTICS_CS40L5X_FLASH(inst)
 
 #define HAPTICS_CS40L5X_INIT(inst, name)                                                           \
 	PM_DEVICE_DT_INST_DEFINE(inst, cs40l5x_pm_action);                                         \

--- a/drivers/haptics/cirrus/cs40l5x.h
+++ b/drivers/haptics/cirrus/cs40l5x.h
@@ -20,15 +20,6 @@ struct cs40l5x_calibration {
 	uint32_t f0;
 };
 
-struct cs40l5x_trigger_gpios {
-	struct gpio_dt_spec *gpio;
-	const uint8_t num_gpio;
-	bool *ready;
-	/* Addresses for rising- and falling-edge events */
-	uint8_t *rising_edge;
-	uint8_t *falling_edge;
-};
-
 struct cs40l5x_config {
 	LOG_INSTANCE_PTR_DECLARE(log);
 	/* Log instance declaration requires blank line. */
@@ -37,7 +28,9 @@ struct cs40l5x_config {
 	const struct cs40lxx_io_bus io_bus;
 	struct gpio_dt_spec reset_gpio;
 	struct gpio_dt_spec interrupt_gpio;
-	struct cs40l5x_trigger_gpios trigger_gpios;
+	const struct gpio_dt_spec *const trigger_gpios;
+	const int *const trigger_mapping;
+	const uint8_t num_triggers;
 	const struct device *flash;
 	const off_t flash_offset;
 	const struct device *const external_boost;

--- a/dts/bindings/haptics/cirrus,cs40l26-base.yaml
+++ b/dts/bindings/haptics/cirrus,cs40l26-base.yaml
@@ -12,6 +12,15 @@ properties:
     type: phandle-array
     description: Input pin mapped to CS40L26/27 interrupt pin.
 
+  trigger-gpios:
+    type: phandle-array
+    description: Host GPIOs used to trigger haptic effects.
+
+  trigger-mapping:
+    type: array
+    description: For each host GPIO provided to 'trigger-gpios',
+      provide the corresponding CS40L26/27 GPIO pin number.
+
   flash-storage:
     type: phandle
     description: Flash storage for CS40L26 data. Must be a phandle to

--- a/include/zephyr/drivers/haptics/cs40l26.h
+++ b/include/zephyr/drivers/haptics/cs40l26.h
@@ -6,6 +6,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_HAPTICS_CS40L26_H_
 #define ZEPHYR_INCLUDE_DRIVERS_HAPTICS_CS40L26_H_
 
+#include <zephyr/drivers/haptics.h>
 #include <zephyr/kernel.h>
 
 #ifdef __cplusplus
@@ -27,6 +28,15 @@ enum cs40l26_bank {
 	CS40L26_ROM_BANK, /**< Playback from the pre-programmed ROM library */
 	CS40L26_BUZ_BANK, /**< Playback from buzz source programmed at runtime */
 	CS40L26_NO_BANK,  /**< Reserved for driver error handling */
+};
+
+/**
+ * @brief Options for edge-triggered haptics effects
+ * @details Provide to @ref cs40l26_configure_trigger() to specify the edge for haptic effects.
+ */
+enum cs40l26_trigger_edge {
+	CS40L26_RISING_EDGE,  /**< Configure a rising-edge haptic effect */
+	CS40L26_FALLING_EDGE, /**< Configure a falling-edge haptic effect */
 };
 
 /**
@@ -54,6 +64,24 @@ int cs40l26_calibrate(const struct device *const dev);
  */
 int cs40l26_configure_buzz(const struct device *const dev, const uint32_t frequency,
 			   const uint8_t level, const uint32_t duration);
+
+/**
+ * @brief Configure edge-triggered haptic effect
+ *
+ * @param[in] dev Pointer to the device structure for haptic device instance
+ * @param[in] gpio Pointer to the device structure for the GPIO used as the trigger source
+ * @param[in] src Playback source (of type @ref haptics_source)
+ * @param[in] cfg Source configuration (of type @ref haptics_config) or NULL
+ * @param[in] attenuation Attenuation in dB for desired haptic effect (range 0 to 7)
+ * @param[in] edge Specify edge (rising or falling) to trigger haptic effects
+ *
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL Invalid wavetable source and index provided (e.g., index out of bounds).
+ * @retval -EIO A control port transaction failed.
+ */
+int cs40l26_configure_trigger(const struct device *const dev, const struct gpio_dt_spec *const gpio,
+			      const enum haptics_source src, const union haptics_config *const cfg,
+			      const int8_t attenuation, const enum cs40l26_trigger_edge edge);
 
 /**
  * @brief Select haptic effect triggered via @ref haptics_start_output()

--- a/include/zephyr/drivers/haptics/cs40l5x.h
+++ b/include/zephyr/drivers/haptics/cs40l5x.h
@@ -32,21 +32,6 @@ extern "C" {
  */
 
 /**
- * @brief Attenuation options for triggered haptic effects
- * @details Provide to @ref cs40l5x_configure_trigger().
- */
-enum cs40l5x_attenuation {
-	CS40L5X_ATTENUATION_7DB = -7, /**< Configure haptic effect with 7 dB attenuation */
-	CS40L5X_ATTENUATION_6DB,      /**< Configure haptic effect with 6 dB attenuation */
-	CS40L5X_ATTENUATION_5DB,      /**< Configure haptic effect with 5 dB attenuation */
-	CS40L5X_ATTENUATION_4DB,      /**< Configure haptic effect with 4 dB attenuation */
-	CS40L5X_ATTENUATION_3DB,      /**< Configure haptic effect with 3 dB attenuation */
-	CS40L5X_ATTENUATION_2DB,      /**< Configure haptic effect with 2 dB attenuation */
-	CS40L5X_ATTENUATION_1DB,      /**< Configure haptic effect with 1 dB attenuation */
-	CS40L5X_ATTENUATION_0DB,      /**< Configure haptic effect with no attenuation */
-};
-
-/**
  * @brief Wavetable sources for haptic effects
  * @details Provide to @ref cs40l5x_configure_trigger() or @ref cs40l5x_select_output().
  */
@@ -154,9 +139,9 @@ int cs40l5x_configure_buzz(const struct device *const dev, const uint32_t freque
  *
  * @param[in] dev Pointer to the device structure for haptic device instance
  * @param[in] gpio Pointer to the device structure for the GPIO used as the trigger source
- * @param[in] bank Wavetable source for desired haptic effect, see @ref cs40l5x_bank
- * @param[in] index Wavetable index for desired haptic effect
- * @param[in] attenuation Attenuation in dB for desired haptic effect, see @ref cs40l5x_attenuation
+ * @param[in] src Playback source (of type @ref haptics_source)
+ * @param[in] cfg Source configuration (of type @ref haptics_config) or NULL
+ * @param[in] attenuation Attenuation in dB for desired haptic effect (range 0 to 7)
  * @param[in] edge Specify edge (rising or falling) to trigger haptic effects
  *
  * @return 0 on success, negative errno value on failure.
@@ -164,9 +149,8 @@ int cs40l5x_configure_buzz(const struct device *const dev, const uint32_t freque
  * @retval -EIO A control port transaction failed.
  */
 int cs40l5x_configure_trigger(const struct device *const dev, const struct gpio_dt_spec *const gpio,
-			      const enum cs40l5x_bank bank, const uint8_t index,
-			      const enum cs40l5x_attenuation attenuation,
-			      const enum cs40l5x_trigger_edge edge);
+			      const enum haptics_source src, const union haptics_config *const cfg,
+			      const int8_t attenuation, const enum cs40l5x_trigger_edge edge);
 
 /**
  * @brief Enable or disable runtime haptics logging


### PR DESCRIPTION
Simplifies the trigger implementation for CS40L5x and ports the changes to the CS40L26/27 driver to add trigger gpio support.

Depends on #113169 and #113176.