### PR TITLE
drivers: sdhc: cdns: Invalidate the whole read buffer

### DIFF
--- a/drivers/sdhc/sdhc_cdns.c
+++ b/drivers/sdhc/sdhc_cdns.c
@@ -90,7 +90,7 @@ static int sdhc_cdns_request(const struct device *dev,
 				return -ENODATA;
 			}
 			ret = cdns_sdmmc_ops->cache_invd(data->block_addr, (uintptr_t)data->data,
-				data->block_size);
+				data->blocks * data->block_size);
 			if (ret != 0) {
 				return ret;
 			}


### PR DESCRIPTION
After a read the cache invalidation only covered one block even for multi-block transfers, leaving the remaining blocks to be read from stale cache lines. Invalidate the full transfer size, which matches the range flushed when the DMA descriptors are prepared.