### PR TITLE
dts: arm: nuvoton: add pwm nodes for numaker m031x

### DIFF
--- a/drivers/pwm/pwm_numaker.c
+++ b/drivers/pwm/pwm_numaker.c
@@ -360,8 +360,12 @@ static void pwm_numaker_isr(const struct device *dev, uint32_t st_channel, uint3
 	uint32_t int_mask = (BIT(st_channel) | BIT(end_channel));
 	uint32_t cap_int_rise_mask, cap_int_fall_mask;
 	uint32_t cap_int_mask =
+#if defined(CONFIG_SOC_SERIES_M031X)
+		(NUMAKER_PWM_CHANNEL_MASK << 8 | NUMAKER_PWM_CHANNEL_MASK);
+#else
 		(EPWM_CAPIF_CFLIF0_Msk << st_channel | EPWM_CAPIF_CRLIF0_Msk << st_channel |
 		 EPWM_CAPIF_CFLIF0_Msk << end_channel | EPWM_CAPIF_CRLIF0_Msk << end_channel);
+#endif
 
 	/* Get Output int status */
 	int_status = epwm->AINTSTS & int_mask;
@@ -397,6 +401,13 @@ static void pwm_numaker_isr(const struct device *dev, uint32_t st_channel, uint3
 	}
 }
 
+#if defined(CONFIG_SOC_SERIES_M031X)
+static void pwm_numaker_pair_isr(const struct device *dev)
+{
+	/* Pair service channel 0 to 5 */
+	pwm_numaker_isr(dev, 0, 5);
+}
+#else
 static void pwm_numaker_p0_isr(const struct device *dev)
 {
 	/* Pair0 service channel 0, 1 */
@@ -414,6 +425,7 @@ static void pwm_numaker_p2_isr(const struct device *dev)
 	/* Pair2 service channel 4, 5 */
 	pwm_numaker_isr(dev, 4, 5);
 }
+#endif /* CONFIG_SOC_SERIES_M031X */
 #endif /* CONFIG_PWM_CAPTURE */
 
 /* PWM driver registration */
@@ -552,6 +564,17 @@ done:
 }
 
 #ifdef CONFIG_PWM_CAPTURE
+#if defined(CONFIG_SOC_SERIES_M031X)
+#define NUMAKER_PWM_IRQ_CONFIG_FUNC(n)                                                             \
+	static void pwm_numaker_irq_config_##n(const struct device *dev)                           \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(n),                                                       \
+			    DT_INST_IRQ(n, priority), pwm_numaker_pair_isr,                        \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+                                                                                                   \
+		irq_enable(DT_INST_IRQN(n));                                                       \
+	}
+#else
 #define NUMAKER_PWM_IRQ_CONFIG_FUNC(n)                                                             \
 	static void pwm_numaker_irq_config_##n(const struct device *dev)                           \
 	{                                                                                          \
@@ -573,6 +596,7 @@ done:
                                                                                                    \
 		irq_enable(DT_INST_IRQ_BY_NAME(n, pair2, irq));                                    \
 	}
+#endif
 #define IRQ_FUNC_INIT(n) .irq_config_func = pwm_numaker_irq_config_##n
 #else
 #define NUMAKER_PWM_IRQ_CONFIG_FUNC(n)

--- a/dts/arm/nuvoton/m031x.dtsi
+++ b/dts/arm/nuvoton/m031x.dtsi
@@ -288,6 +288,28 @@
 			#size-cells = <0>;
 			status = "disabled";
 		};
+
+		pwm0: pwm@40058000 {
+			compatible = "nuvoton,numaker-pwm";
+			reg = <0x40058000 0x37c>;
+			interrupts = <6 0>;
+			resets = <&rst NUMAKER_PWM0_RST>;
+			prescaler = <19>;
+			clocks = <&pcc NUMAKER_PWM0_MODULE NUMAKER_CLK_CLKSEL2_PWM0SEL_PCLK0 0>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwm1: pwm@40059000 {
+			compatible = "nuvoton,numaker-pwm";
+			reg = <0x40059000 0x37c>;
+			interrupts = <7 0>;
+			resets = <&rst NUMAKER_PWM1_RST>;
+			prescaler = <19>;
+			clocks = <&pcc NUMAKER_PWM1_MODULE NUMAKER_CLK_CLKSEL2_PWM1SEL_PCLK1 0>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/west.yml
+++ b/west.yml
@@ -208,7 +208,7 @@ manifest:
       groups:
         - hal
     - name: hal_nuvoton
-      revision: 6e993ab4d923575a69c91fa40897d87c5d779708
+      revision: 0f411a85da7d17a612d54450f608f4d30cdb971f
       path: modules/hal/nuvoton
       groups:
         - hal


### PR DESCRIPTION
This PR is to add pwm nodes for numaker m031x.
Also modified numaker pwm driver to support m031x.

pwm_loopback test:
```
===================================================================
TESTSUITE pwm_loopback succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [pwm_loopback]: pass = 7, fail = 0, skip = 1, total = 8 duration = 4.309 seconds
 - PASS - [pwm_loopback.test_capture_busy] duration = 0.033 seconds
 - PASS - [pwm_loopback.test_capture_timeout] duration = 1.026 seconds
 - PASS - [pwm_loopback.test_continuous_capture] duration = 1.114 seconds
 - PASS - [pwm_loopback.test_period_capture] duration = 0.513 seconds
 - PASS - [pwm_loopback.test_period_capture_inverted] duration = 0.487 seconds
 - SKIP - [pwm_loopback.test_pulse_and_period_capture] duration = 0.134 seconds
 - PASS - [pwm_loopback.test_pulse_capture] duration = 0.515 seconds
 - PASS - [pwm_loopback.test_pulse_capture_inverted] duration = 0.487 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
```