### PR TITLE
doc: enable cross-references from Doxygen to the main documentation

### DIFF
--- a/doc/_doxygen/doxygen-awesome-zephyr.css
+++ b/doc/_doxygen/doxygen-awesome-zephyr.css
@@ -164,3 +164,10 @@ dl.section dd, dl.bug dd, dl.deprecated dd {
     background-color: #3498db;
     color: white;
 }
+
+/* Cross-references to the main (Sphinx-based) documentation, as resolved by
+   the zephyr.doxyxref extension */
+a.doxyxref,
+a.doxyxref code {
+    color: var(--link-color);
+}

--- a/doc/_extensions/zephyr/doxyxref.py
+++ b/doc/_extensions/zephyr/doxyxref.py
@@ -1,0 +1,327 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Linux Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Doxygen to Sphinx cross-reference resolver
+##########################################
+
+This extension makes it possible to reference Sphinx documentation content (e.g. Kconfig options,
+Devicetree bindings, or any ``:ref:`` target) from Doxygen comments, and have the Doxygen-generated
+HTML pages link back to the corresponding pages of the Sphinx-based documentation.
+
+Doxygen aliases (defined in ``zephyr.doxyfile.in``) such as ``@kconfig{}``, ``@dtcompatible{}`` or
+``@rstref{}`` expand to HTML placeholders like::
+
+    <code class='doxyxref' data-stype='kconfig:option' data-starget='CONFIG_GPIO'>CONFIG_GPIO</code>
+
+Once the Sphinx HTML build is finished, this extension scans the Doxygen-generated HTML pages and
+resolves such placeholders into actual hyperlinks, using the Sphinx object inventory
+(``objects.inv``) produced by the very same build. Links are written as relative URLs so that they
+remain valid wherever the documentation set is hosted (docs.zephyrproject.org/latest, versioned
+copies, local builds, downstream distributions, ...).
+
+Placeholders that cannot be resolved are left untouched (they degrade to plain, code-styled text)
+and a Sphinx warning is emitted for each of them.
+
+Configuration options
+=====================
+
+- ``doxyxref_projects``: Dictionary of Doxygen projects, mapping project name to the Doxygen output
+  directory (same format as ``doxybridge_projects``).
+"""
+
+from __future__ import annotations
+
+import html
+import os
+import re
+import zlib
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import quote
+
+if TYPE_CHECKING:
+    from sphinx.util.typing import Inventory
+
+__version__ = "0.1.0"
+
+
+class ObjType(StrEnum):
+    """Sphinx object types (``domain:objtype``, as used to key the object inventory).
+
+    Only the types this extension gives special treatment to are listed. Any other type is looked up
+    in the inventory as-is, so new Doxygen aliases can be added to ``zephyr.doxyfile.in`` without
+    any change here.
+    """
+
+    KCONFIG_OPTION = "kconfig:option"
+    KCONFIG_OPTION_REGEX = "kconfig:option-regex"
+    REF = "std:ref"
+    LABEL = "std:label"
+    DOC = "std:doc"
+
+
+PLACEHOLDER_RE = re.compile(
+    r"<(?P<tag>code|span) class='doxyxref' "
+    r"data-stype='(?P<stype>[^']+)' "
+    r"data-starget='(?P<starget>[^']*)'>"
+    r".*?</(?P=tag)>",
+    re.DOTALL,
+)
+"""Placeholder markup, as emitted by the ALIASES defined in zephyr.doxyfile.in."""
+
+
+@dataclass(frozen=True)
+class Xref:
+    """A cross-reference from a Doxygen page back to the main documentation.
+
+    Attributes:
+        stype: Sphinx object type of the target (e.g. ``kconfig:option``, ``std:ref``).
+        target: Reference target, with any explicit link title removed.
+        uri: Location of the target relative to the documentation root, or ``None`` when the
+            reference could not be resolved.
+        text: Text to display for the resolved link.
+    """
+
+    stype: str
+    target: str
+    uri: str | None = None
+    text: str = ""
+
+    @property
+    def resolved(self) -> bool:
+        """Whether the reference was resolved to a documentation URI."""
+        return self.uri is not None
+
+
+def split_titled_ref(raw: str) -> tuple[str | None, str]:
+    """Split an explicit-title reference into its title and target parts.
+
+    Explicit titles use the same ``custom text <target>`` notation as Sphinx roles.
+
+    Args:
+        raw: Reference, with or without an explicit title.
+
+    Returns:
+        The title and the target. When no explicit title is present, the title is ``None`` and the
+        whole input is the target.
+    """
+    if raw.endswith(">"):
+        open_pos = raw.rfind("<")
+        title = raw[:open_pos].rstrip() if open_pos > 0 else ""
+        target = raw[open_pos + 1 : -1]
+        if title and target and ">" not in target:
+            return title, target
+
+    return None, raw
+
+
+def lookup_kconfig_regex(inventory: Inventory, target: str) -> str | None:
+    """Resolve a Kconfig regex reference to the Kconfig search page.
+
+    The link points to the Kconfig search page pre-filled with the given pattern, mirroring the
+    Sphinx ``:kconfig:option-regex:`` role. The reference only resolves if at least one Kconfig
+    option matches, using the same semantics as the search page: whitespace-separated,
+    case-insensitive regular expressions searched within option names.
+
+    Args:
+        inventory: Parsed object inventory.
+        target: Whitespace-separated regular expressions to search option names for.
+
+    Returns:
+        The search-page URI (relative to the documentation root), or ``None`` if no option matches.
+    """
+    options = inventory.get(ObjType.KCONFIG_OPTION, {})
+    if not options:
+        return None
+
+    try:
+        patterns = [re.compile(term.lower()) for term in target.split()]
+    except re.error:
+        return None
+
+    if not patterns:
+        return None
+
+    if not any(all(pattern.search(name.lower()) for pattern in patterns) for name in options):
+        return None
+
+    # all options live on the search page: derive its URI from any entry
+    page_uri = next(iter(options.values())).uri.partition("#")[0]
+    return f"{page_uri}#!{quote(target)}"
+
+
+def resolve(inventory: Inventory, stype: str, raw_target: str) -> Xref:
+    """Parse and resolve a single cross-reference placeholder into an :class:`Xref`.
+
+    ``std:ref`` references may carry an explicit ``title <target>`` title (as the Sphinx ``:ref:``
+    role does) and are resolved against reference labels (stored lowercased in the inventory), with
+    document names (``:doc:`` targets) as a fallback.
+
+    Args:
+        inventory: Parsed object inventory.
+        stype: Sphinx object type of the target, as carried by the placeholder.
+        raw_target: Reference target, possibly carrying an explicit title.
+
+    Returns:
+        The cross-reference, left unresolved if the target is not in the inventory.
+    """
+    if stype == ObjType.KCONFIG_OPTION_REGEX:
+        uri = lookup_kconfig_regex(inventory, raw_target)
+        return Xref(stype, raw_target, uri, raw_target)
+
+    if stype == ObjType.REF:
+        title, target = split_titled_ref(raw_target)
+        item = inventory.get(ObjType.LABEL, {}).get(target.lower())
+        if item is None:
+            item = inventory.get(ObjType.DOC, {}).get(target.strip("/"))
+    else:
+        title, target = None, raw_target
+        item = inventory.get(stype, {}).get(target)
+
+    if item is None:
+        return Xref(stype, target)
+
+    text = title or (item.display_name if item.display_name not in ("", "-") else target)
+    return Xref(stype, target, item.uri, text)
+
+
+def render_link(tag: str, xref: Xref, url_base: str) -> str:
+    """Render a resolved :class:`Xref` as an HTML anchor.
+
+    Args:
+        tag: Tag of the placeholder being replaced. A ``code`` placeholder keeps its monospace
+            styling by wrapping the link text.
+        xref: Resolved cross-reference.
+        url_base: Prefix prepended to the documentation-root-relative URI of the target.
+
+    Returns:
+        The HTML anchor.
+    """
+    text = html.escape(xref.text)
+    if tag == "code":
+        text = f"<code>{text}</code>"
+
+    href = html.escape(url_base + (xref.uri or ""), quote=True)
+    return f'<a class="doxyxref" href="{href}">{text}</a>'
+
+
+def process_html_content(
+    content: str,
+    inventory: Inventory,
+    url_base: str,
+) -> tuple[str, list[Xref]]:
+    """Resolve all cross-reference placeholders found in an HTML document.
+
+    Args:
+        content: HTML content to process.
+        inventory: Parsed object inventory.
+        url_base: Prefix prepended to the documentation-root-relative URI of each resolved target.
+            Can be an absolute URL or a relative path (with trailing slash).
+
+    Returns:
+        The processed content, and the list of references that could not be resolved.
+    """
+    unresolved: list[Xref] = []
+
+    def _replace(m: re.Match) -> str:
+        xref = resolve(inventory, m.group("stype"), m.group("starget").strip())
+        if not xref.resolved:
+            unresolved.append(xref)
+            return m.group(0)
+
+        return render_link(m.group("tag"), xref, url_base)
+
+    return PLACEHOLDER_RE.sub(_replace, content), unresolved
+
+
+def process_html_dir(
+    html_dir: Path,
+    inventory: Inventory,
+    docs_root: Path,
+) -> list[Xref]:
+    """Resolve cross-reference placeholders in all HTML files of a directory.
+
+    Args:
+        html_dir: Directory containing the Doxygen-generated HTML files.
+        inventory: Parsed object inventory.
+        docs_root: Root directory of the Sphinx HTML output. Links are computed relative to each
+            processed file.
+
+    Returns:
+        List of references that could not be resolved.
+    """
+    unresolved: list[Xref] = []
+
+    for file in sorted(html_dir.rglob("*.html")):
+        content = file.read_text(encoding="utf-8", errors="surrogateescape")
+        if "class='doxyxref'" not in content:
+            continue
+
+        rel = os.path.relpath(docs_root, file.parent).replace(os.sep, "/")
+        base = "" if rel == "." else f"{rel}/"
+
+        new_content, missing = process_html_content(content, inventory, base)
+        unresolved.extend(missing)
+
+        if new_content != content:
+            file.write_text(new_content, encoding="utf-8", errors="surrogateescape")
+
+    return unresolved
+
+
+def doxyxref_resolve(app, exception) -> None:
+    """Sphinx ``build-finished`` hook resolving Doxygen cross-references.
+
+    Args:
+        app: Sphinx application instance.
+        exception: Exception raised by the build, if it failed.
+    """
+    from sphinx.util import logging
+    from sphinx.util.inventory import InventoryFile
+
+    logger = logging.getLogger(__name__)
+
+    if exception is not None or app.builder.format != "html":
+        return
+
+    outdir = Path(app.outdir)
+    inventory_file = outdir / "objects.inv"
+    if not inventory_file.exists():
+        logger.warning(f"doxyxref: object inventory not found: {inventory_file}")
+        return
+
+    try:
+        # uri="" keeps the target locations relative to the documentation root
+        inventory = InventoryFile.loads(inventory_file.read_bytes(), uri="").data
+    except (OSError, ValueError, zlib.error) as e:
+        logger.warning(f"doxyxref: could not read object inventory {inventory_file}: {e}")
+        return
+
+    for project, project_outdir in (app.config.doxyxref_projects or {}).items():
+        html_dir = Path(project_outdir) / "html"
+        if not html_dir.is_dir():
+            logger.warning(f"doxyxref: no Doxygen HTML output found for project '{project}'")
+            continue
+
+        logger.info(f"doxyxref: resolving Sphinx cross-references for project '{project}'...")
+        unresolved = process_html_dir(html_dir, inventory, docs_root=outdir)
+        for stype, target in sorted({(xref.stype, xref.target) for xref in unresolved}):
+            logger.warning(
+                f"doxyxref: unresolved {stype} cross-reference: '{target}' (project '{project}')",
+                type="doxyxref",
+            )
+
+
+def setup(app):
+    app.add_config_value("doxyxref_projects", {}, "env")
+
+    app.connect("build-finished", doxyxref_resolve)
+
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -108,6 +108,7 @@ extensions = [
     "zephyr.doxyrunner",
     "zephyr.doxybridge",
     "zephyr.doxytooltip",
+    "zephyr.doxyxref",
     "zephyr.gh_utils",
     "zephyr.manifest_projects_table",
     "notfound.extension",
@@ -319,6 +320,10 @@ if SKIP_DOXYGEN:
     # No Doxygen XML to bridge; C-domain references are replaced with plain
     # text by zephyr.partial_build before resolution.
     doxybridge_projects = {}
+
+# -- Options for zephyr.doxyxref plugin ------------------------------------
+
+doxyxref_projects = doxybridge_projects
 
 # -- Options for html_redirect plugin -------------------------------------
 

--- a/doc/contribute/documentation/generation.rst
+++ b/doc/contribute/documentation/generation.rst
@@ -339,6 +339,22 @@ it locally, and watch the documentation directory for changes. When changes are
 observed, it will automatically rebuild the documentation and refresh the hosted
 files.
 
+Building the Doxygen documentation standalone
+*********************************************
+
+The ``doxygen`` build target can be used to only build the Doxygen (API) documentation, which is
+much faster than building the full documentation set::
+
+   cd ~/zephyrproject/zephyr/doc
+   make doxygen
+
+The output can be found in ``_build/doxygen/html``.
+
+In the regular documentation build, references made from Doxygen comments to the main
+documentation (e.g. ``@kconfig{}``, ``@dtcompatible{}`` or ``@rstref{}``, see
+:ref:`doxygen_sphinx_xrefs`) are automatically resolved into hyperlinks. In a standalone Doxygen
+build, they are left as plain text since the rest of the documentation is not available.
+
 Linking external Doxygen projects against Zephyr
 ************************************************
 

--- a/doc/contribute/style/doxygen.rst
+++ b/doc/contribute/style/doxygen.rst
@@ -310,6 +310,51 @@ For function-like macros, document parameters like you would for functions.
     */
    #define DT_REG_SIZE(node_id) DT_REG_SIZE_BY_IDX(node_id, 0)
 
+.. _doxygen_sphinx_xrefs:
+
+Referencing the main documentation
+**********************************
+
+API documentation can reference content from the main, Sphinx-based documentation using the
+commands described below. In the generated API documentation pages, these references are rendered
+as hyperlinks pointing back to the corresponding page of the main documentation.
+
+``@kconfig{<option>}``
+  Reference a Kconfig option by its full name (including the ``CONFIG_`` prefix). This is the
+  Doxygen counterpart of the :rst:role:`kconfig:option` role.
+
+  Example: ``@kconfig{CONFIG_GPIO}``
+
+``@kconfig_regex{<regex>}``
+  Reference all the Kconfig options matching a regular expression, as a link to the Kconfig search
+  page with the pattern pre-filled. This is the Doxygen counterpart of the
+  :rst:role:`kconfig:option-regex` role. As commas have a special meaning in Doxygen commands, they
+  must be escaped with a backslash.
+
+  Example: ``@kconfig_regex{CONFIG_SECURE_STORAGE_ITS_.*_CUSTOM}``
+
+``@dtcompatible{<compatible>}``
+  Reference a Devicetree binding by its compatible string. This is the Doxygen counterpart of the
+  :rst:role:`dtcompatible` role. As commas have a special meaning in Doxygen commands, they must be
+  escaped with a backslash.
+
+  Example: ``@dtcompatible{zephyr\,input-longpress}``
+
+``@rstref{<target>}`` or ``@rstref{<text> <target>}``
+  Reference any documentation page or section by its reference label (or document name), similar to
+  the Sphinx :rst:role:`ref` role. When no custom text is provided, the title of the referenced
+  page or section is used as the link text.
+
+  Example: ``@rstref{zephyr_licensing}`` or ``@rstref{the licensing page <zephyr_licensing>}``
+
+References are checked when the documentation is built: a reference to a Kconfig option, binding,
+or label that does not exist causes a documentation build warning.
+
+.. note::
+
+   These commands expand to plain text when the Doxygen documentation is built standalone, i.e.
+   without the rest of the documentation. See :ref:`zephyr_doc` for more details.
+
 .. _doxygen_internals:
 
 Hiding internal details

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -285,7 +285,27 @@ TAB_SIZE               = 8
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                = "kconfig{1}=\c \1" \
+# The kconfig, dtcompatible and rstref aliases expand to HTML placeholders
+# that are resolved into links pointing back to the Sphinx-based documentation
+# (e.g. docs.zephyrproject.org) by the 'zephyr.doxyxref' Sphinx extension (see
+# doc/_extensions/zephyr/doxyxref.py). When left unresolved, the placeholders
+# gracefully degrade to plain text.
+#
+# - kconfig{1}:      reference a Kconfig option, e.g. @kconfig{CONFIG_GPIO}
+# - kconfig_regex{1}: reference all Kconfig options matching a regular
+#                    expression, linking to the Kconfig search page, e.g.
+#                    @kconfig_regex{CONFIG_SECURE_STORAGE_ITS_.*_CUSTOM}
+# - dtcompatible{1}: reference a Devicetree binding by compatible string,
+#                    e.g. @dtcompatible{zephyr\,input-longpress} (note the
+#                    escaped comma)
+# - rstref{1}:       reference any Sphinx ':ref:' target, with optional custom
+#                    text, e.g. @rstref{coding_guidelines} or
+#                    @rstref{the coding guidelines <coding_guidelines>}
+
+ALIASES                = "kconfig{1}=\htmlonly<code class='doxyxref' data-stype='kconfig:option' data-starget='\1'>\1</code>\endhtmlonly" \
+                         "kconfig_regex{1}=\htmlonly<code class='doxyxref' data-stype='kconfig:option-regex' data-starget='\1'>\1</code>\endhtmlonly" \
+                         "dtcompatible{1}=\htmlonly<code class='doxyxref' data-stype='std:dtcompatible' data-starget='\1'>\1</code>\endhtmlonly" \
+                         "rstref{1}=\htmlonly<span class='doxyxref' data-stype='std:ref' data-starget='\1'>\1</span>\endhtmlonly" \
                          "kconfig_dep{1}=\attention Available only when the following Kconfig option is enabled: \kconfig{\1}." \
                          "kconfig_dep{2}=\attention Available only when the following Kconfig options are enabled: \kconfig{\1}, \kconfig{\2}." \
                          "kconfig_dep{3}=\attention Available only when the following Kconfig options are enabled: \kconfig{\1}, \kconfig{\2}, \kconfig{\3}." \

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -67,7 +67,7 @@ struct bt_cap_unicast_group;
  * Service instance.
  *
  * This shall only be done as a server, and requires
- * @kconfig{BT_CAP_ACCEPTOR_SET_MEMBER}. If @kconfig{BT_CAP_ACCEPTOR_SET_MEMBER}
+ * @kconfig{CONFIG_BT_CAP_ACCEPTOR_SET_MEMBER}. If @kconfig{CONFIG_BT_CAP_ACCEPTOR_SET_MEMBER}
  * is not enabled, the Common Audio Service will by statically registered.
  *
  * @param[in]  param     Coordinated Set Identification Service register

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -795,7 +795,7 @@ enum bt_le_adv_opt {
 	 * Coding Selection. If these conditions are not met, it will default to
 	 * no required coding scheme.
 	 *
-	 * @kconfig_dep{BT_EXT_ADV_CODING_SELECTION}
+	 * @kconfig_dep{CONFIG_BT_EXT_ADV_CODING_SELECTION}
 	 */
 	BT_LE_ADV_OPT_REQUIRE_S2_CODING = BIT(20),
 
@@ -812,7 +812,7 @@ enum bt_le_adv_opt {
 	 * Coding Selection. If these conditions are not met, it will default to
 	 * no required coding scheme.
 	 *
-	 * @kconfig_dep{BT_EXT_ADV_CODING_SELECTION}
+	 * @kconfig_dep{CONFIG_BT_EXT_ADV_CODING_SELECTION}
 	 */
 	BT_LE_ADV_OPT_REQUIRE_S8_CODING = BIT(21),
 

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -181,8 +181,8 @@ int bt_br_oob_get_local(struct bt_br_oob *oob);
  * to first be in connectable state.
  *
  * If the device enters limited discoverable mode, the controller will leave from discoverable
- * mode after the duration of @kconfig{BT_LIMITED_DISCOVERABLE_DURATION} seconds in the limited
- * discoverable mode.
+ * mode after the duration of @kconfig{CONFIG_BT_LIMITED_DISCOVERABLE_DURATION} seconds in the
+ * limited discoverable mode.
  *
  * @param enable Value allowing/disallowing controller to become discoverable.
  * @param limited Value allowing/disallowing controller to enter limited discoverable mode.
@@ -239,7 +239,7 @@ typedef enum bt_br_conn_req_rsp (*bt_br_conn_req_func_t)(const bt_addr_t *addr, 
  *               false, this parameter is ignored.
  *               If @p func is NULL, the conn_req will be accepted internally. The default role
  *               is peripheral. The role switch request can be performed if the
- *               @kconfig{BT_ACCEPT_CONN_AS_CENTRAL} is enabled.
+ *               @kconfig{CONFIG_BT_ACCEPT_CONN_AS_CENTRAL} is enabled.
  *               If @p func is provided, the conn_req will be passed to the callback function
  *               for the application to decide whether to accept or reject the connection, and
  *               the desired role for the connection.

--- a/include/zephyr/bluetooth/classic/hfp_ag.h
+++ b/include/zephyr/bluetooth/classic/hfp_ag.h
@@ -256,7 +256,7 @@ struct bt_hfp_ag_cb {
 	 *
 	 *  @param ag HFP AG object.
 	 *  @param number Buffer to store the last dialed phone number.
-	 *                The buffer size is @kconfig{BT_HFP_AG_PHONE_NUMBER_MAX_LEN} + 1,
+	 *                The buffer size is @kconfig{CONFIG_BT_HFP_AG_PHONE_NUMBER_MAX_LEN} + 1,
 	 *                and should be null-terminated.
 	 *
 	 *  @return 0 in case of success or negative value in case of error.

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -443,22 +443,22 @@ struct bt_l2cap_br_endpoint {
 	uint8_t                                 max_transmit;
 	/** Endpoint Retransmission Timeout
 	 * The field is configured by
-	 * `@kconfig{BT_L2CAP_BR_RET_TIMEOUT}`
+	 * @kconfig{CONFIG_BT_L2CAP_BR_RET_TIMEOUT}
 	 * The field should be no more than the field
 	 * `monitor_timeout`.
 	 */
 	uint16_t                                ret_timeout;
 	/** Endpoint Monitor Timeout
 	 * The field is configured by
-	 * `@kconfig{BT_L2CAP_BR_MONITOR_TIMEOUT}`
+	 * @kconfig{CONFIG_BT_L2CAP_BR_MONITOR_TIMEOUT}
 	 */
 	uint16_t                                monitor_timeout;
 	/** Endpoint Maximum PDU payload Size */
 	uint16_t                                mps;
 	/** Endpoint Maximum Window Size
 	 * MAX supported window size is configured by
-	 * `@kconfig{BT_L2CAP_MAX_WINDOW_SIZE}`. The field
-	 * should be no more then `CONFIG_BT_L2CAP_MAX_WINDOW_SIZE`.
+	 * @kconfig{CONFIG_BT_L2CAP_MAX_WINDOW_SIZE}. The field
+	 * should be no more than @kconfig{CONFIG_BT_L2CAP_MAX_WINDOW_SIZE}.
 	 */
 	uint16_t                                max_window;
 	/** Endpoint FCS Type

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -1217,7 +1217,7 @@ void z_spi_transfer_signal_cb(const struct device *dev, int result, void *userda
  * @note The chip select behavior as described by @ref spi_transceive and
  *       the function of controller/peripheral modes is the same.
  *
- * @kconfig_dep{CONFIG_SPI_ASYNC, CONFIG_POLL}
+ * @kconfig_dep{CONFIG_SPI_ASYNC,CONFIG_POLL}
  *
  * @param dev Pointer to the device structure for the driver instance
  * @param config Pointer to a valid spi_config structure instance.
@@ -1256,7 +1256,7 @@ static inline int spi_transceive_signal(const struct device *dev,
  *
  * @note This function is a helper function calling spi_transceive_signal.
  *
- * @kconfig_dep{CONFIG_SPI_ASYNC, CONFIG_POLL}
+ * @kconfig_dep{CONFIG_SPI_ASYNC,CONFIG_POLL}
  *
  * @param dev Pointer to the device structure for the driver instance
  * @param config Pointer to a valid spi_config structure instance.
@@ -1289,7 +1289,7 @@ static inline int spi_read_signal(const struct device *dev,
  *
  * @note This function is a helper function calling spi_transceive_signal.
  *
- * @kconfig_dep{CONFIG_SPI_ASYNC, CONFIG_POLL}
+ * @kconfig_dep{CONFIG_SPI_ASYNC,CONFIG_POLL}
  *
  * @param dev Pointer to the device structure for the driver instance
  * @param config Pointer to a valid spi_config structure instance.

--- a/include/zephyr/dt-bindings/lvgl/lvgl.h
+++ b/include/zephyr/dt-bindings/lvgl/lvgl.h
@@ -18,8 +18,8 @@
  * @ingroup input_interface
  * @brief Predefined LVGL keys for use in Devicetree.
  *
- * Used in the @c lvgl-codes property of a <tt>zephyr,lvgl-keypad-input</tt> node to map input event
- * codes to LVGL keys. Values mirror <tt>enum _lv_key_t</tt> from LVGL's @c lv_group.h.
+ * Used in the @c lvgl-codes property of a @dtcompatible{zephyr,lvgl-keypad-input} node to map input
+ * event codes to LVGL keys. Values mirror <tt>enum _lv_key_t</tt> from LVGL's @c lv_group.h.
  *
  * Example devicetree usage:
  *

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -98,6 +98,11 @@ rsource "Kconfig.adv"
 
 config BT_CONN
 	bool
+	help
+	  Indicates that support for Bluetooth LE connections (ACL) is enabled.
+	  This internal option is selected automatically by the roles that need
+	  connections, such as BT_PERIPHERAL and BT_CENTRAL, and is not meant to
+	  be set directly.
 
 config BT_MAX_CONN
 	int "Maximum number of simultaneous connections"

--- a/subsys/bluetooth/audio/Kconfig
+++ b/subsys/bluetooth/audio/Kconfig
@@ -21,9 +21,19 @@ if BT_AUDIO
 
 config BT_AUDIO_RX
 	def_bool BT_ASCS_ASE_SNK || BT_BAP_UNICAST_CLIENT_ASE_SRC || BT_BAP_BROADCAST_SINK
+	help
+	  Indicates that the stack is configured with support for receiving
+	  audio (for example as a unicast Audio Stream sink or a Broadcast
+	  Sink). This internal option is derived automatically and is not meant
+	  to be set directly.
 
 config BT_AUDIO_TX
 	def_bool BT_ASCS_ASE_SRC || BT_BAP_UNICAST_CLIENT_ASE_SNK || BT_BAP_BROADCAST_SOURCE
+	help
+	  Indicates that the stack is configured with support for transmitting
+	  audio (for example as a unicast Audio Stream source or a Broadcast
+	  Source). This internal option is derived automatically and is not
+	  meant to be set directly.
 
 config BT_AUDIO_NOTIFY_RETRY_DELAY
 	int "Delay for notification sending retried attempt in 1.25 ms units"

--- a/subsys/secure_storage/include/internal/zephyr/secure_storage/its/store/settings_get.h
+++ b/subsys/secure_storage/include/internal/zephyr/secure_storage/its/store/settings_get.h
@@ -10,7 +10,7 @@
  * of the settings implementation of the ITS store module.
  * They are not meant to be called directly other than by the settings ITS store module.
  * This header file may and must be included when providing a custom implementation of one
- * or more of these functions (@kconfig{CONFIG_SECURE_STORAGE_ITS_STORE_SETTINGS_*_CUSTOM}).
+ * or more of these functions (@kconfig_regex{CONFIG_SECURE_STORAGE_ITS_STORE_SETTINGS_.*_CUSTOM}).
  */
 #include <zephyr/secure_storage/its/common.h>
 

--- a/subsys/secure_storage/include/internal/zephyr/secure_storage/its/transform/aead_get.h
+++ b/subsys/secure_storage/include/internal/zephyr/secure_storage/its/transform/aead_get.h
@@ -10,7 +10,7 @@
  * of the AEAD implementation of the ITS transform module.
  * They are not meant to be called directly other than by the AEAD ITS transform module.
  * This header file may and must be included when providing a custom implementation of one
- * or more of these functions (@kconfig{CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_*_CUSTOM}).
+ * or more of these functions (@kconfig_regex{CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_.*_CUSTOM}).
  */
 #include <zephyr/secure_storage/its/common.h>
 #include <psa/crypto_types.h>


### PR DESCRIPTION
Introduce a mechanism allowing Doxygen comments to reference content from the main, Sphinx-based documentation, with the generated Doxygen HTML pages linking back to docs.zephyrproject.org Sphinx docs

See example of a cross-reference to a Kconfig symbol here: https://builds.zephyrproject.io/zephyr/pr/113565/docs/doxygen/html/group__thread__apis.html#ga95560cb85f6656b981a9a50ff2cd70b7

The following aliases are available:

- `@kconfig{CONFIG_FOO}`: reference a Kconfig option (upgraded from the existing alias which only rendered the option name as code text). `kconfig_regex` also available and mapping to `kconfig:option-regex`
- `@dtcompatible{vnd\,device}`: reference a Devicetree binding
- `@rstref{label}` / `@rstref{text <label>}`: reference any Sphinx `:ref:` target

Unresolved references degrade to plain code-styled text and emit a build warning so broken references are caught in CI.
