### PR TITLE
Revert "west.yml: update hal nxp to the latest version"

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: b0d24fd6fd036f54a43721f4b0415df43317d7e0
+      revision: 02a097059315d7b9a7f7f7d38ee9c97f906867ce
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This reverts commit a9f8e1a2391f01395e97a80d0b5bced051a13745.

Unfortunately, this HAL update introduced multiple failures in main building some NXP platforms.
Let's revert the update to stabilize main while the issues are addressed calmly.

PR being reverted:
* https://github.com/zephyrproject-rtos/zephyr/pull/112725

2 failures can be seen here:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/29457462043/job/87493927314#step:12:1458
https://github.com/zephyrproject-rtos/zephyr/actions/runs/29457462043/job/87493927287#step:12:1870
(there may be more)