### PR TITLE
input: kbd_matrix: Fix set_detect_mode parameter name

### DIFF
--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -103,7 +103,7 @@ struct input_kbd_matrix_api {
 	 * interrupts row pin changes.
 	 *
 	 * @param dev Pointer to the keyboard matrix device.
-	 * @param enable Whether detection mode has to be enabled or disabled.
+	 * @param enabled Whether detection mode has to be enabled or disabled.
 	 */
 	void (*set_detect_mode)(const struct device *dev, bool enabled);
 };


### PR DESCRIPTION
The `set_detect_mode` callback documented an `enable` parameter, but the signature names it `enabled`.