### PR TITLE
Fix shell msleep

### DIFF
--- a/subsys/shell/modules/kernel_service/reboot.c
+++ b/subsys/shell/modules/kernel_service/reboot.c
@@ -15,7 +15,7 @@ static int cmd_kernel_reboot_warm(const struct shell *sh,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 #if (CONFIG_KERNEL_SHELL_REBOOT_DELAY > 0)
-	k_sleep(K_MSEC(CONFIG_KERNEL_SHELL_REBOOT_DELAY));
+	k_msleep(CONFIG_KERNEL_SHELL_REBOOT_DELAY);
 #endif
 	sys_reboot(SYS_REBOOT_WARM);
 	return 0;
@@ -27,7 +27,7 @@ static int cmd_kernel_reboot_cold(const struct shell *sh,
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 #if (CONFIG_KERNEL_SHELL_REBOOT_DELAY > 0)
-	k_sleep(K_MSEC(CONFIG_KERNEL_SHELL_REBOOT_DELAY));
+	k_msleep(CONFIG_KERNEL_SHELL_REBOOT_DELAY);
 #endif
 	sys_reboot(SYS_REBOOT_COLD);
 	return 0;

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1715,7 +1715,7 @@ static void shell_log_process(const struct shell *sh)
 		 * readable and can be used to enter further commands.
 		 */
 		if (sh->ctx->cmd_buff_len) {
-			k_sleep(K_MSEC(15));
+			k_msleep(15);
 		}
 
 	} while (processed && !k_event_test(&sh->ctx->signal_event, SHELL_SIGNAL_RXRDY));


### PR DESCRIPTION
This PR replaces the deprecated `k_sleep(K_MSEC(time))` pattern with the modern, more efficient `k_msleep(time)` API within the shell subsystem (`shell.c` and `reboot.c`).

Using `k_msleep()` prevents double-macro expansion overhead and adheres to Zephyr's preferred style guidelines for timeouts and delays.
