### PR TITLE
samples openthread shell x24: Disable test

### DIFF
--- a/samples/net/openthread/shell/tests.yaml
+++ b/samples/net/openthread/shell/tests.yaml
@@ -40,6 +40,7 @@ tests:
       - esp32c6_devkitc/esp32c6/hpcore
       - esp32h2_devkitm
   sample.net.openthread.shell.xg24:
+    skip: true
     build_only: true
     extra_args:
       - CONFIG_BUILD_ONLY_NO_BLOBS=y


### PR DESCRIPTION
Since PR #111619 was merged modifying this silabs 15.4 driver this sample does not build anymore for this silabs targets without blobs. Let's disable this particular combination until the issue is fixed.

https://github.com/zephyrproject-rtos/zephyr/issues/113574 created for follow up