### PR TITLE
boards: microchip: Add support for flashing with mplab_ipe

### DIFF
--- a/boards/microchip/pic32c/pic32ck_gc01_cult/board.cmake
+++ b/boards/microchip/pic32c/pic32ck_gc01_cult/board.cmake
@@ -1,6 +1,8 @@
 # Copyright (c) 2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(mplab_ipe "--tool" "PKOB4" "--part" "32CK2051GC01144" "--erase" "--verify")
 board_runner_args(jlink "--device=PIC32CK2051GC" "--speed=4000")
 
+include(${ZEPHYR_BASE}/boards/common/mplab_ipe.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/microchip/pic32c/pic32ck_gc01_cult/doc/index.rst
+++ b/boards/microchip/pic32c/pic32ck_gc01_cult/doc/index.rst
@@ -50,6 +50,10 @@ Programming & Debugging
 
 .. zephyr:board-supported-runners::
 
+Flash Using MPLAB IPE
+=====================
+For instructions on flashing using MPLAB IPE see :ref:`microchip-mplab-ipe-flashing`.
+
 Flash Using J-Link
 ==================
 

--- a/boards/microchip/pic32c/pic32cm_gc00_cpro/board.cmake
+++ b/boards/microchip/pic32c/pic32cm_gc00_cpro/board.cmake
@@ -1,6 +1,8 @@
 # Copyright (c) 2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(mplab_ipe "--tool" "PKOB4" "--part" "32CM5112GC00100" "--erase" "--verify")
 board_runner_args(jlink "--device=PIC32CM5112GC" "--speed=auto")
 
+include(${ZEPHYR_BASE}/boards/common/mplab_ipe.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/microchip/pic32c/pic32cm_gc00_cpro/doc/index.rst
+++ b/boards/microchip/pic32c/pic32cm_gc00_cpro/doc/index.rst
@@ -46,6 +46,10 @@ Programming & Debugging
 
 .. zephyr:board-supported-runners::
 
+Flash Using MPLAB IPE
+=====================
+For instructions on flashing using MPLAB IPE see :ref:`microchip-mplab-ipe-flashing`.
+
 Flash Using J-Link
 ==================
 

--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/board.cmake
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/board.cmake
@@ -2,4 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=pic32cm5164jh01048" "--frequency=400000")
+board_runner_args(mplab_ipe "--tool" "nEDBG" "--part" "32CM5164JH01048" "--erase" "--verify")
+
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/mplab_ipe.board.cmake)

--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/doc/index.rst
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/doc/index.rst
@@ -55,6 +55,10 @@ Programming & Debugging
 Setting Up the Debug Interface
 ==============================
 
+Flash Using MPLAB IPE
+=====================
+For instructions on flashing using MPLAB IPE see :ref:`microchip-mplab-ipe-flashing`.
+
 PyOCD Setup
 ===========
 

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/board.cmake
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/board.cmake
@@ -1,8 +1,10 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=pic32cm5164jh01100" "--frequency=4000")
 board_runner_args(jlink "--device=PIC32CM5164JH" "--speed=4000")
+board_runner_args(mplab_ipe "--tool" "EDBG" "--part" "32CM5164JH01100" "--erase" "--verify")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/mplab_ipe.board.cmake)

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/doc/index.rst
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/doc/index.rst
@@ -120,6 +120,9 @@ J-Link Setup
    - Connect the other end of the J32 Debug Probe to your **host machine (PC)** via USB.
    - Connect the DEBUG USB port on the board to your host machine to **power up the board**.
 
+Flash Using MPLAB IPE
+=====================
+For instructions on flashing using MPLAB IPE see :ref:`microchip-mplab-ipe-flashing`.
 
 Building and Flashing the Application
 =====================================

--- a/boards/microchip/pic32c/pic32cm_pl10_cnano/board.cmake
+++ b/boards/microchip/pic32c/pic32cm_pl10_cnano/board.cmake
@@ -2,4 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=pic32cm6408pl10048" "--frequency=100000")
+board_runner_args(mplab_ipe "--tool" "nEDBG" "--part" "32CM6408PL10048" "--erase" "--verify")
+
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/mplab_ipe.board.cmake)

--- a/boards/microchip/pic32c/pic32cm_pl10_cnano/doc/index.rst
+++ b/boards/microchip/pic32c/pic32cm_pl10_cnano/doc/index.rst
@@ -55,6 +55,10 @@ Programming & Debugging
 
 .. zephyr:board-supported-runners::
 
+Flash Using MPLAB IPE
+=====================
+For instructions on flashing using MPLAB IPE see :ref:`microchip-mplab-ipe-flashing`.
+
 Setting Up the Debug Interface
 ==============================
 

--- a/boards/microchip/pic32c/pic32cm_sg00_cpro/board.cmake
+++ b/boards/microchip/pic32c/pic32cm_sg00_cpro/board.cmake
@@ -1,6 +1,8 @@
 # Copyright (c) 2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(mplab_ipe "--tool" "PKOB4" "--part" "32CM5112SG00100" "--erase" "--verify")
 board_runner_args(jlink "--device=PIC32CM5112SG" "--speed=auto")
 
+include(${ZEPHYR_BASE}/boards/common/mplab_ipe.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/microchip/pic32c/pic32cm_sg00_cpro/doc/index.rst
+++ b/boards/microchip/pic32c/pic32cm_sg00_cpro/doc/index.rst
@@ -46,6 +46,10 @@ Programming & Debugging
 
 .. zephyr:board-supported-runners::
 
+Flash Using MPLAB IPE
+=====================
+For instructions on flashing using MPLAB IPE see :ref:`microchip-mplab-ipe-flashing`.
+
 Flash Using J-Link
 ==================
 

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/board.cmake
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/board.cmake
@@ -1,6 +1,8 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(mplab_ipe "--tool" "PKOB4" "--part" "32CX1025SG61128" "--erase" "--verify")
 board_runner_args(jlink "--device=PIC32CX1025SG61128" "--speed=4000")
 
+include(${ZEPHYR_BASE}/boards/common/mplab_ipe.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/doc/index.rst
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/doc/index.rst
@@ -42,6 +42,10 @@ Programming & Debugging
 
 .. zephyr:board-supported-runners::
 
+Flash Using MPLAB IPE
+=====================
+For instructions on flashing using MPLAB IPE see :ref:`microchip-mplab-ipe-flashing`.
+
 Flash Using J-Link
 ==================
 

--- a/boards/microchip/pic32c/pic32cz_ca80_cult/board.cmake
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/board.cmake
@@ -1,6 +1,8 @@
-# Copyright (c) 2025 Microchip Technology Inc.
+# Copyright (c) 2025-2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(mplab_ipe "--tool" "PKOB4" "--part" "32CZ8110CA80208" "--erase" "--verify")
 board_runner_args(jlink "--device=PIC32CZ8110CA80" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/mplab_ipe.board.cmake)

--- a/boards/microchip/pic32c/pic32cz_ca80_cult/doc/index.rst
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/doc/index.rst
@@ -44,6 +44,10 @@ Programming & Debugging
 
 .. zephyr:board-supported-runners::
 
+Flash Using MPLAB IPE
+=====================
+For instructions on flashing using MPLAB IPE see :ref:`microchip-mplab-ipe-flashing`.
+
 Flash Using J-Link
 ==================
 

--- a/boards/microchip/pic32c/pic32cz_ca90_cult/board.cmake
+++ b/boards/microchip/pic32c/pic32cz_ca90_cult/board.cmake
@@ -1,6 +1,8 @@
 # Copyright (c) 2026 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(mplab_ipe "--tool" "PKOB4" "--part" "32CZ8110CA90208" "--erase" "--verify")
 board_runner_args(jlink "--device=PIC32CZ8110CA90" "--speed=4000")
 
+include(${ZEPHYR_BASE}/boards/common/mplab_ipe.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/microchip/pic32c/pic32cz_ca90_cult/doc/index.rst
+++ b/boards/microchip/pic32c/pic32cz_ca90_cult/doc/index.rst
@@ -41,6 +41,10 @@ Programming & Debugging
 
 .. zephyr:board-supported-runners::
 
+Flash Using MPLAB IPE
+=====================
+For instructions on flashing using MPLAB IPE see :ref:`microchip-mplab-ipe-flashing`.
+
 Flash Using J-Link
 ==================
 


### PR DESCRIPTION
- Added support for flashing for the following boards using `mplab_ipe` runner
  - pic32ck_gc01_cult
  - pic32cm_gc00_cpro
  - pic32cm_jh01_cnano
  - pic32cm_jh01_cpro
  - pic32cm_pl10_cnano
  - pic32cm_pl10_cnano
  - pic32cx_sg61_cult
  - pic32cz_ca80_cult
  - pic32cz_ca90_cult