### PR TITLE
babblesim bt samples tests: Build and run with twister

### DIFF
--- a/samples/bluetooth/peripheral_gap_svc/tests.yaml
+++ b/samples/bluetooth/peripheral_gap_svc/tests.yaml
@@ -1,6 +1,9 @@
 sample:
   name: Bluetooth Peripheral GAP service non default implementation
   description: Demonstrates the GAP service implementation on application side.
+common:
+  tags:
+    - bluetooth
 tests:
   sample.bluetooth.peripheral_gap_svc:
     harness: bluetooth
@@ -11,4 +14,14 @@ tests:
       - ophelia4ev/nrf54l15/cpuapp
     integration_platforms:
       - qemu_cortex_m3
-    tags: bluetooth
+  sample.bluetooth.peripheral_gap_svc.bsim:
+    depends_on: bsim
+    build_only: true
+    sysbuild: true
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    harness: bsim
+    harness_config:
+      bsim_exe_name: samples_bluetooth_peripheral_gap_svc_prj_conf

--- a/samples/bluetooth/peripheral_hr/tests.yaml
+++ b/samples/bluetooth/peripheral_hr/tests.yaml
@@ -1,6 +1,9 @@
 sample:
   name: Bluetooth Peripheral HR
   description: Demonstrates the HR (Heart Rate) GATT Service
+common:
+  tags:
+    - bluetooth
 tests:
   sample.bluetooth.peripheral_hr:
     harness: bluetooth
@@ -27,8 +30,18 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20a/cpuapp
-    tags: bluetooth
     sysbuild: true
+  sample.bluetooth.peripheral_hr.bsim:
+    harness: bsim
+    depends_on: bsim
+    build_only: true
+    sysbuild: true
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    harness_config:
+      bsim_exe_name: samples_bluetooth_peripheral_hr_prj_conf
   sample.bluetooth.peripheral_hr.minimal:
     harness: bluetooth
     platform_allow:
@@ -37,7 +50,6 @@ tests:
       - qemu_cortex_m3
     extra_args:
       - CONF_FILE=prj_minimal.conf
-    tags: bluetooth
   sample.bluetooth.peripheral_hr.bt_ll_sw_split.minimal:
     harness: bluetooth
     platform_allow:
@@ -51,7 +63,6 @@ tests:
     extra_args:
       - CONF_FILE=prj_minimal.conf
       - EXTRA_CONF_FILE=overlay-bt_ll_sw_split-minimal.conf
-    tags: bluetooth
   sample.bluetooth.peripheral_hr.bt_ll_sw_split.extended:
     harness: bluetooth
     platform_allow:
@@ -63,7 +74,6 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
     extra_args: EXTRA_CONF_FILE=overlay-extended.conf
-    tags: bluetooth
   sample.bluetooth.peripheral_hr.multicore.bt_ll_sw_split.extended:
     harness: bluetooth
     platform_allow:
@@ -73,8 +83,20 @@ tests:
       - nrf5340bsim/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpuapp
     extra_args: CONFIG_BT_EXT_ADV=y
-    tags: bluetooth
     sysbuild: true
+  sample.bluetooth.peripheral_hr.extended.bsim:
+    harness: bsim
+    depends_on: bsim
+    build_only: true
+    sysbuild: true
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    harness_config:
+      bsim_exe_name: samples_bluetooth_peripheral_hr_prj_conf_overlay-extended_conf
+    extra_conf_files:
+      - overlay-extended.conf
   sample.bluetooth.peripheral_hr.bt_ll_sw_split.phy_coded:
     harness: bluetooth
     platform_allow:
@@ -86,7 +108,6 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
     extra_args: EXTRA_CONF_FILE=overlay-phy_coded.conf
-    tags: bluetooth
     sysbuild: true
   sample.bluetooth.peripheral_hr.multicore.bt_ll_sw_split.phy_coded:
     harness: bluetooth
@@ -98,8 +119,33 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     extra_args:
       - CONFIG_BT_EXT_ADV=y
-    tags: bluetooth
     sysbuild: true
+  sample.bluetooth.peripheral_hr.phy_coded.bsim:
+    harness: bsim
+    depends_on: bsim
+    build_only: true
+    sysbuild: true
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    harness_config:
+      bsim_exe_name: samples_bluetooth_peripheral_hr_prj_conf_overlay-phy_coded_conf
+    extra_conf_files:
+      - overlay-phy_coded.conf
+  sample.bluetooth.peripheral_hr.static_callbacks.bsim:
+    harness: bsim
+    depends_on: bsim
+    build_only: true
+    sysbuild: true
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    harness_config:
+      bsim_exe_name: samples_bluetooth_peripheral_hr_prj_conf_overlay-static_callbacks_conf
+    extra_conf_files:
+      - overlay-static_callbacks.conf
   sample.bluetooth.peripheral_hr_rv32m1_vega_openisa_rv32m1_ri5cy:
     platform_allow: rv32m1_vega/openisa_rv32m1/ri5cy
     tags: bluetooth
@@ -107,5 +153,4 @@ tests:
   sample.bluetooth.peripheral_hr.frdm_kw41z_shield:
     harness: bluetooth
     depends_on: arduino_serial
-    tags: bluetooth
     extra_args: SHIELD=frdm_kw41z

--- a/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
@@ -21,6 +21,4 @@ app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-interleaved.conf sysbuild=1
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-ticker_expire_info.conf sysbuild=1 compile
 app=tests/bsim/bluetooth/ll/cis conf_overlay=overlay-acl_group.conf sysbuild=1 compile
 
-run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
-
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
@@ -25,6 +25,4 @@ app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-sequential.conf compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-interleaved.conf  compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-ticker_expire_info.conf compile
 
-run_in_background ${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
-
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/compile.sh
+++ b/tests/bsim/bluetooth/compile.sh
@@ -15,6 +15,5 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 # launching too many parallel builds which can lead to a too high system load.
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/ll/compile.sh
 ${ZEPHYR_BASE}/tests/bsim/bluetooth/mesh/compile.sh
-${ZEPHYR_BASE}/tests/bsim/bluetooth/samples/compile.sh
 
 wait_for_background_jobs

--- a/tests/bsim/bluetooth/samples/battery_service/tests.yaml
+++ b/tests/bsim/bluetooth/samples/battery_service/tests.yaml
@@ -1,0 +1,11 @@
+tests:
+  tests.bsim.bluetooth.samples.battery_service:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    harness: bsim
+    platform_allow:
+      - nrf52_bsim
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_samples_battery_service_prj_conf

--- a/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests.yaml
+++ b/tests/bsim/bluetooth/samples/central_hr_peripheral_hr/tests.yaml
@@ -1,0 +1,68 @@
+common:
+  tags:
+    - bluetooth
+  depends_on: bsim
+  harness: bsim
+  sysbuild: true
+  platform_allow:
+    - nrf52_bsim
+    - nrf5340bsim/nrf5340/cpuapp
+    - nrf54l15bsim/nrf54l15/cpuapp
+
+tests:
+  tests.bsim.bluetooth.samples.central_hr_peripheral_hr:
+    extra_conf_files:
+      - ${ZEPHYR_BASE}/samples/bluetooth/central_hr/prj.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_samples_central_hr_peripheral_hr_prj_conf
+      tests_scripts:
+        - tests_scripts/central_hr_peripheral_hr.sh
+    required_applications:
+      - application: sample.bluetooth.peripheral_hr.bsim
+        path: $ZEPHYR_BASE/samples/bluetooth/peripheral_hr
+
+  tests.bsim.bluetooth.samples.central_hr_peripheral_hr.extended:
+    extra_conf_files:
+      - ${ZEPHYR_BASE}/samples/bluetooth/central_hr/prj.conf
+    extra_overlay_confs:
+      - ${ZEPHYR_BASE}/samples/bluetooth/central_hr/overlay-extended.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: >-
+        tests_bsim_bluetooth_samples_central_hr_peripheral_hr_prj_conf_overlay-extended_conf
+      tests_scripts:
+        - tests_scripts/central_hr_peripheral_hr_extended.sh
+    required_applications:
+      - application: sample.bluetooth.peripheral_hr.extended.bsim
+        path: $ZEPHYR_BASE/samples/bluetooth/peripheral_hr
+
+  tests.bsim.bluetooth.samples.central_hr_peripheral_hr.phy_coded:
+    extra_conf_files:
+      - ${ZEPHYR_BASE}/samples/bluetooth/central_hr/prj.conf
+    extra_overlay_confs:
+      - ${ZEPHYR_BASE}/samples/bluetooth/central_hr/overlay-phy_coded.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: >-
+        tests_bsim_bluetooth_samples_central_hr_peripheral_hr_prj_conf_overlay-phy_coded_conf
+      tests_scripts:
+        - tests_scripts/central_hr_peripheral_hr_phy_coded.sh
+    required_applications:
+      - application: sample.bluetooth.peripheral_hr.phy_coded.bsim
+        path: $ZEPHYR_BASE/samples/bluetooth/peripheral_hr
+
+  tests.bsim.bluetooth.samples.central_hr_peripheral_hr.static_callbacks:
+    extra_conf_files:
+      - ${ZEPHYR_BASE}/samples/bluetooth/central_hr/prj.conf
+    extra_overlay_confs:
+      - ${ZEPHYR_BASE}/samples/bluetooth/central_hr/overlay-static_callbacks.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: >-
+        tests_bsim_bluetooth_samples_central_hr_peripheral_hr_prj_conf_overlay-static_callbacks_conf
+      tests_scripts:
+        - tests_scripts/central_hr_peripheral_hr_static_callbacks.sh
+    required_applications:
+      - application: sample.bluetooth.peripheral_hr.static_callbacks.bsim
+        path: $ZEPHYR_BASE/samples/bluetooth/peripheral_hr

--- a/tests/bsim/bluetooth/samples/peripheral_gap_svc/tests.yaml
+++ b/tests/bsim/bluetooth/samples/peripheral_gap_svc/tests.yaml
@@ -1,0 +1,17 @@
+tests:
+  tests.bsim.bluetooth.samples.peripheral_gap_svc:
+    tags:
+      - bluetooth
+    depends_on: bsim
+    harness: bsim
+    sysbuild: true
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_samples_peripheral_gap_svc_prj_conf
+    required_applications:
+      - application: sample.bluetooth.peripheral_gap_svc.bsim
+        path: $ZEPHYR_BASE/samples/bluetooth/peripheral_gap_svc

--- a/tests/bsim/bluetooth/tests.nrf52bsim.txt
+++ b/tests/bsim/bluetooth/tests.nrf52bsim.txt
@@ -2,4 +2,3 @@
 # This file is used in CI to select which tests are run
 tests/bsim/bluetooth/ll/
 tests/bsim/bluetooth/mesh/
-tests/bsim/bluetooth/samples/

--- a/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt
@@ -6,5 +6,3 @@ tests/bsim/bluetooth/ll/multiple_id/
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_interleaved.sh
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_sequential.sh
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
-tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
-tests/bsim/bluetooth/samples/peripheral_gap_svc/

--- a/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
@@ -8,5 +8,3 @@ tests/bsim/bluetooth/ll/multiple_id/
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_interleaved.sh
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_sequential.sh
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_ticker_expire_info.sh
-tests/bsim/bluetooth/samples/central_hr_peripheral_hr/
-tests/bsim/bluetooth/samples/peripheral_gap_svc/

--- a/tests/bsim/ci.bt.sh
+++ b/tests/bsim/ci.bt.sh
@@ -21,6 +21,8 @@ ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/hci_ua
 
 ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/host/
 
+${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/samples/
+
 ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/tester/
 
 # nrf52_bsim set:


### PR DESCRIPTION
For background and motivation see https://github.com/zephyrproject-rtos/zephyr/pull/113101

This PR changes the BT samples bsim tests to be both built and run using twister.
This means that users which have Babblesim installed can run these tests with twister in a quite comparable way to single device test. For example:
twister -T tests/bsim/bluetooth/samples/ -vv --fixture bsim_multi_test

Note these tests can still be run with run_parallel.sh as before. Just now the default test list used by CI does not include them.

Related to:
* https://github.com/zephyrproject-rtos/zephyr/pull/113475
* https://github.com/zephyrproject-rtos/zephyr/pull/113401
* https://github.com/zephyrproject-rtos/zephyr/pull/113395
* https://github.com/zephyrproject-rtos/zephyr/pull/113225
* https://github.com/zephyrproject-rtos/zephyr/pull/113244
* https://github.com/zephyrproject-rtos/zephyr/pull/113101