### PR TITLE
doc: fix typos in ring buffer and libcsp guides

### DIFF
--- a/doc/develop/manifest/external/libcsp.rst
+++ b/doc/develop/manifest/external/libcsp.rst
@@ -21,7 +21,7 @@ libcsp is licensed under the MIT license.
 Usage with Zephyr
 *****************
 
-To use libcsp with Zephyr, you first need to add the following snipet to your ``west.yaml``:
+To use libcsp with Zephyr, you first need to add the following snippet to your ``west.yaml``:
 
 .. code-block:: yaml
 

--- a/doc/kernel/data_structures/ringq.rst
+++ b/doc/kernel/data_structures/ringq.rst
@@ -69,7 +69,7 @@ items and ensures proper boundary checking of the underlying data buffer.
     }
 
 In addition to the standard data operations (sys_ringq_put() and sys_ringq_get()), the sys_ringq API provides a set
-of utility functions for managing and inspecting the data strucures state.
+of utility functions for managing and inspecting the data structures state.
 
 * sys_ringq_capacity() – Returns the total capacity of the sys_ringq in terms of the number of items it can hold.
 * sys_ringq_empty() – Returns true if the sys_ringq contains no items.


### PR DESCRIPTION
Fix two spelling typos in the documentation:

- `strucures` -> `structures` in the ring buffer / data structures page
- `snipet` -> `snippet` in the libcsp external manifest page

Documentation-only change; no functional impact.