### PR TITLE
soc: realtek: fix timing init order

### DIFF
--- a/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
+++ b/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
@@ -18,9 +18,6 @@ config SYS_CLOCK_TICKS_PER_SEC
 config TIMESLICE_SIZE
 	default 10
 
-config ARCH_HAS_CUSTOM_BUSY_WAIT
-	default y
-
 if BT
 
 config NUM_METAIRQ_PRIORITIES

--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -149,17 +149,17 @@ void soc_early_init_hook(void)
 	power_manager_master_init();
 	power_manager_slave_init();
 	platform_pm_init();
+}
 
+void soc_late_init_hook(void)
+{
 	/* Initialize OSC32 SDM software timer. */
 	init_osc_sdm_timer();
 
 	/* Initialize PHY hardware control. */
 	phy_hw_control_init(false);
 	phy_init(false);
-}
 
-void soc_late_init_hook(void)
-{
 	/* Initialize HW AES mutex. */
 	hw_aes_create_mutex();
 

--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -15,7 +15,6 @@
 #include "rom_uuid.h"
 #include "rtl_boot_record.h"
 #include "system_rtl876x.h"
-#include "utils.h"
 #include "vector_table.h"
 #include "rtl876x_aon_reg.h"
 
@@ -175,10 +174,3 @@ void soc_late_init_hook(void)
 
 	rtl_boot_stage_record(PON_BOOT_DONE);
 }
-
-#ifdef CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT
-void arch_busy_wait(uint32_t usec_to_wait)
-{
-	platform_delay_us(usec_to_wait);
-}
-#endif

--- a/soc/realtek/bee/rtl87x2g/soc.c
+++ b/soc/realtek/bee/rtl87x2g/soc.c
@@ -197,6 +197,14 @@ void soc_early_init_hook(void)
 	power_manager_slave_init();
 	platform_pm_init();
 
+#ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
+	/* Route interrupts to Non-Secure state. */
+	setup_non_secure_nvic();
+#endif
+}
+
+void soc_late_init_hook(void)
+{
 	/* Initialize OSC32 SDM software timer. */
 	init_osc_sdm_timer();
 
@@ -210,14 +218,6 @@ void soc_early_init_hook(void)
 	/* Initialize thermal compensation tracking. */
 	thermal_tracking_timer_init();
 
-#ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
-	/* Route interrupts to Non-Secure state. */
-	setup_non_secure_nvic();
-#endif
-}
-
-void soc_late_init_hook(void)
-{
 	/* Initialize HW AES mutex. */
 	hw_aes_mutex_init();
 


### PR DESCRIPTION
The rtl8752h (CM0+) SysTick does not have the COUNTFLAG early-assertion hardware bug present on the KM4 core (rtl87x2g), so the default k_busy_wait() implementation works correctly on this platform.

The previous custom arch_busy_wait() was a NOP-loop calibrated for a specific optimization level. It terminates one tick too early, causing test_slice_scheduling to fail with tick_delta=199 (expected ~200) when the test suite uses k_busy_wait() instead of the uptime-polling spin_for_ms() (see #113550).

Remove ARCH_HAS_CUSTOM_BUSY_WAIT and its arch_busy_wait() implementation to fall back to the default k_busy_wait(), which gives reliable results on this platform.

This also moves Realtek SoC init steps that use kernel timers to the late init hook. The system timer is not ready when the early init hook runs, so timer-dependent init must run later after Zephyr has initialized timer support. The ordering update is applied to both rtl8752h and rtl87x2g.

Testing:
- rtl8752h tests/kernel/sched/schedule_api: all slice timing tests pass after removing the custom busy wait.
- git diff --check -- soc/realtek/bee/rtl8752h/soc.c soc/realtek/bee/rtl87x2g/soc.c