### PR TITLE
boards: st: nucleo_h745zi_q/h755zi_q: fix m4 i2c1 enablement

### DIFF
--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.yaml
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m4.yaml
@@ -9,7 +9,6 @@ ram: 128
 flash: 1024
 supported:
   - arduino_gpio
-  - arduino_i2c
   - arduino_serial
   - arduino_spi
   - gpio

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m4.yaml
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m4.yaml
@@ -9,7 +9,6 @@ ram: 128
 flash: 1024
 supported:
   - arduino_gpio
-  - arduino_i2c
   - arduino_serial
   - arduino_spi
   - gpio


### PR DESCRIPTION
This PR fixes `m4` shield/sensor build failures on `nucleo_h745zi_q `and  `nucleo_h755zi_q` boards.



To reproduce : 

`west build -p -b nucleo_h755zi_q/stm32h755xx/m4 samples/shields/x_nucleo_iks01a2/standard -T sample.shields.x_nucleo_iks01a2.standard`