### PR TITLE
doc: enable cross-references from Doxygen to the main documentation

### DIFF
--- a/doc/_doxygen/doxygen-awesome-zephyr.css
+++ b/doc/_doxygen/doxygen-awesome-zephyr.css
@@ -129,3 +129,10 @@ dl.section dd, dl.bug dd, dl.deprecated dd {
     background-color: #3498db;
     color: white;
 }
+
+/* Cross-references to the main (Sphinx-based) documentation, as resolved by
+   the zephyr.doxyxref extension */
+a.doxyxref,
+a.doxyxref code {
+    color: var(--link-color);
+}

--- a/doc/_extensions/zephyr/doxyxref.py
+++ b/doc/_extensions/zephyr/doxyxref.py
@@ -64,11 +64,52 @@ PLACEHOLDER_RE = re.compile(
 )
 """Placeholder markup, as emitted by the ALIASES defined in zephyr.doxyfile.in."""
 
-TITLED_REF_RE = re.compile(r"^(?P<title>.+?)\s*<(?P<target>[^<>]+)>$", re.DOTALL)
-"""Explicit title notation, i.e. ``custom text <target>`` (as in Sphinx roles)."""
 
-INVENTORY_ENTRY_RE = re.compile(r"(?x)(.+?)\s+(\S+)\s+(-?\d+)\s+?(\S*)\s+(.*)")
-"""Entry line of a version 2 Sphinx object inventory."""
+def split_titled_ref(raw: str) -> tuple[str | None, str]:
+    """Split an explicit-title reference into its title and target parts.
+
+    Explicit titles use the same ``custom text <target>`` notation as Sphinx
+    roles. When no explicit title is present, the returned title is ``None``
+    and the whole input is the target.
+    """
+    if raw.endswith(">"):
+        open_pos = raw.rfind("<")
+        title = raw[:open_pos].rstrip() if open_pos > 0 else ""
+        target = raw[open_pos + 1 : -1]
+        if title and target and ">" not in target:
+            return title, target
+
+    return None, raw
+
+
+def parse_inventory_entry(line: str) -> tuple[str, str, str, str] | None:
+    """Parse an entry line of a version 2 Sphinx object inventory.
+
+    Entries have the form ``name type priority location dispname``, where both
+    the name and the display name may contain spaces.
+
+    Returns:
+        The ``(name, type, location, dispname)`` tuple, or ``None`` if the
+        line is not a valid inventory entry.
+    """
+    words = line.split(" ")
+
+    # the name is the shortest sequence of words followed by a type (which
+    # always contains a colon), a priority (an integer), and a location
+    for i in range(1, len(words) - 2):
+        if ":" not in words[i]:
+            continue
+        try:
+            int(words[i + 1])
+        except ValueError:
+            continue
+
+        name = " ".join(words[:i])
+        location = words[i + 2]
+        dispname = " ".join(words[i + 3 :]) or "-"
+        return name, words[i], location, dispname
+
+    return None
 
 
 def parse_inventory(data: bytes) -> dict[str, dict[str, tuple[str, str]]]:
@@ -96,10 +137,10 @@ def parse_inventory(data: bytes) -> dict[str, dict[str, tuple[str, str]]]:
 
     inventory: dict[str, dict[str, tuple[str, str]]] = {}
     for line in zlib.decompress(compressed).decode("utf-8").splitlines():
-        m = INVENTORY_ENTRY_RE.match(line.rstrip())
-        if not m:
+        entry = parse_inventory_entry(line.rstrip())
+        if entry is None:
             continue
-        name, stype, _prio, location, dispname = m.groups()
+        name, stype, location, dispname = entry
         if location.endswith("$"):
             location = location[:-1] + name
         inventory.setdefault(stype, {})[name] = (location, dispname)
@@ -149,12 +190,10 @@ def process_html_content(
         stype = m.group("stype")
         raw_target = m.group("starget")
 
-        title = None
-        target = raw_target
         if stype == "std:ref":
-            tm = TITLED_REF_RE.match(raw_target)
-            if tm:
-                title, target = tm.group("title"), tm.group("target")
+            title, target = split_titled_ref(raw_target)
+        else:
+            title, target = None, raw_target
 
         entry = lookup(inventory, stype, target)
         if entry is None:

--- a/doc/_extensions/zephyr/doxyxref.py
+++ b/doc/_extensions/zephyr/doxyxref.py
@@ -52,6 +52,7 @@ import re
 import sys
 import zlib
 from pathlib import Path
+from urllib.parse import urlparse
 
 __version__ = "0.1.0"
 
@@ -317,7 +318,7 @@ def main() -> int:
     parser.add_argument(
         "--inventory",
         required=True,
-        help="Sphinx object inventory (objects.inv): local file path or http(s) URL",
+        help="Sphinx object inventory (objects.inv): local file path or https:// URL",
     )
     parser.add_argument(
         "--base-url",
@@ -330,13 +331,19 @@ def main() -> int:
     if not args.html_dir.is_dir():
         sys.exit(f"error: not a directory: {args.html_dir}")
 
-    if args.inventory.startswith(("http://", "https://")):
+    scheme = urlparse(args.inventory).scheme
+    if scheme == "https":
         from urllib.request import urlopen
 
         with urlopen(args.inventory) as f:
             data = f.read()
+    elif scheme in ("http", "ftp", "file"):
+        sys.exit(f"error: only https:// URLs are supported for --inventory: {args.inventory}")
     else:
-        data = Path(args.inventory).read_bytes()
+        inventory_file = Path(args.inventory).resolve()
+        if not inventory_file.is_file():
+            sys.exit(f"error: not a file: {args.inventory}")
+        data = inventory_file.read_bytes()
 
     inventory = parse_inventory(data)
 

--- a/doc/_extensions/zephyr/doxyxref.py
+++ b/doc/_extensions/zephyr/doxyxref.py
@@ -1,0 +1,314 @@
+"""
+Doxygen to Sphinx cross-reference resolver
+##########################################
+
+Copyright (c) 2026 The Linux Foundation
+SPDX-License-Identifier: Apache-2.0
+
+This extension makes it possible to reference Sphinx documentation content
+(e.g. Kconfig options, Devicetree bindings, or any ``:ref:`` target) from
+Doxygen comments, and have the Doxygen-generated HTML pages link back to the
+corresponding pages of the Sphinx-based documentation.
+
+Doxygen aliases (defined in ``zephyr.doxyfile.in``) such as ``@kconfig{}``,
+``@dtcompatible{}`` or ``@rstref{}`` expand to HTML placeholders like::
+
+    <code class='doxyxref' data-stype='kconfig:option'
+          data-starget='CONFIG_GPIO'>CONFIG_GPIO</code>
+
+Once the Sphinx HTML build is finished, this extension scans the
+Doxygen-generated HTML pages and resolves such placeholders into actual
+hyperlinks, using the Sphinx object inventory (``objects.inv``) produced by
+the very same build. Links are written as relative URLs so that they remain
+valid wherever the documentation set is hosted (docs.zephyrproject.org/latest,
+versioned copies, local builds, downstream distributions, ...).
+
+Placeholders that cannot be resolved are left untouched (they degrade to
+plain, code-styled text) and a Sphinx warning is emitted for each of them.
+
+The module can also be used as a standalone command line tool, which is
+useful when only building the Doxygen documentation (e.g. the ``doxygen``
+CMake target). In that case, placeholders can be resolved against the object
+inventory of an already published documentation set::
+
+    python doc/_extensions/zephyr/doxyxref.py \\
+        --html-dir doc/_build/doxygen/html \\
+        --inventory https://docs.zephyrproject.org/latest/objects.inv \\
+        --base-url https://docs.zephyrproject.org/latest/
+
+Configuration options
+=====================
+
+- ``doxyxref_projects``: Dictionary of Doxygen projects, mapping project name
+  to the Doxygen output directory (same format as ``doxybridge_projects``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import os
+import re
+import sys
+import zlib
+from pathlib import Path
+
+__version__ = "0.1.0"
+
+PLACEHOLDER_RE = re.compile(
+    r"<(?P<tag>code|span) class='doxyxref' "
+    r"data-stype='(?P<stype>[^']+)' "
+    r"data-starget='(?P<starget>[^']*)'>"
+    r".*?</(?P=tag)>",
+    re.DOTALL,
+)
+"""Placeholder markup, as emitted by the ALIASES defined in zephyr.doxyfile.in."""
+
+TITLED_REF_RE = re.compile(r"^(?P<title>.+?)\s*<(?P<target>[^<>]+)>$", re.DOTALL)
+"""Explicit title notation, i.e. ``custom text <target>`` (as in Sphinx roles)."""
+
+INVENTORY_ENTRY_RE = re.compile(r"(?x)(.+?)\s+(\S+)\s+(-?\d+)\s+?(\S*)\s+(.*)")
+"""Entry line of a version 2 Sphinx object inventory."""
+
+
+def parse_inventory(data: bytes) -> dict[str, dict[str, tuple[str, str]]]:
+    """Parse a version 2 Sphinx object inventory (``objects.inv``).
+
+    Args:
+        data: Raw content of the inventory file.
+
+    Returns:
+        A mapping of object type (e.g. ``std:label``) to a dictionary mapping
+        object name to a ``(uri, display name)`` tuple. URIs are relative to
+        the documentation root.
+    """
+    header, _, remainder = data.partition(b"\n")
+    if header.rstrip() != b"# Sphinx inventory version 2":
+        raise ValueError(f"Unsupported inventory format: {header.decode(errors='replace')}")
+
+    # skip project name/version lines, check compression marker
+    try:
+        _, _, compression, compressed = remainder.split(b"\n", 3)
+    except ValueError as e:
+        raise ValueError("Malformed inventory header") from e
+    if b"zlib" not in compression:
+        raise ValueError("Unsupported inventory compression")
+
+    inventory: dict[str, dict[str, tuple[str, str]]] = {}
+    for line in zlib.decompress(compressed).decode("utf-8").splitlines():
+        m = INVENTORY_ENTRY_RE.match(line.rstrip())
+        if not m:
+            continue
+        name, stype, _prio, location, dispname = m.groups()
+        if location.endswith("$"):
+            location = location[:-1] + name
+        inventory.setdefault(stype, {})[name] = (location, dispname)
+
+    return inventory
+
+
+def lookup(
+    inventory: dict[str, dict[str, tuple[str, str]]], stype: str, target: str
+) -> tuple[str, str] | None:
+    """Look up a reference target in the object inventory.
+
+    ``std:ref`` targets are resolved like the Sphinx ``:ref:`` role, i.e.
+    against reference labels (which are stored lowercased in the inventory),
+    with document names (``:doc:`` targets) as a fallback.
+    """
+    if stype == "std:ref":
+        entry = inventory.get("std:label", {}).get(target.lower())
+        if entry is None:
+            entry = inventory.get("std:doc", {}).get(target.strip("/"))
+        return entry
+
+    return inventory.get(stype, {}).get(target)
+
+
+def process_html_content(
+    content: str,
+    inventory: dict[str, dict[str, tuple[str, str]]],
+    url_base: str,
+) -> tuple[str, list[tuple[str, str]]]:
+    """Resolve all cross-reference placeholders found in an HTML document.
+
+    Args:
+        content: HTML content to process.
+        inventory: Parsed object inventory.
+        url_base: Prefix prepended to the documentation-root-relative URI of
+            each resolved target. Can be an absolute URL or a relative path
+            (with trailing slash).
+
+    Returns:
+        The processed content, and the list of ``(type, target)`` tuples that
+        could not be resolved.
+    """
+    unresolved: list[tuple[str, str]] = []
+
+    def _replace(m: re.Match) -> str:
+        stype = m.group("stype")
+        raw_target = m.group("starget")
+
+        title = None
+        target = raw_target
+        if stype == "std:ref":
+            tm = TITLED_REF_RE.match(raw_target)
+            if tm:
+                title, target = tm.group("title"), tm.group("target")
+
+        entry = lookup(inventory, stype, target)
+        if entry is None:
+            unresolved.append((stype, target))
+            return m.group(0)
+
+        uri, dispname = entry
+        if title is None:
+            title = dispname if dispname and dispname != "-" else target
+
+        text = html.escape(title)
+        if m.group("tag") == "code":
+            text = f"<code>{text}</code>"
+
+        href = html.escape(url_base + uri, quote=True)
+        return f'<a class="doxyxref" href="{href}">{text}</a>'
+
+    return PLACEHOLDER_RE.sub(_replace, content), unresolved
+
+
+def process_html_dir(
+    html_dir: Path,
+    inventory: dict[str, dict[str, tuple[str, str]]],
+    url_base: str | None = None,
+    docs_root: Path | None = None,
+) -> list[tuple[str, str]]:
+    """Resolve cross-reference placeholders in all HTML files of a directory.
+
+    Args:
+        html_dir: Directory containing the Doxygen-generated HTML files.
+        inventory: Parsed object inventory.
+        url_base: Fixed URL prefix for resolved links (e.g.
+            ``https://docs.zephyrproject.org/latest/``). Mutually exclusive
+            with ``docs_root``.
+        docs_root: Root directory of the Sphinx HTML output. When given,
+            links are computed relative to each processed file.
+
+    Returns:
+        List of ``(type, target)`` tuples that could not be resolved.
+    """
+    if (url_base is None) == (docs_root is None):
+        raise ValueError("Exactly one of url_base and docs_root must be provided")
+
+    unresolved: list[tuple[str, str]] = []
+
+    for file in sorted(html_dir.rglob("*.html")):
+        content = file.read_text(encoding="utf-8", errors="surrogateescape")
+        if "class='doxyxref'" not in content:
+            continue
+
+        if docs_root is not None:
+            rel = os.path.relpath(docs_root, file.parent).replace(os.sep, "/")
+            base = "" if rel == "." else f"{rel}/"
+        else:
+            base = url_base
+
+        new_content, missing = process_html_content(content, inventory, base)
+        unresolved.extend(missing)
+
+        if new_content != content:
+            file.write_text(new_content, encoding="utf-8", errors="surrogateescape")
+
+    return unresolved
+
+
+def doxyxref_resolve(app, exception) -> None:
+    """Sphinx ``build-finished`` hook resolving Doxygen cross-references."""
+    from sphinx.util import logging
+
+    logger = logging.getLogger(__name__)
+
+    if exception is not None or app.builder.format != "html":
+        return
+
+    outdir = Path(app.outdir)
+    inventory_file = outdir / "objects.inv"
+    if not inventory_file.exists():
+        logger.warning(f"doxyxref: object inventory not found: {inventory_file}")
+        return
+
+    inventory = parse_inventory(inventory_file.read_bytes())
+
+    for project, project_outdir in (app.config.doxyxref_projects or {}).items():
+        html_dir = Path(project_outdir) / "html"
+        if not html_dir.is_dir():
+            logger.warning(f"doxyxref: no Doxygen HTML output found for project '{project}'")
+            continue
+
+        logger.info(f"doxyxref: resolving Sphinx cross-references for project '{project}'...")
+        unresolved = process_html_dir(html_dir, inventory, docs_root=outdir)
+        for stype, target in sorted(set(unresolved)):
+            logger.warning(
+                f"doxyxref: unresolved {stype} cross-reference: '{target}' (project '{project}')",
+                type="doxyxref",
+            )
+
+
+def setup(app):
+    app.add_config_value("doxyxref_projects", {}, "env")
+
+    app.connect("build-finished", doxyxref_resolve)
+
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve Sphinx cross-reference placeholders in Doxygen HTML output.",
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "--html-dir",
+        type=Path,
+        required=True,
+        help="Directory containing the Doxygen-generated HTML files",
+    )
+    parser.add_argument(
+        "--inventory",
+        required=True,
+        help="Sphinx object inventory (objects.inv): local file path or http(s) URL",
+    )
+    parser.add_argument(
+        "--base-url",
+        required=True,
+        help="Base URL of the documentation set links should point to, e.g. "
+        "https://docs.zephyrproject.org/latest/",
+    )
+    args = parser.parse_args()
+
+    if not args.html_dir.is_dir():
+        sys.exit(f"error: not a directory: {args.html_dir}")
+
+    if args.inventory.startswith(("http://", "https://")):
+        from urllib.request import urlopen
+
+        with urlopen(args.inventory) as f:
+            data = f.read()
+    else:
+        data = Path(args.inventory).read_bytes()
+
+    inventory = parse_inventory(data)
+
+    base_url = args.base_url if args.base_url.endswith("/") else f"{args.base_url}/"
+    unresolved = process_html_dir(args.html_dir, inventory, url_base=base_url)
+
+    for stype, target in sorted(set(unresolved)):
+        print(f"warning: unresolved {stype} cross-reference: '{target}'", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/doc/_extensions/zephyr/doxyxref.py
+++ b/doc/_extensions/zephyr/doxyxref.py
@@ -52,7 +52,7 @@ import re
 import sys
 import zlib
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 __version__ = "0.1.0"
 
@@ -167,6 +167,37 @@ def lookup(
     return inventory.get(stype, {}).get(target)
 
 
+def lookup_kconfig_regex(
+    inventory: dict[str, dict[str, tuple[str, str]]], target: str
+) -> tuple[str, str] | None:
+    """Resolve a Kconfig regex reference to the Kconfig search page.
+
+    The link points to the Kconfig search page pre-filled with the given
+    pattern, mirroring the Sphinx ``:kconfig:option-regex:`` role. The
+    reference only resolves if at least one Kconfig option matches, using the
+    same semantics as the search page: whitespace-separated, case-insensitive
+    regular expressions searched within option names.
+    """
+    options = inventory.get("kconfig:option", {})
+    if not options:
+        return None
+
+    try:
+        patterns = [re.compile(term.lower()) for term in target.split()]
+    except re.error:
+        return None
+
+    if not patterns:
+        return None
+
+    if not any(all(pattern.search(name.lower()) for pattern in patterns) for name in options):
+        return None
+
+    # all options live on the search page: derive its URI from any entry
+    page_uri = next(iter(options.values()))[0].partition("#")[0]
+    return f"{page_uri}#!{quote(target)}", "-"
+
+
 def process_html_content(
     content: str,
     inventory: dict[str, dict[str, tuple[str, str]]],
@@ -191,12 +222,15 @@ def process_html_content(
         stype = m.group("stype")
         raw_target = m.group("starget")
 
-        if stype == "std:ref":
+        if stype in ("std:ref", "kconfig:option-regex"):
             title, target = split_titled_ref(raw_target)
         else:
             title, target = None, raw_target
 
-        entry = lookup(inventory, stype, target)
+        if stype == "kconfig:option-regex":
+            entry = lookup_kconfig_regex(inventory, target)
+        else:
+            entry = lookup(inventory, stype, target)
         if entry is None:
             unresolved.append((stype, target))
             return m.group(0)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -88,6 +88,7 @@ extensions = [
     "zephyr.doxyrunner",
     "zephyr.doxybridge",
     "zephyr.doxytooltip",
+    "zephyr.doxyxref",
     "zephyr.gh_utils",
     "zephyr.manifest_projects_table",
     "notfound.extension",
@@ -292,6 +293,10 @@ os.environ["DOXYGEN_SITEMAP_URL"] = f"{html_baseurl}doxygen/html"
 # -- Options for zephyr.doxybridge plugin ---------------------------------
 
 doxybridge_projects = {"zephyr": doxyrunner_projects["zephyr"]["outdir"]}
+
+# -- Options for zephyr.doxyxref plugin ------------------------------------
+
+doxyxref_projects = doxybridge_projects
 
 # -- Options for html_redirect plugin -------------------------------------
 

--- a/doc/contribute/documentation/generation.rst
+++ b/doc/contribute/documentation/generation.rst
@@ -306,6 +306,29 @@ it locally, and watch the documentation directory for changes. When changes are
 observed, it will automatically rebuild the documentation and refresh the hosted
 files.
 
+Building the Doxygen documentation standalone
+*********************************************
+
+The ``doxygen`` build target can be used to only build the Doxygen (API) documentation, which is
+much faster than building the full documentation set::
+
+   cd ~/zephyrproject/zephyr/doc
+   make doxygen
+
+The output can be found in ``_build/doxygen/html``.
+
+In the regular documentation build, references made from Doxygen comments to the main
+documentation (e.g. ``@kconfig{}``, ``@dtcompatible{}`` or ``@rstref{}``, see
+:ref:`doxygen_sphinx_xrefs`) are automatically resolved into hyperlinks. In a standalone Doxygen
+build, they are left as plain text since the rest of the documentation is not available. If
+needed, they can be manually resolved against the object inventory of an already published
+documentation set using the ``doxyxref`` tool::
+
+   python3 _extensions/zephyr/doxyxref.py \
+       --html-dir _build/doxygen/html \
+       --inventory https://docs.zephyrproject.org/latest/objects.inv \
+       --base-url https://docs.zephyrproject.org/latest/
+
 Linking external Doxygen projects against Zephyr
 ************************************************
 

--- a/doc/contribute/style/doxygen.rst
+++ b/doc/contribute/style/doxygen.rst
@@ -325,6 +325,14 @@ as hyperlinks pointing back to the corresponding page of the main documentation.
 
   Example: ``@kconfig{CONFIG_GPIO}``
 
+``@kconfig_regex{<regex>}`` or ``@kconfig_regex{<text> <regex>}``
+  Reference all the Kconfig options matching a regular expression, as a link to the Kconfig search
+  page with the pattern pre-filled. This is the Doxygen counterpart of the
+  :rst:role:`kconfig:option-regex` role. As commas have a special meaning in Doxygen commands, they
+  must be escaped with a backslash.
+
+  Example: ``@kconfig_regex{CONFIG_SECURE_STORAGE_ITS_.*_CUSTOM}``
+
 ``@dtcompatible{<compatible>}``
   Reference a Devicetree binding by its compatible string. This is the Doxygen counterpart of the
   :rst:role:`dtcompatible` role. As commas have a special meaning in Doxygen commands, they must be

--- a/doc/contribute/style/doxygen.rst
+++ b/doc/contribute/style/doxygen.rst
@@ -310,6 +310,43 @@ For function-like macros, document parameters like you would for functions.
     */
    #define DT_REG_SIZE(node_id) DT_REG_SIZE_BY_IDX(node_id, 0)
 
+.. _doxygen_sphinx_xrefs:
+
+Referencing the main documentation
+**********************************
+
+API documentation can reference content from the main, Sphinx-based documentation using the
+commands described below. In the generated API documentation pages, these references are rendered
+as hyperlinks pointing back to the corresponding page of the main documentation.
+
+``@kconfig{<option>}``
+  Reference a Kconfig option by its full name (including the ``CONFIG_`` prefix). This is the
+  Doxygen counterpart of the :rst:role:`kconfig:option` role.
+
+  Example: ``@kconfig{CONFIG_GPIO}``
+
+``@dtcompatible{<compatible>}``
+  Reference a Devicetree binding by its compatible string. This is the Doxygen counterpart of the
+  :rst:role:`dtcompatible` role. As commas have a special meaning in Doxygen commands, they must be
+  escaped with a backslash.
+
+  Example: ``@dtcompatible{zephyr\,input-longpress}``
+
+``@rstref{<target>}`` or ``@rstref{<text> <target>}``
+  Reference any documentation page or section by its reference label (or document name), similar to
+  the Sphinx :rst:role:`ref` role. When no custom text is provided, the title of the referenced
+  page or section is used as the link text.
+
+  Example: ``@rstref{zephyr_licensing}`` or ``@rstref{the licensing page <zephyr_licensing>}``
+
+References are checked when the documentation is built: a reference to a Kconfig option, binding,
+or label that does not exist causes a documentation build warning.
+
+.. note::
+
+   These commands expand to plain text when the Doxygen documentation is built standalone, i.e.
+   without the rest of the documentation. See :ref:`zephyr_doc` for more details.
+
 .. _doxygen_internals:
 
 Hiding internal details

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -293,6 +293,9 @@ TAB_SIZE               = 8
 # unresolved, the placeholders gracefully degrade to plain text.
 #
 # - kconfig{1}:      reference a Kconfig option, e.g. @kconfig{CONFIG_GPIO}
+# - kconfig_regex{1}: reference all Kconfig options matching a regular
+#                    expression, linking to the Kconfig search page, e.g.
+#                    @kconfig_regex{CONFIG_SECURE_STORAGE_ITS_.*_CUSTOM}
 # - dtcompatible{1}: reference a Devicetree binding by compatible string,
 #                    e.g. @dtcompatible{zephyr\,input-longpress} (note the
 #                    escaped comma)
@@ -301,6 +304,7 @@ TAB_SIZE               = 8
 #                    @rstref{the coding guidelines <coding_guidelines>}
 
 ALIASES                = "kconfig{1}=\htmlonly<code class='doxyxref' data-stype='kconfig:option' data-starget='\1'>\1</code>\endhtmlonly" \
+                         "kconfig_regex{1}=\htmlonly<code class='doxyxref' data-stype='kconfig:option-regex' data-starget='\1'>\1</code>\endhtmlonly" \
                          "dtcompatible{1}=\htmlonly<code class='doxyxref' data-stype='std:dtcompatible' data-starget='\1'>\1</code>\endhtmlonly" \
                          "rstref{1}=\htmlonly<span class='doxyxref' data-stype='std:ref' data-starget='\1'>\1</span>\endhtmlonly" \
                          "req{1}=\ref ZEPH_\1 \"ZEPH-\1\"" \

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -285,7 +285,24 @@ TAB_SIZE               = 8
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                = "kconfig{1}=\c \1" \
+# The kconfig, dtcompatible and rstref aliases expand to HTML placeholders
+# that are resolved into links pointing back to the Sphinx-based documentation
+# (e.g. docs.zephyrproject.org) by the 'zephyr.doxyxref' Sphinx extension (see
+# doc/_extensions/zephyr/doxyxref.py, which can also be used as a standalone
+# tool to post-process the output of a Doxygen-only build). When left
+# unresolved, the placeholders gracefully degrade to plain text.
+#
+# - kconfig{1}:      reference a Kconfig option, e.g. @kconfig{CONFIG_GPIO}
+# - dtcompatible{1}: reference a Devicetree binding by compatible string,
+#                    e.g. @dtcompatible{zephyr\,input-longpress} (note the
+#                    escaped comma)
+# - rstref{1}:       reference any Sphinx ':ref:' target, with optional custom
+#                    text, e.g. @rstref{coding_guidelines} or
+#                    @rstref{the coding guidelines <coding_guidelines>}
+
+ALIASES                = "kconfig{1}=\htmlonly<code class='doxyxref' data-stype='kconfig:option' data-starget='\1'>\1</code>\endhtmlonly" \
+                         "dtcompatible{1}=\htmlonly<code class='doxyxref' data-stype='std:dtcompatible' data-starget='\1'>\1</code>\endhtmlonly" \
+                         "rstref{1}=\htmlonly<span class='doxyxref' data-stype='std:ref' data-starget='\1'>\1</span>\endhtmlonly" \
                          "req{1}=\ref ZEPH_\1 \"ZEPH-\1\"" \
                          "satisfy{1}=\xrefitem satisfy \"Satisfies requirement\" \"Requirement Implementation\" \1" \
                          "verify{1}=\xrefitem verify \"Verifies requirement\" \"Requirement Verification\" \1" \

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -67,7 +67,7 @@ struct bt_cap_unicast_group;
  * Service instance.
  *
  * This shall only be done as a server, and requires
- * @kconfig{BT_CAP_ACCEPTOR_SET_MEMBER}. If @kconfig{BT_CAP_ACCEPTOR_SET_MEMBER}
+ * @kconfig{CONFIG_BT_CAP_ACCEPTOR_SET_MEMBER}. If @kconfig{CONFIG_BT_CAP_ACCEPTOR_SET_MEMBER}
  * is not enabled, the Common Audio Service will by statically registered.
  *
  * @param[in]  param     Coordinated Set Identification Service register

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -795,7 +795,7 @@ enum bt_le_adv_opt {
 	 * Coding Selection. If these conditions are not met, it will default to
 	 * no required coding scheme.
 	 *
-	 * @kconfig_dep{BT_EXT_ADV_CODING_SELECTION}
+	 * @kconfig_dep{CONFIG_BT_EXT_ADV_CODING_SELECTION}
 	 */
 	BT_LE_ADV_OPT_REQUIRE_S2_CODING = BIT(20),
 
@@ -812,7 +812,7 @@ enum bt_le_adv_opt {
 	 * Coding Selection. If these conditions are not met, it will default to
 	 * no required coding scheme.
 	 *
-	 * @kconfig_dep{BT_EXT_ADV_CODING_SELECTION}
+	 * @kconfig_dep{CONFIG_BT_EXT_ADV_CODING_SELECTION}
 	 */
 	BT_LE_ADV_OPT_REQUIRE_S8_CODING = BIT(21),
 

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -181,7 +181,7 @@ int bt_br_oob_get_local(struct bt_br_oob *oob);
  * to first be in connectable state.
  *
  * If the device enters limited discoverable mode, the controller will leave from discoverable
- * mode after the duration of @kconfig{BT_LIMITED_DISCOVERABLE_DURATION} seconds in the limited
+ * mode after the duration of @kconfig{CONFIG_BT_LIMITED_DISCOVERABLE_DURATION} seconds in the limited
  * discoverable mode.
  *
  * @param enable Value allowing/disallowing controller to become discoverable.
@@ -239,7 +239,7 @@ typedef enum bt_br_conn_req_rsp (*bt_br_conn_req_func_t)(const bt_addr_t *addr, 
  *               false, this parameter is ignored.
  *               If @p func is NULL, the conn_req will be accepted internally. The default role
  *               is peripheral. The role switch request can be performed if the
- *               @kconfig{BT_ACCEPT_CONN_AS_CENTRAL} is enabled.
+ *               @kconfig{CONFIG_BT_ACCEPT_CONN_AS_CENTRAL} is enabled.
  *               If @p func is provided, the conn_req will be passed to the callback function
  *               for the application to decide whether to accept or reject the connection, and
  *               the desired role for the connection.

--- a/include/zephyr/bluetooth/classic/hfp_ag.h
+++ b/include/zephyr/bluetooth/classic/hfp_ag.h
@@ -256,7 +256,7 @@ struct bt_hfp_ag_cb {
 	 *
 	 *  @param ag HFP AG object.
 	 *  @param number Buffer to store the last dialed phone number.
-	 *                The buffer size is @kconfig{BT_HFP_AG_PHONE_NUMBER_MAX_LEN} + 1,
+	 *                The buffer size is @kconfig{CONFIG_BT_HFP_AG_PHONE_NUMBER_MAX_LEN} + 1,
 	 *                and should be null-terminated.
 	 *
 	 *  @return 0 in case of success or negative value in case of error.

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -443,21 +443,21 @@ struct bt_l2cap_br_endpoint {
 	uint8_t                                 max_transmit;
 	/** Endpoint Retransmission Timeout
 	 * The field is configured by
-	 * `@kconfig{BT_L2CAP_BR_RET_TIMEOUT}`
+	 * @kconfig{CONFIG_BT_L2CAP_BR_RET_TIMEOUT}
 	 * The field should be no more than the field
 	 * `monitor_timeout`.
 	 */
 	uint16_t                                ret_timeout;
 	/** Endpoint Monitor Timeout
 	 * The field is configured by
-	 * `@kconfig{BT_L2CAP_BR_MONITOR_TIMEOUT}`
+	 * @kconfig{CONFIG_BT_L2CAP_BR_MONITOR_TIMEOUT}
 	 */
 	uint16_t                                monitor_timeout;
 	/** Endpoint Maximum PDU payload Size */
 	uint16_t                                mps;
 	/** Endpoint Maximum Window Size
 	 * MAX supported window size is configured by
-	 * `@kconfig{BT_L2CAP_MAX_WINDOW_SIZE}`. The field
+	 * @kconfig{CONFIG_BT_L2CAP_MAX_WINDOW_SIZE}. The field
 	 * should be no more then `CONFIG_BT_L2CAP_MAX_WINDOW_SIZE`.
 	 */
 	uint16_t                                max_window;

--- a/subsys/secure_storage/include/internal/zephyr/secure_storage/its/store/settings_get.h
+++ b/subsys/secure_storage/include/internal/zephyr/secure_storage/its/store/settings_get.h
@@ -10,7 +10,7 @@
  * of the settings implementation of the ITS store module.
  * They are not meant to be called directly other than by the settings ITS store module.
  * This header file may and must be included when providing a custom implementation of one
- * or more of these functions (@kconfig{CONFIG_SECURE_STORAGE_ITS_STORE_SETTINGS_*_CUSTOM}).
+ * or more of these functions (`CONFIG_SECURE_STORAGE_ITS_STORE_SETTINGS_*_CUSTOM`).
  */
 #include <zephyr/secure_storage/its/common.h>
 

--- a/subsys/secure_storage/include/internal/zephyr/secure_storage/its/store/settings_get.h
+++ b/subsys/secure_storage/include/internal/zephyr/secure_storage/its/store/settings_get.h
@@ -10,7 +10,7 @@
  * of the settings implementation of the ITS store module.
  * They are not meant to be called directly other than by the settings ITS store module.
  * This header file may and must be included when providing a custom implementation of one
- * or more of these functions (`CONFIG_SECURE_STORAGE_ITS_STORE_SETTINGS_*_CUSTOM`).
+ * or more of these functions (@kconfig_regex{CONFIG_SECURE_STORAGE_ITS_STORE_SETTINGS_.*_CUSTOM}).
  */
 #include <zephyr/secure_storage/its/common.h>
 

--- a/subsys/secure_storage/include/internal/zephyr/secure_storage/its/transform/aead_get.h
+++ b/subsys/secure_storage/include/internal/zephyr/secure_storage/its/transform/aead_get.h
@@ -10,7 +10,7 @@
  * of the AEAD implementation of the ITS transform module.
  * They are not meant to be called directly other than by the AEAD ITS transform module.
  * This header file may and must be included when providing a custom implementation of one
- * or more of these functions (@kconfig{CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_*_CUSTOM}).
+ * or more of these functions (`CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_*_CUSTOM`).
  */
 #include <zephyr/secure_storage/its/common.h>
 #include <psa/crypto_types.h>

--- a/subsys/secure_storage/include/internal/zephyr/secure_storage/its/transform/aead_get.h
+++ b/subsys/secure_storage/include/internal/zephyr/secure_storage/its/transform/aead_get.h
@@ -10,7 +10,7 @@
  * of the AEAD implementation of the ITS transform module.
  * They are not meant to be called directly other than by the AEAD ITS transform module.
  * This header file may and must be included when providing a custom implementation of one
- * or more of these functions (`CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_*_CUSTOM`).
+ * or more of these functions (@kconfig_regex{CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_.*_CUSTOM}).
  */
 #include <zephyr/secure_storage/its/common.h>
 #include <psa/crypto_types.h>


### PR DESCRIPTION
Introduce a mechanism allowing Doxygen comments to reference content from the main, Sphinx-based documentation, with the generated Doxygen HTML pages linking back to docs.zephyrproject.org Sphinx docs

https://builds.zephyrproject.io/zephyr/pr/113539/docs/doxygen/html/index.html



Doxygen aliases expand to HTML placeholders that a new 'zephyr.doxyxref' Sphinx extension resolves into actual hyperlinks at the end of the HTML build, using the Sphinx object inventory (objects.inv) produced by the very same build. Links are emitted as relative URLs, so they remain correct for /latest/, versioned releases, and local builds alike.

The following aliases are available:

- @kconfig{CONFIG_FOO}: reference a Kconfig option (upgraded from the existing alias which only rendered the option name as code text)
- @dtcompatible{vnd\,device}: reference a Devicetree binding
- @rstref{label} / @rstref{text <label>}: reference any Sphinx :ref: target (with :doc: targets as fallback)

Unresolved references degrade to plain code-styled text and emit a build warning so broken references are caught in CI.

The extension can also be used as a standalone CLI tool to post-process a Doxygen-only build against the object inventory of an already published documentation set.