### PR TITLE
usb: device_next: initialize flash_img with the selected DFU slot

### DIFF
--- a/subsys/usb/device_next/class/usbd_dfu_flash.c
+++ b/subsys/usb/device_next/class/usbd_dfu_flash.c
@@ -95,7 +95,7 @@ static int dfu_flash_write(void *const priv,
 	int ret;
 
 	if (block == 0) {
-		if (flash_img_init(&data->fi_ctx)) {
+		if (flash_img_init_id(&data->fi_ctx, data->id)) {
 			return -EINVAL;
 		}
 


### PR DESCRIPTION
The DFU flash backend always initialized flash_img with the default upload partition, even when the active DFU alt setting was bound to a different flash area.

On boards exposing both slot0_image and slot1_image, a download started through slot1_image could therefore incorrectly write data to slot0.
