### PR TITLE
arch: riscv: pmp: clear trailing PMP entries in kernel mode context switch

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -951,8 +951,9 @@ void z_riscv_pmp_kernelmode_enable(struct k_thread *thread)
 
 	/* Write our m-mode MPP entries */
 	if (thread->arch.m_mode_pmp_end_index > global_end_index) {
+		/* Clear trailing entries from the previous thread */
 		write_pmp_entries(global_end_index, thread->arch.m_mode_pmp_end_index,
-				  false /* no need to clear to the end */, PMP_M_MODE(thread));
+				  true, PMP_M_MODE(thread));
 	}
 
 #if defined(CONFIG_PMP_DATA_EXECUTION_PREVENTION) && defined(CONFIG_USERSPACE)


### PR DESCRIPTION
z_riscv_pmp_kernelmode_enable() passes clear_trailing_entries=false
to write_pmp_entries(), unlike the user-mode counterpart which passes
true. When two threads have different m_mode_pmp_end_index values,
the hardware PMP slots beyond the new thread's last entry retain the
previous thread's permissions, potentially leaking access or causing
spurious faults.

Fix by passing true to clear_trailing_entries, matching the user-mode
path. The index_limit parameter already bounds clearing to
PMP_USABLE_SLOTS, so locked global entries are safe.

Fixes #113868

Signed-off-by: Hongquan Li <hongquan.li@processmission.com>
