### PR TITLE
soc: realtek: rts5912: wait for PLL to lock upon wakeup

### DIFF
--- a/soc/realtek/ec/rts5912/power.c
+++ b/soc/realtek/ec/rts5912/power.c
@@ -39,6 +39,15 @@ static void rts5912_heavy_sleep(void)
 
 	realtek_WFI();
 
+	/* If we were running on the PLL before sleep, wait for it to become
+	 * stable and ready before we resume system execution.
+	 */
+	if ((main_clk_src_record & SYSTEM_SYSCLK_SRC_Msk) != 0) {
+		while ((sys_reg->PLLCTRL & SYSTEM_PLLCTRL_RDY_Msk) == 0x00) {
+			; /* Busy-wait on the safe clock until PLL locks */
+		}
+	}
+
 	if ((main_clk_src_record & SYSTEM_SYSCLK_SRC_Msk) == 0) {
 		sys_reg->SYSCLK &= ~SYSTEM_SYSCLK_SRC_Msk; /* Return system clock to 25M */
 		if ((PLL_en_record & SYSTEM_PLLCTRL_EN_Msk) == 0x0) {


### PR DESCRIPTION
Upon waking from heavy sleep, the CPU resumes on a slow 25MHz RC clock while the main PLL stabilizes (~40us). Returning immediately from rts5912_heavy_sleep() causes early resume code to run at 25MHz, leading to timing corruption and driver timeouts on high-speed buses like eSPI.

Fix this by adding a busy-wait loop after WFI to poll the PLL ready flag (RTS5912_PLLCTRL_RDY), ensuring the CPU runs at full speed before proceeding.