### PR TITLE
[Backport v4.3-branch] net: ipv6: Fix zero reachable time from Router Advertisement

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2092,6 +2092,31 @@ static inline void net_if_ipv6_set_base_reachable_time(struct net_if *iface,
 }
 
 /**
+ * @brief Get IPv6 base reachable time for a given interface
+ *
+ * @param iface Network interface
+ *
+ * @return Base reachable time in milliseconds
+ */
+static inline uint32_t net_if_ipv6_get_base_reachable_time(struct net_if *iface)
+{
+#if defined(CONFIG_NET_NATIVE_IPV6)
+	if (iface == NULL) {
+		return 0;
+	}
+
+	if (iface->config.ip.ipv6 == NULL) {
+		return 0;
+	}
+
+	return iface->config.ip.ipv6->base_reachable_time;
+#else
+	ARG_UNUSED(iface);
+	return 0;
+#endif
+}
+
+/**
  * @brief Get IPv6 reachable timeout specified for a given interface
  *
  * @param iface Network interface

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -2704,7 +2704,7 @@ static int handle_ra_input(struct net_icmp_ctx *ctx,
 	}
 
 	if (reachable_time && reachable_time <= MAX_REACHABLE_TIME &&
-	    (net_if_ipv6_get_reachable_time(net_pkt_iface(pkt)) !=
+	    (net_if_ipv6_get_base_reachable_time(net_pkt_iface(pkt)) !=
 	     reachable_time)) {
 		net_if_ipv6_set_base_reachable_time(net_pkt_iface(pkt),
 						    reachable_time);

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3411,17 +3411,32 @@ struct net_if *net_if_ipv6_select_src_iface(const struct in6_addr *dst)
 uint32_t net_if_ipv6_calc_reachable_time(struct net_if_ipv6 *ipv6)
 {
 	uint32_t min_reachable, max_reachable;
+	uint32_t spread;
+
+	if (ipv6->base_reachable_time == 0U) {
+		return REACHABLE_TIME;
+	}
 
 	min_reachable = (MIN_RANDOM_NUMER * ipv6->base_reachable_time)
 			/ MIN_RANDOM_DENOM;
 	max_reachable = (MAX_RANDOM_NUMER * ipv6->base_reachable_time)
 			/ MAX_RANDOM_DENOM;
 
+	/* RFC 4861 uses MIN_RANDOM_FACTOR (1/2); round up so the range is never 0 ms */
+	if (min_reachable == 0U) {
+		min_reachable = 1U;
+	}
+
 	NET_DBG("min_reachable:%u max_reachable:%u", min_reachable,
 		max_reachable);
 
-	return min_reachable +
-	       sys_rand32_get() % (max_reachable - min_reachable);
+	if (max_reachable <= min_reachable) {
+		return min_reachable;
+	}
+
+	spread = max_reachable - min_reachable;
+
+	return min_reachable + sys_rand32_get() % spread;
 }
 
 static void iface_ipv6_start(struct net_if *iface)

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -2263,6 +2263,64 @@ ZTEST(net_ipv6, test_nd_reachability_hint)
 	zassert_equal(net_ipv6_nbr_data(nbr)->state, NET_IPV6_NBR_STATE_REACHABLE);
 }
 
+#define DEFAULT_REACHABLE_MS (MSEC_PER_SEC * 30)
+
+static uint32_t expected_reachable_min(uint32_t base)
+{
+	uint32_t min = base / 2U;
+
+	return (min == 0U) ? 1U : min;
+}
+
+static uint32_t expected_reachable_max(uint32_t base)
+{
+	return (3U * base) / 2U;
+}
+
+ZTEST(net_ipv6, test_calc_reachable_time_base_zero)
+{
+	struct net_if_ipv6 ipv6 = { .base_reachable_time = 0U };
+
+	zassert_equal(net_if_ipv6_calc_reachable_time(&ipv6), DEFAULT_REACHABLE_MS);
+}
+
+ZTEST(net_ipv6, test_calc_reachable_time_small_base)
+{
+	struct net_if_ipv6 ipv6 = { .base_reachable_time = 1U };
+
+	zassert_equal(net_if_ipv6_calc_reachable_time(&ipv6), 1U);
+}
+
+ZTEST(net_ipv6, test_calc_reachable_time_in_range)
+{
+	struct net_if_ipv6 ipv6 = { .base_reachable_time = DEFAULT_REACHABLE_MS };
+	uint32_t min = expected_reachable_min(DEFAULT_REACHABLE_MS);
+	uint32_t max = expected_reachable_max(DEFAULT_REACHABLE_MS);
+
+	for (int i = 0; i < 100; i++) {
+		uint32_t reachable = net_if_ipv6_calc_reachable_time(&ipv6);
+
+		zassert_true(reachable >= min, "below min: %u", reachable);
+		zassert_true(reachable < max, "at/above max: %u", reachable);
+	}
+}
+
+ZTEST(net_ipv6, test_set_reachable_time)
+{
+	struct net_if_ipv6 ipv6 = { .base_reachable_time = DEFAULT_REACHABLE_MS };
+	uint32_t min = expected_reachable_min(DEFAULT_REACHABLE_MS);
+	uint32_t max = expected_reachable_max(DEFAULT_REACHABLE_MS);
+
+	net_if_ipv6_set_reachable_time(&ipv6);
+
+	zassert_true(ipv6.reachable_time >= min,
+		     "reachable_time %u below min %u",
+		     ipv6.reachable_time, min);
+	zassert_true(ipv6.reachable_time < max,
+		     "reachable_time %u at/above max %u",
+		     ipv6.reachable_time, max);
+}
+
 static bool is_pe_address_found(struct net_if *iface, struct in6_addr *prefix)
 {
 	struct net_if_ipv6 *ipv6;


### PR DESCRIPTION
Backport 67f26ae740b81e573f67670b7bffad31a35d4d6f~3..67f26ae740b81e573f67670b7bffad31a35d4d6f from #113226.

_Original PR description:_

---

* Fix net_if_ipv6_calc_reachable_time() so small BaseReachableTime values (e.g. from a malicious RA with reachable_time = 1) no longer compute to 0 ms due to integer division
* Update RA handling to compare BaseReachableTime instead of the randomized ReachableTime, per RFC 4861
* Add unit tests in tests/net/ipv6 covering the zero/small-base cases and the RFC randomization range

Fixes #113684