### PR TITLE
Remove experimental from old and stable networking features

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -720,8 +720,7 @@ config NET_BUF_FIXED_DATA_SIZE
 	  as necessary to reach that request.
 
 config NET_BUF_VARIABLE_DATA_SIZE
-	bool "Variable data size buffer [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "Variable data size buffer"
 	help
 	  The buffer is dynamically allocated from runtime requested size.
 

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -122,9 +122,8 @@ config NET_IPV4_ACD
 	  The conflict detection is based on ARP probes/announcements.
 
 config NET_IPV4_AUTO
-	bool "IPv4 autoconfiguration [EXPERIMENTAL]"
+	bool "IPv4 autoconfiguration"
 	depends on NET_ARP
-	select EXPERIMENTAL
 	select NET_IPV4_ACD
 	select NET_MGMT
 	select NET_MGMT_EVENT

--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NET_GPTP
-	bool "IEEE 802.1AS (gPTP) support [EXPERIMENTAL]"
+	bool "IEEE 802.1AS (gPTP) support"
 	select PTP_CLOCK
 	select NET_L2_PTP_TIMESTAMPING
-	select EXPERIMENTAL
 	help
 	  Enable gPTP driver that send and receives gPTP packets
 	  and handles network packet timestamps.

--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -109,8 +109,7 @@ config COAP_OVER_RELIABLE_TRANSPORT
 	  (CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets)
 
 config COAP_CLIENT
-	bool "CoAP client support [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "CoAP client support"
 	select ZVFS
 	select ZVFS_EVENTFD
 	help
@@ -232,8 +231,7 @@ config COAP_CLIENT_TCP_BLOCKWISE_REUSE_TOKEN
 endif # COAP_OVER_RELIABLE_TRANSPORT
 
 config COAP_SERVER
-	bool "CoAP server support [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "CoAP server support"
 	select NET_SOCKETS
 	select ZVFS
 	select ZVFS_EVENTFD

--- a/subsys/net/lib/latmon/Kconfig
+++ b/subsys/net/lib/latmon/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config NET_LATMON
-	bool "Latency monitoring support"
+	bool "Latency monitoring support [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	select NET_SOCKETS
 	depends on NET_TCP

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -111,7 +111,7 @@ config LWM2M_QUEUE_MODE_UPTIME
 	  values though.
 
 config LWM2M_QUEUE_MODE_NO_MSG_BUFFERING
-	bool "Disable buffering notifications and messages on queue mode"
+	bool "Disable buffering notifications and messages on queue mode [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
 	  Messages are sent right away instead of waiting for next registration update.

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -474,10 +474,9 @@ module-help = Enables logging for sockets code.
 source "subsys/net/Kconfig.template.log_config.net"
 
 config NET_SOCKETS_OBJ_CORE
-	bool "Object core socket support [EXPERIMENTAL]"
+	bool "Object core socket support"
 	depends on OBJ_CORE
 	select OBJ_CORE_STATS
-	select EXPERIMENTAL
 	help
 	  Select this if you want to use object core with socket API to get
 	  network socket information and statistics via object core.

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -386,10 +386,9 @@ config NET_SOCKETS_INET_RAW
 	  to receive raw IP datagrams before further processing takes place.
 
 config NET_SOCKETS_CAN
-	bool "Socket CAN support [EXPERIMENTAL]"
+	bool "Socket CAN support"
 	select NET_L2_CANBUS_RAW
 	select NET_CONNECTION_SOCKETS
-	select EXPERIMENTAL
 	help
 	  The value depends on your network needs.
 


### PR DESCRIPTION
As discussed in TSC 15.7.2026 about experimental status, I went through networking and picked several APIs that have been in use for long time and could be considered stable enough so that the experimental status can be removed.