### PR TITLE
drivers: sensor: tdk: Fix tad214x, mpu9250 and icm40627 bugs

### DIFF
--- a/drivers/sensor/tdk/icm40627/icm40627.c
+++ b/drivers/sensor/tdk/icm40627/icm40627.c
@@ -636,8 +636,10 @@ static inline int icm40627_bus_check(const struct device *dev)
 
 static int icm40627_init(const struct device *dev)
 {
+	const struct icm40627_config *cfg = dev->config;
+
 	if (icm40627_bus_check(dev) < 0) {
-		LOG_ERR_DEVICE_NOT_READY(config->bus.bus);
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.i2c.bus);
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tdk/mpu9250/mpu9250.c
+++ b/drivers/sensor/tdk/mpu9250/mpu9250.c
@@ -175,10 +175,10 @@ static int mpu9250_channel_get(const struct device *dev,
 		return ak8963_convert_magn(val, drv_data->magn_z,
 				    drv_data->magn_scale_z,
 				    drv_data->magn_st2);
+#endif
 	case SENSOR_CHAN_DIE_TEMP:
 		mpu9250_convert_temp(val, drv_data->temp);
 		break;
-#endif
 	default:
 		return -ENOTSUP;
 	}

--- a/drivers/sensor/tdk/tad2144/tad214x_drv.c
+++ b/drivers/sensor/tdk/tad2144/tad214x_drv.c
@@ -65,7 +65,7 @@ static void tad214x_convert_encoder(struct sensor_value *val, uint16_t raw_val)
 
 static void tad214x_convert_angle(struct sensor_value *val, uint16_t raw_val)
 {
-	raw_val = (raw_val*36000/65635+18000) % 36000;
+	raw_val = ((uint32_t)raw_val*36000/65535+18000) % 36000;
 	val->val1 = raw_val / 100;
 	val->val2 = (raw_val % 100) * 1000;
 }

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1642,3 +1642,13 @@ test_i2c_tmp451: tmp451@d5 {
 	reg = <0xd5>;
 	alert-gpios = <&test_gpio 0 0>;
 };
+
+test_i2c_icm40627: icm40627@d6 {
+	compatible = "invensense,icm40627";
+	reg = <0xd6>;
+	int-gpios = <&test_gpio 0 0>;
+	accel-hz = <100>;
+	gyro-hz = <100>;
+	accel-fs = <16>;
+	gyro-fs = <2000>;
+};


### PR DESCRIPTION
- **drivers: sensor: tad214x: Fix angle full-scale divisor and overflow** — The angle conversion divided by 65635 instead of the 16-bit full scale 65535, and raw_val * 36000 overflows signed 32-bit for large readings. Use 65535 and widen to uint32_t.
- **drivers: sensor: mpu9250: Make die temperature channel unconditional** — The SENSOR_CHAN_DIE_TEMP case sat inside the CONFIG_MPU9250_MAGN_EN guard, so temperature reads returned -ENOTSUP with the magnetometer disabled even though the register is always fetched.
- **drivers: sensor: icm40627: Fix undefined variable in init error path** — icm40627_init() logged a failed bus check through an undeclared 'config' pointer and a nonexistent bus.bus member, breaking the build when the driver is compiled. Point LOG_ERR_DEVICE_NOT_READY at the underlying I2C bus device.
- **tests: drivers: build_all: sensor: Add icm40627 node** — The invensense,icm40627 driver was not instantiated by any build_all overlay, so it had no compile coverage and a build error in its init error path went unnoticed. Add a node so CI builds it.