### PR TITLE
drivers: sdhc: Add R-Car V4H SDHI support

### DIFF
--- a/boards/retronix/sparrowhawk_rcar_v4h/Kconfig.defconfig
+++ b/boards/retronix/sparrowhawk_rcar_v4h/Kconfig.defconfig
@@ -6,3 +6,11 @@ config BUILD_OUTPUT_BIN
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/clocks/clock-cl16m_rt,clock-frequency)
+
+if BOARD_SPARROWHAWK_RCAR_V4H_R8A779G0_A76
+
+# GPIO must initialize after the GIC/PFC and before GPIO regulators.
+config GPIO_INIT_PRIORITY
+	default 70
+
+endif

--- a/boards/retronix/sparrowhawk_rcar_v4h/sparrowhawk_rcar_v4h_r8a779g0_a76-pinctrl.dtsi
+++ b/boards/retronix/sparrowhawk_rcar_v4h/sparrowhawk_rcar_v4h_r8a779g0_a76-pinctrl.dtsi
@@ -14,4 +14,72 @@
 	hscif0_data_rx_default: hscif0_data_rx_default {
 		pin = <PIN_HRX0 FUNC_HRX0>;
 	};
+
+	mmc_clk: mmc_clk {
+		pin = <PIN_MMC_SD_CLK FUNC_MMC_SD_CLK>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
+	mmc_uhs_clk: mmc_uhs_clk {
+		pin = <PIN_MMC_SD_CLK FUNC_MMC_SD_CLK>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_cmd: mmc_cmd {
+		pin = <PIN_MMC_SD_CMD FUNC_MMC_SD_CMD>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
+	mmc_uhs_cmd: mmc_uhs_cmd {
+		pin = <PIN_MMC_SD_CMD FUNC_MMC_SD_CMD>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_data0: mmc_data0 {
+		pin = <PIN_MMC_SD_D0 FUNC_MMC_SD_D0>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
+	mmc_uhs_data0: mmc_uhs_data0 {
+		pin = <PIN_MMC_SD_D0 FUNC_MMC_SD_D0>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_data1: mmc_data1 {
+		pin = <PIN_MMC_SD_D1 FUNC_MMC_SD_D1>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
+	mmc_uhs_data1: mmc_uhs_data1 {
+		pin = <PIN_MMC_SD_D1 FUNC_MMC_SD_D1>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_data2: mmc_data2 {
+		pin = <PIN_MMC_SD_D2 FUNC_MMC_SD_D2>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
+	mmc_uhs_data2: mmc_uhs_data2 {
+		pin = <PIN_MMC_SD_D2 FUNC_MMC_SD_D2>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	mmc_data3: mmc_data3 {
+		pin = <PIN_MMC_SD_D3 FUNC_MMC_SD_D3>;
+		power-source = <PIN_VOLTAGE_3P3V>;
+	};
+
+	mmc_uhs_data3: mmc_uhs_data3 {
+		pin = <PIN_MMC_SD_D3 FUNC_MMC_SD_D3>;
+		power-source = <PIN_VOLTAGE_1P8V>;
+	};
+
+	sd_cd: sd_cd {
+		pin = <PIN_SD_CD>;
+	};
+
+	sd_vqmmc: sd_vqmmc {
+		pin = <PIN_GP8_13>;
+	};
 };

--- a/boards/retronix/sparrowhawk_rcar_v4h/sparrowhawk_rcar_v4h_r8a779g0_a76.dts
+++ b/boards/retronix/sparrowhawk_rcar_v4h/sparrowhawk_rcar_v4h_r8a779g0_a76.dts
@@ -7,6 +7,7 @@
 
 /dts-v1/;
 #include <mem.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <arm64/renesas/r8a779g0.dtsi>
 #include "sparrowhawk_rcar_v4h_r8a779g0_a76-pinctrl.dtsi"
 
@@ -20,9 +21,24 @@
 		zephyr,shell-uart = &hscif0;
 	};
 
+	aliases {
+		sdhc0 = &mmc0;
+	};
+
 	ram: memory@40000000 {
 		device_type = "memory";
 		reg = <0x0 0x40000000 0x0 DT_SIZE_G(2)>;
+	};
+
+	vcc_sdhi: regulator-vcc-sdhi {
+		compatible = "regulator-gpio";
+		regulator-name = "SD0_VCCQ";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+		gpios = <&gpio8 13 GPIO_ACTIVE_HIGH>;
+		states = <1800000 0>, <3300000 1>;
+		regulator-boot-on;
+		status = "okay";
 	};
 };
 
@@ -31,4 +47,35 @@
 	pinctrl-0 = <&hscif0_data_tx_default &hscif0_data_rx_default>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&gpio3 {
+	pinctrl-0 = <&sd_cd>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&gpio8 {
+	pinctrl-0 = <&sd_vqmmc>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&mmc0 {
+	pinctrl-0 = <&mmc_clk &mmc_cmd &mmc_data0 &mmc_data1 &mmc_data2 &mmc_data3>;
+	pinctrl-1 = <&mmc_uhs_clk &mmc_uhs_cmd &mmc_uhs_data0 &mmc_uhs_data1
+		     &mmc_uhs_data2 &mmc_uhs_data3>;
+	pinctrl-names = "default", "uhs";
+
+	bus-width = <4>;
+	mmc-sdr104-support;
+	cd-gpios = <&gpio3 11 GPIO_ACTIVE_LOW>;
+	vqmmc-supply = <&vcc_sdhi>;
+	status = "okay";
+
+	disk {
+		compatible = "zephyr,sdmmc-disk";
+		disk-name = "SD";
+		status = "okay";
+	};
 };

--- a/boards/retronix/sparrowhawk_rcar_v4h/sparrowhawk_rcar_v4h_r8a779g0_a76.yaml
+++ b/boards/retronix/sparrowhawk_rcar_v4h/sparrowhawk_rcar_v4h_r8a779g0_a76.yaml
@@ -8,4 +8,5 @@ toolchain:
 supported:
   - pinctrl
   - clock_control
+  - sdhc
   - uart

--- a/drivers/clock_control/clock_control_r8a779g0_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_r8a779g0_cpg_mssr.c
@@ -99,7 +99,7 @@ int r8a779g0_cpg_mssr_on_off(const struct device *dev, clock_control_subsys_t sy
 	} else if (clk->domain == CPG_CORE) {
 		if (is_on && clk->rate > 0) {
 			ret = rcar_cpg_set_rate(dev, (clock_control_subsys_t)clk,
-						(clock_control_subsys_rate_t)clk->rate);
+						(clock_control_subsys_rate_t)(uintptr_t)clk->rate);
 		}
 	} else {
 		ret = -EINVAL;

--- a/drivers/clock_control/clock_control_r8a779g0_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_r8a779g0_cpg_mssr.c
@@ -59,8 +59,13 @@ static struct cpg_clk_info_table core_props[] = {
 				RCAR_CPG_KHZ(66660)),
 	RCAR_CORE_CLK_INFO_ITEM(R8A779G0_CLK_CL16M, RCAR_CPG_NONE, RCAR_CPG_NONE,
 				RCAR_CPG_KHZ(16660)),
+
+	RCAR_CORE_CLK_INFO_ITEM(R8A779G0_CLK_SD0H, 0x0870, CLK_SDSRC, RCAR_CPG_NONE),
+	RCAR_CORE_CLK_INFO_ITEM(R8A779G0_CLK_SD0, 0x0870, R8A779G0_CLK_SD0H, RCAR_CPG_NONE),
+
 	RCAR_CORE_CLK_INFO_ITEM(R8A779G0_CLK_SASYNCPERD1, RCAR_CPG_NONE, RCAR_CPG_NONE, 266666666),
 	RCAR_CORE_CLK_INFO_ITEM(CLK_PLL5, RCAR_CPG_NONE, RCAR_CPG_NONE, RCAR_CPG_MHZ(3200)),
+	RCAR_CORE_CLK_INFO_ITEM(CLK_SDSRC, 0x08A4, CLK_PLL5, RCAR_CPG_NONE),
 };
 
 /*
@@ -75,10 +80,72 @@ static struct cpg_clk_info_table mod_props[] = {
 	RCAR_MOD_CLK_INFO_ITEM(514, R8A779G0_CLK_SASYNCPERD1), /* HSCIF0 */
 	RCAR_MOD_CLK_INFO_ITEM(515, R8A779G0_CLK_SASYNCPERD1), /* HSCIF1 */
 	RCAR_MOD_CLK_INFO_ITEM(702, R8A779G0_CLK_S0D12_PER),   /* SCIF0 */
-	RCAR_MOD_CLK_INFO_ITEM(915, R8A779G0_CLK_CL16M),       /* GPIO0 group 0 */
-	RCAR_MOD_CLK_INFO_ITEM(916, R8A779G0_CLK_CL16M),       /* GPIO1 group 0 */
-	RCAR_MOD_CLK_INFO_ITEM(917, R8A779G0_CLK_CL16M),       /* GPIO2 group 0 */
+	RCAR_MOD_CLK_INFO_ITEM(706, R8A779G0_CLK_SD0),         /* SD0 */
+	RCAR_MOD_CLK_INFO_ITEM(915, R8A779G0_CLK_CL16M),       /* PFC0: gpio0-1 */
+	RCAR_MOD_CLK_INFO_ITEM(916, R8A779G0_CLK_CL16M),       /* PFC1: gpio2-3 */
+	RCAR_MOD_CLK_INFO_ITEM(917, R8A779G0_CLK_CL16M),       /* PFC2: gpio4-7 */
+	RCAR_MOD_CLK_INFO_ITEM(918, R8A779G0_CLK_CL16M),       /* PFC3: gpio8   */
 };
+
+static int r8a779g0_cpg_enable_disable_core(const struct device *dev,
+					    struct cpg_clk_info_table *clk_info, uint32_t enable)
+{
+	int ret = 0;
+	uint32_t reg;
+
+	switch (clk_info->module) {
+	case R8A779G0_CLK_SD0:
+		reg = sys_read32(DEVICE_MMIO_GET(dev) + clk_info->offset);
+		reg &= ~BIT(R8A779G0_CLK_SD0_STOP_BIT);
+		reg |= (!enable << R8A779G0_CLK_SD0_STOP_BIT);
+		break;
+	case R8A779G0_CLK_SD0H:
+		reg = sys_read32(DEVICE_MMIO_GET(dev) + clk_info->offset);
+		reg &= ~BIT(R8A779G0_CLK_SD0H_STOP_BIT);
+		reg |= (!enable << R8A779G0_CLK_SD0H_STOP_BIT);
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
+	}
+
+	if (!ret) {
+		rcar_cpg_write(DEVICE_MMIO_GET(dev), clk_info->offset, reg);
+	}
+	return ret;
+}
+
+static int r8a779g0_cpg_core_clock_endisable(const struct device *dev, struct rcar_cpg_clk *clk,
+					     bool enable)
+{
+	struct cpg_clk_info_table *clk_info;
+	struct r8a779g0_cpg_mssr_data *data = dev->data;
+	k_spinlock_key_t key;
+
+	clk_info = rcar_cpg_find_clk_info_by_module_id(dev, clk->domain, clk->module);
+	if (!clk_info) {
+		return -EINVAL;
+	}
+
+	if (enable) {
+		if (clk->rate > 0) {
+			int ret;
+			uintptr_t rate = clk->rate;
+
+			ret = rcar_cpg_set_rate(dev, (clock_control_subsys_t)clk,
+						(clock_control_subsys_rate_t)rate);
+			if (ret < 0) {
+				return ret;
+			}
+		}
+	}
+
+	key = k_spin_lock(&data->cmn.lock);
+	r8a779g0_cpg_enable_disable_core(dev, clk_info, enable);
+	k_spin_unlock(&data->cmn.lock, key);
+
+	return 0;
+}
 
 int r8a779g0_cpg_mssr_on_off(const struct device *dev, clock_control_subsys_t sys, bool is_on)
 {
@@ -97,10 +164,7 @@ int r8a779g0_cpg_mssr_on_off(const struct device *dev, clock_control_subsys_t sy
 		ret = rcar_cpg_mstp_clock_endisable(DEVICE_MMIO_GET(dev), clk->module, is_on);
 		k_spin_unlock(&data->cmn.lock, key);
 	} else if (clk->domain == CPG_CORE) {
-		if (is_on && clk->rate > 0) {
-			ret = rcar_cpg_set_rate(dev, (clock_control_subsys_t)clk,
-						(clock_control_subsys_rate_t)(uintptr_t)clk->rate);
-		}
+		ret = r8a779g0_cpg_core_clock_endisable(dev, clk, is_on);
 	} else {
 		ret = -EINVAL;
 	}

--- a/drivers/pinctrl/renesas/rcar/Kconfig
+++ b/drivers/pinctrl/renesas/rcar/Kconfig
@@ -11,6 +11,7 @@ config PINCTRL_RCAR_PFC
 config PINCTRL_RCAR_VOLTAGE_CONTROL
 	bool "Voltage control functionality of Renesas R-Car PFC driver"
 	default y if SOC_SERIES_RCAR_GEN3
+	default y if SOC_R8A779G0_R52 || SOC_R8A779G0_A76
 	depends on PINCTRL_RCAR_PFC
 
 config PINCTRL_RCAR_SCMI

--- a/drivers/pinctrl/renesas/rcar/pfc_rcar.c
+++ b/drivers/pinctrl/renesas/rcar/pfc_rcar.c
@@ -203,7 +203,7 @@ int pfc_rcar_set_bias(uintptr_t pfc_base, uint16_t pin, uint16_t flags)
 
 #ifdef CONFIG_PINCTRL_RCAR_VOLTAGE_CONTROL
 
-const struct pfc_pocctrl_reg pfc_r8a77951_r8a77961_volt_regs[] = {
+__maybe_unused const struct pfc_pocctrl_reg pfc_r8a77951_r8a77961_volt_regs[] = {
 	{
 		.offset = 0x0380,
 		.pins = {
@@ -244,9 +244,58 @@ const struct pfc_pocctrl_reg pfc_r8a77951_r8a77961_volt_regs[] = {
 	{ /* sentinel */ },
 };
 
+/*
+ * R-Car V4H has one POC register per GPIO group.  The SDHI pins are in
+ * GPIO group 3 and POC3 is at offset 0x0a0 in that group's PFC window.
+ */
+__maybe_unused const struct pfc_pocctrl_reg pfc_r8a779g0_volt_regs[] = {
+	{
+		.offset = 0x00a0,
+		.pins = {
+			[0] = RCAR_GP_PIN(3, 0),  /* MMC_SD_D1 */
+			[1] = RCAR_GP_PIN(3, 1),  /* MMC_SD_D0 */
+			[2] = RCAR_GP_PIN(3, 2),  /* MMC_SD_D2 */
+			[3] = RCAR_GP_PIN(3, 3),  /* MMC_SD_CLK */
+			[4] = RCAR_GP_PIN(3, 4),  /* MMC_DS */
+			[5] = RCAR_GP_PIN(3, 5),  /* MMC_SD_D3 */
+			[6] = RCAR_GP_PIN(3, 6),  /* MMC_D5 */
+			[7] = RCAR_GP_PIN(3, 7),  /* MMC_D4 */
+			[8] = RCAR_GP_PIN(3, 8),  /* MMC_D7 */
+			[9] = RCAR_GP_PIN(3, 9),  /* MMC_D6 */
+			[10] = RCAR_GP_PIN(3, 10), /* MMC_SD_CMD */
+			[11] = RCAR_GP_PIN(3, 11), /* SD_CD */
+			[12] = RCAR_GP_PIN(3, 12), /* SD_WP */
+			[13] = -1,
+			[14] = -1,
+			[15] = -1,
+			[16] = -1,
+			[17] = -1,
+			[18] = -1,
+			[19] = -1,
+			[20] = -1,
+			[21] = -1,
+			[22] = -1,
+			[23] = -1,
+			[24] = -1,
+			[25] = -1,
+			[26] = -1,
+			[27] = -1,
+			[28] = -1,
+			[29] = -1,
+			[30] = -1,
+			[31] = -1,
+		}
+	},
+	{ /* sentinel */ },
+};
+
 static const struct pfc_pocctrl_reg *pfc_rcar_get_io_voltage_regs(void)
 {
+#if defined(CONFIG_SOC_R8A779G0_R52) || defined(CONFIG_SOC_R8A779G0_A76)
+	return pfc_r8a779g0_volt_regs;
+#else
 	return pfc_r8a77951_r8a77961_volt_regs;
+#endif
 }
 
 static const struct pfc_pocctrl_reg *pfc_rcar_get_pocctrl_reg(uint16_t pin, uint8_t *bit)

--- a/drivers/pinctrl/renesas/rcar/pfc_rcar.c
+++ b/drivers/pinctrl/renesas/rcar/pfc_rcar.c
@@ -203,7 +203,7 @@ int pfc_rcar_set_bias(uintptr_t pfc_base, uint16_t pin, uint16_t flags)
 
 #ifdef CONFIG_PINCTRL_RCAR_VOLTAGE_CONTROL
 
-__maybe_unused const struct pfc_pocctrl_reg pfc_r8a77951_r8a77961_volt_regs[] = {
+__maybe_unused static const struct pfc_pocctrl_reg pfc_r8a77951_r8a77961_volt_regs[] = {
 	{
 		.offset = 0x0380,
 		.pins = {
@@ -248,7 +248,7 @@ __maybe_unused const struct pfc_pocctrl_reg pfc_r8a77951_r8a77961_volt_regs[] = 
  * R-Car V4H has one POC register per GPIO group.  The SDHI pins are in
  * GPIO group 3 and POC3 is at offset 0x0a0 in that group's PFC window.
  */
-__maybe_unused const struct pfc_pocctrl_reg pfc_r8a779g0_volt_regs[] = {
+__maybe_unused static const struct pfc_pocctrl_reg pfc_r8a779g0_volt_regs[] = {
 	{
 		.offset = 0x00a0,
 		.pins = {

--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -30,6 +30,24 @@ LOG_MODULE_REGISTER(rcar_mmc, CONFIG_LOG_DEFAULT_LEVEL);
 #define MMC_POLL_FLAGS_ONE_CYCLE_TIMEOUT_US 1
 #define MMC_BUS_CLOCK_FREQ 800000000
 
+/*
+ * CONFIG_SD_CMD_TIMEOUT and CONFIG_SD_DATA_TIMEOUT are provided by the SD
+ * subsystem (CONFIG_SD_STACK). The tuning procedure issues commands on its own,
+ * so it must also build when this driver is used without the SD subsystem.
+ * Fall back to the same defaults the subsystem defines in that case.
+ */
+#ifdef CONFIG_SD_CMD_TIMEOUT
+#define RCAR_MMC_CMD_TIMEOUT CONFIG_SD_CMD_TIMEOUT
+#else
+#define RCAR_MMC_CMD_TIMEOUT 200
+#endif
+
+#ifdef CONFIG_SD_DATA_TIMEOUT
+#define RCAR_MMC_DATA_TIMEOUT CONFIG_SD_DATA_TIMEOUT
+#else
+#define RCAR_MMC_DATA_TIMEOUT 10000
+#endif
+
 #ifdef CONFIG_RCAR_MMC_DMA_SUPPORT
 #define ALIGN_BUF_DMA __aligned(CONFIG_SDHC_BUFFER_ALIGNMENT)
 #else
@@ -1602,11 +1620,11 @@ static int rcar_mmc_execute_tuning(const struct device *dev)
 	}
 
 	cmd.response_type = SD_RSP_TYPE_R1;
-	cmd.timeout_ms = CONFIG_SD_CMD_TIMEOUT;
+	cmd.timeout_ms = RCAR_MMC_CMD_TIMEOUT;
 
 	data.blocks = 1;
 	data.data = dev_data->tuning_buf;
-	data.timeout_ms = CONFIG_SD_DATA_TIMEOUT;
+	data.timeout_ms = RCAR_MMC_DATA_TIMEOUT;
 	if (dev_data->host_io.bus_width == SDHC_BUS_WIDTH4BIT) {
 		data.block_size = sizeof(tun_block_4_bits_bus);
 		tun_block_ptr = tun_block_4_bits_bus;
@@ -1659,7 +1677,7 @@ static int rcar_mmc_execute_tuning(const struct device *dev)
 				struct sdhc_command stop_cmd = {
 					.opcode = SD_STOP_TRANSMISSION,
 					.response_type = SD_RSP_TYPE_R1b,
-					.timeout_ms = CONFIG_SD_CMD_TIMEOUT,
+					.timeout_ms = RCAR_MMC_CMD_TIMEOUT,
 				};
 
 				rcar_mmc_request(dev, &stop_cmd, NULL);

--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/disk.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sdhc.h>
 #include <zephyr/drivers/clock_control/renesas_cpg_mssr.h>
 #include <zephyr/drivers/pinctrl.h>
@@ -91,6 +92,7 @@ struct mmc_rcar_cfg {
 	const struct pinctrl_dev_config *pcfg;
 	const struct device *regulator_vqmmc;
 	const struct device *regulator_vmmc;
+	struct gpio_dt_spec cd_gpio;
 
 	uint32_t max_frequency;
 
@@ -1530,6 +1532,10 @@ static int rcar_mmc_get_card_present(const struct device *dev)
 		return 1;
 	}
 
+	if (cfg->cd_gpio.port != NULL) {
+		return gpio_pin_get_dt(&cfg->cd_gpio);
+	}
+
 	return !!(rcar_mmc_read_reg32(dev, RCAR_MMC_INFO1) & RCAR_MMC_INFO1_CD);
 }
 
@@ -2112,6 +2118,20 @@ static int rcar_mmc_init(const struct device *dev)
 		goto exit_unmap;
 	}
 
+	if (cfg->cd_gpio.port != NULL) {
+		if (!gpio_is_ready_dt(&cfg->cd_gpio)) {
+			LOG_ERR("%s: card-detect GPIO is not ready", dev->name);
+			ret = -ENODEV;
+			goto exit_unmap;
+		}
+
+		ret = gpio_pin_configure_dt(&cfg->cd_gpio, GPIO_INPUT);
+		if (ret < 0) {
+			LOG_ERR("%s: failed to configure card-detect GPIO: %d", dev->name, ret);
+			goto exit_unmap;
+		}
+	}
+
 	if (!device_is_ready(cfg->cpg_dev)) {
 		LOG_ERR("%s: error cpg_dev isn't ready", dev->name);
 		ret = -ENODEV;
@@ -2176,6 +2196,7 @@ exit_unmap:
 		.bus_clk.module = DT_INST_CLOCKS_CELL_BY_IDX(n, 1, module),                        \
 		.bus_clk.domain = DT_INST_CLOCKS_CELL_BY_IDX(n, 1, domain),                        \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
+		.cd_gpio = GPIO_DT_SPEC_INST_GET_OR(n, cd_gpios, {0}),                             \
 		.regulator_vqmmc = DEVICE_DT_GET(DT_PHANDLE(DT_DRV_INST(n), vqmmc_supply)),        \
 		.regulator_vmmc = DEVICE_DT_GET(DT_PHANDLE(DT_DRV_INST(n), vmmc_supply)),          \
 		.max_frequency = DT_INST_PROP(n, max_bus_freq),                                    \

--- a/dts/arm64/renesas/r8a779g0.dtsi
+++ b/dts/arm64/renesas/r8a779g0.dtsi
@@ -88,6 +88,17 @@
 			#reset-cells = <1>;
 		};
 
+		mmc0: mmc@ee140000 {
+			compatible = "renesas,rcar-mmc";
+			reg = <0 0xee140000 0 0x2000>;
+			vmmc-supply = <&reg_3p3v>;
+			vqmmc-supply = <&reg_1p8v>;
+			interrupts = <GIC_SPI 440 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&cpg CPG_MOD 706>, <&cpg CPG_CORE R8A779G0_CLK_SD0H>;
+			max-bus-freq = <200000000>;
+			status = "disabled";
+		};
+
 		pfc: pin-controller@e6050000 {
 			compatible = "renesas,rcar-pfc";
 			reg = <0 0xe6050000 0 0x16c>, <0 0xe6050800 0 0x16c>,

--- a/samples/subsys/fs/fs_sample/boards/sparrowhawk_rcar_v4h_r8a779g0_a76.conf
+++ b/samples/subsys/fs/fs_sample/boards/sparrowhawk_rcar_v4h_r8a779g0_a76.conf
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+# Read an existing FAT filesystem without formatting or creating entries.
+CONFIG_FILE_SYSTEM_MKFS=n
+CONFIG_FS_SAMPLE_CREATE_SOME_ENTRIES=n
+CONFIG_FS_FATFS_MOUNT_MKFS=n
+
+# Use 3.3 V signaling for the initial SD card check.
+CONFIG_SD_UHS_PROTOCOL=n

--- a/samples/subsys/fs/fs_sample/boards/sparrowhawk_rcar_v4h_r8a779g0_a76.overlay
+++ b/samples/subsys/fs/fs_sample/boards/sparrowhawk_rcar_v4h_r8a779g0_a76.overlay
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 TOKITA Hiroshi
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mmc0 {
+	status = "okay";
+	bus-width = <4>;
+
+	disk {
+		compatible = "zephyr,sdmmc-disk";
+		disk-name = "SD";
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Add MMC clock, card detection, and tuning support for R-Car V4H.
Add SDHI pinctrl, voltage regulator, and MMC device configuration for Retronix SparrowHawk.