### PR TITLE
kernel: misc. Doxygen documentation fixes

### DIFF
--- a/include/zephyr/kernel/obj_core.h
+++ b/include/zephyr/kernel/obj_core.h
@@ -487,7 +487,7 @@ int k_obj_core_stats_reset(struct k_obj_core *obj_core);
 int k_obj_core_stats_disable(struct k_obj_core *obj_core);
 
 /**
- * @brief Reset the stats associated with the kernel object
+ * @brief Resume gathering the stats associated with the kernel object
  *
  * This function resumes the gathering of statistics associated with the kernel
  * object core specified by @a obj_core.

--- a/include/zephyr/kernel/thread_stack.h
+++ b/include/zephyr/kernel/thread_stack.h
@@ -129,7 +129,7 @@ static inline char *z_stack_ptr_align(char *ptr)
  * stack. It accepts the indicated "size" as a parameter and pads some
  * extra bytes (e.g. for alignment).
  *
- * @param size Size of the shadow stack memory region
+ * @param size_ Size of the shadow stack memory region
  */
 #define K_THREAD_HW_SHADOW_STACK_SIZE(size_) \
 	ARCH_THREAD_HW_SHADOW_STACK_SIZE(size_)
@@ -176,7 +176,7 @@ struct _stack_to_hw_shadow_stack {
  * defined with K_THREAD_STACK_DEFINE().
  *
  * @param sym Hardware shadow stack symbol name
- * @param size Size of the shadow stack memory region
+ * @param size_ Size of the shadow stack memory region
  */
 #define K_THREAD_HW_SHADOW_STACK_DEFINE(sym, size_) \
 	ARCH_THREAD_HW_SHADOW_STACK_DEFINE(__ ## sym ## _shstk, size_); \
@@ -204,8 +204,8 @@ struct _stack_to_hw_shadow_stack_arr {
  * defined with K_THREAD_STACK_ARRAY_DEFINE().
  *
  * @param sym Hardware shadow stack array symbol name
- * @param nmemb Number of stacks defined
- * @param size Size of the shadow stack memory region
+ * @param nmemb_ Number of stacks defined
+ * @param size_ Size of the shadow stack memory region
  */
 #define K_THREAD_HW_SHADOW_STACK_ARRAY_DEFINE(sym, nmemb_, size_) \
 	ARCH_THREAD_HW_SHADOW_STACK_ARRAY_DEFINE(__ ## sym ## _shstk_arr, nmemb_, \


### PR DESCRIPTION
Fix a copy-pasted `@brief` and `@param` names that don't match the HW shadow-stack macro signatures.