### PR TITLE
drivers: wifi: esp32: retry tx when out of tx buffers

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -191,6 +191,15 @@ config ESP32_WIFI_DYNAMIC_TX_BUFFER_NUM
 	  than WiFi layer can transmit. In these cases, we may run out of TX
 	  buffers.
 
+config ESP32_WIFI_TX_RETRY_TIMEOUT_MS
+	int "Wi-Fi TX retry timeout (ms)"
+	default 50
+	range 0 1000
+	help
+	  How long a transmit waits for one of the TX buffers above to free up
+	  before the packet is dropped. This blocks the calling thread, so the
+	  timeout also bounds the added latency. Set to 0 to drop immediately.
+
 choice ESP32_WIFI_MGMT_RX_BUFFER
 	prompt "Type of WiFi RX MGMT buffers"
 	default ESP32_WIFI_STATIC_RX_MGMT_BUFFER

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -82,13 +82,14 @@ struct esp32_wifi_runtime {
 	scan_result_cb_t scan_cb;
 	uint8_t state;
 	uint8_t ap_connection_cnt;
+	struct k_mutex send_lock;
+	struct k_sem tx_done_sem;
 #if defined(CONFIG_ESP32_WIFI_ENTERPRISE)
 	struct wifi_enterprise_creds_params enterprise_creds;
 #endif
 };
 
 static struct net_mgmt_event_callback esp32_dhcp_cb;
-static K_MUTEX_DEFINE(esp32_wifi_send_lock);
 
 static void wifi_event_handler(struct net_mgmt_event_callback *cb, uint64_t mgmt_event,
 			       struct net_if *iface)
@@ -100,6 +101,34 @@ static void wifi_event_handler(struct net_mgmt_event_callback *cb, uint64_t mgmt
 	default:
 		break;
 	}
+}
+
+static void esp32_wifi_tx_done(uint8_t ifidx, uint8_t *data __unused, uint16_t *data_len __unused,
+			       bool status __unused)
+{
+	struct esp32_wifi_runtime *runtime_data = &esp32_data;
+
+#if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
+	if (ifidx == ESP_IF_WIFI_AP) {
+		runtime_data = &esp32_ap_sta_data;
+	}
+#else
+	ARG_UNUSED(ifidx);
+#endif
+
+	k_sem_give(&runtime_data->tx_done_sem);
+}
+
+static int esp32_wifi_start(void)
+{
+	int ret;
+
+	ret = esp_wifi_start();
+	if (ret) {
+		return ret;
+	}
+
+	return esp_wifi_set_tx_done_cb(esp32_wifi_tx_done);
 }
 
 static inline struct esp32_wifi_runtime *esp32_wifi_data_get(struct net_if *iface __maybe_unused)
@@ -121,6 +150,8 @@ static int esp32_wifi_send(const struct device *dev __unused, struct net_pkt *pk
 			   data->state == ESP32_AP_DISCONNECTED);
 	bool sta_connected = (data->state == ESP32_STA_CONNECTED);
 	esp_interface_t ifx = ap_running ? ESP_IF_WIFI_AP : ESP_IF_WIFI_STA;
+	k_timepoint_t end;
+	int err;
 
 	if (!sta_connected && !ap_running) {
 		return -EIO;
@@ -131,19 +162,26 @@ static int esp32_wifi_send(const struct device *dev __unused, struct net_pkt *pk
 		goto out;
 	}
 
-	k_mutex_lock(&esp32_wifi_send_lock, K_FOREVER);
+	k_mutex_lock(&data->send_lock, K_FOREVER);
 
 	/* Read the packet payload */
 	if (net_pkt_read(pkt, data->frame_buf, pkt_len) < 0) {
 		goto unlock;
 	}
 
-	/* Enqueue packet for transmission */
-	if (esp_wifi_internal_tx(ifx, (void *)data->frame_buf, pkt_len) != ESP_OK) {
+	k_sem_reset(&data->tx_done_sem);
+	end = sys_timepoint_calc(K_MSEC(CONFIG_ESP32_WIFI_TX_RETRY_TIMEOUT_MS));
+
+	do {
+		err = esp_wifi_internal_tx(ifx, (void *)data->frame_buf, pkt_len);
+	} while (err == ESP_ERR_NO_MEM &&
+		 k_sem_take(&data->tx_done_sem, sys_timepoint_timeout(end)) == 0);
+
+	if (err != ESP_OK) {
 		goto unlock;
 	}
 
-	k_mutex_unlock(&esp32_wifi_send_lock);
+	k_mutex_unlock(&data->send_lock);
 
 #if defined(CONFIG_NET_STATISTICS_WIFI)
 	data->stats.bytes.sent += pkt_len;
@@ -154,7 +192,7 @@ static int esp32_wifi_send(const struct device *dev __unused, struct net_pkt *pk
 	return 0;
 
 unlock:
-	k_mutex_unlock(&esp32_wifi_send_lock);
+	k_mutex_unlock(&data->send_lock);
 out:
 
 	LOG_ERR("Failed to send packet");
@@ -898,7 +936,7 @@ static int esp32_wifi_connect(const struct device *dev __unused,
 		return -EAGAIN;
 	}
 
-	ret = esp_wifi_start();
+	ret = esp32_wifi_start();
 	if (ret) {
 		LOG_ERR("Failed to start Wi-Fi driver (%d)", ret);
 		return -EAGAIN;
@@ -1079,7 +1117,7 @@ static int esp32_wifi_scan(const struct device *dev __unused,
 		return -EINVAL;
 	}
 
-	ret = esp_wifi_start();
+	ret = esp32_wifi_start();
 	if (ret) {
 		LOG_ERR("Failed to start Wi-Fi driver (%d)", ret);
 		data->scan_cb = NULL;
@@ -1201,7 +1239,7 @@ static int esp32_wifi_ap_enable(const struct device *dev __unused, struct net_if
 		return -EINVAL;
 	}
 
-	err = esp_wifi_start();
+	err = esp32_wifi_start();
 	if (err) {
 		LOG_ERR("Failed to enable Wi-Fi AP mode");
 		return -EAGAIN;
@@ -1233,7 +1271,7 @@ static int esp32_wifi_ap_disable(const struct device *dev __unused, struct net_i
 	esp_wifi_get_mode(&mode);
 	if (mode == ESP32_WIFI_MODE_APSTA) {
 		err = esp_wifi_set_mode(ESP32_WIFI_MODE_STA);
-		err |= esp_wifi_start();
+		err |= esp32_wifi_start();
 	} else {
 		err = esp_wifi_stop();
 	}
@@ -1508,7 +1546,16 @@ static int esp32_wifi_dev_init(const struct device *dev)
 #endif /* CONFIG_SOC_SERIES_ESP32S2 || CONFIG_SOC_SERIES_ESP32C3 */
 
 	wifi_init_config_t config = WIFI_INIT_CONFIG_DEFAULT();
-	esp_err_t ret = esp_wifi_init(&config);
+	esp_err_t ret;
+
+	k_mutex_init(&esp32_data.send_lock);
+	k_sem_init(&esp32_data.tx_done_sem, 0, 1);
+#if defined(CONFIG_ESP32_WIFI_AP_STA_MODE)
+	k_mutex_init(&esp32_ap_sta_data.send_lock);
+	k_sem_init(&esp32_ap_sta_data.tx_done_sem, 0, 1);
+#endif
+
+	ret = esp_wifi_init(&config);
 
 	if (ret == ESP_ERR_NO_MEM) {
 		LOG_ERR("Not enough memory to initialize Wi-Fi.");
@@ -1526,7 +1573,7 @@ static int esp32_wifi_dev_init(const struct device *dev)
 	}
 
 	/* Start Wi-Fi early to enable coexistence for WiFi/BT operation. */
-	ret = esp_wifi_start();
+	ret = esp32_wifi_start();
 	if (ret != ESP_OK) {
 		LOG_ERR("Unable to start the Wi-Fi: %d", ret);
 		return -EIO;

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -151,6 +151,7 @@ static int esp32_wifi_send(const struct device *dev __unused, struct net_pkt *pk
 	bool sta_connected = (data->state == ESP32_STA_CONNECTED);
 	esp_interface_t ifx = ap_running ? ESP_IF_WIFI_AP : ESP_IF_WIFI_STA;
 	k_timepoint_t end;
+	int ret;
 	int err;
 
 	if (!sta_connected && !ap_running) {
@@ -159,6 +160,7 @@ static int esp32_wifi_send(const struct device *dev __unused, struct net_pkt *pk
 
 	if (pkt_len > sizeof(data->frame_buf)) {
 		LOG_ERR("Packet too large to send: %zu > %zu", pkt_len, sizeof(data->frame_buf));
+		ret = -EMSGSIZE;
 		goto out;
 	}
 
@@ -166,6 +168,7 @@ static int esp32_wifi_send(const struct device *dev __unused, struct net_pkt *pk
 
 	/* Read the packet payload */
 	if (net_pkt_read(pkt, data->frame_buf, pkt_len) < 0) {
+		ret = -EIO;
 		goto unlock;
 	}
 
@@ -178,6 +181,7 @@ static int esp32_wifi_send(const struct device *dev __unused, struct net_pkt *pk
 		 k_sem_take(&data->tx_done_sem, sys_timepoint_timeout(end)) == 0);
 
 	if (err != ESP_OK) {
+		ret = (err == ESP_ERR_NO_MEM) ? -ENOBUFS : -EIO;
 		goto unlock;
 	}
 
@@ -195,11 +199,11 @@ unlock:
 	k_mutex_unlock(&data->send_lock);
 out:
 
-	LOG_ERR("Failed to send packet");
+	LOG_ERR("Failed to send packet: %d", ret);
 #if defined(CONFIG_NET_STATISTICS_WIFI)
 	data->stats.errors.tx++;
 #endif
-	return -EIO;
+	return ret;
 }
 
 static esp_err_t eth_esp32_rx(void *buffer, uint16_t len, void *eb)


### PR DESCRIPTION
The driver dropped a frame as soon as the low-level Wi-Fi TX buffers
ran out, so a bursty sender lost data even while its own buffers were
nearly empty.

Wait for an in-flight frame to complete and retry, bounded by
CONFIG_ESP32_WIFI_TX_RETRY_TIMEOUT_MS (default 50ms, 0 restores the
old drop-immediately behavior). Send failures now also report
-ENOBUFS or -EMSGSIZE instead of a blanket -EIO.

Measured with zperf UDP upload at 30Mbps, packet loss counted at the
receiver:

| | before | after |
|---|---|---|
| esp32s3 (STA) | 29.9% | 0.01% |
| esp32s3 (AP)  | 1126 lost | 0 |
| esp32c6 (STA) | 17.0% | 0.02% |

Fixes #113666