### PR TITLE
Revert 112539 (llext: enable loadable extensions under userspace on RISC-V) due to failing llext test 

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -1112,20 +1112,9 @@ static void resync_pmp_domain(struct k_thread *thread,
 				   PMP_U_MODE(thread));
 #endif
 
-		/*
-		 * The available slot count is an optimistic estimate (see
-		 * arch_mem_domain_max_partitions_get), so a domain may hold more
-		 * partitions than fit in this thread's remaining PMP entries. If we
-		 * run out, stop programming rather than asserting: the thread runs
-		 * with the partitions that fit and faults - only that thread - on an
-		 * access to an unmapped one, which is recoverable, whereas an assert
-		 * here runs during a context switch and takes down the whole system.
-		 */
-		if (!ok) {
-			LOG_ERR("no PMP slot left for %d remaining partitions in domain %p",
-				remaining_partitions + 1, domain);
-			break;
-		}
+		__ASSERT(ok,
+			 "no PMP slot left for %d remaining partitions in domain %p",
+			 remaining_partitions + 1, domain);
 	}
 
 	thread->arch.u_mode_pmp_end_index = index;

--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -1262,21 +1262,6 @@ int arch_buffer_validate(const void *addr, size_t size, int write)
 		if (IS_WITHIN(start, size, ro_start, ro_size)) {
 			return 0;
 		}
-
-		/*
-		 * On SoCs whose flash-mapped read-only data lives in a window
-		 * separate from the executable text (so __rom_region only spans
-		 * the text), the rodata - which holds const data and string
-		 * literals passed to syscalls - is covered by its own globally
-		 * readable region. Accept it here too.
-		 */
-		uintptr_t rodata_start = (uintptr_t)__rodata_region_start;
-		uintptr_t rodata_end = (uintptr_t)__rodata_region_end;
-
-		if (rodata_end > rodata_start &&
-		    IS_WITHIN(start, size, rodata_start, rodata_end - rodata_start)) {
-			return 0;
-		}
 	}
 
 	/* Look for a matching partition in our memory domain */

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -8,7 +8,6 @@
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <zephyr/arch/riscv/csr.h>
-#include <zephyr/llext/symbol.h>
 #include <pmp.h>
 
 #ifdef CONFIG_USERSPACE
@@ -16,17 +15,6 @@
  * Per-thread (TLS) variable indicating whether execution is in user mode.
  */
 Z_THREAD_LOCAL uint8_t is_user_mode;
-
-/*
- * Exported accessor for the user-mode flag so loadable extensions (llext) -
- * which cannot relocate a thread-local symbol - can resolve it and thus call
- * syscalls. Mirrors the Arm z_arm_thread_is_in_user_mode().
- */
-bool z_riscv_thread_is_user_mode(void)
-{
-	return is_user_mode != 0;
-}
-EXPORT_SYMBOL(z_riscv_thread_is_user_mode);
 #endif
 
 void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,

--- a/include/zephyr/arch/riscv/syscall.h
+++ b/include/zephyr/arch/riscv/syscall.h
@@ -27,7 +27,6 @@
 
 #include <zephyr/types.h>
 #include <stdbool.h>
-#include <zephyr/arch/riscv/thread.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -165,12 +164,10 @@ static inline bool arch_is_user_context(void)
 		return false;
 	}
 
-	/*
-	 * Use an exported accessor (declared in arch/riscv/thread.h) rather
-	 * than the thread-local directly, so loadable extensions, which cannot
-	 * relocate a thread-local symbol, can call syscalls.
-	 */
-	return z_riscv_thread_is_user_mode();
+	/* Defined in arch/riscv/core/thread.c */
+	extern Z_THREAD_LOCAL uint8_t is_user_mode;
+
+	return is_user_mode != 0;
 }
 #endif
 

--- a/include/zephyr/arch/riscv/thread.h
+++ b/include/zephyr/arch/riscv/thread.h
@@ -20,7 +20,6 @@
 #define ZEPHYR_INCLUDE_ARCH_RISCV_THREAD_H_
 
 #ifndef _ASMLANGUAGE
-#include <stdbool.h>
 #include <zephyr/types.h>
 
 /*
@@ -95,13 +94,6 @@ BUILD_ASSERT(sizeof(struct _thread_arch) >= 1);
 #endif
 
 typedef struct _thread_arch _thread_arch_t;
-
-#ifdef CONFIG_USERSPACE
-/* Exported accessor for the per-thread user-mode flag, used by
- * arch_is_user_context() so loadable extensions can resolve it.
- */
-extern bool z_riscv_thread_is_user_mode(void);
-#endif
 
 #endif /* _ASMLANGUAGE */
 

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -565,21 +565,6 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 				return ret;
 			}
 
-			/*
-			 * The relocation writes a field starting at r_offset
-			 * within the target section. Reject an offset at or past
-			 * the section end before applying it. This bounds the
-			 * start of the write; the field width is relocation-type
-			 * specific and left to the per-arch handler.
-			 */
-			if (rel.r_offset >= ext->sect_hdrs[shdr->sh_info].sh_size) {
-				LOG_ERR("relocation r_offset %#zx out of section %d "
-					"(size %#zx)",
-					(size_t)rel.r_offset, shdr->sh_info,
-					(size_t)ext->sect_hdrs[shdr->sh_info].sh_size);
-				return -ENOEXEC;
-			}
-
 #if CONFIG_LLEXT_LOG_LEVEL > LOG_LEVEL_INF /* also gets skipped without CONFIG_LOG */
 			uintptr_t link_addr;
 			uintptr_t op_loc = llext_get_reloc_instruction_location(ldr, ext,

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -25,13 +25,6 @@ LOG_MODULE_DECLARE(llext, CONFIG_LLEXT_LOG_LEVEL);
 bool llext_heap_inited;
 #endif
 
-/* PMP granularity is only defined when RISC-V PMP is built in. */
-#ifdef CONFIG_PMP_GRANULARITY
-#define LLEXT_PMP_GRANULARITY CONFIG_PMP_GRANULARITY
-#else
-#define LLEXT_PMP_GRANULARITY 1
-#endif
-
 /*
  * Initialize the memory partition associated with the specified memory region
  */
@@ -106,18 +99,6 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 				/* ARMv8-M and newer ARC MPUs use 32-byte alignment. */
 				region_alloc = ROUND_UP(region_alloc, LLEXT_PAGE_SIZE);
 				region_align = MAX(region_align, LLEXT_PAGE_SIZE);
-			} else if (IS_ENABLED(CONFIG_RISCV_PMP)) {
-				/*
-				 * RISC-V PMP regions only need to be sized and
-				 * aligned to the PMP granularity; TOR matching
-				 * removes any power-of-two requirement.
-				 */
-				region_alloc = ROUND_UP(region_alloc, LLEXT_PMP_GRANULARITY);
-				region_align = MAX(region_align, LLEXT_PMP_GRANULARITY);
-			} else {
-				LOG_ERR("region %d: no memory protection alignment "
-					"rule for this architecture", mem_idx);
-				return -ENOTSUP;
 			}
 		}
 	}

--- a/tests/subsys/llext/src/multi_file_ext1.c
+++ b/tests/subsys/llext/src/multi_file_ext1.c
@@ -27,13 +27,8 @@ void test_entry(void)
 		/* initial run: test variable initialization */
 		break;
 	case 42:
-		/*
-		 * Second (user-mode) run: the extension's writable data persists
-		 * from the first run, which left both globals swapped. Re-init
-		 * both so the checks below start from the loaded values again.
-		 */
+		/* user-mode run: reinit number */
 		number = 0x42;
-		ext_number = 0x18;
 		break;
 	default:
 		/* possible llext loader issue */

--- a/tests/subsys/llext/src/riscv_edge_case_non_paired_hi20_lo12.c
+++ b/tests/subsys/llext/src/riscv_edge_case_non_paired_hi20_lo12.c
@@ -33,13 +33,6 @@ void test_entry(void)
 {
 	int ret_value;
 
-	/*
-	 * The extension's writable data persists between the supervisor and
-	 * user-mode runs, and the call below mutates it, so restore the initial
-	 * value first to make the test repeatable across both runs.
-	 */
-	_data_segment_symbol = DATA_SEGMENT_SYMBOL_INITIAL;
-
 	ret_value = _riscv_edge_case_non_paired_hi20_lo12();
 
 	zassert_equal(ret_value, DATA_SEGMENT_SYMBOL_INITIAL);

--- a/tests/subsys/llext/tests.yaml
+++ b/tests/subsys/llext/tests.yaml
@@ -91,28 +91,6 @@ tests:
       - CONFIG_LLEXT_HEAP_MEMBLK=y
       - CONFIG_LLEXT_EXT_HEAP_SIZE=64
       - CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE=8192
-  # RISC-V userspace: exercises calling syscalls from an extension and running
-  # it in a user-mode thread. Every syscall stub inlines arch_is_user_context();
-  # on RISC-V that check used to read a thread-local symbol a loaded extension
-  # cannot relocate, so any such extension failed to link. RISC-V runs the
-  # extension from RAM and needs writable storage, so it is covered here rather
-  # than by the readonly_mpu cases above.
-  llext.userspace:
-    arch_allow:
-      - riscv
-    platform_allow:
-      - qemu_riscv32
-    filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_RISCV_PMP
-    integration_platforms:
-      - qemu_riscv32
-    extra_configs:
-      - CONFIG_USERSPACE=y
-      - CONFIG_LLEXT_STORAGE_WRITABLE=y
-      - CONFIG_LLEXT_TYPE_ELF_RELOCATABLE=y
-      # RISC-V runs the loaded extension from RAM, so the extension heap must
-      # stay executable. Data-execution prevention installs a locked catch-all
-      # PMP entry that makes all RAM non-executable, so it must be off here.
-      - CONFIG_PMP_DATA_EXECUTION_PREVENTION=n
   llext.readonly_mmu:
     arch_allow:
       - arm64


### PR DESCRIPTION
* https://github.com/zephyrproject-rtos/zephyr/pull/112539

introduced a failure where a llext test hangs:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/29791027748/job/88512790303#step:12:1402

The failure is bisected to ff65c45d2139525af6d470834c3d41dbb5c914fb

Can be reproduced with:
`twister -T tests/subsys/llext -p qemu_cortex_r5/zynqmp_rpu -s llext.readonly_mpu`

Let's revert the PR to stabilize main, while the issue is fixed calmly. The original PR can be resubmitted with the proper fix.
