### PR TITLE
drivers: gpio: adp5585: Configure input pins as inputs

### DIFF
--- a/drivers/gpio/gpio_adp5585.c
+++ b/drivers/gpio/gpio_adp5585.c
@@ -158,7 +158,7 @@ static int gpio_adp5585_config(const struct device *dev, gpio_pin_t pin, gpio_fl
 		reg_value = adp5585_pin_output << bank_pin;
 	} else if ((flags & GPIO_INPUT) != 0) {
 		/* reg_value for ADP5585_GPIO_DIRECTION */
-		reg_value = adp5585_pin_output << bank_pin;
+		reg_value = adp5585_pin_input << bank_pin;
 	}
 
 	ret = i2c_reg_update_byte_dt(&parent_cfg->i2c_bus,


### PR DESCRIPTION
The GPIO_INPUT branch wrote adp5585_pin_output into the direction
register, so pins requested as inputs were driven as outputs.