### PR TITLE
drivers: clock_control: stm32: Fix h7, mp13 and f4 clock bugs

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -748,9 +748,9 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 		}
 #else /* CONFIG_SOC_SERIES_STM32H7RSX */
 		if (IS_ENABLED(STM32_TIMER_PRESCALER)) {
-			*rate = STM32_D2PPRE2 <= 4 ? ahb_clock : apb1_clock * 4;
+			*rate = STM32_D2PPRE2 <= 4 ? ahb_clock : apb2_clock * 4;
 		} else {
-			*rate = STM32_D2PPRE2 <= 2 ? ahb_clock : apb1_clock * 2;
+			*rate = STM32_D2PPRE2 <= 2 ? ahb_clock : apb2_clock * 2;
 		}
 #endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 		break;

--- a/drivers/clock_control/clock_stm32_ll_mp13.c
+++ b/drivers/clock_control/clock_stm32_ll_mp13.c
@@ -142,7 +142,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *dev,
 	case STM32_CLOCK_BUS_APB2:
 		switch (pclken->enr) {
 		case LL_APB2_GRP1_PERIPH_SPI1:
-			*rate = LL_RCC_GetUARTClockFreq(LL_RCC_SPI1_CLKSOURCE);
+			*rate = LL_RCC_GetSPIClockFreq(LL_RCC_SPI1_CLKSOURCE);
 			break;
 		default:
 			return -ENOTSUP;

--- a/drivers/clock_control/clock_stm32f2_f4_f7.c
+++ b/drivers/clock_control/clock_stm32f2_f4_f7.c
@@ -155,7 +155,7 @@ void config_pll_sysclock(void)
 	LL_RCC_PLL_ConfigDomain_SAI(get_pll_source(),
 				    pllm(STM32_PLL_M_DIVISOR),
 				    STM32_PLL_N_MULTIPLIER,
-				    pllr(STM32_PLL_R_DIVISOR)
+				    pllr(STM32_PLL_R_DIVISOR),
 				    plldivr(STM32_PLL_POST_R_DIVISOR));
 #elif defined(RCC_PLLR_I2S_CLKSOURCE_SUPPORT) /* RCC_DCKCFGR_PLLDIVR */
 	/* STM32F410 / F412 / F446 */


### PR DESCRIPTION
- **drivers: clock_control: stm32h7: Fix TIMPCLK2 base clock** — The APB2 timer clock computed its rate from apb1_clock while testing the APB2 prescaler, so APB2 timers reported APB1's frequency whenever the prescaler exceeded the threshold. Use apb2_clock, as the H7RS branch and every sibling series driver do.
- **drivers: clock_control: stm32mp13: Use SPI clock getter for SPI1** — The SPI1 rate query passed an SPI clock-source selector to LL_RCC_GetUARTClockFreq(), returning a bogus frequency. Call LL_RCC_GetSPIClockFreq() like the other SPI cases and the mp1/mp2 drivers.
- **drivers: clock_control: stm32f4: Fix missing comma in PLL SAI config** — The STM32F413/F423 PLL configuration merged the R divider and post-R divider into one macro argument due to a missing comma, so LL_RCC_PLL_ConfigDomain_SAI() received four arguments instead of five and the branch did not compile when selected.