### PR TITLE
doc: doxygen: make Topics the focal point of the landing page

### DIFF
--- a/doc/_doxygen/doxygen-awesome-zephyr.css
+++ b/doc/_doxygen/doxygen-awesome-zephyr.css
@@ -110,6 +110,41 @@ dl.section dd, dl.bug dd, dl.deprecated dd {
     text-align: center;
 }
 
+/* Landing page topic cards */
+.topic-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: var(--spacing-medium);
+    margin: var(--spacing-large) 0;
+}
+
+.topic-card {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: var(--spacing-medium);
+    border: 1px solid var(--separator-color);
+    border-radius: var(--border-radius-medium);
+    background-color: var(--page-background-color);
+    text-decoration: none !important;
+    transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
+}
+
+.topic-card:hover {
+    border-color: var(--primary-color);
+    box-shadow: var(--box-shadow);
+}
+
+.topic-card .topic-card-title {
+    font-weight: 600;
+    color: var(--primary-dark-color) !important;
+}
+
+.topic-card .topic-card-desc {
+    font-size: var(--page-font-size);
+    color: var(--page-secondary-foreground-color) !important;
+}
+
 /* Driver ops "badges" */
 .op-badge {
     font-size: 12px;

--- a/doc/_doxygen/mainpage.md
+++ b/doc/_doxygen/mainpage.md
@@ -1,27 +1,67 @@
-# Introduction
+# Zephyr API Reference
 
-The Zephyr OS is a small-footprint kernel designed for use on
-resource-constrained and embedded systems: from simple embedded
-environmental sensors and LED wearables to sophisticated embedded
-controllers, smart watches, and IoT wireless applications.
+This is the reference documentation for the [Zephyr RTOS](https://zephyrproject.org) C API: all the
+functions, macros, and data structures available to Zephyr applications and subsystems, generated
+directly from the source code.
 
-See the [zephyrproject.org](https://zephyrproject.org) site for more
-information about the project and becoming a member, and this [summary
-of Zephyr resources](https://docs.zephyrproject.org/latest/introduction/index.html#resources)
-to help you find your way around the project.
+## Browse the API by topic
 
-## Supported Boards
+The API is organized as a hierarchy of [**Topics**](topics.html) covering the main areas of the OS.
+Start with one of the main categories below, or browse the [full topic list](topics.html).
 
-The Zephyr kernel supports multiple architectures, including ARM
-Cortex-M, Intel x86, ARC, NIOS II, Tensilica Xtensa, and RISC-V 32.  For
-details, see the [latest supported boards
-documentation](https://docs.zephyrproject.org/latest/boards/index.html).
+<div class="topic-cards">
+  <a class="topic-card" href="group__kernel__apis.html">
+    <span class="topic-card-title">Kernel</span>
+    <span class="topic-card-desc">
+      Threads, scheduling, synchronization, timers, and other core RTOS primitives.
+    </span>
+  </a>
+  <a class="topic-card" href="group__io__interfaces.html">
+    <span class="topic-card-title">Device Drivers</span>
+    <span class="topic-card-desc">
+      Hardware-agnostic interfaces for peripherals: GPIO, I2C, SPI, sensors, and more.
+    </span>
+  </a>
+  <a class="topic-card" href="group__os__services.html">
+    <span class="topic-card-title">Operating System Services</span>
+    <span class="topic-card-desc">
+      Networking, Bluetooth, storage, logging, and other services built on the kernel.
+    </span>
+  </a>
+  <a class="topic-card" href="group__devicetree.html">
+    <span class="topic-card-title">Devicetree</span>
+    <span class="topic-card-desc">
+      Macros for reading the hardware description of the system at build time.
+    </span>
+  </a>
+  <a class="topic-card" href="group__device__model.html">
+    <span class="topic-card-title">Device Model</span>
+    <span class="topic-card-desc">
+      The abstraction that binds drivers to the hardware instances they manage.
+    </span>
+  </a>
+  <a class="topic-card" href="group__mem__mgmt.html">
+    <span class="topic-card-title">Memory Management</span>
+    <span class="topic-card-desc">Heaps, memory slabs, and memory-mapping interfaces.</span>
+  </a>
+  <a class="topic-card" href="group__utilities.html">
+    <span class="topic-card-title">Utilities</span>
+    <span class="topic-card-desc">General-purpose helpers, including the data structure APIs.</span>
+  </a>
+  <a class="topic-card" href="group__testing.html">
+    <span class="topic-card-title">Testing</span>
+    <span class="topic-card-desc">The Ztest framework and related testing helpers.</span>
+  </a>
+</div>
 
-## Licensing
+## Other ways to explore
 
-Zephyr is permissively licensed using the Apache 2.0 license (as found
-in the [project's GitHub LICENSE
-file](https://github.com/zephyrproject-rtos/zephyr/blob/main/LICENSE).
-There are some imported or reused components of the Zephyr project that
-use other licensing, as described in [Licensing of Zephyr Project
-components](https://docs.zephyrproject.org/latest/LICENSING.html#zephyr-licensing).
+- [Data Structures](annotated.html): an index of all documented `struct`s and `union`s.
+- [Files](files.html): browse the API header by header.
+- [Deprecated List](deprecated.html): APIs scheduled for removal, and what to use instead.
+- Use the search box to find any documented symbol by name.
+
+## Looking for something else?
+
+This site only covers the C API. For guides, samples, supported boards, and everything else, head
+over to the main [Zephyr Project documentation](https://docs.zephyrproject.org/latest/).


### PR DESCRIPTION
The Doxygen main page was a generic project introduction (what Zephyr is, supported boards, licensing) that duplicated the main documentation and did not help readers who came looking for API reference material.

Rework it into an actual API reference landing page: lead with the Topics index and a linked overview of the curated top-level API categories, list the other ways to explore the reference (data structures, files, deprecated list, search), and close with a pointer to the main documentation for everything that is not C API reference.

https://builds.zephyrproject.io/zephyr/pr/113538/docs/doxygen/html/index.html