### PR TITLE
bluetooth: classic: goep: use assertions in accept callbacks

### DIFF
--- a/subsys/bluetooth/host/classic/bip.c
+++ b/subsys/bluetooth/host/classic/bip.c
@@ -105,7 +105,7 @@ static int bip_rfcomm_accept(struct bt_conn *conn, struct bt_goep_transport_rfco
 			     struct bt_goep **goep)
 {
 	struct bt_bip_rfcomm_server *bip_server = BIP_RFDCOMM_SERVER(server);
-	struct bt_bip *bip;
+	struct bt_bip *bip = NULL;
 	int err;
 
 	if (bip_server->accept == NULL) {
@@ -118,10 +118,7 @@ static int bip_rfcomm_accept(struct bt_conn *conn, struct bt_goep_transport_rfco
 		return err;
 	}
 
-	if (bip == NULL || bip->ops == NULL) {
-		LOG_ERR("Invalid bip instance");
-		return -EINVAL;
-	}
+	__ASSERT(bip != NULL && bip->ops != NULL, "Invalid bip instance");
 
 	bip->role = BT_BIP_ROLE_RESPONDER;
 	bip->goep.transport_ops = &bip_rfcomm_ops;
@@ -247,7 +244,7 @@ static int bip_l2cap_accept(struct bt_conn *conn, struct bt_goep_transport_l2cap
 			    struct bt_goep **goep)
 {
 	struct bt_bip_l2cap_server *bip_server = BIP_L2CAP_SERVER(server);
-	struct bt_bip *bip;
+	struct bt_bip *bip = NULL;
 	int err;
 
 	if (bip_server->accept == NULL) {
@@ -260,10 +257,7 @@ static int bip_l2cap_accept(struct bt_conn *conn, struct bt_goep_transport_l2cap
 		return err;
 	}
 
-	if (bip == NULL || bip->ops == NULL) {
-		LOG_WRN("Invalid parameter");
-		return -EINVAL;
-	}
+	__ASSERT(bip != NULL && bip->ops != NULL, "Invalid bip instance");
 
 	bip->role = BT_BIP_ROLE_RESPONDER;
 	bip->goep.transport_ops = &bip_l2cap_ops;

--- a/subsys/bluetooth/host/classic/goep.c
+++ b/subsys/bluetooth/host/classic/goep.c
@@ -199,7 +199,7 @@ static int goep_rfcomm_accept(struct bt_conn *conn, struct bt_rfcomm_server *ser
 			      struct bt_rfcomm_dlc **dlc)
 {
 	struct bt_goep_transport_rfcomm_server *rfcomm_server;
-	struct bt_goep *goep;
+	struct bt_goep *goep = NULL;
 	int err;
 
 	rfcomm_server = CONTAINER_OF(server, struct bt_goep_transport_rfcomm_server, rfcomm);
@@ -215,10 +215,8 @@ static int goep_rfcomm_accept(struct bt_conn *conn, struct bt_rfcomm_server *ser
 		return err;
 	}
 
-	if (goep == NULL || goep->v1 == NULL || goep->v2 != NULL || goep->transport_ops == NULL) {
-		LOG_DBG("Invalid parameter");
-		return -EINVAL;
-	}
+	__ASSERT(goep != NULL && goep->v1 != NULL && goep->v2 == NULL &&
+		 goep->transport_ops != NULL, "Invalid parameter of GOEP RFCOMM transport");
 
 	goep_rfcomm_init(conn, goep);
 
@@ -493,7 +491,7 @@ static int goep_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *serve
 			     struct bt_l2cap_chan **chan)
 {
 	struct bt_goep_transport_l2cap_server *l2cap_server;
-	struct bt_goep *goep;
+	struct bt_goep *goep = NULL;
 	int err;
 
 	l2cap_server = CONTAINER_OF(server, struct bt_goep_transport_l2cap_server, l2cap);
@@ -509,10 +507,8 @@ static int goep_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *serve
 		return err;
 	}
 
-	if (goep == NULL || goep->v2 == NULL || goep->v1 != NULL || goep->transport_ops == NULL) {
-		LOG_DBG("Invalid parameter");
-		return -EINVAL;
-	}
+	__ASSERT(goep != NULL && goep->v2 != NULL && goep->v1 == NULL &&
+		 goep->transport_ops != NULL, "Invalid parameter of GOEP L2CAP transport");
 
 	goep_l2cap_init(conn, goep);
 

--- a/subsys/bluetooth/host/classic/goep.c
+++ b/subsys/bluetooth/host/classic/goep.c
@@ -170,7 +170,7 @@ static const struct bt_obex_transport_ops goep_rfcomm_transport_ops = {
 	.disconnect = goep_rfcomm_disconnect,
 };
 
-static int goep_rfcomm_init(struct bt_conn *conn, struct bt_goep *goep)
+static void goep_rfcomm_init(struct bt_conn *conn, struct bt_goep *goep)
 {
 	struct bt_goep_transport_v1 *goep_transport_v1 = goep->v1;
 	uint32_t mtu;
@@ -183,11 +183,8 @@ static int goep_rfcomm_init(struct bt_conn *conn, struct bt_goep *goep)
 	/* Set the default MTU to the largest value that the configuration can support */
 	goep->obex.rx.mtu = mtu;
 
-	if (goep->obex.rx.mtu < GOEP_MIN_MTU) {
-		LOG_ERR("GOEP RFCOMM MTU less than minimum size (%d < %d)", goep->obex.rx.mtu,
-			GOEP_MIN_MTU);
-		return -EINVAL;
-	}
+	__ASSERT(goep->obex.rx.mtu >= GOEP_MIN_MTU, "GOEP RFCOMM MTU less than minimum size "
+		 "(%d < %d)", goep->obex.rx.mtu, GOEP_MIN_MTU);
 
 	bt_obex_reg_transport(&goep->obex, &goep_rfcomm_transport_ops);
 
@@ -196,8 +193,6 @@ static int goep_rfcomm_init(struct bt_conn *conn, struct bt_goep *goep)
 	goep_transport_v1->dlc.mtu = goep->obex.rx.mtu;
 	goep_transport_v1->dlc.ops = &goep_rfcomm_ops;
 	goep_transport_v1->dlc.required_sec_level = BT_SECURITY_L2;
-
-	return 0;
 }
 
 static int goep_rfcomm_accept(struct bt_conn *conn, struct bt_rfcomm_server *server,
@@ -225,11 +220,7 @@ static int goep_rfcomm_accept(struct bt_conn *conn, struct bt_rfcomm_server *ser
 		return -EINVAL;
 	}
 
-	err = goep_rfcomm_init(conn, goep);
-	if (err != 0) {
-		LOG_ERR("Fail to init goep");
-		return err;
-	}
+	goep_rfcomm_init(conn, goep);
 
 	*dlc = &goep->v1->dlc;
 
@@ -275,11 +266,7 @@ int bt_goep_transport_rfcomm_connect(struct bt_conn *conn, struct bt_goep *goep,
 		return -EINVAL;
 	}
 
-	err = goep_rfcomm_init(conn, goep);
-	if (err != 0) {
-		LOG_ERR("Fail to init goep");
-		return err;
-	}
+	goep_rfcomm_init(conn, goep);
 
 	err = bt_rfcomm_dlc_connect(conn, &goep->v1->dlc, channel);
 	if (err != 0) {
@@ -465,7 +452,7 @@ static const struct bt_obex_transport_ops goep_l2cap_transport_ops = {
 	.disconnect = goep_l2cap_disconnect,
 };
 
-static int goep_l2cap_init(struct bt_conn *conn, struct bt_goep *goep)
+static void goep_l2cap_init(struct bt_conn *conn, struct bt_goep *goep)
 {
 	struct bt_goep_transport_v2 *goep_transport_v2 = goep->v2;
 	uint32_t mtu;
@@ -478,11 +465,8 @@ static int goep_l2cap_init(struct bt_conn *conn, struct bt_goep *goep)
 	/* Set the default MTU to the largest value that the configuration can support */
 	goep->obex.rx.mtu = mtu;
 
-	if (goep->obex.rx.mtu < GOEP_MIN_MTU) {
-		LOG_ERR("GOEP L2CAP MTU less than minimum size (%d < %d)", goep->obex.rx.mtu,
-			GOEP_MIN_MTU);
-		return -EINVAL;
-	}
+	__ASSERT(goep->obex.rx.mtu >= GOEP_MIN_MTU, "GOEP L2CAP MTU less than minimum size "
+		 "(%d < %d)", goep->obex.rx.mtu, GOEP_MIN_MTU);
 
 	bt_obex_reg_transport(&goep->obex, &goep_l2cap_transport_ops);
 
@@ -503,8 +487,6 @@ static int goep_l2cap_init(struct bt_conn *conn, struct bt_goep *goep)
 	goep_transport_v2->chan.rx.fcs = BT_L2CAP_BR_FCS_16BIT;
 	goep_transport_v2->chan.chan.ops = &goep_l2cap_ops;
 	goep_transport_v2->chan.required_sec_level = BT_SECURITY_L2;
-
-	return 0;
 }
 
 static int goep_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
@@ -532,11 +514,7 @@ static int goep_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *serve
 		return -EINVAL;
 	}
 
-	err = goep_l2cap_init(conn, goep);
-	if (err != 0) {
-		LOG_ERR("Fail to init goep");
-		return err;
-	}
+	goep_l2cap_init(conn, goep);
 
 	*chan = &goep->v2->chan.chan;
 	atomic_set(&goep->_state, BT_GOEP_TRANSPORT_CONNECTING);
@@ -588,11 +566,7 @@ int bt_goep_transport_l2cap_connect(struct bt_conn *conn, struct bt_goep *goep, 
 		return -EBUSY;
 	}
 
-	err = goep_l2cap_init(conn, goep);
-	if (err != 0) {
-		LOG_ERR("Fail to init goep");
-		return err;
-	}
+	goep_l2cap_init(conn, goep);
 
 	err = bt_l2cap_chan_connect(conn, &goep->v2->chan.chan, psm);
 	if (err != 0) {

--- a/subsys/bluetooth/host/classic/goep.c
+++ b/subsys/bluetooth/host/classic/goep.c
@@ -175,7 +175,6 @@ static int goep_rfcomm_init(struct bt_conn *conn, struct bt_goep *goep)
 	struct bt_goep_transport_v1 *goep_transport_v1 = goep->v1;
 	uint32_t mtu;
 	uint32_t hdr_size;
-	int err;
 
 	hdr_size = BT_L2CAP_HDR_SIZE + BT_RFCOMM_OVERHEAD_SIZE;
 
@@ -190,11 +189,7 @@ static int goep_rfcomm_init(struct bt_conn *conn, struct bt_goep *goep)
 		return -EINVAL;
 	}
 
-	err = bt_obex_reg_transport(&goep->obex, &goep_rfcomm_transport_ops);
-	if (err != 0) {
-		LOG_ERR("Fail to reg transport ops");
-		return err;
-	}
+	bt_obex_reg_transport(&goep->obex, &goep_rfcomm_transport_ops);
 
 	goep->_acl = conn;
 	goep_transport_v1->goep = goep;
@@ -475,7 +470,6 @@ static int goep_l2cap_init(struct bt_conn *conn, struct bt_goep *goep)
 	struct bt_goep_transport_v2 *goep_transport_v2 = goep->v2;
 	uint32_t mtu;
 	uint32_t hdr_size;
-	int err;
 
 	hdr_size = sizeof(struct bt_l2cap_hdr);
 
@@ -490,11 +484,7 @@ static int goep_l2cap_init(struct bt_conn *conn, struct bt_goep *goep)
 		return -EINVAL;
 	}
 
-	err = bt_obex_reg_transport(&goep->obex, &goep_l2cap_transport_ops);
-	if (err != 0) {
-		LOG_ERR("Fail to reg transport ops");
-		return err;
-	}
+	bt_obex_reg_transport(&goep->obex, &goep_l2cap_transport_ops);
 
 	goep->_acl = conn;
 	goep_transport_v2->goep = goep;

--- a/subsys/bluetooth/host/classic/map.c
+++ b/subsys/bluetooth/host/classic/map.c
@@ -1318,7 +1318,7 @@ static const struct bt_obex_server_ops mce_mns_ops = {
 #define MNS_L2CAP_SERVER(server)  CONTAINER_OF(server, struct bt_map_mce_mns_l2cap_server, server)
 static int mce_mns_accept(struct bt_conn *conn, void *server, uint8_t type, struct bt_goep **goep)
 {
-	struct bt_map_mce_mns *mce_mns;
+	struct bt_map_mce_mns *mce_mns = NULL;
 	int err;
 
 	LOG_DBG("MCE MNS %s accept", type == MAP_TRANSPORT_TYPE_RFCOMM ? "RFCOMM" : "L2CAP");
@@ -1346,10 +1346,7 @@ static int mce_mns_accept(struct bt_conn *conn, void *server, uint8_t type, stru
 		return err;
 	}
 
-	if (mce_mns == NULL || mce_mns->_cb == NULL) {
-		LOG_WRN("Invalid parameter");
-		return -EINVAL;
-	}
+	__ASSERT(mce_mns != NULL && mce_mns->_cb != NULL, "Invalid mce_mns instance or callback");
 
 	mce_mns->goep.transport_ops = &mce_mns_transport_ops;
 	if (type == MAP_TRANSPORT_TYPE_RFCOMM) {
@@ -1926,7 +1923,7 @@ static const struct bt_obex_server_ops mse_mas_ops = {
 #define MAS_L2CAP_SERVER(server)  CONTAINER_OF(server, struct bt_map_mse_mas_l2cap_server, server)
 static int mse_mas_accept(struct bt_conn *conn, void *server, uint8_t type, struct bt_goep **goep)
 {
-	struct bt_map_mse_mas *mse_mas;
+	struct bt_map_mse_mas *mse_mas = NULL;
 	int err;
 
 	LOG_DBG("MSE MAS %s accept", type == MAP_TRANSPORT_TYPE_RFCOMM ? "RFCOMM" : "L2CAP");
@@ -1954,10 +1951,7 @@ static int mse_mas_accept(struct bt_conn *conn, void *server, uint8_t type, stru
 		return err;
 	}
 
-	if (mse_mas == NULL || mse_mas->_cb == NULL) {
-		LOG_WRN("Invalid parameter");
-		return -EINVAL;
-	}
+	__ASSERT(mse_mas != NULL && mse_mas->_cb != NULL, "Invalid mse_mas instance or callback");
 
 	mse_mas->goep.transport_ops = &mse_mas_transport_ops;
 	if (type == MAP_TRANSPORT_TYPE_RFCOMM) {

--- a/subsys/bluetooth/host/classic/obex.c
+++ b/subsys/bluetooth/host/classic/obex.c
@@ -1693,15 +1693,11 @@ int bt_obex_transport_disconnected(struct bt_obex *obex)
 	return 0;
 }
 
-int bt_obex_reg_transport(struct bt_obex *obex, const struct bt_obex_transport_ops *ops)
+void bt_obex_reg_transport(struct bt_obex *obex, const struct bt_obex_transport_ops *ops)
 {
-	if (obex == NULL || ops == NULL) {
-		LOG_WRN("Invalid parameter");
-		return -EINVAL;
-	}
+	__ASSERT(obex != NULL && ops != NULL, "Invalid obex instance or transport ops");
 
 	obex->_transport_ops = ops;
-	return 0;
 }
 
 int bt_obex_recv(struct bt_obex *obex, struct net_buf *buf)

--- a/subsys/bluetooth/host/classic/obex_internal.h
+++ b/subsys/bluetooth/host/classic/obex_internal.h
@@ -52,7 +52,7 @@ struct bt_obex_setpath_req_hdr {
 } __packed;
 
 /* OBEX initialization */
-int bt_obex_reg_transport(struct bt_obex *obex, const struct bt_obex_transport_ops *ops);
+void bt_obex_reg_transport(struct bt_obex *obex, const struct bt_obex_transport_ops *ops);
 
 /* Process the received OBEX packet */
 int bt_obex_recv(struct bt_obex *obex, struct net_buf *buf);

--- a/subsys/bluetooth/host/classic/pbap.c
+++ b/subsys/bluetooth/host/classic/pbap.c
@@ -1233,7 +1233,7 @@ static int pbap_pse_rfcomm_accept(struct bt_conn *conn,
 				  struct bt_goep **goep)
 {
 	struct bt_pbap_pse_rfcomm *pbap_pse_rfcomm;
-	struct bt_pbap_pse *pbap_pse;
+	struct bt_pbap_pse *pbap_pse = NULL;
 	int err;
 
 	pbap_pse_rfcomm = CONTAINER_OF(server, struct bt_pbap_pse_rfcomm, server);
@@ -1246,10 +1246,7 @@ static int pbap_pse_rfcomm_accept(struct bt_conn *conn,
 		return err;
 	}
 
-	if (pbap_pse == NULL) {
-		LOG_WRN("Invalid parameter");
-		return -EINVAL;
-	}
+	__ASSERT(pbap_pse != NULL, "Invalid pbap pse instance");
 
 	pbap_pse->_goep.transport_ops = &pse_rfcomm_transport_ops;
 	BT_GOEP_INIT_V1(&pbap_pse->_goep, &pbap_pse->_goep_transport.v1);
@@ -1265,7 +1262,7 @@ static int pbap_pse_l2cap_accept(struct bt_conn *conn,
 				 struct bt_goep **goep)
 {
 	struct bt_pbap_pse_l2cap *pbap_pse_l2cap;
-	struct bt_pbap_pse *pbap_pse;
+	struct bt_pbap_pse *pbap_pse = NULL;
 	int err;
 
 	pbap_pse_l2cap = CONTAINER_OF(server, struct bt_pbap_pse_l2cap, server);
@@ -1278,10 +1275,7 @@ static int pbap_pse_l2cap_accept(struct bt_conn *conn,
 		return err;
 	}
 
-	if (pbap_pse == NULL) {
-		LOG_WRN("Invalid parameter");
-		return -EINVAL;
-	}
+	__ASSERT(pbap_pse != NULL, "Invalid pbap pse instance");
 
 	pbap_pse->_goep.transport_ops = &pse_l2cap_transport_ops;
 	BT_GOEP_INIT_V2(&pbap_pse->_goep, &pbap_pse->_goep_transport.v2);


### PR DESCRIPTION
In original implementation, there is a corner case that the instance has been allocated by upper layer and passed it through `accept()` callbacks. And normally the allocated instance will be destroyed after the connection broken. While in the post-accept, due to some errors, it is possible that the connection may not be accepted by the logic following the function's `accept()`. And all of these errors are programming errors.

Replace programming error checking with runtime assertions in `accept()` functions. The parameter validation and initialization error checks are converted to `__ASSERT()` calls since these conditions indicate programming errors rather than runtime failures.

The change is used to treat invalid instance parameters as programming errors that should be caught during development.
