### PR TITLE
driver: flash: nrf_mramc driver allow to read tfm secure memory

### DIFF
--- a/drivers/flash/soc_flash_nrf_mramc.c
+++ b/drivers/flash/soc_flash_nrf_mramc.c
@@ -12,6 +12,7 @@
 
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 #include "tfm_ioctl_core_api.h"
+#include <soc_secure.h>
 #else
 #include <nrfx_mramc.h>
 #endif
@@ -167,6 +168,10 @@ static int nrf_mramc_read(const struct device *dev, off_t offset, void *data, si
 	/* Buffer read number of bytes and store in data pointer.
 	 */
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	if (soc_secure_flash_range_is_secure((uintptr_t)addr, len)) {
+		LOG_DBG("read secure mem: %x:%zu", addr, len);
+		return soc_secure_mem_read(data, (void *)addr, len);
+	}
 	memcpy(data, (void *)addr, len);
 #else
 	nrfx_mramc_buffer_read(data, addr, len);


### PR DESCRIPTION
Implement soc_secure_mem_read for flash driver to read secure memory, access to the range of secure memory from non secure side should be governed by tfm_platform allow list.