### PR TITLE
soc: espressif: run flash erase once for sysbuild images

### DIFF
--- a/soc/espressif/soc.yml
+++ b/soc/espressif/soc.yml
@@ -43,3 +43,33 @@ family:
       cpuclusters:
       - name: hpcore
       - name: lpcore
+runners:
+  run_once:
+    '--erase':
+    - runners:
+      - esp32
+      run: first
+      groups:
+      - qualifiers:
+        - esp32/procpu
+        - esp32/appcpu
+      - qualifiers:
+        - esp32s2
+      - qualifiers:
+        - esp32s3/procpu
+        - esp32s3/appcpu
+      - qualifiers:
+        - esp32c2
+      - qualifiers:
+        - esp32c3
+      - qualifiers:
+        - esp32c5/hpcore
+        - esp32c5/lpcore
+      - qualifiers:
+        - esp32c6/hpcore
+        - esp32c6/lpcore
+      - qualifiers:
+        - esp32h2
+      - qualifiers:
+        - esp32p4/hpcore
+        - esp32p4/lpcore


### PR DESCRIPTION
The esp32 runner implements the erase option as a full chip erase. Flashing a sysbuild build with west flash --erase wiped the previously programmed image before each new one, leaving the device unbootable. Mark the erase option as a run-once command so only the first image erases the chip.