### PR TITLE
drivers: sensor: bmi270: guard any-motion against missing feature set

### DIFF
--- a/drivers/sensor/bosch/bmi270/bmi270_trigger.c
+++ b/drivers/sensor/bosch/bmi270/bmi270_trigger.c
@@ -228,6 +228,16 @@ static int bmi270_anymo_config(const struct device *dev, bool enable)
 	uint16_t anymo_2;
 	int ret;
 
+	/* Any-motion registers only exist in feature sets that define them
+	 * (e.g. the base config). The default max_fifo feature set leaves these
+	 * pointers NULL; without this guard the writes below would dereference
+	 * NULL and silently program an unintended feature-page address.
+	 */
+	if (cfg->feature->anymo_1 == NULL || cfg->feature->anymo_2 == NULL) {
+		LOG_ERR("any-motion not supported by the configured feature set");
+		return -ENOTSUP;
+	}
+
 	if (enable) {
 		ret = bmi270_feature_reg_write(dev, cfg->feature->anymo_1,
 					       data->anymo_1);


### PR DESCRIPTION
Fixes #112938

## Problem
With the default `bosch,bmi270` compatible, the driver selects the `max_fifo`
feature set, whose `anymo_1`/`anymo_2` register descriptors are `NULL`.
Enabling `SENSOR_TRIG_MOTION` then calls `bmi270_anymo_config()`, which passes
those `NULL` pointers to `bmi270_feature_reg_write()`. On Cortex-M address 0 is
readable, so the write silently targets an unintended feature page and returns
success — the any-motion trigger becomes a no-op with no error to the caller.

## Fix
Return `-ENOTSUP` from `bmi270_anymo_config()` when the configured feature set
does not provide the any-motion registers, so the unsupported configuration is
reported instead of failing silently. This matches the expected behaviour
described in the issue ("returns -ENOTSUP when the selected feature set has no
any-motion support").

Kept intentionally minimal so it is easy to review and backport. The larger
items noted in the issue — providing/documenting a `bosch,bmi270-base` binding
and the `adv_power_save` timing issues around feature-page writes — are better
addressed as separate follow-up changes.

## Testing
Symbol/scope reviewed against the driver; relies on Zephyr CI (`build_all`
sensor) for the compile. The defensive `-ENOTSUP` path does not require the
sensor; I do not have BMI270 hardware to exercise the positive any-motion path,
so this change is deliberately scoped to the safe failure behaviour.