### PR TITLE
drivers: watchdog: numaker: Fix inverted clock rate check

### DIFF
--- a/drivers/watchdog/wdt_numaker.c
+++ b/drivers/watchdog/wdt_numaker.c
@@ -54,7 +54,7 @@ static uint32_t wdt_numaker_calc_ms(const struct device *dev, const uint32_t tou
 
 	if (clock_control_get_rate(cfg->clk_dev, (clock_control_subsys_t)&scc_subsys, &clk_freq) !=
 		    0 ||
-	    clk_freq != 0) {
+	    clk_freq == 0) {
 		return 0;
 	}
 


### PR DESCRIPTION
The period calculation bailed out when the clock rate was non-zero, i.e. on every successful clock query, so the computed period was always zero and install_timeout() always failed with -EINVAL. Bail out on a zero rate instead.