### PR TITLE
drivers: i3c: Free the static address after DAA in four controllers

### DIFF
--- a/drivers/i3c/i3c_max32.c
+++ b/drivers/i3c/i3c_max32.c
@@ -1079,7 +1079,7 @@ static int max32_i3c_do_daa(const struct device *dev)
 			 */
 			if ((target->static_addr != 0U) && (dyn_addr != target->static_addr)) {
 				i3c_addr_slots_mark_free(&data->common.attached_dev.addr_slots,
-							 dyn_addr);
+							 target->static_addr);
 			}
 
 			/* Emit process DAA again to send the address to the device */

--- a/drivers/i3c/i3c_mcux.c
+++ b/drivers/i3c/i3c_mcux.c
@@ -1277,7 +1277,7 @@ static int mcux_i3c_do_daa(const struct device *dev)
 			 */
 			if ((target->static_addr != 0U) && (dyn_addr != target->static_addr)) {
 				i3c_addr_slots_mark_free(&data->common.attached_dev.addr_slots,
-							 dyn_addr);
+							 target->static_addr);
 			}
 
 			/* Emit process DAA again to send the address to the device */

--- a/drivers/i3c/i3c_npcx.c
+++ b/drivers/i3c/i3c_npcx.c
@@ -1527,7 +1527,7 @@ static int npcx_i3c_do_daa(const struct device *dev)
 			if ((target != NULL) && (target->static_addr != 0U) &&
 			    (dyn_addr != target->static_addr)) {
 				i3c_addr_slots_mark_free(&data->common.attached_dev.addr_slots,
-							 dyn_addr);
+							 target->static_addr);
 			}
 
 			/* Emit process DAA again to send the address to the device */

--- a/drivers/i3c/i3c_stm32.c
+++ b/drivers/i3c/i3c_stm32.c
@@ -1842,7 +1842,8 @@ static void i3c_stm32_event_isr_tx(const struct device *dev)
 		/* Mark the static address as free */
 		if ((target != NULL) && (target->static_addr != 0) &&
 		    (dyn_addr != target->static_addr)) {
-			i3c_addr_slots_mark_free(&data->drv_data.attached_dev.addr_slots, dyn_addr);
+			i3c_addr_slots_mark_free(&data->drv_data.attached_dev.addr_slots,
+						 target->static_addr);
 		}
 
 		break;


### PR DESCRIPTION
After dynamic address assignment, the newly assigned dynamic address was being freed instead of the device's static address. This undoes the reservation made just above and lets the same dynamic address be handed out to another device.