### PR TITLE
kernel: smp/ipi: pass cpu_id as function argument

### DIFF
--- a/kernel/smp/ipi.c
+++ b/kernel/smp/ipi.c
@@ -105,10 +105,9 @@ void signal_pending_ipi(void)
 }
 
 #ifdef CONFIG_SCHED_IPI_SUPPORTED
-static struct k_ipi_work *first_ipi_work(sys_dlist_t *list)
+static struct k_ipi_work *first_ipi_work(sys_dlist_t *list, unsigned int cpu_id)
 {
 	sys_dnode_t *work = sys_dlist_peek_head(list);
-	unsigned int cpu_id = _current_cpu->id;
 
 	return (work == NULL) ? NULL
 			      : CONTAINER_OF(work, struct k_ipi_work, node[cpu_id]);
@@ -169,14 +168,12 @@ void k_ipi_work_signal(void)
 	signal_pending_ipi();
 }
 
-static void ipi_work_process(sys_dlist_t *list)
+static void ipi_work_process(sys_dlist_t *list, unsigned int cpu_id)
 {
-	unsigned int cpu_id = _current_cpu->id;
-
 	k_spinlock_key_t key = k_spin_lock(&ipi_lock);
 
-	for (struct k_ipi_work *work = first_ipi_work(list);
-	     work != NULL; work = first_ipi_work(list)) {
+	for (struct k_ipi_work *work = first_ipi_work(list, cpu_id);
+	     work != NULL; work = first_ipi_work(list, cpu_id)) {
 		sys_dlist_remove(&work->node[cpu_id]);
 		k_spin_unlock(&ipi_lock, key);
 
@@ -208,6 +205,8 @@ void z_sched_ipi(void)
 #endif
 
 #ifdef CONFIG_SCHED_IPI_SUPPORTED
-	ipi_work_process(&_kernel.cpus[_current_cpu->id].ipi_workq);
+	unsigned int cpu_id = _current_cpu->id;
+
+	ipi_work_process(&_kernel.cpus[cpu_id].ipi_workq, cpu_id);
 #endif
 }


### PR DESCRIPTION
There is no need to grab CPU ID from _current_cpu->id down in the ipi_work_process() call chain, as it can be passed as a function argument and can be reused. Using _current_cpu can be costly with assertion on as it calls z_smp_cpu_mobile for each call.