### PR TITLE
tests: kernel: mbox_usage: move test_msg_receiver to 1cpu

### DIFF
--- a/tests/kernel/mbox/mbox_usage/src/main.c
+++ b/tests/kernel/mbox/mbox_usage/src/main.c
@@ -113,7 +113,7 @@ static void test_send(void *p1, void *p2, void *p3)
  * @see k_mbox_get()
  * @see k_mbox_put()
  */
-ZTEST(mbox_usage, test_msg_receiver)
+ZTEST(mbox_usage_1cpu, test_msg_receiver)
 {
 	static k_tid_t tid;
 


### PR DESCRIPTION
### Background

It was noted that test_msg_receiver started failing on `fvp_base_revc_2xaem/v8a_aarch32/smp` (a new SMP target proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112775) target after commit 0933252 ("kernel: smp: ipi: do not drain self bit in signal_pending_ipi()"). Further analysis showed that the IPI fix changed the timing on the receiving CPU - the calling CPU's own pending bit is now retained, adding latency between `k_thread_create()` and the `k_mbox_get()` - which made this latent bug reachable.

```
west twister -p fvp_base_revc_2xaem/v8a_aarch32/smp -s kernel.mailbox.usage

START - test_msg_receiver
    Assertion failed at WEST_TOPDIR/zephyr/tests/kernel/mbox/mbox_usage/src/main.c:47: msg_sender: (ret is non-zero)
k_mbox_put() failed, ret -35
 FAIL - test_msg_receiver in 0.001 seconds
```

### Analysis and fix

`test_msg_receiver` starts a `K_NO_WAIT` sender thread and then does a timed receive, expecting the send to succeed. `test_send` calls `k_mbox_put()` with `K_NO_WAIT`. A synchronous mailbox put with `K_NO_WAIT` returns `-ENOMSG` when no receiver is pending, so the test only passes if the receiver blocks in `k_mbox_get()` before the sender runs. That ordering is only guaranteed on a uniprocessor: the newly readied `PREEMPT(0)` sender cannot run until the creating thread blocks in `k_mbox_get()`, so the receiver always pends first. On SMP the sender is scheduled on another CPU the instant it is readied and can call `k_mbox_put()` before the receiver pends. The put then finds no waiter, returns `-ENOMSG` and fails the assertion.

Move `test_msg_receiver` to the existing `mbox_usage_1cpu` suite to restore that ordering guarantee. `test_msg_receiver_unlimited` is left in the SMP suite as it uses `K_FOREVER` on both the put and the get, so the blocking put waits for the receiver regardless of scheduling order. `test_msg_receiver` relies on a non-blocking put and genuinely needs 1cpu.