### PR TITLE
drivers: input: paw32xx: Use the cached device in the work handler

### DIFF
--- a/drivers/input/input_paw32xx.c
+++ b/drivers/input/input_paw32xx.c
@@ -218,8 +218,8 @@ static void paw32xx_motion_work_handler(struct k_work *work)
 
 	LOG_DBG("x=%4d y=%4d", x, y);
 
-	input_report_rel(data->dev, cfg->axis_x, x, false, K_FOREVER);
-	input_report_rel(data->dev, cfg->axis_y, y, true, K_FOREVER);
+	input_report_rel(dev, cfg->axis_x, x, false, K_FOREVER);
+	input_report_rel(dev, cfg->axis_y, y, true, K_FOREVER);
 
 	/* Trigger one more scan if more data is available. */
 	if (gpio_pin_get_dt(&cfg->motion_gpio)) {


### PR DESCRIPTION
The motion work handler already caches data->dev in a local, so reuse it in both input_report_rel() calls instead of dereferencing data->dev again.