### PR TITLE
cmake: kconfig: Ensure .config is regenerated when devicetree changes

### DIFF
--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -345,9 +345,14 @@ if(KCONFIG_VARIANT_SOURCE)
 endif()
 
 # Calculate a checksum of merge_config_files to determine if we need
-# to re-generate .config
+# to re-generate .config. DTS is also checksummed since it can affect
+# configurations via $(dt...) functions.
+set(config_checksum_files ${merge_config_files})
+if(DEFINED ZEPHYR_DTS)
+  set(config_checksum_files ${config_checksum_files};${ZEPHYR_DTS})
+endif()
 set(merge_config_files_checksum "")
-foreach(f ${merge_config_files})
+foreach(f ${config_checksum_files})
   file(MD5 ${f} checksum)
   set(merge_config_files_checksum "${merge_config_files_checksum}${checksum}")
 endforeach()


### PR DESCRIPTION
Kconfig values can be derived from devicetree via $(dt...) functions which means the .config file must be regenerated whenever devicetree changes.

Fixes #116169