### PR TITLE
﻿dts: arm: st: stm32f1: add STM32F103X6 SoC description

### DIFF
--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -215,15 +215,6 @@
 			status = "disabled";
 		};
 
-		usart3: serial@40004800 {
-			compatible = "st,stm32-usart", "st,stm32-uart";
-			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
-			resets = <&rctl STM32_RESET(APB1, 18)>;
-			interrupts = <39 0>;
-			status = "disabled";
-		};
-
 		i2c1: i2c@40005400 {
 			compatible = "st,stm32-i2c-v1";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
@@ -232,18 +223,6 @@
 			reg = <0x40005400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <31 0>, <32 0>;
-			interrupt-names = "event", "error";
-			status = "disabled";
-		};
-
-		i2c2: i2c@40005800 {
-			compatible = "st,stm32-i2c-v1";
-			clock-frequency = <I2C_BITRATE_STANDARD>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
-			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
 		};
@@ -360,35 +339,6 @@
 			};
 		};
 
-		timers4: timers@40000800 {
-			compatible = "st,stm32-timers";
-			reg = <0x40000800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
-				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
-			resets = <&rctl STM32_RESET(APB1, 2)>;
-			interrupts = <30 0>;
-			interrupt-names = "global";
-			st,prescaler = <0>;
-			status = "disabled";
-
-			pwm {
-				compatible = "st,stm32-pwm";
-				status = "disabled";
-				#pwm-cells = <3>;
-			};
-
-			counter {
-				compatible = "st,stm32-counter";
-				status = "disabled";
-			};
-
-			qdec {
-				compatible = "st,stm32-qdec";
-				st,input-filter-level = <NO_FILTER>;
-				status = "disabled";
-			};
-		};
-
 		rtc: rtc@40002800 {
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
@@ -455,14 +405,6 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		i2c = <&i2c1>;
-		status = "disabled";
-	};
-
-	smbus2: smbus2 {
-		compatible = "st,stm32-smbus";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		i2c = <&i2c2>;
 		status = "disabled";
 	};
 };

--- a/dts/arm/st/f1/stm32f100Xb.dtsi
+++ b/dts/arm/st/f1/stm32f100Xb.dtsi
@@ -45,6 +45,56 @@
 			status = "disabled";
 		};
 
+		usart3: serial@40004800 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
+			interrupts = <39 0>;
+			status = "disabled";
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "st,stm32-i2c-v1";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
+			interrupts = <33 0>, <34 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+		};
+
+		timers4: timers@40000800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
+				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1, 2)>;
+			interrupts = <30 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
@@ -56,5 +106,13 @@
 
 	die_temp: dietemp {
 		v25 = <1410>;
+	};
+
+	smbus2: smbus2 {
+		compatible = "st,stm32-smbus";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c = <&i2c2>;
+		status = "disabled";
 	};
 };

--- a/dts/arm/st/f1/stm32f103X6.dtsi
+++ b/dts/arm/st/f1/stm32f103X6.dtsi
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <st/f1/stm32f1.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(10)>;
+	};
+
+	soc {
+		compatible = "st,stm32f103", "st,stm32f1", "simple-bus";
+
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(32)>;
+				ranges = <0 0x8000000 DT_SIZE_K(32)>;
+				erase-block-size = <DT_SIZE_K(1)>;
+			};
+		};
+
+		usb: usb@40005c00 {
+			compatible = "st,stm32-usb";
+			reg = <0x40005c00 0x400>;
+			interrupts = <20 0>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <8>;
+			ram-size = <512>;
+			maximum-speed = "full-speed";
+			status = "disabled";
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
+			phys = <&usb_fs_phy>;
+		};
+
+		can1: can@40006400 {
+			compatible = "st,stm32-bxcan";
+			reg = <0x40006400 0x400>;
+			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
+			interrupt-names = "TX", "RX0", "RX1", "SCE";
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
+			status = "disabled";
+		};
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+	};
+};

--- a/dts/arm/st/f1/stm32f103X8.dtsi
+++ b/dts/arm/st/f1/stm32f103X8.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/f1/stm32f1.dtsi>
+#include <st/f1/stm32f103X6.dtsi>
 
 / {
 	sram0: memory@20000000 {
@@ -12,8 +12,6 @@
 	};
 
 	soc {
-		compatible = "st,stm32f103", "st,stm32f1", "simple-bus";
-
 		flash-controller@40022000 {
 			flash0: flash@8000000 {
 				reg = <0x08000000 DT_SIZE_K(64)>;
@@ -36,31 +34,62 @@
 			status = "disabled";
 		};
 
-		usb: usb@40005c00 {
-			compatible = "st,stm32-usb";
-			reg = <0x40005c00 0x400>;
-			interrupts = <20 0>;
-			interrupt-names = "usb";
-			num-bidir-endpoints = <8>;
-			ram-size = <512>;
-			maximum-speed = "full-speed";
+		usart3: serial@40004800 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
+			interrupts = <39 0>;
 			status = "disabled";
-			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
-			phys = <&usb_fs_phy>;
 		};
 
-		can1: can@40006400 {
-			compatible = "st,stm32-bxcan";
-			reg = <0x40006400 0x400>;
-			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
-			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
+		i2c2: i2c@40005800 {
+			compatible = "st,stm32-i2c-v1";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
+			interrupts = <33 0>, <34 0>;
+			interrupt-names = "event", "error";
 			status = "disabled";
+		};
+
+		timers4: timers@40000800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
+				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1, 2)>;
+			interrupts = <30 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
 		};
 	};
 
-	usb_fs_phy: usbphy {
-		compatible = "usb-nop-xceiv";
-		#phy-cells = <0>;
+	smbus2: smbus2 {
+		compatible = "st,stm32-smbus";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c = <&i2c2>;
+		status = "disabled";
 	};
 };

--- a/dts/arm/st/f1/stm32f105.dtsi
+++ b/dts/arm/st/f1/stm32f105.dtsi
@@ -62,6 +62,56 @@
 			#io-channel-cells = <1>;
 		};
 
+		usart3: serial@40004800 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x40004800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
+			resets = <&rctl STM32_RESET(APB1, 18)>;
+			interrupts = <39 0>;
+			status = "disabled";
+		};
+
+		i2c2: i2c@40005800 {
+			compatible = "st,stm32-i2c-v1";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40005800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
+			interrupts = <33 0>, <34 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+		};
+
+		timers4: timers@40000800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
+				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1, 2)>;
+			interrupts = <30 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
@@ -182,5 +232,13 @@
 	otgfs_phy: otgfs_phy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;
+	};
+
+	smbus2: smbus2 {
+		compatible = "st,stm32-smbus";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c = <&i2c2>;
+		status = "disabled";
 	};
 };


### PR DESCRIPTION
## Description

Introduces `stm32f103X6.dtsi`, the SoC description for the
low-density STM32F103x4/x6 line, needed by #112998.

### Changes

- **New:** `stm32f103X6.dtsi` — base for the low-density F103 line.
- `stm32f103X8.dtsi` — now includes X6 instead of `stm32f1.dtsi`;
  adds i2c2/usart3/timers4.
- `stm32f1.dtsi` — removes i2c2/usart3/timers4/smbus2 (not universal
  across the F1 family).
- `stm32f100Xb.dtsi`, `stm32f105.dtsi` — gain local copies of those
  nodes, since they include `stm32f1.dtsi` directly and don't chain
  through X8 (same pattern already used there for spi2).

### Testing

Build-tested (`samples/hello_world`) on all boards whose SoC chain is
affected: stm32vl_disco, stm3210c_eval, nucleo_f103rb,
olimexino_stm32, stm32_h103, stm32_min_dev, stm32f103_mini,
waveshare_open103z, e80_900mbl_01 and all passed.

### Related

This is a prerequisite for #112998, which adds the
`stm32_LD_min_dev` board on top of `stm32f103X6.dtsi`.