### PR TITLE
drivers: sensor: hc-sr04: handle runtime clock frequency

### DIFF
--- a/drivers/sensor/hc_sr04/hc_sr04.c
+++ b/drivers/sensor/hc_sr04/hc_sr04.c
@@ -15,8 +15,6 @@ LOG_MODULE_REGISTER(HC_SR04, CONFIG_SENSOR_LOG_LEVEL);
 
 #define HC_SR04_MM_PER_MS     171
 
-static const uint32_t hw_cycles_per_ms = sys_clock_hw_cycles_per_sec() / 1000;
-
 struct hcsr04_data {
 	const struct device *dev;
 	struct gpio_callback gpio_cb;
@@ -29,6 +27,11 @@ struct hcsr04_config {
 	struct gpio_dt_spec trigger_gpios;
 	struct gpio_dt_spec echo_gpios;
 };
+
+static inline uint32_t hw_cycles_per_ms(void)
+{
+	return sys_clock_hw_cycles_per_sec() / 1000U;
+}
 
 static void hcsr04_gpio_callback(const struct device *dev, struct gpio_callback *cb, uint32_t pins);
 
@@ -160,8 +163,7 @@ static int hcsr04_channel_get(const struct device *dev, enum sensor_channel chan
 		return -ENOTSUP;
 	}
 
-	distance_mm = HC_SR04_MM_PER_MS * atomic_get(&data->echo_high_cycles) /
-			hw_cycles_per_ms;
+	distance_mm = HC_SR04_MM_PER_MS * atomic_get(&data->echo_high_cycles) / hw_cycles_per_ms();
 	return sensor_value_from_milli(val, distance_mm);
 }
 


### PR DESCRIPTION
### Motivation

The HC-SR04 driver uses the SoC frequency to compute distance from the measured time. It was originally declared as:

```c
static const uint32_t hw_cycles_per_ms = sys_clock_hw_cycles_per_sec() / 1000;
```
However, on some SoCs/boards (e.g. `rpi_4b/bcm2711`), this frequency is only available at runtime, which causes the following compilation error:

```
In file included from /home/abc/Zephyr/zephyrproject/zephyr/include/zephyr/sys/util.h:1048,
                 from /home/abc/Zephyr/zephyrproject/zephyr/include/zephyr/sys/atomic.h:24,
                 from /home/abc/Zephyr/zephyrproject/zephyr/include/zephyr/kernel_includes.h:25,
                 from /home/abc/Zephyr/zephyrproject/zephyr/include/zephyr/kernel.h:17,
                 from /home/abc/Zephyr/zephyrproject/zephyr/drivers/sensor/hc_sr04/hc_sr04.c:9:
/home/abc/Zephyr/zephyrproject/zephyr/include/zephyr/sys/time_units.h:90:39: error: initializer element is not constant
   90 | #define sys_clock_hw_cycles_per_sec() sys_clock_hw_cycles_per_sec_runtime_get()
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/abc/Zephyr/zephyrproject/zephyr/drivers/sensor/hc_sr04/hc_sr04.c:18:42: note: in expansion of macro 'sys_clock_hw_cycles_per_sec'
   18 | static const uint32_t hw_cycles_per_ms = sys_clock_hw_cycles_per_sec() / 1000;
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /usr/bin/cmake --build /home/abc/Zephyr/zephyrproject/applications/build
```

### Solutions

The two solutions I considered were replacing `hw_cycles_per_ms` with either a macro or an inline function. This PR uses the latter because it preserves type safety and debuggability.

### Changes

Modify only `drivers/sensor/hc_sr04/hc_sr04.c` by removing the constant declaration, introducing an equivalent function, and using it in distance computation.