### PR TITLE
tests: kernel: Fix changing SoC specific Kconfig

### DIFF
--- a/tests/kernel/context/prj.conf
+++ b/tests/kernel/context/prj.conf
@@ -6,6 +6,3 @@ CONFIG_MP_MAX_NUM_CPUS=1
 # idle is the scheduled user timer. Timeslicing would break that by
 # rescheduling its own periodic slice timeout behind our back.
 CONFIG_TIMESLICING=n
-
-# On MAX32, this will prevent WFI by default, so disable this config
-CONFIG_MAX32_ON_ENTER_CPU_IDLE_HOOK=n

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -80,6 +80,12 @@ extern const int32_t z_sys_timer_irq_for_test;
 #define HAS_POWERSAVE_INSTRUCTION
 #endif
 
+/* MAX32 CPU idle hook prevents WFI, so no powersave instruction if that
+ * config is set.
+ */
+#if defined(CONFIG_MAX32_ON_ENTER_CPU_IDLE_HOOK)
+#undef HAS_POWERSAVE_INSTRUCTION
+#endif
 
 /* whisper simulator does not currently have working implementation for
  * wfi instruction. It simply treats wfi as no-op such that k_cpu_idle()


### PR DESCRIPTION
Fixes wrongly setting a Kconfig for all devices for a Kconfig that is SoC specific