### PR TITLE
dts: arm: st: *: add ranges property to pinctrl nodes 

### DIFF
--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -235,6 +235,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x50000000 0x2000>;
+			ranges;
 
 			gpioa: gpio@50000000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -353,6 +353,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x42020000 0x2000>;
+			ranges;
 
 			gpioa: gpio@42020000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -160,6 +160,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x48000000 0x1800>;
+			ranges;
 
 			gpioa: gpio@48000000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -155,6 +155,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40010800 0x1c00>;
+			ranges;
 
 			gpioa: gpio@40010800 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -134,6 +134,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40020000 0x2000>;
+			ranges;
 
 			gpioa: gpio@40020000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -164,6 +164,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x48000000 0x1800>;
+			ranges;
 
 			gpioa: gpio@48000000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -207,6 +207,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40020000 0x2000>;
+			ranges;
 
 			gpioa: gpio@40020000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -236,6 +236,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40020000 0x2400>;
+			ranges;
 
 			gpioa: gpio@40020000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -199,6 +199,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x50000000 0x2000>;
+			ranges;
 
 			gpioa: gpio@50000000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -250,6 +250,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x48000000 0x2000>;
+			ranges;
 
 			gpioa: gpio@48000000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -228,6 +228,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x42020000 0x2000>;
+			ranges;
 
 			gpioa: gpio@42020000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -243,6 +243,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x58020000 0x2400>;
+			ranges;
 
 			gpioa: gpio@58020000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -281,6 +281,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x58020000 0x2400>;
+			ranges;
 
 			gpioa: gpio@58020000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -199,6 +199,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x50000000 0x2000>;
+			ranges;
 
 			gpioa: gpio@50000000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -539,6 +539,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40020000 0x2000>;
+			ranges;
 
 			gpioa: gpio@40020000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -214,6 +214,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x48000000 0x2000>;
+			ranges;
 
 			gpioa: gpio@48000000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -234,6 +234,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x42020000 0x2000>;
+			ranges;
 
 			gpioa: gpio@42020000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -91,6 +91,7 @@
 		pinctrl: pin-controller@50002000 {
 			compatible = "st,stm32-pinctrl";
 			reg = <0x50002000 0x9000>;
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -84,6 +84,7 @@
 		pinctrl: pin-controller@50002000 {
 			compatible = "st,stm32-pinctrl";
 			reg = <0x50002000 0x9000>;
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 

--- a/dts/arm/st/mp2/stm32mp2_m33.dtsi
+++ b/dts/arm/st/mp2/stm32mp2_m33.dtsi
@@ -62,6 +62,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x44240000 0xb0000>;
+			ranges;
 
 			gpioa: gpio@44240000 {
 				compatible = "st,stm32mp2-gpio";

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -202,6 +202,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x50000000 0x2000>;
+			ranges;
 
 			gpioa: gpio@50000000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -186,6 +186,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x42020000 0x2000>;
+			ranges;
 
 			gpioa: gpio@42020000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -265,7 +265,7 @@
 			compatible = "st,stm32-pinctrl";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			reg = <0x42020000 0x2000>;
+			reg = <0x42020000 0x2800>;
 
 			gpioa: gpio@42020000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -266,6 +266,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x42020000 0x2800>;
+			ranges;
 
 			gpioa: gpio@42020000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/u5/stm32u595.dtsi
+++ b/dts/arm/st/u5/stm32u595.dtsi
@@ -27,11 +27,6 @@
 		compatible = "st,stm32u595", "st,stm32u5", "simple-bus";
 
 		pinctrl: pin-controller@42020000 {
-			compatible = "st,stm32-pinctrl";
-			#address-cells = <1>;
-			#size-cells = <1>;
-			reg = <0x42020000 0x2800>;
-
 			gpioj: gpio@42022400 {
 				compatible = "st,stm32-gpio";
 				gpio-controller;

--- a/dts/arm/st/u5/stm32u5_extra.dtsi
+++ b/dts/arm/st/u5/stm32u5_extra.dtsi
@@ -15,20 +15,22 @@
 			status = "disabled";
 		};
 
-		gpiof: gpio@42021400 {
-			compatible = "st,stm32-gpio";
-			gpio-controller;
-			#gpio-cells = <2>;
-			reg = <0x42021400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
-		};
+		pinctrl: pin-controller@42020000 {
+			gpiof: gpio@42021400 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x42021400 0x400>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
+			};
 
-		gpioi: gpio@42022000 {
-			compatible = "st,stm32-gpio";
-			gpio-controller;
-			#gpio-cells = <2>;
-			reg = <0x42022000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 8)>;
+			gpioi: gpio@42022000 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x42022000 0x400>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 8)>;
+			};
 		};
 
 		sdmmc2: sdmmc@420c8c00 {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -233,6 +233,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x48000000 0x2000>;
+			ranges;
 
 			gpioa: gpio@48000000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/wb0/stm32wb0.dtsi
+++ b/dts/arm/st/wb0/stm32wb0.dtsi
@@ -206,6 +206,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x48000000 DT_SIZE_M(2)>;
+			ranges;
 
 			gpioa: gpio@48000000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -326,6 +326,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x42020000 0x2000>;
+			ranges;
 
 			gpioa: gpio@42020000 {
 				compatible = "st,stm32-gpio";

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -207,6 +207,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x48000000 0x2000>;
+			ranges;
 
 			gpioa: gpio@48000000 {
 				compatible = "st,stm32-gpio";


### PR DESCRIPTION
Add empty `ranges` properties to STM32 `pinctrl` nodes such that the GPIO port nodes are mapped in the root address space on all series. Previously, only STM32N6 had this property as it was required for proper switching between Secure and Non-Secure aliases.

While at it, fix an error in and cleanup the `pinctrl`/`gpio` nodes in DTSI of STM32U5 series.