### PR TITLE
Bluetooth: Classic: misc. Doxygen documentation fixes

### DIFF
--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -87,7 +87,6 @@ extern "C" {
  *  @param _min_bitpool sbc codec min bit pool. for example: 18
  *  @param _max_bitpool sbc codec max bit pool. for example: 35
  *  @param _delay_report delay report capability
- *  @
  */
 #define BT_A2DP_SBC_SINK_EP(_name, _freq, _ch_mode, _blk_len, _subband, _alloc_mthd, _min_bitpool, \
 			    _max_bitpool, _delay_report)                                           \
@@ -468,6 +467,7 @@ struct bt_a2dp_cb {
 	 * reconfigured.
 	 *
 	 *  @param[in] stream    Pointer to stream object.
+	 *  @param[in] codec_cfg Codec configuration.
 	 *  @param[out] rsp_err_code  give the error code if response error.
 	 *                          bt_a2dp_err_code or bt_avdtp_err_code
 	 *
@@ -783,6 +783,7 @@ struct bt_a2dp_stream_ops {
 #if defined(CONFIG_BT_A2DP_SINK)
 	/** @brief the media streaming data, only for sink
 	 *
+	 *  @param stream the stream object
 	 *  @param buf the data buf
 	 *  @param seq_num the sequence number
 	 *  @param ts the time stamp

--- a/include/zephyr/bluetooth/classic/avrcp.h
+++ b/include/zephyr/bluetooth/classic/avrcp.h
@@ -1883,7 +1883,7 @@ struct bt_avrcp_tg_cb {
 	 *  @param tid The transaction label of the request.
 	 *  @param buf The buffer containing the PASS THROUGH command payload.
 	 *             The application can parse this payload according to the format defined
-	 *             in @ref bt_avrcp_passthrough_rsp. Note that the data is encoded
+	 *             in @ref bt_avrcp_passthrough_cmd. Note that the data is encoded
 	 *             in big-endian format.
 	 */
 	void (*passthrough_req)(struct bt_avrcp_tg *tg, uint8_t tid, struct net_buf *buf);
@@ -1940,8 +1940,8 @@ struct bt_avrcp_tg_cb {
 	 *
 	 *  @param tg AVRCP TG connection object.
 	 *  @param tid The transaction label of the command.
-	 *  @param buf The buffer containing the GET_PLAYER_APP_SETTING_VAL_TEXT command payload,
-	 *            formatted as @ref bt_avrcp_get_player_app_setting_val_text_cmd.
+	 *  @param buf The buffer containing the GET_PLAYER_APP_SETTING_ATTR_TEXT command payload,
+	 *            formatted as @ref bt_avrcp_get_player_app_setting_attr_text_cmd.
 	 *            The application should parse fields in big-endian order.
 	 */
 	void (*get_player_app_setting_attr_text)(struct bt_avrcp_tg *tg, uint8_t tid,

--- a/include/zephyr/bluetooth/classic/bip.h
+++ b/include/zephyr/bluetooth/classic/bip.h
@@ -1780,7 +1780,7 @@ int bt_bip_get_partial_image_rsp(struct bt_bip_server *server, uint8_t rsp_code,
  * The following OBEX headers should be included for the first request,
  * @ref BT_OBEX_HEADER_ID_CONN_ID, @ref BT_OBEX_HEADER_ID_TYPE,
  * and @ref BT_OBEX_HEADER_ID_APP_PARAM.
- * And the value of type header is @ref BT_BIP_HDR_TYPE_GET_PARTIAL_IMAGE.
+ * And the value of type header is @ref BT_BIP_HDR_TYPE_GET_MONITORING_IMAGE.
  * The application parameter should include ID @ref BT_BIP_APPL_PARAM_TAG_ID_STORE_FLAG.
  *
  * @param client BIP client instance

--- a/include/zephyr/bluetooth/classic/hfp_ag.h
+++ b/include/zephyr/bluetooth/classic/hfp_ag.h
@@ -302,7 +302,7 @@ struct bt_hfp_ag_cb {
 	 *  call is in the ringing
 	 *
 	 *  @param call HFP AG call object.
-	 *  @param in_bond true - in-bond ringing, false - No in-bond ringing
+	 *  @param in_band true - in-band ringing, false - No in-band ringing
 	 */
 	void (*ringing)(struct bt_hfp_ag_call *call, bool in_band);
 
@@ -357,6 +357,7 @@ struct bt_hfp_ag_cb {
 	 *  supported codec ids are updated.
 	 *
 	 *  @param ag HFP AG object.
+	 *  @param ids Bitmap of supported codec IDs.
 	 */
 	void (*codec)(struct bt_hfp_ag *ag, uint32_t ids);
 
@@ -383,7 +384,6 @@ struct bt_hfp_ag_cb {
 	 *  default codec id `BT_HFP_AG_CODEC_CVSD`.
 	 *
 	 *  @param ag HFP AG object.
-	 *  @param err Result of codec negotiation.
 	 */
 	void (*audio_connect_req)(struct bt_hfp_ag *ag);
 


### PR DESCRIPTION
Fix copy-pasted struct references, a stray `@` token, and mismatched or undocumented callback parameters in the A2DP, AVRCP, BIP and HFP headers.

One commit per header; documentation only, no functional change.