### PR TITLE
drivers: input: gpio_kbd_matrix: Hoist the changed-column mask

### DIFF
--- a/drivers/input/input_gpio_kbd_matrix.c
+++ b/drivers/input/input_gpio_kbd_matrix.c
@@ -70,10 +70,12 @@ static void gpio_kbd_matrix_drive_column(const struct device *dev, int col)
 		return;
 	}
 
+	uint32_t changed = data->last_col_state ^ state;
+
 	for (int i = 0; i < common->col_size; i++) {
 		const struct gpio_dt_spec *gpio = &cfg->col_gpio[i];
 
-		if ((data->last_col_state ^ state) & BIT(i)) {
+		if (changed & BIT(i)) {
 			if (cfg->col_drive_inactive) {
 				gpio_pin_set_dt(gpio, state & BIT(i));
 			} else if (state & BIT(i)) {


### PR DESCRIPTION
The changed-column mask is loop invariant, so compute it once before the drive loop instead of reloading last_col_state through the escaped data pointer on every iteration.