### PR TITLE
usb: Fix incorrect Doxygen comments in USB headers

### DIFF
--- a/include/zephyr/usb/class/hid.h
+++ b/include/zephyr/usb/class/hid.h
@@ -325,8 +325,8 @@ extern "C" {
 /**
  * @brief Define HID Logical Maximum item with the data length of two bytes.
  *
- * @param a Minimum value lower byte
- * @param b Minimum value higher byte
+ * @param a Maximum value lower byte
+ * @param b Maximum value higher byte
  * @return  HID Logical Maximum item
  */
 #define HID_LOGICAL_MAX16(a, b)		\
@@ -347,10 +347,10 @@ extern "C" {
 /**
  * @brief Define HID Logical Maximum item with the data length of four bytes.
  *
- * @param a Minimum value lower byte
- * @param b Minimum value low middle byte
- * @param c Minimum value high middle byte
- * @param d Minimum value higher byte
+ * @param a Maximum value lower byte
+ * @param b Maximum value low middle byte
+ * @param c Maximum value high middle byte
+ * @param d Maximum value higher byte
  * @return  HID Logical Maximum item
  */
 #define HID_LOGICAL_MAX32(a, b, c, d)	\

--- a/include/zephyr/usb/class/usb_audio.h
+++ b/include/zephyr/usb/class/usb_audio.h
@@ -170,6 +170,7 @@ enum usb_audio_terminal_types {
 	USB_AUDIO_IO_SPEAKERPHONE_ECHO_SUP	= 0x0404,
 	/** Speakerphone, echo cancellation */
 	USB_AUDIO_IO_SPEAKERPHONE_ECHO_CAN	= 0x0405,
+	/** @} */
 };
 
 /**

--- a/include/zephyr/usb/class/usbd_dfu.h
+++ b/include/zephyr/usb/class/usbd_dfu.h
@@ -147,6 +147,7 @@ struct usbd_dfu_image {
  *
  * @param id     Identifier by which the linker sorts registered images
  * @param iname  Image name as used in interface descriptor
+ * @param ipriv  Pointer to private data passed to the callbacks
  * @param iread  Image read callback
  * @param iwrite Image write callback
  * @param inext  Notify/confirm next state

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -1109,12 +1109,14 @@ int usbd_ep_buf_free(struct usbd_context *uds_ctx, struct net_buf *buf);
  *
  * @param[in] uds_ctx Pointer to USB device support context
  *
- * @return true if endpoint is halted, false otherwise
+ * @return true if the device is suspended, false otherwise
  */
 bool usbd_is_suspended(struct usbd_context *uds_ctx);
 
 /**
  * @brief Initiate the USB remote wakeup (TBD)
+ *
+ * @param[in] uds_ctx Pointer to USB device support context
  *
  * @return 0 on success, other values on fail.
  */


### PR DESCRIPTION
Fix a number of errors in Doxygen comments: copy-pasted parameter wording, missing `@param`, wrong `@return`, ...

No functional change.