### PR TITLE
soc: sifli: sf32: Fix ftab partition addresses

### DIFF
--- a/soc/sifli/sf32/gen_ftab.py
+++ b/soc/sifli/sf32/gen_ftab.py
@@ -172,10 +172,8 @@ def main() -> None:
     except KeyError as exc:
         raise SystemExit("Unable to locate 'ptable' labeled partition in devicetree") from exc
 
-    code_offset, code_size = _partition_bounds(code_node)
-    code_start = flash_base + code_offset
-    ptable_offset, _ = _partition_bounds(ptable_node)
-    ptable_addr = flash_base + ptable_offset
+    code_start, code_size = _partition_bounds(code_node)
+    ptable_addr, _ = _partition_bounds(ptable_node)
     sec_image_desc_index = (
         PartitionIndex.SECONDARY_BOOTLOADER.value - PartitionIndex.LCPU_IMAGE_PING.value
     )


### PR DESCRIPTION
The zephyr,mapped-partition binding translates partition reg addresses through the parent ranges properties. gen_ftab.py was treating the translated addresses as offsets relative to the NOR flash base and added the base address a second time.

Use the partition addresses directly when populating the ftab and writing the generated Intel HEX image.

Fixes: 7989a094f8a0