### PR TITLE
timer: fixes addressing multiple timer drivers

### DIFF
--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -96,6 +96,11 @@ static void set_trigger(uint64_t deadline)
  */
 #define TIMER_CORE_BACKEND_COMPARE
 #define TIMER_CORE_64BIT_CYCLES
+/* The TSC is 64 bits wide regardless of the CPU's register width: declare it
+ * so a 32-bit build does not fall back to the native-register default and
+ * alias deltas beyond 2^32 cycles.
+ */
+#define TIMER_CORE_CYCLES_WIDTH 64
 
 static inline uint64_t timer_driver_cycle_get(void)
 {

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -159,9 +159,10 @@ static cycle_t cycle_pre_idle;
  * holds the amount of elapsed HW cycles due to (possibly) multiple
  * timer wraps (overflows).
  *
- * @param val_out Optional pointer to store the SysTick->VAL snapshot (val2)
- *                used in the calculation, so a caller needing that raw value
- *                gets it with no gap after the measurement (see
+ * @param val_out Optional pointer to store the raw SysTick->VAL snapshot
+ *                (val2, as read, before wrap-realignment) used in the
+ *                calculation, so a caller needing that raw value gets it
+ *                with no gap after the measurement (see
  *                timer_driver_set_reload()).
  *
  * Prerequisites:
@@ -202,6 +203,10 @@ static uint32_t elapsed(uint32_t *val_out)
 	 * So the count in val2 is post-wrap and last_load needs to be
 	 * added if and only if COUNTFLAG is set or val1 < val2.
 	 */
+	if (val_out != NULL) {
+		*val_out = val2;
+	}
+
 	if (val1 == 0) {
 		val1 = last_load;
 	}
@@ -216,10 +221,6 @@ static uint32_t elapsed(uint32_t *val_out)
 		/* We know there was a wrap, but we might not have
 		 * seen it in CTRL, so clear it. */
 		(void)SysTick->CTRL;
-	}
-
-	if (val_out != NULL) {
-		*val_out = val2;
 	}
 
 	return (last_load - val2) + overflow_cyc;

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -270,9 +270,16 @@ static inline void hpet_timer_comparator_set_safe(uint64_t next)
  * is rearmed by hpet_timer_comparator_set_safe(), satisfying the core's "must
  * not miss a past deadline" contract. Under QEMU SMP the shared counter can be
  * observed reading backwards, handled via TIMER_CORE_COUNTER_NONMONOTONIC.
+ *
+ * The counter is genuinely 64 bits wide even on a 32-bit CPU, so declare its
+ * width rather than take the core's native-register default: a 32-bit mask
+ * would alias any delta beyond 2^32 cycles, and the comparator (checked
+ * against the full 64-bit count) would then be armed a whole 2^32-cycle
+ * period behind the counter.
  */
 #define TIMER_CORE_BACKEND_COMPARE
 #define TIMER_CORE_64BIT_CYCLES
+#define TIMER_CORE_CYCLES_WIDTH 64
 #if defined(CONFIG_SMP) && defined(CONFIG_QEMU_TARGET)
 #define TIMER_CORE_COUNTER_NONMONOTONIC
 #endif

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -50,7 +50,7 @@ static inline void timer_driver_set_compare(uint64_t cycles)
 
 	uint32_t now = get_cp0_count();
 
-	while ((int32_t)(next - now) < (int32_t)MIN_DELAY) {
+	while ((int32_t)(next - now) <= 0) {
 		next = now + MIN_DELAY;
 		set_cp0_compare(next);
 		now = get_cp0_count();

--- a/drivers/timer/openrisc_tick_timer.c
+++ b/drivers/timer/openrisc_tick_timer.c
@@ -63,7 +63,7 @@ static inline void timer_driver_set_compare(uint64_t cycles)
 
 	uint32_t now = get_count() & MAX_CYC;
 
-	while (cyc_diff(next, now) < (int32_t)MIN_DELAY) {
+	while (cyc_diff(next, now) <= 0) {
 		next = (now + MIN_DELAY) & MAX_CYC;
 		set_compare(next);
 		now = get_count() & MAX_CYC;

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -72,6 +72,11 @@ static uint64_t mtime(void)
 #define TIMER_CORE_BACKEND_COMPARE
 #define TIMER_CORE_HAVE_CYCLE_GET_32
 #define TIMER_CORE_HAVE_CYCLE_GET_64
+/* mtime is 64 bits wide even on RV32: declare its width rather than take the
+ * native-register default, which would mask deltas to 32 bits there and alias
+ * any gap beyond 2^32 cycles.
+ */
+#define TIMER_CORE_CYCLES_WIDTH 64
 
 static inline uint64_t timer_driver_cycle_get(void)
 {

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -75,7 +75,7 @@ static inline void timer_driver_set_compare(uint64_t cycles)
 
 	uint32_t now = ccount();
 
-	while ((int32_t)(next - now) < (int32_t)MIN_DELAY) {
+	while ((int32_t)(next - now) <= 0) {
 		next = now + MIN_DELAY;
 		set_ccompare(next - ccount_comp());
 		now = ccount();


### PR DESCRIPTION
- **drivers: timer: cortex_m_systick: keep the drift-comp VAL sample raw**
- **drivers: timer: fix the equality-match compare catch-up livelock**
