### PR TITLE
Bluetooth: Host: Doxygen fixes in GATT service headers

### DIFF
--- a/include/zephyr/bluetooth/services/cts.h
+++ b/include/zephyr/bluetooth/services/cts.h
@@ -163,7 +163,7 @@ struct bt_cts_cb {
 	 *
 	 * It is the responsibility of the application to store the new Local time.
 	 *
-	 * @param[in] local_time Requested local time to write
+	 * @param[in] cts_local_time Requested local time to write
 	 *
 	 * @return 0 if written successfully, negative error code on failure
 	 *

--- a/include/zephyr/bluetooth/services/ias.h
+++ b/include/zephyr/bluetooth/services/ias.h
@@ -87,11 +87,11 @@ struct bt_ias_client_cb {
 /** @brief Set alert level
  *
  *  @param conn Bluetooth connection object
- *  @param bt_ias_alert_lvl Level of alert to write
+ *  @param level Level of alert to write
  *
  *  @return Zero in case of success and error code in case of error.
  */
-int bt_ias_client_alert_write(struct bt_conn *conn, enum bt_ias_alert_lvl);
+int bt_ias_client_alert_write(struct bt_conn *conn, enum bt_ias_alert_lvl level);
 
 /** @brief Discover Immediate Alert Service
  *

--- a/include/zephyr/bluetooth/services/ots.h
+++ b/include/zephyr/bluetooth/services/ots.h
@@ -148,7 +148,7 @@ enum {
 #define BT_OTS_OBJ_SET_PROP_PATCH(prop) \
 	WRITE_BIT(prop, BT_OTS_OBJ_PROP_PATCH, 1)
 
-/** @brief Set @ref BT_OTS_OBJ_SET_PROP_MARKED property.
+/** @brief Set @ref BT_OTS_OBJ_PROP_MARKED property.
  *
  *  @param prop Object properties.
  */
@@ -262,7 +262,7 @@ enum bt_ots_oacp_write_op_mode {
 	BT_OTS_OACP_WRITE_OP_MODE_TRUNCATE = BIT(1),
 };
 
-/** @brief Set @ref BT_OTS_OACP_SET_FEAT_CREATE feature.
+/** @brief Set @ref BT_OTS_OACP_FEAT_CREATE feature.
  *
  *  @param feat OTS features.
  */


### PR DESCRIPTION
Fix mismatched `@param` names and self-referential `@ref` in the CTS, IAS and OTS setter macros.

One commit per header; documentation only, no functional change.