### PR TITLE
STM32 XSPI code relocation

### DIFF
--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -164,6 +164,17 @@ if(CONFIG_SOC_FLASH_STM32)
   endif()
 endif()
 
+if(CONFIG_FLASH_STM32_XSPI_XIP_RELOCATE)
+  zephyr_code_relocate(FILES flash_stm32_xspi.c LOCATION RAM_TEXT_RODATA NOKEEP)
+  zephyr_code_relocate(FILES ${ZEPHYR_BASE}/soc/st/stm32/common/stm32cube_hal.c LOCATION RAM_TEXT_RODATA NOKEEP)
+
+  # Relocate HAL XSPI and HAL timebase code to RAM for STM32N6 series.
+  if(CONFIG_SOC_SERIES_STM32N6X)
+    zephyr_code_relocate(FILES ${ZEPHYR_HAL_STM32_MODULE_DIR}/stm32cube/stm32n6xx/drivers/src/stm32n6xx_hal_xspi.c LOCATION RAM_TEXT_RODATA NOKEEP)
+    zephyr_code_relocate(FILES ${ZEPHYR_HAL_STM32_MODULE_DIR}/stm32cube/stm32n6xx/drivers/src/stm32n6xx_hal.c LOCATION RAM_TEXT_RODATA NOKEEP)
+  endif()
+endif()
+
 if(CONFIG_SOC_FLASH_GD32)
   zephyr_library_sources(flash_gd32.c)
 

--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -171,6 +171,7 @@ endif()
 
 if(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
   zephyr_code_relocate(FILES flash_stm32_xspi.c LOCATION RAM_TEXT_RODATA NOKEEP)
+  zephyr_code_relocate(FILES ${ZEPHYR_BASE}/soc/st/stm32/common/stm32_xspi_hal_timer.c LOCATION RAM_TEXT_RODATA NOKEEP)
 
   # Relocate HAL XSPI and HAL timebase code to RAM for STM32N6 and STM32H7S series.
   if(CONFIG_SOC_SERIES_STM32N6X)

--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -169,6 +169,19 @@ if(CONFIG_SOC_FLASH_STM32)
   endif()
 endif()
 
+if(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
+  zephyr_code_relocate(FILES flash_stm32_xspi.c LOCATION RAM_TEXT_RODATA NOKEEP)
+
+  # Relocate HAL XSPI and HAL timebase code to RAM for STM32N6 and STM32H7S series.
+  if(CONFIG_SOC_SERIES_STM32N6X)
+    zephyr_code_relocate(FILES ${ZEPHYR_HAL_STM32_MODULE_DIR}/stm32cube/stm32n6xx/drivers/src/stm32n6xx_hal_xspi.c LOCATION RAM_TEXT_RODATA NOKEEP)
+    zephyr_code_relocate(FILES ${ZEPHYR_HAL_STM32_MODULE_DIR}/stm32cube/stm32n6xx/drivers/src/stm32n6xx_hal.c LOCATION RAM_TEXT_RODATA NOKEEP)
+  elseif(CONFIG_SOC_SERIES_STM32H7RSX)
+    zephyr_code_relocate(FILES ${ZEPHYR_HAL_STM32_MODULE_DIR}/stm32cube/stm32h7rsxx/drivers/src/stm32h7rsxx_hal_xspi.c LOCATION RAM_TEXT_RODATA NOKEEP)
+    zephyr_code_relocate(FILES ${ZEPHYR_HAL_STM32_MODULE_DIR}/stm32cube/stm32h7rsxx/drivers/src/stm32h7rsxx_hal.c LOCATION RAM_TEXT_RODATA NOKEEP)
+  endif()
+endif()
+
 if(CONFIG_SOC_FLASH_GD32)
   zephyr_library_sources(flash_gd32.c)
 

--- a/drivers/flash/Kconfig.stm32_xspi
+++ b/drivers/flash/Kconfig.stm32_xspi
@@ -33,4 +33,16 @@ config FLASH_STM32_XSPI_DMA
 	help
 	  Enable the DMA mode for XSPI flash driver instance
 
+config FLASH_STM32_XSPI_XIP_RELOCATE
+	bool "Relocate STM32 XSPI driver code for external Flash XIP"
+	default y
+	select CODE_DATA_RELOCATION
+	depends on XIP && STM32_APP_IN_EXT_FLASH
+	depends on SOC_SERIES_STM32N6X
+	help
+	  Relocate STM32 XSPI driver code out of external flash so erase/write
+	  operations remain possible while executing from external Flash.
+	  When enabled, the driver also locks interrupts during the critical
+	  window where memory-mapped mode is disabled.
+
 endif # FLASH_STM32_XSPI

--- a/drivers/flash/Kconfig.stm32_xspi
+++ b/drivers/flash/Kconfig.stm32_xspi
@@ -33,4 +33,18 @@ config FLASH_STM32_XSPI_DMA
 	help
 	  Enable the DMA mode for XSPI flash driver instance
 
+config FLASH_STM32_XSPI_RAM_RELOCATION
+	bool "Relocate STM32 XSPI driver code for external Flash XIP"
+	default y
+	select EXPERIMENTAL
+	select CODE_DATA_RELOCATION
+	select CODE_DATA_RELOCATION_SRAM
+	depends on XIP && STM32_APP_IN_EXT_FLASH
+	depends on SOC_SERIES_STM32N6X || SOC_SERIES_STM32H7RSX
+	help
+	  Relocate STM32 XSPI driver code outside the external flash so that erase/write
+	  operations remain possible while executing from external flash.
+	  When enabled, the driver also locks interrupts during the critical
+	  window where memory-mapped mode is disabled.
+
 endif # FLASH_STM32_XSPI

--- a/drivers/flash/Kconfig.stm32_xspi
+++ b/drivers/flash/Kconfig.stm32_xspi
@@ -39,8 +39,10 @@ config FLASH_STM32_XSPI_RAM_RELOCATION
 	select EXPERIMENTAL
 	select CODE_DATA_RELOCATION
 	select CODE_DATA_RELOCATION_SRAM
+	select CORTEX_M_DWT
 	depends on XIP && STM32_APP_IN_EXT_FLASH
 	depends on SOC_SERIES_STM32N6X || SOC_SERIES_STM32H7RSX
+	depends on CPU_CORTEX_M_HAS_DWT
 	help
 	  Relocate STM32 XSPI driver code outside the external flash so that erase/write
 	  operations remain possible while executing from external flash.

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2097,6 +2097,10 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	uint32_t prescaler = STM32_XSPI_CLOCK_PRESCALER_MIN;
 	int ret;
 
+	/* Initialize semaphores */
+	k_sem_init(&dev_data->sem, 1, 1);
+	k_sem_init(&dev_data->sync, 0, 1);
+
 #if defined(CONFIG_STM32_APP_IN_EXT_FLASH) && defined(CONFIG_XIP)
 	/* If MemoryMapped then configure skip init
 	 * Check clock status first as reading CR register without bus clock doesn't work on N6
@@ -2116,6 +2120,9 @@ static int flash_stm32_xspi_init(const struct device *dev)
 #endif
 			/* Force HAL instance in correct state */
 			dev_data->hxspi.State = HAL_XSPI_STATE_BUSY_MEM_MAPPED;
+
+			/* Run IRQ init */
+			dev_cfg->irq_config(dev);
 			return 0;
 		}
 	}
@@ -2243,10 +2250,6 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	__HAL_LINKDMA(&dev_data->hxspi, hdmarx, hdma_rx);
 
 #endif /* CONFIG_USE_STM32_HAL_DMA */
-	/* Initialize semaphores */
-	k_sem_init(&dev_data->sem, 1, 1);
-	k_sem_init(&dev_data->sync, 0, 1);
-
 	/* Run IRQ init */
 	dev_cfg->irq_config(dev);
 

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2123,6 +2123,10 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	uint32_t prescaler = STM32_XSPI_CLOCK_PRESCALER_MIN;
 	int ret;
 
+	/* Initialize semaphores */
+	k_sem_init(&dev_data->sem, 1, 1);
+	k_sem_init(&dev_data->sync, 0, 1);
+
 #if defined(CONFIG_STM32_APP_IN_EXT_FLASH) && defined(CONFIG_XIP)
 	/* If MemoryMapped then configure skip init
 	 * Check clock status first as reading CR register without bus clock doesn't work on N6
@@ -2142,6 +2146,9 @@ static int flash_stm32_xspi_init(const struct device *dev)
 #endif
 			/* Force HAL instance in correct state */
 			dev_data->hxspi.State = HAL_XSPI_STATE_BUSY_MEM_MAPPED;
+
+			/* Run IRQ init */
+			dev_cfg->irq_config(dev);
 			return 0;
 		}
 	}
@@ -2269,10 +2276,6 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	__HAL_LINKDMA(&dev_data->hxspi, hdmarx, hdma_rx);
 
 #endif /* CONFIG_USE_STM32_HAL_DMA */
-	/* Initialize semaphores */
-	k_sem_init(&dev_data->sem, 1, 1);
-	k_sem_init(&dev_data->sync, 0, 1);
-
 	/* Run IRQ init */
 	dev_cfg->irq_config(dev);
 

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -1657,11 +1657,7 @@ static int setup_pages_layout(const struct device *dev)
 		}
 	}
 
-	uint32_t erase_size = BIT(value);
-
-	if (erase_size == 0) {
-		erase_size = SPI_NOR_SECTOR_SIZE;
-	}
+	uint32_t erase_size = (value != 0U) ? BIT(value) : SPI_NOR_SECTOR_SIZE;
 
 	/* We need layout page size to be compatible with erase size */
 	if ((layout_page_size % erase_size) != 0) {

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -1134,9 +1134,13 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 	xspi_lock_thread(dev);
 
 #if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
+	bool was_memmap = false;
+
 	if (stm32_xspi_is_memorymap(dev_data)) {
+		was_memmap = true;
 		/* Abort ongoing transfer to force CS high/BUSY deasserted */
 		ret = stm32_xspi_abort(dev);
+
 		if (ret != 0) {
 			XSPI_LOG_ERR("Failed to abort memory-mapped access before erase");
 			goto erase_end;
@@ -1265,6 +1269,17 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 	/* Ends the erase operation */
 
 erase_end:
+#if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
+	if (was_memmap) {
+		if (stm32_xspi_set_memorymap(dev_data, data_mode, data_rate) != 0) {
+			/* Failed to restore memory map mode */
+			while (1) {
+				/* Infinite loop to prevent further execution */
+			}
+		}
+	}
+#endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
+
 	stm32_xspi_invalidate_mmap_cache(dev, erase_addr, erase_size);
 
 	xspi_unlock_thread(dev);
@@ -1437,9 +1452,13 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 	xspi_lock_thread(dev);
 
 #if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
+	bool was_memmap = false;
+
 	if (stm32_xspi_is_memorymap(dev_data)) {
 		/* Abort ongoing transfer to force CS high/BUSY deasserted */
+		was_memmap = true;
 		ret = stm32_xspi_abort(dev);
+
 		if (ret != 0) {
 			XSPI_LOG_ERR("Failed to abort memory-mapped access before write");
 			goto write_end;
@@ -1540,6 +1559,16 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 	/* Ends the write operation */
 
 write_end:
+#if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
+	if (was_memmap) {
+		if (stm32_xspi_set_memorymap(dev_data, data_mode, data_rate) != 0) {
+			/* Failed to restore memory map mode */
+			while (1) {
+				/* Infinite loop to prevent further execution */
+			}
+		}
+	}
+#endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
 	stm32_xspi_invalidate_mmap_cache(dev, write_addr, write_size);
 
 	xspi_unlock_thread(dev);

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -191,19 +191,24 @@ static int xspi_write_access(struct flash_stm32_xspi_data *dev_data,
 		return -EIO;
 	}
 
-#ifdef CONFIG_FLASH_STM32_XSPI_DMA
+#if defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
+	/* Use blocking transmit - IRQs are locked while memmap is off */
+	hal_ret = HAL_XSPI_Transmit(&dev_data->hxspi, (uint8_t *)data,
+				    HAL_XSPI_TIMEOUT_DEFAULT_VALUE);
+#elif defined(CONFIG_FLASH_STM32_XSPI_DMA)
 	hal_ret = HAL_XSPI_Transmit_DMA(&dev_data->hxspi, (uint8_t *)data);
-#else
+#else /* !CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION && !CONFIG_FLASH_STM32_XSPI_DMA */
 	hal_ret = HAL_XSPI_Transmit_IT(&dev_data->hxspi, (uint8_t *)data);
-#endif
+#endif /* CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
 
 	if (hal_ret != HAL_OK) {
 		XSPI_LOG_ERR("%d: Failed to write data", hal_ret);
 		return -EIO;
 	}
 
+#if !defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
 	k_sem_take(&dev_data->sync, K_FOREVER);
-
+#endif /* !CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
 	return dev_data->cmd_status;
 }
 
@@ -423,6 +428,13 @@ static int stm32_xspi_wait_auto_polling(struct flash_stm32_xspi_data *dev_data,
 {
 	dev_data->cmd_status = 0;
 
+#if defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
+	/* Use blocking polling - IRQs are locked while memmap is off */
+	if (HAL_XSPI_AutoPolling(&dev_data->hxspi, s_config, timeout_ms) != HAL_OK) {
+		return -EIO;
+	}
+	return dev_data->cmd_status;
+#else
 	if (HAL_XSPI_AutoPolling_IT(&dev_data->hxspi, s_config) != HAL_OK) {
 		XSPI_LOG_ERR("XSPI AutoPoll failed");
 		return -EIO;
@@ -441,6 +453,7 @@ static int stm32_xspi_wait_auto_polling(struct flash_stm32_xspi_data *dev_data,
 	 * cmd_status.
 	 */
 	return dev_data->cmd_status;
+#endif /* CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
 }
 
 /*
@@ -1135,9 +1148,16 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 
 #if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
 	bool was_memmap = false;
+	unsigned int irq_key = 0;
 
 	if (stm32_xspi_is_memorymap(dev_data)) {
 		was_memmap = true;
+
+		if (IS_ENABLED(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)) {
+			/* Lock IRQs for entire operation - ISR handlers are in flash */
+			irq_key = irq_lock();
+		}
+
 		/* Abort ongoing transfer to force CS high/BUSY deasserted */
 		ret = stm32_xspi_abort(dev);
 
@@ -1276,6 +1296,10 @@ erase_end:
 			while (1) {
 				/* Infinite loop to prevent further execution */
 			}
+		}
+		if (IS_ENABLED(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)) {
+			/* Unlock IRQs only after memmap is restored */
+			irq_unlock(irq_key);
 		}
 	}
 #endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
@@ -1453,10 +1477,17 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 
 #if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
 	bool was_memmap = false;
+	unsigned int irq_key = 0;
 
 	if (stm32_xspi_is_memorymap(dev_data)) {
 		/* Abort ongoing transfer to force CS high/BUSY deasserted */
 		was_memmap = true;
+
+		if (IS_ENABLED(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)) {
+			/* Lock IRQs for entire operation - ISR handlers are in flash */
+			irq_key = irq_lock();
+		}
+
 		ret = stm32_xspi_abort(dev);
 
 		if (ret != 0) {
@@ -1566,6 +1597,10 @@ write_end:
 			while (1) {
 				/* Infinite loop to prevent further execution */
 			}
+		}
+		if (IS_ENABLED(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)) {
+			/* Unlock IRQs only after memmap is restored */
+			irq_unlock(irq_key);
 		}
 	}
 #endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -32,6 +32,19 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(flash_stm32_xspi, CONFIG_FLASH_LOG_LEVEL);
 
+/* Keep log callsites in the driver, but silence them when relocation mode is enabled */
+#if defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
+#define XSPI_LOG_DBG(...)
+#define XSPI_LOG_INF(...)
+#define XSPI_LOG_WRN(...)
+#define XSPI_LOG_ERR(...)
+#else
+#define XSPI_LOG_DBG(...) LOG_DBG(__VA_ARGS__)
+#define XSPI_LOG_INF(...) LOG_INF(__VA_ARGS__)
+#define XSPI_LOG_WRN(...) LOG_WRN(__VA_ARGS__)
+#define XSPI_LOG_ERR(...) LOG_ERR(__VA_ARGS__)
+#endif /* CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
+
 #define STM32_XSPI_NODE(inst) DT_INST_PARENT(inst)
 
 #define STM32_XSPI_RESET_GPIO DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
@@ -68,16 +81,16 @@ static int xspi_send_cmd(const struct device *dev, XSPI_RegularCmdTypeDef *cmd)
 	struct flash_stm32_xspi_data *dev_data = dev->data;
 	HAL_StatusTypeDef hal_ret;
 
-	LOG_DBG("Instruction 0x%x", cmd->Instruction);
+	XSPI_LOG_DBG("Instruction 0x%x", cmd->Instruction);
 
 	dev_data->cmd_status = 0;
 
 	hal_ret = HAL_XSPI_Command(&dev_data->hxspi, cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE);
 	if (hal_ret != HAL_OK) {
-		LOG_ERR("%d: Failed to send XSPI instruction", hal_ret);
+		XSPI_LOG_ERR("%d: Failed to send XSPI instruction", hal_ret);
 		return -EIO;
 	}
-	LOG_DBG("CCR 0x%x", dev_data->hxspi.Instance->CCR);
+	XSPI_LOG_DBG("CCR 0x%x", dev_data->hxspi.Instance->CCR);
 
 	return dev_data->cmd_status;
 }
@@ -123,7 +136,7 @@ static int xspi_write_access(const struct device *dev, XSPI_RegularCmdTypeDef *c
 	struct flash_stm32_xspi_data *dev_data = dev->data;
 	HAL_StatusTypeDef hal_ret;
 
-	LOG_DBG("Instruction 0x%x", cmd->Instruction);
+	XSPI_LOG_DBG("Instruction 0x%x", cmd->Instruction);
 
 	cmd->DataLength = size;
 
@@ -132,13 +145,13 @@ static int xspi_write_access(const struct device *dev, XSPI_RegularCmdTypeDef *c
 	/* in OPI/STR the 3-byte AddressWidth is not supported by the NOR flash */
 	if ((dev_cfg->data_mode == XSPI_OCTO_MODE) &&
 		(cmd->AddressWidth != HAL_XSPI_ADDRESS_32_BITS)) {
-		LOG_ERR("XSPI wr in OPI/STR mode is for 32bit address only");
+		XSPI_LOG_ERR("XSPI wr in OPI/STR mode is for 32bit address only");
 		return -EIO;
 	}
 
 	hal_ret = HAL_XSPI_Command(&dev_data->hxspi, cmd, HAL_XSPI_TIMEOUT_DEFAULT_VALUE);
 	if (hal_ret != HAL_OK) {
-		LOG_ERR("%d: Failed to send XSPI instruction", hal_ret);
+		XSPI_LOG_ERR("%d: Failed to send XSPI instruction", hal_ret);
 		return -EIO;
 	}
 
@@ -149,7 +162,7 @@ static int xspi_write_access(const struct device *dev, XSPI_RegularCmdTypeDef *c
 #endif
 
 	if (hal_ret != HAL_OK) {
-		LOG_ERR("%d: Failed to write data", hal_ret);
+		XSPI_LOG_ERR("%d: Failed to write data", hal_ret);
 		return -EIO;
 	}
 
@@ -376,14 +389,14 @@ static int stm32_xspi_wait_auto_polling(const struct device *dev,
 	dev_data->cmd_status = 0;
 
 	if (HAL_XSPI_AutoPolling_IT(&dev_data->hxspi, s_config) != HAL_OK) {
-		LOG_ERR("XSPI AutoPoll failed");
+		XSPI_LOG_ERR("XSPI AutoPoll failed");
 		return -EIO;
 	}
 
 	if (k_sem_take(&dev_data->sync, K_MSEC(timeout_ms)) != 0) {
-		LOG_ERR("XSPI AutoPoll wait failed");
+		XSPI_LOG_ERR("XSPI AutoPoll wait failed");
 		if (HAL_XSPI_Abort(&dev_data->hxspi) != HAL_OK) {
-			LOG_ERR("XSPI abort failed");
+			XSPI_LOG_ERR("XSPI abort failed");
 		}
 		k_sem_reset(&dev_data->sync);
 		return -EIO;
@@ -440,7 +453,7 @@ static int stm32_xspi_mem_erased(const struct device *dev)
 
 	if (HAL_XSPI_Command(&dev_data->hxspi, &s_command,
 		HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
-		LOG_ERR("XSPI AutoPoll command (WEL) failed");
+		XSPI_LOG_ERR("XSPI AutoPoll command (WEL) failed");
 		return -EIO;
 	}
 
@@ -490,7 +503,7 @@ static int stm32_xspi_mem_ready(const struct device *dev, uint8_t nor_mode,
 
 	if (HAL_XSPI_Command(&dev_data->hxspi, &s_command,
 		HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
-		LOG_ERR("XSPI AutoPoll command failed");
+		XSPI_LOG_ERR("XSPI AutoPoll command failed");
 		return -EIO;
 	}
 
@@ -521,7 +534,7 @@ static int stm32_xspi_write_enable(const struct device *dev,
 
 	if (HAL_XSPI_Command(&dev_data->hxspi, &s_command,
 		HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
-		LOG_ERR("XSPI flash write enable cmd failed");
+		XSPI_LOG_ERR("XSPI flash write enable cmd failed");
 		return -EIO;
 	}
 
@@ -548,7 +561,7 @@ static int stm32_xspi_write_enable(const struct device *dev,
 
 	if (HAL_XSPI_Command(&dev_data->hxspi, &s_command,
 		HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
-		LOG_ERR("XSPI config auto polling cmd failed");
+		XSPI_LOG_ERR("XSPI config auto polling cmd failed");
 		return -EIO;
 	}
 
@@ -885,7 +898,7 @@ static int stm32_xspi_set_memorymap(const struct device *dev)
 	if ((dev_cfg->data_mode == XSPI_SPI_MODE) &&
 		(stm32_xspi_hal_address_size(dev) == HAL_XSPI_ADDRESS_24_BITS)) {
 		/* OPI mode and 3-bytes address size not supported by memory */
-		LOG_ERR("XSPI_SPI_MODE in 3Bytes addressing is not supported");
+		XSPI_LOG_ERR("XSPI_SPI_MODE in 3Bytes addressing is not supported");
 		return -EIO;
 	}
 
@@ -945,7 +958,7 @@ static int stm32_xspi_set_memorymap(const struct device *dev)
 
 	ret = HAL_XSPI_Command(&dev_data->hxspi, &s_command, HAL_XSPI_TIMEOUT_DEFAULT_VALUE);
 	if (ret != HAL_OK) {
-		LOG_ERR("%d: Failed to set memory map", ret);
+		XSPI_LOG_ERR("%d: Failed to set memory map", ret);
 		return -EIO;
 	}
 
@@ -965,7 +978,7 @@ static int stm32_xspi_set_memorymap(const struct device *dev)
 
 	ret = HAL_XSPI_Command(&dev_data->hxspi, &s_command, HAL_XSPI_TIMEOUT_DEFAULT_VALUE);
 	if (ret != HAL_OK) {
-		LOG_ERR("%d: Failed to set memory mapped", ret);
+		XSPI_LOG_ERR("%d: Failed to set memory mapped", ret);
 		return -EIO;
 	}
 
@@ -981,11 +994,11 @@ static int stm32_xspi_set_memorymap(const struct device *dev)
 
 	ret = HAL_XSPI_MemoryMapped(&dev_data->hxspi, &s_MemMappedCfg);
 	if (ret != HAL_OK) {
-		LOG_ERR("%d: Failed to enable memory mapped", ret);
+		XSPI_LOG_ERR("%d: Failed to enable memory mapped", ret);
 		return -EIO;
 	}
 
-	LOG_DBG("MemoryMap mode enabled");
+	XSPI_LOG_DBG("MemoryMap mode enabled");
 	return 0;
 }
 #endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
@@ -995,7 +1008,7 @@ static int stm32_xspi_abort(const struct device *dev)
 	struct flash_stm32_xspi_data *dev_data = dev->data;
 
 	if (HAL_XSPI_Abort(&dev_data->hxspi) != HAL_OK) {
-		LOG_ERR("XSPI abort failed");
+		XSPI_LOG_ERR("XSPI abort failed");
 		return -EIO;
 	}
 
@@ -1069,7 +1082,7 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 		/* Abort ongoing transfer to force CS high/BUSY deasserted */
 		ret = stm32_xspi_abort(dev);
 		if (ret != 0) {
-			LOG_ERR("Failed to abort memory-mapped access before erase");
+			XSPI_LOG_ERR("Failed to abort memory-mapped access before erase");
 			goto erase_end;
 		}
 	}
@@ -1088,7 +1101,7 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 
 	if (stm32_xspi_mem_ready(dev,
 		dev_cfg->data_mode, dev_cfg->data_rate) != 0) {
-		LOG_ERR("Erase failed : flash busy");
+		XSPI_LOG_ERR("Erase failed : flash busy");
 		goto erase_end;
 	}
 
@@ -1107,13 +1120,13 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 		ret = stm32_xspi_write_enable(dev,
 			dev_cfg->data_mode, dev_cfg->data_rate);
 		if (ret != 0) {
-			LOG_ERR("Erase failed : write enable");
+			XSPI_LOG_ERR("Erase failed : write enable");
 			break;
 		}
 
 		if (size == dev_cfg->flash_size) {
 			/* Chip erase */
-			LOG_DBG("Chip Erase");
+			XSPI_LOG_DBG("Chip Erase");
 
 			cmd_erase.Address = 0;
 			cmd_erase.Instruction = (dev_cfg->data_mode == XSPI_OCTO_MODE)
@@ -1127,12 +1140,12 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 			/* Chip (Bulk) erase started, wait until WEL becomes 0 */
 			ret = stm32_xspi_mem_erased(dev);
 			if (ret != 0) {
-				LOG_ERR("Chip Erase failed");
+				XSPI_LOG_ERR("Chip Erase failed");
 				break;
 			}
 		} else {
 			/* Sector or Block erase depending on the size */
-			LOG_DBG("Sector/Block Erase");
+			XSPI_LOG_DBG("Sector/Block Erase");
 
 			cmd_erase.AddressMode =
 				(dev_cfg->data_mode == XSPI_OCTO_MODE)
@@ -1178,9 +1191,10 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 				 */
 				bet = NULL;
 			}
-			LOG_DBG("Sector/Block Erase addr 0x%x, asize 0x%x amode 0x%x  instr 0x%x",
-				cmd_erase.Address, cmd_erase.AddressWidth,
-				cmd_erase.AddressMode, cmd_erase.Instruction);
+			XSPI_LOG_DBG("Sector/Block Erase addr 0x%x, asize 0x%x "
+				     "amode 0x%x instr 0x%x",
+				     cmd_erase.Address, cmd_erase.AddressWidth,
+				     cmd_erase.AddressMode, cmd_erase.Instruction);
 
 			xspi_send_cmd(dev, &cmd_erase);
 
@@ -1362,7 +1376,7 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 		/* Abort ongoing transfer to force CS high/BUSY deasserted */
 		ret = stm32_xspi_abort(dev);
 		if (ret != 0) {
-			LOG_ERR("Failed to abort memory-mapped access before write");
+			XSPI_LOG_ERR("Failed to abort memory-mapped access before write");
 			goto write_end;
 		}
 	}
@@ -1413,14 +1427,14 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 	cmd_pp.AddressWidth = stm32_xspi_hal_address_size(dev);
 	cmd_pp.DummyCycles = 0U;
 
-	LOG_DBG("XSPI: write %zu data at 0x%lx",
+	XSPI_LOG_DBG("XSPI: write %zu data at 0x%lx",
 		size,
 		(long)(dev_cfg->mem_map_based_address + addr));
 
 	ret = stm32_xspi_mem_ready(dev,
 				   dev_cfg->data_mode, dev_cfg->data_rate);
 	if (ret != 0) {
-		LOG_ERR("XSPI: write not ready");
+		XSPI_LOG_ERR("XSPI: write not ready");
 		goto write_end;
 	}
 
@@ -1429,7 +1443,7 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 		ret = stm32_xspi_write_enable(dev,
 					      dev_cfg->data_mode, dev_cfg->data_rate);
 		if (ret != 0) {
-			LOG_ERR("XSPI: write not enabled");
+			XSPI_LOG_ERR("XSPI: write not enabled");
 			break;
 		}
 		/* Don't write more than a page. */
@@ -1447,7 +1461,7 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 
 		ret = xspi_write_access(dev, &cmd_pp, data, to_write);
 		if (ret != 0) {
-			LOG_ERR("XSPI: write not access");
+			XSPI_LOG_ERR("XSPI: write not access");
 			break;
 		}
 
@@ -1459,7 +1473,7 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 		ret = stm32_xspi_mem_ready(dev,
 						 dev_cfg->data_mode, dev_cfg->data_rate);
 		if (ret != 0) {
-			LOG_ERR("XSPI: write PP not ready");
+			XSPI_LOG_ERR("XSPI: write PP not ready");
 			break;
 		}
 	}

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -10,6 +10,32 @@
  * This driver is based on the stm32Cube HAL XSPI driver
  * with one xspi DTS NODE
  * **************************************************************************
+ *
+ * CRITICAL CONSTRAINT: Avoid Flash Access in XIP Critical Path
+ * **************************************************************************
+ *
+ * When CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION is enabled, driver code may
+ * execute from RAM while the external XSPI flash is NOT in memory-mapped
+ * mode. During these critical sections, the code MUST NOT access flash
+ * memory to read driver data or configuration structures.
+ *
+ * Code Patterns to Maintain this Constraint:
+ *
+ * 1. FETCH CONFIG VALUES BEFORE THE CRITICAL PATH:
+ *    - Read dev_cfg, dev_data, mode, rate before entering critical section
+ *    - Pass them as function parameters; do not pass dev and dereference inside
+ *    - Example: stm32_xspi_mem_ready(dev_data, mode, rate)
+ *              NOT stm32_xspi_mem_ready(dev, mode, rate)
+ *
+ * 2. AVOID IMPLICIT STRUCTURE INITIALIZATION:
+ *    - Initialize every structure field explicitly in the critical path.
+ *    - Do not use aggregate initializers that may generate implicit memset
+ *      calls accessing flash memory.
+ *
+ * 3. SUPPRESS LOGGING in XIP_RELOCATE mode to avoid any unintended flash access
+ *
+ * DO NOT modify these patterns without ensuring no flash accesses occur
+ * during code execution from RAM in the critical path.
  */
 #define DT_DRV_COMPAT st_stm32_xspi_nor
 
@@ -62,6 +88,17 @@ LOG_MODULE_REGISTER(flash_stm32_xspi, CONFIG_FLASH_LOG_LEVEL);
 
 #include "flash_stm32_xspi.h"
 
+static void stm32_xspi_bzero(void *destination, size_t size)
+{
+	volatile uint8_t *destination_ptr = destination;
+
+	while (size > 0U) {
+		*destination_ptr = 0U;
+		destination_ptr++;
+		size--;
+	}
+}
+
 static inline void xspi_lock_thread(const struct device *dev)
 {
 	struct flash_stm32_xspi_data *dev_data = dev->data;
@@ -76,9 +113,9 @@ static inline void xspi_unlock_thread(const struct device *dev)
 	k_sem_give(&dev_data->sem);
 }
 
-static int xspi_send_cmd(const struct device *dev, XSPI_RegularCmdTypeDef *cmd)
+static int xspi_send_cmd(struct flash_stm32_xspi_data *dev_data,
+			 XSPI_RegularCmdTypeDef *cmd)
 {
-	struct flash_stm32_xspi_data *dev_data = dev->data;
 	HAL_StatusTypeDef hal_ret;
 
 	XSPI_LOG_DBG("Instruction 0x%x", cmd->Instruction);
@@ -129,21 +166,20 @@ static int xspi_read_access(const struct device *dev, XSPI_RegularCmdTypeDef *cm
 	return dev_data->cmd_status;
 }
 
-static int xspi_write_access(const struct device *dev, XSPI_RegularCmdTypeDef *cmd,
+static int xspi_write_access(struct flash_stm32_xspi_data *dev_data,
+			     uint8_t data_mode,
+			     XSPI_RegularCmdTypeDef *cmd,
 			     const uint8_t *data, const size_t size)
 {
-	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
-	struct flash_stm32_xspi_data *dev_data = dev->data;
 	HAL_StatusTypeDef hal_ret;
 
 	XSPI_LOG_DBG("Instruction 0x%x", cmd->Instruction);
 
 	cmd->DataLength = size;
-
 	dev_data->cmd_status = 0;
 
 	/* in OPI/STR the 3-byte AddressWidth is not supported by the NOR flash */
-	if ((dev_cfg->data_mode == XSPI_OCTO_MODE) &&
+	if ((data_mode == XSPI_OCTO_MODE) &&
 		(cmd->AddressWidth != HAL_XSPI_ADDRESS_32_BITS)) {
 		XSPI_LOG_ERR("XSPI wr in OPI/STR mode is for 32bit address only");
 		return -EIO;
@@ -175,68 +211,66 @@ static int xspi_write_access(const struct device *dev, XSPI_RegularCmdTypeDef *c
  * Gives a XSPI_RegularCmdTypeDef with all parameters set
  * except Instruction, Address, DummyCycles, NbData
  */
-static XSPI_RegularCmdTypeDef xspi_prepare_cmd(const uint8_t transfer_mode,
-					       const uint8_t transfer_rate)
+static void xspi_prepare_cmd(XSPI_RegularCmdTypeDef *cmd_tmp,
+				 const uint8_t transfer_mode,
+				 const uint8_t transfer_rate)
 {
-	XSPI_RegularCmdTypeDef cmd_tmp = {
-		.OperationType = HAL_XSPI_OPTYPE_COMMON_CFG,
-		.InstructionWidth = ((transfer_mode == XSPI_OCTO_MODE)
-				? HAL_XSPI_INSTRUCTION_16_BITS
-				: HAL_XSPI_INSTRUCTION_8_BITS),
-		.InstructionDTRMode = ((transfer_rate == XSPI_DTR_TRANSFER)
-				? HAL_XSPI_INSTRUCTION_DTR_ENABLE
-				: HAL_XSPI_INSTRUCTION_DTR_DISABLE),
-		.AddressDTRMode = ((transfer_rate == XSPI_DTR_TRANSFER)
-				? HAL_XSPI_ADDRESS_DTR_ENABLE
-				: HAL_XSPI_ADDRESS_DTR_DISABLE),
-		/* AddressWidth must be set to 32bits for init and mem config phase */
-		.AddressWidth = HAL_XSPI_ADDRESS_32_BITS,
-		.AlternateBytesMode = HAL_XSPI_ALT_BYTES_NONE,
-		.DataDTRMode = ((transfer_rate == XSPI_DTR_TRANSFER)
-				? HAL_XSPI_DATA_DTR_ENABLE
-				: HAL_XSPI_DATA_DTR_DISABLE),
-		.DQSMode = (transfer_rate == XSPI_DTR_TRANSFER)
-				? HAL_XSPI_DQS_ENABLE
-				: HAL_XSPI_DQS_DISABLE,
+	stm32_xspi_bzero(cmd_tmp, sizeof(*cmd_tmp));
+
+	cmd_tmp->OperationType = HAL_XSPI_OPTYPE_COMMON_CFG;
+	cmd_tmp->InstructionWidth = ((transfer_mode == XSPI_OCTO_MODE)
+			? HAL_XSPI_INSTRUCTION_16_BITS
+			: HAL_XSPI_INSTRUCTION_8_BITS);
+	cmd_tmp->InstructionDTRMode = ((transfer_rate == XSPI_DTR_TRANSFER)
+			? HAL_XSPI_INSTRUCTION_DTR_ENABLE
+			: HAL_XSPI_INSTRUCTION_DTR_DISABLE);
+	cmd_tmp->AddressDTRMode = ((transfer_rate == XSPI_DTR_TRANSFER)
+			? HAL_XSPI_ADDRESS_DTR_ENABLE
+			: HAL_XSPI_ADDRESS_DTR_DISABLE);
+	/* AddressWidth must be set to 32bits for init and mem config phase */
+	cmd_tmp->AddressWidth = HAL_XSPI_ADDRESS_32_BITS;
+	cmd_tmp->AlternateBytesMode = HAL_XSPI_ALT_BYTES_NONE;
+	cmd_tmp->DataDTRMode = ((transfer_rate == XSPI_DTR_TRANSFER)
+			? HAL_XSPI_DATA_DTR_ENABLE
+			: HAL_XSPI_DATA_DTR_DISABLE);
+	cmd_tmp->DQSMode = (transfer_rate == XSPI_DTR_TRANSFER)
+			? HAL_XSPI_DQS_ENABLE
+			: HAL_XSPI_DQS_DISABLE;
 #ifdef XSPI_CCR_SIOO
-		.SIOOMode = HAL_XSPI_SIOO_INST_EVERY_CMD,
+	cmd_tmp->SIOOMode = HAL_XSPI_SIOO_INST_EVERY_CMD;
 #endif /* XSPI_CCR_SIOO */
-	};
 
 	switch (transfer_mode) {
 	case XSPI_OCTO_MODE: {
-		cmd_tmp.InstructionMode = HAL_XSPI_INSTRUCTION_8_LINES;
-		cmd_tmp.AddressMode = HAL_XSPI_ADDRESS_8_LINES;
-		cmd_tmp.DataMode = HAL_XSPI_DATA_8_LINES;
+		cmd_tmp->InstructionMode = HAL_XSPI_INSTRUCTION_8_LINES;
+		cmd_tmp->AddressMode = HAL_XSPI_ADDRESS_8_LINES;
+		cmd_tmp->DataMode = HAL_XSPI_DATA_8_LINES;
 		break;
 	}
 	case XSPI_QUAD_MODE: {
-		cmd_tmp.InstructionMode = HAL_XSPI_INSTRUCTION_4_LINES;
-		cmd_tmp.AddressMode = HAL_XSPI_ADDRESS_4_LINES;
-		cmd_tmp.DataMode = HAL_XSPI_DATA_4_LINES;
+		cmd_tmp->InstructionMode = HAL_XSPI_INSTRUCTION_4_LINES;
+		cmd_tmp->AddressMode = HAL_XSPI_ADDRESS_4_LINES;
+		cmd_tmp->DataMode = HAL_XSPI_DATA_4_LINES;
 		break;
 	}
 	case XSPI_DUAL_MODE: {
-		cmd_tmp.InstructionMode = HAL_XSPI_INSTRUCTION_2_LINES;
-		cmd_tmp.AddressMode = HAL_XSPI_ADDRESS_2_LINES;
-		cmd_tmp.DataMode = HAL_XSPI_DATA_2_LINES;
+		cmd_tmp->InstructionMode = HAL_XSPI_INSTRUCTION_2_LINES;
+		cmd_tmp->AddressMode = HAL_XSPI_ADDRESS_2_LINES;
+		cmd_tmp->DataMode = HAL_XSPI_DATA_2_LINES;
 		break;
 	}
 	default: {
-		cmd_tmp.InstructionMode = HAL_XSPI_INSTRUCTION_1_LINE;
-		cmd_tmp.AddressMode = HAL_XSPI_ADDRESS_1_LINE;
-		cmd_tmp.DataMode = HAL_XSPI_DATA_1_LINE;
+		cmd_tmp->InstructionMode = HAL_XSPI_INSTRUCTION_1_LINE;
+		cmd_tmp->AddressMode = HAL_XSPI_ADDRESS_1_LINE;
+		cmd_tmp->DataMode = HAL_XSPI_DATA_1_LINE;
 		break;
 	}
 	}
 
-	return cmd_tmp;
 }
 
-static uint32_t stm32_xspi_hal_address_size(const struct device *dev)
+static uint32_t stm32_xspi_hal_address_size(const struct flash_stm32_xspi_data *dev_data)
 {
-	struct flash_stm32_xspi_data *dev_data = dev->data;
-
 	if (dev_data->address_width == 4U) {
 		return HAL_XSPI_ADDRESS_32_BITS;
 	}
@@ -255,10 +289,12 @@ static int stm32_xspi_read_jedec_id(const struct device *dev)
 	struct flash_stm32_xspi_data *dev_data = dev->data;
 
 	/* This is a SPI/STR command to issue to the external Flash device */
-	XSPI_RegularCmdTypeDef cmd = xspi_prepare_cmd(XSPI_SPI_MODE, XSPI_STR_TRANSFER);
+	XSPI_RegularCmdTypeDef cmd;
+
+	xspi_prepare_cmd(&cmd, XSPI_SPI_MODE, XSPI_STR_TRANSFER);
 
 	cmd.Instruction = JESD216_CMD_READ_ID;
-	cmd.AddressWidth = stm32_xspi_hal_address_size(dev);
+	cmd.AddressWidth = stm32_xspi_hal_address_size(dev_data);
 	cmd.AddressMode = HAL_XSPI_ADDRESS_NONE;
 	cmd.DataLength = JESD216_READ_ID_LEN; /* 3 bytes in the READ ID */
 
@@ -317,9 +353,10 @@ static int stm32_xspi_read_sfdp(const struct device *dev, off_t addr,
 {
 	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
 	struct flash_stm32_xspi_data *dev_data = dev->data;
+	XSPI_RegularCmdTypeDef cmd;
 
-	XSPI_RegularCmdTypeDef cmd = xspi_prepare_cmd(dev_cfg->data_mode,
-						      dev_cfg->data_rate);
+	xspi_prepare_cmd(&cmd, dev_cfg->data_mode, dev_cfg->data_rate);
+
 	if (dev_cfg->data_mode == XSPI_OCTO_MODE) {
 		cmd.Instruction = JESD216_OCMD_READ_SFDP;
 		cmd.DummyCycles = 20U;
@@ -381,11 +418,9 @@ static bool xspi_address_is_valid(const struct device *dev, off_t addr,
 	return (addr >= 0) && ((uint64_t)addr + (uint64_t)size <= flash_size);
 }
 
-static int stm32_xspi_wait_auto_polling(const struct device *dev,
+static int stm32_xspi_wait_auto_polling(struct flash_stm32_xspi_data *dev_data,
 		XSPI_AutoPollingTypeDef *s_config, uint32_t timeout_ms)
 {
-	struct flash_stm32_xspi_data *dev_data = dev->data;
-
 	dev_data->cmd_status = 0;
 
 	if (HAL_XSPI_AutoPolling_IT(&dev_data->hxspi, s_config) != HAL_OK) {
@@ -414,15 +449,14 @@ static int stm32_xspi_wait_auto_polling(const struct device *dev,
  * in nor_mode SPI/OPI XSPI_SPI_MODE or XSPI_OCTO_MODE
  * and nor_rate transfer STR/DTR XSPI_STR_TRANSFER or XSPI_DTR_TRANSFER
  */
-static int stm32_xspi_mem_erased(const struct device *dev)
+static int stm32_xspi_mem_erased(struct flash_stm32_xspi_data *dev_data,
+		uint8_t nor_mode, uint8_t nor_rate)
 {
-	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
-	struct flash_stm32_xspi_data *dev_data = dev->data;
-	uint8_t nor_mode = dev_cfg->data_mode;
-	uint8_t nor_rate = dev_cfg->data_rate;
+	XSPI_AutoPollingTypeDef s_config;
+	XSPI_RegularCmdTypeDef s_command;
 
-	XSPI_AutoPollingTypeDef s_config = {0};
-	XSPI_RegularCmdTypeDef s_command = xspi_prepare_cmd(nor_mode, nor_rate);
+	stm32_xspi_bzero(&s_config, sizeof(s_config));
+	xspi_prepare_cmd(&s_command, nor_mode, nor_rate);
 
 	/* Configure automatic polling mode command to wait for memory ready */
 	if (nor_mode == XSPI_OCTO_MODE) {
@@ -458,7 +492,7 @@ static int stm32_xspi_mem_erased(const struct device *dev)
 	}
 
 	/* Start Automatic-Polling mode to wait until the memory is totally erased */
-	return stm32_xspi_wait_auto_polling(dev,
+	return stm32_xspi_wait_auto_polling(dev_data,
 			&s_config, STM32_XSPI_BULK_ERASE_MAX_TIME);
 }
 
@@ -467,13 +501,14 @@ static int stm32_xspi_mem_erased(const struct device *dev)
  * in nor_mode SPI/OPI XSPI_SPI_MODE or XSPI_OCTO_MODE
  * and nor_rate transfer STR/DTR XSPI_STR_TRANSFER or XSPI_DTR_TRANSFER
  */
-static int stm32_xspi_mem_ready(const struct device *dev, uint8_t nor_mode,
-		uint8_t nor_rate)
+static int stm32_xspi_mem_ready(struct flash_stm32_xspi_data *dev_data,
+		uint8_t nor_mode, uint8_t nor_rate)
 {
-	struct flash_stm32_xspi_data *dev_data = dev->data;
+	XSPI_AutoPollingTypeDef s_config;
+	XSPI_RegularCmdTypeDef s_command;
 
-	XSPI_AutoPollingTypeDef s_config = {0};
-	XSPI_RegularCmdTypeDef s_command = xspi_prepare_cmd(nor_mode, nor_rate);
+	stm32_xspi_bzero(&s_config, sizeof(s_config));
+	xspi_prepare_cmd(&s_command, nor_mode, nor_rate);
 
 	/* Configure automatic polling mode command to wait for memory ready */
 	if (nor_mode == XSPI_OCTO_MODE) {
@@ -508,17 +543,18 @@ static int stm32_xspi_mem_ready(const struct device *dev, uint8_t nor_mode,
 	}
 
 	/* Start Automatic-Polling mode to wait until the memory is ready WIP=0 */
-	return stm32_xspi_wait_auto_polling(dev, &s_config, HAL_XSPI_TIMEOUT_DEFAULT_VALUE);
+	return stm32_xspi_wait_auto_polling(dev_data, &s_config, HAL_XSPI_TIMEOUT_DEFAULT_VALUE);
 }
 
 /* Enables writing to the memory sending a Write Enable and wait it is effective */
-static int stm32_xspi_write_enable(const struct device *dev,
+static int stm32_xspi_write_enable(struct flash_stm32_xspi_data *dev_data,
 		uint8_t nor_mode, uint8_t nor_rate)
 {
-	struct flash_stm32_xspi_data *dev_data = dev->data;
+	XSPI_AutoPollingTypeDef s_config;
+	XSPI_RegularCmdTypeDef s_command;
 
-	XSPI_AutoPollingTypeDef s_config = {0};
-	XSPI_RegularCmdTypeDef s_command = xspi_prepare_cmd(nor_mode, nor_rate);
+	stm32_xspi_bzero(&s_config, sizeof(s_config));
+	xspi_prepare_cmd(&s_command, nor_mode, nor_rate);
 
 	/* Initialize the write enable command */
 	if (nor_mode == XSPI_OCTO_MODE) {
@@ -571,37 +607,43 @@ static int stm32_xspi_write_enable(const struct device *dev,
 	s_config.IntervalTime    = SPI_NOR_AUTO_POLLING_INTERVAL;
 	s_config.AutomaticStop   = HAL_XSPI_AUTOMATIC_STOP_ENABLE;
 
-	return stm32_xspi_wait_auto_polling(dev, &s_config, HAL_XSPI_TIMEOUT_DEFAULT_VALUE);
+	return stm32_xspi_wait_auto_polling(dev_data, &s_config, HAL_XSPI_TIMEOUT_DEFAULT_VALUE);
 }
 
 static int xspi_write_unprotect(const struct device *dev)
 {
 	int ret = 0;
+	struct flash_stm32_xspi_data *dev_data = dev->data;
 
 	/* This is a SPI/STR command to issue to the external Flash device */
-	XSPI_RegularCmdTypeDef cmd_unprotect = xspi_prepare_cmd(XSPI_SPI_MODE, XSPI_STR_TRANSFER);
+	XSPI_RegularCmdTypeDef cmd_unprotect;
+
+	xspi_prepare_cmd(&cmd_unprotect, XSPI_SPI_MODE, XSPI_STR_TRANSFER);
 
 	cmd_unprotect.Instruction = SPI_NOR_CMD_ULBPR;
 	cmd_unprotect.InstructionMode = HAL_XSPI_INSTRUCTION_1_LINE;
 	cmd_unprotect.AddressMode = HAL_XSPI_ADDRESS_NONE;
 	cmd_unprotect.DataMode    = HAL_XSPI_DATA_NONE;
 
-	ret = stm32_xspi_write_enable(dev, XSPI_SPI_MODE, XSPI_STR_TRANSFER);
+	ret = stm32_xspi_write_enable(dev_data, XSPI_SPI_MODE, XSPI_STR_TRANSFER);
 	if (ret != 0) {
 		return ret;
 	}
 
-	return xspi_send_cmd(dev, &cmd_unprotect);
+	return xspi_send_cmd(dev_data, &cmd_unprotect);
 }
 
 /* Write Flash configuration register 2 with new dummy cycles */
 static int stm32_xspi_write_cfg2reg_dummy(const struct device *dev,
 					uint8_t nor_mode, uint8_t nor_rate)
 {
-	XSPI_RegularCmdTypeDef s_command = xspi_prepare_cmd(nor_mode, nor_rate);
 	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
 	struct flash_stm32_xspi_data *dev_data = dev->data;
 	uint8_t transmit_data;
+
+	XSPI_RegularCmdTypeDef s_command;
+
+	xspi_prepare_cmd(&s_command, nor_mode, nor_rate);
 
 	if (dev_cfg->max_frequency == MHZ(200)) {
 		/* Use memory default value */
@@ -638,7 +680,9 @@ static int stm32_xspi_write_cfg2reg_dummy(const struct device *dev,
 static int stm32_xspi_write_cfg2reg_io(XSPI_HandleTypeDef *hxspi,
 				       uint8_t nor_mode, uint8_t nor_rate, uint8_t op_enable)
 {
-	XSPI_RegularCmdTypeDef s_command = xspi_prepare_cmd(nor_mode, nor_rate);
+	XSPI_RegularCmdTypeDef s_command;
+
+	xspi_prepare_cmd(&s_command, nor_mode, nor_rate);
 
 	/* Initialize the writing of configuration register 2 */
 	s_command.Instruction = (nor_mode == XSPI_SPI_MODE)
@@ -668,7 +712,9 @@ static int stm32_xspi_write_cfg2reg_io(XSPI_HandleTypeDef *hxspi,
 static int stm32_xspi_read_cfg2reg(XSPI_HandleTypeDef *hxspi,
 				   uint8_t nor_mode, uint8_t nor_rate, uint8_t *value)
 {
-	XSPI_RegularCmdTypeDef s_command = xspi_prepare_cmd(nor_mode, nor_rate);
+	XSPI_RegularCmdTypeDef s_command;
+
+	xspi_prepare_cmd(&s_command, nor_mode, nor_rate);
 
 	/* Initialize the writing of configuration register 2 */
 	s_command.Instruction = (nor_mode == XSPI_SPI_MODE)
@@ -712,7 +758,7 @@ static int stm32_xspi_config_mem(const struct device *dev)
 	/* Going to set the XPI mode (STR or DTR transfer rate) */
 	LOG_DBG("XSPI configuring Octo SPI mode");
 
-	if (stm32_xspi_write_enable(dev,
+	if (stm32_xspi_write_enable(dev_data,
 		XSPI_SPI_MODE, XSPI_STR_TRANSFER) != 0) {
 		LOG_ERR("OSPI write Enable failed");
 		return -EIO;
@@ -724,12 +770,12 @@ static int stm32_xspi_config_mem(const struct device *dev)
 		LOG_ERR("XSPI write CFGR2 failed");
 		return -EIO;
 	}
-	if (stm32_xspi_mem_ready(dev,
+	if (stm32_xspi_mem_ready(dev_data,
 		XSPI_SPI_MODE, XSPI_STR_TRANSFER) != 0) {
 		LOG_ERR("XSPI autopolling failed");
 		return -EIO;
 	}
-	if (stm32_xspi_write_enable(dev,
+	if (stm32_xspi_write_enable(dev_data,
 		XSPI_SPI_MODE, XSPI_STR_TRANSFER) != 0) {
 		LOG_ERR("XSPI write Enable 2 failed");
 		return -EIO;
@@ -757,7 +803,7 @@ static int stm32_xspi_config_mem(const struct device *dev)
 	}
 
 	if (dev_cfg->data_rate == XSPI_STR_TRANSFER) {
-		if (stm32_xspi_mem_ready(dev,
+		if (stm32_xspi_mem_ready(dev_data,
 			XSPI_OCTO_MODE, XSPI_STR_TRANSFER) != 0) {
 			/* Check Flash busy ? */
 			LOG_ERR("XSPI flash busy failed");
@@ -775,7 +821,7 @@ static int stm32_xspi_config_mem(const struct device *dev)
 	}
 
 	if (dev_cfg->data_rate == XSPI_DTR_TRANSFER) {
-		if (stm32_xspi_mem_ready(dev,
+		if (stm32_xspi_mem_ready(dev_data,
 			XSPI_OCTO_MODE, XSPI_DTR_TRANSFER) != 0) {
 			/* Check Flash busy ? */
 			LOG_ERR("XSPI flash busy failed");
@@ -886,17 +932,20 @@ static int stm32_xspi_mem_reset(const struct device *dev)
 
 #if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
 /* Function to configure the octoflash in MemoryMapped mode */
-static int stm32_xspi_set_memorymap(const struct device *dev)
+static int stm32_xspi_set_memorymap(struct flash_stm32_xspi_data *dev_data,
+				    uint8_t data_mode,
+				    uint8_t data_rate)
 {
 	HAL_StatusTypeDef ret;
-	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
-	struct flash_stm32_xspi_data *dev_data = dev->data;
-	XSPI_RegularCmdTypeDef s_command = {0}; /* Non-zero values disturb the command */
-	XSPI_MemoryMappedTypeDef s_MemMappedCfg = {0};
+	XSPI_RegularCmdTypeDef s_command;
+	XSPI_MemoryMappedTypeDef s_MemMappedCfg;
+
+	stm32_xspi_bzero(&s_command, sizeof(s_command));
+	stm32_xspi_bzero(&s_MemMappedCfg, sizeof(s_MemMappedCfg));
 
 	/* Configure octoflash in MemoryMapped mode */
-	if ((dev_cfg->data_mode == XSPI_SPI_MODE) &&
-		(stm32_xspi_hal_address_size(dev) == HAL_XSPI_ADDRESS_24_BITS)) {
+	if ((data_mode == XSPI_SPI_MODE) &&
+		(stm32_xspi_hal_address_size(dev_data) == HAL_XSPI_ADDRESS_24_BITS)) {
 		/* OPI mode and 3-bytes address size not supported by memory */
 		XSPI_LOG_ERR("XSPI_SPI_MODE in 3Bytes addressing is not supported");
 		return -EIO;
@@ -904,52 +953,52 @@ static int stm32_xspi_set_memorymap(const struct device *dev)
 
 	/* Initialize the read command */
 	s_command.OperationType = HAL_XSPI_OPTYPE_READ_CFG;
-	s_command.InstructionMode = (dev_cfg->data_rate == XSPI_STR_TRANSFER)
-				? ((dev_cfg->data_mode == XSPI_SPI_MODE)
+	s_command.InstructionMode = (data_rate == XSPI_STR_TRANSFER)
+				? ((data_mode == XSPI_SPI_MODE)
 					? HAL_XSPI_INSTRUCTION_1_LINE
 					: HAL_XSPI_INSTRUCTION_8_LINES)
 				: HAL_XSPI_INSTRUCTION_8_LINES;
-	s_command.InstructionDTRMode = (dev_cfg->data_rate == XSPI_STR_TRANSFER)
+	s_command.InstructionDTRMode = (data_rate == XSPI_STR_TRANSFER)
 				? HAL_XSPI_INSTRUCTION_DTR_DISABLE
 				: HAL_XSPI_INSTRUCTION_DTR_ENABLE;
-	s_command.InstructionWidth = (dev_cfg->data_rate == XSPI_STR_TRANSFER)
-				? ((dev_cfg->data_mode == XSPI_SPI_MODE)
+	s_command.InstructionWidth = (data_rate == XSPI_STR_TRANSFER)
+				? ((data_mode == XSPI_SPI_MODE)
 					? HAL_XSPI_INSTRUCTION_8_BITS
 					: HAL_XSPI_INSTRUCTION_16_BITS)
 				: HAL_XSPI_INSTRUCTION_16_BITS;
-	s_command.Instruction = (dev_cfg->data_rate == XSPI_STR_TRANSFER)
-				? ((dev_cfg->data_mode == XSPI_SPI_MODE)
-					? ((stm32_xspi_hal_address_size(dev) ==
+	s_command.Instruction = (data_rate == XSPI_STR_TRANSFER)
+				? ((data_mode == XSPI_SPI_MODE)
+					? ((stm32_xspi_hal_address_size(dev_data) ==
 					HAL_XSPI_ADDRESS_24_BITS)
 						? SPI_NOR_CMD_READ_FAST
 						: SPI_NOR_CMD_READ_FAST_4B)
 					: dev_data->read_opcode)
 				: SPI_NOR_OCMD_DTR_RD;
-	s_command.AddressMode = (dev_cfg->data_rate == XSPI_STR_TRANSFER)
-				? ((dev_cfg->data_mode == XSPI_SPI_MODE)
+	s_command.AddressMode = (data_rate == XSPI_STR_TRANSFER)
+				? ((data_mode == XSPI_SPI_MODE)
 					? HAL_XSPI_ADDRESS_1_LINE
 					: HAL_XSPI_ADDRESS_8_LINES)
 				: HAL_XSPI_ADDRESS_8_LINES;
-	s_command.AddressDTRMode = (dev_cfg->data_rate == XSPI_STR_TRANSFER)
+	s_command.AddressDTRMode = (data_rate == XSPI_STR_TRANSFER)
 				? HAL_XSPI_ADDRESS_DTR_DISABLE
 				: HAL_XSPI_ADDRESS_DTR_ENABLE;
-	s_command.AddressWidth = (dev_cfg->data_rate == XSPI_STR_TRANSFER)
-				? stm32_xspi_hal_address_size(dev)
+	s_command.AddressWidth = (data_rate == XSPI_STR_TRANSFER)
+				? stm32_xspi_hal_address_size(dev_data)
 				: HAL_XSPI_ADDRESS_32_BITS;
-	s_command.DataMode = (dev_cfg->data_rate == XSPI_STR_TRANSFER)
-				? ((dev_cfg->data_mode == XSPI_SPI_MODE)
+	s_command.DataMode = (data_rate == XSPI_STR_TRANSFER)
+				? ((data_mode == XSPI_SPI_MODE)
 					? HAL_XSPI_DATA_1_LINE
 					: HAL_XSPI_DATA_8_LINES)
 				: HAL_XSPI_DATA_8_LINES;
-	s_command.DataDTRMode = (dev_cfg->data_rate == XSPI_STR_TRANSFER)
+	s_command.DataDTRMode = (data_rate == XSPI_STR_TRANSFER)
 				? HAL_XSPI_DATA_DTR_DISABLE
 				: HAL_XSPI_DATA_DTR_ENABLE;
-	s_command.DummyCycles = (dev_cfg->data_rate == XSPI_STR_TRANSFER)
-				? ((dev_cfg->data_mode == XSPI_SPI_MODE)
+	s_command.DummyCycles = (data_rate == XSPI_STR_TRANSFER)
+				? ((data_mode == XSPI_SPI_MODE)
 					? SPI_NOR_DUMMY_RD
 					: SPI_NOR_DUMMY_RD_OCTAL)
 				: SPI_NOR_DUMMY_RD_OCTAL_DTR;
-	s_command.DQSMode = (dev_cfg->data_rate == XSPI_STR_TRANSFER)
+	s_command.DQSMode = (data_rate == XSPI_STR_TRANSFER)
 				? HAL_XSPI_DQS_DISABLE
 				: HAL_XSPI_DQS_ENABLE;
 #ifdef XSPI_CCR_SIOO
@@ -964,9 +1013,9 @@ static int stm32_xspi_set_memorymap(const struct device *dev)
 
 	/* Initialize the program command */
 	s_command.OperationType = HAL_XSPI_OPTYPE_WRITE_CFG;
-	if (dev_cfg->data_rate == XSPI_STR_TRANSFER) {
-		s_command.Instruction = (dev_cfg->data_mode == XSPI_SPI_MODE)
-					? ((stm32_xspi_hal_address_size(dev) ==
+	if (data_rate == XSPI_STR_TRANSFER) {
+		s_command.Instruction = (data_mode == XSPI_SPI_MODE)
+					? ((stm32_xspi_hal_address_size(dev_data) ==
 					HAL_XSPI_ADDRESS_24_BITS)
 						? SPI_NOR_CMD_PP
 						: SPI_NOR_CMD_PP_4B)
@@ -1016,10 +1065,8 @@ static int stm32_xspi_abort(const struct device *dev)
 }
 
 /* Function to return true if the octoflash is in MemoryMapped else false */
-static bool stm32_xspi_is_memorymap(const struct device *dev)
+static bool stm32_xspi_is_memorymap(struct flash_stm32_xspi_data *dev_data)
 {
-	struct flash_stm32_xspi_data *dev_data = dev->data;
-
 	return stm32_reg_read_bits(&dev_data->hxspi.Instance->CR, XSPI_CR_FMODE) == XSPI_CR_FMODE;
 }
 
@@ -1049,6 +1096,9 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 {
 	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
 	struct flash_stm32_xspi_data *dev_data = dev->data;
+	const size_t flash_size = dev_cfg->flash_size;
+	const uint8_t data_mode = dev_cfg->data_mode;
+	const uint8_t data_rate = dev_cfg->data_rate;
 	int ret = 0;
 
 	/* Ignore zero size erase */
@@ -1057,8 +1107,8 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 	}
 
 	/* Maximise erase size : means the complete chip */
-	if (size > dev_cfg->flash_size) {
-		size = dev_cfg->flash_size;
+	if (size > flash_size) {
+		size = flash_size;
 	}
 
 	if (!xspi_address_is_valid(dev, addr, size)) {
@@ -1072,13 +1122,19 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 		return -ENOTSUP;
 	}
 
+	XSPI_RegularCmdTypeDef cmd_erase;
+
+	stm32_xspi_bzero(&cmd_erase, sizeof(cmd_erase));
+
+	compiler_barrier();
+
 	const off_t erase_addr = addr;
 	const size_t erase_size = size;
 
 	xspi_lock_thread(dev);
 
 #if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
-	if (stm32_xspi_is_memorymap(dev)) {
+	if (stm32_xspi_is_memorymap(dev_data)) {
 		/* Abort ongoing transfer to force CS high/BUSY deasserted */
 		ret = stm32_xspi_abort(dev);
 		if (ret != 0) {
@@ -1088,57 +1144,53 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 	}
 #endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
 
-	XSPI_RegularCmdTypeDef cmd_erase = {
-		.OperationType = HAL_XSPI_OPTYPE_COMMON_CFG,
-		.AlternateBytesMode = HAL_XSPI_ALT_BYTES_NONE,
-		.DataMode = HAL_XSPI_DATA_NONE,
-		.DummyCycles = 0U,
-		.DQSMode = HAL_XSPI_DQS_DISABLE,
+	cmd_erase.OperationType = HAL_XSPI_OPTYPE_COMMON_CFG;
+	cmd_erase.AlternateBytesMode = HAL_XSPI_ALT_BYTES_NONE;
+	cmd_erase.DataMode = HAL_XSPI_DATA_NONE;
+	cmd_erase.DummyCycles = 0U;
+	cmd_erase.DQSMode = HAL_XSPI_DQS_DISABLE;
 #ifdef XSPI_CCR_SIOO
-		.SIOOMode = HAL_XSPI_SIOO_INST_EVERY_CMD,
+	cmd_erase.SIOOMode = HAL_XSPI_SIOO_INST_EVERY_CMD;
 #endif /* XSPI_CCR_SIOO */
-	};
 
-	if (stm32_xspi_mem_ready(dev,
-		dev_cfg->data_mode, dev_cfg->data_rate) != 0) {
+	if (stm32_xspi_mem_ready(dev_data, data_mode, data_rate) != 0) {
 		XSPI_LOG_ERR("Erase failed : flash busy");
 		goto erase_end;
 	}
 
-	cmd_erase.InstructionMode    = (dev_cfg->data_mode == XSPI_OCTO_MODE)
+	cmd_erase.InstructionMode    = (data_mode == XSPI_OCTO_MODE)
 					? HAL_XSPI_INSTRUCTION_8_LINES
 					: HAL_XSPI_INSTRUCTION_1_LINE;
-	cmd_erase.InstructionDTRMode = (dev_cfg->data_rate == XSPI_DTR_TRANSFER)
+	cmd_erase.InstructionDTRMode = (data_rate == XSPI_DTR_TRANSFER)
 					? HAL_XSPI_INSTRUCTION_DTR_ENABLE
 					: HAL_XSPI_INSTRUCTION_DTR_DISABLE;
-	cmd_erase.InstructionWidth    = (dev_cfg->data_mode == XSPI_OCTO_MODE)
+	cmd_erase.InstructionWidth    = (data_mode == XSPI_OCTO_MODE)
 					? HAL_XSPI_INSTRUCTION_16_BITS
 					: HAL_XSPI_INSTRUCTION_8_BITS;
 
 	while ((size > 0) && (ret == 0)) {
 
-		ret = stm32_xspi_write_enable(dev,
-			dev_cfg->data_mode, dev_cfg->data_rate);
+		ret = stm32_xspi_write_enable(dev_data, data_mode, data_rate);
 		if (ret != 0) {
 			XSPI_LOG_ERR("Erase failed : write enable");
 			break;
 		}
 
-		if (size == dev_cfg->flash_size) {
+		if (size == flash_size) {
 			/* Chip erase */
 			XSPI_LOG_DBG("Chip Erase");
 
 			cmd_erase.Address = 0;
-			cmd_erase.Instruction = (dev_cfg->data_mode == XSPI_OCTO_MODE)
+			cmd_erase.Instruction = (data_mode == XSPI_OCTO_MODE)
 					? SPI_NOR_OCMD_BULKE
 					: SPI_NOR_CMD_BULKE;
 			cmd_erase.AddressMode = HAL_XSPI_ADDRESS_NONE;
 			/* Full chip erase (Bulk) command */
-			xspi_send_cmd(dev, &cmd_erase);
+			xspi_send_cmd(dev_data, &cmd_erase);
 
-			size -= dev_cfg->flash_size;
+			size -= flash_size;
 			/* Chip (Bulk) erase started, wait until WEL becomes 0 */
-			ret = stm32_xspi_mem_erased(dev);
+			ret = stm32_xspi_mem_erased(dev_data, data_mode, data_rate);
 			if (ret != 0) {
 				XSPI_LOG_ERR("Chip Erase failed");
 				break;
@@ -1148,14 +1200,14 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 			XSPI_LOG_DBG("Sector/Block Erase");
 
 			cmd_erase.AddressMode =
-				(dev_cfg->data_mode == XSPI_OCTO_MODE)
+				(data_mode == XSPI_OCTO_MODE)
 				? HAL_XSPI_ADDRESS_8_LINES
 				: HAL_XSPI_ADDRESS_1_LINE;
 			cmd_erase.AddressDTRMode =
-				(dev_cfg->data_rate == XSPI_DTR_TRANSFER)
+				(data_rate == XSPI_DTR_TRANSFER)
 				? HAL_XSPI_ADDRESS_DTR_ENABLE
 				: HAL_XSPI_ADDRESS_DTR_DISABLE;
-			cmd_erase.AddressWidth = stm32_xspi_hal_address_size(dev);
+			cmd_erase.AddressWidth = stm32_xspi_hal_address_size(dev_data);
 			cmd_erase.Address = addr;
 
 			const struct jesd216_erase_type *erase_types =
@@ -1176,11 +1228,11 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 					cmd_erase.Instruction = bet->cmd;
 				} else if (bet == NULL) {
 					/* Use the default sector erase cmd */
-					if (dev_cfg->data_mode == XSPI_OCTO_MODE) {
+					if (data_mode == XSPI_OCTO_MODE) {
 						cmd_erase.Instruction = SPI_NOR_OCMD_SE;
 					} else {
 						cmd_erase.Instruction =
-							(stm32_xspi_hal_address_size(dev) ==
+							(stm32_xspi_hal_address_size(dev_data) ==
 							HAL_XSPI_ADDRESS_32_BITS)
 							? SPI_NOR_CMD_SE_4B
 							: SPI_NOR_CMD_SE;
@@ -1196,7 +1248,7 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 				     cmd_erase.Address, cmd_erase.AddressWidth,
 				     cmd_erase.AddressMode, cmd_erase.Instruction);
 
-			xspi_send_cmd(dev, &cmd_erase);
+			xspi_send_cmd(dev_data, &cmd_erase);
 
 			if (bet != NULL) {
 				addr += BIT(bet->exp);
@@ -1206,8 +1258,7 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 				size -= SPI_NOR_SECTOR_SIZE;
 			}
 
-			ret = stm32_xspi_mem_ready(dev, dev_cfg->data_mode,
-						dev_cfg->data_rate);
+			ret = stm32_xspi_mem_ready(dev_data, data_mode, data_rate);
 		}
 
 	}
@@ -1250,9 +1301,12 @@ static int flash_stm32_xspi_read(const struct device *dev, off_t addr,
 #if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
 
 	/* Do reads through memory-mapping instead of indirect */
-	if (!stm32_xspi_is_memorymap(dev)) {
+	if (!stm32_xspi_is_memorymap(dev_data)) {
+		const uint8_t data_mode = dev_cfg->data_mode;
+		const uint8_t data_rate = dev_cfg->data_rate;
+
 		xspi_lock_thread(dev);
-		ret = stm32_xspi_set_memorymap(dev);
+		ret = stm32_xspi_set_memorymap(dev_data, data_mode, data_rate);
 		xspi_unlock_thread(dev);
 
 		if (ret != 0) {
@@ -1261,7 +1315,7 @@ static int flash_stm32_xspi_read(const struct device *dev, off_t addr,
 		}
 	}
 
-	__ASSERT_NO_MSG(stm32_xspi_is_memorymap(dev));
+	__ASSERT_NO_MSG(stm32_xspi_is_memorymap(dev_data));
 #endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
 
 	uintptr_t mmap_addr = dev_cfg->mem_map_based_address + addr;
@@ -1274,7 +1328,9 @@ static int flash_stm32_xspi_read(const struct device *dev, off_t addr,
        * || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION
        */
 
-	XSPI_RegularCmdTypeDef cmd = xspi_prepare_cmd(dev_cfg->data_mode, dev_cfg->data_rate);
+	XSPI_RegularCmdTypeDef cmd;
+
+	xspi_prepare_cmd(&cmd, dev_cfg->data_mode, dev_cfg->data_rate);
 
 	if (dev_cfg->data_mode != XSPI_OCTO_MODE) {
 		switch (dev_data->read_mode) {
@@ -1310,7 +1366,7 @@ static int flash_stm32_xspi_read(const struct device *dev, off_t addr,
 
 	/* Instruction and DummyCycles are set below */
 	cmd.Address = addr; /* AddressSize is 32bits in OPSI mode */
-	cmd.AddressWidth = stm32_xspi_hal_address_size(dev);
+	cmd.AddressWidth = stm32_xspi_hal_address_size(dev_data);
 	/* DataSize is set by the read cmd */
 
 	/* Configure other parameters */
@@ -1352,6 +1408,8 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 {
 	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
 	struct flash_stm32_xspi_data *dev_data = dev->data;
+	const uint8_t data_mode = dev_cfg->data_mode;
+	const uint8_t data_rate = dev_cfg->data_rate;
 	size_t to_write;
 	int ret = 0;
 
@@ -1369,10 +1427,17 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 	const off_t write_addr = addr;
 	const size_t write_size = size;
 
+	/* Build page-program command before entering XSPI critical section. */
+	XSPI_RegularCmdTypeDef cmd_pp;
+
+	xspi_prepare_cmd(&cmd_pp, data_mode, data_rate);
+
+	compiler_barrier();
+
 	xspi_lock_thread(dev);
 
 #if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
-	if (stm32_xspi_is_memorymap(dev)) {
+	if (stm32_xspi_is_memorymap(dev_data)) {
 		/* Abort ongoing transfer to force CS high/BUSY deasserted */
 		ret = stm32_xspi_abort(dev);
 		if (ret != 0) {
@@ -1381,13 +1446,11 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 		}
 	}
 #endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
-	/* page program for STR or DTR mode */
-	XSPI_RegularCmdTypeDef cmd_pp = xspi_prepare_cmd(dev_cfg->data_mode, dev_cfg->data_rate);
 
 	/* using 32bits address also in SPI/STR mode */
 	cmd_pp.Instruction = dev_data->write_opcode;
 
-	if (dev_cfg->data_mode != XSPI_OCTO_MODE) {
+	if (data_mode != XSPI_OCTO_MODE) {
 		switch (cmd_pp.Instruction) {
 		case SPI_NOR_CMD_PP_4B:
 			__fallthrough;
@@ -1424,15 +1487,14 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 	}
 
 	cmd_pp.Address = addr;
-	cmd_pp.AddressWidth = stm32_xspi_hal_address_size(dev);
+	cmd_pp.AddressWidth = stm32_xspi_hal_address_size(dev_data);
 	cmd_pp.DummyCycles = 0U;
 
 	XSPI_LOG_DBG("XSPI: write %zu data at 0x%lx",
 		size,
 		(long)(dev_cfg->mem_map_based_address + addr));
 
-	ret = stm32_xspi_mem_ready(dev,
-				   dev_cfg->data_mode, dev_cfg->data_rate);
+	ret = stm32_xspi_mem_ready(dev_data, data_mode, data_rate);
 	if (ret != 0) {
 		XSPI_LOG_ERR("XSPI: write not ready");
 		goto write_end;
@@ -1440,8 +1502,7 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 
 	while ((size > 0) && (ret == 0)) {
 		to_write = size;
-		ret = stm32_xspi_write_enable(dev,
-					      dev_cfg->data_mode, dev_cfg->data_rate);
+		ret = stm32_xspi_write_enable(dev_data, data_mode, data_rate);
 		if (ret != 0) {
 			XSPI_LOG_ERR("XSPI: write not enabled");
 			break;
@@ -1459,7 +1520,7 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 		}
 		cmd_pp.Address = addr;
 
-		ret = xspi_write_access(dev, &cmd_pp, data, to_write);
+		ret = xspi_write_access(dev_data, data_mode, &cmd_pp, data, to_write);
 		if (ret != 0) {
 			XSPI_LOG_ERR("XSPI: write not access");
 			break;
@@ -1470,8 +1531,7 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 		addr += to_write;
 
 		/* Configure automatic polling mode to wait for end of program */
-		ret = stm32_xspi_mem_ready(dev,
-						 dev_cfg->data_mode, dev_cfg->data_rate);
+		ret = stm32_xspi_mem_ready(dev_data, data_mode, data_rate);
 		if (ret != 0) {
 			XSPI_LOG_ERR("XSPI: write PP not ready");
 			break;
@@ -1730,6 +1790,7 @@ static int stm32_xspi_read_status_register(const struct device *dev, uint8_t reg
 
 static int stm32_xspi_write_status_register(const struct device *dev, uint8_t reg_num, uint8_t reg)
 {
+	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
 	struct flash_stm32_xspi_data *data = dev->data;
 	XSPI_RegularCmdTypeDef s_command = {
 		.Instruction = SPI_NOR_CMD_WRSR,
@@ -1779,7 +1840,7 @@ static int stm32_xspi_write_status_register(const struct device *dev, uint8_t re
 		return -EINVAL;
 	}
 
-	return xspi_write_access(dev, &s_command, regs_p, size);
+	return xspi_write_access(data, dev_cfg->data_mode, &s_command, regs_p, size);
 }
 
 static int stm32_xspi_enable_qe(const struct device *dev)
@@ -1826,7 +1887,7 @@ static int stm32_xspi_enable_qe(const struct device *dev)
 		return 0;
 	}
 
-	ret = stm32_xspi_write_enable(dev, XSPI_SPI_MODE, XSPI_STR_TRANSFER);
+	ret = stm32_xspi_write_enable(data, XSPI_SPI_MODE, XSPI_STR_TRANSFER);
 	if (ret < 0) {
 		return ret;
 	}
@@ -1838,7 +1899,7 @@ static int stm32_xspi_enable_qe(const struct device *dev)
 		return ret;
 	}
 
-	ret = stm32_xspi_mem_ready(dev, XSPI_SPI_MODE, XSPI_STR_TRANSFER);
+	ret = stm32_xspi_mem_ready(data, XSPI_SPI_MODE, XSPI_STR_TRANSFER);
 	if (ret < 0) {
 		return ret;
 	}
@@ -2151,7 +2212,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	if (clock_control_get_status(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 				     (clock_control_subsys_t) &dev_cfg->pclken)
 				     == CLOCK_CONTROL_STATUS_ON) {
-		if (stm32_xspi_is_memorymap(dev)) {
+		if (stm32_xspi_is_memorymap(dev_data)) {
 			LOG_DBG("NOR init'd in MemMapped mode");
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 			ret = setup_pages_layout(dev);
@@ -2240,7 +2301,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 		dev_data->hxspi.Init.DelayHoldQuarterCycle = HAL_XSPI_DHQC_ENABLE;
 	}
 
-	if (stm32_xspi_is_memorymap(dev)) {
+	if (stm32_xspi_is_memorymap(dev_data)) {
 		/* Memory-mapping could have been set by previous application.
 		 * Force HAL instance in correct state.
 		 */
@@ -2295,7 +2356,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	/* Run IRQ init */
 	dev_cfg->irq_config(dev);
 
-	if (stm32_xspi_is_memorymap(dev)) {
+	if (stm32_xspi_is_memorymap(dev_data)) {
 		/* Memory-mapping could have been set by previous application.
 		 * Abort to allow following Jedec transactions, it will be
 		 * re-enabled afterwards if needed by the application.
@@ -2316,7 +2377,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	LOG_DBG("Reset Mem (SPI/STR)");
 
 	/* Check if memory is ready in the SPI/STR mode */
-	if (stm32_xspi_mem_ready(dev,
+	if (stm32_xspi_mem_ready(dev_data,
 		XSPI_SPI_MODE, XSPI_STR_TRANSFER) != 0) {
 		LOG_ERR("XSPI memory not ready");
 		return -EIO;
@@ -2448,7 +2509,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_FLASH_STM32_NOR_MEMMAP
-	ret = stm32_xspi_set_memorymap(dev);
+	ret = stm32_xspi_set_memorymap(dev_data, dev_cfg->data_mode, dev_cfg->data_rate);
 	if (ret != 0) {
 		LOG_ERR("Failed to enable memory-mapped mode: %d", ret);
 		return ret;

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -1965,6 +1965,20 @@ static inline uint8_t spi_nor_convert_write_to_4b(const uint8_t opcode)
 	}
 }
 
+static uint32_t xspi_default_write_opcode(uint8_t data_mode, bool four_byte_opcodes)
+{
+	switch (data_mode) {
+	case XSPI_OCTO_MODE:
+		return SPI_NOR_OCMD_PAGE_PRG;
+	case XSPI_QUAD_MODE:
+		return SPI_NOR_CMD_PP_1_4_4;
+	case XSPI_DUAL_MODE:
+		return SPI_NOR_CMD_PP_1_1_2;
+	default:
+		return four_byte_opcodes ? SPI_NOR_CMD_PP_4B : SPI_NOR_CMD_PP;
+	}
+}
+
 static int spi_nor_process_bfp(const struct device *dev,
 			       const struct jesd216_param_header *php,
 			       const struct jesd216_bfp *bfp)
@@ -2005,20 +2019,7 @@ static int spi_nor_process_bfp(const struct device *dev,
 
 	/* use PP opcode based on configured data mode if nothing is set in DTS */
 	if (data->write_opcode == SPI_NOR_WRITEOC_NONE) {
-		switch (dev_cfg->data_mode) {
-		case XSPI_OCTO_MODE:
-			data->write_opcode = SPI_NOR_OCMD_PAGE_PRG;
-			break;
-		case XSPI_QUAD_MODE:
-			data->write_opcode = SPI_NOR_CMD_PP_1_4_4;
-			break;
-		case XSPI_DUAL_MODE:
-			data->write_opcode = SPI_NOR_CMD_PP_1_1_2;
-			break;
-		default:
-			data->write_opcode = SPI_NOR_CMD_PP;
-			break;
-		}
+		data->write_opcode = xspi_default_write_opcode(dev_cfg->data_mode, false);
 	}
 
 	if (dev_cfg->data_mode != XSPI_OCTO_MODE) {
@@ -2214,6 +2215,21 @@ static int flash_stm32_xspi_init(const struct device *dev)
 				     == CLOCK_CONTROL_STATUS_ON) {
 		if (stm32_xspi_is_memorymap(dev_data)) {
 			LOG_DBG("NOR init'd in MemMapped mode");
+
+			/* Full init is bypassed when already in XIP ext-flash mode,
+			 * so set required runtime defaults here.
+			 */
+			if ((dev_cfg->four_byte_opcodes) || (dev_cfg->flash_size > BIT(24))) {
+				dev_data->address_width = 4U;
+			} else if (dev_data->address_width == 0U) {
+				dev_data->address_width = 3U;
+			}
+
+			if (dev_data->write_opcode == SPI_NOR_WRITEOC_NONE) {
+				dev_data->write_opcode = xspi_default_write_opcode(
+					dev_cfg->data_mode, dev_cfg->four_byte_opcodes);
+			}
+
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 			ret = setup_pages_layout(dev);
 			if (ret != 0) {

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -871,7 +871,7 @@ static int stm32_xspi_mem_reset(const struct device *dev)
 	return 0;
 }
 
-#ifdef CONFIG_FLASH_STM32_NOR_MEMMAP
+#if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
 /* Function to configure the octoflash in MemoryMapped mode */
 static int stm32_xspi_set_memorymap(const struct device *dev)
 {
@@ -988,7 +988,7 @@ static int stm32_xspi_set_memorymap(const struct device *dev)
 	LOG_DBG("MemoryMap mode enabled");
 	return 0;
 }
-#endif /* CONFIG_FLASH_STM32_NOR_MEMMAP */
+#endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
 
 static int stm32_xspi_abort(const struct device *dev)
 {
@@ -1064,7 +1064,7 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 
 	xspi_lock_thread(dev);
 
-#ifdef CONFIG_FLASH_STM32_NOR_MEMMAP
+#if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
 	if (stm32_xspi_is_memorymap(dev)) {
 		/* Abort ongoing transfer to force CS high/BUSY deasserted */
 		ret = stm32_xspi_abort(dev);
@@ -1073,7 +1073,7 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 			goto erase_end;
 		}
 	}
-#endif /* CONFIG_FLASH_STM32_NOR_MEMMAP */
+#endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
 
 	XSPI_RegularCmdTypeDef cmd_erase = {
 		.OperationType = HAL_XSPI_OPTYPE_COMMON_CFG,
@@ -1226,13 +1226,14 @@ static int flash_stm32_xspi_read(const struct device *dev, off_t addr,
 		return 0;
 	}
 
-#if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || (defined(CONFIG_STM32_APP_IN_EXT_FLASH) \
-	&& defined(CONFIG_XIP))
+#if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || \
+	(defined(CONFIG_STM32_APP_IN_EXT_FLASH) && defined(CONFIG_XIP)) || \
+	defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
 	/*
 	 * When the call is made by an app executing in external flash,
 	 * skip the memory-mapped mode check
 	 */
-#ifdef CONFIG_FLASH_STM32_NOR_MEMMAP
+#if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
 
 	/* Do reads through memory-mapping instead of indirect */
 	if (!stm32_xspi_is_memorymap(dev)) {
@@ -1247,14 +1248,17 @@ static int flash_stm32_xspi_read(const struct device *dev, off_t addr,
 	}
 
 	__ASSERT_NO_MSG(stm32_xspi_is_memorymap(dev));
-#endif /* CONFIG_FLASH_STM32_NOR_MEMMAP */
+#endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
+
 	uintptr_t mmap_addr = dev_cfg->mem_map_based_address + addr;
 
 	LOG_DBG("Memory-mapped read from 0x%08lx, len %zu", mmap_addr, size);
 	memcpy(data, (void *)mmap_addr, size);
 	return ret;
 
-#else /* CONFIG_FLASH_STM32_NOR_MEMMAP || (CONFIG_STM32_APP_IN_EXT_FLASH && CONFIG_XIP) */
+#else /* CONFIG_FLASH_STM32_NOR_MEMMAP || (CONFIG_STM32_APP_IN_EXT_FLASH && CONFIG_XIP)
+       * || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION
+       */
 
 	XSPI_RegularCmdTypeDef cmd = xspi_prepare_cmd(dev_cfg->data_mode, dev_cfg->data_rate);
 
@@ -1323,7 +1327,9 @@ static int flash_stm32_xspi_read(const struct device *dev, off_t addr,
 	xspi_unlock_thread(dev);
 
 	return ret;
-#endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || (CONFIG_STM32_APP_IN_EXT_FLASH && CONFIG_XIP) */
+#endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || (CONFIG_STM32_APP_IN_EXT_FLASH && CONFIG_XIP)
+	* || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION
+	*/
 }
 
 /* Function to write the flash (page program) : with possible OCTO/SPI and STR/DTR */
@@ -1351,7 +1357,7 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 
 	xspi_lock_thread(dev);
 
-#ifdef CONFIG_FLASH_STM32_NOR_MEMMAP
+#if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
 	if (stm32_xspi_is_memorymap(dev)) {
 		/* Abort ongoing transfer to force CS high/BUSY deasserted */
 		ret = stm32_xspi_abort(dev);
@@ -1360,7 +1366,7 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 			goto write_end;
 		}
 	}
-#endif
+#endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
 	/* page program for STR or DTR mode */
 	XSPI_RegularCmdTypeDef cmd_pp = xspi_prepare_cmd(dev_cfg->data_mode, dev_cfg->data_rate);
 

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -1149,23 +1149,6 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 #if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
 	bool was_memmap = false;
 	unsigned int irq_key = 0;
-
-	if (stm32_xspi_is_memorymap(dev_data)) {
-		was_memmap = true;
-
-		if (IS_ENABLED(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)) {
-			/* Lock IRQs for entire operation - ISR handlers are in flash */
-			irq_key = irq_lock();
-		}
-
-		/* Abort ongoing transfer to force CS high/BUSY deasserted */
-		ret = stm32_xspi_abort(dev);
-
-		if (ret != 0) {
-			XSPI_LOG_ERR("Failed to abort memory-mapped access before erase");
-			goto erase_end;
-		}
-	}
 #endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
 
 	cmd_erase.OperationType = HAL_XSPI_OPTYPE_COMMON_CFG;
@@ -1176,11 +1159,6 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 #ifdef XSPI_CCR_SIOO
 	cmd_erase.SIOOMode = HAL_XSPI_SIOO_INST_EVERY_CMD;
 #endif /* XSPI_CCR_SIOO */
-
-	if (stm32_xspi_mem_ready(dev_data, data_mode, data_rate) != 0) {
-		XSPI_LOG_ERR("Erase failed : flash busy");
-		goto erase_end;
-	}
 
 	cmd_erase.InstructionMode    = (data_mode == XSPI_OCTO_MODE)
 					? HAL_XSPI_INSTRUCTION_8_LINES
@@ -1194,10 +1172,34 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 
 	while ((size > 0) && (ret == 0)) {
 
+#if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
+		if (stm32_xspi_is_memorymap(dev_data)) {
+			was_memmap = true;
+
+			if (IS_ENABLED(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)) {
+				/* Lock IRQs for one erase operation */
+				irq_key = irq_lock();
+			}
+
+			/* Abort ongoing transfer to force CS high/BUSY deasserted */
+			ret = stm32_xspi_abort(dev);
+			if (ret != 0) {
+				XSPI_LOG_ERR("Failed to abort memory-mapped access before erase");
+				goto erase_chunk_end;
+			}
+		}
+#endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
+
+		if (stm32_xspi_mem_ready(dev_data, data_mode, data_rate) != 0) {
+			XSPI_LOG_ERR("Erase failed : flash busy");
+			ret = -EIO;
+			goto erase_chunk_end;
+		}
+
 		ret = stm32_xspi_write_enable(dev_data, data_mode, data_rate);
 		if (ret != 0) {
 			XSPI_LOG_ERR("Erase failed : write enable");
-			break;
+			goto erase_chunk_end;
 		}
 
 		if (size == flash_size) {
@@ -1217,7 +1219,7 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 			ret = stm32_xspi_mem_erased(dev_data, data_mode, data_rate);
 			if (ret != 0) {
 				XSPI_LOG_ERR("Chip Erase failed");
-				break;
+				goto erase_chunk_end;
 			}
 		} else {
 			/* Sector or Block erase depending on the size */
@@ -1285,24 +1287,25 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 			ret = stm32_xspi_mem_ready(dev_data, data_mode, data_rate);
 		}
 
-	}
-	/* Ends the erase operation */
-
-erase_end:
+erase_chunk_end:
 #if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
-	if (was_memmap) {
-		if (stm32_xspi_set_memorymap(dev_data, data_mode, data_rate) != 0) {
-			/* Failed to restore memory map mode */
-			while (1) {
-				/* Infinite loop to prevent further execution */
+		if (was_memmap) {
+			if (stm32_xspi_set_memorymap(dev_data, data_mode, data_rate) != 0) {
+				/* Failed to restore memory map mode */
+				while (1) {
+					/* Infinite loop to prevent further execution */
+				}
+			}
+
+			was_memmap = false;
+
+			if (IS_ENABLED(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)) {
+				irq_unlock(irq_key);
 			}
 		}
-		if (IS_ENABLED(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)) {
-			/* Unlock IRQs only after memmap is restored */
-			irq_unlock(irq_key);
-		}
-	}
 #endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
+		continue;
+	}
 
 	stm32_xspi_invalidate_mmap_cache(dev, erase_addr, erase_size);
 
@@ -1478,23 +1481,6 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 #if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
 	bool was_memmap = false;
 	unsigned int irq_key = 0;
-
-	if (stm32_xspi_is_memorymap(dev_data)) {
-		/* Abort ongoing transfer to force CS high/BUSY deasserted */
-		was_memmap = true;
-
-		if (IS_ENABLED(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)) {
-			/* Lock IRQs for entire operation - ISR handlers are in flash */
-			irq_key = irq_lock();
-		}
-
-		ret = stm32_xspi_abort(dev);
-
-		if (ret != 0) {
-			XSPI_LOG_ERR("Failed to abort memory-mapped access before write");
-			goto write_end;
-		}
-	}
 #endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
 
 	/* using 32bits address also in SPI/STR mode */
@@ -1544,18 +1530,37 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 		size,
 		(long)(dev_cfg->mem_map_based_address + addr));
 
-	ret = stm32_xspi_mem_ready(dev_data, data_mode, data_rate);
-	if (ret != 0) {
-		XSPI_LOG_ERR("XSPI: write not ready");
-		goto write_end;
-	}
-
 	while ((size > 0) && (ret == 0)) {
+
+#if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
+		if (stm32_xspi_is_memorymap(dev_data)) {
+			was_memmap = true;
+
+			if (IS_ENABLED(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)) {
+				/* Lock IRQs for one page-program operation. */
+				irq_key = irq_lock();
+			}
+
+			/* Abort ongoing transfer to force CS high/BUSY deasserted. */
+			ret = stm32_xspi_abort(dev);
+			if (ret != 0) {
+				XSPI_LOG_ERR("Failed to abort memory-mapped access before write");
+				goto write_chunk_end;
+			}
+		}
+#endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
+
+		ret = stm32_xspi_mem_ready(dev_data, data_mode, data_rate);
+		if (ret != 0) {
+			XSPI_LOG_ERR("XSPI: write not ready");
+			goto write_chunk_end;
+		}
+
 		to_write = size;
 		ret = stm32_xspi_write_enable(dev_data, data_mode, data_rate);
 		if (ret != 0) {
 			XSPI_LOG_ERR("XSPI: write not enabled");
-			break;
+			goto write_chunk_end;
 		}
 		/* Don't write more than a page. */
 		if (to_write >= SPI_NOR_PAGE_SIZE) {
@@ -1573,7 +1578,7 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 		ret = xspi_write_access(dev_data, data_mode, &cmd_pp, data, to_write);
 		if (ret != 0) {
 			XSPI_LOG_ERR("XSPI: write not access");
-			break;
+			goto write_chunk_end;
 		}
 
 		size -= to_write;
@@ -1584,26 +1589,29 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 		ret = stm32_xspi_mem_ready(dev_data, data_mode, data_rate);
 		if (ret != 0) {
 			XSPI_LOG_ERR("XSPI: write PP not ready");
-			break;
+			goto write_chunk_end;
 		}
-	}
-	/* Ends the write operation */
 
-write_end:
+write_chunk_end:
 #if defined(CONFIG_FLASH_STM32_NOR_MEMMAP) || defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
-	if (was_memmap) {
-		if (stm32_xspi_set_memorymap(dev_data, data_mode, data_rate) != 0) {
-			/* Failed to restore memory map mode */
-			while (1) {
-				/* Infinite loop to prevent further execution */
+		if (was_memmap) {
+			if (stm32_xspi_set_memorymap(dev_data, data_mode, data_rate) != 0) {
+				/* Failed to restore memory map mode */
+				while (1) {
+					/* Infinite loop to prevent further execution */
+				}
+			}
+
+			was_memmap = false;
+
+			if (IS_ENABLED(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)) {
+				irq_unlock(irq_key);
 			}
 		}
-		if (IS_ENABLED(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)) {
-			/* Unlock IRQs only after memmap is restored */
-			irq_unlock(irq_key);
-		}
-	}
 #endif /* CONFIG_FLASH_STM32_NOR_MEMMAP || CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
+		continue;
+	}
+
 	stm32_xspi_invalidate_mmap_cache(dev, write_addr, write_size);
 
 	xspi_unlock_thread(dev);

--- a/soc/st/stm32/common/CMakeLists.txt
+++ b/soc/st/stm32/common/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 zephyr_sources_ifdef(CONFIG_STM32_WKUP_PINS pwr_wkupctrl.c)
 zephyr_sources_ifdef(CONFIG_STM32_IOCELL stm32_iocell.c)
 zephyr_sources_ifdef(CONFIG_STM32_XSPIM stm32_xspim.c)
+zephyr_sources_ifdef(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION stm32_xspi_hal_timer.c)
 
 if(CONFIG_PM AND CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP)
   message(WARNING "\

--- a/soc/st/stm32/common/stm32_xspi_hal_timer.c
+++ b/soc/st/stm32/common/stm32_xspi_hal_timer.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+#include <cmsis_core.h>
+#include <soc.h>
+
+#define DWT_CYCLES_PER_MS (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC / 1000U)
+
+static uint32_t dwt_last;
+static uint32_t elapsed_ms;
+
+/**
+ * @brief This function computes the elapsed cycles between two DWT cycle counter values.
+ * @return The number of elapsed cycles between the two DWT cycle counter values.
+ */
+static uint32_t stm32_xspi_dwt_elapsed_cycles(uint32_t current, uint32_t previous)
+{
+	if (current >= previous) {
+		return current - previous;
+	}
+
+	return (UINT32_MAX - previous) + 1U + current;
+}
+
+/**
+ * @brief This function initializes the DWT cycle counter for time measurement in milliseconds.
+ */
+static int stm32_xspi_hal_dwt_init(void)
+{
+	DCB->DEMCR |= DCB_DEMCR_TRCENA_Msk;
+
+	DWT->CYCCNT = 0U;
+	DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+
+	dwt_last = DWT->CYCCNT;
+
+	return 0;
+}
+
+/**
+ * @brief This function provides the current tick value in milliseconds
+ * based on the DWT cycle counter.
+ * @return The current tick value in milliseconds.
+ */
+uint32_t HAL_GetTick(void)
+{
+	uint32_t current_cycles;
+	uint32_t elapsed_cycles;
+	uint32_t elapsed_whole_ms;
+
+	current_cycles = DWT->CYCCNT;
+	elapsed_cycles = stm32_xspi_dwt_elapsed_cycles(current_cycles, dwt_last);
+	dwt_last = current_cycles;
+
+	elapsed_whole_ms = elapsed_cycles / DWT_CYCLES_PER_MS;
+	elapsed_ms += elapsed_whole_ms;
+
+	return elapsed_ms;
+}
+
+/**
+ * @brief This function provides minimum delay (in milliseconds) based
+ *	  on variable incremented.
+ * @param Delay: specifies the delay time length, in milliseconds.
+ * @return None
+ */
+void HAL_Delay(__IO uint32_t Delay)
+{
+	const uint32_t start = HAL_GetTick();
+
+	while ((HAL_GetTick() - start) < Delay) {
+	}
+}
+
+SYS_INIT(stm32_xspi_hal_dwt_init, PRE_KERNEL_1, 0);

--- a/soc/st/stm32/common/stm32cube_hal.c
+++ b/soc/st/stm32/common/stm32cube_hal.c
@@ -14,6 +14,8 @@
 
 #include <zephyr/kernel.h>
 #include <soc.h>
+
+#if !defined(CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION)
 /**
  * @brief This function configures the source of stm32cube time base.
  *        Cube HAL expects a 1ms tick which matches with k_uptime_get_32.
@@ -35,6 +37,7 @@ void HAL_Delay(__IO uint32_t Delay)
 {
 	k_msleep(Delay);
 }
+#endif /* !CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION */
 
 #ifdef CONFIG_USE_STM32_ASSERT
 #ifdef CONFIG_STM32_HAL2

--- a/tests/drivers/flash/common/tests.yaml
+++ b/tests/drivers/flash/common/tests.yaml
@@ -74,6 +74,7 @@ tests:
       - kit_pse84_ai/pse846gps2dbzc4a/m33
       - kit_pse84_ai/pse846gps2dbzc4a/m33/ns
       - kit_pse84_ai/pse846gps2dbzc4a/m55
+      - stm32h7s78_dk/stm32h7s7xx/ext_flash_app
     integration_platforms:
       - qemu_x86
       - mimxrt1060_evk/mimxrt1062/qspi
@@ -196,6 +197,7 @@ tests:
       - nucleo_g474re
     platform_exclude:
       - nucleo_wb55rg
+      - stm32h7s78_dk/stm32h7s7xx/ext_flash_app
   drivers.flash.common.non_quad_mode:
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE=boards/mx25r64_non_quad.overlay
@@ -220,6 +222,7 @@ tests:
       - kit_pse84_ai/pse846gps2dbzc4a/m33
       - kit_pse84_ai/pse846gps2dbzc4a/m33/ns
       - kit_pse84_ai/pse846gps2dbzc4a/m55
+      - stm32h7s78_dk/stm32h7s7xx/ext_flash_app
     extra_args:
       - CONFIG_TEST_FORCE_STORAGE_PARTITION=y
   drivers.flash.common.test_storage_partition.nrf54lm20:
@@ -347,3 +350,10 @@ tests:
       - CONFIG_TEST_DRIVER_FLASH_SIZE=-1
     integration_platforms:
       - kit_pse84_eval/pse846gps2dbzc4a/m33
+  drivers.flash.common.stm32.xspi_driver_relocation:
+    filter: CONFIG_FLASH_STM32_XSPI_RAM_RELOCATION
+    sysbuild: true
+    platform_allow:
+      - stm32h7s78_dk/stm32h7s7xx/ext_flash_app
+    integration_platforms:
+      - stm32h7s78_dk/stm32h7s7xx/ext_flash_app


### PR DESCRIPTION
This PR introduces code relocation for the STM32 XSPI driver for the N6. Thanks to this, the erase/write operations remain reliable when running from external flash in XIP.

The PR adds the following:

- Relocates critical XSPI code paths for STM32N6 to SRAM for XIP use cases.
- Avoids flash accesses in the critical path while memory-mapped mode is temporarily disabled.
- Restores memory-mapped mode after write and erase operations.
- Locks IRQs during write/erase commands when XIP relocation is enabled to prevent interrupt handlers from executing from unavailable external flash.
- Adds a DWT-based HAL tick to avoid IRQs usage while they are locked.
- Sets safe defaults on XIP init bypass path.
- Cleans up logs in critical sections.

Can be tested with the flash_shell sample with the following build commands:
`west build -b stm32n6570_dk --sysbuild zephyr/samples/drivers/flash_shell/ -p always -- -DCONFIG_CODE_DATA_RELOCATION_SRAM=y -DCONFIG_FLASH_STM32_XSPI_XIP_RELOCATE=y`