### PR TITLE
drivers: sensor: adi: Fix max31875 and max32664c attribute handling

### DIFF
--- a/drivers/sensor/adi/max32664c/max32664c.c
+++ b/drivers/sensor/adi/max32664c/max32664c.c
@@ -778,7 +778,7 @@ static int max32664c_attr_set(const struct device *dev, enum sensor_channel chan
 	case SENSOR_ATTR_MAX32664C_GENDER: {
 		tx[0] = 0x50;
 		tx[1] = 0x07;
-		tx[2] = 0x08;
+		tx[2] = 0x09;
 		tx[3] = val->val1 & 0x00FF;
 		if (max32664c_i2c_transmit(dev, tx, 4, &rx, 1, MAX32664C_DEFAULT_CMD_DELAY)) {
 			LOG_ERR("Can not set gender!");

--- a/drivers/sensor/maxim/max31875/max31875.c
+++ b/drivers/sensor/maxim/max31875/max31875.c
@@ -142,7 +142,7 @@ static int max31875_attr_set(const struct device *dev,
 			return -ENOTSUP;
 		}
 
-		ret = max31875_update_config(dev, MAX31875_DATA_FORMAT_SHIFT, value);
+		ret = max31875_update_config(dev, BIT(MAX31875_DATA_FORMAT_SHIFT), value);
 		if (ret < 0) {
 			LOG_ERR("Failed to set attribute!");
 			return ret;


### PR DESCRIPTION
- **drivers: sensor: max31875: Pass a mask to the config update helper** — The full-scale attribute passed MAX31875_DATA_FORMAT_SHIFT (a bit position) as the register mask, clearing the conversion-rate bits and never setting the data format. Use BIT(MAX31875_DATA_FORMAT_SHIFT).
- **drivers: sensor: max32664c: Fix gender algorithm config sub-index** — Setting the gender attribute wrote sub-index 0x08, which belongs to age (height 0x06, weight 0x07, age 0x08), overwriting the age setting. Use sub-index 0x09.