### PR TITLE
net: mdns_responder: add CONFIG_MDNS_RESPONDER_ANNOUNCE_DNS_SD

### DIFF
--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -373,6 +373,24 @@ config MDNS_RESPONDER_DNS_SD_SERVICE_TYPE_ENUMERATION
 	  Chapter 9. By doing so, Zephyr network services are discoverable
 	  using e.g. 'avahi-browse -t -r _services._dns-sd._udp.local'.
 
+config MDNS_RESPONDER_ANNOUNCE_DNS_SD
+	bool "Include DNS-SD service records in mDNS announcements"
+	depends on MDNS_RESPONDER_PROBE
+	help
+	  RFC 6762 Section 8.3 requires the startup announcement to contain
+	  all of a responder's newly registered resource records, not just
+	  address records -- this covers the shared PTR record and unique
+	  SRV/TXT records for every DNS-SD service registered via
+	  DNS_SD_REGISTER_SERVICE() (and any records set through
+	  mdns_responder_set_ext_records()).
+
+	  Enable this for full RFC 6762 compliance. Leave disabled to keep
+	  announcements limited to address records only (smaller, less
+	  frequent traffic on startup) -- clients that actively query for
+	  services (e.g. avahi-browse) are unaffected either way, since
+	  normal query/response handling already answers DNS-SD queries
+	  regardless of this option.
+
 endif # MDNS_RESPONDER_DNS_SD
 
 module = MDNS_RESPONDER

--- a/subsys/net/lib/dns/dns_sd.c
+++ b/subsys/net/lib/dns/dns_sd.c
@@ -830,7 +830,7 @@ static inline bool port_in_use(uint16_t proto, uint16_t port, const struct net_i
 
 int dns_sd_handle_ptr_query(struct net_if *iface, const struct dns_sd_rec *inst,
 			    const struct net_in_addr *addr4, const struct net_in6_addr *addr6,
-			    uint8_t *buf, uint16_t buf_size)
+			    uint8_t *buf, uint16_t buf_size, bool announce)
 {
 	/*
 	 * RFC 6763 Section 12.1
@@ -844,6 +844,14 @@ int dns_sd_handle_ptr_query(struct net_if *iface, const struct dns_sd_rec *inst,
 	 * o  All address records (type "A" and "AAAA") named in the SRV rdata.
 	 *	contain the SRV record(s), the TXT record(s), and the address
 	 *      records (A or AAAA)
+	 *
+	 * RFC 6762 Section 8.3
+	 *
+	 * Unlike a response to an explicit query, an unsolicited announcement
+	 * MUST place every record being announced in the Answer Section, not
+	 * the Additional Record Section. When @p announce is true, the SRV,
+	 * TXT and address records below are counted towards ancount instead
+	 * of arcount to reflect this.
 	 */
 
 	uint16_t instance_offset;
@@ -853,6 +861,12 @@ int dns_sd_handle_ptr_query(struct net_if *iface, const struct dns_sd_rec *inst,
 	uint16_t proto;
 	uint16_t offset = sizeof(struct dns_header);
 	struct dns_header *rsp = (struct dns_header *)buf;
+	/* Additional records for a direct query response; part of the Answer
+	 * section instead when this packet is an unsolicited announcement.
+	 * Accumulated locally since &rsp->ancount/&rsp->arcount can't be taken
+	 * (rsp is packed).
+	 */
+	uint16_t extra_count = 0;
 	uint32_t tmp;
 	int r;
 
@@ -893,13 +907,12 @@ int dns_sd_handle_ptr_query(struct net_if *iface, const struct dns_sd_rec *inst,
 	rsp->ancount++;
 	offset += r;
 
-	/* then add the additional records */
 	r = add_txt_record(inst, DNS_SD_TXT_TTL, instance_offset, buf, offset, buf_size);
 	if (r < 0) {
 		return r; /* LCOV_EXCL_LINE */
 	}
 
-	rsp->arcount++;
+	extra_count++;
 	offset += r;
 
 	r = add_srv_record(inst, DNS_SD_SRV_TTL, instance_offset, domain_offset, buf, offset,
@@ -908,7 +921,7 @@ int dns_sd_handle_ptr_query(struct net_if *iface, const struct dns_sd_rec *inst,
 		return r; /* LCOV_EXCL_LINE */
 	}
 
-	rsp->arcount++;
+	extra_count++;
 	offset += r;
 
 	if (addr6 != NULL && !net_ipv6_is_addr_unspecified(addr6)) {
@@ -918,7 +931,7 @@ int dns_sd_handle_ptr_query(struct net_if *iface, const struct dns_sd_rec *inst,
 			return r; /* LCOV_EXCL_LINE */
 		}
 
-		rsp->arcount++;
+		extra_count++;
 		offset += r;
 	}
 
@@ -930,7 +943,7 @@ int dns_sd_handle_ptr_query(struct net_if *iface, const struct dns_sd_rec *inst,
 			return r; /* LCOV_EXCL_LINE */
 		}
 
-		rsp->arcount++;
+		extra_count++;
 		offset += r;
 	}
 
@@ -941,7 +954,7 @@ int dns_sd_handle_ptr_query(struct net_if *iface, const struct dns_sd_rec *inst,
 		r = add_remaining_aaaa_records(iface, inst, host_offset, addr6,
 					       buf, &offset, buf_size);
 		/* offset was updated inside the function */
-		rsp->arcount += r;
+		extra_count += r;
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
@@ -951,7 +964,13 @@ int dns_sd_handle_ptr_query(struct net_if *iface, const struct dns_sd_rec *inst,
 		r = add_remaining_a_records(iface, inst, host_offset, addr4,
 					    buf, &offset, buf_size);
 		/* offset was updated inside the function */
-		rsp->arcount += r;
+		extra_count += r;
+	}
+
+	if (announce) {
+		rsp->ancount += extra_count;
+	} else {
+		rsp->arcount = extra_count;
 	}
 
 	/* Set the Response and AA bits */

--- a/subsys/net/lib/dns/dns_sd.h
+++ b/subsys/net/lib/dns/dns_sd.h
@@ -133,13 +133,16 @@ bool dns_sd_rec_match(const struct dns_sd_rec *record,
  * @param addr6 pointer to the IPv6 address
  * @param buf output buffer
  * @param buf_size size of the output buffer
+ * @param announce if true, place the SRV/TXT/A/AAAA records in the Answer
+ *        section instead of the Additional Records section, as required by
+ *        RFC 6762 Section 8.3 for unsolicited announcements
  *
  * @return on success, number of bytes written to @p buf
  * @return on failure, a negative errno value
  */
 int dns_sd_handle_ptr_query(struct net_if *iface, const struct dns_sd_rec *inst,
 	const struct net_in_addr *addr4, const struct net_in6_addr *addr6,
-	uint8_t *buf, uint16_t buf_size);
+	uint8_t *buf, uint16_t buf_size, bool announce);
 
 /**
  * @brief Handle a Service Type Enumeration with DNS Service Discovery

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -807,7 +807,7 @@ static void send_sd_response(int sock,
 				}
 			} else {
 				ret = dns_sd_handle_ptr_query(iface, record, addr4, addr6,
-						result->data, net_buf_max_len(result));
+						result->data, net_buf_max_len(result), false);
 				if (ret < 0) {
 					NET_DBG("dns_sd_handle_ptr_query() failed (%d)", ret);
 					continue;
@@ -2234,6 +2234,69 @@ static bool check_if_needs_announce(struct net_if *iface)
 	return false;
 }
 
+#if defined(CONFIG_MDNS_RESPONDER_ANNOUNCE_DNS_SD)
+/* RFC 6762 8.3 requires announcing all newly registered records, not just addresses. Sends
+ * one extra packet per service via dns_sd_handle_ptr_query() (already used for direct
+ * queries), since that encoder resets its own header and can't compose into the address
+ * announce's buffer without a rewrite.
+ */
+static void send_dns_sd_announce(struct net_if *iface, int sock, net_sa_family_t family,
+				 struct net_sockaddr *dst_addr, net_socklen_t dst_len)
+{
+	const struct net_in_addr *addr4 = NULL;
+	const struct net_in6_addr *addr6 = NULL;
+	const struct dns_sd_rec *record;
+	struct net_buf *answer;
+	size_t rec_num;
+	size_t ext_rec_num = external_records_count;
+	int ret;
+
+	if (IS_ENABLED(CONFIG_NET_IPV4) && family == NET_AF_INET) {
+		addr4 = net_if_ipv4_select_src_addr(iface, &net_sin(dst_addr)->sin_addr);
+	} else if (IS_ENABLED(CONFIG_NET_IPV6) && family == NET_AF_INET6) {
+		addr6 = net_if_ipv6_select_src_addr(iface, &net_sin6(dst_addr)->sin6_addr);
+	} else {
+		return;
+	}
+
+	answer = net_buf_alloc(&mdns_msg_pool, BUF_ALLOC_TIMEOUT);
+	if (answer == NULL) {
+		return;
+	}
+
+	DNS_SD_COUNT(&rec_num);
+
+	while (rec_num > 0 || ext_rec_num > 0) {
+		if (rec_num > 0) {
+			DNS_SD_GET(rec_num - 1, &record);
+			rec_num--;
+		} else {
+			record = &external_records[ext_rec_num - 1];
+			ext_rec_num--;
+		}
+
+		ret = dns_sd_handle_ptr_query(iface, record, addr4, addr6, answer->data,
+					      net_buf_max_len(answer), true);
+		if (ret < 0) {
+			continue;
+		}
+
+		answer->len = ret;
+
+		ret = zsock_sendto(sock, answer->data, answer->len, 0, dst_addr, dst_len);
+		if (ret < 0) {
+			NET_DBG("Cannot send %s DNS-SD announce for %s.%s.%s.%s (%d)", "mDNS",
+				record->instance, record->service, record->proto, record->domain,
+				-errno);
+		} else {
+			net_stats_update_dns_sent(iface);
+		}
+	}
+
+	net_buf_unref(answer);
+}
+#endif /* CONFIG_MDNS_RESPONDER_ANNOUNCE_DNS_SD */
+
 static int send_announce(const char *name)
 {
 	struct net_buf *answer;
@@ -2279,6 +2342,11 @@ static int send_announce(const char *name)
 
 		NET_DBG("Announcing %s responder for %s%s (iface %d)",
 			"mDNS", name, ".local", net_if_get_by_iface(v4_ctx[i].iface));
+
+#if defined(CONFIG_MDNS_RESPONDER_ANNOUNCE_DNS_SD)
+		send_dns_sd_announce(v4_ctx[i].iface, v4_ctx[i].sock, NET_AF_INET,
+				     (struct net_sockaddr *)&dst_addr4, sizeof(dst_addr4));
+#endif
 	}
 #endif /* defined(CONFIG_NET_IPV4) */
 
@@ -2322,6 +2390,11 @@ static int send_announce(const char *name)
 
 		NET_DBG("Announcing %s responder for %s%s (iface %d)",
 			"mDNS", name, ".local", net_if_get_by_iface(v6_ctx[i].iface));
+
+#if defined(CONFIG_MDNS_RESPONDER_ANNOUNCE_DNS_SD)
+		send_dns_sd_announce(v6_ctx[i].iface, v6_ctx[i].sock, NET_AF_INET6,
+				     (struct net_sockaddr *)&dst_addr6, sizeof(dst_addr6));
+#endif
 	}
 #endif /* defined(CONFIG_NET_IPV6) */
 

--- a/tests/net/lib/dns_sd/src/main.c
+++ b/tests/net/lib/dns_sd/src/main.c
@@ -536,7 +536,7 @@ ZTEST(dns_sd, test_dns_sd_handle_ptr_query)
 						 NULL,
 						 &actual_rsp[0],
 						 sizeof(actual_rsp) -
-						 sizeof(struct dns_header));
+						 sizeof(struct dns_header), false);
 
 	zassert_true(actual_int > 0,
 		     "dns_sd_handle_ptr_query() failed (%d)",
@@ -551,7 +551,7 @@ ZTEST(dns_sd, test_dns_sd_handle_ptr_query)
 	nonconst_port = 0;
 	zassert_equal(-EHOSTDOWN, dns_sd_handle_ptr_query(NULL, &nasxxxxxx_ephemeral,
 		&addr, NULL, &actual_rsp[0], sizeof(actual_rsp) -
-		sizeof(struct dns_header)), "port zero should not "
+		sizeof(struct dns_header), false), "port zero should not "
 		"produce any DNS-SD query response");
 
 	/* show advertisement for initialized port */
@@ -559,12 +559,44 @@ ZTEST(dns_sd, test_dns_sd_handle_ptr_query)
 	expected_int = sizeof(expected_rsp);
 	zassert_equal(expected_int, dns_sd_handle_ptr_query(NULL, &nasxxxxxx_ephemeral,
 		&addr, NULL, &actual_rsp[0], sizeof(actual_rsp) -
-		sizeof(struct dns_header)), "");
+		sizeof(struct dns_header), false), "");
 
 	zassert_equal(-EINVAL, dns_sd_handle_ptr_query(
 		NULL, &invalid_dns_sd_record,
 		&addr, NULL, &actual_rsp[0], sizeof(actual_rsp) -
-		sizeof(struct dns_header)), "");
+		sizeof(struct dns_header), false), "");
+}
+
+/* RFC 6762 Section 8.3: unsolicited announcements must place every record in the
+ * Answer Section, not the Additional Record Section. Same wire bytes as
+ * test_dns_sd_handle_ptr_query's expected_rsp, except ancount/arcount in the header
+ * (offsets 6-7 and 10-11): all 4 non-PTR records move from arcount into ancount.
+ */
+ZTEST(dns_sd, test_dns_sd_handle_ptr_query_announce)
+{
+	struct net_in_addr addr = {{{177, 5, 240, 13}}};
+	static uint8_t actual_rsp[512];
+	static uint8_t expected_rsp[] = {
+		0x00, 0x00, 0x84, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x05,
+		0x5f, 0x68, 0x74, 0x74, 0x70, 0x04, 0x5f, 0x74, 0x63, 0x70, 0x05, 0x6c, 0x6f,
+		0x63, 0x61, 0x6c, 0x00, 0x00, 0x0c, 0x00, 0x01, 0x00, 0x00, 0x11, 0x94, 0x00,
+		0x0c, 0x09, 0x4e, 0x41, 0x53, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0xc0, 0x0c,
+		0xc0, 0x28, 0x00, 0x10, 0x80, 0x01, 0x00, 0x00, 0x11, 0x94, 0x00, 0x07, 0x06,
+		0x70, 0x61, 0x74, 0x68, 0x3d, 0x2f, 0xc0, 0x28, 0x00, 0x21, 0x80, 0x01, 0x00,
+		0x00, 0x00, 0x78, 0x00, 0x12, 0x00, 0x00, 0x00, 0x00, 0x1f, 0x90, 0x09, 0x4e,
+		0x41, 0x53, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0xc0, 0x17, 0xc0, 0x59, 0x00,
+		0x01, 0x80, 0x01, 0x00, 0x00, 0x00, 0x78, 0x00, 0x04, 0xb1, 0x05, 0xf0, 0x0d,
+	};
+	int expected_int = sizeof(expected_rsp);
+	int actual_int =
+		dns_sd_handle_ptr_query(NULL, &nasxxxxxx, &addr, NULL, &actual_rsp[0],
+					sizeof(actual_rsp) - sizeof(struct dns_header), true);
+
+	zassert_true(actual_int > 0, "dns_sd_handle_ptr_query() failed (%d)", actual_int);
+
+	zassert_equal(actual_int, expected_int, "act: %d exp: %d", actual_int, expected_int);
+
+	zassert_mem_equal(actual_rsp, expected_rsp, MIN(actual_int, expected_int), "");
 }
 
 /** Test for @ref dns_sd_handle_ptr_query */

--- a/tests/net/lib/mdns_responder_probe/prj.conf
+++ b/tests/net/lib/mdns_responder_probe/prj.conf
@@ -12,11 +12,13 @@ CONFIG_TEST_RANDOM_GENERATOR=y
 
 CONFIG_MDNS_RESPONDER=y
 CONFIG_MDNS_RESPONDER_PROBE=y
+CONFIG_MDNS_RESPONDER_ANNOUNCE_DNS_SD=y
 CONFIG_NET_DHCPV4=y
 CONFIG_NET_HOSTNAME_ENABLE=y
 CONFIG_DNS_SD=y
 
-# send_probe()'s call depth exceeds the non-X86 default (1024 bytes) on real
+# send_probe()'s call depth plus MDNS_RESPONDER_ANNOUNCE_DNS_SD's extra
+# announce packet exceed the non-X86 default (1024 bytes) on real
 # stack-constrained targets (e.g. mps2/an385, qemu_cortex_a9) -- this was
 # invisible on native_sim, which uses the larger X86 default and runs on a
 # real host pthread stack underneath regardless of the Kconfig value.

--- a/tests/net/lib/mdns_responder_probe/src/main.c
+++ b/tests/net/lib/mdns_responder_probe/src/main.c
@@ -25,15 +25,41 @@ LOG_MODULE_REGISTER(mdns_resp_probe_test);
 
 #include "dns_pack.h"
 
+/* Why this is a separate test suite/directory instead of living in
+ * tests/net/lib/mdns_responder/:
+ *
+ * That suite's prj.conf does not enable CONFIG_MDNS_RESPONDER_PROBE, and its
+ * tests drive dns_read() directly against hand-built packets on a two-iface
+ * setup -- synchronous, with no real RFC 6762 probe/announce timing at all.
+ *
+ * This suite exists to exercise the real, timed probe -> init_listener ->
+ * announce sequence (CONFIG_MDNS_RESPONDER_PROBE), on a single iface, with
+ * outbound packets captured via the iface's .send callback instead of being
+ * fed synchronously to dns_read(). test_announce_includes_dns_sd_records()
+ * below needs that real sequence: it registers a DNS-SD record and then
+ * waits out PROBE_SEQUENCE_TIMEOUT for a real unsolicited announce to be
+ * sent, to confirm the announce includes the service's PTR/SRV/TXT records
+ * (RFC 6762 8.3), not just its address records.
+ *
+ * Folding this into tests/net/lib/mdns_responder/'s existing ZTEST_SUITE
+ * would mean bolting this single-iface, real-timing, packet-capture fixture
+ * onto that suite's incompatible two-iface, synchronous one in the same
+ * main.c, and adding a multi-second real sleep to any scenario that also
+ * builds today's fast unit tests unless they're kept in separate tests.yaml
+ * scenarios anyway -- at which point little is actually saved by sharing the
+ * directory.
+ */
+
 #define RESPONSE_TIMEOUT_MS 250
 #define RESPONSE_TIMEOUT    (K_MSEC(RESPONSE_TIMEOUT_MS))
 
 /* RFC 6762 8.1 PROBE_TIMEOUT is 1750ms, plus up to a 250ms random initial
  * delay (see mdns_addr_event_handler()'s probe_delay) before the probe even
- * starts, so the responder cannot become reachable before ~2s. Instead of
- * sleeping the full worst case unconditionally (which needlessly stretches
- * every CI run), poll for an actual response and stop as soon as the
- * responder answers, bounding the total wait at this worst-case cap.
+ * starts, so the responder cannot become reachable, and the announce cannot
+ * be sent, before ~2s. Instead of sleeping the full worst case
+ * unconditionally (which needlessly stretches every CI run), poll for the
+ * actual response/announce and stop as soon as it arrives, bounding the
+ * total wait at this worst-case cap.
  */
 #define PROBE_SEQUENCE_TIMEOUT_MS 4000
 #define PROBE_MAX_POLLS           (PROBE_SEQUENCE_TIMEOUT_MS / RESPONSE_TIMEOUT_MS)
@@ -148,6 +174,9 @@ static void *test_setup(void)
 	 * opens both the IPv4 and IPv6 listeners together in one call, so this
 	 * is a valid way to observe whether init_listener() ran at all,
 	 * regardless of which address family triggered the race being tested.
+	 * On its own it's also enough to drive a full, non-racing
+	 * probe -> init_listener -> announce cycle -- no need for IPv4/DHCP
+	 * involvement in the DNS-SD announce test.
 	 */
 	ifaddr = net_if_ipv6_addr_add(iface1, &ll_addr, NET_ADDR_MANUAL, 0);
 	zassert_not_null(ifaddr, "Failed to add LL-addr");
@@ -290,6 +319,102 @@ static bool responder_answers_query(void)
 	}
 
 	return false;
+}
+
+/* Peeks at a captured packet's first Answer record without any fatal
+ * assertions (unlike validate_label()/check_*_resp() elsewhere in this
+ * codebase) -- needed here because this test doesn't know in advance which of
+ * several captured announce packets (address-only vs. DNS-SD) it's looking
+ * at, and a non-matching one must not abort the test.
+ */
+static bool packet_has_ptr_answer(struct net_pkt *pkt, const char *service, const char *proto,
+				  const char *domain)
+{
+	const char *expect[3] = {service, proto, domain};
+	uint8_t label_len;
+	char buf[DNS_SD_INSTANCE_MAX_SIZE + 1];
+
+	net_pkt_cursor_init(pkt);
+	net_pkt_set_overwrite(pkt, true);
+
+	if (net_pkt_skip(pkt, NET_IPV6UDPH_LEN) || net_pkt_skip(pkt, sizeof(struct dns_header))) {
+		return false;
+	}
+
+	for (int i = 0; i < 3; i++) {
+		if (net_pkt_read_u8(pkt, &label_len) != 0 || label_len == 0 ||
+		    label_len != strlen(expect[i])) {
+			return false;
+		}
+		if (net_pkt_read(pkt, buf, label_len) != 0) {
+			return false;
+		}
+		buf[label_len] = '\0';
+		if (strcmp(buf, expect[i]) != 0) {
+			return false;
+		}
+	}
+
+	/* terminating root label */
+	if (net_pkt_read_u8(pkt, &label_len) != 0 || label_len != 0) {
+		return false;
+	}
+
+	return true;
+}
+
+/* Regression test for the RFC 6762 8.3 announce-completeness feature:
+ * send_announce() used to only ever announce address (A/AAAA) records on
+ * startup/re-announce, never a registered DNS-SD service's PTR/SRV/TXT
+ * records, even though RFC 6762 8.3 requires announcing *all* of a
+ * responder's newly registered records. This registers one external DNS-SD
+ * record, drives the responder through a normal (non-racing) bring-up, and
+ * checks that at least one of the announce packets sent to the mDNS group
+ * is a PTR answer for that service -- not just the address-only announce.
+ */
+ZTEST(test_mdns_responder_probe, test_announce_includes_dns_sd_records)
+{
+	static const uint16_t svc_port = sys_cpu_to_be16(5353);
+	static const char instance[] = "zephyr";
+	static const char service[] = "_zephyr";
+	static const char proto[] = "_tcp";
+	static const char domain[] = "local";
+	static const struct dns_sd_rec record = {
+		.instance = instance,
+		.service = service,
+		.proto = proto,
+		.domain = domain,
+		.text = DNS_SD_EMPTY_TXT,
+		.text_size = sizeof(dns_sd_empty_txt),
+		.port = &svc_port,
+	};
+	bool found_dns_sd_announce = false;
+
+	zassert_ok(mdns_responder_set_ext_records(&record, 1),
+		   "Failed to register the external DNS-SD record");
+
+	/* Poll for the announce instead of sleeping the full worst-case
+	 * probe window: this returns as soon as the DNS-SD PTR answer shows
+	 * up, while still bounding the wait at PROBE_SEQUENCE_TIMEOUT_MS.
+	 */
+	for (int poll = 0; poll < PROBE_MAX_POLLS && !found_dns_sd_announce; poll++) {
+		k_sleep(RESPONSE_TIMEOUT);
+
+		for (size_t i = 0; i < responses_count; i++) {
+			if (packet_has_ptr_answer(response_pkts[i], service, proto, domain)) {
+				found_dns_sd_announce = true;
+				break;
+			}
+		}
+	}
+
+	zassert_true(responses_count > 0, "No announce packets were sent at all");
+
+	zassert_true(found_dns_sd_announce,
+		     "None of the %zu announce packets included a PTR answer for the "
+		     "registered DNS-SD service -- RFC 6762 8.3 announce-completeness "
+		     "not honored",
+		     responses_count);
 }
 
 /* Regression test for the "DHCP-bound announce races ahead of the RFC 6762


### PR DESCRIPTION
## Summary

RFC 6762 Section 8.3 requires the startup announcement to contain all
of a responder's newly registered resource records, not just address
records -- but `send_announce()` only ever sent A/AAAA records, never a
registered DNS-SD service's PTR/SRV/TXT records.

Adds `send_dns_sd_announce()`, called from `send_announce()`'s
per-family loop when `CONFIG_MDNS_RESPONDER_ANNOUNCE_DNS_SD` is
enabled: sends one extra packet per DNS-SD service (registered via
`DNS_SD_REGISTER_SERVICE()` or `mdns_responder_set_ext_records()`)
alongside the existing address-only announce, reusing
`dns_sd_handle_ptr_query()` (already used for direct query responses).

Disabled by default to keep startup announcements smaller/less
frequent for devices that don't need it -- clients that actively query
for services (e.g. avahi-browse) are unaffected either way, since
normal query/response handling already answers DNS-SD queries
regardless of this option.

**Depends on #114096** (`net: mdns_responder: fix v4_svc/v6_svc
undersized for probe's resolver`), currently approved but not yet
merged. This PR's diff will include that commit until #114096 merges
to `main`, at which point GitHub will recompute the diff down to just
this PR's own commit. `CONFIG_MDNS_RESPONDER_PROBE` fails independently
of this feature without #114096's fix (probing itself can't
complete), which would make this PR's test fail for an unrelated
reason if applied alone.

## Test plan

- `tests/net/lib/mdns_responder_probe/`: `test_announce_includes_dns_sd_records`
  registers one external DNS-SD record, drives the responder through a
  normal (non-racing) bring-up, and confirms at least one of the
  resulting announce packets is a PTR answer for that service.
- Verified as a genuine regression test: reverting the two
  `send_dns_sd_announce()` call sites reproduces the exact "no announce
  packet included a PTR answer" failure.
- `twister -p native_sim/native/64 -T tests/net/lib/mdns_responder_probe`:
  1/1 passing.

Assisted-by: Claude:claude-sonnet-5
