### PR TITLE
MAINTAINERS: ti: mspm: add Aman-Lachhiramka-ti as collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5959,6 +5959,7 @@ TI MSPM Platforms:
     - glneo
   collaborators:
     - d-philpot
+    - Aman-Lachhiramka-ti
   files:
     - soc/ti/mspm/
     - boards/ti/*mspm*/


### PR DESCRIPTION
Add myself as collaborator for TI MSPM Platforms.
Contributed initial MSPM33C Cortex-M33 SoC, DTS, and board support to upstream Zephyr and existing mspm0 support.
Plan to continue contributing to platform driver improvements and MSPM0 and MSPM33 peripheral enablement.

Merged contributions:
  - #111577 add MSPM33C Cortex-M33 initial support
  - #113223 boards: ti: lp_mspm0l2228: Add GPTIMER counter support
  - #102007 drivers: pinctrl: mspm0: Add validation for pin configurations
  - #102773 manifest: update hal_ti revision
  - hal_ti https://github.com/zephyrproject-rtos/hal_ti/pull/81



Open:
  - #113204 drivers: counter: ti: mspm0: Convert to native register access
  - #112498 drivers: pinctrl: ti: mspm0: convert to native register writes
  - hal_ti https://github.com/zephyrproject-rtos/hal_ti/pull/91 hal: ti: dts: restructure pinctrl dtsi
 
