### PR TITLE
subsys: usb: fix building issue caused by log format string

### DIFF
--- a/subsys/usb/device_next/class/loopback.c
+++ b/subsys/usb/device_next/class/loopback.c
@@ -220,7 +220,7 @@ static struct net_buf *lb_control_to_host(struct usbd_class_data *c_data,
 
 		net_buf_add_mem(buf, lb_buf, len);
 
-		LOG_WRN("Device-to-Host, wLength %u | %zu", setup->wLength, len);
+		LOG_WRN("Device-to-Host, wLength %u | %u", setup->wLength, len);
 
 		return buf;
 	}


### PR DESCRIPTION
Fix the following building issue:
usb/device_next/class/loopback.c:223:25: error: format '%zu' expects argument of type 'size_t', but argument 3 has type 'int' [-Werror=format=]
  223 |                 LOG_WRN("Device-to-Host, wLength %u | %zu",
		  setup->wLength, len);

Fixes #113792