### PR TITLE
drivers: mbox: andes_plic_sw: Fix channel bounds check

### DIFF
--- a/drivers/mbox/mbox_andes_plic_sw.c
+++ b/drivers/mbox/mbox_andes_plic_sw.c
@@ -29,7 +29,7 @@ static inline bool is_channel_valid(const struct device *dev, uint32_t ch)
 {
 	const struct mbox_plic_conf *conf = dev->config;
 
-	return (ch <= conf->channel_max) && conf->irq_sources[ch];
+	return (ch < conf->channel_max) && conf->irq_sources[ch];
 }
 
 static int mbox_plic_send(const struct device *dev, uint32_t ch, const struct mbox_msg *msg)


### PR DESCRIPTION
channel_max holds the channel count, so accepting a channel equal to it read one past the irq_sources array and let callers index the callback arrays out of bounds.

