### PR TITLE
input: touch: require screen dimensions only when inverting

### DIFF
--- a/drivers/input/input_touch.c
+++ b/drivers/input/input_touch.c
@@ -10,9 +10,10 @@ void input_touchscreen_report_pos(const struct device *dev,
 		k_timeout_t timeout)
 {
 	const struct input_touchscreen_common_config *cfg = dev->config;
-	__ASSERT(cfg->inverted_y == (cfg->screen_height > 0),
+
+	__ASSERT(!cfg->inverted_y || cfg->screen_height > 0,
 		 "Y coordinate inversion requires screen-height");
-	__ASSERT(cfg->inverted_x == (cfg->screen_width > 0),
+	__ASSERT(!cfg->inverted_x || cfg->screen_width > 0,
 		 "X coordinate inversion requires screen-width");
 	const uint32_t reported_x_code = cfg->swapped_x_y ? INPUT_ABS_Y : INPUT_ABS_X;
 	const uint32_t reported_y_code = cfg->swapped_x_y ? INPUT_ABS_X : INPUT_ABS_Y;


### PR DESCRIPTION
The two dimension checks in `input_touchscreen_report_pos()` are written as equivalences:

```c
__ASSERT(cfg->inverted_x == (cfg->screen_width > 0),
	 "X coordinate inversion requires screen-width");
```

This asserts more than the message says. It does require a width when inverting, but it equally forbids declaring `screen-width` *without* asking for inversion — so a node that states the touchscreen's resolution for any other reason trips an assert whose text does not mention that case.

Several in-tree boards already do exactly that. All of these set `screen-width` / `screen-height` with no `inverted-x` or `inverted-y`, and fire the assert under `CONFIG_ASSERT`:

- `boards/st/stm32f469i_disco`
- `boards/st/stm32h573i_dk`
- `boards/st/stm32l562e_dk`
- `boards/adafruit/adafruit_2_8_tft_touch_v2`
- `boards/m5stack/m5stack_core2`
- `boards/lilygo/twatch_s3`
- `tests/.../g1120b0mipi.overlay`

Making the checks implications lets each property mean what its message says.

Note for the reviewer: this is also a prerequisite for a `display-width` / `display-height` scaling change I am proposing separately, which needs the dimensions declared without inversion — but it stands on its own as a fix.