### PR TITLE
drivers: input: analog_axis: Cache the axis count in the log loop

### DIFF
--- a/drivers/input/input_analog_axis_settings.c
+++ b/drivers/input/input_analog_axis_settings.c
@@ -21,9 +21,10 @@ LOG_MODULE_REGISTER(analog_axis_settings, CONFIG_INPUT_LOG_LEVEL);
 static void analog_axis_calibration_log(const struct device *dev)
 {
 	struct analog_axis_calibration cal;
+	int axes = analog_axis_num_axes(dev);
 	int i;
 
-	for (i = 0; i < analog_axis_num_axes(dev); i++) {
+	for (i = 0; i < axes; i++) {
 		analog_axis_calibration_get(dev, i, &cal);
 
 		LOG_INF("%s: ch: %d min: %d max: %d deadzone: %d",


### PR DESCRIPTION
analog_axis_num_axes() is defined in another translation unit and cannot be inlined here, so cache its result in a local instead of calling it on every loop iteration, matching the save and load helpers.