### PR TITLE
manifest: tf-m: include OTP provisionning for STM32U5

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -399,7 +399,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: f2f7a8edd109825de35b0c239c8fbb77b06f24a2
+      revision: pull/205/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee

--- a/west.yml
+++ b/west.yml
@@ -403,7 +403,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: e0b7b16a58d8f54a5833bd91f7227cf08742c8f3
+      revision: c821782bcf12b01807359a51de76066317cc616b
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Bump revision of trusted-firmware-m to include the OTP provisionning script and template for STM32U5x. Also include PSA Certified Cert ID for STM32U5x.

[TF-M PR reference](https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/205)