### PR TITLE
drivers: sensor: fix sign-compare in fixed-point conversion

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1429,7 +1429,7 @@ static inline int sensor_value_to_fixed_point(uint32_t *val, struct sensor_value
 
 		*val = (uint32_t)(raw & BIT64_MASK(num_bits));
 	} else {
-		if (!IN_RANGE(raw, 0, BIT64_MASK(num_bits))) {
+		if (!IN_RANGE(raw, 0, (int64_t)BIT64_MASK(num_bits))) {
 			return -ERANGE;
 		}
 


### PR DESCRIPTION
sensor_value_to_fixed_point() compared the int64_t `raw` against
BIT64_MASK(num_bits), which expands to an unsigned long long. The
IN_RANGE() comparison then promoted the signed operand to unsigned,
producing a -Wsign-compare warning:

  include/zephyr/sys/util.h:558:58: warning: comparison of integer
  expressions of different signedness: 'int64_t' and 'long long
  unsigned int' [-Wsign-compare]

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
