### PR TITLE
drivers: input: sdl: report mouse wheel and extra buttons

### DIFF
--- a/drivers/input/input_sdl_touch.c
+++ b/drivers/input/input_sdl_touch.c
@@ -26,6 +26,21 @@ static void sdl_input_callback(struct sdl_input_data *data)
 		input_report_abs(data->dev, INPUT_ABS_Y, data->y, false, K_FOREVER);
 		input_report_key(data->dev, INPUT_BTN_TOUCH, 1, true, K_FOREVER);
 	}
+
+	if (data->middle_pending) {
+		input_report_key(data->dev, INPUT_BTN_MIDDLE, data->middle, true, K_FOREVER);
+		data->middle_pending = false;
+	}
+
+	if (data->right_pending) {
+		input_report_key(data->dev, INPUT_BTN_RIGHT, data->right, true, K_FOREVER);
+		data->right_pending = false;
+	}
+
+	if (data->wheel != 0) {
+		input_report_rel(data->dev, INPUT_REL_WHEEL, data->wheel, true, K_FOREVER);
+		data->wheel = 0;
+	}
 }
 
 static int sdl_init(const struct device *dev)

--- a/drivers/input/input_sdl_touch_bottom.c
+++ b/drivers/input/input_sdl_touch_bottom.c
@@ -21,6 +21,8 @@ static bool event_targets_display(SDL_Event *event, struct sdl_input_data *data)
 		window = SDL_GetWindowFromID(event->button.windowID);
 	} else if (event->type == SDL_MOUSEMOTION) {
 		window = SDL_GetWindowFromID(event->motion.windowID);
+	} else if (event->type == SDL_MOUSEWHEEL) {
+		window = SDL_GetWindowFromID(event->wheel.windowID);
 	} else {
 		return false;
 	}
@@ -44,16 +46,38 @@ static int sdl_filter(void *arg, SDL_Event *event)
 	}
 
 	switch (event->type) {
-	case SDL_MOUSEBUTTONUP:
-		data->pressed = false;
-		data->just_released = true;
-		break;
 	case SDL_MOUSEBUTTONDOWN:
-		data->pressed = true;
+	case SDL_MOUSEBUTTONUP: {
+		bool down = (event->type == SDL_MOUSEBUTTONDOWN);
+
+		switch (event->button.button) {
+		case SDL_BUTTON_LEFT:
+			/* The left button emulates a touch/press. */
+			data->pressed = down;
+			if (!down) {
+				data->just_released = true;
+			}
+			break;
+		case SDL_BUTTON_MIDDLE:
+			data->middle = down;
+			data->middle_pending = true;
+			break;
+		case SDL_BUTTON_RIGHT:
+			data->right = down;
+			data->right_pending = true;
+			break;
+		default:
+			/* Ignore additional buttons (e.g. X1/X2). */
+			return 1;
+		}
 		break;
+	}
 	case SDL_MOUSEMOTION:
 		data->x = event->button.x;
 		data->y = event->button.y;
+		break;
+	case SDL_MOUSEWHEEL:
+		data->wheel = event->wheel.y;
 		break;
 	default:
 		return 1;

--- a/drivers/input/input_sdl_touch_bottom.h
+++ b/drivers/input/input_sdl_touch_bottom.h
@@ -26,8 +26,13 @@ struct sdl_input_data {
 	void (*callback)(struct sdl_input_data *data);
 	int x;
 	int y;
+	int wheel;
 	bool pressed;
 	bool just_released;
+	bool middle;
+	bool middle_pending;
+	bool right;
+	bool right_pending;
 };
 
 void sdl_input_init_bottom(struct sdl_input_data *data);

--- a/samples/modules/lvgl/demos/Kconfig
+++ b/samples/modules/lvgl/demos/Kconfig
@@ -72,4 +72,7 @@ config LV_Z_DEMO_RENDER_DYNAMIC_SCENE_TIMEOUT
 
 endif
 
+configdefault LV_Z_POINTER_FROM_CHOSEN_TOUCH
+	default n if LV_Z_DEMO_KEYPAD_AND_ENCODER
+
 source "Kconfig.zephyr"

--- a/samples/modules/lvgl/demos/Kconfig
+++ b/samples/modules/lvgl/demos/Kconfig
@@ -75,4 +75,7 @@ endif
 configdefault CPU_LOAD
 	default y if LV_USE_PERF_MONITOR
 
+configdefault LV_Z_POINTER_FROM_CHOSEN_TOUCH
+	default n if LV_Z_DEMO_KEYPAD_AND_ENCODER
+
 source "Kconfig.zephyr"

--- a/samples/modules/lvgl/demos/README.rst
+++ b/samples/modules/lvgl/demos/README.rst
@@ -30,7 +30,20 @@ Requirements
 * A board with display, ideally with 480x272 resolution or higher.
 * A pointer input device: touchpad, mouse, or touch screen capable display, compatible with :dtcompatible:`zephyr,lvgl-pointer-input`.
 
-Note that other input devices types are not demonstrated in these demos, namely keyboards, keypads (:dtcompatible:`zephyr,lvgl-keypad-input`), rotary encoders (:dtcompatible:`zephyr,lvgl-encoder-input`) and hardware buttons (:dtcompatible:`zephyr,lvgl-button-input`).
+Note that other input devices types are not demonstrated in these demos, namely keyboards, keypads (:dtcompatible:`zephyr,lvgl-keypad-input`) and hardware buttons (:dtcompatible:`zephyr,lvgl-button-input`).
+
+Keypad and Encoder demo on native_sim
+*************************************
+
+On :zephyr:board:`native_sim` the Keypad and Encoder demo is driven by a rotary
+encoder (:dtcompatible:`zephyr,lvgl-encoder-input`) emulated with the SDL mouse:
+the mouse wheel rotates the encoder and the middle button (wheel-click) acts as
+ENTER. No extra hardware is required.
+
+Since this demo is meant to be navigated with the encoder, the LVGL pointer that
+is otherwise derived from the ``zephyr,touch`` chosen device is disabled for it,
+so that pointer clicks do not short-circuit the encoder navigation. The other
+demos keep their pointer.
 
 Building and Running
 ********************

--- a/samples/modules/lvgl/demos/boards/native_sim.overlay
+++ b/samples/modules/lvgl/demos/boards/native_sim.overlay
@@ -3,9 +3,19 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 &sdl_dc {
 	compatible = "zephyr,sdl-dc";
 	height = <272>;
 	width = <480>;
+};
+
+/ {
+	lvgl_encoder: lvgl_encoder {
+		compatible = "zephyr,lvgl-encoder-input";
+		input = <&input_sdl_touch>;
+		rotation-input-code = <INPUT_REL_WHEEL>;
+		button-input-code = <INPUT_BTN_MIDDLE>;
+	};
 };


### PR DESCRIPTION
## Summary

The `input_sdl_touch` driver only reported the primary mouse button (as
`INPUT_BTN_TOUCH`) and pointer motion. The mouse wheel and the middle/right
buttons were silently dropped, so there was no way to drive a scroll/rotation
input source — such as an LVGL **encoder** input device — from the SDL
simulator. As a result the LVGL *keypad and encoder* demo was not navigable on
`native_sim`.

This series adds mouse-wheel and extra-button reporting to the driver, and
wires up the demo so the encoder can be exercised on `native_sim` with no extra
hardware.

## Changes

**1. `drivers: input: sdl: report mouse wheel and extra buttons`**
- Report `SDL_MOUSEWHEEL` as a relative `INPUT_REL_WHEEL` event.
- Report the middle and right mouse buttons as `INPUT_BTN_MIDDLE` /
  `INPUT_BTN_RIGHT`.
- The left button keeps its existing `INPUT_BTN_TOUCH` behaviour, so the
  touch/pointer path is unchanged.

**2. `samples: modules: lvgl: run the keypad/encoder demo on native_sim`**
- Add a `zephyr,lvgl-encoder-input` node to the sample's `native_sim` overlay,
  fed by `input_sdl_touch`: the wheel rotates the encoder and the middle button
  (wheel-click) acts as `ENTER`.
- Disable the pointer derived from the `zephyr,touch` chosen device *for this
  demo only* (via `configdefault`), so pointer clicks don't short-circuit the
  encoder navigation. Other demos keep their pointer.

## Behaviour change (please review)

Previously **any** mouse button was reported as `INPUT_BTN_TOUCH`. Now only the
**left** button maps to `INPUT_BTN_TOUCH`; middle/right map to their own codes.
This makes a right/middle click no longer register as a touch. That matches the
usual "left button = touch" expectation and is what makes a distinct encoder
button possible, but it is a change for anyone relying on the previous
all-buttons-are-touch behaviour.

## Testing

Built and run on `native_sim/native/64` with SDL:

- `keypad_and_encoder` demo: two-finger swipe (→ `MOUSEWHEEL` → `INPUT_REL_WHEEL`)
  rotates encoder focus; middle button — via a mouse wheel-click, or a
  three-finger trackpad tap (→ `button=2`) — fires `INPUT_BTN_MIDDLE` → encoder
  `ENTER`; the pointer is disabled for this demo. Verified with event traces at
  the SDL, `input`, and LVGL layers.
- `widgets` demo: pointer remains enabled (`CONFIG_LV_Z_POINTER_FROM_CHOSEN_TOUCH=y`),
  single-finger click works as before; the `configdefault` override is confirmed
  to apply only to the keypad/encoder demo.

## Notes / limitations

- The keypad half of the demo is still not drivable on `native_sim`: there is no
  SDL keyboard → `input` driver, so no keypad input device exists there. This
  series only addresses the encoder.
- The encoder input node lives in the shared `native_sim.overlay`, so an
  (unused, unbound) encoder indev is also created for the other demos. It is
  inert there — no demo other than keypad/encoder binds a group to it — but you may prefer a different scoping (e.g. a snippet)
