### PR TITLE
drivers: flash: ite_it8xxx2: add delay in status polling loop

### DIFF
--- a/drivers/flash/flash_ite_it8xxx2.c
+++ b/drivers/flash/flash_ite_it8xxx2.c
@@ -212,7 +212,9 @@ void __soc_ram_code ramcode_flash_cmd_read_status(enum flash_status_mask mask,
 	 */
 	while ((flash_regs->SMFI_ECINDDR & mask) != target) {
 		/* read status and check if it is we want. */
-		;
+		for (volatile int delay = 0; delay < 100; delay++) {
+			/* Inline delay to ensure this is RAM resident */
+		}
 	}
 
 	/* transaction done, drive #CS high */


### PR DESCRIPTION
In ramcode_flash_cmd_read_status, the status polling loop continuously reads SMFI_ECINDDR in RAM without any delay cycles. During flash erase operations, tight polling can cause bus contention or premature register evaluation on fast silicon and at higher compiler optimization levels, resulting in intermittent erase failures (rc=-2).

Add a small delay loop inside the status polling loop to throttle register reads.

Tested on board with it8xxx2 EC.

Assisted-by: Gemini CLI