### PR TITLE
arch: arm64: mmu: add MT_NORMAL_WT to get_region_desc() switch

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -239,7 +239,7 @@ static void debug_show_pte(uint64_t *pte, unsigned int level)
 
 	uint8_t mem_type = (*pte >> 2) & MT_TYPE_MASK;
 
-	MMU_DEBUG((mem_type == MT_NORMAL) ? "MEM" :
+	MMU_DEBUG((mem_type == MT_NORMAL || mem_type == MT_NORMAL_WT) ? "MEM" :
 		  ((mem_type == MT_NORMAL_NC) ? "NC" : "DEV"));
 	MMU_DEBUG((*pte & PTE_BLOCK_DESC_AP_RO) ? "-RO" : "-RW");
 	MMU_DEBUG((*pte & PTE_BLOCK_DESC_NS) ? "-NS" : "-S");
@@ -744,6 +744,7 @@ static uint64_t get_region_desc(uint32_t attrs)
 		break;
 	case MT_NORMAL_NC:
 	case MT_NORMAL:
+	case MT_NORMAL_WT:
 		/* Make Normal RW memory as execute never */
 		if ((attrs & MT_RW) || (attrs & MT_P_EXECUTE_NEVER)) {
 			desc |= PTE_BLOCK_DESC_PXN;
@@ -761,7 +762,7 @@ static uint64_t get_region_desc(uint32_t attrs)
 		}
 #endif
 
-		if (mem_type == MT_NORMAL) {
+		if (mem_type == MT_NORMAL || mem_type == MT_NORMAL_WT) {
 			desc |= PTE_BLOCK_DESC_INNER_SHARE;
 		} else {
 			desc |= PTE_BLOCK_DESC_OUTER_SHARE;


### PR DESCRIPTION
MT_NORMAL_WT (Write-Through Normal memory) was defined in the MAIR table but missing from the get_region_desc() switch.  Mappings created with K_MEM_CACHE_WT fell through to the implicit default, leaving shareability unset (NON_SHAREABLE), PXN/UXN unset (executable), and no GP bit for BTI.

Add MT_NORMAL_WT alongside MT_NORMAL so it inherits Inner Shareability and the execute-never logic.  Also fix the debug log to recognize MT_NORMAL_WT as "MEM" instead of "DEV".

Fixes #113472