### PR TITLE
net: shell: improve PTP clock capability description

### DIFF
--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -82,7 +82,7 @@ static void print_supported_ethernet_capabilities(
 
 #ifdef CONFIG_PTP_CLOCK
 	if (net_eth_get_ptp_clock(iface) != NULL) {
-		PR("\t%s\n", "IEEE 802.1AS gPTP clock");
+		PR("\t%s\n", "IEEE 1588 PTP clock");
 	}
 #endif
 }


### PR DESCRIPTION
PTP clock is term from IEEE 1588, while IEEE 802.1AS gPTP is just a profile of IEEE 1588. We should specify IEEE 1588 PTP clock capability here. It can be used for gPTP or any other profiles.