### PR TITLE
arch: fix arch_user_string_nlen() reading past maxsize (RISC-V, ARM, x86, ARC, Xtensa)

### DIFF
--- a/arch/arc/core/userspace.S
+++ b/arch/arc/core/userspace.S
@@ -251,19 +251,22 @@ SECTION_FUNC(TEXT, arch_user_string_nlen)
 	/* Loop setup.
 	 * r12 (position locator) = s - 1
 	 * r0 (length counter return value)) = 0
-	 * lp_count = maxsize + 1
+	 * lp_count = maxsize
 	 * */
 	sub r12, r0, 0x1
 	mov_s r0, 0
-	add_s r1, r1, 1
 	mov lp_count, r1
 
 strlen_loop:
+	/* max length reached? then stop without reading any further */
+	breq lp_count, 0, strlen_done
+
 z_arc_user_string_nlen_fault_start:
 	/* is the byte at ++r12 a NULL? if so, we're done. Might fault! */
 	ldb.aw r1, [r12, 1]
 
 z_arc_user_string_nlen_fault_end:
+	sub lp_count, lp_count, 0x1
 	brne_s r1, 0, not_null
 
 strlen_done:
@@ -279,12 +282,6 @@ z_arc_user_string_nlen_fixup:
 	st_s r1, [r2, 0]
 
 not_null:
-	/* check if we've hit the maximum, if so we're done. */
-	brne.d.nt lp_count, 0x1, inc_len
-	sub lp_count, lp_count, 0x1
-	b_s strlen_done
-
-inc_len:
 	/* increment length measurement, loop again */
 	add_s r0, r0, 1
 	b_s strlen_loop

--- a/arch/arm/core/userspace.S
+++ b/arch/arm/core/userspace.S
@@ -628,6 +628,8 @@ SECTION_FUNC(TEXT, arch_user_string_nlen)
     movs r3, #0		/* r3 is the counter */
 
 strlen_loop:
+    cmp r3, r1
+    beq strlen_done
 z_arm_user_string_nlen_fault_start:
     /* r0 contains the string. r5 = *(r0 + r3]). This could fault. */
     ldrb r5, [r0, r3]
@@ -635,9 +637,6 @@ z_arm_user_string_nlen_fault_start:
 z_arm_user_string_nlen_fault_end:
 #if defined(CONFIG_CPU_AARCH32_CORTEX_R)
     cmp r5, #0
-    beq strlen_done
-
-    cmp r3, r1
     beq strlen_done
 
     adds r3, #1
@@ -649,9 +648,6 @@ z_arm_user_string_nlen_fault_end:
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
     cbz	r5, strlen_done
 #endif
-    cmp	r3, r1
-    beq.n strlen_done
-
     adds r3, #1
     b.n	strlen_loop
 #endif

--- a/arch/riscv/core/userspace.S
+++ b/arch/riscv/core/userspace.S
@@ -29,13 +29,12 @@ SECTION_FUNC(TEXT, arch_user_string_nlen)
 	sw	a5, 0(a2)	# Init error value to 0
 
 loop:
+	beq	a5, a1, exit		# Check if max length is reached
 	add	a4, a0, a5	# Determine character address
 z_riscv_user_string_nlen_fault_start:
 	lbu	a4, 0(a4)	# Load string's character
 z_riscv_user_string_nlen_fault_end:
-	beqz	a4, exit	# Test string's end of line
-
-	bne	a5, a1, continue	# Check if max length is reached
+	bnez	a4, continue	# Test string's end of line
 
 exit:
 	mv	a0, a5		# Return counter value (length)

--- a/arch/x86/core/ia32/userspace.S
+++ b/arch/x86/core/ia32/userspace.S
@@ -255,12 +255,12 @@ SECTION_FUNC(TEXT, arch_user_string_nlen)
 
 	/* This code might page fault */
 strlen_loop:
+	cmp	0xc(%ebp), %eax		/* Max length reached? */
+	je	strlen_done
 z_x86_user_string_nlen_fault_start:
 	cmpb	$0x0, (%edx, %eax, 1)	/* *(EDX + EAX) == 0? Could fault. */
 
 z_x86_user_string_nlen_fault_end:
-	je	strlen_done
-	cmp	0xc(%ebp), %eax		/* Max length reached? */
 	je	strlen_done
 	inc	%eax			/* EAX++ and loop again */
 	jmp	strlen_loop

--- a/arch/x86/core/intel64/userspace.S
+++ b/arch/x86/core/intel64/userspace.S
@@ -237,14 +237,14 @@ arch_user_string_nlen:
 
 	/* This code might page fault */
 strlen_loop:
+	cmp	%rsi, %rax		/* Max length reached? */
+	je	strlen_done
 .global z_x86_user_string_nlen_fault_start
 z_x86_user_string_nlen_fault_start:
 	cmpb	$0x0, (%rdi, %rax, 1)	/* *(RDI + RAX) == 0? Could fault. */
 
 .global z_x86_user_string_nlen_fault_end
 z_x86_user_string_nlen_fault_end:
-	je	strlen_done
-	cmp	%rsi, %rax		/* Max length reached? */
 	je	strlen_done
 	inc	%rax			/* EAX++ and loop again */
 	jmp	strlen_loop

--- a/arch/xtensa/core/mpu/mpu_core.c
+++ b/arch/xtensa/core/mpu/mpu_core.c
@@ -1030,6 +1030,71 @@ out:
 	return ret;
 }
 
+bool xtensa_buffer_is_kernel_readable(const void *addr, size_t size)
+{
+	uintptr_t aligned_addr;
+	size_t aligned_size, addr_offset;
+	bool ret = false;
+
+	/* addr/size arbitrary, fix this up into an aligned region */
+	aligned_addr = ROUND_DOWN((uintptr_t)addr, XCHAL_MPU_ALIGN);
+	addr_offset = (uintptr_t)addr - aligned_addr;
+
+	if (size_add_overflow(size, addr_offset, &aligned_size)) {
+		goto out;
+	}
+
+	aligned_size = ROUND_UP(size + addr_offset, XCHAL_MPU_ALIGN);
+
+	for (size_t offset = 0; offset < aligned_size; offset += XCHAL_MPU_ALIGN) {
+		uint32_t probed = xtensa_pptlb_probe(aligned_addr + offset);
+
+		if ((probed & XTENSA_MPU_PROBE_VALID_ENTRY_MASK) == 0U) {
+			/* There is no foreground or background entry associated
+			 * with the region.
+			 */
+			goto out;
+		}
+
+		uint8_t access_rights = (probed & XTENSA_MPU_PPTLB_ACCESS_RIGHTS_MASK) >>
+					XTENSA_MPU_PPTLB_ACCESS_RIGHTS_SHIFT;
+
+		/* The region must be readable in privileged (kernel) mode. */
+		switch (access_rights) {
+		case XTENSA_MPU_ACCESS_P_RO_U_NA:
+			__fallthrough;
+		case XTENSA_MPU_ACCESS_P_RX_U_NA:
+			__fallthrough;
+		case XTENSA_MPU_ACCESS_P_RW_U_NA:
+			__fallthrough;
+		case XTENSA_MPU_ACCESS_P_RWX_U_NA:
+			__fallthrough;
+		case XTENSA_MPU_ACCESS_P_RW_U_RWX:
+			__fallthrough;
+		case XTENSA_MPU_ACCESS_P_RW_U_RO:
+			__fallthrough;
+		case XTENSA_MPU_ACCESS_P_RWX_U_RX:
+			__fallthrough;
+		case XTENSA_MPU_ACCESS_P_RO_U_RO:
+			__fallthrough;
+		case XTENSA_MPU_ACCESS_P_RX_U_RX:
+			__fallthrough;
+		case XTENSA_MPU_ACCESS_P_RW_U_RW:
+			__fallthrough;
+		case XTENSA_MPU_ACCESS_P_RWX_U_RWX:
+			/* These permissions are okay. */
+			break;
+		default:
+			goto out;
+		}
+	}
+
+	ret = true;
+
+out:
+	return ret;
+}
+
 void xtensa_user_stack_perms(struct k_thread *thread)
 {
 	int ret;

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -1699,7 +1699,18 @@ static bool page_validate(uint32_t *ptables, uint32_t page, uint8_t ring, bool w
 	return true;
 }
 
-int arch_buffer_validate(const void *addr, size_t size, int write)
+/**
+ * @brief Check if a memory region can be legally accessed.
+ *
+ * @param[in] addr Start virtual address of the memory region to be checked.
+ * @param[in] size Size of the memory region to be checked.
+ * @param[in] write True if the access needs to write to this page, false if read only.
+ * @param[in] ring Ring value for the access (RING_USER or RING_KERNEL).
+ *
+ * @retval 0 Access is legal.
+ * @retval -1 Access is not legal and will probably generate page fault.
+ */
+static int mem_buffer_validate(const void *addr, size_t size, int write, uint8_t ring)
 {
 	int ret = 0;
 	uint8_t *virt;
@@ -1713,13 +1724,23 @@ int arch_buffer_validate(const void *addr, size_t size, int write)
 
 	for (size_t offset = 0; offset < aligned_size;
 	     offset += CONFIG_MMU_PAGE_SIZE) {
-		if (!page_validate(ptables, (uint32_t)(virt + offset), RING_USER, write)) {
+		if (!page_validate(ptables, (uint32_t)(virt + offset), ring, write)) {
 			ret = -1;
 			break;
 		}
 	}
 
 	return ret;
+}
+
+int arch_buffer_validate(const void *addr, size_t size, int write)
+{
+	return mem_buffer_validate(addr, size, write, RING_USER);
+}
+
+bool xtensa_buffer_is_kernel_readable(const void *addr, size_t size)
+{
+	return mem_buffer_validate(addr, size, false, RING_KERNEL) == 0;
 }
 
 void xtensa_exc_dtlb_multihit_handle(void *vaddr)

--- a/arch/xtensa/core/syscall_helper.c
+++ b/arch/xtensa/core/syscall_helper.c
@@ -160,27 +160,25 @@ bool xtensa_is_user_context(void)
 
 size_t arch_user_string_nlen(const char *s, size_t maxsize, int *err_arg)
 {
-	/* Check if we can actually read the whole length.
+	if (maxsize == 0) {
+		*err_arg = 0;
+
+		return 0;
+	}
+
+	/* Xtensa cannot safely recover from a fault while examining a string.
+	 * For MMU systems, an unmapped address can trigger an infinite DTLB
+	 * miss storm if its L2 page table does not exist. For MPU systems,
+	 * an access fault terminates the thread. Validate that the requested
+	 * range is readable in kernel mode before calling strnlen().
 	 *
-	 * arch_user_string_nlen() is supposed to naively go through
-	 * the string passed from user thread, and relies on page faults
-	 * to catch inaccessible strings, such that user thread can pass
-	 * a string that is shorter than the max length this function
-	 * caller expects. So at least we want to make sure kernel has
-	 * access to the whole length, aka. memory being mapped.
-	 * Note that arch_user_string_nlen() should never result in
-	 * thread termination due to page faults, and must always
-	 * return to the caller with err_arg set or cleared.
-	 * For MMU systems, unmapped memory will result in a DTLB miss
-	 * and that might trigger an infinite DTLB miss storm if
-	 * the corresponding L2 page table never exists in the first
-	 * place (which would result in DTLB misses through L1 page
-	 * table), until some other exceptions occur to break
-	 * the cycle.
-	 * For MPU systems, this would simply results in access errors
-	 * and the exception handler will terminate the thread.
+	 * Only kernel mode readability is checked here: per
+	 * the k_usermode_string_nlen() contract, user mode accessibility
+	 * is verified separately by the syscall marshalling layer (e.g.
+	 * via K_SYSCALL_MEMORY_READ()) once the length is known, so
+	 * kernel mode callers must be able to measure kernel strings.
 	 */
-	if (arch_buffer_validate(s, maxsize, 0)) {
+	if (!xtensa_buffer_is_kernel_readable(s, maxsize)) {
 		/*
 		 * API says we need to set err_arg to -1 if there are
 		 * any errors.

--- a/arch/xtensa/include/xtensa_internal.h
+++ b/arch/xtensa/include/xtensa_internal.h
@@ -91,6 +91,27 @@ void xtensa_exc_itlb_multihit_handle(void *vaddr);
  */
 bool xtensa_exc_load_store_ring_error_check(void *bsa_p);
 
+#ifdef CONFIG_USERSPACE
+/**
+ * @brief Check if a memory region is readable in privileged (kernel) mode.
+ *
+ * Given a memory region, return whether the current memory management
+ * hardware configuration would allow the kernel to read that region.
+ * Unlike arch_buffer_validate(), this does not require the region to be
+ * accessible from user mode. It is used by arch_user_string_nlen() to
+ * make sure the string can be examined without causing memory access
+ * faults, as user mode accessibility is verified separately by the
+ * syscall marshalling layer.
+ *
+ * @param addr start address of the buffer
+ * @param size the size of the buffer
+ *
+ * @retval true if the region is readable in kernel mode
+ * @retval false otherwise
+ */
+bool xtensa_buffer_is_kernel_readable(const void *addr, size_t size);
+#endif /* CONFIG_USERSPACE */
+
 /**
  * @}
  */

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -300,6 +300,36 @@ ZTEST_USER(syscalls, test_string_nlen)
 }
 
 /**
+ * @brief Test that string_nlen with maxlen 0 does not touch the string
+ *
+ * @details strnlen() semantics require examining at most maxlen bytes,
+ * so with maxlen == 0 the source pointer must not be dereferenced at
+ * all: even an inaccessible address must yield length 0 and no error.
+ * Regression test for arch implementations that loaded the string
+ * byte before checking the length limit.
+ *
+ * @ingroup kernel_memprotect_tests
+ *
+ * @see k_usermode_string_nlen()
+ */
+ZTEST(syscalls, test_string_nlen_maxsize_zero)
+{
+	int err = 0;
+	size_t ret;
+	char buf[8] = "abcdefg";
+
+	ret = k_usermode_string_nlen((const char *)FAULTY_ADDRESS, 0, &err);
+	zassert_equal(ret, 0, "maxlen=0 returned %zu", ret);
+	zassert_equal(err, 0, "maxlen=0 dereferenced the pointer (err %d)", err);
+
+	/* Capped length: no NUL within maxlen must return maxlen. */
+	err = 0;
+	ret = k_usermode_string_nlen(buf, 4, &err);
+	zassert_equal(ret, 4, "capped length returned %zu", ret);
+	zassert_equal(err, 0, "capped length faulted (err %d)", err);
+}
+
+/**
  * @brief Test to verify syscall for string alloc copy
  *
  * @ingroup kernel_memprotect_tests


### PR DESCRIPTION
`arch_user_string_nlen()` is required to behave exactly like libc `strnlen()`:
it must examine at most `maxsize` bytes and must not dereference `s` at all when
`maxsize == 0` (see `include/zephyr/arch/arch_interface.h:982-993`).

The RISC-V, ARM (AArch32), x86 (ia32 and intel64), Xtensa and ARC implementations all
load `s[counter]` before checking `counter == maxsize`, so they read
`s[maxsize]` when the first `maxsize` bytes are non-NUL, and they dereference
`s[0]` when `maxsize == 0`. The over-read byte cannot change the returned
length, but if it is inaccessible to the caller the exception fixup reports a
spurious error and valid syscall input is rejected with `EFAULT` (e.g. via
`k_usermode_string_copy()`).

## Change summary

- `arch: arc`: check the limit before the load.
- `arch: riscv:` check the limit before the load.
- `arch: arm:` same; one shared pre-load check now serves all three ISA
  variants (`ARMV6_M_ARMV8_M_BASELINE`, `ARMV7_M_ARMV8_M_MAINLINE`,
  `CPU_AARCH32_CORTEX_R`), which is valid on all of them.
- `arch: x86:` same reordering in both the ia32 and intel64 implementations.
- `arch: arc:` set `lp_count` to `maxsize` (was `maxsize + 1`) and test it
  before the load instead of after it.
- `tests: kernel/mem_protect:` add `test_string_nlen_maxsize_zero` — with
  `maxlen == 0` an inaccessible pointer must yield length 0 and no error, plus
  a capped-length functional case.


Fixes zephyrproject-rtos/zephyr#113722
