### PR TITLE
drivers: i2c: mchp_sercom_g1: Fix CTRLA field clear mask

### DIFF
--- a/drivers/i2c/i2c_mchp_sercom_g1.c
+++ b/drivers/i2c/i2c_mchp_sercom_g1.c
@@ -339,7 +339,7 @@ static bool i2c_set_baudrate(const struct device *dev, uint32_t bitrate, uint32_
 
 		i2c_regs->I2CM.SERCOM_CTRLA =
 			((i2c_regs->I2CM.SERCOM_CTRLA &
-			  (~SERCOM_I2CM_CTRLA_SPEED_Msk | ~SERCOM_I2CM_CTRLA_SDAHOLD_Msk)) |
+			  ~(SERCOM_I2CM_CTRLA_SPEED_Msk | SERCOM_I2CM_CTRLA_SDAHOLD_Msk)) |
 			 (SERCOM_I2CM_CTRLA_SPEED(i2c_speed_mode) |
 			  SERCOM_I2CM_CTRLA_SDAHOLD(sda_hold_time)));
 	}


### PR DESCRIPTION
(~SPEED_Msk | ~SDAHOLD_Msk) is all-ones for disjoint fields, so
reconfiguration never cleared the old SPEED/SDAHOLD bits. Use
~(SPEED_Msk | SDAHOLD_Msk).