### PR TITLE
drivers: adc: stm32: improve error message for common sampling times

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1605,7 +1605,9 @@ static int adc_stm32_sampling_time_setup(const struct device *dev, uint8_t id,
 							     (uint32_t)acq_time_index);
 		} else {
 			/* Reg is used and value does not match */
-			LOG_ERR("Multiple sampling times not supported");
+			LOG_ERR("Multiple sampling times not supported. "
+				"Previously configured sampling time remain reserved until the "
+				"next ADC read.");
 			return -EINVAL;
 		}
 #endif
@@ -1637,7 +1639,9 @@ static int adc_stm32_sampling_time_setup(const struct device *dev, uint8_t id,
 							     (uint32_t)acq_time_index);
 		} else {
 			/* Both regs are used, value does not match any of them */
-			LOG_ERR("Only two different sampling times supported");
+			LOG_ERR("Only two different sampling times supported. "
+				"Previously configured sampling times remain reserved until the "
+				"next ADC read.");
 			return -EINVAL;
 		}
 #endif


### PR DESCRIPTION
For ADCs that use a common register for sampling times, improve the error message when the common registers are already set and can't accept a new value.

Fixes #112080