### PR TITLE
drivers: Typo and copy-paste error fixes in Doxygen comments

### DIFF
--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -1298,6 +1298,8 @@ static inline int z_impl_adc_get_decoder(const struct device *dev,
  * Returns the voltage corresponding to @ref ADC_REF_INTERNAL,
  * measured in millivolts.
  *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
  * @return a positive value is the reference voltage value.  Returns
  * zero if reference voltage information is not available.
  */

--- a/include/zephyr/drivers/bbram.h
+++ b/include/zephyr/drivers/bbram.h
@@ -219,7 +219,7 @@ static inline int z_impl_bbram_read(const struct device *dev, size_t offset,
  * @param[in]  dev The BBRAM device pointer to write to.
  * @param[in]  offset The offset into the RAM address to start writing to.
  * @param[in]  size The number of bytes to write.
- * @param[out] data Pointer to the start of data to write.
+ * @param[in]  data Pointer to the start of data to write.
  * @return 0 on success, -EFAULT if the address range is out of bounds.
  */
 __syscall int bbram_write(const struct device *dev, size_t offset, size_t size,

--- a/include/zephyr/drivers/cache.h
+++ b/include/zephyr/drivers/cache.h
@@ -273,8 +273,8 @@ int cache_instr_flush_and_invd_range(void *addr, size_t size);
  * The function must be implemented only when CONFIG_ICACHE_LINE_SIZE_DETECT is
  * defined.
  *
- * @retval size Size of the d-cache line.
- * @retval 0 The d-cache is not enabled.
+ * @retval size Size of the i-cache line.
+ * @retval 0 The i-cache is not enabled.
  */
 size_t cache_instr_line_size_get(void);
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -459,7 +459,7 @@ typedef int (*can_send_t)(const struct device *dev,
 
 /**
  * @brief Callback API upon adding an RX filter
- * See @a can_add_rx_callback() for argument description
+ * See @a can_add_rx_filter() for argument description
  */
 typedef int (*can_add_rx_filter_t)(const struct device *dev,
 				   can_rx_callback_t callback,

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -595,7 +595,7 @@ static inline int dac_millivolts_to_raw(uint32_t ref_mv, uint8_t resolution, uin
 }
 
 /**
- * @brief Convert a raw DAC value to microvolts.
+ * @brief Convert a microvolts value to a raw DAC value.
  *
  * @see dac_x_to_raw_fn
  */

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -397,7 +397,7 @@ static inline int z_impl_dai_remove(const struct device *dev)
  * The function can be called in NOT_READY or READY state only. If executed
  * successfully the function will change the interface state to READY.
  *
- * If the function is called with the parameter cfg->frame_clk_freq set to 0
+ * If the function is called with the parameter cfg->rate set to 0
  * the interface state will be changed to NOT_READY.
  *
  * @param dev Pointer to the device structure for the driver instance.

--- a/include/zephyr/drivers/emul_fuel_gauge.h
+++ b/include/zephyr/drivers/emul_fuel_gauge.h
@@ -53,7 +53,7 @@ __subsystem struct fuel_gauge_emul_driver_api {
  * @param uA Microamps describing the battery current where negative is discharging.
  *
  * @retval 0 If successful.
- * @retval -EINVAL if mV or mA are 0.
+ * @retval -EINVAL if uV or uA are 0.
  */
 __syscall int emul_fuel_gauge_set_battery_charging(const struct emul *target, uint32_t uV, int uA);
 static inline int z_impl_emul_fuel_gauge_set_battery_charging(const struct emul *target,

--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -1052,7 +1052,7 @@ static inline int z_impl_espi_write_flash(const struct device *dev,
 }
 
 /**
- * @brief Sends a write request packet for shared flash.
+ * @brief Sends an erase request packet for shared flash.
  *
  * This routine provides an interface to send a request to erase the flash
  * components shared between the eSPI controller and eSPI targets.

--- a/include/zephyr/drivers/espi_saf.h
+++ b/include/zephyr/drivers/espi_saf.h
@@ -344,9 +344,9 @@ static inline int z_impl_espi_saf_flash_write(const struct device *dev,
 }
 
 /**
- * @brief Sends a write request packet for slave attached flash.
+ * @brief Sends an erase request packet for slave attached flash.
  *
- * This routines provides an interface to send a request to write to the flash
+ * This routines provides an interface to send a request to erase the flash
  * components shared between the eSPI master and eSPI slaves.
  *
  * @param dev Pointer to the device structure for the driver instance.

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -680,7 +680,7 @@ struct gpio_dt_spec {
  * @param inst @c DT_DRV_COMPAT instance number
  * @param ngpios number of GPIOs
  * @return the bitmask of allowed gpios
- * @see GPIO_DT_NGPIOS_PORT_PIN_MASK_EXC()
+ * @see GPIO_DT_PORT_PIN_MASK_NGPIOS_EXC()
  */
 #define GPIO_DT_INST_PORT_PIN_MASK_NGPIOS_EXC(inst, ngpios)	\
 		GPIO_DT_PORT_PIN_MASK_NGPIOS_EXC(DT_DRV_INST(inst), ngpios)

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -88,12 +88,11 @@ extern "C" {
 
 /**
  * @brief Complete I2C DT information
- *
- * @param bus is the I2C bus
- * @param addr is the target address
  */
 struct i2c_dt_spec {
+	/** I2C bus */
 	const struct device *bus;
+	/** Target address */
 	uint16_t addr;
 };
 
@@ -544,7 +543,7 @@ static inline bool i2c_is_read_op(const struct i2c_msg *msg)
  *
  * @param msg The message to check
  * @retval true The I2C message includes a stop.
- * @retval false The I2C message includes a stop.
+ * @retval false The I2C message does not include a stop.
  */
 static inline bool i2c_is_stop_op(const struct i2c_msg *msg)
 {
@@ -556,7 +555,7 @@ static inline bool i2c_is_stop_op(const struct i2c_msg *msg)
  *
  * @param msg The message to check
  * @return true if the I2C message includes a restart
- * @return false if the I2C message includes a restart
+ * @return false if the I2C message does not include a restart
  */
 static inline bool i2c_is_restart_op(const struct i2c_msg *msg)
 {

--- a/include/zephyr/drivers/i2s.h
+++ b/include/zephyr/drivers/i2s.h
@@ -214,7 +214,7 @@ typedef uint8_t i2s_opt_t;
 #define I2S_OPT_PINGPONG                    BIT(6)
 
 /**
- * @brief I2C Direction
+ * @brief I2S Direction
  */
 enum i2s_dir {
 	/** Receive data */

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -1508,15 +1508,15 @@ static inline int i3c_configure(const struct device *dev,
 }
 #if defined(CONFIG_I3C_CONTROLLER) || defined(__DOXYGEN__)
 /**
- * @brief Get the controller device configuration for an I3C device.
+ * @brief Set the controller device configuration for an I3C device.
  *
- * This function retrieves the configuration parameters specific to an
- * I3C controller device. It is a type-safe wrapper around @ref i3c_config_get
+ * This function applies the configuration parameters specific to an
+ * I3C controller device. It is a type-safe wrapper around @ref i3c_configure
  * that ensures the correct structure type is passed.
  *
  * @param dev Pointer to the I3C controller device instance.
  * @param config Pointer to a @ref i3c_config_controller structure
- *               where the configuration will be stored.
+ *               containing the configuration to apply.
  *
  * @retval 0 on success.
  * @retval -EIO General Input/Output errors.
@@ -1530,15 +1530,15 @@ static inline int i3c_configure_controller(const struct device *dev,
 #endif /* CONFIG_I3C_CONTROLLER */
 #if defined(CONFIG_I3C_TARGET) || defined(__DOXYGEN__)
 /**
- * @brief Get the target device configuration for an I3C device.
+ * @brief Set the target device configuration for an I3C device.
  *
- * This function retrieves the configuration parameters specific to an
- * I3C target device. It is a type-safe wrapper around @ref i3c_config_get
+ * This function applies the configuration parameters specific to an
+ * I3C target device. It is a type-safe wrapper around @ref i3c_configure
  * that ensures the correct structure type is passed.
  *
  * @param dev Pointer to the I3C controller device instance.
  * @param config Pointer to a @ref i3c_config_target structure
- *                    where the configuration will be stored.
+ *                    containing the configuration to apply.
  *
  * @retval 0 on success.
  * @retval -EIO General Input/Output errors.
@@ -1585,7 +1585,7 @@ static inline int i3c_config_get(const struct device *dev,
 /**
  * @brief Get the controller device configuration for an I3C device.
  *
- * This function sets the configuration parameters specific to an
+ * This function gets the configuration parameters specific to an
  * I3C controller device. It is a type-safe wrapper around @ref i3c_config_get
  * that ensures the correct structure type is passed.
  *
@@ -1607,7 +1607,7 @@ static inline int i3c_config_get_controller(const struct device *dev,
 /**
  * @brief Get the target device configuration for an I3C device.
  *
- * This function sets the configuration parameters specific to an
+ * This function gets the configuration parameters specific to an
  * I3C target device. It is a type-safe wrapper around @ref i3c_config_get
  * that ensures the correct structure type is passed.
  *
@@ -2133,7 +2133,7 @@ static inline int i3c_ibi_enable(struct i3c_device_desc *target)
 /**
  * @brief Disable IBI of a target device.
  *
- * This enables IBI of a target device where the IBI has already been
+ * This disables IBI of a target device where the IBI has already been
  * request.
  *
  * @param target I3C target device descriptor.
@@ -2180,7 +2180,7 @@ static inline int i3c_ibi_has_payload(struct i3c_device_desc *target)
  * Note that BCR must have been obtained from device and
  * i3c_device_desc::bcr must be set.
  *
- * @return True if IBI has payload, false otherwise.
+ * @return True if device is IBI capable, false otherwise.
  */
 static inline int i3c_device_is_ibi_capable(struct i3c_device_desc *target)
 {

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -277,6 +277,7 @@ typedef int (*lora_api_recv)(const struct device *dev, uint8_t *data,
  *
  * @param dev Modem to receive data on.
  * @param cb Callback to run on receiving data.
+ * @param user_data User data passed to callback
  */
 typedef int (*lora_api_recv_async)(const struct device *dev, lora_recv_cb cb,
 			     void *user_data);

--- a/include/zephyr/drivers/mbox.h
+++ b/include/zephyr/drivers/mbox.h
@@ -132,7 +132,7 @@ struct mbox_dt_spec {
 	}
 
 /**
- * @brief Instance version of MBOX_DT_CHANNEL_GET()
+ * @brief Instance version of MBOX_DT_SPEC_GET()
  *
  * @param inst @c DT_DRV_COMPAT instance number
  * @param name lowercase-and-underscores name of the mboxes element
@@ -395,7 +395,7 @@ static inline int z_impl_mbox_mtu_get(const struct device *dev)
  *
  * @param spec MBOX specification from devicetree
  *
- * @return See return values for mbox_register_callback()
+ * @return See return values for mbox_mtu_get()
  */
 static inline int mbox_mtu_get_dt(const struct mbox_dt_spec *spec)
 {

--- a/include/zephyr/drivers/mdio.h
+++ b/include/zephyr/drivers/mdio.h
@@ -129,7 +129,7 @@ static inline int z_impl_mdio_write(const struct device *dev, uint8_t prtad,
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  * @retval -ETIMEDOUT If transaction timedout on the bus
- * @retval -ENOSYS if write using Clause 45 access is not supported
+ * @retval -ENOSYS if read using Clause 45 access is not supported
  */
 __syscall int mdio_read_c45(const struct device *dev, uint8_t prtad,
 			    uint8_t devad, uint16_t regad, uint16_t *data);

--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -448,7 +448,7 @@ struct pwm_event_callback;
  * support.
  *
  * @param[in] dev PWM device instance.
- * @param callback Original struct gpio_callback owning this handler.
+ * @param callback Original struct pwm_event_callback owning this handler.
  * @param channel PWM channel.
  * @param events Event mask. See @ref PWM_EVENT_TYPES.
  *

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -513,11 +513,11 @@ static inline unsigned int regulator_count_voltages(const struct device *dev)
  *
  * @param dev Regulator device instance.
  * @param idx Voltage index.
- * @param[out] volt_uv Where voltage for the given @p index will be stored, in
+ * @param[out] volt_uv Where voltage for the given @p idx will be stored, in
  * microvolts.
  *
- * @retval 0 @p index corresponds to a supported voltage.
- * @retval -EINVAL @p index does not correspond to a supported voltage.
+ * @retval 0 @p idx corresponds to a supported voltage.
+ * @retval -EINVAL @p idx does not correspond to a supported voltage.
  */
 static inline int regulator_list_voltage(const struct device *dev,
 					 unsigned int idx, int32_t *volt_uv)
@@ -616,11 +616,11 @@ static inline unsigned int regulator_count_current_limits(const struct device *d
  *
  * @param dev Regulator device instance.
  * @param idx Current index.
- * @param[out] current_ua Where current for the given @p index will be stored, in
+ * @param[out] current_ua Where current for the given @p idx will be stored, in
  * microamps.
  *
- * @retval 0 @p index corresponds to a supported current limit.
- * @retval -EINVAL @p index does not correspond to a supported current limit.
+ * @retval 0 @p idx corresponds to a supported current limit.
+ * @retval -EINVAL @p idx does not correspond to a supported current limit.
  */
 static inline int regulator_list_current_limit(const struct device *dev,
 					       unsigned int idx, int32_t *current_ua)

--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -128,7 +128,7 @@ enum sdhc_timing_mode {
 	SDHC_TIMING_SDR25 = 4U,
 	/*!< High speed mode & SDR25 */
 	SDHC_TIMING_SDR50 = 5U,
-	/*!< SDR49 mode*/
+	/*!< SDR50 mode*/
 	SDHC_TIMING_SDR104 = 6U,
 	/*!< SDR104 mode */
 	SDHC_TIMING_DDR50 = 7U,

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1130,7 +1130,7 @@ static inline int sensor_stream(const struct rtio_iodev *iodev, struct rtio *ctx
 /**
  * @brief Blocking one shot read of samples from a sensor into a buffer
  *
- * Using @p cfg, read data from the device by using the provided RTIO context
+ * Using @p iodev, read data from the device by using the provided RTIO context
  * @p ctx. This call will generate a @ref rtio_sqe that will be given the provided buffer. The call
  * will wait for the read to complete before returning to the caller.
  *
@@ -1173,7 +1173,7 @@ static inline int sensor_read(const struct rtio_iodev *iodev, struct rtio *ctx, 
 /**
  * @brief One shot non-blocking read with pool allocated buffer
  *
- * Using @p cfg, read one snapshot of data from the device by using the provided RTIO context
+ * Using @p iodev, read one snapshot of data from the device by using the provided RTIO context
  * @p ctx. This call will generate a @ref rtio_sqe that will leverage the RTIO's internal
  * mempool when the time comes to service the read.
  *

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -550,7 +550,7 @@ struct spi_dt_spec {
  * spi_dt_spec</tt> by reading the relevant bus, frequency, slave, and cs
  * data from the devicetree.
  *
- * @important Multiple fields are automatically constructed by this macro
+ * @note Multiple fields are automatically constructed by this macro
  * which must be checked before use. @ref spi_is_ready_dt performs the required
  * @ref device_is_ready checks.
  *

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -88,7 +88,7 @@ __subsystem struct syscon_driver_api {
 /**
  * @brief Get the syscon base address
  *
- * @param dev The device to get the register size for.
+ * @param dev The device to get the base address for.
  * @param addr Where to write the base address.
  *
  * @retval 0 When @a addr was written to.
@@ -113,7 +113,7 @@ static inline int z_impl_syscon_get_base(const struct device *dev, uintptr_t *ad
  *
  * This function reads from a specific register in the syscon area
  *
- * @param dev The device to get the register size for.
+ * @param dev The device to read from.
  * @param reg The register offset
  * @param val The returned value read from the syscon register
  *
@@ -139,7 +139,7 @@ static inline int z_impl_syscon_read_reg(const struct device *dev, uint32_t reg,
  *
  * This function writes to a specific register in the syscon area
  *
- * @param dev The device to get the register size for.
+ * @param dev The device to write to.
  * @param reg The register offset
  * @param val The value to be written in the register
  *

--- a/include/zephyr/drivers/w1.h
+++ b/include/zephyr/drivers/w1.h
@@ -264,7 +264,7 @@ static inline int z_impl_w1_write_byte(const struct device *dev, uint8_t byte)
 __syscall int w1_read_block(const struct device *dev, uint8_t *buffer, size_t len);
 
 /**
- * @brief Write a block of data from the 1-Wire bus.
+ * @brief Write a block of data to the 1-Wire bus.
  *
  * @param[in] dev    Pointer to the device structure for the driver instance.
  * @param[in] buffer Pointer to transmitting buffer.
@@ -562,7 +562,7 @@ int w1_write_read(const struct device *dev, const struct w1_slave_config *config
  * Note: Filtering on families is not supported.
  *
  * @param[in] dev       Pointer to the device structure for the driver instance.
- * @param command       Can either be W1_SEARCH_ALARM or W1_SEARCH_ROM.
+ * @param command       Can either be W1_CMD_SEARCH_ALARM or W1_CMD_SEARCH_ROM.
  * @param family        W1_SEARCH_ALL_FAMILIES searcheas all families,
  *                      filtering on a specific family is not yet supported.
  * @param callback      Application callback handler function to be called

--- a/include/zephyr/drivers/wuc.h
+++ b/include/zephyr/drivers/wuc.h
@@ -60,7 +60,7 @@ struct wuc_dt_spec {
  *	         .id = 10
  *	 }
  *
- * The 'wuc' field must still be checked for readiness, e.g. using
+ * The 'dev' field must still be checked for readiness, e.g. using
  * device_is_ready(). It is an error to use this macro unless the node
  * exists, has the given property, and that property specifies a wakeup
  * controller wakeup source id as shown above.


### PR DESCRIPTION
Trivial Doxygen fixes across all main driver headers 