### PR TITLE
boards: shields: add Heltec T114 v2 display shield

### DIFF
--- a/boards/heltec/heltec_t114_v2/heltec_t114_v2_nrf52840_common.dts
+++ b/boards/heltec/heltec_t114_v2/heltec_t114_v2_nrf52840_common.dts
@@ -127,7 +127,7 @@
 			ram-param = [00 f0];
 			rgb-param = [cd 08 14];
 			mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
-			pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+			pixel-format = <PANEL_PIXEL_FORMAT_RGB_565X>;
 			status = "okay";
 		};
 	};

--- a/boards/shields/heltec_t114_v2_display/Kconfig.defconfig
+++ b/boards/shields/heltec_t114_v2_display/Kconfig.defconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Yeray Lois Sanchez
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_HELTEC_T114_V2_DISPLAY
+
+if DISPLAY
+
+# Needed by the fixed regulators in the shield overlay.
+configdefault REGULATOR
+	default y
+
+endif # DISPLAY
+
+endif # SHIELD_HELTEC_T114_V2_DISPLAY

--- a/boards/shields/heltec_t114_v2_display/Kconfig.shield
+++ b/boards/shields/heltec_t114_v2_display/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Yeray Lois Sanchez
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_HELTEC_T114_V2_DISPLAY
+	def_bool $(shields_list_contains,heltec_t114_v2_display)

--- a/boards/shields/heltec_t114_v2_display/doc/index.rst
+++ b/boards/shields/heltec_t114_v2_display/doc/index.rst
@@ -1,0 +1,38 @@
+.. _heltec_t114_v2_display:
+
+Heltec T114 v2 display shield
+#############################
+
+Overview
+********
+
+The 1.14-inch ST7789V TFT is an optional module for the Heltec T114 v2.
+The base board keeps its power and backlight disabled. Select this shield to
+power the module when building a display application.
+
+Programming
+***********
+
+Add ``--shield heltec_t114_v2_display`` to the build command. For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/display
+   :board: heltec_t114_v2/nrf52840/uf2
+   :shield: heltec_t114_v2_display
+   :goals: build
+
+Landscape orientation
+*********************
+
+To use a 240 by 135 pixel landscape orientation, add the following snippet to
+the application overlay and build with the same shield:
+
+.. code-block:: dts
+
+   &tft_display {
+           width = <240>;
+           height = <135>;
+           x-offset = <40>;
+           y-offset = <53>;
+           mdac = <0x60>;
+   };

--- a/boards/shields/heltec_t114_v2_display/heltec_t114_v2_display.overlay
+++ b/boards/shields/heltec_t114_v2_display/heltec_t114_v2_display.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Yeray Lois Sanchez
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&tft_en {
+	/delete-property/ gpios;
+	compatible = "regulator-fixed";
+	regulator-name = "tft_power_enable";
+	enable-gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+	regulator-boot-on;
+};
+
+&tft_led_en {
+	/delete-property/ gpios;
+	compatible = "regulator-fixed";
+	regulator-name = "tft_backlight_enable";
+	enable-gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+	regulator-boot-on;
+};
+
+/ {
+	aliases {
+		/delete-property/ tft-en;
+		/delete-property/ tft-led-en;
+	};
+};

--- a/boards/shields/heltec_t114_v2_display/shield.yml
+++ b/boards/shields/heltec_t114_v2_display/shield.yml
@@ -1,0 +1,6 @@
+shields:
+  - name: heltec_t114_v2_display
+    full_name: Heltec T114 v2 Display
+    vendor: heltec
+    supported_features:
+      - display


### PR DESCRIPTION
## Summary

- Fix the T114 v2 ST7789V pixel format by selecting `RGB565X`.
- Add `heltec_t114_v2_display`, a board-specific shield for the optional TFT module.
- Keep the panel power and backlight pins under application control when the shield is not selected.
- Document the regular portrait build and a hardware-tested landscape application overlay.

## Motivation

The ST7789V display sold for the Heltec T114 v2 is optional. On the base board,
`TFT_EN` and `TFT_LED_EN` are intentionally exposed as GPIO-based board controls.
However, a display application cannot power the module automatically, and the
write-only panel can initialize without reporting that it is still unpowered.

The shield opts into display power by changing those two existing nodes into
boot-on fixed regulators. It also removes their aliases while the regulator
driver owns the pins. Boards without the optional module retain the base-board
behavior and do not enable the regulator subsystem.

The board now selects `RGB565X`, matching the byte order required by the panel
and completing the board-side adoption of the LVGL support merged in #108610.

## Usage

```shell
west build -b heltec_t114_v2/nrf52840/uf2 \
  --shield heltec_t114_v2_display samples/drivers/display
```

The shield documentation includes the tested `240x135` landscape overlay. A
separate landscape shield is deliberately not exposed because orientation is
an application choice rather than different hardware.

## Validation

- `samples/drivers/display` without the shield: builds successfully and does
  not enable `REGULATOR`.
- Portrait shield build: builds successfully and renders the expected color
  pattern on hardware.
- Landscape application overlay (`240x135`, offsets `40/53`, `mdac = 0x60`):
  builds successfully and renders correctly on hardware with USB-C on the left.
- Repeated power-on tests succeeded without `startup-delay-us`.

Related ST7789V initialization work was also validated on this hardware and
merged in #108609.
