### PR TITLE
modem: pipe: support chained transmit buffers

### DIFF
--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -212,8 +212,6 @@ enum modem_chat_script_send_state {
 	MODEM_CHAT_SCRIPT_SEND_STATE_IDLE,
 	/* Sending request */
 	MODEM_CHAT_SCRIPT_SEND_STATE_REQUEST,
-	/* Sending delimiter */
-	MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER,
 };
 
 /**

--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -163,7 +163,9 @@ struct modem_cmux_frame {
 	bool pf;
 	uint8_t type;
 	const uint8_t *data;
+	const uint8_t *tx_extra;
 	uint16_t data_len;
+	uint16_t tx_extra_len;
 };
 
 struct modem_cmux_work {

--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -31,6 +31,14 @@ enum modem_pipe_event {
 	MODEM_PIPE_EVENT_CLOSED,
 };
 
+/** Fragment of multi-part data */
+struct modem_pipe_data_fragment {
+	/** Data pointer */
+	const uint8_t *data;
+	/** Length of data in @a data */
+	size_t size;
+};
+
 /**
  * @cond INTERNAL_HIDDEN
  */
@@ -52,13 +60,19 @@ typedef int (*modem_pipe_api_open)(void *data);
 
 typedef int (*modem_pipe_api_transmit)(void *data, const uint8_t *buf, size_t size);
 
+typedef int (*modem_pipe_api_transmit_chain)(void *data,
+					     const struct modem_pipe_data_fragment *frags,
+					     size_t num_frags);
+
 typedef int (*modem_pipe_api_receive)(void *data, uint8_t *buf, size_t size);
 
 typedef int (*modem_pipe_api_close)(void *data);
 
 struct modem_pipe_api {
 	modem_pipe_api_open open;
+	/* Only one of 'transmit' and 'transmit_chain' needs to be implemented */
 	modem_pipe_api_transmit transmit;
+	modem_pipe_api_transmit_chain transmit_chain;
 	modem_pipe_api_receive receive;
 	modem_pipe_api_close close;
 };
@@ -126,6 +140,21 @@ int modem_pipe_open_async(struct modem_pipe *pipe);
 void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback, void *user_data);
 
 /**
+ * @brief Transmit a chain of data buffers through pipe
+ *
+ * @param pipe Pipe to transmit through
+ * @param frags Array of data fragments to transmit
+ * @param num_frags Number of fragments in @a frags
+ *
+ * @return Number of bytes placed in pipe (0 if pipe closed)
+ * @retval -errno code on error
+ *
+ * @warning This call must be non-blocking
+ */
+int modem_pipe_transmit_chain(struct modem_pipe *pipe, const struct modem_pipe_data_fragment *frags,
+			      size_t num_frags);
+
+/**
  * @brief Transmit data through pipe
  *
  * @param pipe Pipe to transmit through
@@ -137,7 +166,15 @@ void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback
  *
  * @warning This call must be non-blocking
  */
-int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size);
+static inline int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size)
+{
+	const struct modem_pipe_data_fragment frag = {
+		.data = buf,
+		.size = size,
+	};
+
+	return modem_pipe_transmit_chain(pipe, &frag, 1);
+}
 
 /**
  * @brief Receive data through pipe

--- a/subsys/modem/backends/modem_backend_tty.c
+++ b/subsys/modem/backends/modem_backend_tty.c
@@ -65,14 +65,27 @@ static int modem_backend_tty_open(void *data)
 	return 0;
 }
 
-static int modem_backend_tty_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_backend_tty_transmit_chain(void *data,
+					    const struct modem_pipe_data_fragment *frags,
+					    size_t num_frags)
 {
 	struct modem_backend_tty *backend = (struct modem_backend_tty *)data;
+	int sent = 0;
 	int ret;
 
-	ret = nsi_host_write(backend->tty_fd, buf, size);
+	for (int i = 0; i < num_frags; i++) {
+		ret = nsi_host_write(backend->tty_fd, frags[i].data, frags[i].size);
+		if (ret < 0) {
+			return ret;
+		}
+		sent += ret;
+		if (ret != frags[i].size) {
+			/* No more data can fit */
+			break;
+		}
+	}
 	modem_pipe_notify_transmit_idle(&backend->pipe);
-	return ret;
+	return sent;
 }
 
 static int modem_backend_tty_receive(void *data, uint8_t *buf, size_t size)
@@ -100,7 +113,7 @@ static int modem_backend_tty_close(void *data)
 
 static const struct modem_pipe_api modem_backend_tty_api = {
 	.open = modem_backend_tty_open,
-	.transmit = modem_backend_tty_transmit,
+	.transmit_chain = modem_backend_tty_transmit_chain,
 	.receive = modem_backend_tty_receive,
 	.close = modem_backend_tty_close,
 };

--- a/subsys/modem/backends/modem_backend_uart_async.c
+++ b/subsys/modem/backends/modem_backend_uart_async.c
@@ -213,11 +213,15 @@ static uint32_t get_transmit_buf_size(struct modem_backend_uart *backend)
 	return backend->async.common.transmit_buf_size;
 }
 
-static int modem_backend_uart_async_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_backend_uart_async_transmit_chain(void *data,
+						   const struct modem_pipe_data_fragment *frags,
+						   size_t num_frags)
 {
 	struct modem_backend_uart *backend = (struct modem_backend_uart *)data;
+	uint32_t remaining = get_transmit_buf_size(backend);
+	uint32_t offset = 0;
+	uint32_t to_copy;
 	bool transmitting;
-	uint32_t bytes_to_transmit;
 	int ret;
 
 	transmitting = atomic_test_and_set_bit(&backend->async.common.state,
@@ -226,26 +230,31 @@ static int modem_backend_uart_async_transmit(void *data, const uint8_t *buf, siz
 		return 0;
 	}
 
-	/* Determine amount of bytes to transmit */
-	bytes_to_transmit = MIN(size, get_transmit_buf_size(backend));
+	/* Linearize data from fragments into internal buffer */
+	for (int i = 0; i < num_frags; i++) {
+		to_copy = MIN(remaining, frags[i].size);
+		memcpy(backend->async.common.transmit_buf + offset, frags[i].data, to_copy);
+		offset += to_copy;
+		remaining -= to_copy;
+		if (remaining == 0) {
+			/* Early exit if no space remaining */
+			break;
+		}
+	}
 
-	/* Copy buf to transmit buffer which is passed to UART */
-	memcpy(backend->async.common.transmit_buf, buf, bytes_to_transmit);
-
-	ret = uart_tx(backend->uart, backend->async.common.transmit_buf, bytes_to_transmit,
+	ret = uart_tx(backend->uart, backend->async.common.transmit_buf, offset,
 		      CONFIG_MODEM_BACKEND_UART_ASYNC_TRANSMIT_TIMEOUT_MS * 1000L);
 
 #if CONFIG_MODEM_STATS
-	advertise_transmit_buf_stats(backend, bytes_to_transmit);
+	advertise_transmit_buf_stats(backend, offset);
 #endif
 
 	if (ret != 0) {
-		LOG_ERR("Failed to %s %u bytes. (%d)",
-			"start async transmit for", bytes_to_transmit, ret);
+		LOG_ERR("Failed to %s %u bytes. (%d)", "start async transmit for", offset, ret);
 		return ret;
 	}
 
-	return (int)bytes_to_transmit;
+	return (int)offset;
 }
 
 static int modem_backend_uart_async_receive(void *data, uint8_t *buf, size_t size)
@@ -296,7 +305,7 @@ static int modem_backend_uart_async_close(void *data)
 
 static const struct modem_pipe_api modem_backend_uart_async_api = {
 	.open = modem_backend_uart_async_open,
-	.transmit = modem_backend_uart_async_transmit,
+	.transmit_chain = modem_backend_uart_async_transmit_chain,
 	.receive = modem_backend_uart_async_receive,
 	.close = modem_backend_uart_async_close,
 };

--- a/subsys/modem/backends/modem_backend_uart_async_hwfc.c
+++ b/subsys/modem/backends/modem_backend_uart_async_hwfc.c
@@ -270,11 +270,14 @@ static uint32_t get_transmit_buf_size(const struct modem_backend_uart *backend)
 	return backend->async.common.transmit_buf_size;
 }
 
-static int modem_backend_uart_async_hwfc_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_backend_uart_async_hwfc_transmit_chain(
+	void *data, const struct modem_pipe_data_fragment *frags, size_t num_frags)
 {
 	struct modem_backend_uart *backend = (struct modem_backend_uart *)data;
+	uint32_t remaining = get_transmit_buf_size(backend);
+	uint32_t offset = 0;
+	uint32_t to_copy;
 	bool transmitting;
-	uint32_t bytes_to_transmit;
 	int ret;
 
 	transmitting = atomic_test_and_set_bit(&backend->async.common.state,
@@ -283,26 +286,31 @@ static int modem_backend_uart_async_hwfc_transmit(void *data, const uint8_t *buf
 		return 0;
 	}
 
-	/* Determine amount of bytes to transmit */
-	bytes_to_transmit = MIN(size, get_transmit_buf_size(backend));
+	/* Linearize data from fragments into internal buffer */
+	for (int i = 0; i < num_frags; i++) {
+		to_copy = MIN(remaining, frags[i].size);
+		memcpy(backend->async.common.transmit_buf + offset, frags[i].data, to_copy);
+		offset += to_copy;
+		remaining -= to_copy;
+		if (remaining == 0) {
+			/* Early exit if no space remaining */
+			break;
+		}
+	}
 
-	/* Copy buf to transmit buffer which is passed to UART */
-	memcpy(backend->async.common.transmit_buf, buf, bytes_to_transmit);
-
-	ret = uart_tx(backend->uart, backend->async.common.transmit_buf, bytes_to_transmit,
+	ret = uart_tx(backend->uart, backend->async.common.transmit_buf, offset,
 		      CONFIG_MODEM_BACKEND_UART_ASYNC_TRANSMIT_TIMEOUT_MS * 1000L);
 
 #if CONFIG_MODEM_STATS
-	advertise_transmit_buf_stats(backend, bytes_to_transmit);
+	advertise_transmit_buf_stats(backend, offset);
 #endif
 
 	if (ret != 0) {
-		LOG_ERR("Failed to %s %u bytes. (%d)",
-			"start async transmit for", bytes_to_transmit, ret);
+		LOG_ERR("Failed to %s %u bytes. (%d)", "start async transmit for", offset, ret);
 		return ret;
 	}
 
-	return (int)bytes_to_transmit;
+	return (int)offset;
 }
 
 static int modem_backend_uart_async_hwfc_receive(void *data, uint8_t *buf, size_t size)
@@ -386,7 +394,7 @@ static int modem_backend_uart_async_hwfc_close(void *data)
 
 static const struct modem_pipe_api modem_backend_uart_async_api = {
 	.open = modem_backend_uart_async_hwfc_open,
-	.transmit = modem_backend_uart_async_hwfc_transmit,
+	.transmit_chain = modem_backend_uart_async_hwfc_transmit_chain,
 	.receive = modem_backend_uart_async_hwfc_receive,
 	.close = modem_backend_uart_async_hwfc_close,
 };

--- a/subsys/modem/backends/modem_backend_uart_isr.c
+++ b/subsys/modem/backends/modem_backend_uart_isr.c
@@ -180,17 +180,27 @@ static bool modem_backend_uart_isr_transmit_buf_above_limit(struct modem_backend
 	return backend->isr.transmit_buf_put_limit < get_transmit_buf_length(backend);
 }
 
-static int modem_backend_uart_isr_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_backend_uart_isr_transmit_chain(void *data,
+						 const struct modem_pipe_data_fragment *frags,
+						 size_t num_frags)
 {
 	struct modem_backend_uart *backend = (struct modem_backend_uart *)data;
-	int written;
+	int written = 0;
+	int put;
 
 	if (modem_backend_uart_isr_transmit_buf_above_limit(backend) == true) {
 		return 0;
 	}
 
 	uart_irq_tx_disable(backend->uart);
-	written = ring_buf_put(&backend->isr.transmit_rb, buf, size);
+	for (int i = 0; i < num_frags; i++) {
+		put = ring_buf_put(&backend->isr.transmit_rb, frags[i].data, frags[i].size);
+		written += put;
+		if (put < frags[i].size) {
+			/* No more space in buffer, terminate */
+			break;
+		}
+	}
 	uart_irq_tx_enable(backend->uart);
 
 	/* Update transmit buf capacity tracker */
@@ -268,7 +278,7 @@ static int modem_backend_uart_isr_close(void *data)
 
 static const struct modem_pipe_api modem_backend_uart_isr_api = {
 	.open = modem_backend_uart_isr_open,
-	.transmit = modem_backend_uart_isr_transmit,
+	.transmit_chain = modem_backend_uart_isr_transmit_chain,
 	.receive = modem_backend_uart_isr_receive,
 	.close = modem_backend_uart_isr_close,
 };

--- a/subsys/modem/modem_chat.c
+++ b/subsys/modem/modem_chat.c
@@ -317,32 +317,32 @@ static bool modem_chat_send_script_request_part(struct modem_chat *chat)
 {
 	const struct modem_chat_script_chat *script_chat =
 		&chat->script->script_chats[chat->script_chat_it];
-
-	uint8_t *request_part;
-	uint16_t request_size;
-	uint16_t request_part_size;
+	uint32_t total_size = script_chat->request_size + chat->delimiter_size;
+	struct modem_pipe_data_fragment frags[2];
+	size_t num_frags;
 	int ret;
 
-	switch (chat->script_send_state) {
-	case MODEM_CHAT_SCRIPT_SEND_STATE_REQUEST:
-		request_part = (uint8_t *)(&script_chat->request[chat->script_send_pos]);
-		request_size = script_chat->request_size;
-		break;
-
-	case MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER:
-		request_part = (uint8_t *)(&chat->delimiter[chat->script_send_pos]);
-		request_size = chat->delimiter_size;
-		break;
-
-	default:
-		return false;
+	if (chat->script_send_pos < script_chat->request_size) {
+		/* Still sending the request */
+		frags[0].data = &script_chat->request[chat->script_send_pos];
+		frags[0].size = script_chat->request_size - chat->script_send_pos;
+		frags[1].data = (uint8_t *)chat->delimiter;
+		frags[1].size = chat->delimiter_size;
+		num_frags = 2;
+	} else {
+		/* Purely into the delimiter */
+		frags[0].data = &chat->delimiter[chat->script_send_pos - script_chat->request_size];
+		frags[0].size = total_size - chat->script_send_pos;
+		/* Set for LOG_ERR below */
+		frags[1].size = 0;
+		num_frags = 1;
 	}
 
-	request_part_size = request_size - chat->script_send_pos;
-	ret = modem_pipe_transmit(chat->pipe, request_part, request_part_size);
+	ret = modem_pipe_transmit_chain(chat->pipe, frags, num_frags);
 	if (ret < 1) {
 		if (ret < 0) {
-			LOG_ERR("Failed to %s %u bytes. (%d)", "transmit", request_part_size, ret);
+			LOG_ERR("Failed to %s %zu bytes. (%d)", "transmit",
+				frags[0].size + frags[1].size, ret);
 		}
 		return false;
 	}
@@ -350,7 +350,7 @@ static bool modem_chat_send_script_request_part(struct modem_chat *chat)
 	chat->script_send_pos += (uint16_t)ret;
 
 	/* Return true if all data was sent */
-	return request_size <= chat->script_send_pos;
+	return total_size <= chat->script_send_pos;
 }
 
 static void modem_chat_script_send_handler(struct k_work *item)
@@ -361,26 +361,17 @@ static void modem_chat_script_send_handler(struct k_work *item)
 		return;
 	}
 
-	switch (chat->script_send_state) {
-	case MODEM_CHAT_SCRIPT_SEND_STATE_IDLE:
+	if (chat->script_send_state == MODEM_CHAT_SCRIPT_SEND_STATE_IDLE) {
 		return;
-
-	case MODEM_CHAT_SCRIPT_SEND_STATE_REQUEST:
-		if (!modem_chat_send_script_request_part(chat)) {
-			return;
-		}
-
-		modem_chat_set_script_send_state(chat, MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER);
-		__fallthrough;
-
-	case MODEM_CHAT_SCRIPT_SEND_STATE_DELIMITER:
-		if (!modem_chat_send_script_request_part(chat)) {
-			return;
-		}
-
-		modem_chat_set_script_send_state(chat, MODEM_CHAT_SCRIPT_SEND_STATE_IDLE);
-		break;
 	}
+
+	if (!modem_chat_send_script_request_part(chat)) {
+		/* Request still in progress */
+		return;
+	}
+
+	/* Request transmission complete */
+	modem_chat_set_script_send_state(chat, MODEM_CHAT_SCRIPT_SEND_STATE_IDLE);
 
 	if (modem_chat_script_chat_has_matches(chat)) {
 		modem_chat_script_set_response_matches(chat);

--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -413,9 +413,13 @@ static void modem_cmux_log_frame(const struct modem_cmux_frame *frame,
 				 const char *action, size_t hexdump_len)
 {
 	LOG_DBG("%s ch:%u cr:%u pf:%u type:%s dlen:%u", action, frame->dlci_address,
-		frame->cr, frame->pf, modem_cmux_frame_type_to_str(frame->type), frame->data_len);
+		frame->cr, frame->pf, modem_cmux_frame_type_to_str(frame->type),
+		frame->data_len + frame->tx_extra_len);
 	if (hexdump_len > 0) {
 		LOG_HEXDUMP_DBG(frame->data, hexdump_len, "data:");
+	}
+	if (frame->tx_extra_len > 0) {
+		LOG_HEXDUMP_DBG(frame->tx_extra, frame->tx_extra_len, "data:");
 	}
 }
 #else
@@ -563,12 +567,18 @@ static uint16_t modem_cmux_transmit_frame(struct modem_cmux *cmux,
 	uint8_t buf[MODEM_CMUX_HEADER_SIZE];
 	uint8_t fcs;
 	uint16_t space;
+	uint16_t tx_len = frame->data_len + frame->tx_extra_len;
+	uint16_t real_extra_len;
+	uint16_t real_len;
 	uint16_t data_len;
 	uint16_t buf_idx;
 
 	space = ring_buf_space_get(&cmux->transmit_rb) - MODEM_CMUX_HEADER_SIZE;
-	data_len = MIN(space, frame->data_len);
+	data_len = MIN(space, tx_len);
 	data_len = MIN(data_len, CONFIG_MODEM_CMUX_MTU);
+
+	real_len = MIN(frame->data_len, data_len);
+	real_extra_len = data_len - real_len;
 
 	/* SOF */
 	buf[0] = MODEM_CMUX_SOF;
@@ -593,17 +603,22 @@ static uint16_t modem_cmux_transmit_frame(struct modem_cmux *cmux,
 	fcs = crc8_rohc(MODEM_CMUX_FCS_INIT_VALUE, &buf[1], (buf_idx - 1));
 
 	/* FCS final */
-	if (frame->type == MODEM_CMUX_FRAME_TYPE_UIH) {
-		fcs = 0xFF - fcs;
-	} else {
-		fcs = 0xFF - crc8_rohc(fcs, frame->data, data_len);
+	if (frame->type != MODEM_CMUX_FRAME_TYPE_UIH) {
+		fcs = crc8_rohc(fcs, frame->data, real_len);
+		if (real_extra_len > 0) {
+			fcs = crc8_rohc(fcs, frame->tx_extra, real_extra_len);
+		}
 	}
+	fcs = 0xFF - fcs;
 
 	/* Frame header */
 	ring_buf_put(&cmux->transmit_rb, buf, buf_idx);
 
 	/* Data */
-	ring_buf_put(&cmux->transmit_rb, frame->data, data_len);
+	ring_buf_put(&cmux->transmit_rb, frame->data, real_len);
+	if (real_extra_len > 0) {
+		ring_buf_put(&cmux->transmit_rb, frame->tx_extra, real_extra_len);
+	}
 
 	/* FCS and EOF will be put on the same call */
 	buf[0] = fcs;
@@ -1930,7 +1945,9 @@ static int modem_cmux_dlci_pipe_api_open(void *data)
 	return 0;
 }
 
-static int modem_cmux_dlci_pipe_api_transmit(void *data, const uint8_t *buf, size_t size)
+static int modem_cmux_dlci_pipe_api_transmit_chain(void *data,
+						   const struct modem_pipe_data_fragment *frags,
+						   size_t num_frags)
 {
 	struct modem_cmux_dlci *dlci = (struct modem_cmux_dlci *)data;
 	struct modem_cmux *cmux = dlci->cmux;
@@ -1939,7 +1956,7 @@ static int modem_cmux_dlci_pipe_api_transmit(void *data, const uint8_t *buf, siz
 		return -EPERM;
 	}
 
-	if (size == 0 || buf == NULL) {
+	if (frags[0].size == 0 || frags[0].data == NULL) {
 		/* Allow empty transmit request to wake up CMUX */
 		runtime_pm_keepalive(cmux);
 		k_work_reschedule(&cmux->transmit_work, K_NO_WAIT);
@@ -1950,13 +1967,19 @@ static int modem_cmux_dlci_pipe_api_transmit(void *data, const uint8_t *buf, siz
 		return 0;
 	}
 
+	/* The CMUX frame object also supports reception, using `data_fragment` internally would
+	 * be a large change with little benefit. Support up to two buffers with `chain`, which
+	 * supports the common `modem_chat` usage.
+	 */
 	struct modem_cmux_frame frame = {
 		.dlci_address = dlci->dlci_address,
 		.cr = cmux->initiator,
 		.pf = false,
 		.type = MODEM_CMUX_FRAME_TYPE_UIH,
-		.data = buf,
-		.data_len = size,
+		.data = frags[0].data,
+		.tx_extra = num_frags > 1 ? frags[1].data : NULL,
+		.data_len = frags[0].size,
+		.tx_extra_len = num_frags > 1 ? frags[1].size : 0,
 	};
 
 	return modem_cmux_transmit_data_frame(cmux, &frame);
@@ -2011,7 +2034,7 @@ static int modem_cmux_dlci_pipe_api_close(void *data)
 
 static const struct modem_pipe_api modem_cmux_dlci_pipe_api = {
 	.open = modem_cmux_dlci_pipe_api_open,
-	.transmit = modem_cmux_dlci_pipe_api_transmit,
+	.transmit_chain = modem_cmux_dlci_pipe_api_transmit_chain,
 	.receive = modem_cmux_dlci_pipe_api_receive,
 	.close = modem_cmux_dlci_pipe_api_close,
 };

--- a/subsys/modem/modem_pipe.c
+++ b/subsys/modem/modem_pipe.c
@@ -11,8 +11,7 @@
 #define PIPE_EVENT_RECEIVE_READY_BIT BIT(2)
 #define PIPE_EVENT_TRANSMIT_IDLE_BIT BIT(3)
 
-static void pipe_set_callback(struct modem_pipe *pipe,
-			      modem_pipe_api_callback callback,
+static void pipe_set_callback(struct modem_pipe *pipe, modem_pipe_api_callback callback,
 			      void *user_data)
 {
 	K_SPINLOCK(&pipe->spinlock) {
@@ -35,9 +34,7 @@ static uint32_t pipe_test_events(struct modem_pipe *pipe, uint32_t events)
 	return k_event_test(&pipe->event, events);
 }
 
-static uint32_t pipe_await_events(struct modem_pipe *pipe,
-				  uint32_t events,
-				  k_timeout_t timeout)
+static uint32_t pipe_await_events(struct modem_pipe *pipe, uint32_t events, k_timeout_t timeout)
 {
 	return k_event_wait(&pipe->event, events, false, timeout);
 }
@@ -62,9 +59,18 @@ static int pipe_call_open(struct modem_pipe *pipe)
 	return pipe->api->open(pipe->data);
 }
 
-static int pipe_call_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size)
+static int pipe_call_transmit_chain(struct modem_pipe *pipe,
+				    const struct modem_pipe_data_fragment *frags, size_t num_frags)
 {
-	return pipe->api->transmit(pipe->data, buf, size);
+	if (pipe->api->transmit_chain) {
+		/* Native support for `transmit_chain` */
+		return pipe->api->transmit_chain(pipe->data, frags, num_frags);
+	}
+	/* Fallback to legacy `transmit` (send first part of chain only).
+	 * This is valid because the `transmit_chain` API is documented as queuing as many bytes as
+	 * it can, not necessarily all the bytes provided.
+	 */
+	return pipe->api->transmit(pipe->data, frags[0].data, frags[0].size);
 }
 
 static int pipe_call_receive(struct modem_pipe *pipe, uint8_t *buf, size_t size)
@@ -133,14 +139,15 @@ void modem_pipe_attach(struct modem_pipe *pipe, modem_pipe_api_callback callback
 	}
 }
 
-int modem_pipe_transmit(struct modem_pipe *pipe, const uint8_t *buf, size_t size)
+int modem_pipe_transmit_chain(struct modem_pipe *pipe, const struct modem_pipe_data_fragment *frags,
+			      size_t num_frags)
 {
-	if (!pipe_test_events(pipe, PIPE_EVENT_OPENED_BIT)) {
+	if (!pipe_test_events(pipe, PIPE_EVENT_OPENED_BIT) || (num_frags == 0)) {
 		return 0;
 	}
 
 	pipe_clear_events(pipe, PIPE_EVENT_TRANSMIT_IDLE_BIT);
-	return pipe_call_transmit(pipe, buf, size);
+	return pipe_call_transmit_chain(pipe, frags, num_frags);
 }
 
 int modem_pipe_receive(struct modem_pipe *pipe, uint8_t *buf, size_t size)

--- a/tests/subsys/modem/mock/modem_backend_mock.c
+++ b/tests/subsys/modem/mock/modem_backend_mock.c
@@ -47,6 +47,62 @@ static bool modem_backend_mock_update(struct modem_backend_mock *mock, const uin
 	return false;
 }
 
+#ifdef CONFIG_TEST_MODEM_MOCK_BACKEND_TRANSMIT_CHAIN
+
+static int modem_backend_mock_transmit_chain(void *data,
+					     const struct modem_pipe_data_fragment *frags,
+					     size_t num_frags)
+{
+	struct modem_backend_mock *mock = (struct modem_backend_mock *)data;
+	int remaining = mock->limit;
+	int frag_remaining;
+	int written = 0;
+	int ret;
+
+	if (mock->bridge) {
+		struct modem_backend_mock *t_mock = mock->bridge;
+
+		for (int i = 0; i < num_frags; i++) {
+			/* Don't put more data than the mock limit */
+			frag_remaining = MIN(frags[i].size, remaining);
+			ret = ring_buf_put(&t_mock->rx_rb, frags[i].data, frag_remaining);
+			remaining -= ret;
+			written += ret;
+			if (ret < frags[i].size) {
+				/* No more space in buffer, terminate */
+				break;
+			}
+		}
+		k_work_submit(&t_mock->receive_ready_work);
+		k_work_submit(&mock->transmit_idle_work);
+		return written;
+	}
+
+	k_work_submit(&mock->transmit_idle_work);
+
+	for (int i = 0; i < num_frags; i++) {
+		frag_remaining = MIN(frags[i].size, remaining);
+
+		if (modem_backend_mock_update(mock, frags[i].data, frag_remaining)) {
+			/* Skip ringbuffer if transaction consumes bytes */
+			ret = frag_remaining;
+			modem_backend_mock_put(mock, mock->transaction->put,
+					       mock->transaction->put_size);
+			modem_backend_mock_prime(mock, mock->transaction->next);
+		} else {
+			ret = ring_buf_put(&mock->tx_rb, frags[i].data, frag_remaining);
+		}
+		written += ret;
+		remaining -= ret;
+		if (ret < frags[i].size) {
+			break;
+		}
+	}
+	return written;
+}
+
+#else
+
 static int modem_backend_mock_transmit(void *data, const uint8_t *buf, size_t size)
 {
 	struct modem_backend_mock *mock = (struct modem_backend_mock *)data;
@@ -68,8 +124,7 @@ static int modem_backend_mock_transmit(void *data, const uint8_t *buf, size_t si
 	if (modem_backend_mock_update(mock, buf, size)) {
 		/* Skip ringbuffer if transaction consumes bytes */
 		ret = size;
-		modem_backend_mock_put(mock, mock->transaction->put,
-				       mock->transaction->put_size);
+		modem_backend_mock_put(mock, mock->transaction->put, mock->transaction->put_size);
 
 		modem_backend_mock_prime(mock, mock->transaction->next);
 	} else {
@@ -78,6 +133,8 @@ static int modem_backend_mock_transmit(void *data, const uint8_t *buf, size_t si
 
 	return ret;
 }
+
+#endif
 
 static int modem_backend_mock_receive(void *data, uint8_t *buf, size_t size)
 {
@@ -97,7 +154,11 @@ static int modem_backend_mock_close(void *data)
 
 struct modem_pipe_api modem_backend_mock_api = {
 	.open = modem_backend_mock_open,
+#ifdef CONFIG_TEST_MODEM_MOCK_BACKEND_TRANSMIT_CHAIN
+	.transmit_chain = modem_backend_mock_transmit_chain,
+#else
 	.transmit = modem_backend_mock_transmit,
+#endif
 	.receive = modem_backend_mock_receive,
 	.close = modem_backend_mock_close,
 };
@@ -156,8 +217,7 @@ void modem_backend_mock_put(struct modem_backend_mock *mock, const uint8_t *buf,
 		return;
 	}
 
-	__ASSERT(ring_buf_put(&mock->rx_rb, buf, size) == size,
-		 "Mock buffer capacity exceeded");
+	__ASSERT(ring_buf_put(&mock->rx_rb, buf, size) == size, "Mock buffer capacity exceeded");
 
 	k_work_submit(&mock->receive_ready_work);
 }

--- a/tests/subsys/modem/modem_cmux/Kconfig
+++ b/tests/subsys/modem/modem_cmux/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Embeint Inc
+# SPDX-License-Identifier: Apache-2.0
+
+config TEST_MODEM_MOCK_BACKEND_TRANSMIT_CHAIN
+	bool "Support the `transmit_chain` API variant"
+
+source "Kconfig.zephyr"

--- a/tests/subsys/modem/modem_cmux/src/main.c
+++ b/tests/subsys/modem/modem_cmux/src/main.c
@@ -17,24 +17,24 @@
 /*************************************************************************************************/
 /*                                         Definitions                                           */
 /*************************************************************************************************/
-#define EVENT_CMUX_CONNECTED		BIT(0)
-#define EVENT_CMUX_DLCI1_OPEN		BIT(1)
-#define EVENT_CMUX_DLCI2_OPEN		BIT(2)
-#define EVENT_CMUX_DLCI1_RECEIVE_READY	BIT(3)
-#define EVENT_CMUX_DLCI1_TRANSMIT_IDLE	BIT(4)
-#define EVENT_CMUX_DLCI2_RECEIVE_READY	BIT(5)
-#define EVENT_CMUX_DLCI2_TRANSMIT_IDLE	BIT(6)
-#define EVENT_CMUX_DLCI1_CLOSED		BIT(7)
-#define EVENT_CMUX_DLCI2_CLOSED		BIT(8)
-#define EVENT_CMUX_DISCONNECTED		BIT(9)
-#define CMUX_BASIC_HRD_SMALL_SIZE	6
-#define CMUX_BASIC_HRD_LARGE_SIZE	7
-#define TRANSMISSION_DELAY_MS		10
-#define TRANSMISSION_DELAY		K_MSEC(TRANSMISSION_DELAY_MS)
-#define PIPE_EVENT_OPENED_BIT		BIT(0)
-#define MODEM_CMUX_T1_TIMEOUT		(K_MSEC(CONFIG_MODEM_CMUX_T1_TIMEOUT))
-#define MODEM_CMUX_T2_TIMEOUT		(K_MSEC(CONFIG_MODEM_CMUX_T2_TIMEOUT))
-#define MODEM_CMUX_T3_TIMEOUT		(K_SECONDS(CONFIG_MODEM_CMUX_T3_TIMEOUT))
+#define EVENT_CMUX_CONNECTED           BIT(0)
+#define EVENT_CMUX_DLCI1_OPEN          BIT(1)
+#define EVENT_CMUX_DLCI2_OPEN          BIT(2)
+#define EVENT_CMUX_DLCI1_RECEIVE_READY BIT(3)
+#define EVENT_CMUX_DLCI1_TRANSMIT_IDLE BIT(4)
+#define EVENT_CMUX_DLCI2_RECEIVE_READY BIT(5)
+#define EVENT_CMUX_DLCI2_TRANSMIT_IDLE BIT(6)
+#define EVENT_CMUX_DLCI1_CLOSED        BIT(7)
+#define EVENT_CMUX_DLCI2_CLOSED        BIT(8)
+#define EVENT_CMUX_DISCONNECTED        BIT(9)
+#define CMUX_BASIC_HRD_SMALL_SIZE      6
+#define CMUX_BASIC_HRD_LARGE_SIZE      7
+#define TRANSMISSION_DELAY_MS          10
+#define TRANSMISSION_DELAY             K_MSEC(TRANSMISSION_DELAY_MS)
+#define PIPE_EVENT_OPENED_BIT          BIT(0)
+#define MODEM_CMUX_T1_TIMEOUT          (K_MSEC(CONFIG_MODEM_CMUX_T1_TIMEOUT))
+#define MODEM_CMUX_T2_TIMEOUT          (K_MSEC(CONFIG_MODEM_CMUX_T2_TIMEOUT))
+#define MODEM_CMUX_T3_TIMEOUT          (K_SECONDS(CONFIG_MODEM_CMUX_T3_TIMEOUT))
 
 /*************************************************************************************************/
 /*                                          Instances                                            */
@@ -136,9 +136,9 @@ static uint8_t cmux_frame_dlci2_msc_cmd[] = {0xF9, 0x03, 0xEF, 0x09, 0xE3,
 static uint8_t cmux_frame_dlci2_msc_ack[] = {0xF9, 0x03, 0xEF, 0x09, 0xE1,
 					     0x05, 0x0B, 0x8D, 0xFB, 0xF9};
 static uint8_t cmux_frame_dlci2_msc_fcon_cmd[] = {0xF9, 0x03, 0xEF, 0x09, 0xE3,
-					     0x05, 0x0B, 0x8F, 0xFB, 0xF9};
+						  0x05, 0x0B, 0x8F, 0xFB, 0xF9};
 static uint8_t cmux_frame_dlci2_msc_fcon_ack[] = {0xF9, 0x03, 0xEF, 0x09, 0xE1,
-					     0x05, 0x0B, 0x8F, 0xFB, 0xF9};
+						  0x05, 0x0B, 0x8F, 0xFB, 0xF9};
 static uint8_t cmux_frame_dlci2_ua_ack[] = {0xF9, 0x0B, 0x73, 0x01, 0x92, 0xF9};
 static uint8_t cmux_frame_control_msc_cmd[] = {0xF9, 0x01, 0xEF, 0x09, 0xE3,
 					       0x05, 0x07, 0x01, 0x9A, 0xF9};
@@ -213,7 +213,7 @@ static uint8_t cmux_frame_data_dlci2_ppp_18[] = {0x7E, 0xFF, 0x7D, 0x23, 0xC0, 0
 						 0x7D, 0x22, 0x7D, 0x21, 0x7D, 0x20,
 						 0x7D, 0x24, 0x7D, 0x3C, 0x90, 0x7E};
 
-static uint8_t cmux_frame_data_large[127] = { [0 ... 126] = 0xAA };
+static uint8_t cmux_frame_data_large[127] = {[0 ... 126] = 0xAA};
 
 /*************************************************************************************************/
 /*                                   Power Save CMUX frames                                      */
@@ -239,15 +239,15 @@ static uint8_t cmux_frame_control_psc_ack[] = {0xF9, 0x01, 0xFF, 0x05, 0x41, 0x0
  * PSC command type (0x43), length=0 (0x01).
  * FCS computed over header {0x03, 0xFF, 0x05}.
  */
-static uint8_t cmux_frame_control_psc_initiator_cmd[] = {
-	0xF9, 0x03, 0xFF, 0x05, 0x43, 0x01, 0xE7, 0xF9};
+static uint8_t cmux_frame_control_psc_initiator_cmd[] = {0xF9, 0x03, 0xFF, 0x05,
+							 0x43, 0x01, 0xE7, 0xF9};
 
 /*
  * PSC ack from peer to CMUX initiator.
  * DCE sends responses with C/R=1, so address stays 0x03; PSC type cr cleared (0x41).
  */
-static uint8_t cmux_frame_control_psc_initiator_ack[] = {
-	0xF9, 0x03, 0xFF, 0x05, 0x41, 0x01, 0xE7, 0xF9};
+static uint8_t cmux_frame_control_psc_initiator_ack[] = {0xF9, 0x03, 0xFF, 0x05,
+							 0x41, 0x01, 0xE7, 0xF9};
 
 /*
  * Three flags should trigger peer to start retrying flag characters.
@@ -260,29 +260,25 @@ const static struct modem_backend_mock_transaction transaction_control_cld = {
 	.get = cmux_frame_control_cld_cmd,
 	.get_size = sizeof(cmux_frame_control_cld_cmd),
 	.put = cmux_frame_control_cld_ack,
-	.put_size = sizeof(cmux_frame_control_cld_ack)
-};
+	.put_size = sizeof(cmux_frame_control_cld_ack)};
 
 const static struct modem_backend_mock_transaction transaction_control_sabm = {
 	.get = cmux_frame_control_sabm_cmd,
 	.get_size = sizeof(cmux_frame_control_sabm_cmd),
 	.put = cmux_frame_control_sabm_ack,
-	.put_size = sizeof(cmux_frame_control_sabm_ack)
-};
+	.put_size = sizeof(cmux_frame_control_sabm_ack)};
 
 const static struct modem_backend_mock_transaction transaction_dlci1_disc = {
 	.get = cmux_frame_dlci1_disc_cmd,
 	.get_size = sizeof(cmux_frame_dlci1_disc_cmd),
 	.put = cmux_frame_dlci1_ua_ack,
-	.put_size = sizeof(cmux_frame_dlci1_ua_ack)
-};
+	.put_size = sizeof(cmux_frame_dlci1_ua_ack)};
 
 const static struct modem_backend_mock_transaction transaction_dlci2_disc = {
 	.get = cmux_frame_dlci2_disc_cmd,
 	.get_size = sizeof(cmux_frame_dlci2_disc_cmd),
 	.put = cmux_frame_dlci2_ua_ack,
-	.put_size = sizeof(cmux_frame_dlci2_ua_ack)
-};
+	.put_size = sizeof(cmux_frame_dlci2_ua_ack)};
 
 const static struct modem_backend_mock_transaction transaction_dlci1_msc = {
 	.get = cmux_frame_dlci1_msc_cmd,
@@ -642,8 +638,7 @@ ZTEST(modem_cmux, test_modem_cmux_flow_control_dlci2)
 	zassert_true(ret == sizeof(cmux_frame_dlci2_ppp_52),
 		     "Transmit failed after flow control is enabled");
 
-	zassert_true(memcmp(buffer1, cmux_frame_dlci2_ppp_52,
-			    sizeof(cmux_frame_dlci2_ppp_52)) == 0,
+	zassert_true(memcmp(buffer1, cmux_frame_dlci2_ppp_52, sizeof(cmux_frame_dlci2_ppp_52)) == 0,
 		     "Incorrect data received");
 }
 
@@ -679,18 +674,15 @@ ZTEST(modem_cmux, test_modem_cmux_dlci1_close_open)
 	zassert_true(ret == sizeof(cmux_frame_dlci1_disc_cmd),
 		     "Incorrect number of bytes received for DLCI1 close cmd");
 
-	zassert_true(memcmp(buffer1, cmux_frame_dlci1_disc_cmd,
-			    sizeof(cmux_frame_dlci1_disc_cmd)) == 0,
-		     "Incorrect DLCI1 close cmd received");
+	zassert_true(
+		memcmp(buffer1, cmux_frame_dlci1_disc_cmd, sizeof(cmux_frame_dlci1_disc_cmd)) == 0,
+		"Incorrect DLCI1 close cmd received");
 
-	modem_backend_mock_put(&bus_mock, cmux_frame_dlci1_ua_ack,
-			       sizeof(cmux_frame_dlci1_ua_ack));
+	modem_backend_mock_put(&bus_mock, cmux_frame_dlci1_ua_ack, sizeof(cmux_frame_dlci1_ua_ack));
 
-	events = k_event_wait_all(&cmux_event, (EVENT_CMUX_DLCI1_CLOSED),
-				  false, K_MSEC(100));
+	events = k_event_wait_all(&cmux_event, (EVENT_CMUX_DLCI1_CLOSED), false, K_MSEC(100));
 
-	zassert_true((events & EVENT_CMUX_DLCI1_CLOSED),
-		     "DLCI1 not closed as expected");
+	zassert_true((events & EVENT_CMUX_DLCI1_CLOSED), "DLCI1 not closed as expected");
 
 	/* Wait for potential T2 timeout */
 	k_msleep(CONFIG_MODEM_CMUX_T2_TIMEOUT + TRANSMISSION_DELAY_MS);
@@ -707,18 +699,16 @@ ZTEST(modem_cmux, test_modem_cmux_dlci1_close_open)
 	zassert_true(ret == sizeof(cmux_frame_dlci1_sabm_cmd),
 		     "Incorrect number of bytes received for DLCI1 open cmd");
 
-	zassert_true(memcmp(buffer1, cmux_frame_dlci1_sabm_cmd,
-			    sizeof(cmux_frame_dlci1_sabm_cmd)) == 0,
-		     "Incorrect DLCI1 open cmd received");
+	zassert_true(
+		memcmp(buffer1, cmux_frame_dlci1_sabm_cmd, sizeof(cmux_frame_dlci1_sabm_cmd)) == 0,
+		"Incorrect DLCI1 open cmd received");
 
 	modem_backend_mock_put(&bus_mock, cmux_frame_dlci1_sabm_ack,
 			       sizeof(cmux_frame_dlci1_sabm_ack));
 
-	events = k_event_wait_all(&cmux_event, (EVENT_CMUX_DLCI1_OPEN),
-				  false, K_MSEC(100));
+	events = k_event_wait_all(&cmux_event, (EVENT_CMUX_DLCI1_OPEN), false, K_MSEC(100));
 
-	zassert_true((events & EVENT_CMUX_DLCI1_OPEN),
-		     "DLCI1 not opened as expected");
+	zassert_true((events & EVENT_CMUX_DLCI1_OPEN), "DLCI1 not opened as expected");
 
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci1_msc);
 	modem_backend_mock_wait_for_transaction(&bus_mock);
@@ -736,11 +726,9 @@ ZTEST(modem_cmux, test_modem_cmux_disconnect_connect)
 	zassert_true(modem_pipe_close_async(dlci1_pipe) == 0, "Failed to close DLCI1");
 	zassert_true(modem_pipe_close_async(dlci2_pipe) == 0, "Failed to close DLCI2");
 
-	modem_backend_mock_put(&bus_mock, cmux_frame_dlci1_ua_ack,
-			       sizeof(cmux_frame_dlci1_ua_ack));
+	modem_backend_mock_put(&bus_mock, cmux_frame_dlci1_ua_ack, sizeof(cmux_frame_dlci1_ua_ack));
 
-	modem_backend_mock_put(&bus_mock, cmux_frame_dlci2_ua_ack,
-			       sizeof(cmux_frame_dlci2_ua_ack));
+	modem_backend_mock_put(&bus_mock, cmux_frame_dlci2_ua_ack, sizeof(cmux_frame_dlci2_ua_ack));
 
 	events = k_event_wait_all(&cmux_event, (EVENT_CMUX_DLCI1_CLOSED | EVENT_CMUX_DLCI2_CLOSED),
 				  false, K_MSEC(100));
@@ -809,18 +797,16 @@ ZTEST(modem_cmux, test_modem_cmux_disconnect_connect)
 	zassert_true(ret == sizeof(cmux_frame_dlci1_sabm_cmd),
 		     "Incorrect number of bytes received for DLCI1 open cmd");
 
-	zassert_true(memcmp(buffer1, cmux_frame_dlci1_sabm_cmd,
-			    sizeof(cmux_frame_dlci1_sabm_cmd)) == 0,
-		     "Incorrect DLCI1 open cmd received");
+	zassert_true(
+		memcmp(buffer1, cmux_frame_dlci1_sabm_cmd, sizeof(cmux_frame_dlci1_sabm_cmd)) == 0,
+		"Incorrect DLCI1 open cmd received");
 
 	modem_backend_mock_put(&bus_mock, cmux_frame_dlci1_sabm_ack,
 			       sizeof(cmux_frame_dlci1_sabm_ack));
 
-	events = k_event_wait_all(&cmux_event, (EVENT_CMUX_DLCI1_OPEN),
-				  false, K_MSEC(100));
+	events = k_event_wait_all(&cmux_event, (EVENT_CMUX_DLCI1_OPEN), false, K_MSEC(100));
 
-	zassert_true((events & EVENT_CMUX_DLCI1_OPEN),
-		     "DLCI1 not opened as expected");
+	zassert_true((events & EVENT_CMUX_DLCI1_OPEN), "DLCI1 not opened as expected");
 
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci1_msc);
 	modem_backend_mock_wait_for_transaction(&bus_mock);
@@ -840,15 +826,14 @@ ZTEST(modem_cmux, test_modem_cmux_disconnect_connect)
 	zassert_true(ret == sizeof(cmux_frame_dlci2_sabm_cmd),
 		     "Incorrect number of bytes received for DLCI1 open cmd");
 
-	zassert_true(memcmp(buffer1, cmux_frame_dlci2_sabm_cmd,
-			    sizeof(cmux_frame_dlci2_sabm_cmd)) == 0,
-		     "Incorrect DLCI1 open cmd received");
+	zassert_true(
+		memcmp(buffer1, cmux_frame_dlci2_sabm_cmd, sizeof(cmux_frame_dlci2_sabm_cmd)) == 0,
+		"Incorrect DLCI1 open cmd received");
 
 	modem_backend_mock_put(&bus_mock, cmux_frame_dlci2_sabm_ack,
 			       sizeof(cmux_frame_dlci2_sabm_ack));
 
-	events = k_event_wait_all(&cmux_event, (EVENT_CMUX_DLCI2_OPEN),
-				  false, K_MSEC(100));
+	events = k_event_wait_all(&cmux_event, (EVENT_CMUX_DLCI2_OPEN), false, K_MSEC(100));
 
 	zassert_true((events & EVENT_CMUX_DLCI2_OPEN), "DLCI2 not opened as expected");
 
@@ -874,21 +859,17 @@ ZTEST(modem_cmux, test_modem_cmux_disconnect_connect_sync)
 
 	modem_backend_mock_prime(&bus_mock, &transaction_control_cld);
 	zassert_true(modem_cmux_disconnect(&cmux) == 0, "Failed to disconnect CMUX");
-	zassert_true(modem_cmux_disconnect(&cmux) == -EALREADY,
-		     "Should already be disconnected");
+	zassert_true(modem_cmux_disconnect(&cmux) == -EALREADY, "Should already be disconnected");
 
 	modem_backend_mock_prime(&bus_mock, &transaction_control_sabm);
 	zassert_true(modem_cmux_connect(&cmux) == 0, "Failed to connect CMUX");
-	zassert_true(modem_cmux_connect(&cmux) == -EALREADY,
-		     "Should already be connected");
+	zassert_true(modem_cmux_connect(&cmux) == -EALREADY, "Should already be connected");
 
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci1_sabm);
-	zassert_true(modem_pipe_open(dlci1_pipe, K_SECONDS(10)) == 0,
-		     "Failed to open DLCI1 pipe");
+	zassert_true(modem_pipe_open(dlci1_pipe, K_SECONDS(10)) == 0, "Failed to open DLCI1 pipe");
 	modem_backend_mock_wait_for_transaction(&bus_mock);
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci2_sabm);
-	zassert_true(modem_pipe_open(dlci2_pipe, K_SECONDS(10)) == 0,
-		     "Failed to open DLCI2 pipe");
+	zassert_true(modem_pipe_open(dlci2_pipe, K_SECONDS(10)) == 0, "Failed to open DLCI2 pipe");
 	modem_backend_mock_wait_for_transaction(&bus_mock);
 }
 
@@ -899,12 +880,10 @@ ZTEST(modem_cmux, test_modem_cmux_dlci_close_open_sync)
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci2_disc);
 	zassert_true(modem_pipe_close(dlci2_pipe, K_SECONDS(10)) == 0, "Failed to close DLCI2");
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci1_sabm);
-	zassert_true(modem_pipe_open(dlci1_pipe, K_SECONDS(10)) == 0,
-		     "Failed to open DLCI1 pipe");
+	zassert_true(modem_pipe_open(dlci1_pipe, K_SECONDS(10)) == 0, "Failed to open DLCI1 pipe");
 	modem_backend_mock_wait_for_transaction(&bus_mock);
 	modem_backend_mock_prime(&bus_mock, &transaction_dlci2_sabm);
-	zassert_true(modem_pipe_open(dlci2_pipe, K_SECONDS(10)) == 0,
-		     "Failed to open DLCI2 pipe");
+	zassert_true(modem_pipe_open(dlci2_pipe, K_SECONDS(10)) == 0, "Failed to open DLCI2 pipe");
 	modem_backend_mock_wait_for_transaction(&bus_mock);
 }
 
@@ -1006,8 +985,7 @@ ZTEST(modem_cmux, test_modem_cmux_split_large_data)
 	int ret;
 	uint32_t events;
 
-	ret = modem_pipe_transmit(dlci2_pipe, cmux_frame_data_large,
-				  sizeof(cmux_frame_data_large));
+	ret = modem_pipe_transmit(dlci2_pipe, cmux_frame_data_large, sizeof(cmux_frame_data_large));
 	zassert_true(ret == CONFIG_MODEM_CMUX_MTU, "Failed to split large data %d", ret);
 
 	events = k_event_wait(&cmux_event, EVENT_CMUX_DLCI2_TRANSMIT_IDLE, false, K_MSEC(200));
@@ -1016,6 +994,27 @@ ZTEST(modem_cmux, test_modem_cmux_split_large_data)
 
 	ret = modem_backend_mock_get(&bus_mock, buffer2, sizeof(buffer2));
 	zassert_true(ret == CONFIG_MODEM_CMUX_MTU + CMUX_BASIC_HRD_SMALL_SIZE,
+		     "Incorrect number of bytes transmitted %d", ret);
+}
+
+ZTEST(modem_cmux, test_modem_cmux_chain_send)
+{
+	const struct modem_pipe_data_fragment frags[2] = {
+		[0] = {.data = "ATE0", .size = 4},
+		[1] = {.data = "\r", .size = 1},
+	};
+	uint32_t events;
+	int ret;
+
+	ret = modem_pipe_transmit_chain(dlci2_pipe, frags, ARRAY_SIZE(frags));
+	zassert_true(ret == 5, "Failed to transmit both buffers %d", ret);
+
+	events = k_event_wait(&cmux_event, EVENT_CMUX_DLCI2_TRANSMIT_IDLE, false, K_MSEC(200));
+	zassert_equal(events, EVENT_CMUX_DLCI2_TRANSMIT_IDLE,
+		      "Transmit idle event not received for DLCI2 pipe");
+
+	ret = modem_backend_mock_get(&bus_mock, buffer2, sizeof(buffer2));
+	zassert_true(ret == CMUX_BASIC_HRD_SMALL_SIZE + 5,
 		     "Incorrect number of bytes transmitted %d", ret);
 }
 
@@ -1039,12 +1038,10 @@ ZTEST(modem_cmux, test_modem_cmux_invalid_cr)
 
 ZTEST(modem_cmux, test_modem_cmux_invalid_command)
 {
-	static uint8_t invalid_cmd[] = {0xF9, 0x03, 0xEF, 0x09, 0x00,
-					     0x00, 0x00, 0x00, 0xFB, 0xF9};
+	static uint8_t invalid_cmd[] = {0xF9, 0x03, 0xEF, 0x09, 0x00, 0x00, 0x00, 0x00, 0xFB, 0xF9};
 	uint32_t events;
 
-	modem_backend_mock_put(&bus_mock, invalid_cmd,
-			       sizeof(invalid_cmd));
+	modem_backend_mock_put(&bus_mock, invalid_cmd, sizeof(invalid_cmd));
 
 	events = k_event_wait_all(&cmux_event,
 				  (MODEM_CMUX_EVENT_CONNECTED | MODEM_CMUX_EVENT_DISCONNECTED),
@@ -1067,12 +1064,10 @@ ZTEST(modem_cmux, test_modem_cmux_dlc0_disc)
 	k_msleep(TRANSMISSION_DELAY_MS);
 
 	ret = modem_backend_mock_get(&bus_mock, buffer1, sizeof(buffer1));
-	zassert_true(ret == sizeof(cmux_frame_dlci0_ua_ack),
-		     "Incorrect number of bytes received");
+	zassert_true(ret == sizeof(cmux_frame_dlci0_ua_ack), "Incorrect number of bytes received");
 
-	zassert_mem_equal(buffer1, cmux_frame_dlci0_ua_ack,
-			    sizeof(cmux_frame_dlci0_ua_ack),
-		     "Incorrect UA ACK received");
+	zassert_mem_equal(buffer1, cmux_frame_dlci0_ua_ack, sizeof(cmux_frame_dlci0_ua_ack),
+			  "Incorrect UA ACK received");
 	events = k_event_wait(&cmux_event, EVENT_CMUX_DISCONNECTED, false, K_SECONDS(1));
 	zassert_equal(events, EVENT_CMUX_DISCONNECTED,
 		      "DLCI0 DISC should cause CMUX disconnection");
@@ -1096,10 +1091,9 @@ ZTEST(modem_cmux, test_modem_cmux_power_save_peer_initiated)
 
 	/* CMUX must respond with a PSC ack frame */
 	ret = modem_backend_mock_get(&bus_mock, buffer1, sizeof(buffer1));
-	zassert_equal(ret, sizeof(cmux_frame_control_psc_ack),
-		      "Unexpected PSC ack byte count: %d", ret);
-	zassert_mem_equal(buffer1, cmux_frame_control_psc_ack,
-			  sizeof(cmux_frame_control_psc_ack),
+	zassert_equal(ret, sizeof(cmux_frame_control_psc_ack), "Unexpected PSC ack byte count: %d",
+		      ret);
+	zassert_mem_equal(buffer1, cmux_frame_control_psc_ack, sizeof(cmux_frame_control_psc_ack),
 			  "Incorrect PSC ack frame");
 
 	/*
@@ -1128,8 +1122,7 @@ ZTEST(modem_cmux, test_modem_cmux_power_save_wakeup_on_receive)
 	k_event_set(&cmux.event, BIT(MODEM_CMUX_STATE_POWERSAVE));
 
 	/* Peer transmits a data frame to CMUX while CMUX is asleep */
-	modem_backend_mock_put(&bus_mock, cmux_frame_dlci1_at_at,
-			       sizeof(cmux_frame_dlci1_at_at));
+	modem_backend_mock_put(&bus_mock, cmux_frame_dlci1_at_at, sizeof(cmux_frame_dlci1_at_at));
 
 	k_msleep(TRANSMISSION_DELAY_MS);
 
@@ -1145,8 +1138,7 @@ ZTEST(modem_cmux, test_modem_cmux_power_save_wakeup_on_receive)
 	ret = modem_pipe_receive(dlci1_pipe, buffer1, sizeof(buffer1));
 	zassert_equal(ret, (int)sizeof(cmux_frame_data_dlci1_at_at),
 		      "Incorrect byte count received after power save wakeup");
-	zassert_mem_equal(buffer1, cmux_frame_data_dlci1_at_at,
-			  sizeof(cmux_frame_data_dlci1_at_at),
+	zassert_mem_equal(buffer1, cmux_frame_data_dlci1_at_at, sizeof(cmux_frame_data_dlci1_at_at),
 			  "Incorrect data received after power save wakeup");
 }
 
@@ -1194,8 +1186,8 @@ ZTEST(modem_cmux, test_modem_cmux_power_save_wakeup_on_transmit)
 		     "Queued data frame should have been transmitted after wakeup");
 	data_offset = ret - sizeof(cmux_frame_dlci2_ppp_18);
 	for (int i = 0; i < data_offset; i++) {
-		zassert_equal(buffer1[i], 0xF9,
-			      "Pre-frame byte %d should be a SOF wakeup retry", i);
+		zassert_equal(buffer1[i], 0xF9, "Pre-frame byte %d should be a SOF wakeup retry",
+			      i);
 	}
 	zassert_mem_equal(&buffer1[data_offset], cmux_frame_dlci2_ppp_18,
 			  sizeof(cmux_frame_dlci2_ppp_18),
@@ -1374,8 +1366,7 @@ ZTEST(modem_cmux, test_modem_cmux_power_save_no_powersave_handshake)
 
 	/* Bus must be empty on entry; no PSC frame should have been sent */
 	ret = modem_backend_mock_get(&bus_mock, buffer1, sizeof(buffer1));
-	zassert_equal(ret, 0,
-		      "Bus must be empty on entry; no PSC frame was expected");
+	zassert_equal(ret, 0, "Bus must be empty on entry; no PSC frame was expected");
 
 	/* Transmitting data during POWERSAVE re-opens the pipe and resumes */
 	zassert_equal(modem_pipe_transmit(dlci2_pipe, cmux_frame_data_dlci2_ppp_18,
@@ -1397,8 +1388,7 @@ ZTEST(modem_cmux, test_modem_cmux_power_save_no_powersave_handshake)
 	ret = modem_backend_mock_get(&bus_mock, buffer1, sizeof(buffer1));
 	zassert_equal(ret, (int)sizeof(cmux_frame_dlci2_ppp_18),
 		      "Bus should contain only the data frame; no wakeup pattern was sent");
-	zassert_mem_equal(buffer1, cmux_frame_dlci2_ppp_18,
-			  sizeof(cmux_frame_dlci2_ppp_18),
+	zassert_mem_equal(buffer1, cmux_frame_dlci2_ppp_18, sizeof(cmux_frame_dlci2_ppp_18),
 			  "Incorrect data frame transmitted after wakeup");
 
 	/* Restore config */

--- a/tests/subsys/modem/modem_cmux/tests.yaml
+++ b/tests/subsys/modem/modem_cmux/tests.yaml
@@ -1,11 +1,15 @@
 # Copyright (c) 2023 Trackunit Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+common:
+  tags: modem_cmux
+  harness: ztest
+  platform_allow:
+    - native_sim
+  integration_platforms:
+    - native_sim
 tests:
-  modem.modem_cmux:
-    tags: modem_cmux
-    harness: ztest
-    platform_allow:
-      - native_sim
-    integration_platforms:
-      - native_sim
+  modem.modem_cmux: {}
+  modem.modem_cmux.transmit_chain:
+    extra_configs:
+      - CONFIG_TEST_MODEM_MOCK_BACKEND_TRANSMIT_CHAIN=y

--- a/tests/subsys/modem/modem_pipe/Kconfig
+++ b/tests/subsys/modem/modem_pipe/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Embeint Inc
+# SPDX-License-Identifier: Apache-2.0
+
+config TEST_PIPE_BACKEND_TRANSMIT_CHAIN
+	bool "Support the `transmit_chain` API variant"
+
+source "Kconfig.zephyr"

--- a/tests/subsys/modem/modem_pipe/src/main.c
+++ b/tests/subsys/modem/modem_pipe/src/main.c
@@ -32,15 +32,20 @@ struct modem_backend_fake {
 
 	const uint8_t *transmit_buffer;
 	size_t transmit_buffer_size;
+#ifdef CONFIG_TEST_PIPE_BACKEND_TRANSMIT_CHAIN
+	const struct modem_pipe_data_fragment *frags;
+	size_t num_frags;
+#endif /* CONFIG_TEST_PIPE_BACKEND_TRANSMIT_CHAIN */
 
 	uint8_t *receive_buffer;
 	size_t receive_buffer_size;
 
-	uint8_t synchronous : 1;
-	uint8_t open_called : 1;
-	uint8_t transmit_called : 1;
-	uint8_t receive_called : 1;
-	uint8_t close_called : 1;
+	uint8_t synchronous: 1;
+	uint8_t open_called: 1;
+	uint8_t transmit_called: 1;
+	uint8_t transmit_chain_called: 1;
+	uint8_t receive_called: 1;
+	uint8_t close_called: 1;
 };
 
 static void modem_backend_fake_opened_handler(struct k_work *item)
@@ -76,6 +81,38 @@ static void modem_backend_fake_transmit_idle_handler(struct k_work *item)
 	modem_pipe_notify_transmit_idle(&backend->pipe);
 }
 
+#ifdef CONFIG_TEST_PIPE_BACKEND_TRANSMIT_CHAIN
+
+static int modem_backend_fake_transmit_chain(void *data,
+					     const struct modem_pipe_data_fragment *frags,
+					     size_t num_frags)
+{
+	struct modem_backend_fake *backend = data;
+	int total_size = 0;
+
+	backend->transmit_chain_called = true;
+	/* Store the first fragment explicitly so the `transmit` API tests pass */
+	backend->transmit_buffer = frags[0].data;
+	backend->transmit_buffer_size = frags[0].size;
+	/* Store the full chain for `transmit_chain` tests */
+	backend->frags = frags;
+	backend->num_frags = num_frags;
+
+	for (int i = 0; i < num_frags; i++) {
+		total_size += frags[i].size;
+	}
+
+	if (backend->synchronous) {
+		modem_pipe_notify_transmit_idle(&backend->pipe);
+	} else {
+		k_work_schedule(&backend->transmit_idle_dwork, TEST_MODEM_PIPE_NOTIFY_TIMEOUT);
+	}
+
+	return total_size;
+}
+
+#else
+
 static int modem_backend_fake_transmit(void *data, const uint8_t *buf, size_t size)
 {
 	struct modem_backend_fake *backend = data;
@@ -92,6 +129,8 @@ static int modem_backend_fake_transmit(void *data, const uint8_t *buf, size_t si
 
 	return size;
 }
+
+#endif /* CONFIG_TEST_PIPE_BACKEND_TRANSMIT_CHAIN */
 
 static int modem_backend_fake_receive(void *data, uint8_t *buf, size_t size)
 {
@@ -129,7 +168,11 @@ static int modem_backend_fake_close(void *data)
 
 static struct modem_pipe_api modem_backend_fake_api = {
 	.open = modem_backend_fake_open,
+#ifdef CONFIG_TEST_PIPE_BACKEND_TRANSMIT_CHAIN
+	.transmit_chain = modem_backend_fake_transmit_chain,
+#else
 	.transmit = modem_backend_fake_transmit,
+#endif
 	.receive = modem_backend_fake_receive,
 	.close = modem_backend_fake_close,
 };
@@ -267,12 +310,15 @@ static void test_pipe_reclose(void)
 
 static void test_pipe_async_transmit(void)
 {
+	bool is_chain = IS_ENABLED(CONFIG_TEST_PIPE_BACKEND_TRANSMIT_CHAIN);
+
 	zassert_equal(modem_pipe_transmit(test_pipe, test_buffer, test_buffer_size),
 		      test_buffer_size, "Failed to transmit");
-	zassert_true(test_backend.transmit_called, "transmit was not called");
+	zassert_equal(is_chain, test_backend.transmit_chain_called,
+		      "Unexpected transmit_chain call count");
+	zassert_equal(!is_chain, test_backend.transmit_called, "Unexpected transmit call count");
 	zassert_equal(test_backend.transmit_buffer, test_buffer, "Incorrect buffer");
-	zassert_equal(test_backend.transmit_buffer_size, test_buffer_size,
-		      "Incorrect buffer size");
+	zassert_equal(test_backend.transmit_buffer_size, test_buffer_size, "Incorrect buffer size");
 	zassert_equal(atomic_get(&test_state), 0, "Unexpected state %u",
 		      (uint32_t)atomic_get(&test_state));
 	k_sleep(TEST_MODEM_PIPE_WAIT_TIMEOUT);
@@ -282,12 +328,74 @@ static void test_pipe_async_transmit(void)
 
 static void test_pipe_sync_transmit(void)
 {
+	bool is_chain = IS_ENABLED(CONFIG_TEST_PIPE_BACKEND_TRANSMIT_CHAIN);
+
 	zassert_equal(modem_pipe_transmit(test_pipe, test_buffer, test_buffer_size),
 		      test_buffer_size, "Failed to transmit");
-	zassert_true(test_backend.transmit_called, "transmit was not called");
+	zassert_equal(is_chain, test_backend.transmit_chain_called,
+		      "Unexpected transmit_chain call count");
+	zassert_equal(!is_chain, test_backend.transmit_called, "Unexpected transmit call count");
 	zassert_equal(test_backend.transmit_buffer, test_buffer, "Incorrect buffer");
-	zassert_equal(test_backend.transmit_buffer_size, test_buffer_size,
-		      "Incorrect buffer size");
+	zassert_equal(test_backend.transmit_buffer_size, test_buffer_size, "Incorrect buffer size");
+	zassert_equal(atomic_get(&test_state), BIT(TEST_MODEM_PIPE_EVENT_TRANSMIT_IDLE_BIT),
+		      "Unexpected state %u", (uint32_t)atomic_get(&test_state));
+}
+
+static void test_pipe_async_transmit_chain(void)
+{
+	const struct modem_pipe_data_fragment frags[2] = {
+		[0] = {.data = test_buffer, .size = test_buffer_size},
+		[1] = {.data = test_buffer, .size = 1},
+	};
+	int rc;
+
+	rc = modem_pipe_transmit_chain(test_pipe, frags, ARRAY_SIZE(frags));
+
+#ifdef CONFIG_TEST_PIPE_BACKEND_TRANSMIT_CHAIN
+	zassert_equal(rc, test_buffer_size + 1);
+	zassert_equal(0, test_backend.transmit_called);
+	zassert_equal(1, test_backend.transmit_chain_called);
+	zassert_equal(test_backend.frags, frags, "Unexpected fragment pointer");
+	zassert_equal(test_backend.num_frags, ARRAY_SIZE(frags), "Unexpected fragment counter");
+#else
+	zassert_equal(rc, test_buffer_size);
+	zassert_equal(1, test_backend.transmit_called);
+	zassert_equal(0, test_backend.transmit_chain_called);
+	zassert_equal(test_backend.transmit_buffer, test_buffer, "Incorrect buffer");
+	zassert_equal(test_backend.transmit_buffer_size, test_buffer_size, "Incorrect buffer size");
+#endif
+
+	zassert_equal(atomic_get(&test_state), 0, "Unexpected state %u",
+		      (uint32_t)atomic_get(&test_state));
+	k_sleep(TEST_MODEM_PIPE_WAIT_TIMEOUT);
+	zassert_equal(atomic_get(&test_state), BIT(TEST_MODEM_PIPE_EVENT_TRANSMIT_IDLE_BIT),
+		      "Unexpected state %u", (uint32_t)atomic_get(&test_state));
+}
+
+static void test_pipe_sync_transmit_chain(void)
+{
+	const struct modem_pipe_data_fragment frags[2] = {
+		[0] = {.data = test_buffer, .size = test_buffer_size},
+		[1] = {.data = test_buffer, .size = 1},
+	};
+	int rc;
+
+	rc = modem_pipe_transmit_chain(test_pipe, frags, ARRAY_SIZE(frags));
+
+#ifdef CONFIG_TEST_PIPE_BACKEND_TRANSMIT_CHAIN
+	zassert_equal(rc, test_buffer_size + 1);
+	zassert_equal(0, test_backend.transmit_called);
+	zassert_equal(1, test_backend.transmit_chain_called);
+	zassert_equal(test_backend.frags, frags, "Unexpected fragment pointer");
+	zassert_equal(test_backend.num_frags, ARRAY_SIZE(frags), "Unexpected fragment counter");
+#else
+	zassert_equal(rc, test_buffer_size);
+	zassert_equal(1, test_backend.transmit_called);
+	zassert_equal(0, test_backend.transmit_chain_called);
+	zassert_equal(test_backend.transmit_buffer, test_buffer, "Incorrect buffer");
+	zassert_equal(test_backend.transmit_buffer_size, test_buffer_size, "Incorrect buffer size");
+#endif
+
 	zassert_equal(atomic_get(&test_state), BIT(TEST_MODEM_PIPE_EVENT_TRANSMIT_IDLE_BIT),
 		      "Unexpected state %u", (uint32_t)atomic_get(&test_state));
 }
@@ -360,6 +468,7 @@ ZTEST(modem_pipe, test_sync_open_close)
 
 ZTEST(modem_pipe, test_async_transmit)
 {
+	modem_backend_fake_set_sync(&test_backend, false);
 	test_pipe_open();
 	test_reset();
 	test_pipe_async_transmit();
@@ -371,6 +480,22 @@ ZTEST(modem_pipe, test_sync_transmit)
 	test_pipe_open();
 	test_reset();
 	test_pipe_sync_transmit();
+}
+
+ZTEST(modem_pipe, test_async_transmit_chain)
+{
+	modem_backend_fake_set_sync(&test_backend, false);
+	test_pipe_open();
+	test_reset();
+	test_pipe_async_transmit_chain();
+}
+
+ZTEST(modem_pipe, test_sync_transmit_chain)
+{
+	modem_backend_fake_set_sync(&test_backend, true);
+	test_pipe_open();
+	test_reset();
+	test_pipe_sync_transmit_chain();
 }
 
 ZTEST(modem_pipe, test_attach)

--- a/tests/subsys/modem/modem_pipe/tests.yaml
+++ b/tests/subsys/modem/modem_pipe/tests.yaml
@@ -1,8 +1,12 @@
 # Copyright (c) 2023 Trackunit Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+common:
+  tags: modem_pipe
+  harness: ztest
+  platform_allow: native_sim
 tests:
-  modem.modem_pipe:
-    tags: modem_pipe
-    harness: ztest
-    platform_allow: native_sim
+  modem.modem_pipe: {}
+  modem.modem_pipe.transmit_chain:
+    extra_configs:
+      - CONFIG_TEST_PIPE_BACKEND_TRANSMIT_CHAIN=y


### PR DESCRIPTION
Extend the current modem pipe API to support transmitting an arbitrary chain of transmission buffers.
The existing function `modem_pipe_transmit` continues to work as it does now, regardless of backend support for `transmit_chain`.
The new function `modem_pipe_transmit_chain` works regardless of backend support for `transmit_chain`.

Handle sending the request and delimiter strings in a single call to the pipe backend. This has two advantages:
1. No time gap between request and delimiter on the interface (more efficient line utilization)
2. Fewer bytes transmitted on the line for pipes that perform wrapping (CMUX).

For example, sending "ATE0" + "\n" through CMUX now takes 11 bytes, instead of the previous 17 bytes (10 + 7):
```
[00:00:38.268,064] <wrn> modem_cmux: TX
                                     f9 0b ef 0b 41 54 45 30  0d 5d f9                |....ATE0 .].
```
The chained buffer send functionality is exposed through a new function in the modem pipe API, meaning all existing code does not require any changes to continue operating as before.

Validated with `zephyr/samples/net/modem_cellular` on a `nRF93M1 DK` with the `uart_isr` backend (stacked on my other nRF93M1 related PRs), with hexdumps injecting into the transmit interrupt to check for buffer splitting.
```
[00:00:01.988,828] <dbg> modem_chat.modem_chat_script_next: sending: ATE0
[00:00:01.988,872] <err> modem_backend_uart_isr: TX
                                                 41 54 45 30 0d 0a                                |ATE0..
...
[00:00:02.724,500] <dbg> modem_chat.modem_chat_script_next: sending: AT+CMUX=0,0,5,127
[00:00:02.724,543] <err> modem_backend_uart_isr: TX
                                                 41 54 2b 43 4d 55 58 3d  30 2c 30 2c 35 2c 31 32 |AT+CMUX= 0,0,5,12
                                                 37 0d 0a                                         |7..
... // After CMUX
[00:00:03.179,113] <dbg> modem_chat.modem_chat_script_next: sending: AT+CEREG=2
[00:00:03.179,184] <err> modem_backend_uart_isr: TX
                                                 f9 07 ef 19 41 54 2b 43  45 52 45 47 3d 32 0d 0a |....AT+C EREG=2..
                                                 25 f9                                            |%.
```

First attempt: #98541
Second attempt: #109366