### PR TITLE
boards: espressif: esp32s3_box3: add GT911 touch support

### DIFF
--- a/boards/espressif/esp32s3_box3/doc/index.rst
+++ b/boards/espressif/esp32s3_box3/doc/index.rst
@@ -43,7 +43,7 @@ The ESP32-S3-BOX-3 uses the following GPIO pin assignments:
 - GPIO0: Boot button
 - GPIO1: Mute button / Speaker mute status
 - GPIO2: I2S MCLK
-- GPIO3: Touch screen interrupt (TT21100)
+- GPIO3: Touch screen interrupt (GT911)
 - GPIO4: Display DC pin (SPI)
 - GPIO5: Display CS pin (SPI)
 - GPIO6: Display SDA/MOSI (SPI)

--- a/boards/espressif/esp32s3_box3/esp32s3_box3-pinctrl.dtsi
+++ b/boards/espressif/esp32s3_box3/esp32s3_box3-pinctrl.dtsi
@@ -20,4 +20,14 @@
 			output-low;
 		};
 	};
+
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <I2C0_SDA_GPIO8>,
+				 <I2C0_SCL_GPIO18>;
+			bias-pull-up;
+			drive-open-drain;
+			output-high;
+		};
+	};
 };

--- a/boards/espressif/esp32s3_box3/esp32s3_box3_procpu.dts
+++ b/boards/espressif/esp32s3_box3/esp32s3_box3_procpu.dts
@@ -29,6 +29,7 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &esp32_bt_hci;
 		zephyr,display = &ili9342c;
+		zephyr,touch = &gt911;
 	};
 
 	buttons {
@@ -81,6 +82,21 @@
 	status = "okay";
 	pinctrl-0 = <&spim2_default>;
 	pinctrl-names = "default";
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+
+	gt911: gt911@5d {
+		compatible = "goodix,gt911";
+		reg = <0x5d>;
+		irq-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+		alt-addr = <0x14>;
+		status = "okay";
+	};
 };
 
 &gpio0 {


### PR DESCRIPTION
Add GT911 capacitive touch controller on I2C0 (SDA=GPIO8, SCL=GPIO18) and wire it as zephyr,touch in chosen to enable input samples such as draw_touch_events.

The GT911 and ILI9342C display share the GPIO48 reset line. Set INPUT_INIT_PRIORITY to 81 so the GT911 initializes after the MIPI DBI driver (80) configures the GPIO, but before the display driver (85) asserts reset and leaves it low. This ensures the GT911 completes its reset sequence while the line is still high.

Also add the missing i2c0_default pinctrl group and enable the i2c0 bus node.