### PR TITLE
net: conn_mgr: use NET_MGMT_REGISTER_EVENT_HANDLER

### DIFF
--- a/subsys/net/conn_mgr/conn_mgr_monitor.c
+++ b/subsys/net/conn_mgr/conn_mgr_monitor.c
@@ -220,47 +220,6 @@ static void conn_mgr_mon_handle_update(void)
 	k_mutex_unlock(&conn_mgr_mon_lock);
 }
 
-/**
- * @brief Initialize the internal state flags for the given iface using its current status
- *
- * @param iface - iface to initialize from.
- */
-static void conn_mgr_mon_initial_state(struct net_if *iface)
-{
-	int idx = conn_mgr_get_index_for_if(iface);
-
-	k_mutex_lock(&conn_mgr_mon_lock, K_FOREVER);
-
-	if (net_if_is_up(iface)) {
-		NET_DBG("Iface %p UP", iface);
-		iface_states[idx] |= CONN_MGR_IF_UP;
-	}
-
-	if (IS_ENABLED(CONFIG_NET_NATIVE_IPV6)) {
-		if (net_if_ipv6_get_global_addr(NET_ADDR_PREFERRED, &iface)) {
-			NET_DBG("IPv6 addr set");
-			iface_states[idx] |= CONN_MGR_IF_IPV6_SET;
-		}
-	}
-
-	if (IS_ENABLED(CONFIG_NET_NATIVE_IPV4)) {
-		if (net_if_ipv4_get_global_addr(iface, NET_ADDR_PREFERRED)) {
-			NET_DBG("IPv4 addr set");
-			iface_states[idx] |= CONN_MGR_IF_IPV4_SET;
-		}
-
-	}
-
-	k_mutex_unlock(&conn_mgr_mon_lock);
-}
-
-static void conn_mgr_mon_init_cb(struct net_if *iface, void *user_data)
-{
-	ARG_UNUSED(user_data);
-
-	conn_mgr_mon_initial_state(iface);
-}
-
 static void conn_mgr_mon_thread_fn(void *p1, void *p2, void *p3)
 {
 	ARG_UNUSED(p1);
@@ -270,10 +229,6 @@ static void conn_mgr_mon_thread_fn(void *p1, void *p2, void *p3)
 	k_mutex_lock(&conn_mgr_mon_lock, K_FOREVER);
 
 	conn_mgr_conn_init();
-
-	conn_mgr_init_events_handler();
-
-	net_if_foreach(conn_mgr_mon_init_cb, NULL);
 
 	k_mutex_unlock(&conn_mgr_mon_lock);
 

--- a/subsys/net/conn_mgr/conn_mgr_private.h
+++ b/subsys/net/conn_mgr/conn_mgr_private.h
@@ -60,8 +60,6 @@
 extern struct k_sem conn_mgr_mon_updated;
 extern struct k_mutex conn_mgr_mon_lock;
 
-void conn_mgr_init_events_handler(void);
-
 /* Cause conn_mgr_connectivity to Initialize all connectivity implementation bindings */
 void conn_mgr_conn_init(void);
 

--- a/subsys/net/conn_mgr/events_handler.c
+++ b/subsys/net/conn_mgr/events_handler.c
@@ -13,13 +13,9 @@ LOG_MODULE_DECLARE(conn_mgr, CONFIG_NET_CONNECTION_MANAGER_LOG_LEVEL);
 #include <zephyr/net/net_mgmt.h>
 #include "conn_mgr_private.h"
 
-static struct net_mgmt_event_callback iface_events_cb;
-static struct net_mgmt_event_callback ipv6_events_cb;
-static struct net_mgmt_event_callback ipv4_events_cb;
-
-static void conn_mgr_iface_events_handler(struct net_mgmt_event_callback *cb,
-					  uint64_t mgmt_event,
-					  struct net_if *iface)
+static void conn_mgr_iface_events_handler(uint64_t mgmt_event, struct net_if *iface,
+					  void *info __unused, size_t info_length __unused,
+					  void *user_data __unused)
 {
 	uint16_t *iface_states = conn_mgr_if_state_internal();
 	int idx;
@@ -53,10 +49,13 @@ done:
 	k_mutex_unlock(&conn_mgr_mon_lock);
 }
 
+NET_MGMT_REGISTER_EVENT_HANDLER(conn_mgr_iface_events, CONN_MGR_IFACE_EVENTS_MASK,
+				conn_mgr_iface_events_handler, NULL);
+
 #if defined(CONFIG_NET_IPV6)
-static void conn_mgr_ipv6_events_handler(struct net_mgmt_event_callback *cb,
-					 uint64_t mgmt_event,
-					 struct net_if *iface)
+static void conn_mgr_ipv6_events_handler(uint64_t mgmt_event, struct net_if *iface,
+					 void *info __unused, size_t info_length __unused,
+					 void *user_data __unused)
 {
 	uint16_t *iface_states = conn_mgr_if_state_internal();
 	int idx;
@@ -99,22 +98,15 @@ static void conn_mgr_ipv6_events_handler(struct net_mgmt_event_callback *cb,
 done:
 	k_mutex_unlock(&conn_mgr_mon_lock);
 }
-#else
-static inline
-void conn_mgr_ipv6_events_handler(struct net_mgmt_event_callback *cb,
-				  uint64_t mgmt_event,
-				  struct net_if *iface)
-{
-	ARG_UNUSED(cb);
-	ARG_UNUSED(mgmt_event);
-	ARG_UNUSED(iface);
-}
+
+NET_MGMT_REGISTER_EVENT_HANDLER(conn_mgr_ipv6_events, CONN_MGR_IPV6_EVENTS_MASK,
+				conn_mgr_ipv6_events_handler, NULL);
 #endif /* CONFIG_NET_IPV6 */
 
 #if defined(CONFIG_NET_IPV4)
-static void conn_mgr_ipv4_events_handler(struct net_mgmt_event_callback *cb,
-					 uint64_t mgmt_event,
-					 struct net_if *iface)
+static void conn_mgr_ipv4_events_handler(uint64_t mgmt_event, struct net_if *iface,
+					 void *info __unused, size_t info_length __unused,
+					 void *user_data __unused)
 {
 	uint16_t *iface_states = conn_mgr_if_state_internal();
 	int idx;
@@ -158,36 +150,7 @@ static void conn_mgr_ipv4_events_handler(struct net_mgmt_event_callback *cb,
 done:
 	k_mutex_unlock(&conn_mgr_mon_lock);
 }
-#else
-static inline
-void conn_mgr_ipv4_events_handler(struct net_mgmt_event_callback *cb,
-				  uint64_t mgmt_event,
-				  struct net_if *iface)
-{
-	ARG_UNUSED(cb);
-	ARG_UNUSED(mgmt_event);
-	ARG_UNUSED(iface);
-}
+
+NET_MGMT_REGISTER_EVENT_HANDLER(conn_mgr_ipv4_events, CONN_MGR_IPV4_EVENTS_MASK,
+				conn_mgr_ipv4_events_handler, NULL);
 #endif /* CONFIG_NET_IPV4 */
-
-void conn_mgr_init_events_handler(void)
-{
-	net_mgmt_init_event_callback(&iface_events_cb,
-				     conn_mgr_iface_events_handler,
-				     CONN_MGR_IFACE_EVENTS_MASK);
-	net_mgmt_add_event_callback(&iface_events_cb);
-
-	if (IS_ENABLED(CONFIG_NET_IPV6)) {
-		net_mgmt_init_event_callback(&ipv6_events_cb,
-					     conn_mgr_ipv6_events_handler,
-					     CONN_MGR_IPV6_EVENTS_MASK);
-		net_mgmt_add_event_callback(&ipv6_events_cb);
-	}
-
-	if (IS_ENABLED(CONFIG_NET_IPV4)) {
-		net_mgmt_init_event_callback(&ipv4_events_cb,
-					     conn_mgr_ipv4_events_handler,
-					     CONN_MGR_IPV4_EVENTS_MASK);
-		net_mgmt_add_event_callback(&ipv4_events_cb);
-	}
-}


### PR DESCRIPTION
use NET_MGMT_REGISTER_EVENT_HANDLER,
so we no longer need to init that part durring
runtime. As these are now registered durring
build we also no longer have to check the state
of the ifaces before registering the event handlers.