### PR TITLE
include: logging: misc. Doxygen documentation fixes

### DIFF
--- a/include/zephyr/logging/log_backend.h
+++ b/include/zephyr/logging/log_backend.h
@@ -266,7 +266,7 @@ static inline uint8_t log_backend_id_get(const struct log_backend *const backend
 /**
  * @brief Get backend.
  *
- * @param[in] idx  Pointer to the backend instance.
+ * @param[in] idx  Index of the backend instance.
  *
  * @return    Pointer to the backend instance.
  */

--- a/include/zephyr/logging/log_link.h
+++ b/include/zephyr/logging/log_link.h
@@ -292,7 +292,7 @@ static inline int log_link_get_levels(const struct log_link *link,
  * @param[in] link	Log link instance.
  * @param[in] domain_id	Relative domain ID.
  * @param[in] source_id	Source ID.
- * @param[out] level	Requested level.
+ * @param[in] level	Requested level.
  *
  * @return 0 on success or error code.
  */

--- a/include/zephyr/logging/log_output.h
+++ b/include/zephyr/logging/log_output.h
@@ -129,8 +129,6 @@ struct log_output {
  * @param output Pointer to log_output struct.
  * @param msg Pointer to log_msg struct.
  * @param flags Flags used for text formatting options.
- *
- * @return Function pointer based on Kconfigs defined for backends.
  */
 typedef void (*log_format_func_t)(const struct log_output *output,
 					struct log_msg *msg, uint32_t flags);


### PR DESCRIPTION
Fix a copy-pasted `idx` parameter description, a wrong `@param[out]` direction, and a bogus `@return` on a void callback typedef.