### PR TITLE
samples: boards: st: power_mgmt: blinky: fix test harness regexp

### DIFF
--- a/samples/boards/st/power_mgmt/blinky/tests.yaml
+++ b/samples/boards/st/power_mgmt/blinky/tests.yaml
@@ -9,7 +9,7 @@ tests:
     harness_config:
       type: one_line
       regex:
-        - "Blinking every [0-9]+ seconds\n"
+        - "Blinking every [0-9]+ seconds"
     filter: dt_compat_enabled("zephyr,power-state") and
             dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
             (dt_compat_enabled("st,stm32-lptim") or


### PR DESCRIPTION
The regular expression should not include the end-of-line `\n` character. (mistake in #112999)