### PR TITLE
ci: test_plan_v2: fix ManifestStrategy crash on unchanged revisions

### DIFF
--- a/scripts/ci/test_plan_v2.py
+++ b/scripts/ci/test_plan_v2.py
@@ -3182,7 +3182,7 @@ class ManifestStrategy(SelectionStrategy):
                 "(e.g. comment / formatting edit) - no module tests needed.",
                 self.name,
             )
-            return set(manifest_files), set(manifest_files)
+            return [], set(manifest_files)
 
         log.info(
             "[%s] Changed west.yml modules: %s",

--- a/scripts/tests/ci/test_test_plan_v2.py
+++ b/scripts/tests/ci/test_test_plan_v2.py
@@ -613,6 +613,39 @@ class TestIgnoreStrategy:
 
 
 # ---------------------------------------------------------------------------
+# ManifestStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestManifestStrategy:
+    """Unit tests for ManifestStrategy."""
+
+    def _strategy(self, tmp_path, diff_result):
+        strategy = tp.ManifestStrategy(
+            zephyr_base=str(tmp_path), repo=mock.Mock(), commits="base..head"
+        )
+        strategy._diff_manifests = mock.Mock(return_value=diff_result)
+        return strategy
+
+    def test_no_revision_change_returns_no_calls(self, tmp_path):
+        # west.yml changed but no project revision differs (e.g. a
+        # comment/formatting edit, or an unrelated field such as
+        # `west-commands`). `calls` must stay a list of TwisterCall objects,
+        # not the set of consumed filenames - see run()'s `call.full_run`.
+        strategy = self._strategy(tmp_path, set())
+        calls, handled = strategy.analyze(["west.yml"])
+        assert calls == []
+        assert handled == {"west.yml"}
+
+    def test_revision_change_emits_call(self, tmp_path):
+        strategy = self._strategy(tmp_path, {"hal_realtek"})
+        calls, handled = strategy.analyze(["west.yml"])
+        assert len(calls) == 1
+        assert calls[0].extra_args == ["-t", "hal_realtek"]
+        assert handled == {"west.yml"}
+
+
+# ---------------------------------------------------------------------------
 # DirectTestStrategy
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`ManifestStrategy.analyze()` returns `set(manifest_files)` (the set of
consumed filenames) as the `calls` list when `west.yml` changed but no
project revision actually differs (e.g. an unrelated field addition or a
formatting edit). `TestPlanOrchestrator.run()` iterates `calls` and reads
`call.full_run`, so a plain filename string blows up with:

```
AttributeError: 'str' object has no attribute 'full_run'
```

This crashes the `twister-build-prep` job for any PR that touches
`west.yml` without bumping a project revision, regardless of what the
actual manifest change is. Observed on #110632, which only added a
`west-commands:` field to an existing `hal_realtek` entry.

## Fix

Return an empty `calls` list (`[]`) instead of the filename set, while
still returning the filenames as `handled` so the strategy correctly
consumes them.

## Test plan

- Added `TestManifestStrategy` covering both the no-revision-change path
  (previously crashing) and the revision-change path.
- Reverted the fix locally and confirmed the new
  `test_no_revision_change_returns_no_calls` test fails with the same
  `AssertionError` mirroring the original `AttributeError`, then restored
  the fix and confirmed it passes.
- `python3 -m pytest scripts/tests/ci/test_test_plan_v2.py` - 93 passed.
- `ruff check` on both changed files - clean.