### PR TITLE
[Backport v4.3-branch] net: ipv6: fix memory leak for unsent NS packet

### DIFF
--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -2149,6 +2149,7 @@ int net_ipv6_send_ns(struct net_if *iface,
 
 			/* Let the system timeout and then send the NS again */
 			net_ipv6_nbr_unlock();
+			net_pkt_unref(pkt);
 			return 0;
 		}
 	}

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -837,12 +837,11 @@ ZTEST(net_ipv6, test_send_neighbor_discovery)
 	zassert_equal(pkt_num, 4, "Unexpected number of packets sent (%d)", pkt_num);
 
 	/* If there are anything pending by the NS reply timer, then
-	 * then 1 is returned and we can update the buffer and packet
-	 * counts.
+	 * 1 is returned. A pending timer does not imply that a TX packet or
+	 * buffer is still allocated at this point.
 	 */
 	ret = net_ipv6_nbr_test_cancel();
-	avail_pkt_count -= ret;
-	avail_buf_count -= ret;
+	ARG_UNUSED(ret);
 
 	zassert_equal(k_mem_slab_num_free_get(tx), avail_pkt_count,
 		      "Unexpected tx packet pool free count (%d vs %d)",


### PR DESCRIPTION
Backport of the fix from #112372 to `v4.3-branch`.

Fixes: #113653