### PR TITLE
drivers: watchdog: andes_atcwdt200: Fix overflow in timeout conversion

### DIFF
--- a/drivers/watchdog/wdt_andes_atcwdt200.c
+++ b/drivers/watchdog/wdt_andes_atcwdt200.c
@@ -221,7 +221,7 @@ static uint32_t wdt_atcwdt200_convtime(uint32_t timeout, uint32_t *scaler)
 	int i;
 	uint32_t rst_period, cnt;
 
-	cnt = (uint32_t)((timeout * EXT_CLOCK_FREQ) / 1000);
+	cnt = (uint32_t)(((uint64_t)timeout * EXT_CLOCK_FREQ) / 1000);
 	rst_period = cnt;
 
 	for (i = 0; i < 14 && cnt > 0; i++) {


### PR DESCRIPTION
The millisecond timeout was multiplied by the external clock
frequency in 32-bit arithmetic, overflowing for timeouts above
131 seconds and programming a much shorter period than requested.
Do the conversion in 64-bit.