### PR TITLE
drivers: gicv3: Fix Affinity Routing initialization if CONFIG_ARMV*_A_NS is set

### DIFF
--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -632,8 +632,12 @@ static void gicv3_dist_init(void)
 	}
 
 #if defined(CONFIG_ARMV8_A_NS) || defined(CONFIG_ARMV7_A_NS)
-	/* Enable distributor with ARE */
-	sys_write32(BIT(GICD_CTRL_ARE_NS) | BIT(GICD_CTLR_ENABLE_G1NS), GICD_CTLR);
+	/*
+	 * Enable Affinity Routing in the distributor.
+	 * Since we are already in NS state, we need to use the S bit position,
+	 * because ARE_S in Secure view has the same position as ARE_NS in Non-Secure view.
+	 */
+	sys_write32(BIT(GICD_CTRL_ARE_S) | BIT(GICD_CTLR_ENABLE_G1NS), GICD_CTLR);
 #elif defined(CONFIG_GIC_SINGLE_SECURITY_STATE)
 	/*
 	 * For GIC single security state, the config GIC_SINGLE_SECURITY_STATE


### PR DESCRIPTION
`CONFIG_ARMV8_A_NS` or `CONFIG_ARMV7_A_NS` implies that Zephyr is loaded as a Non-secure software on the target platform. This means, that it cannot issue Secure accesses to the GIC, and as such all it's requests to GIC will be Non-secure. This usually also requires the platform to first host a firmware running in the Secure world (can be ARM Trusted Firmware), that would later hand off control to the Non-secure software (in this case Zephyr).

Looking at the documentation of GICv3 (section `GICD_CTLR, Distributor Control Register`) we can see that the layout of Distributor's `Control` register changes between Secure and Non-secure views.

<img width="839" height="230" alt="image" src="https://github.com/user-attachments/assets/f29c71f7-8e9a-4f34-aa02-e0edff76b5d5" />

<img width="839" height="174" alt="image" src="https://github.com/user-attachments/assets/5cd1a816-a83c-4489-aa34-cb9742d686fb" />

The position of the bit `GICD_CTRL_ARE_NS` changes depending whether we are in Secure or Non-secure view - from 5 to 4th bit, respectively. `GICD_CTRL_ARE_S` is coded as bit 4 in Zephyr, and as such we need to use this one to access `ARE_NS` in Non-secure Distributor view.

This issue had a low impact since:
* Bit 5 which was erroneously accessed is `Reserved` and writing to it seems to have no side effect. But since it's `Reserved` it should not be modified.
* ARM Trusted Firmware enables Affinity Routing for both Secure and Non-secure world [by itself](https://github.com/ARM-software/arm-trusted-firmware/blob/b5eaba47efc5e4e3029086d5c25eee0e8dbb0129/drivers/arm/gic/v3/gicv3_main.c#L204-L206). Thus, this issue becomes relevant only when the Firmware running on the device is either modified not to configure the bit, or is not ARM Trusted Firmware.