### PR TITLE
drivers: timer: fix the post-#112959 CI failures and harden the generic core

### DIFF
--- a/drivers/timer/apic_tsc.c
+++ b/drivers/timer/apic_tsc.c
@@ -96,6 +96,11 @@ static void set_trigger(uint64_t deadline)
  */
 #define TIMER_CORE_BACKEND_COMPARE
 #define TIMER_CORE_64BIT_CYCLES
+/* The TSC is 64 bits wide regardless of the CPU's register width: declare it
+ * so a 32-bit build does not fall back to the native-register default and
+ * alias deltas beyond 2^32 cycles.
+ */
+#define TIMER_CORE_CYCLES_WIDTH 64
 
 static inline uint64_t timer_driver_cycle_get(void)
 {

--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -150,6 +150,11 @@ void sys_clock_unused(void)
 	k_spinlock_key_t key = sys_clock_lock();
 
 	timer_driver_set_reload(TIMER_CORE_CYCLES_MAX);
+	/* The hardware no longer matches what the core armed, so drop its
+	 * cached deadline or the next sys_clock_set_timeout() landing on the
+	 * same tick would be skipped with the long reload still in flight.
+	 */
+	timer_core_armed_deadline = UINT64_MAX;
 	sys_clock_unlock(key);
 }
 

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -159,9 +159,10 @@ static cycle_t cycle_pre_idle;
  * holds the amount of elapsed HW cycles due to (possibly) multiple
  * timer wraps (overflows).
  *
- * @param val_out Optional pointer to store the SysTick->VAL snapshot (val2)
- *                used in the calculation, so a caller needing that raw value
- *                gets it with no gap after the measurement (see
+ * @param val_out Optional pointer to store the raw SysTick->VAL snapshot
+ *                (val2, as read, before wrap-realignment) used in the
+ *                calculation, so a caller needing that raw value gets it
+ *                with no gap after the measurement (see
  *                timer_driver_set_reload()).
  *
  * Prerequisites:
@@ -202,6 +203,10 @@ static uint32_t elapsed(uint32_t *val_out)
 	 * So the count in val2 is post-wrap and last_load needs to be
 	 * added if and only if COUNTFLAG is set or val1 < val2.
 	 */
+	if (val_out != NULL) {
+		*val_out = val2;
+	}
+
 	if (val1 == 0) {
 		val1 = last_load;
 	}
@@ -216,10 +221,6 @@ static uint32_t elapsed(uint32_t *val_out)
 		/* We know there was a wrap, but we might not have
 		 * seen it in CTRL, so clear it. */
 		(void)SysTick->CTRL;
-	}
-
-	if (val_out != NULL) {
-		*val_out = val2;
 	}
 
 	return (last_load - val2) + overflow_cyc;

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -432,9 +432,13 @@ void sys_clock_unused(void)
 	/* Fast CPUs and a 24 bit counter mean that even idle systems need to
 	 * wake up multiple times per second. With no timeout pending and sloppy
 	 * idle allowing the uptime to drift, shut off the counter entirely.
+	 * The hardware no longer matches what the core armed, so drop its
+	 * cached deadline or the next sys_clock_set_timeout() landing on the
+	 * same tick would be skipped with the counter stopped.
 	 */
 	SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
 	last_load = TIMER_STOPPED;
+	timer_core_armed_deadline = UINT64_MAX;
 }
 
 #if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -270,9 +270,16 @@ static inline void hpet_timer_comparator_set_safe(uint64_t next)
  * is rearmed by hpet_timer_comparator_set_safe(), satisfying the core's "must
  * not miss a past deadline" contract. Under QEMU SMP the shared counter can be
  * observed reading backwards, handled via TIMER_CORE_COUNTER_NONMONOTONIC.
+ *
+ * The counter is genuinely 64 bits wide even on a 32-bit CPU, so declare its
+ * width rather than take the core's native-register default: a 32-bit mask
+ * would alias any delta beyond 2^32 cycles, and the comparator (checked
+ * against the full 64-bit count) would then be armed a whole 2^32-cycle
+ * period behind the counter.
  */
 #define TIMER_CORE_BACKEND_COMPARE
 #define TIMER_CORE_64BIT_CYCLES
+#define TIMER_CORE_CYCLES_WIDTH 64
 #if defined(CONFIG_SMP) && defined(CONFIG_QEMU_TARGET)
 #define TIMER_CORE_COUNTER_NONMONOTONIC
 #endif

--- a/drivers/timer/mips_cp0_timer.c
+++ b/drivers/timer/mips_cp0_timer.c
@@ -50,7 +50,7 @@ static inline void timer_driver_set_compare(uint64_t cycles)
 
 	uint32_t now = get_cp0_count();
 
-	while ((int32_t)(next - now) < (int32_t)MIN_DELAY) {
+	while ((int32_t)(next - now) <= 0) {
 		next = now + MIN_DELAY;
 		set_cp0_compare(next);
 		now = get_cp0_count();

--- a/drivers/timer/openrisc_tick_timer.c
+++ b/drivers/timer/openrisc_tick_timer.c
@@ -63,7 +63,7 @@ static inline void timer_driver_set_compare(uint64_t cycles)
 
 	uint32_t now = get_count() & MAX_CYC;
 
-	while (cyc_diff(next, now) < (int32_t)MIN_DELAY) {
+	while (cyc_diff(next, now) <= 0) {
 		next = (now + MIN_DELAY) & MAX_CYC;
 		set_compare(next);
 		now = get_count() & MAX_CYC;

--- a/drivers/timer/openrisc_tick_timer.c
+++ b/drivers/timer/openrisc_tick_timer.c
@@ -16,7 +16,12 @@
 
 static ALWAYS_INLINE void set_compare(uint32_t time)
 {
-	openrisc_write_spr(SPR_TTMR, SPR_TTMR_IE | SPR_TTMR_CR | time);
+	/* TTMR.IP is cleared by writing 0 and unaffected by writing 1, so
+	 * writing it back keeps a match that raced this rewrite pending
+	 * instead of silently dropping it. The ISR acknowledges by writing
+	 * TTMR with IP cleared (clear_compare()).
+	 */
+	openrisc_write_spr(SPR_TTMR, SPR_TTMR_IE | SPR_TTMR_CR | SPR_TTMR_IP | time);
 }
 
 static ALWAYS_INLINE void clear_compare(void)
@@ -45,7 +50,7 @@ static ALWAYS_INLINE int32_t cyc_diff(uint32_t a, uint32_t b)
  * width. TTMR matches only TTCR[27:0] == TP, so timer_driver_set_compare() bumps an
  * already-past target at least MIN_DELAY ahead rather than let it wait for the
  * 28-bit count to wrap, meeting the core's "must not miss a past deadline"
- * contract; writing TTMR also clears the pending interrupt.
+ * contract.
  */
 #define TIMER_CORE_CYCLES_WIDTH 28
 #define TIMER_CORE_BACKEND_COMPARE
@@ -78,12 +83,12 @@ void z_openrisc_timer_isr(void)
 		sys_trace_isr_enter();
 	}
 
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		/* Disarm; the kernel re-arms through sys_clock_set_timeout() after
-		 * the announce. A tickful kernel re-arms in timer_core_announce().
-		 */
-		clear_compare();
-	}
+	/* Acknowledge (clear TTMR.IP) and disarm; set_compare() preserves a
+	 * pending IP, so this write is the only place the interrupt is acked.
+	 * The kernel re-arms through sys_clock_set_timeout() after the
+	 * announce; a tickful kernel re-arms in timer_core_announce().
+	 */
+	clear_compare();
 
 	timer_core_announce();
 

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -72,6 +72,11 @@ static uint64_t mtime(void)
 #define TIMER_CORE_BACKEND_COMPARE
 #define TIMER_CORE_HAVE_CYCLE_GET_32
 #define TIMER_CORE_HAVE_CYCLE_GET_64
+/* mtime is 64 bits wide even on RV32: declare its width rather than take the
+ * native-register default, which would mask deltas to 32 bits there and alias
+ * any gap beyond 2^32 cycles.
+ */
+#define TIMER_CORE_CYCLES_WIDTH 64
 
 static inline uint64_t timer_driver_cycle_get(void)
 {

--- a/drivers/timer/riscv_supervisor_timer.c
+++ b/drivers/timer/riscv_supervisor_timer.c
@@ -53,9 +53,16 @@ static uint64_t stime(void)
  * Free-running "time" counter plus an absolute SBI set-timer deadline: a
  * COMPARE backend. The generic core owns the tick accounting and the clock
  * lock; the driver only reads the counter and programs the deadline.
+ *
+ * The "time" CSR is 64 bits wide even on RV32, so declare its width rather
+ * than take the core's native-register default: a 32-bit mask would alias
+ * any delta beyond 2^32 cycles, and the SBI deadline (compared against the
+ * full 64-bit count) would then be set a whole 2^32-cycle period behind the
+ * counter.
  */
 #define TIMER_CORE_BACKEND_COMPARE
 #define TIMER_CORE_64BIT_CYCLES
+#define TIMER_CORE_CYCLES_WIDTH 64
 
 static inline uint64_t timer_driver_cycle_get(void)
 {

--- a/drivers/timer/system_timer_generic.h
+++ b/drivers/timer/system_timer_generic.h
@@ -206,6 +206,32 @@ static uint64_t timer_core_last_cycle;
 static uint64_t timer_core_last_tick;
 static uint32_t timer_core_last_elapsed;
 
+#if defined(TIMER_CORE_BACKEND_RELOAD)
+/* A catch-up reload (floored at TIMER_CORE_MIN_DELAY because the deadline is
+ * already due, or because the un-announced span is about to overrun
+ * TIMER_CORE_CYCLES_MAX) is in flight. Programming a reload restarts the
+ * counter, so a stream of set_timeout() calls arriving faster than the floor
+ * would rewrite the reload before it can expire and postpone the announce
+ * indefinitely; while this is set, timer_core_arm() leaves the hardware alone
+ * so the pending fire gets through. Cleared by the announce.
+ */
+static bool timer_core_catchup;
+#endif
+
+/* Tick-aligned deadline currently armed in the hardware, or UINT64_MAX when
+ * nothing is known to be armed (initially, and after each announce, which
+ * consumes the programmed deadline). timer_core_arm() programs the hardware
+ * only when the deadline actually moves: the kernel re-evaluates its earliest
+ * timeout on every add and abort (a timeslice reset is one of each), so
+ * back-to-back calls usually land on the same tick boundary, and rewriting
+ * the timer for those is pure churn. For a RELOAD backend the rewrite is
+ * worse than churn: it restarts the counter, so a sustained stream of
+ * rewrites (e.g. timeslice resets from a syscall-heavy thread) keeps any
+ * period from ever completing and postpones the announce for the duration of
+ * the stream.
+ */
+static uint64_t timer_core_armed_deadline = UINT64_MAX;
+
 /* Whole ticks elapsed since the last announce, from the current counter. */
 static inline uint32_t timer_core_delta_ticks(void)
 {
@@ -239,6 +265,13 @@ static inline uint32_t timer_core_delta_ticks(void)
  */
 static void timer_core_arm(uint32_t ticks)
 {
+	uint64_t deadline_tick = timer_core_last_tick + timer_core_last_elapsed + ticks;
+
+	if (deadline_tick == timer_core_armed_deadline) {
+		return;
+	}
+	timer_core_armed_deadline = deadline_tick;
+
 #if defined(TIMER_CORE_BACKEND_COMPARE)
 	/*
 	 * Absolute, tick-aligned deadline. last_cycle is linear (its low
@@ -246,8 +279,7 @@ static void timer_core_arm(uint32_t ticks)
 	 * truncates the value to its comparator width when it writes it, so a
 	 * linear deadline is correct for both wide and narrow counters.
 	 */
-	uint64_t deadline = (timer_core_last_tick + timer_core_last_elapsed + ticks) *
-			    TIMER_CORE_CYC_PER_TICK;
+	uint64_t deadline = deadline_tick * TIMER_CORE_CYC_PER_TICK;
 
 	if ((deadline - timer_core_last_cycle) > TIMER_CORE_CYCLES_MAX) {
 		deadline = timer_core_last_cycle + TIMER_CORE_CYCLES_MAX;
@@ -280,6 +312,20 @@ static void timer_core_arm(uint32_t ticks)
 		rel = (int64_t)TIMER_CORE_CYCLES_MAX - (int64_t)done;
 	}
 	if (rel < (int64_t)TIMER_CORE_MIN_DELAY) {
+		/*
+		 * The announce is due (or overdue): fire as soon as the floor
+		 * allows. If a floored reload is already in flight, leave it
+		 * to expire rather than restart the counter, or a set_timeout()
+		 * stream arriving faster than the floor (e.g. timeslice resets
+		 * from a syscall-heavy thread) would push the fire point out
+		 * forever and freeze announced time for the storm's duration.
+		 * No incoming deadline can need to fire sooner than the floor
+		 * anyway.
+		 */
+		if (timer_core_catchup) {
+			return;
+		}
+		timer_core_catchup = true;
 		rel = TIMER_CORE_MIN_DELAY;
 	}
 	timer_driver_set_reload((uint64_t)rel);
@@ -322,6 +368,14 @@ static void timer_core_announce_from(k_spinlock_key_t key)
 	timer_core_last_cycle += (uint64_t)dticks * TIMER_CORE_CYC_PER_TICK;
 	timer_core_last_tick += dticks;
 	timer_core_last_elapsed = 0;
+	/* The programmed deadline is consumed (or obsolete): the kernel decides
+	 * the next one after the announce, and it must reach the hardware even
+	 * if it lands on the same tick.
+	 */
+	timer_core_armed_deadline = UINT64_MAX;
+#if defined(TIMER_CORE_BACKEND_RELOAD)
+	timer_core_catchup = false;
+#endif
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 #if defined(TIMER_CORE_BACKEND_COMPARE)

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -75,7 +75,7 @@ static inline void timer_driver_set_compare(uint64_t cycles)
 
 	uint32_t now = ccount();
 
-	while ((int32_t)(next - now) < (int32_t)MIN_DELAY) {
+	while ((int32_t)(next - now) <= 0) {
 		next = now + MIN_DELAY;
 		set_ccompare(next - ccount_comp());
 		now = ccount();

--- a/tests/drivers/reset/mmio/boards/qemu_cortex_m3.overlay
+++ b/tests/drivers/reset/mmio/boards/qemu_cortex_m3.overlay
@@ -1,13 +1,31 @@
+/*
+ * Copyright (c) 2025 Google LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * The fake reset registers below are backed by plain SRAM, so the words
+ * they occupy must not be part of the RAM the kernel links into: a write
+ * through the reset driver would clobber whatever data or function
+ * pointer the linker happened to place there (moving with every layout
+ * change). Shrink the kernel's view of the 64 KiB SRAM by one KiB and
+ * place the registers in the carved-out tail.
+ */
+&sram0 {
+	reg = <0x20000000 0xfc00>;
+};
+
 / {
-	reset0: reset@20000004 {
+	reset0: reset@2000fc00 {
 		compatible = "reset-mmio";
-		reg = <0x20000004 0x4>;
+		reg = <0x2000fc00 0x4>;
 		num-resets = <16>;
 	};
 
-	reset1: reset@20000008 {
+	reset1: reset@2000fc04 {
 		compatible = "reset-mmio";
-		reg = <0x20000008 0x4>;
+		reg = <0x2000fc04 0x4>;
 		num-resets = <16>;
 		active-low;
 	};


### PR DESCRIPTION
Standalone, complete fix for the CI failures that appeared on main after the generic tickless timer core (#112959) merged: the mps2/an385 networking suites, the qemu_or1k timeouts, the qemu_x86/atom gdbstub error and the qemu_cortex_a9 conn_mgr timeout.

The first three commits are Anas Nashif's fixes from #114250, carried here with authorship intact so the whole set can go through CI as one unit (the assistance trailer is reformatted as body text, which is what compliance accepts):

- cortex_m_systick: hand the drift compensation the raw VAL sample instead of the wrap-realigned one. QEMU holds VAL at zero around a reprogram, so the realigned sample credited a full timer period per back-to-back rearm and uptime raced ahead of real time (the mps2 net failures).
- openrisc/mips_cp0/xtensa: relax the equality-match catch-up loop exit so it converges; the old exit condition could only be met if the counter stood still, a deterministic livelock under QEMU icount (the qemu_or1k timeouts).
- apic_tsc/hpet/riscv_machine: declare the 64-bit counter width so a 32-bit build does not mask deltas at the native register width (the qemu_x86/atom gdbstub error, where icount makes virtual time race while the stub polls).

On top of those:

- riscv_supervisor: the same width declaration, found while reviewing the sweep; the 64-bit "time" CSR has the identical RV32 aliasing exposure.
- openrisc: arm TTMR with IP written back so a comparator match racing a rearm is not silently dropped, and acknowledge only in the ISR.
- generic core: program the hardware only when the tick-aligned deadline actually moves, and leave an in-flight floored catch-up reload alone instead of restarting it. The kernel re-evaluates its earliest timeout on every add and abort (a timeslice reset is one of each), so a syscall-heavy thread produces a sustained rearm stream: on RELOAD backends that keeps any period from completing and stalls the announce, and every avoided reprogram is also one less window for the emulator model races above. This commit is the fix for the qemu_cortex_a9 net.conn_mgr.conn timeout, which still fails with the driver fixes alone.

Verified on this exact tree: the six qemu_or1k failures plus kernel.common (87/87 cases), the mps2/an385 net.socket.udp.preempt, net.mqtt.client.preempt, net.mdns and kernel.timer suites (160/160), debug.gdbstub.breakpoints on qemu_x86/atom, net.conn_mgr.conn on qemu_cortex_a9 (38/38), and build sanity across the riscv32/riscv64/arm64/x86/systick/or1k backends.

Supersedes #114250 by including it.