### PR TITLE
drivers: intc: nxp_pint: Fix pin bounds checks

### DIFF
--- a/drivers/interrupt_controller/intc_nxp_pint.c
+++ b/drivers/interrupt_controller/intc_nxp_pint.c
@@ -115,7 +115,7 @@ void nxp_pint_pin_disable(uint8_t pin)
 {
 	uint8_t slot;
 
-	if (pin > ARRAY_SIZE(pin_pint_id)) {
+	if (pin >= ARRAY_SIZE(pin_pint_id)) {
 		return;
 	}
 
@@ -142,7 +142,7 @@ int nxp_pint_pin_set_callback(uint8_t pin, nxp_pint_cb_t cb, void *data)
 {
 	uint8_t slot;
 
-	if (pin > ARRAY_SIZE(pin_pint_id)) {
+	if (pin >= ARRAY_SIZE(pin_pint_id)) {
 		return -EINVAL;
 	}
 
@@ -165,7 +165,7 @@ void nxp_pint_pin_unset_callback(uint8_t pin)
 {
 	uint8_t slot;
 
-	if (pin > ARRAY_SIZE(pin_pint_id)) {
+	if (pin >= ARRAY_SIZE(pin_pint_id)) {
 		return;
 	}
 
@@ -181,7 +181,7 @@ int nxp_pint_pin_get_slot_index(uint8_t pin)
 {
 	int slot;
 
-	if (pin > ARRAY_SIZE(pin_pint_id)) {
+	if (pin >= ARRAY_SIZE(pin_pint_id)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Four functions validated the pin index with '>' against
ARRAY_SIZE(pin_pint_id), letting pin == ARRAY_SIZE read one element
past the end of the array. Use '>=', matching nxp_pint_pin_enable().