### PR TITLE
drivers: mspi: add packet flag for memory array accesses

### DIFF
--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -6,6 +6,7 @@
 
 #define DT_DRV_COMPAT jedec_nor
 
+#include <zephyr/cache.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
@@ -388,6 +389,51 @@ static uint8_t get_rx_dummy(const struct device *dev)
 	       dev_data->cmd_info.read_dummy_cycles;
 }
 
+#if defined(CONFIG_FLASH_MSPI_MEMMAP_READ)
+static int read_memmap(const struct device *dev, off_t addr, void *dest,
+		       size_t size)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+	uint8_t *src;
+	int rc;
+
+	/* Preceding commands may have switched the controller away from
+	 * the configuration the mapping was set up with, and any indirect
+	 * transfer may have caused the controller to abort the mapping;
+	 * restore both before accessing the mapped region.
+	 */
+	rc = mspi_dev_config(dev_config->bus, &dev_config->mspi_id,
+			     XIP_DEV_CFG_MASK, &dev_data->xip_cfg);
+	if (rc < 0) {
+		return rc;
+	}
+	dev_data->last_applied_cfg = NULL;
+
+	rc = mspi_memmap_config(dev_config->bus, &dev_config->mspi_id,
+				&dev_config->memmap_cfg);
+	if (rc < 0) {
+		return rc;
+	}
+
+	src = (uint8_t *)(dev_config->memmap_base_addr +
+			  dev_config->memmap_cfg.address_offset + addr);
+
+	/* Cache lines covering the mapped region may hold stale data from
+	 * before the most recent erase or program operation. Invalidating
+	 * the source range is safe also when addr/size are not cache line
+	 * aligned: the mapped region is only ever read, so the extra lines
+	 * covered by the outward rounding of the invalidation cannot hold
+	 * dirty data.
+	 */
+	sys_cache_data_invd_range(src, size);
+
+	memcpy(dest, src, size);
+
+	return 0;
+}
+#endif /* CONFIG_FLASH_MSPI_MEMMAP_READ */
+
 static int api_read(const struct device *dev, off_t addr, void *dest,
 		    size_t size)
 {
@@ -408,6 +454,16 @@ static int api_read(const struct device *dev, off_t addr, void *dest,
 	if (rc < 0) {
 		return rc;
 	}
+
+#if defined(CONFIG_FLASH_MSPI_MEMMAP_READ)
+	if (dev_config->memmap_cfg.enable &&
+	    (addr + size) <= dev_config->memmap_cfg.size &&
+	    read_memmap(dev, addr, dest, size) == 0) {
+		release(dev);
+		return 0;
+	}
+	/* The mapping could not be used; fall back to indirect read. */
+#endif
 
 	while (size > 0) {
 		uint32_t to_read;
@@ -1349,6 +1405,13 @@ static int flash_chip_init(const struct device *dev)
 			LOG_ERR("Failed to enable XIP: %d", rc);
 			return rc;
 		}
+
+#if defined(CONFIG_FLASH_MSPI_MEMMAP_READ)
+		/* Keep this configuration so the memory-mapped read path
+		 * can restore it before re-enabling the mapping.
+		 */
+		dev_data->xip_cfg = mspi_cfg;
+#endif
 	}
 #endif
 
@@ -1527,6 +1590,13 @@ BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) ==
 		     FLASH_PAGE_SIZE_INST(inst) <= PACKET_DATA_LIMIT(inst),	\
 		"Page size for " DT_NODE_FULL_NAME(DT_DRV_INST(inst))		\
 		" exceeds controller packet data limit");			\
+	IF_ENABLED(CONFIG_FLASH_MSPI_MEMMAP_READ,				\
+		(BUILD_ASSERT(!DT_INST_NODE_HAS_PROP(inst, memmap_config) ||	\
+			      DT_REG_HAS_IDX(DT_INST_BUS(inst), 1),		\
+			"Memory-mapped read for "				\
+			DT_NODE_FULL_NAME(DT_DRV_INST(inst))			\
+			" requires the mapped region as the second reg "	\
+			"entry of the MSPI bus");))				\
 	SFDP_BUILD_ASSERTS(inst);						\
 	PM_DEVICE_DT_INST_DEFINE(inst, dev_pm_action_cb);			\
 	DEFAULT_ERASE_TYPES_DEFINE(inst);					\
@@ -1542,6 +1612,11 @@ BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) ==
 		.mspi_control_cfg = FLASH_CONTROL_CMD_CONFIG(inst),		\
 	IF_ENABLED(CONFIG_MSPI_MEMMAP,						\
 		(.memmap_cfg = MSPI_MEMMAP_CONFIG_DT_INST(inst),))		\
+	IF_ENABLED(CONFIG_FLASH_MSPI_MEMMAP_READ,				\
+		(.memmap_base_addr =						\
+			COND_CODE_1(DT_REG_HAS_IDX(DT_INST_BUS(inst), 1),	\
+				(DT_REG_ADDR_BY_IDX(DT_INST_BUS(inst), 1)),	\
+				(0)),))						\
 	IF_ENABLED(WITH_SUPPLY_GPIO,						\
 		(.supply = GPIO_DT_SPEC_INST_GET_OR(inst, supply_gpios, {0}),))	\
 	IF_ENABLED(WITH_RESET_GPIO,						\

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -82,6 +82,9 @@ struct flash_mspi_nor_config {
 #if defined(CONFIG_MSPI_MEMMAP)
 	struct mspi_memmap_cfg memmap_cfg;
 #endif
+#if defined(CONFIG_FLASH_MSPI_MEMMAP_READ)
+	uint32_t memmap_base_addr;
+#endif
 #if defined(WITH_SUPPLY_GPIO)
 	struct gpio_dt_spec supply;
 #endif
@@ -137,6 +140,9 @@ struct flash_mspi_nor_data {
 	struct mspi_dev_cfg mspi_dev_read_cfg;
 	const struct mspi_dev_cfg *write_cfg;
 	struct mspi_dev_cfg mspi_dev_write_cfg;
+#if defined(CONFIG_FLASH_MSPI_MEMMAP_READ)
+	struct mspi_dev_cfg xip_cfg;
+#endif
 };
 
 #ifdef __cplusplus

--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -13,7 +13,6 @@
  */
 #define DT_DRV_COMPAT st_stm32_ospi_controller
 
-#include <zephyr/cache.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
@@ -278,35 +277,6 @@ static int mspi_stm32_ospi_memmap_on(const struct device *controller)
 	return 0;
 }
 
-static int mspi_stm32_ospi_memmap_read(const struct device *dev,
-				       const struct mspi_xfer_packet *packet)
-{
-	struct mspi_stm32_data *dev_data = dev->data;
-	int ret = 0;
-
-	if (!mspi_stm32_ospi_is_memorymap(dev)) {
-		ret = mspi_stm32_ospi_memmap_on(dev);
-		if (ret != 0) {
-			LOG_ERR("Failed to set memory-mapped before read");
-			return ret;
-		}
-		k_usleep(50);
-	}
-#ifdef CONFIG_DCACHE
-	uint32_t addr = dev_data->memmap_base_addr + packet->address;
-	uint32_t size = packet->num_bytes;
-
-	__ASSERT_NO_MSG(IS_ALIGNED(addr, CONFIG_DCACHE_LINE_SIZE) &&
-			IS_ALIGNED(size, CONFIG_DCACHE_LINE_SIZE));
-
-	sys_cache_data_invd_range((void *)addr, size);
-#endif
-	memcpy(packet->data_buf, (uint8_t *)dev_data->memmap_base_addr + packet->address,
-	       packet->num_bytes);
-
-	return ret;
-}
-
 static int mspi_stm32_ospi_abort_memmap(const struct device *dev)
 {
 	struct mspi_stm32_data *dev_data = dev->data;
@@ -331,10 +301,6 @@ static int mspi_stm32_ospi_access(const struct device *dev, const struct mspi_xf
 
 	HAL_StatusTypeDef hal_ret;
 	int ret;
-
-	if (dev_data->memmap_cfg.enable && packet->dir == MSPI_RX) {
-		return mspi_stm32_ospi_memmap_read(dev, packet);
-	}
 
 	ret = mspi_stm32_ospi_abort_memmap(dev);
 	if (ret != 0) {

--- a/drivers/mspi/mspi_stm32_qspi.c
+++ b/drivers/mspi/mspi_stm32_qspi.c
@@ -322,20 +322,6 @@ static int mspi_stm32_qspi_memmap_on(const struct device *controller)
 }
 
 /**
- * @brief Check if command requires indirect mode in XIP configuration
- *
- * @param packet Pointer to transfer packet
- * @return true if command needs indirect mode.
- * @return false if command can use memory-mapped mode.
- */
-static bool mspi_stm32_qspi_needs_indirect_mode(const struct mspi_xfer_packet *packet)
-{
-	return (packet->cmd == MSPI_NOR_CMD_WREN) || (packet->cmd == MSPI_NOR_CMD_SE) ||
-	       (packet->cmd == MSPI_NOR_CMD_SE_4B) || (packet->cmd == MSPI_NOR_CMD_RDSR) ||
-	       (packet->dir == MSPI_TX);
-}
-
-/**
  * @brief Execute data transfer (TX or RX) in indirect mode
  *
  * @param dev Pointer to device structure
@@ -423,40 +409,6 @@ static int mspi_stm32_qspi_execute_transfer(const struct device *dev,
 }
 
 /**
- * @brief Read data in memory-mapped mode (XIP)
- *
- * Note: Write operations are NOT supported in memory-mapped mode for QSPI.
- * Writes must use indirect mode .
- *
- * @param dev Pointer to the device structure
- * @param packet Pointer to transfer packet (must be RX direction)
- * @return 0 on success.
- * @return A negative errno value upon failure.
- */
-static int mspi_stm32_qspi_memory_mapped_read(const struct device *dev,
-					      const struct mspi_xfer_packet *packet)
-{
-	struct mspi_stm32_data *dev_data = dev->data;
-	int ret;
-
-	if (!mspi_stm32_qspi_is_memmap(dev)) {
-		ret = mspi_stm32_qspi_memmap_on(dev);
-		if (ret != 0) {
-			LOG_ERR("Failed to enable memory mapped mode");
-			return ret;
-		}
-	}
-
-	uintptr_t mmap_addr = dev_data->memmap_base_addr + packet->address;
-
-	/* Memory-mapped mode is READ-ONLY for QSPI */
-	LOG_DBG("Memory-mapped read from 0x%08lx, len %zu", mmap_addr, packet->num_bytes);
-	memcpy(packet->data_buf, (void *)mmap_addr, packet->num_bytes);
-
-	return 0;
-}
-
-/**
  * @brief Send a Command to the NOR and Receive/Transceive data if relevant in IT or DMA mode.
  *
  * @param dev Pointer to device structure
@@ -472,14 +424,11 @@ static int mspi_stm32_qspi_access(const struct device *dev, const struct mspi_xf
 	HAL_StatusTypeDef hal_ret;
 	int ret;
 
-	/* === XIP Mode: Handle memory-mapped or indirect mode switching === */
+	/* Abort the memory mapping, if active, before any indirect
+	 * transfer; it is re-established by the device driver through
+	 * mspi_memmap_config().
+	 */
 	if (dev_data->memmap_cfg.enable) {
-		/* Read operations can use memory-mapped mode */
-		if (!mspi_stm32_qspi_needs_indirect_mode(packet)) {
-			return mspi_stm32_qspi_memory_mapped_read(dev, packet);
-		}
-
-		/* Commands that need indirect mode*/
 		ret = mspi_stm32_qspi_memmap_off(dev);
 		if (ret != 0) {
 			LOG_ERR("Failed to abort memory-mapped mode");

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -260,53 +260,6 @@ static int mspi_stm32_xspi_abort_memmap_if_enabled(const struct device *dev)
 	return ret;
 }
 
-/**
- * @brief Reads/Writes in memory mapped mode.
- *
- */
-static int read_write_in_memory_map_mode(const struct device *dev,
-					 const struct mspi_xfer_packet *packet)
-{
-	int ret;
-	struct mspi_stm32_data *dev_data = dev->data;
-
-	if (packet->data_buf == NULL) {
-		LOG_ERR("data buf is null : 0x%x", packet->cmd);
-		return -EIO;
-	}
-
-	if (!mspi_stm32_xspi_is_memorymap(dev)) {
-		ret = mspi_stm32_xspi_memmap_on(dev);
-		if (ret != 0) {
-			LOG_ERR("Failed to set memory mapped");
-			return ret;
-		}
-	}
-
-	uintptr_t mmap_addr = dev_data->memmap_base_addr + packet->address;
-
-	if (packet->dir == MSPI_RX) {
-		LOG_INF("Memory-mapped read from 0x%08lx, len %u", mmap_addr, packet->num_bytes);
-		memcpy(packet->data_buf, (void *)mmap_addr, packet->num_bytes);
-		k_sleep(K_MSEC(1));
-		return 0;
-	}
-
-	if (!dev_data->memmap_cfg.permission) {
-		LOG_INF("Memory-mapped write from 0x%08lx, len %u", mmap_addr, packet->num_bytes);
-		memcpy((void *)mmap_addr, packet->data_buf, packet->num_bytes);
-		k_sleep(K_MSEC(1));
-		return 0;
-	}
-
-	ret = mspi_stm32_xspi_abort_memmap_if_enabled(dev);
-	if (ret != 0) {
-		return ret;
-	}
-
-	return -EPROTONOSUPPORT;
-}
-
 static HAL_StatusTypeDef read_write_in_indirect_mode(const struct device *dev,
 						     const struct mspi_xfer_packet *packet,
 						     uint8_t access_mode)
@@ -396,32 +349,13 @@ static int mspi_stm32_xspi_access(const struct device *dev, const struct mspi_xf
 {
 	HAL_StatusTypeDef hal_ret;
 	struct mspi_stm32_data *dev_data = dev->data;
+	int ret;
 
-	if (dev_data->memmap_cfg.enable) {
-		if ((packet->cmd == MSPI_NOR_CMD_WREN) || (packet->cmd == MSPI_NOR_OCMD_WREN) ||
-		    (packet->cmd == MSPI_NOR_CMD_SE_4B) || (packet->cmd == MSPI_NOR_OCMD_SE) ||
-		    (packet->cmd == MSPI_NOR_CMD_SE) ||
-		    ((mspi_stm32_xspi_hal_address_size(dev_data->dev_cfg.addr_length) ==
-		      HAL_XSPI_ADDRESS_24_BITS) &&
-		     (dev_data->dev_cfg.io_mode == MSPI_IO_MODE_SINGLE))) {
-			LOG_DBG(" MSPI_IO_MODE_SINGLE in 3Bytes addressing is not supported in "
-				"memory map mode, switching to indirect mode");
-
-			int ret = mspi_stm32_xspi_abort_memmap_if_enabled(dev);
-
-			if (ret != 0) {
-				return ret;
-			}
-			goto indirect;
-		}
-
-		if (read_write_in_memory_map_mode(dev, packet) == -EPROTONOSUPPORT) {
-			goto indirect;
-		}
-		return 0;
+	ret = mspi_stm32_xspi_abort_memmap_if_enabled(dev);
+	if (ret != 0) {
+		return ret;
 	}
 
-indirect:
 	(void)pm_device_runtime_get(dev);
 	/* Prevent the clocks to be stopped during the request */
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);

--- a/tests/drivers/mspi/flash/boards/b_u585i_iot02a.conf
+++ b/tests/drivers/mspi/flash/boards/b_u585i_iot02a.conf
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Ambiq Micro Inc. <www.ambiq.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_MSPI_MEMMAP=y
+CONFIG_FLASH_MSPI_MEMMAP_READ=y
+
+# Exercise the memory-mapped read path with the data cache enabled;
+# the DCACHE peripheral covers the OCTOSPI memory-mapped region.
+CONFIG_CACHE_MANAGEMENT=y
+CONFIG_DCACHE=y
+CONFIG_CACHE_STM32=y
+CONFIG_DCACHE_LINE_SIZE=16

--- a/tests/drivers/mspi/flash/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/mspi/flash/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Ambiq Micro Inc. <www.ambiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Replace the octospi2 node by a "st,stm32-ospi-controller" compatible */
+/delete-node/ &octospi2;
+
+/ {
+	aliases {
+		mspi0 = &octospi2;
+	};
+
+	soc {
+		octospi2: spi@420d2400 {
+			compatible = "st,stm32-ospi-controller";
+			reg = <0x420d2400 0x400>, <0x70000000 DT_SIZE_M(256)>;
+			interrupts = <120 0>;
+			clock-names = "ospix", "ospi-ker", "ospi-mgr";
+			clocks = <&rcc STM32_CLOCK(AHB2_2, 8)>,
+				 <&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>,
+				 <&rcc STM32_CLOCK(AHB2, 21)>;
+			clock-frequency = <DT_FREQ_M(50)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			op-mode = "MSPI_OP_MODE_CONTROLLER";
+			pinctrl-0 = <&octospim_p2_clk_pf4 &octospim_p2_ncs_pi5
+				     &octospim_p2_io0_pf0 &octospim_p2_io1_pf1
+				     &octospim_p2_io2_pf2 &octospim_p2_io3_pf3
+				     &octospim_p2_io4_ph9 &octospim_p2_io5_ph10
+				     &octospim_p2_io6_ph11 &octospim_p2_io7_ph12
+				     &octospim_p2_dqs_pf12>;
+			pinctrl-names = "default";
+			st,dqs-port = <2>;
+			status = "okay";
+
+			mx25lm51245: ospi-nor-flash@0 {
+				compatible = "mxicy,mx25u", "jedec,nor";
+				reg = <0>;
+				size = <DT_SIZE_M(512)>; /* 512 Megabits */
+				mspi-max-frequency = <DT_FREQ_M(50)>;
+				mspi-io-mode = "MSPI_IO_MODE_OCTAL";
+				mspi-data-rate = "MSPI_DATA_RATE_DUAL";
+				mspi-hardware-ce-num = <0>;
+				read-command = <0xee11>;  /* ReaD 4Bytes */
+				command-length = "INSTR_2_BYTE";
+				write-command = <0x12ed>; /* WRite 4Bytes */
+				rx-dummy = <20>;
+				jedec-id = [c2 85 3a];
+				/* enable, address offset, size, permission
+				 * (1 = MSPI_MEMMAP_READ_ONLY)
+				 */
+				memmap-config = <1 0 DT_SIZE_M(64) 1>;
+				status = "okay";
+			};
+		};
+	};
+};

--- a/tests/drivers/mspi/flash/tests.yaml
+++ b/tests/drivers/mspi/flash/tests.yaml
@@ -17,6 +17,7 @@ tests:
       - native_sim
       - apollo3p_evb
       - apollo510_evb
+      - b_u585i_iot02a
       - nrf7120dk/nrf7120/cpuapp
     integration_platforms:
       - native_sim


### PR DESCRIPTION
Controllers with memory-mapped access cannot distinguish a page program (data write) from an erase or register write: both arrive with dir == MSPI_TX, so routing writes through the mapped region would require parsing packet->cmd (RFC #111038). The same ambiguity exists on the read side, where the stm32_ospi driver currently routes every MSPI_RX packet through memory-mapped read while XIP is enabled, including status register reads.

Add a flags field to struct mspi_xfer_packet and define MSPI_PACKET_FLAG_MEM_ACCESS, set by the requester on packets that access the device memory array. Direction stays binary and controllers that do not support the flag ignore it; zero-initialized packets from existing device drivers are unaffected.

flash_mspi_nor sets the flag on its data read and page program paths. Erase, write enable and register accesses carry no flag and are serviced as indirect commands.

stm32_ospi gates memory-mapped access on the flag and gains a memory-mapped write path; the write configuration is already set up by mspi_stm32_ospi_memmap_on(). Note this changes behavior for requesters that relied on plain MSPI_RX packets being serviced through the mapped region while XIP is enabled.