### PR TITLE
drivers: pinctrl: mci_io_mux: Fix GPIO group boundary

### DIFF
--- a/drivers/pinctrl/pinctrl_mci_io_mux.c
+++ b/drivers/pinctrl/pinctrl_mci_io_mux.c
@@ -158,7 +158,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			mci_iomux->S_GPIO |= (0x1 << (gpio_idx - 32));
 			break;
 		case IOMUX_GPIO:
-			if (gpio_idx > 32) {
+			if (gpio_idx >= 32) {
 				mci_iomux->GPIO_GRP1 |= (0x1 << (gpio_idx - 32));
 			} else {
 				mci_iomux->GPIO_GRP0 |= (0x1 << gpio_idx);


### PR DESCRIPTION
GPIO index 32 belongs to GPIO_GRP1 bit 0, but the split used '> 32',
sending index 32 into a 32-bit shift on GPIO_GRP0 instead. Use '>=',
consistent with the gpio_idx - 32 addressing used for the high group.