### PR TITLE
drivers: sensor: sb_tsi: Fix channel check in emulator set_channel

### DIFF
--- a/drivers/sensor/amd_sb_tsi/sb_tsi_emul.c
+++ b/drivers/sensor/amd_sb_tsi/sb_tsi_emul.c
@@ -107,7 +107,7 @@ static int sb_tsi_emul_set_channel(const struct emul *target, struct sensor_chan
 	int32_t millicelsius;
 	int32_t reg_value;
 
-	if (ch.chan_type != SENSOR_CHAN_AMBIENT_TEMP && ch.chan_idx != 0) {
+	if (ch.chan_type != SENSOR_CHAN_AMBIENT_TEMP || ch.chan_idx != 0) {
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
The channel guard combined its checks with &&, accepting any channel
type with index 0. Use ||, matching sb_tsi_emul_get_sample_range().