### PR TITLE
manifest: tf-m: include fix for FWU partition

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -399,7 +399,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: 52c7593c1f361a9d7cebc0fa83e5bcfb1e415032
+      revision: pull/210/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Bump revision of trusted-firmware-m to include fix for FWU partition support.

Fixes the following error when `CONFIG_TFM_PARTITION_FIRMWARE_UPDATE=y`:
```
In file included from /home/user/west_workspace/modules/crypto/tf-psa-crypto/include/psa/crypto_platform.h:24,
                 from /home/user/west_workspace/modules/crypto/tf-psa-crypto/include/psa/crypto.h:16,
                 from /home/user/west_workspace/modules/tee/tf-m/trusted-firmware-m/secure_fw/partitions/firmware_update/bootloader/mcuboot/tfm_mcuboot_fwu.c:8:
/home/user/west_workspace/modules/crypto/tf-psa-crypto/include/tf-psa-crypto/build_info.h:173:10: fatal error: mbedtls/private/crypto_adjust_config_tweak_builtins.h: No such file or directory
  173 | #include "mbedtls/private/crypto_adjust_config_tweak_builtins.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```