### PR TITLE
boards: seeed: xiao_nrf54l15: enable OpenOCD flash verification

### DIFF
--- a/boards/seeed/xiao_nrf54l15/board.cmake
+++ b/boards/seeed/xiao_nrf54l15/board.cmake
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_SOC_NRF54L15_CPUAPP)
-  board_runner_args(openocd "--cmd-load=nrf54l-load" "--cmd-erase=nrf54l_mass_erase" -c "targets nrf54l.cpu")
+  board_runner_args(openocd "--cmd-load=nrf54l-load" "--cmd-erase=nrf54l_mass_erase"
+                    "--cmd-verify=verify_image" -c "targets nrf54l.cpu")
   board_runner_args(jlink "--device=nRF54L15_M33" "--speed=4000")
 elseif(CONFIG_SOC_NRF54L15_CPUFLPR)
   board_runner_args(openocd "--cmd-load=nrf54l-load" "--cmd-erase=nrf54l_mass_erase" -c "targets nrf54l.aux")


### PR DESCRIPTION
Enable `west flash --runner openocd --verify` for the CPUAPP target.

The board already supplies a custom OpenOCD load command for nRF54L15 RRAM programming. The OpenOCD runner requires a board-specific verify command for non-ELF images; configuring its built-in `verify_image` command enables post-flash verification.
