### PR TITLE
toolchain: Add Pragma Unroll

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -353,6 +353,15 @@ do {                                                                    \
  * -wno-deprecated, which has implications for -Werror.
  */
 
+/**
+ * @brief Request the compiler to fully unroll a loop up to @p n iterations.
+ *
+ * @param n Maximum iteration count (must be a literal integer).
+ */
+#ifndef TOOLCHAIN_PRAGMA_UNROLL
+#define TOOLCHAIN_PRAGMA_UNROLL(n) _Pragma("GCC unroll " #n)
+#endif
+
 /*
  * Expands to nothing and generates a warning. Used like
  *

--- a/include/zephyr/toolchain/iar/iccarm.h
+++ b/include/zephyr/toolchain/iar/iccarm.h
@@ -226,6 +226,14 @@ do {                                                                    \
 #endif
 
 #define __PRAGMA(...) _Pragma(#__VA_ARGS__)
+
+/**
+ * @brief Request the compiler to fully unroll a loop up to @p n iterations.
+ *
+ * @param n Maximum iteration count (must be a literal integer).
+ */
+#define TOOLCHAIN_PRAGMA_UNROLL(n) __PRAGMA(unroll = n)
+
 #define ARG_UNUSED(x) (void)(x)
 
 #define likely(x)   (__builtin_expect((bool)!!(x), true) != 0L)

--- a/include/zephyr/toolchain/mwdt.h
+++ b/include/zephyr/toolchain/mwdt.h
@@ -132,6 +132,8 @@
 #define TOOLCHAIN_HAS_C_AUTO_TYPE               1
 
 #include <zephyr/toolchain/gcc.h>
+/* Synopsys MetaWare pragma unroll support is unknown. */
+#undef TOOLCHAIN_PRAGMA_UNROLL
 
 #undef BUILD_ASSERT
 #if defined(__cplusplus) && (__cplusplus >= 201103L)

--- a/include/zephyr/toolchain/xcc.h
+++ b/include/zephyr/toolchain/xcc.h
@@ -42,6 +42,8 @@
 #include <zephyr/toolchain/llvm.h>
 #else
 #include <zephyr/toolchain/gcc.h>
+/* Cadence/Tensilica XCC pragma unroll support is unknown. */
+#undef TOOLCHAIN_PRAGMA_UNROLL
 #endif
 
 #ifdef __clang__


### PR DESCRIPTION
This PR adds support for explicit loop unrolling. It is supported by GCC, Clang/LLVM, and IAR. This was discussed today in Architecture WG as a requirement for #106831/#110787 (which requires specific `nop` counts).

Clang uses the same syntax as GCC, and the GCC header is already included from the LLVM header. ARM Clang includes the LLVM header.

I was not certain how to handle Cadence XCC/Synopsys MetaWare since I do not have access to documentation for those compilers (or at least could not find it).

Assisted-by: Claude:claude-opus-4.8