### PR TITLE
[Backport v3.7-branch] bluetooth: classic: l2cap: add state validation in receive path

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -634,6 +634,8 @@ void bt_l2cap_br_connected(struct bt_conn *conn)
 			return;
 		}
 
+		bt_l2cap_br_chan_set_state(chan, BT_L2CAP_CONNECTING);
+
 		/*
 		 * other fixed channels will be connected after Information
 		 * Response is received
@@ -1812,7 +1814,8 @@ void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf)
 
 static int l2cap_br_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
-	int i;
+	struct bt_l2cap_br *l2cap;
+	uint8_t index;
 	static const struct bt_l2cap_chan_ops ops = {
 		.connected = l2cap_br_connected,
 		.disconnected = l2cap_br_disconnected,
@@ -1821,22 +1824,20 @@ static int l2cap_br_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 
 	LOG_DBG("conn %p handle %u", conn, conn->handle);
 
-	for (i = 0; i < ARRAY_SIZE(bt_l2cap_br_pool); i++) {
-		struct bt_l2cap_br *l2cap = &bt_l2cap_br_pool[i];
+	index = bt_conn_index(conn);
+	__ASSERT(index < ARRAY_SIZE(bt_l2cap_br_pool), "Invalid ACL conn index");
 
-		if (l2cap->chan.chan.conn) {
-			continue;
-		}
+	l2cap = &bt_l2cap_br_pool[index];
 
-		l2cap->chan.chan.ops = &ops;
-		*chan = &l2cap->chan.chan;
-		atomic_set(l2cap->chan.flags, 0);
-		return 0;
+	if (l2cap->chan.state != BT_L2CAP_DISCONNECTED) {
+		LOG_ERR("Signal chan %p is not idle (state %u)", &l2cap->chan, l2cap->chan.state);
+		return -EBUSY;
 	}
 
-	LOG_ERR("No available L2CAP context for conn %p", conn);
-
-	return -ENOMEM;
+	l2cap->chan.chan.ops = &ops;
+	*chan = &l2cap->chan.chan;
+	atomic_set(l2cap->chan.flags, 0);
+	return 0;
 }
 
 BT_L2CAP_BR_CHANNEL_DEFINE(br_fixed_chan, BT_L2CAP_CID_BR_SIG, l2cap_br_accept);

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -1788,8 +1788,7 @@ void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf)
 
 	if (buf->len < sizeof(*hdr)) {
 		LOG_ERR("Too small L2CAP PDU received");
-		net_buf_unref(buf);
-		return;
+		goto done;
 	}
 
 	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
@@ -1798,8 +1797,7 @@ void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf)
 	chan = bt_l2cap_br_lookup_rx_cid(conn, cid);
 	if (!chan) {
 		LOG_WRN("Ignoring data for unknown channel ID 0x%04x", cid);
-		net_buf_unref(buf);
-		return;
+		goto done;
 	}
 
 	/*
@@ -1808,7 +1806,14 @@ void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf)
 	 */
 	check_fixed_channel(chan);
 
+	if (BR_CHAN(chan)->state < BT_L2CAP_CONNECTED) {
+		LOG_ERR("Chan %p in invalid state %u, ignoring data", chan, BR_CHAN(chan)->state);
+		goto done;
+	}
+
 	chan->ops->recv(chan, buf);
+
+done:
 	net_buf_unref(buf);
 }
 

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -443,6 +443,7 @@ static void connect_fixed_channel(struct bt_l2cap_br_chan *chan)
 		return;
 	}
 
+	bt_l2cap_br_chan_set_state(&chan->chan, BT_L2CAP_CONNECTED);
 	if (chan->chan.ops && chan->chan.ops->connected) {
 		chan->chan.ops->connected(&chan->chan);
 	}

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1533,40 +1533,39 @@ static bool br_sc_supported(void)
 
 static int bt_smp_br_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
+	struct bt_smp_br *smp;
+	uint8_t index;
 	static const struct bt_l2cap_chan_ops ops = {
 		.connected = bt_smp_br_connected,
 		.disconnected = bt_smp_br_disconnected,
 		.recv = bt_smp_br_recv,
 	};
-	int i;
 
 	/* Check BR/EDR SC is supported */
 	if (!br_sc_supported()) {
 		return -ENOTSUP;
 	}
 
+	index = bt_conn_index(conn);
+	__ASSERT(index < ARRAY_SIZE(bt_smp_br_pool), "Invalid ACL conn index");
+
 	LOG_DBG("conn %p handle %u", conn, conn->handle);
 
-	for (i = 0; i < ARRAY_SIZE(bt_smp_pool); i++) {
-		struct bt_smp_br *smp = &bt_smp_br_pool[i];
+	smp = &bt_smp_br_pool[index];
 
-		if (smp->chan.chan.conn) {
-			continue;
-		}
-
-		smp->chan.chan.ops = &ops;
-
-		*chan = &smp->chan.chan;
-
-		k_work_init_delayable(&smp->work, smp_br_timeout);
-		smp_br_reset(smp);
-
-		return 0;
+	if (smp->chan.state != BT_L2CAP_DISCONNECTED) {
+		LOG_ERR("SMP BR chan %p is not idle (state %u)", &smp->chan, smp->chan.state);
+		return -EBUSY;
 	}
 
-	LOG_ERR("No available SMP context for conn %p", conn);
+	smp->chan.chan.ops = &ops;
 
-	return -ENOMEM;
+	*chan = &smp->chan.chan;
+
+	k_work_init_delayable(&smp->work, smp_br_timeout);
+	smp_br_reset(smp);
+
+	return 0;
 }
 
 static struct bt_smp_br *smp_br_chan_get(struct bt_conn *conn)


### PR DESCRIPTION
Backport of the fix from #112394 to `v3.7-branch`.

Fixes: #113698