### PR TITLE
net: lib: dns: remove dns_dispatcher_init()

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -689,7 +689,6 @@ static inline int services_init(void)
 
 	net_dhcpv4_server_init();
 
-	dns_dispatcher_init();
 	dns_init_resolver();
 	mdns_init_responder();
 

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -152,12 +152,6 @@ static inline int net_context_get_local_addr(struct net_context *context,
 }
 #endif
 
-#if defined(CONFIG_DNS_SOCKET_DISPATCHER)
-extern void dns_dispatcher_init(void);
-#else
-static inline void dns_dispatcher_init(void) { }
-#endif
-
 #if defined(CONFIG_MDNS_RESPONDER)
 extern void mdns_init_responder(void);
 #else

--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(net_dns_dispatcher, CONFIG_DNS_SOCKET_DISPATCHER_LOG_LEVEL);
 
 static K_MUTEX_DEFINE(lock);
 
-static sys_slist_t sockets;
+static sys_slist_t sockets = SYS_SLIST_STATIC_INIT(&sockets);
 
 #define DNS_RESOLVER_MIN_BUF	1
 #define DNS_RESOLVER_BUF_CTR	(DNS_RESOLVER_MIN_BUF + \
@@ -359,9 +359,4 @@ out:
 	k_mutex_unlock(&lock);
 
 	return ret;
-}
-
-void dns_dispatcher_init(void)
-{
-	sys_slist_init(&sockets);
 }


### PR DESCRIPTION
remove dns_dispatcher_init, as
it is no longer needed.