### PR TITLE
modem: chat: conditional chat scripts

### DIFF
--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -191,6 +191,7 @@ config MODEM_CELL_INFO
 # zephyr-keep-sorted-start
 source "drivers/modem/Kconfig.at_shell"
 source "drivers/modem/Kconfig.cellular"
+source "drivers/modem/vendor_modem_cellular/Kconfig"
 source "drivers/modem/vendor_standalone/Kconfig"
 # zephyr-keep-sorted-stop
 

--- a/drivers/modem/vendor_modem_cellular/Kconfig
+++ b/drivers/modem/vendor_modem_cellular/Kconfig
@@ -1,0 +1,5 @@
+# Configuration specific to individual backends
+# Copyright (c) 2026 Embeint Inc
+
+configdefault MODEM_CHAT_CONDITIONAL_COMMANDS
+	default y if DT_HAS_NORDIC_NRF93M1_ENABLED

--- a/drivers/modem/vendor_modem_cellular/Kconfig
+++ b/drivers/modem/vendor_modem_cellular/Kconfig
@@ -1,0 +1,5 @@
+# Configuration specific to individual backends
+# Copyright (c) 2026 Embeint Inc
+
+configdefault MODEM_CHAT_COMMANDS_CONDITIONAL
+	default y if DT_HAS_NORDIC_NRF93M1_ENABLED

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
@@ -10,8 +10,21 @@
 
 #define DT_DRV_COMPAT nordic_nrf93m1
 
+struct nrf93m1_modem_cellular_data {
+	/** Common modem data */
+	struct modem_cellular_data data;
+	/** Vendor specific data */
+
+	/** IFC already correctly configured */
+	bool ifc_configured;
+};
+BUILD_ASSERT(offsetof(struct nrf93m1_modem_cellular_data, data) == 0,
+	     "Common data must be at start of struct");
+
 static void nrf93m1_on_bcinfosc(struct modem_chat *chat, char **argv, uint16_t argc,
 				void *user_data);
+static void nrf93m1_on_ifc(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data);
+static bool nrf93m1_ifc_required(void *user_data);
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 MODEM_CHAT_MATCH_DEFINE(pwd_match, "POWERED DOWN", "", NULL);
@@ -20,11 +33,18 @@ MODEM_CHAT_MATCHES_DEFINE(nordic_nrf93m1_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATC
 			  MODEM_CHAT_MATCH("RDY", "", modem_cellular_chat_on_modem_ready),
 			  MODEM_CHAT_MATCH("%BCINFOSC:", ",", nrf93m1_on_bcinfosc));
 
+/* Multi-line response matches - use partial=true for intermediate lines
+ * so the script doesn't advance until the final OK is received.
+ */
+MODEM_CHAT_MATCHES_DEFINE(nordic_nrf93m1_ifc_matches,
+			  MODEM_CHAT_MATCH_INITIALIZER("+IFC:", ",", nrf93m1_on_ifc, false, true),
+			  MODEM_CHAT_MATCH("OK", "", NULL));
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
-	nordic_nrf93m1_init_chat_script_cmds,
-	MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+IFC=2,2", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP_NONE("", 100),
+	nordic_nrf93m1_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP_MULT("AT+IFC?", nordic_nrf93m1_ifc_matches),
+	MODEM_CHAT_SCRIPT_CMD_RESP_COND("AT+IFC=2,2", ok_match, nrf93m1_ifc_required),
+	MODEM_CHAT_SCRIPT_CMD_RESP_NONE_COND("", 100, nrf93m1_ifc_required),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMI", cgmi_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
@@ -101,6 +121,29 @@ static void nrf93m1_on_bcinfosc(struct modem_chat *chat, char **argv, uint16_t a
 	modem_cellular_emit_network_status(data, &evt);
 }
 
+static void nrf93m1_on_ifc(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
+{
+	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
+	struct nrf93m1_modem_cellular_data *vendor_data =
+		CONTAINER_OF(data, struct nrf93m1_modem_cellular_data, data);
+
+	/* IFC configuration is stored in flash, so only needs to be set once.
+	 * If the configuration is already correct, we can skip the delay that needs to be
+	 * respected while the interface is reconfigured.
+	 */
+	vendor_data->ifc_configured =
+		(argc == 3) && (strtol(argv[1], NULL, 10) == 2) && (strtol(argv[2], NULL, 10) == 2);
+}
+
+static bool nrf93m1_ifc_required(void *user_data)
+{
+	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
+	struct nrf93m1_modem_cellular_data *vendor_data =
+		CONTAINER_OF(data, struct nrf93m1_modem_cellular_data, data);
+
+	return !vendor_data->ifc_configured;
+}
+
 static const struct modem_cellular_vendor_config nrf93m1_vendor = {
 	/* clang-format off */
 	.scripts = {
@@ -127,7 +170,7 @@ static const struct modem_cellular_vendor_config nrf93m1_vendor = {
 #define MODEM_CELLULAR_DEVICE_NORDIC_NRF93M1(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 1500);     \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
+	static struct nrf93m1_modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);            \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \

--- a/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_nordic_nrf93m1.c
@@ -10,8 +10,21 @@
 
 #define DT_DRV_COMPAT nordic_nrf93m1
 
+struct nrf93m1_modem_cellular_data {
+	/** Common modem data */
+	struct modem_cellular_data data;
+	/** Vendor specific data */
+
+	/** IFC already correctly configured */
+	bool ifc_configured;
+};
+BUILD_ASSERT(offsetof(struct nrf93m1_modem_cellular_data, data) == 0,
+	     "Common data must be at start of struct");
+
 static void nrf93m1_on_bcinfosc(struct modem_chat *chat, char **argv, uint16_t argc,
 				void *user_data);
+static void nrf93m1_on_ifc(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data);
+static bool nrf93m1_ifc_required(void *user_data);
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 MODEM_CHAT_MATCH_DEFINE(pwd_match, "POWERED DOWN", "", NULL);
@@ -20,11 +33,18 @@ MODEM_CHAT_MATCHES_DEFINE(nordic_nrf93m1_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATC
 			  MODEM_CHAT_MATCH("RDY", "", modem_cellular_chat_on_modem_ready),
 			  MODEM_CHAT_MATCH("%BCINFOSC:", ",", nrf93m1_on_bcinfosc));
 
+/* Multi-line response matches - use partial=true for intermediate lines
+ * so the script doesn't advance until the final OK is received.
+ */
+MODEM_CHAT_MATCHES_DEFINE(nordic_nrf93m1_ifc_matches,
+			  MODEM_CHAT_MATCH_INITIALIZER("+IFC:", ",", nrf93m1_on_ifc, false, true),
+			  MODEM_CHAT_MATCH("OK", "", NULL));
+
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
-	nordic_nrf93m1_init_chat_script_cmds,
-	MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP("AT+IFC=2,2", ok_match),
-	MODEM_CHAT_SCRIPT_CMD_RESP_NONE("", 100),
+	nordic_nrf93m1_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
+	MODEM_CHAT_SCRIPT_CMD_RESP_MULT("AT+IFC?", nordic_nrf93m1_ifc_matches),
+	MODEM_CHAT_SCRIPT_CMD_RESP_COND("AT+IFC=2,2", ok_match, nrf93m1_ifc_required),
+	MODEM_CHAT_SCRIPT_CMD_RESP_NONE_COND("", 100, nrf93m1_ifc_required),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 	MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMI", cgmi_match), MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
@@ -108,6 +128,29 @@ MODEM_CHAT_SCRIPT_DEFINE(nordic_nrf93m1_dlci_setup_chat_script,
 			 nordic_nrf93m1_dlci_setup_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 1);
 
+static void nrf93m1_on_ifc(struct modem_chat *chat, char **argv, uint16_t argc, void *user_data)
+{
+	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
+	struct nrf93m1_modem_cellular_data *vendor_data =
+		CONTAINER_OF(data, struct nrf93m1_modem_cellular_data, data);
+
+	/* IFC configuration is stored in flash, so only needs to be set once.
+	 * If the configuration is already correct, we can skip the delay that needs to be
+	 * respected while the interface is reconfigured.
+	 */
+	vendor_data->ifc_configured =
+		(argc == 3) && (strtol(argv[1], NULL, 10) == 2) && (strtol(argv[2], NULL, 10) == 2);
+}
+
+static bool nrf93m1_ifc_required(void *user_data)
+{
+	struct modem_cellular_data *data = (struct modem_cellular_data *)user_data;
+	struct nrf93m1_modem_cellular_data *vendor_data =
+		CONTAINER_OF(data, struct nrf93m1_modem_cellular_data, data);
+
+	return !vendor_data->ifc_configured;
+}
+
 static const struct modem_cellular_vendor_config nrf93m1_vendor = {
 	/* clang-format off */
 	.scripts = {
@@ -135,7 +178,7 @@ static const struct modem_cellular_vendor_config nrf93m1_vendor = {
 #define MODEM_CELLULAR_DEVICE_NORDIC_NRF93M1(inst)                                                 \
 	MODEM_DT_INST_PPP_DEFINE(inst, MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 1500, 1500);     \
                                                                                                    \
-	static struct modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);                    \
+	static struct nrf93m1_modem_cellular_data MODEM_CELLULAR_INST_NAME(data, inst);            \
                                                                                                    \
 	MODEM_CELLULAR_DEFINE_AND_INIT_USER_PIPES(inst, (user_pipe_0, 3), (user_pipe_1, 4))        \
                                                                                                    \

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -31,6 +31,16 @@ extern "C" {
 struct modem_chat;
 
 /**
+ * @brief Callback called to determine if a chat command should be run
+ *
+ * @param user_data Free to use user data set during modem_chat_init()
+ *
+ * @retval true Chat command should be run
+ * @retval false Chat command should be skipped
+ */
+typedef bool (*modem_chat_run_callback)(void *user_data);
+
+/**
  * @brief Callback called when matching chat is received
  *
  * @param chat Pointer to chat instance instance
@@ -118,8 +128,18 @@ struct modem_chat_script_chat {
 	uint16_t response_matches_size;
 	/** Timeout before chat script may continue to next step in milliseconds */
 	uint16_t timeout;
+#if defined(CONFIG_MODEM_CHAT_CONDITIONAL_COMMANDS) || defined(__DOXYGEN__)
+	/** Callback that returns whether @a request should be run or skipped */
+	modem_chat_run_callback run_check;
+#endif
 };
 
+/**
+ * @brief Command that expects a single response
+ *
+ * @param _request Command string to send
+ * @param _response_match Expected response, as created by @ref MODEM_CHAT_MATCH or variant
+ */
 #define MODEM_CHAT_SCRIPT_CMD_RESP(_request, _response_match)                                      \
 	{                                                                                          \
 		.request = (uint8_t *)(_request),                                                  \
@@ -129,6 +149,12 @@ struct modem_chat_script_chat {
 		.timeout = 0,                                                                      \
 	}
 
+/**
+ * @brief Command that can handle multiple responses
+ *
+ * @param _request Command string to send
+ * @param _response_matches Accepted responses, as created by @ref MODEM_CHAT_MATCHES_DEFINE
+ */
 #define MODEM_CHAT_SCRIPT_CMD_RESP_MULT(_request, _response_matches)                               \
 	{                                                                                          \
 		.request = (uint8_t *)(_request),                                                  \
@@ -138,6 +164,12 @@ struct modem_chat_script_chat {
 		.timeout = 0,                                                                      \
 	}
 
+/**
+ * @brief Command that does not expect any response
+ *
+ * @param _request Command string to send
+ * @param _timeout_ms Duration to wait in milliseconds before continuing the script
+ */
 #define MODEM_CHAT_SCRIPT_CMD_RESP_NONE(_request, _timeout_ms)                                     \
 	{                                                                                          \
 		.request = (uint8_t *)(_request),                                                  \
@@ -147,6 +179,63 @@ struct modem_chat_script_chat {
 		.timeout = _timeout_ms,                                                            \
 	}
 
+/**
+ * @brief Command that expects a single response, conditionally run
+ *
+ * @param _request Command string to send
+ * @param _response_match Expected response, as created by @ref MODEM_CHAT_MATCH or variant
+ * @param _run_check Callback that controls whether the command is run or not
+ */
+#define MODEM_CHAT_SCRIPT_CMD_RESP_COND(_request, _response_match, _run_check)                     \
+	{                                                                                          \
+		.request = (uint8_t *)(_request),                                                  \
+		.request_size = (uint16_t)(sizeof(_request) - 1),                                  \
+		.response_matches = &_response_match,                                              \
+		.response_matches_size = 1,                                                        \
+		.timeout = 0,                                                                      \
+		.run_check = _run_check                                                            \
+	}
+
+/**
+ * @brief Command that can handle multiple responses, conditionally run
+ *
+ * @param _request Command string to send
+ * @param _response_matches Accepted responses, as created by @ref MODEM_CHAT_MATCHES_DEFINE
+ * @param _run_check Callback that controls whether the command is run or not
+ */
+#define MODEM_CHAT_SCRIPT_CMD_RESP_MULT_COND(_request, _response_matches, _run_check)              \
+	{                                                                                          \
+		.request = (uint8_t *)(_request),                                                  \
+		.request_size = (uint16_t)(sizeof(_request) - 1),                                  \
+		.response_matches = _response_matches,                                             \
+		.response_matches_size = ARRAY_SIZE(_response_matches),                            \
+		.timeout = 0,                                                                      \
+		.run_check = _run_check                                                            \
+	}
+
+/**
+ * @brief Command that does not expect any response, conditionally run
+ *
+ * @param _request Command string to send
+ * @param _timeout_ms Duration to wait in milliseconds before continuing the script
+ * @param _run_check Callback that controls whether the command is run or not
+ */
+#define MODEM_CHAT_SCRIPT_CMD_RESP_NONE_COND(_request, _timeout_ms, _run_check)                    \
+	{                                                                                          \
+		.request = (uint8_t *)(_request),                                                  \
+		.request_size = (uint16_t)(sizeof(_request) - 1),                                  \
+		.response_matches = NULL,                                                          \
+		.response_matches_size = 0,                                                        \
+		.timeout = _timeout_ms,                                                            \
+		.run_check = _run_check                                                            \
+	}
+
+/**
+ * @brief Define a static const @ref modem_chat_script_chat array
+ *
+ * @param _sym Name of the created array
+ * @param ... Arbitrary number of @ref MODEM_CHAT_SCRIPT_CMD_RESP and variant macros
+ */
 #define MODEM_CHAT_SCRIPT_CMDS_DEFINE(_sym, ...)                                                   \
 	const static struct modem_chat_script_chat _sym[] = {__VA_ARGS__}
 

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -31,6 +31,16 @@ extern "C" {
 struct modem_chat;
 
 /**
+ * @brief Callback called to determine if a chat command should be run
+ *
+ * @param user_data Free to use user data set during modem_chat_init()
+ *
+ * @retval true Chat command should be run
+ * @retval false Chat command should be skipped
+ */
+typedef bool (*modem_chat_run_check)(void *user_data);
+
+/**
  * @brief Callback called when matching chat is received
  *
  * @param chat Pointer to chat instance instance
@@ -118,8 +128,18 @@ struct modem_chat_script_chat {
 	uint16_t response_matches_size;
 	/** Timeout before chat script may continue to next step in milliseconds */
 	uint16_t timeout;
+#if defined(CONFIG_MODEM_CHAT_COMMANDS_CONDITIONAL) || defined(__DOXYGEN__)
+	/** Callback that returns whether @a request should be run or skipped */
+	modem_chat_run_check run_check;
+#endif
 };
 
+/**
+ * @brief Command that expects a single response
+ *
+ * @param _request Command string to send
+ * @param _response_match Expected response, as created by @ref MODEM_CHAT_MATCH or variant
+ */
 #define MODEM_CHAT_SCRIPT_CMD_RESP(_request, _response_match)                                      \
 	{                                                                                          \
 		.request = (uint8_t *)(_request),                                                  \
@@ -129,6 +149,12 @@ struct modem_chat_script_chat {
 		.timeout = 0,                                                                      \
 	}
 
+/**
+ * @brief Command that can handle multiple responses
+ *
+ * @param _request Command string to send
+ * @param _response_matches Accepted responses, as created by @ref MODEM_CHAT_MATCHES_DEFINE
+ */
 #define MODEM_CHAT_SCRIPT_CMD_RESP_MULT(_request, _response_matches)                               \
 	{                                                                                          \
 		.request = (uint8_t *)(_request),                                                  \
@@ -138,6 +164,12 @@ struct modem_chat_script_chat {
 		.timeout = 0,                                                                      \
 	}
 
+/**
+ * @brief Command that does not expect any response
+ *
+ * @param _request Command string to send
+ * @param _timeout_ms Duration to wait in milliseconds before continuing the script
+ */
 #define MODEM_CHAT_SCRIPT_CMD_RESP_NONE(_request, _timeout_ms)                                     \
 	{                                                                                          \
 		.request = (uint8_t *)(_request),                                                  \
@@ -147,6 +179,63 @@ struct modem_chat_script_chat {
 		.timeout = _timeout_ms,                                                            \
 	}
 
+/**
+ * @brief Command that expects a single response, conditionally run
+ *
+ * @param _request Command string to send
+ * @param _response_match Expected response, as created by @ref MODEM_CHAT_MATCH or variant
+ * @param _run_check Callback that controls whether the command is run or not
+ */
+#define MODEM_CHAT_SCRIPT_CMD_RESP_COND(_request, _response_match, _run_check)                     \
+	{                                                                                          \
+		.request = (uint8_t *)(_request),                                                  \
+		.request_size = (uint16_t)(sizeof(_request) - 1),                                  \
+		.response_matches = &_response_match,                                              \
+		.response_matches_size = 1,                                                        \
+		.timeout = 0,                                                                      \
+		.run_check = _run_check                                                            \
+	}
+
+/**
+ * @brief Command that can handle multiple responses, conditionally run
+ *
+ * @param _request Command string to send
+ * @param _response_matches Accepted responses, as created by @ref MODEM_CHAT_MATCHES_DEFINE
+ * @param _run_check Callback that controls whether the command is run or not
+ */
+#define MODEM_CHAT_SCRIPT_CMD_RESP_MULT_COND(_request, _response_matches, _run_check)              \
+	{                                                                                          \
+		.request = (uint8_t *)(_request),                                                  \
+		.request_size = (uint16_t)(sizeof(_request) - 1),                                  \
+		.response_matches = _response_matches,                                             \
+		.response_matches_size = ARRAY_SIZE(_response_matches),                            \
+		.timeout = 0,                                                                      \
+		.run_check = _run_check                                                            \
+	}
+
+/**
+ * @brief Command that does not expect any response, conditionally run
+ *
+ * @param _request Command string to send
+ * @param _timeout_ms Duration to wait in milliseconds before continuing the script
+ * @param _run_check Callback that controls whether the command is run or not
+ */
+#define MODEM_CHAT_SCRIPT_CMD_RESP_NONE_COND(_request, _timeout_ms, _run_check)                    \
+	{                                                                                          \
+		.request = (uint8_t *)(_request),                                                  \
+		.request_size = (uint16_t)(sizeof(_request) - 1),                                  \
+		.response_matches = NULL,                                                          \
+		.response_matches_size = 0,                                                        \
+		.timeout = _timeout_ms,                                                            \
+		.run_check = _run_check                                                            \
+	}
+
+/**
+ * @brief Define a static const @ref modem_chat_script_chat array
+ *
+ * @param _sym Name of the created array
+ * @param ... Arbitrary number of @ref MODEM_CHAT_SCRIPT_CMD_RESP and variant macros
+ */
 #define MODEM_CHAT_SCRIPT_CMDS_DEFINE(_sym, ...)                                                   \
 	const static struct modem_chat_script_chat _sym[] = {__VA_ARGS__}
 

--- a/subsys/modem/Kconfig
+++ b/subsys/modem/Kconfig
@@ -28,6 +28,13 @@ config MODEM_CHAT
 
 if MODEM_CHAT
 
+config MODEM_CHAT_CONDITIONAL_COMMANDS
+	bool
+	help
+	  Modem chat usage requires conditional command support. This option
+	  should be selected by any modem chat user that defines a conditional
+	  command, for example `MODEM_CHAT_SCRIPT_CMD_RESP_COND`.
+
 config MODEM_CHAT_WORK_BUFFER_SIZE
 	int "Modem chat work buffer size in bytes"
 	default 32

--- a/subsys/modem/Kconfig
+++ b/subsys/modem/Kconfig
@@ -28,6 +28,13 @@ config MODEM_CHAT
 
 if MODEM_CHAT
 
+config MODEM_CHAT_COMMANDS_CONDITIONAL
+	bool
+	help
+	  Modem chat usage requires conditional command support. This option
+	  should be selected by any modem chat user that defines a conditional
+	  command, for example `MODEM_CHAT_SCRIPT_CMD_RESP_COND`.
+
 config MODEM_CHAT_WORK_BUFFER_SIZE
 	int "Modem chat work buffer size in bytes"
 	default 32

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -250,6 +250,15 @@ static void modem_chat_script_next(struct modem_chat *chat, bool initial)
 
 	script_chat = &chat->script->script_chats[chat->script_chat_it];
 
+#if defined(CONFIG_MODEM_CHAT_CONDITIONAL_COMMANDS)
+	if ((script_chat->run_check != NULL) && !script_chat->run_check(chat->user_data)) {
+		/* Current chat should be skipped, reschedule work immediately to run next step */
+		LOG_DBG("skipping: %.*s", script_chat->request_size, script_chat->request);
+		modem_work_schedule(&chat->script_send_timeout_work, K_NO_WAIT);
+		return;
+	}
+#endif
+
 	/* Continue script */
 	if (modem_chat_script_chat_has_request(chat)) {
 		LOG_DBG("sending: %.*s", script_chat->request_size, script_chat->request);

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -250,6 +250,15 @@ static void modem_chat_script_next(struct modem_chat *chat, bool initial)
 
 	script_chat = &chat->script->script_chats[chat->script_chat_it];
 
+#if defined(CONFIG_MODEM_CHAT_COMMANDS_CONDITIONAL)
+	if ((script_chat->run_check != NULL) && !script_chat->run_check(chat->user_data)) {
+		/* Current chat should be skipped, reschedule work immediately to run next step */
+		LOG_DBG("skipping: %.*s", script_chat->request_size, script_chat->request);
+		modem_work_schedule(&chat->script_send_timeout_work, K_NO_WAIT);
+		return;
+	}
+#endif
+
 	/* Continue script */
 	if (modem_chat_script_chat_has_request(chat)) {
 		LOG_DBG("sending: %.*s", script_chat->request_size, script_chat->request);

--- a/tests/subsys/modem/modem_chat/Kconfig
+++ b/tests/subsys/modem/modem_chat/Kconfig
@@ -5,4 +5,8 @@ config MODEM_MOCK_BACKEND_LIMIT
 	int "Mock backend TX limit for test"
 	default 8
 
+config MODEM_CHAT_TEST_CONDITIONAL_COMMANDS
+	bool "Force MODEM_CHAT_CONDITIONAL_COMMANDS for testing"
+	select MODEM_CHAT_CONDITIONAL_COMMANDS
+
 source "Kconfig.zephyr"

--- a/tests/subsys/modem/modem_chat/Kconfig
+++ b/tests/subsys/modem/modem_chat/Kconfig
@@ -5,4 +5,8 @@ config MODEM_MOCK_BACKEND_LIMIT
 	int "Mock backend TX limit for test"
 	default 8
 
+config MODEM_CHAT_TEST_COMMANDS_CONDITIONAL
+	bool "Force MODEM_CHAT_COMMANDS_CONDITIONAL for testing"
+	select MODEM_CHAT_COMMANDS_CONDITIONAL
+
 source "Kconfig.zephyr"

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -783,6 +783,83 @@ ZTEST(modem_chat, test_runtime_script)
 	zassert_equal(ret, -EINVAL, "Should have failed to set abort matches");
 }
 
+#if defined(CONFIG_MODEM_CHAT_CONDITIONAL_COMMANDS)
+static bool test_chat_run_result;
+
+static bool test_chat_run(void *user_data)
+{
+	zassert_equal(&cmd_user_data, user_data, "Unexpected user data");
+	return test_chat_run_result;
+}
+
+MODEM_CHAT_MATCHES_DEFINE(partial_matches,
+			  MODEM_CHAT_MATCH_INITIALIZER("ERR", "", NULL, false, false),
+			  MODEM_CHAT_MATCH_INITIALIZER("OK", "", NULL, false, false));
+
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(script_cond_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("AT", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP_COND("RSP", ok_match, test_chat_run),
+			      MODEM_CHAT_SCRIPT_CMD_RESP_MULT_COND("MULT", partial_matches,
+								   test_chat_run),
+			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE_COND("NONE", 100, test_chat_run),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT", ok_match));
+
+MODEM_CHAT_SCRIPT_DEFINE(cond_script, script_cond_cmds, abort_matches, on_script_result, 4);
+#endif
+
+ZTEST(modem_chat, test_script_skip_chats)
+{
+#if defined(CONFIG_MODEM_CHAT_CONDITIONAL_COMMANDS)
+
+	/* Conditional commands are skipped */
+	test_chat_run_result = false;
+	zassert_true(modem_chat_script_run(&cmd, &cond_script) == 0, "Failed to start script");
+	k_msleep(100);
+
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "AT\r", sizeof("AT\r") - 1) == 0,
+		     "Request not sent as expected");
+	modem_backend_mock_put(&mock, ok_response, sizeof(ok_response) - 1);
+	k_msleep(100);
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "AT\r", sizeof("AT\r") - 1) == 0,
+		     "Request not sent as expected");
+	modem_backend_mock_put(&mock, ok_response, sizeof(ok_response) - 1);
+	k_msleep(100);
+
+	/* Conditional commands are run */
+	test_chat_run_result = true;
+	zassert_true(modem_chat_script_run(&cmd, &cond_script) == 0, "Failed to start script");
+	k_msleep(100);
+
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "AT\r", sizeof("AT\r") - 1) == 0,
+		     "Request not sent as expected");
+	modem_backend_mock_put(&mock, ok_response, sizeof(ok_response) - 1);
+	k_msleep(100);
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "RSP\r", sizeof("RSP\r") - 1) == 0,
+		     "Request not sent as expected");
+	modem_backend_mock_put(&mock, ok_response, sizeof(ok_response) - 1);
+	k_msleep(100);
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "MULT\r", sizeof("MULT\r") - 1) == 0,
+		     "Request not sent as expected");
+	modem_backend_mock_put(&mock, ok_response, sizeof(ok_response) - 1);
+	k_msleep(100);
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "NONE\r", sizeof("NONE\r") - 1) == 0,
+		     "Request not sent as expected");
+	k_msleep(100);
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "AT\r", sizeof("AT\r") - 1) == 0,
+		     "Request not sent as expected");
+	modem_backend_mock_put(&mock, ok_response, sizeof(ok_response) - 1);
+	k_msleep(100);
+#else
+	ztest_test_skip();
+#endif
+}
+
 /*************************************************************************************************/
 /*                                         Test suite                                            */
 /*************************************************************************************************/

--- a/tests/subsys/modem/modem_chat/src/main.c
+++ b/tests/subsys/modem/modem_chat/src/main.c
@@ -783,6 +783,83 @@ ZTEST(modem_chat, test_runtime_script)
 	zassert_equal(ret, -EINVAL, "Should have failed to set abort matches");
 }
 
+#if defined(CONFIG_MODEM_CHAT_COMMANDS_CONDITIONAL)
+static bool test_chat_run_result;
+
+static bool test_chat_run(void *user_data)
+{
+	zassert_equal(&cmd_user_data, user_data, "Unexpected user data");
+	return test_chat_run_result;
+}
+
+MODEM_CHAT_MATCHES_DEFINE(partial_matches,
+			  MODEM_CHAT_MATCH_INITIALIZER("ERR", "", NULL, false, false),
+			  MODEM_CHAT_MATCH_INITIALIZER("OK", "", NULL, false, false));
+
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(script_cond_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("AT", ok_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP_COND("RSP", ok_match, test_chat_run),
+			      MODEM_CHAT_SCRIPT_CMD_RESP_MULT_COND("MULT", partial_matches,
+								   test_chat_run),
+			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE_COND("NONE", 100, test_chat_run),
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT", ok_match));
+
+MODEM_CHAT_SCRIPT_DEFINE(cond_script, script_cond_cmds, abort_matches, on_script_result, 4);
+#endif
+
+ZTEST(modem_chat, test_script_skip_chats)
+{
+#if defined(CONFIG_MODEM_CHAT_COMMANDS_CONDITIONAL)
+
+	/* Conditional commands are skipped */
+	test_chat_run_result = false;
+	zassert_true(modem_chat_script_run(&cmd, &cond_script) == 0, "Failed to start script");
+	k_msleep(100);
+
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "AT\r", sizeof("AT\r") - 1) == 0,
+		     "Request not sent as expected");
+	modem_backend_mock_put(&mock, ok_response, sizeof(ok_response) - 1);
+	k_msleep(100);
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "AT\r", sizeof("AT\r") - 1) == 0,
+		     "Request not sent as expected");
+	modem_backend_mock_put(&mock, ok_response, sizeof(ok_response) - 1);
+	k_msleep(100);
+
+	/* Conditional commands are run */
+	test_chat_run_result = true;
+	zassert_true(modem_chat_script_run(&cmd, &cond_script) == 0, "Failed to start script");
+	k_msleep(100);
+
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "AT\r", sizeof("AT\r") - 1) == 0,
+		     "Request not sent as expected");
+	modem_backend_mock_put(&mock, ok_response, sizeof(ok_response) - 1);
+	k_msleep(100);
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "RSP\r", sizeof("RSP\r") - 1) == 0,
+		     "Request not sent as expected");
+	modem_backend_mock_put(&mock, ok_response, sizeof(ok_response) - 1);
+	k_msleep(100);
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "MULT\r", sizeof("MULT\r") - 1) == 0,
+		     "Request not sent as expected");
+	modem_backend_mock_put(&mock, ok_response, sizeof(ok_response) - 1);
+	k_msleep(100);
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "NONE\r", sizeof("NONE\r") - 1) == 0,
+		     "Request not sent as expected");
+	k_msleep(100);
+	modem_backend_mock_get(&mock, buffer, ARRAY_SIZE(buffer));
+	zassert_true(memcmp(buffer, "AT\r", sizeof("AT\r") - 1) == 0,
+		     "Request not sent as expected");
+	modem_backend_mock_put(&mock, ok_response, sizeof(ok_response) - 1);
+	k_msleep(100);
+#else
+	ztest_test_skip();
+#endif
+}
+
 /*************************************************************************************************/
 /*                                         Test suite                                            */
 /*************************************************************************************************/

--- a/tests/subsys/modem/modem_chat/tests.yaml
+++ b/tests/subsys/modem/modem_chat/tests.yaml
@@ -16,3 +16,6 @@ tests:
   modem.modem_chat.workq:
     extra_configs:
       - CONFIG_MODEM_DEDICATED_WORKQUEUE=y
+  modem.modem_chat.conditional_commands:
+    extra_configs:
+      - CONFIG_MODEM_CHAT_TEST_CONDITIONAL_COMMANDS=y

--- a/tests/subsys/modem/modem_chat/tests.yaml
+++ b/tests/subsys/modem/modem_chat/tests.yaml
@@ -16,3 +16,6 @@ tests:
   modem.modem_chat.workq:
     extra_configs:
       - CONFIG_MODEM_DEDICATED_WORKQUEUE=y
+  modem.modem_chat.commands_conditional:
+    extra_configs:
+      - CONFIG_MODEM_CHAT_TEST_COMMANDS_CONDITIONAL=y


### PR DESCRIPTION
Add the ability to attach a conditional check to an individual command within a chat script that determines whether the command is run or not. This is intended for use in long init or configuration scripts, where dynamically creating the script is infeasible, but there is still a query that should be run on the modem that triggers different behaviors.

For nRF93M1, the flow control configuration and associated delay (`AT+IFC`) only need to be sent if the configuration is not already correct. Since the setting is saved in flash, the vast majority of boots can be made 100 ms faster by querying the current setting and skipping the configuration if it already matches.

Triggered by #113492.

Relevant output of `samples/net/cellular_modem/` with these changes:
```
[00:00:02.153,089] <dbg> modem_chat.modem_chat_script_next: nordic_nrf93m1_init_chat_script: step: 1
[00:00:02.153,102] <dbg> modem_chat.modem_chat_script_next: sending: AT+IFC?
[00:00:02.175,280] <dbg> modem_chat.modem_chat_log_received_command: +IFC:  2  2
[00:00:02.175,333] <dbg> modem_chat.modem_chat_log_received_command: OK
[00:00:02.175,345] <dbg> modem_chat.modem_chat_script_next: nordic_nrf93m1_init_chat_script: step: 2
[00:00:02.175,358] <dbg> modem_chat.modem_chat_script_next: skipping: AT+IFC=2,2
[00:00:02.175,384] <dbg> modem_chat.modem_chat_script_next: nordic_nrf93m1_init_chat_script: step: 3
[00:00:02.175,398] <dbg> modem_chat.modem_chat_script_next: skipping:
[00:00:02.175,435] <dbg> modem_chat.modem_chat_script_next: nordic_nrf93m1_init_chat_script: step: 4
[00:00:02.175,449] <dbg> modem_chat.modem_chat_script_next: sending: AT+CGSN
```

The option was hidden behind a Kconfig in order to eliminate any size increases unless a driver needs it. The cost for adding the field to the struct is approximately 100 bytes (for `samples/net/cellular_modem`), but an argument could be made that since #113915 saves 4kB, we could just enable this by default and drop the complexity of the Kconfig.