### PR TITLE
misc: SonarQube fixes

### DIFF
--- a/drivers/dma/dma_emul.c
+++ b/drivers/dma/dma_emul.c
@@ -18,9 +18,9 @@
 #define DT_DRV_COMPAT zephyr_dma_emul
 
 #ifdef CONFIG_DMA_64BIT
-#define dma_addr_t uint64_t
+typedef uint64_t dma_addr_t;
 #else
-#define dma_addr_t uint32_t
+typedef uint32_t dma_addr_t;
 #endif
 
 enum dma_emul_channel_state {

--- a/drivers/wifi/hwsim/wifi_hwsim.c
+++ b/drivers/wifi/hwsim/wifi_hwsim.c
@@ -181,7 +181,7 @@ static int hwsim_mgmt_ap_enable(const struct device *dev, struct net_if *iface,
 	struct hwsim_radio *radio = (struct hwsim_radio *)dev->data;
 	struct net_linkaddr *lla = net_if_get_link_addr(iface);
 
-	if (params == NULL || params->ssid == NULL ||
+	if (params == NULL || params->ssid == NULL || lla == NULL ||
 	    params->ssid_length == 0 || params->ssid_length > WIFI_SSID_MAX_LEN) {
 		wifi_mgmt_raise_ap_enable_result_event(radio->iface,
 						       WIFI_STATUS_AP_FAIL);

--- a/tests/drivers/wifi/hwsim/src/main.c
+++ b/tests/drivers/wifi/hwsim/src/main.c
@@ -172,7 +172,7 @@ static bool scan_found_ssid;
 static void scan_result_cb(struct net_mgmt_event_callback *cb, uint64_t event,
 			   struct net_if *iface)
 {
-	struct wifi_scan_result *res = (struct wifi_scan_result *)cb->info;
+	const struct wifi_scan_result *res = cb->info;
 
 	ARG_UNUSED(iface);
 	if (event == NET_EVENT_WIFI_SCAN_RESULT && res != NULL &&

--- a/tests/drivers/wifi/hwsim/src/main.c
+++ b/tests/drivers/wifi/hwsim/src/main.c
@@ -21,7 +21,7 @@ static struct net_if *iface_ap;
 static struct net_if *iface_sta;
 
 static struct wifi_connect_req_params default_ap_params = {
-	.ssid = (uint8_t *)"ZephyrHwsim",
+	.ssid = "ZephyrHwsim",
 	.ssid_length = 10,
 	.channel = 6,
 	.security = WIFI_SECURITY_TYPE_NONE,

--- a/tests/drivers/wifi/hwsim/src/main.c
+++ b/tests/drivers/wifi/hwsim/src/main.c
@@ -35,9 +35,9 @@ static struct wifi_connect_req_params default_ap_params = {
  * associate" a secured connect against a stale scan entry left by the other
  * test on the same (reused) AP BSSID.
  */
-static uint8_t psk_ssid[] = "ZephyrPsk";
-static uint8_t sae_ssid[] = "ZephyrSae";
-static uint8_t secured_psk[] = "ZephyrPass123";
+static const uint8_t psk_ssid[] = "ZephyrPsk";
+static const uint8_t sae_ssid[] = "ZephyrSae";
+static const uint8_t secured_psk[] = "ZephyrPass123";
 
 static struct wifi_connect_req_params wpa2_psk_params = {
 	.ssid = psk_ssid,


### PR DESCRIPTION
- tests: wifi: hwsim: callback info is const
- tests: wifi: hwsim: make strings `const`
- tests: wifi: hwsim: drop unneeded, incorrect cast
- wifi: hwsim: ensure non-NULL `memcpy` arg
- dma: emul: use `typedef` instead of `#define`

Fixes to a random list of SonarQube issues a PR sent me to