### PR TITLE
doc: kernel/ipi: fix sample on calling k_ipi_work_signal()

### DIFF
--- a/doc/kernel/services/smp/smp.rst
+++ b/doc/kernel/services/smp/smp.rst
@@ -366,7 +366,7 @@ information across a set of CPUs as a result of one CPU handling an ISR.
 
         k_ipi_work_add(&my_work, cpu_mask, remote_cpu_action);
 
-        k_ipi_signal();
+        k_ipi_work_signal();
     }
 
 


### PR DESCRIPTION
Should be calling to k_ipi_work_signal() instead of k_ipi_signal().