### PR TITLE
arch: arm64: fix a4 result corruption

### DIFF
--- a/arch/arm64/core/smccc-call.S
+++ b/arch/arm64/core/smccc-call.S
@@ -18,11 +18,11 @@
 
 .macro SMCCC instr
 	\instr  #0
-	ldr     x4, [sp]
-	stp     x0, x1, [x4, __arm_smccc_res_t_a0_a1_OFFSET]
-	stp     x2, x3, [x4, __arm_smccc_res_t_a2_a3_OFFSET]
-	stp     x4, x5, [x4, __arm_smccc_res_t_a4_a5_OFFSET]
-	stp     x6, x7, [x4, __arm_smccc_res_t_a6_a7_OFFSET]
+	ldr     x9, [sp]
+	stp     x0, x1, [x9, __arm_smccc_res_t_a0_a1_OFFSET]
+	stp     x2, x3, [x9, __arm_smccc_res_t_a2_a3_OFFSET]
+	stp     x4, x5, [x9, __arm_smccc_res_t_a4_a5_OFFSET]
+	stp     x6, x7, [x9, __arm_smccc_res_t_a6_a7_OFFSET]
 	ret
 .endm
 


### PR DESCRIPTION
The SMCCC macro in arch/arm64/core/smccc-call.S used x4 to load the result pointer from the stack after the smc/hvc instruction.  However, per the SMCCC calling convention x4 holds the returned a4 value at that point, so loading the pointer overwrote the real return value and res->a4 ended up containing the result pointer itself.

Use x9 as the temporary register for the result pointer so that x4 is preserved until it is stored into res->a4.

Fixes #113379