### PR TITLE
drivers: input: pmw3610: Use the cached device in the work handler

### DIFF
--- a/drivers/input/input_pmw3610.c
+++ b/drivers/input/input_pmw3610.c
@@ -218,8 +218,8 @@ static void pmw3610_motion_work_handler(struct k_work *work)
 	x = sign_extend(x, PMW3610_DATA_SIZE_BITS - 1);
 	y = sign_extend(y, PMW3610_DATA_SIZE_BITS - 1);
 
-	input_report_rel(data->dev, cfg->axis_x, x, false, K_FOREVER);
-	input_report_rel(data->dev, cfg->axis_y, y, true, K_FOREVER);
+	input_report_rel(dev, cfg->axis_x, x, false, K_FOREVER);
+	input_report_rel(dev, cfg->axis_y, y, true, K_FOREVER);
 
 	if (cfg->smart_mode) {
 		uint16_t shutter_val = sys_get_be16(&burst_data[BURST_SHUTTER_HI]);


### PR DESCRIPTION
The work handler already caches data->dev in a local, so reuse it in both input_report_rel() calls instead of dereferencing data->dev again.