### PR TITLE
tests: arm: exclude RTL87x2G and RTL8752H from vector table relocation tests

### DIFF
--- a/tests/application_development/vector_table_relocation/tests.yaml
+++ b/tests/application_development/vector_table_relocation/tests.yaml
@@ -4,6 +4,8 @@ tests:
   application_development.vector_table_relocation.arm:
     arch_allow: arm
     filter: CONFIG_CPU_CORTEX_M_HAS_VTOR
+            and not CONFIG_SOC_SERIES_RTL87X2G
+            and not CONFIG_SOC_SERIES_RTL8752H
     # Exclude mps3/corstone310 because it uses another mechanism to support relocation
     # of the vector table (CONFIG_ROMSTART_RELOCATION_ROM).
     platform_exclude:
@@ -30,6 +32,7 @@ tests:
   application_development.vector_table_relocation.itcm:
     arch_allow: arm
     filter: CONFIG_CPU_CORTEX_M_HAS_VTOR and dt_chosen_enabled("zephyr,itcm")
+            and not CONFIG_SOC_SERIES_RTL87X2G
     # Exclude RAM-target boards where ITCM aliases flash: .sram_vt and
     # .rom_start then overlap due to independent linker counters.
     platform_exclude:

--- a/tests/arch/arm/arm_sw_vector_relay/tests.yaml
+++ b/tests/arch/arm/arm_sw_vector_relay/tests.yaml
@@ -1,13 +1,15 @@
 tests:
   arch.arm.sw_vector_relay:
-    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+    filter: (CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+          and not CONFIG_SOC_SERIES_RTL87X2G and not CONFIG_SOC_SERIES_RTL8752H
     tags:
       - vector_relay
     arch_allow: arm
     integration_platforms:
       - mps2/an385
   arch.arm.sw_vector_relay.sram_vector_table:
-    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+    filter: (CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+          and not CONFIG_SOC_SERIES_RTL87X2G and not CONFIG_SOC_SERIES_RTL8752H
     tags:
       - vector_relay
     arch_allow: arm


### PR DESCRIPTION
## Problem

`tests/application_development/vector_table_relocation` and
`tests/arch/arm/arm_sw_vector_relay` fail on `rtl87x2g_evb_a` and
`rtl8752h_evb` variants.

## Root Cause

RTL87x2G and RTL8752H reserve a dedicated RAM region for the vector
table and point `SCB->VTOR` to that address during SoC initialization.
Because `VTOR` is already set to a RAM address before any test code
runs, the precondition assumed by the vector-table relocation tests
(i.e. that they are free to move the vector table themselves) does not
hold, causing the tests to fail.

## Fix

Exclude `CONFIG_SOC_SERIES_RTL87X2G` and `CONFIG_SOC_SERIES_RTL8752H`
from the affected test cases via their `filter` expressions, consistent
with how other platforms with non-standard vector table handling are
already excluded (e.g. `mps3/corstone310`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)