### PR TITLE
drivers: stepper: gpio_step_dir: Fix step interval check for dual edge

### DIFF
--- a/drivers/stepper/gpio_stepper/gpio_step_dir_stepper_ctrl.c
+++ b/drivers/stepper/gpio_stepper/gpio_step_dir_stepper_ctrl.c
@@ -166,7 +166,7 @@ static int gpio_step_dir_stepper_ctrl_set_microstep_interval(const struct device
 		return -EINVAL;
 	}
 
-	if (microstep_interval_ns < 2 * data->step_width_ns) {
+	if (!data->dual_edge && (microstep_interval_ns < 2 * data->step_width_ns)) {
 		LOG_ERR("Step interval too small for configured step width");
 		return -EINVAL;
 	}


### PR DESCRIPTION
The dual-edge minimum interval check was immediately overridden by an unconditional check requiring twice the step width, which only applies to single-edge stepping, so valid dual-edge intervals were rejected. Restrict the stricter check to single-edge mode.