### PR TITLE
github: hello_world: test on cortex-m3 on windows

### DIFF
--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -79,7 +79,7 @@ jobs:
             EXTRA_TWISTER_FLAGS="--exclude-platform native_sim/native"
           fi
           west twister \
-              -p native_sim -p qemu_cortex_m0 -p qemu_riscv32 -p qemu_riscv64 \
+              -p native_sim -p qemu_cortex_m3 -p qemu_riscv32 -p qemu_riscv64 \
               --runtime-artifact-cleanup \
               --force-color \
               --inline-logs \


### PR DESCRIPTION
Seems like qemu on windows is not very reliable and cortex-m0 has some clock issues, set test on cortex-m3 instead.

Link: https://github.com/zephyrproject-rtos/zephyr/pull/113543#pullrequestreview-4739248986