### PR TITLE
kernel: mmu: fix redundantl guard page assertions

### DIFF
--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -703,18 +703,18 @@ void k_mem_unmap_phys_guard(void *addr, size_t size, bool is_anon)
 	 */
 	pos = addr;
 	ret = arch_page_phys_get(pos - CONFIG_MMU_PAGE_SIZE, NULL);
+	__ASSERT(ret != 0,
+		 "%s: cannot find preceding guard page for (%p, %zu)",
+		 __func__, addr, size);
 	if (ret == 0) {
-		__ASSERT(ret == 0,
-			 "%s: cannot find preceding guard page for (%p, %zu)",
-			 __func__, addr, size);
 		goto out;
 	}
 
 	ret = arch_page_phys_get(pos + size, NULL);
+	__ASSERT(ret != 0,
+		 "%s: cannot find succeeding guard page for (%p, %zu)",
+		 __func__, addr, size);
 	if (ret == 0) {
-		__ASSERT(ret == 0,
-			 "%s: cannot find succeeding guard page for (%p, %zu)",
-			 __func__, addr, size);
 		goto out;
 	}
 


### PR DESCRIPTION
The guard page checks in k_mem_unmap_phys_guard() asserted
ret == 0 inside an if (ret == 0) branch, so the assertions
could never fire and the "cannot find guard page" diagnostic
was unreachable in any build.

Assert the intended invariant (ret != 0, i.e. the guard page
is unmapped) before the branch, matching the assert-then-
handle pattern used elsewhere in this function. Behavior with
CONFIG_ASSERT=n is unchanged.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
