### PR TITLE
drivers: audio: wm8904 add input pga configuration

### DIFF
--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -24,6 +24,7 @@ struct wm8904_driver_config {
 	const struct device *mclk_dev;
 	clock_control_subsys_t mclk_name;
 	int fs_ratio;
+	int in_pga_sel;
 };
 
 struct wm8904_driver_data {
@@ -731,8 +732,10 @@ static void wm8904_configure_output(const struct device *dev)
 
 static void wm8904_configure_input(const struct device *dev)
 {
-	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_LEFT, 2);
-	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_RIGHT, 2);
+	const struct wm8904_driver_config *const dev_cfg = DEV_CFG(dev);
+
+	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_LEFT, dev_cfg->in_pga_sel);
+	wm8904_route_input(dev, AUDIO_CHANNEL_FRONT_RIGHT, dev_cfg->in_pga_sel);
 
 	wm8904_in_volume_config(dev, AUDIO_CHANNEL_ALL, WM8904_INPUT_VOLUME_DEFAULT);
 	wm8904_in_mute_config(dev, AUDIO_CHANNEL_ALL, false);
@@ -758,7 +761,8 @@ static DEVICE_API(audio_codec, wm8904_driver_api) = {
 		.mclk_name = COND_CODE_1(DT_INST_CLOCKS_HAS_NAME(n, mclk),                         \
 			((clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(n, mclk, name)),      \
 			(NULL)),                                                                   \
-		.fs_ratio = DT_INST_PROP_OR(n, fs_ratio, 0)};                                      \
+		.fs_ratio = DT_INST_PROP_OR(n, fs_ratio, 0),                                       \
+		.in_pga_sel = DT_INST_PROP_OR(n, input_pga_select, 2)};                            \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, NULL, NULL, &wm8904_device_data_##n, &wm8904_device_config_##n,   \
 			      POST_KERNEL, CONFIG_AUDIO_CODEC_INIT_PRIORITY, &wm8904_driver_api);

--- a/dts/bindings/audio/wolfson,wm8904.yaml
+++ b/dts/bindings/audio/wolfson,wm8904.yaml
@@ -33,3 +33,10 @@ properties:
       On such platforms, the driver assumes the MCLK frequency to be equal
       to (fs-ratio * <sample rate>), where the sample rate comes from the
       audio codec configuration provided at runtime.
+  input-pga-select:
+    type: int
+    enum: [1, 2, 3]
+    description: |
+      Selects the WM8904 input PGA source channel.
+      Only single-ended input mode is supported.
+      On the 32-pin QFN package, only channels 1 and 2 are supported.


### PR DESCRIPTION
Add a devicetree property to configure the WM8904 input PGA source channel.

The selected channel is used when configuring the analog input path. For the 32-pin QFN package, only input channels 1 and 2 are valid because the IN3L/IN3R pins are not exposed. The driver currently supports single-ended input mode only