### PR TITLE
FRDM-MCXL255: LPADC support for CM33

### DIFF
--- a/boards/nxp/frdm_mcxl255/board.c
+++ b/boards/nxp/frdm_mcxl255/board.c
@@ -127,6 +127,13 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_GateAonUART);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpadc0))
+	CLOCK_AttachClk(kFRO12M_to_ADC0);
+	CLOCK_SetClockDiv(kCLOCK_DivADC0, 1U);
+	RESET_ReleasePeripheralReset(kADC0_RST_SHIFT_RSTn);
+	CLOCK_EnableClock(kCLOCK_GateADC0);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(aon_qtmr0)) || \
 	DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(aon_qtmr1))
 	CLOCK_AttachClk(kFROdiv4_to_AON_TMR);

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255-pinctrl.dtsi
@@ -16,6 +16,15 @@
 		};
 	};
 
+	pinmux_lpadc0: pinmux_lpadc0 {
+		group0 {
+			pinmux = <HSADC0_A0_P3_9>,
+				 <HSADC0_A1_P3_4>;
+			drive-strength = "low";
+			slew-rate = "fast";
+		};
+	};
+
 	pinmux_aon_lpuart0: pinmux_aon_lpuart0 {
 		group0 {
 			pinmux = <AON_LPUART0_TX_P0_6>,

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
@@ -99,6 +99,12 @@
 	pinctrl-names = "default";
 };
 
+&lpadc0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpadc0>;
+	pinctrl-names = "default";
+};
+
 &rtc {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.yaml
@@ -15,4 +15,5 @@ supported:
   - gpio
   - rtc
   - crc
+  - adc
 vendor: nxp

--- a/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxl255_cm33.dtsi
@@ -43,6 +43,24 @@
 	arm,num-irq-priority-bits = <3>;
 };
 
+&peripheral {
+	lpadc0: adc@af000 {
+		compatible = "nxp,lpc-lpadc";
+		reg = <0xaf000 0x1000>;
+		interrupts = <62 0>;
+		status = "disabled";
+		clk-divider = <1>;
+		clk-source = <0>;
+		voltage-ref = <1>;
+		calibration-average = <128>;
+		power-level = <1>;
+		offset-value-a = <0>;
+		offset-value-b = <0>;
+		#io-channel-cells = <1>;
+		clocks = <&syscon MCUX_LPADC1_CLK>;
+	};
+};
+
 &aon_qtmr0 {
 	interrupts = <151 0>;
 };


### PR DESCRIPTION
Add LPADC support for the FRDM-MCXL255 CM33 core.

This PR adds the MCXL255 main-domain ADC0 devicetree node, enables ADC0
on FRDM-MCXL255 CM33, and configures the required clock, reset, and
analog input pins.

The ADC is exposed through the existing NXP LPADC driver. Analog
inputs HSADC0_A0 on P3_9 and HSADC0_A1 on P3_4 are configured.

Tested on frdm_mcxl255/mcxl255/cpu0:
- samples/hello_world
- samples/drivers/adc/adc_dt (with custom overlay)