### PR TITLE
tests: drivers: dma: Add platform allow entries

### DIFF
--- a/tests/drivers/dma/cyclic/tests.yaml
+++ b/tests/drivers/dma/cyclic/tests.yaml
@@ -7,4 +7,5 @@ tests:
     platform_allow:
       - xmc47_relax_kit
       - xmc45_relax_kit
+      - pic32cz_ca80_cult
     filter: dt_nodelabel_enabled("tst_dma0")

--- a/tests/drivers/dma/scatter_gather/tests.yaml
+++ b/tests/drivers/dma/scatter_gather/tests.yaml
@@ -24,6 +24,7 @@ tests:
       - adp_xc7k/ae350/clic
       - bg29_rb4420a
       - xg24_rb4187c
+      - pic32cz_ca80_cult
     filter: dt_nodelabel_enabled("tst_dma0")
     integration_platforms:
       - intel_adsp/cavs25


### PR DESCRIPTION
Add platform allow entries for pic32cz_ca80_cult in scatter_gather and cyclic test projects