### PR TITLE
mgmt: mcumgr: transport: add support for polling

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -213,7 +213,6 @@ config IPM_CONSOLE_LINE_BUF_LEN
 
 config UART_MCUMGR
 	bool "MCUmgr UART driver"
-	select UART_INTERRUPT_DRIVEN
 	help
 	  Enable the MCUmgr UART driver. This driver allows the application to
 	  communicate over UART using the MCUmgr (over console) protocol for image upgrade and

--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -40,9 +40,9 @@ static bool uart_mcumgr_ignoring;
 K_MEM_SLAB_DEFINE_TYPE(uart_mcumgr_slab, struct uart_mcumgr_rx_buf,
 		       CONFIG_UART_MCUMGR_RX_BUF_COUNT);
 
-#if defined(CONFIG_MCUMGR_TRANSPORT_UART_ASYNC)
-uint8_t async_buffer[CONFIG_MCUMGR_TRANSPORT_UART_ASYNC_BUFS]
-		    [CONFIG_MCUMGR_TRANSPORT_UART_ASYNC_BUF_SIZE];
+#if defined(CONFIG_MCUMGR_TRANSPORT_UART_MODE_ASYNC)
+uint8_t async_buffer[CONFIG_MCUMGR_TRANSPORT_UART_MODE_ASYNC_BUFS]
+		    [CONFIG_MCUMGR_TRANSPORT_UART_MODE_ASYNC_BUF_SIZE];
 static int async_current;
 #endif
 
@@ -70,7 +70,7 @@ void uart_mcumgr_free_rx_buf(struct uart_mcumgr_rx_buf *rx_buf)
 	k_mem_slab_free(&uart_mcumgr_slab, block);
 }
 
-#if !defined(CONFIG_MCUMGR_TRANSPORT_UART_ASYNC)
+#if defined(CONFIG_MCUMGR_TRANSPORT_UART_MODE_INTERRUPT)
 /**
  * Reads a chunk of received data from the UART.
  */
@@ -139,7 +139,7 @@ static struct uart_mcumgr_rx_buf *uart_mcumgr_rx_byte(uint8_t byte)
 #endif
 }
 
-#if defined(CONFIG_MCUMGR_TRANSPORT_UART_ASYNC)
+#if defined(CONFIG_MCUMGR_TRANSPORT_UART_MODE_ASYNC)
 static void uart_mcumgr_async(const struct device *dev, struct uart_event *evt, void *user_data)
 {
 	struct uart_mcumgr_rx_buf *rx_buf;
@@ -175,7 +175,7 @@ static void uart_mcumgr_async(const struct device *dev, struct uart_event *evt, 
 		 * UART_RX_BUF_REQUEST is processed.
 		 */
 		++async_current;
-		async_current %= CONFIG_MCUMGR_TRANSPORT_UART_ASYNC_BUFS;
+		async_current %= CONFIG_MCUMGR_TRANSPORT_UART_MODE_ASYNC_BUFS;
 		uart_rx_buf_rsp(dev, async_buffer[async_current],
 				sizeof(async_buffer[async_current]));
 		break;
@@ -184,7 +184,7 @@ static void uart_mcumgr_async(const struct device *dev, struct uart_event *evt, 
 		break;
 	}
 }
-#else
+#elif defined(CONFIG_MCUMGR_TRANSPORT_UART_MODE_INTERRUPT)
 /**
  * ISR that is called when UART bytes are received.
  */
@@ -244,7 +244,7 @@ int uart_mcumgr_send(const uint8_t *data, int len)
 #endif
 }
 
-#if defined(CONFIG_MCUMGR_TRANSPORT_UART_ASYNC)
+#if defined(CONFIG_MCUMGR_TRANSPORT_UART_MODE_ASYNC)
 static void uart_mcumgr_setup(const struct device *uart)
 {
 	uart_callback_set(uart, uart_mcumgr_async, NULL);
@@ -252,7 +252,7 @@ static void uart_mcumgr_setup(const struct device *uart)
 	uart_rx_enable(uart, async_buffer[0], sizeof(async_buffer[0]),
 		       CONFIG_UART_CONSOLE_MCUMGR_ASYNC_RX_TIMEOUT_US);
 }
-#else
+#elif defined(CONFIG_MCUMGR_TRANSPORT_UART_MODE_INTERRUPT)
 static void uart_mcumgr_setup(const struct device *uart)
 {
 	uart_irq_rx_disable(uart);

--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -218,6 +218,20 @@ static void uart_mcumgr_isr(const struct device *unused, void *user_data)
 		}
 	}
 }
+#elif defined(CONFIG_MCUMGR_TRANSPORT_UART_MODE_POLL)
+static void timer_handler(struct k_timer *timer)
+{
+	unsigned char byte;
+	struct uart_mcumgr_rx_buf *rx_buf;
+
+	while (uart_poll_in(uart_mcumgr_dev, &byte) >= 0) {
+		rx_buf = uart_mcumgr_rx_byte(byte);
+		if (rx_buf != NULL) {
+			uart_mcumgr_recv_cb(rx_buf);
+		}
+	}
+}
+K_TIMER_DEFINE(uart_mcumgr_timer, timer_handler, NULL);
 #endif
 
 /**
@@ -261,6 +275,13 @@ static void uart_mcumgr_setup(const struct device *uart)
 	uart_irq_callback_set(uart, uart_mcumgr_isr);
 
 	uart_irq_rx_enable(uart);
+}
+#elif defined(CONFIG_MCUMGR_TRANSPORT_UART_MODE_POLL)
+static void uart_mcumgr_setup(const struct device *uart)
+{
+	ARG_UNUSED(uart);
+	k_timer_start(&uart_mcumgr_timer, K_MSEC(CONFIG_MCUMGR_TRANSPORT_UART_MODE_POLL_PERIOD),
+		      K_MSEC(CONFIG_MCUMGR_TRANSPORT_UART_MODE_POLL_PERIOD));
 }
 #endif
 

--- a/subsys/mgmt/mcumgr/transport/Kconfig.common
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.common
@@ -24,6 +24,7 @@ choice MCUMGR_TRANSPORT_UART_MODE
 	prompt "UART transport mode"
 	default MCUMGR_TRANSPORT_UART_MODE_INTERRUPT if UART_INTERRUPT_DRIVEN
 	default MCUMGR_TRANSPORT_UART_MODE_ASYNC if UART_ASYNC_API
+	default MCUMGR_TRANSPORT_UART_MODE_POLL
 
 config MCUMGR_TRANSPORT_UART_MODE_INTERRUPT
 	bool "Interrupt"
@@ -32,6 +33,9 @@ config MCUMGR_TRANSPORT_UART_MODE_INTERRUPT
 config MCUMGR_TRANSPORT_UART_MODE_ASYNC
 	bool "Async"
 	depends on UART_ASYNC_API
+
+config MCUMGR_TRANSPORT_UART_MODE_POLL
+	bool "Poll"
 
 endchoice
 
@@ -54,6 +58,16 @@ config MCUMGR_TRANSPORT_UART_MODE_ASYNC_BUF_SIZE
 	  The size of single buffer for asynchronous RX.
 
 endif # MCUMGR_TRANSPORT_UART_MODE_ASYNC
+
+if MCUMGR_TRANSPORT_UART_MODE_POLL
+
+config MCUMGR_TRANSPORT_UART_MODE_POLL_PERIOD
+	int "RX polling period (in milliseconds)"
+	default 10
+	help
+	  Determines how often UART is polled for RX byte.
+
+endif # MCUMGR_TRANSPORT_UART_MODE_POLL
 
 endif # (MCUMGR_TRANSPORT_UART || MCUMGR_TRANSPORT_RAW_UART)
 

--- a/subsys/mgmt/mcumgr/transport/Kconfig.common
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.common
@@ -18,16 +18,26 @@ config MCUMGR_TRANSPORT_SERIAL_HAS_RAW_BINARY_NON_SMP_OVER_CONSOLE
 	  Hidden Kconfig selected by transports that implement the raw binary non-SMP over console
 	  serial transport and need this functionality to be available in the serial_util.c file.
 
-if (MCUMGR_TRANSPORT_UART || MCUMGR_TRANSPORT_RAW_UART) && UART_ASYNC_API
+if (MCUMGR_TRANSPORT_UART || MCUMGR_TRANSPORT_RAW_UART)
 
-menuconfig MCUMGR_TRANSPORT_UART_ASYNC
-	bool "Use async UART API when available"
-	help
-	  The option enables use of UART async API when available for selected MCUmgr UART port.
+choice MCUMGR_TRANSPORT_UART_MODE
+	prompt "UART transport mode"
+	default MCUMGR_TRANSPORT_UART_MODE_INTERRUPT if UART_INTERRUPT_DRIVEN
+	default MCUMGR_TRANSPORT_UART_MODE_ASYNC if UART_ASYNC_API
 
-if MCUMGR_TRANSPORT_UART_ASYNC
+config MCUMGR_TRANSPORT_UART_MODE_INTERRUPT
+	bool "Interrupt"
+	depends on UART_INTERRUPT_DRIVEN
 
-config MCUMGR_TRANSPORT_UART_ASYNC_BUFS
+config MCUMGR_TRANSPORT_UART_MODE_ASYNC
+	bool "Async"
+	depends on UART_ASYNC_API
+
+endchoice
+
+if MCUMGR_TRANSPORT_UART_MODE_ASYNC
+
+config MCUMGR_TRANSPORT_UART_MODE_ASYNC_BUFS
 	int "Number of async RX UART buffers"
 	range 2 8
 	default 2
@@ -37,14 +47,14 @@ config MCUMGR_TRANSPORT_UART_ASYNC_BUFS
 	  receive data without stopping due to running out of buffer space. At least two buffers
 	  area required for smooth RX operation.
 
-config MCUMGR_TRANSPORT_UART_ASYNC_BUF_SIZE
+config MCUMGR_TRANSPORT_UART_MODE_ASYNC_BUF_SIZE
 	int "Size of single async RX UART buffer"
 	default 64
 	help
 	  The size of single buffer for asynchronous RX.
 
-endif # MCUMGR_TRANSPORT_UART_ASYNC
+endif # MCUMGR_TRANSPORT_UART_MODE_ASYNC
 
-endif # (MCUMGR_TRANSPORT_UART || MCUMGR_TRANSPORT_RAW_UART) && UART_ASYNC_API
+endif # (MCUMGR_TRANSPORT_UART || MCUMGR_TRANSPORT_RAW_UART)
 
 endmenu


### PR DESCRIPTION
The main motivation of this change is being able to use SMP over RTT using the rtt-uart driver. Since RTT has no events or interrupts, it needs to be polled.

You can test this with this overlay:

```
/ {
	chosen {
		zephyr,uart-mcumgr = &rtt0;
	};

	rtt0: rtt0 {
		compatible = "segger,rtt-uart";
		status = "okay";
	};
};
```

and this config:

```
# RTT
CONFIG_USE_SEGGER_RTT=y
CONFIG_SEGGER_RTT_BUFFER_SIZE_DOWN=256

# MCUmgr
CONFIG_BASE64=y
CONFIG_UART_MCUMGR=y
CONFIG_MCUMGR_TRANSPORT_UART=y
CONFIG_MCUMGR_TRANSPORT_UART_MODE_POLL=y
```

The eventual goal is to integrate RTT support directly into [smpmgr](https://github.com/intercreate/smpmgr) (I'm not the maintainer), so this works on all platforms. But for now this can be used on Unix systems using this Python script, which forwards data between rtt and a pseudo tty. You may have to change the arguments to `session_with_chosen_probe`, depending on your probe and target.

```python
import os
import time

from pyocd.core.helpers import ConnectHelper
from pyocd.core.soc_target import SoCTarget
from pyocd.core.target import Target
from pyocd.debug.elf.symbols import ELFSymbolProvider
from pyocd.debug.rtt import RTTControlBlock, RTTDownChannel, RTTUpChannel

master, slave = os.openpty()
print(os.ttyname(slave))

os.set_blocking(master, False)

with ConnectHelper.session_with_chosen_probe(
    target_override="efr32mg13p732f512gm48"
) as session:
    target: SoCTarget = session.board.target

    control_block = RTTControlBlock.from_target(target)
    control_block.start()

    up_chan: RTTUpChannel = control_block.up_channels[0]
    down_chan: RTTDownChannel = control_block.down_channels[0]

    if down_chan.size == 0:
        raise Exception("RTT down channel was not initialized, yet")

    target.resume()

    while True:
        time.sleep(0.001)

        try:
            data = os.read(master, down_chan.size)
            print("pty data", data)
            down_chan.write(data)
        except BlockingIOError:
            pass

        data = up_chan.read()
        if len(data) > 0:
            print("rtt data", data)
            os.write(master, data)
```

Once that's running, you can use the smpmgr CLI in serial mode on the path printed by the python script, e.g.:

```bash
smpmgr --port /dev/pts/1 image state-read
```