### PR TITLE
Bluetooth: CCP: Fix typo in ccp_call_control_client file header

### DIFF
--- a/subsys/bluetooth/audio/ccp_call_control_client.c
+++ b/subsys/bluetooth/audio/ccp_call_control_client.c
@@ -1,4 +1,4 @@
-/* Bluetooth CCP - Call Control Profile Call Control Server
+/* Bluetooth CCP - Call Control Profile Call Control Client
  *
  * Copyright (c) 2024 Nordic Semiconductor ASA
  *


### PR DESCRIPTION
It should say client and not server.