### PR TITLE
drivers: ethernet: mchp_gmac_g1: Collapse RX descriptor writes

### DIFF
--- a/drivers/ethernet/eth_mchp_gmac_g1.c
+++ b/drivers/ethernet/eth_mchp_gmac_g1.c
@@ -589,9 +589,8 @@ static struct net_pkt *gmac_extract_and_replace_buffers(struct gmac_queue *queue
 		frag = new_frag;
 		rx_frag_list[tail] = frag;
 		rx_desc->status = 0U;
-		rx_desc->addr &= (~GMAC_RXW0_ADDR);
-		rx_desc->addr |= ((uint32_t)frag->data & GMAC_RXW0_ADDR);
-		rx_desc->addr &= (~GMAC_RXW0_OWNERSHIP);
+		rx_desc->addr = ((uint32_t)frag->data & GMAC_RXW0_ADDR) |
+				(rx_desc->addr & GMAC_RXW0_WRAP);
 
 		MODULO_INC(tail, rx_desc_list->len);
 		rx_desc = &rx_desc_list->buf_desc[tail];


### PR DESCRIPTION
Replace the three read-modify-write operations on the RX descriptor address word with a single read and write producing the same final value.