### PR TITLE
Mke1xz drivers enablement and core freq bug fix

### DIFF
--- a/boards/nxp/frdm_ke15z/frdm_ke15z-pinctrl.dtsi
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z-pinctrl.dtsi
@@ -31,4 +31,31 @@
 			slew-rate = "slow";
 		};
 	};
+
+	flexio_pwm_default: flexio_pwm_default {
+		group0 {
+			pinmux = <FXIO_D3_PTE16>,
+				 <FXIO_D5_PTE11>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
+
+	ftm2_default: ftm2_default {
+		group0 {
+			pinmux = <FTM2_CH0_PTC5>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
+
+	ftm0_default: ftm0_default {
+		group0 {
+			pinmux = <FTM0_CH0_PTD15>,
+				 <FTM0_CH1_PTD16>,
+				 <FTM0_CH2_PTD0>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
 };

--- a/boards/nxp/frdm_ke15z/frdm_ke15z-pinctrl.dtsi
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z-pinctrl.dtsi
@@ -14,6 +14,15 @@
 		};
 	};
 
+	lpuart0_default: lpuart0_default {
+		group0 {
+			pinmux = <LPUART0_RX_PTB0>,
+				 <LPUART0_TX_PTB1>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
+
 	lpuart1_default: lpuart1_default {
 		group0 {
 			pinmux = <LPUART1_RX_PTC6>,

--- a/boards/nxp/frdm_ke15z/frdm_ke15z.dts
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -126,4 +126,21 @@
 
 &crc {
 	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 2KB.
+		 */
+		storage_partition: partition@3e000 {
+			label = "storage";
+			reg = <0x0003e000 DT_SIZE_K(8)>;
+		};
+	};
 };

--- a/boards/nxp/frdm_ke15z/frdm_ke15z.dts
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z.dts
@@ -10,6 +10,7 @@
 #include "frdm_ke15z-pinctrl.dtsi"
 #include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	model = "NXP Freedom KE15Z board";
@@ -22,6 +23,9 @@
 		led2 = &red_led;
 		sw0 = &user_button_0;
 		sw1 = &user_button_1;
+		pwm-led0 = &green_pwm_led;
+		pwm-led1 = &blue_pwm_led;
+		pwm-led2 = &red_pwm_led;
 	};
 
 	chosen {
@@ -48,6 +52,25 @@
 		blue_led: led_2 {
 			gpios = <&gpiod 15 GPIO_ACTIVE_LOW>;
 			label = "BLUE LED";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		red_pwm_led: led_pwm_0 {
+			pwms = <&ftm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "RED RGB PWM LED";
+		};
+
+		green_pwm_led: led_pwm_1 {
+			pwms = <&ftm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "GREEN RGB PWM LED";
+		};
+
+		blue_pwm_led: led_pwm_2 {
+			pwms = <&ftm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "BLUE RGB PWM LED";
 		};
 	};
 
@@ -138,6 +161,37 @@
 
 &edma {
 	status = "okay";
+};
+
+&sosc_clk {
+	status = "okay";
+	clock-frequency = <DT_FREQ_M(8)>;
+};
+
+&soscdiv2_clk {
+	clock-div = <1>;
+};
+
+&ftm0 {
+	status = "okay";
+	compatible = "nxp,ftm-pwm";
+	#pwm-cells = <3>;
+	clocks = <&scg KINETIS_SCG_SOSC_CLK>;
+	prescaler = <128>;
+	pinctrl-0 = <&ftm0_default>;
+	pinctrl-names = "default";
+	clock-source = "fixed";
+};
+
+&ftm2 {
+	status = "okay";
+	compatible = "nxp,ftm-pwm";
+	#pwm-cells = <3>;
+	clocks = <&scg KINETIS_SCG_SOSC_CLK>;
+	prescaler = <128>;
+	pinctrl-0 = <&ftm2_default>;
+	pinctrl-names = "default";
+	clock-source = "fixed";
 };
 
 &flash0 {

--- a/boards/nxp/frdm_ke15z/frdm_ke15z.dts
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z.dts
@@ -97,6 +97,14 @@
 	};
 };
 
+&lpuart0 {
+	dmas = <&edma 2 2>, <&edma 3 3>;
+	dma-names = "rx", "tx";
+	current-speed = <115200>;
+	pinctrl-0 = <&lpuart0_default>;
+	pinctrl-names = "default";
+};
+
 &lpuart1 {
 	status = "okay";
 	current-speed = <115200>;
@@ -125,6 +133,10 @@
 };
 
 &crc {
+	status = "okay";
+};
+
+&edma {
 	status = "okay";
 };
 

--- a/boards/nxp/frdm_ke15z/frdm_ke15z.yaml
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z.yaml
@@ -9,6 +9,7 @@ flash: 256
 ram: 24
 supported:
   - adc
+  - dma
   - flash
   - gpio
   - hwinfo

--- a/boards/nxp/frdm_ke15z/frdm_ke15z.yaml
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z.yaml
@@ -13,6 +13,7 @@ supported:
   - flash
   - gpio
   - hwinfo
+  - pwm
   - uart
   - watchdog
   - crc

--- a/boards/nxp/frdm_ke17z/frdm_ke17z-pinctrl.dtsi
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z-pinctrl.dtsi
@@ -24,6 +24,15 @@
 		};
 	};
 
+	lpuart2_default: lpuart2_default {
+		group0 {
+			pinmux = <LPUART2_RX_PTD6>,
+				 <LPUART2_TX_PTD7>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
+
 	ftm2_default: ftm2_default {
 		group0 {
 			pinmux = <FTM2_CH0_PTD10>,

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.dts
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.dts
@@ -159,15 +159,24 @@
 	status = "okay";
 };
 
+&sosc_clk {
+	status = "okay";
+	clock-frequency = <DT_FREQ_M(8)>;
+};
+
+&soscdiv2_clk {
+	clock-div = <1>;
+};
+
 &ftm2 {
 	status = "okay";
 	compatible = "nxp,ftm-pwm";
 	#pwm-cells = <3>;
-	clocks = <&scg KINETIS_SCG_SIRC_CLK>;
+	clocks = <&scg KINETIS_SCG_SOSC_CLK>;
 	prescaler = <128>;
 	pinctrl-0 = <&ftm2_default>;
 	pinctrl-names = "default";
-	clock-source = "system";
+	clock-source = "fixed";
 };
 
 &flash0 {

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.dts
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.dts
@@ -129,11 +129,17 @@
 };
 
 &lpuart0 {
-	dmas = <&edma 1 2>, <&edma 2 3>;
-	dma-names = "rx", "tx";
 	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&lpuart0_default>;
+	pinctrl-names = "default";
+};
+
+&lpuart2 {
+	dmas = <&edma 2 6>, <&edma 3 7>;
+	dma-names = "rx", "tx";
+	current-speed = <115200>;
+	pinctrl-0 = <&lpuart2_default>;
 	pinctrl-names = "default";
 };
 

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512-pinctrl.dtsi
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512-pinctrl.dtsi
@@ -16,6 +16,15 @@
 	};
 
 	/* Configures pin routing and optionally pin electrical features. */
+	lpuart0_default: lpuart0_default {
+		group0 {
+			pinmux = <LPUART0_RX_PTB0>,
+				 <LPUART0_TX_PTB1>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
+
 	lpuart2_default: lpuart2_default {
 		group0 {
 			pinmux = <LPUART2_TX_PTE12>,

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
@@ -180,15 +180,24 @@
 	pinctrl-names = "default";
 };
 
+&sosc_clk {
+	status = "okay";
+	clock-frequency = <DT_FREQ_M(8)>;
+};
+
+&soscdiv2_clk {
+	clock-div = <1>;
+};
+
 &ftm2 {
 	status = "okay";
 	compatible = "nxp,ftm-pwm";
 	#pwm-cells = <3>;
-	clocks = <&scg KINETIS_SCG_SIRC_CLK>;
+	clocks = <&scg KINETIS_SCG_SOSC_CLK>;
 	prescaler = <128>;
 	pinctrl-0 = <&ftm2_default>;
 	pinctrl-names = "default";
-	clock-source = "system";
+	clock-source = "fixed";
 };
 
 &flash0 {

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
@@ -132,9 +132,15 @@
 	exit-latency-us = <13>;
 };
 
-&lpuart2 {
-	dmas = <&edma 5 6>, <&edma 6 7>;
+&lpuart0 {
+	dmas = <&edma 2 2>, <&edma 3 3>;
 	dma-names = "rx", "tx";
+	current-speed = <115200>;
+	pinctrl-0 = <&lpuart0_default>;
+	pinctrl-names = "default";
+};
+
+&lpuart2 {
 	status = "okay";
 	pinctrl-0 = <&lpuart2_default>;
 	pinctrl-names = "default";

--- a/dts/arm/nxp/kinetis/nxp_ke17z512.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_ke17z512.dtsi
@@ -10,6 +10,18 @@
 /delete-node/ &sram_u;
 
 / {
+	cpus {
+		/* Fix cpu0, it has different frequency on KE17Z512 */
+		/delete-node/ cpu@0;
+
+		cpu0: cpu@0 {
+			compatible = "arm,cortex-m0+";
+			clock-frequency = <DT_FREQ_M(96)>;
+			reg = <0>;
+			cpu-power-states = <&idle &pstop2 &pstop1 &stop>;
+		};
+	};
+
 	/* Fix sram_l and sram_u, they have different addr and size on KE17Z512 */
 	sram_l: memory@1fff8000 {
 		compatible = "zephyr,memory-region", "mmio-sram";

--- a/dts/arm/nxp/kinetis/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_ke1xz.dtsi
@@ -87,6 +87,12 @@
 			reg = <0x40064000 0x1000>;
 			#clock-cells = <1>;
 
+			sosc_clk: sosc_clk {
+				compatible = "fixed-clock";
+				status = "disabled";
+				#clock-cells = <0>;
+			};
+
 			sirc_clk: sirc_clk {
 				compatible = "fixed-clock";
 				clock-frequency = <DT_FREQ_M(8)>;
@@ -107,7 +113,7 @@
 
 			core_clk: core_clk {
 				compatible = "fixed-factor-clock";
-				#clocks = <&firc_clk>;
+                                #clocks = <&firc_clk>;
 				clocks = <&lpfll_clk>;
 				clock-div = <1>;
 				#clock-cells = <0>;
@@ -117,6 +123,13 @@
 				compatible = "fixed-factor-clock";
 				clocks = <&core_clk>;
 				clock-div = <4>;
+				#clock-cells = <0>;
+			};
+
+			soscdiv2_clk: soscdiv2_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&sosc_clk>;
+				clock-div = <0>;
 				#clock-cells = <0>;
 			};
 

--- a/dts/arm/nxp/kinetis/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_ke1xz.dtsi
@@ -24,7 +24,7 @@
 
 		cpu0: cpu@0 {
 			compatible = "arm,cortex-m0+";
-			clock-frequency = <DT_FREQ_M(48)>;
+			clock-frequency = <DT_FREQ_M(72)>;
 			reg = <0>;
 			cpu-power-states = <&idle &pstop2 &pstop1 &stop>;
 		};
@@ -113,7 +113,6 @@
 
 			core_clk: core_clk {
 				compatible = "fixed-factor-clock";
-                                #clocks = <&firc_clk>;
 				clocks = <&lpfll_clk>;
 				clock-div = <1>;
 				#clock-cells = <0>;

--- a/samples/drivers/led/pwm/boards/frdm_ke15z.conf
+++ b/samples/drivers/led/pwm/boards/frdm_ke15z.conf
@@ -1,0 +1,3 @@
+# FTM on KE15Z tops out at ~1048 ms period (SOSC 8 MHz / prescaler 128).
+# led_blink(on, off) = total period, so cap each delay at ~500 ms.
+CONFIG_BLINK_DELAY_LONG=500

--- a/samples/drivers/led/pwm/boards/frdm_ke17z.conf
+++ b/samples/drivers/led/pwm/boards/frdm_ke17z.conf
@@ -1,0 +1,3 @@
+# FTM on KE17Z tops out at ~1048 ms period (SOSC 8 MHz / prescaler 128).
+# led_blink(on, off) = total period, so cap each delay at ~500 ms.
+CONFIG_BLINK_DELAY_LONG=500

--- a/samples/drivers/led/pwm/boards/frdm_ke17z512.conf
+++ b/samples/drivers/led/pwm/boards/frdm_ke17z512.conf
@@ -1,0 +1,3 @@
+# FTM on KE17Z512 tops out at ~1048 ms period (SOSC 8 MHz / prescaler 128).
+# led_blink(on, off) = total period, so cap each delay at ~500 ms.
+CONFIG_BLINK_DELAY_LONG=500

--- a/samples/drivers/led/pwm/tests.yaml
+++ b/samples/drivers/led/pwm/tests.yaml
@@ -9,7 +9,7 @@ tests:
     platform_exclude: reel_board
     integration_platforms:
       - frdm_k22f
-    timeout: 20
+    timeout: 60
     harness: console
     harness_config:
       type: multi_line

--- a/soc/nxp/kinetis/ke1xz/soc.c
+++ b/soc/nxp/kinetis/ke1xz/soc.c
@@ -89,7 +89,7 @@ ASSERT_ASYNC_CLK_DIV_VALID(SCG_CLOCK_DIV(soscdiv2_clk), "Invalid SCG SOSC divide
 static const scg_sosc_config_t scg_sosc_config = {
 	.freq = DT_PROP(SCG_CLOCK_NODE(sosc_clk), clock_frequency),
 	.monitorMode = kSCG_SysOscMonitorDisable,
-	.enableMode = kSCG_SysOscEnable | kSCG_SysOscEnableInLowPower,
+	.enableMode = kSCG_SysOscEnable | kSCG_SysOscEnableInLowPower | kSCG_SysOscEnableErClk,
 	.div2 = TO_ASYNC_CLK_DIV(SCG_CLOCK_DIV(soscdiv2_clk)),
 	.workMode = DT_PROP(DT_INST(0, nxp_kinetis_scg), sosc_mode)};
 #endif

--- a/tests/drivers/comparator/gpio_loopback/boards/frdm_ke17z.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/frdm_ke17z.overlay
@@ -1,15 +1,10 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor
- * Copyright 2026 NXP
- *
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKE15Z256VLL7-pinctrl.h>
-#include <zephyr/dt-bindings/gpio/gpio.h>
-
 /*
- * PTA1 looped back to PTA0 (Arduino J4-4 to J4-2 on FRDM-KE15Z).
+ * PTA1 looped back to PTA0 (Arduino J4-10 to J4-12 on FRDM-KE17Z).
  */
 
 / {

--- a/tests/drivers/comparator/gpio_loopback/boards/frdm_ke17z512.overlay
+++ b/tests/drivers/comparator/gpio_loopback/boards/frdm_ke17z512.overlay
@@ -1,15 +1,10 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor
- * Copyright 2026 NXP
- *
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <nxp/kinetis/MKE15Z256VLL7-pinctrl.h>
-#include <zephyr/dt-bindings/gpio/gpio.h>
-
 /*
- * PTA1 looped back to PTA0 (Arduino J4-4 to J4-2 on FRDM-KE15Z).
+ * PTA8 looped back to PTA0 (MikroBus J5-2 to J5-1 on FRDM-KE17Z512).
  */
 
 / {
@@ -18,7 +13,7 @@
 	};
 
 	zephyr,user {
-		test-gpios = <&gpioa 1 GPIO_ACTIVE_HIGH>;
+		test-gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/tests/drivers/comparator/gpio_loopback/tests.yaml
+++ b/tests/drivers/comparator/gpio_loopback/tests.yaml
@@ -20,6 +20,8 @@ tests:
   drivers.comparator.gpio_loopback.mcux_acmp:
     platform_allow:
       - frdm_ke15z
+      - frdm_ke17z
+      - frdm_ke17z512
       - frdm_mcxe247
       - frdm_imxrt1186/mimxrt1186/cm33
       - frdm_imxrt1186/mimxrt1186/cm7

--- a/tests/drivers/dma/chan_blen_transfer/boards/frdm_ke15z.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/frdm_ke15z.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &edma {};

--- a/tests/drivers/dma/chan_link_transfer/boards/frdm_ke15z.overlay
+++ b/tests/drivers/dma/chan_link_transfer/boards/frdm_ke15z.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &edma {};

--- a/tests/drivers/dma/loop_transfer/boards/frdm_ke15z.conf
+++ b/tests/drivers/dma/loop_transfer/boards/frdm_ke15z.conf
@@ -1,0 +1,3 @@
+# KE15Z has only 24 KB SRAM. Default 8 KB buffers × 5 = 40 KB won't fit.
+# 1 KB × 5 = 5 KB keeps the test within reach.
+CONFIG_DMA_LOOP_TRANSFER_SIZE=1024

--- a/tests/drivers/dma/loop_transfer/boards/frdm_ke15z.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/frdm_ke15z.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+tst_dma0: &edma {};

--- a/tests/drivers/pwm/pwm_api/boards/frdm_ke15z.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/frdm_ke15z.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &ftm2;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/tests.yaml
+++ b/tests/drivers/pwm/pwm_api/tests.yaml
@@ -13,8 +13,9 @@ tests:
       - userspace
 
     extra_args:
-      - platform:frdm_ke17z:DTC_OVERLAY_FILE="boards/frdm_ke1xz_flexio_pwm.overlay"
-      - platform:frdm_ke17z512:DTC_OVERLAY_FILE="boards/frdm_ke1xz_flexio_pwm.overlay"
+      - platform:frdm_ke15z/mke15z7:DTC_OVERLAY_FILE="boards/frdm_ke1xz_flexio_pwm.overlay"
+      - platform:frdm_ke17z/mke17z7:DTC_OVERLAY_FILE="boards/frdm_ke1xz_flexio_pwm.overlay"
+      - platform:frdm_ke17z512/mke17z9:DTC_OVERLAY_FILE="boards/frdm_ke1xz_flexio_pwm.overlay"
       - platform:mimxrt700_evk/mimxrt798s/cm33_cpu0:DTC_OVERLAY_FILE="boards/mimxrt700_evk_mimxrt798s_cm33_cpu0_flexio_pwm.overlay"
       - platform:mimxrt1180_evk/mimxrt1189/cm33:DTC_OVERLAY_FILE="boards/mimxrt1180_evk_flexio_pwm.overlay"
       - platform:mimxrt1180_evk/mimxrt1189/cm7:DTC_OVERLAY_FILE="boards/mimxrt1180_evk_flexio_pwm.overlay"
@@ -25,6 +26,7 @@ tests:
       - platform:frdm_imxrt1186/mimxrt1186/cm33:DTC_OVERLAY_FILE="boards/frdm_imxrt1186_flexio_pwm.overlay"
       - platform:frdm_imxrt1186/mimxrt1186/cm7:DTC_OVERLAY_FILE="boards/frdm_imxrt1186_flexio_pwm.overlay"
     platform_allow:
+      - frdm_ke15z
       - frdm_ke17z
       - frdm_ke17z512
       - mimxrt700_evk/mimxrt798s/cm33_cpu0

--- a/tests/drivers/pwm/pwm_loopback/boards/frdm_ke15z.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/frdm_ke15z.overlay
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * To test this sample, connect
+ * PTA15 (Arduino D10) ---> PTE2 (Arduino D11)
+ */
+
+&pinctrl {
+	ftm1_default: ftm1_default {
+		group0 {
+			pinmux = <FTM1_CH2_PTA15>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
+
+	pwt_default: pwt_default {
+		group0 {
+			pinmux = <PWT_IN3_PTE2>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
+};
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&ftm1 2 0 PWM_POLARITY_NORMAL>, /* PTA15 Arduino D10 */
+		       <&pwt 3 0 PWM_POLARITY_NORMAL>;  /* PTE2  Arduino D11 */
+	};
+};
+
+&ftm1 {
+	status = "okay";
+	compatible = "nxp,ftm-pwm";
+	clocks = <&scg KINETIS_SCG_SOSC_CLK>;
+	prescaler = <128>;
+	#pwm-cells = <3>;
+	pinctrl-0 = <&ftm1_default>;
+	pinctrl-names = "default";
+	clock-source = "fixed";
+};
+
+&pwt {
+	status = "okay";
+	prescaler = <32>;
+	pinctrl-0 = <&pwt_default>;
+	pinctrl-names = "default";
+};

--- a/tests/drivers/pwm/pwm_loopback/boards/frdm_ke17z.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/frdm_ke17z.overlay
@@ -38,12 +38,12 @@
 &ftm0 {
 	status = "okay";
 	compatible = "nxp,ftm-pwm";
-	clocks = <&scg KINETIS_SCG_SIRC_CLK>;
+	clocks = <&scg KINETIS_SCG_SOSC_CLK>;
 	prescaler = <128>;
 	#pwm-cells = <3>;
 	pinctrl-0 = <&ftm0_default>;
 	pinctrl-names = "default";
-	clock-source = "system";
+	clock-source = "fixed";
 };
 
 &pwt {
@@ -51,14 +51,4 @@
 	prescaler = <32>;
 	pinctrl-0 = <&pwt_default>;
 	pinctrl-names = "default";
-};
-
-&scg {
-	core_clk {
-		clocks = <&sirc_clk>;
-	};
-
-	bus_clk {
-		clock-div = <2>;
-	};
 };

--- a/tests/drivers/pwm/pwm_loopback/boards/frdm_ke17z512.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/frdm_ke17z512.overlay
@@ -38,12 +38,12 @@
 &ftm0 {
 	status = "okay";
 	compatible = "nxp,ftm-pwm";
-	clocks = <&scg KINETIS_SCG_SIRC_CLK>;
+	clocks = <&scg KINETIS_SCG_SOSC_CLK>;
 	prescaler = <128>;
 	#pwm-cells = <3>;
 	pinctrl-0 = <&ftm0_default>;
 	pinctrl-names = "default";
-	clock-source = "system";
+	clock-source = "fixed";
 };
 
 &pwt {
@@ -51,14 +51,4 @@
 	prescaler = <32>;
 	pinctrl-0 = <&pwt_default>;
 	pinctrl-names = "default";
-};
-
-&scg {
-	core_clk {
-		clocks = <&sirc_clk>;
-	};
-
-	bus_clk {
-		clock-div = <2>;
-	};
 };

--- a/tests/drivers/uart/uart_async_api/boards/frdm_ke15z.conf
+++ b/tests/drivers/uart/uart_async_api/boards/frdm_ke15z.conf
@@ -1,0 +1,5 @@
+# KE15Z has only 24 KB SRAM. Default TEST_LONG_BUFFER_SIZE=1024 plus
+# ~50 test-side buffers + ZTEST framework overflows RAM. Trim to fit.
+CONFIG_TEST_LONG_BUFFER_SIZE=128
+CONFIG_MAIN_STACK_SIZE=1024
+CONFIG_ZTEST_STACK_SIZE=1024

--- a/tests/drivers/uart/uart_async_api/boards/frdm_ke17z.conf
+++ b/tests/drivers/uart/uart_async_api/boards/frdm_ke17z.conf
@@ -1,0 +1,5 @@
+# KE17Z has only 32 KB SRAM. Default TEST_LONG_BUFFER_SIZE=1024 plus
+# ~50 test-side buffers + ZTEST framework overflows RAM. Trim to fit.
+CONFIG_TEST_LONG_BUFFER_SIZE=256
+CONFIG_MAIN_STACK_SIZE=1024
+CONFIG_ZTEST_STACK_SIZE=1024

--- a/tests/drivers/uart/uart_async_api/tests.yaml
+++ b/tests/drivers/uart/uart_async_api/tests.yaml
@@ -73,6 +73,8 @@ tests:
     extra_args:
       - platform:frdm_k82f/mk82f25615:"DTC_OVERLAY_FILE=nxp/dut_lpuart0_loopback.overlay"
       - platform:frdm_ke15z/mke15z7:"DTC_OVERLAY_FILE=nxp/dut_lpuart0_loopback.overlay"
+      - platform:frdm_ke17z/mke17z7:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay"
+      - platform:frdm_ke17z512/mke17z9:"DTC_OVERLAY_FILE=nxp/dut_lpuart0_loopback.overlay"
       - platform:frdm_mcxa156/mcxa156:"DTC_OVERLAY_FILE=nxp/dut_lpuart1.overlay"
       - platform:frdm_mcxe247/mcxe247:"DTC_OVERLAY_FILE=nxp/dut_lpuart1.overlay"
       - platform:frdm_mcxa153/mcxa153:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay;nxp/enable_edma0.overlay"

--- a/tests/drivers/uart/uart_async_api/tests.yaml
+++ b/tests/drivers/uart/uart_async_api/tests.yaml
@@ -72,6 +72,7 @@ tests:
       - CONFIG_TEST_USERSPACE=n
     extra_args:
       - platform:frdm_k82f/mk82f25615:"DTC_OVERLAY_FILE=nxp/dut_lpuart0_loopback.overlay"
+      - platform:frdm_ke15z/mke15z7:"DTC_OVERLAY_FILE=nxp/dut_lpuart0_loopback.overlay"
       - platform:frdm_mcxa156/mcxa156:"DTC_OVERLAY_FILE=nxp/dut_lpuart1.overlay"
       - platform:frdm_mcxe247/mcxe247:"DTC_OVERLAY_FILE=nxp/dut_lpuart1.overlay"
       - platform:frdm_mcxa153/mcxa153:"DTC_OVERLAY_FILE=nxp/dut_lpuart2_loopback.overlay;nxp/enable_edma0.overlay"


### PR DESCRIPTION
frdm_ke15z: Enabled flash/acmp/edma/flexio/pwt/ftm drivers
frdm_ke17z/ke17z512: Enabled uart_async_api and comparator driver tests.
ke1xz: Fixed cpu core frequency - from 48MHz to 72MHz for ke15z/ke17z and 96MHz for ke17z512 with lpfll clock source
ke1xz: Enabled SOSC clock source which is required in FTM driver