### PR TITLE
doc: hardware: peripherals: group peripherals into categorized cards

### DIFF
--- a/doc/hardware/peripherals/analog.rst
+++ b/doc/hardware/peripherals/analog.rst
@@ -1,0 +1,14 @@
+.. _analog_peripherals:
+
+Analog
+######
+
+Analog-to-digital and digital-to-analog converters, comparators, and amplifiers.
+
+.. toctree::
+   :maxdepth: 1
+
+   adc.rst
+   dac.rst
+   comparator.rst
+   opamp.rst

--- a/doc/hardware/peripherals/communication.rst
+++ b/doc/hardware/peripherals/communication.rst
@@ -1,0 +1,23 @@
+.. _communication_peripherals:
+
+Communication
+#############
+
+Serial buses (I2C, SPI, UART, CAN) and other communication interfaces.
+
+.. toctree::
+   :maxdepth: 1
+
+   can/index.rst
+   i2c.rst
+   i3c.rst
+   spi.rst
+   pcie.rst
+   uart.rst
+   espi.rst
+   mdio.rst
+   mspi.rst
+   smbus.rst
+   ipm.rst
+   mbox.rst
+   w1.rst

--- a/doc/hardware/peripherals/display.rst
+++ b/doc/hardware/peripherals/display.rst
@@ -1,0 +1,15 @@
+.. _display_peripherals:
+
+Display
+#######
+
+Visual output, video interfaces, and LED and lighting control.
+
+.. toctree::
+   :maxdepth: 1
+
+   display/index.rst
+   auxdisplay.rst
+   video.rst
+   led.rst
+   dali.rst

--- a/doc/hardware/peripherals/gpio_input.rst
+++ b/doc/hardware/peripherals/gpio_input.rst
@@ -1,0 +1,13 @@
+.. _gpio_input_peripherals:
+
+GPIO & Input
+############
+
+General-purpose I/O and input devices.
+
+.. toctree::
+   :maxdepth: 1
+
+   gpio.rst
+   ps2.rst
+   tgpio.rst

--- a/doc/hardware/peripherals/index.rst
+++ b/doc/hardware/peripherals/index.rst
@@ -3,73 +3,142 @@
 Peripherals
 ###########
 
-..
-  Please keep the ToC tree sorted based on the titles of the pages included
+Zephyr supports a wide range of hardware peripherals through a set of
+device driver APIs. They are grouped into the categories below; each card lists
+the peripherals in that category, or follow the category title for more detail.
 
-.. toctree::
-   :maxdepth: 1
+.. grid:: 1
+   :class-container: sd-index-grid
+   :gutter: 0
 
-   w1.rst
-   adc.rst
-   auxdisplay.rst
-   audio/index.rst
-   bbram.rst
-   bc12.rst
-   biometrics.rst
-   buzzer.rst
-   clock_control.rst
-   clock_monitor.rst
-   can/index.rst
-   charger.rst
-   comparator.rst
-   coredump.rst
-   counter.rst
-   crc.rst
-   dac.rst
-   dali.rst
-   dma.rst
-   display/index.rst
-   eeprom/index.rst
-   espi.rst
-   entropy.rst
-   edac/index.rst
-   flash.rst
-   fuel_gauge.rst
-   gnss.rst
-   gpio.rst
-   haptics.rst
-   hwinfo.rst
-   hwspinlock.rst
-   i2c_eeprom_target.rst
-   i3c.rst
-   i2c.rst
-   ipm.rst
-   led.rst
-   mdio.rst
-   memc.rst
-   mspi.rst
-   mbox.rst
-   opamp.rst
-   otp/index.rst
-   pcie.rst
-   peci.rst
-   ps2.rst
-   psi5.rst
-   pwm.rst
-   rtc.rst
-   regulators.rst
-   reset.rst
-   retained_mem.rst
-   sdhc.rst
-   sensor/index.rst
-   sent.rst
-   spi.rst
-   stepper/index.rst
-   smbus.rst
-   uart.rst
-   usbc_vbus.rst
-   tcpc.rst
-   tgpio.rst
-   video.rst
-   watchdog.rst
-   wuc.rst
+   .. grid-item-card:: :ref:`Analog <analog_peripherals>`
+      :class-card: sd-index-card
+
+      .. rst-class:: sd-index-watermark
+
+      :material-twotone:`show_chart;7em`
+
+      .. toctree::
+         :maxdepth: 2
+
+         analog
+
+   .. grid-item-card:: :ref:`Audio <audio_reference>`
+      :class-card: sd-index-card
+
+      .. rst-class:: sd-index-watermark
+
+      :material-twotone:`speaker;7em`
+
+      .. toctree::
+         :maxdepth: 2
+
+         audio/index
+
+   .. grid-item-card:: :ref:`Communication <communication_peripherals>`
+      :class-card: sd-index-card
+
+      .. rst-class:: sd-index-watermark
+
+      :material-twotone:`settings_ethernet;7em`
+
+      .. toctree::
+         :maxdepth: 2
+
+         communication
+
+   .. grid-item-card:: :ref:`Display <display_peripherals>`
+      :class-card: sd-index-card
+
+      .. rst-class:: sd-index-watermark
+
+      :material-twotone:`monitor;7em`
+
+      .. toctree::
+         :maxdepth: 2
+
+         display
+
+   .. grid-item-card:: :ref:`GPIO & Input <gpio_input_peripherals>`
+      :class-card: sd-index-card
+
+      .. rst-class:: sd-index-watermark
+
+      :material-twotone:`touch_app;7em`
+
+      .. toctree::
+         :maxdepth: 2
+
+         gpio_input
+
+   .. grid-item-card:: :ref:`Memory & Storage <memory_storage_peripherals>`
+      :class-card: sd-index-card
+
+      .. rst-class:: sd-index-watermark
+
+      :material-twotone:`save;7em`
+
+      .. toctree::
+         :maxdepth: 2
+
+         memory_storage
+
+   .. grid-item-card:: :ref:`Power <power_peripherals>`
+      :class-card: sd-index-card
+
+      .. rst-class:: sd-index-watermark
+
+      :material-twotone:`battery_charging_full;7em`
+
+      .. toctree::
+         :maxdepth: 2
+
+         power
+
+   .. grid-item-card:: :ref:`Sensors <sensor_peripherals>`
+      :class-card: sd-index-card
+
+      .. rst-class:: sd-index-watermark
+
+      :material-twotone:`sensors;7em`
+
+      .. toctree::
+         :maxdepth: 2
+
+         sensors
+
+   .. grid-item-card:: :ref:`Motion & Actuation <motion_actuation_peripherals>`
+      :class-card: sd-index-card
+
+      .. rst-class:: sd-index-watermark
+
+      :material-twotone:`precision_manufacturing;7em`
+
+      .. toctree::
+         :maxdepth: 2
+
+         motion_actuation
+
+   .. grid-item-card:: :ref:`System & Diagnostics <system_diagnostics_peripherals>`
+      :class-card: sd-index-card
+
+      .. rst-class:: sd-index-watermark
+
+      :material-twotone:`bug_report;7em`
+
+      .. toctree::
+         :maxdepth: 2
+
+         system_diagnostics
+
+   .. grid-item-card:: :ref:`Timing <timing_peripherals>`
+      :class-card: sd-index-card
+
+      .. rst-class:: sd-index-watermark
+
+      :material-twotone:`schedule;7em`
+
+      .. toctree::
+         :maxdepth: 2
+
+         timing

--- a/doc/hardware/peripherals/memory_storage.rst
+++ b/doc/hardware/peripherals/memory_storage.rst
@@ -1,0 +1,18 @@
+.. _memory_storage_peripherals:
+
+Memory & Storage
+################
+
+Non-volatile memory, flash storage, EEPROM, and memory controllers.
+
+.. toctree::
+   :maxdepth: 1
+
+   flash.rst
+   eeprom/index.rst
+   sdhc.rst
+   bbram.rst
+   retained_mem.rst
+   i2c_eeprom_target.rst
+   memc.rst
+   otp/index.rst

--- a/doc/hardware/peripherals/motion_actuation.rst
+++ b/doc/hardware/peripherals/motion_actuation.rst
@@ -1,0 +1,14 @@
+.. _motion_actuation_peripherals:
+
+Motion & Actuation
+##################
+
+PWM, stepper motors, haptics, buzzers, and other actuators.
+
+.. toctree::
+   :maxdepth: 1
+
+   haptics.rst
+   pwm.rst
+   stepper/index.rst
+   buzzer.rst

--- a/doc/hardware/peripherals/power.rst
+++ b/doc/hardware/peripherals/power.rst
@@ -1,0 +1,18 @@
+.. _power_peripherals:
+
+Power
+#####
+
+Power management, charging, regulators, reset, and wake-up controllers.
+
+.. toctree::
+   :maxdepth: 1
+
+   bc12.rst
+   charger.rst
+   fuel_gauge.rst
+   regulators.rst
+   reset.rst
+   tcpc.rst
+   usbc_vbus.rst
+   wuc.rst

--- a/doc/hardware/peripherals/sensors.rst
+++ b/doc/hardware/peripherals/sensors.rst
@@ -1,0 +1,15 @@
+.. _sensor_peripherals:
+
+Sensors
+#######
+
+Environmental and motion sensors, GNSS, biometrics, and sensor interfaces.
+
+.. toctree::
+   :maxdepth: 1
+
+   sensor/index.rst
+   gnss.rst
+   psi5.rst
+   sent.rst
+   biometrics.rst

--- a/doc/hardware/peripherals/system_diagnostics.rst
+++ b/doc/hardware/peripherals/system_diagnostics.rst
@@ -1,0 +1,18 @@
+.. _system_diagnostics_peripherals:
+
+System & Diagnostics
+####################
+
+System information, synchronization, DMA, and diagnostics.
+
+.. toctree::
+   :maxdepth: 1
+
+   hwinfo.rst
+   hwspinlock.rst
+   entropy.rst
+   edac/index.rst
+   coredump.rst
+   crc.rst
+   peci.rst
+   dma.rst

--- a/doc/hardware/peripherals/timing.rst
+++ b/doc/hardware/peripherals/timing.rst
@@ -1,0 +1,15 @@
+.. _timing_peripherals:
+
+Timing
+######
+
+Timers, clocks, watchdogs, and timekeeping primitives.
+
+.. toctree::
+   :maxdepth: 1
+
+   clock_control.rst
+   clock_monitor.rst
+   counter.rst
+   rtc.rst
+   watchdog.rst


### PR DESCRIPTION
Replaces the flat peripherals list with the same category-card layout used for the OS Services index (see #100126).

<img width="1211" height="853" alt="image" src="https://github.com/user-attachments/assets/26598f9e-22e6-4350-9465-5043648e5935" />

https://builds.zephyrproject.io/zephyr/pr/113586/docs/hardware/peripherals/index.html