### PR TITLE
arch: riscv: coredump: skip priv stack dump for unstarted user threads

### DIFF
--- a/arch/riscv/core/coredump.c
+++ b/arch/riscv/core/coredump.c
@@ -211,6 +211,10 @@ void arch_coredump_priv_stack_dump(struct k_thread *thread)
 {
 	uintptr_t start_addr, end_addr;
 
+	if (thread->arch.priv_stack_start == 0) {
+		return;
+	}
+
 	/* See: zephyr/include/zephyr/arch/riscv/arch.h */
 	if (IS_ENABLED(CONFIG_PMP_POWER_OF_TWO_ALIGNMENT)) {
 		start_addr = thread->arch.priv_stack_start + Z_RISCV_STACK_GUARD_SIZE;


### PR DESCRIPTION
Skip the privilege stack dump for RISC-V user threads that have never entered user mode. Their `priv_stack_start` is still 0, so the coredump hook would otherwise read from an invalid low-address region and could trigger a nested memory fault.

Fixes #113875