### PR TITLE
soc: st: stm32: add support for STM32L151xE

### DIFF
--- a/dts/arm/st/l1/stm32l151Xe.dtsi
+++ b/dts/arm/st/l1/stm32l151Xe.dtsi
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Draeger
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/l1/stm32l151.dtsi>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(80)>;
+	};
+
+	soc {
+		flash-controller@40023c00 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(512)>;
+				ranges = <0 0x8000000 DT_SIZE_K(512)>;
+			};
+		};
+
+		timers5: timers@40000c00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
+				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1, 3)>;
+			interrupts = <46 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
+		spi3: spi@40003c00 {
+			compatible = "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
+			interrupts = <47 0>;
+			st,spi-data-width = "limited-8-16-bit";
+			status = "disabled";
+		};
+
+		eeprom: eeprom@8080000 {
+			reg = <0x08080000 DT_SIZE_K(16)>;
+		};
+
+		rtc@40002800 {
+			bbram: backup_regs {
+				compatible = "st,stm32-bbram";
+				st,backup-regs = <32>;
+				status = "disabled";
+			};
+		};
+	};
+};

--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -190,6 +190,7 @@ family:
     - name: stm32l151xb
     - name: stm32l151xba
     - name: stm32l151xc
+    - name: stm32l151xe
     - name: stm32l152xc
     - name: stm32l152xe
   - name: stm32l4x

--- a/soc/st/stm32/stm32l1x/Kconfig.soc
+++ b/soc/st/stm32/stm32l1x/Kconfig.soc
@@ -26,6 +26,10 @@ config SOC_STM32L151XC
 	bool
 	select SOC_SERIES_STM32L1X
 
+config SOC_STM32L151XE
+	bool
+	select SOC_SERIES_STM32L1X
+
 config SOC_STM32L152XC
 	bool
 	select SOC_SERIES_STM32L1X
@@ -39,5 +43,6 @@ config SOC
 	default "stm32l151xb" if SOC_STM32L151XB
 	default "stm32l151xba" if SOC_STM32L151XBA
 	default "stm32l151xc" if SOC_STM32L151XC
+	default "stm32l151xe" if SOC_STM32L151XE
 	default "stm32l152xc" if SOC_STM32L152XC
 	default "stm32l152xe" if SOC_STM32L152XE


### PR DESCRIPTION
This is almost a copy of the STM32L152xE support.

The STM32L152xE is already supported and is nearly identical; the STM32L151xE differs only by lacking the LCD interface.