### PR TITLE
drivers: fix a few duplicate const

### DIFF
--- a/drivers/bluetooth/hci/hci_sf32lb.c
+++ b/drivers/bluetooth/hci/hci_sf32lb.c
@@ -562,7 +562,7 @@ static int bt_hci_sf32lb_open(const struct device *dev)
 	return r;
 }
 
-static const DEVICE_API(bt_hci, hci_sf32lb_driver_api) = {
+static DEVICE_API(bt_hci, hci_sf32lb_driver_api) = {
 	.open = bt_hci_sf32lb_open,
 	.send = bt_hci_sf32lb_send,
 };

--- a/drivers/wuc/wuc_nxp_llwu.c
+++ b/drivers/wuc/wuc_nxp_llwu.c
@@ -186,7 +186,7 @@ static const struct mcux_llwu_config llwu_config = {
 
 static struct mcux_llwu_data llwu_data;
 
-static const DEVICE_API(wuc, mcux_llwu_api) = {
+static DEVICE_API(wuc, mcux_llwu_api) = {
 	.enable = mcux_llwu_enable_wakeup_source,
 	.disable = mcux_llwu_disable_wakeup_source,
 	.triggered = mcux_llwu_check_wakeup_source_triggered,

--- a/drivers/wuc/wuc_nxp_wuu.c
+++ b/drivers/wuc/wuc_nxp_wuu.c
@@ -228,7 +228,7 @@ static struct mcux_wuu_config wuu_config = {
 
 static struct mcux_wuu_data wuu_data;
 
-static const DEVICE_API(wuc, wuu_api) = {
+static DEVICE_API(wuc, wuu_api) = {
 	.enable = mcux_wuu_enable_wakeup_source,
 	.disable = mcux_wuu_disable_wakeup_source,
 	.triggered = mcux_wuu_check_wakeup_source_triggered,


### PR DESCRIPTION
Fix few:
wuc_nxp_wuu.c:231:14: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier]

warnings, DEVICE_API already includes the const qualifier. Only exposed when compiling with COMPILER_SAVE_TEMPS=y for some reason.