### PR TITLE
net: conn: Reject non-matching connections with the cheapest test first

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -920,6 +920,11 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 	k_mutex_lock(&conn_lock, K_FOREVER);
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&conn_used, conn, node) {
+		/* Is the candidate connection matching the packet's protocol within the family? */
+		if (conn->proto != proto) {
+			continue; /* wrong protocol */
+		}
+
 		/* Is the candidate connection matching the packet's interface? */
 		if (!is_iface_matching(conn, pkt)) {
 			continue; /* wrong interface */
@@ -937,11 +942,6 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 			}
 
 			/* We might have a match for v4-to-v6 mapping, check more */
-		}
-
-		/* Is the candidate connection matching the packet's protocol within the family? */
-		if (conn->proto != proto) {
-			continue; /* wrong protocol */
 		}
 
 		/* Apply protocol-specific matching criteria... */


### PR DESCRIPTION
The per-packet connection lookup loop checked the interface binding first, which requires following two pointers into the connection's context, before the protocol comparison that is a single byte compare. Since a mixed UDP/TCP system always has connections of the other protocol registered, do the protocol check first so most non-matching connections are rejected with a single comparison.