### PR TITLE
soc: stm32h5: enable data cache during early boot

### DIFF
--- a/soc/st/stm32/stm32h5x/soc.c
+++ b/soc/st/stm32/stm32h5x/soc.c
@@ -31,6 +31,8 @@ void soc_early_init_hook(void)
 {
 	sys_cache_instr_enable();
 
+	sys_cache_data_enable();
+
 	/* Update CMSIS SystemCoreClock variable (HCLK) */
 	/* At reset, system core clock is set to 32 MHz from HSI with a HSIDIV = 2 */
 	SystemCoreClock = 32000000;


### PR DESCRIPTION
STM32H5 has a hardware data cache (DCACHE1, and DCACHE2 on some part numbers) but unlike other STM32 series its soc_early_init_hook() did not enable it, so the data cache was left disabled by default.

Enable it in soc_early_init_hook(), matching the behavior of the stm32h7/h7rsx/f7/n6 SoCs. Invalidate the whole data cache before enabling to avoid fetching stale tags left from reset.

sys_cache_data_enable() is a no-op when the part has no data cache (e.g. STM32H503, where CPU_HAS_DCACHE is not selected), so this is safe across the whole H5 series.