### PR TITLE
samples: sensor: sensor_shell: Use CONFIG_QEMU_ICOUNT=n for all qemus

### DIFF
--- a/samples/sensor/sensor_shell/boards/qemu_riscv64_qemu_virt_riscv64.conf
+++ b/samples/sensor/sensor_shell/boards/qemu_riscv64_qemu_virt_riscv64.conf
@@ -1,8 +1,3 @@
 CONFIG_SHELL_STACK_SIZE=4096
 CONFIG_SHELL_BACKEND_SERIAL_TX_RING_BUFFER_SIZE=1024
 CONFIG_SHELL_PRINTF_BUFF_SIZE=256
-# The interrupt-driven shell cannot echo the next command within the harness's
-# 1 s timeout while draining the large "sensor get" burst under QEMU icount
-# mode, which advances virtual time slowly in wall-clock terms. Disable icount
-# so the guest runs at host speed, matching the already-passing smp variant.
-CONFIG_QEMU_ICOUNT=n

--- a/samples/sensor/sensor_shell/tests.yaml
+++ b/samples/sensor/sensor_shell/tests.yaml
@@ -22,7 +22,13 @@ tests:
     extra_configs:
       - arch:posix:CONFIG_UART_NATIVE_PTY_0_ON_STDINOUT=y
       - platform:iotdk/arc_iot:CONFIG_ARC_IOT_CUSTOM_CPU_IDLE=y
-    extra_args: DTC_OVERLAY_FILE=fake_sensor.overlay
+    extra_args:
+      - DTC_OVERLAY_FILE=fake_sensor.overlay
+      # The interrupt-driven shell cannot echo the next command within the harness's
+      # 1 s timeout while draining the large "sensor get" burst under QEMU icount
+      # mode, which advances virtual time slowly in wall-clock terms. Disable icount
+      # so the guest runs at host speed.
+      - simulation:qemu:CONFIG_QEMU_ICOUNT=n
     integration_platforms:
       - native_sim
   sample.sensor.shell.shields:


### PR DESCRIPTION
Use setting used so far for qemu_riscv64 for all qemu's as it was failing on other qemu targets as well.

Reverted b7c552fe336b1 which was applying this setting only for riscv64 QEMU.
