### PR TITLE
tests: lib: cmsis_nn: fix fully_connected on MVE targets

### DIFF
--- a/tests/lib/cmsis_nn/src/main.c
+++ b/tests/lib/cmsis_nn/src/main.c
@@ -405,6 +405,21 @@ ZTEST(cmsis_nn, test_fully_connected)
 
 	ctx.buf = malloc(buf_size);
 	ctx.size = buf_size;
+
+#if defined(ARM_MATH_MVEI)
+	/* On MVE targets the buffer must be pre-filled with per-row kernel sums
+	 * (bias + lhs_offset * sum-of-weights) before calling arm_fully_connected_s8.
+	 */
+	zassert_equal(ARM_CMSIS_NN_SUCCESS,
+		      arm_vector_sum_s8((int32_t *)ctx.buf,
+					filter_dims.n,
+					output_dims.c,
+					kernel_data,
+					fc_params.input_offset,
+					fc_params.filter_offset,
+					bias_data), "");
+#endif
+
 	arm_cmsis_nn_status result = arm_fully_connected_s8(&ctx,
 						   &fc_params,
 						   &quant_params,


### PR DESCRIPTION
## Problem

On Cortex-M55 (ARM_MATH_MVEI), `arm_fully_connected_s8()` requires
`ctx->buf` to be pre-populated with per-row kernel sums
(`bias + lhs_offset × Σweights`) via `arm_vector_sum_s8()` before
inference. Without this step the buffer contains uninitialised data,
causing wrong outputs and a test failure:

```
FAIL - test_fully_connected in 0.016 seconds
Assertion failed at tests/lib/cmsis_nn/src/main.c:422:
  (fully_connected_mve_0_output_ref not equal to output)
```

Reproduced on `rtl87x2g_evb_a/rtl8762gku` (Cortex-M55 with MVE).

## Root Cause

The official CMSIS-NN unit test (`Tests/UnitTest/TestCases/test_arm_fully_connected_s8/test_arm_fully_connected_s8.c`)
already guards the `arm_vector_sum_s8()` call with
`#if defined(ARM_MATH_MVEI)`. The Zephyr integration test was ported
without this step.

In the MVE code path of `arm_nn_vec_mat_mult_t_s8()`, the buffer is
read as the initial accumulator value (`acc_0 = *kernel_sum++`). On
non-MVE targets `get_buffer_size` returns 0 and the pointer is
discarded via `(void)kernel_sum`, so those targets are unaffected.

## Fix

Add the `#if defined(ARM_MATH_MVEI)` guarded `arm_vector_sum_s8()`
call before `arm_fully_connected_s8()`, matching the pattern used in
the official CMSIS-NN test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)