### PR TITLE
drivers: bbram: fix data parameter direction in bbram_write docs

### DIFF
--- a/include/zephyr/drivers/bbram.h
+++ b/include/zephyr/drivers/bbram.h
@@ -219,7 +219,7 @@ static inline int z_impl_bbram_read(const struct device *dev, size_t offset,
  * @param[in]  dev The BBRAM device pointer to write to.
  * @param[in]  offset The offset into the RAM address to start writing to.
  * @param[in]  size The number of bytes to write.
- * @param[out] data Pointer to the start of data to write.
+ * @param[in]  data Pointer to the start of data to write.
  * @return 0 on success, -EFAULT if the address range is out of bounds.
  */
 __syscall int bbram_write(const struct device *dev, size_t offset, size_t size,


### PR DESCRIPTION
The data argument of bbram_write() is an input source buffer, so document it as @param[in] rather than @param[out].