### PR TITLE
drivers: sensor: nxp: Fix fxos8700, fxas21002 and pmc_tmpsns bugs

### DIFF
--- a/drivers/sensor/nxp/fxas21002/fxas21002.c
+++ b/drivers/sensor/nxp/fxas21002/fxas21002.c
@@ -40,7 +40,7 @@ int fxas21002_read_spi(const struct device *dev,
 	const struct fxas21002_config *cfg = dev->config;
 
 	/* Reads must clock out a dummy byte after sending the address. */
-	uint8_t reg_buf[2] = { DIR_READ(reg), 0 };
+	uint8_t reg_buf[3] = { DIR_READ(reg), 0, 0 };
 	const struct spi_buf buf[2] = {
 		{ .buf = reg_buf, .len = 3 },
 		{ .buf = data, .len = length }

--- a/drivers/sensor/nxp/fxos8700/fxos8700_trigger.c
+++ b/drivers/sensor/nxp/fxos8700/fxos8700_trigger.c
@@ -342,7 +342,7 @@ static int fxos8700_motion_init(const struct device *dev)
 
 	/* Set motion threshold to maximum */
 	if (config->ops->byte_write(dev, FXOS8700_REG_FF_MT_THS,
-				    FXOS8700_REG_FF_MT_THS)) {
+				    FXOS8700_FF_MT_THS_MASK)) {
 		return -EIO;
 	}
 

--- a/drivers/sensor/nxp/nxp_pmc_tmpsns/nxp_pmc_tmpsns.c
+++ b/drivers/sensor/nxp/nxp_pmc_tmpsns/nxp_pmc_tmpsns.c
@@ -210,7 +210,7 @@ static DEVICE_API(sensor, nxp_pmc_tmpsns_api) = {
 		.adc_seq = {									\
 			.channels = BIT(DT_INST_IO_CHANNELS_INPUT(inst)),			\
 			.buffer = &_CONCAT(nxp_pmc_tmpsns_data, inst).buffer,			\
-			.buffer_size = sizeof(_CONCAT(nxp_pmc_tmpsns_data, inst)),		\
+			.buffer_size = sizeof(_CONCAT(nxp_pmc_tmpsns_data, inst).buffer),	\
 			.resolution = 16,							\
 			.oversampling = 7,							\
 		},										\


### PR DESCRIPTION
- **drivers: sensor: fxos8700: Fix motion threshold value** — The trigger setup wrote the FF_MT_THS register address (0x17) as the threshold instead of the maximum. Write FXOS8700_FF_MT_THS_MASK as the comment describes.
- **drivers: sensor: fxas21002: Fix out-of-bounds SPI command buffer** — The SPI read command buffer was 2 bytes but described with a length of 3, reading past the stack array and clocking out an indeterminate byte. Size the buffer to match.
- **drivers: sensor: nxp_pmc_tmpsns: Fix ADC sequence buffer size** — buffer_size was set to the size of the whole data struct instead of the uint16_t buffer member. Use sizeof of the member.