### PR TITLE
drivers: sensor: akm09918c: condition fetch delay

### DIFF
--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c.c
@@ -86,15 +86,18 @@ int akm09918c_fetch_measurement_blocking(const struct device *dev, int16_t *x, i
 static int akm09918c_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct akm09918c_data *data = dev->data;
-
+	/* Avoid introducing delay on continuous measurements */
+	bool wait_for_sample = data->mode == AKM09918C_CNTL2_PWR_DOWN;
 	int ret = akm09918c_start_measurement_blocking(dev, chan);
 
 	if (ret) {
 		return ret;
 	}
-	/* Wait for sample */
-	LOG_DBG("Waiting for sample...");
-	k_usleep(AKM09918C_MEASURE_TIME_US);
+
+	if (wait_for_sample) {
+		LOG_DBG("Waiting for sample...");
+		k_usleep(AKM09918C_MEASURE_TIME_US);
+	}
 
 	return akm09918c_fetch_measurement_blocking(dev, &data->x_sample, &data->y_sample,
 						    &data->z_sample);


### PR DESCRIPTION
The akm09918c driver imposes and unconditional wait time on fetch. This is only neccesary for single-shot sampling. If the sensor is configured in continuous mode, an application can time the fetch to align with the sensor ODR. For continous mode operation it does not make sense to have an artificial delay added - if the application is trying to fetch values at a higher frequency than the ODR it can just handle the -EBUSY by adding its own delay and retrying the fetch or reading the old values. Verified this change testing parallel sampling with an LSM6DSO IMU, Fetching all channels on DRDY of the IMU with the same ODR configured for both IMU and magnetometer.