### PR TITLE
drivers: audio: codec_dummy: implement start_output and stop_output

### DIFF
--- a/drivers/audio/codec_dummy.c
+++ b/drivers/audio/codec_dummy.c
@@ -140,8 +140,23 @@ static int dummy_codec_init(const struct device *dev)
 	return 0;
 }
 
+/* The API helpers dereference these without a NULL check, so they must be
+ * provided even though this codec has no output stage.
+ */
+static void dummy_codec_start_output(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+}
+
+static void dummy_codec_stop_output(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+}
+
 static DEVICE_API(audio_codec, dummy_codec_api) = {
 	.configure = dummy_codec_configure,
+	.start_output = dummy_codec_start_output,
+	.stop_output = dummy_codec_stop_output,
 	.set_property = dummy_codec_set_property,
 	.start = dummy_codec_start,
 	.stop = dummy_codec_stop,

--- a/drivers/audio/codec_dummy.c
+++ b/drivers/audio/codec_dummy.c
@@ -132,6 +132,27 @@ static int dummy_codec_write(const struct device *dev, uint8_t *data, size_t dat
 	return 0;
 }
 
+/*
+ * Mandatory ops. This codec has no output stage to gate and no registers to
+ * commit, so they succeed without doing anything.
+ */
+static void dummy_codec_start_output(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+}
+
+static void dummy_codec_stop_output(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+}
+
+static int dummy_codec_apply_properties(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return 0;
+}
+
 static int dummy_codec_init(const struct device *dev)
 {
 	struct dummy_codec_data *data = dev->data;
@@ -142,7 +163,10 @@ static int dummy_codec_init(const struct device *dev)
 
 static DEVICE_API(audio_codec, dummy_codec_api) = {
 	.configure = dummy_codec_configure,
+	.start_output = dummy_codec_start_output,
+	.stop_output = dummy_codec_stop_output,
 	.set_property = dummy_codec_set_property,
+	.apply_properties = dummy_codec_apply_properties,
 	.start = dummy_codec_start,
 	.stop = dummy_codec_stop,
 	.write = dummy_codec_write,


### PR DESCRIPTION
`audio_codec_start_output()` and `audio_codec_stop_output()` call through
  `api->start_output` / `api->stop_output` with no NULL check, unlike the nine
  other ops in `codec.h` which all guard. The API therefore treats these two as
  mandatory, but `codec_dummy` does not implement them, so any caller jumps to
  address 0.

  Reproduced on native_sim:

  #0  0x0000000000000000 in ?? ()
  #1  audio_codec_start_output (dev=...) at include/zephyr/audio/codec.h:435
  #2  mp_zaud_i2s_codec_sink_chainfn (...) at subsys/mp/plugins/zaud/mp_zaud_i2s_codec_sink.c:423

  This adds empty implementations, which is the minimum a codec with no output
  stage can provide.

  That said, the opposite fix may be better: make both optional in `codec.h` like
  the other nine. A codec with no distinct output stage has nothing meaningful to
  implement, and requiring stubs pushes the same boilerplate onto every minimal
  or emulated codec driver. Happy to switch this PR to that if maintainers prefer
  it.
