### PR TITLE
drivers: add pm_action for Infineon drivers

### DIFF
--- a/drivers/audio/dmic_infineon.c
+++ b/drivers/audio/dmic_infineon.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,13 @@
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/irq.h>
 #include <zephyr/drivers/dma.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/pm.h>
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+#include <power.h>
+#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(dmic_infineon, CONFIG_AUDIO_DMIC_LOG_LEVEL);
@@ -54,6 +61,10 @@ struct ifx_dmic_data {
 	/* pdm_pcm_ch_cfg[] indexed by PDM channel number */
 	cy_stc_pdm_pcm_channel_config_t pdm_pcm_ch_cfg[PDM_PCM_MAX_CHANNELS];
 	struct ifx_cat1_clock clock;
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/* Warm-boot generation this instance was last rebuilt at (retained). */
+	uint32_t warm_boot_gen;
+#endif
 	struct dma_channel dma_rx;
 	enum dmic_state state;
 	struct k_mem_slab *mem_slab;
@@ -62,6 +73,8 @@ struct ifx_dmic_data {
 	void *active_buf;
 	uint8_t num_pdm_channels;
 	uint8_t configured_pdm_channels; /* bitmask */
+	/* True while a device runtime PM reference is held for the capture window. */
+	bool pm_runtime_active;
 };
 
 static int dmic_stop_capture(const struct device *dev);
@@ -262,6 +275,15 @@ static int ifx_dmic_configure(const struct device *dev, struct dmic_cfg *cfg)
 	uint8_t pdm_ctl_idx_1;
 	enum pdm_lr lr_1;
 
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/*
+	 * If a DeepSleep-RAM warm boot happened since this instance was last used,
+	 * rebuild the base PDM hardware here, in the caller's thread context,
+	 * before (re)configuring the stream.  A no-op on every other call.
+	 */
+	(void)ifx_pm_warm_boot_reinit(dev, &data->warm_boot_gen);
+#endif
+
 	if (data->state == DMIC_STATE_ACTIVE) {
 		LOG_ERR("Cannot configure DMIC in active state");
 		return -EBUSY;
@@ -459,11 +481,20 @@ static int ifx_dmic_trigger(const struct device *dev, enum dmic_trigger cmd)
 			return -EIO;
 		}
 
+		/*
+		 * Reference the device for the capture window. With device runtime
+		 * PM this resumes the PDM block; the matching release happens on
+		 * PAUSE/STOP/RESET. Inert under system-managed PM.
+		 */
+		(void)pm_device_runtime_get(dev);
+
 		ret = dmic_start_capture(dev);
 		if (ret != 0) {
 			LOG_ERR("Failed to start capture: %d", ret);
+			(void)pm_device_runtime_put(dev);
 			return ret;
 		}
+		data->pm_runtime_active = true;
 
 		break;
 
@@ -472,11 +503,15 @@ static int ifx_dmic_trigger(const struct device *dev, enum dmic_trigger cmd)
 			return -EIO;
 		}
 
+		(void)pm_device_runtime_get(dev);
+
 		ret = dmic_start_capture(dev);
 		if (ret != 0) {
 			LOG_ERR("Failed to start capture: %d", ret);
+			(void)pm_device_runtime_put(dev);
 			return ret;
 		}
+		data->pm_runtime_active = true;
 
 		break;
 
@@ -491,6 +526,12 @@ static int ifx_dmic_trigger(const struct device *dev, enum dmic_trigger cmd)
 			      : (cmd == DMIC_TRIGGER_PAUSE) ? DMIC_STATE_PAUSED
 							    : DMIC_STATE_CONFIGURED;
 		dmic_stop_capture(dev);
+
+		/* Drop the capture-window reference taken at START/RELEASE. */
+		if (data->pm_runtime_active) {
+			data->pm_runtime_active = false;
+			(void)pm_device_runtime_put(dev);
+		}
 
 		break;
 
@@ -576,6 +617,81 @@ static int dmic_init(const struct device *dev)
 
 	return 0;
 }
+
+/*
+ * Cold-boot init wrapper. dmic_init() doubles as the PM TURN_ON handler and
+ * runs on every warm boot, so device runtime PM must be enabled here (once)
+ * rather than inside dmic_init().
+ */
+static int ifx_dmic_init(const struct device *dev)
+{
+	int ret = dmic_init(dev);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/* Enable device runtime PM; system-managed PM still applies when unused. */
+	ret = pm_device_runtime_enable(dev);
+	if (ret < 0) {
+		return ret;
+	}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
+
+	return 0;
+}
+
+#ifdef CONFIG_PM_DEVICE
+static int ifx_dmic_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct ifx_dmic_data *const data = dev->data;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend while a capture is running: DeepSleep gates
+		 * the PDM clock and halts the DMA, so the audio stream would be
+		 * corrupted (dropped/garbled samples).  Returning -EBUSY aborts
+		 * the low-power transition; the PM subsystem retries once the
+		 * application stops or pauses the stream.  In every non-active
+		 * state the PDM block is idle and safe to suspend.
+		 */
+		if (data->state == DMIC_STATE_ACTIVE) {
+			return -EBUSY;
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/*
+		 * A regular DeepSleep gates the clocks but retains the PDM
+		 * configuration, and capture is never active across the gate
+		 * (suspend is vetoed while active), so nothing needs restoring.
+		 * The DeepSleep-RAM warm-boot case, where the peripheral domain is
+		 * power-cycled and all PDM state is lost, is a power-loss
+		 * transition handled by PM_DEVICE_ACTION_TURN_ON.
+		 */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power-loss recovery.  A DeepSleep-RAM warm boot power-cycles the
+		 * peripheral domain and loses all PDM state, so re-initialize the
+		 * base hardware (pinctrl, peripheral clock divider, PDM de-init,
+		 * trigger mux, interrupts).  The application must call
+		 * dmic_configure() again before the next capture, mirroring the
+		 * post-init contract.  This action is emitted only on a genuine
+		 * DS-RAM warm boot, by the SoC's deferred re-init worker running in
+		 * thread context.
+		 */
+		return dmic_init(dev);
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
 
 static void dmic_isr(const struct device *dev, uint8_t channel)
 {
@@ -741,7 +857,10 @@ static DEVICE_API(dmic, dmic_ops) = {
 		.rx_queue = &dmic_msgq##index,                                                     \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(index, &dmic_init, NULL, &dmic_data_##index, &dmic_config_##index,   \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dmic_ops);
+	PM_DEVICE_DT_INST_DEFINE(index, ifx_dmic_pm_action);                                       \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(index, &ifx_dmic_init, PM_DEVICE_DT_INST_GET(index),                 \
+			      &dmic_data_##index, &dmic_config_##index, POST_KERNEL,               \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dmic_ops);
 
 DT_INST_FOREACH_STATUS_OKAY(IFX_DMIC_INIT)

--- a/drivers/audio/dmic_infineon.c
+++ b/drivers/audio/dmic_infineon.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,9 @@
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/irq.h>
 #include <zephyr/drivers/dma.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/pm.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(dmic_infineon, CONFIG_AUDIO_DMIC_LOG_LEVEL);
@@ -459,9 +462,17 @@ static int ifx_dmic_trigger(const struct device *dev, enum dmic_trigger cmd)
 			return -EIO;
 		}
 
+		/*
+		 * Take the capture-window reference. With device runtime PM this
+		 * resumes the PDM block; the matching release happens on
+		 * PAUSE/STOP/RESET. Inert under system-managed PM.
+		 */
+		(void)pm_device_runtime_get(dev);
+
 		ret = dmic_start_capture(dev);
 		if (ret != 0) {
 			LOG_ERR("Failed to start capture: %d", ret);
+			(void)pm_device_runtime_put(dev);
 			return ret;
 		}
 
@@ -472,9 +483,12 @@ static int ifx_dmic_trigger(const struct device *dev, enum dmic_trigger cmd)
 			return -EIO;
 		}
 
+		(void)pm_device_runtime_get(dev);
+
 		ret = dmic_start_capture(dev);
 		if (ret != 0) {
 			LOG_ERR("Failed to start capture: %d", ret);
+			(void)pm_device_runtime_put(dev);
 			return ret;
 		}
 
@@ -482,7 +496,10 @@ static int ifx_dmic_trigger(const struct device *dev, enum dmic_trigger cmd)
 
 	case DMIC_TRIGGER_PAUSE:
 	case DMIC_TRIGGER_STOP:
-	case DMIC_TRIGGER_RESET:
+	case DMIC_TRIGGER_RESET: {
+		/* A capture-window reference is held only while ACTIVE. */
+		bool was_active = (data->state == DMIC_STATE_ACTIVE);
+
 		for (uint8_t ch = 0; ch < PDM_PCM_MAX_CHANNELS; ch++) {
 			/* prevent interrupts from occurring while stopping the stream */
 			Cy_PDM_PCM_Channel_SetInterruptMask(config->reg_addr, ch, 0);
@@ -492,7 +509,14 @@ static int ifx_dmic_trigger(const struct device *dev, enum dmic_trigger cmd)
 							    : DMIC_STATE_CONFIGURED;
 		dmic_stop_capture(dev);
 
+		/* Drop the capture-window reference taken at START/RELEASE. */
+		if (was_active) {
+			ret = pm_device_runtime_put(dev);
+			__ASSERT(ret == 0, "unbalanced PM runtime put: %d", ret);
+		}
+
 		break;
+	}
 
 	default:
 		return -EINVAL;
@@ -576,6 +600,64 @@ static int dmic_init(const struct device *dev)
 
 	return 0;
 }
+
+/*
+ * Cold-boot init wrapper. dmic_init() doubles as the PM TURN_ON handler and
+ * runs on every warm boot, so device runtime PM must be enabled here (once)
+ * rather than inside dmic_init().
+ */
+static int ifx_dmic_init(const struct device *dev)
+{
+	int ret = dmic_init(dev);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/* Enable device runtime PM; system-managed PM still applies when unused. */
+	ret = pm_device_runtime_enable(dev);
+	if (ret < 0) {
+		return ret;
+	}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
+
+	return 0;
+}
+
+#ifdef CONFIG_PM_DEVICE
+static int ifx_dmic_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct ifx_dmic_data *const data = dev->data;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend while capturing: gating the PDM clock would
+		 * corrupt the audio stream. Retried once capture stops or pauses.
+		 */
+		if (data->state == DMIC_STATE_ACTIVE) {
+			return -EBUSY;
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/* Configuration is retained across the gate; nothing to restore. */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power was lost: re-init the base hardware. The application must
+		 * call dmic_configure() again before the next capture.
+		 */
+		return dmic_init(dev);
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
 
 static void dmic_isr(const struct device *dev, uint8_t channel)
 {
@@ -741,7 +823,10 @@ static DEVICE_API(dmic, dmic_ops) = {
 		.rx_queue = &dmic_msgq##index,                                                     \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(index, &dmic_init, NULL, &dmic_data_##index, &dmic_config_##index,   \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dmic_ops);
+	PM_DEVICE_DT_INST_DEFINE(index, ifx_dmic_pm_action);                                       \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(index, &ifx_dmic_init, PM_DEVICE_DT_INST_GET(index),                 \
+			      &dmic_data_##index, &dmic_config_##index, POST_KERNEL,               \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &dmic_ops);
 
 DT_INST_FOREACH_STATUS_OKAY(IFX_DMIC_INIT)

--- a/drivers/counter/counter_infineon_tcpwm.c
+++ b/drivers/counter/counter_infineon_tcpwm.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,12 +11,18 @@
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/pm.h>
 #include <infineon_kconfig.h>
 #include <zephyr/drivers/timer/ifx_tcpwm.h>
 #include <zephyr/dt-bindings/pinctrl/ifx_cat1-pinctrl.h>
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/util.h>
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+#include <power.h>
+#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ifx_tcpwm_counter, CONFIG_COUNTER_LOG_LEVEL);
@@ -50,6 +56,16 @@ struct ifx_tcpwm_counter_data {
 	struct ifx_cat1_clock clock;
 	/* Counter input frequency, cached at init (see ifx_tcpwm_counter_get_freq) */
 	uint32_t freq;
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/* Warm-boot generation this instance was last rebuilt at (retained). */
+	uint32_t warm_boot_gen;
+#endif
+#ifdef CONFIG_PM_DEVICE
+	/* Whether the counter was running when suspend was entered, so
+	 * resume only restarts a counter that was previously active.
+	 */
+	bool was_running;
+#endif /* CONFIG_PM_DEVICE */
 };
 
 static const cy_stc_tcpwm_counter_config_t counter_default_config = {
@@ -205,6 +221,14 @@ static int ifx_tcpwm_counter_start(const struct device *dev)
 
 	const struct ifx_tcpwm_counter_config *config = dev->config;
 
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	{
+		struct ifx_tcpwm_counter_data *const pm_data = dev->data;
+
+		(void)ifx_pm_warm_boot_reinit(dev, &pm_data->warm_boot_gen);
+	}
+#endif
+
 	Cy_TCPWM_Counter_Enable(config->reg_base, config->index);
 
 #if defined(CONFIG_SOC_FAMILY_INFINEON_PSOC4)
@@ -212,6 +236,14 @@ static int ifx_tcpwm_counter_start(const struct device *dev)
 #else
 	Cy_TCPWM_TriggerStart_Single(config->reg_base, config->index);
 #endif
+
+#ifdef CONFIG_PM_DEVICE
+	{
+		struct ifx_tcpwm_counter_data *const data = dev->data;
+
+		data->was_running = true;
+	}
+#endif /* CONFIG_PM_DEVICE */
 
 	return 0;
 }
@@ -223,6 +255,14 @@ static int ifx_tcpwm_counter_stop(const struct device *dev)
 	const struct ifx_tcpwm_counter_config *config = dev->config;
 
 	Cy_TCPWM_Counter_Disable(config->reg_base, config->index);
+
+#ifdef CONFIG_PM_DEVICE
+	{
+		struct ifx_tcpwm_counter_data *const data = dev->data;
+
+		data->was_running = false;
+	}
+#endif /* CONFIG_PM_DEVICE */
 
 	return 0;
 }
@@ -245,6 +285,19 @@ static int ifx_tcpwm_counter_get_value(const struct device *dev, uint32_t *ticks
 	__ASSERT_NO_MSG(ticks != NULL);
 
 	const struct ifx_tcpwm_counter_config *config = dev->config;
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/*
+	 * If a DeepSleep-RAM warm boot happened since this counter was last used,
+	 * rebuild (and restart) it here, in the caller's thread context, before
+	 * reading the count.  A no-op on every other call.
+	 */
+	{
+		struct ifx_tcpwm_counter_data *const pm_data = dev->data;
+
+		(void)ifx_pm_warm_boot_reinit(dev, &pm_data->warm_boot_gen);
+	}
+#endif
 
 	*ticks = Cy_TCPWM_Counter_GetCounter(config->reg_base, config->index);
 
@@ -480,6 +533,72 @@ static int ifx_tcpwm_counter_set_guard_period(const struct device *dev, uint32_t
 	return 0;
 }
 
+#ifdef CONFIG_PM_DEVICE
+static int ifx_tcpwm_counter_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct ifx_tcpwm_counter_data *const data = dev->data;
+#if defined(CONFIG_PM_S2RAM)
+	int ret;
+#endif /* CONFIG_PM_S2RAM */
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/* Nothing to do. Returning success ensures DeepSleep entry is never blocked. */
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/*
+		 * Resume from a retained low-power state (regular DeepSleep): the
+		 * clocks were gated but the peripheral domain and its configuration
+		 * survived, so only restart the counter if it was running before the
+		 * transition.
+		 */
+#if defined(CONFIG_PM_S2RAM)
+		/*
+		 * RESUME is invoked for BOTH SUSPEND_TO_IDLE (regular, retained
+		 * DeepSleep) and SUSPEND_TO_RAM (DS-RAM warm boot).  A DS-RAM warm
+		 * boot power-cycles the domain and loses all counter state; the block
+		 * is rebuilt by PM_DEVICE_ACTION_TURN_ON (the SoC's deferred re-init
+		 * worker), which fully re-inits and restarts it.  Skip the light
+		 * restart here on that path so a power-cycled, unconfigured block is
+		 * not enabled before TURN_ON re-initializes it.
+		 */
+		if (pm_state_next_get(_current_cpu->id)->state == PM_STATE_SUSPEND_TO_RAM) {
+			break;
+		}
+#endif /* CONFIG_PM_S2RAM */
+		if (data->was_running) {
+			(void)ifx_tcpwm_counter_start(dev);
+		}
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power-loss recovery.  A DeepSleep-RAM warm boot power-cycles the
+		 * peripheral domain and loses all counter state, so re-initialize the
+		 * block and restart it if it was running before the transition.  This
+		 * action is emitted only on a genuine DS-RAM warm boot (by the SoC's
+		 * deferred re-init worker running in thread context), so its
+		 * invocation is the "power was lost" signal - no separate warm-boot
+		 * flag query is needed.
+		 */
+		ret = ifx_tcpwm_counter_init(dev);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (data->was_running) {
+			(void)ifx_tcpwm_counter_start(dev);
+		}
+		break;
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
+
 static DEVICE_API(counter, counter_api) = {
 	.start = ifx_tcpwm_counter_start,
 	.stop = ifx_tcpwm_counter_stop,
@@ -545,6 +664,8 @@ static DEVICE_API(counter, counter_api) = {
 	static struct ifx_tcpwm_counter_data ifx_tcpwm_counter##n##_data = {                       \
 		COUNTER_PERI_CLOCK_INIT(n)};                                                       \
                                                                                                    \
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_tcpwm_counter_pm_action);                                  \
+                                                                                                   \
 	static const struct ifx_tcpwm_counter_config ifx_tcpwm_counter##n##_config = {             \
 		.counter_info = {.max_top_value = (DT_PROP(DT_INST_PARENT(n), resolution) == 32)   \
 							  ? UINT32_MAX                             \
@@ -560,8 +681,8 @@ static DEVICE_API(counter, counter_api) = {
 		.irq_enable_func = ifx_counter_irq_enable_func_##n,                                \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, ifx_tcpwm_counter_init, NULL, &ifx_tcpwm_counter##n##_data,       \
-			      &ifx_tcpwm_counter##n##_config, POST_KERNEL,                         \
-			      CONFIG_COUNTER_INIT_PRIORITY, &counter_api);
+	DEVICE_DT_INST_DEFINE(n, ifx_tcpwm_counter_init, PM_DEVICE_DT_INST_GET(n),                 \
+			      &ifx_tcpwm_counter##n##_data, &ifx_tcpwm_counter##n##_config,        \
+			      PRE_KERNEL_1, CONFIG_COUNTER_INIT_PRIORITY, &counter_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INFINEON_TCPWM_COUNTER_INIT);

--- a/drivers/counter/counter_infineon_tcpwm.c
+++ b/drivers/counter/counter_infineon_tcpwm.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,6 +11,8 @@
 
 #include <zephyr/drivers/counter.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/pm.h>
 #include <infineon_kconfig.h>
 #include <zephyr/drivers/timer/ifx_tcpwm.h>
 #include <zephyr/dt-bindings/pinctrl/ifx_cat1-pinctrl.h>
@@ -50,6 +52,12 @@ struct ifx_tcpwm_counter_data {
 	struct ifx_cat1_clock clock;
 	/* Counter input frequency, cached at init (see ifx_tcpwm_counter_get_freq) */
 	uint32_t freq;
+#ifdef CONFIG_PM_DEVICE
+	/* Whether the counter was running when suspend was entered, so
+	 * resume only restarts a counter that was previously active.
+	 */
+	bool was_running;
+#endif /* CONFIG_PM_DEVICE */
 };
 
 static const cy_stc_tcpwm_counter_config_t counter_default_config = {
@@ -213,6 +221,14 @@ static int ifx_tcpwm_counter_start(const struct device *dev)
 	Cy_TCPWM_TriggerStart_Single(config->reg_base, config->index);
 #endif
 
+#ifdef CONFIG_PM_DEVICE
+	{
+		struct ifx_tcpwm_counter_data *const data = dev->data;
+
+		data->was_running = true;
+	}
+#endif /* CONFIG_PM_DEVICE */
+
 	return 0;
 }
 
@@ -223,6 +239,14 @@ static int ifx_tcpwm_counter_stop(const struct device *dev)
 	const struct ifx_tcpwm_counter_config *config = dev->config;
 
 	Cy_TCPWM_Counter_Disable(config->reg_base, config->index);
+
+#ifdef CONFIG_PM_DEVICE
+	{
+		struct ifx_tcpwm_counter_data *const data = dev->data;
+
+		data->was_running = false;
+	}
+#endif /* CONFIG_PM_DEVICE */
 
 	return 0;
 }
@@ -480,6 +504,54 @@ static int ifx_tcpwm_counter_set_guard_period(const struct device *dev, uint32_t
 	return 0;
 }
 
+#ifdef CONFIG_PM_DEVICE
+static int ifx_tcpwm_counter_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct ifx_tcpwm_counter_data *const data = dev->data;
+#if defined(CONFIG_PM_S2RAM)
+	int ret;
+#endif /* CONFIG_PM_S2RAM */
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/* Nothing to do; the block can be gated as-is. */
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+#if defined(CONFIG_PM_S2RAM)
+		/*
+		 * On a DS-RAM warm boot the block is power-cycled and rebuilt by
+		 * TURN_ON, so skip the light restart here.
+		 */
+		if (pm_state_next_get(_current_cpu->id)->state == PM_STATE_SUSPEND_TO_RAM) {
+			break;
+		}
+#endif /* CONFIG_PM_S2RAM */
+		/* Configuration is retained across the gate; restart if it was running. */
+		if (data->was_running) {
+			(void)ifx_tcpwm_counter_start(dev);
+		}
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/* Power was lost: re-init the block and restart if it was running. */
+		ret = ifx_tcpwm_counter_init(dev);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (data->was_running) {
+			(void)ifx_tcpwm_counter_start(dev);
+		}
+		break;
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
+
 static DEVICE_API(counter, counter_api) = {
 	.start = ifx_tcpwm_counter_start,
 	.stop = ifx_tcpwm_counter_stop,
@@ -545,6 +617,8 @@ static DEVICE_API(counter, counter_api) = {
 	static struct ifx_tcpwm_counter_data ifx_tcpwm_counter##n##_data = {                       \
 		COUNTER_PERI_CLOCK_INIT(n)};                                                       \
                                                                                                    \
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_tcpwm_counter_pm_action);                                  \
+                                                                                                   \
 	static const struct ifx_tcpwm_counter_config ifx_tcpwm_counter##n##_config = {             \
 		.counter_info = {.max_top_value = (DT_PROP(DT_INST_PARENT(n), resolution) == 32)   \
 							  ? UINT32_MAX                             \
@@ -560,8 +634,8 @@ static DEVICE_API(counter, counter_api) = {
 		.irq_enable_func = ifx_counter_irq_enable_func_##n,                                \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, ifx_tcpwm_counter_init, NULL, &ifx_tcpwm_counter##n##_data,       \
-			      &ifx_tcpwm_counter##n##_config, POST_KERNEL,                         \
-			      CONFIG_COUNTER_INIT_PRIORITY, &counter_api);
+	DEVICE_DT_INST_DEFINE(n, ifx_tcpwm_counter_init, PM_DEVICE_DT_INST_GET(n),                 \
+			      &ifx_tcpwm_counter##n##_data, &ifx_tcpwm_counter##n##_config,        \
+			      PRE_KERNEL_1, CONFIG_COUNTER_INIT_PRIORITY, &counter_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INFINEON_TCPWM_COUNTER_INIT);

--- a/drivers/dma/dma_infineon_pdl.c
+++ b/drivers/dma/dma_infineon_pdl.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,6 +20,8 @@
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/cache.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/pm.h>
 
 #include <cy_pdl.h>
 #include <soc.h>
@@ -490,6 +492,57 @@ static int ifx_cat1_dma_init(const struct device *dev)
 	return 0;
 }
 
+#ifdef CONFIG_PM_DEVICE
+static int ifx_cat1_dma_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	uint32_t channel;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend while any channel is still enabled: a
+		 * DeepSleep gates the DMA clock and would abort an in-flight
+		 * transfer, losing data.  Consumers disable their channel once
+		 * the transfer completes, so an enabled channel signals work in
+		 * progress.  Returning -EBUSY aborts the low-power transition;
+		 * the PM subsystem retries once the channels are idle.
+		 */
+		for (channel = 0U; channel < cfg->num_channels; channel++) {
+			if (Cy_DMA_Channel_IsEnabled(cfg->regs, channel)) {
+				return -EBUSY;
+			}
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/*
+		 * A regular DeepSleep gates the clock but retains the DMA block
+		 * and channel configuration, so nothing needs restoring on that
+		 * path.  The DeepSleep-RAM warm-boot case, where the peripheral
+		 * domain is power-cycled and all DMA state is lost, is a
+		 * power-loss transition handled by PM_DEVICE_ACTION_TURN_ON.
+		 */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power-loss recovery.  A DeepSleep-RAM warm boot power-cycles the
+		 * peripheral domain and loses all DMA state, so re-enable the DMA
+		 * block and reconnect its interrupts.  The per-channel descriptors
+		 * are reprogrammed by the consumer on its next dma_config().  This
+		 * action is emitted only on a genuine DS-RAM warm boot, by the SoC's
+		 * deferred re-init worker running in thread context.
+		 */
+		return ifx_cat1_dma_init(dev);
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
+
 /* Handles DMA interrupts and dispatches to the individual channel */
 struct ifx_cat1_dma_irq_context {
 	const struct device *dev;
@@ -606,8 +659,10 @@ static DEVICE_API(dma, ifx_cat1_dma_api) = {
 		CONFIGURE_ALL_IRQS(n, DT_NUM_IRQS(DT_DRV_INST(n)));                                \
 	}                                                                                          \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_dma_init, NULL, &ifx_cat1_dma_data##n,                  \
-			      &ifx_cat1_dma_config##n, PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,     \
-			      &ifx_cat1_dma_api);
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_cat1_dma_pm_action);                                       \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_dma_init, PM_DEVICE_DT_INST_GET(n),                     \
+			      &ifx_cat1_dma_data##n, &ifx_cat1_dma_config##n, PRE_KERNEL_1,        \
+			      CONFIG_DMA_INIT_PRIORITY, &ifx_cat1_dma_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INFINEON_CAT1_DMA_INIT)

--- a/drivers/dma/dma_infineon_pdl.c
+++ b/drivers/dma/dma_infineon_pdl.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,6 +20,8 @@
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/cache.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/pm.h>
 
 #include <cy_pdl.h>
 #include <soc.h>
@@ -490,6 +492,45 @@ static int ifx_cat1_dma_init(const struct device *dev)
 	return 0;
 }
 
+#ifdef CONFIG_PM_DEVICE
+static int ifx_cat1_dma_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct ifx_cat1_dma_config *const cfg = dev->config;
+	uint32_t channel;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend while any channel is enabled: gating the DMA
+		 * clock would abort an in-flight transfer. Consumers disable
+		 * their channel once the transfer completes.
+		 */
+		for (channel = 0U; channel < cfg->num_channels; channel++) {
+			if (Cy_DMA_Channel_IsEnabled(cfg->regs, channel)) {
+				return -EBUSY;
+			}
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/* Configuration is retained across the gate; nothing to restore. */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power was lost: re-enable the DMA block and reconnect its IRQs.
+		 * Per-channel descriptors are reprogrammed by the consumer on its
+		 * next dma_config().
+		 */
+		return ifx_cat1_dma_init(dev);
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
+
 /* Handles DMA interrupts and dispatches to the individual channel */
 struct ifx_cat1_dma_irq_context {
 	const struct device *dev;
@@ -606,8 +647,10 @@ static DEVICE_API(dma, ifx_cat1_dma_api) = {
 		CONFIGURE_ALL_IRQS(n, DT_NUM_IRQS(DT_DRV_INST(n)));                                \
 	}                                                                                          \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_dma_init, NULL, &ifx_cat1_dma_data##n,                  \
-			      &ifx_cat1_dma_config##n, PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,     \
-			      &ifx_cat1_dma_api);
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_cat1_dma_pm_action);                                       \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_dma_init, PM_DEVICE_DT_INST_GET(n),                     \
+			      &ifx_cat1_dma_data##n, &ifx_cat1_dma_config##n, PRE_KERNEL_1,        \
+			      CONFIG_DMA_INIT_PRIORITY, &ifx_cat1_dma_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INFINEON_CAT1_DMA_INIT)

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,6 +17,13 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/pm.h>
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+#include <power.h>
+#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(i2c_infineon, CONFIG_I2C_LOG_LEVEL);
@@ -69,6 +76,10 @@ struct ifx_cat1_i2c_data {
 	bool error;
 	uint32_t async_pending;
 	struct ifx_cat1_clock clock;
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/* Warm-boot generation this instance was last rebuilt at (retained). */
+	uint32_t warm_boot_gen;
+#endif
 #if defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) || defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
 	uint8_t clock_peri_group;
 #endif
@@ -494,6 +505,18 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 		data->scb_config.ackGeneralAddr = false;
 	}
 
+#ifdef CONFIG_PM_DEVICE
+	/*
+	 * Enable I2C address-match wakeup from DeepSleep when this instance is
+	 * marked as a wakeup source (only DeepSleep-capable SCB instances such
+	 * as SCB0 support this).  The vendor Cy_SCB_I2C_DeepSleepCallback then
+	 * keeps the target alive across DeepSleep (externally-clocked address
+	 * match) so an addressed transaction wakes the device instead of being
+	 * NAKed.  The flag is inert for controller mode.
+	 */
+	data->scb_config.enableWakeFromSleep = pm_device_wakeup_is_enabled(dev);
+#endif /* CONFIG_PM_DEVICE */
+
 	/* De-initialize SCB before re-configuring (required when switching modes) */
 	Cy_SCB_I2C_Disable(config->base, &data->context);
 	Cy_SCB_I2C_DeInit(config->base);
@@ -623,16 +646,38 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 	struct ifx_cat1_i2c_data *data = dev->data;
 	int ret;
 
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/*
+	 * If a DeepSleep-RAM warm boot happened since this instance was last
+	 * used, the SCB has lost its state; rebuild it before taking
+	 * operation_sem.  The TURN_ON handler replays ifx_cat1_i2c_configure(),
+	 * which acquires operation_sem itself, so rebuilding while already
+	 * holding the semaphore would self-deadlock.  A no-op on every other
+	 * transfer.
+	 */
+	(void)ifx_pm_warm_boot_reinit(dev, &data->warm_boot_gen);
+#endif
+
 	/* Acquire semaphore (block I2C transfer for another thread) */
 	ret = k_sem_take(&data->operation_sem, K_FOREVER);
 	if (ret < 0) {
 		return -EIO;
 	}
 
+	/*
+	 * Reference the device for the duration of the transfer.  When device
+	 * runtime PM is enabled this resumes the SCB on the 0->1 reference and
+	 * suspends it again on the matching put once the transfer completes; when
+	 * runtime PM is not configured these calls are inert and the device stays
+	 * system managed.
+	 */
+	(void)pm_device_runtime_get(dev);
+
 	/* This function checks if msg.buf is not NULL and if
 	 * target address is not 10 bit.
 	 */
 	if (ifx_cat1_i2c_msg_validate(msg, num_msgs) != 0) {
+		(void)pm_device_runtime_put(dev);
 		k_sem_give(&data->operation_sem);
 		return -EINVAL;
 	}
@@ -662,19 +707,30 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 		}
 
 		/* Initiate master write and read transfer using tx_buff and rx_buff respectively */
+#if defined(CONFIG_SOC_SERIES_PSE84)
+		ifx_pm_deepsleep_lock();
+#endif
 		ret = _i2c_master_transfer_async(dev, addr, (tx_msg == NULL) ? NULL : tx_msg->buf,
 						 (tx_msg == NULL) ? 0 : tx_msg->len,
 						 (rx_msg == NULL) ? NULL : rx_msg->buf,
 						 (rx_msg == NULL) ? 0 : rx_msg->len);
 
 		if (ret < 0) {
+#if defined(CONFIG_SOC_SERIES_PSE84)
+			ifx_pm_deepsleep_unlock();
+#endif
+			(void)pm_device_runtime_put(dev);
 			k_sem_give(&data->operation_sem);
 			return ret;
 		}
 
 		/* Acquire semaphore (block I2C async transfer for another thread) */
 		ret = k_sem_take(&data->transfer_sem, K_FOREVER);
+#if defined(CONFIG_SOC_SERIES_PSE84)
+		ifx_pm_deepsleep_unlock();
+#endif
 		if (ret < 0) {
+			(void)pm_device_runtime_put(dev);
 			k_sem_give(&data->operation_sem);
 			return -EIO;
 		}
@@ -682,6 +738,7 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 		/* Check for an error during the transfer */
 		if (data->error) {
 			/* Release semaphore */
+			(void)pm_device_runtime_put(dev);
 			k_sem_give(&data->operation_sem);
 			return -EIO;
 		}
@@ -691,6 +748,7 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 	data->irq_cause &= ~I2C_CAT1_EVENTS_MASK;
 
 	/* Release semaphore (After I2C transfer is complete) */
+	(void)pm_device_runtime_put(dev);
 	k_sem_give(&data->operation_sem);
 	return 0;
 }
@@ -733,8 +791,102 @@ static int ifx_cat1_i2c_init(const struct device *dev)
 
 	config->irq_config_func(dev);
 
-	return ifx_cat1_i2c_configure(dev, I2C_MODE_CONTROLLER | I2C_SPEED_SET(I2C_SPEED_STANDARD));
+	ret = ifx_cat1_i2c_configure(dev, I2C_MODE_CONTROLLER | I2C_SPEED_SET(I2C_SPEED_STANDARD));
+	if (ret < 0) {
+		return ret;
+	}
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/*
+	 * Opt this instance into device runtime PM whenever it is configured.  The
+	 * SCB is then reference counted per transfer (see ifx_cat1_i2c_transfer())
+	 * instead of being suspended/resumed by the system-managed policy around
+	 * every low-power transition.  With CONFIG_PM_DEVICE_RUNTIME disabled this
+	 * is compiled out and the device stays system managed.
+	 */
+	ret = pm_device_runtime_enable(dev);
+	if (ret < 0) {
+		return ret;
+	}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
+
+	return 0;
 }
+
+#ifdef CONFIG_PM_DEVICE
+static int ifx_cat1_i2c_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct ifx_cat1_i2c_data *const data = dev->data;
+	const struct ifx_cat1_i2c_config *const config = dev->config;
+#if defined(CONFIG_PM_S2RAM)
+	cy_rslt_t result;
+	int ret;
+#endif /* CONFIG_PM_S2RAM */
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend while a transfer is in progress: entering
+		 * DeepSleep gates the SCB clock and would corrupt the in-flight
+		 * transaction (SCL stretched/aborted mid-byte).  Returning
+		 * -EBUSY aborts the low-power transition; the PM subsystem
+		 * retries once the transfer completes.  The busy flag differs by
+		 * role, so query the status that matches the configured mode.
+		 */
+		if (data->scb_config.i2cMode == CY_SCB_I2C_SLAVE) {
+			if ((Cy_SCB_I2C_SlaveGetStatus(config->base, &data->context) &
+			     (CY_SCB_I2C_SLAVE_RD_BUSY | CY_SCB_I2C_SLAVE_WR_BUSY)) != 0U) {
+				return -EBUSY;
+			}
+		} else {
+			if ((Cy_SCB_I2C_MasterGetStatus(config->base, &data->context) &
+			     CY_SCB_I2C_MASTER_BUSY) != 0U) {
+				return -EBUSY;
+			}
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/*
+		 * Resume from a retained low-power state (regular DeepSleep): the
+		 * clocks were gated but the SCB configuration survived, so there is
+		 * nothing to restore here.  The DeepSleep-RAM warm-boot case, where
+		 * the peripheral domain is power-cycled and all SCB state is lost, is
+		 * a power-loss transition handled by PM_DEVICE_ACTION_TURN_ON instead.
+		 */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power-loss recovery.  A DeepSleep-RAM warm boot power-cycles the
+		 * peripheral domain and loses all SCB state, so re-initialize the I2C
+		 * block: re-apply pinctrl, re-assign the peripheral clock divider, and
+		 * replay the retained configuration through ifx_cat1_i2c_configure().
+		 * This action is emitted only on a genuine DS-RAM warm boot (by the
+		 * SoC's deferred re-init worker running in thread context).
+		 */
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+
+		result = ifx_cat1_utils_peri_pclk_assign_divider(config->clk_dst, &data->clock);
+		if (result != CY_RSLT_SUCCESS) {
+			return -EIO;
+		}
+
+		ret = ifx_cat1_i2c_configure(dev, 0);
+		if (ret < 0) {
+			return ret;
+		}
+		break;
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
 
 void _i2c_free(const struct device *dev)
 {
@@ -1031,8 +1183,10 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 				   &ifx_cat1_i2c_data##n.i2c_deep_sleep_param, NULL, NULL, 1},     \
 		I2C_PERI_CLOCK_INIT(n)};                                                           \
                                                                                                    \
-	I2C_DEVICE_DT_INST_DEFINE(n, ifx_cat1_i2c_init, NULL, &ifx_cat1_i2c_data##n,               \
-				  &i2c_cat1_cfg_##n, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,        \
-				  &i2c_cat1_driver_api);
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_cat1_i2c_pm_action);                                       \
+                                                                                                   \
+	I2C_DEVICE_DT_INST_DEFINE(n, ifx_cat1_i2c_init, PM_DEVICE_DT_INST_GET(n),                  \
+				  &ifx_cat1_i2c_data##n, &i2c_cat1_cfg_##n, POST_KERNEL,           \
+				  CONFIG_I2C_INIT_PRIORITY, &i2c_cat1_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INFINEON_CAT1_I2C_INIT)

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,6 +17,10 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(i2c_infineon, CONFIG_I2C_LOG_LEVEL);
@@ -29,6 +33,22 @@ LOG_MODULE_REGISTER(i2c_infineon, CONFIG_I2C_LOG_LEVEL);
 #include "i2c_bitbang.h"
 #include <zephyr/drivers/gpio.h>
 #endif /* CONFIG_I2C_INFINEON_BUS_RECOVERY */
+
+static inline void ifx_cat1_i2c_deepsleep_lock(void)
+{
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+#if defined(CONFIG_PM_S2RAM)
+	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+#endif
+}
+
+static inline void ifx_cat1_i2c_deepsleep_unlock(void)
+{
+#if defined(CONFIG_PM_S2RAM)
+	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+#endif
+	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+}
 
 #define I2C_CAT1_EVENTS_MASK                                                                       \
 	(CY_SCB_I2C_MASTER_WR_CMPLT_EVENT | CY_SCB_I2C_MASTER_RD_CMPLT_EVENT |                     \
@@ -501,6 +521,18 @@ static int ifx_cat1_i2c_configure(const struct device *dev, uint32_t dev_config)
 		data->scb_config.ackGeneralAddr = false;
 	}
 
+#ifdef CONFIG_PM_DEVICE
+	/*
+	 * Enable I2C address-match wakeup from DeepSleep when this instance is
+	 * marked as a wakeup source (only DeepSleep-capable SCB instances such
+	 * as SCB0 support this).  The vendor Cy_SCB_I2C_DeepSleepCallback then
+	 * keeps the target alive across DeepSleep (externally-clocked address
+	 * match) so an addressed transaction wakes the device instead of being
+	 * NAKed.  The flag is inert for controller mode.
+	 */
+	data->scb_config.enableWakeFromSleep = pm_device_wakeup_is_enabled(dev);
+#endif /* CONFIG_PM_DEVICE */
+
 	/* De-initialize SCB before re-configuring (required when switching modes) */
 	Cy_SCB_I2C_Disable(config->base, &data->context);
 	Cy_SCB_I2C_DeInit(config->base);
@@ -633,10 +665,20 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 		return -EIO;
 	}
 
+	/*
+	 * Reference the device for the duration of the transfer.  When device
+	 * runtime PM is enabled this resumes the SCB on the 0->1 reference and
+	 * suspends it again on the matching put once the transfer completes; when
+	 * runtime PM is not configured these calls are inert and the device stays
+	 * system managed.
+	 */
+	(void)pm_device_runtime_get(dev);
+
 	/* This function checks if msg.buf is not NULL and if
 	 * target address is not 10 bit.
 	 */
 	if (ifx_cat1_i2c_msg_validate(msg, num_msgs) != 0) {
+		(void)pm_device_runtime_put(dev);
 		k_sem_give(&data->operation_sem);
 		return -EINVAL;
 	}
@@ -666,12 +708,15 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 		}
 
 		/* Initiate master write and read transfer using tx_buff and rx_buff respectively */
+		ifx_cat1_i2c_deepsleep_lock();
 		ret = _i2c_master_transfer_async(dev, addr, (tx_msg == NULL) ? NULL : tx_msg->buf,
 						 (tx_msg == NULL) ? 0 : tx_msg->len,
 						 (rx_msg == NULL) ? NULL : rx_msg->buf,
 						 (rx_msg == NULL) ? 0 : rx_msg->len);
 
 		if (ret < 0) {
+			ifx_cat1_i2c_deepsleep_unlock();
+			(void)pm_device_runtime_put(dev);
 			k_sem_give(&data->operation_sem);
 			return ret;
 		}
@@ -680,6 +725,12 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 		 * per-bus transfer timeout.
 		 */
 		ret = k_sem_take(&data->transfer_sem, config->transfer_timeout);
+
+		/* Release the deep-sleep policy lock taken before this transfer
+		 * so it stays balanced on every exit below - the timeout, error,
+		 * and success paths.
+		 */
+		ifx_cat1_i2c_deepsleep_unlock();
 		if (ret != 0) {
 			cy_rslt_t abort_status;
 
@@ -701,6 +752,7 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 			data->irq_cause &= ~I2C_CAT1_EVENTS_MASK;
 			irq_enable(config->irq_num);
 
+			(void)pm_device_runtime_put(dev);
 			k_sem_give(&data->operation_sem);
 			return -ETIMEDOUT;
 		}
@@ -708,6 +760,7 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 		/* Check for an error during the transfer */
 		if (data->error) {
 			/* Release semaphore */
+			(void)pm_device_runtime_put(dev);
 			k_sem_give(&data->operation_sem);
 			return -EIO;
 		}
@@ -717,6 +770,7 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 	data->irq_cause &= ~I2C_CAT1_EVENTS_MASK;
 
 	/* Release semaphore (After I2C transfer is complete) */
+	(void)pm_device_runtime_put(dev);
 	k_sem_give(&data->operation_sem);
 	return 0;
 }
@@ -764,10 +818,91 @@ static int ifx_cat1_i2c_init(const struct device *dev)
 	 * controller is usable at the configured rate without an explicit
 	 * i2c_configure() call.
 	 */
-	return ifx_cat1_i2c_configure(dev,
-				      I2C_MODE_CONTROLLER |
-					      i2c_map_dt_bitrate(config->master_frequency));
+	ret = ifx_cat1_i2c_configure(dev, I2C_MODE_CONTROLLER |
+						  i2c_map_dt_bitrate(config->master_frequency));
+
+	if (ret < 0) {
+		return ret;
+	}
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/*
+	 * Opt this instance into device runtime PM whenever it is configured.  The
+	 * SCB is then reference counted per transfer (see ifx_cat1_i2c_transfer())
+	 * instead of being suspended/resumed by the system-managed policy around
+	 * every low-power transition.  With CONFIG_PM_DEVICE_RUNTIME disabled this
+	 * is compiled out and the device stays system managed.
+	 */
+	ret = pm_device_runtime_enable(dev);
+	if (ret < 0) {
+		return ret;
+	}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
+
+	return 0;
 }
+
+#ifdef CONFIG_PM_DEVICE
+static int ifx_cat1_i2c_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct ifx_cat1_i2c_data *const data = dev->data;
+	const struct ifx_cat1_i2c_config *const config = dev->config;
+#if defined(CONFIG_PM_S2RAM)
+	cy_rslt_t result;
+	int ret;
+#endif /* CONFIG_PM_S2RAM */
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend while a transfer is in progress: gating the
+		 * SCB clock would corrupt the in-flight transaction. The busy
+		 * flag differs by role, so query the configured mode.
+		 */
+		if (data->scb_config.i2cMode == CY_SCB_I2C_SLAVE) {
+			if ((Cy_SCB_I2C_SlaveGetStatus(config->base, &data->context) &
+			     (CY_SCB_I2C_SLAVE_RD_BUSY | CY_SCB_I2C_SLAVE_WR_BUSY)) != 0U) {
+				return -EBUSY;
+			}
+		} else {
+			if ((Cy_SCB_I2C_MasterGetStatus(config->base, &data->context) &
+			     CY_SCB_I2C_MASTER_BUSY) != 0U) {
+				return -EBUSY;
+			}
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/* Configuration is retained across the gate; nothing to restore. */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power was lost: re-init the I2C block - re-apply pinctrl,
+		 * re-assign the clock divider, and replay the retained config.
+		 */
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+
+		result = ifx_cat1_utils_peri_pclk_assign_divider(config->clk_dst, &data->clock);
+		if (result != CY_RSLT_SUCCESS) {
+			return -EIO;
+		}
+
+		ret = ifx_cat1_i2c_configure(dev, 0);
+		if (ret < 0) {
+			return ret;
+		}
+		break;
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
 
 void _i2c_free(const struct device *dev)
 {
@@ -1038,9 +1173,7 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 		.irq_config_func = ifx_cat1_i2c_irq_config_func_##n,                               \
 		.i2c_handle_events_func = i2c_handle_events_func_##n,                              \
 		.transfer_timeout = I2C_DT_INST_TRANSFER_TIMEOUT(n),                               \
-		I2C_CAT1_SCL_INIT(n)                                                               \
-		I2C_CAT1_SDA_INIT(n)                                                               \
-	};                                                                                         \
+		I2C_CAT1_SCL_INIT(n) I2C_CAT1_SDA_INIT(n)};                                        \
                                                                                                    \
 	static struct ifx_cat1_i2c_data ifx_cat1_i2c_data##n = {                                   \
 		.i2c_deep_sleep_param = {(CySCB_Type *)DT_INST_REG_ADDR(n), NULL},                 \
@@ -1049,8 +1182,10 @@ static DEVICE_API(i2c, i2c_cat1_driver_api) = {
 				   &ifx_cat1_i2c_data##n.i2c_deep_sleep_param, NULL, NULL, 1},     \
 		I2C_PERI_CLOCK_INIT(n)};                                                           \
                                                                                                    \
-	I2C_DEVICE_DT_INST_DEFINE(n, ifx_cat1_i2c_init, NULL, &ifx_cat1_i2c_data##n,               \
-				  &i2c_cat1_cfg_##n, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,        \
-				  &i2c_cat1_driver_api);
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_cat1_i2c_pm_action);                                       \
+                                                                                                   \
+	I2C_DEVICE_DT_INST_DEFINE(n, ifx_cat1_i2c_init, PM_DEVICE_DT_INST_GET(n),                  \
+				  &ifx_cat1_i2c_data##n, &i2c_cat1_cfg_##n, POST_KERNEL,           \
+				  CONFIG_I2C_INIT_PRIORITY, &i2c_cat1_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INFINEON_CAT1_I2C_INIT)

--- a/drivers/i2s/i2s_infineon.c
+++ b/drivers/i2s/i2s_infineon.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,13 @@
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/irq.h>
 #include <zephyr/drivers/dma.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/pm.h>
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+#include <power.h>
+#endif
 
 #include <infineon_kconfig.h>
 #include <cy_tdm.h>
@@ -56,6 +63,8 @@ struct i2s_stream {
 	uint32_t max_transfer_size; /* bytes */
 	bool last_block;
 	bool drain;
+	/* True while a device runtime PM reference is held for this stream. */
+	bool pm_ref_held;
 };
 
 struct dma_channel {
@@ -75,9 +84,55 @@ struct ifx_i2s_data {
 	struct queue_item rx_queue_buffer[RX_QUEUE_SIZE];
 	struct queue_item tx_queue_buffer[TX_QUEUE_SIZE];
 	struct ifx_cat1_clock clock;
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/* Warm-boot generation this instance was last rebuilt at (retained). */
+	uint32_t warm_boot_gen;
+#endif
 	uint8_t clock_peri_group;
 	bool tx_waiting_to_start;
 };
+
+/*
+ * Per-stream device runtime PM references.  A reference is taken when a stream
+ * starts and dropped once it returns to I2S_STATE_READY.  The get() may sleep,
+ * so it is only ever called from thread context outside the trigger's IRQ lock;
+ * releases can originate from an ISR, so they use the async put.  The flag makes
+ * the get/put idempotent per stream so no path can imbalance the count.  All
+ * calls are inert no-ops under system-managed PM.
+ */
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+static bool i2s_stream_pm_acquire(const struct device *dev, struct i2s_stream *stream)
+{
+	if (stream->pm_ref_held) {
+		return false;
+	}
+	stream->pm_ref_held = true;
+	(void)pm_device_runtime_get(dev);
+	return true;
+}
+
+static void i2s_stream_pm_release(const struct device *dev, struct i2s_stream *stream)
+{
+	if (!stream->pm_ref_held) {
+		return;
+	}
+	stream->pm_ref_held = false;
+	(void)pm_device_runtime_put_async(dev, K_NO_WAIT);
+}
+#else
+static inline bool i2s_stream_pm_acquire(const struct device *dev, struct i2s_stream *stream)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(stream);
+	return false;
+}
+
+static inline void i2s_stream_pm_release(const struct device *dev, struct i2s_stream *stream)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(stream);
+}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
 
 /* This function is executed in the interrupt context */
 static void dma_tx_callback(const struct device *dma_dev, void *arg, uint32_t channel, int status)
@@ -132,6 +187,7 @@ static void dma_rx_callback(const struct device *dma_dev, void *arg, uint32_t ch
 		if (data->rx.last_block) {
 			i2s_rx_stream_disable(dev, false);
 			data->rx.state = I2S_STATE_READY;
+			i2s_stream_pm_release(dev, &data->rx);
 			return;
 		}
 	}
@@ -479,6 +535,15 @@ static int ifx_i2s_configure(const struct device *dev, enum i2s_dir dir,
 	bool frame_clk_target = (0 != (I2S_OPT_FRAME_CLK_TARGET & i2s_cfg->options));
 	cy_en_tdm_device_cfg_t master_mode;
 
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/*
+	 * If a DeepSleep-RAM warm boot happened since this instance was last used,
+	 * rebuild the base TDM hardware here, in the caller's thread context,
+	 * before (re)configuring the stream.  A no-op on every other call.
+	 */
+	(void)ifx_pm_warm_boot_reinit(dev, &data->warm_boot_gen);
+#endif
+
 	switch (dir) {
 	case I2S_DIR_RX:
 		stream = &data->rx;
@@ -761,6 +826,8 @@ static int ifx_i2s_trigger(const struct device *dev, enum i2s_dir dir, enum i2s_
 	struct i2s_stream *stream;
 	unsigned int key;
 	int ret = 0;
+	bool acquired_here = false;
+	bool release_ref = false;
 
 	switch (dir) {
 	case I2S_DIR_RX:
@@ -774,6 +841,14 @@ static int ifx_i2s_trigger(const struct device *dev, enum i2s_dir dir, enum i2s_
 		return -ENOSYS;
 	default:
 		return -EINVAL;
+	}
+
+	if (cmd == I2S_TRIGGER_START) {
+		/*
+		 * Resume the device before touching hardware. The get() may sleep,
+		 * so it must run outside the IRQ-locked state transition below.
+		 */
+		acquired_here = i2s_stream_pm_acquire(dev, stream);
 	}
 
 	key = irq_lock();
@@ -843,6 +918,7 @@ static int ifx_i2s_trigger(const struct device *dev, enum i2s_dir dir, enum i2s_
 		}
 
 		stream->state = I2S_STATE_READY;
+		release_ref = true;
 		break;
 
 	case I2S_TRIGGER_PREPARE:
@@ -859,6 +935,7 @@ static int ifx_i2s_trigger(const struct device *dev, enum i2s_dir dir, enum i2s_
 		}
 
 		stream->state = I2S_STATE_READY;
+		release_ref = true;
 		break;
 
 	default:
@@ -867,6 +944,15 @@ static int ifx_i2s_trigger(const struct device *dev, enum i2s_dir dir, enum i2s_
 	}
 
 	irq_unlock(key);
+
+	if (release_ref || (acquired_here && ret < 0)) {
+		/*
+		 * Drop the reference on the paths that return the stream to
+		 * I2S_STATE_READY (DROP/PREPARE) or when START failed after taking
+		 * one. Normal stream completion releases from the ISR instead.
+		 */
+		i2s_stream_pm_release(dev, stream);
+	}
 
 	return ret;
 }
@@ -938,6 +1024,86 @@ static int i2s_init(const struct device *dev)
 	return 0;
 }
 
+/*
+ * Cold-boot init wrapper. i2s_init() doubles as the PM TURN_ON handler and runs
+ * on every warm boot, so device runtime PM must be enabled here (once) rather
+ * than inside i2s_init().
+ */
+static int ifx_i2s_init(const struct device *dev)
+{
+	int ret = i2s_init(dev);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/* Enable device runtime PM; system-managed PM still applies when unused. */
+	ret = pm_device_runtime_enable(dev);
+	if (ret < 0) {
+		return ret;
+	}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
+
+	return 0;
+}
+
+#ifdef CONFIG_PM_DEVICE
+static int ifx_i2s_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct ifx_i2s_data *const data = dev->data;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend while either direction is streaming:
+		 * DeepSleep gates the TDM clock and halts the DMA, so an
+		 * in-flight transfer would be corrupted (dropped/garbled
+		 * samples).  RUNNING is an active transfer and STOPPING is
+		 * still draining the FIFO, so both are unsafe.  Returning
+		 * -EBUSY aborts the low-power transition; the PM subsystem
+		 * retries once the application stops the stream.  In every
+		 * other state the TDM block is idle and safe to suspend.
+		 */
+		if ((data->tx.state == I2S_STATE_RUNNING) ||
+		    (data->tx.state == I2S_STATE_STOPPING) ||
+		    (data->rx.state == I2S_STATE_RUNNING) ||
+		    (data->rx.state == I2S_STATE_STOPPING)) {
+			return -EBUSY;
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/*
+		 * A regular DeepSleep gates the TDM clock but retains the block
+		 * configuration, so nothing needs restoring on that path.  The
+		 * DeepSleep-RAM warm-boot case, where the peripheral domain is
+		 * power-cycled and all TDM state is lost, is a power-loss
+		 * transition handled by PM_DEVICE_ACTION_TURN_ON.
+		 */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power-loss recovery.  A DeepSleep-RAM warm boot power-cycles the
+		 * peripheral domain and loses all TDM state, so re-initialize the
+		 * base hardware (pinctrl, peripheral clock divider, interrupts,
+		 * interrupt masks, FIFO flush).  The application must call
+		 * i2s_configure() again before the next transfer, mirroring the
+		 * post-init contract (i2s_init() leaves both streams in
+		 * I2S_STATE_NOT_READY).  This action is emitted only on a genuine
+		 * DS-RAM warm boot, by the SoC's deferred re-init worker running in
+		 * thread context.
+		 */
+		return i2s_init(dev);
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
+
 /* This function is executed in the interrupt context */
 static void i2s_tx_isr(const struct device *dev)
 {
@@ -957,6 +1123,7 @@ static void i2s_tx_isr(const struct device *dev)
 		i2s_tx_stream_disable(dev, false);
 		if (stream->last_block && stream->drain) {
 			data->tx.state = I2S_STATE_READY;
+			i2s_stream_pm_release(dev, &data->tx);
 		} else {
 			LOG_DBG("I2S TX FIFO underflow");
 			stream->state = I2S_STATE_ERROR;
@@ -1114,7 +1281,10 @@ static DEVICE_API(i2s, ifx_i2s_api) = {
 		.tx_irq_num = DT_INST_IRQN_BY_IDX(index, 1),                                       \
 		.irq_config_func = ifx_i2s_irq_config_func_##index};                               \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(index, &i2s_init, NULL, &i2s_data_##index, &i2s_config_##index,      \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ifx_i2s_api);
+	PM_DEVICE_DT_INST_DEFINE(index, ifx_i2s_pm_action);                                        \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(index, &ifx_i2s_init, PM_DEVICE_DT_INST_GET(index),                  \
+			      &i2s_data_##index, &i2s_config_##index, POST_KERNEL,                 \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ifx_i2s_api);
 
 DT_INST_FOREACH_STATUS_OKAY(IFX_I2S_INIT)

--- a/drivers/i2s/i2s_infineon.c
+++ b/drivers/i2s/i2s_infineon.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,9 @@
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/irq.h>
 #include <zephyr/drivers/dma.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/pm.h>
 
 #include <infineon_kconfig.h>
 #include <cy_tdm.h>
@@ -56,6 +59,8 @@ struct i2s_stream {
 	uint32_t max_transfer_size; /* bytes */
 	bool last_block;
 	bool drain;
+	/* True while a device runtime PM reference is held for this stream. */
+	bool pm_ref_held;
 };
 
 struct dma_channel {
@@ -78,6 +83,48 @@ struct ifx_i2s_data {
 	uint8_t clock_peri_group;
 	bool tx_waiting_to_start;
 };
+
+/*
+ * Per-stream device runtime PM references.  A reference is taken when a stream
+ * starts and dropped once it returns to I2S_STATE_READY.  The get() may sleep,
+ * so it is only ever called from thread context outside the trigger's IRQ lock;
+ * releases can originate from an ISR, so they use the async put.  The flag makes
+ * the get/put idempotent per stream so no path can imbalance the count.  All
+ * calls are inert no-ops under system-managed PM.
+ */
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+static bool i2s_stream_pm_acquire(const struct device *dev, struct i2s_stream *stream)
+{
+	if (stream->pm_ref_held) {
+		return false;
+	}
+	stream->pm_ref_held = true;
+	(void)pm_device_runtime_get(dev);
+	return true;
+}
+
+static void i2s_stream_pm_release(const struct device *dev, struct i2s_stream *stream)
+{
+	if (!stream->pm_ref_held) {
+		return;
+	}
+	stream->pm_ref_held = false;
+	(void)pm_device_runtime_put_async(dev, K_NO_WAIT);
+}
+#else
+static inline bool i2s_stream_pm_acquire(const struct device *dev, struct i2s_stream *stream)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(stream);
+	return false;
+}
+
+static inline void i2s_stream_pm_release(const struct device *dev, struct i2s_stream *stream)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(stream);
+}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
 
 /* This function is executed in the interrupt context */
 static void dma_tx_callback(const struct device *dma_dev, void *arg, uint32_t channel, int status)
@@ -132,6 +179,7 @@ static void dma_rx_callback(const struct device *dma_dev, void *arg, uint32_t ch
 		if (data->rx.last_block) {
 			i2s_rx_stream_disable(dev, false);
 			data->rx.state = I2S_STATE_READY;
+			i2s_stream_pm_release(dev, &data->rx);
 			return;
 		}
 	}
@@ -761,6 +809,8 @@ static int ifx_i2s_trigger(const struct device *dev, enum i2s_dir dir, enum i2s_
 	struct i2s_stream *stream;
 	unsigned int key;
 	int ret = 0;
+	bool acquired_here = false;
+	bool release_ref = false;
 
 	switch (dir) {
 	case I2S_DIR_RX:
@@ -774,6 +824,14 @@ static int ifx_i2s_trigger(const struct device *dev, enum i2s_dir dir, enum i2s_
 		return -ENOSYS;
 	default:
 		return -EINVAL;
+	}
+
+	if (cmd == I2S_TRIGGER_START) {
+		/*
+		 * Resume the device before touching hardware. The get() may sleep,
+		 * so it must run outside the IRQ-locked state transition below.
+		 */
+		acquired_here = i2s_stream_pm_acquire(dev, stream);
 	}
 
 	key = irq_lock();
@@ -843,6 +901,7 @@ static int ifx_i2s_trigger(const struct device *dev, enum i2s_dir dir, enum i2s_
 		}
 
 		stream->state = I2S_STATE_READY;
+		release_ref = true;
 		break;
 
 	case I2S_TRIGGER_PREPARE:
@@ -859,6 +918,7 @@ static int ifx_i2s_trigger(const struct device *dev, enum i2s_dir dir, enum i2s_
 		}
 
 		stream->state = I2S_STATE_READY;
+		release_ref = true;
 		break;
 
 	default:
@@ -867,6 +927,15 @@ static int ifx_i2s_trigger(const struct device *dev, enum i2s_dir dir, enum i2s_
 	}
 
 	irq_unlock(key);
+
+	if (release_ref || (acquired_here && ret < 0)) {
+		/*
+		 * Drop the reference on the paths that return the stream to
+		 * I2S_STATE_READY (DROP/PREPARE) or when START failed after taking
+		 * one. Normal stream completion releases from the ISR instead.
+		 */
+		i2s_stream_pm_release(dev, stream);
+	}
 
 	return ret;
 }
@@ -938,6 +1007,69 @@ static int i2s_init(const struct device *dev)
 	return 0;
 }
 
+/*
+ * Cold-boot init wrapper. i2s_init() doubles as the PM TURN_ON handler and runs
+ * on every warm boot, so device runtime PM must be enabled here (once) rather
+ * than inside i2s_init().
+ */
+static int ifx_i2s_init(const struct device *dev)
+{
+	int ret = i2s_init(dev);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/* Enable device runtime PM; system-managed PM still applies when unused. */
+	ret = pm_device_runtime_enable(dev);
+	if (ret < 0) {
+		return ret;
+	}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
+
+	return 0;
+}
+
+#ifdef CONFIG_PM_DEVICE
+static int ifx_i2s_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	struct ifx_i2s_data *const data = dev->data;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend while either direction is streaming: gating
+		 * the TDM clock would corrupt an in-flight transfer. RUNNING is an
+		 * active transfer and STOPPING is still draining the FIFO.
+		 */
+		if ((data->tx.state == I2S_STATE_RUNNING) ||
+		    (data->tx.state == I2S_STATE_STOPPING) ||
+		    (data->rx.state == I2S_STATE_RUNNING) ||
+		    (data->rx.state == I2S_STATE_STOPPING)) {
+			return -EBUSY;
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/* Configuration is retained across the gate; nothing to restore. */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power was lost: re-init the base hardware. The application must
+		 * call i2s_configure() again before the next transfer (i2s_init()
+		 * leaves both streams in I2S_STATE_NOT_READY).
+		 */
+		return i2s_init(dev);
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
+
 /* This function is executed in the interrupt context */
 static void i2s_tx_isr(const struct device *dev)
 {
@@ -957,6 +1089,7 @@ static void i2s_tx_isr(const struct device *dev)
 		i2s_tx_stream_disable(dev, false);
 		if (stream->last_block && stream->drain) {
 			data->tx.state = I2S_STATE_READY;
+			i2s_stream_pm_release(dev, &data->tx);
 		} else {
 			LOG_DBG("I2S TX FIFO underflow");
 			stream->state = I2S_STATE_ERROR;
@@ -1114,7 +1247,10 @@ static DEVICE_API(i2s, ifx_i2s_api) = {
 		.tx_irq_num = DT_INST_IRQN_BY_IDX(index, 1),                                       \
 		.irq_config_func = ifx_i2s_irq_config_func_##index};                               \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(index, &i2s_init, NULL, &i2s_data_##index, &i2s_config_##index,      \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ifx_i2s_api);
+	PM_DEVICE_DT_INST_DEFINE(index, ifx_i2s_pm_action);                                        \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(index, &ifx_i2s_init, PM_DEVICE_DT_INST_GET(index),                  \
+			      &i2s_data_##index, &i2s_config_##index, POST_KERNEL,                 \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ifx_i2s_api);
 
 DT_INST_FOREACH_STATUS_OKAY(IFX_I2S_INIT)

--- a/drivers/pwm/pwm_infineon_tcpwm.c
+++ b/drivers/pwm/pwm_infineon_tcpwm.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,12 @@
 
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/pm.h>
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+#include <power.h>
+#endif
 
 #include <infineon_kconfig.h>
 #include <zephyr/drivers/timer/ifx_tcpwm.h>
@@ -48,6 +54,22 @@ struct ifx_tcpwm_pwm_config {
 
 struct ifx_tcpwm_pwm_data {
 	struct ifx_cat1_clock clock;
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/* Warm-boot generation this instance was last rebuilt at (retained). */
+	uint32_t warm_boot_gen;
+#endif
+#ifdef CONFIG_PM_DEVICE
+	/* Last values programmed via set_cycles, replayed on resume to
+	 * restore the PWM after DS-RAM (all peripheral state lost).
+	 */
+	uint32_t last_period_cycles;
+	uint32_t last_pulse_cycles;
+	pwm_flags_t last_flags;
+	/* Whether the counter was running when suspend was entered, so
+	 * resume only restarts a PWM that was previously active.
+	 */
+	bool was_running;
+#endif /* CONFIG_PM_DEVICE */
 #ifdef CONFIG_PWM_EVENT
 	sys_slist_t event_callbacks;
 	struct k_spinlock lock;
@@ -101,8 +123,26 @@ static int ifx_tcpwm_pwm_set_cycles(const struct device *dev, uint32_t channel,
 	ARG_UNUSED(channel);
 
 	const struct ifx_tcpwm_pwm_config *config = dev->config;
+#ifdef CONFIG_PM_DEVICE
+	struct ifx_tcpwm_pwm_data *const data = dev->data;
+#endif /* CONFIG_PM_DEVICE */
 	uint32_t pwm_status;
 	uint32_t ctrl_temp;
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/*
+	 * If a DeepSleep-RAM warm boot happened since this PWM was last used,
+	 * rebuild it here, in the caller's thread context, before touching the
+	 * TCPWM registers.  A no-op on every other call.  The TURN_ON handler
+	 * restores state via this same entry; ifx_pm_warm_boot_reinit() records the
+	 * generation before invoking TURN_ON so that nested call does not recurse.
+	 */
+	{
+		struct ifx_tcpwm_pwm_data *const pm_data = dev->data;
+
+		(void)ifx_pm_warm_boot_reinit(dev, &pm_data->warm_boot_gen);
+	}
+#endif
 
 	if (!config->resolution_32_bits &&
 	    ((period_cycles > UINT16_MAX) || (pulse_cycles > UINT16_MAX))) {
@@ -163,6 +203,14 @@ static int ifx_tcpwm_pwm_set_cycles(const struct device *dev, uint32_t channel,
 
 	/* Start the TCPWM block */
 	IFX_TCPWM_TriggerStart_Single(config->reg_base);
+
+#ifdef CONFIG_PM_DEVICE
+	/* Cache the request so it can be replayed on resume after DS-RAM. */
+	data->last_period_cycles = period_cycles;
+	data->last_pulse_cycles = pulse_cycles;
+	data->last_flags = flags;
+	data->was_running = true;
+#endif /* CONFIG_PM_DEVICE */
 
 	return 0;
 }
@@ -241,6 +289,83 @@ static int ifx_tcpwm_pwm_manage_event_callback(const struct device *dev,
 }
 #endif /* CONFIG_PWM_EVENT */
 
+#ifdef CONFIG_PM_DEVICE
+static int ifx_tcpwm_pwm_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct ifx_tcpwm_pwm_config *config = dev->config;
+	struct ifx_tcpwm_pwm_data *const data = dev->data;
+#if defined(CONFIG_PM_S2RAM)
+	int ret;
+#endif /* CONFIG_PM_S2RAM */
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/* Nothing to do. Returning success ensures DeepSleep entry is never blocked. */
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/*
+		 * Resume from a retained low-power state (regular DeepSleep): the
+		 * clocks were gated but the peripheral domain and its configuration
+		 * survived.  Regular DeepSleep does clear the block's ENABLED bit,
+		 * so re-enable it before re-triggering start - the same sequence
+		 * ifx_tcpwm_pwm_set_cycles() uses (and the counter driver mirrors in
+		 * ifx_tcpwm_counter_start()).  Without the re-enable the trigger has
+		 * no effect and the PWM output stays dead after wake.  Only restart
+		 * if the PWM was running before the transition.
+		 */
+#if defined(CONFIG_PM_S2RAM)
+		/*
+		 * RESUME is invoked for BOTH SUSPEND_TO_IDLE (regular, retained
+		 * DeepSleep) and SUSPEND_TO_RAM (DS-RAM warm boot), so the two must
+		 * be distinguished here.  A DS-RAM warm boot power-cycles the domain
+		 * and loses all PWM state; the block is rebuilt by
+		 * PM_DEVICE_ACTION_TURN_ON (the SoC's deferred re-init worker).  Do
+		 * NOT enable/trigger on that path: starting the power-cycled block
+		 * (PERIOD0 == 0) latches STATUS.RUNNING, which makes the subsequent
+		 * set_cycles() take its "already running" buffered-update path and
+		 * never load the real period, leaving the LED output dead.
+		 */
+		if (pm_state_next_get(_current_cpu->id)->state == PM_STATE_SUSPEND_TO_RAM) {
+			break;
+		}
+#endif /* CONFIG_PM_S2RAM */
+		if (data->was_running) {
+			IFX_TCPWM_PWM_Enable(config->reg_base);
+			IFX_TCPWM_TriggerStart_Single(config->reg_base);
+		}
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power-loss recovery.  A DeepSleep-RAM warm boot power-cycles the
+		 * peripheral domain and loses all PWM state, so re-initialize the
+		 * block and replay the cached configuration from RAM.  This action is
+		 * emitted only on a genuine DS-RAM warm boot (by the SoC's deferred
+		 * re-init worker running in thread context), so its invocation is the
+		 * "power was lost" signal - no separate warm-boot flag query is
+		 * needed.  ifx_tcpwm_pwm_set_cycles() restores the running state, so
+		 * no explicit trigger-start is issued here.
+		 */
+		ret = ifx_tcpwm_pwm_init(dev);
+		if (ret < 0) {
+			return ret;
+		}
+
+		ret = ifx_tcpwm_pwm_set_cycles(dev, 0, data->last_period_cycles,
+					       data->last_pulse_cycles, data->last_flags);
+		if (ret < 0) {
+			return ret;
+		}
+		break;
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
+
 static DEVICE_API(pwm, ifx_tcpwm_pwm_api) = {
 	.set_cycles = ifx_tcpwm_pwm_set_cycles,
 	.get_cycles_per_sec = ifx_tcpwm_pwm_get_cycles_per_sec,
@@ -314,6 +439,8 @@ static DEVICE_API(pwm, ifx_tcpwm_pwm_api) = {
 	IF_ENABLED(CONFIG_PWM_EVENT, (INFINEON_TCPWM_PWM_IRQ_INIT(n)))                             \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
                                                                                                    \
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_tcpwm_pwm_pm_action);                                      \
+                                                                                                   \
 	static struct ifx_tcpwm_pwm_data ifx_tcpwm_pwm##n##_data = {PWM_PERI_CLOCK_INIT(n)};       \
                                                                                                    \
 	static const struct ifx_tcpwm_pwm_config pwm_tcpwm_config_##n = {                          \
@@ -332,8 +459,8 @@ static DEVICE_API(pwm, ifx_tcpwm_pwm_api) = {
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(                                                                     \
 		n, COND_CODE_1(CONFIG_PWM_EVENT, (ifx_tcpwm_pwm_init_##n), (ifx_tcpwm_pwm_init)),  \
-		NULL, &ifx_tcpwm_pwm##n##_data, &pwm_tcpwm_config_##n, POST_KERNEL,                \
-		CONFIG_PWM_INIT_PRIORITY, &ifx_tcpwm_pwm_api);
+		PM_DEVICE_DT_INST_GET(n), &ifx_tcpwm_pwm##n##_data, &pwm_tcpwm_config_##n,         \
+		POST_KERNEL, CONFIG_PWM_INIT_PRIORITY, &ifx_tcpwm_pwm_api);
 /* clang-format on */
 
 DT_INST_FOREACH_STATUS_OKAY(INFINEON_TCPWM_PWM_INIT)

--- a/drivers/pwm/pwm_infineon_tcpwm.c
+++ b/drivers/pwm/pwm_infineon_tcpwm.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,8 @@
 
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/pm.h>
 
 #include <infineon_kconfig.h>
 #include <zephyr/drivers/timer/ifx_tcpwm.h>
@@ -48,6 +50,18 @@ struct ifx_tcpwm_pwm_config {
 
 struct ifx_tcpwm_pwm_data {
 	struct ifx_cat1_clock clock;
+#ifdef CONFIG_PM_DEVICE
+	/* Last values programmed via set_cycles, replayed on resume to
+	 * restore the PWM after DS-RAM (all peripheral state lost).
+	 */
+	uint32_t last_period_cycles;
+	uint32_t last_pulse_cycles;
+	pwm_flags_t last_flags;
+	/* Whether the counter was running when suspend was entered, so
+	 * resume only restarts a PWM that was previously active.
+	 */
+	bool was_running;
+#endif /* CONFIG_PM_DEVICE */
 #ifdef CONFIG_PWM_EVENT
 	sys_slist_t event_callbacks;
 	struct k_spinlock lock;
@@ -101,6 +115,9 @@ static int ifx_tcpwm_pwm_set_cycles(const struct device *dev, uint32_t channel,
 	ARG_UNUSED(channel);
 
 	const struct ifx_tcpwm_pwm_config *config = dev->config;
+#ifdef CONFIG_PM_DEVICE
+	struct ifx_tcpwm_pwm_data *const data = dev->data;
+#endif /* CONFIG_PM_DEVICE */
 	uint32_t pwm_status;
 	uint32_t ctrl_temp;
 
@@ -163,6 +180,14 @@ static int ifx_tcpwm_pwm_set_cycles(const struct device *dev, uint32_t channel,
 
 	/* Start the TCPWM block */
 	IFX_TCPWM_TriggerStart_Single(config->reg_base);
+
+#ifdef CONFIG_PM_DEVICE
+	/* Cache the request so it can be replayed on resume after DS-RAM. */
+	data->last_period_cycles = period_cycles;
+	data->last_pulse_cycles = pulse_cycles;
+	data->last_flags = flags;
+	data->was_running = true;
+#endif /* CONFIG_PM_DEVICE */
 
 	return 0;
 }
@@ -241,6 +266,68 @@ static int ifx_tcpwm_pwm_manage_event_callback(const struct device *dev,
 }
 #endif /* CONFIG_PWM_EVENT */
 
+#ifdef CONFIG_PM_DEVICE
+static int ifx_tcpwm_pwm_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct ifx_tcpwm_pwm_config *config = dev->config;
+	struct ifx_tcpwm_pwm_data *const data = dev->data;
+#if defined(CONFIG_PM_S2RAM)
+	int ret;
+#endif /* CONFIG_PM_S2RAM */
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/* Nothing to do; the block can be gated as-is. */
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+#if defined(CONFIG_PM_S2RAM)
+		/*
+		 * On a DS-RAM warm boot the block is power-cycled and rebuilt by
+		 * TURN_ON, so skip the restart here: enabling a power-cycled block
+		 * (PERIOD0 == 0) latches STATUS.RUNNING and makes the later
+		 * set_cycles() miss the real period, leaving the output dead.
+		 */
+		if (pm_state_next_get(_current_cpu->id)->state == PM_STATE_SUSPEND_TO_RAM) {
+			break;
+		}
+#endif /* CONFIG_PM_S2RAM */
+		/*
+		 * Configuration is retained across the gate, but DeepSleep clears
+		 * the ENABLED bit; re-enable before re-triggering. Restart only if
+		 * it was running.
+		 */
+		if (data->was_running) {
+			IFX_TCPWM_PWM_Enable(config->reg_base);
+			IFX_TCPWM_TriggerStart_Single(config->reg_base);
+		}
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power was lost: re-init the block and replay the cached config.
+		 * set_cycles() restores the running state, so no explicit
+		 * trigger-start is issued here.
+		 */
+		ret = ifx_tcpwm_pwm_init(dev);
+		if (ret < 0) {
+			return ret;
+		}
+
+		ret = ifx_tcpwm_pwm_set_cycles(dev, 0, data->last_period_cycles,
+					       data->last_pulse_cycles, data->last_flags);
+		if (ret < 0) {
+			return ret;
+		}
+		break;
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
+
 static DEVICE_API(pwm, ifx_tcpwm_pwm_api) = {
 	.set_cycles = ifx_tcpwm_pwm_set_cycles,
 	.get_cycles_per_sec = ifx_tcpwm_pwm_get_cycles_per_sec,
@@ -314,6 +401,8 @@ static DEVICE_API(pwm, ifx_tcpwm_pwm_api) = {
 	IF_ENABLED(CONFIG_PWM_EVENT, (INFINEON_TCPWM_PWM_IRQ_INIT(n)))                             \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
                                                                                                    \
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_tcpwm_pwm_pm_action);                                      \
+                                                                                                   \
 	static struct ifx_tcpwm_pwm_data ifx_tcpwm_pwm##n##_data = {PWM_PERI_CLOCK_INIT(n)};       \
                                                                                                    \
 	static const struct ifx_tcpwm_pwm_config pwm_tcpwm_config_##n = {                          \
@@ -332,8 +421,8 @@ static DEVICE_API(pwm, ifx_tcpwm_pwm_api) = {
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(                                                                     \
 		n, COND_CODE_1(CONFIG_PWM_EVENT, (ifx_tcpwm_pwm_init_##n), (ifx_tcpwm_pwm_init)),  \
-		NULL, &ifx_tcpwm_pwm##n##_data, &pwm_tcpwm_config_##n, POST_KERNEL,                \
-		CONFIG_PWM_INIT_PRIORITY, &ifx_tcpwm_pwm_api);
+		PM_DEVICE_DT_INST_GET(n), &ifx_tcpwm_pwm##n##_data, &pwm_tcpwm_config_##n,         \
+		POST_KERNEL, CONFIG_PWM_INIT_PRIORITY, &ifx_tcpwm_pwm_api);
 /* clang-format on */
 
 DT_INST_FOREACH_STATUS_OKAY(INFINEON_TCPWM_PWM_INIT)

--- a/drivers/sdhc/sdhc_infineon.c
+++ b/drivers/sdhc/sdhc_infineon.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -43,6 +43,13 @@
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/cache.h>
 #include "sdhc_helpers.h"
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/pm.h>
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+#include <power.h>
+#endif
 
 #include "cy_sd_host.h"
 #include "cy_sysclk.h"
@@ -86,6 +93,10 @@ struct __aligned(CONFIG_SDHC_BUFFER_ALIGNMENT) sdhc_infineon_data {
 	struct sdhc_host_props props;
 #if defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
 	struct ifx_cat1_clock clock;
+#endif
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/* Warm-boot generation this instance was last rebuilt at (retained). */
+	uint32_t warm_boot_gen;
 #endif
 	uint32_t irq_cause;
 	void *sdio_cb_user_data;
@@ -546,6 +557,21 @@ static int sdhc_infineon_request(const struct device *dev, struct sdhc_command *
 	/* Reset semaphore */
 	k_sem_reset(&sdhc_data->transfer_sem);
 
+	/*
+	 * Reference the device for the duration of the request. With device
+	 * runtime PM this resumes the controller; inert under system-managed PM.
+	 */
+	(void)pm_device_runtime_get(dev);
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/*
+	 * If a DeepSleep-RAM warm boot happened since this instance was last
+	 * used, rebuild the host controller here, in the caller's thread
+	 * context, before issuing the command.  A no-op on every other call.
+	 */
+	(void)ifx_pm_warm_boot_reinit(dev, &sdhc_data->warm_boot_gen);
+#endif
+
 	cy_stc_sd_host_cmd_config_t cmd_config = {
 		.commandIndex = cmd->opcode,
 		.commandArgument = cmd->arg,
@@ -676,6 +702,8 @@ end:
 	} else {
 		sdhc_data->app_cmd = false;
 	}
+
+	(void)pm_device_runtime_put(dev);
 	k_sem_give(&sdhc_data->thread_lock);
 
 	return result;
@@ -1033,6 +1061,73 @@ static int sdhc_infineon_init(const struct device *dev)
 	return 0;
 }
 
+#ifdef CONFIG_PM_DEVICE
+static int sdhc_infineon_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct sdhc_infineon_config *const config = dev->config;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend while a command or data transfer is still on
+		 * the bus: entering DeepSleep gates the SDHC clock and would
+		 * corrupt the in-flight transaction (the controller stops driving
+		 * the clock mid-transfer).  The present-state command and data
+		 * inhibit bits are set while the respective lines are busy.
+		 * Returning -EBUSY aborts the low-power transition; the PM
+		 * subsystem retries once the bus is idle.
+		 */
+		if ((Cy_SD_Host_GetPresentState(config->reg_addr) &
+		     (CY_SD_HOST_CMD_INHIBIT | CY_SD_HOST_CMD_CMD_INHIBIT_DAT)) != 0U) {
+			return -EBUSY;
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/*
+		 * A regular DeepSleep gates the clocks but retains the SDHC
+		 * configuration, so nothing needs restoring on that path.  The
+		 * DeepSleep-RAM warm-boot case, where the peripheral domain is
+		 * power-cycled and all SDHC state is lost, is a power-loss
+		 * transition handled by PM_DEVICE_ACTION_TURN_ON.
+		 */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power-loss recovery.  A DeepSleep-RAM warm boot power-cycles the
+		 * peripheral domain and loses all SDHC state, so fully re-initialize
+		 * the controller: re-apply pinctrl, re-assign the peripheral clock
+		 * divider, re-enable and re-init the SD host block, and clear the
+		 * slot data so the card is re-initialized on the next set_io().
+		 * This action is emitted only on a genuine DS-RAM warm boot, by the
+		 * SoC's deferred re-init worker running in thread context.
+		 */
+		return sdhc_infineon_init(dev);
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
+
+/*
+ * Enable device runtime PM on cold boot only. sdhc_infineon_init() doubles as
+ * the PM TURN_ON handler and re-runs on every warm boot, so the enable lives in
+ * this helper (called from the per-instance init wrapper) instead.
+ */
+static int sdhc_infineon_pm_runtime_enable(const struct device *dev)
+{
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/* System-managed PM still applies when the device is left unreferenced. */
+	return pm_device_runtime_enable(dev);
+#else
+	ARG_UNUSED(dev);
+	return 0;
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
+}
+
 static DEVICE_API(sdhc, sdhc_infineon_api) = {
 	.reset = sdhc_infineon_reset,
 	.request = sdhc_infineon_request,
@@ -1097,8 +1192,14 @@ static DEVICE_API(sdhc, sdhc_infineon_api) = {
                                                                                                    \
 	static int sdhc_infineon_init##n(const struct device *dev)                                 \
 	{                                                                                          \
+		int ret;                                                                           \
+                                                                                                   \
 		IFX_SDHC_IRQ_CONFIG(n);                                                            \
-		return sdhc_infineon_init(dev);                                                    \
+		ret = sdhc_infineon_init(dev);                                                     \
+		if (ret < 0) {                                                                     \
+			return ret;                                                                \
+		}                                                                                  \
+		return sdhc_infineon_pm_runtime_enable(dev);                                       \
 	}                                                                                          \
                                                                                                    \
 	static const struct sdhc_infineon_config sdhc_infineon_##n##_config = {                    \
@@ -1108,7 +1209,7 @@ static DEVICE_API(sdhc, sdhc_infineon_api) = {
 		.irq_priority = DT_INST_IRQ(n, priority),                                          \
 		IRQ_INFO(n),                                                                       \
 		IF_ENABLED(CONFIG_SOC_FAMILY_INFINEON_EDGE,                                        \
-			   (.clk_dst = DT_INST_PROP(n, clk_dst),)) };                              \
+			   (.clk_dst = DT_INST_PROP(n, clk_dst),)) }; \
                                                                                                    \
 	static struct sdhc_infineon_data sdhc_infineon_##n##_data = {                              \
 		.power_mode = SDHC_POWER_ON,                                                       \
@@ -1131,13 +1232,15 @@ static DEVICE_API(sdhc, sdhc_infineon_api) = {
 					.sdr104_support = false,                                   \
 					.sdr50_support = true,                                     \
 					.bus_8_bit_support = false},                               \
-			  .bus_4_bit_support = (DT_INST_PROP(n, bus_width) == 4),		   \
-			  .hs200_support = false,						   \
+			  .bus_4_bit_support = (DT_INST_PROP(n, bus_width) == 4),                  \
+			  .hs200_support = false,                                                  \
 			  .hs400_support = false},                                                 \
 		IFX_SDHC_PERI_CLOCK_INIT(n)};                                                      \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &sdhc_infineon_init##n, NULL, &sdhc_infineon_##n##_data,          \
-			      &sdhc_infineon_##n##_config, POST_KERNEL, CONFIG_SDHC_INIT_PRIORITY, \
-			      &sdhc_infineon_api);
+	PM_DEVICE_DT_INST_DEFINE(n, sdhc_infineon_pm_action);                                      \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, &sdhc_infineon_init##n, PM_DEVICE_DT_INST_GET(n),                 \
+			      &sdhc_infineon_##n##_data, &sdhc_infineon_##n##_config, POST_KERNEL, \
+			      CONFIG_SDHC_INIT_PRIORITY, &sdhc_infineon_api);
 
 DT_INST_FOREACH_STATUS_OKAY(IFX_SDHC_INIT)

--- a/drivers/sdhc/sdhc_infineon.c
+++ b/drivers/sdhc/sdhc_infineon.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -43,6 +43,9 @@
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/cache.h>
 #include "sdhc_helpers.h"
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/pm.h>
 
 #include "cy_sd_host.h"
 #include "cy_sysclk.h"
@@ -546,6 +549,12 @@ static int sdhc_infineon_request(const struct device *dev, struct sdhc_command *
 	/* Reset semaphore */
 	k_sem_reset(&sdhc_data->transfer_sem);
 
+	/*
+	 * Reference the device for the duration of the request. With device
+	 * runtime PM this resumes the controller; inert under system-managed PM.
+	 */
+	(void)pm_device_runtime_get(dev);
+
 	cy_stc_sd_host_cmd_config_t cmd_config = {
 		.commandIndex = cmd->opcode,
 		.commandArgument = cmd->arg,
@@ -676,6 +685,8 @@ end:
 	} else {
 		sdhc_data->app_cmd = false;
 	}
+
+	(void)pm_device_runtime_put(dev);
 	k_sem_give(&sdhc_data->thread_lock);
 
 	return result;
@@ -1033,6 +1044,59 @@ static int sdhc_infineon_init(const struct device *dev)
 	return 0;
 }
 
+#ifdef CONFIG_PM_DEVICE
+static int sdhc_infineon_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct sdhc_infineon_config *const config = dev->config;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend while a command or data transfer is on the
+		 * bus: gating the SDHC clock would corrupt the in-flight
+		 * transaction. The inhibit bits are set while the lines are busy.
+		 */
+		if ((Cy_SD_Host_GetPresentState(config->reg_addr) &
+		     (CY_SD_HOST_CMD_INHIBIT | CY_SD_HOST_CMD_CMD_INHIBIT_DAT)) != 0U) {
+			return -EBUSY;
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/* Configuration is retained across the gate; nothing to restore. */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power was lost: fully re-init the controller - re-apply pinctrl,
+		 * re-assign the clock divider, re-enable and re-init the SD host,
+		 * and clear the slot so the card is re-initialized on next set_io().
+		 */
+		return sdhc_infineon_init(dev);
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
+
+/*
+ * Enable device runtime PM on cold boot only. sdhc_infineon_init() doubles as
+ * the PM TURN_ON handler and re-runs on every warm boot, so the enable lives in
+ * this helper (called from the per-instance init wrapper) instead.
+ */
+static int sdhc_infineon_pm_runtime_enable(const struct device *dev)
+{
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/* System-managed PM still applies when the device is left unreferenced. */
+	return pm_device_runtime_enable(dev);
+#else
+	ARG_UNUSED(dev);
+	return 0;
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
+}
+
 static DEVICE_API(sdhc, sdhc_infineon_api) = {
 	.reset = sdhc_infineon_reset,
 	.request = sdhc_infineon_request,
@@ -1097,8 +1161,14 @@ static DEVICE_API(sdhc, sdhc_infineon_api) = {
                                                                                                    \
 	static int sdhc_infineon_init##n(const struct device *dev)                                 \
 	{                                                                                          \
+		int ret;                                                                           \
+                                                                                                   \
 		IFX_SDHC_IRQ_CONFIG(n);                                                            \
-		return sdhc_infineon_init(dev);                                                    \
+		ret = sdhc_infineon_init(dev);                                                     \
+		if (ret < 0) {                                                                     \
+			return ret;                                                                \
+		}                                                                                  \
+		return sdhc_infineon_pm_runtime_enable(dev);                                       \
 	}                                                                                          \
                                                                                                    \
 	static const struct sdhc_infineon_config sdhc_infineon_##n##_config = {                    \
@@ -1108,7 +1178,7 @@ static DEVICE_API(sdhc, sdhc_infineon_api) = {
 		.irq_priority = DT_INST_IRQ(n, priority),                                          \
 		IRQ_INFO(n),                                                                       \
 		IF_ENABLED(CONFIG_SOC_FAMILY_INFINEON_EDGE,                                        \
-			   (.clk_dst = DT_INST_PROP(n, clk_dst),)) };                              \
+			   (.clk_dst = DT_INST_PROP(n, clk_dst),)) }; \
                                                                                                    \
 	static struct sdhc_infineon_data sdhc_infineon_##n##_data = {                              \
 		.power_mode = SDHC_POWER_ON,                                                       \
@@ -1131,13 +1201,15 @@ static DEVICE_API(sdhc, sdhc_infineon_api) = {
 					.sdr104_support = false,                                   \
 					.sdr50_support = true,                                     \
 					.bus_8_bit_support = false},                               \
-			  .bus_4_bit_support = (DT_INST_PROP(n, bus_width) == 4),		   \
-			  .hs200_support = false,						   \
+			  .bus_4_bit_support = (DT_INST_PROP(n, bus_width) == 4),                  \
+			  .hs200_support = false,                                                  \
 			  .hs400_support = false},                                                 \
 		IFX_SDHC_PERI_CLOCK_INIT(n)};                                                      \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &sdhc_infineon_init##n, NULL, &sdhc_infineon_##n##_data,          \
-			      &sdhc_infineon_##n##_config, POST_KERNEL, CONFIG_SDHC_INIT_PRIORITY, \
-			      &sdhc_infineon_api);
+	PM_DEVICE_DT_INST_DEFINE(n, sdhc_infineon_pm_action);                                      \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, &sdhc_infineon_init##n, PM_DEVICE_DT_INST_GET(n),                 \
+			      &sdhc_infineon_##n##_data, &sdhc_infineon_##n##_config, POST_KERNEL, \
+			      CONFIG_SDHC_INIT_PRIORITY, &sdhc_infineon_api);
 
 DT_INST_FOREACH_STATUS_OKAY(IFX_SDHC_INIT)

--- a/drivers/serial/uart_infineon_pdl.c
+++ b/drivers/serial/uart_infineon_pdl.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2025 Cypress Semiconductor Corporation (an Infineon company) or
- * an affiliate of Cypress Semiconductor Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +16,9 @@
 #include <zephyr/irq.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/pm.h>
 #include <zephyr/kernel.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -30,6 +33,10 @@
 
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+#include <power.h>
+#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uart_ifx, CONFIG_UART_LOG_LEVEL);
@@ -121,9 +128,25 @@ struct ifx_cat1_uart_data {
 	cy_stc_scb_uart_context_t context;
 	cy_stc_scb_uart_config_t scb_config;
 	uint32_t baud_rate;
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/* Warm-boot generation this instance was last rebuilt at (retained). */
+	uint32_t warm_boot_gen;
+#endif
 #ifdef CONFIG_UART_ASYNC_API
 	struct ifx_cat1_uart_async async;
 #endif
+	/*
+	 * Restricted-scope device runtime PM reference flags. A flag is set
+	 * while an interrupt-driven or async transfer session holds a runtime
+	 * reference and cleared when it is dropped, keeping every get/put
+	 * idempotent. They are only touched when the instance is runtime
+	 * managed, but are always present so the helper call sites compile
+	 * regardless of the selected PM configuration.
+	 */
+	bool pm_irq_tx_ref;
+	bool pm_irq_rx_ref;
+	bool pm_async_tx_ref;
+	bool pm_async_rx_ref;
 };
 
 /* Device config structure */
@@ -153,6 +176,73 @@ const uint8_t parity_lut[] = {
 	[UART_CFG_PARITY_ODD] = CY_SCB_UART_PARITY_ODD,
 	[UART_CFG_PARITY_EVEN] = CY_SCB_UART_PARITY_EVEN,
 };
+
+#if defined(CONFIG_PM_DEVICE_RUNTIME)
+/*
+ * Restricted-scope device runtime PM helpers. A runtime reference is held while
+ * an interrupt-driven or async transfer session is open and dropped when it
+ * ends, so an idle UART can be runtime suspended. poll_in()/poll_out() are
+ * deliberately not instrumented: they must never sleep and the console relies
+ * on them, so the console UART is left runtime unmanaged (opt-in per instance
+ * through the zephyr,pm-device-runtime-auto devicetree property). The get() may
+ * sleep and is only called from thread context at session start; releases may
+ * originate from an ISR or DMA callback, so they use the async put. The
+ * per-reference flag keeps every get/put idempotent so no path can imbalance
+ * the usage count. All calls are inert when the instance is not runtime
+ * managed.
+ */
+static void ifx_cat1_uart_pm_ref_get(const struct device *dev, bool *held)
+{
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	struct ifx_cat1_uart_data *const data = dev->data;
+
+	/*
+	 * Single choke point for every runtime-managed hardware acquire (interrupt
+	 * and async TX/RX all pass through here).  Rebuild the SCB state lost across
+	 * a DeepSleep-RAM warm boot once, before the device is resumed, so no managed
+	 * API entry can miss it.  A no-op on every other call.  The console poll path
+	 * is unmanaged and rebuilds itself in poll_in()/poll_out().
+	 */
+	(void)ifx_pm_warm_boot_reinit(dev, &data->warm_boot_gen);
+#endif
+
+	if (!*held) {
+		*held = true;
+		(void)pm_device_runtime_get(dev);
+	}
+}
+
+static void ifx_cat1_uart_pm_ref_put(const struct device *dev, bool *held)
+{
+	if (*held) {
+		*held = false;
+		(void)pm_device_runtime_put_async(dev, K_NO_WAIT);
+	}
+}
+#else
+static inline void ifx_cat1_uart_pm_ref_get(const struct device *dev, bool *held)
+{
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	struct ifx_cat1_uart_data *const data = dev->data;
+
+	/*
+	 * Same warm-boot rebuild choke point as the runtime-managed variant above.
+	 * The device is system managed when runtime PM is not configured, but a
+	 * DeepSleep-RAM warm boot still power-cycles it, so rebuild it on first use.
+	 */
+	(void)ifx_pm_warm_boot_reinit(dev, &data->warm_boot_gen);
+#else
+	ARG_UNUSED(dev);
+#endif
+	ARG_UNUSED(held);
+}
+
+static inline void ifx_cat1_uart_pm_ref_put(const struct device *dev, bool *held)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(held);
+}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
 
 static inline uint32_t convert_uart_parity_z_to_cy(uint32_t parity)
 {
@@ -274,6 +364,17 @@ cy_rslt_t ifx_cat1_uart_set_baud(const struct device *dev, uint32_t baudrate)
 		return -EINVAL;
 	}
 
+	/*
+	 * A programmable divider must be disabled before its value is changed
+	 * (see Cy_SysClk_PeriPclkSetDivider): writing the divider while it is
+	 * still enabled does not latch the new value cleanly.  This also matters
+	 * after a DeepSleep-RAM warm boot, where the peripheral domain is
+	 * power-cycled and the divider comes back disabled: set alone would leave
+	 * the SCB without a clock and the UART would time out.  Disable, set, then
+	 * re-enable so the new rate takes effect immediately.
+	 */
+	(void)ifx_cat1_utils_peri_pclk_disable_divider(config->clk_dst, &(data->clock));
+
 	/* Set baud rate */
 	if ((data->clock.block & 0x02) == 0) {
 		status = ifx_cat1_utils_peri_pclk_set_divider(config->clk_dst, &(data->clock),
@@ -282,6 +383,8 @@ cy_rslt_t ifx_cat1_uart_set_baud(const struct device *dev, uint32_t baudrate)
 		status = ifx_cat1_utils_peri_pclk_set_frac_divider(config->clk_dst, &(data->clock),
 								   divider - 1, 0);
 	}
+
+	(void)ifx_cat1_utils_peri_pclk_enable_divider(config->clk_dst, &(data->clock));
 
 	if (status < 0) {
 		return status;
@@ -324,6 +427,15 @@ bool ifx_cat1_uart_get_tx_active(const struct device *dev)
 static int ifx_cat1_uart_poll_in(const struct device *dev, unsigned char *c)
 {
 	const struct ifx_cat1_uart_config *const config = dev->config;
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	struct ifx_cat1_uart_data *const data = dev->data;
+
+	/*
+	 * The console input path is unmanaged (no runtime PM); rebuild the SCB state
+	 * lost across a DeepSleep-RAM warm boot before reading.  A no-op otherwise.
+	 */
+	(void)ifx_pm_warm_boot_reinit(dev, &data->warm_boot_gen);
+#endif
 
 	uint32_t read_value = Cy_SCB_UART_Get(config->reg_addr);
 
@@ -338,6 +450,16 @@ static int ifx_cat1_uart_poll_in(const struct device *dev, unsigned char *c)
 static void ifx_cat1_uart_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct ifx_cat1_uart_config *const config = dev->config;
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	struct ifx_cat1_uart_data *const data = dev->data;
+
+	/*
+	 * On the first character after a DeepSleep-RAM warm boot the SCB has lost
+	 * its state; rebuild it here, in the caller's thread context, before
+	 * writing so the console comes back cleanly.  A no-op on every other call.
+	 */
+	(void)ifx_pm_warm_boot_reinit(dev, &data->warm_boot_gen);
+#endif
 
 	while (Cy_SCB_UART_Put(config->reg_addr, c) == 0) {
 		/* Wait until the character is placed in the FIFO */
@@ -500,12 +622,24 @@ void ifx_cat1_uart_enable_event(const struct device *dev, uint32_t event, bool e
 
 static void ifx_cat1_uart_irq_tx_enable(const struct device *dev)
 {
+	struct ifx_cat1_uart_data *const data = dev->data;
+
+	/*
+	 * Expected to be called from thread context; get() may sleep.  The warm-boot
+	 * rebuild (after a DeepSleep-RAM wake) is performed inside pm_ref_get(), the
+	 * shared acquire choke point, so it cannot be missed here.
+	 */
+	ifx_cat1_uart_pm_ref_get(dev, &data->pm_irq_tx_ref);
 	ifx_cat1_uart_enable_event(dev, (uint32_t)CY_SCB_UART_TRANSMIT_EMTPY, 1);
 }
 
 static void ifx_cat1_uart_irq_tx_disable(const struct device *dev)
 {
+	struct ifx_cat1_uart_data *const data = dev->data;
+
 	ifx_cat1_uart_enable_event(dev, (uint32_t)CY_SCB_UART_TRANSMIT_EMTPY, 0);
+	/* Safe from an ISR callback: async put is used. */
+	ifx_cat1_uart_pm_ref_put(dev, &data->pm_irq_tx_ref);
 }
 
 /* Check if UART TX buffer can accept a new char */
@@ -529,12 +663,23 @@ static int ifx_cat1_uart_irq_tx_complete(const struct device *dev)
 
 static void ifx_cat1_uart_irq_rx_enable(const struct device *dev)
 {
+	struct ifx_cat1_uart_data *const data = dev->data;
+
+	/*
+	 * Expected to be called from thread context; get() may sleep.  The warm-boot
+	 * rebuild is performed inside pm_ref_get() (see ifx_cat1_uart_irq_tx_enable).
+	 */
+	ifx_cat1_uart_pm_ref_get(dev, &data->pm_irq_rx_ref);
 	ifx_cat1_uart_enable_event(dev, (uint32_t)CY_SCB_UART_RECEIVE_NOT_EMTPY, 1);
 }
 
 static void ifx_cat1_uart_irq_rx_disable(const struct device *dev)
 {
+	struct ifx_cat1_uart_data *const data = dev->data;
+
 	ifx_cat1_uart_enable_event(dev, (uint32_t)CY_SCB_UART_RECEIVE_NOT_EMTPY, 0);
+	/* Safe from an ISR callback: async put is used. */
+	ifx_cat1_uart_pm_ref_put(dev, &data->pm_irq_rx_ref);
 }
 
 /* Check if UART RX buffer has a received char */
@@ -572,24 +717,9 @@ static void ifx_cat1_uart_irq_err_disable(const struct device *dev)
 static int ifx_cat1_uart_irq_is_pending(const struct device *dev)
 {
 	const struct ifx_cat1_uart_config *const config = dev->config;
-	int rx_pending = 0;
-	int tx_pending = 0;
+	uint32_t intcause = Cy_SCB_GetInterruptCause(config->reg_addr);
 
-	/*
-	 * Report pending state from live hardware state, not the latched
-	 * cause register which the ISR clears before the callback runs.
-	 * Gate on the interrupt mask: rx_ready() reflects raw FIFO occupancy,
-	 * so an ungated check would spin the ISR loop when RX is disabled.
-	 */
-	if ((Cy_SCB_GetRxInterruptMask(config->reg_addr) & CY_SCB_UART_RX_NOT_EMPTY) != 0u) {
-		rx_pending = ifx_cat1_uart_irq_rx_ready(dev);
-	}
-
-	if ((Cy_SCB_GetTxInterruptMask(config->reg_addr) & CY_SCB_UART_TX_EMPTY) != 0u) {
-		tx_pending = ifx_cat1_uart_irq_tx_ready(dev);
-	}
-
-	return ((rx_pending != 0) || (tx_pending != 0)) ? 1 : 0;
+	return (int)(intcause & (CY_SCB_TX_INTR | CY_SCB_RX_INTR));
 }
 
 /* Start processing interrupts in ISR.
@@ -601,6 +731,12 @@ static void ifx_cat1_uart_irq_update(const struct device *dev)
 {
 	const struct ifx_cat1_uart_config *const config = dev->config;
 
+	/*
+	 * Read interrupt cause and RX FIFO count have a side effect
+	 * to clear stale interrupt flags, so that FIFO is flushed
+	 * properly and the current hardware state is reflected.
+	 * This is required for proper UART operation.
+	 */
 	(void) (ifx_cat1_uart_irq_is_pending(dev));
 	(void) (Cy_SCB_UART_GetNumInRxFifo(config->reg_addr));
 }
@@ -744,6 +880,12 @@ static int ifx_cat1_uart_async_tx(const struct device *dev, const uint8_t *tx_da
 		return -EINVAL;
 	}
 
+	/*
+	 * Hold a runtime reference for the whole TX session. get() may sleep,
+	 * so it is taken before the irq_lock below.
+	 */
+	ifx_cat1_uart_pm_ref_get(dev, &data->pm_async_tx_ref);
+
 	unsigned int key = irq_lock();
 
 	/* Store information about data buffer need to send */
@@ -766,6 +908,10 @@ static int ifx_cat1_uart_async_tx(const struct device *dev, const uint8_t *tx_da
 
 exit:
 	irq_unlock(key);
+	if (err) {
+		/* No completion callback will run; drop the reference. */
+		ifx_cat1_uart_pm_ref_put(dev, &data->pm_async_tx_ref);
+	}
 	return err;
 }
 
@@ -802,6 +948,8 @@ static int ifx_cat1_uart_async_tx_abort(const struct device *dev)
 
 unlock:
 	irq_unlock(key);
+	/* TX ended; release outside the irq_lock (thread context). */
+	ifx_cat1_uart_pm_ref_put(dev, &data->pm_async_tx_ref);
 	return err;
 }
 
@@ -834,6 +982,9 @@ static void dma_callback_tx_done(const struct device *dma_dev, void *arg, uint32
 		/* DMA error */
 		dma_stop(data->async.dma_tx.dma_dev, data->async.dma_tx.dma_channel);
 	}
+
+	/* TX finished (done or error); release from ISR via async put. */
+	ifx_cat1_uart_pm_ref_put(uart_dev, &data->pm_async_tx_ref);
 
 	irq_unlock(key);
 }
@@ -958,6 +1109,12 @@ static int ifx_cat1_uart_async_rx_enable(const struct device *dev, uint8_t *rx_d
 		return -EBUSY;
 	}
 
+	/*
+	 * Hold a runtime reference for the whole RX session. get() may sleep,
+	 * so it is taken before the irq_lock below.
+	 */
+	ifx_cat1_uart_pm_ref_get(dev, &data->pm_async_rx_ref);
+
 	unsigned int key = irq_lock();
 
 	if (data->async.dma_rx.buf_len != 0) {
@@ -989,6 +1146,10 @@ static int ifx_cat1_uart_async_rx_enable(const struct device *dev, uint8_t *rx_d
 
 unlock:
 	irq_unlock(key);
+	if (err) {
+		/* RX never started; drop the reference. */
+		ifx_cat1_uart_pm_ref_put(dev, &data->pm_async_rx_ref);
+	}
 	return err;
 }
 
@@ -1017,6 +1178,8 @@ static void dma_callback_rx_rdy(const struct device *dma_dev, void *arg, uint32_
 		if (!data->async.rx_next_buf) {
 			dma_stop(data->async.dma_rx.dma_dev, data->async.dma_rx.dma_channel);
 			async_evt_rx_disabled(data);
+			/* RX ended; release from ISR via async put. */
+			ifx_cat1_uart_pm_ref_put(uart_dev, &data->pm_async_rx_ref);
 			goto unlock;
 		}
 
@@ -1045,6 +1208,8 @@ static void dma_callback_rx_rdy(const struct device *dma_dev, void *arg, uint32_
 		async_evt_rx_release_buffer(data, CURRENT_BUFFER);
 		async_evt_rx_release_buffer(data, NEXT_BUFFER);
 		async_evt_rx_disabled(data);
+		/* RX ended; release from ISR via async put. */
+		ifx_cat1_uart_pm_ref_put(uart_dev, &data->pm_async_rx_ref);
 		goto unlock;
 	}
 
@@ -1120,6 +1285,9 @@ static int ifx_cat1_uart_async_rx_disable(const struct device *dev)
 	async_evt_rx_disabled(data);
 
 	irq_unlock(key);
+
+	/* RX ended; release outside the irq_lock (thread context). */
+	ifx_cat1_uart_pm_ref_put(dev, &data->pm_async_rx_ref);
 
 	return 0;
 }
@@ -1393,8 +1561,89 @@ static int ifx_cat1_uart_init(const struct device *dev)
 	k_work_init_delayable(&data->async.dma_rx.timeout_work, ifx_cat1_uart_async_rx_timeout);
 #endif /* CONFIG_UART_ASYNC_API */
 
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/*
+	 * Opt-in: only instances tagged zephyr,pm-device-runtime-auto in
+	 * devicetree become runtime managed. The console UART is intentionally
+	 * left system managed because poll_out() never takes a runtime
+	 * reference and must always stay resumed. This is not the pm_action
+	 * TURN_ON handler (which re-initializes inline), so enabling here runs
+	 * only on cold boot.
+	 */
+	if (ret == 0) {
+		ret = pm_device_runtime_auto_enable(dev);
+	}
+#endif
+
 	return ret;
 }
+
+#ifdef CONFIG_PM_DEVICE
+static int ifx_cat1_uart_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct ifx_cat1_uart_config *const config = dev->config;
+#if defined(CONFIG_PM_S2RAM)
+	struct ifx_cat1_uart_data *const data = dev->data;
+	cy_rslt_t result;
+	int ret;
+#endif /* CONFIG_PM_S2RAM */
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend while a transmission is still in flight:
+		 * entering DeepSleep gates the SCB clock and would truncate the
+		 * frame on the wire.  Returning -EBUSY aborts the low-power
+		 * transition; the PM subsystem retries once TX has drained.
+		 */
+		if (!Cy_SCB_UART_IsTxComplete(config->reg_addr)) {
+			return -EBUSY;
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/*
+		 * Resume from a retained low-power state (regular DeepSleep): the
+		 * clocks were gated but the SCB configuration survived, so there is
+		 * nothing to restore here.  The DeepSleep-RAM warm-boot case, where
+		 * the peripheral domain is power-cycled and all SCB state is lost, is
+		 * a power-loss transition handled by PM_DEVICE_ACTION_TURN_ON instead.
+		 */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power-loss recovery.  A DeepSleep-RAM warm boot power-cycles the
+		 * peripheral domain and loses all SCB state, so re-initialize the
+		 * UART: re-apply pinctrl, re-assign the peripheral clock divider, and
+		 * replay the cached runtime configuration.  This action is emitted
+		 * only on a genuine DS-RAM warm boot (by the SoC's deferred re-init
+		 * worker running in thread context).
+		 */
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+
+		result = ifx_cat1_utils_peri_pclk_assign_divider(config->clk_dst, &data->clock);
+		if (result != CY_RSLT_SUCCESS) {
+			return -EIO;
+		}
+
+		ret = ifx_cat1_uart_configure(dev, &data->cfg);
+		if (ret < 0) {
+			return ret;
+		}
+
+		irq_enable(config->irq_num);
+		break;
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
 
 static DEVICE_API(uart, ifx_cat1_uart_driver_api) = {
 	.poll_in = ifx_cat1_uart_poll_in,
@@ -1531,6 +1780,8 @@ static DEVICE_API(uart, ifx_cat1_uart_driver_api) = {
 		return ifx_cat1_uart_init(dev);                                                    \
 	}                                                                                          \
                                                                                                    \
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_cat1_uart_pm_action);                                      \
+                                                                                                   \
 	static struct ifx_cat1_uart_config ifx_cat1_uart##n##_cfg = {                              \
 		.dt_cfg.baudrate = DT_INST_PROP(n, current_speed),                                 \
 		.dt_cfg.parity = DT_INST_ENUM_IDX_OR(n, parity, UART_CFG_PARITY_NONE),             \
@@ -1542,8 +1793,8 @@ static DEVICE_API(uart, ifx_cat1_uart_driver_api) = {
 		.clk_dst = DT_INST_PROP(n, clk_dst),                                               \
 		IRQ_INFO(n)};                                                                      \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_uart_init##n, NULL, &ifx_cat1_uart##n##_data,           \
-			      &ifx_cat1_uart##n##_cfg, PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,  \
-			      &ifx_cat1_uart_driver_api);
+	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_uart_init##n, PM_DEVICE_DT_INST_GET(n),                 \
+			      &ifx_cat1_uart##n##_data, &ifx_cat1_uart##n##_cfg, PRE_KERNEL_1,     \
+			      CONFIG_SERIAL_INIT_PRIORITY, &ifx_cat1_uart_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INFINEON_CAT1_UART_INIT)

--- a/drivers/serial/uart_infineon_pdl.c
+++ b/drivers/serial/uart_infineon_pdl.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2025 Cypress Semiconductor Corporation (an Infineon company) or
- * an affiliate of Cypress Semiconductor Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +16,9 @@
 #include <zephyr/irq.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/pm.h>
 #include <zephyr/kernel.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -124,6 +127,18 @@ struct ifx_cat1_uart_data {
 #ifdef CONFIG_UART_ASYNC_API
 	struct ifx_cat1_uart_async async;
 #endif
+	/*
+	 * Restricted-scope device runtime PM reference flags. A flag is set
+	 * while an interrupt-driven or async transfer session holds a runtime
+	 * reference and cleared when it is dropped, keeping every get/put
+	 * idempotent. They are only touched when the instance is runtime
+	 * managed, but are always present so the helper call sites compile
+	 * regardless of the selected PM configuration.
+	 */
+	bool pm_irq_tx_ref;
+	bool pm_irq_rx_ref;
+	bool pm_async_tx_ref;
+	bool pm_async_rx_ref;
 };
 
 /* Device config structure */
@@ -153,6 +168,49 @@ const uint8_t parity_lut[] = {
 	[UART_CFG_PARITY_ODD] = CY_SCB_UART_PARITY_ODD,
 	[UART_CFG_PARITY_EVEN] = CY_SCB_UART_PARITY_EVEN,
 };
+
+#if defined(CONFIG_PM_DEVICE_RUNTIME)
+/*
+ * Restricted-scope device runtime PM helpers. A runtime reference is held while
+ * an interrupt-driven or async transfer session is open and dropped when it
+ * ends, so an idle UART can be runtime suspended. poll_in()/poll_out() are
+ * deliberately not instrumented: they must never sleep and the console relies
+ * on them, so the console UART is left runtime unmanaged (opt-in per instance
+ * through the zephyr,pm-device-runtime-auto devicetree property). The get() may
+ * sleep and is only called from thread context at session start; releases may
+ * originate from an ISR or DMA callback, so they use the async put. The
+ * per-reference flag keeps every get/put idempotent so no path can imbalance
+ * the usage count. All calls are inert when the instance is not runtime
+ * managed.
+ */
+static void ifx_cat1_uart_pm_ref_get(const struct device *dev, bool *held)
+{
+	if (!*held) {
+		*held = true;
+		(void)pm_device_runtime_get(dev);
+	}
+}
+
+static void ifx_cat1_uart_pm_ref_put(const struct device *dev, bool *held)
+{
+	if (*held) {
+		*held = false;
+		(void)pm_device_runtime_put_async(dev, K_NO_WAIT);
+	}
+}
+#else
+static inline void ifx_cat1_uart_pm_ref_get(const struct device *dev, bool *held)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(held);
+}
+
+static inline void ifx_cat1_uart_pm_ref_put(const struct device *dev, bool *held)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(held);
+}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
 
 static inline uint32_t convert_uart_parity_z_to_cy(uint32_t parity)
 {
@@ -274,6 +332,17 @@ cy_rslt_t ifx_cat1_uart_set_baud(const struct device *dev, uint32_t baudrate)
 		return -EINVAL;
 	}
 
+	/*
+	 * A programmable divider must be disabled before its value is changed
+	 * (see Cy_SysClk_PeriPclkSetDivider): writing the divider while it is
+	 * still enabled does not latch the new value cleanly.  This also matters
+	 * after a DeepSleep-RAM warm boot, where the peripheral domain is
+	 * power-cycled and the divider comes back disabled: set alone would leave
+	 * the SCB without a clock and the UART would time out.  Disable, set, then
+	 * re-enable so the new rate takes effect immediately.
+	 */
+	(void)ifx_cat1_utils_peri_pclk_disable_divider(config->clk_dst, &(data->clock));
+
 	/* Set baud rate */
 	if ((data->clock.block & 0x02) == 0) {
 		status = ifx_cat1_utils_peri_pclk_set_divider(config->clk_dst, &(data->clock),
@@ -282,6 +351,8 @@ cy_rslt_t ifx_cat1_uart_set_baud(const struct device *dev, uint32_t baudrate)
 		status = ifx_cat1_utils_peri_pclk_set_frac_divider(config->clk_dst, &(data->clock),
 								   divider - 1, 0);
 	}
+
+	(void)ifx_cat1_utils_peri_pclk_enable_divider(config->clk_dst, &(data->clock));
 
 	if (status < 0) {
 		return status;
@@ -500,12 +571,24 @@ void ifx_cat1_uart_enable_event(const struct device *dev, uint32_t event, bool e
 
 static void ifx_cat1_uart_irq_tx_enable(const struct device *dev)
 {
+	struct ifx_cat1_uart_data *const data = dev->data;
+
+	/*
+	 * Expected to be called from thread context; get() may sleep.  The warm-boot
+	 * rebuild (after a DeepSleep-RAM wake) is performed inside pm_ref_get(), the
+	 * shared acquire choke point, so it cannot be missed here.
+	 */
+	ifx_cat1_uart_pm_ref_get(dev, &data->pm_irq_tx_ref);
 	ifx_cat1_uart_enable_event(dev, (uint32_t)CY_SCB_UART_TRANSMIT_EMTPY, 1);
 }
 
 static void ifx_cat1_uart_irq_tx_disable(const struct device *dev)
 {
+	struct ifx_cat1_uart_data *const data = dev->data;
+
 	ifx_cat1_uart_enable_event(dev, (uint32_t)CY_SCB_UART_TRANSMIT_EMTPY, 0);
+	/* Safe from an ISR callback: async put is used. */
+	ifx_cat1_uart_pm_ref_put(dev, &data->pm_irq_tx_ref);
 }
 
 /* Check if UART TX buffer can accept a new char */
@@ -529,12 +612,23 @@ static int ifx_cat1_uart_irq_tx_complete(const struct device *dev)
 
 static void ifx_cat1_uart_irq_rx_enable(const struct device *dev)
 {
+	struct ifx_cat1_uart_data *const data = dev->data;
+
+	/*
+	 * Expected to be called from thread context; get() may sleep.  The warm-boot
+	 * rebuild is performed inside pm_ref_get() (see ifx_cat1_uart_irq_tx_enable).
+	 */
+	ifx_cat1_uart_pm_ref_get(dev, &data->pm_irq_rx_ref);
 	ifx_cat1_uart_enable_event(dev, (uint32_t)CY_SCB_UART_RECEIVE_NOT_EMTPY, 1);
 }
 
 static void ifx_cat1_uart_irq_rx_disable(const struct device *dev)
 {
+	struct ifx_cat1_uart_data *const data = dev->data;
+
 	ifx_cat1_uart_enable_event(dev, (uint32_t)CY_SCB_UART_RECEIVE_NOT_EMTPY, 0);
+	/* Safe from an ISR callback: async put is used. */
+	ifx_cat1_uart_pm_ref_put(dev, &data->pm_irq_rx_ref);
 }
 
 /* Check if UART RX buffer has a received char */
@@ -572,24 +666,9 @@ static void ifx_cat1_uart_irq_err_disable(const struct device *dev)
 static int ifx_cat1_uart_irq_is_pending(const struct device *dev)
 {
 	const struct ifx_cat1_uart_config *const config = dev->config;
-	int rx_pending = 0;
-	int tx_pending = 0;
+	uint32_t intcause = Cy_SCB_GetInterruptCause(config->reg_addr);
 
-	/*
-	 * Report pending state from live hardware state, not the latched
-	 * cause register which the ISR clears before the callback runs.
-	 * Gate on the interrupt mask: rx_ready() reflects raw FIFO occupancy,
-	 * so an ungated check would spin the ISR loop when RX is disabled.
-	 */
-	if ((Cy_SCB_GetRxInterruptMask(config->reg_addr) & CY_SCB_UART_RX_NOT_EMPTY) != 0u) {
-		rx_pending = ifx_cat1_uart_irq_rx_ready(dev);
-	}
-
-	if ((Cy_SCB_GetTxInterruptMask(config->reg_addr) & CY_SCB_UART_TX_EMPTY) != 0u) {
-		tx_pending = ifx_cat1_uart_irq_tx_ready(dev);
-	}
-
-	return ((rx_pending != 0) || (tx_pending != 0)) ? 1 : 0;
+	return (int)(intcause & (CY_SCB_TX_INTR | CY_SCB_RX_INTR));
 }
 
 /* Start processing interrupts in ISR.
@@ -601,6 +680,12 @@ static void ifx_cat1_uart_irq_update(const struct device *dev)
 {
 	const struct ifx_cat1_uart_config *const config = dev->config;
 
+	/*
+	 * Read interrupt cause and RX FIFO count have a side effect
+	 * to clear stale interrupt flags, so that FIFO is flushed
+	 * properly and the current hardware state is reflected.
+	 * This is required for proper UART operation.
+	 */
 	(void) (ifx_cat1_uart_irq_is_pending(dev));
 	(void) (Cy_SCB_UART_GetNumInRxFifo(config->reg_addr));
 }
@@ -744,6 +829,12 @@ static int ifx_cat1_uart_async_tx(const struct device *dev, const uint8_t *tx_da
 		return -EINVAL;
 	}
 
+	/*
+	 * Hold a runtime reference for the whole TX session. get() may sleep,
+	 * so it is taken before the irq_lock below.
+	 */
+	ifx_cat1_uart_pm_ref_get(dev, &data->pm_async_tx_ref);
+
 	unsigned int key = irq_lock();
 
 	/* Store information about data buffer need to send */
@@ -766,6 +857,10 @@ static int ifx_cat1_uart_async_tx(const struct device *dev, const uint8_t *tx_da
 
 exit:
 	irq_unlock(key);
+	if (err) {
+		/* No completion callback will run; drop the reference. */
+		ifx_cat1_uart_pm_ref_put(dev, &data->pm_async_tx_ref);
+	}
 	return err;
 }
 
@@ -802,6 +897,8 @@ static int ifx_cat1_uart_async_tx_abort(const struct device *dev)
 
 unlock:
 	irq_unlock(key);
+	/* TX ended; release outside the irq_lock (thread context). */
+	ifx_cat1_uart_pm_ref_put(dev, &data->pm_async_tx_ref);
 	return err;
 }
 
@@ -834,6 +931,9 @@ static void dma_callback_tx_done(const struct device *dma_dev, void *arg, uint32
 		/* DMA error */
 		dma_stop(data->async.dma_tx.dma_dev, data->async.dma_tx.dma_channel);
 	}
+
+	/* TX finished (done or error); release from ISR via async put. */
+	ifx_cat1_uart_pm_ref_put(uart_dev, &data->pm_async_tx_ref);
 
 	irq_unlock(key);
 }
@@ -958,6 +1058,12 @@ static int ifx_cat1_uart_async_rx_enable(const struct device *dev, uint8_t *rx_d
 		return -EBUSY;
 	}
 
+	/*
+	 * Hold a runtime reference for the whole RX session. get() may sleep,
+	 * so it is taken before the irq_lock below.
+	 */
+	ifx_cat1_uart_pm_ref_get(dev, &data->pm_async_rx_ref);
+
 	unsigned int key = irq_lock();
 
 	if (data->async.dma_rx.buf_len != 0) {
@@ -989,6 +1095,10 @@ static int ifx_cat1_uart_async_rx_enable(const struct device *dev, uint8_t *rx_d
 
 unlock:
 	irq_unlock(key);
+	if (err) {
+		/* RX never started; drop the reference. */
+		ifx_cat1_uart_pm_ref_put(dev, &data->pm_async_rx_ref);
+	}
 	return err;
 }
 
@@ -1017,6 +1127,8 @@ static void dma_callback_rx_rdy(const struct device *dma_dev, void *arg, uint32_
 		if (!data->async.rx_next_buf) {
 			dma_stop(data->async.dma_rx.dma_dev, data->async.dma_rx.dma_channel);
 			async_evt_rx_disabled(data);
+			/* RX ended; release from ISR via async put. */
+			ifx_cat1_uart_pm_ref_put(uart_dev, &data->pm_async_rx_ref);
 			goto unlock;
 		}
 
@@ -1045,6 +1157,8 @@ static void dma_callback_rx_rdy(const struct device *dma_dev, void *arg, uint32_
 		async_evt_rx_release_buffer(data, CURRENT_BUFFER);
 		async_evt_rx_release_buffer(data, NEXT_BUFFER);
 		async_evt_rx_disabled(data);
+		/* RX ended; release from ISR via async put. */
+		ifx_cat1_uart_pm_ref_put(uart_dev, &data->pm_async_rx_ref);
 		goto unlock;
 	}
 
@@ -1120,6 +1234,9 @@ static int ifx_cat1_uart_async_rx_disable(const struct device *dev)
 	async_evt_rx_disabled(data);
 
 	irq_unlock(key);
+
+	/* RX ended; release outside the irq_lock (thread context). */
+	ifx_cat1_uart_pm_ref_put(dev, &data->pm_async_rx_ref);
 
 	return 0;
 }
@@ -1393,8 +1510,77 @@ static int ifx_cat1_uart_init(const struct device *dev)
 	k_work_init_delayable(&data->async.dma_rx.timeout_work, ifx_cat1_uart_async_rx_timeout);
 #endif /* CONFIG_UART_ASYNC_API */
 
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/*
+	 * Opt-in: only instances tagged zephyr,pm-device-runtime-auto in
+	 * devicetree become runtime managed. The console UART is intentionally
+	 * left system managed because poll_out() never takes a runtime
+	 * reference and must always stay resumed. This is not the pm_action
+	 * TURN_ON handler (which re-initializes inline), so enabling here runs
+	 * only on cold boot.
+	 */
+	if (ret == 0) {
+		ret = pm_device_runtime_auto_enable(dev);
+	}
+#endif
+
 	return ret;
 }
+
+#ifdef CONFIG_PM_DEVICE
+static int ifx_cat1_uart_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct ifx_cat1_uart_config *const config = dev->config;
+#if defined(CONFIG_PM_S2RAM)
+	struct ifx_cat1_uart_data *const data = dev->data;
+	cy_rslt_t result;
+	int ret;
+#endif /* CONFIG_PM_S2RAM */
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend while a transmission is in flight: gating the
+		 * SCB clock would truncate the frame on the wire.
+		 */
+		if (!Cy_SCB_UART_IsTxComplete(config->reg_addr)) {
+			return -EBUSY;
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/* Configuration is retained across the gate; nothing to restore. */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power was lost: re-init the UART - re-apply pinctrl, re-assign
+		 * the clock divider, and replay the cached runtime config.
+		 */
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+
+		result = ifx_cat1_utils_peri_pclk_assign_divider(config->clk_dst, &data->clock);
+		if (result != CY_RSLT_SUCCESS) {
+			return -EIO;
+		}
+
+		ret = ifx_cat1_uart_configure(dev, &data->cfg);
+		if (ret < 0) {
+			return ret;
+		}
+
+		irq_enable(config->irq_num);
+		break;
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
 
 static DEVICE_API(uart, ifx_cat1_uart_driver_api) = {
 	.poll_in = ifx_cat1_uart_poll_in,
@@ -1531,6 +1717,8 @@ static DEVICE_API(uart, ifx_cat1_uart_driver_api) = {
 		return ifx_cat1_uart_init(dev);                                                    \
 	}                                                                                          \
                                                                                                    \
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_cat1_uart_pm_action);                                      \
+                                                                                                   \
 	static struct ifx_cat1_uart_config ifx_cat1_uart##n##_cfg = {                              \
 		.dt_cfg.baudrate = DT_INST_PROP(n, current_speed),                                 \
 		.dt_cfg.parity = DT_INST_ENUM_IDX_OR(n, parity, UART_CFG_PARITY_NONE),             \
@@ -1542,8 +1730,8 @@ static DEVICE_API(uart, ifx_cat1_uart_driver_api) = {
 		.clk_dst = DT_INST_PROP(n, clk_dst),                                               \
 		IRQ_INFO(n)};                                                                      \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_uart_init##n, NULL, &ifx_cat1_uart##n##_data,           \
-			      &ifx_cat1_uart##n##_cfg, PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,  \
-			      &ifx_cat1_uart_driver_api);
+	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_uart_init##n, PM_DEVICE_DT_INST_GET(n),                 \
+			      &ifx_cat1_uart##n##_data, &ifx_cat1_uart##n##_cfg, PRE_KERNEL_1,     \
+			      CONFIG_SERIAL_INIT_PRIORITY, &ifx_cat1_uart_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INFINEON_CAT1_UART_INIT)

--- a/drivers/spi/spi_infineon_pdl.c
+++ b/drivers/spi/spi_infineon_pdl.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,6 +19,13 @@ LOG_MODULE_REGISTER(cat1_spi, CONFIG_SPI_LOG_LEVEL);
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/kernel.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/pm.h>
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+#include <power.h>
+#endif
 
 #ifdef CONFIG_SPI_INFINEON_DMA
 #include <zephyr/drivers/dma.h>
@@ -100,7 +107,10 @@ struct ifx_cat1_spi_data {
 	uint8_t dfs_value;
 	size_t chunk_len;
 	bool dma_configured;
-
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/* Warm-boot generation this instance was last rebuilt at (retained). */
+	uint32_t warm_boot_gen;
+#endif
 #ifdef CONFIG_SPI_INFINEON_DMA
 	struct ifx_cat1_dma_stream dma_rx;
 	struct ifx_cat1_dma_stream dma_tx;
@@ -551,9 +561,30 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 
 	spi_context_lock(ctx, asynchronous, cb, userdata, spi_cfg);
 
+	/*
+	 * Reference the device for the duration of the transfer.  When device
+	 * runtime PM is enabled this resumes the SCB on the 0->1 reference and
+	 * suspends it again on the matching put; when runtime PM is not configured
+	 * these calls are inert and the device stays system managed.
+	 */
+	(void)pm_device_runtime_get(dev);
+
+#if defined(CONFIG_PM_S2RAM) && defined(CONFIG_PM_DEVICE)
+	/*
+	 * transceive() is the single choke point for all SPI hardware access, so a
+	 * warm-boot rebuild placed here cannot be missed by any API entry.  If a
+	 * DeepSleep-RAM warm boot happened since this instance was last used, the SCB
+	 * has lost its state; rebuild it here, in the caller's thread context and
+	 * serialized by the SPI context lock, before configuring the transfer.  A
+	 * no-op on every other call.
+	 */
+	(void)ifx_pm_warm_boot_reinit(dev, &data->warm_boot_gen);
+#endif
+
 	result = spi_config(dev, spi_cfg);
 	if (result) {
 		LOG_ERR("Error in SPI Configuration (result: 0x%x)", result);
+		(void)pm_device_runtime_put(dev);
 		spi_context_release(ctx, result);
 		return result;
 	}
@@ -564,6 +595,7 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 	transfer_chunk(dev);
 	result = spi_context_wait_for_completion(&data->ctx);
 
+	(void)pm_device_runtime_put(dev);
 	spi_context_release(ctx, result);
 
 	return result;
@@ -679,8 +711,102 @@ static int ifx_cat1_spi_init(const struct device *dev)
 #ifdef CONFIG_PM
 	Cy_SysPm_RegisterCallback(&data->spi_deep_sleep);
 #endif
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/*
+	 * Opt this instance into device runtime PM whenever it is configured.  The
+	 * SCB is then reference counted per transfer (see transceive()) instead of
+	 * being suspended/resumed by the system-managed policy around every
+	 * low-power transition.  With CONFIG_PM_DEVICE_RUNTIME disabled this is
+	 * compiled out and the device stays system managed.
+	 */
+	ret = pm_device_runtime_enable(dev);
+	if (ret < 0) {
+		return ret;
+	}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
+
 	return 0;
 }
+
+#ifdef CONFIG_PM_DEVICE
+static int ifx_cat1_spi_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct ifx_cat1_spi_config *const config = dev->config;
+#if defined(CONFIG_PM_S2RAM)
+	struct ifx_cat1_spi_data *const data = dev->data;
+	cy_rslt_t result;
+	int ret;
+#endif /* CONFIG_PM_S2RAM */
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend while a transfer is still on the bus:
+		 * entering DeepSleep gates the SCB clock and would corrupt the
+		 * in-flight frame (a master stops driving SCLK mid-word).
+		 * Returning -EBUSY aborts the low-power transition; the PM
+		 * subsystem retries once the bus is idle.
+		 */
+		if (Cy_SCB_SPI_IsBusBusy(config->reg_addr) ||
+		    !Cy_SCB_SPI_IsTxComplete(config->reg_addr)) {
+			return -EBUSY;
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/*
+		 * Resume from a retained low-power state (regular DeepSleep):
+		 * the clocks were gated but the SCB configuration and the CPU
+		 * core survived, so there is nothing to restore here.  The
+		 * DeepSleep-RAM warm-boot case, where the peripheral domain and
+		 * the core are power-cycled and all SCB state is lost, is a
+		 * power-loss transition handled by PM_DEVICE_ACTION_TURN_ON
+		 * instead (see below).  This matches the Zephyr device PM model:
+		 * RESUME is SUSPENDED->ACTIVE (hardware state retained), whereas
+		 * TURN_ON is OFF->SUSPENDED (rebuild after power loss).
+		 */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power-loss recovery.  A DeepSleep-RAM warm boot power-cycles
+		 * the peripheral domain and the CPU core and loses all SCB
+		 * state, so rebuild the lost hardware: re-apply pinctrl,
+		 * re-assign the peripheral clock divider, re-configure the
+		 * chip-select GPIOs, and re-run the IRQ connect.
+		 *
+		 * This action is emitted only on a genuine DS-RAM warm boot (by
+		 * the SoC's deferred re-init worker running in thread context),
+		 * so its mere invocation is the "power was lost" signal - no
+		 * separate warm-boot flag query is needed.
+		 */
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+
+		result = ifx_cat1_utils_peri_pclk_assign_divider(config->clk_dst, &data->clock);
+		if (result != CY_RSLT_SUCCESS) {
+			return -EIO;
+		}
+
+		ret = spi_context_cs_configure_all(&data->ctx);
+		if (ret < 0) {
+			return ret;
+		}
+
+		config->irq_config_func(dev);
+
+		data->ctx.config = NULL;
+		break;
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
 
 #if defined(CONFIG_SPI_INFINEON_DMA)
 #define SPI_DMA_CHANNEL_INIT(index, dir, ch_dir, src_data_size, dst_data_size)                     \
@@ -785,8 +911,8 @@ static int ifx_cat1_spi_init(const struct device *dev)
 				 DT_INST_PROP_OR(n, enable_miso_late_sample, true),                \
 			 .EN_XFER_SEPARATION =                                                     \
 				 DT_INST_PROP_OR(n, enable_transfer_separation, false),            \
-			 ADVANCED_SPI_FIELDS(n)                                                   \
-			 .enableWakeFromSleep = DT_INST_PROP_OR(n, enableWakeFromSleep, false),    \
+			 ADVANCED_SPI_FIELDS(n).enableWakeFromSleep =                              \
+				 DT_INST_PROP(n, wakeup_source),                                   \
 			 .ssPolarity = DT_INST_PROP_OR(n, ss_polarity, CY_SCB_SPI_ACTIVE_LOW),     \
 			 .rxFifoTriggerLevel = DT_INST_PROP_OR(n, rx_fifo_trigger_level, 0),       \
 			 .rxFifoIntEnableMask = DT_INST_PROP_OR(n, rx_fifo_int_enable_mask, 0),    \
@@ -815,7 +941,9 @@ static int ifx_cat1_spi_init(const struct device *dev)
 			CY_SYSPM_SKIP_BEFORE_TRANSITION,                                           \
 			&spi_cat1_config_##n.spi_deep_sleep_param, NULL, NULL, 1}};                \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_spi_init, NULL, &spi_cat1_data_##n,                     \
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_cat1_spi_pm_action);                                       \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_spi_init, PM_DEVICE_DT_INST_GET(n), &spi_cat1_data_##n, \
 			      &spi_cat1_config_##n, POST_KERNEL,                                   \
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ifx_cat1_spi_api);
 
@@ -1015,6 +1143,15 @@ static cy_rslt_t ifx_cat1_spi_int_frequency(const struct device *dev, uint32_t h
 		CY_UNUSED_PARAMETER(last_ovrsmpl_val);
 	}
 
+	/*
+	 * A programmable divider must be disabled before its value is changed
+	 * (see Cy_SysClk_PeriPclkSetDivider): writing the divider while it is
+	 * still enabled does not latch the new value cleanly, so the first
+	 * transfer after boot can run without a usable SCB clock and time out.
+	 * Disable, set, then re-enable so the new rate takes effect immediately.
+	 */
+	(void)ifx_cat1_utils_peri_pclk_disable_divider(config->clk_dst, &(data->clock));
+
 	if ((data->clock.block & 0x02) == 0) {
 		result = ifx_cat1_utils_peri_pclk_set_divider(config->clk_dst, &(data->clock),
 							      last_dvdr_val - 1);
@@ -1022,6 +1159,8 @@ static cy_rslt_t ifx_cat1_spi_int_frequency(const struct device *dev, uint32_t h
 		result = ifx_cat1_utils_peri_pclk_set_frac_divider(config->clk_dst, &(data->clock),
 								   last_dvdr_val - 1, 0);
 	}
+
+	(void)ifx_cat1_utils_peri_pclk_enable_divider(config->clk_dst, &(data->clock));
 
 	return result;
 }

--- a/drivers/spi/spi_infineon_pdl.c
+++ b/drivers/spi/spi_infineon_pdl.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,6 +19,9 @@ LOG_MODULE_REGISTER(cat1_spi, CONFIG_SPI_LOG_LEVEL);
 #include <zephyr/drivers/clock_control/clock_control_ifx_cat1.h>
 #include <zephyr/dt-bindings/clock/ifx_clock_source_common.h>
 #include <zephyr/kernel.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/pm.h>
 
 #ifdef CONFIG_SPI_INFINEON_DMA
 #include <zephyr/drivers/dma.h>
@@ -100,7 +103,6 @@ struct ifx_cat1_spi_data {
 	uint8_t dfs_value;
 	size_t chunk_len;
 	bool dma_configured;
-
 #ifdef CONFIG_SPI_INFINEON_DMA
 	struct ifx_cat1_dma_stream dma_rx;
 	struct ifx_cat1_dma_stream dma_tx;
@@ -551,9 +553,18 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 
 	spi_context_lock(ctx, asynchronous, cb, userdata, spi_cfg);
 
+	/*
+	 * Reference the device for the duration of the transfer.  When device
+	 * runtime PM is enabled this resumes the SCB on the 0->1 reference and
+	 * suspends it again on the matching put; when runtime PM is not configured
+	 * these calls are inert and the device stays system managed.
+	 */
+	(void)pm_device_runtime_get(dev);
+
 	result = spi_config(dev, spi_cfg);
 	if (result) {
 		LOG_ERR("Error in SPI Configuration (result: 0x%x)", result);
+		(void)pm_device_runtime_put(dev);
 		spi_context_release(ctx, result);
 		return result;
 	}
@@ -564,6 +575,7 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 	transfer_chunk(dev);
 	result = spi_context_wait_for_completion(&data->ctx);
 
+	(void)pm_device_runtime_put(dev);
 	spi_context_release(ctx, result);
 
 	return result;
@@ -679,8 +691,82 @@ static int ifx_cat1_spi_init(const struct device *dev)
 #ifdef CONFIG_PM
 	Cy_SysPm_RegisterCallback(&data->spi_deep_sleep);
 #endif
+
+#ifdef CONFIG_PM_DEVICE_RUNTIME
+	/*
+	 * Opt this instance into device runtime PM whenever it is configured.  The
+	 * SCB is then reference counted per transfer (see transceive()) instead of
+	 * being suspended/resumed by the system-managed policy around every
+	 * low-power transition.  With CONFIG_PM_DEVICE_RUNTIME disabled this is
+	 * compiled out and the device stays system managed.
+	 */
+	ret = pm_device_runtime_enable(dev);
+	if (ret < 0) {
+		return ret;
+	}
+#endif /* CONFIG_PM_DEVICE_RUNTIME */
+
 	return 0;
 }
+
+#ifdef CONFIG_PM_DEVICE
+static int ifx_cat1_spi_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	const struct ifx_cat1_spi_config *const config = dev->config;
+#if defined(CONFIG_PM_S2RAM)
+	struct ifx_cat1_spi_data *const data = dev->data;
+	cy_rslt_t result;
+	int ret;
+#endif /* CONFIG_PM_S2RAM */
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		/*
+		 * Refuse to suspend mid-transfer: gating the SCB clock would
+		 * corrupt the in-flight frame. Retried once the bus is idle.
+		 */
+		if (Cy_SCB_SPI_IsBusBusy(config->reg_addr) ||
+		    !Cy_SCB_SPI_IsTxComplete(config->reg_addr)) {
+			return -EBUSY;
+		}
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		/* Configuration is retained across the gate; nothing to restore. */
+		break;
+#if defined(CONFIG_PM_S2RAM)
+	case PM_DEVICE_ACTION_TURN_ON:
+		/*
+		 * Power was lost: rebuild the SCB - re-apply pinctrl, re-assign
+		 * the clock divider, re-configure the CS GPIOs, and re-connect
+		 * the IRQ.
+		 */
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+
+		result = ifx_cat1_utils_peri_pclk_assign_divider(config->clk_dst, &data->clock);
+		if (result != CY_RSLT_SUCCESS) {
+			return -EIO;
+		}
+
+		ret = spi_context_cs_configure_all(&data->ctx);
+		if (ret < 0) {
+			return ret;
+		}
+
+		config->irq_config_func(dev);
+
+		data->ctx.config = NULL;
+		break;
+#endif /* CONFIG_PM_S2RAM */
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_PM_DEVICE */
 
 #if defined(CONFIG_SPI_INFINEON_DMA)
 #define SPI_DMA_CHANNEL_INIT(index, dir, ch_dir, src_data_size, dst_data_size)                     \
@@ -785,8 +871,8 @@ static int ifx_cat1_spi_init(const struct device *dev)
 				 DT_INST_PROP_OR(n, enable_miso_late_sample, true),                \
 			 .EN_XFER_SEPARATION =                                                     \
 				 DT_INST_PROP_OR(n, enable_transfer_separation, false),            \
-			 ADVANCED_SPI_FIELDS(n)                                                   \
-			 .enableWakeFromSleep = DT_INST_PROP_OR(n, enableWakeFromSleep, false),    \
+			 ADVANCED_SPI_FIELDS(n).enableWakeFromSleep =                              \
+				 DT_INST_PROP(n, wakeup_source),                                   \
 			 .ssPolarity = DT_INST_PROP_OR(n, ss_polarity, CY_SCB_SPI_ACTIVE_LOW),     \
 			 .rxFifoTriggerLevel = DT_INST_PROP_OR(n, rx_fifo_trigger_level, 0),       \
 			 .rxFifoIntEnableMask = DT_INST_PROP_OR(n, rx_fifo_int_enable_mask, 0),    \
@@ -815,7 +901,9 @@ static int ifx_cat1_spi_init(const struct device *dev)
 			CY_SYSPM_SKIP_BEFORE_TRANSITION,                                           \
 			&spi_cat1_config_##n.spi_deep_sleep_param, NULL, NULL, 1}};                \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_spi_init, NULL, &spi_cat1_data_##n,                     \
+	PM_DEVICE_DT_INST_DEFINE(n, ifx_cat1_spi_pm_action);                                       \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_spi_init, PM_DEVICE_DT_INST_GET(n), &spi_cat1_data_##n, \
 			      &spi_cat1_config_##n, POST_KERNEL,                                   \
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &ifx_cat1_spi_api);
 
@@ -1015,6 +1103,15 @@ static cy_rslt_t ifx_cat1_spi_int_frequency(const struct device *dev, uint32_t h
 		CY_UNUSED_PARAMETER(last_ovrsmpl_val);
 	}
 
+	/*
+	 * A programmable divider must be disabled before its value is changed
+	 * (see Cy_SysClk_PeriPclkSetDivider): writing the divider while it is
+	 * still enabled does not latch the new value cleanly, so the first
+	 * transfer after boot can run without a usable SCB clock and time out.
+	 * Disable, set, then re-enable so the new rate takes effect immediately.
+	 */
+	(void)ifx_cat1_utils_peri_pclk_disable_divider(config->clk_dst, &(data->clock));
+
 	if ((data->clock.block & 0x02) == 0) {
 		result = ifx_cat1_utils_peri_pclk_set_divider(config->clk_dst, &(data->clock),
 							      last_dvdr_val - 1);
@@ -1022,6 +1119,8 @@ static cy_rslt_t ifx_cat1_spi_int_frequency(const struct device *dev, uint32_t h
 		result = ifx_cat1_utils_peri_pclk_set_frac_divider(config->clk_dst, &(data->clock),
 								   last_dvdr_val - 1, 0);
 	}
+
+	(void)ifx_cat1_utils_peri_pclk_enable_divider(config->clk_dst, &(data->clock));
 
 	return result;
 }

--- a/include/zephyr/drivers/clock_control/clock_control_ifx_cat1.h
+++ b/include/zephyr/drivers/clock_control/clock_control_ifx_cat1.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2025 Cypress Semiconductor Corporation (an Infineon company) or
- * an affiliate of Cypress Semiconductor Corporation
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -470,6 +470,30 @@ static inline cy_rslt_t ifx_cat1_utils_peri_pclk_enable_divider(en_clk_dst_t clk
 #else
 	CY_UNUSED_PARAMETER(clk_dest);
 	return Cy_SysClk_PeriphEnableDivider(
+		IFX_CAT1_PERIPHERAL_GROUP_GET_DIVIDER_TYPE(_clock->block), _clock->channel);
+#endif
+}
+
+/**
+ * @brief Disable the divider associated with a peripheral clock.
+ *
+ * A programmable divider must be disabled before its value is changed; the
+ * caller re-enables it afterwards so the new value takes effect cleanly.
+ *
+ * @param clk_dest Peripheral clock destination.
+ * @param _clock Clock descriptor.
+ * @return Result code from the underlying PDL call.
+ */
+static inline cy_rslt_t
+ifx_cat1_utils_peri_pclk_disable_divider(en_clk_dst_t clk_dest, const struct ifx_cat1_clock *_clock)
+{
+#if defined(COMPONENT_CAT1B) || defined(COMPONENT_CAT1C) || defined(CONFIG_SOC_FAMILY_INFINEON_EDGE)
+	return Cy_SysClk_PeriPclkDisableDivider(
+		clk_dest, IFX_CAT1_PERIPHERAL_GROUP_GET_DIVIDER_TYPE(_clock->block),
+		_clock->channel);
+#else
+	CY_UNUSED_PARAMETER(clk_dest);
+	return Cy_SysClk_PeriphDisableDivider(
 		IFX_CAT1_PERIPHERAL_GROUP_GET_DIVIDER_TYPE(_clock->block), _clock->channel);
 #endif
 }


### PR DESCRIPTION
Added pm_action suspend/resume/turn_on routine for multiple Infineon drivers:

- (TCPWM) PWM, Counter
- (SCB) UART, SPI, I2C
- DMA
- DMIC
- I2S
- SDHC
- (PERI)Clock

Related PRs:
- https://github.com/zephyrproject-rtos/hal_infineon/pull/69
- https://github.com/zephyrproject-rtos/zephyr/pull/114221
- https://github.com/zephyrproject-rtos/zephyr/pull/114224