### PR TITLE
scripts: checkpatch.pl: relax Missing a blank line

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -868,6 +868,7 @@ our $FuncArg = qr{$Typecast{0,1}($LvalOrFunc|$Constant|$String)};
 our $declaration_macros = qr{(?x:
 	(?:$Storage\s+)?(?:[A-Z_][A-Z0-9]*_){0,2}(?:DEFINE|DECLARE)(?:_[A-Z0-9]+){0,6}\s*\(|
 	(?:$Storage\s+)?[HLP]?LIST_HEAD\s*\(|
+	(?:DEVICE_MMIO_)(?:NAMED_)?(?:ROM|RAM)(?!_PTR)|
 	(?:SKCIPHER_REQUEST|SHASH_DESC|AHASH_REQUEST)_ON_STACK\s*\(
 )};
 


### PR DESCRIPTION
add the delaring macros from
zephyr/sys/device_mmio.h
as to list so it does not complain about it.