### PR TITLE
[Backport v3.7-branch] drivers: watchdog: stm32: fix WWDG EWI callback never invoked

### DIFF
--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -265,7 +265,9 @@ void wwdg_stm32_isr(const struct device *dev)
 	if (LL_WWDG_IsEnabledIT_EWKUP(wwdg)) {
 		if (LL_WWDG_IsActiveFlag_EWKUP(wwdg)) {
 			LL_WWDG_ClearFlag_EWKUP(wwdg);
-			data->callback(dev, 0);
+			if (data->callback != NULL) {
+				data->callback(dev, 0);
+			}
 		}
 	}
 }

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -70,7 +70,7 @@
 #define WDT_NODE DT_ALIAS(watchdog0)
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_window_watchdog)
 #define WDT_NODE DT_INST(0, st_stm32_window_watchdog)
-#define TIMEOUTS 0
+#define TIMEOUTS 1
 #define WDT_TEST_MAX_WINDOW 200
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_watchdog)
 #define WDT_NODE DT_INST(0, st_stm32_watchdog)

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -27,6 +27,7 @@ tests:
       - nucleo_f429zi
       - nucleo_f746zg
       - nucleo_g071rb
+      - nucleo_g0b1re
       - nucleo_g474re
       - nucleo_l073rz
       - nucleo_l152re


### PR DESCRIPTION
This PR backports two upstream commits authored by @FRASTM to Zephyr's v3.7 LTS branch, plus a companion test-enablement change.


## Patches 1-2: upstream commits by @FRASTM 

(Applied via `git cherry-pick -x -s` )

- 278d8e298d7f0c724722282175201d0dc116ad2f (drivers: watchdog: stm32 wwdg enable Early
  WKUP int with pclk) - enables the EWI interrupt only after the WWDG peripheral clock
  is on, and clears any stale EWKUP flag before arming it.
- c32b481413c45a2068933ea2a3492fac8c0d3490 (drivers: watchdog: stm32 wwdg check
  callback before calling) - guards the ISR's callback invocation with a NULL check.


## Patch 3: test enablement
Enables the previously-disabled EWI callback test (test_wdt_callback_1) for the STM32
window watchdog in tests/drivers/watchdog/wdt_basic_api, and adds nucleo_g0b1re (the
board from the original bug report) to that test's platform_allow list, since this code
path was not exercised by CI on this branch before.

## Background
Reported and root-caused on STM32G0C1RET3 (Nucleo-G0B1RE) in
zephyrproject-rtos/zephyr#105540. Confirmed applicable to G0 and a v3.7.1 PR explicitly
invited by @erwango:

Fixes #105540