### PR TITLE
modules: openthread: Add openthread_work_q_get() API

### DIFF
--- a/modules/openthread/include/openthread.h
+++ b/modules/openthread/include/openthread.h
@@ -78,6 +78,11 @@ int openthread_state_changed_callback_unregister(struct openthread_state_changed
 k_tid_t openthread_thread_id_get(void);
 
 /**
+ * @brief Get OpenThread work queue.
+ */
+struct k_work_q *openthread_work_q_get(void);
+
+/**
  * @brief Get pointer to default OpenThread instance.
  *
  * @retval !NULL On success.

--- a/modules/openthread/openthread.c
+++ b/modules/openthread/openthread.c
@@ -128,6 +128,11 @@ k_tid_t openthread_thread_id_get(void)
 	return openthread_work_q.thread_id;
 }
 
+struct k_work_q *openthread_work_q_get(void)
+{
+	return &openthread_work_q;
+}
+
 static int ncp_hdlc_send(const uint8_t *buf, uint16_t len)
 {
 	otError err = OT_ERROR_NONE;


### PR DESCRIPTION
Expose the OpenThread work queue pointer so callers can submit work without relying on the deprecated k_work_q.thread field.