### PR TITLE
drivers: ipm: esp32: Account for the shared memory split

### DIFF
--- a/drivers/ipm/ipm_esp32.c
+++ b/drivers/ipm/ipm_esp32.c
@@ -110,7 +110,7 @@ static int esp32_ipm_send(const struct device *dev, int wait, uint32_t id,
 		return -EINVAL;
 	}
 
-	if (dev_data->shm_size < size) {
+	if ((dev_data->shm_size / 2) < size) {
 		LOG_ERR("Not enough memory in IPM channel");
 		return -ENOMEM;
 	}
@@ -179,7 +179,7 @@ static int esp32_ipm_max_data_size_get(const struct device *dev)
 {
 	struct esp32_ipm_data *data = (struct esp32_ipm_data *)dev->data;
 
-	return data->shm_size;
+	return data->shm_size / 2;
 }
 
 static uint32_t esp_32_ipm_max_id_val_get(const struct device *dev)


### PR DESCRIPTION
The shared memory region is split in half between the two directions, but the size check and max_data_size_get() used the full region size, so a maximum-sized message overflowed the region by half its size. Use the per-direction capacity.