### PR TITLE
input: cf1133: report through the common touchscreen helper

### DIFF
--- a/drivers/input/Kconfig.cf1133
+++ b/drivers/input/Kconfig.cf1133
@@ -6,6 +6,7 @@ menuconfig INPUT_CF1133
 	default y
 	depends on DT_HAS_SITRONIX_CF1133_ENABLED
 	select I2C
+	select INPUT_TOUCH
 	help
 	  Enable driver for Sitronix capacitive touch panel
 	  controller. This driver should support CF1133.

--- a/drivers/input/input_cf1133.c
+++ b/drivers/input/input_cf1133.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/input/input.h>
+#include <zephyr/input/input_touch.h>
 #include <zephyr/logging/log.h>
 #include <stdbool.h>
 
@@ -64,6 +65,8 @@ LOG_MODULE_REGISTER(cf1133, CONFIG_INPUT_LOG_LEVEL);
 
 /* CF1133 configuration (DT) */
 struct cf1133_config {
+	/** Common touchscreen config, must stay first. */
+	struct input_touchscreen_common_config common;
 	/** I2C bus. */
 	struct i2c_dt_spec bus;
 #ifdef CONFIG_INPUT_CF1133_INTERRUPT
@@ -71,6 +74,8 @@ struct cf1133_config {
 	struct gpio_dt_spec int_gpio;
 #endif
 };
+
+INPUT_TOUCH_STRUCT_CHECK(struct cf1133_config);
 
 /* CF1133 data */
 struct cf1133_data {
@@ -212,14 +217,12 @@ static int cf1133_process(const struct device *dev)
 
 		if (!data->pressed_old) {
 			/* Finger pressed */
-			input_report_abs(dev, INPUT_ABS_X, x, false, K_FOREVER);
-			input_report_abs(dev, INPUT_ABS_Y, y, false, K_FOREVER);
+			input_touchscreen_report_pos(dev, x, y, K_FOREVER);
 			input_report_key(dev, INPUT_BTN_TOUCH, 1, true, K_FOREVER);
 			LOG_DBG("Finger is touching x = %i y = %i", x, y);
 		} else if (data->pressed_old) {
 			/* Continuous pressed */
-			input_report_abs(dev, INPUT_ABS_X, x, false, K_FOREVER);
-			input_report_abs(dev, INPUT_ABS_Y, y, false, K_FOREVER);
+			input_touchscreen_report_pos(dev, x, y, K_FOREVER);
 			LOG_DBG("Finger keeps touching x = %i y = %i", x, y);
 		}
 	} else {
@@ -320,6 +323,7 @@ static int cf1133_init(const struct device *dev)
 
 #define CF1133_INIT(index)								\
 	static const struct cf1133_config cf1133_config_##index = {			\
+		.common = INPUT_TOUCH_DT_INST_COMMON_CONFIG_INIT(index),		\
 		.bus = I2C_DT_SPEC_INST_GET(index),					\
 		IF_ENABLED(CONFIG_INPUT_CF1133_INTERRUPT,				\
 		(.int_gpio = GPIO_DT_SPEC_INST_GET(index, int_gpios),			\

--- a/dts/bindings/input/sitronix,cf1133.yaml
+++ b/dts/bindings/input/sitronix,cf1133.yaml
@@ -8,7 +8,7 @@ description: CF1133 capacitive touch panels
 
 compatible: "sitronix,cf1133"
 
-include: i2c-device.yaml
+include: [i2c-device.yaml, touchscreen-common.yaml]
 
 properties:
   int-gpios:


### PR DESCRIPTION
`input_cf1133.c` reports raw controller coordinates straight to `INPUT_ABS_X` / `INPUT_ABS_Y`, so none of the `touchscreen-common` orientation properties reach it — a board wiring this part to a rotated or mirrored panel has no way to describe that in devicetree. Every other touch driver in the tree goes through `input_touchscreen_report_pos()`.

This routes both report paths through the helper and includes `touchscreen-common.yaml` in the binding. `select INPUT_TOUCH` comes with it: `input_touch.c` is gated on that symbol, so without it the helper is never compiled and the driver fails to link.

Behaviour is unchanged for existing users — with none of the orientation properties set the helper passes coordinates through untouched.

Context: found while driving a Sitronix ST1633I, which the tree already treats as CF1133-compatible (see `st_lcd_dsi_mb1835`, whose `st1633i@70` node uses `compatible = "sitronix,cf1133"`).

Independent of #114046 and #114047, though it is what makes those useful on this driver.