### PR TITLE
Bluetooth: Audio: Fix incorrect Doxygen documentation in headers

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1084,7 +1084,7 @@ int bt_audio_codec_cap_set_freq(struct bt_audio_codec_cap *codec_cap,
 				enum bt_audio_codec_cap_freq freq);
 
 /**
- * @brief Extract the frequency from a codec capability.
+ * @brief Extract the frame duration from a codec capability.
  *
  * @param codec_cap The codec capabilities to extract data from.
  *
@@ -1109,7 +1109,7 @@ int bt_audio_codec_cap_set_frame_dur(struct bt_audio_codec_cap *codec_cap,
 				     enum bt_audio_codec_cap_frame_dur frame_dur);
 
 /**
- * @brief Extract the frequency from a codec capability.
+ * @brief Extract the supported audio channel counts from a codec capability.
  *
  * @param codec_cap The codec capabilities to extract data from.
  * @param fallback_to_default If true this function will provide the default value of 1

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -499,8 +499,6 @@ struct bt_bap_scan_delegator_cb {
 	 * @param conn       Pointer to the connection to a remote device if
 	 *                   the change was caused by it, otherwise NULL.
 	 * @param recv_state Pointer to the receive state that was updated.
-	 *
-	 * @return 0 in case of success or negative value in case of error.
 	 */
 	void (*recv_state_updated)(struct bt_conn *conn,
 				   const struct bt_bap_scan_delegator_recv_state *recv_state);
@@ -929,7 +927,7 @@ void bt_bap_stream_cb_register(struct bt_bap_stream *stream, struct bt_bap_strea
  * @param ep Remote Audio Endpoint being configured
  * @param codec_cfg Codec configuration
  *
- * @return Allocated Audio Stream object or NULL in case of error.
+ * @return 0 in case of success or negative value in case of error.
  */
 int bt_bap_stream_config(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep,
 			 const struct bt_audio_codec_cfg *codec_cfg);

--- a/include/zephyr/bluetooth/audio/bap_lc3_preset.h
+++ b/include/zephyr/bluetooth/audio/bap_lc3_preset.h
@@ -223,7 +223,7 @@ struct bt_bap_lc3_preset {
 			  BT_BAP_QOS_CFG_UNFRAMED(10000u, 120u, 5u, 20u, 40000u))
 
 /**
- * @brief Helper to declare LC3 Unicast 8_5_1 codec configuration
+ * @brief Helper to declare LC3 Unicast 48_5_1 codec configuration
  *
  * @param _loc             Audio channel location bitfield (@ref bt_audio_location)
  * @param _stream_context  Stream context (``BT_AUDIO_CONTEXT_*``)

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -1068,10 +1068,10 @@ int bt_cap_handover_broadcast_to_unicast(
 /** Callback structure for CAP procedures */
 struct bt_cap_commander_cb {
 	/**
-	 * @brief Callback for bt_cap_initiator_unicast_discover().
+	 * @brief Callback for bt_cap_commander_discover().
 	 *
 	 * @param conn      The connection pointer supplied to
-	 *                  bt_cap_initiator_unicast_discover().
+	 *                  bt_cap_commander_discover().
 	 * @param err       0 if Common Audio Service was found else -ENODATA.
 	 * @param member    Pointer to the set member. NULL if err != 0.
 	 * @param csis_inst The Coordinated Set Identification Service if

--- a/include/zephyr/bluetooth/audio/csip.h
+++ b/include/zephyr/bluetooth/audio/csip.h
@@ -459,8 +459,6 @@ typedef void (*bt_csip_set_coordinator_lock_set_cb)(int err);
  * @param inst    The Coordinated Set Identification Service instance that was
  *                changed.
  * @param locked  Whether the lock is locked or release.
- *
- * @return int Return 0 on success, or an errno value on error.
  */
 typedef void (*bt_csip_set_coordinator_lock_changed_cb)(
 	struct bt_csip_set_coordinator_csis_inst *inst, bool locked);
@@ -487,6 +485,7 @@ typedef void (*bt_csip_set_coordinator_sirk_changed_cb)(
  * bt_csip_set_coordinator_discover() to rediscover and read the characteristic values of the sets
  * on each device.
  *
+ * @param conn    Pointer to the remote device.
  * @param inst    The Coordinated Set Identification Service instance that was changed.
  *                The new size is stored in the @p inst->info.size.
  */

--- a/include/zephyr/bluetooth/audio/gmap.h
+++ b/include/zephyr/bluetooth/audio/gmap.h
@@ -163,10 +163,10 @@ struct bt_gmap_feat {
 	enum bt_gmap_bgr_feat bgr_feat;
 };
 
-/** @brief Hearing Access Service Client callback structure. */
+/** @brief Gaming Audio Profile callback structure. */
 struct bt_gmap_cb {
 	/**
-	 * @brief Callback function for bt_has_discover.
+	 * @brief Callback function for bt_gmap_discover().
 	 *
 	 * This callback is called when discovery procedure is complete.
 	 *

--- a/include/zephyr/bluetooth/audio/lc3.h
+++ b/include/zephyr/bluetooth/audio/lc3.h
@@ -36,9 +36,9 @@ extern "C" {
  *
  * @p _max_frames_per_sdu is optional and will be included only if != 1
  *
- * @ref COND_CODE_1 is used to omit an LTV entry in case the @p _frames_per_sdu is 1.
+ * @ref COND_CODE_1 is used to omit an LTV entry in case the @p _max_frames_per_sdu is 1.
  * @ref COND_CODE_1 will evaluate to second argument if the flag parameter(first argument) is 1
- * - removing one layer of paranteses.
+ * - removing one layer of parentheses.
  * If the flags argument is != 1 it will evaluate to the third argument which inserts a LTV
  * entry for the max_frames_per_sdu value.
 

--- a/include/zephyr/bluetooth/audio/mcc.h
+++ b/include/zephyr/bluetooth/audio/mcc.h
@@ -207,7 +207,7 @@ typedef void (*bt_mcc_read_current_track_obj_id_cb)(struct bt_conn *conn, int er
 typedef void (*bt_mcc_set_current_track_obj_id_cb)(struct bt_conn *conn, int err, uint64_t id);
 
 /**
- * @brief Callback function for bt_mcc_read_next_track_obj_id_obj()
+ * @brief Callback function for bt_mcc_read_next_track_obj_id()
  *
  * Called when the next track object ID is read or notified
  *

--- a/include/zephyr/bluetooth/audio/media_proxy.h
+++ b/include/zephyr/bluetooth/audio/media_proxy.h
@@ -902,6 +902,8 @@ int media_proxy_ctrl_get_icon_id(struct media_player *player);
  * Get a URL to the media player's icon.
  *
  * @param player   Media player instance pointer
+ *
+ * @return 0 if success, errno on failure.
  */
 int media_proxy_ctrl_get_icon_url(struct media_player *player);
 
@@ -1488,7 +1490,7 @@ struct media_proxy_pl_calls {
 	/**
 	 * @brief Read Playing Order
 	 *
-	 * return The media player's current playing order
+	 * @return The media player's current playing order
 	 */
 	uint8_t (*get_playing_order)(void);
 

--- a/include/zephyr/bluetooth/audio/micp.h
+++ b/include/zephyr/bluetooth/audio/micp.h
@@ -259,10 +259,10 @@ int bt_micp_mic_ctlr_conn_get(const struct bt_micp_mic_ctlr *mic_ctlr,
 			      struct bt_conn **conn);
 
 /**
- * @brief Get the volume controller from a connection pointer
+ * @brief Get the Microphone Controller from a connection pointer
  *
- * Get the Volume Control Profile Volume Controller pointer from a connection pointer.
- * Only volume controllers that have been initiated via bt_micp_mic_ctlr_discover() can be
+ * Get the Microphone Control Profile Microphone Controller pointer from a connection pointer.
+ * Only microphone controllers that have been initiated via bt_micp_mic_ctlr_discover() can be
  * retrieved.
  *
  * @param conn     Connection pointer.

--- a/include/zephyr/bluetooth/audio/tmap.h
+++ b/include/zephyr/bluetooth/audio/tmap.h
@@ -73,7 +73,7 @@ enum bt_tmap_role {
 	/**
 	 * @brief TMAP Broadcast Media Receiver role
 	 *
-	 * This role is defined send media audio to TMAP Broadcast Media Senders.
+	 * This role is defined to receive media audio from TMAP Broadcast Media Senders.
 	 * Audio streams in this role are always uni-directional.
 	 */
 	BT_TMAP_ROLE_BMR = BIT(5U),

--- a/include/zephyr/bluetooth/audio/vocs.h
+++ b/include/zephyr/bluetooth/audio/vocs.h
@@ -130,10 +130,10 @@ void *bt_vocs_svc_decl_get(struct bt_vocs *vocs);
 /**
  * @brief Get the connection pointer of a client instance
  *
- * Get the Bluetooth connection pointer of a Audio Input Control Service
+ * Get the Bluetooth connection pointer of a Volume Offset Control Service
  * client instance.
  *
- * @param vocs    Audio Input Control Service client instance pointer.
+ * @param vocs    Volume Offset Control Service client instance pointer.
  * @param conn    Connection pointer.
  *
  * @return 0 if success, errno on failure.


### PR DESCRIPTION
Audit of the Bluetooth audio headers correcting a number of Doxygen errors: copy-pasted briefs and @return docs, mismatched parameter references, ...

One commit per header; documentation only, no functional change.