### PR TITLE
drivers: adc & gpio: tla2528: Remove double const

### DIFF
--- a/drivers/adc/adc_tla2528.c
+++ b/drivers/adc/adc_tla2528.c
@@ -224,7 +224,7 @@ static int tla2528_init(const struct device *dev)
 	return 0;
 }
 
-static const DEVICE_API(adc, adc_tla2528_api) = {
+static DEVICE_API(adc, adc_tla2528_api) = {
 	.channel_setup = tla2528_channel_setup,
 	.read = tla2528_read,
 	.ref_internal = TLA2528_REF_INTERNAL,

--- a/drivers/gpio/gpio_tla2528.c
+++ b/drivers/gpio/gpio_tla2528.c
@@ -260,7 +260,7 @@ static int tla2528_init(const struct device *dev)
 	return 0;
 }
 
-static const DEVICE_API(gpio, gpio_tla2528_api) = {
+static DEVICE_API(gpio, gpio_tla2528_api) = {
 	.pin_configure = tla2528_pin_configure,
 	.port_get_raw = tla2528_port_get_raw,
 	.port_set_masked_raw = tla2528_port_set_masked_raw,


### PR DESCRIPTION
DEVICE_API already includes const, with another const, clang warns us about the double specifier.

Remove it to avoid the warning.

The issue can be repro'd building for native_sim/native `tests/drivers/build_all/gpio` and `tests/drivers/build_all/adc/` with clang
```
ZEPHYR_TOOLCHAIN_VARIANT=host/llvm cmake -GNinja -DBOARD=native_sim ../tests/drivers/build_all/gpio/
ninja
```

Introduced by e72986dc950f9439a620ffb1d2a0ba5837ec91b8  https://github.com/zephyrproject-rtos/zephyr/pull/110722

CI failure: https://github.com/zephyrproject-rtos/zephyr/actions/runs/29338658194/job/87104324402#step:12:928