### PR TITLE
drivers: mspi: stm32: Fix MSPI controller lock lifecycle on XSPI, OSPI and QSPI

### DIFF
--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -728,6 +728,10 @@ static int mspi_stm32_ospi_dev_config(const struct device *controller,
 	bool locked = false;
 
 	if (data->dev_id != dev_id) {
+		/* The controller lock is taken here and kept for the whole
+		 * session, until the device releases it through
+		 * mspi_get_channel_status().
+		 */
 		if (k_mutex_lock(&data->lock, K_MSEC(CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE))) {
 			LOG_ERR("MSPI config failed to access controller.");
 			return -EBUSY;
@@ -741,26 +745,29 @@ static int mspi_stm32_ospi_dev_config(const struct device *controller,
 		goto e_return;
 	}
 
-	if (param_mask == MSPI_DEVICE_CONFIG_NONE && !cfg->mspicfg.sw_multi_periph) {
-		/* Nothing to do but saving the device ID */
-		data->dev_id = dev_id;
-		goto e_return;
-	}
-
 	/*
 	 * The SFDP is able to change the addr_length 4bytes or 3bytes
 	 * this is reflected by the serial_cfg
 	 */
 	data->dev_id = dev_id;
+
+	if (param_mask == MSPI_DEVICE_CONFIG_NONE && !cfg->mspicfg.sw_multi_periph) {
+		return 0;
+	}
+
 	/* Go on with other parameters if supported */
 	if (mspi_stm32_ospi_dev_cfg_save(controller, param_mask, dev_cfg) != 0) {
 		LOG_ERR("failed to set device config");
 		ret = -EIO;
+		goto e_return;
 	}
+
+	return 0;
 
 e_return:
 
 	if (locked) {
+		data->dev_id = NULL;
 		k_mutex_unlock(&data->lock);
 	}
 
@@ -823,18 +830,21 @@ static int mspi_stm32_ospi_memmap_config(const struct device *controller,
 static int mspi_stm32_ospi_get_channel_status(const struct device *controller, uint8_t ch)
 {
 	struct mspi_stm32_data *dev_data = controller->data;
-	int ret = 0;
 
 	ARG_UNUSED(ch);
 
 	if (mspi_stm32_ospi_is_inp(controller) ||
 	    __HAL_OSPI_GET_FLAG(&dev_data->hmspi.ospi, HAL_OSPI_FLAG_BUSY) == SET) {
-		ret = -EBUSY;
+		return -EBUSY;
 	}
 
+	/* The controller is idle: end the session started by
+	 * mspi_dev_config() and release the controller lock.
+	 */
 	dev_data->dev_id = NULL;
+	k_mutex_unlock(&dev_data->lock);
 
-	return ret;
+	return 0;
 }
 
 static int mspi_stm32_ospi_pio_transceive(const struct device *controller,
@@ -1282,6 +1292,8 @@ static int mspi_stm32_ospi_config(const struct mspi_dt_spec *spec)
 	}
 
 	if (config->re_init) {
+		/* Force-release a session that may still hold the lock */
+		dev_data->dev_id = NULL;
 		k_mutex_unlock(&dev_data->lock);
 	}
 end:

--- a/drivers/mspi/mspi_stm32_qspi.c
+++ b/drivers/mspi/mspi_stm32_qspi.c
@@ -961,6 +961,10 @@ static int mspi_stm32_qspi_dev_config(const struct device *controller,
 
 	/* Check if device ID has changed and lock accordingly */
 	if (data->dev_id != dev_id) {
+		/* The controller lock is taken here and kept for the whole
+		 * session, until the device releases it through
+		 * mspi_get_channel_status().
+		 */
 		if (k_mutex_lock(&data->lock, K_MSEC(CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE))) {
 			LOG_ERR("Failed to acquire lock for device config");
 			return -EBUSY;
@@ -974,21 +978,25 @@ static int mspi_stm32_qspi_dev_config(const struct device *controller,
 		goto e_return;
 	}
 
+	data->dev_id = dev_id;
+
 	if (param_mask == MSPI_DEVICE_CONFIG_NONE && !cfg->mspicfg.sw_multi_periph) {
 		/* Nothing to do but saving the device ID */
-		data->dev_id = dev_id;
-		goto e_return;
+		return 0;
 	}
 
-	data->dev_id = dev_id;
 	/* Validate and save device configuration */
 	ret = mspi_stm32_qspi_dev_cfg_save(controller, param_mask, dev_cfg);
 	if (ret != 0) {
 		LOG_ERR("failed to change device cfg");
+		goto e_return;
 	}
+
+	return 0;
 
 e_return:
 	if (locked) {
+		data->dev_id = NULL;
 		k_mutex_unlock(&data->lock);
 	}
 
@@ -1058,17 +1066,20 @@ static int mspi_stm32_qspi_get_channel_status(const struct device *controller, u
 {
 	struct mspi_stm32_data *data = controller->data;
 	QSPI_HandleTypeDef *hmspi = &data->hmspi.qspi;
-	int ret = 0;
 
 	ARG_UNUSED(ch);
 
 	if (mspi_is_inp(controller) || (hmspi->Instance->SR & QUADSPI_SR_BUSY) != 0) {
-		ret = -EBUSY;
+		return -EBUSY;
 	}
 
+	/* The controller is idle: end the session started by
+	 * mspi_dev_config() and release the controller lock.
+	 */
 	data->dev_id = NULL;
+	k_mutex_unlock(&data->lock);
 
-	return ret;
+	return 0;
 }
 
 /**

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -834,6 +834,10 @@ static int mspi_stm32_xspi_dev_config(const struct device *controller,
 	struct mspi_stm32_data *data = controller->data;
 
 	if (data->dev_id != dev_id) {
+		/* The controller lock is taken here and kept for the whole
+		 * session, until the device releases it through
+		 * mspi_get_channel_status().
+		 */
 		if (k_mutex_lock(&data->lock, K_MSEC(CONFIG_MSPI_COMPLETION_TIMEOUT_TOLERANCE))) {
 			LOG_ERR("MSPI config failed to access controller");
 			return -EBUSY;
@@ -843,28 +847,28 @@ static int mspi_stm32_xspi_dev_config(const struct device *controller,
 	}
 
 	if (mspi_stm32_xspi_is_inp(controller)) {
-		if (locked) {
-			k_mutex_unlock(&data->lock);
-		}
-		return -EBUSY;
-	}
-
-	if (param_mask == MSPI_DEVICE_CONFIG_NONE && !cfg->mspicfg.sw_multi_periph) {
-		data->dev_id = dev_id;
-		if (locked) {
-			k_mutex_unlock(&data->lock);
-		}
-		return 0;
+		ret = -EBUSY;
+		goto e_return;
 	}
 
 	data->dev_id = dev_id;
+
+	if (param_mask == MSPI_DEVICE_CONFIG_NONE && !cfg->mspicfg.sw_multi_periph) {
+		return 0;
+	}
+
 	/* Go on with other parameters if supported */
 	if (mspi_stm32_xspi_dev_cfg_save(controller, param_mask, dev_cfg) != 0) {
 		LOG_ERR("failed to change device cfg");
 		ret = -EIO;
+		goto e_return;
 	}
 
+	return 0;
+
+e_return:
 	if (locked) {
+		data->dev_id = NULL;
 		k_mutex_unlock(&data->lock);
 	}
 	return ret;
@@ -924,16 +928,21 @@ static int mspi_stm32_xspi_memmap_config(const struct device *controller,
 static int mspi_stm32_xspi_get_channel_status(const struct device *controller, uint8_t ch)
 {
 	struct mspi_stm32_data *dev_data = controller->data;
-	int ret = 0;
 
 	ARG_UNUSED(ch);
 
 	if (mspi_stm32_xspi_is_inp(controller) ||
 	    (HAL_XSPI_GET_FLAG(&dev_data->hmspi.xspi, HAL_XSPI_FLAG_BUSY) == SET)) {
-		ret = -EBUSY;
+		return -EBUSY;
 	}
 
-	return ret;
+	/* The controller is idle: end the session started by
+	 * mspi_dev_config() and release the controller lock.
+	 */
+	dev_data->dev_id = NULL;
+	k_mutex_unlock(&dev_data->lock);
+
+	return 0;
 }
 
 static int mspi_stm32_xspi_pio_dma_transceive(const struct device *controller,
@@ -1290,6 +1299,8 @@ static int mspi_stm32_xspi_config(const struct mspi_dt_spec *spec)
 		k_sem_give(&dev_data->ctx.lock);
 	}
 	if (config->re_init) {
+		/* Force-release a session that may still hold the lock */
+		dev_data->dev_id = NULL;
 		k_mutex_unlock(&dev_data->lock);
 	}
 


### PR DESCRIPTION
## Summary

The STM32 XSPI, OSPI and QSPI MSPI drivers took the controller mutex in `mspi_dev_config()` but released it again before returning. As a result the lock only guarded the configuration call itself, and no exclusive session was ever held between `mspi_dev_config()` and `mspi_get_channel_status()`. This series fixes the controller lock lifecycle in all three drivers so that an `mspi_dev_config()` … `mspi_get_channel_status()` pair actually holds the controller for the duration of the session, matching the session model already used by other MSPI controller drivers (e.g. ambiq).

## Background: the MSPI session contract

The MSPI API models controller access as an exclusive session owned by one device at a time:

- `mspi_dev_config()` acquires the controller for a given `dev_id` (and optionally applies device configuration).
- The device then drives transfers.
- `mspi_get_channel_status()` is the point at which the device hands off the controller, once it is idle.

Between those two calls the controller mutex (`data->lock`) is expected to stay held, so that a second device - or a second thread cannot reconfigure or drive the controller in the middle of another device's session. The lock is intentionally taken only when a *different* `dev_id` shows up, and the owner is expected to hold it across the whole session.

## The bug

In all three STM32 drivers, `mspi_dev_config()` unlocked the mutex again on its way out (`e_return` / the `if (locked) k_mutex_unlock(...)` tail), including on the successful configuration path. So the mutex was released as soon as `mspi_dev_config()` returned, and the session ran completely unlocked.

### Failure scenario

With two devices A and B sharing one controller (`sw_multi_periph`, or two flash chips on separate chip-select lines, driven from two threads):

1. Device A calls `mspi_dev_config(A)` → takes the lock, sets `dev_id = A`, then releases the lock before returning.
2. Device B calls `mspi_dev_config(B)` → since `dev_id (A) != B`, it tries to take the lock and **succeeds immediately** (A already released it), instead of blocking until A's session ends. It reconfigures the controller for B and sets `dev_id = B`.
3. Device A now issues a transfer, but the controller hardware is configured for B → transfer against the wrong device / corruption.

The whole point of holding the lock from `mspi_dev_config()` to `mspi_get_channel_status()` is that B's `mspi_dev_config()` must *block* in `k_mutex_lock()` until A calls `mspi_get_channel_status()`. With the lock released early, that mutual exclusion never happens.

## The fix

The same pattern is applied to all three drivers:

- A successful `mspi_dev_config()` **keeps** the controller lock - the session stays open. Both success paths (`MSPI_DEVICE_CONFIG_NONE` and a successful device-config save) now `return 0` without unlocking.
- `mspi_get_channel_status()` **releases** the lock and clears the device ownership (`dev_id = NULL`) once the controller is idle, and returns `-EBUSY` without touching the lock while the controller is still busy.
- Error paths in `mspi_dev_config()` release the lock and reset ownership **only when that call actually took the lock** (`locked == true`), so a failed re-configuration inside an ongoing session does not tear the session down.

## Per-driver notes

**XSPI** (`mspi_stm32_xspi.c`)
- Restructured `mspi_dev_config()` so success keeps the lock and only error paths reach the unlock.
- The controller re-init force-release now also clears `dev_id`, so a subsequent `mspi_dev_config()` re-takes the lock instead of skipping it because of a stale owner.

**OSPI** (`mspi_stm32_ospi.c`)
- Same `mspi_dev_config()` / `mspi_get_channel_status()` fix, including the re-init force-release clearing `dev_id`.
- `mspi_get_channel_status()` previously cleared `dev_id` unconditionally, even on the busy (`-EBUSY`) path; it now clears it and releases the lock only when the controller is idle.
- Dropped a redundant `dev_id` assignment.

**QSPI** (`mspi_stm32_qspi.c`)
- Same `mspi_dev_config()` / `mspi_get_channel_status()` fix.
- QSPI has no controller re-init force-release path, so that part of the fix does not apply.
- The PM suspend handler already takes and releases the lock as a self-contained pair; with this change it now correctly refuses to suspend (`-EBUSY`) while a device session still holds the controller.