### PR TITLE
drivers: pinctrl: mchp_port_g1: Clear OUT latch for pull-down

### DIFF
--- a/drivers/pinctrl/pinctrl_mchp_port_g1.c
+++ b/drivers/pinctrl/pinctrl_mchp_port_g1.c
@@ -118,6 +118,9 @@ static void pinctrl_set_flags(const pinctrl_soc_pin_t *pin)
 				 * set the corresponding bit in PORT_OUT reg
 				 */
 				pRegister->PORT_OUT |= (1 << pin_num);
+			} else {
+				/* Pull-down: drive the OUT latch low */
+				pRegister->PORT_OUT &= ~(1 << pin_num);
 			}
 			pRegister->PORT_PINCFG[pin_num] |= PORT_PINCFG_PULLEN(1);
 		} else {


### PR DESCRIPTION
With PULLEN set, the PORT_OUT bit selects the pull direction. The
pull-down path never cleared a previously set OUT bit, so a requested
pull-down could configure a pull-up instead. Clear the latch in the
pull-down case, as the gpio_mchp_port_g1 driver does.