### PR TITLE
arch: arm: add ARM_A_PROFILE_AARCH32 capability flag

### DIFF
--- a/arch/arm/core/cortex_a_r/Kconfig
+++ b/arch/arm/core/cortex_a_r/Kconfig
@@ -42,15 +42,24 @@ config CPU_CORTEX_A32
 
 if CPU_AARCH32_CORTEX_A
 
+config ARM_A_PROFILE_AARCH32
+	bool
+	help
+	  Capability flag enabled for any ARM A-profile processor running in the
+	  AArch32 execution state (ARMv7-A or ARMv8-A AArch32).
+
+	  This option is not user-selectable; A-profile AArch32 architecture
+	  symbols select it.
+
 config ARMV7_A
 	bool
+	select ARM_A_PROFILE_AARCH32
 	select ATOMIC_OPERATIONS_BUILTIN
 	select ISA_ARM
 
-# TODO: Introduce an ARM_A_PROFILE_AARCH32 capability flag selected by both
-# ARMV7_A and AARCH32_ARMV8_A to simplify the conditional guards in shared code.
 config AARCH32_ARMV8_A
 	bool
+	select ARM_A_PROFILE_AARCH32
 	select ATOMIC_OPERATIONS_BUILTIN
 	select ISA_ARM
 	help

--- a/arch/arm/core/cortex_a_r/Kconfig
+++ b/arch/arm/core/cortex_a_r/Kconfig
@@ -51,15 +51,24 @@ config CPU_CORTEX_A32
 
 if CPU_AARCH32_CORTEX_A
 
+config ARM_A_PROFILE_AARCH32
+	bool
+	help
+	  Capability flag enabled for any ARM A-profile processor running in the
+	  AArch32 execution state (ARMv7-A or ARMv8-A AArch32).
+
+	  This option is not user-selectable; A-profile AArch32 architecture
+	  symbols select it.
+
 config ARMV7_A
 	bool
+	select ARM_A_PROFILE_AARCH32
 	select ATOMIC_OPERATIONS_BUILTIN
 	select ISA_ARM
 
-# TODO: Introduce an ARM_A_PROFILE_AARCH32 capability flag selected by both
-# ARMV7_A and AARCH32_ARMV8_A to simplify the conditional guards in shared code.
 config AARCH32_ARMV8_A
 	bool
+	select ARM_A_PROFILE_AARCH32
 	select ATOMIC_OPERATIONS_BUILTIN
 	select ISA_ARM
 	help

--- a/arch/arm/core/cortex_a_r/fault.c
+++ b/arch/arm/core/cortex_a_r/fault.c
@@ -101,7 +101,7 @@ static uint32_t dump_fault(uint32_t status, uint32_t addr)
 		reason = K_ERR_ARM_UNSUPPORTED_EXCLUSIVE_ACCESS_FAULT;
 		EXCEPTION_DUMP("Unsupported Exclusive Access Fault @ 0x%08x", addr);
 		break;
-#elif defined(CONFIG_ARMV7_A) || defined(CONFIG_AARCH32_ARMV8_A)
+#elif defined(CONFIG_ARM_A_PROFILE_AARCH32)
 	case FSR_FS_PERMISSION_FAULT_2ND_LEVEL:
 		reason = K_ERR_ARM_PERMISSION_FAULT_2ND_LEVEL;
 		EXCEPTION_DUMP("2nd Level Permission Fault @ 0x%08x", addr);

--- a/arch/arm/core/cortex_a_r/prep_c.c
+++ b/arch/arm/core/cortex_a_r/prep_c.c
@@ -27,7 +27,7 @@
 #include <zephyr/arch/common/xip.h>
 #include <zephyr/arch/common/init.h>
 
-#if defined(CONFIG_ARMV7_R) || defined(CONFIG_ARMV7_A) || defined(CONFIG_AARCH32_ARMV8_A)
+#if defined(CONFIG_ARMV7_R) || defined(CONFIG_ARM_A_PROFILE_AARCH32)
 #include <cortex_a_r/stack.h>
 #endif
 
@@ -110,8 +110,8 @@ FUNC_NORETURN void z_prep_c(void)
 #endif
 	arch_bss_zero();
 	arch_data_copy();
-#if ((defined(CONFIG_ARMV7_R) || defined(CONFIG_ARMV7_A) || \
-	defined(CONFIG_AARCH32_ARMV8_A)) && defined(CONFIG_INIT_STACKS))
+#if ((defined(CONFIG_ARMV7_R) || defined(CONFIG_ARM_A_PROFILE_AARCH32)) && \
+	defined(CONFIG_INIT_STACKS))
 	z_arm_init_stacks();
 #endif
 	z_arm_interrupt_init();

--- a/arch/arm/core/cortex_a_r/prep_c.c
+++ b/arch/arm/core/cortex_a_r/prep_c.c
@@ -27,7 +27,7 @@
 #include <zephyr/arch/common/xip.h>
 #include <zephyr/arch/common/init.h>
 
-#if defined(CONFIG_ARMV7_R) || defined(CONFIG_ARMV7_A) || defined(CONFIG_AARCH32_ARMV8_A)
+#if defined(CONFIG_ARMV7_R) || defined(CONFIG_ARM_A_PROFILE_AARCH32)
 #include <cortex_a_r/stack.h>
 #endif
 
@@ -110,8 +110,8 @@ FUNC_NORETURN void z_prep_c(void)
 #endif
 	arch_bss_zero();
 	arch_data_copy();
-#if ((defined(CONFIG_ARMV7_R) || defined(CONFIG_ARMV7_A) || \
-	defined(CONFIG_AARCH32_ARMV8_A)) && defined(CONFIG_INIT_STACKS))
+#if (defined(CONFIG_ARMV7_R) || defined(CONFIG_ARM_A_PROFILE_AARCH32)) &&                          \
+	defined(CONFIG_INIT_STACKS)
 	z_arm_init_stacks();
 #endif
 	z_arm_interrupt_init();

--- a/include/zephyr/arch/arm/asm_inline_gcc.h
+++ b/include/zephyr/arch/arm/asm_inline_gcc.h
@@ -57,7 +57,7 @@ static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 	__set_BASEPRI_MAX(_EXC_IRQ_DEFAULT_PRIO);
 	__ISB();
 #elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) \
-	|| defined(CONFIG_ARMV7_A) || defined(CONFIG_AARCH32_ARMV8_A)
+	|| defined(CONFIG_ARM_A_PROFILE_AARCH32)
 	__asm__ volatile(
 		"mrs %0, cpsr;"
 		"and %0, #" STRINGIFY(I_BIT) ";"
@@ -89,7 +89,7 @@ static ALWAYS_INLINE void arch_irq_unlock(unsigned int key)
 	__set_BASEPRI(key);
 	__ISB();
 #elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) \
-	|| defined(CONFIG_ARMV7_A) || defined(CONFIG_AARCH32_ARMV8_A)
+	|| defined(CONFIG_ARM_A_PROFILE_AARCH32)
 	if (key != 0U) {
 		return;
 	}
@@ -113,7 +113,7 @@ static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	return __get_BASEPRI() == 0U;
 #elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) \
-	|| defined(CONFIG_ARMV7_A) || defined(CONFIG_AARCH32_ARMV8_A)
+	|| defined(CONFIG_ARM_A_PROFILE_AARCH32)
 	unsigned int cpsr;
 
 	__asm__ volatile("mrs %0, cpsr" : "=r" (cpsr));

--- a/include/zephyr/arch/arm/asm_inline_gcc.h
+++ b/include/zephyr/arch/arm/asm_inline_gcc.h
@@ -56,8 +56,8 @@ static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 	key = __get_BASEPRI();
 	__set_BASEPRI_MAX(_EXC_IRQ_DEFAULT_PRIO);
 	__ISB();
-#elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) \
-	|| defined(CONFIG_ARMV7_A) || defined(CONFIG_AARCH32_ARMV8_A)
+#elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) ||                                \
+	defined(CONFIG_ARM_A_PROFILE_AARCH32)
 	__asm__ volatile(
 		"mrs %0, cpsr;"
 		"and %0, #" STRINGIFY(I_BIT) ";"
@@ -88,8 +88,8 @@ static ALWAYS_INLINE void arch_irq_unlock(unsigned int key)
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	__set_BASEPRI(key);
 	__ISB();
-#elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) \
-	|| defined(CONFIG_ARMV7_A) || defined(CONFIG_AARCH32_ARMV8_A)
+#elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) ||                                \
+	defined(CONFIG_ARM_A_PROFILE_AARCH32)
 	if (key != 0U) {
 		return;
 	}
@@ -112,8 +112,8 @@ static ALWAYS_INLINE bool arch_cpu_irqs_are_enabled(void)
 	return __get_PRIMASK() == 0U;
 #elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
 	return __get_BASEPRI() == 0U;
-#elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) \
-	|| defined(CONFIG_ARMV7_A) || defined(CONFIG_AARCH32_ARMV8_A)
+#elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) ||                                \
+	defined(CONFIG_ARM_A_PROFILE_AARCH32)
 	unsigned int cpsr;
 
 	__asm__ volatile("mrs %0, cpsr" : "=r" (cpsr));

--- a/include/zephyr/arch/arm/error.h
+++ b/include/zephyr/arch/arm/error.h
@@ -44,7 +44,7 @@ do {\
 		: "r0", "memory"); \
 } while (false)
 #elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) \
-	|| defined(CONFIG_ARMV7_A) || defined(CONFIG_AARCH32_ARMV8_A)
+	|| defined(CONFIG_ARM_A_PROFILE_AARCH32)
 /*
  * In order to support using svc for an exception while running in an
  * isr, stack $lr_svc before calling svc.  While exiting the isr,

--- a/include/zephyr/arch/arm/error.h
+++ b/include/zephyr/arch/arm/error.h
@@ -43,8 +43,8 @@ do {\
 		:: [_reason] "r" (reason_p), [id] "i" (_SVC_CALL_RUNTIME_EXCEPT) \
 		: "r0", "memory"); \
 } while (false)
-#elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) \
-	|| defined(CONFIG_ARMV7_A) || defined(CONFIG_AARCH32_ARMV8_A)
+#elif defined(CONFIG_ARMV7_R) || defined(CONFIG_AARCH32_ARMV8_R) ||                                \
+	defined(CONFIG_ARM_A_PROFILE_AARCH32)
 /*
  * In order to support using svc for an exception while running in an
  * isr, stack $lr_svc before calling svc.  While exiting the isr,

--- a/modules/cmsis/cmsis_core_a_r_ext.h
+++ b/modules/cmsis/cmsis_core_a_r_ext.h
@@ -29,7 +29,7 @@
 #define FSR_FS_ALIGNMENT_FAULT				(33)
 #define FSR_FS_DEBUG_EVENT				(34)
 #define FSR_FS_UNSUPPORTED_EXCLUSIVE_ACCESS_FAULT	(53)
-#elif defined(CONFIG_ARMV7_A) || defined(CONFIG_AARCH32_ARMV8_A)
+#elif defined(CONFIG_ARM_A_PROFILE_AARCH32)
 
 /**
  * N.B.: these FSR encodings are only valid when the


### PR DESCRIPTION
# Summary
Both of ARMv7-A and ARMv8-A AArch32 shared the same capability: ARM A profile AArch32.
Introduce a capability flag, `ARM_A_PROFILE_AARCH32`, to represent this capability which improves the maintainability.

# Motivation
The AArch32 A-profile support was shared between ARMv7-A and ARMv8-A AArch32 by threading "defined(CONFIG_ARMV7_A) ||
defined(CONFIG_AARCH32_ARMV8_A)" through every affected site. Each new A-profile AArch32 variant would have to be added to all of those guards.

# Modification
Introduce a hidden capability flag, ARM_A_PROFILE_AARCH32, selected by both ARMV7_A and AARCH32_ARMV8_A, and migrate the shared guards to the single CONFIG_ARM_A_PROFILE_AARCH32 symbol. Since the flag is selected by exactly those two symbols, the guards are logically unchanged; a future A-profile AArch32 variant now only needs to select the flag to pick up the shared code paths.

# Note
This feature was left as a TODO in #107644
This PR related to the RFC #105804