### PR TITLE
soc: nordic: Use static macro for printk when printk goes through logging

### DIFF
--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -15,10 +15,6 @@
  * @{
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 struct emul;
 
 /* #includes required after forward-declaration of struct emul later defined in this header. */
@@ -30,6 +26,10 @@ struct emul;
 #include <zephyr/drivers/mspi_emul.h>
 #include <zephyr/drivers/uart_emul.h>
 #include <zephyr/sys/iterable_sections.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * The types of supported buses.

--- a/soc/nordic/Kconfig.defconfig
+++ b/soc/nordic/Kconfig.defconfig
@@ -36,4 +36,7 @@ config UART_USE_RUNTIME_CONFIGURE
 config PINCTRL_KEEP_SLEEP_STATE
 	default y
 
+config LOG_PRINTK_STATIC
+	default y
+
 endif # SOC_FAMILY_NORDIC_NRF


### PR DESCRIPTION
When logging is enabled and printk goes through the logging, enable using macro for printk which statically creates logging message instead of the runtime mode which is more time consuming and requires string formatting function to be compiled in.

Initially macro-approach for printk was by default enabled (#112464) but there were CI failures and it was changed to be by default disabled (#112692). Wrong placement of  `extern "C"` in `emul.h` was one of the failures root cause and it is fixed in this PR. Another thing is that [nxp hal ](https://github.com/zephyrproject-rtos/hal_nxp/blob/b0d24fd6fd036f54a43721f4b0415df43317d7e0/mcux/middleware/wifi_nxp/cli/wifi_shell.c#L148) is doing a lot `(void)PRINTF(...)` where `#define PRINTF printk` and this `(void)` is failing to compile when printk is a macro and it's not easy to consume this casting. 