### PR TITLE
drivers: haptics: Documentation cleanup for haptic drivers

### DIFF
--- a/drivers/haptics/cirrus/cs40l26-firmware.c
+++ b/drivers/haptics/cirrus/cs40l26-firmware.c
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2026, Cirrus Logic, Inc.
+ * Copyright (c) 2026 Cirrus Logic, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 /**
  * @file
- * @brief Firmware for Cirrus Logic CS40L26/27 Haptic Devices
+ * @brief Firmware functions for Cirrus Logic CS40L26/27 haptic drivers
  */
 
 #include "cs40l26.h"

--- a/drivers/haptics/cirrus/cs40l26.c
+++ b/drivers/haptics/cirrus/cs40l26.c
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2026, Cirrus Logic, Inc.
+ * Copyright (c) 2026 Cirrus Logic, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 /**
  * @file
- * @brief Core Driver for Cirrus Logic CS40L26/27 Haptic Devices
+ * @brief Core functions for Cirrus Logic CS40L26/27 haptic drivers
  */
 
 #include "cs40l26.h"

--- a/drivers/haptics/cirrus/cs40l26.h
+++ b/drivers/haptics/cirrus/cs40l26.h
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2026, Cirrus Logic, Inc.
+ * Copyright (c) 2026 Cirrus Logic, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_DRIVERS_HAPTICS_CS40L26_H_
-#define ZEPHYR_DRIVERS_HAPTICS_CS40L26_H_
+#ifndef ZEPHYR_DRIVERS_HAPTICS_CIRRUS_CS40L26_H_
+#define ZEPHYR_DRIVERS_HAPTICS_CIRRUS_CS40L26_H_
 
 #include "cs40lxx.h"
 #include <sys/types.h>
@@ -98,4 +98,4 @@ int cs40l26_firmware_multi_write(const struct device *const dev,
 }
 #endif /* __cplusplus */
 
-#endif /* ZEPHYR_DRIVERS_HAPTICS_CS40L26_H_ */
+#endif /* ZEPHYR_DRIVERS_HAPTICS_CIRRUS_CS40L26_H_ */

--- a/drivers/haptics/cirrus/cs40l5x.c
+++ b/drivers/haptics/cirrus/cs40l5x.c
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2025, Cirrus Logic, Inc.
+ * Copyright (c) 2025 Cirrus Logic, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 /**
  * @file
- * @brief Core Driver for Cirrus Logic CS40L5x Haptic Devices
+ * @brief Core functions for Cirrus Logic CS40L5x haptic drivers
  */
 
 #include "cs40l5x.h"

--- a/include/zephyr/drivers/haptics/cs40l26.h
+++ b/include/zephyr/drivers/haptics/cs40l26.h
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file providing the API for the CS40L26/27 haptic driver
+ * @ingroup cs40l26_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_HAPTICS_CS40L26_H_
 #define ZEPHYR_INCLUDE_DRIVERS_HAPTICS_CS40L26_H_
 
@@ -13,9 +19,10 @@ extern "C" {
 #endif /* __cplusplus */
 
 /**
- * @file
- * @brief Public API for CS40L26 haptic driver
+ * @defgroup cs40l26_interface CS40L26/27
  * @ingroup haptics_interface_ext
+ * @brief CS40L26 Haptic Driver for LRA and VCM
+ * @{
  */
 
 /**
@@ -78,6 +85,8 @@ int cs40l26_select_output(const struct device *const dev, const enum cs40l26_ban
  * @retval <0 if failed
  */
 int cs40l26_set_gain(const struct device *const dev, const uint8_t gain);
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/haptics/cs40l5x.h
+++ b/include/zephyr/drivers/haptics/cs40l5x.h
@@ -27,7 +27,7 @@ extern "C" {
 /**
  * @defgroup cs40l5x_interface CS40L5x
  * @ingroup haptics_interface_ext
- * @brief CS40L5x Haptic Driver
+ * @brief CS40L5x Haptic Driver for LRA and VCM
  * @{
  */
 
@@ -260,4 +260,4 @@ int cs40l5x_upload_pwle(const struct device *const dev, const enum cs40l5x_custo
 }
 #endif /* __cplusplus */
 
-#endif
+#endif /* ZEPHYR_INCLUDE_DRIVERS_HAPTICS_CS40L5X_H_ */

--- a/include/zephyr/drivers/haptics/drv2605.h
+++ b/include/zephyr/drivers/haptics/drv2605.h
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- /**
-  * @file
-  * @brief Header file providing the API for the DRV2605 haptic driver
-  * @ingroup drv2605_interface
-  */
+/**
+ * @file
+ * @brief Header file providing the API for the DRV2605 haptic driver
+ * @ingroup drv2605_interface
+ */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_HAPTICS_DRV2605_H_
 #define ZEPHYR_INCLUDE_DRIVERS_HAPTICS_DRV2605_H_

--- a/include/zephyr/drivers/haptics/tm6605.h
+++ b/include/zephyr/drivers/haptics/tm6605.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2026 Anuj Deshpande
- *
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -23,7 +22,7 @@ extern "C" {
 /**
  * @defgroup tm6605_interface TM6605
  * @ingroup haptics_interface_ext
- * @brief TM6605 Linear Resonant Actuator (LRA) Haptic Driver
+ * @brief TM6605 Haptic Driver for LRA
  *
  * The TM6605 from Titan Micro Electronics is an I2C-controlled haptic driver
  * for LRAs. It exposes 44 pre-programmed effects selectable by ID and is


### PR DESCRIPTION
Unifies documentation for haptic drivers.

CS40L26/27 currently shows up under "Files" in Haptics documentation while the other three drivers show up under "Topics": https://docs.zephyrproject.org/latest/doxygen/html/group__haptics__interface__ext.html

<img width="1633" height="719" alt="image" src="https://github.com/user-attachments/assets/30e4b63c-9aad-4b88-818c-27cecdd5f5b2" />


Refactors CS40L26/27 accordingly and updates language for the device drivers to be uniform, e.g.,

- "XYZ Haptic Driver for [supported actuators]"

Here is a screenshot of the fixed documentation build:
<img width="1633" height="719" alt="image" src="https://github.com/user-attachments/assets/6c74ea66-eb8d-4e78-aaf4-26eabd9177cf" />