### PR TITLE
drivers: Remove redundant casts in syscall handlers

### DIFF
--- a/drivers/adc/adc_handlers.c
+++ b/drivers/adc/adc_handlers.c
@@ -18,7 +18,7 @@ static inline int z_vrfy_adc_channel_setup(const struct device *dev,
 				(struct adc_channel_cfg *)user_channel_cfg,
 				sizeof(struct adc_channel_cfg)));
 
-	return z_impl_adc_channel_setup((const struct device *)dev,
+	return z_impl_adc_channel_setup(dev,
 					&channel_cfg);
 }
 #include <zephyr/syscalls/adc_channel_setup_mrsh.c>
@@ -64,7 +64,7 @@ static inline int z_vrfy_adc_read(const struct device *dev,
 			    "ADC sequence callbacks forbidden from user mode"));
 	}
 
-	return z_impl_adc_read((const struct device *)dev, &sequence);
+	return z_impl_adc_read(dev, &sequence);
 }
 #include <zephyr/syscalls/adc_read_mrsh.c>
 
@@ -86,8 +86,8 @@ static inline int z_vrfy_adc_read_async(const struct device *dev,
 	}
 	K_OOPS(K_SYSCALL_OBJ(async, K_OBJ_POLL_SIGNAL));
 
-	return z_impl_adc_read_async((const struct device *)dev, &sequence,
-				     (struct k_poll_signal *)async);
+	return z_impl_adc_read_async(dev, &sequence,
+				     async);
 }
 #include <zephyr/syscalls/adc_read_async_mrsh.c>
 #endif /* CONFIG_ADC_ASYNC */

--- a/drivers/counter/counter_handlers.c
+++ b/drivers/counter/counter_handlers.c
@@ -118,14 +118,14 @@ static inline int z_vrfy_counter_get_value(const struct device *dev, uint32_t *t
 {
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, get_value));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(ticks, sizeof(*ticks)));
-	return z_impl_counter_get_value((const struct device *)dev, ticks);
+	return z_impl_counter_get_value(dev, ticks);
 }
 #include <zephyr/syscalls/counter_get_value_mrsh.c>
 
 static inline int z_vrfy_counter_set_value(const struct device *dev, uint32_t ticks)
 {
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, set_value));
-	return z_impl_counter_set_value((const struct device *)dev, ticks);
+	return z_impl_counter_set_value(dev, ticks);
 }
 #include <zephyr/syscalls/counter_set_value_mrsh.c>
 
@@ -134,14 +134,14 @@ static inline int z_vrfy_counter_get_value_64(const struct device *dev, uint64_t
 {
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, get_value_64));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(ticks, sizeof(*ticks)));
-	return z_impl_counter_get_value_64((const struct device *)dev, ticks);
+	return z_impl_counter_get_value_64(dev, ticks);
 }
 #include <zephyr/syscalls/counter_get_value_64_mrsh.c>
 
 static inline int z_vrfy_counter_set_value_64(const struct device *dev, uint64_t ticks)
 {
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, set_value_64));
-	return z_impl_counter_set_value_64((const struct device *)dev, ticks);
+	return z_impl_counter_set_value_64(dev, ticks);
 }
 #include <zephyr/syscalls/counter_set_value_64_mrsh.c>
 #endif /* CONFIG_COUNTER_64BITS_TICKS */
@@ -155,7 +155,7 @@ static inline int z_vrfy_counter_set_channel_alarm(const struct device *dev, uin
 	K_OOPS(k_usermode_from_copy(&cfg_copy, alarm_cfg, sizeof(cfg_copy)));
 	K_OOPS(K_SYSCALL_VERIFY_MSG(cfg_copy.callback == NULL,
 				    "callbacks may not be set from user mode"));
-	return z_impl_counter_set_channel_alarm((const struct device *)dev, (uint8_t)chan_id,
+	return z_impl_counter_set_channel_alarm(dev, (uint8_t)chan_id,
 						(const struct counter_alarm_cfg *)&cfg_copy);
 }
 #include <zephyr/syscalls/counter_set_channel_alarm_mrsh.c>
@@ -163,7 +163,7 @@ static inline int z_vrfy_counter_set_channel_alarm(const struct device *dev, uin
 static inline int z_vrfy_counter_cancel_channel_alarm(const struct device *dev, uint8_t chan_id)
 {
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, cancel_alarm));
-	return z_impl_counter_cancel_channel_alarm((const struct device *)dev, (uint8_t)chan_id);
+	return z_impl_counter_cancel_channel_alarm(dev, (uint8_t)chan_id);
 }
 #include <zephyr/syscalls/counter_cancel_channel_alarm_mrsh.c>
 
@@ -176,7 +176,7 @@ static inline int z_vrfy_counter_set_top_value(const struct device *dev,
 	K_OOPS(k_usermode_from_copy(&cfg_copy, cfg, sizeof(cfg_copy)));
 	K_OOPS(K_SYSCALL_VERIFY_MSG(cfg_copy.callback == NULL,
 				    "callbacks may not be set from user mode"));
-	return z_impl_counter_set_top_value((const struct device *)dev,
+	return z_impl_counter_set_top_value(dev,
 					    (const struct counter_top_cfg *)&cfg_copy);
 }
 #include <zephyr/syscalls/counter_set_top_value_mrsh.c>
@@ -205,7 +205,7 @@ static inline int z_vrfy_counter_set_top_value_64(const struct device *dev,
 	K_OOPS(k_usermode_from_copy(&cfg_copy, cfg, sizeof(cfg_copy)));
 	K_OOPS(K_SYSCALL_VERIFY_MSG(cfg_copy.callback == NULL,
 				    "callbacks may not be set from user mode"));
-	return z_impl_counter_set_top_value_64((const struct device *)dev,
+	return z_impl_counter_set_top_value_64(dev,
 					       (const struct counter_top_cfg_64 *)&cfg_copy);
 }
 #include <zephyr/syscalls/counter_set_top_value_64_mrsh.c>
@@ -219,7 +219,7 @@ static inline int z_vrfy_counter_set_channel_alarm_64(const struct device *dev, 
 	K_OOPS(k_usermode_from_copy(&cfg_copy, alarm_cfg, sizeof(cfg_copy)));
 	K_OOPS(K_SYSCALL_VERIFY_MSG(cfg_copy.callback == NULL,
 				    "callbacks may not be set from user mode"));
-	return z_impl_counter_set_channel_alarm_64((const struct device *)dev, (uint8_t)chan_id,
+	return z_impl_counter_set_channel_alarm_64(dev, (uint8_t)chan_id,
 						   (const struct counter_alarm_cfg_64 *)&cfg_copy);
 }
 #include <zephyr/syscalls/counter_set_channel_alarm_64_mrsh.c>
@@ -258,7 +258,7 @@ static inline int z_vrfy_counter_set_guard_period(const struct device *dev, uint
 						  uint32_t flags)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_set_guard_period((const struct device *)dev, ticks, flags);
+	return z_impl_counter_set_guard_period(dev, ticks, flags);
 }
 #include <zephyr/syscalls/counter_set_guard_period_mrsh.c>
 
@@ -274,7 +274,7 @@ static inline int z_vrfy_counter_set_guard_period_64(const struct device *dev, u
 						     uint32_t flags)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_set_guard_period_64((const struct device *)dev, ticks, flags);
+	return z_impl_counter_set_guard_period_64(dev, ticks, flags);
 }
 #include <zephyr/syscalls/counter_set_guard_period_64_mrsh.c>
 #endif /* CONFIG_COUNTER_64BITS_TICKS */
@@ -284,7 +284,7 @@ static inline int z_vrfy_counter_enable_capture(const struct device *dev,
 						uint8_t chan_id)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_enable_capture((const struct device *)dev, chan_id);
+	return z_impl_counter_enable_capture(dev, chan_id);
 }
 #include <zephyr/syscalls/counter_enable_capture_mrsh.c>
 
@@ -292,7 +292,7 @@ static inline int z_vrfy_counter_disable_capture(const struct device *dev,
 						 uint8_t chan_id)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
-	return z_impl_counter_disable_capture((const struct device *)dev, chan_id);
+	return z_impl_counter_disable_capture(dev, chan_id);
 }
 #include <zephyr/syscalls/counter_disable_capture_mrsh.c>
 #endif /* CONFIG_COUNTER_CAPTURE */
@@ -301,7 +301,7 @@ static inline int z_vrfy_counter_disable_capture(const struct device *dev,
 static inline int z_vrfy_counter_set_calibration(const struct device *dev, int32_t calibration)
 {
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, set_calibration));
-	return z_impl_counter_set_calibration((const struct device *)dev, calibration);
+	return z_impl_counter_set_calibration(dev, calibration);
 }
 #include <zephyr/syscalls/counter_set_calibration_mrsh.c>
 
@@ -309,7 +309,7 @@ static inline int z_vrfy_counter_get_calibration(const struct device *dev, int32
 {
 	K_OOPS(K_SYSCALL_DRIVER_COUNTER(dev, get_calibration));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(calibration, sizeof(int32_t)));
-	return z_impl_counter_get_calibration((const struct device *)dev, calibration);
+	return z_impl_counter_get_calibration(dev, calibration);
 }
 #include <zephyr/syscalls/counter_get_calibration_mrsh.c>
 #endif /* CONFIG_COUNTER_CALIBRATION */

--- a/drivers/dac/dac_handlers.c
+++ b/drivers/dac/dac_handlers.c
@@ -18,7 +18,7 @@ static inline int z_vrfy_dac_channel_setup(const struct device *dev,
 				(struct dac_channel_cfg *)user_channel_cfg,
 				sizeof(struct dac_channel_cfg)));
 
-	return z_impl_dac_channel_setup((const struct device *)dev,
+	return z_impl_dac_channel_setup(dev,
 					&channel_cfg);
 }
 #include <zephyr/syscalls/dac_channel_setup_mrsh.c>
@@ -28,7 +28,7 @@ static inline int z_vrfy_dac_write_value(const struct device *dev,
 {
 	K_OOPS(K_SYSCALL_DRIVER_DAC(dev, write_value));
 
-	return z_impl_dac_write_value((const struct device *)dev, channel,
+	return z_impl_dac_write_value(dev, channel,
 				      value);
 }
 #include <zephyr/syscalls/dac_write_value_mrsh.c>

--- a/drivers/eeprom/eeprom_handlers.c
+++ b/drivers/eeprom/eeprom_handlers.c
@@ -12,9 +12,7 @@ static inline int z_vrfy_eeprom_read(const struct device *dev, off_t offset,
 {
 	K_OOPS(K_SYSCALL_DRIVER_EEPROM(dev, read));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(data, len));
-	return z_impl_eeprom_read((const struct device *)dev, offset,
-				  (void *)data,
-				  len);
+	return z_impl_eeprom_read(dev, offset, data, len);
 }
 #include <zephyr/syscalls/eeprom_read_mrsh.c>
 
@@ -23,14 +21,13 @@ static inline int z_vrfy_eeprom_write(const struct device *dev, off_t offset,
 {
 	K_OOPS(K_SYSCALL_DRIVER_EEPROM(dev, write));
 	K_OOPS(K_SYSCALL_MEMORY_READ(data, len));
-	return z_impl_eeprom_write((const struct device *)dev, offset,
-				   (const void *)data, len);
+	return z_impl_eeprom_write(dev, offset, data, len);
 }
 #include <zephyr/syscalls/eeprom_write_mrsh.c>
 
 static inline size_t z_vrfy_eeprom_get_size(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_DRIVER_EEPROM(dev, size));
-	return z_impl_eeprom_get_size((const struct device *)dev);
+	return z_impl_eeprom_get_size(dev);
 }
 #include <zephyr/syscalls/eeprom_get_size_mrsh.c>

--- a/drivers/entropy/entropy_handlers.c
+++ b/drivers/entropy/entropy_handlers.c
@@ -13,8 +13,6 @@ static inline int z_vrfy_entropy_get_entropy(const struct device *dev,
 {
 	K_OOPS(K_SYSCALL_DRIVER_ENTROPY(dev, get_entropy));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(buffer, len));
-	return z_impl_entropy_get_entropy((const struct device *)dev,
-					  (uint8_t *)buffer,
-					  len);
+	return z_impl_entropy_get_entropy(dev, buffer, len);
 }
 #include <zephyr/syscalls/entropy_get_entropy_mrsh.c>

--- a/drivers/flash/flash_handlers.c
+++ b/drivers/flash/flash_handlers.c
@@ -13,9 +13,7 @@ static inline int z_vrfy_flash_read(const struct device *dev, off_t offset,
 {
 	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, read));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(data, len));
-	return z_impl_flash_read((const struct device *)dev, offset,
-				 (void *)data,
-				 len);
+	return z_impl_flash_read(dev, offset, data, len);
 }
 #include <zephyr/syscalls/flash_read_mrsh.c>
 
@@ -24,8 +22,7 @@ static inline int z_vrfy_flash_write(const struct device *dev, off_t offset,
 {
 	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, write));
 	K_OOPS(K_SYSCALL_MEMORY_READ(data, len));
-	return z_impl_flash_write((const struct device *)dev, offset,
-				  (const void *)data, len);
+	return z_impl_flash_write(dev, offset, data, len);
 }
 #include <zephyr/syscalls/flash_write_mrsh.c>
 
@@ -33,7 +30,7 @@ static inline int z_vrfy_flash_erase(const struct device *dev, off_t offset,
 				     size_t size)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_FLASH));
-	return z_impl_flash_erase((const struct device *)dev, offset, size);
+	return z_impl_flash_erase(dev, offset, size);
 }
 #include <zephyr/syscalls/flash_erase_mrsh.c>
 
@@ -41,7 +38,7 @@ static inline int z_vrfy_flash_get_size(const struct device *dev, uint64_t *size
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_FLASH));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(size, sizeof(*size)));
-	return z_impl_flash_get_size((const struct device *)dev, size);
+	return z_impl_flash_get_size(dev, size);
 }
 #include <zephyr/syscalls/flash_get_size_mrsh.c>
 
@@ -82,9 +79,7 @@ static inline int z_vrfy_flash_get_page_info_by_offs(const struct device *dev,
 {
 	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, page_layout));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(info, sizeof(struct flash_pages_info)));
-	return z_impl_flash_get_page_info_by_offs((const struct device *)dev,
-						  offs,
-						  (struct flash_pages_info *)info);
+	return z_impl_flash_get_page_info_by_offs(dev, offs, info);
 }
 #include <zephyr/syscalls/flash_get_page_info_by_offs_mrsh.c>
 
@@ -94,16 +89,14 @@ static inline int z_vrfy_flash_get_page_info_by_idx(const struct device *dev,
 {
 	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, page_layout));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(info, sizeof(struct flash_pages_info)));
-	return z_impl_flash_get_page_info_by_idx((const struct device *)dev,
-						 idx,
-						 (struct flash_pages_info *)info);
+	return z_impl_flash_get_page_info_by_idx(dev, idx, info);
 }
 #include <zephyr/syscalls/flash_get_page_info_by_idx_mrsh.c>
 
 static inline size_t z_vrfy_flash_get_page_count(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_DRIVER_FLASH(dev, page_layout));
-	return z_impl_flash_get_page_count((const struct device *)dev);
+	return z_impl_flash_get_page_count(dev);
 }
 #include <zephyr/syscalls/flash_get_page_count_mrsh.c>
 

--- a/drivers/i2c/i2c_handlers.c
+++ b/drivers/i2c/i2c_handlers.c
@@ -12,7 +12,7 @@ static inline int z_vrfy_i2c_configure(const struct device *dev,
 				       uint32_t dev_config)
 {
 	K_OOPS(K_SYSCALL_DRIVER_I2C(dev, configure));
-	return z_impl_i2c_configure((const struct device *)dev, dev_config);
+	return z_impl_i2c_configure(dev, dev_config);
 }
 #include <zephyr/syscalls/i2c_configure_mrsh.c>
 
@@ -65,9 +65,7 @@ static inline int z_vrfy_i2c_transfer(const struct device *dev,
 	K_OOPS(K_SYSCALL_MEMORY_ARRAY_READ(msgs, num_msgs,
 					   sizeof(struct i2c_msg)));
 
-	return copy_msgs_and_transfer((const struct device *)dev,
-				      (struct i2c_msg *)msgs,
-				      (uint8_t)num_msgs, (uint16_t)addr);
+	return copy_msgs_and_transfer(dev, msgs, num_msgs, addr);
 }
 #include <zephyr/syscalls/i2c_transfer_mrsh.c>
 

--- a/drivers/i2s/i2s_handlers.c
+++ b/drivers/i2s/i2s_handlers.c
@@ -45,7 +45,7 @@ static inline int z_vrfy_i2s_configure(const struct device *dev,
 	}
 
 do_configure:
-	ret = z_impl_i2s_configure((const struct device *)dev, dir, &config);
+	ret = z_impl_i2s_configure(dev, dir, &config);
 out:
 	return ret;
 }

--- a/drivers/i2s/i2s_handlers.c
+++ b/drivers/i2s/i2s_handlers.c
@@ -60,7 +60,7 @@ static inline int z_vrfy_i2s_buf_read(const struct device *dev,
 
 	K_OOPS(K_SYSCALL_DRIVER_I2S(dev, read));
 
-	ret = i2s_read((const struct device *)dev, &mem_block, &data_size);
+	ret = i2s_read(dev, &mem_block, &data_size);
 
 	if (!ret) {
 		const struct i2s_config *rx_cfg;
@@ -69,10 +69,9 @@ static inline int z_vrfy_i2s_buf_read(const struct device *dev,
 		/* Presumed to be configured otherwise the i2s_read() call
 		 * would have failed.
 		 */
-		rx_cfg = i2s_config_get((const struct device *)dev, I2S_DIR_RX);
+		rx_cfg = i2s_config_get(dev, I2S_DIR_RX);
 
-		copy_success = k_usermode_to_copy((void *)buf, mem_block,
-					      data_size);
+		copy_success = k_usermode_to_copy(buf, mem_block, data_size);
 
 		k_mem_slab_free(rx_cfg->mem_slab, mem_block);
 		K_OOPS(copy_success);
@@ -92,7 +91,7 @@ static inline int z_vrfy_i2s_buf_write(const struct device *dev,
 	void *mem_block;
 
 	K_OOPS(K_SYSCALL_DRIVER_I2S(dev, write));
-	tx_cfg = i2s_config_get((const struct device *)dev, I2S_DIR_TX);
+	tx_cfg = i2s_config_get(dev, I2S_DIR_TX);
 	if (!tx_cfg) {
 		return -EIO;
 	}
@@ -106,13 +105,13 @@ static inline int z_vrfy_i2s_buf_write(const struct device *dev,
 		return -ENOMEM;
 	}
 
-	ret = k_usermode_from_copy(mem_block, (void *)buf, size);
+	ret = k_usermode_from_copy(mem_block, buf, size);
 	if (ret) {
 		k_mem_slab_free(tx_cfg->mem_slab, mem_block);
 		K_OOPS(ret);
 	}
 
-	ret = i2s_write((const struct device *)dev, mem_block, size);
+	ret = i2s_write(dev, mem_block, size);
 	if (ret != 0) {
 		k_mem_slab_free(tx_cfg->mem_slab, mem_block);
 	}
@@ -127,6 +126,6 @@ static inline int z_vrfy_i2s_trigger(const struct device *dev,
 {
 	K_OOPS(K_SYSCALL_DRIVER_I2S(dev, trigger));
 
-	return z_impl_i2s_trigger((const struct device *)dev, dir, cmd);
+	return z_impl_i2s_trigger(dev, dir, cmd);
 }
 #include <zephyr/syscalls/i2s_trigger_mrsh.c>

--- a/drivers/i3c/i3c_handlers.c
+++ b/drivers/i3c/i3c_handlers.c
@@ -75,8 +75,6 @@ static inline int z_vrfy_i3c_transfer(struct i3c_device_desc *target,
 	K_OOPS(K_SYSCALL_MEMORY_ARRAY_READ(msgs, num_msgs,
 					   sizeof(struct i3c_msg)));
 
-	return copy_i3c_msgs_and_transfer((struct i3c_device_desc *)target,
-					  (struct i3c_msg *)msgs,
-					  (uint8_t)num_msgs);
+	return copy_i3c_msgs_and_transfer(target, msgs, num_msgs);
 }
 #include <zephyr/syscalls/i3c_transfer_mrsh.c>

--- a/drivers/ipm/ipm_handlers.c
+++ b/drivers/ipm/ipm_handlers.c
@@ -13,15 +13,14 @@ static inline int z_vrfy_ipm_send(const struct device *dev, int wait,
 {
 	K_OOPS(K_SYSCALL_DRIVER_IPM(dev, send));
 	K_OOPS(K_SYSCALL_MEMORY_READ(data, size));
-	return z_impl_ipm_send((const struct device *)dev, wait, id,
-			       (const void *)data, size);
+	return z_impl_ipm_send(dev, wait, id, data, size);
 }
 #include <zephyr/syscalls/ipm_send_mrsh.c>
 
 static inline int z_vrfy_ipm_max_data_size_get(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_DRIVER_IPM(dev, max_data_size_get));
-	return z_impl_ipm_max_data_size_get((const struct device *)dev);
+	return z_impl_ipm_max_data_size_get(dev);
 }
 #include <zephyr/syscalls/ipm_max_data_size_get_mrsh.c>
 
@@ -35,6 +34,6 @@ static inline uint32_t z_vrfy_ipm_max_id_val_get(const struct device *dev)
 static inline int z_vrfy_ipm_set_enabled(const struct device *dev, int enable)
 {
 	K_OOPS(K_SYSCALL_DRIVER_IPM(dev, set_enabled));
-	return z_impl_ipm_set_enabled((const struct device *)dev, enable);
+	return z_impl_ipm_set_enabled(dev, enable);
 }
 #include <zephyr/syscalls/ipm_set_enabled_mrsh.c>

--- a/drivers/led/led_handlers.c
+++ b/drivers/led/led_handlers.c
@@ -11,8 +11,7 @@ static inline int z_vrfy_led_blink(const struct device *dev, uint32_t led,
 				   uint32_t delay_on, uint32_t delay_off)
 {
 	K_OOPS(K_SYSCALL_DRIVER_LED(dev, blink));
-	return z_impl_led_blink((const struct device *)dev, led, delay_on,
-					delay_off);
+	return z_impl_led_blink(dev, led, delay_on, delay_off);
 }
 #include <zephyr/syscalls/led_blink_mrsh.c>
 
@@ -30,8 +29,7 @@ static inline int z_vrfy_led_set_brightness(const struct device *dev,
 					    uint8_t value)
 {
 	K_OOPS(K_SYSCALL_DRIVER_LED(dev, set_brightness));
-	return z_impl_led_set_brightness((const struct device *)dev, led,
-					 value);
+	return z_impl_led_set_brightness(dev, led, value);
 }
 #include <zephyr/syscalls/led_set_brightness_mrsh.c>
 
@@ -65,13 +63,13 @@ static inline int z_vrfy_led_set_color(const struct device *dev, uint32_t led,
 static inline int z_vrfy_led_on(const struct device *dev, uint32_t led)
 {
 	K_OOPS(K_SYSCALL_DRIVER_LED(dev, on));
-	return z_impl_led_on((const struct device *)dev, led);
+	return z_impl_led_on(dev, led);
 }
 #include <zephyr/syscalls/led_on_mrsh.c>
 
 static inline int z_vrfy_led_off(const struct device *dev, uint32_t led)
 {
 	K_OOPS(K_SYSCALL_DRIVER_LED(dev, off));
-	return z_impl_led_off((const struct device *)dev, led);
+	return z_impl_led_off(dev, led);
 }
 #include <zephyr/syscalls/led_off_mrsh.c>

--- a/drivers/pwm/pwm_handlers.c
+++ b/drivers/pwm/pwm_handlers.c
@@ -13,8 +13,7 @@ static inline int z_vrfy_pwm_set_cycles(const struct device *dev,
 					uint32_t pulse, pwm_flags_t flags)
 {
 	K_OOPS(K_SYSCALL_DRIVER_PWM(dev, set_cycles));
-	return z_impl_pwm_set_cycles((const struct device *)dev, channel,
-					 period, pulse, flags);
+	return z_impl_pwm_set_cycles(dev, channel, period, pulse, flags);
 }
 #include <zephyr/syscalls/pwm_set_cycles_mrsh.c>
 
@@ -24,8 +23,7 @@ static inline int z_vrfy_pwm_get_cycles_per_sec(const struct device *dev,
 {
 	K_OOPS(K_SYSCALL_DRIVER_PWM(dev, get_cycles_per_sec));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(cycles, sizeof(uint64_t)));
-	return z_impl_pwm_get_cycles_per_sec((const struct device *)dev,
-					     channel, (uint64_t *)cycles);
+	return z_impl_pwm_get_cycles_per_sec(dev, channel, cycles);
 }
 #include <zephyr/syscalls/pwm_get_cycles_per_sec_mrsh.c>
 
@@ -35,7 +33,7 @@ static inline int z_vrfy_pwm_enable_capture(const struct device *dev,
 					    uint32_t channel)
 {
 	K_OOPS(K_SYSCALL_DRIVER_PWM(dev, enable_capture));
-	return z_impl_pwm_enable_capture((const struct device *)dev, channel);
+	return z_impl_pwm_enable_capture(dev, channel);
 }
 #include <zephyr/syscalls/pwm_enable_capture_mrsh.c>
 
@@ -43,7 +41,7 @@ static inline int z_vrfy_pwm_disable_capture(const struct device *dev,
 					     uint32_t channel)
 {
 	K_OOPS(K_SYSCALL_DRIVER_PWM(dev, disable_capture));
-	return z_impl_pwm_disable_capture((const struct device *)dev, channel);
+	return z_impl_pwm_disable_capture(dev, channel);
 }
 #include <zephyr/syscalls/pwm_disable_capture_mrsh.c>
 
@@ -61,7 +59,7 @@ static inline int z_vrfy_pwm_capture_cycles(const struct device *dev,
 	K_OOPS(K_SYSCALL_DRIVER_PWM(dev, enable_capture));
 	K_OOPS(K_SYSCALL_DRIVER_PWM(dev, disable_capture));
 
-	err = z_impl_pwm_capture_cycles((const struct device *)dev, channel,
+	err = z_impl_pwm_capture_cycles(dev, channel,
 					flags, &period, &pulse, timeout);
 	if (period_cycles != NULL) {
 		K_OOPS(k_usermode_to_copy(period_cycles, &period,

--- a/drivers/sensor/sensor_handlers.c
+++ b/drivers/sensor/sensor_handlers.c
@@ -14,8 +14,7 @@ static inline int z_vrfy_sensor_attr_set(const struct device *dev,
 {
 	K_OOPS(K_SYSCALL_DRIVER_SENSOR(dev, attr_set));
 	K_OOPS(K_SYSCALL_MEMORY_READ(val, sizeof(struct sensor_value)));
-	return z_impl_sensor_attr_set((const struct device *)dev, chan, attr,
-				      (const struct sensor_value *)val);
+	return z_impl_sensor_attr_set(dev, chan, attr, val);
 }
 #include <zephyr/syscalls/sensor_attr_set_mrsh.c>
 
@@ -26,15 +25,14 @@ static inline int z_vrfy_sensor_attr_get(const struct device *dev,
 {
 	K_OOPS(K_SYSCALL_DRIVER_SENSOR(dev, attr_get));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(val, sizeof(struct sensor_value)));
-	return z_impl_sensor_attr_get((const struct device *)dev, chan, attr,
-				      (struct sensor_value *)val);
+	return z_impl_sensor_attr_get(dev, chan, attr, val);
 }
 #include <zephyr/syscalls/sensor_attr_get_mrsh.c>
 
 static inline int z_vrfy_sensor_sample_fetch(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_DRIVER_SENSOR(dev, sample_fetch));
-	return z_impl_sensor_sample_fetch((const struct device *)dev);
+	return z_impl_sensor_sample_fetch(dev);
 }
 #include <zephyr/syscalls/sensor_sample_fetch_mrsh.c>
 
@@ -42,8 +40,7 @@ static inline int z_vrfy_sensor_sample_fetch_chan(const struct device *dev,
 						  enum sensor_channel type)
 {
 	K_OOPS(K_SYSCALL_DRIVER_SENSOR(dev, sample_fetch));
-	return z_impl_sensor_sample_fetch_chan((const struct device *)dev,
-					       type);
+	return z_impl_sensor_sample_fetch_chan(dev, type);
 }
 #include <zephyr/syscalls/sensor_sample_fetch_chan_mrsh.c>
 
@@ -53,8 +50,7 @@ static inline int z_vrfy_sensor_channel_get(const struct device *dev,
 {
 	K_OOPS(K_SYSCALL_DRIVER_SENSOR(dev, channel_get));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(val, sizeof(struct sensor_value)));
-	return z_impl_sensor_channel_get((const struct device *)dev, chan,
-					 (struct sensor_value *)val);
+	return z_impl_sensor_channel_get(dev, chan, val);
 }
 #include <zephyr/syscalls/sensor_channel_get_mrsh.c>
 

--- a/drivers/serial/uart_handlers.c
+++ b/drivers/serial/uart_handlers.c
@@ -157,8 +157,7 @@ static inline int z_vrfy_uart_line_ctrl_set(const struct device *dev,
 					    uint32_t ctrl, uint32_t val)
 {
 	K_OOPS(K_SYSCALL_DRIVER_UART(dev, line_ctrl_set));
-	return z_impl_uart_line_ctrl_set((const struct device *)dev, ctrl,
-					 val);
+	return z_impl_uart_line_ctrl_set(dev, ctrl, val);
 }
 #include <zephyr/syscalls/uart_line_ctrl_set_mrsh.c>
 
@@ -167,8 +166,7 @@ static inline int z_vrfy_uart_line_ctrl_get(const struct device *dev,
 {
 	K_OOPS(K_SYSCALL_DRIVER_UART(dev, line_ctrl_get));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(val, sizeof(uint32_t)));
-	return z_impl_uart_line_ctrl_get((const struct device *)dev, ctrl,
-					 (uint32_t *)val);
+	return z_impl_uart_line_ctrl_get(dev, ctrl, val);
 }
 #include <zephyr/syscalls/uart_line_ctrl_get_mrsh.c>
 #endif /* CONFIG_UART_LINE_CTRL */
@@ -178,7 +176,7 @@ static inline int z_vrfy_uart_drv_cmd(const struct device *dev, uint32_t cmd,
 				      uint32_t p)
 {
 	K_OOPS(K_SYSCALL_DRIVER_UART(dev, drv_cmd));
-	return z_impl_uart_drv_cmd((const struct device *)dev, cmd, p);
+	return z_impl_uart_drv_cmd(dev, cmd, p);
 }
 #include <zephyr/syscalls/uart_drv_cmd_mrsh.c>
 #endif /* CONFIG_UART_DRV_CMD */

--- a/drivers/spi/spi_handlers.c
+++ b/drivers/spi/spi_handlers.c
@@ -80,8 +80,7 @@ static inline int z_vrfy_spi_transceive(const struct device *dev,
 	K_OOPS(K_SYSCALL_DRIVER_SPI(dev, transceive));
 
 	if (tx_bufs) {
-		const struct spi_buf_set *tx =
-			(const struct spi_buf_set *)tx_bufs;
+		const struct spi_buf_set *tx = tx_bufs;
 
 		K_OOPS(K_SYSCALL_MEMORY_READ(tx_bufs,
 					     sizeof(struct spi_buf_set)));
@@ -93,7 +92,7 @@ static inline int z_vrfy_spi_transceive(const struct device *dev,
 
 	if (rx_bufs) {
 		const struct spi_buf_set *rx =
-			(const struct spi_buf_set *)rx_bufs;
+			rx_bufs;
 
 		K_OOPS(K_SYSCALL_MEMORY_READ(rx_bufs,
 					     sizeof(struct spi_buf_set)));
@@ -109,7 +108,7 @@ static inline int z_vrfy_spi_transceive(const struct device *dev,
 				     K_OBJ_DRIVER_GPIO));
 	}
 
-	return copy_bufs_and_transceive((const struct device *)dev,
+	return copy_bufs_and_transceive(dev,
 					&config_copy,
 					&tx_bufs_copy,
 					&rx_bufs_copy);
@@ -121,6 +120,6 @@ static inline int z_vrfy_spi_release(const struct device *dev,
 {
 	K_OOPS(K_SYSCALL_MEMORY_READ(config, sizeof(*config)));
 	K_OOPS(K_SYSCALL_DRIVER_SPI(dev, release));
-	return z_impl_spi_release((const struct device *)dev, config);
+	return z_impl_spi_release(dev, config);
 }
 #include <zephyr/syscalls/spi_release_mrsh.c>

--- a/drivers/w1/w1_handlers.c
+++ b/drivers/w1/w1_handlers.c
@@ -11,7 +11,7 @@ static inline int z_vrfy_w1_reset_bus(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_DRIVER_W1(dev, reset_bus));
 
-	return z_impl_w1_reset_bus((const struct device *)dev);
+	return z_impl_w1_reset_bus(dev);
 }
 #include <zephyr/syscalls/w1_reset_bus_mrsh.c>
 
@@ -19,7 +19,7 @@ static inline int z_vrfy_w1_read_bit(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_DRIVER_W1(dev, read_bit));
 
-	return z_impl_w1_read_bit((const struct device *)dev);
+	return z_impl_w1_read_bit(dev);
 }
 #include <zephyr/syscalls/w1_read_bit_mrsh.c>
 
@@ -27,7 +27,7 @@ static inline int z_vrfy_w1_write_bit(const struct device *dev, bool bit)
 {
 	K_OOPS(K_SYSCALL_DRIVER_W1(dev, write_bit));
 
-	return z_impl_w1_write_bit((const struct device *)dev, bit);
+	return z_impl_w1_write_bit(dev, bit);
 }
 #include <zephyr/syscalls/w1_write_bit_mrsh.c>
 
@@ -35,7 +35,7 @@ static inline int z_vrfy_w1_read_byte(const struct device *dev)
 {
 	K_OOPS(K_SYSCALL_DRIVER_W1(dev, read_byte));
 
-	return z_impl_w1_read_byte((const struct device *)dev);
+	return z_impl_w1_read_byte(dev);
 }
 #include <zephyr/syscalls/w1_read_byte_mrsh.c>
 
@@ -43,7 +43,7 @@ static inline int z_vrfy_w1_write_byte(const struct device *dev, uint8_t byte)
 {
 	K_OOPS(K_SYSCALL_DRIVER_W1(dev, write_byte));
 
-	return z_impl_w1_write_byte((const struct device *)dev, (uint8_t)byte);
+	return z_impl_w1_write_byte(dev, byte);
 }
 #include <zephyr/syscalls/w1_write_byte_mrsh.c>
 
@@ -53,8 +53,7 @@ static inline int z_vrfy_w1_read_block(const struct device *dev,
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_W1));
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(buffer, len));
 
-	return z_impl_w1_read_block((const struct device *)dev,
-				    (uint8_t *)buffer, (size_t)len);
+	return z_impl_w1_read_block(dev, buffer, len);
 }
 #include <zephyr/syscalls/w1_read_block_mrsh.c>
 
@@ -64,8 +63,7 @@ static inline int z_vrfy_w1_write_block(const struct device *dev,
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_W1));
 	K_OOPS(K_SYSCALL_MEMORY_READ(buffer, len));
 
-	return z_impl_w1_write_block((const struct device *)dev,
-				     (const uint8_t *)buffer, (size_t)len);
+	return z_impl_w1_write_block(dev, buffer, len);
 }
 #include <zephyr/syscalls/w1_write_block_mrsh.c>
 
@@ -73,7 +71,7 @@ static inline int z_vrfy_w1_change_bus_lock(const struct device *dev, bool lock)
 {
 	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_W1));
 
-	return z_impl_w1_change_bus_lock((const struct device *)dev, lock);
+	return z_impl_w1_change_bus_lock(dev, lock);
 }
 #include <zephyr/syscalls/w1_change_bus_lock_mrsh.c>
 
@@ -106,10 +104,7 @@ static inline int z_vrfy_w1_search_bus(const struct device *dev,
 				    "callbacks may not be set from user mode"));
 	/* user_data is not dereferenced, no need to check parameter */
 
-	return z_impl_w1_search_bus((const struct device *)dev,
-				    (uint8_t)command, (uint8_t)family,
-				    (w1_search_callback_t)callback,
-				    (void *)user_data);
+	return z_impl_w1_search_bus(dev, command, family, callback, user_data);
 }
 
 #include <zephyr/syscalls/w1_search_bus_mrsh.c>

--- a/scripts/coccinelle/syscall_redundant_ptr_cast.cocci
+++ b/scripts/coccinelle/syscall_redundant_ptr_cast.cocci
@@ -1,0 +1,100 @@
+///
+/// In syscall verifiers (z_vrfy_*) a pointer parameter forwarded to the
+/// corresponding z_impl_* with an identical cast — (T *)ptr where ptr is
+/// already declared as T * — is redundant.  The cast silences compiler
+/// type-checking without adding any value; drop it.
+///
+// Confidence: High
+// Copyright (c) 2026 Hubble Network
+// SPDX-License-Identifier: Apache-2.0
+// Comments:
+//   Run with:
+//     spatch --sp-file scripts/coccinelle/misc/syscall_redundant_ptr_cast.cocci \
+//            --dir drivers/ --no-includes --include-headers -D report
+//   For automatic patching:
+//     spatch --sp-file scripts/coccinelle/misc/syscall_redundant_ptr_cast.cocci \
+//            --dir drivers/ --no-includes --include-headers -D patch \
+//            --in-place
+// Options: --no-includes --include-headers
+
+virtual context
+virtual org
+virtual report
+virtual patch
+
+@find depends on !(file in "ext")@
+identifier vrfy =~ "^z_vrfy_";
+identifier impl =~ "^z_impl_";
+type T;
+identifier ptr;
+position p;
+@@
+
+static inline int vrfy(..., T *ptr, ...) {
+  ...
+  impl(..., (T *)ptr@p, ...)
+  ...
+}
+
+// ======================================================================
+// Context mode
+// ======================================================================
+
+@depends on context && find@
+identifier find.vrfy;
+identifier find.impl;
+type find.T;
+identifier find.ptr;
+@@
+
+static inline int vrfy(..., T *ptr, ...) {
+  ...
+* impl(..., (T *)ptr, ...)
+  ...
+}
+
+// ======================================================================
+// Report mode
+// ======================================================================
+
+@script:python depends on report && find@
+vrfy << find.vrfy;
+ptr  << find.ptr;
+p    << find.p;
+@@
+
+msg = "redundant cast for pointer '%s' in %s: already the correct type, drop the cast" \
+      % (ptr, vrfy)
+coccilib.report.print_report(p[0], msg)
+
+// ======================================================================
+// Org mode
+// ======================================================================
+
+@script:python depends on org && find@
+vrfy << find.vrfy;
+ptr  << find.ptr;
+p    << find.p;
+@@
+
+msg = "redundant cast for pointer '%s' in %s: already the correct type, drop the cast" \
+      % (ptr, vrfy)
+msg_safe = msg.replace("[", "@(").replace("]", ")")
+cocci.print_main(msg_safe, p)
+
+// ======================================================================
+// Patch mode — remove the redundant cast
+// ======================================================================
+
+@fix depends on patch && !(file in "ext")@
+identifier vrfy =~ "^z_vrfy_";
+type T;
+identifier ptr;
+@@
+
+static inline int vrfy(..., T *ptr, ...) {
+<...
+- (T *)ptr
++ ptr
+...>
+}


### PR DESCRIPTION
Syscall verifier functions (z_vrfy_\*) were forwarding pointer parameters to the corresponding implementation (z_impl_\*) with identical casts — (T \*)ptr where ptr is already declared as T \*. 

It also adds a Coccinelle script to detect and fix the pattern automatically.