### PR TITLE
net: Avoid redundant packet length walks in the hot path

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -491,13 +491,17 @@ err:
 
 static void net_rx(struct net_if *iface, struct net_pkt *pkt)
 {
-	size_t pkt_len;
+	/* Only walk the fragment chain to get the packet length if
+	 * someone is going to use it.
+	 */
+	if (IS_ENABLED(CONFIG_NET_STATISTICS) ||
+	    CONFIG_NET_CORE_LOG_LEVEL >= LOG_LEVEL_DBG) {
+		size_t pkt_len = net_pkt_get_len(pkt);
 
-	pkt_len = net_pkt_get_len(pkt);
+		NET_DBG("Received pkt %p len %zu", pkt, pkt_len);
 
-	NET_DBG("Received pkt %p len %zu", pkt, pkt_len);
-
-	net_stats_update_bytes_recv(iface, pkt_len);
+		net_stats_update_bytes_recv(iface, pkt_len);
+	}
 
 	if (IS_ENABLED(CONFIG_NET_LOOPBACK)) {
 #ifdef CONFIG_NET_L2_DUMMY
@@ -525,7 +529,7 @@ void net_process_rx_packet(struct net_pkt *pkt)
 
 static void net_queue_rx(struct net_if *iface, struct net_pkt *pkt)
 {
-	size_t len = net_pkt_get_len(pkt);
+	size_t len = IS_ENABLED(CONFIG_NET_STATISTICS) ? net_pkt_get_len(pkt) : 0;
 	uint8_t prio = net_pkt_priority(pkt);
 	uint8_t tc = net_rx_priority2tc(prio);
 

--- a/subsys/net/l2/dummy/dummy.c
+++ b/subsys/net/l2/dummy/dummy.c
@@ -36,16 +36,21 @@ static inline enum net_verdict dummy_recv(struct net_if *iface,
 static inline int dummy_send(struct net_if *iface, struct net_pkt *pkt)
 {
 	const struct dummy_api *api = net_if_get_device(iface)->api;
+	size_t pkt_len;
 	int ret;
 
 	if (!api) {
 		return -ENOENT;
 	}
 
+	/* Get the length before sending: a loopback driver hands the
+	 * packet over to the RX path which may consume it as soon as it
+	 * has been sent.
+	 */
+	pkt_len = net_pkt_get_len(pkt);
+
 	ret = net_l2_send(api->send, net_if_get_device(iface), iface, pkt);
 	if (!ret) {
-		size_t pkt_len = net_pkt_get_len(pkt);
-
 		if (IS_ENABLED(CONFIG_NET_STATISTICS)) {
 			NET_DBG("Sending pkt %p len %zu", pkt, pkt_len);
 			net_stats_update_bytes_sent(iface, pkt_len);


### PR DESCRIPTION
net_pkt_get_len() walks the whole fragment chain. It is called for every packet in net_rx() and net_queue_rx() even though the result is only used for statistics and debug logging, and in dummy_send() after the packet has already been handed over to the driver.

Only compute the length when statistics or debug logging actually consume it, and in dummy_send() get the length before sending: with a loopback driver the RX path may consume (and shorten) the packet as soon as it has been handed over.