### PR TITLE
dts/boards: atmel/microchip: migrate flash partitions to zephyr,mapped-partition

### DIFF
--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 Justin Watson
  * Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
  * Copyright (c) 2020 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -170,15 +171,16 @@ zephyr_udc0: &usbhs {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * The first half of sector 0 (64 kbytes)
 		 * is reserved for the bootloader
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 0x00010000>;
 			read-only;
@@ -186,18 +188,21 @@ zephyr_udc0: &usbhs {
 
 		/* From sector 1 to sector 7 (included): slot0 (896 kbytes) */
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 0x000e0000>;
 		};
 
 		/* From sector 8 to sector 14 (included): slot1 (896 kbytes) */
 		slot1_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00100000 0x000e0000>;
 		};
 
 		/* Sector 15: scratch (128 kbytes) */
 		scratch_partition: partition@1e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x001e0000 0x00020000>;
 		};

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 Justin Watson
  * Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
  * Copyright (c) 2019-2024 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -315,15 +316,16 @@ zephyr_udc0: &usbhs {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * The first half of sector 0 (64 kbytes)
 		 * is reserved for the bootloader
 		 */
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 0x00010000>;
 			read-only;
@@ -331,18 +333,21 @@ zephyr_udc0: &usbhs {
 
 		/* From sector 1 to sector 7 (included): slot0 (896 kbytes) */
 		slot0_partition: partition@20000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00020000 0x000e0000>;
 		};
 
 		/* From sector 8 to sector 14 (included): slot1 (896 kbytes) */
 		slot1_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00100000 0x000e0000>;
 		};
 
 		/* Sector 15: scratch (128 kbytes) */
 		scratch_partition: partition@1e0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-scratch";
 			reg = <0x001e0000 0x00020000>;
 		};

--- a/boards/atmel/sam0/samc21n_xpro/samc21n_xpro.dts
+++ b/boards/atmel/sam0/samc21n_xpro/samc21n_xpro.dts
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2022 Kamil Serwus
  * # Copyright (c) 2024-2025 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -151,9 +152,9 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * The final 16 KiB is reserved for the application.
@@ -161,6 +162,7 @@
 		 * if enabled.
 		 */
 		storage_partition: partition@3c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0003c000 0x00004000>;
 		};

--- a/boards/atmel/sam0/samd20_xpro/samd20_xpro.dts
+++ b/boards/atmel/sam0/samd20_xpro/samd20_xpro.dts
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018 Sean Nyekjaer
  * # Copyright (c) 2024-2025 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -108,9 +109,9 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * The final 16 KiB is reserved for the application.
@@ -118,6 +119,7 @@
 		 * if enabled.
 		 */
 		storage_partition: partition@3c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0003c000 0x00004000>;
 		};

--- a/boards/atmel/sam0/same54_xpro/same54_xpro.dts
+++ b/boards/atmel/sam0/same54_xpro/same54_xpro.dts
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019 Benjamin Valentin
  * # Copyright (c) 2024-2025 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -198,9 +199,9 @@ zephyr_udc0: &usb0 {
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * The final 16 KiB is reserved for the application.
@@ -208,6 +209,7 @@ zephyr_udc0: &usb0 {
 		 * if enabled.
 		 */
 		storage_partition: partition@fc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x000fc000 0x00004000>;
 		};

--- a/boards/atmel/sam0/samr21_xpro/samr21_xpro.dts
+++ b/boards/atmel/sam0/samr21_xpro/samr21_xpro.dts
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019 Benjamin Valentin
  * Copyright (c) 2019-2025 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -233,9 +234,9 @@ ext2_i2c: &sercom1 {};
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * The final 16 KiB is reserved for the application.
@@ -243,6 +244,7 @@ ext2_i2c: &sercom1 {};
 		 * if enabled.
 		 */
 		storage_partition: partition@3c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0003c000 0x00004000>;
 		};

--- a/boards/microchip/ev11l78a/ev11l78a.dts
+++ b/boards/microchip/ev11l78a/ev11l78a.dts
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -87,9 +88,9 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		/*
 		 * The final 16 KiB is reserved for the application.
@@ -97,6 +98,7 @@
 		 * if enabled.
 		 */
 		storage_partition: partition@c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <DT_SIZE_K(64-16) DT_SIZE_K(16)>;
 		};

--- a/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.dts
+++ b/boards/microchip/pic32c/pic32cm_jh01_cnano/pic32cm_jh01_cnano.dts
@@ -47,11 +47,12 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		storage_partition: partition@7c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0007c000 0x4000>;
 		};

--- a/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
+++ b/boards/microchip/pic32c/pic32cm_jh01_cpro/pic32cm_jh01_cpro.dts
@@ -60,11 +60,12 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		storage_partition: partition@7c000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x0007c000 0x4000>;
 		};

--- a/boards/microchip/pic32c/pic32cm_pl10_cnano/pic32cm_pl10_cnano.dts
+++ b/boards/microchip/pic32c/pic32cm_pl10_cnano/pic32cm_pl10_cnano.dts
@@ -37,17 +37,20 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
 			reg = <0x0 DT_SIZE_K(60)>;
 		};
 
-		storage_partition: partition@bfff000 {
+		storage_partition: partition@f000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x0bfff000 DT_SIZE_K(4)>;
+			reg = <0xf000 DT_SIZE_K(4)>;
 		};
 	};
 };

--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -80,25 +80,32 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
-
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "mcuboot";
 			reg = <0x00000000 0x00010000>;  /* 64 KB bootloader */
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
 			reg = <0x00010000 0x00070000>;  /* 448 KB primary app slot */
 		};
 
 		slot1_partition: partition@80000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-1";
 			reg = <0x00080000 0x00070000>;  /* 448 KB secondary app slot */
 		};
 
 		storage_partition: partition@f0000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
 			reg = <0x000f0000 0x00010000>;  /* 64 KB storage area */
 		};
 	};

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -80,25 +80,32 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
-
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "mcuboot";
 			reg = <0x00000000 0x00010000>;  /* 64 KB bootloader */
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
 			reg = <0x00010000 0x00070000>;  /* 448 KB primary app slot */
 		};
 
 		slot1_partition: partition@80000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-1";
 			reg = <0x00080000 0x00070000>;  /* 448 KB secondary app slot */
 		};
 
 		storage_partition: partition@f0000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
 			reg = <0x000f0000 0x00010000>;  /* 64 KB storage area */
 		};
 	};

--- a/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
+++ b/boards/microchip/pic32c/pic32cz_ca80_cult/pic32cz_ca80_cult.dts
@@ -60,13 +60,14 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		storage_partition: partition@7fc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x0007fc000 0x4000>;
+			reg = <0x007fc000 0x4000>;
 		};
 	};
 };

--- a/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.dts
+++ b/boards/microchip/pic32c/pic32cz_ca90_cult/pic32cz_ca90_cult.dts
@@ -60,13 +60,14 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		storage_partition: partition@7fc000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
-			reg = <0x0007fc000 0x4000>;
+			reg = <0x007fc000 0x4000>;
 		};
 	};
 };

--- a/boards/microchip/sam/sam_e54_cult/sam_e54_cult.dts
+++ b/boards/microchip/sam/sam_e54_cult/sam_e54_cult.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -60,24 +60,32 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "mcuboot";
 			reg = <0x00000000 0x00010000>;  /* 64 KB bootloader */
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
 			reg = <0x00010000 0x00070000>;  /* 448 KB primary app slot */
 		};
 
 		slot1_partition: partition@80000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-1";
 			reg = <0x00080000 0x00070000>;  /* 448 KB secondary app slot */
 		};
 
 		storage_partition: partition@f0000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
 			reg = <0x000f0000 0x00010000>;  /* 64 KB storage area */
 		};
 	};

--- a/boards/microchip/sam/sam_e54_xpro/sam_e54_xpro.dts
+++ b/boards/microchip/sam/sam_e54_xpro/sam_e54_xpro.dts
@@ -157,24 +157,32 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "mcuboot";
 			reg = <0x00000000 0x00010000>;  /* 64 KB bootloader */
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-0";
 			reg = <0x00010000 0x00070000>;  /* 448 KB primary app slot */
 		};
 
 		slot1_partition: partition@80000 {
+			compatible = "zephyr,mapped-partition";
+			label = "image-1";
 			reg = <0x00080000 0x00070000>;  /* 448 KB secondary app slot */
 		};
 
 		storage_partition: partition@f0000 {
+			compatible = "zephyr,mapped-partition";
+			label = "storage";
 			reg = <0x000f0000 0x00010000>;  /* 64 KB storage area */
 		};
 	};

--- a/boards/peregrine/sam4l_wm400_cape/sam4l_wm400_cape.dts
+++ b/boards/peregrine/sam4l_wm400_cape/sam4l_wm400_cape.dts
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2025 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2026 Microchip Technology Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -71,16 +72,18 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "sam-ba";
-			reg = <0x000000000 0x00004000>;
+			reg = <0x00000000 0x00004000>;
 		};
 
 		code_partition: partition@4000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image";
 			reg = <0x00004000 0x0003c000>;
 		};

--- a/boards/sparkfun/samd21_dev_breakout/sparkfun_samd21_breakout.dts
+++ b/boards/sparkfun/samd21_dev_breakout/sparkfun_samd21_breakout.dts
@@ -1,5 +1,6 @@
 /*
  * Copyright The Zephyr Project Contributors
+ * Copyright (c) 2026 Microchip Technology Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -103,9 +104,9 @@ zephyr_udc0: &usb0 {
 
 &flash0 {
 	partitions {
-		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
 			compatible = "zephyr,mapped-partition";

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2025 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -68,12 +69,16 @@
 			interrupts = <0 0>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 
 				write-block-size = <8>;
 				erase-block-size = <512>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
 			};
 
 			/*

--- a/dts/arm/atmel/samc2x.dtsi
+++ b/dts/arm/atmel/samc2x.dtsi
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2022 Kamil Serwus
  * Copyright (c) 2024-2025 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -79,7 +80,7 @@
 				write-block-size = <4>;
 				#address-cells = <1>;
 				#size-cells = <1>;
-				/* reg and ranges are specified in samx2xx1x dtsi */
+				ranges;
 			};
 		};
 

--- a/dts/arm/atmel/samd2x.dtsi
+++ b/dts/arm/atmel/samd2x.dtsi
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017 Google LLC.
  * Copyright (c) 2024-2025 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -79,7 +80,7 @@
 				write-block-size = <4>;
 				#address-cells = <1>;
 				#size-cells = <1>;
-				/* reg and ranges are specified in samx2xx1x dtsi */
+				ranges;
 			};
 		};
 

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019 ML!PA Consulting GmbH
  * Copyright (c) 2024-2025 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -119,6 +120,7 @@
 
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			lock-regions = <32>;
 
@@ -126,6 +128,9 @@
 				compatible = "soc-nv-flash";
 
 				write-block-size = <8>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
 			};
 		};
 

--- a/dts/arm/atmel/samx7x.dtsi
+++ b/dts/arm/atmel/samx7x.dtsi
@@ -2,6 +2,7 @@
  * Copyright (c) 2017 Piotr Mienkowski
  * Copyright (c) 2017 Justin Watson
  * Copyright (c) 2026 Gerson Fernando Budke <nandojve@gmail.com>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -366,11 +367,14 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			#erase-block-cells = <2>;
+			ranges;
 
 			flash0: flash@400000 {
 				compatible = "atmel,sam-flash", "soc-nv-flash";
 				write-block-size = <16>;
 				erase-block-size = <8192>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 

--- a/dts/arm/atmel/samx7xx19.dtsi
+++ b/dts/arm/atmel/samx7xx19.dtsi
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019 Gerson Fernando Budke
  * Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +17,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(512)>;
+				ranges = <0x0 0x400000 DT_SIZE_K(512)>;
 				erase-blocks = <&eefc 8 2048>, <&eefc 62 8192>;
 			};
 		};

--- a/dts/arm/atmel/samx7xx20.dtsi
+++ b/dts/arm/atmel/samx7xx20.dtsi
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019 Gerson Fernando Budke
  * Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +17,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(1024)>;
+				ranges = <0x0 0x400000 DT_SIZE_K(1024)>;
 				erase-blocks = <&eefc 8 2048>, <&eefc 126 8192>;
 			};
 		};

--- a/dts/arm/atmel/samx7xx21.dtsi
+++ b/dts/arm/atmel/samx7xx21.dtsi
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019 Gerson Fernando Budke
  * Copyright (c) 2020 Stephanos Ioannidis <root@stephanos.io>
+ * Copyright (c) 2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +17,7 @@
 		flash-controller@400e0c00 {
 			flash0: flash@400000 {
 				reg = <0x00400000 DT_SIZE_K(2048)>;
+				ranges = <0x0 0x400000 DT_SIZE_K(2048)>;
 				erase-blocks = <&eefc 8 2048>, <&eefc 254 8192>;
 			};
 		};

--- a/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_jh/common/pic32cm_jh.dtsi
@@ -40,6 +40,9 @@
 		flash0: flash@0 {
 			compatible = "soc-nv-flash";
 			write-block-size = <4>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
 		};
 
 		nvm_sw_calib_area: nvm-sw-calib-area@806020 {

--- a/dts/arm/microchip/pic32c/pic32cm_pl/common/pic32cm_pl.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cm_pl/common/pic32cm_pl.dtsi
@@ -28,6 +28,7 @@
 			write-block-size = <4>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges = <0x0 0xc000000 DT_SIZE_K(64)>;
 		};
 
 		sram0: memory@20000000 {

--- a/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cx_sg/common/pic32cx_sg.dtsi
@@ -219,6 +219,7 @@
 			lock-regions = <32>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 			status = "okay";
 
 			flash0: flash@0 {
@@ -226,6 +227,9 @@
 				reg = <0x0 DT_SIZE_K(1024)>;
 				write-block-size = <8>;
 				erase-block-size = <8192>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
 			};
 
 			userrow: nvmuserrow@804000 {

--- a/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_1051_ca.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_1051_ca.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +8,7 @@
 	soc {
 		flash0: flash@8000000 {
 			reg = <0x08000000 DT_SIZE_M(1)>;
+			ranges = <0x0 0x8000000 DT_SIZE_M(1)>;
 		};
 
 		sram0: memory@20000000 {

--- a/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_2051_ca.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_2051_ca.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +8,7 @@
 	soc {
 		flash0: flash@8000000 {
 			reg = <0x08000000 DT_SIZE_M(2)>;
+			ranges = <0x0 0x8000000 DT_SIZE_M(2)>;
 		};
 
 		sram0: memory@20000000 {

--- a/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_4010_ca.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_4010_ca.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +8,7 @@
 	soc {
 		flash0: flash@8000000 {
 			reg = <0x08000000 DT_SIZE_M(4)>;
+			ranges = <0x0 0x8000000 DT_SIZE_M(4)>;
 		};
 
 		sram0: memory@20000000 {

--- a/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_8110_ca.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_8110_ca.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Microchip Technology Inc.
+ * Copyright (c) 2025-2026 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +8,7 @@
 	soc {
 		flash0: flash@8000000 {
 			reg = <0x08000000 DT_SIZE_M(8)>;
+			ranges = <0x0 0x8000000 DT_SIZE_M(8)>;
 		};
 
 		sram0: memory@20000000 {

--- a/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca.dtsi
+++ b/dts/arm/microchip/pic32c/pic32cz_ca/common/pic32cz_ca.dtsi
@@ -31,6 +31,8 @@
 		flash0: flash@8000000 {
 			compatible = "soc-nv-flash";
 			write-block-size = <8>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 		};
 
 		sram0: memory@20000000 {

--- a/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi
+++ b/dts/arm/microchip/sam/sam_d5x_e5x/common/samd5xe5x.dtsi
@@ -212,11 +212,15 @@
 			lock-regions = <32>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 				write-block-size = <8>;
 				erase-block-size = <8192>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
 			};
 
 			userrow: nvmuserrow@804000 {


### PR DESCRIPTION
**Summary**

- Migrate `flash-partitions` to `zephyr,mapped-partition` compatible on `Atmel/Microchip` boards
- Add required `ranges` property to flash nodes for partition to physical address translation

Fixes #107737