### PR TITLE
drivers: wifi: nxp: bring up SDIO Wi-Fi module on i.MX93 AArch64 (nitrogen93_smarc)

### DIFF
--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -67,6 +67,7 @@ struct usdhc_config {
 	uint8_t nusdhc;
 	const struct gpio_dt_spec pwr_gpio;
 	const struct gpio_dt_spec detect_gpio;
+	bool non_removable;
 	bool detect_dat3;
 	bool detect_cd;
 	bool no_180_vol;
@@ -967,6 +968,8 @@ static int imx_usdhc_get_card_present(const struct device *dev)
 		data->card_present = USDHC_DetectCardInsert(base);
 	} else if (cfg->detect_gpio.port) {
 		data->card_present = gpio_pin_get_dt(&cfg->detect_gpio) > 0;
+	} else if (cfg->non_removable) {
+		data->card_present = true;
 	} else {
 		LOG_WRN("No card detection method configured, assuming card "
 			"is present");
@@ -1167,6 +1170,8 @@ static int imx_usdhc_init(const struct device *dev)
 		if (ret) {
 			return ret;
 		}
+	} else if (cfg->non_removable) {
+		LOG_INF("No power control GPIO defined for non-removable SDIO device");
 	} else {
 		LOG_WRN("No power control GPIO defined. Without power control,\n"
 			"the SD card may fail to communicate with the host");
@@ -1251,6 +1256,7 @@ static DEVICE_API(sdhc, usdhc_api) = {
 		.nusdhc = n,                                                                       \
 		.pwr_gpio = GPIO_DT_SPEC_INST_GET_OR(n, pwr_gpios, {0}),                           \
 		.detect_gpio = GPIO_DT_SPEC_INST_GET_OR(n, cd_gpios, {0}),                         \
+		.non_removable = DT_INST_PROP_OR(n, non_removable, false),                         \
 		.data_timeout = DT_INST_PROP(n, data_timeout),                                     \
 		.detect_dat3 = DT_INST_PROP(n, detect_dat3),                                       \
 		.detect_cd = DT_INST_PROP(n, detect_cd),                                           \

--- a/drivers/wifi/nxp/src/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/src/nxp_wifi_drv.c
@@ -412,11 +412,15 @@ int nxp_wifi_wlan_event_callback(enum wlan_event_reason reason, void *data)
 static int nxp_wifi_cpu_reset(uint8_t enable)
 {
 	int err = 0;
-#if DT_NODE_HAS_PROP(DT_DRV_INST(0), sd_gpios) &&    \
-	DT_NODE_HAS_PROP(DT_DRV_INST(0), pwr_gpios)
+#if DT_NODE_HAS_PROP(DT_DRV_INST(0), sd_gpios)
+	const int reset_assert_ms = 100;
+	const int reset_release_ms = 300;
 
 	struct gpio_dt_spec sdio_reset = GPIO_DT_SPEC_GET(DT_DRV_INST(0), sd_gpios);
+
+#if DT_NODE_HAS_PROP(DT_DRV_INST(0), pwr_gpios)
 	struct gpio_dt_spec pwr_gpios = GPIO_DT_SPEC_GET(DT_DRV_INST(0), pwr_gpios);
+#endif
 
 #if DT_NODE_HAS_PROP(DT_DRV_INST(0), ext1_pwren_gpios)
 	struct gpio_dt_spec ext1_pwren = GPIO_DT_SPEC_GET(DT_DRV_INST(0), ext1_pwren_gpios);
@@ -459,57 +463,69 @@ static int nxp_wifi_cpu_reset(uint8_t enable)
 		return -EIO;
 	}
 
-	/* Configure sdio_reset as output  */
-	err = gpio_pin_configure_dt(&sdio_reset, GPIO_OUTPUT);
+	err = gpio_pin_configure_dt(&sdio_reset, GPIO_OUTPUT_INACTIVE);
 	if (err) {
 		LOG_ERR("Error %d: failed to configure sdio_reset %s pin %d", err,
 				sdio_reset.port->name, sdio_reset.pin);
 		return err;
 	}
 
+#if DT_NODE_HAS_PROP(DT_DRV_INST(0), pwr_gpios)
 	if (!gpio_is_ready_dt(&pwr_gpios)) {
 		LOG_ERR("Error: failed to configure pwr_gpios %s pin %d", pwr_gpios.port->name,
 				pwr_gpios.pin);
 		return -EIO;
 	}
 
-	/* Configure wlan-power-io as an output  */
-	err = gpio_pin_configure_dt(&pwr_gpios, GPIO_OUTPUT);
+	err = gpio_pin_configure_dt(&pwr_gpios, GPIO_OUTPUT_INACTIVE);
 	if (err) {
 		LOG_ERR("Error %d: failed to configure pwr_gpios %s pin %d", err,
 				pwr_gpios.port->name, pwr_gpios.pin);
 		return err;
 	}
+#endif
 
 	if (enable) {
-		/* Set SDIO reset pin as high  */
+		/* Assert reset first. For GPIO_ACTIVE_LOW this drives the line low. */
 		err = gpio_pin_set_dt(&sdio_reset, 1);
 		if (err) {
 			return err;
 		}
-		/* wait for reset done */
-		k_sleep(K_MSEC(100));
+		k_sleep(K_MSEC(reset_assert_ms));
 
-		/* Set power gpio pin as high  */
-		err = gpio_pin_set_dt(&pwr_gpios, 1);
-		if (err) {
-			return err;
-		}
-	} else {
-		/* Set SDIO reset pin as low */
+		/* Release reset. For GPIO_ACTIVE_LOW this drives the line high. */
 		err = gpio_pin_set_dt(&sdio_reset, 0);
 		if (err) {
 			return err;
 		}
 
-		/* Set power gpio pin as low */
+#if DT_NODE_HAS_PROP(DT_DRV_INST(0), pwr_gpios)
+		/* Set power gpio pin as active  */
+		err = gpio_pin_set_dt(&pwr_gpios, 1);
+		if (err) {
+			return err;
+		}
+#endif
+
+		/* Hold time after reset release before first SDIO command. */
+		k_sleep(K_MSEC(reset_release_ms));
+	} else {
+		/* Keep module in reset when disabled. */
+		err = gpio_pin_set_dt(&sdio_reset, 1);
+		if (err) {
+			return err;
+		}
+
+#if DT_NODE_HAS_PROP(DT_DRV_INST(0), pwr_gpios)
+		/* Set power gpio pin as inactive */
 		err = gpio_pin_set_dt(&pwr_gpios, 0);
 		if (err) {
 			return err;
 		}
+#endif
+
+		k_sleep(K_MSEC(reset_assert_ms));
 	}
-	/* wait for reset done */
-	k_sleep(K_MSEC(100));
 #endif
 
 	return err;

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -561,6 +561,19 @@
 		status = "disabled";
 	};
 
+	usdhc3: usdhc@428b0000 {
+		compatible = "nxp,imx-usdhc";
+		reg = <0x428b0000 0x10000>;
+		interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_USDHC3_CLK 0 0>;
+		max-current-330 = <1020>;
+		max-current-180 = <1020>;
+		max-bus-freq = <208000000>;
+		min-bus-freq = <400000>;
+		status = "disabled";
+	};
+
 	enet: enet@42890000 {
 		compatible = "nxp,enet";
 		reg = <0x42890000 DT_SIZE_K(64)>;

--- a/dts/bindings/sdhc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/sdhc/nxp,imx-usdhc.yaml
@@ -96,3 +96,10 @@ properties:
       Use the host's internal card detect signal (USDHC_CD) to detect the SD
       card. This signal is available as an alternative to card detect via GPIO,
       and should be connected to the SD slot's detect pin if used.
+
+  non-removable:
+    type: boolean
+    description: |
+      Indicates a non-removable device such as an SDIO Wi-Fi module.
+      When set, the host treats the device as always present and skips
+      removable card detection.

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/CMakeLists.txt
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/CMakeLists.txt
@@ -7,10 +7,10 @@ include(basic.cmake)
 # Use optimized memory functions, which have better performance,
 # also will avoid issues with unaligned access to peripheral RAM regions
 # caused by the memcpy implementation in newlib
-if(CONFIG_MCUX_OPTIMIZED_MEMCPY)
+if(CONFIG_MCUX_OPTIMIZED_MEMCPY AND NOT CONFIG_ARM64)
   zephyr_library_sources(${ZEPHYR_CURRENT_MODULE_DIR}/mcux/mcux-sdk-ng/components/misc_utilities/fsl_memcpy.S)
 endif()
-if(CONFIG_MCUX_OPTIMIZED_MEMSET)
+if(CONFIG_MCUX_OPTIMIZED_MEMSET AND NOT CONFIG_ARM64)
   zephyr_library_sources(${ZEPHYR_CURRENT_MODULE_DIR}/mcux/mcux-sdk-ng/components/misc_utilities/fsl_memset.S)
 endif()
 

--- a/subsys/sd/sd.c
+++ b/subsys/sd/sd.c
@@ -60,6 +60,18 @@ static int sd_send_interface_condition(struct sd_card *card)
 	ret = sdhc_request(card->sdhc, &cmd, NULL);
 	if (ret) {
 		LOG_DBG("SD CMD8 failed with error %d", ret);
+		if (ret == -ETIMEDOUT && !IS_ENABLED(CONFIG_SDMMC_STACK)) {
+			/*
+			 * Without SDMMC support compiled in, a real SD memory card
+			 * can never be usable on this bus, so a CMD8 timeout can only
+			 * mean a legacy/SDIO-only device. Propagate the timeout so
+			 * the caller can switch to the legacy initialization path
+			 * immediately instead of spinning through retries. When
+			 * SDMMC support is present, fall through to the normal retry
+			 * path below so a real SD card gets its full retry budget.
+			 */
+			return ret;
+		}
 		/* Retry */
 		return SD_RETRY;
 	}

--- a/subsys/sd/sdio.c
+++ b/subsys/sd/sdio.c
@@ -610,7 +610,8 @@ int sdio_card_init(struct sd_card *card)
 		if (IS_ENABLED(CONFIG_SD_UHS_PROTOCOL) &&
 		    (card->flags & SD_1800MV_FLAG) &&
 		    (!card->host_props.is_spi) &&
-		    (card->host_props.host_caps.vol_180_support)) {
+		    (card->host_props.host_caps.vol_180_support) &&
+		    (card->bus_io.signal_voltage != SD_VOL_1_8_V)) {
 			ret = sdmmc_switch_voltage(card);
 			if (ret) {
 				/* Disable host support for 1.8 V */
@@ -623,6 +624,12 @@ int sdio_card_init(struct sd_card *card)
 				card->status = CARD_ERROR;
 				return SD_RESTART;
 			}
+		} else if (IS_ENABLED(CONFIG_SD_UHS_PROTOCOL) &&
+			   (card->flags & SD_1800MV_FLAG) &&
+			   (!card->host_props.is_spi) &&
+			   (card->host_props.host_caps.vol_180_support) &&
+			   (card->bus_io.signal_voltage == SD_VOL_1_8_V)) {
+			LOG_DBG("Skipping CMD11 voltage switch: bus already at 1.8V");
 		}
 		if ((card->flags & SD_MEM_PRESENT_FLAG) &&
 			((card->flags & SD_SDHC_FLAG) == 0)) {


### PR DESCRIPTION
## Summary

Brings up the NXP SDIO Wi-Fi module on the i.MX93 (Cortex-A55/AArch64)
based nitrogen93_smarc board: adds the missing USDHC3 controller node,
fixes an AArch64 build failure in the mcux-sdk-ng optimized memcpy/memset
glue, and fixes several SD/SDIO subsystem and Wi-Fi driver bugs that
prevented this SDIO-only, non-removable device from ever completing card
initialization.

The board used to test this is not yet in the tree. These changes are foundational to introducing the new board in the near future.

## Changes

- **dts: arm64: imx93: add usdhc3 controller node** — the i.MX93 SoC
  devicetree only described usdhc1/usdhc2; adds the missing usdhc3 node
  (disabled by default).

- **drivers: sdhc: imx_usdhc: add non-removable devicetree property** —
  lets a board declare a USDHC instance as permanently wired to a
  non-removable device (no card-detect GPIO/line available), instead of
  relying on the "no card detection method configured" fallback warning.

- **modules: hal_nxp: mcux-sdk-ng: skip Cortex-M asm memcpy/memset on
  aarch64** — fsl_memcpy.S/fsl_memset.S are Cortex-M assembly and don't
  build for AArch64; guards them out so AArch64 boards that enable
  CONFIG_MCUX_OPTIMIZED_MEMCPY/MEMSET via SoC defaults can build at all.

- **subsys: sd: return early on CMD8 timeout when SDMMC is not
  supported** — on builds without CONFIG_SDMMC_STACK, a CMD8 timeout can
  only mean a legacy/SDIO-only device, so this skips the ~10-retry,
  multi-second delay before falling back to legacy/SDIO init. Boards with
  SDMMC support compiled in are unaffected and keep their full retry
  budget.

- **subsys: sd: sdio: skip CMD11 voltage switch if already at 1.8V** —
  avoids a redundant/unnecessary voltage switch during SDIO init when the
  bus is already at 1.8V.

- **drivers: wifi: nxp: fix SDIO reset sequencing and independent
  pwr-gpios** — pwr-gpios was previously required alongside sd-gpios for
  any reset logic to run at all, making reset a silent no-op on boards
  (like this one) that only wire sd-gpios. Also fixes the enable path,
  which asserted reset but never released it before communication began.

## Testing

Built and tested on nitrogen93_smarc/mimx9352/a55 with the shell sample;
SDIO Wi-Fi module now completes card initialization successfully
(previously failed to init entirely).
Wi-Fi works:

```
uart:~$ wifi scan
Scan requested

Num  | SSID                             (len) | Chan (Band)   | RSSI | Security             | BSSID             | MFP     
1    |                                  0     | 44   (5GHz  ) | -33  | WPA2-PSK             | DE:AD:BE:EF:00:01 | Disable 
2    |                                  0     | 60   (5GHz  ) | -56  | OPEN                 | AB:CD:EF:12:34:01 | Disable 
3    |                                  0     | 149  (5GHz  ) | -44  | OPEN                 | AB:CD:EF:12:34:02 | Disable 
4    | SampleAP                         8     | 10   (2.4GHz) | -60  | WPA3-SAE-HNP         | CA:FE:BA:BE:00:01 | Optional
5    | SampleAP_IoT                     12    | 10   (2.4GHz) | -59  | WPA2-PSK             | CA:FE:BA:BE:00:02 | Disable 
6    | SampleAP                         8     | 44   (5GHz  ) | -33  | WPA3-SAE-HNP         | DE:AD:BE:EF:00:02 | Optional
7    | SampleAP_IoT                     12    | 10   (2.4GHz) | -30  | WPA2-PSK             | DE:AD:BE:EF:00:03 | Disable 
8    | SampleAP_IoT                     12    | 44   (5GHz  ) | -33  | WPA2-PSK             | DE:AD:BE:EF:00:04 | Disable 
9    |                                  0     | 10   (2.4GHz) | -30  | WPA2-PSK             | DE:AD:BE:EF:00:05 | Disable 
10   | SampleAP                         8     | 10   (2.4GHz) | -30  | WPA3-SAE-HNP         | DE:AD:BE:EF:00:06 | Optional
Scan request done

uart:~$ wifi status
Status: successful
==================
State: COMPLETED
Interface Mode: STATION
Link Mode: WIFI 6 (802.11ax/HE)
SSID: S******
BSSID: 46:**:**:**:**:**
Band: 5GHz
Channel: 44
Security:  WPA2-PSK
MFP: Optional
RSSI: -34
Beacon Interval: 100
DTIM: 0
TWT: Not supported
Current PHY TX rate (Mbps) : 600.0
```

This depends on: https://github.com/zephyrproject-rtos/hal_nxp/pull/773