### PR TITLE
drivers: mipi_dsi: adopt driver_ops Doxygen convention

### DIFF
--- a/include/zephyr/drivers/mipi_dsi.h
+++ b/include/zephyr/drivers/mipi_dsi.h
@@ -121,15 +121,47 @@ struct mipi_dsi_msg {
 	void *user_data;
 };
 
-/** MIPI-DSI host driver API. */
+/**
+ * @def_driverbackendgroup{MIPI-DSI,mipi_dsi_interface}
+ * @{
+ */
+
+/**
+ * @brief Attach a new device to the MIPI-DSI bus.
+ * See mipi_dsi_attach() for argument description.
+ */
+typedef int (*mipi_dsi_api_attach_t)(const struct device *dev, uint8_t channel,
+				     const struct mipi_dsi_device *mdev);
+
+/**
+ * @brief Transfer data to/from a device attached to the MIPI-DSI bus.
+ * See mipi_dsi_transfer() for argument description.
+ */
+typedef ssize_t (*mipi_dsi_api_transfer_t)(const struct device *dev, uint8_t channel,
+					   struct mipi_dsi_msg *msg);
+
+/**
+ * @brief Detach a device from the MIPI-DSI bus.
+ * See mipi_dsi_detach() for argument description.
+ */
+typedef int (*mipi_dsi_api_detach_t)(const struct device *dev, uint8_t channel,
+				     const struct mipi_dsi_device *mdev);
+
+/**
+ * @driver_ops{MIPI-DSI}
+ */
 __subsystem struct mipi_dsi_driver_api {
-	int (*attach)(const struct device *dev, uint8_t channel,
-		      const struct mipi_dsi_device *mdev);
-	ssize_t (*transfer)(const struct device *dev, uint8_t channel,
-			    struct mipi_dsi_msg *msg);
-	int (*detach)(const struct device *dev, uint8_t channel,
-		      const struct mipi_dsi_device *mdev);
+	/** @driver_ops_mandatory @copybrief mipi_dsi_attach */
+	mipi_dsi_api_attach_t attach;
+	/** @driver_ops_mandatory @copybrief mipi_dsi_transfer */
+	mipi_dsi_api_transfer_t transfer;
+	/** @driver_ops_optional @copybrief mipi_dsi_detach */
+	mipi_dsi_api_detach_t detach;
 };
+
+/**
+ * @}
+ */
 
 /**
  * @brief Attach a new device to the MIPI-DSI bus.


### PR DESCRIPTION
Introduce documented typedefs for the MIPI-DSI driver operations,
group the backend definitions in a dedicated backend API group and
document the driver API structure with the driver_ops Doxygen
commands, tagging each operation as mandatory or optional.

https://builds.zephyrproject.io/zephyr/pr/113887/docs/doxygen/html/structmipi__dsi__driver__api.html
