### PR TITLE
soc: nxp: rw: re-power TDDR PLL when enabling Ethernet after MCUboot

### DIFF
--- a/soc/nxp/rw/soc.c
+++ b/soc/nxp/rw/soc.c
@@ -310,6 +310,10 @@ __weak __ramfunc void clock_init(void)
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(enet)) && CONFIG_NET_L2_ETHERNET && CONFIG_ETH_DRIVER
+	/* Re-assert TDDR_PDB: MCUboot may have cleared it
+	 * via CLOCK_DeinitTddrRefClk() in soc_early_init_hook()
+	 */
+	SYSCTL2->PLL_CTRL |= SYSCTL2_PLL_CTRL_TDDR_PDB_MASK;
 	RESET_PeripheralReset(kENET_IPG_RST_SHIFT_RSTn);
 	RESET_PeripheralReset(kENET_IPG_S_RST_SHIFT_RSTn);
 #else


### PR DESCRIPTION
MCUboot's soc_early_init_hook() calls CLOCK_DeinitTddrRefClk() even when not using Ethernet, which clears the TDDR_PDB bit and powers down the TDDR PLL. When the application later boots and re-initializes Ethernet, the NXP SDK's clock enable functions re-enable the peripheral clock outputs but never re-set the PLL power-down-bypass bit.

Add an explicit write of the TDDR_PDB bit to PLL_CTRL before resetting the ENET peripherals. This is a no-op on cold boot since the bit is already set, but fixes Ethernet after any scenario where CLOCK_DeinitTddrRefClk() was called (sysbuild).

Fixes: zephyrproject-rtos/zephyr#108399