### PR TITLE
dts: bindings: nxp,imx-flexspi-device: drop spi-device.yaml include

### DIFF
--- a/dts/bindings/mtd/nxp,imx-flexspi-device.yaml
+++ b/dts/bindings/mtd/nxp,imx-flexspi-device.yaml
@@ -3,9 +3,20 @@
 
 description: NXP FlexSPI device
 
-include: [spi-device.yaml, "jedec,jesd216.yaml"]
+include: [base.yaml, power.yaml, "jedec,jesd216.yaml"]
 
 properties:
+  reg:
+    required: true
+    description: FlexSPI port number for this device.
+
+  spi-max-frequency:
+    type: int
+    required: true
+    description: |
+      Maximum clock frequency of the FlexSPI serial interface in Hz.
+      Used to configure the FlexSPI root clock (flexspiRootClk).
+
   cs-interval-unit:
     type: int
     default: 1


### PR DESCRIPTION
FlexSPI is NXP's proprietary memory-mapped flash/PSRAM controller
  with its own LUT engine, AHB buffers, and clock tree — it is not a
  standard SPI bus. Including spi-device.yaml pulled in `on-bus: spi`
  semantics and 11 SPI-specific properties (duplex, spi-cpol, spi-cpha,
  etc.) that are meaningless for FlexSPI devices.
 
  Replace the spi-device.yaml include with base.yaml and power.yaml,
  and directly declare the only two properties FlexSPI actually uses
  from the SPI binding: `reg` and `spi-max-frequency`.
 
  This removes the incorrect SPI bus semantics from the FlexSPI binding
  chain, which caused all FlexSPI descendants (including `soc-nv-flash`
  grandchild nodes) to appear as SPI bus devices, misleading downstream
  DTS authors into placing SPI-specific properties on nodes whose
  bindings do not declare them.