### PR TITLE
twister: fix per test coverage collection

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -321,6 +321,11 @@ class Lcov(CoverageTool):
                     continue
                 files += files_
             logger.debug("Coverage merge %d reports in %s", len(files), outdir)
+            if not files:
+                # lcov requires at least one action option, so an empty merge
+                # would fail with an unhelpful command line error.
+                logger.error("No per-instance coverage tracefiles to merge in: %s", outdir)
+                return 1, {}
             cmd = ["--output-file", coveragefile]
             for filename in files:
                 cmd.append("--add-tracefile")

--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -429,11 +429,17 @@ void gcov_coverage_dump_tagged(const char *tag)
 	int fd;
 
 #if defined(CONFIG_REBOOT)
-	if (gcov_filename_key != GCOV_FILENAME_KEY) {
-		gcov_filename_key = GCOV_FILENAME_KEY;
-		gcov_filename_idx = 0;
-	} else {
-		gcov_filename_idx += 1;
+	/* The reboot index only uniquifies successive untagged dumps; a tag already
+	 * makes the path unique, and appending an index to it would break the
+	 * "<canonical>.gcda@@<tag>" name the host tooling matches on.
+	 */
+	if (tag == NULL) {
+		if (gcov_filename_key != GCOV_FILENAME_KEY) {
+			gcov_filename_key = GCOV_FILENAME_KEY;
+			gcov_filename_idx = 0;
+		} else {
+			gcov_filename_idx += 1;
+		}
 	}
 #endif /* defined(CONFIG_REBOOT) */
 
@@ -457,9 +463,13 @@ void gcov_coverage_dump_tagged(const char *tag)
 		}
 
 #if defined(CONFIG_REBOOT)
-		snprintf(gcov_filename, sizeof(gcov_filename), "%s.%d", gcov_list->filename,
-			 gcov_filename_idx);
-		filename = gcov_filename;
+		if (tag == NULL) {
+			snprintf(gcov_filename, sizeof(gcov_filename), "%s.%d",
+				 gcov_list->filename, gcov_filename_idx);
+			filename = gcov_filename;
+		} else {
+			filename = gcov_list->filename;
+		}
 #else
 		filename = gcov_list->filename;
 #endif /* defined(CONFIG_REBOOT) */


### PR DESCRIPTION

A bad rebase made this feature regress, fix the issue..

- **testsuite: coverage: don't index tagged per-test gcda dumps**
- **twister: coverage: fail clearly on an empty tracefile merge**


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/113496