### PR TITLE
tests: drivers: dma: fill tx buffer in loop_transfer repeated start stop

### DIFF
--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -373,6 +373,10 @@ static int test_loop_repeated_start_stop(const struct device *dma)
 
 	memset(tx_data, 0, sizeof(tx_data));
 
+	for (int i = 0; i < CONFIG_DMA_LOOP_TRANSFER_SIZE; i++) {
+		tx_data[i] = i;
+	}
+
 	memset(rx_data, 0, sizeof(rx_data));
 
 	if (!device_is_ready(dma)) {


### PR DESCRIPTION
### Description

`test_loop_repeated_start_stop()` in `tests/drivers/dma/loop_transfer`
zeroes `tx_data` and never fills it before starting the transfer, unlike
`test_loop()`, which fills `tx_data` with a pattern after the memset. The
subtest's verification therefore compares an all-zero RX buffer against an
all-zero TX buffer — and passes even when the DMA controller moves no data
at all.

This was observed on hardware while bringing up HPDMA1 on the STM32N6570-DK
(#113855): due to a channel isolation issue (transactions from channels with no CID 
configured were being silently discarded), the controller was demonstrably
transferring nothing — every other DMA subtest failed data verification
with zero-filled destination buffers — yet this subtest reported PASS.

### Fix

Fill `tx_data` with the same pattern used by `test_loop()` so the
comparison is meaningful.

### Validation

Run on an STM32N6570-DK (`stm32n6570_dk/stm32n657xx/sb`, GPDMA1):
the subtest still passes with the fix, now against real transferred data.

<details>
<summary><strong>Click to expand console output</strong></summary>

```console
*** Booting Zephyr OS build v4.4.0-8685-gcad37583ddd4 ***
Running TESTSUITE dma_m2m_loop
===================================================================
START - test_tst_dma0_m2m_loop
DMA memory to memory transfer started
Preparing DMA Controller: dma@50021000
this platform do not support the dma channel
Starting the transfer on channel 8 and waiting for 1 second
Each RX buffer should contain the full TX buffer string.
RX data Loop 0
RX data Loop 1
RX data Loop 2
RX data Loop 3
Finished DMA: dma@50021000
 PASS - test_tst_dma0_m2m_loop in 0.283 seconds
===================================================================
START - test_tst_dma0_m2m_loop_repeated_start_stop
DMA memory to memory transfer started
Preparing DMA Controller
this platform do not support the dma channel
Starting the transfer on channel 8 and waiting for 1 second
Each RX buffer should contain the full TX buffer string.
RX data Loop 0
RX data Loop 1
RX data Loop 2
RX data Loop 3
Finished: DMA
 PASS - test_tst_dma0_m2m_loop_repeated_start_stop in 0.281 seconds
===================================================================
START - test_tst_dma0_m2m_loop_suspend_resume
DMA memory to memory transfer started
Preparing DMA Controller: dma@50021000
this platform do not support the dma channel
Starting the transfer on channel 8 and waiting for 1 second
suspended after 0 transfers occurred
resuming after 0 transfers occurred
Resumed transfers
Transfer count 4
Each RX buffer should contain the full TX buffer string.
RX data Loop 0
RX data Loop 1
RX data Loop 2
RX data Loop 3
Finished DMA: dma@50021000
 PASS - test_tst_dma0_m2m_loop_suspend_resume in 0.544 seconds
===================================================================
TESTSUITE dma_m2m_loop succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [dma_m2m_loop]: pass = 3, fail = 0, skip = 0, total = 3 duration = 1.108 seconds
 - PASS - [dma_m2m_loop.test_tst_dma0_m2m_loop] duration = 0.283 seconds
 - PASS - [dma_m2m_loop.test_tst_dma0_m2m_loop_repeated_start_stop] duration = 0.281 seconds
 - PASS - [dma_m2m_loop.test_tst_dma0_m2m_loop_suspend_resume] duration = 0.544 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```
</details>