### PR TITLE
drivers: clock_control: rza2m: Return an error for invalid dividers

### DIFF
--- a/drivers/clock_control/clock_control_renesas_rza2m_cpg_lld.c
+++ b/drivers/clock_control/clock_control_renesas_rza2m_cpg_lld.c
@@ -336,7 +336,7 @@ int rza2m_cpg_set_sub_clock_divider(const struct device *dev, enum rza2m_cp_sub_
 	case 0x333: /* "VALID":do nothing, fall through */
 		break;
 	default:
-		return !EINVAL;
+		return -EINVAL;
 	}
 
 	/* Update local divisor variables based on the clock type */


### PR DESCRIPTION
The invalid divider-combination path returned !EINVAL, which is 0, so
rejected FRQCR combinations were reported as success without
programming the register. Return -EINVAL.