### PR TITLE
twister: script harness: Properly log script not found failures

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -416,12 +416,10 @@ class Script(Harness):
     def run(self, timeout: float) -> bool:
         self.instance.testcases = []
         for script in self._get_test_scripts():
-            rc = -1
             if not os.path.exists(script):
-                reason = f"{script} not found!"
-                logger.error(reason)
-                self._add_testcase_from_script(script, rc, reason=reason)
+                self._handle_missing_script(script)
                 continue
+            rc = -1
             duration = 0.0
             cmd = self._build_script_command(script)
             logger.debug(f"Running command: {shlex.join(cmd)}")
@@ -436,6 +434,13 @@ class Script(Harness):
         self.instance.record(self.recording)
         self._update_test_status()
         return True
+
+    def _handle_missing_script(self, script: str) -> None:
+        reason = f"{script} not found!"
+        logger.error(reason)
+        self._add_testcase_from_script(script, rc=-1, reason=reason)
+        with open(self.log_file_path, 'a') as log_file:
+            log_file.write(reason + '\n\n')
 
     def _get_env(self) -> dict[str, str]:
         """Return environment variables with BOARD set to the platform name."""


### PR DESCRIPTION
Before this patch, when a script is not found, `twister_harness.log` would not be created.

This would result in the error reporting in runner.py to refer users to the build.log; and if `--inline-logs` was used, it would inline the build.log in the console output which was irrelevant (a lot of confusing noise for users).

Instead let's create twister_harness.log logging a "not found" error. So we both refer users to it in the console output, and, if we inline anything, we inline that.

You can reproduce the issue modifying any script harness based test to have a wrong path, like
```diff
diff --git a/tests/bsim/bluetooth/audio/tests.yaml b/tests/bsim/bluetooth/audio/tests.yaml
index 8e0d0fce3b3..4a8da18a636 100644
--- a/tests/bsim/bluetooth/audio/tests.yaml
+++ b/tests/bsim/bluetooth/audio/tests.yaml
@@ -9,7 +9,7 @@ common:
     fixture: bsim_multi_test
     bsim_exe_name: tests_bsim_bluetooth_audio_prj_conf
     tests_scripts:
-      - test_scripts
+      - test_scriptst
 
 tests:
   bluetooth.audio:
```
And running it:
`twister -p nrf52_bsim -T tests/bsim/bluetooth/audio/  --aggressive-no-clean -vv --fixture bsim_multi_test --inline-logs`

