### PR TITLE
drivers: crypto: stm32_hash: add support for STM32H5

### DIFF
--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -65,6 +65,10 @@
 	};
 };
 
+&hash {
+	status = "okay";
+};
+
 &rng {
 	status = "okay";
 };

--- a/drivers/crypto/crypto_stm32_hash.c
+++ b/drivers/crypto/crypto_stm32_hash.c
@@ -105,6 +105,43 @@ static int stm32_hash_handler(struct hash_ctx *ctx, struct hash_pkt *pkt, bool f
 	status = HAL_HASH_Compute(&data->hhash, pkt->in_buf, pkt->in_len, pkt->out_buf,
 				  UINT32_MAX, &digest_size, HAL_MAX_DELAY);
 	UNUSED(digest_size);
+#elif defined(HAL_HASH_VERSION) && HAL_HASH_VERSION == 200
+	HASH_ConfigTypeDef hash_cfg = {
+		.DataType = HASH_BYTE_SWAP,
+	};
+
+	switch (session->algo) {
+	case CRYPTO_HASH_ALGO_SHA224:
+		hash_cfg.Algorithm = HASH_ALGOSELECTION_SHA224;
+		break;
+	case CRYPTO_HASH_ALGO_SHA256:
+		hash_cfg.Algorithm = HASH_ALGOSELECTION_SHA256;
+		break;
+#if DT_INST_PROP(0, st_has_sha384_algorithm)
+	case CRYPTO_HASH_ALGO_SHA384:
+		hash_cfg.Algorithm = HASH_ALGOSELECTION_SHA384;
+		break;
+#endif /* DT_INST_PROP(0, st_has_sha384_algorithm) */
+#if DT_INST_PROP(0, st_has_sha512_algorithm)
+	case CRYPTO_HASH_ALGO_SHA512:
+		hash_cfg.Algorithm = HASH_ALGOSELECTION_SHA512;
+		break;
+#endif /* DT_INST_PROP(0, st_has_sha512_algorithm) */
+	default:
+		k_sem_give(&data->device_sem);
+		LOG_ERR("Unsupported algorithm in handler: %d", session->algo);
+		return -ENOTSUP;
+	}
+
+	status = HAL_HASH_SetConfig(&data->hhash, &hash_cfg);
+	if (status != HAL_OK) {
+		k_sem_give(&data->device_sem);
+		LOG_ERR("HAL_HASH_SetConfig failed: %d", status);
+		return -EIO;
+	}
+
+	status = HAL_HASH_Start(&data->hhash, pkt->in_buf, pkt->in_len, pkt->out_buf,
+				  HAL_MAX_DELAY);
 #else /* CONFIG_STM32_HAL2 */
 	switch (session->algo) {
 	case CRYPTO_HASH_ALGO_SHA224:
@@ -229,6 +266,12 @@ static int crypto_stm32_hash_init(const struct device *dev)
 	 * so don't bother configuring "DataType" here since
 	 * it will be overwritten later.
 	 */
+#elif defined(HAL_HASH_VERSION) && HAL_HASH_VERSION == 200
+	data->hhash.Instance = cfg->base;
+	if (HAL_HASH_Init(&data->hhash) != HAL_OK) {
+		LOG_ERR("Peripheral init error");
+		return -EIO;
+	}
 #else /* CONFIG_STM32_HAL2 */
 	data->hhash.Init.DataType = HASH_DATATYPE_8B;
 	if (HAL_HASH_Init(&data->hhash) != HAL_OK) {
@@ -249,6 +292,7 @@ static DEVICE_API(crypto, stm32_hash_funcs) = {
 static struct crypto_stm32_hash_data crypto_stm32_hash_dev_data = {0};
 
 static const struct crypto_stm32_hash_config crypto_stm32_hash_dev_config = {
+	.base = (void *)DT_INST_REG_ADDR(0),
 	.reset = RESET_DT_SPEC_INST_GET(0),
 	.pclken = STM32_DT_INST_CLOCK_INFO(0),
 };

--- a/drivers/crypto/crypto_stm32_hash_priv.h
+++ b/drivers/crypto/crypto_stm32_hash_priv.h
@@ -19,6 +19,7 @@ typedef HASH_HandleTypeDef	stm32_hash_handle_t;
 #define STM32_HASH_MAX_DIGEST_SIZE (32)
 
 struct crypto_stm32_hash_config {
+	HASH_TypeDef *base;
 	const struct reset_dt_spec reset;
 	struct stm32_pclken pclken;
 };

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -604,6 +604,15 @@
 			status = "disabled";
 		};
 
+		hash: crypto@420c0400 {
+			compatible = "st,stm32-hash";
+			reg = <0x420c0400 0x800>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
+			resets = <&rctl STM32_RESET(AHB2, 17)>;
+			interrupts = <117 0>;
+			status = "disabled";
+		};
+
 		rng: rng@420c0800 {
 			compatible = "st,stm32-rng";
 			reg = <0x420c0800 0x400>;

--- a/dts/arm/st/h5/stm32h523.dtsi
+++ b/dts/arm/st/h5/stm32h523.dtsi
@@ -93,6 +93,11 @@
 			st,adc-has-injected-support;
 			status = "disabled";
 		};
+
+		hash: crypto@420c0400 {
+			st,has-sha384-algorithm;
+			st,has-sha512-algorithm;
+		};
 	};
 };
 

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -553,6 +553,11 @@
 			};
 		};
 
+		hash: crypto@420c0400 {
+			st,has-sha384-algorithm;
+			st,has-sha512-algorithm;
+		};
+
 		rng: rng@420c0800 {
 			nist-config = <0xf00e00>;
 			health-test-config = <0x6a91>;

--- a/tests/crypto/crypto_hash/tests.yaml
+++ b/tests/crypto/crypto_hash/tests.yaml
@@ -22,6 +22,7 @@ tests:
       - nucleo_c562re
       - nucleo_h753zi
       - sf32lb52_devkit_lcd
+      - stm32h573i_dk
       - kit_psc3m5_evk
       - cyw920829m2evk_02/cyw20829b1340
       - cyw920829m2evk_02/cyw20829b1010


### PR DESCRIPTION
Add support for STM32H5 series in the STM32 HASH driver.

Tested OK on `stm32h573i_dk`:

```
(.venv) jguittet@WIPC26010524:~/zephyrproject/zephyr$ west twister -vv -ll debug -T tests/crypto/crypto_hash --device-testing --device-serial /dev/ttyACM0 -p stm32h573i_dk
Renaming previous output directory to /home/jguittet/zephyrproject/zephyr/twister-out.1
INFO    - Using Ninja..
INFO    - Zephyr version: v4.4.0-8558-g640b25d911f7
DEBUG   - Running cmake script /home/jguittet/zephyrproject/zephyr/cmake/verify-toolchain.cmake
DEBUG   - Calling cmake: /usr/bin/cmake -DFORMAT=json -P /home/jguittet/zephyrproject/zephyr/cmake/verify-toolchain.cmake
DEBUG   - Finished running /home/jguittet/zephyrproject/zephyr/cmake/verify-toolchain.cmake
INFO    - Using 'zephyr/gnu' toolchain variant.
DEBUG   - Reading testsuite configuration files under /home/jguittet/zephyrproject/zephyr/tests/crypto/crypto_hash...
DEBUG   - Found possible testsuite in /home/jguittet/zephyrproject/zephyr/tests/crypto/crypto_hash
DEBUG   - No duplicates found.
DEBUG   -  platform filter: ['stm32h573i_dk']
DEBUG   - platform_pattern: []
DEBUG   -    vendor filter: []
DEBUG   -      arch_filter: None
DEBUG   -       tag_filter: None
DEBUG   -      exclude_tag: None
DEBUG   - Checking platform filter: ['stm32h573i_dk']
INFO    - Building initial testsuite list...
INFO    - Built testsuite list in 0.00 seconds
INFO    - stm32h573i_dk/stm32h573xx crypto.hash.mbedtls_shim                           FILTERED: Not in testsuite platform allow list
INFO    - Writing JSON report /home/jguittet/zephyrproject/zephyr/twister-out/testplan.json

Device testing on:

| Platform                  | ID   | Serial device   |
|---------------------------|------|-----------------|
| stm32h573i_dk/stm32h573xx |      | /dev/ttyACM0    |

INFO    - JOBS: 16
INFO    - Adding tasks to the queue...
DEBUG   - adding stm32h573i_dk/stm32h573xx/zephyr/gnu/crypto.hash
INFO    - Added initial list of jobs to queue
DEBUG   - Running cmake on /home/jguittet/zephyrproject/zephyr/tests/crypto/crypto_hash for stm32h573i_dk/stm32h573xx
DEBUG   - Calling cmake: /usr/bin/cmake -B/home/jguittet/zephyrproject/zephyr/twister-out/stm32h573i_dk_stm32h573xx/zephyr_gnu/tests/crypto/crypto_hash/crypto.hash -DTC_RUNID=59e653c5f8d0366610ef9a675b2b6e9f -DTC_NAME=crypto.hash -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y -DEXTRA_GEN_EDT_ARGS=--edtlib-Werror -GNinja -DPython3_EXECUTABLE=/home/jguittet/zephyrproject/.venv/bin/python3 -DZEPHYR_TOOLCHAIN_VARIANT=zephyr/gnu -S/home/jguittet/zephyrproject/zephyr/tests/crypto/crypto_hash -DBOARD=stm32h573i_dk/stm32h573xx
DEBUG   - Launched 16 jobs
DEBUG   - Finished running cmake /home/jguittet/zephyrproject/zephyr/tests/crypto/crypto_hash for stm32h573i_dk/stm32h573xx in 65.20 seconds
DEBUG   - build test: stm32h573i_dk/stm32h573xx/zephyr/gnu/crypto.hash
DEBUG   - Building /home/jguittet/zephyrproject/zephyr/tests/crypto/crypto_hash for stm32h573i_dk/stm32h573xx
DEBUG   - Running /usr/bin/cmake --build /home/jguittet/zephyrproject/zephyr/twister-out/stm32h573i_dk_stm32h573xx/zephyr_gnu/tests/crypto/crypto_hash/crypto.hash
DEBUG   - Finished building /home/jguittet/zephyrproject/zephyr/tests/crypto/crypto_hash for stm32h573i_dk/stm32h573xx in 58.82 seconds
DEBUG   - Determine test cases for test instance: stm32h573i_dk/stm32h573xx/zephyr/gnu/crypto.hash
DEBUG   - Determine test cases for test suite: crypto.hash
DEBUG   - Test instance stm32h573i_dk/stm32h573xx/zephyr/gnu/crypto.hash already has 4 testcase(s) known: [<TestCase crypto.hash.crypto_hash.sha384 with None>, <TestCase crypto.hash.crypto_hash.sha512 with None>, <TestCase crypto.hash.crypto_hash.sha224 with None>, <TestCase crypto.hash.crypto_hash.sha256 with None>]
DEBUG   - Detected 4 Ztest case(s): [crypto.hash.crypto_hash.sha512, crypto.hash.crypto_hash.sha384, crypto.hash.crypto_hash.sha256, crypto.hash.crypto_hash.sha224] in /home/jguittet/zephyrproject/zephyr/twister-out/stm32h573i_dk_stm32h573xx/zephyr_gnu/tests/crypto/crypto_hash/crypto.hash/zephyr/zephyr.elf
DEBUG   - Retain DUT:stm32h573i_dk/stm32h573xx, Id:None, counter:1, failures:0
DEBUG   - run test: stm32h573i_dk/stm32h573xx/zephyr/gnu/crypto.hash
DEBUG   - Reset instance status from 'passed' to None before run.
DEBUG   - Using serial device /dev/ttyACM0 @ 115200 baud
DEBUG   - Flash command: ['west', 'flash', '--no-rebuild', '-d', '/home/jguittet/zephyrproject/zephyr/twister-out/stm32h573i_dk_stm32h573xx/zephyr_gnu/tests/crypto/crypto_hash/crypto.hash']
DEBUG   - DEVICE: *** Booting Zephyr OS build v4.4.0-8558-g640b25d911f7 ***
DEBUG   - DEVICE: Running TESTSUITE crypto_hash
DEBUG   - DEVICE: ===================================================================
DEBUG   - DEVICE: START - test_sha224
DEBUG   - DEVICE: D: begin_session (algo=1)
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Session freed
DEBUG   - DEVICE: PASS - test_sha224 in 0.024 seconds
DEBUG   - DEVICE: ===================================================================
DEBUG   - DEVICE: START - test_sha256
DEBUG   - DEVICE: D: begin_session (algo=2)
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Session freed
DEBUG   - DEVICE: PASS - test_sha256 in 0.024 seconds
DEBUG   - DEVICE: ===================================================================
DEBUG   - DEVICE: START - test_sha384
DEBUG   - DEVICE: D: begin_session (algo=3)
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Session freed
DEBUG   - DEVICE: PASS - test_sha384 in 0.024 seconds
DEBUG   - DEVICE: ===================================================================
DEBUG   - DEVICE: START - test_sha512
DEBUG   - DEVICE: D: begin_session (algo=4)
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - -- west flash: using runner stm32cubeprogrammer
reset after flashing requested
      -------------------------------------------------------------------
                        STM32CubeProgrammer v2.22.0                  
      -------------------------------------------------------------------

ST-LINK SN  : 003F002F3132511138363431
ST-LINK FW  : V3J11M3
Board       : STM32H573I-DK
Voltage     : 3.26V
SWD freq    : 8000 KHz
Connect mode: Under Reset
Reset mode  : Hardware reset
Device ID   : 0x484
Revision ID : Rev X
Device name : STM32H56x/573
NVM size  : 2 MBytes
Device type : MCU
Device CPU  : Cortex-M33
BL Version  : 0xE4
SFSP Version: v2.5.0
Debug in Low Power mode enabled



Opening and parsing file: zephyr.hex


Memory Programming ...
  File          : zephyr.hex
  Size          : 46.09 KB 
  Address       : 0x08000000


Erasing memory corresponding to segment 0:
Erasing internal memory sectors [0 5]
Download in Progress:
[==================================================] 100% 

File download complete
Time elapsed during download operation: 00:00:00.226

MCU Reset

Software reset is performed

DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Hash computation successful
DEBUG   - DEVICE: D: Session freed
DEBUG   - DEVICE: PASS - test_sha512 in 0.024 seconds
DEBUG   - DEVICE: ===================================================================
DEBUG   - DEVICE: TESTSUITE crypto_hash succeeded
DEBUG   - DEVICE: ------ TESTSUITE SUMMARY START ------
DEBUG   - DEVICE: SUITE PASS - 100.00% [crypto_hash]: pass = 4, fail = 0, skip = 0, total = 4 duration = 0.096 seconds
DEBUG   - DEVICE: - PASS - [crypto_hash.test_sha224] duration = 0.024 seconds
DEBUG   - DEVICE: - PASS - [crypto_hash.test_sha256] duration = 0.024 seconds
DEBUG   - DEVICE: - PASS - [crypto_hash.test_sha384] duration = 0.024 seconds
DEBUG   - DEVICE: - PASS - [crypto_hash.test_sha512] duration = 0.024 seconds
DEBUG   - DEVICE: ------ TESTSUITE SUMMARY END ------
DEBUG   - DEVICE: ===================================================================
DEBUG   - DEVICE: RunID: 59e653c5f8d0366610ef9a675b2b6e9f
DEBUG   - DEVICE: PROJECT EXECUTION SUCCESSFUL
DEBUG   - Expected suite names:['crypto_hash']
DEBUG   - Detected suite names:['crypto_hash']
DEBUG   - run status: stm32h573i_dk/stm32h573xx/zephyr/gnu/crypto.hash passed
DEBUG   - Release DUT:stm32h573i_dk/stm32h573xx, Id:None, counter:1, failures:0
INFO    - 1/1 stm32h573i_dk/stm32h573xx crypto.hash                                        PASSED (device: None, 8.089s <zephyr/gnu>)
INFO    -                                    crypto.hash.crypto_hash.sha512                                              PASSED      
INFO    -                                    crypto.hash.crypto_hash.sha384                                              PASSED      
INFO    -                                    crypto.hash.crypto_hash.sha256                                              PASSED      
INFO    -                                    crypto.hash.crypto_hash.sha224                                              PASSED      

INFO    - 2 test scenarios (2 configurations) selected, 1 configurations filtered (1 by static filter, 0 at runtime).
Summary
├── Total test suites: 2
├── Processed test suites: 2
│   ├── Filtered test suites: 1
│   │   ├── Filtered test suites (static): 1
│   │   └── Filtered test suites (at runtime): 0
│   └── Selected test suites: 1
│       ├── Skipped test suites: 0
│       ├── Passed test suites: 1
│       ├── Built only test suites: 0
│       ├── Failed test suites: 0
│       └── Errors in test suites: 0
└── Total test cases: 8
    ├── Filtered test cases: 4
    └── Selected test cases: 4
        ├── Passed test cases: 4
        ├── Skipped test cases: 0
        ├── Built only test cases: 0
        ├── Blocked test cases: 0
        ├── Failed test cases: 0
        └── Errors in test cases: 0
INFO    - 1 of 1 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 149.85 seconds.
INFO    - 4 of 4 executed test cases passed (100.00%) on 1 out of total 1636 platforms (0.06%).
INFO    - 1 test configurations executed on platforms, 0 test configurations were only built.

Hardware distribution summary:

| Board                     | ID   |   Counter |   Failures |
|---------------------------|------|-----------|------------|
| stm32h573i_dk/stm32h573xx |      |         1 |          0 |
INFO    - Saving reports...
INFO    - Writing JSON report /home/jguittet/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/jguittet/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/jguittet/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```