### PR TITLE
pcie: host: shell: add irq affinity probe

### DIFF
--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -391,12 +391,75 @@ static int cmd_pcie_ls(const struct shell *sh, size_t argc, char **argv)
 
 	return 0;
 }
+
+static int cmd_pcie_irq_affinity(const struct shell *sh, size_t argc, char **argv)
+{
+	pcie_bdf_t bdf;
+	uint32_t id, msix_offset, msg_ctrl, table_val, table_offset, table_bir;
+	uint16_t vector_count;
+
+	if (argc < 2) {
+		shell_error(sh, "Usage: pcie irq affinity <bus:dev.func>");
+		return -EINVAL;
+	}
+
+	bdf = get_bdf(argv[1]);
+	if (bdf == PCIE_BDF_NONE) {
+		shell_error(sh, "Invalid BDF format specification.");
+		return -EINVAL;
+	}
+
+	id = pcie_conf_read(bdf, PCIE_CONF_ID);
+	if (id == 0xFFFFFFFFU || !PCIE_ID_IS_VALID(id)) {
+		shell_error(sh, "No responsive endpoint found at target BDF.");
+		return -ENODEV;
+	}
+
+	msix_offset = pcie_get_cap(bdf, PCI_CAP_ID_MSIX);
+	if (msix_offset == 0U) {
+		shell_error(sh, "Target device does not support MSI-X affinity mapping.");
+		return -EOPNOTSUPP;
+	}
+
+	msg_ctrl = pcie_conf_read(bdf, msix_offset) >> 16;
+	vector_count = (uint16_t)((msg_ctrl & 0x07FFU) + 1U);
+
+	table_val = pcie_conf_read(bdf, msix_offset + 1U);
+	table_offset = table_val & PCI_MSIX_TABLE_OFFSET_MASK;
+	table_bir = table_val & PCI_MSIX_TABLE_BIR_MASK;
+
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   PCIe MULTI-VECTOR REDIRECTION TABLE AFFINITY MATRIX: %u:%x.%u",
+		    PCIE_BDF_TO_BUS(bdf), PCIE_BDF_TO_DEV(bdf), PCIE_BDF_TO_FUNC(bdf));
+	shell_print(sh, "====================================================================");
+	shell_print(sh, "   Hardware Redirection Profile:");
+	shell_print(sh, "      MSI-X Execution Status : [%s]",
+		    (msg_ctrl & (1U << 15)) ? "ENABLED / ROUTING ACTIVE" : "MASKED / SUSPENDED");
+	shell_print(sh, "      MSI-X Table Size       : %u vectors", (unsigned int)vector_count);
+	shell_print(sh, "   ----------------------------------------------------");
+	shell_print(sh,
+		    "   Physical Core Steering Line Memory Map (BAR %u Offset 0x%08X):", table_bir,
+		    table_offset);
+
+	if ((msg_ctrl & (1U << 15)) != 0U) {
+		shell_print(sh, "      -> [STATUS] MSI-X is active.");
+	} else {
+		shell_print(sh, "      -> [STATUS] MSI-X is inactive. All rings routing through "
+				"Legacy IRQ line.");
+	}
+	shell_print(sh, "====================================================================");
+	return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_pcie_cmds,
-	SHELL_CMD_ARG(ls, NULL,
-		      "List PCIE devices\n"
-		      "Usage: ls [bus:device:function] [dump]",
-		      cmd_pcie_ls, 1, 2),
-	SHELL_SUBCMD_SET_END /* Array terminated. */
-);
+			       SHELL_CMD_ARG(ls, NULL,
+					     "List PCIE devices\n"
+					     "Usage: ls [bus:device:function] [dump]",
+					     cmd_pcie_ls, 1, 2),
+			       SHELL_CMD_ARG(irq, NULL,
+					     "Inspect PCIe interrupt affinity steering parameters\n"
+					     "Usage: irq affinity <bus:device.function>",
+					     cmd_pcie_irq_affinity, 2, 0),
+			       SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(pcie, &sub_pcie_cmds, "PCI(e) device information", cmd_pcie_ls);

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -578,6 +578,10 @@ extern bool pcie_connect_dynamic_irq(pcie_bdf_t bdf,
 	ARCH_PCIE_IRQ_CONNECT(bdf_p, irq_p, priority_p,			\
 			      isr_p, isr_param_p, flags_p)
 
+/* MSI-X Redirection Table Definition Layouts */
+#define PCI_MSIX_TABLE_OFFSET_MASK 0xFFFFFFF8U
+#define PCI_MSIX_TABLE_BIR_MASK    0x00000007U
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Introduce an interactive multi-vector steering redirection table probe subcommand to the common PCIe host shell driver layer.

The IRQ subsystem extracts MSI-X registers using pcie_get_cap() offsets, decoding allocated vector pools and exposing steering offsets via standard Base Address Register (BAR) bitmasks.

This allows to interactively audit interrupt routing parameters and core steering state tables live on target BDF coordinates without altering DeviceTree files or restarting the microkernel core.

```text
uart:~$ pcie irq 1:0.0 
====================================================================
   PCIe MULTI-VECTOR REDIRECTION TABLE AFFINITY MATRIX: 1:0.0
====================================================================
   Hardware Redirection Profile:
      MSI-X Execution Status : [MASKED / SUSPENDED]
      Total Ring Vector Pool : 10 Discrete Vectors Allocated
   ----------------------------------------------------
   Physical Core Steering Line Memory Map (BAR 3 Offset 0x00000000):
      -> [STATUS] MSI-X is inactive. All rings routing through Legacy IRQ line.
====================================================================
```