### PR TITLE
arch: riscv: stacktrace: fix exception frame unwinding

### DIFF
--- a/arch/riscv/core/CMakeLists.txt
+++ b/arch/riscv/core/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 zephyr_library()
 
+zephyr_cc_option_ifdef(CONFIG_FRAME_POINTER -mno-omit-leaf-frame-pointer)
+
 zephyr_library_sources(
   cpu_idle.c
   fatal.c

--- a/arch/riscv/core/stacktrace.c
+++ b/arch/riscv/core/stacktrace.c
@@ -134,40 +134,15 @@ static void walk_stackframe(riscv_stacktrace_cb cb, void *cookie, const struct k
 		/* Unwind to the previous frame */
 		frame = (struct stackframe *)fp - 1;
 
-		if ((i == 0) && (esf != NULL)) {
-			/* Print `esf->ra` if we are at the top of the stack */
-			if (in_text_region(esf->ra) && !cb(cookie, esf->ra, fp)) {
-				break;
-			}
-			/**
-			 * For the first stack frame, the `ra` is not stored in the frame if the
-			 * preempted function doesn't call any other function, we can observe:
-			 *
-			 *                     .-------------.
-			 *   frame[0]->fp ---> | frame[0] fp |
-			 *                     :-------------:
-			 *   frame[0]->ra ---> | frame[1] fp |
-			 *                     | frame[1] ra |
-			 *                     :~~~~~~~~~~~~~:
-			 *                     | frame[N] fp |
-			 *
-			 * Instead of:
-			 *
-			 *                     .-------------.
-			 *   frame[0]->fp ---> | frame[0] fp |
-			 *   frame[0]->ra ---> | frame[1] ra |
-			 *                     :-------------:
-			 *                     | frame[1] fp |
-			 *                     | frame[1] ra |
-			 *                     :~~~~~~~~~~~~~:
-			 *                     | frame[N] fp |
-			 *
-			 * Check if `frame->ra` actually points to a `fp`, and adjust accordingly
-			 */
-			if (vrfy(frame->ra, thread, esf)) {
-				fp = frame->ra;
-				frame = (struct stackframe *)fp;
-			}
+		/*
+		 * frame->ra is a return address in a regular frame. A compact
+		 * leaf frame stores the caller's frame pointer there instead.
+		 */
+		if ((i == 0) && (esf != NULL) && (frame->ra > fp) &&
+		    vrfy(frame->ra, thread, esf)) {
+			fp = frame->ra;
+			ra = esf->ra;
+			continue;
 		}
 
 		fp = frame->fp;

--- a/tests/arch/common/stack_unwind/CMakeLists.txt
+++ b/tests/arch/common/stack_unwind/CMakeLists.txt
@@ -7,3 +7,7 @@ project(stack_unwind_test)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
+
+if(CONFIG_RISCV)
+  target_sources(app PRIVATE src/riscv_leaf.S)
+endif()

--- a/tests/arch/common/stack_unwind/src/main.c
+++ b/tests/arch/common/stack_unwind/src/main.c
@@ -9,6 +9,17 @@
 
 #include <zephyr/kernel.h>
 
+#if defined(STACK_UNWIND_LEAF_TEST)
+extern void leaf_fault(void);
+
+static void (*volatile leaf_fault_call)(void) = leaf_fault;
+
+static void __noinline leaf_caller(void)
+{
+	leaf_fault_call();
+	printf("unexpected return\n");
+}
+#else
 static void func1(int a);
 static void func2(int a);
 
@@ -17,7 +28,11 @@ static void __noinline func2(int a)
 	printf("%d: %s\n", a, __func__);
 
 	if (a >= 5) {
+#if defined(STACK_UNWIND_NONLEAF_TEST)
+		__asm__ volatile(".word 0");
+#else
 		k_oops();
+#endif
 	}
 
 	func1(a + 1);
@@ -30,12 +45,17 @@ static void __noinline func1(int a)
 	func2(a + 1);
 	printf("bottom %d: %s\n", a, __func__);
 }
+#endif
 
 int main(void)
 {
 	printf("Hello World! %s\n", CONFIG_BOARD);
 
+#if defined(STACK_UNWIND_LEAF_TEST)
+	leaf_caller();
+#else
 	func1(1);
+#endif
 
 	return 0;
 }

--- a/tests/arch/common/stack_unwind/src/riscv_leaf.S
+++ b/tests/arch/common/stack_unwind/src/riscv_leaf.S
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+
+GTEXT(leaf_fault)
+SECTION_FUNC(TEXT, leaf_fault)
+
+	/*
+	 * Model a leaf frame that saves its frame pointer but not ra. The
+	 * exception frame is the only source for the direct caller address.
+	 */
+	addi sp, sp, -16
+#ifdef CONFIG_64BIT
+	sd s0, 8(sp)
+#else
+	sw s0, 12(sp)
+#endif
+	addi s0, sp, 16
+
+	.word 0

--- a/tests/arch/common/stack_unwind/tests.yaml
+++ b/tests/arch/common/stack_unwind/tests.yaml
@@ -19,6 +19,37 @@ tests:
         - "E: call trace:"
         - "E:       0: fp: \\w+ ra: \\w+"
         - "E:       1: fp: \\w+ ra: \\w+"
+  arch.common.stack_unwind.riscv_fp_nonleaf:
+    arch_allow: riscv
+    integration_platforms:
+      - qemu_riscv32e
+      - qemu_riscv32
+      - qemu_riscv64
+    extra_args: EXTRA_CFLAGS=-DSTACK_UNWIND_NONLEAF_TEST
+    extra_configs:
+      - CONFIG_FRAME_POINTER=y
+      - CONFIG_SYMTAB=y
+    harness_config:
+      type: multi_line
+      regex:
+        - "E:       0: fp: \\w+ ra: \\w+ \\[func2\\+0x\\w+\\]"
+        - "E:       1: fp: \\w+ ra: \\w+ \\[func1\\+0x\\w+\\]"
+  arch.common.stack_unwind.riscv_fp_leaf:
+    arch_allow: riscv
+    integration_platforms:
+      - qemu_riscv32e
+      - qemu_riscv32
+      - qemu_riscv64
+    extra_args: EXTRA_CFLAGS=-DSTACK_UNWIND_LEAF_TEST
+    extra_configs:
+      - CONFIG_FRAME_POINTER=y
+      - CONFIG_SYMTAB=y
+    harness_config:
+      type: multi_line
+      regex:
+        - "E:       0: fp: \\w+ ra: \\w+ \\[leaf_fault\\+0x\\w+\\]"
+        - "E:       1: fp: \\w+ ra: \\w+ \\[leaf_caller\\+0x\\w+\\]"
+        - "E:       2: fp: \\w+ ra: \\w+ \\[main\\+0x\\w+\\]"
   arch.common.stack_unwind.riscv_sp:
     arch_allow: riscv
     integration_platforms:


### PR DESCRIPTION
The ra register is caller-saved. For a non-leaf function interrupted after a call, esf->ra points back into that function instead of to its caller. Emitting it unconditionally adds a bogus frame.

A leaf frame may have no saved return address, so its direct caller must come from esf->ra. Detect the compact leaf layout using a validated, monotonically increasing caller frame pointer, then continue through the normal walk loop. This preserves callback and maximum-depth semantics.

Request leaf frame pointers when CONFIG_FRAME_POINTER is enabled so supporting compilers cannot omit the frame entirely. Older compact leaf frames remain supported.

Add exact RV32E, RV32, and RV64 traces for leaf and non-leaf exception frames. Trigger the fault with an illegal instruction so M-mode and S-mode exercise the same exception path without relying on ebreak behavior.