### PR TITLE
llext: arm64: fix swapped MOVZ/MOVN opcode in signed MOVW relocations

### DIFF
--- a/arch/arm64/core/elf.c
+++ b/arch/arm64/core/elf.c
@@ -274,10 +274,10 @@ static int movw_reloc_handler(elf_rela_t *rel, elf_word reloc_type, uintptr_t lo
 		opcode &= ~(AARCH64_MASK_MOV_OPCODE << AARCH64_SHIFT_MOV_OPCODE);
 
 		if (x >= 0) {
-			opcode |= (AARCH64_OPCODE_MOVN << AARCH64_SHIFT_MOV_OPCODE);
-		} else {
 			opcode |= (AARCH64_OPCODE_MOVZ << AARCH64_SHIFT_MOV_OPCODE);
-			/* Need to invert immediate value for MOVZ. */
+		} else {
+			opcode |= (AARCH64_OPCODE_MOVN << AARCH64_SHIFT_MOV_OPCODE);
+			/* Need to invert immediate value for MOVN. */
 			imm = ~imm;
 		}
 	}


### PR DESCRIPTION
In `movw_reloc_handler()`, the MOVZ/MOVN opcode selection for signed AArch64 MOVW relocations was inverted: positive relocation values were encoded with MOVN (negate) and negative values with MOVZ (zero), causing all signed MOVW relocations to produce wrong immediate values.

Swap the two branches so that `x >= 0` selects MOVZ and `x < 0` selects MOVN with immediate inversion, matching the AArch64 instruction semantics where MOVZ zero-extends and MOVN negates the immediate.

Fixes zephyrproject-rtos/zephyr#113383.