### PR TITLE
boards: nordic: Add DTR and RI pins to nRF93M1 DK

### DIFF
--- a/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_common_0_3_0.dtsi
+++ b/boards/nordic/nrf93m1dk/nrf93m1dk_nrf54l15_common_0_3_0.dtsi
@@ -54,5 +54,7 @@
 		power-domains = <&modem_dcdc>;
 		mdm-power-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
 		mdm-reset-gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		mdm-dtr-gpios = <&gpio2 7 GPIO_ACTIVE_LOW>;
+		mdm-ring-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 	};
 };


### PR DESCRIPTION
Add DTR and RING pin definitions for nRF93M1 DK board.