### PR TITLE
Bluetooth: CAP: Handover: Shell: Workaround for case for bsrc started

### DIFF
--- a/subsys/bluetooth/audio/shell/cap_handover.c
+++ b/subsys/bluetooth/audio/shell/cap_handover.c
@@ -63,6 +63,7 @@ static void unicast_to_broadcast_complete_cb(int err, struct bt_conn *conn,
 	if (err != 0) {
 		const char *unicast_group_del_str =
 			unicast_group != NULL ? " without deleting the unicast_group" : "";
+		bool reset_default_source = broadcast_source == NULL;
 
 		if (err == -ECANCELED) {
 			bt_shell_print("Unicast to broadcast handover was cancelled for conn %p%s",
@@ -75,15 +76,25 @@ static void unicast_to_broadcast_complete_cb(int err, struct bt_conn *conn,
 		if (broadcast_source != NULL) {
 			err = bt_cap_initiator_broadcast_audio_delete(broadcast_source);
 
+			/* If we do not manage to delete the source here if it is in the streaming
+			 * state, then that needs to be done manually by the shell user
+			 */
 			if (err != 0) {
-				bt_shell_error("Failed to delete broadcast source: %d", err);
+				bt_shell_error("Failed to delete broadcast source: %d. Use "
+					       "`cmd_broadcast_stop` and `cmd_broadcast_delete` "
+					       "to manually stop and delete",
+					       err);
+			} else {
+				reset_default_source = true;
 			}
 		}
 
-		default_source.cap_source = NULL;
-		default_source.is_cap = false;
-		default_source.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
-		default_source.adv_sid = BT_GAP_SID_INVALID;
+		if (reset_default_source) {
+			default_source.cap_source = NULL;
+			default_source.is_cap = false;
+			default_source.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
+			default_source.adv_sid = BT_GAP_SID_INVALID;
+		}
 	} else {
 		bt_shell_print(
 			"Unicast to broadcast handover completed with new broadcast source %p",


### PR DESCRIPTION
If the broadcast source was created and started but the handover still failed, then we should stop and delete the broadcast source.

However bt_cap_initiator_broadcast_audio_stop is not a synchronous function, and we cannot just stop it directly in the callback. Instead of offloading that to another thread, we simply instruct the shell user to manually stop and delete the source (if they want to).