### PR TITLE
drivers: clock_control: npcm: Fix clock-change polling

### DIFF
--- a/drivers/clock_control/clock_control_npcm.c
+++ b/drivers/clock_control/clock_control_npcm.c
@@ -343,7 +343,7 @@ static int npcm_clock_control_init(const struct device *dev)
 		/* Load M and N values into the frequency multiplier */
 		priv->hfcgctrl |= BIT(NPCM_HFCGCTRL_LOAD);
 		/* Wait for stable */
-		while (sys_test_bit(priv->hfcgctrl, NPCM_HFCGCTRL_CLK_CHNG)) {
+		while (IS_BIT_SET(priv->hfcgctrl, NPCM_HFCGCTRL_CLK_CHNG)) {
 		}
 	}
 


### PR DESCRIPTION
The wait loop passed the HFCGCTRL register value to sys_test_bit(),
which expects a memory address, so the loop read from a wild address
instead of testing the CLK_CHNG bit. Test the register value with
IS_BIT_SET, as the npcx driver does.