### PR TITLE
modules: hal_realtek: fix undefined Kconfig symbol in os_wrapper

### DIFF
--- a/modules/hal_realtek/ameba/os_wrapper/os_wrapper_critical.c
+++ b/modules/hal_realtek/ameba/os_wrapper/os_wrapper_critical.c
@@ -13,11 +13,7 @@ static volatile uint32_t critical_nesting;
 
 int rtos_critical_is_in_interrupt(void)
 {
-#ifdef CONFIG_ARM_CORE_CM4
-	return (__get_xPSR() & 0x1FF) != 0;
-#else
 	return __get_IPSR() != 0;
-#endif
 }
 
 /*-------------------------------critical------------------------------*/


### PR DESCRIPTION
## Problem

`check_compliance.py`'s Kconfig undefined-reference check fails when
`hal_realtek` has not been fetched via `west update`:

```
Found references to undefined Kconfig symbols.
CONFIG_ARM_CORE_CM4    modules/hal_realtek/ameba/os_wrapper/os_wrapper_critical.c:16
```

## Root cause

`CONFIG_ARM_CORE_CM4` is defined only inside the external `hal_realtek`
west module (`modules/hal/realtek/ameba/<soc>/Kconfig`), reachable from
the zephyr tree only through the `osource` in
`modules/hal_realtek/Kconfig`, which resolves only once the module is
checked out. In a bare zephyr checkout without the module present, the
symbol is never parsed, so the compliance check reports it as
undefined even though the reference itself is legitimate.

## Fix

Both branches of the `#ifdef CONFIG_ARM_CORE_CM4` in
`rtos_critical_is_in_interrupt()` are functionally identical:
`__get_xPSR() & 0x1FF` extracts the ISR_NUMBER field, which is exactly
what `__get_IPSR()` already returns directly on Cortex-M. Dropping the
conditional removes the dependency on the HAL-only Kconfig symbol
instead of just allowlisting it.

## Testing

- `./scripts/checkpatch.pl --git HEAD` — clean
- `gitlint --commits upstream/main..HEAD` — clean