### PR TITLE
net: ethernet: gptp: use net_pkt_set_tx_timestamping

### DIFF
--- a/drivers/ethernet/dsa/dsa_tag_netc.c
+++ b/drivers/ethernet/dsa/dsa_tag_netc.c
@@ -129,7 +129,7 @@ struct net_pkt *dsa_tag_netc_xmit(struct net_if *iface, struct net_pkt *pkt)
 	void *tag;
 
 	/* Tag is inserted after DMAC/SMAC fields. Decide header size per tag type. */
-	if (net_ntohs(NET_ETH_HDR(pkt)->type) == NET_ETH_PTYPE_PTP) {
+	if (net_pkt_is_tx_timestamping(pkt)) {
 		header_len += sizeof(struct netc_switch_tag_port_two_step_ts);
 	} else {
 		header_len += sizeof(struct netc_switch_tag_port_no_ts);
@@ -151,7 +151,7 @@ struct net_pkt *dsa_tag_netc_xmit(struct net_if *iface, struct net_pkt *pkt)
 
 #ifdef CONFIG_NET_L2_PTP_TIMESTAMPING
 	/* Enable two-step timestamping for gPTP. */
-	if (net_ntohs(NET_ETH_HDR(pkt)->type) == NET_ETH_PTYPE_PTP) {
+	if (net_pkt_is_tx_timestamping(pkt)) {
 
 		/* Utilize control block for timestamp request ID */
 		((struct netc_switch_tag_port_two_step_ts *)tag)->ts_req_id = pkt->cb.cb[0] & 0xf;

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -137,26 +137,6 @@ static inline struct net_if *get_iface(struct nxp_enet_mac_data *data)
 }
 
 #if defined(CONFIG_PTP_CLOCK_NXP_ENET)
-static bool eth_get_ptp_data(struct net_if *iface, struct net_pkt *pkt)
-{
-	struct net_eth_vlan_hdr *hdr_vlan = (struct net_eth_vlan_hdr *)NET_ETH_HDR(pkt);
-	struct ethernet_context *eth_ctx = net_if_l2_data(iface);
-	bool pkt_is_ptp;
-
-	if (net_eth_is_vlan_enabled(eth_ctx, iface)) {
-		pkt_is_ptp = net_ntohs(hdr_vlan->type) == NET_ETH_PTYPE_PTP;
-	} else {
-		pkt_is_ptp = net_ntohs(NET_ETH_HDR(pkt)->type) == NET_ETH_PTYPE_PTP;
-	}
-
-	if (pkt_is_ptp) {
-		net_pkt_set_priority(pkt, NET_PRIORITY_CA);
-	}
-
-	return pkt_is_ptp;
-}
-
-
 static inline void ts_register_tx_event(const struct device *dev,
 					 enet_frame_info_t *frameinfo)
 {
@@ -164,9 +144,7 @@ static inline void ts_register_tx_event(const struct device *dev,
 	struct net_pkt *pkt = frameinfo->context;
 
 	if (pkt && atomic_get(&pkt->atomic_ref) > 0) {
-		if ((eth_get_ptp_data(net_pkt_iface(pkt), pkt) ||
-		     net_pkt_is_tx_timestamping(pkt)) &&
-		    frameinfo->isTsAvail) {
+		if (net_pkt_is_tx_timestamping(pkt) && frameinfo->isTsAvail) {
 			/* Timestamp is written to packet in ISR.
 			 * Semaphore ensures sequential execution of writing
 			 * the timestamp here and subsequently reading the timestamp
@@ -193,7 +171,6 @@ static inline void eth_wait_for_ptp_ts(const struct device *dev, struct net_pkt 
 	}
 }
 #else
-#define eth_get_ptp_data(...) false
 #define ts_register_tx_event(...)
 #define eth_wait_for_ptp_ts(...)
 #endif /* CONFIG_PTP_CLOCK_NXP_ENET */
@@ -224,8 +201,7 @@ static int eth_nxp_enet_tx(const struct device *dev, struct net_pkt *pkt)
 		return ret;
 	}
 
-	frame_is_timestamped =
-		eth_get_ptp_data(net_pkt_iface(pkt), pkt) || net_pkt_is_tx_timestamping(pkt);
+	frame_is_timestamped = net_pkt_is_tx_timestamping(pkt);
 
 	ret = ENET_SendFrame(data->base, &data->enet_handle, data->tx_frame_buf, total_len, RING_ID,
 			     frame_is_timestamped, pkt);

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -123,9 +123,6 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 	struct net_buf *fragment = pkt->frags;
 	int frags_count = 0, total_bytes = 0, frags_idx = 0;
 	int ret;
-#if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
-	bool pkt_is_ptp;
-#endif
 
 	/* Only allow send of the maximum normal packet size */
 	while (fragment != NULL) {
@@ -188,8 +185,7 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 	last_desc_ptr->read.control1 |= TX_INTERRUPT_ON_COMPLETE_FLAG;
 
 #if defined(CONFIG_PTP_CLOCK_NXP_ENET_QOS)
-	pkt_is_ptp = net_ntohs(NET_ETH_HDR(pkt)->type) == NET_ETH_PTYPE_PTP;
-	if (net_pkt_is_tx_timestamping(pkt) || pkt_is_ptp) {
+	if (net_pkt_is_tx_timestamping(pkt)) {
 		LOG_DBG("SET TX TIMESTAMP %p control %x", pkt, base->MAC_TIMESTAMP_CONTROL);
 		last_desc_ptr->read.control1 |= TX_TIMESTAMP_ENABLE_FLAG;
 	}

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -187,7 +187,6 @@ void eth_stm32_mcast_filter(const struct device *dev,
 
 #ifdef CONFIG_PTP_CLOCK_STM32_HAL
 const struct device *eth_stm32_get_ptp_clock(const struct device *dev, struct net_if *iface);
-bool eth_stm32_is_ptp_pkt(struct net_if *iface, struct net_pkt *pkt);
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
 #endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_STM32_HAL_PRIV_H_ */

--- a/drivers/ethernet/eth_stm32_hal_ptp.c
+++ b/drivers/ethernet/eth_stm32_hal_ptp.c
@@ -29,17 +29,6 @@ LOG_MODULE_REGISTER(eth_stm32_hal_ptp, CONFIG_ETHERNET_LOG_LEVEL);
 #define ETH_STM32_PTP_NOT_CONFIGURED HAL_ETH_PTP_NOT_CONFIGURED
 #endif /* stm32F7x or sm32F4x */
 
-bool eth_stm32_is_ptp_pkt(struct net_if *iface, struct net_pkt *pkt)
-{
-	if (net_ntohs(NET_ETH_HDR(pkt)->type) != NET_ETH_PTYPE_PTP) {
-		return false;
-	}
-
-	net_pkt_set_priority(pkt, NET_PRIORITY_CA);
-
-	return true;
-}
-
 void HAL_ETH_TxPtpCallback(uint32_t *buff, ETH_TimeStampTypeDef *timestamp)
 {
 	struct eth_stm32_tx_context *ctx = (struct eth_stm32_tx_context *)buff;

--- a/drivers/ethernet/eth_stm32_hal_v2.c
+++ b/drivers/ethernet/eth_stm32_hal_v2.c
@@ -182,10 +182,6 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 		.CRCPadCtrl = ETH_CRC_PAD_INSERT,
 	};
 
-#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
-	bool timestamped_frame;
-#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
-
 	__ASSERT_NO_MSG(pkt != NULL);
 	__ASSERT_NO_MSG(pkt->frags != NULL);
 
@@ -206,9 +202,7 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 	buf_header = &dev_data->tx_buffer_header[ctx->first_tx_buffer_index];
 
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
-	timestamped_frame = eth_stm32_is_ptp_pkt(net_pkt_iface(pkt), pkt) ||
-		net_pkt_is_tx_timestamping(pkt);
-	if (timestamped_frame) {
+	if (net_pkt_is_tx_timestamping(pkt)) {
 		/* Enable transmit timestamp */
 		if (HAL_ETH_PTP_InsertTxTimestamp(heth) != HAL_OK) {
 			res = -EIO;
@@ -295,9 +289,6 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 			ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC : ETH_CHECKSUM_DISABLE,
 		.CRCPadCtrl = ETH_CRC_PAD_INSERT,
 	};
-#if defined(CONFIG_PTP_CLOCK_STM32_HAL)
-	bool timestamped_frame;
-#endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
 	__ASSERT_NO_MSG(pkt != NULL);
 	__ASSERT_NO_MSG(pkt->frags != NULL);
@@ -312,9 +303,7 @@ int eth_stm32_tx(const struct device *dev, struct net_pkt *pkt)
 	buf_header = &dev_data->tx_buffer_header[ctx->first_tx_buffer_index];
 
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
-	timestamped_frame = eth_stm32_is_ptp_pkt(net_pkt_iface(pkt), pkt) ||
-			    net_pkt_is_tx_timestamping(pkt);
-	if (timestamped_frame) {
+	if (net_pkt_is_tx_timestamping(pkt)) {
 		/* Enable transmit timestamp */
 		if (HAL_ETH_PTP_InsertTxTimestamp(heth) != HAL_OK) {
 			return -EIO;

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -444,9 +444,7 @@ static int eth_xmc4xxx_send(const struct device *dev, struct net_pkt *pkt)
 			dma_desc->status |= ETH_MAC_DMA_TDES0_FS;
 
 #if defined(CONFIG_NET_GPTP)
-			struct net_eth_hdr *hdr = NET_ETH_HDR(pkt);
-
-			if (net_ntohs(hdr->type) == NET_ETH_PTYPE_PTP) {
+			if (net_pkt_is_tx_timestamping(pkt)) {
 				dma_desc->status |= ETH_MAC_DMA_TDES0_TTSE;
 			}
 #endif

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -451,9 +451,7 @@ int netc_eth_tx(const struct device *dev, struct net_pkt *pkt)
 	status_t result;
 	int ret;
 	ep_tx_opt opt = {0};
-#ifdef CONFIG_PTP_CLOCK_NXP_NETC
-	bool pkt_is_gptp;
-#endif
+
 	__ASSERT(pkt, "Packet pointer is NULL");
 
 	iface_dst = data->iface;
@@ -480,8 +478,7 @@ int netc_eth_tx(const struct device *dev, struct net_pkt *pkt)
 #endif
 
 #ifdef CONFIG_PTP_CLOCK_NXP_NETC
-	pkt_is_gptp = net_ntohs(NET_ETH_HDR(pkt)->type) == NET_ETH_PTYPE_PTP;
-	if ((pkt_is_gptp || net_pkt_is_tx_timestamping(pkt)) &&
+	if (net_pkt_is_tx_timestamping(pkt) &&
 	    (netc_eth_get_ptp_clock(dev, data->iface) != NULL)) {
 		opt.flags |= kEP_TX_OPT_REQ_TS;
 	}
@@ -508,7 +505,7 @@ int netc_eth_tx(const struct device *dev, struct net_pkt *pkt)
 					   NETC_SI_TXDESCRIP_RD_SMSO_MASK |
 					   NETC_SI_TXDESCRIP_RD_PORT(dst_port);
 #ifdef CONFIG_PTP_CLOCK_NXP_NETC
-		if (pkt_is_gptp || net_pkt_is_tx_timestamping(pkt)) {
+		if (net_pkt_is_tx_timestamping(pkt)) {
 			txDesc[0].standard.flags |= NETC_SI_TXDESCRIP_RD_TSR_MASK;
 		}
 #endif

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -195,6 +195,7 @@ struct net_pkt *gptp_prepare_sync(int port)
 	}
 
 	net_pkt_set_priority(pkt, NET_PRIORITY_IC);
+	net_pkt_set_tx_timestamping(pkt, true);
 
 	port_ds = GPTP_PORT_DS(port);
 	sync = GPTP_SYNC(pkt);
@@ -355,6 +356,7 @@ struct net_pkt *gptp_prepare_pdelay_resp(int port,
 	}
 
 	net_pkt_set_priority(pkt, NET_PRIORITY_IC);
+	net_pkt_set_tx_timestamping(pkt, true);
 
 	port_ds = GPTP_PORT_DS(port);
 


### PR DESCRIPTION
use net_pkt_set_tx_timestamping to
enable timestamping for that packet.
Only timestamp these packets with
GPTP_SYNC_MESSAGE or
GPTP_PATH_DELAY_RESP_MESSAGE
as only these have callbacks registered with
net_if_register_timestamp_cb().

Also cleap up the ethernet drivers to then also only use `net_pkt_is_tx_timestamping()`