### PR TITLE
arch: arm64: cortex_r: add XN and SH to K_MEM_PARTITION macros

### DIFF
--- a/include/zephyr/arch/arm64/cortex_r/arm_mpu.h
+++ b/include/zephyr/arch/arm64/cortex_r/arm_mpu.h
@@ -228,13 +228,13 @@ struct arm_mpu_config {
 	}
 
 #define K_MEM_PARTITION_P_RW_U_RW ((k_mem_partition_attr_t) \
-	{(P_RW_U_RW_Msk), MPU_MAIR_INDEX_SRAM})
+	{(NOT_EXEC | P_RW_U_RW_Msk | INNER_SHAREABLE_Msk), MPU_MAIR_INDEX_SRAM})
 #define K_MEM_PARTITION_P_RW_U_NA ((k_mem_partition_attr_t) \
-	{(P_RW_U_NA_Msk), MPU_MAIR_INDEX_SRAM})
+	{(NOT_EXEC | P_RW_U_NA_Msk | INNER_SHAREABLE_Msk), MPU_MAIR_INDEX_SRAM})
 #define K_MEM_PARTITION_P_RO_U_RO ((k_mem_partition_attr_t) \
-	{(P_RO_U_RO_Msk), MPU_MAIR_INDEX_SRAM})
+	{(NOT_EXEC | P_RO_U_RO_Msk | INNER_SHAREABLE_Msk), MPU_MAIR_INDEX_SRAM})
 #define K_MEM_PARTITION_P_RO_U_NA ((k_mem_partition_attr_t) \
-	{(P_RO_U_NA_Msk), MPU_MAIR_INDEX_SRAM})
+	{(NOT_EXEC | P_RO_U_NA_Msk | INNER_SHAREABLE_Msk), MPU_MAIR_INDEX_SRAM})
 
 typedef struct arm_mpu_region_attr k_mem_partition_attr_t;
 


### PR DESCRIPTION
The K_MEM_PARTITION_* macros for the ARMv8-R64 MPU only set AP bits in RBAR, omitting XN (eXecute Never) and SH (Shareability). This caused user thread stacks and memory domain partitions to be mapped as executable (XN=0) and non-shareable (SH=00).

XN=0 defeats the hardware W^X enforcement the MPU is meant to provide, allowing shellcode execution from user stacks or shared memory. SH=00 can cause stale cache lines and data corruption on SMP systems.

Add NOT_EXEC and INNER_SHAREABLE_Msk to all four K_MEM_PARTITION_* macros, matching the conventions used by REGION_RAM_ATTR and REGION_RAM_RO_ATTR for fixed regions.

Fixes #113558