### PR TITLE
drivers: wifi: esp_hosted: Support full-duplex SPI transfer.

### DIFF
--- a/drivers/wifi/esp_hosted/Kconfig.esp_hosted
+++ b/drivers/wifi/esp_hosted/Kconfig.esp_hosted
@@ -25,9 +25,17 @@ config WIFI_ESP_HOSTED_EVENT_TASK_PRIORITY
 	int "Event task priority"
 	default 4
 
+config WIFI_ESP_HOSTED_TX_QUEUE_SIZE
+	int "TX message queue size"
+	default 8
+
+config WIFI_ESP_HOSTED_RX_QUEUE_SIZE
+	int "RX message queue size"
+	default 8
+
 config WIFI_ESP_HOSTED_EVENT_TASK_STACK_SIZE
 	int "Event task stack size"
-	default 16384
+	default 8192
 
 config WIFI_ESP_HOSTED_EVENT_TASK_POLL_MS
 	int "Event task poll rate in ms"

--- a/drivers/wifi/esp_hosted/esp_hosted_hal.c
+++ b/drivers/wifi/esp_hosted/esp_hosted_hal.c
@@ -50,28 +50,22 @@ bool esp_hosted_hal_data_ready(const struct device *dev)
 int esp_hosted_hal_spi_transfer(const struct device *dev, void *tx, void *rx, uint32_t size)
 {
 	int ret = 0;
-	esp_hosted_data_t *data = dev->data;
 	const esp_hosted_config_t *config = dev->config;
 
-	const struct spi_buf tx_buf = {.buf = tx ? tx : rx, .len = size};
+	const struct spi_buf tx_buf = {.buf = tx, .len = size};
 	const struct spi_buf_set tx_set = {.buffers = &tx_buf, .count = 1};
 
-	const struct spi_buf rx_buf = {.buf = rx ? rx : tx, .len = size};
+	const struct spi_buf rx_buf = {.buf = rx, .len = size};
 	const struct spi_buf_set rx_set = {.buffers = &rx_buf, .count = 1};
 
 	/* Wait for handshake pin to go high. */
 	for (uint64_t start = k_uptime_get();; k_msleep(1)) {
-		if (gpio_pin_get_dt(&config->handshake_gpio) &&
-		    (rx == NULL || gpio_pin_get_dt(&config->dataready_gpio))) {
+		if (gpio_pin_get_dt(&config->handshake_gpio)) {
 			break;
 		}
 		if ((k_uptime_get() - start) >= 100) {
 			return -ETIMEDOUT;
 		}
-	}
-
-	if (k_sem_take(&data->bus_sem, K_FOREVER) != 0) {
-		return -1;
 	}
 
 	/* Transfer SPI buffers. */
@@ -80,6 +74,5 @@ int esp_hosted_hal_spi_transfer(const struct device *dev, void *tx, void *rx, ui
 		ret = -EIO;
 	}
 
-	k_sem_give(&data->bus_sem);
 	return ret;
 }

--- a/drivers/wifi/esp_hosted/esp_hosted_util.h
+++ b/drivers/wifi/esp_hosted/esp_hosted_util.h
@@ -148,7 +148,7 @@ static inline int esp_hosted_ctrl_response(CtrlMsg *ctrl_msg)
 }
 
 #if defined(CONFIG_WIFI_ESP_HOSTED_DEBUG)
-static void esp_hosted_frame_dump(esp_frame_t *frame)
+static void esp_hosted_frame_dump(esp_hosted_frame_t *frame)
 {
 	static const char *const if_strs[] = {"STA", "AP", "SERIAL", "HCI", "PRIV", "TEST"};
 
@@ -160,15 +160,17 @@ static void esp_hosted_frame_dump(esp_frame_t *frame)
 		frame->flags);
 
 	if (frame->if_type == ESP_HOSTED_SERIAL_IF) {
+		esp_hosted_tlv_t *tlv = (esp_hosted_tlv_t *)frame->payload;
+
 		LOG_DBG("tlv header: ep_type %d ep_length %d ep_value %.8s data_type %d "
 			"data_length %d",
-			frame->ep_type, frame->ep_length, frame->ep_value, frame->data_type,
-			frame->data_length);
+			tlv->ep_type, tlv->ep_length, tlv->ep_value, tlv->data_type,
+			tlv->data_length);
 	}
 }
 #endif
 
-static inline uint16_t esp_hosted_frame_checksum(esp_frame_t *frame)
+static inline uint16_t esp_hosted_frame_checksum(esp_hosted_frame_t *frame)
 {
 	uint16_t checksum = 0;
 	uint8_t *buf = (uint8_t *)frame;
@@ -181,4 +183,38 @@ static inline uint16_t esp_hosted_frame_checksum(esp_frame_t *frame)
 	return checksum;
 }
 
+/* Validate a frame fragment and append it to the reassembly accumulator. */
+static inline bool esp_hosted_frame_append(esp_hosted_frame_t *acc, esp_hosted_frame_t *frag)
+{
+	uint16_t checksum = frag->checksum;
+
+	if (frag->len == 0 || frag->len > ESP_FRAME_MAX_PAYLOAD ||
+	    frag->offset != ESP_FRAME_HEADER_SIZE) {
+		/* Invalid or empty frame: ignore silently. */
+		return false;
+	}
+	if (checksum != esp_hosted_frame_checksum(frag)) {
+		LOG_ERR("invalid checksum");
+		return false;
+	}
+	if (acc->len == 0) {
+		/* First fragment: copy the whole frame. */
+		memcpy(acc, frag, ESP_FRAME_SIZE);
+	} else {
+		/* Subsequent fragment: append payload and update header. */
+		if (frag->seq_num != (uint16_t)(acc->seq_num + 1)) {
+			LOG_ERR("unexpected fragmented frame sequence");
+			return false;
+		}
+		if (acc->len + frag->len > ESP_FRAME_MAX_PAYLOAD * 2) {
+			LOG_ERR("reassembly overflow: %u + %u", acc->len, frag->len);
+			return false;
+		}
+		memcpy(acc->payload + acc->len, frag->payload, frag->len);
+		acc->len += frag->len;
+		acc->seq_num++;
+		acc->flags = frag->flags;
+	}
+	return true;
+}
 #endif /* ZEPHYR_DRIVERS_WIFI_ESP_HOSTED_UTIL_H_ */

--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.c
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.c
@@ -4,21 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <pb_encode.h>
-#include <pb_decode.h>
-#include <esp_hosted_proto.pb.h>
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(esp_hosted, CONFIG_WIFI_LOG_LEVEL);
 
 #include <esp_hosted_wifi.h>
 #include <esp_hosted_hal.h>
 #include <esp_hosted_util.h>
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(esp_hosted, CONFIG_WIFI_LOG_LEVEL);
-
 static struct k_thread esp_hosted_event_thread;
 K_THREAD_STACK_DEFINE(esp_hosted_event_stack, CONFIG_WIFI_ESP_HOSTED_EVENT_TASK_STACK_SIZE);
-
-K_MSGQ_DEFINE(esp_hosted_msgq, sizeof(CtrlMsg), 8, 4);
 
 static esp_hosted_config_t esp_hosted_config = {
 	.reset_gpio = GPIO_DT_SPEC_INST_GET(0, reset_gpios),
@@ -39,8 +33,11 @@ static int esp_hosted_request(const struct device *dev, CtrlMsgId msg_id, CtrlMs
 			      uint32_t timeout)
 {
 	size_t payload_size = 0;
-	esp_frame_t frame = {0};
-	esp_hosted_data_t *data = (esp_hosted_data_t *)dev->data;
+	esp_hosted_data_t *data = dev->data;
+
+	uint8_t buf[ESP_FRAME_SIZE] __aligned(4) = {0};
+	esp_hosted_frame_t *frame = (esp_hosted_frame_t *)buf;
+	esp_hosted_tlv_t *tlv = (esp_hosted_tlv_t *)frame->payload;
 
 	/* Init control message */
 	ctrl_msg->msg_type = CtrlMsgType_Req;
@@ -56,18 +53,18 @@ static int esp_hosted_request(const struct device *dev, CtrlMsgId msg_id, CtrlMs
 	}
 
 	/* Create frame. */
-	frame.if_type = ESP_HOSTED_SERIAL_IF;
-	frame.len = payload_size + TLV_HEADER_SIZE;
-	frame.offset = ESP_FRAME_HEADER_SIZE;
-	frame.seq_num = data->seq_num++;
+	frame->if_type = ESP_HOSTED_SERIAL_IF;
+	frame->len = payload_size + TLV_HEADER_SIZE;
+	frame->offset = ESP_FRAME_HEADER_SIZE;
+	frame->seq_num = data->seq_num++;
 
-	frame.ep_type = TLV_HEADER_TYPE_EP;
-	frame.ep_length = 8;
-	memcpy(frame.ep_value, TLV_HEADER_EP_RESP, 8);
-	frame.data_type = TLV_HEADER_TYPE_DATA;
-	frame.data_length = payload_size;
+	tlv->ep_type = TLV_HEADER_TYPE_EP;
+	tlv->ep_length = 8;
+	memcpy(tlv->ep_value, TLV_HEADER_EP_RESP, 8);
+	tlv->data_type = TLV_HEADER_TYPE_DATA;
+	tlv->data_length = payload_size;
 
-	pb_ostream_t stream = pb_ostream_from_buffer(frame.data_value, frame.data_length);
+	pb_ostream_t stream = pb_ostream_from_buffer(tlv->data_value, tlv->data_length);
 
 	if (!pb_encode(&stream, CtrlMsg_fields, ctrl_msg)) {
 		LOG_ERR("failed to encode protobuf");
@@ -75,10 +72,11 @@ static int esp_hosted_request(const struct device *dev, CtrlMsgId msg_id, CtrlMs
 	}
 
 	/* Update frame checksum and send the frame. */
-	frame.checksum = esp_hosted_frame_checksum(&frame);
-	if (esp_hosted_hal_spi_transfer(dev, &frame, NULL, ESP_FRAME_SIZE_ROUND(frame))) {
-		LOG_ERR("request %d failed", msg_id);
-		return -1;
+	frame->checksum = esp_hosted_frame_checksum(frame);
+
+	if (k_msgq_put(&data->tx_msgq, frame, K_MSEC(ESP_HOSTED_QUEUE_TIMEOUT))) {
+		LOG_ERR("Failed to enqueue message");
+		return -ENOBUFS;
 	}
 	return 0;
 }
@@ -86,12 +84,11 @@ static int esp_hosted_request(const struct device *dev, CtrlMsgId msg_id, CtrlMs
 static int esp_hosted_response(const struct device *dev, CtrlMsgId msg_id, CtrlMsg *ctrl_msg,
 			       uint32_t timeout)
 {
-	if (k_msgq_get(&esp_hosted_msgq, ctrl_msg, K_MSEC(timeout))) {
-		if (timeout == 0) {
-			return 0;
-		}
+	esp_hosted_data_t *data = dev->data;
+
+	if (k_msgq_get(&data->rx_msgq, ctrl_msg, K_MSEC(timeout))) {
 		LOG_ERR("failed to receive response for %d", msg_id);
-		return -1;
+		return -EAGAIN;
 	}
 
 	if (ctrl_msg->msg_id != msg_id) {
@@ -137,79 +134,103 @@ static void esp_hosted_event_task(const struct device *dev, void *p2, void *p3)
 {
 	esp_hosted_data_t *data = dev->data;
 
-	for (;; k_msleep(CONFIG_WIFI_ESP_HOSTED_EVENT_TASK_POLL_MS)) {
-		esp_frame_t frame = {0};
+	uint8_t tx_buf[ESP_FRAME_SIZE] __aligned(4) = {0};
+	esp_hosted_frame_t *tx = (esp_hosted_frame_t *)tx_buf;
+
+	uint8_t rx_buf[ESP_FRAME_SIZE] __aligned(4) = {0};
+	esp_hosted_frame_t *rx = (esp_hosted_frame_t *)rx_buf;
+
+	esp_hosted_frame_t *frame = (esp_hosted_frame_t *)data->acc_buf;
+
+	for (;;) {
+		bool rx_valid = false;
+
+		/* Reset the reassembly accumulator */
+		memset(frame, 0, ESP_FRAME_HEADER_SIZE);
 
 		do {
-			esp_frame_t ffrag = {0};
+			/*
+			 * If the ESP doesn't have anything to send, block
+			 * on the TX queue until an enqueued frame wakes us.
+			 */
+			if (tx->len == 0) {
+				k_timeout_t timeout =
+					esp_hosted_hal_data_ready(dev)
+						? K_NO_WAIT
+						: K_MSEC(CONFIG_WIFI_ESP_HOSTED_EVENT_TASK_POLL_MS);
 
-			if (((ESP_FRAME_SIZE * 2) - frame.len) < ESP_FRAME_SIZE) {
-				/* This shouldn't happen, but if it did stop the thread. */
-				LOG_ERR("spi buffer overflow offset: %d", frame.len);
-				return;
+				k_msgq_get(&data->tx_msgq, tx_buf, timeout);
 			}
 
-			if (esp_hosted_hal_spi_transfer(dev, NULL, &ffrag, ESP_FRAME_SIZE)) {
-				goto restart;
+			/* Nothing to send and nothing to receive. */
+			if (tx->len == 0 && !esp_hosted_hal_data_ready(dev)) {
+				rx_valid = false;
+				break;
 			}
 
-			if (!ESP_FRAME_CHECK_VALID(ffrag)) {
-				goto restart;
+			/* Full-duplex SPI transfer. */
+			if (esp_hosted_hal_spi_transfer(dev, tx_buf, rx_buf, ESP_FRAME_SIZE)) {
+				LOG_ERR("SPI transfer failed");
+				rx_valid = false;
+				break;
 			}
 
-			if (ffrag.checksum != esp_hosted_frame_checksum(&ffrag)) {
-				LOG_ERR("invalid checksum");
-				goto restart;
+			/* Reset the TX frame (if any) after it's been clocked out. */
+			if (tx->len != 0) {
+				memset(tx_buf, 0, ESP_FRAME_SIZE);
 			}
 
-			if (frame.len == 0) {
-				/* First frame */
-				memcpy(&frame, &ffrag, sizeof(esp_frame_t));
-			} else {
-				/* Fragmented frame */
-				if ((frame.seq_num + 1) != ffrag.seq_num) {
-					LOG_ERR("unexpected fragmented frame sequence");
-					goto restart;
-				}
+			/* Validate and append the received fragment to accumulator. */
+			rx_valid = esp_hosted_frame_append(frame, rx);
+		} while (rx_valid && (frame->flags & ESP_FRAME_FLAGS_FRAGMENT));
 
-				/* Append the current fragment's payload. */
-				memcpy(frame.payload + frame.len, ffrag.payload, ffrag.len);
+		if (!rx_valid) {
+			continue;
+		}
 
-				/* Update frame */
-				frame.len += ffrag.len;
-				frame.seq_num++;
-				frame.flags = ffrag.flags;
-				LOG_DBG("received fragmented frame, length: %d", frame.len);
-			}
-		} while (frame.flags & ESP_FRAME_FLAGS_FRAGMENT);
-
-		switch (frame.if_type) {
+		switch (frame->if_type) {
 		case ESP_HOSTED_SAP_IF:
 		case ESP_HOSTED_STA_IF: {
-			esp_hosted_recv(data->iface[frame.if_type], frame.payload, frame.len);
+			if (frame->len > NET_ETH_MAX_FRAME_SIZE) {
+				LOG_ERR("oversized ethernet frame: %u", frame->len);
+				continue;
+			}
+			esp_hosted_recv(data->iface[frame->if_type], frame->payload, frame->len);
 			continue;
 		}
 		case ESP_HOSTED_PRIV_IF: {
-			if (frame.priv_pkt_type == ESP_PACKET_TYPE_EVENT &&
-			    frame.event_type == ESP_PRIV_EVENT_INIT) {
-				LOG_INF("chip id %d spi_mhz %d caps 0x%x", frame.event_data[2],
-					frame.event_data[5], frame.event_data[8]);
+			esp_hosted_event_t *ev = (esp_hosted_event_t *)frame->payload;
+
+			if (frame->priv_pkt_type == ESP_PACKET_TYPE_EVENT &&
+			    ev->event_type == ESP_PRIV_EVENT_INIT && ev->event_len > 8) {
+				LOG_INF("chip id %d spi_mhz %d caps 0x%x", ev->event_data[2],
+					ev->event_data[5], ev->event_data[8]);
 			}
 			continue;
 		}
 		case ESP_HOSTED_SERIAL_IF: /* Requires further processing */
 			break;
 		default:
-			LOG_ERR("unexpected interface type %d", frame.if_type);
+			LOG_ERR("unexpected interface type %d", frame->if_type);
 			continue;
 		}
 
 #if defined(CONFIG_WIFI_ESP_HOSTED_DEBUG)
-		esp_hosted_frame_dump(&frame);
+		esp_hosted_frame_dump(frame);
 #endif
 
+		esp_hosted_tlv_t *tlv = (esp_hosted_tlv_t *)frame->payload;
+
+		/* Guard against a malformed TLV payload. */
+		if (frame->len < TLV_HEADER_SIZE ||
+		    tlv->data_length > frame->len - TLV_HEADER_SIZE) {
+			LOG_ERR("invalid TLV length %u (frame len %u)",
+				tlv->data_length, frame->len);
+			continue;
+		}
+
 		CtrlMsg ctrl_msg = CtrlMsg_init_zero;
-		pb_istream_t stream = pb_istream_from_buffer(frame.data_value, frame.data_length);
+		pb_istream_t stream = pb_istream_from_buffer(tlv->data_value, tlv->data_length);
 
 		if (!pb_decode(&stream, CtrlMsg_fields, &ctrl_msg)) {
 			LOG_ERR("failed to decode protobuf");
@@ -249,13 +270,12 @@ static void esp_hosted_event_task(const struct device *dev, void *p2, void *p3)
 		}
 
 		/* Queue control message resp/event for further processing. */
-		if (k_msgq_put(&esp_hosted_msgq, &ctrl_msg, K_FOREVER)) {
-			LOG_ERR("Failed to enqueue message");
-			return;
+		if (k_msgq_put(&data->rx_msgq, &ctrl_msg, K_MSEC(ESP_HOSTED_QUEUE_TIMEOUT))) {
+			LOG_ERR("rx queue full, dropping control message");
+			continue;
 		}
 
 		LOG_DBG("pushed msg_type %u msg_id %u", ctrl_msg.msg_type, ctrl_msg.msg_id);
-restart:;
 	}
 }
 
@@ -383,34 +403,35 @@ static int esp_hosted_ap_disable(const struct device *dev, struct net_if *iface)
 
 static int esp_hosted_send(const struct device *dev, struct net_pkt *pkt)
 {
-	esp_frame_t frame = {0};
 	size_t pkt_len = net_pkt_get_len(pkt);
 	size_t itf = esp_hosted_get_iface(dev);
-#if defined(CONFIG_NET_STATISTICS_WIFI)
 	esp_hosted_data_t *data = dev->data;
-#endif
+
+	uint8_t buf[ESP_FRAME_SIZE] __aligned(4) = {0};
+	esp_hosted_frame_t *frame = (esp_hosted_frame_t *)buf;
 
 	if (pkt_len > ESP_FRAME_MAX_PAYLOAD) {
 		LOG_ERR("packet length > SPI buf length");
-		return -ENOMEM;
+		return -EMSGSIZE;
 	}
 
 	/* Create frame. */
-	frame.if_type = itf;
-	frame.len = pkt_len;
-	frame.offset = ESP_FRAME_HEADER_SIZE;
+	frame->if_type = itf;
+	frame->len = pkt_len;
+	frame->offset = ESP_FRAME_HEADER_SIZE;
 
 	/* Copy frame payload. */
-	if (net_pkt_read(pkt, frame.payload, pkt_len) < 0) {
+	if (net_pkt_read(pkt, frame->payload, pkt_len) < 0) {
 		LOG_ERR("net_pkt_read failed");
 		return -EIO;
 	}
 
 	/* Update frame checksum and send the frame. */
-	frame.checksum = esp_hosted_frame_checksum(&frame);
-	if (esp_hosted_hal_spi_transfer(dev, &frame, NULL, ESP_FRAME_SIZE_ROUND(frame))) {
-		LOG_ERR("spi_transfer failed");
-		return -EIO;
+	frame->checksum = esp_hosted_frame_checksum(frame);
+
+	if (k_msgq_put(&data->tx_msgq, frame, K_MSEC(ESP_HOSTED_QUEUE_TIMEOUT))) {
+		LOG_ERR("Failed to enqueue message");
+		return -ENOBUFS;
 	}
 
 #if defined(CONFIG_NET_STATISTICS_WIFI)
@@ -584,15 +605,15 @@ static int esp_hosted_dev_init(const struct device *dev)
 {
 	esp_hosted_data_t *data = dev->data;
 
+	/* Initialize message queues. */
+	k_msgq_init(&data->tx_msgq, data->tx_qbuf, ESP_FRAME_SIZE,
+		    CONFIG_WIFI_ESP_HOSTED_TX_QUEUE_SIZE);
+	k_msgq_init(&data->rx_msgq, data->rx_qbuf, sizeof(CtrlMsg),
+		    CONFIG_WIFI_ESP_HOSTED_RX_QUEUE_SIZE);
+
 	/* Pins config and SPI init. */
 	if (esp_hosted_hal_init(dev)) {
 		return -EAGAIN;
-	}
-
-	/* Initialize semaphores. */
-	if (k_sem_init(&data->bus_sem, 1, 1)) {
-		LOG_ERR("k_sem_init() failed");
-		return -EINVAL;
 	}
 
 	data->tid = k_thread_create(&esp_hosted_event_thread, esp_hosted_event_stack,
@@ -618,7 +639,7 @@ static int esp_hosted_dev_init(const struct device *dev)
 	CtrlMsg_Resp_GetFwVersion *fw = &ctrl_msg.resp_get_fw_version;
 
 	if (esp_hosted_ctrl(dev, CtrlMsgId_Req_GetFwVersion, &ctrl_msg, ESP_HOSTED_SYNC_TIMEOUT)) {
-		LOG_INF("legacy firmware detected\n");
+		LOG_INF("legacy firmware detected");
 	} else {
 		data->fw_version.major1 = fw->major1;
 		data->fw_version.major2 = fw->major2;

--- a/drivers/wifi/esp_hosted/esp_hosted_wifi.h
+++ b/drivers/wifi/esp_hosted/esp_hosted_wifi.h
@@ -16,16 +16,32 @@
 #include <zephyr/net/wifi_nm.h>
 #include <zephyr/net/conn_mgr/connectivity_wifi_mgmt.h>
 
+#include <pb_encode.h>
+#include <pb_decode.h>
+#include <esp_hosted_proto.pb.h>
+
 #define DT_DRV_COMPAT espressif_esp_hosted
 
-#define ESP_HOSTED_MAC_ADDR_LEN (6)
-#define ESP_HOSTED_MAC_STR_LEN  (17)
-#define ESP_HOSTED_MAX_SSID_LEN (32)
-#define ESP_HOSTED_MAX_PASS_LEN (64)
-#define ESP_HOSTED_SYNC_TIMEOUT (5000)
-#define ESP_HOSTED_SCAN_TIMEOUT (10000)
+#define ESP_HOSTED_MAC_ADDR_LEN  (6)
+#define ESP_HOSTED_MAC_STR_LEN   (17)
+#define ESP_HOSTED_MAX_SSID_LEN  (32)
+#define ESP_HOSTED_MAX_PASS_LEN  (64)
+#define ESP_HOSTED_SYNC_TIMEOUT  (5000)
+#define ESP_HOSTED_SCAN_TIMEOUT  (10000)
+#define ESP_HOSTED_QUEUE_TIMEOUT (1000)
 #define ESP_HOSTED_SPI_CONFIG                                                                      \
 	(SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8) | SPI_MODE_CPOL)
+
+#define TLV_HEADER_SIZE      (14)
+#define TLV_HEADER_TYPE_EP   (1)
+#define TLV_HEADER_TYPE_DATA (2)
+#define TLV_HEADER_EP_RESP   "ctrlResp"
+#define TLV_HEADER_EP_EVENT  "ctrlEvnt"
+
+#define ESP_FRAME_SIZE           (1600)
+#define ESP_FRAME_HEADER_SIZE    (12)
+#define ESP_FRAME_MAX_PAYLOAD    (ESP_FRAME_SIZE - ESP_FRAME_HEADER_SIZE)
+#define ESP_FRAME_FLAGS_FRAGMENT (1 << 0)
 
 typedef enum {
 	ESP_HOSTED_STA_IF = 0,
@@ -36,6 +52,48 @@ typedef enum {
 	ESP_HOSTED_TEST_IF,
 	ESP_HOSTED_MAX_IF,
 } esp_hosted_interface_t;
+
+typedef enum {
+	ESP_PACKET_TYPE_EVENT,
+} esp_hosted_priv_packet_t;
+
+typedef enum {
+	ESP_PRIV_EVENT_INIT,
+} esp_hosted_priv_event_t;
+
+/* TLV payload. */
+typedef struct __packed {
+	uint8_t ep_type;
+	uint16_t ep_length;
+	uint8_t ep_value[8];
+	uint8_t data_type;
+	uint16_t data_length;
+	uint8_t data_value[];
+} esp_hosted_tlv_t;
+
+/* Event payload. */
+typedef struct __packed {
+	uint8_t event_type;
+	uint8_t event_len;
+	uint8_t event_data[];
+} esp_hosted_event_t;
+
+/* ESP frame struct (with data, event or TLV payload) */
+typedef struct __packed {
+	uint8_t if_type: 4;
+	uint8_t if_num: 4;
+	uint8_t flags;
+	uint16_t len;
+	uint16_t offset;
+	uint16_t checksum;
+	uint16_t seq_num;
+	uint8_t reserved2;
+	union {
+		uint8_t hci_pkt_type;
+		uint8_t priv_pkt_type;
+	};
+	uint8_t payload[];
+} esp_hosted_frame_t;
 
 typedef struct {
 	struct gpio_dt_spec cs_gpio;
@@ -51,7 +109,6 @@ typedef struct {
 	struct net_if *iface[2];
 	uint8_t mac_addr[2][6];
 	k_tid_t tid;
-	struct k_sem bus_sem;
 #if defined(CONFIG_NET_STATISTICS_WIFI)
 	struct net_stats_wifi stats;
 #endif
@@ -63,65 +120,16 @@ typedef struct {
 		uint32_t rev_patch1;
 		uint32_t rev_patch2;
 	} fw_version;
+
+	/* RX reassembly accumulator. */
+	uint8_t acc_buf[ESP_FRAME_SIZE * 2] __aligned(4);
+
+	/* queue of outgoing frames to transmit */
+	struct k_msgq tx_msgq;
+	uint8_t tx_qbuf[ESP_FRAME_SIZE * CONFIG_WIFI_ESP_HOSTED_TX_QUEUE_SIZE];
+
+	/* queue of received control responses/events */
+	struct k_msgq rx_msgq;
+	uint8_t rx_qbuf[sizeof(CtrlMsg) * CONFIG_WIFI_ESP_HOSTED_RX_QUEUE_SIZE];
 } esp_hosted_data_t;
-
-#define TLV_HEADER_SIZE      (14)
-#define TLV_HEADER_TYPE_EP   (1)
-#define TLV_HEADER_TYPE_DATA (2)
-#define TLV_HEADER_EP_RESP   "ctrlResp"
-#define TLV_HEADER_EP_EVENT  "ctrlEvnt"
-
-#define ESP_FRAME_SIZE           (1600)
-#define ESP_FRAME_HEADER_SIZE    (12)
-#define ESP_FRAME_MAX_PAYLOAD    (ESP_FRAME_SIZE - ESP_FRAME_HEADER_SIZE)
-#define ESP_FRAME_FLAGS_FRAGMENT (1 << 0)
-
-typedef enum {
-	ESP_PACKET_TYPE_EVENT,
-} esp_hosted_priv_packet_t;
-
-typedef enum {
-	ESP_PRIV_EVENT_INIT,
-} esp_hosted_priv_event_t;
-
-typedef struct __packed {
-	uint8_t if_type: 4;
-	uint8_t if_num: 4;
-	uint8_t flags;
-	uint16_t len;
-	uint16_t offset;
-	uint16_t checksum;
-	uint16_t seq_num;
-	uint8_t reserved2;
-	union {
-		uint8_t hci_pkt_type;
-		uint8_t priv_pkt_type;
-	};
-	union {
-		struct __packed {
-			uint8_t event_type;
-			uint8_t event_len;
-			uint8_t event_data[];
-		};
-		struct __packed {
-			uint8_t ep_type;
-			uint16_t ep_length;
-			uint8_t ep_value[8];
-			uint8_t data_type;
-			uint16_t data_length;
-			uint8_t data_value[];
-		};
-		struct {
-			/* To support fragmented frames, reserve 2x payload size. */
-			uint8_t payload[ESP_FRAME_MAX_PAYLOAD * 2];
-		};
-	};
-} esp_frame_t;
-
-#define ESP_FRAME_CHECK_VALID(frame)                                                               \
-	(frame.len > 0 && frame.len <= ESP_FRAME_MAX_PAYLOAD &&                                    \
-	 frame.offset == ESP_FRAME_HEADER_SIZE)
-
-#define ESP_FRAME_SIZE_ROUND(frame) ((ESP_FRAME_HEADER_SIZE + frame.len + 3) & ~3U)
-
 #endif /* ZEPHYR_DRIVERS_WIFI_ESP_HOSTED_WIFI_H_ */


### PR DESCRIPTION
Before this change, the host performed half-duplex SPI transactions, which caused frames that happen to be queued by ESP at the same time of a TX transfer to be dropped. This is especially noticeable with the new firmware.

Rework the driver so every SPI transaction is full-duplex: outgoing frames are queued and the event task drains TX while simultaneously capturing RX, so nothing is lost.

Other major improvements of the driver:

* Remove SPI bus semaphore, since only the event task uses the bus now.
* Reduce stack usage of all threads by 50% by refactoring data structures.
* Simplify event task by moving fragment validation and reassembly into a utility function.
* Fix undefined behavior in checksum validation.
* Fix the reassembly overflow guard (was off by twice the header).
* Split TX/RX queue sizes into separate Kconfig options.
* Fix and improve error codes usage (use -ENOBUFS, -EMSGSIZE, etc).

Testing:
* Tested SSL connection with legacy and v1.0 firmwares.

Fixes: #114526