### PR TITLE
manifest: hal_nxp: upgrade connectivity middlewares to mcux 26.06.00

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 6c77523dfdfc5a1ecefbafb31feee6499a5de8ec
+      revision: 90733605b734e3704a4c27097272b7da7bc5d72a
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Sync hal_nxp to integrate new revision of the connectivity middlewares.