### PR TITLE
drivers: rtc: ds3231: Fix CONV bit position and 12-hour conversion

### DIFF
--- a/drivers/rtc/rtc_ds3231.c
+++ b/drivers/rtc/rtc_ds3231.c
@@ -318,7 +318,7 @@ static int rtc_ds3231_buf_to_rtc_time(const uint8_t *buf, struct rtc_time *timep
 
 		hour &= ~DS3231_BITS_TIME_12HR;
 		hour &= ~DS3231_BITS_TIME_PM;
-		timeptr->tm_hour = bcd2bin(hour + 12 * pm);
+		timeptr->tm_hour = bcd2bin(hour) + 12 * pm;
 	} else {
 		timeptr->tm_hour = bcd2bin(hour);
 	}

--- a/drivers/rtc/rtc_ds3231.h
+++ b/drivers/rtc/rtc_ds3231.h
@@ -72,7 +72,7 @@
  *  A user-initiated temperature conversion
  *  does not affect the internal 64-second update cycle.
  */
-#define DS3231_BITS_CTRL_CONV BIT(6)
+#define DS3231_BITS_CTRL_CONV BIT(5)
 
 /* Rate selectors */
 /* RS2 | RS1 | SQW FREQ


### PR DESCRIPTION
- **drivers: rtc: ds3231: Fix CONV control bit position** — DS3231_BITS_CTRL_CONV was defined as BIT(6), colliding with BBSQW; the temperature-conversion bit is bit 5 in the control register, as the RS2/RS1 positions below it confirm.

<img width="707" height="206" alt="image" src="https://github.com/user-attachments/assets/28678088-083a-4078-830c-4eb469b68292" />

- **drivers: rtc: ds3231: Fix 12-hour time conversion** — The 12-hour read path added decimal 12 to the still-BCD hour value before converting, producing wrong afternoon hours (8 PM decoded as 14). Convert from BCD first, then add the PM offset.