### PR TITLE
modules/lvgl: imply CPU_LOAD when the system monitor is enabled

### DIFF
--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -7,12 +7,17 @@ config ZEPHYR_LVGL_MODULE
 
 config LVGL
 	bool "LVGL support"
+	# Without CPU_LOAD the system monitor always reads 0% idle (100% CPU).
+	imply CPU_LOAD if LV_USE_SYSMON
 	help
 	  This option enables the LVGL graphics library.
 
 if LVGL
 
 config LV_USE_MONKEY
+	bool
+
+config LV_USE_SYSMON
 	bool
 
 config LV_DPI_DEF

--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -7,6 +7,7 @@ config ZEPHYR_LVGL_MODULE
 
 config LVGL
 	bool "LVGL support"
+	imply CPU_LOAD if LV_USE_SYSMON
 	help
 	  This option enables the LVGL graphics library.
 
@@ -16,6 +17,9 @@ config LV_DRAW_BUF_ALIGN
 	int
 
 config LV_USE_MONKEY
+	bool
+
+config LV_USE_SYSMON
 	bool
 
 config LV_DPI_DEF


### PR DESCRIPTION
### Explanation

LVGL's system monitor derives CPU usage from `100 - lv_os_get_idle_percent()`. On Zephyr, that hook is implemented in `modules/lvgl/lvgl_zephyr_osal.c` and can only return a real idle percentage when `CONFIG_CPU_LOAD` is enabled. Without it the hook returns `0`, so the monitor permanently reads **0% idle / 100% CPU** regardless of actual load.

This change makes `LVGL` `imply CPU_LOAD` when `LV_USE_SYSMON` is enabled, so the monitor reports real CPU usage out of the box.

`imply` is used rather than `select` on purpose: `CPU_LOAD` has its own dependencies —

```kconfig
config CPU_LOAD
	select TRACING
	depends on CPU_CORTEX_M || RISCV || CPU_CORTEX_A
	depends on !SMP
```

A hard `select` would force it on even where those are unmet (e.g. the POSIX arch / `native_sim`, or SMP builds), producing "unmet direct dependencies" warnings and broken configurations. `imply` enables it only where the dependencies are satisfied and leaves it overridable.

### Testing

Configured the LVGL sample with `CONFIG_LV_USE_SYSMON=y` and no explicit `CPU_LOAD` in the board/app config:

- **`stm32u5g9j_dk2`** (Cortex-M33): `CONFIG_CPU_LOAD=y` is pulled in by the imply (and `CONFIG_TRACING=y` follows), no warnings.
- **`native_sim`** (POSIX): `CPU_LOAD` correctly stays unset, no unmet-dependency warnings.
