### PR TITLE
Bluetooth: Host: misc. Doxygen documentation fixes

### DIFF
--- a/include/zephyr/bluetooth/assigned_numbers.h
+++ b/include/zephyr/bluetooth/assigned_numbers.h
@@ -761,9 +761,9 @@ extern "C" {
 #define BT_MESH_MODEL_ID_LARGE_COMP_DATA_SRV       0x0012
 /** Large Composition Data Client */
 #define BT_MESH_MODEL_ID_LARGE_COMP_DATA_CLI       0x0013
-/** Solicitation PDU RPL Configuration Client */
-#define BT_MESH_MODEL_ID_SOL_PDU_RPL_SRV	   0x0014
 /** Solicitation PDU RPL Configuration Server */
+#define BT_MESH_MODEL_ID_SOL_PDU_RPL_SRV	   0x0014
+/** Solicitation PDU RPL Configuration Client */
 #define BT_MESH_MODEL_ID_SOL_PDU_RPL_CLI	   0x0015
 /** Private Proxy Server */
 #define BT_MESH_MODEL_ID_ON_DEMAND_PROXY_SRV	   0x000c

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1214,8 +1214,8 @@ struct bt_le_per_adv_param {
 /**
  * Helper to declare periodic advertising parameters inline
  *
- * @param _int_min     Minimum periodic advertising interval, N * 0.625 milliseconds
- * @param _int_max     Maximum periodic advertising interval, N * 0.625 milliseconds
+ * @param _int_min     Minimum periodic advertising interval, N * 1.25 ms
+ * @param _int_max     Maximum periodic advertising interval, N * 1.25 ms
  * @param _options     Periodic advertising properties bitfield, see @ref bt_le_adv_opt
  *                     field.
  */
@@ -1229,8 +1229,8 @@ struct bt_le_per_adv_param {
 /**
  * Helper to declare periodic advertising parameters inline
  *
- * @param _int_min     Minimum periodic advertising interval, N * 0.625 milliseconds
- * @param _int_max     Maximum periodic advertising interval, N * 0.625 milliseconds
+ * @param _int_min     Minimum periodic advertising interval, N * 1.25 ms
+ * @param _int_max     Maximum periodic advertising interval, N * 1.25 ms
  * @param _options     Periodic advertising properties bitfield, see @ref bt_le_adv_opt
  *                     field.
  */
@@ -1473,6 +1473,8 @@ int bt_le_ext_adv_update_param(struct bt_le_ext_adv *adv,
  * Delete advertising set. This will free up the advertising set and make it
  * possible to create a new advertising set if the limit @kconfig{CONFIG_BT_EXT_ADV_MAX_ADV_SET}
  * was reached.
+ *
+ * @param adv Advertising set object.
  *
  * @return Zero on success or (negative) error code otherwise.
  */

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2399,7 +2399,7 @@ struct bt_conn_cb {
 	 *  connection has changed.
 	 *
 	 *  @param conn Connection object.
-	 *  @param info Connection LE PHY information.
+	 *  @param param Connection LE PHY information.
 	 */
 	void (*le_phy_updated)(struct bt_conn *conn,
 			       struct bt_conn_le_phy_info *param);
@@ -2549,7 +2549,7 @@ struct bt_conn_cb {
 	 *
 	 *  @param conn Connection object.
 	 *  @param status HCI status of complete event.
-	 *  @param remote_cs_capabilities Pointer to CS Capabilities on success or NULL otherwise.
+	 *  @param params Pointer to CS Capabilities on success or NULL otherwise.
 	 */
 	void (*le_cs_read_remote_capabilities_complete)(struct bt_conn *conn,
 							uint8_t status,

--- a/include/zephyr/bluetooth/cs.h
+++ b/include/zephyr/bluetooth/cs.h
@@ -522,7 +522,7 @@ struct bt_le_cs_create_config_params {
 struct bt_le_cs_test_cb {
 	/**@brief CS Test Subevent data.
 	 *
-	 * @param[in] Subevent results.
+	 * @param[in] data Subevent results.
 	 */
 	void (*le_cs_test_subevent_data_available)(struct bt_conn_le_cs_subevent_result *data);
 	/**@brief CS Test End Complete. */

--- a/include/zephyr/bluetooth/gap.h
+++ b/include/zephyr/bluetooth/gap.h
@@ -187,14 +187,14 @@ enum bt_gap_adv_prop {
 #define BT_GAP_PER_ADV_MAX_INTERVAL             0xFFFF /* 81.91875 s */
 
 /**
- * @brief Convert periodic advertising interval (N * 0.625 ms) to microseconds
+ * @brief Convert advertising interval (N * 0.625 ms) to microseconds
  *
  * Value range of @p _interval is @ref BT_LE_ADV_INTERVAL_MIN to @ref BT_LE_ADV_INTERVAL_MAX
  */
 #define BT_GAP_ADV_INTERVAL_TO_US(_interval) ((uint32_t)((_interval) * 625U))
 
 /**
- * @brief Convert periodic advertising interval (N * 0.625 ms) to milliseconds
+ * @brief Convert advertising interval (N * 0.625 ms) to milliseconds
  *
  * Value range of @p _interval is @ref BT_LE_ADV_INTERVAL_MIN to @ref BT_LE_ADV_INTERVAL_MAX
  *
@@ -294,7 +294,7 @@ enum bt_gap_adv_prop {
  * Value range of @p _timeout is 100000 to 163840000
  *
  * @note If @p _timeout is not a multiple of the unit, it will round down to nearest.
- * For example BT_GAP_MS_TO_PER_ADV_SYNC_TIMEOUT(4005000) will become 4000000 microseconds
+ * For example BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(4005000) will become 4000000 microseconds
  */
 #define BT_GAP_US_TO_PER_ADV_SYNC_TIMEOUT(_timeout)                                                \
 	(BT_GAP_MS_TO_PER_ADV_SYNC_TIMEOUT((_timeout) / USEC_PER_MSEC))

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -642,7 +642,7 @@ struct bt_l2cap_chan_ops {
 	 *  controller.
 	 *
 	 *  @param chan The channel which has made encryption status changed.
-	 *  @param status HCI status of performed security procedure caused
+	 *  @param hci_status HCI status of performed security procedure caused
 	 *  by channel security requirements. The value is populated
 	 *  by HCI layer and set to 0 when success and to non-zero (reference to
 	 *  HCI Error Codes) when security/authentication failed.

--- a/include/zephyr/bluetooth/uuid.h
+++ b/include/zephyr/bluetooth/uuid.h
@@ -1492,7 +1492,7 @@ struct bt_uuid_any {
  */
 #define BT_UUID_HRS_BODY_SENSOR_VAL 0x2a38
 /**
- *  @brief HRS Characteristic Control Point
+ *  @brief HRS Characteristic Body Sensor Location
  */
 #define BT_UUID_HRS_BODY_SENSOR \
 	BT_UUID_DECLARE_16(BT_UUID_HRS_BODY_SENSOR_VAL)
@@ -5135,11 +5135,11 @@ struct bt_uuid_any {
 	BT_UUID_DECLARE_16(BT_UUID_UDI_FOR_MEDICAL_DEVICES_VAL)
 
 /**
- *  @brief Gaming Service UUID value
+ *  @brief Gaming Audio Service UUID value
  */
 #define BT_UUID_GMAS_VAL 0x1858
 /**
- *  @brief Common Audio Service
+ *  @brief Gaming Audio Service
  */
 #define BT_UUID_GMAS	 BT_UUID_DECLARE_16(BT_UUID_GMAS_VAL)
 


### PR DESCRIPTION
Fix mismatched and missing `@param` names, wrong advertising interval units, swapped Server/Client briefs, and incorrect UUID briefs.

One commit per header; documentation only, no functional change.