### PR TITLE
drivers: ethernet: nxp_enet_qos: fix MAC config sequence for speed/duplex

### DIFF
--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos.c
@@ -101,21 +101,31 @@ static void eth_nxp_enet_qos_phy_cb(const struct device *phy,
 		const struct nxp_enet_qos_mac_config *config = dev->config;
 		enet_qos_t *base = config->module.base;
 
+		uint32_t mac_cfg = base->MAC_CONFIGURATION;
+
 		if (PHY_LINK_IS_SPEED_10M(state->speed)) {
 			LOG_DBG("Link Speed reduced to 10MBit");
-			base->MAC_CONFIGURATION &= ~ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1);
+			mac_cfg &= ~ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1);
 		} else {
 			LOG_DBG("Link Speed 100MBit or higher");
-			base->MAC_CONFIGURATION |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1);
+			mac_cfg |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1);
 		}
 
+		/* Duplex configuration */
 		if (PHY_LINK_IS_FULL_DUPLEX(state->speed)) {
 			LOG_DBG("Link Full Duplex");
-			base->MAC_CONFIGURATION |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1);
+			mac_cfg |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1);
 		} else {
 			LOG_DBG("Link Half Duplex");
-			base->MAC_CONFIGURATION &= ~ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1);
+			mac_cfg &= ~ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1);
 		}
+
+		/* Transmit and receive enable */
+		mac_cfg |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, TE, 0b1);
+		mac_cfg |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, RE, 0b1);
+
+		/* Single write back */
+		base->MAC_CONFIGURATION = mac_cfg;
 	}
 }
 
@@ -710,11 +720,6 @@ static inline void enet_qos_start(enet_qos_t *base)
 		/* Receive and Transmit IRQs */
 		ENET_QOS_REG_PREP(MAC_INTERRUPT_ENABLE, TXSTSIE, 0b1) |
 		ENET_QOS_REG_PREP(MAC_INTERRUPT_ENABLE, RXSTSIE, 0b1);
-
-	/* Start the TX and RX on the MAC */
-	base->MAC_CONFIGURATION |=
-		ENET_QOS_REG_PREP(MAC_CONFIGURATION, TE, 0b1) |
-		ENET_QOS_REG_PREP(MAC_CONFIGURATION, RE, 0b1);
 }
 
 static inline void enet_qos_tx_desc_init(enet_qos_t *base, struct nxp_enet_qos_tx_data *tx)

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -65,26 +65,37 @@ static void eth_nxp_enet_qos_phy_cb(const struct device *phy,
 	net_eth_carrier_set(data->iface, state->is_up);
 
 	/* handle link speed and duplex in MAC configuration register */
+
 	if (state->is_up) {
 		const struct nxp_enet_qos_mac_config *config = dev->config;
 		struct nxp_enet_qos_config *module_cfg = ENET_QOS_MODULE_CFG(config->enet_dev);
 		enet_qos_t *base = module_cfg->base;
 
+		uint32_t mac_cfg = base->MAC_CONFIGURATION;
+
 		if (PHY_LINK_IS_SPEED_10M(state->speed)) {
 			LOG_DBG("Link Speed reduced to 10MBit");
-			base->MAC_CONFIGURATION &= ~ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1);
+			mac_cfg &= ~ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1);
 		} else {
 			LOG_DBG("Link Speed 100MBit or higher");
-			base->MAC_CONFIGURATION |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1);
+			mac_cfg |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, FES, 0b1);
 		}
 
+		/* Duplex configuration */
 		if (PHY_LINK_IS_FULL_DUPLEX(state->speed)) {
 			LOG_DBG("Link Full Duplex");
-			base->MAC_CONFIGURATION |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1);
+			mac_cfg |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1);
 		} else {
 			LOG_DBG("Link Half Duplex");
-			base->MAC_CONFIGURATION &= ~ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1);
+			mac_cfg &= ~ENET_QOS_REG_PREP(MAC_CONFIGURATION, DM, 0b1);
 		}
+
+		/*Transmit and receive enable */
+		mac_cfg |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, TE, 0b1);
+		mac_cfg |= ENET_QOS_REG_PREP(MAC_CONFIGURATION, RE, 0b1);
+
+		/* Single write back */
+		base->MAC_CONFIGURATION = mac_cfg;
 	}
 }
 
@@ -691,10 +702,6 @@ static inline void enet_qos_start(enet_qos_t *base)
 		ENET_QOS_REG_PREP(MAC_INTERRUPT_ENABLE, TXSTSIE, 0b1) |
 		ENET_QOS_REG_PREP(MAC_INTERRUPT_ENABLE, RXSTSIE, 0b1);
 
-	/* Start the TX and RX on the MAC */
-	base->MAC_CONFIGURATION |=
-		ENET_QOS_REG_PREP(MAC_CONFIGURATION, TE, 0b1) |
-		ENET_QOS_REG_PREP(MAC_CONFIGURATION, RE, 0b1);
 }
 
 static inline void enet_qos_tx_desc_init(enet_qos_t *base, struct nxp_enet_qos_tx_data *tx)


### PR DESCRIPTION
The `eth_nxp_enet_qos_mac.c` driver programs the MAC in a sequence that
violates the Synopsys DWC_ether_qos databook.

The databook states:

> Do not change configuration parameters (such as duplex mode, speed,
> port, or loopback) while the MAC is actively transmitting or receiving.
> These parameters must only be modified when both the MAC transmitter
> and receiver are disabled.

Previously, `enet_qos_start()` set the TE/RE bits (enabling the MAC
transmitter and receiver) during MAC init, **before** the PHY link
callback `eth_nxp_enet_qos_phy_cb()` updated the FES (speed) and DM
(duplex) fields in `MAC_CONFIGURATION`. As a result, speed and duplex
could be modified while the MAC was already active, which is not allowed
and can cause incorrect device behavior.

### Changes

- Do not enable TE/RE in `enet_qos_start()`. The MAC transmitter and
  receiver stay disabled after init, so speed/duplex can be safely
  configured.
- In `eth_nxp_enet_qos_phy_cb()`, compute the speed (FES) and duplex (DM)
  settings, then enable TE/RE, and commit everything to
  `MAC_CONFIGURATION` in a single register write. This guarantees
  that speed/duplex are only changed while the MAC is disabled and avoids
  back-to-back writes to the same register.