### PR TITLE
soc: st: stm32: add USB support for STM32L1 family

### DIFF
--- a/drivers/clock_control/clock_stm32l0_l1.c
+++ b/drivers/clock_control/clock_stm32l0_l1.c
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 #include <soc.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_rcc.h>
@@ -81,6 +80,17 @@ uint32_t get_pllout_frequency(void)
 					 pll_div(STM32_PLL_DIVISOR));
 }
 
+#if defined(CONFIG_SOC_SERIES_STM32L1X) && DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb)
+#define STM32_USB_PLL_VCO_FREQ                                                                     \
+	(STM32_PLL_MULTIPLIER * COND_CASE_1(IS_ENABLED(STM32_PLL_SRC_HSI), (STM32_HSI_FREQ),       \
+					    IS_ENABLED(STM32_PLL_SRC_HSE), (STM32_HSE_FREQ), (0)))
+BUILD_ASSERT(STM32_USB_PLL_VCO_FREQ == MHZ(96),
+	     "USB on STM32L1 requires PLL VCO = 96 MHz so that the USB clock equals 48 MHz");
+#endif /* CONFIG_SOC_SERIES_STM32L1X && st_stm32_usb okay */
+
+#else  /* !defined(STM32_PLL_ENABLED) */
+BUILD_ASSERT(!IS_ENABLED(CONFIG_SOC_SERIES_STM32L1X) || !DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb),
+	     "USB on STM32L1 requires the PLL to be enabled");
 #endif /* defined(STM32_PLL_ENABLED) */
 
 /**

--- a/drivers/usb/udc/Kconfig.stm32
+++ b/drivers/usb/udc/Kconfig.stm32
@@ -42,10 +42,11 @@ config UDC_STM32_MAX_QMESSAGES
 
 config UDC_STM32_CLOCK_CHECK
 	bool "Runtime USB 48MHz clock check"
-	default n if SOC_SERIES_STM32F1X || \
-		     SOC_SERIES_STM32F3X || \
-		     SOC_SERIES_STM32U5X || \
-		     SOC_SERIES_STM32WBAX
+	default n if SOC_SERIES_STM32F1X \
+		|| SOC_SERIES_STM32F3X \
+		|| SOC_SERIES_STM32L1X \
+		|| SOC_SERIES_STM32U5X \
+		|| SOC_SERIES_STM32WBAX
 	default y
 	help
 	  Enable USB clock 48MHz configuration runtime check.

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -412,6 +412,15 @@ void HAL_PCDEx_SetConnectionState(stm32_pcd_handle_t *hpcd, uint8_t state)
 	struct udc_stm32_data *priv = hpcd2data(hpcd);
 	const struct udc_stm32_config *cfg = priv->dev->config;
 
+#if defined(CONFIG_SOC_SERIES_STM32L1X)
+	/* On STM32L1 series, the USB D+ pull-up is controlled by software. */
+	if (state) {
+		LL_SYSCFG_EnableUSBPullUp();
+	} else {
+		LL_SYSCFG_DisableUSBPullUp();
+	}
+#endif /* CONFIG_SOC_SERIES_STM32L1X */
+
 	if (cfg->disconnect_gpio.port != NULL) {
 		gpio_pin_configure_dt(&cfg->disconnect_gpio,
 				      state ? GPIO_OUTPUT_ACTIVE : GPIO_OUTPUT_INACTIVE);

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -245,6 +245,19 @@
 			status = "disabled";
 		};
 
+		usb: usb@40005c00 {
+			compatible = "st,stm32-usb";
+			reg = <0x40005c00 0x400>;
+			interrupts = <20 0>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <8>;
+			ram-size = <512>;
+			maximum-speed = "full-speed";
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
+			phys = <&usb_fs_phy>;
+			status = "disabled";
+		};
+
 		pwr: power@40007000 {
 			compatible = "st,stm32-pwr";
 			reg = <0x40007000 0x400>; /* PWR register bank */
@@ -617,6 +630,11 @@
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
 			status = "disabled";
 		};
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
 	};
 
 	die_temp: dietemp {


### PR DESCRIPTION
This is an approach to fix #114106 and get USB working on one of my boards.

It appears to work well, but I must admit I arrived at this proposal through a lot of trial—and even more error...
Could someone familiar with STM32 controllers please take a thorough look at these changes?

Enable the full-speed USB device controller on STM32L1:
- Assert that the PLL VCO is 96 MHz at build time (USB clock = VCO / 2).
- Skip the runtime 48 MHz clock check since the clock is deterministic.
- Drive the DP pull-up via `SYSCFG_PMC USB_PU`.
- Add the USB controller node and a `usb-nop-xceiv` PHY to the devicetree.