### PR TITLE
drivers: i3c: adopt driver_ops convention for target device API

### DIFF
--- a/include/zephyr/drivers/i3c/target_device.h
+++ b/include/zephyr/drivers/i3c/target_device.h
@@ -267,10 +267,38 @@ struct i3c_target_callbacks {
 	int (*controller_handoff_cb)(struct i3c_target_config *config);
 };
 
+/**
+ * @def_driverbackendgroup{I3C Target Device,i3c_target_device}
+ * @{
+ */
+
+/**
+ * @brief Instruct the I3C target device driver to register itself with its bus controller.
+ */
+typedef int (*i3c_target_api_driver_register_t)(const struct device *dev);
+
+/**
+ * @brief Instruct the I3C target device driver to unregister itself from its bus controller.
+ */
+typedef int (*i3c_target_api_driver_unregister_t)(const struct device *dev);
+
+/**
+ * @driver_ops{I3C Target Device}
+ */
 __subsystem struct i3c_target_driver_api {
-	int (*driver_register)(const struct device *dev);
-	int (*driver_unregister)(const struct device *dev);
+	/**
+	 * @driver_ops_mandatory Instruct the I3C target device driver to register itself with
+	 * its bus controller.
+	 */
+	i3c_target_api_driver_register_t driver_register;
+	/**
+	 * @driver_ops_mandatory Instruct the I3C target device driver to unregister itself from
+	 * its bus controller.
+	 */
+	i3c_target_api_driver_unregister_t driver_unregister;
 };
+
+/** @} */
 
 /**
  * @brief Accept or Decline Controller Handoffs


### PR DESCRIPTION
Introduce documented typedefs for the I3C target device driver
operations, group the backend definitions in a dedicated backend API
group and document the driver API structure with the driver_ops
Doxygen commands, tagging each operation as mandatory.

https://builds.zephyrproject.io/zephyr/pr/113895/docs/doxygen/html/structi3c__target__driver__api.html
