### PR TITLE
arch: arm: Add minimal dump_fault when CONFIG_FAULT_DUMP < 2

### DIFF
--- a/arch/arm/core/cortex_a_r/fault.c
+++ b/arch/arm/core/cortex_a_r/fault.c
@@ -331,9 +331,12 @@ bool z_arm_fault_prefetch(struct arch_esf *esf)
 #endif
 	/* Print fault information*/
 	EXCEPTION_DUMP("***** PREFETCH ABORT *****");
-	if (FAULT_DUMP_VERBOSE) {
-		reason = dump_fault(fs, ifar);
-	}
+#if FAULT_DUMP_VERBOSE
+	reason = dump_fault(fs, ifar);
+#else
+	ARG_UNUSED(fs);
+	ARG_UNUSED(ifar);
+#endif
 
 	/* Simplify exception codes if requested */
 	if (IS_ENABLED(CONFIG_SIMPLIFIED_EXCEPTION_CODES) && (reason >= K_ERR_ARCH_START)) {
@@ -415,9 +418,12 @@ bool z_arm_fault_data(struct arch_esf *esf)
 
 	/* Print fault information*/
 	EXCEPTION_DUMP("***** DATA ABORT *****");
-	if (FAULT_DUMP_VERBOSE) {
-		reason = dump_fault(fs, dfar);
-	}
+#if FAULT_DUMP_VERBOSE
+	reason = dump_fault(fs, dfar);
+#else
+	ARG_UNUSED(fs);
+	ARG_UNUSED(dfar);
+#endif
 
 	/* Simplify exception codes if requested */
 	if (IS_ENABLED(CONFIG_SIMPLIFIED_EXCEPTION_CODES) && (reason >= K_ERR_ARCH_START)) {


### PR DESCRIPTION
Provide a minimal dump_fault function when CONFIG_FAULT_DUMP < 2. Otherwise, "warning: implicit declaration of function 'dump_fault'" is generated, which may be promoted to an error when also using CONFIG_COMPILER_WARNINGS_AS_ERRORS=y.