### PR TITLE
manifest: hal_nxp: test pinctrl deduplication (hal_nxp#771)

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 6c77523dfdfc5a1ecefbafb31feee6499a5de8ec
+      revision: pull/771/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Companion manifest PR for zephyrproject-rtos/hal_nxp#771: runs full CI/twister against the hal_nxp pinctrl deduplication.

hal_nxp#771 rewrites 572 duplicate SOC pinctrl files under `dts/nxp` as include wrappers and delta wrappers (`dts/nxp` shrinks from 64MB to 14MB, -78%). The effective preprocessor / devicetree content of every part number is unchanged, verified per file with `gcc -E -dM` (.h) and dtlib devicetree semantic equality (.dtsi) — so all board builds are expected to be bit-identical.

**Do not merge as-is**: `revision: pull/771/head` is for testing only and will be updated to the merge SHA once hal_nxp#771 lands.