### PR TITLE
arch: arm64: use csprng for PAC per-thread key generation

### DIFF
--- a/arch/arm64/core/pac.c
+++ b/arch/arm64/core/pac.c
@@ -11,12 +11,15 @@
 /**
  * @brief Generate random PAC keys
  *
- * Uses a single sys_rand_get() call for efficiency.
+ * Uses a single sys_csrand_get() call for efficiency.
+ *
+ * @retval 0 on success
+ * @retval -EIO if CSPRNG fails
  */
-void z_arm64_pac_keys_generate(struct pac_keys *keys)
+int z_arm64_pac_keys_generate(struct pac_keys *keys)
 {
 	/* Generate all keys with a single random call using the union */
-	sys_rand_get(keys->raw_bytes, sizeof(keys->raw_bytes));
+	return sys_csrand_get(keys->raw_bytes, sizeof(keys->raw_bytes));
 }
 
 /**

--- a/arch/arm64/core/thread.c
+++ b/arch/arm64/core/thread.c
@@ -155,7 +155,9 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 
 #ifdef CONFIG_ARM_PAC_PER_THREAD
 	/* Generate unique PAC keys for this thread */
-	z_arm64_pac_keys_generate(&thread->arch.pac_keys);
+	if (z_arm64_pac_keys_generate(&thread->arch.pac_keys) != 0) {
+		k_panic();
+	}
 #endif
 }
 

--- a/include/zephyr/arch/arm64/pac.h
+++ b/include/zephyr/arch/arm64/pac.h
@@ -38,7 +38,7 @@ struct pac_key {
  * These keys provide isolation between threads/processes.
  *
  * The union allows efficient initialization of all keys with a single
- * sys_rand_get() call while maintaining individual key access.
+ * sys_csrand_get() call while maintaining individual key access.
  */
 struct pac_keys {
 	union {
@@ -57,8 +57,9 @@ struct pac_keys {
  * @brief Generate random PAC keys
  *
  * @param keys Pointer to pac_keys structure to populate
+ * @retval 0 on success -EIO if entropy reseed error
  */
-void z_arm64_pac_keys_generate(struct pac_keys *keys);
+int z_arm64_pac_keys_generate(struct pac_keys *keys);
 
 /**
  * @brief Save current PAC keys from hardware registers


### PR DESCRIPTION
z_arm64_pac_keys_generate() used sys_rand_get() to generate 80 bytes of PAC key material for per-thread pointer authentication. sys_rand_get() is explicitly documented as not cryptographically secure, making PAC keys predictable and defeating the hardware protection against ROP/JOP attacks.

Replace sys_rand_get() with sys_csrand_get(), matching the cortex_m implementation under the same CONFIG_ARM_PAC_PER_THREAD config. Propagate the return value so callers can detect CSPRNG failures and k_panic() instead of silently using zero-initialized keys.

Also fix a stale comment referencing sys_rand_get() in the pac_keys struct documentation.

Fixes #113557