### PR TITLE
drivers: sensor: ntc_thermistor: Fix NCP15XH103 table entry

### DIFF
--- a/drivers/sensor/ntc_thermistor/ntc_thermistor.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor.c
@@ -262,7 +262,7 @@ static __unused const struct ntc_compensation comp_murata_ncp15xh103[] = {
 	{  35,  6947 },
 	{  45,  4916 },
 	{  55,  3535 },
-	{  64,  2586 },
+	{  65,  2586 },
 	{  75,  1924 },
 	{  85,  1452 },
 	{  95,  1109 },


### PR DESCRIPTION
The 2586 Ohm point was listed at 64 degC in a table that steps by exactly 10 degC, skewing interpolation between 55 and 75 degC. Use 65 degC.

see page 17 of https://www.mouser.com/catalog/specsheets/Murata_01-04-2026_r44e.pdf for confirmation