### PR TITLE
drivers: ipm: stm32_ipcc: Fix receive channel disable on processor 1

### DIFF
--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -40,7 +40,7 @@ LOG_MODULE_REGISTER(ipm_stm32_ipcc, CONFIG_IPM_LOG_LEVEL);
 #define IPCC_EnableTransmitChannel(hipcc, ch)	\
 			LL_C1_IPCC_EnableTransmitChannel(hipcc, 1 << ch)
 #define IPCC_DisableReceiveChannel(hipcc, ch)	\
-			LL_C2_IPCC_DisableReceiveChannel(hipcc, 1 << ch)
+			LL_C1_IPCC_DisableReceiveChannel(hipcc, 1 << ch)
 #define IPCC_DisableTransmitChannel(hipcc, ch)	\
 			LL_C1_IPCC_DisableTransmitChannel(hipcc, 1 << ch)
 


### PR DESCRIPTION
In the processor 1 macro block, every helper maps to the LL_C1 variant except IPCC_DisableReceiveChannel, which used the LL_C2 function and therefore masked the other core's receive channel. Disabling reception was a no-op on the local core and corrupted the remote core's mask instead.