### PR TITLE
drivers: timer: add generic companion counter mechanism support

### DIFF
--- a/drivers/timer/Kconfig.mcux_os
+++ b/drivers/timer/Kconfig.mcux_os
@@ -10,6 +10,7 @@ config MCUX_OS_TIMER
 	select TICKLESS_CAPABLE
 	select TIMER_HAS_64BIT_CYCLE_COUNTER
 	select RESET
+	select SYSTEM_TIMER_HAS_LPM_COMPANION_SUPPORT
 	help
 	  This module implements a kernel device driver for the NXP OS
 	  event timer and provides the standard "system clock driver" interfaces.

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -10,12 +10,14 @@
 
 #include <zephyr/init.h>
 #include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/drivers/timer/system_timer_lpm.h>
 #include <zephyr/drivers/timer/nxp_os_timer.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/pm/pm.h>
+#include <zephyr/pm/state.h>
 #include <zephyr/drivers/reset.h>
 #include "fsl_ostimer.h"
 #if !defined(CONFIG_SOC_FAMILY_MCXN) && !defined(CONFIG_SOC_FAMILY_MCXA)
@@ -39,13 +41,34 @@ static OSTIMER_Type *base = (OSTIMER_Type *)DT_INST_REG_ADDR(0);
  * certain deep sleep modes and the time elapsed when it is powered off.
  */
 static uint64_t cyc_sys_compensated;
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
+/*
+ * Some SoCs power off the OS Timer domain in deep low-power states (e.g. RT700
+ * Deep Sleep Retention), so it cannot wake the system. Two companion mechanisms
+ * keep timekeeping and wakeup working across such a state:
+ *   - Generic system-timer LPM companion (CONFIG_SYSTEM_TIMER_LPM_COMPANION_*
+ *     + /chosen/zephyr,system-timer-companion); board-agnostic, preferred.
+ *   - Legacy "deep-sleep-counter" phandle on the nxp,os-timer node, for boards
+ *     whose companion counter does not fit the generic Counter alarm API.
+ */
+#if defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER) || \
+	defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_HOOKS)
+#define MCUX_OS_TIMER_LPM_GENERIC 1
+/* Indicates the low-power companion has been armed for the current sleep. */
+static bool lpm_companion_armed;
+#elif DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
+/* Legacy deep-sleep-counter path (see comment above). */
+#define MCUX_OS_TIMER_LPM_LEGACY 1
 /* This is the counter device used when OS timer is not available in standby mode. */
 static const struct device *counter_dev =
 	DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(0, deep_sleep_counter));
 /* Indicates if the counter is running. */
 static bool counter_running;
 static uint32_t counter_max_val;
+#endif
+
+/* Either companion mechanism enables the shared low-power timeout integration. */
+#if defined(MCUX_OS_TIMER_LPM_GENERIC) || defined(MCUX_OS_TIMER_LPM_LEGACY)
+#define MCUX_OS_TIMER_LPM 1
 #endif
 /* Indicates we received a call with ticks set to wait forever */
 static bool wait_forever;
@@ -100,7 +123,62 @@ void mcux_lpc_ostick_isr(const void *arg)
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? elapsed_ticks : 1);
 }
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
+#if defined(MCUX_OS_TIMER_LPM_GENERIC)
+
+/* In a handoff-power-state the OS Timer is powered off and cannot wake the
+ * system, so delegate wakeup to the generic companion and capture the OS Timer
+ * value (lost across the state) for restoration on wakeup.
+ */
+static uint32_t mcux_lpc_ostick_set_counter_timeout(uint64_t timeout_us)
+{
+	/* Arm the system-timer low-power companion to wake the system. */
+	z_sys_clock_lpm_enter(timeout_us);
+	lpm_companion_armed = true;
+
+	/* Capture the OS Timer value; it loses its state in a handoff-power-state. */
+	cyc_sys_compensated += OSTIMER_GetCurrentTimerValue(base);
+
+	/* The OS Timer is not a wakeup source for this state (the companion is), but
+	 * it still has its previous match interrupt enabled. If that match is pending
+	 * when the low-power entry executes WFI, WFI returns immediately and the state
+	 * is never entered, so mask the match interrupt here. The kernel re-enables it
+	 * after wakeup when it programs the next timeout.
+	 */
+	base->OSEVENT_CTRL &= ~OSTIMER_OSEVENT_CTRL_OSTIMER_INTENA_MASK;
+
+	return 0;
+}
+
+static uint32_t mcux_lpc_ostick_compensate_system_timer(void)
+{
+	uint64_t slept_time_us;
+
+	if (!lpm_companion_armed) {
+		return 0;
+	}
+	lpm_companion_armed = false;
+
+	/* Recover the time spent in low power from the companion counter. */
+	slept_time_us = z_sys_clock_lpm_exit();
+	cyc_sys_compensated += (uint64_t)CYC_PER_US * slept_time_us;
+
+	/* The OS Timer lost its state in the handoff-power-state; reset it to a
+	 * known state and reinitialize it.
+	 */
+	const struct reset_dt_spec reset = RESET_DT_SPEC_INST_GET_OR(0, {0});
+
+	if (reset.dev != NULL) {
+		reset_line_toggle_dt(&reset);
+	}
+	OSTIMER_Init(base);
+
+	/* Announce the time slept to the kernel. */
+	mcux_lpc_ostick_isr(NULL);
+
+	return 0;
+}
+
+#elif defined(MCUX_OS_TIMER_LPM_LEGACY) /* legacy deep-sleep-counter path */
 
 static struct counter_top_cfg top_cfg = {0};
 static struct counter_alarm_cfg alarm_cfg = {0};
@@ -203,6 +281,48 @@ static uint32_t mcux_lpc_ostick_compensate_system_timer(void)
 	return 0;
 }
 
+#endif /* MCUX_OS_TIMER_LPM_GENERIC / MCUX_OS_TIMER_LPM_LEGACY */
+
+#if defined(MCUX_OS_TIMER_LPM)
+/* Whether the OS Timer stops keeping time in a power state and must hand off to
+ * the companion. Driven by "handoff-power-states"; the legacy deep-sleep-counter
+ * path (no such property) falls back to PM_STATE_STANDBY.
+ */
+#if DT_INST_NODE_HAS_PROP(0, handoff_power_states)
+#define OS_TIMER_HANDOFF_STATE(node_id, prop, idx) \
+	PM_STATE_DT_INIT(DT_PHANDLE_BY_IDX(node_id, prop, idx)),
+static const enum pm_state os_timer_handoff_states[] = {
+	DT_INST_FOREACH_PROP_ELEM(0, handoff_power_states, OS_TIMER_HANDOFF_STATE)
+};
+static bool os_timer_state_needs_handoff(enum pm_state state)
+{
+	ARRAY_FOR_EACH(os_timer_handoff_states, i) {
+		if (os_timer_handoff_states[i] == state) {
+			return true;
+		}
+	}
+	return false;
+}
+#elif defined(MCUX_OS_TIMER_LPM_LEGACY)
+/* Legacy deep-sleep-counter boards do not set handoff-power-states; keep the
+ * historical behavior of handing off in PM_STATE_STANDBY.
+ */
+static inline bool os_timer_state_needs_handoff(enum pm_state state)
+{
+	return state == PM_STATE_STANDBY;
+}
+#else
+static inline bool os_timer_state_needs_handoff(enum pm_state state)
+{
+	ARG_UNUSED(state);
+	return false;
+}
+#endif /* handoff-power-states */
+
+/* Poke-path helper: the SoC signals a low-power entry via a zero-tick idle
+ * timeout. Hand off to the companion only when the next power state is one in
+ * which the OS Timer stops keeping time (handoff-power-states).
+ */
 static void mcux_os_timer_set_lp_counter_timeout(void)
 {
 	uint64_t timeout;
@@ -211,7 +331,7 @@ static void mcux_os_timer_set_lp_counter_timeout(void)
 	 * For these cases, we start a counter that can wakeup
 	 * from low power modes.
 	 */
-	if (pm_state_next_get(0)->state != PM_STATE_STANDBY) {
+	if (!os_timer_state_needs_handoff(pm_state_next_get(0)->state)) {
 		return;
 	}
 
@@ -237,7 +357,7 @@ static void mcux_os_timer_set_lp_counter_timeout(void)
 }
 #else
 #define mcux_os_timer_set_lp_counter_timeout(...) do { } while (0)
-#endif
+#endif /* MCUX_OS_TIMER_LPM */
 
 bool z_nxp_os_timer_ignore_timer_wakeup(void)
 {
@@ -251,7 +371,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
+#if defined(MCUX_OS_TIMER_LPM)
 	/* We intercept calls from idle with a 0 tick count when PM=y */
 	if (idle && (ticks == 0)) {
 		mcux_os_timer_set_lp_counter_timeout();
@@ -266,7 +386,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	wait_forever = (ticks == SYS_CLOCK_MAX_WAIT);
 #else
 	ARG_UNUSED(idle);
-#endif
+#endif /* MCUX_OS_TIMER_LPM */
 	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 
 	k_spinlock_key_t key = k_spin_lock(&lock);
@@ -322,14 +442,14 @@ uint64_t sys_clock_cycle_get_64(void)
 
 void sys_clock_idle_exit(void)
 {
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
-	/* The tick should be compensated for states where the
-	 * OS Timer is disabled
+#if defined(MCUX_OS_TIMER_LPM)
+	/* Recover the tick for a handoff-power-state where the OS Timer was
+	 * disabled. compensate() no-ops if the companion was not armed.
 	 */
-	if (pm_state_next_get(0)->state == PM_STATE_STANDBY) {
+	if (os_timer_state_needs_handoff(pm_state_next_get(0)->state)) {
 		mcux_lpc_ostick_compensate_system_timer();
 	}
-#endif
+#endif /* MCUX_OS_TIMER_LPM */
 }
 
 static int sys_clock_driver_init(void)
@@ -345,7 +465,7 @@ static int sys_clock_driver_init(void)
 	irq_enable(DT_INST_IRQN(0));
 
 /* On some SoC's, OS Timer cannot wakeup from low power mode in standby modes */
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
+#if defined(MCUX_OS_TIMER_LPM_LEGACY)
 	counter_dev = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(0, deep_sleep_counter));
 	if (NULL != counter_dev) {
 		counter_max_val = counter_get_max_top_value(counter_dev);

--- a/dts/bindings/timer/nxp,os-timer.yaml
+++ b/dts/bindings/timer/nxp,os-timer.yaml
@@ -21,6 +21,16 @@ properties:
       certain deep power down modes. The OS Timer driver will use this
       counter to wakeup and also to keep track of system time.
 
+  handoff-power-states:
+    type: phandles
+    description: |
+      List of power states in which the OS Timer is powered off or reset and can
+      no longer keep time. When the system is about to enter one of these states,
+      the driver hands timekeeping over to the low-power companion selected by
+      /chosen/zephyr,system-timer-companion for the duration of that state. Each
+      phandle points to a "zephyr,power-state" node. If omitted, the OS Timer is
+      assumed to keep time in all low-power states and no handoff is performed.
+
   resets:
     type: phandle-array
     description: reset line


### PR DESCRIPTION
Some NXP SoCs power off the power domain containing the OS Timer in deep low-power states (e.g. Deep Sleep Retention on RT700). Once powered off, the OS Timer can neither keep time nor wake the system. Therefore, before entering such states, the driver must hand off both duties — timekeeping and timed wakeup — to a companion timer that stays alive in the low-power state, and after wakeup, compensate the slept time back into the system clock.

1. Legacy mechanism
The board hangs a deep-sleep-counter phandle on the nxp,os-timer node, pointing to a counter device that keeps working in low-power states (e.g. rtc_highres on RW612), and the driver operates it directly via the Counter API (counter_set_top_value/alarm). Limitations: the state is hardcoded to PM_STATE_STANDBY, it depends on the specific standby node label, the companion must fit into the Counter alarm API, and every board carries its own private convention.

2. New mechanism
Reuse the existing generic system-timer LPM companion framework. The driver no longer operates the counter itself; it only calls two framework interfaces: before entering low power, z_sys_clock_lpm_enter(timeout_us) arms the companion for a timed wakeup; after wakeup, z_sys_clock_lpm_exit() retrieves how many microseconds were actually slept, accumulates that into cyc_sys_compensated, and announces it to the kernel via a single ISR call.

New handoff-power-states property
The legacy path hardcodes the answer as PM_STATE_STANDBY and binds to the standby node label at compile time. But on a different chip, the state where the OS Timer loses power may be something else (e.g. RT700's DSR, which is a suspend-to-RAM-like state), and there may be more than one such state.

The new property is a phandle list pointing directly to zephyr,power-state nodes in the DT. At compile time the driver expands it into a state table with PM_STATE_DT_INIT(); at runtime os_timer_state_needs_handoff() looks up the table to decide whether the next state requires a handoff — describing the capability rather than binding to a specific instance name.