### PR TITLE
drivers: intc: mtk_adsp: Fix enable state query

### DIFF
--- a/drivers/interrupt_controller/intc_mtk_adsp.c
+++ b/drivers/interrupt_controller/intc_mtk_adsp.c
@@ -18,7 +18,7 @@ bool intc_mtk_adsp_get_enable(const struct device *dev, int irq)
 {
 	const struct intc_mtk_cfg *cfg = dev->config;
 
-	return (*cfg->enable_reg | (BIT(irq) & cfg->irq_mask)) != 0;
+	return (*cfg->enable_reg & BIT(irq) & cfg->irq_mask) != 0;
 }
 
 void intc_mtk_adsp_set_enable(const struct device *dev, int irq, bool val)


### PR DESCRIPTION
intc_mtk_adsp_get_enable() OR-ed the enable register with the IRQ bit, returning true whenever any interrupt in the block was enabled. AND the register with the requested IRQ bit instead.