### PR TITLE
samples: sensor: sensor_shell: fix pytest timeout on mps3/an536/cpu0

### DIFF
--- a/samples/sensor/sensor_shell/boards/mps3_an536_cpu0.conf
+++ b/samples/sensor/sensor_shell/boards/mps3_an536_cpu0.conf
@@ -1,0 +1,9 @@
+CONFIG_SHELL_STACK_SIZE=4096
+CONFIG_SHELL_BACKEND_SERIAL_TX_RING_BUFFER_SIZE=1024
+CONFIG_SHELL_PRINTF_BUFF_SIZE=256
+# This board defaults to QEMU icount mode (CONFIG_QEMU_ICOUNT=y,
+# QEMU_ICOUNT_SHIFT=7), which advances virtual time slowly in wall-clock terms.
+# The interrupt-driven shell then cannot drain the large "sensor get" burst and
+# echo the next command within the harness's wall-clock timeouts, so the test
+# times out. Disable icount so the guest runs at host speed.
+CONFIG_QEMU_ICOUNT=n


### PR DESCRIPTION
## Problem

`sample.sensor.shell.pytest` fails with a **test timeout** on `mps3/an536/cpu0` (seen in CI, e.g. #112988).

`mps3/an536/cpu0` is a QEMU target that defaults to icount mode (`CONFIG_QEMU_ICOUNT=y` via `boards/Kconfig`, with `CONFIG_QEMU_ICOUNT_SHIFT=7` in its defconfig). icount advances *virtual* time (one instruction per 2^7 ns), decoupled from wall-clock. The pytest harness enforces **wall-clock** deadlines (a 1 s command-echo timeout in `shell.py` and the overall test timeout), while `test_sensor_shell_get` / `test_sensor_shell_attr_get` walk every sensor channel and emit a large `sensor get` output burst. Under icount the interrupt-driven shell cannot drain that burst and echo the next command in time, so the guest never keeps up — it does not even reach the shell prompt before timing out.

This is the same icount-slowness class as the qemu_riscv64 fix (#113455), not the qemu_cortex_r5 UART character-corruption case that needs blocking TX.

## Fix

Add a targeted per-board conf (`boards/mps3_an536_cpu0.conf`) that bumps the shell resources and disables icount (`CONFIG_QEMU_ICOUNT=n`), so the guest runs at host speed.

## Verification

Locally, on `mps3/an536/cpu0`:
- **Before:** hard 180 s test timeout (never reaches the shell prompt)
- **After:** 3/3 runs PASSED, ~3 s each
