### PR TITLE
drivers: sensor: adxl345: fix over-sized buffer request in submit_fetch

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345_rtio.c
+++ b/drivers/sensor/adi/adxl345/adxl345_rtio.c
@@ -18,7 +18,7 @@ static void adxl345_submit_fetch(struct rtio_iodev_sqe *iodev_sqe)
 			(const struct sensor_read_config *) iodev_sqe->sqe.iodev->data;
 	const struct device *dev = cfg->sensor;
 	int rc;
-	uint32_t min_buffer_len = sizeof(struct adxl345_dev_data);
+	uint32_t min_buffer_len = sizeof(struct adxl345_sample);
 	uint8_t *buffer;
 	uint32_t buffer_len;
 


### PR DESCRIPTION
adxl345_submit_fetch() requests sizeof(struct adxl345_dev_data) bytes from the RTIO buffer pool, but only writes sizeof(struct adxl345_sample) into it. The decoder also casts the buffer to struct adxl345_sample *.

This over-allocation wastes memory and prevents callers from using reasonably-sized read buffers (e.g. 128 bytes) since adxl345_dev_data can exceed 200 bytes when triggers or streaming are enabled.

Assisted-by: Claude:claude-opus-4-6