### PR TITLE
cmake: gcc: drop -gdwarf-4 pyelftools workaround

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -254,10 +254,6 @@ set_compiler_property(PROPERTY linker_script -T)
 # Flags to not track macro expansion
 set_compiler_property(PROPERTY no_track_macro_expansion -ftrack-macro-expansion=0)
 
-# GCC 11 by default emits DWARF version 5 which cannot be parsed by
-# pyelftools. Can be removed once pyelftools supports v5.
-check_set_compiler_property(APPEND PROPERTY debug -gdwarf-4)
-
 set_compiler_property(PROPERTY no_common -fno-common)
 
 # GCC compiler flags for imacros. The specific header must be appended by user.

--- a/cmake/linker/ld/gcc/linker_flags.cmake
+++ b/cmake/linker/ld/gcc/linker_flags.cmake
@@ -9,10 +9,6 @@ endif()
 
 check_set_linker_property(TARGET linker APPEND PROPERTY gprof -pg)
 
-# GCC 11 by default emits DWARF version 5 which cannot be parsed by
-# pyelftools. Can be removed once pyelftools supports v5.
-add_link_options(-gdwarf-4)
-
 # Extra warnings options for twister run
 set_property(TARGET linker PROPERTY warnings_as_errors -Wl,--fatal-warnings)
 

--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -171,9 +171,19 @@ def debug_die(die, text):
     files = lp_header["file_entry"]
     includes = lp_header["include_directory"]
 
-    fileinfo = files[die.attributes["DW_AT_decl_file"].value - 1]
+    dwarf_v5 = lp_header.version >= 5
+
+    file_index = die.attributes["DW_AT_decl_file"].value
+    fileinfo = files[file_index if dwarf_v5 else file_index - 1]
     filename = fileinfo.name.decode("utf-8")
-    filedir = includes[fileinfo.dir_index - 1].decode("utf-8")
+
+    dir_index = fileinfo.dir_index
+    if dwarf_v5:
+        filedir = includes[dir_index].decode("utf-8")
+    elif dir_index == 0:
+        filedir = ""
+    else:
+        filedir = includes[dir_index - 1].decode("utf-8")
 
     path = os.path.join(filedir, filename)
     lineno = die.attributes["DW_AT_decl_line"].value

--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -198,6 +198,7 @@ def debug_die(die, text):
 DW_OP_addr = 0x3
 DW_OP_plus_uconst = 0x23
 DW_OP_fbreg = 0x91
+DW_OP_addrx = 0xA1
 STACK_TYPE = "z_thread_stack_element"
 thread_counter = 0
 sys_mutex_counter = 0
@@ -632,7 +633,7 @@ def find_kobjects(elf, syms):
             continue
 
         opcode = loc.value[0]
-        if opcode != DW_OP_addr:
+        if opcode not in (DW_OP_addr, DW_OP_addrx):
             # Check if frame pointer offset DW_OP_fbreg
             if opcode == DW_OP_fbreg:
                 debug_die(die, f"kernel object '{name}' found on stack")
@@ -641,7 +642,16 @@ def find_kobjects(elf, syms):
             continue
 
         endian_code = "<" if elf.little_endian else ">"
-        if "CONFIG_64BIT" in syms:
+        if opcode == DW_OP_addrx:
+            # DWARF v5: the operand is a ULEB128 index into .debug_addr rather
+            # than an inline address.
+            addr_index, uconst_idx = decode_uleb128(loc.value, 1)
+            try:
+                addr = die.dwarfinfo.get_addr(die.cu, addr_index)
+            except Exception:
+                debug_die(die, f"kernel object '{name}' unresolvable DW_OP_addrx index")
+                continue
+        elif "CONFIG_64BIT" in syms:
             addr = struct.unpack(endian_code + "Q", bytes(loc.value[1:9]))[0]
             uconst_idx = 9
         else:

--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -460,6 +460,19 @@ def analyze_die_const(die):
     type_env[die.offset] = ConstType(type_offset)
 
 
+def _is_constant_form(form):
+    # A subrange bound is a plain integer count only for constant-class forms.
+    # DWARF <=4 GCC uses DW_FORM_dataN; DWARF 5 GCC uses DW_FORM_implicit_const,
+    # and other producers use the signed/unsigned LEB forms. Anything else
+    # (an exprloc/block computing a dynamic bound, or a reference) is not a
+    # constant we can turn into an element count, so it is skipped.
+    return form.startswith("DW_FORM_data") or form in (
+        "DW_FORM_implicit_const",
+        "DW_FORM_sdata",
+        "DW_FORM_udata",
+    )
+
+
 def analyze_die_array(die):
     type_offset = die_get_type_offset(die)
     elements = []
@@ -471,7 +484,7 @@ def analyze_die_array(die):
         if "DW_AT_upper_bound" in child.attributes:
             ub = child.attributes["DW_AT_upper_bound"]
 
-            if not ub.form.startswith("DW_FORM_data"):
+            if not _is_constant_form(ub.form):
                 continue
 
             elements.append(ub.value + 1)
@@ -480,7 +493,7 @@ def analyze_die_array(die):
         elif "DW_AT_count" in child.attributes:
             ub = child.attributes["DW_AT_count"]
 
-            if not ub.form.startswith("DW_FORM_data"):
+            if not _is_constant_form(ub.form):
                 continue
 
             elements.append(ub.value)

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -351,11 +351,16 @@ def get_section_ranges(elf):
 
 def get_die_filename(die, lineprog):
     """Get the source code filename associated with a DIE"""
+    dwarf_v5 = lineprog.header.version >= 5
+
     file_index = die.attributes['DW_AT_decl_file'].value
-    file_entry = lineprog['file_entry'][file_index - 1]
+    file_entry = lineprog['file_entry'][file_index if dwarf_v5 else file_index - 1]
 
     dir_index = file_entry['dir_index']
-    if dir_index == 0:
+    if dwarf_v5:
+        directory = lineprog.header['include_directory'][dir_index]
+        filename = os.path.join(directory, file_entry.name)
+    elif dir_index == 0:
         filename = file_entry.name
     else:
         directory = lineprog.header['include_directory'][dir_index - 1]

--- a/scripts/logging/dictionary/database_gen.py
+++ b/scripts/logging/dictionary/database_gen.py
@@ -24,7 +24,7 @@ import dictionary_parser.log_database
 import elftools
 from dictionary_parser.log_database import LogDatabase
 from dictionary_parser.utils import extract_one_string_in_section, find_string_in_mappings
-from elftools.dwarf.descriptions import describe_DWARF_expr
+from elftools.dwarf.dwarf_expr import DWARFExprParser
 from elftools.dwarf.locationlists import LocationExpr, LocationParser
 from elftools.elf.constants import SH_FLAGS
 from elftools.elf.descriptions import describe_ei_data
@@ -44,10 +44,6 @@ STATIC_STRING_SECTIONS = [
 
 # Sections that contains static strings but are not part of the binary (allocable).
 REMOVED_STRING_SECTIONS = ['log_strings']
-
-
-# Regulation expression to match DWARF location
-DT_LOCATION_REGEX = re.compile(r"\(DW_OP_addr: ([0-9a-f]+)")
 
 
 # Format string for pointers (default for 32-bit pointers)
@@ -329,6 +325,26 @@ def is_die_var_const_char(compile_unit, die):
     return bool(var_type is not None and var_type.endswith('char') and is_const)
 
 
+def _static_addr_from_locexpr(loc_expr, cu, dwarf_info, expr_parser):
+    """Return the static address a location expression points at, or None.
+
+    A ``const char`` log string lives at a fixed address, expressed either as
+    ``DW_OP_addr`` (the address inline, DWARF <=4 and GCC) or, since DWARF 5,
+    as ``DW_OP_addrx`` (an index into ``.debug_addr``, emitted by Clang). Parse
+    the opcode directly rather than rendering the expression to text: the text
+    form of ``DW_OP_addrx`` carries the index, not the address.
+    """
+    ops = expr_parser.parse_expr(loc_expr)
+    if not ops:
+        return None
+    op = ops[0]
+    if op.op_name == 'DW_OP_addr':
+        return op.args[0]
+    if op.op_name == 'DW_OP_addrx':
+        return dwarf_info.get_addr(cu, op.args[0])
+    return None
+
+
 def extract_string_variables(elf):
     """
     Find all string variables (char) in all Compilation Units and
@@ -339,6 +355,7 @@ def extract_string_variables(elf):
     loc_parser = LocationParser(loc_lists)
 
     strings = []
+    expr_parser = DWARFExprParser(dwarf_info.structs)
 
     # Loop through all Compilation Units and
     # Debug information Entry (DIE) to extract all string variables
@@ -358,19 +375,17 @@ def extract_string_variables(elf):
                     loc = loc_parser.parse_from_attribute(loc_attr, die.cu['version'], die)
                     if isinstance(loc, LocationExpr):
                         try:
-                            addr = describe_DWARF_expr(loc.loc_expr, dwarf_info.structs)
-
-                            matcher = DT_LOCATION_REGEX.match(addr)
-                            if matcher:
-                                addr = int(matcher.group(1), 16)
-                                if addr > 0:
-                                    strings.append(
-                                        {
-                                            'name': die.attributes['DW_AT_name'].value,
-                                            'addr': addr,
-                                            'die': die,
-                                        }
-                                    )
+                            addr = _static_addr_from_locexpr(
+                                loc.loc_expr, compile_unit, dwarf_info, expr_parser
+                            )
+                            if addr is not None and addr > 0:
+                                strings.append(
+                                    {
+                                        'name': die.attributes['DW_AT_name'].value,
+                                        'addr': addr,
+                                        'die': die,
+                                    }
+                                )
                         except KeyError:
                             pass
 


### PR DESCRIPTION
GCC 11+ defaults to DWARF v5, and `-gdwarf-4` was forced only because older pyelftools could not parse it. pyelftools has supported DWARF v5 since 0.27, and Zephyr now requires pyelftools>=0.29 (with CI pinned to 0.33), so the workaround is no longer needed.