### PR TITLE
drivers: ethernet: ptp: introduce snps,dwmac-ptp-clock binding

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -145,6 +145,7 @@ menuconfig PTP_CLOCK_STM32_HAL
 	default y
 	depends on PTP_CLOCK
 	select NET_L2_PTP_TIMESTAMPING
+	depends on DT_HAS_SNPS_DWMAC_PTP_CLOCK_ENABLED
 	depends on ETH_STM32_HAL_API_V2
 	depends on SOC_SERIES_STM32F7X \
 		   || SOC_SERIES_STM32H5X \
@@ -174,14 +175,6 @@ config ETH_STM32_HAL_PTP_CLOCK_ADJ_MAX_PCT
 	default 110
 	help
 	  Specifies upper bound of PTP clock rate adjustment.
-
-config ETH_STM32_HAL_PTP_CLOCK_INIT_PRIO
-	int
-	default 85
-	help
-	  STM32 PTP Clock initialization priority level. There is
-	  a dependency from the network stack that this device
-	  initializes before network stack (NET_INIT_PRIO).
 
 endif # PTP_CLOCK_STM32_HAL
 

--- a/drivers/ethernet/eth_stm32_hal_ptp.c
+++ b/drivers/ethernet/eth_stm32_hal_ptp.c
@@ -16,7 +16,7 @@
 
 #include "eth_stm32_hal_priv.h"
 
-#define DT_DRV_COMPAT st_stm32_ethernet
+#define DT_DRV_COMPAT snps_dwmac_ptp_clock
 
 LOG_MODULE_REGISTER(eth_stm32_hal_ptp, CONFIG_ETHERNET_LOG_LEVEL);
 
@@ -58,17 +58,11 @@ const struct device *eth_stm32_get_ptp_clock(const struct device *dev,
 	return dev_data->ptp_clock;
 }
 
-struct ptp_context {
-	struct eth_stm32_hal_dev_data *eth_dev_data;
-};
-
-static struct ptp_context ptp_stm32_0_context;
-
 static int ptp_clock_stm32_set(const struct device *dev,
 			      struct net_ptp_time *tm)
 {
-	struct ptp_context *ptp_context = dev->data;
-	struct eth_stm32_hal_dev_data *eth_dev_data = ptp_context->eth_dev_data;
+	const struct device *eth_dev = dev->config;
+	struct eth_stm32_hal_dev_data *eth_dev_data = eth_dev->data;
 	ETH_HandleTypeDef *heth = &eth_dev_data->heth;
 	unsigned int key;
 
@@ -98,8 +92,8 @@ static int ptp_clock_stm32_set(const struct device *dev,
 static int ptp_clock_stm32_get(const struct device *dev,
 			      struct net_ptp_time *tm)
 {
-	struct ptp_context *ptp_context = dev->data;
-	struct eth_stm32_hal_dev_data *eth_dev_data = ptp_context->eth_dev_data;
+	const struct device *eth_dev = dev->config;
+	struct eth_stm32_hal_dev_data *eth_dev_data = eth_dev->data;
 	ETH_HandleTypeDef *heth = &eth_dev_data->heth;
 	unsigned int key;
 	uint32_t second_2;
@@ -131,8 +125,8 @@ static int ptp_clock_stm32_get(const struct device *dev,
 
 static int ptp_clock_stm32_adjust(const struct device *dev, int increment)
 {
-	struct ptp_context *ptp_context = dev->data;
-	struct eth_stm32_hal_dev_data *eth_dev_data = ptp_context->eth_dev_data;
+	const struct device *eth_dev = dev->config;
+	struct eth_stm32_hal_dev_data *eth_dev_data = eth_dev->data;
 	ETH_HandleTypeDef *heth = &eth_dev_data->heth;
 	int key, ret;
 
@@ -175,8 +169,8 @@ static int ptp_clock_stm32_adjust(const struct device *dev, int increment)
 
 static int ptp_clock_stm32_rate_adjust(const struct device *dev, double ratio)
 {
-	struct ptp_context *ptp_context = dev->data;
-	struct eth_stm32_hal_dev_data *eth_dev_data = ptp_context->eth_dev_data;
+	const struct device *eth_dev = dev->config;
+	struct eth_stm32_hal_dev_data *eth_dev_data = eth_dev->data;
 	ETH_HandleTypeDef *heth = &eth_dev_data->heth;
 	int key, ret;
 	uint32_t addend_val;
@@ -294,20 +288,18 @@ BUILD_ASSERT(NSEC_PER_SEC % CONFIG_ETH_STM32_HAL_PTP_CLOCK_SRC_HZ == 0,
 BUILD_ASSERT(NSEC_PER_SEC / CONFIG_ETH_STM32_HAL_PTP_CLOCK_SRC_HZ <= UINT8_MAX,
 	     "PTP clock period is more than 255 nanoseconds");
 
-static int ptp_stm32_init(const struct device *port)
+static int ptp_stm32_init(const struct device *dev)
 {
-	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(mac));
-	struct eth_stm32_hal_dev_data *eth_dev_data = dev->data;
-	const struct eth_stm32_hal_dev_cfg *eth_cfg = dev->config;
-	struct ptp_context *ptp_context = port->data;
+	const struct device *const eth_dev = dev->config;
+	struct eth_stm32_hal_dev_data *eth_dev_data = eth_dev->data;
+	const struct eth_stm32_hal_dev_cfg *eth_cfg = eth_dev->config;
 	ETH_HandleTypeDef *heth = &eth_dev_data->heth;
 	int ret;
 	uint32_t ptp_clk_rate;
 	uint32_t ss_incr_ns = NSEC_PER_SEC / CONFIG_ETH_STM32_HAL_PTP_CLOCK_SRC_HZ;
 	uint32_t addend_val;
 
-	eth_dev_data->ptp_clock = port;
-	ptp_context->eth_dev_data = eth_dev_data;
+	eth_dev_data->ptp_clock = dev;
 
 	eth_stm32_ptp_enable_timestamping(heth);
 
@@ -354,6 +346,8 @@ static int ptp_stm32_init(const struct device *port)
 	return 0;
 }
 
-DEVICE_DEFINE(stm32_ptp_clock_0, PTP_CLOCK_NAME, ptp_stm32_init,
-		NULL, &ptp_stm32_0_context, NULL, POST_KERNEL,
-		CONFIG_ETH_STM32_HAL_PTP_CLOCK_INIT_PRIO, &api);
+#define PTP_CLOCK_STM32_INIT(n)                                                                    \
+	DEVICE_DT_INST_DEFINE(n, ptp_stm32_init, NULL, NULL, DEVICE_DT_GET(DT_INST_PARENT(n)),     \
+			      POST_KERNEL, CONFIG_PTP_CLOCK_INIT_PRIORITY, &api);
+
+DT_INST_FOREACH_STATUS_OKAY(PTP_CLOCK_STM32_INIT)

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -194,6 +194,10 @@
 				#size-cells = <0>;
 				status = "disabled";
 			};
+
+			ptp_clock: ptp-clock {
+				compatible = "snps,dwmac-ptp-clock";
+			};
 		};
 
 		exti: interrupt-controller@44022000 {

--- a/dts/arm/st/f1/stm32f107.dtsi
+++ b/dts/arm/st/f1/stm32f107.dtsi
@@ -35,6 +35,10 @@
 				#size-cells = <0>;
 				status = "disabled";
 			};
+
+			ptp_clock: ptp-clock {
+				compatible = "snps,dwmac-ptp-clock";
+			};
 		};
 	};
 };

--- a/dts/arm/st/f2/stm32f207.dtsi
+++ b/dts/arm/st/f2/stm32f207.dtsi
@@ -27,6 +27,10 @@
 				#size-cells = <0>;
 				status = "disabled";
 			};
+
+			ptp_clock: ptp-clock {
+				compatible = "snps,dwmac-ptp-clock";
+			};
 		};
 
 		can1: can@40006400 {

--- a/dts/arm/st/f4/stm32f407.dtsi
+++ b/dts/arm/st/f4/stm32f407.dtsi
@@ -27,6 +27,10 @@
 				#size-cells = <0>;
 				status = "disabled";
 			};
+
+			ptp_clock: ptp-clock {
+				compatible = "snps,dwmac-ptp-clock";
+			};
 		};
 	};
 };

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -93,6 +93,10 @@
 				#size-cells = <0>;
 				status = "disabled";
 			};
+
+			ptp_clock: ptp-clock {
+				compatible = "snps,dwmac-ptp-clock";
+			};
 		};
 	};
 

--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -138,6 +138,10 @@
 				#size-cells = <0>;
 				status = "disabled";
 			};
+
+			ptp_clock: ptp-clock {
+				compatible = "snps,dwmac-ptp-clock";
+			};
 		};
 
 		sdmmc2: sdmmc@40011c00 {

--- a/dts/arm/st/h5/stm32h563.dtsi
+++ b/dts/arm/st/h5/stm32h563.dtsi
@@ -38,6 +38,10 @@
 				#size-cells = <0>;
 				status = "disabled";
 			};
+
+			ptp_clock: ptp-clock {
+				compatible = "snps,dwmac-ptp-clock";
+			};
 		};
 
 		fdcan2: can@4000a800 {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1245,6 +1245,10 @@
 				#size-cells = <0>;
 				status = "disabled";
 			};
+
+			ptp_clock: ptp-clock {
+				compatible = "snps,dwmac-ptp-clock";
+			};
 		};
 
 		fmc: memory-controller@52004000 {

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1017,6 +1017,10 @@
 				#size-cells = <0>;
 				status = "disabled";
 			};
+
+			ptp_clock: ptp-clock {
+				compatible = "snps,dwmac-ptp-clock";
+			};
 		};
 
 		usbotg_fs: usb@40080000 {

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -345,6 +345,10 @@
 				#size-cells = <0>;
 				status = "disabled";
 			};
+
+			ptp_clock0: ptp-clock {
+				compatible = "snps,dwmac-ptp-clock";
+			};
 		};
 
 		crc: crc1: crc@58009000 {

--- a/dts/arm/st/mp13/stm32mp133.dtsi
+++ b/dts/arm/st/mp13/stm32mp133.dtsi
@@ -30,6 +30,10 @@
 				#size-cells = <0>;
 				status = "disabled";
 			};
+
+			ptp_clock1: ptp-clock {
+				compatible = "snps,dwmac-ptp-clock";
+			};
 		};
 	};
 };

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -958,6 +958,10 @@
 					#size-cells = <0>;
 					status = "disabled";
 				};
+
+				ptp_clock: ptp-clock {
+					compatible = "snps,dwmac-ptp-clock";
+				};
 			};
 
 			sdmmc1: sdmmc@58027000 {

--- a/dts/bindings/ethernet/snps,dwmac-ptp-clock.yaml
+++ b/dts/bindings/ethernet/snps,dwmac-ptp-clock.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+description: Synopsys DesignWare MAC PTP (Precision Time Protocol) Clock
+
+compatible: "snps,dwmac-ptp-clock"
+
+include: ["base.yaml"]


### PR DESCRIPTION
add snps,dwmac-ptp-clock binding for the ptp clock and use it for the stm32. This is a prep for adding ptp support for the generic dwc_mac driver.