### PR TITLE
drivers: counter: stm32_rtc: Fix HSE async prescaler macro name

### DIFF
--- a/drivers/counter/counter_stm32_rtc.c
+++ b/drivers/counter/counter_stm32_rtc.c
@@ -876,7 +876,7 @@ static const struct rtc_stm32_config rtc_config = {
 	.sync_prescaler = DT_INST_PROP_OR(0, sync_prescaler, RTC_SYNCPRE),
 #endif /* !CONFIG_SOC_SERIES_STM32F1X */
 #elif DT_INST_CLOCKS_CELL_BY_IDX(0, 1, bus) == STM32_SRC_HSE
-	.async_prescaler = DT_INST_PROP_OR(0, async_prescaler, _HSE_ASYNC_PRESCALER - 1),
+	.async_prescaler = DT_INST_PROP_OR(0, async_prescaler, RTC_HSE_ASYNC_PRESCALER - 1),
 #if !defined(CONFIG_SOC_SERIES_STM32F1X)
 	.sync_prescaler = DT_INST_PROP_OR(0, hse_prescaler, RTC_HSE_SYNC_PRESCALER - 1),
 #endif /* !CONFIG_SOC_SERIES_STM32F1X */


### PR DESCRIPTION
The async-prescaler default referenced _HSE_ASYNC_PRESCALER, a
truncated spelling of RTC_HSE_ASYNC_PRESCALER that is defined
nowhere, breaking the build for HSE-clocked RTC configurations
without the async-prescaler property.