### PR TITLE
babblesim bt hci_uart: Build and run with twister

### DIFF
--- a/samples/bluetooth/hci_uart/tests.yaml
+++ b/samples/bluetooth/hci_uart/tests.yaml
@@ -1,6 +1,10 @@
 sample:
   name: Bluetooth HCI UART
   description: Allows Zephyr to provide Bluetooth connectivity via UART
+common:
+  tags:
+    - uart
+    - bluetooth
 tests:
   sample.bluetooth.hci_uart.nrf5:
     harness: bluetooth
@@ -16,9 +20,6 @@ tests:
       - nrf21540dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-    tags:
-      - uart
-      - bluetooth
   sample.bluetooth.hci_uart.nrf52833.df:
     harness: bluetooth
     platform_allow: nrf52833dk/nrf52833
@@ -27,18 +28,12 @@ tests:
     extra_args: DTC_OVERLAY_FILE=./boards/nrf52833dk_nrf52833_df.overlay
     extra_configs:
       - CONFIG_BT_CTLR_DF=y
-    tags:
-      - uart
-      - bluetooth
   sample.bluetooth.hci_uart.nrf5340_netcore.df:
     harness: bluetooth
     platform_allow: nrf5340dk/nrf5340/cpunet
     extra_args: DTC_OVERLAY_FILE=./boards/nrf5340dk_nrf5340_cpunet_df.overlay
     extra_configs:
       - CONFIG_BT_CTLR_DF=y
-    tags:
-      - uart
-      - bluetooth
   sample.bluetooth.hci_uart.nrf52833.df.iq_report:
     harness: bluetooth
     platform_allow: nrf52833dk/nrf52833
@@ -48,9 +43,6 @@ tests:
     extra_configs:
       - CONFIG_BT_CTLR_DF=y
       - CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT=y
-    tags:
-      - uart
-      - bluetooth
   sample.bluetooth.hci_uart.nrf5340_netcore.df.iq_report:
     harness: bluetooth
     platform_allow: nrf5340dk/nrf5340/cpunet
@@ -58,18 +50,12 @@ tests:
     extra_configs:
       - CONFIG_BT_CTLR_DF=y
       - CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT=y
-    tags:
-      - uart
-      - bluetooth
   sample.bluetooth.hci_uart.nrf5340dk_cpuapp:
     harness: bluetooth
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
-    tags:
-      - uart
-      - bluetooth
   sample.bluetooth.hci_uart.nrf5340_audio_dk_cpuapp.fem:
     harness: bluetooth
     platform_allow:
@@ -77,9 +63,6 @@ tests:
     integration_platforms:
       - nrf5340_audio_dk/nrf5340/cpuapp
     extra_args: DTC_OVERLAY_FILE=./boards/nrf5340_audio_dk_nrf5340_cpuapp_nrf21540_ek.overlay
-    tags:
-      - uart
-      - bluetooth
   sample.bluetooth.hci_uart.nrf52833.all:
     harness: bluetooth
     platform_allow: nrf52833dk/nrf52833
@@ -88,9 +71,6 @@ tests:
     extra_args:
       - EXTRA_CONF_FILE=overlay-all-bt_ll_sw_split.conf
       - DTC_OVERLAY_FILE=./boards/nrf52833dk_nrf52833_df.overlay
-    tags:
-      - uart
-      - bluetooth
   sample.bluetooth.hci_uart.nrf54l15.all:
     harness: bluetooth
     platform_allow: nrf54l15dk/nrf54l15/cpuapp
@@ -99,9 +79,6 @@ tests:
     extra_args:
       - EXTRA_CONF_FILE=overlay-all-bt_ll_sw_split.conf
       - DTC_OVERLAY_FILE=./boards/nrf54l15dk_nrf54l15_cpuapp_df.overlay
-    tags:
-      - uart
-      - bluetooth
   sample.bluetooth.hci_uart.nrf54lm20a.all:
     harness: bluetooth
     platform_allow: nrf54lm20dk/nrf54lm20a/cpuapp
@@ -110,6 +87,11 @@ tests:
     extra_args:
       - EXTRA_CONF_FILE=overlay-all-bt_ll_sw_split.conf
       - DTC_OVERLAY_FILE=./boards/nrf54lm20dk_nrf54lm20a_cpuapp_df.overlay
-    tags:
-      - uart
-      - bluetooth
+  sample.bluetooth.hci_uart.bsim:
+    depends_on: bsim
+    build_only: true
+    platform_allow:
+      - nrf52_bsim
+    harness: bsim
+    harness_config:
+      bsim_exe_name: samples_bluetooth_hci_uart_prj_conf

--- a/samples/bluetooth/hci_uart_async/tests.yaml
+++ b/samples/bluetooth/hci_uart_async/tests.yaml
@@ -9,11 +9,21 @@ sample:
     over a UART.
 
     This implementation is based on the Zephyr Asynchronous UART API.
+
+common:
+  tags:
+    - uart
+    - bluetooth
 tests:
   sample.bluetooth.hci_uart_async.nrf5:
     harness: bluetooth
     platform_allow:
       - nrf52dk/nrf52832
-    tags:
-      - uart
-      - bluetooth
+  sample.bluetooth.hci_uart_async.bsim:
+    depends_on: bsim
+    build_only: true
+    platform_allow:
+      - nrf52_bsim
+    harness: bsim
+    harness_config:
+      bsim_exe_name: samples_bluetooth_hci_uart_async_prj_conf

--- a/tests/bsim/bluetooth/compile.sh
+++ b/tests/bsim/bluetooth/compile.sh
@@ -16,8 +16,5 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/ll/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/mesh/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
-if [ ${BOARD} == "nrf52_bsim/native" ]; then
-	${ZEPHYR_BASE}/tests/bsim/bluetooth/hci_uart/compile.sh
-fi
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/hci_uart/tests.yaml
+++ b/tests/bsim/bluetooth/hci_uart/tests.yaml
@@ -1,0 +1,22 @@
+common:
+  tags:
+    - bluetooth
+  depends_on: bsim
+  harness: bsim
+
+tests:
+  tests.bsim.bluetooth.hci_uart:
+    platform_allow:
+      - nrf52_bsim
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+    required_applications:
+      - application: sample.bluetooth.hci_uart.bsim
+        path: $ZEPHYR_BASE/samples/bluetooth/hci_uart
+      - application: sample.bluetooth.hci_uart_async.bsim
+        path: $ZEPHYR_BASE/samples/bluetooth/hci_uart_async
+      - application: tests.bsim.bluetooth.ll.conn.split_hci_uart
+        path: $ZEPHYR_BASE/tests/bsim/bluetooth/ll/conn/
+      - application: tests.bsim.bluetooth.ll.conn.split_hci_uart.psa
+        path: $ZEPHYR_BASE/tests/bsim/bluetooth/ll/conn/

--- a/tests/bsim/bluetooth/ll/conn/tests.yaml
+++ b/tests/bsim/bluetooth/ll/conn/tests.yaml
@@ -1,0 +1,27 @@
+common:
+  tags:
+    - bluetooth
+  depends_on: bsim
+  harness: bsim
+
+tests:
+  tests.bsim.bluetooth.ll.conn.split_hci_uart:
+    platform_allow:
+      - nrf52_bsim
+    build_only: true
+    extra_args: CONF_FILE=prj_split_hci_uart.conf
+    extra_dtc_overlay_files:
+      - hci-uart.overlay
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_ll_conn_prj_split_hci_uart_conf
+  tests.bsim.bluetooth.ll.conn.split_hci_uart.psa:
+    platform_allow:
+      - nrf52_bsim
+    build_only: true
+    extra_args: CONF_FILE=prj_split_hci_uart.conf
+    extra_overlay_confs:
+      - psa_overlay.conf
+    extra_dtc_overlay_files:
+      - hci-uart.overlay
+    harness_config:
+      bsim_exe_name: tests_bsim_bluetooth_ll_conn_prj_split_hci_uart_conf_psa_overlay_conf

--- a/tests/bsim/bluetooth/tests.nrf52bsim.txt
+++ b/tests/bsim/bluetooth/tests.nrf52bsim.txt
@@ -1,6 +1,5 @@
 # Search paths(s) for tests which will be run in the nrf52bsim
 # This file is used in CI to select which tests are run
-tests/bsim/bluetooth/hci_uart/
 tests/bsim/bluetooth/ll/
 tests/bsim/bluetooth/mesh/
 tests/bsim/bluetooth/samples/

--- a/tests/bsim/ci.bt.sh
+++ b/tests/bsim/ci.bt.sh
@@ -17,6 +17,8 @@ ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/audio/
 
 ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/audio_samples/
 
+${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/hci_uart/
+
 ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/host/
 
 ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/tester/


### PR DESCRIPTION
For background and motivation see https://github.com/zephyrproject-rtos/zephyr/pull/113101

This PR changes the BT HCI UART bsim tests to be both built and run using twister.
This means that users which have Babblesim installed can run these tests with twister in a quite comparable way to single device test. For example:
twister -T tests/bsim/bluetooth/hci_uart/ -vv --fixture bsim_multi_test

Note these tests can still be run with run_parallel.sh as before. Just now the default test list used by CI does not include them.

Related to:
* https://github.com/zephyrproject-rtos/zephyr/pull/113401
* https://github.com/zephyrproject-rtos/zephyr/pull/113395
* https://github.com/zephyrproject-rtos/zephyr/pull/113225
* https://github.com/zephyrproject-rtos/zephyr/pull/113244
* https://github.com/zephyrproject-rtos/zephyr/pull/113101