### PR TITLE
dts: bindings: add arm,cortex-a57 CPU binding

### DIFF
--- a/dts/bindings/cpu/arm,cortex-a57.yaml
+++ b/dts/bindings/cpu/arm,cortex-a57.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 BayLibre SAS
+# SPDX-License-Identifier: Apache-2.0
+
+description: ARM Cortex-A57 CPU
+
+compatible: "arm,cortex-a57"
+
+include: cpu.yaml


### PR DESCRIPTION
Since commit 7afcac3f51e9 ("drivers: interrupt_controller: Use new CPU macro to iterate through CPUs"), CPU enumeration depends on the `device_type` property being declared by a matched binding, which broke the build for CPU compatibles lacking a binding (`arm,cortex-r8f`, `arm,armv8`, `arm,cortex-a57`).

#114145 added the first two, which also unbroke `rcar_h3ulcb/r8a77951/a57` through the `arm,armv8` fallback in its CPU nodes' compatible list. This PR now only adds the remaining `arm,cortex-a57` binding so those CPUs match their specific compatible rather than the generic fallback.

Fixes #114110