### PR TITLE
dts: arm: st: n6: use empty ranges for pinctrl

### DIFF
--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -390,7 +390,7 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 				reg = <0x56020000 0x4400>;
-				ranges = <0x56020000 0x56020000 0x4400>;
+				ranges;
 
 				gpioa: gpio@56020000 {
 					compatible = "st,stm32-gpio";


### PR DESCRIPTION
The provided `ranges` property was performing using an identity mapping, so it's wiser to replace it with an empty `ranges;` instead.

cc @arnopo 