### PR TITLE
doc: gsg: install python deps before exporting cmake

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -370,14 +370,6 @@ installation.
       To reduce disk space usage and avoid downloading unnecessary modules or vendor HALs during
       setup, you may configure :ref:`west-manifest-groups` before running ``west update``.
 
-#. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This registers your current
-   Zephyr checkout in CMake's user package registry so ``find_package(Zephyr)``
-   can locate it automatically when building applications.
-
-   .. code-block:: shell
-
-      west zephyr-export
-
 #. Install Zephyr's Python dependencies:
 
    ``west packages`` reads the Python requirements from the checked-out Zephyr
@@ -413,6 +405,14 @@ installation.
    .. note::
 
       Installing these dependencies can downgrade or upgrade west itself.
+
+#. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This registers your current
+   Zephyr checkout in CMake's user package registry so ``find_package(Zephyr)``
+   can locate it automatically when building applications.
+
+   .. code-block:: shell
+
+      west zephyr-export
 
 Install the Zephyr SDK
 **********************

--- a/scripts/pylib/build_helpers/domains.py
+++ b/scripts/pylib/build_helpers/domains.py
@@ -12,13 +12,9 @@ import logging
 import os
 from dataclasses import dataclass
 
+import jsonschema
 import yaml
-
-try:
-    import jsonschema
-    from jsonschema.exceptions import best_match
-except ImportError:
-    jsonschema = None
+from jsonschema.exceptions import best_match
 
 DOMAINS_SCHEMA = '''
 # JSON schema for basic validation of the structure of a domains YAML file.
@@ -72,11 +68,6 @@ logger.addHandler(handler)
 class Domains:
 
     def __init__(self, data: dict):
-        if jsonschema is None:
-            logger.critical('jsonschema module not found, please install it to '
-                            'validate and parse domains.yaml files')
-            exit(1)
-
         validator_class = jsonschema.validators.validator_for(schema)
         validator_class.check_schema(schema)
         domains_validator = validator_class(schema)


### PR DESCRIPTION
Better fix for #112662. Adjust the getting started guide to always install python dependencies before running `west zephyr-export` which can require other python modules than west itself. Reverts the old fix as it is no longer necessary.

Fixes #112662
Fixes #112968

Sorry for the noise.