### PR TITLE
tests: ipc: benchmark: fix cpu_load.h include

### DIFF
--- a/tests/subsys/ipc/ipc_service_benchmark/remote/src/main.c
+++ b/tests/subsys/ipc/ipc_service_benchmark/remote/src/main.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
-#include <zephyr/debug/cpu_load.h>
+#include <zephyr/sys/cpu_load.h>
 #include <zephyr/ipc/ipc_service.h>
 #include <zephyr/logging/log.h>
 #include "common.h"

--- a/tests/subsys/ipc/ipc_service_benchmark/src/main.c
+++ b/tests/subsys/ipc/ipc_service_benchmark/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/ztest.h>
 #include <zephyr/ztress.h>
-#include <zephyr/debug/cpu_load.h>
+#include <zephyr/sys/cpu_load.h>
 #include <zephyr/random/random.h>
 #include <zephyr/ipc/ipc_service.h>
 #include <sys/errno.h>


### PR DESCRIPTION
Use correct include zephyr/sys/cpu_load.h

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
