### PR TITLE
soc: espressif: shrink esp timer task stack default

### DIFF
--- a/soc/espressif/common/Kconfig
+++ b/soc/espressif/common/Kconfig
@@ -29,10 +29,12 @@ config ESP_SIMPLE_BOOT
 
 config ESP32_TIMER_TASK_STACK_SIZE
 	int "Stack size of the high resolution ESP Timer"
-	default 4096
+	default 1536
 	help
 	  Set the stack size for the internal high resolution ESP Timer
-	  used in Wi-Fi and BLE peripherals.
+	  used in Wi-Fi and BLE peripherals. Registered timer callbacks
+	  run in this task's context, including Wi-Fi, BLE, mesh, PHY and
+	  coexistence callbacks that dispatch here.
 
 config ESP32_TIMER_TASK_PRIO
 	int "Task priority of the high resolution ESP Timer"


### PR DESCRIPTION
The timer task stack was sized at 4096 bytes, far above what the registered callbacks use. Measured peak usage on Wi-Fi plus BLE and Wi-Fi mesh workloads is around 350 bytes. Lower the default to 1536, which keeps a wide margin above the observed peak while reclaiming memory from every build that enables Wi-Fi or BLE.