### PR TITLE
drivers: sensor: mtch9010: Fix reference averaging and heartbeat fetch

### DIFF
--- a/drivers/sensor/microchip/mtch9010/mtch9010.c
+++ b/drivers/sensor/microchip/mtch9010/mtch9010.c
@@ -116,7 +116,7 @@ static int mtch9010_set_reference(const struct device *dev, char *temp_buffer)
 			return -EIO;
 		}
 
-		if (mtch9010_timeout_receive(dev, temp_buffer, sizeof(temp_buffer),
+		if (mtch9010_timeout_receive(dev, temp_buffer, MTCH9010_INTERNAL_BUFFER_SIZE,
 					     CONFIG_MTCH9010_SAMPLE_DELAY_TIMEOUT_MS) == 0) {
 			LOG_INST_ERR(config->log, "Reference value timed "
 						  "out during averaging");

--- a/drivers/sensor/microchip/mtch9010/mtch9010.c
+++ b/drivers/sensor/microchip/mtch9010/mtch9010.c
@@ -805,7 +805,7 @@ static int mtch9010_sample_fetch(const struct device *dev, enum sensor_channel c
 	case SENSOR_CHAN_MTCH9010_HEARTBEAT_ERROR_STATE: {
 		/* Returns true if the heartbeat is an error state */
 		mtch9010_update_heartbeat(dev);
-	}
+	} break;
 	default: {
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
- **drivers: sensor: mtch9010: Fix receive length in reference averaging** — sizeof(temp_buffer) on a pointer parameter truncated the UART receive to the pointer size. Pass MTCH9010_INTERNAL_BUFFER_SIZE.
- **drivers: sensor: mtch9010: Fix heartbeat error channel fall-through** — The heartbeat error case fell through into default and returned -ENOTSUP, so fetching the channel always failed. Add the missing break.