### PR TITLE
mgmt: mcumgr: transport: smp_raw_dummy: Rename functions

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/smp_raw_dummy.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_raw_dummy.c
@@ -32,9 +32,9 @@
 BUILD_ASSERT(CONFIG_MCUMGR_TRANSPORT_RAW_DUMMY_RX_BUF_SIZE != 0,
 	     "CONFIG_MCUMGR_TRANSPORT_RAW_DUMMY_RX_BUF_SIZE must be > 0");
 
-static struct mcumgr_serial_rx_ctxt smp_dummy_rx_ctxt;
-static struct mcumgr_serial_rx_ctxt smp_dummy_tx_ctxt;
-static struct smp_transport smp_dummy_transport;
+static struct mcumgr_serial_rx_ctxt smp_raw_dummy_rx_ctxt;
+static struct mcumgr_serial_rx_ctxt smp_raw_dummy_tx_ctxt;
+static struct smp_transport smp_raw_dummy_transport;
 static bool enable_dummy_smp;
 static struct k_sem smp_data_ready_sem;
 static uint8_t smp_send_buffer[CONFIG_MCUMGR_TRANSPORT_RAW_DUMMY_RX_BUF_SIZE];
@@ -76,7 +76,7 @@ static void smp_raw_dummy_process_frag(struct uart_mcumgr_rx_buf *rx_buf)
 	/* Decode the fragment and write the result to the global receive
 	 * context.
 	 */
-	nb = mcumgr_dummy_process_frag(&smp_dummy_rx_ctxt,
+	nb = mcumgr_dummy_process_frag(&smp_raw_dummy_rx_ctxt,
 					rx_buf->data, rx_buf->length);
 
 	/* Release the encoded fragment. */
@@ -86,7 +86,7 @@ static void smp_raw_dummy_process_frag(struct uart_mcumgr_rx_buf *rx_buf)
 	 * processing.
 	 */
 	if (nb != NULL) {
-		smp_rx_req(&smp_dummy_transport, nb);
+		smp_rx_req(&smp_raw_dummy_transport, nb);
 	}
 }
 
@@ -96,13 +96,12 @@ static void smp_raw_dummy_process_frag(struct uart_mcumgr_rx_buf *rx_buf)
  */
 struct net_buf *smp_raw_dummy_get_outgoing(void)
 {
-
 	struct net_buf *nb;
 
 	/* Decode the fragment and write the result to the global receive
 	 * context.
 	 */
-	nb = mcumgr_dummy_process_frag(&smp_dummy_tx_ctxt, smp_send_buffer, smp_send_pos);
+	nb = mcumgr_dummy_process_frag(&smp_raw_dummy_tx_ctxt, smp_send_buffer, smp_send_pos);
 
 	return nb;
 }
@@ -136,10 +135,10 @@ static int smp_raw_dummy_init(void)
 
 	k_sem_init(&smp_data_ready_sem, 0, 1);
 
-	smp_dummy_transport.functions.output = smp_raw_dummy_tx_pkt_int;
-	smp_dummy_transport.functions.get_mtu = smp_raw_dummy_get_mtu;
+	smp_raw_dummy_transport.functions.output = smp_raw_dummy_tx_pkt_int;
+	smp_raw_dummy_transport.functions.get_mtu = smp_raw_dummy_get_mtu;
 
-	rc = smp_transport_init(&smp_dummy_transport);
+	rc = smp_transport_init(&smp_raw_dummy_transport);
 
 	if (rc != 0) {
 		return rc;
@@ -245,7 +244,6 @@ static struct net_buf *mcumgr_dummy_process_frag(
 			return NULL;
 		}
 	}
-
 
 	net_buf_add_mem(rx_ctxt->nb, frag, frag_len);
 


### PR DESCRIPTION
Renames functions to have raw in the names, this helps when debugging with both raw and raw dummy transports enabled, as without the change the debugger will show the names as the same