### PR TITLE
drivers: rtc: nxp_irtc: Fix build with RTC update callbacks

### DIFF
--- a/drivers/rtc/rtc_nxp_irtc.c
+++ b/drivers/rtc/rtc_nxp_irtc.c
@@ -327,7 +327,7 @@ static int nxp_irtc_update_set_callback(const struct device *dev, rtc_update_cal
 					void *user_data)
 {
 	ARG_UNUSED(dev);
-	ARG_UNUSED(calibration);
+	ARG_UNUSED(callback);
 	ARG_UNUSED(user_data);
 	return -ENOTSUP;
 }

--- a/tests/drivers/build_all/rtc/tests.yaml
+++ b/tests/drivers/build_all/rtc/tests.yaml
@@ -7,6 +7,9 @@ tests:
   drivers.rtc.build.sf32lb:
     platform_allow:
       - sf32lb52_devkit_lcd
+  drivers.rtc.build.nxp_irtc:
+    platform_allow:
+      - frdm_mcxn947/mcxn947/cpu0
   drivers.rtc.build.pcf8523:
     depends_on:
       - arduino_spi


### PR DESCRIPTION
The update_set_callback stub referenced a nonexistent calibration
parameter, copied from the calibration stubs, breaking the build with
CONFIG_RTC_UPDATE. Reference the actual callback parameter.

Also add test coverage so that issues like this are caught in the future :)