### PR TITLE
drivers: ethernet: use net_pkt_frag_unref

### DIFF
--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -249,7 +249,7 @@ static void dwmac_receive(const struct device *dev)
 		p->rx_frags[d_idx] = NULL;
 
 		if (p->rx_pkt == NULL) {
-			net_buf_unref(frag);
+			net_pkt_frag_unref(frag);
 			continue;
 		}
 
@@ -261,7 +261,7 @@ static void dwmac_receive(const struct device *dev)
 			eth_stats_update_errors_rx(p->iface);
 			net_pkt_unref(p->rx_pkt);
 			p->rx_pkt = NULL;
-			net_buf_unref(frag);
+			net_pkt_frag_unref(frag);
 			continue;
 		}
 

--- a/drivers/ethernet/eth_mchp_gmac_g1.c
+++ b/drivers/ethernet/eth_mchp_gmac_g1.c
@@ -207,7 +207,7 @@ static void gmac_free_rx_bufs(struct net_buf **rx_frag_list, uint16_t len)
 {
 	for (int i = 0; i < len; i++) {
 		if (rx_frag_list[i] != NULL) {
-			net_buf_unref(rx_frag_list[i]);
+			net_pkt_frag_unref(rx_frag_list[i]);
 			rx_frag_list[i] = NULL;
 		}
 	}

--- a/drivers/ethernet/eth_stm32_hal2.c
+++ b/drivers/ethernet/eth_stm32_hal2.c
@@ -131,7 +131,7 @@ hal_status_t rx_channel_callback(hal_eth_handle_t *h_eth, uint32_t channel, void
 	if (!frag || size == 0U || size > frag->size) {
 		LOG_ERR("RX: Invalid frag or size");
 		if (frag) {
-			net_buf_unref(frag);
+			net_pkt_frag_unref(frag);
 		}
 		return HAL_ERROR;
 	}
@@ -141,7 +141,7 @@ hal_status_t rx_channel_callback(hal_eth_handle_t *h_eth, uint32_t channel, void
 
 	if (!pkt) {
 		LOG_ERR("RX: net_pkt_rx_alloc failed");
-		net_buf_unref(frag);
+		net_pkt_frag_unref(frag);
 		return HAL_ERROR;
 	}
 


### PR DESCRIPTION
use net_pkt_frag_unref instead of net_buf_unref,
so the allocation tracking information is correct.

see https://github.com/zephyrproject-rtos/zephyr/pull/114038