### PR TITLE
llext: read target section size once per relocation section

### DIFF
--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -553,6 +553,8 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 
 		sect_base = (uintptr_t) llext_loaded_sect_ptr(ldr, ext, shdr->sh_info);
 
+		size_t tgt_sect_size = ext->sect_hdrs[shdr->sh_info].sh_size;
+
 		for (int j = 0; j < rel_cnt; j++) {
 			/* get each relocation entry */
 			ret = llext_seek(ldr, shdr->sh_offset + j * shdr->sh_entsize);
@@ -572,11 +574,10 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 			 * start of the write; the field width is relocation-type
 			 * specific and left to the per-arch handler.
 			 */
-			if (rel.r_offset >= ext->sect_hdrs[shdr->sh_info].sh_size) {
+			if (rel.r_offset >= tgt_sect_size) {
 				LOG_ERR("relocation r_offset %#zx out of section %d "
 					"(size %#zx)",
-					(size_t)rel.r_offset, shdr->sh_info,
-					(size_t)ext->sect_hdrs[shdr->sh_info].sh_size);
+					(size_t)rel.r_offset, shdr->sh_info, tgt_sect_size);
 				return -ENOEXEC;
 			}
 


### PR DESCRIPTION
The relocation bounds check read the target section header from ext->sect_hdrs on every loop iteration.
The check itself never fails for valid extensions, but the per-iteration read enlarged
the relocation loop enough to shift runtime layout and trip an execute fault in loaded
extensions on arm cortex-r5 with the power-of-two MPU, hanging the llext readonly_mpu suite.
Read the size into a local once per relocation section, which is loop-invariant, and compare against that instead.

Fixes `west build -p -b qemu_cortex_r5/zynqmp_rpu tests/subsys/llext -T llext.readonly_mpu`:

```c
SUITE PASS - 100.00% [llext]: pass = 12, fail = 0, skip = 0, total = 12 duration = 0.344 seconds
 - PASS - [llext.test_ext_syscall_fail] duration = 0.007 seconds
 - PASS - [llext.test_fs_loader] duration = 0.103 seconds
 - PASS - [llext.test_inspect] duration = 0.012 seconds
 - PASS - [llext.test_load_unload_align] duration = 0.048 seconds
 - PASS - [llext.test_load_unload_hello_world] duration = 0.016 seconds
 - PASS - [llext.test_load_unload_init_fini] duration = 0.023 seconds
 - PASS - [llext.test_load_unload_logging] duration = 0.017 seconds
 - PASS - [llext.test_load_unload_object] duration = 0.027 seconds
 - PASS - [llext.test_load_unload_relative_jump] duration = 0.026 seconds
 - PASS - [llext.test_load_unload_syscalls] duration = 0.020 seconds
 - PASS - [llext.test_load_unload_threads_kernel_objects] duration = 0.043 seconds
 - PASS - [llext.test_printk_exported] duration = 0.002 seconds

------ TESTSUITE SUMMARY END ------

``` 
