### PR TITLE
soc: nxp: mcxe31x: add SAI (I2S) support

### DIFF
--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b-pinctrl.dtsi
@@ -124,4 +124,23 @@
 			output-enable;
 		};
 	};
+
+	pinmux_sai_0: pinmux_sai_0 {
+		group1 {
+			/* Each entry combines the pad's output mux with its
+			 * own IMCR input path (input buffer enabled), so the
+			 * receiver samples the transmitter's data, bit clock
+			 * and frame sync directly on-pad — TX->RX loopback
+			 * without external wiring:
+			 * PTB2  D0   out (MSCR34 SSS=6)  + RX D0   in (IMCR316)
+			 * PTC12 BCLK out (MSCR76 SSS=7)  + RX BCLK in (IMCR315)
+			 * PTC13 SYNC out (MSCR77 SSS=7)  + RX SYNC in (IMCR321)
+			 */
+			pinmux = <NXP_SIUL2_PINMUX(0, 0, 34, 6, 316, 1)>,
+				 <NXP_SIUL2_PINMUX(0, 0, 76, 7, 315, 1)>,
+				 <NXP_SIUL2_PINMUX(0, 0, 77, 7, 321, 1)>;
+			output-enable;
+			input-enable;
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.dts
@@ -185,6 +185,20 @@
 	status = "okay";
 };
 
+/*
+ * SAI0 on header J1: D0 = PTB2, BCLK = PTC12, SYNC = PTC13. The
+ * transmitter drives all three pads and each pad's input buffer feeds
+ * the receiver back (see pinmux_sai_0), so the receiver runs fully
+ * asynchronous from the looped-back clocks and TX->RX loopback needs
+ * no external wiring.
+ */
+&sai_0 {
+	pinctrl-0 = <&pinmux_sai_0>;
+	pinctrl-names = "default";
+	nxp,tx-channel = <1>;
+	status = "okay";
+};
+
 &gpioc_l {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
@@ -20,5 +20,6 @@ supported:
   - adc
   - hwinfo
   - pwm
+  - i2s
   - spi
 vendor: nxp

--- a/drivers/clock_control/clock_control_nxp_mc_cgm.c
+++ b/drivers/clock_control/clock_control_nxp_mc_cgm.c
@@ -115,6 +115,10 @@ static const struct mc_cgm_gate_entry mc_cgm_gate_map[] = {
 	LISTIFY(MC_CGM_COUNT(FSL_FEATURE_SOC_ADC_COUNT),
 		MC_CGM_GATE_ENTRY, (,), ADC, Adc),
 #endif
+#if defined(CONFIG_I2S_MCUX_SAI) && defined(FSL_FEATURE_SOC_I2S_COUNT)
+	LISTIFY(MC_CGM_COUNT(FSL_FEATURE_SOC_I2S_COUNT),
+		MC_CGM_GATE_ENTRY, (,), SAI, Sai),
+#endif
 };
 
 /*
@@ -156,6 +160,10 @@ static const struct mc_cgm_rate_entry mc_cgm_rate_map[] = {
 #if defined(CONFIG_ADC_NXP_SAR_ADC) && defined(FSL_FEATURE_SOC_ADC_COUNT)
 	LISTIFY(MC_CGM_COUNT(FSL_FEATURE_SOC_ADC_COUNT),
 		MC_CGM_RATE_ENTRY, (,), ADC, Adc),
+#endif
+#if defined(CONFIG_I2S_MCUX_SAI) && defined(FSL_FEATURE_SOC_I2S_COUNT)
+	LISTIFY(MC_CGM_COUNT(FSL_FEATURE_SOC_I2S_COUNT),
+		MC_CGM_RATE_ENTRY, (,), SAI, Sai),
 #endif
 };
 

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021,2023-2025 NXP
+ * Copyright 2021,2023-2026 NXP
  * All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -114,6 +114,7 @@ struct i2s_mcux_config {
 	void (*irq_connect)(const struct device *dev);
 	sai_sync_mode_t rx_sync_mode;
 	sai_sync_mode_t tx_sync_mode;
+	sai_bclk_source_t bclk_source;
 };
 
 /* Device run time data */
@@ -496,6 +497,7 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 	uint8_t word_size_bytes = word_size_bits / 8;
 	uint8_t num_words = i2s_cfg->channels;
 	sai_transceiver_t config;
+	struct stream *strm;
 	int ret = -EINVAL;
 	uint32_t mclk;
 
@@ -503,17 +505,23 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 		return -ENOSYS;
 	}
 
-	if ((dev_data->tx.state != I2S_STATE_NOT_READY) &&
-	    (dev_data->tx.state != I2S_STATE_READY) &&
-	    (dev_data->rx.state != I2S_STATE_NOT_READY) &&
-	    (dev_data->rx.state != I2S_STATE_READY)) {
-		LOG_ERR("invalid state tx(%u) rx(%u)", dev_data->tx.state, dev_data->rx.state);
-		goto invalid_config;
+	/* only the stream being configured matters here, the other direction
+	 * may well be running
+	 */
+	strm = (dir == I2S_DIR_TX) ? &dev_data->tx : &dev_data->rx;
+
+	if ((strm->state != I2S_STATE_NOT_READY) && (strm->state != I2S_STATE_READY)) {
+		LOG_ERR("invalid state %u", strm->state);
+		return -EINVAL;
 	}
 
 	if (i2s_cfg->frame_clk_freq == 0U) {
-		LOG_ERR("Invalid frame_clk_freq %u", i2s_cfg->frame_clk_freq);
-		goto invalid_config;
+		/* deconfigure the stream: release any queued buffers and
+		 * return the interface to the NOT_READY state
+		 */
+		i2s_purge_stream_buffers(strm, strm->cfg.mem_slab, true, true);
+		strm->state = I2S_STATE_NOT_READY;
+		return 0;
 	}
 
 	if (word_size_bits < SAI_WORD_SIZE_BITS_MIN || word_size_bits > SAI_WORD_SIZE_BITS_MAX) {
@@ -541,8 +549,6 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 	get_mclk_rate(dev, &mclk);
 	LOG_DBG("mclk is %d", mclk);
 
-	/* bit clock source is MCLK */
-	config.bitClock.bclkSource = kSAI_BclkSourceMclkDiv;
 	/*
 	 * additional settings for bclk
 	 * read the SDK header file for more details
@@ -592,6 +598,11 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 		ret = -EINVAL;
 		goto invalid_config;
 	}
+
+	/* The SAI_Get*Config() helpers above reset the bit clock source to
+	 * the master clock divider; honor the devicetree selection instead.
+	 */
+	config.bitClock.bclkSource = dev_cfg->bclk_source;
 
 	/* sync mode configurations */
 	if (dir == I2S_DIR_TX) {
@@ -719,12 +730,16 @@ invalid_config:
 const struct i2s_config *i2s_mcux_config_get(const struct device *dev, enum i2s_dir dir)
 {
 	struct i2s_dev_data *dev_data = dev->data;
+	struct stream *strm = (dir == I2S_DIR_RX) ? &dev_data->rx : &dev_data->tx;
 
-	if (dir == I2S_DIR_RX) {
-		return &dev_data->rx.cfg;
+	/* the i2s API expects NULL for a stream that is not configured, so
+	 * that the leftover configuration is not mistaken for a live one
+	 */
+	if (strm->state == I2S_STATE_NOT_READY) {
+		return NULL;
 	}
 
-	return &dev_data->tx.cfg;
+	return &strm->cfg;
 }
 
 static int i2s_tx_stream_start(const struct device *dev)
@@ -789,6 +804,11 @@ static int i2s_tx_stream_start(const struct device *dev)
 		LOG_ERR("dma_start failed (%d)", ret);
 		return ret;
 	}
+
+	/* reset the FIFO pointers, which may hold stale words from a
+	 * previous run of the stream
+	 */
+	base->TCSR |= I2S_TCSR_FR_MASK;
 
 	/* Enable DMA enable bit */
 	SAI_TxEnableDMA(base, kSAI_FIFORequestDMAEnable, true);
@@ -889,6 +909,11 @@ static int i2s_rx_stream_start(const struct device *dev)
 		LOG_ERR("Failed to start DMA Ch%d (%d)", strm->dma_channel, ret);
 		return ret;
 	}
+
+	/* reset the FIFO pointers, which may hold stale words from a
+	 * previous run of the stream
+	 */
+	base->RCSR |= I2S_RCSR_FR_MASK;
 
 	/* Enable DMA enable bit */
 	SAI_RxEnableDMA(base, kSAI_FIFORequestDMAEnable, true);
@@ -1282,6 +1307,7 @@ static DEVICE_API(i2s, i2s_mcux_driver_api) = {
 		.rx_sync_mode =                                                                    \
 			DT_INST_PROP(i2s_id, nxp_rx_sync_mode) ? kSAI_ModeSync : kSAI_ModeAsync,   \
 		.tx_channel = DT_INST_PROP(i2s_id, nxp_tx_channel),                                \
+		.bclk_source = DT_INST_PROP(i2s_id, nxp_bclk_source),                              \
 	};                                                                                         \
                                                                                                    \
 	static struct i2s_dev_data i2s_##i2s_id##_data = {                                         \

--- a/dts/arm/nxp/mcx/nxp_mcxe31x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxe31x_common.dtsi
@@ -893,16 +893,34 @@
 	};
 
 	sai_0: sai@36c000 {
-		compatible = "nxp,sai";
+		compatible = "nxp,mcux-i2s";
 		reg = <0x36c000 0x100>;
 		interrupts = <174 0>;
+		clocks = <&mc_cgm MCUX_SAI0_CLK>;
+		dmas = <&edma 3 55>, <&edma 4 56>;
+		dma-names = "rx", "tx";
+		nxp,rx-dma-channel = <3>;
+		nxp,tx-dma-channel = <4>;
+		nxp,bclk-source = <0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		#pinmux-cells = <2>;
 		status = "disabled";
 	};
 
 	sai_1: sai@4dc000 {
-		compatible = "nxp,sai";
+		compatible = "nxp,mcux-i2s";
 		reg = <0x4dc000 0x100>;
 		interrupts = <175 0>;
+		clocks = <&mc_cgm MCUX_SAI1_CLK>;
+		dmas = <&edma 19 56>, <&edma 20 57>;
+		dma-names = "rx", "tx";
+		nxp,rx-dma-channel = <19>;
+		nxp,tx-dma-channel = <20>;
+		nxp,bclk-source = <0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		#pinmux-cells = <2>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/i2s/nxp,mcux-i2s.yaml
+++ b/dts/bindings/i2s/nxp,mcux-i2s.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021,2023-2025 NXP
+# Copyright 2021,2023-2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP mcux SAI-I2S controller
@@ -64,6 +64,17 @@ properties:
   clock-mux:
     type: int
     description: Clock mux source for SAI root clock
+
+  nxp,bclk-source:
+    type: int
+    default: 1
+    enum: [0, 1, 2, 3]
+    description: |
+      Bit clock source (TCR2/RCR2 MSEL). 0 = bus clock, 1 = master clock
+      divider / MCLK option 1, 2/3 = MCLK option 2/3 or other SAI. Defaults
+      to 1, the master clock divider, which matches the i.MX-family SAI
+      clocking. SoCs without an internal master clock divider and no MCLK
+      routing (e.g. MCXE31x) must select the bus clock (0).
 
   mclk-output:
     type: boolean

--- a/soc/nxp/mcx/mcxe/mcxe31x/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxe/mcxe31x/Kconfig.defconfig
@@ -20,4 +20,9 @@ config CORTEX_M_SYSTICK
 config ROM_START_OFFSET
 	default 0x1000
 
+# The MC_CGM clock driver cannot program an audio PLL; the SAI driver
+# derives the bit clock from the SAI module clock instead.
+config I2S_HAS_PLL_SETTING
+	default n
+
 endif # SOC_SERIES_MCXE31X

--- a/tests/drivers/i2s/i2s_api/tests.yaml
+++ b/tests/drivers/i2s/i2s_api/tests.yaml
@@ -6,6 +6,7 @@ tests:
       - userspace
     filter: not CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
     platform_exclude:
+      - frdm_mcxe31b/mcxe31b
       - frdm_mcxn947/mcxn947/cpu0
       - mcx_n9xx_evk/mcxn947/cpu0
       - mimxrt595_evk/mimxrt595s/cm33

--- a/tests/drivers/i2s/i2s_speed/boards/frdm_mcxe31b.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/frdm_mcxe31b.overlay
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * SAI0 loops TX back to RX on the PTB2 pad itself (see pinmux_sai_0 in
+ * the board pinctrl), so this test runs without external wiring.
+ */
+/ {
+	aliases {
+		i2s-node0 = &sai_0;
+	};
+};


### PR DESCRIPTION
Add SAI (I2S) support for MCXE31x and enable SAI0 on FRDM-MCXE31B.

- `clock_control: nxp_mc_cgm`: SAI gate/rate clock entries
- `i2s: mcux_sai`: stream deconfiguration per the i2s API, FIFO
  pointer reset on stream start, and a new `nxp,bclk-source` binding
  property (defaults to the master clock divider, so existing users
  are unaffected) for SoCs whose SAI bit clock derives from the bus
  clock
- `soc: mcxe31x`: real `nxp,mcux-i2s` nodes with clocks and eDMA
  channels, `I2S_HAS_PLL_SETTING=n`
- `boards: frdm_mcxe31b`: SAI0 on header J1; each pad's input path is
  looped back on-pad, so TX-to-RX loopback needs no external wiring
- `tests: drivers: i2s`: i2s_speed overlay for the board

Testing: `tests/drivers/i2s/i2s_speed` on FRDM-MCXE31B — all eight
sample-rate cases pass with no external connections; default-config
regression checked (`hello_world` selection signature unchanged).
