### PR TITLE
twister: Do not print twice logs with `inline_logs` for `script` harness tests

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -348,7 +348,7 @@ class JsonReport:
                 continue
             suite = {}
             handler_log = os.path.join(instance.build_dir, "handler.log")
-            pytest_log = os.path.join(instance.build_dir, "twister_harness.log")
+            script_log = os.path.join(instance.build_dir, "twister_harness.log")
             build_log = os.path.join(instance.build_dir, "build.log")
             device_log = os.path.join(instance.build_dir, "device.log")
 
@@ -388,8 +388,8 @@ class JsonReport:
             if instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
                 suite['status'] = instance.status
                 # FIXME
-                if os.path.exists(pytest_log):
-                    suite["log"] = self.process_log(pytest_log)
+                if os.path.exists(script_log):
+                    suite["log"] = self.process_log(script_log)
                 elif os.path.exists(handler_log):
                     suite["log"] = self.process_log(handler_log)
                 elif os.path.exists(device_log):

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -648,10 +648,25 @@ class ProjectBuilder(FilterBuilder):
     def trace(self) -> bool:
         return self.options.verbose > 2
 
-    def log_info(self, filename, inline_logs, log_testcases=False):
+    def log_info(self, filename, inline_logs, log_only_failed=False):
         filename = os.path.abspath(os.path.realpath(filename))
         if inline_logs:
             logger.info(f"{filename:-^100}")
+
+            if log_only_failed:
+                any_found = False
+                for tc in self.instance.testcases:
+                    if not tc.reason:
+                        continue
+                    logger.error(
+                        f"\n{str(tc.name).center(100, '_')}\n"
+                        f"{tc.reason}\n"
+                        f"{100*'_'}\n"
+                        f"{tc.output}"
+                    )
+                    any_found = True
+                if any_found:
+                    return
 
             try:
                 with open(filename) as fp:
@@ -670,16 +685,6 @@ class ProjectBuilder(FilterBuilder):
 
             logger.info(f"{filename:-^100}")
 
-            if log_testcases:
-                for tc in self.instance.testcases:
-                    if not tc.reason:
-                        continue
-                    logger.info(
-                        f"\n{str(tc.name).center(100, '_')}\n"
-                        f"{tc.reason}\n"
-                        f"{100*'_'}\n"
-                        f"{tc.output}"
-                    )
         else:
             logger.error("see: " + Fore.YELLOW + filename + Fore.RESET)
 
@@ -695,7 +700,7 @@ class ProjectBuilder(FilterBuilder):
         if os.path.exists(v_log) and "Valgrind" in self.instance.reason:
             self.log_info(f"{v_log}", inline_logs)
         elif os.path.exists(script_log) and os.path.getsize(script_log) > 0:
-            self.log_info(f"{script_log}", inline_logs, log_testcases=True)
+            self.log_info(f"{script_log}", inline_logs, log_only_failed=True)
         elif os.path.exists(h_log) and os.path.getsize(h_log) > 0:
             self.log_info(f"{h_log}", inline_logs)
         elif os.path.exists(he_log) and os.path.getsize(he_log) > 0:

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -690,12 +690,12 @@ class ProjectBuilder(FilterBuilder):
         b_log = f"{build_dir}/build.log"
         v_log = f"{build_dir}/valgrind.log"
         d_log = f"{build_dir}/device.log"
-        pytest_log = f"{build_dir}/twister_harness.log"
+        script_log = f"{build_dir}/twister_harness.log"
 
         if os.path.exists(v_log) and "Valgrind" in self.instance.reason:
             self.log_info(f"{v_log}", inline_logs)
-        elif os.path.exists(pytest_log) and os.path.getsize(pytest_log) > 0:
-            self.log_info(f"{pytest_log}", inline_logs, log_testcases=True)
+        elif os.path.exists(script_log) and os.path.getsize(script_log) > 0:
+            self.log_info(f"{script_log}", inline_logs, log_testcases=True)
         elif os.path.exists(h_log) and os.path.getsize(h_log) > 0:
             self.log_info(f"{h_log}", inline_logs)
         elif os.path.exists(he_log) and os.path.getsize(he_log) > 0:


### PR DESCRIPTION
For `script` type harnesses, when `--inline_logs` is used, the output of all the scripts which are part of the test are printed to console first (both passed and failed ones). 
And then again the failed ones.
This is quite undesirable, as it fills the console with unnecessary logs, which makes it more difficult and slow to find the problem.

Instead, for the script harness, let's print only the failed ones.

As a bonus, fix the variable name that holds the script harness log filename. (The pytest harness now is a child of the script harness. And all script harnesses use twister_harness.log for their output)