### PR TITLE
net: ethernet: lldp: use NET_MGMT_REGISTER_EVENT_HANDLER

### DIFF
--- a/include/zephyr/net/lldp.h
+++ b/include/zephyr/net/lldp.h
@@ -198,11 +198,6 @@ int net_lldp_config_optional(struct net_if *iface, const uint8_t *tlv,
 			     size_t len);
 
 /**
- * @brief Initialize LLDP engine.
- */
-void net_lldp_init(void);
-
-/**
  * @brief LLDP Receive packet callback
  *
  * Callback gets called upon receiving packet. It is responsible for

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -168,9 +168,6 @@ static void net_post_init(void)
 #if defined(CONFIG_NET_ARP)
 	net_arp_init();
 #endif
-#if defined(CONFIG_NET_LLDP)
-	net_lldp_init();
-#endif
 #if defined(CONFIG_NET_GPTP)
 	net_gptp_init();
 #endif

--- a/subsys/net/l2/ethernet/lldp/lldp.c
+++ b/subsys/net/l2/ethernet/lldp/lldp.c
@@ -20,7 +20,11 @@ LOG_MODULE_REGISTER(net_lldp, CONFIG_NET_LLDP_LOG_LEVEL);
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/lldp.h>
 
-static struct net_mgmt_event_callback cb;
+static void iface_event_handler(uint64_t mgmt_event, struct net_if *iface, void *info,
+				size_t info_length, void *user_data);
+
+NET_MGMT_REGISTER_EVENT_HANDLER(lldp_events, NET_EVENT_IF_UP | NET_EVENT_IF_DOWN,
+				iface_event_handler, NULL);
 
 static void lldp_tx_timeout(struct k_work *work);
 /* Have only one timer in order to save memory */
@@ -246,21 +250,10 @@ int net_lldp_register_callback(struct net_if *iface, net_lldp_recv_cb_t recv_cb)
 	return 0;
 }
 
-static void iface_event_handler(struct net_mgmt_event_callback *evt_cb,
-				uint64_t mgmt_event, struct net_if *iface)
+static void iface_event_handler(uint64_t mgmt_event, struct net_if *iface, void *info __unused,
+				size_t info_length __unused, void *user_data __unused)
 {
 	lldp_start(iface, mgmt_event);
-}
-
-static void iface_cb(struct net_if *iface, void *user_data)
-{
-	/* If the network interface is already up, then call the sender
-	 * immediately. If the interface is not ethernet one, then
-	 * lldp_start() will return immediately.
-	 */
-	if (net_if_oper_state(iface) == NET_IF_OPER_UP) {
-		lldp_start(iface, NET_EVENT_IF_UP);
-	}
 }
 
 int net_lldp_config(struct net_if *iface, const struct net_lldpdu *lldpdu)
@@ -311,13 +304,4 @@ void net_lldp_unset_lldpdu(struct net_if *iface)
 {
 	net_lldp_config(iface, NULL);
 	net_lldp_config_optional(iface, NULL, 0);
-}
-
-void net_lldp_init(void)
-{
-	net_mgmt_init_event_callback(&cb, iface_event_handler,
-				     NET_EVENT_IF_UP | NET_EVENT_IF_DOWN);
-	net_mgmt_add_event_callback(&cb);
-
-	net_if_foreach(iface_cb, NULL);
 }


### PR DESCRIPTION
use NET_MGMT_REGISTER_EVENT_HANDLER for
registering the event at compile time. With that the lldp init is no more nessesary.