### PR TITLE
doc: security: fill in published CVE details

### DIFF
--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -1872,32 +1872,255 @@ This has been fixed in main for v4.5.0
 :cve:`2026-10674`
 -----------------
 
-Under embargo until 2026-07-18
+DoS (hard fault) in NXP LPUART driver: unsupported runtime UART config leaves clocks disabled
+
+The NXP LPUART serial driver (``drivers/serial/uart_mcux_lpuart.c``), when
+``CONFIG_UART_USE_RUNTIME_CONFIGURE`` is enabled, called ``LPUART_Deinit()`` at the
+start of ``mcux_lpuart_configure()``, which disables the LPUART peripheral clocks. The
+requested configuration is validated only afterwards (in
+``mcux_lpuart_configure_basic``), and unsupported parity/data-bit/stop-bit/flow-control
+values return ``-ENOTSUP`` before the clock is re-enabled.
+
+As a result, a ``uart_configure()`` request with an unsupported configuration left the
+LPUART in a clock-disabled state; any subsequent access to LPUART registers
+(``poll_out``/``poll_in``, interrupt handling, or a later reconfigure) faults on the
+gated peripheral and escalates to a hard fault, crashing the system.
+
+``uart_configure()`` is a Zephyr syscall whose verifier (``z_vrfy_uart_configure``) only
+checks that ``cfg`` is readable user memory and forwards the caller-supplied
+configuration unchanged, so an unprivileged userspace thread with access to an LPUART
+device can deterministically trigger the fault, a persistent system-wide denial of
+service.
+
+Introduced in v2.5.0 and present in all subsequent releases until this fix, which
+removes the ``LPUART_Deinit()`` call and instead only disables the transmitter/receiver,
+leaving the clock running.
+
+- `Zephyr project bug tracker GHSA-mw68-r353-m3vf
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-mw68-r353-m3vf>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107186 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107186>`_
+
+- `PR 111106 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111106>`_
+
+- `PR 111105 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111105>`_
+
+- `PR 111104 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111104>`_
 
 :cve:`2026-10675`
 -----------------
 
-Under embargo until 2026-07-19
+Bluetooth Mesh PB-ADV: invalidated provisioning link kept alive indefinitely, blocking (re)provisioning (DoS)
+
+In Zephyr's Bluetooth Mesh PB-ADV provisioning bearer
+(``subsys/bluetooth/mesh/pb_adv.c``), ``prov_msg_recv()`` rescheduled the provisioning
+protocol watchdog timer unconditionally at the top of the function, before the FCS check
+and before the ``ADV_LINK_INVALID`` check. Once a provisioning attempt fails,
+``prov_failed()`` sets ``ADV_LINK_INVALID`` and the only recovery path is the protocol
+timer firing (``protocol_timeout`` -> ``prov_link_close`` -> ``close_link`` ->
+``reset_adv_link`` and re-enabling of scanning and the unprovisioned device beacon).
+
+A remote, unauthenticated attacker on the BLE advertising channel can first induce a
+provisioning failure (e.g. with a malformed generic-provisioning PDU) and then transmit
+any FCS-valid PB-ADV transaction PDU on the same link ID more often than once per
+protocol timeout (60 s, or 120 s for OOB input/output). Because each such packet reset
+the timer even on an invalidated link, ``protocol_timeout`` never fired, the dead link
+was never torn down, and the device remained pinned in an un-provisionable state with
+its unprovisioned beacon disabled and new Link Open requests rejected.
+
+PB-ADV PDUs are processed without authentication and the FCS is a keyless CRC, so no
+pairing or prior trust is required and the attacker chooses the link ID itself. The
+impact is a persistent denial of provisioning/re-provisioning service; there is no
+memory-safety, confidentiality, or integrity impact.
+
+The vulnerable code shipped in releases through v4.4.1. The fix moves the timer
+reschedule to after the ``ADV_LINK_INVALID`` check (and the FCS check before the reset)
+so an invalidated link can no longer be kept alive by incoming packets.
+
+- `Zephyr project bug tracker GHSA-4rwg-6mr4-55hc
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-4rwg-6mr4-55hc>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 109324 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109324>`_
+
+- `PR 110910 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110910>`_
+
+- `PR 110909 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110909>`_
+
+- `PR 110911 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110911>`_
 
 :cve:`2026-10677`
 -----------------
 
-Under embargo until 2026-07-19
+Kernel heap memory leak in ``z_vrfy_k_poll()`` lets an unprivileged user thread exhaust the kernel resource pool
+
+The ``CONFIG_USERSPACE`` syscall verifier ``z_vrfy_k_poll()`` in ``kernel/poll.c``
+allocates a kernel-side copy of the user-supplied ``k_poll_event[]`` via
+``z_thread_malloc()`` and then validates each event's object handle. Before this fix,
+validation used ``K_OOPS(K_SYSCALL_OBJ(...))`` inline inside the loop, which kills the
+calling thread without freeing ``events_copy``.
+
+A user thread can pass ``num_events >= 1`` with a forged object handle to leak the
+allocation; because newly spawned user threads inherit the parent's ``resource_pool``
+(``kernel/thread.c``), an attacker spawns sacrificial threads to repeat the leak until
+the shared kernel heap is exhausted. Once depleted, legitimate kernel allocations from
+that pool (``k_queue`` alloc nodes, ``k_msgq`` buffers, future ``k_poll`` calls, etc.)
+fail, causing a system-level denial of service.
+
+The fix replaces each inline ``K_OOPS`` with a conditional ``goto oops_free`` so the
+buffer is freed before the thread is killed. Affects Zephyr releases from v1.12.0 (when
+``k_poll`` was first exposed to user mode) through v4.4.1.
+
+- `Zephyr project bug tracker GHSA-r3cc-8wcr-xfj9
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-r3cc-8wcr-xfj9>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 109361 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109361>`_
+
+- `PR 111111 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111111>`_
+
+- `PR 111112 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111112>`_
+
+- `PR 109535 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109535>`_
 
 :cve:`2026-10678`
 -----------------
 
-Under embargo until 2026-07-20
+NULL-pointer / out-of-bounds write in Zephyr MCTP I2C+GPIO target binding driven by an unauthenticated I2C controller
+
+The MCTP-over-I2C+GPIO target binding in Zephyr
+(``subsys/pmci/mctp/mctp_i2c_gpio_target.c``) processes pseudo-register writes from an
+I2C bus master byte-by-byte in ``mctp_i2c_gpio_target_write_received()`` without
+validating the order or the receive buffer. In the affected versions the
+``MCTP_I2C_GPIO_RX_MSG_ADDR`` (data) handler dereferences and writes through
+``b->rx_pkt`` without checking that the receive buffer was allocated: a controller that
+selects the data register and writes a byte without first sending the length register
+(which is what allocates the buffer) causes a write of an attacker-chosen byte through a
+NULL/unallocated ``mctp_pktbuf`` pointer (i.e. into a small attacker-advanceable offset
+above address 0), producing memory corruption or a hard fault.
+
+The same handler also performs a write-then-check bounds test, allowing a one-byte heap
+overflow at ``data[255]`` when more than 255 data bytes are sent.
+
+Because the I2C target callback is invoked with raw bytes supplied by whatever device is
+the bus master and the binding performs no authentication, a malicious or malfunctioning
+controller on the bus can trigger these without any prior protocol state, leading to
+memory corruption and/or denial of service on the target device.
+
+The vulnerable code was introduced when the I2C+GPIO target binding was added and
+shipped in Zephyr v4.3.0 and v4.4.0. The fix defers allocation to the first data byte
+with a NULL check, treats a missing length as a zero-sized packet rejected by libmctp,
+and moves the bounds check before the store.
+
+- `Zephyr project bug tracker GHSA-pmwm-5rcm-39rr
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-pmwm-5rcm-39rr>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 109428 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109428>`_
+
+- `PR 111118 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111118>`_
+
+- `PR 111117 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111117>`_
 
 :cve:`2026-10679`
 -----------------
 
-Under embargo until 2026-07-21
+Divide-by-zero in DesignWare SPI driver reachable from spi_transceive syscall (local DoS)
+
+The DesignWare SPI driver (drivers/spi/spi_dw.c) computed the SPI BAUDR clock divider as
+``info->clock_frequency / config->frequency`` without validating ``config->frequency``.
+
+``spi_transceive`` is a Zephyr __syscall and its verify handler
+(drivers/spi/spi_handlers.c) copies the caller-supplied ``spi_config`` from userspace
+without checking the frequency field, so a userspace thread that has been granted access
+to a DesignWare SPI device kernel object can pass ``frequency = 0`` and trigger an
+unsigned integer divide-by-zero in ``spi_dw_configure()``.
+
+On Cortex-M Mainline (``SCB->CCR.DIV_0_TRP`` is set in ``z_arm_fault_init()``) and on
+ARC (a dedicated ``__ev_div_zero`` vector) this raises a CPU exception, resulting in a
+kernel fault and local denial of service.
+
+The fix rejects zero frequency and frequencies above ``clock_frequency / 2`` (the
+DesignWare SSI databook minimum SCKDIV of 2) with -EINVAL. The defect affects all Zephyr
+releases up to and including v4.4.0; exploitation requires ``CONFIG_USERSPACE=y`` and an
+unprivileged thread already granted SPI driver permission. There is no memory-corruption
+or information-disclosure impact.
+
+- `Zephyr project bug tracker GHSA-3qcm-qwh2-v4hq
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3qcm-qwh2-v4hq>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 105452 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/105452>`_
+
+- `PR 111121 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111121>`_
+
+- `PR 111120 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111120>`_
 
 :cve:`2026-10680`
 -----------------
 
-Under embargo until 2026-07-21
+Out-of-bounds access in Zephyr BR/EDR L2CAP configuration request handling via ``uint16_t`` length underflow
+
+The Classic (BR/EDR) L2CAP signaling handlers ``l2cap_br_conf_req()`` and
+``l2cap_br_conf_rsp()`` in ``subsys/bluetooth/host/classic/l2cap_br.c`` validated the
+minimum command size against ``buf->len`` (the bytes remaining in the whole received
+PDU) instead of ``len`` (the per-command data length from the L2CAP signaling header).
+Because multiple signaling commands can be packed into one PDU, ``buf->len`` may exceed
+a command's ``len``. An attacker can send a ``CONF_REQ`` command with a header length
+smaller than the configuration-request structure (e.g. 0), followed by another command
+so that ``buf->len`` still satisfies the check. The check then passes incorrectly and
+``opt_len = len - sizeof(*req)`` underflows the ``uint16_t`` to a near-0xFFFF value. The
+configuration-option loop, which lacks an ``opt_len``-versus-``buf->len`` guard, then
+walks far past the end of the pooled ACL receive buffer using ``net_buf`` pull
+primitives that perform no runtime bounds check, producing an out-of-bounds read of host
+memory and, when the out-of-bounds option bytes encode an MTU or flush-timeout option,
+an out-of-bounds write. The BR/EDR signaling channel is processed before
+pairing/encryption and an L2CAP channel to an L0 service such as SDP can be opened
+without pairing, so an unauthenticated peer within radio range that can establish an ACL
+connection can trigger the flaw, leading to memory corruption and denial of service
+(host/device crash). The defect is present in released versions including v4.4.0. The
+fix validates against ``len`` instead of ``buf->len`` in both handlers.
+
+- `Zephyr project bug tracker GHSA-vrwx-p97q-8854
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-vrwx-p97q-8854>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 109308 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109308>`_
+
+- `PR 110661 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110661>`_
+
+- `PR 110662 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110662>`_
+
+- `PR 111405 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111405>`_
 
 :cve:`2026-10681`
 -----------------
@@ -2047,7 +2270,49 @@ Under embargo until 2026-08-13
 :cve:`2026-7007`
 ----------------
 
-Under embargo until 2026-07-23
+Division by zero in Zephyr ext2 superblock parsing allows DoS via crafted filesystem image
+
+The Zephyr ext2 file system validates the on-disk superblock in
+``ext2_verify_disk_superblock()`` (subsys/fs/ext2/ext2_impl.c) before completing a
+mount. The validator checked the magic number, block size, revision and feature flags,
+but did not verify that the on-disk fields ``s_blocks_per_group`` and
+``s_inodes_per_group`` are non-zero. Both fields are read directly from the image and
+are later used as divisors during mount-time initialization.
+
+During mount, ``get_ngroups()`` divides and modulos ``s_blocks_count`` by
+``s_blocks_per_group`` (reached via ``ext2_fetch_block_group()`` from
+``ext2_init_fs()``), and ``get_itable_entry()`` divides ``(ino - 1)`` by
+``s_inodes_per_group`` when fetching the root inode (both in
+subsys/fs/ext2/ext2_diskops.c). A superblock with either field set to zero therefore
+causes an integer division by zero during the mount sequence.
+
+An attacker who can present a crafted ext2 image to a device that mounts ext2 —
+removable media such as an SD card or a USB mass-storage device — can trigger this. On
+ARMv7-M / ARMv8-M-mainline Cortex-M targets, divide-by-zero trapping is enabled
+(``SCB_CCR_DIV_0_TRP``), so the division raises a UsageFault that Zephyr treats as a
+fatal error, producing a denial of service. The impact is limited to availability; the
+malformed value is consumed only as a divisor.
+
+The fix rejects a zero ``s_blocks_per_group`` or ``s_inodes_per_group`` in the
+superblock validator, returning ``-EINVAL`` so the mount fails before any block-group or
+inode I/O occurs.
+
+- `Zephyr project bug tracker GHSA-wrf2-79mm-cvw5
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-wrf2-79mm-cvw5>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107929 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107929>`_
+
+- `PR 113331 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/113331>`_
+
+- `PR 110884 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110884>`_
+
+- `PR 110883 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110883>`_
 
 :cve:`2026-8023`
 ----------------
@@ -2229,7 +2494,43 @@ This has been fixed in main for v4.5.0
 :cve:`2026-10673`
 -----------------
 
-Under embargo until 2026-07-15
+Out-of-bounds write in ADIN2111/ADIN1110 OA SPI Ethernet RX frame reassembly
+
+The Zephyr ADIN2111/ADIN1110 10BASE-T1S/T1L Ethernet driver
+(``drivers/ethernet/eth_adin2111.c``) reassembles received Ethernet frames in OPEN
+Alliance (OA) SPI mode by copying device-supplied 64-byte data chunks into a fixed
+static buffer ``ctx->buf`` of size ``CONFIG_ETH_ADIN2111_BUFFER_SIZE`` (default 1524
+bytes). In ``eth_adin2111_oa_data_read()``, each valid chunk was ``memcpy``'d into
+``ctx->buf[ctx->scur]`` and the write cursor ``scur`` advanced, with no check that
+``scur`` + len stayed within the buffer. The number of chunks (up to 255, from the
+BUFSTS RCA field) and the per-chunk length are taken entirely from the frame data
+received off the wire; the cursor is only reset on a start-of-frame chunk. An attacker
+on the single-pair Ethernet segment can therefore send a frame whose reassembled size
+exceeds the configured buffer, causing the driver's RX offload thread to write
+attacker-controlled frame bytes past the end of the static buffer into adjacent
+driver/kernel memory (up to roughly 14.8 KB in the worst case). This is a
+remotely/adjacently reachable out-of-bounds write (CWE-787) that can corrupt memory and
+cause denial of service or potentially code execution. The defect was introduced when OA
+SPI support was added (commit 0ca8b0756b1) and shipped in releases v3.7.0 through
+v4.4.0. The fix adds a bounds check that drops the oversized frame and resets the cursor
+before the copy.
+
+- `Zephyr project bug tracker GHSA-hm6v-4jh4-3qc4
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-hm6v-4jh4-3qc4>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108200 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108200>`_
+
+- `PR 108900 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108900>`_
+
+- `PR 108901 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108901>`_
+
+- `PR 108899 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108899>`_
 
 :cve:`2026-12629`
 -----------------
@@ -2401,3 +2702,235 @@ Under embargo until 2026-09-07
 -----------------
 
 Under embargo until 2026-09-08
+
+:cve:`2026-6682`
+----------------
+
+Integer overflow in FatFs FAT32 volume mount (mount_volume) yields an attacker-controlled file size and out-of-bounds access in Zephyr
+
+Zephyr bundles ChaN's FatFs (via the ``zephyrproject-rtos/fatfs`` west module) as the
+FAT/exFAT filesystem backing ``subsys/fs/fat_fs.c``. In ``mount_volume()``
+(modules/fs/fatfs/ff.c), the FAT area size is computed as ``fasize = ld_32(BPB_FATSz32);
+... fasize *= fs->n_fats;`` — a 32-bit multiply with no overflow check.
+
+A crafted FAT32 volume that sets ``BPB_FATSz32 = 0x80000001`` with two FATs makes the
+product wrap (to ``0x00000002``), so the computed data region overlaps the FAT region.
+Because the pre-multiply value is kept in ``fs->fsize``, the later plausibility check
+does not catch the wrap.
+
+An attacker who can get the device to mount such a volume (a malicious SD card or USB
+medium) can place forged directory entries in the overlapped region, causing
+``f_stat()``/directory reads to return attacker-controlled file sizes; application code
+that reads a file using that size as a length then overflows its buffers, giving
+heap- or stack-based memory corruption during ordinary file operations.
+
+This is a core FAT32 code path with no compile-time gate (FAT12/16/32 is always built),
+so a default Zephyr FatFs configuration is affected. Upstream FatFs is unmaintained for
+security purposes (the maintainer did not respond to runZero or JPCERT/CC), so Zephyr
+carries the fix in its vendored copy. Tracked upstream as CVE-2026-6682.
+
+- `Zephyr project bug tracker GHSA-m537-wqw2-2wrj
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-m537-wqw2-2wrj>`_
+
+This has been fixed in main for v4.5.0
+
+:cve:`2026-6683`
+----------------
+
+Divide-by-zero in FatFs exFAT sync (sync_fs) crashes Zephyr on a crafted exFAT volume
+
+Zephyr's bundled FatFs (``zephyrproject-rtos/fatfs``) supports exFAT when
+``CONFIG_FS_FATFS_EXFAT`` is enabled. In ``sync_fs()`` (modules/fs/fatfs/ff.c) the
+free-cluster bookkeeping divides by ``(fs->n_fatent - 2)``.
+
+The cluster count is read from the exFAT boot region as ``ncl = ld_32(BPB_NumClusEx)``
+and is validated only against an upper bound (``> MAX_EXFAT``), never a lower bound, so
+a crafted exFAT volume with ``BPB_NumClusEx = 0`` yields ``n_fatent = 2`` and a divisor
+of zero.
+
+Mounting such a volume and performing any write/sync triggers a divide-by-zero (SIGFPE /
+CPU fault), a denial of service.
+
+The defect is present only when exFAT is compiled in, which is not the default Zephyr
+configuration; devices that enable exFAT and mount untrusted removable media are
+exposed. Upstream FatFs is unmaintained for security, so Zephyr carries the fix in its
+vendored copy. Tracked upstream as CVE-2026-6683.
+
+- `Zephyr project bug tracker GHSA-c5j5-mrhx-hjg4
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-c5j5-mrhx-hjg4>`_
+
+This has been fixed in main for v4.5.0
+
+:cve:`2026-6685`
+----------------
+
+Integer underflow in FatFs dirty-sector cache (f_read/f_write) causes wrong-sector I/O on crafted fragmented media in Zephyr
+
+In FatFs's read/write path (``f_read``/``f_write`` in modules/fs/fatfs/ff.c), the
+dirty-sector cache-refill decision compares ``fp->sect - sect`` against the run length
+``cc`` using unsigned arithmetic. On a fragmented FAT layout where a later cluster maps
+to a lower absolute sector than the currently cached one, the subtraction underflows
+(wraps to a large unsigned value), so the guard that decides whether the cached window
+overlaps the requested range is evaluated incorrectly.
+
+The result is that FatFs flushes or reuses the wrong cached sector, reading or writing
+file data to/from an incorrect on-disk location — cross-file data corruption and
+potential disclosure of unrelated file contents, and a path to out-of-bounds behaviour
+during ordinary file operations.
+
+A crafted volume with a deliberately fragmented cluster chain (attacker-controlled
+removable media) triggers the condition. This is on the default read/write path (no
+exFAT or LFN gating). Upstream FatFs is unmaintained for security, so Zephyr carries the
+fix in its vendored copy. Tracked upstream as CVE-2026-6685.
+
+- `Zephyr project bug tracker GHSA-rg3p-32gq-hqw3
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-rg3p-32gq-hqw3>`_
+
+This has been fixed in main for v4.5.0
+
+:cve:`2026-6686`
+----------------
+
+FatFs f_lseek past end-of-file exposes uninitialized/stale cluster contents (deleted file data) in Zephyr
+
+In FatFs (``f_lseek`` in modules/fs/fatfs/ff.c), seeking a file opened for write to an
+offset beyond its current end extends the cluster chain via ``create_chain()`` but does
+not zero the newly allocated clusters.
+
+FatFs marks the file as larger without initializing the backing sectors, so a subsequent
+read of the grown region returns whatever was previously on the medium in those clusters
+— typically the residual contents of deleted files. On a device where a lower-privileged
+or later actor can read a file that was extended this way, previously deleted or
+unrelated file data is disclosed (CWE-908, use of uninitialized resource). No
+memory-safety corruption occurs; the impact is confidentiality of on-media data.
+
+The bug is on the default write path (no exFAT/LFN gating). Upstream FatFs is
+unmaintained for security, so Zephyr carries the fix in its vendored copy. Tracked
+upstream as CVE-2026-6686.
+
+- `Zephyr project bug tracker GHSA-rjhg-f2h7-rffm
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-rjhg-f2h7-rffm>`_
+
+This has been fixed in main for v4.5.0
+
+:cve:`2026-6687`
+----------------
+
+Stack buffer overflow in FatFs exFAT volume-label read (f_getlabel) via an unvalidated on-disk length in Zephyr
+
+In FatFs's ``f_getlabel()`` (modules/fs/fatfs/ff.c), the exFAT volume-label copy loop is
+bounded by the raw on-disk byte ``dj.dir[XDIR_NumLabel]`` (0–255) rather than the spec
+maximum of 11 characters.
+
+A crafted exFAT volume that sets ``XDIR_NumLabel`` to a large value (e.g. 128) makes the
+loop read label characters past the 32-byte directory entry and write up to that many
+UTF-decoded characters into the caller-supplied ``label[]`` buffer, overflowing a
+typical fixed-size label array (e.g. ``char label[12]``/``label[24]``) on the stack —
+memory corruption with potential control-flow impact.
+
+In Zephyr this is reachable only in downstream applications: ``f_getlabel`` is compiled
+solely with ``CONFIG_FS_FATFS_EXTRA_NATIVE_API=y``, exFAT must be enabled, and no
+in-tree Zephyr code calls it (application code supplies the buffer). It is nonetheless a
+genuine defect in the vendored library, and because upstream FatFs is unmaintained for
+security Zephyr carries the fix (clamp the label length) in its vendored copy so
+opted-in applications are protected. Tracked upstream as CVE-2026-6687.
+
+- `Zephyr project bug tracker GHSA-fxw6-w668-cgfh
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-fxw6-w668-cgfh>`_
+
+This has been fixed in main for v4.5.0
+
+:cve:`2026-15890`
+-----------------
+
+Under embargo until 2026-09-11
+
+:cve:`2026-15891`
+-----------------
+
+Under embargo until 2026-09-11
+
+:cve:`2026-15892`
+-----------------
+
+Under embargo until 2026-09-12
+
+:cve:`2026-15893`
+-----------------
+
+Under embargo until 2026-09-13
+
+:cve:`2026-15894`
+-----------------
+
+Under embargo until 2026-09-13
+
+:cve:`2026-15923`
+-----------------
+
+Under embargo until 2026-09-13
+
+:cve:`2026-15924`
+-----------------
+
+Under embargo until 2026-09-13
+
+:cve:`2026-16147`
+-----------------
+
+Under embargo until 2026-09-14
+
+:cve:`2026-16148`
+-----------------
+
+Under embargo until 2026-09-14
+
+:cve:`2026-16511`
+-----------------
+
+Under embargo until 2026-09-18
+
+:cve:`2026-16512`
+-----------------
+
+Under embargo until 2026-09-18
+
+:cve:`2026-16513`
+-----------------
+
+Under embargo until 2026-09-18
+
+:cve:`2026-16514`
+-----------------
+
+Under embargo until 2026-09-18
+
+:cve:`2026-16515`
+-----------------
+
+Under embargo until 2026-09-18
+
+:cve:`2026-17050`
+-----------------
+
+Under embargo until 2026-09-19
+
+:cve:`2026-17051`
+-----------------
+
+Under embargo until 2026-09-20
+
+:cve:`2026-17052`
+-----------------
+
+Under embargo until 2026-09-20
+
+:cve:`2026-17053`
+-----------------
+
+Under embargo until 2026-09-20
+
+:cve:`2026-17054`
+-----------------
+
+Under embargo until 2026-09-21

--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -898,25 +898,26 @@ This has been fixed in main for v4.5.0
 
 Out-of-bounds read in Zephyr ext2 directory entry traversal from a crafted filesystem image
 
-The Zephyr ext2 filesystem driver (subsys/fs/ext2) trusted the on-disk directory entry
-fields de_rec_len and de_name_len when walking a directory block. ext2_fetch_direntry()
-guarded only with ``de_name_len > EXT2_MAX_FILE_NAME``, but de_name_len is a uint8_t and
-EXT2_MAX_FILE_NAME is 255, so the check is always false; the function then memcpy'd up
-to 255 name bytes and the lookup/readdir paths advanced traversal by an unvalidated
-de_rec_len. Each directory block is read into a block_size-sized slab buffer, and
-block_off can be driven near the block end by preceding entries' rec_len, so the 8-byte
-header read and the subsequent name memcpy can read up to ~263 bytes past the end of the
-block buffer into adjacent heap/slab memory. On the readdir path those bytes are
-returned to the caller in fs_dirent.name, leaking adjacent kernel heap memory; a
-de_rec_len of 0 also causes a zero-progress infinite loop (denial of service), and the
-unlink path's memmove(de, next, next_reclen) over unvalidated records is an additional
-OOB read/write source. The defect is reached by any path-based operation (open, stat,
+The Zephyr ext2 filesystem driver (``subsys/fs/ext2``) trusted the on-disk directory
+entry fields ``de_rec_len`` and ``de_name_len`` when walking a directory block.
+``ext2_fetch_direntry()`` guarded only with ``de_name_len > EXT2_MAX_FILE_NAME``, but
+``de_name_len`` is a ``uint8_t`` and ``EXT2_MAX_FILE_NAME`` is 255, so the check is
+always false; the function then ``memcpy``'d up to 255 name bytes and the lookup/readdir
+paths advanced traversal by an unvalidated ``de_rec_len``. Each directory block is read
+into a ``block_size``-sized slab buffer, and ``block_off`` can be driven near the block
+end by preceding entries' ``rec_len``, so the 8-byte header read and the subsequent name
+``memcpy`` can read up to ~263 bytes past the end of the block buffer into adjacent
+heap/slab memory. On the readdir path those bytes are returned to the caller in
+``fs_dirent.name``, leaking adjacent kernel heap memory; a ``de_rec_len`` of 0 also
+causes a zero-progress infinite loop (denial of service), and the unlink path's
+``memmove(de, next, next_reclen)`` over unvalidated records is an additional OOB
+read/write source. The defect is reached by any path-based operation (open, stat,
 unlink, rename, mkdir) or directory listing on a mounted ext2 volume, so a crafted or
 corrupted ext2 image on attacker-supplied storage (SD card, USB mass storage, or
 otherwise mounted image) triggers it. Affected: Zephyr ext2 from its introduction in
-v3.5.0 through v4.4.0. The fix validates rec_len and name_len in the parser and rejects
-entries whose header does not fit the remaining block or whose rec_len crosses the block
-boundary in every traversal caller.
+v3.5.0 through v4.4.0. The fix validates ``rec_len`` and ``name_len`` in the parser and
+rejects entries whose header does not fit the remaining block or whose ``rec_len``
+crosses the block boundary in every traversal caller.
 
 - `Zephyr project bug tracker GHSA-hwrh-9h3x-vccm
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-hwrh-9h3x-vccm>`_
@@ -1332,26 +1333,27 @@ This has been fixed in main for v4.5.0
 
 Out-of-bounds read in Zephyr DNS resolver mDNS suffix check (memcmp past string NUL)
 
-Zephyr's DNS resolver detects mDNS (.local) queries in dns_resolve_name_internal()
-(subsys/net/lib/dns/resolve.c) with ``memcmp(strrchr(query, '.'), ".local", 7)``, which
-always reads a fixed 7 bytes from the suffix pointer. When the resolved hostname's final
-label is shorter than 7 bytes (e.g. names ending in .org, .com, .net, .io, or a trailing
-dot), the comparison reads 1-2 bytes past the string's NUL terminator.
+Zephyr's DNS resolver detects mDNS (.local) queries in ``dns_resolve_name_internal()``
+(``subsys/net/lib/dns/resolve.c``) with ``memcmp(strrchr(query, '.'), ".local", 7)``,
+which always reads a fixed 7 bytes from the suffix pointer. When the resolved hostname's
+final label is shorter than 7 bytes (e.g. names ending in .org, .com, .net, .io, or a
+trailing dot), the comparison reads 1-2 bytes past the string's NUL terminator.
 
 The hostname (``query``) is the caller-supplied name passed through the standard
-getaddrinfo()/dns_get_addr_info()/dns_resolve_name() path and is influenceable by
-operators or remote inputs (server names from configuration, parsed URLs, or app-facing
-interfaces).
+``getaddrinfo()``/``dns_get_addr_info()``/``dns_resolve_name()`` path and is
+influenceable by operators or remote inputs (server names from configuration, parsed
+URLs, or app-facing interfaces).
 
-On a tightly-sized buffer with no slack (for example a userspace getaddrinfo call where
-the hostname is copied with k_usermode_string_alloc_copy to exactly strlen+1 bytes), the
-over-read crosses the allocation boundary; if that boundary is unmapped (guard page,
-memory-domain boundary under MPU, or an address sanitizer) the over-read faults, causing
-a denial of service. The over-read bytes are never returned, so there is no information
-disclosure.
+On a tightly-sized buffer with no slack (for example a userspace ``getaddrinfo`` call
+where the hostname is copied with ``k_usermode_string_alloc_copy`` to exactly
+``strlen+1`` bytes), the over-read crosses the allocation boundary; if that boundary is
+unmapped (guard page, memory-domain boundary under MPU, or an address sanitizer) the
+over-read faults, causing a denial of service. The over-read bytes are never returned,
+so there is no information disclosure.
 
-The flaw is compiled only when CONFIG_MDNS_RESOLVER is enabled, exists since v1.10.0,
-and is fixed by replacing the fixed-length memcmp with a NUL-safe strcmp(ptr, ".local").
+The flaw is compiled only when ``CONFIG_MDNS_RESOLVER`` is enabled, exists since
+v1.10.0, and is fixed by replacing the fixed-length ``memcmp`` with a NUL-safe
+``strcmp(ptr, ".local")``.
 
 - `Zephyr project bug tracker GHSA-76jh-3j5f-9vq4
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-76jh-3j5f-9vq4>`_
@@ -2047,24 +2049,25 @@ This has been fixed in main for v4.5.0
 
 Divide-by-zero in DesignWare SPI driver reachable from spi_transceive syscall (local DoS)
 
-The DesignWare SPI driver (drivers/spi/spi_dw.c) computed the SPI BAUDR clock divider as
-``info->clock_frequency / config->frequency`` without validating ``config->frequency``.
+The DesignWare SPI driver (``drivers/spi/spi_dw.c``) computed the SPI BAUDR clock
+divider as ``info->clock_frequency / config->frequency`` without validating
+``config->frequency``.
 
-``spi_transceive`` is a Zephyr __syscall and its verify handler
-(drivers/spi/spi_handlers.c) copies the caller-supplied ``spi_config`` from userspace
-without checking the frequency field, so a userspace thread that has been granted access
-to a DesignWare SPI device kernel object can pass ``frequency = 0`` and trigger an
-unsigned integer divide-by-zero in ``spi_dw_configure()``.
+``spi_transceive`` is a Zephyr ``__syscall`` and its verify handler
+(``drivers/spi/spi_handlers.c``) copies the caller-supplied ``spi_config`` from
+userspace without checking the frequency field, so a userspace thread that has been
+granted access to a DesignWare SPI device kernel object can pass ``frequency = 0`` and
+trigger an unsigned integer divide-by-zero in ``spi_dw_configure()``.
 
 On Cortex-M Mainline (``SCB->CCR.DIV_0_TRP`` is set in ``z_arm_fault_init()``) and on
 ARC (a dedicated ``__ev_div_zero`` vector) this raises a CPU exception, resulting in a
 kernel fault and local denial of service.
 
 The fix rejects zero frequency and frequencies above ``clock_frequency / 2`` (the
-DesignWare SSI databook minimum SCKDIV of 2) with -EINVAL. The defect affects all Zephyr
-releases up to and including v4.4.0; exploitation requires ``CONFIG_USERSPACE=y`` and an
-unprivileged thread already granted SPI driver permission. There is no memory-corruption
-or information-disclosure impact.
+DesignWare SSI databook minimum SCKDIV of 2) with ``-EINVAL``. The defect affects all
+Zephyr releases up to and including v4.4.0; exploitation requires ``CONFIG_USERSPACE=y``
+and an unprivileged thread already granted SPI driver permission. There is no
+memory-corruption or information-disclosure impact.
 
 - `Zephyr project bug tracker GHSA-3qcm-qwh2-v4hq
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3qcm-qwh2-v4hq>`_
@@ -2273,7 +2276,7 @@ Under embargo until 2026-08-13
 Division by zero in Zephyr ext2 superblock parsing allows DoS via crafted filesystem image
 
 The Zephyr ext2 file system validates the on-disk superblock in
-``ext2_verify_disk_superblock()`` (subsys/fs/ext2/ext2_impl.c) before completing a
+``ext2_verify_disk_superblock()`` (``subsys/fs/ext2/ext2_impl.c``) before completing a
 mount. The validator checked the magic number, block size, revision and feature flags,
 but did not verify that the on-disk fields ``s_blocks_per_group`` and
 ``s_inodes_per_group`` are non-zero. Both fields are read directly from the image and
@@ -2283,7 +2286,7 @@ During mount, ``get_ngroups()`` divides and modulos ``s_blocks_count`` by
 ``s_blocks_per_group`` (reached via ``ext2_fetch_block_group()`` from
 ``ext2_init_fs()``), and ``get_itable_entry()`` divides ``(ino - 1)`` by
 ``s_inodes_per_group`` when fetching the root inode (both in
-subsys/fs/ext2/ext2_diskops.c). A superblock with either field set to zero therefore
+``subsys/fs/ext2/ext2_diskops.c``). A superblock with either field set to zero therefore
 causes an integer division by zero during the mount sequence.
 
 An attacker who can present a crafted ext2 image to a device that mounts ext2 —
@@ -2324,21 +2327,21 @@ type (``HTTP_RESOURCE_TYPE_STATIC_FS``, available when ``CONFIG_FILE_SYSTEM`` is
 enabled) that serves files from a configured root directory. Before this fix, both the
 HTTP/1 and HTTP/2 front-ends placed the raw, attacker-controlled request path into
 ``client->url_buffer`` (assembled in ``on_url()`` for HTTP/1 and copied verbatim from
-the :path pseudo-header for HTTP/2) without resolving ``.``/``..`` segments. The
+the ``:path`` pseudo-header for HTTP/2) without resolving ``.``/``..`` segments. The
 static-FS handler then built the on-disk filename by directly concatenating the
 configured root with that raw URL (``snprintk(fname, ..., "%s%s",
 static_fs_detail->fs_path, client->url_buffer)`` at ``http_server_http1.c:603`` and
 ``http_server_http2.c:490``) and opened it with ``fs_open(fname, FS_O_READ)``. Because
 the handler is reached via wildcard/leading-dir (``fnmatch`` ``FNM_LEADING_DIR``) or
-fallback resource matching, a request such as GET /<prefix>/../../<file> is dispatched
-to the handler and, after the underlying filesystem (e.g. LittleFS/FAT) resolves the
-``..`` segments, escapes the configured web root, letting an unauthenticated remote
-client read arbitrary readable files on the mounted volume (information disclosure). The
-HTTP server requires no TLS or authentication to reach this path. The fix adds
-``http_server_remove_dot_segments()``, which canonicalizes the path portion of the URL
-before resource lookup in both protocol handlers, neutralizing the traversal. Affects
-releases v4.0.0 through v4.4.0 for deployments that register a static-filesystem
-resource.
+fallback resource matching, a request such as ``GET /<prefix>/../../<file>`` is
+dispatched to the handler and, after the underlying filesystem (e.g. LittleFS/FAT)
+resolves the ``..`` segments, escapes the configured web root, letting an
+unauthenticated remote client read arbitrary readable files on the mounted volume
+(information disclosure). The HTTP server requires no TLS or authentication to reach
+this path. The fix adds ``http_server_remove_dot_segments()``, which canonicalizes the
+path portion of the URL before resource lookup in both protocol handlers, neutralizing
+the traversal. Affects releases v4.0.0 through v4.4.0 for deployments that register a
+static-filesystem resource.
 
 - `Zephyr project bug tracker GHSA-hch3-53g6-jj3h
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-hch3-53g6-jj3h>`_
@@ -2412,24 +2415,24 @@ Broken IPv6 Neighbor Discovery input validation allows spoofed RA/NS/NA acceptan
 The IPv6 Neighbor Discovery handlers in ``subsys/net/ip/ipv6_nbr.c``
 (``handle_ra_input``, ``handle_ns_input``, ``handle_na_input``) used an incorrect
 boolean expression that combined the RFC 4861 validity checks with the ICMPv6 code check
-using the wrong operator precedence: the form was '((length/hop/source/target checks) &&
-(icmp_hdr->code != 0))'. Because every legitimate ND message carries ICMPv6 code 0, an
-attacker setting code == 0 (the normal value) caused the entire predicate to evaluate
-false, so the packet was never dropped and all of the other checks were silently
-skipped. The bypassed checks include the mandatory Hop Limit == 255 verification (which
-proves an ND packet originated on-link and was not forwarded) and, for Router
-Advertisements, the requirement that the source be a link-local address, as well as
-multicast-target sanity checks. As a result, an adjacent on-link attacker — and, because
-the Hop-Limit-255 guard is bypassed, potentially a remote/off-link attacker whose
-packets would otherwise be rejected — can have forged Router Advertisement, Neighbor
-Solicitation, and Neighbor Advertisement messages accepted. A forged RA lets the
-attacker reconfigure the victim's default router, on-link prefixes (SLAAC), MTU,
+using the wrong operator precedence: the form was ``((length/hop/source/target checks)
+&& (icmp_hdr->code != 0))``. Because every legitimate ND message carries ICMPv6 code 0,
+an attacker setting ``code == 0`` (the normal value) caused the entire predicate to
+evaluate false, so the packet was never dropped and all of the other checks were
+silently skipped. The bypassed checks include the mandatory Hop Limit == 255
+verification (which proves an ND packet originated on-link and was not forwarded) and,
+for Router Advertisements, the requirement that the source be a link-local address, as
+well as multicast-target sanity checks. As a result, an adjacent on-link attacker — and,
+because the Hop-Limit-255 guard is bypassed, potentially a remote/off-link attacker
+whose packets would otherwise be rejected — can have forged Router Advertisement,
+Neighbor Solicitation, and Neighbor Advertisement messages accepted. A forged RA lets
+the attacker reconfigure the victim's default router, on-link prefixes (SLAAC), MTU,
 reachable/retransmit timers, and (with ``CONFIG_NET_IPV6_RA_RDNSS``) DNS servers, while
 forged NS/NA enable neighbor-cache poisoning, enabling man-in-the-middle, traffic
 redirection, and denial of service. The flaw is an input-validation/authentication
 weakness rather than a memory-safety issue: the underlying packet-parsing primitives
 (``net_pkt_get_data``, ``net_pkt_read``, ``net_pkt_skip``) are independently bounds-safe
-and the validated 'length' is the true buffer length, so skipping the length check
+and the validated ``length`` is the true buffer length, so skipping the length check
 causes no out-of-bounds access. The defect has existed since the logic was introduced in
 2018 and shipped in all releases through v4.4.0; it is fixed by splitting the condition
 so any failing check drops the packet.
@@ -2710,8 +2713,9 @@ Integer overflow in FatFs FAT32 volume mount (mount_volume) yields an attacker-c
 
 Zephyr bundles ChaN's FatFs (via the ``zephyrproject-rtos/fatfs`` west module) as the
 FAT/exFAT filesystem backing ``subsys/fs/fat_fs.c``. In ``mount_volume()``
-(modules/fs/fatfs/ff.c), the FAT area size is computed as ``fasize = ld_32(BPB_FATSz32);
-... fasize *= fs->n_fats;`` — a 32-bit multiply with no overflow check.
+(``modules/fs/fatfs/ff.c``), the FAT area size is computed as ``fasize =
+ld_32(BPB_FATSz32); ... fasize *= fs->n_fats;`` — a 32-bit multiply with no overflow
+check.
 
 A crafted FAT32 volume that sets ``BPB_FATSz32 = 0x80000001`` with two FATs makes the
 product wrap (to ``0x00000002``), so the computed data region overlaps the FAT region.
@@ -2740,7 +2744,7 @@ This has been fixed in main for v4.5.0
 Divide-by-zero in FatFs exFAT sync (sync_fs) crashes Zephyr on a crafted exFAT volume
 
 Zephyr's bundled FatFs (``zephyrproject-rtos/fatfs``) supports exFAT when
-``CONFIG_FS_FATFS_EXFAT`` is enabled. In ``sync_fs()`` (modules/fs/fatfs/ff.c) the
+``CONFIG_FS_FATFS_EXFAT`` is enabled. In ``sync_fs()`` (``modules/fs/fatfs/ff.c``) the
 free-cluster bookkeeping divides by ``(fs->n_fatent - 2)``.
 
 The cluster count is read from the exFAT boot region as ``ncl = ld_32(BPB_NumClusEx)``
@@ -2766,7 +2770,7 @@ This has been fixed in main for v4.5.0
 
 Integer underflow in FatFs dirty-sector cache (f_read/f_write) causes wrong-sector I/O on crafted fragmented media in Zephyr
 
-In FatFs's read/write path (``f_read``/``f_write`` in modules/fs/fatfs/ff.c), the
+In FatFs's read/write path (``f_read``/``f_write`` in ``modules/fs/fatfs/ff.c``), the
 dirty-sector cache-refill decision compares ``fp->sect - sect`` against the run length
 ``cc`` using unsigned arithmetic. On a fragmented FAT layout where a later cluster maps
 to a lower absolute sector than the currently cached one, the subtraction underflows
@@ -2793,9 +2797,9 @@ This has been fixed in main for v4.5.0
 
 FatFs f_lseek past end-of-file exposes uninitialized/stale cluster contents (deleted file data) in Zephyr
 
-In FatFs (``f_lseek`` in modules/fs/fatfs/ff.c), seeking a file opened for write to an
-offset beyond its current end extends the cluster chain via ``create_chain()`` but does
-not zero the newly allocated clusters.
+In FatFs (``f_lseek`` in ``modules/fs/fatfs/ff.c``), seeking a file opened for write to
+an offset beyond its current end extends the cluster chain via ``create_chain()`` but
+does not zero the newly allocated clusters.
 
 FatFs marks the file as larger without initializing the backing sectors, so a subsequent
 read of the grown region returns whatever was previously on the medium in those clusters
@@ -2818,9 +2822,9 @@ This has been fixed in main for v4.5.0
 
 Stack buffer overflow in FatFs exFAT volume-label read (f_getlabel) via an unvalidated on-disk length in Zephyr
 
-In FatFs's ``f_getlabel()`` (modules/fs/fatfs/ff.c), the exFAT volume-label copy loop is
-bounded by the raw on-disk byte ``dj.dir[XDIR_NumLabel]`` (0–255) rather than the spec
-maximum of 11 characters.
+In FatFs's ``f_getlabel()`` (``modules/fs/fatfs/ff.c``), the exFAT volume-label copy
+loop is bounded by the raw on-disk byte ``dj.dir[XDIR_NumLabel]`` (0–255) rather than
+the spec maximum of 11 characters.
 
 A crafted exFAT volume that sets ``XDIR_NumLabel`` to a large value (e.g. 128) makes the
 loop read label characters past the 32-byte directory entry and write up to that many

--- a/doc/security/vulnerabilities.rst
+++ b/doc/security/vulnerabilities.rst
@@ -338,12 +338,84 @@ Under embargo until 2026-08-08
 :cve:`2026-9263`
 ----------------
 
-Under embargo until 2026-06-28
+Out-of-bounds read in Bluetooth Controller ISOAL framed RX reassembly leaks adjacent memory into host HCI ISO packets
+
+The Zephyr Bluetooth controller ISO Adaptation Layer
+(``subsys/bluetooth/controller/ll_sw/isoal.c``) fails to validate the length field of a
+framed ISO PDU start segment. Per the Bluetooth specification a start segment (``sc=0``)
+always carries a 3-byte ``time_offset``, so its segment-header ``len`` must be at least
+``PDU_ISO_SEG_TIMEOFFSET_SIZE`` (3). ``isoal_check_seg_header()`` accepted start
+segments with ``len`` < 3 as valid, and ``isoal_rx_framed_consume()`` then computed
+``length = seg_hdr->len - 3`` in a ``uint8_t``, underflowing to 253-255 when ``len`` is
+0-2. That oversized length is passed to ``isoal_rx_append_to_sdu()``, whose copy is
+clamped only against the destination SDU buffer size, not the source PDU length, so up
+to ~255 bytes of controller memory beyond the received PDU are copied (via
+``sink_sdu_write_hci()``/``net_buf_add_mem``) into an HCI ISO data packet and delivered
+to the host. The PDU and its segment headers are entirely attacker-controlled and arrive
+over the air, reachable through both the CIS and BIS-sync HCI data paths
+(``hci_driver.c``) and the vendor data path (``ull_iso.c``), so a remote CIS peer or a
+broadcaster the device is synced to can trigger an out-of-bounds read causing
+information disclosure to the host and potential denial of service (faults or malformed
+oversized HCI ISO packets). The flaw affects all Zephyr releases since framed ISO
+reception was introduced in v3.0.0. The fix rejects ``sc=0`` segments with ``len`` < 3
+in ``isoal_check_seg_header()`` and adds a guard before the subtraction in
+``isoal_rx_framed_consume()``.
+
+- `Zephyr project bug tracker GHSA-6gvp-pmh8-fjh2
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-6gvp-pmh8-fjh2>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 109369 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109369>`_
+
+- `PR 109617 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109617>`_
+
+- `PR 109619 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109619>`_
+
+- `PR 109618 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109618>`_
 
 :cve:`2026-10593`
 -----------------
 
-Under embargo until 2026-06-23
+Remotely triggerable NULL-pointer dereference in Bluetooth LE Audio BAP unicast client QoS-state handling
+
+The Zephyr Bluetooth LE Audio Basic Audio Profile (BAP) unicast client mishandles
+peer-supplied ASE state notifications. In ``unicast_client_ep_qos_state()``
+(``subsys/bluetooth/audio/bap_unicast_client.c``), the handler writes
+attacker-controlled QoS fields (``interval``, ``framing``, ``phy``, ``sdu``, ``rtn``,
+``latency``, ``pd``) through the ``stream->qos`` pointer with only a ``stream != NULL``
+guard. ``stream->qos`` is ``NULL`` for any stream that has been codec-configured via
+``bt_bap_stream_config()`` but not yet added to a unicast group (it is set only by
+``unicast_group_add_stream()``).
+
+A malicious or buggy remote ASCS server, to which the local device is connected as a BAP
+unicast client, can send a GATT notification announcing the ASE has entered the QoS
+Configured state while the local endpoint is still in the Codec Configured state — a
+transition the dispatcher explicitly permits — during that window, causing a write
+through a NULL pointer and a crash (denial of service). The data written is itself
+remote-controlled.
+
+The defect shipped in v4.3.0 and v4.4.0 (and earlier). The fix re-points all BAP QoS
+storage to the always-valid embedded ``ep->qos`` struct, eliminating the NULL
+dereference.
+
+- `Zephyr project bug tracker GHSA-22q8-m94g-2pwh
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-22q8-m94g-2pwh>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 104887 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/104887>`_
+
+- `PR 110779 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110779>`_
+
+- `PR 110777 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110777>`_
 
 :cve:`2026-10634`
 -----------------
@@ -697,132 +769,1105 @@ This has been fixed in main for v4.5.0
 :cve:`2026-10642`
 -----------------
 
-Under embargo until 2026-06-17
+Unbounded TX busy-loop DoS in Zephyr PL011 UART driver under CTS hardware flow control
+
+The Zephyr PL011 UART driver (``drivers/serial/uart_pl011.c``) contains an unbounded
+software loop in ``pl011_irq_tx_enable()`` that repeatedly invokes the interrupt-driven
+application callback while the TX interrupt mask bit (``PL011_IMSC_TXIM``) is set, to
+work around the controller's level-transition TX-interrupt behavior.
+
+When CTS hardware flow control is enabled (devicetree ``hw-flow-control`` or runtime
+``UART_CFG_FLOW_CTRL_RTS_CTS``) and the wired serial peer de-asserts CTS, the controller
+stops draining the TX FIFO; ``pl011_fifo_fill()`` then returns 0 on every call while the
+application still has pending data and therefore never disables the TX interrupt. The
+loop condition never clears, so the thread that called ``uart_irq_tx_enable()`` (e.g.
+``h4_send()`` in the Bluetooth HCI H4 driver) spins indefinitely, hanging the executing
+context and stalling the transport — a denial of service (CWE-835).
+
+An attacker controlling the device attached to the UART's CTS line can trigger the hang
+by withholding CTS during transmission. Because that peer is the device wired to the
+UART — which may be a removable or external module (e.g. an off-board Bluetooth
+controller on the HCI H4 link) rather than a permanently-bonded on-PCB part — the attack
+vector is scored Adjacent (AV:A) rather than Physical; the security subcommittee should
+confirm the vector against the specific deployment. Impact is availability only; there
+is no memory-safety, confidentiality, or integrity consequence.
+
+The vulnerable loop was introduced in commit b783bc8448ef (Feb 2025) and shipped in
+releases v4.1.0 through v4.4.0. The fix breaks out of the loop when CTS is blocking and
+arms the CTS modem-status interrupt to resume transmission when CTS re-asserts.
+
+- `Zephyr project bug tracker GHSA-3fgh-73jh-2q5j
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3fgh-73jh-2q5j>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 103684 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/103684>`_
+
+- `PR 110768 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110768>`_
+
+- `PR 110767 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110767>`_
 
 :cve:`2026-10643`
 -----------------
 
-Under embargo until 2026-06-19
+Out-of-bounds heap write in Zephyr ``recvmsg()`` ancillary-data path (``insert_pktinfo`` undersizes the control-buffer capacity check)
+
+Zephyr's IP socket ``recvmsg()`` implementation
+(``subsys/net/lib/sockets/sockets_inet.c``, ``insert_pktinfo()``) validated the
+user-supplied ancillary (``msg_control``) buffer using only the payload length
+(``msg->msg_controllen`` < ``pktinfo_len``) before writing a full control message
+consisting of an aligned cmsg header plus the payload. Because the check omitted the
+cmsg header size, a control buffer whose length falls in the under-checked window (e.g.
+16-27 bytes for IPv4 ``IP_PKTINFO`` on a 64-bit target, where a single element actually
+occupies 28 bytes) passes the guard yet causes a fixed-size out-of-bounds write of up to
+one cmsg header (~12 bytes) past the end of the buffer.
+
+Under ``CONFIG_USERSPACE`` the ``recvmsg`` verifier allocates a kernel-heap copy of the
+control buffer sized to ``msg_controllen`` and runs the implementation against it, so
+the overflow corrupts kernel heap memory and is triggerable from an unprivileged
+userspace thread; in supervisor mode it corrupts the caller's buffer.
+
+The path is reachable on a UDP/IP socket with ``IP_PKTINFO``/``IPV6_RECVPKTINFO`` (or
+hoplimit/timestamping) enabled when the application calls ``recvmsg()`` with an
+undersized control buffer and a datagram is received; part of the overwritten bytes (the
+destination IP in ``ipi_addr``) is influenced by the received packet.
+
+The fix makes the capacity check use ``NET_CMSG_SPACE(pktinfo_len)`` (aligned header +
+aligned data) and returns ``-ENOMEM`` when the buffer is too small. Affected: v3.6.0
+through v4.4.0.
+
+- `Zephyr project bug tracker GHSA-pvf7-7mrp-35w7
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-pvf7-7mrp-35w7>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 106464 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/106464>`_
+
+- `PR 110668 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110668>`_
+
+- `PR 110669 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110669>`_
+
+- `PR 110670 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110670>`_
 
 :cve:`2026-10644`
 -----------------
 
-Under embargo until 2026-06-20
+Out-of-bounds write in Microchip SERCOM-G1 (PIC32CM-JH) async UART RX with 1-byte buffer
+
+The Microchip SERCOM-G1 UART driver (``drivers/serial/uart_mchp_sercom_g1.c``), used by
+the PIC32CM-JH SoC family, contains an out-of-bounds write in its asynchronous (DMA)
+receive path. When ``uart_rx_enable()`` is invoked with a one-byte receive buffer (``len
+== 1``) and ``CONFIG_UART_MCHP_ASYNC`` is enabled, the RX-complete ISR starts a
+single-beat DMA transfer while a received byte is already pending in the SERCOM DATA
+register. On this SoC the peripheral-triggered DMA start sequencing then writes one byte
+past the end of the caller-supplied buffer (CWE-787).
+
+The overflowed byte's value is the UART RX data supplied by the connected serial peer
+(adjacent attacker), while its size and location are fixed at one byte immediately after
+the buffer.
+
+Exploitation requires the async UART config (not enabled by default on the in-tree
+PIC32CM-JH boards) and a consumer that enables RX with a one-byte buffer; impact is
+limited single-byte memory corruption adjacent to the RX buffer (possible crash / denial
+of service).
+
+The defect shipped in v4.4.0. The fix reads the first byte with the CPU and, for
+one-byte buffers, performs no DMA at all; for larger buffers it sizes the DMA for the
+remaining ``len-1`` bytes.
+
+- `Zephyr project bug tracker GHSA-xv2x-56j7-6wc3
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-xv2x-56j7-6wc3>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107400 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107400>`_
+
+- `PR 110750 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110750>`_
 
 :cve:`2026-10645`
 -----------------
 
-Under embargo until 2026-06-21
+Out-of-bounds read in Zephyr ext2 directory entry traversal from a crafted filesystem image
+
+The Zephyr ext2 filesystem driver (subsys/fs/ext2) trusted the on-disk directory entry
+fields de_rec_len and de_name_len when walking a directory block. ext2_fetch_direntry()
+guarded only with ``de_name_len > EXT2_MAX_FILE_NAME``, but de_name_len is a uint8_t and
+EXT2_MAX_FILE_NAME is 255, so the check is always false; the function then memcpy'd up
+to 255 name bytes and the lookup/readdir paths advanced traversal by an unvalidated
+de_rec_len. Each directory block is read into a block_size-sized slab buffer, and
+block_off can be driven near the block end by preceding entries' rec_len, so the 8-byte
+header read and the subsequent name memcpy can read up to ~263 bytes past the end of the
+block buffer into adjacent heap/slab memory. On the readdir path those bytes are
+returned to the caller in fs_dirent.name, leaking adjacent kernel heap memory; a
+de_rec_len of 0 also causes a zero-progress infinite loop (denial of service), and the
+unlink path's memmove(de, next, next_reclen) over unvalidated records is an additional
+OOB read/write source. The defect is reached by any path-based operation (open, stat,
+unlink, rename, mkdir) or directory listing on a mounted ext2 volume, so a crafted or
+corrupted ext2 image on attacker-supplied storage (SD card, USB mass storage, or
+otherwise mounted image) triggers it. Affected: Zephyr ext2 from its introduction in
+v3.5.0 through v4.4.0. The fix validates rec_len and name_len in the parser and rejects
+entries whose header does not fit the remaining block or whose rec_len crosses the block
+boundary in every traversal caller.
+
+- `Zephyr project bug tracker GHSA-hwrh-9h3x-vccm
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-hwrh-9h3x-vccm>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108226 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108226>`_
+
+- `PR 110031 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110031>`_
+
+- `PR 110033 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110033>`_
+
+- `PR 110030 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110030>`_
 
 :cve:`2026-10646`
 -----------------
 
-Under embargo until 2026-06-22
+Use-after-return in ``zsock_getaddrinfo()`` when a timed-out DNS query is retried without cancellation
+
+Zephyr's BSD-sockets ``getaddrinfo()`` implementation
+(``subsys/net/lib/sockets/getaddrinfo.c``) passes a pointer to a stack-allocated state
+object (``struct getaddrinfo_state ai_state``) as the ``user_data`` of an asynchronous
+DNS resolver query. The socket layer waits on a semaphore with a timeout deliberately
+set slightly longer than the resolver's own per-query timeout. When that semaphore wait
+nonetheless times out (``-EAGAIN``) - which can occur when the resolver's timeout work
+is delayed by workqueue contention, or in the documented multi-retry configuration where
+``CONFIG_NET_SOCKETS_DNS_TIMEOUT`` exceeds ``CONFIG_NET_SOCKETS_DNS_BACKOFF_INTERVAL`` -
+the pre-fix code retries the query (``goto again``) without cancelling the previous one
+and without resetting the semaphore.
+
+The previous query slot remains active in the resolver with its callback and the stack
+pointer as ``user_data``, and ``ai_state->dns_id`` is overwritten so the stale query can
+no longer be cancelled. A subsequent DNS response delivered over UDP and matched by its
+16-bit transaction id (in ``dispatcher_cb()``/``dns_read()``), or the resolver's own
+delayed query-timeout work, then invokes ``dns_resolve_cb()`` against the now
+out-of-scope stack frame, writing through the stale pointer (``state->status``,
+``state->idx``, ``state->ai_arr[]``, and ``k_sem_give()``).
+
+Because the triggering response is network-delivered and its 16-bit id is
+spoofable/replayable by an on- or off-path attacker, this is a network-influenceable
+use-after-return that can corrupt reused stack memory, leading to crashes/denial of
+service or memory corruption.
+
+The fix cancels the timed-out query by name and type before retrying and resets the
+local semaphore, eliminating the stale callback path. Affected: Zephyr v4.0.0 through
+v4.4.0.
+
+- `Zephyr project bug tracker GHSA-h752-vhmf-29w6
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-h752-vhmf-29w6>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107609 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107609>`_
+
+- `PR 110774 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110774>`_
+
+- `PR 110773 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110773>`_
 
 :cve:`2026-10647`
 -----------------
 
-Under embargo until 2026-06-23
+Deadlock denial of service in USB CDC-NCM device class on TX enqueue failure
+
+The USB CDC-NCM device class (``subsys/usb/device_next/class/usbd_cdc_ncm.c``) ignores
+the return value of ``usbd_ep_enqueue()`` in its ethernet transmit callback
+``cdc_ncm_send()``. When the enqueue fails, the function still calls
+``k_sem_take(&data->sync_sem, K_FOREVER)``, blocking on a completion semaphore that is
+only ever signaled from the bulk-IN transfer-completion callback. Because nothing was
+enqueued, that callback never fires and the calling thread — a shared network
+traffic-class TX thread — deadlocks permanently while holding the interface TX lock,
+halting transmission until reboot (and leaking the transmit buffer).
+
+The enqueue fails under conditions controlled by the attached USB host:
+``usbd_ep_enqueue()`` returns ``-EPERM`` whenever the bus is suspended (a standard,
+persistent host operation), and the underlying ``udc_ep_enqueue()`` returns
+``-EPERM``/``-ENODEV`` on disconnect, bus reset, or endpoint disable. The
+``cdc_ncm_send()`` guard only checks the ``DATA_IFACE_ENABLED`` and ``IFACE_UP`` flags,
+not the suspended state, so a packet transmitted while the host holds the bus suspended
+reaches the failing enqueue and deadlocks the TX path.
+
+The realistic trigger is a bus suspend that occurs while the exported network interface
+is active and has traffic to send — host sleep, USB selective/auto-suspend, or hub power
+management — after which any device-originated packet deadlocks the path, recoverable
+only by reboot. The impact is a persistent loss of the virtual network connection
+between the host's NCM interface and the Zephyr device; because the deadlocked thread is
+a shared traffic-class TX thread, egress on other network interfaces can stall as well.
+There is no memory corruption or information disclosure.
+
+The defect was introduced with the CDC-NCM driver and shipped in releases through
+v4.4.0; it is fixed by checking the ``usbd_ep_enqueue()`` return value and freeing the
+buffer before the blocking wait.
+
+- `Zephyr project bug tracker GHSA-xcf7-r86m-5q9f
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-xcf7-r86m-5q9f>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107126 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107126>`_
+
+- `PR 110652 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110652>`_
+
+- `PR 110653 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110653>`_
 
 :cve:`2026-10648`
 -----------------
 
-Under embargo until 2026-06-26
+NULL-pointer dereference in MCUmgr serial/console SMP transport on buffer-pool exhaustion
+
+``mcumgr_serial_process_frag()`` in ``subsys/mgmt/mcumgr/transport/src/serial_util.c``
+calls ``net_buf_reset()`` on the result of ``smp_packet_alloc()`` before checking it for
+``NULL``. ``smp_packet_alloc()`` uses ``net_buf_alloc(K_NO_WAIT)`` against the shared
+MCUmgr packet pool (``CONFIG_MCUMGR_TRANSPORT_NETBUF_COUNT``, default 4), which returns
+``NULL`` when the pool is exhausted. In default builds the ``__ASSERT_NO_MSG`` in
+``net_buf_reset`` is a no-op, so ``net_buf_simple_reset`` writes through the ``NULL``
+pointer (``buf->len = 0; buf->data = buf->__buf``), causing a fault/crash.
+
+The fragment data reaches this code from attacker-controlled bytes on the MCUmgr
+serial/UART/shell-console transports (``smp_uart.c``, ``smp_raw_uart.c``,
+``smp_shell.c``), and a fresh buffer is allocated at the start of essentially every new
+packet. An attacker on the serial/console link can flood the transport to drive the
+4-entry buffer pool to exhaustion and induce the ``NULL`` dereference, crashing the
+device (denial of service).
+
+The defect was introduced after the original MCUmgr rework and shipped in Zephyr v4.4.0.
+The fix moves the ``NULL`` check ahead of ``net_buf_reset``.
+
+- `Zephyr project bug tracker GHSA-j64f-h3ww-f32c
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-j64f-h3ww-f32c>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107812 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107812>`_
+
+- `PR 108026 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108026>`_
 
 :cve:`2026-10651`
 -----------------
 
-Under embargo until 2026-06-26
+Out-of-bounds read in Bluetooth Classic SDP attribute parsing (``bt_sdp_parse_attribute``)
+
+``bt_sdp_parse_attribute()`` in ``subsys/bluetooth/host/classic/sdp.c`` validated only
+that the SDP record buffer held the type-marker byte plus the 2-byte attribute ID (a
+check of ``buf->len < 3``) but then read a fourth byte, the data-element descriptor
+(``type``), via ``net_buf_simple_pull_u8()``. Because ``net_buf_simple_pull_u8()``
+dereferences ``buf->data[0]`` before its only bounds guard (an ``__ASSERT_NO_MSG`` that
+compiles out when ``CONFIG_ASSERT`` is disabled, the production default), a record of
+exactly three bytes (0x09 followed by a 2-byte attribute ID) causes a one-byte read past
+the end of the logical buffer. The parser is reachable from inbound, remote-controlled
+data: a Bluetooth BR/EDR peer acting as an SDP server returns discovery-response records
+that are stored verbatim in the client receive buffer and parsed via the public
+``bt_sdp_get_attr()``/``bt_sdp_has_attr()``/``bt_sdp_record_parse()`` helpers. The
+over-read is bounded to a single byte that is used only as an internal length selector
+and is never leaked to the attacker; subsequent length checks then reject the malformed
+record. Realistic impact is therefore limited to an edge-case denial of service (a fault
+only if the record ends exactly at a mapped-memory boundary, or a deterministic assert
+panic when ``CONFIG_ASSERT=y``). Affects Zephyr v4.3.0 and v4.4.0; fixed by adding
+``sizeof(type)`` to the length check.
+
+- `Zephyr project bug tracker GHSA-p93g-3r68-cj53
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-p93g-3r68-cj53>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107325 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107325>`_
+
+- `PR 110850 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110850>`_
+
+- `PR 110851 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110851>`_
 
 :cve:`2026-10652`
 -----------------
 
-Under embargo until 2026-06-28
+Out-of-bounds read in Zephyr DNS resolver TXT/SRV record parsing (unvalidated ``rdlength``)
+
+Zephyr's DNS resolver (``subsys/net/lib/dns``) parses resource records from DNS
+responses in ``dns_unpack_answer()``, which validated only the fixed RR header (type,
+class, TTL, ``rdlength``) and accepted any attacker-declared ``rdlength``, including one
+extending past the end of the received datagram. The TXT and SRV consumers in
+``dns_validate_record()`` (``resolve.c``) then read up to ``rdlength`` bytes (clamped
+only to a record-type maximum such as ``DNS_MAX_TEXT_SIZE``, default 64, not to the
+packet) from the receive buffer via ``memcpy`` without their own bounds check, and pass
+the result to the application's resolve callback. A malicious or spoofed DNS server, an
+on-path attacker forging UDP DNS replies, or (with mDNS/LLMNR enabled) any LAN node can
+craft a truncated TXT or SRV response that causes an out-of-bounds read of adjacent
+receive-pool memory; the disclosed stale bytes (residual contents of prior DNS packets /
+uninitialized pool memory) are returned to the application as TXT/SRV record contents,
+an information leak, and may in some configurations cross the allocation boundary and
+fault, causing a denial of service. The read is bounded (~64 bytes for TXT, ~6 for SRV)
+and read-only (no write). The fix rejects any record whose declared rdata extends past
+``dns_msg->msg_size`` at the single chokepoint in ``dns_unpack_answer()``. Affected:
+v4.3.0 and v4.4.0.
+
+- `Zephyr project bug tracker GHSA-3jxq-xx8g-q8j2
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3jxq-xx8g-q8j2>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107977 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107977>`_
+
+- `PR 108844 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108844>`_
+
+- `PR 108843 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108843>`_
+
+- `PR 108845 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108845>`_
 
 :cve:`2026-10653`
 -----------------
 
-Under embargo until 2026-06-29
+Non-atomic ``net_buf`` reference counts cause double-free / free-list corruption under concurrent unref
+
+The Zephyr ``net_buf`` library (``lib/net_buf/buf.c``) manipulated both of its reference
+counts -- the per-header ``buf->ref`` and the per-data-block ``ref_count`` at the start
+of each variable/heap data allocation -- with plain non-atomic C operators
+(``buf->ref++``, ``if (--buf->ref > 0)``, ``if (--(*ref_count))``).
+
+The API is documented as self-synchronizing: callers may share one buffer across threads
+(e.g. via ``k_fifo``) and each holder independently calls ``net_buf_unref()`` with no
+surrounding lock. Under true concurrency (SMP, or single-core preemption between the
+non-atomic load and store while another context unrefs the same buffer), two holders can
+both observe the same prior reference value and both conclude they are the last
+reference.
+
+For heap/variable-data pools (``mem_pool_data_unref``/``heap_data_unref``, used by zbus
+message subscribers, the IP stack RX/TX buffers when
+``CONFIG_NET_BUF_FIXED_DATA_SIZE=n``, capture, wireguard, ISO-TP and usbip) this
+produces a double ``k_heap_free()``/``k_free()`` of the same block -- heap-metadata
+corruption and a use-after-free on the heap-hardening poison pattern.
+
+For the per-header refcount the buffer is returned to the pool free LIFO twice for any
+pool type (including fixed-data pools used by Bluetooth and networking), corrupting the
+free list so a later allocation hands the same buffer to two owners.
+
+The fix converts both refcounts to ``atomic_inc``/``atomic_dec`` (overlaying
+``buf->ref`` in an ``atomic_t``-sized union and changing the data-block refcount from
+``uint8_t`` to ``atomic_t``).
+
+Impact is gated on genuine concurrency and on an application architecture that shares
+one buffer among multiple independent unref'ers; the trigger is a refcount/timing race
+rather than packet content, so an external attacker has at most weak indirect influence
+over the race window. Affects all Zephyr releases through v4.4.0.
+
+- `Zephyr project bug tracker GHSA-284j-5jm9-55hh
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-284j-5jm9-55hh>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108065 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108065>`_
+
+- `PR 110853 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110853>`_
+
+- `PR 110852 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110852>`_
 
 :cve:`2026-10654`
 -----------------
 
-Under embargo until 2026-06-29
+RFCOMM session-disconnect race leaks session/L2CAP and denies further RFCOMM service in Zephyr Bluetooth Classic
+
+A race condition in the Zephyr Bluetooth Classic RFCOMM host stack
+(``subsys/bluetooth/host/classic/rfcomm.c``) mishandles a simultaneous bidirectional
+session disconnect. When the local device has initiated a session teardown (state
+``BT_RFCOMM_STATE_DISCONNECTING``, DISC sent, RTX timer armed) and the connected peer
+concurrently sends its own DISC frame for dlci 0, ``rfcomm_handle_disc()`` invokes
+``rfcomm_session_disconnected()``, which unconditionally forced the session to
+``BT_RFCOMM_STATE_DISCONNECTED`` without ever calling ``bt_l2cap_chan_disconnect()``.
+
+Because the recovery timer was also cancelled and a later UA is ignored in the
+DISCONNECTED state, the session becomes permanently wedged: the underlying L2CAP channel
+is never released and the session slot in the fixed
+``bt_rfcomm_pool[CONFIG_BT_MAX_CONN]`` array is never reclaimed (its ``conn`` pointer
+stays set).
+
+Subsequent ``bt_rfcomm_dlc_connect()`` calls on that connection fail with ``-EINVAL``
+due to the invalid session state, so RFCOMM service is denied for that peer, and
+repeated occurrences can exhaust the session pool. The DISC frame is peer-controlled
+over the air, but exploitation requires the peer's DISC to collide with a
+local-initiated disconnect (a high-complexity timing race). Impact is
+availability/resource-leak only; there is no memory-safety, confidentiality, or
+integrity consequence. The defect shipped in released versions (present in v4.4.0 and
+earlier).
+
+The fix only transitions to DISCONNECTED when the session is not already in
+DISCONNECTING, preserving the proper L2CAP teardown path.
+
+- `Zephyr project bug tracker GHSA-4m37-wp5x-hq4h
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-4m37-wp5x-hq4h>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108089 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108089>`_
+
+- `PR 110865 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110865>`_
+
+- `PR 110864 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110864>`_
+
+- `PR 110863 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110863>`_
 
 :cve:`2026-10655`
 -----------------
 
-Under embargo until 2026-06-30
+Use-after-free race in SNTP async client when closing the socket while the socket service is still polling it
+
+The asynchronous SNTP client in Zephyr (``subsys/net/lib/sntp/sntp.c``,
+``sntp_close_async``) closed the UDP socket file descriptor directly from the calling
+thread immediately after detaching it from the network socket service, without
+synchronizing with the socket-service poll thread.
+
+The socket service thread polls each socket via ``zvfs_poll``, which (in
+``zsock_poll_prepare_ctx``) registers a ``k_poll_event`` pointing into the socket's
+``net_context`` (``&ctx->recv_q``) and then blocks in ``k_poll`` without holding a
+reference or lock. ``net_context`` objects are allocated from a fixed pool
+(``contexts[CONFIG_NET_MAX_CONTEXTS]``) and reused after close.
+
+When ``sntp_close_async`` is invoked from a different thread than the poll thread (in
+the in-tree consumer ``subsys/net/lib/config/init_clock_sntp.c``, the SNTP timeout
+handler runs on the system workqueue while the socket service thread is blocked in poll
+on the same fd), the close frees and may reuse the ``net_context`` while the poll thread
+still has a poller node linked into the freed object, resulting in a use-after-free /
+object confusion of kernel poll structures.
+
+The SNTP timeout path is the normal no-response failure mode, so a network peer or
+off-path attacker who drops or delays the SNTP/NTP response can drive the racing close
+repeatedly (and periodically with ``NET_CONFIG_SNTP_INIT_RESYNC``). The most likely
+consequence is a crash of the networking thread (denial of service), with potential
+memory corruption when the freed context slot is reallocated.
+
+The fix defers the close to the socket service thread itself via
+``net_socket_service_close`` (``NET_SOCKET_SERVICE_CLOSE_SOCKETS``), so the same thread
+that polls performs the close, eliminating the race. Affected releases: v4.2.0 through
+v4.4.0.
+
+- `Zephyr project bug tracker GHSA-34wr-cg29-c4mw
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-34wr-cg29-c4mw>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108180 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108180>`_
+
+- `PR 110860 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110860>`_
+
+- `PR 110858 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110858>`_
 
 :cve:`2026-10656`
 -----------------
 
-Under embargo until 2026-07-05
+NULL-pointer dereference DoS in MAX32 USB device controller transfer-completion handlers
+
+The MAX32xxx USB device controller driver (``drivers/usb/udc/udc_max32.c``, compatible
+``adi_max32_usbhs``) dereferenced an endpoint buffer in its OUT and IN
+transfer-completion handlers without checking it for ``NULL``.
+``udc_event_xfer_out_done()`` called ``net_buf_add(buf, ep_request->actlen)``
+immediately after ``buf = udc_buf_get(ep_cfg)``, where ``udc_buf_get()`` returns
+``NULL`` when the endpoint FIFO is empty.
+
+A transfer-completion event is queued from interrupt context and processed
+asynchronously by the driver thread; between queuing and processing, the endpoint FIFO
+can be drained by host-controlled control flow — in particular ``udc_setup_received()``
+drains the EP0 OUT/IN FIFOs whenever a new SETUP packet arrives, and
+dequeue/disable/purge paths drain it likewise.
+
+A USB host that aborts an in-flight EP0 control transfer with a new SETUP packet (legal
+USB behavior) can therefore cause a stale ``XFER_OUT_DONE`` event to be processed
+against an empty FIFO, producing ``net_buf_add(NULL, ...)``, a near-NULL pointer
+dereference that faults and crashes the device. No authentication is required; the
+attacker is the USB host the device is connected to (physical bus access). Impact is
+denial of service (device crash).
+
+The defect was introduced when the MAX32 UDC driver was added and shipped in Zephyr
+v4.4.0. The fix adds NULL-buffer checks that return early with
+``UDC_EVT_ERROR``/-ENOBUFS in both the OUT-done and IN-done handlers.
+
+- `Zephyr project bug tracker GHSA-58p9-6mjq-rf2m
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-58p9-6mjq-rf2m>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108447 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108447>`_
+
+- `PR 109517 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109517>`_
 
 :cve:`2026-10657`
 -----------------
 
-Under embargo until 2026-07-05
+Out-of-bounds read in Zephyr DNS resolver mDNS suffix check (memcmp past string NUL)
+
+Zephyr's DNS resolver detects mDNS (.local) queries in dns_resolve_name_internal()
+(subsys/net/lib/dns/resolve.c) with ``memcmp(strrchr(query, '.'), ".local", 7)``, which
+always reads a fixed 7 bytes from the suffix pointer. When the resolved hostname's final
+label is shorter than 7 bytes (e.g. names ending in .org, .com, .net, .io, or a trailing
+dot), the comparison reads 1-2 bytes past the string's NUL terminator.
+
+The hostname (``query``) is the caller-supplied name passed through the standard
+getaddrinfo()/dns_get_addr_info()/dns_resolve_name() path and is influenceable by
+operators or remote inputs (server names from configuration, parsed URLs, or app-facing
+interfaces).
+
+On a tightly-sized buffer with no slack (for example a userspace getaddrinfo call where
+the hostname is copied with k_usermode_string_alloc_copy to exactly strlen+1 bytes), the
+over-read crosses the allocation boundary; if that boundary is unmapped (guard page,
+memory-domain boundary under MPU, or an address sanitizer) the over-read faults, causing
+a denial of service. The over-read bytes are never returned, so there is no information
+disclosure.
+
+The flaw is compiled only when CONFIG_MDNS_RESOLVER is enabled, exists since v1.10.0,
+and is fixed by replacing the fixed-length memcmp with a NUL-safe strcmp(ptr, ".local").
+
+- `Zephyr project bug tracker GHSA-76jh-3j5f-9vq4
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-76jh-3j5f-9vq4>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108372 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108372>`_
+
+- `PR 110870 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110870>`_
+
+- `PR 110867 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110867>`_
+
+- `PR 110868 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110868>`_
 
 :cve:`2026-10658`
 -----------------
 
-Under embargo until 2026-07-07
+Out-of-bounds access in Bluetooth ISO receive (``bt_iso_recv``) due to missing SDU-header length validation
+
+``bt_iso_recv()`` in ``subsys/bluetooth/host/iso.c`` pulled the ISO SDU header (4 bytes)
+or, when the timestamp flag is set, the timestamped SDU header (8 bytes) from the
+inbound HCI ISO Data buffer via ``net_buf_pull_mem()`` without first checking
+``buf->len``. The upstream ``hci_iso()`` handler enforces ``buf->len`` == the
+controller-declared ISO Data_Load length, so a malicious or buggy controller / adjacent
+BLE peer on an established CIS/BIS can present a first-fragment (``BT_ISO_START``) or
+single (``BT_ISO_SINGLE``) PDU shorter than the SDU header. Because
+``net_buf_simple_pull_mem`` only guards length with ``__ASSERT_NO_MSG`` (compiled out
+when ``CONFIG_ASSERT`` is disabled, the production default), the pull underflows
+``buf->len`` (``uint16_t``, e.g. ``0 - 8 = 0xFFF8``) and advances ``buf->data`` past
+valid data: the subsequent reads of ``hdr->slen`` and ``hdr->sn`` are out-of-bounds
+reads of adjacent pool memory. For the multi-fragment (START) case the corrupted buffer
+is retained as ``iso->rx``, and a following CONT/END fragment's ``net_buf_tailroom()``
+guard underflows to a near-``SIZE_MAX`` value, defeating the bounds check and causing
+``net_buf_add_mem()`` to ``memcpy`` attacker-supplied fragment data far past the RX pool
+buffer (out-of-bounds write). The flaw affects ISO receive builds (``CONFIG_BT_ISO_RX``,
+selected by the default-off LE Audio options
+``BT_ISO_PERIPHERAL``/``BT_ISO_CENTRAL``/``BT_ISO_SYNC_RECEIVER``) and has existed since
+the ISO subsystem was introduced (v2.6.0) through v4.4.0. The fix adds explicit
+``buf->len < sizeof(*ts_hdr)`` and ``buf->len < sizeof(*hdr)`` checks that drop the
+buffer before pulling.
+
+- `Zephyr project bug tracker GHSA-26g8-rmpf-j6cw
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-26g8-rmpf-j6cw>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108603 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108603>`_
+
+- `PR 111024 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111024>`_
+
+- `PR 110959 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110959>`_
+
+- `PR 110958 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110958>`_
 
 :cve:`2026-10659`
 -----------------
 
-Under embargo until 2026-07-07
+NULL pointer dereference in Zephyr Dhara FTL disk driver on flash read error during journal resume
+
+The Dhara flash translation layer disk driver (``drivers/disk/ftl_dhara.c``) implemented
+the ``dhara_nand_*`` callbacks so that, on a flash error, the error code was written
+unconditionally through the caller-supplied ``dhara_error_t *err`` pointer (e.g. ``*err
+= DHARA_E_ECC`` in ``dhara_nand_read``, and similar in
+``dhara_nand_erase``/``prog``/``copy``).
+
+The upstream Dhara library calls these callbacks with ``err == NULL`` along its
+journal-resume binary search: ``find_last_checkblock()`` invokes ``find_checkblock(j,
+mid, &found, NULL)``, which forwards the NULL pointer into ``dhara_nand_read()``. This
+path runs during ``disk_ftl_access_init()`` -> ``dhara_map_resume()`` whenever the FTL
+disk is mounted/initialised.
+
+If a flash read error (uncorrectable ECC, bad block, controller error) occurs on one of
+the probed checkpoint pages, the driver dereferences and writes to ``NULL``, faulting
+the kernel (denial of service). The trigger is conditioned on the NAND medium
+content/health, which can be influenced by media wear, induced faults, or a
+corrupted/crafted on-flash image.
+
+The fix routes all error assignments through the library's NULL-safe
+``dhara_set_error()`` helper. Affects Zephyr v4.4.0, where the driver was introduced.
+
+- `Zephyr project bug tracker GHSA-q28v-3729-f82g
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-q28v-3729-f82g>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108594 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108594>`_
+
+- `PR 110955 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110955>`_
 
 :cve:`2026-10660`
 -----------------
 
-Under embargo until 2026-07-11
+Shared reassembly buffer in Bluetooth BAP Broadcast Assistant enables cross-connection memory corruption
+
+The Bluetooth BAP Broadcast Assistant GATT client in
+``subsys/bluetooth/audio/bap_broadcast_assistant.c`` reassembled remote Broadcast
+Receive State data into a single file-static ``net_buf_simple`` (``att_buf``,
+``BT_ATT_MAX_ATTRIBUTE_LEN`` = 512 bytes) shared by all connection instances, while the
+BUSY flag, long-read handle, and reset/offset state were per-connection.
+
+When the device acts as a Broadcast Assistant connected to multiple Scan Delegator
+peripherals, notification and long-read callbacks from different connections interleave
+on the shared buffer: the append in ``notify_handler`` (``net_buf_simple_add_mem`` at
+the not-busy branch) performs no tailroom check, so receive-state notifications from two
+or more delegators accumulate on the same 512-byte buffer and, with a sufficiently large
+configured ATT MTU (``BT_L2CAP_TX_MTU`` up to 2000) and two-to-three concurrent
+connections, write past the buffer into adjacent .bss (``net_buf_simple_add`` only
+asserts in debug builds).
+
+Even below the overflow threshold, one connection's ``net_buf_simple_reset`` zeroes the
+shared length while another connection's reassembly and GATT read offset are in flight,
+mixing one peer's data into another's parse. A malicious or compromised Scan Delegator
+(or two colluding peers) over BLE can trigger this, causing out-of-bounds writes (memory
+corruption / denial of service) and cross-connection data corruption.
+
+The fix moves the buffer into the per-connection instance struct so each connection
+reassembles into its own buffer. Affects Zephyr releases shipping the Broadcast
+Assistant with the shared buffer, including v4.4.0 and earlier.
+
+- `Zephyr project bug tracker GHSA-73c7-3rh7-v5p9
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-73c7-3rh7-v5p9>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107563 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107563>`_
+
+- `PR 111066 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111066>`_
+
+- `PR 111065 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111065>`_
+
+- `PR 111182 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111182>`_
 
 :cve:`2026-10663`
 -----------------
 
-Under embargo until 2026-07-12
+Use-after-free / double-free of the root USB device in the experimental USB host stack
+
+In Zephyr's experimental USB host stack (``CONFIG_USB_HOST_STACK``),
+``usbh_device_disconnect()`` (``subsys/usb/host/usbh_device.c``) freed the root
+``usb_device`` slab object without clearing the cached pointer ``ctx->root``. The bus
+removal handler ``dev_removed_handler()`` (``subsys/usb/host/usbh_core.c``) decides what
+to tear down solely from ``ctx->root``, checking only that it is non-NULL.
+
+Because UHC controller drivers (e.g. ``uhc_max3421e``, ``uhc_mcux_common``) synthesize
+``UHC_EVT_DEV_REMOVED`` directly from physical bus line state with no debounce or state
+guard, an attacker with physical USB access (or a rogue device that bounces its
+connection) can deliver a second device-removed event after a root device disconnect.
+The handler then re-enters ``usbh_device_disconnect()`` with the dangling pointer,
+locking a mutex inside the freed object (use-after-free), removing the freed node from
+the device list, and calling ``k_mem_slab_free()`` on the already-freed block
+(double-free). If the slab block has been reissued to a newly attached device in
+between, this corrupts a live object.
+
+Impact is denial of service (crash) and memory corruption; the attack vector is
+physical/local. The flaw was introduced in v4.4.0 by the connect/disconnect refactor and
+is fixed by clearing ``ctx->root`` in ``usbh_device_disconnect()`` before freeing.
+
+- `Zephyr project bug tracker GHSA-26q8-xjq3-f5p6
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-26q8-xjq3-f5p6>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108796 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108796>`_
+
+- `PR 111021 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111021>`_
 
 :cve:`2026-10664`
 -----------------
 
-Under embargo until 2026-07-12
+Out-of-bounds write in nRF70 Wi-Fi driver power-save event handler (unbounded TWT flow count)
+
+The nRF70 Wi-Fi driver's power-save event handler
+``nrf_wifi_event_proc_get_power_save_info()`` in
+``drivers/wifi/nrf_wifi/src/wifi_mgmt.c`` copied TWT (Target Wake Time) flow entries
+from an ``nrf_wifi_umac_event_power_save_info`` event into the fixed-size
+``twt_flows[WIFI_MAX_TWT_FLOWS]`` (8-element) array of a caller-supplied ``struct
+wifi_ps_config``, looping over event-provided ``num_twt_flows`` without validating it
+against ``WIFI_MAX_TWT_FLOWS`` or checking ``event_len``. When ``num_twt_flows`` exceeds
+8, the handler writes past the destination array (which is typically on the caller's
+stack, e.g. the ``wifi ps`` shell command) -- an out-of-bounds write of ~40-byte TWT
+entries -- and reads ``twt_flow_info[i]`` past the event buffer. The event is delivered
+by the nRF70 co-processor firmware in response to a host-initiated power-save GET, so
+reaching the overflow requires the firmware to emit a malformed or out-of-range event;
+the trust boundary is host-to-trusted-coprocessor rather than a direct remote-AP write,
+with over-the-air influence on the flow count being indirect and bounded by the 3-bit
+TWT flow-id space. Affected: builds with ``CONFIG_NRF70_STA_MODE`` on releases through
+v4.4.0. The fix rejects events with ``num_twt_flows`` > ``WIFI_MAX_TWT_FLOWS`` or with
+``event_len`` shorter than the claimed entries, and adds a NULL check on the caller
+buffer.
+
+- `Zephyr project bug tracker GHSA-3r6j-pm38-r43m
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3r6j-pm38-r43m>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108849 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108849>`_
+
+- `PR 109067 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109067>`_
+
+- `PR 109068 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109068>`_
 
 :cve:`2026-10665`
 -----------------
 
-Under embargo until 2026-07-12
+Heap buffer overflow on WireGuard receive path via unbounded incoming packet length
+
+In Zephyr's WireGuard subsystem (``subsys/net/lib/wireguard``),
+``wg_process_data_message()`` in ``wg_crypto.c`` linearizes an inbound transport-data
+payload into a fixed pool buffer of ``CONFIG_WIREGUARD_BUF_LEN`` bytes before
+decryption. The call ``net_buf_linearize(buf->data, data_len, pkt->buffer, ...,
+data_len)`` passed the attacker-derived ``data_len`` as both the destination capacity
+and the copy length, defeating the function's internal ``len = min(len, dst_len)``
+bound. ``data_len`` is derived from the received UDP datagram length and is only
+lower-bounded by ``wg_ctrl_recv()`` (no upper bound). When ``data_len`` exceeds
+``CONFIG_WIREGUARD_BUF_LEN`` — e.g. when the buffer length is lowered below the link
+MTU, on links with MTU above the buffer size, or via reassembled IPv4/IPv6 fragments
+that exceed it — the underlying ``memcpy`` writes past the end of the pool buffer, an
+out-of-bounds write (CWE-787). The overflow occurs before the Poly1305 authentication
+check, so it requires only a valid receiver session index rather than a valid
+authenticator, and is reachable by a malicious or compromised peer (or an on-path
+attacker driving an established session) over the network, yielding remote memory
+corruption and at minimum a reliable denial of service. The defect was present in the
+WireGuard implementation shipped in Zephyr 4.4.0. The fix adds an explicit ``data_len >
+CONFIG_WIREGUARD_BUF_LEN`` rejection and corrects the linearize call to pass
+``net_buf_max_len(buf)`` as the destination capacity.
+
+- `Zephyr project bug tracker GHSA-3wqm-wgx2-9367
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-3wqm-wgx2-9367>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108841 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108841>`_
+
+- `PR 111084 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111084>`_
 
 :cve:`2026-10667`
 -----------------
 
-Under embargo until 2026-07-12
+SMP use-after-free in Zephyr ``CONFIG_USERSPACE`` dynamic kernel-object tracking, reachable from unprivileged user threads
+
+Zephyr's dynamic kernel-object tracking (``kernel/userspace/userspace.c``, formerly
+``kernel/userspace.c``) maintains a doubly-linked list (``obj_list``) of dynamically
+allocated kernel objects. Iteration over this list in ``k_object_wordlist_foreach()``
+was performed under ``lists_lock`` using the SAFE iterator (which caches the next node),
+but list removal and freeing of nodes was performed under different, disjoint spinlocks:
+``objfree_lock`` in ``k_object_free()`` and ``obj_lock`` in ``unref_check()``. On an SMP
+system, while one CPU iterated ``obj_list`` under ``lists_lock``, another CPU could
+unlink and ``k_free()`` the ``dyn_obj`` node that the iterator had cached as its next
+pointer, causing the iterator to dereference freed kernel memory (use-after-free /
+dangling list traversal). All of the racing operations are reachable from unprivileged
+user-mode threads via system calls: ``k_object_alloc``/``k_object_alloc_size`` and
+``k_object_release`` drive removals through ``unref_check()`` (under ``obj_lock``),
+while ``k_thread_abort`` and thread creation drive the iteration through
+``k_thread_perms_all_clear()``/``k_thread_perms_inherit()`` (under ``lists_lock``). A
+deprivileged user thread on a ``CONFIG_SMP`` + ``CONFIG_USERSPACE`` build can therefore
+corrupt the kernel's object-tracking structures across the userspace security boundary,
+yielding kernel memory corruption (potential privilege escalation) or a kernel crash
+(denial of service). The fix removes ``objfree_lock`` and serializes every ``obj_list``
+modification under ``lists_lock``, including holding it across find+remove in
+``k_object_free()`` and around ``unref_check()`` in ``k_thread_perms_clear()``. Affects
+``CONFIG_SMP``+``CONFIG_USERSPACE``+``CONFIG_DYNAMIC_OBJECTS`` configurations; the
+defect dates to the 2019 spinlockification (commit 8a3d57b6cc6, first released in
+v1.14.0) and shipped through v4.4.0.
+
+- `Zephyr project bug tracker GHSA-9x5j-h3rh-x579
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-9x5j-h3rh-x579>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108721 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108721>`_
+
+- `PR 111067 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111067>`_
+
+- `PR 111019 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111019>`_
+
+- `PR 111018 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111018>`_
 
 :cve:`2026-10668`
 -----------------
 
-Under embargo until 2026-07-12
+Host-triggerable control-endpoint wedge (DoS) in Nuvoton NuMaker HSUSBD UDC driver
+
+The Nuvoton NuMaker HSUSBD USB device-controller driver
+(``drivers/usb/udc/udc_numaker.c``) armed the control Data IN stage unconditionally
+(``base->CEPTXCNT = len`` in ``numaker_hsusbd_ep_trigger``). Because the HSUSBD hardware
+cannot disarm a control Data IN already armed for a previous transfer, a USB host that
+cancels an in-flight control transfer (timeout) and then issues a new SETUP packet can
+drive the driver out of sync: stale data may be transmitted in the new transfer and the
+control endpoint can become permanently stuck NAK'ing every subsequent control transfer.
+
+A malicious or buggy host (physical/adjacent attacker driving the bus) can repeatedly
+cancel-and-re-SETUP to wedge the device's USB control endpoint, denying service to the
+device's USB function (the device stops enumerating/responding on the control pipe)
+until a USB reset or re-plug. The flaw is an availability-only denial of service; the
+FIFO copy loops (bounded by ``net_buf`` length and the hardware BUFFULL flag) and the
+``net_buf`` lifecycle are independent of the arming desync, so there is no out-of-bounds
+access, use-after-free, or information leak.
+
+The fix monitors the IN-token and new-SETUP events (``k_event``) and only arms control
+Data IN when an IN token is present and no new SETUP has arrived, cancelling the current
+transfer on a new SETUP. Affects boards using the Nuvoton NuMaker HSUSBD controller
+(``CONFIG_UDC_NUMAKER`` with ``DT_HAS_NUVOTON_NUMAKER_HSUSBD_ENABLED``); shipped in
+v4.4.0.
+
+- `Zephyr project bug tracker GHSA-rm28-x84j-4qrx
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-rm28-x84j-4qrx>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107010 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107010>`_
+
+- `PR 110646 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/110646>`_
 
 :cve:`2026-10669`
 -----------------
 
-Under embargo until 2026-07-14
+Xtensa MPU ``arch_buffer_validate()`` integer-overflow lets a user thread bypass syscall pointer validation
+
+On Xtensa SoCs built with ``CONFIG_XTENSA_MPU`` and ``CONFIG_USERSPACE``,
+``arch_buffer_validate()`` in ``arch/xtensa/core/mpu.c`` — the architecture hook that
+verifies a user-mode-supplied buffer is accessible to the calling user thread with the
+requested permission — defaulted its return value to 0 (access permitted) and only set a
+denial result inside its per-MPU-region probe loop. When the rounded extent of the
+buffer wraps the 32-bit address space (size + alignment offset near ``SIZE_MAX``, or
+``ROUND_UP(size + offset)`` overflowing to 0), the loop executes zero iterations and the
+function returns 0 = permitted without probing any MPU region.
+
+The syscall-layer pre-checks (``K_SYSCALL_MEMORY_SIZE_CHECK`` /
+``Z_DETECT_POINTER_OVERFLOW``) only catch a raw ``addr+size`` wrap and do not cover the
+``ROUND_UP``-induced wrap, and the string path (``arch_user_string_nlen`` ->
+``arch_buffer_validate``) has no syscall-layer guard at all.
+
+An unprivileged user-mode thread can therefore pass a crafted ``(addr, size)`` to any
+syscall that validates user buffers via ``k_usermode_from_copy``/``to_copy`` or
+``k_usermode_string_copy`` and have validation succeed for memory it must not access;
+the kernel then reads from (disclosure) or, with ``write=1``, writes to (corruption)
+attacker-chosen kernel or other-partition memory on the thread's behalf, enabling
+information disclosure, memory corruption, privilege escalation, and denial of service.
+
+Affected from v3.7.0 (when Xtensa MPU userspace support was added) through v4.4.0. The
+fix changes the default to ``-EINVAL`` (deny by default), adds an explicit
+``size_add_overflow`` check, and sets the success value only after the full range has
+been validated.
+
+- `Zephyr project bug tracker GHSA-4r4p-gh69-v6w4
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-4r4p-gh69-v6w4>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 109000 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109000>`_
+
+- `PR 109239 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109239>`_
+
+- `PR 109238 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109238>`_
+
+- `PR 109236 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109236>`_
 
 :cve:`2026-10670`
 -----------------
 
-Under embargo until 2026-07-14
+User-triggerable kernel NULL-pointer dereference (DoS) in ``k_thread_name_copy()`` syscall verifier
+
+The ``CONFIG_USERSPACE`` verification handler for the ``k_thread_name_copy()`` system
+call (``z_vrfy_k_thread_name_copy()`` in ``kernel/thread.c``) calls ``k_object_find()``
+on the caller-supplied thread pointer and then dereferences the returned ``struct
+k_object`` without checking it for ``NULL``. ``k_object_find()`` returns ``NULL``
+whenever the supplied pointer is not a registered (static or dynamic) kernel object.
+
+The pre-fix guard tested ``thread == NULL`` instead of ``ko == NULL``, so an
+unprivileged user-mode thread that invokes ``k_thread_name_copy()`` with any non-NULL
+but unregistered pointer (e.g. an arbitrary address) passes the NULL test, after which
+the verifier reads ``ko->type`` through a NULL pointer.
+
+Because the syscall verifier runs in supervisor mode, this NULL dereference is a
+kernel-mode fault that halts or reboots the system, allowing untrusted user code to
+crash the kernel across the userspace security boundary (denial of service). The
+marshaller passes the thread argument to the verifier without any prior
+``K_SYSCALL_OBJ`` validation, so the bad pointer reaches the defect directly.
+
+The flaw affects builds with ``CONFIG_USERSPACE`` and ``CONFIG_THREAD_NAME`` enabled and
+has been present since the special-case lookup was introduced around v2.0.0; it is
+present in v4.4.0 and earlier. The fix changes the guard to check the
+``k_object_find()`` return value (``ko == NULL``) before dereferencing it.
+
+- `Zephyr project bug tracker GHSA-82h2-v4vm-q2g9
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-82h2-v4vm-q2g9>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 109076 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109076>`_
+
+- `PR 111088 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111088>`_
+
+- `PR 111089 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111089>`_
+
+- `PR 109364 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109364>`_
 
 :cve:`2026-10671`
 -----------------
 
-Under embargo until 2026-07-14
+User thread can re-initialize an in-use ``k_pipe``, corrupting kernel wait queues (``CONFIG_USERSPACE``)
+
+In Zephyr's kernel pipe implementation, the userspace syscall verifier
+``z_vrfy_k_pipe_init()`` in ``kernel/pipe.c`` used ``K_SYSCALL_OBJ()`` (which requires
+the kernel object to already be initialized) instead of ``K_SYSCALL_OBJ_NEVER_INIT()``
+(which rejects an already-initialized object). As a result, on ``CONFIG_USERSPACE``
+builds an unprivileged user thread that has been granted access to a ``k_pipe`` object
+can invoke the ``k_pipe_init`` syscall to re-initialize a pipe that is already in use.
+
+``z_impl_k_pipe_init()`` unconditionally resets the ring buffer, sets ``pipe->waiting``
+to 0, and re-initializes both wait queues (``z_waitq_init`` on ``pipe->data`` and
+``pipe->space``) without waking or accounting for threads currently blocked on the pipe.
+Any thread already pended in ``k_pipe_read()``/``k_pipe_write()`` is left orphaned:
+still marked pending with ``pended_on`` pointing at the cleared wait queue and with
+stale ``qnode_dlist`` links into the (now re-initialized) embedded list head.
+
+When such an orphaned waiter is later timed out or woken, the scheduler calls
+``sys_dlist_remove()`` on its stale node, writing through dangling ``prev``/``next``
+pointers into kernel wait-queue/scheduler structures, causing list corruption (an
+attacker-driven invalid kernel write), lost wakeups, indefinitely blocked threads, and
+silent data loss. The flaw lets a deprivileged user thread corrupt the state of a kernel
+object shared with other threads/partitions.
+
+The fix switches the verifier to ``K_SYSCALL_OBJ_NEVER_INIT()``, matching the existing
+``k_msgq_init`` verifier, so a user thread can no longer re-initialize a live pipe. The
+vulnerable code shipped in v4.1.0 and remained through v4.4.0.
+
+- `Zephyr project bug tracker GHSA-p8w8-3x99-mg8f
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-p8w8-3x99-mg8f>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 109091 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109091>`_
+
+- `PR 111101 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111101>`_
+
+- `PR 111102 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111102>`_
 
 :cve:`2026-10672`
 -----------------
 
-Under embargo until 2026-07-14
+Unterminated URI buffer causes out-of-bounds read in LwM2M firmware pull (Package URI)
+
+``subsys/net/lib/lwm2m/lwm2m_pull_context.c`` copied the firmware-update Package URI
+into a fixed static buffer (``context.uri``, size
+``CONFIG_LWM2M_SWMGMT_PACKAGE_URI_LEN``, default 128) with ``memcpy(context.uri, uri,
+LWM2M_PACKAGE_URI_LEN)``, copying exactly the destination size with no length
+validation. The Firmware-Update object stores the server-supplied Package URI (/5/0/1)
+in a 255-byte buffer, so a LwM2M management server (or an on-path attacker on a session
+lacking strong DTLS) can WRITE a URI of 128-254 characters; only the first 128 bytes are
+then copied into ``context.uri`` with no NUL terminator. That buffer is subsequently
+consumed as a C string by ``http_parser_parse_url(context.uri, strlen(context.uri),
+...)``, ``strlen``-based CoAP URI-path/PROXY-URI option appends, and
+``lwm2m_parse_peerinfo()``, causing an out-of-bounds read of adjacent static memory. The
+over-read bytes are appended to outbound CoAP requests (information disclosure of
+adjacent device memory to the server/proxy) and can crash the device (denial of
+service). The vulnerable copy was introduced by the pull-context refactor (first
+released in v3.0.0) and is present through v4.4.0; the default-on
+``CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT`` path is affected. The fix adds a
+``strlen(uri) >= sizeof(context.uri)`` check returning ``-ENOMEM`` and switches to
+``strcpy()``, guaranteeing a bounded, NUL-terminated buffer.
+
+- `Zephyr project bug tracker GHSA-rf6j-4mpp-j9mf
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-rf6j-4mpp-j9mf>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108964 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108964>`_
+
+- `PR 109235 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109235>`_
+
+- `PR 109234 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109234>`_
+
+- `PR 109233 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109233>`_
 
 :cve:`2026-10674`
 -----------------
@@ -1007,7 +2052,42 @@ Under embargo until 2026-07-23
 :cve:`2026-8023`
 ----------------
 
-Under embargo until 2026-06-26
+Path traversal in Zephyr HTTP server static-filesystem resource handler allows unauthenticated remote arbitrary file read
+
+Zephyr's HTTP server (``subsys/net/lib/http``) provides a static-filesystem resource
+type (``HTTP_RESOURCE_TYPE_STATIC_FS``, available when ``CONFIG_FILE_SYSTEM`` is
+enabled) that serves files from a configured root directory. Before this fix, both the
+HTTP/1 and HTTP/2 front-ends placed the raw, attacker-controlled request path into
+``client->url_buffer`` (assembled in ``on_url()`` for HTTP/1 and copied verbatim from
+the :path pseudo-header for HTTP/2) without resolving ``.``/``..`` segments. The
+static-FS handler then built the on-disk filename by directly concatenating the
+configured root with that raw URL (``snprintk(fname, ..., "%s%s",
+static_fs_detail->fs_path, client->url_buffer)`` at ``http_server_http1.c:603`` and
+``http_server_http2.c:490``) and opened it with ``fs_open(fname, FS_O_READ)``. Because
+the handler is reached via wildcard/leading-dir (``fnmatch`` ``FNM_LEADING_DIR``) or
+fallback resource matching, a request such as GET /<prefix>/../../<file> is dispatched
+to the handler and, after the underlying filesystem (e.g. LittleFS/FAT) resolves the
+``..`` segments, escapes the configured web root, letting an unauthenticated remote
+client read arbitrary readable files on the mounted volume (information disclosure). The
+HTTP server requires no TLS or authentication to reach this path. The fix adds
+``http_server_remove_dot_segments()``, which canonicalizes the path portion of the URL
+before resource lookup in both protocol handlers, neutralizing the traversal. Affects
+releases v4.0.0 through v4.4.0 for deployments that register a static-filesystem
+resource.
+
+- `Zephyr project bug tracker GHSA-hch3-53g6-jj3h
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-hch3-53g6-jj3h>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108531 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108531>`_
+
+- `PR 111347 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111347>`_
+
+- `PR 111346 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/111346>`_
 
 :cve:`2026-9728`
 ----------------
@@ -1058,3 +2138,266 @@ Under embargo until 2026-08-16
 -----------------
 
 Under embargo until 2026-08-16
+
+:cve:`2026-7656`
+----------------
+
+Broken IPv6 Neighbor Discovery input validation allows spoofed RA/NS/NA acceptance in Zephyr net stack
+
+The IPv6 Neighbor Discovery handlers in ``subsys/net/ip/ipv6_nbr.c``
+(``handle_ra_input``, ``handle_ns_input``, ``handle_na_input``) used an incorrect
+boolean expression that combined the RFC 4861 validity checks with the ICMPv6 code check
+using the wrong operator precedence: the form was '((length/hop/source/target checks) &&
+(icmp_hdr->code != 0))'. Because every legitimate ND message carries ICMPv6 code 0, an
+attacker setting code == 0 (the normal value) caused the entire predicate to evaluate
+false, so the packet was never dropped and all of the other checks were silently
+skipped. The bypassed checks include the mandatory Hop Limit == 255 verification (which
+proves an ND packet originated on-link and was not forwarded) and, for Router
+Advertisements, the requirement that the source be a link-local address, as well as
+multicast-target sanity checks. As a result, an adjacent on-link attacker — and, because
+the Hop-Limit-255 guard is bypassed, potentially a remote/off-link attacker whose
+packets would otherwise be rejected — can have forged Router Advertisement, Neighbor
+Solicitation, and Neighbor Advertisement messages accepted. A forged RA lets the
+attacker reconfigure the victim's default router, on-link prefixes (SLAAC), MTU,
+reachable/retransmit timers, and (with ``CONFIG_NET_IPV6_RA_RDNSS``) DNS servers, while
+forged NS/NA enable neighbor-cache poisoning, enabling man-in-the-middle, traffic
+redirection, and denial of service. The flaw is an input-validation/authentication
+weakness rather than a memory-safety issue: the underlying packet-parsing primitives
+(``net_pkt_get_data``, ``net_pkt_read``, ``net_pkt_skip``) are independently bounds-safe
+and the validated 'length' is the true buffer length, so skipping the length check
+causes no out-of-bounds access. The defect has existed since the logic was introduced in
+2018 and shipped in all releases through v4.4.0; it is fixed by splitting the condition
+so any failing check drops the packet.
+
+- `Zephyr project bug tracker GHSA-cpjw-rvwx-ph9f
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-cpjw-rvwx-ph9f>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 107902 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/107902>`_
+
+- `PR 108131 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108131>`_
+
+- `PR 108192 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108192>`_
+
+- `PR 108195 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108195>`_
+
+:cve:`2026-10666`
+-----------------
+
+Stack buffer overflow in ``net_ipaddr_parse()`` IPv4 address-with-port parsing in ``subsys/net/ip/utils.c``
+
+``parse_ipv4()`` in ``subsys/net/ip/utils.c`` (reached via ``net_ipaddr_parse()`` for
+strings of the form "a.b.c.d:port") copies the port substring into a fixed 17-byte stack
+buffer (``char ipaddr[NET_IPV4_ADDR_LEN + 1]``) using a length of ``str_len - end - 1``,
+where ``str_len`` is the full, unbounded input length and end is only the (<=15-byte)
+offset of the ':' delimiter. Because the destination size is never consulted, a crafted
+address string with a long suffix after the colon (e.g. "1.2.3.4:" followed by hundreds
+of bytes) causes an out-of-bounds stack write whose length and contents are fully
+attacker-controlled (``memcpy`` of the suffix plus a trailing NUL), enabling memory
+corruption and at minimum a denial of service, and potentially control-flow hijack. The
+parser is reached from the standard socket API (``zsock_getaddrinfo`` / literal-address
+resolution), DNS server-string configuration, and the eswifi Wi-Fi co-processor
+DNS-response path, so an application that resolves a network-influenced address string
+is exposed. The bug was introduced when the parser was added (Zephyr v1.9.0) and shipped
+in all releases through v4.4.0. The fix removes the unbounded copy and validates the
+port length before copying into a small dedicated buffer. Note: the equivalent IPv6
+"[addr]:port" path in ``parse_ipv6()`` retains the same unbounded copy at this commit
+and remains a separate, still-reachable instance of the defect.
+
+- `Zephyr project bug tracker GHSA-532c-7g7f-jhmh
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-532c-7g7f-jhmh>`_
+
+This has been fixed in main for v4.5.0
+
+- `PR 108529 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/108529>`_
+
+- `PR 109058 fix for v4.4
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109058>`_
+
+- `PR 109072 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109072>`_
+
+- `PR 109065 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/109065>`_
+
+:cve:`2026-10673`
+-----------------
+
+Under embargo until 2026-07-15
+
+:cve:`2026-12629`
+-----------------
+
+Under embargo until 2026-08-16
+
+:cve:`2026-12630`
+-----------------
+
+Under embargo until 2026-08-16
+
+:cve:`2026-12631`
+-----------------
+
+Under embargo until 2026-08-16
+
+:cve:`2026-12632`
+-----------------
+
+Under embargo until 2026-08-16
+
+:cve:`2026-12633`
+-----------------
+
+Under embargo until 2026-08-16
+
+:cve:`2026-12634`
+-----------------
+
+Under embargo until 2026-08-16
+
+:cve:`2026-12999`
+-----------------
+
+Under embargo until 2026-08-22
+
+:cve:`2026-13212`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13213`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13214`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13215`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13216`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13217`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13343`
+-----------------
+
+Under embargo until 2026-08-23
+
+:cve:`2026-13351`
+-----------------
+
+net: Maliciously fragmented IPv6 packets can prevent receiving/processing future incoming packets
+
+The Zephyr network stack can be prevented from receiving or processing future
+incoming packets by sending a few maliciously fragmented IPv6 packets. When
+``net_ipv6_handle_fragment_hdr()`` triggers an ICMPv6 error response for a
+malformed fragment, it returns ``NET_OK`` without unreferencing the packet,
+leaking the RX network packet buffer. Each call to ``k_mem_slab_alloc()`` lacks a
+counterpart ``k_mem_slab_free()``, so replaying such a packet a few times
+exhausts the RX buffer slab, after which the driver repeatedly fails to obtain RX
+buffers, resulting in a denial of service.
+
+- `Zephyr project bug tracker GHSA-cv4q-2j56-4wqf
+  <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-cv4q-2j56-4wqf>`_
+
+This has been fixed in main for v4.4.0
+
+- `PR 104044 fix for main
+  <https://github.com/zephyrproject-rtos/zephyr/pull/104044>`_
+
+- `PR 104205 fix for v4.3
+  <https://github.com/zephyrproject-rtos/zephyr/pull/104205>`_
+
+- `PR 104206 fix for v4.2
+  <https://github.com/zephyrproject-rtos/zephyr/pull/104206>`_
+
+- `PR 104209 fix for v3.7
+  <https://github.com/zephyrproject-rtos/zephyr/pull/104209>`_
+
+:cve:`2026-13478`
+-----------------
+
+Under embargo until 2026-08-25
+
+:cve:`2026-13479`
+-----------------
+
+Under embargo until 2026-08-26
+
+:cve:`2026-13480`
+-----------------
+
+Under embargo until 2026-08-26
+
+:cve:`2026-13481`
+-----------------
+
+Under embargo until 2026-08-26
+
+:cve:`2026-13734`
+-----------------
+
+Under embargo until 2026-08-28
+
+:cve:`2026-13735`
+-----------------
+
+Under embargo until 2026-08-28
+
+:cve:`2026-14366`
+-----------------
+
+Under embargo until 2026-08-30
+
+:cve:`2026-14367`
+-----------------
+
+Under embargo until 2026-08-30
+
+:cve:`2026-14368`
+-----------------
+
+Under embargo until 2026-08-30
+
+:cve:`2026-14696`
+-----------------
+
+Under embargo until 2026-08-31
+
+:cve:`2026-14697`
+-----------------
+
+Under embargo until 2026-08-31
+
+:cve:`2026-14986`
+-----------------
+
+Under embargo until 2026-09-04
+
+:cve:`2026-15460`
+-----------------
+
+Under embargo until 2026-09-07
+
+:cve:`2026-15461`
+-----------------
+
+Under embargo until 2026-09-08


### PR DESCRIPTION
Brings `doc/security/vulnerabilities.rst` current with the advisories that have
come out of embargo, and registers the ones still pending.

## What changed

| | Commit 1 | Commit 2 | PR total |
|---|---:|---:|---:|
| Embargo placeholder replaced with full disclosure | 29 | 8 | 36 |
| New entry added, already disclosed | 3 | 5 | 9 |
| New embargo placeholder registered | 29 | 19 | 47 |

The PR totals are not column sums: CVE-2026-10673 is registered as a placeholder
in the first commit and disclosed in the second, so it nets out as a new
disclosed entry rather than one of each.

The file goes from 97 to 153 CVE sections. 87 remain under embargo, with
disclosure dates from 2026-07-25 through 2026-09-21. No existing text is
reworded and no entry is removed, so every change is either a placeholder
becoming prose or a brand-new section.

## Commit 1 — `doc: security: fill in published CVE details`

Disclosed (placeholder → description, GHSA link, per-branch fix PRs):
2026-8023, 2026-9263, 2026-10593, 2026-10642 through 2026-10648,
2026-10651 through 2026-10660, 2026-10663 through 2026-10665,
2026-10667 through 2026-10672.

Added already-disclosed: 2026-7656, 2026-10666, 2026-13351.

The CVE-2026-13351 text (IPv6 fragment RX buffer leak leading to slab exhaustion
and DoS) is taken from @ceolin's #112054, which overlaps with this set.

New placeholders: 2026-10673, 2026-12629 through 2026-12634, 2026-12999,
2026-13212 through 2026-13217, 2026-13343, 2026-13478 through 2026-13481,
2026-13734, 2026-13735, 2026-14366 through 2026-14368, 2026-14696, 2026-14697,
2026-14986, 2026-15460, 2026-15461.

## Commit 2 — `doc: security: Publish CVE details and add new embargoes`

Disclosed:

- 2026-7007 — divide-by-zero in ext2 superblock parsing (crafted image)
- 2026-10673 — ADIN2111/ADIN1110 OA SPI RX reassembly out-of-bounds write
- 2026-10674 — NXP LPUART left clock-gated after an unsupported `uart_configure()`
- 2026-10675 — Bluetooth Mesh PB-ADV invalidated link kept alive indefinitely
- 2026-10677 — kernel heap leak in the `k_poll()` syscall verifier
- 2026-10678 — MCTP I2C+GPIO target NULL / out-of-bounds write
- 2026-10679 — DesignWare SPI divide-by-zero via `spi_transceive`
- 2026-10680 — BR/EDR L2CAP config-request `uint16_t` length underflow

Added already-disclosed — the FatFs set (2026-6682, 2026-6683, 2026-6685,
2026-6686, 2026-6687). These are defects in ChaN's FatFs, vendored via the
`zephyrproject-rtos/fatfs` module. Upstream is unmaintained for security
purposes, so Zephyr carries the fixes in its own copy; the entries have GHSA
links but no per-branch fix PR list.

New placeholders: 2026-15890 through 2026-15894, 2026-15923, 2026-15924,
2026-16147, 2026-16148, 2026-16511 through 2026-16515, 2026-17050 through
2026-17054.
