### PR TITLE
boards: nucode: limit NU40 application flash size

### DIFF
--- a/boards/nucode/nucode_nu40/Kconfig.defconfig
+++ b/boards/nucode/nucode_nu40/Kconfig.defconfig
@@ -18,6 +18,11 @@ config FLASH_LOAD_OFFSET
 	default 0x1000
 	depends on BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
 
+# Keep directly loaded applications below the onboard bootloader at 0xe0000.
+config FLASH_LOAD_SIZE
+	default 0xdf000
+	depends on BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
+
 source "boards/common/usb/Kconfig.cdc_acm_serial.defconfig"
 
 endif # BOARD_NUCODE_NU40


### PR DESCRIPTION
## Description

The NU40 UF2 bootloader starts at `0xe0000`, but direct application builds
currently allow linking through the end of the 1 MiB flash. A sufficiently
large UF2 image can therefore overlap the onboard bootloader.

Set `FLASH_LOAD_SIZE` to `0xdf000` for non-bare direct builds, limiting the
application to `0x1000..0xdffff`. The bare variant and devicetree partition
builds remain unchanged.

## Testing

- `west build -p always -b nucode_nu40/nrf52840 samples/hello_world`
- `west build -p always -b nucode_nu40/nrf52840/bare samples/hello_world`
- Verified that a 900 KiB test payload, which linked past `0xe0000` before
  this change, is now rejected with a FLASH region overflow.
- Checkpatch, GitDiffCheck, Gitlint, Identity, and KconfigFormat compliance
  checks.

No device flash was required because this change only constrains the linker
FLASH region.
