### PR TITLE
drivers: i2c: bcm_iproc: Fix target address validation

### DIFF
--- a/drivers/i2c/i2c_bcm_iproc.c
+++ b/drivers/i2c/i2c_bcm_iproc.c
@@ -210,7 +210,7 @@ static int iproc_i2c_target_set_address(const struct device *dev, uint16_t addr)
 	mem_addr_t base = DEV_BASE(dev);
 	uint32_t val;
 
-	if ((addr == 0) && (addr > I2C_MAX_TARGET_ADDR)) {
+	if ((addr == 0) || (addr > I2C_MAX_TARGET_ADDR)) {
 		LOG_ERR("Invalid target address(0x%x) received", addr);
 		return -EINVAL;
 	}


### PR DESCRIPTION
The guard required addr == 0 && addr > I2C_MAX_TARGET_ADDR, which is
never true, so invalid addresses were accepted. Use ||.