### PR TITLE
arch: riscv: pmp: fix TOR empty range for size=0 whole address space

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -303,6 +303,14 @@ static bool set_pmp_entry(unsigned int *index_p, uint8_t perm,
 	if (index >= index_limit) {
 		LOG_ERR("out of PMP slots");
 		ok = false;
+	} else if (PMP_NAPOT_SUPPORTED && size == 0) {
+		/*
+		 * "start=0 size=0" means the whole address range.
+		 * NAPOT all-ones encoding covers every address from 0.
+		 */
+		pmp_addr[index] = -1UL;
+		pmp_n_cfg[index] = perm | PMP_NAPOT;
+		index += 1;
 	} else if (PMP_TOR_SUPPORTED &&
 		   ((index == 0 && start == 0) ||
 		    (index != 0 && pmp_addr[index - 1] == PMP_ADDR(start)))) {


### PR DESCRIPTION
set_pmp_entry() documents that start=0 size=0 means the whole address range, but when index==0 the TOR optimization produces pmpaddr[0]=0, creating an empty TOR range [0,0). This breaks set_pmp_mprv_catchall() when the catch-all is the first PMP entry.

Fix by inserting a size==0 check before the TOR optimization that uses NAPOT all-ones encoding, which is the standard RISC-V encoding for the entire address space.

Fixes #113867