### PR TITLE
ci: workflows: consolidate and harden CI workflows

### DIFF
--- a/.github/actions/zephyr-ci-env/action.yml
+++ b/.github/actions/zephyr-ci-env/action.yml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Zephyr CI setup'
+description: >-
+  Rebase the pull request, initialise the west workspace and update modules
+  from the repo cache. Optionally print the toolchain/environment state. Must
+  run after the repository has been checked out.
+
+inputs:
+  group-filter:
+    description: >-
+      Value passed to "west config manifest.group-filter". When empty the
+      manifest group filter is left unchanged.
+    required: false
+    default: ''
+  base-ref:
+    description: 'Base ref to rebase pull requests onto (github.base_ref).'
+    required: false
+    default: ''
+  run-checks:
+    description: >-
+      When "true", print the CMake/toolchain versions and git refs after the
+      workspace has been set up.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Environment Setup
+      shell: bash
+      env:
+        BASE_REF: ${{ inputs.base-ref }}
+        GROUP_FILTER: ${{ inputs.group-filter }}
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          git config --global user.email "bot@zephyrproject.org"
+          git config --global user.name "Zephyr Builder"
+          rm -fr ".git/rebase-apply"
+          rm -fr ".git/rebase-merge"
+          git rebase origin/${BASE_REF}
+          git clean -f -d
+          git log --pretty=oneline -n 10
+        fi
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+        west init -l . || true
+        if [ -n "${GROUP_FILTER}" ]; then
+          west config manifest.group-filter -- ${GROUP_FILTER}
+        fi
+        west config --global update.narrow true
+        west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
+        west forall -c 'git reset --hard HEAD'
+
+        echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
+
+    - name: Check Environment
+      if: inputs.run-checks == 'true'
+      shell: bash
+      run: |
+        cmake --version
+        gcc --version
+        cargo --version
+        rustup target list --installed
+        ls -la
+        echo "github.ref: ${{ github.ref }}"
+        echo "github.base_ref: ${{ github.base_ref }}"
+        echo "github.ref_name: ${{ github.ref_name }}"

--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -23,6 +23,7 @@ jobs:
     name: Pull Request/Issue Assignment
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       issues: write        # to add assignees to issues
       pull-requests: write # posting comments when new users being added.

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,6 +14,7 @@ jobs:
   backport:
     name: Backport
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: write       # to create/push backport branches
       pull-requests: write  # to create backport PRs

--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -20,6 +20,7 @@ jobs:
       group: backport-issue-check-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     if: github.repository == 'zephyrproject-rtos/zephyr'
     permissions:
       issues: read # to check if associated issue exists for backport and post comments

--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 1
           sparse-checkout: |
             scripts/release/list_backports.py

--- a/.github/workflows/bsim-tests-publish.yaml
+++ b/.github/workflows/bsim-tests-publish.yaml
@@ -13,6 +13,7 @@ jobs:
   bsim-test-results:
     name: "Publish BabbleSim Test Results"
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     if: github.event.workflow_run.conclusion != 'skipped'
     permissions:
       checks: write # to create the check run entry with test results

--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -41,6 +41,7 @@ jobs:
     if: github.repository_owner == 'zephyrproject-rtos'
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
+    timeout-minutes: 120
     container:
       image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -77,6 +77,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Environment Setup

--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -81,23 +81,10 @@ jobs:
           fetch-depth: 0
 
       - name: Environment Setup
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          git config --global user.email "bot@zephyrproject.org"
-          git config --global user.name "Zephyr Bot"
-          rm -fr ".git/rebase-apply"
-          rm -fr ".git/rebase-merge"
-          git rebase origin/${BASE_REF}
-          git clean -f -d
-          git log  --pretty=oneline | head -n 10
-          west init -l . || true
-          west config manifest.group-filter -- +ci
-          west config --global update.narrow true
-          west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
-          west forall -c 'git reset --hard HEAD'
-
-          echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
+        uses: ./.github/actions/zephyr-ci-env
+        with:
+          group-filter: '+ci'
+          base-ref: ${{ github.base_ref }}
 
       - name: Install Python packages
         run: |

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -136,6 +136,7 @@ jobs:
     name: "Publish Unit Tests Results"
     needs: clang-build
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     permissions:
       checks: write # to create GitHub annotations
     if: (success() || failure())

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -60,25 +60,9 @@ jobs:
           persist-credentials: false
 
       - name: Environment Setup
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          git config --global user.email "bot@zephyrproject.org"
-          git config --global user.name "Zephyr Bot"
-          rm -fr ".git/rebase-apply"
-          rm -fr ".git/rebase-merge"
-          git clean -f -d
-          git log  --pretty=oneline | head -n 10
-          west init -l . || true
-          west config --global update.narrow true
-          west config manifest.group-filter -- +ci,+optional
-          # In some cases modules are left in a state where they can't be
-          # updated (i.e. when we cancel a job and the builder is killed),
-          # So first retry to update, if that does not work, remove all modules
-          # and start over. (Workaround until we implement more robust module
-          # west caching).
-          west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west2.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
-
-          echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
+        uses: ./.github/actions/zephyr-ci-env
+        with:
+          group-filter: '+ci,+optional'
 
       - name: Check Environment
         run: |

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -70,6 +70,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Python
@@ -165,6 +166,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Python

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -19,6 +19,7 @@ jobs:
     if: github.repository_owner == 'zephyrproject-rtos'
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
+    timeout-minutes: 360
     container:
       image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
       options: '--entrypoint /bin/bash'
@@ -156,6 +157,7 @@ jobs:
     name: "Publish Coverage Results"
     needs: codecov
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     # the codecov job might be skipped, we don't need to run this job then
     if: success() || failure()
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,11 @@ on:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     permissions:
       security-events: write
     strategy:

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -5,6 +5,10 @@ on: pull_request
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   compliance_job:
     runs-on: ubuntu-24.04

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Checkout the code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        persist-credentials: false
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   compliance_job:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     name: Run coding guidelines checks on patch series (PR)
     steps:
     - name: Checkout the code

--- a/.github/workflows/coding_guidelines_full.yml
+++ b/.github/workflows/coding_guidelines_full.yml
@@ -14,6 +14,7 @@ jobs:
     if: github.repository_owner == 'zephyrproject-rtos'
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
+    timeout-minutes: 300
     container:
       image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
       options: '--entrypoint /bin/bash'

--- a/.github/workflows/coding_guidelines_full.yml
+++ b/.github/workflows/coding_guidelines_full.yml
@@ -49,28 +49,10 @@ jobs:
           persist-credentials: false
 
       - name: Environment Setup
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-          west init -l . || true
-          west config manifest.group-filter -- +ci,+optional
-          west config --global update.narrow true
-          west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
-          west forall -c 'git reset --hard HEAD'
-
-          echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
-
-      - name: Check Environment
-        run: |
-          cmake --version
-          gcc --version
-          cargo --version
-          rustup target list --installed
-          ls -la
-          echo "github.ref: ${{ github.ref }}"
-          echo "github.base_ref: ${{ github.base_ref }}"
-          echo "github.ref_name: ${{ github.ref_name }}"
+        uses: ./.github/actions/zephyr-ci-env
+        with:
+          group-filter: '+ci,+optional'
+          run-checks: 'true'
 
       - name: SCA Setup
         uses: zephyrproject-rtos/action-sca-setup@681d9f46f28d391eb57e6f15fdb76af25d6c46bc

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_compliance:
     runs-on: ubuntu-24.04

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   check_compliance:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     name: Run compliance checks on patch series (PR)
     steps:
     - name: Update PATH for west

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Checkout the code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        persist-credentials: false
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 

--- a/.github/workflows/daily_test_version.yml
+++ b/.github/workflows/daily_test_version.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   get_version:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     if: github.repository == 'zephyrproject-rtos/zephyr'
 
     steps:

--- a/.github/workflows/daily_test_version.yml
+++ b/.github/workflows/daily_test_version.yml
@@ -30,6 +30,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        persist-credentials: false
         fetch-depth: 0
 
     - name: Set up Python

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   devicetree-checks:
     name: Devicetree script tests

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -27,6 +27,7 @@ jobs:
   devicetree-checks:
     name: Devicetree script tests
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ['3.12', '3.13']

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -31,6 +31,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        persist-credentials: false
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - name: Check if any file pulled into the Sphinx documentation changed
@@ -101,6 +102,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        persist-credentials: false
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
@@ -321,6 +323,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        persist-credentials: false
         path: zephyr
 
     - name: Set up Python

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -23,6 +23,7 @@ jobs:
   doc-file-check:
     name: Check for doc changes
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     outputs:
       sphinx_check: ${{ steps.check-sphinx-files.outputs.any_modified }}
       doxygen_check: ${{ steps.check-doxygen-files.outputs.any_modified }}

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -74,9 +74,6 @@ jobs:
     concurrency:
       group: doc-build-html-${{ github.ref }}
       cancel-in-progress: true
-    env:
-      BASE_REF: ${{ github.base_ref }}
-
 
     steps:
 
@@ -107,25 +104,9 @@ jobs:
         fetch-depth: 0
 
     - name: Environment Setup
-      run: |
-        if [ "${{github.event_name}}" = "pull_request" ]; then
-          git config --global user.email "bot@zephyrproject.org"
-          git config --global user.name "Zephyr Builder"
-          rm -fr ".git/rebase-apply"
-          rm -fr ".git/rebase-merge"
-          git rebase origin/${BASE_REF}
-          git clean -f -d
-          git log  --pretty=oneline | head -n 10
-        fi
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-        west init -l . || true
-        west config --global update.narrow true
-        west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
-        west forall -c 'git reset --hard HEAD'
-
-        echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
+      uses: ./.github/actions/zephyr-ci-env
+      with:
+        base-ref: ${{ github.base_ref }}
 
     - name: Install Python packages required for documentation build
       run: |

--- a/.github/workflows/doc-publish-pr.yml
+++ b/.github/workflows/doc-publish-pr.yml
@@ -17,6 +17,7 @@ jobs:
   doc-publish:
     name: Publish Documentation
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     if: |
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -20,6 +20,7 @@ jobs:
   doc-publish:
     name: Publish Documentation
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     if: |
       github.event.workflow_run.event != 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&

--- a/.github/workflows/doxygen-checks.yml
+++ b/.github/workflows/doxygen-checks.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Checkout PR Branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 

--- a/.github/workflows/doxygen-checks.yml
+++ b/.github/workflows/doxygen-checks.yml
@@ -34,6 +34,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   doxygen-checks:
     name: "Doxygen Checks"

--- a/.github/workflows/doxygen-checks.yml
+++ b/.github/workflows/doxygen-checks.yml
@@ -69,17 +69,9 @@ jobs:
           fetch-depth: 0
 
       - name: Environment Setup
-        run: |
-          git config --global user.email "bot@zephyrproject.org"
-          git config --global user.name "Zephyr Builder"
-          git rebase origin/${BASE_REF}
-          git clean -f -d
-
-          west init -l . || true
-          west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
-          west forall -c 'git reset --hard HEAD'
-
-          echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
+        uses: ./.github/actions/zephyr-ci-env
+        with:
+          base-ref: ${{ github.base_ref }}
 
       - name: Install Python packages
         run: |

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   check-errno:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-errno:
     runs-on: ubuntu-24.04

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -18,6 +18,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           path: zephyr
 
       - name: Setup Zephyr project

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -65,6 +65,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -26,6 +26,7 @@ jobs:
   footprint-tracking:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
+    timeout-minutes: 120
     if: github.repository_owner == 'zephyrproject-rtos'
     container:
       image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422

--- a/.github/workflows/greet_first_time_contributor.yml
+++ b/.github/workflows/greet_first_time_contributor.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   check_for_first_interaction:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     if: github.repository == 'zephyrproject-rtos/zephyr'
     permissions:
       pull-requests: write # to comment on pull requests

--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-14, windows-2025]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           path: zephyr
           fetch-depth: 0
 

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Checkout the code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        persist-credentials: false
         fetch-depth: 0
     - name: Scan the code
       id: scancode

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -5,6 +5,10 @@ on: [pull_request]
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scancode_job:
     runs-on: ubuntu-24.04

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   scancode_job:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     name: Scan code for licenses
     steps:
     - name: Checkout the code

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   contribs:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       pull-requests: write # to create/update pull request comments
     name: Manifest

--- a/.github/workflows/pinned-gh-actions.yml
+++ b/.github/workflows/pinned-gh-actions.yml
@@ -16,5 +16,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Ensure SHA pinned actions
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@ca46236c6ce584ae24bc6283ba8dcf4b3ec8a066 # v5.0.4

--- a/.github/workflows/pinned-gh-actions.yml
+++ b/.github/workflows/pinned-gh-actions.yml
@@ -12,6 +12,7 @@ jobs:
   check-sha-pinned-actions:
     name: Verify GitHub Actions
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/pinned-gh-actions.yml
+++ b/.github/workflows/pinned-gh-actions.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-sha-pinned-actions:
     name: Verify GitHub Actions

--- a/.github/workflows/pr_metadata_check.yml
+++ b/.github/workflows/pr_metadata_check.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           sparse-checkout: |
             scripts/ci/do_not_merge.py
             scripts/requirements-actions-basic.txt

--- a/.github/workflows/push_artifacts.yml
+++ b/.github/workflows/push_artifacts.yml
@@ -67,23 +67,7 @@ jobs:
           persist-credentials: false
 
       - name: Environment Setup
-        run: |
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-          west init -l . || true
-          west config --global update.narrow true
-          west update \
-            --path-cache /repo-cache/zephyrproject 2>&1 | tee west.update.log \
-            || west update \
-              --path-cache /repo-cache/zephyrproject 2>&1 | tee west.update.log \
-            || (
-              rm -rf ../modules ../bootloader ../tools
-              west update --path-cache /repo-cache/zephyrproject
-            )
-          west forall -c 'git reset --hard HEAD'
-
-          echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$(cat SDK_VERSION)" \
-            >> $GITHUB_ENV
+        uses: ./.github/actions/zephyr-ci-env
 
       - name: Install Python packages
         run: |

--- a/.github/workflows/pylib_tests.yml
+++ b/.github/workflows/pylib_tests.yml
@@ -26,6 +26,7 @@ jobs:
   pylib-tests:
     name: Misc. Pylib Unit Tests
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ['3.12', '3.13']

--- a/.github/workflows/pylib_tests.yml
+++ b/.github/workflows/pylib_tests.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/pylib_tests.yml
+++ b/.github/workflows/pylib_tests.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pylib-tests:
     name: Misc. Pylib Unit Tests

--- a/.github/workflows/ready-to-merge.yml
+++ b/.github/workflows/ready-to-merge.yml
@@ -14,6 +14,7 @@ jobs:
   all_jobs_passed:
     name: all jobs passed
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: "Check status of all required jobs"
         run: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Get the version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     permissions:
       contents: write # to create GitHub release entry
     steps:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -21,6 +21,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       # Needed for Code scanning upload
       security-events: write

--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -35,6 +35,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 

--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -26,6 +26,7 @@ jobs:
   scripts-tests:
     name: Scripts tests
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
       matrix:
         python-version: ['3.12', '3.13']

--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scripts-tests:
     name: Scripts tests

--- a/.github/workflows/stale-workflow-queue-cleanup.yml
+++ b/.github/workflows/stale-workflow-queue-cleanup.yml
@@ -17,6 +17,7 @@ jobs:
   cleanup:
     name: Cleanup
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     if: github.ref == 'refs/heads/main'
     permissions:
       actions: write # to delete stale workflow runs

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -10,6 +10,7 @@ jobs:
   stale:
     name: Find Stale issues and PRs
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     if: github.repository == 'zephyrproject-rtos/zephyr'
     permissions:
       pull-requests: write # to comment on stale pull requests

--- a/.github/workflows/stats_merged_prs.yml
+++ b/.github/workflows/stats_merged_prs.yml
@@ -19,6 +19,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: |
             scripts/ci/stats/merged_prs.py

--- a/.github/workflows/stats_merged_prs.yml
+++ b/.github/workflows/stats_merged_prs.yml
@@ -14,6 +14,7 @@ jobs:
   record_merged:
     if: github.event.pull_request.merged == true && github.repository == 'zephyrproject-rtos/zephyr'
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/twister-publish.yaml
+++ b/.github/workflows/twister-publish.yaml
@@ -20,6 +20,7 @@ jobs:
       ELASTICSEARCH_KEY: ${{ secrets.ELASTICSEARCH_KEY }}
       ELASTICSEARCH_SERVER: "https://elasticsearch.zephyrproject.io:443"
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       # Needed for elasticearch and upload script
       - name: Checkout

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -27,6 +27,7 @@ jobs:
     if: github.repository_owner == 'zephyrproject-rtos'
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
+    timeout-minutes: 60
     container:
       image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
       options: '--entrypoint /bin/bash'
@@ -305,6 +306,7 @@ jobs:
     needs:
       - twister-build
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       checks: write # to create the check run entry with Twister test results
     # the build-and-test job might be skipped, we don't need to run this job then

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -34,6 +34,7 @@ jobs:
       subset: ${{ steps.output-services.outputs.subset }}
       size: ${{ steps.output-services.outputs.size }}
       fullrun: ${{ steps.output-services.outputs.fullrun }}
+      testplan: ${{ steps.test-plan.outputs.has_testplan }}
     env:
       MATRIX_SIZE: 10
       PUSH_MATRIX_SIZE: 25
@@ -130,7 +131,20 @@ jobs:
           else
             echo "TWISTER_NODES=${MATRIX_SIZE}" >> $GITHUB_ENV
           fi
-          rm -f testplan.json .testplan
+          if [ -f testplan.json ]; then
+            echo "has_testplan=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_testplan=false" >> $GITHUB_OUTPUT
+          fi
+          rm -f .testplan
+
+      - name: Upload Test Plan
+        if: github.event_name == 'pull_request' && steps.test-plan.outputs.has_testplan == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: testplan
+          if-no-files-found: error
+          path: testplan.json
 
       - name: Determine matrix size
         id: output-services
@@ -267,6 +281,13 @@ jobs:
           west update
           make everything -s -j 8
 
+      - name: Download Test Plan
+        if: github.event_name == 'pull_request' && needs.twister-build-prep.outputs.testplan == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: testplan
+          path: .
+
       - if: github.event_name == 'push'
         name: Run Tests with Twister (Push)
         id: run_twister
@@ -285,12 +306,8 @@ jobs:
         name: Run Tests with Twister (Pull Request)
         id: run_twister_pr
         run: |
-          rm -f testplan.json
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-          python3 ./scripts/ci/test_plan_v2.py -c origin/${BASE_REF}.. \
-            --disable-strategy  BoilerplateFilter
-
           if [ -f testplan.json ]; then
             ./scripts/twister --subset ${{matrix.subset}}/${{ strategy.job-total }} --load-tests testplan.json ${TWISTER_COMMON} ${PR_OPTIONS}
             if [ "${{matrix.subset}}" = "1" -a ${{needs.twister-build-prep.outputs.fullrun}} = 'True' ]; then

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -139,6 +139,7 @@ jobs:
             subset="[$(seq -s',' 1 ${WEEKLY_MATRIX_SIZE})]"
             size=${WEEKLY_MATRIX_SIZE}
           else
+            subset='[]'
             size=0
           fi
 

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -238,47 +238,49 @@ jobs:
           name: testplan
           path: .
 
-      - if: github.event_name == 'push'
-        name: Run Tests with Twister (Push)
+      - name: Run Tests with Twister
         id: run_twister
         run: |
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-          ./scripts/twister --subset ${{matrix.subset}}/${{ strategy.job-total }} ${TWISTER_COMMON} ${PUSH_OPTIONS}
-          if [ "${{matrix.subset}}" = "1" ]; then
-            ./scripts/zephyr_module.py --twister-out module_tests.args
-            if [ -s module_tests.args ]; then
-              ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} ${PUSH_OPTIONS}
-            fi
-          fi
 
-      - if: github.event_name == 'pull_request'
-        name: Run Tests with Twister (Pull Request)
-        id: run_twister_pr
-        run: |
-          export ZEPHYR_BASE=${PWD}
-          export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-          if [ -f testplan.json ]; then
-            ./scripts/twister --subset ${{matrix.subset}}/${{ strategy.job-total }} --load-tests testplan.json ${TWISTER_COMMON} ${PR_OPTIONS}
-            if [ "${{matrix.subset}}" = "1" -a ${{needs.twister-build-prep.outputs.fullrun}} = 'True' ]; then
+          # Select the per-event twister options and, for pull requests, load
+          # the pre-computed test plan.
+          LOAD_TESTS=""
+          case "${{ github.event_name }}" in
+            push)
+              OPTIONS="${PUSH_OPTIONS}"
+              ;;
+            schedule)
+              OPTIONS="${WEEKLY_OPTIONS}"
+              ;;
+            pull_request)
+              OPTIONS="${PR_OPTIONS}"
+              # testplan.json is only present when targeted tests were
+              # selected; without it there is nothing to run.
+              if [ ! -f testplan.json ]; then
+                echo "No testplan.json - nothing to run."
+                exit 0
+              fi
+              LOAD_TESTS="--load-tests testplan.json"
+              ;;
+          esac
+
+          ./scripts/twister --subset ${{matrix.subset}}/${{ strategy.job-total }} ${LOAD_TESTS} ${TWISTER_COMMON} ${OPTIONS}
+
+          # Module tests run once, on the first subset. On pull requests they
+          # only run for a full run.
+          if [ "${{matrix.subset}}" = "1" ]; then
+            run_modules=true
+            if [ "${{ github.event_name }}" = "pull_request" ] && \
+               [ "${{ needs.twister-build-prep.outputs.fullrun }}" != "True" ]; then
+              run_modules=false
+            fi
+            if [ "${run_modules}" = "true" ]; then
               ./scripts/zephyr_module.py --twister-out module_tests.args
               if [ -s module_tests.args ]; then
-                ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} ${PR_OPTIONS}
+                ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} ${OPTIONS}
               fi
-            fi
-          fi
-
-      - if: github.event_name == 'schedule'
-        name: Run Tests with Twister (Weekly)
-        id: run_twister_sched
-        run: |
-          export ZEPHYR_BASE=${PWD}
-          export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-          ./scripts/twister --subset ${{matrix.subset}}/${{ strategy.job-total }} ${TWISTER_COMMON} ${WEEKLY_OPTIONS}
-          if [ "${{matrix.subset}}" = "1" ]; then
-            ./scripts/zephyr_module.py --twister-out module_tests.args
-            if [ -s module_tests.args ]; then
-              ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} ${WEEKLY_OPTIONS}
             fi
           fi
 

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -71,6 +71,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Only needed on pull requests, where the test plan is generated below.
+      # On push/schedule the matrix size is fixed and needs no west workspace.
+      # Runs before the Python setup so requirements are installed from the
+      # rebased tree.
+      - name: Set up Zephyr environment
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/zephyr-ci-env
+        with:
+          group-filter: '+ci,'
+          base-ref: ${{ github.base_ref }}
+          run-checks: 'true'
+
       - name: Set up Python
         if: github.event_name == 'pull_request'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -83,16 +95,6 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           pip install -r scripts/requirements-actions.txt --require-hashes
-
-      # Only needed on pull requests, where the test plan is generated below.
-      # On push/schedule the matrix size is fixed and needs no west workspace.
-      - name: Set up Zephyr environment
-        if: github.event_name == 'pull_request'
-        uses: ./.github/actions/zephyr-ci-env
-        with:
-          group-filter: '+ci,'
-          base-ref: ${{ github.base_ref }}
-          run-checks: 'true'
 
       - name: Generate Test Plan with Twister
         if: github.event_name == 'pull_request'

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -40,7 +40,6 @@ jobs:
       PUSH_MATRIX_SIZE: 25
       WEEKLY_MATRIX_SIZE: 200
       TESTS_PER_BUILDER: 900
-      COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
     steps:
       - name: Print cloud service information
@@ -172,7 +171,6 @@ jobs:
       WEEKLY_OPTIONS: ' -M --build-only --all --show-footprint --report-filtered -j 32'
       PR_OPTIONS: ' --clobber-output --integration -j 16'
       PUSH_OPTIONS: ' --clobber-output -M --show-footprint --report-filtered -j 16'
-      COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       LLVM_TOOLCHAIN_PATH: /usr/lib/llvm-20
     steps:
       - name: Print cloud service information

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -84,38 +84,15 @@ jobs:
         run: |
           pip install -r scripts/requirements-actions.txt --require-hashes
 
-      - name: Environment Setup
-        run: |
-          if [ "${{github.event_name}}" = "pull_request" ]; then
-            git config --global user.email "bot@zephyrproject.org"
-            git config --global user.name "Zephyr Builder"
-            rm -fr ".git/rebase-apply"
-            rm -fr ".git/rebase-merge"
-            git rebase origin/${BASE_REF}
-            git clean -f -d
-            git log  --pretty=oneline | head -n 10
-          fi
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-          west init -l . || true
-          west config manifest.group-filter -- +ci,
-          west config --global update.narrow true
-          west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
-          west forall -c 'git reset --hard HEAD'
-
-          echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
-
-      - name: Check Environment
-        run: |
-          cmake --version
-          gcc --version
-          cargo --version
-          rustup target list --installed
-          ls -la
-          echo "github.ref: ${{ github.ref }}"
-          echo "github.base_ref: ${{ github.base_ref }}"
-          echo "github.ref_name: ${{ github.ref_name }}"
+      # Only needed on pull requests, where the test plan is generated below.
+      # On push/schedule the matrix size is fixed and needs no west workspace.
+      - name: Set up Zephyr environment
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/zephyr-ci-env
+        with:
+          group-filter: '+ci,'
+          base-ref: ${{ github.base_ref }}
+          run-checks: 'true'
 
       - name: Generate Test Plan with Twister
         if: github.event_name == 'pull_request'
@@ -196,7 +173,6 @@ jobs:
       PR_OPTIONS: ' --clobber-output --integration -j 16'
       PUSH_OPTIONS: ' --clobber-output -M --show-footprint --report-filtered -j 16'
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
-      BASE_REF: ${{ github.base_ref }}
       LLVM_TOOLCHAIN_PATH: /usr/lib/llvm-20
     steps:
       - name: Print cloud service information
@@ -226,38 +202,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Environment Setup
-        run: |
-          if [ "${{github.event_name}}" = "pull_request" ]; then
-            git config --global user.email "bot@zephyrproject.org"
-            git config --global user.name "Zephyr Builder"
-            rm -fr ".git/rebase-apply"
-            rm -fr ".git/rebase-merge"
-            git rebase origin/${BASE_REF}
-            git clean -f -d
-            git log  --pretty=oneline | head -n 10
-          fi
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-          west init -l . || true
-          west config manifest.group-filter -- +ci,+optional,+testing
-          west config --global update.narrow true
-          west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
-          west forall -c 'git reset --hard HEAD'
-
-          echo "ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-$( cat SDK_VERSION )" >> $GITHUB_ENV
-
-      - name: Check Environment
-        run: |
-          cmake --version
-          gcc --version
-          cargo --version
-          rustup target list --installed
-          ls -la
-          echo "github.ref: ${{ github.ref }}"
-          echo "github.base_ref: ${{ github.base_ref }}"
-          echo "github.ref_name: ${{ github.ref_name }}"
+      - name: Set up Zephyr environment
+        uses: ./.github/actions/zephyr-ci-env
+        with:
+          group-filter: '+ci,+optional,+testing'
+          base-ref: ${{ github.base_ref }}
+          run-checks: 'true'
 
       - name: Install Python packages
         run: |

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -33,6 +33,7 @@ jobs:
   twister-tests:
     name: Twister Unit Tests
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
       matrix:
         python-version: ['3.12', '3.13']

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -29,6 +29,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   twister-tests:
     name: Twister Unit Tests

--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -21,6 +21,10 @@ permissions:
 env:
   PYTHONIOENCODING: utf-8
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   twister-tests:
     name: Twister Black Box Tests

--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        persist-credentials: false
         path: zephyr
         fetch-depth: 0
 

--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -29,6 +29,7 @@ jobs:
         python-version: ['3.12', '3.13']
       fail-fast: false
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -28,6 +28,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   west-commands:
     name: West Command Tests

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -32,6 +32,7 @@ jobs:
   west-commands:
     name: West Command Tests
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ['3.12', '3.13']


### PR DESCRIPTION
Cleans up the GitHub Actions workflows with no change to what CI verifies. The
duplicated repo-cache west setup (west init/update + toolchain checks) is
extracted into a reusable zephyr-ci-env composite action and adopted across the
twister, doc-build, coding-guidelines, bsim, clang, doxygen, and push-artifacts
workflows.

The twister flow is tightened along the way — the PR test plan is computed once
and shared as an artifact, the per-event run steps are unified, and dead config
is removed.

On top of that, tree-wide hygiene: explicit timeout-minutes on jobs
that inherited the 6-hour default, persist-credentials: false on non-pushing
checkouts, and concurrency cancellation on PR check workflows.
