### PR TITLE
Net shell dplpmtud cache handling

### DIFF
--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -574,7 +574,13 @@ drop:
 
 enum net_verdict net_ipv4_prepare_for_send(struct net_pkt *pkt)
 {
-	if (IS_ENABLED(CONFIG_NET_IPV4_PMTU)) {
+	/* ARP packets share the AF_INET family but are not IPv4 datagrams, so
+	 * their L2 protocol type is used to skip them here. Otherwise the code
+	 * below would read the ARP body as an IPv4 header and create bogus PMTU
+	 * cache entries.
+	 */
+	if (IS_ENABLED(CONFIG_NET_IPV4_PMTU) &&
+	    net_pkt_ll_proto_type(pkt) == NET_ETH_PTYPE_IP) {
 		struct net_pmtu_entry *entry;
 		struct net_sockaddr_in dst = {
 			.sin_family = NET_AF_INET,

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -1013,7 +1013,7 @@ try_send:
 		entry = net_pmtu_get_entry((struct net_sockaddr *)&dst);
 		if (entry == NULL) {
 			ret = net_pmtu_update_mtu((struct net_sockaddr *)&dst,
-						  net_if_get_mtu(iface));
+						  net_if_get_mtu(net_pkt_iface(pkt)));
 			if (ret < 0) {
 				NET_DBG("Cannot update PMTU for %s (%d)",
 					net_sprint_ipv6_addr(&dst.sin6_addr),

--- a/subsys/net/lib/shell/pmtu.c
+++ b/subsys/net/lib/shell/pmtu.c
@@ -10,21 +10,18 @@ LOG_MODULE_DECLARE(net_shell);
 #include "net_shell_private.h"
 
 #include "pmtu.h"
+#include "dplpmtud_internal.h"
 
 #if !defined(CONFIG_NET_PMTU)
 static void print_pmtu_error(const struct shell *sh)
 {
 	PR_INFO("Set %s to enable %s support.\n",
 		"CONFIG_NET_IPV6_PMTU or CONFIG_NET_IPV4_PMTU", "PMTU");
+	PR_INFO("Set %s to enable %s support.\n",
+		"CONFIG_NET_IPV6_PMTU_DPLPMTUD or CONFIG_NET_IPV4_PMTU_DPLPMTUD",
+		"DPLPMTUD");
 }
 #endif
-
-#if defined(CONFIG_NET_PMTU)
-static void pmtu_cb(struct net_pmtu_entry *entry, void *user_data)
-{
-	struct net_shell_user_data *data = user_data;
-	const struct shell *sh = data->sh;
-	int *count = data->user_data;
 
 #if defined(CONFIG_NET_IPV4) && defined(CONFIG_NET_IPV6)
 /* Use the value of NET_IPV6_ADDR_LEN */
@@ -36,6 +33,13 @@ static void pmtu_cb(struct net_pmtu_entry *entry, void *user_data)
 #else
 #define ADDR_STR_LEN NET_INET_ADDRSTRLEN
 #endif
+
+#if defined(CONFIG_NET_PMTU)
+static void pmtu_cb(struct net_pmtu_entry *entry, void *user_data)
+{
+	struct net_shell_user_data *data = user_data;
+	const struct shell *sh = data->sh;
+	int *count = data->user_data;
 
 	if (!entry->in_use) {
 		return;
@@ -55,6 +59,31 @@ static void pmtu_cb(struct net_pmtu_entry *entry, void *user_data)
 }
 #endif /* CONFIG_NET_PMTU */
 
+#if defined(CONFIG_NET_PMTU_DPLPMTUD)
+static void dplpmtud_cb(struct net_dplpmtud_entry *entry, void *user_data)
+{
+	struct net_shell_user_data *data = user_data;
+	const struct shell *sh = data->sh;
+	int *count = data->user_data;
+
+	if (!entry->in_use) {
+		return;
+	}
+
+	if (*count == 0) {
+		PR("     %" STRINGIFY(ADDR_STR_LEN) "s   PLPMTU  Age (sec)\n",
+		   "Destination Address");
+	}
+
+	PR("[%2d] %" STRINGIFY(ADDR_STR_LEN) "s %8d  %d\n", *count + 1,
+	   net_sprint_addr(entry->dst.family, (void *)&entry->dst.in_addr),
+	   entry->validated_plpmtu,
+	   (k_uptime_get_32() - entry->last_update) / 1000U);
+
+	(*count)++;
+}
+#endif /* CONFIG_NET_PMTU_DPLPMTUD */
+
 static int cmd_net_pmtu(const struct shell *sh, size_t argc, char *argv[])
 {
 #if defined(CONFIG_NET_PMTU)
@@ -71,11 +100,20 @@ static int cmd_net_pmtu(const struct shell *sh, size_t argc, char *argv[])
 		user_data.sh = sh;
 		user_data.user_data = &count;
 
+		PR("%s destination cache content:\n", "PMTU");
 		(void)net_pmtu_foreach(pmtu_cb, &user_data);
-
 		if (count == 0) {
-			PR("PMTU destination cache is empty.\n");
+			PR("%s destination cache is empty.\n", "PMTU");
 		}
+
+#if defined(CONFIG_NET_PMTU_DPLPMTUD)
+		PR("%s destination cache content:\n", "DPLPMTUD");
+		count = 0;
+		(void)net_dplpmtud_foreach(dplpmtud_cb, &user_data);
+		if (count == 0) {
+			PR("%s destination cache is empty.\n", "DPLPMTUD");
+		}
+#endif
 	}
 #else
 	print_pmtu_error(sh);
@@ -90,8 +128,13 @@ static int cmd_net_pmtu_flush(const struct shell *sh, size_t argc, char *argv[])
 	ARG_UNUSED(argv);
 
 #if defined(CONFIG_NET_PMTU)
-	PR("Flushing PMTU destination cache.\n");
+	PR("Flushing %s destination cache.\n", "PMTU");
 	net_pmtu_init();
+
+#if defined(CONFIG_NET_PMTU_DPLPMTUD)
+	PR("Flushing %s destination cache.\n", "DPLPMTUD");
+	net_dplpmtud_init();
+#endif
 #else
 	print_pmtu_error(sh);
 #endif
@@ -99,13 +142,21 @@ static int cmd_net_pmtu_flush(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+#if defined(CONFIG_NET_PMTU) && defined(CONFIG_NET_PMTU_DPLPMTUD)
+#define PMTU_STR "PMTU/DPLPMTUD"
+#elif defined(CONFIG_NET_PMTU)
+#define PMTU_STR "PMTU"
+#else
+#define PMTU_STR "PMTU"
+#endif /* CONFIG_NET_PMTU && CONFIG_NET_PMTU_DPLPMTUD */
+
 SHELL_STATIC_SUBCMD_SET_CREATE(net_cmd_pmtu,
 	SHELL_CMD(flush, NULL,
-		  SHELL_HELP("Remove all entries from PMTU destination cache", ""),
+		  SHELL_HELP("Remove all entries from " PMTU_STR " destination cache", ""),
 		  cmd_net_pmtu_flush),
 	SHELL_SUBCMD_SET_END
 );
 
 SHELL_SUBCMD_ADD((net), pmtu, &net_cmd_pmtu,
-		 "Show PMTU information.",
+		 "Show " PMTU_STR " information.",
 		 cmd_net_pmtu, 1, 0);


### PR DESCRIPTION
Update pmtu shell command `net pmtu` to print dplpmtud information.
Fix also two issues found during debugging:
* Check ARP packet properly so that those packets do not cause pmtu cache update
* Update MTU for IPv6 packet properly in the cache
