### PR TITLE
include: zbus: use kconfig_dep alias across all APIs

### DIFF
--- a/include/zephyr/zbus/proxy_agent/zbus_proxy_agent.h
+++ b/include/zephyr/zbus/proxy_agent/zbus_proxy_agent.h
@@ -20,6 +20,9 @@ extern "C" {
  * @brief Zbus Multi-domain API
  * @defgroup zbus_proxy_agent Zbus Proxy Agent API
  * @ingroup zbus_apis
+ *
+ * @kconfig_dep{CONFIG_ZBUS_PROXY_AGENT}
+ *
  * @{
  */
 

--- a/include/zephyr/zbus/proxy_agent/zbus_proxy_agent_ipc.h
+++ b/include/zephyr/zbus/proxy_agent/zbus_proxy_agent_ipc.h
@@ -24,14 +24,16 @@ extern "C" {
  * @defgroup zbus_proxy_agent_ipc_backend Zbus Proxy Agent IPC Backend
  * @ingroup zbus_proxy_agent
  *
+ * @kconfig_dep{CONFIG_ZBUS_PROXY_AGENT_IPC}
+ *
  * @details The IPC backend uses a shared-memory message passing model via
  * `ipc_service`, and therefore transfers fixed-size proxy frames
  * (`struct zbus_proxy_msg`) between domains. This means on-wire transfer size is
  * equal to `sizeof(struct zbus_proxy_msg)` even when `message_size` or
  * `channel_name_len` are smaller. Because this frame size is determined at compile time from
- * `CONFIG_ZBUS_PROXY_AGENT_MAX_MESSAGE_SIZE` and
- * `CONFIG_ZBUS_PROXY_AGENT_MAX_CHANNEL_NAME_SIZE`, all communicating domains must use identical
- * values for these options. The IPC backend validates incoming data against
+ * @kconfig{CONFIG_ZBUS_PROXY_AGENT_MAX_MESSAGE_SIZE} and
+ * @kconfig{CONFIG_ZBUS_PROXY_AGENT_MAX_CHANNEL_NAME_SIZE}, all communicating domains must use
+ * identical values for these options. The IPC backend validates incoming data against
  * `sizeof(struct zbus_proxy_msg)`, so mismatched configuration across domains will cause
  * received messages to be rejected.
  * @{

--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -801,6 +801,8 @@ int zbus_chan_notify(const struct zbus_channel *chan, k_timeout_t timeout);
  *
  * This routine returns the channel's name reference.
  *
+ * @kconfig_dep{CONFIG_ZBUS_CHANNEL_NAME}
+ *
  * @param chan The channel's reference.
  *
  * @return Channel's name reference.
@@ -819,6 +821,8 @@ static inline const char *zbus_chan_name(const struct zbus_channel *chan)
 /**
  * @brief Retrieve a zbus channel from its numeric identifier
  *
+ * @kconfig_dep{CONFIG_ZBUS_CHANNEL_ID}
+ *
  * @param channel_id Unique channel ID from @ref ZBUS_CHAN_DEFINE_WITH_ID
  *
  * @retval NULL If channel with ID @a channel_id does not exist.
@@ -832,6 +836,8 @@ const struct zbus_channel *zbus_chan_from_id(uint32_t channel_id);
 
 /**
  * @brief Retrieve a zbus channel from its name string
+ *
+ * @kconfig_dep{CONFIG_ZBUS_CHANNEL_NAME}
  *
  * @param name Name of the channel to retrieve.
  *
@@ -1002,6 +1008,8 @@ static inline void *zbus_chan_user_data(const struct zbus_channel *chan)
 /**
  * @brief Set the channel's msg subscriber `net_buf` pool.
  *
+ * @kconfig_dep{CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION}
+ *
  * @param chan The channel's reference.
  * @param pool The reference to the `net_buf` memory pool.
  */
@@ -1025,6 +1033,8 @@ static inline void zbus_chan_set_msg_sub_pool(const struct zbus_channel *chan,
  * @ref zbus_chan_finish workflow, which cannot automatically determine whether
  * new data has been published or not.
  *
+ * @kconfig_dep{CONFIG_ZBUS_CHANNEL_PUBLISH_STATS}
+ *
  * @warning This function must only be used directly for already locked channels.
  *
  * @param chan The channel's reference.
@@ -1039,6 +1049,8 @@ static inline void zbus_chan_pub_stats_update(const struct zbus_channel *chan)
 
 /**
  * @brief Get the time a channel was last published to.
+ *
+ * @kconfig_dep{CONFIG_ZBUS_CHANNEL_PUBLISH_STATS}
  *
  * @note Will return 0 if channel has not yet been published to.
  *
@@ -1056,6 +1068,8 @@ static inline k_ticks_t zbus_chan_pub_stats_last_time(const struct zbus_channel 
 /**
  * @brief Get the number of times a channel has been published to.
  *
+ * @kconfig_dep{CONFIG_ZBUS_CHANNEL_PUBLISH_STATS}
+ *
  * @note Will return 0 if channel has not yet been published to.
  *
  * @param chan The channel's reference.
@@ -1071,6 +1085,8 @@ static inline uint32_t zbus_chan_pub_stats_count(const struct zbus_channel *chan
 
 /**
  * @brief Get the average period between publishes to a channel.
+ *
+ * @kconfig_dep{CONFIG_ZBUS_CHANNEL_PUBLISH_STATS}
  *
  * @note Will return 0 if channel has not yet been published to.
  *
@@ -1092,6 +1108,8 @@ static inline uint32_t zbus_chan_pub_stats_avg_period(const struct zbus_channel 
 
 /**
  * @brief Get the age of a message in a channel
+ *
+ * @kconfig_dep{CONFIG_ZBUS_CHANNEL_PUBLISH_STATS}
  *
  * @param chan The channel's reference.
  *
@@ -1120,6 +1138,7 @@ static inline void zbus_chan_pub_stats_update(const struct zbus_channel *chan)
 /**
  * @brief Structure used to register runtime observers
  *
+ * @kconfig_dep{CONFIG_ZBUS_RUNTIME_OBSERVERS}
  */
 struct zbus_observer_node {
 	sys_snode_t node;
@@ -1133,8 +1152,9 @@ struct zbus_observer_node {
 /**
  * @brief Add an observer to a channel.
  *
- * This routine adds an observer to the channel by providing an allocated node. This function is
- * only supported if the CONFIG_ZBUS_RUNTIME_OBSERVERS_NODE_ALLOC_NONE is enabled.
+ * This routine adds an observer to the channel by providing an allocated node.
+ *
+ * @kconfig_dep{CONFIG_ZBUS_RUNTIME_OBSERVERS}
  *
  * @param chan The channel's reference.
  * @param obs The observer's reference to be added.
@@ -1148,6 +1168,7 @@ struct zbus_observer_node {
  * @retval -EAGAIN Waiting period timed out.
  * @retval -EINVAL Some parameter is invalid.
  * @retval -EBUSY The node is already in use.
+ * @retval -ENOTSUP If @kconfig{CONFIG_ZBUS_RUNTIME_OBSERVERS_NODE_ALLOC_NONE} is not enabled.
  */
 int zbus_chan_add_obs_with_node(const struct zbus_channel *chan, const struct zbus_observer *obs,
 				struct zbus_observer_node *node, k_timeout_t timeout);
@@ -1169,10 +1190,9 @@ static inline int zbus_chan_add_obs_with_node(const struct zbus_channel *chan,
 /**
  * @brief Add an observer to a channel.
  *
- * This routine adds an observer to the channel in runtime. This function is only supported if the
- * CONFIG_ZBUS_RUNTIME_OBSERVERS_NODE_ALLOC_DYNAMIC or
- * CONFIG_ZBUS_RUNTIME_OBSERVERS_NODE_ALLOC_STATIC is enabled.
+ * This routine adds an observer to the channel in runtime.
  *
+ * @kconfig_dep{CONFIG_ZBUS_RUNTIME_OBSERVERS}
  *
  * @param chan The channel's reference.
  * @param obs The observer's reference to be added.
@@ -1185,6 +1205,7 @@ static inline int zbus_chan_add_obs_with_node(const struct zbus_channel *chan,
  * @retval -EEXIST The observer is already present in the channel's observers list.
  * @retval -EALREADY The observer is already present in the channel's runtime observers list.
  * @retval -ENOMEM No memory available for a new runtime observer node.
+ * @retval -ENOTSUP If @kconfig{CONFIG_ZBUS_RUNTIME_OBSERVERS_NODE_ALLOC_NONE} is enabled.
  */
 int zbus_chan_add_obs(const struct zbus_channel *chan, const struct zbus_observer *obs,
 		      k_timeout_t timeout);
@@ -1204,6 +1225,8 @@ static inline int zbus_chan_add_obs(const struct zbus_channel *chan,
  * @brief Remove an observer from a channel.
  *
  * This routine removes an observer to the channel.
+ *
+ * @kconfig_dep{CONFIG_ZBUS_RUNTIME_OBSERVERS}
  *
  * @param chan The channel's reference.
  * @param obs The observer's reference to be removed.
@@ -1294,6 +1317,8 @@ int zbus_obs_is_chan_notification_masked(const struct zbus_observer *obs,
  *
  * This routine returns the observer's name reference.
  *
+ * @kconfig_dep{CONFIG_ZBUS_OBSERVER_NAME}
+ *
  * @param obs The observer's reference.
  *
  * @return The observer's name reference.
@@ -1312,6 +1337,8 @@ static inline const char *zbus_obs_name(const struct zbus_observer *obs)
 /**
  * @brief Set the observer thread priority by attaching it to a thread.
  *
+ * @kconfig_dep{CONFIG_ZBUS_PRIORITY_BOOST}
+ *
  * @param[in] obs The observer's reference.
  *
  * @retval 0 Observer detached from the thread.
@@ -1322,6 +1349,8 @@ int zbus_obs_attach_to_thread(const struct zbus_observer *obs);
 
 /**
  * @brief Clear the observer thread priority by detaching it from a thread.
+ *
+ * @kconfig_dep{CONFIG_ZBUS_PRIORITY_BOOST}
  *
  * @param[in] obs The observer's reference.
  *
@@ -1360,6 +1389,8 @@ int zbus_sub_wait(const struct zbus_observer *sub, const struct zbus_channel **c
  * @brief Wait for a channel message.
  *
  * This routine makes the subscriber wait for the new message in case of channel publication.
+ *
+ * @kconfig_dep{CONFIG_ZBUS_MSG_SUBSCRIBER}
  *
  * @param[in] sub The subscriber's reference.
  * @param[out] chan The notification channel's reference.

--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -31,6 +31,8 @@ extern "C" {
  * Every channel has a zbus_channel_data structure associated.
  */
 struct zbus_channel_data {
+	/** @cond INTERNAL_HIDDEN */
+
 	/** Static channel observer list start index. Considering the ITERABLE SECTIONS allocation
 	 * order.
 	 */
@@ -73,6 +75,8 @@ struct zbus_channel_data {
 	/** Number of times data has been published to this channel */
 	uint32_t publish_count;
 #endif /* CONFIG_ZBUS_CHANNEL_PUBLISH_STATS */
+
+	/** @endcond */
 };
 
 /**
@@ -93,6 +97,7 @@ typedef bool (*zbus_validator)(const void *msg, size_t msg_size);
  * access and usage.
  */
 struct zbus_channel {
+	/** @cond INTERNAL_HIDDEN */
 #if defined(CONFIG_ZBUS_CHANNEL_NAME) || defined(__DOXYGEN__)
 	/** Channel name. */
 	const char *name;
@@ -122,6 +127,7 @@ struct zbus_channel {
 
 	/** Mutable channel data struct. */
 	struct zbus_channel_data *data;
+	/** @endcond */
 };
 
 /**
@@ -146,6 +152,7 @@ enum __packed zbus_observer_type {
 	ZBUS_OBSERVER_ASYNC_LISTENER_TYPE,
 };
 
+/** @cond INTERNAL_HIDDEN */
 struct zbus_observer_data {
 	/** Enabled flag. Indicates if observer is receiving notification. */
 	bool enabled;
@@ -155,6 +162,7 @@ struct zbus_observer_data {
 	int priority;
 #endif /* CONFIG_ZBUS_PRIORITY_BOOST */
 };
+/** @endcond */
 
 /**
  * @brief Type used to represent an observer.
@@ -172,6 +180,7 @@ struct zbus_observer_data {
  *
  */
 struct zbus_observer {
+	/** @cond INTERNAL_HIDDEN */
 #if defined(CONFIG_ZBUS_OBSERVER_NAME) || defined(__DOXYGEN__)
 	/** Observer name. */
 	const char *name;
@@ -203,6 +212,7 @@ struct zbus_observer {
 		struct k_work *work;
 #endif /* CONFIG_ZBUS_ASYNC_LISTENER */
 	};
+	/** @endcond */
 };
 
 /** @cond INTERNAL_HIDDEN */


### PR DESCRIPTION
Standardize how Kconfig-gated zbus APIs are documented, and stop exposing internal struct state in
the generated documentation.

**Annotate public APIs** — every Kconfig-gated zbus public function (and the proxy-agent / IPC
backend Doxygen groups) now carries the `@kconfig_dep{CONFIG_...}` alias, so availability is
documented uniformly instead of in ad-hoc prose. This includes the runtime-observer `add` /
`add_with_node` helpers, whose node-allocation-mode requirement is documented as an `-ENOTSUP`
`@retval` — both symbols always exist under `CONFIG_ZBUS_RUNTIME_OBSERVERS`, and the mode only
selects the real function vs an `-ENOTSUP` stub.

**Hide internal details** — the zbus structs are opaque from a user's standpoint (they only pass
pointers), so their fields are wrapped in `@cond INTERNAL_HIDDEN`, matching the convention used by
core kernel objects such as `struct k_timer`:
- `zbus_observer_data` is never exposed in any API, so the whole struct is hidden.
- `zbus_channel`, `zbus_observer` and `zbus_channel_data` stay documented but their fields are
  hidden (`zbus_channel_data` remains visible because it appears in the public
  `zbus_runtime_channel_init()` signature).

Supersedes #113575, which applied the alias to a first few symbols.

---

🤖 ✅ 👨 Developed with AI assistance (Claude Code—see the `Assisted-by:` trailers), reviewed and validated closely by me.