### PR TITLE
drivers: wifi: esp_hosted: fix iface_status signature

### DIFF
--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.c
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.c
@@ -492,8 +492,11 @@ static int esp_hosted_stats(const struct device *dev,
 }
 #endif
 
-static int esp_hosted_status(const struct device *dev, struct wifi_iface_status *status)
+static int esp_hosted_status(const struct device *dev, struct net_if *iface,
+			     struct wifi_iface_status *status)
 {
+	ARG_UNUSED(iface);
+
 	esp_hosted_data_t *data = dev->data;
 	CtrlMsg ctrl_msg = CtrlMsg_init_zero;
 	size_t itf = esp_hosted_get_iface(dev);


### PR DESCRIPTION
The wifi_mgmt iface_status callback gained a struct net_if pointer parameter, but esp_hosted_status was left with the old signature, causing an incompatible pointer type error at driver registration. Add the missing net_if parameter to match the callback interface.

Fixes #113488