### PR TITLE
[v3.7-branch] mgmt: mcumgr: grp: settings_mgmt: Fix k_free -> free

### DIFF
--- a/subsys/mgmt/mcumgr/grp/settings_mgmt/src/settings_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/settings_mgmt/src/settings_mgmt.c
@@ -108,8 +108,8 @@ static int settings_mgmt_read(struct smp_streamer *ctxt)
 		if (status != MGMT_CB_OK) {
 			if (status == MGMT_CB_ERROR_RC) {
 #ifdef CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_HEAP
-				k_free(key_name);
-				k_free(data);
+				free(key_name);
+				free(data);
 #endif
 				return ret_rc;
 			}
@@ -225,7 +225,7 @@ static int settings_mgmt_write(struct smp_streamer *ctxt)
 		if (status != MGMT_CB_OK) {
 			if (status == MGMT_CB_ERROR_RC) {
 #ifdef CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_HEAP
-				k_free(key_name);
+				free(key_name);
 #endif
 				return ret_rc;
 			}
@@ -327,7 +327,7 @@ static int settings_mgmt_delete(struct smp_streamer *ctxt)
 		if (status != MGMT_CB_OK) {
 			if (status == MGMT_CB_ERROR_RC) {
 #ifdef CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_HEAP
-				k_free(key_name);
+				free(key_name);
 #endif
 				return ret_rc;
 			}


### PR DESCRIPTION
The functions in v3.7 did not use k_malloc, therefore drop the k_ prefix from free functions

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/112782
(well, fixes a mistake in the backport PR)