### PR TITLE
drivers: ethernet: w6100: Skip no-op SLIRCLR write

### DIFF
--- a/drivers/ethernet/eth_w6100.c
+++ b/drivers/ethernet/eth_w6100.c
@@ -329,7 +329,10 @@ static void w6100_thread(void *p1, void *p2, void *p3)
 			/* Read interrupt */
 			w6100_spi_read(dev, W6100_S0_IR, &ir, 1);
 			w6100_spi_read(dev, W6100_SLIR, &slir, 1);
-			w6100_spi_write(dev, W6100_SLIRCLR, &slir, 1);
+			/* SLIRCLR is write-1-to-clear; nothing to do when slir == 0 */
+			if (slir != 0U) {
+				w6100_spi_write(dev, W6100_SLIRCLR, &slir, 1);
+			}
 
 
 			if (ir) {


### PR DESCRIPTION
SLIRCLR is write-1-to-clear, so writing zero clears nothing. Skip the SPI write when slir is zero.
