### PR TITLE
i2c: npcx: support per controller timeout

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -392,9 +392,10 @@ static int i2c_ctrl_recovery(const struct device *dev)
 
 static int i2c_ctrl_wait_completion(const struct device *dev)
 {
+	const struct i2c_ctrl_config *const config = dev->config;
 	struct i2c_ctrl_data *const data = dev->data;
 
-	if (k_sem_take(&data->sync_sem, I2C_TRANSFER_TIMEOUT) == 0) {
+	if (k_sem_take(&data->sync_sem, config->transfer_timeout) == 0) {
 		return data->trans_err;
 	} else {
 		return -ETIMEDOUT;
@@ -1231,6 +1232,7 @@ static int i2c_ctrl_init(const struct device *dev)
 		.base = DT_INST_REG_ADDR(inst),                                                    \
 		.irq = DT_INST_IRQN(inst),                                                         \
 		.clk_cfg = NPCX_DT_CLK_CFG_ITEM(inst),                                             \
+		.transfer_timeout = I2C_DT_INST_TRANSFER_TIMEOUT(inst),                            \
 		IF_ENABLED(CONFIG_I2C_TARGET, (                                                    \
 			.smb_wui = NPCX_DT_WUI_ITEM_BY_NAME(inst, smb_wui),                        \
 			.wakeup_source = DT_INST_PROP_OR(inst, wakeup_source, 0)                   \

--- a/drivers/i2c/i2c_npcx_controller.h
+++ b/drivers/i2c/i2c_npcx_controller.h
@@ -66,6 +66,7 @@ struct i2c_ctrl_config {
 	uintptr_t base;              /* i2c controller base address */
 	struct npcx_clk_cfg clk_cfg; /* clock configuration */
 	uint8_t irq;                 /* i2c controller irq */
+	k_timeout_t transfer_timeout;
 #ifdef CONFIG_I2C_TARGET
 	/* i2c wake-up input source configuration */
 	const struct npcx_wui smb_wui;


### PR DESCRIPTION
Use the per controller timeout macro instead of the config directly, this allows using per controller timeout and is a no-op for existing users.