### PR TITLE
net: utils: Speed up checksum calculation on 64-bit targets

### DIFF
--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -611,6 +611,51 @@ uint16_t calc_chksum(uint16_t sum_in, const uint8_t *data, size_t len)
 		sum = sum + *((uint16_t *)data);
 		data += sizeof(uint16_t);
 	}
+#if defined(CONFIG_64BIT) && defined(__SIZEOF_INT128__)
+	/* On 64-bit targets, process the bulk of the data 8 bytes at a
+	 * time, accumulating into two independent 128-bit accumulators
+	 * so that the additions can run in parallel and no carry
+	 * handling is needed in the loop.
+	 */
+	if ((((uintptr_t)data & 0x04) != 0) && (pending >= sizeof(uint32_t))) {
+		pending -= sizeof(uint32_t);
+		sum = sum + *((uint32_t *)data);
+		data += sizeof(uint32_t);
+	}
+
+	if (pending >= sizeof(uint64_t)) {
+		unsigned __int128 acc_a = 0;
+		unsigned __int128 acc_b = 0;
+		const uint64_t *p64 = (const uint64_t *)data;
+		uint64_t lo;
+		uint64_t hi;
+
+		while (pending >= sizeof(uint64_t) * 4) {
+			acc_a += p64[0];
+			acc_b += p64[1];
+			acc_a += p64[2];
+			acc_b += p64[3];
+			pending -= sizeof(uint64_t) * 4;
+			p64 += 4;
+		}
+		while (pending >= sizeof(uint64_t)) {
+			acc_a += *p64++;
+			pending -= sizeof(uint64_t);
+		}
+
+		acc_a += acc_b;
+		lo = (uint64_t)acc_a;
+		hi = (uint64_t)(acc_a >> 64);
+
+		sum += (lo & 0xffffffffULL) + (lo >> 32) + hi;
+		sum = (sum & 0xffffffffULL) + (sum >> 32);
+
+		data = (const uint8_t *)p64;
+	}
+
+	p = (uint32_t *)data;
+	i = 0;
+#else
 	p = (uint32_t *)data;
 
 	/* Do loop unrolling for the very large data sets */
@@ -624,6 +669,7 @@ uint16_t calc_chksum(uint16_t sum_in, const uint8_t *data, size_t len)
 		i += 4;
 		sum += sum_a + sum_b;
 	}
+#endif /* CONFIG_64BIT && __SIZEOF_INT128__ */
 	while (pending >= sizeof(uint32_t)) {
 		pending -= sizeof(uint32_t);
 		sum = sum + p[i++];


### PR DESCRIPTION
On 64-bit targets, process the bulk of the checksummed data 8 bytes at a time, accumulating into two independent 128-bit accumulators. This doubles the bytes moved per load, needs no carry handling inside the loop, and the two accumulators let the additions execute in parallel, unlike an end-around-carry chain which serializes on the carry of every addition.

Correctness verified against the existing implementation with 200000 randomized buffers covering all alignments (0-7), lengths 0-2000 and initial sums, plus the tests/net/utils suite.

In isolation the checksum runs 1.1x faster for 256 byte buffers and up to 1.75x faster for large buffers on x86-64.