### PR TITLE
Infineon PSE84: low power mode support

### DIFF
--- a/dts/arm/infineon/edge/pse84/pse84.cm33.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.cm33.dtsi
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,7 +17,7 @@
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			clock-frequency = <200000000>;
-			cpu-power-states = <&sleep &deepsleep>;
+			cpu-power-states = <&sleep &deepsleep &deepsleep_ram>;
 		};
 	};
 
@@ -33,6 +33,25 @@
 			power-state-name = "suspend-to-idle";
 			min-residency-us = <100>;
 			exit-latency-us = <20>;
+		};
+
+		/*
+		 * DeepSleep-RAM is disabled by default so a plain application only
+		 * sees runtime-idle and regular DeepSleep. Enabling this node
+		 * turns on CONFIG_PM_S2RAM.
+		 */
+		deepsleep_ram: deepsleep_ram {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			min-residency-us = <1000000>;
+			/*
+			 * Warm boot resumes through the MCUboot chainload and a full
+			 * Zephyr re-init, so the exit latency is dominated by that
+			 * cold-boot path (measured ~381 ms; rounded up for margin)
+			 * rather than the raw hardware wake time.
+			 */
+			exit-latency-us = <400000>;
+			status = "disabled";
 		};
 
 		deepsleep_off: deepsleep_off {

--- a/dts/arm/infineon/edge/pse84/pse84.cm33.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.cm33.dtsi
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,7 +17,7 @@
 			compatible = "arm,cortex-m33";
 			reg = <0>;
 			clock-frequency = <200000000>;
-			cpu-power-states = <&sleep &deepsleep>;
+			cpu-power-states = <&sleep &deepsleep &deepsleep_ram>;
 		};
 	};
 
@@ -33,6 +33,25 @@
 			power-state-name = "suspend-to-idle";
 			min-residency-us = <100>;
 			exit-latency-us = <20>;
+		};
+
+		/*
+		 * DeepSleep-RAM is disabled by default so a plain application only
+		 * sees runtime-idle and regular DeepSleep. Enabling this node
+		 * turns on CONFIG_PM_S2RAM.
+		 */
+		deepsleep_ram: deepsleep_ram {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			min-residency-us = <1000000>;
+			/*
+			 * The DS-RAM wake is a full reset that resumes through the
+			 * MCUboot chainload, TF-M secure init and a complete Zephyr
+			 * re-init, so the exit latency is dominated by that cold-boot
+			 * path rather than the raw hardware wake time.
+			 */
+			exit-latency-us = <460000>;
+			status = "disabled";
 		};
 
 		deepsleep_off: deepsleep_off {

--- a/dts/arm/infineon/edge/pse84/pse84.cm55.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.cm55.dtsi
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,7 +17,7 @@
 			compatible = "arm,cortex-m55";
 			reg = <1>;
 			clock-frequency = <400000000>;
-			cpu-power-states = <&sleep &deepsleep>;
+			cpu-power-states = <&sleep &deepsleep &deepsleep_ram>;
 		};
 	};
 
@@ -33,6 +33,25 @@
 			power-state-name = "suspend-to-idle";
 			min-residency-us = <100>;
 			exit-latency-us = <20>;
+		};
+
+		/*
+		 * DeepSleep-RAM is disabled by default so a plain application only
+		 * sees runtime-idle and regular DeepSleep. Enabling this node
+		 * turns on CONFIG_PM_S2RAM.
+		 */
+		deepsleep_ram: deepsleep_ram {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			min-residency-us = <1000000>;
+			/*
+			 * Warm boot resumes through the MCUboot chainload and a full
+			 * Zephyr re-init, so the exit latency is dominated by that
+			 * cold-boot path (measured ~381 ms; rounded up for margin)
+			 * rather than the raw hardware wake time.
+			 */
+			exit-latency-us = <400000>;
+			status = "disabled";
 		};
 
 		deepsleep_off: deepsleep_off {

--- a/dts/arm/infineon/edge/pse84/pse84.cm55.dtsi
+++ b/dts/arm/infineon/edge/pse84/pse84.cm55.dtsi
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,7 +17,7 @@
 			compatible = "arm,cortex-m55";
 			reg = <1>;
 			clock-frequency = <400000000>;
-			cpu-power-states = <&sleep &deepsleep>;
+			cpu-power-states = <&sleep &deepsleep &deepsleep_ram>;
 		};
 	};
 
@@ -33,6 +33,25 @@
 			power-state-name = "suspend-to-idle";
 			min-residency-us = <100>;
 			exit-latency-us = <20>;
+		};
+
+		/*
+		 * DeepSleep-RAM is disabled by default so a plain application only
+		 * sees runtime-idle and regular DeepSleep. Enabling this node
+		 * turns on CONFIG_PM_S2RAM.
+		 */
+		deepsleep_ram: deepsleep_ram {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-ram";
+			min-residency-us = <1000000>;
+			/*
+			 * The DS-RAM wake is a full reset that resumes through the
+			 * MCUboot chainload, TF-M secure init and a complete Zephyr
+			 * re-init, so the exit latency is dominated by that cold-boot
+			 * path rather than the raw hardware wake time.
+			 */
+			exit-latency-us = <460000>;
+			status = "disabled";
 		};
 
 		deepsleep_off: deepsleep_off {

--- a/dts/bindings/power/infineon,hibernate-wakeup.yaml
+++ b/dts/bindings/power/infineon,hibernate-wakeup.yaml
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Infineon hibernate / hibernate-RAM wakeup source configuration.
+
+  Infineon SoCs provide a set of dedicated hardware sources that can wake the
+  device from the hibernate (and, where supported, hibernate-RAM) power modes.
+  The set of available sources and the pin-to-pad mapping are fixed in silicon
+  and differ per device; consult the SoC datasheet or the SoC devicetree for
+  the mapping.  A device implements only a subset of the properties below
+  - set only the ones the target SoC supports.
+
+  Typical availability:
+    PIN0, PIN1, LPCOMP0, LPCOMP1, WDT, RTC alarm
+
+  Each pin and LPCOMP source can be independently enabled and configured to wake
+  on a high or low logic level.
+
+  Example (wake on the first dedicated pin, active low):
+
+    hibernate_wakeup: hibernate-wakeup {
+        compatible = "infineon,hibernate-wakeup";
+        wakeup-pin0-trigger = "low";
+    };
+
+compatible: "infineon,hibernate-wakeup"
+
+properties:
+  wakeup-pin0-trigger:
+    type: string
+    enum:
+      - "low"
+      - "high"
+    description: |
+      Enable dedicated wake PIN0 as a hibernate wakeup source.  The physical pad
+      is device-specific (see the SoC devicetree/datasheet).  Set to "low" to
+      wake on a low logic level, "high" for a high level.  Omit to disable PIN0.
+
+  wakeup-pin1-trigger:
+    type: string
+    enum:
+      - "low"
+      - "high"
+    description: |
+      Enable dedicated wake PIN1 as a hibernate wakeup source.  The physical pad
+      is device-specific (see the SoC devicetree/datasheet).  Set to "low" to
+      wake on a low logic level, "high" for a high level.  Omit to disable PIN1.
+
+  wakeup-pin2-trigger:
+    type: string
+    enum:
+      - "low"
+      - "high"
+    description: |
+      Enable dedicated wake PIN2 as a hibernate wakeup source (device-specific;
+      for example PSB3).  The physical pad is device-specific.  Set to "low" to
+      wake on a low logic level, "high" for a high level.  Omit to disable PIN2.
+
+  wakeup-pin3-trigger:
+    type: string
+    enum:
+      - "low"
+      - "high"
+    description: |
+      Enable dedicated wake PIN3 as a hibernate wakeup source (device-specific;
+      for example PSB3).  The physical pad is device-specific.  Set to "low" to
+      wake on a low logic level, "high" for a high level.  Omit to disable PIN3.
+
+  wakeup-lpcomp0-trigger:
+    type: string
+    enum:
+      - "low"
+      - "high"
+    description: |
+      Enable low-power comparator 0 (LPCOMP0) as a hibernate wakeup source.
+      Set to "low" to wake on a low output level, "high" for a high level.
+      Omit to disable LPCOMP0.
+
+  wakeup-lpcomp1-trigger:
+    type: string
+    enum:
+      - "low"
+      - "high"
+    description: |
+      Enable low-power comparator 1 (LPCOMP1) as a hibernate wakeup source.
+      Set to "low" to wake on a low output level, "high" for a high level.
+      Omit to disable LPCOMP1.
+
+  wakeup-wdt:
+    type: boolean
+    description: |
+      Enable the watchdog timer as a hibernate wakeup source.  Use on
+      single-watchdog devices.
+
+  wakeup-wdt0:
+    type: boolean
+    description: |
+      Enable WDT0 as a hibernate wakeup source.  Use on dual-watchdog devices.
+
+  wakeup-wdt1:
+    type: boolean
+    description: |
+      Enable WDT1 as a hibernate wakeup source.  Use on dual-watchdog devices.
+
+  wakeup-rtc-alarm:
+    type: boolean
+    description: Enable RTC alarm as a hibernate wakeup source.

--- a/soc/infineon/edge/pse84/CMakeLists.txt
+++ b/soc/infineon/edge/pse84/CMakeLists.txt
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
-# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -68,6 +68,24 @@ if(NOT CONFIG_TRUSTED_EXECUTION_NONSECURE)
 endif()
 zephyr_sources_ifdef(CONFIG_SOC_PSE84_LPM_TIMER lpm_timer.c)
 zephyr_sources_ifdef(CONFIG_POWEROFF poweroff.c)
+
+# mtb_hal_syspm_lock_deepsleep()/unlock_deepsleep() are the vendor HAL's
+# "keep the core out of DeepSleep for now" guard: MTB HAL and SRF operations
+# that must not be interrupted by a low-power transition bracket themselves with
+# these calls (the CM55 SRF/IPC relay's blocking completion wait is one such
+# caller, but not the only one).  On their own they only touch an MTB-internal
+# counter that the Zephyr pm_state_set() never consults, so on Zephyr they do
+# nothing to keep the core awake: the idle thread can still CPU-gate the core
+# (SUSPEND_TO_IDLE / SUSPEND_TO_RAM) mid-operation and drop the pending
+# completion.  Wrap both symbols so power.c can also take/release a Zephyr
+# PM-policy lock around every such section - for every caller, not just the SRF
+# client - without editing the vendor module.
+if(CONFIG_PM)
+  zephyr_link_libraries(
+    -Wl,--wrap=mtb_hal_syspm_lock_deepsleep
+    -Wl,--wrap=mtb_hal_syspm_unlock_deepsleep
+  )
+endif()
 
 zephyr_include_directories(.)
 

--- a/soc/infineon/edge/pse84/Kconfig
+++ b/soc/infineon/edge/pse84/Kconfig
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
-# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -16,6 +16,7 @@ config SOC_SERIES_PSE84
 	select PM_STATE_SET_IRQ_UNLOCKED
 	select HAS_POWEROFF
 	select CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
+	select HAS_PM_S2RAM_CUSTOM_MARKING if PM_S2RAM
 
 config SOC_SERIES_PSE84_M33
 	select CPU_CORTEX_M33

--- a/soc/infineon/edge/pse84/Kconfig
+++ b/soc/infineon/edge/pse84/Kconfig
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
-# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -16,6 +16,8 @@ config SOC_SERIES_PSE84
 	select PM_STATE_SET_IRQ_UNLOCKED
 	select HAS_POWEROFF
 	select CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
+	select HAS_PM_S2RAM_CUSTOM_MARKING if PM_S2RAM
+	select PM_DEVICE if PM_S2RAM
 
 config SOC_SERIES_PSE84_M33
 	select CPU_CORTEX_M33

--- a/soc/infineon/edge/pse84/Kconfig.defconfig
+++ b/soc/infineon/edge/pse84/Kconfig.defconfig
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
-# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -26,6 +26,18 @@ endchoice
 # the companion timer is the sole time reference across the sleep.
 config SYSTEM_TIMER_RESET_BY_LPM
 	default y if PM_S2RAM
+
+# The MCWDT counter runs at full PILO (32768 Hz); the kernel tick rate is
+# PILO/4 (8192 Hz), so one system tick is ~122 us.
+# subsys/pm arms the companion (via sys_clock_set_timeout(..., idle=true)) only
+# when a power state's exit-latency-us converts to a non-zero tick count. With
+# the default nearest/floor rounding a sub-tick exit latency (e.g. the 20 us of
+# the suspend-to-idle state) rounds to 0 ticks, so the companion is never armed
+# and the core never wakes from DeepSleep. Round up so any non-zero exit latency
+# yields at least one tick and the companion is always armed.
+choice PM_PREWAKEUP_CONV_MODE
+	default PM_PREWAKEUP_CONV_MODE_CEIL if SYSTEM_TIMER_LPM_COMPANION_HOOKS
+endchoice
 
 choice NULL_POINTER_EXCEPTION_DETECTION
 	default NULL_POINTER_EXCEPTION_DETECTION_NONE

--- a/soc/infineon/edge/pse84/power.c
+++ b/soc/infineon/edge/pse84/power.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,50 +11,573 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/barrier.h>
 #include <zephyr/pm/pm.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/platform/hooks.h>
+#include <zephyr/sys/poweroff.h>
 #include <zephyr/logging/log.h>
 
 #include <cy_syspm.h>
+#include <cy_syspm_pdcm.h>
+#include <cy_syspm_ppu.h>
+#include <cy_sysclk.h>
+#include <cy_syslib.h>
+#include <system_edge.h>
 
 #include <soc.h>
+#include <power.h>
+
+/*
+ * Warm-boot peripheral re-init is compiled only when DeepSleep-RAM can
+ * power-cycle the peripheral domain (CONFIG_PM_S2RAM) and the PM device model is
+ * present to carry each peripheral's TURN_ON rebuild (CONFIG_PM_DEVICE).
+ */
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+#define IFX_PM_WARM_BOOT 1
+#endif
+
+#if defined(CONFIG_PM_S2RAM)
+#include <zephyr/arch/common/pm_s2ram.h>
+#include <zephyr/arch/common/init.h>
+#include <zephyr/arch/arm/cortex_m/fpu.h>
+#include <zephyr/arch/arm/cortex_m/scb.h>
+#include <zephyr/arch/arm/mpu/arm_mpu.h>
+#include <kernel_arch_func.h>
+#endif
 
 LOG_MODULE_REGISTER(soc_power, CONFIG_SOC_LOG_LEVEL);
 
+#if defined(CONFIG_PM)
 /*
- * Called from pm_system_suspend(int32_t ticks) in subsys/power.c
- * For deep sleep pm_system_suspend has executed all the driver
- * power management call backs.
+ * Zephyr PM-policy bridge for the MTB deepsleep lock (see the --wrap flags in
+ * this SoC's CMakeLists.txt).
+ *
+ * mtb_hal_syspm_lock_deepsleep()/unlock_deepsleep() are the vendor HAL's "keep
+ * the core out of DeepSleep for now" guard: MTB HAL and SRF operations that must
+ * not be interrupted by a low-power transition bracket themselves with these
+ * calls.  The CM55 SRF/IPC relay's blocking completion wait
+ * (mtb_srf_ipc_request_send()) is the most prominent caller, but it is not the
+ * only one - any library that uses the vendor deepsleep lock relies on the same
+ * behavior.  On their own, though, they only increment/decrement an MTB-internal
+ * counter that is consulted solely by the MTB HAL's own deepsleep entry, a path
+ * the Zephyr pm_state_set() never takes, so on Zephyr they do nothing to
+ * actually keep the core awake.  While such a section is in progress and the
+ * calling thread blocks with no other thread ready, the idle thread can let the
+ * PM policy enter a CPU-gating state (SUSPEND_TO_IDLE / SUSPEND_TO_RAM), which
+ * gates the core and drops the pending completion so the operation never
+ * finishes.
+ *
+ * The linker redirects both symbols here via --wrap: __real_* runs the original
+ * vendor bookkeeping, and around it we take/release a Zephyr PM-policy lock so
+ * only shallow runtime-idle (WFI, interrupts live) stays available for the
+ * duration of the guarded section.  This protects every caller of the vendor
+ * deepsleep lock platform-wide, not just the SRF client, without editing the
+ * vendor module or touching each call site.  The get/put calls are
+ * reference-counted, so nested sections balance correctly.
  */
+void __real_mtb_hal_syspm_lock_deepsleep(void);
+void __real_mtb_hal_syspm_unlock_deepsleep(void);
+
+void __wrap_mtb_hal_syspm_lock_deepsleep(void)
+{
+	__real_mtb_hal_syspm_lock_deepsleep();
+	ifx_pm_deepsleep_lock();
+}
+
+void __wrap_mtb_hal_syspm_unlock_deepsleep(void)
+{
+	ifx_pm_deepsleep_unlock();
+	__real_mtb_hal_syspm_unlock_deepsleep();
+}
+#endif /* CONFIG_PM */
+
+#if defined(CONFIG_PM_S2RAM)
+
+#if defined(IFX_PM_WARM_BOOT)
+/*
+ * Armed by ifx_pm_s2ram_enter() when the Zephyr S2RAM marker
+ * (pm_s2ram_mark_check_and_clear()) confirms a genuine DeepSleep-RAM warm boot,
+ * i.e. arch_pm_s2ram_suspend() returned 0 because the CPU was power-cycled and
+ * resumed through the reset handler.  A failed DS-RAM entry (which never powered
+ * the domain down) leaves it clear, so no spurious peripheral re-init occurs.
+ *
+ * Consumed exactly once per warm boot by an atomic compare-and-set: on non-SRF
+ * builds by pm_state_exit_post_ops() (which then rebuilds eagerly), on SRF
+ * builds by ifx_pm_warm_boot_reinit_all() (which re-establishes the SRF client
+ * before the device walk).  The CAS provides that once-only guarantee without a
+ * mutex or generation counter.
+ */
+static atomic_t ifx_pm_s2ram_warm_boot;
+#endif /* IFX_PM_WARM_BOOT */
+
+/*
+ * Custom S2RAM marker (CONFIG_HAS_PM_S2RAM_CUSTOM_MARKING).
+ *
+ * Warm resume IS supported.  The marker, the saved CPU context (_cpu_context)
+ * and the suspend stack all live in the CM55 "RAM" output region, which the
+ * linker places at 0x26100000 (SOCMEM-backed system RAM) -- NOT in the CM55
+ * tightly-coupled memories.  Only ITCM (0x00000000) and DTCM (0x20000000) are
+ * powered down with the CPU subsystem during DeepSleep-RAM; the SOCMEM RAM is
+ * retained because pm_state_set() programs the SOCMEM DeepSleep mode to
+ * CY_SYSPM_MODE_DEEPSLEEP_RAM before entry.  So everything the reset handler
+ * needs to warm-resume survives the DS-RAM power cycle.
+ *
+ * arch_pm_s2ram_suspend() saves _cpu_context and pushes the callee-saved GPRs
+ * onto the (retained) stack, calls pm_s2ram_mark_set() to arm the marker, then
+ * enters DS-RAM.  The DS-RAM wake is a full reset: the CM55 reset handler runs
+ * arch_pm_s2ram_resume() -> pm_s2ram_mark_check_and_clear() very early (before
+ * .bss is zeroed), and when the marker is found set it restores _cpu_context,
+ * pops the GPRs and returns into ifx_pm_s2ram_enter() with rc == 0, resuming at
+ * the WFI call site instead of re-running kernel init and main().
+ *
+ * The marker is self-clearing: pm_s2ram_mark_check_and_clear() clears it on
+ * every boot, so a genuine cold boot (marker naturally 0 in zeroed/retained
+ * RAM after a power cycle, or cleared by the previous resume) falls through to
+ * normal init.  A hardware warm-boot witness readable this early from CM55-NS
+ * does not exist (SRSS reset-cause is PPC-secured under TF-M and SRF/IPC is not
+ * up in the reset handler); if a more robust discriminator than the retained
+ * marker is required, the secure core can read Cy_SysPm_GetBootMode() and hand
+ * the result to CM55-NS, which validates/clears the marker once the kernel and
+ * IPC are up.
+ */
+#define IFX_S2RAM_MARKER_MAGIC 0xDABBAD00U
+
+static __noinit uint32_t ifx_s2ram_marker;
+
+void pm_s2ram_mark_set(void)
+{
+	/*
+	 * Arm the warm-boot marker just before DS-RAM entry.  It lives in the
+	 * retained SOCMEM RAM region (see the note above), so it survives the
+	 * DS-RAM power cycle and is visible to arch_pm_s2ram_resume() in the
+	 * reset handler.
+	 */
+	ifx_s2ram_marker = IFX_S2RAM_MARKER_MAGIC;
+}
+
+bool pm_s2ram_mark_check_and_clear(void)
+{
+	/*
+	 * Called from arch_pm_s2ram_resume() in the reset handler, before .bss
+	 * is zeroed.  If the marker is set this is a DS-RAM warm boot: report it
+	 * so the caller restores _cpu_context and returns to the suspend point.
+	 * The marker is always cleared (self-clearing) so a later genuine cold
+	 * boot is not mistaken for a warm boot.
+	 */
+	bool was_suspended = (ifx_s2ram_marker == IFX_S2RAM_MARKER_MAGIC);
+
+	/* Data cache is disabled this early after reset, so this write reaches
+	 * retained SOCMEM RAM directly; drain the write buffer to be certain the
+	 * cleared marker survives even if a later step faults.
+	 */
+	ifx_s2ram_marker = 0U;
+	__DSB();
+
+	return was_suspended;
+}
+
+#define NVIC_ISER_COUNT DIV_ROUND_UP(CONFIG_NUM_IRQS, 32)
+#define NVIC_IPR_COUNT  CONFIG_NUM_IRQS
+
+struct nvic_context {
+	uint32_t iser[NVIC_ISER_COUNT];
+	uint8_t ipr[NVIC_IPR_COUNT];
+};
+
+static struct fpu_ctx_full fpu_state;
+static struct scb_context scb_state;
+#if defined(CONFIG_ARM_MPU)
+static struct z_mpu_context_retained mpu_state;
+#endif
+static struct nvic_context nvic_state;
+
+static void s2ram_save_nvic_context(struct nvic_context *ctx)
+{
+	for (uint32_t i = 0; i < NVIC_ISER_COUNT; i++) {
+		ctx->iser[i] = NVIC->ISER[i];
+	}
+	for (uint32_t i = 0; i < NVIC_IPR_COUNT; i++) {
+		ctx->ipr[i] = NVIC->IPR[i];
+	}
+}
+
+static void s2ram_restore_nvic_context(const struct nvic_context *ctx)
+{
+	for (uint32_t i = 0; i < NVIC_ISER_COUNT; i++) {
+		NVIC->ISER[i] = ctx->iser[i];
+	}
+	for (uint32_t i = 0; i < NVIC_IPR_COUNT; i++) {
+		NVIC->IPR[i] = ctx->ipr[i];
+	}
+}
+
+/**
+ * @brief Low-power mode entry for ds-ram and ds-off.
+ *
+ * Called by arch_pm_s2ram_suspend() after CPU context has been saved.
+ * Cleans the D-cache so the retained warm-boot state is coherent with
+ * SOCMEM, then enters DeepSleep-RAM/OFF via Cy_SysPm_CpuEnterDeepSleep(),
+ * which sets SLEEPDEEP, brackets the FPU, and executes WFI internally.
+ *
+ * @return Does not return on a successful warm boot (resumes through the
+ *         reset handler); returns -EAGAIN if the CPU wakes without a power
+ *         cycle.
+ */
+static int enter_deepsleep(void)
+{
+	/*
+	 * The warm-boot state that arch_pm_s2ram_resume() reads back in the
+	 * reset handler -- the S2RAM marker (ifx_s2ram_marker), the saved CPU
+	 * context (_cpu_context) and the callee-saved GPRs pushed onto the
+	 * suspend stack -- all live in the retained SOCMEM RAM region but were
+	 * written through the CM55 write-back D-cache by arch_pm_s2ram_suspend()
+	 * and pm_s2ram_mark_set().  DeepSleep-RAM powers the CPU subsystem (and
+	 * therefore the L1 D-cache) down, so any line still dirty in the cache
+	 * is lost and never reaches physical SOCMEM.  On warm boot the marker
+	 * check would then read a stale value, miss the warm boot and cold-boot
+	 * instead.  A bare __DSB() is not enough: it orders accesses but does
+	 * not evict dirty write-back lines.  Clean (write back) the D-cache so
+	 * the retained copies are coherent with SOCMEM before entry.
+	 */
+#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+	SCB_CleanDCache();
+#endif
+	__DSB();
+	__ISB();
+
+	Cy_SysPm_CpuEnterDeepSleep(CY_SYSPM_WAIT_FOR_INTERRUPT);
+	SCB_SCR &= (uint32_t)~SCB_SCR_SLEEPDEEP_Msk;
+
+	return -EAGAIN;
+}
+
+/**
+ * @brief Restore system state after DS-RAM warm boot.
+ *
+ * DS-RAM retains all SRAM/SOCMEM, so the C runtime, kernel state, the
+ * SystemCoreClock value and the SRF/IPC client context all survive, and the
+ * CM33 companion re-establishes the clock tree before it re-enables this core.
+ * The only state physically lost is the CM55 tightly-coupled memory (ITCM,
+ * powered down with the CPU subsystem) and the L1 caches.  Both are restored
+ * here with purely local operations.
+ *
+ * Crucially this runs on the resumed CPU context, i.e. with PRIMASK = 1 (the
+ * interrupt-masked state that was saved at suspend), so it must NOT call any
+ * routine that relays to the secure core over SRF/IPC.  In particular
+ * soc_early_init_hook() and SystemCoreClockUpdate() are deliberately NOT called
+ * here: SystemCoreClockUpdate() -> Cy_SysClk_ClkHfGetFrequency() is a
+ * PPC-secured SRF relay whose blocking IPC semaphore wait cannot complete with
+ * interrupts masked and faults (observed as a HardFault in
+ * Cy_SysClk_ClkHfGetFrequency).  Neither is needed anyway because RAM (and thus
+ * SystemCoreClock) is retained and the clock tree is already live.
+ *
+ * CM33 does not use ITCM — its ramfunc sections reside in retained SRAM and
+ * survive DS-RAM.  When CM33 S2RAM support is added, only the cache
+ * re-initialization portion is needed.
+ */
+#if defined(CONFIG_CPU_CORTEX_M55) && defined(CONFIG_CODE_DATA_RELOCATION)
+extern void data_copy_xip_relocation(void);
+extern void bss_zeroing_relocation(void);
+#endif /* CONFIG_CPU_CORTEX_M55 && CONFIG_CODE_DATA_RELOCATION */
+
+static void s2ram_restore_system(void)
+{
+#if defined(CONFIG_CPU_CORTEX_M55)
+	/*
+	 * Restore the CM55 memory that the DS-RAM power cycle loses. Only the
+	 * CPU-local tightly-coupled memory is affected; SOCMEM-backed SRAM is
+	 * retained, so nothing placed there needs rebuilding here.
+	 *
+	 * data_copy_xip_relocation()/bss_zeroing_relocation() rebuild every
+	 * section declared via zephyr_code_relocate() (CONFIG_CODE_DATA_RELOCATION),
+	 * not just TCM ones. On this SoC relocation is used only to place
+	 * code/rodata in ITCM, which is lost, so re-running them is correct. An
+	 * application that instead relocates data or BSS into retained SRAM would
+	 * have that state wiped here and must not do so on a DS-RAM build.
+	 */
+	extern char __itcm_start[];
+	extern char __itcm_load_start[];
+	extern char __itcm_size[];
+
+#if defined(CONFIG_CODE_DATA_RELOCATION)
+	data_copy_xip_relocation();
+	bss_zeroing_relocation();
+#endif /* CONFIG_CODE_DATA_RELOCATION */
+	arch_early_memcpy(&__itcm_start, &__itcm_load_start, (size_t)&__itcm_size);
+#endif /* CONFIG_CPU_CORTEX_M55 */
+
+	/* Re-enable the L1 caches, which are invalidated by the DS-RAM power
+	 * cycle.  These are local CPU (CMSIS) operations with no secure relay,
+	 * so they are safe on this interrupt-masked resume path.
+	 * z_arm_restore_scb_context() later restores CCR/cache enables from the
+	 * saved SCB context.
+	 */
+#if defined(__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+	SCB_InvalidateICache();
+#endif
+#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+	SCB_InvalidateDCache();
+#endif
+}
+
+/**
+ * @brief Enter suspend-to-RAM (DeepSleep-RAM) state.
+ *
+ * Saves FPU, SCB, MPU, and NVIC context, then calls arch_pm_s2ram_suspend
+ * which saves CPU registers and invokes enter_deepsleep().  On warm boot
+ * the reset handler restores CPU context and returns here with rc == 0.
+ *
+ * Resume ordering is critical:
+ *   1. CPACR — enables FPU/MVE coprocessors so compiler-generated
+ *      vector instructions in subsequent C code do not fault (NOCP).
+ *   2. System restore — ITCM re-copy, clock tree, caches.
+ *   3. Clear bus faults — peripheral re-init may have generated
+ *      benign imprecise bus faults; clear them while BUSFAULTENA
+ *      is still at its reset default (disabled).
+ *   4. Full SCB restore.
+ *   5. MPU, FP, NVIC restore.
+ */
+void ifx_pm_s2ram_enter(void)
+{
+	int rc;
+
+	z_arm_save_fp_context(&fpu_state);
+	z_arm_save_scb_context(&scb_state);
+#if defined(CONFIG_ARM_MPU)
+	z_arm_save_mpu_context(&mpu_state);
+#endif
+	s2ram_save_nvic_context(&nvic_state);
+
+	rc = arch_pm_s2ram_suspend(enter_deepsleep);
+
+	if (rc == 0) {
+#if defined(IFX_PM_WARM_BOOT)
+		/* Marker-confirmed warm boot: the peripheral domain was
+		 * power-cycled.  Arm the flag so the peripheral rebuild runs once,
+		 * either eagerly in pm_state_exit_post_ops() (non-SRF) or from
+		 * ifx_pm_warm_boot_reinit_all() (SRF).
+		 */
+		atomic_set(&ifx_pm_s2ram_warm_boot, 1);
+#endif /* IFX_PM_WARM_BOOT */
+
+		/* Step 1: enable FPU/MVE coprocessors (CPACR defaults to 0
+		 * after DS-RAM reset).  Full SCB restore is deferred — its
+		 * BUSFAULTENA would escalate pending bus faults from step 2.
+		 */
+#if defined(CPACR_PRESENT)
+		SCB->CPACR = scb_state.cpacr;
+		__DSB();
+		__ISB();
+#endif
+		/* Step 2: re-init ITCM, clocks, caches */
+		s2ram_restore_system();
+
+		/* Steps 3: restore remaining core context */
+		z_arm_restore_scb_context(&scb_state);
+#if defined(CONFIG_ARM_MPU)
+		z_arm_restore_mpu_context(&mpu_state);
+#endif
+		z_arm_restore_fp_context(&fpu_state);
+		s2ram_restore_nvic_context(&nvic_state);
+		__DSB();
+		__ISB();
+	}
+
+	if (rc != 0) {
+		LOG_WRN("S2RAM entry failed: rc=%d ICSR=0x%08x", rc, (uint32_t)SCB->ICSR);
+	}
+}
+#endif /* CONFIG_PM_S2RAM */
+
+#if defined(IFX_PM_WARM_BOOT)
+/*
+ * DeepSleep-RAM warm-boot peripheral re-init: walk every device in link
+ * (initialization) order and invoke its PM_DEVICE_ACTION_TURN_ON handler,
+ * rebuilding all peripherals in a single up-front pass.
+ *
+ * DS-RAM power-cycles the peripheral domain, so after a warm boot every
+ * peripheral has lost its hardware state and must be rebuilt from scratch: a
+ * power-loss OFF->SUSPENDED transition, expressed by PM_DEVICE_ACTION_TURN_ON
+ * (not RESUME, which is for a retained low-power state where the hardware kept
+ * its config).  Devices are walked in link order, so each is rebuilt only after
+ * the parents it was initialized after; a device with no TURN_ON handler returns
+ * -ENOTSUP and is skipped.
+ *
+ * Public so an application can force a full peripheral restore after a warm boot
+ * from its own thread context.  On builds without the SRF relay this is also the
+ * automatic path: pm_state_exit_post_ops() calls it while the scheduler is still
+ * locked, because a driver's TURN_ON rebuild is then pure local MMIO (pinctrl,
+ * IP init, clock divider, NVIC) and never blocks.
+ *
+ * On SRF builds each TURN_ON handler instead relays PPC-secured clock/PDL
+ * operations to the secure core over blocking IPC, so it must run in thread
+ * context and the application must call it itself (pm_state_exit_post_ops()
+ * cannot, being scheduler-locked with interrupts only just re-enabled).  Two
+ * extra steps then bracket the walk:
+ *
+ *   - The SRF/IPC client is re-established first.  The CM33 secure image
+ *     cold-booted and republished the IPC/SRF endpoint during the warm boot, so
+ *     the stale pre-sleep handle would fault on the first secure request.  The
+ *     ifx_pm_s2ram_warm_boot flag, armed once per warm boot, is consumed by an
+ *     atomic compare-and-set so the re-establish runs exactly once even if the
+ *     application calls this more than once.  (The base clock tree is restored
+ *     by the CM33 companion and the CM55 system clock republished by this client
+ *     bring-up; each driver re-programs its own peripheral clock from its
+ *     TURN_ON handler, so no separate clock step is needed here.)
+ *
+ *   - The whole sequence runs under a Zephyr PM-policy lock so the idle thread
+ *     cannot CPU-gate the core mid-handshake (the SRF client's blocking IPC
+ *     give/take uses an infinite timeout and is not bracketed by the vendor
+ *     deepsleep lock); only shallow runtime-idle stays available meanwhile.
+ */
+void ifx_pm_warm_boot_reinit_all(void)
+{
+#if defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+	ifx_pm_deepsleep_lock();
+
+	if (atomic_cas(&ifx_pm_s2ram_warm_boot, 1, 0)) {
+		ifx_soc_srf_client_reinit();
+	}
+#endif
+	STRUCT_SECTION_FOREACH(device, dev) {
+		struct pm_device_base *pm = dev->pm_base;
+
+		if ((pm != NULL) && (pm->action_cb != NULL)) {
+			(void)pm->action_cb(dev, PM_DEVICE_ACTION_TURN_ON);
+		}
+	}
+#if defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+	ifx_pm_deepsleep_unlock();
+#endif
+}
+#endif /* IFX_PM_WARM_BOOT */
+
+/*
+ * pm_state_set() has two build variants on this SoC:
+ *
+ *  - CM55 (IFX_PM_VARIANT_CM55, non-secure): the PDL services Cy_SysPm_*
+ *    directly without the SRF relay, so it drives the DeepSleep transition.  Its
+ *    default mode selectors are configured once in ifx_pm_init(); the whole-SoC
+ *    DeepSleep-OFF is driven from the CM33 side.
+ *
+ *  - CM33 (IFX_PM_VARIANT_CM33_NS): everything that is not CM55.  Under TF-M the
+ *    non-secure CM33 cannot enter any DeepSleep - TF-M keeps deep-sleep control
+ *    secure-only (SCR.SLEEPDEEPS = 1), so a SLEEPDEEP write from the non-secure
+ *    state is ignored and WFI always performs a shallow CPU sleep;
+ *    Cy_SysPm_CpuEnter*() would relay to the secure image over a blocking
+ *    SRF/IPC round-trip that cannot be issued from pm_state_set() anyway.  Every
+ *    low-power state therefore collapses to a plain WFI (ifx_pm_cm33_ns_sleep());
+ *    real DeepSleep is driven from the secure side.
+ *
+ *    The secure-stub CM33 companion (the pse84_boot.c build, which defines
+ *    COMPONENT_SECURE_DEVICE) also maps here.  It runs its own boot-and-sleep
+ *    loop and does not rely on Zephyr's pm_state_set() for DeepSleep, so the
+ *    shallow-WFI fallback keeps that image building and behaving safely if it
+ *    enables CONFIG_PM.
+ */
+#if defined(CONFIG_CPU_CORTEX_M55)
+#define IFX_PM_VARIANT_CM55 1
+#else
+#define IFX_PM_VARIANT_CM33_NS 1
+#endif
+
+#if defined(IFX_PM_VARIANT_CM33_NS)
+/*
+ * CM33 non-secure shallow sleep.
+ *
+ * TF-M owns deep-sleep control (SCR.SLEEPDEEPS = 1), so this core cannot enter
+ * any DeepSleep: clear SLEEPDEEP (a non-secure write to it is ignored anyway)
+ * and execute a plain WFI.  Used for every PM state on this build variant.
+ */
+static void ifx_pm_cm33_ns_sleep(void)
+{
+	SCB_SCR &= (uint32_t)~SCB_SCR_SLEEPDEEP_Msk;
+	__DSB();
+	__WFI();
+}
+#endif /* IFX_PM_VARIANT_CM33_NS */
+
 __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
-	/* Switch to using PRIMASK instead of BASEPRI register, since
-	 * we are only able to wake up from standby while using PRIMASK.
-	 */
-	/* Set PRIMASK */
+	/* Use PRIMASK instead of BASEPRI for wake-up from standby. */
 	__disable_irq();
-
-	/* Set BASEPRI to 0 */
 	irq_unlock(0);
 
 	switch (state) {
 	case PM_STATE_RUNTIME_IDLE:
 		LOG_DBG("Entering PM state runtime idle");
+#if defined(IFX_PM_VARIANT_CM33_NS)
+		ifx_pm_cm33_ns_sleep();
+#else
 		Cy_SysPm_CpuEnterSleep(CY_SYSPM_WAIT_FOR_INTERRUPT);
+#endif
 		break;
 	case PM_STATE_SUSPEND_TO_IDLE:
 		LOG_DBG("Entering PM state suspend to idle");
+#if defined(IFX_PM_VARIANT_CM33_NS)
+		ifx_pm_cm33_ns_sleep();
+#else
+		Cy_SysPm_DeepSleepSetup(CY_SYSPM_MODE_DEEPSLEEP);
+		Cy_SysPm_SetSOCMEMDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);
 		Cy_SysPm_CpuEnterDeepSleep(CY_SYSPM_WAIT_FOR_INTERRUPT);
 		SCB_SCR &= (uint32_t)~SCB_SCR_SLEEPDEEP_Msk;
+#endif /* IFX_PM_VARIANT_CM33_NS */
 		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_STATE_SUSPEND_TO_RAM:
+		LOG_DBG("Entering PM state suspend to RAM (DS-RAM)");
+#if defined(IFX_PM_VARIANT_CM33_NS)
+		ifx_pm_cm33_ns_sleep();
+#else
+		Cy_SysPm_DeepSleepSetup(CY_SYSPM_MODE_DEEPSLEEP_RAM);
+		Cy_SysPm_SetSOCMEMDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP_RAM);
+		ifx_pm_s2ram_enter();
+#endif /* IFX_PM_VARIANT_CM33_NS */
+		break;
+#endif
 	case PM_STATE_SOFT_OFF:
 		if (substate_id == 1) {
-			LOG_DBG("Entering PM state soft-off (DeepSleep-OFF)");
-			Cy_SysPm_SetDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP_OFF);
+			LOG_DBG("Entering PM state soft-off (DS-OFF)");
+#if defined(IFX_PM_VARIANT_CM33_NS)
+			ifx_pm_cm33_ns_sleep();
+#else
+			Cy_SysPm_DeepSleepSetup(CY_SYSPM_MODE_DEEPSLEEP_OFF);
+			Cy_SysPm_SetSOCMEMDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP_OFF);
 			Cy_SysPm_CpuEnterDeepSleep(CY_SYSPM_WAIT_FOR_INTERRUPT);
-			/* Restore default mode if entry failed (pending IRQ) */
-			Cy_SysPm_SetDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);
+			SCB_SCR &= (uint32_t)~SCB_SCR_SLEEPDEEP_Msk;
+#endif /* IFX_PM_VARIANT_CM33_NS */
 		} else {
 			LOG_DBG("Entering PM state soft-off (Hibernate)");
+#if defined(CONFIG_POWEROFF)
+			/*
+			 * Route hibernate through the poweroff driver
+			 * (z_sys_poweroff()), the one path valid across every build
+			 * variant.  pm_state_set() runs with PRIMASK=1 (see the
+			 * __disable_irq() at the top), so it cannot itself complete the
+			 * secure SRF/IPC hibernate relay the TF-M builds require; the
+			 * poweroff driver re-enables interrupts and either issues that
+			 * relay (CM33-NS and CM55 under TF-M, where SRSS_PWR_HIBERNATE is
+			 * PPC-secured and cannot be written from the non-secure core) or
+			 * writes the register directly (non-TF-M / stub-secure build).
+			 * sys_poweroff() never returns.
+			 */
+			__enable_irq();
+			sys_poweroff();
+#elif !defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+			/*
+			 * Non-TF-M (stub-secure) build: SRSS_PWR_HIBERNATE is directly
+			 * accessible, so enter hibernate in place.
+			 * Cy_SysPm_SystemEnterHibernate() never returns.
+			 */
 			Cy_SysPm_SystemEnterHibernate();
+#else
+			/*
+			 * TF-M / SRF build without a poweroff driver: hibernate can only
+			 * be entered over the secure SRF relay, which needs thread
+			 * context (a blocking IPC round-trip) and so cannot be issued
+			 * from here.  Enable CONFIG_POWEROFF to reach it.
+			 */
+			LOG_ERR("Hibernate needs CONFIG_POWEROFF on TF-M/SRF builds");
+#endif
 		}
 		break;
 	default:
@@ -64,26 +587,61 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 }
 
 /*
- * Zephyr PM code expects us to enabled interrupts at post op exit. Zephyr used
- * arch_irq_lock() which sets BASEPRI to a non-zero value masking all interrupts
- * preventing wake. MCHP z_power_soc_(deep)_sleep sets PRIMASK=1 and BASEPRI=0
- * allowing wake from any enabled interrupt and prevents the CPU from entering
- * an ISR on wake except for faults. We re-enable interrupts by setting PRIMASK
- * to 0.
+ * Zephyr PM expects interrupts re-enabled at exit.  pm_state_set() uses
+ * PRIMASK=1 / BASEPRI=0 so any enabled interrupt can wake the CPU without
+ * entering an ISR.  We clear PRIMASK here to resume normal dispatch.
  */
 __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
+	ARG_UNUSED(state);
 	ARG_UNUSED(substate_id);
 
-	/* Clear PRIMASK */
 	__enable_irq();
+
+#if defined(IFX_PM_WARM_BOOT)
+	/*
+	 * A DeepSleep-RAM warm boot power-cycles the peripheral domain, so every
+	 * peripheral must be rebuilt by its device TURN_ON pm_action.  The
+	 * ifx_pm_s2ram_warm_boot flag was armed by ifx_pm_s2ram_enter() only on a
+	 * genuine warm boot (never on the retained suspend-to-idle path).
+	 *
+	 *  - Without the SRF relay the rebuild is non-blocking local MMIO, so run
+	 *    it eagerly now, while the scheduler is still locked and no application
+	 *    thread has run: it completes ahead of the first peripheral use with no
+	 *    race.  The atomic compare-and-set consumes the flag.
+	 *
+	 *  - With the SRF relay the rebuild relays to the secure core over blocking
+	 *    IPC, which needs the scheduler running and interrupts enabled (neither
+	 *    is true here) and must not race the waking application.  Leave the flag
+	 *    armed; the application restores the peripherals from thread context by
+	 *    calling ifx_pm_warm_boot_reinit_all(), which consumes it.
+	 */
+#if !defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+	if (atomic_cas(&ifx_pm_s2ram_warm_boot, 1, 0)) {
+		ifx_pm_warm_boot_reinit_all();
+	}
+#endif
+#endif /* IFX_PM_WARM_BOOT */
 }
 
 static int ifx_pm_init(void)
 {
-#if defined(CONFIG_SOC_SERIES_PSE84)
+#if defined(IFX_PM_VARIANT_CM55)
+	/*
+	 * On the CM55 the PDL services these calls directly (no SRF relay), so
+	 * configure the default DeepSleep modes once here at init rather than
+	 * from the application.  Keeping the APP CPU domain in regular DeepSleep
+	 * (not OFF) retains this core across a DeepSleep so it wakes on any
+	 * enabled interrupt; the whole-SoC DeepSleep-OFF is driven from the
+	 * CM33-NS side.
+	 */
+	Cy_SysPm_DeepSleepSetup(CY_SYSPM_MODE_DEEPSLEEP);
+
 	/* System Domain Idle Power Mode Configuration */
 	Cy_SysPm_SetDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);
+
+	/* APP CPU Domain Idle Power Mode Configuration */
+	Cy_SysPm_SetAppDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);
 
 	/* SoCMEM Idle Power Mode Configuration */
 	Cy_SysPm_SetSOCMEMDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);

--- a/soc/infineon/edge/pse84/power.c
+++ b/soc/infineon/edge/pse84/power.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,50 +11,691 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/barrier.h>
 #include <zephyr/pm/pm.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/platform/hooks.h>
+#include <zephyr/sys/poweroff.h>
 #include <zephyr/logging/log.h>
 
 #include <cy_syspm.h>
+#include <cy_syspm_pdcm.h>
+#include <cy_syspm_ppu.h>
+#include <cy_sysclk.h>
+#include <cy_syslib.h>
+#include <system_edge.h>
 
 #include <soc.h>
+#include <power.h>
+
+/*
+ * Warm-boot peripheral re-init is compiled only when DeepSleep-RAM can
+ * power-cycle the peripheral domain (CONFIG_PM_S2RAM) and the PM device model is
+ * present to carry each peripheral's TURN_ON rebuild (CONFIG_PM_DEVICE).
+ */
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+#define IFX_PM_WARM_BOOT 1
+#endif
+
+#if defined(CONFIG_PM_S2RAM)
+#include <zephyr/arch/common/pm_s2ram.h>
+#include <zephyr/arch/common/init.h>
+#include <zephyr/arch/arm/cortex_m/fpu.h>
+#include <zephyr/arch/arm/cortex_m/scb.h>
+#include <zephyr/arch/arm/mpu/arm_mpu.h>
+#include <kernel_arch_func.h>
+#endif
 
 LOG_MODULE_REGISTER(soc_power, CONFIG_SOC_LOG_LEVEL);
 
+#if defined(CONFIG_PM)
 /*
- * Called from pm_system_suspend(int32_t ticks) in subsys/power.c
- * For deep sleep pm_system_suspend has executed all the driver
- * power management call backs.
+ * Zephyr PM-policy bridge for the MTB deepsleep lock (see the --wrap flags in
+ * this SoC's CMakeLists.txt).
+ *
+ * mtb_hal_syspm_lock_deepsleep()/unlock_deepsleep() are the vendor HAL's "keep
+ * the core out of DeepSleep for now" guard: MTB HAL and SRF operations that must
+ * not be interrupted by a low-power transition bracket themselves with these
+ * calls.  The CM55 SRF/IPC relay's blocking completion wait
+ * (mtb_srf_ipc_request_send()) is the most prominent caller, but it is not the
+ * only one - any library that uses the vendor deepsleep lock relies on the same
+ * behavior.  On their own, though, they only increment/decrement an MTB-internal
+ * counter that is consulted solely by the MTB HAL's own deepsleep entry, a path
+ * the Zephyr pm_state_set() never takes, so on Zephyr they do nothing to
+ * actually keep the core awake.  While such a section is in progress and the
+ * calling thread blocks with no other thread ready, the idle thread can let the
+ * PM policy enter a CPU-gating state (SUSPEND_TO_IDLE / SUSPEND_TO_RAM), which
+ * gates the core and drops the pending completion so the operation never
+ * finishes.
+ *
+ * The linker redirects both symbols here via --wrap: __real_* runs the original
+ * vendor bookkeeping, and around it we take/release a Zephyr PM-policy lock so
+ * only shallow runtime-idle (WFI, interrupts live) stays available for the
+ * duration of the guarded section.  This protects every caller of the vendor
+ * deepsleep lock platform-wide, not just the SRF client, without editing the
+ * vendor module or touching each call site.  The get/put calls are
+ * reference-counted, so nested sections balance correctly.
  */
+void __real_mtb_hal_syspm_lock_deepsleep(void);
+void __real_mtb_hal_syspm_unlock_deepsleep(void);
+
+void __wrap_mtb_hal_syspm_lock_deepsleep(void)
+{
+	__real_mtb_hal_syspm_lock_deepsleep();
+	ifx_pm_deepsleep_lock();
+}
+
+void __wrap_mtb_hal_syspm_unlock_deepsleep(void)
+{
+	ifx_pm_deepsleep_unlock();
+	__real_mtb_hal_syspm_unlock_deepsleep();
+}
+#endif /* CONFIG_PM */
+
+#if defined(CONFIG_PM_S2RAM)
+
+#if defined(IFX_PM_WARM_BOOT)
+/*
+ * Set true by ifx_pm_s2ram_enter() when the Zephyr S2RAM marker
+ * (pm_s2ram_mark_check_and_clear()) confirms a genuine DeepSleep-RAM warm boot,
+ * i.e. arch_pm_s2ram_suspend() returned 0 because the CPU was power-cycled and
+ * resumed through the reset handler.  Consumed and cleared by
+ * pm_state_exit_post_ops() when it bumps the warm-boot generation counter, so a
+ * failed DS-RAM entry (which never powered the domain down) does not trigger a
+ * spurious peripheral re-init.
+ */
+static bool ifx_pm_s2ram_warm_boot;
+#endif /* IFX_PM_WARM_BOOT */
+
+/*
+ * Custom S2RAM marker (CONFIG_HAS_PM_S2RAM_CUSTOM_MARKING).
+ *
+ * Warm resume IS supported.  The marker, the saved CPU context (_cpu_context)
+ * and the suspend stack all live in the CM55 "RAM" output region, which the
+ * linker places at 0x26100000 (SOCMEM-backed system RAM) -- NOT in the CM55
+ * tightly-coupled memories.  Only ITCM (0x00000000) and DTCM (0x20000000) are
+ * powered down with the CPU subsystem during DeepSleep-RAM; the SOCMEM RAM is
+ * retained because pm_state_set() programs the SOCMEM DeepSleep mode to
+ * CY_SYSPM_MODE_DEEPSLEEP_RAM before entry.  So everything the reset handler
+ * needs to warm-resume survives the DS-RAM power cycle.
+ *
+ * arch_pm_s2ram_suspend() saves _cpu_context and pushes the callee-saved GPRs
+ * onto the (retained) stack, calls pm_s2ram_mark_set() to arm the marker, then
+ * enters DS-RAM.  The DS-RAM wake is a full reset: the CM55 reset handler runs
+ * arch_pm_s2ram_resume() -> pm_s2ram_mark_check_and_clear() very early (before
+ * .bss is zeroed), and when the marker is found set it restores _cpu_context,
+ * pops the GPRs and returns into ifx_pm_s2ram_enter() with rc == 0, resuming at
+ * the WFI call site instead of re-running kernel init and main().
+ *
+ * The marker is self-clearing: pm_s2ram_mark_check_and_clear() clears it on
+ * every boot, so a genuine cold boot (marker naturally 0 in zeroed/retained
+ * RAM after a power cycle, or cleared by the previous resume) falls through to
+ * normal init.  A hardware warm-boot witness readable this early from CM55-NS
+ * does not exist (SRSS reset-cause is PPC-secured under TF-M and SRF/IPC is not
+ * up in the reset handler); if a more robust discriminator than the retained
+ * marker is required, the secure core can read Cy_SysPm_GetBootMode() and hand
+ * the result to CM55-NS, which validates/clears the marker once the kernel and
+ * IPC are up.
+ */
+#define IFX_S2RAM_MARKER_MAGIC 0xDABBAD00U
+
+static __noinit uint32_t ifx_s2ram_marker;
+
+void pm_s2ram_mark_set(void)
+{
+	/*
+	 * Arm the warm-boot marker just before DS-RAM entry.  It lives in the
+	 * retained SOCMEM RAM region (see the note above), so it survives the
+	 * DS-RAM power cycle and is visible to arch_pm_s2ram_resume() in the
+	 * reset handler.
+	 */
+	ifx_s2ram_marker = IFX_S2RAM_MARKER_MAGIC;
+}
+
+bool pm_s2ram_mark_check_and_clear(void)
+{
+	/*
+	 * Called from arch_pm_s2ram_resume() in the reset handler, before .bss
+	 * is zeroed.  If the marker is set this is a DS-RAM warm boot: report it
+	 * so the caller restores _cpu_context and returns to the suspend point.
+	 * The marker is always cleared (self-clearing) so a later genuine cold
+	 * boot is not mistaken for a warm boot.
+	 */
+	bool was_suspended = (ifx_s2ram_marker == IFX_S2RAM_MARKER_MAGIC);
+
+	/* Data cache is disabled this early after reset, so this write reaches
+	 * retained SOCMEM RAM directly; drain the write buffer to be certain the
+	 * cleared marker survives even if a later step faults.
+	 */
+	ifx_s2ram_marker = 0U;
+	__DSB();
+
+	return was_suspended;
+}
+
+#define NVIC_ISER_COUNT DIV_ROUND_UP(CONFIG_NUM_IRQS, 32)
+#define NVIC_IPR_COUNT  CONFIG_NUM_IRQS
+
+struct nvic_context {
+	uint32_t iser[NVIC_ISER_COUNT];
+	uint8_t ipr[NVIC_IPR_COUNT];
+};
+
+static struct fpu_ctx_full fpu_state;
+static struct scb_context scb_state;
+#if defined(CONFIG_ARM_MPU)
+static struct z_mpu_context_retained mpu_state;
+#endif
+static struct nvic_context nvic_state;
+
+static void s2ram_save_nvic_context(struct nvic_context *ctx)
+{
+	for (uint32_t i = 0; i < NVIC_ISER_COUNT; i++) {
+		ctx->iser[i] = NVIC->ISER[i];
+	}
+	for (uint32_t i = 0; i < NVIC_IPR_COUNT; i++) {
+		ctx->ipr[i] = NVIC->IPR[i];
+	}
+}
+
+static void s2ram_restore_nvic_context(const struct nvic_context *ctx)
+{
+	for (uint32_t i = 0; i < NVIC_ISER_COUNT; i++) {
+		NVIC->ISER[i] = ctx->iser[i];
+	}
+	for (uint32_t i = 0; i < NVIC_IPR_COUNT; i++) {
+		NVIC->IPR[i] = ctx->ipr[i];
+	}
+}
+
+/**
+ * @brief Low-power mode entry for ds-ram and ds-off.
+ *
+ * Called by arch_pm_s2ram_suspend() after CPU context has been saved.
+ * Cleans the D-cache so the retained warm-boot state is coherent with
+ * SOCMEM, then enters DeepSleep-RAM/OFF via Cy_SysPm_CpuEnterDeepSleep(),
+ * which sets SLEEPDEEP, brackets the FPU, and executes WFI internally.
+ *
+ * @return Does not return on a successful warm boot (resumes through the
+ *         reset handler); returns -EAGAIN if the CPU wakes without a power
+ *         cycle.
+ */
+static int enter_deepsleep(void)
+{
+	/*
+	 * The warm-boot state that arch_pm_s2ram_resume() reads back in the
+	 * reset handler -- the S2RAM marker (ifx_s2ram_marker), the saved CPU
+	 * context (_cpu_context) and the callee-saved GPRs pushed onto the
+	 * suspend stack -- all live in the retained SOCMEM RAM region but were
+	 * written through the CM55 write-back D-cache by arch_pm_s2ram_suspend()
+	 * and pm_s2ram_mark_set().  DeepSleep-RAM powers the CPU subsystem (and
+	 * therefore the L1 D-cache) down, so any line still dirty in the cache
+	 * is lost and never reaches physical SOCMEM.  On warm boot the marker
+	 * check would then read a stale value, miss the warm boot and cold-boot
+	 * instead.  A bare __DSB() is not enough: it orders accesses but does
+	 * not evict dirty write-back lines.  Clean (write back) the D-cache so
+	 * the retained copies are coherent with SOCMEM before entry.
+	 */
+#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+	SCB_CleanDCache();
+#endif
+	__DSB();
+	__ISB();
+
+	Cy_SysPm_CpuEnterDeepSleep(CY_SYSPM_WAIT_FOR_INTERRUPT);
+	SCB_SCR &= (uint32_t)~SCB_SCR_SLEEPDEEP_Msk;
+
+	return -EAGAIN;
+}
+
+/**
+ * @brief Restore system state after DS-RAM warm boot.
+ *
+ * DS-RAM retains all SRAM/SOCMEM, so the C runtime, kernel state, the
+ * SystemCoreClock value and the SRF/IPC client context all survive, and the
+ * CM33 companion re-establishes the clock tree before it re-enables this core.
+ * The only state physically lost is the CM55 tightly-coupled memory (ITCM,
+ * powered down with the CPU subsystem) and the L1 caches.  Both are restored
+ * here with purely local operations.
+ *
+ * Crucially this runs on the resumed CPU context, i.e. with PRIMASK = 1 (the
+ * interrupt-masked state that was saved at suspend), so it must NOT call any
+ * routine that relays to the secure core over SRF/IPC.  In particular
+ * soc_early_init_hook() and SystemCoreClockUpdate() are deliberately NOT called
+ * here: SystemCoreClockUpdate() -> Cy_SysClk_ClkHfGetFrequency() is a
+ * PPC-secured SRF relay whose blocking IPC semaphore wait cannot complete with
+ * interrupts masked and faults (observed as a HardFault in
+ * Cy_SysClk_ClkHfGetFrequency).  Neither is needed anyway because RAM (and thus
+ * SystemCoreClock) is retained and the clock tree is already live.
+ *
+ * CM33 does not use ITCM — its ramfunc sections reside in retained SRAM and
+ * survive DS-RAM.  When CM33 S2RAM support is added, only the cache
+ * re-initialization portion is needed.
+ */
+#if defined(CONFIG_CPU_CORTEX_M55) && defined(CONFIG_CODE_DATA_RELOCATION)
+extern void data_copy_xip_relocation(void);
+extern void bss_zeroing_relocation(void);
+#endif /* CONFIG_CPU_CORTEX_M55 && CONFIG_CODE_DATA_RELOCATION */
+
+static void s2ram_restore_system(void)
+{
+#if defined(CONFIG_CPU_CORTEX_M55)
+	/*
+	 * Restore the CM55 memory that the DS-RAM power cycle loses. Only the
+	 * CPU-local tightly-coupled memory is affected; SOCMEM-backed SRAM is
+	 * retained, so nothing placed there needs rebuilding here.
+	 *
+	 * data_copy_xip_relocation()/bss_zeroing_relocation() rebuild every
+	 * section declared via zephyr_code_relocate() (CONFIG_CODE_DATA_RELOCATION),
+	 * not just TCM ones. On this SoC relocation is used only to place
+	 * code/rodata in ITCM, which is lost, so re-running them is correct. An
+	 * application that instead relocates data or BSS into retained SRAM would
+	 * have that state wiped here and must not do so on a DS-RAM build.
+	 */
+	extern char __itcm_start[];
+	extern char __itcm_load_start[];
+	extern char __itcm_size[];
+
+#if defined(CONFIG_CODE_DATA_RELOCATION)
+	data_copy_xip_relocation();
+	bss_zeroing_relocation();
+#endif /* CONFIG_CODE_DATA_RELOCATION */
+	arch_early_memcpy(&__itcm_start, &__itcm_load_start, (size_t)&__itcm_size);
+#endif /* CONFIG_CPU_CORTEX_M55 */
+
+	/* Re-enable the L1 caches, which are invalidated by the DS-RAM power
+	 * cycle.  These are local CPU (CMSIS) operations with no secure relay,
+	 * so they are safe on this interrupt-masked resume path.
+	 * z_arm_restore_scb_context() later restores CCR/cache enables from the
+	 * saved SCB context.
+	 */
+#if defined(__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+	SCB_InvalidateICache();
+#endif
+#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+	SCB_InvalidateDCache();
+#endif
+}
+
+/**
+ * @brief Enter suspend-to-RAM (DeepSleep-RAM) state.
+ *
+ * Saves FPU, SCB, MPU, and NVIC context, then calls arch_pm_s2ram_suspend
+ * which saves CPU registers and invokes enter_deepsleep().  On warm boot
+ * the reset handler restores CPU context and returns here with rc == 0.
+ *
+ * Resume ordering is critical:
+ *   1. CPACR — enables FPU/MVE coprocessors so compiler-generated
+ *      vector instructions in subsequent C code do not fault (NOCP).
+ *   2. System restore — ITCM re-copy, clock tree, caches.
+ *   3. Clear bus faults — peripheral re-init may have generated
+ *      benign imprecise bus faults; clear them while BUSFAULTENA
+ *      is still at its reset default (disabled).
+ *   4. Full SCB restore.
+ *   5. MPU, FP, NVIC restore.
+ */
+void ifx_pm_s2ram_enter(void)
+{
+	int rc;
+
+	z_arm_save_fp_context(&fpu_state);
+	z_arm_save_scb_context(&scb_state);
+#if defined(CONFIG_ARM_MPU)
+	z_arm_save_mpu_context(&mpu_state);
+#endif
+	s2ram_save_nvic_context(&nvic_state);
+
+	rc = arch_pm_s2ram_suspend(enter_deepsleep);
+
+	if (rc == 0) {
+#if defined(IFX_PM_WARM_BOOT)
+		/* Marker-confirmed warm boot: the peripheral domain was
+		 * power-cycled.  Record it so pm_state_exit_post_ops() schedules
+		 * the deferred peripheral re-init worker.
+		 */
+		ifx_pm_s2ram_warm_boot = true;
+#endif /* IFX_PM_WARM_BOOT */
+
+		/* Step 1: enable FPU/MVE coprocessors (CPACR defaults to 0
+		 * after DS-RAM reset).  Full SCB restore is deferred — its
+		 * BUSFAULTENA would escalate pending bus faults from step 2.
+		 */
+#if defined(CPACR_PRESENT)
+		SCB->CPACR = scb_state.cpacr;
+		__DSB();
+		__ISB();
+#endif
+		/* Step 2: re-init ITCM, clocks, caches */
+		s2ram_restore_system();
+
+		/* Steps 3: restore remaining core context */
+		z_arm_restore_scb_context(&scb_state);
+#if defined(CONFIG_ARM_MPU)
+		z_arm_restore_mpu_context(&mpu_state);
+#endif
+		z_arm_restore_fp_context(&fpu_state);
+		s2ram_restore_nvic_context(&nvic_state);
+		__DSB();
+		__ISB();
+	}
+
+	if (rc != 0) {
+		LOG_WRN("S2RAM entry failed: rc=%d ICSR=0x%08x", rc, (uint32_t)SCB->ICSR);
+	}
+}
+#endif /* CONFIG_PM_S2RAM */
+
+#if defined(IFX_PM_WARM_BOOT)
+/*
+ * DeepSleep-RAM warm-boot re-init, performed lazily in the consuming thread.
+ *
+ * DS-RAM power-cycles the peripheral domain, so after a warm boot every
+ * peripheral has lost its hardware state and must be rebuilt: a power-loss
+ * OFF->SUSPENDED transition, expressed by PM_DEVICE_ACTION_TURN_ON (not RESUME,
+ * which is for a retained low-power state where the hardware kept its config).
+ * The rebuild relays PPC-secured clock/PDL operations to the secure core over
+ * the SRF/IPC, which blocks, so it cannot run from pm_state_exit_post_ops()
+ * (scheduler-locked) and must not race the waking application.
+ *
+ * Rather than rebuild everything up front from a worker - which would either race
+ * the already-runnable application thread the moment a relay blocks, or force us
+ * to suspend the application threads for the duration - each driver rebuilds
+ * itself lazily, on its first use after the warm boot, from the thread that is
+ * about to use it.  That thread blocks on its own re-init (the idle thread WFIs
+ * and the IPC completes by ISR), then proceeds; because it is the same thread
+ * that will touch the peripheral, there is no cross-thread race and no console
+ * corruption.
+ *
+ * ifx_pm_warm_boot_gen is bumped once per genuine warm boot (see
+ * pm_state_exit_post_ops()).  A driver records the generation it last rebuilt at
+ * in its retained driver data and calls ifx_pm_warm_boot_reinit() at each API
+ * entry; the counters differ only on the first use after a warm boot.
+ */
+static atomic_t ifx_pm_warm_boot_gen;
+
+#if defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+/* Generation whose warm-boot prerequisites have already been re-established. */
+static atomic_t ifx_pm_prepared_gen;
+static K_MUTEX_DEFINE(ifx_pm_prepare_mutex);
+
+/*
+ * Re-establish the global prerequisites every driver's warm-boot rebuild depends
+ * on, once per warm-boot generation, before any per-driver TURN_ON runs.
+ *
+ * DS-RAM power-cycles the peripheral domain, so on the first post-wake use two
+ * things must be restored, in order, ahead of any driver rebuild:
+ *
+ *   1. The base clock tree.  A driver cannot reprogram its own peripheral clock
+ *      until the tree it hangs off is running again.  On this SoC the base tree
+ *      is restored by the CM33 companion during its own warm boot and the CM55
+ *      system clock is republished by the SRF client bring-up below, so there is
+ *      no separate CM55-side step here; a SoC without a secure companion would
+ *      re-run its clock init at this point.
+ *
+ *   2. The SRF/IPC client.  The CM33 secure image cold-booted and republished
+ *      the IPC/SRF endpoint during the warm boot; without re-establishing the
+ *      client the stale pre-sleep handle would fault on the first secure request
+ *      (every PPC-secured clock/PDL relay a driver rebuild issues).  Each
+ *      consuming driver then re-programs its own peripheral clock divider from
+ *      its TURN_ON handler (there are no separate divider devices on this core),
+ *      so no explicit divider re-program step is needed here.
+ *
+ * Single-flight: concurrent first-users serialize on the mutex and only the
+ * winner runs the blocking handshake.  Must run in thread context.
+ */
+static void ifx_pm_warm_boot_prepare(uint32_t gen)
+{
+	if ((uint32_t)atomic_get(&ifx_pm_prepared_gen) == gen) {
+		return;
+	}
+
+	k_mutex_lock(&ifx_pm_prepare_mutex, K_FOREVER);
+
+	if ((uint32_t)atomic_get(&ifx_pm_prepared_gen) != gen) {
+		/*
+		 * Hold a Zephyr PM-policy lock across the client re-init.  Its
+		 * blocking IPC semaphore give/take is NOT bracketed by the vendor
+		 * deepsleep lock and uses an infinite timeout, so without this the idle
+		 * thread could CPU-gate the core mid-handshake and drop the pending
+		 * completion.  Only shallow runtime-idle (WFI, interrupts live) stays
+		 * available for the duration.
+		 */
+		ifx_pm_deepsleep_lock();
+		ifx_soc_srf_client_reinit();
+		ifx_pm_deepsleep_unlock();
+
+		atomic_set(&ifx_pm_prepared_gen, (atomic_val_t)gen);
+	}
+
+	k_mutex_unlock(&ifx_pm_prepare_mutex);
+}
+#endif /* CONFIG_PSOC_EDGE_M55_SRF_SUPPORT */
+
+/*
+ * Eager warm-boot rebuild: walk every device in link (initialization) order and
+ * invoke its PM_DEVICE_ACTION_TURN_ON handler, restoring all peripherals in a
+ * single up-front pass instead of lazily on first use.
+ *
+ * Public so an application can force a full peripheral restore after a
+ * DeepSleep-RAM warm boot from its own thread context.  On builds without the
+ * SRF relay this is also the automatic path: pm_state_exit_post_ops() calls it
+ * while the scheduler is still locked, because a driver's TURN_ON rebuild is
+ * then pure local MMIO (pinctrl, IP init, clock divider, NVIC) and never blocks.
+ *
+ * On SRF builds each TURN_ON handler relays PPC-secured clock/PDL operations to
+ * the secure core over blocking IPC, so this must run in thread context: it
+ * first re-establishes the SRF client - once per warm-boot generation, via
+ * ifx_pm_warm_boot_prepare(), which also keeps the per-driver lazy path from
+ * redundantly re-establishing it - and then walks with the PM-policy lock held
+ * so the idle thread cannot CPU-gate the core mid-handshake.  A peripheral
+ * touched by a thread before this call rebuilds itself lazily; one touched after
+ * it is already live, and its lazy TURN_ON becomes an idempotent repeat.
+ *
+ * Devices are walked in link order, so each is rebuilt only after the parents it
+ * was initialized after; a device with no TURN_ON handler returns -ENOTSUP and
+ * is skipped.
+ */
+void ifx_pm_warm_boot_reinit_all(void)
+{
+#if defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+	ifx_pm_warm_boot_prepare((uint32_t)atomic_get(&ifx_pm_warm_boot_gen));
+	ifx_pm_deepsleep_lock();
+#endif
+	STRUCT_SECTION_FOREACH(device, dev) {
+		struct pm_device_base *pm = dev->pm_base;
+
+		if ((pm != NULL) && (pm->action_cb != NULL)) {
+			(void)pm->action_cb(dev, PM_DEVICE_ACTION_TURN_ON);
+		}
+	}
+#if defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+	ifx_pm_deepsleep_unlock();
+#endif
+}
+
+bool ifx_pm_warm_boot_reinit(const struct device *dev, uint32_t *last_gen)
+{
+#if defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+	uint32_t gen = (uint32_t)atomic_get(&ifx_pm_warm_boot_gen);
+	struct pm_device_base *pm;
+
+	if (*last_gen == gen) {
+		return false;
+	}
+
+	/*
+	 * The rebuild relays over blocking IPC, so it needs thread context.  If the
+	 * first post-wake use happens in an ISR, skip it: the device stays stale
+	 * until a thread-context caller rebuilds it.  In practice the application
+	 * touches each peripheral from a thread before any ISR does.
+	 */
+	if (k_is_in_isr()) {
+		return false;
+	}
+
+	ifx_pm_warm_boot_prepare(gen);
+
+	/*
+	 * Record the generation before invoking TURN_ON, not after.  Some drivers
+	 * (e.g. PWM/counter) restore their hardware from their own API entry inside
+	 * the TURN_ON handler; that nested call re-enters this function, and marking
+	 * the generation first makes it observe an up-to-date value and fall through
+	 * to the real work instead of recursing.  A failed rebuild is therefore not
+	 * retried, which is acceptable: a warm-boot re-init failure is unrecoverable
+	 * for that peripheral regardless.
+	 */
+	*last_gen = gen;
+
+	pm = dev->pm_base;
+	if ((pm != NULL) && (pm->action_cb != NULL)) {
+		/*
+		 * Invoke TURN_ON directly (not via pm_device_action_run()) so the
+		 * rebuild runs regardless of the device's tracked PM state and leaves
+		 * the runtime PM bookkeeping untouched.  A driver with no warm-boot
+		 * work returns -ENOTSUP, which is ignored here.
+		 */
+		(void)pm->action_cb(dev, PM_DEVICE_ACTION_TURN_ON);
+	}
+
+	return true;
+#else  /* !CONFIG_PSOC_EDGE_M55_SRF_SUPPORT */
+	/*
+	 * Non-SRF builds rebuild every device eagerly in pm_state_exit_post_ops()
+	 * (the rebuild never blocks), so the per-driver lazy hook has nothing left
+	 * to do.  Kept as a no-op so drivers can call it unconditionally.
+	 */
+	ARG_UNUSED(dev);
+	ARG_UNUSED(last_gen);
+	return false;
+#endif /* CONFIG_PSOC_EDGE_M55_SRF_SUPPORT */
+}
+#endif /* IFX_PM_WARM_BOOT */
+
+/*
+ * pm_state_set() has two build variants on this SoC:
+ *
+ *  - CM55 (IFX_PM_VARIANT_CM55, non-secure): the PDL services Cy_SysPm_*
+ *    directly without the SRF relay, so it drives the DeepSleep transition.  Its
+ *    default mode selectors are configured once in ifx_pm_init(); the whole-SoC
+ *    DeepSleep-OFF is driven from the CM33 side.
+ *
+ *  - CM33 (IFX_PM_VARIANT_CM33_NS): everything that is not CM55.  Under TF-M the
+ *    non-secure CM33 cannot enter any DeepSleep - TF-M keeps deep-sleep control
+ *    secure-only (SCR.SLEEPDEEPS = 1), so a SLEEPDEEP write from the non-secure
+ *    state is ignored and WFI always performs a shallow CPU sleep;
+ *    Cy_SysPm_CpuEnter*() would relay to the secure image over a blocking
+ *    SRF/IPC round-trip that cannot be issued from pm_state_set() anyway.  Every
+ *    low-power state therefore collapses to a plain WFI (ifx_pm_cm33_ns_sleep());
+ *    real DeepSleep is driven from the secure side.
+ *
+ *    The secure-stub CM33 companion (the pse84_boot.c build, which defines
+ *    COMPONENT_SECURE_DEVICE) also maps here.  It runs its own boot-and-sleep
+ *    loop and does not rely on Zephyr's pm_state_set() for DeepSleep, so the
+ *    shallow-WFI fallback keeps that image building and behaving safely if it
+ *    enables CONFIG_PM.
+ */
+#if defined(CONFIG_CPU_CORTEX_M55)
+#define IFX_PM_VARIANT_CM55 1
+#else
+#define IFX_PM_VARIANT_CM33_NS 1
+#endif
+
+#if defined(IFX_PM_VARIANT_CM33_NS)
+/*
+ * CM33 non-secure shallow sleep.
+ *
+ * TF-M owns deep-sleep control (SCR.SLEEPDEEPS = 1), so this core cannot enter
+ * any DeepSleep: clear SLEEPDEEP (a non-secure write to it is ignored anyway)
+ * and execute a plain WFI.  Used for every PM state on this build variant.
+ */
+static void ifx_pm_cm33_ns_sleep(void)
+{
+	SCB_SCR &= (uint32_t)~SCB_SCR_SLEEPDEEP_Msk;
+	__DSB();
+	__WFI();
+}
+#endif /* IFX_PM_VARIANT_CM33_NS */
+
 __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
-	/* Switch to using PRIMASK instead of BASEPRI register, since
-	 * we are only able to wake up from standby while using PRIMASK.
-	 */
-	/* Set PRIMASK */
+	/* Use PRIMASK instead of BASEPRI for wake-up from standby. */
 	__disable_irq();
-
-	/* Set BASEPRI to 0 */
 	irq_unlock(0);
 
 	switch (state) {
 	case PM_STATE_RUNTIME_IDLE:
 		LOG_DBG("Entering PM state runtime idle");
+#if defined(IFX_PM_VARIANT_CM33_NS)
+		ifx_pm_cm33_ns_sleep();
+#else
 		Cy_SysPm_CpuEnterSleep(CY_SYSPM_WAIT_FOR_INTERRUPT);
+#endif
 		break;
 	case PM_STATE_SUSPEND_TO_IDLE:
 		LOG_DBG("Entering PM state suspend to idle");
+#if defined(IFX_PM_VARIANT_CM33_NS)
+		ifx_pm_cm33_ns_sleep();
+#else
+		Cy_SysPm_DeepSleepSetup(CY_SYSPM_MODE_DEEPSLEEP);
+		Cy_SysPm_SetSOCMEMDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);
 		Cy_SysPm_CpuEnterDeepSleep(CY_SYSPM_WAIT_FOR_INTERRUPT);
 		SCB_SCR &= (uint32_t)~SCB_SCR_SLEEPDEEP_Msk;
+#endif /* IFX_PM_VARIANT_CM33_NS */
 		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_STATE_SUSPEND_TO_RAM:
+		LOG_DBG("Entering PM state suspend to RAM (DS-RAM)");
+#if defined(IFX_PM_VARIANT_CM33_NS)
+		ifx_pm_cm33_ns_sleep();
+#else
+		Cy_SysPm_DeepSleepSetup(CY_SYSPM_MODE_DEEPSLEEP_RAM);
+		Cy_SysPm_SetSOCMEMDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP_RAM);
+		ifx_pm_s2ram_enter();
+#endif /* IFX_PM_VARIANT_CM33_NS */
+		break;
+#endif
 	case PM_STATE_SOFT_OFF:
 		if (substate_id == 1) {
-			LOG_DBG("Entering PM state soft-off (DeepSleep-OFF)");
-			Cy_SysPm_SetDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP_OFF);
+			LOG_DBG("Entering PM state soft-off (DS-OFF)");
+#if defined(IFX_PM_VARIANT_CM33_NS)
+			ifx_pm_cm33_ns_sleep();
+#else
+			Cy_SysPm_DeepSleepSetup(CY_SYSPM_MODE_DEEPSLEEP_OFF);
+			Cy_SysPm_SetSOCMEMDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP_OFF);
 			Cy_SysPm_CpuEnterDeepSleep(CY_SYSPM_WAIT_FOR_INTERRUPT);
-			/* Restore default mode if entry failed (pending IRQ) */
-			Cy_SysPm_SetDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);
+			SCB_SCR &= (uint32_t)~SCB_SCR_SLEEPDEEP_Msk;
+#endif /* IFX_PM_VARIANT_CM33_NS */
 		} else {
 			LOG_DBG("Entering PM state soft-off (Hibernate)");
+#if defined(CONFIG_POWEROFF)
+			/*
+			 * Route hibernate through the poweroff driver
+			 * (z_sys_poweroff()), the one path valid across every build
+			 * variant.  pm_state_set() runs with PRIMASK=1 (see the
+			 * __disable_irq() at the top), so it cannot itself complete the
+			 * secure SRF/IPC hibernate relay the TF-M builds require; the
+			 * poweroff driver re-enables interrupts and either issues that
+			 * relay (CM33-NS and CM55 under TF-M, where SRSS_PWR_HIBERNATE is
+			 * PPC-secured and cannot be written from the non-secure core) or
+			 * writes the register directly (non-TF-M / stub-secure build).
+			 * sys_poweroff() never returns.
+			 */
+			__enable_irq();
+			sys_poweroff();
+#elif !defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+			/*
+			 * Non-TF-M (stub-secure) build: SRSS_PWR_HIBERNATE is directly
+			 * accessible, so enter hibernate in place.
+			 * Cy_SysPm_SystemEnterHibernate() never returns.
+			 */
 			Cy_SysPm_SystemEnterHibernate();
+#else
+			/*
+			 * TF-M / SRF build without a poweroff driver: hibernate can only
+			 * be entered over the secure SRF relay, which needs thread
+			 * context (a blocking IPC round-trip) and so cannot be issued
+			 * from here.  Enable CONFIG_POWEROFF to reach it.
+			 */
+			LOG_ERR("Hibernate needs CONFIG_POWEROFF on TF-M/SRF builds");
+#endif
 		}
 		break;
 	default:
@@ -64,26 +705,67 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 }
 
 /*
- * Zephyr PM code expects us to enabled interrupts at post op exit. Zephyr used
- * arch_irq_lock() which sets BASEPRI to a non-zero value masking all interrupts
- * preventing wake. MCHP z_power_soc_(deep)_sleep sets PRIMASK=1 and BASEPRI=0
- * allowing wake from any enabled interrupt and prevents the CPU from entering
- * an ISR on wake except for faults. We re-enable interrupts by setting PRIMASK
- * to 0.
+ * Zephyr PM expects interrupts re-enabled at exit.  pm_state_set() uses
+ * PRIMASK=1 / BASEPRI=0 so any enabled interrupt can wake the CPU without
+ * entering an ISR.  We clear PRIMASK here to resume normal dispatch.
  */
 __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 {
+	ARG_UNUSED(state);
 	ARG_UNUSED(substate_id);
 
-	/* Clear PRIMASK */
 	__enable_irq();
+
+#if defined(IFX_PM_WARM_BOOT)
+	/*
+	 * A DeepSleep-RAM warm boot power-cycles the peripheral domain, so every
+	 * peripheral must be re-initialized by its device TURN_ON pm_action.
+	 * ifx_pm_s2ram_warm_boot is set by ifx_pm_s2ram_enter() only on a genuine
+	 * warm boot (never on the retained suspend-to-idle path), so the generation
+	 * advances only when peripheral state was actually lost.
+	 *
+	 * How the rebuild is driven depends on whether the SRF relay is in play:
+	 *
+	 *  - With SRF, the rebuild relays to the secure core (PPC-secured clock/PDL
+	 *    calls over blocking IPC), which needs the scheduler running and
+	 *    interrupts enabled - neither is true here (this runs under
+	 *    k_sched_lock with PRIMASK just cleared) - and rebuilding up front would
+	 *    also race the waking application thread.  So just bump the generation
+	 *    counter; each driver rebuilds itself lazily on its first post-wake use,
+	 *    from the consuming thread's own context (see ifx_pm_warm_boot_reinit()).
+	 *
+	 *  - Without SRF the rebuild is non-blocking local MMIO, so do it eagerly
+	 *    now, while the scheduler is still locked and no application thread has
+	 *    run: it completes ahead of the first peripheral use with no race.
+	 */
+	if (ifx_pm_s2ram_warm_boot) {
+		ifx_pm_s2ram_warm_boot = false;
+		atomic_inc(&ifx_pm_warm_boot_gen);
+#if !defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+		ifx_pm_warm_boot_reinit_all();
+#endif
+	}
+#endif /* IFX_PM_WARM_BOOT */
 }
 
 static int ifx_pm_init(void)
 {
-#if defined(CONFIG_SOC_SERIES_PSE84)
+#if defined(IFX_PM_VARIANT_CM55)
+	/*
+	 * On the CM55 the PDL services these calls directly (no SRF relay), so
+	 * configure the default DeepSleep modes once here at init rather than
+	 * from the application.  Keeping the APP CPU domain in regular DeepSleep
+	 * (not OFF) retains this core across a DeepSleep so it wakes on any
+	 * enabled interrupt; the whole-SoC DeepSleep-OFF is driven from the
+	 * CM33-NS side.
+	 */
+	Cy_SysPm_DeepSleepSetup(CY_SYSPM_MODE_DEEPSLEEP);
+
 	/* System Domain Idle Power Mode Configuration */
 	Cy_SysPm_SetDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);
+
+	/* APP CPU Domain Idle Power Mode Configuration */
+	Cy_SysPm_SetAppDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);
 
 	/* SoCMEM Idle Power Mode Configuration */
 	Cy_SysPm_SetSOCMEMDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);

--- a/soc/infineon/edge/pse84/power.h
+++ b/soc/infineon/edge/pse84/power.h
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief Infineon PSOC Edge power management interface.
+ */
+
+#ifndef ZEPHYR_SOC_INFINEON_EDGE_PSE84_POWER_H_
+#define ZEPHYR_SOC_INFINEON_EDGE_PSE84_POWER_H_
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/device.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/pm/policy.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Block the CPU-gating low-power states around a critical section.
+ *
+ * Holds a Zephyr PM-policy lock on both deep states this SoC can enter from
+ * idle - DeepSleep (PM_STATE_SUSPEND_TO_IDLE) and DeepSleep-RAM
+ * (PM_STATE_SUSPEND_TO_RAM) - so that while the calling thread blocks (on a
+ * transfer-completion semaphore, a vendor deepsleep-lock section, a blocking
+ * IPC round-trip, etc.) the idle thread cannot let the policy gate the core
+ * mid-operation and drop the pending completion.  Only shallow runtime-idle
+ * (WFI, interrupts live) stays available for the duration.
+ *
+ * The locks are reference-counted, so nested and concurrent sections balance
+ * correctly; every ifx_pm_deepsleep_lock() must be paired with a matching
+ * ifx_pm_deepsleep_unlock().
+ */
+static inline void ifx_pm_deepsleep_lock(void)
+{
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+}
+
+/**
+ * @brief Release the lock taken by ifx_pm_deepsleep_lock().
+ *
+ * Releases in reverse order of acquisition.
+ */
+static inline void ifx_pm_deepsleep_unlock(void)
+{
+	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+}
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+/**
+ * @brief Re-establish the CM55 SRF/IPC client after a DeepSleep-RAM warm boot.
+ *
+ * DeepSleep-RAM power-cycles this core: it resumes from retained RAM without
+ * re-running soc_early_init_hook(), so its SRF client still references the
+ * IPC/SRF endpoint published before sleep.  Meanwhile the CM33 secure image
+ * cold-boots and republishes that endpoint.  The stale client would fault on
+ * the first secure request (a PPC-secured clock/PDL call relayed over IPC), so
+ * the SoC power resume path calls this to re-run the SRF portion of the SoC
+ * bring-up and re-synchronize the client with the freshly published endpoint.
+ *
+ * Must be called in thread context (interrupts enabled, scheduler running): the
+ * IPC handle handshake blocks on a secure-core semaphore.
+ */
+void ifx_soc_srf_client_reinit(void);
+#endif /* CONFIG_PM_S2RAM && CONFIG_PSOC_EDGE_M55_SRF_SUPPORT */
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+/**
+ * @brief Eagerly rebuild every device after a DeepSleep-RAM warm boot.
+ *
+ * Walks every device in link (initialization) order and invokes its
+ * PM_DEVICE_ACTION_TURN_ON handler, restoring all peripherals in a single
+ * up-front pass.  DeepSleep-RAM power-cycles the peripheral domain, so after a
+ * warm boot every peripheral has lost its hardware state; the application calls
+ * this from thread context, once it is running again, to restore them.
+ *
+ * Must be called from thread context on SRF builds: each TURN_ON handler relays
+ * to the secure core over blocking IPC, so this re-establishes the SRF client
+ * first and serializes the walk under the PM-policy lock.  A device with no
+ * PM_DEVICE_ACTION_TURN_ON handler is skipped.
+ */
+void ifx_pm_warm_boot_reinit_all(void);
+#else
+static inline void ifx_pm_warm_boot_reinit_all(void)
+{
+}
+#endif /* CONFIG_PM_S2RAM && CONFIG_PM_DEVICE */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_SOC_INFINEON_EDGE_PSE84_POWER_H_ */

--- a/soc/infineon/edge/pse84/power.h
+++ b/soc/infineon/edge/pse84/power.h
@@ -1,0 +1,176 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief Infineon PSOC Edge power management interface.
+ */
+
+#ifndef ZEPHYR_SOC_INFINEON_EDGE_PSE84_POWER_H_
+#define ZEPHYR_SOC_INFINEON_EDGE_PSE84_POWER_H_
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/device.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/pm/policy.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Block the CPU-gating low-power states around a critical section.
+ *
+ * Holds a Zephyr PM-policy lock on both deep states this SoC can enter from
+ * idle - DeepSleep (PM_STATE_SUSPEND_TO_IDLE) and DeepSleep-RAM
+ * (PM_STATE_SUSPEND_TO_RAM) - so that while the calling thread blocks (on a
+ * transfer-completion semaphore, a vendor deepsleep-lock section, a blocking
+ * IPC round-trip, etc.) the idle thread cannot let the policy gate the core
+ * mid-operation and drop the pending completion.  Only shallow runtime-idle
+ * (WFI, interrupts live) stays available for the duration.
+ *
+ * The locks are reference-counted, so nested and concurrent sections balance
+ * correctly; every ifx_pm_deepsleep_lock() must be paired with a matching
+ * ifx_pm_deepsleep_unlock().
+ */
+static inline void ifx_pm_deepsleep_lock(void)
+{
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+}
+
+/**
+ * @brief Release the lock taken by ifx_pm_deepsleep_lock().
+ *
+ * Releases in reverse order of acquisition.
+ */
+static inline void ifx_pm_deepsleep_unlock(void)
+{
+	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+}
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+/**
+ * @brief Re-establish the CM55 SRF/IPC client after a DeepSleep-RAM warm boot.
+ *
+ * DeepSleep-RAM power-cycles this core: it resumes from retained RAM without
+ * re-running soc_early_init_hook(), so its SRF client still references the
+ * IPC/SRF endpoint published before sleep.  Meanwhile the CM33 secure image
+ * cold-boots and republishes that endpoint.  The stale client would fault on
+ * the first secure request (a PPC-secured clock/PDL call relayed over IPC), so
+ * the SoC power resume path calls this to re-run the SRF portion of the SoC
+ * bring-up and re-synchronize the client with the freshly published endpoint.
+ *
+ * Must be called in thread context (interrupts enabled, scheduler running): the
+ * IPC handle handshake blocks on a secure-core semaphore.
+ */
+void ifx_soc_srf_client_reinit(void);
+#endif /* CONFIG_PM_S2RAM && CONFIG_PSOC_EDGE_M55_SRF_SUPPORT */
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+/**
+ * @brief Lazily rebuild a device after a DeepSleep-RAM warm boot.
+ *
+ * DS-RAM power-cycles the peripheral domain, so after a warm boot every
+ * peripheral has lost its hardware state and must be rebuilt.  Rather than
+ * rebuild everything up front from a worker - which races the already-runnable
+ * application thread the moment a re-init relay blocks on the secure core - each
+ * driver rebuilds itself lazily, on its first use after the warm boot, from the
+ * thread that is about to use it.  Because the consuming thread performs (and
+ * blocks on) its own re-init, there is no cross-thread race and no console
+ * corruption.
+ *
+ * The SoC bumps an internal generation counter once per genuine warm boot.  The
+ * driver stores the generation it last rebuilt at in its (retained) driver data
+ * and passes a pointer to it here; the counters differ only on the first call
+ * after a warm boot, which is when the rebuild runs.  On that call this
+ * re-establishes the SRF client (once per generation) and then invokes the
+ * device's PM_DEVICE_ACTION_TURN_ON handler.
+ *
+ * Must be called in thread context - the rebuild relays over blocking IPC.  When
+ * called from an ISR it is a no-op (returns false) and the device is left stale
+ * until a thread-context caller rebuilds it.  The caller must serialize
+ * concurrent calls for the same device (drivers do this with their existing
+ * per-device lock; the console is single-threaded during recovery).
+ *
+ * @param dev      Device to rebuild.
+ * @param last_gen Pointer to the driver's stored warm-boot generation.
+ * @return true if a rebuild was performed, false otherwise.
+ */
+bool ifx_pm_warm_boot_reinit(const struct device *dev, uint32_t *last_gen);
+
+/**
+ * @brief Eagerly rebuild every device after a DeepSleep-RAM warm boot.
+ *
+ * Walks every device in link (initialization) order and invokes its
+ * PM_DEVICE_ACTION_TURN_ON handler, restoring all peripherals in a single
+ * up-front pass rather than lazily on first use (see ifx_pm_warm_boot_reinit()).
+ * Intended for an application that wants to force a full peripheral restore
+ * after a warm boot instead of relying on the per-driver lazy path.
+ *
+ * Must be called from thread context on SRF builds: each TURN_ON handler relays
+ * to the secure core over blocking IPC, so this re-establishes the SRF client
+ * first and serializes the walk under the PM-policy lock.  A device with no
+ * PM_DEVICE_ACTION_TURN_ON handler is skipped.
+ */
+void ifx_pm_warm_boot_reinit_all(void);
+#else
+static inline bool ifx_pm_warm_boot_reinit(const struct device *dev, uint32_t *last_gen)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(last_gen);
+	return false;
+}
+
+static inline void ifx_pm_warm_boot_reinit_all(void)
+{
+}
+#endif /* CONFIG_PM_S2RAM && CONFIG_PM_DEVICE */
+
+#if defined(CONFIG_POWEROFF) && defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+/**
+ * @brief Release the Hibernate I/O freeze and arm a Hibernate wakeup source.
+ *
+ * Both Cy_SysPm_IoUnfreeze() (release the freeze latched on the previous
+ * Hibernate wakeup) and Cy_SysPm_SetHibernateWakeupSource() (arm the source for
+ * the next Hibernate) write SRSS registers that are PPC-secured on this SoC and
+ * bus-fault from a non-secure core.  This relays the combined operation to the
+ * secure image over the Secure Request Framework (SRF), so the application does
+ * not need to know whether the platform provides a secure relay.
+ *
+ * Must be called in thread context (interrupts enabled, scheduler running): the
+ * SRF/IPC round-trip completes on an IPC interrupt and blocks on an RTOS
+ * semaphore.
+ *
+ * @param wakeup_source Hibernate wakeup source(s) to arm, using the
+ *                      CY_SYSPM_HIBERNATE_* encoding of
+ *                      Cy_SysPm_SetHibernateWakeupSource().
+ * @return 0 on success, -EIO if the secure request failed.
+ */
+int ifx_pse84_hibernate_wake_prepare(uint32_t wakeup_source);
+#else
+/**
+ * @brief Stub for platforms with no secure relay for the operation.
+ *
+ * @return -ENOTSUP always; the secure boot code performs the equivalent
+ *         unfreeze/wakeup-source setup itself on these platforms.
+ */
+static inline int ifx_pse84_hibernate_wake_prepare(uint32_t wakeup_source)
+{
+	ARG_UNUSED(wakeup_source);
+	return -ENOTSUP;
+}
+#endif /* CONFIG_POWEROFF && CONFIG_PSOC_EDGE_M55_SRF_SUPPORT */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_SOC_INFINEON_EDGE_PSE84_POWER_H_ */

--- a/soc/infineon/edge/pse84/poweroff.c
+++ b/soc/infineon/edge/pse84/poweroff.c
@@ -1,19 +1,180 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys/poweroff.h>
 #include <zephyr/toolchain.h>
+#include <zephyr/logging/log.h>
 
+#include <errno.h>
+#include <string.h>
+
+#include <cy_pdl.h>
 #include <cy_syspm.h>
+
+LOG_MODULE_REGISTER(soc_poweroff, CONFIG_SOC_LOG_LEVEL);
+
+#if defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+#include <cy_syspm_srf.h>
+#include <mtb_srf_pool.h>
+
+/*
+ * Mirror of the PDL's private status output struct (cy_syspm_v4.c). The
+ * secure SysPm operations return a single cy_en_syspm_status_t value.
+ */
+struct ifx_syspm_srf_status_out {
+	cy_en_syspm_status_t ret_val;
+};
+
+/*
+ * Mirror of the PDL's private input struct for CY_PDL_SYSPM_OP_HIBWAKEPREP
+ * (cy_syspm_v4.c). The secure handler expects a single wakeup-source word.
+ */
+struct ifx_syspm_srf_hibwakeprep_in {
+	uint32_t wakeup_source;
+};
+
+/*
+ * Enter hibernate from the CM55 non-secure core.
+ *
+ * The PDL compiles the SRF relay out of Cy_SysPm_SystemEnterHibernate()
+ * for CM55 (guarded by !(CY_CPU_CORTEX_M55)), so the stock call writes
+ * SRSS_PWR_HIBERNATE directly and bus-faults from the non-secure core.
+ * The secure image already registers the hibernate operation
+ * (CY_PDL_SYSPM_OP_SYSTEMENTERHIBERNATE), so invoke it over the SRF
+ * directly - the same relay the PDL uses for the other cores.
+ */
+static cy_en_syspm_status_t ifx_cm55_enter_hibernate_srf(void)
+{
+	mtb_srf_invec_ns_t *in_vec = NULL;
+	mtb_srf_outvec_ns_t *out_vec = NULL;
+	mtb_srf_output_ns_t *output = NULL;
+	struct ifx_syspm_srf_status_out output_args = {
+		.ret_val = CY_SYSPM_FAIL,
+	};
+	cy_rslt_t result;
+
+	result = mtb_srf_pool_allocate(&cy_pdl_srf_default_pool, &in_vec, &out_vec,
+				       CY_PDL_SYSPM_SRF_POOL_TIMEOUT);
+	if (result != CY_RSLT_SUCCESS) {
+		return CY_SYSPM_FAIL;
+	}
+
+	cy_pdl_invoke_srf_args invoke_args = {
+		.inVec = in_vec,
+		.outVec = out_vec,
+		.output_ptr = &output,
+		.op_id = (uint8_t)CY_PDL_SYSPM_OP_SYSTEMENTERHIBERNATE,
+		.submodule_id = CY_PDL_SECURE_SUBMODULE_SYSPM,
+		.base = NULL,
+		.sub_block = 0UL,
+		.input_base = NULL,
+		.input_len = 0UL,
+		.output_base = (uint8_t *)&output_args,
+		.output_len = sizeof(output_args),
+		.invec_bases = NULL,
+		.invec_sizes = 0UL,
+		.outvec_bases = NULL,
+		.outvec_sizes = 0UL,
+	};
+
+	result = _Cy_PDL_Invoke_SRF(&invoke_args);
+	if ((result == CY_RSLT_SUCCESS) && (output != NULL)) {
+		memcpy(&output_args, &output->output_values[0], sizeof(output_args));
+	}
+
+	(void)mtb_srf_pool_free(&cy_pdl_srf_default_pool, in_vec, out_vec);
+
+	return (result == CY_RSLT_SUCCESS) ? output_args.ret_val : CY_SYSPM_FAIL;
+}
+
+/*
+ * Release the Hibernate I/O freeze and arm a Hibernate wakeup source from a
+ * non-secure core.  Both Cy_SysPm_IoUnfreeze() and
+ * Cy_SysPm_SetHibernateWakeupSource() write PPC-secured SRSS registers that
+ * bus-fault from a non-secure core and have no stock SRF relay, so invoke the
+ * combined secure operation (CY_PDL_SYSPM_OP_HIBWAKEPREP) over the SRF - the
+ * same relay used above for the Hibernate-entry operation.  Runs in thread
+ * context; the SRF round-trip completes on an IPC interrupt.
+ */
+int ifx_pse84_hibernate_wake_prepare(uint32_t wakeup_source)
+{
+	mtb_srf_invec_ns_t *in_vec = NULL;
+	mtb_srf_outvec_ns_t *out_vec = NULL;
+	mtb_srf_output_ns_t *output = NULL;
+	struct ifx_syspm_srf_hibwakeprep_in input_args = {
+		.wakeup_source = wakeup_source,
+	};
+	cy_rslt_t result;
+
+	result = mtb_srf_pool_allocate(&cy_pdl_srf_default_pool, &in_vec, &out_vec,
+				       CY_PDL_SYSPM_SRF_POOL_TIMEOUT);
+	if (result != CY_RSLT_SUCCESS) {
+		return -EIO;
+	}
+
+	cy_pdl_invoke_srf_args invoke_args = {
+		.inVec = in_vec,
+		.outVec = out_vec,
+		.output_ptr = &output,
+		.op_id = (uint8_t)CY_PDL_SYSPM_OP_HIBWAKEPREP,
+		.submodule_id = CY_PDL_SECURE_SUBMODULE_SYSPM,
+		.base = NULL,
+		.sub_block = 0UL,
+		.input_base = (uint8_t *)&input_args,
+		.input_len = sizeof(input_args),
+		.output_base = NULL,
+		.output_len = 0UL,
+		.invec_bases = NULL,
+		.invec_sizes = 0UL,
+		.outvec_bases = NULL,
+		.outvec_sizes = 0UL,
+	};
+
+	result = _Cy_PDL_Invoke_SRF(&invoke_args);
+
+	(void)mtb_srf_pool_free(&cy_pdl_srf_default_pool, in_vec, out_vec);
+
+	return (result == CY_RSLT_SUCCESS) ? 0 : -EIO;
+}
+#endif /* CONFIG_PSOC_EDGE_M55_SRF_SUPPORT */
 
 void z_sys_poweroff(void)
 {
-	Cy_SysPm_SystemEnterHibernate();
+	cy_en_syspm_status_t status;
 
-	CODE_UNREACHABLE;
+#if defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+	/*
+	 * sys_poweroff() masks interrupts before calling us, but the SRF
+	 * round-trip to the secure image completes on an IPC interrupt and
+	 * blocks on an RTOS semaphore. Re-enable interrupts so that ISR can
+	 * run: on this path the chip is about to hibernate, so there is
+	 * nothing left to protect from preemption.
+	 */
+	irq_unlock(0);
+
+	status = ifx_cm55_enter_hibernate_srf();
+#else
+	status = Cy_SysPm_SystemEnterHibernate();
+#endif
+
+	/*
+	 * A successful hibernate request never returns - the system powers down.
+	 * Reaching here means the request failed (the secure relay rejected it,
+	 * or the direct PDL call could not enter hibernate), which is
+	 * unrecoverable. z_sys_poweroff() is FUNC_NORETURN, so log the failure
+	 * and spin with interrupts masked instead of returning into an undefined
+	 * state.
+	 */
+	LOG_ERR("Hibernate entry failed (status %d); halting", (int)status);
+
+	(void)irq_lock();
+	for (;;) {
+		__WFI();
+	}
 }

--- a/soc/infineon/edge/pse84/poweroff.c
+++ b/soc/infineon/edge/pse84/poweroff.c
@@ -1,19 +1,251 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/irq.h>
 #include <zephyr/sys/poweroff.h>
 #include <zephyr/toolchain.h>
+#include <zephyr/logging/log.h>
 
+#include <errno.h>
+#include <string.h>
+
+#include <cy_pdl.h>
 #include <cy_syspm.h>
+
+LOG_MODULE_REGISTER(soc_poweroff, CONFIG_SOC_LOG_LEVEL);
+
+#if defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+#include <cy_syspm_srf.h>
+#include <mtb_srf_pool.h>
+
+/*
+ * Mirror of the PDL's private status output struct (cy_syspm_v4.c). The
+ * secure SysPm operations return a single cy_en_syspm_status_t value.
+ */
+struct ifx_syspm_srf_status_out {
+	cy_en_syspm_status_t ret_val;
+};
+
+/*
+ * Mirror of the PDL's private input struct for CY_PDL_SYSPM_OP_HIBWAKEPREP
+ * (cy_syspm_v4.c). The secure handler expects a single wakeup-source word.
+ */
+struct ifx_syspm_srf_hibwakeprep_in {
+	uint32_t wakeup_source;
+};
+
+/*
+ * Enter hibernate from the CM55 non-secure core.
+ *
+ * The PDL compiles the SRF relay out of Cy_SysPm_SystemEnterHibernate()
+ * for CM55 (guarded by !(CY_CPU_CORTEX_M55)), so the stock call writes
+ * SRSS_PWR_HIBERNATE directly and bus-faults from the non-secure core.
+ * The secure image already registers the hibernate operation
+ * (CY_PDL_SYSPM_OP_SYSTEMENTERHIBERNATE), so invoke it over the SRF
+ * directly - the same relay the PDL uses for the other cores.
+ */
+static cy_en_syspm_status_t ifx_cm55_enter_hibernate_srf(void)
+{
+	mtb_srf_invec_ns_t *in_vec = NULL;
+	mtb_srf_outvec_ns_t *out_vec = NULL;
+	mtb_srf_output_ns_t *output = NULL;
+	struct ifx_syspm_srf_status_out output_args = {
+		.ret_val = CY_SYSPM_FAIL,
+	};
+	cy_rslt_t result;
+
+	result = mtb_srf_pool_allocate(&cy_pdl_srf_default_pool, &in_vec, &out_vec,
+				       CY_PDL_SYSPM_SRF_POOL_TIMEOUT);
+	if (result != CY_RSLT_SUCCESS) {
+		return CY_SYSPM_FAIL;
+	}
+
+	cy_pdl_invoke_srf_args invoke_args = {
+		.inVec = in_vec,
+		.outVec = out_vec,
+		.output_ptr = &output,
+		.op_id = (uint8_t)CY_PDL_SYSPM_OP_SYSTEMENTERHIBERNATE,
+		.submodule_id = CY_PDL_SECURE_SUBMODULE_SYSPM,
+		.base = NULL,
+		.sub_block = 0UL,
+		.input_base = NULL,
+		.input_len = 0UL,
+		.output_base = (uint8_t *)&output_args,
+		.output_len = sizeof(output_args),
+		.invec_bases = NULL,
+		.invec_sizes = 0UL,
+		.outvec_bases = NULL,
+		.outvec_sizes = 0UL,
+	};
+
+	result = _Cy_PDL_Invoke_SRF(&invoke_args);
+	if ((result == CY_RSLT_SUCCESS) && (output != NULL)) {
+		memcpy(&output_args, &output->output_values[0], sizeof(output_args));
+	}
+
+	(void)mtb_srf_pool_free(&cy_pdl_srf_default_pool, in_vec, out_vec);
+
+	return (result == CY_RSLT_SUCCESS) ? output_args.ret_val : CY_SYSPM_FAIL;
+}
+
+/*
+ * Release the Hibernate I/O freeze and arm a Hibernate wakeup source from a
+ * non-secure core.  Both Cy_SysPm_IoUnfreeze() and
+ * Cy_SysPm_SetHibernateWakeupSource() write PPC-secured SRSS registers that
+ * bus-fault from a non-secure core and have no stock SRF relay, so invoke the
+ * combined secure operation (CY_PDL_SYSPM_OP_HIBWAKEPREP) over the SRF - the
+ * same relay used above for the Hibernate-entry operation.  Runs in thread
+ * context; the SRF round-trip completes on an IPC interrupt.
+ */
+static int ifx_hib_wake_prepare_srf(uint32_t wakeup_source)
+{
+	mtb_srf_invec_ns_t *in_vec = NULL;
+	mtb_srf_outvec_ns_t *out_vec = NULL;
+	mtb_srf_output_ns_t *output = NULL;
+	struct ifx_syspm_srf_hibwakeprep_in input_args = {
+		.wakeup_source = wakeup_source,
+	};
+	cy_rslt_t result;
+
+	result = mtb_srf_pool_allocate(&cy_pdl_srf_default_pool, &in_vec, &out_vec,
+				       CY_PDL_SYSPM_SRF_POOL_TIMEOUT);
+	if (result != CY_RSLT_SUCCESS) {
+		return -EIO;
+	}
+
+	cy_pdl_invoke_srf_args invoke_args = {
+		.inVec = in_vec,
+		.outVec = out_vec,
+		.output_ptr = &output,
+		.op_id = (uint8_t)CY_PDL_SYSPM_OP_HIBWAKEPREP,
+		.submodule_id = CY_PDL_SECURE_SUBMODULE_SYSPM,
+		.base = NULL,
+		.sub_block = 0UL,
+		.input_base = (uint8_t *)&input_args,
+		.input_len = sizeof(input_args),
+		.output_base = NULL,
+		.output_len = 0UL,
+		.invec_bases = NULL,
+		.invec_sizes = 0UL,
+		.outvec_bases = NULL,
+		.outvec_sizes = 0UL,
+	};
+
+	result = _Cy_PDL_Invoke_SRF(&invoke_args);
+
+	(void)mtb_srf_pool_free(&cy_pdl_srf_default_pool, in_vec, out_vec);
+
+	return (result == CY_RSLT_SUCCESS) ? 0 : -EIO;
+}
+
+#if DT_HAS_COMPAT_STATUS_OKAY(infineon_hibernate_wakeup)
+
+#define IFX_HIB_WAKEUP_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(infineon_hibernate_wakeup)
+
+/*
+ * Build the Hibernate wakeup-source mask from the infineon,hibernate-wakeup
+ * devicetree node.
+ */
+static uint32_t ifx_hib_wakeup_source_mask(void)
+{
+	uint32_t src = 0U;
+
+#if DT_NODE_HAS_PROP(IFX_HIB_WAKEUP_NODE, wakeup_pin0_trigger)
+	src |= (DT_ENUM_IDX(IFX_HIB_WAKEUP_NODE, wakeup_pin0_trigger) == 0)
+		       ? CY_SYSPM_HIBERNATE_PIN0_LOW
+		       : CY_SYSPM_HIBERNATE_PIN0_HIGH;
+#endif
+#if DT_NODE_HAS_PROP(IFX_HIB_WAKEUP_NODE, wakeup_pin1_trigger)
+	src |= (DT_ENUM_IDX(IFX_HIB_WAKEUP_NODE, wakeup_pin1_trigger) == 0)
+		       ? CY_SYSPM_HIBERNATE_PIN1_LOW
+		       : CY_SYSPM_HIBERNATE_PIN1_HIGH;
+#endif
+#if DT_NODE_HAS_PROP(IFX_HIB_WAKEUP_NODE, wakeup_lpcomp0_trigger)
+	src |= (DT_ENUM_IDX(IFX_HIB_WAKEUP_NODE, wakeup_lpcomp0_trigger) == 0)
+		       ? CY_SYSPM_HIBERNATE_LPCOMP0_LOW
+		       : CY_SYSPM_HIBERNATE_LPCOMP0_HIGH;
+#endif
+#if DT_NODE_HAS_PROP(IFX_HIB_WAKEUP_NODE, wakeup_lpcomp1_trigger)
+	src |= (DT_ENUM_IDX(IFX_HIB_WAKEUP_NODE, wakeup_lpcomp1_trigger) == 0)
+		       ? CY_SYSPM_HIBERNATE_LPCOMP1_LOW
+		       : CY_SYSPM_HIBERNATE_LPCOMP1_HIGH;
+#endif
+#if DT_PROP(IFX_HIB_WAKEUP_NODE, wakeup_wdt)
+	src |= CY_SYSPM_HIBERNATE_WDT;
+#endif
+#if DT_PROP(IFX_HIB_WAKEUP_NODE, wakeup_rtc_alarm)
+	src |= CY_SYSPM_HIBERNATE_RTC_ALARM;
+#endif
+
+	return src;
+}
+
+/*
+ * Release any Hibernate I/O freeze from a previous wake and arm the Hibernate
+ * wakeup source(s) described by the infineon,hibernate-wakeup devicetree node.
+ * On the non-secure CM55 both the unfreeze and the wakeup-source write target
+ * PPC-secured SRSS registers, so the combined HIBWAKEPREP secure operation
+ * performs them over the SRF.  Runs in thread context (POST_KERNEL or later,
+ * once the kernel is alive) so the blocking SRF round-trip can complete.
+ */
+static int ifx_hib_wakeup_arm(void)
+{
+	uint32_t src = ifx_hib_wakeup_source_mask();
+	int ret;
+
+	if (src == 0U) {
+		return 0;
+	}
+
+	ret = ifx_hib_wake_prepare_srf(src);
+	if (ret != 0) {
+		LOG_WRN("Hibernate wakeup source arm failed (%d)", ret);
+	}
+
+	return 0;
+}
+
+SYS_INIT(ifx_hib_wakeup_arm, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(infineon_hibernate_wakeup) */
+#endif /* CONFIG_PSOC_EDGE_M55_SRF_SUPPORT */
 
 void z_sys_poweroff(void)
 {
-	Cy_SysPm_SystemEnterHibernate();
+	cy_en_syspm_status_t status;
 
-	CODE_UNREACHABLE;
+#if defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
+	/*
+	 * sys_poweroff() masks interrupts before calling us, but the SRF
+	 * round-trip to the secure image completes on an IPC interrupt and
+	 * blocks on an RTOS semaphore. Re-enable interrupts so that ISR can
+	 * run: on this path the chip is about to hibernate, so there is
+	 * nothing left to protect from preemption.
+	 */
+	irq_unlock(0);
+
+	status = ifx_cm55_enter_hibernate_srf();
+#else
+	status = Cy_SysPm_SystemEnterHibernate();
+#endif
+
+	/*
+	 * A successful hibernate request never returns - the system powers down.
+	 * Reaching here means the request failed (the secure relay rejected it,
+	 * or the direct PDL call could not enter hibernate), which is
+	 * unrecoverable. z_sys_poweroff() is FUNC_NORETURN, so log the failure
+	 * and spin with interrupts masked instead of returning into an undefined
+	 * state.
+	 */
+	LOG_ERR("Hibernate entry failed (status %d); halting", (int)status);
+
+	(void)irq_lock();
+	for (;;) {
+		__WFI();
+	}
 }

--- a/soc/infineon/edge/pse84/security_config/pse84_boot.c
+++ b/soc/infineon/edge/pse84/security_config/pse84_boot.c
@@ -1,15 +1,47 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "pse84_boot.h"
 
+#include <zephyr/drivers/timer/system_timer.h>
+
+/*
+ * Deep-sleep mode selection for the CM33 secure app.
+ *
+ * The app configures the system-domain deep-sleep mode and then parks the
+ * CM33 in WFI so that both cores always enter the selected mode.
+ * The selector is manual rather than a Kconfig option to avoid build-time coupling.
+ * Building a custom low-power flow can be done by setting DEEPSLEEP_MODE to:
+ *   PM_MODE_DS     - regular DeepSleep (all retained)
+ *   PM_MODE_DS_RAM - DeepSleep-RAM (SOCMEM in retention, RAM preserved, cold boot)
+ *   PM_MODE_DS_OFF - DeepSleep-OFF (SOCMEM powered off, cold boot)
+ */
+
+/* Deep sleep modes */
+#define PM_MODE_DS     0
+#define PM_MODE_DS_RAM 1
+#define PM_MODE_DS_OFF 2
+#define DEEPSLEEP_MODE PM_MODE_DS
+
+#if (DEEPSLEEP_MODE == PM_MODE_DS)
+#define DEEPSLEEP_MODE_ENUM CY_SYSPM_MODE_DEEPSLEEP
+#elif (DEEPSLEEP_MODE == PM_MODE_DS_RAM)
+#define DEEPSLEEP_MODE_ENUM CY_SYSPM_MODE_DEEPSLEEP_RAM
+#elif (DEEPSLEEP_MODE == PM_MODE_DS_OFF)
+#define DEEPSLEEP_MODE_ENUM CY_SYSPM_MODE_DEEPSLEEP_OFF
+#endif
+
 #if defined(CONFIG_SOC_PSE84_M55_ENABLE)
 void ifx_pse84_cm55_startup(void)
 {
+	/* The IO-freeze bits are set by hardware on Hibernate/DS-OFF entry */
+	Cy_SysPm_DeepSleepIoUnfreeze();
+	Cy_SysPm_IoUnfreeze();
+
 	/* Setup System Control Block */
 	SysCtrlBlk_Setup();
 	/* Setup NS NVIC interrupts */
@@ -43,26 +75,52 @@ void ifx_pse84_cm55_startup(void)
 	/* Clear SYSCPU and APPCPU power domain dependency set by boot code */
 	cy_pd_pdcm_clear_dependency(CY_PD_PDCM_APPCPU, CY_PD_PDCM_SYSCPU);
 
+#if (DEEPSLEEP_MODE != PM_MODE_DS)
+	/* DS-RAM and DS-OFF both require SOCMEM to be independent of SYSCPU so
+	 * the power controller can place SOCMEM into retention (DS-RAM) or power
+	 * it off (DS-OFF) without the SYSCPU domain holding it up.
+	 */
+	cy_pd_pdcm_clear_dependency(CY_PD_PDCM_SOCMEM, CY_PD_PDCM_SYSCPU);
+#endif
+
 	uint32_t cm55_start_address = DT_REG_ADDR(DT_NODELABEL(m55_xip));
 
 	/* Enable CM55 */
 	Cy_SysEnableCM55(MXCM55, cm55_start_address, CM55_BOOT_WAIT_TIME_USEC);
 
 	/* System Domain Idle Power Mode Configuration */
-	Cy_SysPm_SetDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);
+	Cy_SysPm_SetDeepSleepMode(DEEPSLEEP_MODE_ENUM);
+	Cy_SysPm_SetAppDeepSleepMode(DEEPSLEEP_MODE_ENUM);
+	Cy_SysPm_SetSOCMEMDeepSleepMode(DEEPSLEEP_MODE_ENUM);
 
-	/* SoCMEM Idle Power Mode Configuration */
-	Cy_SysPm_SetSOCMEMDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);
+#if (DEEPSLEEP_MODE == PM_MODE_DS_OFF)
+	/* TOKEN must be before PPC configuration */
+	SRSS_PWR_HIBERNATE |= (uint32_t)CY_SYSLIB_DEEP_SLEEP_OFF_TOKEN;
+#endif
 
 	/* Configure Peripheral Protection Controller for Non-Secure */
 	cy_ppc0_init();
 	cy_ppc1_init();
 
-#ifdef CONFIG_CORTEX_M_SYSTICK
-	sys_clock_disable();
+	/* Manually set DeepSleep configuration to avoid SRF dependency */
+	SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+	__DSB();
+
+#if (DEEPSLEEP_MODE != PM_MODE_DS)
+	/* FPU must be power-gated for DS-RAM/DS-OFF entry */
+	SCS_CPPWR |= SCS_ENABLE_CPPWR_SU10_SU11;
+	SCB->CPACR &= ~SCB_ENABLE_CPACR_CP10_CP11;
+	__DSB();
 #endif
 
+	/* Stop the SysTick so its per-tick interrupt does not wake the core out
+	 * of the deep-sleep the park loop below is trying to hold.
+	 */
+	sys_clock_disable();
+
+	/* Enter the configured deep-sleep mode (DS by default) */
 	for (;;) {
+		__WFI();
 	}
 }
 #endif

--- a/soc/infineon/edge/pse84/security_config/pse84_boot.c
+++ b/soc/infineon/edge/pse84/security_config/pse84_boot.c
@@ -1,15 +1,45 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "pse84_boot.h"
 
+/*
+ * Deep-sleep mode selection for the CM33 secure app.
+ *
+ * The app configures the system-domain deep-sleep mode and then parks the
+ * CM33 in WFI so that both cores always enter the selected mode.
+ * The selector is manual rather than a Kconfig option to avoid build-time coupling.
+ * Building a custom low-power flow can be done by setting DEEPSLEEP_MODE to:
+ *   PM_MODE_DS     - regular DeepSleep (all retained)
+ *   PM_MODE_DS_RAM - DeepSleep-RAM (SOCMEM in retention, RAM preserved, cold boot)
+ *   PM_MODE_DS_OFF - DeepSleep-OFF (SOCMEM powered off, cold boot)
+ */
+
+/* Deep sleep modes */
+#define PM_MODE_DS     0
+#define PM_MODE_DS_RAM 1
+#define PM_MODE_DS_OFF 2
+#define DEEPSLEEP_MODE PM_MODE_DS
+
+#if (DEEPSLEEP_MODE == PM_MODE_DS)
+#define DEEPSLEEP_MODE_ENUM CY_SYSPM_MODE_DEEPSLEEP
+#elif (DEEPSLEEP_MODE == PM_MODE_DS_RAM)
+#define DEEPSLEEP_MODE_ENUM CY_SYSPM_MODE_DEEPSLEEP_RAM
+#elif (DEEPSLEEP_MODE == PM_MODE_DS_OFF)
+#define DEEPSLEEP_MODE_ENUM CY_SYSPM_MODE_DEEPSLEEP_OFF
+#endif
+
 #if defined(CONFIG_SOC_PSE84_M55_ENABLE)
 void ifx_pse84_cm55_startup(void)
 {
+	/* The IO-freeze bits are set by hardware on Hibernate/DS-OFF entry */
+	Cy_SysPm_DeepSleepIoUnfreeze();
+	Cy_SysPm_IoUnfreeze();
+
 	/* Setup System Control Block */
 	SysCtrlBlk_Setup();
 	/* Setup NS NVIC interrupts */
@@ -43,26 +73,47 @@ void ifx_pse84_cm55_startup(void)
 	/* Clear SYSCPU and APPCPU power domain dependency set by boot code */
 	cy_pd_pdcm_clear_dependency(CY_PD_PDCM_APPCPU, CY_PD_PDCM_SYSCPU);
 
+#if (DEEPSLEEP_MODE != PM_MODE_DS)
+	/* DS-RAM and DS-OFF both require SOCMEM to be independent of SYSCPU so
+	 * the power controller can place SOCMEM into retention (DS-RAM) or power
+	 * it off (DS-OFF) without the SYSCPU domain holding it up.
+	 */
+	cy_pd_pdcm_clear_dependency(CY_PD_PDCM_SOCMEM, CY_PD_PDCM_SYSCPU);
+#endif
+
 	uint32_t cm55_start_address = DT_REG_ADDR(DT_NODELABEL(m55_xip));
 
 	/* Enable CM55 */
 	Cy_SysEnableCM55(MXCM55, cm55_start_address, CM55_BOOT_WAIT_TIME_USEC);
 
 	/* System Domain Idle Power Mode Configuration */
-	Cy_SysPm_SetDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);
+	Cy_SysPm_SetDeepSleepMode(DEEPSLEEP_MODE_ENUM);
+	Cy_SysPm_SetAppDeepSleepMode(DEEPSLEEP_MODE_ENUM);
+	Cy_SysPm_SetSOCMEMDeepSleepMode(DEEPSLEEP_MODE_ENUM);
 
-	/* SoCMEM Idle Power Mode Configuration */
-	Cy_SysPm_SetSOCMEMDeepSleepMode(CY_SYSPM_MODE_DEEPSLEEP);
+#if (DEEPSLEEP_MODE == PM_MODE_DS_OFF)
+	/* TOKEN must be before PPC configuration */
+	SRSS_PWR_HIBERNATE |= (uint32_t)CY_SYSLIB_DEEP_SLEEP_OFF_TOKEN;
+#endif
 
 	/* Configure Peripheral Protection Controller for Non-Secure */
 	cy_ppc0_init();
 	cy_ppc1_init();
 
-#ifdef CONFIG_CORTEX_M_SYSTICK
-	sys_clock_disable();
+	/* Manually set DeepSleep configuration to avoid SRF dependency */
+	SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+	__DSB();
+
+#if (DEEPSLEEP_MODE != PM_MODE_DS)
+	/* FPU must be power-gated for DS-RAM/DS-OFF entry */
+	SCS_CPPWR |= SCS_ENABLE_CPPWR_SU10_SU11;
+	SCB->CPACR &= ~SCB_ENABLE_CPACR_CP10_CP11;
+	__DSB();
 #endif
 
+	/* Enter the configured deep-sleep mode (DS by default) */
 	for (;;) {
+		__WFI();
 	}
 }
 #endif

--- a/soc/infineon/edge/pse84/soc_pse84_m33_s.c
+++ b/soc/infineon/edge/pse84/soc_pse84_m33_s.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -88,6 +88,14 @@ void soc_early_init_hook(void)
 
 	/* Initializes the system */
 	SystemInit();
+
+	/*
+	 * On a wakeup from Hibernate the SRSS keeps the GPIOs frozen across the
+	 * cold reset until firmware releases them.
+	 */
+	if (Cy_SysPm_IoIsFrozen()) {
+		Cy_SysPm_IoUnfreeze();
+	}
 }
 
 void soc_late_init_hook(void)

--- a/soc/infineon/edge/pse84/soc_pse84_m55.c
+++ b/soc/infineon/edge/pse84/soc_pse84_m55.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -32,6 +32,15 @@
 #define CY_IPC_MAX_ENDPOINTS (8UL)
 #define PSE84_CPU_FREQ_HZ    DT_PROP(DT_PATH(cpus, cpu_1), clock_frequency)
 #define CM55_STARTUP_WAIT_MS 50U
+
+/*
+ * IPC pipe endpoint table consumed by Cy_IPC_Pipe_Config() during SoC
+ * bring-up.  Declared outside the SRF guard because both the SRF
+ * (pse84_srf_bringup()) and the non-SRF soc_early_init_hook() paths configure
+ * the IPC pipe.  The type comes from cy_pdl.h, which is included in every
+ * build.
+ */
+static cy_stc_ipc_pipe_ep_t system_ipc_pipe_ep_array[CY_IPC_MAX_ENDPOINTS];
 
 /* -------------------------------------------------------------------------- */
 /* CM55 SRF client                                                            */
@@ -148,6 +157,46 @@ static void pse84_srf_ipc_init(void)
 	}
 }
 
+/*
+ * Bring up the CM55 SRF/IPC client: initialize the IPC semaphore, the SRF
+ * request pool and the IPC/SRF client, publish the system clock and configure
+ * the IPC pipe.  Shared verbatim by the cold-boot path (soc_early_init_hook())
+ * and the DS-RAM warm-boot re-init (ifx_soc_srf_client_reinit()).  The caller
+ * owns any wait needed for the CM33 to publish its endpoint first.
+ */
+static void pse84_srf_bringup(void)
+{
+	Cy_IPC_Sema_Init(IPC0_SEMA_CH_NUM, 0, NULL);
+	pse84_srf_pool_init();
+	pse84_srf_ipc_init();
+
+	SystemCoreClockSetup(PSE84_CPU_FREQ_HZ, PSE84_CPU_FREQ_HZ);
+
+	Cy_IPC_Pipe_Config(system_ipc_pipe_ep_array);
+}
+
+#if defined(CONFIG_PM_S2RAM)
+void ifx_soc_srf_client_reinit(void)
+{
+	/*
+	 * DeepSleep-RAM warm-boot re-establishment of the CM55 SRF/IPC client.
+	 *
+	 * On DS-RAM the CM33 secure image cold-boots from scratch at the same time
+	 * this core resumes from retained RAM.  soc_early_init_hook() is not re-run
+	 * on the warm-boot path, so the SRF client, IPC handle and shared memory are
+	 * never re-synchronized with the freshly published CM33 endpoint and the
+	 * first secure request faults.  Re-run the same SRF bring-up the cold-boot
+	 * path uses to rebuild the client.  Runs in thread context, where the
+	 * blocking IPC handle handshake (mtb_ipc_get_handle) is allowed.
+	 *
+	 * No CM33 startup delay is needed here (unlike cold boot): by the time the
+	 * application reaches its post-wake resume the CM33 has long finished
+	 * booting, and mtb_ipc_get_handle() blocks until the CM33 endpoint is up.
+	 */
+	pse84_srf_bringup();
+}
+#endif /* CONFIG_PM_S2RAM */
+
 #endif /* CONFIG_PSOC_EDGE_M55_SRF_SUPPORT */
 
 /* -------------------------------------------------------------------------- */
@@ -156,8 +205,6 @@ static void pse84_srf_ipc_init(void)
 
 void soc_early_init_hook(void)
 {
-	static cy_stc_ipc_pipe_ep_t system_ipc_pipe_ep_array[CY_IPC_MAX_ENDPOINTS];
-
 	/* Enable Loop and branch info cache */
 	__DMB();
 	__ISB();
@@ -171,22 +218,17 @@ void soc_early_init_hook(void)
 	 */
 	Cy_SysLib_Delay(CM55_STARTUP_WAIT_MS);
 
-	/* Init is done on CM33 NS; this call only retrieves the configuration. */
-	Cy_IPC_Sema_Init(IPC0_SEMA_CH_NUM, 0, NULL);
-
-	pse84_srf_pool_init();
-	pse84_srf_ipc_init();
+	/* IPC semaphore, SRF pool/client, system clock and IPC pipe. */
+	pse84_srf_bringup();
 #else
 	/* Initializes the system */
 	ifx_cycfg_init();
-#endif
 
 	/* Initialize SystemCoreClock variable. */
 	SystemCoreClockSetup(PSE84_CPU_FREQ_HZ, PSE84_CPU_FREQ_HZ);
 
 	Cy_IPC_Pipe_Config(system_ipc_pipe_ep_array);
 
-#if !defined(CONFIG_PSOC_EDGE_M55_SRF_SUPPORT)
 	/*
 	 * Wait for the CM33 to finish configuring peripherals before the CM55
 	 * application proceeds.


### PR DESCRIPTION
* Added deepsleep-ram low power mode support to pse84
* Mapped DS-RAM to CM55 S2RAM
* Mapped DS-OFF to CM55 soft-off
* Updated hibernate soft-off to work in TF-M environment
* Updated CM33 stub to support Deepsleep modes
* Custom mtb_hal_syspm_lock/unlock_deepsleep implementation
* Added IPC channel for performing CM33 NS DeepSleep MBox
* Unfreeze frozen pins in CM33 secure flow
* Added SRF restoration routine in CM55 reset flow

Related PRs:
- https://github.com/zephyrproject-rtos/hal_infineon/pull/69
- https://github.com/zephyrproject-rtos/zephyr/pull/114224
- https://github.com/zephyrproject-rtos/zephyr/pull/114225