### PR TITLE
drivers: spi: esp32: select the peripheral clock source

### DIFF
--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -672,6 +672,8 @@ static int spi_esp32_init(const struct device *dev)
 	/* Enable internal SPI clock - new HAL requires explicit call */
 	spi_ll_enable_clock(cfg->dma_host + 1, true);
 
+	spi_ll_set_clk_source(cfg->spi, cfg->clock_source);
+
 	if (cfg->dma_enabled) {
 		err = spi_esp32_init_dma(dev);
 		if (err) {


### PR DESCRIPTION
The driver reads the rate of the configured clock source and calculates the timing divider against it, but never programs the hardware mux that selects that source. The mux keeps its reset value, so the peripheral runs from XTAL while the divider assumes a PLL rate.

Fixes #113568