### PR TITLE
drivers: charger: axp2101: add option to disable temp sense

### DIFF
--- a/drivers/charger/charger_axp2101.c
+++ b/drivers/charger/charger_axp2101.c
@@ -44,9 +44,13 @@ LOG_MODULE_REGISTER(charger_axp2101, CONFIG_CHARGER_LOG_LEVEL);
 
 #define AXP2101_CV_CHARGER_VOLTAGE		0x64
 
+#define AXP2101_REG_TS_CONTROL			0x50
+	#define TS_DISABLE			BIT(4)
+
 struct axp2101_config {
 	struct i2c_dt_spec i2c;
 	bool vbackup_enable;
+	bool ts_disable;
 };
 
 struct axp2101_data {
@@ -358,6 +362,15 @@ static int axp2101_init(const struct device *dev)
 		}
 	}
 
+	if (config->ts_disable) {
+		ret = i2c_reg_update_byte_dt(&config->i2c, AXP2101_REG_TS_CONTROL,
+					     TS_DISABLE,
+					     TS_DISABLE);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
 	val.const_charge_current_ua = data->cc_current_ua;
 	ret = set_constant_charge_current_ua(dev, &val);
 	if (ret < 0) {
@@ -389,6 +402,7 @@ static DEVICE_API(charger, axp2101_driver_api) = {
 	static const struct axp2101_config axp2101_config_##inst = {                               \
 		.i2c = I2C_DT_SPEC_GET(DT_PARENT(DT_INST(inst, DT_DRV_COMPAT))),                   \
 		.vbackup_enable = DT_INST_PROP(inst, vbackup_enable),                              \
+		.ts_disable = DT_INST_PROP(inst, ts_disable),                                      \
 	};                                                                                         \
 	static struct axp2101_data axp2101_data_##inst = {                                         \
 		.cc_current_ua = DT_INST_PROP(inst, constant_charge_current_max_microamp),         \

--- a/drivers/charger/charger_axp2101.c
+++ b/drivers/charger/charger_axp2101.c
@@ -33,6 +33,9 @@ LOG_MODULE_REGISTER(charger_axp2101, CONFIG_CHARGER_LOG_LEVEL);
 	#define BUTTON_BATTERY_CHARGE_ENABLE	BIT(2)
 	#define CELL_BATTERY_CHARGE_ENABLE	BIT(1)
 
+#define AXP2101_REG_TS_CONTROL			0x50
+	#define TS_DISABLE			BIT(4)
+
 #define AXP2101_IPRECH_CHARGER_SETTING		0x61
 	#define PRE_CHARGE_CURRENT_STEP_UA	25000
 
@@ -47,6 +50,7 @@ LOG_MODULE_REGISTER(charger_axp2101, CONFIG_CHARGER_LOG_LEVEL);
 struct axp2101_config {
 	struct i2c_dt_spec i2c;
 	bool vbackup_enable;
+	bool ts_disable;
 };
 
 struct axp2101_data {
@@ -358,6 +362,15 @@ static int axp2101_init(const struct device *dev)
 		}
 	}
 
+	if (config->ts_disable) {
+		ret = i2c_reg_update_byte_dt(&config->i2c, AXP2101_REG_TS_CONTROL,
+					     TS_DISABLE,
+					     TS_DISABLE);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
 	val.const_charge_current_ua = data->cc_current_ua;
 	ret = set_constant_charge_current_ua(dev, &val);
 	if (ret < 0) {
@@ -389,6 +402,7 @@ static DEVICE_API(charger, axp2101_driver_api) = {
 	static const struct axp2101_config axp2101_config_##inst = {                               \
 		.i2c = I2C_DT_SPEC_GET(DT_PARENT(DT_INST(inst, DT_DRV_COMPAT))),                   \
 		.vbackup_enable = DT_INST_PROP(inst, vbackup_enable),                              \
+		.ts_disable = DT_INST_PROP(inst, ts_disable),                                      \
 	};                                                                                         \
 	static struct axp2101_data axp2101_data_##inst = {                                         \
 		.cc_current_ua = DT_INST_PROP(inst, constant_charge_current_max_microamp),         \

--- a/dts/bindings/charger/x-powers,axp2101-charger.yaml
+++ b/dts/bindings/charger/x-powers,axp2101-charger.yaml
@@ -59,6 +59,13 @@ properties:
       Enable Vbackup on boot. This is normally used to charge a button battery
       that is used by some RTC IC.
 
+  ts-disable:
+    type: boolean
+    description:
+      Temperature Sensor is enabled by default. Some boards skip this and use a 100Ohm
+      resistor from the TS pin to ground. In these situations the TS disable bit needs
+      to be set otherwise the charger will fault.
+
 examples:
   - |
     axp2101@34 {

--- a/dts/bindings/charger/x-powers,axp2101-charger.yaml
+++ b/dts/bindings/charger/x-powers,axp2101-charger.yaml
@@ -59,6 +59,13 @@ properties:
       Enable Vbackup on boot. This is normally used to charge a button battery
       that is used by some RTC IC.
 
+  ts-disable:
+    type: boolean
+    description:
+      The temperature sensor is enabled by default. Some boards omit it and use a
+      100 ohm resistor from the TS pin to ground. In these situations, the TS
+      disable bit must be set; otherwise the charger will fault.
+
 examples:
   - |
     axp2101@34 {


### PR DESCRIPTION
temp sense is enabled by default but some boards skip this feature and use a 100Ohm resistor from the TS pin to ground.

In these situations the TS disable bit needs to be set otherwise the charger will fault.