### PR TITLE
boards: adi: Enable async UART DMA support for MAX32655/7/8

### DIFF
--- a/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
+++ b/boards/adi/max32655evkit/max32655evkit_max32655_m4.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Analog Devices, Inc.
+ * Copyright (c) 2023-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -55,6 +55,19 @@
 	current-speed = <115200>;
 	data-bits = <8>;
 	parity = "none";
+	dmas = <&dma0 1 MAX32_DMA_SLOT_UART0_TX>, <&dma0 0 MAX32_DMA_SLOT_UART0_RX>;
+	dma-names = "tx", "rx";
+};
+
+&uart3 {
+	pinctrl-0 = <&lpuartb_tx_p2_7 &lpuartb_rx_p2_6>;
+	status = "okay";
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	data-bits = <8>;
+	parity = "none";
+	dmas = <&dma0 1 MAX32_DMA_SLOT_UART3_TX>, <&dma0 0 MAX32_DMA_SLOT_UART3_RX>;
+	dma-names = "tx", "rx";
 };
 
 /*

--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025 Analog Devices, Inc.
+ * Copyright (c) 2023-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -41,6 +41,19 @@
 	data-bits = <8>;
 	parity = "none";
 	status = "okay";
+	dmas = <&dma0 1 MAX32_DMA_SLOT_UART0_TX>, <&dma0 0 MAX32_DMA_SLOT_UART0_RX>;
+	dma-names = "tx", "rx";
+};
+
+&uart3 {
+	pinctrl-0 = <&lpuartb_tx_p2_7 &lpuartb_rx_p2_6>;
+	status = "okay";
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	data-bits = <8>;
+	parity = "none";
+	dmas = <&dma0 1 MAX32_DMA_SLOT_UART3_TX>, <&dma0 0 MAX32_DMA_SLOT_UART3_RX>;
+	dma-names = "tx", "rx";
 };
 
 &clk_ipo {

--- a/boards/adi/max32657evkit/max32657evkit_max32657.dts
+++ b/boards/adi/max32657evkit/max32657evkit_max32657.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -48,5 +48,14 @@
 };
 
 &trng {
+	status = "okay";
+};
+
+&uart0 {
+	dmas = <&dma1 1 MAX32_DMA_SLOT_UART_TX>, <&dma1 0 MAX32_DMA_SLOT_UART_RX>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
 	status = "okay";
 };

--- a/boards/adi/max32657evkit/max32657evkit_max32657_ns.dts
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_ns.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -72,4 +72,13 @@
 			reg = <0xf0000 DT_SIZE_K(64)>;
 		};
 	};
+};
+
+&uart0 {
+	dmas = <&dma0 1 MAX32_DMA_SLOT_UART_TX>, <&dma0 0 MAX32_DMA_SLOT_UART_RX>;
+	dma-names = "tx", "rx";
+};
+
+&dma0 {
+	status = "okay";
 };

--- a/boards/adi/max32658evkit/max32658evkit_max32658.dts
+++ b/boards/adi/max32658evkit/max32658evkit_max32658.dts
@@ -50,3 +50,12 @@
 &trng {
 	status = "okay";
 };
+
+&uart0 {
+	dmas = <&dma1 1 MAX32_DMA_SLOT_UART_TX>, <&dma1 0 MAX32_DMA_SLOT_UART_RX>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
+	status = "okay";
+};

--- a/boards/adi/max32658evkit/max32658evkit_max32658_ns.dts
+++ b/boards/adi/max32658evkit/max32658evkit_max32658_ns.dts
@@ -73,3 +73,12 @@
 		};
 	};
 };
+
+&uart0 {
+	dmas = <&dma0 1 MAX32_DMA_SLOT_UART_TX>, <&dma0 0 MAX32_DMA_SLOT_UART_RX>;
+	dma-names = "tx", "rx";
+};
+
+&dma0 {
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_async_api/boards/max32655evkit_max32655_m4.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/max32655evkit_max32655_m4.overlay
@@ -1,18 +1,7 @@
 /*
- * Copyright (c) 2024 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dut: &uart3 {
-	status = "okay";
-	pinctrl-0 = <&lpuartb_tx_p2_7 &lpuartb_rx_p2_6>;
-	pinctrl-names = "default";
-
-	dmas = <&dma0 1 MAX32_DMA_SLOT_UART3_TX>, <&dma0 2 MAX32_DMA_SLOT_UART3_RX>;
-	dma-names = "tx", "rx";
-
-	current-speed = <115200>;
-	data-bits = <8>;
-	parity = "none";
-};
+dut: &uart3 {};

--- a/tests/drivers/uart/uart_async_api/boards/max32655fthr_max32655_m4.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/max32655fthr_max32655_m4.overlay
@@ -1,18 +1,7 @@
 /*
- * Copyright (c) 2024 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dut: &uart3 {
-	status = "okay";
-	pinctrl-0 = <&lpuartb_tx_p2_7 &lpuartb_rx_p2_6>;
-	pinctrl-names = "default";
-
-	dmas = <&dma0 1 MAX32_DMA_SLOT_UART3_TX>, <&dma0 2 MAX32_DMA_SLOT_UART3_RX>;
-	dma-names = "tx", "rx";
-
-	current-speed = <115200>;
-	data-bits = <8>;
-	parity = "none";
-};
+dut: &uart3 {};

--- a/tests/drivers/uart/uart_async_api/tests.yaml
+++ b/tests/drivers/uart/uart_async_api/tests.yaml
@@ -3,6 +3,10 @@ common:
     - stamp_c3
     - wio_terminal
     - xiao_esp32c3
+    - max32657evkit/max32657
+    - max32657evkit/max32657/ns
+    - max32658evkit/max32658
+    - max32658evkit/max32658/ns
   tags:
     - drivers
     - uart


### PR DESCRIPTION
Adds the required DMA configuration for asynchronous UART support on MAX32655/7/8 evaluation boards.