### PR TITLE
pcie: host: shell: add offload capability probe

### DIFF
--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -391,12 +391,63 @@ static int cmd_pcie_ls(const struct shell *sh, size_t argc, char **argv)
 
 	return 0;
 }
+
+static int cmd_pcie_offload_capabilities(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id, exp_offset, devcap2;
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie offload <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	exp_offset = pcie_get_cap(bdf, PCI_CAP_ID_EXP);
+	if (exp_offset == 0U) {
+		shell_error(sh, "Target device does not support native PCIe Capabilities.");
+		return -EOPNOTSUPP;
+	}
+
+	devcap2 = pcie_conf_read(bdf, exp_offset + 9U);
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   SILICON HARDWARE TRANSPORT OVERLAY DECODER MATRIX: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   Raw DEVCAP2 Value: 0x%08X", devcap2);
+	shell_print(sh, "   ----------------------------------------------------");
+	shell_print(sh, "   Supported Physical Transaction Offloads:");
+	shell_print(sh, "      Alternative Routing-ID (ARI) : [%s]",
+		    (devcap2 & PCI_EXP_DEVCAP2_ARI_MASK) ? "SUPPORTED" : "UNAVAILABLE");
+	shell_print(sh, "      Single-Root I/O Virt (SR-IOV): [%s]",
+		    (devcap2 & PCI_EXP_DEVCAP2_SRIOV_MASK) ? "SUPPORTED" : "UNAVAILABLE");
+	shell_print(sh, "      NVMe MMIO Transport Offloads : [%s]",
+		    (devcap2 & PCI_EXP_DEVCAP2_NVME_OFFLOAD) ? "DEPLOYED" : "UNAVAILABLE");
+	shell_print(sh, "====================================================================");
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_pcie_cmds,
-	SHELL_CMD_ARG(ls, NULL,
-		      "List PCIE devices\n"
-		      "Usage: ls [bus:device:function] [dump]",
-		      cmd_pcie_ls, 1, 2),
-	SHELL_SUBCMD_SET_END /* Array terminated. */
-);
+			       SHELL_CMD_ARG(ls, NULL,
+					     "List PCIE devices\n"
+					     "Usage: ls [bus:device:function] [dump]",
+					     cmd_pcie_ls, 1, 2),
+			       SHELL_CMD_ARG(offload, NULL,
+					     "Probe dynamic vector routing capabilities\n"
+					     "Usage: offload <bus:device.function>",
+					     cmd_pcie_offload_capabilities, 2, 0),
+			       SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(pcie, &sub_pcie_cmds, "PCI(e) device information", cmd_pcie_ls);

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -578,6 +578,11 @@ extern bool pcie_connect_dynamic_irq(pcie_bdf_t bdf,
 	ARCH_PCIE_IRQ_CONNECT(bdf_p, irq_p, priority_p,			\
 			      isr_p, isr_param_p, flags_p)
 
+/* Device Capabilities 2 Register Decoding Masks */
+#define PCI_EXP_DEVCAP2_ARI_MASK     0x00000020U /* Bit 5: Alternative Routing-ID */
+#define PCI_EXP_DEVCAP2_SRIOV_MASK   0x00000010U /* Bit 4: Single Root I/O Virt */
+#define PCI_EXP_DEVCAP2_NVME_OFFLOAD 0x000000C0U /* Memory-mapped offload markers */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Introduce a dynamic hardware capability offload telemetry probe command to the common PCIe host shell subsystem layer.

The capability subsystem automatically resolves and decodes the Device Capabilities 2 (DEVCAP2) register map via the native pcie_get_cap() engine. It evaluates bitmasks for Alternative Routing-ID (ARI), Single-Root I/O Virtualization (SR-IOV), and NVMe MMIO transaction offloads.

```text
uart:~$ pcie offload 1:0.0 
====================================================================
   SILICON HARDWARE TRANSPORT OVERLAY DECODER MATRIX: 1:0.0
====================================================================
   Raw DEVCAP2 Value: 0x00300020
   ----------------------------------------------------
   Supported Physical Transaction Offloads:
      Alternative Routing-ID (ARI) : [SUPPORTED]
      Single-Root I/O Virt (SR-IOV): [UNAVAILABLE]
      NVMe MMIO Transport Offloads : [UNAVAILABLE]
====================================================================
uart:~$ pcie offload 0:1.0
```