### PR TITLE
drivers: ipm: imx: Do not write back the shifted status register

### DIFF
--- a/drivers/ipm/ipm_imx.c
+++ b/drivers/ipm/ipm_imx.c
@@ -108,7 +108,7 @@ static void imx_mu_isr(const struct device *dev)
 	int32_t i;
 	bool all_registers_full;
 
-	status_reg = base->SR >>= MU_SR_RFn_SHIFT;
+	status_reg = base->SR >> MU_SR_RFn_SHIFT;
 
 	for (id = CONFIG_IPM_IMX_MAX_ID_VAL; id >= 0; id--) {
 		if (status_reg & 0x1U) {


### PR DESCRIPTION
The receive flag extraction used a compound shift assignment, writing the right-shifted value back into the volatile MU status register as a side effect. Use a plain shift into the local.