### PR TITLE
posix: mqueue: skip used-count syscalls when no notification is set

### DIFF
--- a/subsys/portability/posix/options/mqueue.c
+++ b/subsys/portability/posix/options/mqueue.c
@@ -470,16 +470,23 @@ static int32_t send_message(mqueue_desc *mqd, const char *msg_ptr, size_t msg_le
 		return ret;
 	}
 
-	uint32_t msgq_num = k_msgq_num_used_get(&mqd->mqueue->queue);
+	struct sigevent *sevp = &mqd->mqueue->not;
+	bool notify = (sevp->sigev_notify & SIGEV_MASK) != 0;
+	uint32_t msgq_num = 0;
+
+	/* The used-count is only needed to detect the empty->non-empty edge that
+	 * triggers a registered notification; skip the syscalls when none is set.
+	 */
+	if (notify) {
+		msgq_num = k_msgq_num_used_get(&mqd->mqueue->queue);
+	}
 
 	if (k_msgq_put(&mqd->mqueue->queue, (void *)msg_ptr, timeout) != 0) {
 		errno = K_TIMEOUT_EQ(timeout, K_NO_WAIT) ? EAGAIN : ETIMEDOUT;
 		return ret;
 	}
 
-	if (k_msgq_num_used_get(&mqd->mqueue->queue) - msgq_num > 0) {
-		struct sigevent *sevp = &mqd->mqueue->not;
-
+	if (notify && (k_msgq_num_used_get(&mqd->mqueue->queue) - msgq_num > 0)) {
 		if (sevp->sigev_notify == SIGEV_NONE) {
 			sevp->sigev_notify_function(sevp->sigev_value);
 		} else if (sevp->sigev_notify == SIGEV_THREAD) {


### PR DESCRIPTION
`send_message()` called `k_msgq_num_used_get()` twice on every `mq_send()`,
only to detect the empty→non-empty edge that fires a registered notification.
Gate both calls on a notification actually being registered so the common
no-notify send path avoids them.

**Tests:** `xsi_realtime` mqueue suite passes on qemu_x86 (54/54).
