### PR TITLE
Renesas RZ fix tint issues

### DIFF
--- a/drivers/interrupt_controller/intc_renesas_rz_tint.c
+++ b/drivers/interrupt_controller/intc_renesas_rz_tint.c
@@ -79,6 +79,10 @@ struct intc_rz_tint_data {
 static const uint8_t gpioint_table[] = DT_PROP(DT_NODELABEL(intc), gpioint_table);
 static struct k_spinlock lock;
 
+/* Helper function to read TINT status
+ * V2H, V2N: TSTATn bit of TSCTR register
+ * Others: TSTATSn bit of TSCR register
+ */
 static inline bool intc_rz_tint_status_read(mem_addr_t base, uint8_t tint)
 {
 #ifdef CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG
@@ -89,6 +93,10 @@ static inline bool intc_rz_tint_status_read(mem_addr_t base, uint8_t tint)
 #endif /* CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG */
 }
 
+/* Helper function to clear TINT status
+ * V2H, V2N: TCLRn bit of TSCLR register
+ * Others: TSTATSn bit of TSCR register
+ */
 static inline void intc_rz_tint_status_clear(mem_addr_t base, uint8_t tint)
 {
 #ifdef CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG
@@ -99,19 +107,27 @@ static inline void intc_rz_tint_status_clear(mem_addr_t base, uint8_t tint)
 #endif /* CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG */
 }
 
+/* Helper function to perform the process of clearing the interrupt status after changing
+ * the setting as per User's manual "Precaution when Changing Interrupt Settings".
+ */
 static inline void intc_rz_tint_clear_irq_status(const struct device *dev)
 {
 	const struct intc_rz_tint_config *config = dev->config;
 	mem_addr_t base = INTC_BASE;
 	uint8_t tint = config->tint;
 
-	intc_rz_tint_status_clear(base, tint);
-
-	/*
-	 * User's manual: Clear Timing of Interrupt Cause
-	 * Dummy read is required after write
+	/* As per TSCLR register (V2H, V2N, G3E) and TSCR register (A3x, G2x, G3S, V2L)
+	 * Only clear TINTn status flags when it is 1. Otherwise, writing has no effect
 	 */
-	(void)intc_rz_tint_status_read(base, tint);
+	if (intc_rz_tint_status_read(base, tint)) {
+		intc_rz_tint_status_clear(base, tint);
+
+		/*
+		 * User's manual: Clear Timing of Interrupt Cause
+		 * Dummy read is required after write
+		 */
+		(void)intc_rz_tint_status_read(base, tint);
+	}
 }
 
 int intc_rz_tint_enable(const struct device *dev)

--- a/drivers/interrupt_controller/intc_renesas_rz_tint.c
+++ b/drivers/interrupt_controller/intc_renesas_rz_tint.c
@@ -153,7 +153,6 @@ int intc_rz_tint_set_type(const struct device *dev, enum intc_rz_tint_trigger tr
 	const struct intc_rz_tint_config *config = dev->config;
 	struct intc_rz_tint_data *data = dev->data;
 	uint8_t tint = config->tint;
-	uint32_t flags = IRQ_TYPE_LEVEL;
 	uint32_t set = 0;
 	mem_addr_t base = INTC_BASE;
 	uint32_t reg_val;
@@ -189,13 +188,17 @@ int intc_rz_tint_set_type(const struct device *dev, enum intc_rz_tint_trigger tr
 		 * write 0 to the TSTATn bit of TSCR.
 		 */
 		if ((trig == RZ_TINT_RISING_EDGE) || (trig == RZ_TINT_FAILING_EDGE)) {
-			flags = IRQ_TYPE_EDGE;
 			intc_rz_tint_clear_irq_status(dev);
 		}
 
 		/* Set interrupt type for GIC, and clear pending interrupt */
 #ifdef CONFIG_GIC
+#if defined(CONFIG_SOC_SERIES_RZV2H)
+		uint32_t flags = ((trig == RZ_TINT_RISING_EDGE) || (trig == RZ_TINT_FAILING_EDGE))
+				 ? IRQ_TYPE_EDGE : IRQ_TYPE_LEVEL;
+
 		arm_gic_irq_set_priority(config->irq, config->prio, flags);
+#endif
 		arm_gic_irq_clear_pending(config->irq);
 #else
 		NVIC_ClearPendingIRQ(config->irq);

--- a/drivers/interrupt_controller/intc_renesas_rz_tint.c
+++ b/drivers/interrupt_controller/intc_renesas_rz_tint.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/irq.h>
+#include <zephyr/spinlock.h>
 #include <zephyr/drivers/interrupt_controller/gic.h>
 #include <zephyr/drivers/interrupt_controller/intc_rz_tint.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
@@ -76,6 +77,7 @@ struct intc_rz_tint_data {
 };
 
 static const uint8_t gpioint_table[] = DT_PROP(DT_NODELABEL(intc), gpioint_table);
+static struct k_spinlock lock;
 
 static inline bool intc_rz_tint_status_read(mem_addr_t base, uint8_t tint)
 {
@@ -138,7 +140,7 @@ int intc_rz_tint_set_type(const struct device *dev, enum intc_rz_tint_trigger tr
 	uint32_t flags = IRQ_TYPE_LEVEL;
 	uint32_t set = 0;
 	mem_addr_t base = INTC_BASE;
-	uint32_t reg_val = REG_TITSR_READ(base, tint);
+	uint32_t reg_val;
 
 	switch (trig) {
 	case RZ_TINT_FAILING_EDGE:
@@ -158,30 +160,33 @@ int intc_rz_tint_set_type(const struct device *dev, enum intc_rz_tint_trigger tr
 		return -ENOTSUP;
 	}
 
-	/* Select interrupt type */
-	reg_val = (reg_val & ~REG_TITSR_TITSEL_MASK(tint)) |
-		  FIELD_PREP(REG_TITSR_TITSEL_MASK(tint), set);
-	REG_TITSR_WRITE(base, tint, reg_val);
+	K_SPINLOCK(&lock) {
+		/* Select interrupt type */
+		reg_val = REG_TITSR_READ(base, tint);
+		reg_val = (reg_val & ~REG_TITSR_TITSEL_MASK(tint)) |
+			  FIELD_PREP(REG_TITSR_TITSEL_MASK(tint), set);
+		REG_TITSR_WRITE(base, tint, reg_val);
 
-	/*
-	 * User's manual: Precaution when Changing Interrupt Settings
-	 * When changing the TINT interrupt detection method to the edge type,
-	 * write 0 to the TSTATn bit of TSCR.
-	 */
-	if ((trig == RZ_TINT_RISING_EDGE) || (trig == RZ_TINT_FAILING_EDGE)) {
-		flags = IRQ_TYPE_EDGE;
-		intc_rz_tint_clear_irq_status(dev);
-	}
+		/*
+		 * User's manual: Precaution when Changing Interrupt Settings
+		 * When changing the TINT interrupt detection method to the edge type,
+		 * write 0 to the TSTATn bit of TSCR.
+		 */
+		if ((trig == RZ_TINT_RISING_EDGE) || (trig == RZ_TINT_FAILING_EDGE)) {
+			flags = IRQ_TYPE_EDGE;
+			intc_rz_tint_clear_irq_status(dev);
+		}
 
-	/* Set interrupt type for GIC, and clear pending interrupt */
+		/* Set interrupt type for GIC, and clear pending interrupt */
 #ifdef CONFIG_GIC
-	arm_gic_irq_set_priority(config->irq, config->prio, flags);
-	arm_gic_irq_clear_pending(config->irq);
+		arm_gic_irq_set_priority(config->irq, config->prio, flags);
+		arm_gic_irq_clear_pending(config->irq);
 #else
-	NVIC_ClearPendingIRQ(config->irq);
+		NVIC_ClearPendingIRQ(config->irq);
 #endif
 
-	data->trigger_type = trig;
+		data->trigger_type = trig;
+	}
 
 	return 0;
 }
@@ -248,16 +253,18 @@ int intc_rz_tint_connect(const struct device *dev, uint8_t port, uint8_t pin)
 		return -EINVAL;
 	}
 
-	uint32_t reg_val = REG_TSSR_READ(base, tint);
+	K_SPINLOCK(&lock) {
+		uint32_t reg_val = REG_TSSR_READ(base, tint);
 
-	reg_val &= ~(REG_TSSR_TSSEL_MASK(tint) | REG_TSSR_TIEN_MASK(tint));
-	reg_val |= FIELD_PREP(REG_TSSR_TSSEL_MASK(tint), gpioint);
-	reg_val |= FIELD_PREP(REG_TSSR_TIEN_MASK(tint), 1U);
-	REG_TSSR_WRITE(base, tint, reg_val);
+		reg_val &= ~(REG_TSSR_TSSEL_MASK(tint) | REG_TSSR_TIEN_MASK(tint));
+		reg_val |= FIELD_PREP(REG_TSSR_TSSEL_MASK(tint), gpioint);
+		reg_val |= FIELD_PREP(REG_TSSR_TIEN_MASK(tint), 1U);
+		REG_TSSR_WRITE(base, tint, reg_val);
 
-	data->gpioint = gpioint;
-	data->port = port;
-	data->pin = pin;
+		data->gpioint = gpioint;
+		data->port = port;
+		data->pin = pin;
+	}
 
 	return 0;
 }

--- a/drivers/interrupt_controller/intc_renesas_rz_tint.c
+++ b/drivers/interrupt_controller/intc_renesas_rz_tint.c
@@ -60,6 +60,9 @@ DEVICE_MMIO_TOPLEVEL_STATIC(intc_regs, DT_NODELABEL(intc));
 #define REG_INTSEL_WRITE(base, irq, v) sys_write32((v), INTSEL(base) + (OFFSET(irq) / 3) * 4)
 #define REG_INTSEL_SPIk_SEL_MASK(irq)  (BIT_MASK(10) << ((OFFSET(irq) % 3) * 10))
 
+/* data->gpioint value for a tint channel that is not connected to a GPIO pin yet */
+#define GPIOINT_UNASSIGNED 0xFFU
+
 struct intc_rz_tint_config {
 	uint8_t tint;
 	uint8_t max_gpioint;
@@ -78,6 +81,9 @@ struct intc_rz_tint_data {
 
 static const uint8_t gpioint_table[] = DT_PROP(DT_NODELABEL(intc), gpioint_table);
 static struct k_spinlock lock;
+#if defined(CONFIG_ASSERT)
+static bool used_gpioint[DT_PROP(DT_NODELABEL(intc), max_gpioint) + 1];
+#endif
 
 /* Helper function to read TINT status
  * V2H, V2N: TSTATn bit of TSCTR register
@@ -268,13 +274,29 @@ int intc_rz_tint_connect(const struct device *dev, uint8_t port, uint8_t pin)
 	/* Map to GPIOINT */
 	uint8_t gpioint = gpioint_table[port] + pin;
 
-	if (gpioint > config->max_gpioint) {
-		return -EINVAL;
-	}
+	__ASSERT(gpioint <= config->max_gpioint,
+		 "port %u pin %u maps to gpioint %u, out of range (max %u)", port, pin, gpioint,
+		 config->max_gpioint);
 
 	K_SPINLOCK(&lock) {
-		uint32_t reg_val = REG_TSSR_READ(base, tint);
+		uint32_t reg_val;
 
+		/* Already mapped, no need to remap and return successfully */
+		if (data->gpioint == gpioint) {
+			K_SPINLOCK_BREAK;
+		}
+
+		__ASSERT(data->gpioint == GPIOINT_UNASSIGNED,
+			 "tint %u already assigned to port %u pin %u", tint,
+			 data->port, data->pin);
+		__ASSERT(!used_gpioint[gpioint],
+			 "port %u pin %u (gpioint %u) already assigned to another tint", port,
+			 pin, gpioint);
+#if defined(CONFIG_ASSERT)
+		used_gpioint[gpioint] = true;
+#endif
+
+		reg_val = REG_TSSR_READ(base, tint);
 		reg_val &= ~(REG_TSSR_TSSEL_MASK(tint) | REG_TSSR_TIEN_MASK(tint));
 		reg_val |= FIELD_PREP(REG_TSSR_TSSEL_MASK(tint), gpioint);
 		reg_val |= FIELD_PREP(REG_TSSR_TIEN_MASK(tint), 1U);
@@ -311,6 +333,7 @@ int intc_rz_tint_set_callback(const struct device *dev, intc_rz_tint_callback_t 
 		.max_gpioint = DT_PROP(DT_INST_PARENT(index), max_gpioint),                        \
 	};                                                                                         \
 	struct intc_rz_tint_data intc_rz_tint_data##index = {                                      \
+		.gpioint = GPIOINT_UNASSIGNED,                                                     \
 		.trigger_type = DT_INST_ENUM_IDX_OR(index, trigger_type, 0),                       \
 	};                                                                                         \
 	static int intc_rz_tint_init##index(const struct device *dev)                              \

--- a/drivers/interrupt_controller/intc_renesas_rz_tint.c
+++ b/drivers/interrupt_controller/intc_renesas_rz_tint.c
@@ -15,6 +15,50 @@
 
 LOG_MODULE_REGISTER(rz_intc, CONFIG_INTC_LOG_LEVEL);
 
+DEVICE_MMIO_TOPLEVEL_STATIC(intc_regs, DT_NODELABEL(intc));
+
+#define INTC_BASE DEVICE_MMIO_TOPLEVEL_GET(intc_regs)
+
+#define TSCR_OFFSET   DT_REG_ADDR_BY_NAME(DT_NODELABEL(intc), tscr)
+#define TITSR0_OFFSET DT_REG_ADDR_BY_NAME(DT_NODELABEL(intc), titsr0)
+#define TSSR0_OFFSET  DT_REG_ADDR_BY_NAME(DT_NODELABEL(intc), tssr0)
+#define INTSEL_OFFSET DT_REG_ADDR_BY_NAME(DT_NODELABEL(intc), intsel)
+
+#define TSCR(base)   (base + TSCR_OFFSET)
+#define TITSR0(base) (base + TITSR0_OFFSET)
+#define TSSR0(base)  (base + TSSR0_OFFSET)
+#define INTSEL(base) (base + INTSEL_OFFSET)
+
+#define REG_TITSR_READ(base, tint)     sys_read32(TITSR0(base) + ((tint) / 16) * 4)
+#define REG_TITSR_WRITE(base, tint, v) sys_write32((v), TITSR0(base) + ((tint) / 16) * 4)
+#define REG_TITSR_TITSEL_MASK(tint)    (BIT_MASK(2) << ((tint % 16) * 2))
+
+#ifdef CONFIG_SOC_SERIES_RZG3E
+#define REG_TSSR_READ(base, tint)     sys_read32(TSSR0(base) + ((tint) / 2) * 4)
+#define REG_TSSR_WRITE(base, tint, v) sys_write32((v), TSSR0(base) + ((tint) / 2) * 4)
+#define REG_TSSR_TSSEL_MASK(tint)     (BIT_MASK(8) << ((tint % 2) * 16))
+#define REG_TSSR_TIEN_MASK(tint)      (BIT(15) << ((tint % 2) * 16))
+#else
+#define REG_TSSR_READ(base, tint)     sys_read32(TSSR0(base) + ((tint) / 4) * 4)
+#define REG_TSSR_WRITE(base, tint, v) sys_write32((v), TSSR0(base) + ((tint) / 4) * 4)
+#define REG_TSSR_TSSEL_MASK(tint)     (BIT_MASK(7) << ((tint % 4) * 8))
+#define REG_TSSR_TIEN_MASK(tint)      (BIT(7) << ((tint % 4) * 8))
+#endif
+
+#if defined(CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG)
+/* V2H, V2N */
+#define REG_TSCTR_READ(base, tint)     sys_read32(TSCR(base))
+#define REG_TSCLR_WRITE(base, tint, v) sys_write32((v), TSCR(base) + 4)
+#else
+#define REG_TSCR_READ(base, tint)     sys_read32(TSCR(base))
+#define REG_TSCR_WRITE(base, tint, v) sys_write32((v), TSCR(base))
+#endif
+
+#define OFFSET(irq)                    ((irq) - 353 - COND_CODE_1(CONFIG_GIC, (32), (0)))
+#define REG_INTSEL_READ(base, irq)     sys_read32(INTSEL(base) + (OFFSET(irq) / 3) * 4)
+#define REG_INTSEL_WRITE(base, irq, v) sys_write32((v), INTSEL(base) + (OFFSET(irq) / 3) * 4)
+#define REG_INTSEL_SPIk_SEL_MASK(irq)  (BIT_MASK(10) << ((OFFSET(irq) % 3) * 10))
+
 struct intc_rz_tint_config {
 	uint8_t tint;
 	uint8_t max_gpioint;
@@ -31,60 +75,41 @@ struct intc_rz_tint_data {
 	void *callback_data;
 };
 
-#define RZ_INTC_BASE   DT_REG_ADDR(DT_NODELABEL(intc))
-#define RZ_INTC_TSCR   (RZ_INTC_BASE + DT_REG_ADDR_BY_NAME(DT_NODELABEL(intc), tscr))
-#define RZ_INTC_TITSR0 (RZ_INTC_BASE + DT_REG_ADDR_BY_NAME(DT_NODELABEL(intc), titsr0))
-#define RZ_INTC_TSSR0  (RZ_INTC_BASE + DT_REG_ADDR_BY_NAME(DT_NODELABEL(intc), tssr0))
-#define RZ_INTC_INTSEL (RZ_INTC_BASE + DT_REG_ADDR_BY_NAME(DT_NODELABEL(intc), intsel))
-
-#define REG_TITSR_READ(tint)        sys_read32(RZ_INTC_TITSR0 + ((tint) / 16) * 4)
-#define REG_TITSR_WRITE(tint, v)    sys_write32((v), RZ_INTC_TITSR0 + ((tint) / 16) * 4)
-#define REG_TITSR_TITSEL_MASK(tint) (BIT_MASK(2) << ((tint % 16) * 2))
-
-#ifdef CONFIG_SOC_SERIES_RZG3E
-#define REG_TSSR_READ(tint)       sys_read32(RZ_INTC_TSSR0 + ((tint) / 2) * 4)
-#define REG_TSSR_WRITE(tint, v)   sys_write32((v), RZ_INTC_TSSR0 + ((tint) / 2) * 4)
-#define REG_TSSR_TSSEL_MASK(tint) (BIT_MASK(8) << ((tint % 2) * 16))
-#define REG_TSSR_TIEN_MASK(tint)  (BIT(15) << ((tint % 2) * 16))
-#else
-#define REG_TSSR_READ(tint)       sys_read32(RZ_INTC_TSSR0 + ((tint) / 4) * 4)
-#define REG_TSSR_WRITE(tint, v)   sys_write32((v), RZ_INTC_TSSR0 + ((tint) / 4) * 4)
-#define REG_TSSR_TSSEL_MASK(tint) (BIT_MASK(7) << ((tint % 4) * 8))
-#define REG_TSSR_TIEN_MASK(tint)  (BIT(7) << ((tint % 4) * 8))
-#endif
-
-#if defined(CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG)
-/* V2H, V2N */
-#define REG_TSCTR_READ(tint)     sys_read32(RZ_INTC_TSCR)
-#define REG_TSCLR_WRITE(tint, v) sys_write32((v), RZ_INTC_TSCR + 4)
-#define TINT_STATUS_READ(tint)   REG_TSCTR_READ(tint)
-#define TINT_STATUS_CLEAR(tint)  REG_TSCLR_WRITE(tint, TINT_STATUS_READ(tint) | BIT(tint))
-#else
-#define REG_TSCR_READ(tint)     sys_read32(RZ_INTC_TSCR)
-#define REG_TSCR_WRITE(tint, v) sys_write32((v), RZ_INTC_TSCR)
-#define TINT_STATUS_READ(tint)  REG_TSCR_READ(tint)
-#define TINT_STATUS_CLEAR(tint) REG_TSCR_WRITE(tint, TINT_STATUS_READ(tint) & ~BIT(tint))
-#endif
-
-#define OFFSET(irq)                   ((irq) - 353 - COND_CODE_1(CONFIG_GIC, (32), (0)))
-#define REG_INTSEL_READ(irq)          sys_read32(RZ_INTC_INTSEL + (OFFSET(irq) / 3) * 4)
-#define REG_INTSEL_WRITE(irq, v)      sys_write32((v), RZ_INTC_INTSEL + (OFFSET(irq) / 3) * 4)
-#define REG_INTSEL_SPIk_SEL_MASK(irq) (BIT_MASK(10) << ((OFFSET(irq) % 3) * 10))
-
 static const uint8_t gpioint_table[] = DT_PROP(DT_NODELABEL(intc), gpioint_table);
+
+static inline bool intc_rz_tint_status_read(mem_addr_t base, uint8_t tint)
+{
+#ifdef CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG
+	/* V2H, V2N */
+	return IS_BIT_SET(REG_TSCTR_READ(base, tint), tint);
+#else
+	return IS_BIT_SET(REG_TSCR_READ(base, tint), tint);
+#endif /* CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG */
+}
+
+static inline void intc_rz_tint_status_clear(mem_addr_t base, uint8_t tint)
+{
+#ifdef CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG
+	/* V2H, V2N */
+	REG_TSCLR_WRITE(base, tint, BIT(tint));
+#else
+	REG_TSCR_WRITE(base, tint, ~BIT(tint));
+#endif /* CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG */
+}
 
 static inline void intc_rz_tint_clear_irq_status(const struct device *dev)
 {
 	const struct intc_rz_tint_config *config = dev->config;
+	mem_addr_t base = INTC_BASE;
 	uint8_t tint = config->tint;
 
-	TINT_STATUS_CLEAR(tint);
+	intc_rz_tint_status_clear(base, tint);
 
 	/*
 	 * User's manual: Clear Timing of Interrupt Cause
 	 * Dummy read is required after write
 	 */
-	TINT_STATUS_READ(tint);
+	(void)intc_rz_tint_status_read(base, tint);
 }
 
 int intc_rz_tint_enable(const struct device *dev)
@@ -110,9 +135,10 @@ int intc_rz_tint_set_type(const struct device *dev, enum intc_rz_tint_trigger tr
 	const struct intc_rz_tint_config *config = dev->config;
 	struct intc_rz_tint_data *data = dev->data;
 	uint8_t tint = config->tint;
-	uint32_t reg_val = REG_TITSR_READ(tint);
 	uint32_t flags = IRQ_TYPE_LEVEL;
 	uint32_t set = 0;
+	mem_addr_t base = INTC_BASE;
+	uint32_t reg_val = REG_TITSR_READ(base, tint);
 
 	switch (trig) {
 	case RZ_TINT_FAILING_EDGE:
@@ -135,7 +161,7 @@ int intc_rz_tint_set_type(const struct device *dev, enum intc_rz_tint_trigger tr
 	/* Select interrupt type */
 	reg_val = (reg_val & ~REG_TITSR_TITSEL_MASK(tint)) |
 		  FIELD_PREP(REG_TITSR_TITSEL_MASK(tint), set);
-	REG_TITSR_WRITE(tint, reg_val);
+	REG_TITSR_WRITE(base, tint, reg_val);
 
 	/*
 	 * User's manual: Precaution when Changing Interrupt Settings
@@ -179,6 +205,16 @@ void intc_rz_tint_isr(const struct device *dev)
 	}
 }
 
+/* Map the shared intc register block once, before any tint instance is initialized. */
+static int intc_rz_tint_map_regs(void)
+{
+	DEVICE_MMIO_TOPLEVEL_MAP(intc_regs, K_MEM_CACHE_NONE);
+
+	return 0;
+}
+
+SYS_INIT(intc_rz_tint_map_regs, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY);
+
 static int intc_rz_tint_init(const struct device *dev)
 {
 	struct intc_rz_tint_data *data = dev->data;
@@ -187,12 +223,13 @@ static int intc_rz_tint_init(const struct device *dev)
 	const struct intc_rz_tint_config *config = dev->config;
 	uint8_t tint = config->tint;
 	uint32_t irq = config->irq;
-	uint32_t reg_val = REG_INTSEL_READ(irq);
+	mem_addr_t base = INTC_BASE;
+	uint32_t reg_val = REG_INTSEL_READ(base, irq);
 
 	reg_val &= ~REG_INTSEL_SPIk_SEL_MASK(irq);
 	reg_val |= FIELD_PREP(REG_INTSEL_SPIk_SEL_MASK(irq), tint);
 
-	REG_INTSEL_WRITE(irq, reg_val);
+	REG_INTSEL_WRITE(base, irq, reg_val);
 #endif
 	return intc_rz_tint_set_type(dev, data->trigger_type);
 };
@@ -201,8 +238,8 @@ int intc_rz_tint_connect(const struct device *dev, uint8_t port, uint8_t pin)
 {
 	const struct intc_rz_tint_config *config = dev->config;
 	struct intc_rz_tint_data *data = dev->data;
-
 	uint8_t tint = config->tint;
+	mem_addr_t base = INTC_BASE;
 
 	/* Map to GPIOINT */
 	uint8_t gpioint = gpioint_table[port] + pin;
@@ -211,12 +248,12 @@ int intc_rz_tint_connect(const struct device *dev, uint8_t port, uint8_t pin)
 		return -EINVAL;
 	}
 
-	uint32_t reg_val = REG_TSSR_READ(tint);
+	uint32_t reg_val = REG_TSSR_READ(base, tint);
 
 	reg_val &= ~(REG_TSSR_TSSEL_MASK(tint) | REG_TSSR_TIEN_MASK(tint));
 	reg_val |= FIELD_PREP(REG_TSSR_TSSEL_MASK(tint), gpioint);
 	reg_val |= FIELD_PREP(REG_TSSR_TIEN_MASK(tint), 1U);
-	REG_TSSR_WRITE(tint, reg_val);
+	REG_TSSR_WRITE(base, tint, reg_val);
 
 	data->gpioint = gpioint;
 	data->port = port;

--- a/drivers/interrupt_controller/intc_renesas_rz_tint.c
+++ b/drivers/interrupt_controller/intc_renesas_rz_tint.c
@@ -60,6 +60,9 @@ DEVICE_MMIO_TOPLEVEL_STATIC(intc_regs, DT_NODELABEL(intc));
 #define REG_INTSEL_WRITE(base, irq, v) sys_write32((v), INTSEL(base) + (OFFSET(irq) / 3) * 4)
 #define REG_INTSEL_SPIk_SEL_MASK(irq)  (BIT_MASK(10) << ((OFFSET(irq) % 3) * 10))
 
+/* data->gpioint value for a tint channel that is not connected to a GPIO pin yet */
+#define GPIOINT_UNASSIGNED 0xFFU
+
 struct intc_rz_tint_config {
 	uint8_t tint;
 	uint8_t max_gpioint;
@@ -77,6 +80,7 @@ struct intc_rz_tint_data {
 };
 
 static const uint8_t gpioint_table[] = DT_PROP(DT_NODELABEL(intc), gpioint_table);
+static bool used_gpioint[DT_PROP(DT_NODELABEL(intc), max_gpioint) + 1];
 static struct k_spinlock lock;
 
 /* Helper function to read TINT status
@@ -267,13 +271,27 @@ int intc_rz_tint_connect(const struct device *dev, uint8_t port, uint8_t pin)
 	/* Map to GPIOINT */
 	uint8_t gpioint = gpioint_table[port] + pin;
 
-	if (gpioint > config->max_gpioint) {
-		return -EINVAL;
-	}
+	__ASSERT(gpioint <= config->max_gpioint,
+		 "port %u pin %u maps to gpioint %u, out of range (max %u)", port, pin, gpioint,
+		 config->max_gpioint);
 
 	K_SPINLOCK(&lock) {
-		uint32_t reg_val = REG_TSSR_READ(base, tint);
+		uint32_t reg_val;
 
+		/* Already mapped, no need to remap and return successfully */
+		if (data->gpioint == gpioint) {
+			K_SPINLOCK_BREAK;
+		}
+
+		__ASSERT(data->gpioint == GPIOINT_UNASSIGNED,
+			 "tint %u already assigned to port %u pin %u", tint,
+			 data->port, data->pin);
+		__ASSERT(!used_gpioint[gpioint],
+			 "port %u pin %u (gpioint %u) already assigned to another tint", port,
+			 pin, gpioint);
+		used_gpioint[gpioint] = true;
+
+		reg_val = REG_TSSR_READ(base, tint);
 		reg_val &= ~(REG_TSSR_TSSEL_MASK(tint) | REG_TSSR_TIEN_MASK(tint));
 		reg_val |= FIELD_PREP(REG_TSSR_TSSEL_MASK(tint), gpioint);
 		reg_val |= FIELD_PREP(REG_TSSR_TIEN_MASK(tint), 1U);
@@ -310,6 +328,7 @@ int intc_rz_tint_set_callback(const struct device *dev, intc_rz_tint_callback_t 
 		.max_gpioint = DT_PROP(DT_INST_PARENT(index), max_gpioint),                        \
 	};                                                                                         \
 	struct intc_rz_tint_data intc_rz_tint_data##index = {                                      \
+		.gpioint = GPIOINT_UNASSIGNED,                                                     \
 		.trigger_type = DT_INST_ENUM_IDX_OR(index, trigger_type, 0),                       \
 	};                                                                                         \
 	static int intc_rz_tint_init##index(const struct device *dev)                              \

--- a/drivers/interrupt_controller/intc_renesas_rz_tint.c
+++ b/drivers/interrupt_controller/intc_renesas_rz_tint.c
@@ -79,6 +79,10 @@ struct intc_rz_tint_data {
 static const uint8_t gpioint_table[] = DT_PROP(DT_NODELABEL(intc), gpioint_table);
 static struct k_spinlock lock;
 
+/* Helper function to read TINT status
+ * V2H, V2N: TSTATn bit of TSCTR register
+ * Others: TSTATSn bit of TSCR register
+ */
 static inline bool intc_rz_tint_status_read(mem_addr_t base, uint8_t tint)
 {
 #ifdef CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG
@@ -89,6 +93,10 @@ static inline bool intc_rz_tint_status_read(mem_addr_t base, uint8_t tint)
 #endif /* CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG */
 }
 
+/* Helper function to clear TINT status
+ * V2H, V2N: TCLRn bit of TSCLR register
+ * Others: TSTATSn bit of TSCR register
+ */
 static inline void intc_rz_tint_status_clear(mem_addr_t base, uint8_t tint)
 {
 #ifdef CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG
@@ -99,19 +107,27 @@ static inline void intc_rz_tint_status_clear(mem_addr_t base, uint8_t tint)
 #endif /* CONFIG_RENESAS_RZ_TINT_SUPPORT_STATUS_CLEAR_REG */
 }
 
+/* Helper function to perform the process of clearing the interrupt status after changing
+ * the setting as per User's manual "Precaution when Changing Interrupt Settings".
+ */
 static inline void intc_rz_tint_clear_irq_status(const struct device *dev)
 {
 	const struct intc_rz_tint_config *config = dev->config;
 	mem_addr_t base = INTC_BASE;
 	uint8_t tint = config->tint;
 
-	intc_rz_tint_status_clear(base, tint);
-
-	/*
-	 * User's manual: Clear Timing of Interrupt Cause
-	 * Dummy read is required after write
+	/* As per TSCLR register (V2H, V2N) and TSCR register (A3x, G2x, G3x, V2L)
+	 * Only clear TINTn status flags when it is 1. Otherwise, writing has no effect
 	 */
-	(void)intc_rz_tint_status_read(base, tint);
+	if (intc_rz_tint_status_read(base, tint)) {
+		intc_rz_tint_status_clear(base, tint);
+
+		/*
+		 * User's manual: Clear Timing of Interrupt Cause
+		 * Dummy read is required after write
+		 */
+		(void)intc_rz_tint_status_read(base, tint);
+	}
 }
 
 int intc_rz_tint_enable(const struct device *dev)

--- a/drivers/interrupt_controller/intc_renesas_rz_tint.c
+++ b/drivers/interrupt_controller/intc_renesas_rz_tint.c
@@ -195,7 +195,9 @@ int intc_rz_tint_set_type(const struct device *dev, enum intc_rz_tint_trigger tr
 
 		/* Set interrupt type for GIC, and clear pending interrupt */
 #ifdef CONFIG_GIC
+#if defined(CONFIG_SOC_SERIES_RZV2H)
 		arm_gic_irq_set_priority(config->irq, config->prio, flags);
+#endif
 		arm_gic_irq_clear_pending(config->irq);
 #else
 		NVIC_ClearPendingIRQ(config->irq);

--- a/dts/arm64/renesas/rz/rza/r9a07g063.dtsi
+++ b/dts/arm64/renesas/rz/rza/r9a07g063.dtsi
@@ -751,7 +751,7 @@
 			tint0: tint0@0 {
 				compatible = "renesas,rz-tint";
 				reg = <0x0>;
-				interrupts = <GIC_SPI 444 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 444 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -760,7 +760,7 @@
 			tint1: tint1@1 {
 				compatible = "renesas,rz-tint";
 				reg = <0x1>;
-				interrupts = <GIC_SPI 445 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 445 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -769,7 +769,7 @@
 			tint2: tint2@2 {
 				compatible = "renesas,rz-tint";
 				reg = <0x2>;
-				interrupts = <GIC_SPI 446 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 446 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -778,7 +778,7 @@
 			tint3: tint3@3 {
 				compatible = "renesas,rz-tint";
 				reg = <0x3>;
-				interrupts = <GIC_SPI 447 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 447 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -787,7 +787,7 @@
 			tint4: tint4@4 {
 				compatible = "renesas,rz-tint";
 				reg = <0x4>;
-				interrupts = <GIC_SPI 448 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 448 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -796,7 +796,7 @@
 			tint5: tint5@5 {
 				compatible = "renesas,rz-tint";
 				reg = <0x5>;
-				interrupts = <GIC_SPI 449 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 449 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -805,7 +805,7 @@
 			tint6: tint6@6 {
 				compatible = "renesas,rz-tint";
 				reg = <0x6>;
-				interrupts = <GIC_SPI 450 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 450 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -814,7 +814,7 @@
 			tint7: tint7@7 {
 				compatible = "renesas,rz-tint";
 				reg = <0x7>;
-				interrupts = <GIC_SPI 451 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 451 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -823,7 +823,7 @@
 			tint8: tint8@8 {
 				compatible = "renesas,rz-tint";
 				reg = <0x8>;
-				interrupts = <GIC_SPI 452 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 452 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -832,7 +832,7 @@
 			tint9: tint9@9 {
 				compatible = "renesas,rz-tint";
 				reg = <0x9>;
-				interrupts = <GIC_SPI 453 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 453 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -841,7 +841,7 @@
 			tint10: tint10@a {
 				compatible = "renesas,rz-tint";
 				reg = <0xa>;
-				interrupts = <GIC_SPI 454 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 454 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -850,7 +850,7 @@
 			tint11: tint11@b {
 				compatible = "renesas,rz-tint";
 				reg = <0xb>;
-				interrupts = <GIC_SPI 455 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 455 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -859,7 +859,7 @@
 			tint12: tint12@c {
 				compatible = "renesas,rz-tint";
 				reg = <0xc>;
-				interrupts = <GIC_SPI 456 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 456 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -868,7 +868,7 @@
 			tint13: tint13@d {
 				compatible = "renesas,rz-tint";
 				reg = <0xd>;
-				interrupts = <GIC_SPI 457 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 457 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -877,7 +877,7 @@
 			tint14: tint14@e {
 				compatible = "renesas,rz-tint";
 				reg = <0xe>;
-				interrupts = <GIC_SPI 458 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 458 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -886,7 +886,7 @@
 			tint15: tint15@f {
 				compatible = "renesas,rz-tint";
 				reg = <0xf>;
-				interrupts = <GIC_SPI 459 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 459 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -895,7 +895,7 @@
 			tint16: tint16@10 {
 				compatible = "renesas,rz-tint";
 				reg = <0x10>;
-				interrupts = <GIC_SPI 460 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 460 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -904,7 +904,7 @@
 			tint17: tint17@11 {
 				compatible = "renesas,rz-tint";
 				reg = <0x11>;
-				interrupts = <GIC_SPI 461 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 461 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -913,7 +913,7 @@
 			tint18: tint18@12 {
 				compatible = "renesas,rz-tint";
 				reg = <0x12>;
-				interrupts = <GIC_SPI 462 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 462 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -922,7 +922,7 @@
 			tint19: tint19@13 {
 				compatible = "renesas,rz-tint";
 				reg = <0x13>;
-				interrupts = <GIC_SPI 463 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 463 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -931,7 +931,7 @@
 			tint20: tint20@14 {
 				compatible = "renesas,rz-tint";
 				reg = <0x14>;
-				interrupts = <GIC_SPI 464 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 464 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -940,7 +940,7 @@
 			tint21: tint21@15 {
 				compatible = "renesas,rz-tint";
 				reg = <0x15>;
-				interrupts = <GIC_SPI 465 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 465 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -949,7 +949,7 @@
 			tint22: tint22@16 {
 				compatible = "renesas,rz-tint";
 				reg = <0x16>;
-				interrupts = <GIC_SPI 466 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 466 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -958,7 +958,7 @@
 			tint23: tint23@17 {
 				compatible = "renesas,rz-tint";
 				reg = <0x17>;
-				interrupts = <GIC_SPI 467 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 467 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -967,7 +967,7 @@
 			tint24: tint24@18 {
 				compatible = "renesas,rz-tint";
 				reg = <0x18>;
-				interrupts = <GIC_SPI 468 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 468 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -976,7 +976,7 @@
 			tint25: tint25@19 {
 				compatible = "renesas,rz-tint";
 				reg = <0x19>;
-				interrupts = <GIC_SPI 469 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 469 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -985,7 +985,7 @@
 			tint26: tint26@1a {
 				compatible = "renesas,rz-tint";
 				reg = <0x1a>;
-				interrupts = <GIC_SPI 470 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 470 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -994,7 +994,7 @@
 			tint27: tint27@1b {
 				compatible = "renesas,rz-tint";
 				reg = <0x1b>;
-				interrupts = <GIC_SPI 471 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 471 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -1003,7 +1003,7 @@
 			tint28: tint28@1c {
 				compatible = "renesas,rz-tint";
 				reg = <0x1c>;
-				interrupts = <GIC_SPI 472 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 472 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -1012,7 +1012,7 @@
 			tint29: tint29@1d {
 				compatible = "renesas,rz-tint";
 				reg = <0x1d>;
-				interrupts = <GIC_SPI 473 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 473 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -1021,7 +1021,7 @@
 			tint30: tint30@1e {
 				compatible = "renesas,rz-tint";
 				reg = <0x1e>;
-				interrupts = <GIC_SPI 474 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 474 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";
@@ -1030,7 +1030,7 @@
 			tint31: tint31@1f {
 				compatible = "renesas,rz-tint";
 				reg = <0x1f>;
-				interrupts = <GIC_SPI 475 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
+				interrupts = <GIC_SPI 475 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				trigger-type = "rising";
 				#irq-cells = <1>;
 				status = "disabled";


### PR DESCRIPTION
This PR addresses several issues pointed out by https://github.com/zephyrproject-rtos/zephyr/pull/91031

- ~Refactor tint driver to use MMIO device APIs (mentioned in https://github.com/zephyrproject-rtos/zephyr/pull/91031#discussion_r3043794128)~
  - ~Convert from direct register access to Zephyr MMIO device APIs to support ARM64 with MMU~
 
- Add locking for shared TINT registers (reported in https://github.com/zephyrproject-rtos/zephyr/pull/91031#discussion_r3337767099)
  - Introduce spinlock to protect shared TSCR/TITSR/TSSR registers from concurrent access across different TINT instances

- Fix status clear logic (reported in https://github.com/zephyrproject-rtos/zephyr/pull/91031#discussion_r3337834403)
  - Only clear TINT status flag when it's actually set (per register spec)
  - Add explanatory comments for V2H/V2N vs other SoC register differences

- GIC interrupt type of TINT is fixed to level except for V2H (https://github.com/zephyrproject-rtos/zephyr/pull/91031#discussion_r3337736726)
  - Only RZ/V2H supports both GIC interrupt types (level/edge) for TINT
  - Other RZ series now keep GIC interrupt type unchanged

- Prevent duplicate gpioint/tint mapping (reported in https://github.com/zephyrproject-rtos/zephyr/pull/91031#discussion_r3337784372)
  - Add atomic bitmap to track assigned GPIO pins and prevent conflicts
  - Reject attempts to remap an already-assigned TINT or reuse a GPIO pin across multiple TINTs