### PR TITLE
i2c: dw: kconfig cleanup and timeout macro reuse

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -402,6 +402,10 @@ Haptics
 I2C
 ===
 
+* On controller based on :kconfig:option:`CONFIG_I2C_DW` the
+  ``CONFIG_I2C_DW_RW_TIMEOUT_MS`` option has been replaced with
+  :kconfig:option:`CONFIG_I2C_TRANSFER_TIMEOUT_MS`, with a default of 500ms.
+
 * The ITE I2C controllers :dtcompatible:`ite,enhance-i2c`
   :dtcompatible:`ite,it51xxx-i2c` :dtcompatible:`ite,it8xxx2-i2c` transfer
   timeout is now using the generic ``zephyr,transfer-timeout-ms`` property

--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -9,6 +9,7 @@ menuconfig I2C_DW
 	depends on !$(dt_compat_any_has_prop,$(DT_COMPAT_SNPS_DESIGNWARE_I2C),clocks) || CLOCK_CONTROL
 	select PCIE if $(dt_compat_on_bus,$(DT_COMPAT_SNPS_DESIGNWARE_I2C),pcie)
 	select DYNAMIC_INTERRUPTS if $(dt_compat_on_bus,$(DT_COMPAT_SNPS_DESIGNWARE_I2C),pcie)
+	select I2C_TRANSFER_TIMEOUT_SUPPORTED
 	help
 	  Enable the Design Ware I2C driver
 
@@ -28,10 +29,6 @@ config I2C_DW_LPSS_DMA
 	  This option enables I2C DMA feature to be used for asynchronous
 	  data transfers. All Tx operations are done using dma channel 0 and
 	  all Rx operations are done using dma channel 1.
-
-config I2C_DW_RW_TIMEOUT_MS
-	int "Set the Read/Write timeout in milliseconds"
-	default 100
 
 config I2C_DW_EXTENDED_SUPPORT
 	bool "Extended DW features"

--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -12,15 +12,16 @@ menuconfig I2C_DW
 	help
 	  Enable the Design Ware I2C driver
 
+if I2C_DW
+
 config I2C_DW_CLOCK_SPEED
 	int "Set the clock speed for I2C"
-	depends on I2C_DW
 	default 100 if I2C_RTS5912
 	default 32
 
 config I2C_DW_LPSS_DMA
 	bool "Use I2C integrated DMA for asynchronous transfer"
-	depends on (I2C_DW && !I2C_RTS5912)
+	depends on !I2C_RTS5912
 	select DMA
 	select DMA_INTEL_LPSS
 	help
@@ -30,7 +31,6 @@ config I2C_DW_LPSS_DMA
 
 config I2C_DW_RW_TIMEOUT_MS
 	int "Set the Read/Write timeout in milliseconds"
-	depends on I2C_DW
 	default 100
 
 config I2C_DW_EXTENDED_SUPPORT
@@ -47,7 +47,6 @@ config I2C_DW_PM_POLICY_STATE_LOCK
 
 config I2C_DW_IC_CLK_FREQ_OPTIMIZATION
 	bool "Core Clock Frequency Optimization"
-	depends on I2C_DW
 	help
 	  Enable hardware optimization to reduce the required I2C core clock frequency.
 
@@ -57,3 +56,5 @@ config I2C_DW_IC_CLK_FREQ_OPTIMIZATION
 
 	  Enable this option only if your hardware IP supports this specific latency
 	  reduction feature.
+
+endif # I2C_DW

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -845,6 +845,7 @@ bool i2c_dw_is_busy(const struct device *dev)
 static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
 			   uint16_t slave_address)
 {
+	const struct i2c_dw_rom_config *const rom = dev->config;
 	struct i2c_dw_dev_config *const dw = dev->data;
 	struct i2c_msg *cur_msg = msgs;
 	uint8_t msg_left = num_msgs;
@@ -964,7 +965,7 @@ static int i2c_dw_transfer(const struct device *dev, struct i2c_msg *msgs, uint8
 		}
 
 		/* Wait for transfer to be done */
-		ret = k_sem_take(&dw->device_sync_sem, K_MSEC(CONFIG_I2C_DW_RW_TIMEOUT_MS));
+		ret = k_sem_take(&dw->device_sync_sem, rom->transfer_timeout);
 		if (ret != 0) {
 			if (test_bit_con_master_mode(reg_base)) {
 				/* Trigger abort and wait for it to complete. */
@@ -1624,6 +1625,7 @@ static int i2c_dw_initialize(const struct device *dev)
 		.hcnt_offset = (int16_t)DT_INST_PROP_OR(n, hcnt_offset, 0),                        \
 		.fs_spk_len = MAX((uint8_t)DT_INST_PROP_OR(n, fs_spike_len, 0), DW_IC_SPKLEN_MIN), \
 		.hs_spk_len = MAX((uint8_t)DT_INST_PROP_OR(n, hs_spike_len, 0), DW_IC_SPKLEN_MIN), \
+		.transfer_timeout = I2C_DT_INST_TRANSFER_TIMEOUT(inst),                            \
 		TIMEOUT_DW_CONFIG(n) RESET_DW_CONFIG(n) PINCTRL_DW_CONFIG(n) I2C_DW_INIT_PCIE(n)   \
 			I2C_CONFIG_DMA_INIT(n) CLOCK_DW_CONFIG(n)};                                \
 	BUILD_ASSERT(DT_INST_PROP_OR(n, sda_hold_tx, 0) <= 0xffff, "Invalid SDA_HOLD_TX value");   \

--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -157,6 +157,7 @@ struct i2c_dw_rom_config {
 	int16_t hcnt_offset;
 	uint8_t fs_spk_len;
 	uint8_t hs_spk_len;
+	k_timeout_t transfer_timeout;
 
 #if I2C_DW_PINCTRL_ENABLED
 	const struct pinctrl_dev_config *pcfg;


### PR DESCRIPTION
- i2c: dw: use a common "if I2C_DW"
- i2c: dw: use the generic timeout macro