### PR TITLE
drivers: input: Add touch_input_common

### DIFF
--- a/drivers/input/input_chsc6x.c
+++ b/drivers/input/input_chsc6x.c
@@ -24,6 +24,8 @@ struct chsc6x_config {
 	chsc6x_read_data_fn read_data;
 };
 
+INPUT_TOUCH_STRUCT_CHECK(struct chsc6x_config);
+
 struct chsc6x_data {
 	const struct device *dev;
 	struct k_work work;

--- a/drivers/input/input_cst8xx.c
+++ b/drivers/input/input_cst8xx.c
@@ -11,6 +11,7 @@
 
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/input/input.h>
+#include <zephyr/input/input_touch.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/logging/log.h>
@@ -89,6 +90,7 @@ LOG_MODULE_REGISTER(cst8xx, CONFIG_INPUT_LOG_LEVEL);
 
 /** cst8xx configuration (DT). */
 struct cst8xx_config {
+	struct input_touchscreen_common_config common;
 	struct i2c_dt_spec i2c;
 	const struct gpio_dt_spec rst_gpio;
 #ifdef CONFIG_INPUT_CST8XX_INTERRUPT
@@ -107,6 +109,8 @@ struct cst8xx_config {
 	} lp_profile;
 #endif
 };
+
+INPUT_TOUCH_STRUCT_CHECK(struct cst8xx_config);
 
 /** cst8xx data. */
 struct cst8xx_data {
@@ -169,8 +173,7 @@ static int cst8xx_process(const struct device *dev)
 	LOG_DBG("event: %d, row: %d, col: %d", event, row, col);
 
 	if (pressed) {
-		input_report_abs(dev, INPUT_ABS_X, col, false, K_FOREVER);
-		input_report_abs(dev, INPUT_ABS_Y, row, false, K_FOREVER);
+		input_touchscreen_report_pos(dev, col, row, K_FOREVER);
 		input_report_key(dev, INPUT_BTN_TOUCH, 1, true, K_FOREVER);
 	} else {
 		input_report_key(dev, INPUT_BTN_TOUCH, 0, true, K_FOREVER);
@@ -402,13 +405,15 @@ static int cst8xx_pm_action(const struct device *dev, enum pm_device_action acti
 
 /* clang-format off */
 #define CST8XX_DEFINE(index)                                                                       \
+	PM_DEVICE_DT_INST_DEFINE(index, cst8xx_pm_action);                                         \
 	static struct cst8xx_data cst8xx_data_##index;                                             \
 	static const struct cst8xx_config cst8xx_config_##index = {                                \
+		.common = INPUT_TOUCH_DT_INST_COMMON_CONFIG_INIT(index),                           \
 		.i2c = I2C_DT_SPEC_INST_GET(index),                                                \
 		.rst_gpio = GPIO_DT_SPEC_INST_GET_OR(index, rst_gpios, {}),                        \
 		IF_ENABLED(CONFIG_INPUT_CST8XX_INTERRUPT,                                          \
 				(.int_gpio = GPIO_DT_SPEC_INST_GET(index, irq_gpios),))            \
-				 IF_ENABLED(CONFIG_PM_DEVICE,                                      \
+		IF_ENABLED(CONFIG_PM_DEVICE,                                                      \
 				(.lp_profile = {                                                   \
 					.auto_wake_time_min = DT_INST_PROP(index, auto_wake_time), \
 					.scan_th = DT_INST_PROP(index, scan_th),                   \
@@ -416,11 +421,9 @@ static int cst8xx_pm_action(const struct device *dev, enum pm_device_action acti
 					.scan_freq = DT_INST_PROP(index, scan_freq),               \
 					.scan_i_dac = DT_INST_PROP(index, scan_i_dac),             \
 					.auto_sleep_time_s = DT_INST_PROP(index, auto_sleep_time), \
-			},)) };                                                                    \
-                                                                                                   \
-	PM_DEVICE_DT_INST_DEFINE(index, cst8xx_pm_action);                                         \
-                                                                                                   \
-	DEVICE_DT_INST_DEFINE(index, cst8xx_init, PM_DEVICE_DT_INST_GET(index),                    \
+				},))                                                         \
+	};                                                                           \
+	DEVICE_DT_INST_DEFINE(index, cst8xx_init, PM_DEVICE_DT_INST_GET(index),                \
 			      &cst8xx_data_##index, &cst8xx_config_##index, POST_KERNEL,           \
 			      CONFIG_INPUT_INIT_PRIORITY, NULL);
 

--- a/drivers/input/input_ili2132a.c
+++ b/drivers/input/input_ili2132a.c
@@ -9,6 +9,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/input/input.h>
+#include <zephyr/input/input_touch.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/sys/byteorder.h>
 
@@ -27,10 +28,13 @@ struct ili2132a_data {
 };
 
 struct ili2132a_config {
+	struct input_touchscreen_common_config common;
 	struct i2c_dt_spec i2c;
 	struct gpio_dt_spec rst;
 	struct gpio_dt_spec irq;
 };
+
+INPUT_TOUCH_STRUCT_CHECK(struct ili2132a_config);
 
 static void gpio_isr(const struct device *dev, struct gpio_callback *cb, uint32_t pin)
 {
@@ -55,8 +59,7 @@ static void ili2132a_process(const struct device *dev)
 	if (buf[TIP] & IS_TOUCHED_BIT) {
 		x = sys_get_le16(&buf[X_COORD]);
 		y = sys_get_le16(&buf[Y_COORD]);
-		input_report_abs(dev, INPUT_ABS_X, x, false, K_FOREVER);
-		input_report_abs(dev, INPUT_ABS_Y, y, false, K_FOREVER);
+		input_touchscreen_report_pos(dev, x, y, K_FOREVER);
 		input_report_key(dev, INPUT_BTN_TOUCH, 1, true, K_FOREVER);
 	} else {
 		input_report_key(dev, INPUT_BTN_TOUCH, 0, true, K_FOREVER);
@@ -129,6 +132,7 @@ static int ili2132a_init(const struct device *dev)
 }
 #define ILI2132A_INIT(index)                                                                       \
 	static const struct ili2132a_config ili2132a_config_##index = {                            \
+		.common = INPUT_TOUCH_DT_INST_COMMON_CONFIG_INIT(index),                           \
 		.i2c = I2C_DT_SPEC_INST_GET(index),                                                \
 		.rst = GPIO_DT_SPEC_INST_GET(index, rst_gpios),                                    \
 		.irq = GPIO_DT_SPEC_INST_GET(index, irq_gpios),                                    \

--- a/drivers/input/input_xpt2046.c
+++ b/drivers/input/input_xpt2046.c
@@ -8,12 +8,14 @@
 
 #include <zephyr/drivers/spi.h>
 #include <zephyr/input/input.h>
+#include <zephyr/input/input_touch.h>
 #include <zephyr/kernel.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(xpt2046, CONFIG_INPUT_LOG_LEVEL);
 
 struct xpt2046_config {
+	const struct input_touchscreen_common_config common;
 	const struct spi_dt_spec bus;
 	const struct gpio_dt_spec int_gpio;
 	uint16_t min_x;
@@ -35,6 +37,8 @@ struct xpt2046_data {
 	uint32_t last_y;
 	bool pressed;
 };
+
+INPUT_TOUCH_STRUCT_CHECK(struct xpt2046_config);
 
 enum xpt2046_channel {
 	CH_TEMP0 = 0,
@@ -170,8 +174,7 @@ static void xpt2046_work_handler(struct k_work *kw)
 	if (pressed) {
 		LOG_DBG("raw: x=%4u y=%4u ==> x=%4d y=%4d", meas.x, meas.y, x, y);
 
-		input_report_abs(data->dev, INPUT_ABS_X, x, false, K_FOREVER);
-		input_report_abs(data->dev, INPUT_ABS_Y, y, false, K_FOREVER);
+		input_touchscreen_report_pos(data->dev, x, y, K_FOREVER);
 		input_report_key(data->dev, INPUT_BTN_TOUCH, 1, true, K_FOREVER);
 
 		data->last_x = x;
@@ -247,6 +250,7 @@ static int xpt2046_init(const struct device *dev)
 		.screen_size_x = DT_INST_PROP(index, touchscreen_size_x),                          \
 		.screen_size_y = DT_INST_PROP(index, touchscreen_size_y),                          \
 		.reads = DT_INST_PROP(index, reads),                                               \
+		.common = INPUT_TOUCH_DT_INST_COMMON_CONFIG_INIT(index),                           \
 	};                                                                                         \
 	static struct xpt2046_data xpt2046_data_##index;                                           \
 	DEVICE_DT_INST_DEFINE(index, xpt2046_init, NULL, &xpt2046_data_##index,                    \

--- a/dts/bindings/input/hynitron,cst8xx.yaml
+++ b/dts/bindings/input/hynitron,cst8xx.yaml
@@ -5,7 +5,7 @@ description: Hynitron CST8XX touchscreen sensor
 
 compatible: "hynitron,cst8xx"
 
-include: i2c-device.yaml
+include: [i2c-device.yaml, touchscreen-common.yaml]
 
 properties:
   irq-gpios:

--- a/dts/bindings/input/ilitek,ili2132a.yaml
+++ b/dts/bindings/input/ilitek,ili2132a.yaml
@@ -5,7 +5,7 @@ description: ILI2132A capacitive touch controller
 
 compatible: "ilitek,ili2132a"
 
-include: i2c-device.yaml
+include: [i2c-device.yaml, touchscreen-common.yaml]
 
 properties:
   irq-gpios:

--- a/dts/bindings/input/xptek,xpt2046.yaml
+++ b/dts/bindings/input/xptek,xpt2046.yaml
@@ -4,7 +4,7 @@
 description: Driver for XPT2046 touch IC
 compatible: "xptek,xpt2046"
 
-include: spi-device.yaml
+include: [spi-device.yaml, touchscreen-common.yaml]
 
 properties:
   int-gpios:


### PR DESCRIPTION
Adds to the drivers a touch_input_common struct to allow for coordinate space manipulation.