### PR TITLE
modules: lvgl: Deprecate swap-xy, invert-{x,y} for pointer input

### DIFF
--- a/boards/renesas/da14695_dk_usb/dts/da14695_dk_usb_lcdc.overlay
+++ b/boards/renesas/da14695_dk_usb/dts/da14695_dk_usb_lcdc.overlay
@@ -16,7 +16,6 @@
 	lvgl_pointer {
 		input = <&display_touch>;
 		status = "okay";
-		swap-xy;
 	};
 };
 
@@ -47,6 +46,7 @@
 		status = "okay";
 		reg = <0x38>;
 		int-gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+		swap-xy;
 	};
 };
 

--- a/boards/renesas/da14695_dk_usb/dts/da14695_dk_usb_mipi_dbi.overlay
+++ b/boards/renesas/da14695_dk_usb/dts/da14695_dk_usb_mipi_dbi.overlay
@@ -16,9 +16,6 @@
 	lvgl_pointer {
 		input = <&display_touch>;
 		status = "okay";
-		swap-xy;
-		invert-x;
-		invert-y;
 	};
 };
 
@@ -31,6 +28,9 @@
 		status = "okay";
 		reg = <0x38>;
 		int-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+		swap-xy;
+		invert-x;
+		invert-y;
 	};
 };
 

--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
@@ -16,7 +16,6 @@
 	lvgl_pointer {
 		input = <&display_touch>;
 		status = "okay";
-		swap-xy;
 	};
 };
 
@@ -47,6 +46,7 @@
 		status = "okay";
 		reg = <0x38>;
 		int-gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+		swap-xy;
 	};
 };
 

--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_mipi_dbi.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_mipi_dbi.overlay
@@ -16,9 +16,6 @@
 	lvgl_pointer {
 		input = <&display_touch>;
 		status = "okay";
-		swap-xy;
-		invert-x;
-		invert-y;
 	};
 };
 
@@ -31,6 +28,9 @@
 		status = "okay";
 		reg = <0x38>;
 		int-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+		swap-xy;
+		invert-x;
+		invert-y;
 	};
 };
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1154,6 +1154,14 @@ Modules
 * Support for the `CANopenNode <https://github.com/CANopenNode/CANopenNode>`_ protocol stack was
   moved to an :ref:`external module<external_module_canopennode>`.
 
+lvgl
+====
+
+* The ``zephyr,lvgl-pointer-input`` devicetree binding marks the ``swap-xy``, ``invert-x``, and
+  ``invert-y`` properties as **deprecated**. Users should instead add these properties to the
+  underlying touch input controller device node, where they are now the canonical location for
+  such transformations.
+
 hal_nxp
 =======
 

--- a/dts/bindings/input/zephyr,lvgl-pointer-input.yaml
+++ b/dts/bindings/input/zephyr,lvgl-pointer-input.yaml
@@ -17,18 +17,24 @@ include: zephyr,lvgl-common-input.yaml
 properties:
   swap-xy:
     type: boolean
+    deprecated: true
     description: |
       Swap x-y axes to align input with the display.
+      Deprecated: Use the swap-xy property of the underlying input device instead.
 
   invert-x:
     type: boolean
+    deprecated: true
     description: |
       Invert x axes to align input with the display.
+      Deprecated: Use the invert-x property of the underlying input device instead.
 
   invert-y:
     type: boolean
+    deprecated: true
     description: |
       Invert y axes to align input with the display.
+      Deprecated: Use the invert-y property of the underlying input device instead.
 
 examples:
   - |


### PR DESCRIPTION
The swap-xy, invert-x, and invert-y properties in the zephyr,lvgl-pointer-input devicetree binding are deprecated. Users should instead add these properties to the underlying touch input controller device node.