### PR TITLE
drivers: ethernet: nxp_enet_qos: Zero only used TX descriptors

### DIFF
--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos.c
@@ -185,7 +185,9 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 	LOG_DBG("Setting up TX descriptors for packet %p", pkt);
 
 	/* Reset the descriptors */
-	memset((void *)data->tx.descriptors, 0, sizeof(union nxp_enet_qos_tx_desc) * frags_count);
+	/* TX packs up to 2 fragments per descriptor, so used descs = (frags_count + 1) / 2. */
+	memset((void *)data->tx.descriptors, 0,
+	       sizeof(union nxp_enet_qos_tx_desc) * ((frags_count + 1) / 2));
 
 	/* Setting up the descriptors  */
 	fragment = pkt->frags;

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -157,7 +157,8 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 	LOG_DBG("Setting up TX descriptors for packet %p", pkt);
 
 	/* Reset the descriptors */
-	memset((void *)data->tx.descriptors, 0, sizeof(union nxp_enet_qos_tx_desc) * frags_count);
+	memset((void *)data->tx.descriptors, 0,
+	       sizeof(union nxp_enet_qos_tx_desc) * ((frags_count + 1) / 2));
 
 	/* Setting up the descriptors  */
 	fragment = pkt->frags;


### PR DESCRIPTION
The setup loop packs up to two fragments per descriptor, so only (frags_count + 1) / 2 descriptors are used. Size the memset to that.