### PR TITLE
samples: add infineon soc low power modes demo

### DIFF
--- a/samples/boards/infineon/low_power_modes/CMakeLists.txt
+++ b/samples/boards/infineon/low_power_modes/CMakeLists.txt
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(low_power_modes)
+
+target_sources(app PRIVATE src/main.c)
+
+# The DUT drives the test sequence and its peripheral self-tests; the companion
+# is the second-core mailbox receiver.  Exactly one role is built per image.
+target_sources_ifdef(CONFIG_APP_ROLE_DUT app PRIVATE src/main_dut.c)
+target_sources_ifdef(CONFIG_APP_ROLE_DUT app PRIVATE src/peripherals.c)
+target_sources_ifdef(CONFIG_APP_ROLE_COMPANION app PRIVATE src/main_companion.c)
+
+# The inter-core mailbox is needed by the companion (receiver) and by a DUT that
+# commands a companion (sender).  Single-core DUTs omit it entirely.
+if(CONFIG_APP_ROLE_COMPANION OR CONFIG_APP_COMPANION_MBOX)
+  target_sources(app PRIVATE src/ds_mbox.c)
+endif()

--- a/samples/boards/infineon/low_power_modes/Kconfig
+++ b/samples/boards/infineon/low_power_modes/Kconfig
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Infineon low-power modes sample"
+
+# Role and capability selection for the low-power modes sample.
+#
+# The sample is split into a device-under-test (DUT) image that drives the
+# power-management sequence and an optional companion image that a second core
+# runs to receive low-power commands over an inter-core mailbox.  The defaults
+# below reproduce the PSE84 behavior out of the box:
+#
+#   * TF-M / SRF two-application flow (PSOC_EDGE_M55_SRF_SUPPORT=y): the CM55 is
+#     the DUT with the deep power-down modes and the mailbox enabled; the CM33-NS
+#     builds as the companion.
+#   * sysbuild flow with pse84_boot.c (SRF support off): the CM55 is the DUT but
+#     runs regular DeepSleep only, with no companion and no mailbox.
+#
+# A new single-core SoC needs no change here: it is not the companion, so it
+# defaults to the DUT role.  Enable APP_DEEP_MODES once its SoC power management
+# implements the retained/power-down modes; leave APP_COMPANION_MBOX off because
+# it owns all the power-management registers directly.
+
+config APP_ROLE_COMPANION
+	bool "Build the companion-core application"
+	default y if SOC_SERIES_PSE84_M33
+	help
+	  Build main_companion.c: the second-core image that receives low-power
+	  mode commands from the DUT over the inter-core mailbox and enters the
+	  requested DeepSleep mode.  Enabled by default for the PSE84 CM33-NS
+	  companion.
+
+config APP_ROLE_DUT
+	bool "Build the device-under-test application"
+	default y if !APP_ROLE_COMPANION
+	help
+	  Build main_dut.c: the application that drives the power-management test
+	  sequence and exercises each peripheral's pm_action callback.  This is
+	  the default role for any single-image target.
+
+config APP_COMPANION_MBOX
+	bool "Command a companion core over the inter-core mailbox"
+	depends on APP_ROLE_DUT
+	default y if PSOC_EDGE_M55_SRF_SUPPORT
+	help
+	  On multi-core targets the DUT commands the companion core into the same
+	  low-power mode over an inter-core mailbox before it sleeps.  Disable on
+	  single-core targets that own all the power-management registers directly
+	  and therefore have no companion to notify.
+
+config APP_DEEP_MODES
+	bool "Exercise the retained and power-down deep sleep modes"
+	depends on APP_ROLE_DUT
+	default y if PSOC_EDGE_M55_SRF_SUPPORT
+	help
+	  Run the DeepSleep-RAM, DeepSleep-OFF and hibernate phases in addition to
+	  regular DeepSleep.  Leave disabled on targets whose SoC power management
+	  only implements regular DeepSleep, so the sample runs the shallow phases
+	  only.
+
+source "Kconfig.zephyr"

--- a/samples/boards/infineon/low_power_modes/README.rst
+++ b/samples/boards/infineon/low_power_modes/README.rst
@@ -1,0 +1,178 @@
+.. _ifx_low_power_modes:
+
+Infineon Low-Power Modes
+########################
+
+Overview
+********
+
+This sample exercises the low-power (DeepSleep) modes of an Infineon SoC and
+confirms that on-board peripherals recover after each transition.  In DeepSleep
+the high-frequency clocks are gated, so peripheral blocks stop; every driver
+implements a device ``pm_action`` callback that re-arms its hardware on wake, so
+the application does not reconfigure anything itself.
+
+The power modes exercised, from shallowest to deepest, are:
+
+* **Runtime idle** - CPU WFI sleep with the clocks still running.
+* **DeepSleep** (suspend-to-idle) - high-frequency clocks gated; SRAM and
+  peripheral state retained; wake resumes in-session.
+* **DeepSleep-RAM** (suspend-to-ram) - deeper retention with a warm boot on wake;
+  drivers are re-initialized from their ``pm_action`` callbacks.
+* **DeepSleep-OFF / hibernate** - the terminal power-down modes; wake is a cold
+  boot triggered by the wake button, so they end the run.
+
+A set of on-board peripherals (PWM, counter, and, depending on the board,
+communication and analog blocks) is self-tested once at startup and again after
+each wake.  The exact set is defined by the board devicetree, so it varies per
+silicon; a peripheral absent from the devicetree is compiled out and simply
+skipped.  A matching result after wake confirms that peripheral's ``pm_action``
+restored it.
+
+Application roles
+*****************
+
+.. _lpm_roles:
+
+The sample builds one of two images per target, selected in Kconfig:
+
+* **DUT** (``CONFIG_APP_ROLE_DUT``, ``src/main_dut.c``) drives the power-mode
+  sequence and the peripheral self-tests.  This is the default role for any
+  single-image target.
+* **Companion** (``CONFIG_APP_ROLE_COMPANION``, ``src/main_companion.c``) runs on
+  the second core of a multi-core SoC and enters the mode the DUT commands over
+  an inter-core mailbox.
+
+Two capability options gate the deeper behavior, so a new SoC only enables what
+its power management implements:
+
+* ``CONFIG_APP_DEEP_MODES`` - run DeepSleep-RAM and the terminal power-down modes
+  in addition to regular DeepSleep.
+* ``CONFIG_APP_COMPANION_MBOX`` - command a companion core over the mailbox before
+  sleeping.  Single-core SoCs leave this off and drive every register directly.
+
+On the PSOC Edge E84 both options default on with
+``CONFIG_PSOC_EDGE_M55_SRF_SUPPORT`` (the TF-M two-application flow) and off in
+the sysbuild flow, which runs regular DeepSleep only.
+
+Sequence
+********
+
+* **Phase 1 - runtime idle only.** DeepSleep is locked out via the PM policy, so
+  the core only enters WFI sleep with clocks running.
+* **Phase 2 - deep sleep.** The PM policy is allowed to select DeepSleep, then
+  (when supported) DeepSleep-RAM, and finally the terminal power-down mode.  The
+  LED thread is suspended so idle periods are long enough for the policy to
+  choose the mode; after each in-session wake the sample re-tests every
+  peripheral and reports the result.
+
+UART output and deepsleep entry
+*******************************
+
+The UART output (printk) in this sample can block the device from entering
+DeepSleep.  ``printk`` is synchronous and the console UART driver refuses to
+suspend while a transmission is still in flight, so pending output reaches the
+wire before the clocks are gated without any application-level draining.
+
+The UART output generated when the USER button is pressed can block DeepSleep.
+So, the USER button can be used to illustrate the blocking behavior.  It may take
+several button presses for that behavior to occur.
+
+Supported SoCs
+**************
+
+The following SoCs are supported by this sample code:
+
+* infineon/edge/pse84
+
+Building and Running
+********************
+
+Make sure to reset the board after programming (XRES) to ensure that the
+debugger is not attached, as this prevents the device from entering deep sleep.
+
+Standalone (sysbuild, regular DeepSleep only)
+=============================================
+
+This builds the CM55 DUT together with the secure boot stub.  Only regular
+DeepSleep is exercised; the companion and the deeper modes are skipped.
+
+.. code-block:: console
+
+   west build -p auto -b kit_pse84_eval/pse846gps2dbzc4a/m55 \
+     samples/boards/infineon/low_power_modes --sysbuild
+   west flash
+
+TF-M + mcuboot multi-core flow (all modes)
+==========================================
+
+The deeper modes need the CM33 non-secure (TF-M) companion, which arms the secure
+side and votes the SoC into DeepSleep.  Build and flash three images in order: the
+mcuboot bootloader, the CM33-NS companion, then the CM55 DUT.  The DUT build points
+at the companion build directory with ``-DPSE84_CM33_BUILD_DIR`` so the two images
+are chain-loaded together.
+
+Build and flash the mcuboot bootloader:
+
+.. code-block:: console
+
+   west build -p auto -b kit_pse84_eval/pse846gps2dbzc4a/m33 \
+     ../bootloader/mcuboot/boot/zephyr -d build_mcuboot -- \
+     -DEXTRA_DTC_OVERLAY_FILE="$PWD/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot_bl.overlay" \
+     -DEXTRA_CONF_FILE="$PWD/boards/infineon/kit_pse84_eval/kit_pse84_eval_mcuboot.conf" \
+     -DCONFIG_UPDATEABLE_IMAGE_NUMBER=3
+   west flash -d build_mcuboot
+
+Build and flash the CM33 non-secure companion:
+
+.. code-block:: console
+
+   west build -p auto -b kit_pse84_eval/pse846gps2dbzc4a/m33/ns \
+     samples/boards/infineon/low_power_modes -d build_tfm_ns -- \
+     -DEXTRA_CONF_FILE="$PWD/boards/infineon/kit_pse84_eval/kit_pse84_eval_slot.conf" \
+     -DCONFIG_PSOC_EDGE_M55_SRF_SUPPORT=y
+   west flash -d build_tfm_ns
+
+Build and flash the CM55 DUT, pointing it at the CM33-NS build:
+
+.. code-block:: console
+
+   west build -p auto -b kit_pse84_eval/pse846gps2dbzc4a/m55 \
+     samples/boards/infineon/low_power_modes -d build_multicore_55 -- \
+     -DCONFIG_PSOC_EDGE_M55_SRF_SUPPORT=y \
+     -DPSE84_CM33_BUILD_DIR=build_tfm_ns \
+     -DEXTRA_CONF_FILE="$PWD/boards/infineon/kit_pse84_eval/kit_pse84_eval_slot.conf"
+   west flash -d build_multicore_55
+
+Sample Output
+=============
+
+To check output of this sample, open a serial console, and select the proper COM port
+(i.e. on Linux minicom, putty, screen, etc).
+
+The console output should look approximately like this:
+
+.. code-block:: console
+
+   *** Booting Zephyr OS build ***
+   PWM blue LED started at 2 Hz
+   Free-running counter started
+   Phase 1: runtime-idle only
+   Sleep: 5 | Deepsleep: 0
+   Phase 2: run each low-power mode in sequence
+   Phase 2: exercising DeepSleep
+   Phase 2: enter DeepSleep (counter=12345, watch blue LED freeze)
+   Phase 2: woke after 2000 ms
+   Sleep: 5 | Deepsleep: 1
+   Phase 2: exercising DeepSleep-RAM
+   Phase 2: enter DeepSleep-RAM (counter=23456, watch blue LED freeze)
+   Phase 2: woke after 2000 ms
+   Sleep: 5 | Deepsleep: 1
+   Phase 2: exercising DeepSleep-OFF
+   Phase 2: entering DeepSleep-OFF. Press the button to wake/reset.
+   Sequence complete
+
+The per-mode peripheral self-test lines between the wake messages depend on the
+board devicetree and are omitted here.  On a single-core target, or in the
+sysbuild flow, the DeepSleep-RAM and terminal power-down lines are replaced by a
+single ``regular DeepSleep only`` notice.

--- a/samples/boards/infineon/low_power_modes/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
+++ b/samples/boards/infineon/low_power_modes/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# CM55 DUT configuration for the low-power modes sample.  The CM33-NS (TF-M)
+# companion built from this same sample uses only the common settings in
+# prj.conf.
+CONFIG_PM_DEVICE=y
+# Device runtime PM is enabled automatically by every transaction driver in this
+# sample (I2C, SPI, DMIC, I2S, SDHC): each takes a pm_device_runtime_get/put
+# reference around its active window, so the peripheral is reference counted per
+# transaction instead of being frozen by the system-managed policy. The second
+# UART instance (SCB5) opts in per node via zephyr,pm-device-runtime-auto and
+# takes a reference around its interrupt-driven TX/RX sessions. Free-running or
+# always-on peripherals (PWM, counter, UART console) do not call runtime
+# get/put and remain system managed.
+CONFIG_PM_DEVICE_RUNTIME=y
+# System-managed device PM defaults to disabled once PM_DEVICE_RUNTIME is set
+# (Kconfig: "default y if !PM_DEVICE_RUNTIME"). The non-runtime peripherals in
+# this sample still rely on it, so without this the PM subsystem never calls
+# their SUSPEND/RESUME pm_action around a regular (retained) DeepSleep.
+CONFIG_PM_DEVICE_SYSTEM_MANAGED=y
+CONFIG_POWEROFF=y
+CONFIG_PWM=y
+CONFIG_COUNTER=y
+CONFIG_SPI=y
+CONFIG_I2C=y
+CONFIG_DMA=y
+CONFIG_AUDIO=y
+CONFIG_AUDIO_DMIC=y
+CONFIG_I2S=y
+CONFIG_SDHC=y
+
+# Second UART instance (SCB5) loopback self-test uses the interrupt-driven API
+# to drive the UART driver's restricted-scope device runtime PM get/put paths.
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# The suspend-to-RAM (DS-RAM) entry path runs on the idle thread stack and is
+# far deeper than a plain WFI idle: ifx_pm_s2ram_enter() saves FPU/SCB/MPU/NVIC
+# context and calls arch_pm_s2ram_suspend(). The default 320-byte idle stack
+# overflows (K_ERR_STACK_CHK_FAIL). Enlarge it so the S2RAM path fits.
+CONFIG_IDLE_STACK_SIZE=2048

--- a/samples/boards/infineon/low_power_modes/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
+++ b/samples/boards/infineon/low_power_modes/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.conf
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# CM55 DUT configuration for the low-power modes sample.  The CM33-NS (TF-M)
+# companion built from this same sample uses only the common settings in
+# prj.conf.
+CONFIG_PM_DEVICE=y
+# Device runtime PM is enabled automatically by every transaction driver in this
+# sample (I2C, SPI, DMIC, I2S, SDHC): each takes a pm_device_runtime_get/put
+# reference around its active window, so the peripheral is reference counted per
+# transaction instead of being frozen by the system-managed policy. The second
+# UART instance (SCB5) opts in per node via zephyr,pm-device-runtime-auto and
+# takes a reference around its interrupt-driven TX/RX sessions. Free-running or
+# always-on peripherals (PWM, counter, UART console) do not call runtime
+# get/put and remain system managed.
+CONFIG_PM_DEVICE_RUNTIME=y
+# System-managed device PM defaults to disabled once PM_DEVICE_RUNTIME is set
+# (Kconfig: "default y if !PM_DEVICE_RUNTIME"). The non-runtime peripherals in
+# this sample still rely on it, so without this the PM subsystem never calls
+# their SUSPEND/RESUME pm_action around a regular (retained) DeepSleep.
+CONFIG_PM_DEVICE_SYSTEM_MANAGED=y
+CONFIG_POWEROFF=y
+CONFIG_PWM=y
+CONFIG_COUNTER=y
+CONFIG_SPI=y
+CONFIG_I2C=y
+CONFIG_DMA=y
+CONFIG_AUDIO=y
+CONFIG_AUDIO_DMIC=y
+CONFIG_I2S=y
+CONFIG_SDHC=y
+
+# Second UART instance (SCB5) loopback self-test uses the interrupt-driven API
+# to drive the UART driver's restricted-scope device runtime PM get/put paths.
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# The suspend-to-RAM (DS-RAM) entry path runs on the idle thread stack and is
+# far deeper than a plain WFI idle: ifx_pm_s2ram_enter() saves FPU/SCB/MPU/NVIC
+# context and calls arch_pm_s2ram_suspend(). The default 320-byte idle stack
+# overflows (K_ERR_STACK_CHK_FAIL). Enlarge it so the S2RAM path fits.
+CONFIG_IDLE_STACK_SIZE=2048
+
+# The MXCRYPTO block (hardware crypto + TRNG entropy) is owned by the TF-M
+# secure world on this device. Under the manual mcuboot -> TF-M -> CM33-NS ->
+# CM55 topology, TF-M grants the peripheral to the CM33-NS master but not to
+# the CM55 (APPCPU) master, so a non-secure register access from the CM55
+# (Cy_Crypto_Core_Enable at PRE_KERNEL_1) triggers a PPC/bus fault and resets
+# the SoC in an endless MCUboot reboot loop. The board defconfig enables this
+# stack by default; this sample does not use hardware crypto, so disable the
+# whole MXCRYPTO crypto/entropy/MFD stack on the CM55 image. A non-secure app
+# needing crypto or entropy should use PSA APIs routed through TF-M instead.
+CONFIG_MFD_INFINEON_MXCRYPTO=n
+CONFIG_CRYPTO_INFINEON_MXCRYPTO=n
+CONFIG_ENTROPY_INFINEON_MXCRYPTO_TRNG=n

--- a/samples/boards/infineon/low_power_modes/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/boards/infineon/low_power_modes/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,267 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led_blue;
+		counter0 = &counter0_1;
+		spi-loopback = &spi10;
+		dmic0 = &dmic0;
+		i2s-tx = &i2s1;
+		uart-test = &uart5;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led_blue: pwm_led_blue {
+			label = "PWM Blue LED";
+			pwms = <&pwm0_5 0 PWM_MSEC(500) PWM_POLARITY_NORMAL>;
+		};
+	};
+};
+
+/* DeepSleep-RAM is disabled by default in the SoC devicetree so a plain
+ * application only sees runtime-idle and regular DeepSleep.  This sample
+ * exercises the suspend-to-RAM warm-boot path, so re-enable the state here.
+ */
+&deepsleep_ram {
+	status = "okay";
+};
+
+/* Use blue LED (P16.5) as PWM output on TCPWM0_5.
+ * During deepsleep, HF clocks stop and the PWM output freezes.
+ * This provides a visual indicator of deepsleep entry.
+ */
+&tcpwm0_5 {
+	status = "okay";
+
+	pwm0_5: pwm0_5 {
+		clocks = <&peri0_group1_16bit_1>;
+		compatible = "infineon,tcpwm-pwm";
+		status = "okay";
+		pinctrl-0 = <&p16_5_pwm0_5>;
+		pinctrl-names = "default";
+	};
+};
+
+&p16_5_pwm0_5 {
+	drive-push-pull;
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	/* 400 MHz HF / 400 = 1 MHz PWM input clock.
+	 * With a 32-bit counter and period = 500000, gives 2 Hz blink.
+	 */
+	clock-div = <400>;
+};
+
+/* Free-running 16-bit TCPWM counter used to demonstrate that the counter
+ * driver's pm_action restarts the counter after regular DeepSleep.  The
+ * counter stops while HF clocks are gated during DeepSleep and resumes
+ * counting on wake via the device PM resume callback.
+ */
+&tcpwm0_1 {
+	status = "okay";
+
+	counter0_1 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_2>;
+	};
+};
+
+&peri0_group1_16bit_2 {
+	status = "okay";
+	/* 400 MHz HF / 4000 = 100 kHz counter input clock. */
+	clock-div = <4000>;
+};
+
+/* SPI loopback on SCB10: jumper P16.1 (MOSI) to P16.2 (MISO).
+ * Exercises the SPI driver's pm_action across DeepSleep: after a regular
+ * DeepSleep the SCB config is retained, and after a DeepSleep-RAM warm boot
+ * the resume callback re-applies pinctrl / clock divider / CS GPIO and forces
+ * the next transfer to re-init the block, so the loopback still matches.
+ */
+spi10: &scb10 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	compatible = "infineon,spi";
+	status = "okay";
+
+	pinctrl-0 = <&p16_1_scb10_spi_m_mosi &p16_2_scb10_spi_m_miso &p16_0_scb10_spi_m_clk>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio_prt16 3 GPIO_ACTIVE_LOW>;
+
+	/* i2c0 already uses peri0_group1_16bit_3, so use a separate divider. */
+	clocks = <&peri0_group1_16bit_0>;
+
+	loopback_dev: loopback@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+&peri0_group1_16bit_0 {
+	status = "okay";
+};
+
+&p16_1_scb10_spi_m_mosi {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+&p16_2_scb10_spi_m_miso {
+	drive-strength = "full";
+	input-enable;
+};
+
+&p16_0_scb10_spi_m_clk {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+/* PDM/PCM microphone on PDM3 (P8.5 clk, P8.6 data) routed through DMA0 ch0.
+ * Exercises the DMIC driver's pm_action: a regular DeepSleep is refused while
+ * a capture is active (so audio is never corrupted mid-stream), and a
+ * DeepSleep-RAM warm boot re-initializes the PDM block via the resume
+ * callback.  The DMA driver's pm_action re-enables the DMA controller on the
+ * same warm-boot path so the next capture can reprogram its channel.
+ */
+&dmic0 {
+	pinctrl-0 = <&p8_5_pdm3_pdm_clk &p8_6_pdm3_pdm_data>;
+	pinctrl-names = "default";
+	clocks = <&peri1_group1_16_5bit_2>;
+	status = "okay";
+
+	dmas = <&dma0 0>;
+	dma-names = "rx";
+};
+
+&dmic0_ch2 {
+	status = "okay";
+	use-alt-io;
+};
+
+&dmic0_ch3 {
+	status = "okay";
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&clk_hf7 {
+	status = "okay";
+	source-path = <IFX_CLK_HF_IN_CLKPATH3>;
+};
+
+&peri1_group1_16_5bit_2 {
+	status = "okay";
+	clock-div = <2>;
+	div-frac-value = <7>;
+};
+
+&p8_5_pdm3_pdm_clk {
+	drive-strength = "half";
+	drive-push-pull;
+};
+
+&p8_6_pdm3_pdm_data {
+	drive-strength = "half";
+	input-enable;
+};
+
+/* I2S transmitter on TDM I2S1 (P11.0 tx_sck, P11.1 tx_fsync, P11.2 tx_sd)
+ * driven by DMA0 channel 1.  Configured as controller so it generates its own
+ * bit and frame clocks and can stream out without an external codec.
+ *
+ * Exercises the I2S driver's pm_action: a regular DeepSleep is refused while a
+ * transmit stream is active (so audio is never corrupted mid-stream), and a
+ * DeepSleep-RAM warm boot re-initializes the TDM block via the resume callback.
+ * The DMA driver's pm_action re-enables the DMA controller on the same
+ * warm-boot path so the next transfer can reprogram its channel.
+ */
+&i2s1 {
+	pinctrl-0 = <&p11_0_tdm_i2s1_tx_sck &p11_1_tdm_i2s1_tx_fsync &p11_2_tdm_i2s1_tx_sd>;
+	pinctrl-names = "default";
+	clocks = <&peri0_group1_16_5bit_0>;
+	status = "okay";
+
+	dmas = <&dma0 1>;
+	dma-names = "tx";
+};
+
+&peri0_group1_16_5bit_0 {
+	status = "okay";
+	/* 400 MHz HF / 40 = 10 MHz I2S source clock.  The driver derives the
+	 * TDM bit-clock divider from this for the requested sample rate.
+	 */
+	clock-div = <40>;
+};
+
+&p11_0_tdm_i2s1_tx_sck {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+&p11_1_tdm_i2s1_tx_fsync {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+&p11_2_tdm_i2s1_tx_sd {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+/* Second UART instance on SCB5 (P17.1 TX, P17.0 RX) used purely to exercise the
+ * UART driver's restricted-scope device runtime PM.  The console stays on its
+ * own separate UART; this instance opts in to runtime management via the
+ * zephyr,pm-device-runtime-auto property, so the interrupt-driven TX/RX enable
+ * paths take a pm_device_runtime_get() reference and the disable paths drop it,
+ * letting the block be runtime suspended between transfers.  poll_out() is
+ * deliberately never instrumented, which is why the console UART is left
+ * unmanaged.
+ *
+ * Loopback needs a physical jumper from P17.1 (TX) to P17.0 (RX): the SCB UART
+ * driver has no internal loopback.  The interrupt-driven API is used (no DMA)
+ * so this test never competes with the DMIC/I2S DMA channels.
+ */
+uart5: &scb5 {
+	compatible = "infineon,uart";
+	status = "okay";
+	current-speed = <115200>;
+	zephyr,pm-device-runtime-auto;
+
+	/* The driver derives the real clock divider from the target baud, so the
+	 * clock-div on the divider node below is only an initial placeholder.  A
+	 * dedicated 16.5-bit channel is used so it never collides with the other
+	 * peripherals in this overlay.
+	 */
+	clocks = <&peri0_group1_16_5bit_1>;
+
+	pinctrl-0 = <&p17_1_scb5_uart_tx &p17_0_scb5_uart_rx>;
+	pinctrl-names = "default";
+};
+
+&peri0_group1_16_5bit_1 {
+	status = "okay";
+};
+
+&p17_1_scb5_uart_tx {
+	drive-push-pull;
+};
+
+&p17_0_scb5_uart_rx {
+	input-enable;
+};

--- a/samples/boards/infineon/low_power_modes/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
+++ b/samples/boards/infineon/low_power_modes/boards/kit_pse84_eval_pse846gps2dbzc4a_m55.overlay
@@ -1,0 +1,276 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led_blue;
+		counter0 = &counter0_1;
+		spi-loopback = &spi10;
+		dmic0 = &dmic0;
+		i2s-tx = &i2s1;
+		uart-test = &uart5;
+	};
+
+	/* SW2 (P8.3, active low) is wired to dedicated hibernate wake PIN1.
+	 * Describe it here so the SoC arms PIN1 as the hibernate wakeup source at
+	 * boot; the application still owns the pad through the GPIO driver.
+	 */
+	hibernate_wakeup: hibernate-wakeup {
+		compatible = "infineon,hibernate-wakeup";
+		wakeup-pin1-trigger = "low";
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led_blue: pwm_led_blue {
+			label = "PWM Blue LED";
+			pwms = <&pwm0_5 0 PWM_MSEC(500) PWM_POLARITY_NORMAL>;
+		};
+	};
+};
+
+/* DeepSleep-RAM is disabled by default in the SoC devicetree so a plain
+ * application only sees runtime-idle and regular DeepSleep.  This sample
+ * exercises the suspend-to-RAM warm-boot path, so re-enable the state here.
+ */
+&deepsleep_ram {
+	status = "okay";
+};
+
+/* Use blue LED (P16.5) as PWM output on TCPWM0_5.
+ * During deepsleep, HF clocks stop and the PWM output freezes.
+ * This provides a visual indicator of deepsleep entry.
+ */
+&tcpwm0_5 {
+	status = "okay";
+
+	pwm0_5: pwm0_5 {
+		clocks = <&peri0_group1_16bit_1>;
+		compatible = "infineon,tcpwm-pwm";
+		status = "okay";
+		pinctrl-0 = <&p16_5_pwm0_5>;
+		pinctrl-names = "default";
+	};
+};
+
+&p16_5_pwm0_5 {
+	drive-push-pull;
+};
+
+&peri0_group1_16bit_1 {
+	status = "okay";
+	/* 400 MHz HF / 400 = 1 MHz PWM input clock.
+	 * With a 32-bit counter and period = 500000, gives 2 Hz blink.
+	 */
+	clock-div = <400>;
+};
+
+/* Free-running 16-bit TCPWM counter used to demonstrate that the counter
+ * driver's pm_action restarts the counter after regular DeepSleep.  The
+ * counter stops while HF clocks are gated during DeepSleep and resumes
+ * counting on wake via the device PM resume callback.
+ */
+&tcpwm0_1 {
+	status = "okay";
+
+	counter0_1 {
+		status = "okay";
+		clocks = <&peri0_group1_16bit_2>;
+	};
+};
+
+&peri0_group1_16bit_2 {
+	status = "okay";
+	/* 400 MHz HF / 4000 = 100 kHz counter input clock. */
+	clock-div = <4000>;
+};
+
+/* SPI loopback on SCB10: jumper P16.1 (MOSI) to P16.2 (MISO).
+ * Exercises the SPI driver's pm_action across DeepSleep: after a regular
+ * DeepSleep the SCB config is retained, and after a DeepSleep-RAM warm boot
+ * the resume callback re-applies pinctrl / clock divider / CS GPIO and forces
+ * the next transfer to re-init the block, so the loopback still matches.
+ */
+spi10: &scb10 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	compatible = "infineon,spi";
+	status = "okay";
+
+	pinctrl-0 = <&p16_1_scb10_spi_m_mosi &p16_2_scb10_spi_m_miso &p16_0_scb10_spi_m_clk>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpio_prt16 3 GPIO_ACTIVE_LOW>;
+
+	/* i2c0 already uses peri0_group1_16bit_3, so use a separate divider. */
+	clocks = <&peri0_group1_16bit_0>;
+
+	loopback_dev: loopback@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+&peri0_group1_16bit_0 {
+	status = "okay";
+};
+
+&p16_1_scb10_spi_m_mosi {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+&p16_2_scb10_spi_m_miso {
+	drive-strength = "full";
+	input-enable;
+};
+
+&p16_0_scb10_spi_m_clk {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+/* PDM/PCM microphone on PDM3 (P8.5 clk, P8.6 data) routed through DMA0 ch0.
+ * Exercises the DMIC driver's pm_action: a regular DeepSleep is refused while
+ * a capture is active (so audio is never corrupted mid-stream), and a
+ * DeepSleep-RAM warm boot re-initializes the PDM block via the resume
+ * callback.  The DMA driver's pm_action re-enables the DMA controller on the
+ * same warm-boot path so the next capture can reprogram its channel.
+ */
+&dmic0 {
+	pinctrl-0 = <&p8_5_pdm3_pdm_clk &p8_6_pdm3_pdm_data>;
+	pinctrl-names = "default";
+	clocks = <&peri1_group1_16_5bit_2>;
+	status = "okay";
+
+	dmas = <&dma0 0>;
+	dma-names = "rx";
+};
+
+&dmic0_ch2 {
+	status = "okay";
+	use-alt-io;
+};
+
+&dmic0_ch3 {
+	status = "okay";
+};
+
+&dma0 {
+	status = "okay";
+};
+
+&clk_hf7 {
+	status = "okay";
+	source-path = <IFX_CLK_HF_IN_CLKPATH3>;
+};
+
+&peri1_group1_16_5bit_2 {
+	status = "okay";
+	clock-div = <2>;
+	div-frac-value = <7>;
+};
+
+&p8_5_pdm3_pdm_clk {
+	drive-strength = "half";
+	drive-push-pull;
+};
+
+&p8_6_pdm3_pdm_data {
+	drive-strength = "half";
+	input-enable;
+};
+
+/* I2S transmitter on TDM I2S1 (P11.0 tx_sck, P11.1 tx_fsync, P11.2 tx_sd)
+ * driven by DMA0 channel 1.  Configured as controller so it generates its own
+ * bit and frame clocks and can stream out without an external codec.
+ *
+ * Exercises the I2S driver's pm_action: a regular DeepSleep is refused while a
+ * transmit stream is active (so audio is never corrupted mid-stream), and a
+ * DeepSleep-RAM warm boot re-initializes the TDM block via the resume callback.
+ * The DMA driver's pm_action re-enables the DMA controller on the same
+ * warm-boot path so the next transfer can reprogram its channel.
+ */
+&i2s1 {
+	pinctrl-0 = <&p11_0_tdm_i2s1_tx_sck &p11_1_tdm_i2s1_tx_fsync &p11_2_tdm_i2s1_tx_sd>;
+	pinctrl-names = "default";
+	clocks = <&peri0_group1_16_5bit_0>;
+	status = "okay";
+
+	dmas = <&dma0 1>;
+	dma-names = "tx";
+};
+
+&peri0_group1_16_5bit_0 {
+	status = "okay";
+	/* 400 MHz HF / 40 = 10 MHz I2S source clock.  The driver derives the
+	 * TDM bit-clock divider from this for the requested sample rate.
+	 */
+	clock-div = <40>;
+};
+
+&p11_0_tdm_i2s1_tx_sck {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+&p11_1_tdm_i2s1_tx_fsync {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+&p11_2_tdm_i2s1_tx_sd {
+	drive-strength = "full";
+	drive-push-pull;
+};
+
+/* Second UART instance on SCB5 (P17.1 TX, P17.0 RX) used purely to exercise the
+ * UART driver's restricted-scope device runtime PM.  The console stays on its
+ * own separate UART; this instance opts in to runtime management via the
+ * zephyr,pm-device-runtime-auto property, so the interrupt-driven TX/RX enable
+ * paths take a pm_device_runtime_get() reference and the disable paths drop it,
+ * letting the block be runtime suspended between transfers.  poll_out() is
+ * deliberately never instrumented, which is why the console UART is left
+ * unmanaged.
+ *
+ * Loopback needs a physical jumper from P17.1 (TX) to P17.0 (RX): the SCB UART
+ * driver has no internal loopback.  The interrupt-driven API is used (no DMA)
+ * so this test never competes with the DMIC/I2S DMA channels.
+ */
+uart5: &scb5 {
+	compatible = "infineon,uart";
+	status = "okay";
+	current-speed = <115200>;
+	zephyr,pm-device-runtime-auto;
+
+	/* The driver derives the real clock divider from the target baud, so the
+	 * clock-div on the divider node below is only an initial placeholder.  A
+	 * dedicated 16.5-bit channel is used so it never collides with the other
+	 * peripherals in this overlay.
+	 */
+	clocks = <&peri0_group1_16_5bit_1>;
+
+	pinctrl-0 = <&p17_1_scb5_uart_tx &p17_0_scb5_uart_rx>;
+	pinctrl-names = "default";
+};
+
+&peri0_group1_16_5bit_1 {
+	status = "okay";
+};
+
+&p17_1_scb5_uart_tx {
+	drive-push-pull;
+};
+
+&p17_0_scb5_uart_rx {
+	input-enable;
+};

--- a/samples/boards/infineon/low_power_modes/prj.conf
+++ b/samples/boards/infineon/low_power_modes/prj.conf
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Common configuration shared by the DUT and the companion image built from
+# this sample.  Target-specific peripheral and stack settings live in the
+# per-board files under boards/.
+CONFIG_GPIO=y
+CONFIG_PM=y
+CONFIG_HWINFO=y

--- a/samples/boards/infineon/low_power_modes/src/ds_mbox.c
+++ b/samples/boards/infineon/low_power_modes/src/ds_mbox.c
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <zephyr/kernel.h>
+#include <zephyr/irq.h>
+#include <soc.h>
+#include <cy_ipc_drv.h>
+
+#include "ds_mbox.h"
+
+/* SRF owns MTB_IPC_CHAN_0 (CY_IPC_CHAN_USER) and interrupt structs
+ * CY_IPC_INTR_USER..+3, so the DeepSleep mailbox uses the next free user
+ * channel and interrupt structure.  Both cores agree on these numbers.
+ */
+#define DS_MBOX_IPC_CHAN (CY_IPC_CHAN_USER + 1U)
+#define DS_MBOX_IPC_INTR (CY_IPC_INTR_USER + 4U)
+
+#if defined(CONFIG_APP_COMPANION_MBOX)
+
+#define DS_MBOX_NOTIFY_MASK  CY_IPC_INTR_MASK(DS_MBOX_IPC_INTR)
+#define DS_MBOX_SEND_RETRIES 10U
+
+void ds_mbox_send(uint32_t mode)
+{
+	IPC_STRUCT_Type *ipc = Cy_IPC_Drv_GetIpcBaseAddress(DS_MBOX_IPC_CHAN);
+	cy_en_ipcdrv_status_t st = CY_IPC_DRV_ERROR;
+	uint32_t retries = DS_MBOX_SEND_RETRIES;
+
+	/* SendMsgWord acquires the channel lock, writes the command word and
+	 * raises the CM33-NS notify interrupt.  If the CM33 has not yet released
+	 * a previous message the channel is still locked, so retry briefly.
+	 */
+	do {
+		st = Cy_IPC_Drv_SendMsgWord(ipc, DS_MBOX_NOTIFY_MASK, mode);
+		if (st == CY_IPC_DRV_SUCCESS) {
+			break;
+		}
+		k_busy_wait(1000);
+	} while (--retries > 0U);
+
+	if (st == CY_IPC_DRV_SUCCESS) {
+		printk("DS mbox: sent mode=%u to CM33-NS\n", (unsigned int)mode);
+	} else {
+		printk("DS mbox: send failed (%d)\n", (int)st);
+	}
+}
+
+#endif /* CONFIG_APP_COMPANION_MBOX */
+
+#if defined(CONFIG_APP_ROLE_COMPANION)
+
+#define DS_MBOX_CH_MASK CY_IPC_CH_MASK(DS_MBOX_IPC_CHAN)
+
+/* Latch a DeepSleep request from the mailbox ISR so the blink loop enters the
+ * requested low-power mode at its next wait point.  The SW0 wake source is armed
+ * by the CM55 controller, so this core only reacts to the mailbox command.
+ */
+static K_SEM_DEFINE(ds_off_req_sem, 0, 1);
+
+/* Low-power mode requested by the last mailbox message; defaults to DS-RAM so
+ * an SW0 press before any CM55 command still uses the previous behavior.
+ */
+static volatile uint32_t ds_mbox_mode = DS_MBOX_CMD_DS_RAM;
+
+static void ds_mbox_isr(const void *arg)
+{
+	IPC_INTR_STRUCT_Type *intr = Cy_IPC_Drv_GetIntrBaseAddr(DS_MBOX_IPC_INTR);
+	IPC_STRUCT_Type *ipc = Cy_IPC_Drv_GetIpcBaseAddress(DS_MBOX_IPC_CHAN);
+	uint32_t msg = 0U;
+
+	ARG_UNUSED(arg);
+
+	/* Read the command word the CM55 placed in the channel, latch the
+	 * requested mode and wake the blink loop, then release the channel lock
+	 * so the sender can reuse it and clear our notify interrupt.
+	 */
+	if (Cy_IPC_Drv_ReadMsgWord(ipc, &msg) == CY_IPC_DRV_SUCCESS) {
+		ds_mbox_mode = msg;
+		k_sem_give(&ds_off_req_sem);
+	}
+
+	Cy_IPC_Drv_ReleaseNotify(ipc, 0U);
+	Cy_IPC_Drv_ClearInterrupt(intr, 0U, DS_MBOX_CH_MASK);
+}
+
+void ds_mbox_receiver_init(void)
+{
+	IPC_INTR_STRUCT_Type *intr = Cy_IPC_Drv_GetIntrBaseAddr(DS_MBOX_IPC_INTR);
+
+	/* Route a notify event on our channel to our interrupt structure. */
+	Cy_IPC_Drv_SetInterruptMask(intr, 0U, DS_MBOX_CH_MASK);
+
+	IRQ_CONNECT(CY_IPC_INTR_MUX(DS_MBOX_IPC_INTR), 3, ds_mbox_isr, NULL, 0);
+	irq_enable(CY_IPC_INTR_MUX(DS_MBOX_IPC_INTR));
+}
+
+int ds_mbox_wait(uint32_t *mode, k_timeout_t timeout)
+{
+	if (k_sem_take(&ds_off_req_sem, timeout) != 0) {
+		return -EAGAIN;
+	}
+
+	if (mode != NULL) {
+		*mode = ds_mbox_mode;
+	}
+
+	return 0;
+}
+
+#endif /* CONFIG_APP_ROLE_COMPANION */

--- a/samples/boards/infineon/low_power_modes/src/ds_mbox.h
+++ b/samples/boards/infineon/low_power_modes/src/ds_mbox.h
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DS_MBOX_H_
+#define DS_MBOX_H_
+
+#include <stdint.h>
+#include <zephyr/kernel.h>
+
+/*
+ * Inter-core DeepSleep command mailbox (CM55 controller -> CM33-NS companion).
+ *
+ * A raw Cy_IPC_Drv channel lets the CM55 application command which system
+ * low-power mode the CM33-NS core should enter.  SRF owns MTB_IPC_CHAN_0
+ * (CY_IPC_CHAN_USER) and interrupt structs CY_IPC_INTR_USER..+3, so the mailbox
+ * uses the next free user channel and interrupt structure.  These reservations
+ * match soc/infineon/edge/pse84/mtb_ipc_config.h (MTB_IPC_CHANNEL_DS_MBOX /
+ * MTB_IPC_IRQ_DS_MBOX).  Both cores include this header and link ds_mbox.c.
+ */
+
+/* Command word exchanged over the mailbox channel data register. */
+#define DS_MBOX_CMD_DS     0U
+#define DS_MBOX_CMD_DS_RAM 1U
+#define DS_MBOX_CMD_DS_OFF 2U
+
+#if defined(CONFIG_APP_COMPANION_MBOX)
+/* DUT side: post a DeepSleep command word to the companion receiver. */
+void ds_mbox_send(uint32_t mode);
+#endif /* CONFIG_APP_COMPANION_MBOX */
+
+#if defined(CONFIG_APP_ROLE_COMPANION)
+/* Companion side: bring up the mailbox receiver (interrupt + channel mask). */
+void ds_mbox_receiver_init(void);
+
+/* Wait up to timeout for a mailbox command.  On success stores the requested
+ * command word in *mode and returns 0; returns -EAGAIN on timeout.
+ */
+int ds_mbox_wait(uint32_t *mode, k_timeout_t timeout);
+#endif /* CONFIG_APP_ROLE_COMPANION */
+
+#endif /* DS_MBOX_H_ */

--- a/samples/boards/infineon/low_power_modes/src/ds_mbox.h
+++ b/samples/boards/infineon/low_power_modes/src/ds_mbox.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DS_MBOX_H_
+#define DS_MBOX_H_
+
+#include <stdint.h>
+#include <zephyr/kernel.h>
+
+/*
+ * Inter-core DeepSleep command mailbox (CM55 controller -> CM33-NS companion).
+ *
+ * A raw Cy_IPC_Drv channel lets the CM55 application command which system
+ * low-power mode the CM33-NS core should enter.  SRF owns MTB_IPC_CHAN_0
+ * (CY_IPC_CHAN_USER) and interrupt structs CY_IPC_INTR_USER..+3, so the mailbox
+ * uses the next free user channel and interrupt structure.  These reservations
+ * match soc/infineon/edge/pse84/mtb_ipc_config.h (MTB_IPC_CHANNEL_DS_MBOX /
+ * MTB_IPC_IRQ_DS_MBOX).  Both cores include this header and link ds_mbox.c.
+ */
+
+/* Command word exchanged over the mailbox channel data register. */
+#define DS_MBOX_CMD_DS     0U
+#define DS_MBOX_CMD_DS_RAM 1U
+#define DS_MBOX_CMD_DS_OFF 2U
+#define DS_MBOX_CMD_HIB    3U
+
+#if defined(CONFIG_APP_COMPANION_MBOX)
+/* DUT side: post a DeepSleep command word to the companion receiver. */
+void ds_mbox_send(uint32_t mode);
+#endif /* CONFIG_APP_COMPANION_MBOX */
+
+#if defined(CONFIG_APP_ROLE_COMPANION)
+/* Companion side: bring up the mailbox receiver (interrupt + channel mask). */
+void ds_mbox_receiver_init(void);
+
+/* Wait up to timeout for a mailbox command.  On success stores the requested
+ * command word in *mode and returns 0; returns -EAGAIN on timeout.
+ */
+int ds_mbox_wait(uint32_t *mode, k_timeout_t timeout);
+#endif /* CONFIG_APP_ROLE_COMPANION */
+
+#endif /* DS_MBOX_H_ */

--- a/samples/boards/infineon/low_power_modes/src/main.c
+++ b/samples/boards/infineon/low_power_modes/src/main.c
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+/*
+ * The per-core application (app_main) runs in a dedicated worker thread rather
+ * than on the main thread.  The DUT application builds several large
+ * driver-config structs on the stack and its DS-RAM entry path is deep, so it
+ * needs more stack than the default main thread; giving the worker its own
+ * 8 KiB stack keeps the main stack at its default size.  app_main is provided
+ * by the active target's source file (main_dut.c or main_companion.c).
+ */
+#define APP_THREAD_STACK_SIZE 8192
+#define APP_THREAD_PRIORITY   5
+
+void app_main(void);
+
+K_THREAD_STACK_DEFINE(app_thread_stack, APP_THREAD_STACK_SIZE);
+static struct k_thread app_thread;
+
+static void app_thread_entry(void *p1, void *p2, void *p3)
+{
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	app_main();
+}
+
+int main(void)
+{
+	k_thread_create(&app_thread, app_thread_stack, K_THREAD_STACK_SIZEOF(app_thread_stack),
+			app_thread_entry, NULL, NULL, NULL, APP_THREAD_PRIORITY, 0, K_NO_WAIT);
+
+	return 0;
+}

--- a/samples/boards/infineon/low_power_modes/src/main_companion.c
+++ b/samples/boards/infineon/low_power_modes/src/main_companion.c
@@ -1,0 +1,199 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#if defined(CONFIG_APP_ROLE_COMPANION)
+/* CM33 non-secure (TF-M) companion: PM-driven DeepSleep demo that blinks led0
+ * and enters the DeepSleep mode requested by the CM55 over the SRF mailbox.
+ * Brought over from samples/basic/blinky so this sample builds the CM33 image
+ * as well as the CM55 controller.
+ */
+#include <zephyr/drivers/gpio.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <cy_syspm.h>
+#include <soc.h>
+#include <cy_pdl.h>
+#include <cy_syslib.h>
+#include <cy_syspm_srf.h>
+#include <mtb_srf_pool.h>
+#include <system_edge.h>
+
+#include "ds_mbox.h"
+
+/* 1000 msec = 1 sec */
+#define SLEEP_TIME_MS 1000
+
+/* The devicetree node identifier for the "led0" alias. */
+#define LED0_NODE DT_ALIAS(led0)
+
+static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
+
+/* Map a mailbox command to the PDL DeepSleep-mode enum. */
+static cy_en_syspm_deep_sleep_mode_t ds_cmd_to_cy_mode(uint32_t mode)
+{
+	switch (mode) {
+	case DS_MBOX_CMD_DS:
+		return CY_SYSPM_MODE_DEEPSLEEP;
+	case DS_MBOX_CMD_DS_OFF:
+		return CY_SYSPM_MODE_DEEPSLEEP_OFF;
+	case DS_MBOX_CMD_DS_RAM:
+	default:
+		return CY_SYSPM_MODE_DEEPSLEEP_RAM;
+	}
+}
+
+/* Mirror of the PDL's private SRF structs (cy_syspm_v4.c).  The dedicated
+ * DS-OFF token operation takes the target DeepSleep mode plus a prepare/restore
+ * flag and returns a single cy_en_syspm_status_t.
+ */
+struct ds_srf_dsofftoken_in {
+	uint32_t deep_sleep_mode;
+	bool restore;
+};
+
+struct ds_srf_status_out {
+	cy_en_syspm_status_t ret_val;
+};
+
+/*
+ * Arm (prepare) or undo (restore) the DS-OFF retention token and the
+ * SOCMEM/APPCPU power dependencies over the dedicated secure operation.  These
+ * writes target secured registers that fault from the non-secure core, so relay
+ * them to the secure image - the same prepare/restore the PDL performs inside
+ * its CpuEnterDeepSleep relay.  Must run from a context where the SRF/IPC
+ * round-trip can complete (interrupts enabled), which is why it is issued here
+ * from the blink thread rather than from pm_state_set().
+ */
+static cy_en_syspm_status_t ds_arm_dsoff_token_srf(uint32_t deep_sleep_mode, bool restore)
+{
+	mtb_srf_invec_ns_t *in_vec = NULL;
+	mtb_srf_outvec_ns_t *out_vec = NULL;
+	mtb_srf_output_ns_t *output = NULL;
+	struct ds_srf_dsofftoken_in input_args = {
+		.deep_sleep_mode = deep_sleep_mode,
+		.restore = restore,
+	};
+	struct ds_srf_status_out output_args = {
+		.ret_val = CY_SYSPM_FAIL,
+	};
+	cy_rslt_t result;
+
+	result = mtb_srf_pool_allocate(&cy_pdl_srf_default_pool, &in_vec, &out_vec,
+				       CY_PDL_SYSPM_SRF_POOL_TIMEOUT);
+	if (result != CY_RSLT_SUCCESS) {
+		return CY_SYSPM_FAIL;
+	}
+
+	cy_pdl_invoke_srf_args invoke_args = {
+		.inVec = in_vec,
+		.outVec = out_vec,
+		.output_ptr = &output,
+		.op_id = (uint8_t)CY_PDL_SYSPM_OP_SETDSOFFTOKEN,
+		.submodule_id = CY_PDL_SECURE_SUBMODULE_SYSPM,
+		.base = NULL,
+		.sub_block = 0UL,
+		.input_base = (uint8_t *)&input_args,
+		.input_len = sizeof(input_args),
+		.output_base = (uint8_t *)&output_args,
+		.output_len = sizeof(output_args),
+		.invec_bases = NULL,
+		.invec_sizes = 0UL,
+		.outvec_bases = NULL,
+		.outvec_sizes = 0UL,
+	};
+
+	result = _Cy_PDL_Invoke_SRF(&invoke_args);
+	if ((result == CY_RSLT_SUCCESS) && (output != NULL)) {
+		memcpy(&output_args, &output->output_values[0], sizeof(output_args));
+	}
+
+	(void)mtb_srf_pool_free(&cy_pdl_srf_default_pool, in_vec, out_vec);
+
+	return (result == CY_RSLT_SUCCESS) ? output_args.ret_val : CY_SYSPM_FAIL;
+}
+
+/* Program every DeepSleep-mode selector this core owns for the requested
+ * low-power mode and, for DS-RAM / DS-OFF, arm the retention token and tear
+ * down the SOCMEM/APPCPU dependencies over the SRF.  Everything here relays to
+ * the secure image, so it must run from thread context (interrupts enabled);
+ * pm_state_set() runs interrupt-masked and only issues the local WFI.
+ */
+static void ds_apply_mode(uint32_t mode)
+{
+	cy_en_syspm_deep_sleep_mode_t cy_mode = ds_cmd_to_cy_mode(mode);
+
+	Cy_SysPm_DeepSleepSetup(cy_mode);
+	Cy_SysPm_SetSysDeepSleepMode(cy_mode);
+	Cy_SysPm_SetAppDeepSleepMode(cy_mode);
+
+	/* Regular DeepSleep needs neither the token nor the PDCM teardown. */
+	if ((cy_mode == CY_SYSPM_MODE_DEEPSLEEP_RAM) || (cy_mode == CY_SYSPM_MODE_DEEPSLEEP_OFF)) {
+		(void)ds_arm_dsoff_token_srf((uint32_t)cy_mode, false);
+	}
+}
+
+static int cm33_blinky_main(void)
+{
+	int ret;
+
+	if (!gpio_is_ready_dt(&led)) {
+		return 0;
+	}
+
+	ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
+	if (ret < 0) {
+		return 0;
+	}
+
+	/* Bring up the CM55 -> CM33-NS DeepSleep command mailbox; the CM55
+	 * controller requests the low-power mode and owns the SW0 wake source.
+	 */
+	ds_mbox_receiver_init();
+
+	while (1) {
+		uint32_t mode = 0U;
+
+		ret = gpio_pin_toggle_dt(&led);
+		if (ret < 0) {
+			return 0;
+		}
+
+		/* CM33 non-secure requires the IPC to request the CM33 secure code
+		 * to enter deep-sleep. Therefore regular k_msleep() cannot be used
+		 * for this purpose. ds_mbox_wait() blocks for one blink period.
+		 * If the CM55 commanded a mode, apply it and enter DeepSleep.
+		 */
+		if (ds_mbox_wait(&mode, K_MSEC(SLEEP_TIME_MS)) == 0) {
+			/* Hibernate is a system-wide SRSS power-off driven by the
+			 * CM55 with no inter-CPU handshake.  The companion must stay
+			 * active: entering a DeepSleep mode here drives the shared
+			 * SRSS/PDCM power state into retention and blocks the CM55
+			 * Hibernate from powering the chip down.
+			 */
+			if (mode != DS_MBOX_CMD_HIB) {
+				ds_apply_mode(mode);
+				(void)Cy_SysPm_CpuEnterDeepSleep(CY_SYSPM_WAIT_FOR_INTERRUPT);
+				SCB_SCR &= (uint32_t)~SCB_SCR_SLEEPDEEP_Msk;
+			}
+		}
+	}
+
+	return 0;
+}
+
+/* Application entry for the CM33-NS companion.  Invoked from the shared worker
+ * thread in main.c.
+ */
+void app_main(void)
+{
+	(void)cm33_blinky_main();
+}
+
+#endif /* CONFIG_APP_ROLE_COMPANION */

--- a/samples/boards/infineon/low_power_modes/src/main_companion.c
+++ b/samples/boards/infineon/low_power_modes/src/main_companion.c
@@ -1,0 +1,191 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#if defined(CONFIG_APP_ROLE_COMPANION)
+/* CM33 non-secure (TF-M) companion: PM-driven DeepSleep demo that blinks led0
+ * and enters the DeepSleep mode requested by the CM55 over the SRF mailbox.
+ * Brought over from samples/basic/blinky so this sample builds the CM33 image
+ * as well as the CM55 controller.
+ */
+#include <zephyr/drivers/gpio.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <cy_syspm.h>
+#include <soc.h>
+#include <cy_pdl.h>
+#include <cy_syslib.h>
+#include <cy_syspm_srf.h>
+#include <mtb_srf_pool.h>
+#include <system_edge.h>
+
+#include "ds_mbox.h"
+
+/* 1000 msec = 1 sec */
+#define SLEEP_TIME_MS 1000
+
+/* The devicetree node identifier for the "led0" alias. */
+#define LED0_NODE DT_ALIAS(led0)
+
+static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
+
+/* Map a mailbox command to the PDL DeepSleep-mode enum. */
+static cy_en_syspm_deep_sleep_mode_t ds_cmd_to_cy_mode(uint32_t mode)
+{
+	switch (mode) {
+	case DS_MBOX_CMD_DS:
+		return CY_SYSPM_MODE_DEEPSLEEP;
+	case DS_MBOX_CMD_DS_OFF:
+		return CY_SYSPM_MODE_DEEPSLEEP_OFF;
+	case DS_MBOX_CMD_DS_RAM:
+	default:
+		return CY_SYSPM_MODE_DEEPSLEEP_RAM;
+	}
+}
+
+/* Mirror of the PDL's private SRF structs (cy_syspm_v4.c).  The dedicated
+ * DS-OFF token operation takes the target DeepSleep mode plus a prepare/restore
+ * flag and returns a single cy_en_syspm_status_t.
+ */
+struct ds_srf_dsofftoken_in {
+	uint32_t deep_sleep_mode;
+	bool restore;
+};
+
+struct ds_srf_status_out {
+	cy_en_syspm_status_t ret_val;
+};
+
+/*
+ * Arm (prepare) or undo (restore) the DS-OFF retention token and the
+ * SOCMEM/APPCPU power dependencies over the dedicated secure operation.  These
+ * writes target secured registers that fault from the non-secure core, so relay
+ * them to the secure image - the same prepare/restore the PDL performs inside
+ * its CpuEnterDeepSleep relay.  Must run from a context where the SRF/IPC
+ * round-trip can complete (interrupts enabled), which is why it is issued here
+ * from the blink thread rather than from pm_state_set().
+ */
+static cy_en_syspm_status_t ds_arm_dsoff_token_srf(uint32_t deep_sleep_mode, bool restore)
+{
+	mtb_srf_invec_ns_t *in_vec = NULL;
+	mtb_srf_outvec_ns_t *out_vec = NULL;
+	mtb_srf_output_ns_t *output = NULL;
+	struct ds_srf_dsofftoken_in input_args = {
+		.deep_sleep_mode = deep_sleep_mode,
+		.restore = restore,
+	};
+	struct ds_srf_status_out output_args = {
+		.ret_val = CY_SYSPM_FAIL,
+	};
+	cy_rslt_t result;
+
+	result = mtb_srf_pool_allocate(&cy_pdl_srf_default_pool, &in_vec, &out_vec,
+				       CY_PDL_SYSPM_SRF_POOL_TIMEOUT);
+	if (result != CY_RSLT_SUCCESS) {
+		return CY_SYSPM_FAIL;
+	}
+
+	cy_pdl_invoke_srf_args invoke_args = {
+		.inVec = in_vec,
+		.outVec = out_vec,
+		.output_ptr = &output,
+		.op_id = (uint8_t)CY_PDL_SYSPM_OP_SETDSOFFTOKEN,
+		.submodule_id = CY_PDL_SECURE_SUBMODULE_SYSPM,
+		.base = NULL,
+		.sub_block = 0UL,
+		.input_base = (uint8_t *)&input_args,
+		.input_len = sizeof(input_args),
+		.output_base = (uint8_t *)&output_args,
+		.output_len = sizeof(output_args),
+		.invec_bases = NULL,
+		.invec_sizes = 0UL,
+		.outvec_bases = NULL,
+		.outvec_sizes = 0UL,
+	};
+
+	result = _Cy_PDL_Invoke_SRF(&invoke_args);
+	if ((result == CY_RSLT_SUCCESS) && (output != NULL)) {
+		memcpy(&output_args, &output->output_values[0], sizeof(output_args));
+	}
+
+	(void)mtb_srf_pool_free(&cy_pdl_srf_default_pool, in_vec, out_vec);
+
+	return (result == CY_RSLT_SUCCESS) ? output_args.ret_val : CY_SYSPM_FAIL;
+}
+
+/* Program every DeepSleep-mode selector this core owns for the requested
+ * low-power mode and, for DS-RAM / DS-OFF, arm the retention token and tear
+ * down the SOCMEM/APPCPU dependencies over the SRF.  Everything here relays to
+ * the secure image, so it must run from thread context (interrupts enabled);
+ * pm_state_set() runs interrupt-masked and only issues the local WFI.
+ */
+static void ds_apply_mode(uint32_t mode)
+{
+	cy_en_syspm_deep_sleep_mode_t cy_mode = ds_cmd_to_cy_mode(mode);
+
+	Cy_SysPm_DeepSleepSetup(cy_mode);
+	Cy_SysPm_SetSysDeepSleepMode(cy_mode);
+	Cy_SysPm_SetAppDeepSleepMode(cy_mode);
+
+	/* Regular DeepSleep needs neither the token nor the PDCM teardown. */
+	if ((cy_mode == CY_SYSPM_MODE_DEEPSLEEP_RAM) || (cy_mode == CY_SYSPM_MODE_DEEPSLEEP_OFF)) {
+		(void)ds_arm_dsoff_token_srf((uint32_t)cy_mode, false);
+	}
+}
+
+static int cm33_blinky_main(void)
+{
+	int ret;
+
+	if (!gpio_is_ready_dt(&led)) {
+		return 0;
+	}
+
+	ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
+	if (ret < 0) {
+		return 0;
+	}
+
+	/* Bring up the CM55 -> CM33-NS DeepSleep command mailbox; the CM55
+	 * controller requests the low-power mode and owns the SW0 wake source.
+	 */
+	ds_mbox_receiver_init();
+
+	while (1) {
+		uint32_t mode = 0U;
+
+		ret = gpio_pin_toggle_dt(&led);
+		if (ret < 0) {
+			return 0;
+		}
+
+		/* CM33 non-secure requires the IPC to request the CM33 secure code
+		 * to enter deep-sleep. Therefore regular k_msleep() cannot be used
+		 * for this purpose. ds_mbox_wait() blocks for one blink period.
+		 * If the CM55 commanded a mode, apply it and enter DeepSleep.
+		 */
+		if (ds_mbox_wait(&mode, K_MSEC(SLEEP_TIME_MS)) == 0) {
+			ds_apply_mode(mode);
+			(void)Cy_SysPm_CpuEnterDeepSleep(CY_SYSPM_WAIT_FOR_INTERRUPT);
+			SCB_SCR &= (uint32_t)~SCB_SCR_SLEEPDEEP_Msk;
+		}
+	}
+
+	return 0;
+}
+
+/* Application entry for the CM33-NS companion.  Invoked from the shared worker
+ * thread in main.c.
+ */
+void app_main(void)
+{
+	(void)cm33_blinky_main();
+}
+
+#endif /* CONFIG_APP_ROLE_COMPANION */

--- a/samples/boards/infineon/low_power_modes/src/main_dut.c
+++ b/samples/boards/infineon/low_power_modes/src/main_dut.c
@@ -1,0 +1,411 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#if defined(CONFIG_APP_ROLE_DUT)
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/sys/poweroff.h>
+
+#include <cy_syspm.h>
+#include <soc.h>
+#include <power.h>
+
+#if defined(CONFIG_APP_COMPANION_MBOX)
+#include "ds_mbox.h"
+#endif
+#include "peripherals.h"
+
+#define MAIN_SLEEP_TIME_MS 2000
+
+#define PM_MODE_DS     0
+#define PM_MODE_DS_RAM 1
+#define PM_MODE_DS_OFF 2
+#define PM_MODE_HIB    3
+
+/*
+ * Terminal low-power mode that ends the Phase-2 sequence.  The sequence always
+ * runs DeepSleep then DeepSleep-RAM (both return in-session), then one terminal
+ * mode, which powers the SoC down; wake is a button-press cold boot, so the run
+ * ends here.  The terminal mode is chosen at runtime: press the button to toggle
+ * between DeepSleep-OFF and hibernate, and the displayed mode is entered once no
+ * press arrives for this idle window (see run_terminal_mode()).
+ */
+#define TERMINAL_SELECT_TIMEOUT_MS 2000
+
+/*
+ * Two independent capabilities gate the Phase-2 sequence, both set in Kconfig:
+ *
+ *   CONFIG_APP_DEEP_MODES     - the SoC power management implements the retained
+ *                               (DeepSleep-RAM) and power-down (DeepSleep-OFF /
+ *                               hibernate) modes.
+ *   CONFIG_APP_COMPANION_MBOX - a second core runs the companion image and must
+ *                               be commanded into the same mode over the
+ *                               inter-core mailbox before this core sleeps.
+ *
+ * On PSE84 both track the SRF companion, so they are enabled together in the
+ * TF-M flow and disabled together in the sysbuild (pse84_boot.c) flow.  A
+ * single-core SoC enables APP_DEEP_MODES only and drives every register itself.
+ */
+
+#define LED0_NODE DT_ALIAS(led0)
+
+static const struct gpio_dt_spec red_led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
+
+#define SW0_NODE DT_ALIAS(sw0)
+#if !DT_NODE_HAS_STATUS(SW0_NODE, okay)
+#error "Unsupported board: sw0 devicetree alias is not defined"
+#endif
+static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET(SW0_NODE, gpios);
+static struct gpio_callback button_cb_data;
+
+/* Signalled from the button ISR; used to toggle the terminal mode selection. */
+K_SEM_DEFINE(button_sem, 0, 1);
+
+static uint32_t sleep_count;
+static uint32_t deepsleep_count;
+static uint32_t deepsleep_ram_count;
+
+static void pm_notifier_entry(enum pm_state state)
+{
+	switch (state) {
+	case PM_STATE_RUNTIME_IDLE:
+		sleep_count++;
+		break;
+	case PM_STATE_SUSPEND_TO_IDLE:
+		deepsleep_count++;
+		break;
+	case PM_STATE_SUSPEND_TO_RAM:
+		deepsleep_ram_count++;
+		break;
+	default:
+		break;
+	}
+}
+
+static struct pm_notifier pm_notif = {
+	.state_entry = pm_notifier_entry,
+};
+
+static void button_pressed(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
+{
+	printk("Button pressed at %" PRIu32 "\n", k_cycle_get_32());
+	k_sem_give(&button_sem);
+}
+
+static void print_pm_counts(void)
+{
+	printk("Sleep: %u | Deepsleep: %u\n", sleep_count, deepsleep_count);
+}
+
+/* Number of times the PM subsystem has entered a given deep state, used to
+ * confirm that a requested low-power mode actually engaged.
+ */
+static uint32_t pm_state_entry_count(enum pm_state state)
+{
+	switch (state) {
+	case PM_STATE_SUSPEND_TO_IDLE:
+		return deepsleep_count;
+	case PM_STATE_SUSPEND_TO_RAM:
+		return deepsleep_ram_count;
+	default:
+		return 0;
+	}
+}
+
+/* Run one retained/warm-boot low-power mode test (DeepSleep or DeepSleep-RAM).
+ * Commands the CM33-NS into the same mode over the mailbox, unlocks this mode's
+ * PM policy state so the idle loop can select it, exercises one sleep/wake cycle
+ * re-testing every present peripheral after wake, then restores the policy lock
+ * so the next mode in the sequence starts from a known state.
+ */
+static void run_retained_mode_test(uint32_t mbox_mode, enum pm_state test_state, const char *name)
+{
+	printk("Phase 2: exercising %s\n", name);
+
+	pm_policy_state_lock_put(test_state, PM_ALL_SUBSTATES);
+
+#if defined(CONFIG_APP_COMPANION_MBOX)
+	ds_mbox_send(mbox_mode);
+#else
+	ARG_UNUSED(mbox_mode);
+#endif
+
+	uint32_t cnt_before = peripherals_counter_read();
+	uint32_t entries_before = pm_state_entry_count(test_state);
+
+	printk("Phase 2: enter %s (counter=%u, watch blue LED freeze)\n", name, cnt_before);
+
+	uint32_t t0 = k_uptime_get_32();
+
+	k_msleep(MAIN_SLEEP_TIME_MS);
+
+	uint32_t t1 = k_uptime_get_32();
+
+	/* After a DeepSleep-RAM warm boot the peripheral hardware is powered
+	 * down and must be rebuilt before it is used - including the console
+	 * UART - so this eager rebuild runs before the first post-wake console
+	 * output.  ifx_pm_warm_boot_reinit_all() walks every device in link
+	 * order and runs its TURN_ON handler from this thread.  It stays
+	 * portable across Infineon devices: on a SoC whose warm boot already
+	 * rebuilds peripherals automatically it is a harmless idempotent repeat,
+	 * and on a SoC without DeepSleep-RAM it compiles to a no-op stub, so no
+	 * SoC-specific guard is needed here.
+	 */
+	if (test_state == PM_STATE_SUSPEND_TO_RAM) {
+		ifx_pm_warm_boot_reinit_all();
+	}
+
+	printk("Phase 2: woke after %u ms\n", t1 - t0);
+	print_pm_counts();
+
+	/* Confirm the requested state actually engaged.  If the platform only
+	 * supports a shallower mode (for example the sysbuild secure boot stub
+	 * configures regular DeepSleep only), the PM policy falls back and the
+	 * entry count does not advance.
+	 */
+	if (pm_state_entry_count(test_state) == entries_before) {
+		printk("Phase 2: WARNING - %s did not engage; platform fell back to a "
+		       "shallower state\n",
+		       name);
+	}
+
+	/* Re-test every present peripheral now that the clocks are back. */
+	peripherals_test_after_wake(name);
+
+	/* Lock the mode so the HF clocks stay on, then hold here.
+	 * The blue LED should blink during this window, which visually
+	 * confirms the PWM driver rebuilt the channel when the sample
+	 * re-applied it after wake (see peripherals_test_after_wake()).
+	 * Leave the lock held on exit so the next mode starts from a known
+	 * (locked) state without re-entering DeepSleep here.
+	 */
+	pm_policy_state_lock_get(test_state, PM_ALL_SUBSTATES);
+	printk("Phase 2: watch blue LED blink (PWM resumed via pm_action)\n");
+	k_msleep(MAIN_SLEEP_TIME_MS);
+}
+
+#if defined(CONFIG_APP_DEEP_MODES)
+
+/* Runtime-selected terminal power-down mode; toggled by the button in
+ * run_terminal_mode().  Starts at DeepSleep-OFF.
+ */
+static uint32_t terminal_pm_mode = PM_MODE_DS_OFF;
+
+static const char *terminal_mode_name(uint32_t mode)
+{
+	return (mode == PM_MODE_HIB) ? "Hibernate" : "DeepSleep-OFF";
+}
+
+/* Terminal mode: system DeepSleep-OFF.  Commands the CM33-NS into the same mode,
+ * then powers the CPU domain down: wake is a full cold boot, so this does not
+ * return on success and ends the run.  Enter through pm_state_set() (it masks
+ * interrupts before WFI) and press the wake button to trigger the cold boot.
+ */
+static void run_ds_off_mode(void)
+{
+	printk("Phase 2: exercising DeepSleep-OFF\n");
+
+	printk("Phase 2: entering DeepSleep-OFF. Press the button to wake/reset.\n");
+
+#if defined(CONFIG_APP_COMPANION_MBOX)
+	ds_mbox_send(PM_MODE_DS_OFF);
+#endif
+	pm_state_set(PM_STATE_SOFT_OFF, 1);
+
+	__enable_irq();
+	printk("Phase 2: DeepSleep-OFF did not engage\n");
+}
+
+/* Terminal mode: system hibernate.  Commands the CM33-NS into the same mode,
+ * then powers the whole chip down; wake is a button-press cold boot, so this
+ * does not return and ends the run.  Re-arm PIN1 (P8.3 / SW2, active low) as the
+ * hibernate wake source right before entry so its configuration is unambiguous.
+ */
+static void run_hibernate_mode(void)
+{
+	int ret;
+
+	printk("Phase 2: exercising Hibernate\n");
+
+	if (!gpio_is_ready_dt(&button)) {
+		printk("Error: button device %s is not ready\n", button.port->name);
+		return;
+	}
+	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
+	if (ret != 0) {
+		printk("Error %d: failed to configure %s pin %d\n", ret, button.port->name,
+		       button.pin);
+		return;
+	}
+	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret != 0) {
+		printk("Error %d: failed to configure interrupt on %s pin %d\n", ret,
+		       button.port->name, button.pin);
+		return;
+	}
+
+#if defined(CONFIG_APP_COMPANION_MBOX)
+	ds_mbox_send(PM_MODE_HIB);
+#endif
+	printk("Phase 2: entering hibernate. Press the button to wake/reset.\n");
+
+	/* Arm PIN1 (button, active low) as the hibernate wake source. */
+	ret = ifx_pse84_hibernate_wake_prepare(CY_SYSPM_HIBERNATE_PIN1_LOW);
+	if (ret != 0) {
+		printk("Phase 2: WARNING - wake source setup unavailable (%d)\n", ret);
+	}
+
+	pm_state_set(PM_STATE_SOFT_OFF, 0);
+
+	__enable_irq();
+	printk("Phase 2: Hibernate did not engage\n");
+}
+
+/* Let the operator choose the terminal power-down mode at runtime.  Each button
+ * press toggles between DeepSleep-OFF and hibernate; the displayed mode is
+ * entered once no press arrives for TERMINAL_SELECT_TIMEOUT_MS.  Entering a
+ * terminal mode powers the SoC down, so the selected mode ends the run.
+ */
+static void run_terminal_mode(void)
+{
+	printk("Phase 2: press the button to toggle the terminal mode "
+	       "(entered after %d ms idle)\n",
+	       TERMINAL_SELECT_TIMEOUT_MS);
+	printk("Phase 2: terminal mode = %s\n", terminal_mode_name(terminal_pm_mode));
+
+	/* Ignore any press latched during the earlier tests. */
+	k_sem_reset(&button_sem);
+
+	while (k_sem_take(&button_sem, K_MSEC(TERMINAL_SELECT_TIMEOUT_MS)) == 0) {
+		terminal_pm_mode =
+			(terminal_pm_mode == PM_MODE_DS_OFF) ? PM_MODE_HIB : PM_MODE_DS_OFF;
+		printk("Phase 2: terminal mode = %s\n", terminal_mode_name(terminal_pm_mode));
+	}
+
+	if (terminal_pm_mode == PM_MODE_HIB) {
+		run_hibernate_mode();
+	} else {
+		run_ds_off_mode();
+	}
+}
+
+#endif /* CONFIG_APP_DEEP_MODES */
+
+static int test_pm(void)
+{
+	int ret;
+
+	if (!gpio_is_ready_dt(&red_led)) {
+		return 0;
+	}
+	ret = gpio_pin_configure_dt(&red_led, GPIO_OUTPUT_INACTIVE);
+	if (ret < 0) {
+		return 0;
+	}
+
+	if (!gpio_is_ready_dt(&button)) {
+		printk("Error: button device %s is not ready\n", button.port->name);
+		return 0;
+	}
+	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
+	if (ret != 0) {
+		printk("Error %d: failed to configure %s pin %d\n", ret, button.port->name,
+		       button.pin);
+		return 0;
+	}
+	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret != 0) {
+		printk("Error %d: failed to configure interrupt on %s pin %d\n", ret,
+		       button.port->name, button.pin);
+		return 0;
+	}
+	gpio_init_callback(&button_cb_data, button_pressed, BIT(button.pin));
+	gpio_add_callback(button.port, &button_cb_data);
+
+	/* Configure every peripheral present in the devicetree and run its
+	 * baseline self-test.  Peripherals absent on this board are compiled
+	 * out inside peripherals.c.
+	 */
+	peripherals_setup();
+
+	/* Leave the DeepSleep mode configuration at its default.  The SoC's
+	 * pm_state_set() already selects the correct Cy_SysPm DeepSleep mode for
+	 * each transition (regular DeepSleep, DeepSleep-RAM, DeepSleep-OFF), so
+	 * the application must not override it here.
+	 */
+
+	pm_notifier_register(&pm_notif);
+
+	/* Startup: release any Hibernate I/O freeze latched by a prior hibernate
+	 * wake now that all pins are reconfigured, and pre-arm the wake button.
+	 * Best-effort: on a plain power-on boot nothing is frozen, and on a
+	 * platform with no secure relay (-ENOTSUP) the boot code performs the
+	 * unfreeze instead, so the result is intentionally ignored here.
+	 */
+	(void)ifx_pse84_hibernate_wake_prepare(CY_SYSPM_HIBERNATE_PIN1_LOW);
+
+	/*
+	 * Phase 1: Runtime-idle only (WFI sleep, clocks running)
+	 *
+	 * DeepSleep is locked out so the policy can only pick runtime-idle.
+	 * The blue LED keeps blinking and the counter keeps advancing.
+	 */
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+
+	printk("Phase 1: runtime-idle only\n");
+	k_msleep(MAIN_SLEEP_TIME_MS);
+	print_pm_counts();
+
+	/*
+	 * Phase 2: exercise the deep sleep modes
+	 *
+	 * For the retained (DS) and warm-boot (DS-RAM) modes, suspend the LED
+	 * thread so idle periods are long enough for the PM policy to select
+	 * the mode, then re-test every peripheral after wake to confirm the
+	 * device pm_action callbacks restored it.
+	 */
+	printk("Phase 2: run each low-power mode in sequence\n");
+
+	/* DeepSleep and DeepSleep-RAM return in-session, so run them back to
+	 * back, each commanding the CM33-NS into the same mode and re-testing
+	 * every peripheral after wake.
+	 */
+	run_retained_mode_test(PM_MODE_DS, PM_STATE_SUSPEND_TO_IDLE, "DeepSleep");
+
+#if defined(CONFIG_APP_DEEP_MODES)
+	run_retained_mode_test(PM_MODE_DS_RAM, PM_STATE_SUSPEND_TO_RAM, "DeepSleep-RAM");
+
+	/* The terminal mode powers the SoC down; wake is a button-press cold
+	 * boot, so it ends the run.  The button also selects DeepSleep-OFF vs
+	 * hibernate at runtime (see run_terminal_mode()).
+	 */
+	run_terminal_mode();
+#else
+	printk("Phase 2: DeepSleep-RAM and terminal power-down skipped "
+	       "(regular DeepSleep only)\n");
+#endif /* CONFIG_APP_DEEP_MODES */
+
+	printk("Sequence complete\n");
+
+	return 0;
+}
+
+/* Application entry for the DUT (device under test).  Invoked from the shared
+ * worker thread in main.c, which owns the enlarged stack this deep call path
+ * needs.
+ */
+void app_main(void)
+{
+	(void)test_pm();
+}
+
+#endif /* CONFIG_APP_ROLE_DUT */

--- a/samples/boards/infineon/low_power_modes/src/main_dut.c
+++ b/samples/boards/infineon/low_power_modes/src/main_dut.c
@@ -1,0 +1,397 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#if defined(CONFIG_APP_ROLE_DUT)
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
+#include <zephyr/sys/poweroff.h>
+
+#include <cy_syspm.h>
+#include <soc.h>
+#include <power.h>
+
+#if defined(CONFIG_APP_COMPANION_MBOX)
+#include "ds_mbox.h"
+#endif
+#include "peripherals.h"
+
+#define MAIN_SLEEP_TIME_MS 2000
+
+#define PM_MODE_DS     0
+#define PM_MODE_DS_RAM 1
+#define PM_MODE_DS_OFF 2
+#define PM_MODE_HIB    3
+
+/*
+ * Terminal low-power mode that ends the Phase-2 sequence.  The sequence always
+ * runs DeepSleep then DeepSleep-RAM (both return in-session), then one terminal
+ * mode, which powers the SoC down; wake is a button-press cold boot, so the run
+ * ends here.  The terminal mode is chosen at runtime: press the button to toggle
+ * between DeepSleep-OFF and hibernate, and the displayed mode is entered once no
+ * press arrives for this idle window (see run_terminal_mode()).
+ */
+#define TERMINAL_SELECT_TIMEOUT_MS 2000
+
+/*
+ * Two independent capabilities gate the Phase-2 sequence, both set in Kconfig:
+ *
+ *   CONFIG_APP_DEEP_MODES     - the SoC power management implements the retained
+ *                               (DeepSleep-RAM) and power-down (DeepSleep-OFF /
+ *                               hibernate) modes.
+ *   CONFIG_APP_COMPANION_MBOX - a second core runs the companion image and must
+ *                               be commanded into the same mode over the
+ *                               inter-core mailbox before this core sleeps.
+ *
+ * On PSE84 both track the SRF companion, so they are enabled together in the
+ * TF-M flow and disabled together in the sysbuild (pse84_boot.c) flow.  A
+ * single-core SoC enables APP_DEEP_MODES only and drives every register itself.
+ */
+
+#define LED0_NODE DT_ALIAS(led0)
+
+static const struct gpio_dt_spec red_led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
+
+#define SW0_NODE DT_ALIAS(sw0)
+#if !DT_NODE_HAS_STATUS(SW0_NODE, okay)
+#error "Unsupported board: sw0 devicetree alias is not defined"
+#endif
+static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET(SW0_NODE, gpios);
+static struct gpio_callback button_cb_data;
+
+/* Signalled from the button ISR; used to toggle the terminal mode selection. */
+K_SEM_DEFINE(button_sem, 0, 1);
+
+static uint32_t sleep_count;
+static uint32_t deepsleep_count;
+static uint32_t deepsleep_ram_count;
+
+static void pm_notifier_entry(enum pm_state state)
+{
+	switch (state) {
+	case PM_STATE_RUNTIME_IDLE:
+		sleep_count++;
+		break;
+	case PM_STATE_SUSPEND_TO_IDLE:
+		deepsleep_count++;
+		break;
+	case PM_STATE_SUSPEND_TO_RAM:
+		deepsleep_ram_count++;
+		break;
+	default:
+		break;
+	}
+}
+
+static struct pm_notifier pm_notif = {
+	.state_entry = pm_notifier_entry,
+};
+
+static void button_pressed(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
+{
+	printk("Button pressed at %" PRIu32 "\n", k_cycle_get_32());
+	k_sem_give(&button_sem);
+}
+
+static void print_pm_counts(void)
+{
+	printk("Sleep: %u | Deepsleep: %u\n", sleep_count, deepsleep_count);
+}
+
+/* Number of times the PM subsystem has entered a given deep state, used to
+ * confirm that a requested low-power mode actually engaged.
+ */
+static uint32_t pm_state_entry_count(enum pm_state state)
+{
+	switch (state) {
+	case PM_STATE_SUSPEND_TO_IDLE:
+		return deepsleep_count;
+	case PM_STATE_SUSPEND_TO_RAM:
+		return deepsleep_ram_count;
+	default:
+		return 0;
+	}
+}
+
+/* Run one retained/warm-boot low-power mode test (DeepSleep or DeepSleep-RAM).
+ * Commands the CM33-NS into the same mode over the mailbox, unlocks this mode's
+ * PM policy state so the idle loop can select it, exercises one sleep/wake cycle
+ * re-testing every present peripheral after wake, then restores the policy lock
+ * so the next mode in the sequence starts from a known state.
+ */
+static void run_retained_mode_test(uint32_t mbox_mode, enum pm_state test_state, const char *name)
+{
+	printk("Phase 2: exercising %s\n", name);
+
+	pm_policy_state_lock_put(test_state, PM_ALL_SUBSTATES);
+
+#if defined(CONFIG_APP_COMPANION_MBOX)
+	ds_mbox_send(mbox_mode);
+#else
+	ARG_UNUSED(mbox_mode);
+#endif
+
+	uint32_t cnt_before = peripherals_counter_read();
+	uint32_t entries_before = pm_state_entry_count(test_state);
+
+	printk("Phase 2: enter %s (counter=%u, watch blue LED freeze)\n", name, cnt_before);
+
+	uint32_t t0 = k_uptime_get_32();
+
+	k_msleep(MAIN_SLEEP_TIME_MS);
+
+	uint32_t t1 = k_uptime_get_32();
+
+	/* After a DeepSleep-RAM warm boot the peripheral hardware is powered
+	 * down and must be rebuilt before it is used - including the console
+	 * UART - so this eager rebuild runs before the first post-wake console
+	 * output.  ifx_pm_warm_boot_reinit_all() walks every device in link
+	 * order and runs its TURN_ON handler from this thread.  It stays
+	 * portable across Infineon devices: on a SoC whose warm boot already
+	 * rebuilds peripherals automatically it is a harmless idempotent repeat,
+	 * and on a SoC without DeepSleep-RAM it compiles to a no-op stub, so no
+	 * SoC-specific guard is needed here.
+	 */
+	if (test_state == PM_STATE_SUSPEND_TO_RAM) {
+		ifx_pm_warm_boot_reinit_all();
+	}
+
+	printk("Phase 2: woke after %u ms\n", t1 - t0);
+	print_pm_counts();
+
+	/* Confirm the requested state actually engaged.  If the platform only
+	 * supports a shallower mode (for example the sysbuild secure boot stub
+	 * configures regular DeepSleep only), the PM policy falls back and the
+	 * entry count does not advance.
+	 */
+	if (pm_state_entry_count(test_state) == entries_before) {
+		printk("Phase 2: WARNING - %s did not engage; platform fell back to a "
+		       "shallower state\n",
+		       name);
+	}
+
+	/* Re-test every present peripheral now that the clocks are back. */
+	peripherals_test_after_wake(name);
+
+	/* Lock the mode so the HF clocks stay on, then hold here.
+	 * The blue LED should blink during this window, which visually
+	 * confirms the PWM driver rebuilt the channel when the sample
+	 * re-applied it after wake (see peripherals_test_after_wake()).
+	 * Leave the lock held on exit so the next mode starts from a known
+	 * (locked) state without re-entering DeepSleep here.
+	 */
+	pm_policy_state_lock_get(test_state, PM_ALL_SUBSTATES);
+	printk("Phase 2: watch blue LED blink (PWM resumed via pm_action)\n");
+	k_msleep(MAIN_SLEEP_TIME_MS);
+}
+
+#if defined(CONFIG_APP_DEEP_MODES)
+
+/* Runtime-selected terminal power-down mode; toggled by the button in
+ * run_terminal_mode().  Starts at DeepSleep-OFF.
+ */
+static uint32_t terminal_pm_mode = PM_MODE_DS_OFF;
+
+static const char *terminal_mode_name(uint32_t mode)
+{
+	return (mode == PM_MODE_HIB) ? "Hibernate" : "DeepSleep-OFF";
+}
+
+/* Terminal mode: system DeepSleep-OFF.  Commands the CM33-NS into the same mode,
+ * then powers the CPU domain down: wake is a full cold boot, so this does not
+ * return on success and ends the run.  Enter through pm_state_set() (it masks
+ * interrupts before WFI) and press the wake button to trigger the cold boot.
+ */
+static void run_ds_off_mode(void)
+{
+	printk("Phase 2: exercising DeepSleep-OFF\n");
+
+	printk("Phase 2: entering DeepSleep-OFF. Press the button to wake/reset.\n");
+
+#if defined(CONFIG_APP_COMPANION_MBOX)
+	ds_mbox_send(PM_MODE_DS_OFF);
+#endif
+	pm_state_set(PM_STATE_SOFT_OFF, 1);
+
+	__enable_irq();
+	printk("Phase 2: DeepSleep-OFF did not engage\n");
+}
+
+/* Terminal mode: system hibernate.  Commands the CM33-NS into the same mode,
+ * then powers the whole chip down; wake is a button-press cold boot, so this
+ * does not return and ends the run.  The hibernate wake source is armed by
+ * the SoC at boot from the infineon,hibernate-wakeup devicetree node.
+ */
+static void run_hibernate_mode(void)
+{
+	int ret;
+
+	printk("Phase 2: exercising Hibernate\n");
+
+	if (!gpio_is_ready_dt(&button)) {
+		printk("Error: button device %s is not ready\n", button.port->name);
+		return;
+	}
+	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
+	if (ret != 0) {
+		printk("Error %d: failed to configure %s pin %d\n", ret, button.port->name,
+		       button.pin);
+		return;
+	}
+	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret != 0) {
+		printk("Error %d: failed to configure interrupt on %s pin %d\n", ret,
+		       button.port->name, button.pin);
+		return;
+	}
+
+#if defined(CONFIG_APP_COMPANION_MBOX)
+	ds_mbox_send(PM_MODE_HIB);
+#endif
+	printk("Phase 2: entering hibernate. Press the button to wake/reset.\n");
+
+	pm_state_set(PM_STATE_SOFT_OFF, 0);
+
+	__enable_irq();
+	printk("Phase 2: Hibernate did not engage\n");
+}
+
+/* Let the operator choose the terminal power-down mode at runtime.  Each button
+ * press toggles between DeepSleep-OFF and hibernate; the displayed mode is
+ * entered once no press arrives for TERMINAL_SELECT_TIMEOUT_MS.  Entering a
+ * terminal mode powers the SoC down, so the selected mode ends the run.
+ */
+static void run_terminal_mode(void)
+{
+	printk("Phase 2: press the button to toggle the terminal mode "
+	       "(entered after %d ms idle)\n",
+	       TERMINAL_SELECT_TIMEOUT_MS);
+	printk("Phase 2: terminal mode = %s\n", terminal_mode_name(terminal_pm_mode));
+
+	/* Ignore any press latched during the earlier tests. */
+	k_sem_reset(&button_sem);
+
+	while (k_sem_take(&button_sem, K_MSEC(TERMINAL_SELECT_TIMEOUT_MS)) == 0) {
+		terminal_pm_mode =
+			(terminal_pm_mode == PM_MODE_DS_OFF) ? PM_MODE_HIB : PM_MODE_DS_OFF;
+		printk("Phase 2: terminal mode = %s\n", terminal_mode_name(terminal_pm_mode));
+	}
+
+	if (terminal_pm_mode == PM_MODE_HIB) {
+		run_hibernate_mode();
+	} else {
+		run_ds_off_mode();
+	}
+}
+
+#endif /* CONFIG_APP_DEEP_MODES */
+
+static int test_pm(void)
+{
+	int ret;
+
+	if (!gpio_is_ready_dt(&red_led)) {
+		return 0;
+	}
+	ret = gpio_pin_configure_dt(&red_led, GPIO_OUTPUT_INACTIVE);
+	if (ret < 0) {
+		return 0;
+	}
+
+	if (!gpio_is_ready_dt(&button)) {
+		printk("Error: button device %s is not ready\n", button.port->name);
+		return 0;
+	}
+	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
+	if (ret != 0) {
+		printk("Error %d: failed to configure %s pin %d\n", ret, button.port->name,
+		       button.pin);
+		return 0;
+	}
+	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_EDGE_TO_ACTIVE);
+	if (ret != 0) {
+		printk("Error %d: failed to configure interrupt on %s pin %d\n", ret,
+		       button.port->name, button.pin);
+		return 0;
+	}
+	gpio_init_callback(&button_cb_data, button_pressed, BIT(button.pin));
+	gpio_add_callback(button.port, &button_cb_data);
+
+	/* Configure every peripheral present in the devicetree and run its
+	 * baseline self-test.  Peripherals absent on this board are compiled
+	 * out inside peripherals.c.
+	 */
+	peripherals_setup();
+
+	/* Leave the DeepSleep mode configuration at its default.  The SoC's
+	 * pm_state_set() already selects the correct Cy_SysPm DeepSleep mode for
+	 * each transition (regular DeepSleep, DeepSleep-RAM, DeepSleep-OFF), so
+	 * the application must not override it here.
+	 */
+
+	pm_notifier_register(&pm_notif);
+
+	/*
+	 * Phase 1: Runtime-idle only (WFI sleep, clocks running)
+	 *
+	 * DeepSleep is locked out so the policy can only pick runtime-idle.
+	 * The blue LED keeps blinking and the counter keeps advancing.
+	 */
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+
+	printk("Phase 1: runtime-idle only\n");
+	k_msleep(MAIN_SLEEP_TIME_MS);
+	print_pm_counts();
+
+	/*
+	 * Phase 2: exercise the deep sleep modes
+	 *
+	 * For the retained (DS) and warm-boot (DS-RAM) modes, suspend the LED
+	 * thread so idle periods are long enough for the PM policy to select
+	 * the mode, then re-test every peripheral after wake to confirm the
+	 * device pm_action callbacks restored it.
+	 */
+	printk("Phase 2: run each low-power mode in sequence\n");
+
+	/* DeepSleep and DeepSleep-RAM return in-session, so run them back to
+	 * back, each commanding the CM33-NS into the same mode and re-testing
+	 * every peripheral after wake.
+	 */
+	run_retained_mode_test(PM_MODE_DS, PM_STATE_SUSPEND_TO_IDLE, "DeepSleep");
+
+#if defined(CONFIG_APP_DEEP_MODES)
+	run_retained_mode_test(PM_MODE_DS_RAM, PM_STATE_SUSPEND_TO_RAM, "DeepSleep-RAM");
+
+	/* The terminal mode powers the SoC down; wake is a button-press cold
+	 * boot, so it ends the run.  The button also selects DeepSleep-OFF vs
+	 * hibernate at runtime (see run_terminal_mode()).
+	 */
+	run_terminal_mode();
+#else
+	printk("Phase 2: DeepSleep-RAM and terminal power-down skipped "
+	       "(regular DeepSleep only)\n");
+#endif /* CONFIG_APP_DEEP_MODES */
+
+	printk("Sequence complete\n");
+
+	return 0;
+}
+
+/* Application entry for the DUT (device under test).  Invoked from the shared
+ * worker thread in main.c, which owns the enlarged stack this deep call path
+ * needs.
+ */
+void app_main(void)
+{
+	(void)test_pm();
+}
+
+#endif /* CONFIG_APP_ROLE_DUT */

--- a/samples/boards/infineon/low_power_modes/src/peripherals.c
+++ b/samples/boards/infineon/low_power_modes/src/peripherals.c
@@ -1,0 +1,645 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#if defined(CONFIG_APP_ROLE_DUT)
+
+#include <zephyr/drivers/pwm.h>
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/i2s.h>
+#include <zephyr/drivers/sdhc.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/audio/dmic.h>
+#include <string.h>
+
+#include "peripherals.h"
+
+/*
+ * Per-peripheral presence guards.  Each peripheral's device, self-test and
+ * baseline/after-wake handling is compiled in only when the matching node is
+ * present in the board's devicetree, so this file adapts to other PSOC Edge E84
+ * boards that expose a different subset of peripherals.
+ */
+#define PERIPH_HAS_PWM     DT_NODE_HAS_STATUS(DT_ALIAS(pwm_led0), okay)
+#define PERIPH_HAS_COUNTER DT_NODE_HAS_STATUS(DT_ALIAS(counter0), okay)
+#define PERIPH_HAS_SPI     DT_NODE_HAS_STATUS(DT_NODELABEL(loopback_dev), okay)
+#define PERIPH_HAS_I2C     DT_NODE_HAS_STATUS(DT_NODELABEL(i2c0), okay)
+#define PERIPH_HAS_DMIC    DT_NODE_HAS_STATUS(DT_NODELABEL(dmic0), okay)
+#define PERIPH_HAS_I2S     DT_NODE_HAS_STATUS(DT_ALIAS(i2s_tx), okay)
+#define PERIPH_HAS_SDHC    DT_NODE_HAS_STATUS(DT_NODELABEL(sdhc1), okay)
+#define PERIPH_HAS_UART    DT_NODE_HAS_STATUS(DT_ALIAS(uart_test), okay)
+
+#if PERIPH_HAS_PWM
+static const struct pwm_dt_spec pwm_led = PWM_DT_SPEC_GET(DT_ALIAS(pwm_led0));
+#endif
+
+#if PERIPH_HAS_COUNTER
+static const struct device *const counter_dev = DEVICE_DT_GET(DT_ALIAS(counter0));
+#endif
+
+#if PERIPH_HAS_SPI
+#define SPI_LOOPBACK_NODE DT_NODELABEL(loopback_dev)
+static const struct spi_dt_spec spi_loopback =
+	SPI_DT_SPEC_GET(SPI_LOOPBACK_NODE, SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_TRANSFER_MSB);
+
+/* SPI loopback self-test: jumper P16.1 (MOSI) to P16.2 (MISO).  Sends a known
+ * pattern and checks the received bytes match.  Run before and after DeepSleep
+ * to confirm the SPI driver's pm_action keeps the block working across the
+ * low-power transition.
+ */
+static int spi_loopback_test(void)
+{
+	static const uint8_t tx_data[] = {0xA5, 0x5A, 0x00, 0xFF, 0x12, 0x34, 0x56, 0x78};
+	uint8_t rx_data[sizeof(tx_data)] = {0};
+	const struct spi_buf tx_buf = {.buf = (void *)tx_data, .len = sizeof(tx_data)};
+	const struct spi_buf rx_buf = {.buf = rx_data, .len = sizeof(rx_data)};
+	const struct spi_buf_set tx_set = {.buffers = &tx_buf, .count = 1};
+	const struct spi_buf_set rx_set = {.buffers = &rx_buf, .count = 1};
+	int ret;
+
+	ret = spi_transceive_dt(&spi_loopback, &tx_set, &rx_set);
+	if (ret < 0) {
+		printk("SPI: transceive failed (%d)\n", ret);
+		return ret;
+	}
+
+	if (memcmp(tx_data, rx_data, sizeof(tx_data)) != 0) {
+		printk("SPI loopback: MISMATCH (is P16.1 jumpered to P16.2?)\n");
+		return -EIO;
+	}
+
+	printk("SPI loopback: OK (%u bytes matched)\n", (unsigned int)sizeof(tx_data));
+	return 0;
+}
+#endif /* PERIPH_HAS_SPI */
+
+#if PERIPH_HAS_I2C
+/* I2C controller on SCB0 (P8.0 SCL / P8.1 SDA).  The eval board populates a
+ * BMI270 IMU at address 0x68; reading its CHIP_ID register is a self-contained
+ * single-instance probe.  The probe is repeated after each DeepSleep wake; an
+ * identical result confirms the I2C driver's pm_action kept the block working.
+ * If no device answers, the probe simply returns an error consistently.
+ */
+#define I2C_BUS_NODE DT_NODELABEL(i2c0)
+static const struct device *const i2c_dev = DEVICE_DT_GET(I2C_BUS_NODE);
+#define I2C_PROBE_ADDR 0x68U
+#define I2C_PROBE_REG  0x00U
+
+static int i2c_probe_test(void)
+{
+	uint8_t chip_id = 0;
+	int ret;
+
+	ret = i2c_reg_read_byte(i2c_dev, I2C_PROBE_ADDR, I2C_PROBE_REG, &chip_id);
+	if (ret < 0) {
+		printk("I2C probe: addr 0x%02x no response (%d)\n", I2C_PROBE_ADDR, ret);
+		return ret;
+	}
+
+	printk("I2C probe: addr 0x%02x reg 0x%02x = 0x%02x\n", I2C_PROBE_ADDR, I2C_PROBE_REG,
+	       chip_id);
+	return 0;
+}
+#endif /* PERIPH_HAS_I2C */
+
+#if PERIPH_HAS_DMIC
+/* PDM/PCM microphone on PDM3 (P8.5 clk, P8.6 data) captured through DMA0.  A
+ * single mono stream is started before and after each DeepSleep as a liveness
+ * check: the capture is refused while active so a regular DeepSleep never
+ * corrupts the stream, and bringing the stream back up after wake confirms the
+ * DMIC and DMA driver pm_action callbacks kept the audio path alive.
+ */
+#define DMIC_NODE DT_NODELABEL(dmic0)
+static const struct device *const dmic_dev = DEVICE_DT_GET(DMIC_NODE);
+#define DMIC_SAMPLE_RATE      16000U
+#define DMIC_SAMPLE_BITS      16U
+#define DMIC_HW_CHAN_IDX      1U
+#define DMIC_BYTES_PER_SAMPLE (DMIC_SAMPLE_BITS / 8U)
+/* One block holds 100 ms of mono audio. */
+#define DMIC_BLOCK_SIZE       (DMIC_BYTES_PER_SAMPLE * (DMIC_SAMPLE_RATE / 10U))
+#define DMIC_BLOCK_COUNT      4U
+#define DMIC_READ_TIMEOUT     1000
+K_MEM_SLAB_DEFINE_STATIC(dmic_mem_slab, DMIC_BLOCK_SIZE, DMIC_BLOCK_COUNT, 4);
+
+/* DMIC self-test: configure a single mono stream, start it and try to read one
+ * 100 ms block, then stop.  The goal here is a liveness check rather than a
+ * pass/fail on the audio data: if configure and START are accepted the PDM
+ * block and its DMA channel came up, so a read that returns data reports the
+ * captured size, and a read that merely times out (no block within the window)
+ * still reports the block as alive and streaming.  Run before and after
+ * DeepSleep to confirm the DMIC and DMA driver pm_action callbacks kept the
+ * audio path alive across the low-power transition.
+ */
+static int dmic_test(void)
+{
+	struct pcm_stream_cfg stream = {
+		.pcm_width = DMIC_SAMPLE_BITS,
+		.mem_slab = &dmic_mem_slab,
+	};
+	struct dmic_cfg cfg = {
+		.io = {
+			.min_pdm_clk_freq = 1000000,
+			.max_pdm_clk_freq = 3500000,
+			.min_pdm_clk_dc = 40,
+			.max_pdm_clk_dc = 60,
+		},
+		.streams = &stream,
+		.channel = {
+			.req_num_streams = 1,
+			.req_num_chan = 1,
+		},
+	};
+	void *buffer;
+	uint32_t size;
+	int ret;
+
+	cfg.channel.req_chan_map_lo = dmic_build_channel_map(0, DMIC_HW_CHAN_IDX, PDM_CHAN_LEFT);
+	cfg.streams[0].pcm_rate = DMIC_SAMPLE_RATE;
+	cfg.streams[0].block_size = DMIC_BLOCK_SIZE;
+
+	ret = dmic_configure(dmic_dev, &cfg);
+	if (ret < 0) {
+		printk("DMIC: configure failed (%d)\n", ret);
+		return ret;
+	}
+
+	ret = dmic_trigger(dmic_dev, DMIC_TRIGGER_START);
+	if (ret < 0) {
+		printk("DMIC: START trigger failed (%d)\n", ret);
+		return ret;
+	}
+
+	/* The block is alive from here: configure and START were accepted. */
+	ret = dmic_read(dmic_dev, 0, &buffer, &size, DMIC_READ_TIMEOUT);
+	if (ret == 0) {
+		printk("DMIC: alive, captured %u bytes\n", size);
+		k_mem_slab_free(&dmic_mem_slab, buffer);
+	} else if (ret == -EAGAIN) {
+		printk("DMIC: alive (configured + streaming), no block in %d ms\n",
+		       DMIC_READ_TIMEOUT);
+	} else {
+		printk("DMIC: read error (%d)\n", ret);
+	}
+
+	ret = dmic_trigger(dmic_dev, DMIC_TRIGGER_STOP);
+	if (ret < 0) {
+		printk("DMIC: STOP trigger failed (%d)\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+#endif /* PERIPH_HAS_DMIC */
+
+#if PERIPH_HAS_I2S
+/* I2S transmitter on TDM I2S1 (P11.0 SCK, P11.1 FSYNC, P11.2 SD) driven by
+ * DMA0.  Configured as a controller so it generates its own clocks and streams
+ * out a single block without needing an external codec.  The block is sent
+ * before and after each DeepSleep: a regular DeepSleep is refused while the
+ * stream is active so it never corrupts a transfer, and a successful re-send
+ * after wake confirms the I2S and DMA driver pm_action callbacks restored the
+ * TDM block.
+ */
+#define I2S_NODE DT_ALIAS(i2s_tx)
+static const struct device *const i2s_dev = DEVICE_DT_GET(I2S_NODE);
+#define I2S_SAMPLE_RATE   44100U
+#define I2S_WORD_SIZE     16U
+#define I2S_CHANNELS      2U
+#define I2S_SAMPLES       64U
+/* One stereo block of 16-bit samples. */
+#define I2S_BLOCK_SIZE    (I2S_SAMPLES * I2S_CHANNELS * sizeof(int16_t))
+#define I2S_BLOCK_COUNT   4U
+#define I2S_WRITE_TIMEOUT 1000
+K_MEM_SLAB_DEFINE_STATIC(i2s_mem_slab, I2S_BLOCK_SIZE, I2S_BLOCK_COUNT, 4);
+
+/* I2S self-test: configure the transmit stream as controller, queue one block
+ * of silence, start the stream and let it clock out, then drop it.  Run before
+ * and after DeepSleep to confirm the I2S driver's pm_action keeps the TDM block
+ * working across the low-power transition.
+ *
+ * The I2S API is asynchronous: I2S_TRIGGER_DRAIN/STOP only request a stop and
+ * the stream returns to the READY state later from the TX-underflow ISR.  This
+ * self-test instead uses I2S_TRIGGER_DROP, which returns the stream to READY
+ * synchronously, so the driver is never left in the RUNNING/STOPPING state when
+ * this function returns.  That matters here because a stream stuck in STOPPING
+ * would make the I2S pm_action veto every DeepSleep attempt and would reject the
+ * next i2s_configure() call.
+ */
+static int i2s_test(void)
+{
+	struct i2s_config i2s_cfg = {
+		.word_size = I2S_WORD_SIZE,
+		.channels = I2S_CHANNELS,
+		.format = I2S_FMT_DATA_FORMAT_I2S,
+		.options = I2S_OPT_FRAME_CLK_CONTROLLER | I2S_OPT_BIT_CLK_CONTROLLER,
+		.frame_clk_freq = I2S_SAMPLE_RATE,
+		.block_size = I2S_BLOCK_SIZE,
+		.mem_slab = &i2s_mem_slab,
+		.timeout = I2S_WRITE_TIMEOUT,
+	};
+	void *tx_block;
+	int ret;
+
+	ret = i2s_configure(i2s_dev, I2S_DIR_TX, &i2s_cfg);
+	if (ret < 0) {
+		printk("I2S: configure failed (%d)\n", ret);
+		return ret;
+	}
+
+	ret = k_mem_slab_alloc(&i2s_mem_slab, &tx_block, K_NO_WAIT);
+	if (ret < 0) {
+		printk("I2S: block alloc failed (%d)\n", ret);
+		return ret;
+	}
+	memset(tx_block, 0, I2S_BLOCK_SIZE);
+
+	ret = i2s_write(i2s_dev, tx_block, I2S_BLOCK_SIZE);
+	if (ret < 0) {
+		printk("I2S: write failed (%d)\n", ret);
+		k_mem_slab_free(&i2s_mem_slab, tx_block);
+		return ret;
+	}
+
+	ret = i2s_trigger(i2s_dev, I2S_DIR_TX, I2S_TRIGGER_START);
+	if (ret < 0) {
+		printk("I2S: START trigger failed (%d)\n", ret);
+		return ret;
+	}
+
+	/* Let the queued block clock out (one block is ~3 ms at 44.1 kHz). */
+	k_msleep(10);
+
+	/* DROP returns the stream to READY synchronously and frees any queued
+	 * buffers, so the driver is left idle and ready to be reconfigured.
+	 */
+	ret = i2s_trigger(i2s_dev, I2S_DIR_TX, I2S_TRIGGER_DROP);
+	if (ret < 0) {
+		printk("I2S: DROP trigger failed (%d)\n", ret);
+		return ret;
+	}
+
+	printk("I2S transmit: OK (%u bytes)\n", (unsigned int)I2S_BLOCK_SIZE);
+	return 0;
+}
+#endif /* PERIPH_HAS_I2S */
+
+#if PERIPH_HAS_SDHC
+/* SD host controller on SDHC1, the eval board's microSD card slot (P7.x) with
+ * card-detect on P17.7.  The self-test reads the host properties and applies an
+ * I/O configuration (power on, minimum clock, 1-bit bus), which programs the
+ * SDHC block registers and bus-clock divider; this needs no formatted card and
+ * card presence is only reported for information.  Run before and after each
+ * DeepSleep: an identical result confirms the SDHC driver's pm_action kept the
+ * block working across the low-power transition (the configuration is retained
+ * after a regular DeepSleep and fully re-initialized after a DeepSleep-RAM warm
+ * boot).
+ */
+#define SDHC_NODE DT_NODELABEL(sdhc1)
+static const struct device *const sdhc_dev = DEVICE_DT_GET(SDHC_NODE);
+
+/* SDHC self-test: read the host properties and apply an I/O configuration
+ * (power on, minimum clock, 1-bit bus, 3.3 V).  This programs the SDHC block
+ * registers and bus-clock divider without requiring a formatted card.  Run
+ * before and after DeepSleep to confirm the SDHC driver's pm_action keeps the
+ * block working across the low-power transition.
+ */
+static int sdhc_test(void)
+{
+	struct sdhc_host_props props;
+	struct sdhc_io io = {0};
+	int present;
+	int ret;
+
+	ret = sdhc_get_host_props(sdhc_dev, &props);
+	if (ret < 0) {
+		printk("SDHC: get_host_props failed (%d)\n", ret);
+		return ret;
+	}
+
+	io.clock = props.f_min;
+	io.bus_mode = SDHC_BUSMODE_PUSHPULL;
+	io.power_mode = SDHC_POWER_ON;
+	io.bus_width = SDHC_BUS_WIDTH1BIT;
+	io.timing = SDHC_TIMING_LEGACY;
+	io.signal_voltage = SD_VOL_3_3_V;
+
+	ret = sdhc_set_io(sdhc_dev, &io);
+	if (ret < 0) {
+		printk("SDHC: set_io failed (%d)\n", ret);
+		return ret;
+	}
+
+	present = sdhc_card_present(sdhc_dev);
+	printk("SDHC host configured: OK (f_min %u Hz, card %s)\n", props.f_min,
+	       (present == 1) ? "present" : "absent");
+	return 0;
+}
+#endif /* PERIPH_HAS_SDHC */
+
+#if PERIPH_HAS_UART
+/* Second UART instance on SCB5 (P17.1 TX, P17.0 RX).  This is a separate UART
+ * from the console and is the only one wired for device runtime PM in this
+ * sample: it opts in through zephyr,pm-device-runtime-auto, so the driver's
+ * interrupt-driven TX/RX enable paths take a runtime reference and the disable
+ * paths drop it.  The self-test loops a known pattern back through a physical
+ * P17.1 (TX) to P17.0 (RX) jumper using the interrupt-driven API, which both
+ * verifies the link and drives the runtime PM get/put paths.  Run before and
+ * after DeepSleep to confirm the block keeps working across the transition.
+ */
+#define UART_TEST_NODE DT_ALIAS(uart_test)
+static const struct device *const uart_test_dev = DEVICE_DT_GET(UART_TEST_NODE);
+
+static const uint8_t uart_test_tx[] = {0xC3, 0x3C, 0x00, 0xFF, 0xA5, 0x5A, 0x0F, 0xF0};
+static volatile uint8_t uart_test_rx[sizeof(uart_test_tx)];
+static volatile size_t uart_test_tx_idx;
+static volatile size_t uart_test_rx_idx;
+static K_SEM_DEFINE(uart_test_done, 0, 1);
+
+/* Interrupt-driven loopback ISR: fills the TX FIFO from the pattern and drains
+ * the RX FIFO into the receive buffer.  Each direction disables its own
+ * interrupt once complete, which drops the matching runtime PM reference.
+ */
+static void uart_test_isr(const struct device *dev, void *user_data)
+{
+	ARG_UNUSED(user_data);
+
+	uart_irq_update(dev);
+
+	while (uart_irq_is_pending(dev)) {
+		if (uart_irq_rx_ready(dev)) {
+			uint8_t c;
+
+			while ((uart_test_rx_idx < sizeof(uart_test_rx)) &&
+			       (uart_fifo_read(dev, &c, 1) == 1)) {
+				uart_test_rx[uart_test_rx_idx++] = c;
+			}
+
+			if (uart_test_rx_idx >= sizeof(uart_test_rx)) {
+				uart_irq_rx_disable(dev);
+				k_sem_give(&uart_test_done);
+			}
+		}
+
+		if (uart_irq_tx_ready(dev)) {
+			if (uart_test_tx_idx < sizeof(uart_test_tx)) {
+				uart_test_tx_idx += uart_fifo_fill(
+					dev, (const uint8_t *)&uart_test_tx[uart_test_tx_idx],
+					sizeof(uart_test_tx) - uart_test_tx_idx);
+			}
+
+			if ((uart_test_tx_idx >= sizeof(uart_test_tx)) &&
+			    uart_irq_tx_complete(dev)) {
+				uart_irq_tx_disable(dev);
+			}
+		}
+
+		uart_irq_update(dev);
+	}
+}
+
+/* UART loopback self-test: send the pattern with the interrupt-driven API and
+ * check the received bytes match.  Requires P17.1 (TX) jumpered to P17.0 (RX).
+ */
+static int uart_test(void)
+{
+	int ret;
+
+	uart_test_tx_idx = 0;
+	uart_test_rx_idx = 0;
+	memset((void *)uart_test_rx, 0, sizeof(uart_test_rx));
+	k_sem_reset(&uart_test_done);
+
+	ret = uart_irq_callback_user_data_set(uart_test_dev, uart_test_isr, NULL);
+	if (ret < 0) {
+		printk("UART: callback set failed (%d)\n", ret);
+		return ret;
+	}
+
+	uart_irq_rx_enable(uart_test_dev);
+	uart_irq_tx_enable(uart_test_dev);
+
+	if (k_sem_take(&uart_test_done, K_MSEC(100)) != 0) {
+		uart_irq_tx_disable(uart_test_dev);
+		uart_irq_rx_disable(uart_test_dev);
+		printk("UART loopback: TIMEOUT (is P17.1 jumpered to P17.0?)\n");
+		return -ETIMEDOUT;
+	}
+
+	if (memcmp((const void *)uart_test_rx, uart_test_tx, sizeof(uart_test_tx)) != 0) {
+		printk("UART loopback: MISMATCH (is P17.1 jumpered to P17.0?)\n");
+		return -EIO;
+	}
+
+	printk("UART loopback: OK (%u bytes matched)\n", (unsigned int)sizeof(uart_test_tx));
+	return 0;
+}
+#endif /* PERIPH_HAS_UART */
+
+void peripherals_setup(void)
+{
+#if PERIPH_HAS_PWM
+	/* PWM on blue LED at 2 Hz - HF clocks stop during DeepSleep, so a
+	 * frozen blue LED confirms DeepSleep entry and a resumed blink
+	 * confirms the PWM driver's pm_action restarted it on wake.
+	 */
+	if (!pwm_is_ready_dt(&pwm_led)) {
+		printk("Error: PWM device not ready\n");
+	} else {
+		int ret = pwm_set_dt(&pwm_led, PWM_MSEC(500), PWM_MSEC(250));
+
+		if (ret < 0) {
+			printk("Error %d: failed to set PWM\n", ret);
+		} else {
+			printk("PWM blue LED started at 2 Hz\n");
+		}
+	}
+#endif
+
+#if PERIPH_HAS_COUNTER
+	/* Free-running counter - it stops while HF clocks are gated during
+	 * DeepSleep and resumes counting on wake via the counter driver's
+	 * pm_action.  Reading the value across a sleep confirms it resumed.
+	 */
+	if (!device_is_ready(counter_dev)) {
+		printk("Error: counter device not ready\n");
+	} else {
+		int ret = counter_start(counter_dev);
+
+		if (ret < 0) {
+			printk("Error %d: failed to start counter\n", ret);
+		} else {
+			printk("Free-running counter started\n");
+		}
+	}
+#endif
+
+#if PERIPH_HAS_SPI
+	/* SPI loopback baseline - confirms the link works before any sleep.
+	 * Requires P16.1 (MOSI) jumpered to P16.2 (MISO).
+	 */
+	if (!spi_is_ready_dt(&spi_loopback)) {
+		printk("Error: SPI loopback device not ready\n");
+	} else {
+		printk("SPI loopback baseline:\n");
+		(void)spi_loopback_test();
+	}
+#endif
+
+#if PERIPH_HAS_I2C
+	/* I2C probe baseline - reads the on-board BMI270 CHIP_ID register. */
+	if (!device_is_ready(i2c_dev)) {
+		printk("Error: I2C bus %s not ready\n", i2c_dev->name);
+	} else {
+		printk("I2C probe baseline:\n");
+		(void)i2c_probe_test();
+	}
+#endif
+
+#if PERIPH_HAS_DMIC
+	/* DMIC capture baseline - captures one mono block from the PDM mic. */
+	if (!device_is_ready(dmic_dev)) {
+		printk("Error: DMIC device %s not ready\n", dmic_dev->name);
+	} else {
+		printk("DMIC capture baseline:\n");
+		(void)dmic_test();
+	}
+#endif
+
+#if PERIPH_HAS_I2S
+	/* I2S transmit baseline - streams one block out of the TDM block. */
+	if (!device_is_ready(i2s_dev)) {
+		printk("Error: I2S device %s not ready\n", i2s_dev->name);
+	} else {
+		printk("I2S transmit baseline:\n");
+		(void)i2s_test();
+	}
+#endif
+
+#if PERIPH_HAS_SDHC
+	/* SDHC baseline - configures the SD host block (no card required). */
+	if (!device_is_ready(sdhc_dev)) {
+		printk("Error: SDHC device %s not ready\n", sdhc_dev->name);
+	} else {
+		printk("SDHC baseline:\n");
+		(void)sdhc_test();
+	}
+#endif
+
+#if PERIPH_HAS_UART
+	/* UART loopback baseline - confirms the SCB5 link works before any sleep.
+	 * Requires P17.1 (TX) jumpered to P17.0 (RX).
+	 */
+	if (!device_is_ready(uart_test_dev)) {
+		printk("Error: UART test device %s not ready\n", uart_test_dev->name);
+	} else {
+		printk("UART loopback baseline:\n");
+		(void)uart_test();
+	}
+#endif
+}
+
+uint32_t peripherals_counter_read(void)
+{
+#if PERIPH_HAS_COUNTER
+	uint32_t val = 0;
+
+	(void)counter_get_value(counter_dev, &val);
+	return val;
+#else
+	return 0U;
+#endif
+}
+
+void peripherals_test_after_wake(const char *phase)
+{
+#if PERIPH_HAS_PWM
+	/* The PWM free-runs in hardware and is never read back, so unlike the
+	 * other peripherals nothing touches it after wake to trigger the
+	 * driver's lazy DeepSleep-RAM rebuild.  Re-apply the same setting here:
+	 * the first post-wake pwm_set_dt() runs the PWM driver's warm-boot
+	 * re-init (pm_action) and restarts the 2 Hz blink.
+	 */
+	if (pwm_is_ready_dt(&pwm_led)) {
+		int ret = pwm_set_dt(&pwm_led, PWM_MSEC(500), PWM_MSEC(250));
+
+		printk("Phase 2: PWM blue LED re-armed after %s (%s)\n", phase,
+		       (ret < 0) ? "FAILED" : "blinking");
+	}
+#endif
+
+#if PERIPH_HAS_COUNTER
+	uint32_t cnt_wake = 0;
+	uint32_t cnt_after = 0;
+
+	/* Two quick reads with clocks on: a changing value proves the
+	 * counter is running again, so its pm_action restarted it.
+	 */
+	(void)counter_get_value(counter_dev, &cnt_wake);
+	k_busy_wait(1000);
+	(void)counter_get_value(counter_dev, &cnt_after);
+
+	printk("Phase 2: counter %u -> %u (%s)\n", cnt_wake, cnt_after,
+	       (cnt_after != cnt_wake) ? "running" : "STOPPED");
+#endif
+
+#if PERIPH_HAS_SPI
+	/* Re-run the SPI loopback after waking: a match proves the SPI
+	 * driver's pm_action restored the block.
+	 */
+	printk("Phase 2: SPI loopback after %s:\n", phase);
+	(void)spi_loopback_test();
+#endif
+
+#if PERIPH_HAS_I2C
+	/* Re-run the I2C probe after waking: an identical result proves
+	 * the I2C driver's pm_action restored the SCB block.
+	 */
+	printk("Phase 2: I2C probe after %s:\n", phase);
+	(void)i2c_probe_test();
+#endif
+
+#if PERIPH_HAS_DMIC
+	/* Re-run the DMIC capture after waking: bringing the stream back up
+	 * proves the DMIC and DMA driver pm_action callbacks kept the audio
+	 * path alive.
+	 */
+	printk("Phase 2: DMIC capture after %s:\n", phase);
+	(void)dmic_test();
+#endif
+
+#if PERIPH_HAS_I2S
+	/* Re-run the I2S transmit after waking: a successful stream
+	 * proves the I2S and DMA driver pm_action callbacks restored
+	 * the TDM block.
+	 */
+	printk("Phase 2: I2S transmit after %s:\n", phase);
+	(void)i2s_test();
+#endif
+
+#if PERIPH_HAS_SDHC
+	/* Re-run the SDHC configuration after waking: an identical
+	 * result proves the SDHC driver's pm_action restored the host
+	 * block.
+	 */
+	printk("Phase 2: SDHC after %s:\n", phase);
+	(void)sdhc_test();
+#endif
+
+#if PERIPH_HAS_UART
+	/* Re-run the UART loopback after waking: a match proves the UART
+	 * driver kept the SCB5 block working and its restricted-scope
+	 * runtime PM get/put paths still balance across the transition.
+	 */
+	printk("Phase 2: UART loopback after %s:\n", phase);
+	(void)uart_test();
+#endif
+}
+
+#endif /* CONFIG_APP_ROLE_DUT */

--- a/samples/boards/infineon/low_power_modes/src/peripherals.h
+++ b/samples/boards/infineon/low_power_modes/src/peripherals.h
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef PERIPHERALS_H_
+#define PERIPHERALS_H_
+
+#include <stdint.h>
+
+/*
+ * Optional peripheral self-tests for the DUT application.
+ *
+ * Every peripheral is guarded by its devicetree presence inside peripherals.c,
+ * so this sample can target other Infineon boards that expose a different subset
+ * of peripherals.  A peripheral that is absent from the board's devicetree is
+ * compiled out entirely and its self-test simply does nothing.
+ */
+
+/*
+ * Configure every peripheral present on this board and run its baseline
+ * self-test.  Call once before the low-power sequence starts.
+ */
+void peripherals_setup(void);
+
+/*
+ * Read the free-running counter used to observe clock gating across DeepSleep.
+ * Returns 0 when no counter is present.
+ */
+uint32_t peripherals_counter_read(void);
+
+/*
+ * Re-run every present peripheral's self-test after a low-power wake and report
+ * whether the free-running counter resumed.  @p phase is the mode name printed
+ * with each result (for example "DeepSleep").
+ */
+void peripherals_test_after_wake(const char *phase);
+
+#endif /* PERIPHERALS_H_ */

--- a/samples/boards/infineon/low_power_modes/tests.yaml
+++ b/samples/boards/infineon/low_power_modes/tests.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+sample:
+  name: Infineon Low-Power Modes
+tests:
+  infineon.low_power_modes:
+    platform_allow:
+      - kit_pse84_eval/pse846gps2dbzc4a/m33
+      - kit_pse84_eval/pse846gps2dbzc4a/m55
+    tags:
+      - pm
+      - pwm
+      - counter
+      - gpio
+    filter: dt_compat_enabled("infineon,cat1-lp-timer-pdl")
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "PWM blue LED started at 2 Hz"
+        - "Free-running counter started"
+        - "Phase 1: runtime-idle only"
+        - "Phase 2: enter DeepSleep"
+        - "Phase 2: woke after [0-9]+ ms; counter [0-9]+ -> [0-9]+ \\(running\\)"
+        - "Sleep: [0-9]+ \\| Deepsleep: [1-9][0-9]*"
+        - "DeepSleep demo complete"


### PR DESCRIPTION
Sample to demonstrate the low power modes of Infineon SoCs. Each power mode is verified by monitoring the console to verify deep sleep entry and exit processes.

The sample is meant to be usable across several Infineon devices that support similar power modes. For PSE84, it focuses on CM55 as the DUT with the CM33 as a companion, and it can be built for two flavors:

1. Stub CM33 from pse84_boot.c that sets up the system deepsleep mode (regular DS by default). The sample only exercises regular sleep and deepsleep.
2. MCUBoot + TF-M CM33 + CM55. This exercises all power modes - sleep, deepsleep, ds-ram, ds-off, hibernate. Power modes ds-ram, ds-off, and hibernate perform a system reset, and require a valid application at a predetermined location in RRAM (hence MCUBoot). The TF-M sets up secure request framework (SRF), which allows CM33 non-secure and CM55 non-secure to request secure operations in the CM33 secure TF-M image. For the CM33, only the secure app can enter system deepsleep. The CM33 non-secure requires the interrupts to be enabled to use the SRF via IPC, and therefore it can only enter system deepsleep in thread context (instead of in the idle thread). An application-level IPC request is added so that the CM55 can request the CM33 non-secure to enter different power modes from it's own context.

Related PRs:
- https://github.com/zephyrproject-rtos/hal_infineon/pull/69
- https://github.com/zephyrproject-rtos/zephyr/pull/114221
- https://github.com/zephyrproject-rtos/zephyr/pull/114225