### PR TITLE
tests: drivers: build_all: video: build by default also with clang

### DIFF
--- a/tests/drivers/build_all/video/tests.yaml
+++ b/tests/drivers/build_all/video/tests.yaml
@@ -11,6 +11,9 @@ tests:
     depends_on:
       - gpio
       - i2c
+    integration_toolchains:
+      - host/gcc
+      - host/llvm
   drivers.video.spi.build:
     extra_args: DTC_OVERLAY_FILE="spi_devices.overlay"
     extra_configs:
@@ -21,6 +24,9 @@ tests:
     depends_on:
       - gpio
       - spi
+    integration_toolchains:
+      - host/gcc
+      - host/llvm
   drivers.video.mcux_csi.build:
     platform_allow:
       - mimxrt1064_evk


### PR DESCRIPTION
Given that this test is a build all test, we may as well also build it with clang/llvm to catch whatever issues may be in this code in PRs that clang may catch and gcc won't
