### PR TITLE
drivers: smbus: adopt driver_ops Doxygen convention

### DIFF
--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -333,75 +333,151 @@ struct smbus_dt_spec {
 #define SMBUS_DT_SPEC_INST_GET(inst) SMBUS_DT_SPEC_GET(DT_DRV_INST(inst))
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * These are for internal use only, so skip these in
- * public documentation.
+ * @def_driverbackendgroup{SMBus,smbus_interface}
+ * @{
  */
 
+/**
+ * @brief Configure operation of a SMBus host controller.
+ * See smbus_configure() for argument description.
+ */
 typedef int (*smbus_api_configure_t)(const struct device *dev,
 				     uint32_t dev_config);
+/**
+ * @brief Get configuration of a SMBus host controller.
+ * See smbus_get_config() for argument description.
+ */
 typedef int (*smbus_api_get_config_t)(const struct device *dev,
 				      uint32_t *dev_config);
+/**
+ * @brief Perform SMBus Quick operation.
+ * See smbus_quick() for argument description.
+ */
 typedef int (*smbus_api_quick_t)(const struct device *dev,
 				 uint16_t addr, enum smbus_direction);
+/**
+ * @brief Perform SMBus Byte Write operation.
+ * See smbus_byte_write() for argument description.
+ */
 typedef int (*smbus_api_byte_write_t)(const struct device *dev,
 				      uint16_t addr, uint8_t byte);
+/**
+ * @brief Perform SMBus Byte Read operation.
+ * See smbus_byte_read() for argument description.
+ */
 typedef int (*smbus_api_byte_read_t)(const struct device *dev,
 				     uint16_t addr, uint8_t *byte);
+/**
+ * @brief Perform SMBus Byte Data Write operation.
+ * See smbus_byte_data_write() for argument description.
+ */
 typedef int (*smbus_api_byte_data_write_t)(const struct device *dev,
 					   uint16_t addr, uint8_t cmd,
 					   uint8_t byte);
+/**
+ * @brief Perform SMBus Byte Data Read operation.
+ * See smbus_byte_data_read() for argument description.
+ */
 typedef int (*smbus_api_byte_data_read_t)(const struct device *dev,
 					  uint16_t addr, uint8_t cmd,
 					  uint8_t *byte);
+/**
+ * @brief Perform SMBus Word Data Write operation.
+ * See smbus_word_data_write() for argument description.
+ */
 typedef int (*smbus_api_word_data_write_t)(const struct device *dev,
 					   uint16_t addr, uint8_t cmd,
 					   uint16_t word);
+/**
+ * @brief Perform SMBus Word Data Read operation.
+ * See smbus_word_data_read() for argument description.
+ */
 typedef int (*smbus_api_word_data_read_t)(const struct device *dev,
 					  uint16_t addr, uint8_t cmd,
 					  uint16_t *word);
+/**
+ * @brief Perform SMBus Process Call operation.
+ * See smbus_pcall() for argument description.
+ */
 typedef int (*smbus_api_pcall_t)(const struct device *dev,
 				 uint16_t addr, uint8_t cmd,
 				 uint16_t send_word, uint16_t *recv_word);
+/**
+ * @brief Perform SMBus Block Write operation.
+ * See smbus_block_write() for argument description.
+ */
 typedef int (*smbus_api_block_write_t)(const struct device *dev,
 				       uint16_t addr, uint8_t cmd,
 				       uint8_t count, uint8_t *buf);
+/**
+ * @brief Perform SMBus Block Read operation.
+ * See smbus_block_read() for argument description.
+ */
 typedef int (*smbus_api_block_read_t)(const struct device *dev,
 				      uint16_t addr, uint8_t cmd,
 				      uint8_t *count, uint8_t *buf);
+/**
+ * @brief Perform SMBus Block Process Call operation.
+ * See smbus_block_pcall() for argument description.
+ */
 typedef int (*smbus_api_block_pcall_t)(const struct device *dev,
 				       uint16_t addr, uint8_t cmd,
 				       uint8_t send_count, uint8_t *send_buf,
 				       uint8_t *recv_count, uint8_t *recv_buf);
+/**
+ * @brief Add or remove a SMBALERT callback.
+ * See smbus_smbalert_set_cb() and smbus_smbalert_remove_cb() for argument description.
+ */
 typedef int (*smbus_api_smbalert_cb_t)(const struct device *dev,
 				       struct smbus_callback *cb);
+/**
+ * @brief Add or remove a Host Notify callback.
+ * See smbus_host_notify_set_cb() and smbus_host_notify_remove_cb() for argument description.
+ */
 typedef int (*smbus_api_host_notify_cb_t)(const struct device *dev,
 					  struct smbus_callback *cb);
 
+/**
+ * @driver_ops{SMBus}
+ */
 __subsystem struct smbus_driver_api {
+	/** @driver_ops_mandatory @copybrief smbus_configure */
 	smbus_api_configure_t configure;
+	/** @driver_ops_optional @copybrief smbus_get_config */
 	smbus_api_get_config_t get_config;
+	/** @driver_ops_optional Perform SMBus Quick operation. */
 	smbus_api_quick_t smbus_quick;
+	/** @driver_ops_optional Perform SMBus Byte Write operation. */
 	smbus_api_byte_write_t smbus_byte_write;
+	/** @driver_ops_optional Perform SMBus Byte Read operation. */
 	smbus_api_byte_read_t smbus_byte_read;
+	/** @driver_ops_optional Perform SMBus Byte Data Write operation. */
 	smbus_api_byte_data_write_t smbus_byte_data_write;
+	/** @driver_ops_optional Perform SMBus Byte Data Read operation. */
 	smbus_api_byte_data_read_t smbus_byte_data_read;
+	/** @driver_ops_optional Perform SMBus Word Data Write operation. */
 	smbus_api_word_data_write_t smbus_word_data_write;
+	/** @driver_ops_optional Perform SMBus Word Data Read operation. */
 	smbus_api_word_data_read_t smbus_word_data_read;
+	/** @driver_ops_optional Perform SMBus Process Call operation. */
 	smbus_api_pcall_t smbus_pcall;
+	/** @driver_ops_optional Perform SMBus Block Write operation. */
 	smbus_api_block_write_t smbus_block_write;
+	/** @driver_ops_optional Perform SMBus Block Read operation. */
 	smbus_api_block_read_t smbus_block_read;
+	/** @driver_ops_optional Perform SMBus Block Process Call operation. */
 	smbus_api_block_pcall_t smbus_block_pcall;
+	/** @driver_ops_optional Add SMBUSALERT callback for a SMBus host controller. */
 	smbus_api_smbalert_cb_t smbus_smbalert_set_cb;
+	/** @driver_ops_optional Remove SMBUSALERT callback from a SMBus host controller. */
 	smbus_api_smbalert_cb_t smbus_smbalert_remove_cb;
+	/** @driver_ops_optional Add Host Notify callback for a SMBus host controller. */
 	smbus_api_host_notify_cb_t smbus_host_notify_set_cb;
+	/** @driver_ops_optional Remove Host Notify callback from a SMBus host controller. */
 	smbus_api_host_notify_cb_t smbus_host_notify_remove_cb;
 };
 
-/**
- * @endcond
- */
+/** @} */
 
 #if defined(CONFIG_SMBUS_STATS) || defined(__DOXYGEN__)
 

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -626,7 +626,7 @@ static inline void smbus_xfer_stats(const struct device *dev, uint8_t sent,
 	SMBUS_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
- * @brief Configure operation of a SMBus host controller.
+ * @brief Configure operation of an SMBus host controller.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
  * @param dev_config Bit-packed 32-bit value to the device runtime configuration
@@ -644,7 +644,7 @@ static inline int z_impl_smbus_configure(const struct device *dev,
 }
 
 /**
- * @brief Get configuration of a SMBus host controller.
+ * @brief Get configuration of an SMBus host controller.
  *
  * This routine provides a way to get current configuration. It is allowed to
  * call the function before smbus_configure, because some SMBus ports can be
@@ -678,7 +678,7 @@ static inline int z_impl_smbus_get_config(const struct device *dev,
 }
 
 /**
- * @brief Add SMBUSALERT callback for a SMBus host controller.
+ * @brief Add SMBALERT callback for an SMBus host controller.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
  * @param cb Pointer to a callback structure.
@@ -701,7 +701,7 @@ static inline int smbus_smbalert_set_cb(const struct device *dev,
 }
 
 /**
- * @brief Remove SMBUSALERT callback from a SMBus host controller.
+ * @brief Remove SMBALERT callback from an SMBus host controller.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
  * @param cb Pointer to a callback structure.
@@ -727,7 +727,7 @@ static inline int z_impl_smbus_smbalert_remove_cb(const struct device *dev,
 }
 
 /**
- * @brief Add Host Notify callback for a SMBus host controller.
+ * @brief Add Host Notify callback for an SMBus host controller.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
  * @param cb Pointer to a callback structure.
@@ -750,7 +750,7 @@ static inline int smbus_host_notify_set_cb(const struct device *dev,
 }
 
 /**
- * @brief Remove Host Notify callback from a SMBus host controller.
+ * @brief Remove Host Notify callback from an SMBus host controller.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
  * @param cb Pointer to a callback structure.
@@ -776,9 +776,9 @@ static inline int z_impl_smbus_host_notify_remove_cb(const struct device *dev,
 }
 
 /**
- * @brief Perform SMBus Quick operation
+ * @brief Perform an SMBus Quick operation
  *
- * This routine provides a generic interface to perform SMBus Quick
+ * This routine provides a generic interface to perform an SMBus Quick
  * operation.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
@@ -811,9 +811,9 @@ static inline int z_impl_smbus_quick(const struct device *dev, uint16_t addr,
 }
 
 /**
- * @brief Perform SMBus Byte Write operation
+ * @brief Perform an SMBus Byte Write operation
  *
- * This routine provides a generic interface to perform SMBus
+ * This routine provides a generic interface to perform an SMBus
  * Byte Write operation.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
@@ -841,9 +841,9 @@ static inline int z_impl_smbus_byte_write(const struct device *dev,
 }
 
 /**
- * @brief Perform SMBus Byte Read operation
+ * @brief Perform an SMBus Byte Read operation
  *
- * This routine provides a generic interface to perform SMBus
+ * This routine provides a generic interface to perform an SMBus
  * Byte Read operation.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
@@ -871,9 +871,9 @@ static inline int z_impl_smbus_byte_read(const struct device *dev,
 }
 
 /**
- * @brief Perform SMBus Byte Data Write operation
+ * @brief Perform an SMBus Byte Data Write operation
  *
- * This routine provides a generic interface to perform SMBus
+ * This routine provides a generic interface to perform an SMBus
  * Byte Data Write operation.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
@@ -903,9 +903,9 @@ static inline int z_impl_smbus_byte_data_write(const struct device *dev,
 }
 
 /**
- * @brief Perform SMBus Byte Data Read operation
+ * @brief Perform an SMBus Byte Data Read operation
  *
- * This routine provides a generic interface to perform SMBus
+ * This routine provides a generic interface to perform an SMBus
  * Byte Data Read operation.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
@@ -935,9 +935,9 @@ static inline int z_impl_smbus_byte_data_read(const struct device *dev,
 }
 
 /**
- * @brief Perform SMBus Word Data Write operation
+ * @brief Perform an SMBus Word Data Write operation
  *
- * This routine provides a generic interface to perform SMBus
+ * This routine provides a generic interface to perform an SMBus
  * Word Data Write operation.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
@@ -967,9 +967,9 @@ static inline int z_impl_smbus_word_data_write(const struct device *dev,
 }
 
 /**
- * @brief Perform SMBus Word Data Read operation
+ * @brief Perform an SMBus Word Data Read operation
  *
- * This routine provides a generic interface to perform SMBus
+ * This routine provides a generic interface to perform an SMBus
  * Word Data Read operation.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
@@ -999,9 +999,9 @@ static inline int z_impl_smbus_word_data_read(const struct device *dev,
 }
 
 /**
- * @brief Perform SMBus Process Call operation
+ * @brief Perform an SMBus Process Call operation
  *
- * This routine provides a generic interface to perform SMBus
+ * This routine provides a generic interface to perform an SMBus
  * Process Call operation, which means Write 2 bytes following by
  * Read 2 bytes.
  *
@@ -1033,9 +1033,9 @@ static inline int z_impl_smbus_pcall(const struct device *dev,
 }
 
 /**
- * @brief Perform SMBus Block Write operation
+ * @brief Perform an SMBus Block Write operation
  *
- * This routine provides a generic interface to perform SMBus
+ * This routine provides a generic interface to perform an SMBus
  * Block Write operation.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
@@ -1070,9 +1070,9 @@ static inline int z_impl_smbus_block_write(const struct device *dev,
 }
 
 /**
- * @brief Perform SMBus Block Read operation
+ * @brief Perform an SMBus Block Read operation
  *
- * This routine provides a generic interface to perform SMBus
+ * This routine provides a generic interface to perform an SMBus
  * Block Read operation.
  *
  * @param dev Pointer to the device structure for the SMBus driver instance.
@@ -1103,9 +1103,9 @@ static inline int z_impl_smbus_block_read(const struct device *dev,
 }
 
 /**
- * @brief Perform SMBus Block Process Call operation
+ * @brief Perform an SMBus Block Process Call operation
  *
- * This routine provides a generic interface to perform SMBus
+ * This routine provides a generic interface to perform an SMBus
  * Block Process Call operation. This operation is basically
  * Block Write followed by Block Read.
  *

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -333,75 +333,151 @@ struct smbus_dt_spec {
 #define SMBUS_DT_SPEC_INST_GET(inst) SMBUS_DT_SPEC_GET(DT_DRV_INST(inst))
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * These are for internal use only, so skip these in
- * public documentation.
+ * @def_driverbackendgroup{SMBus,smbus_interface}
+ * @{
  */
 
+/**
+ * @brief Configure operation of an SMBus host controller.
+ * See smbus_configure() for argument description.
+ */
 typedef int (*smbus_api_configure_t)(const struct device *dev,
 				     uint32_t dev_config);
+/**
+ * @brief Get configuration of an SMBus host controller.
+ * See smbus_get_config() for argument description.
+ */
 typedef int (*smbus_api_get_config_t)(const struct device *dev,
 				      uint32_t *dev_config);
+/**
+ * @brief Perform an SMBus Quick operation.
+ * See smbus_quick() for argument description.
+ */
 typedef int (*smbus_api_quick_t)(const struct device *dev,
 				 uint16_t addr, enum smbus_direction);
+/**
+ * @brief Perform an SMBus Byte Write operation.
+ * See smbus_byte_write() for argument description.
+ */
 typedef int (*smbus_api_byte_write_t)(const struct device *dev,
 				      uint16_t addr, uint8_t byte);
+/**
+ * @brief Perform an SMBus Byte Read operation.
+ * See smbus_byte_read() for argument description.
+ */
 typedef int (*smbus_api_byte_read_t)(const struct device *dev,
 				     uint16_t addr, uint8_t *byte);
+/**
+ * @brief Perform an SMBus Byte Data Write operation.
+ * See smbus_byte_data_write() for argument description.
+ */
 typedef int (*smbus_api_byte_data_write_t)(const struct device *dev,
 					   uint16_t addr, uint8_t cmd,
 					   uint8_t byte);
+/**
+ * @brief Perform an SMBus Byte Data Read operation.
+ * See smbus_byte_data_read() for argument description.
+ */
 typedef int (*smbus_api_byte_data_read_t)(const struct device *dev,
 					  uint16_t addr, uint8_t cmd,
 					  uint8_t *byte);
+/**
+ * @brief Perform an SMBus Word Data Write operation.
+ * See smbus_word_data_write() for argument description.
+ */
 typedef int (*smbus_api_word_data_write_t)(const struct device *dev,
 					   uint16_t addr, uint8_t cmd,
 					   uint16_t word);
+/**
+ * @brief Perform an SMBus Word Data Read operation.
+ * See smbus_word_data_read() for argument description.
+ */
 typedef int (*smbus_api_word_data_read_t)(const struct device *dev,
 					  uint16_t addr, uint8_t cmd,
 					  uint16_t *word);
+/**
+ * @brief Perform an SMBus Process Call operation.
+ * See smbus_pcall() for argument description.
+ */
 typedef int (*smbus_api_pcall_t)(const struct device *dev,
 				 uint16_t addr, uint8_t cmd,
 				 uint16_t send_word, uint16_t *recv_word);
+/**
+ * @brief Perform an SMBus Block Write operation.
+ * See smbus_block_write() for argument description.
+ */
 typedef int (*smbus_api_block_write_t)(const struct device *dev,
 				       uint16_t addr, uint8_t cmd,
 				       uint8_t count, uint8_t *buf);
+/**
+ * @brief Perform an SMBus Block Read operation.
+ * See smbus_block_read() for argument description.
+ */
 typedef int (*smbus_api_block_read_t)(const struct device *dev,
 				      uint16_t addr, uint8_t cmd,
 				      uint8_t *count, uint8_t *buf);
+/**
+ * @brief Perform an SMBus Block Process Call operation.
+ * See smbus_block_pcall() for argument description.
+ */
 typedef int (*smbus_api_block_pcall_t)(const struct device *dev,
 				       uint16_t addr, uint8_t cmd,
 				       uint8_t send_count, uint8_t *send_buf,
 				       uint8_t *recv_count, uint8_t *recv_buf);
+/**
+ * @brief Add or remove an SMBALERT callback.
+ * See smbus_smbalert_set_cb() and smbus_smbalert_remove_cb() for argument description.
+ */
 typedef int (*smbus_api_smbalert_cb_t)(const struct device *dev,
 				       struct smbus_callback *cb);
+/**
+ * @brief Add or remove a Host Notify callback.
+ * See smbus_host_notify_set_cb() and smbus_host_notify_remove_cb() for argument description.
+ */
 typedef int (*smbus_api_host_notify_cb_t)(const struct device *dev,
 					  struct smbus_callback *cb);
 
+/**
+ * @driver_ops{SMBus}
+ */
 __subsystem struct smbus_driver_api {
+	/** @driver_ops_mandatory Configure operation of an SMBus host controller. */
 	smbus_api_configure_t configure;
+	/** @driver_ops_optional Get configuration of an SMBus host controller. */
 	smbus_api_get_config_t get_config;
+	/** @driver_ops_optional Perform an SMBus Quick operation. */
 	smbus_api_quick_t smbus_quick;
+	/** @driver_ops_optional Perform an SMBus Byte Write operation. */
 	smbus_api_byte_write_t smbus_byte_write;
+	/** @driver_ops_optional Perform an SMBus Byte Read operation. */
 	smbus_api_byte_read_t smbus_byte_read;
+	/** @driver_ops_optional Perform an SMBus Byte Data Write operation. */
 	smbus_api_byte_data_write_t smbus_byte_data_write;
+	/** @driver_ops_optional Perform an SMBus Byte Data Read operation. */
 	smbus_api_byte_data_read_t smbus_byte_data_read;
+	/** @driver_ops_optional Perform an SMBus Word Data Write operation. */
 	smbus_api_word_data_write_t smbus_word_data_write;
+	/** @driver_ops_optional Perform an SMBus Word Data Read operation. */
 	smbus_api_word_data_read_t smbus_word_data_read;
+	/** @driver_ops_optional Perform an SMBus Process Call operation. */
 	smbus_api_pcall_t smbus_pcall;
+	/** @driver_ops_optional Perform an SMBus Block Write operation. */
 	smbus_api_block_write_t smbus_block_write;
+	/** @driver_ops_optional Perform an SMBus Block Read operation. */
 	smbus_api_block_read_t smbus_block_read;
+	/** @driver_ops_optional Perform an SMBus Block Process Call operation. */
 	smbus_api_block_pcall_t smbus_block_pcall;
+	/** @driver_ops_optional Add SMBALERT callback for an SMBus host controller. */
 	smbus_api_smbalert_cb_t smbus_smbalert_set_cb;
+	/** @driver_ops_optional Remove SMBALERT callback from an SMBus host controller. */
 	smbus_api_smbalert_cb_t smbus_smbalert_remove_cb;
+	/** @driver_ops_optional Add Host Notify callback for an SMBus host controller. */
 	smbus_api_host_notify_cb_t smbus_host_notify_set_cb;
+	/** @driver_ops_optional Remove Host Notify callback from an SMBus host controller. */
 	smbus_api_host_notify_cb_t smbus_host_notify_remove_cb;
 };
 
-/**
- * @endcond
- */
+/** @} */
 
 #if defined(CONFIG_SMBUS_STATS) || defined(__DOXYGEN__)
 


### PR DESCRIPTION
Group the SMBus driver backend definitions in a dedicated backend API
group and document the driver API structure with the driver_ops
Doxygen commands, tagging each operation as mandatory or optional.

https://builds.zephyrproject.io/zephyr/pr/113891/docs/doxygen/html/structsmbus__driver__api.html
