### PR TITLE
mem_mgmt: modularize memory management backend

### DIFF
--- a/arch/arm/core/mmu/arm_mmu.c
+++ b/arch/arm/core/mmu/arm_mmu.c
@@ -964,8 +964,10 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
  * @param size Size (in bytes) of the memory area to map.
  * @param flags Memory attributes & permissions. Comp. K_MEM_...
  *              flags in kernel/mm.h.
+ *
+ * @retval 0 on success
  */
-void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
+int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 {
 	int ret = __arch_mem_map(virt, phys, size, flags);
 
@@ -975,6 +977,8 @@ void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 	} else {
 		invalidate_tlb_all();
 	}
+
+	return 0;
 }
 
 /**
@@ -1024,8 +1028,11 @@ static int __arch_mem_unmap(void *addr, size_t size)
  *
  * @param addr 32-bit virtual address to unmap.
  * @param size Size (in bytes) of the memory area to unmap.
+ *
+ * @retval 0 on success
+ * @retval -EINVAL Invalid arguments
  */
-void arch_mem_unmap(void *addr, size_t size)
+int arch_mem_unmap(void *addr, size_t size)
 {
 	int ret = __arch_mem_unmap(addr, size);
 
@@ -1034,6 +1041,8 @@ void arch_mem_unmap(void *addr, size_t size)
 	} else {
 		invalidate_tlb_all();
 	}
+
+	return ret;
 }
 
 /**

--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -1543,7 +1543,7 @@ static uint64_t *get_pte_location(struct arm_mmu_ptables *ptables,
 	}
 }
 
-void arch_mem_page_out(void *addr, uintptr_t location)
+int arch_mem_page_out(void *addr, uintptr_t location)
 {
 	uintptr_t virt = (uintptr_t)addr;
 	uint64_t *pte = get_pte_location(&kernel_ptables, virt);
@@ -1573,9 +1573,11 @@ void arch_mem_page_out(void *addr, uintptr_t location)
 
 	sync_domains(virt, CONFIG_MMU_PAGE_SIZE, "page_out");
 	invalidate_tlb_page(virt);
+
+	return 0;
 }
 
-void arch_mem_page_in(void *addr, uintptr_t phys)
+int arch_mem_page_in(void *addr, uintptr_t phys)
 {
 	uintptr_t virt = (uintptr_t)addr;
 	uint64_t *pte = get_pte_location(&kernel_ptables, virt);
@@ -1611,6 +1613,8 @@ void arch_mem_page_in(void *addr, uintptr_t phys)
 
 	sync_domains(virt, CONFIG_MMU_PAGE_SIZE, "page_in");
 	invalidate_tlb_page(virt);
+
+	return 0;
 }
 
 enum sys_mm_vm_page_location arch_page_location_get(void *addr, uintptr_t *location)

--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -1609,30 +1609,30 @@ void arch_mem_page_in(void *addr, uintptr_t phys)
 	invalidate_tlb_page(virt);
 }
 
-enum arch_page_location arch_page_location_get(void *addr, uintptr_t *location)
+enum sys_mm_vm_page_location arch_page_location_get(void *addr, uintptr_t *location)
 {
 	uintptr_t virt = (uintptr_t)addr;
 	uint64_t *pte = get_pte_location(&kernel_ptables, virt);
 	uint64_t desc;
-	enum arch_page_location status;
+	enum sys_mm_vm_page_location status;
 
 	if (!pte) {
-		return ARCH_PAGE_LOCATION_BAD;
+		return SYS_MM_VM_PAGE_LOCATION_BAD;
 	}
 	desc = *pte;
 	if (is_free_desc(desc)) {
-		return ARCH_PAGE_LOCATION_BAD;
+		return SYS_MM_VM_PAGE_LOCATION_BAD;
 	}
 
 	switch (desc & PTE_DESC_TYPE_MASK) {
 	case PTE_PAGE_DESC:
-		status = ARCH_PAGE_LOCATION_PAGED_IN;
+		status = SYS_MM_VM_PAGE_LOCATION_PAGED_IN;
 		break;
 	case PTE_INVALID_DESC:
-		status = ARCH_PAGE_LOCATION_PAGED_OUT;
+		status = SYS_MM_VM_PAGE_LOCATION_PAGED_OUT;
 		break;
 	default:
-		return ARCH_PAGE_LOCATION_BAD;
+		return SYS_MM_VM_PAGE_LOCATION_BAD;
 	}
 
 	*location = desc & PTE_PHYSADDR_MASK;
@@ -1647,38 +1647,38 @@ uintptr_t arch_page_info_get(void *addr, uintptr_t *phys, bool clear_accessed)
 	uintptr_t status = 0;
 
 	if (!pte) {
-		return ARCH_DATA_PAGE_NOT_MAPPED;
+		return SYS_MM_VM_DATA_PAGE_NOT_MAPPED;
 	}
 	desc = *pte;
 	if (is_free_desc(desc)) {
-		return ARCH_DATA_PAGE_NOT_MAPPED;
+		return SYS_MM_VM_DATA_PAGE_NOT_MAPPED;
 	}
 
 	switch (desc & PTE_DESC_TYPE_MASK) {
 	case PTE_PAGE_DESC:
-		status |= ARCH_DATA_PAGE_LOADED;
+		status |= SYS_MM_VM_DATA_PAGE_LOADED;
 		break;
 	case PTE_INVALID_DESC:
 		/* page not loaded */
 		break;
 	default:
-		return ARCH_DATA_PAGE_NOT_MAPPED;
+		return SYS_MM_VM_DATA_PAGE_NOT_MAPPED;
 	}
 
 	if (phys) {
 		*phys = desc & PTE_PHYSADDR_MASK;
 	}
 
-	if ((status & ARCH_DATA_PAGE_LOADED) == 0) {
+	if ((status & SYS_MM_VM_DATA_PAGE_LOADED) == 0) {
 		return status;
 	}
 
 	if ((desc & PTE_BLOCK_DESC_AF) != 0) {
-		status |= ARCH_DATA_PAGE_ACCESSED;
+		status |= SYS_MM_VM_DATA_PAGE_ACCESSED;
 	}
 
 	if ((desc & PTE_BLOCK_DESC_AP_RO) == 0) {
-		status |= ARCH_DATA_PAGE_DIRTY;
+		status |= SYS_MM_VM_DATA_PAGE_DIRTY;
 	}
 
 	if (clear_accessed) {

--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -1211,7 +1211,7 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
 	return add_map(ptables, "generic", phys, (uintptr_t)virt, size, entry_flags);
 }
 
-void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
+int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 {
 	int ret = __arch_mem_map(virt, phys, size, flags);
 
@@ -1222,13 +1222,17 @@ void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 		sync_domains((uintptr_t)virt, size, "mem_map");
 		invalidate_tlb_all();
 	}
+
+	return 0;
 }
 
-void arch_mem_unmap(void *addr, size_t size)
+int arch_mem_unmap(void *addr, size_t size)
 {
 	remove_map(&kernel_ptables, "generic", (uintptr_t)addr, size);
 	sync_domains((uintptr_t)addr, size, "mem_unmap");
 	invalidate_tlb_all();
+
+	return 0;
 }
 
 int arch_page_phys_get(void *virt, uintptr_t *phys)

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -2032,7 +2032,7 @@ int arch_page_phys_get(void *virt, uintptr_t *phys)
  */
 #define MMU_LRU_TRACK	MMU_G
 
-void arch_mem_page_out(void *addr, uintptr_t location)
+int arch_mem_page_out(void *addr, uintptr_t location)
 {
 	int ret;
 	pentry_t mask = PTE_MASK | MMU_P | MMU_A | MMU_LRU_TRACK;
@@ -2046,10 +2046,10 @@ void arch_mem_page_out(void *addr, uintptr_t location)
 	ret = range_map(addr, location, CONFIG_MMU_PAGE_SIZE, MMU_A, mask,
 			OPTION_FLUSH);
 	__ASSERT_NO_MSG(ret == 0);
-	ARG_UNUSED(ret);
+	return ret;
 }
 
-void arch_mem_page_in(void *addr, uintptr_t phys)
+int arch_mem_page_in(void *addr, uintptr_t phys)
 {
 	int ret;
 	pentry_t mask = PTE_MASK | MMU_P | MMU_D | MMU_A | MMU_LRU_TRACK;
@@ -2057,7 +2057,7 @@ void arch_mem_page_in(void *addr, uintptr_t phys)
 	ret = range_map(addr, phys, CONFIG_MMU_PAGE_SIZE, MMU_P, mask,
 			OPTION_FLUSH);
 	__ASSERT_NO_MSG(ret == 0);
-	ARG_UNUSED(ret);
+	return ret;
 }
 
 #ifdef CONFIG_EVICTION_LRU

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1244,25 +1244,25 @@ static pentry_t flags_to_entry(uint32_t flags)
 }
 
 /* map new region virt..virt+size to phys with provided arch-neutral flags */
-void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
+int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 {
 	int ret;
 
 	ret = range_map_unlocked(virt, phys, size, flags_to_entry(flags),
 				 MASK_ALL, 0);
 	__ASSERT_NO_MSG(ret == 0);
-	ARG_UNUSED(ret);
+	return ret;
 }
 
 /* unmap region addr..addr+size, reset entries and flush TLB */
-void arch_mem_unmap(void *addr, size_t size)
+int arch_mem_unmap(void *addr, size_t size)
 {
 	int ret;
 
 	ret = range_map_unlocked(addr, 0, size, 0, 0,
 				 OPTION_FLUSH | OPTION_CLEAR);
 	__ASSERT_NO_MSG(ret == 0);
-	ARG_UNUSED(ret);
+	return ret;
 }
 
 #ifdef K_MEM_IS_VM_KERNEL

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -2158,7 +2158,7 @@ uintptr_t arch_page_info_get(void *addr, uintptr_t *phys, bool clear_accessed)
 	 * else in this case.
 	 */
 	if (all_pte == 0) {
-		return ARCH_DATA_PAGE_NOT_MAPPED;
+		return SYS_MM_VM_DATA_PAGE_NOT_MAPPED;
 	}
 
 #if defined(CONFIG_USERSPACE) && !defined(CONFIG_X86_COMMON_PAGE_TABLE)
@@ -2200,17 +2200,17 @@ uintptr_t arch_page_info_get(void *addr, uintptr_t *phys, bool clear_accessed)
 	}
 
 	/* We don't filter out any other bits in the PTE and the kernel
-	 * ignores them. For the case of ARCH_DATA_PAGE_NOT_MAPPED,
+	 * ignores them. For the case of SYS_MM_VM_DATA_PAGE_NOT_MAPPED,
 	 * we use a bit which is never set in a real PTE (the PAT bit) in the
 	 * current system.
 	 *
-	 * The other ARCH_DATA_PAGE_* macros are defined to their corresponding
+	 * The other SYS_MM_VM_DATA_PAGE_* macros are defined to their corresponding
 	 * bits in the PTE.
 	 */
 	return (uintptr_t)all_pte;
 }
 
-enum arch_page_location arch_page_location_get(void *addr, uintptr_t *location)
+enum sys_mm_vm_page_location arch_page_location_get(void *addr, uintptr_t *location)
 {
 	pentry_t pte;
 	int level;
@@ -2222,14 +2222,14 @@ enum arch_page_location arch_page_location_get(void *addr, uintptr_t *location)
 
 	if (pte == 0) {
 		/* Not mapped */
-		return ARCH_PAGE_LOCATION_BAD;
+		return SYS_MM_VM_PAGE_LOCATION_BAD;
 	}
 
 	__ASSERT(level == PTE_LEVEL, "bigpage found at %p", addr);
 	*location = (uintptr_t)get_entry_phys(pte, PTE_LEVEL);
 
 	if ((pte & MMU_P) != 0) {
-		return ARCH_PAGE_LOCATION_PAGED_IN;
+		return SYS_MM_VM_PAGE_LOCATION_PAGED_IN;
 	}
 
 #ifdef CONFIG_EVICTION_LRU
@@ -2239,11 +2239,11 @@ enum arch_page_location arch_page_location_get(void *addr, uintptr_t *location)
 	 * paged-out entries.
 	 */
 	if ((pte & MMU_LRU_TRACK) != 0) {
-		return ARCH_PAGE_LOCATION_PAGED_IN;
+		return SYS_MM_VM_PAGE_LOCATION_PAGED_IN;
 	}
 #endif
 
-	return ARCH_PAGE_LOCATION_PAGED_OUT;
+	return SYS_MM_VM_PAGE_LOCATION_PAGED_OUT;
 }
 
 #ifdef CONFIG_X86_KPTI

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -684,7 +684,7 @@ static inline void __arch_mem_map(void *vaddr, uintptr_t paddr, uint32_t attrs, 
 #endif /* CONFIG_USERSPACE */
 }
 
-void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
+int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 {
 	uint32_t va = (uint32_t)virt;
 	uint32_t pa = (uint32_t)phys;
@@ -741,6 +741,8 @@ void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags)
 	}
 
 	k_spin_unlock(&xtensa_mmu_lock, key);
+
+	return 0;
 }
 
 /**
@@ -849,7 +851,7 @@ static inline void __arch_mem_unmap(void *vaddr)
 #endif /* CONFIG_USERSPACE */
 }
 
-void arch_mem_unmap(void *addr, size_t size)
+int arch_mem_unmap(void *addr, size_t size)
 {
 	uint32_t va = (uint32_t)addr;
 	uint32_t rem_size = (uint32_t)size;
@@ -857,12 +859,12 @@ void arch_mem_unmap(void *addr, size_t size)
 
 	if (addr == NULL) {
 		LOG_ERR("Cannot unmap NULL pointer");
-		return;
+		return -EINVAL;
 	}
 
 	if (size == 0) {
 		LOG_ERR("Cannot unmap virtual memory with zero size");
-		return;
+		return -EINVAL;
 	}
 
 	key = k_spin_lock(&xtensa_mmu_lock);
@@ -883,6 +885,8 @@ void arch_mem_unmap(void *addr, size_t size)
 	}
 
 	k_spin_unlock(&xtensa_mmu_lock, key);
+
+	return 0;
 }
 
 /* This should be implemented in the SoC layer.

--- a/doc/hardware/arch/arm_cortex_m.rst
+++ b/doc/hardware/arch/arm_cortex_m.rst
@@ -526,7 +526,7 @@ For example, to define a new non-cacheable memory region in devicetree:
 
 This will automatically create a new MPU entry in with the correct name, base,
 size and attributes gathered directly from the devicetree. See :ref:`cache_guide`
-and :ref:`mem_mgmt_api` for more details.
+and :ref:`mem_attrs_api` for more details.
 
 Static MPU regions
 ------------------

--- a/doc/hardware/cache/config.rst
+++ b/doc/hardware/cache/config.rst
@@ -42,7 +42,7 @@ implemented and controlled.
   driver.
 
 * :kconfig:option:`CONFIG_MEM_ATTR`: this option allows the user to
-  specify (using :ref:`memory region attributes<mem_mgmt_api>`) a fixed region
+  specify (using :ref:`memory region attributes<mem_attrs_api>`) a fixed region
   in memory that will have caching disabled once the kernel has initialized.
 
 * :kconfig:option:`CONFIG_NOCACHE_MEMORY`: this option allows the user to

--- a/doc/hardware/cache/guide.rst
+++ b/doc/hardware/cache/guide.rst
@@ -70,7 +70,7 @@ Requirements:
 * :kconfig:option:`CONFIG_MEM_ATTR`: enable the ``mem-attr`` library for
   handling memory attributes in the device tree.
 
-* Annotate your device tree according to :ref:`mem_mgmt_api`.
+* Annotate your device tree according to :ref:`mem_attrs_api`.
 
 Assuming the MPU driver is enabled, it will configure the specified regions
 according to the memory attributes specified during kernel initialization. When

--- a/doc/kernel/usermode/memory_domain.rst
+++ b/doc/kernel/usermode/memory_domain.rst
@@ -28,7 +28,7 @@ contain the following:
   have an MPU region configuring it. It is strongly recommended to use this
   to maximize the number of available MPU regions for the end user. On
   ARMv7-M/ARMv8-M this is called the System Address Map, other CPUs may
-  have similar capabilities. See :ref:`mem_mgmt_api` for information on
+  have similar capabilities. See :ref:`mem_attrs_api` for information on
   how to annotate the system map in the device tree.
 
 - A read-only, executable region or regions for program text and ro-data, that

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -250,6 +250,18 @@ New APIs and options
   * :c:func:`lora_recv_duty_cycle`
   * :c:func:`lora_recv_duty_cycle_async`
 
+* Memory Management
+
+  * :c:func:`sys_mm_vm_backend_mem_map`
+  * :c:func:`sys_mm_vm_backend_mem_unmap`
+  * :c:func:`sys_mm_vm_backend_page_phys_get`
+  * :c:func:`sys_mm_vm_backend_reserved_pages_update`
+  * :c:func:`sys_mm_vm_backend_mem_page_out`
+  * :c:func:`sys_mm_vm_backend_mem_page_in`
+  * :c:func:`sys_mm_vm_backend_mem_scratch`
+  * :c:func:`sys_mm_vm_backend_page_location_get`
+  * :c:func:`sys_mm_vm_backend_mem_page_info_get`
+
 * Network
 
   * Add :c:func:`net_eth_set_if_type_wifi` to set the ethernet interface type to Wi-Fi.

--- a/doc/services/mem_mgmt/mem_attrs.rst
+++ b/doc/services/mem_mgmt/mem_attrs.rst
@@ -1,4 +1,4 @@
-.. _mem_mgmt_api:
+.. _mem_attrs_api:
 
 Memory Attributes
 #################

--- a/doc/services/mem_mgmt/virt_mem.rst
+++ b/doc/services/mem_mgmt/virt_mem.rst
@@ -1,0 +1,70 @@
+.. _mem_mgmt_virt_mem_api:
+
+Virtual Memory Backend
+######################
+
+Virtual memory backend provides the APIs to support
+:ref:`virtual memory<memory_management_api_virtual_memory>` in kernel.
+This backend can also be used without kernel virtual memory support, and
+thus allowing applications to explicitly control memory mappings.
+There can only be one backend enabled per build and the information is
+available via :kconfig:option:`CONFIG_MEM_MGMT_VM_BACKEND`.
+
+Here are the APIs for memory mapping:
+
+  * :c:func:`sys_mm_vm_backend_mem_map`
+  * :c:func:`sys_mm_vm_backend_mem_unmap`
+  * :c:func:`sys_mm_vm_backend_page_phys_get`
+
+Here are the APIs for demand paging (if enabled):
+
+  * :c:func:`sys_mm_vm_backend_reserved_pages_update`
+  * :c:func:`sys_mm_vm_backend_mem_page_out`
+  * :c:func:`sys_mm_vm_backend_mem_page_in`
+  * :c:func:`sys_mm_vm_backend_mem_scratch`
+  * :c:func:`sys_mm_vm_backend_page_location_get`
+  * :c:func:`sys_mm_vm_backend_mem_page_info_get`
+
+Architecture-specific Virtual Memory Backend
+********************************************
+
+This uses the memory mapping code implemented in the architecture layer and
+is selected via :kconfig:option:`CONFIG_MEM_MGMT_VM_BACKEND_ARCH`.
+Refer to the :ref:`architecture_porting_guide` on specifics. The system
+virtual memory backend APIs are simply wrappers to the ones in
+the architecture layer:
+
+  * :c:func:`sys_mm_vm_backend_mem_map` -> :c:func:`arch_mem_map`
+  * :c:func:`sys_mm_vm_backend_mem_unmap` -> :c:func:`arch_mem_unmap`
+  * :c:func:`sys_mm_vm_backend_page_phys_get` -> :c:func:`arch_page_phys_get`
+  * :c:func:`sys_mm_vm_backend_reserved_pages_update` -> :c:func:`arch_reserved_pages_update`
+  * :c:func:`sys_mm_vm_backend_mem_page_out` -> :c:func:`arch_mem_page_out`
+  * :c:func:`sys_mm_vm_backend_mem_page_in` -> :c:func:`arch_mem_page_in`
+  * :c:func:`sys_mm_vm_backend_mem_scratch` -> :c:func:`arch_mem_scratch`
+  * :c:func:`sys_mm_vm_backend_page_location_get` -> :c:func:`arch_page_location_get`
+  * :c:func:`sys_mm_vm_backend_mem_page_info_get` -> :c:func:`arch_page_info_get`
+
+Custom Virtual Memory Backend
+*****************************
+
+When :kconfig:option:`CONFIG_MEM_MGMT_VM_BACKEND_CUSTOM` is enabled, a custom
+implementation of virtual memory backend will be used. This allows hardware
+external to the CPU to provide support for memory mapping. This custom
+implementation must implement these APIs to support memory mappings:
+
+  * :c:func:`sys_mm_vm_backend_mem_map`
+  * :c:func:`sys_mm_vm_backend_mem_unmap`
+  * :c:func:`sys_mm_vm_backend_page_phys_get`
+
+If support for demand paging is needed, these macros must be defined in
+header file ``sys_mm_vm_backend_custom.h``:
+
+  * :c:macro:`SYS_MM_VM_DATA_PAGE_LOADED`
+  * :c:macro:`SYS_MM_VM_DATA_PAGE_ACCESSED`
+  * :c:macro:`SYS_MM_VM_DATA_PAGE_DIRTY`
+  * :c:macro:`SYS_MM_VM_DATA_PAGE_NOT_MAPPED`
+
+API Reference
+*************
+
+.. doxygengroup:: mem_mgmt_vm_backend

--- a/doc/services/memory_management.rst
+++ b/doc/services/memory_management.rst
@@ -10,5 +10,5 @@ pools.
 .. toctree::
    :maxdepth: 1
 
-   mem_mgmt/index.rst
+   mem_mgmt/mem_attrs.rst
    net_buf/index.rst

--- a/doc/services/memory_management.rst
+++ b/doc/services/memory_management.rst
@@ -12,3 +12,4 @@ pools.
 
    mem_mgmt/mem_attrs.rst
    net_buf/index.rst
+   mem_mgmt/virt_mem.rst

--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -26,7 +26,7 @@
 #include <zephyr/drivers/mm/mm_drv_bank.h>
 #include <zephyr/debug/sparse.h>
 #include <zephyr/cache.h>
-#include <kernel_arch_interface.h>
+#include <zephyr/mem_mgmt/system_vm/backend.h>
 
 #define SRAM_BANK_PAGE_NUM   (SRAM_BANK_SIZE / CONFIG_MM_DRV_PAGE_SIZE)
 
@@ -277,7 +277,7 @@ int sys_mm_drv_map_page(void *virt, uintptr_t phys, uint32_t flags)
 	tlb_entries[entry_idx] = entry;
 
 #ifdef CONFIG_MMU
-	arch_mem_map(virt, va, CONFIG_MM_DRV_PAGE_SIZE, flags);
+	sys_mm_vm_backend_mem_map(virt, va, CONFIG_MM_DRV_PAGE_SIZE, flags);
 #endif
 	/*
 	 * Invalid the cache of the newly mapped virtual page to
@@ -386,7 +386,7 @@ static int sys_mm_drv_unmap_page_wflush(void *virt, bool flush_data)
 	if (flush_data) {
 		sys_cache_data_flush_range(virt, CONFIG_MM_DRV_PAGE_SIZE);
 #ifdef CONFIG_MMU
-		arch_mem_unmap(virt, CONFIG_MM_DRV_PAGE_SIZE);
+		sys_mm_vm_backend_mem_unmap(virt, CONFIG_MM_DRV_PAGE_SIZE);
 #endif
 	}
 
@@ -471,7 +471,7 @@ int sys_mm_drv_update_page_flags(void *virt, uint32_t flags)
 	tlb_entries[entry_idx] = entry;
 
 #ifdef CONFIG_MMU
-	arch_mem_map(virt, va, CONFIG_MM_DRV_PAGE_SIZE, flags);
+	sys_mm_vm_backend_mem_map(virt, va, CONFIG_MM_DRV_PAGE_SIZE, flags);
 #endif
 
 out:
@@ -854,8 +854,9 @@ static void adsp_mm_save_context(void *storage_buffer)
 			tlb_entries[entry_idx] = entry;
 
 #ifdef CONFIG_MMU
-			arch_mem_map(UINT_TO_POINTER(phys_addr), phys_addr, CONFIG_MM_DRV_PAGE_SIZE,
-				     K_MEM_CACHE_WB | K_MEM_PERM_RW);
+			sys_mm_vm_backend_mem_map(UINT_TO_POINTER(phys_addr), phys_addr,
+						  CONFIG_MM_DRV_PAGE_SIZE,
+						  K_MEM_CACHE_WB | K_MEM_PERM_RW);
 #endif
 
 			/* Invalidate cache to avoid stalled data

--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -277,7 +277,10 @@ int sys_mm_drv_map_page(void *virt, uintptr_t phys, uint32_t flags)
 	tlb_entries[entry_idx] = entry;
 
 #ifdef CONFIG_MMU
-	sys_mm_vm_backend_mem_map(virt, va, CONFIG_MM_DRV_PAGE_SIZE, flags);
+	int ret2 = sys_mm_vm_backend_mem_map(virt, va, CONFIG_MM_DRV_PAGE_SIZE, flags);
+
+	ARG_UNUSED(ret2);
+	__ASSERT_NO_MSG(ret2 == 0);
 #endif
 	/*
 	 * Invalid the cache of the newly mapped virtual page to
@@ -386,7 +389,10 @@ static int sys_mm_drv_unmap_page_wflush(void *virt, bool flush_data)
 	if (flush_data) {
 		sys_cache_data_flush_range(virt, CONFIG_MM_DRV_PAGE_SIZE);
 #ifdef CONFIG_MMU
-		sys_mm_vm_backend_mem_unmap(virt, CONFIG_MM_DRV_PAGE_SIZE);
+		int ret2 = sys_mm_vm_backend_mem_unmap(virt, CONFIG_MM_DRV_PAGE_SIZE);
+
+		ARG_UNUSED(ret2);
+		__ASSERT_NO_MSG(ret2 == 0);
 #endif
 	}
 
@@ -471,7 +477,10 @@ int sys_mm_drv_update_page_flags(void *virt, uint32_t flags)
 	tlb_entries[entry_idx] = entry;
 
 #ifdef CONFIG_MMU
-	sys_mm_vm_backend_mem_map(virt, va, CONFIG_MM_DRV_PAGE_SIZE, flags);
+	int ret2 = sys_mm_vm_backend_mem_map(virt, va, CONFIG_MM_DRV_PAGE_SIZE, flags);
+
+	ARG_UNUSED(ret2);
+	__ASSERT_NO_MSG(ret2 == 0);
 #endif
 
 out:
@@ -854,9 +863,12 @@ static void adsp_mm_save_context(void *storage_buffer)
 			tlb_entries[entry_idx] = entry;
 
 #ifdef CONFIG_MMU
-			sys_mm_vm_backend_mem_map(UINT_TO_POINTER(phys_addr), phys_addr,
-						  CONFIG_MM_DRV_PAGE_SIZE,
-						  K_MEM_CACHE_WB | K_MEM_PERM_RW);
+			int ret2 = sys_mm_vm_backend_mem_map(UINT_TO_POINTER(phys_addr), phys_addr,
+							     CONFIG_MM_DRV_PAGE_SIZE,
+							     K_MEM_CACHE_WB | K_MEM_PERM_RW);
+
+			ARG_UNUSED(ret2);
+			__ASSERT_NO_MSG(ret2 == 0);
 #endif
 
 			/* Invalidate cache to avoid stalled data

--- a/include/zephyr/arch/arm64/arm_mmu.h
+++ b/include/zephyr/arch/arm64/arm_mmu.h
@@ -96,10 +96,10 @@
 #endif
 
 /* Definitions used by arch_page_info_get() */
-#define ARCH_DATA_PAGE_LOADED		BIT(0)
-#define ARCH_DATA_PAGE_ACCESSED		BIT(1)
-#define ARCH_DATA_PAGE_DIRTY		BIT(2)
-#define ARCH_DATA_PAGE_NOT_MAPPED	BIT(3)
+#define SYS_MM_VM_DATA_PAGE_LOADED	BIT(0)
+#define SYS_MM_VM_DATA_PAGE_ACCESSED	BIT(1)
+#define SYS_MM_VM_DATA_PAGE_DIRTY	BIT(2)
+#define SYS_MM_VM_DATA_PAGE_NOT_MAPPED	BIT(3)
 
 /*
  * Special unpaged "location" tags (highest possible descriptor physical

--- a/include/zephyr/arch/x86/mmustructs.h
+++ b/include/zephyr/arch/x86/mmustructs.h
@@ -25,12 +25,12 @@
 #endif
 
 /* For these we'll just use the same bits in the PTE */
-#define ARCH_DATA_PAGE_DIRTY		((uintptr_t)BIT(6))
-#define ARCH_DATA_PAGE_LOADED		((uintptr_t)BIT(0))
-#define ARCH_DATA_PAGE_ACCESSED		((uintptr_t)BIT(5))
+#define SYS_MM_VM_DATA_PAGE_DIRTY	((uintptr_t)BIT(6))
+#define SYS_MM_VM_DATA_PAGE_LOADED	((uintptr_t)BIT(0))
+#define SYS_MM_VM_DATA_PAGE_ACCESSED	((uintptr_t)BIT(5))
 
 /* Use an PAT bit for this one since it's never set in a mapped PTE */
-#define ARCH_DATA_PAGE_NOT_MAPPED	((uintptr_t)BIT(7))
+#define SYS_MM_VM_DATA_PAGE_NOT_MAPPED	((uintptr_t)BIT(7))
 
 /*
  * Special unpaged "location" tags. These are defined as the highest possible

--- a/include/zephyr/kernel/mm.h
+++ b/include/zephyr/kernel/mm.h
@@ -126,9 +126,9 @@ extern "C" {
  * addresses in that range are accessed. This is incompatible with
  * K_MEM_MAP_LOCK.
  *
- * When this flag is specified, the phys argument to arch_mem_map()
+ * When this flag is specified, the phys argument to sys_mm_vm_backend_mem_map()
  * is interpreted as a backing store location value not a physical address.
- * This is very similar to arch_mem_page_out() in that regard.
+ * This is very similar to sys_mm_vm_backend_mem_page_out() in that regard.
  * Two special location values are defined: ARCH_UNPAGED_ANON_ZERO and
  * ARCH_UNPAGED_ANON_UNINIT. Those are to be used with anonymous memory
  * mappings for zeroed and uninitialized pages respectively.

--- a/include/zephyr/mem_mgmt/system_vm/backend.h
+++ b/include/zephyr/mem_mgmt/system_vm/backend.h
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief System Virtual Memory Backend interface
+ *
+ * APIs for the system virtual memory backend which can be
+ * implemented in the architecture layer, or with a custom
+ * solution.
+ */
+
+#ifndef ZEPHYR_INCLUDE_MEM_MGMT_SYSTEM_VM_BACKEND_H_
+#define ZEPHYR_INCLUDE_MEM_MGMT_SYSTEM_VM_BACKEND_H_
+
+/**
+ * @brief Virtual Memory Backend Interface
+ * @defgroup mem_mgmt_vm_backend Virtual Memory Backend Interface
+ * @ingroup mem_mgmt
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(CONFIG_MEM_MGMT_VM_BACKEND_ARCH)
+
+/* Forward to the architecture-specific implementation. */
+#include <zephyr/mem_mgmt/system_vm/backend_arch.h>
+
+#elif defined(CONFIG_MEM_MGMT_VM_BACKEND_CUSTOM)
+
+/* Custom VM backend implementation.
+ *
+ * This header needs to be present in search path.
+ */
+#include <sys_mm_vm_backend_custom.h>
+
+#elif defined(CONFIG_MEM_MGMT_VM_BACKEND_NONE)
+
+/* No VM backend. All sys_mm_vm_backend_*() are not available. */
+
+#else
+#error "No CONFIG_MEM_MGMT_VM_BACKEND_* backend selected"
+#endif
+
+/**
+ * Map a physical memory region into the virtual address space.
+ *
+ * This is a low-level interface to mapping pages into the address space.
+ * Behavior when providing unaligned addresses/sizes is undefined, these
+ * are assumed to be aligned to CONFIG_MMU_PAGE_SIZE.
+ *
+ * Management of virtual address space is handled outside of this function.
+ * By the time this function is invoked, we know exactly where this mapping
+ * will be established. If the page tables already had mappings installed
+ * for the virtual memory region, they will be overwritten.
+ *
+ * The memory range itself is never accessed by this operation.
+ *
+ * This API must be safe to call in ISRs or exception handlers. Calls
+ * to this API are assumed to be serialized, and indeed all usage will
+ * originate from functions which handles virtual memory management.
+ *
+ * The backend must never require allocation for paging structures; page tables
+ * for the whole address space are expected to be pre-allocated.
+ *
+ * Validation of arguments should be done via assertions.
+ *
+ * @param virt Page-aligned destination virtual address to map
+ * @param phys Page-aligned source physical address to map
+ * @param size Page-aligned size of the mapped region in bytes
+ * @param flags Caching, access and control flags (see K_MEM_* macros)
+ */
+void sys_mm_vm_backend_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags);
+
+/**
+ * Remove mappings for a provided virtual address range
+ *
+ * This is a low-level interface for un-mapping pages from the address space.
+ * When this completes, the relevant page table entries will be updated as
+ * if no mapping was ever made for that memory range. No previous context
+ * needs to be preserved. This function must update mappings in all active
+ * page tables.
+ *
+ * Behavior when providing unaligned addresses/sizes is undefined, these
+ * are assumed to be aligned to CONFIG_MMU_PAGE_SIZE.
+ *
+ * Behavior when providing an address range that is not already mapped is
+ * undefined.
+ *
+ * This function should never require memory allocations for paging structures,
+ * and it is not necessary to free any paging structures. Empty page tables
+ * due to all contained entries being un-mapped may remain in place.
+ *
+ * Implementations must invalidate TLBs as necessary.
+ *
+ * @param addr Page-aligned base virtual address to un-map
+ * @param size Page-aligned region size
+ */
+void sys_mm_vm_backend_mem_unmap(void *addr, size_t size);
+
+/**
+ * Get the mapped physical memory address from virtual address.
+ *
+ * The function only needs to query the current set of page tables as
+ * the information it reports must be common to all of them if multiple
+ * page tables are in use. If multiple page tables are active it is unnecessary
+ * to iterate over all of them.
+ *
+ * Unless otherwise specified, virtual pages have the same mappings
+ * across all page tables. Calling this function on data pages that are
+ * exceptions to this rule (such as the scratch page) is undefined behavior.
+ *
+ * @param virt Page-aligned virtual address
+ * @param[out] phys Mapped physical address (can be NULL if only checking
+ *                  if virtual address is mapped)
+ *
+ * @retval 0 if mapping is found and valid
+ * @retval -EFAULT if virtual address is not mapped
+ */
+int sys_mm_vm_backend_page_phys_get(void *virt, uintptr_t *phys);
+
+/**
+ * Mark reserved page frames in the page frame database.
+ *
+ * Some page frames within system RAM are not available for use (for example
+ * reserved regions in the first megabyte on PC-like systems).
+ *
+ * Implementations of this function should mark all relevant entries in
+ * k_mem_page_frames with K_PAGE_FRAME_RESERVED. This function is called at
+ * early system initialization.
+ */
+void sys_mm_vm_backend_reserved_pages_update(void);
+
+/**
+ * Update all page tables for a paged-out data page
+ *
+ * This function:
+ * - Sets the data page virtual address to trigger a fault if accessed that
+ *   can be distinguished from access violations or un-mapped pages.
+ * - Saves the provided location value so that it can retrieved for that
+ *   data page in the page fault handler.
+ * - The location value semantics are undefined here but the value will be
+ *   always be page-aligned. It could be 0.
+ *
+ * If multiple page tables are in use, this must update all page tables.
+ * This function is called with interrupts locked.
+ *
+ * Calling this function on data pages which are already paged out is
+ * undefined behavior.
+ *
+ * @param addr Virtual data page address being evicted
+ * @param location Backing store location value to associate with the page
+ */
+void sys_mm_vm_backend_mem_page_out(void *addr, uintptr_t location);
+
+/**
+ * Update all page tables for a paged-in data page
+ *
+ * This function:
+ * - Maps the specified virtual data page address to the provided physical
+ *   page frame address, such that future memory accesses will function as
+ *   expected. Access and caching attributes are undisturbed.
+ * - Clears any accounting for "accessed" and "dirty" states.
+ *
+ * @param addr Virtual data page address being paged in
+ * @param phys Physical page frame address to map it to
+ */
+void sys_mm_vm_backend_mem_page_in(void *addr, uintptr_t phys);
+
+/**
+ * Temporarily map a physical page frame for scratch access.
+ *
+ * Map the physical page @p phys to a special virtual address
+ * K_MEM_SCRATCH_PAGE, with supervisor read/write access, such that
+ * when this function returns, the calling context can read/write the page
+ * frame's contents from the K_MEM_SCRATCH_PAGE address.
+ *
+ * This mapping only needs to be done on the current set of page tables,
+ * as it is only used for a short period of time exclusively by the caller.
+ * This function is called with interrupts locked.
+ *
+ * @param phys Physical page frame address to map at the scratch page
+ */
+void sys_mm_vm_backend_mem_scratch(uintptr_t phys);
+
+/**
+ * Fetch location information about a page at a particular address
+ *
+ * The function only needs to query the current set of page tables as
+ * the information it reports must be common to all of them if multiple
+ * page tables are in use. If multiple page tables are active it is unnecessary
+ * to iterate over all of them.
+ *
+ * This function is called with interrupts locked, so that the reported
+ * information can't become stale while decisions are being made based on it.
+ *
+ * Unless otherwise specified, virtual data pages have the same mappings
+ * across all page tables. Calling this function on data pages that are
+ * exceptions to this rule (such as the scratch page) is undefined behavior.
+ * Just check the currently installed page tables and return the information
+ * in that.
+ *
+ * @param addr Virtual data page address that took the page fault
+ * @param[out] location In the case of ARCH_PAGE_LOCATION_PAGED_OUT, the backing store
+ *                      location value used to retrieve the data page. In the case of
+ *                      ARCH_PAGE_LOCATION_PAGED_IN, the physical address the page is
+ *                      mapped to.
+ *
+ * @retval ARCH_PAGE_LOCATION_PAGED_OUT The page was evicted to the backing store
+ * @retval ARCH_PAGE_LOCATION_PAGED_IN The page is resident in memory
+ * @retval ARCH_PAGE_LOCATION_BAD The page is un-mapped or otherwise has had invalid access
+ */
+enum arch_page_location sys_mm_vm_backend_page_location_get(void *addr, uintptr_t *location);
+
+/**
+ * Retrieve page characteristics from the page table(s)
+ *
+ * The backend is responsible for maintaining "accessed" and "dirty"
+ * states of data pages to support marking eviction algorithms. This can
+ * either be directly supported by hardware or emulated by modifying
+ * protection policy to generate faults on reads or writes. In all cases
+ * the backend must maintain this information in some way.
+ *
+ * For the provided virtual address, report the logical OR of the accessed
+ * and dirty states for the relevant entries in all active page tables in
+ * the system if the page is mapped and not paged out.
+ *
+ * If @p clear_accessed is true, the ARCH_DATA_PAGE_ACCESSED flag will be reset.
+ * This function will report its prior state. If multiple page tables are in
+ * use, this function clears accessed state in all of them.
+ *
+ * This function is called with interrupts locked, so that the reported
+ * information can't become stale while decisions are being made based on it.
+ *
+ * The return value may have other bits set which the caller must ignore.
+ *
+ * Clearing accessed state for data pages that are not ARCH_DATA_PAGE_LOADED
+ * is undefined behavior.
+ *
+ * ARCH_DATA_PAGE_DIRTY and ARCH_DATA_PAGE_ACCESSED bits in the return value
+ * are only significant if ARCH_DATA_PAGE_LOADED is set, otherwise ignore
+ * them.
+ *
+ * ARCH_DATA_PAGE_NOT_MAPPED bit in the return value is only significant
+ * if ARCH_DATA_PAGE_LOADED is un-set, otherwise ignore it.
+ *
+ * Unless otherwise specified, virtual data pages have the same mappings
+ * across all page tables. Calling this function on data pages that are
+ * exceptions to this rule (such as the scratch page) is undefined behavior.
+ *
+ * @param addr Virtual address to look up in page tables
+ * @param[out] location If non-NULL, updated with either physical page frame
+ *                      address or backing store location depending on
+ *                      ARCH_DATA_PAGE_LOADED state. This is not touched if
+ *                      ARCH_DATA_PAGE_NOT_MAPPED.
+ * @param clear_accessed Whether to clear ARCH_DATA_PAGE_ACCESSED state
+ *
+ * @retval Value with ARCH_DATA_PAGE_* bits set reflecting the data page
+ *         configuration
+ */
+uintptr_t sys_mm_vm_backend_mem_page_info_get(void *addr, uintptr_t *location, bool clear_accessed);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_MEM_MGMT_SYSTEM_VM_BACKEND_H_ */

--- a/include/zephyr/mem_mgmt/system_vm/backend.h
+++ b/include/zephyr/mem_mgmt/system_vm/backend.h
@@ -27,6 +27,8 @@
 extern "C" {
 #endif
 
+#include <zephyr/mem_mgmt/system_vm/priv.h>
+
 #if defined(CONFIG_MEM_MGMT_VM_BACKEND_ARCH)
 
 /* Forward to the architecture-specific implementation. */
@@ -37,6 +39,13 @@ extern "C" {
 /* Custom VM backend implementation.
  *
  * This header needs to be present in search path.
+ *
+ * Needs to define these macros in the header file so they can be used by
+ * kernel and demand paging eviction algorithms:
+ *   SYS_MM_VM_DATA_PAGE_LOADED
+ *   SYS_MM_VM_DATA_PAGE_ACCESSED
+ *   SYS_MM_VM_DATA_PAGE_DIRTY
+ *   SYS_MM_VM_DATA_PAGE_NOT_MAPPED
  */
 #include <sys_mm_vm_backend_custom.h>
 
@@ -207,16 +216,16 @@ void sys_mm_vm_backend_mem_scratch(uintptr_t phys);
  * in that.
  *
  * @param addr Virtual data page address that took the page fault
- * @param[out] location In the case of ARCH_PAGE_LOCATION_PAGED_OUT, the backing store
+ * @param[out] location In the case of ::SYS_MM_VM_PAGE_LOCATION_PAGED_OUT, the backing store
  *                      location value used to retrieve the data page. In the case of
- *                      ARCH_PAGE_LOCATION_PAGED_IN, the physical address the page is
+ *                      ::SYS_MM_VM_PAGE_LOCATION_PAGED_IN, the physical address the page is
  *                      mapped to.
  *
- * @retval ARCH_PAGE_LOCATION_PAGED_OUT The page was evicted to the backing store
- * @retval ARCH_PAGE_LOCATION_PAGED_IN The page is resident in memory
- * @retval ARCH_PAGE_LOCATION_BAD The page is un-mapped or otherwise has had invalid access
+ * @retval SYS_MM_VM_PAGE_LOCATION_PAGED_OUT The page was evicted to the backing store
+ * @retval SYS_MM_VM_PAGE_LOCATION_PAGED_IN The page is resident in memory
+ * @retval SYS_MM_VM_PAGE_LOCATION_BAD The page is un-mapped or otherwise has had invalid access
  */
-enum arch_page_location sys_mm_vm_backend_page_location_get(void *addr, uintptr_t *location);
+enum sys_mm_vm_page_location sys_mm_vm_backend_page_location_get(void *addr, uintptr_t *location);
 
 /**
  * Retrieve page characteristics from the page table(s)
@@ -231,8 +240,8 @@ enum arch_page_location sys_mm_vm_backend_page_location_get(void *addr, uintptr_
  * and dirty states for the relevant entries in all active page tables in
  * the system if the page is mapped and not paged out.
  *
- * If @p clear_accessed is true, the ARCH_DATA_PAGE_ACCESSED flag will be reset.
- * This function will report its prior state. If multiple page tables are in
+ * If @p clear_accessed is true, the ::SYS_MM_VM_DATA_PAGE_ACCESSED flag will be
+ * reset. This function will report its prior state. If multiple page tables are in
  * use, this function clears accessed state in all of them.
  *
  * This function is called with interrupts locked, so that the reported
@@ -240,15 +249,15 @@ enum arch_page_location sys_mm_vm_backend_page_location_get(void *addr, uintptr_
  *
  * The return value may have other bits set which the caller must ignore.
  *
- * Clearing accessed state for data pages that are not ARCH_DATA_PAGE_LOADED
+ * Clearing accessed state for data pages that are not ::SYS_MM_VM_DATA_PAGE_LOADED
  * is undefined behavior.
  *
- * ARCH_DATA_PAGE_DIRTY and ARCH_DATA_PAGE_ACCESSED bits in the return value
- * are only significant if ARCH_DATA_PAGE_LOADED is set, otherwise ignore
+ * ::SYS_MM_VM_DATA_PAGE_DIRTY and ::SYS_MM_VM_DATA_PAGE_ACCESSED bits in the return
+ * value are only significant if ::SYS_MM_VM_DATA_PAGE_LOADED is set, otherwise ignore
  * them.
  *
- * ARCH_DATA_PAGE_NOT_MAPPED bit in the return value is only significant
- * if ARCH_DATA_PAGE_LOADED is un-set, otherwise ignore it.
+ * ::SYS_MM_VM_DATA_PAGE_NOT_MAPPED bit in the return value is only significant
+ * if ::SYS_MM_VM_DATA_PAGE_LOADED is un-set, otherwise ignore it.
  *
  * Unless otherwise specified, virtual data pages have the same mappings
  * across all page tables. Calling this function on data pages that are
@@ -257,11 +266,11 @@ enum arch_page_location sys_mm_vm_backend_page_location_get(void *addr, uintptr_
  * @param addr Virtual address to look up in page tables
  * @param[out] location If non-NULL, updated with either physical page frame
  *                      address or backing store location depending on
- *                      ARCH_DATA_PAGE_LOADED state. This is not touched if
- *                      ARCH_DATA_PAGE_NOT_MAPPED.
- * @param clear_accessed Whether to clear ARCH_DATA_PAGE_ACCESSED state
+ *                      ::SYS_MM_VM_DATA_PAGE_LOADED state. This is not touched if
+ *                      ::SYS_MM_VM_DATA_PAGE_NOT_MAPPED.
+ * @param clear_accessed Whether to clear ::SYS_MM_VM_DATA_PAGE_ACCESSED state
  *
- * @retval Value with ARCH_DATA_PAGE_* bits set reflecting the data page
+ * @retval Value with SYS_MM_VM_DATA_PAGE_* bits set reflecting the data page
  *         configuration
  */
 uintptr_t sys_mm_vm_backend_mem_page_info_get(void *addr, uintptr_t *location, bool clear_accessed);

--- a/include/zephyr/mem_mgmt/system_vm/backend.h
+++ b/include/zephyr/mem_mgmt/system_vm/backend.h
@@ -84,8 +84,13 @@ extern "C" {
  * @param phys Page-aligned source physical address to map
  * @param size Page-aligned size of the mapped region in bytes
  * @param flags Caching, access and control flags (see K_MEM_* macros)
+ *
+ * @retval 0 Successfully mapped memory
+ * @retval -EINVAL Invalid arguments
+ * @retval -ENOMEM  Not enough memory to perform memory mapping
+ * @retval -ENOTSUP Memory mapping is not supported
  */
-void sys_mm_vm_backend_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags);
+int sys_mm_vm_backend_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags);
 
 /**
  * Remove mappings for a provided virtual address range
@@ -110,8 +115,12 @@ void sys_mm_vm_backend_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t
  *
  * @param addr Page-aligned base virtual address to un-map
  * @param size Page-aligned region size
+ *
+ * @retval 0 Successfully unmapped memory
+ * @retval -EINVAL Invalid arguments
+ * @retval -ENOTSUP Memory unmapping is not supported
  */
-void sys_mm_vm_backend_mem_unmap(void *addr, size_t size);
+int sys_mm_vm_backend_mem_unmap(void *addr, size_t size);
 
 /**
  * Get the mapped physical memory address from virtual address.

--- a/include/zephyr/mem_mgmt/system_vm/backend.h
+++ b/include/zephyr/mem_mgmt/system_vm/backend.h
@@ -174,8 +174,13 @@ void sys_mm_vm_backend_reserved_pages_update(void);
  *
  * @param addr Virtual data page address being evicted
  * @param location Backing store location value to associate with the page
+ *
+ * @retval 0 Successfully paging out memory
+ * @retval -EFAULT Fail to page out memory
+ * @retval -EINVAL Invalid arguments
+ * @retval -ENOTSUP Paging out is not supported
  */
-void sys_mm_vm_backend_mem_page_out(void *addr, uintptr_t location);
+int sys_mm_vm_backend_mem_page_out(void *addr, uintptr_t location);
 
 /**
  * Update all page tables for a paged-in data page
@@ -188,8 +193,13 @@ void sys_mm_vm_backend_mem_page_out(void *addr, uintptr_t location);
  *
  * @param addr Virtual data page address being paged in
  * @param phys Physical page frame address to map it to
+ *
+ * @retval 0 Successfully paging in memory
+ * @retval -EFAULT Fail to page in memory
+ * @retval -EINVAL Invalid arguments
+ * @retval -ENOTSUP Paging in is not supported
  */
-void sys_mm_vm_backend_mem_page_in(void *addr, uintptr_t phys);
+int sys_mm_vm_backend_mem_page_in(void *addr, uintptr_t phys);
 
 /**
  * Temporarily map a physical page frame for scratch access.

--- a/include/zephyr/mem_mgmt/system_vm/backend_arch.h
+++ b/include/zephyr/mem_mgmt/system_vm/backend_arch.h
@@ -29,22 +29,12 @@ extern "C" {
 static ALWAYS_INLINE int sys_mm_vm_backend_mem_map(void *virt, uintptr_t phys, size_t size,
 						   uint32_t flags)
 {
-	arch_mem_map(virt, phys, size, flags);
-
-	/* arch_mem_map() would cause kernel panic if fails to map.
-	 * If we get here, mapping is successful.
-	 */
-	return 0;
+	return arch_mem_map(virt, phys, size, flags);
 }
 
 static ALWAYS_INLINE int sys_mm_vm_backend_mem_unmap(void *addr, size_t size)
 {
-	arch_mem_unmap(addr, size);
-
-	/* arch_mem_unmap() would cause kernel panic if fails to unmap.
-	 * If we get here, unmapping is successful.
-	 */
-	return 0;
+	return arch_mem_unmap(addr, size);
 }
 
 static ALWAYS_INLINE int sys_mm_vm_backend_page_phys_get(void *virt, uintptr_t *phys)

--- a/include/zephyr/mem_mgmt/system_vm/backend_arch.h
+++ b/include/zephyr/mem_mgmt/system_vm/backend_arch.h
@@ -26,15 +26,25 @@ extern "C" {
 
 /** @cond INTERNAL_HIDDEN */
 
-static ALWAYS_INLINE void sys_mm_vm_backend_mem_map(void *virt, uintptr_t phys, size_t size,
-						    uint32_t flags)
+static ALWAYS_INLINE int sys_mm_vm_backend_mem_map(void *virt, uintptr_t phys, size_t size,
+						   uint32_t flags)
 {
 	arch_mem_map(virt, phys, size, flags);
+
+	/* arch_mem_map() would cause kernel panic if fails to map.
+	 * If we get here, mapping is successful.
+	 */
+	return 0;
 }
 
-static ALWAYS_INLINE void sys_mm_vm_backend_mem_unmap(void *addr, size_t size)
+static ALWAYS_INLINE int sys_mm_vm_backend_mem_unmap(void *addr, size_t size)
 {
 	arch_mem_unmap(addr, size);
+
+	/* arch_mem_unmap() would cause kernel panic if fails to unmap.
+	 * If we get here, unmapping is successful.
+	 */
+	return 0;
 }
 
 static ALWAYS_INLINE int sys_mm_vm_backend_page_phys_get(void *virt, uintptr_t *phys)

--- a/include/zephyr/mem_mgmt/system_vm/backend_arch.h
+++ b/include/zephyr/mem_mgmt/system_vm/backend_arch.h
@@ -49,16 +49,12 @@ static ALWAYS_INLINE void sys_mm_vm_backend_reserved_pages_update(void)
 
 static ALWAYS_INLINE int sys_mm_vm_backend_mem_page_out(void *addr, uintptr_t location)
 {
-	arch_mem_page_out(addr, location);
-
-	return 0;
+	return arch_mem_page_out(addr, location);
 }
 
 static ALWAYS_INLINE int sys_mm_vm_backend_mem_page_in(void *addr, uintptr_t phys)
 {
-	arch_mem_page_in(addr, phys);
-
-	return 0;
+	return arch_mem_page_in(addr, phys);
 }
 
 static ALWAYS_INLINE void sys_mm_vm_backend_mem_scratch(uintptr_t phys)

--- a/include/zephyr/mem_mgmt/system_vm/backend_arch.h
+++ b/include/zephyr/mem_mgmt/system_vm/backend_arch.h
@@ -47,14 +47,18 @@ static ALWAYS_INLINE void sys_mm_vm_backend_reserved_pages_update(void)
 	arch_reserved_pages_update();
 }
 
-static ALWAYS_INLINE void sys_mm_vm_backend_mem_page_out(void *addr, uintptr_t location)
+static ALWAYS_INLINE int sys_mm_vm_backend_mem_page_out(void *addr, uintptr_t location)
 {
 	arch_mem_page_out(addr, location);
+
+	return 0;
 }
 
-static ALWAYS_INLINE void sys_mm_vm_backend_mem_page_in(void *addr, uintptr_t phys)
+static ALWAYS_INLINE int sys_mm_vm_backend_mem_page_in(void *addr, uintptr_t phys)
 {
 	arch_mem_page_in(addr, phys);
+
+	return 0;
 }
 
 static ALWAYS_INLINE void sys_mm_vm_backend_mem_scratch(uintptr_t phys)

--- a/include/zephyr/mem_mgmt/system_vm/backend_arch.h
+++ b/include/zephyr/mem_mgmt/system_vm/backend_arch.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Architecture backend for the low-level virtual memory operations.
+ *
+ * This backend forwards every low-level virtual memory operation to the
+ * architecture-specific arch_mem_*() implementation.
+ */
+
+#ifndef ZEPHYR_INCLUDE_MEM_MGMT_SYSTEM_VM_BACKEND_ARCH_H_
+#define ZEPHYR_INCLUDE_MEM_MGMT_SYSTEM_VM_BACKEND_ARCH_H_
+
+#include <zephyr/toolchain.h>
+#include <kernel_arch_interface.h>
+
+#ifndef _ASMLANGUAGE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+
+static ALWAYS_INLINE void sys_mm_vm_backend_mem_map(void *virt, uintptr_t phys, size_t size,
+						    uint32_t flags)
+{
+	arch_mem_map(virt, phys, size, flags);
+}
+
+static ALWAYS_INLINE void sys_mm_vm_backend_mem_unmap(void *addr, size_t size)
+{
+	arch_mem_unmap(addr, size);
+}
+
+static ALWAYS_INLINE int sys_mm_vm_backend_page_phys_get(void *virt, uintptr_t *phys)
+{
+	return arch_page_phys_get(virt, phys);
+}
+
+static ALWAYS_INLINE void sys_mm_vm_backend_reserved_pages_update(void)
+{
+	arch_reserved_pages_update();
+}
+
+static ALWAYS_INLINE void sys_mm_vm_backend_mem_page_out(void *addr, uintptr_t location)
+{
+	arch_mem_page_out(addr, location);
+}
+
+static ALWAYS_INLINE void sys_mm_vm_backend_mem_page_in(void *addr, uintptr_t phys)
+{
+	arch_mem_page_in(addr, phys);
+}
+
+static ALWAYS_INLINE void sys_mm_vm_backend_mem_scratch(uintptr_t phys)
+{
+	arch_mem_scratch(phys);
+}
+
+static ALWAYS_INLINE enum arch_page_location
+sys_mm_vm_backend_page_location_get(void *addr, uintptr_t *location)
+{
+	return arch_page_location_get(addr, location);
+}
+
+static ALWAYS_INLINE uintptr_t sys_mm_vm_backend_mem_page_info_get(void *addr, uintptr_t *location,
+								   bool clear_accessed)
+{
+	return arch_page_info_get(addr, location, clear_accessed);
+}
+
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_MEM_MGMT_SYSTEM_VM_BACKEND_ARCH_H_ */

--- a/include/zephyr/mem_mgmt/system_vm/backend_arch.h
+++ b/include/zephyr/mem_mgmt/system_vm/backend_arch.h
@@ -62,7 +62,7 @@ static ALWAYS_INLINE void sys_mm_vm_backend_mem_scratch(uintptr_t phys)
 	arch_mem_scratch(phys);
 }
 
-static ALWAYS_INLINE enum arch_page_location
+static ALWAYS_INLINE enum sys_mm_vm_page_location
 sys_mm_vm_backend_page_location_get(void *addr, uintptr_t *location)
 {
 	return arch_page_location_get(addr, location);

--- a/include/zephyr/mem_mgmt/system_vm/priv.h
+++ b/include/zephyr/mem_mgmt/system_vm/priv.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Private definitions for the low-level virtual memory management layer.
+ *
+ * What defined here should only be used in kernel, drivers or subsystems to
+ * allow managing virtual memory, and should not be used in application.
+ */
+
+#ifndef ZEPHYR_INCLUDE_MEM_MGMT_VM_PRIV_H_
+#define ZEPHYR_INCLUDE_MEM_MGMT_VM_PRIV_H_
+
+#ifndef _ASMLANGUAGE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @ingroup mem_mgmt_vm_backend
+ * @{
+ */
+
+/**
+ * Status of a particular page location.
+ */
+enum sys_mm_vm_page_location {
+	/** The page has been evicted to the backing store. */
+	SYS_MM_VM_PAGE_LOCATION_PAGED_OUT,
+
+	/** The page is resident in memory. */
+	SYS_MM_VM_PAGE_LOCATION_PAGED_IN,
+
+	/** The page is not mapped. */
+	SYS_MM_VM_PAGE_LOCATION_BAD
+};
+
+/**
+ * @def SYS_MM_VM_DATA_PAGE_ACCESSED
+ *
+ * Bit indicating the data page was accessed since the value was last cleared.
+ *
+ * Used by marking eviction algorithms. Safe to set this if uncertain.
+ *
+ * This bit is undefined if SYS_MM_VM_DATA_PAGE_LOADED is not set.
+ *
+ * The actual bit value is provided by the backend.
+ */
+#ifdef __DOXYGEN__
+#define SYS_MM_VM_DATA_PAGE_ACCESSED
+#endif
+
+/**
+ * @def SYS_MM_VM_DATA_PAGE_DIRTY
+ *
+ * Bit indicating the data page, if evicted, will need to be paged out.
+ *
+ * Set if the data page was modified since it was last paged out, or if
+ * it has never been paged out before. Safe to set this if uncertain.
+ *
+ * This bit is undefined if SYS_MM_VM_DATA_PAGE_LOADED is not set.
+ *
+ * The actual bit value is provided by the backend.
+ */
+#ifdef __DOXYGEN__
+#define SYS_MM_VM_DATA_PAGE_DIRTY
+#endif
+
+/**
+ * @def SYS_MM_VM_DATA_PAGE_LOADED
+ *
+ * Bit indicating that the data page is loaded into a physical page frame.
+ *
+ * If un-set, the data page is paged out or not mapped.
+ *
+ * The actual bit value is provided by the backend.
+ */
+#ifdef __DOXYGEN__
+#define SYS_MM_VM_DATA_PAGE_LOADED
+#endif
+
+/**
+ * @def SYS_MM_VM_DATA_PAGE_NOT_MAPPED
+ *
+ * If SYS_MM_VM_DATA_PAGE_LOADED is un-set, this will indicate that the page
+ * is not mapped at all. This bit is undefined if SYS_MM_VM_DATA_PAGE_LOADED
+ * is set.
+ *
+ * The actual bit value is provided by the backend.
+ */
+#ifdef __DOXYGEN__
+#define SYS_MM_VM_DATA_PAGE_NOT_MAPPED
+#endif
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_MEM_MGMT_VM_PRIV_H_ */

--- a/kernel/Kconfig.vm
+++ b/kernel/Kconfig.vm
@@ -106,7 +106,7 @@ config MMU
 	select KERNEL_VM_SUPPORT
 	help
 	  This option is enabled when the CPU's memory management unit is active
-	  and the arch_mem_map() API is available.
+	  and the sys_mm_vm_backend_mem_map() API is available.
 
 if MMU
 config MMU_PAGE_SIZE

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -330,8 +330,10 @@ static inline bool arch_is_in_isr(void);
  * @param phys Page-aligned Source physical address to map
  * @param size Page-aligned size of the mapped memory region in bytes
  * @param flags Caching, access and control flags, see K_MAP_* macros
+ *
+ * @return 0 on success, negative errno code on fail
  */
-void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags);
+int arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags);
 
 /**
  * Remove mappings for a provided virtual address range
@@ -358,8 +360,10 @@ void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags);
  *
  * @param addr Page-aligned base virtual address to un-map
  * @param size Page-aligned region size
+ *
+ * @return 0 on success, negative errno code on fail
  */
-void arch_mem_unmap(void *addr, size_t size);
+int arch_mem_unmap(void *addr, size_t size);
 
 /**
  * Get the mapped physical memory address from virtual address.

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -19,6 +19,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/arch/arch_interface.h>
+#include <zephyr/mem_mgmt/system_vm/priv.h>
 
 #ifndef _ASMLANGUAGE
 
@@ -452,20 +453,6 @@ void arch_mem_page_in(void *addr, uintptr_t phys);
 void arch_mem_scratch(uintptr_t phys);
 
 /**
- * Status of a particular page location.
- */
-enum arch_page_location {
-	/** The page has been evicted to the backing store. */
-	ARCH_PAGE_LOCATION_PAGED_OUT,
-
-	/** The page is resident in memory. */
-	ARCH_PAGE_LOCATION_PAGED_IN,
-
-	/** The page is not mapped. */
-	ARCH_PAGE_LOCATION_BAD
-};
-
-/**
  * Fetch location information about a page at a particular address
  *
  * The function only needs to query the current set of page tables as
@@ -484,63 +471,15 @@ enum arch_page_location {
  * in that.
  *
  * @param addr Virtual data page address that took the page fault
- * @param [out] location In the case of ARCH_PAGE_LOCATION_PAGED_OUT, the backing
+ * @param [out] location In the case of ::SYS_MM_VM_PAGE_LOCATION_PAGED_OUT, the backing
  *        store location value used to retrieve the data page. In the case of
- *        ARCH_PAGE_LOCATION_PAGED_IN, the physical address the page is mapped to.
- * @retval ARCH_PAGE_LOCATION_PAGED_OUT The page was evicted to the backing store.
- * @retval ARCH_PAGE_LOCATION_PAGED_IN The data page is resident in memory.
- * @retval ARCH_PAGE_LOCATION_BAD The page is un-mapped or otherwise has had
+ *        ::SYS_MM_VM_PAGE_LOCATION_PAGED_IN, the physical address the page is mapped to.
+ * @retval SYS_MM_VM_PAGE_LOCATION_PAGED_OUT The page was evicted to the backing store.
+ * @retval SYS_MM_VM_PAGE_LOCATION_PAGED_IN The data page is resident in memory.
+ * @retval SYS_MM_VM_PAGE_LOCATION_BAD The page is un-mapped or otherwise has had
  *         invalid access
  */
-enum arch_page_location arch_page_location_get(void *addr, uintptr_t *location);
-
-/**
- * @def ARCH_DATA_PAGE_ACCESSED
- *
- * Bit indicating the data page was accessed since the value was last cleared.
- *
- * Used by marking eviction algorithms. Safe to set this if uncertain.
- *
- * This bit is undefined if ARCH_DATA_PAGE_LOADED is not set.
- */
-#ifdef __DOXYGEN__
-#define ARCH_DATA_PAGE_ACCESSED
-#endif
-
- /**
-  * @def ARCH_DATA_PAGE_DIRTY
-  *
-  * Bit indicating the data page, if evicted, will need to be paged out.
-  *
-  * Set if the data page was modified since it was last paged out, or if
-  * it has never been paged out before. Safe to set this if uncertain.
-  *
-  * This bit is undefined if ARCH_DATA_PAGE_LOADED is not set.
-  */
-#ifdef __DOXYGEN__
-#define ARCH_DATA_PAGE_DIRTY
-#endif
-
- /**
-  * @def ARCH_DATA_PAGE_LOADED
-  *
-  * Bit indicating that the data page is loaded into a physical page frame.
-  *
-  * If un-set, the data page is paged out or not mapped.
-  */
-#ifdef __DOXYGEN__
-#define ARCH_DATA_PAGE_LOADED
-#endif
-
-/**
- * @def ARCH_DATA_PAGE_NOT_MAPPED
- *
- * If ARCH_DATA_PAGE_LOADED is un-set, this will indicate that the page
- * is not mapped at all. This bit is undefined if ARCH_DATA_PAGE_LOADED is set.
- */
-#ifdef __DOXYGEN__
-#define ARCH_DATA_PAGE_NOT_MAPPED
-#endif
+enum sys_mm_vm_page_location arch_page_location_get(void *addr, uintptr_t *location);
 
 /**
  * Retrieve page characteristics from the page table(s)
@@ -555,7 +494,7 @@ enum arch_page_location arch_page_location_get(void *addr, uintptr_t *location);
  * and dirty states for the relevant entries in all active page tables in
  * the system if the page is mapped and not paged out.
  *
- * If clear_accessed is true, the ARCH_DATA_PAGE_ACCESSED flag will be reset.
+ * If clear_accessed is true, the ::SYS_MM_VM_DATA_PAGE_ACCESSED flag will be reset.
  * This function will report its prior state. If multiple page tables are in
  * use, this function clears accessed state in all of them.
  *
@@ -564,15 +503,15 @@ enum arch_page_location arch_page_location_get(void *addr, uintptr_t *location);
  *
  * The return value may have other bits set which the caller must ignore.
  *
- * Clearing accessed state for data pages that are not ARCH_DATA_PAGE_LOADED
+ * Clearing accessed state for data pages that are not ::SYS_MM_VM_DATA_PAGE_LOADED
  * is undefined behavior.
  *
- * ARCH_DATA_PAGE_DIRTY and ARCH_DATA_PAGE_ACCESSED bits in the return value
- * are only significant if ARCH_DATA_PAGE_LOADED is set, otherwise ignore
+ * ::SYS_MM_VM_DATA_PAGE_DIRTY and ::SYS_MM_VM_DATA_PAGE_ACCESSED bits in the return value
+ * are only significant if ::SYS_MM_VM_DATA_PAGE_LOADED is set, otherwise ignore
  * them.
  *
- * ARCH_DATA_PAGE_NOT_MAPPED bit in the return value is only significant
- * if ARCH_DATA_PAGE_LOADED is un-set, otherwise ignore it.
+ * ::SYS_MM_VM_DATA_PAGE_NOT_MAPPED bit in the return value is only significant
+ * if ::SYS_MM_VM_DATA_PAGE_LOADED is un-set, otherwise ignore it.
  *
  * Unless otherwise specified, virtual data pages have the same mappings
  * across all page tables. Calling this function on data pages that are
@@ -583,10 +522,10 @@ enum arch_page_location arch_page_location_get(void *addr, uintptr_t *location);
  * @param addr Virtual address to look up in page tables
  * @param [out] location If non-NULL, updated with either physical page frame
  *                   address or backing store location depending on
- *                   ARCH_DATA_PAGE_LOADED state. This is not touched if
- *                   ARCH_DATA_PAGE_NOT_MAPPED.
- * @param clear_accessed Whether to clear ARCH_DATA_PAGE_ACCESSED state
- * @retval Value with ARCH_DATA_PAGE_* bits set reflecting the data page
+ *                   ::SYS_MM_VM_DATA_PAGE_LOADED state. This is not touched if
+ *                   ::SYS_MM_VM_DATA_PAGE_NOT_MAPPED.
+ * @param clear_accessed Whether to clear ::SYS_MM_VM_DATA_PAGE_ACCESSED state
+ * @retval Value with SYS_MM_VM_DATA_PAGE_* bits set reflecting the data page
  *         configuration
  */
 uintptr_t arch_page_info_get(void *addr, uintptr_t *location,

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -418,8 +418,10 @@ void arch_reserved_pages_update(void);
  * undefined behavior.
  *
  * This API is part of infrastructure still under development and may change.
+ *
+ * @return 0 on success, negative errno code on fail
  */
-void arch_mem_page_out(void *addr, uintptr_t location);
+int arch_mem_page_out(void *addr, uintptr_t location);
 
 /**
  * Update all page tables for a paged-in data page
@@ -437,8 +439,10 @@ void arch_mem_page_out(void *addr, uintptr_t location);
  * undefined behavior.
  *
  * This API is part of infrastructure still under development and may change.
+ *
+ * @return 0 on success, negative errno code on fail
  */
-void arch_mem_page_in(void *addr, uintptr_t phys);
+int arch_mem_page_in(void *addr, uintptr_t phys);
 
 /**
  * Update current page tables for a temporary mapping

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -576,6 +576,7 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 	k_spinlock_key_t key;
 	uint8_t *pos;
 	bool uninit = (flags & K_MEM_MAP_UNINIT) != 0U;
+	uint8_t *failed_unmap_from, *failed_unmap_to;
 
 	__ASSERT(!is_anon || (is_anon && page_frames_initialized),
 		 "%s called too early", __func__);
@@ -644,13 +645,9 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 				ret = map_anon_page(pos, flags);
 
 				if (ret != 0) {
-					/* TODO:
-					 * call k_mem_unmap(dst, pos - dst)
-					 * when implemented in #28990 and
-					 * release any guard virtual page as well.
-					 */
-					dst = NULL;
-					goto out;
+					failed_unmap_from = dst;
+					failed_unmap_to = pos;
+					goto fail_need_unmap;
 				}
 			}
 		}
@@ -675,6 +672,14 @@ out:
 	}
 
 	return dst;
+
+fail_need_unmap:
+	/* Need to unmap already mappped pages if we encounter any errors. */
+	arch_mem_unmap(failed_unmap_from, failed_unmap_to - failed_unmap_from);
+
+	k_spin_unlock(&z_mm_lock, key);
+
+	return NULL;
 }
 
 void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -525,13 +525,13 @@ static int map_anon_page(void *addr, uint32_t flags)
 	struct k_mem_page_frame *pf;
 	uintptr_t phys;
 	bool lock = (flags & K_MEM_MAP_LOCK) != 0U;
+	int ret;
 
 	pf = free_page_frame_list_get();
 	if (pf == NULL) {
 #ifdef CONFIG_DEMAND_PAGING
 		uintptr_t location;
 		bool dirty;
-		int ret;
 
 		pf = k_mem_paging_eviction_select(&dirty);
 		__ASSERT(pf != NULL, "failed to get a page frame");
@@ -540,19 +540,25 @@ static int map_anon_page(void *addr, uint32_t flags)
 			k_mem_page_frame_to_phys(pf));
 		ret = page_frame_prepare_locked(pf, &dirty, false, &location);
 		if (ret != 0) {
-			return -ENOMEM;
+			ret = -ENOMEM;
+			goto out;
 		}
 		if (dirty) {
 			do_backing_store_page_out(location);
 		}
 		pf->va_and_flags = 0;
 #else
-		return -ENOMEM;
+		ret = -ENOMEM;
+		goto out;
 #endif /* CONFIG_DEMAND_PAGING */
 	}
 
 	phys = k_mem_page_frame_to_phys(pf);
-	sys_mm_vm_backend_mem_map(addr, phys, CONFIG_MMU_PAGE_SIZE, flags);
+	ret = sys_mm_vm_backend_mem_map(addr, phys, CONFIG_MMU_PAGE_SIZE, flags);
+	if (ret != 0) {
+		free_page_frame_list_put(pf);
+		goto out;
+	}
 
 	if (lock) {
 		k_mem_page_frame_set(pf, K_MEM_PAGE_FRAME_PINNED);
@@ -566,7 +572,121 @@ static int map_anon_page(void *addr, uint32_t flags)
 
 	LOG_DBG("memory mapping anon page %p -> 0x%lx", addr, phys);
 
-	return 0;
+out:
+	return ret;
+}
+
+static int unmap_region(void *addr, size_t size, bool is_anon)
+{
+	uintptr_t phys;
+	uint8_t *pos;
+	struct k_mem_page_frame *pf;
+	int ret = -EINVAL;
+
+	if (is_anon) {
+		/* Unmapping anonymous memory */
+		VIRT_FOREACH(addr, size, pos) {
+#ifdef CONFIG_DEMAND_PAGING
+			enum sys_mm_vm_page_location status;
+			uintptr_t location;
+
+			status = sys_mm_vm_backend_page_location_get(pos, &location);
+			switch (status) {
+			case SYS_MM_VM_PAGE_LOCATION_PAGED_OUT:
+				/*
+				 * No pf is associated with this mapping.
+				 * Simply get rid of the MMU entry and free
+				 * corresponding backing store.
+				 */
+				ret = sys_mm_vm_backend_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
+				k_mem_paging_backing_store_location_free(location);
+				continue;
+			case SYS_MM_VM_PAGE_LOCATION_PAGED_IN:
+				/*
+				 * The page is in memory but it may not be
+				 * accessible in order to manage tracking
+				 * of the SYS_MM_VM_DATA_PAGE_ACCESSED flag
+				 * meaning sys_mm_vm_backend_page_phys_get() could fail.
+				 * Still, we know the actual phys address.
+				 */
+				phys = location;
+				ret = 0;
+				break;
+			default:
+				ret = sys_mm_vm_backend_page_phys_get(pos, &phys);
+				break;
+			}
+#else
+			ret = sys_mm_vm_backend_page_phys_get(pos, &phys);
+#endif
+			__ASSERT(ret == 0,
+				 "%s: cannot unmap an unmapped address %p",
+				 __func__, pos);
+			if (ret != 0) {
+				/* Found an address not mapped. Do not continue. */
+				ret = -EFAULT;
+				goto out;
+			}
+
+			__ASSERT(k_mem_is_page_frame(phys),
+				 "%s: 0x%lx is not a page frame", __func__, phys);
+			if (!k_mem_is_page_frame(phys)) {
+				/* Physical address has no corresponding page frame
+				 * description in the page frame array.
+				 * This should not happen. Do not continue.
+				 */
+				ret = -EFAULT;
+				goto out;
+			}
+
+			/* Grab the corresponding page frame from physical address */
+			pf = k_mem_phys_to_page_frame(phys);
+
+			__ASSERT(k_mem_page_frame_is_mapped(pf),
+				 "%s: 0x%lx is not a mapped page frame", __func__, phys);
+			if (!k_mem_page_frame_is_mapped(pf)) {
+				/* Page frame is not marked mapped.
+				 * This should not happen. Do not continue.
+				 */
+				ret = -EFAULT;
+				goto out;
+			}
+
+			ret = sys_mm_vm_backend_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
+			__ASSERT(ret == 0, "%s: cannot unmap an unmapped address %p", __func__,
+				 pos);
+			if (ret != 0) {
+				/* Fail to unmap. Do not continue. */
+				goto out;
+			}
+#ifdef CONFIG_DEMAND_PAGING
+			if (IS_ENABLED(CONFIG_EVICTION_TRACKING) &&
+			    (!k_mem_page_frame_is_pinned(pf))) {
+				k_mem_paging_eviction_remove(pf);
+			}
+#endif
+
+			/* Put the page frame back into free list */
+			page_frame_free_locked(pf);
+		}
+	} else {
+		/*
+		 * Unmapping previous mapped memory with specific physical address.
+		 *
+		 * Note that we don't have to unmap the guard pages, as they should
+		 * have been unmapped. We just need to unmapped the in-between
+		 * region [addr, (addr + size)).
+		 */
+		ret = sys_mm_vm_backend_mem_unmap(addr, size);
+		__ASSERT(ret == 0, "%s: cannot unmap an mapped address %p", __func__, addr);
+		if (ret != 0) {
+			/* Fail to unmap. Do not continue. */
+			goto out;
+		}
+	}
+
+out:
+	return ret;
 }
 
 void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_anon)
@@ -617,8 +737,19 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 	/* Unmap both guard pages to make sure accessing them
 	 * will generate fault.
 	 */
-	sys_mm_vm_backend_mem_unmap(dst, CONFIG_MMU_PAGE_SIZE);
-	sys_mm_vm_backend_mem_unmap(dst + CONFIG_MMU_PAGE_SIZE + size, CONFIG_MMU_PAGE_SIZE);
+	ret = sys_mm_vm_backend_mem_unmap(dst, CONFIG_MMU_PAGE_SIZE);
+	__ASSERT(ret == 0, "%s: cannot unmap %p", __func__, dst);
+	if (ret != 0) {
+		dst = NULL;
+		goto out;
+	}
+
+	ret = sys_mm_vm_backend_mem_unmap(dst + CONFIG_MMU_PAGE_SIZE + size, CONFIG_MMU_PAGE_SIZE);
+	__ASSERT(ret == 0, "%s: cannot unmap %p", __func__, dst + CONFIG_MMU_PAGE_SIZE + size);
+	if (ret != 0) {
+		dst = NULL;
+		goto out;
+	}
 
 	/* Skip over the "before" guard page in returned address. */
 	dst += CONFIG_MMU_PAGE_SIZE;
@@ -630,10 +761,16 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 		if ((flags & K_MEM_MAP_LOCK) == 0) {
 			flags |= K_MEM_MAP_UNPAGED;
 			VIRT_FOREACH(dst, size, pos) {
-				sys_mm_vm_backend_mem_map(pos,
-							  uninit ? ARCH_UNPAGED_ANON_UNINIT
-								 : ARCH_UNPAGED_ANON_ZERO,
-							  CONFIG_MMU_PAGE_SIZE, flags);
+				ret = sys_mm_vm_backend_mem_map(pos,
+								uninit ? ARCH_UNPAGED_ANON_UNINIT
+								       : ARCH_UNPAGED_ANON_ZERO,
+								CONFIG_MMU_PAGE_SIZE, flags);
+
+				if (ret != 0) {
+					failed_unmap_from = dst;
+					failed_unmap_to = pos;
+					goto fail_need_unmap;
+				}
 			}
 			LOG_DBG("memory mapping anon pages %p to %p unpaged", dst, pos-1);
 			/* skip the memset() below */
@@ -652,13 +789,13 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 			}
 		}
 	} else {
-		/* Mapping known physical memory.
-		 *
-		 * sys_mm_vm_backend_mem_map() is a void function and does not return
-		 * anything. Arch code usually uses ASSERT() to catch
-		 * mapping errors. Assume this works correctly for now.
-		 */
-		sys_mm_vm_backend_mem_map(dst, phys, size, flags);
+		/* Mapping known physical memory. */
+		ret = sys_mm_vm_backend_mem_map(dst, phys, size, flags);
+
+		if (ret != 0) {
+			dst = NULL;
+			goto out;
+		}
 	}
 
 out:
@@ -675,7 +812,9 @@ out:
 
 fail_need_unmap:
 	/* Need to unmap already mappped pages if we encounter any errors. */
-	sys_mm_vm_backend_mem_unmap(failed_unmap_from, failed_unmap_to - failed_unmap_from);
+	ret = unmap_region(failed_unmap_from, failed_unmap_to - failed_unmap_from, is_anon);
+	__ASSERT_NO_MSG(ret == 0);
+	ARG_UNUSED(ret);
 
 	k_spin_unlock(&z_mm_lock, key);
 
@@ -684,9 +823,7 @@ fail_need_unmap:
 
 void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 {
-	uintptr_t phys;
 	uint8_t *pos;
-	struct k_mem_page_frame *pf;
 	k_spinlock_key_t key;
 	size_t total_size;
 	int ret;
@@ -723,93 +860,9 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 		goto out;
 	}
 
-	if (is_anon) {
-		/* Unmapping anonymous memory */
-		VIRT_FOREACH(addr, size, pos) {
-#ifdef CONFIG_DEMAND_PAGING
-			enum sys_mm_vm_page_location status;
-			uintptr_t location;
-
-			status = sys_mm_vm_backend_page_location_get(pos, &location);
-			switch (status) {
-			case SYS_MM_VM_PAGE_LOCATION_PAGED_OUT:
-				/*
-				 * No pf is associated with this mapping.
-				 * Simply get rid of the MMU entry and free
-				 * corresponding backing store.
-				 */
-				sys_mm_vm_backend_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
-				k_mem_paging_backing_store_location_free(location);
-				continue;
-			case SYS_MM_VM_PAGE_LOCATION_PAGED_IN:
-				/*
-				 * The page is in memory but it may not be
-				 * accessible in order to manage tracking
-				 * of the SYS_MM_VM_DATA_PAGE_ACCESSED flag
-				 * meaning sys_mm_vm_backend_page_phys_get() could fail.
-				 * Still, we know the actual phys address.
-				 */
-				phys = location;
-				ret = 0;
-				break;
-			default:
-				ret = sys_mm_vm_backend_page_phys_get(pos, &phys);
-				break;
-			}
-#else
-			ret = sys_mm_vm_backend_page_phys_get(pos, &phys);
-#endif
-			__ASSERT(ret == 0,
-				 "%s: cannot unmap an unmapped address %p",
-				 __func__, pos);
-			if (ret != 0) {
-				/* Found an address not mapped. Do not continue. */
-				goto out;
-			}
-
-			__ASSERT(k_mem_is_page_frame(phys),
-				 "%s: 0x%lx is not a page frame", __func__, phys);
-			if (!k_mem_is_page_frame(phys)) {
-				/* Physical address has no corresponding page frame
-				 * description in the page frame array.
-				 * This should not happen. Do not continue.
-				 */
-				goto out;
-			}
-
-			/* Grab the corresponding page frame from physical address */
-			pf = k_mem_phys_to_page_frame(phys);
-
-			__ASSERT(k_mem_page_frame_is_mapped(pf),
-				 "%s: 0x%lx is not a mapped page frame", __func__, phys);
-			if (!k_mem_page_frame_is_mapped(pf)) {
-				/* Page frame is not marked mapped.
-				 * This should not happen. Do not continue.
-				 */
-				goto out;
-			}
-
-			sys_mm_vm_backend_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
-#ifdef CONFIG_DEMAND_PAGING
-			if (IS_ENABLED(CONFIG_EVICTION_TRACKING) &&
-			    (!k_mem_page_frame_is_pinned(pf))) {
-				k_mem_paging_eviction_remove(pf);
-			}
-#endif
-
-			/* Put the page frame back into free list */
-			page_frame_free_locked(pf);
-		}
-	} else {
-		/*
-		 * Unmapping previous mapped memory with specific physical address.
-		 *
-		 * Note that we don't have to unmap the guard pages, as they should
-		 * have been unmapped. We just need to unmapped the in-between
-		 * region [addr, (addr + size)).
-		 */
-		sys_mm_vm_backend_mem_unmap(addr, size);
-	}
+	ret = unmap_region(addr, size, is_anon);
+	__ASSERT_NO_MSG(ret == 0);
+	ARG_UNUSED(ret);
 
 	/* There are guard pages just before and after the mapped
 	 * region. So we also need to free them from the bitmap.
@@ -844,8 +897,14 @@ int k_mem_update_flags(void *addr, size_t size, uint32_t flags)
 
 	/* TODO: detect and handle paged-out memory as well */
 
-	sys_mm_vm_backend_mem_unmap(addr, size);
-	sys_mm_vm_backend_mem_map(addr, phys, size, flags);
+	ret = sys_mm_vm_backend_mem_unmap(addr, size);
+	__ASSERT(ret == 0, "update flags: fails to unmap %p", addr);
+	if (ret != 0) {
+		goto out;
+	}
+
+	ret = sys_mm_vm_backend_mem_map(addr, phys, size, flags);
+	__ASSERT(ret == 0, "update flags: fails to map %p", addr);
 
 out:
 	k_spin_unlock(&z_mm_lock, key);
@@ -903,6 +962,7 @@ void k_mem_map_phys_bare(uint8_t **virt_ptr, uintptr_t phys, size_t size, uint32
 	uint8_t *dest_addr;
 	size_t num_bits;
 	size_t offset;
+	int ret;
 
 #ifndef CONFIG_KERNEL_DIRECT_MAP
 	__ASSERT(!(flags & K_MEM_DIRECT_MAP), "The direct-map is not enabled");
@@ -965,7 +1025,11 @@ void k_mem_map_phys_bare(uint8_t **virt_ptr, uintptr_t phys, size_t size, uint32
 	LOG_DBG("sys_mm_vm_backend_mem_map(%p, 0x%lx, %zu, %x) offset %lu", (void *)dest_addr,
 		aligned_phys, aligned_size, flags, addr_offset);
 
-	sys_mm_vm_backend_mem_map(dest_addr, aligned_phys, aligned_size, flags);
+	ret = sys_mm_vm_backend_mem_map(dest_addr, aligned_phys, aligned_size, flags);
+	if (ret != 0) {
+		goto fail;
+	}
+
 	k_spin_unlock(&z_mm_lock, key);
 
 	*virt_ptr = dest_addr + addr_offset;
@@ -988,6 +1052,7 @@ void k_mem_unmap_phys_bare(uint8_t *virt, size_t size)
 	uintptr_t aligned_virt, addr_offset;
 	size_t aligned_size;
 	k_spinlock_key_t key;
+	int ret;
 
 	addr_offset = k_mem_region_align(&aligned_virt, &aligned_size,
 					 POINTER_TO_UINT(virt), size,
@@ -1002,7 +1067,10 @@ void k_mem_unmap_phys_bare(uint8_t *virt, size_t size)
 	LOG_DBG("sys_mm_vm_backend_mem_unmap(0x%lx, %zu) offset %lu",
 		aligned_virt, aligned_size, addr_offset);
 
-	sys_mm_vm_backend_mem_unmap(UINT_TO_POINTER(aligned_virt), aligned_size);
+	ret = sys_mm_vm_backend_mem_unmap(UINT_TO_POINTER(aligned_virt), aligned_size);
+	__ASSERT(ret == 0, "%s: cannot unmap address %p", __func__, UINT_TO_POINTER(aligned_virt));
+	ARG_UNUSED(ret);
+
 	virt_region_free(UINT_TO_POINTER(aligned_virt), aligned_size);
 	k_spin_unlock(&z_mm_lock, key);
 }
@@ -1066,12 +1134,16 @@ static void z_paging_ondemand_section_map(void)
 	size_t size;
 	uintptr_t location;
 	uint32_t flags;
+	int ret;
+
+	ARG_UNUSED(ret);
 
 	size = (uintptr_t)lnkr_ondemand_text_size;
 	flags = K_MEM_MAP_UNPAGED | K_MEM_PERM_EXEC | K_MEM_CACHE_WB;
 	VIRT_FOREACH(lnkr_ondemand_text_start, size, addr) {
 		k_mem_paging_backing_store_location_query(addr, &location);
-		sys_mm_vm_backend_mem_map(addr, location, CONFIG_MMU_PAGE_SIZE, flags);
+		ret = sys_mm_vm_backend_mem_map(addr, location, CONFIG_MMU_PAGE_SIZE, flags);
+		__ASSERT_NO_MSG(ret == 0);
 		sys_bitarray_set_region(&virt_region_bitmap, 1,
 					virt_to_bitmap_offset(addr, CONFIG_MMU_PAGE_SIZE));
 	}
@@ -1080,7 +1152,8 @@ static void z_paging_ondemand_section_map(void)
 	flags = K_MEM_MAP_UNPAGED | K_MEM_CACHE_WB;
 	VIRT_FOREACH(lnkr_ondemand_rodata_start, size, addr) {
 		k_mem_paging_backing_store_location_query(addr, &location);
-		sys_mm_vm_backend_mem_map(addr, location, CONFIG_MMU_PAGE_SIZE, flags);
+		ret = sys_mm_vm_backend_mem_map(addr, location, CONFIG_MMU_PAGE_SIZE, flags);
+		__ASSERT_NO_MSG(ret == 0);
 		sys_bitarray_set_region(&virt_region_bitmap, 1,
 					virt_to_bitmap_offset(addr, CONFIG_MMU_PAGE_SIZE));
 	}

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -727,12 +727,12 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 		/* Unmapping anonymous memory */
 		VIRT_FOREACH(addr, size, pos) {
 #ifdef CONFIG_DEMAND_PAGING
-			enum arch_page_location status;
+			enum sys_mm_vm_page_location status;
 			uintptr_t location;
 
 			status = sys_mm_vm_backend_page_location_get(pos, &location);
 			switch (status) {
-			case ARCH_PAGE_LOCATION_PAGED_OUT:
+			case SYS_MM_VM_PAGE_LOCATION_PAGED_OUT:
 				/*
 				 * No pf is associated with this mapping.
 				 * Simply get rid of the MMU entry and free
@@ -741,11 +741,11 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 				sys_mm_vm_backend_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
 				k_mem_paging_backing_store_location_free(location);
 				continue;
-			case ARCH_PAGE_LOCATION_PAGED_IN:
+			case SYS_MM_VM_PAGE_LOCATION_PAGED_IN:
 				/*
 				 * The page is in memory but it may not be
 				 * accessible in order to manage tracking
-				 * of the ARCH_DATA_PAGE_ACCESSED flag
+				 * of the SYS_MM_VM_DATA_PAGE_ACCESSED flag
 				 * meaning sys_mm_vm_backend_page_phys_get() could fail.
 				 * Still, we know the actual phys address.
 				 */
@@ -1376,15 +1376,15 @@ static int do_mem_evict(void *addr)
 #endif /* CONFIG_DEMAND_PAGING_ALLOW_IRQ */
 	key = k_spin_lock(&z_mm_lock);
 	flags = sys_mm_vm_backend_mem_page_info_get(addr, &phys, false);
-	__ASSERT((flags & ARCH_DATA_PAGE_NOT_MAPPED) == 0,
+	__ASSERT((flags & SYS_MM_VM_DATA_PAGE_NOT_MAPPED) == 0,
 		 "address %p isn't mapped", addr);
-	if ((flags & ARCH_DATA_PAGE_LOADED) == 0) {
+	if ((flags & SYS_MM_VM_DATA_PAGE_LOADED) == 0) {
 		/* Un-mapped or already evicted. Nothing to do */
 		ret = 0;
 		goto out;
 	}
 
-	dirty = (flags & ARCH_DATA_PAGE_DIRTY) != 0;
+	dirty = (flags & SYS_MM_VM_DATA_PAGE_DIRTY) != 0;
 	pf = k_mem_phys_to_page_frame(phys);
 	__ASSERT(k_mem_page_frame_to_virt(pf) == addr, "page frame address mismatch");
 	ret = page_frame_prepare_locked(pf, &dirty, false, &location);
@@ -1469,8 +1469,8 @@ int k_mem_page_frame_evict(uintptr_t phys)
 	}
 	flags = sys_mm_vm_backend_mem_page_info_get(k_mem_page_frame_to_virt(pf), NULL, false);
 	/* Shouldn't ever happen */
-	__ASSERT((flags & ARCH_DATA_PAGE_LOADED) != 0, "data page not loaded");
-	dirty = (flags & ARCH_DATA_PAGE_DIRTY) != 0;
+	__ASSERT((flags & SYS_MM_VM_DATA_PAGE_LOADED) != 0, "data page not loaded");
+	dirty = (flags & SYS_MM_VM_DATA_PAGE_DIRTY) != 0;
 	ret = page_frame_prepare_locked(pf, &dirty, false, &location);
 	if (ret != 0) {
 		goto out;
@@ -1596,7 +1596,7 @@ static bool do_page_fault(void *addr, bool pin)
 	struct k_mem_page_frame *pf;
 	k_spinlock_key_t key;
 	uintptr_t page_in_location, page_out_location;
-	enum arch_page_location status;
+	enum sys_mm_vm_page_location status;
 	bool result;
 	bool dirty = false;
 	struct k_thread *faulting_thread;
@@ -1658,14 +1658,14 @@ static bool do_page_fault(void *addr, bool pin)
 	faulting_thread = _current;
 
 	status = sys_mm_vm_backend_page_location_get(addr, &page_in_location);
-	if (status == ARCH_PAGE_LOCATION_BAD) {
+	if (status == SYS_MM_VM_PAGE_LOCATION_BAD) {
 		/* Return false to treat as a fatal error */
 		result = false;
 		goto out;
 	}
 	result = true;
 
-	if (status == ARCH_PAGE_LOCATION_PAGED_IN) {
+	if (status == SYS_MM_VM_PAGE_LOCATION_PAGED_IN) {
 		if (pin) {
 			/* It's a physical memory address */
 			uintptr_t phys = page_in_location;
@@ -1686,7 +1686,7 @@ static bool do_page_fault(void *addr, bool pin)
 		 */
 		goto out;
 	}
-	__ASSERT(status == ARCH_PAGE_LOCATION_PAGED_OUT,
+	__ASSERT(status == SYS_MM_VM_PAGE_LOCATION_PAGED_OUT,
 		 "unexpected status value %d", status);
 
 	paging_stats_faults_inc(faulting_thread, key.key);
@@ -1792,9 +1792,9 @@ static void do_mem_unpin(void *addr)
 
 	key = k_spin_lock(&z_mm_lock);
 	flags = sys_mm_vm_backend_mem_page_info_get(addr, &phys, false);
-	__ASSERT((flags & ARCH_DATA_PAGE_NOT_MAPPED) == 0,
+	__ASSERT((flags & SYS_MM_VM_DATA_PAGE_NOT_MAPPED) == 0,
 		 "invalid data page at %p", addr);
-	if ((flags & ARCH_DATA_PAGE_LOADED) != 0) {
+	if ((flags & SYS_MM_VM_DATA_PAGE_LOADED) != 0) {
 		pf = k_mem_phys_to_page_frame(phys);
 		if (k_mem_page_frame_is_pinned(pf)) {
 			k_mem_page_frame_clear(pf, K_MEM_PAGE_FRAME_PINNED);

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -1366,7 +1366,7 @@ static void virt_region_foreach(void *addr, size_t size,
  *    - Update page tables with location
  * - Mark page frame as busy
  *
- * Returns -ENOMEM if the backing store is full
+ * Returns -ENOMEM if the backing store is full, -EFAULT if fails to page out.
  */
 static int page_frame_prepare_locked(struct k_mem_page_frame *pf, bool *dirty_ptr,
 				     bool page_fault, uintptr_t *location_ptr)
@@ -1405,7 +1405,12 @@ static int page_frame_prepare_locked(struct k_mem_page_frame *pf, bool *dirty_pt
 			LOG_ERR("out of backing store memory");
 			return -ENOMEM;
 		}
-		sys_mm_vm_backend_mem_page_out(k_mem_page_frame_to_virt(pf), *location_ptr);
+
+		ret = sys_mm_vm_backend_mem_page_out(k_mem_page_frame_to_virt(pf), *location_ptr);
+		if (ret != 0) {
+			LOG_ERR("Cannot page out memory");
+			return -EFAULT;
+		}
 
 		if (IS_ENABLED(CONFIG_EVICTION_TRACKING)) {
 			k_mem_paging_eviction_remove(pf);
@@ -1800,7 +1805,12 @@ static bool do_page_fault(void *addr, bool pin)
 		k_mem_page_frame_set(pf, K_MEM_PAGE_FRAME_PINNED);
 	}
 
-	sys_mm_vm_backend_mem_page_in(addr, k_mem_page_frame_to_phys(pf));
+	ret = sys_mm_vm_backend_mem_page_in(addr, k_mem_page_frame_to_phys(pf));
+	__ASSERT(ret == 0, "failed to page in %p", addr);
+	if (ret != 0) {
+		goto out;
+	}
+
 	k_mem_paging_backing_store_page_finalize(pf, page_in_location);
 	if (IS_ENABLED(CONFIG_EVICTION_TRACKING) && (!pin)) {
 		k_mem_paging_eviction_add(pf);

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -15,6 +15,7 @@
 #include <zephyr/internal/syscall_handler.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/linker/linker-defs.h>
+#include <zephyr/mem_mgmt/system_vm/backend.h>
 #include <zephyr/sys/bitarray.h>
 #include <zephyr/sys/check.h>
 #include <zephyr/sys/math_extras.h>
@@ -551,7 +552,7 @@ static int map_anon_page(void *addr, uint32_t flags)
 	}
 
 	phys = k_mem_page_frame_to_phys(pf);
-	arch_mem_map(addr, phys, CONFIG_MMU_PAGE_SIZE, flags);
+	sys_mm_vm_backend_mem_map(addr, phys, CONFIG_MMU_PAGE_SIZE, flags);
 
 	if (lock) {
 		k_mem_page_frame_set(pf, K_MEM_PAGE_FRAME_PINNED);
@@ -616,9 +617,8 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 	/* Unmap both guard pages to make sure accessing them
 	 * will generate fault.
 	 */
-	arch_mem_unmap(dst, CONFIG_MMU_PAGE_SIZE);
-	arch_mem_unmap(dst + CONFIG_MMU_PAGE_SIZE + size,
-		       CONFIG_MMU_PAGE_SIZE);
+	sys_mm_vm_backend_mem_unmap(dst, CONFIG_MMU_PAGE_SIZE);
+	sys_mm_vm_backend_mem_unmap(dst + CONFIG_MMU_PAGE_SIZE + size, CONFIG_MMU_PAGE_SIZE);
 
 	/* Skip over the "before" guard page in returned address. */
 	dst += CONFIG_MMU_PAGE_SIZE;
@@ -630,10 +630,10 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 		if ((flags & K_MEM_MAP_LOCK) == 0) {
 			flags |= K_MEM_MAP_UNPAGED;
 			VIRT_FOREACH(dst, size, pos) {
-				arch_mem_map(pos,
-					     uninit ? ARCH_UNPAGED_ANON_UNINIT
-						    : ARCH_UNPAGED_ANON_ZERO,
-					     CONFIG_MMU_PAGE_SIZE, flags);
+				sys_mm_vm_backend_mem_map(pos,
+							  uninit ? ARCH_UNPAGED_ANON_UNINIT
+								 : ARCH_UNPAGED_ANON_ZERO,
+							  CONFIG_MMU_PAGE_SIZE, flags);
 			}
 			LOG_DBG("memory mapping anon pages %p to %p unpaged", dst, pos-1);
 			/* skip the memset() below */
@@ -654,11 +654,11 @@ void *k_mem_map_phys_guard(uintptr_t phys, size_t size, uint32_t flags, bool is_
 	} else {
 		/* Mapping known physical memory.
 		 *
-		 * arch_mem_map() is a void function and does not return
+		 * sys_mm_vm_backend_mem_map() is a void function and does not return
 		 * anything. Arch code usually uses ASSERT() to catch
 		 * mapping errors. Assume this works correctly for now.
 		 */
-		arch_mem_map(dst, phys, size, flags);
+		sys_mm_vm_backend_mem_map(dst, phys, size, flags);
 	}
 
 out:
@@ -675,7 +675,7 @@ out:
 
 fail_need_unmap:
 	/* Need to unmap already mappped pages if we encounter any errors. */
-	arch_mem_unmap(failed_unmap_from, failed_unmap_to - failed_unmap_from);
+	sys_mm_vm_backend_mem_unmap(failed_unmap_from, failed_unmap_to - failed_unmap_from);
 
 	k_spin_unlock(&z_mm_lock, key);
 
@@ -707,7 +707,7 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 	 * using k_mem_map().
 	 */
 	pos = addr;
-	ret = arch_page_phys_get(pos - CONFIG_MMU_PAGE_SIZE, NULL);
+	ret = sys_mm_vm_backend_page_phys_get(pos - CONFIG_MMU_PAGE_SIZE, NULL);
 	__ASSERT(ret != 0,
 		 "%s: cannot find preceding guard page for (%p, %zu)",
 		 __func__, addr, size);
@@ -715,7 +715,7 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 		goto out;
 	}
 
-	ret = arch_page_phys_get(pos + size, NULL);
+	ret = sys_mm_vm_backend_page_phys_get(pos + size, NULL);
 	__ASSERT(ret != 0,
 		 "%s: cannot find succeeding guard page for (%p, %zu)",
 		 __func__, addr, size);
@@ -730,7 +730,7 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 			enum arch_page_location status;
 			uintptr_t location;
 
-			status = arch_page_location_get(pos, &location);
+			status = sys_mm_vm_backend_page_location_get(pos, &location);
 			switch (status) {
 			case ARCH_PAGE_LOCATION_PAGED_OUT:
 				/*
@@ -738,7 +738,7 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 				 * Simply get rid of the MMU entry and free
 				 * corresponding backing store.
 				 */
-				arch_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
+				sys_mm_vm_backend_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
 				k_mem_paging_backing_store_location_free(location);
 				continue;
 			case ARCH_PAGE_LOCATION_PAGED_IN:
@@ -746,18 +746,18 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 				 * The page is in memory but it may not be
 				 * accessible in order to manage tracking
 				 * of the ARCH_DATA_PAGE_ACCESSED flag
-				 * meaning arch_page_phys_get() could fail.
+				 * meaning sys_mm_vm_backend_page_phys_get() could fail.
 				 * Still, we know the actual phys address.
 				 */
 				phys = location;
 				ret = 0;
 				break;
 			default:
-				ret = arch_page_phys_get(pos, &phys);
+				ret = sys_mm_vm_backend_page_phys_get(pos, &phys);
 				break;
 			}
 #else
-			ret = arch_page_phys_get(pos, &phys);
+			ret = sys_mm_vm_backend_page_phys_get(pos, &phys);
 #endif
 			__ASSERT(ret == 0,
 				 "%s: cannot unmap an unmapped address %p",
@@ -789,7 +789,7 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 				goto out;
 			}
 
-			arch_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
+			sys_mm_vm_backend_mem_unmap(pos, CONFIG_MMU_PAGE_SIZE);
 #ifdef CONFIG_DEMAND_PAGING
 			if (IS_ENABLED(CONFIG_EVICTION_TRACKING) &&
 			    (!k_mem_page_frame_is_pinned(pf))) {
@@ -808,7 +808,7 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 		 * have been unmapped. We just need to unmapped the in-between
 		 * region [addr, (addr + size)).
 		 */
-		arch_mem_unmap(addr, size);
+		sys_mm_vm_backend_mem_unmap(addr, size);
 	}
 
 	/* There are guard pages just before and after the mapped
@@ -837,15 +837,15 @@ int k_mem_update_flags(void *addr, size_t size, uint32_t flags)
 	 * by unmapping and remapping the same physical memory using new flags.
 	 */
 
-	ret = arch_page_phys_get(addr, &phys);
+	ret = sys_mm_vm_backend_page_phys_get(addr, &phys);
 	if (ret < 0) {
 		goto out;
 	}
 
 	/* TODO: detect and handle paged-out memory as well */
 
-	arch_mem_unmap(addr, size);
-	arch_mem_map(addr, phys, size, flags);
+	sys_mm_vm_backend_mem_unmap(addr, size);
+	sys_mm_vm_backend_mem_map(addr, phys, size, flags);
 
 out:
 	k_spin_unlock(&z_mm_lock, key);
@@ -962,17 +962,17 @@ void k_mem_map_phys_bare(uint8_t **virt_ptr, uintptr_t phys, size_t size, uint32
 		 "wraparound for virtual address %p (size %zu)",
 		 dest_addr, size);
 
-	LOG_DBG("arch_mem_map(%p, 0x%lx, %zu, %x) offset %lu", (void *)dest_addr,
+	LOG_DBG("sys_mm_vm_backend_mem_map(%p, 0x%lx, %zu, %x) offset %lu", (void *)dest_addr,
 		aligned_phys, aligned_size, flags, addr_offset);
 
-	arch_mem_map(dest_addr, aligned_phys, aligned_size, flags);
+	sys_mm_vm_backend_mem_map(dest_addr, aligned_phys, aligned_size, flags);
 	k_spin_unlock(&z_mm_lock, key);
 
 	*virt_ptr = dest_addr + addr_offset;
 	return;
 fail:
 	/* May re-visit this in the future, but for now running out of
-	 * virtual address space or failing the arch_mem_map() call is
+	 * virtual address space or failing the sys_mm_vm_backend_mem_map() call is
 	 * an unrecoverable situation.
 	 *
 	 * Other problems not related to resource exhaustion we leave as
@@ -999,10 +999,10 @@ void k_mem_unmap_phys_bare(uint8_t *virt, size_t size)
 
 	key = k_spin_lock(&z_mm_lock);
 
-	LOG_DBG("arch_mem_unmap(0x%lx, %zu) offset %lu",
+	LOG_DBG("sys_mm_vm_backend_mem_unmap(0x%lx, %zu) offset %lu",
 		aligned_virt, aligned_size, addr_offset);
 
-	arch_mem_unmap(UINT_TO_POINTER(aligned_virt), aligned_size);
+	sys_mm_vm_backend_mem_unmap(UINT_TO_POINTER(aligned_virt), aligned_size);
 	virt_region_free(UINT_TO_POINTER(aligned_virt), aligned_size);
 	k_spin_unlock(&z_mm_lock, key);
 }
@@ -1071,7 +1071,7 @@ static void z_paging_ondemand_section_map(void)
 	flags = K_MEM_MAP_UNPAGED | K_MEM_PERM_EXEC | K_MEM_CACHE_WB;
 	VIRT_FOREACH(lnkr_ondemand_text_start, size, addr) {
 		k_mem_paging_backing_store_location_query(addr, &location);
-		arch_mem_map(addr, location, CONFIG_MMU_PAGE_SIZE, flags);
+		sys_mm_vm_backend_mem_map(addr, location, CONFIG_MMU_PAGE_SIZE, flags);
 		sys_bitarray_set_region(&virt_region_bitmap, 1,
 					virt_to_bitmap_offset(addr, CONFIG_MMU_PAGE_SIZE));
 	}
@@ -1080,7 +1080,7 @@ static void z_paging_ondemand_section_map(void)
 	flags = K_MEM_MAP_UNPAGED | K_MEM_CACHE_WB;
 	VIRT_FOREACH(lnkr_ondemand_rodata_start, size, addr) {
 		k_mem_paging_backing_store_location_query(addr, &location);
-		arch_mem_map(addr, location, CONFIG_MMU_PAGE_SIZE, flags);
+		sys_mm_vm_backend_mem_map(addr, location, CONFIG_MMU_PAGE_SIZE, flags);
 		sys_bitarray_set_region(&virt_region_bitmap, 1,
 					virt_to_bitmap_offset(addr, CONFIG_MMU_PAGE_SIZE));
 	}
@@ -1102,7 +1102,7 @@ void z_mem_manage_init(void)
 	/* If some page frames are unavailable for use as memory, arch
 	 * code will mark K_MEM_PAGE_FRAME_RESERVED in their flags
 	 */
-	arch_reserved_pages_update();
+	sys_mm_vm_backend_reserved_pages_update();
 #endif /* CONFIG_ARCH_HAS_RESERVED_PAGE_FRAMES */
 
 	/* The entire Zephyr image is mapped and pinned at boot. Demand
@@ -1322,7 +1322,7 @@ static int page_frame_prepare_locked(struct k_mem_page_frame *pf, bool *dirty_pt
 	}
 
 	if (dirty || page_fault) {
-		arch_mem_scratch(phys);
+		sys_mm_vm_backend_mem_scratch(phys);
 	}
 
 	if (k_mem_page_frame_is_mapped(pf)) {
@@ -1332,7 +1332,7 @@ static int page_frame_prepare_locked(struct k_mem_page_frame *pf, bool *dirty_pt
 			LOG_ERR("out of backing store memory");
 			return -ENOMEM;
 		}
-		arch_mem_page_out(k_mem_page_frame_to_virt(pf), *location_ptr);
+		sys_mm_vm_backend_mem_page_out(k_mem_page_frame_to_virt(pf), *location_ptr);
 
 		if (IS_ENABLED(CONFIG_EVICTION_TRACKING)) {
 			k_mem_paging_eviction_remove(pf);
@@ -1375,7 +1375,7 @@ static int do_mem_evict(void *addr)
 #endif
 #endif /* CONFIG_DEMAND_PAGING_ALLOW_IRQ */
 	key = k_spin_lock(&z_mm_lock);
-	flags = arch_page_info_get(addr, &phys, false);
+	flags = sys_mm_vm_backend_mem_page_info_get(addr, &phys, false);
 	__ASSERT((flags & ARCH_DATA_PAGE_NOT_MAPPED) == 0,
 		 "address %p isn't mapped", addr);
 	if ((flags & ARCH_DATA_PAGE_LOADED) == 0) {
@@ -1467,7 +1467,7 @@ int k_mem_page_frame_evict(uintptr_t phys)
 		ret = 0;
 		goto out;
 	}
-	flags = arch_page_info_get(k_mem_page_frame_to_virt(pf), NULL, false);
+	flags = sys_mm_vm_backend_mem_page_info_get(k_mem_page_frame_to_virt(pf), NULL, false);
 	/* Shouldn't ever happen */
 	__ASSERT((flags & ARCH_DATA_PAGE_LOADED) != 0, "data page not loaded");
 	dirty = (flags & ARCH_DATA_PAGE_DIRTY) != 0;
@@ -1657,7 +1657,7 @@ static bool do_page_fault(void *addr, bool pin)
 	key = k_spin_lock(&z_mm_lock);
 	faulting_thread = _current;
 
-	status = arch_page_location_get(addr, &page_in_location);
+	status = sys_mm_vm_backend_page_location_get(addr, &page_in_location);
 	if (status == ARCH_PAGE_LOCATION_BAD) {
 		/* Return false to treat as a fatal error */
 		result = false;
@@ -1727,7 +1727,7 @@ static bool do_page_fault(void *addr, bool pin)
 		k_mem_page_frame_set(pf, K_MEM_PAGE_FRAME_PINNED);
 	}
 
-	arch_mem_page_in(addr, k_mem_page_frame_to_phys(pf));
+	sys_mm_vm_backend_mem_page_in(addr, k_mem_page_frame_to_phys(pf));
 	k_mem_paging_backing_store_page_finalize(pf, page_in_location);
 	if (IS_ENABLED(CONFIG_EVICTION_TRACKING) && (!pin)) {
 		k_mem_paging_eviction_add(pf);
@@ -1791,7 +1791,7 @@ static void do_mem_unpin(void *addr)
 	uintptr_t flags, phys;
 
 	key = k_spin_lock(&z_mm_lock);
-	flags = arch_page_info_get(addr, &phys, false);
+	flags = sys_mm_vm_backend_mem_page_info_get(addr, &phys, false);
 	__ASSERT((flags & ARCH_DATA_PAGE_NOT_MAPPED) == 0,
 		 "invalid data page at %p", addr);
 	if ((flags & ARCH_DATA_PAGE_LOADED) != 0) {

--- a/subsys/mem_mgmt/Kconfig
+++ b/subsys/mem_mgmt/Kconfig
@@ -3,6 +3,35 @@
 
 rsource "demand_paging/Kconfig"
 
+choice MEM_MGMT_VM_BACKEND
+	prompt "Low-level virtual memory operations backend"
+	default MEM_MGMT_VM_BACKEND_ARCH if MMU
+	default MEM_MGMT_VM_BACKEND_NONE
+	depends on KERNEL_VM_SUPPORT
+	help
+	  Select the backend implementing the low-level virtual memory operations
+	  (the sys_mm_vm_backend_*() API used for page mapping/unmapping and,
+	  when demand paging is enabled, page-in/out).
+
+config MEM_MGMT_VM_BACKEND_ARCH
+	bool "Architecture-specific"
+	help
+	  Forward the virtual memory operations to the architecture
+	  provided arch_mem_*() implementation.
+
+config MEM_MGMT_VM_BACKEND_CUSTOM
+	bool "Custom implementation"
+	help
+	  Virtual memory operations are provided by a custom implementation
+	  that implements the sys_mm_vm_backend_*() API instead.
+
+config MEM_MGMT_VM_BACKEND_NONE
+	bool "None"
+	help
+	  No virtual memory backend. All sys_mm_vm_backend_*() are unavailable.
+
+endchoice
+
 config MEM_ATTR
 	bool "Memory Attributes management library"
 	default y if ARM_MPU

--- a/subsys/mem_mgmt/demand_paging/eviction/lru.c
+++ b/subsys/mem_mgmt/demand_paging/eviction/lru.c
@@ -35,6 +35,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/kernel/mm/demand_paging.h>
+#include <zephyr/mem_mgmt/system_vm/backend.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/sys/util.h>
 #include <mmu.h>
@@ -117,7 +118,8 @@ static void lru_pf_remove(uint32_t pf_idx)
 	    (LRU_PF_HEAD != 0) &&
 	    (lru_pf_queue[LRU_PF_HEAD].next != 0)) {
 		struct k_mem_page_frame *pf = idx_to_pf(LRU_PF_HEAD);
-		uintptr_t flags = arch_page_info_get(k_mem_page_frame_to_virt(pf), NULL, true);
+		uintptr_t flags = sys_mm_vm_backend_mem_page_info_get(k_mem_page_frame_to_virt(pf),
+								      NULL, true);
 
 		/* clearing the accessed flag expected only on loaded pages */
 		__ASSERT((flags & ARCH_DATA_PAGE_LOADED) != 0, "");
@@ -168,7 +170,8 @@ struct k_mem_page_frame *k_mem_paging_eviction_select(bool *dirty_ptr)
 	}
 
 	struct k_mem_page_frame *pf = idx_to_pf(head_pf_idx);
-	uintptr_t flags = arch_page_info_get(k_mem_page_frame_to_virt(pf), NULL, false);
+	uintptr_t flags = sys_mm_vm_backend_mem_page_info_get(k_mem_page_frame_to_virt(pf), NULL,
+							      false);
 
 	__ASSERT(k_mem_page_frame_is_evictable(pf), "");
 	*dirty_ptr = ((flags & ARCH_DATA_PAGE_DIRTY) != 0);

--- a/subsys/mem_mgmt/demand_paging/eviction/lru.c
+++ b/subsys/mem_mgmt/demand_paging/eviction/lru.c
@@ -39,7 +39,6 @@
 #include <zephyr/spinlock.h>
 #include <zephyr/sys/util.h>
 #include <mmu.h>
-#include <kernel_arch_interface.h>
 
 /*
  * Page frames are ordered according to their access pattern. Using a regular
@@ -122,7 +121,7 @@ static void lru_pf_remove(uint32_t pf_idx)
 								      NULL, true);
 
 		/* clearing the accessed flag expected only on loaded pages */
-		__ASSERT((flags & ARCH_DATA_PAGE_LOADED) != 0, "");
+		__ASSERT((flags & SYS_MM_VM_DATA_PAGE_LOADED) != 0, "");
 		ARG_UNUSED(flags);
 	}
 }
@@ -174,7 +173,7 @@ struct k_mem_page_frame *k_mem_paging_eviction_select(bool *dirty_ptr)
 							      false);
 
 	__ASSERT(k_mem_page_frame_is_evictable(pf), "");
-	*dirty_ptr = ((flags & ARCH_DATA_PAGE_DIRTY) != 0);
+	*dirty_ptr = ((flags & SYS_MM_VM_DATA_PAGE_DIRTY) != 0);
 	return pf;
 }
 

--- a/subsys/mem_mgmt/demand_paging/eviction/nru.c
+++ b/subsys/mem_mgmt/demand_paging/eviction/nru.c
@@ -8,7 +8,6 @@
 #include <zephyr/kernel.h>
 #include <mmu.h>
 #include <kernel_arch_interface.h>
-#include <zephyr/init.h>
 
 #include <zephyr/kernel/mm/demand_paging.h>
 

--- a/subsys/mem_mgmt/demand_paging/eviction/nru.c
+++ b/subsys/mem_mgmt/demand_paging/eviction/nru.c
@@ -10,6 +10,7 @@
 #include <kernel_arch_interface.h>
 
 #include <zephyr/kernel/mm/demand_paging.h>
+#include <zephyr/mem_mgmt/system_vm/backend.h>
 
 /* The accessed and dirty states of each page frame are used to create
  * a hierarchy with a numerical value. When evicting a page, try to evict
@@ -35,8 +36,8 @@ static void nru_periodic_update(struct k_timer *timer)
 		}
 
 		/* Clear accessed bit in page tables */
-		(void)arch_page_info_get(k_mem_page_frame_to_virt(pf),
-					 NULL, true);
+		(void)sys_mm_vm_backend_mem_page_info_get(k_mem_page_frame_to_virt(pf), NULL,
+							  true);
 	}
 
 	irq_unlock(key);
@@ -66,7 +67,8 @@ struct k_mem_page_frame *k_mem_paging_eviction_select(bool *dirty_ptr)
 			continue;
 		}
 
-		flags = arch_page_info_get(k_mem_page_frame_to_virt(pf), NULL, false);
+		flags = sys_mm_vm_backend_mem_page_info_get(k_mem_page_frame_to_virt(pf), NULL,
+							    false);
 		accessed = (flags & ARCH_DATA_PAGE_ACCESSED) != 0UL;
 		dirty = (flags & ARCH_DATA_PAGE_DIRTY) != 0UL;
 

--- a/subsys/mem_mgmt/demand_paging/eviction/nru.c
+++ b/subsys/mem_mgmt/demand_paging/eviction/nru.c
@@ -7,7 +7,6 @@
  */
 #include <zephyr/kernel.h>
 #include <mmu.h>
-#include <kernel_arch_interface.h>
 
 #include <zephyr/kernel/mm/demand_paging.h>
 #include <zephyr/mem_mgmt/system_vm/backend.h>
@@ -69,15 +68,15 @@ struct k_mem_page_frame *k_mem_paging_eviction_select(bool *dirty_ptr)
 
 		flags = sys_mm_vm_backend_mem_page_info_get(k_mem_page_frame_to_virt(pf), NULL,
 							    false);
-		accessed = (flags & ARCH_DATA_PAGE_ACCESSED) != 0UL;
-		dirty = (flags & ARCH_DATA_PAGE_DIRTY) != 0UL;
+		accessed = (flags & SYS_MM_VM_DATA_PAGE_ACCESSED) != 0UL;
+		dirty = (flags & SYS_MM_VM_DATA_PAGE_DIRTY) != 0UL;
 
 		/* Implies a mismatch with page frame ontology and page
 		 * tables
 		 */
-		__ASSERT((flags & ARCH_DATA_PAGE_LOADED) != 0U,
+		__ASSERT((flags & SYS_MM_VM_DATA_PAGE_LOADED) != 0U,
 			 "non-present page, %s",
-			 ((flags & ARCH_DATA_PAGE_NOT_MAPPED) != 0U) ?
+			 ((flags & SYS_MM_VM_DATA_PAGE_NOT_MAPPED) != 0U) ?
 			 "un-mapped" : "paged out");
 
 		prec = (dirty ? 1U : 0U) + (accessed ? 2U : 0U);


### PR DESCRIPTION
This modularizes the memory management backend on virtual memory which would allow implementation of backends other than the architecture ones (e.g. `arch_mem_map()`, `arch_mem_unmap()`, etc.). The mechanism is modeled after atomic where backends can be chosen by kconfig. The default is the architecture ones with redirection wrapper.

See individual commits for more details, but to summarize:
- Added new APIs which is basically renamed of architecture memory management functions with different prefix (`sys_mm_vm_backend_*()`).
- Introduce kconfig choice to specify which backend to use.
- Added some inlined redirection from the new APIs to the architecture ones if the arch backend is selected.
- Mainly renames in common code such as kernel and demand paging eviction algorithms.

This will allow moving the (currently separated) memory management drivers under this umbrella in the future, and allowing them to be used directly by the kernel for memory mappings.