### PR TITLE
drivers: led: lp5562: fix off states using maximum brightness

### DIFF
--- a/drivers/led/lp5562.c
+++ b/drivers/led/lp5562.c
@@ -791,8 +791,7 @@ static int lp5562_led_blink(const struct device *dev, uint32_t led,
 		return ret;
 	}
 
-	ret = lp5562_program_set_brightness(dev, engine, ++command_index,
-			LED_BRIGHTNESS_MAX);
+	ret = lp5562_program_set_brightness(dev, engine, ++command_index, 0);
 	if (ret) {
 		return ret;
 	}
@@ -882,7 +881,7 @@ static inline int lp5562_led_off(const struct device *dev, uint32_t led)
 		}
 	}
 
-	return lp5562_led_set_brightness(dev, led, LED_BRIGHTNESS_MAX);
+	return lp5562_led_set_brightness(dev, led, LED_BRIGHTNESS_MIN);
 }
 
 static int lp5562_led_update_current(const struct device *dev)

--- a/drivers/led/lp5562.c
+++ b/drivers/led/lp5562.c
@@ -791,8 +791,7 @@ static int lp5562_led_blink(const struct device *dev, uint32_t led,
 		return ret;
 	}
 
-	ret = lp5562_program_set_brightness(dev, engine, ++command_index,
-			LED_BRIGHTNESS_MAX);
+	ret = lp5562_program_set_brightness(dev, engine, ++command_index, 0);
 	if (ret) {
 		return ret;
 	}
@@ -882,7 +881,7 @@ static inline int lp5562_led_off(const struct device *dev, uint32_t led)
 		}
 	}
 
-	return lp5562_led_set_brightness(dev, led, LED_BRIGHTNESS_MAX);
+	return lp5562_led_set_brightness(dev, led, 0);
 }
 
 static int lp5562_led_update_current(const struct device *dev)


### PR DESCRIPTION
Commit 62c1fb209760 replaced both minimum-brightness uses with
LED_BRIGHTNESS_MAX, so turning an LED off and the off phase of a blink
program set full brightness instead. Use 0, the minimum brightness the
LED API defines.

- https://github.com/zephyrproject-rtos/zephyr/commit/62c1fb209760976a2c924fe69bf4e2da16a2be00#diff-9065a24ffaa8146df26e0bdb4fd98fa939111c0bad27554298524c5b27b3c1c8R804
- https://github.com/zephyrproject-rtos/zephyr/commit/62c1fb209760976a2c924fe69bf4e2da16a2be00#diff-9065a24ffaa8146df26e0bdb4fd98fa939111c0bad27554298524c5b27b3c1c8R894