### PR TITLE
drivers: pinctrl: aesc: Fix pin index bounds check

### DIFF
--- a/drivers/pinctrl/pinctrl_aesc.c
+++ b/drivers/pinctrl/pinctrl_aesc.c
@@ -40,7 +40,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 	struct pinctrl_aesc_data *data = DEV_DATA(dev);
 
 	for (uint8_t i = 0; i < pin_cnt; i++) {
-		if (pins[i].pin > AESC_PINCTRL_MAX_PINS) {
+		if (pins[i].pin >= AESC_PINCTRL_MAX_PINS) {
 			LOG_ERR("Pin index %u out of range", pins[i].pin);
 			return -EINVAL;
 		}


### PR DESCRIPTION
AESC_PINCTRL_MAX_PINS is the pin count, so valid indices are
0 to MAX_PINS - 1, but the guard used '>', letting pin 128 write one
register past the pin mux range. Use '>='.