### PR TITLE
cmake: snippets: add SNIPPET_POST_CONF_FILE for snippet override

### DIFF
--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -385,15 +385,16 @@ if(EXISTS ${DOTCONFIG} AND EXISTS ${merge_config_files_checksum_file})
   endif()
 endif()
 
+zephyr_get(SNIPPET_POST_CONF_FILE MERGE)
 if(CREATE_NEW_DOTCONFIG)
   if(NOT KCONFIG_VARIANT_SOURCE)
     set(input_configs_flags --handwritten-input-configs)
   endif()
 
-  set(input_configs ${merge_config_files} ${FORCED_CONF_FILE})
+  set(input_configs ${merge_config_files} ${SNIPPET_POST_CONF_FILE} ${FORCED_CONF_FILE})
   build_info(kconfig files PATH ${input_configs})
 else()
-  set(input_configs ${DOTCONFIG} ${FORCED_CONF_FILE})
+  set(input_configs ${DOTCONFIG} ${SNIPPET_POST_CONF_FILE} ${FORCED_CONF_FILE})
 endif()
 
 if(DEFINED FORCED_CONF_FILE)

--- a/scripts/schemas/snippet-schema.yaml
+++ b/scripts/schemas/snippet-schema.yaml
@@ -53,6 +53,12 @@ $defs:
           - type: array
             items:
               type: string
+      SNIPPET_POST_CONF_FILE:
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
       SB_EXTRA_CONF_FILE:
         oneOf:
           - type: string

--- a/scripts/snippets.py
+++ b/scripts/snippets.py
@@ -63,7 +63,10 @@ class Snippet:
         '''Process the data in a snippet.yml file, after it is loaded into a
         python object and validated by jsonschema.'''
         def append_value(variable, value):
-            if variable in ('SB_EXTRA_CONF_FILE', 'EXTRA_DTC_OVERLAY_FILE', 'EXTRA_CONF_FILE'):
+            if variable in (
+                'SB_EXTRA_CONF_FILE', 'EXTRA_DTC_OVERLAY_FILE',
+                'EXTRA_CONF_FILE', 'SNIPPET_POST_CONF_FILE'
+            ):
                 paths = []
                 if not isinstance(value, list):
                     value = [value]


### PR DESCRIPTION
Add SNIPPET_POST_CONF_FILE as a new snippet-specific append variable.
Configs appended via this variable are loaded after all EXTRA_CONF_FILE
entries, allowing vendor/platform snippets to override sample-level
defaults using the standard Kconfig last-wins rule.

Load order:
  CONF_FILE (prj.conf, boards/*.conf)
    -> EXTRA_CONF_FILE (snippet + user)
      -> SNIPPET_POST_CONF_FILE (snippet post-override)

Changes:
- scripts/snippets.py: add SNIPPET_POST_CONF_FILE to allowed variables
- scripts/schemas/snippet-schema.yaml: add SNIPPET_POST_CONF_FILE property
- cmake/modules/kconfig.cmake: retrieve SNIPPET_POST_CONF_FILE from
  snippet scope via zephyr_get() and append after merge_config_files

Fixes: #114147