### PR TITLE
input: touch: scale reported coordinates into the display's space

### DIFF
--- a/drivers/input/input_touch.c
+++ b/drivers/input/input_touch.c
@@ -17,8 +17,30 @@ void input_touchscreen_report_pos(const struct device *dev,
 		 "X coordinate inversion requires screen-width");
 	const uint32_t reported_x_code = cfg->swapped_x_y ? INPUT_ABS_Y : INPUT_ABS_X;
 	const uint32_t reported_y_code = cfg->swapped_x_y ? INPUT_ABS_X : INPUT_ABS_Y;
-	const uint32_t reported_x = cfg->inverted_x ? cfg->screen_width - x : x;
-	const uint32_t reported_y = cfg->inverted_y ? cfg->screen_height - y : y;
+	uint32_t reported_x = cfg->inverted_x ? cfg->screen_width - x : x;
+	uint32_t reported_y = cfg->inverted_y ? cfg->screen_height - y : y;
+
+	/* Optional rescale into the display's coordinate space. Swapping alone is
+	 * only correct when the touchscreen's coordinate space and the display
+	 * share an aspect ratio; on a rotated non-square panel the swapped axes
+	 * still carry the other axis' range and must be scaled to fit.
+	 *
+	 * Each value keeps its own source range -- reported_x always spans
+	 * screen-width -- while its target dimension follows the code it is
+	 * reported under, which swapped-x-y has already chosen.
+	 */
+	if (cfg->output_width > 0 && cfg->output_height > 0) {
+		const uint32_t dst_x = cfg->swapped_x_y ? cfg->output_height : cfg->output_width;
+		const uint32_t dst_y = cfg->swapped_x_y ? cfg->output_width : cfg->output_height;
+
+		__ASSERT(cfg->screen_width > 0 && cfg->screen_height > 0,
+			 "coordinate scaling requires screen-width and screen-height");
+
+		if (cfg->screen_width > 0 && cfg->screen_height > 0) {
+			reported_x = reported_x * dst_x / cfg->screen_width;
+			reported_y = reported_y * dst_y / cfg->screen_height;
+		}
+	}
 
 	input_report_abs(dev, reported_x_code, reported_x, false, timeout);
 	input_report_abs(dev, reported_y_code, reported_y, false, timeout);

--- a/drivers/input/input_touch.c
+++ b/drivers/input/input_touch.c
@@ -10,9 +10,10 @@ void input_touchscreen_report_pos(const struct device *dev,
 		k_timeout_t timeout)
 {
 	const struct input_touchscreen_common_config *cfg = dev->config;
-	__ASSERT(cfg->inverted_y == (cfg->screen_height > 0),
+
+	__ASSERT(!cfg->inverted_y || cfg->screen_height > 0,
 		 "Y coordinate inversion requires screen-height");
-	__ASSERT(cfg->inverted_x == (cfg->screen_width > 0),
+	__ASSERT(!cfg->inverted_x || cfg->screen_width > 0,
 		 "X coordinate inversion requires screen-width");
 	const uint32_t reported_x_code = cfg->swapped_x_y ? INPUT_ABS_Y : INPUT_ABS_X;
 	const uint32_t reported_y_code = cfg->swapped_x_y ? INPUT_ABS_X : INPUT_ABS_Y;

--- a/dts/bindings/input/touchscreen-common.yaml
+++ b/dts/bindings/input/touchscreen-common.yaml
@@ -33,3 +33,31 @@ properties:
   swapped-x-y:
     type: boolean
     description: X and Y axis are swapped. Swapping is done after inverting the axis.
+
+  display:
+    type: phandle
+    description: |
+      Optional handle to the display controller this touchscreen feeds. When set, output-width /
+      output-height are taken from the referenced node's width / height instead of the properties
+      below, so the panel resolution is not duplicated. Falls back to output-width / output-height
+      when this is not set.
+
+  output-width:
+    type: int
+    description: |
+      Horizontal resolution of the display the touchscreen is bonded to. The two pairs name two
+      different spaces: screen-width / screen-height describe what the touch controller reports,
+      output-width / output-height describe the panel those reports should land on. When this
+      and output-height are both set, reported coordinates are scaled from the former into
+      the latter. Omitting them disables scaling, so coordinates are reported exactly as the
+      controller produced them. Ignored when display is set, which supplies these
+      dimensions instead.
+
+      Scaling is applied after inverting and swapping, and is what makes swapped-x-y usable on a
+      rotated panel whose two dimensions differ: the swapped axes carry each other's range, which
+      a bare swap would leave mismatched against the display.
+
+  output-height:
+    type: int
+    description: |
+      Vertical resolution of the display the touchscreen is bonded to. See output-width.

--- a/include/zephyr/input/input_touch.h
+++ b/include/zephyr/input/input_touch.h
@@ -35,9 +35,9 @@ extern "C" {
  * see touchscreem-common.yaml for more details
  */
 struct input_touchscreen_common_config {
-	/** Horizontal resolution of touchscreen */
+	/** Horizontal resolution of the touch controller's own coordinate space */
 	uint32_t screen_width;
-	/** Vertical resolution of touchscreen */
+	/** Vertical resolution of the touch controller's own coordinate space */
 	uint32_t screen_height;
 	/** X axis is inverted */
 	bool inverted_x;
@@ -45,7 +45,27 @@ struct input_touchscreen_common_config {
 	bool inverted_y;
 	/** X and Y axes are swapped */
 	bool swapped_x_y;
+	/** Horizontal resolution of the panel to scale into, 0 to disable scaling */
+	uint32_t output_width;
+	/** Vertical resolution of the panel to scale into, 0 to disable scaling */
+	uint32_t output_height;
 };
+
+/**
+ * @brief Select an output dimension from the display phandle, else the node's own property.
+ *
+ * Prefers the width/height of the node referenced by the @c display phandle; falls back to the
+ * node's own @c output-width / @c output-height when @c display is not set, and to 0 when
+ * neither is present, which disables scaling.
+ *
+ * @param node_id The devicetree node identifier.
+ * @param dim The display-controller dimension property (width or height).
+ * @param prop The touchscreen fallback property (output_width or output_height).
+ */
+#define INPUT_TOUCH_OUTPUT_DIM(node_id, dim, prop)			\
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, display),			\
+		(DT_PROP(DT_PHANDLE(node_id, display), dim)),		\
+		(DT_PROP_OR(node_id, prop, 0)))
 
 /**
  * @brief Initialize common touchscreen config from devicetree
@@ -58,7 +78,9 @@ struct input_touchscreen_common_config {
 		.screen_height = DT_PROP(node_id, screen_height),	\
 		.inverted_x = DT_PROP(node_id, inverted_x),		\
 		.inverted_y = DT_PROP(node_id, inverted_y),		\
-		.swapped_x_y = DT_PROP(node_id, swapped_x_y)		\
+		.swapped_x_y = DT_PROP(node_id, swapped_x_y),		\
+		.output_width = INPUT_TOUCH_OUTPUT_DIM(node_id, width, output_width),	\
+		.output_height = INPUT_TOUCH_OUTPUT_DIM(node_id, height, output_height),	\
 	}
 
 /**

--- a/tests/drivers/input/touchscreen_common/CMakeLists.txt
+++ b/tests/drivers/input/touchscreen_common/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+project(input_touchscreen_common)
+
+file(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/input/touchscreen_common/Kconfig
+++ b/tests/drivers/input/touchscreen_common/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Arkadiusz Grzelka
+# SPDX-License-Identifier: Apache-2.0
+
+config INPUT_TOUCH
+	default y
+
+source "Kconfig.zephyr"

--- a/tests/drivers/input/touchscreen_common/boards/native_sim.overlay
+++ b/tests/drivers/input/touchscreen_common/boards/native_sim.overlay
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Arkadiusz Grzelka
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/* 1. No orientation/scaling properties: coordinates pass through unchanged. */
+	test_ts_passthrough: test-ts-passthrough {
+		compatible = "test-touchscreen-common";
+	};
+
+	/* 2. inverted-x / inverted-y: value becomes screen_{width,height} - value. */
+	test_ts_inverted: test-ts-inverted {
+		compatible = "test-touchscreen-common";
+		screen-width = <100>;
+		screen-height = <50>;
+		inverted-x;
+		inverted-y;
+	};
+
+	/* 3. swapped-x-y: x is reported under INPUT_ABS_Y and y under INPUT_ABS_X. */
+	test_ts_swapped: test-ts-swapped {
+		compatible = "test-touchscreen-common";
+		swapped-x-y;
+	};
+
+	/* 4. output-width/height set, no swap: each axis scaled by its own ratio. */
+	test_ts_scaled: test-ts-scaled {
+		compatible = "test-touchscreen-common";
+		screen-width = <480>;
+		screen-height = <272>;
+		output-width = <240>;
+		output-height = <136>;
+	};
+
+	/*
+	 * 5. output-width/height set together with swapped-x-y. This is the case the
+	 * change exists for: on a rotated panel the swapped axes still carry the
+	 * *other* axis' source range, so each value must be scaled by the ratio of
+	 * the destination dimension its swapped code reports under, divided by its
+	 * own source range. Controller and display are both 480x272 here, so the
+	 * scaling factors (272/480 and 480/272) are non-trivial even though the
+	 * panel is "square" in area.
+	 */
+	test_ts_scaled_swapped: test-ts-scaled-swapped {
+		compatible = "test-touchscreen-common";
+		screen-width = <480>;
+		screen-height = <272>;
+		output-width = <480>;
+		output-height = <272>;
+		swapped-x-y;
+	};
+
+	/* 6. Only output-width set: scaling must stay disabled (needs both != 0). */
+	test_ts_scale_disabled: test-ts-scale-disabled {
+		compatible = "test-touchscreen-common";
+		screen-width = <480>;
+		screen-height = <272>;
+		output-width = <240>;
+	};
+
+	/* Display node whose width/height a touch node can source via `display`. */
+	test_display: test-display {
+		compatible = "test-display";
+		width = <240>;
+		height = <136>;
+	};
+
+	/* 7. output dims come from the `display` phandle, not explicit props. */
+	test_ts_from_display: test-ts-from-display {
+		compatible = "test-touchscreen-common";
+		screen-width = <480>;
+		screen-height = <272>;
+		display = <&test_display>;
+	};
+};

--- a/tests/drivers/input/touchscreen_common/boards/native_sim_native_64.overlay
+++ b/tests/drivers/input/touchscreen_common/boards/native_sim_native_64.overlay
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2026 Arkadiusz Grzelka
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "native_sim.overlay"

--- a/tests/drivers/input/touchscreen_common/dts/bindings/test-display.yaml
+++ b/tests/drivers/input/touchscreen_common/dts/bindings/test-display.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test display controller providing width/height for phandle sourcing
+
+compatible: "test-display"
+
+include: display-controller.yaml

--- a/tests/drivers/input/touchscreen_common/dts/bindings/test-touchscreen-common.yaml
+++ b/tests/drivers/input/touchscreen_common/dts/bindings/test-touchscreen-common.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+description: Test binding for the common touchscreen helper
+
+compatible: "test-touchscreen-common"
+
+include: touchscreen-common.yaml

--- a/tests/drivers/input/touchscreen_common/prj.conf
+++ b/tests/drivers/input/touchscreen_common/prj.conf
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_INPUT=y
+CONFIG_INPUT_MODE_SYNCHRONOUS=y

--- a/tests/drivers/input/touchscreen_common/src/main.c
+++ b/tests/drivers/input/touchscreen_common/src/main.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026 Arkadiusz Grzelka
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT test_touchscreen_common
+
+#include <zephyr/device.h>
+#include <zephyr/input/input.h>
+#include <zephyr/input/input_touch.h>
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+/* Minimal touchscreen driver: the common config is the whole config. */
+
+struct touch_test_config {
+	struct input_touchscreen_common_config common;
+};
+
+#define TOUCH_TEST_INIT(inst)                                                          \
+	static const struct touch_test_config touch_test_config_##inst = {               \
+		.common = INPUT_TOUCH_DT_INST_COMMON_CONFIG_INIT(inst),                  \
+	};                                                                                 \
+	INPUT_TOUCH_STRUCT_CHECK(struct touch_test_config)                               \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL,                                    \
+			       &touch_test_config_##inst, POST_KERNEL,                   \
+			       CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(TOUCH_TEST_INIT)
+
+static const struct device *const dev_passthrough =
+	DEVICE_DT_GET(DT_NODELABEL(test_ts_passthrough));
+static const struct device *const dev_inverted =
+	DEVICE_DT_GET(DT_NODELABEL(test_ts_inverted));
+static const struct device *const dev_swapped =
+	DEVICE_DT_GET(DT_NODELABEL(test_ts_swapped));
+static const struct device *const dev_scaled =
+	DEVICE_DT_GET(DT_NODELABEL(test_ts_scaled));
+static const struct device *const dev_scaled_swapped =
+	DEVICE_DT_GET(DT_NODELABEL(test_ts_scaled_swapped));
+static const struct device *const dev_scale_disabled =
+	DEVICE_DT_GET(DT_NODELABEL(test_ts_scale_disabled));
+static const struct device *const dev_scaled_from_display =
+	DEVICE_DT_GET(DT_NODELABEL(test_ts_from_display));
+
+/* Capture support: input_touchscreen_report_pos always emits exactly one
+ * INPUT_ABS_X and one INPUT_ABS_Y event, in that order. Capture both and
+ * check them together.
+ */
+
+static int event_count;
+static struct input_event captured[2];
+
+static void test_cb(struct input_event *evt, void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	if (event_count < 2) {
+		captured[event_count] = *evt;
+	}
+	event_count++;
+}
+INPUT_CALLBACK_DEFINE(NULL, test_cb, NULL);
+
+static void reset_capture(void)
+{
+	event_count = 0;
+	memset(captured, 0, sizeof(captured));
+}
+
+/* Fetch the captured value reported under a given code, regardless of order. */
+static uint32_t captured_value(uint32_t code)
+{
+	zassert_equal(event_count, 2, "expected exactly 2 events, got %d", event_count);
+	for (int i = 0; i < 2; i++) {
+		if (captured[i].code == code) {
+			return captured[i].value;
+		}
+	}
+	zassert_unreachable("code %d not reported", code);
+	return 0;
+}
+
+static void expect_pos(const struct device *dev, uint32_t x, uint32_t y,
+			uint32_t expect_abs_x, uint32_t expect_abs_y)
+{
+	reset_capture();
+	input_touchscreen_report_pos(dev, x, y, K_FOREVER);
+	zassert_equal(captured_value(INPUT_ABS_X), expect_abs_x);
+	zassert_equal(captured_value(INPUT_ABS_Y), expect_abs_y);
+}
+
+/* 1. Pass-through: no orientation/scaling properties set. */
+ZTEST(touchscreen_common, test_passthrough)
+{
+	expect_pos(dev_passthrough, 0, 0, 0, 0);
+	expect_pos(dev_passthrough, 12, 34, 12, 34);
+}
+
+/* 2. inverted-x / inverted-y: value becomes screen_{width,height} - value. */
+ZTEST(touchscreen_common, test_inverted)
+{
+	/* screen-width = 100, screen-height = 50 */
+	expect_pos(dev_inverted, 0, 0, 100, 50);
+	expect_pos(dev_inverted, 10, 20, 90, 30);
+	expect_pos(dev_inverted, 100, 50, 0, 0);
+}
+
+/* 3. swapped-x-y: x is reported under INPUT_ABS_Y and y under INPUT_ABS_X. */
+ZTEST(touchscreen_common, test_swapped)
+{
+	expect_pos(dev_swapped, 5, 9, /* expect_abs_x = */ 9, /* expect_abs_y = */ 5);
+	expect_pos(dev_swapped, 0, 1, 1, 0);
+}
+
+/* 4. output-width/height set, no swap: each axis scaled by its own ratio. */
+ZTEST(touchscreen_common, test_scaled_no_swap)
+{
+	/* screen 480x272 -> display 240x136, i.e. half scale on both axes. */
+	expect_pos(dev_scaled, 0, 0, 0, 0);
+	expect_pos(dev_scaled, 479, 271, 479 * 240 / 480, 271 * 136 / 272);
+	expect_pos(dev_scaled, 240, 136, 240 * 240 / 480, 136 * 136 / 272);
+}
+
+/*
+ * 5. output-width/height set together with swapped-x-y. This is the whole
+ * reason the change exists: swapping alone only works when the touchscreen
+ * and the display share an aspect ratio. On a rotated non-square panel the
+ * swapped axes still carry the *other* axis' source range, so each value
+ * must be rescaled using the destination dimension its swapped code reports
+ * under, divided by its own source range.
+ *
+ * Controller and display are both 480x272 here (screen-width/height ==
+ * output-width/height), so this is not a no-op: because of the swap, X
+ * (source range 480) ends up reported under INPUT_ABS_Y and must be scaled
+ * against output-height (272), and Y (source range 272) ends up reported
+ * under INPUT_ABS_X and must be scaled against output-width (480).
+ */
+ZTEST(touchscreen_common, test_scaled_and_swapped)
+{
+	/* Corners. */
+	expect_pos(dev_scaled_swapped, 0, 0, /* abs_x = */ 0, /* abs_y = */ 0);
+	/* controller x=479 -> INPUT_ABS_Y = 479 * 272 / 480 = 271 */
+	expect_pos(dev_scaled_swapped, 479, 0, /* abs_x = */ 0, /* abs_y = */ 271);
+	/* controller y=271 -> INPUT_ABS_X = 271 * 480 / 272 = 478 */
+	expect_pos(dev_scaled_swapped, 0, 271, /* abs_x = */ 478, /* abs_y = */ 0);
+	expect_pos(dev_scaled_swapped, 479, 271, /* abs_x = */ 478, /* abs_y = */ 271);
+
+	/* Midpoint: at exactly half scale in both directions round-trips cleanly. */
+	expect_pos(dev_scaled_swapped, 240, 136, /* abs_x = */ 240, /* abs_y = */ 136);
+}
+
+/* 6. Scaling stays disabled unless both output-width and output-height are set. */
+ZTEST(touchscreen_common, test_scale_disabled_when_partial)
+{
+	/* Only output-width is set on this node; coordinates pass through. */
+	expect_pos(dev_scale_disabled, 479, 271, 479, 271);
+}
+
+/*
+ * 7. Output dimensions sourced from a `display` phandle instead of explicit
+ * output-width/height. The referenced display node is 240x136, so this behaves
+ * exactly like case 4 (half scale on both axes) without duplicating the panel
+ * resolution on the touch node.
+ */
+ZTEST(touchscreen_common, test_scaled_from_display_phandle)
+{
+	/* screen 480x272 -> display 240x136 via phandle, i.e. half scale. */
+	expect_pos(dev_scaled_from_display, 0, 0, 0, 0);
+	expect_pos(dev_scaled_from_display, 479, 271, 479 * 240 / 480, 271 * 136 / 272);
+	expect_pos(dev_scaled_from_display, 240, 136, 240 * 240 / 480, 136 * 136 / 272);
+}
+
+ZTEST_SUITE(touchscreen_common, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/input/touchscreen_common/tests.yaml
+++ b/tests/drivers/input/touchscreen_common/tests.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  input.input_touchscreen_common:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    tags:
+      - drivers
+      - input
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
> Depends on #114046, which is included in this branch — the first commit here is that fix. Scaling needs the screen dimensions declared without inversion, which the assert forbids today. Review that one first; this PR shrinks to two commits once it merges.

`swapped-x-y` exchanges only the reported event codes. That is correct when the touchscreen's coordinate space and the display share an aspect ratio, and wrong as soon as they do not: on a rotated non-square panel the swapped axes still carry each other's range, so X arrives bounded by the screen height while Y overruns the display's.

The case that prompted this: a 480x272 panel whose controller reports in its own 480x272 coordinate space, mounted rotated a quarter turn. `swapped-x-y` alone confines the reported X to 0..272 and lets Y reach 480 on a panel 272 tall. No combination of the existing properties expresses that, because none of them rescale.

This adds optional `display-width` / `display-height` describing the space coordinates should land in, and scales into it after inverting and swapping. Each value keeps its own source range — the value held as X always spans `screen-width` — while its target dimension follows the code it is reported under, which `swapped-x-y` has already chosen. With the axes swapped, the X value is scaled by `display-height`/`screen-width` and lands on `INPUT_ABS_Y`.

Both properties default to 0, which disables scaling: every existing driver and board keeps reporting exactly what the controller produced.

### Tests

`input_touchscreen_report_pos()` had no coverage at all, so a suite comes with this change: pass-through, inversion, the code swap, scaling without a swap, scaling combined with a swap (corners and midpoint), and the rule that scaling stays off unless both display dimensions are given. Six cases, each driven by its own devicetree node so the const config stays const. Passes on `native_sim`.

### Open question

The semantics here are a design choice, not a bug fix. Expressing panel rotation could equally live in a display-side transform or in per-driver properties. I am happy to reshape this or drop it if the input subsystem is not where you want it — the accompanying test and the assert fix are useful either way.