### PR TITLE
soc: nordic: nrf71: don't auto-boot Wi-Fi core by default

### DIFF
--- a/soc/nordic/nrf71/Kconfig
+++ b/soc/nordic/nrf71/Kconfig
@@ -35,11 +35,14 @@ config SOC_NRF71_WIFI_DAP
 
 config SOC_NRF71_WIFI_BOOT
 	bool "nRF71 start Wi-Fi on system initialization"
-	default y if !BUILD_WITH_TFM
 	help
 	  This controls whether the Wi-Fi core is started on system initialization. If
 	  disabled, the Wi-Fi core must be started by the application before it can be
 	  used.
+
+	  A booted Wi-Fi core is only useful together with a Wi-Fi driver, so this is
+	  disabled by default and must be enabled explicitly, either by the driver
+	  that owns the core or by the application.
 
 config SOC_NRF7120_TFM_MRAMC_SERVICE
 	bool "TF-M MRAMC service"


### PR DESCRIPTION
## Description

On the nRF71, the SoC layer kickstarts the Wi-Fi core (LMAC, which in
turn boots UMAC) from `soc_early_init_hook()` when
`SOC_NRF71_WIFI_BOOT` is set. Until now this symbol defaulted to `y` on
non-TF-M builds, so the Wi-Fi core was powered on and started
unconditionally — even on images that contain no Wi-Fi driver.

A booted Wi-Fi core is useless without a driver to own and talk to it,
and no such driver exists in upstream Zephyr. Powering it on regardless
just wastes power and leaves the core running with nothing driving it.

This inverts the control:

- `SOC_NRF71_WIFI_BOOT` is left disabled by default and becomes a
  passive capability.
- It is expected to be enabled explicitly — by the driver that owns the
  core (via `select`) or by an application that manages the core itself.

As a result the Wi-Fi core is booted if and only if something that can
actually use it is present. A pure-Zephyr build has no nRF71 Wi-Fi
driver, so defaulting the boot off is the correct behaviour and loses
nothing; applications that drove the core manually can still set the
option explicitly.

## Testing

- Wi-Fi scan verified working with the option enabled.
- With the option disabled, confirmed via the generated `.config` that
  `SOC_NRF71_WIFI_BOOT` is not set and the boot path is compiled out.
