### PR TITLE
Bluetooth: Include: Add missing defined(__DOXYGEN__)

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -238,7 +238,7 @@ struct bt_audio_codec_cfg {
 	 * BT_HCI_CODING_FORMAT_TRANSPARENT if false, else uses the @ref bt_audio_codec_cfg.id.
 	 */
 	bool ctlr_transcode;
-#if defined(CONFIG_BT_BAP_UNICAST)
+#if defined(CONFIG_BT_BAP_UNICAST) || defined(__DOXYGEN__)
 	/** Target latency
 	 *
 	 * Unused for broadcast streams.

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -165,7 +165,7 @@ struct bt_cap_initiator_cb {
 	 */
 	void (*unicast_stop_complete)(int err, struct bt_conn *conn);
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
-#if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
+#if defined(CONFIG_BT_BAP_BROADCAST_SOURCE) || defined(__DOXYGEN__)
 	/**
 	 * @brief The Broadcast Source has started and all of the streams are ready for audio data
 	 *

--- a/include/zephyr/bluetooth/audio/micp.h
+++ b/include/zephyr/bluetooth/audio/micp.h
@@ -217,7 +217,7 @@ struct bt_micp_mic_ctlr_cb {
 	 */
 	void (*unmute_written)(struct bt_micp_mic_ctlr *mic_ctlr, int err);
 
-#if defined(CONFIG_BT_MICP_MIC_CTLR_AICS)
+#if defined(CONFIG_BT_MICP_MIC_CTLR_AICS) || defined(__DOXYGEN__)
 	/** Audio Input Control Service client callback */
 	struct bt_aics_cb               aics_cb;
 #endif /* CONFIG_BT_MICP_MIC_CTLR_AICS */

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -252,7 +252,7 @@ struct bt_le_ext_adv_cb {
 	void (*scanned)(struct bt_le_ext_adv *adv,
 			struct bt_le_ext_adv_scanned_info *info);
 
-#if defined(CONFIG_BT_PRIVACY)
+#if defined(CONFIG_BT_PRIVACY) || defined(__DOXYGEN__)
 	/**
 	 * @brief The RPA validity of the advertising set has expired.
 	 *
@@ -1733,7 +1733,7 @@ struct bt_le_per_adv_sync_synced_info {
 	 *
 	 */
 	struct bt_conn *conn;
-#if defined(CONFIG_BT_PER_ADV_SYNC_RSP)
+#if defined(CONFIG_BT_PER_ADV_SYNC_RSP) || defined(__DOXYGEN__)
 	/** Number of subevents */
 	uint8_t num_subevents;
 
@@ -1804,7 +1804,7 @@ struct bt_le_per_adv_sync_recv_info {
 
 	/** The Constant Tone Extension (CTE) of the advertisement (@ref bt_df_cte_type) */
 	uint8_t cte_type;
-#if defined(CONFIG_BT_PER_ADV_SYNC_RSP)
+#if defined(CONFIG_BT_PER_ADV_SYNC_RSP) || defined(__DOXYGEN__)
 	/** The value of the event counter where the subevent indication was received. */
 	uint16_t periodic_event_counter;
 

--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -780,7 +780,7 @@ struct bt_a2dp_stream_ops {
 	 * @param stream Stream object that has been suspended.
 	 */
 	void (*suspended)(struct bt_a2dp_stream *stream);
-#if defined(CONFIG_BT_A2DP_SINK)
+#if defined(CONFIG_BT_A2DP_SINK) || defined(__DOXYGEN__)
 	/** @brief the media streaming data, only for sink
 	 *
 	 *  @param buf the data buf
@@ -789,8 +789,8 @@ struct bt_a2dp_stream_ops {
 	 */
 	void (*recv)(struct bt_a2dp_stream *stream, struct net_buf *buf, uint16_t seq_num,
 		     uint32_t ts);
-#endif
-#if defined(CONFIG_BT_A2DP_SOURCE)
+#endif /* CONFIG_BT_A2DP_SINK */
+#if defined(CONFIG_BT_A2DP_SOURCE) || defined(__DOXYGEN__)
 	/**
 	 * @brief Stream audio HCI sent callback
 	 *
@@ -814,7 +814,7 @@ struct bt_a2dp_stream_ops {
 	 * @param value The delay report value in 1/10 milliseconds.
 	 */
 	void (*delay_report)(struct bt_a2dp_stream *stream, uint16_t value);
-#endif
+#endif /* CONFIG_BT_A2DP_SOURCE */
 };
 
 /**

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1131,17 +1131,18 @@ struct bt_conn_le_info {
 	uint16_t latency; /**< Connection peripheral latency */
 	uint16_t timeout; /**< Connection supervision timeout */
 
-#if defined(CONFIG_BT_USER_PHY_UPDATE)
+#if defined(CONFIG_BT_USER_PHY_UPDATE) || defined(__DOXYGEN__)
+	/** Connection PHY info  */
 	const struct bt_conn_le_phy_info      *phy;
 #endif /* defined(CONFIG_BT_USER_PHY_UPDATE) */
 
-#if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
-	/* Connection maximum single fragment parameters */
+#if defined(CONFIG_BT_USER_DATA_LEN_UPDATE) || defined(__DOXYGEN__)
+	/** Connection maximum single fragment parameters */
 	const struct bt_conn_le_data_len_info *data_len;
 #endif /* defined(CONFIG_BT_USER_DATA_LEN_UPDATE) */
 
-#if defined(CONFIG_BT_SUBRATING)
-	/* Connection subrating parameters */
+#if defined(CONFIG_BT_SUBRATING) || defined(__DOXYGEN__)
+	/** Connection subrating parameters */
 	const struct bt_conn_le_subrating_info *subrate;
 #endif /* defined(CONFIG_BT_SUBRATING) */
 };
@@ -2161,7 +2162,7 @@ struct bt_conn_le_cs_procedure_enable_complete {
 
 /** @brief BR/EDR specific connection callbacks. */
 struct bt_conn_br_cb {
-#if defined(CONFIG_BT_POWER_MODE_CONTROL)
+#if defined(CONFIG_BT_POWER_MODE_CONTROL) || defined(__DOXYGEN__)
 	/** @brief A BR/EDR connection mode has changed.
 	 *
 	 *  This callback notifies the application that the sniff mode has changed.
@@ -2339,7 +2340,7 @@ struct bt_conn_cb {
 	void (*le_param_update_rejected)(struct bt_conn *conn, uint8_t hci_err);
 #endif /* defined(CONFIG_BT_USER_CONN_PARAM_REJECTED) || defined(__DOXYGEN__) */
 
-#if defined(CONFIG_BT_SMP)
+#if defined(CONFIG_BT_SMP) || defined(__DOXYGEN__)
 	/** @brief Remote Identity Address has been resolved.
 	 *
 	 *  This callback notifies the application that a remote
@@ -2374,7 +2375,7 @@ struct bt_conn_cb {
 				 enum bt_security_err err);
 #endif /* defined(CONFIG_BT_SMP) || defined(CONFIG_BT_CLASSIC) */
 
-#if defined(CONFIG_BT_REMOTE_INFO)
+#if defined(CONFIG_BT_REMOTE_INFO) || defined(__DOXYGEN__)
 	/** @brief Remote information procedures has completed.
 	 *
 	 *  This callback notifies the application that the remote information
@@ -2387,12 +2388,12 @@ struct bt_conn_cb {
 				      struct bt_conn_remote_info *remote_info);
 #endif /* defined(CONFIG_BT_REMOTE_INFO) */
 
-#if defined(CONFIG_BT_CLASSIC)
+#if defined(CONFIG_BT_CLASSIC) || defined(__DOXYGEN__)
 	/** @brief BR/EDR specific callbacks. */
 	struct bt_conn_br_cb br;
 #endif /* CONFIG_BT_CLASSIC */
 
-#if defined(CONFIG_BT_USER_PHY_UPDATE)
+#if defined(CONFIG_BT_USER_PHY_UPDATE) || defined(__DOXYGEN__)
 	/** @brief The PHY of the connection has changed.
 	 *
 	 *  This callback notifies the application that the PHY of the
@@ -2405,7 +2406,7 @@ struct bt_conn_cb {
 			       struct bt_conn_le_phy_info *param);
 #endif /* defined(CONFIG_BT_USER_PHY_UPDATE) */
 
-#if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
+#if defined(CONFIG_BT_USER_DATA_LEN_UPDATE) || defined(__DOXYGEN__)
 	/** @brief The data length parameters of the connection has changed.
 	 *
 	 *  This callback notifies the application that the maximum Link Layer
@@ -2418,7 +2419,7 @@ struct bt_conn_cb {
 				    struct bt_conn_le_data_len_info *info);
 #endif /* defined(CONFIG_BT_USER_DATA_LEN_UPDATE) */
 
-#if defined(CONFIG_BT_DF_CONNECTION_CTE_RX)
+#if defined(CONFIG_BT_DF_CONNECTION_CTE_RX) || defined(__DOXYGEN__)
 	/** @brief Callback for IQ samples report collected when sampling
 	 *        CTE received by data channel PDU.
 	 *
@@ -2429,7 +2430,7 @@ struct bt_conn_cb {
 			      const struct bt_df_conn_iq_samples_report *iq_report);
 #endif /* CONFIG_BT_DF_CONNECTION_CTE_RX */
 
-#if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
+#if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL) || defined(__DOXYGEN__)
 	/** @brief LE Read Remote Transmit Power Level procedure has completed or LE
 	 *  Transmit Power Reporting event.
 	 *
@@ -2445,7 +2446,7 @@ struct bt_conn_cb {
 				const struct bt_conn_le_tx_power_report *report);
 #endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */
 
-#if defined(CONFIG_BT_PATH_LOSS_MONITORING)
+#if defined(CONFIG_BT_PATH_LOSS_MONITORING) || defined(__DOXYGEN__)
 	/** @brief LE Path Loss Threshold event.
 	 *
 	 *  This callback notifies the application that there has been a path loss threshold
@@ -2459,7 +2460,7 @@ struct bt_conn_cb {
 				const struct bt_conn_le_path_loss_threshold_report *report);
 #endif /* CONFIG_BT_PATH_LOSS_MONITORING */
 
-#if defined(CONFIG_BT_SUBRATING)
+#if defined(CONFIG_BT_SUBRATING) || defined(__DOXYGEN__)
 	/** @brief LE Subrate Changed event.
 	 *
 	 *  This callback notifies the application that the subrating parameters
@@ -2499,7 +2500,7 @@ struct bt_conn_cb {
 				  const struct bt_conn_le_conn_rate_changed *params);
 #endif /* CONFIG_BT_SHORTER_CONNECTION_INTERVALS */
 
-#if defined(CONFIG_BT_LE_EXTENDED_FEAT_SET)
+#if defined(CONFIG_BT_LE_EXTENDED_FEAT_SET) || defined(__DOXYGEN__)
 	/** @brief Read all remote features complete event.
 	 *
 	 *  This callback notifies the application that a 'read all remote
@@ -2518,7 +2519,7 @@ struct bt_conn_cb {
 		const struct bt_conn_le_read_all_remote_feat_complete *params);
 #endif /* CONFIG_BT_LE_EXTENDED_FEAT_SET */
 
-#if defined(CONFIG_BT_FRAME_SPACE_UPDATE)
+#if defined(CONFIG_BT_FRAME_SPACE_UPDATE) || defined(__DOXYGEN__)
 	/** @brief Frame Space Update Complete event.
 	 *
 	 *  This callback notifies the application that the frame space of
@@ -2538,7 +2539,7 @@ struct bt_conn_cb {
 		const struct bt_conn_le_frame_space_updated *params);
 #endif /* CONFIG_BT_FRAME_SPACE_UPDATE */
 
-#if defined(CONFIG_BT_CHANNEL_SOUNDING)
+#if defined(CONFIG_BT_CHANNEL_SOUNDING) || defined(__DOXYGEN__)
 	/** @brief LE CS Read Remote Supported Capabilities Complete event.
 	 *
 	 *  This callback notifies the application that a Channel Sounding
@@ -2913,7 +2914,7 @@ struct bt_conn_pairing_feat {
 
 /** Authenticated pairing callback structure */
 struct bt_conn_auth_cb {
-#if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)
+#if defined(CONFIG_BT_SMP_APP_PAIRING_ACCEPT) || defined(__DOXYGEN__)
 	/** @brief Query to proceed incoming pairing or not.
 	 *
 	 *  On any incoming pairing req/rsp this callback will be called for
@@ -2967,7 +2968,7 @@ struct bt_conn_auth_cb {
 	 */
 	void (*passkey_display)(struct bt_conn *conn, unsigned int passkey);
 
-#if defined(CONFIG_BT_PASSKEY_KEYPRESS)
+#if defined(CONFIG_BT_PASSKEY_KEYPRESS) || defined(__DOXYGEN__)
 	/** @brief Receive Passkey Keypress Notification during pairing
 	 *
 	 *  This allows the remote device to use the local device to give users
@@ -2991,7 +2992,7 @@ struct bt_conn_auth_cb {
 	 */
 	void (*passkey_display_keypress)(struct bt_conn *conn,
 					 enum bt_conn_auth_keypress type);
-#endif
+#endif /* CONFIG_BT_PASSKEY_KEYPRESS */
 
 	/** @brief Request the user to enter a passkey.
 	 *
@@ -3089,7 +3090,7 @@ struct bt_conn_auth_cb {
 	 */
 	void (*pairing_confirm)(struct bt_conn *conn);
 
-#if defined(CONFIG_BT_CLASSIC)
+#if defined(CONFIG_BT_CLASSIC) || defined(__DOXYGEN__)
 	/** @brief Request the user to enter a passkey.
 	 *
 	 *  This callback will be called for a BR/EDR (Bluetooth Classic)
@@ -3109,9 +3110,9 @@ struct bt_conn_auth_cb {
 	 *  @param highsec true if 16 digit PIN is required.
 	 */
 	void (*pincode_entry)(struct bt_conn *conn, bool highsec);
-#endif
+#endif /* CONFIG_BT_CLASSIC */
 
-#if defined(CONFIG_BT_APP_PASSKEY)
+#if defined(CONFIG_BT_APP_PASSKEY) || defined(__DOXYGEN__)
 	/** @brief Allow the application to provide a passkey for pairing.
 	 *
 	 *  If implemented, this callback allows the application to provide passkeys for pairing.
@@ -3167,7 +3168,7 @@ struct bt_conn_auth_info_cb {
 	 */
 	void (*bond_deleted)(uint8_t id, const bt_addr_le_t *peer);
 
-#if defined(CONFIG_BT_CLASSIC)
+#if defined(CONFIG_BT_CLASSIC) || defined(__DOXYGEN__)
 	/** @brief Notify that bond of classic has been deleted.
 	 *
 	 *  This callback notifies the application that the bond information of classic

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -2246,13 +2246,13 @@ struct bt_gatt_subscribe_params {
 #endif /* defined(CONFIG_BT_GATT_AUTO_DISCOVER_CCC) || defined(__DOXYGEN__) */
 	/** Subscribe value */
 	uint16_t value;
-#if defined(CONFIG_BT_SMP)
+#if defined(CONFIG_BT_SMP) || defined(__DOXYGEN__)
 	/** Minimum required security for received notification. Notifications
 	 * and indications received over a connection with a lower security
 	 * level are silently discarded.
 	 */
 	bt_security_t min_security;
-#endif
+#endif /* CONFIG_BT_SMP */
 	/** Subscription flags, see @ref bt_gatt_sub_flag */
 	ATOMIC_DEFINE(flags, BT_GATT_SUBSCRIBE_NUM_FLAGS);
 

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -743,7 +743,7 @@ struct bt_l2cap_chan_ops {
 	 */
 	void (*reconfigured)(struct bt_l2cap_chan *chan);
 
-#if defined(CONFIG_BT_L2CAP_SEG_RECV)
+#if defined(CONFIG_BT_L2CAP_SEG_RECV) || defined(__DOXYGEN__)
 	/** @brief Handle L2CAP segments directly
 	 *
 	 *  This is an alternative to @ref bt_l2cap_chan_ops.recv. They cannot

--- a/include/zephyr/bluetooth/services/ots.h
+++ b/include/zephyr/bluetooth/services/ots.h
@@ -520,12 +520,12 @@ struct bt_ots_date_time {
  */
 struct bt_ots_obj_metadata {
 
-#if defined(CONFIG_BT_OTS)
+#if defined(CONFIG_BT_OTS) || defined(__DOXYGEN__)
 	/** @brief Object Name */
 	char                           *name;
 #endif /* CONFIG_BT_OTS */
 
-#if defined(CONFIG_BT_OTS_CLIENT)
+#if defined(CONFIG_BT_OTS_CLIENT) || defined(__DOXYGEN__)
 	/* TODO: Unify client/server name */
 	/** @brief Object name (client) */
 	char                           name_c[CONFIG_BT_OTS_OBJ_MAX_NAME_LEN + 1];
@@ -537,7 +537,7 @@ struct bt_ots_obj_metadata {
 	/** @brief Object Size */
 	struct bt_ots_obj_size         size;
 
-#if defined(CONFIG_BT_OTS_CLIENT)
+#if defined(CONFIG_BT_OTS_CLIENT) || defined(__DOXYGEN__)
 	/** @brief Object first created time */
 	struct bt_ots_date_time        first_created;
 


### PR DESCRIPTION
Add missing `defined(__DOXYGEN__)` for several struct fields.