### PR TITLE
lib: cpp: minimal: Add C++17 aligned operator delete overloads

### DIFF
--- a/lib/cpp/minimal/cpp_new.cpp
+++ b/lib/cpp/minimal/cpp_new.cpp
@@ -84,3 +84,25 @@ void operator delete[](void* ptr, size_t) NOEXCEPT
 	free(ptr);
 }
 #endif // __cplusplus > 201103L
+
+#if __cplusplus >= 201703L
+void operator delete(void* ptr, std::align_val_t) NOEXCEPT
+{
+	free(ptr);
+}
+
+void operator delete[](void* ptr, std::align_val_t) NOEXCEPT
+{
+	free(ptr);
+}
+
+void operator delete(void* ptr, std::size_t, std::align_val_t) NOEXCEPT
+{
+	free(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t, std::align_val_t) NOEXCEPT
+{
+	free(ptr);
+}
+#endif /* __cplusplus >= 201703L */

--- a/lib/cpp/minimal/include/new
+++ b/lib/cpp/minimal/include/new
@@ -30,4 +30,13 @@ namespace std {
 #endif /* CONFIG_STD_CPP17 */
 
 }
+
+#if __cplusplus >= 201703L
+/* Replaceable deallocation functions for aligned allocations */
+void operator delete(void *ptr, std::align_val_t al) noexcept;
+void operator delete[](void *ptr, std::align_val_t al) noexcept;
+void operator delete(void *ptr, std::size_t size, std::align_val_t al) noexcept;
+void operator delete[](void *ptr, std::size_t size, std::align_val_t al) noexcept;
+#endif /* __cplusplus >= 201703L */
+
 #endif /* ZEPHYR_SUBSYS_CPP_INCLUDE_NEW_ */


### PR DESCRIPTION
The minimal C++ library (`CONFIG_MINIMAL_LIBCPP=y`) implements C++17 aligned `operator new` overloads using `std::align_val_t`, but does not provide the corresponding aligned `operator delete` overloads. As a result, any code that allocates an object with extended alignment (e.g. `alignas(64)`) and then deletes it fails to link.

Add the deallocation functions required by the C++17 standard:
- `operator delete(void*, std::align_val_t)`
- `operator delete[](void*, std::align_val_t)`
- `operator delete(void*, std::size_t, std::align_val_t)`
- `operator delete[](void*, std::size_t, std::align_val_t)`

Also declare them in the minimal `<new>` header so they are visible to user translation units.

Fixes #113678