### PR TITLE
llext-edk: Propagate west topdir when --sysbuild is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2426,6 +2426,7 @@ if(CONFIG_LLEXT_EDK)
       ${SYSCALL_LONG_REGISTERS_ARG}
       ${SYSCALL_SPLIT_TIMEOUT_ARG}
     COMMAND ${CMAKE_COMMAND}
+        -DSYSBUILD=${SYSBUILD}
         -P ${ZEPHYR_BASE}/cmake/llext-edk.cmake
     DEPENDS ${logical_target_for_zephyr_elf} ${syscalls_json} build_info_yaml_saved llext_edk_build_props
     COMMAND_EXPAND_LISTS

--- a/cmake/llext-edk.cmake
+++ b/cmake/llext-edk.cmake
@@ -154,7 +154,11 @@ endif()
 
 set(build_flags_dir ${PROJECT_BINARY_DIR}/misc/llext_edk)
 set(build_info_file ${PROJECT_BINARY_DIR}/../build_info.yml)
+set(sysbuild_info_file ${PROJECT_BINARY_DIR}/../../build_info.yml)
 yaml_load(FILE ${build_info_file} NAME build_info)
+if(SYSBUILD)
+  yaml_load(FILE ${sysbuild_info_file} NAME sysbuild_info)
+endif()
 
 # process C flags
 file(READ ${build_flags_dir}/c_flags.txt llext_edk_c_flags_raw)
@@ -181,7 +185,11 @@ list(TRANSFORM llext_edk_c_incs REPLACE "^-I" "")
 
 yaml_get(llext_edk_file NAME build_info KEY cmake llext-edk file)
 yaml_get(APPLICATION_SOURCE_DIR NAME build_info KEY cmake application source-dir)
-yaml_get(WEST_TOPDIR NAME build_info KEY west topdir)
+if(SYSBUILD)
+  yaml_get(WEST_TOPDIR NAME sysbuild_info KEY west topdir)
+else()
+  yaml_get(WEST_TOPDIR NAME build_info KEY west topdir)
+endif()
 
 yaml_get(board_name NAME build_info KEY cmake board name)
 yaml_get(board_qualifiers NAME build_info KEY cmake board qualifiers)


### PR DESCRIPTION
When sysbuild is used with west (west build --sysbuild), west TOPDIR variable is not saved to application build_info.yml, so includes relative to west TOPDIR (such as modules) are handled as absolute paths during EDK build.
Propagate west TOPDIR to application llext-edk entries in build_info.yml so it can be retrieved when the EDK is built.

Fixes: #110728