### PR TITLE
boards: infineon: kit_pse84_eval: use Secure RRAM alias on m33 Secure image

### DIFF
--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.dts
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33.dts
@@ -33,6 +33,22 @@
 	};
 };
 
+/*
+ * On the Secure CM33 image, the on-chip RRAM data array must
+ * be accessed through the Secure address alias. The shared board memory map
+ * (kit_pse84_eval_memory_map.dtsi) declares the RRAM soc-nv-flash at the
+ * Non-Secure data alias (0x22000000) so that the Non-Secure (m33_ns) and CM55
+ * images work. A Secure master accessing the Non-Secure data alias
+ * precise-bus-faults (observed BFAR 0x22051000, the storage_partition_rram
+ * base) on the first RRAM partition access, while the controller MMIO at
+ * 0x42200000 is reachable. Re-point only the data node to the Secure alias
+ * (0x32000000) for this Secure image; the controller MMIO alias is unchanged.
+ */
+&rram0 {
+	reg = <0x32000000 DT_SIZE_K(512)>;
+	ranges = <0x0 0x32000000 DT_SIZE_K(512)>;
+};
+
 &mcwdt0 {
 	status = "okay";
 };


### PR DESCRIPTION
## Summary

On the Secure CM33 image (`kit_pse84_eval/pse846gps2dbzc4a/m33`), a `flash_area`
read/erase/write against the on-chip RRAM storage partition precise-bus-faults
the CM33 at the first access (observed `BFAR 0x22051000`, the
`storage_partition_rram` base). This shows up in `tests/drivers/flash/common`
and in NVS/settings bring-up on the Secure image.

## Root cause

The shared board memory map (`kit_pse84_eval_memory_map.dtsi`) declares the RRAM
`soc-nv-flash` data node (`rram0`) at the **Non-Secure** data alias
`0x22000000`, which is correct for the `m33_ns` and CM55 images. A Secure master
must instead use the **Secure** data alias `0x32000000` (matching
`soc/pse84_s.dtsi`); accessing the Non-Secure alias from Secure precise-bus-faults.
The RRAM controller MMIO at `0x42200000` is reachable from Secure — the fault is
on the data region, not the controller.

## Fix

Re-point only the RRAM data node to the Secure alias in the Secure-only board
DTS (`kit_pse84_eval_m33.dts`):

```dts
&rram0 {
	reg = <0x32000000 DT_SIZE_K(512)>;
	ranges = <0x0 0x32000000 DT_SIZE_K(512)>;
};
```

The controller MMIO alias and the `m33_ns` / CM55 images are unchanged.

## Testing

Build-verified: `kit_pse84_eval/pse846gps2dbzc4a/m33` `tests/drivers/flash/common`
links clean and the generated devicetree resolves `rram0` to `0x32000000`
(`storage_partition_rram` -> `0x32051000`). On-target verification on the Secure
image is pending hardware bring-up.
