### PR TITLE
drivers: dma: amd_acp_host: Reject start from an invalid state

### DIFF
--- a/drivers/dma/dma_amd_acp_host.c
+++ b/drivers/dma/dma_amd_acp_host.c
@@ -209,6 +209,7 @@ static int acp_host_dma_start(const struct device *dev, uint32_t channel)
 	}
 	if (chan->state != ACP_DMA_PREPARED && chan->state != ACP_DMA_SUSPENDED) {
 		ret = -EINVAL;
+		goto out;
 	}
 	chan->state = ACP_DMA_ACTIVE;
 	/* Clear DMAChRun before starting the DMA Ch */


### PR DESCRIPTION
The channel state validation in start computed -EINVAL but fell through and started the transfer anyway, returning success. Bail out like the channel range check above it.