### PR TITLE
sys: Fix incorrect Doxygen documentation in utility headers

### DIFF
--- a/include/zephyr/sys/bitarray.h
+++ b/include/zephyr/sys/bitarray.h
@@ -189,11 +189,11 @@ int sys_bitarray_xor(sys_bitarray_t *dst, sys_bitarray_t *other, size_t num_bits
 /**
  * Find nth bit set in region
  *
- * This counts the number of bits set (@p count) in a
- * region (@p offset, @p num_bits) and returns the index (@p found_at)
- * of the nth set bit, if it exists, as long with a zero return value.
+ * This searches the region (@p offset, @p num_bits) and returns the index
+ * (@p found_at) of the nth set bit, if it exists, along with a zero return
+ * value.
  *
- * If it does not exist, @p found_at is not updated and the method returns
+ * If it does not exist, @p found_at is not updated and the method returns 1.
  *
  * @param[in]  bitarray Bitarray struct
  * @param[in]  n        Nth bit set to look for

--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -103,6 +103,8 @@ extern "C" {
  *
  * @param x argument.
  *
+ * @param flags Package flags.
+ *
  * @return 1 if char * or wchar_t *, 0 otherwise.
  */
 #ifdef __cplusplus
@@ -535,6 +537,8 @@ extern "C" {
 
 /** @brief Calculate number of char * or wchar_t * arguments in the arguments.
  *
+ * @param flags Flags. See @p CBPRINTF_PACKAGE_FLAGS.
+ *
  * @param fmt string.
  *
  * @param ... string arguments.
@@ -693,6 +697,8 @@ extern "C" {
  * Argument is put into the buffer if capable buffer is provided. Length is
  * incremented even if data is not packaged.
  *
+ * @param arg_idx Argument index.
+ *
  * @param _buf buffer.
  *
  * @param _idx index. Index is postincremented.
@@ -746,6 +752,8 @@ do { \
 /** @brief Package single argument.
  *
  * Macro is called in a loop for each argument in the string.
+ *
+ * @param arg_idx Argument index.
  *
  * @param arg argument.
  */

--- a/include/zephyr/sys/crc.h
+++ b/include/zephyr/sys/crc.h
@@ -127,7 +127,7 @@ enum crc_type {
  * and polynomial used in addition to the initial value. This is O(n*8) where n
  * is the length of the buffer provided. No reflection is performed.
  *
- * @note If you are planning to use a CRC based on poly 0x1012 the functions
+ * @note If you are planning to use a CRC based on poly 0x1021 the functions
  * crc16_itu_t() is faster and thus recommended over this one.
  *
  * @param poly The polynomial to use omitting the leading x^16
@@ -148,7 +148,7 @@ uint16_t crc16(uint16_t poly, uint16_t seed, const uint8_t *src, size_t len);
  * and polynomial used in addition to the initial value. This is O(n*8) where n
  * is the length of the buffer provided. Both input and output are reflected.
  *
- * @note If you are planning to use a CRC based on poly 0x1012 the function
+ * @note If you are planning to use a CRC based on poly 0x1021 the function
  * crc16_ccitt() is faster and thus recommended over this one.
  *
  * The following checksums can, among others, be calculated by this function,

--- a/include/zephyr/sys/device_mmio.h
+++ b/include/zephyr/sys/device_mmio.h
@@ -305,7 +305,7 @@ static inline void device_unmap(mm_reg_t virt_addr, size_t size)
 	._mmio = Z_DEVICE_MMIO_ROM_INITIALIZER(node_id)
 
 /**
- * @def DEVICE_MMIO_MAP(device, flags)
+ * @def DEVICE_MMIO_MAP(dev, flags)
  *
  * @brief Map MMIO memory into the address space
  *

--- a/include/zephyr/sys/hash_map.h
+++ b/include/zephyr/sys/hash_map.h
@@ -33,7 +33,7 @@ extern "C" {
  *
  * Declare a Hashmap with control over advanced parameters.
  *
- * @note The allocator @p _alloc is used for allocating internal Hashmap
+ * @note The allocator @p _alloc_func is used for allocating internal Hashmap
  * entries and does not interact with any user-provided keys or values.
  *
  * @param _name Name of the Hashmap.
@@ -61,7 +61,7 @@ extern "C" {
  *
  * Declare a Hashmap statically with control over advanced parameters.
  *
- * @note The allocator @p _alloc is used for allocating internal Hashmap
+ * @note The allocator @p _alloc_func is used for allocating internal Hashmap
  * entries and does not interact with any user-provided keys or values.
  *
  * @param _name Name of the Hashmap.
@@ -266,7 +266,7 @@ static inline bool sys_hashmap_is_empty(const struct sys_hashmap *map)
  * @brief Query the load factor of @p map
  *
  * @note To convert the load factor to a floating-point value use
- * `sys_hash_load_factor(map) / 100.0f`.
+ * `sys_hashmap_load_factor(map) / 100.0f`.
  *
  * @param map Hashmap to query
  *

--- a/include/zephyr/sys/hash_map_cxx.h
+++ b/include/zephyr/sys/hash_map_cxx.h
@@ -32,7 +32,7 @@ extern "C" {
  *
  * Declare a C++ Hashmap with control over advanced parameters.
  *
- * @note The allocator @p _alloc is used for allocating internal Hashmap
+ * @note The allocator @p _alloc_func is used for allocating internal Hashmap
  * entries and does not interact with any user-provided keys or values.
  *
  * @param _name Name of the Hashmap.
@@ -49,7 +49,7 @@ extern "C" {
  *
  * Declare a C++ Hashmap with control over advanced parameters.
  *
- * @note The allocator @p _alloc is used for allocating internal Hashmap
+ * @note The allocator @p _alloc_func is used for allocating internal Hashmap
  * entries and does not interact with any user-provided keys or values.
  *
  * @param _name Name of the Hashmap.

--- a/include/zephyr/sys/hash_map_oa_lp.h
+++ b/include/zephyr/sys/hash_map_oa_lp.h
@@ -36,7 +36,7 @@ struct sys_hashmap_oa_lp_data {
  *
  * Declare a Open Addressing Linear Probe Hashmap with control over advanced parameters.
  *
- * @note The allocator @p _alloc is used for allocating internal Hashmap
+ * @note The allocator @p _alloc_func is used for allocating internal Hashmap
  * entries and does not interact with any user-provided keys or values.
  *
  * @param _name Name of the Hashmap.
@@ -53,7 +53,7 @@ struct sys_hashmap_oa_lp_data {
  *
  * Declare a Open Addressing Linear Probe Hashmap with control over advanced parameters.
  *
- * @note The allocator @p _alloc is used for allocating internal Hashmap
+ * @note The allocator @p _alloc_func is used for allocating internal Hashmap
  * entries and does not interact with any user-provided keys or values.
  *
  * @param _name Name of the Hashmap.

--- a/include/zephyr/sys/hash_map_sc.h
+++ b/include/zephyr/sys/hash_map_sc.h
@@ -49,7 +49,7 @@ extern "C" {
  *
  * Declare a Separate Chaining Hashmap with control over advanced parameters.
  *
- * @note The allocator @p _alloc is used for allocating internal Hashmap
+ * @note The allocator @p _alloc_func is used for allocating internal Hashmap
  * entries and does not interact with any user-provided keys or values.
  *
  * @param _name Name of the Hashmap.

--- a/include/zephyr/sys/iterable_sections.h
+++ b/include/zephyr/sys/iterable_sections.h
@@ -66,7 +66,7 @@ extern "C" {
  * will return '_<SECNAME>_list_end'.
  *
  * @param[in]  secname type name of iterable section.  For 'struct foobar' this
- * would be TYPE_SECTION_START(foobar)
+ * would be TYPE_SECTION_END(foobar)
  */
 #define TYPE_SECTION_END(secname) _CONCAT(_##secname, _list_end)
 

--- a/include/zephyr/sys/mem_manage.h
+++ b/include/zephyr/sys/mem_manage.h
@@ -27,7 +27,7 @@
 /**
  * @brief Check if a physical address is within range of physical memory.
  *
- * This checks if the physical address (@p virt) is within
+ * This checks if the physical address (@p phys) is within
  * permissible range, e.g. between
  * :c:macro:`DT_CHOSEN_SRAM_ADDR` and
  * (:c:macro:`DT_CHOSEN_SRAM_ADDR` +

--- a/include/zephyr/sys/sys_heap.h
+++ b/include/zephyr/sys/sys_heap.h
@@ -261,7 +261,7 @@ static inline bool sys_heap_validate(struct sys_heap *heap)
  * @param alloc_fn Callback to perform an allocation.  Passes back the @a
  *              arg parameter as a context handle.
  * @param free_fn Callback to perform a free of a pointer returned from
- *             @a alloc.  Passes back the @a arg parameter as a
+ *             @a alloc_fn.  Passes back the @a arg parameter as a
  *             context handle.
  * @param arg Context handle to pass back to the callbacks
  * @param total_bytes Size of the byte array the heap was initialized in

--- a/include/zephyr/sys/timeutil.h
+++ b/include/zephyr/sys/timeutil.h
@@ -329,7 +329,7 @@ int timeutil_sync_ref_from_local(const struct timeutil_sync_state *tsp,
  * @retval 1 if successful with a skew not equal to 1
  * @retval -EINVAL
  *   * the time synchronization state is not adequately initialized
- *   * @p refp is null
+ *   * @p localp is null
  */
 int timeutil_sync_local_from_ref(const struct timeutil_sync_state *tsp,
 				 uint64_t ref, int64_t *localp);

--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -686,8 +686,8 @@ int char2hex(char c, uint8_t *x);
 /**
  * @brief      Convert a single hexadecimal nibble into a character.
  *
- * @param c     The number to convert
- * @param x     The address of storage for the converted character.
+ * @param x     The number to convert
+ * @param c     The address of storage for the converted character.
  *
  *  @return Zero on success or (negative) error code otherwise.
  */

--- a/include/zephyr/sys/uuid.h
+++ b/include/zephyr/sys/uuid.h
@@ -116,8 +116,8 @@ bool uuid_is_nil(const struct uuid *data);
  * @param data Input data to copy.
  * @param out Destination for the copy.
  *
- * @retval 0 The UUID has been correctly copied in @p dst
- * @retval -EINVAL @p dst is not acceptable
+ * @retval 0 The UUID has been correctly copied in @p out
+ * @retval -EINVAL @p out is not acceptable
  */
 int uuid_copy(const struct uuid *data, struct uuid *out);
 
@@ -139,18 +139,18 @@ int uuid_from_buffer(const uint8_t data[UUID_SIZE], struct uuid *out);
  * @param out The UUID where the result will be written.
  *
  * @retval 0 The UUID has been correctly parsed and stored in @p out
- * @retval -EINVAL @p input or @p out are not acceptable
+ * @retval -EINVAL @p data or @p out are not acceptable
  */
 int uuid_from_string(const char data[UUID_STR_LEN], struct uuid *out);
 
 /**
- * @brief Create a uuid_t from a binary (big-endian) formatted UUID.
+ * @brief Store a UUID into a binary (big-endian) formatted buffer.
  *
  * @param data The input UUID to store in the buffer.
  * @param out The buffer where the binary UUID is stored in a big-endian order.
  *
- * @retval 0 The UUID has been correctly parsed and stored in @p buff
- * @retval -EINVAL @p buff is not acceptable
+ * @retval 0 The UUID has been correctly parsed and stored in @p out
+ * @retval -EINVAL @p out is not acceptable
  */
 int uuid_to_buffer(const struct uuid *data, uint8_t out[UUID_SIZE]);
 


### PR DESCRIPTION
Correct a number of errors in Doxygen comments: @param / @p references that don't match signatures, undocumented macro parameters, ...