### PR TITLE
Bluetooth: BAP: Fix fake uninitialized pd var

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -478,7 +478,7 @@ static bool encode_base(struct bt_bap_broadcast_source *source, struct net_buf_s
 	struct bt_bap_broadcast_subgroup *subgroup;
 	uint8_t streams_encoded;
 	uint8_t subgroup_count;
-	uint32_t pd;
+	uint32_t pd = 0U;
 
 	/* 13 is the size of the fixed size values following this check */
 	if ((buf->size - buf->len) < MINIMUM_BASE_SIZE) {


### PR DESCRIPTION
Some compilers would give the following warning:

subsys/bluetooth/audio/bap_broadcast_source.c:513:9: warning: 'pd' may be used uninitialized [-Wmaybe-uninitialized]
  513 |         net_buf_simple_add_le24(buf, pd);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Even though the assignment `subgroup_count = 0U;`
and later check `if (subgroup_count == 0U) {` would ensure that `pd = stream->ep->qos.pd;` is always performed.

Add a initialization of the variable to avoid any
warnings.