### PR TITLE
drivers: i3c: Store static address in the allocated descriptor

### DIFF
--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -429,7 +429,7 @@ int i3c_sec_get_basic_info(const struct device *dev, uint8_t dynamic_addr, uint8
 			return -ENOMEM;
 		}
 		desc->pid = id.pid;
-		temp_desc.static_addr = (uint16_t)static_addr;
+		desc->static_addr = (uint16_t)static_addr;
 	}
 	desc->dynamic_addr = dynamic_addr;
 	desc->bcr = bcr;


### PR DESCRIPTION
i3c_sec_get_basic_info() wrote the static address to the temporary
descriptor that is detached and discarded right after, so a device
discovered by a secondary controller lost its static address. Store
it in the descriptor that is actually kept, like the other fields.