### PR TITLE
lib/sys: add sys prefix to word granular access functions

### DIFF
--- a/arch/xtensa/core/instr_mem.c
+++ b/arch/xtensa/core/instr_mem.c
@@ -12,7 +12,7 @@ void *arch_memset_instr(void *buf, int c, size_t n)
 #ifndef CONFIG_ARCH_HAS_WORD_GRANULAR_ACCESS_INSTR_MEM
 	return memset(buf, c, n);
 #else
-	return memset_word_granular_access(buf, c, n);
+	return sys_memset_word_granular_access(buf, c, n);
 #endif
 }
 
@@ -21,7 +21,7 @@ void *arch_memcpy_to_instr(void *d, const void *s, size_t n)
 #ifndef CONFIG_ARCH_HAS_WORD_GRANULAR_ACCESS_INSTR_MEM
 	return memcpy(d, s, n);
 #else
-	return memcpy_to_word_granular_access(d, s, n);
+	return sys_memcpy_to_word_granular_access(d, s, n);
 #endif
 }
 
@@ -30,6 +30,6 @@ void *arch_memcpy_from_instr(void *d, const void *s, size_t n)
 #ifndef CONFIG_ARCH_HAS_WORD_GRANULAR_ACCESS_INSTR_MEM
 	return memcpy(d, s, n);
 #else
-	return memcpy_from_word_granular_access(d, s, n);
+	return sys_memcpy_from_word_granular_access(d, s, n);
 #endif
 }

--- a/include/zephyr/sys/word_granular_access.h
+++ b/include/zephyr/sys/word_granular_access.h
@@ -26,21 +26,21 @@ extern "C" {
  * @cond INTERNAL_HIDDEN
  */
 
-#ifndef __mem_word_t_defined
-#define __mem_word_t_defined
+#ifndef __sys_mem_word_t_defined
+#define __sys_mem_word_t_defined
 
 /**
- * @typedef mem_word_t
+ * @typedef sys_mem_word_t
  *
  * @brief Access type for word granular access memory.
  *
  * Should match the optimal memory access word width
  * on the target platform. Here we default it to uintptr_t.
  */
-typedef uintptr_t __attribute__((may_alias)) mem_word_t;
+typedef uintptr_t __attribute__((may_alias)) sys_mem_word_t;
 
 #define Z_MEM_WORD_T_WIDTH __INTPTR_WIDTH__
-#endif /* __mem_word_t_defined */
+#endif /* __sys_mem_word_t_defined */
 
 BUILD_ASSERT(Z_MEM_WORD_T_WIDTH == 32, "Unsupported word width for access to "
 				       "word granular access memory");
@@ -63,7 +63,7 @@ BUILD_ASSERT(Z_MEM_WORD_T_WIDTH == 32, "Unsupported word width for access to "
  * @param n Number of bytes to set
  * @returns the provided buffer pointer, or `NULL` on error
  */
-void *memset_word_granular_access(void *buf, int c, size_t n);
+void *sys_memset_word_granular_access(void *buf, int c, size_t n);
 
 /**
  * @brief Memcpy buffer into word granular access memory
@@ -80,7 +80,7 @@ void *memset_word_granular_access(void *buf, int c, size_t n);
  * @param n Number of bytes to copy
  * @returns the provided destination buffer pointer, or `NULL` on error
  */
-void *memcpy_to_word_granular_access(void *d, const void *s, size_t n);
+void *sys_memcpy_to_word_granular_access(void *d, const void *s, size_t n);
 
 /**
  * @brief Memcpy buffer out of word granular access memory
@@ -97,7 +97,7 @@ void *memcpy_to_word_granular_access(void *d, const void *s, size_t n);
  * @param n Number of bytes to copy
  * @returns the provided destination buffer pointer, or `NULL` on error
  */
-void *memcpy_from_word_granular_access(void *d, const void *s, size_t n);
+void *sys_memcpy_from_word_granular_access(void *d, const void *s, size_t n);
 
 /** @} */
 

--- a/lib/libc/minimal/source/string/string.c
+++ b/lib/libc/minimal/source/string/string.c
@@ -10,15 +10,15 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#if !defined(__mem_word_t_defined)
-#define __mem_word_t_defined
+#if !defined(__sys_mem_word_t_defined)
+#define __sys_mem_word_t_defined
 
 /*
- * The mem_word_t should match the optimal memory access word width
+ * The sys_mem_word_t should match the optimal memory access word width
  * on the target platform. Here we default it to uintptr_t.
  */
 
-typedef uintptr_t mem_word_t;
+typedef uintptr_t sys_mem_word_t;
 
 #define Z_MEM_WORD_T_WIDTH __INTPTR_WIDTH__
 
@@ -298,7 +298,7 @@ void *memcpy(void *ZRESTRICT d, const void *ZRESTRICT s, size_t n)
 	const unsigned char *s_byte = (const unsigned char *)s;
 
 #if !defined(CONFIG_MINIMAL_LIBC_OPTIMIZE_STRING_FOR_SIZE)
-	const uintptr_t mask = sizeof(mem_word_t) - 1;
+	const uintptr_t mask = sizeof(sys_mem_word_t) - 1;
 
 	if ((((uintptr_t)d ^ (uintptr_t)s_byte) & mask) == 0) {
 
@@ -314,12 +314,12 @@ void *memcpy(void *ZRESTRICT d, const void *ZRESTRICT s, size_t n)
 
 		/* do word-sized copying as long as possible */
 
-		mem_word_t *d_word = (mem_word_t *)d_byte;
-		const mem_word_t *s_word = (const mem_word_t *)s_byte;
+		sys_mem_word_t *d_word = (sys_mem_word_t *)d_byte;
+		const sys_mem_word_t *s_word = (const sys_mem_word_t *)s_byte;
 
-		while (n >= sizeof(mem_word_t)) {
+		while (n >= sizeof(sys_mem_word_t)) {
 			*(d_word++) = *(s_word++);
-			n -= sizeof(mem_word_t);
+			n -= sizeof(sys_mem_word_t);
 		}
 
 		d_byte = (unsigned char *)d_word;
@@ -352,7 +352,7 @@ void *memset(void *buf, int c, size_t n)
 	unsigned char c_byte = (unsigned char)c;
 
 #if !defined(CONFIG_MINIMAL_LIBC_OPTIMIZE_STRING_FOR_SIZE)
-	while (((uintptr_t)d_byte) & (sizeof(mem_word_t) - 1)) {
+	while (((uintptr_t)d_byte) & (sizeof(sys_mem_word_t) - 1)) {
 		if (n == 0) {
 			return buf;
 		}
@@ -362,8 +362,8 @@ void *memset(void *buf, int c, size_t n)
 
 	/* do word-sized initialization as long as possible */
 
-	mem_word_t *d_word = (mem_word_t *)d_byte;
-	mem_word_t c_word = (mem_word_t)c_byte;
+	sys_mem_word_t *d_word = (sys_mem_word_t *)d_byte;
+	sys_mem_word_t c_word = (sys_mem_word_t)c_byte;
 
 	c_word |= c_word << 8;
 	c_word |= c_word << 16;
@@ -371,9 +371,9 @@ void *memset(void *buf, int c, size_t n)
 	c_word |= c_word << 32;
 #endif
 
-	while (n >= sizeof(mem_word_t)) {
+	while (n >= sizeof(sys_mem_word_t)) {
 		*(d_word++) = c_word;
-		n -= sizeof(mem_word_t);
+		n -= sizeof(sys_mem_word_t);
 	}
 
 	/* do byte-sized initialization until finished */

--- a/lib/word_granular_access/word_granular_access_string.c
+++ b/lib/word_granular_access/word_granular_access_string.c
@@ -10,29 +10,29 @@
 static inline void copy_byte_to_word_granular_access(unsigned char *dst, const unsigned char *src)
 {
 	/* Mask off the lower bits to get an aligned pointer */
-	const mem_word_t mask = sizeof(mem_word_t) - 1;
-	mem_word_t d_aligned = (mem_word_t)dst & ~mask;
-	unsigned int d_offset = (mem_word_t)dst & mask;
+	const sys_mem_word_t mask = sizeof(sys_mem_word_t) - 1;
+	sys_mem_word_t d_aligned = (sys_mem_word_t)dst & ~mask;
+	unsigned int d_offset = (sys_mem_word_t)dst & mask;
 
 	/* Clear byte at destination and insert byte from source */
-	mem_word_t d_word = *(mem_word_t *)d_aligned;
-	mem_word_t byte_mask = ~((mem_word_t)0xFF << (d_offset * 8));
+	sys_mem_word_t d_word = *(sys_mem_word_t *)d_aligned;
+	sys_mem_word_t byte_mask = ~((sys_mem_word_t)0xFF << (d_offset * 8));
 
-	d_word = (d_word & byte_mask) | ((mem_word_t)*src << (d_offset * 8));
+	d_word = (d_word & byte_mask) | ((sys_mem_word_t)*src << (d_offset * 8));
 
-	*(mem_word_t *)d_aligned = d_word;
+	*(sys_mem_word_t *)d_aligned = d_word;
 }
 
 /* Copy byte. Read byte with word-sized-aligned read, write byte with byte-sized write */
 static inline void copy_byte_from_word_granular_access(unsigned char *dst, const unsigned char *src)
 {
 	/* Mask off the lower bits to get an aligned pointer */
-	const mem_word_t mask = sizeof(mem_word_t) - 1;
-	mem_word_t s_aligned = (mem_word_t)src & ~mask;
-	unsigned int s_offset = (mem_word_t)src & mask;
+	const sys_mem_word_t mask = sizeof(sys_mem_word_t) - 1;
+	sys_mem_word_t s_aligned = (sys_mem_word_t)src & ~mask;
+	unsigned int s_offset = (sys_mem_word_t)src & mask;
 
 	/* Read aligned word from source and extract byte */
-	mem_word_t s_word = *(mem_word_t *)s_aligned;
+	sys_mem_word_t s_word = *(sys_mem_word_t *)s_aligned;
 	unsigned char s_byte = (s_word >> (s_offset * 8)) & 0xFF;
 
 	*dst = s_byte;
@@ -40,28 +40,28 @@ static inline void copy_byte_from_word_granular_access(unsigned char *dst, const
 
 static inline void set_byte_word_granular_access(unsigned char *dst, unsigned char value)
 {
-	const mem_word_t mask = sizeof(mem_word_t) - 1;
-	mem_word_t d_aligned = (mem_word_t)dst & ~mask;
-	unsigned int d_offset = (mem_word_t)dst & mask;
+	const sys_mem_word_t mask = sizeof(sys_mem_word_t) - 1;
+	sys_mem_word_t d_aligned = (sys_mem_word_t)dst & ~mask;
+	unsigned int d_offset = (sys_mem_word_t)dst & mask;
 
-	mem_word_t d_word = *(mem_word_t *)d_aligned;
+	sys_mem_word_t d_word = *(sys_mem_word_t *)d_aligned;
 
 	/* Clear destination byte and insert new value */
-	mem_word_t byte_mask = ~((mem_word_t)0xFF << (d_offset * 8));
+	sys_mem_word_t byte_mask = ~((sys_mem_word_t)0xFF << (d_offset * 8));
 
-	d_word = (d_word & byte_mask) | ((mem_word_t)value << (d_offset * 8));
+	d_word = (d_word & byte_mask) | ((sys_mem_word_t)value << (d_offset * 8));
 
-	*(mem_word_t *)d_aligned = d_word;
+	*(sys_mem_word_t *)d_aligned = d_word;
 }
 
-void *memset_word_granular_access(void *buf, int c, size_t n)
+void *sys_memset_word_granular_access(void *buf, int c, size_t n)
 {
 	/* Do byte-sized initialization until word-aligned or finished */
 	unsigned char *d_byte = (unsigned char *)buf;
 	unsigned char c_byte = (unsigned char)c;
 
 #if !defined(CONFIG_MINIMAL_LIBC_OPTIMIZE_STRING_FOR_SIZE)
-	while (((mem_word_t)d_byte) & (sizeof(mem_word_t) - 1)) {
+	while (((sys_mem_word_t)d_byte) & (sizeof(sys_mem_word_t) - 1)) {
 		if (n == 0) {
 			return buf;
 		}
@@ -70,15 +70,15 @@ void *memset_word_granular_access(void *buf, int c, size_t n)
 	}
 
 	/* Do word-sized initialization as long as possible */
-	mem_word_t *d_word = (mem_word_t *)d_byte;
-	mem_word_t c_word = (mem_word_t)c_byte;
+	sys_mem_word_t *d_word = (sys_mem_word_t *)d_byte;
+	sys_mem_word_t c_word = (sys_mem_word_t)c_byte;
 
 	c_word |= c_word << 8;
 	c_word |= c_word << 16;
 
-	while (n >= sizeof(mem_word_t)) {
+	while (n >= sizeof(sys_mem_word_t)) {
 		*(d_word++) = c_word;
-		n -= sizeof(mem_word_t);
+		n -= sizeof(sys_mem_word_t);
 	}
 
 	/* Do byte-sized initialization until finished */
@@ -93,18 +93,18 @@ void *memset_word_granular_access(void *buf, int c, size_t n)
 	return buf;
 }
 
-void *memcpy_to_word_granular_access(void *d, const void *s, size_t n)
+void *sys_memcpy_to_word_granular_access(void *d, const void *s, size_t n)
 {
 	/* Attempt word-sized copying only if buffers have identical alignment */
 	unsigned char *d_byte = (unsigned char *)d;
 	const unsigned char *s_byte = (const unsigned char *)s;
 
 #if !defined(CONFIG_MINIMAL_LIBC_OPTIMIZE_STRING_FOR_SIZE)
-	const mem_word_t mask = sizeof(mem_word_t) - 1;
+	const sys_mem_word_t mask = sizeof(sys_mem_word_t) - 1;
 
-	if ((((mem_word_t)d ^ (mem_word_t)s_byte) & mask) == 0) {
+	if ((((sys_mem_word_t)d ^ (sys_mem_word_t)s_byte) & mask) == 0) {
 		/* Deal with unaligned first bytes */
-		while (((mem_word_t)d_byte) & mask) {
+		while (((sys_mem_word_t)d_byte) & mask) {
 			if (n == 0) {
 				return d;
 			}
@@ -113,12 +113,12 @@ void *memcpy_to_word_granular_access(void *d, const void *s, size_t n)
 		}
 
 		/* Do word-sized copying as long as possible */
-		mem_word_t *d_word = (mem_word_t *)d_byte;
-		const mem_word_t *s_word = (const mem_word_t *)s_byte;
+		sys_mem_word_t *d_word = (sys_mem_word_t *)d_byte;
+		const sys_mem_word_t *s_word = (const sys_mem_word_t *)s_byte;
 
-		while (n >= sizeof(mem_word_t)) {
+		while (n >= sizeof(sys_mem_word_t)) {
 			*(d_word++) = *(s_word++);
-			n -= sizeof(mem_word_t);
+			n -= sizeof(sys_mem_word_t);
 		}
 
 		d_byte = (unsigned char *)d_word;
@@ -135,18 +135,18 @@ void *memcpy_to_word_granular_access(void *d, const void *s, size_t n)
 	return d;
 }
 
-void *memcpy_from_word_granular_access(void *d, const void *s, size_t n)
+void *sys_memcpy_from_word_granular_access(void *d, const void *s, size_t n)
 {
 	/* Attempt word-sized copying only if buffers have identical alignment */
 	unsigned char *d_byte = (unsigned char *)d;
 	const unsigned char *s_byte = (const unsigned char *)s;
 
 #if !defined(CONFIG_MINIMAL_LIBC_OPTIMIZE_STRING_FOR_SIZE)
-	const mem_word_t mask = sizeof(mem_word_t) - 1;
+	const sys_mem_word_t mask = sizeof(sys_mem_word_t) - 1;
 
-	if ((((mem_word_t)d ^ (mem_word_t)s_byte) & mask) == 0) {
+	if ((((sys_mem_word_t)d ^ (sys_mem_word_t)s_byte) & mask) == 0) {
 		/* Deal with unaligned first bytes */
-		while (((mem_word_t)d_byte) & mask) {
+		while (((sys_mem_word_t)d_byte) & mask) {
 			if (n == 0) {
 				return d;
 			}
@@ -155,12 +155,12 @@ void *memcpy_from_word_granular_access(void *d, const void *s, size_t n)
 		}
 
 		/* Do word-sized copying as long as possible */
-		mem_word_t *d_word = (mem_word_t *)d_byte;
-		const mem_word_t *s_word = (const mem_word_t *)s_byte;
+		sys_mem_word_t *d_word = (sys_mem_word_t *)d_byte;
+		const sys_mem_word_t *s_word = (const sys_mem_word_t *)s_byte;
 
-		while (n >= sizeof(mem_word_t)) {
+		while (n >= sizeof(sys_mem_word_t)) {
 			*(d_word++) = *(s_word++);
-			n -= sizeof(mem_word_t);
+			n -= sizeof(sys_mem_word_t);
 		}
 
 		d_byte = (unsigned char *)d_word;

--- a/tests/lib/word_granular_access/src/main.c
+++ b/tests/lib/word_granular_access/src/main.c
@@ -108,52 +108,52 @@ ZTEST(lib_word_granular_access, test_mem_is_word_granular_access)
 	ztest_test_fail();
 }
 
-ZTEST(lib_word_granular_access, test_memset_word_granular_access)
+ZTEST(lib_word_granular_access, test_sys_memset_word_granular_access)
 {
 	uint8_t *wga_ptr;
 
 	/* adjacent byte preservation */
 	memset((uint8_t *)(expected_dst_buf + 4) + 2, 0xAB, 1);
 	wga_ptr = (uint8_t *)(wga_buf + 4) + 2;
-	memset_word_granular_access(wga_ptr, 0xAB, 1);
+	sys_memset_word_granular_access(wga_ptr, 0xAB, 1);
 	CHECK_DATA_MEMSET(wga_buf, expected_dst_buf, "memset", 0xAB, wga_ptr, 1);
 
 	/* word-aligned destination, word-aligned end */
 	memset((uint8_t *)(expected_dst_buf + 5), 0xCD, 8);
 	wga_ptr = (uint8_t *)(wga_buf + 5);
-	memset_word_granular_access(wga_ptr, 0xCD, 8);
+	sys_memset_word_granular_access(wga_ptr, 0xCD, 8);
 	CHECK_DATA_MEMSET(wga_buf, expected_dst_buf, "memset", 0xCD, wga_ptr, 8);
 
 	/* word-aligned destination, length is 1 byte under word boundary */
 	memset((uint8_t *)(expected_dst_buf + 7), 0xEF, 7);
 	wga_ptr = (uint8_t *)(wga_buf + 7);
-	memset_word_granular_access(wga_ptr, 0xEF, 7);
+	sys_memset_word_granular_access(wga_ptr, 0xEF, 7);
 	CHECK_DATA_MEMSET(wga_buf, expected_dst_buf, "memset", 0xEF, wga_ptr, 7);
 
 	/* half-aligned destination, length is 1 byte over word boundary */
 	memset((uint8_t *)(expected_dst_buf + 9) + 2, 0x12, 9);
 	wga_ptr = (uint8_t *)(wga_buf + 9) + 2;
-	memset_word_granular_access(wga_ptr, 0x12, 9);
+	sys_memset_word_granular_access(wga_ptr, 0x12, 9);
 	CHECK_DATA_MEMSET(wga_buf, expected_dst_buf, "memset", 0x12, wga_ptr, 9);
 
 	/* byte-aligned destination, spanning two words */
 	memset((uint8_t *)(expected_dst_buf + 12) + 1, 0x34, 4);
 	wga_ptr = (uint8_t *)(wga_buf + 12) + 1;
-	memset_word_granular_access(wga_ptr, 0x34, 4);
+	sys_memset_word_granular_access(wga_ptr, 0x34, 4);
 	CHECK_DATA_MEMSET(wga_buf, expected_dst_buf, "memset", 0x34, wga_ptr, 4);
 
 	/* zero length */
-	memset_word_granular_access(wga_buf, 0x00, 0);
+	sys_memset_word_granular_access(wga_buf, 0x00, 0);
 	CHECK_DATA_MEMSET(wga_buf, expected_dst_buf, "memset", 0x00, wga_buf, 0);
 
 	/* fill buffer with repeating pattern */
 	memset(expected_dst_buf, 0xAB, ARR_SIZE * sizeof(uint32_t));
-	memset_word_granular_access(wga_buf, 0xAB, ARR_SIZE * sizeof(uint32_t));
+	sys_memset_word_granular_access(wga_buf, 0xAB, ARR_SIZE * sizeof(uint32_t));
 	CHECK_DATA_MEMSET(wga_buf, expected_dst_buf, "memset", 0xAB, wga_buf,
 			  ARR_SIZE * sizeof(uint32_t));
 }
 
-ZTEST(lib_word_granular_access, test_memcpy_to_word_granular_access)
+ZTEST(lib_word_granular_access, test_sys_memcpy_to_word_granular_access)
 {
 	uint8_t *non_wga_ptr;
 	uint8_t *wga_ptr;
@@ -162,7 +162,7 @@ ZTEST(lib_word_granular_access, test_memcpy_to_word_granular_access)
 	memcpy((uint8_t *)(expected_dst_buf + 4) + 3, (uint8_t *)expected_src_buf + 1, 1);
 	non_wga_ptr = (uint8_t *)non_wga_buf + 1;
 	wga_ptr = (uint8_t *)(wga_buf + 4) + 3;
-	memcpy_to_word_granular_access(wga_ptr, non_wga_ptr, 1);
+	sys_memcpy_to_word_granular_access(wga_ptr, non_wga_ptr, 1);
 	CHECK_DATA_MEMCPY(non_wga_buf, expected_src_buf, "memcpy", non_wga_ptr, wga_ptr, 1);
 	CHECK_DATA_MEMCPY(wga_buf, expected_dst_buf, "memcpy", non_wga_ptr, wga_ptr, 1);
 
@@ -170,7 +170,7 @@ ZTEST(lib_word_granular_access, test_memcpy_to_word_granular_access)
 	memcpy((uint8_t *)(expected_dst_buf + 5), (uint8_t *)(expected_src_buf + 1), 9);
 	non_wga_ptr = (uint8_t *)(non_wga_buf + 1);
 	wga_ptr = (uint8_t *)(wga_buf + 5);
-	memcpy_to_word_granular_access(wga_ptr, non_wga_ptr, 9);
+	sys_memcpy_to_word_granular_access(wga_ptr, non_wga_ptr, 9);
 	CHECK_DATA_MEMCPY(non_wga_buf, expected_src_buf, "memcpy", non_wga_ptr, wga_ptr, 9);
 	CHECK_DATA_MEMCPY(wga_buf, expected_dst_buf, "memcpy", non_wga_ptr, wga_ptr, 9);
 
@@ -178,7 +178,7 @@ ZTEST(lib_word_granular_access, test_memcpy_to_word_granular_access)
 	memcpy((uint8_t *)(expected_dst_buf + 7) + 2, (uint8_t *)(expected_src_buf + 2) + 2, 9);
 	non_wga_ptr = (uint8_t *)(non_wga_buf + 2) + 2;
 	wga_ptr = (uint8_t *)(wga_buf + 7) + 2;
-	memcpy_to_word_granular_access(wga_ptr, non_wga_ptr, 9);
+	sys_memcpy_to_word_granular_access(wga_ptr, non_wga_ptr, 9);
 	CHECK_DATA_MEMCPY(non_wga_buf, expected_src_buf, "memcpy", non_wga_ptr, wga_ptr, 9);
 	CHECK_DATA_MEMCPY(wga_buf, expected_dst_buf, "memcpy", non_wga_ptr, wga_ptr, 9);
 
@@ -186,12 +186,12 @@ ZTEST(lib_word_granular_access, test_memcpy_to_word_granular_access)
 	memcpy((uint8_t *)(expected_dst_buf + 9) + 1, (uint8_t *)(expected_src_buf + 3) + 3, 6);
 	non_wga_ptr = (uint8_t *)(non_wga_buf + 3) + 3;
 	wga_ptr = (uint8_t *)(wga_buf + 9) + 1;
-	memcpy_to_word_granular_access(wga_ptr, non_wga_ptr, 6);
+	sys_memcpy_to_word_granular_access(wga_ptr, non_wga_ptr, 6);
 	CHECK_DATA_MEMCPY(non_wga_buf, expected_src_buf, "memcpy", non_wga_ptr, wga_ptr, 6);
 	CHECK_DATA_MEMCPY(wga_buf, expected_dst_buf, "memcpy", non_wga_ptr, wga_ptr, 6);
 
 	/* zero length */
-	memcpy_to_word_granular_access(wga_buf, non_wga_buf, 0);
+	sys_memcpy_to_word_granular_access(wga_buf, non_wga_buf, 0);
 	CHECK_DATA_MEMCPY(non_wga_buf, expected_src_buf, "memcpy", non_wga_buf, wga_buf, 0);
 	CHECK_DATA_MEMCPY(wga_buf, expected_dst_buf, "memcpy", non_wga_buf, wga_buf, 0);
 
@@ -200,14 +200,14 @@ ZTEST(lib_word_granular_access, test_memcpy_to_word_granular_access)
 	       (ARR_SIZE * sizeof(uint32_t)) - 4);
 	non_wga_ptr = (uint8_t *)non_wga_buf + 1;
 	wga_ptr = (uint8_t *)(wga_buf) + 3;
-	memcpy_to_word_granular_access(wga_ptr, non_wga_ptr, (ARR_SIZE * sizeof(uint32_t)) - 4);
+	sys_memcpy_to_word_granular_access(wga_ptr, non_wga_ptr, (ARR_SIZE * sizeof(uint32_t)) - 4);
 	CHECK_DATA_MEMCPY(non_wga_buf, expected_src_buf, "memcpy", non_wga_ptr, wga_ptr,
 			  (ARR_SIZE * sizeof(uint32_t)) - 4);
 	CHECK_DATA_MEMCPY(wga_buf, expected_dst_buf, "memcpy", non_wga_ptr, wga_ptr,
 			  (ARR_SIZE * sizeof(uint32_t)) - 4);
 }
 
-ZTEST(lib_word_granular_access, test_memcpy_from_word_granular_access)
+ZTEST(lib_word_granular_access, test_sys_memcpy_from_word_granular_access)
 {
 	uint8_t *wga_ptr;
 	uint8_t *non_wga_ptr;
@@ -216,7 +216,7 @@ ZTEST(lib_word_granular_access, test_memcpy_from_word_granular_access)
 	memcpy((uint8_t *)(expected_dst_buf + 4) + 3, (uint8_t *)expected_src_buf + 1, 1);
 	wga_ptr = (uint8_t *)wga_buf + 1;
 	non_wga_ptr = (uint8_t *)(non_wga_buf + 4) + 3;
-	memcpy_from_word_granular_access(non_wga_ptr, wga_ptr, 1);
+	sys_memcpy_from_word_granular_access(non_wga_ptr, wga_ptr, 1);
 	CHECK_DATA_MEMCPY(wga_buf, expected_src_buf, "memcpy", wga_ptr, non_wga_ptr, 1);
 	CHECK_DATA_MEMCPY(non_wga_buf, expected_dst_buf, "memcpy", wga_ptr, non_wga_ptr, 1);
 
@@ -224,7 +224,7 @@ ZTEST(lib_word_granular_access, test_memcpy_from_word_granular_access)
 	memcpy((uint8_t *)(expected_dst_buf + 5), (uint8_t *)(expected_src_buf + 1), 7);
 	wga_ptr = (uint8_t *)(wga_buf + 1);
 	non_wga_ptr = (uint8_t *)(non_wga_buf + 5);
-	memcpy_from_word_granular_access(non_wga_ptr, wga_ptr, 7);
+	sys_memcpy_from_word_granular_access(non_wga_ptr, wga_ptr, 7);
 	CHECK_DATA_MEMCPY(wga_buf, expected_src_buf, "memcpy", wga_ptr, non_wga_ptr, 7);
 	CHECK_DATA_MEMCPY(non_wga_buf, expected_dst_buf, "memcpy", wga_ptr, non_wga_ptr, 7);
 
@@ -232,7 +232,7 @@ ZTEST(lib_word_granular_access, test_memcpy_from_word_granular_access)
 	memcpy((uint8_t *)(expected_dst_buf + 7) + 2, (uint8_t *)(expected_src_buf + 2) + 2, 7);
 	wga_ptr = (uint8_t *)(wga_buf + 2) + 2;
 	non_wga_ptr = (uint8_t *)(non_wga_buf + 7) + 2;
-	memcpy_from_word_granular_access(non_wga_ptr, wga_ptr, 7);
+	sys_memcpy_from_word_granular_access(non_wga_ptr, wga_ptr, 7);
 	CHECK_DATA_MEMCPY(wga_buf, expected_src_buf, "memcpy", wga_ptr, non_wga_ptr, 7);
 	CHECK_DATA_MEMCPY(non_wga_buf, expected_dst_buf, "memcpy", wga_ptr, non_wga_ptr, 7);
 
@@ -240,12 +240,12 @@ ZTEST(lib_word_granular_access, test_memcpy_from_word_granular_access)
 	memcpy((uint8_t *)(expected_dst_buf + 9) + 1, (uint8_t *)(expected_src_buf + 3) + 3, 6);
 	wga_ptr = (uint8_t *)(wga_buf + 3) + 3;
 	non_wga_ptr = (uint8_t *)(non_wga_buf + 9) + 1;
-	memcpy_from_word_granular_access(non_wga_ptr, wga_ptr, 6);
+	sys_memcpy_from_word_granular_access(non_wga_ptr, wga_ptr, 6);
 	CHECK_DATA_MEMCPY(wga_buf, expected_src_buf, "memcpy", wga_ptr, non_wga_ptr, 6);
 	CHECK_DATA_MEMCPY(non_wga_buf, expected_dst_buf, "memcpy", wga_ptr, non_wga_ptr, 6);
 
 	/* zero length */
-	memcpy_from_word_granular_access(non_wga_buf, wga_buf, 0);
+	sys_memcpy_from_word_granular_access(non_wga_buf, wga_buf, 0);
 	CHECK_DATA_MEMCPY(wga_buf, expected_src_buf, "memcpy", wga_buf, non_wga_buf, 0);
 	CHECK_DATA_MEMCPY(non_wga_buf, expected_dst_buf, "memcpy", wga_buf, non_wga_buf, 0);
 
@@ -254,7 +254,8 @@ ZTEST(lib_word_granular_access, test_memcpy_from_word_granular_access)
 	       (ARR_SIZE * sizeof(uint32_t)) - 4);
 	wga_ptr = (uint8_t *)wga_buf + 1;
 	non_wga_ptr = (uint8_t *)(non_wga_buf) + 3;
-	memcpy_from_word_granular_access(non_wga_ptr, wga_ptr, (ARR_SIZE * sizeof(uint32_t)) - 4);
+	sys_memcpy_from_word_granular_access(non_wga_ptr, wga_ptr,
+					     (ARR_SIZE * sizeof(uint32_t)) - 4);
 	CHECK_DATA_MEMCPY(wga_buf, expected_src_buf, "memcpy", wga_ptr, non_wga_ptr,
 			  (ARR_SIZE * sizeof(uint32_t)) - 4);
 	CHECK_DATA_MEMCPY(non_wga_buf, expected_dst_buf, "memcpy", wga_ptr, non_wga_ptr,


### PR DESCRIPTION
Adds sys_ prefix to functions and typedef of the word granular access library, as it is a sys API.