### PR TITLE
samples: sensor_shell: Exclude in qemu_riscv64/qemu_virt_riscv64

### DIFF
--- a/samples/sensor/sensor_shell/tests.yaml
+++ b/samples/sensor/sensor_shell/tests.yaml
@@ -14,7 +14,9 @@ tests:
     min_ram: 20
     min_flash: 33
   sample.sensor.shell.pytest:
-    platform_exclude: qemu_rx
+    platform_exclude:
+      - qemu_rx
+      - qemu_riscv64/qemu_virt_riscv64 # Flaky
     filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
     min_ram: 40
     harness: pytest


### PR DESCRIPTION
This test fails very flakily in this target in different steps of the test each time.
The test is anyhow trying to test the shell code, the platform is irrelevant, so let's just exclude this platform.