### PR TITLE
drivers: i2s: stm32: Fix inverted busy check on non-H7 parts

### DIFF
--- a/drivers/i2s/i2s_stm32.h
+++ b/drivers/i2s/i2s_stm32.h
@@ -71,8 +71,7 @@ static inline uint32_t ll_i2s_dma_busy(SPI_TypeDef *i2s)
 	return LL_SPI_IsActiveFlag_TXC(i2s) == 0;
 #else
 	/* the I2S Tx empty and busy flags are needed */
-	return (LL_SPI_IsActiveFlag_TXE(i2s) &&
-		!LL_SPI_IsActiveFlag_BSY(i2s));
+	return (!LL_SPI_IsActiveFlag_TXE(i2s) || LL_SPI_IsActiveFlag_BSY(i2s));
 #endif
 }
 


### PR DESCRIPTION
ll_i2s_dma_busy() returned true when the transmitter was idle (TX empty and not busy), the opposite of its name, its H7 branch and what both callers expect. A STOP or DRAIN issued mid-transfer disabled the stream immediately, while one issued when idle parked the stream in STOPPING forever. Return the negated expression.