### PR TITLE
drivers: usb: udc_stm32: release GCCFG.PWRDWN on STM32H5F5/H5E5 FS PHY

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1053,6 +1053,19 @@ int udc_stm32_init(const struct device *dev)
 	}
 #endif /* CONFIG_STM32_HAL2 */
 
+#if defined(STM32H5F5xx) || defined(STM32H5E5xx)
+	/*
+	 * HAL defect: USB_CoreInit() only releases the transceiver
+	 * power-down (GCCFG.PWRDWN) for USB_OTG_HS_EMBEDDED_PHY, so an
+	 * instance using the embedded FS PHY is left powered down and
+	 * presents no pull-up on D+/D-. Release it here until the HAL is
+	 * fixed.
+	 */
+	if (cfg->selected_phy == PCD_PHY_EMBEDDED) {
+		priv->pcd.Instance->GCCFG |= USB_OTG_GCCFG_PWRDWN;
+	}
+#endif /* STM32H5F5xx || STM32H5E5xx */
+
 	if (HAL_PCD_Stop(&priv->pcd) != HAL_OK) {
 		return -EIO;
 	}


### PR DESCRIPTION
### What breaks today

On STM32H5F5x/H5E5x, an OTG instance driving the embedded full-speed PHY
comes up silently broken: `HAL_PCD_Init()` returns `HAL_OK`, VBUS is
sensed valid, but D+/D- present no pull-up and the host never issues a
bus reset.

### Root cause

A HAL defect. `USB_CoreInit()` in `stm32h5xx_ll_usb.c` sets
`GCCFG.PWRDWN` — which releases the USB transceiver from power-down —
only on the branch taken when `cfg.phy_itface == USB_OTG_HS_EMBEDDED_PHY`
(the UTMI HS PHY path). An instance on the embedded FS PHY passes
`PCD_PHY_EMBEDDED`, since that PHY has no UTMI interface, so the branch
is skipped and `GCCFG` is never written at all.

The correct fix belongs in the ST HAL. This works around it in the
driver in the meantime — there is precedent for HAL workarounds in
`udc_stm32.c`.

### Fix

After a successful `HAL_PCD_Init()`, set `GCCFG.PWRDWN` when the
selected PHY is `PCD_PHY_EMBEDDED`, guarded to `STM32H5F5xx` /
`STM32H5E5xx`.

### Verification

Hardware: STM32H5F5J-DK, over SWD. `GCCFG` read back `0x00000000`
immediately after a successful `HAL_PCD_Init()` with the embedded FS PHY
selected. Setting `PWRDWN` is what makes the pull-up appear.

### Risk / scope

Preprocessed out entirely on every part other than H5F5x/H5E5x, and
further gated on `PCD_PHY_EMBEDDED` at runtime. It writes a bit the HAL
already intends to set on the sibling code path.

### Known gaps

- The workaround should be reported to ST so the HAL is fixed and this
  guard can later be removed.
- Not build-verified against `main` (see below).

### Maintainers

`drivers/*/*stm32*.c` falls under **STM32 Platforms** — @erwango and the
collaborator set above. USB device (UDC) reviewers should be looped in
for `udc_stm32.c`.

## Compliance

`scripts/checkpatch.pl` is clean (0 errors, 0 warnings). `udc_stm32.c`
builds against `main` (`stm32h573i_dk`, `samples/subsys/usb/cdc_acm`,
`CONFIG_USB_DEVICE_STACK_NEXT=y`).

Coverage caveat: the new code sits behind an `STM32H5F5xx || STM32H5E5xx`
guard and no upstream board exercises it today — `stm32h5f5j_dk` exists but
its SoC devicetree has no USB node, so a USB sample stops at the devicetree
stage before reaching this code. The change was validated on hardware, not
by an upstream board build.
