### PR TITLE
boards: nxp: mcx_nx4x_evk: add wakeup-button aliases

### DIFF
--- a/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk.dtsi
+++ b/boards/nxp/mcx_nx4x_evk/mcx_nx4x_evk.dtsi
@@ -7,6 +7,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/wuc/wuc_nxp_wuu.h>
 
 / {
 	aliases {
@@ -15,6 +16,7 @@
 		led2 = &blue_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
+		wakeup-button = &user_button_2;
 		sdhc0 = &usdhc0;
 		mcuboot-button0 = &user_button_2;
 	};
@@ -65,6 +67,8 @@
 			label = "User SW2";
 			gpios = <&gpio1 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_0>;
+			/* SW2 (P1_3) wakes via WUU external pin 7. */
+			wakeup-ctrls = <&wuu NXP_WUU_PIN_7_FALLING_INT>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
add wakeup-button aliases
fix https://github.com/zephyrproject-rtos/zephyr/issues/113362