### PR TITLE
arch: arm: fix boot params stack pointers

### DIFF
--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -70,12 +70,17 @@ BUILD_ASSERT(offsetof(struct boot_params, voting) == BOOT_PARAM_VOTING_OFFSET);
 
 volatile struct boot_params arm_cpu_boot_params = {
 	.mpid = -1,
-	.irq_sp = (char *)(z_interrupt_stacks + CONFIG_ISR_STACK_SIZE),
-	.fiq_sp = (char *)(z_arm_fiq_stack + CONFIG_ARMV7_FIQ_STACK_SIZE),
-	.abt_sp = (char *)(z_arm_abort_stack + CONFIG_ARMV7_EXCEPTION_STACK_SIZE),
-	.udf_sp = (char *)(z_arm_undef_stack + CONFIG_ARMV7_EXCEPTION_STACK_SIZE),
-	.svc_sp = (char *)(z_arm_svc_stack + CONFIG_ARMV7_SVC_STACK_SIZE),
-	.sys_sp = (char *)(z_arm_sys_stack + CONFIG_ARMV7_SYS_STACK_SIZE),
+	.irq_sp = (char *)z_interrupt_stacks[0] + K_KERNEL_STACK_RESERVED + CONFIG_ISR_STACK_SIZE,
+	.fiq_sp =
+		(char *)z_arm_fiq_stack[0] + K_KERNEL_STACK_RESERVED + CONFIG_ARMV7_FIQ_STACK_SIZE,
+	.abt_sp = (char *)z_arm_abort_stack[0] + K_KERNEL_STACK_RESERVED +
+		  CONFIG_ARMV7_EXCEPTION_STACK_SIZE,
+	.udf_sp = (char *)z_arm_undef_stack[0] + K_KERNEL_STACK_RESERVED +
+		  CONFIG_ARMV7_EXCEPTION_STACK_SIZE,
+	.svc_sp =
+		(char *)z_arm_svc_stack[0] + K_KERNEL_STACK_RESERVED + CONFIG_ARMV7_SVC_STACK_SIZE,
+	.sys_sp =
+		(char *)z_arm_sys_stack[0] + K_KERNEL_STACK_RESERVED + CONFIG_ARMV7_SYS_STACK_SIZE,
 };
 
 const uint32_t cpu_node_list[] = {
@@ -106,7 +111,7 @@ void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz, arch_cpustart_
 
 	cpu_count = ARRAY_SIZE(cpu_node_list);
 	__ASSERT(cpu_count == CONFIG_MP_MAX_NUM_CPUS,
-		"The count of CPU Cores nodes in dts is not equal to CONFIG_MP_MAX_NUM_CPUS\n");
+		 "The count of CPU Cores nodes in dts is not equal to CONFIG_MP_MAX_NUM_CPUS\n");
 
 	for (i = 0, j = 0; i < cpu_count; i++) {
 		if (cpu_node_list[i] == primary_core_mpid) {


### PR DESCRIPTION
arm_cpu_boot_params stack pointer fields used pointer arithmetic on two-dimensional K_KERNEL_STACK_ARRAY_DECLARE arrays before casting to char *, producing invalid initialized pointer values.

Use K_KERNEL_STACK_BUFFER() on the CPU 0 stack elements instead, matching the runtime initialization in arch_cpu_start().

Fixes #113125