### PR TITLE
drivers: pinctrl: wch_00x_afio: Fix output speed programming

### DIFF
--- a/drivers/pinctrl/pinctrl_wch_00x_afio.c
+++ b/drivers/pinctrl/pinctrl_wch_00x_afio.c
@@ -32,7 +32,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 		uint8_t cfg = 0;
 
 		if (pins->output_high || pins->output_low) {
-			cfg |= BIT(0);
+			cfg |= (pins->slew_rate + 1);
 			if (pins->drive_open_drain) {
 				cfg |= BIT(2);
 			}

--- a/dts/bindings/pinctrl/wch,00x-afio.yaml
+++ b/dts/bindings/pinctrl/wch,00x-afio.yaml
@@ -40,6 +40,8 @@ child-binding:
         type: string
         default: "max-speed-30mhz"
         enum:
+          - "max-speed-10mhz"
+          - "max-speed-2mhz"
           - "max-speed-30mhz"
 
       pinmux:


### PR DESCRIPTION
The binding documents slew-rate with max-speed-30mhz as its only value and default, but the driver hardcoded the MODE field to 0b01, which is 10 MHz, so every output ran at a third of the documented speed. Derive MODE from the configured slew rate as the wch_afio and wch_20x_30x_afio drivers do, and extend the binding enum to the three speeds the hardware supports, keeping max-speed-30mhz as the default.
