### PR TITLE
Revert: twister: make QEMU_BIN_PATH optional #109347

### DIFF
--- a/doc/develop/beyond-GSG.rst
+++ b/doc/develop/beyond-GSG.rst
@@ -300,17 +300,17 @@ needed.
 Run the Application in QEMU
 ===========================
 
-You can run Zephyr applications via emulation on your host system using
-`QEMU <https://www.qemu.org/>`_ when targeting either the x86 or ARM
-Cortex-M3 architectures. QEMU is included with the Zephyr SDK.
+On Linux and macOS, you can run Zephyr applications via emulation on your host
+system using `QEMU <https://www.qemu.org/>`_ when targeting either
+the x86 or ARM Cortex-M3 architectures. (QEMU is included with the Zephyr
+SDK installation.)
 
-If using a manual QEMU installation, ensure it is available in the system
-``PATH`` environment variable.
-
-``QEMU_BIN_PATH`` can be used as an optional override to specify the
-location of QEMU binaries used by Twister. When provided, Twister
-validates that the specified path exists. Otherwise, Twister relies on
-SDK or other QEMU discovery mechanisms.
+On Windows, you need to install QEMU manually from
+`Download QEMU <https://www.qemu.org/download/#windows>`_. After installation,
+add path to QEMU installation folder to PATH environment variable.
+To enable QEMU in Test Runner (Twister) on Windows,
+:ref:`set the environment variable <env_vars>`
+``QEMU_BIN_PATH`` to the path of QEMU installation folder.
 
 For example, you can build and run the :zephyr:code-sample:`hello_world` sample using
 the x86 emulation board configuration (``qemu_x86``), with:

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -258,16 +258,13 @@ class TestInstance(StatusMixin):
         simulation = options.sim_name
 
         simulator = self.platform.simulator_by_name(simulation)
-        if os.name == 'nt' and simulator and simulator.name not in ('na', 'qemu'):
+        if os.name == 'nt' and simulator:
             # running on simulators is currently supported only for QEMU on Windows
-            return False
+            if simulator.name not in ('na', 'qemu'):
+                return False
 
-        # QEMU_BIN_PATH is optional and acts as an override.
-        # Validate it only when explicitly provided.
-        if simulator and simulator.name == 'qemu':
-            qemu_bin_path = os.environ.get('QEMU_BIN_PATH')
-
-            if qemu_bin_path is not None and not os.path.exists(qemu_bin_path):
+            # check presence of QEMU on Windows
+            if simulator.name == 'qemu' and 'QEMU_BIN_PATH' not in os.environ:
                 return False
 
         # we asked for build-only on the command line

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -77,18 +77,17 @@ def test_check_build_or_run(
     _, r = expected
     assert run == r
 
-    # existing QEMU_BIN_PATH
-    with mock.patch('os.environ', {'QEMU_BIN_PATH': '/tmp'}), \
-         mock.patch('os.path.exists', return_value=True):
-        run = testinstance.check_runnable(env.options, env.hwm)
-        _, r = expected
-        assert run == r
-
-    # non-existing QEMU_BIN_PATH
-    with mock.patch('os.environ', {'QEMU_BIN_PATH': '/invalid'}), \
-         mock.patch('os.path.exists', return_value=False):
+    with mock.patch('os.name', 'nt'):
+        # path to QEMU binary is not in QEMU_BIN_PATH environment variable
         run = testinstance.check_runnable(env.options, env.hwm)
         assert not run
+
+        # mock path to QEMU binary in QEMU_BIN_PATH environment variable
+        with mock.patch('os.environ', {'QEMU_BIN_PATH': ''}):
+            run = testinstance.check_runnable(env.options, env.hwm)
+            _, r = expected
+            assert run == r
+
 
 TESTDATA_PART_2 = [
     (True, True, True, ["demo_board_2/unit_testing"], "native",


### PR DESCRIPTION
This reverts PR #109347 as it is causing issues with at least the `qemu_cortex_m0` board timing out in the https://github.com/zephyrproject-rtos/example-application repo CI.

As I do not have access to a Windows PC with a Zephyr development environment, I am unable to debug this further. I can just tell from my tests on https://github.com/zephyrproject-rtos/example-application/pull/105, that reverting this change fixes the issues seen (example can be seen here: https://github.com/zephyrproject-rtos/example-application/actions/runs/29003872452/job/86105322288).