### PR TITLE
Feature/mcux udc remove event slab

### DIFF
--- a/drivers/usb/udc/Kconfig.mcux
+++ b/drivers/usb/udc/Kconfig.mcux
@@ -23,11 +23,3 @@ config UDC_NXP_IP3511
 	imply UDC_WORKQUEUE
 	help
 	  NXP MCUX USB Device Controller Driver for IP3511.
-
-config UDC_NXP_EVENT_COUNT
-	int "Number or blocks in event slab"
-	depends on UDC_NXP_EHCI || UDC_NXP_IP3511
-	range 4 16
-	default 4
-	help
-	  Number of blocks in slab for internal controller events.

--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -64,19 +64,11 @@ struct udc_mcux_data {
 	const struct device *dev;
 	usb_device_struct_t mcux_device;
 	struct k_work work;
-	struct k_fifo fifo;
+	struct k_spinlock lock;
+	struct usb_setup_packet setup_pkt;
+	volatile bool setup_pending;
 	uint8_t controller_id; /* 0xFF is invalid value */
 };
-
-/* Structure for driver's events */
-struct udc_mcux_event {
-	sys_snode_t node;
-	const struct device *dev;
-	usb_device_callback_message_struct_t mcux_msg;
-};
-
-K_MEM_SLAB_DEFINE_TYPE(udc_event_slab, struct udc_mcux_event,
-		       CONFIG_UDC_NXP_EVENT_COUNT);
 
 static void udc_mcux_lock(const struct device *dev)
 {
@@ -100,7 +92,7 @@ static int udc_mcux_control(const struct device *dev, usb_device_control_type_t 
 			command, param);
 
 	if (status != kStatus_USB_Success) {
-		return -ENOMEM;
+		return -EIO;
 	}
 
 	return 0;
@@ -114,10 +106,11 @@ static int udc_mcux_ep_feed(const struct device *dev,
 	const struct udc_mcux_config *config = dev->config;
 	const usb_device_controller_interface_struct_t *mcux_if = config->mcux_if;
 	struct udc_mcux_data *priv = udc_get_private(dev);
+	usb_device_endpoint_status_struct_t ep_status;
 	usb_status_t status = kStatus_USB_Success;
+	k_spinlock_key_t key;
 	uint8_t *data;
 	uint32_t len;
-	usb_device_endpoint_status_struct_t ep_status;
 
 	ep_status.endpointAddress = cfg->addr;
 	udc_mcux_control(dev, kUSB_DeviceControlGetEndpointStatus, &ep_status);
@@ -125,10 +118,10 @@ static int udc_mcux_ep_feed(const struct device *dev,
 		return -EACCES; /* stalled */
 	}
 
-	udc_mcux_lock(dev);
+	key = k_spin_lock(&priv->lock);
 	if (!udc_ep_is_busy(cfg)) {
 		udc_ep_set_busy(cfg, true);
-		udc_mcux_unlock(dev);
+		k_spin_unlock(&priv->lock, key);
 
 		if (USB_EP_DIR_IS_OUT(cfg->addr)) {
 			len = net_buf_tailroom(buf);
@@ -142,13 +135,13 @@ static int udc_mcux_ep_feed(const struct device *dev,
 					cfg->addr, data, len);
 		}
 
-		udc_mcux_lock(dev);
+		key = k_spin_lock(&priv->lock);
 		if (status != kStatus_USB_Success) {
 			udc_ep_set_busy(cfg, false);
 		}
-		udc_mcux_unlock(dev);
+		k_spin_unlock(&priv->lock, key);
 	} else {
-		udc_mcux_unlock(dev);
+		k_spin_unlock(&priv->lock, key);
 		return -EBUSY;
 	}
 
@@ -173,6 +166,9 @@ static int udc_mcux_ep_try_feed(const struct device *dev,
 
 static int udc_mcux_handler_setup(const struct device *dev, struct usb_setup_packet *setup)
 {
+	struct udc_mcux_data *priv = udc_get_private(dev);
+	k_spinlock_key_t key;
+
 	LOG_DBG("setup packet");
 
 	if (setup->RequestType.type == USB_REQTYPE_TYPE_STANDARD &&
@@ -183,7 +179,11 @@ static int udc_mcux_handler_setup(const struct device *dev, struct usb_setup_pac
 			&setup->wValue);
 	}
 
-	udc_setup_received(dev, setup);
+	key = k_spin_lock(&priv->lock);
+	priv->setup_pkt = *setup;
+	priv->setup_pending = true;
+	k_spin_unlock(&priv->lock, key);
+	k_work_submit_to_queue(udc_get_work_q(), &priv->work);
 
 	return 0;
 }
@@ -260,15 +260,16 @@ static int udc_mcux_handler_out(const struct device *dev, uint8_t ep,
 				uint8_t *mcux_buf, uint32_t mcux_len)
 {
 	struct udc_ep_config *const cfg = udc_get_ep_cfg(dev, ep);
-	int err;
+	struct udc_mcux_data *priv = udc_get_private(dev);
+	k_spinlock_key_t key;
 	struct net_buf *buf;
+	int err;
+
+	key = k_spin_lock(&priv->lock);
+	udc_ep_set_busy(cfg, false);
+	k_spin_unlock(&priv->lock, key);
 
 	buf = udc_buf_get(cfg);
-
-	udc_mcux_lock(dev);
-	udc_ep_set_busy(cfg, false);
-	udc_mcux_unlock(dev);
-
 	if (buf == NULL) {
 		return -ENOBUFS;
 	}
@@ -317,8 +318,14 @@ static int udc_mcux_handler_in(const struct device *dev, uint8_t ep,
 				uint8_t *mcux_buf, uint32_t mcux_len)
 {
 	struct udc_ep_config *const cfg = udc_get_ep_cfg(dev, ep);
-	int err;
+	struct udc_mcux_data *priv = udc_get_private(dev);
+	k_spinlock_key_t key;
 	struct net_buf *buf;
+	int err;
+
+	key = k_spin_lock(&priv->lock);
+	udc_ep_set_busy(cfg, false);
+	k_spin_unlock(&priv->lock, key);
 
 	buf = udc_buf_peek(cfg);
 	if (buf == NULL) {
@@ -330,14 +337,10 @@ static int udc_mcux_handler_in(const struct device *dev, uint8_t ep,
 	}
 
 	buf = udc_buf_get(cfg);
-
-	udc_mcux_lock(dev);
-	udc_ep_set_busy(cfg, false);
-	udc_mcux_unlock(dev);
-
 	if (buf == NULL) {
 		return -ENOBUFS;
 	}
+
 	if (ep == USB_CONTROL_EP_IN) {
 		err = udc_mcux_handler_ctrl_in(dev, buf, mcux_buf, mcux_len);
 	} else {
@@ -347,94 +350,88 @@ static int udc_mcux_handler_in(const struct device *dev, uint8_t ep,
 	return err;
 }
 
-static void udc_mcux_event_submit(const struct device *dev,
-				  const usb_device_callback_message_struct_t *mcux_msg)
-{
-	struct udc_mcux_data *priv = udc_get_private(dev);
-	struct udc_mcux_event *ev;
-	int ret;
-
-	ret = k_mem_slab_alloc(&udc_event_slab, (void **)&ev, K_NO_WAIT);
-	if (ret) {
-		udc_submit_event(dev, UDC_EVT_ERROR, ret);
-		LOG_ERR("Failed to allocate slab");
-		return;
-	}
-
-	ev->dev = dev;
-	ev->mcux_msg = *mcux_msg;
-	k_fifo_put(&priv->fifo, ev);
-	k_work_submit_to_queue(udc_get_work_q(), &priv->work);
-}
-
 static void udc_mcux_work_handler(struct k_work *item)
 {
-	struct udc_mcux_event *ev;
+	struct usb_setup_packet setup_pkt;
 	struct udc_mcux_data *priv;
-	usb_device_callback_message_struct_t *mcux_msg;
-	int err;
-	uint8_t ep;
+	bool setup_valid = false;
+	k_spinlock_key_t key;
 
 	priv = CONTAINER_OF(item, struct udc_mcux_data, work);
-	while ((ev = k_fifo_get(&priv->fifo, K_NO_WAIT)) != NULL) {
-		mcux_msg = &ev->mcux_msg;
 
-		if (mcux_msg->code == kUSB_DeviceNotifyBusReset) {
-			struct udc_ep_config *cfg;
-
-			udc_mcux_control(ev->dev, kUSB_DeviceControlSetDefaultStatus, NULL);
-			cfg = udc_get_ep_cfg(ev->dev, USB_CONTROL_EP_OUT);
-			if (cfg->stat.enabled) {
-				udc_ep_disable_internal(ev->dev, USB_CONTROL_EP_OUT);
-			}
-			cfg = udc_get_ep_cfg(ev->dev, USB_CONTROL_EP_IN);
-			if (cfg->stat.enabled) {
-				udc_ep_disable_internal(ev->dev, USB_CONTROL_EP_IN);
-			}
-			if (udc_ep_enable_internal(ev->dev, USB_CONTROL_EP_OUT,
-						USB_EP_TYPE_CONTROL,
-						USB_MCUX_EP0_SIZE, 0)) {
-				LOG_ERR("Failed to enable control endpoint");
-			}
-			if (udc_ep_enable_internal(ev->dev, USB_CONTROL_EP_IN,
-						USB_EP_TYPE_CONTROL,
-						USB_MCUX_EP0_SIZE, 0)) {
-				LOG_ERR("Failed to enable control endpoint");
-			}
-			udc_submit_event(ev->dev, UDC_EVT_RESET, 0);
-		} else {
-			ep  = mcux_msg->code;
-
-			if (mcux_msg->isSetup) {
-				struct usb_setup_packet *setup =
-					(struct usb_setup_packet *)mcux_msg->buffer;
-
-				err = udc_mcux_handler_setup(ev->dev, setup);
-			} else if (USB_EP_DIR_IS_IN(ep)) {
-				err = udc_mcux_handler_in(ev->dev, ep, mcux_msg->buffer,
-							  mcux_msg->length);
-			} else {
-				err = udc_mcux_handler_out(ev->dev, ep, mcux_msg->buffer,
-							   mcux_msg->length);
-			}
-
-			if (unlikely(err)) {
-				udc_submit_event(ev->dev, UDC_EVT_ERROR, err);
-			}
-		}
-
-		k_mem_slab_free(&udc_event_slab, (void *)ev);
+	/* need the spin lock in case the setup is half changed in isr. */
+	key = k_spin_lock(&priv->lock);
+	if (priv->setup_pending) {
+		priv->setup_pending = false;
+		setup_valid = true;
+		setup_pkt = priv->setup_pkt;
 	}
+	k_spin_unlock(&priv->lock, key);
+
+	if (setup_valid) {
+		udc_setup_received(priv->dev, &setup_pkt);
+	}
+}
+
+static void udc_mcux_bus_reset_isr(const struct device *dev)
+{
+	struct udc_mcux_data *priv = udc_get_private(dev);
+	struct udc_ep_config *cfg;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&priv->lock);
+	priv->setup_pending = false;
+	k_spin_unlock(&priv->lock, key);
+
+	udc_mcux_control(dev, kUSB_DeviceControlSetDefaultStatus, NULL);
+	cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
+	if (cfg->stat.enabled) {
+		udc_ep_disable_internal(dev, USB_CONTROL_EP_OUT);
+	}
+	cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_IN);
+	if (cfg->stat.enabled) {
+		udc_ep_disable_internal(dev, USB_CONTROL_EP_IN);
+	}
+	if (udc_ep_enable_internal(dev, USB_CONTROL_EP_OUT, USB_EP_TYPE_CONTROL,
+				   USB_MCUX_EP0_SIZE, 0)) {
+		LOG_ERR("Failed to enable control endpoint");
+	}
+	if (udc_ep_enable_internal(dev, USB_CONTROL_EP_IN, USB_EP_TYPE_CONTROL,
+				   USB_MCUX_EP0_SIZE, 0)) {
+		LOG_ERR("Failed to enable control endpoint");
+	}
+	udc_submit_event(dev, UDC_EVT_RESET, 0);
+}
+
+static int udc_mcux_ep_event_isr(const struct device *dev,
+				 usb_device_callback_message_struct_t *mcux_msg)
+{
+	uint8_t ep = mcux_msg->code;
+	int err;
+
+	if (mcux_msg->isSetup) {
+		struct usb_setup_packet *setup =
+			(struct usb_setup_packet *)mcux_msg->buffer;
+
+		err = udc_mcux_handler_setup(dev, setup);
+	} else if (USB_EP_DIR_IS_IN(ep)) {
+		err = udc_mcux_handler_in(dev, ep, mcux_msg->buffer, mcux_msg->length);
+	} else {
+		err = udc_mcux_handler_out(dev, ep, mcux_msg->buffer, mcux_msg->length);
+	}
+
+	return err;
 }
 
 /* NXP MCUX controller driver notify transfers/status through this interface */
 usb_status_t USB_DeviceNotificationTrigger(void *handle, void *msg)
 {
 	usb_device_callback_message_struct_t *mcux_msg = msg;
+	usb_status_t mcux_status = kStatus_USB_Success;
 	usb_device_notification_t mcux_notify;
 	struct udc_mcux_data *priv;
 	const struct device *dev;
-	usb_status_t mcux_status = kStatus_USB_Success;
+	int err;
 
 	if ((NULL == msg) || (NULL == handle)) {
 		return kStatus_USB_InvalidHandle;
@@ -446,7 +443,7 @@ usb_status_t USB_DeviceNotificationTrigger(void *handle, void *msg)
 
 	switch (mcux_notify) {
 	case kUSB_DeviceNotifyBusReset:
-		udc_mcux_event_submit(dev, mcux_msg);
+		udc_mcux_bus_reset_isr(dev);
 		break;
 	case kUSB_DeviceNotifyError:
 		udc_submit_event(dev, UDC_EVT_ERROR, -EIO);
@@ -471,7 +468,11 @@ usb_status_t USB_DeviceNotificationTrigger(void *handle, void *msg)
 		udc_submit_sof_event(dev);
 		break;
 	default:
-		udc_mcux_event_submit(dev, mcux_msg);
+		err = udc_mcux_ep_event_isr(dev, mcux_msg);
+		if (unlikely(err)) {
+			udc_submit_event(dev, UDC_EVT_ERROR, err);
+			mcux_status = kStatus_USB_Error;
+		}
 		break;
 	}
 
@@ -540,12 +541,15 @@ static int udc_mcux_ep_enqueue(const struct device *dev,
 static int udc_mcux_ep_dequeue(const struct device *dev,
 			       struct udc_ep_config *const cfg)
 {
+	struct udc_mcux_data *priv = udc_get_private(dev);
+	k_spinlock_key_t key;
+
 	cfg->stat.halted = false;
 	udc_ep_cancel_queued(dev, cfg);
 
-	udc_mcux_lock(dev);
+	key = k_spin_lock(&priv->lock);
 	udc_ep_set_busy(cfg, false);
-	udc_mcux_unlock(dev);
+	k_spin_unlock(&priv->lock, key);
 
 	return 0;
 }
@@ -792,7 +796,6 @@ static int udc_mcux_driver_preinit(const struct device *dev)
 	}
 
 	k_mutex_init(&data->mutex);
-	k_fifo_init(&priv->fifo);
 	k_work_init(&priv->work, udc_mcux_work_handler);
 
 	for (int i = 0; i < config->num_of_eps; i++) {

--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -270,7 +270,6 @@ static int udc_mcux_handler_out(const struct device *dev, uint8_t ep,
 	udc_mcux_unlock(dev);
 
 	if (buf == NULL) {
-		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
 		return -ENOBUFS;
 	}
 
@@ -323,7 +322,6 @@ static int udc_mcux_handler_in(const struct device *dev, uint8_t ep,
 
 	buf = udc_buf_peek(cfg);
 	if (buf == NULL) {
-		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
 		return -ENOBUFS;
 	}
 
@@ -338,7 +336,6 @@ static int udc_mcux_handler_in(const struct device *dev, uint8_t ep,
 	udc_mcux_unlock(dev);
 
 	if (buf == NULL) {
-		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
 		return -ENOBUFS;
 	}
 	if (ep == USB_CONTROL_EP_IN) {

--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -188,74 +188,6 @@ static int udc_mcux_handler_setup(const struct device *dev, struct usb_setup_pac
 	return 0;
 }
 
-static int udc_mcux_handler_ctrl_out(const struct device *dev, struct net_buf *buf,
-				uint8_t *mcux_buf, uint32_t mcux_len)
-{
-	int err;
-	uint32_t len;
-
-	err = mcux_len == USB_CANCELLED_TRANSFER_LENGTH ? -ECONNABORTED : 0;
-	if (err == 0) {
-		len = MIN(net_buf_tailroom(buf), mcux_len);
-		net_buf_add(buf, len);
-	}
-
-	return udc_submit_ep_event(dev, buf, err);
-}
-
-static int udc_mcux_handler_ctrl_in(const struct device *dev, struct net_buf *buf,
-				uint8_t *mcux_buf, uint32_t mcux_len)
-{
-	int err;
-	uint32_t len;
-
-	err = mcux_len == USB_CANCELLED_TRANSFER_LENGTH ? -ECONNABORTED : 0;
-	if (err == 0) {
-		len = MIN(buf->len, mcux_len);
-		buf->data += len;
-		buf->len -= len;
-	}
-
-	return udc_submit_ep_event(dev, buf, err);
-}
-
-static int udc_mcux_handler_non_ctrl_in(const struct device *dev, uint8_t ep,
-			struct net_buf *buf, uint8_t *mcux_buf, uint32_t mcux_len)
-{
-	int err;
-	uint32_t len;
-
-	err = mcux_len == USB_CANCELLED_TRANSFER_LENGTH ? -ECONNABORTED : 0;
-	if (err == 0) {
-		len = MIN(buf->len, mcux_len);
-		buf->data += len;
-		buf->len -= len;
-	}
-
-	err = udc_submit_ep_event(dev, buf, err);
-	udc_mcux_ep_try_feed(dev, udc_get_ep_cfg(dev, ep));
-
-	return err;
-}
-
-static int udc_mcux_handler_non_ctrl_out(const struct device *dev, uint8_t ep,
-			struct net_buf *buf, uint8_t *mcux_buf, uint32_t mcux_len)
-{
-	int err;
-	uint32_t len;
-
-	err = mcux_len == USB_CANCELLED_TRANSFER_LENGTH ? -ECONNABORTED : 0;
-	if (err == 0) {
-		len = MIN(net_buf_tailroom(buf), mcux_len);
-		net_buf_add(buf, len);
-	}
-
-	err = udc_submit_ep_event(dev, buf, err);
-	udc_mcux_ep_try_feed(dev, udc_get_ep_cfg(dev, ep));
-
-	return err;
-}
-
 static int udc_mcux_handler_out(const struct device *dev, uint8_t ep,
 				uint8_t *mcux_buf, uint32_t mcux_len)
 {
@@ -274,13 +206,21 @@ static int udc_mcux_handler_out(const struct device *dev, uint8_t ep,
 		return -ENOBUFS;
 	}
 
-	if (ep == USB_CONTROL_EP_OUT) {
-		err = udc_mcux_handler_ctrl_out(dev, buf, mcux_buf, mcux_len);
-	} else {
-		err = udc_mcux_handler_non_ctrl_out(dev, ep, buf, mcux_buf, mcux_len);
+	err = mcux_len == USB_CANCELLED_TRANSFER_LENGTH ? -ECONNABORTED : 0;
+	if (err == 0) {
+		uint32_t len;
+
+		len = MIN(net_buf_tailroom(buf), mcux_len);
+		net_buf_add(buf, len);
 	}
 
-	return err;
+	udc_submit_ep_event(dev, buf, err);
+
+	if (ep != USB_CONTROL_EP_OUT) {
+		udc_mcux_ep_try_feed(dev, udc_get_ep_cfg(dev, ep));
+	}
+
+	return 0;
 }
 
 /* return true - zlp is feed; false - no zlp */
@@ -341,13 +281,22 @@ static int udc_mcux_handler_in(const struct device *dev, uint8_t ep,
 		return -ENOBUFS;
 	}
 
-	if (ep == USB_CONTROL_EP_IN) {
-		err = udc_mcux_handler_ctrl_in(dev, buf, mcux_buf, mcux_len);
-	} else {
-		err = udc_mcux_handler_non_ctrl_in(dev, ep, buf, mcux_buf, mcux_len);
+	err = mcux_len == USB_CANCELLED_TRANSFER_LENGTH ? -ECONNABORTED : 0;
+	if (err == 0) {
+		uint32_t len;
+
+		len = MIN(buf->len, mcux_len);
+		buf->data += len;
+		buf->len -= len;
 	}
 
-	return err;
+	udc_submit_ep_event(dev, buf, err);
+
+	if (ep != USB_CONTROL_EP_IN) {
+		udc_mcux_ep_try_feed(dev, udc_get_ep_cfg(dev, ep));
+	}
+
+	return 0;
 }
 
 static void udc_mcux_work_handler(struct k_work *item)

--- a/drivers/usb/udc/udc_mcux_ehci.c
+++ b/drivers/usb/udc/udc_mcux_ehci.c
@@ -541,10 +541,19 @@ static int udc_mcux_ep_enqueue(const struct device *dev,
 static int udc_mcux_ep_dequeue(const struct device *dev,
 			       struct udc_ep_config *const cfg)
 {
+	const struct udc_mcux_config *config = dev->config;
+	const usb_device_controller_interface_struct_t *mcux_if = config->mcux_if;
 	struct udc_mcux_data *priv = udc_get_private(dev);
 	k_spinlock_key_t key;
+	usb_status_t status;
 
 	cfg->stat.halted = false;
+
+	status = mcux_if->deviceCancel(priv->mcux_device.controllerHandle, cfg->addr);
+	if (status != kStatus_USB_Success) {
+		LOG_WRN("Failed to cancel endpoint 0x%02x", cfg->addr);
+	}
+
 	udc_ep_cancel_queued(dev, cfg);
 
 	key = k_spin_lock(&priv->lock);

--- a/drivers/usb/udc/udc_mcux_ip3511.c
+++ b/drivers/usb/udc/udc_mcux_ip3511.c
@@ -527,10 +527,19 @@ static int udc_mcux_ep_enqueue(const struct device *dev,
 static int udc_mcux_ep_dequeue(const struct device *dev,
 			       struct udc_ep_config *const cfg)
 {
+	const struct udc_mcux_config *config = dev->config;
+	const usb_device_controller_interface_struct_t *mcux_if = config->mcux_if;
 	struct udc_mcux_data *priv = udc_get_private(dev);
 	k_spinlock_key_t key;
+	usb_status_t status;
 
 	cfg->stat.halted = false;
+
+	status = mcux_if->deviceCancel(priv->mcux_device.controllerHandle, cfg->addr);
+	if (status != kStatus_USB_Success) {
+		LOG_WRN("Failed to cancel endpoint 0x%02x", cfg->addr);
+	}
+
 	udc_ep_cancel_queued(dev, cfg);
 
 	key = k_spin_lock(&priv->lock);

--- a/drivers/usb/udc/udc_mcux_ip3511.c
+++ b/drivers/usb/udc/udc_mcux_ip3511.c
@@ -174,74 +174,6 @@ static int udc_mcux_handler_setup(const struct device *dev, struct usb_setup_pac
 	return 0;
 }
 
-static int udc_mcux_handler_ctrl_out(const struct device *dev, struct net_buf *buf,
-				uint8_t *mcux_buf, uint32_t mcux_len)
-{
-	int err;
-	uint32_t len;
-
-	err = mcux_len == USB_CANCELLED_TRANSFER_LENGTH ? -ECONNABORTED : 0;
-	if (err == 0) {
-		len = MIN(net_buf_tailroom(buf), mcux_len);
-		net_buf_add(buf, len);
-	}
-
-	return udc_submit_ep_event(dev, buf, err);
-}
-
-static int udc_mcux_handler_ctrl_in(const struct device *dev, struct net_buf *buf,
-				uint8_t *mcux_buf, uint32_t mcux_len)
-{
-	int err;
-	uint32_t len;
-
-	err = mcux_len == USB_CANCELLED_TRANSFER_LENGTH ? -ECONNABORTED : 0;
-	if (err == 0) {
-		len = MIN(buf->len, mcux_len);
-		buf->data += len;
-		buf->len -= len;
-	}
-
-	return udc_submit_ep_event(dev, buf, err);
-}
-
-static int udc_mcux_handler_non_ctrl_in(const struct device *dev, uint8_t ep,
-			struct net_buf *buf, uint8_t *mcux_buf, uint32_t mcux_len)
-{
-	int err;
-	uint32_t len;
-
-	err = mcux_len == USB_CANCELLED_TRANSFER_LENGTH ? -ECONNABORTED : 0;
-	if (err == 0) {
-		len = MIN(buf->len, mcux_len);
-		buf->data += len;
-		buf->len -= len;
-	}
-
-	err = udc_submit_ep_event(dev, buf, err);
-	udc_mcux_ep_try_feed(dev, udc_get_ep_cfg(dev, ep));
-
-	return err;
-}
-
-static int udc_mcux_handler_non_ctrl_out(const struct device *dev, uint8_t ep,
-			struct net_buf *buf, uint8_t *mcux_buf, uint32_t mcux_len)
-{
-	int err;
-	uint32_t len;
-
-	err = mcux_len == USB_CANCELLED_TRANSFER_LENGTH ? -ECONNABORTED : 0;
-	if (err == 0) {
-		len = MIN(net_buf_tailroom(buf), mcux_len);
-		net_buf_add(buf, len);
-	}
-
-	err = udc_submit_ep_event(dev, buf, err);
-	udc_mcux_ep_try_feed(dev, udc_get_ep_cfg(dev, ep));
-
-	return err;
-}
-
 static int udc_mcux_handler_out(const struct device *dev, uint8_t ep,
 				uint8_t *mcux_buf, uint32_t mcux_len)
 {
@@ -260,13 +192,21 @@ static int udc_mcux_handler_out(const struct device *dev, uint8_t ep,
 		return -ENOBUFS;
 	}
 
-	if (ep == USB_CONTROL_EP_OUT) {
-		err = udc_mcux_handler_ctrl_out(dev, buf, mcux_buf, mcux_len);
-	} else {
-		err = udc_mcux_handler_non_ctrl_out(dev, ep, buf, mcux_buf, mcux_len);
+	err = mcux_len == USB_CANCELLED_TRANSFER_LENGTH ? -ECONNABORTED : 0;
+	if (err == 0) {
+		uint32_t len;
+
+		len = MIN(net_buf_tailroom(buf), mcux_len);
+		net_buf_add(buf, len);
 	}
 
-	return err;
+	udc_submit_ep_event(dev, buf, err);
+
+	if (ep != USB_CONTROL_EP_OUT) {
+		udc_mcux_ep_try_feed(dev, udc_get_ep_cfg(dev, ep));
+	}
+
+	return 0;
 }
 
 /* return true - zlp is feed; false - no zlp */
@@ -327,13 +267,22 @@ static int udc_mcux_handler_in(const struct device *dev, uint8_t ep,
 		return -ENOBUFS;
 	}
 
-	if (ep == USB_CONTROL_EP_IN) {
-		err = udc_mcux_handler_ctrl_in(dev, buf, mcux_buf, mcux_len);
-	} else {
-		err = udc_mcux_handler_non_ctrl_in(dev, ep, buf, mcux_buf, mcux_len);
+	err = mcux_len == USB_CANCELLED_TRANSFER_LENGTH ? -ECONNABORTED : 0;
+	if (err == 0) {
+		uint32_t len;
+
+		len = MIN(buf->len, mcux_len);
+		buf->data += len;
+		buf->len -= len;
 	}
 
-	return err;
+	udc_submit_ep_event(dev, buf, err);
+
+	if (ep != USB_CONTROL_EP_IN) {
+		udc_mcux_ep_try_feed(dev, udc_get_ep_cfg(dev, ep));
+	}
+
+	return 0;
 }
 
 static void udc_mcux_work_handler(struct k_work *item)

--- a/drivers/usb/udc/udc_mcux_ip3511.c
+++ b/drivers/usb/udc/udc_mcux_ip3511.c
@@ -50,19 +50,11 @@ struct udc_mcux_data {
 	const struct device *dev;
 	usb_device_struct_t mcux_device;
 	struct k_work work;
-	struct k_fifo fifo;
+	struct k_spinlock lock;
+	struct usb_setup_packet setup_pkt;
+	volatile bool setup_pending;
 	uint8_t controller_id; /* 0xFF is invalid value */
 };
-
-/* Structure for driver's events */
-struct udc_mcux_event {
-	sys_snode_t node;
-	const struct device *dev;
-	usb_device_callback_message_struct_t mcux_msg;
-};
-
-K_MEM_SLAB_DEFINE_TYPE(udc_event_slab, struct udc_mcux_event,
-		       CONFIG_UDC_NXP_EVENT_COUNT);
 
 static void udc_mcux_lock(const struct device *dev)
 {
@@ -86,7 +78,7 @@ static int udc_mcux_control(const struct device *dev, usb_device_control_type_t 
 			command, param);
 
 	if (status != kStatus_USB_Success) {
-		return -ENOMEM;
+		return -EIO;
 	}
 
 	return 0;
@@ -100,10 +92,11 @@ static int udc_mcux_ep_feed(const struct device *dev,
 	const struct udc_mcux_config *config = dev->config;
 	const usb_device_controller_interface_struct_t *mcux_if = config->mcux_if;
 	struct udc_mcux_data *priv = udc_get_private(dev);
+	usb_device_endpoint_status_struct_t ep_status;
 	usb_status_t status = kStatus_USB_Success;
+	k_spinlock_key_t key;
 	uint8_t *data;
 	uint32_t len;
-	usb_device_endpoint_status_struct_t ep_status;
 
 	ep_status.endpointAddress = cfg->addr;
 	udc_mcux_control(dev, kUSB_DeviceControlGetEndpointStatus, &ep_status);
@@ -111,10 +104,10 @@ static int udc_mcux_ep_feed(const struct device *dev,
 		return -EACCES; /* stalled */
 	}
 
-	udc_mcux_lock(dev);
+	key = k_spin_lock(&priv->lock);
 	if (!udc_ep_is_busy(cfg)) {
 		udc_ep_set_busy(cfg, true);
-		udc_mcux_unlock(dev);
+		k_spin_unlock(&priv->lock, key);
 
 		if (USB_EP_DIR_IS_OUT(cfg->addr)) {
 			len = net_buf_tailroom(buf);
@@ -128,13 +121,13 @@ static int udc_mcux_ep_feed(const struct device *dev,
 					cfg->addr, data, len);
 		}
 
-		udc_mcux_lock(dev);
+		key = k_spin_lock(&priv->lock);
 		if (status != kStatus_USB_Success) {
 			udc_ep_set_busy(cfg, false);
 		}
-		udc_mcux_unlock(dev);
+		k_spin_unlock(&priv->lock, key);
 	} else {
-		udc_mcux_unlock(dev);
+		k_spin_unlock(&priv->lock, key);
 		return -EBUSY;
 	}
 
@@ -159,6 +152,9 @@ static int udc_mcux_ep_try_feed(const struct device *dev,
 
 static int udc_mcux_handler_setup(const struct device *dev, struct usb_setup_packet *setup)
 {
+	struct udc_mcux_data *priv = udc_get_private(dev);
+	k_spinlock_key_t key;
+
 	LOG_DBG("setup packet");
 
 	if (setup->RequestType.type == USB_REQTYPE_TYPE_STANDARD &&
@@ -169,7 +165,11 @@ static int udc_mcux_handler_setup(const struct device *dev, struct usb_setup_pac
 			&setup->wValue);
 	}
 
-	udc_setup_received(dev, setup);
+	key = k_spin_lock(&priv->lock);
+	priv->setup_pkt = *setup;
+	priv->setup_pending = true;
+	k_spin_unlock(&priv->lock, key);
+	k_work_submit_to_queue(udc_get_work_q(), &priv->work);
 
 	return 0;
 }
@@ -246,15 +246,16 @@ static int udc_mcux_handler_out(const struct device *dev, uint8_t ep,
 				uint8_t *mcux_buf, uint32_t mcux_len)
 {
 	struct udc_ep_config *const cfg = udc_get_ep_cfg(dev, ep);
-	int err;
+	struct udc_mcux_data *priv = udc_get_private(dev);
+	k_spinlock_key_t key;
 	struct net_buf *buf;
+	int err;
+
+	key = k_spin_lock(&priv->lock);
+	udc_ep_set_busy(cfg, false);
+	k_spin_unlock(&priv->lock, key);
 
 	buf = udc_buf_get(cfg);
-
-	udc_mcux_lock(dev);
-	udc_ep_set_busy(cfg, false);
-	udc_mcux_unlock(dev);
-
 	if (buf == NULL) {
 		return -ENOBUFS;
 	}
@@ -303,8 +304,14 @@ static int udc_mcux_handler_in(const struct device *dev, uint8_t ep,
 				uint8_t *mcux_buf, uint32_t mcux_len)
 {
 	struct udc_ep_config *const cfg = udc_get_ep_cfg(dev, ep);
-	int err;
+	struct udc_mcux_data *priv = udc_get_private(dev);
+	k_spinlock_key_t key;
 	struct net_buf *buf;
+	int err;
+
+	key = k_spin_lock(&priv->lock);
+	udc_ep_set_busy(cfg, false);
+	k_spin_unlock(&priv->lock, key);
 
 	buf = udc_buf_peek(cfg);
 	if (buf == NULL) {
@@ -316,14 +323,10 @@ static int udc_mcux_handler_in(const struct device *dev, uint8_t ep,
 	}
 
 	buf = udc_buf_get(cfg);
-
-	udc_mcux_lock(dev);
-	udc_ep_set_busy(cfg, false);
-	udc_mcux_unlock(dev);
-
 	if (buf == NULL) {
 		return -ENOBUFS;
 	}
+
 	if (ep == USB_CONTROL_EP_IN) {
 		err = udc_mcux_handler_ctrl_in(dev, buf, mcux_buf, mcux_len);
 	} else {
@@ -333,94 +336,88 @@ static int udc_mcux_handler_in(const struct device *dev, uint8_t ep,
 	return err;
 }
 
-static void udc_mcux_event_submit(const struct device *dev,
-				  const usb_device_callback_message_struct_t *mcux_msg)
-{
-	struct udc_mcux_data *priv = udc_get_private(dev);
-	struct udc_mcux_event *ev;
-	int ret;
-
-	ret = k_mem_slab_alloc(&udc_event_slab, (void **)&ev, K_NO_WAIT);
-	if (ret) {
-		udc_submit_event(dev, UDC_EVT_ERROR, ret);
-		LOG_ERR("Failed to allocate slab");
-		return;
-	}
-
-	ev->dev = dev;
-	ev->mcux_msg = *mcux_msg;
-	k_fifo_put(&priv->fifo, ev);
-	k_work_submit_to_queue(udc_get_work_q(), &priv->work);
-}
-
 static void udc_mcux_work_handler(struct k_work *item)
 {
-	struct udc_mcux_event *ev;
+	struct usb_setup_packet setup_pkt;
 	struct udc_mcux_data *priv;
-	usb_device_callback_message_struct_t *mcux_msg;
-	int err;
-	uint8_t ep;
+	bool setup_valid = false;
+	k_spinlock_key_t key;
 
 	priv = CONTAINER_OF(item, struct udc_mcux_data, work);
-	while ((ev = k_fifo_get(&priv->fifo, K_NO_WAIT)) != NULL) {
-		mcux_msg = &ev->mcux_msg;
 
-		if (mcux_msg->code == kUSB_DeviceNotifyBusReset) {
-			struct udc_ep_config *cfg;
-
-			udc_mcux_control(ev->dev, kUSB_DeviceControlSetDefaultStatus, NULL);
-			cfg = udc_get_ep_cfg(ev->dev, USB_CONTROL_EP_OUT);
-			if (cfg->stat.enabled) {
-				udc_ep_disable_internal(ev->dev, USB_CONTROL_EP_OUT);
-			}
-			cfg = udc_get_ep_cfg(ev->dev, USB_CONTROL_EP_IN);
-			if (cfg->stat.enabled) {
-				udc_ep_disable_internal(ev->dev, USB_CONTROL_EP_IN);
-			}
-			if (udc_ep_enable_internal(ev->dev, USB_CONTROL_EP_OUT,
-						USB_EP_TYPE_CONTROL,
-						USB_MCUX_EP0_SIZE, 0)) {
-				LOG_ERR("Failed to enable control endpoint");
-			}
-			if (udc_ep_enable_internal(ev->dev, USB_CONTROL_EP_IN,
-						USB_EP_TYPE_CONTROL,
-						USB_MCUX_EP0_SIZE, 0)) {
-				LOG_ERR("Failed to enable control endpoint");
-			}
-			udc_submit_event(ev->dev, UDC_EVT_RESET, 0);
-		} else {
-			ep  = mcux_msg->code;
-
-			if (mcux_msg->isSetup) {
-				struct usb_setup_packet *setup =
-					(struct usb_setup_packet *)mcux_msg->buffer;
-
-				err = udc_mcux_handler_setup(ev->dev, setup);
-			} else if (USB_EP_DIR_IS_IN(ep)) {
-				err = udc_mcux_handler_in(ev->dev, ep, mcux_msg->buffer,
-							  mcux_msg->length);
-			} else {
-				err = udc_mcux_handler_out(ev->dev, ep, mcux_msg->buffer,
-							   mcux_msg->length);
-			}
-
-			if (unlikely(err)) {
-				udc_submit_event(ev->dev, UDC_EVT_ERROR, err);
-			}
-		}
-
-		k_mem_slab_free(&udc_event_slab, (void *)ev);
+	/* need the spin lock in case the setup is half changed in isr. */
+	key = k_spin_lock(&priv->lock);
+	if (priv->setup_pending) {
+		priv->setup_pending = false;
+		setup_valid = true;
+		setup_pkt = priv->setup_pkt;
 	}
+	k_spin_unlock(&priv->lock, key);
+
+	if (setup_valid) {
+		udc_setup_received(priv->dev, &setup_pkt);
+	}
+}
+
+static void udc_mcux_bus_reset_isr(const struct device *dev)
+{
+	struct udc_mcux_data *priv = udc_get_private(dev);
+	struct udc_ep_config *cfg;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&priv->lock);
+	priv->setup_pending = false;
+	k_spin_unlock(&priv->lock, key);
+
+	udc_mcux_control(dev, kUSB_DeviceControlSetDefaultStatus, NULL);
+	cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
+	if (cfg->stat.enabled) {
+		udc_ep_disable_internal(dev, USB_CONTROL_EP_OUT);
+	}
+	cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_IN);
+	if (cfg->stat.enabled) {
+		udc_ep_disable_internal(dev, USB_CONTROL_EP_IN);
+	}
+	if (udc_ep_enable_internal(dev, USB_CONTROL_EP_OUT, USB_EP_TYPE_CONTROL,
+				   USB_MCUX_EP0_SIZE, 0)) {
+		LOG_ERR("Failed to enable control endpoint");
+	}
+	if (udc_ep_enable_internal(dev, USB_CONTROL_EP_IN, USB_EP_TYPE_CONTROL,
+				   USB_MCUX_EP0_SIZE, 0)) {
+		LOG_ERR("Failed to enable control endpoint");
+	}
+	udc_submit_event(dev, UDC_EVT_RESET, 0);
+}
+
+static int udc_mcux_ep_event_isr(const struct device *dev,
+				 usb_device_callback_message_struct_t *mcux_msg)
+{
+	uint8_t ep = mcux_msg->code;
+	int err;
+
+	if (mcux_msg->isSetup) {
+		struct usb_setup_packet *setup =
+			(struct usb_setup_packet *)mcux_msg->buffer;
+
+		err = udc_mcux_handler_setup(dev, setup);
+	} else if (USB_EP_DIR_IS_IN(ep)) {
+		err = udc_mcux_handler_in(dev, ep, mcux_msg->buffer, mcux_msg->length);
+	} else {
+		err = udc_mcux_handler_out(dev, ep, mcux_msg->buffer, mcux_msg->length);
+	}
+
+	return err;
 }
 
 /* NXP MCUX controller driver notify transfers/status through this interface */
 usb_status_t USB_DeviceNotificationTrigger(void *handle, void *msg)
 {
 	usb_device_callback_message_struct_t *mcux_msg = msg;
+	usb_status_t mcux_status = kStatus_USB_Success;
 	usb_device_notification_t mcux_notify;
 	struct udc_mcux_data *priv;
 	const struct device *dev;
-	usb_status_t mcux_status = kStatus_USB_Success;
+	int err;
 
 	if ((NULL == msg) || (NULL == handle)) {
 		return kStatus_USB_InvalidHandle;
@@ -432,7 +429,7 @@ usb_status_t USB_DeviceNotificationTrigger(void *handle, void *msg)
 
 	switch (mcux_notify) {
 	case kUSB_DeviceNotifyBusReset:
-		udc_mcux_event_submit(dev, mcux_msg);
+		udc_mcux_bus_reset_isr(dev);
 		break;
 	case kUSB_DeviceNotifyError:
 		udc_submit_event(dev, UDC_EVT_ERROR, -EIO);
@@ -457,7 +454,11 @@ usb_status_t USB_DeviceNotificationTrigger(void *handle, void *msg)
 		udc_submit_sof_event(dev);
 		break;
 	default:
-		udc_mcux_event_submit(dev, mcux_msg);
+		err = udc_mcux_ep_event_isr(dev, mcux_msg);
+		if (unlikely(err)) {
+			udc_submit_event(dev, UDC_EVT_ERROR, err);
+			mcux_status = kStatus_USB_Error;
+		}
 		break;
 	}
 
@@ -526,12 +527,15 @@ static int udc_mcux_ep_enqueue(const struct device *dev,
 static int udc_mcux_ep_dequeue(const struct device *dev,
 			       struct udc_ep_config *const cfg)
 {
+	struct udc_mcux_data *priv = udc_get_private(dev);
+	k_spinlock_key_t key;
+
 	cfg->stat.halted = false;
 	udc_ep_cancel_queued(dev, cfg);
 
-	udc_mcux_lock(dev);
+	key = k_spin_lock(&priv->lock);
 	udc_ep_set_busy(cfg, false);
-	udc_mcux_unlock(dev);
+	k_spin_unlock(&priv->lock, key);
 
 	return 0;
 }
@@ -736,7 +740,6 @@ static int udc_mcux_driver_preinit(const struct device *dev)
 	}
 
 	k_mutex_init(&data->mutex);
-	k_fifo_init(&priv->fifo);
 	k_work_init(&priv->work, udc_mcux_work_handler);
 
 	for (int i = 0; i < config->num_of_eps; i++) {

--- a/drivers/usb/udc/udc_mcux_ip3511.c
+++ b/drivers/usb/udc/udc_mcux_ip3511.c
@@ -256,7 +256,6 @@ static int udc_mcux_handler_out(const struct device *dev, uint8_t ep,
 	udc_mcux_unlock(dev);
 
 	if (buf == NULL) {
-		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
 		return -ENOBUFS;
 	}
 
@@ -309,7 +308,6 @@ static int udc_mcux_handler_in(const struct device *dev, uint8_t ep,
 
 	buf = udc_buf_peek(cfg);
 	if (buf == NULL) {
-		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
 		return -ENOBUFS;
 	}
 
@@ -324,7 +322,6 @@ static int udc_mcux_handler_in(const struct device *dev, uint8_t ep,
 	udc_mcux_unlock(dev);
 
 	if (buf == NULL) {
-		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
 		return -ENOBUFS;
 	}
 	if (ep == USB_CONTROL_EP_IN) {


### PR DESCRIPTION
The NXP MCUX EHCI and IP3511 UDC drivers previously processed controller events through a k_mem_slab event pool, a k_fifo, and the shared system workqueue. Each notification allocated an event block, copied the HAL message, and queued work; the slab could be exhausted under load and the transfer buffer was only touched later in workqueue context.
Rework both drivers to use a dedicated per-instance driver thread woken by a single k_event. Completed transfer buffers are now updated in place in the HAL notification (ISR) context, detached from the endpoint queue, and appended to a per-instance complete_bufs slist; the thread drains the list and reports each buffer to the stack, then feeds the next queued request. Multiple completions coalesce into a single UDC_MCUX_EVT_XFER wake-up and bus reset is handled under UDC_MCUX_EVT_RESET.
The now-unused event slab, k_fifo, and workqueue dependency are removed, and Kconfig gains per-driver thread stack-size and priority options.

Add explicit endpoint transfer cancellation in udc_mcux_ep_dequeue() by calling the controller's deviceCancel() function before clearing the queued transfers. This ensures that the ongoing hardware transfer are properly stopped at the controller level.
Remove the busy state clearing, as the HAL driver's transfer cancellation callback already handles it.
Add locking to prevent transfer interrupts from occurring while transfers are being canceled.