### PR TITLE
[v4.4-branch] manifest: update Mbed TLS to v4.1.1/v3.6.7 and TF-PSA-Crypto to v1.1.1 

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -26,6 +26,36 @@
 
 .. _zephyr_4.4:
 
+.. _zephyr_4.4.3:
+
+Zephyr 4.4.3
+############
+
+This is a bugfix release for Zephyr 4.4.2.
+
+Security Vulnerability Related
+******************************
+
+
+Issues fixed
+************
+
+The following issues are addressed by this release:
+
+
+Mbed TLS / TF-PSA-Crypto
+************************
+
+Mbed TLS was updated to version 4.1.1/3.6.7, and TF-PSA-Crypto to version 1.1.1.
+They address a number of CVEs.
+
+Release notes can be found at:
+
+* https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-4.1.1
+* https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.7
+* https://github.com/Mbed-TLS/TF-PSA-Crypto/releases/tag/tf-psa-crypto-1.1.1
+
+
 .. _zephyr_4.4.2:
 
 Zephyr 4.4.2

--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -1498,6 +1498,18 @@ The following issues are addressed by this release:
 * :github:`114522` - smbus: remove_cb syscalls forward an unvalidated user pointer into the driver
 * :github:`114526` - drivers: wifi: esp_hosted: RX path parses an unvalidated TLV length and can permanently stop the event thread
 
+Mbed TLS / TF-PSA-Crypto
+************************
+
+Mbed TLS was updated to version 4.1.1/3.6.7, and TF-PSA-Crypto to version 1.1.1.
+They address a number of CVEs.
+
+Release notes can be found at:
+
+* https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-4.1.1
+* https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.7
+* https://github.com/Mbed-TLS/TF-PSA-Crypto/releases/tag/tf-psa-crypto-1.1.1
+
 .. _zephyr_4.4.1:
 
 Zephyr 4.4.1

--- a/west.yml
+++ b/west.yml
@@ -324,13 +324,13 @@ manifest:
       revision: 85aa60d18b3d5e5588d7b247abf90198f07c8a63
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: a3e190fe44c78d1ba67f55979e1257328cc7d0d8
+      revision: 098e120afb51877ed814bdc04443890ae12e0642
       path: modules/crypto/mbedtls
       groups:
         - crypto
     - name: mbedtls-3.6 # Required for TF-M build until we bump it to v2.3
       repo-path: mbedtls
-      revision: a00e23de17b6b0a0de28e180cb186da6f0008836
+      revision: 52053a9bf7170f9ba3979ec24ebfcc84c18091d9
       path: modules/crypto/mbedtls-3.6
       groups:
         - crypto
@@ -395,7 +395,7 @@ manifest:
         - testing
         - tee
     - name: tf-psa-crypto
-      revision: dc575a2ddcc8cb16275d24c42a52eaf79ebe2231
+      revision: fa92349590a54959ee2efc21b668e5afdb144726
       path: modules/crypto/tf-psa-crypto
       groups:
         - crypto


### PR DESCRIPTION
And document the updates in the release notes for Zephyr 4.4.3.

Fixes #113690.