### PR TITLE
Bluetooth: CAP: Add bt_cap_handover_cancel

### DIFF
--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -628,7 +628,7 @@ int bt_cap_initiator_unicast_audio_update(const struct bt_cap_unicast_audio_upda
 int bt_cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_param *param);
 
 /**
- * @brief Cancel any current Common Audio Profile procedure
+ * @brief Cancel any current Common Audio Profile Initiator procedure
  *
  * This will stop the current procedure from continuing and making it possible to run a new
  * Common Audio Profile procedure.
@@ -647,8 +647,12 @@ int bt_cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_p
  * The respective callbacks of the procedure will be called as part of this with the connection
  * pointer set to 0 and the err value set to -ECANCELED.
  *
+ * Use bt_cap_commander_cancel() to cancel any CAP Commander procedures.
+ * Use bt_cap_handover_cancel() to cancel any CAP Handover procedures.
+ *
  * @retval 0 on success
  * @retval -EALREADY if no procedure is active
+ * @retval -EOPNOTSUPP A procedure is active, but it is not an Initiator procedure.
  */
 int bt_cap_initiator_unicast_audio_cancel(void);
 
@@ -1065,6 +1069,35 @@ struct bt_cap_handover_broadcast_to_unicast_param {
 int bt_cap_handover_broadcast_to_unicast(
 	const struct bt_cap_handover_broadcast_to_unicast_param *param);
 
+/**
+ * @brief Cancel any current Common Audio Profile Handover procedure
+ *
+ * This will stop the current procedure from continuing and making it possible to run a new
+ * Common Audio Profile procedure.
+ *
+ * It is recommended to do this if any existing procedure takes longer time than expected, which
+ * could indicate a missing response from the Common Audio Profile Acceptor.
+ *
+ * This does not send any requests to any Common Audio Profile Acceptors involved with the current
+ * procedure, and thus notifications from the Common Audio Profile Acceptors may arrive after this
+ * has been called. It is thus recommended to either only use this if a procedure has stalled, or
+ * wait a short while before starting any new Common Audio Profile procedure after this has been
+ * called to avoid getting notifications from the cancelled procedure. The wait time depends on
+ * the connection interval, the number of devices in the previous procedure and the behavior of the
+ * Common Audio Profile Acceptors.
+ *
+ * The respective callbacks of the procedure will be called as part of this with the connection
+ * pointer set to 0 and the err value set to -ECANCELED.
+ *
+ * Use bt_cap_commander_cancel() to cancel any CAP Commander procedures.
+ * Use bt_cap_initiator_unicast_audio_cancel() to cancel any CAP Initiator procedures.
+ *
+ * @retval 0 on success
+ * @retval -EALREADY if no procedure is active
+ * @retval -EOPNOTSUPP A procedure is active, but it is not a Handover procedure.
+ */
+int bt_cap_handover_cancel(void);
+
 /** Callback structure for CAP procedures */
 struct bt_cap_commander_cb {
 	/**
@@ -1248,8 +1281,12 @@ int bt_cap_commander_discover(struct bt_conn *conn);
  * The respective callbacks of the procedure will be called as part of this with the connection
  * pointer set to NULL and the err value set to -ECANCELED.
  *
+ * Use bt_cap_initiator_unicast_audio_cancel() to cancel any CAP Initiator procedures.
+ * Use bt_cap_handover_cancel() to cancel any CAP Handover procedures.
+ *
  * @retval 0 on success
  * @retval -EALREADY if no procedure is active
+ * @retval -EOPNOTSUPP A procedure is active, but it is not a Commander procedure.
  */
 int bt_cap_commander_cancel(void);
 

--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -1512,7 +1512,7 @@ static void cap_commander_proc_complete(struct bt_cap_common_proc *active_proc)
 	err = active_proc->err;
 	proc_type = active_proc->proc_type;
 
-	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_handover_is_active()) {
+	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_active_proc_is_handover()) {
 		bt_cap_handover_commander_proc_complete(active_proc);
 		return;
 	}
@@ -1590,6 +1590,15 @@ int bt_cap_commander_cancel(void)
 		LOG_DBG("No CAP procedure is in progress");
 
 		return -EALREADY;
+	}
+
+	if ((IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_active_proc_is_handover()) ||
+	    !bt_cap_common_active_proc_is_commander()) {
+		bt_cap_common_unlock_proc();
+
+		LOG_DBG("No CAP commander procedure is in progress");
+
+		return -EOPNOTSUPP;
 	}
 
 	bt_cap_common_abort_proc(NULL, -ECANCELED);

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -107,7 +107,7 @@ void bt_cap_common_set_handover_active(void)
 	atomic_set_bit(active_proc.proc_state_flags, BT_CAP_COMMON_PROC_STATE_HANDOVER);
 }
 
-bool bt_cap_common_handover_is_active(void)
+bool bt_cap_common_active_proc_is_handover(void)
 {
 	return atomic_test_bit(active_proc.proc_state_flags, BT_CAP_COMMON_PROC_STATE_HANDOVER);
 }
@@ -187,7 +187,7 @@ void bt_cap_common_abort_proc(struct bt_conn *conn, int err)
 }
 
 #if defined(CONFIG_BT_CAP_INITIATOR_UNICAST)
-static bool active_proc_is_initiator(void)
+bool bt_cap_common_active_proc_is_initiator(void)
 {
 	switch (active_proc.proc_type) {
 	case BT_CAP_COMMON_PROC_TYPE_START:
@@ -201,7 +201,7 @@ static bool active_proc_is_initiator(void)
 #endif /* CONFIG_BT_CAP_INITIATOR_UNICAST */
 
 #if defined(CONFIG_BT_CAP_COMMANDER)
-static bool active_proc_is_commander(void)
+bool bt_cap_common_active_proc_is_commander(void)
 {
 	switch (active_proc.proc_type) {
 	case BT_CAP_COMMON_PROC_TYPE_VOLUME_CHANGE:
@@ -227,14 +227,14 @@ bool bt_cap_common_conn_in_active_proc(const struct bt_conn *conn)
 
 	for (size_t i = 0U; i < active_proc.proc_initiated_cnt; i++) {
 #if defined(CONFIG_BT_CAP_INITIATOR_UNICAST)
-		if (active_proc_is_initiator()) {
+		if (bt_cap_common_active_proc_is_initiator()) {
 			if (active_proc.proc_param.initiator[i].stream->bap_stream.conn == conn) {
 				return true;
 			}
 		}
 #endif /* CONFIG_BT_CAP_INITIATOR_UNICAST */
 #if defined(CONFIG_BT_CAP_COMMANDER)
-		if (active_proc_is_commander()) {
+		if (bt_cap_common_active_proc_is_commander()) {
 			if (active_proc.proc_param.commander[i].conn == conn) {
 				return true;
 			}
@@ -252,7 +252,7 @@ bool bt_cap_common_stream_in_active_proc(const struct bt_cap_stream *cap_stream)
 	}
 
 #if defined(CONFIG_BT_CAP_INITIATOR_UNICAST)
-	if (active_proc_is_initiator()) {
+	if (bt_cap_common_active_proc_is_initiator()) {
 		for (size_t i = 0U; i < active_proc.proc_cnt; i++) {
 			if (active_proc.proc_param.initiator[i].stream == cap_stream) {
 				return true;

--- a/subsys/bluetooth/audio/cap_handover.c
+++ b/subsys/bluetooth/audio/cap_handover.c
@@ -41,7 +41,7 @@ bool bt_cap_handover_is_handover_broadcast_source(
 	const struct bt_cap_handover_proc_param *proc_param = &active_proc->proc_param.handover;
 	bool ret;
 
-	if (!bt_cap_common_handover_is_active()) {
+	if (!bt_cap_common_active_proc_is_handover()) {
 		ret = false;
 	} else if (proc_param->is_unicast_to_broadcast) {
 		ret = cap_broadcast_source == proc_param->unicast_to_broadcast.broadcast_source;
@@ -1101,6 +1101,32 @@ int bt_cap_handover_unregister_cb(const struct bt_cap_handover_cb *cb)
 	}
 
 	cap_cb = NULL;
+
+	return 0;
+}
+
+int bt_cap_handover_cancel(void)
+{
+	struct bt_cap_common_proc *active_proc = bt_cap_common_get_active_proc();
+
+	if (!bt_cap_common_proc_is_active() && !bt_cap_common_proc_is_aborted()) {
+		bt_cap_common_unlock_proc();
+
+		LOG_DBG("No CAP procedure is in progress");
+
+		return -EALREADY;
+	}
+
+	if (!bt_cap_common_active_proc_is_handover()) {
+		bt_cap_common_unlock_proc();
+
+		LOG_DBG("No CAP Handover procedure is in progress");
+
+		return -EOPNOTSUPP;
+	}
+
+	bt_cap_common_abort_proc(NULL, -ECANCELED);
+	bt_cap_handover_complete(active_proc);
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1368,7 +1368,7 @@ static void cap_initiator_unicast_audio_proc_complete(struct bt_cap_common_proc 
 	err = active_proc->err;
 	proc_type = active_proc->proc_type;
 
-	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_handover_is_active()) {
+	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_active_proc_is_handover()) {
 		/* Clear initiator parameters. Normally this is done just before the
 		 * application callbacks with bt_cap_common_clear_proc, but
 		 * since that is not happening here, we clear them manually. They
@@ -2336,6 +2336,15 @@ int bt_cap_initiator_unicast_audio_cancel(void)
 		LOG_DBG("No CAP procedure is in progress");
 
 		return -EALREADY;
+	}
+
+	if ((IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_active_proc_is_handover()) ||
+	    !bt_cap_common_active_proc_is_initiator()) {
+		bt_cap_common_unlock_proc();
+
+		LOG_DBG("No CAP initiator procedure is in progress");
+
+		return -EOPNOTSUPP;
 	}
 
 	bt_cap_common_abort_proc(NULL, -ECANCELED);

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -309,7 +309,10 @@ void bt_cap_common_clear_proc(struct bt_cap_common_proc *proc);
 void bt_cap_common_set_proc(enum bt_cap_common_proc_type proc_type, size_t proc_cnt);
 void bt_cap_common_set_subproc(enum bt_cap_common_subproc_type subproc_type);
 void bt_cap_common_set_handover_active(void);
-bool bt_cap_common_handover_is_active(void);
+
+bool bt_cap_common_active_proc_is_handover(void);
+bool bt_cap_common_active_proc_is_initiator(void);
+bool bt_cap_common_active_proc_is_commander(void);
 bool bt_cap_common_proc_is_type(enum bt_cap_common_proc_type proc_type);
 bool bt_cap_common_subproc_is_type(enum bt_cap_common_subproc_type subproc_type);
 struct bt_conn *bt_cap_common_get_member_conn(enum bt_cap_set_type type,

--- a/subsys/bluetooth/audio/shell/cap_handover.c
+++ b/subsys/bluetooth/audio/shell/cap_handover.c
@@ -246,6 +246,22 @@ static int validate_and_parse_cmd_cap_handover_unicast_to_broadcast_args(
 	return 0;
 }
 
+static int cmd_cap_handover_cancel(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	err = bt_cap_handover_cancel();
+	if (err != 0) {
+		shell_print(sh, "Failed to cancel CAP handover procedure: %d", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
 static int cmd_cap_handover_unicast_to_broadcast(const struct shell *sh, size_t argc, char *argv[])
 {
 	const struct named_lc3_preset *named_preset = &default_broadcast_source_preset;
@@ -796,6 +812,8 @@ static int cmd_cap_handover(const struct shell *sh, size_t argc, char **argv)
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	cap_handover_cmds,
+	SHELL_CMD_ARG(cancel, NULL, "CAP Handover cancel current procedure",
+		      cmd_cap_handover_cancel, 1, 0),
 	SHELL_CMD_ARG(unicast_to_broadcast, NULL,
 		      "Handover current unicast group to broadcast (unicast group will be deleted) "
 		      "[enc <broadcast_code>] [preset <preset_name>]",


### PR DESCRIPTION
Add a new function to specifically cancel handover procedures, similar to the command and initiator functions. Additionally adds checks for the procedure type to ensure that the right cancel function is used, to avoid any unexpected behavior from CAP.