### PR TITLE
drivers: clock_control: numicro_m4: Fix LXT and PLL stabilization

### DIFF
--- a/drivers/clock_control/clock_control_numicro_m4_scc.c
+++ b/drivers/clock_control/clock_control_numicro_m4_scc.c
@@ -431,7 +431,7 @@ static int numicro_scc_init(const struct device *dev)
 
 	if (DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(clk_lxt))) {
 		ret = numicro_scc_start_clock_source(config, CLK_PWRCTL_LXTEN_Pos,
-						     CLK_PWRCTL_HIRCEN_Pos);
+						     CLK_STATUS_LXTSTB_Pos);
 		if (ret < 0) {
 			LOG_WRN("Failed to get LXT stable");
 		}

--- a/drivers/clock_control/clock_control_numicro_m4_scc.c
+++ b/drivers/clock_control/clock_control_numicro_m4_scc.c
@@ -335,7 +335,7 @@ static uint32_t numicro_scc_set_pll_freq(const struct numicro_scc_config *config
 			       (min_nr - 1UL) << CLK_PLLCTL_INDIV_Pos | (min_nf - 2UL);
 
 	/* Wait for PLL clock stable */
-	while (config->regs->STATUS & CLK_STATUS_PLLSTB_Msk) {
+	while ((config->regs->STATUS & CLK_STATUS_PLLSTB_Msk) == 0) {
 	}
 
 	/* Actual PLL output clock frequency */


### PR DESCRIPTION
- **drivers: clock_control: numicro_m4: Poll LXT stability on the right bit** — Starting the LXT passed the PWRCTL HIRC enable bit position as the STATUS bit to poll, so LXT readiness was judged from an unrelated bit. Pass CLK_STATUS_LXTSTB_Pos, matching the HXT and LIRC calls.
- **drivers: clock_control: numicro_m4: Fix inverted PLL stable wait** — The wait loop after enabling the PLL spun while the stable bit was set, so it exited immediately while the PLL was still locking. Wait until the stable bit becomes set.