### PR TITLE
manifest: Update hal_adi for MXC_SPI_InitState for all parts

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -147,7 +147,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: 35d874ccfb8fb062ca8bdf096764b8d34c6d608e
+      revision: a554a31806bc308d954fdb43143d260902da9b1e
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
Some MAX32 parts were missing the declaration for the recently added MXC_SPI_InitState. Pull in an updated hal_adi to pick up fixes for the missing parts.

This fixes the build error in the latest [weekly run](https://github.com/zephyrproject-rtos/zephyr/actions/runs/29177651386)
```
error: implicit declaration of function 'MXC_SPI_InitState'; did you mean 'MXC_SPI_GetSlave'? [-Wimplicit-function-declaration]
```