### PR TITLE
net: use NET_MGMT_REGISTER_EVENT_HANDLER

### DIFF
--- a/include/zephyr/net/ipv4_autoconf.h
+++ b/include/zephyr/net/ipv4_autoconf.h
@@ -52,17 +52,4 @@ static inline void net_ipv4_autoconf_reset(struct net_if *iface)
 }
 #endif
 
-/** @cond INTERNAL_HIDDEN */
-
-/**
- * @brief Initialize IPv4 auto configuration engine.
- */
-#if defined(CONFIG_NET_IPV4_AUTO)
-void net_ipv4_autoconf_init(void);
-#else
-static inline void net_ipv4_autoconf_init(void) { }
-#endif
-
-/** @endcond */
-
 #endif /* ZEPHYR_INCLUDE_NET_IPV4_AUTOCONF_H_ */

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -22,8 +22,6 @@ LOG_MODULE_REGISTER(net_ipv4_autoconf, CONFIG_NET_IPV4_AUTO_LOG_LEVEL);
 #include <zephyr/net/net_log.h>
 #include <zephyr/random/random.h>
 
-static struct net_mgmt_event_callback mgmt4_acd_cb;
-
 static inline void ipv4_autoconf_addr_set(struct net_if_ipv4_autoconf *ipv4auto)
 {
 	struct net_in_addr netmask = { { { 255, 255, 0, 0 } } };
@@ -55,8 +53,8 @@ static inline void ipv4_autoconf_addr_set(struct net_if_ipv4_autoconf *ipv4auto)
 	ipv4auto->state = NET_IPV4_AUTOCONF_ASSIGNED;
 }
 
-static void acd_event_handler(struct net_mgmt_event_callback *cb,
-			      uint64_t mgmt_event, struct net_if *iface)
+static void acd_event_handler(uint64_t mgmt_event, struct net_if *iface, void *info,
+			      size_t info_length, void *user_data __unused)
 {
 	struct net_if_config *cfg;
 	struct net_in_addr *addr;
@@ -76,11 +74,11 @@ static void acd_event_handler(struct net_mgmt_event_callback *cb,
 		return;
 	}
 
-	if (cb->info_length != sizeof(struct net_in_addr)) {
+	if (info_length != sizeof(struct net_in_addr)) {
 		return;
 	}
 
-	addr = (struct net_in_addr *)cb->info;
+	addr = (struct net_in_addr *)info;
 
 	if (!net_ipv4_addr_cmp(&cfg->ipv4auto.requested_ip, addr)) {
 		return;
@@ -102,6 +100,11 @@ static void acd_event_handler(struct net_mgmt_event_callback *cb,
 		break;
 	}
 }
+
+NET_MGMT_REGISTER_EVENT_HANDLER(ipv4_autoconf_events,
+				NET_EVENT_IPV4_ACD_SUCCEED | NET_EVENT_IPV4_ACD_FAILED |
+					NET_EVENT_IPV4_ACD_CONFLICT,
+				acd_event_handler, NULL);
 
 void net_ipv4_autoconf_start(struct net_if *iface)
 {
@@ -153,13 +156,4 @@ void net_ipv4_autoconf_reset(struct net_if *iface)
 	}
 
 	NET_DBG("Autoconf reset for %p", iface);
-}
-
-void net_ipv4_autoconf_init(void)
-{
-	net_mgmt_init_event_callback(&mgmt4_acd_cb, acd_event_handler,
-				     NET_EVENT_IPV4_ACD_SUCCEED |
-				     NET_EVENT_IPV4_ACD_FAILED |
-				     NET_EVENT_IPV4_ACD_CONFLICT);
-	net_mgmt_add_event_callback(&mgmt4_acd_cb);
 }

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -621,8 +621,6 @@ static inline void l3_init(void)
 	net_ipv4_init();
 	net_ipv6_init();
 
-	net_ipv4_autoconf_init();
-
 	if (IS_ENABLED(CONFIG_NET_UDP) ||
 	    IS_ENABLED(CONFIG_NET_TCP) ||
 	    IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) ||

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -30,18 +30,22 @@ LOG_MODULE_REGISTER(net_arp, CONFIG_NET_ARP_LOG_LEVEL);
 static bool arp_cache_initialized;
 static struct arp_entry arp_entries[CONFIG_NET_ARP_TABLE_SIZE];
 
-static sys_slist_t arp_free_entries;
-static sys_slist_t arp_pending_entries;
-static sys_slist_t arp_table;
+static sys_slist_t arp_free_entries = SYS_SLIST_STATIC_INIT(&arp_free_entries);
+static sys_slist_t arp_pending_entries = SYS_SLIST_STATIC_INIT(&arp_pending_entries);
+static sys_slist_t arp_table = SYS_SLIST_STATIC_INIT(&arp_table);
 
-static struct k_work_delayable arp_request_timer;
+static void arp_request_timeout(struct k_work *work);
 
-static struct k_mutex arp_mutex;
+static K_WORK_DELAYABLE_DEFINE(arp_request_timer, arp_request_timeout);
+
+static K_MUTEX_DEFINE(arp_mutex);
 
 #if defined(CONFIG_NET_ARP_GRATUITOUS_TRANSMISSION)
 static struct net_mgmt_event_callback iface_event_cb;
 static struct net_mgmt_event_callback ipv4_event_cb;
-static struct k_work_delayable arp_gratuitous_work;
+static void arp_gratuitous_work_handler(struct k_work *work);
+
+static K_WORK_DELAYABLE_DEFINE(arp_gratuitous_work, arp_gratuitous_work_handler);
 #endif /* defined(CONFIG_NET_ARP_GRATUITOUS_TRANSMISSION) */
 
 static void arp_entry_cleanup(struct arp_entry *entry, bool pending)
@@ -1044,19 +1048,11 @@ void net_arp_init(void)
 		return;
 	}
 
-	sys_slist_init(&arp_free_entries);
-	sys_slist_init(&arp_pending_entries);
-	sys_slist_init(&arp_table);
-
 	for (i = 0; i < CONFIG_NET_ARP_TABLE_SIZE; i++) {
 		/* Inserting entry as free with initialised packet queue */
 		k_fifo_init(&arp_entries[i].pending_queue);
 		sys_slist_prepend(&arp_free_entries, &arp_entries[i].node);
 	}
-
-	k_work_init_delayable(&arp_request_timer, arp_request_timeout);
-
-	k_mutex_init(&arp_mutex);
 
 	arp_cache_initialized = true;
 
@@ -1069,8 +1065,6 @@ void net_arp_init(void)
 	net_mgmt_add_event_callback(&iface_event_cb);
 	net_mgmt_add_event_callback(&ipv4_event_cb);
 
-	k_work_init_delayable(&arp_gratuitous_work,
-			      arp_gratuitous_work_handler);
 	k_work_reschedule(&arp_gratuitous_work,
 			  K_SECONDS(CONFIG_NET_ARP_GRATUITOUS_INTERVAL));
 #endif /* defined(CONFIG_NET_ARP_GRATUITOUS_TRANSMISSION) */

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -41,8 +41,6 @@ static K_WORK_DELAYABLE_DEFINE(arp_request_timer, arp_request_timeout);
 static K_MUTEX_DEFINE(arp_mutex);
 
 #if defined(CONFIG_NET_ARP_GRATUITOUS_TRANSMISSION)
-static struct net_mgmt_event_callback iface_event_cb;
-static struct net_mgmt_event_callback ipv4_event_cb;
 static void arp_gratuitous_work_handler(struct k_work *work);
 
 static K_WORK_DELAYABLE_DEFINE(arp_gratuitous_work, arp_gratuitous_work_handler);
@@ -614,11 +612,9 @@ static void notify_all_ipv4_addr(struct net_if *iface)
 	}
 }
 
-static void iface_event_handler(struct net_mgmt_event_callback *cb,
-				uint64_t mgmt_event, struct net_if *iface)
+static void iface_event_handler(uint64_t mgmt_event, struct net_if *iface, void *info __unused,
+				size_t info_length __unused, void *user_data __unused)
 {
-	ARG_UNUSED(cb);
-
 	if (!(net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET) ||
 	      net_eth_is_vlan_interface(iface))) {
 		return;
@@ -631,8 +627,10 @@ static void iface_event_handler(struct net_mgmt_event_callback *cb,
 	notify_all_ipv4_addr(iface);
 }
 
-static void ipv4_event_handler(struct net_mgmt_event_callback *cb,
-			       uint64_t mgmt_event, struct net_if *iface)
+NET_MGMT_REGISTER_EVENT_HANDLER(arp_iface_events, NET_EVENT_IF_UP, iface_event_handler, NULL);
+
+static void ipv4_event_handler(uint64_t mgmt_event, struct net_if *iface, void *info,
+			       size_t info_length, void *user_data __unused)
 {
 	struct net_in_addr *ipaddr;
 
@@ -649,14 +647,16 @@ static void ipv4_event_handler(struct net_mgmt_event_callback *cb,
 		return;
 	}
 
-	if (cb->info_length != sizeof(struct net_in_addr)) {
+	if (info_length != sizeof(struct net_in_addr)) {
 		return;
 	}
 
-	ipaddr = (struct net_in_addr *)cb->info;
+	ipaddr = (struct net_in_addr *)info;
 
 	arp_gratuitous_send(iface, ipaddr);
 }
+
+NET_MGMT_REGISTER_EVENT_HANDLER(arp_ipv4_events, NET_EVENT_IPV4_ADDR_ADD, ipv4_event_handler, NULL);
 
 static void iface_cb(struct net_if *iface, void *user_data)
 {
@@ -1057,14 +1057,6 @@ void net_arp_init(void)
 	arp_cache_initialized = true;
 
 #if defined(CONFIG_NET_ARP_GRATUITOUS_TRANSMISSION)
-	net_mgmt_init_event_callback(&iface_event_cb, iface_event_handler,
-				     NET_EVENT_IF_UP);
-	net_mgmt_init_event_callback(&ipv4_event_cb, ipv4_event_handler,
-				     NET_EVENT_IPV4_ADDR_ADD);
-
-	net_mgmt_add_event_callback(&iface_event_cb);
-	net_mgmt_add_event_callback(&ipv4_event_cb);
-
 	k_work_reschedule(&arp_gratuitous_work,
 			  K_SECONDS(CONFIG_NET_ARP_GRATUITOUS_INTERVAL));
 #endif /* defined(CONFIG_NET_ARP_GRATUITOUS_TRANSMISSION) */

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -27,7 +27,6 @@ LOG_MODULE_REGISTER(net_arp, CONFIG_NET_ARP_LOG_LEVEL);
 #define NET_BUF_TIMEOUT K_MSEC(100)
 #define ARP_REQUEST_TIMEOUT (2 * MSEC_PER_SEC)
 
-static bool arp_cache_initialized;
 static struct arp_entry arp_entries[CONFIG_NET_ARP_TABLE_SIZE];
 
 static sys_slist_t arp_free_entries = SYS_SLIST_STATIC_INIT(&arp_free_entries);
@@ -1044,17 +1043,11 @@ void net_arp_init(void)
 {
 	int i;
 
-	if (arp_cache_initialized) {
-		return;
-	}
-
 	for (i = 0; i < CONFIG_NET_ARP_TABLE_SIZE; i++) {
 		/* Inserting entry as free with initialised packet queue */
 		k_fifo_init(&arp_entries[i].pending_queue);
 		sys_slist_prepend(&arp_free_entries, &arp_entries[i].node);
 	}
-
-	arp_cache_initialized = true;
 
 #if defined(CONFIG_NET_ARP_GRATUITOUS_TRANSMISSION)
 	k_work_reschedule(&arp_gratuitous_work,


### PR DESCRIPTION
use NET_MGMT_REGISTER_EVENT_HANDLER more often in the network subsystem where possible, so we don't need to use `net_mgmt_init_event_callback` and `net_mgmt_add_event_callback` at runtime