### PR TITLE
video: ctrls: Remove duplicate / dead code

### DIFF
--- a/subsys/video/ctrls.c
+++ b/subsys/video/ctrls.c
@@ -13,40 +13,6 @@
 
 LOG_MODULE_REGISTER(video_controls, CONFIG_VIDEO_LOG_LEVEL);
 
-static inline const char *const *video_get_std_menu_ctrl(uint32_t id)
-{
-	static char const *const power_line_frequency[] = {
-		"Disabled", "50 Hz", "60 Hz", "Auto", NULL,
-	};
-	static char const *const exposure_auto[] = {
-		"Auto Mode", "Manual Mode", "Shutter Priority Mode", "Aperture Priority Mode", NULL,
-	};
-	static char const *const colorfx[] = {
-		"None", "Black & White", "Sepia", "Negative", "Emboss", "Sketch", "Sky Blue",
-		"Grass Green", "Skin Whiten", "Vivid", "Aqua", "Art Freeze", "Silhouette",
-		"Solarization", "Antique", "Set Cb/Cr", NULL,
-	};
-	static char const *const camera_orientation[] = {
-		"Front", "Back", "External", NULL,
-	};
-
-	switch (id) {
-	/* User control menus */
-	case VIDEO_CID_POWER_LINE_FREQUENCY:
-		return power_line_frequency;
-
-	/* Camera control menus */
-	case VIDEO_CID_EXPOSURE_AUTO:
-		return exposure_auto;
-	case VIDEO_CID_COLORFX:
-		return colorfx;
-	case VIDEO_CID_CAMERA_ORIENTATION:
-		return camera_orientation;
-	default:
-		return NULL;
-	}
-}
-
 /* By definition, the cluster is in manual mode if the primary control value is 0 */
 static inline bool is_cluster_manual(const struct video_ctrl *primary)
 {


### PR DESCRIPTION
As part of 93511748eef0b0091e0607619e5b96db8286e90e this function was (partially) moved to be in drivers/video/video_common.c and is used in that file, while it stopped being used from this file, but forgotten here.

So, after this change, this static inline was left as a duplicate of that other one, and because of being static just dead code which did not conflict at link time.

Let's just remove this left over.

clang can be seen complaining here:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/29691778743/job/88205690210#step:12:1193
can be repro'd w
```
ZEPHYR_TOOLCHAIN_VARIANT=host/llvm cmake -GNinja -DBOARD=native_sim ../tests/drivers/build_all/video/
ninja
```