### PR TITLE
drivers: clock_control: test SIRC boolean value

### DIFF
--- a/drivers/clock_control/clock_control_nxp_mcxw7x.c
+++ b/drivers/clock_control/clock_control_nxp_mcxw7x.c
@@ -61,7 +61,7 @@ struct mcxw_clock_control_config {
 	/* FIRC frequency range configuration */
 	uint8_t firc_range;
 
-#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
+#if DT_INST_PROP(0, sirc_supported)
 	/* Enable SIRC in low power mode */
 	bool enable_sirc_in_lp_mode;
 #endif
@@ -158,7 +158,7 @@ static int nxp_mcxw_clock_control_get_rate(const struct device *dev,
 			break;
 		}
 		case MCXW_CLK_IP_MUX_FRO_6M: {
-#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
+#if DT_INST_PROP(0, sirc_supported)
 			*rate = CLOCK_GetFreq(kCLOCK_ScgSircClk);
 #else
 			/* SIRC not present on this SoC; FRO6M runs at a fixed 6 MHz */
@@ -244,7 +244,7 @@ static int nxp_mcxw_clock_control_pm(const struct device *dev, enum pm_device_ac
 
 static int nxp_mcxw_clock_validate_sys_clk_src(const struct mcxw_clock_control_config *config)
 {
-#if !DT_INST_NODE_HAS_PROP(0, sirc_supported)
+#if !DT_INST_PROP(0, sirc_supported)
 	if (config->sys_clk_src == MCXW_CLK_SYSTEM_CLK_SRC_SIRC) {
 		LOG_ERR("SIRC is not available as system clock source on this SoC");
 		return -EINVAL;
@@ -285,7 +285,7 @@ static int nxp_mcxw_clock_control_init(const struct device *dev)
 
 	/* Unlock Reference Clock Status Registers to allow writes */
 	CLOCK_UnlockFircControlStatusReg();
-#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
+#if DT_INST_PROP(0, sirc_supported)
 	CLOCK_UnlockSircControlStatusReg();
 #endif
 	CLOCK_UnlockRoscControlStatusReg();
@@ -336,7 +336,7 @@ static int nxp_mcxw_clock_control_init(const struct device *dev)
 	/* Initialize FIRC */
 	(void)CLOCK_InitFirc(&scg_firc_config);
 
-#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
+#if DT_INST_PROP(0, sirc_supported)
 	if (config->enable_sirc_in_lp_mode) {
 		scg_sirc_config_t scg_sirc_config = {
 			.enableMode = kSCG_SircEnableInSleep,
@@ -435,7 +435,7 @@ static struct mcxw_clock_control_config config = {
 	.coarse_adjustment = DT_INST_PROP(0, osc32k_coarse_adjustment),
 	.firc_mode = DT_INST_PROP(0, firc_mode),
 	.firc_range = DT_INST_PROP(0, firc_range),
-#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
+#if DT_INST_PROP(0, sirc_supported)
 	.enable_sirc_in_lp_mode = DT_INST_PROP(0, enable_sirc_in_lp_mode),
 #endif
 	.sys_clk_src = DT_INST_PROP(0, sys_clk_src),


### PR DESCRIPTION
## Summary

Use the value of the `sirc-supported` boolean property when guarding SIRC-specific code in the NXP MCXW7x clock-control driver.

## Detection

This regression was detected by the Twister CI run for #110582. Although unrelated to that PR's RX timestamp changes, it caused three MCXW72 OpenThread configurations selected by the job to fail to build.

## Root cause

Commit `537f952b2f7f` introduced `sirc-supported` but guarded the affected code with `DT_INST_NODE_HAS_PROP()`.

That macro tests whether a property is defined, not the value of a boolean property. The generated MCXW72 devicetree therefore reported the property as existing with value zero, causing SIRC-specific SDK types and functions to be compiled even though the MCXW72 HAL does not provide them.

This broke MCXW72 builds with errors involving `kCLOCK_ScgSircClk`, `CLOCK_UnlockSircControlStatusReg()`, `scg_sirc_config_t`, and `CLOCK_InitSirc()`.

## Fix

Replace the six `DT_INST_NODE_HAS_PROP()` conditions with `DT_INST_PROP()`.

This excludes the SIRC-specific paths on MCXW72 while preserving them on MCXW70 and MCXW71.

## Testing

- Built `sample.net.openthread.shell.mcxw_openthread_host` on `frdm_mcxw72/mcxw727c`
- Built `sample.net.sockets.echo_client.openthread` on `frdm_mcxw72/mcxw727c`
- Built `sample.net.sockets.echo_server.openthread` on `frdm_mcxw72/mcxw727c`
- Built `cpp.main.minimal` on `frdm_mcxw71/mcxw716c`