### PR TITLE
net: pkt: fix alloc tracking and optimize TX buffer usage

### DIFF
--- a/drivers/wifi/nxp/src/nxp_wifi_net.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_net.c
@@ -639,6 +639,15 @@ int nxp_wifi_internal_tx(const struct device *dev, struct net_pkt *pkt, bool pkt
 	/* Save the ethernet header */
 	net_pkt_set_overwrite(pkt, false);
 	net_pkt_read(pkt, ((outbuf_t *)wmm_outbuf)->eth_header, ETH_HDR_LEN);
+	/* The ETH header has been copied into outbuf->eth_header.
+	 * If the first frag only contained the ETH header, remove it
+	 * to free one tx_buf back to the pool.
+	 */
+	if (pkt->frags != NULL && pkt->frags->len == ETH_HDR_LEN &&
+	    pkt->frags->frags != NULL) {
+		net_pkt_frag_del(pkt, NULL, pkt->frags);
+	}
+
 	((outbuf_t *)wmm_outbuf)->buffer = pkt;
 	/* Save the data payload pointer without ethernet header */
 	if (net_pkt_len > ETH_HDR_LEN) {

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1282,7 +1282,7 @@ void net_pkt_trim_buffer(struct net_pkt *pkt)
 			}
 
 			buf->frags = NULL;
-			net_buf_unref(buf);
+			net_pkt_frag_unref(buf);
 		} else {
 			prev = buf;
 		}
@@ -2352,7 +2352,7 @@ int net_pkt_pull(struct net_pkt *pkt, size_t length)
 			if (buf) {
 				pkt->buffer = buf->frags;
 				buf->frags = NULL;
-				net_buf_unref(buf);
+				net_pkt_frag_unref(buf);
 			}
 
 			net_pkt_cursor_init(pkt);

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -190,6 +190,8 @@ static void net_pkt_alloc_add(void *alloc_data, bool is_pkt,
 		net_pkt_allocs[i].alloc_data = alloc_data;
 		net_pkt_allocs[i].func_alloc = func;
 		net_pkt_allocs[i].line_alloc = line;
+		net_pkt_allocs[i].func_free = NULL;
+		net_pkt_allocs[i].line_free = 0;
 
 		return;
 	}
@@ -1047,11 +1049,13 @@ static struct net_buf *pkt_alloc_buffer(struct net_pkt *pkt,
 
 		timeout = sys_timepoint_timeout(end);
 
-#if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
+#if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 		NET_FRAG_CHECK_IF_NOT_IN_USE(new, new->ref + 1);
+#endif
 
 		net_pkt_alloc_add(new, false, caller, line);
 
+#if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
 		NET_DBG("%s (%s) [%d] frag %p ref %u (%s():%d)",
 			pool2str(pool), get_name(pool), get_frees(pool),
 			new, new->ref, caller, line);
@@ -1067,7 +1071,7 @@ static struct net_buf *pkt_alloc_buffer(struct net_pkt *pkt,
 	return first;
 error:
 	if (first) {
-		net_buf_unref(first);
+		net_pkt_frag_unref(first);
 	}
 
 #if defined(CONFIG_NET_PKT_ALLOC_STATS)
@@ -1105,15 +1109,19 @@ static struct net_buf *pkt_alloc_buffer(struct net_pkt *pkt,
 
 	buf = net_buf_alloc_len(pool, size + headroom, timeout);
 
-#if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
-	NET_FRAG_CHECK_IF_NOT_IN_USE(buf, buf->ref + 1);
-
-	net_pkt_alloc_add(buf, false, caller, line);
-
-	NET_DBG("%s (%s) [%d] frag %p ref %u (%s():%d)",
-		pool2str(pool), get_name(pool), get_frees(pool),
-		buf, buf->ref, caller, line);
+	if (buf) {
+#if NET_LOG_LEVEL >= LOG_LEVEL_DBG
+		NET_FRAG_CHECK_IF_NOT_IN_USE(buf, buf->ref + 1);
 #endif
+
+		net_pkt_alloc_add(buf, false, caller, line);
+
+#if CONFIG_NET_PKT_LOG_LEVEL >= LOG_LEVEL_DBG
+		NET_DBG("%s (%s) [%d] frag %p ref %u (%s():%d)",
+			pool2str(pool), get_name(pool), get_frees(pool),
+			buf, buf->ref, caller, line);
+#endif
+	}
 
 #if defined(CONFIG_NET_PKT_ALLOC_STATS)
 	if (buf) {
@@ -1588,9 +1596,7 @@ static struct net_pkt *pkt_alloc(struct k_mem_slab *slab, k_timeout_t timeout)
 
 	net_pkt_set_vlan_tag(pkt, NET_VLAN_TAG_UNSPEC);
 
-#if NET_LOG_LEVEL >= LOG_LEVEL_DBG
 	net_pkt_alloc_add(pkt, true, caller, line);
-#endif
 
 	net_pkt_cursor_init(pkt);
 


### PR DESCRIPTION
This PR fixes issues with the net_pkt allocation tracking mechanism
(CONFIG_NET_DEBUG_NET_PKT_ALLOC) and optimizes TX buffer usage in the
NXP Wi-Fi driver zero-copy path.

## Problem

1. The `net allocs` shell command shows incomplete or stale allocation
   information because `net_pkt_alloc_add()` and `net_pkt_alloc_del()`
   are not called consistently across all alloc/free paths.

2. In the NXP Wi-Fi zero-copy TX path, the Ethernet header net_buf
   remains attached to the net_pkt after being copied into the outbuf,
   wasting one tx_buf slot per queued packet. Under TX backpressure
   (e.g. during roaming), this accelerates tx_buf pool exhaustion.

## Changes

- **Commit 1**: Fix alloc tracking so `net_pkt_alloc_add()` is called
  for all buffer allocations when CONFIG_NET_DEBUG_NET_PKT_ALLOC is
  enabled, regardless of log level. Also clear stale free info when
  reusing tracking slots.

- **Commit 2**: Replace `net_buf_unref()` with `net_pkt_frag_unref()`
  in `net_pkt_pull()` and `net_pkt_trim_buffer()` so that
  `net_pkt_alloc_del()` is called when the last reference is dropped.

- **Commit 3**: Release the ETH header fragment after copying it into
  the outbuf in the NXP Wi-Fi zero-copy TX path, freeing one tx_buf
  back to the pool immediately.

## Testing

Verified on RW610 (Zephyr):
- TCP upload: `net allocs` shows no stale used entries after completion
- UDP upload: clean alloc state confirmed
- Ping under roaming: reduced tx_buf pressure