### PR TITLE
net: mdns_responder: fix v4_svc/v6_svc undersized for probe's resolver

### DIFF
--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -54,18 +54,39 @@ extern void dns_dispatcher_svc_handler(struct net_socket_service_event *pev);
 
 #define MDNS_TTL CONFIG_MDNS_RESPONDER_TTL /* In seconds */
 
+/* v4_svc/v6_svc are shared between the per-interface listener dispatch below (needs
+ * MDNS_MAX_IPV4/6_IFACE_COUNT fds, one per interface) and, when probing is enabled,
+ * send_probe()'s temporary DNS resolve context (needs DNS_RESOLVER_MAX_POLL fds for its
+ * own server list). net_socket_service_register() fully replaces the previously
+ * registered set on every call rather than accumulating (see cleanup_svc_events() in
+ * sockets_service.c), so sizing only needs to cover whichever of the two is larger, not
+ * their sum -- but it does need to cover both, since the same static object is reused for
+ * both purposes at different times. Without this, dns_resolve_init_with_svc() silently
+ * fails with -ENOMEM ("Too many file descriptors") whenever DNS_RESOLVER_MAX_POLL exceeds
+ * the interface count, which is the common case (DNS_RESOLVER_MAX_POLL is at least 2 with
+ * IPv4+IPv6 mDNS both enabled, vs. the interface-count Kconfigs' default of 1) -- every
+ * probe then times out and the responder never starts.
+ */
+#if defined(CONFIG_MDNS_RESPONDER_PROBE)
+#define MDNS_V4_SVC_POLL_COUNT MAX(MDNS_MAX_IPV4_IFACE_COUNT, DNS_RESOLVER_MAX_POLL)
+#define MDNS_V6_SVC_POLL_COUNT MAX(MDNS_MAX_IPV6_IFACE_COUNT, DNS_RESOLVER_MAX_POLL)
+#else
+#define MDNS_V4_SVC_POLL_COUNT MDNS_MAX_IPV4_IFACE_COUNT
+#define MDNS_V6_SVC_POLL_COUNT MDNS_MAX_IPV6_IFACE_COUNT
+#endif
+
 #if defined(CONFIG_NET_IPV4)
 static struct mdns_responder_context v4_ctx[MAX_IPV4_IFACE_COUNT];
 
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(v4_svc, dns_dispatcher_svc_handler,
-				      MDNS_MAX_IPV4_IFACE_COUNT);
+				      MDNS_V4_SVC_POLL_COUNT);
 #endif
 
 #if defined(CONFIG_NET_IPV6)
 static struct mdns_responder_context v6_ctx[MAX_IPV6_IFACE_COUNT];
 
 NET_SOCKET_SERVICE_SYNC_DEFINE_STATIC(v6_svc, dns_dispatcher_svc_handler,
-				      MDNS_MAX_IPV6_IFACE_COUNT);
+				      MDNS_V6_SVC_POLL_COUNT);
 #endif
 
 static struct net_mgmt_event_callback mgmt_iface_cb;


### PR DESCRIPTION
## Summary

`v4_svc`/`v6_svc` are shared between two different consumers:

1. The per-interface listener dispatch in `init_listener()` (needs one fd
   per interface, sized by `MDNS_MAX_IPV4/6_IFACE_COUNT`, i.e. the
   `CONFIG_NET_IF_MAX_IPV4/6_COUNT` interface-count Kconfigs).
2. When `CONFIG_MDNS_RESPONDER_PROBE` is enabled, `send_probe()`'s
   temporary DNS resolve context, which needs `DNS_RESOLVER_MAX_POLL`
   fds for its own server list (`DNS_RESOLVER_MAX_SERVERS` +
   `MDNS_SERVER_COUNT` + `LLMNR_SERVER_COUNT` -- at least 2 with IPv4 +
   IPv6 mDNS both enabled).

`v4_svc`/`v6_svc` were sized only for the first use. Since the
interface-count Kconfigs default to 1, any probe attempt fails
`net_socket_service_register()`'s capacity check with `-ENOMEM`
("Too many file descriptors"), and every probe silently times out --
`init_listener()` never runs, so the mDNS responder never starts at all
whenever probing is enabled with typical single-interface
configurations. The failure is invisible unless
`CONFIG_DNS_SOCKET_DISPATCHER_LOG_LEVEL_DBG` is specifically enabled
(a module nobody would think to enable while debugging a probe issue).

`net_socket_service_register()` fully replaces the previously
registered descriptor set on every call rather than accumulating (see
`cleanup_svc_events()` in `sockets_service.c`), so the two uses never
need their capacities summed -- just sized to cover whichever is
larger. This PR does exactly that: `MAX(interface count,
DNS_RESOLVER_MAX_POLL)` when probing is enabled, unchanged otherwise
to avoid wasting static memory on non-probing builds.

## Test plan

- Verified as a genuine regression, not just a plausible theory:
  reverted this change (in a local test build) and confirmed probing
  fails with `-ENOMEM` every time; restored, confirmed it works.
- No dedicated test is included in this PR: this is a sizing fix that
  `CONFIG_MDNS_RESPONDER_PROBE` needs to work at all, so it has no
  independently observable behavior of its own to test without also
  exercising probing end to end.
- Confirmed with a real `esp32_devkitc` ESPHome build
  (`CONFIG_MDNS_RESPONDER_PROBE` + `CONFIG_NET_DHCPV4` both on)
  compiling clean end-to-end with this fix applied.

Assisted-by: Claude:claude-sonnet-5