### PR TITLE
bluetooth: classic: Refactor OBEX authentication to be reusable

### DIFF
--- a/include/zephyr/bluetooth/classic/obex.h
+++ b/include/zephyr/bluetooth/classic/obex.h
@@ -1780,6 +1780,68 @@ bool bt_obex_has_header(struct net_buf *buf, uint8_t id);
  */
 bool bt_obex_has_app_param(struct net_buf *buf, uint8_t id);
 
+/** @brief Generate nonce for OBEX authentication challenge.
+ *
+ *  Generates a nonce value used in OBEX authentication challenges.
+ *  The nonce is used to prevent replay attacks during authentication.
+ *
+ *  @param pwd Password bytes used for nonce generation.
+ *  @param pwd_len Length of @p pwd in bytes.
+ *  @param nonce Output buffer to store the generated nonce
+ *               (@ref BT_OBEX_CHALLENGE_TAG_NONCE_LEN bytes).
+ *
+ *  @return 0 on success, negative error code on failure.
+ *
+ *  @warning OBEX authentication uses MD5, which is cryptographically weak.
+ *           It provides only limited security.
+ */
+int bt_obex_generate_nonce(const uint8_t *pwd, size_t pwd_len,
+			   uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN]);
+
+/** @brief Calculate request digest for OBEX authentication response.
+ *
+ *  Computes the MD5 digest for an authentication response based on the password
+ *  and received nonce. This digest is sent to prove knowledge of the password
+ *  without transmitting the password itself.
+ *
+ *  @param pwd Password bytes used for authentication.
+ *  @param pwd_len Length of @p pwd in bytes.
+ *  @param nonce Nonce value received in the authentication challenge
+ *               (@ref BT_OBEX_CHALLENGE_TAG_NONCE_LEN bytes).
+ *  @param digest Output buffer to store the calculated request digest
+ *                (@ref BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN bytes).
+ *
+ *  @return 0 on success, negative error code on failure.
+ *
+ *  @warning OBEX authentication uses MD5, which is cryptographically weak.
+ *           It provides only limited security.
+ */
+int bt_obex_calculate_request_digest(const uint8_t *pwd, size_t pwd_len,
+				     const uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN],
+				     uint8_t digest[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN]);
+
+/** @brief Verify OBEX authentication response.
+ *
+ *  Verifies that the received request digest matches the expected value
+ *  computed from the password and nonce. Used by the authenticating party
+ *  to validate the peer's authentication response.
+ *
+ *  @param pwd Password bytes used for authentication.
+ *  @param pwd_len Length of @p pwd in bytes.
+ *  @param nonce Nonce value that was sent in the authentication challenge
+ *               (@ref BT_OBEX_CHALLENGE_TAG_NONCE_LEN bytes).
+ *  @param digest Request digest received from the peer
+ *                (@ref BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN bytes).
+ *
+ *  @return 0 if authentication succeeds, negative error code on failure.
+ *
+ *  @warning OBEX authentication uses MD5, which is cryptographically weak.
+ *           It provides only limited security.
+ */
+int bt_obex_verify_auth_response(const uint8_t *pwd, size_t pwd_len,
+				 const uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN],
+				 const uint8_t digest[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN]);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/bluetooth/classic/pbap.h
+++ b/include/zephyr/bluetooth/classic/pbap.h
@@ -957,64 +957,6 @@ int bt_pbap_pse_set_phone_book_rsp(struct bt_pbap_pse *pbap_pse, uint8_t rsp_cod
  */
 int bt_pbap_pse_abort_rsp(struct bt_pbap_pse *pbap_pse, uint8_t rsp_code, struct net_buf *buf);
 
-/** @brief Calculate authentication nonce for PBAP challenge.
- *
- *  Generates a random nonce value used in OBEX authentication challenges.
- *  The nonce is used to prevent replay attacks during authentication.
- *
- *  @param pwd Password string used for authentication (null-terminated).
- *  @param nonce Output buffer to store the generated nonce
- *               (@ref BT_OBEX_CHALLENGE_TAG_NONCE_LEN bytes).
- *
- *  @return 0 on success, negative error code on failure.
- *
- *  @warning PBAP v1.x uses MD5 for authentication, which is cryptographically weak.
- *           PBAP authentication provides limited security.
- */
-int bt_pbap_calculate_nonce(const uint8_t *pwd, uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN]);
-
-/** @brief Calculate response digest for PBAP authentication.
- *
- *  Computes the MD5 digest for an authentication response based on the password
- *  and received nonce. This digest is sent back to prove knowledge of the password
- *  without transmitting the password itself.
- *
- *  @param pwd Password string used for authentication (null-terminated).
- *  @param nonce Nonce value received in the authentication challenge
- *               (@ref BT_OBEX_CHALLENGE_TAG_NONCE_LEN bytes).
- *  @param rsp_digest Output buffer to store the calculated response digest
- *                    (@ref BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN bytes).
- *
- *  @return 0 on success, negative error code on failure.
- *
- *  @warning PBAP v1.x uses MD5 for authentication, which is cryptographically weak.
- *           PBAP authentication provides limited security.
- */
-int bt_pbap_calculate_rsp_digest(const uint8_t *pwd,
-				 const uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN],
-				 uint8_t rsp_digest[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN]);
-
-/** @brief Verify authentication response.
- *
- *  Verifies that the received response digest matches the expected value based on
- *  the password and nonce. Used by the authenticating party to validate the
- *  authentication response.
- *
- *  @param nonce Nonce value that was sent in the authentication challenge
- *               (@ref BT_OBEX_CHALLENGE_TAG_NONCE_LEN bytes).
- *  @param rsp_digest Response digest received from the authenticating peer
- *                    (@ref BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN bytes).
- *  @param pwd Password string used for authentication (null-terminated).
- *
- *  @return 0 if authentication is successful, negative error code on failure.
- *
- *  @warning PBAP v1.x uses MD5 for authentication, which is cryptographically weak.
- *           PBAP authentication provides limited security.
- */
-int bt_pbap_verify_authentication(uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN],
-				  uint8_t rsp_digest[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN],
-				  const uint8_t *pwd);
-
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/host/classic/CMakeLists.txt
+++ b/subsys/bluetooth/host/classic/CMakeLists.txt
@@ -55,8 +55,8 @@ zephyr_library_sources_ifdef(
   pbap.c
   )
 
-if(CONFIG_BT_PBAP)
-  message(WARNING "CONFIG_BT_PBAP: PBAP v1.x uses MD5 for authentication, which is "
+if(CONFIG_BT_OBEX_AUTH)
+  message(WARNING "CONFIG_BT_OBEX_AUTH: OBEX uses MD5 for authentication, which is "
                   "cryptographically weak.")
 endif()
 

--- a/subsys/bluetooth/host/classic/CMakeLists.txt
+++ b/subsys/bluetooth/host/classic/CMakeLists.txt
@@ -60,8 +60,8 @@ zephyr_library_sources_ifdef(
   pbap.c
   )
 
-if(CONFIG_BT_PBAP)
-  message(WARNING "CONFIG_BT_PBAP: PBAP v1.x uses MD5 for authentication, which is "
+if(CONFIG_BT_OBEX_AUTH)
+  message(WARNING "CONFIG_BT_OBEX_AUTH: OBEX uses MD5 for authentication, which is "
                   "cryptographically weak.")
 endif()
 

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -712,6 +712,23 @@ config BT_OEBX_RSP_CODE_TO_STR
 	  codes represented as strings.
 	  See bt_obex_rsp_code_to_str() for more details.
 
+config BT_OBEX_AUTH
+	bool "Bluetooth OBEX Authentication support"
+	select PSA_WANT_ALG_MD5
+	select MBEDTLS
+	help
+	  This option enables OBEX authentication feature.
+	  OBEX authentication uses MD5, which is cryptographically weak.
+	  It provides only limited security.
+
+config BT_OBEX_AUTH_PWD_LEN
+	int "Maximum OBEX Authentication Password Length"
+	depends on BT_OBEX_AUTH
+	default 16
+	range 1 255
+	help
+	  This option sets the maximum length of OBEX authentication password.
+
 endif # BT_GOEP
 
 config BT_BIP
@@ -724,8 +741,7 @@ config BT_BIP
 config BT_PBAP
 	bool
 	select BT_GOEP
-	select PSA_WANT_ALG_MD5
-	select MBEDTLS
+	select BT_OBEX_AUTH
 	help
 	  This option enables the PBAP profile
 

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -731,6 +731,23 @@ config BT_OEBX_RSP_CODE_TO_STR
 	  codes represented as strings.
 	  See bt_obex_rsp_code_to_str() for more details.
 
+config BT_OBEX_AUTH
+	bool "Bluetooth OBEX Authentication support"
+	select PSA_WANT_ALG_MD5
+	select MBEDTLS
+	help
+	  This option enables OBEX authentication feature.
+	  OBEX authentication uses MD5, which is cryptographically weak.
+	  It provides only limited security.
+
+config BT_OBEX_AUTH_PWD_LEN
+	int "Maximum OBEX Authentication Password Length"
+	depends on BT_OBEX_AUTH
+	default 16
+	range 1 255
+	help
+	  This option sets the maximum length of OBEX authentication password.
+
 endif # BT_GOEP
 
 config BT_BIP
@@ -743,8 +760,7 @@ config BT_BIP
 config BT_PBAP
 	bool
 	select BT_GOEP
-	select PSA_WANT_ALG_MD5
-	select MBEDTLS
+	select BT_OBEX_AUTH
 	help
 	  This option enables the PBAP profile
 

--- a/subsys/bluetooth/host/classic/obex.c
+++ b/subsys/bluetooth/host/classic/obex.c
@@ -22,6 +22,11 @@
 #include <zephyr/bluetooth/classic/sdp.h>
 #include <zephyr/bluetooth/classic/obex.h>
 
+#if defined(CONFIG_BT_OBEX_AUTH)
+#include <psa/crypto.h>
+#include <mbedtls/constant_time.h>
+#endif /* CONFIG_BT_OBEX_AUTH */
+
 #include "obex_internal.h"
 
 #define LOG_LEVEL CONFIG_BT_GOEP_LOG_LEVEL
@@ -4665,3 +4670,106 @@ const char *bt_obex_rsp_code_to_str(enum bt_obex_rsp_code rsp_code)
 	return rsp_code_str;
 }
 #endif /* CONFIG_BT_OEBX_RSP_CODE_TO_STR */
+
+#if defined(CONFIG_BT_OBEX_AUTH)
+int bt_obex_generate_nonce(const uint8_t *pwd, size_t pwd_len,
+			   uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN])
+{
+	int64_t timestamp = k_uptime_get();
+	uint8_t data[CONFIG_BT_OBEX_AUTH_PWD_LEN + 1U + sizeof(timestamp)];
+	struct net_buf_simple buf;
+	size_t len;
+	int err;
+
+	if (pwd == NULL || nonce == NULL || pwd_len == 0 || pwd_len > CONFIG_BT_OBEX_AUTH_PWD_LEN) {
+		return -EINVAL;
+	}
+
+	LOG_WRN("OBEX authentication relies on legacy MD5-based OBEX authentication");
+
+	net_buf_simple_init_with_data(&buf, data, sizeof(data));
+	net_buf_simple_reset(&buf);
+
+	net_buf_simple_add_mem(&buf, (uint8_t *)&timestamp, sizeof(timestamp));
+	net_buf_simple_add_u8(&buf, (uint8_t)':');
+	net_buf_simple_add_mem(&buf, pwd, pwd_len);
+	err = psa_hash_compute(PSA_ALG_MD5, (const unsigned char *)buf.data, buf.len, nonce,
+			       BT_OBEX_CHALLENGE_TAG_NONCE_LEN, &len);
+	if (err != 0) {
+		LOG_ERR("Generate nonce failed %d", err);
+		return err;
+	}
+
+	if (len != BT_OBEX_CHALLENGE_TAG_NONCE_LEN) {
+		LOG_ERR("Generated nonce len is invalid (%zu != %zu)", len,
+			BT_OBEX_CHALLENGE_TAG_NONCE_LEN);
+		return -EINVAL;
+	}
+	return 0;
+}
+
+int bt_obex_calculate_request_digest(const uint8_t *pwd, size_t pwd_len,
+				     const uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN],
+				     uint8_t digest[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN])
+{
+	uint8_t data[CONFIG_BT_OBEX_AUTH_PWD_LEN + BT_OBEX_CHALLENGE_TAG_NONCE_LEN + 1U];
+	struct net_buf_simple buf;
+	size_t len;
+	int err;
+
+	if (pwd == NULL || nonce == NULL || digest == NULL || pwd_len == 0 ||
+	    pwd_len > CONFIG_BT_OBEX_AUTH_PWD_LEN) {
+		return -EINVAL;
+	}
+
+	LOG_WRN("OBEX authentication relies on legacy MD5-based OBEX authentication");
+
+	net_buf_simple_init_with_data(&buf, data, sizeof(data));
+	net_buf_simple_reset(&buf);
+
+	net_buf_simple_add_mem(&buf, nonce, BT_OBEX_CHALLENGE_TAG_NONCE_LEN);
+	net_buf_simple_add_u8(&buf, (uint8_t)':');
+	net_buf_simple_add_mem(&buf, pwd, pwd_len);
+
+	err = psa_hash_compute(PSA_ALG_MD5, (const unsigned char *)buf.data, buf.len, digest,
+			       BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN, &len);
+	if (err != 0) {
+		LOG_ERR("Generate request-digest failed %d", err);
+		return err;
+	}
+
+	if (len != BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN) {
+		LOG_ERR("Generated request-digest len is invalid (%zu != %zu)", len,
+			BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN);
+		return -EINVAL;
+	}
+	return 0;
+}
+
+int bt_obex_verify_auth_response(const uint8_t *pwd, size_t pwd_len,
+				 const uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN],
+				 const uint8_t digest[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN])
+{
+	uint8_t calc_digest[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN];
+	int err;
+
+	if (pwd == NULL || nonce == NULL || digest == NULL || pwd_len == 0 ||
+	    pwd_len > CONFIG_BT_OBEX_AUTH_PWD_LEN) {
+		return -EINVAL;
+	}
+
+	err = bt_obex_calculate_request_digest(pwd, pwd_len, nonce, calc_digest);
+	if (err != 0) {
+		LOG_ERR("Failed to calculate request digest %d", err);
+		return err;
+	}
+
+	err = mbedtls_ct_memcmp(calc_digest, digest, BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN);
+	if (err != 0) {
+		LOG_ERR("Request-digest is invalid");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_BT_OBEX_AUTH */

--- a/subsys/bluetooth/host/classic/pbap.c
+++ b/subsys/bluetooth/host/classic/pbap.c
@@ -14,8 +14,6 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/kernel.h>
 
-#include "psa/crypto.h"
-
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
@@ -24,8 +22,6 @@
 #include <zephyr/bluetooth/classic/sdp.h>
 #include <zephyr/bluetooth/classic/goep.h>
 #include <zephyr/bluetooth/classic/pbap.h>
-
-#include <mbedtls/constant_time.h>
 
 #include "host/conn_internal.h"
 #include "l2cap_br_internal.h"
@@ -817,113 +813,6 @@ struct net_buf *bt_pbap_pce_create_pdu(struct bt_pbap_pce *pbap_pce, struct net_
 struct net_buf *bt_pbap_pse_create_pdu(struct bt_pbap_pse *pbap_pse, struct net_buf_pool *pool)
 {
 	return bt_pbap_create_pdu(&pbap_pse->_goep, pool);
-}
-
-int bt_pbap_calculate_nonce(const uint8_t *pwd, uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN])
-{
-	int64_t timestamp = k_uptime_get();
-	uint8_t hash_input[PBAP_PWD_MAX_LENGTH + 1U + sizeof(timestamp)];
-	size_t len;
-	uint16_t pwd_len;
-	int err;
-
-	if (pwd == NULL) {
-		LOG_WRN("no available password");
-		return -EINVAL;
-	}
-
-	if (nonce == NULL) {
-		LOG_WRN("no available nonce");
-		return -EINVAL;
-	}
-
-	pwd_len = strlen(pwd);
-	if (pwd_len == 0 || pwd_len > PBAP_PWD_MAX_LENGTH) {
-		LOG_ERR("Password is invalid");
-		return -EINVAL;
-	}
-
-	LOG_WRN("PBAP authentication relies on legacy MD5-based OBEX authentication");
-
-	memcpy(hash_input, &timestamp, sizeof(timestamp));
-	hash_input[sizeof(timestamp)] = ':';
-	memcpy(hash_input + sizeof(timestamp) + 1U, pwd, pwd_len);
-	err = psa_hash_compute(PSA_ALG_MD5, (const unsigned char *)hash_input,
-			       sizeof(timestamp) + 1U + pwd_len, nonce,
-			       BT_OBEX_CHALLENGE_TAG_NONCE_LEN, &len);
-	if (err != 0) {
-		LOG_WRN("Generate nonce failed %d", err);
-		return err;
-	}
-	return 0;
-}
-
-int bt_pbap_calculate_rsp_digest(const uint8_t *pwd,
-				 const uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN],
-				 uint8_t rsp_digest[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN])
-{
-	uint8_t hash_input[PBAP_PWD_MAX_LENGTH + BT_OBEX_CHALLENGE_TAG_NONCE_LEN + 1U];
-	size_t len;
-	uint16_t pwd_len;
-	int err;
-
-	if (pwd == NULL) {
-		LOG_WRN("no available password");
-		return -EINVAL;
-	}
-
-	if (nonce == NULL) {
-		LOG_WRN("no available nonce");
-		return -EINVAL;
-	}
-
-	if (rsp_digest == NULL) {
-		LOG_WRN("no available rsp_digest");
-		return -EINVAL;
-	}
-
-	pwd_len = strlen(pwd);
-	if (pwd_len == 0 || pwd_len > PBAP_PWD_MAX_LENGTH) {
-		LOG_ERR("Password is invalid");
-		return -EINVAL;
-	}
-
-	LOG_WRN("PBAP authentication relies on legacy MD5-based OBEX authentication");
-
-	memcpy(hash_input, nonce, BT_OBEX_CHALLENGE_TAG_NONCE_LEN);
-	hash_input[BT_OBEX_CHALLENGE_TAG_NONCE_LEN] = ':';
-	memcpy(hash_input + BT_OBEX_CHALLENGE_TAG_NONCE_LEN + 1U, pwd, pwd_len);
-
-	err = psa_hash_compute(PSA_ALG_MD5, (const unsigned char *)hash_input,
-			       BT_OBEX_CHALLENGE_TAG_NONCE_LEN + 1U + pwd_len, rsp_digest,
-			       BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN, &len);
-	if (err != 0) {
-		LOG_WRN("Generate response digest failed %d", err);
-		return err;
-	}
-	return 0;
-}
-
-int bt_pbap_verify_authentication(uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN],
-				  uint8_t rsp_digest[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN],
-				  const uint8_t *pwd)
-{
-	uint8_t result[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN];
-	int err;
-
-	err = bt_pbap_calculate_rsp_digest(pwd, nonce, result);
-	if (err != 0) {
-		LOG_ERR("Failed to calculate response digest %d", err);
-		return err;
-	}
-
-	err = mbedtls_ct_memcmp(result, rsp_digest, BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN);
-	if (err != 0) {
-		LOG_ERR("rsp_digest is invalid");
-		return -EINVAL;
-	}
-
-	return 0;
 }
 
 #if defined(CONFIG_BT_PBAP_PSE)

--- a/subsys/bluetooth/host/classic/pbap.c
+++ b/subsys/bluetooth/host/classic/pbap.c
@@ -14,8 +14,6 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/kernel.h>
 
-#include <psa/crypto.h>
-
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
@@ -24,8 +22,6 @@
 #include <zephyr/bluetooth/classic/sdp.h>
 #include <zephyr/bluetooth/classic/goep.h>
 #include <zephyr/bluetooth/classic/pbap.h>
-
-#include <mbedtls/constant_time.h>
 
 #include <host/conn_internal.h>
 #include "l2cap_br_internal.h"
@@ -817,113 +813,6 @@ struct net_buf *bt_pbap_pce_create_pdu(struct bt_pbap_pce *pbap_pce, struct net_
 struct net_buf *bt_pbap_pse_create_pdu(struct bt_pbap_pse *pbap_pse, struct net_buf_pool *pool)
 {
 	return bt_pbap_create_pdu(&pbap_pse->_goep, pool);
-}
-
-int bt_pbap_calculate_nonce(const uint8_t *pwd, uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN])
-{
-	int64_t timestamp = k_uptime_get();
-	uint8_t hash_input[PBAP_PWD_MAX_LENGTH + 1U + sizeof(timestamp)];
-	size_t len;
-	uint16_t pwd_len;
-	int err;
-
-	if (pwd == NULL) {
-		LOG_WRN("no available password");
-		return -EINVAL;
-	}
-
-	if (nonce == NULL) {
-		LOG_WRN("no available nonce");
-		return -EINVAL;
-	}
-
-	pwd_len = strlen(pwd);
-	if (pwd_len == 0 || pwd_len > PBAP_PWD_MAX_LENGTH) {
-		LOG_ERR("Password is invalid");
-		return -EINVAL;
-	}
-
-	LOG_WRN("PBAP authentication relies on legacy MD5-based OBEX authentication");
-
-	memcpy(hash_input, &timestamp, sizeof(timestamp));
-	hash_input[sizeof(timestamp)] = ':';
-	memcpy(hash_input + sizeof(timestamp) + 1U, pwd, pwd_len);
-	err = psa_hash_compute(PSA_ALG_MD5, (const unsigned char *)hash_input,
-			       sizeof(timestamp) + 1U + pwd_len, nonce,
-			       BT_OBEX_CHALLENGE_TAG_NONCE_LEN, &len);
-	if (err != 0) {
-		LOG_WRN("Generate nonce failed %d", err);
-		return err;
-	}
-	return 0;
-}
-
-int bt_pbap_calculate_rsp_digest(const uint8_t *pwd,
-				 const uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN],
-				 uint8_t rsp_digest[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN])
-{
-	uint8_t hash_input[PBAP_PWD_MAX_LENGTH + BT_OBEX_CHALLENGE_TAG_NONCE_LEN + 1U];
-	size_t len;
-	uint16_t pwd_len;
-	int err;
-
-	if (pwd == NULL) {
-		LOG_WRN("no available password");
-		return -EINVAL;
-	}
-
-	if (nonce == NULL) {
-		LOG_WRN("no available nonce");
-		return -EINVAL;
-	}
-
-	if (rsp_digest == NULL) {
-		LOG_WRN("no available rsp_digest");
-		return -EINVAL;
-	}
-
-	pwd_len = strlen(pwd);
-	if (pwd_len == 0 || pwd_len > PBAP_PWD_MAX_LENGTH) {
-		LOG_ERR("Password is invalid");
-		return -EINVAL;
-	}
-
-	LOG_WRN("PBAP authentication relies on legacy MD5-based OBEX authentication");
-
-	memcpy(hash_input, nonce, BT_OBEX_CHALLENGE_TAG_NONCE_LEN);
-	hash_input[BT_OBEX_CHALLENGE_TAG_NONCE_LEN] = ':';
-	memcpy(hash_input + BT_OBEX_CHALLENGE_TAG_NONCE_LEN + 1U, pwd, pwd_len);
-
-	err = psa_hash_compute(PSA_ALG_MD5, (const unsigned char *)hash_input,
-			       BT_OBEX_CHALLENGE_TAG_NONCE_LEN + 1U + pwd_len, rsp_digest,
-			       BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN, &len);
-	if (err != 0) {
-		LOG_WRN("Generate response digest failed %d", err);
-		return err;
-	}
-	return 0;
-}
-
-int bt_pbap_verify_authentication(uint8_t nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN],
-				  uint8_t rsp_digest[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN],
-				  const uint8_t *pwd)
-{
-	uint8_t result[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN];
-	int err;
-
-	err = bt_pbap_calculate_rsp_digest(pwd, nonce, result);
-	if (err != 0) {
-		LOG_ERR("Failed to calculate response digest %d", err);
-		return err;
-	}
-
-	err = mbedtls_ct_memcmp(result, rsp_digest, BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN);
-	if (err != 0) {
-		LOG_ERR("rsp_digest is invalid");
-		return -EINVAL;
-	}
-
-	return 0;
 }
 
 #if defined(CONFIG_BT_PBAP_PSE)

--- a/subsys/bluetooth/host/classic/shell/pbap.c
+++ b/subsys/bluetooth/host/classic/shell/pbap.c
@@ -62,7 +62,7 @@ struct bt_pbap_app {
 	struct net_buf *tx_buf;
 	uint8_t srm_state;
 	uint16_t peer_mopl;
-	uint8_t pwd[APP_PBAP_PWD_MAX_LENGTH];
+	char pwd[APP_PBAP_PWD_MAX_LENGTH];
 	uint8_t local_auth_challenge_nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN];
 	uint8_t peer_auth_challenge_nonce[BT_OBEX_CHALLENGE_TAG_NONCE_LEN];
 	uint8_t auth_state;
@@ -828,9 +828,10 @@ static int pbap_pce_handle_connect_success(struct bt_pbap_app *pbap_app, struct 
 		bt_shell_error("Authentication verification failed");
 		return -EINVAL;
 	}
-	err = bt_pbap_verify_authentication(pbap_app->local_auth_challenge_nonce,
-					    (uint8_t *)bt_auth.data, pbap_app->pwd);
 
+	err = bt_obex_verify_auth_response((const uint8_t *)pbap_app->pwd, strlen(pbap_app->pwd),
+					   pbap_app->local_auth_challenge_nonce,
+					   bt_auth.data);
 	if (err == 0) {
 		bt_shell_print("Authentication verified successfully");
 		bt_shell_print("Connection established with authentication");
@@ -1480,8 +1481,9 @@ static int pbap_pse_verify_local_auth(struct bt_pbap_app *pbap_app, struct net_b
 		return err;
 	}
 
-	err = bt_pbap_verify_authentication(pbap_app->local_auth_challenge_nonce,
-					    (uint8_t *)bt_auth.data, pbap_app->pwd);
+	err = bt_obex_verify_auth_response((const uint8_t *)pbap_app->pwd, strlen(pbap_app->pwd),
+					   pbap_app->local_auth_challenge_nonce,
+					   bt_auth.data);
 
 	bt_shell_print("auth %s", err == 0 ? "success" : "fail");
 	return err;
@@ -2236,7 +2238,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 
 static int cmd_add_auth_challenge(const struct shell *sh, size_t argc, char *argv[])
 {
-	uint8_t length;
+	size_t length;
 	int err;
 	struct bt_obex_tlv data;
 
@@ -2252,13 +2254,15 @@ static int cmd_add_auth_challenge(const struct shell *sh, size_t argc, char *arg
 
 	length = strlen(argv[1]);
 	if (length >= APP_PBAP_PWD_MAX_LENGTH) {
-		bt_shell_error("the length is too long, %d >= %d", length, APP_PBAP_PWD_MAX_LENGTH);
+		bt_shell_error("the length is too long, %zu >= %u", length,
+			       APP_PBAP_PWD_MAX_LENGTH);
 		return -EINVAL;
 	}
 	memcpy(g_pbap_app->pwd, argv[1], length);
 	g_pbap_app->pwd[length] = '\0';
 
-	err = bt_pbap_calculate_nonce(g_pbap_app->pwd, g_pbap_app->local_auth_challenge_nonce);
+	err = bt_obex_generate_nonce((const uint8_t *)g_pbap_app->pwd, length,
+				     g_pbap_app->local_auth_challenge_nonce);
 	if (err != 0) {
 		bt_shell_error("generate auth_challenge nonce failed, err : %d", err);
 		return -EINVAL;
@@ -2279,7 +2283,7 @@ static int cmd_add_auth_challenge(const struct shell *sh, size_t argc, char *arg
 
 static int cmd_add_auth_response(const struct shell *sh, size_t argc, char *argv[])
 {
-	uint8_t length;
+	size_t length;
 	int err;
 	struct bt_obex_tlv data;
 	uint8_t bt_auth_data[BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN] = {0};
@@ -2296,7 +2300,8 @@ static int cmd_add_auth_response(const struct shell *sh, size_t argc, char *argv
 
 	length = strlen(argv[1]);
 	if (length >= APP_PBAP_PWD_MAX_LENGTH) {
-		bt_shell_error("the length is too long, %d >= %d", length, APP_PBAP_PWD_MAX_LENGTH);
+		bt_shell_error("the length is too long, %zu >= %u", length,
+			       APP_PBAP_PWD_MAX_LENGTH);
 		return -EINVAL;
 	}
 	memcpy(g_pbap_app->pwd, argv[1], length);
@@ -2305,8 +2310,9 @@ static int cmd_add_auth_response(const struct shell *sh, size_t argc, char *argv
 	data.type = BT_OBEX_RESPONSE_TAG_REQ_DIGEST;
 	data.data_len = BT_OBEX_RESPONSE_TAG_REQ_DIGEST_LEN;
 	data.data = bt_auth_data;
-	err = bt_pbap_calculate_rsp_digest(g_pbap_app->pwd, g_pbap_app->peer_auth_challenge_nonce,
-					   bt_auth_data);
+	err = bt_obex_calculate_request_digest((const uint8_t *)g_pbap_app->pwd, length,
+					       g_pbap_app->peer_auth_challenge_nonce,
+					       bt_auth_data);
 	if (err != 0) {
 		bt_shell_error("generate auth_challenge response failed, err : %d", err);
 		return -EINVAL;


### PR DESCRIPTION
Move OBEX authentication functions from PBAP to the OBEX layer to make them available for other OBEX-based profiles. The authentication implementation remains unchanged but is now part of the generic OBEX API rather than being PBAP-specific.

Move `bt_pbap_calculate_nonce()` to `bt_obex_generate_nonce()`. Move `bt_pbap_calculate_rsp_digest()` to
`bt_obex_calculate_request_digest()`. Move `bt_pbap_verify_authentication()` to `bt_obex_verify_auth_response()`.

The refactoring allows other OBEX-based profiles to use the same authentication mechanism without code duplication.