### PR TITLE
Update DHCPv6 client code according to RFC 8415

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -433,6 +433,12 @@ struct net_if_dhcpv6 {
 	/** Retransmit timeout for the current message, milliseconds. */
 	uint32_t retransmit_timeout;
 
+	/** Maximum Solicit retransmit timeout, milliseconds. */
+	uint32_t sol_max_rt;
+
+	/** Maximum Information-request retransmit timeout, milliseconds. */
+	uint32_t inf_max_rt;
+
 	/** Current best server preference received. */
 	int16_t server_preference;
 

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -439,6 +439,11 @@ struct net_if_dhcpv6 {
 	/** Maximum Information-request retransmit timeout, milliseconds. */
 	uint32_t inf_max_rt;
 
+	/** Information-request refresh interval, milliseconds; 0 means never
+	 *  refresh (infinity).
+	 */
+	uint32_t info_refresh_time;
+
 	/** Current best server preference received. */
 	int16_t server_preference;
 

--- a/subsys/net/lib/dhcpv6/Kconfig
+++ b/subsys/net/lib/dhcpv6/Kconfig
@@ -1,4 +1,4 @@
-# DHCPv4 server implementation for Zephyr
+# DHCPv6 client implementation for Zephyr
 
 # Copyright (c) 2024 Nordic Semiconductor ASA
 #

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -201,6 +201,15 @@ static uint32_t dhcpv6_next_retransmit_time(int prev_retransmit_time,
 	return retransmit_time;
 }
 
+static uint32_t dhcpv6_sol_max_rt(struct net_if *iface)
+{
+	if (iface->config.dhcpv6.sol_max_rt != 0U) {
+		return iface->config.dhcpv6.sol_max_rt;
+	}
+
+	return DHCPV6_SOL_MAX_RT;
+}
+
 /* DHCPv6 packet encoding functions */
 
 static int dhcpv6_add_header(struct net_pkt *pkt, enum dhcpv6_msg_type type,
@@ -1242,6 +1251,31 @@ static int dhcpv6_parse_option_dns_servers(struct net_pkt *pkt, uint16_t length,
 	return 0;
 }
 
+static int dhcpv6_parse_option_max_rt(struct net_pkt *pkt, uint16_t length,
+				      uint32_t *max_rt)
+{
+	uint32_t max_rt_s;
+	int ret;
+
+	if (length != sizeof(max_rt_s)) {
+		return -EMSGSIZE;
+	}
+
+	ret = net_pkt_read_be32(pkt, &max_rt_s);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (max_rt_s < DHCPV6_MAX_RT_MIN / MSEC_PER_SEC ||
+	    max_rt_s > DHCPV6_MAX_RT_MAX / MSEC_PER_SEC) {
+		return -ERANGE;
+	}
+
+	*max_rt = max_rt_s * MSEC_PER_SEC;
+
+	return 0;
+}
+
 static int dhcpv6_find_option(struct net_pkt *pkt, enum dhcpv6_option_code opt_code,
 			      uint16_t *opt_len)
 {
@@ -1389,6 +1423,44 @@ static int dhcpv6_find_status_code(struct net_pkt *pkt, uint16_t *status)
 	net_pkt_cursor_restore(pkt, &backup);
 
 	return ret;
+}
+
+static int dhcpv6_find_max_rt(struct net_pkt *pkt, enum dhcpv6_option_code opt_code,
+			      uint32_t *max_rt)
+{
+	struct net_pkt_cursor backup;
+	uint16_t length;
+	int ret;
+
+	net_pkt_cursor_backup(pkt, &backup);
+
+	ret = dhcpv6_find_option(pkt, opt_code, &length);
+	if (ret == 0) {
+		ret = dhcpv6_parse_option_max_rt(pkt, length, max_rt);
+	}
+
+	net_pkt_cursor_restore(pkt, &backup);
+
+	return ret;
+}
+
+static void dhcpv6_update_max_rt_options(struct net_if *iface, struct net_pkt *pkt)
+{
+	uint32_t max_rt;
+
+	/* RFC 8415, ch. 21.24 and 21.25: a client MUST process a valid
+	 * SOL_MAX_RT/INF_MAX_RT option even if the message carries a Status
+	 * Code option indicating a failure. A missing, malformed or
+	 * out-of-range option is simply ignored and MUST NOT cause the message
+	 * to be discarded.
+	 */
+	if (dhcpv6_find_max_rt(pkt, DHCPV6_OPTION_CODE_SOL_MAX_RT, &max_rt) == 0) {
+		iface->config.dhcpv6.sol_max_rt = max_rt;
+	}
+
+	if (dhcpv6_find_max_rt(pkt, DHCPV6_OPTION_CODE_INF_MAX_RT, &max_rt) == 0) {
+		iface->config.dhcpv6.inf_max_rt = max_rt;
+	}
 }
 
 static int dhcpv6_handle_dns_server_option(struct net_pkt *pkt)
@@ -1620,6 +1692,12 @@ static int dhcpv6_handle_advertise(struct net_if *iface, struct net_pkt *pkt,
 		return -EBADMSG;
 	}
 
+	/* RFC 8415, ch. 21.24/21.25: process SOL_MAX_RT/INF_MAX_RT before any
+	 * status-based decision, as they MUST be honored even when the message
+	 * indicates a failure (e.g. an Advertise with NoAddrsAvail).
+	 */
+	dhcpv6_update_max_rt_options(iface, pkt);
+
 	/* Verify status code. */
 	ret = dhcpv6_find_status_code(pkt, &status);
 	if (ret < 0) {
@@ -1630,8 +1708,6 @@ static int dhcpv6_handle_advertise(struct net_if *iface, struct net_pkt *pkt,
 		/* Ignore. */
 		return 0;
 	}
-
-	/* TODO Process SOL_MAX_RT/INF_MAX_RT options. */
 
 	/* Verify server preference. */
 	ret = dhcpv6_find_server_preference(pkt, &server_preference);
@@ -1750,7 +1826,11 @@ static int dhcpv6_handle_reply(struct net_if *iface, struct net_pkt *pkt,
 		return -EBADMSG;
 	}
 
-	/* TODO Process SOL_MAX_RT/INF_MAX_RT options. */
+	/* RFC 8415, ch. 21.24/21.25: process SOL_MAX_RT/INF_MAX_RT before any
+	 * status-based decision, as they MUST be honored even when the Reply
+	 * carries a failure Status Code.
+	 */
+	dhcpv6_update_max_rt_options(iface, pkt);
 
 	/* Verify status code. */
 	ret = dhcpv6_find_status_code(pkt, &status);
@@ -2098,7 +2178,7 @@ static uint64_t dhcpv6_manage_timers(struct net_if *iface, int64_t now)
 		iface->config.dhcpv6.retransmit_timeout =
 			dhcpv6_next_retransmit_time(
 				iface->config.dhcpv6.retransmit_timeout,
-				DHCPV6_SOL_MAX_RT);
+				dhcpv6_sol_max_rt(iface));
 
 		(void)dhcpv6_send_solicit(iface);
 		dhcpv6_set_timeout(iface, iface->config.dhcpv6.retransmit_timeout);
@@ -2325,6 +2405,8 @@ void net_dhcpv6_start(struct net_if *iface, struct net_dhcpv6_params *params)
 	NET_DBG("Starting DHCPv6 on iface %p", iface);
 
 	iface->config.dhcpv6.params = *params;
+	iface->config.dhcpv6.sol_max_rt = DHCPV6_SOL_MAX_RT;
+	iface->config.dhcpv6.inf_max_rt = DHCPV6_INF_MAX_RT;
 
 	if (sys_slist_is_empty(&dhcpv6_ifaces)) {
 		net_mgmt_add_event_callback(&dhcpv6_mgmt_cb);

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -1731,6 +1731,15 @@ static int dhcpv6_handle_reply(struct net_if *iface, struct net_pkt *pkt,
 		return ret;
 	}
 
+	if ((iface->config.dhcpv6.state == NET_DHCPV6_REQUESTING ||
+	     iface->config.dhcpv6.state == NET_DHCPV6_RENEWING) &&
+	    (iface->config.dhcpv6.serverid.length != duid.length ||
+	     memcmp(&iface->config.dhcpv6.serverid.duid, &duid.duid,
+		    iface->config.dhcpv6.serverid.length) != 0)) {
+		NET_ERR("Server ID mismatch");
+		return -EBADMSG;
+	}
+
 	/* Verify TID. */
 	if (memcmp(iface->config.dhcpv6.tid, tid,
 		   sizeof(iface->config.dhcpv6.tid)) != 0) {

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -603,8 +603,6 @@ static struct net_pkt *dhcpv6_create_message(struct net_if *iface,
 		goto fail;
 	}
 
-	dhcpv6_generate_tid(iface);
-
 	if (dhcpv6_add_header(pkt, msg_type, iface->config.dhcpv6.tid) < 0) {
 		goto fail;
 	}
@@ -1479,6 +1477,7 @@ static void dhcpv6_enter_soliciting(struct net_if *iface)
 	iface->config.dhcpv6.server_preference = -1;
 	iface->config.dhcpv6.exchange_start = k_uptime_get();
 
+	dhcpv6_generate_tid(iface);
 	(void)dhcpv6_send_solicit(iface);
 	dhcpv6_set_timeout(iface, iface->config.dhcpv6.retransmit_timeout);
 }
@@ -1490,6 +1489,7 @@ static void dhcpv6_enter_requesting(struct net_if *iface)
 	iface->config.dhcpv6.retransmissions = 0;
 	iface->config.dhcpv6.exchange_start = k_uptime_get();
 
+	dhcpv6_generate_tid(iface);
 	(void)dhcpv6_send_request(iface);
 	dhcpv6_set_timeout(iface, iface->config.dhcpv6.retransmit_timeout);
 }
@@ -1501,6 +1501,7 @@ static void dhcpv6_enter_renewing(struct net_if *iface)
 	iface->config.dhcpv6.retransmissions = 0;
 	iface->config.dhcpv6.exchange_start = k_uptime_get();
 
+	dhcpv6_generate_tid(iface);
 	(void)dhcpv6_send_renew(iface);
 	dhcpv6_set_timeout(iface, iface->config.dhcpv6.retransmit_timeout);
 }
@@ -1512,6 +1513,7 @@ static void dhcpv6_enter_rebinding(struct net_if *iface)
 	iface->config.dhcpv6.retransmissions = 0;
 	iface->config.dhcpv6.exchange_start = k_uptime_get();
 
+	dhcpv6_generate_tid(iface);
 	(void)dhcpv6_send_rebind(iface);
 	dhcpv6_set_timeout(iface, iface->config.dhcpv6.retransmit_timeout);
 }
@@ -1523,6 +1525,7 @@ static void dhcpv6_enter_confirming(struct net_if *iface)
 	iface->config.dhcpv6.retransmissions = 0;
 	iface->config.dhcpv6.exchange_start = k_uptime_get();
 
+	dhcpv6_generate_tid(iface);
 	(void)dhcpv6_send_confirm(iface);
 	dhcpv6_set_timeout(iface, iface->config.dhcpv6.retransmit_timeout);
 }

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -2257,12 +2257,18 @@ out:
 	k_mutex_unlock(&lock);
 }
 
-static void dhcpv6_generate_client_duid(struct net_if *iface)
+static int dhcpv6_generate_client_duid(struct net_if *iface)
 {
 	struct net_linkaddr *lladdr = net_if_get_link_addr(iface);
 	struct net_dhcpv6_duid_storage *clientid = &iface->config.dhcpv6.clientid;
 	struct dhcpv6_duid_ll *duid_ll =
 				(struct dhcpv6_duid_ll *)&clientid->duid.buf;
+
+	if (lladdr == NULL ||
+	    lladdr->len > sizeof(clientid->duid.buf) - DHCPV6_DUID_LL_HEADER_SIZE) {
+		NET_ERR("Link address too large for DHCPv6 DUID");
+		return -EMSGSIZE;
+	}
 
 	memset(clientid, 0, sizeof(*clientid));
 
@@ -2273,6 +2279,8 @@ static void dhcpv6_generate_client_duid(struct net_if *iface)
 	memcpy(duid_ll->ll_addr, lladdr->addr, lladdr->len);
 
 	clientid->length = DHCPV6_DUID_LL_HEADER_SIZE + lladdr->len;
+
+	return 0;
 }
 
 /* DHCPv6 public API */
@@ -2289,6 +2297,14 @@ void net_dhcpv6_start(struct net_if *iface, struct net_dhcpv6_params *params)
 
 	if (!params->request_addr && !params->request_prefix) {
 		NET_ERR("Information Request not supported yet");
+		goto out;
+	}
+
+	/* Generate the client DUID before any observable side effects so that a
+	 * failure leaves the interface untouched (not registered, no START
+	 * event emitted).
+	 */
+	if (dhcpv6_generate_client_duid(iface) < 0) {
 		goto out;
 	}
 
@@ -2312,7 +2328,6 @@ void net_dhcpv6_start(struct net_if *iface, struct net_dhcpv6_params *params)
 		iface->config.dhcpv6.prefix_iaid = net_if_get_by_iface(iface);
 	}
 
-	dhcpv6_generate_client_duid(iface);
 	dhcpv6_enter_state(iface, NET_DHCPV6_INIT);
 	dhcpv6_reschedule();
 

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -210,6 +210,15 @@ static uint32_t dhcpv6_sol_max_rt(struct net_if *iface)
 	return DHCPV6_SOL_MAX_RT;
 }
 
+static uint32_t dhcpv6_inf_max_rt(struct net_if *iface)
+{
+	if (iface->config.dhcpv6.inf_max_rt != 0U) {
+		return iface->config.dhcpv6.inf_max_rt;
+	}
+
+	return DHCPV6_INF_MAX_RT;
+}
+
 /* DHCPv6 packet encoding functions */
 
 static int dhcpv6_add_header(struct net_pkt *pkt, enum dhcpv6_msg_type type,
@@ -649,6 +658,35 @@ static int dhcpv6_send_solicit(struct net_if *iface)
 	};
 
 	pkt = dhcpv6_create_message(iface, DHCPV6_MSG_TYPE_SOLICIT, &options);
+	if (pkt == NULL) {
+		return -ENOMEM;
+	}
+
+	ret = net_send_data(pkt);
+	if (ret < 0) {
+		net_pkt_unref(pkt);
+	}
+
+	return ret;
+}
+
+static int dhcpv6_send_info_request(struct net_if *iface)
+{
+	int ret;
+	struct net_pkt *pkt;
+	struct dhcpv6_options_include options = {
+		.clientid = true,
+		.elapsed_time = true,
+		.oro = {
+			DHCPV6_OPTION_CODE_INF_MAX_RT,
+#if defined(CONFIG_NET_DHCPV6_OPTION_DNS_ADDRESS)
+			DHCPV6_OPTION_CODE_OPTION_DNS_SERVERS,
+#endif
+		},
+	};
+
+	pkt = dhcpv6_create_message(iface, DHCPV6_MSG_TYPE_INFORMATION_REQUEST,
+				    &options);
 	if (pkt == NULL) {
 		return -ENOMEM;
 	}
@@ -1463,6 +1501,59 @@ static void dhcpv6_update_max_rt_options(struct net_if *iface, struct net_pkt *p
 	}
 }
 
+static int dhcpv6_find_information_refresh_time(struct net_pkt *pkt, uint32_t *irt_s)
+{
+	struct net_pkt_cursor backup;
+	uint16_t length;
+	int ret;
+
+	net_pkt_cursor_backup(pkt, &backup);
+
+	ret = dhcpv6_find_option(pkt, DHCPV6_OPTION_CODE_INFORMATION_REFRESH_TIME,
+				 &length);
+	if (ret == 0) {
+		if (length != sizeof(*irt_s)) {
+			ret = -EMSGSIZE;
+		} else {
+			ret = net_pkt_read_be32(pkt, irt_s);
+		}
+	}
+
+	net_pkt_cursor_restore(pkt, &backup);
+
+	return ret;
+}
+
+/* RFC 8415, ch. 21.23: derive the interval after which the client refreshes
+ * information obtained via an Information-request exchange. Use the server
+ * provided Information Refresh Time (clamped to IRT_MINIMUM) if present and
+ * valid, IRT_DEFAULT otherwise, and treat the infinity value as no refresh.
+ */
+static void dhcpv6_store_info_refresh_time(struct net_if *iface, struct net_pkt *pkt)
+{
+	uint32_t irt_s = DHCPV6_IRT_DEFAULT;
+	uint64_t irt_ms;
+
+	if (dhcpv6_find_information_refresh_time(pkt, &irt_s) == 0) {
+		if (irt_s == DHCPV6_IRT_INFINITY) {
+			iface->config.dhcpv6.info_refresh_time = 0U;
+			return;
+		}
+
+		if (irt_s < DHCPV6_IRT_MINIMUM) {
+			irt_s = DHCPV6_IRT_MINIMUM;
+		}
+	}
+
+	irt_ms = (uint64_t)irt_s * MSEC_PER_SEC;
+	if (irt_ms > UINT32_MAX) {
+		/* Too far in the future to represent; treat as no refresh. */
+		iface->config.dhcpv6.info_refresh_time = 0U;
+	} else {
+		iface->config.dhcpv6.info_refresh_time = (uint32_t)irt_ms;
+	}
+}
+
 static int dhcpv6_handle_dns_server_option(struct net_pkt *pkt)
 {
 	const struct net_sockaddr *dns_servers[MAX_DNS_SERVERS + 1] = { 0 };
@@ -1554,6 +1645,18 @@ static void dhcpv6_enter_soliciting(struct net_if *iface)
 	dhcpv6_set_timeout(iface, iface->config.dhcpv6.retransmit_timeout);
 }
 
+static void dhcpv6_enter_info_requesting(struct net_if *iface)
+{
+	iface->config.dhcpv6.retransmit_timeout =
+		dhcpv6_initial_retransmit_time(DHCPV6_INF_TIMEOUT);
+	iface->config.dhcpv6.retransmissions = 0;
+	iface->config.dhcpv6.exchange_start = k_uptime_get();
+
+	dhcpv6_generate_tid(iface);
+	(void)dhcpv6_send_info_request(iface);
+	dhcpv6_set_timeout(iface, iface->config.dhcpv6.retransmit_timeout);
+}
+
 static void dhcpv6_enter_requesting(struct net_if *iface)
 {
 	iface->config.dhcpv6.retransmit_timeout =
@@ -1604,7 +1707,21 @@ static void dhcpv6_enter_confirming(struct net_if *iface)
 
 static void dhcpv6_enter_bound(struct net_if *iface)
 {
-	iface->config.dhcpv6.timeout = iface->config.dhcpv6.t1;
+	if (!iface->config.dhcpv6.params.request_addr &&
+	    !iface->config.dhcpv6.params.request_prefix) {
+		/* Information-request exchange: schedule a refresh of the
+		 * received configuration (RFC 8415, ch. 18.2.6). A zero
+		 * interval means the server requested no refresh (infinity).
+		 */
+		if (iface->config.dhcpv6.info_refresh_time == 0U) {
+			iface->config.dhcpv6.timeout = UINT64_MAX;
+		} else {
+			dhcpv6_set_timeout(iface,
+					   iface->config.dhcpv6.info_refresh_time);
+		}
+	} else {
+		iface->config.dhcpv6.timeout = iface->config.dhcpv6.t1;
+	}
 
 	net_mgmt_event_notify_with_info(NET_EVENT_IPV6_DHCP_BOUND, iface,
 					&iface->config.dhcpv6,
@@ -1640,6 +1757,7 @@ static void dhcpv6_enter_state(struct net_if *iface, enum net_dhcpv6_state state
 		dhcpv6_enter_rebinding(iface);
 		break;
 	case NET_DHCPV6_INFO_REQUESTING:
+		dhcpv6_enter_info_requesting(iface);
 		break;
 	case NET_DHCPV6_BOUND:
 		dhcpv6_enter_bound(iface);
@@ -1784,7 +1902,8 @@ static int dhcpv6_handle_reply(struct net_if *iface, struct net_pkt *pkt,
 	if (iface->config.dhcpv6.state != NET_DHCPV6_REQUESTING &&
 	    iface->config.dhcpv6.state != NET_DHCPV6_CONFIRMING &&
 	    iface->config.dhcpv6.state != NET_DHCPV6_RENEWING &&
-	    iface->config.dhcpv6.state != NET_DHCPV6_REBINDING) {
+	    iface->config.dhcpv6.state != NET_DHCPV6_REBINDING &&
+	    iface->config.dhcpv6.state != NET_DHCPV6_INFO_REQUESTING) {
 		return -EINVAL;
 	}
 
@@ -1841,6 +1960,24 @@ static int dhcpv6_handle_reply(struct net_if *iface, struct net_pkt *pkt,
 	if (status == DHCPV6_STATUS_UNSPEC_FAIL) {
 		/* Ignore and try again later. */
 		return 0;
+	}
+
+	if (iface->config.dhcpv6.state == NET_DHCPV6_INFO_REQUESTING) {
+		if (status != DHCPV6_STATUS_SUCCESS) {
+			return 0;
+		}
+
+		dhcpv6_store_info_refresh_time(iface, pkt);
+
+		if (IS_ENABLED(CONFIG_NET_DHCPV6_OPTION_DNS_ADDRESS)) {
+			ret = dhcpv6_handle_dns_server_option(pkt);
+			if (ret < 0) {
+				NET_ERR("DNS server option handling failed");
+				return ret;
+			}
+		}
+
+		goto out;
 	}
 
 	/* DHCPv6 RFC8415, ch. 18.2.10.1.  If the client receives a NotOnLink
@@ -2138,6 +2275,12 @@ static uint64_t dhcpv6_manage_timers(struct net_if *iface, int64_t now)
 		bool have_addr = false;
 		bool have_prefix = false;
 
+		if (!iface->config.dhcpv6.params.request_addr &&
+		    !iface->config.dhcpv6.params.request_prefix) {
+			dhcpv6_enter_state(iface, NET_DHCPV6_INFO_REQUESTING);
+			return iface->config.dhcpv6.timeout;
+		}
+
 		if (iface->config.dhcpv6.params.request_addr &&
 			!net_ipv6_addr_cmp(&iface->config.dhcpv6.addr,
 					net_ipv6_unspecified_address())) {
@@ -2262,9 +2405,28 @@ static uint64_t dhcpv6_manage_timers(struct net_if *iface, int64_t now)
 
 		return iface->config.dhcpv6.timeout;
 	case NET_DHCPV6_INFO_REQUESTING:
-		break;
+		iface->config.dhcpv6.retransmissions++;
+		iface->config.dhcpv6.retransmit_timeout =
+			dhcpv6_next_retransmit_time(
+				iface->config.dhcpv6.retransmit_timeout,
+				dhcpv6_inf_max_rt(iface));
+
+		(void)dhcpv6_send_info_request(iface);
+		dhcpv6_set_timeout(iface, iface->config.dhcpv6.retransmit_timeout);
+
+		return iface->config.dhcpv6.timeout;
 	case NET_DHCPV6_BOUND:
-		dhcpv6_enter_state(iface, NET_DHCPV6_RENEWING);
+		if (!iface->config.dhcpv6.params.request_addr &&
+		    !iface->config.dhcpv6.params.request_prefix) {
+			/* Information-request exchange has no lease to renew;
+			 * refresh the configuration instead (RFC 8415,
+			 * ch. 18.2.6).
+			 */
+			dhcpv6_enter_state(iface, NET_DHCPV6_INFO_REQUESTING);
+		} else {
+			dhcpv6_enter_state(iface, NET_DHCPV6_RENEWING);
+		}
+
 		return iface->config.dhcpv6.timeout;
 	}
 
@@ -2384,11 +2546,6 @@ void net_dhcpv6_start(struct net_if *iface, struct net_dhcpv6_params *params)
 	if (iface->config.dhcpv6.state != NET_DHCPV6_DISABLED) {
 		NET_ERR("DHCPv6 already running on iface %p, state %s", iface,
 			net_dhcpv6_state_name(iface->config.dhcpv6.state));
-		goto out;
-	}
-
-	if (!params->request_addr && !params->request_prefix) {
-		NET_ERR("Information Request not supported yet");
 		goto out;
 	}
 

--- a/subsys/net/lib/dhcpv6/dhcpv6_internal.h
+++ b/subsys/net/lib/dhcpv6/dhcpv6_internal.h
@@ -51,6 +51,9 @@
 #define DHCPV6_SOL_MAX_DELAY 1000 /* Max delay of first Solicit, milliseconds */
 #define DHCPV6_SOL_TIMEOUT 1000 /* Initial Solicit timeout, milliseconds */
 #define DHCPV6_SOL_MAX_RT 3600000 /* Max Solicit timeout value, milliseconds */
+#define DHCPV6_INF_MAX_RT 3600000 /* Max Information-request timeout value, milliseconds */
+#define DHCPV6_MAX_RT_MIN 60000 /* Minimum server-provided max RT, milliseconds */
+#define DHCPV6_MAX_RT_MAX 86400000 /* Maximum server-provided max RT, milliseconds */
 #define DHCPV6_REQ_TIMEOUT 1000 /* Initial Request timeout, milliseconds */
 #define DHCPV6_REQ_MAX_RT 30000 /* Max Request timeout value, milliseconds */
 #define DHCPV6_REQ_MAX_RC 10 /* Max Request retry attempts */

--- a/subsys/net/lib/dhcpv6/dhcpv6_internal.h
+++ b/subsys/net/lib/dhcpv6/dhcpv6_internal.h
@@ -51,9 +51,13 @@
 #define DHCPV6_SOL_MAX_DELAY 1000 /* Max delay of first Solicit, milliseconds */
 #define DHCPV6_SOL_TIMEOUT 1000 /* Initial Solicit timeout, milliseconds */
 #define DHCPV6_SOL_MAX_RT 3600000 /* Max Solicit timeout value, milliseconds */
+#define DHCPV6_INF_TIMEOUT 1000 /* Initial Information-request timeout, milliseconds */
 #define DHCPV6_INF_MAX_RT 3600000 /* Max Information-request timeout value, milliseconds */
 #define DHCPV6_MAX_RT_MIN 60000 /* Minimum server-provided max RT, milliseconds */
 #define DHCPV6_MAX_RT_MAX 86400000 /* Maximum server-provided max RT, milliseconds */
+#define DHCPV6_IRT_DEFAULT 86400 /* Default Information Refresh Time, seconds */
+#define DHCPV6_IRT_MINIMUM 600 /* Minimum Information Refresh Time, seconds */
+#define DHCPV6_IRT_INFINITY 0xffffffffUL /* Information Refresh Time infinity value */
 #define DHCPV6_REQ_TIMEOUT 1000 /* Initial Request timeout, milliseconds */
 #define DHCPV6_REQ_MAX_RT 30000 /* Max Request timeout value, milliseconds */
 #define DHCPV6_REQ_MAX_RC 10 /* Max Request retry attempts */

--- a/tests/net/dhcpv6/src/main.c
+++ b/tests/net/dhcpv6/src/main.c
@@ -226,7 +226,8 @@ static void dhcpv6_tests_before(void *fixture)
 	memset(&test_ctx.iface->config.dhcpv6, 0,
 	       sizeof(test_ctx.iface->config.dhcpv6));
 
-	dhcpv6_generate_client_duid(test_ctx.iface);
+	zassert_ok(dhcpv6_generate_client_duid(test_ctx.iface),
+		   "Cannot generate client DUID");
 	test_ctx.iface->config.dhcpv6.state = NET_DHCPV6_DISABLED;
 	test_ctx.iface->config.dhcpv6.addr_iaid = 10;
 	test_ctx.iface->config.dhcpv6.prefix_iaid = 20;
@@ -240,6 +241,23 @@ static void dhcpv6_tests_before(void *fixture)
 
 	net_if_ipv6_addr_rm(test_ctx.iface, &test_addr);
 	net_if_ipv6_prefix_rm(test_ctx.iface, &test_prefix, test_prefix_len);
+}
+
+ZTEST(dhcpv6_tests, test_client_duid_rejects_too_large_link_addr)
+{
+	struct net_linkaddr *lladdr = net_if_get_link_addr(test_ctx.iface);
+	uint8_t old_len = lladdr->len;
+	int ret;
+
+	lladdr->len = sizeof(test_ctx.iface->config.dhcpv6.clientid.duid.buf) -
+		      DHCPV6_DUID_LL_HEADER_SIZE + 1;
+
+	ret = dhcpv6_generate_client_duid(test_ctx.iface);
+	zassert_equal(ret, -EMSGSIZE, "Expected oversized DUID failure, got %d", ret);
+
+	lladdr->len = old_len;
+	zassert_ok(dhcpv6_generate_client_duid(test_ctx.iface),
+		   "Cannot restore client DUID");
 }
 
 static void dhcpv6_tests_after(void *fixture)

--- a/tests/net/dhcpv6/src/main.c
+++ b/tests/net/dhcpv6/src/main.c
@@ -479,8 +479,8 @@ static void verify_dhcpv6_no_reconfigure_accept(struct net_if *iface,
 	net_pkt_cursor_restore(pkt, &backup);
 }
 
-static void verify_dhcpv6_oro_sol_max_rt(struct net_if *iface,
-					 struct net_pkt *pkt)
+static void verify_dhcpv6_oro_option(struct net_if *iface, struct net_pkt *pkt,
+				     enum dhcpv6_option_code option)
 {
 	struct net_pkt_cursor backup;
 	uint16_t length;
@@ -499,15 +499,26 @@ static void verify_dhcpv6_oro_sol_max_rt(struct net_if *iface,
 		zassert_ok(ret, "ORO read error");
 		length -= sizeof(uint16_t);
 
-		if (oro == DHCPV6_OPTION_CODE_SOL_MAX_RT) {
+		if (oro == option) {
 			break;
 		}
 	}
 
-	zassert_equal(oro, DHCPV6_OPTION_CODE_SOL_MAX_RT,
-		      "No SOL_MAX_RT option request present");
+	zassert_equal(oro, option, "Requested option %u is not present", option);
 
 	net_pkt_cursor_restore(pkt, &backup);
+}
+
+static void verify_dhcpv6_oro_sol_max_rt(struct net_if *iface,
+					 struct net_pkt *pkt)
+{
+	verify_dhcpv6_oro_option(iface, pkt, DHCPV6_OPTION_CODE_SOL_MAX_RT);
+}
+
+static void verify_dhcpv6_oro_inf_max_rt(struct net_if *iface,
+					 struct net_pkt *pkt)
+{
+	verify_dhcpv6_oro_option(iface, pkt, DHCPV6_OPTION_CODE_INF_MAX_RT);
 }
 
 static void verify_solicit_message(struct net_if *iface, struct net_pkt *pkt)
@@ -536,6 +547,28 @@ ZTEST(dhcpv6_tests, test_solicit_message_format)
 
 	ret = dhcpv6_send_solicit(test_ctx.iface);
 	zassert_ok(ret, "dhcpv6_send_solicit failed");
+
+	ret = k_sem_take(&test_ctx.tx_sem, K_SECONDS(1));
+	zassert_ok(ret, "Packet not transmitted");
+}
+
+static void verify_info_request_message(struct net_if *iface, struct net_pkt *pkt)
+{
+	verify_dhcpv6_header(iface, pkt, DHCPV6_MSG_TYPE_INFORMATION_REQUEST);
+	verify_dhcpv6_clientid(iface, pkt);
+	verify_dhcpv6_no_serverid(iface, pkt);
+	verify_dhcpv6_elapsed_time(iface, pkt, 0, 10);
+	verify_dhcpv6_oro_inf_max_rt(iface, pkt);
+}
+
+ZTEST(dhcpv6_tests, test_info_request_message_format)
+{
+	int ret;
+
+	set_dhcpv6_test_fn(verify_info_request_message);
+
+	ret = dhcpv6_send_info_request(test_ctx.iface);
+	zassert_ok(ret, "dhcpv6_send_info_request failed");
 
 	ret = k_sem_take(&test_ctx.tx_sem, K_SECONDS(1));
 	zassert_ok(ret, "Packet not transmitted");
@@ -674,6 +707,8 @@ ZTEST(dhcpv6_tests, test_retransmissions_keep_transaction_id)
 		bool needs_addr;
 	} test_cases[] = {
 		{ DHCPV6_MSG_TYPE_SOLICIT, dhcpv6_send_solicit, false, false },
+		{ DHCPV6_MSG_TYPE_INFORMATION_REQUEST, dhcpv6_send_info_request,
+		  false, false },
 		{ DHCPV6_MSG_TYPE_REQUEST, dhcpv6_send_request, true, false },
 		{ DHCPV6_MSG_TYPE_CONFIRM, dhcpv6_send_confirm, false, true },
 		{ DHCPV6_MSG_TYPE_RENEW, dhcpv6_send_renew, true, true },
@@ -995,8 +1030,26 @@ static int set_reply_options_other_server(struct net_if *iface, struct net_pkt *
 	return 0;
 }
 
+static int set_info_reply_options(struct net_if *iface, struct net_pkt *pkt,
+				  enum dhcpv6_msg_type msg_type)
+{
+	int ret;
+
+	ret = dhcpv6_add_option_clientid(pkt, &iface->config.dhcpv6.clientid);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dhcpv6_add_option_serverid(pkt, &test_serverid);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return add_max_rt_options(pkt);
+}
+
 /* Verify that DHCPv6 client accepts Reply messages in Requesting, Confirming,
- * Renewing and Rebinding states
+ * Renewing, Rebinding and Information-requesting states.
  */
 ZTEST(dhcpv6_tests, test_input_reply)
 {
@@ -1012,7 +1065,8 @@ ZTEST(dhcpv6_tests, test_input_reply)
 
 		pkt = test_dhcpv6_create_message(test_ctx.iface,
 						 DHCPV6_MSG_TYPE_REPLY,
-						 set_reply_options);
+						 state == NET_DHCPV6_INFO_REQUESTING ?
+						 set_info_reply_options : set_reply_options);
 		zassert_not_null(pkt, "Failed to create pkt");
 
 		result = net_ipv6_input(pkt);
@@ -1022,12 +1076,18 @@ ZTEST(dhcpv6_tests, test_input_reply)
 		case NET_DHCPV6_REQUESTING:
 		case NET_DHCPV6_RENEWING:
 		case NET_DHCPV6_REBINDING:
+		case NET_DHCPV6_INFO_REQUESTING:
 			zassert_equal(result, NET_OK, "Message should've been processed");
 
 			/* Confirm is an exception, as it does not update
 			 * address on an interface (only status OK is expected).
 			 */
-			if (state == NET_DHCPV6_CONFIRMING) {
+			if (state == NET_DHCPV6_CONFIRMING ||
+			    state == NET_DHCPV6_INFO_REQUESTING) {
+				zassert_equal(test_ctx.iface->config.dhcpv6.sol_max_rt,
+					      test_sol_max_rt, "Invalid SOL_MAX_RT value");
+				zassert_equal(test_ctx.iface->config.dhcpv6.inf_max_rt,
+					      test_inf_max_rt, "Invalid INF_MAX_RT value");
 				break;
 			}
 
@@ -1097,6 +1157,68 @@ ZTEST(dhcpv6_tests, test_input_reply_rejects_unselected_server)
 
 		net_pkt_unref(pkt);
 	}
+}
+
+static int set_reply_options_fail_max_rt(struct net_if *iface, struct net_pkt *pkt,
+					 enum dhcpv6_msg_type msg_type)
+{
+	int ret;
+
+	ret = dhcpv6_add_option_clientid(pkt, &iface->config.dhcpv6.clientid);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dhcpv6_add_option_serverid(pkt, &test_serverid);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dhcpv6_add_option_header(pkt, DHCPV6_OPTION_CODE_STATUS_CODE,
+				       DHCPV6_OPTION_STATUS_CODE_HEADER_SIZE);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = net_pkt_write_be16(pkt, DHCPV6_STATUS_NOT_ON_LINK);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return add_max_rt_options(pkt);
+}
+
+/* RFC 8415, ch. 21.24/21.25: SOL_MAX_RT and INF_MAX_RT MUST be applied even
+ * when the message carries a failure Status Code.
+ */
+ZTEST(dhcpv6_tests, test_input_reply_max_rt_on_failure)
+{
+	enum net_verdict result;
+	struct net_pkt *pkt;
+
+	/* Start from the defaults so a server-provided update is detectable.
+	 * Use Information-requesting state: a failure Reply there is dropped
+	 * without any outgoing message, keeping the test side-effect free.
+	 */
+	test_ctx.iface->config.dhcpv6.sol_max_rt = DHCPV6_SOL_MAX_RT;
+	test_ctx.iface->config.dhcpv6.inf_max_rt = DHCPV6_INF_MAX_RT;
+	test_ctx.iface->config.dhcpv6.state = NET_DHCPV6_INFO_REQUESTING;
+
+	pkt = test_dhcpv6_create_message(test_ctx.iface, DHCPV6_MSG_TYPE_REPLY,
+					 set_reply_options_fail_max_rt);
+	zassert_not_null(pkt, "Failed to create pkt");
+
+	result = net_ipv6_input(pkt);
+	zassert_equal(result, NET_OK, "Message should've been processed");
+
+	zassert_equal(test_ctx.iface->config.dhcpv6.sol_max_rt, test_sol_max_rt,
+		      "SOL_MAX_RT not applied on failure Reply");
+	zassert_equal(test_ctx.iface->config.dhcpv6.inf_max_rt, test_inf_max_rt,
+		      "INF_MAX_RT not applied on failure Reply");
+
+	net_pkt_unref(pkt);
+
+	test_ctx.iface->config.dhcpv6.state = NET_DHCPV6_DISABLED;
 }
 
 static void test_solicit_expect_request_send_reply(struct net_if *iface,
@@ -1210,6 +1332,69 @@ ZTEST(dhcpv6_tests, test_solicit_exchange)
 					   test_prefix_len);
 	zassert_not_null(addr, "Address not configured on the interface");
 	zassert_not_null(prefix, "Prefix not configured on the interface");
+}
+
+static void test_info_request_send_reply(struct net_if *iface, struct net_pkt *pkt)
+{
+	struct net_pkt *reply;
+	int result;
+
+	verify_dhcpv6_header(iface, pkt, DHCPV6_MSG_TYPE_INFORMATION_REQUEST);
+	verify_dhcpv6_clientid(iface, pkt);
+	verify_dhcpv6_no_serverid(iface, pkt);
+	verify_dhcpv6_oro_inf_max_rt(iface, pkt);
+
+	zassert_equal(iface->config.dhcpv6.state, NET_DHCPV6_INFO_REQUESTING,
+		      "Invalid state");
+
+	set_dhcpv6_test_fn(NULL);
+
+	reply = test_dhcpv6_create_message(test_ctx.iface,
+					   DHCPV6_MSG_TYPE_REPLY,
+					   set_info_reply_options);
+	zassert_not_null(reply, "Failed to create pkt");
+
+	result = net_ipv6_input(reply);
+	zassert_equal(result, NET_OK, "Message should've been processed");
+
+	zassert_equal(iface->config.dhcpv6.state, NET_DHCPV6_BOUND,
+		      "Invalid state");
+	zassert_equal(iface->config.dhcpv6.inf_max_rt, test_inf_max_rt,
+		      "Invalid INF_MAX_RT value");
+	zassert_true(net_ipv6_addr_cmp(&iface->config.dhcpv6.addr,
+				       net_ipv6_unspecified_address()),
+		     "Address should not be configured");
+	zassert_true(net_ipv6_addr_cmp(&iface->config.dhcpv6.prefix,
+				       net_ipv6_unspecified_address()),
+		     "Prefix should not be configured");
+
+	/* Reply had no Information Refresh Time option, so the default applies
+	 * and a refresh must be scheduled (not left running forever).
+	 */
+	zassert_equal(iface->config.dhcpv6.info_refresh_time,
+		      DHCPV6_IRT_DEFAULT * MSEC_PER_SEC,
+		      "Invalid information refresh time");
+	zassert_not_equal(iface->config.dhcpv6.timeout, UINT64_MAX,
+			  "Information refresh not scheduled");
+
+	k_sem_give(&test_ctx.exchange_complete_sem);
+}
+
+ZTEST(dhcpv6_tests, test_info_request_exchange)
+{
+	struct net_dhcpv6_params params = { 0 };
+	int ret;
+
+	test_ctx.reset_dhcpv6 = true;
+	memset(&test_ctx.iface->config.dhcpv6, 0,
+	       sizeof(test_ctx.iface->config.dhcpv6));
+
+	set_dhcpv6_test_fn(test_info_request_send_reply);
+
+	net_dhcpv6_start(test_ctx.iface, &params);
+
+	ret = k_sem_take(&test_ctx.exchange_complete_sem, K_SECONDS(3));
+	zassert_ok(ret, "Exchange not completed in required time");
 }
 
 static void expect_request_send_reply(struct net_if *iface, struct net_pkt *pkt)

--- a/tests/net/dhcpv6/src/main.c
+++ b/tests/net/dhcpv6/src/main.c
@@ -18,6 +18,8 @@ static struct net_in6_addr test_prefix = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 
 					   0, 0, 0, 0, 0, 0, 0, 0 } } };
 static uint8_t test_prefix_len = 64;
 static uint8_t test_preference;
+static uint32_t test_sol_max_rt = 120000;
+static uint32_t test_inf_max_rt = 180000;
 static struct net_dhcpv6_duid_storage test_serverid;
 static struct net_dhcpv6_duid_storage test_other_serverid;
 static uint8_t test_expected_tid[DHCPV6_TID_SIZE];
@@ -130,6 +132,30 @@ static void set_fake_server_duid(struct net_if *iface)
 	       sizeof(test_serverid));
 }
 
+static int add_max_rt_options(struct net_pkt *pkt)
+{
+	int ret;
+
+	ret = dhcpv6_add_option_header(pkt, DHCPV6_OPTION_CODE_SOL_MAX_RT,
+				       sizeof(uint32_t));
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = net_pkt_write_be32(pkt, test_sol_max_rt / MSEC_PER_SEC);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dhcpv6_add_option_header(pkt, DHCPV6_OPTION_CODE_INF_MAX_RT,
+				       sizeof(uint32_t));
+	if (ret < 0) {
+		return ret;
+	}
+
+	return net_pkt_write_be32(pkt, test_inf_max_rt / MSEC_PER_SEC);
+}
+
 #define TEST_MSG_SIZE 256
 
 static struct net_pkt *test_dhcpv6_create_message(
@@ -239,6 +265,8 @@ static void dhcpv6_tests_before(void *fixture)
 	test_ctx.iface->config.dhcpv6.addr_iaid = 10;
 	test_ctx.iface->config.dhcpv6.prefix_iaid = 20;
 	test_ctx.iface->config.dhcpv6.exchange_start = k_uptime_get();
+	test_ctx.iface->config.dhcpv6.sol_max_rt = DHCPV6_SOL_MAX_RT;
+	test_ctx.iface->config.dhcpv6.inf_max_rt = DHCPV6_INF_MAX_RT;
 	test_ctx.iface->config.dhcpv6.params = (struct net_dhcpv6_params){
 		.request_addr = true,
 		.request_prefix = true,
@@ -803,6 +831,11 @@ static int set_advertise_options(struct net_if *iface, struct net_pkt *pkt,
 		return ret;
 	}
 
+	ret = add_max_rt_options(pkt);
+	if (ret < 0) {
+		return ret;
+	}
+
 	return 0;
 }
 
@@ -835,6 +868,10 @@ ZTEST(dhcpv6_tests, test_input_advertise)
 			zassert_mem_equal(&test_ctx.iface->config.dhcpv6.serverid.duid,
 					  &test_serverid.duid, test_serverid.length,
 					  "Invalid Server ID value");
+			zassert_equal(test_ctx.iface->config.dhcpv6.sol_max_rt,
+				      test_sol_max_rt, "Invalid SOL_MAX_RT value");
+			zassert_equal(test_ctx.iface->config.dhcpv6.inf_max_rt,
+				      test_inf_max_rt, "Invalid INF_MAX_RT value");
 
 			break;
 		default:
@@ -901,6 +938,11 @@ static int set_reply_options(struct net_if *iface, struct net_pkt *pkt,
 	}
 
 	ret = dhcpv6_add_option_ia_pd(pkt, &test_ia_pd, true);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = add_max_rt_options(pkt);
 	if (ret < 0) {
 		return ret;
 	}
@@ -1001,6 +1043,10 @@ ZTEST(dhcpv6_tests, test_input_reply)
 			zassert_equal(test_ctx.iface->config.dhcpv6.prefix_len,
 				      test_prefix_len, "Invalid prefix len (state %s)",
 				      net_dhcpv6_state_name(state));
+			zassert_equal(test_ctx.iface->config.dhcpv6.sol_max_rt,
+				      test_sol_max_rt, "Invalid SOL_MAX_RT value");
+			zassert_equal(test_ctx.iface->config.dhcpv6.inf_max_rt,
+				      test_inf_max_rt, "Invalid INF_MAX_RT value");
 
 			break;
 		default:

--- a/tests/net/dhcpv6/src/main.c
+++ b/tests/net/dhcpv6/src/main.c
@@ -19,6 +19,7 @@ static struct net_in6_addr test_prefix = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 
 static uint8_t test_prefix_len = 64;
 static uint8_t test_preference;
 static struct net_dhcpv6_duid_storage test_serverid;
+static struct net_dhcpv6_duid_storage test_other_serverid;
 static struct net_mgmt_event_callback net_mgmt_cb;
 
 typedef void (*test_dhcpv6_pkt_fn_t)(struct net_if *iface,
@@ -100,12 +101,12 @@ static void clear_test_addr_on_iface(struct net_if *iface)
 	test_ctx.iface->config.dhcpv6.prefix_len = 0;
 }
 
-static void generate_fake_server_duid(void)
+static void generate_fake_server_duid(struct net_dhcpv6_duid_storage *serverid,
+				      uint8_t id)
 {
-	struct net_dhcpv6_duid_storage *serverid = &test_serverid;
 	struct dhcpv6_duid_ll *duid_ll =
 				(struct dhcpv6_duid_ll *)&serverid->duid.buf;
-	uint8_t fake_mac[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
+	uint8_t fake_mac[] = { 0x01, 0x02, 0x03, 0x04, 0x05, id };
 
 	memset(serverid, 0, sizeof(*serverid));
 
@@ -205,7 +206,8 @@ static void *dhcpv6_tests_setup(void)
 	k_sem_init(&test_ctx.tx_sem, 0, 1);
 	k_sem_init(&test_ctx.exchange_complete_sem, 0, 1);
 
-	generate_fake_server_duid();
+	generate_fake_server_duid(&test_serverid, 0x06);
+	generate_fake_server_duid(&test_other_serverid, 0x07);
 
 	net_mgmt_init_event_callback(&net_mgmt_cb, evt_handler, NET_EVENT_IF_UP);
 	net_mgmt_add_event_callback(&net_mgmt_cb);
@@ -824,6 +826,51 @@ static int set_reply_options(struct net_if *iface, struct net_pkt *pkt,
 	return 0;
 }
 
+static int set_reply_options_other_server(struct net_if *iface, struct net_pkt *pkt,
+					  enum dhcpv6_msg_type msg_type)
+{
+	struct dhcpv6_ia_na test_ia_na = {
+		.iaid = iface->config.dhcpv6.addr_iaid,
+		.t1 = 60,
+		.t2 = 120,
+		.iaaddr.addr = test_addr,
+		.iaaddr.preferred_lifetime = 120,
+		.iaaddr.valid_lifetime = 240,
+	};
+	struct dhcpv6_ia_pd test_ia_pd = {
+		.iaid = iface->config.dhcpv6.prefix_iaid,
+		.t1 = 60,
+		.t2 = 120,
+		.iaprefix.prefix = test_prefix,
+		.iaprefix.prefix_len = test_prefix_len,
+		.iaprefix.preferred_lifetime = 120,
+		.iaprefix.valid_lifetime = 240,
+	};
+	int ret;
+
+	ret = dhcpv6_add_option_clientid(pkt, &iface->config.dhcpv6.clientid);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dhcpv6_add_option_serverid(pkt, &test_other_serverid);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dhcpv6_add_option_ia_na(pkt, &test_ia_na, true);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dhcpv6_add_option_ia_pd(pkt, &test_ia_pd, true);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
 /* Verify that DHCPv6 client accepts Reply messages in Requesting, Confirming,
  * Renewing and Rebinding states
  */
@@ -878,6 +925,46 @@ ZTEST(dhcpv6_tests, test_input_reply)
 			zassert_equal(result, NET_DROP, "Should've drop the message");
 			break;
 
+		}
+
+		net_pkt_unref(pkt);
+	}
+}
+
+ZTEST(dhcpv6_tests, test_input_reply_rejects_unselected_server)
+{
+	enum net_verdict result;
+	struct net_pkt *pkt;
+	enum net_dhcpv6_state state;
+
+	for (state = NET_DHCPV6_REQUESTING; state <= NET_DHCPV6_REBINDING; state++) {
+		test_ctx.iface->config.dhcpv6.state = state;
+
+		set_fake_server_duid(test_ctx.iface);
+		clear_test_addr_on_iface(test_ctx.iface);
+
+		pkt = test_dhcpv6_create_message(test_ctx.iface,
+						 DHCPV6_MSG_TYPE_REPLY,
+						 set_reply_options_other_server);
+		zassert_not_null(pkt, "Failed to create pkt");
+
+		result = net_ipv6_input(pkt);
+
+		switch (state) {
+		case NET_DHCPV6_REQUESTING:
+		case NET_DHCPV6_RENEWING:
+			zassert_equal(result, NET_DROP,
+				      "Reply from unselected server accepted in state %s",
+				      net_dhcpv6_state_name(state));
+			break;
+		case NET_DHCPV6_CONFIRMING:
+		case NET_DHCPV6_REBINDING:
+			zassert_equal(result, NET_OK,
+				      "Reply from any server rejected in state %s",
+				      net_dhcpv6_state_name(state));
+			break;
+		default:
+			break;
 		}
 
 		net_pkt_unref(pkt);

--- a/tests/net/dhcpv6/src/main.c
+++ b/tests/net/dhcpv6/src/main.c
@@ -20,6 +20,9 @@ static uint8_t test_prefix_len = 64;
 static uint8_t test_preference;
 static struct net_dhcpv6_duid_storage test_serverid;
 static struct net_dhcpv6_duid_storage test_other_serverid;
+static uint8_t test_expected_tid[DHCPV6_TID_SIZE];
+static enum dhcpv6_msg_type test_expected_msg_type;
+static uint8_t test_stable_tid_msg_count;
 static struct net_mgmt_event_callback net_mgmt_cb;
 
 typedef void (*test_dhcpv6_pkt_fn_t)(struct net_if *iface,
@@ -28,6 +31,8 @@ typedef void (*test_dhcpv6_pkt_fn_t)(struct net_if *iface,
 typedef int (*test_dhcpv6_options_fn_t)(struct net_if *iface,
 					struct net_pkt *pkt,
 					enum dhcpv6_msg_type msg_type);
+
+typedef int (*test_dhcpv6_send_fn_t)(struct net_if *iface);
 
 struct test_dhcpv6_context {
 	uint8_t mac[sizeof(struct net_eth_addr)];
@@ -290,6 +295,30 @@ static void verify_dhcpv6_header(struct net_if *iface, struct net_pkt *pkt,
 	zassert_ok(ret, "DHCPv6 header incomplete (tid)");
 	zassert_mem_equal(tid, iface->config.dhcpv6.tid, sizeof(tid),
 			  "Transaction ID doesn't match ID of the current exchange");
+}
+
+static void verify_stable_tid_message(struct net_if *iface, struct net_pkt *pkt)
+{
+	uint8_t tid[DHCPV6_TID_SIZE];
+	uint8_t type;
+	int ret;
+
+	ARG_UNUSED(iface);
+
+	(void)net_pkt_skip(pkt, NET_IPV6UDPH_LEN);
+
+	ret = net_pkt_read_u8(pkt, &type);
+	zassert_ok(ret, "DHCPv6 header incomplete (type)");
+	zassert_equal(type, test_expected_msg_type,
+		      "Invalid message type %u, expected %u",
+		      type, test_expected_msg_type);
+
+	ret = net_pkt_read(pkt, tid, sizeof(tid));
+	zassert_ok(ret, "DHCPv6 header incomplete (tid)");
+	zassert_mem_equal(tid, test_expected_tid, sizeof(tid),
+			  "Transaction ID changed between retransmissions");
+
+	test_stable_tid_msg_count++;
 }
 
 static void verify_dhcpv6_clientid(struct net_if *iface, struct net_pkt *pkt)
@@ -606,6 +635,59 @@ ZTEST(dhcpv6_tests, test_rebind_message_format)
 
 	ret = k_sem_take(&test_ctx.tx_sem, K_SECONDS(1));
 	zassert_ok(ret, "Packet not transmitted");
+}
+
+ZTEST(dhcpv6_tests, test_retransmissions_keep_transaction_id)
+{
+	static const struct {
+		enum dhcpv6_msg_type type;
+		test_dhcpv6_send_fn_t send_fn;
+		bool needs_serverid;
+		bool needs_addr;
+	} test_cases[] = {
+		{ DHCPV6_MSG_TYPE_SOLICIT, dhcpv6_send_solicit, false, false },
+		{ DHCPV6_MSG_TYPE_REQUEST, dhcpv6_send_request, true, false },
+		{ DHCPV6_MSG_TYPE_CONFIRM, dhcpv6_send_confirm, false, true },
+		{ DHCPV6_MSG_TYPE_RENEW, dhcpv6_send_renew, true, true },
+		{ DHCPV6_MSG_TYPE_REBIND, dhcpv6_send_rebind, false, true },
+	};
+	int ret;
+
+	set_dhcpv6_test_fn(verify_stable_tid_message);
+
+	for (size_t i = 0; i < ARRAY_SIZE(test_cases); i++) {
+		test_expected_tid[0] = 0x10;
+		test_expected_tid[1] = 0x20;
+		test_expected_tid[2] = test_cases[i].type;
+		test_expected_msg_type = test_cases[i].type;
+		test_stable_tid_msg_count = 0;
+
+		memcpy(test_ctx.iface->config.dhcpv6.tid, test_expected_tid,
+		       sizeof(test_expected_tid));
+
+		if (test_cases[i].needs_serverid) {
+			set_fake_server_duid(test_ctx.iface);
+		}
+
+		if (test_cases[i].needs_addr) {
+			set_test_addr_on_iface(test_ctx.iface);
+		} else {
+			clear_test_addr_on_iface(test_ctx.iface);
+		}
+
+		ret = test_cases[i].send_fn(test_ctx.iface);
+		zassert_ok(ret, "First DHCPv6 message send failed");
+		ret = k_sem_take(&test_ctx.tx_sem, K_SECONDS(1));
+		zassert_ok(ret, "First DHCPv6 packet not transmitted");
+
+		ret = test_cases[i].send_fn(test_ctx.iface);
+		zassert_ok(ret, "Retransmitted DHCPv6 message send failed");
+		ret = k_sem_take(&test_ctx.tx_sem, K_SECONDS(1));
+		zassert_ok(ret, "Retransmitted DHCPv6 packet not transmitted");
+
+		zassert_equal(test_stable_tid_msg_count, 2,
+			      "Unexpected transmitted DHCPv6 packet count");
+	}
 }
 
 static int set_generic_client_options(struct net_if *iface, struct net_pkt *pkt,


### PR DESCRIPTION
Couple of fixes to DHCPv6 client code when referencing against RFC 8415 https://datatracker.ietf.org/doc/html/rfc8415
