### PR TITLE
arch: arm64: fix arch_buffer_validate() wrap bypass

### DIFF
--- a/arch/arm64/core/userspace.S
+++ b/arch/arm64/core/userspace.S
@@ -57,7 +57,8 @@ strlen_done:
 GTEXT(arch_buffer_validate)
 SECTION_FUNC(TEXT, arch_buffer_validate)
 
-	add	x1, x1, x0
+	adds	x1, x1, x0
+	b.cs	abv_fail
 	mrs	x3, DAIF
 	msr	DAIFSET, #DAIFSET_IRQ_BIT
 


### PR DESCRIPTION
arch_buffer_validate() computes end = addr + size with a plain 64-bit add and never checks for unsigned wrap. When addr + size wraps past 2^64, x1 < x0, so the blo abv_loop condition is false after the first iteration — only the page containing addr is validated, and the function returns 0 (success) for a range that spans the entire address space including kernel memory.

Reject wrapping ranges immediately after computing the end address, before entering the page loop. This mirrors how the Xtensa MPU implementation (PR #109000) and ARM32 is_in_region() (PR #23239) reject wrapping ranges.

Fixes #113800