### PR TITLE
MAINTAINERS.yml: drivers: ethernet: add tpambor

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1941,6 +1941,7 @@ Documentation Infrastructure:
     - lmajewski
     - pdgendt
     - ClaCodes
+    - tpambor
   files:
     - drivers/ethernet/
     - include/zephyr/dt-bindings/ethernet/


### PR DESCRIPTION
Add tpambor to the ethernet driver collaborators.

He is especially active in the generic synopsys dwc_mac ethernet driver.