### PR TITLE
drivers: i2s: mcux_sai: Match status registers with their masks

### DIFF
--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -1097,11 +1097,11 @@ static void i2s_mcux_isr(void *arg)
 	struct device *dev = (struct device *)arg;
 	I2S_Type *base = get_base(dev);
 
-	if ((base->RCSR & I2S_TCSR_FEF_MASK) == I2S_TCSR_FEF_MASK) {
+	if ((base->TCSR & I2S_TCSR_FEF_MASK) == I2S_TCSR_FEF_MASK) {
 		sai_driver_irq(dev);
 	}
 
-	if ((base->TCSR & I2S_RCSR_FEF_MASK) == I2S_RCSR_FEF_MASK) {
+	if ((base->RCSR & I2S_RCSR_FEF_MASK) == I2S_RCSR_FEF_MASK) {
 		sai_driver_irq(dev);
 	}
 	/*


### PR DESCRIPTION
The ISR tested the RX status register against the TX FIFO error mask and vice versa. It works today only because the flag sits at the same offset in both registers; pair each register with its own mask as sai_driver_irq() does.