### PR TITLE
smbus: Fix privilege escalation via callback syscalls

### DIFF
--- a/drivers/smbus/smbus_handlers.c
+++ b/drivers/smbus/smbus_handlers.c
@@ -143,21 +143,3 @@ static inline int z_vrfy_smbus_block_pcall(const struct device *dev,
 					rcv_count, rcv_buf);
 }
 #include <zephyr/syscalls/smbus_block_pcall_mrsh.c>
-
-static inline int z_vrfy_smbus_smbalert_remove_cb(const struct device *dev,
-						  struct smbus_callback *cb)
-{
-	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_SMBUS));
-
-	return z_impl_smbus_smbalert_remove_cb(dev, cb);
-}
-#include <zephyr/syscalls/smbus_smbalert_remove_cb_mrsh.c>
-
-static inline int z_vrfy_smbus_host_notify_remove_cb(const struct device *dev,
-						     struct smbus_callback *cb)
-{
-	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_SMBUS));
-
-	return z_impl_smbus_host_notify_remove_cb(dev, cb);
-}
-#include <zephyr/syscalls/smbus_host_notify_remove_cb_mrsh.c>

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -635,11 +635,8 @@ static inline int smbus_smbalert_set_cb(const struct device *dev,
  * @retval -ENOSYS Function smbus_smbalert_remove_cb() is not implemented
  * by the driver.
  */
-__syscall int smbus_smbalert_remove_cb(const struct device *dev,
-				       struct smbus_callback *cb);
-
-static inline int z_impl_smbus_smbalert_remove_cb(const struct device *dev,
-						  struct smbus_callback *cb)
+static inline int smbus_smbalert_remove_cb(const struct device *dev,
+					   struct smbus_callback *cb)
 {
 	const struct smbus_driver_api *api = DEVICE_API_GET(smbus, dev);
 
@@ -684,11 +681,8 @@ static inline int smbus_host_notify_set_cb(const struct device *dev,
  * @retval -ENOSYS Function smbus_host_notify_remove_cb() is not implemented
  * by the driver.
  */
-__syscall int smbus_host_notify_remove_cb(const struct device *dev,
-					  struct smbus_callback *cb);
-
-static inline int z_impl_smbus_host_notify_remove_cb(const struct device *dev,
-						     struct smbus_callback *cb)
+static inline int smbus_host_notify_remove_cb(const struct device *dev,
+					      struct smbus_callback *cb)
 {
 	const struct smbus_driver_api *api = DEVICE_API_GET(smbus, dev);
 


### PR DESCRIPTION
smbus_smbalert_remove_cb() and smbus_host_notify_remove_cb() were exposed as syscalls, allowing userspace to pass a struct smbus_callback pointer directly to kernel mode. Since struct smbus_callback contains a function pointer (smbus_callback_handler_t), an application could craft a callback struct to redirect kernel execution to an arbitrary address.

Fixes: #114522