### PR TITLE
Create default edtlib.EDT.cpus CPU property

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1683,8 +1683,10 @@ class Node:
                 self._binding = binding_from_parent
                 return
 
-        # No binding found
-        self._binding = None
+        # No binding found. Fall back to a synthesized default binding, if
+        # this node matches one of the well-known default node kinds. Otherwise,
+        # return None
+        self._binding = _default_binding_for(self)
 
     def _binding_from_properties(self) -> None:
         # Sets up a Binding object synthesized from the properties in the node.
@@ -3942,3 +3944,94 @@ _DEFAULT_PROP_SPECS: dict[str, PropertySpec] = {
     name: PropertySpec(name, _DEFAULT_PROP_BINDING)
     for name in _DEFAULT_PROP_TYPES
 }
+
+#
+# Synthesized bindings for well-known "default" nodes that commonly appear
+# without a 'compatible' property, and therefore would otherwise end up with
+# no binding at all (and hence an empty Node.props).
+#
+
+_CPU_BINDING_RAW: dict = {
+    'description': 'Standin binding for /cpus/cpu* nodes without a matching '
+                    'binding, synthesized per Devicetree Specification '
+                    'v0.4 SS3.8 (Tables 3.9-3.12).',
+    'properties': {
+        # Table 3.9: General Properties
+        'device_type': {'type': 'string', 'required': True},
+        'reg': {'type': 'array', 'required': True},
+        'clock-frequency': {'type': 'array'},
+        'timebase-frequency': {'type': 'array'},
+        'status': {'type': 'string', 'enum': _STATUS_ENUM},
+        'enable-method': {'type': 'string-array'},
+        'cpu-release-addr': {'type': 'int'},
+
+        # Table 3.10: Power ISA Properties. The wildcard 'power-isa-*'
+        # category-flag properties (e.g. 'power-isa-e.hv') can't be
+        # expressed here since Binding properties are matched by literal
+        # name, not pattern.
+        'power-isa-version': {'type': 'string'},
+        'cache-op-block-size': {'type': 'int'},
+        'reservation-granule-size': {'type': 'int'},
+        'mmu-type': {'type': 'string', 'enum': [
+            'mpc8xx', 'ppc40x', 'ppc440', 'ppc476', 'power-embedded',
+            'powerpc-classic', 'power-server-stab', 'power-server-slb',
+            'none',
+        ]},
+
+        # Table 3.11: TLB Properties
+        'tlb-split': {'type': 'boolean'},
+        'tlb-size': {'type': 'int'},
+        'tlb-sets': {'type': 'int'},
+        'd-tlb-size': {'type': 'int'},
+        'd-tlb-sets': {'type': 'int'},
+        'i-tlb-size': {'type': 'int'},
+        'i-tlb-sets': {'type': 'int'},
+
+        # Table 3.12: Internal (L1) Cache Properties
+        'cache-unified': {'type': 'boolean'},
+        'cache-size': {'type': 'int'},
+        'cache-sets': {'type': 'int'},
+        'cache-block-size': {'type': 'int'},
+        'cache-line-size': {'type': 'int'},
+        'i-cache-size': {'type': 'int'},
+        'i-cache-sets': {'type': 'int'},
+        'i-cache-block-size': {'type': 'int'},
+        'i-cache-line-size': {'type': 'int'},
+        'd-cache-size': {'type': 'int'},
+        'd-cache-sets': {'type': 'int'},
+        'd-cache-block-size': {'type': 'int'},
+        'd-cache-line-size': {'type': 'int'},
+        'next-level-cache': {'type': 'phandle'},
+        # Deprecated pre-DTSpec form of 'next-level-cache'.
+        'l2-cache': {'type': 'phandle'},
+    },
+}
+
+_CPU_BINDING: Binding = Binding(
+    None, {},
+    raw=_CPU_BINDING_RAW,
+    require_compatible=False,
+    require_description=False,
+)
+
+def _is_cpu_node(node: "Node") -> bool:
+    # A /cpus/cpu* node per DT spec SS3.8 ("The node name for every CPU
+    # node should be cpu"). Mirrors the EDT.cpus check.
+    return bool(node.parent
+                and node.parent.path == "/cpus"
+                and node.name.split("@", 1)[0] == "cpu")
+
+# Predicate -> synthesized Binding, tried in order. Add an entry here to give
+# another well-known kind of binding-less node (identified structurally, not
+# via 'compatible') a fallback Binding, without touching Node._init_binding().
+_DEFAULT_NODE_BINDINGS: list[tuple[Callable[["Node"], bool], Binding]] = [
+    (_is_cpu_node, _CPU_BINDING),
+]
+
+def _default_binding_for(node: "Node") -> Optional[Binding]:
+    # Returns a synthesized fallback Binding if 'node' matches one of the
+    # well-known default node kinds in _DEFAULT_NODE_BINDINGS, else None.
+    for is_match, binding in _DEFAULT_NODE_BINDINGS:
+        if is_match(node):
+            return binding
+    return None

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2404,6 +2404,7 @@ class EDT:
 
         # Public attributes (the rest are properties)
         self.nodes: list[Node] = []
+        self.cpus: list[Node] = []
         self.compat2nodes: dict[str, list[Node]] = defaultdict(list)
         self.compat2okay: dict[str, list[Node]] = defaultdict(list)
         self.compat2notokay: dict[str, list[Node]] = defaultdict(list)
@@ -2735,6 +2736,11 @@ class EDT:
 
             self.nodes.append(node)
             self._node2enode[dt_node] = node
+
+            if (node.parent
+                    and node.parent.path == "/cpus"
+                    and node.name.split("@", 1)[0] == "cpu"):
+                self.cpus.append(node)
 
         for node in self.nodes:
             # Initialize properties that may depend on other Node objects having

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -704,5 +704,15 @@
 			reg = <1>;
 			clock-frequency = <2000>;
 		};
+
+		cpu@2 {
+			/* No 'compatible': binding should be synthesized. */
+			device_type = "cpu";
+			reg = <2>;
+			clock-frequency = <3000>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0xa0000000>;
+			status = "disabled";
+		};
 	};
 };

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -788,8 +788,25 @@ def test_cpus():
 
     cpu0 = edt.get_node("/cpus/cpu@0")
     cpu1 = edt.get_node("/cpus/cpu@1")
+    cpu2 = edt.get_node("/cpus/cpu@2")
 
-    assert edt.cpus == [cpu0, cpu1]
+    assert edt.cpus == [cpu0, cpu1, cpu2]
+
+def test_cpu_default_binding():
+    """CPU nodes without a matching 'compatible' get a synthesized binding
+    with the general properties from DT spec section 3.8."""
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    cpu2 = edt.get_node("/cpus/cpu@2")
+
+    assert cpu2.binding_path is None
+    assert cpu2.props["device_type"].val == "cpu"
+    assert cpu2.props["reg"].val == [2]
+    assert cpu2.props["clock-frequency"].val == [3000]
+    assert cpu2.props["enable-method"].val == ["spin-table"]
+    assert cpu2.props["cpu-release-addr"].val == 0xa0000000
+    assert cpu2.props["status"].val == "disabled"
 
 def test_nexus():
     '''Test <prefix>-map via gpio-map (the most common case).'''

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -781,6 +781,16 @@ def test_cpu_props_fallback_from_cpus_node():
     # CPU-local value takes precedence.
     assert cpu1.props["clock-frequency"].val == 2000
 
+def test_cpus():
+    """Test that edt.cpus contains the /cpus/cpu@N nodes."""
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    cpu0 = edt.get_node("/cpus/cpu@0")
+    cpu1 = edt.get_node("/cpus/cpu@1")
+
+    assert edt.cpus == [cpu0, cpu1]
+
 def test_nexus():
     '''Test <prefix>-map via gpio-map (the most common case).'''
     with from_here():


### PR DESCRIPTION
After merging #112418 build errors began appearing due to certain boards being binding-less.

An alternative mechanism is implemented to check that a node has the name `cpu@<hex>`, where `<hex>` represents some CPU number is needed.