### PR TITLE
drivers: input: chsc5x: Make command buffers static const

### DIFF
--- a/drivers/input/input_analog_axis_settings.c
+++ b/drivers/input/input_analog_axis_settings.c
@@ -21,9 +21,10 @@ LOG_MODULE_REGISTER(analog_axis_settings, CONFIG_INPUT_LOG_LEVEL);
 static void analog_axis_calibration_log(const struct device *dev)
 {
 	struct analog_axis_calibration cal;
+	int axes = analog_axis_num_axes(dev);
 	int i;
 
-	for (i = 0; i < analog_axis_num_axes(dev); i++) {
+	for (i = 0; i < axes; i++) {
 		analog_axis_calibration_get(dev, i, &cal);
 
 		LOG_INF("%s: ch: %d min: %d max: %d deadzone: %d",

--- a/drivers/input/input_bee_keyscan.c
+++ b/drivers/input/input_bee_keyscan.c
@@ -160,6 +160,8 @@ static void bee_keyscan_process_matrix(const struct device *dev, uint8_t new_pre
 	const struct bee_keyscan_config *config = dev->config;
 	const struct input_kbd_matrix_common_config *cfg_common = &config->common;
 	kbd_row_t *matrix_new_state = cfg_common->matrix_new_state;
+	const uint8_t row_size = cfg_common->row_size;
+	const uint8_t col_size = cfg_common->col_size;
 	__maybe_unused struct bee_keyscan_data *data = dev->data;
 	__maybe_unused KEYSCAN_TypeDef *keyscan = config->reg;
 
@@ -167,7 +169,7 @@ static void bee_keyscan_process_matrix(const struct device *dev, uint8_t new_pre
 	KeyScan_Cmd(keyscan, DISABLE);
 #endif
 
-	for (int c = 0; c < cfg_common->col_size; c++) {
+	for (int c = 0; c < col_size; c++) {
 		matrix_new_state[c] = 0;
 	}
 
@@ -175,7 +177,7 @@ static void bee_keyscan_process_matrix(const struct device *dev, uint8_t new_pre
 		uint8_t r = new_keys[i].row;
 		uint8_t c = new_keys[i].column;
 
-		if (r >= cfg_common->row_size || c >= cfg_common->col_size) {
+		if (r >= row_size || c >= col_size) {
 			continue;
 		}
 

--- a/drivers/input/input_chsc5x.c
+++ b/drivers/input/input_chsc5x.c
@@ -68,7 +68,7 @@ static void chsc5x_work_handler(struct k_work *work)
 	uint16_t row, col;
 	bool is_pressed;
 	int ret;
-	const uint8_t write_buffer[] = {
+	static const uint8_t write_buffer[] = {
 		CHSC5X_BASE_ADDR1,
 		CHSC5X_BASE_ADDR2,
 		CHSC5X_BASE_ADDR3,
@@ -112,7 +112,7 @@ static int chsc5x_verify_ic(const struct device *dev)
 {
 	const struct chsc5x_config *cfg = dev->config;
 	int ret;
-	const uint8_t write_buffer[] = {
+	static const uint8_t write_buffer[] = {
 		CHSC5X_BASE_ADDR1,
 		CHSC5X_BASE_ADDR2,
 		CHSC5X_BASE_ADDR3,
@@ -198,7 +198,7 @@ static int chsc5x_pm_action(const struct device *dev, enum pm_device_action acti
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND: {
-		const uint8_t write_buffer[] = {
+		static const uint8_t write_buffer[] = {
 			CHSC5X_BASE_ADDR1,
 			CHSC5X_BASE_ADDR2,
 			CHSC5X_BASE_ADDR3,

--- a/drivers/input/input_gpio_kbd_matrix.c
+++ b/drivers/input/input_gpio_kbd_matrix.c
@@ -70,10 +70,12 @@ static void gpio_kbd_matrix_drive_column(const struct device *dev, int col)
 		return;
 	}
 
+	uint32_t changed = data->last_col_state ^ state;
+
 	for (int i = 0; i < common->col_size; i++) {
 		const struct gpio_dt_spec *gpio = &cfg->col_gpio[i];
 
-		if ((data->last_col_state ^ state) & BIT(i)) {
+		if (changed & BIT(i)) {
 			if (cfg->col_drive_inactive) {
 				gpio_pin_set_dt(gpio, state & BIT(i));
 			} else if (state & BIT(i)) {

--- a/drivers/input/input_gpio_qdec.c
+++ b/drivers/input/input_gpio_qdec.c
@@ -129,9 +129,10 @@ static void gpio_qdec_idle_mode(const struct device *dev)
 static uint8_t gpio_qdec_get_step(const struct device *dev)
 {
 	const struct gpio_qdec_config *cfg = dev->config;
+	bool idle_polling = gpio_qdec_idle_polling_mode(dev);
 	uint8_t step = 0x00;
 
-	if (gpio_qdec_idle_polling_mode(dev)) {
+	if (idle_polling) {
 		for (int i = 0; i < cfg->led_gpio_count; i++) {
 			gpio_pin_set_dt(&cfg->led_gpio[i], 1);
 		}
@@ -146,7 +147,7 @@ static uint8_t gpio_qdec_get_step(const struct device *dev)
 		step |= 0x02;
 	}
 
-	if (gpio_qdec_idle_polling_mode(dev)) {
+	if (idle_polling) {
 		for (int i = 0; i < cfg->led_gpio_count; i++) {
 			gpio_pin_set_dt(&cfg->led_gpio[i], 0);
 		}

--- a/drivers/input/input_gt911.c
+++ b/drivers/input/input_gt911.c
@@ -148,7 +148,8 @@ static int gt911_process(const struct device *dev)
 	points = status & GT911_TOUCH_POINTS_MSK;
 
 	/* need to clear the status */
-	uint8_t clear_buffer[3] = {(uint8_t)GT911_REG_STATUS, (uint8_t)(GT911_REG_STATUS >> 8), 0};
+	static const uint8_t clear_buffer[3] = {(uint8_t)GT911_REG_STATUS,
+						(uint8_t)(GT911_REG_STATUS >> 8), 0};
 
 	r = gt911_i2c_write(dev, clear_buffer, sizeof(clear_buffer));
 	if (r < 0) {

--- a/drivers/input/input_nunchuk.c
+++ b/drivers/input/input_nunchuk.c
@@ -144,8 +144,8 @@ static int nunchuk_init(const struct device *dev)
 	struct nunchuk_data *data = dev->data;
 	int ret;
 
-	uint8_t init_seq_1[2] = {0xf0, 0x55};
-	uint8_t init_seq_2[2] = {0xfb, 0x00};
+	static const uint8_t init_seq_1[2] = {0xf0, 0x55};
+	static const uint8_t init_seq_2[2] = {0xfb, 0x00};
 	uint8_t buffer[NUNCHUK_READ_SIZE];
 
 	data->dev = dev;

--- a/drivers/input/input_pat912x.c
+++ b/drivers/input/input_pat912x.c
@@ -125,7 +125,7 @@ static void pat912x_motion_work_handler(struct k_work *work)
 	if (cfg->axis_x >= 0) {
 		bool sync = cfg->axis_y < 0;
 
-		input_report_rel(data->dev, cfg->axis_x, x, sync, K_FOREVER);
+		input_report_rel(dev, cfg->axis_x, x, sync, K_FOREVER);
 	}
 
 	if (cfg->axis_y >= 0) {

--- a/drivers/input/input_pat912x.c
+++ b/drivers/input/input_pat912x.c
@@ -129,7 +129,7 @@ static void pat912x_motion_work_handler(struct k_work *work)
 	}
 
 	if (cfg->axis_y >= 0) {
-		input_report_rel(data->dev, cfg->axis_y, y, true, K_FOREVER);
+		input_report_rel(dev, cfg->axis_y, y, true, K_FOREVER);
 	}
 
 	/* Trigger one more scan in case more data is available. */

--- a/drivers/input/input_paw32xx.c
+++ b/drivers/input/input_paw32xx.c
@@ -218,8 +218,8 @@ static void paw32xx_motion_work_handler(struct k_work *work)
 
 	LOG_DBG("x=%4d y=%4d", x, y);
 
-	input_report_rel(data->dev, cfg->axis_x, x, false, K_FOREVER);
-	input_report_rel(data->dev, cfg->axis_y, y, true, K_FOREVER);
+	input_report_rel(dev, cfg->axis_x, x, false, K_FOREVER);
+	input_report_rel(dev, cfg->axis_y, y, true, K_FOREVER);
 
 	/* Trigger one more scan if more data is available. */
 	if (gpio_pin_get_dt(&cfg->motion_gpio)) {

--- a/drivers/input/input_pmw3610.c
+++ b/drivers/input/input_pmw3610.c
@@ -218,8 +218,8 @@ static void pmw3610_motion_work_handler(struct k_work *work)
 	x = sign_extend(x, PMW3610_DATA_SIZE_BITS - 1);
 	y = sign_extend(y, PMW3610_DATA_SIZE_BITS - 1);
 
-	input_report_rel(data->dev, cfg->axis_x, x, false, K_FOREVER);
-	input_report_rel(data->dev, cfg->axis_y, y, true, K_FOREVER);
+	input_report_rel(dev, cfg->axis_x, x, false, K_FOREVER);
+	input_report_rel(dev, cfg->axis_y, y, true, K_FOREVER);
 
 	if (cfg->smart_mode) {
 		uint16_t shutter_val = sys_get_be16(&burst_data[BURST_SHUTTER_HI]);

--- a/drivers/input/input_renesas_rx_ctsu.c
+++ b/drivers/input/input_renesas_rx_ctsu.c
@@ -194,7 +194,9 @@ static void process_data(struct k_work *work)
 	}
 
 	/** Wheels */
-	for (int i = 0; i < data->touch_instance.p_cfg->num_wheels; i++) {
+	const int num_wheels = data->touch_instance.p_cfg->num_wheels;
+
+	for (int i = 0; i < num_wheels; i++) {
 		if (data->curr_wheels_position[i] != data->prev_wheels_position[i]) {
 			input_report_abs(dev, config->wheels[i].event,
 					 data->curr_wheels_position[i], true, K_FOREVER);

--- a/drivers/input/input_renesas_rx_ctsu.c
+++ b/drivers/input/input_renesas_rx_ctsu.c
@@ -79,9 +79,9 @@ struct renesas_rx_ctsu_config {
 	uint8_t *channels_index_map;
 	uint8_t *button_position_index;
 	/** Touch components */
-	touch_button_context_t *buttons;
-	touch_slider_context_t *sliders;
-	touch_wheel_context_t *wheels;
+	const touch_button_context_t *buttons;
+	const touch_slider_context_t *sliders;
+	const touch_wheel_context_t *wheels;
 };
 
 struct renesas_rx_ctsu_data {
@@ -530,11 +530,11 @@ static int renesas_rx_ctsu_init(const struct device *dev)
 		}                                                                                  \
 	}                                                                                          \
                                                                                                    \
-	static touch_button_context_t buttons_##idx[] = {                                          \
+	static const touch_button_context_t buttons_##idx[] = {                                    \
 		DT_INST_FOREACH_CHILD_STATUS_OKAY(idx, BUTTON_GET_CONTEXT)};                       \
-	static touch_slider_context_t sliders_##idx[] = {                                          \
+	static const touch_slider_context_t sliders_##idx[] = {                                    \
 		DT_INST_FOREACH_CHILD_STATUS_OKAY(idx, SLIDER_GET_CONTEXT)};                       \
-	static touch_wheel_context_t wheels_##idx[] = {                                            \
+	static const touch_wheel_context_t wheels_##idx[] = {                                      \
 		DT_INST_FOREACH_CHILD_STATUS_OKAY(idx, WHEEL_GET_CONTEXT)};                        \
                                                                                                    \
 	static touch_button_cfg_t                                                                  \

--- a/drivers/input/input_renesas_rx_ctsu.c
+++ b/drivers/input/input_renesas_rx_ctsu.c
@@ -183,7 +183,9 @@ static void process_data(struct k_work *work)
 	data->prev_buttons_data = data->curr_buttons_data;
 
 	/** Sliders */
-	for (int i = 0; i < data->touch_instance.p_cfg->num_sliders; i++) {
+	const int num_sliders = data->touch_instance.p_cfg->num_sliders;
+
+	for (int i = 0; i < num_sliders; i++) {
 		if (data->curr_sliders_position[i] != data->prev_sliders_position[i]) {
 			input_report_abs(dev, config->sliders[i].event,
 					 data->curr_sliders_position[i], true, K_FOREVER);

--- a/drivers/input/input_sbus.c
+++ b/drivers/input/input_sbus.c
@@ -25,7 +25,7 @@ struct sbus_input_channel {
 	uint32_t zephyr_code;
 };
 
-const struct uart_config uart_cfg_sbus = {
+static const struct uart_config uart_cfg_sbus = {
 	.baudrate = 100000,
 	.parity = UART_CFG_PARITY_EVEN,
 	.stop_bits = UART_CFG_STOP_BITS_2,

--- a/drivers/input/input_xec_kbd.c
+++ b/drivers/input/input_xec_kbd.c
@@ -195,7 +195,7 @@ static const struct input_kbd_matrix_api xec_kbd_api = {
 /* To enable wakeup, set the "wakeup-source" on the keyboard scanning device
  * node.
  */
-static struct xec_kbd_config xec_kbd_cfg_0 = {
+static const struct xec_kbd_config xec_kbd_cfg_0 = {
 	.common = INPUT_KBD_MATRIX_DT_INST_COMMON_CONFIG_INIT(0, &xec_kbd_api),
 	.base = DT_INST_REG_ADDR(0),
 	.girq = DEV_CFG_GIRQ(0),


### PR DESCRIPTION
The fixed I2C command buffers in the work handler, IC verify and PM
suspend paths are already const and never modified, so make them static
const to move them out of the stack into read-only memory.