### PR TITLE
boards: heltec: heltec_t114_v2: enable DC/DC and describe battery divider

### DIFF
--- a/boards/heltec/heltec_t114_v2/heltec_t114_v2_nrf52840_common.dts
+++ b/boards/heltec/heltec_t114_v2/heltec_t114_v2_nrf52840_common.dts
@@ -149,6 +149,10 @@
 	};
 };
 
+&reg1 {
+	regulator-initial-mode = <NRF5X_REG_MODE_DCDC>;
+};
+
 &adc {
 	status = "okay";
 	#address-cells = <1>;

--- a/boards/heltec/heltec_t114_v2/heltec_t114_v2_nrf52840_common.dts
+++ b/boards/heltec/heltec_t114_v2/heltec_t114_v2_nrf52840_common.dts
@@ -41,11 +41,6 @@
 			label = "VEXT Control";
 		};
 
-		adc_control: adc_control {
-			gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
-			label = "ADC Control";
-		};
-
 		tft_en: tft_en {
 			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
 			label = "TFT_EN - display enable";
@@ -82,6 +77,14 @@
 			gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
 			label = "gnss PPS";
 		};
+	};
+
+	vbatt: vbatt {
+		compatible = "voltage-divider";
+		io-channels = <&adc 2>;
+		output-ohms = <100000>;
+		full-ohms = <490000>;
+		power-gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
 	};
 
 	led_strip: led_strip {
@@ -141,7 +144,6 @@
 		mcuboot-led4 = &led4;
 		watchdog0 = &wdt0;
 		vext-control = &vext_control;
-		adc-control = &adc_control;
 		tft-en = &tft_en;
 		tft-led-en = &tft_led_en;
 		gnss-rst = &gnss_rst;
@@ -157,7 +159,6 @@
 	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	io-channels = <&adc 2>;
 
 	channel@2 {
 		reg = <2>;


### PR DESCRIPTION

Two power-related improvements for the Heltec T114 v2, one commit each:

- Run the nRF52840 REG1 stage in DC/DC mode. The board wires the module's DC/DC inductors and the vendor firmware ships with the converter enabled, so this reduces active current draw at no cost.
- Describe the battery measurement path as a `vbatt` voltage-divider node (390k/100k per the board schematic) with the divider switch as `power-gpios`, replacing the bare ADC channel plus the inert `adc_control` board_controls entry that applications had to drive by hand.

Tested on hardware (Heltec Mesh Node T114 v2, `heltec_t114_v2/nrf52840/uf2`, `samples/boards/nordic/battery`): boots with the DC/DC converter enabled and reports plausible battery voltage readings through the divider (~3.9 V to 4.2 V on a charging LiPo).