### PR TITLE
drivers: sdhc: sam_hsmci: Fix inverted byte mode in manual transfers

### DIFF
--- a/drivers/sdhc/sam_hsmci.c
+++ b/drivers/sdhc/sam_hsmci.c
@@ -538,11 +538,11 @@ static int sam_hsmci_request_inner(const struct device *dev, struct sdhc_command
 		if ((sd_data->block_size & 0x3) == 0 && (((uint32_t)sd_data->data) & 0x3) == 0) {
 			size = (sd_data->block_size + 3) >> 2;
 			hsmci->HSMCI_MR &= ~HSMCI_MR_FBYTE;
-			byte_mode = true;
+			byte_mode = false;
 		} else {
 			size = sd_data->block_size;
 			hsmci->HSMCI_MR |= HSMCI_MR_FBYTE;
-			byte_mode = false;
+			byte_mode = true;
 		}
 
 		hsmci->HSMCI_BLKR =


### PR DESCRIPTION
The aligned path clears FBYTE and computes a word count but set byte_mode to true, and the unaligned path did the opposite, so manual transfers moved a quarter of the data or overran the buffer fourfold. Swap the two assignments to match the FBYTE setting.