### PR TITLE
scripts: import sys was removed from guiconfig.py but is still in use

### DIFF
--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -61,6 +61,7 @@ $srctree is supported through Kconfiglib.
 import errno
 import os
 import re
+import sys
 
 from tkinter import *
 import tkinter.ttk as ttk


### PR DESCRIPTION
This is a recent regression from commit e95e5b8.