### PR TITLE
drivers: pinctrl: emsdp: Fix UART_B mux selection for PMOD B

### DIFF
--- a/drivers/pinctrl/pinctrl_emsdp.c
+++ b/drivers/pinctrl/pinctrl_emsdp.c
@@ -158,7 +158,7 @@ static int pinctrl_emsdp_set(uint32_t pin, uint32_t type)
 			reg |= PM_B_CFG0_UART2a;
 			break;
 		case PMOD_UARTB:
-			reg |= PM_A_CFG0_UART1b;
+			reg |= PM_B_CFG0_UART2b;
 			break;
 		case PMOD_SPI:
 			reg |= PM_B_CFG0_SPI;


### PR DESCRIPTION
The PMOD_B UARTB case OR-ed PM_A_CFG0_UART1b, which shifts into the
PMOD A mux field, so PMOD B was left unprogrammed and PMOD A's
setting was corrupted. Use PM_B_CFG0_UART2b, the otherwise unused
constant defined for this case.