### PR TITLE
Bluetooth: BAP: Fix stream QoS validation for multi-conn groups

### DIFF
--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -1295,6 +1295,10 @@ int bt_bap_stream_qos(struct bt_conn *conn, struct bt_bap_unicast_group *group)
 	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
 		const struct bt_bap_ep *ep = stream->ep;
 
+		if (conn != stream->conn) {
+			continue;
+		}
+
 		if (ep != NULL && !bap_stream_valid_ase_op(conn, ep, BT_ASCS_QOS_OP)) {
 			return -EBADMSG;
 		}


### PR DESCRIPTION
The bt_bap_stream_qos() function validates ASE operations for all streams in the unicast group, but it should only validate streams that belong to the specified connection.

When a unicast group contains streams from multiple connections, the current implementation incorrectly validates streams belonging to other connections, which may cause false -EBADMSG errors if those streams are in different states.

Add a connection check to skip streams that do not belong to the specified connection during ASE operation validation.