### PR TITLE
soc: st: stm32h5x: keep Type-C dead-battery CC pull-downs for the UDC stack

### DIFF
--- a/soc/st/stm32/stm32h5x/soc.c
+++ b/soc/st/stm32/stm32h5x/soc.c
@@ -46,6 +46,14 @@ void soc_early_init_hook(void)
 	    (!IS_ENABLED(CONFIG_USB_DEVICE_DRIVER) && !IS_ENABLED(CONFIG_UDC_DRIVER))) {
 		/* Disable USB Type-C dead battery pull-down behavior */
 		LL_PWR_DisableUCPDDeadBattery();
+	} else {
+		/*
+		 * An earlier boot stage in the same power cycle (a bootloader
+		 * chain-loading this image without a hardware reset) may have
+		 * disabled the pull-downs already, so restore them explicitly
+		 * rather than merely skipping the disable above.
+		 */
+		LL_PWR_EnableUCPDDeadBattery();
 	}
 
 #endif /* PWR_UCPDR_UCPD_DBDIS */

--- a/soc/st/stm32/stm32h5x/soc.c
+++ b/soc/st/stm32/stm32h5x/soc.c
@@ -36,8 +36,14 @@ void soc_early_init_hook(void)
 	SystemCoreClock = 32000000;
 
 #if defined(PWR_UCPDR_UCPD_DBDIS)
+	/*
+	 * Only disable the Type-C dead battery CC pull-downs when no USB
+	 * device stack is in use: both the legacy stack (USB_DEVICE_DRIVER)
+	 * and the new usbd/UDC stack (UDC_DRIVER) need them, otherwise a
+	 * Type-C source sees no Rd and never applies VBUS.
+	 */
 	if (IS_ENABLED(CONFIG_DT_HAS_ST_STM32_UCPD_ENABLED) ||
-		!IS_ENABLED(CONFIG_USB_DEVICE_DRIVER)) {
+	    (!IS_ENABLED(CONFIG_USB_DEVICE_DRIVER) && !IS_ENABLED(CONFIG_UDC_DRIVER))) {
 		/* Disable USB Type-C dead battery pull-down behavior */
 		LL_PWR_DisableUCPDDeadBattery();
 	}


### PR DESCRIPTION
### What breaks today

Any STM32H5 board using the new usbd/UDC stack has a dead USB device
port. A Type-C host applies no VBUS and never sees the device at all —
enumeration does not fail, it never starts.

### Root cause

`soc_early_init_hook()` decides whether the SoC still needs the Type-C
dead-battery CC pull-downs:

```c
if (IS_ENABLED(CONFIG_DT_HAS_ST_STM32_UCPD_ENABLED) ||
	!IS_ENABLED(CONFIG_USB_DEVICE_DRIVER)) {
	LL_PWR_DisableUCPDDeadBattery();
}
```

The condition only knows the legacy USB device stack. A board on the new
stack (`CONFIG_USB_DEVICE_STACK_NEXT` → `CONFIG_UDC_DRIVER`, e.g.
`CONFIG_UDC_STM32`) has no UCPD devicetree node and does not enable
`CONFIG_USB_DEVICE_DRIVER`, so the hook classifies it as "no USB
present" and sets `PWR->UCPDR.DBDIS`. Without an Rd on CC, a Type-C
source never applies VBUS.

This is SoC-level, not board-level: it affects every H5 board on the new
USB device stack.

### Fix — commit 1

Extend the condition with `&& !IS_ENABLED(CONFIG_UDC_DRIVER)` so the
pull-downs are only removed when neither USB device stack is in use.

### Fix — commit 2 (separable)

Skipping the disable is not sufficient. `PWR->UCPDR.DBDIS` survives a
chain-load, and MCUboot's own build enables neither USB stack — so
MCUboot's pass through this same hook disables the pull-downs before the
application ever runs, and the application's now-correct condition
simply leaves the register alone. The application pass has to re-enable
them explicitly.

Split into its own commit deliberately: commit 1 is unambiguous, commit
2 is a policy choice (the application becomes authoritative over the
register) and can be dropped independently if reviewers disagree.

### Verification

Hardware: STM32H5F5J-DK (`stm32h5f5j_dk`), application on
`CONFIG_UDC_STM32`, booted through MCUboot, sampled over SWD on the
idling application:

| Configuration | `PWR->UCPDR` |
|---|---|
| stock main | `0x1` (DBDIS set — pull-downs off) |
| commit 1 only | `0x1` (MCUboot's pass persists) |
| commits 1 + 2 | `0x0` (pull-downs active) |

Note the register must be sampled non-intrusively on the running target;
halting under reset perturbs the boot-stage sequence being measured.

### Risk / scope

Confined to `soc_early_init_hook()` on STM32H5, and further to builds
where `PWR_UCPDR_UCPD_DBDIS` is defined. Boards with a UCPD node, and
boards with no USB device stack, keep their current behaviour exactly.
Commit 2 changes behaviour only for boards that do enable a USB device
stack — where leaving the pull-downs on is the intended state.

### Maintainers

`soc/st/stm32/` falls under **STM32 Platforms** — maintainer @erwango,
collaborators @FRASTM, @gautierg-st, @mathieuchopstm, @etienne-lms and
others per `MAINTAINERS.yml`.

## Compliance

`scripts/checkpatch.pl` is clean on every commit (0 errors, 0 warnings).
Build-verified against `main`: `nucleo_h563zi` with `samples/hello_world`,
and `stm32h573i_dk` with `samples/subsys/usb/cdc_acm` and
`CONFIG_USB_DEVICE_STACK_NEXT=y` — the latter compiles the new
`CONFIG_UDC_DRIVER` arm of the condition.
