### PR TITLE
boards: shields: nrf7002eb2: remove unused overlay

### DIFF
--- a/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/boards/shields/nrf7002eb2/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2026 Nordic Semiconductor
- *
- * SPDX-License-Identifier: Apache-2.0
- *
- * nRF7002 EB-II board overlay for nrf54lm20dk/nrf54lm20b/cpuapp.
- * Includes common SoC overlay snippet.
- */
-#include "../nrf54lm20.overlay"


### PR DESCRIPTION
This overlay is not needed after #112474. The workaround was removed.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
