### PR TITLE
Support input_pmw3610 with SPI RPI Pico PIO 3-wire mode

### DIFF
--- a/drivers/input/input_pmw3610.c
+++ b/drivers/input/input_pmw3610.c
@@ -120,6 +120,7 @@ static int pmw3610_read(const struct device *dev,
 			uint8_t addr, uint8_t *value, uint8_t len)
 {
 	const struct pmw3610_config *cfg = dev->config;
+	int ret;
 
 	const struct spi_buf tx_buf = {
 		.buf = &addr,
@@ -130,22 +131,23 @@ static int pmw3610_read(const struct device *dev,
 		.count = 1,
 	};
 
-	struct spi_buf rx_buf[] = {
-		{
-			.buf = NULL,
-			.len = sizeof(addr),
-		},
-		{
-			.buf = value,
-			.len = len,
-		},
+	struct spi_buf rx_buf = {
+		.buf = value,
+		.len = len,
 	};
 	const struct spi_buf_set rx = {
-		.buffers = rx_buf,
-		.count = ARRAY_SIZE(rx_buf),
+		.buffers = &rx_buf,
+		.count = 1,
 	};
 
-	return spi_transceive_dt(&cfg->spi, &tx, &rx);
+	ret = spi_write_dt(&cfg->spi, &tx);
+	if (ret) {
+		goto release;
+	}
+	ret = spi_read_dt(&cfg->spi, &rx);
+release:
+	spi_release_dt(&cfg->spi);
+	return ret;
 }
 
 static int pmw3610_read_reg(const struct device *dev, uint8_t addr, uint8_t *value)
@@ -156,6 +158,7 @@ static int pmw3610_read_reg(const struct device *dev, uint8_t addr, uint8_t *val
 static int pmw3610_write_reg(const struct device *dev, uint8_t addr, uint8_t value)
 {
 	const struct pmw3610_config *cfg = dev->config;
+	int ret;
 
 	uint8_t write_buf[] = {addr | SPI_WRITE, value};
 	const struct spi_buf tx_buf = {
@@ -167,7 +170,9 @@ static int pmw3610_write_reg(const struct device *dev, uint8_t addr, uint8_t val
 		.count = 1,
 	};
 
-	return spi_write_dt(&cfg->spi, &tx);
+	ret = spi_write_dt(&cfg->spi, &tx);
+	spi_release_dt(&cfg->spi);
+	return ret;
 }
 
 static int pmw3610_spi_clk_on(const struct device *dev)
@@ -562,7 +567,8 @@ static int pmw3610_pm_action(const struct device *dev,
 #endif
 
 #define PMW3610_SPI_MODE (SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | \
-			  SPI_MODE_CPOL | SPI_MODE_CPHA | SPI_TRANSFER_MSB)
+			  SPI_MODE_CPOL | SPI_MODE_CPHA | SPI_TRANSFER_MSB | \
+			  SPI_HOLD_ON_CS | SPI_LOCK_ON)
 
 #define PMW3610_INIT(n)								\
 	static const struct pmw3610_config pmw3610_cfg_##n = {			\

--- a/drivers/spi/spi_rpi_pico_pio.c
+++ b/drivers/spi/spi_rpi_pico_pio.c
@@ -68,12 +68,11 @@ struct spi_pico_pio_data {
 	uint32_t tx_count;
 	uint32_t rx_count;
 	size_t pio_sm;
+	size_t pio_rx_sm;
 	const pio_program_t *pio_tx_program;
 	const pio_program_t *pio_rx_program;
 	uint32_t pio_tx_offset;
 	uint32_t pio_rx_offset;
-	uint32_t pio_rx_wrap_target;
-	uint32_t pio_rx_wrap;
 	uint32_t bits;
 	uint32_t dfs;
 #if defined(CONFIG_SPI_RPI_PICO_PIO_DMA)
@@ -376,48 +375,81 @@ static int spi_pico_pio_configure(const struct spi_pico_pio_config *dev_cfg,
 
 	if (dev_cfg->sio_gpio.port) {
 #if SPI_RPI_PICO_PIO_HALF_DUPLEX_ENABLED
+		if (data->pio_rx_sm == (size_t) -1) {
+			rc = pio_rpi_pico_allocate_sm(dev_cfg->piodev, &data->pio_rx_sm);
+			if (rc < 0) {
+				return rc;
+			}
+		}
+
 		const struct gpio_dt_spec *sio = &dev_cfg->sio_gpio;
+		uint32_t tx_wrap_target, rx_wrap_target;
+		uint32_t tx_wrap, rx_wrap;
+		int tx_cycles, rx_cycles;
+		float tx_clock_div, rx_clock_div;
 
-		float clock_div = spi_pico_pio_clock_divisor(clock_freq, SPI_SIO_MODE_0_0_TX_CYCLES,
-							     spi_cfg->frequency);
+		if ((cpol == 0) && (cpha == 0)) {
+			data->pio_tx_program = RPI_PICO_PIO_GET_PROGRAM(spi_sio_mode_0_0_tx);
+			tx_wrap_target = RPI_PICO_PIO_GET_WRAP_TARGET(spi_sio_mode_0_0_tx);
+			tx_wrap = RPI_PICO_PIO_GET_WRAP(spi_sio_mode_0_0_tx);
+			tx_cycles = SPI_SIO_MODE_0_0_TX_CYCLES;
 
-		data->pio_tx_program =
-			(pio_program_t *)RPI_PICO_PIO_GET_PROGRAM(spi_sio_mode_0_0_tx);
+			data->pio_rx_program = RPI_PICO_PIO_GET_PROGRAM(spi_sio_mode_0_0_rx);
+			rx_wrap_target = RPI_PICO_PIO_GET_WRAP_TARGET(spi_sio_mode_0_0_rx);
+			rx_wrap = RPI_PICO_PIO_GET_WRAP(spi_sio_mode_0_0_rx);
+			rx_cycles = SPI_SIO_MODE_0_0_RX_CYCLES;
+		} else {
+			LOG_ERR("Not supported:  cpol=%d, cpha=%d", cpol, cpha);
+			return -ENOTSUP;
+		}
+
+		tx_clock_div = spi_pico_pio_clock_divisor(clock_freq, tx_cycles,
+							  spi_cfg->frequency);
+		rx_clock_div = spi_pico_pio_clock_divisor(clock_freq, rx_cycles,
+							  spi_cfg->frequency);
+
+		if (!pio_can_add_program(pio, data->pio_tx_program)) {
+			return -EBUSY;
+		}
 		data->pio_tx_offset = pio_add_program(pio, data->pio_tx_program);
-
-		data->pio_rx_program = RPI_PICO_PIO_GET_PROGRAM(spi_sio_mode_0_0_rx);
+		if (!pio_can_add_program(pio, data->pio_rx_program)) {
+			return -EBUSY;
+		}
 		data->pio_rx_offset = pio_add_program(pio, data->pio_rx_program);
-		data->pio_rx_wrap_target =
-			data->pio_rx_offset + RPI_PICO_PIO_GET_WRAP_TARGET(spi_sio_mode_0_0_rx);
-		data->pio_rx_wrap =
-			data->pio_rx_offset + RPI_PICO_PIO_GET_WRAP(spi_sio_mode_0_0_rx);
 
+		/* Configure TX SM */
 		sm_config = pio_get_default_sm_config();
 
-		sm_config_set_clkdiv(&sm_config, clock_div);
-		sm_config_set_in_pins(&sm_config, sio->pin);
-		sm_config_set_in_shift(&sm_config, lsb, true, data->bits);
+		sm_config_set_clkdiv(&sm_config, tx_clock_div);
 		sm_config_set_out_pins(&sm_config, sio->pin, 1);
 		sm_config_set_out_shift(&sm_config, lsb, false, data->bits);
-		hw_set_bits(&pio->input_sync_bypass, 1u << sio->pin);
 
 		sm_config_set_sideset_pins(&sm_config, clk->pin);
 		sm_config_set_sideset(&sm_config, 1, false, false);
-		sm_config_set_wrap(
-			&sm_config,
-			data->pio_tx_offset + RPI_PICO_PIO_GET_WRAP_TARGET(spi_sio_mode_0_0_tx),
-			data->pio_tx_offset + RPI_PICO_PIO_GET_WRAP(spi_sio_mode_0_0_tx));
+		sm_config_set_wrap(&sm_config, data->pio_tx_offset + tx_wrap_target,
+				   data->pio_tx_offset + tx_wrap);
+		pio_sm_init(pio, data->pio_sm, data->pio_tx_offset, &sm_config);
 
+		/* Configure RX SM */
+		sm_config_set_clkdiv(&sm_config, rx_clock_div);
+		sm_config_set_in_pins(&sm_config, sio->pin);
+		sm_config_set_in_shift(&sm_config, lsb, true, data->bits);
+
+		sm_config_set_wrap(&sm_config, data->pio_rx_offset + rx_wrap_target,
+				   data->pio_rx_offset + rx_wrap);
+		pio_sm_init(pio, data->pio_rx_sm, data->pio_rx_offset, &sm_config);
+
+		/* Enable the SMs */
+		hw_set_bits(&pio->input_sync_bypass, 1u << sio->pin);
+		pio_gpio_init(pio, sio->pin);
+		pio_gpio_init(pio, clk->pin);
 		pio_sm_set_pindirs_with_mask(pio, data->pio_sm,
 					     (BIT(clk->pin) | BIT(sio->pin)),
 					     (BIT(clk->pin) | BIT(sio->pin)));
-		pio_sm_set_pins_with_mask(pio, data->pio_sm, 0,
+		pio_sm_set_pins_with_mask(pio, data->pio_sm, (cpol << clk->pin),
 					  BIT(clk->pin) | BIT(sio->pin));
-		pio_gpio_init(pio, sio->pin);
-		pio_gpio_init(pio, clk->pin);
-
-		pio_sm_init(pio, data->pio_sm, data->pio_tx_offset, &sm_config);
 		pio_sm_set_enabled(pio, data->pio_sm, true);
+		pio_sm_set_enabled(pio, data->pio_rx_sm, true);
 #else
 		LOG_ERR("SIO pin requires half-duplex support");
 		return -EINVAL;
@@ -784,18 +816,8 @@ static void spi_pico_pio_txrx_3_wire(const struct device *dev)
 	PIO pio = pio_rpi_pico_get_pio(dev_cfg->piodev);
 
 	if (txbuf) {
-		pio_sm_set_enabled(pio, data->pio_sm, false);
-		pio_sm_set_wrap(pio, data->pio_sm,
-				data->pio_tx_offset +
-					RPI_PICO_PIO_GET_WRAP_TARGET(spi_sio_mode_0_0_tx),
-				data->pio_tx_offset + RPI_PICO_PIO_GET_WRAP(spi_sio_mode_0_0_tx));
 		pio_sm_clear_fifos(pio, data->pio_sm);
-		pio_sm_set_pindirs_with_mask(pio, data->pio_sm, BIT(sio_pin),
-					     BIT(sio_pin));
-		pio_sm_restart(pio, data->pio_sm);
-		pio_sm_clkdiv_restart(pio, data->pio_sm);
-		pio_sm_exec(pio, data->pio_sm, pio_encode_jmp(data->pio_tx_offset));
-		pio_sm_set_enabled(pio, data->pio_sm, true);
+		pio_sm_set_pindirs_with_mask(pio, data->pio_sm, BIT(sio_pin), BIT(sio_pin));
 
 		while (data->tx_count < tx_size) {
 			/* Fill up fifo with available TX data */
@@ -834,34 +856,27 @@ static void spi_pico_pio_txrx_3_wire(const struct device *dev)
 	}
 
 	if (rxbuf) {
-		pio_sm_set_enabled(pio, data->pio_sm, false);
-		pio_sm_set_wrap(pio, data->pio_sm, data->pio_rx_wrap_target,
-				data->pio_rx_wrap);
-		pio_sm_clear_fifos(pio, data->pio_sm);
-		pio_sm_set_pindirs_with_mask(pio, data->pio_sm, 0, BIT(sio_pin));
-		pio_sm_restart(pio, data->pio_sm);
-		pio_sm_clkdiv_restart(pio, data->pio_sm);
-		pio_sm_put(pio, data->pio_sm, (rx_size * data->bits) - 1);
-		pio_sm_exec(pio, data->pio_sm, pio_encode_jmp(data->pio_rx_offset));
-		pio_sm_set_enabled(pio, data->pio_sm, true);
+		pio_sm_clear_fifos(pio, data->pio_rx_sm);
+		pio_sm_set_pindirs_with_mask(pio, data->pio_rx_sm, 0, BIT(sio_pin));
+		pio_sm_put(pio, data->pio_rx_sm, (rx_size * data->bits) - 1);
 
 		while (data->rx_count < rx_size) {
-			while ((!pio_sm_is_rx_fifo_empty(pio, data->pio_sm)) &&
+			while ((!pio_sm_is_rx_fifo_empty(pio, data->pio_rx_sm)) &&
 			       data->rx_count < rx_size) {
 
 				switch (data->dfs) {
 				case 4: {
-					txrx = spi_pico_pio_sm_get32(pio, data->pio_sm);
+					txrx = spi_pico_pio_sm_get32(pio, data->pio_rx_sm);
 					sys_put_be32(txrx, rxbuf + (data->rx_count * 4));
 				} break;
 
 				case 2: {
-					txrx = spi_pico_pio_sm_get16(pio, data->pio_sm);
+					txrx = spi_pico_pio_sm_get16(pio, data->pio_rx_sm);
 					sys_put_be16(txrx, rxbuf + (data->rx_count * 2));
 				} break;
 
 				case 1: {
-					txrx = spi_pico_pio_sm_get8(pio, data->pio_sm);
+					txrx = spi_pico_pio_sm_get8(pio, data->pio_rx_sm);
 					rxbuf[data->rx_count] = (uint8_t)txrx;
 				} break;
 
@@ -1068,6 +1083,7 @@ int spi_pico_pio_init(const struct device *dev)
 	};                                                                                     \
 	static struct spi_pico_pio_data spi_pico_pio_data_##inst = {                           \
 		.pio_sm = (size_t) -1,                                                         \
+		.pio_rx_sm = (size_t) -1,                                                      \
 		.pio_tx_offset = PIO_MAX_OFFSET,                                               \
 		.pio_rx_offset = PIO_MAX_OFFSET,                                               \
 		SPI_CONTEXT_INIT_LOCK(spi_pico_pio_data_##inst, spi_ctx),                      \

--- a/drivers/spi/spi_rpi_pico_pio.c
+++ b/drivers/spi/spi_rpi_pico_pio.c
@@ -171,6 +171,42 @@ RPI_PICO_PIO_DEFINE_PROGRAM(spi_sio_mode_0_0_rx, SPI_SIO_MODE_0_0_RX_WRAP_TARGET
 			    0x0042, /*  3: jmp    x--, 2          side 0 */
 			    /*     .wrap */
 );
+
+/* ------------------- */
+/* spi_sio_mode_1_1_tx */
+/* ------------------- */
+
+#define SPI_SIO_MODE_1_1_TX_WRAP_TARGET 0
+#define SPI_SIO_MODE_1_1_TX_WRAP        2
+#define SPI_SIO_MODE_1_1_TX_CYCLES      2
+
+RPI_PICO_PIO_DEFINE_PROGRAM(spi_sio_mode_1_1_tx, SPI_SIO_MODE_1_1_TX_WRAP_TARGET,
+			    SPI_SIO_MODE_1_1_TX_WRAP,
+			    /*     .wrap_target */
+			    0x90a0, /*  0: pull   block           side 1 */
+			    0x6001, /*  1: out    pins, 1         side 0 */
+			    0x10e1, /*  2: jmp    !osre, 1        side 1 */
+			    /*     .wrap */
+);
+
+/* ------------------- */
+/* spi_sio_mode_1_1_rx */
+/* ------------------- */
+
+#define SPI_SIO_MODE_1_1_RX_WRAP_TARGET 0
+#define SPI_SIO_MODE_1_1_RX_WRAP        3
+#define SPI_SIO_MODE_1_1_RX_CYCLES      2
+
+RPI_PICO_PIO_DEFINE_PROGRAM(spi_sio_mode_1_1_rx, SPI_SIO_MODE_1_1_RX_WRAP_TARGET,
+			    SPI_SIO_MODE_1_1_RX_WRAP,
+			    /*     .wrap_target */
+			    0x90a0, /*  0: pull   block           side 1 */
+			    0x6020, /*  1: out    x, 32           side 0 */
+			    0x5001, /*  2: in     pins, 1         side 1 */
+			    0x0042, /*  3: jmp    x--, 2          side 0 */
+			    /*     .wrap */
+);
+
 #endif /* SPI_RPI_PICO_PIO_HALF_DUPLEX_ENABLED */
 
 static float spi_pico_pio_clock_divisor(const uint32_t clock_freq, int cycles,
@@ -330,8 +366,8 @@ static int spi_pico_pio_configure(const struct spi_pico_pio_config *dev_cfg,
 		}
 #endif
 
-		if ((cpol != 0) || (cpha != 0)) {
-			LOG_ERR("Only mode (0, 0) supported in 3-wire SIO");
+		if (cpol != cpha) {
+			LOG_ERR("Only mode (0, 0) and (1, 1) supported in 3-wire SIO");
 			return -ENOTSUP;
 		}
 
@@ -398,6 +434,16 @@ static int spi_pico_pio_configure(const struct spi_pico_pio_config *dev_cfg,
 			rx_wrap_target = RPI_PICO_PIO_GET_WRAP_TARGET(spi_sio_mode_0_0_rx);
 			rx_wrap = RPI_PICO_PIO_GET_WRAP(spi_sio_mode_0_0_rx);
 			rx_cycles = SPI_SIO_MODE_0_0_RX_CYCLES;
+		} else if ((cpol == 1) && (cpha == 1)) {
+			data->pio_tx_program = RPI_PICO_PIO_GET_PROGRAM(spi_sio_mode_1_1_tx);
+			tx_wrap_target = RPI_PICO_PIO_GET_WRAP_TARGET(spi_sio_mode_1_1_tx);
+			tx_wrap = RPI_PICO_PIO_GET_WRAP(spi_sio_mode_1_1_tx);
+			tx_cycles = SPI_SIO_MODE_1_1_TX_CYCLES;
+
+			data->pio_rx_program = RPI_PICO_PIO_GET_PROGRAM(spi_sio_mode_1_1_rx);
+			rx_wrap_target = RPI_PICO_PIO_GET_WRAP_TARGET(spi_sio_mode_1_1_rx);
+			rx_wrap = RPI_PICO_PIO_GET_WRAP(spi_sio_mode_1_1_rx);
+			rx_cycles = SPI_SIO_MODE_1_1_TX_CYCLES;
 		} else {
 			LOG_ERR("Not supported:  cpol=%d, cpha=%d", cpol, cpha);
 			return -ENOTSUP;


### PR DESCRIPTION
PMW3610 uses a 3-wire SPI protocol with cpol=1,cpha=1. This pull requests adds 3-wire cpol=1,cpha=1 support to the spi_rpi_pico_pio and adds support for the 3-wire SIO mode to input_pmw3610.

I developed this on a ZMK main with Zephyr 4.1.0+zmk-fixes. While porting my patches to current Zephyr main I had to resolve some conflicts with the DMA patches that landed in the mean time. I was able to build and test the resulting spi_rpi_pico_pio.c in my ZMK build on the 4.1 branch.

I tested on an Adafruit KB2040. The PMW3610 patch was also tested on a nice!nano to ensure the pmw3610 changes are still compatible with spi_nrfx_spim.