### PR TITLE
net: ppp: accept PFC/ACFC compressed frames on receive

### DIFF
--- a/include/zephyr/modem/ppp.h
+++ b/include/zephyr/modem/ppp.h
@@ -49,6 +49,7 @@ enum modem_ppp_receive_state {
 	/* Searching for start of frame and header */
 	MODEM_PPP_RECEIVE_STATE_HDR_SOF = 0,
 	MODEM_PPP_RECEIVE_STATE_HDR_FF,
+	MODEM_PPP_RECEIVE_STATE_HDR_FF_UNESCAPE,
 	MODEM_PPP_RECEIVE_STATE_HDR_CTRL_UNESCAPE,
 	MODEM_PPP_RECEIVE_STATE_HDR_CTRL,
 	/* Writing bytes to network packet */

--- a/subsys/modem/modem_ppp.c
+++ b/subsys/modem/modem_ppp.c
@@ -205,6 +205,28 @@ static bool modem_ppp_is_byte_expected(uint8_t byte, uint8_t expected_byte)
 	return false;
 }
 
+static void modem_ppp_start_acfc_frame(struct modem_ppp *ppp, uint8_t byte)
+{
+	ppp->rx_pkt = net_pkt_rx_alloc_with_buffer(ppp->iface, CONFIG_MODEM_PPP_NET_BUF_FRAG_SIZE,
+						   NET_AF_UNSPEC, 0, K_NO_WAIT);
+	if (ppp->rx_pkt == NULL) {
+		LOG_WRN("Dropped frame, no net_pkt available");
+		ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_SOF;
+		return;
+	}
+
+	net_pkt_cursor_init(ppp->rx_pkt);
+	if (net_pkt_write_u8(ppp->rx_pkt, byte) < 0) {
+		net_pkt_unref(ppp->rx_pkt);
+		ppp->rx_pkt = NULL;
+		ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_SOF;
+		return;
+	}
+
+	LOG_DBG("Receiving ACFC PPP frame");
+	ppp->receive_state = MODEM_PPP_RECEIVE_STATE_WRITING;
+}
+
 static void modem_ppp_process_received_byte(struct modem_ppp *ppp, uint8_t byte)
 {
 	switch (ppp->receive_state) {
@@ -241,11 +263,30 @@ static void modem_ppp_process_received_byte(struct modem_ppp *ppp, uint8_t byte)
 			ppp->receive_offset = 1;
 			break;
 		}
-		if (modem_ppp_is_byte_expected(byte, 0xFF)) {
+		if (byte == 0xFF) {
 			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_CTRL;
-		} else {
-			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_SOF;
+			break;
 		}
+		if (byte == MODEM_PPP_CODE_ESCAPE) {
+			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_FF_UNESCAPE;
+			break;
+		}
+		modem_ppp_start_acfc_frame(ppp, byte);
+		break;
+
+	case MODEM_PPP_RECEIVE_STATE_HDR_FF_UNESCAPE:
+		if (byte == MODEM_PPP_CODE_DELIMITER) {
+			/* 7D 7E is an aborted frame, look for the next one */
+			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_FF;
+			break;
+		}
+		byte ^= MODEM_PPP_VALUE_ESCAPE;
+		if (byte == 0xFF) {
+			/* Escaped Address field, not an ACFC frame */
+			ppp->receive_state = MODEM_PPP_RECEIVE_STATE_HDR_CTRL;
+			break;
+		}
+		modem_ppp_start_acfc_frame(ppp, byte);
 		break;
 
 	case MODEM_PPP_RECEIVE_STATE_HDR_CTRL_UNESCAPE:

--- a/subsys/net/l2/ppp/ppp_l2.c
+++ b/subsys/net/l2/ppp/ppp_l2.c
@@ -77,15 +77,30 @@ static enum net_verdict process_ppp_msg(struct net_if *iface,
 	struct ppp_context *ctx = net_if_l2_data(iface);
 	enum net_verdict verdict = NET_DROP;
 	uint16_t protocol;
+	bool pfc = false;
+	uint8_t hi;
 	int ret;
 
 	if (!ctx->is_ready_to_serve) {
 		goto quit;
 	}
 
-	ret = net_pkt_read_be16(pkt, &protocol);
+	ret = net_pkt_read_u8(pkt, &hi);
 	if (ret < 0) {
 		goto quit;
+	}
+
+	if (hi & 0x01U) {
+		protocol = hi;
+		pfc = true;
+	} else {
+		uint8_t lo;
+
+		ret = net_pkt_read_u8(pkt, &lo);
+		if (ret < 0) {
+			goto quit;
+		}
+		protocol = ((uint16_t)hi << 8) | lo;
 	}
 
 	if ((IS_ENABLED(CONFIG_NET_IPV4) && protocol == PPP_IP) ||
@@ -93,7 +108,11 @@ static enum net_verdict process_ppp_msg(struct net_if *iface,
 		/* Remove the protocol field so that IP packet processing
 		 * continues properly in net_core.c:process_data()
 		 */
-		(void)net_buf_pull_be16(pkt->buffer);
+		if (pfc) {
+			(void)net_buf_pull_u8(pkt->buffer);
+		} else {
+			(void)net_buf_pull_be16(pkt->buffer);
+		}
 		net_pkt_cursor_init(pkt);
 		return NET_CONTINUE;
 	}

--- a/tests/net/ppp/driver/CMakeLists.txt
+++ b/tests/net/ppp/driver/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(iface)
 
-target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)
+target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip
+                                       ${ZEPHYR_BASE}/subsys/net/l2/ppp)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/ppp/driver/src/main.c
+++ b/tests/net/ppp/driver/src/main.c
@@ -30,6 +30,11 @@ LOG_MODULE_REGISTER(net_test, NET_LOG_LEVEL);
 
 #define NET_LOG_ENABLED 1
 #include "net_private.h"
+#if defined(CONFIG_NET_STATISTICS)
+#include "net_stats.h"
+#endif
+
+#include "ppp_internal.h"
 
 typedef enum net_verdict (*ppp_l2_callback_t)(struct net_if *iface,
 					      struct net_pkt *pkt);
@@ -537,6 +542,162 @@ static void test_send_ppp_8(void)
 		zassert_true(false, "Timeout, packet not received");
 	}
 }
+
+/* HDLC-wrap a frame: append the FCS, delimit with 0x7e and escape the body. */
+static size_t hdlc_wrap(uint8_t *out, const uint8_t *frame, size_t len)
+{
+	uint16_t fcs = crc16_ccitt(0xffff, frame, len) ^ 0xffff;
+	size_t pos = 0;
+
+	out[pos++] = 0x7e;
+	for (size_t i = 0; i < len + 2; i++) {
+		uint8_t b;
+
+		if (i < len) {
+			b = frame[i];
+		} else if (i == len) {
+			/* FCS is transmitted low octet first */
+			b = fcs & 0xff;
+		} else {
+			b = fcs >> 8;
+		}
+
+		if (b == 0x7e || b == 0x7d || b < 0x20) {
+			out[pos++] = 0x7d;
+			out[pos++] = b ^ 0x20;
+		} else {
+			out[pos++] = b;
+		}
+	}
+	out[pos++] = 0x7e;
+
+	return pos;
+}
+
+/* 0x0023 has the even-high/odd-low octets required of a PPP protocol number
+ * and PFC compresses it to the single octet 0x23.
+ */
+#define TEST_PFC_PROTOCOL 0x0023
+
+static struct k_sem proto_handler_sem;
+static uint8_t proto_handler_data[32];
+static size_t proto_handler_data_len;
+
+static void test_proto_init(struct ppp_context *ctx)
+{
+	ARG_UNUSED(ctx);
+}
+
+static enum net_verdict test_proto_handler(struct ppp_context *ctx, struct net_if *iface,
+					   struct net_pkt *pkt)
+{
+	size_t len = net_pkt_remaining_data(pkt);
+
+	ARG_UNUSED(ctx);
+	ARG_UNUSED(iface);
+
+	proto_handler_data_len = 0;
+	if (len <= sizeof(proto_handler_data) && net_pkt_read(pkt, proto_handler_data, len) == 0) {
+		proto_handler_data_len = len;
+	}
+
+	k_sem_give(&proto_handler_sem);
+
+	return NET_OK;
+}
+
+PPP_PROTOCOL_REGISTER(TEST_PFC, TEST_PFC_PROTOCOL, test_proto_init, test_proto_handler, NULL, NULL,
+		      NULL, NULL);
+
+static void pfc_iface_setup(void)
+{
+	net_iface = net_if_get_first_by_type(&NET_L2_GET_NAME(PPP));
+	zassert_not_null(net_iface, "PPP interface not found!");
+
+	/* Drive the real L2 receive path, not the HDLC-decode capture
+	 * callback.
+	 */
+	ppp_l2_register_pkt_cb(NULL);
+	net_if_up(net_iface);
+}
+
+ZTEST(net_ppp_test_suite, test_pfc_protocol_receive)
+{
+	/* Payload including bytes that need HDLC escaping */
+	static const uint8_t payload[] = {0x7e, 0x7d, 0x11, 0x00, 0x23, 0x45, 0xff, 0x03};
+	/* FF 03 | 23 | payload: PFC-compressed 1-octet protocol */
+	uint8_t compressed[3 + sizeof(payload)] = {0xff, 0x03, 0x23};
+	/* FF 03 | 00 23 | payload: full 2-octet protocol */
+	uint8_t uncompressed[4 + sizeof(payload)] = {0xff, 0x03, 0x00, 0x23};
+	uint8_t wire[2 * (sizeof(uncompressed) + 2) + 2];
+	size_t wire_len;
+
+	memcpy(&compressed[3], payload, sizeof(payload));
+	memcpy(&uncompressed[4], payload, sizeof(payload));
+
+	pfc_iface_setup();
+	k_sem_init(&proto_handler_sem, 0, 1);
+
+	/* A PFC-compressed frame must reach the protocol handler */
+	wire_len = hdlc_wrap(wire, compressed, sizeof(compressed));
+	ppp_driver_feed_data(wire, wire_len);
+
+	zassert_ok(k_sem_take(&proto_handler_sem, WAIT_TIME_LONG),
+		   "Timeout, PFC frame not received");
+	zassert_equal(proto_handler_data_len, sizeof(payload), "PFC payload length incorrect");
+	zassert_mem_equal(proto_handler_data, payload, sizeof(payload), "PFC payload incorrect");
+
+	/* The uncompressed form must decode to the same payload */
+	wire_len = hdlc_wrap(wire, uncompressed, sizeof(uncompressed));
+	ppp_driver_feed_data(wire, wire_len);
+
+	zassert_ok(k_sem_take(&proto_handler_sem, WAIT_TIME_LONG),
+		   "Timeout, uncompressed frame not received");
+	zassert_equal(proto_handler_data_len, sizeof(payload),
+		      "Uncompressed payload length incorrect");
+	zassert_mem_equal(proto_handler_data, payload, sizeof(payload),
+			  "Uncompressed payload incorrect");
+}
+
+#if defined(CONFIG_NET_STATISTICS) && defined(CONFIG_NET_STATISTICS_IPV4)
+ZTEST(net_ppp_test_suite, test_pfc_ip_frame_receive)
+{
+	/* IPv4/UDP packet; net_ipv4_input() counts it in ipv4.recv before any
+	 * further checks, which only happens if the compressed protocol octet
+	 * alone was removed and the packet still starts with the 0x45 version
+	 * nibble.
+	 */
+	static const uint8_t ip_packet[] = {
+		0x45, 0x00, 0x00, 0x29, 0x87, 0x6e, 0x40, 0x00, 0xe8, 0x11, 0xc1, 0xe9, 0x03, 0xfb,
+		0x05, 0x20, 0x0a, 0x2b, 0x36, 0x26, 0x25, 0x12, 0x8c, 0x3e, 0x00, 0x15, 0xbd, 0xf3,
+		0x2d, 0x00, 0x0b, 0x00, 0x07, 0x00, 0x04, 0x00, 0x04, 0x0a, 0x00, 0x0a, 0x00,
+	};
+	/* FF 03 | 21 | IPv4 packet: IP protocol 0x0021 PFC-compressed */
+	uint8_t frame[3 + sizeof(ip_packet)] = {0xff, 0x03, 0x21};
+	uint8_t wire[2 * (sizeof(frame) + 2) + 2];
+	uint32_t recv_before;
+	size_t wire_len;
+
+	memcpy(&frame[3], ip_packet, sizeof(ip_packet));
+
+	pfc_iface_setup();
+
+	recv_before = GET_STAT(net_iface, ipv4.recv);
+
+	wire_len = hdlc_wrap(wire, frame, sizeof(frame));
+	ppp_driver_feed_data(wire, wire_len);
+
+	for (int i = 0; i < 20; i++) {
+		if (GET_STAT(net_iface, ipv4.recv) != recv_before) {
+			break;
+		}
+		k_msleep(50);
+	}
+
+	zassert_equal(GET_STAT(net_iface, ipv4.recv), recv_before + 1,
+		      "PFC IP frame did not reach IPv4 processing");
+}
+#endif /* CONFIG_NET_STATISTICS && CONFIG_NET_STATISTICS_IPV4 */
 
 ZTEST(net_ppp_test_suite, test_net_ppp)
 {

--- a/tests/subsys/modem/modem_ppp/src/main.c
+++ b/tests/subsys/modem/modem_ppp/src/main.c
@@ -45,6 +45,15 @@ static uint8_t ppp_frame_wrapped[] = {0x7E, 0xFF, 0x7D, 0x23, 0xC0, 0x21, 0x7D, 
 
 static uint8_t ppp_frame_unwrapped[] = {0xC0, 0x21, 0x01, 0x01, 0x00, 0x04};
 
+/*
+ * Same frame as ppp_frame_wrapped but with the Address (0xFF) and Control
+ * (0x03) fields omitted (ACFC). The receiver must start the frame on the first
+ * non-0xFF byte and deliver the same payload. The LCP protocol (0xC0 0x21) is
+ * used because its first octet is not an HDLC-escaped value.
+ */
+static uint8_t ppp_frame_wrapped_acfc[] = {0x7E, 0xC0, 0x21, 0x7D, 0x21, 0x7D, 0x21,
+					   0x7D, 0x20, 0x7D, 0x24, 0xD1, 0xB5, 0x7E};
+
 /* Custom ACCM (Only 0-15 need to be escaped) */
 static uint32_t accm_custom1 = 0x0000ffff;
 static uint8_t ppp_frame_wrapped_accm1[] = {0x7E, 0xFF, 0x7D, 0x23, 0xC0, 0x21, 0x16, 0x7D,
@@ -74,6 +83,31 @@ static uint8_t ip_frame_unwrapped_with_protocol[] = {
 	0xFB, 0x05, 0x20, 0x0A, 0x2B, 0x36, 0x26, 0x25, 0x12, 0x8C, 0x3E, 0x00, 0x15, 0xBD, 0xF3,
 	0x2D, 0x00, 0x0B, 0x00, 0x07, 0x00, 0x04, 0x00, 0x04, 0x0A, 0x00, 0x0A, 0x00};
 
+/*
+ * Same IP frame as ip_frame_wrapped but with the FF 03 Address/Control header
+ * omitted (ACFC). The 2-octet IP protocol 0x0021 keeps its high octet 0x00,
+ * which HDLC escapes to 0x7D 0x20, so the receiver must unescape the first
+ * protocol octet when it starts the frame.
+ */
+static uint8_t ip_frame_wrapped_acfc[] = {
+	0x7E, 0x7D, 0x20, 0x21, 0x45, 0x7D, 0x20, 0x7D, 0x20, 0x29, 0x87, 0x6E, 0x40, 0x7D,
+	0x20, 0xE8, 0x7D, 0x31, 0xC1, 0xE9, 0x7D, 0x23, 0xFB, 0x7D, 0x25, 0x20, 0x7D, 0x2A,
+	0x2B, 0x36, 0x26, 0x25, 0x7D, 0x32, 0x8C, 0x3E, 0x7D, 0x20, 0x7D, 0x35, 0xBD, 0xF3,
+	0x2D, 0x7D, 0x20, 0x7D, 0x2B, 0x7D, 0x20, 0x7D, 0x27, 0x7D, 0x20, 0x7D, 0x24, 0x7D,
+	0x20, 0x7D, 0x24, 0x7D, 0x2A, 0x7D, 0x20, 0x7D, 0x2A, 0x7D, 0x20, 0xD4, 0x31, 0x7E};
+
+/*
+ * Same IP frame with both ACFC and PFC applied, as the Neoway N717 sends
+ * IP data once ACFC is negotiated: no FF 03 header and the protocol
+ * compressed to the single octet 0x21.
+ */
+static uint8_t ip_frame_wrapped_pfc_acfc[] = {
+	0x7E, 0x21, 0x45, 0x7D, 0x20, 0x7D, 0x20, 0x29, 0x87, 0x6E, 0x40, 0x7D, 0x20, 0xE8,
+	0x7D, 0x31, 0xC1, 0xE9, 0x7D, 0x23, 0xFB, 0x7D, 0x25, 0x20, 0x7D, 0x2A, 0x2B, 0x36,
+	0x26, 0x25, 0x7D, 0x32, 0x8C, 0x3E, 0x7D, 0x20, 0x7D, 0x35, 0xBD, 0xF3, 0x2D, 0x7D,
+	0x20, 0x7D, 0x2B, 0x7D, 0x20, 0x7D, 0x27, 0x7D, 0x20, 0x7D, 0x24, 0x7D, 0x20, 0x7D,
+	0x24, 0x7D, 0x2A, 0x7D, 0x20, 0x7D, 0x2A, 0x7D, 0x20, 0xD4, 0x31, 0x7E};
+
 static uint8_t corrupt_start_end_ppp_frame_wrapped[] = {0x2A, 0x46, 0x7E, 0x7E, 0xFF, 0x7D, 0x23,
 							0xC0, 0x21, 0x7D, 0x21, 0x7D, 0x21, 0x7D,
 							0x20, 0x7D, 0x24, 0xD1, 0xB5, 0x7E};
@@ -90,6 +124,8 @@ static uint8_t wrapped_buffer[4096];
 /*************************************************************************************************/
 /*                                  Mock network interface                                       */
 /*************************************************************************************************/
+static K_SEM_DEFINE(rx_pkt_sem, 0, K_SEM_MAX_LIMIT);
+
 static enum net_verdict test_net_l2_recv(struct net_if *iface, struct net_pkt *pkt)
 {
 	/* Validate buffer not overflowing */
@@ -99,6 +135,7 @@ static enum net_verdict test_net_l2_recv(struct net_if *iface, struct net_pkt *p
 	/* Store pointer to received packet */
 	received_packets[received_packets_len] = pkt;
 	received_packets_len++;
+	k_sem_give(&rx_pkt_sem);
 	return NET_OK;
 }
 
@@ -309,6 +346,7 @@ static void test_modem_ppp_before(void *f)
 
 	/* Reset packets received buffer */
 	received_packets_len = 0;
+	k_sem_reset(&rx_pkt_sem);
 
 	/* Reset mock pipe */
 	modem_backend_mock_reset(&mock);
@@ -420,6 +458,91 @@ ZTEST(modem_ppp, test_corrupt_start_end_ppp_frame_receive)
 	net_pkt_cursor_init(pkt);
 	net_pkt_read(pkt, buffer, pkt_len);
 	zassert_true(memcmp(buffer, ppp_frame_unwrapped, pkt_len) == 0,
+		     "Received net pkt data incorrect");
+}
+
+ZTEST(modem_ppp, test_acfc_ppp_frame_receive)
+{
+	struct net_pkt *pkt;
+	size_t pkt_len;
+
+	/* Frame with the FF 03 Address/Control header omitted (ACFC) */
+	modem_backend_mock_put(&mock, ppp_frame_wrapped_acfc, sizeof(ppp_frame_wrapped_acfc));
+
+	/* Wait for the frame to be processed and delivered */
+	zassert_ok(k_sem_take(&rx_pkt_sem, K_SECONDS(1)), "Timeout waiting for received frame");
+
+	/* Validate frame received on mock network interface */
+	zassert_true(received_packets_len == 1, "Expected to receive one network packet");
+
+	pkt = received_packets[0];
+	pkt_len = net_pkt_get_len(pkt);
+
+	/* An ACFC frame must decode to the same payload as the FF 03 form */
+	zassert_true(pkt_len == sizeof(ppp_frame_unwrapped), "Received net pkt data len incorrect");
+
+	net_pkt_cursor_init(pkt);
+	net_pkt_read(pkt, buffer, pkt_len);
+	zassert_true(memcmp(buffer, ppp_frame_unwrapped, pkt_len) == 0,
+		     "Received net pkt data incorrect");
+}
+
+/*
+ * Pure ACFC for IP: the frame omits FF 03 and carries the full 2-octet IP
+ * protocol 0x0021, whose high octet 0x00 is HDLC-escaped (0x7D 0x20), so the
+ * first protocol octet must be unescaped when the frame starts.
+ */
+ZTEST(modem_ppp, test_acfc_ip_frame_receive)
+{
+	struct net_pkt *pkt;
+	size_t pkt_len;
+
+	/* IP frame with the FF 03 header omitted (ACFC), 2-octet protocol */
+	modem_backend_mock_put(&mock, ip_frame_wrapped_acfc, sizeof(ip_frame_wrapped_acfc));
+
+	/* Wait for the frame to be processed and delivered */
+	zassert_ok(k_sem_take(&rx_pkt_sem, K_SECONDS(1)), "Timeout waiting for received frame");
+
+	/* Validate frame received on mock network interface */
+	zassert_true(received_packets_len == 1, "Expected to receive one network packet");
+
+	pkt = received_packets[0];
+	pkt_len = net_pkt_get_len(pkt);
+
+	/* Must decode to the same payload as the FF 03 form, including protocol */
+	zassert_true(pkt_len == sizeof(ip_frame_unwrapped_with_protocol),
+		     "Received net pkt data len incorrect");
+
+	net_pkt_cursor_init(pkt);
+	net_pkt_read(pkt, buffer, pkt_len);
+	zassert_true(memcmp(buffer, ip_frame_unwrapped_with_protocol, pkt_len) == 0,
+		     "Received net pkt data incorrect");
+}
+
+ZTEST(modem_ppp, test_pfc_acfc_ip_frame_receive)
+{
+	struct net_pkt *pkt;
+	size_t pkt_len;
+
+	/* IP frame with no FF 03 header and a 1-octet protocol (PFC + ACFC) */
+	modem_backend_mock_put(&mock, ip_frame_wrapped_pfc_acfc, sizeof(ip_frame_wrapped_pfc_acfc));
+
+	/* Wait for the frame to be processed and delivered */
+	zassert_ok(k_sem_take(&rx_pkt_sem, K_SECONDS(1)), "Timeout waiting for received frame");
+
+	/* Validate frame received on mock network interface */
+	zassert_true(received_packets_len == 1, "Expected to receive one network packet");
+
+	pkt = received_packets[0];
+	pkt_len = net_pkt_get_len(pkt);
+
+	/* Must decode to the compressed 1-octet protocol followed by the IP packet */
+	zassert_true(pkt_len == sizeof(ip_frame_unwrapped_with_protocol) - 1,
+		     "Received net pkt data len incorrect");
+
+	net_pkt_cursor_init(pkt);
+	net_pkt_read(pkt, buffer, pkt_len);
+	zassert_true(memcmp(buffer, &ip_frame_unwrapped_with_protocol[1], pkt_len) == 0,
 		     "Received net pkt data incorrect");
 }
 

--- a/tests/subsys/modem/modem_ppp/src/main.c
+++ b/tests/subsys/modem/modem_ppp/src/main.c
@@ -367,8 +367,8 @@ static void put_and_validate_wrapped_frame(void)
 	/* Put wrapped frame */
 	modem_backend_mock_put(&mock, ppp_frame_wrapped, sizeof(ppp_frame_wrapped));
 
-	/* Give modem ppp time to process received frame */
-	k_msleep(1000);
+	/* Wait for the frame to be processed and delivered */
+	zassert_ok(k_sem_take(&rx_pkt_sem, K_SECONDS(1)), "Timeout waiting for received frame");
 
 	/* Validate frame received on mock network interface */
 	zassert_true(received_packets_len == 1, "Expected to receive one network packet");
@@ -443,8 +443,8 @@ ZTEST(modem_ppp, test_corrupt_start_end_ppp_frame_receive)
 	modem_backend_mock_put(&mock, corrupt_start_end_ppp_frame_wrapped,
 			       sizeof(corrupt_start_end_ppp_frame_wrapped));
 
-	/* Give modem ppp time to process received frame */
-	k_msleep(1000);
+	/* Wait for the frame to be processed and delivered */
+	zassert_ok(k_sem_take(&rx_pkt_sem, K_SECONDS(1)), "Timeout waiting for received frame");
 
 	/* Validate frame received on mock network interface */
 	zassert_true(received_packets_len == 1, "Expected to receive one network packet");
@@ -645,8 +645,8 @@ ZTEST(modem_ppp, test_ip_frame_receive)
 	/* Put wrapped frame */
 	modem_backend_mock_put(&mock, ip_frame_wrapped, sizeof(ip_frame_wrapped));
 
-	/* Give modem ppp time to process received frame */
-	k_msleep(1000);
+	/* Wait for the frame to be processed and delivered */
+	zassert_ok(k_sem_take(&rx_pkt_sem, K_SECONDS(1)), "Timeout waiting for received frame");
 
 	/* Validate frame received on mock network interface */
 	zassert_true(received_packets_len == 1, "Expected to receive one network packet");
@@ -763,7 +763,9 @@ ZTEST(modem_ppp, test_ip_frame_receive_large)
 	zassert_true(size > TEST_MODEM_PPP_IP_FRAME_RECEIVE_LARGE_N, "Failed to wrap data");
 	modem_backend_mock_put(&mock, wrapped_buffer, size);
 
-	k_msleep(TEST_MODEM_PPP_IP_FRAME_RECEIVE_LARGE_N * 2);
+	/* Wait for the frame to be processed and delivered */
+	zassert_ok(k_sem_take(&rx_pkt_sem, K_MSEC(TEST_MODEM_PPP_IP_FRAME_RECEIVE_LARGE_N * 2)),
+		   "Timeout waiting for received frame");
 
 	zassert_true(received_packets_len == 1, "Expected to receive one network packet");
 	pkt = received_packets[0];


### PR DESCRIPTION
Some cellular modems apply PPP header compression without negotiating
it. A usbmon capture of the Neoway N717 shows it PFC-compressing IP
data frames (FF 03 21 45 ...) even after pppd explicitly rejected the
option. LCP and IPCP are exchanged in the full form, so against Zephyr
the link negotiates fine, but every data frame is then dropped: ppp_l2
reads a two-octet protocol field and takes 21 45 for protocol 0x2145.
Linux pppd accepts such frames regardless of what was negotiated.

This adds receive support for both compressed forms, accepted
unconditionally:

 - ppp_l2: an odd first protocol octet is a PFC-compressed single-octet
   protocol (PPP protocol numbers always have bit 0 of the high octet
   clear), so pull one byte instead of two.
 - modem_ppp: a non-0xFF byte in the HDR_FF state means the frame omits
   the FF 03 header (ACFC); start the frame with that byte as the first
   protocol octet, unescaping it first when needed (the 0x00 high octet
   of the IP protocol 0x0021 arrives on the wire as 7D 20).

RFC 1661 only requires accepting the compressed forms once the option
has been negotiated. Accepting them always is still safe, since both
encodings stay unambiguous, and matches pppd. The receive parser is a
superset of the current one, so anything accepted today still is.
Transmit is unchanged and keeps sending the uncompressed forms.

New tests cover an ACFC frame with an escaped and an unescaped first
protocol octet, the combined PFC+ACFC form, and, on the ppp_l2 side,
that the compressed and full protocol fields decode to the same
payload and that a PFC-compressed IP frame reaches IPv4 processing.

Tested on native_sim (modem.modem_ppp) and qemu_x86 (net.ppp,
net.ppp.statistics); verified against a live N717, which brings the
link up and carries IP traffic with its unilaterally PFC-compressed
frames.