### PR TITLE
drivers: bluetooth: hci: ipm_stm32wb: add runtime FW version check

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -128,6 +128,25 @@ config BT_STM32_IPM
 	  STM32WB HCI driver using the shared memory transport between
 	  CPU1 and the wireless coprocessor on CPU2.
 
+config BT_STM32_IPM_FW_INFO_CHECK
+	bool "STM32WB wireless firmware runtime check"
+	default y
+	depends on BT_STM32_IPM
+	select LOG
+	help
+	  Validate at runtime that the STM32WB wireless stack running on CPU2
+	  matches the expected stack type and version used by the driver.
+
+config BT_STM32_IPM_FW_CHECK_STRICT
+	bool "Fail initialization on STM32WB wireless firmware mismatch"
+	default y
+	depends on BT_STM32_IPM_FW_INFO_CHECK
+	help
+	  If enabled, Bluetooth initialization fails when the detected CPU2
+	  wireless firmware stack type or version does not match expectations.
+	  If disabled, mismatches are logged as warnings and initialization
+	  continues.
+
 config BT_STM32WBA
 	bool
 	default y

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -117,17 +117,6 @@ config BT_BLUENRG_ACI
 	  Enable support for devices compatible with the BlueNRG Bluetooth
 	  Stack. Current driver supports: ST BLUENRG-MS.
 
-config BT_STM32_IPM
-	bool
-	default y
-	depends on DT_HAS_ST_STM32WB_RF_ENABLED
-	select USE_STM32_HAL_CORTEX
-	select HAS_STM32LIB
-	select BT_HCI_SETUP
-	help
-	  STM32WB HCI driver using the shared memory transport between
-	  CPU1 and the wireless coprocessor on CPU2.
-
 config BT_STM32WBA
 	bool
 	default y

--- a/drivers/bluetooth/hci/Kconfig.stm32
+++ b/drivers/bluetooth/hci/Kconfig.stm32
@@ -53,3 +53,52 @@ config BT_STM32WBA_FULL_LIB
 endchoice
 
 endmenu
+
+config BT_STM32_IPM
+	bool
+	default y
+	depends on DT_HAS_ST_STM32WB_RF_ENABLED
+	select USE_STM32_HAL_CORTEX
+	select HAS_STM32LIB
+	select BT_HCI_SETUP
+	help
+	  STM32WB HCI driver using the shared memory transport between
+	  CPU1 and the wireless coprocessor on CPU2.
+
+config BT_STM32_IPM_FW_INFO_CHECK
+	bool "STM32WB wireless firmware runtime check"
+	default y
+	depends on BT_STM32_IPM
+	select LOG
+	help
+	  Validate at runtime that the STM32WB wireless stack running on CPU2
+	  matches the expected stack type and version used by the driver.
+
+config BT_STM32_IPM_FW_CHECK_STRICT
+	bool "Fail initialization on STM32WB wireless firmware mismatch"
+	default y
+	depends on BT_STM32_IPM_FW_INFO_CHECK
+	help
+	  If enabled, Bluetooth initialization fails when the detected CPU2
+	  wireless firmware stack type or version does not match expectations.
+	  If disabled, mismatches are logged as warnings and initialization
+	  continues.
+
+if BT_STM32_IPM_FW_INFO_CHECK
+
+config BT_FW_EXPECTED_VERSION_MAJOR
+	int "Expected STM32WB wireless firmware major version"
+	help
+	  Expected STM32WB wireless firmware major version.
+
+config BT_FW_EXPECTED_VERSION_MINOR
+	int "Expected STM32WB wireless firmware minor version"
+	help
+	  Expected STM32WB wireless firmware minor version.
+
+config BT_FW_EXPECTED_VERSION_SUB
+	int "Expected STM32WB wireless firmware sub version"
+	help
+	  Expected STM32WB wireless firmware sub version.
+
+endif # BT_STM32_IPM_FW_INFO_CHECK

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -80,6 +80,80 @@ static struct k_thread ipm_rx_thread_data;
 
 static bool c2_started_flag;
 
+#if defined(CONFIG_BT_STM32_IPM_FW_INFO_CHECK)
+static const char *stm32wb_stack_type_str(uint8_t stack_type)
+{
+	switch (stack_type) {
+	case INFO_STACK_TYPE_BLE_HCI:
+		return "INFO_STACK_TYPE_BLE_HCI";
+	case INFO_STACK_TYPE_BLE_HCI_EXT_ADV:
+		return "INFO_STACK_TYPE_BLE_HCI_EXT_ADV";
+	default:
+		return "INFO_STACK_TYPE_UNKNOWN";
+	}
+}
+
+static bool stm32wb_stack_type_is_compatible(uint8_t stack_type)
+{
+#if defined(CONFIG_BT_EXT_ADV)
+	return stack_type == INFO_STACK_TYPE_BLE_HCI_EXT_ADV;
+#else
+	return (stack_type == INFO_STACK_TYPE_BLE_HCI) ||
+	       (stack_type == INFO_STACK_TYPE_BLE_HCI_EXT_ADV);
+#endif
+}
+
+static int stm32wb_check_wireless_fw(void)
+{
+	WirelessFwInfo_t fw_info;
+	SHCI_CmdStatus_t status;
+	bool version_match;
+	bool stack_match;
+
+	status = SHCI_GetWirelessFwInfo(&fw_info);
+	if (status != SHCI_Success) {
+		LOG_ERR("Cannot read CPU2 wireless FW info (status: 0x%02x)", status);
+		return -EIO;
+	}
+
+	version_match = (fw_info.VersionMajor == CONFIG_BT_FW_EXPECTED_VERSION_MAJOR) &&
+			(fw_info.VersionMinor == CONFIG_BT_FW_EXPECTED_VERSION_MINOR) &&
+			(fw_info.VersionSub == CONFIG_BT_FW_EXPECTED_VERSION_SUB);
+	stack_match = stm32wb_stack_type_is_compatible(fw_info.StackType);
+
+	if (!version_match) {
+		LOG_ERR("CPU2 wireless FW mismatch: found v%u.%u.%u,expected v%d.%d.%d",
+			fw_info.VersionMajor, fw_info.VersionMinor, fw_info.VersionSub,
+			CONFIG_BT_FW_EXPECTED_VERSION_MAJOR,
+			CONFIG_BT_FW_EXPECTED_VERSION_MINOR,
+			CONFIG_BT_FW_EXPECTED_VERSION_SUB);
+		return -EINVAL;
+	}
+
+	if (!stack_match) {
+		LOG_ERR("CPU2 wireless FW build mismatch: found stack=%s,expected %s",
+			stm32wb_stack_type_str(fw_info.StackType),
+#if defined(CONFIG_BT_EXT_ADV)
+			"INFO_STACK_TYPE_BLE_HCI_EXT_ADV");
+#else
+			"INFO_STACK_TYPE_BLE_HCI or INFO_STACK_TYPE_BLE_HCI_EXT_ADV");
+#endif
+		return -EINVAL;
+	}
+
+	LOG_INF("CPU2 wireless FW: v%u.%u.%u",
+		fw_info.VersionMajor, fw_info.VersionMinor,
+		fw_info.VersionSub);
+	LOG_INF("CPU2 wireless FW build: %s (0x%02x)",
+		stm32wb_stack_type_str(fw_info.StackType), fw_info.StackType);
+	LOG_INF("FUS version %d.%d.%d",
+		fw_info.FusVersionMajor, fw_info.FusVersionMinor,
+		fw_info.FusVersionSub);
+
+	return 0;
+}
+#endif
+
 static void stm32wb_set_stack_options(SHCI_C2_Ble_Init_Cmd_Packet_t *ble_init_cmd_packet)
 {
 	ble_init_cmd_packet->Param.Options =
@@ -603,6 +677,17 @@ static int c2_reset(void)
 		return -ETIMEDOUT;
 	}
 	LOG_DBG("C2 unlocked");
+
+#if defined(CONFIG_BT_STM32_IPM_FW_INFO_CHECK)
+	err = stm32wb_check_wireless_fw();
+	if (err) {
+#if defined(CONFIG_BT_STM32_IPM_FW_CHECK_STRICT)
+		return err;
+#else
+		LOG_WRN("Continuing with mismatched CPU2 wireless FW");
+#endif
+	}
+#endif
 
 	stm32wb_start_ble(clk_cfg[1].bus);
 

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -26,6 +26,13 @@ static const struct stm32_pclken clk_cfg[] = STM32_DT_CLOCKS(DT_DRV_INST(0));
 #define POOL_SIZE (CFG_TLBLE_EVT_QUEUE_LENGTH * 4 * \
 		DIVC((sizeof(TL_PacketHeader_t) + TL_BLE_EVENT_FRAME_SIZE), 4))
 
+#if defined(CONFIG_BT_STM32_IPM_FW_INFO_CHECK)
+/* Note: this is the version of the STM32CubeWB package in hal_stm32. */
+#define FW_EXPECTED_VERSION_MAJOR	1
+#define FW_EXPECTED_VERSION_MINOR	24
+#define FW_EXPECTED_VERSION_SUB		0
+#endif
+
 /* Private variables ---------------------------------------------------------*/
 PLACE_IN_SECTION("MB_MEM1") ALIGN(4) static TL_CmdPacket_t BleCmdBuffer;
 PLACE_IN_SECTION("MB_MEM2") ALIGN(4) static uint8_t EvtPool[POOL_SIZE];
@@ -79,6 +86,80 @@ static K_KERNEL_STACK_DEFINE(ipm_rx_stack, CONFIG_BT_DRV_RX_STACK_SIZE);
 static struct k_thread ipm_rx_thread_data;
 
 static bool c2_started_flag;
+
+#if defined(CONFIG_BT_STM32_IPM_FW_INFO_CHECK)
+static const char *stm32wb_stack_type_str(uint8_t stack_type)
+{
+	switch (stack_type) {
+	case INFO_STACK_TYPE_BLE_HCI:
+		return "INFO_STACK_TYPE_BLE_HCI";
+	case INFO_STACK_TYPE_BLE_HCI_EXT_ADV:
+		return "INFO_STACK_TYPE_BLE_HCI_EXT_ADV";
+	default:
+		return "INFO_STACK_TYPE_UNKNOWN";
+	}
+}
+
+static bool stm32wb_stack_type_is_compatible(uint8_t stack_type)
+{
+#if defined(CONFIG_BT_EXT_ADV)
+	return stack_type == INFO_STACK_TYPE_BLE_HCI_EXT_ADV;
+#else
+	return (stack_type == INFO_STACK_TYPE_BLE_HCI) ||
+	       (stack_type == INFO_STACK_TYPE_BLE_HCI_EXT_ADV);
+#endif
+}
+
+static int stm32wb_check_wireless_fw(void)
+{
+	WirelessFwInfo_t fw_info;
+	SHCI_CmdStatus_t status;
+	bool version_match;
+	bool stack_match;
+
+	status = SHCI_GetWirelessFwInfo(&fw_info);
+	if (status != SHCI_Success) {
+		LOG_ERR("Cannot read CPU2 wireless FW info (status: 0x%02x)", status);
+		return -EIO;
+	}
+
+	version_match = (fw_info.VersionMajor == FW_EXPECTED_VERSION_MAJOR) &&
+			(fw_info.VersionMinor == FW_EXPECTED_VERSION_MINOR) &&
+			(fw_info.VersionSub == FW_EXPECTED_VERSION_SUB);
+	stack_match = stm32wb_stack_type_is_compatible(fw_info.StackType);
+
+	if (!version_match) {
+		LOG_ERR("CPU2 wireless FW mismatch: found v%u.%u.%u,expected v%d.%d.%d",
+			fw_info.VersionMajor, fw_info.VersionMinor, fw_info.VersionSub,
+			FW_EXPECTED_VERSION_MAJOR,
+			FW_EXPECTED_VERSION_MINOR,
+			FW_EXPECTED_VERSION_SUB);
+		return -EINVAL;
+	}
+
+	if (!stack_match) {
+		LOG_ERR("CPU2 wireless FW build mismatch: found stack=%s,expected %s",
+			stm32wb_stack_type_str(fw_info.StackType),
+#if defined(CONFIG_BT_EXT_ADV)
+			"INFO_STACK_TYPE_BLE_HCI_EXT_ADV");
+#else
+			"INFO_STACK_TYPE_BLE_HCI or INFO_STACK_TYPE_BLE_HCI_EXT_ADV");
+#endif
+		return -EINVAL;
+	}
+
+	LOG_INF("CPU2 wireless FW: v%u.%u.%u",
+		fw_info.VersionMajor, fw_info.VersionMinor,
+		fw_info.VersionSub);
+	LOG_INF("CPU2 wireless FW build: %s (0x%02x)",
+		stm32wb_stack_type_str(fw_info.StackType), fw_info.StackType);
+	LOG_INF("FUS version %d.%d.%d",
+		fw_info.FusVersionMajor, fw_info.FusVersionMinor,
+		fw_info.FusVersionSub);
+
+	return 0;
+}
+#endif
 
 static void stm32wb_set_stack_options(SHCI_C2_Ble_Init_Cmd_Packet_t *ble_init_cmd_packet)
 {
@@ -603,6 +684,17 @@ static int c2_reset(void)
 		return -ETIMEDOUT;
 	}
 	LOG_DBG("C2 unlocked");
+
+#if defined(CONFIG_BT_STM32_IPM_FW_INFO_CHECK)
+	err = stm32wb_check_wireless_fw();
+	if (err) {
+#if defined(CONFIG_BT_STM32_IPM_FW_CHECK_STRICT)
+		return err;
+#else
+		LOG_WRN("Continuing with mismatched CPU2 wireless FW");
+#endif
+	}
+#endif
 
 	stm32wb_start_ble(clk_cfg[1].bus);
 

--- a/soc/st/stm32/stm32wbx/Kconfig.defconfig
+++ b/soc/st/stm32/stm32wbx/Kconfig.defconfig
@@ -15,4 +15,17 @@ config BT_USER_PHY_UPDATE
 config BUILD_OUTPUT_UF2_FAMILY_ID
 	default "0x70d16653"
 
+if BT_STM32_IPM_FW_INFO_CHECK
+
+configdefault BT_FW_EXPECTED_VERSION_MAJOR
+	default 1
+
+configdefault BT_FW_EXPECTED_VERSION_MINOR
+	default 24
+
+configdefault BT_FW_EXPECTED_VERSION_SUB
+	default 0
+
+endif # BT_STM32_IPM_FW_INFO_CHECK
+
 endif # SOC_SERIES_STM32WBX


### PR DESCRIPTION
Run-time FW version check can be performed in the
stm32wb HCI driver, when initializing the Bluetooth IPM. The wireless firmware information can retrieved
(using the SHCI_GetWirelessFwInfo()) and verified
if it match or not.