### PR TITLE
drivers: wifi: esp32: add wi-fi mesh support

### DIFF
--- a/drivers/wifi/esp32/CMakeLists.txt
+++ b/drivers/wifi/esp32/CMakeLists.txt
@@ -3,3 +3,7 @@
 zephyr_library_sources_ifdef(CONFIG_WIFI_ESP32
   src/esp_wifi_drv.c
   )
+
+zephyr_library_sources_ifdef(CONFIG_WIFI_ESP32_MESH
+  src/esp_wifi_mesh.c
+  )

--- a/drivers/wifi/esp32/CMakeLists.txt
+++ b/drivers/wifi/esp32/CMakeLists.txt
@@ -7,3 +7,7 @@ zephyr_library_sources_ifdef(CONFIG_WIFI_ESP32
 zephyr_library_sources_ifdef(CONFIG_WIFI_ESP32_MESH
   src/esp_wifi_mesh.c
   )
+
+zephyr_library_sources_ifdef(CONFIG_WIFI_ESP32_MESH_IP
+  src/esp_wifi_mesh_netif.c
+  )

--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -328,6 +328,65 @@ config ESP32_WIFI_TASK_STACK_SIZE
 	  and the stack depth requested by the blob at runtime, so a higher
 	  Kconfig value only raises the floor.
 
+config ESP32_WIFI_EVENT_TASK_STACK_SIZE
+	int "Wi-Fi event task stack size"
+	default 2048
+	help
+	  Stack size of the event task that runs the Wi-Fi event
+	  handlers. The Wi-Fi library posts events from its own task; the
+	  handlers run on this dedicated task instead so a handler cannot
+	  overrun the library task stack or stall the library task.
+
+config ESP32_WIFI_EVENT_TASK_PRIORITY
+	int "Wi-Fi event task priority"
+	default 4
+	help
+	  Preemptible priority of the Wi-Fi event task. Keep it above the
+	  application threads so connect and disconnect state changes are
+	  handled promptly. A caller that must observe a state change before
+	  continuing synchronizes on the event rather than relying on this
+	  task preempting it.
+
+config ESP32_WIFI_STA_START_TIMEOUT
+	int "Wi-Fi station-start wait timeout (ms)"
+	default 1000
+	help
+	  Time a connect request waits for the station-started event, which is
+	  handled on the event task, before it gives up. Raise it if a connect
+	  fails with the station not in station mode under a heavy event load.
+
+config ESP32_WIFI_EVENT_QUEUE_SIZE
+	int "Wi-Fi event queue depth"
+	default 16
+	help
+	  Number of posted events buffered between the Wi-Fi library task and
+	  the event task. Each queued entry carries an inline copy of the event
+	  payload, so the RAM cost is this depth times the entry size.
+
+	  Events are delivered asynchronously on the event task rather than
+	  inline on the library task, which keeps handler work off that task.
+	  The mesh needs this: it brings the network stack up (DHCP server, NAT
+	  and routes) from an event handler, which neither fits the library task
+	  stack nor should block it.
+
+	  A post carries the timeout its caller asked for. The libraries post
+	  most events without waiting, so a full queue drops those and logs at
+	  error level; the events able to fill it are the ones that suits, softAP
+	  client churn and mesh routing updates, which the next event or a
+	  re-parent supersedes. The queue is sized to absorb those bursts. A
+	  caller that must not lose its event waits instead, except from the
+	  event task itself, which drains this queue and so never waits on it.
+
+	  Losing a station or softAP state transition this way leaves the driver
+	  state stale until the next one, which is why the depth covers a burst
+	  of them several times over. Reaching it takes the event task being
+	  starved outright, since its handlers only update state and raise a
+	  network management event. The driver state stays readable through
+	  NET_REQUEST_WIFI_IFACE_STATUS in that case, and the notification hop
+	  to the application has its own backpressure in the network management
+	  layer (see NET_MGMT_EVENT_QUEUE_SIZE and NET_MGMT_EVENT_QUEUE_TIMEOUT).
+	  Raise this depth at the cost of more RAM if drops are ever seen.
+
 config ESP32_WIFI_SLP_DEFAULT_MIN_ACTIVE_TIME
 	int "Minimum active time"
 	range 8 60

--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -618,6 +618,19 @@ config WIFI_ESP32_MESH_FORCE_CHILD
 
 endchoice # WIFI_ESP32_MESH_ROLE
 
+config WIFI_ESP32_MESH_IP
+	bool "IP over mesh"
+	select NET_L2_ETHERNET
+	help
+	  Build the Ethernet-over-mesh network interface so IP runs on top of
+	  the mesh transport. It carries Ethernet frames as the mesh payload,
+	  letting the Zephyr network stack (addresses, DHCP, NAT, sockets) run
+	  unmodified over the mesh. Without this option the mesh only carries
+	  application data through esp_wifi_mesh_send()/esp_wifi_mesh_recv().
+
+	  The IP-level policy (addresses, DHCP server, NAT, routes) is left to
+	  the application; the driver only provides the transport interface.
+
 endif # WIFI_ESP32_MESH
 
 config ESP32_WIFI_MBEDTLS_CRYPTO

--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -7,6 +7,7 @@ menuconfig WIFI_ESP32
 	depends on ZEPHYR_HAL_ESPRESSIF_MODULE_BLOBS || BUILD_ONLY_NO_BLOBS
 	depends on !SMP
 	select THREAD_CUSTOM_DATA
+	select EVENTS
 	select NET_L2_WIFI_MGMT
 	select NET_L2_ETHERNET
 	select NET_L2_ETHERNET_MGMT
@@ -332,7 +333,7 @@ config ESP32_WIFI_EVENT_TASK_STACK_SIZE
 	int "Wi-Fi event task stack size"
 	default 2048
 	help
-	  Stack size of the event task that runs the Wi-Fi event
+	  Stack size of the event task that runs the Wi-Fi and mesh event
 	  handlers. The Wi-Fi library posts events from its own task; the
 	  handlers run on this dedicated task instead so a handler cannot
 	  overrun the library task stack or stall the library task.
@@ -437,6 +438,187 @@ config ESP32_WIFI_SOFTAP_SUPPORT
 	default y
 	help
 	  Hidden option to enable Wi-Fi SoftAP functions in WPA supplicant and RF libraries.
+
+menuconfig WIFI_ESP32_MESH
+	bool "ESP Wi-Fi mesh support"
+	depends on SOC_SERIES_ESP32 || SOC_SERIES_ESP32S2 || SOC_SERIES_ESP32S3 || \
+		SOC_SERIES_ESP32C3 || SOC_SERIES_ESP32C5 || SOC_SERIES_ESP32C6
+	select ESP32_WIFI_SOFTAP_SUPPORT
+	help
+	  Enable the self-organizing multi-hop Wi-Fi mesh network stack.
+	  Each node runs Wi-Fi in combined AP and station mode: the station
+	  interface links upward to a parent, the softAP interface accepts
+	  child nodes. Only the root node reaches the external IP network.
+	  Not available on ESP32-C2 and ESP32-H2.
+
+if WIFI_ESP32_MESH
+
+config WIFI_ESP32_MESH_MAX_LAYER
+	int "Maximum mesh layer (tree depth)"
+	default 25
+	range 1 25
+	help
+	  Maximum number of layers (tree depth) the mesh may grow to. The root
+	  is layer 1, its direct children layer 2, and so on. Nodes that would
+	  attach deeper than this limit are refused, bounding the tree height.
+	  The routing table on the root is sized for the whole sub-network, so
+	  the maximum node count is roughly MAX_LAYER * MAX_CONNECTIONS + 1.
+
+config WIFI_ESP32_MESH_MAX_CONNECTIONS
+	int "Maximum direct child connections per node"
+	default 6
+	range 1 10
+	help
+	  Maximum number of direct child nodes a single node accepts on its
+	  softAP interface. This is a per-node fan-out limit, not a whole-network
+	  limit: nodes beyond this count attach one layer deeper instead, so the
+	  network still grows by extending the tree. A larger value makes a
+	  flatter tree (more RAM per node for the extra links); a smaller value
+	  makes a deeper tree. Each direct link consumes Wi-Fi RX/TX buffers from
+	  the system heap, so a node acting as root or as an intermediate hub for
+	  several children needs more heap than a leaf (see the sample prj.conf
+	  for CONFIG_HEAP_MEM_POOL_SIZE guidance).
+
+config WIFI_ESP32_MESH_EVENT_HANDLERS
+	int "Maximum registered mesh event handlers"
+	default 12
+	range 4 32
+	help
+	  Size of the event handler table used to dispatch Wi-Fi and mesh
+	  events. It must cover both the application handlers and the handlers
+	  the mesh stack registers internally, which the application cannot
+	  count; a handler registered beyond this limit is dropped.
+
+config WIFI_ESP32_MESH_START_TIMEOUT
+	int "Mesh-start wait timeout (ms)"
+	default 2000
+	help
+	  Time esp_wifi_mesh_start() waits for the mesh stack to report
+	  MESH_EVENT_STARTED before it proceeds to re-deliver the initial
+	  station-start event. The wait ends as soon as the event arrives; this
+	  is only the upper bound before it gives up and continues anyway.
+
+config WIFI_ESP32_MESH_CHANNEL
+	int "Mesh channel (0 = auto, 1-13 = fixed)"
+	default 0
+	range 0 13
+	help
+	  Channel the mesh network operates on. 0 lets the mesh select the
+	  channel by scanning, which is required when the router channel is
+	  unknown. A fixed value 1-13 pins the channel; all nodes must then
+	  use the same one.
+
+config WIFI_ESP32_MESH_ROUTER_SSID
+	string "Router SSID"
+	default "myssid"
+	help
+	  SSID of the router the root node connects to for external network
+	  access. The mesh stack requires a router SSID to be set, so this
+	  carries a placeholder rather than an empty default. Set it to the
+	  router in use: a node left on the placeholder finds no such network
+	  and keeps searching for a parent.
+
+config WIFI_ESP32_MESH_ROUTER_PSK
+	string "Router password"
+	default "mypassword"
+	help
+	  Password of the router the root node connects to. Leave empty for an
+	  open router.
+
+config WIFI_ESP32_MESH_AP_PSK
+	string "Mesh softAP password"
+	default "meshpassword"
+	help
+	  Password protecting the inter-node mesh softAP links. Must be at
+	  least 8 characters and identical on every node.
+
+config WIFI_ESP32_MESH_ID
+	string "Mesh network ID (6 bytes, colon-separated hex)"
+	default "12:34:56:78:9a:bc"
+	help
+	  Unique 6-byte identifier of this mesh network, written as six
+	  colon-separated hex octets. Nodes only join a mesh that advertises
+	  the same ID, so every node in one network must use the same value and
+	  different networks sharing a channel must use different IDs.
+
+config WIFI_ESP32_MESH_ASSOC_EXPIRE
+	int "Idle child association expiry (seconds)"
+	default 10
+	range 1 60
+	help
+	  How long a node keeps a child association without traffic before
+	  releasing it. When a child re-parents, its previous parent holds the
+	  now-dead association until this expiry, keeping one of its child slots
+	  occupied; with few connections per node a long expiry can stall the
+	  tree from converging. 10 seconds matches the value used with mesh
+	  power save disabled.
+
+config WIFI_ESP32_MESH_XON_QSIZE
+	int "Mesh receive flow-control queue size"
+	default 128
+	range 16 256
+	help
+	  Number of packets the mesh receive queue holds before applying flow
+	  control to upstream senders. A larger queue tolerates bigger traffic
+	  bursts at the cost of RAM.
+
+config WIFI_ESP32_MESH_VOTE_PERCENTAGE
+	int "Root election vote percentage threshold"
+	default 100
+	range 1 100
+	help
+	  Percentage of votes a candidate needs to be approved as root during
+	  self-organized election, as a whole percent (100 = unanimous). Only
+	  relevant in the auto role.
+
+config WIFI_ESP32_MESH_SEND_BLOCK_TIME_MS
+	int "Mesh send block time (milliseconds)"
+	default 30000
+	range 0 60000
+	help
+	  How long esp_wifi_mesh_send() blocks waiting for buffer space under
+	  congestion before failing. A longer time lets bursts drain instead of
+	  dropping frames; 0 fails immediately when no buffer is available.
+
+choice WIFI_ESP32_MESH_ROLE
+	prompt "Mesh role of this node"
+	default WIFI_ESP32_MESH_ROLE_AUTO
+	help
+	  Selects how this node takes its place in the mesh tree.
+
+config WIFI_ESP32_MESH_ROLE_AUTO
+	bool "Self-organized (elect root by router reachability)"
+	help
+	  Default self-organized behavior: the node scans, and if it can reach
+	  the router it votes to become the root, otherwise it attaches to an
+	  in-range mesh node as a child. A router is required for the election.
+
+config WIFI_ESP32_MESH_FORCE_ROOT
+	bool "Force this node to be the root (fixed root)"
+	help
+	  Designate this node as the fixed root of the mesh. It never elects and
+	  always sits at the top of the tree. With a router configured it keeps
+	  the self-organized behavior that drives its association to the router
+	  and the reconnection maintaining that uplink; without one the parent
+	  search is stopped, since there is no parent to find and the search
+	  would disrupt its softAP. A router is still required for children to
+	  auto-attach: a fully router-less mesh needs each child to be given an
+	  explicit parent, which this driver does not do.
+	  The other nodes must be built as fixed children
+	  (WIFI_ESP32_MESH_FORCE_CHILD) so they accept this designated root
+	  instead of running an election.
+
+config WIFI_ESP32_MESH_FORCE_CHILD
+	bool "Force this node to stay a child (never become root)"
+	help
+	  Prevent this node from becoming root, so it always attaches to another
+	  node as a child. Useful with a fixed root, and on a bench where every
+	  board can hear the router and would otherwise each elect itself root
+	  instead of forming one tree.
+
+endchoice # WIFI_ESP32_MESH_ROLE
+
+endif # WIFI_ESP32_MESH
 
 config ESP32_WIFI_MBEDTLS_CRYPTO
 	bool "Use MbedTLS crypto APIs"

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -46,6 +46,14 @@ NET_IF_DT_INST_DECLARE(0, 0);
 #define esp32_wifi_iface NET_IF_DT_INST_GET(0, 0)
 static struct esp32_wifi_runtime esp32_data;
 
+/*
+ * Signalled by the WIFI_EVENT_STA_START handler. Station events run on the
+ * event task, so a caller that starts the station and needs it running (the
+ * connect path) waits on this instead of reading the state right after the
+ * start call returns.
+ */
+static K_SEM_DEFINE(esp32_sta_started_sem, 0, 1);
+
 #if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
 NET_IF_DT_INST_DECLARE(0, 1);
 #define esp32_wifi_iface_ap NET_IF_DT_INST_GET(0, 1)
@@ -88,6 +96,43 @@ struct esp32_wifi_runtime {
 	struct wifi_enterprise_creds_params enterprise_creds;
 #endif
 };
+
+/*
+ * Sized for every event the driver and the mesh stack handle, with a little
+ * headroom: the largest of those payloads is 48 bytes (station connected). The
+ * buffer is copied into every queue entry, so the cost is this size plus the
+ * entry header times ESP32_WIFI_EVENT_QUEUE_SIZE; the BUILD_ASSERT below keeps
+ * it honest if a handled event ever grows.
+ *
+ * Some library events carry far more than this (WPS enrollee credentials are
+ * 289 bytes, a DPP configuration object runs to a few kilobytes), but none of
+ * them are handled here and they are too large to copy inline into every queue
+ * entry. Such an event is rejected by esp_event_post() rather than delivered
+ * without its payload.
+ */
+#define ESP32_WIFI_EVENT_DATA_MAX 64
+
+BUILD_ASSERT(sizeof(wifi_event_sta_connected_t) <= ESP32_WIFI_EVENT_DATA_MAX &&
+		     sizeof(wifi_event_sta_disconnected_t) <= ESP32_WIFI_EVENT_DATA_MAX &&
+		     sizeof(wifi_event_ap_staconnected_t) <= ESP32_WIFI_EVENT_DATA_MAX &&
+		     sizeof(wifi_event_ap_stadisconnected_t) <= ESP32_WIFI_EVENT_DATA_MAX,
+	     "ESP32_WIFI_EVENT_DATA_MAX is too small for a handled Wi-Fi event payload");
+
+#if defined(CONFIG_WIFI_ESP32_MESH)
+BUILD_ASSERT(sizeof(mesh_event_disconnected_t) <= ESP32_WIFI_EVENT_DATA_MAX &&
+		     sizeof(mesh_event_toDS_state_t) <= ESP32_WIFI_EVENT_DATA_MAX,
+	     "ESP32_WIFI_EVENT_DATA_MAX is too small for a handled mesh event payload");
+#endif
+
+struct esp32_wifi_event {
+	esp_event_base_t base;
+	int32_t id;
+	size_t data_size;
+	uint8_t data[ESP32_WIFI_EVENT_DATA_MAX];
+};
+
+K_MSGQ_DEFINE(esp32_wifi_event_msgq, sizeof(struct esp32_wifi_event),
+	      CONFIG_ESP32_WIFI_EVENT_QUEUE_SIZE, 4);
 
 static struct net_mgmt_event_callback esp32_dhcp_cb;
 
@@ -294,6 +339,16 @@ static void scan_done_handler(void)
 	wifi_ap_record_t ap_record;
 	struct wifi_scan_result res = { 0 };
 
+	/*
+	 * A NULL scan callback means the scan was triggered internally (for
+	 * example by the mesh stack), not through a user scan request. In that
+	 * case the scan results belong to the internal consumer, so do not
+	 * drain or clear them here.
+	 */
+	if (esp32_data.scan_cb == NULL) {
+		return;
+	}
+
 	while ((ret = esp_wifi_scan_get_ap_record(&ap_record)) == ESP_OK) {
 		memset(&res, 0, sizeof(struct wifi_scan_result));
 
@@ -351,12 +406,10 @@ static void scan_done_handler(void)
 			break;
 		}
 
-		if (esp32_data.scan_cb) {
-			esp32_data.scan_cb(esp32_wifi_iface, 0, &res);
+		esp32_data.scan_cb(esp32_wifi_iface, 0, &res);
 
-			/* ensure notifications get delivered */
-			k_yield();
-		}
+		/* ensure notifications get delivered */
+		k_yield();
 	}
 
 	if (ret != ESP_FAIL) {
@@ -366,7 +419,7 @@ static void scan_done_handler(void)
 	/* Ensure the hardware releases any records we didn't fetch */
 	esp_wifi_clear_ap_list();
 
-	/* report end of scan event */
+	/* Report end of scan; the internal-scan case already returned above. */
 	esp32_data.scan_cb(esp32_wifi_iface, 0, NULL);
 	esp32_data.scan_cb = NULL;
 }
@@ -836,6 +889,7 @@ void esp_wifi_event_handler(const char *event_base, int32_t event_id, void *even
 	switch (event_id) {
 	case WIFI_EVENT_STA_START:
 		esp32_data.state = ESP32_STA_STARTED;
+		k_sem_give(&esp32_sta_started_sem);
 		break;
 	case WIFI_EVENT_STA_STOP:
 		esp32_data.state = ESP32_STA_STOPPED;
@@ -871,6 +925,97 @@ void esp_wifi_event_handler(const char *event_base, int32_t event_id, void *even
 	default:
 		break;
 	}
+}
+
+/*
+ * Dispatch library-posted events on this dedicated task so a handler runs on
+ * its own stack and cannot stall or overrun the Wi-Fi library task. A single
+ * queue drained by one task preserves event order.
+ */
+static void esp32_wifi_event_task(void *p1, void *p2, void *p3)
+{
+	struct esp32_wifi_event evt;
+
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	while (true) {
+		k_msgq_get(&esp32_wifi_event_msgq, &evt, K_FOREVER);
+
+		esp_wifi_event_handler(evt.base, evt.id, evt.data_size ? evt.data : NULL,
+				       evt.data_size, 0);
+
+	}
+}
+
+K_THREAD_DEFINE(esp32_wifi_event_tid, CONFIG_ESP32_WIFI_EVENT_TASK_STACK_SIZE,
+		esp32_wifi_event_task, NULL, NULL, NULL, CONFIG_ESP32_WIFI_EVENT_TASK_PRIORITY, 0,
+		0);
+
+/*
+ * Entry point the Wi-Fi and mesh libraries post events through, and the only
+ * esp_event_post() in a Zephyr build since components/esp_event is not compiled
+ * here. Pulling in a subsystem that expects the real event loop (esp_netif,
+ * coex) would collide with this and need the upstream loop instead.
+ *
+ * Copy the payload, which is only valid for this call, and queue it for the
+ * event task.
+ */
+esp_err_t esp_event_post(esp_event_base_t event_base, int32_t event_id, const void *event_data,
+			 size_t event_data_size, uint32_t ticks_to_wait)
+{
+	struct esp32_wifi_event evt = {
+		.base = event_base,
+		.id = event_id,
+		.data_size = 0,
+	};
+	k_timeout_t timeout = K_NO_WAIT;
+
+	/*
+	 * Honor the timeout the caller asked for: the libraries post either
+	 * without waiting or, for the few events they must not lose, waiting
+	 * indefinitely. The event task drains this queue, so a post from that
+	 * task never waits, otherwise it would block on itself.
+	 */
+	if (ticks_to_wait != 0 && k_current_get() != esp32_wifi_event_tid) {
+		timeout = (ticks_to_wait == UINT32_MAX) ? K_FOREVER : K_TICKS(ticks_to_wait);
+	}
+
+	if (event_data != NULL && event_data_size > 0) {
+		/*
+		 * Reject rather than deliver a payload-less copy: a handler
+		 * registered for an event that always carries data would
+		 * otherwise be invoked with event_data == NULL. Every event the
+		 * driver and the mesh stack consume fits well inside the buffer
+		 * (the largest is 48 bytes), so this only rejects events nothing
+		 * here handles, such as the WPS enrollee credentials or a DPP
+		 * configuration object, which are far too large to copy inline.
+		 */
+		if (event_data_size > sizeof(evt.data)) {
+			LOG_ERR("event %d payload %zu exceeds %zu, event dropped", event_id,
+				event_data_size, sizeof(evt.data));
+			return ESP_FAIL;
+		}
+
+		memcpy(evt.data, event_data, event_data_size);
+		evt.data_size = event_data_size;
+	}
+
+	/*
+	 * A caller that did not ask to wait has its event dropped when the queue
+	 * is full, which is what the events able to fill it suit: softAP client
+	 * churn and mesh routing updates, superseded by the next event or a
+	 * re-parent. Losing a station or softAP transition leaves the driver
+	 * state stale until the next one, so the depth is sized well above such
+	 * a burst; see CONFIG_ESP32_WIFI_EVENT_QUEUE_SIZE.
+	 */
+	if (k_msgq_put(&esp32_wifi_event_msgq, &evt, timeout) != 0) {
+		LOG_ERR("event queue full, event %d dropped (state may desync)", event_id);
+		return ESP_FAIL;
+	}
+
+	return ESP_OK;
 }
 
 static int esp32_wifi_disconnect(const struct device *dev __unused, struct net_if *iface __unused)
@@ -909,9 +1054,8 @@ static void esp32_wifi_set_channel(struct esp32_wifi_runtime *data,
 	}
 }
 
-static int esp32_wifi_connect(const struct device *dev __unused,
-			    struct net_if *iface,
-			    struct wifi_connect_req_params *params)
+static int esp32_wifi_connect(const struct device *dev __unused, struct net_if *iface,
+			      struct wifi_connect_req_params *params)
 {
 	struct esp32_wifi_runtime *data = esp32_wifi_data_get(iface);
 	wifi_mode_t mode;
@@ -940,6 +1084,8 @@ static int esp32_wifi_connect(const struct device *dev __unused,
 		return -EAGAIN;
 	}
 
+	k_sem_reset(&esp32_sta_started_sem);
+
 	ret = esp32_wifi_start();
 	if (ret) {
 		LOG_ERR("Failed to start Wi-Fi driver (%d)", ret);
@@ -947,9 +1093,14 @@ static int esp32_wifi_connect(const struct device *dev __unused,
 	}
 
 	if (data->state != ESP32_STA_STARTED) {
-		LOG_ERR("Wi-Fi not in station mode");
-		wifi_mgmt_raise_connect_result_event(iface, WIFI_STATUS_CONN_FAIL);
-		return -EIO;
+		(void)k_sem_take(&esp32_sta_started_sem,
+				 K_MSEC(CONFIG_ESP32_WIFI_STA_START_TIMEOUT));
+
+		if (data->state != ESP32_STA_STARTED) {
+			LOG_ERR("Wi-Fi not in station mode");
+			wifi_mgmt_raise_connect_result_event(iface, WIFI_STATUS_CONN_FAIL);
+			return -EIO;
+		}
 	}
 
 	data->state = ESP32_STA_CONNECTING;

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -34,6 +34,10 @@ LOG_MODULE_REGISTER(esp32_wifi, CONFIG_WIFI_LOG_LEVEL);
 #include <esp_mac.h>
 #include "wifi/wifi_event.h"
 
+#if defined(CONFIG_WIFI_ESP32_MESH)
+#include "esp_wifi_mesh_priv.h"
+#endif
+
 #if CONFIG_SOC_SERIES_ESP32S2 || CONFIG_SOC_SERIES_ESP32C3
 #include <esp_private/adc_share_hw_ctrl.h>
 #endif /* CONFIG_SOC_SERIES_ESP32S2 || CONFIG_SOC_SERIES_ESP32C3 */
@@ -199,6 +203,20 @@ static int esp32_wifi_send(const struct device *dev __unused, struct net_pkt *pk
 	int ret;
 	int err;
 
+#if defined(CONFIG_WIFI_ESP32_MESH)
+	/*
+	 * With mesh active this shared interface is the root uplink to the
+	 * router. Mesh traffic goes through the mesh transport, so send frames
+	 * from here out the station regardless of the softAP state. The mesh
+	 * stack owns the link state, so the driver's own station/softAP
+	 * bookkeeping is not updated and must not gate the transmit.
+	 */
+	if (esp_wifi_mesh_is_active()) {
+		ifx = ESP_IF_WIFI_STA;
+		sta_connected = true;
+	}
+#endif
+
 	if (!sta_connected && !ap_running) {
 		return -EIO;
 	}
@@ -290,6 +308,19 @@ pkt_unref:
 
 	return -EIO;
 }
+
+#if defined(CONFIG_WIFI_ESP32_MESH)
+void esp_wifi_mesh_bind_sta_rx(void)
+{
+	/*
+	 * The mesh stack installs its own station receive callback for mesh
+	 * frames. On the root, the station also carries the uplink to the
+	 * router, so restore the driver callback to deliver those frames to the
+	 * station network interface.
+	 */
+	esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, eth_esp32_rx);
+}
+#endif
 
 #if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
 static esp_err_t wifi_esp32_ap_iface_rx(void *buffer, uint16_t len, void *eb)
@@ -441,6 +472,13 @@ static void esp_wifi_handle_sta_disconnect_event(void *event_data)
 	wifi_event_sta_disconnected_t *event = (wifi_event_sta_disconnected_t *)event_data;
 	struct wifi_status result;
 
+#if defined(CONFIG_WIFI_ESP32_MESH)
+	/* The mesh stack owns the station link and reconnects on its own. */
+	if (esp_wifi_mesh_is_active()) {
+		return;
+	}
+#endif
+
 	if (esp32_data.state == ESP32_STA_CONNECTED) {
 		net_if_dormant_on(esp32_wifi_iface);
 #if defined(CONFIG_WIFI_STA_AUTO_DHCPV4)
@@ -539,6 +577,11 @@ static void esp_wifi_handle_ap_connect_event(void *event_data)
 
 	wifi_mgmt_raise_ap_sta_connected_event(iface, &sta_info);
 
+#if defined(CONFIG_WIFI_ESP32_MESH)
+	if (esp_wifi_mesh_is_active()) {
+		return;
+	}
+#endif
 	if (esp32_data.ap_connection_cnt++ == 0) {
 		esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_AP, esp32_rx);
 	}
@@ -562,6 +605,11 @@ static void esp_wifi_handle_ap_disconnect_event(void *event_data)
 	memcpy(sta_info.mac, event->mac, WIFI_MAC_ADDR_LEN);
 	wifi_mgmt_raise_ap_sta_disconnected_event(iface, &sta_info);
 
+#if defined(CONFIG_WIFI_ESP32_MESH)
+	if (esp_wifi_mesh_is_active()) {
+		return;
+	}
+#endif
 	if (--esp32_data.ap_connection_cnt == 0) {
 		esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_AP, NULL);
 	}
@@ -893,6 +941,11 @@ void esp_wifi_event_handler(const char *event_base, int32_t event_id, void *even
 		break;
 	case WIFI_EVENT_STA_STOP:
 		esp32_data.state = ESP32_STA_STOPPED;
+#if defined(CONFIG_WIFI_ESP32_MESH)
+		if (esp_wifi_mesh_is_active()) {
+			break;
+		}
+#endif
 		net_if_dormant_on(esp32_wifi_iface);
 		break;
 	case WIFI_EVENT_STA_CONNECTED:
@@ -906,20 +959,40 @@ void esp_wifi_event_handler(const char *event_base, int32_t event_id, void *even
 		break;
 	case WIFI_EVENT_AP_START:
 		ap_data->state = ESP32_AP_STARTED;
+#if defined(CONFIG_WIFI_ESP32_MESH)
+		if (esp_wifi_mesh_is_active()) {
+			break;
+		}
+#endif
 		net_if_dormant_off(iface_ap);
 		wifi_mgmt_raise_ap_enable_result_event(iface_ap, WIFI_STATUS_AP_SUCCESS);
 		break;
 	case WIFI_EVENT_AP_STOP:
 		ap_data->state = ESP32_AP_STOPPED;
+#if defined(CONFIG_WIFI_ESP32_MESH)
+		if (esp_wifi_mesh_is_active()) {
+			break;
+		}
+#endif
 		net_if_dormant_on(iface_ap);
 		wifi_mgmt_raise_ap_disable_result_event(iface_ap, WIFI_STATUS_AP_SUCCESS);
 		break;
 	case WIFI_EVENT_AP_STACONNECTED:
 		ap_data->state = ESP32_AP_CONNECTED;
+#if defined(CONFIG_WIFI_ESP32_MESH)
+		if (esp_wifi_mesh_is_active()) {
+			break;
+		}
+#endif
 		esp_wifi_handle_ap_connect_event(event_data);
 		break;
 	case WIFI_EVENT_AP_STADISCONNECTED:
 		ap_data->state = ESP32_AP_DISCONNECTED;
+#if defined(CONFIG_WIFI_ESP32_MESH)
+		if (esp_wifi_mesh_is_active()) {
+			break;
+		}
+#endif
 		esp_wifi_handle_ap_disconnect_event(event_data);
 		break;
 	default:
@@ -946,6 +1019,9 @@ static void esp32_wifi_event_task(void *p1, void *p2, void *p3)
 		esp_wifi_event_handler(evt.base, evt.id, evt.data_size ? evt.data : NULL,
 				       evt.data_size, 0);
 
+#if defined(CONFIG_WIFI_ESP32_MESH)
+		esp_wifi_mesh_dispatch_event(evt.base, evt.id, evt.data_size ? evt.data : NULL);
+#endif
 	}
 }
 
@@ -1020,6 +1096,14 @@ esp_err_t esp_event_post(esp_event_base_t event_base, int32_t event_id, const vo
 
 static int esp32_wifi_disconnect(const struct device *dev __unused, struct net_if *iface __unused)
 {
+#if defined(CONFIG_WIFI_ESP32_MESH)
+	/* The mesh stack owns the station link while it runs. */
+	if (esp_wifi_mesh_is_active()) {
+		LOG_WRN("disconnect rejected: mesh owns the Wi-Fi interface");
+		return -EBUSY;
+	}
+#endif
+
 	int ret = esp_wifi_disconnect();
 
 	if (ret != ESP_OK) {
@@ -1060,6 +1144,15 @@ static int esp32_wifi_connect(const struct device *dev __unused, struct net_if *
 	struct esp32_wifi_runtime *data = esp32_wifi_data_get(iface);
 	wifi_mode_t mode;
 	int ret;
+
+#if defined(CONFIG_WIFI_ESP32_MESH)
+	/* The mesh stack owns the station link while it runs. */
+	if (esp_wifi_mesh_is_active()) {
+		LOG_WRN("connect rejected: mesh owns the Wi-Fi interface");
+		wifi_mgmt_raise_connect_result_event(iface, WIFI_STATUS_CONN_FAIL);
+		return -EBUSY;
+	}
+#endif
 
 	if (data->state == ESP32_STA_CONNECTING || data->state == ESP32_STA_CONNECTED) {
 		wifi_mgmt_raise_connect_result_event(iface, WIFI_STATUS_CONN_FAIL);
@@ -1239,6 +1332,14 @@ static int esp32_wifi_scan(const struct device *dev __unused,
 	struct esp32_wifi_runtime *data = esp32_wifi_data_get(iface);
 	int ret = 0;
 
+#if defined(CONFIG_WIFI_ESP32_MESH)
+	/* The mesh stack scans on its own while it runs. */
+	if (esp_wifi_mesh_is_active()) {
+		LOG_WRN("scan rejected: mesh owns the Wi-Fi interface");
+		return -EBUSY;
+	}
+#endif
+
 	if (data->scan_cb != NULL) {
 		LOG_INF("Scan callback in progress");
 		return -EINPROGRESS;
@@ -1294,6 +1395,14 @@ static int esp32_wifi_ap_enable(const struct device *dev __unused, struct net_if
 {
 	struct esp32_wifi_runtime *data = esp32_wifi_data_get(iface);
 	esp_err_t err = 0;
+
+#if defined(CONFIG_WIFI_ESP32_MESH)
+	/* The mesh stack owns the softAP interface while it runs. */
+	if (esp_wifi_mesh_is_active()) {
+		LOG_WRN("ap_enable rejected: mesh owns the Wi-Fi interface");
+		return -EBUSY;
+	}
+#endif
 
 	/* Build Wi-Fi configuration for AP mode */
 	wifi_config_t wifi_config = {
@@ -1422,6 +1531,14 @@ static int esp32_wifi_ap_disable(const struct device *dev __unused, struct net_i
 {
 	int err = 0;
 	wifi_mode_t mode;
+
+#if defined(CONFIG_WIFI_ESP32_MESH)
+	/* The mesh stack owns the softAP interface while it runs. */
+	if (esp_wifi_mesh_is_active()) {
+		LOG_WRN("ap_disable rejected: mesh owns the Wi-Fi interface");
+		return -EBUSY;
+	}
+#endif
 
 	esp_wifi_get_mode(&mode);
 	if (mode == ESP32_WIFI_MODE_APSTA) {

--- a/drivers/wifi/esp32/src/esp_wifi_mesh.c
+++ b/drivers/wifi/esp32/src/esp_wifi_mesh.c
@@ -1,0 +1,586 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Wi-Fi mesh support: mesh bring-up, the application event API, and the
+ * esp_event handler registry the vendor mesh stack posts through.
+ *
+ * The mesh stack registers handlers on WIFI_EVENT and posts MESH_EVENT, and
+ * this file registers an internal MESH_EVENT handler that translates the
+ * vendor events into the Zephyr-native esp_wifi_mesh_event callback. Every
+ * posted event flows through esp_event_post(), which dispatches it to the
+ * handlers kept in this registry in addition to the core Wi-Fi driver handler.
+ *
+ * esp_event_handler_register()/esp_event_handler_unregister() are the event-API
+ * entry points the mesh blob links against (it holds undefined references to
+ * them). They are implemented here as a minimal Zephyr-side registry; the
+ * matching esp_event_post() lives in the core Wi-Fi driver, which owns the
+ * event task.
+ */
+
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h>
+
+#include "esp_event.h"
+#include "esp_wifi.h"
+#include "esp_mesh.h"
+#include "esp_mesh_internal.h"
+
+#include "esp_wifi_mesh_priv.h"
+
+LOG_MODULE_REGISTER(esp_wifi_mesh, CONFIG_WIFI_LOG_LEVEL);
+
+/* The mesh softAP uses WPA2-PSK, which requires an 8..63 character password. */
+BUILD_ASSERT(sizeof(CONFIG_WIFI_ESP32_MESH_AP_PSK) - 1 >= 8 &&
+		     sizeof(CONFIG_WIFI_ESP32_MESH_AP_PSK) - 1 <= 63,
+	     "CONFIG_WIFI_ESP32_MESH_AP_PSK must be 8 to 63 characters");
+
+/*
+ * When the mesh stack is active it drives the station and softAP directly.
+ * Its softAP start/stop and association events would otherwise take the
+ * station interface administratively down, so those transitions are skipped
+ * while the mesh runs and the station interface is kept up.
+ *
+ * Written from the mesh event context and read from the Wi-Fi TX and event
+ * paths, so accessed through the atomic API.
+ */
+static atomic_t mesh_active;
+
+/*
+ * Given by the MESH_EVENT_STARTED handler once the mesh stack has brought its
+ * internal tasks up. esp_wifi_mesh_start() waits on it before re-delivering the
+ * initial station-start event, so the sequencing follows the actual readiness
+ * signal instead of a fixed delay.
+ */
+static K_SEM_DEFINE(mesh_started_sem, 0, 1);
+
+static void esp_wifi_mesh_set_active(bool active)
+{
+	atomic_set(&mesh_active, active ? 1 : 0);
+}
+
+bool esp_wifi_mesh_is_active(void)
+{
+	return atomic_get(&mesh_active) != 0;
+}
+
+#define MESH_EVENT_MAX_HANDLERS CONFIG_WIFI_ESP32_MESH_EVENT_HANDLERS
+
+struct event_handler_entry {
+	esp_event_base_t base;
+	int32_t id;
+	esp_event_handler_t handler;
+	void *arg;
+	bool used;
+};
+
+static struct event_handler_entry event_handlers[MESH_EVENT_MAX_HANDLERS];
+static struct k_spinlock event_lock;
+
+/*
+ * Serializes the vendor routing-table reads. The read fills a shared static
+ * buffer here and is invoked from the mesh send path, the routing-table query,
+ * and the IP-over-mesh downlink broadcast, which can run from different threads
+ * at once, so the lock and the buffer stay behind this one accessor.
+ */
+static K_MUTEX_DEFINE(route_lock);
+
+/* Serializes concurrent root senders so they do not overwrite the shared
+ * routing-table snapshot buffer in esp_wifi_mesh_send() mid-loop.
+ */
+static K_MUTEX_DEFINE(send_lock);
+
+void esp_wifi_mesh_read_routing_table(mesh_addr_t *buf, size_t buf_size, int *count)
+{
+	int table_size = 0;
+
+	k_mutex_lock(&route_lock, K_FOREVER);
+	esp_mesh_get_routing_table(buf, (int)buf_size, &table_size);
+	k_mutex_unlock(&route_lock);
+
+	*count = table_size;
+}
+
+esp_err_t esp_event_handler_register(esp_event_base_t event_base, int32_t event_id,
+				     esp_event_handler_t event_handler, void *event_handler_arg)
+{
+	k_spinlock_key_t key = k_spin_lock(&event_lock);
+
+	for (int i = 0; i < MESH_EVENT_MAX_HANDLERS; i++) {
+		if (!event_handlers[i].used) {
+			event_handlers[i].base = event_base;
+			event_handlers[i].id = event_id;
+			event_handlers[i].handler = event_handler;
+			event_handlers[i].arg = event_handler_arg;
+			event_handlers[i].used = true;
+			k_spin_unlock(&event_lock, key);
+			return ESP_OK;
+		}
+	}
+
+	k_spin_unlock(&event_lock, key);
+	LOG_WRN("event handler registry full (%d), handler dropped", MESH_EVENT_MAX_HANDLERS);
+	return ESP_ERR_NO_MEM;
+}
+
+esp_err_t esp_event_handler_unregister(esp_event_base_t event_base, int32_t event_id,
+				       esp_event_handler_t event_handler)
+{
+	esp_err_t ret = ESP_ERR_NOT_FOUND;
+	k_spinlock_key_t key = k_spin_lock(&event_lock);
+
+	for (int i = 0; i < MESH_EVENT_MAX_HANDLERS; i++) {
+		if (event_handlers[i].used && event_handlers[i].handler == event_handler &&
+		    event_handlers[i].base == event_base && event_handlers[i].id == event_id) {
+			event_handlers[i].used = false;
+			ret = ESP_OK;
+			break;
+		}
+	}
+
+	k_spin_unlock(&event_lock, key);
+	return ret;
+}
+
+void esp_wifi_mesh_dispatch_event(esp_event_base_t event_base, int32_t event_id, void *event_data)
+{
+	esp_event_handler_t matched[MESH_EVENT_MAX_HANDLERS];
+	void *matched_arg[MESH_EVENT_MAX_HANDLERS];
+	int matched_count = 0;
+
+	/*
+	 * Snapshot the matching handlers under the lock, then invoke them with
+	 * the lock released. A handler may block, so it must not run while the
+	 * spinlock is held, and the snapshot avoids racing a concurrent
+	 * register/unregister.
+	 */
+	k_spinlock_key_t key = k_spin_lock(&event_lock);
+
+	for (int i = 0; i < MESH_EVENT_MAX_HANDLERS; i++) {
+		struct event_handler_entry *e = &event_handlers[i];
+
+		if (!e->used) {
+			continue;
+		}
+		if (e->base != ESP_EVENT_ANY_BASE && e->base != event_base) {
+			continue;
+		}
+		if (e->id != ESP_EVENT_ANY_ID && e->id != event_id) {
+			continue;
+		}
+		matched[matched_count] = e->handler;
+		matched_arg[matched_count] = e->arg;
+		matched_count++;
+	}
+
+	k_spin_unlock(&event_lock, key);
+
+	for (int i = 0; i < matched_count; i++) {
+		matched[i](matched_arg[i], event_base, event_id, event_data);
+	}
+}
+
+/*
+ * Parse the 6-byte mesh id from its "xx:xx:xx:xx:xx:xx" Kconfig string into
+ * out. On a malformed value fall back to a fixed default so the mesh still
+ * comes up rather than joining an unintended network.
+ */
+static void mesh_id_parse(uint8_t out[6])
+{
+	static const uint8_t fallback[6] = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc};
+	const char *p = CONFIG_WIFI_ESP32_MESH_ID;
+	uint8_t id[6];
+
+	for (int i = 0; i < 6; i++) {
+		uint8_t hi, lo;
+
+		if (char2hex(p[0], &hi) != 0 || char2hex(p[1], &lo) != 0) {
+			goto invalid;
+		}
+		id[i] = (hi << 4) | lo;
+		p += 2;
+
+		if (i < 5) {
+			if (*p != ':') {
+				goto invalid;
+			}
+			p++;
+		}
+	}
+
+	if (*p != '\0') {
+		goto invalid;
+	}
+
+	memcpy(out, id, sizeof(id));
+	return;
+
+invalid:
+	LOG_WRN("invalid mesh id '%s', using default", CONFIG_WIFI_ESP32_MESH_ID);
+	memcpy(out, fallback, sizeof(fallback));
+}
+
+static esp_wifi_mesh_event_cb_t app_event_cb;
+
+void esp_wifi_mesh_event_cb_register(esp_wifi_mesh_event_cb_t cb)
+{
+	app_event_cb = cb;
+}
+
+static bool tods_reachable;
+
+void esp_wifi_mesh_set_tods_reachable(bool reachable)
+{
+	tods_reachable = reachable;
+	esp_mesh_post_toDS_state(reachable ? MESH_TODS_REACHABLE : MESH_TODS_UNREACHABLE);
+}
+
+void esp_wifi_mesh_get_status(struct esp_wifi_mesh_status *status)
+{
+	if (status == NULL) {
+		return;
+	}
+
+	status->layer = esp_mesh_get_layer();
+	status->is_root = esp_mesh_is_root();
+	status->routing_table_size = esp_mesh_get_routing_table_size();
+	status->tods_reachable = tods_reachable;
+}
+
+int esp_wifi_mesh_get_routing_table(struct esp_wifi_mesh_addr *macs, size_t max, size_t *count)
+{
+	static mesh_addr_t
+		route[CONFIG_WIFI_ESP32_MESH_MAX_LAYER * CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS +
+		      1];
+	int table_size = 0;
+
+	if (macs == NULL || count == NULL) {
+		return -EINVAL;
+	}
+
+	esp_wifi_mesh_read_routing_table(route, sizeof(route), &table_size);
+
+	size_t n = MIN((size_t)table_size, max);
+
+	for (size_t i = 0; i < n; i++) {
+		memcpy(macs[i].addr, route[i].addr, sizeof(macs[i].addr));
+	}
+
+	*count = n;
+	return 0;
+}
+
+static void notify_app(enum esp_wifi_mesh_event event, int reason)
+{
+	if (app_event_cb == NULL) {
+		return;
+	}
+
+	struct esp_wifi_mesh_event_info info = {
+		.layer = esp_mesh_get_layer(),
+		.is_root = esp_mesh_is_root(),
+		.routing_table_size = esp_mesh_get_routing_table_size(),
+		.reason = reason,
+	};
+
+	app_event_cb(event, &info);
+}
+
+/* Translate the vendor mesh events into the Zephyr-native callback. */
+static void mesh_event_handler(void *arg, esp_event_base_t base, int32_t event_id, void *event_data)
+{
+	ARG_UNUSED(arg);
+	ARG_UNUSED(base);
+
+	switch (event_id) {
+	case MESH_EVENT_STARTED:
+		esp_wifi_mesh_set_active(true);
+		k_sem_give(&mesh_started_sem);
+		notify_app(ESP_WIFI_MESH_EVENT_STARTED, 0);
+		break;
+	case MESH_EVENT_STOPPED:
+		notify_app(ESP_WIFI_MESH_EVENT_STOPPED, 0);
+		break;
+	case MESH_EVENT_PARENT_CONNECTED:
+		notify_app(ESP_WIFI_MESH_EVENT_PARENT_CONNECTED, 0);
+		break;
+	case MESH_EVENT_PARENT_DISCONNECTED: {
+		mesh_event_disconnected_t *disc = event_data;
+
+		notify_app(ESP_WIFI_MESH_EVENT_PARENT_DISCONNECTED,
+			   disc != NULL ? disc->reason : 0);
+		break;
+	}
+	case MESH_EVENT_NO_PARENT_FOUND:
+		notify_app(ESP_WIFI_MESH_EVENT_NO_PARENT_FOUND, 0);
+		break;
+	case MESH_EVENT_FIND_NETWORK:
+		notify_app(ESP_WIFI_MESH_EVENT_FIND_NETWORK, 0);
+		break;
+	case MESH_EVENT_CHILD_CONNECTED:
+		notify_app(ESP_WIFI_MESH_EVENT_CHILD_CONNECTED, 0);
+		break;
+	case MESH_EVENT_CHILD_DISCONNECTED:
+		notify_app(ESP_WIFI_MESH_EVENT_CHILD_DISCONNECTED, 0);
+		break;
+	case MESH_EVENT_ROUTING_TABLE_ADD:
+	case MESH_EVENT_ROUTING_TABLE_REMOVE:
+		notify_app(ESP_WIFI_MESH_EVENT_ROUTING_TABLE_CHANGE, 0);
+		break;
+	case MESH_EVENT_TODS_STATE: {
+		mesh_event_toDS_state_t *state = event_data;
+
+		if (state == NULL) {
+			break;
+		}
+
+		notify_app((*state == MESH_TODS_REACHABLE) ? ESP_WIFI_MESH_EVENT_TODS_REACHABLE
+							   : ESP_WIFI_MESH_EVENT_TODS_UNREACHABLE,
+			   0);
+		break;
+	}
+	default:
+		LOG_DBG("mesh event %d", event_id);
+		break;
+	}
+}
+
+int esp_wifi_mesh_start(void)
+{
+	mesh_cfg_t cfg = MESH_INIT_CONFIG_DEFAULT();
+
+	/*
+	 * Self-organized election is driven by router reachability, so the auto
+	 * role needs a router. A fixed root or fixed child does not run an
+	 * election and can form a router-less mesh, so the router is optional.
+	 */
+	if (IS_ENABLED(CONFIG_WIFI_ESP32_MESH_ROLE_AUTO) &&
+	    strlen(CONFIG_WIFI_ESP32_MESH_ROUTER_SSID) == 0) {
+		LOG_ERR("router SSID must be set (CONFIG_WIFI_ESP32_MESH_ROUTER_SSID)");
+		return -EINVAL;
+	}
+
+	/* The Wi-Fi driver has already run esp_wifi_init()/esp_wifi_start(). */
+	esp_wifi_set_mode(ESP32_WIFI_MODE_APSTA);
+
+	if (esp_mesh_init() != ESP_OK) {
+		LOG_ERR("esp_mesh_init failed");
+		return -EIO;
+	}
+
+	if (esp_event_handler_register(MESH_EVENT, ESP_EVENT_ANY_ID, mesh_event_handler, NULL) !=
+	    ESP_OK) {
+		LOG_ERR("mesh event register failed");
+		return -EIO;
+	}
+
+	esp_mesh_set_topology(MESH_TOPO_TREE);
+	esp_mesh_set_max_layer(CONFIG_WIFI_ESP32_MESH_MAX_LAYER);
+	esp_mesh_set_vote_percentage((float)CONFIG_WIFI_ESP32_MESH_VOTE_PERCENTAGE / 100.0f);
+	esp_mesh_set_xon_qsize(CONFIG_WIFI_ESP32_MESH_XON_QSIZE);
+
+	/* Mesh manages the radio power state; keep power save disabled. */
+	esp_mesh_disable_ps();
+
+	esp_mesh_set_ap_assoc_expire(CONFIG_WIFI_ESP32_MESH_ASSOC_EXPIRE);
+
+	cfg.channel = CONFIG_WIFI_ESP32_MESH_CHANNEL;
+	if (cfg.channel == 0) {
+		/* Scan all channels to locate the router. */
+		cfg.allow_channel_switch = true;
+	}
+	uint8_t mesh_id[6];
+
+	mesh_id_parse(mesh_id);
+	memcpy((uint8_t *)&cfg.mesh_id, mesh_id, sizeof(mesh_id));
+
+	/*
+	 * Router credentials: only the elected or fixed root associates to the
+	 * router. esp_mesh_set_config rejects the configuration if the router
+	 * SSID is empty, so a router-less fixed-root mesh supplies a placeholder
+	 * SSID the fixed root never actually associates to; its children attach
+	 * to the root's softAP and the mesh forms with no router involved.
+	 */
+	const char *router_ssid = CONFIG_WIFI_ESP32_MESH_ROUTER_SSID;
+	const char *router_psk = CONFIG_WIFI_ESP32_MESH_ROUTER_PSK;
+
+	if (strlen(router_ssid) == 0) {
+		router_ssid = "esp-mesh-no-router";
+		router_psk = "";
+	}
+
+	cfg.router.ssid_len = MIN(strlen(router_ssid), sizeof(cfg.router.ssid));
+	memcpy(cfg.router.ssid, router_ssid, cfg.router.ssid_len);
+	memcpy(cfg.router.password, router_psk,
+	       MIN(strlen(router_psk), sizeof(cfg.router.password) - 1));
+
+	esp_mesh_set_ap_authmode(WIFI_AUTH_WPA2_PSK);
+	cfg.mesh_ap.max_connection = CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS;
+	memcpy(cfg.mesh_ap.password, CONFIG_WIFI_ESP32_MESH_AP_PSK,
+	       MIN(strlen(CONFIG_WIFI_ESP32_MESH_AP_PSK), sizeof(cfg.mesh_ap.password) - 1));
+
+	esp_err_t cfg_ret = esp_mesh_set_config(&cfg);
+
+	if (cfg_ret != ESP_OK) {
+		LOG_ERR("esp_mesh_set_config failed (0x%x)", cfg_ret);
+		return -EIO;
+	}
+
+	/*
+	 * Fixed-root network: election is disabled and the root is designated,
+	 * not voted for. Every node must share the fixed-root setting; only the
+	 * designated node sets its type to root.
+	 */
+#if defined(CONFIG_WIFI_ESP32_MESH_FORCE_ROOT)
+	esp_mesh_fix_root(true);
+	esp_mesh_set_type(MESH_ROOT);
+	LOG_INF("mesh fixed root");
+#elif defined(CONFIG_WIFI_ESP32_MESH_FORCE_CHILD)
+	esp_mesh_fix_root(true);
+#endif
+
+	k_sem_reset(&mesh_started_sem);
+
+	if (esp_mesh_start() != ESP_OK) {
+		LOG_ERR("esp_mesh_start failed");
+		return -EIO;
+	}
+
+	/*
+	 * Mark the mesh active synchronously so the station/softAP event guards
+	 * take effect immediately. MESH_EVENT_STARTED confirms it later on the
+	 * event task, but that leaves a window where bring-up events would take
+	 * the shared station interface down before the flag is set.
+	 */
+	esp_wifi_mesh_set_active(true);
+
+#if defined(CONFIG_WIFI_ESP32_MESH_FORCE_ROOT)
+	/*
+	 * Without a router there is no parent for the fixed root to find, so the
+	 * self-organized search only keeps scanning and disrupts its softAP,
+	 * which stops children from attaching. With a router configured it must
+	 * stay enabled: self-organized networking also drives the association to
+	 * the router and the reconnection that maintains the root uplink.
+	 */
+	if (strlen(CONFIG_WIFI_ESP32_MESH_ROUTER_SSID) == 0) {
+		esp_mesh_set_self_organized(false, false);
+	}
+#endif
+
+	/* Let mesh sends block under congestion instead of failing fast. */
+	esp_mesh_send_block_time(CONFIG_WIFI_ESP32_MESH_SEND_BLOCK_TIME_MS);
+
+	/*
+	 * The Wi-Fi station is already started by the driver before the mesh
+	 * stack registers its event handlers, so the mesh misses the initial
+	 * WIFI_EVENT_STA_START that would kick off parent scanning. Wait for the
+	 * mesh stack to report MESH_EVENT_STARTED (its internal tasks are then
+	 * up), then re-deliver the event so the mesh begins its self-organizing
+	 * sequence. Waiting on the readiness event makes the sequencing
+	 * deterministic instead of depending on a fixed delay.
+	 */
+	if (k_sem_take(&mesh_started_sem, K_MSEC(CONFIG_WIFI_ESP32_MESH_START_TIMEOUT)) != 0) {
+		LOG_WRN("mesh start not confirmed in %d ms, proceeding anyway",
+			CONFIG_WIFI_ESP32_MESH_START_TIMEOUT);
+	}
+
+	esp_wifi_mesh_dispatch_event(WIFI_EVENT, WIFI_EVENT_STA_START, NULL);
+
+	return 0;
+}
+
+#if !defined(CONFIG_WIFI_ESP32_MESH_IP)
+/*
+ * Raw application messaging path. It reads the mesh receive queue directly with
+ * esp_wifi_mesh_recv(). The IP-over-mesh interface (esp_wifi_mesh_netif.c) reads
+ * the same single queue from its own task, and esp_mesh_recv() does not demux by
+ * destination, so with both active a frame goes to whichever reader pops it
+ * first. The two paths are therefore kept mutually exclusive at build time.
+ *
+ * TODO: fold both readers into one receive task that demultiplexes on the frame
+ * protocol tag (MESH_PROTO_BIN for this raw path, MESH_PROTO_STA/_AP for IP) and
+ * routes each frame to the right consumer, which would let BIN and IP share the
+ * mesh instead of being mutually exclusive.
+ */
+int esp_wifi_mesh_send(const uint8_t *data, size_t len)
+{
+	mesh_data_t msg = {
+		.data = (uint8_t *)data,
+		.size = len,
+		.proto = MESH_PROTO_BIN,
+		.tos = MESH_TOS_P2P,
+	};
+
+	if (esp_mesh_is_root()) {
+		/* The root routing table spans the whole sub-network. */
+		static mesh_addr_t route[CONFIG_WIFI_ESP32_MESH_MAX_LAYER *
+						 CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS +
+					 1];
+		int table_size = 0;
+		int ret = 0;
+
+		/*
+		 * Snapshot the whole routing table once (the accessor takes the
+		 * routing-table lock), then send with that lock released, since
+		 * esp_mesh_send() can block for up to the configured send block
+		 * time. send_lock serializes concurrent senders so the shared
+		 * snapshot buffer is not overwritten mid-loop.
+		 */
+		k_mutex_lock(&send_lock, K_FOREVER);
+		esp_wifi_mesh_read_routing_table(route, sizeof(route), &table_size);
+		table_size = CLAMP(table_size, 0, (int)ARRAY_SIZE(route));
+
+		for (int i = 0; i < table_size; i++) {
+			if (esp_mesh_send(&route[i], &msg, MESH_DATA_P2P, NULL, 0) != ESP_OK) {
+				ret = -EIO;
+			}
+		}
+		k_mutex_unlock(&send_lock);
+		return ret;
+	}
+
+	/* Non-root: to == NULL routes the packet up to the root. */
+	if (esp_mesh_send(NULL, &msg, MESH_DATA_P2P, NULL, 0) != ESP_OK) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+int esp_wifi_mesh_recv(uint8_t *data, size_t *len, int timeout_ms)
+{
+	static uint8_t rx_bounce[MESH_MPS];
+	mesh_addr_t from;
+	mesh_data_t msg = {
+		.data = rx_bounce,
+		.size = sizeof(rx_bounce),
+	};
+	int flag = 0;
+	size_t cap;
+
+	if (data == NULL || len == NULL) {
+		return -EINVAL;
+	}
+	cap = *len;
+
+	/*
+	 * The vendor receive writes the whole frame into the buffer and only
+	 * then reports its length, so it must be given a buffer sized for the
+	 * largest possible payload. Receive into a full-size bounce buffer and
+	 * copy back no more than the caller's capacity to avoid overflowing a
+	 * smaller caller buffer.
+	 */
+	if (esp_mesh_recv(&from, &msg, timeout_ms, &flag, NULL, 0) != ESP_OK) {
+		return -EAGAIN;
+	}
+
+	*len = MIN((size_t)msg.size, cap);
+	memcpy(data, rx_bounce, *len);
+	return 0;
+}
+#endif /* !CONFIG_WIFI_ESP32_MESH_IP */

--- a/drivers/wifi/esp32/src/esp_wifi_mesh_netif.c
+++ b/drivers/wifi/esp32/src/esp_wifi_mesh_netif.c
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Ethernet-over-mesh network interface for the Wi-Fi mesh transport. It carries
+ * Ethernet frames as the mesh payload so the Zephyr network stack (IP, DHCP,
+ * NAT, sockets) runs unmodified on top of the mesh.
+ *
+ *   TX:  net_if send  ->  read Ethernet frame from net_pkt  ->  esp_mesh_send
+ *   RX:  esp_mesh_recv ->  wrap frame in net_pkt            ->  net_recv_data
+ *
+ * Root node:    frames from children arrive toDS and are handed to the IP
+ *               stack, which NATs/forwards them out the station interface.
+ * Non-root:     frames from the IP stack are sent toDS to the root; frames
+ *               from the root arrive and are handed up.
+ *
+ * The interface is a plain Ethernet net_if; all IP-level policy (addresses,
+ * DHCP, NAT, routes) is left to the application.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_pkt.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h>
+
+#include "esp_mesh.h"
+#include "esp_wifi.h"
+#include "esp_wifi_mesh_priv.h"
+
+LOG_MODULE_REGISTER(esp_wifi_mesh_netif, CONFIG_WIFI_LOG_LEVEL);
+
+/*
+ * The mesh transport caps the payload at MESH_MPS bytes, and each IP packet is
+ * carried as an Ethernet frame (payload plus the Ethernet header). Cap the
+ * interface MTU so a full-size packet still fits the mesh payload rather than
+ * being dropped by the transport.
+ */
+#define MESH_NETIF_MTU           (MESH_MPS - sizeof(struct net_eth_hdr))
+#define MESH_NETIF_RX_STACK      4096
+#define MESH_NETIF_RX_TIMEOUT_MS 1000
+#define MESH_ETH_FRAME_MAX       (MESH_NETIF_MTU + sizeof(struct net_eth_hdr))
+
+struct mesh_netif_data {
+	struct net_if *iface;
+	uint8_t mac[6];
+};
+
+static struct mesh_netif_data mesh_netif;
+static uint8_t rx_frame[MESH_ETH_FRAME_MAX];
+
+/*
+ * Outbound frames are queued and sent from a dedicated thread. esp_mesh_send()
+ * is not reentrant and blocks until delivery, and the root forwards frames from
+ * within the mesh receive path (the network stack forwards a masqueraded reply
+ * straight to this interface). Sending inline there would call the mesh stack
+ * reentrantly from its own task and corrupt it, so a queue decouples the two.
+ */
+struct mesh_tx_msg {
+	uint16_t len;
+	uint8_t frame[MESH_ETH_FRAME_MAX];
+};
+
+K_MSGQ_DEFINE(esp_wifi_mesh_tx_msgq, sizeof(struct mesh_tx_msg), 8, 4);
+
+static void mesh_tx_frame(struct mesh_tx_msg *msg)
+{
+	mesh_data_t data = {
+		.data = msg->frame,
+		.size = msg->len,
+		/*
+		 * The protocol tags the direction: a frame from the root softAP
+		 * down to a node carries MESH_PROTO_STA, a frame from a node
+		 * station up to the root carries MESH_PROTO_AP. The receiver uses
+		 * it to deliver the frame to the matching interface.
+		 */
+		.proto = esp_mesh_is_root() ? MESH_PROTO_STA : MESH_PROTO_AP,
+		.tos = MESH_TOS_P2P,
+	};
+
+	if (esp_mesh_is_root()) {
+		/*
+		 * The Ethernet destination is the child's mesh address (the
+		 * interface link address is the node's mesh MAC). A broadcast
+		 * frame, such as an ARP request, is sent to every child in the
+		 * routing table.
+		 */
+		static const uint8_t bcast[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+		mesh_addr_t to;
+
+		if (memcmp(msg->frame, bcast, sizeof(bcast)) == 0) {
+			/*
+			 * The root routing table holds the whole sub-network, not
+			 * just direct children, so size for the full tree.
+			 */
+			static mesh_addr_t route[CONFIG_WIFI_ESP32_MESH_MAX_LAYER *
+							 CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS +
+						 1];
+			int n = 0;
+
+			esp_wifi_mesh_read_routing_table(route, sizeof(route), &n);
+
+			for (int i = 0; i < n; i++) {
+				if (memcmp(route[i].addr, mesh_netif.mac, sizeof(mesh_netif.mac)) ==
+				    0) {
+					continue;
+				}
+				if (esp_mesh_send(&route[i], &data, MESH_DATA_P2P, NULL, 0) !=
+				    ESP_OK) {
+					LOG_DBG("mesh downlink send failed");
+				}
+			}
+		} else {
+			memcpy(to.addr, msg->frame, sizeof(to.addr));
+			if (esp_mesh_send(&to, &data, MESH_DATA_P2P, NULL, 0) != ESP_OK) {
+				LOG_DBG("mesh downlink send failed");
+			}
+		}
+	} else {
+		/*
+		 * Non-root: hand the frame up toward the root. The mesh routes a
+		 * toDS frame to the root, which delivers it to its softAP-side
+		 * interface for the network stack to masquerade and forward.
+		 */
+		if (esp_mesh_send(NULL, &data, MESH_DATA_TODS, NULL, 0) != ESP_OK) {
+			LOG_DBG("mesh uplink send failed");
+		}
+	}
+}
+
+static void mesh_tx_thread(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	static struct mesh_tx_msg msg;
+
+	while (1) {
+		if (k_msgq_get(&esp_wifi_mesh_tx_msgq, &msg, K_FOREVER) == 0) {
+			mesh_tx_frame(&msg);
+		}
+	}
+}
+
+K_THREAD_DEFINE(esp_wifi_mesh_tx_id, 4096, mesh_tx_thread, NULL, NULL, NULL, 5, 0, 0);
+
+/*
+ * net_if TX: queue an outbound IP frame for the mesh transmit thread. The frame
+ * is staged in a file-scope buffer rather than on the stack because it is close
+ * to the interface MTU, which would overflow the small network TX thread stack.
+ * The network stack serializes transmit calls per interface, so a single
+ * staging buffer is safe here.
+ */
+static struct mesh_tx_msg mesh_tx_staging;
+
+static int mesh_netif_send(const struct device *dev, struct net_pkt *pkt)
+{
+	ARG_UNUSED(dev);
+
+	size_t len = net_pkt_get_len(pkt);
+
+	if (len < sizeof(struct net_eth_hdr) || len > sizeof(mesh_tx_staging.frame)) {
+		return -EMSGSIZE;
+	}
+	if (net_pkt_read(pkt, mesh_tx_staging.frame, len) < 0) {
+		return -EIO;
+	}
+
+	mesh_tx_staging.len = len;
+	if (k_msgq_put(&esp_wifi_mesh_tx_msgq, &mesh_tx_staging, K_NO_WAIT) != 0) {
+		return -ENOBUFS;
+	}
+
+	/* The Ethernet L2 unrefs the packet after a successful send. */
+	return 0;
+}
+
+/*
+ * Mesh RX: an inbound mesh frame becomes a net_pkt for the IP stack.
+ *
+ * TODO: this task and the raw esp_wifi_mesh_recv() path both read the single
+ * mesh receive queue with no demux, so they are kept mutually exclusive (the
+ * raw path is compiled out when MESH_IP is set). Folding both into one reader
+ * that demultiplexes on the frame protocol tag (MESH_PROTO_STA/_AP here,
+ * MESH_PROTO_BIN for the raw path) would let them coexist.
+ */
+static void mesh_netif_rx_task(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	mesh_addr_t from;
+	int flag = 0;
+
+	while (1) {
+		mesh_data_t data = {
+			.data = rx_frame,
+			.size = sizeof(rx_frame),
+		};
+
+		if (esp_mesh_recv(&from, &data, MESH_NETIF_RX_TIMEOUT_MS, &flag, NULL, 0) !=
+		    ESP_OK) {
+			continue;
+		}
+
+		struct net_pkt *pkt = net_pkt_rx_alloc_with_buffer(mesh_netif.iface, data.size,
+								   NET_AF_UNSPEC, 0, K_MSEC(100));
+
+		if (pkt == NULL) {
+			continue;
+		}
+		if (net_pkt_write(pkt, data.data, data.size) < 0) {
+			net_pkt_unref(pkt);
+			continue;
+		}
+		if (net_recv_data(mesh_netif.iface, pkt) < 0) {
+			net_pkt_unref(pkt);
+		}
+	}
+}
+
+K_THREAD_DEFINE(esp_wifi_mesh_rx_id, MESH_NETIF_RX_STACK, mesh_netif_rx_task, NULL, NULL, NULL, 5,
+		0, 0);
+
+/*
+ * Root toDS drain: once the root announces external reachability, the mesh
+ * queues child packets bound for an external IP in a separate toDS queue.
+ * Drain it and inject the frames into the network stack, which masquerades and
+ * forwards them out the station just like any other received frame.
+ */
+static uint8_t tods_frame[MESH_ETH_FRAME_MAX];
+
+static void mesh_tods_rx_task(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	mesh_addr_t from;
+	mesh_addr_t to;
+	int flag = 0;
+
+	while (1) {
+		mesh_data_t data = {
+			.data = tods_frame,
+			.size = sizeof(tods_frame),
+		};
+
+		if (!esp_mesh_is_root()) {
+			k_sleep(K_MSEC(500));
+			continue;
+		}
+		if (esp_mesh_recv_toDS(&from, &to, &data, MESH_NETIF_RX_TIMEOUT_MS, &flag, NULL,
+				       0) != ESP_OK) {
+			continue;
+		}
+
+		struct net_pkt *pkt = net_pkt_rx_alloc_with_buffer(mesh_netif.iface, data.size,
+								   NET_AF_UNSPEC, 0, K_MSEC(100));
+
+		if (pkt == NULL) {
+			continue;
+		}
+		if (net_pkt_write(pkt, data.data, data.size) < 0) {
+			net_pkt_unref(pkt);
+			continue;
+		}
+		if (net_recv_data(mesh_netif.iface, pkt) < 0) {
+			net_pkt_unref(pkt);
+		}
+	}
+}
+
+K_THREAD_DEFINE(esp_wifi_mesh_tods_id, MESH_NETIF_RX_STACK, mesh_tods_rx_task, NULL, NULL, NULL, 5,
+		0, 0);
+
+static void mesh_netif_iface_init(struct net_if *iface)
+{
+	mesh_netif.iface = iface;
+
+	esp_wifi_get_mac(ESP_IF_WIFI_STA, mesh_netif.mac);
+	net_if_set_link_addr(iface, mesh_netif.mac, sizeof(mesh_netif.mac), NET_LINK_ETHERNET);
+
+	ethernet_init(iface);
+
+	/* The mesh stack provides the link, so present a live carrier. */
+	net_if_carrier_on(iface);
+}
+
+static const struct ethernet_api mesh_netif_api = {
+	.iface_api.init = mesh_netif_iface_init,
+	.send = mesh_netif_send,
+};
+
+/* A standalone Ethernet net_if that the Zephyr IP stack drives. */
+NET_DEVICE_INIT(mesh_netif, "mesh_netif", NULL, NULL, &mesh_netif, NULL, CONFIG_ETH_INIT_PRIORITY,
+		&mesh_netif_api, ETHERNET_L2, NET_L2_GET_CTX_TYPE(ETHERNET_L2), MESH_NETIF_MTU);
+
+struct net_if *esp_wifi_mesh_netif_get(void)
+{
+	return mesh_netif.iface;
+}

--- a/drivers/wifi/esp32/src/esp_wifi_mesh_priv.h
+++ b/drivers/wifi/esp32/src/esp_wifi_mesh_priv.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Private interface between the core Wi-Fi driver and the mesh support code.
+ */
+
+#ifndef ZEPHYR_DRIVERS_WIFI_ESP32_ESP_WIFI_MESH_PRIV_H_
+#define ZEPHYR_DRIVERS_WIFI_ESP32_ESP_WIFI_MESH_PRIV_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/kernel.h>
+
+#include "esp_event.h"
+#include "esp_mesh.h"
+
+/**
+ * @brief Read the vendor mesh routing table under the shared lock.
+ *
+ * The vendor routing-table read is shared by the mesh send path, the
+ * routing-table query, and the IP-over-mesh downlink broadcast, and it fills a
+ * caller-provided buffer, so this serializes those reads behind one lock owned
+ * by the mesh core.
+ *
+ * @param buf      output array receiving the routing-table entries.
+ * @param buf_size size of @p buf in bytes.
+ * @param count    output set to the number of entries written.
+ */
+void esp_wifi_mesh_read_routing_table(mesh_addr_t *buf, size_t buf_size, int *count);
+
+/**
+ * @brief Query whether the mesh stack is currently active.
+ *
+ * The core driver event handlers consult this to skip station/softAP state
+ * transitions the mesh stack owns while it drives the interfaces directly.
+ *
+ * @return true while the mesh stack manages the Wi-Fi interfaces.
+ */
+bool esp_wifi_mesh_is_active(void);
+
+/**
+ * @brief Dispatch a posted event to the mesh event handler registry.
+ *
+ * Called from esp_event_post() after the core driver handler. Delivers the
+ * event to every matching handler the mesh stack and application registered.
+ */
+void esp_wifi_mesh_dispatch_event(esp_event_base_t event_base, int32_t event_id, void *event_data);
+
+#endif /* ZEPHYR_DRIVERS_WIFI_ESP32_ESP_WIFI_MESH_PRIV_H_ */

--- a/include/zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h
+++ b/include/zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h
@@ -20,6 +20,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_ip.h>
 
 /**
  * @brief ESP32 Wi-Fi Mesh API.
@@ -229,6 +231,17 @@ void esp_wifi_mesh_set_tods_reachable(bool reachable);
  * receive path for that interface. Call once the node becomes the mesh root.
  */
 void esp_wifi_mesh_bind_sta_rx(void);
+
+/**
+ * @brief Get the Ethernet-over-mesh network interface.
+ *
+ * The mesh netif carries Ethernet frames over the Wi-Fi mesh transport so the
+ * Zephyr network stack runs unmodified on top of the mesh. Use the returned
+ * interface to assign IP addresses and drive DHCP, NAT and routing.
+ *
+ * @return the mesh network interface, or NULL before it is initialized.
+ */
+struct net_if *esp_wifi_mesh_netif_get(void);
 
 /**
  * @}

--- a/include/zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h
+++ b/include/zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ESP32 Wi-Fi mesh public API.
+ *
+ * Zephyr-native interface to the ESP Wi-Fi mesh stack: mesh bring-up, the
+ * application event callback, the raw send/receive path, and status and
+ * routing-table queries. It hides the vendor mesh headers so applications
+ * depend only on this API.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_ESP_WIFI_MESH_H_
+#define ZEPHYR_INCLUDE_DRIVERS_ESP_WIFI_MESH_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+/**
+ * @brief ESP32 Wi-Fi Mesh API.
+ * @defgroup esp_wifi_mesh ESP32 Wi-Fi Mesh
+ * @since 4.5
+ * @version 0.1.0
+ * @ingroup wifi_mgmt
+ * @{
+ */
+
+/**
+ * @brief Wi-Fi mesh events delivered to the application callback.
+ *
+ * These abstract the underlying vendor mesh events into a stable Zephyr-native
+ * set so the application does not depend on vendor mesh headers.
+ */
+enum esp_wifi_mesh_event {
+	/** The mesh stack has started. */
+	ESP_WIFI_MESH_EVENT_STARTED,
+	/** The mesh stack has stopped. */
+	ESP_WIFI_MESH_EVENT_STOPPED,
+	/** This node connected to a parent (see is_root in the info). */
+	ESP_WIFI_MESH_EVENT_PARENT_CONNECTED,
+	/** This node lost its parent. */
+	ESP_WIFI_MESH_EVENT_PARENT_DISCONNECTED,
+	/** A child node connected to this node. */
+	ESP_WIFI_MESH_EVENT_CHILD_CONNECTED,
+	/** A child node disconnected from this node. */
+	ESP_WIFI_MESH_EVENT_CHILD_DISCONNECTED,
+	/** No parent was found during the last scan. */
+	ESP_WIFI_MESH_EVENT_NO_PARENT_FOUND,
+	/** The node started looking for a network to join. */
+	ESP_WIFI_MESH_EVENT_FIND_NETWORK,
+	/** The routing table changed (see routing_table_size in the info). */
+	ESP_WIFI_MESH_EVENT_ROUTING_TABLE_CHANGE,
+	/** The root external-network (toDS) path became reachable. */
+	ESP_WIFI_MESH_EVENT_TODS_REACHABLE,
+	/** The root external-network (toDS) path became unreachable. */
+	ESP_WIFI_MESH_EVENT_TODS_UNREACHABLE,
+};
+
+/**
+ * @brief Information delivered with a mesh event.
+ */
+struct esp_wifi_mesh_event_info {
+	/** Current mesh layer (tree depth); -1 while unattached. */
+	int layer;
+	/** True if this node is the mesh root. */
+	bool is_root;
+	/** Current routing table size (valid for routing-table events). */
+	int routing_table_size;
+	/** Disconnect reason (valid for disconnect events). */
+	int reason;
+};
+
+/**
+ * @brief Application mesh event callback.
+ *
+ * @param event the event that occurred.
+ * @param info event details.
+ */
+typedef void (*esp_wifi_mesh_event_cb_t)(enum esp_wifi_mesh_event event,
+					 const struct esp_wifi_mesh_event_info *info);
+
+/**
+ * @brief Register the application mesh event callback.
+ *
+ * The callback runs on the shared Wi-Fi event task and must not block. Its
+ * stack is CONFIG_ESP32_WIFI_EVENT_TASK_STACK_SIZE; heavy work (bringing up the
+ * IP stack, DHCP, NAT) should either run on the application's own thread or the
+ * event task stack should be sized for it. Only one callback is supported;
+ * registering again replaces the previous one.
+ *
+ * @param cb callback to invoke on mesh events, or NULL to unregister.
+ */
+void esp_wifi_mesh_event_cb_register(esp_wifi_mesh_event_cb_t cb);
+
+/**
+ * @brief Start the Wi-Fi mesh stack.
+ *
+ * Performs the full mesh bring-up: puts Wi-Fi in AP+STA mode, initializes and
+ * configures the mesh stack from the driver Kconfig options (mesh id, channel,
+ * router and softAP credentials, tree limits), disables power save, and starts
+ * the mesh.
+ *
+ * The node role follows the WIFI_ESP32_MESH_ROLE choice: the auto role runs
+ * self-organized election (a router is required); WIFI_ESP32_MESH_FORCE_ROOT
+ * designates this node as the fixed root and stops its self-organized parent
+ * search; WIFI_ESP32_MESH_FORCE_CHILD keeps a node from becoming root.
+ *
+ * A router is required. The tree forms around the root's association to the
+ * router, and children auto-attach through the self-organized parent search.
+ * A fully router-less mesh (no router at all) needs each child to be given an
+ * explicit parent, which this driver does not do, so a child does not attach
+ * to a fixed root without a router.
+ *
+ * @note Mesh is a boot-time mode with no runtime teardown. Once started it
+ *       stays resident for the lifetime of the node; there is no stop or
+ *       deinit entry point, and the normal station/softAP wifi_mgmt operations
+ *       (connect, disconnect, ap_enable, scan) are rejected while it runs.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL if the auto role is used without a router SSID.
+ * @retval -EIO on a mesh stack error.
+ */
+int esp_wifi_mesh_start(void);
+
+#if !defined(CONFIG_WIFI_ESP32_MESH_IP)
+/**
+ * @brief Send a data buffer over the mesh.
+ *
+ * On a non-root node the buffer is routed up to the root. On the root it is
+ * sent to every node in the routing table. This is a convenience path for
+ * application messaging that does not use the IP-over-mesh interface.
+ *
+ * @note Not available with CONFIG_WIFI_ESP32_MESH_IP. The IP interface and
+ *       this raw path would both drain the single mesh receive queue with no
+ *       demux, so frames would split non-deterministically between the two
+ *       readers. They are kept mutually exclusive until the receive path
+ *       demultiplexes on the frame protocol tag.
+ *
+ * @param data buffer to send.
+ * @param len number of bytes to send.
+ *
+ * @retval 0 on success (or partial success on the root).
+ * @retval -EIO on a mesh send error.
+ */
+int esp_wifi_mesh_send(const uint8_t *data, size_t len);
+
+/**
+ * @brief Receive a data buffer from the mesh.
+ *
+ * Blocks up to @p timeout_ms for a mesh frame addressed to this node.
+ *
+ * @note Not available with CONFIG_WIFI_ESP32_MESH_IP (see
+ *       esp_wifi_mesh_send()).
+ *
+ * @param data buffer to receive into.
+ * @param len in: buffer size; out: received length.
+ * @param timeout_ms receive timeout in milliseconds.
+ *
+ * @retval 0 on success, with @p len updated to the received size.
+ * @retval -EAGAIN if no frame arrived before the timeout.
+ */
+int esp_wifi_mesh_recv(uint8_t *data, size_t *len, int timeout_ms);
+#endif /* !CONFIG_WIFI_ESP32_MESH_IP */
+
+/**
+ * @brief Current mesh status snapshot.
+ */
+struct esp_wifi_mesh_status {
+	/** Current mesh layer (tree depth); -1 while unattached. */
+	int layer;
+	/** True if this node is the mesh root. */
+	bool is_root;
+	/** Number of nodes in the routing table (root: whole sub-network). */
+	int routing_table_size;
+	/** True once the root announced external-network reachability. */
+	bool tods_reachable;
+};
+
+/**
+ * @brief Read the current mesh status.
+ *
+ * @param status output filled with the current mesh state.
+ */
+void esp_wifi_mesh_get_status(struct esp_wifi_mesh_status *status);
+
+/**
+ * @brief A mesh node address (a 6-byte MAC).
+ */
+struct esp_wifi_mesh_addr {
+	/** 6-byte MAC address of the mesh node. */
+	uint8_t addr[6];
+};
+
+/**
+ * @brief Read the mesh routing table node addresses.
+ *
+ * On the root the table spans the whole sub-network; on an internal node it
+ * holds the node's own sub-tree.
+ *
+ * @param macs   output array receiving the node addresses.
+ * @param max    number of entries @p macs can hold.
+ * @param count  output set to the number of entries written.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL on a NULL argument.
+ */
+int esp_wifi_mesh_get_routing_table(struct esp_wifi_mesh_addr *macs, size_t max, size_t *count);
+
+/**
+ * @brief Announce the root external-network (toDS) reachability to the mesh.
+ *
+ * Called on the root once its uplink is up (or down) so the mesh admits or
+ * stops admitting child traffic bound for the external network.
+ *
+ * @param reachable true if the root can forward toward the external network.
+ */
+void esp_wifi_mesh_set_tods_reachable(bool reachable);
+
+/**
+ * @brief Deliver root station uplink frames to the station interface.
+ *
+ * The mesh stack installs its own station receive callback. On the root, the
+ * station also carries the uplink to the router, so this restores the driver
+ * receive path for that interface. Call once the node becomes the mesh root.
+ */
+void esp_wifi_mesh_bind_sta_rx(void);
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_ESP_WIFI_MESH_H_ */

--- a/samples/boards/espressif/wifi_mesh/CMakeLists.txt
+++ b/samples/boards/espressif/wifi_mesh/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(wifi_mesh)
+
+target_sources(app PRIVATE src/main.c src/mesh_shell.c)

--- a/samples/boards/espressif/wifi_mesh/Kconfig
+++ b/samples/boards/espressif/wifi_mesh/Kconfig
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Wi-Fi mesh sample"
+
+source "Kconfig.zephyr"

--- a/samples/boards/espressif/wifi_mesh/README.rst
+++ b/samples/boards/espressif/wifi_mesh/README.rst
@@ -1,0 +1,137 @@
+.. zephyr:code-sample:: wifi-mesh
+   :name: Wi-Fi Mesh
+
+   Build a self-organizing multi-hop Wi-Fi mesh network.
+
+Overview
+********
+
+This sample forms a self-organizing Wi-Fi mesh network across a group of
+ESP32 boards. Each node runs Wi-Fi in combined AP and station mode: the
+station interface links upward to a parent node, and the softAP interface
+accepts downstream children. The nodes elect a root among themselves. Only
+the root node associates with the configured router to reach the external
+network; internal nodes exchange data purely over the mesh with
+``esp_wifi_mesh_send()`` and ``esp_wifi_mesh_recv()``.
+
+The mesh is driven interactively through a ``mesh`` shell. Received mesh
+messages are logged as they arrive.
+
+This sample carries no IP: no node runs the network stack over the mesh, not
+even the root's link to the router. It moves opaque application payloads
+between nodes with ``esp_wifi_mesh_send()``/``esp_wifi_mesh_recv()`` only. It
+fits applications that define their own light protocol over the mesh and do
+not need sockets, DHCP or internet access, for example collecting sensor
+readings toward the root or pushing commands out to the nodes.
+
+For a node to reach the external network, or to run standard IP (sockets,
+DHCP, mDNS) over the mesh, use the :zephyr:code-sample:`wifi-mesh-ip` sample
+instead. There the root NATs child traffic out to the router, so every node
+reaches the internet through the root, at the cost of the IP-over-mesh
+constraints documented in that sample.
+
+Shell commands
+==============
+
+.. list-table::
+   :header-rows: 1
+
+   * - Command
+     - Description
+   * - ``mesh status``
+     - Show this node's layer, role (root or node), routing table size and
+       toDS reachability.
+   * - ``mesh send <text>``
+     - Send a text message over the mesh. A non-root node sends toward the
+       root; the root sends to each node in its routing table.
+   * - ``mesh table``
+     - Dump the routing table (the node addresses this node routes to).
+   * - ``mesh autotx <on|off>``
+     - Toggle a periodic background sender that emits ``hello seq=N`` every
+       few seconds, off by default.
+
+Requirements
+************
+
+* At least two supported ESP32 boards (esp32, esp32s2, esp32s3, esp32c3,
+  esp32c5, esp32c6). ESP32-C2 and ESP32-H2 do not provide a mesh library.
+* A 2.4 GHz router. In the self-organized mode used by this sample the root
+  is elected by router reachability, so a router is required for the mesh to
+  form even though this sample does not use the external network.
+
+Building and Running
+********************
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/espressif/wifi_mesh
+   :board: esp32c6_devkitc/esp32c6/hpcore
+   :goals: build flash
+   :compact:
+
+Configure the mesh channel and the router credentials through Kconfig
+(``CONFIG_WIFI_ESP32_MESH_CHANNEL``, ``CONFIG_WIFI_ESP32_MESH_ROUTER_SSID``,
+``CONFIG_WIFI_ESP32_MESH_ROUTER_PSK``). The router credentials default to the
+``myssid``/``mypassword`` placeholders and must be set to the router in use;
+a node left on the placeholder finds no such network and keeps searching for
+a parent. Set the channel to the router's channel. Flash the same image to
+every board.
+
+Node role
+=========
+
+The ``CONFIG_WIFI_ESP32_MESH_ROLE`` choice sets how a node takes its place in
+the tree:
+
+* ``CONFIG_WIFI_ESP32_MESH_ROLE_AUTO`` (default): self-organized. The node
+  scans, and if it can reach the router it votes to become the root and
+  connects to it; otherwise it joins an in-range mesh node as a child. A
+  router is required, since the election is driven by router reachability.
+* ``CONFIG_WIFI_ESP32_MESH_FORCE_ROOT``: this node is the fixed root. It never
+  elects and always sits at the top of the tree. With a router configured it
+  still associates to it and maintains that uplink; only in a router-less setup
+  is the parent search stopped, since it would otherwise scan for a parent that
+  does not exist.
+* ``CONFIG_WIFI_ESP32_MESH_FORCE_CHILD``: this node never becomes root and
+  attaches as a child.
+
+A router is required in every role: children attach through the self-organized
+parent search, which is anchored on the root's association to the router. A
+fully router-less mesh would need each child to be given an explicit parent,
+which this sample does not do.
+
+In the auto role, because root election is driven by router reachability,
+boards that are all within range of the router each become their own root; a
+node joins the mesh as a child only when it is out of router range. For bench
+testing with all boards near the router, build the intended child nodes with
+``CONFIG_WIFI_ESP32_MESH_FORCE_CHILD=y`` so they attach to the elected root
+instead of each becoming their own root.
+
+To pin the topology on a bench, build one board with
+``CONFIG_WIFI_ESP32_MESH_FORCE_ROOT=y`` and the rest with
+``CONFIG_WIFI_ESP32_MESH_FORCE_CHILD=y``. The fixed root sits at layer 1 and
+the children attach beneath it.
+
+Sample Output
+*************
+
+.. code-block:: console
+
+   <inf> wifi_mesh: Wi-Fi mesh starting, use the "mesh" shell commands
+   <inf> wifi_mesh: mesh started, layer -1
+   <inf> wifi_mesh: parent connected, layer 1 (root)
+   <inf> wifi_mesh: child connected
+   <inf> wifi_mesh: routing table size 1
+
+   uart:~$ mesh status
+   layer:         1
+   role:          root
+   routing table: 1 node(s)
+   toDS:          unreachable
+   autotx:        off
+   uart:~$ mesh send hello-mesh
+   sent 11 bytes over mesh
+   uart:~$ mesh table
+   routing table: 1 node(s)
+    0: aa:bb:cc:dd:ee:ff
+
+   <inf> wifi_mesh: rx 11 bytes: hello-mesh

--- a/samples/boards/espressif/wifi_mesh/prj.conf
+++ b/samples/boards/espressif/wifi_mesh/prj.conf
@@ -1,0 +1,39 @@
+# Wi-Fi mesh
+CONFIG_WIFI=y
+CONFIG_WIFI_NM=y
+CONFIG_WIFI_ESP32=y
+CONFIG_WIFI_ESP32_MESH=y
+
+# A router is required for the mesh to elect a root: self-organized election
+# is driven by router reachability. The router credentials default to
+# placeholders and must be set to the router in use, through Kconfig
+# (CONFIG_WIFI_ESP32_MESH_ROUTER_SSID/_PSK), for example in a board overlay.
+
+# The mesh stack manages the Wi-Fi interface directly. The network stack is
+# only used to instantiate the Wi-Fi interface; this sample exchanges data
+# over the mesh transport, not over IP.
+CONFIG_NETWORKING=y
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_L2_WIFI_MGMT=y
+
+# Event loop used by the mesh stack to post MESH_EVENT notifications.
+CONFIG_NET_MGMT=y
+CONFIG_NET_MGMT_EVENT=y
+
+# No IP is brought up in this sample.
+CONFIG_NET_CONFIG_AUTO_INIT=n
+
+# Single system heap shared by the Wi-Fi driver and the mesh stack. Most of it
+# holds the Wi-Fi RX/TX buffer pools (see ESP_WIFI_*_BUFFER_NUM), which grow
+# with the number of simultaneous direct links a node carries. The same image
+# is flashed to every board and any node may be elected root, so this is sized
+# for the worst case: a node hosting several direct children. On hardware a
+# root serving five direct children needs roughly 112 KB; a leaf needs far
+# less. Raise this further for a wider tree (higher MESH_MAX_CONNECTIONS).
+CONFIG_HEAP_MEM_POOL_SIZE=114688
+
+CONFIG_LOG=y
+CONFIG_MAIN_STACK_SIZE=4096
+
+# Interactive "mesh" shell: status, send, table, autotx.
+CONFIG_SHELL=y

--- a/samples/boards/espressif/wifi_mesh/src/main.c
+++ b/samples/boards/espressif/wifi_mesh/src/main.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h>
+
+#include "mesh_demo.h"
+
+LOG_MODULE_REGISTER(wifi_mesh, LOG_LEVEL_INF);
+
+/*
+ * Self-organizing Wi-Fi mesh sample.
+ *
+ * Every node runs Wi-Fi in combined AP and station mode. The station side
+ * links upward to a parent, the softAP side accepts children. Nodes elect a
+ * root among themselves; only the root reaches the router (external network).
+ * The Wi-Fi driver performs the mesh bring-up; this sample reacts to mesh
+ * events, logs received mesh messages, and drives the mesh from a shell.
+ */
+
+#define MESH_TX_PERIOD     K_SECONDS(5)
+#define MESH_RX_TIMEOUT_MS 1000
+
+static uint8_t rx_buf[128];
+
+bool mesh_running;
+bool mesh_autotx;
+
+static void mesh_event(enum esp_wifi_mesh_event event, const struct esp_wifi_mesh_event_info *info)
+{
+	switch (event) {
+	case ESP_WIFI_MESH_EVENT_STARTED:
+		mesh_running = true;
+		LOG_INF("mesh started, layer %d", info->layer);
+		break;
+	case ESP_WIFI_MESH_EVENT_STOPPED:
+		mesh_running = false;
+		LOG_INF("mesh stopped");
+		break;
+	case ESP_WIFI_MESH_EVENT_PARENT_CONNECTED:
+		LOG_INF("parent connected, layer %d%s", info->layer,
+			info->is_root ? " (root)" : "");
+		break;
+	case ESP_WIFI_MESH_EVENT_PARENT_DISCONNECTED:
+		LOG_INF("parent disconnected, reason %d", info->reason);
+		break;
+	case ESP_WIFI_MESH_EVENT_NO_PARENT_FOUND:
+		LOG_INF("no parent found, scanning");
+		break;
+	case ESP_WIFI_MESH_EVENT_FIND_NETWORK:
+		LOG_INF("find network");
+		break;
+	case ESP_WIFI_MESH_EVENT_CHILD_CONNECTED:
+		LOG_INF("child connected");
+		break;
+	case ESP_WIFI_MESH_EVENT_CHILD_DISCONNECTED:
+		LOG_INF("child disconnected");
+		break;
+	case ESP_WIFI_MESH_EVENT_ROUTING_TABLE_CHANGE:
+		LOG_INF("routing table size %d", info->routing_table_size);
+		break;
+	case ESP_WIFI_MESH_EVENT_TODS_REACHABLE:
+		LOG_INF("root external network reachable");
+		break;
+	case ESP_WIFI_MESH_EVENT_TODS_UNREACHABLE:
+		LOG_INF("root external network unreachable");
+		break;
+	default:
+		break;
+	}
+}
+
+static void mesh_rx_task(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	while (1) {
+		size_t len = sizeof(rx_buf);
+
+		if (!mesh_running) {
+			k_sleep(K_MSEC(200));
+			continue;
+		}
+
+		if (esp_wifi_mesh_recv(rx_buf, &len, MESH_RX_TIMEOUT_MS) == 0) {
+			/* Terminate before logging: a peer may send a payload
+			 * that is not NUL-terminated or fills the whole buffer.
+			 */
+			rx_buf[MIN(len, sizeof(rx_buf) - 1)] = '\0';
+			LOG_INF("rx %d bytes: %s", (int)len, (char *)rx_buf);
+		}
+	}
+}
+
+/*
+ * Optional periodic sender, off by default and toggled with "mesh autotx".
+ * When enabled it sends a "hello seq=N" message every few seconds so the mesh
+ * can be exercised without typing "mesh send" by hand.
+ */
+static void mesh_tx_task(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	uint8_t tx_buf[64];
+	uint32_t seq = 0;
+
+	while (1) {
+		k_sleep(MESH_TX_PERIOD);
+
+		if (!mesh_running || !mesh_autotx) {
+			continue;
+		}
+
+		int len = snprintk((char *)tx_buf, sizeof(tx_buf), "hello seq=%u", seq++) + 1;
+
+		esp_wifi_mesh_send(tx_buf, len);
+	}
+}
+
+K_THREAD_DEFINE(mesh_rx_id, 4096, mesh_rx_task, NULL, NULL, NULL, 5, 0, 0);
+K_THREAD_DEFINE(mesh_tx_id, 4096, mesh_tx_task, NULL, NULL, NULL, 5, 0, 0);
+
+int main(void)
+{
+	if (net_if_get_first_wifi() == NULL) {
+		LOG_ERR("no Wi-Fi interface found");
+		return -ENODEV;
+	}
+
+	esp_wifi_mesh_event_cb_register(mesh_event);
+
+	if (esp_wifi_mesh_start() != 0) {
+		LOG_ERR("Wi-Fi mesh start failed");
+		return -EIO;
+	}
+
+	LOG_INF("Wi-Fi mesh starting, use the \"mesh\" shell commands");
+	return 0;
+}

--- a/samples/boards/espressif/wifi_mesh/src/mesh_demo.h
+++ b/samples/boards/espressif/wifi_mesh/src/mesh_demo.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef MESH_DEMO_H
+#define MESH_DEMO_H
+
+#include <stdbool.h>
+
+/* Set once the mesh has started; the tx/rx demo tasks gate on it. */
+extern bool mesh_running;
+
+/* Toggled by the "mesh autotx" shell command; drives the periodic sender. */
+extern bool mesh_autotx;
+
+#endif /* MESH_DEMO_H */

--- a/samples/boards/espressif/wifi_mesh/src/mesh_shell.c
+++ b/samples/boards/espressif/wifi_mesh/src/mesh_shell.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Interactive "mesh" shell for the raw-mesh sample: inspect the node state,
+ * send a message over the mesh, dump the routing table, and toggle the
+ * periodic demo sender.
+ */
+
+#include <string.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h>
+
+#include "mesh_demo.h"
+
+/* Bounded by the mesh tree size (max layers * children per node). */
+#define MESH_TABLE_MAX                                                                             \
+	(CONFIG_WIFI_ESP32_MESH_MAX_LAYER * CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS + 1)
+
+static int cmd_mesh_status(const struct shell *sh, size_t argc, char *argv[])
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	struct esp_wifi_mesh_status status;
+
+	if (!mesh_running) {
+		shell_print(sh, "mesh not running");
+		return 0;
+	}
+
+	esp_wifi_mesh_get_status(&status);
+
+	shell_print(sh, "layer:         %d", status.layer);
+	shell_print(sh, "role:          %s", status.is_root ? "root" : "node");
+	shell_print(sh, "routing table: %d node(s)", status.routing_table_size);
+	shell_print(sh, "toDS:          %s", status.tods_reachable ? "reachable" : "unreachable");
+	shell_print(sh, "autotx:        %s", mesh_autotx ? "on" : "off");
+
+	return 0;
+}
+
+static int cmd_mesh_send(const struct shell *sh, size_t argc, char *argv[])
+{
+	if (!mesh_running) {
+		shell_error(sh, "mesh not running");
+		return -ENOEXEC;
+	}
+
+	/* Send the message text plus its terminating NUL so the peer can log it. */
+	size_t len = strlen(argv[1]) + 1;
+
+	if (esp_wifi_mesh_send((const uint8_t *)argv[1], len) != 0) {
+		shell_error(sh, "mesh send failed");
+		return -EIO;
+	}
+
+	shell_print(sh, "sent %d bytes over mesh", (int)len);
+	return 0;
+}
+
+static int cmd_mesh_table(const struct shell *sh, size_t argc, char *argv[])
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	static struct esp_wifi_mesh_addr macs[MESH_TABLE_MAX];
+	size_t count = 0;
+
+	if (!mesh_running) {
+		shell_error(sh, "mesh not running");
+		return -ENOEXEC;
+	}
+
+	if (esp_wifi_mesh_get_routing_table(macs, MESH_TABLE_MAX, &count) != 0) {
+		shell_error(sh, "cannot read routing table");
+		return -EIO;
+	}
+
+	shell_print(sh, "routing table: %d node(s)", (int)count);
+	for (size_t i = 0; i < count; i++) {
+		shell_print(sh, "%2d: %02x:%02x:%02x:%02x:%02x:%02x", (int)i, macs[i].addr[0],
+			    macs[i].addr[1], macs[i].addr[2], macs[i].addr[3], macs[i].addr[4],
+			    macs[i].addr[5]);
+	}
+
+	return 0;
+}
+
+static int cmd_mesh_autotx(const struct shell *sh, size_t argc, char *argv[])
+{
+	if (strcmp(argv[1], "on") == 0) {
+		mesh_autotx = true;
+	} else if (strcmp(argv[1], "off") == 0) {
+		mesh_autotx = false;
+	} else {
+		shell_error(sh, "usage: mesh autotx <on|off>");
+		return -EINVAL;
+	}
+
+	shell_print(sh, "periodic tx %s", mesh_autotx ? "enabled" : "disabled");
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_mesh,
+	SHELL_CMD_ARG(autotx, NULL, "Toggle the periodic sender: mesh autotx <on|off>",
+		      cmd_mesh_autotx, 2, 0),
+	SHELL_CMD_ARG(send, NULL, "Send a message over the mesh: mesh send <text>", cmd_mesh_send,
+		      2, 0),
+	SHELL_CMD_ARG(status, NULL, "Show this node's mesh status", cmd_mesh_status, 1, 0),
+	SHELL_CMD_ARG(table, NULL, "Dump the mesh routing table", cmd_mesh_table, 1, 0),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_REGISTER(mesh, &sub_mesh, "Wi-Fi mesh commands", NULL);

--- a/samples/boards/espressif/wifi_mesh/tests.yaml
+++ b/samples/boards/espressif/wifi_mesh/tests.yaml
@@ -1,0 +1,20 @@
+sample:
+  name: Wi-Fi Mesh
+  description: Self-organizing Wi-Fi mesh network for Espressif ESP32 boards
+tests:
+  sample.boards.espressif.wifi_mesh:
+    tags:
+      - esp32
+      - netif:wifi
+    extra_args:
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+    platform_allow:
+      - esp32_devkitc/esp32/procpu
+      - esp32s2_devkitc
+      - esp32s3_devkitc/esp32s3/procpu
+      - esp32c3_devkitc
+      - esp32c5_devkitc/esp32c5/hpcore
+      - esp32c6_devkitc/esp32c6/hpcore
+    integration_platforms:
+      - esp32c6_devkitc/esp32c6/hpcore
+    build_only: true

--- a/samples/boards/espressif/wifi_mesh_ip/CMakeLists.txt
+++ b/samples/boards/espressif/wifi_mesh_ip/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(wifi_mesh_ip)
+
+target_sources(app PRIVATE src/main.c src/mesh_bridge.c src/mesh_shell.c)

--- a/samples/boards/espressif/wifi_mesh_ip/Kconfig
+++ b/samples/boards/espressif/wifi_mesh_ip/Kconfig
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Wi-Fi mesh IP sample"
+
+source "Kconfig.zephyr"

--- a/samples/boards/espressif/wifi_mesh_ip/README.rst
+++ b/samples/boards/espressif/wifi_mesh_ip/README.rst
@@ -1,0 +1,122 @@
+.. zephyr:code-sample:: wifi-mesh-ip
+   :name: Wi-Fi Mesh IP
+
+   Carry IP over a self-organizing Wi-Fi mesh with a root NAT relay.
+
+Overview
+********
+
+This sample carries IP over a self-organizing Wi-Fi mesh so that unicast IPv4
+sockets run unmodified on every node (see `Limitations`_ for what the mesh
+transport does not carry). It builds on the :zephyr:code-sample:`wifi-mesh`
+sample: the nodes form the same self-organizing mesh (combined AP and station
+mode, root election by router reachability), and this sample adds an IP layer
+on top of the mesh transport.
+
+A small Ethernet interface, provided by the Wi-Fi driver
+(``CONFIG_WIFI_ESP32_MESH_IP``), bridges the Zephyr network stack to the mesh:
+outbound packets are sent with the mesh send API and inbound mesh frames are
+handed to the stack. All IP-level functions are native Zephyr subsystems.
+
+The root serves DHCP to the children on the mesh interface (subnet
+192.168.4.0/24) and masquerades their traffic out the station interface with
+NAT. A child obtains an address from the root over the mesh (for example
+192.168.4.2) and installs a default route toward it. Once the root station has
+its own uplink lease from the router, a child reaches the external network
+through the root's NAT.
+
+The mesh transport cannot carry the ARP broadcast a child would use to resolve
+the root gateway, so the root periodically sends a gratuitous ARP that the mesh
+fans out to every child. A freshly joined child therefore may wait up to
+``CONFIG_NET_ARP_GRATUITOUS_INTERVAL`` seconds for the next gratuitous ARP
+before its uplink resolves the gateway and external traffic starts flowing.
+
+Limitations
+===========
+
+The IP-over-mesh transport is unicast IPv4 only. These are properties of the
+mesh transport, not bugs, but they shape what runs over it:
+
+* No multicast. The mesh has no multicast primitive, so IPv4 multicast and
+  IPv6 neighbor discovery, mDNS and multicast-based service discovery do not
+  traverse the mesh.
+* Broadcast is emulated as one unicast per known node (O(N) over the routing
+  table), used only for the gratuitous-ARP gateway workaround above. It does
+  not scale to general broadcast traffic.
+* IPv4 only. Addressing, DHCP and the root NAT are IPv4; there is no IPv6 path.
+* Reduced MTU with no fragmentation. The mesh interface MTU is smaller than a
+  normal Ethernet link, and frames larger than the mesh payload are rejected
+  rather than fragmented, so the path MTU must be respected.
+
+In short, unmodified unicast IPv4 (TCP and UDP) works across the mesh;
+anything that relies on multicast, broadcast or IPv6 does not.
+
+Requirements
+************
+
+* At least two supported ESP32 boards (esp32, esp32s2, esp32s3, esp32c3,
+  esp32c5, esp32c6). ESP32-C2 and ESP32-H2 do not provide a mesh library.
+* A 2.4 GHz router with internet access. The root associates to it and relays
+  child traffic to the external network.
+
+Memory
+======
+
+The configuration is sized for a root node, which carries the most: the Wi-Fi
+buffer pools for its direct children plus the DHCP server, NAT and routing
+state for the sub-network. The same image is flashed to every board because any
+node may be elected root.
+
+On a SoC with a smaller RAM budget that does not fit, as on the ESP32 and the
+ESP32-S2, trim the mesh fan-out and the Wi-Fi buffer pools (see the board files
+under ``boards/``). A node configured that way runs as a leaf child.
+
+Setting ``CONFIG_NET_DHCPV4_SERVER=n`` and ``CONFIG_NET_IPV4_NAT=n`` drops the
+root relay entirely and frees the memory it needs. Such a node can never serve
+the mesh subnet, so build it only where another node is guaranteed to be root;
+it reports an error if it is elected.
+
+Building and Running
+********************
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/boards/espressif/wifi_mesh_ip
+   :board: esp32c6_devkitc/esp32c6/hpcore
+   :goals: build flash
+   :compact:
+
+Configure the mesh channel and the router credentials through Kconfig
+(``CONFIG_WIFI_ESP32_MESH_CHANNEL``, ``CONFIG_WIFI_ESP32_MESH_ROUTER_SSID``,
+``CONFIG_WIFI_ESP32_MESH_ROUTER_PSK``). The router credentials default to the
+``myssid``/``mypassword`` placeholders and must be set to the router in use;
+a node left on the placeholder finds no such network and keeps searching for
+a parent. Set the channel to the router's
+channel. Flash the same image to every board.
+
+Because root election is driven by router reachability, boards that are all
+within range of the router each become their own root; a node joins the mesh
+as a child only when it is out of router range. For bench testing with all
+boards near the router, build the intended child nodes with
+``CONFIG_WIFI_ESP32_MESH_FORCE_CHILD=y`` so they attach to the elected root
+instead of each becoming their own root.
+
+Sample Output
+*************
+
+The root brings up its uplink and NAT, and a child obtains an address over the
+mesh:
+
+.. code-block:: console
+
+   <inf> wifi_mesh_ip: parent connected, layer 1 (root)
+   <inf> wifi_mesh_ip: mesh root IP: gateway 192.168.4.1, DHCP + NAT up
+   <inf> wifi_mesh_ip: child connected
+   <inf> wifi_mesh_ip: root external network reachable
+   <inf> wifi_mesh_ip: child got IP 192.168.4.2 over mesh
+
+Once the child has its address, confirm it reaches the external network through
+the root's NAT by pinging a public host from the child's shell:
+
+.. code-block:: console
+
+   uart:~$ net ping 1.1.1.1

--- a/samples/boards/espressif/wifi_mesh_ip/boards/esp32_devkitc_procpu.conf
+++ b/samples/boards/espressif/wifi_mesh_ip/boards/esp32_devkitc_procpu.conf
@@ -1,0 +1,11 @@
+# The original ESP32 has a smaller DRAM budget than the newer SoCs, and the
+# defaults in prj.conf are sized for a root node carrying several children. Trim
+# the mesh fan-out and the Wi-Fi buffer pools so the heap still fits alongside
+# the IP stack. A node built this way works as a leaf child; it does not have
+# the buffers to host a wide sub-tree.
+CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS=1
+CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM=4
+CONFIG_ESP32_WIFI_DYNAMIC_RX_BUFFER_NUM=8
+CONFIG_ESP32_WIFI_DYNAMIC_TX_BUFFER_NUM=8
+CONFIG_WIFI_ESP32_MESH_XON_QSIZE=16
+CONFIG_HEAP_MEM_POOL_SIZE=98304

--- a/samples/boards/espressif/wifi_mesh_ip/boards/esp32s2_devkitc.conf
+++ b/samples/boards/espressif/wifi_mesh_ip/boards/esp32s2_devkitc.conf
@@ -1,0 +1,11 @@
+# The ESP32-S2 has a smaller DRAM budget than the other supported SoCs, and the
+# defaults in prj.conf are sized for a root node carrying several children. Trim
+# the mesh fan-out and the Wi-Fi buffer pools so the heap still fits alongside
+# the IP stack. A node built this way works as a leaf child; it does not have
+# the buffers to host a wide sub-tree.
+CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS=1
+CONFIG_ESP32_WIFI_STATIC_RX_BUFFER_NUM=4
+CONFIG_ESP32_WIFI_DYNAMIC_RX_BUFFER_NUM=8
+CONFIG_ESP32_WIFI_DYNAMIC_TX_BUFFER_NUM=8
+CONFIG_WIFI_ESP32_MESH_XON_QSIZE=16
+CONFIG_HEAP_MEM_POOL_SIZE=98304

--- a/samples/boards/espressif/wifi_mesh_ip/prj.conf
+++ b/samples/boards/espressif/wifi_mesh_ip/prj.conf
@@ -1,0 +1,90 @@
+# Wi-Fi mesh with IP over mesh
+CONFIG_WIFI=y
+CONFIG_WIFI_NM=y
+CONFIG_WIFI_ESP32=y
+CONFIG_WIFI_ESP32_MESH=y
+
+# Carry IP over the mesh: builds the Ethernet-over-mesh transport interface in
+# the driver. The root NATs child traffic out its station uplink.
+CONFIG_WIFI_ESP32_MESH_IP=y
+
+# Router the elected root associates to for external access. The credentials
+# default to placeholders and must be set to the router in use, through Kconfig
+# (CONFIG_WIFI_ESP32_MESH_ROUTER_SSID/_PSK), for example in a board overlay.
+
+CONFIG_NETWORKING=y
+CONFIG_NET_L2_ETHERNET=y
+CONFIG_NET_L2_WIFI_MGMT=y
+
+# IP subsystems used by the bridge: DHCP client (station and child), DHCP
+# server and NAT (root), and sockets for the reachability probe.
+CONFIG_NET_IPV4=y
+CONFIG_NET_UDP=y
+CONFIG_NET_TCP=y
+CONFIG_NET_SOCKETS=y
+CONFIG_NET_DHCPV4=y
+CONFIG_NET_DHCPV4_SERVER=y
+CONFIG_NET_IPV4_NAT=y
+CONFIG_NET_IPV4_ROUTE=y
+CONFIG_NET_IPV4_FORWARDING=y
+
+# Event loop used by the mesh stack to post MESH_EVENT notifications.
+CONFIG_NET_MGMT=y
+CONFIG_NET_MGMT_EVENT=y
+CONFIG_NET_MGMT_EVENT_INFO=y
+
+# The mesh transport cannot carry the ARP broadcast a child would use to
+# resolve the root gateway. Instead the root periodically broadcasts a
+# gratuitous ARP, which the mesh fans out to every child, so each child learns
+# the gateway link address through the normal ARP receive path.
+CONFIG_NET_ARP_GRATUITOUS=y
+CONFIG_NET_ARP_GRATUITOUS_TRANSMISSION=y
+CONFIG_NET_ARP_GRATUITOUS_INTERVAL=10
+
+# The station and the mesh bridge are two interfaces, each needing an address.
+CONFIG_NET_IF_MAX_IPV4_COUNT=2
+CONFIG_NET_IF_MAX_IPV6_COUNT=2
+
+# IP is brought up explicitly once the mesh link is established.
+CONFIG_NET_CONFIG_AUTO_INIT=n
+
+# The mesh event callback runs on the Wi-Fi event task, and on the root it
+# brings up the IP stack (DHCP server, NAT, routes) from there. Raise the event
+# task stack above its 2048-byte default to accommodate that work.
+CONFIG_ESP32_WIFI_EVENT_TASK_STACK_SIZE=4096
+
+# Single system heap shared by the Wi-Fi driver, the mesh stack and the IP
+# stack. The same image is flashed to every board and any node may become
+# root, so this is sized for the root, which carries the most: the Wi-Fi
+# RX/TX pools for its direct children plus the DHCP server, NAT and routing
+# state for the sub-network. A root serving several children was verified at
+# 128 KB on hardware; a leaf child needs far less.
+CONFIG_HEAP_MEM_POOL_SIZE=131072
+
+# The root serves DHCP to the whole mesh sub-network, not just its direct
+# children, so the address pool must cover the expected node count.
+CONFIG_NET_DHCPV4_SERVER_ADDR_COUNT=16
+
+# The root installs one masquerade rule per forwarded protocol (TCP, UDP,
+# ICMP); size the table for exactly those.
+CONFIG_NET_IPV4_IPTABLE_RULE_MAX_NUM=3
+
+# The root NATs the whole mesh sub-network, so the connection-tracking table
+# must hold the concurrent flows of all children, not just a handful. The
+# default of 10 is too small for a 16-node pool; size it to match.
+CONFIG_NET_IPV4_CONN_TRACK_MAX_NUM=32
+
+CONFIG_LOG=y
+CONFIG_MAIN_STACK_SIZE=4096
+
+# Shell for interactive inspection: the net shell drives the IP-over-mesh
+# check (ping the external network from a child, list the mesh interface and
+# its DHCP address, show the route to the root), and the mesh commands report
+# the node's mesh role and routing table.
+CONFIG_SHELL=y
+CONFIG_NET_SHELL=y
+
+# The net shell "iptables" command is the NAT rule editor; this sample
+# installs its NAT rules from code, so drop it and avoid pulling the extra
+# option-parser dependency into the shell.
+CONFIG_NET_SHELL_IP_TABLE_SUPPORTED=n

--- a/samples/boards/espressif/wifi_mesh_ip/src/main.c
+++ b/samples/boards/espressif/wifi_mesh_ip/src/main.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h>
+
+#include "mesh_bridge.h"
+
+LOG_MODULE_REGISTER(wifi_mesh_ip, LOG_LEVEL_INF);
+
+/*
+ * IP-over-mesh sample.
+ *
+ * Every node runs Wi-Fi in combined AP and station mode and self-organizes
+ * into a mesh; only the root reaches the router. IP is carried over the mesh
+ * so sockets run unmodified on every node: the root serves DHCP and NATs child
+ * traffic out its station uplink, and a child reaches the external network
+ * through the root. The Wi-Fi driver performs the mesh bring-up and provides
+ * the Ethernet-over-mesh transport; this sample wires the IP layer on top.
+ */
+
+static void mesh_event(enum esp_wifi_mesh_event event, const struct esp_wifi_mesh_event_info *info)
+{
+	switch (event) {
+	case ESP_WIFI_MESH_EVENT_STARTED:
+		LOG_INF("mesh started, layer %d", info->layer);
+		break;
+	case ESP_WIFI_MESH_EVENT_STOPPED:
+		LOG_INF("mesh stopped");
+		break;
+	case ESP_WIFI_MESH_EVENT_PARENT_CONNECTED:
+		LOG_INF("parent connected, layer %d%s", info->layer,
+			info->is_root ? " (root)" : "");
+		if (info->is_root) {
+			struct net_if *sta = net_if_get_first_wifi();
+
+			if (sta != NULL) {
+				mesh_bridge_setup_root(sta);
+			}
+		} else {
+			mesh_bridge_setup_child();
+		}
+		break;
+	case ESP_WIFI_MESH_EVENT_PARENT_DISCONNECTED:
+		LOG_INF("parent disconnected, reason %d", info->reason);
+		break;
+	case ESP_WIFI_MESH_EVENT_NO_PARENT_FOUND:
+		LOG_INF("no parent found, scanning");
+		break;
+	case ESP_WIFI_MESH_EVENT_FIND_NETWORK:
+		LOG_INF("find network");
+		break;
+	case ESP_WIFI_MESH_EVENT_CHILD_CONNECTED:
+		LOG_INF("child connected");
+		break;
+	case ESP_WIFI_MESH_EVENT_CHILD_DISCONNECTED:
+		LOG_INF("child disconnected");
+		break;
+	case ESP_WIFI_MESH_EVENT_ROUTING_TABLE_CHANGE:
+		LOG_INF("routing table size %d", info->routing_table_size);
+		break;
+	case ESP_WIFI_MESH_EVENT_TODS_REACHABLE:
+		LOG_INF("root external network reachable");
+		break;
+	case ESP_WIFI_MESH_EVENT_TODS_UNREACHABLE:
+		LOG_INF("root external network unreachable");
+		break;
+	default:
+		break;
+	}
+}
+
+int main(void)
+{
+	if (net_if_get_first_wifi() == NULL) {
+		LOG_ERR("no Wi-Fi interface found");
+		return -ENODEV;
+	}
+
+	esp_wifi_mesh_event_cb_register(mesh_event);
+
+	if (esp_wifi_mesh_start() != 0) {
+		LOG_ERR("Wi-Fi mesh start failed");
+		return -EIO;
+	}
+
+	LOG_INF("Wi-Fi mesh starting");
+	return 0;
+}

--- a/samples/boards/espressif/wifi_mesh_ip/src/mesh_bridge.c
+++ b/samples/boards/espressif/wifi_mesh_ip/src/mesh_bridge.c
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * IP-over-mesh policy for the sample: address the mesh interface, drive DHCP,
+ * NAT and routing on the root, and request an address on a child. The
+ * Ethernet-over-mesh transport itself is provided by the Wi-Fi driver
+ * (esp_wifi_mesh_netif_get()); this file only wires the IP layer on top.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/net/dhcpv4.h>
+#include <zephyr/net/dhcpv4_server.h>
+#include <zephyr/net/ipv4_nat.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/net_event.h>
+#include <zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h>
+
+#include "mesh_bridge.h"
+
+LOG_MODULE_DECLARE(wifi_mesh_ip, LOG_LEVEL_INF);
+
+static struct net_mgmt_event_callback mesh_dhcp_cb;
+static struct net_mgmt_event_callback mesh_uplink_cb;
+
+/* Root serves this private subnet to the mesh; .1 is the root itself. */
+#define MESH_SUBNET_A 192
+#define MESH_SUBNET_B 168
+#define MESH_SUBNET_C 4
+
+/*
+ * When the root station gets its uplink lease, register the router as the
+ * default router and announce toDS reachability so the mesh starts admitting
+ * child traffic bound for the external network; before the uplink is up there
+ * is nowhere to forward it.
+ */
+static void mesh_uplink_bound(struct net_mgmt_event_callback *cb, uint64_t mgmt_event,
+			      struct net_if *iface)
+{
+	ARG_UNUSED(cb);
+
+	if (mgmt_event == NET_EVENT_IPV4_DHCP_BOUND) {
+		struct net_in_addr gw = net_if_ipv4_get_gw(iface);
+
+		net_if_ipv4_router_add(iface, &gw, true, 0);
+		esp_wifi_mesh_set_tods_reachable(true);
+	}
+}
+
+static void mesh_dhcp_bound(struct net_mgmt_event_callback *cb, uint64_t mgmt_event,
+			    struct net_if *iface)
+{
+	static atomic_t bound_once;
+
+	ARG_UNUSED(cb);
+
+	if (mgmt_event != NET_EVENT_IPV4_DHCP_BOUND) {
+		return;
+	}
+
+	/*
+	 * DHCP raises BOUND on the initial lease and again on every renewal.
+	 * The gateway and route only need setting once, so run this block just
+	 * once and ignore later renewals.
+	 */
+	if (atomic_set(&bound_once, 1) != 0) {
+		return;
+	}
+
+	char buf[NET_IPV4_ADDR_LEN];
+	struct net_if_addr *ifaddr = &iface->config.ip.ipv4->unicast[0].ipv4;
+
+	LOG_INF("child got IP %s over mesh",
+		net_addr_ntop(AF_INET, &ifaddr->address.in_addr, buf, sizeof(buf)));
+
+	/* Route off-subnet traffic to the root over the mesh. */
+	struct net_in_addr gw = {{{MESH_SUBNET_A, MESH_SUBNET_B, MESH_SUBNET_C, 1}}};
+
+	net_if_ipv4_set_gw(esp_wifi_mesh_netif_get(), &gw);
+	net_if_ipv4_router_add(esp_wifi_mesh_netif_get(), &gw, true, 0);
+}
+
+/*
+ * Root: own the mesh subnet gateway address, serve DHCP to the children, and
+ * masquerade their traffic out the station interface toward the router. The
+ * Zephyr network stack does the DHCP, NAT and forwarding; only the addresses
+ * and the rule are set here.
+ */
+#if defined(CONFIG_NET_DHCPV4_SERVER) && defined(CONFIG_NET_IPV4_NAT)
+void mesh_bridge_setup_root(struct net_if *sta_iface)
+{
+	struct net_if *mesh_iface = esp_wifi_mesh_netif_get();
+	struct net_in_addr gw = {{{MESH_SUBNET_A, MESH_SUBNET_B, MESH_SUBNET_C, 1}}};
+	struct net_in_addr netmask = {{{255, 255, 255, 0}}};
+	struct net_in_addr pool_start = {{{MESH_SUBNET_A, MESH_SUBNET_B, MESH_SUBNET_C, 2}}};
+
+	/*
+	 * The mesh stack drives the station to the router, bypassing the normal
+	 * connect path that would bring the station interface up. Force it up so
+	 * the network stack can obtain the uplink address and route.
+	 */
+	esp_wifi_mesh_bind_sta_rx();
+	net_mgmt_init_event_callback(&mesh_uplink_cb, mesh_uplink_bound, NET_EVENT_IPV4_DHCP_BOUND);
+	net_mgmt_add_event_callback(&mesh_uplink_cb);
+
+	net_if_carrier_on(sta_iface);
+	net_if_dormant_off(sta_iface);
+	net_dhcpv4_start(sta_iface);
+
+	net_if_ipv4_addr_add(mesh_iface, &gw, NET_ADDR_MANUAL, 0);
+	net_if_ipv4_set_netmask_by_addr(mesh_iface, &gw, &netmask);
+
+	/*
+	 * Add an explicit connected route for the mesh subnet over the mesh
+	 * interface. When IPv4 forwarding is enabled the forwarding lookup does
+	 * not resolve on-link subnets on its own, so a reply masqueraded back to
+	 * a child would otherwise follow the default route out the station. The
+	 * route carries no next hop, which makes the stack resolve the child
+	 * address directly on the mesh interface.
+	 */
+	struct net_in_addr subnet = {{{MESH_SUBNET_A, MESH_SUBNET_B, MESH_SUBNET_C, 0}}};
+
+	if (net_if_ipv4_route_add(mesh_iface, &subnet, 24, NULL, UINT32_MAX) < 0) {
+		LOG_ERR("mesh subnet route add failed");
+	}
+
+	if (net_dhcpv4_server_start(mesh_iface, &pool_start) < 0) {
+		LOG_ERR("mesh DHCP server start failed");
+	}
+
+	/* NAT is per protocol, so masquerade TCP, UDP and ICMP. */
+	static const enum net_ip_protocol protos[] = {
+		NET_IPPROTO_TCP,
+		NET_IPPROTO_UDP,
+		NET_IPPROTO_ICMP,
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(protos); i++) {
+		struct net_iptable_rule_params rule = {0};
+
+		rule.input_iface_idx = net_if_get_by_iface(mesh_iface);
+		rule.output_iface_idx = net_if_get_by_iface(sta_iface);
+		memcpy(rule.src, (uint8_t[]){MESH_SUBNET_A, MESH_SUBNET_B, MESH_SUBNET_C, 0}, 4);
+		memcpy(rule.src_mask, (uint8_t[]){255, 255, 255, 0}, 4);
+		rule.proto = protos[i];
+		rule.priority = 5;
+
+		if (net_ipv4_table_rule_add(&rule) < 0) {
+			LOG_ERR("mesh NAT rule add failed (proto %d)", protos[i]);
+		}
+	}
+
+	LOG_INF("mesh root IP: gateway %d.%d.%d.1, DHCP + NAT up", MESH_SUBNET_A, MESH_SUBNET_B,
+		MESH_SUBNET_C);
+}
+#else
+/*
+ * Child-only build: the DHCP server and NAT the root relay needs are disabled,
+ * so a node built this way cannot serve the mesh subnet. Useful on a SoC whose
+ * RAM does not fit the root configuration.
+ */
+void mesh_bridge_setup_root(struct net_if *sta_iface)
+{
+	ARG_UNUSED(sta_iface);
+
+	LOG_ERR("elected root, but this image is built without the DHCP server "
+		"and NAT the root needs (CONFIG_NET_DHCPV4_SERVER, "
+		"CONFIG_NET_IPV4_NAT); the mesh subnet has no gateway");
+}
+#endif /* CONFIG_NET_DHCPV4_SERVER && CONFIG_NET_IPV4_NAT */
+
+/* Child: get an address from the root's DHCP server over the mesh. */
+void mesh_bridge_setup_child(void)
+{
+	net_mgmt_init_event_callback(&mesh_dhcp_cb, mesh_dhcp_bound, NET_EVENT_IPV4_DHCP_BOUND);
+	net_mgmt_add_event_callback(&mesh_dhcp_cb);
+
+	net_dhcpv4_start(esp_wifi_mesh_netif_get());
+	LOG_INF("mesh child IP: requesting address over mesh");
+}

--- a/samples/boards/espressif/wifi_mesh_ip/src/mesh_bridge.h
+++ b/samples/boards/espressif/wifi_mesh_ip/src/mesh_bridge.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef MESH_BRIDGE_H
+#define MESH_BRIDGE_H
+
+#include <zephyr/net/net_if.h>
+
+/**
+ * @brief Bring up the root-side IP bridge.
+ *
+ * Runs on the node elected root. Starts the DHCP server that leases addresses
+ * to the mesh sub-network over the mesh interface, and installs the NAT rules
+ * that masquerade child traffic out the station uplink so the whole mesh
+ * reaches the external network through the root.
+ *
+ * @param sta_iface Station interface providing the external uplink.
+ */
+void mesh_bridge_setup_root(struct net_if *sta_iface);
+
+/**
+ * @brief Bring up the child-side IP bridge.
+ *
+ * Runs on a non-root node. Starts a DHCP client on the mesh interface to
+ * obtain an address from the root's DHCP server over the mesh transport,
+ * giving the node IP connectivity through the root.
+ */
+void mesh_bridge_setup_child(void);
+
+#endif /* MESH_BRIDGE_H */

--- a/samples/boards/espressif/wifi_mesh_ip/src/mesh_shell.c
+++ b/samples/boards/espressif/wifi_mesh_ip/src/mesh_shell.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Interactive "mesh" shell for the IP-over-mesh sample: report the node's
+ * mesh role and dump the routing table. The IP-level checks (ping, interface
+ * and route inspection) use the built-in net shell.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/drivers/wifi/esp_wifi/esp_wifi_mesh.h>
+
+/* Bounded by the mesh tree size (max layers * children per node). */
+#define MESH_TABLE_MAX                                                                             \
+	(CONFIG_WIFI_ESP32_MESH_MAX_LAYER * CONFIG_WIFI_ESP32_MESH_MAX_CONNECTIONS + 1)
+
+static int cmd_mesh_status(const struct shell *sh, size_t argc, char *argv[])
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	struct esp_wifi_mesh_status status;
+
+	esp_wifi_mesh_get_status(&status);
+
+	shell_print(sh, "layer:         %d", status.layer);
+	shell_print(sh, "role:          %s", status.is_root ? "root" : "node");
+	shell_print(sh, "routing table: %d node(s)", status.routing_table_size);
+	shell_print(sh, "toDS:          %s", status.tods_reachable ? "reachable" : "unreachable");
+
+	return 0;
+}
+
+static int cmd_mesh_table(const struct shell *sh, size_t argc, char *argv[])
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	static struct esp_wifi_mesh_addr macs[MESH_TABLE_MAX];
+	size_t count = 0;
+
+	if (esp_wifi_mesh_get_routing_table(macs, MESH_TABLE_MAX, &count) != 0) {
+		shell_error(sh, "cannot read routing table");
+		return -EIO;
+	}
+
+	shell_print(sh, "routing table: %d node(s)", (int)count);
+	for (size_t i = 0; i < count; i++) {
+		shell_print(sh, "%2d: %02x:%02x:%02x:%02x:%02x:%02x", (int)i, macs[i].addr[0],
+			    macs[i].addr[1], macs[i].addr[2], macs[i].addr[3], macs[i].addr[4],
+			    macs[i].addr[5]);
+	}
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_mesh,
+			       SHELL_CMD_ARG(status, NULL, "Show this node's mesh status",
+					     cmd_mesh_status, 1, 0),
+			       SHELL_CMD_ARG(table, NULL, "Dump the mesh routing table",
+					     cmd_mesh_table, 1, 0),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_REGISTER(mesh, &sub_mesh, "Wi-Fi mesh commands", NULL);

--- a/samples/boards/espressif/wifi_mesh_ip/tests.yaml
+++ b/samples/boards/espressif/wifi_mesh_ip/tests.yaml
@@ -1,0 +1,20 @@
+sample:
+  name: Wi-Fi Mesh IP
+  description: IP over a self-organizing Wi-Fi mesh with root NAT relay
+tests:
+  sample.boards.espressif.wifi_mesh_ip:
+    tags:
+      - esp32
+      - netif:wifi
+    extra_args:
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+    platform_allow:
+      - esp32_devkitc/esp32/procpu
+      - esp32s2_devkitc
+      - esp32s3_devkitc/esp32s3/procpu
+      - esp32c3_devkitc
+      - esp32c5_devkitc/esp32c5/hpcore
+      - esp32c6_devkitc/esp32c6/hpcore
+    integration_platforms:
+      - esp32c6_devkitc/esp32c6/hpcore
+    build_only: true

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: d6a25c8f2a019f7e4d21cf664075f6b94c28eae8
+      revision: 150e0c1bd24fd568864ae50fa690e9ec526022a4
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Bring ESP-WIFI-MESH to the esp32 Wi-Fi driver: mesh bring-up and the
event/send/recv API, plus an optional IP-over-mesh bridge that NATs child
traffic through the root. Adds raw-mesh and ip-over-mesh samples.