### PR TITLE
doc: gh_utils: replace per-page git invocations with a cached lookup

### DIFF
--- a/doc/_extensions/zephyr/gh_utils.py
+++ b/doc/_extensions/zephyr/gh_utils.py
@@ -38,7 +38,7 @@ import re
 import subprocess
 import sys
 from datetime import datetime
-from functools import partial
+from functools import cache, lru_cache, partial
 from pathlib import Path
 from typing import Final
 from urllib.parse import urlencode
@@ -182,14 +182,42 @@ def git_info_filter(app: Sphinx, pagename) -> tuple[str, str] | None:
     )
 
     # Check if the file is tracked by git
-    try:
-        subprocess.check_output(
-            ["git", "ls-files", "--error-unmatch", orig_path],
-            stderr=subprocess.STDOUT,
-        )
-    except subprocess.CalledProcessError:
+    rel_path = Path(orig_path).relative_to(ZEPHYR_BASE).as_posix()
+    if rel_path not in git_tracked_files():
         return None
 
+    timestamp_and_sha1 = git_last_commit(orig_path)
+    if timestamp_and_sha1 is None:
+        return None
+
+    timestamp, sha1 = timestamp_and_sha1
+    date = str(timestamp)
+    date_object = datetime.fromtimestamp(timestamp)
+    last_update_fmt = app.config.html_last_updated_fmt
+    if last_update_fmt is not None:
+        date = format_date(last_update_fmt, date=date_object, language=app.config.language)
+
+    return (date, sha1)
+
+
+@lru_cache(maxsize=1)
+def git_tracked_files() -> frozenset[str]:
+    """Return the set of git-tracked files in the repository (cached)."""
+    try:
+        output = subprocess.check_output(
+            ["git", "ls-files", "-z"],
+            stderr=subprocess.STDOUT,
+            cwd=ZEPHYR_BASE,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return frozenset()
+
+    return frozenset(f for f in output.decode("utf-8").split("\0") if f)
+
+
+@cache
+def git_last_commit(orig_path: str) -> tuple[int, str] | None:
+    """Return the Unix timestamp and SHA1 of the last commit touching a file (cached)."""
     try:
         date_and_sha1 = (
             subprocess.check_output(
@@ -202,26 +230,29 @@ def git_info_filter(app: Sphinx, pagename) -> tuple[str, str] | None:
                     orig_path,
                 ],
                 stderr=subprocess.STDOUT,
+                cwd=ZEPHYR_BASE,
             )
             .decode("utf-8")
             .strip()
         )
-        if not date_and_sha1:  # added but not committed
-            return None
-        date, sha1 = date_and_sha1.split(" ", 1)
-        date_object = datetime.fromtimestamp(int(date))
-        last_update_fmt = app.config.html_last_updated_fmt
-        if last_update_fmt is not None:
-            date = format_date(last_update_fmt, date=date_object, language=app.config.language)
-
-        return (date, sha1)
     except subprocess.CalledProcessError:
         return None
+
+    if not date_and_sha1:  # added but not committed
+        return None
+
+    date, sha1 = date_and_sha1.split(" ", 1)
+    return (int(date), sha1)
 
 
 def add_jinja_filter(app: Sphinx):
     if app.builder.format != "html":
         return
+
+    # Prime the tracked-files cache in the main process so that parallel write
+    # workers (forked on POSIX platforms) inherit it instead of each running
+    # their own "git ls-files".
+    git_tracked_files()
 
     app.builder.templates.environment.filters["gh_link_get_blob_url"] = partial(
         gh_link_get_url, app, mode="blob"


### PR DESCRIPTION
The `git_info` Jinja filter ran two git subprocesses for every HTML page written: `git ls-files --error-unmatch <page>` to check that the page is tracked, and `git log -1 -- <page>` for its last commit. Over the thousands of pages of a documentation build this adds up to a significant amount of time.

Run `git ls-files` once, cache the resulting set of tracked files (primed in the main process so that forked parallel write workers inherit it), and cache the per-file `git log` lookups so repeated renders of the same page don't shell out again.