### PR TITLE
boards: espressif: esp32p4: skip heap tests on p4 rev1.3

### DIFF
--- a/boards/espressif/esp32p4_function_ev_board/esp32p4_function_ev_board_hpcore.yaml
+++ b/boards/espressif/esp32p4_function_ev_board/esp32p4_function_ev_board_hpcore.yaml
@@ -5,6 +5,9 @@ type: mcu
 arch: riscv
 toolchain:
   - zephyr
+testing:
+  ignore_tags:
+    - heap
 supported:
   - counter
   - entropy


### PR DESCRIPTION
The heap test suite does not fit in the smaller usable SRAM window of the pre-v3 (rev 1.3) ESP32-P4, where the L2 cache sits at the top of SRAM and the ROM reserves memory low. The hardening_full case overflows the region by roughly 77KB. The same coverage runs on the esp32p4x board, so ignore the heap tag here.