### PR TITLE
drivers: espi: rts5912: Add delay for VW TX_FULL flag update

### DIFF
--- a/drivers/espi/espi_realtek_rts5912.c
+++ b/drivers/espi/espi_realtek_rts5912.c
@@ -1389,6 +1389,7 @@ static int espi_rts5912_send_vwire(const struct device *dev, enum espi_vwire_sig
 
 	espi_reg->EVTXDAT = tx_data;
 
+	k_busy_wait(10);
 	WAIT_FOR(!(espi_reg->EVSTS & ESPI_EVSTS_TXFULL), VW_TIMEOUT_US, k_busy_wait(10));
 
 	switch (vw_idx) {


### PR DESCRIPTION
The TX_FULL flag requires a short hardware response time to update. Add a 10us busy wait to ensure the flag is stable before reading it.