### PR TITLE
drivers: emul: Move extern C below include files

### DIFF
--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -15,10 +15,6 @@
  * @{
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 struct emul;
 
 /* #includes required after forward-declaration of struct emul later defined in this header. */
@@ -30,6 +26,10 @@ struct emul;
 #include <zephyr/drivers/mspi_emul.h>
 #include <zephyr/drivers/uart_emul.h>
 #include <zephyr/sys/iterable_sections.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * The types of supported buses.

--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -21,10 +21,6 @@
  * @{
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 struct emul;
 
 /* #includes required after forward-declaration of struct emul later defined in this header. */
@@ -36,6 +32,10 @@ struct emul;
 #include <zephyr/drivers/mspi_emul.h>
 #include <zephyr/drivers/uart_emul.h>
 #include <zephyr/sys/iterable_sections.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * The types of supported buses.


### PR DESCRIPTION
Include files in emul.h were after ifdef __cplusplus guard which could lead to C++ compilation failure if any of included headers were using C++.