### PR TITLE
drivers: sensor: mmc56x3: Apply new auto-self-reset value on change

### DIFF
--- a/drivers/sensor/memsic/mmc56x3/mmc56x3.c
+++ b/drivers/sensor/memsic/mmc56x3/mmc56x3.c
@@ -357,7 +357,7 @@ static int mmc56x3_chip_configure(const struct device *dev, struct mmc56x3_confi
 	}
 
 	if (new_config->auto_sr != config->auto_sr) {
-		ret = mmc56x3_chip_set_auto_self_reset(dev, config->auto_sr);
+		ret = mmc56x3_chip_set_auto_self_reset(dev, new_config->auto_sr);
 	}
 
 	return ret;


### PR DESCRIPTION
The reconfigure path detected an auto_sr change but programmed the
old value, so the attribute never took effect. Pass the new value.