### PR TITLE
arch: arc: fix buffer validate pointer wrap-around

### DIFF
--- a/arch/arc/core/mpu/arc_mpu_v2_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v2_internal.h
@@ -6,6 +6,8 @@
 #ifndef ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_V2_INTERNAL_H_
 #define ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_V2_INTERNAL_H_
 
+#include <zephyr/sys/math_extras.h>
+
 #define AUX_MPU_EN_ENABLE   BIT(30)
 #define AUX_MPU_EN_DISABLE  ~BIT(30)
 
@@ -125,6 +127,7 @@ static inline bool _is_in_region(uint32_t r_index, uint32_t start, uint32_t size
 	uint32_t r_addr_start;
 	uint32_t r_addr_end;
 	uint32_t r_size_lshift;
+	uint32_t end;
 
 	r_addr_start = z_arc_v2_aux_reg_read(_ARC_V2_MPU_RDB0 + r_index * 2U)
 		       & (~AUX_MPU_RDB_VALID_MASK);
@@ -133,7 +136,11 @@ static inline bool _is_in_region(uint32_t r_index, uint32_t start, uint32_t size
 	r_size_lshift = AUX_MPU_RDP_SIZE_SHIFT(r_size_lshift);
 	r_addr_end = r_addr_start  + (1 << (r_size_lshift + 1));
 
-	if (start >= r_addr_start && (start + size) <= r_addr_end) {
+	if (u32_add_overflow(start, size, &end)) {
+		return false;
+	}
+
+	if (start >= r_addr_start && end <= r_addr_end) {
 		return true;
 	}
 

--- a/arch/arc/core/mpu/arc_mpu_v4_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v4_internal.h
@@ -6,6 +6,8 @@
 #ifndef ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_V4_INTERNAL_H_
 #define ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_V4_INTERNAL_H_
 
+#include <zephyr/sys/math_extras.h>
+
 #define AUX_MPU_RPER_SID1       0x10000
 /* valid mask: SID1+secure+valid */
 #define AUX_MPU_RPER_VALID_MASK ((0x1) | AUX_MPU_RPER_SID1 | AUX_MPU_ATTR_S)
@@ -789,16 +791,31 @@ int arc_core_mpu_buffer_validate(const void *addr, size_t size, int write)
 	 * we can stop the iteration immediately once we find the
 	 * matched region that grants permission or denies access.
 	 */
-	r_index = _mpu_probe((uint32_t)addr);
-	/*  match and the area is in one region */
-	if (r_index >= 0 && r_index == _mpu_probe((uint32_t)addr + (size - 1))) {
-		if (_is_user_accessible_region(r_index, write)) {
+	if (size == 0U) {
+		r_index = _mpu_probe((uint32_t)addr);
+		if (r_index >= 0 && _is_user_accessible_region(r_index, write)) {
 			r_index = 0;
 		} else {
 			r_index = -EPERM;
 		}
 	} else {
-		r_index = -EPERM;
+		uint32_t end;
+
+		if (u32_add_overflow((uint32_t)addr, size - 1U, &end)) {
+			r_index = -EPERM;
+		} else {
+			r_index = _mpu_probe((uint32_t)addr);
+			/*  match and the area is in one region */
+			if (r_index >= 0 && r_index == _mpu_probe(end)) {
+				if (_is_user_accessible_region(r_index, write)) {
+					r_index = 0;
+				} else {
+					r_index = -EPERM;
+				}
+			} else {
+				r_index = -EPERM;
+			}
+		}
 	}
 
 	arch_irq_unlock(key);

--- a/arch/arc/core/mpu/arc_mpu_v6_internal.h
+++ b/arch/arc/core/mpu/arc_mpu_v6_internal.h
@@ -6,6 +6,8 @@
 #ifndef ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_V6_INTERNAL_H_
 #define ZEPHYR_ARCH_ARC_CORE_MPU_ARC_MPU_V6_INTERNAL_H_
 
+#include <zephyr/sys/math_extras.h>
+
 #define AUX_MPU_EN_BANK_MASK BIT(0)
 #define AUX_MPU_EN_IC        BIT(12)
 #define AUX_MPU_EN_DC        BIT(13)
@@ -161,6 +163,7 @@ static inline bool _is_in_region(uint32_t r_index, uint32_t start, uint32_t size
 	uint32_t r_addr_start;
 	uint32_t r_addr_end;
 	uint32_t r_size_lshift;
+	uint32_t end;
 	uint32_t bank = r_index / ARC_FEATURE_MPU_BANK_SIZE;
 	uint32_t index = (r_index % ARC_FEATURE_MPU_BANK_SIZE) * 2U;
 
@@ -170,7 +173,11 @@ static inline bool _is_in_region(uint32_t r_index, uint32_t start, uint32_t size
 	r_size_lshift = AUX_MPU_RDP_SIZE_SHIFT(r_size_lshift);
 	r_addr_end = r_addr_start + (1 << (r_size_lshift + 1));
 
-	if (start >= r_addr_start && (start + size) <= r_addr_end) {
+	if (u32_add_overflow(start, size, &end)) {
+		return false;
+	}
+
+	if (start >= r_addr_start && end <= r_addr_end) {
 		return true;
 	}
 


### PR DESCRIPTION
arch_buffer_validate() on ARC computes the end address of the validated range using unprotected unsigned addition. When addr+size wraps around the 32-bit address space the check can succeed for a buffer that spans non-user-accessible memory, violating the arch_buffer_validate() contract.

Add overflow detection using u32_add_overflow(), mirroring the fix already applied to ARM32 (PR #23239) and Xtensa (PR #109000). Handle size == 0 explicitly so that size - 1 does not underflow.

This affects ARC MPUv2/v3/v4/v6/v8 implementations.

Fixes #113832