### PR TITLE
drivers: espi: saf: adopt driver_ops Doxygen convention

### DIFF
--- a/include/zephyr/drivers/espi_saf.h
+++ b/include/zephyr/drivers/espi_saf.h
@@ -122,51 +122,94 @@ struct espi_saf_packet {
  */
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * eSPI driver API definition and system call entry points
- *
- * (Internal use only.)
+ * @def_driverbackendgroup{eSPI SAF,espi_saf_interface}
+ * @{
+ */
+
+/**
+ * @brief Callback API to configure the eSPI SAF controller.
+ * See espi_saf_config() for argument description.
  */
 typedef int (*espi_saf_api_config)(const struct device *dev,
 				   const struct espi_saf_cfg *cfg);
 
+/**
+ * @brief Callback API to set one or more SAF protection regions.
+ * See espi_saf_set_protection_regions() for argument description.
+ */
 typedef int (*espi_saf_api_set_protection_regions)(
 				const struct device *dev,
 				const struct espi_saf_protection *pr);
 
+/**
+ * @brief Callback API to activate the SAF block.
+ * See espi_saf_activate() for argument description.
+ */
 typedef int (*espi_saf_api_activate)(const struct device *dev);
 
+/**
+ * @brief Callback API to query if SAF is ready.
+ * See espi_saf_get_channel_status() for argument description.
+ */
 typedef bool (*espi_saf_api_get_channel_status)(const struct device *dev);
 
+/**
+ * @brief Callback API to send a read request for slave attached flash.
+ * See espi_saf_flash_read() for argument description.
+ */
 typedef int (*espi_saf_api_flash_read)(const struct device *dev,
 				       struct espi_saf_packet *pckt);
+/**
+ * @brief Callback API to send a write request for slave attached flash.
+ * See espi_saf_flash_write() for argument description.
+ */
 typedef int (*espi_saf_api_flash_write)(const struct device *dev,
 					struct espi_saf_packet *pckt);
+/**
+ * @brief Callback API to send an erase request for slave attached flash.
+ * See espi_saf_flash_erase() for argument description.
+ */
 typedef int (*espi_saf_api_flash_erase)(const struct device *dev,
 					struct espi_saf_packet *pckt);
+/**
+ * @brief Callback API to respond unsuccessful completion for slave attached flash.
+ * See espi_saf_flash_unsuccess() for argument description.
+ */
 typedef int (*espi_saf_api_flash_unsuccess)(const struct device *dev,
 					struct espi_saf_packet *pckt);
-/* Callbacks and traffic intercept */
+/**
+ * @brief Callback API to manage (add or remove) application callbacks.
+ * See espi_saf_add_callback() and espi_saf_remove_callback() for argument description.
+ */
 typedef int (*espi_saf_api_manage_callback)(const struct device *dev,
 					    struct espi_callback *callback,
 					    bool set);
 
+/**
+ * @driver_ops{eSPI SAF}
+ */
 __subsystem struct espi_saf_driver_api {
+	/** @driver_ops_mandatory @copybrief espi_saf_config */
 	espi_saf_api_config config;
+	/** @driver_ops_mandatory @copybrief espi_saf_set_protection_regions */
 	espi_saf_api_set_protection_regions set_protection_regions;
+	/** @driver_ops_mandatory @copybrief espi_saf_activate */
 	espi_saf_api_activate activate;
+	/** @driver_ops_mandatory @copybrief espi_saf_get_channel_status */
 	espi_saf_api_get_channel_status get_channel_status;
+	/** @driver_ops_optional @copybrief espi_saf_flash_read */
 	espi_saf_api_flash_read flash_read;
+	/** @driver_ops_optional @copybrief espi_saf_flash_write */
 	espi_saf_api_flash_write flash_write;
+	/** @driver_ops_optional @copybrief espi_saf_flash_erase */
 	espi_saf_api_flash_erase flash_erase;
+	/** @driver_ops_optional @copybrief espi_saf_flash_unsuccess */
 	espi_saf_api_flash_unsuccess flash_unsuccess;
+	/** @driver_ops_optional Manage (add or remove) application callbacks. */
 	espi_saf_api_manage_callback manage_callback;
 };
 
-/**
- * @endcond
- */
+/** @} */
 
 /**
  * @brief Configure operation of a eSPI controller.

--- a/include/zephyr/drivers/espi_saf.h
+++ b/include/zephyr/drivers/espi_saf.h
@@ -122,54 +122,97 @@ struct espi_saf_packet {
  */
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * eSPI driver API definition and system call entry points
- *
- * (Internal use only.)
+ * @def_driverbackendgroup{eSPI SAF,espi_saf_interface}
+ * @{
+ */
+
+/**
+ * @brief Callback API to configure the eSPI SAF controller.
+ * See espi_saf_config() for argument description.
  */
 typedef int (*espi_saf_api_config)(const struct device *dev,
 				   const struct espi_saf_cfg *cfg);
 
+/**
+ * @brief Callback API to set one or more SAF protection regions.
+ * See espi_saf_set_protection_regions() for argument description.
+ */
 typedef int (*espi_saf_api_set_protection_regions)(
 				const struct device *dev,
 				const struct espi_saf_protection *pr);
 
+/**
+ * @brief Callback API to activate the SAF block.
+ * See espi_saf_activate() for argument description.
+ */
 typedef int (*espi_saf_api_activate)(const struct device *dev);
 
+/**
+ * @brief Callback API to query if SAF is ready.
+ * See espi_saf_get_channel_status() for argument description.
+ */
 typedef bool (*espi_saf_api_get_channel_status)(const struct device *dev);
 
+/**
+ * @brief Callback API to send a read request for slave attached flash.
+ * See espi_saf_flash_read() for argument description.
+ */
 typedef int (*espi_saf_api_flash_read)(const struct device *dev,
 				       struct espi_saf_packet *pckt);
+/**
+ * @brief Callback API to send a write request for slave attached flash.
+ * See espi_saf_flash_write() for argument description.
+ */
 typedef int (*espi_saf_api_flash_write)(const struct device *dev,
 					struct espi_saf_packet *pckt);
+/**
+ * @brief Callback API to send an erase request for slave attached flash.
+ * See espi_saf_flash_erase() for argument description.
+ */
 typedef int (*espi_saf_api_flash_erase)(const struct device *dev,
 					struct espi_saf_packet *pckt);
+/**
+ * @brief Callback API to respond unsuccessful completion for slave attached flash.
+ * See espi_saf_flash_unsuccess() for argument description.
+ */
 typedef int (*espi_saf_api_flash_unsuccess)(const struct device *dev,
 					struct espi_saf_packet *pckt);
-/* Callbacks and traffic intercept */
+/**
+ * @brief Callback API to manage (add or remove) application callbacks.
+ * See espi_saf_add_callback() and espi_saf_remove_callback() for argument description.
+ */
 typedef int (*espi_saf_api_manage_callback)(const struct device *dev,
 					    struct espi_callback *callback,
 					    bool set);
 
+/**
+ * @driver_ops{eSPI SAF}
+ */
 __subsystem struct espi_saf_driver_api {
+	/** @driver_ops_mandatory @copybrief espi_saf_config */
 	espi_saf_api_config config;
+	/** @driver_ops_mandatory @copybrief espi_saf_set_protection_regions */
 	espi_saf_api_set_protection_regions set_protection_regions;
+	/** @driver_ops_mandatory @copybrief espi_saf_activate */
 	espi_saf_api_activate activate;
+	/** @driver_ops_mandatory @copybrief espi_saf_get_channel_status */
 	espi_saf_api_get_channel_status get_channel_status;
+	/** @driver_ops_optional @copybrief espi_saf_flash_read */
 	espi_saf_api_flash_read flash_read;
+	/** @driver_ops_optional @copybrief espi_saf_flash_write */
 	espi_saf_api_flash_write flash_write;
+	/** @driver_ops_optional @copybrief espi_saf_flash_erase */
 	espi_saf_api_flash_erase flash_erase;
+	/** @driver_ops_optional @copybrief espi_saf_flash_unsuccess */
 	espi_saf_api_flash_unsuccess flash_unsuccess;
+	/** @driver_ops_optional Manage (add or remove) application callbacks. */
 	espi_saf_api_manage_callback manage_callback;
 };
 
-/**
- * @endcond
- */
+/** @} */
 
 /**
- * @brief Configure operation of a eSPI controller.
+ * @brief Configure operation of an eSPI controller.
  *
  * This routine provides a generic interface to override eSPI controller
  * capabilities.


### PR DESCRIPTION
Group the eSPI SAF driver backend definitions in a dedicated backend
API group and document the driver API structure with the driver_ops
Doxygen commands, tagging each operation as mandatory or optional.

https://builds.zephyrproject.io/zephyr/pr/113897/docs/doxygen/html/structespi__saf__driver__api.html
