### PR TITLE
drivers: intc: intel_vtd: Fix delivery mode selection

### DIFF
--- a/drivers/interrupt_controller/intc_intel_vtd.c
+++ b/drivers/interrupt_controller/intc_intel_vtd.c
@@ -369,7 +369,7 @@ static int vtd_ictl_remap(const struct device *dev,
 	}
 
 	delivery_mode = (flags & IOAPIC_DELIVERY_MODE_MASK);
-	if ((delivery_mode != IOAPIC_FIXED) ||
+	if ((delivery_mode != IOAPIC_FIXED) &&
 	    (delivery_mode != IOAPIC_LOW)) {
 		delivery_mode = IOAPIC_LOW;
 	}


### PR DESCRIPTION
The fallback condition used ||, which is always true for two different
constants, so every interrupt was forced to IOAPIC_LOW delivery and a
requested IOAPIC_FIXED mode was discarded. Use &&.