### PR TITLE
drivers: input: ch9350l: Fix property names in codemap asserts

### DIFF
--- a/drivers/input/input_ch9350l.c
+++ b/drivers/input/input_ch9350l.c
@@ -407,9 +407,9 @@ static int ch9350l_init(struct device const *dev)
 	DEVICE_DT_INST_DEFINE(inst, ch9350l_init, NULL, &ch9350l_data_##inst,			\
 			      &ch9350l_config_##inst, POST_KERNEL, CONFIG_INPUT_INIT_PRIORITY,	\
 			      NULL);								\
-	BUILD_ASSERT((DT_INST_PROP_LEN_OR(inst, kb_code_map, 0) & 0x1) == 0,			\
+	BUILD_ASSERT((DT_INST_PROP_LEN_OR(inst, kb_codemap, 0) & 0x1) == 0,			\
 		"kb-codemap is not of a valid size");						\
-	BUILD_ASSERT((DT_INST_PROP_LEN_OR(inst, mouse_code_map, 0) & 0x1) == 0,			\
+	BUILD_ASSERT((DT_INST_PROP_LEN_OR(inst, mouse_codemap, 0) & 0x1) == 0,			\
 		"mouse-codemap is not of a valid size");
 
 DT_INST_FOREACH_STATUS_OKAY(CH9350L_DEFINE)


### PR DESCRIPTION
The size BUILD_ASSERTs referenced kb_code_map/mouse_code_map, which do not exist, so they always passed. Use the real property names.