### PR TITLE
boards: nxp: frdm_mcxe31b: enable lpi2c support

### DIFF
--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b-pinctrl.dtsi
@@ -49,6 +49,16 @@
 		};
 	};
 
+	pinmux_lpi2c_0: pinmux_lpi2c_0 {
+		group1 {
+			pinmux = <(PTD13_LPI2C0_SDA_I | PTD13_LPI2C0_SDA_O)>,
+				 <(PTD14_LPI2C0_SCL_I | PTD14_LPI2C0_SCL_O)>;
+			input-enable;
+			output-enable;
+			bias-pull-up;
+		};
+	};
+
 	pinmux_lpi2c_1: pinmux_lpi2c_1 {
 		group1 {
 			pinmux = <(PTC6_LPI2C1_SDA_I | PTC6_LPI2C1_SDA_O)>,

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
@@ -24,6 +24,7 @@
 		sw0 = &user_button;
 		rtc = &counter_rtc;
 		watchdog0 = &swt_0;
+		accel0 = &fxls8974;
 	};
 
 	chosen {
@@ -300,6 +301,19 @@ lpuart2: &lpuart_2 {};
 		rs-gpios = <&gpioc_l 8 GPIO_ACTIVE_HIGH>;
 		pinctrl-0 = <&pinmux_flexio_lcd>;
 		pinctrl-names = "default";
+	};
+};
+
+&lpi2c_0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpi2c_0>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+
+	fxls8974: fxls8974@18 {
+		compatible = "nxp,fxls8974";
+		reg = <0x18>;
+		status = "okay";
 	};
 };
 

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
@@ -24,6 +24,7 @@
 		sw0 = &user_button;
 		rtc = &counter_rtc;
 		watchdog0 = &swt_0;
+		accel0 = &fxls8974;
 	};
 
 	chosen {
@@ -314,6 +315,19 @@ lpuart2: &lpuart_2 {};
 		rs-gpios = <&gpioc_l 8 GPIO_ACTIVE_HIGH>;
 		pinctrl-0 = <&pinmux_flexio_lcd>;
 		pinctrl-names = "default";
+	};
+};
+
+&lpi2c_0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_lpi2c_0>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+
+	fxls8974: fxls8974@18 {
+		compatible = "nxp,fxls8974";
+		reg = <0x18>;
+		status = "okay";
 	};
 };
 

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
@@ -19,6 +19,7 @@ supported:
   - watchdog
   - adc
   - hwinfo
+  - i2c
   - pwm
   - i2s
   - spi

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
@@ -19,6 +19,7 @@ supported:
   - watchdog
   - adc
   - hwinfo
+  - i2c
   - pwm
   - spi
 vendor: nxp

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxe31b.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxe31b.overlay
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* LPI2C0 is remuxed from the default on-board sensor pins (PTD13/PTD14)
+ * to PTC8/PTC9, which are exposed on header J8 next to the LPI2C1 pins,
+ * so the two buses can be shorted with two jumpers on a single header.
+ * The LPI2C1 on-board pull-ups (R15/R16) serve the shorted bus.
+ *
+ * To test this sample, connect
+ * LPI2C0 SCL(J8-8, PTC8)    -->        LPI2C1 SCL(J8-3, PTC7)
+ * LPI2C0 SDA(J8-6, PTC9)    -->        LPI2C1 SDA(J8-4, PTC6)
+ */
+
+&pinctrl {
+	pinmux_lpi2c_0_j8: pinmux_lpi2c_0_j8 {
+		group1 {
+			pinmux = <(PTC9_LPI2C0_SDA_I | PTC9_LPI2C0_SDA_O)>,
+				 <(PTC8_LPI2C0_SCL_I | PTC8_LPI2C0_SCL_O)>;
+			input-enable;
+			output-enable;
+			bias-pull-up;
+		};
+	};
+};
+
+&lpi2c_0 {
+	pinctrl-0 = <&pinmux_lpi2c_0_j8>;
+	pinctrl-names = "default";
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&lpi2c_1 {
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -47,6 +47,7 @@ tests:
       - CONFIG_APP_DUAL_ROLE_I2C=y
   drivers.i2c.target_api.single_role:
     platform_allow:
+      - frdm_mcxe31b
       - frdm_mcxn947/mcxn947/cpu0
       - mcx_n9xx_evk/mcxn947/cpu0
       - mcxw72_evk

--- a/tests/drivers/i2c/i2c_target_api/tests.yaml
+++ b/tests/drivers/i2c/i2c_target_api/tests.yaml
@@ -58,6 +58,7 @@ tests:
       - frdm_mcxa366
       - frdm_mcxa577
       - frdm_mcxc242
+      - frdm_mcxe31b
       - frdm_mcxn236
       - frdm_mcxn947/mcxn947/cpu0
       - it51xxx_evb/it51526aw


### PR DESCRIPTION
Enable LPI2C on FRDM-MCXE31B (MCXE31x).

- `boards: nxp: frdm_mcxe31b: enable lpi2c support` — LPI2C0 on
  PTD13/PTD14, the on-board I2C bus per board schematic: FXLS8974CF
  accelerometer at 0x18 with populated pull-ups (no external wiring
  needed). Adds pinctrl group, `fxls8974` child node with `accel0`
  alias, and `i2c` to the board's supported features.
- `tests: drivers: i2c: enable target_api on frdm_mcxe31b` — allow
  `drivers.i2c.target_api.single_role` and add the board overlay with
  virtual eeprom targets on `lpi2c_0`/`lpi2c_1`. Needs only two jumper
  wires (J8-8↔J8-3 SCL, J8-6↔J8-4 SDA, documented in the overlay).

Validation (on hardware):
- `samples/sensor/accel_polling`: FXLS8974 streams valid XYZ data
  (~1 g on Z) over LPI2C0.
- `tests/drivers/i2c/i2c_target_api` (`single_role`, wired per the
  overlay comment): `test_eeprom_target` passes in both directions —
  first coverage of LPI2C target (slave) mode on MCXE31x.
- Twister build-only sweep over i2c-dependent suites on
  `frdm_mcxe31b`: 0 failures; device-specific suites (gy271/at24/
  bme688/i2c_ram) are cleanly devicetree-filtered.
