### PR TITLE
boards: imx93_evk: disable flexspi flash by default

### DIFF
--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -270,7 +270,7 @@
 &flexspi1 {
 	pinctrl-0 = <&pinmux_flexspi>;
 	pinctrl-names = "default";
-	status = "okay";
+	status = "disabled";
 
 	ext_flash_ctrl: flash-controller@0 {
 		compatible = "nxp,imx-flexspi-nor";


### PR DESCRIPTION
As the flash in not onboard and need to plus into m.2 slot with a flash card, so disable it by default.