### PR TITLE
scripts: ci: check_compliance: explain KconfigHWMv2 undefined symbols

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -828,6 +828,11 @@ class KconfigCheck(ComplianceTest):
     # Kconfig symbol prefix/namespace.
     CONFIG_ = "CONFIG_"
 
+    # Additional guidance appended to the "Undefined Kconfig symbols" failure
+    # message. Subclasses can override this to describe probable causes
+    # specific to the Kconfig tree being checked.
+    UNDEF_SYMBOL_HINT = ""
+
     def run(self):
         kconf = self.parse_kconfig()
 
@@ -1504,7 +1509,10 @@ https://docs.zephyrproject.org/latest/build/kconfig/tips.html#menuconfig-symbols
         )
 
         if undef_ref_warnings:
-            self.failure(f"Undefined Kconfig symbols:\n\n {undef_ref_warnings}")
+            msg = f"Undefined Kconfig symbols:\n\n {undef_ref_warnings}"
+            if self.UNDEF_SYMBOL_HINT:
+                msg += f"\n\n{self.UNDEF_SYMBOL_HINT}"
+            self.failure(msg)
 
     def check_soc_name_sync(self, kconf):
         root_args = argparse.Namespace(**{'soc_roots': [ZEPHYR_BASE]})
@@ -1710,10 +1718,23 @@ class KconfigHWMv2Check(KconfigBasicCheck):
     """
 
     name = "KconfigHWMv2"
+    doc = zephyr_doc_detail_builder("/hardware/porting/board_porting.html#write-kconfig-files")
 
     # Use dedicated Kconfig board / soc v2 scheme file.
     # This file sources only v2 scheme tree.
     FILENAME = os.path.join(os.path.dirname(__file__), "Kconfig.board.v2")
+
+    UNDEF_SYMBOL_HINT = """\
+This check loads only the board and SoC Kconfig trees (Kconfig.<board> and
+Kconfig.soc files) without the rest of the Zephyr Kconfig tree, because those
+files must be loadable standalone; for example, sysbuild also loads them.
+
+Probable causes of the undefined symbol warnings above:
+- A Kconfig.<board> or Kconfig.soc file references a symbol defined outside
+  the board and SoC Kconfig trees, for example a driver or subsystem symbol.
+  Move the reference to the Kconfig or Kconfig.defconfig file of the board or
+  SoC instead, as those files are only loaded in the full Zephyr Kconfig tree.
+- The symbol name is misspelled, or the file defining it is not sourced."""
 
 
 class SysbuildKconfigCheck(KconfigCheck):

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -831,6 +831,11 @@ class KconfigCheck(ComplianceTest):
     # Kconfig symbol prefix/namespace.
     CONFIG_ = "CONFIG_"
 
+    # Additional guidance appended to the "Undefined Kconfig symbols" failure
+    # message. Subclasses can override this to describe probable causes
+    # specific to the Kconfig tree being checked.
+    UNDEF_SYMBOL_HINT = ""
+
     def run(self):
         kconf = self.parse_kconfig()
 
@@ -1513,7 +1518,10 @@ https://docs.zephyrproject.org/latest/build/kconfig/tips.html#menuconfig-symbols
         )
 
         if undef_ref_warnings:
-            self.failure(f"Undefined Kconfig symbols:\n\n {undef_ref_warnings}")
+            msg = f"Undefined Kconfig symbols:\n\n {undef_ref_warnings}"
+            if self.UNDEF_SYMBOL_HINT:
+                msg += f"\n\n{self.UNDEF_SYMBOL_HINT}"
+            self.failure(msg)
 
     def check_soc_name_sync(self, kconf):
         root_args = argparse.Namespace(**{'soc_roots': [ZEPHYR_BASE]})
@@ -1719,10 +1727,23 @@ class KconfigHWMv2Check(KconfigBasicCheck):
     """
 
     name = "KconfigHWMv2"
+    doc = zephyr_doc_detail_builder("/hardware/porting/board_porting.html#write-kconfig-files")
 
     # Use dedicated Kconfig board / soc v2 scheme file.
     # This file sources only v2 scheme tree.
     FILENAME = os.path.join(os.path.dirname(__file__), "Kconfig.board.v2")
+
+    UNDEF_SYMBOL_HINT = """\
+This check loads only the board and SoC Kconfig trees (Kconfig.<board> and
+Kconfig.soc files) without the rest of the Zephyr Kconfig tree, because those
+files must be loadable standalone; for example, sysbuild also loads them.
+
+Probable causes of the undefined symbol warnings above:
+- A Kconfig.<board> or Kconfig.soc file references a symbol defined outside
+  the board and SoC Kconfig trees, for example a driver or subsystem symbol.
+  Move the reference to the Kconfig or Kconfig.defconfig file of the board or
+  SoC instead, as those files are only loaded in the full Zephyr Kconfig tree.
+- The symbol name is misspelled, or the file defining it is not sourced."""
 
 
 class SysbuildKconfigCheck(KconfigCheck):


### PR DESCRIPTION
`KconfigHWMv2` loads only the board and SoC Kconfig trees (`Kconfig.<board>` / `Kconfig.soc`), so a reference to a symbol defined elsewhere in Zephyr surfaces as a bare kconfiglib `undefined symbol` warning. As reported in #69838, developers hitting this don't realize the root cause is a misplaced reference, since the symbol *is* defined — just not in the standalone tree.

Adds a `UNDEF_SYMBOL_HINT` hook to `KconfigCheck`, empty by default so all other Kconfig checks are unchanged, and sets it for `KconfigHWMv2Check` to explain why the symbol is missing and where the reference belongs. Also points the check's `doc` link at the board porting guide's "Write Kconfig files" section instead of the generic Kconfig tips page.

### Repro

```
printf '\tselect CPU_HAS_FPU\n' >> soc/ti/k3/am62x/Kconfig.soc
python3 scripts/ci/check_compliance.py -m KconfigHWMv2 -m KconfigBasic
```

`CPU_HAS_FPU` belongs one file over, under `config SOC_SERIES_AM62X_M4` in `soc/ti/k3/am62x/Kconfig`. `KconfigHWMv2` fails as below, while `KconfigBasic` passes — the symbol is defined, in `arch/arm/core/cortex_m/Kconfig`.

<details>
<summary>Resulting <code>KconfigHWMv2</code> failure</summary>

```
See https://docs.zephyrproject.org/latest/hardware/porting/board_porting.html#write-kconfig-files for more details.

 Undefined Kconfig symbols:

 warning: undefined symbol CPU_HAS_FPU:

- Referenced at soc/ti/k3/am62x/Kconfig.soc:41:

config SOC_AM6232_M4
	bool
	select SOC_SERIES_AM62X_M4
	select CPU_HAS_FPU

This check loads only the board and SoC Kconfig trees (Kconfig.<board> and
Kconfig.soc files) without the rest of the Zephyr Kconfig tree, because those
files must be loadable standalone; for example, sysbuild also loads them.

Probable causes of the undefined symbol warnings above:
- A Kconfig.<board> or Kconfig.soc file references a symbol defined outside
  the board and SoC Kconfig trees, for example a driver or subsystem symbol.
  Move the reference to the Kconfig or Kconfig.defconfig file of the board or
  SoC instead, as those files are only loaded in the full Zephyr Kconfig tree.
- The symbol name is misspelled, or the file defining it is not sourced.
```

</details>

Fixes #69838
