### PR TITLE
dts: bindings: wifi: fix compatible in airoc-wifi example

### DIFF
--- a/dts/bindings/wifi/infineon,airoc-wifi.yaml
+++ b/dts/bindings/wifi/infineon,airoc-wifi.yaml
@@ -42,7 +42,7 @@ examples:
       /* Wifi configuration */
       airoc-wifi {
         status = "okay";
-        compatible = "infineon,airoc-wifi-sdio";
+        compatible = "infineon,airoc-wifi";
 
         /* Wi-Fi control gpios */
         wifi-reg-on-gpios    = <&gpio_prt2 6 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
Example was using incorrect compatible