### PR TITLE
drivers: serial: uart_rzt2m: Fix baud table bounds check

### DIFF
--- a/drivers/serial/uart_rzt2m.c
+++ b/drivers/serial/uart_rzt2m.c
@@ -337,7 +337,7 @@ static int rzt2m_uart_init(const struct device *dev)
 		return -ENOTSUP;
 	}
 
-	if (data->uart_cfg.baudrate > ARRAY_SIZE(baud_settings)) {
+	if (data->uart_cfg.baudrate >= ARRAY_SIZE(baud_settings)) {
 		LOG_ERR("Selected baudrate variant is not supported: %u.", data->uart_cfg.baudrate);
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
The enum index guard used '>' against ARRAY_SIZE, allowing a read one element past the end of baud_settings[]. Use '>='.