### PR TITLE
scripts: checkpatch: Recognize tagged types from function-like macros

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -1823,6 +1823,19 @@ sub annotate_values {
 			push(@av_paren_type, $type);
 			$type = 'c';
 
+		} elsif ($perl_version_ok &&
+			 $cur =~ /^((?:$Modifier\s+|const\s+)*(?:struct|union|enum)\s+$Ident\s*$balanced_parens(?:\s|\*)*)(?:$Ident|,|\)|\s*$)/) {
+			# A tagged type whose name is produced by a
+			# function-like macro, e.g. "struct MY_MACRO(NODE)
+			# *spec". Consume the macro's parenthesized argument, and
+			# any trailing pointer '*', as part of the type. This
+			# mirrors how the plain $Type regex absorbs the '*' so it
+			# is not annotated as a binary operator. Requiring a
+			# struct/union/enum tag keeps this from matching a lone
+			# macro that returns a value, e.g. "u32(5) * 2".
+			print "DECLARE($1)\n" if ($dbg_values > 1);
+			$type = 'T';
+
 		} elsif ($cur =~ /^($Type)\s*(?:$Ident|,|\)|\(|\s*$)/) {
 			print "DECLARE($1)\n" if ($dbg_values > 1);
 			$type = 'T';
@@ -4231,6 +4244,37 @@ sub process {
 			$to =~ s/(\b$Modifier$)/$1 /;
 
 ##			print "2: from<$from> to<$to> ident<$ident>\n";
+			if ($from ne $to && $ident !~ /^$Modifier$/) {
+				if (ERROR("POINTER_LOCATION",
+					  "\"foo${from}bar\" should be \"foo${to}bar\"\n" .  $herecurr) &&
+				    $fix) {
+
+					my $sub_from = $match;
+					my $sub_to = $match;
+					$sub_to =~ s/\Q$from\E/$to/;
+					$fixed[$fixlinenr] =~
+					    s@\Q$sub_from\E@$sub_to@;
+				}
+			}
+		}
+		# Same as above, but for a tagged type whose name is produced by
+		# a function-like macro, e.g. "struct MY_MACRO(NODE)*spec". The
+		# macro's parenthesized argument sits between the type and the
+		# '*', so the plain $NonptrType patterns above do not match it.
+		while ($perl_version_ok &&
+		       $line =~ m{(\b(?:$Modifier\b\s*|const\s+)*(?:struct|union|enum)\s+$Ident\s*$balanced_parens(\s*(?:$Modifier\b\s*|\*\s*)+)($Ident))}g) {
+			my ($match, $from, $to, $ident) = ($1, $3, $3, $4);
+
+			# Should start with a space.
+			$to =~ s/^(\S)/ $1/;
+			# Should not end with a space.
+			$to =~ s/\s+$//;
+			# '*'s should not have spaces between.
+			while ($to =~ s/\*\s+\*/\*\*/) {
+			}
+			# Modifiers should have spaces.
+			$to =~ s/(\b$Modifier$)/$1 /;
+
 			if ($from ne $to && $ident !~ /^$Modifier$/) {
 				if (ERROR("POINTER_LOCATION",
 					  "\"foo${from}bar\" should be \"foo${to}bar\"\n" .  $herecurr) &&


### PR DESCRIPTION
checkpatch reported a false-positive `SPACING` error for pointer declarations whose type name comes from a function-like macro, e.g. `struct GPIO_FAST_DISPATCH_TYPE(NODE) *spec`, because the macro's parentheses were parsed as a call and the `*` as a multiply. Add a branch to `annotate_values()` that consumes a `struct`/`union`/`enum` tag plus a function-like macro as part of the type so the `*` is seen as a pointer. Requiring the tag avoids misclassifying genuine multiplies like `u32(5) * 2`.

Closes #113747.

Tested these cases to make sure this does not introduce any regressions:
| # | Test case | Correct output | Correct before? | Correct now? |
|---|---|---|---|---|
| 1  | `struct GPIO_FAST_DISPATCH_TYPE(N) *spec` (issue case) | no finding | ❌ (false `ERROR:SPACING`) | ✅ |
| 2  | `struct MY_MACRO(N) *p = get();` | no finding | ❌ (false `ERROR:SPACING`) | ✅ |
| 3  | `const struct MY_MACRO(N) *q;` | no finding | ❌ (false `ERROR:SPACING`) | ✅ |
| 4  | `foo(a) * b` | no error | ✅ | ✅ |
| 5  | `(a) * b` | no error | ✅ | ✅ |
| 6  | `int(b) * c` | no finding | ✅ | ✅ |
| 7  | `u32(5) * 2` | no finding | ✅ | ✅ |
| 8  | `foo(u32(5) * 2)` | no finding | ✅ | ✅ |
| 9  | `sizeof(int) * count` | no finding | ✅ | ✅ |
| 10 | `struct foo*spec` | `ERROR:POINTER_LOCATION` | ✅ | ✅ |
| 11 | `struct foo * spec` | `ERROR:POINTER_LOCATION` | ✅ | ✅ |
| 12 | `struct MY_MACRO(N)  *spec` (double space) | no error | ❌ (false `ERROR:SPACING`) | ✅ |
| 13 | `struct MY_MACRO(N) * spec` (space after `*`) | `ERROR:POINTER_LOCATION` | ❌ (missed) | ✅ |
| 14 | `struct MY_MACRO(N)*spec` (glued) | `ERROR:POINTER_LOCATION` | ❌ (missed; strict misreported as multiply) | ✅ |
| 15 | `u32(b)*c` (multiply, glued) | strict `CHECK:SPACING` | ✅ | ✅ |
| 16 | `a*b` (multiply, glued) | strict `CHECK:SPACING` | ✅ | ✅ |
| 17 | `int x=1;` (unrelated real error) | `ERROR:SPACING` | ✅ | ✅ |
| 18 | `union MY_MACRO(N)*spec` | `ERROR:POINTER_LOCATION` | ❌ (missed) | ✅ |
| 19 | `enum MY_MACRO(N)*spec` | `ERROR:POINTER_LOCATION` | ❌ (missed) | ✅ |
| 20 | `struct MY_MACRO(N)**spec` | `ERROR:POINTER_LOCATION` | ❌ (missed) | ✅ |
| 21 | `struct MY_MACRO(N) * * spec` | `ERROR:POINTER_LOCATION` | ❌ (false `ERROR:SPACING`) | ✅ |
| 22 | `struct MY_MACRO(N)*const spec` | `ERROR:POINTER_LOCATION` | ❌ (missed) | ✅ |
| 23 | `struct MY_MACRO(DT_INST(0))*spec` (nested parens) | `ERROR:POINTER_LOCATION` | ❌ (missed) | ✅ |
| 24 | `struct MY_MACRO(DT_INST(0)) *spec` (correct) | no finding | ❌ (false `ERROR:SPACING`) | ✅ |
| 25 | `sizeof(struct foo(a))*b` (expression) | strict `CHECK:SPACING` (multiply) | ✅ | ✅ |
| 26 | `sizeof(struct foo) * b` | no finding | ✅ | ✅ |
| 27 | `FOO(struct bar) * b` (cast-like) | strict `CHECK:SPACING` (cast note) | ✅ | ✅ |

Assisted-by: Claude:claude-opus-4.8