### PR TITLE
tests: kernel: split overloaded test cases into focused ones

### DIFF
--- a/tests/kernel/common/src/clock.c
+++ b/tests/kernel/common/src/clock.c
@@ -47,26 +47,23 @@ static ZTEST_BMEM struct timer_data tdata;
  *
  * @details
  * Passing proves the system uptime clock is a forward-progressing time source
- * usable from user mode: both the 64-bit and lower-32-bit uptime readings
- * increase as wall time elapses, the 32-bit reading observes a millisecond
- * boundary crossing, and k_uptime_delta() reports a non-zero elapsed interval
- * between successive calls.
+ * usable from user mode: both the 64-bit and lower-32-bit millisecond uptime
+ * readings increase as wall time elapses and the 32-bit reading observes a
+ * millisecond boundary crossing.
  *
  * Test steps:
  * - Spin until k_uptime_get() advances by at least 5 ms.
  * - Spin until k_uptime_get_32() advances by at least 5 ms.
  * - Sample the 32-bit uptime, align to a millisecond boundary, and confirm it grew.
- * - Seed a delta reference, then spin until k_uptime_delta() returns non-zero.
  *
  * Expected result:
- * - Uptime readings increase over time and k_uptime_delta() reports elapsed time.
+ * - The millisecond uptime readings increase over time.
  *
- * @see k_uptime_get(), k_uptime_get_32(), k_uptime_delta()
+ * @see k_uptime_get(), k_uptime_get_32()
  */
 ZTEST_USER(clock, test_clock_uptime)
 {
 	uint64_t t64, t32;
-	int64_t d64 = 0;
 
 	/**TESTPOINT: uptime elapse*/
 	t64 = k_uptime_get();
@@ -84,6 +81,90 @@ ZTEST_USER(clock, test_clock_uptime)
 	t32 = k_uptime_get_32();
 	ALIGN_MS_BOUNDARY;
 	zassert_true(k_uptime_get_32() > t32);
+}
+
+/**
+ * @brief Verify the system uptime is reported in system ticks.
+ *
+ * @ingroup kernel_clock_tests
+ *
+ * @details
+ * Passing proves k_uptime_ticks() is a forward-progressing reading of the
+ * system uptime in ticks, usable from user mode.
+ *
+ * Test steps:
+ * - Sample k_uptime_ticks() and spin until it advances.
+ *
+ * Expected result:
+ * - The tick reading increases as wall time elapses.
+ *
+ * @see k_uptime_ticks()
+ */
+ZTEST_USER(clock, test_clock_uptime_ticks)
+{
+	int64_t ticks = k_uptime_ticks();
+
+	/**TESTPOINT: uptime in system ticks advances*/
+	while (k_uptime_ticks() <= ticks) {
+		Z_SPIN_DELAY(50);
+	}
+}
+
+/**
+ * @brief Verify the system uptime is reported in whole seconds.
+ *
+ * @ingroup kernel_clock_tests
+ *
+ * @details
+ * Passing proves k_uptime_seconds() reports the uptime in seconds
+ * consistently with the millisecond uptime clock: the value equals the
+ * floor of the millisecond reading converted to seconds.
+ *
+ * Test steps:
+ * - Sample k_uptime_seconds() between two k_uptime_get() readings.
+ * - Check the seconds value against the floor of both millisecond readings.
+ *
+ * Expected result:
+ * - The seconds reading is bounded by the floors of the surrounding
+ *   millisecond readings.
+ *
+ * @see k_uptime_seconds()
+ */
+ZTEST_USER(clock, test_clock_uptime_seconds)
+{
+	/**TESTPOINT: uptime in seconds is consistent with the millisecond reading*/
+	uint64_t ms_before = k_uptime_get();
+	uint32_t secs = k_uptime_seconds();
+	uint64_t ms_after = k_uptime_get();
+
+	zassert_true(secs >= (ms_before / MSEC_PER_SEC),
+		     "uptime seconds %u below floor of %llu ms", secs, ms_before);
+	zassert_true(secs <= (ms_after / MSEC_PER_SEC),
+		     "uptime seconds %u above floor of %llu ms", secs, ms_after);
+}
+
+/**
+ * @brief Verify elapsed time reporting relative to a reference.
+ *
+ * @ingroup kernel_clock_tests
+ *
+ * @details
+ * Passing proves k_uptime_delta() measures the time elapsed since a
+ * caller-held reference time and updates the reference for the next
+ * measurement.
+ *
+ * Test steps:
+ * - Seed a delta reference, then spin until k_uptime_delta() returns a
+ *   non-zero elapsed time.
+ *
+ * Expected result:
+ * - k_uptime_delta() reports a non-zero interval once time has elapsed.
+ *
+ * @see k_uptime_delta()
+ */
+ZTEST_USER(clock, test_clock_uptime_delta)
+{
+	int64_t d64 = 0;
 
 	/**TESTPOINT: uptime delta*/
 	d64 = k_uptime_delta(&d64);

--- a/tests/kernel/events/event_api/src/main.c
+++ b/tests/kernel/events/event_api/src/main.c
@@ -47,7 +47,7 @@ static K_THREAD_STACK_DEFINE(sextra2, STACK_SIZE);
 
 static K_EVENT_DEFINE(test_event);
 static K_EVENT_DEFINE(sync_event);
-static struct k_event deliver_event;
+static K_EVENT_DEFINE(deliver_event);
 static K_EVENT_DEFINE(clear_event);
 
 static K_SEM_DEFINE(receiver_sem, 0, 1);
@@ -206,13 +206,16 @@ static void reset_on_wait(void)
 }
 
 /**
- * receiver helper task
+ * receiver helper task entry points, one per test scenario
  */
 
-static void receiver(void *p1, void *p2, void *p3)
+static void receiver_existing(void *p1, void *p2, void *p3)
 {
 	receive_existing_events();
+}
 
+static void receiver_reset(void *p1, void *p2, void *p3)
+{
 	reset_on_wait();
 }
 
@@ -221,7 +224,7 @@ static void receiver(void *p1, void *p2, void *p3)
  * when some events have already been sent. No additional events are sent
  * to the event object during this block of testing.
  */
-static void test_receive_existing_events(void)
+static void drive_receive_existing_events(void)
 {
 	int  rv;
 
@@ -291,7 +294,7 @@ static void test_receive_existing_events(void)
  * event object are reset at the appropriate time.
  */
 
-static void test_reset_on_wait(void)
+static void drive_reset_on_wait(void)
 {
 	int  rv;
 
@@ -348,73 +351,42 @@ static void test_reset_on_wait(void)
 	zassert_true(test_event.events  == 0x123456);
 
 	k_event_set(&test_event, 0x0);  /* Reset events */
-	k_sem_give(&sync_sem);
-}
-
-void test_wake_multiple_threads(void)
-{
-	uint32_t  events;
-
-	/*
-	 * The extra threads are expected to be waiting on <sync_event>
-	 * Wake them both up.
-	 */
-
-	k_event_set(&sync_event, 0xfff);
-
-	/*
-	 * The extra threads send back the events they received. Wait
-	 * for all of them.
-	 */
-
-	events = k_event_wait_all(&test_event, 0x333, false, SHORT_TIMEOUT);
-
-	zassert_true(events == 0x333);
 }
 
 /**
- * @brief Verify event posting and clearing primitives update stored events.
+ * @brief Verify k_event_post() ORs new events into the stored set.
  *
  * @details
- * Exercises the value-manipulation event system calls without any waking or
- * blocking, validating both the resulting set of posted events and the
- * previous value each call returns. Runs as a user-mode test so the event
- * system calls are also exercised from an unprivileged thread.
+ * Exercises the posting system call without any waking or blocking,
+ * validating both the resulting set of posted events and the previous
+ * value each call returns. Runs as a user-mode test so the post system
+ * call is also exercised from an unprivileged thread.
  *
  * Test steps:
- * - Initialize an event object and confirm it holds no events.
- * - Post events and verify k_event_post() returns the prior set and ORs in
- *   the new bits.
- * - Overwrite events with k_event_set() and verify it returns the prior set.
- * - Use k_event_set_masked() to selectively set/clear bits and verify only
- *   the masked bits change while the returned value reports their prior state.
- *
- * Expected result:
- * - After each call the stored events (read via k_event_test()) match the
- *   expected value, and each call returns the previous state of the affected
+ * - Empty the event object and confirm it holds no events.
+ * - Post a first set of events and verify it is stored verbatim and that
+ *   the call reports no prior events.
+ * - Post an overlapping second set and verify the new bits are ORed into
+ *   the stored set while the call returns the prior state of the posted
  *   bits.
  *
+ * Expected result:
+ * - After each call the stored events (read via k_event_test()) are the
+ *   union of everything posted so far, and each call returns the previous
+ *   state of the affected bits.
+ *
  * @see k_event_post()
- * @see k_event_set()
- * @see k_event_set_masked()
  * @see k_event_test()
  */
-
-ZTEST_USER(events_api, test_event_deliver)
+ZTEST_USER(events_api, test_event_post)
 {
 	struct k_event *event = &deliver_event;
 	uint32_t  events;
-	uint32_t  events_mask;
 	uint32_t  previous;
 
-	k_event_init(event);
+	(void)k_event_set(event, 0);
 
 	zassert_equal(k_event_test(event, ~0), 0);
-
-	/*
-	 * Verify k_event_post()  and k_event_set() update the
-	 * events stored in the event object as expected.
-	 */
 
 	events = 0xAAAA;
 	previous = k_event_post(event, events);
@@ -425,16 +397,80 @@ ZTEST_USER(events_api, test_event_deliver)
 	previous = k_event_post(event, events);
 	zassert_equal(previous, events & 0xAAAA);
 	zassert_equal(k_event_test(event, ~0), events);
+}
 
-	events = 0xAAAA0000;
-	previous = k_event_set(event, events);
+/**
+ * @brief Verify k_event_set() overwrites the stored set of events.
+ *
+ * @details
+ * Exercises the set system call without any waking or blocking, validating
+ * that the stored events are replaced (not merged) and that the previous
+ * set is returned. Runs as a user-mode test so the set system call is also
+ * exercised from an unprivileged thread.
+ *
+ * Test steps:
+ * - Empty the event object and post a known set of events.
+ * - Overwrite the events with k_event_set() and verify the stored set is
+ *   exactly the new value while the call returns the prior set.
+ * - Set a second value and verify the first one is reported back.
+ *
+ * Expected result:
+ * - After each call the stored events (read via k_event_test()) match the
+ *   set value exactly, and each call returns the complete previous set.
+ *
+ * @see k_event_set()
+ * @see k_event_test()
+ */
+ZTEST_USER(events_api, test_event_set)
+{
+	struct k_event *event = &deliver_event;
+	uint32_t  previous;
+
+	(void)k_event_set(event, 0);
+
+	(void)k_event_post(event, 0xAAAA | 0x55555ABC);
+
+	previous = k_event_set(event, 0xAAAA0000);
 	zassert_equal(previous, 0xAAAA | 0x55555ABC);
-	zassert_equal(k_event_test(event, ~0), events);
+	zassert_equal(k_event_test(event, ~0), 0xAAAA0000);
 
-	/*
-	 * Verify k_event_set_masked() update the events
-	 * stored in the event object as expected
-	 */
+	previous = k_event_set(event, 0x33333333);
+	zassert_equal(previous, 0xAAAA0000);
+	zassert_equal(k_event_test(event, ~0), 0x33333333);
+}
+
+/**
+ * @brief Verify k_event_set_masked() changes only the masked events.
+ *
+ * @details
+ * Exercises the masked-set system call without any waking or blocking,
+ * validating that only the events selected by the mask are set or cleared,
+ * that all other events are untouched, and that the previous state of the
+ * masked events is returned. Runs as a user-mode test so the masked-set
+ * system call is also exercised from an unprivileged thread.
+ *
+ * Test steps:
+ * - Set a known pattern of events (0x33333333).
+ * - Clear one masked subset at a time and verify only those bits drop out
+ *   while their prior state is returned.
+ * - Set masked subsets and verify only the masked bits change, including a
+ *   mask that simultaneously sets some bits and clears others.
+ *
+ * Expected result:
+ * - After each call the stored events (read via k_event_test()) differ from
+ *   the prior state only in the masked bits, and each call returns the
+ *   previous state of the masked bits.
+ *
+ * @see k_event_set_masked()
+ * @see k_event_test()
+ */
+ZTEST_USER(events_api, test_event_set_masked)
+{
+	struct k_event *event = &deliver_event;
+	uint32_t  events;
+	uint32_t  events_mask;
+	uint32_t  previous;
+
 	events = 0x33333333;
 	(void)k_event_set(event, events);
 	zassert_equal(k_event_test(event, ~0), events);
@@ -522,46 +558,171 @@ ZTEST_USER(events_api, test_k_event_clear)
 }
 
 /**
- * @brief Verify multi-threaded waiting, reset-on-wait and waking of waiters.
+ * @brief Verify any/all matching of a wait against already-posted events.
  *
  * @details
- * Drives a receiver thread and two extra waiter threads through a scripted
- * sequence of synchronization points to validate the blocking event APIs end
- * to end: matching all-vs-any conditions, returning only the matching bits,
- * optionally resetting the event before waiting, and waking multiple threads
- * blocked on a single event object at once.
+ * Drives a receiver thread through a scripted sequence of synchronization
+ * points to validate the matching rules of the blocking event APIs against
+ * a pre-loaded event object: an any-match wait completes when at least one
+ * requested event is present, an all-match wait completes only when every
+ * requested event is present, and a completed wait reports exactly the
+ * matching events. No events are posted while the receiver is waiting.
  *
  * Test steps:
- * - Pre-load the event object and start a receiver thread plus two extra
- *   threads waiting with k_event_wait()/k_event_wait_all().
- * - Walk the receiver through waits that should miss, partially match and
- *   fully match the posted events, checking the returned bits each time.
- * - Repeat with the reset flag set and confirm the event is cleared before
- *   the new bits are posted.
- * - Wake both extra threads via k_event_set() and collect the events they
- *   report back.
+ * - Pre-load the event object with a known set of events (0x1234) and start
+ *   the receiver thread.
+ * - Walk the receiver through k_event_wait() and k_event_wait_all() calls
+ *   that should miss (no overlap, incomplete overlap) and verify each
+ *   reports no events.
+ * - Walk the receiver through a partially matching k_event_wait() and a
+ *   fully matching k_event_wait_all() and verify the returned bits.
  *
  * Expected result:
- * - Each wait returns exactly the matching bits (0 when the condition is not
- *   satisfied), reset-on-wait clears prior events, and all woken threads
- *   report the expected events.
+ * - Waits whose condition is not met return 0, a matching any-wait returns
+ *   only the overlapping bits (0x0234), and a matching all-wait returns
+ *   exactly the requested bits (0x1234).
+ *
+ * @see k_event_wait()
+ * @see k_event_wait_all()
+ */
+ZTEST(events_api, test_event_receive_existing)
+{
+	k_sem_init(&sync_sem, 0, 1);
+	k_sem_init(&receiver_sem, 0, 1);
+	k_event_set(&test_event, 0x1234);
+
+	(void) k_thread_create(&treceiver, sreceiver, STACK_SIZE,
+			       receiver_existing, NULL, NULL, NULL,
+			       K_PRIO_PREEMPT(0), 0, K_NO_WAIT);
+
+	drive_receive_existing_events();
+
+	zassert_equal(k_thread_join(&treceiver, LONG_TIMEOUT), 0);
+}
+
+/**
+ * @brief Verify waiting for events accepts and honors a timeout.
+ *
+ * @details
+ * Focused test for the timeout behavior of the blocking event APIs: a wait
+ * whose condition is not satisfied within the given timeout returns no
+ * events, and only after the timeout has elapsed. Runs as a user-mode test
+ * so the wait system calls are also exercised from an unprivileged thread.
+ *
+ * Test steps:
+ * - Empty the event object.
+ * - Wait for events with K_NO_WAIT and verify the immediate no-event return.
+ * - Wait for events with a finite timeout and verify no events are returned
+ *   and at least the timeout duration elapsed.
+ * - Post a partial match and verify an all-match wait still times out.
+ *
+ * Expected result:
+ * - Each unsatisfied wait returns 0, the timed waits only return once their
+ *   timeout has expired.
+ *
+ * @see k_event_wait()
+ * @see k_event_wait_all()
+ */
+ZTEST_USER(events_api, test_event_wait_timeout)
+{
+	uint32_t  events;
+	int64_t   reftime;
+	int64_t   elapsed;
+
+	k_event_set(&test_event, 0);
+
+	events = k_event_wait(&test_event, 0xFFF, false, K_NO_WAIT);
+	zassert_equal(events, 0);
+
+	reftime = k_uptime_get();
+	events = k_event_wait(&test_event, 0xFFF, false, SHORT_TIMEOUT);
+	elapsed = k_uptime_delta(&reftime);
+	zassert_equal(events, 0);
+	zassert_true(elapsed >= 100, "wait returned after %d ms", (int)elapsed);
+
+	/* A partial match must not satisfy an all-match wait */
+	k_event_set(&test_event, 0x00F);
+	reftime = k_uptime_get();
+	events = k_event_wait_all(&test_event, 0xFFF, false, SHORT_TIMEOUT);
+	elapsed = k_uptime_delta(&reftime);
+	zassert_equal(events, 0);
+	zassert_true(elapsed >= 100, "wait returned after %d ms", (int)elapsed);
+
+	k_event_set(&test_event, 0);
+}
+
+/**
+ * @brief Verify the reset option clears prior events before waiting.
+ *
+ * @details
+ * Drives a receiver thread through waits issued with the reset flag set,
+ * posting fresh events after each wait has started. Because the event
+ * object is cleared when the wait begins, only the newly posted events can
+ * satisfy the wait condition, and threads whose condition is met by the
+ * post are woken while others time out.
+ *
+ * Test steps:
+ * - Pre-load the event object and start the receiver thread.
+ * - Have the receiver wait with reset=true while events that do not satisfy
+ *   the condition are posted; verify the wait times out, the pre-existing
+ *   events were discarded and only the new post remains stored.
+ * - Repeat with posts that fully or partially satisfy the condition and
+ *   verify the receiver is woken with exactly the matching events.
+ *
+ * Expected result:
+ * - Each wait observes only events posted after it started (prior events
+ *   are reset), unsatisfied waits time out, and satisfied waits wake the
+ *   receiver and return the matching events.
  *
  * @see k_event_post()
+ * @see k_event_wait()
+ * @see k_event_wait_all()
+ */
+ZTEST(events_api, test_event_reset_on_wait)
+{
+	k_sem_init(&sync_sem, 0, 1);
+	k_sem_init(&receiver_sem, 0, 1);
+	k_event_set(&test_event, 0x1234);
+
+	(void) k_thread_create(&treceiver, sreceiver, STACK_SIZE,
+			       receiver_reset, NULL, NULL, NULL,
+			       K_PRIO_PREEMPT(0), 0, K_NO_WAIT);
+
+	drive_reset_on_wait();
+
+	zassert_equal(k_thread_join(&treceiver, LONG_TIMEOUT), 0);
+}
+
+/**
+ * @brief Verify a single event delivery wakes all matching waiters.
+ *
+ * @details
+ * Parks two threads on the same event object -- one waiting for any of its
+ * events, one waiting for all of them -- and wakes both with a single
+ * k_event_set() call. Each woken thread posts the events it received back
+ * to a second event object so the test can confirm both were unpended with
+ * their expected events.
+ *
+ * Test steps:
+ * - Empty both event objects and start the two waiter threads.
+ * - Give the waiters time to pend on the sync event object.
+ * - Deliver events matching both wait conditions with one k_event_set().
+ * - Collect the events each waiter reports back and join the waiters.
+ *
+ * Expected result:
+ * - Both waiting threads are woken by the single delivery and report
+ *   exactly the events that matched their respective wait conditions.
+ *
  * @see k_event_set()
  * @see k_event_wait()
  * @see k_event_wait_all()
  */
-
-ZTEST(events_api, test_event_receive)
+ZTEST(events_api, test_event_wake_multiple)
 {
+	uint32_t  events;
 
-	/* Create helper threads */
-
-	k_event_set(&test_event, 0x1234);
-
-	(void) k_thread_create(&treceiver, sreceiver, STACK_SIZE,
-			       receiver, NULL, NULL, NULL,
-			       K_PRIO_PREEMPT(0), 0, K_NO_WAIT);
+	k_event_set(&test_event, 0);
+	k_event_set(&sync_event, 0);
 
 	(void) k_thread_create(&textra1, sextra1, STACK_SIZE,
 			       entry_extra1, NULL, NULL, NULL,
@@ -571,11 +732,19 @@ ZTEST(events_api, test_event_receive)
 			       entry_extra2, NULL, NULL, NULL,
 			       K_PRIO_PREEMPT(0), 0, K_NO_WAIT);
 
-	test_receive_existing_events();
+	/* Let both waiters pend on <sync_event>, then wake them together. */
+	k_sleep(DELAY);
+	k_event_set(&sync_event, 0xfff);
 
-	test_reset_on_wait();
+	/*
+	 * The extra threads send back the events they received. Wait
+	 * for all of them.
+	 */
+	events = k_event_wait_all(&test_event, 0x333, false, SHORT_TIMEOUT);
+	zassert_true(events == 0x333);
 
-	test_wake_multiple_threads();
+	zassert_equal(k_thread_join(&textra1, LONG_TIMEOUT), 0);
+	zassert_equal(k_thread_join(&textra2, LONG_TIMEOUT), 0);
 }
 
 /**

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
@@ -166,6 +166,120 @@ ZTEST(fifo_api_1cpu, test_fifo_thread2thread)
 }
 
 /**
+ * @brief Verify a FIFO defined at compile time is ready for use.
+ *
+ * @details
+ * A FIFO created with K_FIFO_DEFINE() must be fully initialized at boot:
+ * empty and immediately usable for data passing without any run-time
+ * initialization call.
+ *
+ * Test steps:
+ * - Check the statically defined FIFO is empty.
+ * - Put an item and get it back, verifying the same item is returned.
+ *
+ * Expected result:
+ * - The statically defined FIFO accepts and delivers items as-is.
+ *
+ * @see K_FIFO_DEFINE
+ */
+ZTEST(fifo_api, test_fifo_define)
+{
+	/* usable at boot without any run-time initialization */
+	zassert_true(k_fifo_is_empty(&kfifo));
+
+	k_fifo_put(&kfifo, (void *)&data[0]);
+	zassert_equal(k_fifo_get(&kfifo, K_NO_WAIT), (void *)&data[0]);
+	zassert_true(k_fifo_is_empty(&kfifo));
+}
+
+/**
+ * @brief Verify appending a singly-linked item list to the back of a FIFO.
+ *
+ * @details
+ * k_fifo_put_list() must transfer a caller-built singly-linked list to the
+ * back of the FIFO with its order preserved.
+ *
+ * Test steps:
+ * - Put one item so the FIFO is non-empty.
+ * - Link the items of an array into a list.
+ * - Put the list and confirm it lands behind the pre-existing item.
+ * - Get all items and verify list order is preserved.
+ *
+ * Expected result:
+ * - The pre-existing item is delivered first, then every list item in its
+ *   original order.
+ *
+ * @see k_fifo_put_list()
+ * @see k_fifo_get()
+ */
+ZTEST(fifo_api, test_fifo_put_list_order)
+{
+	static fdata_t *head = &data_l[0], *tail = &data_l[LIST_LEN - 1];
+
+	k_fifo_init(&fifo);
+
+	/* a pre-existing item so the list is demonstrably put behind it */
+	k_fifo_put(&fifo, (void *)&data[0]);
+
+	head->snode.next = (sys_snode_t *)tail;
+	tail->snode.next = NULL;
+	k_fifo_put_list(&fifo, (uint32_t *)head, (uint32_t *)tail);
+
+	zassert_equal(k_fifo_get(&fifo, K_NO_WAIT), (void *)&data[0]);
+	for (int i = 0; i < LIST_LEN; i++) {
+		zassert_equal(k_fifo_get(&fifo, K_NO_WAIT),
+			      (void *)&data_l[i]);
+	}
+	zassert_true(k_fifo_is_empty(&fifo));
+}
+
+/**
+ * @brief Verify putting a sys_slist empties the list into the FIFO.
+ *
+ * @details
+ * k_fifo_put_slist() must move every node of a sys_slist to the back of the
+ * FIFO in list order and leave the source list empty.
+ *
+ * Test steps:
+ * - Put one item so the FIFO is non-empty.
+ * - Build a sys_slist with two nodes and put it on the FIFO.
+ * - Verify the source list is empty afterwards.
+ * - Get all items and confirm the nodes land behind the pre-existing item,
+ *   in list order.
+ *
+ * Expected result:
+ * - The pre-existing item is delivered first, then every node in order, and
+ *   the source list is emptied.
+ *
+ * @see k_fifo_put_slist()
+ * @see k_fifo_get()
+ */
+ZTEST(fifo_api, test_fifo_put_slist_order)
+{
+	sys_slist_t slist;
+
+	k_fifo_init(&fifo);
+
+	/* a pre-existing item so the nodes land behind it */
+	k_fifo_put(&fifo, (void *)&data[0]);
+
+	sys_slist_init(&slist);
+	sys_slist_append(&slist, (sys_snode_t *)&(data_sl[0].snode));
+	sys_slist_append(&slist, (sys_snode_t *)&(data_sl[1].snode));
+	k_fifo_put_slist(&fifo, &slist);
+
+	/* the source list is emptied by the put */
+	zassert_true(sys_slist_is_empty(&slist));
+
+	zassert_equal(k_fifo_get(&fifo, K_NO_WAIT), (void *)&data[0]);
+	for (int i = 0; i < LIST_LEN; i++) {
+		zassert_equal(k_fifo_get(&fifo, K_NO_WAIT),
+			      (void *)&data_sl[i]);
+	}
+	zassert_true(k_fifo_is_empty(&fifo));
+}
+
+/**
  * @brief Verify FIFO data passing from an ISR to a thread.
  *
  * @details

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
@@ -308,6 +308,156 @@ ZTEST(msgq_api_1cpu, test_msgq_thread)
 }
 
 /**
+ * @brief Verify a message queue defined at compile time is ready for use.
+ *
+ * @details
+ * A queue created with K_MSGQ_DEFINE() must be fully initialized at boot for
+ * the size and depth given to the macro: empty, with all slots free, and
+ * immediately usable for message passing without any run-time initialization
+ * call.
+ *
+ * Test steps:
+ * - Check the statically defined queue is empty with MSGQ_LEN free slots and
+ *   that a peek reports no message.
+ * - Put a message and get it back, verifying the data round-trips.
+ *
+ * Expected result:
+ * - The statically defined queue accepts and delivers messages as-is.
+ *
+ * @see K_MSGQ_DEFINE
+ */
+ZTEST_USER(msgq_api, test_msgq_define)
+{
+	uint32_t rx_data;
+
+	k_msgq_purge(&kmsgq);
+
+	/* usable without any run-time initialization */
+	zassert_equal(k_msgq_num_used_get(&kmsgq), 0);
+	zassert_equal(k_msgq_num_free_get(&kmsgq), MSGQ_LEN);
+	zassert_equal(k_msgq_peek(&kmsgq, &rx_data), -ENOMSG);
+
+	zassert_equal(k_msgq_put(&kmsgq, &data[0], K_NO_WAIT), 0);
+	zassert_equal(k_msgq_get(&kmsgq, &rx_data, K_NO_WAIT), 0);
+	zassert_equal(rx_data, data[0]);
+}
+
+/**
+ * @brief Verify run-time initialization of a message queue.
+ *
+ * @details
+ * k_msgq_init() must set up a message queue over a caller-provided buffer for
+ * the given message size and depth: the queue starts empty, with all slots
+ * free, and is immediately usable for message passing.
+ *
+ * Test steps:
+ * - Initialize a queue at run time with a caller-provided buffer.
+ * - Check it is empty (no used slots, all slots free, peek reports no
+ *   message).
+ * - Put a message and get it back, verifying the data round-trips.
+ *
+ * Expected result:
+ * - The initialized queue is empty and accepts and delivers messages.
+ *
+ * @see k_msgq_init()
+ */
+ZTEST(msgq_api, test_msgq_init)
+{
+	uint32_t read_data;
+	uint32_t rx_data;
+
+	k_msgq_init(&msgq, tbuffer, MSG_SIZE, MSGQ_LEN);
+
+	zassert_equal(k_msgq_num_used_get(&msgq), 0);
+	zassert_equal(k_msgq_num_free_get(&msgq), MSGQ_LEN);
+	zassert_equal(k_msgq_peek(&msgq, &read_data), -ENOMSG);
+
+	zassert_equal(k_msgq_put(&msgq, &data[0], K_NO_WAIT), 0);
+	zassert_equal(k_msgq_get(&msgq, &rx_data, K_NO_WAIT), 0);
+	zassert_equal(rx_data, data[0]);
+}
+
+/**
+ * @brief Verify a front-inserted message is received before queued ones.
+ *
+ * @details
+ * k_msgq_put_front() inserts a message at the front of the queue, so a
+ * receiver must get it before messages that were already queued, while the
+ * messages sent to the end keep their relative order.
+ *
+ * Test steps:
+ * - Put a message at the end of the queue.
+ * - Put a second message at the front with k_msgq_put_front().
+ * - Get both messages and verify the front-inserted one arrives first.
+ *
+ * Expected result:
+ * - The front-inserted message is received first, the end-queued one second.
+ *
+ * @see k_msgq_put_front()
+ * @see k_msgq_get()
+ */
+ZTEST_USER(msgq_api, test_msgq_put_front_order)
+{
+	uint32_t rx_data;
+
+	k_msgq_purge(&kmsgq);
+
+	zassert_equal(k_msgq_put(&kmsgq, &data[0], K_NO_WAIT), 0);
+	zassert_equal(k_msgq_put_front(&kmsgq, &data[1]), 0);
+
+	/* the front-inserted message is received first */
+	zassert_equal(k_msgq_get(&kmsgq, &rx_data, K_NO_WAIT), 0);
+	zassert_equal(rx_data, data[1]);
+	zassert_equal(k_msgq_get(&kmsgq, &rx_data, K_NO_WAIT), 0);
+	zassert_equal(rx_data, data[0]);
+}
+
+/**
+ * @brief Verify peeking reads the front message without removing it.
+ *
+ * @details
+ * k_msgq_peek() must report -ENOMSG on an empty queue, return the message at
+ * the front of a non-empty queue without consuming it, and a subsequent get
+ * must return the same message that was peeked.
+ *
+ * Test steps:
+ * - Peek at an empty queue and expect -ENOMSG.
+ * - Put two messages, peek, and verify the front message is returned and the
+ *   used count is unchanged.
+ * - Get a message and verify it matches the peeked one.
+ *
+ * Expected result:
+ * - Peek returns the front message without removing it and fails with
+ *   -ENOMSG on an empty queue.
+ *
+ * @see k_msgq_peek()
+ */
+ZTEST_USER(msgq_api, test_msgq_peek)
+{
+	uint32_t read_data;
+	uint32_t rx_data;
+
+	k_msgq_purge(&kmsgq);
+
+	/* peeking at an empty queue reports no message */
+	zassert_equal(k_msgq_peek(&kmsgq, &read_data), -ENOMSG);
+
+	zassert_equal(k_msgq_put(&kmsgq, &data[0], K_NO_WAIT), 0);
+	zassert_equal(k_msgq_put(&kmsgq, &data[1], K_NO_WAIT), 0);
+
+	/* peek reads the message at the front without removing it */
+	zassert_equal(k_msgq_peek(&kmsgq, &read_data), 0);
+	zassert_equal(read_data, data[0]);
+	zassert_equal(k_msgq_num_used_get(&kmsgq), MSGQ_LEN);
+
+	/* the peeked message is the one a get returns */
+	zassert_equal(k_msgq_get(&kmsgq, &rx_data, K_NO_WAIT), 0);
+	zassert_equal(rx_data, read_data);
+
+	k_msgq_purge(&kmsgq);
+}
+
+/**
  * @brief Verify the ring buffer wraps correctly across put/get cycles.
  *
  * @details

--- a/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
+++ b/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
@@ -18,6 +18,8 @@ static ZTEST_DMEM int thread_ret = TC_FAIL;
 
 /* TESTPOINT: init via K_MUTEX_DEFINE */
 K_MUTEX_DEFINE(kmutex);
+/* only used by test_mutex_define, never re-initialized at run time */
+K_MUTEX_DEFINE(kmutex_define);
 static struct k_mutex tmutex;
 
 static K_THREAD_STACK_DEFINE(tstack, STACK_SIZE);
@@ -210,6 +212,56 @@ static void tThread_waiter(void *p1, void *p2, void *p3)
 }
 
 /*test cases*/
+/**
+ * @brief Verify a mutex defined at compile time is ready for use.
+ *
+ * @details
+ * A mutex created with K_MUTEX_DEFINE() must be fully initialized at boot:
+ * unowned and immediately lockable without any run-time initialization
+ * call. The mutex used here is touched by no other test, so it is
+ * exercised exactly as the macro left it.
+ *
+ * Test steps:
+ * - Lock the statically defined mutex with K_NO_WAIT.
+ * - Unlock it.
+ *
+ * Expected result:
+ * - Both operations succeed without any prior k_mutex_init() call.
+ *
+ * @ingroup kernel_mutex_tests
+ * @see K_MUTEX_DEFINE
+ */
+ZTEST(mutex_api, test_mutex_define)
+{
+	/* usable at boot without any run-time initialization */
+	zassert_equal(k_mutex_lock(&kmutex_define, K_NO_WAIT), 0);
+	zassert_equal(k_mutex_unlock(&kmutex_define), 0);
+}
+
+/**
+ * @brief Verify run-time initialization of a mutex.
+ *
+ * @details
+ * k_mutex_init() must succeed and yield an unowned mutex that is
+ * immediately lockable.
+ *
+ * Test steps:
+ * - Initialize a mutex at run time and check the call succeeds.
+ * - Lock it with K_NO_WAIT and unlock it.
+ *
+ * Expected result:
+ * - Initialization returns 0 and the mutex is immediately usable.
+ *
+ * @ingroup kernel_mutex_tests
+ * @see k_mutex_init()
+ */
+ZTEST(mutex_api, test_mutex_init)
+{
+	zassert_equal(k_mutex_init(&tmutex), 0);
+	zassert_equal(k_mutex_lock(&tmutex, K_NO_WAIT), 0);
+	zassert_equal(k_mutex_unlock(&tmutex), 0);
+}
+
 ZTEST_USER(mutex_api_1cpu, test_mutex_reent_lock_forever)
 {
 	/**TESTPOINT: test k_mutex_init mutex*/

--- a/tests/kernel/poll/src/test_poll.c
+++ b/tests/kernel/poll/src/test_poll.c
@@ -879,6 +879,61 @@ ZTEST(poll_api_1cpu, test_poll_zero_events)
 	zassert_equal(k_poll(&event, 0, K_MSEC(50)), -EAGAIN);
 }
 
+static struct k_poll_signal lifecycle_signal;
+
+/**
+ * @brief Test poll signal initialization and raising
+ *
+ * @ingroup kernel_poll_tests
+ *
+ * @details A poll signal object initialized with k_poll_signal_init() must
+ * start in the unsignaled state; raising it with k_poll_signal_raise() must
+ * put it in the signaled state carrying the caller's result value, as
+ * reported by k_poll_signal_check().
+ *
+ * @see k_poll_signal_init(), k_poll_signal_raise(), k_poll_signal_check()
+ */
+ZTEST(poll_api, test_poll_signal_raise)
+{
+	unsigned int signaled;
+	int result;
+
+	k_poll_signal_init(&lifecycle_signal);
+
+	/* initialized signals start out unsignaled */
+	k_poll_signal_check(&lifecycle_signal, &signaled, &result);
+	zassert_equal(signaled, 0, "signal should start unsignaled");
+
+	/* raising signals the object and stores the result value */
+	zassert_equal(k_poll_signal_raise(&lifecycle_signal, SIGNAL_RESULT), 0);
+	k_poll_signal_check(&lifecycle_signal, &signaled, &result);
+	zassert_not_equal(signaled, 0, "signal should be signaled after raise");
+	zassert_equal(result, SIGNAL_RESULT);
+}
+
+/**
+ * @brief Test resetting a poll signal
+ *
+ * @ingroup kernel_poll_tests
+ *
+ * @details k_poll_signal_reset() must return a raised poll signal to the
+ * unsignaled state.
+ *
+ * @see k_poll_signal_raise(), k_poll_signal_reset(), k_poll_signal_check()
+ */
+ZTEST(poll_api, test_poll_signal_reset)
+{
+	unsigned int signaled;
+	int result;
+
+	k_poll_signal_init(&lifecycle_signal);
+	zassert_equal(k_poll_signal_raise(&lifecycle_signal, SIGNAL_RESULT), 0);
+
+	k_poll_signal_reset(&lifecycle_signal);
+	k_poll_signal_check(&lifecycle_signal, &signaled, &result);
+	zassert_equal(signaled, 0, "signal should be unsignaled after reset");
+}
+
 static struct k_poll_signal persist_signal;
 
 /**

--- a/tests/kernel/queue/src/test_queue_contexts.c
+++ b/tests/kernel/queue/src/test_queue_contexts.c
@@ -171,6 +171,291 @@ ZTEST(queue_api_1cpu, test_queue_thread2thread)
 }
 
 /**
+ * @brief Verify a queue defined at compile time is ready for use.
+ *
+ * @details
+ * A queue created with K_QUEUE_DEFINE() must be fully initialized at boot:
+ * empty and immediately usable for data passing without any run-time
+ * initialization call.
+ *
+ * Test steps:
+ * - Check the statically defined queue is empty.
+ * - Append an item and get it back, verifying the same item is returned.
+ *
+ * Expected result:
+ * - The statically defined queue accepts and delivers items as-is.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see K_QUEUE_DEFINE
+ */
+ZTEST(queue_api, test_queue_define)
+{
+	/* usable at boot without any run-time initialization */
+	zassert_true(k_queue_is_empty(&kqueue));
+
+	k_queue_append(&kqueue, (void *)&data[0]);
+	zassert_equal(k_queue_get(&kqueue, K_NO_WAIT), (void *)&data[0]);
+
+	/* the queue is drained: a non-blocking get returns NULL */
+	zassert_is_null(k_queue_get(&kqueue, K_NO_WAIT));
+}
+
+/**
+ * @brief Verify run-time initialization of a queue.
+ *
+ * @details
+ * k_queue_init() must yield an empty queue that is immediately usable for
+ * data passing.
+ *
+ * Test steps:
+ * - Initialize a queue at run time and check it is empty.
+ * - Append an item and get it back, verifying the same item is returned.
+ *
+ * Expected result:
+ * - The initialized queue is empty and accepts and delivers items.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_init()
+ */
+ZTEST(queue_api, test_queue_init)
+{
+	k_queue_init(&queue);
+
+	zassert_true(k_queue_is_empty(&queue));
+	k_queue_append(&queue, (void *)&data[0]);
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data[0]);
+
+	/* the queue is drained: a non-blocking get returns NULL */
+	zassert_is_null(k_queue_get(&queue, K_NO_WAIT));
+}
+
+/**
+ * @brief Verify prepended items are dequeued before appended ones.
+ *
+ * @details
+ * k_queue_prepend() adds an item to the front of the queue, so items
+ * prepended after an append must be dequeued first, with the most recently
+ * prepended item coming out first.
+ *
+ * Test steps:
+ * - Add one item, then prepend two items.
+ * - Get all three items and verify the order: most recently prepended
+ *   first, appended item last.
+ *
+ * Expected result:
+ * - Items are dequeued in prepend-reverse order followed by the appended
+ *   item.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_prepend()
+ * @see k_queue_get()
+ */
+ZTEST(queue_api, test_queue_prepend_order)
+{
+	k_queue_init(&queue);
+
+	k_queue_append(&queue, (void *)&data[0]);
+	k_queue_prepend(&queue, (void *)&data_p[1]);
+	k_queue_prepend(&queue, (void *)&data_p[0]);
+
+	/* prepended items precede the appended one, most recent first */
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data_p[0]);
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data_p[1]);
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data[0]);
+}
+
+/**
+ * @brief Verify k_queue_insert() places an item after a given node.
+ *
+ * @details
+ * k_queue_insert() adds an item immediately after a caller-specified node
+ * already in the queue, so dequeuing must return the inserted item between
+ * its predecessor and the items that followed it.
+ *
+ * Test steps:
+ * - Append two items.
+ * - Insert a third item after the first one.
+ * - Get all items and verify the inserted item comes out second.
+ *
+ * Expected result:
+ * - The inserted item is dequeued directly after the node it was inserted
+ *   behind.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_insert()
+ * @see k_queue_get()
+ */
+ZTEST(queue_api, test_queue_insert_after)
+{
+	k_queue_init(&queue);
+
+	k_queue_append(&queue, (void *)&data[0]);
+	k_queue_append(&queue, (void *)&data[1]);
+
+	/* insert between the two appended items */
+	k_queue_insert(&queue, (void *)&data[0], (void *)&data_p[0]);
+
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data[0]);
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data_p[0]);
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data[1]);
+}
+
+/**
+ * @brief Verify appending a singly-linked item list to the back of a queue.
+ *
+ * @details
+ * k_queue_append_list() must transfer a caller-built singly-linked list to
+ * the back of the queue with its order preserved.
+ *
+ * Test steps:
+ * - Append one item so the queue is non-empty.
+ * - Link the items of an array into a list.
+ * - Append the list and confirm it lands behind the pre-existing item.
+ * - Get all items and verify list order is preserved.
+ *
+ * Expected result:
+ * - The pre-existing item is delivered first, then every list item in its
+ *   original order.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_append_list()
+ * @see k_queue_get()
+ */
+ZTEST(queue_api, test_queue_append_list_order)
+{
+	static qdata_t *head = &data_l[0], *tail = &data_l[LIST_LEN - 1];
+
+	k_queue_init(&queue);
+
+	/* a pre-existing item so the list is demonstrably appended behind it */
+	k_queue_append(&queue, (void *)&data[0]);
+
+	head->snode.next = (sys_snode_t *)tail;
+	tail->snode.next = NULL;
+	k_queue_append_list(&queue, (uint32_t *)head, (uint32_t *)tail);
+
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data[0]);
+	for (int i = 0; i < LIST_LEN; i++) {
+		zassert_equal(k_queue_get(&queue, K_NO_WAIT),
+			      (void *)&data_l[i]);
+	}
+	zassert_is_null(k_queue_get(&queue, K_NO_WAIT));
+}
+
+/**
+ * @brief Verify merging a sys_slist empties the list into the queue.
+ *
+ * @details
+ * k_queue_merge_slist() must move every node of a sys_slist to the back of
+ * the queue in list order and leave the source list empty.
+ *
+ * Test steps:
+ * - Append one item so the queue is non-empty.
+ * - Build a sys_slist with two nodes and merge it into the queue.
+ * - Verify the source list is empty after the merge.
+ * - Get all items and confirm the merged nodes land behind the pre-existing
+ *   item, in list order.
+ *
+ * Expected result:
+ * - The pre-existing item is delivered first, then every merged node in
+ *   order, and the source list is emptied.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_merge_slist()
+ * @see k_queue_get()
+ */
+ZTEST(queue_api, test_queue_merge_slist_order)
+{
+	sys_slist_t slist;
+
+	k_queue_init(&queue);
+
+	/* a pre-existing item so the merged nodes land behind it */
+	k_queue_append(&queue, (void *)&data[0]);
+
+	sys_slist_init(&slist);
+	sys_slist_append(&slist, (sys_snode_t *)&(data_sl[0].snode));
+	sys_slist_append(&slist, (sys_snode_t *)&(data_sl[1].snode));
+	k_queue_merge_slist(&queue, &slist);
+
+	/* the source list is emptied by the merge */
+	zassert_true(sys_slist_is_empty(&slist));
+
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data[0]);
+	for (int i = 0; i < LIST_LEN; i++) {
+		zassert_equal(k_queue_get(&queue, K_NO_WAIT),
+			      (void *)&data_sl[i]);
+	}
+	zassert_is_null(k_queue_get(&queue, K_NO_WAIT));
+}
+
+static void tqueue_merge_slist_wake_entry(void *p1, void *p2, void *p3)
+{
+	/* blocks until the main thread's k_queue_merge_slist() wakes us */
+	void *rx_data = k_queue_get(&queue, K_FOREVER);
+
+	zassert_equal(rx_data, (void *)&data_sl[0]);
+	k_sem_give(&end_sema);
+}
+
+/**
+ * @brief Verify k_queue_merge_slist() wakes a thread pending on the queue.
+ *
+ * @details
+ * A thread blocked in k_queue_get() on an empty queue must be woken when
+ * another context makes items available with k_queue_merge_slist(), and it
+ * must receive the first node of the merged list.
+ *
+ * Test steps:
+ * - Start a thread that blocks on an empty queue with k_queue_get(K_FOREVER).
+ * - Merge a two-node sys_slist into the queue.
+ * - Verify the woken thread received the first merged node and the second
+ *   node stays queued behind it.
+ *
+ * Expected result:
+ * - The pending thread is woken and dequeues the first merged node; the
+ *   remaining node stays in the queue.
+ *
+ * @ingroup tests_kernel_queue
+ *
+ * @see k_queue_merge_slist()
+ * @see k_queue_get()
+ */
+ZTEST(queue_api_1cpu, test_queue_merge_slist_wake)
+{
+	sys_slist_t slist;
+
+	k_queue_init(&queue);
+	k_sem_init(&end_sema, 0, 1);
+
+	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
+				      tqueue_merge_slist_wake_entry, NULL, NULL,
+				      NULL, K_PRIO_PREEMPT(0), 0, K_NO_WAIT);
+
+	/* let the thread reach k_queue_get() and pend on the empty queue */
+	k_sleep(K_MSEC(10));
+
+	sys_slist_init(&slist);
+	sys_slist_append(&slist, (sys_snode_t *)&(data_sl[0].snode));
+	sys_slist_append(&slist, (sys_snode_t *)&(data_sl[1].snode));
+	k_queue_merge_slist(&queue, &slist);
+
+	/* the merge woke the pending thread, which took the first node */
+	k_sem_take(&end_sema, K_FOREVER);
+	k_thread_abort(tid);
+
+	/* the second node remains queued behind the consumed one */
+	zassert_equal(k_queue_get(&queue, K_NO_WAIT), (void *)&data_sl[1]);
+	zassert_is_null(k_queue_get(&queue, K_NO_WAIT));
+}
+
+/**
  * @brief Verify data passes from an ISR to a thread through a queue.
  *
  * @details

--- a/tests/kernel/stack/stack/src/test_stack_contexts.c
+++ b/tests/kernel/stack/stack/src/test_stack_contexts.c
@@ -123,6 +123,85 @@ ZTEST(stack_contexts, test_stack_thread2thread)
 	tstack_thread_thread(&kstack);
 }
 
+/**
+ * @brief Verify a stack defined at compile time is ready for use.
+ *
+ * @details A stack created with K_STACK_DEFINE() must be fully initialized
+ * at boot: empty and immediately usable without any run-time
+ * initialization call. Push an item onto the statically defined stack and
+ * pop it back, verifying the value round-trips.
+ *
+ * @ingroup kernel_stack_tests
+ *
+ * @see #K_STACK_DEFINE(x), k_stack_push(), k_stack_pop()
+ */
+ZTEST(stack_contexts, test_stack_define)
+{
+	stack_data_t rx_data;
+
+	/* empty at boot: a non-blocking pop fails */
+	zassert_equal(k_stack_pop(&kstack, &rx_data, K_NO_WAIT), -EBUSY);
+
+	/* usable at boot without any run-time initialization */
+	zassert_ok(k_stack_push(&kstack, data[0]));
+	zassert_ok(k_stack_pop(&kstack, &rx_data, K_NO_WAIT));
+	zassert_equal(rx_data, data[0]);
+}
+
+/**
+ * @brief Verify run-time initialization of a stack over a caller buffer.
+ *
+ * @details k_stack_init() must set up a stack over a caller-provided memory
+ * area with the given capacity: the stack starts empty (a non-blocking pop
+ * fails) and accepts and returns items.
+ *
+ * @ingroup kernel_stack_tests
+ *
+ * @see k_stack_init(), k_stack_push(), k_stack_pop()
+ */
+ZTEST(stack_contexts, test_stack_init)
+{
+	static stack_data_t init_buf[STACK_LEN];
+	stack_data_t rx_data;
+
+	k_stack_init(&stack, init_buf, STACK_LEN);
+
+	/* starts out empty */
+	zassert_equal(k_stack_pop(&stack, &rx_data, K_NO_WAIT), -EBUSY);
+
+	zassert_ok(k_stack_push(&stack, data[0]));
+	zassert_ok(k_stack_pop(&stack, &rx_data, K_NO_WAIT));
+	zassert_equal(rx_data, data[0]);
+}
+
+/**
+ * @brief Verify items pop in reverse push order (LIFO).
+ *
+ * @details Popping a stack must return the most recently pushed item that
+ * has not yet been popped. Push two distinct items and verify they pop in
+ * reverse order.
+ *
+ * @ingroup kernel_stack_tests
+ *
+ * @see k_stack_push(), k_stack_pop()
+ */
+ZTEST(stack_contexts, test_stack_pop_order)
+{
+	static stack_data_t order_buf[STACK_LEN];
+	stack_data_t rx_data;
+
+	k_stack_init(&stack, order_buf, STACK_LEN);
+
+	zassert_ok(k_stack_push(&stack, data[0]));
+	zassert_ok(k_stack_push(&stack, data[1]));
+
+	/* the most recently pushed item comes out first */
+	zassert_ok(k_stack_pop(&stack, &rx_data, K_NO_WAIT));
+	zassert_equal(rx_data, data[1]);
+	zassert_ok(k_stack_pop(&stack, &rx_data, K_NO_WAIT));
+	zassert_equal(rx_data, data[0]);
+}
+
 #ifdef CONFIG_USERSPACE
 /**
  * @brief Verifies data passing between user threads via stack

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -206,6 +206,35 @@ ZTEST_USER(timer_api, test_timer_duration_period)
 }
 
 /**
+ * @brief Verify run-time initialization of a timer.
+ *
+ * @details A timer initialized at run time with k_timer_init() must start
+ * out inactive -- no expiries recorded and no time remaining -- and be
+ * immediately usable: starting it as a one-shot makes it expire once.
+ *
+ * @ingroup kernel_timer_tests
+ *
+ * @see k_timer_init(), k_timer_start(), k_timer_status_get()
+ */
+ZTEST(timer_api, test_timer_init_runtime)
+{
+	static struct k_timer runtime_timer;
+
+	k_timer_init(&runtime_timer, NULL, NULL);
+
+	/* freshly initialized: inactive, no expiries */
+	zassert_equal(k_timer_status_get(&runtime_timer), 0);
+	zassert_equal(k_timer_remaining_get(&runtime_timer), 0);
+
+	/* immediately usable as a one-shot timer */
+	k_timer_start(&runtime_timer, K_MSEC(DURATION), K_NO_WAIT);
+	busy_wait_ms(DURATION + 50);
+	zassert_equal(k_timer_status_get(&runtime_timer), 1);
+
+	k_timer_stop(&runtime_timer);
+}
+
+/**
  *
  * @brief Test restart the timer
  *


### PR DESCRIPTION
Several kernel test suites bundled many unrelated behaviors into a single test
body, so a failure anywhere gave one pass/fail verdict and obscured which
behavior actually broke. This series splits those overloaded tests across
events, msgq, queue, mutex, fifo, stack, common (uptime), timer, and poll,
adding focused test cases so each API or scenario is exercised on its own
rather than folded into a larger test.

Behavior coverage is unchanged; the tests are just reorganized to be smaller,
single-purpose, and order-independent.
