### PR TITLE
drivers: rtc: rv8803: Fix weekday alarm readback

### DIFF
--- a/drivers/rtc/rtc_rv8803.c
+++ b/drivers/rtc/rtc_rv8803.c
@@ -572,7 +572,7 @@ static int rv8803_alarm_get_time(const struct device *dev, uint16_t id, uint16_t
 			timeptr->tm_mday = bcd2bin(regs[2] & RV8803_DATE_ALARM_MASK);
 			*mask |= RTC_ALARM_TIME_MASK_MONTHDAY;
 		} else {
-			timeptr->tm_wday = find_lsb_set(regs[2] & RV8803_WEEKDAY_ALARM_MASK);
+			timeptr->tm_wday = rv8803_mask2weekday(regs[2] & RV8803_WEEKDAY_ALARM_MASK);
 			*mask |= RTC_ALARM_TIME_MASK_WEEKDAY;
 		}
 	}


### PR DESCRIPTION
The alarm getter open-coded find_lsb_set on the weekday bitmask
without the -1 index correction, returning the weekday off by one.
Use the rv8803_mask2weekday helper like get_time.