### PR TITLE
boards: arduino: nano33 ble rev2: fix settings for BMI270/BMM150

### DIFF
--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense_rev2.overlay
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_nrf52840_sense_rev2.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
 / {
 	aliases {
 		accel0 = &bmi270;
@@ -15,6 +17,8 @@
 /delete-node/ &hts221;
 
 &i2c1 {
+	clock-frequency = <I2C_BITRATE_FAST>;
+
 	bmi270: bmi270@68 {
 		compatible = "bosch,bmi270";
 		reg = <0x68>;
@@ -29,4 +33,8 @@
 		compatible = "renesas,hs300x";
 		reg = <0x44>;
 	};
+};
+
+&vdd_env {
+	enable-gpios = <&gpio0 22 (GPIO_ACTIVE_HIGH | NRF_GPIO_DRIVE_H0H1)>;
 };

--- a/boards/arduino/nano_33_ble/arduino_nano_33_ble_rev2.overlay
+++ b/boards/arduino/nano_33_ble/arduino_nano_33_ble_rev2.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
+
 / {
 	aliases {
 		accel0 = &bmi270;
@@ -14,6 +16,8 @@
 /delete-node/ &lsm9ds1_mag;
 
 &i2c1 {
+	clock-frequency = <I2C_BITRATE_FAST>;
+
 	bmi270: bmi270@68 {
 		compatible = "bosch,bmi270";
 		reg = <0x68>;
@@ -23,4 +27,8 @@
 		compatible = "bosch,bmm150";
 		reg = <0x10>;
 	};
+};
+
+&vdd_env {
+	enable-gpios = <&gpio0 22 (GPIO_ACTIVE_HIGH | NRF_GPIO_DRIVE_H0H1)>;
 };


### PR DESCRIPTION
The IMU/magnometer sensor do not work reliability on the arduino nano33 rev2 (ble/sense).

Use the following settings to ensure a proper function:
- Enable I2C fast mode (400 kHz), which is required when using the TWIM driver with the BMI270.
- Set high drive mode for vdd_env to ensure line stability when the BMM150 performs a full Power-On Reset (POR) during chip initialization.

These settings align with those found in ArduinoCore-zephyr.

Fixes: #112554 