### PR TITLE
soc: espressif: esp32p4: fix CLIC mcause restore on trap exit

### DIFF
--- a/soc/espressif/esp32p4/soc_irq.S
+++ b/soc/espressif/esp32p4/soc_irq.S
@@ -30,28 +30,21 @@ SECTION_FUNC(exception.other, __soc_handle_irq)
 /*
  * ESP32-P4 CLIC context save/restore.
  *
- * On CLIC, mret restores mintstatus.mil from mcause.mpil ONLY when
- * mcause.interrupt (bit 31) is set. With RISCV_ALWAYS_SWITCH_THROUGH_ECALL,
- * context switches use ecall which saves mcause with bit 31 clear. When
- * this mcause is restored before mret, the hardware skips mil restore,
- * leaving it stuck at the ISR level and blocking same-level interrupts.
+ * On CLIC, mret restores mintstatus.mil from mcause.mpil only when
+ * mcause.interrupt (bit 31) is set. On ESP32-P4, an mret whose
+ * mcause.interrupt does not match the current trap's entry type corrupts
+ * the CLIC state: after a mismatched mret out of an exception-entered
+ * trap (e.g. ecall-based context switch), the illegal-instruction
+ * exception is never delivered again.
  *
- * Save: clear mpil for exceptions so mret restores mil to 0.
- * Restore: force bit 31 so mret always restores mil from mpil.
- *
- * Same workaround as Nuclei ECLIC (soc/gd/gd32/gd32vf103/soc_irq.S).
+ * Hence mcause.interrupt is forced to match the entry type: cleared on
+ * exception entry (mil is already 0), set on interrupt entry, with mpil
+ * cleared for exception-saved frames so they resume at mil 0.
  */
 
 SECTION_FUNC(exception.other, __soc_save_context)
 
 	csrr t0, mcause
-	bltz t0, 1f
-	/* Exception path: zero out mcause.mpil (bits [23:16]) so the
-	 * subsequent mret restores mintstatus.mil to 0.
-	 */
-	li t1, 0xFF00FFFF
-	and t0, t0, t1
-1:
 	sw t0, __soc_esf_t_mcause_OFFSET(a0)
 #ifdef SOC_HAS_MINTTHRESH
 	/* Save mintthresh (CSR 0x347): per-context interrupt threshold. */
@@ -68,10 +61,20 @@ SECTION_FUNC(exception.other, __soc_restore_context)
 	csrw 0x347, t0
 #endif
 	lw t0, __soc_esf_t_mcause_OFFSET(a0)
-	/* Force mcause.interrupt (bit 31) so mret reloads mintstatus.mil
-	 * from mcause.mpil regardless of the saved trap type.
+	/* live mcause = entry type of this trap */
+	csrr t2, mcause
+	bltz t2, 1f
+	/* Exception-entered: keep mcause.interrupt clear; mil stays 0. */
+	li t1, ~RISCV_MCAUSE_IRQ_BIT
+	and t0, t0, t1
+	j 2f
+1:	/* Interrupt-entered: set mcause.interrupt so mret reloads
+	 * mil from mpil; exception-saved frames resume at mil 0.
 	 */
-	li t1, 1 << RISCV_MCAUSE_IRQ_POS
+	bltz t0, 2f
+	li t1, 0xFF00FFFF
+	and t0, t0, t1
+	li t1, RISCV_MCAUSE_IRQ_BIT
 	or t0, t0, t1
-	csrw mcause, t0
+2:	csrw mcause, t0
 	ret


### PR DESCRIPTION
On ESP32-P4, an mret whose mcause.interrupt bit does not match the way the current trap was entered corrupts the CLIC internal state: after a mismatched mret out of an exception-entered trap (e.g. the ecall used for context switches), the illegal-instruction exception is never delivered again and the core stalls at the faulting instruction. This also makes CONFIG_FPU_SHARING unusable, as lazy FPU context switching depends on that exact exception.

The previous code forced mcause.interrupt on every restore so that mret would reload mintstatus.mil, which created exactly this mismatch for every exception-entered trap.

Restore mcause.interrupt to match the trap entry type instead: cleared when the trap was entered via an exception (mil is already 0 and stays unchanged), set when entered via an interrupt, with mpil cleared for exception-saved frames so they resume at interrupt level 0 while interrupt-saved frames keep their preemption level.

Verified on ESP32-P4 rev v3.1: illegal instruction traps correctly in threads (mcause=2 fatal dump), tests/kernel/fpu_sharing/generic passes (previously hung at test_load_store), and interrupt levels are restored correctly across preemption-driven context switches.

Fixes #114028