### PR TITLE
drivers: coredump: adopt driver_ops Doxygen convention

### DIFF
--- a/include/zephyr/drivers/coredump.h
+++ b/include/zephyr/drivers/coredump.h
@@ -56,51 +56,62 @@ struct coredump_mem_region_node {
 typedef void (*coredump_dump_callback_t)(uintptr_t dump_area, size_t dump_area_size);
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * For internal use only, skip these in public documentation.
+ * @def_driverbackendgroup{Coredump pseudo-device,coredump_device_interface}
+ * @{
  */
 
-/*
- * Type definition of coredump API function for adding specified
- * data into coredump
+/**
+ * @brief Add the device's data into the core dump being generated.
+ *
+ * Called by the coredump subsystem at dump time so the device can copy the
+ * registered memory regions and callback data into the core dump.
  */
 typedef void (*coredump_device_dump_t)(const struct device *dev);
 
-/*
- * Type definition of coredump API function for registering a memory
- * region
+/**
+ * @brief Register a memory region to be stored in the core dump.
+ * See coredump_device_register_memory() for argument description.
  */
 typedef bool (*coredump_device_register_memory_t)(const struct device *dev,
 	struct coredump_mem_region_node *region);
 
-/*
- * Type definition of coredump API function for unregistering a memory
- * region
+/**
+ * @brief Unregister a memory region from being stored in the core dump.
+ * See coredump_device_unregister_memory() for argument description.
  */
 typedef bool (*coredump_device_unregister_memory_t)(const struct device *dev,
 	struct coredump_mem_region_node *region);
 
-/*
- * Type definition of coredump API function for registering a dump
- * callback
+/**
+ * @brief Register a callback to be invoked at dump time.
+ * See coredump_device_register_callback() for argument description.
  */
 typedef bool (*coredump_device_register_callback_t)(const struct device *dev,
 	coredump_dump_callback_t callback);
 
-/*
- * API which a coredump pseudo-device driver should expose
+/**
+ * @driver_ops{Coredump pseudo-device}
  */
 __subsystem struct coredump_driver_api {
+	/**
+	 * @driver_ops_mandatory Add the device's data into the core dump being generated.
+	 */
 	coredump_device_dump_t              dump;
+	/**
+	 * @driver_ops_mandatory @copybrief coredump_device_register_memory
+	 */
 	coredump_device_register_memory_t   register_memory;
+	/**
+	 * @driver_ops_mandatory @copybrief coredump_device_unregister_memory
+	 */
 	coredump_device_unregister_memory_t unregister_memory;
+	/**
+	 * @driver_ops_mandatory @copybrief coredump_device_register_callback
+	 */
 	coredump_device_register_callback_t register_callback;
 };
 
-/**
- * @endcond
- */
+/** @} */
 
 /**
  * @brief Register a region of memory to be stored in core dump at the


### PR DESCRIPTION
Group the coredump pseudo-device driver backend definitions in a
dedicated backend API group and document the driver API structure
with the driver_ops Doxygen commands, tagging each operation as
mandatory.

https://builds.zephyrproject.io/zephyr/pr/113881/docs/doxygen/html/structcoredump__driver__api.html
