### PR TITLE
drivers: clock_control: alif: Convert source field width to a mask

### DIFF
--- a/drivers/clock_control/clock_control_alif.c
+++ b/drivers/clock_control/clock_control_alif.c
@@ -253,7 +253,7 @@ static int alif_clock_control_on(const struct device *dev,
 	 */
 	if (ALIF_CLOCK_CFG_SRC_FIELD_WIDTH(clk_id)) {
 		uint32_t src_bit = ALIF_CLOCK_CFG_SRC_FIELD_POS(clk_id);
-		uint32_t src_mask = ALIF_CLOCK_CFG_SRC_FIELD_WIDTH(clk_id);
+		uint32_t src_mask = BIT_MASK(ALIF_CLOCK_CFG_SRC_FIELD_WIDTH(clk_id));
 		uint32_t src_value = ALIF_CLOCK_CFG_SRC_VAL(clk_id);
 
 		/* Clear and set source bits */


### PR DESCRIPTION
The clock source mux update used the encoded field width (in bits)
directly as the clear mask, so only part of a multi-bit source field
was cleared and stale select bits could survive. Convert the width to
a bit mask with BIT_MASK().