### PR TITLE
tests: kernel: sched: schedule_api: replace spin_for_ms with k_busy_wait

### DIFF
--- a/tests/kernel/sched/schedule_api/src/main.c
+++ b/tests/kernel/sched/schedule_api/src/main.c
@@ -13,18 +13,6 @@ K_THREAD_STACK_ARRAY_DEFINE(tstacks, MAX_NUM_THREAD, STACK_SIZE);
 /* Not in header file intentionally, see #16760 */
 K_THREAD_STACK_DECLARE(ustack, STACK_SIZE);
 
-void spin_for_ms(int ms)
-{
-	uint32_t t32 = k_uptime_get_32();
-
-	while (k_uptime_get_32() - t32 < ms) {
-		/* In the posix arch, a busy loop takes no time, so
-		 * let's make it take some
-		 */
-		Z_SPIN_DELAY(50);
-	}
-}
-
 static void *threads_scheduling_tests_setup(void)
 {
 #ifdef CONFIG_USERSPACE

--- a/tests/kernel/sched/schedule_api/src/test_sched.h
+++ b/tests/kernel/sched/schedule_api/src/test_sched.h
@@ -24,8 +24,6 @@ struct thread_data {
 	int executed;
 };
 
-void spin_for_ms(int ticks);
-
 void test_priority_cooperative(void);
 void test_priority_preemptible(void);
 void test_priority_preemptible_wait_prio(void);

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -67,7 +67,7 @@ static void thread_time_slice(void *p1, void *p2, void *p3)
 	/* Keep this thread busy past one slice so the slicer fires and
 	 * hands the CPU to the next thread.
 	 */
-	spin_for_ms(BUSY_MS);
+	k_busy_wait(BUSY_MS * USEC_PER_MSEC);
 	k_sem_give(&sema);
 }
 

--- a/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_slice_scheduling.c
@@ -74,7 +74,7 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 		 * even though, when timeslice used up the next thread
 		 * should be scheduled in.
 		 */
-		spin_for_ms(BUSY_MS);
+		k_busy_wait(BUSY_MS * USEC_PER_MSEC);
 	}
 }
 
@@ -180,7 +180,7 @@ ZTEST(threads_scheduling, test_slice_scheduling)
 		 * even though, when timeslice used up the next thread
 		 * should be scheduled in.
 		 */
-		spin_for_ms(BUSY_MS);
+		k_busy_wait(BUSY_MS * USEC_PER_MSEC);
 
 		/* all threads should have run by now */
 		ticks_delta(&elapsed_slice);


### PR DESCRIPTION

  ### Background

  spin_for_ms() was introduced in #13916 to fix a test failure on nRF52
  (issue #11721). At the time, a previous simplification had replaced the
  per-platform spinning logic with a bare k_busy_wait() call, which broke
  tick alignment on nRF52. The fix refactored all spinning into a single
  spin_for_ms() utility that polls k_uptime_get_32() — with a separate
  k_busy_wait() path for x86_64/QEMU, which had a known HPET interrupt-
  drop bug.

  A later cleanup (700a251) removed the x86_64/QEMU special-case, leaving
  spin_for_ms() as a plain k_uptime_get_32() polling loop on all
  platforms.

  ### Problem

  I hit test failures in this suite on rtl87x2g (Realtek, KM4 core (Cortex-M33 compatiable)
  running a 32 kHz external SysTick). The root cause is a hardware bug in
  the KM4 SysTick IP: COUNTFLAG is asserted one cycle early — when VAL
  reaches 1 rather than 0. This causes elapsed() in cortex_m_systick.c
  to misread COUNTFLAG, incrementing overflow_cyc prematurely and making
  the software clock run fast.

  The consequence for this test: spin_for_ms(220) returns far too early,
  the time-slice timer never gets a chance to fire, round-robin scheduling
  breaks down, and the test ends in a kernel panic.

  We work around this at the platform level by setting
  CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT and redirecting k_busy_wait() to the
  HAL's own delay routine, which does not rely on the SysTick counter.
  spin_for_ms() silently bypasses that fix because it calls
  k_uptime_get_32() directly instead of going through k_busy_wait().

  ### Proposed change

  Replace spin_for_ms(BUSY_MS) with k_busy_wait(BUSY_MS * USEC_PER_MSEC)
  so that each architecture's registered busy-wait implementation is used,
  and remove the now-unused spin_for_ms() definition and declaration.

  ### Question to the community

  I'm aware that spin_for_ms() was introduced deliberately to restore
  tick-boundary alignment on nRF52, and I'm not sure whether replacing it
  with k_busy_wait() would regress that platform or others that depend on
  the uptime-polling behaviour.

  Could maintainers and nRF52/Nordic folks comment on whether this change
  is safe for their platforms? If k_busy_wait() is not a suitable
  replacement here, I'm happy to instead add a CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT
  guard inside spin_for_ms() itself, so platforms with a custom hook use
  it while others retain the existing uptime-polling path.

  Any feedback welcome.
