### PR TITLE
[Backport v3.7-branch] drivers: udc: it82xx2: fix non-ctrl out transfer and suspend work initialization

### DIFF
--- a/drivers/usb/udc/udc_it82xx2.c
+++ b/drivers/usb/udc/udc_it82xx2.c
@@ -1246,7 +1246,6 @@ static int it82xx2_enable(const struct device *dev)
 	struct it82xx2_data *priv = udc_get_private(dev);
 
 	k_sem_init(&priv->suspended_sem, 0, 1);
-	k_work_init_delayable(&priv->suspended_work, suspended_handler);
 
 	/* Initialize FIFO ready status */
 	priv->fifo_ready[0] = false;
@@ -1420,6 +1419,8 @@ static int it82xx2_usb_driver_preinit(const struct device *dev)
 
 	/* Initializing WU (USB D+) */
 	it8xxx2_usb_dc_wuc_init(dev);
+
+	k_work_init_delayable(&priv->suspended_work, suspended_handler);
 
 	/* Connect USB interrupt */
 	irq_connect_dynamic(config->usb_irq, 0, it82xx2_usb_dc_isr, dev, 0);


### PR DESCRIPTION
Backport of the fix from #113463 to `v3.7-branch`.

Fixes: #113845