### PR TITLE
Bluetooth: BAP: Shell: Change to use CONFIG_BT_ISO_MAX_CHAN for cnt

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -246,8 +246,7 @@ struct scan_delegator_sync_state {
 		     CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT),                                  \
 		    (0))
 
-extern struct shell_stream unicast_streams[CONFIG_BT_MAX_CONN * MAX(UNICAST_SERVER_STREAM_COUNT,
-								    UNICAST_CLIENT_STREAM_COUNT)];
+extern struct shell_stream unicast_streams[CONFIG_BT_ISO_MAX_CHAN];
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -66,8 +66,7 @@
 
 #if defined(CONFIG_BT_BAP_UNICAST)
 
-struct shell_stream unicast_streams[CONFIG_BT_MAX_CONN * MAX(UNICAST_SERVER_STREAM_COUNT,
-							     UNICAST_CLIENT_STREAM_COUNT)] = {0};
+struct shell_stream unicast_streams[CONFIG_BT_ISO_MAX_CHAN] = {0};
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 struct unicast_group default_unicast_group = {0};


### PR DESCRIPTION
Instead of support a `shell_stream` for each supported ASE, we now just support CONFIG_BT_ISO_MAX_CHAN. Since
CONFIG_BT_ISO_MAX_CHAN is the limiting factor in actually setting up a stream, this is a significantly better way to control the number of streams. We could optimize further as
CONFIG_BT_ISO_MAX_CHAN contains both unicast and broadcast streams, so we may only support fewer unicast streams than CONFIG_BT_ISO_MAX_CHAN at some points in time.

With the default audio.conf this results in a massive RAM savings:

Before:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      890368 B         1 MB     84.91%
             RAM:      405410 B       448 KB     88.37%
        IDT_LIST:           0 B        32 KB      0.00%
```

After:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      890368 B         1 MB     84.91%
             RAM:      330674 B       448 KB     72.08%
        IDT_LIST:           0 B        32 KB      0.00%
```