### PR TITLE
boards: nxp: imx943_evk: specify mode selection for SM

### DIFF
--- a/boards/nxp/imx943_evk/CMakeLists.txt
+++ b/boards/nxp/imx943_evk/CMakeLists.txt
@@ -23,12 +23,18 @@ if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
     if(CONFIG_SOC_MIMX94398_M7_0)
       set(AHAB_CONFIG_FILE "imx943_evk_mimx94398_m7_0_ahab.yaml")
       set(M_IMAGE_NAME "cortex_m7_app")
+      set(MSEL "4")
     elseif(CONFIG_SOC_MIMX94398_M7_1)
       set(AHAB_CONFIG_FILE "imx943_evk_mimx94398_m7_1_ahab.yaml")
       set(M_IMAGE_NAME "cortex_m7_2_app")
+      set(MSEL "5")
     elseif(CONFIG_SOC_MIMX94398_M33)
       set(AHAB_CONFIG_FILE "imx943_evk_mimx94398_m33_ahab.yaml")
       set(M_IMAGE_NAME "cortex_m33_2_app")
+      set(MSEL "3")
+    endif()
+    if(SPSDK_VERSION VERSION_LESS "3.8.0")
+      message(FATAL_ERROR "meta_data_msel is not supported when SPSDK's version less than 3.8.0!")
     endif()
     file(WRITE ${CMAKE_BINARY_DIR}/zephyr/${AHAB_CONFIG_FILE}
       "
@@ -48,6 +54,7 @@ if(CONFIG_BOARD_NXP_SPSDK_IMAGE OR (DEFINED ENV{USE_NXP_SPSDK_IMAGE}
                 lpddr_dmem_qb:  ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/${DDR_FW}_dmem_qb_v202409.bin
                 oei_ddr:        ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/oei-m33-ddr-${DDR_FW}.bin
               - system_manager: ${CMAKE_BINARY_DIR}/zephyr/${FIRMWARE_RELEASE}/m33_image-mx94alt.bin
+                meta_data_msel: ${MSEL}
               - ${M_IMAGE_NAME}:  ${CMAKE_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.bin
     ")
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands


### PR DESCRIPTION
Add the AHAB meta_data_msel field to the generated image configuration so that the System Manager knows which MCU to kick up on the i.MX943 EVK. A distinct mode selection value is assigned per target core:

  - Cortex-M7_0 -> MSEL 4
  - Cortex-M7_1 -> MSEL 5
  - Cortex-M33  -> MSEL 3

The meta_data_msel field is only supported by SPSDK 3.8.0 and later, so guard its use with a version check and fail early with a clear error message when an older SPSDK is detected.