### PR TITLE
bluetooth: classic: Add `BT_DEV_READY` checks to BR/EDR APIs

### DIFF
--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -1084,6 +1084,10 @@ int bt_br_discovery_start(const struct bt_br_discovery_param *param,
 
 	LOG_DBG("");
 
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
+
 	if (!valid_br_discov_param(param, cnt)) {
 		return -EINVAL;
 	}
@@ -1191,6 +1195,10 @@ static int write_scan_enable(uint8_t scan)
 
 int bt_br_set_connectable(bool enable, bt_br_conn_req_func_t func)
 {
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
+
 	if (enable) {
 		if (atomic_test_bit(bt_dev.flags, BT_DEV_PSCAN)) {
 			return -EALREADY;
@@ -1331,6 +1339,10 @@ static K_WORK_DELAYABLE_DEFINE(bt_br_limited_discoverable_timeout,
 int bt_br_set_discoverable(bool enable, bool limited)
 {
 	int err;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
 
 	if (enable) {
 		if (atomic_test_bit(bt_dev.flags, BT_DEV_ISCAN)) {
@@ -1668,6 +1680,10 @@ int bt_br_write_eir(const struct bt_data *eir, size_t eir_count, bool fec_requir
 	struct bt_hci_cp_write_ext_inquiry_response *cp;
 	struct net_buf *buf;
 	size_t offset = 0;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
 
 	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (buf == NULL) {

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -1084,6 +1084,10 @@ int bt_br_discovery_start(const struct bt_br_discovery_param *param,
 
 	LOG_DBG("");
 
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
+
 	if (!valid_br_discov_param(param, cnt)) {
 		return -EINVAL;
 	}
@@ -1191,6 +1195,10 @@ static int write_scan_enable(uint8_t scan)
 
 int bt_br_set_connectable(bool enable, bt_br_conn_req_func_t func)
 {
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
+
 	if (enable) {
 		if (atomic_test_bit(bt_dev.flags, BT_DEV_PSCAN)) {
 			return -EALREADY;
@@ -1344,6 +1352,10 @@ static K_WORK_DELAYABLE_DEFINE(bt_br_limited_discoverable_timeout,
 int bt_br_set_discoverable(bool enable, bool limited)
 {
 	int err;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
 
 	if (enable) {
 		if (atomic_test_bit(bt_dev.flags, BT_DEV_ISCAN)) {
@@ -1681,6 +1693,10 @@ int bt_br_write_eir(const struct bt_data *eir, size_t eir_count, bool fec_requir
 	struct bt_hci_cp_write_ext_inquiry_response *cp;
 	struct net_buf *buf;
 	size_t offset = 0;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return -EAGAIN;
+	}
 
 	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (buf == NULL) {

--- a/subsys/bluetooth/host/classic/conn_br.c
+++ b/subsys/bluetooth/host/classic/conn_br.c
@@ -32,6 +32,7 @@
 #include "common/assert.h"
 #include "common/bt_str.h"
 
+#include "host/hci_core.h"
 #include "host/conn_internal.h"
 #include "host/l2cap_internal.h"
 #include "host/keys.h"
@@ -55,6 +56,10 @@ struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
 	struct bt_hci_cp_connect *cp;
 	struct bt_conn *conn;
 	struct net_buf *buf;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return NULL;
+	}
 
 	conn = bt_conn_lookup_addr_br(peer);
 	if (conn) {

--- a/subsys/bluetooth/host/classic/conn_br.c
+++ b/subsys/bluetooth/host/classic/conn_br.c
@@ -32,6 +32,7 @@
 #include <common/assert.h>
 #include <common/bt_str.h>
 
+#include <host/hci_core.h>
 #include <host/conn_internal.h>
 #include <host/l2cap_internal.h>
 #include <host/keys.h>
@@ -55,6 +56,10 @@ struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
 	struct bt_hci_cp_connect *cp;
 	struct bt_conn *conn;
 	struct net_buf *buf;
+
+	if (!atomic_test_bit(bt_dev.flags, BT_DEV_READY)) {
+		return NULL;
+	}
 
 	conn = bt_conn_lookup_addr_br(peer);
 	if (conn) {


### PR DESCRIPTION
Add checks for `BT_DEV_READY` flag in Bluetooth Classic (BR/EDR) API functions to prevent operations before the Bluetooth stack is fully initialized.

The following functions now return `-EAGAIN` if called before the stack is ready, including functions `bt_br_discovery_start()`, `bt_br_set_connectable()`, `bt_br_set_discoverable()`, and `bt_br_write_eir()`.

For the function `bt_conn_create_br()`, it returns `NULL` if the stack is not ready.

The changes prevent potential issues from attempting BR/EDR operations before the controller and host are properly initialized.