### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -329,7 +329,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: c38f7a10c14ae8b95c0296cd10320907c28e02c7
+      revision: 7ad67106c3253d03ae4bd8ab48e6bdf7bc46f43e
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  7ad67106c3253d03ae4bd8ab48e6bdf7bc46f43e

Brings following Zephyr relevant fixes:

  - f17d73e8 boot: zephyr: unify USB DFU entrance config with serial recovery
  - 0dd29b54 boot_serial: check flash_area_get_sector() return in decrypt_image_inplace()
  - c437bb46 boot: zephyr: Update sample file
  - 44de2a32 boot: zephyr: Rename samples.yaml as tests.yaml
  - 080e1bcd boot: bootutil: loader: Fix bootstrap with swap modes
  - 0e114d8a boot: bootutil: Add size check assert
  - 1e833a09 boot: zephyr: flash_map_extended: Add sector size check
  - 56cfb5c8 bootutil: Require a power of two logical sector size
  - 2b585683 bootutil: Fail closed on logical sector query error
  - 00aa4c35 bootutil: Fix build with logical sectors and slot info
  - e137493b bootutil: Scramble whole logical sectors
  - 2e235bf0 bootutil: Propagate logical sector verification result
  - 10715540 zephyr: Allow enabling logical sectors
  - ec1e1a81 bootutil: Support for logical sectors
  - 2fe443de boot: zephyr: cmake: Add swap sector overhead
  - 7a19e8c1 boot: zephyr: Add encryption build
  - 79d374c1 boot: bootutil: Fix aes.h include path
  - c4a3ffd6 boot: encrypted_psa: Mbed TLS 4.x compat and -Werror fixes
  - 300b596a boot_serial: register serial_encryption log module
  - 52903082 boot/bootutil/crypto: unconditionally read out rfc3447 version field

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.