### PR TITLE
tests: shell: Fix yaml key

### DIFF
--- a/tests/subsys/shell/shell/tests.yaml
+++ b/tests/subsys/shell/shell/tests.yaml
@@ -11,7 +11,7 @@ tests:
     min_ram: 32
     extra_configs:
       - CONFIG_SHELL_METAKEYS=y
-    exclude_platforms:
+    platform_exclude:
       # flaky tests, platform disables icount with > 1 CPU
       - qemu_x86_64/atom
     integration_platforms:


### PR DESCRIPTION
It's platform_exclude not exclude_platforms

https://github.com/zephyrproject-rtos/zephyr/pull/113629
882fe0e39afba57778cedb9dbe77e4c372e6b92f

ERROR   - tests/subsys/shell/shell: can't load (skipping): <ValidationError: "Additional properties are not allowed ('exclude_platforms' was unexpected)">
