### PR TITLE
drivers: counter: fix rpi pico timer glitch on top value update

### DIFF
--- a/drivers/counter/counter_rpi_pico_pit_channel.c
+++ b/drivers/counter/counter_rpi_pico_pit_channel.c
@@ -93,8 +93,7 @@ static int counter_rpi_pico_pit_channel_set_top_value(const struct device *dev,
 	pwm_set_chan_level(config->slice, 1, 0);
 	pwm_set_chan_level(config->slice, 0, 0);
 
-	data->config_pwm = pwm_get_default_config();
-	pwm_config_set_wrap(&data->config_pwm, cfg->ticks);
+	pwm_set_wrap(config->slice, cfg->ticks);
 	data->top_value = cfg->ticks;
 	data->callback_struct.callback = cfg->callback;
 	data->callback_struct.top_user_data = cfg->user_data;
@@ -104,11 +103,13 @@ static int counter_rpi_pico_pit_channel_set_top_value(const struct device *dev,
 	counter_rpi_pico_pit_manage_callback(config->controller, &data->callback_struct,
 					     callback_set);
 
-	pwm_init(config->slice, &data->config_pwm, data->running);
-	if (cfg->flags & COUNTER_TOP_CFG_DONT_RESET) {
+	if (!(cfg->flags & COUNTER_TOP_CFG_DONT_RESET)) {
+		pwm_set_counter(config->slice, 0);
+	} else {
 		pwm_set_counter(config->slice, counter_value);
 	}
-	pwm_set_clkdiv_int_frac(config->slice, 0, 0);
+
+	pwm_set_enabled(config->slice, data->running);
 
 	return 0;
 }


### PR DESCRIPTION
Fixes #113852

**Description:**
Updating the top value on the RPi Pico timer was causing a hardware glitch that resulted in unusual PWM behavior and frequency spikes. This occurred because the previous code called `pwm_init()` with a default configuration, which temporarily reset the clock divider (causing spikes if the timer was currently running).

This patch resolves the issue by removing the `pwm_init()` call. Instead, it uses `pwm_set_wrap()` to directly update the hardware slice on the fly. Finally, it uses `pwm_set_enabled()` with `data->running` to safely restore the exact previous state of the timer (whether it was running or stopped).