### PR TITLE
usb host: enforce 10ms reset recovery time according to USB2.0 spec

### DIFF
--- a/include/zephyr/drivers/usb/uhc.h
+++ b/include/zephyr/drivers/usb/uhc.h
@@ -334,6 +334,12 @@ static inline int uhc_bus_reset(const struct device *dev)
 
 	api->lock(dev);
 	ret = api->bus_reset(dev);
+
+	/* Enforce reset recovery time 10 ms (TRSTRCY) */
+	if (ret == 0) {
+		k_sleep(K_MSEC(10));
+	}
+
 	api->unlock(dev);
 
 	return ret;


### PR DESCRIPTION
FIXES: #113758

The USB host stack does not implement the reset recovery time required by the USB 2.0 specification after a port reset. This missing delay causes some devices to fail enumeration or be detected incorrectly, particularly devices that need the full recovery window before they can reliably respond to control requests.
Spec Reference
Per the USB 2.0 Specification, Section 7.1.7.5 (Resetting and Enabling a Port), the host must wait a minimum of 10ms after a port reset completes
