### PR TITLE
drivers: display: max7219: Store shadow buffer row at loop index

### DIFF
--- a/drivers/display/display_max7219.c
+++ b/drivers/display/display_max7219.c
@@ -193,7 +193,7 @@ static int max7219_write(const struct device *dev, const uint16_t x, const uint1
 			return ret;
 		}
 
-		dev_data->digit_buf[y] = segment;
+		dev_data->digit_buf[py] = segment;
 	}
 
 	return 0;


### PR DESCRIPTION
The write loop read the retained row state from digit_buf[py] but
stored the updated segment back to digit_buf[y], so only the first
row of the shadow buffer was ever updated and later partial writes
merged against stale row data. Store at the loop index.