### PR TITLE
babblesim bt mesh tests: Build and run with twister

### DIFF
--- a/tests/bsim/bluetooth/mesh/tests.yaml
+++ b/tests/bsim/bluetooth/mesh/tests.yaml
@@ -1,0 +1,345 @@
+common:
+  timeout: 1800
+  tags:
+    - bluetooth
+  depends_on: bsim
+  harness: bsim
+  platform_allow:
+    - nrf52_bsim
+
+tests:
+  ###########################
+  # Images reused by tests: #
+  ###########################
+  tests.bsim.bluetooth.mesh.image:
+    build_only: true
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf
+
+  tests.bsim.bluetooth.mesh.image.pst:
+    build_only: true
+    extra_overlay_confs:
+      - overlay_pst.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_pst_conf
+
+  tests.bsim.bluetooth.mesh.image.gatt:
+    build_only: true
+    extra_overlay_confs:
+      - overlay_gatt.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_gatt_conf
+
+  tests.bsim.bluetooth.mesh.image.gatt_separate:
+    build_only: true
+    extra_overlay_confs:
+      - overlay_gatt_separate.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_gatt_separate_conf
+
+  tests.bsim.bluetooth.mesh.image.low_lat:
+    build_only: true
+    extra_overlay_confs:
+      - overlay_low_lat.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_low_lat_conf
+
+  tests.bsim.bluetooth.mesh.image.workq_sys:
+    build_only: true
+    extra_overlay_confs:
+      - overlay_workq_sys.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_workq_sys_conf
+
+  tests.bsim.bluetooth.mesh.image.multi_adv_sets:
+    build_only: true
+    extra_overlay_confs:
+      - overlay_multi_adv_sets.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_multi_adv_sets_conf
+
+  tests.bsim.bluetooth.mesh.image.lpn_scan_on:
+    build_only: true
+    extra_overlay_confs:
+      - overlay_lpn_scan_on.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_lpn_scan_on_conf
+
+  tests.bsim.bluetooth.mesh.image.gatt_workq_sys:
+    build_only: true
+    extra_overlay_confs:
+      - overlay_gatt.conf
+      - overlay_workq_sys.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_gatt_conf_overlay_workq_sys_conf
+
+  tests.bsim.bluetooth.mesh.image.gatt_low_lat:
+    build_only: true
+    extra_overlay_confs:
+      - overlay_gatt.conf
+      - overlay_low_lat.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_gatt_conf_overlay_low_lat_conf
+
+  tests.bsim.bluetooth.mesh.image.pst_gatt:
+    build_only: true
+    extra_overlay_confs:
+      - overlay_pst.conf
+      - overlay_gatt.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_mesh_prj_conf_overlay_pst_conf_overlay_gatt_conf
+
+  tests.bsim.bluetooth.mesh.image.gatt_multi_adv_sets:
+    build_only: true
+    extra_overlay_confs:
+      - overlay_gatt.conf
+      - overlay_multi_adv_sets.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: >-
+        tests_bsim_bluetooth_mesh_prj_conf_overlay_gatt_conf_overlay_multi_adv_sets_conf
+
+  tests.bsim.bluetooth.mesh.image.pst_gatt_workq_sys:
+    build_only: true
+    extra_overlay_confs:
+      - overlay_pst.conf
+      - overlay_gatt.conf
+      - overlay_workq_sys.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: >-
+        tests_bsim_bluetooth_mesh_prj_conf_overlay_pst_conf_overlay_gatt_conf_overlay_workq_sys_conf
+
+  #################
+  # Actual tests: #
+  #################
+
+  tests.bsim.bluetooth.mesh.access:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/access
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+
+  tests.bsim.bluetooth.mesh.advertiser:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/advertiser
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+      - application: tests.bsim.bluetooth.mesh.image.gatt
+      - application: tests.bsim.bluetooth.mesh.image.gatt_multi_adv_sets
+      - application: tests.bsim.bluetooth.mesh.image.gatt_separate
+      - application: tests.bsim.bluetooth.mesh.image.gatt_workq_sys
+      - application: tests.bsim.bluetooth.mesh.image.low_lat
+      - application: tests.bsim.bluetooth.mesh.image.multi_adv_sets
+      - application: tests.bsim.bluetooth.mesh.image.workq_sys
+
+  tests.bsim.bluetooth.mesh.beacon:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/beacon
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+
+  tests.bsim.bluetooth.mesh.blob_mdls:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/blob_mdls
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+      - application: tests.bsim.bluetooth.mesh.image.pst
+
+  tests.bsim.bluetooth.mesh.bridge:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/bridge
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+      - application: tests.bsim.bluetooth.mesh.image.pst
+
+  tests.bsim.bluetooth.mesh.cdb:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/cdb
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+
+  tests.bsim.bluetooth.mesh.comp_data:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/comp_data
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+
+  tests.bsim.bluetooth.mesh.dfu:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/dfu
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+      - application: tests.bsim.bluetooth.mesh.image.pst
+
+  tests.bsim.bluetooth.mesh.friendship:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/friendship
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+      - application: tests.bsim.bluetooth.mesh.image.low_lat
+      - application: tests.bsim.bluetooth.mesh.image.lpn_scan_on
+
+  tests.bsim.bluetooth.mesh.heartbeat:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/heartbeat
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+
+  tests.bsim.bluetooth.mesh.iv_index:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/iv_index
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+
+  tests.bsim.bluetooth.mesh.large_comp_data:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/large_comp_data
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image.pst
+
+  tests.bsim.bluetooth.mesh.op_agg:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/op_agg
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+
+  tests.bsim.bluetooth.mesh.persistence:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/persistence
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image.pst
+
+  tests.bsim.bluetooth.mesh.priv_beacon:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/priv_beacon
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+      - application: tests.bsim.bluetooth.mesh.image.gatt
+
+  tests.bsim.bluetooth.mesh.provision:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/provision
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+      - application: tests.bsim.bluetooth.mesh.image.gatt
+      - application: tests.bsim.bluetooth.mesh.image.pst
+
+  tests.bsim.bluetooth.mesh.proxy_sol:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/proxy_sol
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image.pst_gatt
+      - application: tests.bsim.bluetooth.mesh.image.pst_gatt_workq_sys
+
+  tests.bsim.bluetooth.mesh.replay_cache:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/replay_cache
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image.pst
+
+  tests.bsim.bluetooth.mesh.sar:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/sar
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+      - application: tests.bsim.bluetooth.mesh.image.pst
+
+  tests.bsim.bluetooth.mesh.scanner:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/scanner
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+
+  tests.bsim.bluetooth.mesh.suspend:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/suspend
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+      - application: tests.bsim.bluetooth.mesh.image.gatt
+      - application: tests.bsim.bluetooth.mesh.image.gatt_low_lat
+      - application: tests.bsim.bluetooth.mesh.image.low_lat
+
+  tests.bsim.bluetooth.mesh.transport:
+    build: false
+    harness_config:
+      fixture: bsim_multi_test
+      tests_scripts:
+        - tests_scripts/transport
+    required_applications:
+      - application: tests.bsim.bluetooth.mesh.image
+      - application: tests.bsim.bluetooth.mesh.image.low_lat

--- a/tests/bsim/bluetooth/tests.nrf52bsim.txt
+++ b/tests/bsim/bluetooth/tests.nrf52bsim.txt
@@ -1,4 +1,3 @@
 # Search paths(s) for tests which will be run in the nrf52bsim
 # This file is used in CI to select which tests are run
 tests/bsim/bluetooth/ll/
-tests/bsim/bluetooth/mesh/

--- a/tests/bsim/ci.bt.sh
+++ b/tests/bsim/ci.bt.sh
@@ -21,6 +21,8 @@ ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/hci_ua
 
 ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/host/
 
+${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/mesh
+
 ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/samples/
 
 ${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/tester/


### PR DESCRIPTION
For background and motivation see https://github.com/zephyrproject-rtos/zephyr/pull/113101

This PR changes the BT mesh bsim tests to be both built and run using twister.
This means that users which have Babblesim installed can run these tests with twister in a quite comparable way to single device test. For example:
twister -T tests/bsim/bluetooth/mesh/ -vv --fixture bsim_multi_test

Note these tests can still be run with run_parallel.sh as before. Just now the default test list used by CI does not include them.

Related to:
* https://github.com/zephyrproject-rtos/zephyr/pull/113502
* https://github.com/zephyrproject-rtos/zephyr/pull/113475
* https://github.com/zephyrproject-rtos/zephyr/pull/113401
* https://github.com/zephyrproject-rtos/zephyr/pull/113395
* https://github.com/zephyrproject-rtos/zephyr/pull/113225
* https://github.com/zephyrproject-rtos/zephyr/pull/113244
* https://github.com/zephyrproject-rtos/zephyr/pull/113101