### PR TITLE
drivers: timer: esp32: wake the LP timer at or before the deadline

### DIFF
--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -128,7 +128,15 @@ void sys_clock_idle_enter(uint32_t ticks)
 		return;
 	}
 
-	uint64_t timeout_us = ((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+	/* The deadline is tick-aligned but the LP timer starts counting here,
+	 * mid-tick, so a period of the full `ticks` would wake up to one tick
+	 * after the deadline; in deep sleep the LP timer is the only wake
+	 * source, so that is a timeout served late. Shorten the period by one
+	 * tick so the wake lands at or before the deadline instead; the floor
+	 * conversion rounds the same safe way.
+	 */
+	uint32_t lp_ticks = (ticks > 0U) ? (ticks - 1U) : 0U;
+	uint64_t timeout_us = k_ticks_to_us_floor64(lp_ticks);
 
 	lptim_pre_idle = esp32_lptim_hook_on_lpm_entry(timeout_us);
 	systimer_pre_idle = get_systimer_alarm();


### PR DESCRIPTION
Follow-up promised in the #112750 review, where Holt-Sun spotted the behaviour change: `sys_clock_idle_enter()` programs the low-power timer with the full requested tick count, but the LP timer starts counting at idle entry, mid-tick, while the deadline sits on a tick boundary, so the wake lands up to one tick after the deadline. In deep sleep the LP timer is the only wake source, so that is a timeout served late.

The pre-conversion driver derived the LP period from its clamped `(ticks - 1)` value and so woke up to one tick early instead, trading a sliver of extra wake time for never missing the deadline. Restore that bound by shortening the LP period by one tick, using `k_ticks_to_us_floor64()` whose floor rounding errs the same safe way.

Build-verified on all eight PM-enabled ESP32 configurations of `samples/boards/espressif/light_sleep` plus a non-PM build. I have no ESP32 hardware to measure the deep-sleep wake timing on, so a check from the Espressif side would be welcome.