### PR TITLE
drivers: adc: ads1112: Fix PGA gain mapping

### DIFF
--- a/drivers/adc/adc_ads1112.c
+++ b/drivers/adc/adc_ads1112.c
@@ -229,10 +229,10 @@ static int ads1112_channel_setup(const struct device *dev,
 	case ADC_GAIN_2:
 		config |= ADS1112_CONFIG_GAIN(ADS1112_CONFIG_GAIN_2);
 		break;
-	case ADC_GAIN_3:
+	case ADC_GAIN_4:
 		config |= ADS1112_CONFIG_GAIN(ADS1112_CONFIG_GAIN_4);
 		break;
-	case ADC_GAIN_4:
+	case ADC_GAIN_8:
 		config |= ADS1112_CONFIG_GAIN(ADS1112_CONFIG_GAIN_8);
 		break;
 	default:


### PR DESCRIPTION
The gain switch mapped ADC_GAIN_3 to hardware gain 4 and ADC_GAIN_4 to gain 8, so requesting gain 4 configured gain 8 and the supported gain 8 was rejected. Map ADC_GAIN_4 and ADC_GAIN_8 to their matching PGA settings and drop the unsupported ADC_GAIN_3.

Worth noting how the commit originally introducing this driver mentions "Higher gains were not tested [...]"