### PR TITLE
scripts: build: gen_kobject_list: handle arrays of const kernel objects

### DIFF
--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -319,6 +319,13 @@ class ConstType:
     def __repr__(self):
         return f"<const {self.child_type}>"
 
+    @property
+    def size(self):
+        # Delegate to the underlying type so that arrays of const-qualified
+        # kernel objects (e.g. "const struct device foo[N]") can compute the
+        # per-element stride. Mirrors has_kobject()/get_kobjects() delegation.
+        return type_env[self.child_type].size
+
     def has_kobject(self):
         if self.child_type not in type_env:
             return False


### PR DESCRIPTION
gen_kobject_list.py aborts with "'ConstType' object has no attribute 'size'" when a kernel object is an array of const-qualified objects, such as "const struct device dummy_devs[N]" in the I3C mem_slab driver.

ArrayType.get_kobjects() locates each element at addr + i * mt.size, where mt is the array's element type. When the element is const, mt is a ConstType, which delegated has_kobject() and get_kobjects() to its child type but never exposed size, so accessing mt.size raised AttributeError and stopped the build under CONFIG_USERSPACE.

Add a size property to ConstType that delegates to the underlying type, mirroring the existing has_kobject()/get_kobjects() delegation.

fix https://github.com/zephyrproject-rtos/zephyr/issues/113105