### PR TITLE
drivers: can: xmc4xxx: Read the receive error counter

### DIFF
--- a/drivers/can/can_xmc4xxx.c
+++ b/drivers/can/can_xmc4xxx.c
@@ -453,7 +453,7 @@ static void can_xmc4xxx_get_state_from_status(const struct device *dev, enum can
 	struct can_xmc4xxx_data *dev_data = dev->data;
 	const struct can_xmc4xxx_config *dev_cfg = dev->config;
 	uint8_t tec = XMC_CAN_NODE_GetTransmitErrorCounter(dev_cfg->can);
-	uint8_t rec = XMC_CAN_NODE_GetTransmitErrorCounter(dev_cfg->can);
+	uint8_t rec = XMC_CAN_NODE_GetReceiveErrorCounter(dev_cfg->can);
 
 	if (err_cnt != NULL) {
 		err_cnt->tx_err_cnt = tec;


### PR DESCRIPTION
get_state_from_status() read the transmit error counter into both
tec and rec, so the reported RX error count mirrored the TX count
and the error-passive state could be reported incorrectly. Use the
receive error counter accessor for rec.