### PR TITLE
tests: kernel: lifo_usage: move test_lifo_nowait to 1cpu

### DIFF
--- a/tests/kernel/lifo/lifo_usage/src/main.c
+++ b/tests/kernel/lifo/lifo_usage/src/main.c
@@ -219,7 +219,7 @@ static void test_thread_put_timeout(void *p1, void *p2, void *p3)
  * @see k_lifo_put()
  * @see k_lifo_get()
  */
-ZTEST(lifo_usage, test_lifo_nowait)
+ZTEST(lifo_usage_1cpu, test_lifo_nowait)
 {
 	k_lifo_init(&lifo);
 


### PR DESCRIPTION
### Background

It was noted that `test_lifo_nowait` started failing on `fvp_base_revc_2xaem/v8a_aarch32/smp`(a new SMP target proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112775) target after commit 093325206d0 ("kernel: smp: ipi: do not drain self bit in signal_pending_ipi()"). Further analysis showed that the IPI fix changed the timing on the producer CPU - the calling CPU's own pending bit is now retained, adding latency between `k_thread_create` and the second `k_lifo_put` -  which made this latent bug reachable. 

```
west twister -p fvp_base_revc_2xaem/v8a_aarch32/smp -s kernel.lifo.usage

START - test_lifo_nowait
    Assertion failed at WEST_TOPDIR/zephyr/tests/kernel/lifo/lifo_usage/src/main.c:99: thread_entry_nowait: ret not equal to (void *)&lifo_data[1]
 FAIL - test_lifo_nowait in 0.001 seconds
```

### Analysis and fix

`test_lifo_nowait` puts one item on a LIFO, creates a preemptible reader thread with `K_NO_WAIT`, then puts a second item and expects the reader's first `k_lifo_get()` to return the second (newest) item. This relies on both puts completing before the reader runs, which is only guaranteed on a uniprocessor: the creating (cooperative) thread cannot be preempted by the `PREEMPT(0)` reader until it blocks. On SMP the reader can be scheduled on another CPU the instant it is readied and can call k_lifo_get() between the two puts, retrieving `lifo_data[0]` and failing the assertion.

This is the same uniprocessor-scheduling assumption that commit d1200d215533 ("tests: Never disable SMP") already flagged for this file's sibling tests (`test_lifo_wait`, `test_timeout_empty_lifo`, `test_timeout_lifo_thread`, `test_timeout_threads_pend_on_lifo`), all of which were moved to the 1cpu suite. Move `test_lifo_nowait` also to the 1cpu suite to complete that triage.
