### PR TITLE
drivers: dac: dac161s997: Return an error on resolution mismatch

### DIFF
--- a/drivers/dac/dac_dac161s997.c
+++ b/drivers/dac/dac_dac161s997.c
@@ -253,7 +253,7 @@ static int dac161s997_init(const struct device *dev)
 	/* Check that DAC_RES bits are all set */
 	if (status.dac_resolution != 0x7) {
 		LOG_ERR("Unexpected DAC resolution value: 0x%02x", status.dac_resolution);
-		return ret;
+		return -EIO;
 	}
 
 	if (config->gpio_errb.port != NULL) {


### PR DESCRIPTION
The init sanity check on the DAC_RES status field logged an error but returned ret, which the preceding successful status read had set to 0, so a failed identity check still reported successful init. Return -EIO.