### PR TITLE
boards: radxa: add ROCK 5B+ support

### DIFF
--- a/boards/firefly/roc_rk3588_pc/roc_rk3588_pc_smp.dts
+++ b/boards/firefly/roc_rk3588_pc/roc_rk3588_pc_smp.dts
@@ -4,3 +4,19 @@
  */
 
 #include "roc_rk3588_pc.dts"
+
+&a76_cpu0 {
+	status = "disabled";
+};
+
+&a76_cpu1 {
+	status = "disabled";
+};
+
+&a76_cpu2 {
+	status = "disabled";
+};
+
+&a76_cpu3 {
+	status = "disabled";
+};

--- a/boards/radxa/rock_5b_plus/Kconfig.rock_5b_plus
+++ b/boards/radxa/rock_5b_plus/Kconfig.rock_5b_plus
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Process Mission
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ROCK_5B_PLUS
+	select SOC_RK3588

--- a/boards/radxa/rock_5b_plus/board.yml
+++ b/boards/radxa/rock_5b_plus/board.yml
@@ -1,0 +1,8 @@
+board:
+  name: rock_5b_plus
+  full_name: ROCK 5B+
+  vendor: radxa
+  socs:
+  - name: rk3588
+    variants:
+    - name: smp

--- a/boards/radxa/rock_5b_plus/doc/index.rst
+++ b/boards/radxa/rock_5b_plus/doc/index.rst
@@ -1,0 +1,84 @@
+.. zephyr:board:: rock_5b_plus
+
+Overview
+********
+
+The Radxa ROCK 5B+ is a single-board computer based on the Rockchip RK3588.
+The SoC combines four Cortex-A76 and four Cortex-A55 CPU cores. The board is
+available with up to 32 GB of LPDDR5 memory and provides eMMC, microSD, PCIe,
+USB, Ethernet, and a 40-pin expansion header.
+
+The SMP variant supports all four Cortex-A55 and four Cortex-A76 cores.
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+The onboard Ethernet interface is not currently supported by Zephyr.
+
+Serial Port
+===========
+
+Zephyr uses UART2 as the serial console at 1.5 Mbit/s.
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
+
+Applications are built with the standard configuration, for example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :host-os: unix
+   :board: rock_5b_plus
+   :goals: build
+
+To run Zephyr on all eight CPU cores, build the SMP variant:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :host-os: unix
+   :board: rock_5b_plus//smp
+   :goals: build
+
+Create a legacy U-Boot image whose payload loads and runs at ``0x10000000``:
+
+.. code-block:: console
+
+   mkimage -C none -A arm64 -O linux -a 0x10000000 -e 0x10000000 \
+     -d build/zephyr/zephyr.bin build/zephyr/zephyr.img
+
+The Radxa U-Boot AArch64 Linux boot path requires a devicetree. Obtain
+``rk3588-rock-5b-plus.dtb`` from the Radxa Linux distribution and copy it and
+``zephyr.img`` to a FAT partition accessible from U-Boot.
+
+Check the temporary kernel and devicetree load addresses provided by U-Boot:
+
+.. code-block:: console
+
+   printenv kernel_addr_r fdt_addr_r
+
+Load each file at its corresponding address, then pass the devicetree address
+to ``bootm``. Adjust the MMC device and partition numbers for the selected boot
+media:
+
+.. code-block:: console
+
+   fatload mmc 1:1 ${kernel_addr_r} zephyr.img
+   fatload mmc 1:1 ${fdt_addr_r} rk3588-rock-5b-plus.dtb
+   bootm ${kernel_addr_r} - ${fdt_addr_r}
+
+The legacy image header instructs U-Boot to move the Zephyr payload from
+``kernel_addr_r`` to ``0x10000000`` before jumping to the entry point. Keeping
+the temporary image, devicetree, and Zephyr runtime regions separate avoids
+overwriting any of them during the handoff.
+
+References
+==========
+
+More information is available from the `Radxa ROCK 5B+ documentation`_.
+
+.. _Radxa ROCK 5B+ documentation:
+   https://docs.radxa.com/en/rock5/rock5b

--- a/boards/radxa/rock_5b_plus/rock_5b_plus.dts
+++ b/boards/radxa/rock_5b_plus/rock_5b_plus.dts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Process Mission
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <arm64/rockchip/rk3588.dtsi>
+#include <common/mem.h>
+
+/ {
+	model = "Radxa ROCK 5B+";
+	compatible = "radxa,rock-5b-plus", "rockchip,rk3588";
+
+	chosen {
+		zephyr,console = &uart2;
+		zephyr,shell-uart = &uart2;
+		zephyr,sram = &dram;
+	};
+
+	dram: memory@10000000 {
+		compatible = "mmio-sram";
+		device_type = "memory";
+		reg = <0x10000000 DT_SIZE_M(128)>;
+	};
+};
+
+&uart2 {
+	status = "okay";
+	current-speed = <1500000>;
+};

--- a/boards/radxa/rock_5b_plus/rock_5b_plus.yaml
+++ b/boards/radxa/rock_5b_plus/rock_5b_plus.yaml
@@ -1,0 +1,8 @@
+identifier: rock_5b_plus
+name: Radxa ROCK 5B+
+type: mcu
+arch: arm64
+toolchain:
+  - zephyr
+  - cross-compile
+ram: 131072

--- a/boards/radxa/rock_5b_plus/rock_5b_plus_defconfig
+++ b/boards/radxa/rock_5b_plus/rock_5b_plus_defconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Process Mission
+# SPDX-License-Identifier: Apache-2.0
+
+# Platform Configuration
+CONFIG_ARM_ARCH_TIMER=y
+
+# Serial Drivers
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# ARMv8 NS world with cache management
+CONFIG_ARMV8_A_NS=y
+CONFIG_CACHE_MANAGEMENT=y
+
+CONFIG_TICKLESS_KERNEL=y

--- a/boards/radxa/rock_5b_plus/rock_5b_plus_smp.dts
+++ b/boards/radxa/rock_5b_plus/rock_5b_plus_smp.dts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Process Mission
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "rock_5b_plus.dts"
+
+&{/cpus} {
+	cpu@400 {
+		device_type = "cpu";
+		compatible = "arm,cortex-a76";
+		enable-method = "psci";
+		reg = <0x400>;
+	};
+
+	cpu@500 {
+		device_type = "cpu";
+		compatible = "arm,cortex-a76";
+		enable-method = "psci";
+		reg = <0x500>;
+	};
+
+	cpu@600 {
+		device_type = "cpu";
+		compatible = "arm,cortex-a76";
+		enable-method = "psci";
+		reg = <0x600>;
+	};
+
+	cpu@700 {
+		device_type = "cpu";
+		compatible = "arm,cortex-a76";
+		enable-method = "psci";
+		reg = <0x700>;
+	};
+};

--- a/boards/radxa/rock_5b_plus/rock_5b_plus_smp.dts
+++ b/boards/radxa/rock_5b_plus/rock_5b_plus_smp.dts
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2026 Process Mission
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "rock_5b_plus.dts"

--- a/boards/radxa/rock_5b_plus/rock_5b_plus_smp.yaml
+++ b/boards/radxa/rock_5b_plus/rock_5b_plus_smp.yaml
@@ -1,0 +1,10 @@
+identifier: rock_5b_plus/rk3588/smp
+name: Radxa ROCK 5B+ SMP
+type: mcu
+arch: arm64
+toolchain:
+  - zephyr
+  - cross-compile
+ram: 131072
+supported:
+  - smp

--- a/boards/radxa/rock_5b_plus/rock_5b_plus_smp_defconfig
+++ b/boards/radxa/rock_5b_plus/rock_5b_plus_smp_defconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Process Mission
+# SPDX-License-Identifier: Apache-2.0
+
+# Platform Configuration
+CONFIG_ARM_ARCH_TIMER=y
+
+# Serial Drivers
+CONFIG_SERIAL=y
+
+# Enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# ARMv8 NS world with cache management
+CONFIG_ARMV8_A_NS=y
+CONFIG_CACHE_MANAGEMENT=y
+
+CONFIG_TICKLESS_KERNEL=y
+
+# SMP support
+CONFIG_SMP=y
+CONFIG_MP_MAX_NUM_CPUS=8
+
+# PSCI support
+CONFIG_PM_CPU_OPS=y

--- a/dts/arm64/rockchip/rk3588.dtsi
+++ b/dts/arm64/rockchip/rk3588.dtsi
@@ -18,7 +18,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		a55_cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-a55";
 			enable-method = "psci";
@@ -26,25 +26,53 @@
 			reg = <0x000>;
 		};
 
-		cpu@100 {
+		a55_cpu1: cpu@100 {
 			device_type = "cpu";
 			compatible = "arm,cortex-a55";
 			enable-method = "psci";
 			reg = <0x100>;
 		};
 
-		cpu@200 {
+		a55_cpu2: cpu@200 {
 			device_type = "cpu";
 			compatible = "arm,cortex-a55";
 			enable-method = "psci";
 			reg = <0x200>;
 		};
 
-		cpu@300 {
+		a55_cpu3: cpu@300 {
 			device_type = "cpu";
 			compatible = "arm,cortex-a55";
 			enable-method = "psci";
 			reg = <0x300>;
+		};
+
+		a76_cpu0: cpu@400 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a76";
+			enable-method = "psci";
+			reg = <0x400>;
+		};
+
+		a76_cpu1: cpu@500 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a76";
+			enable-method = "psci";
+			reg = <0x500>;
+		};
+
+		a76_cpu2: cpu@600 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a76";
+			enable-method = "psci";
+			reg = <0x600>;
+		};
+
+		a76_cpu3: cpu@700 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a76";
+			enable-method = "psci";
+			reg = <0x700>;
 		};
 	};
 

--- a/soc/rockchip/rk35/rk3588/Kconfig
+++ b/soc/rockchip/rk35/rk3588/Kconfig
@@ -3,7 +3,7 @@
 
 config SOC_RK3588
 	select ARM64
-	select CPU_CORTEX_A55
+	select CPU_CORTEX_A76_A55
 	select ARM_ARCH_TIMER
 
 config SOC_PART_NUMBER


### PR DESCRIPTION
## Description

Add initial Zephyr support for the Radxa ROCK 5B+, based on the Rockchip
RK3588 SoC.

The board support provides:

- UART2 console at 1.5 Mbit/s
- ARM architectural timer
- GICv3 interrupt controller
- Cache management
- A 128 MiB Zephyr runtime memory region at `0x10000000`
- PSCI-based SMP startup
- A dedicated SMP variant supporting all four Cortex-A55 and four Cortex-A76
  cores
- Documentation for building and booting Zephyr through U-Boot

The following board configurations are available:

- `rock_5b_plus`: default non-SMP configuration
- `rock_5b_plus//smp`: eight-core SMP configuration

Network and Bluetooth support are outside the scope of this initial
contribution.

## Building

Build the default configuration with:

```console
west build -p always -b rock_5b_plus samples/hello_world
```

Build the eight-core SMP variant with:

```console
west build -p always -b rock_5b_plus//smp samples/synchronization
```

Create a legacy U-Boot image. The image header instructs U-Boot to relocate
the Zephyr payload to its runtime address at `0x10000000`:

```console
mkimage -C none -A arm64 -O linux \
  -a 0x10000000 -e 0x10000000 \
  -d build/zephyr/zephyr.bin \
  build/zephyr/zephyr.img
```

The Radxa U-Boot AArch64 boot path requires an FDT to be passed to `bootm`.
Obtain `rk3588-rock-5b-plus.dtb` from a Radxa Linux distribution and load both
files using the addresses provided by U-Boot:

```console
printenv kernel_addr_r fdt_addr_r

fatload mmc 1:1 ${kernel_addr_r} zephyr.img
fatload mmc 1:1 ${fdt_addr_r} rk3588-rock-5b-plus.dtb
bootm ${kernel_addr_r} - ${fdt_addr_r}
```

The MMC device and partition numbers may need to be adjusted for the selected
boot media.

## Testing

The following builds were verified with the Zephyr SDK:

```console
west build -p always -b rock_5b_plus samples/hello_world
west build -p always -b rock_5b_plus//smp samples/synchronization
```

Runtime testing was performed using the downstream RK3588 machine model from
[processmission/qemu](https://github.com/processmission/qemu).

The
[`rock-5b-plus-rsdk-b2-qemu1` release](https://github.com/processmission/qemu/releases/tag/rock-5b-plus-rsdk-b2-qemu1)
provides the `rock-5b-plus-rsdk-b2-linux.raw.xz` image containing the firmware
and U-Boot boot chain used for testing. Decompress the image before starting
QEMU.

The Zephyr legacy image and board devicetree can be loaded into the U-Boot
default temporary load regions with:

```console
/path/to/qemu-system-aarch64 \
  -accel tcg \
  -machine rock-5b-plus \
  -smp 8 \
  -m 1G \
  -drive file=/path/to/rock-5b-plus-rsdk-b2-linux.raw,if=sd,index=0,format=raw,snapshot=on \
  -device loader,file=build/zephyr/zephyr.img,addr=0x00400000,force-raw=on \
  -device loader,file=/path/to/rk3588-rock-5b-plus.dtb,addr=0x08300000,force-raw=on \
  -serial mon:stdio \
  -display none \
  -no-reboot
```

At the U-Boot prompt, start Zephyr with:

```console
bootm 0x00400000 - 0x08300000
```

U-Boot relocates the Zephyr payload to `0x10000000` according to the legacy
image header. The SMP configuration was verified with all eight CPUs online,
including CPU MPIDs from `0x000` through `0x700`.

The QEMU machine model is used only for external validation and is not
integrated as a Zephyr board runner by this change.
