### PR TITLE
drivers: i2c: infineon: Record RX pending state for read messages

### DIFF
--- a/drivers/i2c/i2c_infineon.c
+++ b/drivers/i2c/i2c_infineon.c
@@ -297,7 +297,7 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 
 		if ((msg[i].flags & I2C_MSG_RW_MASK) == I2C_MSG_READ) {
 			rx_msg = &msg[i];
-			data->async_pending = CAT1_I2C_PENDING_TX;
+			data->async_pending = CAT1_I2C_PENDING_RX;
 		}
 
 		if ((tx_msg != NULL) && ((i + 1U) < num_msgs) &&

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -648,7 +648,7 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 
 		if ((msg[i].flags & I2C_MSG_READ) != 0) {
 			rx_msg = &msg[i];
-			data->async_pending = CAT1_I2C_PENDING_TX;
+			data->async_pending = CAT1_I2C_PENDING_RX;
 		} else {
 			tx_msg = &msg[i];
 


### PR DESCRIPTION
- **drivers: i2c: infineon: Record RX pending state for reads** — The read branch stored CAT1_I2C_PENDING_TX, copied from the write branch; CAT1_I2C_PENDING_RX was never used. Store the RX state.
- **drivers: i2c: infineon_pdl: Record RX pending state for reads** — The read branch stored CAT1_I2C_PENDING_TX, copied from the write branch; CAT1_I2C_PENDING_RX was never used. Store the RX state.