### PR TITLE
drivers: display: renesas_lcdc: Derive HSYNC polarity from hsync-active

### DIFF
--- a/drivers/display/display_renesas_lcdc.c
+++ b/drivers/display/display_renesas_lcdc.c
@@ -654,7 +654,7 @@ static DEVICE_API(display, display_smartbond_driver_api) = {
 		.mode.vsync_pol =	\
 			DT_PROP(DT_INST_CHILD(inst, display_timings), vsync_active) ? 0 : 1,	\
 		.mode.hsync_pol =	\
-			DT_PROP(DT_INST_CHILD(inst, display_timings), vsync_active) ? 0 : 1,	\
+			DT_PROP(DT_INST_CHILD(inst, display_timings), hsync_active) ? 0 : 1,	\
 		.mode.de_pol =	\
 			DT_PROP(DT_INST_CHILD(inst, display_timings), de_active) ? 0 : 1,	\
 		.mode.pixelclk_pol =	\


### PR DESCRIPTION
The HSYNC polarity was computed from the vsync-active timing property, a copy-paste from the VSYNC line above, so a panel with different sync polarities got the wrong HSYNC polarity. Use hsync-active.