### PR TITLE
dts: bindings: ethernet: split mac address into own yaml

### DIFF
--- a/dts/bindings/ethernet/ethernet-controller.yaml
+++ b/dts/bindings/ethernet/ethernet-controller.yaml
@@ -5,33 +5,9 @@
 
 include:
   - name: base.yaml
-  - name: nvmem-consumer.yaml
+  - name: ethernet-mac-address.yaml
 
 properties:
-  local-mac-address:
-    type: uint8-array
-    description: Specifies the MAC address that was assigned to the network device
-
-  zephyr,random-mac-address:
-    type: boolean
-    description: |
-      Use a random MAC address generated when the driver is initialized.
-      Note that using this choice and rebooting a board may leave stale
-      MAC address in peers' ARP caches and lead to issues and delays in
-      communication.  (Use "ip neigh flush all" on Linux peers to clear
-      ARP cache.)
-
-      It is driver specific how the OUI octets are handled.
-
-      If set we ignore any setting of the local-mac-address property.
-
-  zephyr,mac-address-prefix:
-    type: uint8-array
-    description: |
-      A statically assigned MAC address prefix.
-      Can be combined with zephyr,random-mac-address or an NVMEM cell, for
-      example to set the OUI.
-
   phy-handle:
     type: phandle
     dependency-mode: ignore

--- a/dts/bindings/ethernet/ethernet-mac-address.yaml
+++ b/dts/bindings/ethernet/ethernet-mac-address.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for the MAC address of an Ethernet device
+
+include:
+  - name: nvmem-consumer.yaml
+
+properties:
+  local-mac-address:
+    type: uint8-array
+    description: Specifies the MAC address that was assigned to the network device
+
+  zephyr,random-mac-address:
+    type: boolean
+    description: |
+      Use a random MAC address generated when the driver is initialized.
+      Note that using this choice and rebooting a board may leave stale
+      MAC address in peers' ARP caches and lead to issues and delays in
+      communication.  (Use "ip neigh flush all" on Linux peers to clear
+      ARP cache.)
+
+      It is driver specific how the OUI octets are handled.
+
+      If set we ignore any setting of the local-mac-address property.
+
+  zephyr,mac-address-prefix:
+    type: uint8-array
+    description: |
+      A statically assigned MAC address prefix.
+      Can be combined with zephyr,random-mac-address or an NVMEM cell, for
+      example to set the OUI.


### PR DESCRIPTION
split the props for the mac address into
its own yaml, so that can be reused by the
wifi bindings, as their drivers also use the
ethernet api.