### PR TITLE
drivers: flash: si32: Fix alignment check return values

### DIFF
--- a/drivers/flash/flash_si32.c
+++ b/drivers/flash/flash_si32.c
@@ -56,11 +56,11 @@ static bool flash_si32_valid_range(off_t offset, uint32_t size, bool write)
 
 	if (write) {
 		if ((offset % SOC_NV_FLASH_WRITE_BLOCK_SIZE) != 0) {
-			return -EINVAL;
+			return false;
 		}
 
 		if ((size % SOC_NV_FLASH_WRITE_BLOCK_SIZE) != 0) {
-			return -EINVAL;
+			return false;
 		}
 	}
 


### PR DESCRIPTION
flash_si32_valid_range() returns bool, but the write alignment checks returned -EINVAL, which converts to true and marks
misaligned writes as valid. An odd size then made the write loop read one byte past the source buffer. Return false as the other checks do.