### PR TITLE
Bluetooth: Mesh: misc. Doxygen documentation fixes

### DIFF
--- a/include/zephyr/bluetooth/mesh/blob.h
+++ b/include/zephyr/bluetooth/mesh/blob.h
@@ -183,6 +183,8 @@ struct bt_mesh_blob_io {
 	 *  @param io    BLOB stream.
 	 *  @param xfer  BLOB transfer.
 	 *  @param block Block that was started.
+	 *
+	 *  @return 0 on success, or (negative) error code otherwise.
 	 */
 	int (*block_start)(const struct bt_mesh_blob_io *io,
 			   const struct bt_mesh_blob_xfer *xfer,

--- a/include/zephyr/bluetooth/mesh/cdb.h
+++ b/include/zephyr/bluetooth/mesh/cdb.h
@@ -193,7 +193,7 @@ void bt_mesh_cdb_node_del(struct bt_mesh_cdb_node *node, bool store);
  *  Assigns the node a new address and clears the previous persistent storage
  *  entry.
  *
- *  @param node The node to be deleted.
+ *  @param node The node to be updated.
  *  @param addr New unicast address for the node.
  *  @param num_elem Updated number of elements in the node.
  */

--- a/include/zephyr/bluetooth/mesh/cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/cfg_cli.h
@@ -239,7 +239,7 @@ struct bt_mesh_cfg_cli_cb {
 	 *  @param addr        Address of the sender.
 	 *  @param status      Status Code for requesting message.
 	 *  @param elem_addr   The unicast address of the element.
-	 *  @param app_idx     The sub address.
+	 *  @param app_idx     The application key index.
 	 *  @param mod_id      The model ID within the element.
 	 */
 	void (*mod_app_status)(struct bt_mesh_cfg_cli *cli, uint16_t addr,

--- a/include/zephyr/bluetooth/mesh/main.h
+++ b/include/zephyr/bluetooth/mesh/main.h
@@ -221,7 +221,7 @@ struct bt_mesh_prov {
 	 *  once the data has been acquired from the user.
 	 *
 	 *  @param act Action for inputting data.
-	 *  @param num Maximum size of the inputted data.
+	 *  @param size Maximum size of the inputted data.
 	 *
 	 *  @return Zero on success or negative error code otherwise
 	 */


### PR DESCRIPTION
Fix wrong and mismatched `@param` descriptions and a missing `@return` entry.

One commit per header; documentation only, no functional change.