### PR TITLE
drivers: usb: udc: stm32: recover isochronous OUT on incomplete transfer

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -614,6 +614,52 @@ void HAL_PCD_DataOutStageCallback(stm32_pcd_handle_t *hpcd, uint8_t epnum)
 	}
 }
 
+/*
+ * Isochronous OUT "incomplete transfer" recovery.
+ *
+ * When an isochronous OUT endpoint misses its (micro)frame (e.g. the re-arm
+ * landed a frame late, so the host's token found the endpoint armed for the
+ * wrong even/odd frame), the OTG core drops the packet, raises the
+ * incomplete-iso interrupt and disables the endpoint. The HAL then calls this
+ * callback from the ISR. We re-arm the pending receive here: HAL_PCD_EP_Receive
+ * re-selects the correct even/odd frame at arm time, resynchronising the
+ * endpoint.
+ *
+ * Without this, iso OUT reception (e.g. UAC2 host-to-device playback) stalls
+ * permanently after the first missed frame. Isochronous IN (e.g. a UAC2
+ * microphone) degrades gracefully, so it keeps working without an equivalent
+ * IN handler; recovering iso IN correctly has to go through the normal
+ * data-in completion path and is left as a follow-up.
+ */
+void HAL_PCD_ISOOUTIncompleteCallback(stm32_pcd_handle_t *hpcd, uint8_t epnum)
+{
+	struct udc_stm32_data *priv = hpcd2data(hpcd);
+	uint8_t ep = epnum | USB_EP_DIR_OUT;
+	struct udc_ep_config *ep_cfg;
+	struct net_buf *buf;
+	stm32_status_t status;
+
+	ep_cfg = udc_get_ep_cfg(priv->dev, ep);
+	if (ep_cfg == NULL) {
+		return;
+	}
+
+	buf = udc_buf_peek(ep_cfg);
+	if (buf == NULL) {
+		return;
+	}
+
+	/* The pending buffer has not been filled yet (tail == data,
+	 * tailroom == size); use the net_buf accessors to re-arm into the free
+	 * space, matching the normal OUT receive path.
+	 */
+	status = hal_udc_set_endpoint_receive(&priv->pcd, ep, net_buf_tail(buf),
+					      net_buf_tailroom(buf));
+	if (status != HAL_OK) {
+		LOG_ERR("iso OUT re-arm failed(0x%02x), %d", ep, (int)status);
+	}
+}
+
 static void handle_msg_data_out(struct udc_stm32_data *priv, uint8_t epnum, uint16_t rx_count)
 {
 	const struct device *dev = priv->dev;

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -621,6 +621,53 @@ void HAL_PCD_DataOutStageCallback(stm32_pcd_handle_t *hpcd, uint8_t epnum)
 	}
 }
 
+void HAL_PCD_ISOOUTIncompleteCallback(stm32_pcd_handle_t *hpcd, uint8_t epnum)
+{
+	struct udc_stm32_data *priv = hpcd2data(hpcd);
+	uint8_t ep = epnum | USB_EP_DIR_OUT;
+	struct udc_ep_config *ep_cfg;
+	struct net_buf *buf;
+	stm32_status_t status;
+
+	ep_cfg = udc_get_ep_cfg(priv->dev, ep);
+	if (ep_cfg == NULL) {
+		return;
+	}
+
+	buf = udc_buf_peek(ep_cfg);
+	if (buf == NULL) {
+		return;
+	}
+
+	/* When an incomplete ISO OUT transfer occurs, the endpoint is disabled.
+	 * Re-enable the endpoint to allow reception in the remaining free space
+	 * of the buffer. HAL_PCD_DataOutStageCallback() will be called as usual
+	 * when the buffer is eventually filled.
+	 */
+	status = hal_udc_set_endpoint_receive(&priv->pcd, ep, net_buf_tail(buf),
+					      net_buf_tailroom(buf));
+	if (status != HAL_OK) {
+		LOG_ERR("ISO OUT re-enable failed(0x%02x), %d", ep, (int)status);
+	}
+}
+
+void HAL_PCD_ISOINIncompleteCallback(stm32_pcd_handle_t *hpcd, uint8_t epnum)
+{
+	ARG_UNUSED(hpcd);
+	ARG_UNUSED(epnum);
+
+	/* Recovering isochronous IN after an incomplete transfer is a TODO. It
+	 * keeps working today because iso IN is completion-driven: every
+	 * transmitted frame yields a DataInStageCallback that arms the next queued
+	 * buffer, so a missed frame only drops that one packet. Iso OUT gets no
+	 * such completion on a miss (the core disables the endpoint and nothing
+	 * re-arms it), which is why only OUT wedges. A proper IN fix cannot re-arm
+	 * here either: udc_stm32_tx() has already advanced the pending buffer's
+	 * data/len, so it must go through the normal data-in completion path (drop
+	 * the missed frame and arm the next one).
+	 */
+}
+
 static void handle_msg_data_out(struct udc_stm32_data *priv, uint8_t epnum, uint16_t rx_count)
 {
 	const struct device *dev = priv->dev;


### PR DESCRIPTION
### Summary

`udc_stm32.c` never implemented the HAL isochronous *incomplete transfer* callback, so an isochronous endpoint that misses a (micro)frame is disabled by the OTG core and never re-armed. In practice this breaks isochronous **OUT** reception permanently after the first missed frame: a UAC2 host-to-device (playback) stream delivers a few zero-length packets and then goes idle, with the application seeing `data_recv` with `size == 0`. Isochronous IN (e.g. a UAC2 microphone) degrades gracefully, so only the OUT/playback direction was visibly broken.

### Fix

Implement `HAL_PCD_ISOOUTIncompleteCallback()` to re-arm the pending receive via `HAL_PCD_EP_Receive()`, which re-selects the correct even/odd frame parity at arm time and resynchronises the endpoint. The buffer is re-armed with `net_buf_tail()`/`net_buf_tailroom()` (matching the normal OUT receive path), and a failed re-arm is logged. The incomplete-iso interrupts are already enabled by the HAL (`GINTMSK` `IISOIXFRM | PXFRM_IISOOXFRM`).

Isochronous **IN** recovery is intentionally left out of this change: on an IN-incomplete the pending buffer has already been consumed by `udc_stm32_tx()` (`buf->data`/`buf->len` advanced), so it cannot simply be re-armed — a correct fix has to go through the normal data-in completion path (drop the missed frame's buffer and arm the next one). Since iso IN degrades gracefully, that is deferred to a follow-up.

### Testing

Verified on an STM32U575 (OTG-FS) UAC2 + CDC-ACM + DFU composite device with a Linux host: host playback now streams into the peripheral continuously and reaches the DAC, instead of stalling after ~4 frames. UAC2 capture (microphone) keeps working. `scripts/checkpatch.pl` clean.

### Related

Related to #102720 (STM32 UDC UAC2 explicit-feedback playback broken) — this addresses the isochronous re-arm gap that manifests as the OUT/playback stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)