### PR TITLE
twister: more cleanups and deduplication

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -8,6 +8,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import functools
 import json
 import logging
 import os
@@ -54,6 +55,17 @@ PYTEST_PLUGIN_INSTALLED = 'pytest-twister-harness' in installed_packages
 def norm_path(astring):
     newstring = os.path.normpath(astring).replace(os.sep, '/')
     return newstring
+
+
+@functools.cache
+def _parse_modules(zephyr_base: str = ZEPHYR_BASE):
+    """Cached wrapper around zephyr_module.parse_modules.
+
+    parse_modules() walks the workspace for module manifests. Twister needs the
+    result both when building the --board-root default and when TwisterEnv
+    computes its *_roots, so cache the read-only result to avoid scanning twice.
+    """
+    return zephyr_module.parse_modules(zephyr_base)
 
 
 def add_parse_arguments(parser = None) -> argparse.ArgumentParser:
@@ -428,7 +440,7 @@ Artificially long but functional example:
 
     board_root_list = [f"{ZEPHYR_BASE}/boards", f"{ZEPHYR_BASE}/subsys/testsuite/boards"]
 
-    modules = zephyr_module.parse_modules(ZEPHYR_BASE)
+    modules = _parse_modules()
     for module in modules:
         board_root = module.meta.get("build", {}).get("settings", {}).get("board_root")
         if board_root:
@@ -1086,22 +1098,21 @@ class TwisterEnv:
         self.dts_roots = [Path(ZEPHYR_BASE)]
         self.arch_roots = [Path(ZEPHYR_BASE)]
 
-        modules = zephyr_module.parse_modules(ZEPHYR_BASE)
+        # module build.settings key -> the *_roots list it extends
+        root_settings = {
+            "snippet_root": self.snippet_roots,
+            "soc_root": self.soc_roots,
+            "dts_root": self.dts_roots,
+            "arch_root": self.arch_roots,
+        }
+        modules = _parse_modules()
         for module in modules:
             settings = module.meta.get("build", {}).get("settings", {})
             project = Path(module.project)
-            snippet_root = settings.get("snippet_root")
-            if snippet_root:
-                self.snippet_roots.append(project / snippet_root)
-            soc_root = settings.get("soc_root")
-            if soc_root:
-                self.soc_roots.append(project / Path(soc_root))
-            dts_root = settings.get("dts_root")
-            if dts_root:
-                self.dts_roots.append(project / Path(dts_root))
-            arch_root = settings.get("arch_root")
-            if arch_root:
-                self.arch_roots.append(project / Path(arch_root))
+            for setting_key, roots in root_settings.items():
+                root = settings.get(setting_key)
+                if root:
+                    roots.append(project / Path(root))
 
         self.modules = [m.meta for m in modules]
         self.hwm: HardwareMap | None = None

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -55,6 +55,11 @@ except ImportError as capture_error:
 
 logger = logging.getLogger('twister')
 
+# Once a test reports its first status, the QEMU monitor keeps reading briefly
+# to catch late output. Coverage dumps take much longer than a normal tail.
+COVERAGE_TIMEOUT_EXTENSION = 30
+POST_STATUS_TIMEOUT_EXTENSION = 2
+
 
 def terminate_process(proc):
     """
@@ -923,7 +928,68 @@ class DeviceHandler(Handler):
             self.run_custom_script(post_script, timeout)
 
 
-class QEMUHandler(Handler):
+class QEMUHandlerBase(Handler):
+    """Shared behaviour for the POSIX and Windows QEMU handlers.
+
+    Both spawn a thread to monitor QEMU console output and decide the test
+    result from it. The monitor loops themselves differ per OS (select.poll on
+    fifos vs a reader-thread Queue) and are kept in the subclasses; everything
+    that does not depend on that mechanism lives here.
+    """
+
+    @staticmethod
+    def _get_cpu_time(pid):
+        """get process CPU time.
+
+        The guest virtual time in QEMU icount mode isn't host time and
+        it's maintained by counting guest instructions, so we use QEMU
+        process execution time to mostly simulate the time of guest OS.
+        """
+        proc = psutil.Process(pid)
+        cpu_time = proc.cpu_times()
+        return cpu_time.user + cpu_time.system
+
+    @staticmethod
+    def _thread_update_instance_info(handler, status, reason):
+        handler.instance.execution_time = handler.execution_time
+        handler.instance.status = status
+        if reason:
+            handler.instance.reason = reason
+        else:
+            handler.instance.reason = "Unknown Error"
+
+    @staticmethod
+    def _extend_timeout_on_status(harness):
+        """Return the extended monitor deadline after the first test status.
+
+        Coverage dumps can take a while, so allow much longer when capturing.
+        """
+        extension = (
+            COVERAGE_TIMEOUT_EXTENSION if harness.capture_coverage
+            else POST_STATUS_TIMEOUT_EXTENSION
+        )
+        return time.time() + extension
+
+    def _set_qemu_filenames(self, sysbuild_build_dir):
+        # PID file will be created in the main sysbuild app's build dir
+        self.pid_fn = os.path.join(sysbuild_build_dir, "qemu.pid")
+
+        if os.path.exists(self.pid_fn):
+            os.unlink(self.pid_fn)
+
+        self.log_fn = self.log
+
+    def _create_command(self, sysbuild_build_dir):
+        command = [self.generator_cmd]
+        command += ["-C", sysbuild_build_dir, "run"]
+
+        return command
+
+    def get_fifo(self):
+        return self.fifo_fn
+
+
+class QEMUHandler(QEMUHandlerBase):
     """Spawns a thread to monitor QEMU output from pipes
 
     We pass QEMU_PIPE to 'make run' and monitor the pipes for output.
@@ -962,32 +1028,11 @@ class QEMUHandler(Handler):
             self.ignore_unexpected_eof = False
 
     @staticmethod
-    def _get_cpu_time(pid):
-        """get process CPU time.
-
-        The guest virtual time in QEMU icount mode isn't host time and
-        it's maintained by counting guest instructions, so we use QEMU
-        process execution time to mostly simulate the time of guest OS.
-        """
-        proc = psutil.Process(pid)
-        cpu_time = proc.cpu_times()
-        return cpu_time.user + cpu_time.system
-
-    @staticmethod
     def _thread_get_fifo_names(fifo_fn):
         fifo_in = fifo_fn + ".in"
         fifo_out = fifo_fn + ".out"
 
         return fifo_in, fifo_out
-
-    @staticmethod
-    def _thread_update_instance_info(handler, status, reason):
-        handler.instance.execution_time = handler.execution_time
-        handler.instance.status = status
-        if reason:
-            handler.instance.reason = reason
-        else:
-            handler.instance.reason = "Unknown Error"
 
     @staticmethod
     def _thread(handler, timeout, outdir, logfile, fifo_fn, pid_fn,
@@ -1097,10 +1142,7 @@ class QEMUHandler(Handler):
                     # take some time.
                     if not timeout_extended or harness.capture_coverage:
                         timeout_extended = True
-                        if harness.capture_coverage:
-                            timeout_time = time.time() + 30
-                        else:
-                            timeout_time = time.time() + 2
+                        timeout_time = QEMUHandler._extend_timeout_on_status(harness)
                 line = ""
 
             handler.execution_time = time.time() - start_time
@@ -1124,19 +1166,7 @@ class QEMUHandler(Handler):
         # We pass this to QEMU which looks for fifos with .in and .out suffixes.
         # QEMU fifo will use main build dir
         self.fifo_fn = os.path.join(self.instance.build_dir, "qemu-fifo")
-        # PID file will be created in the main sysbuild app's build dir
-        self.pid_fn = os.path.join(sysbuild_build_dir, "qemu.pid")
-
-        if os.path.exists(self.pid_fn):
-            os.unlink(self.pid_fn)
-
-        self.log_fn = self.log
-
-    def _create_command(self, sysbuild_build_dir):
-        command = [self.generator_cmd]
-        command += ["-C", sysbuild_build_dir, "run"]
-
-        return command
+        super()._set_qemu_filenames(sysbuild_build_dir)
 
     def handle(self, harness):
         robot_test = getattr(harness, "is_robot_test", False) is True
@@ -1236,11 +1266,8 @@ class QEMUHandler(Handler):
 
         self._final_handle_actions(harness)
 
-    def get_fifo(self):
-        return self.fifo_fn
 
-
-class QEMUWinHandler(Handler):
+class QEMUWinHandler(QEMUHandlerBase):
     """Spawns a thread to monitor QEMU output from pipes on Windows OS
 
      QEMU creates single duplex pipe at //.pipe/path, where path is fifo_fn.
@@ -1278,18 +1305,6 @@ class QEMUWinHandler(Handler):
             self.ignore_unexpected_eof = False
 
     @staticmethod
-    def _get_cpu_time(pid):
-        """get process CPU time.
-
-        The guest virtual time in QEMU icount mode isn't host time and
-        it's maintained by counting guest instructions, so we use QEMU
-        process execution time to mostly simulate the time of guest OS.
-        """
-        proc = psutil.Process(pid)
-        cpu_time = proc.cpu_times()
-        return cpu_time.user + cpu_time.system
-
-    @staticmethod
     def _open_log_file(logfile):
         return open(logfile, "w")
 
@@ -1308,30 +1323,6 @@ class QEMUWinHandler(Handler):
                 pass
             except OSError:
                 pass
-
-    @staticmethod
-    def _monitor_update_instance_info(handler, status, reason):
-        handler.instance.execution_time = handler.execution_time
-        handler.instance.status = status
-        if reason:
-            handler.instance.reason = reason
-        else:
-            handler.instance.reason = "Unknown Error"
-
-    def _set_qemu_filenames(self, sysbuild_build_dir):
-        # PID file will be created in the main sysbuild app's build dir
-        self.pid_fn = os.path.join(sysbuild_build_dir, "qemu.pid")
-
-        if os.path.exists(self.pid_fn):
-            os.unlink(self.pid_fn)
-
-        self.log_fn = self.log
-
-    def _create_command(self, sysbuild_build_dir):
-        command = [self.generator_cmd]
-        command += ["-C", sysbuild_build_dir, "run"]
-
-        return command
 
     def _enqueue_char(self, queue):
         while not self.stop_thread:
@@ -1445,10 +1436,7 @@ class QEMUWinHandler(Handler):
                 # take some time.
                 if not timeout_extended or harness.capture_coverage:
                     timeout_extended = True
-                    if harness.capture_coverage:
-                        timeout_time = time.time() + 30
-                    else:
-                        timeout_time = time.time() + 2
+                    timeout_time = self._extend_timeout_on_status(harness)
             line = ""
 
         self.stop_thread = True
@@ -1458,7 +1446,7 @@ class QEMUWinHandler(Handler):
             f"QEMU ({self.pid}) complete with {_status} ({_reason}) "
             f"after {self.execution_time} seconds"
         )
-        self._monitor_update_instance_info(self, _status, _reason)
+        self._thread_update_instance_info(self, _status, _reason)
         self._close_log_file(log_out_fp)
         self._stop_qemu_process(self.pid)
 
@@ -1511,6 +1499,3 @@ class QEMUWinHandler(Handler):
         self._update_instance_info(harness, failure_type=failure_type)
 
         self._final_handle_actions(harness)
-
-    def get_fifo(self):
-        return self.fifo_fn

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import platform
 import re
 import shlex
 import shutil
@@ -36,7 +35,13 @@ from twisterlib.testsuitedata import HarnessConfig
 
 logger = logging.getLogger('twister')
 
-_WINDOWS = platform.system() == 'Windows'
+# pytest ExitCodes that mean the test tool itself errored rather than a test
+# failing. Shared by every report-based harness (see ReportHarness.run).
+REPORT_ERROR_EXIT_CODES = (
+    ExitCode.INTERRUPTED,
+    ExitCode.USAGE_ERROR,
+    ExitCode.INTERNAL_ERROR,
+)
 
 
 class HarnessException(Exception):
@@ -424,7 +429,6 @@ class Script(Harness):
                 continue
             duration = 0.0
             cmd = self._build_script_command(script)
-            logger.debug(f"Running command: {shlex.join(cmd)}")
             try:
                 start_time = time.time()
                 rc = self.run_command(cmd, timeout, env=self._get_env())
@@ -472,6 +476,7 @@ class Script(Harness):
 
     def run_command(self, cmd: list[str], timeout: float, env: dict[str, str] | None = None) -> int:
         """Run a command, stream its output, and return the exit code."""
+        logger.debug(f"Running command: {shlex.join(cmd)}")
         with subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
@@ -547,7 +552,59 @@ class Script(Harness):
             self.instance.add_missing_case_status(TwisterStatus.BLOCK, self.instance.reason)
 
 
-class Pytest(Script):
+class ReportHarness(Script):
+    """Base for harnesses that run an external tool and parse a JUnit report.
+
+    Subclasses set ``report_tool`` (the label used in status/reason messages)
+    and implement generate_command() and _parse_report_file(). run() and
+    _update_test_status() are shared here; Script's own script-oriented
+    implementations are deliberately overridden.
+    """
+    report_tool = 'Report'
+
+    def _get_run_env(self) -> dict[str, str] | None:
+        """Environment for the tool command; None inherits the current env."""
+        return None
+
+    def run(self, timeout):
+        try:
+            cmd = self.generate_command()
+            rc = self.run_command(cmd, timeout, self._get_run_env())
+            if rc in REPORT_ERROR_EXIT_CODES:
+                self.status = TwisterStatus.ERROR
+                self.instance.reason = f'{self.report_tool} error - return code {rc}'
+            self._flush_output_to_log(cmd, rc)
+        except HarnessException as err:
+            logger.error(str(err))
+            self.status = TwisterStatus.FAIL
+            self.instance.reason = str(err)
+        finally:
+            self.instance.record(self.recording)
+            self._update_test_status()
+        return True
+
+    def _update_test_status(self):
+        if self.status == TwisterStatus.NONE:
+            self.instance.testcases = []
+            try:
+                self._parse_report_file(self.report_file)
+            except Exception as e:
+                logger.error(f'Error when parsing file {self.report_file}: {e}')
+                self.status = TwisterStatus.FAIL
+            finally:
+                if not self.instance.testcases:
+                    self.instance.init_cases()
+
+        self.instance.status = self.status if self.status != TwisterStatus.NONE else \
+                               TwisterStatus.FAIL
+        if self.instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
+            self.instance.reason = self.instance.reason or f'{self.report_tool} failed'
+            self.instance.add_missing_case_status(TwisterStatus.BLOCK, self.instance.reason)
+
+
+class Pytest(ReportHarness):
+
+    report_tool = 'Pytest'
 
     def configure(self, instance: TestInstance):
         super().configure(instance)
@@ -555,24 +612,6 @@ class Pytest(Script):
         self.report_file = os.path.join(self.running_dir, 'report.xml')
         self.pytest_config_file = os.path.join(self.running_dir, TWISTER_PYTEST_CONFIG_FILE)
         self.pytest_params = HarnessPytestConfig(platform=instance.platform.name)
-
-    def run(self, timeout):
-        try:
-            cmd = self.generate_command()
-            cmd, env = self._update_command_with_env_dependencies(cmd)
-            rc = self.run_command(cmd, timeout, env)
-            if rc in (ExitCode.INTERRUPTED, ExitCode.USAGE_ERROR, ExitCode.INTERNAL_ERROR):
-                self.status = TwisterStatus.ERROR
-                self.instance.reason = f'Pytest error - return code {rc}'
-            self._flush_output_to_log(cmd, rc)
-        except HarnessException as pytest_exception:
-            logger.error(str(pytest_exception))
-            self.status = TwisterStatus.FAIL
-            self.instance.reason = str(pytest_exception)
-        finally:
-            self.instance.record(self.recording)
-            self._update_test_status()
-        return True
 
     def generate_command(self):
         config: HarnessConfig = self.instance.testsuite.harness_config
@@ -626,6 +665,9 @@ class Pytest(Script):
         # Save test parameters to YAML file for pytest-harness
         self.pytest_params.save_to_yaml(self.pytest_config_file)
 
+        if not PYTEST_PLUGIN_INSTALLED:
+            command.extend(['-p', 'twister_harness.plugin'])
+
         return command
 
     def _get_pytest_device_type(self, handler_name: str) -> str:
@@ -658,53 +700,20 @@ class Pytest(Script):
         # Platform flash_before is intended for boards with USB reset issues during flashing
         self.pytest_params.flash_before = self.instance.platform.flash_before
 
-    @staticmethod
-    def _update_command_with_env_dependencies(cmd):
-        '''
-        If python plugin wasn't installed by pip, then try to indicate it to
-        pytest by update PYTHONPATH and append -p argument to pytest command.
-        '''
+    def _get_run_env(self) -> dict[str, str] | None:
+        """Add the plugin source dir to PYTHONPATH."""
+        if PYTEST_PLUGIN_INSTALLED:
+            return None
         env = os.environ.copy()
-        if not PYTEST_PLUGIN_INSTALLED:
-            cmd.extend(['-p', 'twister_harness.plugin'])
-            pytest_plugin_path = os.path.join(
-                ZEPHYR_BASE,
-                'scripts',
-                'pylib',
-                'pytest-twister-harness',
-                'src'
-            )
-            env['PYTHONPATH'] = pytest_plugin_path + os.pathsep + env.get('PYTHONPATH', '')
-            if _WINDOWS:
-                cmd_append_python_path = f'set PYTHONPATH={pytest_plugin_path};%PYTHONPATH% && '
-            else:
-                cmd_append_python_path = (
-                    f'export PYTHONPATH={pytest_plugin_path}:${{PYTHONPATH}} && '
-                )
+        pytest_plugin_path = os.path.join(
+            ZEPHYR_BASE, 'scripts', 'pylib', 'pytest-twister-harness', 'src'
+        )
+        env['PYTHONPATH'] = pytest_plugin_path + os.pathsep + env.get('PYTHONPATH', '')
+        if os.name == 'nt':
+            logger.debug(f'set "PYTHONPATH={env["PYTHONPATH"]}"')
         else:
-            cmd_append_python_path = ''
-        cmd_to_print = cmd_append_python_path + shlex.join(cmd)
-        logger.debug(f'Running pytest command: {cmd_to_print}')
-
-        return cmd, env
-
-    def _update_test_status(self):
-        if self.status == TwisterStatus.NONE:
-            self.instance.testcases = []
-            try:
-                self._parse_report_file(self.report_file)
-            except Exception as e:
-                logger.error(f'Error when parsing file {self.report_file}: {e}')
-                self.status = TwisterStatus.FAIL
-            finally:
-                if not self.instance.testcases:
-                    self.instance.init_cases()
-
-        self.instance.status = self.status if self.status != TwisterStatus.NONE else \
-                               TwisterStatus.FAIL
-        if self.instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
-            self.instance.reason = self.instance.reason or 'Pytest failed'
-            self.instance.add_missing_case_status(TwisterStatus.BLOCK, self.instance.reason)
+            logger.debug(f"export PYTHONPATH={shlex.quote(env['PYTHONPATH'])}")
+        return env
 
     def _parse_report_file(self, report):
         tree = ET.parse(report)
@@ -1178,28 +1187,13 @@ class Bsim(Script):
         shutil.copy(original_exe_path, new_exe_path)
 
 
-class Ctest(Script):
+class Ctest(ReportHarness):
+
+    report_tool = 'Ctest'
+
     def configure(self, instance: TestInstance):
         super().configure(instance)
         self.report_file = os.path.join(self.running_dir, 'report.xml')
-
-    def run(self, timeout):
-        assert self.instance is not None
-        try:
-            cmd = self.generate_command()
-            rc = self.run_command(cmd, timeout)
-            if rc in (ExitCode.INTERRUPTED, ExitCode.USAGE_ERROR, ExitCode.INTERNAL_ERROR):
-                self.status = TwisterStatus.ERROR
-                self.instance.reason = f'Ctest error - return code {rc}'
-            self._flush_output_to_log(cmd, rc)
-        except Exception as err:
-            logger.error(str(err))
-            self.status = TwisterStatus.FAIL
-            self.instance.reason = str(err)
-        finally:
-            self.instance.record(self.recording)
-            self._update_test_status()
-        return True
 
     def generate_command(self):
         config = self.instance.testsuite.harness_config
@@ -1224,24 +1218,6 @@ class Ctest(Script):
             command.extend(handler.options.ctest_args)
 
         return command
-
-    def _update_test_status(self):
-        if self.status == TwisterStatus.NONE:
-            self.instance.testcases = []
-            try:
-                self._parse_report_file(self.report_file)
-            except Exception as e:
-                logger.error(f'Error when parsing file {self.report_file}: {e}')
-                self.status = TwisterStatus.FAIL
-            finally:
-                if not self.instance.testcases:
-                    self.instance.init_cases()
-
-        self.instance.status = self.status if self.status != TwisterStatus.NONE else \
-                               TwisterStatus.FAIL
-        if self.instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
-            self.instance.reason = self.instance.reason or 'Ctest failed'
-            self.instance.add_missing_case_status(TwisterStatus.BLOCK, self.instance.reason)
 
     def _parse_report_file(self, report):
         suite = junit.JUnitXml.fromfile(report)

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -122,76 +122,99 @@ class XUnitXMLReport:
 
         return (fails, passes, errors, skips)
 
+    @staticmethod
+    def _read_json(json_file: str | Path) -> tuple[dict, str | None]:
+        """Load a Twister JSON report and return (json_data, zephyr_version)."""
+        with open(json_file) as json_results:
+            json_data = json.load(json_results)
+        version = json_data.get('environment', {}).get('zephyr_version', None)
+        return json_data, version
+
+    def _new_testsuite(self, parent, name, version, suite=None):
+        """Create a <testsuite> element with the standard zeroed attributes.
+
+        Its counters are filled in later by _finalize_testsuite(). When
+        `suite` is supplied its platform/architecture are added as extra
+        <property> children (used by the per-suite all-testsuites report).
+        """
+        ele = ET.SubElement(
+            parent,
+            'testsuite',
+            name=name,
+            timestamp=self.timestamp,
+            time="0",
+            tests="0",
+            failures="0",
+            errors="0",
+            skipped="0"
+        )
+        properties = ET.SubElement(ele, 'properties')
+        # Multiple 'property' can be added to 'properties'
+        # differing by name and value
+        ET.SubElement(properties, 'property', name="version", value=version)
+        if suite is not None:
+            ET.SubElement(properties, 'property', name="platform", value=suite.get("platform"))
+            ET.SubElement(properties, 'property', name="architecture", value=suite.get("arch"))
+        return ele
+
+    @staticmethod
+    def _finalize_testsuite(ele, duration, stats):
+        """Write the accumulated time/counter attributes onto a <testsuite>."""
+        fails, passes, errors, skips = stats
+        ele.attrib['time'] = f"{duration}"
+        ele.attrib['failures'] = f"{fails}"
+        ele.attrib['errors'] = f"{errors}"
+        ele.attrib['skipped'] = f"{skips}"
+        ele.attrib['tests'] = f"{errors + passes + fails + skips}"
+
+    def _emit_full_report_testcases(self, ele, suite, ts_status, handler_time, runnable, stats):
+        """Emit one <testcase> per testcase of `suite`, returning updated stats."""
+        classname = Path(suite.get("name", "")).name
+        for tc in suite.get("testcases", []):
+            status = TwisterStatus(tc.get('status'))
+            reason = tc.get('reason', suite.get('reason', 'Unknown'))
+            log = tc.get("log", suite.get("log"))
+
+            tc_duration = tc.get('execution_time', handler_time)
+            name = tc.get("identifier")
+            stats = self.xunit_testcase(
+                ele, name, classname, status, ts_status, reason, tc_duration,
+                runnable, stats, log, True)
+        return stats
+
+    @staticmethod
+    def _write_report(eleTestsuites, filename):
+        ET.indent(eleTestsuites, space="\t", level=0)
+        with open(filename, 'wb') as report:
+            report.write(ET.tostring(eleTestsuites))
+
     def create_with_all_testsuites(self, json_file: str | Path, filename: str | Path) -> None:
         """Generate a report with all testsuites instead of doing this per platform."""
 
-        json_data = {}
-        with open(json_file) as json_results:
-            json_data = json.load(json_results)
-
-        env = json_data.get('environment', {})
-        version = env.get('zephyr_version', None)
-
+        json_data, version = self._read_json(json_file)
         eleTestsuites = ET.Element('testsuites')
         all_suites = json_data.get("testsuites", [])
 
         suites_to_report = all_suites
-            # do not create entry if everything is filtered out
+        # do not create entry if everything is filtered out
         if not self.env.options.detailed_skipped_report:
             suites_to_report = list(
                 filter(lambda d: TwisterStatus(d.get('status')) != TwisterStatus.FILTER, all_suites)
             )
 
         for suite in suites_to_report:
-            duration = 0
-            eleTestsuite = ET.SubElement(
-                eleTestsuites,
-                'testsuite',
-                name=suite.get("name"),
-                time="0",
-                timestamp = self.timestamp,
-                tests="0",
-                failures="0",
-                errors="0",
-                skipped="0"
+            eleTestsuite = self._new_testsuite(
+                eleTestsuites, suite.get("name"), version, suite=suite
             )
-            eleTSPropetries = ET.SubElement(eleTestsuite, 'properties')
-            # Multiple 'property' can be added to 'properties'
-            # differing by name and value
-            ET.SubElement(eleTSPropetries, 'property', name="version", value=version)
-            ET.SubElement(eleTSPropetries, 'property', name="platform", value=suite.get("platform"))
-            ET.SubElement(eleTSPropetries, 'property', name="architecture", value=suite.get("arch"))
-
-            total = 0
-            fails = passes = errors = skips = 0
             handler_time = suite.get('execution_time', 0)
             runnable = suite.get('runnable', 0)
-            duration += float(handler_time)
             ts_status = TwisterStatus(suite.get('status'))
-            classname = Path(suite.get("name","")).name
-            for tc in suite.get("testcases", []):
-                status = TwisterStatus(tc.get('status'))
-                reason = tc.get('reason', suite.get('reason', 'Unknown'))
-                log = tc.get("log", suite.get("log"))
+            stats = self._emit_full_report_testcases(
+                eleTestsuite, suite, ts_status, handler_time, runnable, (0, 0, 0, 0)
+            )
+            self._finalize_testsuite(eleTestsuite, float(handler_time), stats)
 
-                tc_duration = tc.get('execution_time', handler_time)
-                name = tc.get("identifier")
-                fails, passes, errors, skips = self.xunit_testcase(eleTestsuite,
-                    name, classname, status, ts_status, reason, tc_duration, runnable,
-                    (fails, passes, errors, skips), log, True)
-
-            total = errors + passes + fails + skips
-
-            eleTestsuite.attrib['time'] = f"{duration}"
-            eleTestsuite.attrib['failures'] = f"{fails}"
-            eleTestsuite.attrib['errors'] = f"{errors}"
-            eleTestsuite.attrib['skipped'] = f"{skips}"
-            eleTestsuite.attrib['tests'] = f"{total}"
-
-        ET.indent(eleTestsuites, space="\t", level=0)
-        result = ET.tostring(eleTestsuites)
-        with open(filename, 'wb') as report:
-            report.write(result)
+        self._write_report(eleTestsuites, filename)
 
     def create(
         self,
@@ -208,13 +231,7 @@ class XUnitXMLReport:
             logger.info(f"Writing xunit report {filename}...")
             selected = self.selected_platforms
 
-        json_data = {}
-        with open(json_file) as json_results:
-            json_data = json.load(json_results)
-
-        env = json_data.get('environment', {})
-        version = env.get('zephyr_version', None)
-
+        json_data, version = self._read_json(json_file)
         eleTestsuites = ET.Element('testsuites')
         all_suites = json_data.get("testsuites", [])
 
@@ -229,24 +246,9 @@ class XUnitXMLReport:
                     continue
 
             duration = 0
-            eleTestsuite = ET.SubElement(
-                eleTestsuites,
-                'testsuite',
-                name=platform,
-                timestamp=self.timestamp,
-                time="0",
-                tests="0",
-                failures="0",
-                errors="0",
-                skipped="0"
-            )
-            eleTSPropetries = ET.SubElement(eleTestsuite, 'properties')
-            # Multiple 'property' can be added to 'properties'
-            # differing by name and value
-            ET.SubElement(eleTSPropetries, 'property', name="version", value=version)
+            eleTestsuite = self._new_testsuite(eleTestsuites, platform, version)
 
-            total = 0
-            fails = passes = errors = skips = 0
+            stats = (0, 0, 0, 0)
             for ts in suites:
                 handler_time = ts.get('execution_time', 0)
                 runnable = ts.get('runnable', 0)
@@ -260,38 +262,21 @@ class XUnitXMLReport:
                 ):
                     continue
                 if full_report:
-                    classname = Path(ts.get("name","")).name
-                    for tc in ts.get("testcases", []):
-                        status = TwisterStatus(tc.get('status'))
-                        reason = tc.get('reason', ts.get('reason', 'Unknown'))
-                        log = tc.get("log", ts.get("log"))
-
-                        tc_duration = tc.get('execution_time', handler_time)
-                        name = tc.get("identifier")
-                        fails, passes, errors, skips = self.xunit_testcase(eleTestsuite,
-                            name, classname, status, ts_status, reason, tc_duration, runnable,
-                            (fails, passes, errors, skips), log, True)
+                    stats = self._emit_full_report_testcases(
+                        eleTestsuite, ts, ts_status, handler_time, runnable, stats
+                    )
                 else:
                     reason = ts.get('reason', 'Unknown')
                     name = ts.get("name")
                     classname = f"{platform}:{name}"
                     log = ts.get("log")
-                    fails, passes, errors, skips = self.xunit_testcase(eleTestsuite,
-                        name, classname, ts_status, ts_status, reason, handler_time, runnable,
-                        (fails, passes, errors, skips), log, False)
+                    stats = self.xunit_testcase(
+                        eleTestsuite, name, classname, ts_status, ts_status, reason,
+                        handler_time, runnable, stats, log, False)
 
-            total = errors + passes + fails + skips
+            self._finalize_testsuite(eleTestsuite, duration, stats)
 
-            eleTestsuite.attrib['time'] = f"{duration}"
-            eleTestsuite.attrib['failures'] = f"{fails}"
-            eleTestsuite.attrib['errors'] = f"{errors}"
-            eleTestsuite.attrib['skipped'] = f"{skips}"
-            eleTestsuite.attrib['tests'] = f"{total}"
-
-        ET.indent(eleTestsuites, space="\t", level=0)
-        result = ET.tostring(eleTestsuites)
-        with open(filename, 'wb') as report:
-            report.write(result)
+        self._write_report(eleTestsuites, filename)
 
 
 class JsonReport:

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -737,294 +737,298 @@ class ProjectBuilder(FilterBuilder):
             logger.error(f"RuntimeError: {e}")
             traceback.print_exc()
 
+    def _mark_status_error(self, sae, op_label=None):
+        # Shared handling for an illegal status assignment raised by a pipeline
+        # stage: log it, force the instance to ERROR and block its remaining
+        # cases with a uniform reason.
+        logger.error(str(sae))
+        self.instance.status = TwisterStatus.ERROR
+        reason = INCORRECT_STATUS_REASON if op_label is None \
+            else f"{INCORRECT_STATUS_REASON} on {op_label}"
+        self.instance.reason = reason
+        self.instance.add_missing_case_status(TwisterStatus.BLOCK, reason)
+
+    # Maps a pipeline op name to the ProjectBuilder method that runs it. Each
+    # handler computes the next op, enqueues follow-up work and owns its own
+    # error handling (via _mark_status_error).
+    _PIPELINE_OPS = {
+        "filter": "_op_filter",
+        "cmake": "_op_cmake",
+        "build": "_op_build",
+        "post_build": "_op_post_build",
+        "gather_metrics": "_op_gather_metrics",
+        "run": "_op_run",
+        "coverage": "_op_coverage",
+        "report": "_op_report",
+        "cleanup": "_op_cleanup",
+    }
+
     def process(self, processing_queue: deque, processing_ready: dict[str, TestInstance],
                 message, lock, results: ExecutionCounter):
-        next_op = None
-        additionals = {}
-
         op = message.get('op')
         options = self.options
         if not logger.handlers:
             setup_logging(options.outdir, options.log_file, options.log_level, options.timestamps)
         self.instance.setup_handler(self.env)
 
-        if op == "filter":
-            try:
-                ret = self.cmake(filter_stages=self.instance.filter_stages)
-                if self.instance.status in [TwisterStatus.FAIL, TwisterStatus.ERROR]:
+        handler_name = self._PIPELINE_OPS.get(op)
+        if handler_name is not None:
+            getattr(self, handler_name)(
+                processing_queue, processing_ready, message, lock, results
+            )
+
+    def _op_filter(self, processing_queue, processing_ready, message, lock, results):
+        next_op = None
+        try:
+            ret = self.cmake(filter_stages=self.instance.filter_stages)
+            if self.instance.status in [TwisterStatus.FAIL, TwisterStatus.ERROR]:
+                next_op = 'report'
+            else:
+                # Here we check the dt/kconfig filter results coming from running cmake
+                if self.instance.name in ret['filter'] and ret['filter'][self.instance.name]:
+                    logger.debug(f"filtering {self.instance.name}")
+                    self.instance.status = TwisterStatus.FILTER
+                    self.instance.reason = RUNTIME_FILTER_REASON
+                    results.filtered_runtime_increment()
+                    self.instance.add_missing_case_status(TwisterStatus.FILTER)
                     next_op = 'report'
                 else:
-                    # Here we check the dt/kconfig filter results coming from running cmake
-                    if self.instance.name in ret['filter'] and ret['filter'][self.instance.name]:
-                        logger.debug(f"filtering {self.instance.name}")
-                        self.instance.status = TwisterStatus.FILTER
-                        self.instance.reason = RUNTIME_FILTER_REASON
-                        results.filtered_runtime_increment()
-                        self.instance.add_missing_case_status(TwisterStatus.FILTER)
-                        next_op = 'report'
-                    else:
-                        next_op = 'cmake'
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
-                self.instance.status = TwisterStatus.ERROR
-                reason = INCORRECT_STATUS_REASON
-                self.instance.reason = reason
-                self.instance.add_missing_case_status(TwisterStatus.BLOCK, reason)
-                next_op = 'report'
-            finally:
-                self._add_to_processing_queue(processing_queue, next_op)
+                    next_op = 'cmake'
+        except StatusAttributeError as sae:
+            self._mark_status_error(sae)
+            next_op = 'report'
+        finally:
+            self._add_to_processing_queue(processing_queue, next_op)
 
-        # The build process, call cmake and build with configured generator
-        elif op == "cmake":
-            try:
-                ret = self.cmake()
-                if self.instance.status in [TwisterStatus.FAIL, TwisterStatus.ERROR]:
-                    next_op = 'report'
-                elif self.options.cmake_only:
-                    if self.instance.status == TwisterStatus.NONE:
-                        logger.debug(f"CMake only: PASS {self.instance.name}")
-                        self.instance.status = TwisterStatus.NOTRUN
-                        self.instance.add_missing_case_status(TwisterStatus.NOTRUN, 'CMake only')
+    # The build process, call cmake and build with configured generator
+    def _op_cmake(self, processing_queue, processing_ready, message, lock, results):
+        next_op = None
+        try:
+            ret = self.cmake()
+            if self.instance.status in [TwisterStatus.FAIL, TwisterStatus.ERROR]:
+                next_op = 'report'
+            elif self.options.cmake_only:
+                if self.instance.status == TwisterStatus.NONE:
+                    logger.debug(f"CMake only: PASS {self.instance.name}")
+                    self.instance.status = TwisterStatus.NOTRUN
+                    self.instance.add_missing_case_status(TwisterStatus.NOTRUN, 'CMake only')
+                next_op = 'report'
+            else:
+                # Here we check the runtime filter results coming from running cmake
+                if self.instance.name in ret['filter'] and ret['filter'][self.instance.name]:
+                    logger.debug(f"filtering {self.instance.name}")
+                    self.instance.status = TwisterStatus.FILTER
+                    self.instance.reason = RUNTIME_FILTER_REASON
+                    results.filtered_runtime_increment()
+                    self.instance.add_missing_case_status(TwisterStatus.FILTER)
                     next_op = 'report'
                 else:
-                    # Here we check the runtime filter results coming from running cmake
-                    if self.instance.name in ret['filter'] and ret['filter'][self.instance.name]:
-                        logger.debug(f"filtering {self.instance.name}")
-                        self.instance.status = TwisterStatus.FILTER
-                        self.instance.reason = RUNTIME_FILTER_REASON
-                        results.filtered_runtime_increment()
-                        self.instance.add_missing_case_status(TwisterStatus.FILTER)
-                        next_op = 'report'
-                    else:
-                        next_op = 'build'
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
+                    next_op = 'build'
+        except StatusAttributeError as sae:
+            self._mark_status_error(sae)
+            next_op = 'report'
+        finally:
+            self._add_to_processing_queue(processing_queue, next_op)
+
+    def _op_build(self, processing_queue, processing_ready, message, lock, results):
+        next_op = None
+        try:
+            logger.debug(f"build test: {self.instance.name}")
+            ret = self.build()
+            if not ret:
                 self.instance.status = TwisterStatus.ERROR
-                reason = INCORRECT_STATUS_REASON
-                self.instance.reason = reason
-                self.instance.add_missing_case_status(TwisterStatus.BLOCK, reason)
+                self.instance.reason = "Build Failure"
                 next_op = 'report'
-            finally:
-                self._add_to_processing_queue(processing_queue, next_op)
+            else:
+                # Count skipped cases during build, for example
+                # due to ram/rom overflow.
+                if  self.instance.status == TwisterStatus.SKIP:
+                    results.skipped_increment()
+                    self.instance.add_missing_case_status(
+                        TwisterStatus.SKIP,
+                        self.instance.reason
+                    )
 
-        elif op == "build":
-            try:
-                logger.debug(f"build test: {self.instance.name}")
-                ret = self.build()
-                if not ret:
-                    self.instance.status = TwisterStatus.ERROR
-                    self.instance.reason = "Build Failure"
-                    next_op = 'report'
-                else:
-                    # Count skipped cases during build, for example
-                    # due to ram/rom overflow.
-                    if  self.instance.status == TwisterStatus.SKIP:
-                        results.skipped_increment()
-                        self.instance.add_missing_case_status(
-                            TwisterStatus.SKIP,
-                            self.instance.reason
-                        )
-
-                    if ret.get('returncode', 1) > 0:
-                        self.instance.add_missing_case_status(
-                            TwisterStatus.BLOCK,
-                            self.instance.reason
-                        )
-                        next_op = 'report'
-                    else:
-                        if self.instance.testsuite.harness in ['ztest', 'test']:
-                            logger.debug(
-                                f"Determine test cases for test instance: {self.instance.name}"
-                            )
-                            try:
-                                self.determine_testcases(results)
-                                next_op = 'post_build'
-                            except BuildError as e:
-                                logger.error(str(e))
-                                self.instance.status = TwisterStatus.ERROR
-                                self.instance.reason = str(e)
-                                next_op = 'report'
-                        else:
-                            next_op = 'post_build'
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
-                self.instance.status = TwisterStatus.ERROR
-                reason = INCORRECT_STATUS_REASON
-                self.instance.reason = reason
-                self.instance.add_missing_case_status(TwisterStatus.BLOCK, reason)
-                next_op = 'report'
-            finally:
-                self._add_to_processing_queue(processing_queue, next_op)
-
-        # Run post-build checks on the freshly built artifacts
-        elif op == "post_build":
-            try:
-                ret = self.post_build()
                 if ret.get('returncode', 1) > 0:
-                    self.instance.status = TwisterStatus.ERROR
-                    self.instance.reason = ret.get('reason', 'Post-build check failure')
                     self.instance.add_missing_case_status(
                         TwisterStatus.BLOCK,
                         self.instance.reason
                     )
                     next_op = 'report'
                 else:
-                    next_op = 'gather_metrics'
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
-                self.instance.status = TwisterStatus.ERROR
-                reason = INCORRECT_STATUS_REASON
-                self.instance.reason = reason
-                self.instance.add_missing_case_status(TwisterStatus.BLOCK, reason)
-                next_op = 'report'
-            finally:
-                self._add_to_processing_queue(processing_queue, next_op)
-
-        elif op == "gather_metrics":
-            try:
-                ret = self.gather_metrics(self.instance)
-                if not ret or ret.get('returncode', 1) > 0:
-                    self.instance.status = TwisterStatus.ERROR
-                    self.instance.reason = "Build Failure at gather_metrics."
-                    next_op = 'report'
-                elif self.instance.run and self.instance.handler.ready:
-                    next_op = 'run'
-                else:
-                    if self.instance.status == TwisterStatus.NOTRUN:
-                        run_conditions =  (
-                            f"(run:{self.instance.run},"
-                            f" handler.ready:{self.instance.handler.ready})"
+                    if self.instance.testsuite.harness in ['ztest', 'test']:
+                        logger.debug(
+                            f"Determine test cases for test instance: {self.instance.name}"
                         )
-                        logger.debug(f"Instance {self.instance.name} can't run {run_conditions}")
-                        self.instance.add_missing_case_status(
-                            TwisterStatus.NOTRUN,
-                            "Nowhere to run"
-                        )
-                    next_op = 'report'
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
+                        try:
+                            self.determine_testcases(results)
+                            next_op = 'post_build'
+                        except BuildError as e:
+                            logger.error(str(e))
+                            self.instance.status = TwisterStatus.ERROR
+                            self.instance.reason = str(e)
+                            next_op = 'report'
+                    else:
+                        next_op = 'post_build'
+        except StatusAttributeError as sae:
+            self._mark_status_error(sae)
+            next_op = 'report'
+        finally:
+            self._add_to_processing_queue(processing_queue, next_op)
+
+    # Run post-build checks on the freshly built artifacts
+    def _op_post_build(self, processing_queue, processing_ready, message, lock, results):
+        next_op = None
+        try:
+            ret = self.post_build()
+            if ret.get('returncode', 1) > 0:
                 self.instance.status = TwisterStatus.ERROR
-                reason = INCORRECT_STATUS_REASON
-                self.instance.reason = reason
-                self.instance.add_missing_case_status(TwisterStatus.BLOCK, reason)
+                self.instance.reason = ret.get('reason', 'Post-build check failure')
+                self.instance.add_missing_case_status(
+                    TwisterStatus.BLOCK,
+                    self.instance.reason
+                )
                 next_op = 'report'
-            finally:
-                self._add_to_processing_queue(processing_queue, next_op)
+            else:
+                next_op = 'gather_metrics'
+        except StatusAttributeError as sae:
+            self._mark_status_error(sae)
+            next_op = 'report'
+        finally:
+            self._add_to_processing_queue(processing_queue, next_op)
 
-        # Run the generated binary using one of the supported handlers
-        elif op == "run":
-            processing_queue_updated = False
-            try:
-                if self.ensure_required_apps_ready(processing_ready):
-                    with self.reserve_hardware() as ready_to_run:
-                        if ready_to_run:
-                            logger.debug(f"run test: {self.instance.name}")
-                            self.run()
-                            logger.debug(f"run status: {self.instance.name} {self.instance.status}")
-
-                # to make it work with pickle
-                self.instance.handler.thread = None
-
-                next_op = "coverage" if self.options.coverage else "report"
-                additionals = {
-                    "status": self.instance.status,
-                    "reason": self.instance.reason
-                }
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
+    def _op_gather_metrics(self, processing_queue, processing_ready, message, lock, results):
+        next_op = None
+        try:
+            ret = self.gather_metrics(self.instance)
+            if not ret or ret.get('returncode', 1) > 0:
                 self.instance.status = TwisterStatus.ERROR
-                reason = INCORRECT_STATUS_REASON
-                self.instance.reason = reason
-                self.instance.add_missing_case_status(TwisterStatus.BLOCK, reason)
+                self.instance.reason = "Build Failure at gather_metrics."
                 next_op = 'report'
-                additionals = {}
-            except (NoDeviceAvailableException, NoRequiredApplicationNotReadyException):
-                if processing_ready.get(self.instance.name) is None:
-                    # Register this instance as ready (build succeeded) so that other instances
-                    # listing it as a required application can unblock and proceed.
-                    # This also handles mutual dependencies between instances,
-                    # letting the pair resolve without deadlock.
-                    # The entry will be overwritten with the final state in the 'report' stage.
-                    with lock:
-                        processing_ready.update({self.instance.name: self.instance})
-
-                # no device available to run the test or required application not ready,
-                # add the task back to the pipeline to process it later
-                processing_queue.appendleft(message)
-                processing_queue_updated = True
-                # to avoid busy waiting
-                time.sleep(1)
-            finally:
-                if not processing_queue_updated:
-                    self._add_to_processing_queue(processing_queue, next_op, additionals)
-
-        # Run per-instance code coverage
-        elif op == "coverage":
-            try:
-                logger.debug(f"Run coverage for '{self.instance.name}'")
-                self.instance.coverage_status, self.instance.coverage = \
-                        run_coverage_instance(self.options, self.instance)
+            elif self.instance.run and self.instance.handler.ready:
+                next_op = 'run'
+            else:
+                if self.instance.status == TwisterStatus.NOTRUN:
+                    run_conditions =  (
+                        f"(run:{self.instance.run},"
+                        f" handler.ready:{self.instance.handler.ready})"
+                    )
+                    logger.debug(f"Instance {self.instance.name} can't run {run_conditions}")
+                    self.instance.add_missing_case_status(
+                        TwisterStatus.NOTRUN,
+                        "Nowhere to run"
+                    )
                 next_op = 'report'
-                additionals = {
-                    "status": self.instance.status,
-                    "reason": self.instance.reason
-                }
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
-                self.instance.status = TwisterStatus.ERROR
-                reason = f"{INCORRECT_STATUS_REASON} on {op}"
-                self.instance.reason = reason
-                self.instance.add_missing_case_status(TwisterStatus.BLOCK, reason)
-                next_op = 'report'
-                additionals = {}
-            finally:
-                self._add_to_processing_queue(processing_queue, next_op, additionals)
+        except StatusAttributeError as sae:
+            self._mark_status_error(sae)
+            next_op = 'report'
+        finally:
+            self._add_to_processing_queue(processing_queue, next_op)
 
-        # Report results and output progress to screen
-        elif op == "report":
-            try:
+    # Run the generated binary using one of the supported handlers
+    def _op_run(self, processing_queue, processing_ready, message, lock, results):
+        next_op = None
+        additionals = {}
+        processing_queue_updated = False
+        try:
+            if self.ensure_required_apps_ready(processing_ready):
+                with self.reserve_hardware() as ready_to_run:
+                    if ready_to_run:
+                        logger.debug(f"run test: {self.instance.name}")
+                        self.run()
+                        logger.debug(f"run status: {self.instance.name} {self.instance.status}")
+
+            # to make it work with pickle
+            self.instance.handler.thread = None
+
+            next_op = "coverage" if self.options.coverage else "report"
+            additionals = {
+                "status": self.instance.status,
+                "reason": self.instance.reason
+            }
+        except StatusAttributeError as sae:
+            self._mark_status_error(sae)
+            next_op = 'report'
+            additionals = {}
+        except (NoDeviceAvailableException, NoRequiredApplicationNotReadyException):
+            if processing_ready.get(self.instance.name) is None:
+                # Register this instance as ready (build succeeded) so that other instances
+                # listing it as a required application can unblock and proceed.
+                # This also handles mutual dependencies between instances,
+                # letting the pair resolve without deadlock.
+                # The entry will be overwritten with the final state in the 'report' stage.
                 with lock:
                     processing_ready.update({self.instance.name: self.instance})
-                    self.report_out(results)
 
-                if not self.options.coverage:
-                    if self.options.prep_artifacts_for_testing:
-                        next_op = 'cleanup'
-                        additionals = {"mode": "device"}
-                    elif self.options.runtime_artifact_cleanup == "pass" and \
-                        self.instance.status in [TwisterStatus.PASS, TwisterStatus.NOTRUN]:
-                        next_op = 'cleanup'
-                        additionals = {"mode": "passed"}
-                    elif self.options.runtime_artifact_cleanup == "all":
-                        next_op = 'cleanup'
-                        additionals = {"mode": "all"}
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
-                self.instance.status = TwisterStatus.ERROR
-                reason = INCORRECT_STATUS_REASON
-                self.instance.reason = reason
-                self.instance.add_missing_case_status(TwisterStatus.BLOCK, reason)
-                next_op = None
-                additionals = {}
-            finally:
+            # no device available to run the test or required application not ready,
+            # add the task back to the pipeline to process it later
+            processing_queue.appendleft(message)
+            processing_queue_updated = True
+            # to avoid busy waiting
+            time.sleep(1)
+        finally:
+            if not processing_queue_updated:
                 self._add_to_processing_queue(processing_queue, next_op, additionals)
 
-        elif op == "cleanup":
-            try:
-                mode = message.get("mode")
-                if mode == "device":
-                    self.cleanup_device_testing_artifacts()
-                elif (
-                    mode == "passed"
-                    or (mode == "all" and self.instance.reason != "CMake build failure")
-                ):
-                    self.cleanup_artifacts()
-            except StatusAttributeError as sae:
-                logger.error(str(sae))
-                self.instance.status = TwisterStatus.ERROR
-                reason = INCORRECT_STATUS_REASON
-                self.instance.reason = reason
-                self.instance.add_missing_case_status(TwisterStatus.BLOCK, reason)
+    # Run per-instance code coverage
+    def _op_coverage(self, processing_queue, processing_ready, message, lock, results):
+        next_op = None
+        additionals = {}
+        try:
+            logger.debug(f"Run coverage for '{self.instance.name}'")
+            self.instance.coverage_status, self.instance.coverage = \
+                    run_coverage_instance(self.options, self.instance)
+            next_op = 'report'
+            additionals = {
+                "status": self.instance.status,
+                "reason": self.instance.reason
+            }
+        except StatusAttributeError as sae:
+            self._mark_status_error(sae, op_label='coverage')
+            next_op = 'report'
+            additionals = {}
+        finally:
+            self._add_to_processing_queue(processing_queue, next_op, additionals)
+
+    # Report results and output progress to screen
+    def _op_report(self, processing_queue, processing_ready, message, lock, results):
+        next_op = None
+        additionals = {}
+        try:
+            with lock:
+                processing_ready.update({self.instance.name: self.instance})
+                self.report_out(results)
+
+            if not self.options.coverage:
+                if self.options.prep_artifacts_for_testing:
+                    next_op = 'cleanup'
+                    additionals = {"mode": "device"}
+                elif self.options.runtime_artifact_cleanup == "pass" and \
+                    self.instance.status in [TwisterStatus.PASS, TwisterStatus.NOTRUN]:
+                    next_op = 'cleanup'
+                    additionals = {"mode": "passed"}
+                elif self.options.runtime_artifact_cleanup == "all":
+                    next_op = 'cleanup'
+                    additionals = {"mode": "all"}
+        except StatusAttributeError as sae:
+            self._mark_status_error(sae)
+            next_op = None
+            additionals = {}
+        finally:
+            self._add_to_processing_queue(processing_queue, next_op, additionals)
+
+    def _op_cleanup(self, processing_queue, processing_ready, message, lock, results):
+        try:
+            mode = message.get("mode")
+            if mode == "device":
+                self.cleanup_device_testing_artifacts()
+            elif (
+                mode == "passed"
+                or (mode == "all" and self.instance.reason != "CMake build failure")
+            ):
+                self.cleanup_artifacts()
+        except StatusAttributeError as sae:
+            self._mark_status_error(sae)
 
     def demangle(self, symbol_name):
         if symbol_name[:2] == '_Z':

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -48,6 +48,14 @@ from twisterlib.testsuite import TestSuite, scan_testsuite_path
 
 logger = logging.getLogger('twister')
 
+# Directory holding twister's YAML schemas.
+TWISTER_SCHEMA_DIR = os.path.join(ZEPHYR_BASE, "scripts", "schemas", "twister")
+
+# Filter reason set for a required application that built but cannot run on the
+# selected device. apply_changes_for_required_applications() matches on it, so
+# the producer and consumer must agree on the exact string.
+NOT_RUNNABLE_ON_DEVICE_REASON = "Not runnable on device"
+
 
 class Filters:
     # platform keys
@@ -78,13 +86,7 @@ class TestLevel:
 
 class TestConfiguration:
     __test__ = False
-    tc_schema_path = os.path.join(
-        ZEPHYR_BASE,
-        "scripts",
-        "schemas",
-        "twister",
-        "test-config-schema.yaml"
-    )
+    tc_schema_path = os.path.join(TWISTER_SCHEMA_DIR, "test-config-schema.yaml")
 
     def __init__(self, config_file):
         self.test_config = None
@@ -152,15 +154,13 @@ class TestPlan:
     dt_re = re.compile('([A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
 
     suite_schema = scl.yaml_load(
-        os.path.join(ZEPHYR_BASE,
-                     "scripts", "schemas", "twister", "testsuite-schema.yaml"))
+        os.path.join(TWISTER_SCHEMA_DIR, "testsuite-schema.yaml"))
     # Fill in the per-sidecar `sidecar_config` schema from the registered
     # sidecars, so adding a sidecar needs no change to the schema file. The file
     # keeps a permissive placeholder for consumers that load it directly.
     suite_schema['$defs']['scenario']['properties']['sidecar_config'] = sidecar_config_schema()
     quarantine_schema = scl.yaml_load(
-        os.path.join(ZEPHYR_BASE,
-                     "scripts", "schemas", "twister", "quarantine-schema.yaml"))
+        os.path.join(TWISTER_SCHEMA_DIR, "quarantine-schema.yaml"))
 
     TEST_DEFINITION_FILENAME = [
             'testcase.yaml',
@@ -259,6 +259,21 @@ class TestPlan:
         level = next((lvl for lvl in self.levels if lvl.name == name), None)
         return level
 
+    def _refresh_selected_platforms(self):
+        """Recompute selected_platforms from the platforms of current instances."""
+        self.selected_platforms = set(p.platform.name for p in self.instances.values())
+
+    def _create_overlay(self, instance):
+        """Create the sanitizer/coverage overlay for an instance from options."""
+        instance.create_overlay(
+            instance.platform,
+            self.options.enable_asan,
+            self.options.enable_ubsan,
+            self.options.enable_coverage,
+            self.options.coverage_platform,
+            self.options.coverage_per_test
+        )
+
     def load(self):
 
         if self.options.report_suffix:
@@ -271,10 +286,10 @@ class TestPlan:
 
         if self.options.only_failed or self.options.report_summary is not None:
             self.load_from_file(last_run)
-            self.selected_platforms = set(p.platform.name for p in self.instances.values())
+            self._refresh_selected_platforms()
         elif self.options.load_tests:
             self.load_from_file(self.options.load_tests)
-            self.selected_platforms = set(p.platform.name for p in self.instances.values())
+            self._refresh_selected_platforms()
         elif self.options.test_only:
             # Get list of connected hardware and filter tests to only be run on connected hardware.
             # If the platform does not exist in the hardware map or was not specified by --platform,
@@ -295,7 +310,7 @@ class TestPlan:
                         connected_list.remove(excluded)
 
             self.load_from_file(last_run, filter_platform=connected_list)
-            self.selected_platforms = set(p.platform.name for p in self.instances.values())
+            self._refresh_selected_platforms()
         else:
             self.apply_filters()
 
@@ -818,13 +833,7 @@ class TestPlan:
                             if tc.get('log'):
                                 case.output = tc.get('log')
 
-                    instance.create_overlay(platform,
-                                            self.options.enable_asan,
-                                            self.options.enable_ubsan,
-                                            self.options.enable_coverage,
-                                            self.options.coverage_platform,
-                                            self.options.coverage_per_test
-                                            )
+                    self._create_overlay(instance)
                     instance_list.append(instance)
                 self.add_instances(instance_list)
         except FileNotFoundError as e:
@@ -1033,7 +1042,7 @@ class TestPlan:
                             instance.add_filter("Not part of requested test plan", Filters.TESTPLAN)
 
                 if (runnable or not ts.build) and not instance.run:
-                    instance.add_filter("Not runnable on device", Filters.CMD_LINE)
+                    instance.add_filter(NOT_RUNNABLE_ON_DEVICE_REASON, Filters.CMD_LINE)
 
                 if (
                     self.options.integration
@@ -1308,14 +1317,9 @@ class TestPlan:
                 continue
             # set run_id for each unfiltered instance
             case.setup_run_id()
-            case.create_overlay(case.platform,
-                                self.options.enable_asan,
-                                self.options.enable_ubsan,
-                                self.options.enable_coverage,
-                                self.options.coverage_platform,
-                                self.options.coverage_per_test)
+            self._create_overlay(case)
 
-        self.selected_platforms = set(p.platform.name for p in self.instances.values())
+        self._refresh_selected_platforms()
 
         filtered_and_skipped_instances = list(
             filter(
@@ -1443,7 +1447,7 @@ class TestPlan:
                         self.options.device_testing
                         and not req_instance.run
                         and len(req_instance.filters) == 1
-                        and req_instance.reason == "Not runnable on device"
+                        and req_instance.reason == NOT_RUNNABLE_ON_DEVICE_REASON
                     ):
                         # clear status flag to build required application
                         self.instances[req_instance.name].status = TwisterStatus.NONE

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -562,16 +562,15 @@ def test_pytest__generate_parameters_for_hardware(tmp_path):
     assert pytest_test.pytest_params.flash_command == "flash_command"
 
 
-def test_pytest__update_command_with_env_dependencies():
-    cmd = ["cmd"]
+def test_pytest_get_run_env():
     pytest_test = Pytest()
-    mock.patch.object(Pytest, "PYTEST_PLUGIN_INSTALLED", False)
 
     # Act
-    result_cmd, _ = pytest_test._update_command_with_env_dependencies(cmd)
+    with mock.patch("twisterlib.harness.PYTEST_PLUGIN_INSTALLED", False):
+        env = pytest_test._get_run_env()
 
     # Assert
-    assert result_cmd == ["cmd", "-p", "twister_harness.plugin"]
+    assert "pytest-twister-harness" in env["PYTHONPATH"]
 
 
 def test_pytest_run(tmp_path, caplog):


### PR DESCRIPTION
- **twister: share run/status logic across report-based harnesses**
- **twister: extract QEMUHandlerBase for the shared QEMU handler logic**
- **twister: de-duplicate XUnitXMLReport.create paths**
- **twister: turn ProjectBuilder.process into a dispatch table**
- **twister: cache module scan and fold the *_roots loop**
- **twister: de-duplicate helpers and literals in TestPlan**
