### PR TITLE
samples: modbus: rtu_server: add stm32f4_disco board support

### DIFF
--- a/samples/subsys/modbus/rtu_server/README.rst
+++ b/samples/subsys/modbus/rtu_server/README.rst
@@ -150,3 +150,41 @@ To read holding registers use FC03 command (read_holding_registers).
 
 .. _`joy-it RS-485 shield for Arduino`: https://joy-it.net/en/products/ARD-RS485
 .. _`PyModbus`: https://github.com/riptideio/pymodbus
+
+STM32F4-Discovery
+=================
+
+The STM32F4-Discovery board uses USART1 (PB6/PB7) for Modbus RTU communication
+with a MAX485 or equivalent RS-485 transceiver. Pin PB8 is used as the
+direction enable (DE/RE) signal.
+
+Wiring
+------
+
+Connect a TTL-to-RS485 module (e.g. MAX485, SP3485, C25B) as follows:
+
++------------------+-------------------+
+| STM32F4-Discovery| RS-485 Module     |
++==================+===================+
+| PB6 (USART1 TX)  | DI                |
++------------------+-------------------+
+| PB7 (USART1 RX)  | RO                |
++------------------+-------------------+
+| PB8 (GPIO)       | DE + RE (tied)    |
++------------------+-------------------+
+| 3.3V             | VCC               |
++------------------+-------------------+
+| GND              | GND               |
++------------------+-------------------+
+
+Connect the RS-485 module A/B terminals to the USB-to-RS485 adapter
+connected to the PC or Raspberry Pi running the Modbus client.
+
+Building and Flashing
+---------------------
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/modbus/rtu_server
+   :board: stm32f4_disco
+   :goals: build flash
+   :compact:

--- a/samples/subsys/modbus/rtu_server/README.rst
+++ b/samples/subsys/modbus/rtu_server/README.rst
@@ -12,9 +12,10 @@ in Zephyr RTOS.
 Requirements
 ************
 
-This sample has been tested with the nRF52840-DK and FRDM-K64F boards,
-but it should work with any board that has a free UART interface or USB
-device controller. Additionally the board should have three LEDs.
+This sample has been tested with the nRF52840-DK, FRDM-K64F and
+STM32F4-Discovery boards, but it should work with any board that has a
+free UART interface or USB device controller. Additionally the board
+should have three LEDs.
 
 RTU server example is running on an evaluation board. Client is running
 on a PC or laptop.

--- a/samples/subsys/modbus/rtu_server/boards/stm32f4_disco.overlay
+++ b/samples/subsys/modbus/rtu_server/boards/stm32f4_disco.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 LakshmiNarasimman R
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&usart1 {
+	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pb7>;
+	pinctrl-names = "default";
+	current-speed = <19200>;
+	status = "okay";
+
+	modbus0 {
+		compatible = "zephyr,modbus-serial";
+		status = "okay";
+		de-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+	};
+};

--- a/samples/subsys/modbus/rtu_server/sample.yaml
+++ b/samples/subsys/modbus/rtu_server/sample.yaml
@@ -6,8 +6,10 @@ tests:
     platform_allow:
       - nrf52840dk_nrf52840
       - frdm_k64f
+      - stm32f4_disco
     integration_platforms:
       - nrf52840dk_nrf52840
+      - stm32f4_disco
     tags:
       - uart
       - modbus


### PR DESCRIPTION
Add board overlay for STM32F4-Discovery to the Modbus RTU server sample.
USART1 (PB6/PB7) is used for RS-485 communication via a MAX485-compatible
transceiver module. PB8 is used as the DE/RE direction control GPIO.

Changes:
- Add boards/stm32f4_disco.overlay with USART1 and DE GPIO configuration
- Add stm32f4_disco to platform_allow and integration_platforms in sample.yaml
- Update README.rst with wiring table and build instructions

Tested with a C25B RS-485 module and USB-to-RS485 adapter connected to
a Raspberry Pi 4 running PyModbus 3.14.0 as the Modbus master. All coil
read/write and holding register operations verified successfully on hardware.