### PR TITLE
drivers: spi: gd32: Fix TX data load for 16-bit frames

### DIFF
--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -212,7 +212,7 @@ static int spi_gd32_frame_exchange(const struct device *dev)
 		spi_context_update_tx(ctx, 1, 1);
 	} else {
 		if (spi_context_tx_buf_on(ctx)) {
-			tx_frame = UNALIGNED_GET((uint8_t *)(data->ctx.tx_buf));
+			tx_frame = UNALIGNED_GET((uint16_t *)(data->ctx.tx_buf));
 		}
 		SPI_DATA(cfg->reg) = tx_frame;
 


### PR DESCRIPTION
The 16-bit branch of spi_gd32_frame_exchange() read the TX buffer
through a uint8_t pointer, copied from the 8-bit branch, so the high
byte of every 16-bit frame was transmitted as zero. Read a full
16-bit word, matching the RX side.