### PR TITLE
boards: weact/usb2canfdv2: remove use of stm32_lp_tick_source

### DIFF
--- a/boards/weact/usb2canfdv2/usb2canfdv2.dts
+++ b/boards/weact/usb2canfdv2/usb2canfdv2.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &fdcan1;
+		zephyr,system-timer = &lptim1;
 	};
 
 	aliases {
@@ -72,7 +73,7 @@
 	apb2-prescaler = <1>;
 };
 
-stm32_lp_tick_source: &lptim1 {
+&lptim1 {
 	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		 <&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";


### PR DESCRIPTION
Using the ``stm32_lp_tick_source`` nodelabel to select an LPTIM as
system timer is no longer supported.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
