### PR TITLE
drivers: i2c: mcux_lpi2c: add pin-low-timeout property

### DIFF
--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -50,6 +50,7 @@ struct mcux_lpi2c_config {
 	void (*irq_config_func)(const struct device *dev);
 	uint32_t bitrate;
 	uint32_t bus_idle_timeout_ns;
+	uint32_t pin_low_timeout_ns;
 	const struct pinctrl_dev_config *pincfg;
 	struct reset_dt_spec reset;
 #ifdef CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY
@@ -598,6 +599,7 @@ static int mcux_lpi2c_init(const struct device *dev)
 
 	LPI2C_MasterGetDefaultConfig(&master_config);
 	master_config.busIdleTimeout_ns = config->bus_idle_timeout_ns;
+	master_config.pinLowTimeout_ns = config->pin_low_timeout_ns;
 	LPI2C_MasterInit(base, &master_config, clock_freq);
 	LPI2C_MasterTransferCreateHandle(base, &data->handle,
 					 mcux_lpi2c_master_transfer_callback,
@@ -695,6 +697,9 @@ static DEVICE_API(i2c, mcux_lpi2c_driver_api) = {
 		.bus_idle_timeout_ns =					\
 			UTIL_AND(DT_INST_NODE_HAS_PROP(n, bus_idle_timeout),\
 				 DT_INST_PROP(n, bus_idle_timeout)),	\
+		.pin_low_timeout_ns =					\
+			UTIL_AND(DT_INST_NODE_HAS_PROP(n, pin_low_timeout),\
+				 DT_INST_PROP(n, pin_low_timeout)),	\
 	};								\
 									\
 	static struct mcux_lpi2c_data mcux_lpi2c_data_##n;		\

--- a/dts/bindings/i2c/nxp,lpi2c.yaml
+++ b/dts/bindings/i2c/nxp,lpi2c.yaml
@@ -15,6 +15,12 @@ properties:
     type: int
     description: Bus idle timeout in nanoseconds
 
+  pin-low-timeout:
+    type: int
+    description: |
+      Pin low timeout in nanoseconds. Aborts the transfer with an error if
+      SCL or SDA is held longer than this timeout.
+
   scl-gpios:
     type: phandle-array
     description: |


### PR DESCRIPTION
## Summary

`mcux_lpi2c_transfer()` waits on `device_sync_sem` with `K_FOREVER`, which is only given from the LPI2C HAL's transfer-complete callback. If SCL or SDA is held low indefinitely (e.g. a wedged slave or wiring fault) rather than producing a NAK or other error, no interrupt ever fires and the wait never returns. Since the bus lock is only released after this wait, the whole controller becomes permanently unusable until a reset.

The LPI2C peripheral has a hardware pin-low-timeout (`MCFGR3.PINLOW`) that detects exactly this condition and raises an error interrupt instead of stretching forever, but the driver never enables it.

This PR exposes it as an optional `pin-low-timeout` devicetree property, mirroring the existing `bus-idle-timeout` property, and wires it into `lpi2c_master_config_t.pinLowTimeout_ns`. Left unset, it defaults to 0 (disabled), so existing boards see no behavior change.

Related to #27715 (does not close it — that issue is a broader cross-driver consistency discussion; this is a standalone, minimal fix for this one driver).

## Test plan

- [ ] Build a board using `nxp,lpi2c` with the property unset — confirm no behavior/config change (existing default path).
- [ ] Build a board using `nxp,lpi2c` with `pin-low-timeout` set — confirm it builds and `LPI2C_MasterInit()` receives a non-zero `pinLowTimeout_ns`.
- [ ] Hardware test: hold SCL low on an LPI2C bus with the property configured, confirm the transfer aborts with an error instead of hanging.