### PR TITLE
dts: arm: infineon: psoc6: disable unused work flash node

### DIFF
--- a/dts/arm/infineon/cat1a/psoc6_01/psoc6_01.dtsi
+++ b/dts/arm/infineon/cat1a/psoc6_01/psoc6_01.dtsi
@@ -43,6 +43,7 @@
 			reg = <0x14000000 0x8000>;
 			write-block-size = <512>;
 			erase-block-size = <512>;
+			status = "disabled";
 		};
 	};
 

--- a/dts/arm/infineon/cat1a/psoc6_02/psoc6_02.dtsi
+++ b/dts/arm/infineon/cat1a/psoc6_02/psoc6_02.dtsi
@@ -43,6 +43,7 @@
 			reg = <0x14000000 0x8000>;
 			write-block-size = <512>;
 			erase-block-size = <512>;
+			status = "disabled";
 		};
 	};
 

--- a/dts/arm/infineon/cat1a/psoc6_03/psoc6_03.dtsi
+++ b/dts/arm/infineon/cat1a/psoc6_03/psoc6_03.dtsi
@@ -43,6 +43,7 @@
 			reg = <0x14000000 0x8000>;
 			write-block-size = <512>;
 			erase-block-size = <512>;
+			status = "disabled";
 		};
 	};
 

--- a/dts/arm/infineon/cat1a/psoc6_04/psoc6_04.dtsi
+++ b/dts/arm/infineon/cat1a/psoc6_04/psoc6_04.dtsi
@@ -43,6 +43,7 @@
 			reg = <0x14000000 0x0>;
 			write-block-size = <512>;
 			erase-block-size = <512>;
+			status = "disabled";
 		};
 	};
 


### PR DESCRIPTION
The PSoC6 flash controller nodes (`psoc6_01`/`02`/`03`/`04`) each declared **two** enabled `soc-nv-flash` children: the main code flash (`flash0 @0x10000000`) and a work flash (`flash1 @0x14000000`).

The Infineon flash driver is single-instance and derives its target via `SOC_NV_FLASH_CHILD_NODE(0)`, which expands `DT_INST_FOREACH_CHILD_STATUS_OKAY` over every enabled `soc-nv-flash` child. With two enabled children the macro concatenates both node identifiers and the driver fails to build.

This surfaced as a build failure of `tests/drivers/flash/common` on PSoC6 boards (e.g. `cy8cproto_063_ble`, `cy8cproto_062_4343w`):

```
error: 'DT_N_S_flash_controller_40250000_S_flash_10000000' undeclared here (not in a function);
       did you mean 'DT_N_S_flash_controller_40250000_S_flash_10000000_ORD'?
```

The work flash has no Zephyr flash-driver consumer, so keep it disabled by default. This restores a single enabled `soc-nv-flash` child under the controller; boards that need the work flash can enable it explicitly alongside the required driver support.

### Testing
Built `tests/drivers/flash/common` for `cy8cproto_063_ble` — fails on `main`, links cleanly with this change.