### PR TITLE
hostap: fix FT-PSK security type shown as UNKNOWN

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -448,6 +448,7 @@ enum wifi_security_type wpas_key_mgmt_to_zephyr(bool is_hapd, void *config, int 
 	case WPA_KEY_MGMT_SAE | WPA_KEY_MGMT_PSK_SHA256:
 	case WPA_KEY_MGMT_SAE | WPA_KEY_MGMT_PSK_SHA256 | WPA_KEY_MGMT_PSK:
 		return WIFI_SECURITY_TYPE_WPA_AUTO_PERSONAL;
+	case WPA_KEY_MGMT_PSK | WPA_KEY_MGMT_FT_PSK:
 	case WPA_KEY_MGMT_FT_PSK:
 		return WIFI_SECURITY_TYPE_FT_PSK;
 	case WPA_KEY_MGMT_FT_SAE:


### PR DESCRIPTION
When a user connects to an AP that advertises both PSK and FT-PSK key
management, wpa_supplicant sets ssid->key_mgmt to
WPA_KEY_MGMT_PSK | WPA_KEY_MGMT_FT_PSK (0x42). The existing switch in
wpas_key_mgmt_to_zephyr() has no matching case for this combined bitmask,
causing wifi status to report the security type as UNKNOWN.

This patch adds a case for the combined bitmask that falls through to
return WIFI_SECURITY_TYPE_FT_PSK, correctly reflecting the active
security mode when FT-PSK is negotiated.
