### PR TITLE
tests: drivers: uart: Avoid nRF7120 console conflicts in test overlays

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -5,14 +5,14 @@
  */
 
 &pinctrl {
-	uart21_default_alt: uart21_default_alt {
+	uart22_default_alt: uart22_default_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>;
 		};
 	};
 
-	uart21_sleep_alt: uart21_sleep_alt {
+	uart22_sleep_alt: uart22_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>;
@@ -21,10 +21,10 @@
 	};
 };
 
-dut: &uart21 {
+dut: &uart22 {
 	status = "okay";
-	pinctrl-0 = <&uart21_default_alt>;
-	pinctrl-1 = <&uart21_sleep_alt>;
+	pinctrl-0 = <&uart22_default_alt>;
+	pinctrl-1 = <&uart22_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	current-speed = <115200>;
 };

--- a/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_common_dual_uart.dtsi
+++ b/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_common_dual_uart.dtsi
@@ -5,7 +5,7 @@
  */
 
 &pinctrl {
-	uart21_default_alt: uart21_default_alt {
+	uart22_default_alt: uart22_default_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 6)>;
@@ -13,7 +13,7 @@
 		};
 	};
 
-	uart21_sleep_alt: uart21_sleep_alt {
+	uart22_sleep_alt: uart22_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 6)>;
@@ -21,7 +21,7 @@
 		};
 	};
 
-	uart22_default: uart22_default {
+	uart23_default: uart23_default {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 4)>,
 				<NRF_PSEL(UART_RX, 1, 15)>;
@@ -29,7 +29,7 @@
 		};
 	};
 
-	uart22_sleep: uart22_sleep {
+	uart23_sleep: uart23_sleep {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 4)>,
 				<NRF_PSEL(UART_RX, 1, 15)>;
@@ -38,18 +38,18 @@
 	};
 };
 
-dut: &uart21 {
+dut: &uart22 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart21_default_alt>;
-	pinctrl-1 = <&uart21_sleep_alt>;
+	pinctrl-0 = <&uart22_default_alt>;
+	pinctrl-1 = <&uart22_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 };
 
-dut_aux: &uart22 {
+dut_aux: &uart23 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart22_default>;
-	pinctrl-1 = <&uart22_sleep>;
+	pinctrl-0 = <&uart23_default>;
+	pinctrl-1 = <&uart23_sleep>;
 	pinctrl-names = "default", "sleep";
 };

--- a/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -5,7 +5,7 @@
  */
 
 &pinctrl {
-	uart21_default_alt: uart21_default_alt {
+	uart22_default_alt: uart22_default_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>,
@@ -14,7 +14,7 @@
 		};
 	};
 
-	uart21_sleep_alt: uart21_sleep_alt {
+	uart22_sleep_alt: uart22_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>,
@@ -25,11 +25,11 @@
 	};
 };
 
-dut: &uart21 {
+dut: &uart22 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart21_default_alt>;
-	pinctrl-1 = <&uart21_sleep_alt>;
+	pinctrl-0 = <&uart22_default_alt>;
+	pinctrl-1 = <&uart22_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	hw-flow-control;
 };

--- a/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_cpuflpr.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nrf7120dk_nrf7120_cpuflpr.overlay
@@ -5,7 +5,7 @@
  */
 
 &pinctrl {
-	uart21_default_alt: uart21_default_alt {
+	uart22_default_alt: uart22_default_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>,
@@ -14,7 +14,7 @@
 		};
 	};
 
-	uart21_sleep_alt: uart21_sleep_alt {
+	uart22_sleep_alt: uart22_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 1, 13)>,
 				<NRF_PSEL(UART_RX, 1, 15)>,
@@ -25,11 +25,11 @@
 	};
 };
 
-dut: &uart21 {
+dut: &uart22 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart21_default_alt>;
-	pinctrl-1 = <&uart21_sleep_alt>;
+	pinctrl-0 = <&uart22_default_alt>;
+	pinctrl-1 = <&uart22_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	hw-flow-control;
 };


### PR DESCRIPTION
Recent pinset updates to aligned with DK now use uart20 and uart21 as console outputs for cpuapp and cpuflpr. Update test overlays to use uart22 and uart23 instances to avoid conflicts with console peripherals.