### PR TITLE
drivers: dma: stm32u5: Fix priority bounds check

### DIFF
--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -336,7 +336,7 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 
 static int dma_stm32_get_priority(uint8_t priority, uint32_t *ll_priority)
 {
-	if (priority > ARRAY_SIZE(table_priority)) {
+	if (priority >= ARRAY_SIZE(table_priority)) {
 		LOG_ERR("Priority error. %d", priority);
 		return -EINVAL;
 	}


### PR DESCRIPTION
A priority equal to the table size passed the check and read one entry past the priority table.