### PR TITLE
samples: sensor: sensor_shell: fix riscv64 base pytest flaky/failing

### DIFF
--- a/samples/sensor/sensor_shell/boards/qemu_riscv64_qemu_virt_riscv64.conf
+++ b/samples/sensor/sensor_shell/boards/qemu_riscv64_qemu_virt_riscv64.conf
@@ -1,3 +1,8 @@
 CONFIG_SHELL_STACK_SIZE=4096
 CONFIG_SHELL_BACKEND_SERIAL_TX_RING_BUFFER_SIZE=1024
 CONFIG_SHELL_PRINTF_BUFF_SIZE=256
+# The interrupt-driven shell cannot echo the next command within the harness's
+# 1 s timeout while draining the large "sensor get" burst under QEMU icount
+# mode, which advances virtual time slowly in wall-clock terms. Disable icount
+# so the guest runs at host speed, matching the already-passing smp variant.
+CONFIG_QEMU_ICOUNT=n


### PR DESCRIPTION
## Summary

`sample.sensor.shell.pytest` fails on `qemu_riscv64/qemu_virt_riscv64` (the base, interrupt-driven variant) with the harness reporting:

```
AssertionError: Did not find line ".*sensor\ get\ sensor@0\ <n>" within 1.0 seconds
```

part-way through the `sensor get` channel dump. It reproduces on **every retry** under CI load, while the `smp` and `smode` variants pass. This is independent of any sensor driver — it surfaced as a `twister-build (2)` failure on an unrelated PR whose changes do not touch this sample, and it is the only failing test configuration in that job.

## Root cause

The base board enables QEMU icount mode: `CONFIG_QEMU_ICOUNT` defaults to `y` via `default y if !NETWORKING && !BT` in `boards/Kconfig`, and this sample uses neither networking nor BT. icount advances the guest on deterministic virtual time, which runs slowly in wall-clock terms, so while the interrupt-driven shell thread drains the large `sensor get` burst it is late echoing the next command and the harness hits its hard-coded 1 s command-echo timeout.

- The `smp` variant passes because its board defconfig already sets `CONFIG_QEMU_ICOUNT=n`.
- The `smode` variant passes because it uses the polling shell backend (`CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN=n`).

The earlier fix (bumping shell stack / TX ring buffer / printf buffer) reduced but did not eliminate the failure on this variant.

## Fix

Disable icount for the base variant, matching the already-passing `smp` variant, so the guest runs at host speed and echoes commands promptly.

## Testing

Verified locally on `qemu_riscv64/qemu_virt_riscv64`:

- **Without** the change: deterministic failure (fails on every run).
- **With** the change: 5/5 clean runs.
- `qemu_riscv64/qemu_virt_riscv64/smp` continues to pass.

```
west twister -p qemu_riscv64/qemu_virt_riscv64 -s sample.sensor.shell.pytest
```