### PR TITLE
drivers: flash: soc_flash_rv32m1: use legacy method to get flash node

### DIFF
--- a/drivers/flash/soc_flash_rv32m1.c
+++ b/drivers/flash/soc_flash_rv32m1.c
@@ -13,9 +13,8 @@
 #include <errno.h>
 #include <zephyr/init.h>
 #include <soc.h>
-#include "flash_priv.h"
 
-#define SOC_NV_FLASH_NODE SOC_NV_FLASH_CHILD_NODE(0)
+#define SOC_NV_FLASH_NODE DT_INST(0, soc_nv_flash)
 
 #include "fsl_common.h"
 #include "fsl_flash.h"


### PR DESCRIPTION
Use legacy method to get the SOC flash node for the rv32m1 flash driver, because users of this flash driver define multiple child nodes with the soc-nv-flash compatible. This prevents use of the
SOC_NV_FLASH_CHILD_NODE helper macro, which relies on one compatible with the child being present.

This fixes the following CI failure on main: https://github.com/zephyrproject-rtos/zephyr/actions/runs/29265017640/job/86868507946#step:12:1994, reproducible with `west build -p -b rv32m1_vega/openisa_rv32m1/ri5cy tests/bluetooth/init -T bluetooth.init.test_llcp` since commit 7acfb6145fdbe1363ffd37310caf91e8da456083