### PR TITLE
arch: arm64: fix user-mode stack guard boundary calculation

### DIFF
--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -435,7 +435,7 @@ static bool z_arm64_stack_corruption_check(struct arch_esf *esf, uint64_t esr, u
 #ifdef CONFIG_USERSPACE
 	else if ((_current->base.user_options & K_USER) != 0 && GET_ESR_EC(esr) == 0x24) {
 		sp_limit = (uint64_t)_current->stack_info.start;
-		guard_start = sp_limit - Z_ARM64_STACK_GUARD_SIZE;
+		guard_start = sp_limit - CONFIG_PRIVILEGED_STACK_SIZE - Z_ARM64_STACK_GUARD_SIZE;
 		sp = esf->sp;
 		if (sp <= sp_limit || (guard_start <= far && far <= sp_limit)) {
 			EXCEPTION_DUMP("STACK OVERFLOW FROM USERSPACE,"


### PR DESCRIPTION
z_arm64_stack_corruption_check() computed the user-mode stack guard page start by subtracting only Z_ARM64_STACK_GUARD_SIZE from stack_info.start.  However, the guard page is located below the privileged stack area, so CONFIG_PRIVILEGED_STACK_SIZE must also be subtracted.  Without this, the computed guard_start falls inside the privileged stack instead of the actual guard page, causing stack overflow detection to miss faults in the guard region.

Fixes #113388