### PR TITLE
Bluetooth: ATT: Do not guard functions with #if defined

### DIFF
--- a/include/zephyr/bluetooth/att.h
+++ b/include/zephyr/bluetooth/att.h
@@ -132,21 +132,35 @@ static inline const char *bt_att_err_to_str(uint8_t att_err)
 }
 #endif
 
-#if defined(CONFIG_BT_EATT)
-#if defined(CONFIG_BT_TESTING)
-
+/** @cond INTERNAL_HIDDEN */
+/**
+ * @brief Test function to disconnect a single EATT bearer
+ *
+ * @kconfig_dep{CONFIG_BT_EATT,CONFIG_BT_TESTING}
+ *
+ * @param conn The connection to disconnect the EATT bearer on
+ * @return 0 in case of success, else negative errno value
+ */
 int bt_eatt_disconnect_one(struct bt_conn *conn);
 
-/* Reconfigure all EATT channels on connection */
+/**
+ * @brief Test function to reconfigure all EATT channels on connection
+ *
+ * @kconfig_dep{CONFIG_BT_EATT,CONFIG_BT_TESTING}
+ *
+ * @param conn The connection to disconnect the EATT bearer on
+ * @return 0 in case of success, else negative errno value
+ */
 int bt_eatt_reconfigure(struct bt_conn *conn, uint16_t mtu);
-
-#endif /* CONFIG_BT_TESTING */
+/** @endcond */
 
 /** @brief Connect Enhanced ATT channels
  *
  * Sends a series of Credit Based Connection Requests to connect @p num_channels
  * Enhanced ATT channels. The peer may have limited resources and fewer channels
  * may be created.
+ *
+ * @kconfig_dep{CONFIG_BT_EATT}
  *
  * @param conn The connection to send the request on
  * @param num_channels The number of Enhanced ATT bearers to request.
@@ -161,14 +175,14 @@ int bt_eatt_connect(struct bt_conn *conn, size_t num_channels);
 
 /** @brief Get number of EATT channels connected.
  *
+ * @kconfig_dep{CONFIG_BT_EATT}
+ *
  * @param conn The connection to get the number of EATT channels for.
  *
  * @return The number of EATT channels connected.
  * Returns 0 if @p conn is NULL or not connected.
  */
 size_t bt_eatt_count(struct bt_conn *conn);
-
-#endif /* CONFIG_BT_EATT */
 
 /** @brief ATT channel option bit field values.
  * @note @ref BT_ATT_CHAN_OPT_UNENHANCED_ONLY and @ref BT_ATT_CHAN_OPT_ENHANCED_ONLY are mutually


### PR DESCRIPTION
Removed the guards, and properly hid the test functions from the documentation, and used @kconfig_dep to provide information about the dependencies.