### PR TITLE
soc: espressif: move riscv boot entry to assembly

### DIFF
--- a/soc/espressif/common/loader.c
+++ b/soc/espressif/common/loader.c
@@ -100,6 +100,7 @@
 #define PART_OFFSET PARTITION_OFFSET(slot0_appcpu_partition)
 #endif
 
+/* Image entry point: start.S on RISC-V, the C function below on Xtensa. */
 void __start(void);
 static HDR_ATTR void (*_entry_point)(void) = &__start;
 
@@ -322,59 +323,9 @@ void map_rom_segments(int core, struct rom_segments *map)
 }
 #endif /* !CONFIG_MCUBOOT */
 
-void __start(void)
+/* Common boot path, entered once the arch-specific entry has zeroed .bss. */
+static void boot_start(void)
 {
-#ifdef CONFIG_RISCV_GP
-	/* Set up stack FIRST - before any other operations */
-	__asm__ __volatile__("li sp, %0" ::"i"(DRAM_STACK_START));
-
-	/* Disable interrupts before setting up the vector table */
-	csr_read_clear(mstatus, MSTATUS_MIE);
-
-	__asm__ __volatile__("la t0, _vector_table\n"
-			     "csrw mtvec, t0\n");
-
-#if SOC_INT_CLIC_SUPPORTED
-	/* CLIC: mtvt points to the hardware-vectored interrupt table.
-	 * mtvec mode bits are hardwired to 3 (CLIC) on ESP32-C5.
-	 */
-	__asm__ __volatile__("la t0, _mtvt_table\n"
-			     "csrw 0x307, t0\n"); /* mtvt CSR */
-#endif
-
-	/* Configure the global pointer register
-	 * (This should be the first thing startup does, as any other piece of code could be
-	 * relaxed by the linker to access something relative to __global_pointer$)
-	 */
-	__asm__ __volatile__(".option push\n"
-			     ".option norelax\n"
-			     "la gp, __global_pointer$\n"
-			     ".option pop");
-
-	arch_bss_zero();
-
-#else /* xtensa */
-
-	extern uint32_t _init_start;
-
-	/* Move the exception vector table to IRAM. */
-	__asm__ __volatile__("wsr %0, vecbase" : : "r"(&_init_start));
-
-	arch_bss_zero();
-
-	__asm__ __volatile__("" : : "g"(&__bss_start) : "memory");
-
-	/* Disable normal interrupts. */
-	__asm__ __volatile__("wsr %0, PS" : : "r"(PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM | PS_WOE));
-
-	/* Initialize the architecture CPU pointer.  Some of the
-	 * initialization code wants a valid arch_curr_cpu() before
-	 * arch_kernel_init() is invoked.
-	 */
-	__asm__ __volatile__("wsr %0, " ZSR_CPU_STR "; rsync" : : "r"(&_kernel.cpus[0]));
-
-#endif /* CONFIG_RISCV_GP */
-
 #ifdef CONFIG_MCUBOOT
 	memset(&_loader_bss_start, 0,
 		(size_t)((uint8_t *)_loader_bss_end - (uint8_t *)_loader_bss_start));
@@ -407,3 +358,40 @@ void __start(void)
 	__esp_platform_mcuboot_start();
 #endif
 }
+
+#ifdef CONFIG_RISCV
+
+/* Entered from start.S, which has set up gp, the stack and the vector table. */
+void start_riscv(void)
+{
+	arch_bss_zero();
+
+	boot_start();
+}
+
+#else /* xtensa */
+
+void __start(void)
+{
+	extern uint32_t _init_start;
+
+	/* Move the exception vector table to IRAM. */
+	__asm__ __volatile__("wsr %0, vecbase" : : "r"(&_init_start));
+
+	arch_bss_zero();
+
+	__asm__ __volatile__("" : : "g"(&__bss_start) : "memory");
+
+	/* Disable normal interrupts. */
+	__asm__ __volatile__("wsr %0, PS" : : "r"(PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM | PS_WOE));
+
+	/* Initialize the architecture CPU pointer.  Some of the
+	 * initialization code wants a valid arch_curr_cpu() before
+	 * arch_kernel_init() is invoked.
+	 */
+	__asm__ __volatile__("wsr %0, " ZSR_CPU_STR "; rsync" : : "r"(&_kernel.cpus[0]));
+
+	boot_start();
+}
+
+#endif /* CONFIG_RISCV */

--- a/soc/espressif/common/start.S
+++ b/soc/espressif/common/start.S
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Boot entry point. The ROM enters here on a stack of its own choosing, which
+ * on some layouts overlaps .bss, so this must run before any compiler-generated
+ * prologue can spill to it. The stack set up here is scratch, used only until
+ * z_cstart() installs the kernel stack.
+ */
+
+#include <zephyr/toolchain.h>
+#include <zephyr/arch/riscv/csr.h>
+#include <soc/soc_caps.h>
+#include "memory.h"
+
+#define CSR_MTVT 0x307
+
+GTEXT(start_riscv)
+GTEXT(_vector_table)
+#if SOC_INT_CLIC_SUPPORTED
+GTEXT(_mtvt_table)
+#endif
+
+GTEXT(__start)
+
+	.section .iram1, "ax"
+	.balign 4
+	.global __start
+	.type __start, @function
+
+__start:
+#ifdef CONFIG_RISCV_GP
+	/* Must precede any access the linker could relax to gp-relative. */
+	.option push
+	.option norelax
+	la gp, __global_pointer$
+	.option pop
+#endif
+
+	li sp, DRAM_STACK_START
+
+	csrci mstatus, MSTATUS_MIE
+
+	la t0, _vector_table
+	csrw mtvec, t0
+
+#if SOC_INT_CLIC_SUPPORTED
+	la t0, _mtvt_table
+	csrw CSR_MTVT, t0
+#endif
+
+	tail start_riscv
+
+	.size __start, . - __start

--- a/soc/espressif/esp32c2/CMakeLists.txt
+++ b/soc/espressif/esp32c2/CMakeLists.txt
@@ -4,6 +4,7 @@ zephyr_sources(
   vectors.S
   soc_irq.S
   soc.c
+  ../common/start.S
   ../common/loader.c
   )
 

--- a/soc/espressif/esp32c3/CMakeLists.txt
+++ b/soc/espressif/esp32c3/CMakeLists.txt
@@ -4,6 +4,7 @@ zephyr_sources(
   vectors.S
   soc_irq.S
   soc.c
+  ../common/start.S
   ../common/loader.c
   )
 

--- a/soc/espressif/esp32c5/CMakeLists.txt
+++ b/soc/espressif/esp32c5/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_sources_ifdef(CONFIG_SOC_ESP32C5_HPCORE
   vectors.S
   soc_irq.S
   soc.c
+  ../common/start.S
   ../common/loader.c
   )
 

--- a/soc/espressif/esp32c6/CMakeLists.txt
+++ b/soc/espressif/esp32c6/CMakeLists.txt
@@ -4,6 +4,7 @@ zephyr_sources_ifdef(CONFIG_SOC_ESP32C6_HPCORE
   vectors.S
   soc_irq.S
   soc.c
+  ../common/start.S
   ../common/loader.c
   )
 

--- a/soc/espressif/esp32h2/CMakeLists.txt
+++ b/soc/espressif/esp32h2/CMakeLists.txt
@@ -4,6 +4,7 @@ zephyr_sources(
   vectors.S
   soc_irq.S
   soc.c
+  ../common/start.S
   ../common/loader.c
   )
 

--- a/soc/espressif/esp32p4/CMakeLists.txt
+++ b/soc/espressif/esp32p4/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_sources_ifdef(CONFIG_SOC_ESP32P4_HPCORE
   vectors.S
   soc_irq.S
   soc.c
+  ../common/start.S
   ../common/loader.c
   )
 

--- a/soc/espressif/esp32p4/memory.h
+++ b/soc/espressif/esp32p4/memory.h
@@ -75,7 +75,12 @@
  * cache is at the bottom, so usable RAM ends at the ROM reserved region.
  */
 #if defined(CONFIG_SOC_ESP32P4_REV_1_3)
-#define DRAM_HW_USER_END (HPSRAM_BASE + HPSRAM_TOTAL_SIZE - L2_CACHE_SIZE)
+/* HP SRAM base and size as plain literals: start.S needs this expression to
+ * survive the assembler, which cannot evaluate devicetree macros.
+ */
+#define HPSRAM_LOW       0x4ff00000
+#define HPSRAM_TOTAL     0xc0000
+#define DRAM_HW_USER_END (HPSRAM_LOW + HPSRAM_TOTAL - L2_CACHE_SIZE)
 #else
 #define DRAM_HW_USER_END DRAM_ROM_RESERVED_START
 #endif


### PR DESCRIPTION
The entry point set the stack pointer from inline asm inside a C function, so the compiler was free to emit a prologue that spilled through the stack inherited from ROM before the switch happened. Where that stack overlaps .bss it corrupts statics arch_bss_zero() has already cleared.

Do the gp, stack and vector table setup in assembly instead, then hand off to C. Gate it on RISCV rather than RISCV_GP, as only the gp setup depends on gp being used for addressing.

Fixes #113691