### PR TITLE
scripts: zspdx: Fix relationship mapping in SDPX 3

### DIFF
--- a/scripts/pylib/zspdx/serializers/spdx3/serializer.py
+++ b/scripts/pylib/zspdx/serializers/spdx3/serializer.py
@@ -617,11 +617,15 @@ class SPDX3Serializer:
         # GENERATED_FROM is intentionally absent: it is handled by the Build profile
         # (see _create_relationships and _artifact_input_ids).
         type_map = {
-            "HAS_PREREQUISITE": (spdx.RelationshipType.dependsOn, False),
+            "HAS_PREREQUISITE": (spdx.RelationshipType.hasPrerequisite, False),
+            "PREREQUISITE_FOR": (spdx.RelationshipType.hasPrerequisite, True),
             "STATIC_LINK": (spdx.RelationshipType.hasStaticLink, False),
             "CONTAINS": (spdx.RelationshipType.contains, False),
+            "CONTAINED_BY": (spdx.RelationshipType.contains, True),
             "DESCRIBES": (spdx.RelationshipType.describes, False),
+            "DESCRIBED_BY": (spdx.RelationshipType.describes, True),
             "DEPENDS_ON": (spdx.RelationshipType.dependsOn, False),
+            "DEPENDENCY_OF": (spdx.RelationshipType.dependsOn, True),
             "DYNAMIC_LINK": (spdx.RelationshipType.hasDynamicLink, False),
             "BUILD_TOOL_OF": (spdx.RelationshipType.usesTool, True),
             "DEV_TOOL_OF": (spdx.RelationshipType.usesTool, True),


### PR DESCRIPTION
Hi, I've came into another incosistency with the SBOM generation, so I've prepared a fix right away.

Previously, the SPDX 3 serializer translated only the forward SPDX 2 relationship forms for some of the relationship types. Inverse forms such as `CONTAINED_BY`, `DESCRIBED_BY`, and `PREREQUISITE_FOR` fell back to the generic SPDX 3 other relationship type, losing their semantics. Also, `HAS_PREREQUISITE` was translated to the `dependsOn` relationship instead of `hasPrerequisite`.

This change preserves the original relationship semantics by:
- Translating `DEPENDENCY_OF` to `dependsOn` with reversed endpoints.
- Translating `CONTAINED_BY` to `contains` with reversed endpoints.
- Translating `DESCRIBED_BY` to `describes` with reversed endpoints.
- Translating `PREREQUISITE_FOR` to `hasPrerequisite` with reversed endpoints.
- Translating `HAS_PREREQUISITE` to the exact SPDX 3 `hasPrerequisite` type.