### PR TITLE
drivers: gpio: mcux_rgpio: Fix pinmux copy size

### DIFF
--- a/drivers/gpio/gpio_mcux_rgpio.c
+++ b/drivers/gpio/gpio_mcux_rgpio.c
@@ -156,7 +156,7 @@ static int mcux_rgpio_configure(const struct device *dev,
 	}
 #endif
 
-	memcpy(&pin_cfg.pinmux, &config->pin_muxes[cfg_idx], sizeof(pin_cfg));
+	memcpy(&pin_cfg.pinmux, &config->pin_muxes[cfg_idx], sizeof(pin_cfg.pinmux));
 	/* cfg register will be set by pinctrl_configure_pins */
 	pin_cfg.pin_ctrl_flags = reg;
 	pinctrl_configure_pins(&pin_cfg, 1, PINCTRL_REG_NONE);


### PR DESCRIPTION
The memcpy used sizeof(pin_cfg), reading a whole pinctrl_soc_pin from
a single pinmux array element and past the end for the last pin. Use
sizeof(pin_cfg.pinmux).