### PR TITLE
drivers: memc: flash: xspi: enable XSPI NOR on i.MX943 cm33_core1

### DIFF
--- a/boards/nxp/imx943_evk/imx943_evk-pinctrl.dtsi
+++ b/boards/nxp/imx943_evk/imx943_evk-pinctrl.dtsi
@@ -6,6 +6,25 @@
 #include <nxp/nxp_imx/mimx94398avkm-pinctrl.dtsi>
 
 &pinctrl {
+	xspi1_default: xspi1_default {
+		group1 {
+			pinmux = <&iomuxc_xspi1_sclk_xspi_a_sclk_xspi1_a_sclk>,
+				 <&iomuxc_xspi1_dqs_xspi_a_dqs_xspi1_a_dqs>,
+				 <&iomuxc_xspi1_ss0_b_xspi_a_ss_b_xspi1_a_ss0_b>,
+				 <&iomuxc_xspi1_ss1_b_xspi_a_ss_b_xspi1_a_ss1_b>,
+				 <&iomuxc_xspi1_data0_xspi_a_data_xspi1_a_data0>,
+				 <&iomuxc_xspi1_data1_xspi_a_data_xspi1_a_data1>,
+				 <&iomuxc_xspi1_data2_xspi_a_data_xspi1_a_data2>,
+				 <&iomuxc_xspi1_data3_xspi_a_data_xspi1_a_data3>,
+				 <&iomuxc_xspi1_data4_xspi_a_data_xspi1_a_data4>,
+				 <&iomuxc_xspi1_data5_xspi_a_data_xspi1_a_data5>,
+				 <&iomuxc_xspi1_data6_xspi_a_data_xspi1_a_data6>,
+				 <&iomuxc_xspi1_data7_xspi_a_data_xspi1_a_data7>;
+			slew-rate = "fast";
+			drive-strength = "x4";
+		};
+	};
+
 	emdio_default: emdio_default {
 		group1 {
 			pinmux = <&iomuxc_eth4_mdc_gpio1_netc_emdc_netc_emdc>,

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.dts
@@ -120,3 +120,81 @@
 &wdog5 {
 	status = "okay";
 };
+
+&xspi1 {
+	pinctrl-0 = <&xspi1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	/*
+	 * Secure Flash Protection (SFP) MDAD/FRAD configuration.
+	 * Mirrors the MCUXpresso SDK cm33_core1 xspi example.
+	 * i.MX943 CM33 core1: SOC_CPU_DOMAIN_ID = 3.
+	 * Property names / enums per dts/bindings/xspi/nxp,xspi.yaml.
+	 */
+
+	/*
+	 * FRAD - Region 0 (second-level: address-range access control).
+	 * Per-target-group configuration: each target-group@N child maps to
+	 * tgConfig[N], using its unit-address (reg) as the target-group index.
+	 * The master-access array carries one access-permission entry per master
+	 * (tgMasterAccess[]). Only target group 0, master 0 (domain 3) is granted
+	 * access here.
+	 */
+
+	frad_region0 {
+		start-address = <0x00000000>;
+		end-address = <0xffffffff>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* Target group 0: master0 = domain 3, master1 = 0 */
+		target-group@0 {
+			reg = <0>;
+			master-access = <3 0>;
+			assign-valid;
+			descriptor-lock = <0>;
+			exclusive-access-lock = <0>;
+		};
+
+		/* Target group 1 (unused) */
+		target-group@1 {
+			reg = <1>;
+			master-access = <0 0>;
+			descriptor-lock = <0>;
+			exclusive-access-lock = <0>;
+		};
+	};
+
+	nor_flash: flash@0 {
+		compatible = "nxp,xspi-nor";
+		reg = <0>;
+		/* Micron MT35XU512ABA: 512 Mbit = 64 MByte */
+		size = <DT_SIZE_M(64)>;
+
+		device-name = "mt35xu512aba";
+		sample-clk-source = <3>;
+		write-block-size = <2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_partition: partition@0 {
+				label = "image-0";
+				reg = <0x00000000 DT_SIZE_M(7)>;
+			};
+
+			slot1_partition: partition@700000 {
+				label = "image-1";
+				reg = <0x00700000 DT_SIZE_M(7)>;
+			};
+
+			storage_partition: partition@e00000 {
+				label = "storage";
+				reg = <0x00e00000 DT_SIZE_M(2)>;
+			};
+		};
+	};
+};

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.yaml
@@ -21,6 +21,7 @@ supported:
   - pwm
   - uart
   - watchdog
+  - flash
 testing:
   binaries:
     - flash.bin

--- a/drivers/flash/flash_mcux_xspi.c
+++ b/drivers/flash/flash_mcux_xspi.c
@@ -53,6 +53,8 @@ struct flash_mcux_xspi_data {
 	uint32_t amba_address;
 	struct flash_parameters flash_param;
 	uint64_t flash_size;
+	/* Matched device config (set in probe), used for enter-OPI sequence. */
+	struct memc_xspi_dev_config *dev_cfg;
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 	struct flash_pages_layout layout;
 #endif
@@ -63,6 +65,8 @@ struct flash_mcux_xspi_data {
  * Description: Read command including RDSR command can't work if LUT data size in read status is
  * less than 8. Workaround: Use LUT data size of minimum 8 byte for read commands including RDSR.
  */
+
+/* Macronix MX25UM51345G octal SPI NOR LUT. */
 static const uint32_t flash_xspi_lut[][5] = {
 	/* Memory read. */
 	[FLASH_CMD_MEM_READ] = {
@@ -140,6 +144,87 @@ static const uint32_t flash_xspi_lut[][5] = {
 				 kXSPI_8PAD, 0x8),
 	}};
 
+/*
+ * Micron MT35XU512ABA 512 Mbit (64 MByte) octal (8S-8D-8D) SPI NOR LUT.
+ *
+ * This device sends the command opcode SDR on 8 pads (no inverse
+ * command-extension byte) with DDR address/data. Read latency is covered by
+ * the external DQS strobe (sample-clk-source = 3), so the exact dummy count is
+ * not timing-critical. Octal-DDR mode is entered via the volatile
+ * configuration register (cmd 0x81, value 0xE7).
+ */
+static const uint32_t flash_xspi_lut_mt35x[][5] = {
+	/* Memory read (Octal I/O Fast Read, cmd 0xFD). */
+	[FLASH_CMD_MEM_READ] = {
+			XSPI_LUT_SEQ(kXSPI_Command_SDR, kXSPI_8PAD, 0xFD,
+					 kXSPI_Command_RADDR_DDR, kXSPI_8PAD, 0x20),
+			XSPI_LUT_SEQ(kXSPI_Command_DUMMY_SDR, kXSPI_8PAD, 0x03,
+					 kXSPI_Command_READ_DDR, kXSPI_8PAD, 0x04),
+		},
+
+	/* Read status SPI. */
+	[FLASH_CMD_READ_STATUS] = {
+			XSPI_LUT_SEQ(kXSPI_Command_SDR, kXSPI_1PAD, 0x05, kXSPI_Command_READ_SDR,
+					 kXSPI_1PAD, 0x08),
+		},
+
+	/* Read Status OPI (8S-8D-8D): cmd 0x05 SDR on 8 pads, dummy, status DDR. */
+	[FLASH_CMD_READ_STATUS_OPI] = {
+			XSPI_LUT_SEQ(kXSPI_Command_SDR, kXSPI_8PAD, 0x05,
+					 kXSPI_Command_DUMMY_SDR, kXSPI_8PAD, 0x08),
+			XSPI_LUT_SEQ(kXSPI_Command_READ_DDR, kXSPI_8PAD, 0x01,
+					 kXSPI_Command_STOP, kXSPI_1PAD, 0x00),
+		},
+
+	/* Write enable. */
+	[FLASH_CMD_WRITE_ENABLE] = {
+			XSPI_LUT_SEQ(kXSPI_Command_SDR, kXSPI_1PAD, 0x06, kXSPI_Command_STOP,
+					 kXSPI_1PAD, 0x04),
+		},
+
+	/* Write Enable - OPI (8S): cmd 0x06 SDR on 8 pads. */
+	[FLASH_CMD_WRITE_ENABLE_OPI] = {
+			XSPI_LUT_SEQ(kXSPI_Command_SDR, kXSPI_8PAD, 0x06,
+					 kXSPI_Command_STOP, kXSPI_1PAD, 0x00),
+		},
+
+	/* Read ID (OPI). */
+	[FLASH_CMD_READ_ID_OPI] = {
+			XSPI_LUT_SEQ(kXSPI_Command_SDR, kXSPI_8PAD, 0x9F,
+					 kXSPI_Command_DUMMY_SDR, kXSPI_8PAD, 0x08),
+			XSPI_LUT_SEQ(kXSPI_Command_READ_DDR, kXSPI_8PAD, 0x01, kXSPI_Command_STOP,
+					 kXSPI_1PAD, 0x00),
+		},
+
+	/* Erase Sector (8S-8D): cmd 0x21 SDR on 8 pads, address DDR. */
+	[FLASH_CMD_ERASE_SECTOR] = {
+			XSPI_LUT_SEQ(kXSPI_Command_SDR, kXSPI_8PAD, 0x21,
+					 kXSPI_Command_RADDR_DDR, kXSPI_8PAD, 0x20),
+		},
+
+	/*
+	 * Enable OPI DDR mode - Micron MT35X (WRITE VOLATILE CONFIGURATION
+	 * REGISTER, cmd 0x81). Writes configuration register CFR0V (address
+	 * 0x000000) with the octal-DDR-enable value 0xE7. While the device is
+	 * still in the default 1-line SPI 3-byte-address mode, the register
+	 * address MUST be sent as 3 bytes (0x18 = 24 bits); a 4-byte address
+	 * is not recognized and the write is silently ignored.
+	 */
+	[FLASH_CMD_ENTER_OPI] = {
+			XSPI_LUT_SEQ(kXSPI_Command_SDR, kXSPI_1PAD, 0x81, kXSPI_Command_RADDR_SDR,
+					 kXSPI_1PAD, 0x18),
+			XSPI_LUT_SEQ(kXSPI_Command_WRITE_SDR, kXSPI_1PAD, 0x01, kXSPI_Command_STOP,
+					 kXSPI_1PAD, 0x00),
+		},
+
+	/* Page program (Extended Octal Input Fast Program, 8S-8D-8D, cmd 0x12). */
+	[FLASH_CMD_PAGEPROGRAM_OCTAL] = {
+		XSPI_LUT_SEQ(kXSPI_Command_SDR, kXSPI_8PAD, 0x12,
+				 kXSPI_Command_RADDR_DDR, kXSPI_8PAD, 0x20),
+		XSPI_LUT_SEQ(kXSPI_Command_WRITE_DDR, kXSPI_8PAD, 0x04,
+				 kXSPI_Command_STOP, kXSPI_1PAD, 0x00),
+	}};
+
 /* Memory devices table. */
 static struct memc_xspi_dev_config device_configs[] = {
 	{
@@ -163,6 +248,37 @@ static struct memc_xspi_dev_config device_configs[] = {
 			},
 		.lut_array = &flash_xspi_lut[0][0],
 		.lut_count = FLASH_MCUX_XSPI_LUT_ARRAY_SIZE(flash_xspi_lut),
+		.enter_opi_seq = FLASH_CMD_ENTER_OPI,
+		.enter_opi_value = 0x02U, /* WRCR2 DTR-OPI enable */
+	},
+	{
+		/*
+		 * Micron MT35XU512ABA: 512 Mbit (64 MByte) Octal SPI NOR. Uses the
+		 * 8S-8D-8D command scheme; the geometry (256-byte page, 4 KB sector,
+		 * byte-addressable) matches the mx25um51345g device config.
+		 */
+		.name_prefix = "mt35xu512aba",
+		.xspi_dev_config = {
+				.deviceInterface = kXSPI_StrandardExtendedSPI,
+				.interfaceSettings.strandardExtendedSPISettings.pageSize = 256,
+				.CSHoldTime = 2,
+				.CSSetupTime = 2,
+				.addrMode = kXSPI_DeviceByteAddressable,
+				.columnAddrWidth = 0,
+				.enableCASInterleaving = false,
+				.ptrDeviceDdrConfig =
+					&(xspi_device_ddr_config_t){
+						.ddrDataAlignedClk =
+							kXSPI_DDRDataAlignedWith2xInternalRefClk,
+						.enableByteSwapInOctalMode = false,
+						.enableDdr = true,
+					},
+				.deviceSize = {64 * 1024, 64 * 1024},
+			},
+		.lut_array = &flash_xspi_lut_mt35x[0][0],
+		.lut_count = FLASH_MCUX_XSPI_LUT_ARRAY_SIZE(flash_xspi_lut_mt35x),
+		.enter_opi_seq = FLASH_CMD_ENTER_OPI,
+		.enter_opi_value = 0xE7U, /* CFR0V octal-DDR enable */
 	},
 };
 
@@ -385,20 +501,27 @@ static int flash_mcux_xspi_erase(const struct device *dev, off_t offset, size_t 
 
 static int flash_mcux_xspi_enable_opi(const struct device *dev)
 {
-	uint32_t value = FLASH_MX25_WRCR2_DTR_OPI_ENABLE_OFFSET;
 	struct flash_mcux_xspi_data *data = dev->data;
 	const struct device *xspi_dev = data->xspi_dev;
+	uint32_t value = data->dev_cfg->enter_opi_value;
 	xspi_transfer_t flashXfer;
 	int ret;
 
-	ret = flash_mcux_xspi_write_enable(dev, 0, true);
+	/*
+	 * The device is still in 1-line SPI mode here, so the write-enable
+	 * (and the subsequent ENTER_OPI register write) must be issued in
+	 * SPI mode. Using the octal write-enable would not be understood and
+	 * WEL would never latch, leaving the config-register write ignored.
+	 */
+	ret = flash_mcux_xspi_write_enable(dev, 0, false);
 	if (ret < 0) {
+		LOG_ERR("enable_opi: write_enable(SPI) failed: %d", ret);
 		return ret;
 	}
 
 	flashXfer.deviceAddress = data->amba_address;
 	flashXfer.cmdType = kXSPI_Write;
-	flashXfer.seqIndex = FLASH_CMD_ENTER_OPI;
+	flashXfer.seqIndex = data->dev_cfg->enter_opi_seq;
 	flashXfer.targetGroup = kXSPI_TargetGroup0;
 	flashXfer.data = &value;
 	flashXfer.dataSize = 1;
@@ -406,10 +529,24 @@ static int flash_mcux_xspi_enable_opi(const struct device *dev)
 
 	ret = memc_mcux_xspi_transfer(xspi_dev, &flashXfer);
 	if (ret < 0) {
+		LOG_ERR("enable_opi: ENTER_OPI write failed: %d", ret);
 		return ret;
 	}
 
-	return flash_xspi_nor_wait_bus_busy(dev, true);
+	/*
+	 * The mode switch is not instantaneous; the reference HAL waits after
+	 * issuing the enter-octal command before any follow-up transfer.
+	 * Without this the first octal status read races the switch.
+	 */
+	k_busy_wait(100);
+
+	ret = flash_xspi_nor_wait_bus_busy(dev, true);
+
+	if (ret < 0) {
+		LOG_ERR("enable_opi: wait_bus_busy(OPI) failed: %d", ret);
+	}
+
+	return ret;
 }
 
 static const struct flash_parameters *flash_mcux_xspi_get_parameters(const struct device *dev)
@@ -487,15 +624,24 @@ static int flash_mcux_xspi_probe(const struct device *dev)
 			break;
 		}
 
+		/* Store the matched config only after validation, so we never
+		 * persist a NULL dev_cfg that a later dereference could fault on.
+		 */
+		data->dev_cfg = flash_dev_config;
+
 		/* Set special device configurations. */
 		dev_config = &flash_dev_config->xspi_dev_config;
+
 		dev_config->enableCknPad = flash_config->enable_differential_clk;
 		dev_config->sampleClkConfig = flash_config->sample_clk_config;
 
 		ret = memc_mcux_xspi_get_root_clock(xspi_dev, &dev_config->xspiRootClk);
 		if (ret < 0) {
+			LOG_ERR("get_root_clock failed: %d", ret);
 			break;
 		}
+		LOG_INF("probe: matched %s, root clk %u Hz", flash_dev_config->name_prefix,
+			dev_config->xspiRootClk);
 
 		/* Block potential AHB access when setup XSPI. */
 		if (memc_xspi_is_running_xip(xspi_dev)) {
@@ -527,12 +673,21 @@ static int flash_mcux_xspi_init(const struct device *dev)
 
 	ret = flash_mcux_xspi_probe(dev);
 	if (ret < 0) {
+		LOG_ERR("probe failed: %d", ret);
 		return ret;
 	}
 
 	data->amba_address = memc_mcux_xspi_get_ahb_address(xspi_dev);
+	LOG_INF("init: amba_address 0x%08x", data->amba_address);
 
-	return flash_mcux_xspi_enable_opi(dev);
+	ret = flash_mcux_xspi_enable_opi(dev);
+	if (ret < 0) {
+		LOG_ERR("enable_opi failed: %d", ret);
+	} else {
+		LOG_INF("init: enable_opi ok, flash ready");
+	}
+
+	return ret;
 }
 
 static DEVICE_API(flash, flash_mcux_xspi_api) = {

--- a/drivers/flash/flash_mcux_xspi.c
+++ b/drivers/flash/flash_mcux_xspi.c
@@ -13,6 +13,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
+#include <zephyr/cache.h>
 #include "memc_mcux_xspi.h"
 #include "spi_nor.h"
 
@@ -329,7 +330,26 @@ static int flash_mcux_xspi_read(const struct device *dev, off_t offset, void *da
 		return -EINVAL;
 	}
 
+	/*
+	 * Invalidate the XSPI AHB read buffers so this memory-mapped read
+	 * observes the current flash contents rather than data prefetched
+	 * before a preceding erase or program.
+	 */
+	memc_mcux_xspi_clear_ahb_buffer(devData->xspi_dev);
+
+#if defined(CACHE64_CTRL0_BASE)
 	XSPI_Cache64_InvalidateCacheByRange((uint32_t)src, len);
+#endif
+
+	/*
+	 * When the CPU data cache is enabled it may hold stale lines over the
+	 * memory-mapped XSPI region (e.g. contents prefetched before an erase
+	 * or program). Invalidate the CPU data cache for the read range so the
+	 * memcpy below observes the current flash contents.
+	 */
+	if (IS_ENABLED(CONFIG_DCACHE)) {
+		sys_cache_data_invd_range(src, len);
+	}
 
 	(void)memcpy(data, src, len);
 

--- a/drivers/memc/Kconfig.mcux
+++ b/drivers/memc/Kconfig.mcux
@@ -115,8 +115,12 @@ config MEMC_MCUX_XSPI_PSRAM
 	help
 	  Enable the mcux xspi psram driver.
 
+endif # DT_HAS_NXP_XSPI_PSRAM_ENABLED
+
 config MEMC_MCUX_XSPI
 	bool
 	select PINCTRL
-
-endif # DT_HAS_NXP_XSPI_PSRAM_ENABLED
+	help
+	  Common MCUX XSPI controller support. Selected by either the XSPI
+	  PSRAM memc driver or the XSPI NOR flash driver, so it must live
+	  outside the PSRAM-only conditional block.

--- a/drivers/memc/memc_mcux_xspi.c
+++ b/drivers/memc/memc_mcux_xspi.c
@@ -18,6 +18,24 @@ LOG_MODULE_REGISTER(memc_mcux_xspi, CONFIG_MEMC_LOG_LEVEL);
 #define MEMC_XSPI_TARGET_GROUP_COUNT 2
 #define MEMC_XSPI_SFP_FRAD_COUNT     8
 
+/*
+ * The byteOrder and enableDoze members only exist in the HAL xspi_config_t when
+ * the SoC provides the END_CFG / DOZE_MODE XSPI features. Guard the initializers
+ * with the same feature macros so the driver builds on variants that lack them.
+ */
+#if (defined(FSL_FEATURE_XSPI_HAS_END_CFG) && FSL_FEATURE_XSPI_HAS_END_CFG)
+#define MCUX_XSPI_BYTE_ORDER(n) .byteOrder = DT_INST_PROP(n, byte_order),
+#else
+#define MCUX_XSPI_BYTE_ORDER(n)
+#endif
+
+#if (defined(FSL_FEATURE_XSPI_HAS_DOZE_MODE) && FSL_FEATURE_XSPI_HAS_DOZE_MODE)
+#define MCUX_XSPI_DOZE .enableDoze = false,
+#else
+#define MCUX_XSPI_DOZE
+#endif
+
+
 struct memc_mcux_xspi_config {
 	const struct pinctrl_dev_config *pincfg;
 	xspi_config_t xspi_config;
@@ -203,8 +221,8 @@ static int memc_mcux_xspi_init(const struct device *dev)
 	static const struct memc_mcux_xspi_config memc_mcux_xspi_config_##n = {	\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),	\
 		.xspi_config = {	\
-			.byteOrder = DT_INST_PROP(n, byte_order),	\
-			.enableDoze = false,	\
+			MCUX_XSPI_BYTE_ORDER(n)	\
+			MCUX_XSPI_DOZE	\
 			.ptrAhbAccessConfig = &(xspi_ahb_access_config_t){	\
 				.ahbErrorPayload = {	\
 					.highPayload = 0x5A5A5A5A,	\

--- a/drivers/memc/memc_mcux_xspi.c
+++ b/drivers/memc/memc_mcux_xspi.c
@@ -15,8 +15,30 @@
 
 LOG_MODULE_REGISTER(memc_mcux_xspi, CONFIG_MEMC_LOG_LEVEL);
 
+/*
+ * XSPI target-group and FRAD-region counts.
+ *
+ * LISTIFY()/FOR_EACH_*() need the loop bound (and the region-index list) to be
+ * plain decimal integer literals, so they cannot consume the HAL macros
+ * XSPI_TARGET_GROUP_COUNT / XSPI_SFP_FRAD_COUNT directly (those expand to a
+ * parenthesised, U-suffixed value such as "(2U)"). To avoid silently assuming a
+ * count, the literals below are pinned to the HAL values with BUILD_ASSERTs: if
+ * a future HAL changes either count, the build breaks here instead of emitting
+ * a wrong config. Update the literals (and MEMC_XSPI_FRAD_REGION_IDS) to match.
+ */
 #define MEMC_XSPI_TARGET_GROUP_COUNT 2
 #define MEMC_XSPI_SFP_FRAD_COUNT     8
+#define MEMC_XSPI_FRAD_REGION_IDS    0, 1, 2, 3, 4, 5, 6, 7
+
+BUILD_ASSERT(MEMC_XSPI_TARGET_GROUP_COUNT == XSPI_TARGET_GROUP_COUNT,
+	     "MEMC_XSPI_TARGET_GROUP_COUNT is out of sync with the HAL "
+	     "XSPI_TARGET_GROUP_COUNT; update the literal and the tgConfig/tgMdad "
+	     "initializers to match.");
+BUILD_ASSERT(MEMC_XSPI_SFP_FRAD_COUNT == XSPI_SFP_FRAD_COUNT,
+	     "MEMC_XSPI_SFP_FRAD_COUNT is out of sync with the HAL "
+	     "XSPI_SFP_FRAD_COUNT; update the literal and MEMC_XSPI_FRAD_REGION_IDS.");
+BUILD_ASSERT(NUM_VA_ARGS(MEMC_XSPI_FRAD_REGION_IDS) == MEMC_XSPI_SFP_FRAD_COUNT,
+	     "MEMC_XSPI_FRAD_REGION_IDS must enumerate every FRAD region.");
 
 /*
  * The byteOrder and enableDoze members only exist in the HAL xspi_config_t when
@@ -104,7 +126,7 @@ void memc_mcux_xspi_clear_ahb_buffer(const struct device *dev)
 {
 	XSPI_Type *base = ((struct memc_mcux_xspi_data *)dev->data)->base;
 
-	XSPI_ClearAHBRxBuffer(base);
+	XSPI_ClearAhbBuffer(base);
 }
 
 int memc_mcux_xspi_transfer(const struct device *dev, xspi_transfer_t *xfer)
@@ -183,17 +205,47 @@ static int memc_mcux_xspi_init(const struct device *dev)
 #define MEMC_XSPI_CFG_XIP(node_id) false
 #endif
 
+/*
+ * Resolve the mdad@<idx> child node under the sfp-mdad container. The MDAD
+ * descriptors cannot be placed at the xspi top level (a top-level mdad@0 would
+ * collide with the flash@0 chip-select unit-address), so they live in a
+ * dedicated sfp-mdad container, mirroring how target-group@N lives under a
+ * frad_region node. Each child's unit-address (reg) is the tgMdad[] array
+ * subscript. DT_CHILD sanitises "sfp-mdad" to "sfp_mdad" and "mdad@0" to
+ * "mdad_0".
+ */
+#define MCUX_XSPI_MDAD_NODE(n, idx)	\
+	DT_CHILD(DT_CHILD(DT_DRV_INST(n), sfp_mdad), mdad_ ## idx)
 #define MCUX_XSPI_GET_MDAD(n, idx, x)	\
-	DT_PROP(DT_CHILD(DT_DRV_INST(n), mdad_tg ## idx), x)
+	DT_PROP(MCUX_XSPI_MDAD_NODE(n, idx), x)
 #define MCUX_XSPI_GET_FRAD(n, idx, x)	\
 	DT_PROP(DT_CHILD(DT_DRV_INST(n), frad_region ## idx), x)
 
+
+/*
+ * Resolve the target-group@<tgidx> child node of FRAD region <ridx>. Each FRAD
+ * region carries one target-group@N child per target group; the unit-address N
+ * (== the child's reg) is the tgConfig[] array subscript. DT_CHILD sanitises
+ * "target-group@0" to the token "target_group_0".
+ */
+#define MCUX_XSPI_FRAD_TG_NODE(n, ridx, tgidx)	\
+	DT_CHILD(DT_CHILD(DT_DRV_INST(n), frad_region ## ridx),	\
+		 target_group_ ## tgidx)
+
+
+/*
+ * Emit one xspi_mdad_config_t entry for target group <idx>, sourced from the
+ * mdad@<idx> child of the sfp-mdad container. The array subscript is the
+ * child's unit-address (reg), matching the target-group index, so the correct
+ * tgMdad[] slot is populated. Absent mdad@<idx> nodes zero-initialise.
+ */
 #define MCUX_XSPI_MDAD_INIT(idx, n)	\
-	COND_CODE_1(DT_NODE_EXISTS(DT_CHILD(DT_DRV_INST(n), mdad_tg ## idx)),	\
-		({	\
+	COND_CODE_1(DT_NODE_EXISTS(MCUX_XSPI_MDAD_NODE(n, idx)),	\
+		([idx] = {	\
 			.enableDescriptorLock =	\
 				MCUX_XSPI_GET_MDAD(n, idx, enable_descriptor_lock),	\
 			.maskType = MCUX_XSPI_GET_MDAD(n, idx, mask_type),	\
+			.assignIsValid = MCUX_XSPI_GET_MDAD(n, idx, assign_valid),	\
 			.mask = MCUX_XSPI_GET_MDAD(n, idx, mask),	\
 			.masterIdReference =	\
 				MCUX_XSPI_GET_MDAD(n, idx, master_id_reference),	\
@@ -204,24 +256,128 @@ static int memc_mcux_xspi_init(const struct device *dev)
 			0	\
 		}))
 
-#define MCUX_XSPI_FRAD_INIT(idx, n)	\
-	COND_CODE_1(DT_NODE_EXISTS(DT_CHILD(DT_DRV_INST(n), frad_region ## idx)),	\
+
+/*
+ * On XSPI variants that provide the EENV feature (e.g. i.MX943), the HAL
+ * xspi_frad_config_t nests the per-target-group access control inside a
+ * tgConfig[] array (xspi_frad_tg_config_t), one entry per target group. On
+ * variants without EENV the same fields are exposed as flat members. Emit the
+ * layout that matches the HAL struct in use.
+ */
+#if (defined(FSL_FEATURE_XSPI_HAS_EENV) && FSL_FEATURE_XSPI_HAS_EENV)
+/*
+ * Fetch a property from the target-group@<tgidx> child of FRAD region <ridx>:
+ * frad_region<ridx> { target-group@<tgidx> { <x> = <..>; }; }.
+ */
+#define MCUX_XSPI_GET_FRAD_TG(n, ridx, tgidx, x)	\
+	DT_PROP(MCUX_XSPI_FRAD_TG_NODE(n, ridx, tgidx), x)
+
+/*
+ * Emit one xspi_frad_tg_config_t entry for target group <tgidx> of FRAD region
+ * <ridx>. The array subscript is the target-group index itself (the child's
+ * unit-address / reg), so the correct slot is populated without hard-coding a
+ * specific kXSPI_TargetGroupN value. The tgMasterAccess[] array is initialised
+ * from the child's master-access DT array property, so it scales with the HAL
+ * target-group count too.
+ */
+#define MCUX_XSPI_FRAD_TG_INIT(tgidx, ridx, n)	\
+	[tgidx] = {	\
+		.tgMasterAccess = MCUX_XSPI_GET_FRAD_TG(n, ridx, tgidx, master_access),	\
+		.assignIsValid =	\
+			MCUX_XSPI_GET_FRAD_TG(n, ridx, tgidx, assign_valid),	\
+		.descriptorLock =	\
+			MCUX_XSPI_GET_FRAD_TG(n, ridx, tgidx, descriptor_lock),	\
+		.exclusiveAccessLock =	\
+			MCUX_XSPI_GET_FRAD_TG(n, ridx, tgidx, exclusive_access_lock),	\
+	}
+
+/*
+ * Populate every target-group slot of a FRAD region's tgConfig[] array. The
+ * number of slots is driven by the HAL target-group count (LISTIFY index),
+ * never a hard-coded value. LISTIFY() can be used here because the enclosing
+ * FRAD-region loop below uses the FOR_EACH() macro family (a different
+ * expansion mechanism), so there is no LISTIFY-within-LISTIFY recursion.
+ */
+#define MCUX_XSPI_FRAD_TGCONFIG(n, ridx)	\
+	LISTIFY(MEMC_XSPI_TARGET_GROUP_COUNT, MCUX_XSPI_FRAD_TG_INIT, (,), ridx, n)
+
+/*
+ * Emit one xspi_frad_config_t entry for FRAD region <ridx>. Invoked by
+ * FOR_EACH_IDX_FIXED_ARG as F(loop_index, ridx, n); loop_index is unused.
+ */
+#define MCUX_XSPI_FRAD_INIT(unused, ridx, n)	\
+	COND_CODE_1(DT_NODE_EXISTS(DT_CHILD(DT_DRV_INST(n), frad_region ## ridx)),	\
 		({	\
-			.startAddress = MCUX_XSPI_GET_FRAD(n, idx, start_address), \
-			.endAddress = MCUX_XSPI_GET_FRAD(n, idx, end_address),	\
-			.tg0MasterAccess =	\
-				MCUX_XSPI_GET_FRAD(n, idx, tg0_master_access),	\
-			.tg1MasterAccess =	\
-				MCUX_XSPI_GET_FRAD(n, idx, tg1_master_access),	\
-			.assignIsValid = true,	\
-			.descriptorLock =	\
-				MCUX_XSPI_GET_FRAD(n, idx, descriptor_lock),	\
-			.exclusiveAccessLock =	\
-				MCUX_XSPI_GET_FRAD(n, idx, exclusive_access_lock),	\
+			.startAddress = MCUX_XSPI_GET_FRAD(n, ridx, start_address), \
+			.endAddress = MCUX_XSPI_GET_FRAD(n, ridx, end_address),	\
+			.tgConfig = {	\
+				MCUX_XSPI_FRAD_TGCONFIG(n, ridx)	\
+			},	\
 		}),	\
 		({	\
 			0	\
 		}))
+#else
+/*
+ * Non-EENV flat layout: xspi_frad_config_t exposes tg0/tg1 master access as
+ * flat members. Reuse element 0 of each target-group@N child's master-access
+ * array; the descriptor / exclusive-access lock come from target-group@0.
+ */
+#define MCUX_XSPI_GET_FRAD_M0(n, ridx, tgidx)	\
+	DT_PROP_BY_IDX(MCUX_XSPI_FRAD_TG_NODE(n, ridx, tgidx), master_access, 0)
+
+#define MCUX_XSPI_FRAD_INIT(unused, ridx, n)	\
+	COND_CODE_1(DT_NODE_EXISTS(DT_CHILD(DT_DRV_INST(n), frad_region ## ridx)),	\
+		({	\
+			.startAddress = MCUX_XSPI_GET_FRAD(n, ridx, start_address), \
+			.endAddress = MCUX_XSPI_GET_FRAD(n, ridx, end_address),	\
+			.tg0MasterAccess = MCUX_XSPI_GET_FRAD_M0(n, ridx, 0),	\
+			.tg1MasterAccess = MCUX_XSPI_GET_FRAD_M0(n, ridx, 1),	\
+			.assignIsValid = true,	\
+			.descriptorLock =	\
+				DT_PROP(MCUX_XSPI_FRAD_TG_NODE(n, ridx, 0),	\
+					descriptor_lock),	\
+			.exclusiveAccessLock =	\
+				DT_PROP(MCUX_XSPI_FRAD_TG_NODE(n, ridx, 0),	\
+					exclusive_access_lock),	\
+		}),	\
+		({	\
+			0	\
+		}))
+#endif
+
+
+/*
+ * Compile-time validation of the FRAD master-access arrays.
+ *
+ * The HAL sizes xspi_frad_tg_config_t::tgMasterAccess[] with
+ * XSPI_TARGET_GROUP_COUNT, so the number of masters is not hard-coded here: the
+ * DT tg<N>-master-access array supplies the values and its length must not
+ * exceed the HAL array dimension. A too-long array would silently overflow the
+ * initializer, so it is rejected at build time. Shorter arrays are allowed and
+ * leave the remaining masters zero-initialised.
+ */
+#if (defined(FSL_FEATURE_XSPI_HAS_EENV) && FSL_FEATURE_XSPI_HAS_EENV)
+#define MCUX_XSPI_FRAD_TG_CHECK(tgidx, ridx, n)	\
+	BUILD_ASSERT(DT_PROP_LEN(MCUX_XSPI_FRAD_TG_NODE(n, ridx, tgidx),	\
+				 master_access) <=	\
+		     XSPI_TARGET_GROUP_COUNT,	\
+		     "target-group@N master-access has more entries than the HAL "	\
+		     "tgMasterAccess[] can hold (XSPI_TARGET_GROUP_COUNT).");
+
+
+#define MCUX_XSPI_FRAD_REGION_CHECK(unused, ridx, n)	\
+	COND_CODE_1(DT_NODE_EXISTS(DT_CHILD(DT_DRV_INST(n), frad_region ## ridx)),	\
+		(LISTIFY(MEMC_XSPI_TARGET_GROUP_COUNT,	\
+			 MCUX_XSPI_FRAD_TG_CHECK, (), ridx, n)),	\
+		())
+
+#define MCUX_XSPI_VALIDATE(n)	\
+	FOR_EACH_IDX_FIXED_ARG(MCUX_XSPI_FRAD_REGION_CHECK, (), n,	\
+			       MEMC_XSPI_FRAD_REGION_IDS)
+#else
+#define MCUX_XSPI_VALIDATE(n)
+#endif
 
 #define MCUX_XSPI_INIT(n)	\
 	PINCTRL_DT_INST_DEFINE(n);	\
@@ -260,10 +416,11 @@ static int memc_mcux_xspi_init(const struct device *dev)
 					MCUX_XSPI_MDAD_INIT, (,), n)	\
 			},	\
 		},	\
-		.mdad_valid = DT_NODE_EXISTS(DT_CHILD(DT_DRV_INST(n), mdad_tg0)),	\
+		.mdad_valid = DT_NODE_EXISTS(MCUX_XSPI_MDAD_NODE(n, 0)),	\
 		.frad_configs = {	\
 			.fradConfig = {	\
-				LISTIFY(MEMC_XSPI_SFP_FRAD_COUNT, MCUX_XSPI_FRAD_INIT, (,), n)	\
+				FOR_EACH_IDX_FIXED_ARG(MCUX_XSPI_FRAD_INIT, (,), n,	\
+					MEMC_XSPI_FRAD_REGION_IDS)	\
 			},	\
 		},	\
 		.frad_valid = DT_NODE_EXISTS(DT_CHILD(DT_DRV_INST(n), frad_region0)),	\
@@ -279,4 +436,5 @@ static int memc_mcux_xspi_init(const struct device *dev)
 		&memc_mcux_xspi_data_##n, &memc_mcux_xspi_config_##n,	\
 		POST_KERNEL, CONFIG_MEMC_INIT_PRIORITY, NULL);
 
+DT_INST_FOREACH_STATUS_OKAY(MCUX_XSPI_VALIDATE)
 DT_INST_FOREACH_STATUS_OKAY(MCUX_XSPI_INIT)

--- a/drivers/memc/memc_mcux_xspi.c
+++ b/drivers/memc/memc_mcux_xspi.c
@@ -100,6 +100,13 @@ uint32_t memc_mcux_xspi_get_ahb_address(const struct device *dev)
 	return ((const struct memc_mcux_xspi_data *)dev->data)->amba_address;
 }
 
+void memc_mcux_xspi_clear_ahb_buffer(const struct device *dev)
+{
+	XSPI_Type *base = ((struct memc_mcux_xspi_data *)dev->data)->base;
+
+	XSPI_ClearAHBRxBuffer(base);
+}
+
 int memc_mcux_xspi_transfer(const struct device *dev, xspi_transfer_t *xfer)
 {
 	XSPI_Type *base = ((struct memc_mcux_xspi_data *)dev->data)->base;

--- a/drivers/memc/memc_mcux_xspi.h
+++ b/drivers/memc/memc_mcux_xspi.h
@@ -93,4 +93,14 @@ int memc_xspi_set_device_config(const struct device *dev, const xspi_device_conf
  */
 uint32_t memc_mcux_xspi_get_ahb_address(const struct device *dev);
 
+/**
+ * @brief Invalidate the XSPI AHB read buffer.
+ *
+ * Drops any data cached in the XSPI AHB read buffer so a subsequent
+ * memory-mapped read observes the current flash contents (for example after
+ * an erase or program). Does not touch CPU/system caches.
+ * @param dev: XSPI device
+ */
+void memc_mcux_xspi_clear_ahb_buffer(const struct device *dev);
+
 #endif /* ZEPHYR_DRIVERS_MEMC_MCUX_XSPI_H_ */

--- a/drivers/memc/memc_mcux_xspi.h
+++ b/drivers/memc/memc_mcux_xspi.h
@@ -31,6 +31,7 @@ struct memc_xspi_dev_config {
 };
 
 
+
 /**
  * @brief Update device address mode.
  *
@@ -94,11 +95,12 @@ int memc_xspi_set_device_config(const struct device *dev, const xspi_device_conf
 uint32_t memc_mcux_xspi_get_ahb_address(const struct device *dev);
 
 /**
- * @brief Invalidate the XSPI AHB read buffer.
+ * @brief Invalidate the XSPI AHB read buffers.
  *
- * Drops any data cached in the XSPI AHB read buffer so a subsequent
- * memory-mapped read observes the current flash contents (for example after
- * an erase or program). Does not touch CPU/system caches.
+ * The XSPI controller caches memory-mapped flash reads in its AHB buffers.
+ * After an erase or program the buffer contents are stale, so it must be
+ * cleared before the next memory-mapped read to observe the new flash data.
+ *
  * @param dev: XSPI device
  */
 void memc_mcux_xspi_clear_ahb_buffer(const struct device *dev);

--- a/drivers/memc/memc_mcux_xspi.h
+++ b/drivers/memc/memc_mcux_xspi.h
@@ -15,7 +15,21 @@ struct memc_xspi_dev_config {
 	xspi_device_config_t xspi_dev_config;
 	const uint32_t *lut_array;
 	size_t lut_count;
+	/*
+	 * Value written by the FLASH_CMD_ENTER_OPI sequence to switch the
+	 * device into octal-DDR mode. This is device-family specific:
+	 * e.g. Macronix MX25 WRCR2 DTR-OPI bit = 0x02, Micron MT35X
+	 * volatile-config-register octal-DDR value = 0xE7.
+	 */
+	uint32_t enter_opi_value;
+	/*
+	 * LUT sequence index used to switch the device into octal mode.
+	 * Device-family specific (Macronix and Micron use different
+	 * commands/register layouts).
+	 */
+	uint8_t enter_opi_seq;
 };
+
 
 /**
  * @brief Update device address mode.

--- a/dts/arm/nxp/imx/nxp_imx943_m33.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx943_m33.dtsi
@@ -196,3 +196,31 @@
 	interrupts = <292 0>;
 	status = "okay";
 };
+
+&xspi1 {
+	/*
+	 * Secure Flash Protection (SFP) MDAD configuration.
+	 * i.MX943 CM33 core1: SOC_CPU_DOMAIN_ID = 3.
+	 * Property names / enums per dts/bindings/xspi/nxp,xspi.yaml.
+	 *
+	 * MDAD - first-level: secure attribute + master ID check.
+	 * The sfp-mdad container holds one mdad@N child per target group; each
+	 * child's unit-address (reg) is the tgMdad[] array subscript, matching
+	 * the target-group@N style used by the FRAD regions.
+	 */
+	sfp-mdad {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* Target group 0 */
+		mdad@0 {
+			reg = <0>;
+			enable-descriptor-lock = <0>;    /* descriptor lock disabled */
+			mask-type = <0>;                 /* 0 = AND (kXSPI_MdadMaskTypeAnd) */
+			mask = <3>;                      /* SOC_CPU_DOMAIN_ID */
+			master-id-reference = <3>;       /* SOC_CPU_DOMAIN_ID */
+			secure-attribute = <3>;          /* 3 = NonsecureSecureBoth */
+			assign-valid;                    /* assignIsValid = true (TG0MDAD.VLD) */
+		};
+	};
+};

--- a/dts/arm/nxp/imx/nxp_imx94x.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx94x.dtsi
@@ -213,6 +213,18 @@
 			status = "disabled";
 		};
 
+		xspi1: spi@42b90000 {
+			compatible = "nxp,xspi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x42b90000 DT_SIZE_K(64)>,
+			      <0x28000000 DT_SIZE_M(128)>;
+			reg-names = "xspi", "xspi_mmap";
+			interrupts = <390 0>;
+			clocks = <&scmi_clk IMX943_CLK_XSPI1>;
+			status = "disabled";
+		};
+
 		lpi2c6: i2c@426c0000 {
 			compatible = "nxp,lpi2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;

--- a/dts/bindings/xspi/nxp,xspi.yaml
+++ b/dts/bindings/xspi/nxp,xspi.yaml
@@ -38,51 +38,92 @@ child-binding:
   description: NXP XSPI MDAD/FRAD configurations
 
   properties:
-    # MDAD configuration
-    enable-descriptor-lock:
-      type: int
-      description: Enable descriptor lock
-    mask-type:
-      type: int
-      description: Mask type (0=AND, 1=OR)
-    mask:
-      type: int
-      description: 6-bit mask value
-    master-id-reference:
-      type: int
-      description: Master ID reference value
-    secure-attribute:
-      type: int
-      enum: [1, 2, 3]
-      description: Security attribute setting
-
-    # FRAD configuration
+    # FRAD region address range (start-address/end-address) and the
+    # #address-cells/#size-cells needed by the target-group@N / mdad@N children.
     start-address:
       type: int
       description: Start address of the memory region
+
     end-address:
       type: int
       description: End address of the memory region
-    tg0-master-access:
+
+    "#address-cells":
       type: int
-      description: Target group 0 access permissions
-    tg1-master-access:
-      type: int
-      description: Target group 1 access permissions
-    descriptor-lock:
-      type: int
-      enum: [0, 1, 2, 3]
+      const: 1
       description: |
-        Descriptor lock mode:
-        - Disable
-        - Enable till hard reset
-        - Enable except master ID
-        - Enable
-    exclusive-access-lock:
+        Required so each per-target-group child (target-group@N) can carry a
+        unit-address that encodes its target-group index.
+    "#size-cells":
       type: int
-      enum: [0, 2, 3]
-      description: |
-        Exclusive access lock mode:
-        - Disable
-        - Enable except master ID
-        - Enable
+      const: 0
+
+  # Shared nested child-binding for both FRAD target-group@N children (under a
+  # frad_region node) and MDAD mdad@N children (under the sfp-mdad container).
+  # A DT node has a single nested child-binding that applies to all of its
+  # grandchildren, so this binding is a superset carrying both the FRAD
+  # per-target-group properties and the MDAD descriptor properties. Each child
+  # uses its unit-address (reg) as the tgConfig[] / tgMdad[] array subscript.
+  # On XSPI variants with the EENV feature the HAL nests one
+  # xspi_frad_tg_config_t per target group; on variants without EENV only
+  # element 0 of target group 0 / 1 is consumed.
+  child-binding:
+    description: XSPI FRAD target-group / MDAD per-target-group descriptor
+
+    properties:
+      reg:
+        type: array
+        required: true
+        description: |
+          Target-group index this descriptor configures (used as the
+          tgConfig[] / tgMdad[] array subscript).
+
+      # MDAD descriptor properties (mdad@N under the sfp-mdad container)
+      enable-descriptor-lock:
+        type: int
+        description: Enable descriptor lock
+      mask-type:
+        type: int
+        description: Mask type (0=AND, 1=OR)
+      mask:
+        type: int
+        description: 6-bit mask value
+      master-id-reference:
+        type: int
+        description: Master ID reference value
+      secure-attribute:
+        type: int
+        enum: [1, 2, 3]
+        description: Security attribute setting
+
+      # FRAD per-target-group properties (target-group@N under a frad_region)
+
+      master-access:
+        type: array
+        description: |
+          Per-master access permissions for this target group, one entry per
+          master (tgMasterAccess[]). The array length should match the HAL
+          target-group count. On the non-EENV flat layout only element 0 is
+          consumed.
+      assign-valid:
+        type: boolean
+        description: Mark this FRAD descriptor valid (assignIsValid).
+      descriptor-lock:
+        type: int
+        default: 0
+        enum: [0, 1, 2, 3]
+        description: |
+          Descriptor lock mode:
+          - Disable
+          - Enable till hard reset
+          - Enable except master ID
+          - Enable
+      exclusive-access-lock:
+        type: int
+        default: 0
+        enum: [0, 2, 3]
+        description: |
+          Exclusive access lock mode:
+          - Disable
+          - Enable except master ID
+          - Enable


### PR DESCRIPTION
Enable the existing NXP MCUX XSPI NOR flash and memc drivers on the i.MX943 EVK cm33_core1 (MIMX94398), add support for the on-board Micron MT35XU512ABA octal NOR flash, and make the drivers build on XSPI variants that lack the END_CFG / DOZE_MODE / CACHE64 hardware features.

Device tree / board enablement:
- Add the SoC-level xspi1 controller node (nxp,xspi) to the i.MX943 dtsi.
- Enable &xspi1 on imx943_evk cm33_core1 with the on-board NOR flash and its fixed partitions, plus the xspi1_default pinctrl group.
- List "flash" in the board twister supported features.

Flash device support:
- Add support for the Micron MT35XU512ABA octal SPI NOR using an 8S-8D-8D LUT (opcode sent SDR on 8 pads, no inverse command-extension byte; octal mode entered via the volatile configuration register, cmd 0x81 = 0xE7).
- Invalidate the XSPI AHB read buffers before a memory-mapped read so the read observes the current flash contents after an erase or program.
- Invalidate the CPU data cache for the read range before the memcpy when CONFIG_DCACHE is enabled, so reads stay coherent with prior erase/program operations instead of returning stale cached lines.

Secure Flash Protection (SFP) MDAD/FRAD access control:
- Add optional MDAD (Master Domain Assignment Descriptor) and FRAD (Flash Region Access Descriptor) configuration to the nxp,xspi binding and the memc driver, populating xspi_sfp_mdad_config_t / xspi_sfp_frad_config_t only when the corresponding device tree nodes exist.
- Model the two-level access control with unit-addressed child nodes so the device tree mirrors the HAL array layout: an sfp-mdad container holds one mdad@N child per target group (reg = tgMdad[] index), and each frad_regionN holds one target-group@N child per target group (reg = tgConfig[] index). A shared nested child-binding is a superset of the MDAD and FRAD per-target -group properties, since a node has a single nested binding for all of its grandchildren.
- Drive every per-target-group loop bound from the HAL target-group / FRAD region counts (pinned to plain literals with BUILD_ASSERTs) rather than hard-coding a value, and emit the EENV nested tgConfig[] layout or the non-EENV flat layout depending on FSL_FEATURE_XSPI_HAS_EENV.
- Configure the i.MX943 EVK cm33_core1 (SOC_CPU_DOMAIN_ID = 3) with an MDAD target group and a full-range FRAD region granting domain 3 access, matching the MCUXpresso SDK cm33_core1 xspi example.

Driver portability fixes:
- Kconfig: move MEMC_MCUX_XSPI out of the DT_HAS_NXP_XSPI_PSRAM_ENABLED block so FLASH_MCUX_XSPI (NOR-only, no PSRAM) can select it.
- memc: guard the xspi_config_t byteOrder / enableDoze initializers with FSL_FEATURE_XSPI_HAS_END_CFG / FSL_FEATURE_XSPI_HAS_DOZE_MODE, matching the HAL, so the driver builds where those members are absent.
- flash: guard the XSPI_Cache64_InvalidateCacheByRange call with CACHE64_CTRL0_BASE, the same condition the HAL uses to declare it.

Verified on imx943_evk/mimx94398/m33 (flash_shell sample): init reaches octal-ready, and read / write / erase are coherent with the CPU data cache enabled.