### PR TITLE
twister/testplan: fail closed when twister crashes

### DIFF
--- a/scripts/ci/test_plan_v2.py
+++ b/scripts/ci/test_plan_v2.py
@@ -449,6 +449,16 @@ class MaintainerAreaStrategy(SelectionStrategy):
 # ---------------------------------------------------------------------------
 
 
+class TwisterExecutionError(RuntimeError):
+    """Raised when a twister enumeration subprocess crashes.
+
+    A crash (missing dependency, import error, OOM, segfault, corrupted
+    output) is distinct from a clean run that legitimately matched no tests.
+    The former must **fail the pipeline** - silently treating it as an empty
+    test plan lets a change merge with no coverage at all.
+    """
+
+
 class TwisterExecutor:
     """Executes :class:`TwisterCall` descriptors and collects results.
 
@@ -478,20 +488,34 @@ class TwisterExecutor:
         try:
             cmd = self._build_cmd(call, partial_path)
             log.info("Running: %s", " ".join(cmd))
-            ret = subprocess.call(cmd)  # noqa: S603
-            if ret != 0:
-                log.warning("twister exited with code %d for call: %s", ret, call.description)
+            res = subprocess.run(  # noqa: S603
+                cmd, text=True, capture_output=True, check=False
+            )
+            # Forward twister's own output so CI logs keep the full detail.
+            if res.stdout:
+                sys.stdout.write(res.stdout)
+            if res.stderr:
+                sys.stderr.write(res.stderr)
 
+            if res.returncode != 0:
+                raise TwisterExecutionError(
+                    f"twister exited with code {res.returncode} for call '{call.description}'"
+                )
+
+            # Exit 0: success. The results file is absent when twister matched
+            # no tests (it exits 0 without writing one) - a valid empty result.
             if not os.path.exists(partial_path) or os.path.getsize(partial_path) == 0:
-                log.warning("twister did not produce output at %s", partial_path)
+                log.info("twister matched no tests for call: %s", call.description)
                 return []
 
             try:
                 with open(partial_path, encoding="utf-8") as fh:
                     data = json.load(fh)
             except json.JSONDecodeError as err:
-                log.warning("twister produced invalid JSON at %s: %s", partial_path, err)
-                return []
+                raise TwisterExecutionError(
+                    f"twister exited 0 but produced invalid JSON for call "
+                    f"'{call.description}': {err}"
+                ) from err
             return data.get("testsuites", [])
         finally:
             if os.path.exists(partial_path):
@@ -3989,7 +4013,16 @@ def main():
         tests_per_builder=args.tests_per_builder,
     )
 
-    return orchestrator.run(changed_files, args.output_file)
+    try:
+        return orchestrator.run(changed_files, args.output_file)
+    except TwisterExecutionError as err:
+        log.error("Test plan generation FAILED: %s", err)
+        log.error(
+            "Not emitting a test plan. Failing the job so the change is not "
+            "built/merged with an incomplete or empty plan. Fix the twister "
+            "environment (e.g. missing Python dependencies) and re-run."
+        )
+        return 1
 
 
 if __name__ == "__main__":

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -221,17 +221,21 @@ class TestPlan:
         num = self.add_testsuites(testsuite_filter=self.options.test,
                                 testsuite_pattern=self.options.test_pattern)
 
+        if self.load_errors:
+            logger.error(f"Found {self.load_errors} errors loading {num} test configurations.")
+            raise SystemExit(1)
+
         if num == 0:
-            logger.error("No testsuites found at the specified location...")
-            raise SystemExit("No testsuites found at the specified location...")
+            logger.warning("No testsuites found at the specified location...")
+            raise SystemExit(0)
 
         self.add_testsuites_for_required_applications()
 
+        # check for error and exit if any were found during loading of testsuites in
+        # add_testsuites_for_required_applications, which is also calls add_testsuites.
         if self.load_errors:
             logger.error(f"Found {self.load_errors} errors loading {num} test configurations.")
-            raise SystemExit(
-                f"Found {self.load_errors} errors loading {num} test configurations."
-            )
+            raise SystemExit(1)
 
         self.find_subtests()
         # get list of scenarios we have parsed into one list

--- a/scripts/tests/twister_blackbox/test_errors.py
+++ b/scripts/tests/twister_blackbox/test_errors.py
@@ -53,7 +53,7 @@ class TestInvalidTestSelection:
         result = twister_main(args)
 
         captured = capsys.readouterr()
-        assert result != 0
+        assert result == 0
         assert 'No testsuites found' in captured.err
 
     @pytest.mark.fast

--- a/scripts/tests/twister_blackbox/test_selection.py
+++ b/scripts/tests/twister_blackbox/test_selection.py
@@ -106,7 +106,7 @@ class TestTestSelection:
         result = twister_main(args)
 
         captured = capsys.readouterr()
-        assert result != 0
+        assert result == 0
         assert 'No testsuites found' in captured.err
 
 


### PR DESCRIPTION

Seen in many CI jobs where twister would crash and the testplan would just
continue delivering 0 tests and marking a PR green.

Twister now fails for real and the testplan aborts on such crashes or when
loading invalid tests.

Also add colorlog to the requirements, it is indirectly needed by twister and
its dependencies.

