### PR TITLE
Add hwinfo driver support for microchip pic32cmjh family

### DIFF
--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.yaml
@@ -16,6 +16,7 @@ supported:
   - dac
   - dma
   - gpio
+  - hwinfo
   - i2c
   - pinctrl
   - pwm

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
@@ -46,6 +46,14 @@
 			reg = <0x00806020 0x8>;
 		};
 
+		hwinfo: device_id@80a00c {
+			compatible = "microchip,hwinfo-g1";
+			reg = <0x0080a00c 0x4>,
+			      <0x0080a040 0x4>,
+			      <0x0080a044 0x4>,
+			      <0x0080a048 0x4>;
+		};
+
 		sram0: memory@20000000 {
 			compatible = "mmio-sram";
 		};


### PR DESCRIPTION
- Added hwinfo node in the pic32cm_jh.dtsi file
- Update pic32cm_jh01_cpro.yaml to reflect G1 hwinfo support on the board.