### PR TITLE
net: lib: rtp: Avoid label at end of compound statement warning

### DIFF
--- a/subsys/net/lib/rtp/rtp.c
+++ b/subsys/net/lib/rtp/rtp.c
@@ -53,7 +53,7 @@ static int rtp_session_start_rx(struct rtp_session *session)
 	}
 #endif /* CONFIG_NET_IPV6 */
 	default:
-		/* Ignore */
+		break; /* Ignore */
 	}
 #endif /* CONFIG_RTP_LOG_LEVEL >= LOG_LEVEL_DBG */
 
@@ -129,7 +129,7 @@ static int rtp_session_start_tx(struct rtp_session *session)
 	}
 #endif /* CONFIG_NET_IPV6 */
 	default:
-		/* Ignore */
+		break; /* Ignore */
 	}
 #endif /* CONFIG_RTP_LOG_LEVEL >= LOG_LEVEL_DBG */
 
@@ -172,7 +172,7 @@ static int rtp_session_stop_rx(struct rtp_session *session)
 	}
 #endif /* CONFIG_NET_IPV6 */
 	default:
-		/* Ignore */
+		break; /* Ignore */
 	}
 #endif
 
@@ -221,7 +221,7 @@ static int rtp_session_stop_tx(struct rtp_session *session)
 	}
 #endif /* CONFIG_NET_IPV6 */
 	default:
-		/* Ignore */
+		break; /* Ignore */
 	}
 #endif /* CONFIG_RTP_LOG_LEVEL >= LOG_LEVEL_DBG */
 


### PR DESCRIPTION
A label at the end of a block is, in principle an extension. clang warns about this even in switch defaults, so let's just add a break in that final empty case.

can be seen failing in CI here:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/29791027580/job/88512664578#step:12:2219

Can be repro'd w
`ZEPHYR_TOOLCHAIN_VARIANT=host/llvm twister -T tests/net/rtp/loopback/ -p native_sim`

