### PR TITLE
stepper: adi_tmc: Separate regs into headers by series

### DIFF
--- a/drivers/stepper/adi_tmc/common/include/adi_tmc_reg.h
+++ b/drivers/stepper/adi_tmc/common/include/adi_tmc_reg.h
@@ -1,8 +1,12 @@
 /**
  * @file drivers/stepper/adi_tmc/adi_tmc_reg.h
  *
- * @brief TMC Registers
+ * @brief Common TMC5xxx register definitions and field masks
  *
+ * @details This header holds only the register fields and constants that are
+ * identical across the ADI Trinamic 5-series parts (TMC50xx, TMC51xx, etc.).
+ * The part-specific register address maps live in each driver's own
+ * `tmcXXxx_reg.h` header (e.g. `tmc50xx/tmc50xx_reg.h`).
  */
 
 /*
@@ -17,9 +21,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/** Common Registers for TMC50XX and TMC51XX */
-#if defined(CONFIG_STEPPER_ADI_TMC50XX) || defined(CONFIG_STEPPER_ADI_TMC51XX)
 
 #define TMC5XXX_WRITE_BIT        0x80U
 #define TMC5XXX_ADDRESS_MASK     0x7FU
@@ -88,108 +89,6 @@ extern "C" {
 #define TMC5XXX_DRV_STATUS_SG_RESULT_MASK  GENMASK(9, 0)
 #define TMC5XXX_DRV_STATUS_SG_STATUS_MASK  BIT(24)
 #define TMC5XXX_DRV_STATUS_SG_STATUS_SHIFT 24
-
-#define TMC50XX_MOTOR_ADDR(m)     (0x20 << (m))
-#define TMC50XX_MOTOR_ADDR_DRV(m) ((m) << 4)
-
-#define TMC50XX_RAMPMODE(motor)   (0x00 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_XACTUAL(motor)    (0x01 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_VACTUAL(motor)    (0x02 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_VSTART(motor)     (0x03 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_A1(motor)         (0x04 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_V1(motor)         (0x05 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_AMAX(motor)       (0x06 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_VMAX(motor)       (0x07 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_DMAX(motor)       (0x08 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_D1(motor)         (0x0A | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_VSTOP(motor)      (0x0B | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_TZEROWAIT(motor)  (0x0C | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_XTARGET(motor)    (0x0D | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_SWMODE(motor)     (0x14 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_RAMPSTAT(motor)   (0x15 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_CHOPCONF(motor)   (0x6C | TMC50XX_MOTOR_ADDR_DRV(motor))
-#define TMC50XX_COOLCONF(motor)   (0x6D | TMC50XX_MOTOR_ADDR_DRV(motor))
-#define TMC50XX_DRVSTATUS(motor)  (0x6F | TMC50XX_MOTOR_ADDR_DRV(motor))
-
-#endif
-
-#ifdef CONFIG_STEPPER_ADI_TMC50XX
-
-#define TMC50XX_MOTOR_ADDR_PWM(m) ((m) << 3)
-
-/**
- * @name TMC50XX module registers
- * @anchor TMC50XX_REGISTERS
- *
- * @{
- */
-
-#define TMC50XX_GCONF_POSCMP_ENABLE_SHIFT 3
-#define TMC50XX_GCONF_TEST_MODE_SHIFT     7
-#define TMC50XX_GCONF_SHAFT_SHIFT(n)      ((n) ? 8 : 9)
-#define TMC50XX_LOCK_GCONF_SHIFT          10
-
-#define TMC50XX_PWMCONF(motor)    (0x10 | TMC50XX_MOTOR_ADDR_PWM(motor))
-#define TMC50XX_PWM_STATUS(motor) (0x11 | TMC50XX_MOTOR_ADDR_PWM(motor))
-
-#define TMC50XX_IHOLD_IRUN(motor) (0x10 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_VCOOLTHRS(motor)  (0x11 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_VHIGH(motor)      (0x12 | TMC50XX_MOTOR_ADDR(motor))
-#define TMC50XX_XLATCH(motor)     (0x16 | TMC50XX_MOTOR_ADDR(motor))
-
-#define TMC50XX_MSLUT0(motor)     (0x60 | TMC50XX_MOTOR_ADDR_DRV(motor))
-#define TMC50XX_MSLUT1(motor)     (0x61 | TMC50XX_MOTOR_ADDR_DRV(motor))
-#define TMC50XX_MSLUT2(motor)     (0x62 | TMC50XX_MOTOR_ADDR_DRV(motor))
-#define TMC50XX_MSLUT3(motor)     (0x63 | TMC50XX_MOTOR_ADDR_DRV(motor))
-#define TMC50XX_MSLUT4(motor)     (0x64 | TMC50XX_MOTOR_ADDR_DRV(motor))
-#define TMC50XX_MSLUT5(motor)     (0x65 | TMC50XX_MOTOR_ADDR_DRV(motor))
-#define TMC50XX_MSLUT6(motor)     (0x66 | TMC50XX_MOTOR_ADDR_DRV(motor))
-#define TMC50XX_MSLUT7(motor)     (0x67 | TMC50XX_MOTOR_ADDR_DRV(motor))
-#define TMC50XX_MSLUTSEL(motor)   (0x68 | TMC50XX_MOTOR_ADDR_DRV(motor))
-#define TMC50XX_MSLUTSTART(motor) (0x69 | TMC50XX_MOTOR_ADDR_DRV(motor))
-#define TMC50XX_MSCNT(motor)      (0x6A | TMC50XX_MOTOR_ADDR_DRV(motor))
-#define TMC50XX_MSCURACT(motor)   (0x6B | TMC50XX_MOTOR_ADDR_DRV(motor))
-
-#endif /* CONFIG_STEPPER_ADI_TMC50XX */
-
-#ifdef CONFIG_STEPPER_ADI_TMC51XX
-
-#define TMC51XX_GCONF_EN_PWM_MODE_SHIFT        2
-#define TMC51XX_GCONF_SHAFT_SHIFT              4
-#define TMC51XX_GCONF_DIAG0_INT_PUSHPULL_SHIFT 12
-#define TMC51XX_GCONF_TEST_MODE_SHIFT          17
-
-#define TMC51XX_IHOLD_IRUN	0x10
-#define TMC51XX_TPOWER_DOWN	0x11
-#define TMC51XX_TSTEP		0x12
-#define TMC51XX_TPWMTHRS	0x13
-#define TMC51XX_TCOOLTHRS	0x14
-#define TMC51XX_THIGH		0x15
-
-#define TMC51XX_RAMPMODE	TMC50XX_RAMPMODE(0)
-#define TMC51XX_XACTUAL		TMC50XX_XACTUAL(0)
-#define TMC51XX_VACTUAL		TMC50XX_VACTUAL(0)
-#define TMC51XX_VSTART		TMC50XX_VSTART(0)
-#define TMC51XX_A1		TMC50XX_A1(0)
-#define TMC51XX_V1		TMC50XX_V1(0)
-#define TMC51XX_AMAX		TMC50XX_AMAX(0)
-#define TMC51XX_VMAX		TMC50XX_VMAX(0)
-#define TMC51XX_DMAX		TMC50XX_DMAX(0)
-#define TMC51XX_D1		TMC50XX_D1(0)
-#define TMC51XX_VSTOP		TMC50XX_VSTOP(0)
-#define TMC51XX_TZEROWAIT	TMC50XX_TZEROWAIT(0)
-#define TMC51XX_XTARGET		TMC50XX_XTARGET(0)
-#define TMC51XX_SWMODE		TMC50XX_SWMODE(0)
-#define TMC51XX_RAMPSTAT	TMC50XX_RAMPSTAT(0)
-#define TMC51XX_CHOPCONF	TMC50XX_CHOPCONF(0)
-#define TMC51XX_COOLCONF	TMC50XX_COOLCONF(0)
-#define TMC51XX_DRVSTATUS	TMC50XX_DRVSTATUS(0)
-
-#endif /* CONFIG_STEPPER_ADI_TMC51XX */
-
-/**
- * @}
- */
 
 #ifdef __cplusplus
 }

--- a/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
+++ b/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
@@ -15,6 +15,7 @@
 #include <adi_tmc_spi.h>
 #include "tmc50xx.h"
 #include <adi_tmc5xxx_common.h>
+#include "tmc50xx_reg.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(tmc50xx, CONFIG_STEPPER_LOG_LEVEL);

--- a/drivers/stepper/adi_tmc/tmc50xx/tmc50xx_reg.h
+++ b/drivers/stepper/adi_tmc/tmc50xx/tmc50xx_reg.h
@@ -1,0 +1,88 @@
+/**
+ * @file drivers/stepper/adi_tmc/tmc50xx/tmc50xx_reg.h
+ *
+ * @brief TMC50XX Registers
+ *
+ */
+
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Carl Zeiss Meditec AG
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Prevas A/S
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_STEPPER_ADI_TMC_TMC50XX_TMC50XX_REG_H_
+#define ZEPHYR_DRIVERS_STEPPER_ADI_TMC_TMC50XX_TMC50XX_REG_H_
+
+#include <adi_tmc_reg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name TMC50XX module registers
+ * @anchor TMC50XX_REGISTERS
+ *
+ * @{
+ */
+
+#define TMC50XX_MOTOR_ADDR(m)     (0x20 << (m))
+#define TMC50XX_MOTOR_ADDR_DRV(m) ((m) << 4)
+
+#define TMC50XX_RAMPMODE(motor)   (0x00 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_XACTUAL(motor)    (0x01 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_VACTUAL(motor)    (0x02 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_VSTART(motor)     (0x03 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_A1(motor)         (0x04 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_V1(motor)         (0x05 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_AMAX(motor)       (0x06 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_VMAX(motor)       (0x07 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_DMAX(motor)       (0x08 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_D1(motor)         (0x0A | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_VSTOP(motor)      (0x0B | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_TZEROWAIT(motor)  (0x0C | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_XTARGET(motor)    (0x0D | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_SWMODE(motor)     (0x14 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_RAMPSTAT(motor)   (0x15 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_CHOPCONF(motor)   (0x6C | TMC50XX_MOTOR_ADDR_DRV(motor))
+#define TMC50XX_COOLCONF(motor)   (0x6D | TMC50XX_MOTOR_ADDR_DRV(motor))
+#define TMC50XX_DRVSTATUS(motor)  (0x6F | TMC50XX_MOTOR_ADDR_DRV(motor))
+
+#define TMC50XX_MOTOR_ADDR_PWM(m) ((m) << 3)
+
+#define TMC50XX_GCONF_POSCMP_ENABLE_SHIFT 3
+#define TMC50XX_GCONF_TEST_MODE_SHIFT     7
+#define TMC50XX_GCONF_SHAFT_SHIFT(n)      ((n) ? 8 : 9)
+#define TMC50XX_LOCK_GCONF_SHIFT          10
+
+#define TMC50XX_PWMCONF(motor)    (0x10 | TMC50XX_MOTOR_ADDR_PWM(motor))
+#define TMC50XX_PWM_STATUS(motor) (0x11 | TMC50XX_MOTOR_ADDR_PWM(motor))
+
+#define TMC50XX_IHOLD_IRUN(motor) (0x10 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_VCOOLTHRS(motor)  (0x11 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_VHIGH(motor)      (0x12 | TMC50XX_MOTOR_ADDR(motor))
+#define TMC50XX_XLATCH(motor)     (0x16 | TMC50XX_MOTOR_ADDR(motor))
+
+#define TMC50XX_MSLUT0(motor)     (0x60 | TMC50XX_MOTOR_ADDR_DRV(motor))
+#define TMC50XX_MSLUT1(motor)     (0x61 | TMC50XX_MOTOR_ADDR_DRV(motor))
+#define TMC50XX_MSLUT2(motor)     (0x62 | TMC50XX_MOTOR_ADDR_DRV(motor))
+#define TMC50XX_MSLUT3(motor)     (0x63 | TMC50XX_MOTOR_ADDR_DRV(motor))
+#define TMC50XX_MSLUT4(motor)     (0x64 | TMC50XX_MOTOR_ADDR_DRV(motor))
+#define TMC50XX_MSLUT5(motor)     (0x65 | TMC50XX_MOTOR_ADDR_DRV(motor))
+#define TMC50XX_MSLUT6(motor)     (0x66 | TMC50XX_MOTOR_ADDR_DRV(motor))
+#define TMC50XX_MSLUT7(motor)     (0x67 | TMC50XX_MOTOR_ADDR_DRV(motor))
+#define TMC50XX_MSLUTSEL(motor)   (0x68 | TMC50XX_MOTOR_ADDR_DRV(motor))
+#define TMC50XX_MSLUTSTART(motor) (0x69 | TMC50XX_MOTOR_ADDR_DRV(motor))
+#define TMC50XX_MSCNT(motor)      (0x6A | TMC50XX_MOTOR_ADDR_DRV(motor))
+#define TMC50XX_MSCURACT(motor)   (0x6B | TMC50XX_MOTOR_ADDR_DRV(motor))
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_DRIVERS_STEPPER_ADI_TMC_TMC50XX_TMC50XX_REG_H_ */

--- a/drivers/stepper/adi_tmc/tmc50xx/tmc50xx_stepper_ctrl.c
+++ b/drivers/stepper/adi_tmc/tmc50xx/tmc50xx_stepper_ctrl.c
@@ -11,6 +11,7 @@
 
 #include "tmc50xx.h"
 #include <adi_tmc5xxx_common.h>
+#include "tmc50xx_reg.h"
 
 #include <zephyr/drivers/stepper/stepper_ctrl.h>
 #include <zephyr/drivers/stepper/stepper_trinamic.h>

--- a/drivers/stepper/adi_tmc/tmc50xx/tmc50xx_stepper_driver.c
+++ b/drivers/stepper/adi_tmc/tmc50xx/tmc50xx_stepper_driver.c
@@ -8,6 +8,7 @@
 
 #include "tmc50xx.h"
 #include <adi_tmc5xxx_common.h>
+#include "tmc50xx_reg.h"
 
 #include <zephyr/drivers/stepper/stepper.h>
 

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
@@ -18,6 +18,7 @@
 #include <adi_tmc5xxx_common.h>
 
 #include "tmc51xx.h"
+#include "tmc51xx_reg.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(tmc51xx, CONFIG_STEPPER_LOG_LEVEL);

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx_reg.h
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx_reg.h
@@ -1,0 +1,69 @@
+/**
+ * @file drivers/stepper/adi_tmc/tmc51xx/tmc51xx_reg.h
+ *
+ * @brief TMC51XX Registers
+ *
+ */
+
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Carl Zeiss Meditec AG
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Prevas A/S
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_STEPPER_ADI_TMC_TMC51XX_TMC51XX_REG_H_
+#define ZEPHYR_DRIVERS_STEPPER_ADI_TMC_TMC51XX_TMC51XX_REG_H_
+
+#include <adi_tmc_reg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name TMC51XX module registers
+ * @anchor TMC51XX_REGISTERS
+ *
+ * @{
+ */
+
+#define TMC51XX_GCONF_EN_PWM_MODE_SHIFT        2
+#define TMC51XX_GCONF_SHAFT_SHIFT              4
+#define TMC51XX_GCONF_DIAG0_INT_PUSHPULL_SHIFT 12
+#define TMC51XX_GCONF_TEST_MODE_SHIFT          17
+
+#define TMC51XX_IHOLD_IRUN	0x10
+#define TMC51XX_TPOWER_DOWN	0x11
+#define TMC51XX_TSTEP		0x12
+#define TMC51XX_TPWMTHRS	0x13
+#define TMC51XX_TCOOLTHRS	0x14
+#define TMC51XX_THIGH		0x15
+
+#define TMC51XX_RAMPMODE	0x20
+#define TMC51XX_XACTUAL		0x21
+#define TMC51XX_VACTUAL		0x22
+#define TMC51XX_VSTART		0x23
+#define TMC51XX_A1		0x24
+#define TMC51XX_V1		0x25
+#define TMC51XX_AMAX		0x26
+#define TMC51XX_VMAX		0x27
+#define TMC51XX_DMAX		0x28
+#define TMC51XX_D1		0x2A
+#define TMC51XX_VSTOP		0x2B
+#define TMC51XX_TZEROWAIT	0x2C
+#define TMC51XX_XTARGET		0x2D
+#define TMC51XX_SWMODE		0x34
+#define TMC51XX_RAMPSTAT	0x35
+#define TMC51XX_CHOPCONF	0x6C
+#define TMC51XX_COOLCONF	0x6D
+#define TMC51XX_DRVSTATUS	0x6F
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_DRIVERS_STEPPER_ADI_TMC_TMC51XX_TMC51XX_REG_H_ */

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx_stepper_ctrl.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx_stepper_ctrl.c
@@ -9,6 +9,7 @@
 
 #include <zephyr/drivers/stepper/stepper_ctrl.h>
 #include "tmc51xx.h"
+#include "tmc51xx_reg.h"
 #include <adi_tmc5xxx_common.h>
 
 #include <zephyr/logging/log.h>

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx_stepper_driver.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx_stepper_driver.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/stepper/stepper.h>
 #include <zephyr/drivers/gpio.h>
 #include "tmc51xx.h"
+#include "tmc51xx_reg.h"
 #include <adi_tmc5xxx_common.h>
 
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
This PR separates the stepper `adi_tmc` registers into separate headers by series. It removes any dependencies between series in the register definitions. See https://github.com/zephyrproject-rtos/zephyr/issues/105388#issuecomment-4049191809.

This is the first step to adding the TMC 52XX series.

Assisted-by: Claude:claude-opus-4.8