### PR TITLE
drivers: pinctrl: rza2m: Fix POC0/POCSEL0 clear mask

### DIFF
--- a/drivers/pinctrl/renesas/rz/pinctrl_renesas_rza2m.c
+++ b/drivers/pinctrl/renesas/rz/pinctrl_renesas_rza2m.c
@@ -231,7 +231,7 @@ static int rza2m_set_ppoc(const pinctrl_soc_pin_t pin)
 
 		/* Set POC0 and POCSEL0 */
 		reg_32 = sys_read32(RZA2M_PPOC);
-		reg_32 &= ~(RZA2M_PPOC_POC0 & RZA2M_PPOC_POCSEL0);
+		reg_32 &= ~(RZA2M_PPOC_POC0 | RZA2M_PPOC_POCSEL0);
 		reg_32 |= ppoc_val;
 		sys_write32(reg_32, RZA2M_PPOC);
 


### PR DESCRIPTION
The PIN_POSEL case AND-ed the two disjoint bit masks, producing 0, so
the old POC0/POCSEL0 values were never cleared and could not be set
back to zero. OR the masks, matching the POC2/POC3 cases.