### PR TITLE
drivers: serial: silabs: Fix IRQ lock leaks in rx_buf_rsp

### DIFF
--- a/drivers/serial/uart_silabs_eusart.c
+++ b/drivers/serial/uart_silabs_eusart.c
@@ -697,8 +697,10 @@ static int eusart_async_rx_buf_rsp(const struct device *dev, uint8_t *buf, size_
 	key = irq_lock();
 
 	if (data->rx_next_buffer) {
+		irq_unlock(key);
 		return -EBUSY;
 	} else if (!data->dma_rx.enabled) {
+		irq_unlock(key);
 		return -EACCES;
 	}
 

--- a/drivers/serial/uart_silabs_usart.c
+++ b/drivers/serial/uart_silabs_usart.c
@@ -665,8 +665,10 @@ static int uart_silabs_async_rx_buf_rsp(const struct device *dev, uint8_t *buf, 
 	key = irq_lock();
 
 	if (data->rx_next_buffer) {
+		irq_unlock(key);
 		return -EBUSY;
 	} else if (!data->dma_rx.enabled) {
+		irq_unlock(key);
 		return -EACCES;
 	}
 


### PR DESCRIPTION
- **drivers: serial: silabs: Fix IRQ lock leak in eusart rx_buf_rsp** — eusart_async_rx_buf_rsp() returned -EBUSY/-EACCES without releasing the irq_lock taken at entry, leaving interrupts disabled. Unlock before the early returns.
- **drivers: serial: silabs: Fix IRQ lock leak in usart rx_buf_rsp** — uart_silabs_async_rx_buf_rsp() returned -EBUSY/-EACCES without releasing the irq_lock taken at entry, leaving interrupts disabled. Unlock before the early returns.