### PR TITLE
doc: getting_started: fix typo "andd" -> "and"

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -33,7 +33,7 @@ Click the operating system you are using.
    .. group-tab:: macOS
 
       Select :menuselection:`System Settings --> General --> Software Update`
-      andd install any available updates. See `this Apple support topic
+      and install any available updates. See `this Apple support topic
       <https://support.apple.com/en-us/HT201541>`_ for more details.
 
       .. note::


### PR DESCRIPTION
Fix a small typo in the macOS software-update step of the Getting Started guide.