### PR TITLE
drivers: mspi: adopt driver_ops Doxygen convention

### DIFF
--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -123,7 +123,7 @@ static int perform_xfer(const struct device *dev, uint8_t cmd)
 		dev_data->packet.cmd = cmd;
 	}
 
-	/* Commands before chip is initialized manually apply a MSPI config
+	/* Commands before chip is initialized manually apply an MSPI config
 	 * which all flash chips support by JEDEC standard. Do not switch
 	 * to device tree config yet.
 	 * If multiple IO lines are used in all the transfer phases

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -481,50 +481,96 @@ typedef void (*mspi_callback_handler_t)(struct mspi_callback_context *mspi_cb_ct
 /** @} */
 
 /**
- * MSPI driver API definition and system call entry points
+ * @def_driverbackendgroup{MSPI,mspi_interface}
+ * @{
+ */
+
+/**
+ * @brief Configure a MSPI controller.
+ * See mspi_config() for argument description.
  */
 typedef int (*mspi_api_config)(const struct mspi_dt_spec *spec);
 
+/**
+ * @brief Configure a MSPI controller with device specific parameters.
+ * See mspi_dev_config() for argument description.
+ */
 typedef int (*mspi_api_dev_config)(const struct device *controller,
 				   const struct mspi_dev_id *dev_id,
 				   const enum mspi_dev_cfg_mask param_mask,
 				   const struct mspi_dev_cfg *cfg);
 
+/**
+ * @brief Query to see if it a channel is ready.
+ * See mspi_get_channel_status() for argument description.
+ */
 typedef int (*mspi_api_get_channel_status)(const struct device *controller, uint8_t ch);
 
+/**
+ * @brief Transfer request over MSPI.
+ * See mspi_transceive() for argument description.
+ */
 typedef int (*mspi_api_transceive)(const struct device *controller,
 				   const struct mspi_dev_id *dev_id,
 				   const struct mspi_xfer *req);
 
+/**
+ * @brief Register the mspi callback functions.
+ * See mspi_register_callback() for argument description.
+ */
 typedef int (*mspi_api_register_callback)(const struct device *controller,
 					  const struct mspi_dev_id *dev_id,
 					  const enum mspi_bus_event evt_type,
 					  mspi_callback_handler_t cb,
 					  struct mspi_callback_context *ctx);
 
-/** @brief Callback API for memory map configuration @see mspi_memmap_config() */
+/**
+ * @brief Configure a MSPI memory map settings.
+ * See mspi_memmap_config() for argument description.
+ */
 typedef int (*mspi_api_memmap_config)(const struct device *controller,
 				      const struct mspi_dev_id *dev_id,
 				      const struct mspi_memmap_cfg *memmap_cfg);
 
+/**
+ * @brief Configure a MSPI scrambling settings.
+ * See mspi_scramble_config() for argument description.
+ */
 typedef int (*mspi_api_scramble_config)(const struct device *controller,
 					const struct mspi_dev_id *dev_id,
 					const struct mspi_scramble_cfg *scramble_cfg);
 
+/**
+ * @brief Configure a MSPI timing settings.
+ * See mspi_timing_config() for argument description.
+ */
 typedef int (*mspi_api_timing_config)(const struct device *controller,
 				      const struct mspi_dev_id *dev_id, const uint32_t param_mask,
 				      void *timing_cfg);
 
+/**
+ * @driver_ops{MSPI}
+ */
 __subsystem struct mspi_driver_api {
+	/** @driver_ops_mandatory @copybrief mspi_config */
 	mspi_api_config                config;
+	/** @driver_ops_mandatory @copybrief mspi_dev_config */
 	mspi_api_dev_config            dev_config;
+	/** @driver_ops_mandatory @copybrief mspi_get_channel_status */
 	mspi_api_get_channel_status    get_channel_status;
+	/** @driver_ops_optional @copybrief mspi_transceive */
 	mspi_api_transceive            transceive;
+	/** @driver_ops_optional @copybrief mspi_register_callback */
 	mspi_api_register_callback     register_callback;
-	mspi_api_memmap_config         memmap_config; /**< @see mspi_memmap_config() */
+	/** @driver_ops_optional @copybrief mspi_memmap_config */
+	mspi_api_memmap_config         memmap_config;
+	/** @driver_ops_optional @copybrief mspi_scramble_config */
 	mspi_api_scramble_config       scramble_config;
+	/** @driver_ops_optional @copybrief mspi_timing_config */
 	mspi_api_timing_config         timing_config;
 };
+
+/** @} */
 
 /**
  * @addtogroup mspi_configure_api

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -481,50 +481,96 @@ typedef void (*mspi_callback_handler_t)(struct mspi_callback_context *mspi_cb_ct
 /** @} */
 
 /**
- * MSPI driver API definition and system call entry points
+ * @def_driverbackendgroup{MSPI,mspi_interface}
+ * @{
+ */
+
+/**
+ * @brief Configure an MSPI controller.
+ * See mspi_config() for argument description.
  */
 typedef int (*mspi_api_config)(const struct mspi_dt_spec *spec);
 
+/**
+ * @brief Configure an MSPI controller with device specific parameters.
+ * See mspi_dev_config() for argument description.
+ */
 typedef int (*mspi_api_dev_config)(const struct device *controller,
 				   const struct mspi_dev_id *dev_id,
 				   const enum mspi_dev_cfg_mask param_mask,
 				   const struct mspi_dev_cfg *cfg);
 
+/**
+ * @brief Query to see if it a channel is ready.
+ * See mspi_get_channel_status() for argument description.
+ */
 typedef int (*mspi_api_get_channel_status)(const struct device *controller, uint8_t ch);
 
+/**
+ * @brief Transfer request over MSPI.
+ * See mspi_transceive() for argument description.
+ */
 typedef int (*mspi_api_transceive)(const struct device *controller,
 				   const struct mspi_dev_id *dev_id,
 				   const struct mspi_xfer *req);
 
+/**
+ * @brief Register the mspi callback functions.
+ * See mspi_register_callback() for argument description.
+ */
 typedef int (*mspi_api_register_callback)(const struct device *controller,
 					  const struct mspi_dev_id *dev_id,
 					  const enum mspi_bus_event evt_type,
 					  mspi_callback_handler_t cb,
 					  struct mspi_callback_context *ctx);
 
-/** @brief Callback API for memory map configuration @see mspi_memmap_config() */
+/**
+ * @brief Configure MSPI memory map settings.
+ * See mspi_memmap_config() for argument description.
+ */
 typedef int (*mspi_api_memmap_config)(const struct device *controller,
 				      const struct mspi_dev_id *dev_id,
 				      const struct mspi_memmap_cfg *memmap_cfg);
 
+/**
+ * @brief Configure MSPI scrambling settings.
+ * See mspi_scramble_config() for argument description.
+ */
 typedef int (*mspi_api_scramble_config)(const struct device *controller,
 					const struct mspi_dev_id *dev_id,
 					const struct mspi_scramble_cfg *scramble_cfg);
 
+/**
+ * @brief Configure MSPI timing settings.
+ * See mspi_timing_config() for argument description.
+ */
 typedef int (*mspi_api_timing_config)(const struct device *controller,
 				      const struct mspi_dev_id *dev_id, const uint32_t param_mask,
 				      void *timing_cfg);
 
+/**
+ * @driver_ops{MSPI}
+ */
 __subsystem struct mspi_driver_api {
+	/** @driver_ops_mandatory @copybrief mspi_config */
 	mspi_api_config                config;
+	/** @driver_ops_mandatory @copybrief mspi_dev_config */
 	mspi_api_dev_config            dev_config;
+	/** @driver_ops_mandatory @copybrief mspi_get_channel_status */
 	mspi_api_get_channel_status    get_channel_status;
+	/** @driver_ops_optional @copybrief mspi_transceive */
 	mspi_api_transceive            transceive;
+	/** @driver_ops_optional @copybrief mspi_register_callback */
 	mspi_api_register_callback     register_callback;
-	mspi_api_memmap_config         memmap_config; /**< @see mspi_memmap_config() */
+	/** @driver_ops_optional @copybrief mspi_memmap_config */
+	mspi_api_memmap_config         memmap_config;
+	/** @driver_ops_optional @copybrief mspi_scramble_config */
 	mspi_api_scramble_config       scramble_config;
+	/** @driver_ops_optional @copybrief mspi_timing_config */
 	mspi_api_timing_config         timing_config;
 };
+
+/** @} */
 
 /**
  * @addtogroup mspi_configure_api
@@ -532,7 +578,7 @@ __subsystem struct mspi_driver_api {
  */
 
 /**
- * @brief Configure a MSPI controller.
+ * @brief Configure an MSPI controller.
  *
  * This routine provides a generic interface to override MSPI controller
  * capabilities.
@@ -560,7 +606,7 @@ static inline int z_impl_mspi_config(const struct mspi_dt_spec *spec)
 }
 
 /**
- * @brief Configure a MSPI controller with device specific parameters.
+ * @brief Configure an MSPI controller with device specific parameters.
  *
  * This routine provides a generic interface to override MSPI controller
  * device specific settings that should be derived from device datasheets.
@@ -725,7 +771,7 @@ static inline int mspi_transceive_data_only(const struct device *controller,
  */
 
 /**
- * @brief Configure a MSPI memory map settings.
+ * @brief Configure MSPI memory map settings.
  *
  * This routine provides a generic interface to configure the memory map feature.
  *
@@ -756,7 +802,7 @@ static inline int z_impl_mspi_memmap_config(const struct device *controller,
 }
 
 /**
- * @brief Configure a MSPI scrambling settings.
+ * @brief Configure MSPI scrambling settings.
  *
  * This routine provides a generic interface to configure the scrambling
  * feature.
@@ -788,7 +834,7 @@ static inline int z_impl_mspi_scramble_config(const struct device *controller,
 }
 
 /**
- * @brief Configure a MSPI timing settings.
+ * @brief Configure MSPI timing settings.
  *
  * This routine provides a generic interface to configure MSPI controller
  * timing if necessary.

--- a/include/zephyr/drivers/mspi/devicetree.h
+++ b/include/zephyr/drivers/mspi/devicetree.h
@@ -181,7 +181,7 @@ extern "C" {
 
 
 /**
- * @brief Get a <tt>struct gpio_dt_spec</tt> for a MSPI device's chip enable pin
+ * @brief Get a <tt>struct gpio_dt_spec</tt> for an MSPI device's chip enable pin
  *
  * Example devicetree fragment:
  *
@@ -214,7 +214,7 @@ extern "C" {
  *           // { DEVICE_DT_GET(DT_NODELABEL(gpio2)), 20, GPIO_ACTIVE_LOW }
  * @endcode
  *
- * @param mspi_dev a MSPI device node identifier
+ * @param mspi_dev an MSPI device node identifier
  * @return #gpio_dt_spec struct corresponding with mspi_dev's chip enable
  */
 #define MSPI_DEV_CE_GPIOS_DT_SPEC_GET(mspi_dev)                                                   \
@@ -222,7 +222,7 @@ extern "C" {
 					   DT_REG_ADDR_RAW(mspi_dev), {})
 
 /**
- * @brief Get a <tt>struct gpio_dt_spec</tt> for a MSPI device's chip enable pin
+ * @brief Get a <tt>struct gpio_dt_spec</tt> for an MSPI device's chip enable pin
  *
  * This is equivalent to
  * <tt>MSPI_DEV_CE_GPIOS_DT_SPEC_GET(DT_DRV_INST(inst))</tt>.
@@ -235,7 +235,7 @@ extern "C" {
 
 
 /**
- * @brief Get an array of <tt>struct gpio_dt_spec</tt> from devicetree for a MSPI controller
+ * @brief Get an array of <tt>struct gpio_dt_spec</tt> from devicetree for an MSPI controller
  *
  * This helper macro check whether <tt>ce_gpios</tt> binding exist first
  * before calling <tt>GPIO_DT_SPEC_GET_BY_IDX</tt> and expand to an array of
@@ -252,7 +252,7 @@ extern "C" {
 }
 
 /**
- * @brief Get an array of <tt>struct gpio_dt_spec</tt> for a MSPI controller
+ * @brief Get an array of <tt>struct gpio_dt_spec</tt> for an MSPI controller
  *
  * This is equivalent to
  * <tt>MSPI_CE_GPIOS_DT_SPEC_GET(DT_DRV_INST(inst))</tt>.
@@ -267,9 +267,9 @@ extern "C" {
  * @brief Initialize and get a pointer to a @p mspi_ce_control from a
  *        devicetree node identifier
  *
- * This helper is useful for initializing a device on a MSPI bus. It
+ * This helper is useful for initializing a device on an MSPI bus. It
  * initializes a struct mspi_ce_control and returns a pointer to it.
- * Here, @p node_id is a node identifier for a MSPI device, not a MSPI
+ * Here, @p node_id is a node identifier for an MSPI device, not an MSPI
  * controller.
  *
  * Example devicetree fragment:
@@ -297,7 +297,7 @@ extern "C" {
  *     };
  * @endcode
  *
- * @param node_id Devicetree node identifier for a device on a MSPI bus
+ * @param node_id Devicetree node identifier for a device on an MSPI bus
  * @param delay_ The @p delay field to set in the @p mspi_ce_control
  * @return a pointer to the @p mspi_ce_control structure
  */

--- a/include/zephyr/drivers/mspi_emul.h
+++ b/include/zephyr/drivers/mspi_emul.h
@@ -34,7 +34,7 @@ extern "C" {
 struct mspi_emul;
 
 /**
- * Find an emulator present on a MSPI bus
+ * Find an emulator present on an MSPI bus
  *
  * At present the function is used only to find an emulator of the host
  * device. It may be useful in systems with the SPI flash chips.

--- a/samples/drivers/mspi/mspi_async/README.rst
+++ b/samples/drivers/mspi/mspi_async/README.rst
@@ -7,7 +7,7 @@
 Overview
 ********
 
-This sample demonstrates using the :ref:`MSPI API <mspi_api>` on a MSPI
+This sample demonstrates using the :ref:`MSPI API <mspi_api>` on an MSPI
 memory device.  The asynchronous transceive call need to be supported
 either by a software queue or hardware queue from the controller hardware.
 To this sample, however, the implementation should make no difference.

--- a/samples/drivers/mspi/mspi_flash/README.rst
+++ b/samples/drivers/mspi/mspi_flash/README.rst
@@ -2,12 +2,12 @@
    :name: JEDEC MSPI-NOR flash
    :relevant-api: flash_interface
 
-   Use the flash API to interact with a MSPI NOR serial flash memory device.
+   Use the flash API to interact with an MSPI NOR serial flash memory device.
 
 Overview
 ********
 
-This sample demonstrates using the :ref:`flash API <flash_api>` on a MSPI NOR serial flash
+This sample demonstrates using the :ref:`flash API <flash_api>` on an MSPI NOR serial flash
 memory device.  While trivial it is an example of direct access and
 allows confirmation that the flash is working and that automatic power
 savings is correctly implemented.


### PR DESCRIPTION
Group the MSPI driver backend definitions in a dedicated backend API
group and document the driver API structure with the driver_ops
Doxygen commands, tagging each operation as mandatory or optional.

https://builds.zephyrproject.io/zephyr/pr/113894/docs/doxygen/html/structmspi__driver__api.html
