### PR TITLE
posix: fs: skip free-space scan for a failing stat()

### DIFF
--- a/subsys/portability/posix/options/fs.c
+++ b/subsys/portability/posix/options/fs.c
@@ -151,12 +151,6 @@ int stat(const char *path, struct stat *buf)
 		return -1;
 	}
 
-	rc = fs_statvfs(path, &stat_vfs);
-	if (rc < 0) {
-		errno = -rc;
-		return -1;
-	}
-
 	rc = fs_stat(path, &stat_file);
 	if (rc < 0) {
 		errno = -rc;
@@ -176,6 +170,18 @@ int stat(const char *path, struct stat *buf)
 		errno = EIO;
 		return -1;
 	}
+
+	/*
+	 * fs_statvfs() is only needed for the block-size hint below, and on some
+	 * filesystems it scans the whole volume for free space. Defer it until
+	 * after fs_stat() so a failed lookup skips the scan entirely.
+	 */
+	rc = fs_statvfs(path, &stat_vfs);
+	if (rc < 0) {
+		errno = -rc;
+		return -1;
+	}
+
 	buf->st_size = stat_file.size;
 	buf->st_blksize = stat_vfs.f_bsize;
 	/*

--- a/tests/subsys/portability/posix/fs/src/test_fs_stat.c
+++ b/tests/subsys/portability/posix/fs/src/test_fs_stat.c
@@ -73,6 +73,9 @@ ZTEST(posix_fs_stat_test, test_fs_stat_file)
 	zassert_equal(0, stat(TEST_FILE, &buf));
 	zassert_equal(TEST_FILE_SIZE, buf.st_size);
 	zassert_equal(S_IFREG, buf.st_mode);
+	/* The block-size hint (from statvfs) must still be populated. */
+	zassert_true(buf.st_blksize > 0);
+	zassert_equal(buf.st_blocks, (buf.st_size + buf.st_blksize - 1) / buf.st_blksize);
 
 	zassert_equal(0, stat(TEST_DIR_FILE, &buf));
 	zassert_equal(TEST_DIR_FILE_SIZE, buf.st_size);


### PR DESCRIPTION
`stat()` called `fs_statvfs()` before `fs_stat()`, so every lookup paid a
filesystem-wide free-space scan — O(fs size) on littlefs, a full FAT read on
FatFs — even for a path that doesn't exist. That scan result is only used for
the block-size hint.

Run `fs_stat()` first and return early on failure; the successful-`stat()`
output is unchanged.

**Tests:** `fs` suite passes; adds an assertion that the block-size hint stays
populated.
