### PR TITLE
drivers: clock_control: nxp_mcxw7x: fix SIRC boolean property guards

### DIFF
--- a/drivers/clock_control/clock_control_nxp_mcxw7x.c
+++ b/drivers/clock_control/clock_control_nxp_mcxw7x.c
@@ -61,7 +61,7 @@ struct mcxw_clock_control_config {
 	/* FIRC frequency range configuration */
 	uint8_t firc_range;
 
-#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
+#if DT_INST_PROP(0, sirc_supported)
 	/* Enable SIRC in low power mode */
 	bool enable_sirc_in_lp_mode;
 #endif
@@ -158,7 +158,7 @@ static int nxp_mcxw_clock_control_get_rate(const struct device *dev,
 			break;
 		}
 		case MCXW_CLK_IP_MUX_FRO_6M: {
-#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
+#if DT_INST_PROP(0, sirc_supported)
 			*rate = CLOCK_GetFreq(kCLOCK_ScgSircClk);
 #else
 			/* SIRC not present on this SoC; FRO6M runs at a fixed 6 MHz */
@@ -244,7 +244,7 @@ static int nxp_mcxw_clock_control_pm(const struct device *dev, enum pm_device_ac
 
 static int nxp_mcxw_clock_validate_sys_clk_src(const struct mcxw_clock_control_config *config)
 {
-#if !DT_INST_NODE_HAS_PROP(0, sirc_supported)
+#if !DT_INST_PROP(0, sirc_supported)
 	if (config->sys_clk_src == MCXW_CLK_SYSTEM_CLK_SRC_SIRC) {
 		LOG_ERR("SIRC is not available as system clock source on this SoC");
 		return -EINVAL;
@@ -285,7 +285,7 @@ static int nxp_mcxw_clock_control_init(const struct device *dev)
 
 	/* Unlock Reference Clock Status Registers to allow writes */
 	CLOCK_UnlockFircControlStatusReg();
-#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
+#if DT_INST_PROP(0, sirc_supported)
 	CLOCK_UnlockSircControlStatusReg();
 #endif
 	CLOCK_UnlockRoscControlStatusReg();
@@ -336,7 +336,7 @@ static int nxp_mcxw_clock_control_init(const struct device *dev)
 	/* Initialize FIRC */
 	(void)CLOCK_InitFirc(&scg_firc_config);
 
-#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
+#if DT_INST_PROP(0, sirc_supported)
 	if (config->enable_sirc_in_lp_mode) {
 		scg_sirc_config_t scg_sirc_config = {
 			.enableMode = kSCG_SircEnableInSleep,
@@ -435,7 +435,7 @@ static struct mcxw_clock_control_config config = {
 	.coarse_adjustment = DT_INST_PROP(0, osc32k_coarse_adjustment),
 	.firc_mode = DT_INST_PROP(0, firc_mode),
 	.firc_range = DT_INST_PROP(0, firc_range),
-#if DT_INST_NODE_HAS_PROP(0, sirc_supported)
+#if DT_INST_PROP(0, sirc_supported)
 	.enable_sirc_in_lp_mode = DT_INST_PROP(0, enable_sirc_in_lp_mode),
 #endif
 	.sys_clk_src = DT_INST_PROP(0, sys_clk_src),


### PR DESCRIPTION
The driver guarded all SIRC code with DT_INST_NODE_HAS_PROP(0, sirc_supported).
For a boolean property that macro always evaluates to 1, so the SIRC paths
were always compiled regardless of the property value.

This stayed hidden until MCUX SDK 26.06.00, whose MCXW727C fsl_clock.h dropped
all SIRC symbols. On mcxw72 (which does not set sirc-supported) the always-true
guard then referenced the now-removed APIs and broke the build.

Switch the six SIRC guards to DT_INST_PROP(0, sirc_supported) so SIRC is only
compiled when the property is actually true. mcxw71 keeps the SIRC path,
mcxw72 no longer compiles it. The sys_clk_div_plat guards stay as
DT_INST_NODE_HAS_PROP since that property is not a boolean.
