### PR TITLE
drivers: watchdog: intel_adsp: Fix reset flag handling

### DIFF
--- a/drivers/watchdog/wdt_intel_adsp.c
+++ b/drivers/watchdog/wdt_intel_adsp.c
@@ -109,9 +109,7 @@ static int intel_adsp_wdt_install_timeout(const struct device *dev,
 		return ret;
 	}
 
-	if (config->flags & WDT_FLAG_RESET_CPU_CORE) {
-		dev_data->allow_reset = true;
-	}
+	dev_data->allow_reset = (config->flags & WDT_FLAG_RESET_MASK) != WDT_FLAG_RESET_NONE;
 
 	return 0;
 }


### PR DESCRIPTION
The reset flags are a two-bit enumerated field, not independent bits, so testing flags with a bitwise AND against
WDT_FLAG_RESET_CPU_CORE left WDT_FLAG_RESET_SOC without reset enabled. The flag was also never cleared on re-install. Derive allow_reset from the masked field on every install.