### PR TITLE
drivers: dma: dw-axi: Fix multiple channel control issues and support extended register layouts

### DIFF
--- a/drivers/dma/dma_dw_axi.c
+++ b/drivers/dma/dma_dw_axi.c
@@ -829,9 +829,9 @@ static int dma_dw_axi_resume(const struct device *dev, uint32_t channel)
 
 	reg = sys_read64(reg_base + DMA_DW_AXI_CHENREG);
 	/* channel susp write enable bit has to be asserted */
-	WRITE_BIT(reg, CH_RESUME_WE(channel), 1);
+	reg |= CH_RESUME_WE(channel);
 	/* channel susp bit must be cleared to resume a channel*/
-	WRITE_BIT(reg, CH_RESUME(channel), 0);
+	reg &= ~CH_RESUME(channel);
 	/* resume a channel by writing 0: ch_susp and 1: ch_susp_we */
 	sys_write64(reg, reg_base + DMA_DW_AXI_CHENREG);
 

--- a/drivers/dma/dma_dw_axi.c
+++ b/drivers/dma/dma_dw_axi.c
@@ -810,7 +810,7 @@ static int dma_dw_axi_stop(const struct device *dev, uint32_t channel)
 
 static int dma_dw_axi_resume(const struct device *dev, uint32_t channel)
 {
-	uint32_t reg;
+	uint64_t reg;
 	uintptr_t reg_base = DEVICE_MMIO_NAMED_GET(dev, dma_mmio);
 	const struct dma_dw_axi_dev_cfg *dw_dma_config = DEV_CFG(dev);
 	uint32_t ch_state;

--- a/drivers/dma/dma_dw_axi.c
+++ b/drivers/dma/dma_dw_axi.c
@@ -861,7 +861,7 @@ static int dma_dw_axi_suspend(const struct device *dev, uint32_t channel)
 	/* suspend dma transfer */
 	sys_write64(CH_SUSP(channel), reg_base + DMA_DW_AXI_CHENREG);
 
-	ret = WAIT_FOR(dma_dw_axi_get_ch_status(dev, channel) &
+	ret = WAIT_FOR(dma_dw_axi_get_ch_status(dev, channel) ==
 			DMA_DW_AXI_CH_SUSPENDED, CONFIG_DMA_CHANNEL_STATUS_TIMEOUT,
 			k_busy_wait(10));
 	if (ret == 0) {

--- a/drivers/dma/dma_dw_axi.c
+++ b/drivers/dma/dma_dw_axi.c
@@ -81,16 +81,17 @@ LOG_MODULE_REGISTER(dma_designware_axi, CONFIG_DMA_LOG_LEVEL);
 #define DMA_DW_AXI_AXPROT   (DMA_DW_AXI_AXPROT_NON_SECURE)
 
 /* Channel enable by setting ch_en and ch_en_we */
-#define CH_EN(chan)    (BIT64(8 + chan) | BIT64(chan))
+#define CH_EN_BIT(chan)    BIT64(chan)
+#define CH_EN_WE(chan)     BIT64(8 + chan)
+#define CH_EN(chan)        (CH_EN_WE(chan) | CH_EN_BIT(chan))
 /* Channel enable by setting ch_susp and ch_susp_we */
-#define CH_SUSP(chan)  (BIT64(24 + chan) | BIT64(16 + chan))
+#define CH_SUSP_BIT(chan)  BIT64(16 + chan)
+#define CH_SUSP_WE(chan)   BIT64(24 + chan)
+#define CH_SUSP(chan)      (CH_SUSP_WE(chan) | CH_SUSP_BIT(chan))
 /* Channel enable by setting ch_abort and ch_abort_we */
-#define CH_ABORT(chan) (BIT64(40 + chan) | BIT64(32 + chan))
-
-/* channel susp/resume write enable pos */
-#define CH_RESUME_WE(chan) (BIT64(24 + chan))
-/* channel resume bit pos */
-#define CH_RESUME(chan)    (BIT64(16 + chan))
+#define CH_ABORT_BIT(chan) BIT64(32 + chan)
+#define CH_ABORT_WE(chan)  BIT64(40 + chan)
+#define CH_ABORT(chan)     (CH_ABORT_WE(chan) | CH_ABORT_BIT(chan))
 
 #define DMA_DW_AXI_CHAN_OFFSET(chan)             (0x100 * chan)
 
@@ -311,21 +312,18 @@ struct dma_dw_axi_dev_cfg {
  */
 static uint32_t dma_dw_axi_get_ch_status(const struct device *dev, uint32_t ch)
 {
-	uint32_t bit_status;
 	uint64_t ch_status;
 	uintptr_t reg_base = DEVICE_MMIO_NAMED_GET(dev, dma_mmio);
 
 	ch_status = sys_read64(reg_base + DMA_DW_AXI_CHENREG);
 
 	/* channel is active/busy in the dma transfer */
-	bit_status = ((ch_status >> ch) & 1);
-	if (bit_status) {
+	if ((ch_status & CH_EN_BIT(ch)) {
 		return DMA_DW_AXI_CH_ACTIVE;
 	}
 
 	/* channel is currently suspended */
-	bit_status = ((ch_status >> (16 + ch)) & 1);
-	if (bit_status) {
+	if ((ch_status & CH_SUSP_BIT(ch)) {
 		return DMA_DW_AXI_CH_SUSPENDED;
 	}
 
@@ -790,14 +788,14 @@ static int dma_dw_axi_stop(const struct device *dev, uint32_t channel)
 	/* Try to disable the channel */
 	sys_clear_bit(reg_base + DMA_DW_AXI_CHENREG, channel);
 
-	is_channel_busy = WAIT_FOR((sys_read64(reg_base + DMA_DW_AXI_CHENREG)) & (BIT(channel)),
+	is_channel_busy = WAIT_FOR((sys_read64(reg_base + DMA_DW_AXI_CHENREG)) & CH_EN_BIT(channel),
 						CONFIG_DMA_CHANNEL_STATUS_TIMEOUT, k_busy_wait(10));
 	if (is_channel_busy) {
 		LOG_WRN("No response from handshaking interface... Aborting a channel...");
 		sys_write64(CH_ABORT(channel), reg_base + DMA_DW_AXI_CHENREG);
 
 		is_channel_busy = WAIT_FOR((sys_read64(reg_base + DMA_DW_AXI_CHENREG)) &
-				(BIT(channel)), CONFIG_DMA_CHANNEL_STATUS_TIMEOUT,
+				CH_EN_BIT(channel), CONFIG_DMA_CHANNEL_STATUS_TIMEOUT,
 				k_busy_wait(10));
 		if (is_channel_busy) {
 			LOG_ERR("Channel abort failed");
@@ -829,9 +827,9 @@ static int dma_dw_axi_resume(const struct device *dev, uint32_t channel)
 
 	reg = sys_read64(reg_base + DMA_DW_AXI_CHENREG);
 	/* channel susp write enable bit has to be asserted */
-	reg |= CH_RESUME_WE(channel);
+	reg |= CH_SUSP_WE(channel);
 	/* channel susp bit must be cleared to resume a channel*/
-	reg &= ~CH_RESUME(channel);
+	reg &= ~CH_SUSP_BIT(channel);
 	/* resume a channel by writing 0: ch_susp and 1: ch_susp_we */
 	sys_write64(reg, reg_base + DMA_DW_AXI_CHENREG);
 

--- a/drivers/dma/dma_dw_axi.c
+++ b/drivers/dma/dma_dw_axi.c
@@ -414,9 +414,9 @@ static void dma_dw_axi_isr(const struct device *dev)
 				reg_base + DMA_DW_AXI_CH_INTCLEARREG(channel));
 
 		if (chan_data->dma_xfer_callback) {
+			atomic_set(&chan_data->ch_state, dma_dw_axi_get_ch_status(dev, channel));
 			chan_data->dma_xfer_callback(dev, chan_data->priv_data_xfer,
 						channel, ret_status);
-			atomic_set(&chan_data->ch_state, dma_dw_axi_get_ch_status(dev, channel));
 		}
 	}
 }

--- a/drivers/dma/dma_dw_axi.c
+++ b/drivers/dma/dma_dw_axi.c
@@ -875,7 +875,7 @@ static int dma_dw_axi_suspend(const struct device *dev, uint32_t channel)
 static int dma_dw_axi_init(const struct device *dev)
 {
 	DEVICE_MMIO_NAMED_MAP(dev, dma_mmio, K_MEM_CACHE_NONE);
-	int i, ret;
+	int i;
 	struct dma_dw_axi_ch_data *chan_data;
 	const struct dma_dw_axi_dev_cfg *dw_dma_config = DEV_CFG(dev);
 	struct dma_dw_axi_dev_data *const dw_dev_data = DEV_DATA(dev);
@@ -883,6 +883,8 @@ static int dma_dw_axi_init(const struct device *dev)
 #if DMA_DW_AXI_RESET_SUPPORTED
 
 	if (dw_dma_config->reset.dev != NULL) {
+		int ret;
+
 	/* check if reset manager is in ready state */
 		if (!device_is_ready(dw_dma_config->reset.dev)) {
 			LOG_ERR("reset controller device not found");

--- a/drivers/dma/dma_dw_axi.c
+++ b/drivers/dma/dma_dw_axi.c
@@ -319,12 +319,13 @@ static uint32_t dma_dw_axi_get_ch_status(const struct device *dev, uint32_t ch)
 
 	/* channel is active/busy in the dma transfer */
 	if ((ch_status & CH_EN_BIT(ch)) {
-		return DMA_DW_AXI_CH_ACTIVE;
-	}
 
-	/* channel is currently suspended */
-	if ((ch_status & CH_SUSP_BIT(ch)) {
-		return DMA_DW_AXI_CH_SUSPENDED;
+		/* channel is currently suspended */
+		if ((ch_status & CH_SUSP_BIT(ch)) {
+			return DMA_DW_AXI_CH_SUSPENDED;
+		}
+
+		return DMA_DW_AXI_CH_ACTIVE;
 	}
 
 	/* channel is idle */

--- a/drivers/dma/dma_dw_axi.c
+++ b/drivers/dma/dma_dw_axi.c
@@ -37,6 +37,8 @@ LOG_MODULE_REGISTER(dma_designware_axi, CONFIG_DMA_LOG_LEVEL);
 #define DMA_DW_AXI_COMPVERREG                    0x08
 #define DMA_DW_AXI_CFGREG                        0x10
 #define DMA_DW_AXI_CHENREG                       0x18
+#define DMA_DW_AXI_CHSUSPREG                     0x20
+#define DMA_DW_AXI_CHABORTREG                    0x28
 #define DMA_DW_AXI_INTSTATUSREG                  0x30
 #define DMA_DW_AXI_COMMONREG_INTCLEARREG         0x38
 #define DMA_DW_AXI_COMMONREG_INTSTATUS_ENABLEREG 0x40
@@ -82,6 +84,7 @@ LOG_MODULE_REGISTER(dma_designware_axi, CONFIG_DMA_LOG_LEVEL);
 
 /* Channel enable by setting ch_en and ch_en_we */
 #define CH_EN_BIT(chan)    BIT64(chan)
+#define CH_EN_BIT_N(chan)  (chan)
 #define CH_EN_WE(chan)     BIT64(8 + chan)
 #define CH_EN(chan)        (CH_EN_WE(chan) | CH_EN_BIT(chan))
 /* Channel enable by setting ch_susp and ch_susp_we */
@@ -92,6 +95,14 @@ LOG_MODULE_REGISTER(dma_designware_axi, CONFIG_DMA_LOG_LEVEL);
 #define CH_ABORT_BIT(chan) BIT64(32 + chan)
 #define CH_ABORT_WE(chan)  BIT64(40 + chan)
 #define CH_ABORT(chan)     (CH_ABORT_WE(chan) | CH_ABORT_BIT(chan))
+
+/* Extended registers for ch_num >= 16 */
+#define CH_EXT_WE(chan)    ((chan < 16) ? BIT64(16 + chan) : BIT64(32 + chan))
+#define CH_EXT_BIT(chan)   ((chan < 16) ? BIT64(chan)      : BIT64(16 + chan))
+#define CH_EXT_BIT_N(chan) ((chan < 16) ? chan : 16 + chan)
+#define CH_EXT_EN(chan)    (CH_EXT_WE(chan) | CH_EXT_BIT(chan))
+#define CH_EXT_SUSP(chan)  CH_EXT_EN(chan)
+#define CH_EXT_ABORT(chan) CH_EXT_EN(chan)
 
 #define DMA_DW_AXI_CHAN_OFFSET(chan)             (0x100 * chan)
 
@@ -302,6 +313,11 @@ struct dma_dw_axi_dev_cfg {
 	uint32_t max_channel;
 };
 
+static inline bool dma_dw_axi_is_split_regs(const struct dma_dw_axi_dev_cfg *config)
+{
+	return config->max_channel > 8;
+}
+
 /**
  * @brief get current status of the channel
  *
@@ -314,14 +330,25 @@ static uint32_t dma_dw_axi_get_ch_status(const struct device *dev, uint32_t ch)
 {
 	uint64_t ch_status;
 	uintptr_t reg_base = DEVICE_MMIO_NAMED_GET(dev, dma_mmio);
+	const struct dma_dw_axi_dev_cfg *dw_dma_config = DEV_CFG(dev);
+	bool is_active, is_suspend;
 
-	ch_status = sys_read64(reg_base + DMA_DW_AXI_CHENREG);
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		ch_status = sys_read64(reg_base + DMA_DW_AXI_CHENREG);
+		is_active  = !!(ch_status & CH_EXT_BIT(ch));
+		ch_status = sys_read64(reg_base + DMA_DW_AXI_CHSUSPREG);
+		is_suspend = !!(ch_status & CH_EXT_BIT(ch));
+	} else {
+		ch_status = sys_read64(reg_base + DMA_DW_AXI_CHENREG);
+		is_active  = !!(ch_status & CH_EN_BIT(ch));
+		is_suspend = !!(ch_status & CH_SUSP_BIT(ch));
+	}
 
 	/* channel is active/busy in the dma transfer */
-	if ((ch_status & CH_EN_BIT(ch)) {
+	if (is_active) {
 
 		/* channel is currently suspended */
-		if ((ch_status & CH_SUSP_BIT(ch)) {
+		if (is_suspend) {
 			return DMA_DW_AXI_CH_SUSPENDED;
 		}
 
@@ -702,6 +729,7 @@ static int dma_dw_axi_start(const struct device *dev, uint32_t channel)
 	struct dma_dw_axi_dev_data *const dw_dev_data = DEV_DATA(dev);
 	const struct dma_dw_axi_dev_cfg *dw_dma_config = DEV_CFG(dev);
 	uintptr_t reg_base = DEVICE_MMIO_NAMED_GET(dev, dma_mmio);
+	uint64_t mask;
 
 	/* validate channel number */
 	if (channel > dw_dma_config->max_channel - 1) {
@@ -751,8 +779,15 @@ static int dma_dw_axi_start(const struct device *dev, uint32_t channel)
 #endif
 
 	/* Enable the channel which will initiate DMA transfer */
-	sys_write64(CH_EN(channel), reg_base + DMA_DW_AXI_CHENREG);
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		mask = CH_EXT_EN(channel);
+	} else {
+		mask = CH_EN(channel);
+	}
+	sys_write64(mask, reg_base + DMA_DW_AXI_CHENREG);
+
 	atomic_set(&chan_data->ch_state, dma_dw_axi_get_ch_status(dev, channel));
+
 	return 0;
 }
 
@@ -762,6 +797,9 @@ static int dma_dw_axi_stop(const struct device *dev, uint32_t channel)
 	uint32_t ch_state;
 	const struct dma_dw_axi_dev_cfg *dw_dma_config = DEV_CFG(dev);
 	uintptr_t reg_base = DEVICE_MMIO_NAMED_GET(dev, dma_mmio);
+	uint32_t reg_offset;
+	uint64_t mask;
+	int bit;
 
 	/* channel should be valid */
 	if (channel > dw_dma_config->max_channel - 1) {
@@ -784,19 +822,48 @@ static int dma_dw_axi_stop(const struct device *dev, uint32_t channel)
 	 * Flush out FIFO and data will be lost. Then corresponding interrupt will
 	 * be raised for abort and CH_EN bit will be cleared from CHENREG register
 	 */
-	sys_write64(CH_SUSP(channel), reg_base + DMA_DW_AXI_CHENREG);
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		mask = CH_EXT_SUSP(channel);
+		reg_offset = DMA_DW_AXI_CHSUSPREG;
+	} else {
+		mask = CH_SUSP(channel);
+		reg_offset = DMA_DW_AXI_CHENREG;
+	}
+	sys_write64(mask, reg_base + reg_offset);
 
 	/* Try to disable the channel */
-	sys_clear_bit(reg_base + DMA_DW_AXI_CHENREG, channel);
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		bit = CH_EXT_BIT_N(channel);
+	} else {
+		bit = CH_EN_BIT_N(channel);
+	}
+	sys_clear_bit(reg_base + DMA_DW_AXI_CHENREG, bit);
 
-	is_channel_busy = WAIT_FOR((sys_read64(reg_base + DMA_DW_AXI_CHENREG)) & CH_EN_BIT(channel),
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		mask = CH_EXT_BIT(channel);
+	} else {
+		mask = CH_EN_BIT(channel);
+	}
+	is_channel_busy = WAIT_FOR((sys_read64(reg_base + DMA_DW_AXI_CHENREG)) & mask,
 						CONFIG_DMA_CHANNEL_STATUS_TIMEOUT, k_busy_wait(10));
 	if (is_channel_busy) {
 		LOG_WRN("No response from handshaking interface... Aborting a channel...");
-		sys_write64(CH_ABORT(channel), reg_base + DMA_DW_AXI_CHENREG);
+		if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+			mask = CH_EXT_ABORT(channel);
+			reg_offset = DMA_DW_AXI_CHABORTREG;
+		} else {
+			mask = CH_ABORT(channel);
+			reg_offset = DMA_DW_AXI_CHENREG;
+		}
+		sys_write64(mask, reg_base + reg_offset);
 
+		if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+			mask = CH_EXT_BIT(channel);
+		} else {
+			mask = CH_EN_BIT(channel);
+		}
 		is_channel_busy = WAIT_FOR((sys_read64(reg_base + DMA_DW_AXI_CHENREG)) &
-				CH_EN_BIT(channel), CONFIG_DMA_CHANNEL_STATUS_TIMEOUT,
+				mask, CONFIG_DMA_CHANNEL_STATUS_TIMEOUT,
 				k_busy_wait(10));
 		if (is_channel_busy) {
 			LOG_ERR("Channel abort failed");
@@ -813,6 +880,8 @@ static int dma_dw_axi_resume(const struct device *dev, uint32_t channel)
 	uintptr_t reg_base = DEVICE_MMIO_NAMED_GET(dev, dma_mmio);
 	const struct dma_dw_axi_dev_cfg *dw_dma_config = DEV_CFG(dev);
 	uint32_t ch_state;
+	uint32_t reg_offset;
+	uint64_t we_mask, bit_mask;
 
 	/* channel should be valid */
 	if (channel > dw_dma_config->max_channel - 1) {
@@ -826,13 +895,22 @@ static int dma_dw_axi_resume(const struct device *dev, uint32_t channel)
 		return 0;
 	}
 
-	reg = sys_read64(reg_base + DMA_DW_AXI_CHENREG);
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		reg_offset = DMA_DW_AXI_CHSUSPREG;
+		we_mask = CH_EXT_WE(channel);
+		bit_mask = CH_EXT_BIT(channel);
+	} else {
+		reg_offset = DMA_DW_AXI_CHENREG;
+		we_mask = CH_SUSP_WE(channel);
+		bit_mask = CH_SUSP_BIT(channel);
+	}
+	reg = sys_read64(reg_base + reg_offset);
 	/* channel susp write enable bit has to be asserted */
-	reg |= CH_SUSP_WE(channel);
+	reg |= we_mask;
 	/* channel susp bit must be cleared to resume a channel*/
-	reg &= ~CH_SUSP_BIT(channel);
+	reg &= ~bit_mask;
 	/* resume a channel by writing 0: ch_susp and 1: ch_susp_we */
-	sys_write64(reg, reg_base + DMA_DW_AXI_CHENREG);
+	sys_write64(reg, reg_base + reg_offset);
 
 	return 0;
 }
@@ -844,6 +922,8 @@ static int dma_dw_axi_suspend(const struct device *dev, uint32_t channel)
 	uintptr_t reg_base = DEVICE_MMIO_NAMED_GET(dev, dma_mmio);
 	const struct dma_dw_axi_dev_cfg *dw_dma_config = DEV_CFG(dev);
 	uint32_t ch_state;
+	uint32_t reg_offset;
+	uint64_t mask;
 
 	/* channel should be valid */
 	if (channel > dw_dma_config->max_channel - 1) {
@@ -858,7 +938,14 @@ static int dma_dw_axi_suspend(const struct device *dev, uint32_t channel)
 	}
 
 	/* suspend dma transfer */
-	sys_write64(CH_SUSP(channel), reg_base + DMA_DW_AXI_CHENREG);
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		reg_offset = DMA_DW_AXI_CHSUSPREG;
+		mask = CH_EXT_SUSP(channel);
+	} else {
+		reg_offset = DMA_DW_AXI_CHENREG;
+		mask = CH_SUSP(channel);
+	}
+	sys_write64(mask, reg_base + reg_offset);
 
 	ret = WAIT_FOR(dma_dw_axi_get_ch_status(dev, channel) ==
 			DMA_DW_AXI_CH_SUSPENDED, CONFIG_DMA_CHANNEL_STATUS_TIMEOUT,

--- a/drivers/dma/dma_dw_axi.c
+++ b/drivers/dma/dma_dw_axi.c
@@ -319,12 +319,13 @@ static uint32_t dma_dw_axi_get_ch_status(const struct device *dev, uint32_t ch)
 
 	/* channel is active/busy in the dma transfer */
 	if (ch_status & CH_EN_BIT(ch)) {
-		return DMA_DW_AXI_CH_ACTIVE;
-	}
 
-	/* channel is currently suspended */
-	if (ch_status & CH_SUSP_BIT(ch)) {
-		return DMA_DW_AXI_CH_SUSPENDED;
+		/* channel is currently suspended */
+		if (ch_status & CH_SUSP_BIT(ch)) {
+			return DMA_DW_AXI_CH_SUSPENDED;
+		}
+
+		return DMA_DW_AXI_CH_ACTIVE;
 	}
 
 	/* channel is idle */

--- a/drivers/dma/dma_dw_axi.c
+++ b/drivers/dma/dma_dw_axi.c
@@ -37,6 +37,8 @@ LOG_MODULE_REGISTER(dma_designware_axi, CONFIG_DMA_LOG_LEVEL);
 #define DMA_DW_AXI_COMPVERREG                    0x08
 #define DMA_DW_AXI_CFGREG                        0x10
 #define DMA_DW_AXI_CHENREG                       0x18
+#define DMA_DW_AXI_CHSUSPREG                     0x20
+#define DMA_DW_AXI_CHABORTREG                    0x28
 #define DMA_DW_AXI_INTSTATUSREG                  0x30
 #define DMA_DW_AXI_COMMONREG_INTCLEARREG         0x38
 #define DMA_DW_AXI_COMMONREG_INTSTATUS_ENABLEREG 0x40
@@ -82,6 +84,7 @@ LOG_MODULE_REGISTER(dma_designware_axi, CONFIG_DMA_LOG_LEVEL);
 
 /* Channel enable by setting ch_en and ch_en_we */
 #define CH_EN_BIT(chan)    BIT64(chan)
+#define CH_EN_BIT_N(chan)  (chan)
 #define CH_EN_WE(chan)     BIT64(8 + chan)
 #define CH_EN(chan)        (CH_EN_WE(chan) | CH_EN_BIT(chan))
 /* Channel enable by setting ch_susp and ch_susp_we */
@@ -92,6 +95,14 @@ LOG_MODULE_REGISTER(dma_designware_axi, CONFIG_DMA_LOG_LEVEL);
 #define CH_ABORT_BIT(chan) BIT64(32 + chan)
 #define CH_ABORT_WE(chan)  BIT64(40 + chan)
 #define CH_ABORT(chan)     (CH_ABORT_WE(chan) | CH_ABORT_BIT(chan))
+
+/* Extended registers for ch_num >= 16 */
+#define CH_EXT_WE(chan)    ((chan < 16) ? BIT64(16 + chan) : BIT64(32 + chan))
+#define CH_EXT_BIT(chan)   ((chan < 16) ? BIT64(chan)      : BIT64(16 + chan))
+#define CH_EXT_BIT_N(chan) ((chan < 16) ? chan : 16 + chan)
+#define CH_EXT_EN(chan)    (CH_EXT_WE(chan) | CH_EXT_BIT(chan))
+#define CH_EXT_SUSP(chan)  CH_EXT_EN(chan)
+#define CH_EXT_ABORT(chan) CH_EXT_EN(chan)
 
 #define DMA_DW_AXI_CHAN_OFFSET(chan)             (0x100 * chan)
 
@@ -302,6 +313,11 @@ struct dma_dw_axi_dev_cfg {
 	uint32_t max_channel;
 };
 
+static inline bool dma_dw_axi_is_split_regs(const struct dma_dw_axi_dev_cfg *config)
+{
+	return config->max_channel > 8;
+}
+
 /**
  * @brief get current status of the channel
  *
@@ -314,14 +330,25 @@ static uint32_t dma_dw_axi_get_ch_status(const struct device *dev, uint32_t ch)
 {
 	uint64_t ch_status;
 	uintptr_t reg_base = DEVICE_MMIO_NAMED_GET(dev, dma_mmio);
+	const struct dma_dw_axi_dev_cfg *dw_dma_config = DEV_CFG(dev);
+	bool is_active, is_suspend;
 
-	ch_status = sys_read64(reg_base + DMA_DW_AXI_CHENREG);
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		ch_status = sys_read64(reg_base + DMA_DW_AXI_CHENREG);
+		is_active  = !!(ch_status & CH_EXT_BIT(ch));
+		ch_status = sys_read64(reg_base + DMA_DW_AXI_CHSUSPREG);
+		is_suspend = !!(ch_status & CH_EXT_BIT(ch));
+	} else {
+		ch_status = sys_read64(reg_base + DMA_DW_AXI_CHENREG);
+		is_active  = !!(ch_status & CH_EN_BIT(ch));
+		is_suspend = !!(ch_status & CH_SUSP_BIT(ch));
+	}
 
 	/* channel is active/busy in the dma transfer */
-	if (ch_status & CH_EN_BIT(ch)) {
+	if (is_active) {
 
 		/* channel is currently suspended */
-		if (ch_status & CH_SUSP_BIT(ch)) {
+		if (is_suspend) {
 			return DMA_DW_AXI_CH_SUSPENDED;
 		}
 
@@ -702,6 +729,7 @@ static int dma_dw_axi_start(const struct device *dev, uint32_t channel)
 	struct dma_dw_axi_dev_data *const dw_dev_data = DEV_DATA(dev);
 	const struct dma_dw_axi_dev_cfg *dw_dma_config = DEV_CFG(dev);
 	uintptr_t reg_base = DEVICE_MMIO_NAMED_GET(dev, dma_mmio);
+	uint64_t mask;
 
 	/* validate channel number */
 	if (channel > dw_dma_config->max_channel - 1) {
@@ -751,8 +779,15 @@ static int dma_dw_axi_start(const struct device *dev, uint32_t channel)
 #endif
 
 	/* Enable the channel which will initiate DMA transfer */
-	sys_write64(CH_EN(channel), reg_base + DMA_DW_AXI_CHENREG);
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		mask = CH_EXT_EN(channel);
+	} else {
+		mask = CH_EN(channel);
+	}
+	sys_write64(mask, reg_base + DMA_DW_AXI_CHENREG);
+
 	atomic_set(&chan_data->ch_state, dma_dw_axi_get_ch_status(dev, channel));
+
 	return 0;
 }
 
@@ -762,6 +797,9 @@ static int dma_dw_axi_stop(const struct device *dev, uint32_t channel)
 	uint32_t ch_state;
 	const struct dma_dw_axi_dev_cfg *dw_dma_config = DEV_CFG(dev);
 	uintptr_t reg_base = DEVICE_MMIO_NAMED_GET(dev, dma_mmio);
+	uint32_t reg_offset;
+	uint64_t mask;
+	int bit;
 
 	/* channel should be valid */
 	if (channel > dw_dma_config->max_channel - 1) {
@@ -784,19 +822,48 @@ static int dma_dw_axi_stop(const struct device *dev, uint32_t channel)
 	 * Flush out FIFO and data will be lost. Then corresponding interrupt will
 	 * be raised for abort and CH_EN bit will be cleared from CHENREG register
 	 */
-	sys_write64(CH_SUSP(channel), reg_base + DMA_DW_AXI_CHENREG);
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		mask = CH_EXT_SUSP(channel);
+		reg_offset = DMA_DW_AXI_CHSUSPREG;
+	} else {
+		mask = CH_SUSP(channel);
+		reg_offset = DMA_DW_AXI_CHENREG;
+	}
+	sys_write64(mask, reg_base + reg_offset);
 
 	/* Try to disable the channel */
-	sys_clear_bit(reg_base + DMA_DW_AXI_CHENREG, channel);
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		bit = CH_EXT_BIT_N(channel);
+	} else {
+		bit = CH_EN_BIT_N(channel);
+	}
+	sys_clear_bit(reg_base + DMA_DW_AXI_CHENREG, bit);
 
-	is_channel_busy = WAIT_FOR((sys_read64(reg_base + DMA_DW_AXI_CHENREG)) & CH_EN_BIT(channel),
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		mask = CH_EXT_BIT(channel);
+	} else {
+		mask = CH_EN_BIT(channel);
+	}
+	is_channel_busy = WAIT_FOR((sys_read64(reg_base + DMA_DW_AXI_CHENREG)) & mask,
 						CONFIG_DMA_CHANNEL_STATUS_TIMEOUT, k_busy_wait(10));
 	if (is_channel_busy) {
 		LOG_WRN("No response from handshaking interface... Aborting a channel...");
-		sys_write64(CH_ABORT(channel), reg_base + DMA_DW_AXI_CHENREG);
+		if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+			mask = CH_EXT_ABORT(channel);
+			reg_offset = DMA_DW_AXI_CHABORTREG;
+		} else {
+			mask = CH_ABORT(channel);
+			reg_offset = DMA_DW_AXI_CHENREG;
+		}
+		sys_write64(mask, reg_base + reg_offset);
 
+		if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+			mask = CH_EXT_BIT(channel);
+		} else {
+			mask = CH_EN_BIT(channel);
+		}
 		is_channel_busy = WAIT_FOR((sys_read64(reg_base + DMA_DW_AXI_CHENREG)) &
-				CH_EN_BIT(channel), CONFIG_DMA_CHANNEL_STATUS_TIMEOUT,
+				mask, CONFIG_DMA_CHANNEL_STATUS_TIMEOUT,
 				k_busy_wait(10));
 		if (is_channel_busy) {
 			LOG_ERR("Channel abort failed");
@@ -813,6 +880,8 @@ static int dma_dw_axi_resume(const struct device *dev, uint32_t channel)
 	uintptr_t reg_base = DEVICE_MMIO_NAMED_GET(dev, dma_mmio);
 	const struct dma_dw_axi_dev_cfg *dw_dma_config = DEV_CFG(dev);
 	uint32_t ch_state;
+	uint32_t reg_offset;
+	uint64_t we_mask, bit_mask;
 
 	/* channel should be valid */
 	if (channel > dw_dma_config->max_channel - 1) {
@@ -826,13 +895,22 @@ static int dma_dw_axi_resume(const struct device *dev, uint32_t channel)
 		return 0;
 	}
 
-	reg = sys_read64(reg_base + DMA_DW_AXI_CHENREG);
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		reg_offset = DMA_DW_AXI_CHSUSPREG;
+		we_mask = CH_EXT_WE(channel);
+		bit_mask = CH_EXT_BIT(channel);
+	} else {
+		reg_offset = DMA_DW_AXI_CHENREG;
+		we_mask = CH_SUSP_WE(channel);
+		bit_mask = CH_SUSP_BIT(channel);
+	}
+	reg = sys_read64(reg_base + reg_offset);
 	/* channel susp write enable bit has to be asserted */
-	reg |= CH_SUSP_WE(channel);
+	reg |= we_mask;
 	/* channel susp bit must be cleared to resume a channel*/
-	reg &= ~CH_SUSP_BIT(channel);
+	reg &= ~bit_mask;
 	/* resume a channel by writing 0: ch_susp and 1: ch_susp_we */
-	sys_write64(reg, reg_base + DMA_DW_AXI_CHENREG);
+	sys_write64(reg, reg_base + reg_offset);
 
 	return 0;
 }
@@ -844,6 +922,8 @@ static int dma_dw_axi_suspend(const struct device *dev, uint32_t channel)
 	uintptr_t reg_base = DEVICE_MMIO_NAMED_GET(dev, dma_mmio);
 	const struct dma_dw_axi_dev_cfg *dw_dma_config = DEV_CFG(dev);
 	uint32_t ch_state;
+	uint32_t reg_offset;
+	uint64_t mask;
 
 	/* channel should be valid */
 	if (channel > dw_dma_config->max_channel - 1) {
@@ -858,7 +938,14 @@ static int dma_dw_axi_suspend(const struct device *dev, uint32_t channel)
 	}
 
 	/* suspend dma transfer */
-	sys_write64(CH_SUSP(channel), reg_base + DMA_DW_AXI_CHENREG);
+	if (dma_dw_axi_is_split_regs(dw_dma_config)) {
+		reg_offset = DMA_DW_AXI_CHSUSPREG;
+		mask = CH_EXT_SUSP(channel);
+	} else {
+		reg_offset = DMA_DW_AXI_CHENREG;
+		mask = CH_SUSP(channel);
+	}
+	sys_write64(mask, reg_base + reg_offset);
 
 	ret = WAIT_FOR(dma_dw_axi_get_ch_status(dev, channel) ==
 			DMA_DW_AXI_CH_SUSPENDED, CONFIG_DMA_CHANNEL_STATUS_TIMEOUT,

--- a/drivers/dma/dma_dw_axi.c
+++ b/drivers/dma/dma_dw_axi.c
@@ -81,16 +81,17 @@ LOG_MODULE_REGISTER(dma_designware_axi, CONFIG_DMA_LOG_LEVEL);
 #define DMA_DW_AXI_AXPROT   (DMA_DW_AXI_AXPROT_NON_SECURE)
 
 /* Channel enable by setting ch_en and ch_en_we */
-#define CH_EN(chan)    (BIT64(8 + chan) | BIT64(chan))
+#define CH_EN_BIT(chan)    BIT64(chan)
+#define CH_EN_WE(chan)     BIT64(8 + chan)
+#define CH_EN(chan)        (CH_EN_WE(chan) | CH_EN_BIT(chan))
 /* Channel enable by setting ch_susp and ch_susp_we */
-#define CH_SUSP(chan)  (BIT64(24 + chan) | BIT64(16 + chan))
+#define CH_SUSP_BIT(chan)  BIT64(16 + chan)
+#define CH_SUSP_WE(chan)   BIT64(24 + chan)
+#define CH_SUSP(chan)      (CH_SUSP_WE(chan) | CH_SUSP_BIT(chan))
 /* Channel enable by setting ch_abort and ch_abort_we */
-#define CH_ABORT(chan) (BIT64(40 + chan) | BIT64(32 + chan))
-
-/* channel susp/resume write enable pos */
-#define CH_RESUME_WE(chan) (BIT64(24 + chan))
-/* channel resume bit pos */
-#define CH_RESUME(chan)    (BIT64(16 + chan))
+#define CH_ABORT_BIT(chan) BIT64(32 + chan)
+#define CH_ABORT_WE(chan)  BIT64(40 + chan)
+#define CH_ABORT(chan)     (CH_ABORT_WE(chan) | CH_ABORT_BIT(chan))
 
 #define DMA_DW_AXI_CHAN_OFFSET(chan)             (0x100 * chan)
 
@@ -311,21 +312,18 @@ struct dma_dw_axi_dev_cfg {
  */
 static uint32_t dma_dw_axi_get_ch_status(const struct device *dev, uint32_t ch)
 {
-	uint32_t bit_status;
 	uint64_t ch_status;
 	uintptr_t reg_base = DEVICE_MMIO_NAMED_GET(dev, dma_mmio);
 
 	ch_status = sys_read64(reg_base + DMA_DW_AXI_CHENREG);
 
 	/* channel is active/busy in the dma transfer */
-	bit_status = ((ch_status >> ch) & 1);
-	if (bit_status) {
+	if (ch_status & CH_EN_BIT(ch)) {
 		return DMA_DW_AXI_CH_ACTIVE;
 	}
 
 	/* channel is currently suspended */
-	bit_status = ((ch_status >> (16 + ch)) & 1);
-	if (bit_status) {
+	if (ch_status & CH_SUSP_BIT(ch)) {
 		return DMA_DW_AXI_CH_SUSPENDED;
 	}
 
@@ -790,14 +788,14 @@ static int dma_dw_axi_stop(const struct device *dev, uint32_t channel)
 	/* Try to disable the channel */
 	sys_clear_bit(reg_base + DMA_DW_AXI_CHENREG, channel);
 
-	is_channel_busy = WAIT_FOR((sys_read64(reg_base + DMA_DW_AXI_CHENREG)) & (BIT(channel)),
+	is_channel_busy = WAIT_FOR((sys_read64(reg_base + DMA_DW_AXI_CHENREG)) & CH_EN_BIT(channel),
 						CONFIG_DMA_CHANNEL_STATUS_TIMEOUT, k_busy_wait(10));
 	if (is_channel_busy) {
 		LOG_WRN("No response from handshaking interface... Aborting a channel...");
 		sys_write64(CH_ABORT(channel), reg_base + DMA_DW_AXI_CHENREG);
 
 		is_channel_busy = WAIT_FOR((sys_read64(reg_base + DMA_DW_AXI_CHENREG)) &
-				(BIT(channel)), CONFIG_DMA_CHANNEL_STATUS_TIMEOUT,
+				CH_EN_BIT(channel), CONFIG_DMA_CHANNEL_STATUS_TIMEOUT,
 				k_busy_wait(10));
 		if (is_channel_busy) {
 			LOG_ERR("Channel abort failed");
@@ -829,9 +827,9 @@ static int dma_dw_axi_resume(const struct device *dev, uint32_t channel)
 
 	reg = sys_read64(reg_base + DMA_DW_AXI_CHENREG);
 	/* channel susp write enable bit has to be asserted */
-	reg |= CH_RESUME_WE(channel);
+	reg |= CH_SUSP_WE(channel);
 	/* channel susp bit must be cleared to resume a channel*/
-	reg &= ~CH_RESUME(channel);
+	reg &= ~CH_SUSP_BIT(channel);
 	/* resume a channel by writing 0: ch_susp and 1: ch_susp_we */
 	sys_write64(reg, reg_base + DMA_DW_AXI_CHENREG);
 


### PR DESCRIPTION
This series fixes multiple issues in the dw-axi-dma driver, including channel state handling, suspend/resume control, CHENREG access, and callback ordering.

The series also adds support for controllers configured with more than 8 DMA channels, which use a different channel control
register layout for enable, suspend, and abort operations.

Patch summary:
- fix unused variable warning
- fix resume register bit updates
- fix CHENREG read-modify-write truncation
- fix suspended-state checks
- clean up channel control bit definitions
- add support for extended channel control register layouts
- update channel state before invoking callbacks
