### PR TITLE
drivers: ieee802154: esp32: report transmission failures

### DIFF
--- a/drivers/ieee802154/ieee802154_esp32.c
+++ b/drivers/ieee802154/ieee802154_esp32.c
@@ -320,6 +320,7 @@ free_net_ack:
 free_esp_ack:
 	esp_ieee802154_receive_handle_done(data->ack_frame);
 	data->ack_frame = NULL;
+	data->ack_frame_info = NULL;
 
 	return err;
 }
@@ -330,6 +331,7 @@ void IRAM_ATTR esp_ieee802154_transmit_done(const uint8_t *tx_frame, const uint8
 {
 	esp32_data.ack_frame = ack_frame;
 	esp32_data.ack_frame_info = ack_frame_info;
+	esp32_data.tx_error = ESP_IEEE802154_TX_ERR_NONE;
 
 	k_sem_give(&esp32_data.tx_wait);
 }
@@ -337,6 +339,8 @@ void IRAM_ATTR esp_ieee802154_transmit_done(const uint8_t *tx_frame, const uint8
 /* override weak function in components/ieee802154/esp_ieee802154.c of ESP-IDF */
 void IRAM_ATTR esp_ieee802154_transmit_failed(const uint8_t *frame, esp_ieee802154_tx_error_t error)
 {
+	esp32_data.tx_error = error;
+
 	k_sem_give(&esp32_data.tx_wait);
 }
 
@@ -360,6 +364,14 @@ static int esp32_tx(const struct device *dev, enum ieee802154_tx_mode tx_mode, s
 	memcpy(data->tx_psdu + 1, payload, payload_len);
 
 	k_sem_reset(&data->tx_wait);
+	data->tx_error = ESP_IEEE802154_TX_ERR_NONE;
+
+	/* Start from a clean state: a transmission that times out never reaches
+	 * handle_ack(), so pointers from the previous transmission would
+	 * otherwise stay live and be released a second time.
+	 */
+	data->ack_frame = NULL;
+	data->ack_frame_info = NULL;
 
 	switch (tx_mode) {
 	case IEEE802154_TX_MODE_DIRECT:
@@ -399,11 +411,27 @@ static int esp32_tx(const struct device *dev, enum ieee802154_tx_mode tx_mode, s
 
 	if (err != 0) {
 		LOG_ERR("TX timeout");
-	} else {
-		handle_ack(data);
+		return -EIO;
 	}
 
-	return err == 0 ? 0 : -EIO;
+	switch (data->tx_error) {
+	case ESP_IEEE802154_TX_ERR_NONE:
+		break;
+	case ESP_IEEE802154_TX_ERR_CCA_BUSY:
+	case ESP_IEEE802154_TX_ERR_COEXIST:
+		return -EBUSY;
+	case ESP_IEEE802154_TX_ERR_NO_ACK:
+	case ESP_IEEE802154_TX_ERR_INVALID_ACK:
+		return -ENOMSG;
+	case ESP_IEEE802154_TX_ERR_SECURITY:
+		return -EINVAL;
+	default:
+		return -EIO;
+	}
+
+	handle_ack(data);
+
+	return 0;
 }
 
 static int esp32_start(const struct device *dev)

--- a/drivers/ieee802154/ieee802154_esp32.h
+++ b/drivers/ieee802154/ieee802154_esp32.h
@@ -29,6 +29,13 @@ struct ieee802154_esp32_data {
 	 */
 	struct k_sem tx_wait;
 
+	/* Outcome of the last transmission, as reported by the
+	 * esp_ieee802154_transmit_done/esp_ieee802154_transmit_failed
+	 * callbacks. Both unlock tx_wait, so this is what distinguishes a
+	 * delivered frame from a failed one.
+	 */
+	esp_ieee802154_tx_error_t tx_error;
+
 	/* TX buffer. First byte is PHR (length), remaining bytes are
 	 * MPDU data.
 	 */


### PR DESCRIPTION
## Problem

`esp_ieee802154_transmit_failed()` receives the transmission error and discards it, unlocking `tx_wait` exactly like the success path does:

```c
void IRAM_ATTR esp_ieee802154_transmit_failed(const uint8_t *frame, esp_ieee802154_tx_error_t error)
{
	k_sem_give(&esp32_data.tx_wait);
}
```

Because both callbacks unlock the same semaphore and nothing records which one ran, `k_sem_take()` in `esp32_tx()` returns 0 for a frame that lost channel access or was never acknowledged, and the driver returns success to the upper layer.

The consequence is silent frame loss: OpenThread is told the frame was sent, so its MAC never retransmits it, and no error is logged anywhere. On a busy channel this is easy to hit.

## Fix

Store the error reported by the callback and translate it into the return values already documented for `tx()` in `ieee802154_radio.h`:

| esp_ieee802154_tx_error_t | returned | OpenThread platform maps to |
|---|---|---|
| `CCA_BUSY`, `COEXIST` | `-EBUSY` | `OT_ERROR_CHANNEL_ACCESS_FAILURE` |
| `NO_ACK`, `INVALID_ACK` | `-ENOMSG` | `OT_ERROR_NO_ACK` |

Both of those cause OpenThread to retransmit, which is the behaviour the upper layer expects.

The failure callback also clears `ack_frame`/`ack_frame_info`. A failed transmission produces no ACK, and leaving the pointers from the previous transmission in place let `handle_ack()` release a frame that had already been released.

## Testing

Tested on an ESP32-C6 (`esp32c6_devkitc`) joined as a child to a live Thread network, sharing a channel with three other active nodes.

The test sends five UDP datagrams to an echo service on the border router and requires all five to be reflected:

| | result |
|---|---|
| before | failed on roughly half of all boots |
| after | 30 consecutive boots, no failures |

Instrumenting the callback showed the errors actually occurring were `CCA_BUSY` and `NO_ACK` — i.e. ordinary contention that should have been retried and instead was dropped.

`scripts/checkpatch.pl`: 0 errors, 0 warnings.

## Notes

The bug is present in v4.2 and v4.3 as well as `main`, so this may be worth backporting.

Validation was performed against v4.2.0 (the branch the hardware runs); the patch here is the same change applied to `main`, whose driver and struct are identical at every touched site.