### PR TITLE
drivers: sensor: lsm9ds0: Fix ODR programming and runtime-config builds

### DIFF
--- a/drivers/sensor/st/lsm9ds0_gyro/lsm9ds0_gyro.c
+++ b/drivers/sensor/st/lsm9ds0_gyro/lsm9ds0_gyro.c
@@ -85,7 +85,7 @@ static inline int lsm9ds0_gyro_set_odr_raw(const struct device *dev,
 
 	return i2c_reg_update_byte_dt(&config->i2c, LSM9DS0_GYRO_REG_CTRL_REG1_G,
 				      LSM9DS0_GYRO_MASK_CTRL_REG1_G_DR,
-				      odr << LSM9DS0_GYRO_SHIFT_CTRL_REG1_G_BW);
+				      odr << LSM9DS0_GYRO_SHIFT_CTRL_REG1_G_DR);
 }
 
 #if defined(CONFIG_LSM9DS0_GYRO_SAMPLING_RATE_RUNTIME)

--- a/drivers/sensor/st/lsm9ds0_gyro/lsm9ds0_gyro.c
+++ b/drivers/sensor/st/lsm9ds0_gyro/lsm9ds0_gyro.c
@@ -50,6 +50,8 @@ static int lsm9ds0_gyro_set_fs_raw(const struct device *dev, uint8_t fs)
 	}
 
 #if defined(CONFIG_LSM9DS0_GYRO_FULLSCALE_RUNTIME)
+	struct lsm9ds0_gyro_data *data = dev->data;
+
 	data->fs = fs;
 #endif
 

--- a/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -151,10 +151,10 @@ static int lsm9ds0_mfd_magn_set_odr(const struct device *dev,
 {
 	uint8_t i;
 
-	for (i = 0U; i < ARRAY_SIZE(lsm9ds0_mfd_accel_odr_map); ++i) {
-		if (val->val1 < lsm9ds0_mfd_accel_odr_map[i].freq_int ||
-		    (val->val1 == lsm9ds0_mfd_accel_odr_map[i].freq_int &&
-		     val->val2 <= lsm9ds0_mfd_accel_odr_map[i].freq_micro)) {
+	for (i = 0U; i < ARRAY_SIZE(lsm9ds0_mfd_magn_odr_map); ++i) {
+		if (val->val1 < lsm9ds0_mfd_magn_odr_map[i].freq_int ||
+		    (val->val1 == lsm9ds0_mfd_magn_odr_map[i].freq_int &&
+		     val->val2 <= lsm9ds0_mfd_magn_odr_map[i].freq_micro)) {
 			return lsm9ds0_mfd_magn_set_odr_raw(dev, i);
 		}
 	}

--- a/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
+++ b/drivers/sensor/st/lsm9ds0_mfd/lsm9ds0_mfd.c
@@ -94,6 +94,8 @@ static inline int lsm9ds0_mfd_accel_set_fs_raw(const struct device *dev,
 	}
 
 #if defined(CONFIG_LSM9DS0_MFD_ACCEL_FULL_SCALE_RUNTIME)
+	struct lsm9ds0_mfd_data *data = dev->data;
+
 	data->accel_fs = fs;
 #endif
 
@@ -175,6 +177,8 @@ static inline int lsm9ds0_mfd_magn_set_fs_raw(const struct device *dev,
 	}
 
 #if defined(CONFIG_LSM9DS0_MFD_MAGN_FULL_SCALE_RUNTIME)
+	struct lsm9ds0_mfd_data *data = dev->data;
+
 	data->magn_fs = fs;
 #endif
 


### PR DESCRIPTION
- **drivers: sensor: lsm9ds0_gyro: Fix ODR field shift in CTRL_REG1_G** — The sample rate was shifted with the bandwidth field shift, so the value never intersected the DR mask and the requested ODR was always programmed as zero. Use the DR field shift.
- **drivers: sensor: lsm9ds0_mfd: Use magn ODR map in magn ODR setter** — lsm9ds0_mfd_magn_set_odr() iterated the accelerometer ODR map instead of the dedicated magnetometer map, producing out-of-range M_ODR codes for frequencies above 100 Hz.
- **drivers: sensor: lsm9ds0_gyro: Fix build with runtime full-scale** — lsm9ds0_gyro_set_fs_raw() used an undeclared data pointer when CONFIG_LSM9DS0_GYRO_FULLSCALE_RUNTIME is enabled. Declare it from dev->data.
- **drivers: sensor: lsm9ds0_mfd: Fix build with runtime full-scale** — The accel and magn full-scale setters used an undeclared data pointer when the respective FULL_SCALE_RUNTIME options are enabled. Declare it from dev->data.