### PR TITLE
babblesim bt LL: Build and run with twister

### DIFF
--- a/tests/bsim/bluetooth/ll/advx/tests.yaml
+++ b/tests/bsim/bluetooth/ll/advx/tests.yaml
@@ -1,0 +1,34 @@
+common:
+  tags:
+    - bluetooth
+  depends_on: bsim
+  platform_allow:
+    - nrf52_bsim/native
+    - nrf5340bsim/nrf5340/cpunet
+    - nrf54l15bsim/nrf54l15/cpuapp
+  harness: bsim
+tests:
+  bluetooth.ll.advx:
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_advx_prj_conf
+      tests_scripts:
+        - tests_scripts/basic_advx.sh
+
+  bluetooth.ll.advx.ticker_expire_info:
+    extra_overlay_confs:
+      - overlay-ticker_expire_info.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_advx_prj_conf_overlay-ticker_expire_info_conf
+      tests_scripts:
+        - tests_scripts/basic_advx_ticker_expire_info.sh
+
+  bluetooth.ll.advx.scan_aux_use_chains:
+    extra_overlay_confs:
+      - overlay-scan_aux_use_chains.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_advx_prj_conf_overlay-scan_aux_use_chains_conf
+      tests_scripts:
+        - tests_scripts/basic_advx_scan_aux_use_chains.sh

--- a/tests/bsim/bluetooth/ll/bis/tests.yaml
+++ b/tests/bsim/bluetooth/ll/bis/tests.yaml
@@ -1,45 +1,104 @@
 common:
-  build_only: true
+  timeout: 120
   tags:
     - bluetooth
   depends_on: bsim
+  harness: bsim
 
 tests:
-  bluetooth.ll.bis:
+  bluetooth.ll.bis.sequential:
     sysbuild: true
-    harness: bsim
+    platform_allow:
+      - nrf52_bsim/native
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf5340bsim/nrf5340/cpunet
+      - nrf54l15bsim/nrf54l15/cpuapp
+    extra_overlay_confs:
+      - overlay-sequential.conf
     harness_config:
-      bsim_exe_name: tests_bsim_bluetooth_ll_bis_prj_conf
-  bluetooth.ll.bis_ticker_expire_info:
-    extra_args: EXTRA_CONF_FILE=overlay-ticker_expire_info.conf
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_bis_prj_conf_overlay-sequential_conf
+      tests_scripts:
+        - tests_scripts/broadcast_iso_sequential.sh
+
+  bluetooth.ll.bis.interleaved:
+    sysbuild: true
+    platform_allow:
+      - nrf52_bsim/native
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf5340bsim/nrf5340/cpunet
+      - nrf54l15bsim/nrf54l15/cpuapp
+    extra_overlay_confs:
+      - overlay-interleaved.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_bis_prj_conf_overlay-interleaved_conf
+      tests_scripts:
+        - tests_scripts/broadcast_iso_interleaved.sh
+
+  bluetooth.ll.bis.ll_interface:
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
-    integration_platforms:
-      - nrf52_bsim/native
-      - nrf5340bsim/nrf5340/cpunet
-    harness: bsim
+    extra_overlay_confs:
+      - overlay-ll_interface.conf
     harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_bis_prj_conf_overlay-ll_interface_conf
+      tests_scripts:
+        - tests_scripts/broadcast_iso_ll_interface.sh
+
+  bluetooth.ll.bis.ticker_expire_info:
+    sysbuild: true
+    platform_allow:
+      - nrf52_bsim/native
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf5340bsim/nrf5340/cpunet
+      - nrf54l15bsim/nrf54l15/cpuapp
+    extra_overlay_confs:
+      - overlay-ticker_expire_info.conf
+    harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_ll_bis_prj_conf_overlay-ticker_expire_info_conf
-  bluetooth.ll.bis_vs_dp:
-    extra_args: CONF_FILE=prj_vs_dp.conf
+      tests_scripts:
+        - tests_scripts/broadcast_iso_ticker_expire_info.sh
+
+  bluetooth.ll.bis.scan_aux_use_chains:
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
-    integration_platforms:
+    extra_overlay_confs:
+      - overlay-scan_aux_use_chains.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_bis_prj_conf_overlay-scan_aux_use_chains_conf
+      tests_scripts:
+        - tests_scripts/broadcast_iso_scan_aux_use_chains.sh
+
+  bluetooth.ll.bis.vs_dp:
+    platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
-    harness: bsim
+    extra_args:
+      CONF_FILE=prj_vs_dp.conf
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_ll_bis_prj_vs_dp_conf
-  bluetooth.ll.bis_past:
-    extra_args: CONF_FILE=prj_past.conf
+      tests_scripts:
+        - tests_scripts/broadcast_iso_vs_dp.sh
+    required_applications:
+      - application: bluetooth.ll.bis.sequential
+
+  bluetooth.ll.bis.past:
     platform_allow:
       - nrf52_bsim/native
       - nrf5340bsim/nrf5340/cpunet
-    integration_platforms:
-      - nrf52_bsim/native
-      - nrf5340bsim/nrf5340/cpunet
-    harness: bsim
+    extra_args:
+      CONF_FILE=prj_past.conf
     harness_config:
+      fixture: bsim_multi_test
       bsim_exe_name: tests_bsim_bluetooth_ll_bis_prj_past_conf
+      tests_scripts:
+        - tests_scripts/past.sh
+        - tests_scripts/past_default_past_params.sh
+        - tests_scripts/past_send_from_broadcaster.sh

--- a/tests/bsim/bluetooth/ll/cis/tests.yaml
+++ b/tests/bsim/bluetooth/ll/cis/tests.yaml
@@ -1,0 +1,114 @@
+common:
+  timeout: 300
+  tags:
+    - bluetooth
+  depends_on: bsim
+  harness: bsim
+  platform_allow:
+    - nrf52_bsim/native
+    - nrf5340bsim/nrf5340/cpunet
+
+tests:
+  bluetooth.ll.cis:
+    extra_overlay_confs:
+      - overlay.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_cis_prj_conf_overlay_conf
+      tests_scripts:
+        - tests_scripts/connected_iso.sh
+
+  bluetooth.ll.cis.acl_first:
+    extra_overlay_confs:
+      - overlay-acl_first.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_cis_prj_conf_overlay-acl_first_conf
+      tests_scripts:
+        - tests_scripts/connected_iso_acl_first.sh
+
+  bluetooth.ll.cis.legacy_adv:
+    extra_overlay_confs:
+      - overlay-legacy_adv.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_cis_prj_conf_overlay-legacy_adv_conf
+      tests_scripts:
+        - tests_scripts/connected_iso_legacy_adv.sh
+
+  bluetooth.ll.cis.legacy_adv_acl_first:
+    extra_overlay_confs:
+      - overlay-legacy_adv_acl_first.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_cis_prj_conf_overlay-legacy_adv_acl_first_conf
+      tests_scripts:
+        - tests_scripts/connected_iso_legacy_adv_acl_first.sh
+
+  bluetooth.ll.cis.acl_group:
+    sysbuild: true
+    platform_allow:
+      - nrf52_bsim/native
+      - nrf5340bsim/nrf5340/cpunet
+      - nrf5340bsim/nrf5340/cpuapp
+    extra_overlay_confs:
+      - overlay-acl_group.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_cis_prj_conf_overlay-acl_group_conf
+      tests_scripts:
+        - tests_scripts/connected_iso_acl_group.sh
+
+  bluetooth.ll.cis.acl_group_acl_first:
+    extra_overlay_confs:
+      - overlay-acl_group_acl_first.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_cis_prj_conf_overlay-acl_group_acl_first_conf
+      tests_scripts:
+        - tests_scripts/connected_iso_acl_group_acl_first.sh
+
+  bluetooth.ll.cis.peripheral_cis:
+    extra_overlay_confs:
+      - overlay-peripheral_cis.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_cis_prj_conf_overlay-peripheral_cis_conf
+      tests_scripts:
+        - tests_scripts/connected_iso_peripheral_cis.sh
+
+  bluetooth.ll.cis.acl_first_ft_per_skip_2_se:
+    extra_overlay_confs:
+      - overlay-acl_first_ft_per_skip_2_se.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_cis_prj_conf_overlay-acl_first_ft_per_skip_2_se_conf
+      tests_scripts:
+        - tests_scripts/connected_iso_acl_first_ft_per_skip_2_se.sh
+
+  bluetooth.ll.cis.acl_first_ft_per_skip_4_se:
+    extra_overlay_confs:
+      - overlay-acl_first_ft_per_skip_4_se.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_cis_prj_conf_overlay-acl_first_ft_per_skip_4_se_conf
+      tests_scripts:
+        - tests_scripts/connected_iso_acl_first_ft_per_skip_4_se.sh
+
+  bluetooth.ll.cis.acl_first_ft_cen_skip_2_se:
+    extra_overlay_confs:
+      - overlay-acl_first_ft_cen_skip_2_se.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_cis_prj_conf_overlay-acl_first_ft_cen_skip_2_se_conf
+      tests_scripts:
+        - tests_scripts/connected_iso_acl_first_ft_cen_skip_2_se.sh
+
+  bluetooth.ll.cis.acl_first_ft_cen_skip_4_se:
+    extra_overlay_confs:
+      - overlay-acl_first_ft_cen_skip_4_se.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_cis_prj_conf_overlay-acl_first_ft_cen_skip_4_se_conf
+      tests_scripts:
+        - tests_scripts/connected_iso_acl_first_ft_cen_skip_4_se.sh

--- a/tests/bsim/bluetooth/ll/conn/tests.yaml
+++ b/tests/bsim/bluetooth/ll/conn/tests.yaml
@@ -5,6 +5,76 @@ common:
   harness: bsim
 
 tests:
+  tests.bsim.bluetooth.ll.conn.split:
+    platform_allow:
+      - nrf52_bsim
+      - nrf54l15bsim/nrf54l15/cpuapp
+    extra_args: CONF_FILE=prj_split.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_conn_prj_split_conf
+      tests_scripts:
+        - tests_scripts/basic_conn_split.sh
+        - tests_scripts/basic_conn20_split.sh
+        - tests_scripts/basic_conn_encrypted_split.sh
+
+  tests.bsim.bluetooth.ll.conn.split_1ms:
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpunet
+    extra_args: CONF_FILE=prj_split_1ms.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_conn_prj_split_1ms_conf
+      tests_scripts:
+        - tests_scripts/basic_conn_split_1ms.sh
+
+  tests.bsim.bluetooth.ll.conn.split_tx_defer:
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpunet
+    extra_args: CONF_FILE=prj_split_tx_defer.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_conn_prj_split_tx_defer_conf
+      tests_scripts:
+        - tests_scripts/basic_conn_split_tx_defer.sh
+
+  tests.bsim.bluetooth.ll.conn.split_privacy:
+    sysbuild: true
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf54l15bsim/nrf54l15/cpuapp
+    extra_args: CONF_FILE=prj_split_privacy.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_conn_prj_split_privacy_conf
+      tests_scripts:
+        - tests_scripts/basic_conn_encrypted_split_privacy.sh
+
+  tests.bsim.bluetooth.ll.conn.split_low_lat:
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpunet
+    extra_args: CONF_FILE=prj_split_low_lat.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_conn_prj_split_low_lat_conf
+      tests_scripts:
+        - tests_scripts/basic_conn_split_low_lat.sh
+
+  tests.bsim.bluetooth.ll.conn.split_single_timer:
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpunet
+    extra_args: CONF_FILE=prj_split_single_timer.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_conn_prj_split_single_timer_conf
+      tests_scripts:
+        - tests_scripts/basic_conn_encrypted_split_single_timer.sh
+
   tests.bsim.bluetooth.ll.conn.split_hci_uart:
     platform_allow:
       - nrf52_bsim
@@ -14,6 +84,7 @@ tests:
       - hci-uart.overlay
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_ll_conn_prj_split_hci_uart_conf
+
   tests.bsim.bluetooth.ll.conn.split_hci_uart.psa:
     platform_allow:
       - nrf52_bsim

--- a/tests/bsim/bluetooth/ll/edtt/gatt_test_app/tests.yaml
+++ b/tests/bsim/bluetooth/ll/edtt/gatt_test_app/tests.yaml
@@ -1,0 +1,22 @@
+common:
+  timeout: 1200
+  tags:
+    - bluetooth
+  depends_on: bsim
+  platform_allow:
+    - nrf52_bsim/native
+    - nrf5340bsim/nrf5340/cpunet
+    - nrf54l15bsim/nrf54l15/cpuapp
+  harness: bsim
+tests:
+  bluetooth.ll.edtt.gatt_test_app:
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_edtt_gatt_test_app_prj_llcp_conf
+      tests_scripts:
+        - ../tests_scripts/gatt.llcp.sh
+    extra_args:
+      CONF_FILE=prj_llcp.conf
+    required_applications:
+      - name: bluetooth.ll.edtt.hci_test_app.dut
+        path: ../hci_test_app

--- a/tests/bsim/bluetooth/ll/edtt/hci_test_app/tests.yaml
+++ b/tests/bsim/bluetooth/ll/edtt/hci_test_app/tests.yaml
@@ -1,0 +1,31 @@
+common:
+  timeout: 1200
+  tags:
+    - bluetooth
+  depends_on: bsim
+  platform_allow:
+    - nrf52_bsim/native
+    - nrf5340bsim/nrf5340/cpunet
+    - nrf54l15bsim/nrf54l15/cpuapp
+  harness: bsim
+tests:
+  bluetooth.ll.edtt.hci_test_app.dut:
+    build_only: true
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_edtt_hci_test_app_prj_dut_llcp_conf
+    extra_args:
+      CONF_FILE=prj_dut_llcp.conf
+  bluetooth.ll.edtt.hci_test_app.tst:
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_edtt_hci_test_app_prj_tst_llcp_conf
+      tests_scripts:
+        - ../tests_scripts/gap.llcp.sh
+        - ../tests_scripts/hci.llcp.sh
+        - ../tests_scripts/ll.1.llcp.sh
+        - ../tests_scripts/ll.2.llcp.sh
+    extra_args:
+      CONF_FILE=prj_tst_llcp.conf
+    required_applications:
+      - name: bluetooth.ll.edtt.hci_test_app.dut

--- a/tests/bsim/bluetooth/ll/multiple_id/tests.yaml
+++ b/tests/bsim/bluetooth/ll/multiple_id/tests.yaml
@@ -1,0 +1,18 @@
+common:
+  timeout: 3600
+  tags:
+    - bluetooth
+  depends_on: bsim
+  harness: bsim
+
+tests:
+  tests.bsim.bluetooth.ll.multiple_id:
+    sysbuild: true
+    platform_allow:
+      - nrf52_bsim
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf5340bsim/nrf5340/cpunet
+      - nrf54l15bsim/nrf54l15/cpuapp
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_multiple_id_prj_conf

--- a/tests/bsim/bluetooth/ll/throughput/tests.yaml
+++ b/tests/bsim/bluetooth/ll/throughput/tests.yaml
@@ -1,0 +1,29 @@
+common:
+  timeout: 2400
+  tags:
+    - bluetooth
+  depends_on: bsim
+  harness: bsim
+  sysbuild: true
+  platform_allow:
+    - nrf52_bsim
+    - nrf5340bsim/nrf5340/cpuapp
+    - nrf5340bsim/nrf5340/cpunet
+    - nrf54l15bsim/nrf54l15/cpuapp
+
+tests:
+  tests.bsim.bluetooth.ll.throughput:
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_throughput_prj_conf
+      tests_scripts:
+        - tests_scripts/gatt_write.sh
+
+  tests.bsim.bluetooth.ll.throughput_no_phy_update:
+    extra_overlay_confs:
+      - overlay-no_phy_update.conf
+    harness_config:
+      fixture: bsim_multi_test
+      bsim_exe_name: tests_bsim_bluetooth_ll_throughput_prj_conf_overlay-no_phy_update_conf
+      tests_scripts:
+        - tests_scripts/gatt_write_no_phy_update.sh

--- a/tests/bsim/ci.bt.sh
+++ b/tests/bsim/ci.bt.sh
@@ -13,48 +13,4 @@ set -uex
 
 TWISTER_OPTIONS="-vv --fixture bsim_multi_test --no-clean --force-color --inline-logs"
 
-${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/audio/
-
-${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/audio_samples/
-
-${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/hci_uart/
-
-${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/host/
-
-${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/mesh
-
-${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/samples/
-
-${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/tester/
-
-# nrf52_bsim set:
-nice tests/bsim/bluetooth/compile.sh
-
-BOARD=nrf52_bsim/native \
-RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.bt.52.xml \
-TESTS_FILE=tests/bsim/bluetooth/tests.nrf52bsim.txt \
-tests/bsim/run_parallel.sh
-
-# nrf5340bsim/nrf5340/cpunet set:
-nice tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpunet.sh
-
-BOARD=nrf5340bsim/nrf5340/cpunet \
-RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.bt.53_cpunet.xml \
-TESTS_FILE=tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpunet.txt \
-tests/bsim/run_parallel.sh
-
-# nrf5340 split stack set:
-nice tests/bsim/bluetooth/compile.nrf5340bsim_nrf5340_cpuapp.sh
-
-BOARD=nrf5340bsim/nrf5340/cpuapp \
-RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.bt.53_cpuapp.xml \
-TESTS_FILE=tests/bsim/bluetooth/tests.nrf5340bsim_nrf5340_cpuapp.txt \
-tests/bsim/run_parallel.sh
-
-# nrf54l15bsim/nrf54l15/cpuapp set:
-nice tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
-
-BOARD=nrf54l15bsim/nrf54l15/cpuapp \
-RESULTS_FILE=${ZEPHYR_BASE}/bsim_out/bsim_results.bt.54l15_cpuapp.xml \
-TESTS_FILE=tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt \
-tests/bsim/run_parallel.sh
+${ZEPHYR_BASE}/scripts/twister ${TWISTER_OPTIONS} -T tests/bsim/bluetooth/


### PR DESCRIPTION
For background and motivation see https://github.com/zephyrproject-rtos/zephyr/pull/113101

This PR changes the BT LL bsim tests to be both built and run using twister.
This means that users which have Babblesim installed can run these tests with twister in a quite comparable way to single device test. For example:
twister -T tests/bsim/bluetooth/ll/ -vv --fixture bsim_multi_test

Note these tests can still be run with run_parallel.sh as before. Just now CI uses twister directly.

Related to (the last commit assumes all BT ones in these set have been merged):
* https://github.com/zephyrproject-rtos/zephyr/pull/113588
* https://github.com/zephyrproject-rtos/zephyr/pull/113502
* https://github.com/zephyrproject-rtos/zephyr/pull/113475
* https://github.com/zephyrproject-rtos/zephyr/pull/113401
* https://github.com/zephyrproject-rtos/zephyr/pull/113395
* https://github.com/zephyrproject-rtos/zephyr/pull/113225
* https://github.com/zephyrproject-rtos/zephyr/pull/113244
* https://github.com/zephyrproject-rtos/zephyr/pull/113101