### PR TITLE
drivers: counter: add lptmr counter wakeup capability

### DIFF
--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -16,6 +16,7 @@
 #endif /* CONFIG_GIC */
 #include <fsl_lptmr.h>
 #include <zephyr/spinlock.h>
+#include <zephyr/drivers/wuc.h>
 
 /*
  * Skip the instance reserved as the system timer via zephyr,system-timer.
@@ -26,6 +27,14 @@
 		(DT_SAME_NODE(DT_INST(n, nxp_lptmr),			\
 			      DT_CHOSEN(zephyr_system_timer))),		\
 		(0))
+
+/* True for the instance chosen as the system-timer low-power companion. */
+#if DT_HAS_CHOSEN(zephyr_system_timer_companion)
+#define COUNTER_MCUX_LPTMR_IS_COMPANION(n)				\
+	DT_SAME_NODE(DT_DRV_INST(n), DT_CHOSEN(zephyr_system_timer_companion))
+#else
+#define COUNTER_MCUX_LPTMR_IS_COMPANION(n) 0
+#endif /* DT_HAS_CHOSEN(zephyr_system_timer_companion) */
 
 #define COUNTER_MCUX_LPTMR_COUNT_USABLE(n) + (!COUNTER_MCUX_LPTMR_IS_SYSTEM_TIMER(n))
 
@@ -46,6 +55,9 @@ struct mcux_lptmr_config {
 	lptmr_pin_polarity_t polarity;
 	unsigned int irqn;
 	void (*irq_config_func)(const struct device *dev);
+	struct wuc_dt_spec wuc;
+	bool is_companion;
+	bool wakeup_source;
 };
 
 static ALWAYS_INLINE void irq_set_pending(unsigned int irq)
@@ -112,6 +124,14 @@ static int mcux_lptmr_get_value(const struct device *dev, uint32_t *ticks)
 }
 
 #if defined(CONFIG_COUNTER_MCUX_LPTMR_ALARM)
+/* True when the LPTMR is a wakeup source routed to a wakeup controller. */
+static ALWAYS_INLINE bool mcux_lptmr_is_wakeup_source(const struct device *dev)
+{
+	const struct mcux_lptmr_config *config = dev->config;
+
+	return config->wakeup_source && IS_ENABLED(CONFIG_WUC) && (config->wuc.dev != NULL);
+}
+
 static int mcux_lptmr_set_alarm(const struct device *dev, uint8_t chan_id,
 				const struct counter_alarm_cfg *alarm_cfg)
 {
@@ -166,6 +186,16 @@ static int mcux_lptmr_set_alarm(const struct device *dev, uint8_t chan_id,
 		return ret;
 	}
 
+	/* Arm the wakeup controller so the companion's alarm can wake the SoC. */
+	if (mcux_lptmr_is_wakeup_source(dev) && config->is_companion) {
+		int err = wuc_enable_wakeup_source_dt(&config->wuc);
+
+		if (err != 0) {
+			k_spin_unlock(&data->lock, key);
+			return err;
+		}
+	}
+
 	data->alarm_callback = alarm_cfg->callback;
 	data->alarm_user_data = alarm_cfg->user_data;
 	data->alarm_active = true;
@@ -213,6 +243,7 @@ static int mcux_lptmr_cancel_alarm(const struct device *dev, uint8_t chan_id)
 	const struct mcux_lptmr_config *config = dev->config;
 	struct mcux_lptmr_data *data = dev->data;
 	k_spinlock_key_t key;
+	int err = 0;
 
 	if (chan_id >= config->info.channels) {
 		return -EINVAL;
@@ -231,6 +262,10 @@ static int mcux_lptmr_cancel_alarm(const struct device *dev, uint8_t chan_id)
 	data->alarm_sw_pending = false;
 	data->alarm_active = false;
 
+	if (mcux_lptmr_is_wakeup_source(dev)) {
+		err = wuc_disable_wakeup_source_dt(&config->wuc);
+	}
+
 	k_spin_unlock(&data->lock, key);
 
 	LPTMR_StopTimer(config->base);
@@ -241,7 +276,7 @@ static int mcux_lptmr_cancel_alarm(const struct device *dev, uint8_t chan_id)
 	LPTMR_SetTimerPeriod(config->base, config->info.max_top_value);
 	LPTMR_ClearStatusFlags(config->base, kLPTMR_TimerCompareFlag);
 
-	return 0;
+	return err;
 }
 
 static uint32_t mcux_lptmr_get_guard_period(const struct device *dev, uint32_t flags)
@@ -402,6 +437,10 @@ static void mcux_lptmr_isr(const struct device *dev)
 		data->alarm_user_data = NULL;
 		data->alarm_sw_pending = false;
 		data->alarm_active = false;
+
+		if (mcux_lptmr_is_wakeup_source(dev)) {
+			(void)wuc_disable_wakeup_source_dt(&config->wuc);
+		}
 
 		k_spin_unlock(&data->lock, key);
 
@@ -566,6 +605,10 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 			MCUX_LPTMR_PRESCALE_GLITCH_VAL(n),			\
 		.irqn = DT_INST_IRQN(n),					\
 		.irq_config_func = mcux_lptmr_irq_config_##n,			\
+		.wuc = COND_CODE_1(CONFIG_WUC,					\
+			(WUC_DT_SPEC_GET_OR(DT_DRV_INST(n), {0})), ({0})),	\
+		.is_companion = COUNTER_MCUX_LPTMR_IS_COMPANION(n),		\
+		.wakeup_source = DT_INST_PROP_OR(n, wakeup_source, 0),		\
 	};									\
 										\
 	DEVICE_DT_INST_DEFINE(n, &mcux_lptmr_init, NULL,			\

--- a/drivers/counter/counter_mcux_lptmr.c
+++ b/drivers/counter/counter_mcux_lptmr.c
@@ -17,6 +17,7 @@
 #include <fsl_lptmr.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/drivers/wuc.h>
+#include <zephyr/pm/device.h>
 
 /*
  * Skip the instance reserved as the system timer via zephyr,system-timer.
@@ -186,8 +187,12 @@ static int mcux_lptmr_set_alarm(const struct device *dev, uint8_t chan_id,
 		return ret;
 	}
 
-	/* Arm the wakeup controller so the companion's alarm can wake the SoC. */
-	if (mcux_lptmr_is_wakeup_source(dev) && config->is_companion) {
+	/*
+	 * Arm the wakeup controller so the alarm can wake the SoC: for the
+	 * system-timer companion, or when enabled as a wakeup source at run time.
+	 */
+	if (mcux_lptmr_is_wakeup_source(dev) &&
+	    (config->is_companion || pm_device_wakeup_is_enabled(dev))) {
 		int err = wuc_enable_wakeup_source_dt(&config->wuc);
 
 		if (err != 0) {
@@ -495,6 +500,20 @@ static int mcux_lptmr_reset(const struct device *dev)
 	return 0;
 }
 
+static int mcux_lptmr_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	ARG_UNUSED(dev);
+
+	/* No device power state to manage; needed only to register a pm_device. */
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+	case PM_DEVICE_ACTION_SUSPEND:
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
 static int mcux_lptmr_init(const struct device *dev)
 {
 	const struct mcux_lptmr_config *config = dev->config;
@@ -518,7 +537,7 @@ static int mcux_lptmr_init(const struct device *dev)
 
 	config->irq_config_func(dev);
 
-	return 0;
+	return pm_device_driver_init(dev, mcux_lptmr_pm_action);
 }
 
 static DEVICE_API(counter, mcux_lptmr_driver_api) = {
@@ -611,7 +630,9 @@ static DEVICE_API(counter, mcux_lptmr_driver_api) = {
 		.wakeup_source = DT_INST_PROP_OR(n, wakeup_source, 0),		\
 	};									\
 										\
-	DEVICE_DT_INST_DEFINE(n, &mcux_lptmr_init, NULL,			\
+	PM_DEVICE_DT_INST_DEFINE(n, mcux_lptmr_pm_action);			\
+										\
+	DEVICE_DT_INST_DEFINE(n, &mcux_lptmr_init, PM_DEVICE_DT_INST_GET(n),	\
 		&mcux_lptmr_data_##n,						\
 		&mcux_lptmr_config_##n,						\
 		POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY,			\

--- a/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
@@ -360,6 +360,7 @@
 			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <32>;
+			wakeup-source;
 			wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
@@ -583,6 +583,7 @@
 			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <32>;
+			wakeup-source;
 			wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
@@ -524,6 +524,7 @@
 			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <32>;
+			wakeup-source;
 			wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -562,6 +562,7 @@
 		prescale-glitch-filter-bypass;
 		clk-source = <1>;
 		resolution = <32>;
+		wakeup-source;
 		wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -246,6 +246,7 @@
 			prescale-glitch-filter-bypass;
 			clk-source = <1>;
 			resolution = <32>;
+			wakeup-source;
 			wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 			status = "disabled";
 		};

--- a/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxn23x_common.dtsi
@@ -1015,6 +1015,7 @@
 		prescale-glitch-filter-bypass;
 		clk-source = <1>;
 		resolution = <32>;
+		wakeup-source;
 		wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 	};
 

--- a/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
@@ -1166,6 +1166,7 @@
 		prescale-glitch-filter-bypass;
 		clk-source = <1>;
 		resolution = <32>;
+		wakeup-source;
 		wakeup-ctrls = <&wuu NXP_WUU_MODULE_6_INT>;
 	};
 

--- a/samples/boards/nxp/mcxn_a/s2ram/src/main.c
+++ b/samples/boards/nxp/mcxn_a/s2ram/src/main.c
@@ -88,20 +88,10 @@ static struct pm_notifier button_pm_notifier = {
 	.state_exit = on_pm_state_exit,
 };
 #else
-/* LPTMR0 (the system-timer companion) reaches the core as a WUU internal-module
- * wakeup source.
+/* The timer variant relies on LPTMR0, which the counter driver arms as a
+ * wakeup source on its own.
  */
-static const struct wuc_dt_spec timer_wakeup = WUC_DT_SPEC_GET(DT_NODELABEL(lptmr0));
 #endif /* CONFIG_SAMPLE_S2RAM_WAKEUP_BUTTON */
-
-static void arm_wakeup_source(void)
-{
-#if defined(CONFIG_SAMPLE_S2RAM_WAKEUP_BUTTON)
-	(void)wuc_enable_wakeup_source_dt(&button);
-#else
-	(void)wuc_enable_wakeup_source_dt(&timer_wakeup);
-#endif
-}
 
 static void app_thread(void *p1, void *p2, void *p3)
 {
@@ -123,12 +113,12 @@ static void app_thread(void *p1, void *p2, void *p3)
 		/* Let the UART finish shifting out the line above before DPD cuts its clock. */
 		k_busy_wait(2000);
 
-#if defined(CONFIG_SOC_SERIES_MCXAXX6) || defined(CONFIG_SOC_SERIES_MCXAXX7)
-		/* On MCXAxx6 / MCXAxx7 the Deep Power Down wakeup reset clears the
-		 * WUU wakeup-source configuration, so the source has to be re-armed
-		 * before every entry.
+#if defined(CONFIG_SAMPLE_S2RAM_WAKEUP_BUTTON) &&				\
+	(defined(CONFIG_SOC_SERIES_MCXAXX6) || defined(CONFIG_SOC_SERIES_MCXAXX7))
+		/* MCXAxx6 / MCXAxx7 clear the WUU config on the DPD wakeup reset,
+		 * so re-arm the button before each entry.
 		 */
-		arm_wakeup_source();
+		(void)wuc_enable_wakeup_source_dt(&button);
 #endif
 
 		pm_state_force(0U, &(struct pm_state_info){PM_STATE_SUSPEND_TO_RAM, 0, 0});
@@ -162,13 +152,11 @@ int main(void)
 	pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
 
-	/* The application selects and enables its own wakeup source through the
-	 * WUC subsystem; the SoC power code does not hard-code one.
-	 */
 #if defined(CONFIG_SAMPLE_S2RAM_WAKEUP_BUTTON)
+	/* Arm the button as the wakeup source. */
 	pm_notifier_register(&button_pm_notifier);
+	(void)wuc_enable_wakeup_source_dt(&button);
 #endif
-	arm_wakeup_source();
 
 	k_thread_create(&app_thread_data, app_stack, APP_STACK_SIZE, app_thread,
 			NULL, NULL, NULL, APP_PRIORITY, 0, K_NO_WAIT);

--- a/samples/boards/nxp/mcxn_a/system_off/src/main.c
+++ b/samples/boards/nxp/mcxn_a/system_off/src/main.c
@@ -16,8 +16,6 @@
 
 #define WAKEUP_DELAY_S 5U
 static const struct device *const lptmr = DEVICE_DT_GET(DT_NODELABEL(lptmr0));
-/* LPTMR0 reaches the core as a WUU internal-module wakeup source. */
-static const struct wuc_dt_spec wakeup = WUC_DT_SPEC_GET(DT_NODELABEL(lptmr0));
 #else
 /* The wakeup button (a WUU external pin) is described per board and aliased as
  * "wakeup-button".
@@ -129,29 +127,32 @@ int main(void)
 		return 0;
 	}
 
-	if (!device_is_ready(wakeup.dev)) {
-		printk("WUC device %s not ready\n", wakeup.dev->name);
-		return 0;
-	}
-
 #if defined(CONFIG_SAMPLE_SYSTEM_OFF_WAKEUP_TIMER)
 	if (!device_is_ready(lptmr)) {
 		printk("LPTMR counter device not ready\n");
 		return 0;
 	}
 
+	/* LPTMR0 is the system-timer companion, so the counter driver arms it as
+	 * a wakeup source when the alarm is set - nothing else is needed here.
+	 */
 	ret = arm_timer_wakeup();
 	if (ret < 0) {
 		printk("Failed to arm LPTMR wakeup (%d)\n", ret);
 		return 0;
 	}
-#endif
+#else
+	if (!device_is_ready(wakeup.dev)) {
+		printk("WUC device %s not ready\n", wakeup.dev->name);
+		return 0;
+	}
 
 	ret = wuc_enable_wakeup_source_dt(&wakeup);
 	if (ret < 0) {
 		printk("Failed to enable wakeup source (%d)\n", ret);
 		return 0;
 	}
+#endif
 
 	cycles++;
 	retain_counter_ram();


### PR DESCRIPTION
1. When using LPTMR as a wakeup source, we should add `wakeup-source` property to the DTS to indicate that the device has wakeup capability.

2. When using LPTMR as a companion counter, WUC should be enabled in the "Set Alarm" function and disabled in the "Cancel Alarm/ISR" function. This is because when used as a companion counter, the system timer only starts the companion counter in `non-K_TICKS_FOREVER` states, and in this state, the companion counter must be a wakeup source; otherwise, it will miss events.

3. If LPTMR is not used as a companion counter but as a regular alarm counter, then WUC needs to be enabled according to the software's actual intent (`WS_ENABLED`).

fix https://github.com/zephyrproject-rtos/zephyr/issues/113064, https://github.com/zephyrproject-rtos/zephyr/issues/113753