### PR TITLE
drivers: i2c: andes_atciic100: Fix Fast-Plus configuration

### DIFF
--- a/drivers/i2c/i2c_andes_atciic100.c
+++ b/drivers/i2c/i2c_andes_atciic100.c
@@ -111,6 +111,7 @@ static int i2c_atciic100_configure(const struct device *dev,
 
 	case I2C_SPEED_FAST_PLUS:
 		reg |= SETUP_SPEED_FAST_PLUS;
+		break;
 
 	case I2C_SPEED_HIGH:
 		ret = -EIO;


### PR DESCRIPTION
The I2C_SPEED_FAST_PLUS case fell through into the unsupported
I2C_SPEED_HIGH case and returned -EIO. Add the missing break.