### PR TITLE
drivers: dac: fix reversed brief for dac_microvolts_to_raw

### DIFF
--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -595,7 +595,7 @@ static inline int dac_millivolts_to_raw(uint32_t ref_mv, uint8_t resolution, uin
 }
 
 /**
- * @brief Convert a raw DAC value to microvolts.
+ * @brief Convert a microvolts value to a raw DAC value.
  *
  * @see dac_x_to_raw_fn
  */


### PR DESCRIPTION
The dac_microvolts_to_raw() brief described the reverse conversion; state that it converts a microvolts value to a raw DAC value.