### PR TITLE
tests: lib: fix word granular access test filter

### DIFF
--- a/tests/lib/word_granular_access/tests.yaml
+++ b/tests/lib/word_granular_access/tests.yaml
@@ -1,3 +1,4 @@
 tests:
   libraries.word_granular_access:
-    filter: CONFIG_ARCH_HAS_WORD_GRANULAR_ACCESS_INSTR_MEM
+    platform_allow:
+      - esp32_devkitc/esp32/procpu


### PR DESCRIPTION
Not all platforms that have word granular instruction memory have an 'iram.data' section in their linker script; this test will not work for these platform. Restrict the test to one known working platform.

(@ttmut pointed out there are failures in the [weekly](https://github.com/zephyrproject-rtos/zephyr/actions/runs/29177651386/job/86609627862) because of this)