### PR TITLE
drivers: input: sbus: Give the UART config internal linkage

### DIFF
--- a/drivers/input/input_sbus.c
+++ b/drivers/input/input_sbus.c
@@ -25,7 +25,7 @@ struct sbus_input_channel {
 	uint32_t zephyr_code;
 };
 
-const struct uart_config uart_cfg_sbus = {
+static const struct uart_config uart_cfg_sbus = {
 	.baudrate = 100000,
 	.parity = UART_CFG_PARITY_EVEN,
 	.stop_bits = UART_CFG_STOP_BITS_2,


### PR DESCRIPTION
uart_cfg_sbus is only referenced within this file, so mark it static to give it internal linkage.