### PR TITLE
nRF7120 cpuflpr MRAM node update

### DIFF
--- a/drivers/flash/soc_flash_nrf_mramc.c
+++ b/drivers/flash/soc_flash_nrf_mramc.c
@@ -20,8 +20,8 @@ LOG_MODULE_REGISTER(flash_nrf_mramc, CONFIG_FLASH_LOG_LEVEL);
 
 #define DT_DRV_COMPAT nordic_nrf_mramc
 
-#define MRAM_NODE		  DT_NODELABEL(cpuapp_mram)
-#define MRAM_BASE		 DT_REG_ADDR(MRAM_NODE)
+#define MRAM_NODE		  DT_INST(0, soc_nv_flash)
+#define MRAM_BASE		  DT_REG_ADDR(MRAM_NODE)
 #define MRAM_SIZE		  DT_REG_SIZE(MRAM_NODE)
 
 BUILD_ASSERT(MRAM_BASE <= UINT32_MAX, "MRAM_BASE is not in size of uint32_t");

--- a/dts/riscv/nordic/nrf7120_enga_cpuflpr.dtsi
+++ b/dts/riscv/nordic/nrf7120_enga_cpuflpr.dtsi
@@ -21,7 +21,7 @@ clic: &cpuflpr_clic {};
 		reg = <0x3de000 DT_SIZE_K(116)>;
 		ranges = <0x0 0x3de000 DT_SIZE_K(116)>;
 		erase-block-size = <4096>;
-		write-block-size = <4>;
+		write-block-size = <16>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 	};


### PR DESCRIPTION
**Device Tree and Driver Configuration Updates:**

* Changed the MRAM node reference in `soc_flash_nrf_mramc.c` to use `DT_INST(0, soc_nv_flash)` instead of a fixed node label, making the driver more flexible and compatible with device tree instance bindings.
* Increased to use the correct `write-block-size` for MRAM in `nrf7120_enga_cpuflpr.dtsi` from 4 bytes to 16 bytes.