### PR TITLE
add onboard SPI Flash samples and tests for the nrf7120dk

### DIFF
--- a/samples/drivers/spi_flash/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/samples/drivers/spi_flash/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi00 {
+	status = "okay";
+
+	mx25u25645g_spi: flash@0 {
+		compatible = "jedec,spi-nor";
+		status = "okay";
+		reg = <0>;
+		jedec-id = [c2 25 39];
+		sfdp-bfp = [e5 20 fb ff ff ff ff 0f 44 eb 08 6b 08 3b 04 bb
+			    fe ff ff ff ff ff 00 ff ff ff 44 eb 0c 20 0f 52
+			    10 d8 00 ff 87 49 b5 00 82 d2 04 d2 44 03 67 38
+			    30 b0 30 b0 f7 bd d5 5c 4a 9e 29 ff f0 50 f9 85];
+		sfdp-ff84 = [7f 8f ff ff 21 5c dc ff];
+		size = <268435456>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <30000>;
+		reset-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		t-reset-recovery = <35000>;
+		spi-max-frequency = <DT_FREQ_M(66)>;
+	};
+};

--- a/tests/drivers/flash/interface_test/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/flash/interface_test/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mspi00 {
+	status = "okay";
+};
+
+&mx25u25645g {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		slot1_partition: partition@0 {
+			label = "image-1";
+			reg = <0x0 DT_SIZE_K(680)>;
+		};
+	};
+};
+
+&cpuapp_mram {
+	partitions {
+		/delete-node/ partition@178000;
+	};
+};

--- a/tests/drivers/flash/interface_test/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/flash/interface_test/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mspi00 {
+	status = "okay";
+};
+
+/delete-node/ &slot1_partition;
+
+&mx25u25645g {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		slot1_partition: partition@0 {
+			label = "image-1";
+			reg = <0x0 DT_SIZE_K(680)>;
+		};
+	};
+};


### PR DESCRIPTION
This PR adds support for the nrf7120dk's onboard NOR flash for samples/drivers/spi_flash and tests/drivers/flash/interface_test. 