### PR TITLE
boards: realtek: rtl87x2g: resize TCM split to 176K SRAM / 28K ITCM

### DIFF
--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.yaml
@@ -2,7 +2,7 @@ identifier: rtl87x2g_evb_a/rtl8762gkh
 name: RTL87x2G Model A Evaluation Board with RTL8762GKH Daughter Board
 type: mcu
 arch: arm
-ram: 100
+ram: 176
 flash: 828
 toolchain:
   - zephyr

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.yaml
@@ -2,7 +2,7 @@ identifier: rtl87x2g_evb_a/rtl8762gku
 name: RTL87x2G Model A Evaluation Board with RTL8762GKU Daughter Board
 type: mcu
 arch: arm
-ram: 100
+ram: 176
 flash: 828
 toolchain:
   - zephyr

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.yaml
@@ -2,7 +2,7 @@ identifier: rtl87x2g_evb_a/rtl8762grh
 name: RTL87x2G Model A Evaluation Board with RTL8762GRH Daughter Board
 type: mcu
 arch: arm
-ram: 100
+ram: 176
 flash: 316
 toolchain:
   - zephyr

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.yaml
@@ -2,7 +2,7 @@ identifier: rtl87x2g_evb_a/rtl8762gru
 name: RTL87x2G Model A Evaluation Board with RTL8762GRU Daughter Board
 type: mcu
 arch: arm
-ram: 100
+ram: 176
 flash: 316
 toolchain:
   - zephyr

--- a/dts/arm/realtek/bee/rtl87x2g.dtsi
+++ b/dts/arm/realtek/bee/rtl87x2g.dtsi
@@ -59,16 +59,16 @@
 			reg = <0x100000 DT_SIZE_K(3)>;
 		};
 
-		/* 0x100c00-0x13cc00: Free space for Zephyr */
+		/* 0x100c00-0x133c00: Free space for Zephyr */
 		tcm0: memory@100c00 {
 			/* TCM0, used as zephyr-sram */
-			reg = <0x100c00 DT_SIZE_K(100)>;
+			reg = <0x100c00 DT_SIZE_K(176)>;
 		};
 
-		tcm1: memory@119c00 {
+		tcm1: memory@12cc00 {
 			/* TCM1, used as zephyr-itcm */
 			compatible = "zephyr,memory-region", "arm,itcm";
-			reg = <0x119c00 DT_SIZE_K(104)>;
+			reg = <0x12cc00 DT_SIZE_K(28)>;
 			zephyr,memory-region = "ITCM";
 		};
 


### PR DESCRIPTION
## Summary

Resize the TCM split for RTL87x2G and correct the board yaml `ram`
fields to match the actual `zephyr,sram` allocation.

## Problem

RTL87x2G exposes 204 KB of TCM to Zephyr (0x100c00–0x133c00).
The previous split was 100 KB SRAM / 104 KB ITCM.  Actual ITCM usage
is ~2.2 KB of relocation tables, so ~101 KB of ITCM was idle.
Meanwhile SRAM is a bottleneck: tests such as the CMSIS-DSP
`matrix.binary_q15` require ≥144 KB of SRAM and fail with OOM.

The board yaml `ram` field was also stale (100 instead of the actual
`zephyr,sram` size).

## Changes

**`dts/arm/realtek/bee/rtl87x2g.dtsi`**

| Region | Before | After |
|--------|--------|-------|
| `tcm0` (zephyr,sram) start | 0x100c00 | 0x100c00 (unchanged) |
| `tcm0` size | 100 KB | **176 KB** |
| `tcm0` end | 0x119c00 | **0x12cc00** |
| `tcm1` (zephyr,itcm) start | 0x119c00 | **0x12cc00** |
| `tcm1` size | 104 KB | **28 KB** |
| `tcm1` end | 0x133c00 | 0x133c00 (unchanged) |

The total TCM window allocated to Zephyr is unchanged (204 KB).

**Board yaml** — `ram` updated from 100 → 176 for all four variants:
`rtl8762gkh`, `rtl8762gku`, `rtl8762grh`, `rtl8762gru`

🤖 Generated with [Claude Code](https://claude.com/claude-code)