### PR TITLE
tests: shell: exclude qemu_x86_64/atom on shell.core.metakeys

### DIFF
--- a/tests/subsys/shell/shell/tests.yaml
+++ b/tests/subsys/shell/shell/tests.yaml
@@ -11,6 +11,9 @@ tests:
     min_ram: 32
     extra_configs:
       - CONFIG_SHELL_METAKEYS=y
+    exclude_platforms:
+      # flaky tests, platform disables icount with > 1 CPU
+      - qemu_x86_64/atom
     integration_platforms:
       - native_sim
   # all tests below are just a build test verifying config options, it fails if run


### PR DESCRIPTION
Test is flaky on this platform with icount disabled.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
