### PR TITLE
drivers: gpio: b91: Fix bit index for GPIO function enable

### DIFF
--- a/drivers/gpio/gpio_b91.c
+++ b/drivers/gpio/gpio_b91.c
@@ -334,7 +334,7 @@ static int gpio_b91_pin_configure(const struct device *dev,
 	}
 
 	/* GPIO function enable */
-	WRITE_BIT(gpio->actas_gpio, BIT(pin), 1);
+	WRITE_BIT(gpio->actas_gpio, pin, 1);
 
 	/* Set GPIO pull-up / pull-down resistors */
 	gpio_b91_config_up_down_res(gpio, pin, flags);


### PR DESCRIPTION
WRITE_BIT takes a bit index but was passed BIT(pin), applying the
GPIO-function enable to the wrong bit. Pass the pin index.