### PR TITLE
drivers: display: co5300: Send full init command parameters

### DIFF
--- a/drivers/display/display_co5300.c
+++ b/drivers/display/display_co5300.c
@@ -438,7 +438,6 @@ static int co5300_init(const struct device *dev)
 	struct display_cmds lcm_init_settings = {0};
 	uint8_t *ptr_to_cmd_register = 0;
 	uint8_t *ptr_to_last_cmd = 0;
-	uint8_t cmd_params = 0;
 	uint8_t cmd_param_size = 0;
 	uint8_t cmd_register = 0;
 	int ret = 0;
@@ -470,11 +469,10 @@ static int co5300_init(const struct device *dev)
 		 */
 		cmd_register = *ptr_to_cmd_register++;
 		cmd_param_size = *ptr_to_cmd_register++;
-		cmd_params = *ptr_to_cmd_register;
-		ptr_to_cmd_register += cmd_param_size;
 
-		ret = mipi_dsi_dcs_write(config->mipi_dsi, config->channel,
-				cmd_register, &cmd_params, cmd_param_size);
+		ret = mipi_dsi_dcs_write(config->mipi_dsi, config->channel, cmd_register,
+					 ptr_to_cmd_register, cmd_param_size);
+		ptr_to_cmd_register += cmd_param_size;
 		if (ret < 0) {
 			return ret;
 		}


### PR DESCRIPTION
The init sequence parser copied only the first parameter byte into
a local variable but passed the full parameter size to
mipi_dsi_dcs_write(), sending stack garbage for every multi-byte
command such as the column and page address setup. Pass the
parameter bytes straight from the command table.