### PR TITLE
drivers: ethernet: oa_tc6: Hoist loop-invariant RX header

### DIFF
--- a/drivers/ethernet/oa_tc6.c
+++ b/drivers/ethernet/oa_tc6.c
@@ -410,6 +410,9 @@ int oa_tc6_read_chunks(struct oa_tc6 *tc6, struct net_pkt *pkt)
 		tc6->concat_buf = NULL;
 	}
 
+	hdr = FIELD_PREP(OA_DATA_HDR_DNC, 1);
+	hdr |= FIELD_PREP(OA_DATA_HDR_P, oa_tc6_get_parity(hdr));
+
 	do {
 		if (!buf_rx) {
 			buf_rx = net_pkt_get_frag(pkt, buf_rx_size, OA_TC6_BUF_ALLOC_TIMEOUT);
@@ -418,9 +421,6 @@ int oa_tc6_read_chunks(struct oa_tc6 *tc6, struct net_pkt *pkt)
 				return -ENOMEM;
 			}
 		}
-
-		hdr = FIELD_PREP(OA_DATA_HDR_DNC, 1);
-		hdr |= FIELD_PREP(OA_DATA_HDR_P, oa_tc6_get_parity(hdr));
 
 		ret = oa_tc6_chunk_spi_transfer(tc6, buf_rx->data + buf_rx_used, NULL, hdr, &ftr);
 		if (ret < 0) {


### PR DESCRIPTION
The RX chunk request header is constant across chunks, so compute it once before the receive loop. SPI traffic is unchanged.