### PR TITLE
ci: check DCO sign-off with a dedicated workflow

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -90,10 +90,6 @@ jobs:
         # Increase rename limit to allow for large PRs
         git config diff.renameLimit 10000
         excludes="-e KconfigBasic -e SysbuildKconfigBasic -e ClangFormat"
-        # The signed-off-by check for dependabot should be skipped
-        if [ "${{ github.actor }}" == "dependabot[bot]" ]; then
-          excludes="$excludes -e Identity"
-        fi
         ./scripts/ci/check_compliance.py --annotate $excludes -c origin/${BASE_REF}..
 
     - name: upload-results

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+name: DCO Check
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dco-check:
+    name: Check DCO sign-off
+    runs-on: ubuntu-24.04
+    # The sign-off check for dependabot should be skipped
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history and the PR head so the action can resolve the base
+          # branch and merge-base (see actions/checkout#552).
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Check commit sign-off
+        uses: zephyrproject-rtos/action-dco@e3485a11e085fdc05fa4320e9cc3a86ccd665d89 # v1.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,6 @@ DevicetreeBindings.txt
 DevicetreeLinting.txt
 GitDiffCheck.txt
 Gitlint.txt
-Identity.txt
 ImageSize.txt
 Kconfig.txt
 KconfigBasic.txt

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -2108,66 +2108,6 @@ class CMakeStyle(StyleCheckMixin, ComplianceTest):
         )
 
 
-class Identity(ComplianceTest):
-    """
-    Checks if Emails of author and signed-off messages are consistent.
-    """
-
-    name = "Identity"
-    doc = zephyr_doc_detail_builder("/contribute/guidelines.html#commit-guidelines")
-
-    def run(self):
-        for shaidx in get_shas(COMMIT_RANGE):
-            commit_info = git('show', '-s', '--format=%an%n%ae%n%b', shaidx).split('\n', 2)
-
-            failures = []
-
-            if len(commit_info) == 2:
-                failures.append(f'{shaidx}: Empty commit message body')
-                auth_name, auth_email = commit_info
-                body = ''
-            elif len(commit_info) == 3:
-                auth_name, auth_email, body = commit_info
-            else:
-                self.failure(f'Unable to parse commit message for {shaidx}')
-                continue
-
-            if auth_email.endswith("@users.noreply.github.com"):
-                failures.append(
-                    f"{shaidx}: author email ({auth_email}) must "
-                    "be a real email and cannot end in "
-                    "@users.noreply.github.com"
-                )
-
-            # Returns an array of everything to the right of ':' on each signoff line
-            signoff_lines = re.findall(r"signed-off-by:\s(.*)", body, re.IGNORECASE)
-            if len(signoff_lines) == 0:
-                failures.append(f'{shaidx}: Missing signed-off-by line')
-            else:
-                # Validate all signoff lines' syntax while also searching for commit author
-                found_author_signoff = False
-                for signoff in signoff_lines:
-                    match = re.search(r"(.+) <(.+)>", signoff)
-
-                    if not match:
-                        failures.append(
-                            f"{shaidx}: Signed-off-by line ({signoff}) "
-                            "does not follow the syntax: First "
-                            "Last <email>."
-                        )
-                    elif (auth_name, auth_email) == match.groups():
-                        found_author_signoff = True
-
-                if not found_author_signoff:
-                    failures.append(
-                        f"{shaidx}: author name ({auth_name}) and email ({auth_email}) "
-                        "needs to match one of the signed-off-by entries."
-                    )
-
-            if failures:
-                self.failure('\n'.join(failures))
-
-
 class BinaryFiles(ComplianceTest):
     """
     Check that the diff contains no binary files.
@@ -3018,7 +2958,7 @@ def parse_args(argv):
         const=f'{empty_tree}..HEAD',
         help="""The full history commit range. Useful for testing purposes.
                 WARNING: Should not be set for checks that perform per-commit actions, such as
-                GitDiffCheck/GitLint/Identity.""",
+                GitDiffCheck/GitLint.""",
     )
     parser.add_argument(
         '-o',


### PR DESCRIPTION
Add a dco.yml workflow that runs the [action-dco](https://github.com/zephyrproject-rtos/action-dco) composite action over a pull request's commits, verifying each carries a `Signed-off-by` line matching the author (`First Last <email>`) as required by the DCO.

Drop the now-redundant `Identity` compliance check, along with its .gitignore output entry and the dependabot exclude in compliance.yml. The empty-body check it also did stays covered by gitlint's body-is-missing rule.