### PR TITLE
drivers: usb: common: stm32: wait for VDDUSB ready on STM32H5

### DIFF
--- a/drivers/usb/common/stm32/stm32_usb_pwr.c
+++ b/drivers/usb/common/stm32/stm32_usb_pwr.c
@@ -16,6 +16,15 @@
 LOG_MODULE_REGISTER(stm32_usb_pwr, CONFIG_STM32_USB_COMMON_LOG_LEVEL);
 
 /*
+ * No HAL/datasheet timing constant is published for VMSR.USB33RDY: the flag
+ * reflects a comparator against an internal reference and is expected to
+ * settle in well under a millisecond. 1 ms is a generous bound for that -
+ * two orders of magnitude below the 100 ms PHY-clock-stable timeout used for
+ * a similar (but genuinely slower, PLL-based) ready wait in udc_numaker.c.
+ */
+#define STM32H5_VDDUSB_READY_TIMEOUT_US 1000
+
+/*
  * Keep track of whether power is already
  * enabled here to simplify the USB drivers.
  */
@@ -100,6 +109,35 @@ int stm32_usb_pwr_enable(void)
 	while (!LL_PWR_IsActiveFlag_USBBOOSTRDY()) {
 		/* Wait for USB OTG booster to be ready */
 	}
+#elif defined(CONFIG_SOC_SERIES_STM32H5X)
+	/*
+	 * Enable the USB 3.3V voltage detector/monitor first and wait for
+	 * VDDUSB to be reported ready (VMSR.USB33RDY) before switching VDDUSB
+	 * itself on. Without this wait the USB PHY/OTG core never sees valid
+	 * analog power: USB_CoreReset() then spins for the full
+	 * HAL_USB_TIMEOUT polling GRSTCTL and the controller never comes up.
+	 */
+	LL_PWR_EnableUSBVoltageDetector();
+	if (!WAIT_FOR(LL_PWR_IsActiveFlag_VDDUSB(), STM32H5_VDDUSB_READY_TIMEOUT_US, NULL)) {
+		LOG_WRN("VDDUSB ready flag (PWR->VMSR.USB33RDY) not set within %u us, "
+			"continuing anyway",
+			STM32H5_VDDUSB_READY_TIMEOUT_US);
+	}
+
+	/* Enable VDDUSB */
+	LL_PWR_EnableVDDUSB();
+
+# if defined(PWR_USBSCR_OTGHSEN) && DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)
+	/*
+	 * The embedded OTG_HS PHY has its own analog supply switch, separate
+	 * from the generic VDDUSB enable above: PWR->USBSCR.OTGHSEN. Without
+	 * it GRSTCTL.CSRST never clears and USB_CoreReset() spins for the
+	 * full HAL_USB_TIMEOUT -- verified on stm32h5f5j_dk hardware: USBSCR
+	 * read 0x03000000 (USB33DEN|USB33SV, OTGHSEN clear) and GRSTCTL read
+	 * 0x80000001 (AHBIDL set, CSRST stuck) while HAL_PCD_Init() failed.
+	 */
+	LL_PWR_EnableUSBOTGHSPhy();
+# endif /* PWR_USBSCR_OTGHSEN && DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs) */
 #elif defined(PWR_USBSCR_USB33SV) || defined(PWR_SVMCR_USV)
 	/*
 	 * VDDUSB independent USB supply (PWR clock is on)

--- a/drivers/usb/common/stm32/stm32_usb_pwr.c
+++ b/drivers/usb/common/stm32/stm32_usb_pwr.c
@@ -15,6 +15,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(stm32_usb_pwr, CONFIG_STM32_USB_COMMON_LOG_LEVEL);
 
+#define STM32H5_VDDUSB_READY_TIMEOUT_US 1000
+
 /*
  * Keep track of whether power is already
  * enabled here to simplify the USB drivers.
@@ -40,6 +42,13 @@ int stm32_usb_pwr_enable(void)
 	}
 
 #if defined(CONFIG_SOC_SERIES_STM32H5X)
+	LL_PWR_EnableUSBVoltageDetector();
+	if (!WAIT_FOR(LL_PWR_IsActiveFlag_VDDUSB(), STM32H5_VDDUSB_READY_TIMEOUT_US, NULL)) {
+		LOG_WRN("VDDUSB ready flag (PWR->VMSR.USB33RDY) not set within %u us, "
+			"continuing anyway",
+			STM32H5_VDDUSB_READY_TIMEOUT_US);
+	}
+
 	LL_PWR_EnableVddUSB();
 
 # if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs)


### PR DESCRIPTION
## Description

STM32H5's `stm32_usb_pwr_enable()` sets `PWR->USBSCR.USB33SV` and returns immediately, without enabling the USB33DEN voltage detector or waiting for `PWR->VMSR.USB33RDY` first - unlike the H7, N6 and WBA arms in the same file.

On STM32H5F5 hardware this leaves the OTG PHY without valid analog power: `HAL_PCD_Init()` -> `USB_CoreReset()` busy-waits on `GRSTCTL` for the full `HAL_USB_TIMEOUT` (~20-22 s at `POST_KERNEL`), then gives up with `HAL_TIMEOUT`, and USB never enumerates.

This enables the detector and waits on `USB33RDY` before setting `USB33SV`, mirroring STM32N6X's sequence. The wait is bounded via `WAIT_FOR()`: no datasheet timing is published for `USB33RDY`, so 1000 us is a conservative estimate for a comparator readout. On timeout it logs a warning and continues rather than failing the function.

## Testing

`samples/subsys/usb/cdc_acm` builds for `stm32h5f5j_dk`; the new arm's warning string is present in the linked `zephyr.elf`, confirming it is not compiled out.

The hardware measurement that opened this pull request predates 3cb68a9fc4f, which added the STM32H5 arm this change extends, so it no longer describes this diff and has been dropped. A fresh measurement on `stm32h5f5j_dk` is still needed.

> Split out of #113873 per review feedback: that PR is a display re-land and this fix does not belong in it.
