### PR TITLE
boards: infineon: pse84: run counter test on all pse84 cores

### DIFF
--- a/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33_ns.yaml
+++ b/boards/infineon/kit_pse84_ai/kit_pse84_ai_m33_ns.yaml
@@ -13,6 +13,7 @@ toolchain:
   - zephyr
 supported:
   - clock_control
+  - counter
   - gpio
   - pinctrl
   - bluetooth

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.yaml
@@ -14,6 +14,7 @@ toolchain:
 supported:
   - bluetooth
   - clock_control
+  - counter
   - dma
   - gpio
   - hwinfo

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns.yaml
@@ -13,6 +13,7 @@ toolchain:
   - zephyr
 supported:
   - clock_control
+  - counter
   - gpio
   - pinctrl
   - bluetooth

--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m55.yaml
@@ -15,6 +15,7 @@ supported:
   - adc
   - bluetooth
   - clock_control
+  - counter
   - dma
   - gpio
   - hwinfo

--- a/tests/drivers/counter/counter_basic_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m33_ns.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/kit_pse84_ai_pse846gps2dbzc4a_m33_ns.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_ai_common.overlay"

--- a/tests/drivers/counter/counter_basic_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"


### PR DESCRIPTION
The counter (TCPWM) block is identical across every PSOC Edge E84 core, yet the `drivers.counter.basic_api` test only ran on `kit_pse84_ai` `m33` and `m55`. The other four pse84 targets were statically filtered because `counter` was missing from their board `supported:` lists, and the two non-secure targets additionally lacked a twister overlay (the auto-applied overlay name includes the `/ns` suffix, so `_m33` does not apply to `m33/ns`).

This change:
- adds `counter` to the `supported:` lists of `kit_pse84_eval` `m33`, `m55` and `m33/ns` and `kit_pse84_ai` `m33/ns`;
- adds the missing `_m33_ns` counter overlays for both kits (each just includes the shared common overlay, mirroring the existing `_m33`/`_m55` overlays).

The test now runs on all six pse84 targets (eval + ai, each m33/m33-ns/m55).

### Test
Verified on hardware on `kit_pse84_eval/pse846gps2dbzc4a/m33/ns` — the full suite passes (9/9 cases). The secure `m33`/`m55` cores are a strict superset of the non-secure case and their `kit_pse84_ai` twins already pass in CI.