### PR TITLE
drivers: spi: psoc6: Fix chip-select bounds check

### DIFF
--- a/drivers/spi/spi_psoc6.c
+++ b/drivers/spi/spi_psoc6.c
@@ -232,7 +232,7 @@ static int spi_psoc6_configure(const struct device *dev,
 	if (SPI_OP_MODE_GET(spi_cfg->operation) == SPI_OP_MODE_MASTER) {
 		spi_psoc6_master_get_defaults(&data->cfg);
 
-		if (spi_cfg->slave > SPI_CHIP_SELECT_COUNT) {
+		if (spi_cfg->slave >= SPI_CHIP_SELECT_COUNT) {
 			LOG_ERR("Slave %d is greater than %d",
 				spi_cfg->slave, SPI_CHIP_SELECT_COUNT);
 			return -EINVAL;

--- a/drivers/spi/spi_psoc6.c
+++ b/drivers/spi/spi_psoc6.c
@@ -232,8 +232,8 @@ static int spi_psoc6_configure(const struct device *dev,
 	if (SPI_OP_MODE_GET(spi_cfg->operation) == SPI_OP_MODE_MASTER) {
 		spi_psoc6_master_get_defaults(&data->cfg);
 
-		if (spi_cfg->slave > SPI_CHIP_SELECT_COUNT) {
-			LOG_ERR("Slave %d is greater than %d",
+		if (spi_cfg->slave >= SPI_CHIP_SELECT_COUNT) {
+			LOG_ERR("Slave %d is greater than or equal to %d",
 				spi_cfg->slave, SPI_CHIP_SELECT_COUNT);
 			return -EINVAL;
 		}


### PR DESCRIPTION
Valid slave selects are 0 to SPI_CHIP_SELECT_COUNT - 1, but the guard
used '>', letting slave 4 through to
Cy_SCB_SPI_SetActiveSlaveSelect(). Use '>='.