### PR TITLE
tests: drivers: pwm: Fix gpio and pwm for FLPR

### DIFF
--- a/tests/drivers/gpio/gpio_get_direction/boards/nrf54h20dk_nrf54h20_cpuflpr.conf
+++ b/tests/drivers/gpio/gpio_get_direction/boards/nrf54h20dk_nrf54h20_cpuflpr.conf
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# FLPR does not support GPIO interrupts. Disabling interrupt support removes
+# the driver's dependency on the (disabled-by-default) GPIOTE130 peripheral,
+CONFIG_GPIO_NRFX_INTERRUPT=n

--- a/tests/drivers/gpio/gpio_get_direction/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
+++ b/tests/drivers/gpio/gpio_get_direction/boards/nrf54h20dk_nrf54h20_cpuflpr.overlay
@@ -15,10 +15,6 @@
 	};
 };
 
-&gpiote130 {
-	status = "okay";
-};
-
 &gpio9 {
 	status = "okay";
 };

--- a/tests/drivers/pwm/pwm_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/pwm/pwm_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -11,12 +11,35 @@
 			low-power-enable;
 		};
 	};
+
+	pwm120_default: pwm120_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>;
+		};
+	};
+
+	pwm120_sleep: pwm120_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>;
+			low-power-enable;
+		};
+	};
 };
 
+/* Reserved for the cpuppr image (slow PWM instance). */
 &pwm130 {
 	status = "reserved";
 	interrupt-parent = <&cpuppr_clic>;
 	pinctrl-0 = <&pwm_default>;
 	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+/* Reserved for the cpuflpr image (fast PWM instance). */
+&pwm120 {
+	status = "reserved";
+	interrupt-parent = <&cpuflpr_clic>;
+	pinctrl-0 = <&pwm120_default>;
+	pinctrl-1 = <&pwm120_sleep>;
 	pinctrl-names = "default", "sleep";
 };


### PR DESCRIPTION
Remove implicit usage of GPIOTE130 which forces
interrupts, because these are unsupported on FLPR.
Add missing flpr instance in vpr_launcher overlay.