### PR TITLE
modem: cellular: remove `struct modem_cellular_data` from `.data` section

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1023,6 +1023,12 @@ Ethernet
   ``pkt->timestamp`` must be updated or their RX timestamps will not be passed to
   socket applications. (:github:`110582`)
 
+Modem
+=====
+
+* Cellular modem chat delimiters and filters are now specified in
+  :c:struct:`modem_cellular_vendor_config`, not :c:struct:`modem_cellular_data`.
+
 PTP
 ===
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1028,6 +1028,8 @@ Modem
 
 * Cellular modem chat delimiters and filters are now specified in
   :c:struct:`modem_cellular_vendor_config`, not :c:struct:`modem_cellular_data`.
+* Cellular modem instance PPP pointer is now automatically populated in
+  :c:struct:`modem_cellular_config`. Assignment to :c:struct:`modem_cellular_data` must be removed.
 
 PTP
 ===

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -755,7 +755,7 @@ static int modem_cellular_on_idle_state_enter(struct modem_cellular_data *data)
 	modem_cellular_clear_registration_status(data);
 	modem_cellular_notify_user_pipes_disconnected(data);
 	modem_chat_release(&data->chat);
-	modem_ppp_release(data->ppp);
+	modem_ppp_release(config->ppp);
 	modem_cmux_release(&data->cmux);
 	modem_pipe_close_async(data->uart_pipe);
 	k_sem_give(&data->suspended_sem);
@@ -1162,7 +1162,7 @@ static void modem_cellular_run_init_script_event_handler(struct modem_cellular_d
 		link_addr_len = MIN(NET_LINK_ADDR_MAX_LENGTH, imei_len);
 		link_addr_ptr = data->imei + (imei_len - link_addr_len);
 
-		err = net_if_set_link_addr(modem_ppp_get_iface(data->ppp), link_addr_ptr,
+		err = net_if_set_link_addr(modem_ppp_get_iface(config->ppp), link_addr_ptr,
 					   link_addr_len, NET_LINK_UNKNOWN);
 		if (err) {
 			LOG_WRN("Failed to set link address on PPP interface (%d)", err);
@@ -1515,9 +1515,9 @@ static void modem_cellular_run_dial_script_event_handler(struct modem_cellular_d
 		modem_chat_attach(&data->chat, data->dlci1_pipe);
 
 		/* PHY is now up and searching for network */
-		net_if_carrier_on(modem_ppp_get_iface(data->ppp));
+		net_if_carrier_on(modem_ppp_get_iface(config->ppp));
 
-		if (modem_ppp_attach(data->ppp, data->dlci2_pipe) < 0) {
+		if (modem_ppp_attach(config->ppp, data->dlci2_pipe) < 0) {
 			LOG_ERR("Failed to attach PPP to DLCI2");
 			modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_SUSPEND);
 			break;
@@ -1618,7 +1618,7 @@ static void modem_cellular_await_registered_event_handler(struct modem_cellular_
 		break;
 
 	case MODEM_CELLULAR_EVENT_SUSPEND:
-		net_if_carrier_off(modem_ppp_get_iface(data->ppp));
+		net_if_carrier_off(modem_ppp_get_iface(config->ppp));
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_INIT_POWER_OFF);
 		break;
 	case MODEM_CELLULAR_EVENT_RING:
@@ -1638,7 +1638,9 @@ static int modem_cellular_on_await_registered_state_leave(struct modem_cellular_
 
 static int modem_cellular_on_registered_state_enter(struct modem_cellular_data *data)
 {
-	net_if_dormant_off(modem_ppp_get_iface(data->ppp));
+	const struct modem_cellular_config *config = data->dev->config;
+
+	net_if_dormant_off(modem_ppp_get_iface(config->ppp));
 	modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
 	return 0;
 }
@@ -1660,7 +1662,7 @@ static void modem_cellular_registered_event_handler(struct modem_cellular_data *
 	case MODEM_CELLULAR_EVENT_SCRIPT_FAILED:
 		modem_cellular_script_failed(data);
 		if (modem_cellular_is_script_retry_exceeded(data)) {
-			net_if_carrier_off(modem_ppp_get_iface(data->ppp));
+			net_if_carrier_off(modem_ppp_get_iface(config->ppp));
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_IDLE);
 			modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_RESUME);
 			LOG_WRN("Maximum script failures reached, restarting modem");
@@ -1699,16 +1701,16 @@ static void modem_cellular_registered_event_handler(struct modem_cellular_data *
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_AWAIT_PPP_DEAD);
 		break;
 	case MODEM_CELLULAR_EVENT_PPP_DEAD:
-		if (net_if_is_admin_up(modem_ppp_get_iface(data->ppp))) {
+		if (net_if_is_admin_up(modem_ppp_get_iface(config->ppp))) {
 			modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_AWAIT_PPP_DEAD);
 			modem_cellular_start_timer(data, MODEM_CELLULAR_PERIODIC_SCRIPT_TIMEOUT);
 		}
 		break;
 
 	case MODEM_CELLULAR_EVENT_SUSPEND:
-		net_if_carrier_off(modem_ppp_get_iface(data->ppp));
+		net_if_carrier_off(modem_ppp_get_iface(config->ppp));
 		modem_chat_release(&data->chat);
-		modem_ppp_release(data->ppp);
+		modem_ppp_release(config->ppp);
 		modem_cellular_enter_state(data, MODEM_CELLULAR_STATE_INIT_POWER_OFF);
 		break;
 	case MODEM_CELLULAR_EVENT_RING:
@@ -1729,7 +1731,9 @@ static int modem_cellular_on_registered_state_leave(struct modem_cellular_data *
 
 static int modem_cellular_on_await_ppp_dead_state_enter(struct modem_cellular_data *data)
 {
-	net_if_dormant_on(modem_ppp_get_iface(data->ppp));
+	const struct modem_cellular_config *config = data->dev->config;
+
+	net_if_dormant_on(modem_ppp_get_iface(config->ppp));
 	IF_ENABLED(CONFIG_MODEM_CELLULAR_STATS, (data->stats.link_drops += 1));
 
 	return 0;
@@ -1739,6 +1743,7 @@ static void modem_cellular_await_ppp_dead_event_handler(struct modem_cellular_da
 						 enum modem_cellular_event evt)
 {
 	const struct modem_cellular_config *config = data->dev->config;
+
 	switch (evt) {
 	case MODEM_CELLULAR_EVENT_RING:
 		LOG_DBG("RING received!");
@@ -1762,9 +1767,11 @@ static void modem_cellular_await_ppp_dead_event_handler(struct modem_cellular_da
 
 static int modem_cellular_on_await_ppp_dead_state_leave(struct modem_cellular_data *data)
 {
-	net_if_carrier_off(modem_ppp_get_iface(data->ppp));
+	const struct modem_cellular_config *config = data->dev->config;
+
+	net_if_carrier_off(modem_ppp_get_iface(config->ppp));
 	modem_chat_release(&data->chat);
-	modem_ppp_release(data->ppp);
+	modem_ppp_release(config->ppp);
 
 	return 0;
 }
@@ -1778,9 +1785,11 @@ static int modem_cellular_on_init_power_off_state_enter(struct modem_cellular_da
 
 static void modem_cellular_cmux_cleanup(struct modem_cellular_data *data)
 {
+	const struct modem_cellular_config *config = data->dev->config;
+
 	modem_cellular_notify_user_pipes_disconnected(data);
 	modem_chat_release(&data->chat);
-	modem_ppp_release(data->ppp);
+	modem_ppp_release(config->ppp);
 }
 
 static void modem_cellular_init_power_off_event_handler(struct modem_cellular_data *data,

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -2740,10 +2740,12 @@ int modem_cellular_init(const struct device *dev)
 			.user_data = data,
 			.receive_buf = data->chat_receive_buf,
 			.receive_buf_size = ARRAY_SIZE(data->chat_receive_buf),
-			.delimiter = data->chat_delimiter,
-			.delimiter_size = strlen(data->chat_delimiter),
-			.filter = data->chat_filter,
-			.filter_size = data->chat_filter ? strlen(data->chat_filter) : 0,
+			.delimiter = (const uint8_t *)config->vendor->chat_delimiter,
+			.delimiter_size = strlen(config->vendor->chat_delimiter),
+			.filter = (const uint8_t *)config->vendor->chat_filter,
+			.filter_size = config->vendor->chat_filter
+					       ? strlen(config->vendor->chat_filter)
+					       : 0,
 			.argv = data->chat_argv,
 			.argv_size = ARRAY_SIZE(data->chat_argv),
 			.unsol_matches = config->vendor->unsol_matches.matches,

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
@@ -86,9 +86,7 @@ static const struct modem_cellular_vendor_config nrf91_slm_vendor = {
 #define MODEM_CELLULAR_DEVICE_NORDIC_NRF91_SLM(inst)                                               \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 1500);     \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3))                            \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf91_slm.c
@@ -76,6 +76,7 @@ static const struct modem_cellular_vendor_config nrf91_slm_vendor = {
 		.size = ARRAY_SIZE(nordic_nrf91_slm_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r\n",
 	.power_pulse_duration_ms = 0,
 	.reset_pulse_duration_ms = 500,
 	.startup_time_ms = 5000,
@@ -86,7 +87,6 @@ static const struct modem_cellular_vendor_config nrf91_slm_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 1500);     \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r\n",                                                          \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
@@ -115,6 +115,7 @@ static const struct modem_cellular_vendor_config nrf93m1_vendor = {
 		.size = ARRAY_SIZE(nordic_nrf93m1_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r\n",
 	.power_pulse_duration_ms = 100,
 	.reset_pulse_duration_ms = 500,
 	/* In practice RDY event short circuits this timeout */
@@ -127,7 +128,6 @@ static const struct modem_cellular_vendor_config nrf93m1_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 1500);     \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r\n",                                                          \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
@@ -127,9 +127,7 @@ static const struct modem_cellular_vendor_config nrf93m1_vendor = {
 #define MODEM_CELLULAR_DEVICE_NORDIC_NRF93M1(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 1500);     \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
@@ -71,6 +71,8 @@ static const struct modem_cellular_vendor_config quectel_bg9x_vendor = {
 		.size = ARRAY_SIZE(quectel_bg9x_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 500,
 	.reset_pulse_duration_ms = 1000,
 	.startup_time_ms = 5000,
@@ -81,8 +83,6 @@ static const struct modem_cellular_vendor_config quectel_bg9x_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_bg9x.c
@@ -82,9 +82,7 @@ static const struct modem_cellular_vendor_config quectel_bg9x_vendor = {
 #define MODEM_CELLULAR_DEVICE_QUECTEL_BG9X(inst)                                                   \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg25_g.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg25_g.c
@@ -44,29 +44,34 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMEE=1", ok_match),
 	IF_ENABLED(DT_PROP(DT_BUS(DT_COMPAT_GET_ANY_STATUS_OKAY(quectel_eg25_g)), hw_flow_control),
 		   (MODEM_CHAT_SCRIPT_CMD_RESP("AT+IFC=2,2", ok_match),))
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG=1", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG=1", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG=1", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG?", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG?", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMI", cgmi_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMR", cgmr_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CIMI", cimi_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT+CMUX=0,0," QUECTEL_EG25_G_CMUX_PORT_SPEED
-					",127,10,3,30,10,2", 100));
+			MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG=1", ok_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG=1", ok_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG=1", ok_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG?", ok_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG?", ok_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMI", cgmi_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMR", cgmr_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("AT+CIMI", cimi_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
+		MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT+CMUX=0,0," QUECTEL_EG25_G_CMUX_PORT_SPEED
+						",127,10,3,30,10,2",
+						100));
 
 MODEM_CHAT_SCRIPT_DEFINE(quectel_eg25_g_init_chat_script, quectel_eg25_g_init_chat_script_cmds,
 			 abort_matches, modem_cellular_chat_callback_handler, 10);
 
 #if CONFIG_MODEM_CELLULAR_NEW_BAUDRATE != 115200
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
-	quectel_eg25_g_set_baudrate_chat_script_cmds,
-	MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
+	quectel_eg25_g_set_baudrate_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+IPR=" STRINGIFY(CONFIG_MODEM_CELLULAR_NEW_BAUDRATE),
-				   ok_match));
+						       ok_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(quectel_eg25_g_set_baudrate_chat_script,
 			 quectel_eg25_g_set_baudrate_chat_script_cmds, abort_matches,
@@ -106,6 +111,8 @@ static const struct modem_cellular_vendor_config quectel_eg25_g_vendor = {
 		.size = ARRAY_SIZE(quectel_eg25_g_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 1500,
 	.reset_pulse_duration_ms = 500,
 	.startup_time_ms = 15000,
@@ -116,8 +123,6 @@ static const struct modem_cellular_vendor_config quectel_eg25_g_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg25_g.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg25_g.c
@@ -122,9 +122,7 @@ static const struct modem_cellular_vendor_config quectel_eg25_g_vendor = {
 #define MODEM_CELLULAR_DEVICE_QUECTEL_EG25_G(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg800q.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg800q.c
@@ -62,6 +62,8 @@ static const struct modem_cellular_vendor_config quectel_eg800q_vendor = {
 		.size = ARRAY_SIZE(quectel_eg800q_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 1500,
 	.reset_pulse_duration_ms = 500,
 	.startup_time_ms = 15000,
@@ -72,8 +74,6 @@ static const struct modem_cellular_vendor_config quectel_eg800q_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg800q.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg800q.c
@@ -73,9 +73,7 @@ static const struct modem_cellular_vendor_config quectel_eg800q_vendor = {
 #define MODEM_CELLULAR_DEVICE_QUECTEL_EG800Q(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg915u.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg915u.c
@@ -73,9 +73,7 @@ static const struct modem_cellular_vendor_config quectel_eg915u_vendor = {
 #define MODEM_CELLULAR_DEVICE_QUECTEL_EG915U(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg915u.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg915u.c
@@ -62,6 +62,8 @@ static const struct modem_cellular_vendor_config quectel_eg915u_vendor = {
 		.size = ARRAY_SIZE(quectel_eg915u_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 2000,
 	.reset_pulse_duration_ms = 500,
 	.startup_time_ms = 15000,
@@ -72,8 +74,6 @@ static const struct modem_cellular_vendor_config quectel_eg915u_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_simcom_a76xx.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_simcom_a76xx.c
@@ -82,9 +82,7 @@ static const struct modem_cellular_vendor_config simcom_a76xx_vendor = {
 #define MODEM_CELLULAR_DEVICE_SIMCOM_A76XX(inst)                                                   \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_simcom_a76xx.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_simcom_a76xx.c
@@ -71,6 +71,8 @@ static const struct modem_cellular_vendor_config simcom_a76xx_vendor = {
 		.size = ARRAY_SIZE(simcom_a76xx_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 500,
 	.reset_pulse_duration_ms = 100,
 	.startup_time_ms = 20000,
@@ -81,8 +83,6 @@ static const struct modem_cellular_vendor_config simcom_a76xx_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_simcom_sim7080.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_simcom_sim7080.c
@@ -60,6 +60,8 @@ static const struct modem_cellular_vendor_config simcom_sim7080_vendor = {
 		.size = ARRAY_SIZE(simcom_sim7080_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 1500,
 	.reset_pulse_duration_ms = 100,
 	.startup_time_ms = 10000,
@@ -70,8 +72,6 @@ static const struct modem_cellular_vendor_config simcom_sim7080_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_simcom_sim7080.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_simcom_sim7080.c
@@ -71,9 +71,7 @@ static const struct modem_cellular_vendor_config simcom_sim7080_vendor = {
 #define MODEM_CELLULAR_DEVICE_SIMCOM_SIM7080(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_sqn_gm02s.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_sqn_gm02s.c
@@ -53,6 +53,8 @@ static const struct modem_cellular_vendor_config sqn_gm02s_vendor = {
 		.size = ARRAY_SIZE(sqn_gm02s_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 1500,
 	.reset_pulse_duration_ms = 100,
 	.startup_time_ms = 2000,
@@ -64,8 +66,6 @@ static const struct modem_cellular_vendor_config sqn_gm02s_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_sqn_gm02s.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_sqn_gm02s.c
@@ -65,9 +65,7 @@ static const struct modem_cellular_vendor_config sqn_gm02s_vendor = {
 #define MODEM_CELLULAR_DEVICE_SQN_GM02S(inst)                                                      \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_swir_hl7800.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_swir_hl7800.c
@@ -79,9 +79,7 @@ static const struct modem_cellular_vendor_config hl7800_vendor = {
 #define MODEM_CELLULAR_DEVICE_SWIR_HL7800(inst)                                                    \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_swir_hl7800.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_swir_hl7800.c
@@ -68,6 +68,8 @@ static const struct modem_cellular_vendor_config hl7800_vendor = {
 		.size = ARRAY_SIZE(swir_hl7800_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 1500,
 	.reset_pulse_duration_ms = 100,
 	.startup_time_ms = 10000,
@@ -78,8 +80,6 @@ static const struct modem_cellular_vendor_config hl7800_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
@@ -66,6 +66,8 @@ static const struct modem_cellular_vendor_config telit_le910c1tx_vendor = {
 		.size = ARRAY_SIZE(telit_le910c1tx_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 5050,
 	.reset_pulse_duration_ms = 250,
 	.startup_time_ms = 20000,
@@ -76,8 +78,6 @@ static const struct modem_cellular_vendor_config telit_le910c1tx_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_le910c1tx.c
@@ -77,9 +77,7 @@ static const struct modem_cellular_vendor_config telit_le910c1tx_vendor = {
 #define MODEM_CELLULAR_DEVICE_TELIT_LE910C1TX(inst)                                                \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_lex10q1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_lex10q1.c
@@ -72,6 +72,8 @@ static const struct modem_cellular_vendor_config telit_lex10q1_vendor = {
 		.size = ARRAY_SIZE(telit_lex10q1_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 5050,
 	.reset_pulse_duration_ms = 250,
 	.startup_time_ms = 20000,
@@ -82,8 +84,6 @@ static const struct modem_cellular_vendor_config telit_lex10q1_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_lex10q1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_lex10q1.c
@@ -10,6 +10,8 @@
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
+MODEM_CHAT_MATCHES_DEFINE(telit_lex10q1_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES);
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	telit_lex10q1_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 300),
 	MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100), MODEM_CHAT_SCRIPT_CMD_RESP_NONE("AT", 100),
@@ -57,11 +59,23 @@ MODEM_CHAT_SCRIPT_DEFINE(telit_lex10q1_shutdown_chat_script,
 			 telit_lex10q1_shutdown_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 10);
 
-static const struct modem_cellular_config_scripts telit_lex10q1_scripts = {
-	.init = &telit_lex10q1_init_chat_script,
-	.dial = &telit_lex10q1_dial_chat_script,
-	.periodic = &telit_lex10q1_periodic_chat_script,
-	.shutdown = &telit_lex10q1_shutdown_chat_script,
+static const struct modem_cellular_vendor_config telit_lex10q1_vendor = {
+	/* clang-format off */
+	.scripts = {
+		.init = &telit_lex10q1_init_chat_script,
+		.dial = &telit_lex10q1_dial_chat_script,
+		.periodic = &telit_lex10q1_periodic_chat_script,
+		.shutdown = &telit_lex10q1_shutdown_chat_script,
+	},
+	.unsol_matches = {
+		.matches = telit_lex10q1_unsol,
+		.size = ARRAY_SIZE(telit_lex10q1_unsol),
+	},
+	/* clang-format on */
+	.power_pulse_duration_ms = 5050,
+	.reset_pulse_duration_ms = 250,
+	.startup_time_ms = 20000,
+	.shutdown_time_ms = 5000,
 };
 
 #define MODEM_CELLULAR_DEVICE_TELIT_LEX10Q1(inst)                                                  \
@@ -75,6 +89,6 @@ static const struct modem_cellular_config_scripts telit_lex10q1_scripts = {
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \
-	MODEM_CELLULAR_DEFINE_INSTANCE(inst, 5050, 250, 20000, 5000, false, &telit_lex10q1_scripts)
+	MODEM_CELLULAR_DEFINE_INSTANCE(inst, &telit_lex10q1_vendor);
 
 DT_INST_FOREACH_STATUS_OKAY(MODEM_CELLULAR_DEVICE_TELIT_LEX10Q1)

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_lex10q1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_lex10q1.c
@@ -83,9 +83,7 @@ static const struct modem_cellular_vendor_config telit_lex10q1_vendor = {
 #define MODEM_CELLULAR_DEVICE_TELIT_LEX10Q1(inst)                                                  \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_mex10g1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_mex10g1.c
@@ -83,9 +83,7 @@ __maybe_unused static const struct modem_cellular_vendor_config telit_me910g1_ve
 #define MODEM_CELLULAR_DEVICE_TELIT_ME910G1(inst)                                                  \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_telit_mex10g1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_telit_mex10g1.c
@@ -72,6 +72,8 @@ __maybe_unused static const struct modem_cellular_vendor_config telit_me910g1_ve
 		.size = ARRAY_SIZE(telit_mex10g1_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 5050,
 	.reset_pulse_duration_ms = 250,
 	.startup_time_ms = 15000,
@@ -82,8 +84,6 @@ __maybe_unused static const struct modem_cellular_vendor_config telit_me910g1_ve
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \
@@ -105,6 +105,8 @@ static const struct modem_cellular_vendor_config telit_me310g1_vendor = {
 		.size = ARRAY_SIZE(telit_mex10g1_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 5050,
 	.reset_pulse_duration_ms = 0,
 	.startup_time_ms = 1000,
@@ -116,8 +118,6 @@ static const struct modem_cellular_vendor_config telit_me310g1_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_trasna_lexi_r10.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_trasna_lexi_r10.c
@@ -87,9 +87,7 @@ static const struct modem_cellular_vendor_config trasna_lexi_r10_vendor = {
 #define MODEM_CELLULAR_DEVICE_TRASNA_LEXI_R10(inst)                                                \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3))                          \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_trasna_lexi_r10.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_trasna_lexi_r10.c
@@ -76,6 +76,8 @@ static const struct modem_cellular_vendor_config trasna_lexi_r10_vendor = {
 		.size = ARRAY_SIZE(trasna_lexi_r10_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 1500,
 	.reset_pulse_duration_ms = 100,
 	.startup_time_ms = 9000,
@@ -86,8 +88,6 @@ static const struct modem_cellular_vendor_config trasna_lexi_r10_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_lara_r6.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_lara_r6.c
@@ -95,6 +95,8 @@ static const struct modem_cellular_vendor_config u_blox_lara_r6_vendor = {
 		.size = ARRAY_SIZE(u_blox_lara_r6_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 1500,
 	.reset_pulse_duration_ms = 100,
 	.startup_time_ms = 9000,
@@ -105,8 +107,6 @@ static const struct modem_cellular_vendor_config u_blox_lara_r6_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_lara_r6.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_lara_r6.c
@@ -106,9 +106,7 @@ static const struct modem_cellular_vendor_config u_blox_lara_r6_vendor = {
 #define MODEM_CELLULAR_DEVICE_U_BLOX_LARA_R6(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3), (user_pipe_0, 4))          \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r4.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r4.c
@@ -71,9 +71,7 @@ static const struct modem_cellular_vendor_config u_blox_sara_r4_vendor = {
 #define MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R4(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 3), (user_pipe_0, 4))          \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r4.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r4.c
@@ -60,6 +60,8 @@ static const struct modem_cellular_vendor_config u_blox_sara_r4_vendor = {
 		.size = ARRAY_SIZE(u_blox_sara_r4_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 1500,
 	.reset_pulse_duration_ms = 100,
 	.startup_time_ms = 10000,
@@ -70,8 +72,6 @@ static const struct modem_cellular_vendor_config u_blox_sara_r4_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r5.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r5.c
@@ -76,9 +76,7 @@ static const struct modem_cellular_vendor_config u_blox_sara_r5_vendor = {
 #define MODEM_CELLULAR_DEVICE_U_BLOX_SARA_R5(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
-	};                                                                                         \
+	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (gnss_pipe, 4), (user_pipe_0, 3))          \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r5.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_u_blox_sara_r5.c
@@ -64,6 +64,8 @@ static const struct modem_cellular_vendor_config u_blox_sara_r5_vendor = {
 		.size = ARRAY_SIZE(u_blox_sara_r5_unsol),
 	},
 	/* clang-format on */
+	.chat_delimiter = "\r",
+	.chat_filter = "\n",
 	.power_pulse_duration_ms = 1500,
 	.reset_pulse_duration_ms = 100,
 	.startup_time_ms = 1500,
@@ -75,8 +77,6 @@ static const struct modem_cellular_vendor_config u_blox_sara_r5_vendor = {
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 64);       \
                                                                                                    \
 	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst) = {                 \
-		.chat_delimiter = "\r",                                                            \
-		.chat_filter = "\n",                                                               \
 		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 	};                                                                                         \
                                                                                                    \

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -170,13 +170,6 @@ struct modem_cellular_data {
 
 	struct modem_chat_script board_init_script;
 
-	/* PPP */
-	/** @endcond */
-
-	/** PPP context used for the modem data connection. Must not be NULL. */
-	struct modem_ppp *ppp;
-
-	/** @cond INTERNAL_HIDDEN */
 	struct net_mgmt_event_callback net_mgmt_event_callback;
 
 	enum modem_cellular_state state;
@@ -303,6 +296,7 @@ struct modem_cellular_vendor_config {
 struct modem_cellular_config {
 	const struct device *uart;
 	const struct modem_cellular_vendor_config *vendor;
+	struct modem_ppp *ppp;
 	struct gpio_dt_spec power_gpio;
 	struct gpio_dt_spec reset_gpio;
 	struct gpio_dt_spec wake_gpio;
@@ -527,6 +521,7 @@ void modem_cellular_chat_callback_handler(struct modem_chat *chat,
 	static const struct modem_cellular_config MODEM_CELLULAR_INST_NAME(config, inst) = {       \
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),                                          \
 		.vendor = vendor_config,                                                           \
+		.ppp = &MODEM_CELLULAR_INST_NAME(ppp, inst),                                       \
 		.power_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_power_gpios, {}),                 \
 		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_reset_gpios, {}),                 \
 		.wake_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, mdm_wake_gpios, {}),                   \

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -144,23 +144,6 @@ struct modem_cellular_data {
 	/* Modem chat */
 	struct modem_chat chat;
 	uint8_t chat_receive_buf[CONFIG_MODEM_CELLULAR_CHAT_BUFFER_SIZE];
-	/** @endcond */
-
-	/**
-	 * Command delimiter used by the modem, as a NULL-terminated string.
-	 *
-	 * Must not be NULL and must remain valid for the lifetime of the device.
-	 */
-	uint8_t *chat_delimiter;
-	/**
-	 * Characters filtered from modem responses, as a NULL-terminated string.
-	 *
-	 * May be NULL to disable filtering. A non-NULL string must remain valid for the lifetime of
-	 * the device.
-	 */
-	uint8_t *chat_filter;
-
-	/** @cond INTERNAL_HIDDEN */
 	uint8_t *chat_argv[32];
 	uint8_t script_failure_counter;
 	uint8_t recovery_count;
@@ -285,6 +268,19 @@ struct modem_cellular_vendor_config {
 		/** Number of elements in @c matches. */
 		uint16_t size;
 	} unsol_matches;
+	/**
+	 * Command delimiter used by the modem, as a NULL-terminated string.
+	 *
+	 * Must not be NULL and must remain valid for the lifetime of the device.
+	 */
+	const char *chat_delimiter;
+	/**
+	 * Characters filtered from modem responses, as a NULL-terminated string.
+	 *
+	 * May be NULL to disable filtering. A non-NULL string must remain valid for the lifetime of
+	 * the device.
+	 */
+	const char *chat_filter;
 	/** Duration of the modem power-key pulse, in milliseconds. */
 	uint16_t power_pulse_duration_ms;
 	/** Duration of the modem reset pulse, in milliseconds. */

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -238,12 +238,12 @@ struct modem_chat {
 	uint16_t work_buf_len;
 
 	/* Chat delimiter */
-	uint8_t *delimiter;
+	const uint8_t *delimiter;
 	uint16_t delimiter_size;
 	uint16_t delimiter_match_len;
 
 	/* Array of bytes which are discarded out by parser */
-	uint8_t *filter;
+	const uint8_t *filter;
 	uint16_t filter_size;
 
 	/* Parsed arguments */
@@ -308,11 +308,11 @@ struct modem_chat_config {
 	/** Size of receive buffer should be longest line + longest match */
 	uint16_t receive_buf_size;
 	/** Delimiter */
-	uint8_t *delimiter;
+	const uint8_t *delimiter;
 	/** Size of delimiter */
 	uint8_t delimiter_size;
 	/** Bytes which are discarded by parser */
-	uint8_t *filter;
+	const uint8_t *filter;
 	/** Size of filter */
 	uint8_t filter_size;
 	/** Array of pointers used to point to parsed arguments */

--- a/tests/drivers/build_all/modem/uart.dtsi
+++ b/tests/drivers/build_all/modem/uart.dtsi
@@ -126,3 +126,10 @@ test_trasna_lexi_r10: trasna_lexi_r10 {
 	mdm-power-gpios = <&test_gpio 0 0>;
 	mdm-reset-gpios = <&test_gpio 0 0>;
 };
+
+test_telit_lex10q1: telit_lex10q1 {
+	compatible = "telit,lex10q1";
+
+	mdm-power-gpios = <&test_gpio 0 0>;
+	mdm-reset-gpios = <&test_gpio 0 0>;
+};


### PR DESCRIPTION
Apply tweaks to the cellular modem internals to that vendor drivers no longer need to assign directly to fields in `struct modem_cellular_data` inside the instantiation macros. This means a copy of the initialized variable no longer needs to live in the `.data` section, and because this type is huge, this saves ~4kB of ROM.

 - Move the specification of the chat delimiter and filter strings to the vendor configuration struct.
 - Move the PPP instance pointer from the `struct modem_cellular_data` object to `struct modem_cellular_config`. This requires adding a new argument to `MODEM_CELLULAR_DEFINE_INSTANCE`.

Before and after image sizes:
```
> west build -b nrf93m1dk/nrf54l15/cpuapp ./zephyr/samples/net/cellular_modem/
Memory region         Used Size  Region Size  %age Used
           FLASH:      200532 B      1524 KB     12.85%
Memory region         Used Size  Region Size  %age Used
           FLASH:      196236 B      1524 KB     12.57%
```
