### PR TITLE
[Backport v4.3-branch] net: sockets/tls: valide buffer in peer_connection_id_value_get

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1966,6 +1966,10 @@ static int tls_opt_dtls_peer_connection_id_value_get(struct tls_context *context
 		return -ENOTCONN;
 	}
 
+	if (*optlen < MBEDTLS_SSL_CID_OUT_LEN_MAX) {
+		return -EINVAL;
+	}
+
 	ret = mbedtls_ssl_get_peer_cid(&context->ssl, &enabled, optval, &optlen_local);
 	if (enabled) {
 		*optlen = optlen_local;


### PR DESCRIPTION
Backport of the fix from #109244 to `v4.3-branch`.

Fixes: #113748