### PR TITLE
drivers: i2s: nrf_tdm: Check TX buffer prepare result

### DIFF
--- a/drivers/i2s/i2s_nrf_tdm.c
+++ b/drivers/i2s/i2s_nrf_tdm.c
@@ -694,6 +694,10 @@ static int tdm_nrf_write(const struct device *dev, void *mem_block, size_t size)
 
 	ret = dmm_buffer_out_prepare(drv_cfg->mem_reg, buf.mem_block, buf.size,
 				     (void **)&buf.dmm_buf);
+	if (ret < 0) {
+		LOG_ERR("Failed to prepare buffer: %d", ret);
+		return ret;
+	}
 	ret = k_msgq_put(&drv_data->tx_queue, &buf, SYS_TIMEOUT_MS(drv_data->tx.cfg.timeout));
 	if (ret < 0) {
 		return ret;


### PR DESCRIPTION
The return value of dmm_buffer_out_prepare() was immediately overwritten by the queue put, so a failed preparation went
unnoticed and an invalid buffer could be handed to the TDM peripheral. Propagate the error like the RX path does.