### PR TITLE
drivers: uart: esp32: Handle non-DMA async TX buffers

### DIFF
--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -57,6 +57,8 @@
 #include <hal/gdma_ll.h>
 #include <hal/gdma_hal.h>
 #include <hal/dma_types.h>
+#include <esp_memory_utils.h>
+#include <soc/soc_caps.h>
 #endif
 #include <soc/uart_struct.h>
 #include <hal/uart_ll.h>
@@ -960,6 +962,27 @@ static int uart_esp32_async_callback_set(const struct device *dev, uart_callback
 	return 0;
 }
 
+static bool uart_esp32_tx_dma_capable(const uint8_t *buf)
+{
+	if (esp_ptr_dma_capable(buf)) {
+		return true;
+	}
+
+#if defined(CONFIG_ESP_SPIRAM)
+	if (esp_ptr_dma_ext_capable(buf)) {
+		return true;
+	}
+#endif
+
+#if defined(SOC_DMA_CAN_ACCESS_FLASH)
+	if (esp_ptr_in_drom(buf)) {
+		return true;
+	}
+#endif
+
+	return false;
+}
+
 static int uart_esp32_async_tx(const struct device *dev, const uint8_t *buf, size_t len,
 			       int32_t timeout)
 {
@@ -973,6 +996,12 @@ static int uart_esp32_async_tx(const struct device *dev, const uint8_t *buf, siz
 
 	if (config->tx_dma_channel == 0xFF) {
 		LOG_ERR("Tx DMA channel is not configured");
+		err = -ENOTSUP;
+		goto unlock;
+	}
+
+	if (!uart_esp32_tx_dma_capable(buf)) {
+		LOG_ERR("Tx buffer not in DMA capable memory: %p", buf);
 		err = -ENOTSUP;
 		goto unlock;
 	}

--- a/tests/drivers/uart/uart_async_api/boards/esp32c6_devkitc_hpcore.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/esp32c6_devkitc_hpcore.overlay
@@ -8,12 +8,12 @@
 	uart1_test: uart1_test {
 		group1 {
 			pinmux = <UART1_TX_GPIO2>;
-			input-enable;   /* Connect GPIO2 and GPIO3 externally for testing */
+			input-enable;
 		};
 
 		group2 {
-			pinmux = <UART1_RX_GPIO3>;
-			output-enable;  /* Connect GPIO2 and GPIO3 externally for testing */
+			pinmux = <UART1_RX_GPIO2>;
+			output-enable;
 		};
 	};
 };

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -243,7 +243,12 @@ static void single_read(enum uart_config_data_bits data_bits)
 	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), -EAGAIN,
 		      "RX_RDY not expected at this point");
 
-	uart_tx(uart_dev, tx_buf, 5, 100 * USEC_PER_MSEC);
+	rv = uart_tx(uart_dev, tx_buf, 5, 100 * USEC_PER_MSEC);
+	if (rv == -ENOTSUP) {
+		uart_rx_disable(uart_dev);
+		ztest_test_skip();
+	}
+	zassert_ok(rv, "uart_tx failed");
 	sent_bytes += 5;
 
 	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
@@ -344,6 +349,10 @@ ZTEST_USER(uart_async_multi_rx, test_multiple_rx_enable)
 
 	/* Send enough data to completely fill RX buffer, so that RX ends. */
 	ret = uart_tx(uart_dev, tx_buf, sizeof(tx_buf), 100 * USEC_PER_MSEC);
+	if (ret == -ENOTSUP) {
+		uart_rx_disable(uart_dev);
+		ztest_test_skip();
+	}
 	zassert_equal(ret, 0, "uart_tx failed");
 	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
 	zassert_equal(k_sem_take(&rx_rdy, K_MSEC(100)), 0, "RX_RDY timeout");
@@ -954,7 +963,13 @@ ZTEST_USER(uart_async_chain_write, test_chained_write)
 
 	uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), 50 * USEC_PER_MSEC);
 
-	uart_tx(uart_dev, chained_write_tx_bufs[0], 10, 100 * USEC_PER_MSEC);
+	int ret = uart_tx(uart_dev, chained_write_tx_bufs[0], 10, 100 * USEC_PER_MSEC);
+
+	if (ret == -ENOTSUP) {
+		uart_rx_disable(uart_dev);
+		ztest_test_skip();
+	}
+	zassert_ok(ret, "uart_tx failed");
 	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
 	zassert_equal(k_sem_take(&tx_done, K_MSEC(100)), 0, "TX_DONE timeout");
 	zassert_equal(chained_write_next_buf, false, "Sent no message");


### PR DESCRIPTION
Update UART driver to return -ENOTSUP when async TX uses a buffer GDMA cannot read. Allow flash/DROM TX only on SoCs with SOC_DMA_CAN_ACCESS_FLASH.

Update `uart_async_api` testcase to skip test when -ENOTSUP is returned at uart_tx(), so testsuite doesn't fail for some devices.

Fix C6 loopback pins to allow CI testing without external wiring.