### PR TITLE
net: pkt: Optimize front pulls without exposing fragment layout

### DIFF
--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -1898,7 +1898,10 @@ void net_pkt_frag_insert(struct net_pkt *pkt, struct net_buf *frag);
 /**
  * @brief Compact the fragment list of a packet.
  *
- * @details After this there is no more any free space in individual fragments.
+ * @details Move data from later fragments into available tailroom in earlier
+ *          fragments and remove empty fragments. This does not reclaim
+ *          headroom or guarantee that the packet becomes a single fragment.
+ *
  * @param pkt Network packet.
  */
 void net_pkt_compact(struct net_pkt *pkt);
@@ -2654,12 +2657,17 @@ static inline size_t net_pkt_get_len(struct net_pkt *pkt)
 int net_pkt_update_length(struct net_pkt *pkt, size_t length);
 
 /**
- * @brief Remove data from the start of the packet.
+ * @brief Remove data from the packet at the current cursor position.
  *
- * @details net_pkt's cursor should be properly initialized.
- *          Note that net_pkt's cursor is reset by this function.
- *          This functions works in similar way as net_buf_pull(),
- *          but it can handle multiple net_buf fragments.
+ * @details The packet cursor should be properly initialized and positioned.
+ *          The cursor is reset by this function. This function works in a
+ *          similar way to net_buf_pull(), but it can handle multiple net_buf
+ *          fragments.
+ *
+ *          The underlying fragment layout is not preserved: remaining data
+ *          may be moved or a fragment's data pointer may be advanced. Callers
+ *          must not rely on fragment data pointers, headroom, or tailroom
+ *          remaining unchanged.
  *
  * @param pkt    Network packet
  * @param length Number of bytes to be removed

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -2336,6 +2336,17 @@ int net_pkt_pull(struct net_pkt *pkt, size_t length)
 			rem = length;
 		}
 
+		if (rem < left && c_op->pos == c_op->buf->data) {
+			/* Pulling from the front of the fragment: advance
+			 * the data pointer instead of moving the remaining
+			 * payload down.
+			 */
+			(void)net_buf_pull(c_op->buf, rem);
+			c_op->pos = c_op->buf->data;
+			length -= rem;
+			continue;
+		}
+
 		c_op->buf->len -= rem;
 		left -= rem;
 		if (left) {

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -477,17 +477,40 @@ static enum net_verdict ieee802154_recv(struct net_if *iface, struct net_pkt *pk
 /**
  * Implements (part of) the MCPS-DATA.request/confirm primitives, see sections 8.3.2/3.
  */
+static int copy_pkt_to_frame(struct net_buf *frame_buf, const struct net_buf *pkt_buf,
+			     size_t pkt_len, uint8_t authtag_len)
+{
+	size_t tailroom = net_buf_tailroom(frame_buf);
+	size_t copied;
+
+	if (authtag_len > tailroom || pkt_len > tailroom - authtag_len) {
+		return -EMSGSIZE;
+	}
+
+	copied = net_buf_linearize(net_buf_tail(frame_buf), tailroom - authtag_len, pkt_buf, 0,
+				   pkt_len);
+	if (copied != pkt_len) {
+		NET_ERR("Failed to copy packet to frame (%zu/%zu)", copied, pkt_len);
+		return -EINVAL;
+	}
+
+	net_buf_add(frame_buf, copied);
+
+	return 0;
+}
+
 static int ieee802154_send(struct net_if *iface, struct net_pkt *pkt)
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
+	struct net_buf *pkt_buf;
 	uint8_t ll_hdr_len = 0, authtag_len = 0;
 	static struct net_buf *frame_buf;
-	static struct net_buf *pkt_buf;
+	size_t pkt_len;
 	bool send_raw = false;
+	bool requires_fragmentation = false;
 	int len;
 #ifdef CONFIG_NET_L2_IEEE802154_FRAGMENT
 	struct ieee802154_6lo_fragment_ctx frag_ctx;
-	int requires_fragmentation = 0;
 #endif
 
 	if (frame_buf == NULL) {
@@ -541,15 +564,24 @@ static int ieee802154_send(struct net_if *iface, struct net_pkt *pkt)
 
 #ifdef CONFIG_NET_6LO
 #ifdef CONFIG_NET_L2_IEEE802154_FRAGMENT
-		requires_fragmentation =
-			ieee802154_6lo_encode_pkt(iface, pkt, &frag_ctx, ll_hdr_len, authtag_len);
-		if (requires_fragmentation < 0) {
-			return requires_fragmentation;
+		int ret;
+
+		ret = ieee802154_6lo_encode_pkt(iface, pkt, &frag_ctx, ll_hdr_len, authtag_len);
+		if (ret < 0) {
+			return ret;
 		}
+
+		requires_fragmentation = (ret != 0);
 #else
 		ieee802154_6lo_encode_pkt(iface, pkt, NULL, ll_hdr_len, authtag_len);
 #endif /* CONFIG_NET_L2_IEEE802154_FRAGMENT */
 #endif /* CONFIG_NET_6LO */
+	}
+
+	pkt_len = net_pkt_get_len(pkt);
+	if (!requires_fragmentation && ll_hdr_len + pkt_len + authtag_len > IEEE802154_MTU) {
+		NET_ERR("Frame too long: %zu", ll_hdr_len + pkt_len + authtag_len);
+		return -EMSGSIZE;
 	}
 
 	net_capture_pkt(iface, pkt);
@@ -567,16 +599,20 @@ static int ieee802154_send(struct net_if *iface, struct net_pkt *pkt)
 		if (requires_fragmentation) {
 			pkt_buf = ieee802154_6lo_fragment(&frag_ctx, frame_buf, true);
 		} else {
-			net_buf_add_mem(frame_buf, pkt_buf->data, pkt_buf->len);
-			pkt_buf = pkt_buf->frags;
+			ret = copy_pkt_to_frame(frame_buf, pkt->buffer, pkt_len, authtag_len);
+			if (ret < 0) {
+				return ret;
+			}
+
+			pkt_buf = NULL;
 		}
 #else
-		if (ll_hdr_len + pkt_buf->len + authtag_len > IEEE802154_MTU) {
-			NET_ERR("Frame too long: %d", pkt_buf->len);
-			return -EINVAL;
+		ret = copy_pkt_to_frame(frame_buf, pkt->buffer, pkt_len, authtag_len);
+		if (ret < 0) {
+			return ret;
 		}
-		net_buf_add_mem(frame_buf, pkt_buf->data, pkt_buf->len);
-		pkt_buf = pkt_buf->frags;
+
+		pkt_buf = NULL;
 #endif /* CONFIG_NET_L2_IEEE802154_FRAGMENT */
 
 		__ASSERT_NO_MSG(authtag_len <= net_buf_tailroom(frame_buf));

--- a/tests/net/ieee802154/6lo_fragment/src/main.c
+++ b/tests/net/ieee802154/6lo_fragment/src/main.c
@@ -239,14 +239,14 @@ static struct net_pkt *create_pkt(struct net_fragment_data *data)
 
 	pkt = net_pkt_alloc_on_iface(
 		net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY)), K_FOREVER);
-	if (!pkt) {
+	if (pkt == NULL) {
 		return NULL;
 	}
 
 	net_pkt_set_ip_hdr_len(pkt, NET_IPV6H_LEN);
 
 	buf = net_pkt_get_frag(pkt, NET_IPV6UDPH_LEN, K_FOREVER);
-	if (!buf) {
+	if (buf == NULL) {
 		net_pkt_unref(pkt);
 		return NULL;
 	}
@@ -476,7 +476,7 @@ static bool test_fragment(struct net_fragment_data *data)
 	int hdr_diff;
 
 	pkt = create_pkt(data);
-	if (!pkt) {
+	if (pkt == NULL) {
 		TC_PRINT("%s: failed to create buffer\n", __func__);
 		goto end;
 	}
@@ -500,7 +500,7 @@ static bool test_fragment(struct net_fragment_data *data)
 	}
 
 	f_pkt = net_pkt_alloc(K_FOREVER);
-	if (!f_pkt) {
+	if (f_pkt == NULL) {
 		goto end;
 	}
 
@@ -512,7 +512,7 @@ static bool test_fragment(struct net_fragment_data *data)
 		buf = ieee802154_6lo_fragment(&ctx, &frame_buf, data->iphc);
 
 		dfrag = net_pkt_get_frag(f_pkt, frame_buf.len, K_FOREVER);
-		if (!dfrag) {
+		if (dfrag == NULL) {
 			goto end;
 		}
 
@@ -538,12 +538,12 @@ reassemble:
 	buf = f_pkt->buffer;
 	while (buf) {
 		rxpkt = net_pkt_rx_alloc(K_FOREVER);
-		if (!rxpkt) {
+		if (rxpkt == NULL) {
 			goto end;
 		}
 
 		dfrag = net_pkt_get_frag(rxpkt, buf->len, K_FOREVER);
-		if (!dfrag) {
+		if (dfrag == NULL) {
 			goto end;
 		}
 
@@ -578,15 +578,15 @@ compare:
 	}
 
 end:
-	if (pkt) {
+	if (pkt != NULL) {
 		net_pkt_unref(pkt);
 	}
 
-	if (f_pkt) {
+	if (f_pkt != NULL) {
 		net_pkt_unref(f_pkt);
 	}
 
-	if (rxpkt) {
+	if (rxpkt != NULL) {
 		net_pkt_unref(rxpkt);
 	}
 

--- a/tests/net/ieee802154/6lo_fragment/src/main.c
+++ b/tests/net/ieee802154/6lo_fragment/src/main.c
@@ -493,7 +493,29 @@ static bool test_fragment(struct net_fragment_data *data)
 	}
 
 	if (!ieee802154_6lo_requires_fragmentation(pkt, 0, 0)) {
-		f_pkt = pkt;
+		size_t pkt_len = net_pkt_get_len(pkt);
+		size_t copied;
+
+		f_pkt = net_pkt_alloc(K_FOREVER);
+		if (f_pkt == NULL) {
+			goto end;
+		}
+
+		dfrag = net_pkt_get_frag(f_pkt, pkt_len, K_FOREVER);
+		if (dfrag == NULL) {
+			goto end;
+		}
+
+		net_pkt_frag_add(f_pkt, dfrag);
+
+		copied = net_buf_linearize(dfrag->data, net_buf_tailroom(dfrag), pkt->buffer, 0,
+					   pkt_len);
+		if (copied != pkt_len) {
+			goto end;
+		}
+
+		net_buf_add(dfrag, copied);
+		net_pkt_unref(pkt);
 		pkt = NULL;
 
 		goto reassemble;

--- a/tests/net/ieee802154/l2/src/ieee802154_test.c
+++ b/tests/net/ieee802154/l2/src/ieee802154_test.c
@@ -320,7 +320,7 @@ static struct net_pkt *get_data_pkt_with_ar(void)
 
 	pkt = net_pkt_rx_alloc_with_buffer(net_iface, sizeof(data_pkt_with_ar), NET_AF_UNSPEC, 0,
 					   K_FOREVER);
-	if (!pkt) {
+	if (pkt == NULL) {
 		NET_ERR("*** No buffer to allocate");
 		return NULL;
 	}
@@ -493,7 +493,7 @@ static bool test_ns_sending(struct ieee802154_pkt_test *t, bool with_short_addr)
 	k_yield();
 	k_sem_take(&driver_lock, K_SECONDS(1));
 
-	if (!current_pkt->frags) {
+	if (current_pkt->frags == NULL) {
 		NET_ERR("*** Could not send IPv6 NS packet");
 		goto out;
 	}
@@ -551,7 +551,7 @@ static bool test_wait_for_ack(struct ieee802154_pkt_test *t)
 
 	one_ack_pkt = net_pkt_rx_alloc_with_buffer(net_iface, IEEE802154_ACK_PKT_LENGTH,
 						   NET_AF_UNSPEC, 0, K_FOREVER);
-	if (!one_ack_pkt) {
+	if (one_ack_pkt == NULL) {
 		NET_ERR("*** Could not allocate ack pkt.");
 		goto release_tx_pkt;
 	}
@@ -591,7 +591,7 @@ static bool test_packet_cloning_with_cb(void)
 	NET_INFO("- Cloning packet");
 
 	pkt = net_pkt_rx_alloc_with_buffer(net_iface, 64, NET_AF_UNSPEC, 0, K_NO_WAIT);
-	if (!pkt) {
+	if (pkt == NULL) {
 		NET_ERR("*** No buffer to allocate");
 		return false;
 	}
@@ -625,7 +625,7 @@ static bool test_packet_rssi_conversion(void)
 	NET_INFO("- RSSI conversion between unsigned and signed representation");
 
 	pkt = net_pkt_rx_alloc_on_iface(net_iface, K_NO_WAIT);
-	if (!pkt) {
+	if (pkt == NULL) {
 		NET_ERR("*** No pkt to allocate");
 		return false;
 	}
@@ -734,7 +734,7 @@ static bool test_dgram_packet_sending(void *dst_sll, uint8_t dst_sll_halen, uint
 	k_yield();
 	k_sem_take(&driver_lock, K_SECONDS(1));
 
-	if (!current_pkt->frags) {
+	if (current_pkt->frags == NULL) {
 		NET_ERR("*** Could not send DGRAM packet");
 		goto release_fd;
 	}
@@ -809,7 +809,7 @@ static bool test_dgram_packet_reception(void *src_ll_addr, uint8_t src_ll_addr_l
 	}
 
 	pkt = net_pkt_rx_alloc(K_FOREVER);
-	if (!pkt) {
+	if (pkt == NULL) {
 		NET_ERR("*** Failed to allocate net pkt.");
 		goto release_fd;
 	}
@@ -834,7 +834,7 @@ static bool test_dgram_packet_reception(void *src_ll_addr, uint8_t src_ll_addr_l
 	pkt->lladdr_src.type = NET_LINK_IEEE802154;
 
 	frame_buf = net_pkt_get_frag(pkt, IEEE802154_MTU, K_FOREVER);
-	if (!frame_buf) {
+	if (frame_buf == NULL) {
 		NET_ERR("*** Failed to allocate net pkt frag.");
 		goto release_pkt;
 	}
@@ -881,7 +881,7 @@ static bool test_dgram_packet_reception(void *src_ll_addr, uint8_t src_ll_addr_l
 		goto release_pkt;
 	}
 
-	if (current_pkt->frags) {
+	if (current_pkt->frags != NULL) {
 		NET_ERR("*** Generated unexpected (ACK?) packet when processing packet.");
 		net_pkt_frag_unref(current_pkt->frags);
 		current_pkt->frags = NULL;
@@ -966,7 +966,7 @@ static bool test_raw_packet_sending(void)
 	k_yield();
 	k_sem_take(&driver_lock, K_SECONDS(1));
 
-	if (!current_pkt->frags) {
+	if (current_pkt->frags == NULL) {
 		NET_ERR("*** Could not send RAW packet");
 		goto release_fd;
 	}
@@ -1015,13 +1015,13 @@ static bool test_raw_packet_reception(void)
 	}
 
 	pkt = net_pkt_rx_alloc(K_FOREVER);
-	if (!pkt) {
+	if (pkt == NULL) {
 		NET_ERR("*** Failed to allocate net pkt.");
 		goto release_fd;
 	}
 
 	frame_buf = net_pkt_get_frag(pkt, sizeof(raw_payload), K_FOREVER);
-	if (!frame_buf) {
+	if (frame_buf == NULL) {
 		NET_ERR("*** Failed to allocate net pkt frag.");
 		goto release_pkt;
 	}
@@ -1034,7 +1034,7 @@ static bool test_raw_packet_reception(void)
 		goto release_pkt;
 	}
 
-	if (current_pkt->frags) {
+	if (current_pkt->frags != NULL) {
 		NET_ERR("*** Generated unexpected packet when processing packet.");
 		net_pkt_frag_unref(current_pkt->frags);
 		current_pkt->frags = NULL;
@@ -1185,7 +1185,7 @@ static bool test_recv_and_send_ack_reply(struct ieee802154_pkt_test *t)
 	k_sem_take(&driver_lock, K_SECONDS(1));
 
 	/* an ACK packet should be in current_pkt */
-	if (!current_pkt->frags) {
+	if (current_pkt->frags == NULL) {
 		NET_ERR("*** No ACK reply sent");
 		goto release_rx_pkt;
 	}
@@ -1233,7 +1233,7 @@ static bool initialize_test_environment(void)
 	k_sem_reset(&driver_lock);
 
 	current_pkt = net_pkt_rx_alloc(K_FOREVER);
-	if (!current_pkt) {
+	if (current_pkt == NULL) {
 		NET_ERR("*** No buffer to allocate");
 		return false;
 	}

--- a/tests/net/ieee802154/l2/src/ieee802154_test.c
+++ b/tests/net/ieee802154/l2/src/ieee802154_test.c
@@ -523,6 +523,89 @@ out:
 	return result;
 }
 
+static bool test_partitioned_pkt_sending(const uint8_t *payload, size_t payload_len,
+					 const size_t *frag_sizes, size_t frag_count)
+{
+	static const uint8_t broadcast_addr[IEEE802154_SHORT_ADDR_LENGTH] = {0xff, 0xff};
+	struct ieee802154_mpdu mpdu;
+	struct net_pkt *pkt;
+	size_t offset = 0;
+	bool result = false;
+
+	k_sem_reset(&driver_lock);
+
+	pkt = net_pkt_alloc_on_iface(net_iface, K_FOREVER);
+	if (pkt == NULL) {
+		NET_ERR("*** Failed to allocate partitioned packet");
+		return false;
+	}
+
+	net_pkt_lladdr_src(pkt)->type = NET_LINK_IEEE802154;
+	net_pkt_lladdr_dst(pkt)->type = NET_LINK_IEEE802154;
+	if (net_linkaddr_set(net_pkt_lladdr_dst(pkt), broadcast_addr, sizeof(broadcast_addr)) < 0) {
+		NET_ERR("*** Failed to set destination address");
+		goto release_pkt;
+	}
+
+	for (size_t i = 0; i < frag_count; i++) {
+		struct net_buf *frag;
+
+		frag = net_pkt_get_frag(pkt, frag_sizes[i], K_FOREVER);
+		if (frag == NULL) {
+			NET_ERR("*** Failed to allocate packet fragment");
+			goto release_pkt;
+		}
+
+		net_buf_add_mem(frag, payload + offset, frag_sizes[i]);
+		net_pkt_frag_add(pkt, frag);
+		offset += frag_sizes[i];
+	}
+
+	if (offset != payload_len) {
+		NET_ERR("*** Fragment sizes do not match payload length");
+		goto release_pkt;
+	}
+
+	if (net_if_send_data(net_iface, pkt) != NET_OK) {
+		NET_ERR("*** Failed to send partitioned packet");
+		goto release_pkt;
+	}
+
+	pkt = NULL;
+	k_yield();
+	if (k_sem_take(&driver_lock, K_SECONDS(1)) < 0) {
+		NET_ERR("*** Timed out waiting for partitioned packet");
+		goto out;
+	}
+
+	if (current_pkt->frags == NULL || current_pkt->frags->frags != NULL) {
+		NET_ERR("*** Packet storage fragments became MAC frame boundaries");
+		goto release_frame;
+	}
+
+	if (!ieee802154_validate_frame(current_pkt->frags->data, current_pkt->frags->len, &mpdu)) {
+		NET_ERR("*** Sent partitioned packet is not valid");
+		goto release_frame;
+	}
+
+	if (mpdu.payload_length != payload_len || memcmp(mpdu.payload, payload, payload_len)) {
+		NET_ERR("*** Sent partitioned payload differs from source");
+		goto release_frame;
+	}
+
+	result = true;
+
+release_frame:
+	net_pkt_frag_unref(current_pkt->frags);
+	current_pkt->frags = NULL;
+out:
+	return result;
+
+release_pkt:
+	net_pkt_unref(pkt);
+	goto out;
+}
+
 static bool test_wait_for_ack(struct ieee802154_pkt_test *t)
 {
 	struct ieee802154_mpdu mpdu;
@@ -1311,6 +1394,25 @@ ZTEST(ieee802154_l2, test_sending_ns_pkt_with_short_addr)
 	ret = test_ns_sending(&test_ns_pkt, true);
 
 	zassert_true(ret, "NS sent");
+}
+
+ZTEST(ieee802154_l2, test_sending_partitioned_pkt)
+{
+	static const uint8_t payload[] = {
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+		0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+		0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+	};
+	static const size_t one_frag[] = {sizeof(payload)};
+	static const size_t two_frags[] = {1, sizeof(payload) - 1};
+	static const size_t three_frags[] = {7, 5, sizeof(payload) - 12};
+
+	zassert_true(test_partitioned_pkt_sending(payload, sizeof(payload), one_frag,
+						  ARRAY_SIZE(one_frag)));
+	zassert_true(test_partitioned_pkt_sending(payload, sizeof(payload), two_frags,
+						  ARRAY_SIZE(two_frags)));
+	zassert_true(test_partitioned_pkt_sending(payload, sizeof(payload), three_frags,
+						  ARRAY_SIZE(three_frags)));
 }
 
 ZTEST(ieee802154_l2, test_parsing_ack_pkt)


### PR DESCRIPTION
Avoid `memmove()` when `net_pkt_pull()` removes data from the start of a fragment by advancing its data pointer instead.

This exposed an existing layer violation: IEEE 802.15.4 treated `net_buf` storage boundaries as MAC frame boundaries, requiring 6LoWPAN to preserve a particular packet layout.

Fix this at the L2 boundary by serializing an unfragmented packet chain into a single MAC frame, which keeps `net_buf` layout private to packet storage.

### Testing

Tested on an STM32F746G-DISCO at 216 MHz over 100 Mbps Ethernet sending TCP traffic using zperf to my Mac running iperf2.

Compared `HEAD^` against `HEAD` across:

- `CONFIG_NET_BUF_DATA_SIZE`: 128, 256, 512, 1024, 1514 bytes
- TCP write sizes: 64, 128, 256, 512, 1024, 1460 bytes
- Nagle enabled vs. `TCP_NODELAY`
- One warm-up plus five measured uploads

Across 60 paired cases, the median improvement was **+1.56%** and the mean improvement was **+1.53%**. **55/60** cases improved, with results ranging from **−1.38% to +4.91%**.

<img width="2480" height="1839" alt="image" src="https://github.com/user-attachments/assets/d033b56d-d9c7-48af-b4d8-2c9bf6dc5132" />

Fixes: #114895