### PR TITLE
net: misc. Doxygen fixes

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -175,7 +175,7 @@ enum coap_response_code {
 	COAP_RESPONSE_CODE_NOT_ACCEPTABLE = COAP_MAKE_RESPONSE_CODE(4, 6),
 	/** 4.08 - Request Entity Incomplete */
 	COAP_RESPONSE_CODE_INCOMPLETE = COAP_MAKE_RESPONSE_CODE(4, 8),
-	/** 4.12 - Precondition Failed */
+	/** 4.09 - Conflict */
 	COAP_RESPONSE_CODE_CONFLICT = COAP_MAKE_RESPONSE_CODE(4, 9),
 	/** 4.12 - Precondition Failed */
 	COAP_RESPONSE_CODE_PRECONDITION_FAILED = COAP_MAKE_RESPONSE_CODE(4, 12),
@@ -1189,8 +1189,8 @@ struct coap_reply *coap_reply_next_unused(
  * coap_pending_clear().
  *
  * @param response The received response
- * @param pendings Pointer to the array of #coap_reply structures
- * @param len Size of the array of #coap_reply structures
+ * @param pendings Pointer to the array of #coap_pending structures
+ * @param len Size of the array of #coap_pending structures
  *
  * @return pointer to the associated #coap_pending structure, NULL in
  * case none could be found.

--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -101,7 +101,7 @@ typedef void (*coap_client_response_cb_t)(const struct coap_client_response_data
  * payload pointer, payload size and information whether more data blocks are expected.
  * Setting the @p last_block parameter to false on the initial callback call triggers
  * a block transfer upload. The library will keep calling the callback until the
- * @p last_block parameter is set to false.
+ * @p last_block parameter is set to true.
  *
  * @note If block transfer is used, the application is expected to provide full blocks of
  * payload. Only the final block (i.e. when @p last_block is set to true) can be shorter

--- a/include/zephyr/net/conn_mgr_connectivity.h
+++ b/include/zephyr/net/conn_mgr_connectivity.h
@@ -378,8 +378,8 @@ int conn_mgr_all_if_connect(bool skip_ignored);
  *
  * @param skip_ignored - If true, only affect ifaces that aren't ignored by conn_mgr.
  *			 Otherwise, affect all ifaces.
- * @return 0 if all net_if_up and conn_mgr_if_connect calls returned 0, otherwise the first nonzero
- *	   value returned by either net_if_up or conn_mgr_if_connect.
+ * @return 0 if all net_if_down calls returned 0, otherwise the first nonzero
+ *	   value returned by a net_if_down call.
  */
 int conn_mgr_all_if_disconnect(bool skip_ignored);
 

--- a/include/zephyr/net/dhcpv4_server.h
+++ b/include/zephyr/net/dhcpv4_server.h
@@ -114,6 +114,8 @@ typedef void (*net_dhcpv4_lease_cb_t)(struct net_if *iface,
  * @param iface Pointer to the network interface, can be NULL
  * @param cb User-supplied callback function to call
  * @param user_data User specified data
+ *
+ * @return 0 on success, a negative error code otherwise.
  */
 int net_dhcpv4_server_foreach_lease(struct net_if *iface,
 				    net_dhcpv4_lease_cb_t cb,

--- a/include/zephyr/net/dns_sd.h
+++ b/include/zephyr/net/dns_sd.h
@@ -183,7 +183,7 @@ extern "C" {
  * @param service name of the service, such as "_tftp"
  * @param domain the domain of the service, such as "local" or "zephyrproject.org"
  * @param text information for the DNS TXT record
- * @param port a pointer to the port number that this service will use
+ * @param port the port number that this service will use
  *
  * @see <a href="https://tools.ietf.org/html/rfc6763">RFC 6763</a>
  */

--- a/include/zephyr/net/ftp_client.h
+++ b/include/zephyr/net/ftp_client.h
@@ -333,6 +333,8 @@ int ftp_login(struct ftp_client *client, const char *username,
 
 /**@brief Close FTP connection.
  *
+ * @param client FTP client context
+ *
  * @return 0 on success.
  *         A negative errno code in case of a failure.
  *         A positive FTP status code in case of an unexpected server response.
@@ -458,7 +460,7 @@ int ftp_get(struct ftp_client *client, const char *file);
  * @param file Target file name
  * @param data Data to be stored
  * @param length Length of data to be stored
- * @param type specify FTP put types, see enum ftp_reply_code
+ * @param type specify FTP put types, see enum ftp_put_type
  *
  * @return 0 on success.
  *         A negative errno code in case of a failure.

--- a/include/zephyr/net/ieee802154_ie.h
+++ b/include/zephyr/net/ieee802154_ie.h
@@ -268,7 +268,7 @@ struct ieee802154_header_ie {
  *   uint16_t csl_period = ...;
  *   uint16_t csl_rendezvous_time = ...;
  *   struct ieee802154_header_ie header_ie =
- *       IEEE802154_DEFINE_HEADER_IE_CSL_REDUCED(csl_phase, csl_period, csl_rendezvous_time);
+ *       IEEE802154_DEFINE_HEADER_IE_CSL_FULL(csl_phase, csl_period, csl_rendezvous_time);
  * @endcode
  *
  * @param _csl_phase CSL phase in CPU byte order

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -774,7 +774,7 @@ int lwm2m_swmgmt_set_write_package_cb(uint16_t obj_inst_id, lwm2m_engine_set_dat
  * @param[in] error_code The result code of the operation. Zero on success
  * otherwise it should be a negative integer.
  *
- * return 0 on success, otherwise a negative integer.
+ * @return 0 on success, otherwise a negative integer.
  */
 int lwm2m_swmgmt_install_completed(uint16_t obj_inst_id, int error_code);
 

--- a/include/zephyr/net/lwm2m_path.h
+++ b/include/zephyr/net/lwm2m_path.h
@@ -8,7 +8,7 @@
 #define ZEPHYR_INCLUDE_NET_LWM2M_PATH_H_
 
 /**
- * @file lwm2m.h
+ * @file lwm2m_path.h
  *
  * @brief LwM2M path helper macros
  *

--- a/include/zephyr/net/net_config.h
+++ b/include/zephyr/net/net_config.h
@@ -195,6 +195,7 @@ struct net_config_ssh_key {
  *        This buffer is needed for loading and saving keys.
  *        The buffer can be shared between private and public key configurations if needed,
  *        but it must be big enough to hold the key data for both configurations.
+ * @param _key_buf_len Size of the key buffer in bytes.
  * @param _key_name SSH key name. This is used when saving or loading keys to
  *        identify them. The key name cannot contain spaces.
  * @param _key_id Key id. This is used to identify the key.
@@ -229,6 +230,7 @@ struct net_config_ssh_key {
  *        This buffer is needed for loading and saving keys.
  *        The buffer can be shared between private and public key configurations if needed,
  *        but it must be big enough to hold the key data for both configurations.
+ * @param _key_buf_len Size of the key buffer in bytes.
  * @param _key_name SSH key name. This is used when saving or loading keys to
  *        identify them. The key name cannot contain spaces.
  * @param _key_id Key id. This is used to identify the key.

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -529,7 +529,7 @@ static inline void net_context_set_state(struct net_context *context,
  *
  * @param context Network context.
  *
- * @return Network state.
+ * @return Network address family.
  */
 static inline net_sa_family_t net_context_get_family(struct net_context *context)
 {
@@ -1435,7 +1435,7 @@ void net_context_foreach(net_context_cb_t cb, void *user_data);
  * pools.
  *
  * @param context Context that will use the given net_buf pools.
- * @param tx_pool Pointer to the function that will return TX pool
+ * @param tx_slab Pointer to the function that will return TX pool
  * to the caller. The TX pool is used when sending data to network.
  * There is one TX net_pkt for each network packet that is sent.
  * @param data_pool Pointer to the function that will return DATA pool

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1013,7 +1013,7 @@ enum net_verdict net_if_try_send_data(struct net_if *iface,
 /**
  * @brief Send a packet through a net iface
  *
- * This is equivalent to net_if_try_queue_tx with an infinite timeout
+ * This is equivalent to net_if_try_send_data with an infinite timeout
  * @param iface Pointer to a network interface structure
  * @param pkt Pointer to a net packet to send
  *
@@ -3588,6 +3588,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
  * Enables to use of `NET_IF_GET` above the instantiation macro.
  *
  * @param dev_id Device ID provided to `NET_IF_INIT` or `NET_IF_OFFLOAD_INIT`
+ * @param inst Instance identifier
  */
 #define NET_IF_DECLARE(dev_id, inst) \
 	static struct net_if NET_IF_GET_NAME(dev_id, inst)

--- a/include/zephyr/net/net_mgmt.h
+++ b/include/zephyr/net/net_mgmt.h
@@ -331,7 +331,7 @@ static inline void net_mgmt_event_notify(uint64_t mgmt_event,
 /**
  * @brief Used to wait synchronously on an event mask
  * @param mgmt_event_mask A mask of relevant events to wait on.
- * @param raised_event a pointer on a uint32_t to get which event from
+ * @param raised_event a pointer on a uint64_t to get which event from
  *        the mask generated the event. Can be NULL if the caller is not
  *        interested in that information.
  * @param iface a pointer on a place holder for the iface on which the
@@ -379,7 +379,7 @@ static inline int net_mgmt_event_wait(uint64_t mgmt_event_mask,
  * @param mgmt_event_mask A mask of relevant events to wait on. Listened
  *        to events should be relevant to iface events and thus have the bit
  *        NET_MGMT_IFACE_BIT set.
- * @param raised_event a pointer on a uint32_t to get which event from
+ * @param raised_event a pointer on a uint64_t to get which event from
  *        the mask generated the event. Can be NULL if the caller is not
  *        interested in that information.
  * @param info a valid pointer if user wants to get the information the

--- a/include/zephyr/net/net_stats.h
+++ b/include/zephyr/net/net_stats.h
@@ -624,10 +624,10 @@ struct net_stats_eth_hw_timestamp {
 	/** Number of RX hardware timestamp cleared */
 	net_stats_t rx_hwtstamp_cleared;
 
-	/** Number of RX hardware timestamp timeout */
+	/** Number of TX hardware timestamp timeout */
 	net_stats_t tx_hwtstamp_timeouts;
 
-	/** Number of RX hardware timestamp skipped */
+	/** Number of TX hardware timestamp skipped */
 	net_stats_t tx_hwtstamp_skipped;
 };
 

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -2123,7 +2123,7 @@ struct wifi_mgmt_ops {
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param iface Network interface to use for the filter operation
-	 * @param packet filter settings
+	 * @param filter Filter settings
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
@@ -2219,7 +2219,7 @@ struct wifi_mgmt_ops {
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.
 	 * @param iface Network interface to use for the RTS threshold operation
-	 * @param RTS threshold value
+	 * @param rts_threshold RTS threshold value
 	 *
 	 * @return 0 if ok, < 0 if error
 	 */
@@ -2513,7 +2513,7 @@ void wifi_mgmt_raise_ap_sta_disconnected_event(struct net_if *iface,
  * @brief Raise P2P device found event
  *
  * @param iface Network interface
- * @param device_info P2P device information
+ * @param peer_info P2P device information
  */
 void wifi_mgmt_raise_p2p_device_found_event(struct net_if *iface,
 		struct wifi_p2p_device_info *peer_info);


### PR DESCRIPTION
Audit of the networking subsystem headers correcting a number of factual
Doxygen defects — mismatched @param names, copy-pasted briefs and return
docs, wrong types/values, undocumented parameters, and an unclosed @cond.

One commit per header; documentation only, no functional change.