### PR TITLE
arch/arm: Fix CFSR MMARVALID/BFARVALID clear with write-1-to-clear

### DIFF
--- a/arch/arm/core/cortex_m/fault.c
+++ b/arch/arm/core/cortex_m/fault.c
@@ -220,7 +220,7 @@ static uint32_t mem_manage_fault(struct arch_esf *esf, int from_hard_fault, bool
 			PR_EXC("  MMFAR Address: 0x%x", mmfar);
 			if (from_hard_fault != 0) {
 				/* clear SCB_MMAR[VALID] to reset */
-				SCB->CFSR &= ~SCB_CFSR_MMARVALID_Msk;
+				SCB->CFSR = SCB_CFSR_MMARVALID_Msk;
 			}
 		}
 	}
@@ -373,7 +373,7 @@ static int bus_fault(struct arch_esf *esf, int from_hard_fault, bool *recoverabl
 			PR_EXC("  BFAR Address: 0x%x", bfar);
 			if (from_hard_fault != 0) {
 				/* clear SCB_CFSR_BFAR[VALID] to reset */
-				SCB->CFSR &= ~SCB_CFSR_BFARVALID_Msk;
+				SCB->CFSR = SCB_CFSR_BFARVALID_Msk;
 			}
 		}
 	}


### PR DESCRIPTION
The CFSR register uses write-1-to-clear semantics for all fault status bits per the ARMv7-M/ARMv8-M Architecture Reference Manual. Two locations in the MemManage and BusFault handlers incorrectly used `&= ~Msk` (write-0) instead of `= Msk` (write-1), which has no effect on these sticky bits.

This caused stale VALID bits to persist, leading subsequent fault handlers to read expired MMFAR/BFAR addresses and potentially misdiagnose stack overflows.

Fixes zephyrproject-rtos/zephyr#113515