### PR TITLE
drivers: mbox: nrf_vevif_event_tx: Accept the highest event channel

### DIFF
--- a/drivers/mbox/mbox_nrf_vevif_event_tx.c
+++ b/drivers/mbox/mbox_nrf_vevif_event_tx.c
@@ -22,7 +22,7 @@ BUILD_ASSERT(DT_INST_PROP(0, nordic_events) <= NRF_VPR_EVENTS_TRIGGERED_COUNT,
 
 static inline bool vevif_event_tx_is_valid(uint32_t id)
 {
-	return (id < EVENTS_IDX_MAX) && ((VEVIF_EVENTS_MASK & BIT(id)) != 0U);
+	return (id <= EVENTS_IDX_MAX) && ((VEVIF_EVENTS_MASK & BIT(id)) != 0U);
 }
 
 static int vevif_event_tx_send(const struct device *dev, uint32_t id, const struct mbox_msg *msg)


### PR DESCRIPTION
EVENTS_IDX_MAX is an inclusive maximum index, as used by the RX sibling and both VEVIF task drivers, but the TX channel validation used a strict comparison and rejected the last valid channel.