### PR TITLE
drivers: input: gt911: Make the status clear buffer static const

### DIFF
--- a/drivers/input/input_gt911.c
+++ b/drivers/input/input_gt911.c
@@ -148,7 +148,8 @@ static int gt911_process(const struct device *dev)
 	points = status & GT911_TOUCH_POINTS_MSK;
 
 	/* need to clear the status */
-	uint8_t clear_buffer[3] = {(uint8_t)GT911_REG_STATUS, (uint8_t)(GT911_REG_STATUS >> 8), 0};
+	static const uint8_t clear_buffer[3] = {(uint8_t)GT911_REG_STATUS,
+						(uint8_t)(GT911_REG_STATUS >> 8), 0};
 
 	r = gt911_i2c_write(dev, clear_buffer, sizeof(clear_buffer));
 	if (r < 0) {


### PR DESCRIPTION
The status clear command buffer is built from compile-time constants and only read, so make it static const to keep it in read-only memory instead of rebuilding it on the stack on every call.