### PR TITLE
mgmt: ec_host_cmd: shi_ite: Switch pinctrl states during device PM

### DIFF
--- a/dts/riscv/ite/it8xxx2-pinctrl-map.dtsi
+++ b/dts/riscv/ite/it8xxx2-pinctrl-map.dtsi
@@ -454,6 +454,27 @@
 		pinmuxs = <&pinctrlm 5 IT8XXX2_ALT_FUNC_1>;
 	};
 
+	/* SHI tri-state alternate function */
+	/omit-if-no-ref/ shi_mosi_gpm0_sleep: shi_mosi_gpm0_sleep {
+		pinmuxs = <&pinctrlm 0 IT8XXX2_ALT_DEFAULT>;
+		bias-high-impedance;
+	};
+
+	/omit-if-no-ref/ shi_miso_gpm1_sleep: shi_miso_gpm1_sleep {
+		pinmuxs = <&pinctrlm 1 IT8XXX2_ALT_DEFAULT>;
+		bias-high-impedance;
+	};
+
+	/omit-if-no-ref/ shi_clk_gpm4_sleep: shi_clk_gpm4_sleep {
+		pinmuxs = <&pinctrlm 4 IT8XXX2_ALT_DEFAULT>;
+		bias-high-impedance;
+	};
+
+	/omit-if-no-ref/ shi_cs_gpm5_sleep: shi_cs_gpm5_sleep {
+		pinmuxs = <&pinctrlm 5 IT8XXX2_ALT_DEFAULT>;
+		bias-high-impedance;
+	};
+
 	/* Tachometer alternate function */
 	/omit-if-no-ref/ tach0a_gpd6_default: tach0a_gpd6_default {
 		pinmuxs = <&pinctrld 6 IT8XXX2_ALT_FUNC_1>;

--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_ite.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_ite.c
@@ -511,14 +511,27 @@ PINCTRL_DT_INST_DEFINE(0);
 #ifdef CONFIG_PM_DEVICE
 static int shi_ite_pm_cb(const struct device *dev, enum pm_device_action action)
 {
+	const struct shi_it8xxx2_cfg *cfg = dev->config;
 	struct shi_it8xxx2_data *data = dev->data;
-	int ret = 0;
+	int ret;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
 		shi_ite_set_state(data, SHI_STATE_DISABLED);
+
+		ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
+		if (ret < 0) {
+			LOG_ERR("%s: Failed to configure gpio pins", dev->name);
+			return ret;
+		}
 		break;
 	case PM_DEVICE_ACTION_RESUME:
+		ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			LOG_ERR("%s: Failed to configure SHI pins", dev->name);
+			return ret;
+		}
+
 		shi_ite_set_state(data, SHI_STATE_READY_TO_RECV);
 		break;
 	default:
@@ -526,12 +539,15 @@ static int shi_ite_pm_cb(const struct device *dev, enum pm_device_action action)
 		break;
 	}
 
-	return ret;
+	return 0;
 }
 #endif
 
 /* Assume only one peripheral */
 PM_DEVICE_DT_INST_DEFINE(0, shi_ite_pm_cb);
+
+BUILD_ASSERT(!IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) || IS_ENABLED(CONFIG_PM_DEVICE_SYSTEM_MANAGED),
+	     "CONFIG_PM_DEVICE_SYSTEM_MANAGED must be enabled when using CONFIG_PM_DEVICE_RUNTIME");
 
 static const struct ec_host_cmd_backend_api ec_host_cmd_api = {
 	.init = shi_ite_backend_init,


### PR DESCRIPTION
Apply the default pinctrl state during PM_DEVICE_ACTION_RESUME to restore normal SHI operation.
Apply the sleep pinctrl state during PM_DEVICE_ACTION_SUSPEND to disable the SHI interface pins and prevent leakage.

This lets board/shim code control the pin state purely via pm_device_runtime_get()/put().