### PR TITLE
drivers: dma: ti_mspm0: Fix data width byte counts

### DIFF
--- a/drivers/dma/dma_ti_mspm0.c
+++ b/drivers/dma/dma_ti_mspm0.c
@@ -23,8 +23,8 @@ LOG_MODULE_REGISTER(ti_mspm0_dma, CONFIG_DMA_LOG_LEVEL);
 /* Data Transfer Width */
 #define DMA_TI_MSPM0_DATAWIDTH_BYTE	1
 #define DMA_TI_MSPM0_DATAWIDTH_HALF	2
-#define DMA_TI_MSPM0_DATAWIDTH_WORD	3
-#define DMA_TI_MSPM0_DATAWIDTH_LONG	4
+#define DMA_TI_MSPM0_DATAWIDTH_WORD	4
+#define DMA_TI_MSPM0_DATAWIDTH_LONG	8
 
 struct dma_ti_mspm0_config {
 	DMA_Regs *regs;


### PR DESCRIPTION
The width selectors are matched against the configured data sizes, which are byte counts, but the word and long constants held enum style values of three and four. A 32-bit element therefore selected the 64-bit hardware width and the word width was unreachable. Use the actual byte counts of four and eight.