### PR TITLE
drivers: i2c: mchp: sercom g1: Add I2C support for PIC32CZ CA and fix SERCOM G1 driver issues

### DIFF
--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult-pinctrl.dtsi
@@ -13,4 +13,11 @@
 				 <PC7D_SERCOM1_PAD3>;
 		};
 	};
+
+	sercom9_i2c_default: sercom9_i2c_default {
+		group1 {
+			pinmux = <PD28D_SERCOM9_PAD0>,
+				 <PD29D_SERCOM9_PAD1>;
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
@@ -8,6 +8,7 @@
 #include <microchip/pic32c/pic32cz_ca/pic32cz_ca80/pic32cz8110ca80208.dtsi>
 #include "pic32cz_ca80_cult-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	model = "PIC32CZ CA80 Curiosity Ultra";
@@ -185,4 +186,25 @@
 
 &dmac {
 	status = "okay";
+};
+
+&sercom9 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom9_i2c_default>;
+	pinctrl-names = "default";
+	dmas = <&dmac 2 0x17>, <&dmac 3 0x18>;
+	dma-names = "rx", "tx";
+	status = "okay";
+
+	eeprom: eeprom@56 {
+		compatible = "atmel,at24", "atmel,24mac402";
+		reg = <0x56>;
+		size = <256>;
+		pagesize = <16>;
+		address-width = <8>;
+		timeout = <5>;
+	};
 };

--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
@@ -8,6 +8,7 @@
 #include <microchip/pic32c/pic32cz_ca/pic32cz_ca80/pic32cz8110ca80208.dtsi>
 #include "pic32cz_ca80_cult-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	model = "PIC32CZ CA80 Curiosity Ultra";
@@ -184,4 +185,25 @@
 
 &dmac {
 	status = "okay";
+};
+
+&sercom9 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom9_i2c_default>;
+	pinctrl-names = "default";
+	dmas = <&dmac 2 0x17>, <&dmac 3 0x18>;
+	dma-names = "rx", "tx";
+	status = "okay";
+
+	eeprom: eeprom@56 {
+		compatible = "atmel,at24", "atmel,24mac402";
+		reg = <0x56>;
+		size = <256>;
+		pagesize = <16>;
+		address-width = <8>;
+		timeout = <5>;
+	};
 };

--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.yaml
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.yaml
@@ -13,6 +13,7 @@ supported:
   - clock_control
   - dma
   - gpio
+  - i2c
   - pinctrl
   - uart
 vendor: microchip

--- a/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult-pinctrl.dtsi
+++ b/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult-pinctrl.dtsi
@@ -13,4 +13,11 @@
 				 <PC7D_SERCOM1_PAD3>;
 		};
 	};
+
+	sercom9_i2c_default: sercom9_i2c_default {
+		group1 {
+			pinmux = <PD28D_SERCOM9_PAD0>,
+				 <PD29D_SERCOM9_PAD1>;
+		};
+	};
 };

--- a/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.dts
+++ b/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.dts
@@ -8,6 +8,7 @@
 #include <microchip/pic32c/pic32cz_ca/pic32cz_ca90/pic32cz8110ca90208.dtsi>
 #include "pic32cz_ca90_cult-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	model = "PIC32CZ CA90 Curiosity Ultra";
@@ -181,4 +182,29 @@
 	pinctrl-0 = <&sercom1_uart_default>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&dmac {
+	status = "okay";
+};
+
+&sercom9 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom9_i2c_default>;
+	pinctrl-names = "default";
+	dmas = <&dmac 2 0x17>, <&dmac 3 0x18>;
+	dma-names = "rx", "tx";
+	status = "okay";
+
+	eeprom: eeprom@56 {
+		compatible = "atmel,at24", "atmel,24mac402";
+		reg = <0x56>;
+		size = <256>;
+		pagesize = <16>;
+		address-width = <8>;
+		timeout = <5>;
+	};
 };

--- a/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.dts
+++ b/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.dts
@@ -8,6 +8,7 @@
 #include <microchip/pic32c/pic32cz_ca/pic32cz_ca90/pic32cz8110ca90208.dtsi>
 #include "pic32cz_ca90_cult-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	model = "PIC32CZ CA90 Curiosity Ultra";
@@ -180,4 +181,29 @@
 	pinctrl-0 = <&sercom1_uart_default>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&dmac {
+	status = "okay";
+};
+
+&sercom9 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom9_i2c_default>;
+	pinctrl-names = "default";
+	dmas = <&dmac 2 0x17>, <&dmac 3 0x18>;
+	dma-names = "rx", "tx";
+	status = "okay";
+
+	eeprom: eeprom@56 {
+		compatible = "atmel,at24", "atmel,24mac402";
+		reg = <0x56>;
+		size = <256>;
+		pagesize = <16>;
+		address-width = <8>;
+		timeout = <5>;
+	};
 };

--- a/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.yaml
+++ b/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.yaml
@@ -12,6 +12,7 @@ ram: 1024
 supported:
   - clock_control
   - gpio
+  - i2c
   - pinctrl
   - uart
 vendor: microchip

--- a/drivers/dma/dma_mchp_dmac_g3.c
+++ b/drivers/dma/dma_mchp_dmac_g3.c
@@ -252,6 +252,12 @@ static int dmac_setup_desc(struct dma_block_config *desc_config, dma_descriptor_
 				    ? config->dest_burst_length
 				    : config->source_burst_length;
 	}
+
+	/* Default to 1 if burst_len is 0 (CSZ=0 causes bus errors) */
+	if (burst_len == 0U) {
+		burst_len = 1U;
+	}
+
 	if (burst_len > (DMA_CHXSIZ_CSZ_Msk >> DMA_CHXSIZ_CSZ_Pos)) {
 		return -EINVAL;
 	}

--- a/drivers/i2c/i2c_mchp_sercom_g1.c
+++ b/drivers/i2c/i2c_mchp_sercom_g1.c
@@ -40,6 +40,7 @@ LOG_MODULE_REGISTER(i2c_mchp_sercom_g1, CONFIG_I2C_LOG_LEVEL);
 #define I2C_TIMEOUT_US                   1000U
 #define I2C_POLL_DELAY_US                2U
 #define I2C_CMD_STOP                     0x3U
+#define I2C_BUS_STATE_IDLE               0x1U
 #define SERCOM_I2CS_SPEED_FAST_MODE_PLUS 0x1U
 
 #define DEV_CFG(dev)  ((const struct i2c_mchp_dev_config *)(dev)->config)
@@ -107,12 +108,13 @@ struct i2c_mchp_dev_data {
 	struct k_sem sync_sem;
 	int xfer_status;
 	uint32_t dev_config;
-	uint32_t byte_idx;
-	uint32_t seg_remaining;
+	uint32_t byte_idx; /* Current byte index within current message */
+	/* segment: consecutive messages with same direction (all reads or all writes) */
+	uint32_t seg_byte_cnt; /* Bytes pending in current segment */
 	uint16_t target_addr;
-	uint8_t msg_idx;
-	uint8_t num_msgs;
-	uint8_t next_seg_idx;
+	uint8_t msg_idx;      /* Current message index being processed */
+	uint8_t num_msgs;     /* Total number of messages */
+	uint8_t next_seg_idx; /* Index of first message in next segment */
 	bool target_mode;
 #if defined(CONFIG_I2C_MCHP_DMA_DRIVEN)
 	bool dma_active;
@@ -185,7 +187,7 @@ static void i2c_set_runstandby(const struct device *dev)
 static void i2c_set_bus_idle(const struct device *dev)
 {
 	I2CM(dev).SERCOM_STATUS = (I2CM(dev).SERCOM_STATUS & ~SERCOM_I2CM_STATUS_BUSSTATE_Msk) |
-				  SERCOM_I2CM_STATUS_BUSSTATE(SERCOM_I2CM_STATUS_BUSSTATE_IDLE_Val);
+				  SERCOM_I2CM_STATUS_BUSSTATE(I2C_BUS_STATE_IDLE);
 
 	if (!I2C_WAIT_SYNC_M(dev, SERCOM_I2CM_SYNCBUSY_SYSOP_Msk)) {
 		LOG_ERR("Bus idle sync timeout");
@@ -206,10 +208,11 @@ static void i2c_send_stop(const struct device *dev)
 /* Sets ACK/NACK control for I2C target response */
 static inline void i2c_set_ack(const struct device *dev, bool ack)
 {
-	uint32_t ctrlb = I2CM(dev).SERCOM_CTRLB;
-
-	ctrlb = (ctrlb & ~SERCOM_I2CM_CTRLB_ACKACT_Msk) | SERCOM_I2CM_CTRLB_ACKACT(!ack);
-	I2CM(dev).SERCOM_CTRLB = ctrlb;
+	if (ack) {
+		I2CM(dev).SERCOM_CTRLB &= ~SERCOM_I2CM_CTRLB_ACKACT_Msk;
+	} else {
+		I2CM(dev).SERCOM_CTRLB |= SERCOM_I2CM_CTRLB_ACKACT_Msk;
+	}
 }
 
 /* Checks if NACK was received from I2C slave */
@@ -434,8 +437,8 @@ static void i2c_init_segment(struct i2c_mchp_dev_data *data)
 {
 	data->msg_idx = data->next_seg_idx;
 	data->byte_idx = 0;
-	data->seg_remaining = i2c_segment_len(data->msgs, data->num_msgs, data->next_seg_idx,
-					      &data->next_seg_idx);
+	data->seg_byte_cnt = i2c_segment_len(data->msgs, data->num_msgs, data->next_seg_idx,
+					     &data->next_seg_idx);
 }
 
 /* Completes I2C transfer: signals callback (async) or semaphore (sync) */
@@ -466,15 +469,18 @@ static void i2c_handle_error(const struct device *dev, int error_status)
 
 #if defined(CONFIG_I2C_MCHP_DMA_DRIVEN)
 	struct i2c_mchp_dev_data *data = DEV_DATA(dev);
+	const struct i2c_mchp_dev_config *cfg = DEV_CFG(dev);
+	struct i2c_msg *msg = I2C_CURR_MSG(data);
+	uint32_t ch = i2c_is_read_op(msg) ? cfg->dma.rx_dma_channel : cfg->dma.tx_dma_channel;
+
+	unsigned int key = irq_lock();
 
 	if (data->dma_active) {
-		const struct i2c_mchp_dev_config *cfg = DEV_CFG(dev);
-		struct i2c_msg *msg = I2C_CURR_MSG(data);
-		uint32_t ch =
-			i2c_is_read_op(msg) ? cfg->dma.rx_dma_channel : cfg->dma.tx_dma_channel;
 		dma_stop(cfg->dma.dma_dev, ch);
 		data->dma_active = false;
 	}
+
+	irq_unlock(key);
 #endif /*CONFIG_I2C_MCHP_DMA_DRIVEN*/
 
 	I2CM(dev).SERCOM_INTENCLR = SERCOM_I2CM_INTENCLR_Msk;
@@ -498,7 +504,12 @@ static int i2c_validate_msgs(struct i2c_msg *msgs, uint8_t num_msgs)
 
 	for (uint8_t i = 0; i < num_msgs; i++) {
 
-		if ((msgs[i].buf == NULL) || (msgs[i].len == 0)) {
+		if ((msgs[i].len == 0) && i2c_is_read_op(&msgs[i])) {
+			LOG_WRN("Zero-length read not supported");
+			return -EINVAL;
+		}
+
+		if ((msgs[i].len > 0) && (msgs[i].buf == NULL)) {
 			return -EINVAL;
 		}
 
@@ -527,17 +538,17 @@ static bool i2c_advance_byte(struct i2c_mchp_dev_data *data)
 	struct i2c_msg *msg = I2C_CURR_MSG(data);
 
 	data->byte_idx++;
-	data->seg_remaining--;
+	data->seg_byte_cnt--;
 
 	if (data->byte_idx >= msg->len) {
-		if (data->seg_remaining > 0) {
+		if (data->seg_byte_cnt > 0) {
 			data->msg_idx++;
 		}
 
 		data->byte_idx = 0;
 	}
 
-	return (data->seg_remaining == 0);
+	return (data->seg_byte_cnt == 0);
 }
 
 /* Writes a single byte to I2C data register */
@@ -554,14 +565,52 @@ static void i2c_int_start_xfer(const struct device *dev, uint16_t addr, bool is_
 {
 	struct i2c_mchp_dev_data *data = DEV_DATA(dev);
 	struct i2c_msg *msg = I2C_CURR_MSG(data);
-	uint8_t flag = (is_read) ? SERCOM_I2CM_INTFLAG_SB_Msk : SERCOM_I2CM_INTFLAG_MB_Msk;
 
-	I2CM(dev).SERCOM_INTFLAG = flag;
-	I2CM(dev).SERCOM_INTENSET = flag;
+	/*
+	 * Always enable MB interrupt: for writes it signals byte completion,
+	 * for reads it signals address phase completion and error conditions.
+	 * Additionally enable SB for reads to handle received data bytes.
+	 */
+	I2CM(dev).SERCOM_INTENSET = SERCOM_I2CM_INTENSET_MB_Msk;
+	if (is_read) {
+		I2CM(dev).SERCOM_INTENSET = SERCOM_I2CM_INTENSET_SB_Msk;
+	}
 
 	if (MSG_HAS_RESTART(msg) != 0) {
 		i2c_write_addr(dev, addr, is_read);
 	}
+}
+
+/* Starts next I2C segment using DMA or interrupt mode as appropriate */
+static void i2c_start_next_segment(const struct device *dev)
+{
+	struct i2c_mchp_dev_data *data = DEV_DATA(dev);
+
+	i2c_init_segment(data);
+
+	struct i2c_msg *msg = I2C_CURR_MSG(data);
+	bool is_read = i2c_is_read_op(msg);
+	uint16_t hw_addr = data->target_addr << 1;
+
+#if defined(CONFIG_I2C_MCHP_DMA_DRIVEN)
+	const struct i2c_mchp_dev_config *cfg = DEV_CFG(dev);
+
+	if (cfg->dma.dma_dev != NULL && msg->len > 1) {
+		if (i2c_dma_setup(dev, is_read) != 0) {
+			i2c_xfer_complete(dev, -EIO);
+			return;
+		}
+
+		uint32_t ch = is_read ? cfg->dma.rx_dma_channel : cfg->dma.tx_dma_channel;
+
+		dma_start(cfg->dma.dma_dev, ch);
+		data->dma_active = true;
+		i2c_write_addr(dev, hw_addr, is_read);
+		return;
+	}
+#endif /* CONFIG_I2C_MCHP_DMA_DRIVEN */
+
+	i2c_int_start_xfer(dev, hw_addr, is_read);
 }
 
 /* Handles interrupt-driven I2C byte read operation */
@@ -570,9 +619,26 @@ static void i2c_int_read_byte(const struct device *dev)
 	struct i2c_mchp_dev_data *data = DEV_DATA(dev);
 	struct i2c_msg *msg = I2C_CURR_MSG(data);
 
-	if ((data->seg_remaining == 1) && (i2c_is_stop_op(msg))) {
+	/* Last byte of read segment */
+	if (data->seg_byte_cnt == 1) {
+
+		/* always NACK (for both STOP and RESTART) */
 		i2c_set_ack(dev, false);
-		i2c_send_stop(dev);
+
+		if (i2c_is_stop_op(msg)) {
+			i2c_send_stop(dev);
+		} else {
+			if (data->next_seg_idx < data->num_msgs) {
+				/*
+				 * RESTART: Reading DATA triggers NACK which releases bus to IDLE.
+				 * Write ADDR first so bus stays in OWNER state and then read DATA.
+				 */
+				I2CM(dev).SERCOM_INTENCLR = SERCOM_I2CM_INTENCLR_SB_Msk;
+				i2c_start_next_segment(dev);
+				msg->buf[msg->len - 1] = I2CM(dev).SERCOM_DATA;
+				return;
+			}
+		}
 	}
 
 	*I2C_CURR_BYTE_PTR(data) = I2CM(dev).SERCOM_DATA;
@@ -582,10 +648,7 @@ static void i2c_int_read_byte(const struct device *dev)
 		I2CM(dev).SERCOM_INTENCLR = SERCOM_I2CM_INTENCLR_SB_Msk;
 
 		if (data->next_seg_idx < data->num_msgs) {
-			i2c_init_segment(data);
-			bool is_read = i2c_is_read_op(I2C_CURR_MSG(data));
-
-			i2c_int_start_xfer(dev, data->target_addr << 1, is_read);
+			i2c_start_next_segment(dev);
 		} else {
 			i2c_xfer_complete(dev, 0);
 		}
@@ -596,6 +659,7 @@ static void i2c_int_read_byte(const struct device *dev)
 static void i2c_int_write_byte(const struct device *dev)
 {
 	struct i2c_mchp_dev_data *data = DEV_DATA(dev);
+	struct i2c_msg *msg = I2C_CURR_MSG(data);
 
 	if (i2c_got_nack(dev)) {
 		I2CM(dev).SERCOM_INTENCLR = SERCOM_I2CM_INTENCLR_MB_Msk;
@@ -604,9 +668,7 @@ static void i2c_int_write_byte(const struct device *dev)
 		return;
 	}
 
-	if (data->seg_remaining == 0) {
-		struct i2c_msg *msg = I2C_CURR_MSG(data);
-
+	if (data->seg_byte_cnt == 0) {
 		I2CM(dev).SERCOM_INTENCLR = SERCOM_I2CM_INTENCLR_MB_Msk;
 
 		if (i2c_is_stop_op(msg)) {
@@ -614,10 +676,7 @@ static void i2c_int_write_byte(const struct device *dev)
 		}
 
 		if (data->next_seg_idx < data->num_msgs) {
-			i2c_init_segment(data);
-			bool is_read = i2c_is_read_op(I2C_CURR_MSG(data));
-
-			i2c_int_start_xfer(dev, data->target_addr << 1, is_read);
+			i2c_start_next_segment(dev);
 		} else {
 			i2c_xfer_complete(dev, 0);
 		}
@@ -662,7 +721,9 @@ static int i2c_transfer_internal(const struct device *dev, struct i2c_msg *msgs,
 	I2CM(dev).SERCOM_INTENSET = SERCOM_I2CM_INTENSET_ERROR_Msk;
 
 #if defined(CONFIG_I2C_MCHP_DMA_DRIVEN)
-	if (DEV_CFG(dev)->dma.dma_dev != NULL) {
+	struct i2c_msg *msg = I2C_CURR_MSG(data);
+
+	if (DEV_CFG(dev)->dma.dma_dev != NULL && msg->len > 1) {
 		if (i2c_dma_setup(dev, is_read) != 0) {
 			k_sem_give(&data->lock);
 			return -EIO;
@@ -695,62 +756,80 @@ static int i2c_transfer_internal(const struct device *dev, struct i2c_msg *msgs,
 }
 
 #if defined(CONFIG_I2C_MCHP_DMA_DRIVEN)
+/*
+ * Starts DMA or interrupt transfer for the current message.
+ * For multi-byte: sets up DMA and starts transfer.
+ * For single-byte: falls back to interrupt mode.
+ */
+static void i2c_dma_start_msg(const struct device *dev, bool is_read)
+{
+	struct i2c_mchp_dev_data *data = DEV_DATA(dev);
+	const struct i2c_mchp_dev_config *cfg = DEV_CFG(dev);
+	struct i2c_msg *msg = I2C_CURR_MSG(data);
+
+	if (msg->len > 1) {
+		if (i2c_dma_setup(dev, is_read) != 0) {
+			data->dma_active = false;
+			i2c_xfer_complete(dev, -EIO);
+			return;
+		}
+		uint32_t ch = is_read ? cfg->dma.rx_dma_channel : cfg->dma.tx_dma_channel;
+
+		dma_start(cfg->dma.dma_dev, ch);
+		data->dma_active = true;
+		return;
+	}
+
+	data->dma_active = false;
+	i2c_int_start_xfer(dev, data->target_addr << 1, is_read);
+}
 
 /* DMA completion callback - advances to next segment or completes transfer */
 static void i2c_dma_callback(const struct device *dma_dev, void *arg, uint32_t channel, int status)
 {
 	struct i2c_mchp_dev_data *data = arg;
 	const struct device *dev = data->dev;
-	const struct i2c_mchp_dev_config *cfg = DEV_CFG(dev);
 	struct i2c_msg *msg = I2C_CURR_MSG(data);
 	bool is_read = i2c_is_read_op(msg);
 	uint32_t prev_msg_len = msg->len;
 	bool new_segment = (data->msg_idx + 1 >= data->next_seg_idx);
 
+	ARG_UNUSED(dma_dev);
 	ARG_UNUSED(channel);
 
-	data->dma_active = false;
-
 	if (status < 0) {
+		data->dma_active = false;
 		i2c_handle_error(dev, status);
 		return;
 	}
 
+	/*
+	 * For reads: DMA transfers len-1 bytes; the last byte must be read via SB
+	 * interrupt to allow issuing STOP or RESTART command before reading DATA.
+	 * For writes with STOP: enable MB to wait for final byte completion.
+	 */
+	if (is_read) {
+		I2CM(dev).SERCOM_INTENSET = SERCOM_I2CM_INTENSET_SB_Msk;
+		return;
+	}
+
 	if (i2c_is_stop_op(msg)) {
-
-		if (is_read) {
-			I2CM(dev).SERCOM_INTENSET = SERCOM_I2CM_INTENSET_SB_Msk;
-		} else {
-			I2CM(dev).SERCOM_INTENSET = SERCOM_I2CM_INTENSET_MB_Msk;
-		}
-
+		I2CM(dev).SERCOM_INTENSET = SERCOM_I2CM_INTENSET_MB_Msk;
 		return;
 	}
 
-	data->msg_idx++;
-	data->byte_idx = 0;
-
+	/* Start new segment, or same segment (write-write): continue to next message */
 	if (new_segment) {
-		i2c_init_segment(data);
+		data->dma_active = false;
+		i2c_start_next_segment(dev);
 	} else {
-		data->seg_remaining -= prev_msg_len;
-	}
+		data->msg_idx++;
+		data->byte_idx = 0;
+		data->seg_byte_cnt -= prev_msg_len;
 
-	msg = I2C_CURR_MSG(data);
-	is_read = i2c_is_read_op(msg);
-
-	if (i2c_dma_setup(dev, is_read) != 0) {
-		i2c_xfer_complete(dev, -EIO);
-		return;
-	}
-
-	uint32_t ch = (is_read) ? cfg->dma.rx_dma_channel : cfg->dma.tx_dma_channel;
-
-	dma_start(cfg->dma.dma_dev, ch);
-	data->dma_active = true;
-
-	if ((new_segment) || (MSG_HAS_RESTART(msg) != 0)) {
-		i2c_write_addr(dev, data->target_addr << 1, is_read);
+		msg = I2C_CURR_MSG(data);
+		is_read = i2c_is_read_op(msg);
+		i2c_dma_start_msg(dev, is_read);
 	}
 }
 
@@ -774,7 +853,19 @@ static int i2c_dma_setup(const struct device *dev, bool is_read)
 	dma_cfg.head_block = &blk;
 
 	if (is_read) {
-		blk.block_size = msg->len - 1; /* Last byte read manually */
+		/*
+		 * Hardware's Host DMA mode (ADDR.LENEN=1) is NOT used because it
+		 * auto-generates NACK and STOP after LEN bytes with no RESTART option,
+		 * breaking Zephyr's write-restart-read pattern (i2c_write_read).
+		 *
+		 * Instead, DMA transfers len-1 bytes; final byte handled via SB interrupt.
+		 * Commands (STOP/RESTART) require SB=1 or MB=1. Reading DATA clears SB.
+		 * - Read: SB clears when DATA read. If DMA reads last byte, cannot issue CMD.
+		 * - Write: MB stays set after TX. DMA can send all bytes, MB available for CMD.
+		 *
+		 * Single-byte reads fall back to interrupt mode.
+		 */
+		blk.block_size = msg->len - 1;
 		blk.source_address = (uint32_t)&cfg->regs->I2CM.SERCOM_DATA;
 		blk.dest_address = (uint32_t)msg->buf;
 		blk.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
@@ -802,6 +893,9 @@ static int i2c_dma_setup(const struct device *dev, bool is_read)
 /* Handles DMA transmission completion */
 static void i2c_dma_tx_complete(const struct device *dev)
 {
+	struct i2c_mchp_dev_data *data = DEV_DATA(dev);
+
+	data->dma_active = false;
 	I2CM(dev).SERCOM_INTENCLR = SERCOM_I2CM_INTENCLR_MB_Msk;
 	i2c_send_stop(dev);
 	i2c_xfer_complete(dev, 0);
@@ -812,15 +906,44 @@ static void i2c_dma_rx_complete(const struct device *dev)
 {
 	struct i2c_mchp_dev_data *data = DEV_DATA(dev);
 	struct i2c_msg *msg = I2C_CURR_MSG(data);
-
-	if (i2c_is_stop_op(msg)) {
-		i2c_set_ack(dev, false);
-		i2c_send_stop(dev);
-		msg->buf[msg->len - 1] = I2CM(dev).SERCOM_DATA;
-	}
+	uint32_t prev_msg_len = msg->len;
+	bool is_stop = i2c_is_stop_op(msg);
+	bool new_segment = (data->msg_idx + 1 >= data->next_seg_idx);
+	bool has_more_segments = new_segment && (data->next_seg_idx < data->num_msgs);
 
 	I2CM(dev).SERCOM_INTENCLR = SERCOM_I2CM_INTENCLR_SB_Msk;
-	i2c_xfer_complete(dev, 0);
+
+	if (is_stop || new_segment) {
+		data->dma_active = false;
+		i2c_set_ack(dev, false);
+
+		if (is_stop) {
+			i2c_send_stop(dev);
+		} else {
+			if (has_more_segments) {
+				/* Writing ADDR issues NACK and RESTART, keeps bus OWNER */
+				i2c_start_next_segment(dev);
+			}
+		}
+
+		msg->buf[msg->len - 1] = I2CM(dev).SERCOM_DATA;
+
+		if (is_stop) {
+			i2c_xfer_complete(dev, 0);
+		}
+
+		return;
+	}
+
+	/* Same segment (read-read): ACK and continue to next message */
+	i2c_set_ack(dev, true);
+	msg->buf[msg->len - 1] = I2CM(dev).SERCOM_DATA;
+
+	data->msg_idx++;
+	data->byte_idx = 0;
+	data->seg_byte_cnt -= prev_msg_len;
+
+	i2c_dma_start_msg(dev, true);
 }
 #endif /* CONFIG_I2C_MCHP_DMA_DRIVEN */
 
@@ -1001,16 +1124,16 @@ static void i2c_target_isr(const struct device *dev)
 /* I2C interrupt handler - routes to target ISR or handles controller mode interrupts */
 static void i2c_mchp_isr(const struct device *dev)
 {
-#if defined(CONFIG_I2C_TARGET)
 	struct i2c_mchp_dev_data *data = DEV_DATA(dev);
 
+#if defined(CONFIG_I2C_TARGET)
 	if (data->target_mode) {
 		i2c_target_isr(dev);
 		return;
 	}
 #endif /*CONFIG_I2C_TARGET*/
 
-	uint8_t intflags = I2CM(dev).SERCOM_INTFLAG & SERCOM_I2CM_INTFLAG_Msk;
+	uint8_t intflags = I2CM(dev).SERCOM_INTFLAG;
 
 	if ((intflags & SERCOM_I2CM_INTFLAG_ERROR_Msk) != 0) {
 		i2c_handle_error(dev, -EIO);
@@ -1018,20 +1141,37 @@ static void i2c_mchp_isr(const struct device *dev)
 	}
 
 	if ((intflags & SERCOM_I2CM_INTFLAG_MB_Msk) != 0) {
-#if defined(CONFIG_I2C_MCHP_DMA_DRIVEN)
-		if (DEV_CFG(dev)->dma.dma_dev != NULL) {
-			i2c_dma_tx_complete(dev);
+		struct i2c_msg *msg = I2C_CURR_MSG(data);
+		bool is_read = i2c_is_read_op(msg);
+
+		if (is_read) {
+			/*
+			 * MB during read: address phase complete.
+			 * Disable MB - SB will handle data reception.
+			 * Check for NACK (device not responding) and handle error.
+			 */
+			I2CM(dev).SERCOM_INTENCLR = SERCOM_I2CM_INTENCLR_MB_Msk;
+			if (i2c_got_nack(dev)) {
+				i2c_send_stop(dev);
+				i2c_xfer_complete(dev, -EIO);
+			}
+			return;
 		} else {
-#endif /*CONFIG_I2C_MCHP_DMA_DRIVEN*/
-			i2c_int_write_byte(dev);
 #if defined(CONFIG_I2C_MCHP_DMA_DRIVEN)
-		}
+			if (data->dma_active) {
+				i2c_dma_tx_complete(dev);
+			} else {
 #endif /*CONFIG_I2C_MCHP_DMA_DRIVEN*/
+				i2c_int_write_byte(dev);
+#if defined(CONFIG_I2C_MCHP_DMA_DRIVEN)
+			}
+#endif /*CONFIG_I2C_MCHP_DMA_DRIVEN*/
+		}
 	}
 
 	if ((intflags & SERCOM_I2CM_INTFLAG_SB_Msk) != 0) {
 #if defined(CONFIG_I2C_MCHP_DMA_DRIVEN)
-		if (DEV_CFG(dev)->dma.dma_dev != NULL) {
+		if (data->dma_active) {
 			i2c_dma_rx_complete(dev);
 		} else {
 #endif /*CONFIG_I2C_MCHP_DMA_DRIVEN*/
@@ -1302,29 +1442,20 @@ static DEVICE_API(i2c, i2c_mchp_api) = {
 	.recover_bus = i2c_mchp_recover,
 };
 
-#define I2C_MCHP_IRQ_CONNECT(n, idx)                                                               \
-	do {                                                                                       \
-		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, idx, irq), DT_INST_IRQ_BY_IDX(n, idx, priority), \
-			    i2c_mchp_isr, DEVICE_DT_INST_GET(n), 0);                               \
-		irq_enable(DT_INST_IRQ_BY_IDX(n, idx, irq));                                       \
-	} while (false)
+#define I2C_MCHP_IRQ_CONNECT(idx, inst)                                                            \
+	IRQ_CONNECT(DT_INST_IRQ_BY_IDX(inst, idx, irq), DT_INST_IRQ_BY_IDX(inst, idx, priority),   \
+		    i2c_mchp_isr, DEVICE_DT_INST_GET(inst), 0);                                    \
+	irq_enable(DT_INST_IRQ_BY_IDX(inst, idx, irq))
 
-#if DT_INST_IRQ_HAS_IDX(0, 3)
 #define I2C_MCHP_IRQ_HANDLER(n)                                                                    \
 	static void i2c_mchp_irq_config_##n(const struct device *dev)                              \
 	{                                                                                          \
-		I2C_MCHP_IRQ_CONNECT(n, 0);                                                        \
-		I2C_MCHP_IRQ_CONNECT(n, 1);                                                        \
-		I2C_MCHP_IRQ_CONNECT(n, 2);                                                        \
-		I2C_MCHP_IRQ_CONNECT(n, 3);                                                        \
+		ARG_UNUSED(dev);                                                                   \
+		LISTIFY(DT_INST_NUM_IRQS(n),                                                       \
+			I2C_MCHP_IRQ_CONNECT,                                                      \
+			(;),                                                                       \
+			n);                           \
 	}
-#else
-#define I2C_MCHP_IRQ_HANDLER(n)                                                                    \
-	static void i2c_mchp_irq_config_##n(const struct device *dev)                              \
-	{                                                                                          \
-		I2C_MCHP_IRQ_CONNECT(n, 0);                                                        \
-	}
-#endif
 
 #define I2C_MCHP_CLOCK_INIT(n)                                                                     \
 	.clk.mclk_sys = (void *)(DT_INST_CLOCKS_CELL_BY_NAME(n, mclk, subsystem)),                 \

--- a/dts/bindings/i2c/microchip,sercom-g1-i2c.yaml
+++ b/dts/bindings/i2c/microchip,sercom-g1-i2c.yaml
@@ -7,7 +7,9 @@ description: |
   Microchip SERCOM I2C driver bindings.
 
   Group g1 SERCOM I2C driver supports following hardware peripherals:
-    - module name="SERCOM" id="U2201" version="3.1.1","5.0.0"
+    - module name="SERCOM"
+          id="U2201" version="3.1.1","5.0.0"
+          id="03715" name2="com_sercom_u2201_v6" version="6b0"
 
 compatible: "microchip,sercom-g1-i2c"
 

--- a/tests/drivers/i2c/i2c_async/boards/pic32cz_ca80_cult.overlay
+++ b/tests/drivers/i2c/i2c_async/boards/pic32cz_ca80_cult.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sercom9 {
+	eeprom0: eeprom@56 {};
+};

--- a/tests/drivers/i2c/i2c_async/boards/pic32cz_ca90_cult.overlay
+++ b/tests/drivers/i2c/i2c_async/boards/pic32cz_ca90_cult.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sercom9 {
+	eeprom0: eeprom@56 {};
+};

--- a/tests/drivers/i2c/i2c_async/tests.yaml
+++ b/tests/drivers/i2c/i2c_async/tests.yaml
@@ -8,3 +8,4 @@ tests:
     platform_allow:
       - sam_e54_xpro
       - pic32cx_sg41_cult
+      - pic32cz_ca80_cult

--- a/tests/drivers/i2c/i2c_target_api/boards/pic32cz_ca80_cult.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/pic32cz_ca80_cult.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Connect PC0 to PC8 (SDA), and PC1 to PC9 (SCL) */
+
+&pinctrl {
+	sercom0_i2c_default: sercom0_i2c_default {
+		group1 {
+			pinmux = <PC0D_SERCOM0_PAD0>,
+				 <PC1D_SERCOM0_PAD1>;
+		};
+	};
+
+	sercom2_i2c_default: sercom2_i2c_default {
+		group1 {
+			pinmux = <PC8D_SERCOM2_PAD0>,
+				 <PC9D_SERCOM2_PAD1>;
+		};
+	};
+};
+
+&sercom0 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom0_i2c_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&sercom2 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom2_i2c_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom1: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/boards/pic32cz_ca90_cult.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/pic32cz_ca90_cult.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Connect PC0 to PC8 (SDA), and PC1 to PC9 (SCL) */
+
+&pinctrl {
+	sercom0_i2c_default: sercom0_i2c_default {
+		group1 {
+			pinmux = <PC0D_SERCOM0_PAD0>,
+				 <PC1D_SERCOM0_PAD1>;
+		};
+	};
+
+	sercom2_i2c_default: sercom2_i2c_default {
+		group1 {
+			pinmux = <PC8D_SERCOM2_PAD0>,
+				 <PC9D_SERCOM2_PAD1>;
+		};
+	};
+};
+
+&sercom0 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom0_i2c_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&sercom2 {
+	compatible = "microchip,sercom-g1-i2c";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&sercom2_i2c_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom1: eeprom@58 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x58>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -87,6 +87,7 @@ tests:
       - sam_e54_xpro
       - pic32cx_sg41_cult
       - pic32cm_jh01_cpro
+      - pic32cz_ca80_cult
     integration_platforms:
       - max32690evkit/max32690/m4
       - nrf54l15dk/nrf54l15/cpuapp

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -87,9 +87,10 @@ tests:
       - ophelia4ev/nrf54l15/cpuapp
       - pic32cm_jh01_cpro
       - pic32cx_sg41_cult
+      - pic32cz_ca80_cult
+      - sam_e54_xpro
       - s32k5xxcvb/s32k566/m7
       - s32k5xxcvb/s32k566/r52
-      - sam_e54_xpro
     integration_platforms:
       - max32690evkit/max32690/m4
       - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
**Summary**

- Add I2C support for PIC32CZ CA80/CA90 Curiosity boards with proper SERCOM G1 bindings
- Fix critical DMA transfer issues and NACK detection in the SERCOM G1 I2C driver
- Fix DMA controller burst length configuration that caused transfer errors

**Changes:**

**Device Tree / Bindings:**

- Add version property support in SERCOM G1 I2C binding YAML for PIC32CZ CA
- Update pic32cz_ca80_cult and pic32cz_ca90_cult board DTS for SERCOM I2C nodes

**I2C Driver (drivers/i2c/i2c_mchp_sercom_g1.c):**

- Fix zero/single-byte reads by falling back to interrupt mode (DMA requires ≥2 bytes)
- Fix read-to-RESTART sequencing: write ADDR before reading last DATA byte to prevent bus IDLE
- Fix NACK detection: always enable MB interrupt for reads to catch address phase errors
- Allow zero-length messages for I2C address scanning
- Use LISTIFY with DT_INST_NUM_IRQS for flexible interrupt registration

**DMA Driver (drivers/dma/dma_mchp_g3.c):**

- Default burst_len to 1 when zero to prevent WRE/RDE interrupt errors (CSZ=0 is invalid)