### PR TITLE
video: bugfix `video_driver_set_stream()`

### DIFF
--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -513,7 +513,7 @@ static inline int video_driver_set_stream(const struct device *dev, bool enable,
 		return -ENOSYS;
 	}
 
-	return api->set_stream(dev, true, type);
+	return api->set_stream(dev, enable, type);
 }
 
 /**


### PR DESCRIPTION
The refactor in #112420 introduced `video_driver_set_stream()` which takes a bool `enable` param, but doesn't actually pass it to the underlying call. This PR makes the trivial fix.

I observed this bug to prevent stopping a camera stream on my ESP32-S3 + OV3660 camera. With the fix applied, it works.

(Wooooo, I'm climbing another rung up the ladder from pure documentation nit-picks--#110180--to a one-line easy bugfix! I'll be a maintainer before you know it!)