### PR TITLE
drivers: stepper: adi_tmc: Fix stallguard build, VACTUAL sign and rampstat

### DIFF
--- a/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
+++ b/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
@@ -101,10 +101,11 @@ int tmc50xx_read(const struct device *dev, const uint8_t reg_addr, uint32_t *reg
 
 static void log_stallguard(const struct device *dev, const uint32_t drv_status)
 {
+	struct tmc50xx_data *data = dev->data;
 	int32_t position;
 	int err;
 
-	err = tmc50xx_read_actual_position(dev, &position);
+	err = tmc50xx_read_actual_position(dev, data->work_index, &position);
 	if (err != 0) {
 		LOG_ERR("%s: Failed to read XACTUAL register", dev->name);
 		return;

--- a/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
+++ b/drivers/stepper/adi_tmc/tmc50xx/tmc50xx.c
@@ -216,7 +216,7 @@ static void rampstat_work_handler(struct k_work *work)
 	const struct device *dev = data->dev;
 	const struct tmc50xx_config *config = dev->config;
 
-	for (uint8_t i = 0; i < config->num_stepper_drivers; i++) {
+	for (uint8_t i = 0; i < config->num_motion_controllers; i++) {
 		data->work_index = tmc50xx_stepper_ctrl_index(config->motion_controllers[i]);
 		rampstat_work(dev);
 	}

--- a/include/zephyr/drivers/stepper/stepper_trinamic.h
+++ b/include/zephyr/drivers/stepper/stepper_trinamic.h
@@ -31,7 +31,7 @@
 extern "C" {
 #endif
 
-#define TMC_RAMP_VACTUAL_SHIFT  22
+#define TMC_RAMP_VACTUAL_SHIFT  23
 #define TMC_RAMP_XACTUAL_SHIFT  31
 
 /**


### PR DESCRIPTION
- **drivers: stepper: tmc50xx: Fix build with stallguard logging** — log_stallguard() called tmc50xx_read_actual_position() without the motor index argument, breaking the build whenever CONFIG_STEPPER_ADI_TMC50XX_RAMPSTAT_POLL_STALLGUARD_LOG is enabled. Pass the index of the motor being polled.
- **drivers: stepper: adi_tmc: Fix VACTUAL sign bit position** — VACTUAL is a 24-bit signed register field, so its sign bit is bit 23, but the sign extension used bit 22. Any velocity of 2^22 or more, which the VMAX limit explicitly allows, was read back as a large negative value, corrupting velocity readout and the stallguard velocity threshold check.
- **drivers: stepper: tmc50xx: Iterate rampstat over motion controllers** — The rampstat poll loop indexes the motion controller array but was bounded by the stepper driver count, skipping controllers or reading out of bounds when the two child counts differ.