### PR TITLE
drivers: video: optional user-managed lazy video buffer allocation

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -23,6 +23,13 @@ config VIDEO_INIT_PRIORITY
 	help
 	  System initialization priority for video drivers.
 
+config VIDEO_BUFFER_POOL_ALLOC_OPS
+	bool "Use user-managed video buffer allocation"
+	help
+	  When enabled, video buffers allocation is in charge of the user
+	  instead of pre-reserving a fixed video buffer pool. This is
+	  useful when the pool is not always needed to save memory.
+
 config VIDEO_BUFFER_POOL_HEAP_SIZE
 	int "Size in byte of the video buffer pool"
 	default 2097152

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -21,6 +21,7 @@
 
 LOG_MODULE_REGISTER(video_common, CONFIG_VIDEO_LOG_LEVEL);
 
+#if !defined(CONFIG_VIDEO_BUFFER_POOL_ALLOC_OPS)
 #if defined(CONFIG_VIDEO_BUFFER_USE_SHARED_MULTI_HEAP)
 #include <zephyr/multi_heap/shared_multi_heap.h>
 
@@ -61,10 +62,33 @@ static void *video_buffer_k_heap_aligned_alloc(size_t align, size_t bytes, k_tim
 #define VIDEO_COMMON_FREE(block) k_heap_free(&video_buffer_pool, block)
 #endif
 
+#endif
+
 static struct video_buffer video_buf[CONFIG_VIDEO_BUFFER_POOL_NUM_MAX];
+
+#if defined(CONFIG_VIDEO_BUFFER_POOL_ALLOC_OPS)
+static const struct video_user_buffer_ops *user_buffer_ops;
+
+int video_register_user_buffer_ops(const struct video_user_buffer_ops *ops)
+{
+	if (ops == NULL) {
+		return -EINVAL;
+	}
+
+	user_buffer_ops = ops;
+
+	return 0;
+}
+#endif
 
 struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align, k_timeout_t timeout)
 {
+#if defined(CONFIG_VIDEO_BUFFER_POOL_ALLOC_OPS)
+	if (user_buffer_ops != NULL && user_buffer_ops->aligned_alloc != NULL) {
+		return user_buffer_ops->aligned_alloc(size, align, timeout);
+	}
+	return NULL;
+#else
 	struct video_buffer *vbuf = NULL;
 
 	/* find available video buffer */
@@ -91,6 +115,7 @@ struct video_buffer *video_buffer_aligned_alloc(size_t size, size_t align, k_tim
 	vbuf->bytesused = 0;
 
 	return vbuf;
+#endif
 }
 
 struct video_buffer *video_buffer_alloc(size_t size, k_timeout_t timeout)
@@ -100,6 +125,14 @@ struct video_buffer *video_buffer_alloc(size_t size, k_timeout_t timeout)
 
 int video_buffer_release(struct video_buffer *vbuf)
 {
+#if defined(CONFIG_VIDEO_BUFFER_POOL_ALLOC_OPS)
+	if (user_buffer_ops == NULL || user_buffer_ops->release == NULL) {
+		LOG_ERR("User buffer callbacks are not configured");
+		return -EINVAL;
+	}
+
+	return user_buffer_ops->release(vbuf);
+#else
 	if (vbuf == NULL || vbuf->index >= ARRAY_SIZE(video_buf)) {
 		LOG_ERR("Invalid buffer index: %u", vbuf->index);
 		return -EINVAL;
@@ -117,6 +150,7 @@ int video_buffer_release(struct video_buffer *vbuf)
 	video_buf[vbuf->index].buffer = NULL;
 
 	return 0;
+#endif
 }
 
 struct video_buffer *video_import_buffer(uint8_t *mem, size_t sz)

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -1013,6 +1013,29 @@ struct video_buffer *video_buffer_alloc(size_t size, k_timeout_t timeout);
  */
 int video_buffer_release(struct video_buffer *buf);
 
+#if defined(CONFIG_VIDEO_BUFFER_POOL_ALLOC_OPS)
+/**
+ * @brief User-managed video buffer callbacks.
+ *
+ * Register these callbacks from user code to provide buffer allocation/release hooks
+ * to the video driver at runtime.
+ */
+struct video_user_buffer_ops {
+	struct video_buffer *(*aligned_alloc)(size_t size, size_t align, k_timeout_t timeout);
+	int (*release)(struct video_buffer *buf);
+};
+
+/**
+ * @brief Register user-managed video buffer callbacks.
+ *
+ * @param ops Pointer to callbacks. Must remain valid for the program lifetime.
+ *
+ * @retval 0 If successful.
+ * @retval -EINVAL If @p ops is NULL.
+ */
+int video_register_user_buffer_ops(const struct video_user_buffer_ops *ops);
+#endif
+
 /**
  * @brief Search for a format that matches in a list of capabilities
  *


### PR DESCRIPTION
This change adds an optional user-managed video buffer path behind CONFIG_VIDEO_BUFFER_POOL_ALLOC_OPS.

When enabled, video buffer allocation and release are delegated to user callbacks instead of using the pre-reserved internal pool. This allows lazy allocation and helps reduce fixed RAM reservation when CONFIG_VIDEO is enabled but the application does not always use the camera path.

When disabled, the existing internal pool behavior is unchanged.