### PR TITLE
clock_control: mspm0: remove empty APIs

### DIFF
--- a/drivers/clock_control/clock_control_mspm0.c
+++ b/drivers/clock_control/clock_control_mspm0.c
@@ -125,16 +125,6 @@ static DL_SYSCTL_SYSPLLConfig clock_mspm0_cfg_syspll = {
 };
 #endif
 
-static int clock_mspm0_on(const struct device *dev, clock_control_subsys_t sys)
-{
-	return 0;
-}
-
-static int clock_mspm0_off(const struct device *dev, clock_control_subsys_t sys)
-{
-	return 0;
-}
-
 static int clock_mspm0_get_rate(const struct device *dev,
 				clock_control_subsys_t sys,
 				uint32_t *rate)
@@ -275,8 +265,6 @@ static int clock_mspm0_init(const struct device *dev)
 }
 
 static DEVICE_API(clock_control, clock_mspm0_driver_api) = {
-	.on = clock_mspm0_on,
-	.off = clock_mspm0_off,
 	.get_rate = clock_mspm0_get_rate,
 };
 


### PR DESCRIPTION
The current on/off APIs return 0 despite doing nothing. This is because clock control (selection and gating) for each peripheral happens at each peripheral's own register space. If a user accidentally calls these APIs, they might expect them to work, but there is no need/way to have centralized clock control. Hence, remove these APIs and let the subsystem return -ENOSYS as intended.