### PR TITLE
Revise Arm maintainership

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -376,6 +376,15 @@ Alif Semiconductor Platforms:
   description: >-
     Alif Semiconductor SoCs, device tree files, and related drivers.
 
+Allwinner Platforms:
+  status: odd fixes
+  files:
+    - dts/arm/allwinner/
+    - dts/arm64/allwinner/
+    - soc/allwinner/
+  labels:
+    - "platform: Allwinner"
+
 Ambiq Platforms:
   status: maintained
   maintainers:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -261,12 +261,18 @@ ARM Platforms:
     - boards/arm/mps*/
     - boards/arm/v2m_*/
     - boards/arm/fvp_base*/
+    - boards/qemu/cortex_a53/
+    - boards/qemu/kvm_arm64/
     - soc/arm/mps*/
     - soc/arm/musca/
     - soc/arm/beetle/
     - soc/arm/designstart/
     - soc/arm/fvp_aemv8*/
+    - soc/arm/qemu_cortex_a53/
+    - soc/arm/qemu_virt_arm64/
     - dts/arm/armv*.dtsi
+    - dts/arm64/fvp/
+    - dts/arm64/qemu/
     - dts/bindings/arm/arm*.yaml
     - drivers/interrupt_controller/intc_gic*
   labels:
@@ -322,9 +328,7 @@ ARM64 arch:
     - arch/arm64/
     - include/zephyr/arch/arm64/
     - tests/arch/arm64/
-    - dts/arm64/
-    - boards/qemu/kvm_arm64/
-    - boards/qemu/cortex_a53/
+    - dts/arm64/armv*.dtsi
   labels:
     - "area: ARM64"
   tests:
@@ -5966,6 +5970,7 @@ TI K3 Platforms:
     - dts/arm/ti/j7*
     - dts/bindings/*/ti,k3*
     - dts/vendor/ti/
+    - dts/arm64/ti/
     - soc/ti/k3/
   labels:
     - "platform: TI K3"

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -275,6 +275,7 @@ ARM Platforms:
     - dts/arm64/qemu/
     - dts/bindings/arm/arm*.yaml
     - drivers/interrupt_controller/intc_gic*
+    - tests/arch/arm64/arm64_gicv3_its/boards/fvp_*.conf
   labels:
     - "platform: ARM"
 
@@ -329,6 +330,8 @@ ARM64 arch:
     - include/zephyr/arch/arm64/
     - tests/arch/arm64/
     - dts/arm64/armv*.dtsi
+  files-exclude:
+    - tests/arch/arm64/arm64_gicv3_its/boards/
   labels:
     - "area: ARM64"
   tests:
@@ -4375,6 +4378,7 @@ NXP Platforms (MPU):
     - soc/nxp/imx/
     - soc/nxp/layerscape/
     - boards/nxp/ls1046ardb/
+    - tests/arch/arm64/arm64_gicv3_its/boards/imx*.conf
   files-regex:
     - boards/nxp/.*m?imx[^(rt)].*/
   labels:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5461,6 +5461,15 @@ Retention:
   labels:
     - "area: Retention"
 
+Rockchip Platforms:
+  status: odd fixes
+  files:
+    - dts/arm/rockchip/
+    - dts/arm64/rockchip/
+    - soc/rockchip/
+  labels:
+    - "platform: Rockchip"
+
 SPARC arch:
   status: odd fixes
   collaborators:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -291,11 +291,11 @@ ARM SiP SVC:
 ARM arch:
   status: maintained
   maintainers:
-    - wearyzen
     - ithinuel
   collaborators:
     - MaureenHelm
     - stephanosio
+    - wearyzen
   files:
     - arch/arm/
     - arch/arm/core/offsets/


### PR DESCRIPTION
The current MAINTAINERS layout causes many platform-specific changes to be routed to the ARM64 architecture maintainers simply because they target Arm64-based SoCs. In practice, these changes are often unrelated to the ARM64 architecture itself and are better reviewed independently of the architecture maintainers.

This PR refines the maintainership boundaries by limiting ARM64 architecture ownership to architecture-specific code and assigning platform-specific boards, SoCs, devicetree files, and test configurations to their corresponding platform areas.

This reduces unnecessary review requests for ARM64 architecture maintainers, makes ownership gaps explicit, and better distributes review responsibility across maintainers.
