### PR TITLE
drivers: sensor: afbr_s50: Fix misplaced comparison in BUILD_ASSERT

### DIFF
--- a/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
+++ b/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
@@ -380,7 +380,7 @@ BUILD_ASSERT(CONFIG_MAIN_STACK_SIZE >= 4096,
 
 #define AFBR_S50_INIT(inst)									   \
 												   \
-	BUILD_ASSERT(DT_INST_PROP(inst, dual_freq_mode == 0) ||					   \
+	BUILD_ASSERT(DT_INST_PROP(inst, dual_freq_mode) == 0 ||					   \
 		     ((DT_INST_PROP(inst, dual_freq_mode) != 0) ^				   \
 		      ((DT_INST_PROP(inst, measurement_mode) & ARGUS_MODE_FLAG_HIGH_SPEED) != 0)), \
 		     "High Speed mode is not compatible with Dual-Frequency mode enabled. "	   \


### PR DESCRIPTION
The dual-frequency assertion placed '== 0' inside the DT_INST_PROP
property-name argument. Move the comparison outside the macro call,
matching the assertion below it.