### PR TITLE
drivers: sensor: tmag5273: fix invalid default ANGLE_EN setting

### DIFF
--- a/drivers/sensor/ti/tmag5273/tmag5273.c
+++ b/drivers/sensor/ti/tmag5273/tmag5273.c
@@ -1078,7 +1078,7 @@ static inline int tmag5273_init_sensor_settings(const struct tmag5273_config *dr
 	case TMAG5273_DT_ANGLE_MAG_NONE:
 		__fallthrough;
 	default:
-		regdata |= TMAG5273_ANGLE_EN_POS;
+		regdata |= TMAG5273_ANGLE_EN_NONE;
 		break;
 	}
 

--- a/dts/bindings/sensor/ti,tmag5273.yaml
+++ b/dts/bindings/sensor/ti,tmag5273.yaml
@@ -39,11 +39,11 @@ properties:
       - 0  # TMAG5273_DT_AXIS_NONE
       - 1  # TMAG5273_DT_AXIS_X
       - 2  # TMAG5273_DT_AXIS_Y
-      - 3  # TMAG5273_DT_AXIS_Z
-      - 4  # TMAG5273_DT_AXIS_XY
-      - 5  # TMAG5273_DT_AXIS_XZ
-      - 6  # TMAG5273_DT_AXIS_YZ
-      - 7  # TMAG5273_DT_AXIS_XYZ
+      - 3  # TMAG5273_DT_AXIS_XY  (TMAG5173_DT_AXIS_X | TMAG5173_DT_AXIS_Y)
+      - 4  # TMAG5273_DT_AXIS_Z
+      - 5  # TMAG5273_DT_AXIS_XZ  (TMAG5173_DT_AXIS_X | TMAG5173_DT_AXIS_Z)
+      - 6  # TMAG5273_DT_AXIS_YZ  (TMAG5173_DT_AXIS_Y | TMAG5173_DT_AXIS_Z)
+      - 7  # TMAG5273_DT_AXIS_XYZ (TMAG5173_DT_AXIS_X | TMAG5173_DT_AXIS_Y | TMAG5173_DT_AXIS_Z)
       - 8  # TMAG5273_DT_AXIS_XYX (pseudo-simultaneous sampling)
       - 9  # TMAG5273_DT_AXIS_YXY (pseudo-simultaneous sampling)
       - 10 # TMAG5273_DT_AXIS_YZY (pseudo-simultaneous sampling)


### PR DESCRIPTION
While using the TMAG5273 driver, I noticed that selecting the low magnetic range had no effect and the device was always configured for the high range.

After tracing the register configuration, I found that the default case of the angle_magnitude_axis switch uses TMAG5273_ANGLE_EN_POS. This value affects bits outside of the ANGLE_EN field and overlaps with the range configuration bits in SENSOR_CONFIG_2, causing the selected range setting to be overwritten.

This change updates the default case to use TMAG5273_ANGLE_EN_NONE, which correctly disables angle calculation without modifying unrelated register fields.

The PR also includes a small update to the devicetree binding documentation (ti,tmag5273.yaml) to correct the documented axis enum values and align them with the values used by the driver.