### PR TITLE
boards: qemu_x86_tiny: up DRAM size to 384K

### DIFF
--- a/boards/qemu/x86/qemu_x86_tiny.dts
+++ b/boards/qemu/x86/qemu_x86_tiny.dts
@@ -6,5 +6,5 @@
 
 /* Note: this is the unit-address (in hex) of the node */
 #define DT_DRAM_BASE            100000
-#define DT_DRAM_SIZE            DT_SIZE_K(256)
+#define DT_DRAM_SIZE            DT_SIZE_K(384)
 #include "qemu_x86.dts"

--- a/boards/qemu/x86/qemu_x86_tiny.yaml
+++ b/boards/qemu/x86/qemu_x86_tiny.yaml
@@ -14,5 +14,5 @@ testing:
     - llext
   ignore_tags:
     - benchmark
-ram: 256
+ram: 384
 vendor: qemu


### PR DESCRIPTION
Some of the tests are complaining about ROM size so we need to up the DRAM size to accommodate ever increasing binary size.