### PR TITLE
tests: bluetooth: tester: refactor gatt discover and read operations

### DIFF
--- a/tests/bluetooth/tester/src/btp.c
+++ b/tests/bluetooth/tester/src/btp.c
@@ -48,8 +48,6 @@ static struct btp_buf cmd_buf[CMD_QUEUED];
 static K_FIFO_DEFINE(cmds_queue);
 static K_FIFO_DEFINE(avail_queue);
 
-static struct btp_buf *delayed_cmd;
-
 static struct {
 	const struct btp_handler *handlers;
 	size_t num;
@@ -129,14 +127,9 @@ static void cmd_handler(void *p1, void *p2, void *p3)
 		} else {
 			status = BTP_STATUS_UNKNOWN_CMD;
 		}
-		/* Allow to delay only 1 command. This is for convenience only
-		 * of using cmd data without need of copying those in async
-		 * functions. Should be not needed eventually.
-		 */
+
 		if (status == BTP_STATUS_DELAY_REPLY) {
-			__ASSERT_NO_MSG(delayed_cmd == NULL);
-			delayed_cmd = cmd;
-			continue;
+			goto done;
 		}
 
 		if ((status == BTP_STATUS_SUCCESS) && rsp_len > 0) {
@@ -146,7 +139,7 @@ static void cmd_handler(void *p1, void *p2, void *p3)
 			tester_rsp_with_index(hdr->service, hdr->opcode,
 					      hdr->index, status);
 		}
-
+done:
 		(void)memset(cmd, 0, sizeof(*cmd));
 		k_fifo_put(&avail_queue, cmd);
 	}
@@ -335,38 +328,20 @@ void tester_event(uint8_t service, uint8_t opcode, const void *data, size_t len)
 
 void tester_rsp_full(uint8_t service, uint8_t opcode, const void *rsp, size_t len)
 {
-	struct btp_buf *cmd;
-
 	__ASSERT_NO_MSG(opcode < 0x80);
-	__ASSERT_NO_MSG(delayed_cmd != NULL);
 
 	LOG_DBG("service 0x%02x opcode 0x%02x", service, opcode);
 
 	tester_send_with_index(service, opcode, BTP_INDEX, rsp, len);
-
-	cmd = delayed_cmd;
-	delayed_cmd = NULL;
-
-	(void)memset(cmd, 0, sizeof(*cmd));
-	k_fifo_put(&avail_queue, cmd);
 }
 
 void tester_rsp(uint8_t service, uint8_t opcode, uint8_t status)
 {
-	struct btp_buf *cmd;
-
 	__ASSERT_NO_MSG(opcode < 0x80);
-	__ASSERT_NO_MSG(delayed_cmd != NULL);
 
 	LOG_DBG("service 0x%02x opcode 0x%02x status 0x%02x", service, opcode, status);
 
 	tester_rsp_with_index(service, opcode, BTP_INDEX, status);
-
-	cmd = delayed_cmd;
-	delayed_cmd = NULL;
-
-	(void)memset(cmd, 0, sizeof(*cmd));
-	k_fifo_put(&avail_queue, cmd);
 }
 
 uint16_t tester_supported_commands(uint8_t service, uint8_t *cmds)

--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -79,15 +79,14 @@ static uint8_t svc_attr_count;
 static uint8_t svc_count;
 static bool ccc_added;
 
+#define BTP_GATT_GATT_BUF_COUNT 2
+
 /*
- * gatt_buf - cache used by a gatt client (to cache data read/discovered)
+ * btp_gatt_buf_pool - cache used by a gatt client (to cache data read/discovered)
  * and gatt server (to store attribute user_data).
  * It is not intended to be used by client and server at the same time.
  */
-static struct {
-	uint16_t len;
-	uint8_t buf[MAX_BUFFER_SIZE];
-} gatt_buf;
+NET_BUF_POOL_FIXED_DEFINE(btp_gatt_buf_pool, BTP_GATT_GATT_BUF_COUNT, MAX_BUFFER_SIZE, 0, NULL);
 
 struct get_attr_data {
 	struct net_buf_simple *buf;
@@ -124,35 +123,42 @@ static int ccc_find_by_ccc(const struct bt_gatt_attr *attr)
 	return -ENOENT;
 }
 
-static void *gatt_buf_add(const void *data, size_t len)
+static struct net_buf *gatt_buf_allocate(void)
 {
-	void *ptr = gatt_buf.buf + gatt_buf.len;
+	return net_buf_alloc(&btp_gatt_buf_pool, K_NO_WAIT);
+}
 
-	if ((len + gatt_buf.len) > MAX_BUFFER_SIZE) {
+static void *gatt_buf_add(struct net_buf *buf, const void *data, size_t len)
+{
+	void *ptr;
+
+	if (net_buf_tailroom(buf) < len) {
 		return NULL;
 	}
 
-	if (data) {
-		memcpy(ptr, data, len);
-	} else {
+	if (data == NULL) {
+		ptr = net_buf_add(buf, len);
 		(void)memset(ptr, 0, len);
+	} else {
+		ptr = net_buf_add_mem(buf, data, len);
 	}
 
-	gatt_buf.len += len;
-
-	LOG_DBG("%d/%d used", gatt_buf.len, MAX_BUFFER_SIZE);
+	LOG_DBG("%d/%d used", buf->len, MAX_BUFFER_SIZE);
 
 	return ptr;
 }
 
-static void *gatt_buf_reserve(size_t len)
+static void *gatt_buf_reserve(struct net_buf *buf, size_t len)
 {
-	return gatt_buf_add(NULL, len);
+	return gatt_buf_add(buf, NULL, len);
 }
 
-static void gatt_buf_clear(void)
+static void gatt_buf_clear(struct net_buf *buf)
 {
-	(void)memset(&gatt_buf, 0, sizeof(gatt_buf));
+	if (buf == NULL) {
+		return;
+	}
+	net_buf_unref(buf);
 }
 
 static struct bt_gatt_attr *gatt_db_add(const struct bt_gatt_attr *pattern,
@@ -987,29 +993,42 @@ static uint8_t exchange_mtu(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-static struct bt_gatt_discover_params discover_params;
+static struct btp_gatt_discover_params {
+	struct bt_gatt_discover_params params;
+	struct net_buf *buf;
+} discover_params;
 static struct bt_uuid_any uuid;
 static uint8_t btp_opcode;
 
-static void discover_destroy(struct bt_gatt_discover_params *params)
+#define BTP_GET_DISCOVER_PARAMS(_params) \
+	CONTAINER_OF(_params, struct btp_gatt_discover_params, params);
+
+static void discover_destroy(struct btp_gatt_discover_params *discover)
 {
-	(void)memset(params, 0, sizeof(*params));
-	gatt_buf_clear();
+	gatt_buf_clear(discover->buf);
+	(void)memset(discover, 0, sizeof(*discover));
 }
 
 static uint8_t disc_prim_cb(struct bt_conn *conn,
 			 const struct bt_gatt_attr *attr,
 			 struct bt_gatt_discover_params *params)
 {
+	struct btp_gatt_discover_params *discover = BTP_GET_DISCOVER_PARAMS(params);
 	struct bt_gatt_service_val *data;
-	struct btp_gatt_disc_prim_rp *rp = (void *) gatt_buf.buf;
+	struct btp_gatt_disc_prim_rp *rp;
 	struct btp_gatt_service *service;
 	uint8_t uuid_length;
 
-	if (!attr) {
+	if (discover->buf == NULL) {
+		return BT_GATT_ITER_STOP;
+	}
+
+	rp = (void *)discover->buf->data;
+
+	if (attr == NULL) {
 		tester_rsp_full(BTP_SERVICE_ID_GATT, btp_opcode,
-				gatt_buf.buf, gatt_buf.len);
-		discover_destroy(params);
+				discover->buf->data, discover->buf->len);
+		discover_destroy(discover);
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -1017,10 +1036,10 @@ static uint8_t disc_prim_cb(struct bt_conn *conn,
 
 	uuid_length = data->uuid->type == BT_UUID_TYPE_16 ? 2 : 16;
 
-	service = gatt_buf_reserve(sizeof(*service) + uuid_length);
-	if (!service) {
+	service = gatt_buf_reserve(discover->buf, sizeof(*service) + uuid_length);
+	if (service == NULL) {
 		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode, BTP_STATUS_FAILED);
-		discover_destroy(params);
+		discover_destroy(discover);
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -1033,8 +1052,7 @@ static uint8_t disc_prim_cb(struct bt_conn *conn,
 
 		memcpy(service->uuid, &u16, uuid_length);
 	} else {
-		memcpy(service->uuid, BT_UUID_128(data->uuid)->val,
-		       uuid_length);
+		memcpy(service->uuid, BT_UUID_128(data->uuid)->val, uuid_length);
 	}
 
 	rp->services_count++;
@@ -1053,23 +1071,30 @@ static uint8_t disc_all_prim(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	if (!gatt_buf_reserve(sizeof(struct btp_gatt_disc_prim_rp))) {
+	discover_params.buf = gatt_buf_allocate();
+	if (discover_params.buf == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	discover_params.uuid = NULL;
-	discover_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
-	discover_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
-	discover_params.type = BT_GATT_DISCOVER_PRIMARY;
-	discover_params.func = disc_prim_cb;
+	if (gatt_buf_reserve(discover_params.buf, sizeof(struct btp_gatt_disc_prim_rp)) == NULL) {
+		discover_destroy(&discover_params);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	discover_params.params.uuid = NULL;
+	discover_params.params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
+	discover_params.params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
+	discover_params.params.type = BT_GATT_DISCOVER_PRIMARY;
+	discover_params.params.func = disc_prim_cb;
 #if defined(CONFIG_BT_EATT)
-	discover_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	discover_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	btp_opcode = BTP_GATT_DISC_ALL_PRIM;
 
-	if (bt_gatt_discover(conn, &discover_params) < 0) {
+	if (bt_gatt_discover(conn, &discover_params.params) < 0) {
 		discover_destroy(&discover_params);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
@@ -1101,23 +1126,30 @@ static uint8_t disc_prim_uuid(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	if (!gatt_buf_reserve(sizeof(struct btp_gatt_disc_prim_rp))) {
+	discover_params.buf = gatt_buf_allocate();
+	if (discover_params.buf == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	discover_params.uuid = &uuid.uuid;
-	discover_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
-	discover_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
-	discover_params.type = BT_GATT_DISCOVER_PRIMARY;
-	discover_params.func = disc_prim_cb;
+	if (gatt_buf_reserve(discover_params.buf, sizeof(struct btp_gatt_disc_prim_rp)) == NULL) {
+		discover_destroy(&discover_params);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	discover_params.params.uuid = &uuid.uuid;
+	discover_params.params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
+	discover_params.params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
+	discover_params.params.type = BT_GATT_DISCOVER_PRIMARY;
+	discover_params.params.func = disc_prim_cb;
 #if defined(CONFIG_BT_EATT)
-	discover_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	discover_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	btp_opcode = BTP_GATT_DISC_PRIM_UUID;
 
-	if (bt_gatt_discover(conn, &discover_params) < 0) {
+	if (bt_gatt_discover(conn, &discover_params.params) < 0) {
 		discover_destroy(&discover_params);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
@@ -1132,15 +1164,22 @@ static uint8_t find_included_cb(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				struct bt_gatt_discover_params *params)
 {
+	struct btp_gatt_discover_params *discover = BTP_GET_DISCOVER_PARAMS(params);
 	struct bt_gatt_include *data;
-	struct btp_gatt_find_included_rp *rp = (void *) gatt_buf.buf;
+	struct btp_gatt_find_included_rp *rp;
 	struct btp_gatt_included *included;
 	uint8_t uuid_length;
 
+	if (discover->buf == NULL) {
+		return BT_GATT_ITER_STOP;
+	}
+
+	rp = (void *)discover->buf->data;
+
 	if (!attr) {
 		tester_rsp_full(BTP_SERVICE_ID_GATT, BTP_GATT_FIND_INCLUDED,
-				gatt_buf.buf, gatt_buf.len);
-		discover_destroy(params);
+				discover->buf->data, discover->buf->len);
+		discover_destroy(discover);
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -1148,10 +1187,10 @@ static uint8_t find_included_cb(struct bt_conn *conn,
 
 	uuid_length = data->uuid->type == BT_UUID_TYPE_16 ? 2 : 16;
 
-	included = gatt_buf_reserve(sizeof(*included) + uuid_length);
+	included = gatt_buf_reserve(discover->buf, sizeof(*included) + uuid_length);
 	if (!included) {
 		tester_rsp(BTP_SERVICE_ID_GATT, BTP_GATT_FIND_INCLUDED, BTP_STATUS_FAILED);
-		discover_destroy(params);
+		discover_destroy(discover);
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -1185,20 +1224,28 @@ static uint8_t find_included(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	if (!gatt_buf_reserve(sizeof(struct btp_gatt_find_included_rp))) {
+	discover_params.buf = gatt_buf_allocate();
+	if (discover_params.buf == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	discover_params.start_handle = sys_le16_to_cpu(cp->start_handle);
-	discover_params.end_handle = sys_le16_to_cpu(cp->end_handle);
-	discover_params.type = BT_GATT_DISCOVER_INCLUDE;
-	discover_params.func = find_included_cb;
+	if (gatt_buf_reserve(discover_params.buf, sizeof(struct btp_gatt_find_included_rp)) ==
+	    NULL) {
+		discover_destroy(&discover_params);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	discover_params.params.start_handle = sys_le16_to_cpu(cp->start_handle);
+	discover_params.params.end_handle = sys_le16_to_cpu(cp->end_handle);
+	discover_params.params.type = BT_GATT_DISCOVER_INCLUDE;
+	discover_params.params.func = find_included_cb;
 #if defined(CONFIG_BT_EATT)
-	discover_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	discover_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
-	if (bt_gatt_discover(conn, &discover_params) < 0) {
+	if (bt_gatt_discover(conn, &discover_params.params) < 0) {
 		discover_destroy(&discover_params);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
@@ -1213,15 +1260,22 @@ static uint8_t disc_chrc_cb(struct bt_conn *conn,
 			    const struct bt_gatt_attr *attr,
 			    struct bt_gatt_discover_params *params)
 {
+	struct btp_gatt_discover_params *discover = BTP_GET_DISCOVER_PARAMS(params);
 	struct bt_gatt_chrc *data;
-	struct btp_gatt_disc_chrc_rp *rp = (void *) gatt_buf.buf;
+	struct btp_gatt_disc_chrc_rp *rp;
 	struct btp_gatt_characteristic *chrc;
 	uint8_t uuid_length;
 
+	if (discover->buf == NULL) {
+		return BT_GATT_ITER_STOP;
+	}
+
+	rp = (void *)discover->buf->data;
+
 	if (!attr) {
 		tester_rsp_full(BTP_SERVICE_ID_GATT, btp_opcode,
-				gatt_buf.buf, gatt_buf.len);
-		discover_destroy(params);
+				discover->buf->data, discover->buf->len);
+		discover_destroy(discover);
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -1229,10 +1283,10 @@ static uint8_t disc_chrc_cb(struct bt_conn *conn,
 
 	uuid_length = data->uuid->type == BT_UUID_TYPE_16 ? 2 : 16;
 
-	chrc = gatt_buf_reserve(sizeof(*chrc) + uuid_length);
+	chrc = gatt_buf_reserve(discover->buf, sizeof(*chrc) + uuid_length);
 	if (!chrc) {
 		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode, BTP_STATUS_FAILED);
-		discover_destroy(params);
+		discover_destroy(discover);
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -1265,23 +1319,30 @@ static uint8_t disc_all_chrc(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	if (!gatt_buf_reserve(sizeof(struct btp_gatt_disc_chrc_rp))) {
+	discover_params.buf = gatt_buf_allocate();
+	if (discover_params.buf == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	discover_params.start_handle = sys_le16_to_cpu(cp->start_handle);
-	discover_params.end_handle = sys_le16_to_cpu(cp->end_handle);
-	discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
-	discover_params.func = disc_chrc_cb;
+	if (gatt_buf_reserve(discover_params.buf, sizeof(struct btp_gatt_disc_chrc_rp)) == NULL) {
+		discover_destroy(&discover_params);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	discover_params.params.start_handle = sys_le16_to_cpu(cp->start_handle);
+	discover_params.params.end_handle = sys_le16_to_cpu(cp->end_handle);
+	discover_params.params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
+	discover_params.params.func = disc_chrc_cb;
 #if defined(CONFIG_BT_EATT)
-	discover_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	discover_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	/* TODO should be handled as user_data via CONTAINER_OF macro */
 	btp_opcode = BTP_GATT_DISC_ALL_CHRC;
 
-	if (bt_gatt_discover(conn, &discover_params) < 0) {
+	if (bt_gatt_discover(conn, &discover_params.params) < 0) {
 		discover_destroy(&discover_params);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
@@ -1313,24 +1374,31 @@ static uint8_t disc_chrc_uuid(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	if (!gatt_buf_reserve(sizeof(struct btp_gatt_disc_chrc_rp))) {
+	discover_params.buf = gatt_buf_allocate();
+	if (discover_params.buf == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	discover_params.uuid = &uuid.uuid;
-	discover_params.start_handle = sys_le16_to_cpu(cp->start_handle);
-	discover_params.end_handle = sys_le16_to_cpu(cp->end_handle);
-	discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
-	discover_params.func = disc_chrc_cb;
+	if (gatt_buf_reserve(discover_params.buf, sizeof(struct btp_gatt_disc_chrc_rp)) == NULL) {
+		discover_destroy(&discover_params);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	discover_params.params.uuid = &uuid.uuid;
+	discover_params.params.start_handle = sys_le16_to_cpu(cp->start_handle);
+	discover_params.params.end_handle = sys_le16_to_cpu(cp->end_handle);
+	discover_params.params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
+	discover_params.params.func = disc_chrc_cb;
 #if defined(CONFIG_BT_EATT)
-	discover_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	discover_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	/* TODO should be handled as user_data via CONTAINER_OF macro */
 	btp_opcode = BTP_GATT_DISC_CHRC_UUID;
 
-	if (bt_gatt_discover(conn, &discover_params) < 0) {
+	if (bt_gatt_discover(conn, &discover_params.params) < 0) {
 		discover_destroy(&discover_params);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
@@ -1345,23 +1413,30 @@ static uint8_t disc_all_desc_cb(struct bt_conn *conn,
 				const struct bt_gatt_attr *attr,
 				struct bt_gatt_discover_params *params)
 {
-	struct btp_gatt_disc_all_desc_rp *rp = (void *) gatt_buf.buf;
+	struct btp_gatt_discover_params *discover = BTP_GET_DISCOVER_PARAMS(params);
+	struct btp_gatt_disc_all_desc_rp *rp;
 	struct btp_gatt_descriptor *descriptor;
 	uint8_t uuid_length;
 
+	if (discover->buf == NULL) {
+		return BT_GATT_ITER_STOP;
+	}
+
+	rp = (void *)discover->buf->data;
+
 	if (!attr) {
 		tester_rsp_full(BTP_SERVICE_ID_GATT, BTP_GATT_DISC_ALL_DESC,
-				gatt_buf.buf, gatt_buf.len);
-		discover_destroy(params);
+				discover->buf->data, discover->buf->len);
+		discover_destroy(discover);
 		return BT_GATT_ITER_STOP;
 	}
 
 	uuid_length = attr->uuid->type == BT_UUID_TYPE_16 ? 2 : 16;
 
-	descriptor = gatt_buf_reserve(sizeof(*descriptor) + uuid_length);
+	descriptor = gatt_buf_reserve(discover->buf, sizeof(*descriptor) + uuid_length);
 	if (!descriptor) {
 		tester_rsp(BTP_SERVICE_ID_GATT, BTP_GATT_DISC_ALL_DESC, BTP_STATUS_FAILED);
-		discover_destroy(params);
+		discover_destroy(discover);
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -1393,20 +1468,28 @@ static uint8_t disc_all_desc(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	if (!gatt_buf_reserve(sizeof(struct btp_gatt_disc_all_desc_rp))) {
+	discover_params.buf = gatt_buf_allocate();
+	if (discover_params.buf == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	discover_params.start_handle = sys_le16_to_cpu(cp->start_handle);
-	discover_params.end_handle = sys_le16_to_cpu(cp->end_handle);
-	discover_params.type = BT_GATT_DISCOVER_DESCRIPTOR;
-	discover_params.func = disc_all_desc_cb;
+	if (gatt_buf_reserve(discover_params.buf, sizeof(struct btp_gatt_disc_all_desc_rp)) ==
+	    NULL) {
+		discover_destroy(&discover_params);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	discover_params.params.start_handle = sys_le16_to_cpu(cp->start_handle);
+	discover_params.params.end_handle = sys_le16_to_cpu(cp->end_handle);
+	discover_params.params.type = BT_GATT_DISCOVER_DESCRIPTOR;
+	discover_params.params.func = disc_all_desc_cb;
 #if defined(CONFIG_BT_EATT)
-	discover_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	discover_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
-	if (bt_gatt_discover(conn, &discover_params) < 0) {
+	if (bt_gatt_discover(conn, &discover_params.params) < 0) {
 		discover_destroy(&discover_params);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
@@ -1417,19 +1500,32 @@ static uint8_t disc_all_desc(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_DELAY_REPLY;
 }
 
-static struct bt_gatt_read_params read_params;
+static struct btp_gatt_read_params {
+	struct bt_gatt_read_params params;
+	struct net_buf *buf;
+} read_params;
 
-static void read_destroy(struct bt_gatt_read_params *params)
+static void read_destroy(struct btp_gatt_read_params *read)
 {
-	(void)memset(params, 0, sizeof(*params));
-	gatt_buf_clear();
+	gatt_buf_clear(read->buf);
+	(void)memset(read, 0, sizeof(*read));
 }
+
+#define BTP_GET_READ_PARAMS(_params) \
+	CONTAINER_OF(_params, struct btp_gatt_read_params, params);
 
 static uint8_t read_cb(struct bt_conn *conn, uint8_t err,
 		       struct bt_gatt_read_params *params, const void *data,
 		       uint16_t length)
 {
-	struct btp_gatt_read_rp *rp = (void *) gatt_buf.buf;
+	struct btp_gatt_read_params *read = BTP_GET_READ_PARAMS(params);
+	struct btp_gatt_read_rp *rp;
+
+	if (read->buf == NULL) {
+		return BT_GATT_ITER_STOP;
+	}
+
+	rp = (void *)read->buf->data;
 
 	/* Respond to the Lower Tester with ATT Error received */
 	if (err) {
@@ -1437,16 +1533,15 @@ static uint8_t read_cb(struct bt_conn *conn, uint8_t err,
 	}
 
 	/* read complete */
-	if (!data) {
-		tester_rsp_full(BTP_SERVICE_ID_GATT, btp_opcode,
-				gatt_buf.buf, gatt_buf.len);
-		read_destroy(params);
+	if (data == NULL) {
+		tester_rsp_full(BTP_SERVICE_ID_GATT, btp_opcode, read->buf->data, read->buf->len);
+		read_destroy(read);
 		return BT_GATT_ITER_STOP;
 	}
 
-	if (!gatt_buf_add(data, length)) {
+	if (gatt_buf_add(read->buf, data, length) == NULL) {
 		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode, BTP_STATUS_FAILED);
-		read_destroy(params);
+		read_destroy(read);
 		return BT_GATT_ITER_STOP;
 	}
 
@@ -1456,11 +1551,18 @@ static uint8_t read_cb(struct bt_conn *conn, uint8_t err,
 }
 
 static uint8_t read_uuid_cb(struct bt_conn *conn, uint8_t err,
-		       struct bt_gatt_read_params *params, const void *data,
-		       uint16_t length)
+			    struct bt_gatt_read_params *params, const void *data,
+			    uint16_t length)
 {
-	struct btp_gatt_read_uuid_rp *rp = (void *)gatt_buf.buf;
+	struct btp_gatt_read_params *read = BTP_GET_READ_PARAMS(params);
+	struct btp_gatt_read_uuid_rp *rp;
 	struct btp_gatt_char_value value;
+
+	if (read->buf == NULL) {
+		return BT_GATT_ITER_STOP;
+	}
+
+	rp = (void *)read->buf->data;
 
 	/* Respond to the Lower Tester with ATT Error received */
 	if (err) {
@@ -1469,9 +1571,8 @@ static uint8_t read_uuid_cb(struct bt_conn *conn, uint8_t err,
 
 	/* read complete */
 	if (!data) {
-		tester_rsp_full(BTP_SERVICE_ID_GATT, btp_opcode,
-				gatt_buf.buf, gatt_buf.len);
-		read_destroy(params);
+		tester_rsp_full(BTP_SERVICE_ID_GATT, btp_opcode, read->buf->data, read->buf->len);
+		read_destroy(read);
 
 		return BT_GATT_ITER_STOP;
 	}
@@ -1479,16 +1580,16 @@ static uint8_t read_uuid_cb(struct bt_conn *conn, uint8_t err,
 	value.handle = params->by_uuid.start_handle;
 	value.data_len = length;
 
-	if (!gatt_buf_add(&value, sizeof(struct btp_gatt_char_value))) {
+	if (gatt_buf_add(read->buf, &value, sizeof(struct btp_gatt_char_value)) == NULL) {
 		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode, BTP_STATUS_FAILED);
-		read_destroy(params);
+		read_destroy(read);
 
 		return BT_GATT_ITER_STOP;
 	}
 
-	if (!gatt_buf_add(data, length)) {
+	if (gatt_buf_add(read->buf, data, length) == NULL) {
 		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode, BTP_STATUS_FAILED);
-		read_destroy(params);
+		read_destroy(read);
 
 		return BT_GATT_ITER_STOP;
 	}
@@ -1509,23 +1610,30 @@ static uint8_t read_data(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	if (!gatt_buf_reserve(sizeof(struct btp_gatt_read_rp))) {
+	read_params.buf = gatt_buf_allocate();
+	if (read_params.buf == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.handle_count = 1;
-	read_params.single.handle = sys_le16_to_cpu(cp->handle);
-	read_params.single.offset = 0x0000;
-	read_params.func = read_cb;
+	if (gatt_buf_reserve(read_params.buf, sizeof(struct btp_gatt_read_rp)) == NULL) {
+		read_destroy(&read_params);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	read_params.params.handle_count = 1;
+	read_params.params.single.handle = sys_le16_to_cpu(cp->handle);
+	read_params.params.single.offset = 0x0000;
+	read_params.params.func = read_cb;
 #if defined(CONFIG_BT_EATT)
-	read_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	read_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	/* TODO should be handled as user_data via CONTAINER_OF macro */
 	btp_opcode = BTP_GATT_READ;
 
-	if (bt_gatt_read(conn, &read_params) < 0) {
+	if (bt_gatt_read(conn, &read_params.params) < 0) {
 		read_destroy(&read_params);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
@@ -1557,23 +1665,30 @@ static uint8_t read_uuid(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	if (!gatt_buf_reserve(sizeof(struct btp_gatt_read_uuid_rp))) {
+	read_params.buf = gatt_buf_allocate();
+	if (read_params.buf == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.by_uuid.uuid = &uuid.uuid;
-	read_params.handle_count = 0;
-	read_params.by_uuid.start_handle = sys_le16_to_cpu(cp->start_handle);
-	read_params.by_uuid.end_handle = sys_le16_to_cpu(cp->end_handle);
-	read_params.func = read_uuid_cb;
+	if (gatt_buf_reserve(read_params.buf, sizeof(struct btp_gatt_read_uuid_rp)) == NULL) {
+		read_destroy(&read_params);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	read_params.params.by_uuid.uuid = &uuid.uuid;
+	read_params.params.handle_count = 0;
+	read_params.params.by_uuid.start_handle = sys_le16_to_cpu(cp->start_handle);
+	read_params.params.by_uuid.end_handle = sys_le16_to_cpu(cp->end_handle);
+	read_params.params.func = read_uuid_cb;
 #if defined(CONFIG_BT_EATT)
-	read_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	read_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	btp_opcode = BTP_GATT_READ_UUID;
 
-	if (bt_gatt_read(conn, &read_params) < 0) {
+	if (bt_gatt_read(conn, &read_params.params) < 0) {
 		read_destroy(&read_params);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
@@ -1595,23 +1710,30 @@ static uint8_t read_long(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	if (!gatt_buf_reserve(sizeof(struct btp_gatt_read_rp))) {
+	read_params.buf = gatt_buf_allocate();
+	if (read_params.buf == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.handle_count = 1;
-	read_params.single.handle = sys_le16_to_cpu(cp->handle);
-	read_params.single.offset = sys_le16_to_cpu(cp->offset);
-	read_params.func = read_cb;
+	if (gatt_buf_reserve(read_params.buf, sizeof(struct btp_gatt_read_rp)) == NULL) {
+		read_destroy(&read_params);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	read_params.params.handle_count = 1;
+	read_params.params.single.handle = sys_le16_to_cpu(cp->handle);
+	read_params.params.single.offset = sys_le16_to_cpu(cp->offset);
+	read_params.params.func = read_cb;
 #if defined(CONFIG_BT_EATT)
-	read_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	read_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	/* TODO should be handled as user_data via CONTAINER_OF macro */
 	btp_opcode = BTP_GATT_READ_LONG;
 
-	if (bt_gatt_read(conn, &read_params) < 0) {
+	if (bt_gatt_read(conn, &read_params.params) < 0) {
 		read_destroy(&read_params);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
@@ -1648,24 +1770,31 @@ static uint8_t read_multiple(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	if (!gatt_buf_reserve(sizeof(struct btp_gatt_read_rp))) {
+	read_params.buf = gatt_buf_allocate();
+	if (read_params.buf == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.func = read_cb;
-	read_params.handle_count = cp->handles_count;
-	read_params.multiple.handles = handles; /* not used in read func */
-	read_params.multiple.variable = false;
+	if (gatt_buf_reserve(read_params.buf, sizeof(struct btp_gatt_read_rp)) == NULL) {
+		read_destroy(&read_params);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	read_params.params.func = read_cb;
+	read_params.params.handle_count = cp->handles_count;
+	read_params.params.multiple.handles = handles; /* not used in read func */
+	read_params.params.multiple.variable = false;
 #if defined(CONFIG_BT_EATT)
-	read_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	read_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	/* TODO should be handled as user_data via CONTAINER_OF macro */
 	btp_opcode = BTP_GATT_READ_MULTIPLE;
 
-	if (bt_gatt_read(conn, &read_params) < 0) {
-		gatt_buf_clear();
+	if (bt_gatt_read(conn, &read_params.params) < 0) {
+		read_destroy(&read_params);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
@@ -1700,24 +1829,31 @@ static uint8_t read_multiple_var(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	if (!gatt_buf_reserve(sizeof(struct btp_gatt_read_rp))) {
+	read_params.buf = gatt_buf_allocate();
+	if (read_params.buf == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.func = read_cb;
-	read_params.handle_count = cp->handles_count;
-	read_params.multiple.handles = handles; /* not used in read func */
-	read_params.multiple.variable = true;
+	if (gatt_buf_reserve(read_params.buf, sizeof(struct btp_gatt_read_rp)) == NULL) {
+		read_destroy(&read_params);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	read_params.params.func = read_cb;
+	read_params.params.handle_count = cp->handles_count;
+	read_params.params.multiple.handles = handles; /* not used in read func */
+	read_params.params.multiple.variable = true;
 #if defined(CONFIG_BT_EATT)
-	read_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	read_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	/* TODO should be handled as user_data via CONTAINER_OF macro */
 	btp_opcode = BTP_GATT_READ_MULTIPLE_VAR;
 
-	if (bt_gatt_read(conn, &read_params) < 0) {
-		gatt_buf_clear();
+	if (bt_gatt_read(conn, &read_params.params) < 0) {
+		read_destroy(&read_params);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
@@ -1887,7 +2023,7 @@ static void discover_complete(struct bt_conn *conn,
 	struct bt_gatt_subscribe_params *subscription;
 	uint8_t op, status;
 
-	subscription = find_subscription(discover_params.end_handle);
+	subscription = find_subscription(discover_params.params.end_handle);
 	__ASSERT_NO_MSG(subscription);
 
 	/* If no value handle it means that chrc has not been found */
@@ -1929,7 +2065,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 		return BT_GATT_ITER_STOP;
 	}
 
-	subscription = find_subscription(discover_params.end_handle);
+	subscription = find_subscription(discover_params.params.end_handle);
 	__ASSERT_NO_MSG(subscription);
 
 	/* Characteristic Value Handle is the next handle beyond declaration */
@@ -1954,17 +2090,17 @@ static int enable_subscription(struct bt_conn *conn, uint16_t ccc_handle,
 	}
 
 	/* if discovery is busy fail */
-	if (discover_params.start_handle) {
+	if (discover_params.params.start_handle) {
 		return -EBUSY;
 	}
 
 	/* Discover Characteristic Value this CCC Descriptor refers to */
-	discover_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
-	discover_params.end_handle = ccc_handle;
-	discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
-	discover_params.func = discover_func;
+	discover_params.params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
+	discover_params.params.end_handle = ccc_handle;
+	discover_params.params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
+	discover_params.params.func = discover_func;
 #if defined(CONFIG_BT_EATT)
-	discover_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	discover_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	subscription->ccc_handle = ccc_handle;
@@ -1974,7 +2110,7 @@ static int enable_subscription(struct bt_conn *conn, uint16_t ccc_handle,
 	/* require security level from time of subscription */
 	subscription->min_security = bt_conn_get_security(conn);
 
-	return bt_gatt_discover(conn, &discover_params);
+	return bt_gatt_discover(conn, &discover_params.params);
 }
 
 static int disable_subscription(struct bt_conn *conn, uint16_t ccc_handle)

--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -996,9 +996,9 @@ static uint8_t exchange_mtu(const void *cmd, uint16_t cmd_len,
 static struct btp_gatt_discover_params {
 	struct bt_gatt_discover_params params;
 	struct net_buf *buf;
+	uint8_t opcode;
 } discover_params;
 static struct bt_uuid_any uuid;
-static uint8_t btp_opcode;
 
 #define BTP_GET_DISCOVER_PARAMS(_params) \
 	CONTAINER_OF(_params, struct btp_gatt_discover_params, params);
@@ -1026,8 +1026,8 @@ static uint8_t disc_prim_cb(struct bt_conn *conn,
 	rp = (void *)discover->buf->data;
 
 	if (attr == NULL) {
-		tester_rsp_full(BTP_SERVICE_ID_GATT, btp_opcode,
-				discover->buf->data, discover->buf->len);
+		tester_rsp_full(BTP_SERVICE_ID_GATT, discover->opcode, discover->buf->data,
+				discover->buf->len);
 		discover_destroy(discover);
 		return BT_GATT_ITER_STOP;
 	}
@@ -1038,7 +1038,7 @@ static uint8_t disc_prim_cb(struct bt_conn *conn,
 
 	service = gatt_buf_reserve(discover->buf, sizeof(*service) + uuid_length);
 	if (service == NULL) {
-		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode, BTP_STATUS_FAILED);
+		tester_rsp(BTP_SERVICE_ID_GATT, discover->opcode, BTP_STATUS_FAILED);
 		discover_destroy(discover);
 		return BT_GATT_ITER_STOP;
 	}
@@ -1092,7 +1092,7 @@ static uint8_t disc_all_prim(const void *cmd, uint16_t cmd_len,
 	discover_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
-	btp_opcode = BTP_GATT_DISC_ALL_PRIM;
+	discover_params.opcode = BTP_GATT_DISC_ALL_PRIM;
 
 	if (bt_gatt_discover(conn, &discover_params.params) < 0) {
 		discover_destroy(&discover_params);
@@ -1147,7 +1147,7 @@ static uint8_t disc_prim_uuid(const void *cmd, uint16_t cmd_len,
 	discover_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
-	btp_opcode = BTP_GATT_DISC_PRIM_UUID;
+	discover_params.opcode = BTP_GATT_DISC_PRIM_UUID;
 
 	if (bt_gatt_discover(conn, &discover_params.params) < 0) {
 		discover_destroy(&discover_params);
@@ -1273,7 +1273,7 @@ static uint8_t disc_chrc_cb(struct bt_conn *conn,
 	rp = (void *)discover->buf->data;
 
 	if (!attr) {
-		tester_rsp_full(BTP_SERVICE_ID_GATT, btp_opcode,
+		tester_rsp_full(BTP_SERVICE_ID_GATT, discover->opcode,
 				discover->buf->data, discover->buf->len);
 		discover_destroy(discover);
 		return BT_GATT_ITER_STOP;
@@ -1285,7 +1285,7 @@ static uint8_t disc_chrc_cb(struct bt_conn *conn,
 
 	chrc = gatt_buf_reserve(discover->buf, sizeof(*chrc) + uuid_length);
 	if (!chrc) {
-		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode, BTP_STATUS_FAILED);
+		tester_rsp(BTP_SERVICE_ID_GATT, discover->opcode, BTP_STATUS_FAILED);
 		discover_destroy(discover);
 		return BT_GATT_ITER_STOP;
 	}
@@ -1339,8 +1339,7 @@ static uint8_t disc_all_chrc(const void *cmd, uint16_t cmd_len,
 	discover_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
-	/* TODO should be handled as user_data via CONTAINER_OF macro */
-	btp_opcode = BTP_GATT_DISC_ALL_CHRC;
+	discover_params.opcode = BTP_GATT_DISC_ALL_CHRC;
 
 	if (bt_gatt_discover(conn, &discover_params.params) < 0) {
 		discover_destroy(&discover_params);
@@ -1395,8 +1394,7 @@ static uint8_t disc_chrc_uuid(const void *cmd, uint16_t cmd_len,
 	discover_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
-	/* TODO should be handled as user_data via CONTAINER_OF macro */
-	btp_opcode = BTP_GATT_DISC_CHRC_UUID;
+	discover_params.opcode = BTP_GATT_DISC_CHRC_UUID;
 
 	if (bt_gatt_discover(conn, &discover_params.params) < 0) {
 		discover_destroy(&discover_params);
@@ -1505,6 +1503,7 @@ static uint8_t disc_all_desc(const void *cmd, uint16_t cmd_len,
 static struct btp_gatt_read_params {
 	struct bt_gatt_read_params params;
 	struct net_buf *buf;
+	uint8_t opcode;
 } read_params[BTP_READ_PARAMS_COUNT];
 
 static void read_destroy(struct btp_gatt_read_params *read)
@@ -1559,13 +1558,13 @@ static uint8_t read_cb(struct bt_conn *conn, uint8_t err,
 
 	/* read complete */
 	if (data == NULL) {
-		tester_rsp_full(BTP_SERVICE_ID_GATT, btp_opcode, read->buf->data, read->buf->len);
+		tester_rsp_full(BTP_SERVICE_ID_GATT, read->opcode, read->buf->data, read->buf->len);
 		read_destroy(read);
 		return BT_GATT_ITER_STOP;
 	}
 
 	if (gatt_buf_add(read->buf, data, length) == NULL) {
-		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode, BTP_STATUS_FAILED);
+		tester_rsp(BTP_SERVICE_ID_GATT, read->opcode, BTP_STATUS_FAILED);
 		read_destroy(read);
 		return BT_GATT_ITER_STOP;
 	}
@@ -1596,7 +1595,7 @@ static uint8_t read_uuid_cb(struct bt_conn *conn, uint8_t err,
 
 	/* read complete */
 	if (!data) {
-		tester_rsp_full(BTP_SERVICE_ID_GATT, btp_opcode, read->buf->data, read->buf->len);
+		tester_rsp_full(BTP_SERVICE_ID_GATT, read->opcode, read->buf->data, read->buf->len);
 		read_destroy(read);
 
 		return BT_GATT_ITER_STOP;
@@ -1606,14 +1605,14 @@ static uint8_t read_uuid_cb(struct bt_conn *conn, uint8_t err,
 	value.data_len = length;
 
 	if (gatt_buf_add(read->buf, &value, sizeof(struct btp_gatt_char_value)) == NULL) {
-		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode, BTP_STATUS_FAILED);
+		tester_rsp(BTP_SERVICE_ID_GATT, read->opcode, BTP_STATUS_FAILED);
 		read_destroy(read);
 
 		return BT_GATT_ITER_STOP;
 	}
 
 	if (gatt_buf_add(read->buf, data, length) == NULL) {
-		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode, BTP_STATUS_FAILED);
+		tester_rsp(BTP_SERVICE_ID_GATT, read->opcode, BTP_STATUS_FAILED);
 		read_destroy(read);
 
 		return BT_GATT_ITER_STOP;
@@ -1656,8 +1655,7 @@ static uint8_t read_data(const void *cmd, uint16_t cmd_len,
 	read->params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
-	/* TODO should be handled as user_data via CONTAINER_OF macro */
-	btp_opcode = BTP_GATT_READ;
+	read->opcode = BTP_GATT_READ;
 
 	if (bt_gatt_read(conn, &read->params) < 0) {
 		read_destroy(read);
@@ -1713,7 +1711,7 @@ static uint8_t read_uuid(const void *cmd, uint16_t cmd_len,
 	read->params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
-	btp_opcode = BTP_GATT_READ_UUID;
+	read->opcode = BTP_GATT_READ_UUID;
 
 	if (bt_gatt_read(conn, &read->params) < 0) {
 		read_destroy(read);
@@ -1758,8 +1756,7 @@ static uint8_t read_long(const void *cmd, uint16_t cmd_len,
 	read->params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
-	/* TODO should be handled as user_data via CONTAINER_OF macro */
-	btp_opcode = BTP_GATT_READ_LONG;
+	read->opcode = BTP_GATT_READ_LONG;
 
 	if (bt_gatt_read(conn, &read->params) < 0) {
 		read_destroy(read);
@@ -1819,8 +1816,7 @@ static uint8_t read_multiple(const void *cmd, uint16_t cmd_len,
 	read->params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
-	/* TODO should be handled as user_data via CONTAINER_OF macro */
-	btp_opcode = BTP_GATT_READ_MULTIPLE;
+	read->opcode = BTP_GATT_READ_MULTIPLE;
 
 	if (bt_gatt_read(conn, &read->params) < 0) {
 		read_destroy(read);
@@ -1879,8 +1875,7 @@ static uint8_t read_multiple_var(const void *cmd, uint16_t cmd_len,
 	read->params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
-	/* TODO should be handled as user_data via CONTAINER_OF macro */
-	btp_opcode = BTP_GATT_READ_MULTIPLE_VAR;
+	read->opcode = BTP_GATT_READ_MULTIPLE_VAR;
 
 	if (bt_gatt_read(conn, &read->params) < 0) {
 		read_destroy(read);

--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -1500,15 +1500,40 @@ static uint8_t disc_all_desc(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_DELAY_REPLY;
 }
 
+#define BTP_READ_PARAMS_COUNT 2
+
 static struct btp_gatt_read_params {
 	struct bt_gatt_read_params params;
 	struct net_buf *buf;
-} read_params;
+} read_params[BTP_READ_PARAMS_COUNT];
 
 static void read_destroy(struct btp_gatt_read_params *read)
 {
 	gatt_buf_clear(read->buf);
 	(void)memset(read, 0, sizeof(*read));
+}
+
+static struct btp_gatt_read_params *read_allocate(void)
+{
+	struct btp_gatt_read_params *read = NULL;
+
+	ARRAY_FOR_EACH(read_params, i) {
+		if (read_params[i].buf == NULL) {
+			read = &read_params[i];
+		}
+	}
+
+	if (read == NULL) {
+		return NULL;
+	}
+
+	read->buf = gatt_buf_allocate();
+	if (read->buf == NULL) {
+		read_destroy(read);
+		return NULL;
+	}
+
+	return read;
 }
 
 #define BTP_GET_READ_PARAMS(_params) \
@@ -1602,6 +1627,7 @@ static uint8_t read_uuid_cb(struct bt_conn *conn, uint8_t err,
 static uint8_t read_data(const void *cmd, uint16_t cmd_len,
 			 void *rsp, uint16_t *rsp_len)
 {
+	struct btp_gatt_read_params *read;
 	const struct btp_gatt_read_cmd *cp = cmd;
 	struct bt_conn *conn;
 
@@ -1610,31 +1636,31 @@ static uint8_t read_data(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.buf = gatt_buf_allocate();
-	if (read_params.buf == NULL) {
+	read = read_allocate();
+	if (read == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	if (gatt_buf_reserve(read_params.buf, sizeof(struct btp_gatt_read_rp)) == NULL) {
-		read_destroy(&read_params);
+	if (gatt_buf_reserve(read->buf, sizeof(struct btp_gatt_read_rp)) == NULL) {
+		read_destroy(read);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.params.handle_count = 1;
-	read_params.params.single.handle = sys_le16_to_cpu(cp->handle);
-	read_params.params.single.offset = 0x0000;
-	read_params.params.func = read_cb;
+	read->params.handle_count = 1;
+	read->params.single.handle = sys_le16_to_cpu(cp->handle);
+	read->params.single.offset = 0x0000;
+	read->params.func = read_cb;
 #if defined(CONFIG_BT_EATT)
-	read_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	read->params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	/* TODO should be handled as user_data via CONTAINER_OF macro */
 	btp_opcode = BTP_GATT_READ;
 
-	if (bt_gatt_read(conn, &read_params.params) < 0) {
-		read_destroy(&read_params);
+	if (bt_gatt_read(conn, &read->params) < 0) {
+		read_destroy(read);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
@@ -1647,6 +1673,7 @@ static uint8_t read_data(const void *cmd, uint16_t cmd_len,
 static uint8_t read_uuid(const void *cmd, uint16_t cmd_len,
 			 void *rsp, uint16_t *rsp_len)
 {
+	struct btp_gatt_read_params *read;
 	const struct btp_gatt_read_uuid_cmd *cp = cmd;
 	struct bt_conn *conn;
 
@@ -1665,31 +1692,31 @@ static uint8_t read_uuid(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.buf = gatt_buf_allocate();
-	if (read_params.buf == NULL) {
+	read = read_allocate();
+	if (read == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	if (gatt_buf_reserve(read_params.buf, sizeof(struct btp_gatt_read_uuid_rp)) == NULL) {
-		read_destroy(&read_params);
+	if (gatt_buf_reserve(read->buf, sizeof(struct btp_gatt_read_uuid_rp)) == NULL) {
+		read_destroy(read);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.params.by_uuid.uuid = &uuid.uuid;
-	read_params.params.handle_count = 0;
-	read_params.params.by_uuid.start_handle = sys_le16_to_cpu(cp->start_handle);
-	read_params.params.by_uuid.end_handle = sys_le16_to_cpu(cp->end_handle);
-	read_params.params.func = read_uuid_cb;
+	read->params.by_uuid.uuid = &uuid.uuid;
+	read->params.handle_count = 0;
+	read->params.by_uuid.start_handle = sys_le16_to_cpu(cp->start_handle);
+	read->params.by_uuid.end_handle = sys_le16_to_cpu(cp->end_handle);
+	read->params.func = read_uuid_cb;
 #if defined(CONFIG_BT_EATT)
-	read_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	read->params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	btp_opcode = BTP_GATT_READ_UUID;
 
-	if (bt_gatt_read(conn, &read_params.params) < 0) {
-		read_destroy(&read_params);
+	if (bt_gatt_read(conn, &read->params) < 0) {
+		read_destroy(read);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
@@ -1702,6 +1729,7 @@ static uint8_t read_uuid(const void *cmd, uint16_t cmd_len,
 static uint8_t read_long(const void *cmd, uint16_t cmd_len,
 			 void *rsp, uint16_t *rsp_len)
 {
+	struct btp_gatt_read_params *read;
 	const struct btp_gatt_read_long_cmd *cp = cmd;
 	struct bt_conn *conn;
 
@@ -1710,31 +1738,31 @@ static uint8_t read_long(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.buf = gatt_buf_allocate();
-	if (read_params.buf == NULL) {
+	read = read_allocate();
+	if (read == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	if (gatt_buf_reserve(read_params.buf, sizeof(struct btp_gatt_read_rp)) == NULL) {
-		read_destroy(&read_params);
+	if (gatt_buf_reserve(read->buf, sizeof(struct btp_gatt_read_rp)) == NULL) {
+		read_destroy(read);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.params.handle_count = 1;
-	read_params.params.single.handle = sys_le16_to_cpu(cp->handle);
-	read_params.params.single.offset = sys_le16_to_cpu(cp->offset);
-	read_params.params.func = read_cb;
+	read->params.handle_count = 1;
+	read->params.single.handle = sys_le16_to_cpu(cp->handle);
+	read->params.single.offset = sys_le16_to_cpu(cp->offset);
+	read->params.func = read_cb;
 #if defined(CONFIG_BT_EATT)
-	read_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	read->params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	/* TODO should be handled as user_data via CONTAINER_OF macro */
 	btp_opcode = BTP_GATT_READ_LONG;
 
-	if (bt_gatt_read(conn, &read_params.params) < 0) {
-		read_destroy(&read_params);
+	if (bt_gatt_read(conn, &read->params) < 0) {
+		read_destroy(read);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
@@ -1747,6 +1775,7 @@ static uint8_t read_long(const void *cmd, uint16_t cmd_len,
 static uint8_t read_multiple(const void *cmd, uint16_t cmd_len,
 			     void *rsp, uint16_t *rsp_len)
 {
+	struct btp_gatt_read_params *read;
 	const struct btp_gatt_read_multiple_cmd *cp = cmd;
 	uint16_t handles[5];
 	struct bt_conn *conn;
@@ -1770,31 +1799,31 @@ static uint8_t read_multiple(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.buf = gatt_buf_allocate();
-	if (read_params.buf == NULL) {
+	read = read_allocate();
+	if (read == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	if (gatt_buf_reserve(read_params.buf, sizeof(struct btp_gatt_read_rp)) == NULL) {
-		read_destroy(&read_params);
+	if (gatt_buf_reserve(read->buf, sizeof(struct btp_gatt_read_rp)) == NULL) {
+		read_destroy(read);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.params.func = read_cb;
-	read_params.params.handle_count = cp->handles_count;
-	read_params.params.multiple.handles = handles; /* not used in read func */
-	read_params.params.multiple.variable = false;
+	read->params.func = read_cb;
+	read->params.handle_count = cp->handles_count;
+	read->params.multiple.handles = handles; /* not used in read func */
+	read->params.multiple.variable = false;
 #if defined(CONFIG_BT_EATT)
-	read_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	read->params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	/* TODO should be handled as user_data via CONTAINER_OF macro */
 	btp_opcode = BTP_GATT_READ_MULTIPLE;
 
-	if (bt_gatt_read(conn, &read_params.params) < 0) {
-		read_destroy(&read_params);
+	if (bt_gatt_read(conn, &read->params) < 0) {
+		read_destroy(read);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
@@ -1807,6 +1836,7 @@ static uint8_t read_multiple(const void *cmd, uint16_t cmd_len,
 static uint8_t read_multiple_var(const void *cmd, uint16_t cmd_len,
 				 void *rsp, uint16_t *rsp_len)
 {
+	struct btp_gatt_read_params *read;
 	const struct btp_gatt_read_multiple_var_cmd *cp = cmd;
 	uint16_t handles[5];
 	struct bt_conn *conn;
@@ -1829,31 +1859,31 @@ static uint8_t read_multiple_var(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.buf = gatt_buf_allocate();
-	if (read_params.buf == NULL) {
+	read = read_allocate();
+	if (read == NULL) {
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	if (gatt_buf_reserve(read_params.buf, sizeof(struct btp_gatt_read_rp)) == NULL) {
-		read_destroy(&read_params);
+	if (gatt_buf_reserve(read->buf, sizeof(struct btp_gatt_read_rp)) == NULL) {
+		read_destroy(read);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
 
-	read_params.params.func = read_cb;
-	read_params.params.handle_count = cp->handles_count;
-	read_params.params.multiple.handles = handles; /* not used in read func */
-	read_params.params.multiple.variable = true;
+	read->params.func = read_cb;
+	read->params.handle_count = cp->handles_count;
+	read->params.multiple.handles = handles; /* not used in read func */
+	read->params.multiple.variable = true;
 #if defined(CONFIG_BT_EATT)
-	read_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	read->params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
 	/* TODO should be handled as user_data via CONTAINER_OF macro */
 	btp_opcode = BTP_GATT_READ_MULTIPLE_VAR;
 
-	if (bt_gatt_read(conn, &read_params.params) < 0) {
-		read_destroy(&read_params);
+	if (bt_gatt_read(conn, &read->params) < 0) {
+		read_destroy(read);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}

--- a/tests/bluetooth/tester/src/btp_gatt.c
+++ b/tests/bluetooth/tester/src/btp_gatt.c
@@ -1916,22 +1916,36 @@ static uint8_t write_without_rsp(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-static void write_rsp(struct bt_conn *conn, uint8_t err,
-		      struct bt_gatt_write_params *params)
+static struct btp_gatt_write_params {
+	struct bt_gatt_write_params params;
+	struct net_buf *buf;
+} write_params;
+
+static void write_destroy(struct btp_gatt_write_params *write)
 {
-	tester_rsp_full(BTP_SERVICE_ID_GATT, BTP_GATT_WRITE, &err, sizeof(err));
+	gatt_buf_clear(write->buf);
+	(void)memset(write, 0, sizeof(*write));
 }
 
-static struct bt_gatt_write_params write_params;
+#define BTP_GET_WRITE_PARAMS(_params) \
+	CONTAINER_OF(_params, struct btp_gatt_write_params, params);
+
+static void write_rsp(struct bt_conn *conn, uint8_t err, struct bt_gatt_write_params *params)
+{
+	struct btp_gatt_write_params *write = BTP_GET_WRITE_PARAMS(params);
+
+	write_destroy(write);
+	tester_rsp_full(BTP_SERVICE_ID_GATT, BTP_GATT_WRITE, &err, sizeof(err));
+}
 
 static uint8_t write_data(const void *cmd, uint16_t cmd_len,
 			  void *rsp, uint16_t *rsp_len)
 {
 	const struct btp_gatt_write_cmd *cp = cmd;
 	struct bt_conn *conn;
+	uint16_t len = sys_le16_to_cpu(cp->data_length);
 
-	if (cmd_len < sizeof(*cp) ||
-	    cmd_len != sizeof(*cp) + sys_le16_to_cpu(cp->data_length)) {
+	if (cmd_len < sizeof(*cp) || cmd_len != sizeof(*cp) + len) {
 		return BTP_STATUS_FAILED;
 	}
 
@@ -1940,16 +1954,31 @@ static uint8_t write_data(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	write_params.handle = sys_le16_to_cpu(cp->handle);
-	write_params.func = write_rsp;
-	write_params.offset = 0U;
-	write_params.data = cp->data;
-	write_params.length = sys_le16_to_cpu(cp->data_length);
+	write_params.buf = gatt_buf_allocate();
+	if (write_params.buf == NULL) {
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	if (net_buf_tailroom(write_params.buf) < len) {
+		write_destroy(&write_params);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	net_buf_add_mem(write_params.buf, cp->data, len);
+
+	write_params.params.handle = sys_le16_to_cpu(cp->handle);
+	write_params.params.func = write_rsp;
+	write_params.params.offset = 0U;
+	write_params.params.data = write_params.buf->data;
+	write_params.params.length = len;
 #if defined(CONFIG_BT_EATT)
-	write_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	write_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
-	if (bt_gatt_write(conn, &write_params) < 0) {
+	if (bt_gatt_write(conn, &write_params.params) < 0) {
+		write_destroy(&write_params);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}
@@ -1961,6 +1990,9 @@ static uint8_t write_data(const void *cmd, uint16_t cmd_len,
 static void write_long_rsp(struct bt_conn *conn, uint8_t err,
 			   struct bt_gatt_write_params *params)
 {
+	struct btp_gatt_write_params *write = BTP_GET_WRITE_PARAMS(params);
+
+	write_destroy(write);
 	tester_rsp_full(BTP_SERVICE_ID_GATT, BTP_GATT_WRITE_LONG, &err, sizeof(err));
 }
 
@@ -1969,9 +2001,9 @@ static uint8_t write_long(const void *cmd, uint16_t cmd_len,
 {
 	const struct btp_gatt_write_long_cmd *cp = cmd;
 	struct bt_conn *conn;
+	uint16_t len = sys_le16_to_cpu(cp->data_length);
 
-	if (cmd_len < sizeof(*cp) ||
-	    cmd_len != sizeof(*cp) + sys_le16_to_cpu(cp->data_length)) {
+	if (cmd_len < sizeof(*cp) || cmd_len != sizeof(*cp) + len) {
 		return BTP_STATUS_FAILED;
 	}
 
@@ -1980,16 +2012,31 @@ static uint8_t write_long(const void *cmd, uint16_t cmd_len,
 		return BTP_STATUS_FAILED;
 	}
 
-	write_params.handle = sys_le16_to_cpu(cp->handle);
-	write_params.func = write_long_rsp;
-	write_params.offset = sys_le16_to_cpu(cp->offset);
-	write_params.data = cp->data;
-	write_params.length = sys_le16_to_cpu(cp->data_length);
+	write_params.buf = gatt_buf_allocate();
+	if (write_params.buf == NULL) {
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	if (net_buf_tailroom(write_params.buf) < len) {
+		write_destroy(&write_params);
+		bt_conn_unref(conn);
+		return BTP_STATUS_FAILED;
+	}
+
+	net_buf_add_mem(write_params.buf, cp->data, len);
+
+	write_params.params.handle = sys_le16_to_cpu(cp->handle);
+	write_params.params.func = write_long_rsp;
+	write_params.params.offset = sys_le16_to_cpu(cp->offset);
+	write_params.params.data = write_params.buf->data;
+	write_params.params.length = len;
 #if defined(CONFIG_BT_EATT)
-	write_params.chan_opt = BT_ATT_CHAN_OPT_NONE;
+	write_params.params.chan_opt = BT_ATT_CHAN_OPT_NONE;
 #endif
 
-	if (bt_gatt_write(conn, &write_params) < 0) {
+	if (bt_gatt_write(conn, &write_params.params) < 0) {
+		write_destroy(&write_params);
 		bt_conn_unref(conn);
 		return BTP_STATUS_FAILED;
 	}


### PR DESCRIPTION
* tests: bluetooth: tester: refactor gatt buffer management to use net_buf

Replace static gatt_buf structure with dynamic net_buf allocation for GATT client operations. This change introduces a buffer pool to manage multiple concurrent GATT operations more efficiently.

This refactoring enables better memory management and prepares the code for handling concurrent GATT operations without buffer conflicts.

* tests: bluetooth: tester: support concurrent GATT read operations

Replace single read_params instance with an array of read parameter structures to enable concurrent GATT read operations. Introduce read_allocate() function to manage allocation from the read_params pool.

This change allows up to BTP_READ_PARAMS_COUNT (2) concurrent GATT read operations, preventing conflicts when multiple read requests are in progress simultaneously.

All read operation functions (read_data, read_uuid, read_long, read_multiple, read_multiple_var) now allocate their parameters dynamically from the pool instead of using a shared global instance.

* tests: bluetooth: tester: refactor opcode storage in GATT operations

Since the dedicated gatt discover and read params are added, the `opcode` of the request can be saved to the related params.

Move opcode storage from global btp_opcode variable into the operation parameter structures (`btp_gatt_discover_params` and `btp_gatt_read_params`).

This change eliminates the shared global btp_opcode variable by adding an opcode field to each operation's parameter structure. Each operation now stores its own opcode, preventing conflicts when multiple concurrent GATT operations are in progress.

The refactoring affects both discovery operations (disc_prim_cb, disc_chrc_cb) and read operations (read_cb, read_uuid_cb), ensuring each operation uses its own opcode when sending responses via tester_rsp_full() and tester_rsp().

This prepares the code for better handling of concurrent GATT operations by removing shared state dependencies.

* tests: bluetooth: tester: refactor GATT write to use net_buf

Replace direct data pointer usage with dynamic net_buf allocation for GATT write operations. This change introduces a btp_gatt_write_params structure that wraps bt_gatt_write_params and includes a net_buf pointer for data management.

Add write_destroy() function to handle cleanup of the write buffer and parameter structure. This function is called in write_rsp() and write_long_rsp() callbacks, as well as in error paths to ensure proper resource cleanup.

This refactoring aligns write operations with the existing read and discovery operations' buffer management pattern, preparing the code for better handling of concurrent GATT operations by eliminating direct pointer dependencies on command data.

* tests: bluetooth: tester: simplify delayed command handling

Remove the global delayed_cmd variable and associated cleanup logic from tester_rsp() and tester_rsp_full() functions. The delayed command buffer management is now handled directly in the cmd_handler() loop.

When a command returns BTP_STATUS_DELAY_REPLY, the handler now jumps to the cleanup label instead of storing the command in delayed_cmd. This allows the command buffer to be cleaned up and returned to the available queue immediately after processing, rather than waiting for a later call to tester_rsp() or tester_rsp_full().

The tester_rsp() and tester_rsp_full() functions are simplified to only send responses without managing command buffer lifecycle.

This change removes shared state dependencies and simplifies the command handling flow, continuing the refactoring effort to support concurrent GATT operations.
