### PR TITLE
tests: drivers: counter: counter_basic_api: fix cyw20829 divider conflict

### DIFF
--- a/tests/drivers/counter/counter_basic_api/boards/cyw920829m2evk_02_common.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/cyw920829m2evk_02_common.overlay
@@ -12,11 +12,18 @@
 
 	counter0_1 {
 		status = "okay";
-		clocks = <&peri0_group1_16bit_0>;
+		/*
+		 * Use the highest group1 16-bit divider channel. The console
+		 * UART's legacy CAT1 HAL dynamically allocates the lowest free
+		 * group1 16-bit divider (peri0_group1_16bit_0) for its baud
+		 * clock, which would otherwise clobber the counter's divider
+		 * and run it at ~923 kHz instead of the configured 10 kHz.
+		 */
+		clocks = <&peri0_group1_16bit_3>;
 	};
 };
 
-&peri0_group1_16bit_0 {
+&peri0_group1_16bit_3 {
 	status = "okay";
 	clock-div = <9599>;
 };


### PR DESCRIPTION
On cyw920829m2evk_02 the `counter_basic_api` overlay assigned the TCPWM
counter to the first group1 16-bit peripheral divider,
`peri0_group1_16bit_0`, intending 96 MHz / 9600 = 10 kHz.

However the console UART (legacy CAT1 HAL) uses a *dynamic* peripheral
divider allocator that grabs the first free group1 16-bit divider — the
same `peri0_group1_16bit_0` — and reprograms it to /104 (~923 kHz) for
its 115200 baud clock. This happens after the peripheral clock driver
programs the DT-configured value but before the application runs, so the
counter ends up running at ~923 kHz instead of 10 kHz.

At ~923 kHz one tick is ~1.08 µs, so a 1-tick relative alarm cannot be
armed before the counter passes the compare value and
`test_short_relative_alarm` fails ("Expected 2 callbacks, got 1").

This PR moves the counter to the highest group1 16-bit divider channel,
`peri0_group1_16bit_3`, which the dynamic allocator (lowest-first) will
not take. The counter must stay in group1 because `tcpwm0_1` `clk_dst`
is in group1.

### Testing

Verified on hardware (cyw920829m2evk_02 / cyw20829b0lkml). Counter now
measures 10001 Hz and the full suite passes:

```
SUITE PASS - 100.00% [counter_basic]: pass = 8, fail = 0, skip = 2, total = 10
  - PASS test_short_relative_alarm
  - PASS test_set_top_value_with_alarm
  ...
SUITE PASS - 100.00% [counter_no_callback]
```
