### PR TITLE
drivers: mfd: npm13xx: Don't allow immediate hibernate wakeup

### DIFF
--- a/drivers/mfd/mfd_npm13xx.c
+++ b/drivers/mfd/mfd_npm13xx.c
@@ -28,6 +28,7 @@
 
 #define SHIP_OFFSET_HIBERNATE 0x00U
 #define SHIP_OFFSET_CFGSTROBE 0x01U
+#define SHIP_OFFSET_SHIPMODE  0x02U
 #define SHIP_OFFSET_CONFIG    0x04U
 #define SHIP_OFFSET_LPCONFIG  0x06U
 
@@ -284,6 +285,11 @@ int mfd_npm13xx_hibernate(const struct device *dev, uint32_t time_ms)
 	k_msleep(1);
 
 	return mfd_npm13xx_reg_write(dev, NPM13XX_SHIP_BASE, SHIP_OFFSET_HIBERNATE, 1U);
+}
+
+int mfd_npm13xx_ship_mode(const struct device *dev)
+{
+	return mfd_npm13xx_reg_write(dev, NPM13XX_SHIP_BASE, SHIP_OFFSET_SHIPMODE, 1U);
 }
 
 int mfd_npm13xx_add_callback(const struct device *dev, struct gpio_callback *callback)

--- a/drivers/mfd/mfd_npm13xx.c
+++ b/drivers/mfd/mfd_npm13xx.c
@@ -267,7 +267,14 @@ int mfd_npm13xx_reset(const struct device *dev)
 
 int mfd_npm13xx_hibernate(const struct device *dev, uint32_t time_ms)
 {
-	int ret = mfd_npm13xx_set_timer(dev, time_ms);
+	int ret;
+
+	/* Close to zero immediately wakes up, won't hibernate */
+	if (time_ms < TIMER_PRESCALER_MS) {
+		return -EINVAL;
+	}
+
+	ret = mfd_npm13xx_set_timer(dev, time_ms);
 
 	if (ret != 0) {
 		return ret;

--- a/include/zephyr/drivers/mfd/npm13xx.h
+++ b/include/zephyr/drivers/mfd/npm13xx.h
@@ -125,9 +125,9 @@ int mfd_npm13xx_reset(const struct device *dev);
  * Enters low power state, and wakes after specified time
  *
  * @param dev npm13xx mfd device
- * @param time_ms timer value in ms
+ * @param time_ms timer value in ms, must be at least one timer tick (16 ms)
  * @return 0 on success, negative errno value on failure (see i2c_write_dt()).
- * @retval -EINVAL Time value is too large.
+ * @retval -EINVAL Time value is too large, or shorter than one timer tick
  */
 int mfd_npm13xx_hibernate(const struct device *dev, uint32_t time_ms);
 

--- a/include/zephyr/drivers/mfd/npm13xx.h
+++ b/include/zephyr/drivers/mfd/npm13xx.h
@@ -132,6 +132,17 @@ int mfd_npm13xx_reset(const struct device *dev);
 int mfd_npm13xx_hibernate(const struct device *dev, uint32_t time_ms);
 
 /**
+ * @brief npm13xx ship mode
+ *
+ * Enters lowest power state. Unlike hibernate no wake-up timer is running;
+ * the device only wakes on SHPHLD button press or VBUS connection.
+ *
+ * @param dev npm13xx mfd device
+ * @return 0 on success, negative errno value on failure (see i2c_write_dt()).
+ */
+int mfd_npm13xx_ship_mode(const struct device *dev);
+
+/**
  * @brief Add npm13xx event callback
  *
  * @param dev npm13xx mfd device


### PR DESCRIPTION
tick=0 immediately wakes back up, it's not a useful parameter.