### PR TITLE
drivers: sensor: bmp581: ifdef static function

### DIFF
--- a/drivers/sensor/bosch/bmp581/bmp581.c
+++ b/drivers/sensor/bosch/bmp581/bmp581.c
@@ -44,6 +44,7 @@ static int set_iir_config(const struct sensor_value *iir, const struct device *d
 static int get_power_mode(enum bmp5_powermode *powermode, const struct device *dev);
 static int set_power_mode(enum bmp5_powermode powermode, const struct device *dev);
 
+#ifdef CONFIG_SENSOR_ASYNC_API
 #ifdef CONFIG_PM_DEVICE
 static int bmp581_pm_busy_check(const struct device *dev)
 {
@@ -55,13 +56,14 @@ static int bmp581_pm_busy_check(const struct device *dev)
 	}
 	return 0;
 }
-#else
+#else /* CONFIG_PM_DEVICE */
 static inline int bmp581_pm_busy_check(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 	return 0;
 }
-#endif
+#endif /* CONFIG_PM_DEVICE */
+#endif /* CONFIG_SENSOR_ASYNC_API */
 
 static int set_power_mode(enum bmp5_powermode powermode, const struct device *dev)
 {


### PR DESCRIPTION
So it is only built when needed, and we avoid a compiler warning: 
`bmp581.c:59:19: error: unused function 'bmp581_pm_busy_check'`

The issue was there since c68a25e4d531462505eaf4e9f45c1d31a311088b but only became apparent in CI when its test was added in f0802b645b6ad215af05adbde72ab35333834191

Can be seen failing in CI in
https://github.com/zephyrproject-rtos/zephyr/actions/runs/29691778743/job/88205690210#step:12:649
Can be repro'd w
```
ZEPHYR_TOOLCHAIN_VARIANT=host/llvm cmake -GNinja -DBOARD=native_sim ../tests/drivers/sensor/bmp581/ 
ninja
```