### PR TITLE
posix: pthread: unlink thread-specific data in O(1) on thread exit

### DIFF
--- a/subsys/portability/posix/options/key.c
+++ b/subsys/portability/posix/options/key.c
@@ -108,7 +108,7 @@ int pthread_key_create(pthread_key_t *key,
 		return ENOMEM;
 	}
 
-	sys_slist_init(&(new_key->key_data_l));
+	sys_dlist_init(&(new_key->key_data_l));
 
 	new_key->destructor = destructor;
 	LOG_DBG("Initialized key %p (%x)", new_key, *key);
@@ -127,7 +127,7 @@ int pthread_key_delete(pthread_key_t key)
 	int ret = EINVAL;
 	pthread_key_obj *key_obj = NULL;
 	struct pthread_key_data *key_data;
-	sys_snode_t *node_l, *next_node_l;
+	sys_dnode_t *node_l;
 
 	SYS_SEM_LOCK(&pthread_key_lock) {
 		key_obj = get_posix_key(key);
@@ -137,10 +137,8 @@ int pthread_key_delete(pthread_key_t key)
 		}
 
 		/* Delete thread-specific elements associated with the key */
-		SYS_SLIST_FOR_EACH_NODE_SAFE(&(key_obj->key_data_l), node_l, next_node_l) {
-
-			/* Remove the object from the list key_data_l */
-			key_data = (struct pthread_key_data *)sys_slist_get(&(key_obj->key_data_l));
+		while ((node_l = sys_dlist_get(&key_obj->key_data_l)) != NULL) {
+			key_data = CONTAINER_OF(node_l, struct pthread_key_data, node);
 
 			/* Deallocate the object's memory */
 			k_free((void *)key_data);
@@ -227,7 +225,7 @@ int pthread_setspecific(pthread_key_t key, const void *value)
 		sys_slist_append((&thread->key_list), (sys_snode_t *)(&key_data->thread_data));
 
 		/* Append new key data to the key object's list */
-		sys_slist_append(&(key_obj->key_data_l), (sys_snode_t *)key_data);
+		sys_dlist_append(&key_obj->key_data_l, &key_data->node);
 
 		LOG_DBG("Paired key %x to value %p for thread %x", key, value, pthread_self());
 	}

--- a/subsys/portability/posix/options/posix_internal.h
+++ b/subsys/portability/posix/options/posix_internal.h
@@ -89,7 +89,7 @@ typedef struct pthread_key_obj {
 	/* List of pthread_key_data objects that contain thread
 	 * specific data for the key
 	 */
-	sys_slist_t key_data_l;
+	sys_dlist_t key_data_l;
 
 	/* Optional destructor that is passed to pthread_key_create() */
 	void (*destructor)(void *value);
@@ -104,7 +104,7 @@ typedef struct pthread_thread_data {
 } pthread_thread_data;
 
 struct pthread_key_data {
-	sys_snode_t node;
+	sys_dnode_t node;
 	pthread_thread_data thread_data;
 };
 

--- a/subsys/portability/posix/options/pthread.c
+++ b/subsys/portability/posix/options/pthread.c
@@ -470,7 +470,6 @@ static void posix_thread_finalize(struct posix_thread *t, void *retval)
 	sys_snode_t *node_l, *node_s;
 	pthread_key_obj *key_obj;
 	pthread_thread_data *thread_spec_data;
-	sys_snode_t *node_key_data, *node_key_data_s, *node_key_data_prev = NULL;
 	struct pthread_key_data *key_data;
 
 	SYS_SLIST_FOR_EACH_NODE_SAFE(&t->key_list, node_l, node_s) {
@@ -482,22 +481,10 @@ static void posix_thread_finalize(struct posix_thread *t, void *retval)
 			}
 
 			SYS_SEM_LOCK(&pthread_key_lock) {
-				SYS_SLIST_FOR_EACH_NODE_SAFE(
-					&key_obj->key_data_l,
-					node_key_data,
-					node_key_data_s) {
-					key_data = (struct pthread_key_data *)node_key_data;
-					if (&key_data->thread_data == thread_spec_data) {
-						sys_slist_remove(
-							&key_obj->key_data_l,
-							node_key_data_prev,
-							node_key_data
-						);
-						k_free(key_data);
-						break;
-					}
-					node_key_data_prev = node_key_data;
-				}
+				key_data = CONTAINER_OF(thread_spec_data, struct pthread_key_data,
+							thread_data);
+				sys_dlist_remove(&key_data->node);
+				k_free(key_data);
 			}
 		}
 	}


### PR DESCRIPTION
`posix_thread_finalize()` rescanned each key's entire data list to unlink a
single node on every thread exit — O(keys × threads). Storing the key-side
data on a doubly-linked list makes the unlink O(1) via `CONTAINER_OF()`.

Also drops the stale-predecessor bookkeeping that `sys_slist_remove()` required
(a latent list-corruption hazard).

**Tests:** `threads_base` key suite passes, incl.
`test_thread_specific_data_deallocation`.
