### PR TITLE
drivers: serial: uart_max32: Fix RX DMA direction and flow-control lookup

### DIFF
--- a/drivers/serial/uart_max32.c
+++ b/drivers/serial/uart_max32.c
@@ -1220,7 +1220,7 @@ static DEVICE_API(uart, uart_max32_driver_api) = {
 		.uart_conf.data_bits = DT_INST_ENUM_IDX(_num, data_bits),                          \
 		.uart_conf.stop_bits = DT_INST_ENUM_IDX(_num, stop_bits),                          \
 		.uart_conf.flow_ctrl =                                                             \
-			DT_INST_PROP_OR(index, hw_flow_control, UART_CFG_FLOW_CTRL_NONE),          \
+			DT_INST_PROP_OR(_num, hw_flow_control, UART_CFG_FLOW_CTRL_NONE),           \
 		MAX32_UART_DMA_INIT(_num) IF_ENABLED(                                              \
 			MAX32_UART_USE_IRQ, (.irq_config_func = uart_max32_irq_init_##_num,))};    \
 	static struct max32_uart_data max32_uart_data##_num = {                                    \

--- a/drivers/serial/uart_max32.c
+++ b/drivers/serial/uart_max32.c
@@ -899,7 +899,7 @@ static int api_rx_enable(const struct device *dev, uint8_t *buf, size_t len, int
 	data->async.rx.buf = buf;
 	data->async.rx.len = len;
 
-	dma_cfg.channel_direction = MEMORY_TO_PERIPHERAL;
+	dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
 	dma_cfg.dma_callback = uart_max32_async_rx_callback;
 	dma_cfg.user_data = (void *)dev;
 	dma_cfg.dma_slot = config->rx_dma.slot;


### PR DESCRIPTION
- **drivers: serial: uart_max32: Fix RX DMA transfer direction** — api_rx_enable() configured the RX channel as MEMORY_TO_PERIPHERAL, copied from the TX path. Use PERIPHERAL_TO_MEMORY.
- **drivers: serial: uart_max32: Fix hw-flow-control property lookup** — The init macro read the property with DT_INST_PROP_OR(index, ...) instead of the _num macro parameter, so devicetree flow control was always ignored.