### PR TITLE
[Backport v4.3-branch] drivers: udc: it82xx2: fix non-ctrl out transfer and suspend work initialization

### DIFF
--- a/drivers/usb/udc/udc_it82xx2.c
+++ b/drivers/usb/udc/udc_it82xx2.c
@@ -1422,7 +1422,6 @@ static int it82xx2_enable(const struct device *dev)
 	struct it82xx2_data *priv = udc_get_private(dev);
 
 	k_sem_init(&priv->suspended_sem, 0, 1);
-	k_work_init_delayable(&priv->suspended_work, suspended_handler);
 
 	atomic_clear_bit(&priv->out_fifo_state, IT82xx2_STATE_OUT_SHARED_FIFO_BUSY);
 
@@ -1593,6 +1592,8 @@ static int it82xx2_usb_driver_preinit(const struct device *dev)
 
 	/* Initializing WU (USB D+) */
 	it8xxx2_usb_dc_wuc_init(dev);
+
+	k_work_init_delayable(&priv->suspended_work, suspended_handler);
 
 	/* Connect USB interrupt */
 	irq_connect_dynamic(config->usb_irq, 0, it82xx2_usb_dc_isr, dev, 0);

--- a/drivers/usb/udc/udc_it82xx2.c
+++ b/drivers/usb/udc/udc_it82xx2.c
@@ -1142,20 +1142,27 @@ static inline int work_handler_out(const struct device *dev, uint8_t ep)
 
 	LOG_DBG("Handle data OUT, %zu | %zu", len, net_buf_tailroom(buf));
 
+	if (ep != USB_CONTROL_EP_OUT) {
+		atomic_clear_bit(&priv->out_fifo_state, IT82xx2_STATE_OUT_SHARED_FIFO_BUSY);
+	}
+
+	udc_ep_set_busy(ep_cfg, false);
+
 	if (net_buf_tailroom(buf) && len == udc_mps_ep_size(ep_cfg)) {
-		work_handler_xfer_continue(dev, ep, buf);
-		if (ep != USB_CONTROL_EP_OUT) {
-			err = udc_submit_ep_event(dev, buf, 0);
+		/* For non-control endpoints, the next out transfer will be started outside
+		 * this function. Do nothing here to avoid triggering it twice.
+		 */
+		if (ep == USB_CONTROL_EP_OUT) {
+			work_handler_xfer_continue(dev, ep, buf);
 		}
-		return err;
+
+		return 0;
 	}
 
 	buf = udc_buf_get(ep_cfg);
 	if (buf == NULL) {
 		return -ENODATA;
 	}
-
-	udc_ep_set_busy(ep_cfg, false);
 
 	if (ep == USB_CONTROL_EP_OUT) {
 		if (udc_ctrl_stage_is_status_out(dev)) {
@@ -1171,7 +1178,6 @@ static inline int work_handler_out(const struct device *dev, uint8_t ep)
 			err = udc_ctrl_submit_s_out_status(dev, buf);
 		}
 	} else {
-		atomic_clear_bit(&priv->out_fifo_state, IT82xx2_STATE_OUT_SHARED_FIFO_BUSY);
 		err = udc_submit_ep_event(dev, buf, 0);
 	}
 


### PR DESCRIPTION
Backport of the fix from #113463 to `v4.3-branch`.

Fixes: #113845