### PR TITLE
drivers: adc: ambiq: Validate buffer size with the real channel count

### DIFF
--- a/drivers/adc/adc_ambiq.c
+++ b/drivers/adc/adc_ambiq.c
@@ -234,12 +234,13 @@ static int adc_ambiq_start_read(const struct device *dev, const struct adc_seque
 		return -EINVAL;
 	}
 
+	active_channels = POPCOUNT(sequence->channels);
+
 	error = adc_ambiq_check_buffer_size(sequence, active_channels);
 	if (error < 0) {
 		return error;
 	}
 
-	active_channels = POPCOUNT(sequence->channels);
 	if (active_channels > AMBIQ_ADC_SLOT_NUMBER) {
 		LOG_ERR("Too many channels for sequencer. Max: %d", AMBIQ_ADC_SLOT_NUMBER);
 		return -ENOTSUP;


### PR DESCRIPTION
The buffer check ran before active_channels was computed, so it validated against zero required bytes and always passed, letting undersized buffers through. Compute the channel count first.