### PR TITLE
samples: drivers: stepper: fix build with h-bridge shield

### DIFF
--- a/boards/shields/mikroe_h_bridge_4_click/mikroe_h_bridge_4_click.overlay
+++ b/boards/shields/mikroe_h_bridge_4_click/mikroe_h_bridge_4_click.overlay
@@ -5,7 +5,7 @@
 
 / {
 	aliases {
-		stepper = &mikroe_h_bridge_4_click;
+		stepper-ctrl = &mikroe_h_bridge_4_click;
 	};
 };
 
@@ -14,7 +14,6 @@
 		status = "okay";
 		compatible = "zephyr,h-bridge-stepper-ctrl";
 
-		en-gpios = <&mikrobus_header 2 GPIO_ACTIVE_LOW>;
 		gpios = <&mikrobus_header 0 GPIO_ACTIVE_LOW>, /* IN1 */
 			<&mikrobus_header 1 GPIO_ACTIVE_LOW>, /* IN2 */
 			<&mikrobus_header 6 GPIO_ACTIVE_LOW>, /* IN3 */

--- a/samples/drivers/stepper/generic/src/main.c
+++ b/samples/drivers/stepper/generic/src/main.c
@@ -13,7 +13,18 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(stepper_generic, CONFIG_STEPPER_LOG_LEVEL);
 
+/*
+ * The stepper-driver alias is optional: some stepper controllers (e.g. h-bridge based ones)
+ * drive the motor directly and do not have a separate hardware driver to enable/disable.
+ */
+#if DT_NODE_EXISTS(DT_ALIAS(stepper_driver))
+#define HAS_STEPPER_DRIVER 1
+#define STEPPER_DRIVER_MICRO_STEP_RES DT_PROP_OR(DT_ALIAS(stepper_driver), micro_step_res, 1)
 static const struct device *stepper_driver = DEVICE_DT_GET(DT_ALIAS(stepper_driver));
+#else
+#define HAS_STEPPER_DRIVER 0
+#define STEPPER_DRIVER_MICRO_STEP_RES 1
+#endif
 static const struct device *stepper_ctrl = DEVICE_DT_GET(DT_ALIAS(stepper_ctrl));
 
 enum stepper_mode {
@@ -29,7 +40,7 @@ enum stepper_mode {
 static atomic_t stepper_mode = ATOMIC_INIT(STEPPER_MODE_DISABLE);
 
 static int32_t ping_pong_target_position = CONFIG_STEPS_PER_REV * CONFIG_PING_PONG_N_REV *
-					   DT_PROP_OR(DT_ALIAS(stepper_driver), micro_step_res, 1);
+					   STEPPER_DRIVER_MICRO_STEP_RES;
 
 static K_SEM_DEFINE(stepper_generic_sem, 0, 1);
 
@@ -71,6 +82,12 @@ int main(void)
 		LOG_ERR("Device %s is not ready", stepper_ctrl->name);
 		return -ENODEV;
 	}
+#if HAS_STEPPER_DRIVER
+	if (!device_is_ready(stepper_driver)) {
+		LOG_ERR("Device %s is not ready", stepper_driver->name);
+		return -ENODEV;
+	}
+#endif
 	LOG_DBG("stepper is %p, name is %s", stepper_ctrl, stepper_ctrl->name);
 
 	stepper_ctrl_set_event_cb(stepper_ctrl, stepper_callback, NULL);
@@ -81,7 +98,9 @@ int main(void)
 		k_sem_take(&stepper_generic_sem, K_FOREVER);
 		switch (atomic_get(&stepper_mode)) {
 		case STEPPER_MODE_ENABLE:
+#if HAS_STEPPER_DRIVER
 			stepper_enable(stepper_driver);
+#endif
 			LOG_INF("mode: enable");
 			break;
 		case STEPPER_MODE_PING_PONG_RELATIVE:
@@ -107,7 +126,9 @@ int main(void)
 			LOG_INF("mode: stop");
 			break;
 		case STEPPER_MODE_DISABLE:
+#if HAS_STEPPER_DRIVER
 			stepper_disable(stepper_driver);
+#endif
 			LOG_INF("mode: disable");
 			break;
 		default:

--- a/samples/drivers/stepper/generic/tests.yaml
+++ b/samples/drivers/stepper/generic/tests.yaml
@@ -6,3 +6,11 @@ tests:
     tags: stepper
     platform_allow: nucleo_g071rb
     depends_on: gpio input
+  sample.drivers.stepper.generic.h_bridge_4_click:
+    build_only: true
+    tags:
+      - stepper
+      - shield
+    platform_allow: mikroe_clicker_ra4m1
+    extra_args: SHIELD=mikroe_h_bridge_4_click
+    depends_on: gpio


### PR DESCRIPTION
The generic stepper sample fails to build for the mikroe_h_bridge_4_click shield because its overlay carries an en-gpios property left over from before the stepper driver/ controller API split, which is not declared in the zephyr,h-bridge-stepper-ctrl binding.

Fix the overlay by dropping the stale en-gpios property and renaming its alias from stepper to stepper-ctrl, matching the driver/ctrl alias scheme the sample expects.

The H-bridge controller combines the motor driver and motion controller into a single device (it only implements the stepper_ctrl API), so it has no separate stepper-driver alias to enable/disable. Update the sample to treat the stepper-driver alias as optional, skipping enable/disable calls when it is absent, instead of failing to compile.

Add a build-only twister test for the mikroe_clicker_ra4m1 board with the mikroe_h_bridge_4_click shield so this combination is exercised in CI going forward.

Fixes #113638 