### PR TITLE
arch: riscv: fix arch_float_disable() behavior and enable RISC-V test

### DIFF
--- a/arch/riscv/core/fpu.c
+++ b/arch/riscv/core/fpu.c
@@ -82,6 +82,7 @@ static void z_riscv_fpu_load(void)
 
 	/* become new owner */
 	atomic_ptr_set(&_current_cpu->arch.fpu_owner, _current);
+	_current->base.user_options |= K_FP_REGS;
 
 	/* restore our content */
 	z_riscv_status_set(MSTATUS_FS_INIT);
@@ -368,6 +369,7 @@ int arch_float_disable(struct k_thread *thread)
 	}
 
 	z_riscv_fpu_flush_thread(thread);
+	thread->base.user_options &= ~K_FP_REGS;
 
 	return 0;
 }

--- a/arch/riscv/core/fpu.c
+++ b/arch/riscv/core/fpu.c
@@ -336,22 +336,38 @@ void z_riscv_fpu_irq_offload_exit(void)
 }
 #endif /* CONFIG_RISCV_S_MODE */
 
-int arch_float_disable(struct k_thread *thread)
+/*
+ * Flush the FPU context for a thread without altering its user_options or
+ * fpu_recently_used state. This is used internally by the lazy-FPU IPI path
+ * and by arch_float_disable().
+ */
+void z_riscv_fpu_flush_thread(struct k_thread *thread)
 {
-	if (thread != NULL) {
-		unsigned int key = arch_irq_lock();
+	if (thread == NULL) {
+		return;
+	}
+
+	unsigned int key = arch_irq_lock();
 
 #ifdef CONFIG_SMP
-		flush_owned_fpu(thread);
+	flush_owned_fpu(thread);
 #else
-		if (thread == _current_cpu->arch.fpu_owner) {
-			z_riscv_fpu_disable();
-			arch_flush_local_fpu();
-		}
+	if (thread == _current_cpu->arch.fpu_owner) {
+		z_riscv_fpu_disable();
+		arch_flush_local_fpu();
+	}
 #endif
 
-		arch_irq_unlock(key);
+	arch_irq_unlock(key);
+}
+
+int arch_float_disable(struct k_thread *thread)
+{
+	if (thread == NULL) {
+		return -EINVAL;
 	}
+
+	z_riscv_fpu_flush_thread(thread);
 
 	return 0;
 }

--- a/arch/riscv/core/fpu.c
+++ b/arch/riscv/core/fpu.c
@@ -370,6 +370,7 @@ int arch_float_disable(struct k_thread *thread)
 
 	z_riscv_fpu_flush_thread(thread);
 	thread->base.user_options &= ~K_FP_REGS;
+	thread->arch.fpu_recently_used = false;
 
 	return 0;
 }

--- a/arch/riscv/core/ipi_clint.c
+++ b/arch/riscv/core/ipi_clint.c
@@ -83,9 +83,10 @@ void arch_spin_relax(void)
 	if (atomic_test_and_clear_bit(pending_ipi, IPI_FPU_FLUSH)) {
 		/*
 		 * We may not be in IRQ context here hence cannot use
-		 * arch_flush_local_fpu() directly.
+		 * arch_flush_local_fpu() directly. Use the helper that
+		 * flushes the FPU context without altering thread options.
 		 */
-		arch_float_disable(_current_cpu->arch.fpu_owner);
+		z_riscv_fpu_flush_thread(_current_cpu->arch.fpu_owner);
 	}
 }
 #endif /* CONFIG_FPU_SHARING */

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -114,6 +114,7 @@ int z_irq_do_offload(void);
 #ifdef CONFIG_FPU_SHARING
 void arch_flush_local_fpu(void);
 void arch_flush_fpu_ipi(unsigned int cpu);
+void z_riscv_fpu_flush_thread(struct k_thread *thread);
 #endif
 
 #ifndef CONFIG_MULTITHREADING

--- a/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
+++ b/tests/kernel/fpu_sharing/float_disable/src/k_float_disable.c
@@ -18,7 +18,7 @@
 #if defined(CONFIG_X86) && defined(CONFIG_X86_SSE)
 #define K_FP_OPTS (K_FP_REGS | K_SSE_REGS)
 #elif defined(CONFIG_X86) || defined(CONFIG_ARM64) || defined(CONFIG_ARM) || \
-	defined(CONFIG_SPARC)
+	defined(CONFIG_SPARC) || defined(CONFIG_RISCV)
 #define K_FP_OPTS K_FP_REGS
 #else
 #error "Architecture not supported for this test"
@@ -38,7 +38,7 @@ static void usr_fp_thread_entry_1(void *p1, void *p2, void *p3)
 	k_yield();
 }
 
-#if defined(CONFIG_ARM64) || defined(CONFIG_ARM) || \
+#if defined(CONFIG_ARM64) || defined(CONFIG_ARM) || defined(CONFIG_RISCV) || \
 	(defined(CONFIG_X86) && defined(CONFIG_LAZY_FPU_SHARING))
 #define K_FLOAT_DISABLE_SYSCALL_RETVAL 0
 #else
@@ -102,7 +102,8 @@ ZTEST(k_float_disable, test_k_float_disable_common)
 	zassert_true(
 		(usr_fp_thread.base.user_options & K_FP_OPTS) != 0,
 		"usr_fp_thread FP options cleared");
-#elif defined(CONFIG_ARM64) || (defined(CONFIG_X86) && defined(CONFIG_LAZY_FPU_SHARING))
+#elif defined(CONFIG_ARM64) || defined(CONFIG_RISCV) || \
+	(defined(CONFIG_X86) && defined(CONFIG_LAZY_FPU_SHARING))
 	zassert_true((k_float_disable(&usr_fp_thread) == 0),
 		"k_float_disable() failure");
 
@@ -145,7 +146,7 @@ ZTEST(k_float_disable, test_k_float_disable_syscall)
 	/* Yield will swap-in usr_fp_thread */
 	k_yield();
 
-#if defined(CONFIG_ARM64) || defined(CONFIG_ARM) || \
+#if defined(CONFIG_ARM64) || defined(CONFIG_ARM) || defined(CONFIG_RISCV) || \
 	(defined(CONFIG_X86) && defined(CONFIG_LAZY_FPU_SHARING))
 
 	/* Verify K_FP_OPTS are now cleared by the user thread itself */

--- a/tests/kernel/fpu_sharing/float_disable/tests.yaml
+++ b/tests/kernel/fpu_sharing/float_disable/tests.yaml
@@ -8,6 +8,7 @@ tests:
     arch_allow:
       - arm
       - arm64
+      - riscv
       - sparc
     filter: CONFIG_ARMV7_M_ARMV8_M_FP or CONFIG_ARMV7_R_FP or CONFIG_CPU_HAS_FPU
     extra_configs:


### PR DESCRIPTION
This PR fixes several issues in the RISC-V implementation of `arch_float_disable()`:                                      
                                                                                                                               
- Validate `thread` is non-NULL (return `-EINVAL`).                                                                       
- Clear `K_FP_REGS` so the kernel no longer treats the thread as FP-capable.                                              
- Clear `thread->arch.fpu_recently_used` so the lazy-FPU context switch path does not silently re-enable FPU access on the next switch back.                                                                                                           
                                                                                                                               
Unlike Cortex-M, RISC-V does not restrict `arch_float_disable()` to the current thread or exclude ISR context: 
`flush_owned_fpu()` can flush state for any thread, and FPU access is already disabled on exception entry.                  
                                                                                                                         
The `tests/kernel/fpu_sharing/float_disable` test is updated to run on RISC-V and treats it like ARM64/X86 lazy-FPU, i.e. `k_float_disable()` is supported for any thread.                                                                            
                                                                                                                         
Fixes #113645       