### PR TITLE
twister: Deal with trailing slash in outdir

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -715,6 +715,7 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
     parser.add_argument(
         "-O", "--outdir",
         default=os.path.join(os.getcwd(), "twister-out"),
+        type=os.path.normpath,
         help="Output directory for logs and binaries. "
              "Default is 'twister-out' in the current directory. "
              "This directory will be cleaned unless '--no-clean' is set. "


### PR DESCRIPTION
This change allows the following command to be run more than once without crashing:

> twister --outdir directory-with-trailing-slash/

Without this fix, the 2nd run would abort with an error like this:

> shutil.Error: Cannot move a directory 'directory-with-trailing-slash/'
> into itself 'directory-with-trailing-slash/.1'.