### PR TITLE
drivers: crypto: stm32_hash: enlarge support for STM32C5 series

### DIFF
--- a/drivers/crypto/crypto_stm32_hash.c
+++ b/drivers/crypto/crypto_stm32_hash.c
@@ -73,6 +73,16 @@ static int stm32_hash_handler(struct hash_ctx *ctx, struct hash_pkt *pkt, bool f
 	case CRYPTO_HASH_ALGO_SHA256:
 		hash_cfg.algorithm = HAL_HASH_ALGO_SHA256;
 		break;
+#if DT_INST_PROP(0, st_has_sha384_algorithm)
+	case CRYPTO_HASH_ALGO_SHA384:
+		hash_cfg.algorithm = HAL_HASH_ALGO_SHA384;
+		break;
+#endif /* DT_INST_PROP(0, st_has_sha384_algorithm) */
+#if DT_INST_PROP(0, st_has_sha512_algorithm)
+	case CRYPTO_HASH_ALGO_SHA512:
+		hash_cfg.algorithm = HAL_HASH_ALGO_SHA512;
+		break;
+#endif /* DT_INST_PROP(0, st_has_sha512_algorithm) */
 	default:
 		k_sem_give(&data->device_sem);
 		LOG_ERR("Unsupported algorithm in handler: %d", session->algo);
@@ -105,6 +115,18 @@ static int stm32_hash_handler(struct hash_ctx *ctx, struct hash_pkt *pkt, bool f
 		status = HAL_HASHEx_SHA256_Start(&data->hhash, pkt->in_buf, pkt->in_len,
 						 pkt->out_buf, HAL_MAX_DELAY);
 		break;
+#if DT_INST_PROP(0, st_has_sha384_algorithm)
+	case CRYPTO_HASH_ALGO_SHA384:
+		status = HAL_HASHEx_SHA384_Start(&data->hhash, pkt->in_buf, pkt->in_len,
+						 pkt->out_buf, HAL_MAX_DELAY);
+		break;
+#endif /* DT_INST_PROP(0, st_has_sha384_algorithm) */
+#if DT_INST_PROP(0, st_has_sha512_algorithm)
+	case CRYPTO_HASH_ALGO_SHA512:
+		status = HAL_HASHEx_SHA512_Start(&data->hhash, pkt->in_buf, pkt->in_len,
+						 pkt->out_buf, HAL_MAX_DELAY);
+		break;
+#endif /* DT_INST_PROP(0, st_has_sha512_algorithm) */
 	default:
 		k_sem_give(&data->device_sem);
 		LOG_ERR("Unsupported algorithm in handler: %d", session->algo);
@@ -132,6 +154,12 @@ static int stm32_hash_begin_session(const struct device *dev, struct hash_ctx *c
 	switch (algo) {
 	case CRYPTO_HASH_ALGO_SHA224:
 	case CRYPTO_HASH_ALGO_SHA256:
+#if DT_INST_PROP(0, st_has_sha384_algorithm)
+	case CRYPTO_HASH_ALGO_SHA384:
+#endif /* DT_INST_PROP(0, st_has_sha384_algorithm) */
+#if DT_INST_PROP(0, st_has_sha512_algorithm)
+	case CRYPTO_HASH_ALGO_SHA512:
+#endif /* DT_INST_PROP(0, st_has_sha512_algorithm) */
 		break;
 	default:
 		LOG_ERR("Unsupported hash algorithm: %d", algo);

--- a/dts/arm/st/c5/stm32c591.dtsi
+++ b/dts/arm/st/c5/stm32c591.dtsi
@@ -125,5 +125,10 @@
 			interrupts = <97 0>;
 			status = "disabled";
 		};
+
+		hash: crypto@420c0400 {
+			st,has-sha384-algorithm;
+			st,has-sha512-algorithm;
+		};
 	};
 };

--- a/dts/bindings/crypto/st,stm32-hash.yaml
+++ b/dts/bindings/crypto/st,stm32-hash.yaml
@@ -4,8 +4,8 @@
 title: STM32 HASH Processor
 
 description: |
-  STM32 hardware hash accelerator supporting SHA-224 and SHA-256
-  hashing algorithms.
+  STM32 hardware hash accelerator supporting SHA-224, SHA-256
+  and optionally SHA-384 and SHA-512 hashing algorithms.
 
 compatible: "st,stm32-hash"
 
@@ -20,3 +20,13 @@ properties:
 
   resets:
     required: true
+
+  st,has-sha384-algorithm:
+    type: boolean
+    description: |
+      Support SHA384 algorithm.
+
+  st,has-sha512-algorithm:
+    type: boolean
+    description: |
+      Support SHA512 algorithm.


### PR DESCRIPTION
Some of the MCUs from STM32C5 series support SHA384 and SHA512.