### PR TITLE
scripts: west_commands: packages: add uv subcommand

### DIFF
--- a/scripts/utils/west-packages-uv-install.cmd
+++ b/scripts/utils/west-packages-uv-install.cmd
@@ -1,0 +1,27 @@
+:: SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+:: SPDX-License-Identifier: Apache-2.0
+
+@echo off
+rem Collect packages from west and install them with a single uv call.
+setlocal enabledelayedexpansion
+
+set "PACKAGES="
+
+for /f "usebackq delims=" %%p in (`west packages uv`) do (
+	if defined PACKAGES (
+		set "PACKAGES=!PACKAGES! %%p"
+	) else (
+		set "PACKAGES=%%p"
+	)
+)
+
+if not defined PACKAGES (
+	echo west packages uv returned no packages to install.
+	exit /b 0
+)
+
+echo Installing packages with: uv.exe pip install %PACKAGES%
+uv.exe pip install %PACKAGES%
+set "RESULT=%ERRORLEVEL%"
+
+endlocal & exit /b %RESULT%

--- a/scripts/west_commands/packages.py
+++ b/scripts/west_commands/packages.py
@@ -5,6 +5,7 @@
 import argparse
 import os
 import platform
+import shutil
 import subprocess
 import sys
 import textwrap
@@ -105,6 +106,44 @@ class Packages(WestCommand):
             "in a CI environment where the virtual environment is not set up.",
         )
 
+        uv_parser = subparsers_gen.add_parser(
+            "uv",
+            help="manage packages with uv",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=textwrap.dedent(
+                """
+            Manage packages with uv:
+
+                Run 'west packages uv' to print all requirement and override
+                files needed by Zephyr and modules, formatted for use with
+                'uv pip install'.
+
+                Requirement files are taken from the 'pip' package-managers
+                section, and override files from the 'uv' package-managers
+                section, of a module's 'zephyr/module.yml'. Override files
+                are emitted as '--override <file>' entries.
+            """
+            ),
+        )
+
+        uv_parser.add_argument(
+            "--install",
+            action="store_true",
+            help="Install packages using uv instead of listing them. "
+            "A single 'uv pip install' command is built and executed. "
+            "Additional uv arguments can be passed after a -- separator "
+            "from the original 'west packages uv --install' command. For example pass "
+            "'--dry-run' to uv not to actually install anything, but print what would be.",
+        )
+
+        uv_parser.add_argument(
+            "--ignore-venv-check",
+            action="store_true",
+            help="Ignore the virtual environment check. "
+            "This is useful when running 'west packages uv --install' "
+            "in a CI environment where the virtual environment is not set up.",
+        )
+
         return parser
 
     def do_run(self, args, unknown):
@@ -130,74 +169,130 @@ class Packages(WestCommand):
         if args.manager == "pip":
             return self.do_run_pip(args, unknown[1:])
 
+        if args.manager == "uv":
+            return self.do_run_uv(args, unknown[1:])
+
         # Unreachable but print an error message if an implementation is missing.
         self.die(f'Unsupported package manager: "{args.manager}"')
 
-    def do_run_pip(self, args, manager_args):
+    def collect_files(self, args):
         requirements = []
+        overrides = []
 
         if not args.modules or "zephyr" in args.modules:
             requirements.append(ZEPHYR_BASE / "scripts/requirements.txt")
 
         for module in self.zephyr_modules:
-            module_name = module.meta.get("name")
-            if args.modules and module_name not in args.modules:
-                if args.install:
-                    self.dbg(f"Skipping module {module_name}")
-                continue
+            module_requirements, module_overrides = self.collect_module_files(module, args)
+            requirements += module_requirements
+            overrides += module_overrides
 
-            # Get the optional pip section from the package managers
-            pip = module.meta.get("package-managers", {}).get("pip")
-            if pip is None:
-                if args.install:
-                    self.dbg(f"Nothing to install for {module_name}")
-                continue
+        return requirements, overrides
 
-            # Add requirements files
-            requirements += [Path(module.project) / r for r in pip.get("requirement-files", [])]
+    def collect_module_files(self, module, args):
+        module_name = module.meta.get("name")
+        if args.modules and module_name not in args.modules:
+            if args.install:
+                self.dbg(f"Skipping module {module_name}")
+            return [], []
+
+        # Get the optional pip and uv sections from the package managers
+        package_managers = module.meta.get("package-managers", {})
+        pip = package_managers.get("pip")
+        uv = package_managers.get("uv")
+        if pip is None and uv is None:
+            if args.install:
+                self.dbg(f"Nothing to install for {module_name}")
+            return [], []
+
+        # Requirements files are declared under the pip section
+        requirements = []
+        if pip is not None:
+            requirements = [Path(module.project) / r for r in pip.get("requirement-files", [])]
+
+        # Override files are declared under the uv section
+        overrides = []
+        if uv is not None:
+            overrides = [Path(module.project) / o for o in uv.get("override-files", [])]
+
+        return requirements, overrides
+
+    def do_install(self, base_cmd, requirement_args, extra_args, manager, cmdscript_name):
+        if shutil.which(base_cmd[0]) is None:
+            self.die(f'"{base_cmd[0]}" not found; is it installed and on PATH?')
+
+        cmd = list(base_cmd)
+        cmd += requirement_args
+        cmd += extra_args
+        self.dbg(quote_sh_list(cmd))
+
+        # Use os.execvp to execute a new program, replacing the current west process,
+        # this unloads all python modules first and allows the manager to update packages safely
+        if platform.system() != 'Windows':
+            os.execvp(cmd[0], cmd)
+
+        # Only reachable on Windows systems
+        # Windows does not really support os.execv:
+        # https://github.com/python/cpython/issues/63323
+        # https://github.com/python/cpython/issues/101191
+        # Warn the users about permission errors as those reported in:
+        # https://github.com/zephyrproject-rtos/zephyr/issues/100296
+        cmdscript = PureWindowsPath(__file__).parents[1] / "utils" / cmdscript_name
+        self.wrn(
+            f"Updating packages on Windows with 'west packages {manager} --install', that are "
+            "currently in use by west, results in permission errors. Leaving your "
+            "environment with conflicting package versions. Recommended is to start with "
+            "a new environment in that case.\n\n"
+            "To avoid this using powershell run the following command instead:\n"
+            f"{quote_sh_list(base_cmd)} @((west packages {manager}) -split ' ')\n\n"
+            "Using cmd.exe execute the helper script:\n"
+            f"cmd /c {cmdscript}\n\n"
+            f"Running 'west packages {manager} --install -- --dry-run' can provide information "
+            "without actually updating the environment."
+        )
+        subprocess.check_call(cmd)
+
+    def do_run_pip(self, args, pip_args):
+        requirements, _ = self.collect_files(args)
 
         if args.install:
             if not in_venv() and not args.ignore_venv_check:
                 self.die("Running pip install outside of a virtual environment")
 
             if len(requirements) > 0:
-                cmd = [sys.executable, "-m", "pip", "install"]
-                cmd += chain.from_iterable([("-r", str(r)) for r in requirements])
-                cmd += manager_args
-                self.dbg(quote_sh_list(cmd))
-
-                # Use os.execv to execute a new program, replacing the current west process,
-                # this unloads all python modules first and allows for pip to update packages safely
-                if platform.system() != 'Windows':
-                    os.execv(cmd[0], cmd)
-
-                # Only reachable on Windows systems
-                # Windows does not really support os.execv:
-                # https://github.com/python/cpython/issues/63323
-                # https://github.com/python/cpython/issues/101191
-                # Warn the users about permission errors as those reported in:
-                # https://github.com/zephyrproject-rtos/zephyr/issues/100296
-                cmdscript = (
-                    PureWindowsPath(__file__).parents[1] / "utils" / "west-packages-pip-install.cmd"
+                requirement_args = list(chain.from_iterable(("-r", str(r)) for r in requirements))
+                self.do_install(
+                    [sys.executable, "-m", "pip", "install"],
+                    requirement_args,
+                    pip_args,
+                    "pip",
+                    "west-packages-pip-install.cmd",
                 )
-                self.wrn(
-                    "Updating packages on Windows with 'west packages pip --install', that are "
-                    "currently in use by west, results in permission errors. Leaving your "
-                    "environment with conflicting package versions. Recommended is to start with "
-                    "a new environment in that case.\n\n"
-                    "To avoid this using powershell run the following command instead:\n"
-                    f"{sys.executable} -m pip install @((west packages pip) -split ' ')\n\n"
-                    "Using cmd.exe execute the helper script:\n"
-                    f"cmd /c {cmdscript}\n\n"
-                    "Running 'west packages pip --install -- --dry-run' can provide information "
-                    "without actually updating the environment."
-                )
-                subprocess.check_call(cmd)
             else:
                 self.inf("Nothing to install")
             return
 
-        if len(manager_args) > 0:
-            self.die(f'west packages pip does not support unknown arguments: "{manager_args}"')
-
         self.inf("\n".join([f"-r {r}" for r in requirements]))
+
+    def do_run_uv(self, args, uv_args):
+        requirements, overrides = self.collect_files(args)
+
+        if args.install:
+            if len(requirements) > 0:
+                requirement_args = list(chain.from_iterable(("-r", str(r)) for r in requirements))
+                requirement_args += list(
+                    chain.from_iterable(("--override", str(o)) for o in overrides)
+                )
+                self.do_install(
+                    ["uv", "pip", "install"],
+                    requirement_args,
+                    uv_args,
+                    "uv",
+                    "west-packages-uv-install.cmd",
+                )
+            else:
+                self.inf("Nothing to install")
+            return
+
+        lines = [f"-r {r}" for r in requirements] + [f"--override {o}" for o in overrides]
+        self.inf("\n".join(lines))

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -155,6 +155,13 @@ properties:
             type: array
             items:
               type: string
+      uv:
+        type: object
+        properties:
+          override-files:
+            type: array
+            items:
+              type: string
   runners:
     type: array
     items:


### PR DESCRIPTION
## Description

Add a `west packages uv` subcommand, analog to existing `west packages pip`. 
It considers all requirement files declared in `zephyr/module.yml` section `package-managers.pip`, plus it allows additional override-files (which are only supported by `uv`) declared under section `package-managers.uv.override-files`.
By default the command prints the arguments for `uv pip install` (`-r <file>` / `--override <file>`).

Analog to `west packages pip`, passing `--install` runs `uv pip install` directly instead of just printing the arguments.

Note: `uv` reuses `pip.requirement-files` to avoid duplications for pip and uv.

```
package-managers:
  pip:
    requirement-files:
      - zephyr/requirements.txt
  uv:
    override-files:
      - zephyr/overrides.txt
```


## Use Case

Dependency conflicts across various modules can currently only be worked around by patching `requirements.txt` files or not running `west packages pip --install` at all, since `pip` has no built-in way to force a specific version when two requirement files disagree. 
Luckily `uv` solves this natively via its `--override` argument, which lets a higher-priority constraint file win regardless of what individual requirement files ask for.

This is especially useful for out-of-tree modules: 
a zephyr module might pin a package to a version that differs from what another requirement file specifies (e.g. if an old version is pinned).
Today there is no clean way to solve that. I believe @pdgendt knows this issue as we had run into this few months ago (codechecker).

The new `west packages uv` exposes this mechanism to downstream projects the same way `requirement-files` already works for `pip`: modules declare `override-files` in `zephyr/module.yml`, and `west` aggregates them across Zephyr
and all modules into a single `uv pip install` invocation.

