### PR TITLE
drivers: rtc: mc146818: Write "don't-care" to the right alarm registers

### DIFF
--- a/drivers/rtc/rtc_mc146818.c
+++ b/drivers/rtc/rtc_mc146818.c
@@ -321,12 +321,12 @@ static int rtc_mc146818_alarm_set_time(const struct device *dev, uint16_t id, ui
 	if (mask & RTC_ALARM_TIME_MASK_MINUTE) {
 		mfd_mc146818_std_write(config->mfd, RTC_ALARM_MIN, timeptr->tm_min);
 	} else {
-		mfd_mc146818_std_write(config->mfd, RTC_ALARM_SEC, RTC_ALARM_DC);
+		mfd_mc146818_std_write(config->mfd, RTC_ALARM_MIN, RTC_ALARM_DC);
 	}
 	if (mask & RTC_ALARM_TIME_MASK_HOUR) {
 		mfd_mc146818_std_write(config->mfd, RTC_ALARM_HOUR, timeptr->tm_hour);
 	} else {
-		mfd_mc146818_std_write(config->mfd, RTC_ALARM_SEC, RTC_ALARM_DC);
+		mfd_mc146818_std_write(config->mfd, RTC_ALARM_HOUR, RTC_ALARM_DC);
 	}
 
 	mfd_mc146818_std_write(config->mfd, RTC_DATA,


### PR DESCRIPTION
The minute and hour "don't-care" branches both wrote RTC_ALARM_SEC, clobbering the seconds alarm programmed just before and leaving stale minute/hour match values active. Target the minute and hour alarm registers.