### PR TITLE
drivers: spi: smartbond: Pass device to PM lock release in ISR

### DIFF
--- a/drivers/spi/spi_smartbond.c
+++ b/drivers/spi/spi_smartbond.c
@@ -676,7 +676,7 @@ static void spi_smartbond_isr(void *args)
 		spi_context_complete(ctx, dev, 0);
 
 		spi_context_cs_control(ctx, false);
-		spi_smartbond_pm_policy_state_lock_put(data);
+		spi_smartbond_pm_policy_state_lock_put(dev);
 	}
 #endif
 }


### PR DESCRIPTION
The async completion path handed the driver data pointer to
spi_smartbond_pm_policy_state_lock_put(), which expects the device and
forwards it to pm_device_runtime_put(). Pass dev, as every other call
site does.