### PR TITLE
drivers: pinctrl: numicro: Fix DINOFF read-modify-write

### DIFF
--- a/drivers/pinctrl/pinctrl_numicro.c
+++ b/drivers/pinctrl/pinctrl_numicro.c
@@ -76,7 +76,7 @@ static int gpio_configure(const pinctrl_soc_pin_t *pin)
 		     ((pin->input_debounce ? 1 : 0) << pin_idx);
 	port->SMTEN = (port->SMTEN & ~BIT(pin_idx)) |
 		      ((pin->schmitt_trigger ? 1 : 0) << pin_idx);
-	port->DINOFF = (port->SMTEN & ~DINOFF_MASK(pin_idx)) |
+	port->DINOFF = (port->DINOFF & ~DINOFF_MASK(pin_idx)) |
 		       ((pin->input_disable ? 1 : 0) << DINOFF_PIN_SHIFT(pin_idx));
 	port->PUSEL = (port->PUSEL & ~PUSEL_MASK(pin_idx)) |
 		      (bias << PUSEL_PIN_SHIFT(pin_idx));


### PR DESCRIPTION
The DINOFF update read back SMTEN instead of DINOFF, so the write
seeded the input-disable register from Schmitt-trigger state and
destroyed the other pins' DINOFF bits. Read DINOFF, matching every
other read-modify-write in the function.