### PR TITLE
twister: Use default outdir from environment

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -714,9 +714,9 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
 
     parser.add_argument(
         "-O", "--outdir",
-        default=os.path.join(os.getcwd(), "twister-out"),
+        default=os.environ.get("TWISTER_OUTDIR", os.path.join(os.getcwd(), "twister-out")),
         help="Output directory for logs and binaries. "
-             "Default is 'twister-out' in the current directory. "
+             "Default is 'twister-out' in the current directory, or, if set, TWISTER_OUTDIR. "
              "This directory will be cleaned unless '--no-clean' is set. "
              "The '--clobber-output' option controls what cleaning does.")
 


### PR DESCRIPTION
When running twister frequently during (local) development work, I want past twister-out directories to be archived (by renaming them to .1, .2, .3, ...), and not use --no-clean or the like. However, unlike my checked out Zephyr repo, I do not want those bulky directories to be involved in my (frequent) BTRFS file system snapshots.

Before this commit, passing --outdir "/some/other/partition" to twister for every invocation of twister was needed.

With this change, it is enough to set TWISTER_OUTDIR to "/some/other/partition" in my environment just once.

Open questions:

- Where would it be sensible to document this new env variable?