### PR TITLE
boards: nxp: frdm_mcxe31b: add FlexIO PWM and SPI support

### DIFF
--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b-pinctrl.dtsi
@@ -73,6 +73,26 @@
 		};
 	};
 
+	pinmux_flexio_pwm: pinmux_flexio_pwm {
+		group1 {
+			pinmux = <PTE15_FXIO_D2_O>;
+			output-enable;
+		};
+	};
+
+	pinmux_flexio_spi: pinmux_flexio_spi {
+		group1 {
+			pinmux = <PTE1_FXIO_D2_O>,
+				 <PTE2_FXIO_D13_O>;
+			output-enable;
+		};
+
+		group2 {
+			pinmux = <PTE0_FXIO_D3_I>;
+			input-enable;
+		};
+	};
+
 	pinmux_flexio_lcd: pinmux_flexio_lcd {
 		group1 {
 			pinmux = <PTC23_FXIO_D16_O>,

--- a/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
+++ b/boards/nxp/frdm_mcxe31b/frdm_mcxe31b.yaml
@@ -19,5 +19,6 @@ supported:
   - watchdog
   - adc
   - hwinfo
+  - pwm
   - spi
 vendor: nxp

--- a/tests/drivers/pwm/pwm_api/boards/frdm_mcxe31b_flexio_pwm.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/frdm_mcxe31b_flexio_pwm.overlay
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* PWM signal is visible on J4-4 (PTE15, FXIO_D2). */
+/ {
+	aliases {
+		pwm-test = &flexio_pwm;
+	};
+};
+
+&flexio {
+	flexio_pwm: flexio_pwm {
+		compatible = "nxp,flexio-pwm";
+		#pwm-cells = <3>;
+		status = "okay";
+		pinctrl-0 = <&pinmux_flexio_pwm>;
+		pinctrl-names = "default";
+
+		pwm_0 {
+			pin-id = <2>;
+			prescaler = <1>;
+		};
+	};
+};

--- a/tests/drivers/pwm/pwm_api/tests.yaml
+++ b/tests/drivers/pwm/pwm_api/tests.yaml
@@ -21,6 +21,7 @@ tests:
       - platform:frdm_mcxa366/mcxa366:DTC_OVERLAY_FILE="boards/frdm_mcxa366_flexio_pwm.overlay"
       - platform:frdm_mcxa266/mcxa266:DTC_OVERLAY_FILE="boards/frdm_mcxa266_flexio_pwm.overlay"
       - platform:frdm_mcxe247/mcxe247:DTC_OVERLAY_FILE="boards/frdm_mcxe247_flexio_pwm.overlay"
+      - platform:frdm_mcxe31b/mcxe31b:DTC_OVERLAY_FILE="boards/frdm_mcxe31b_flexio_pwm.overlay"
       - platform:frdm_imxrt1186/mimxrt1186/cm33:DTC_OVERLAY_FILE="boards/frdm_imxrt1186_flexio_pwm.overlay"
       - platform:frdm_imxrt1186/mimxrt1186/cm7:DTC_OVERLAY_FILE="boards/frdm_imxrt1186_flexio_pwm.overlay"
     platform_allow:
@@ -32,6 +33,7 @@ tests:
       - frdm_mcxa366/mcxa366
       - frdm_mcxa266/mcxa266
       - frdm_mcxe247
+      - frdm_mcxe31b
       - frdm_imxrt1186/mimxrt1186/cm33
       - frdm_imxrt1186/mimxrt1186/cm7
     filter: dt_alias_exists("pwm-test") and CONFIG_DT_HAS_NXP_FLEXIO_ENABLED

--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxe31b_flexio_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxe31b_flexio_spi.overlay
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* To run the loopback test, connect on the Arduino header:
+ * SDO (J2-8, D11) <--> SDI (J2-10, D12).
+ * This is the same jumper as the LPSPI0 loopback (frdm_mcxe31b.overlay).
+ */
+
+/* FlexIO reuses the Arduino SPI pads, so LPSPI0 must release them. */
+&lpspi_0 {
+	status = "disabled";
+};
+
+&flexio {
+	flexio_spi: flexio_spi {
+		compatible = "nxp,flexio-spi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		cs-gpios = <&gpioe_l 6 GPIO_ACTIVE_LOW>;
+		sdo-pin = <13>;
+		sdi-pin = <3>;
+		sck-pin = <2>;
+		pinctrl-0 = <&pinmux_flexio_spi>;
+		pinctrl-names = "default";
+		status = "okay";
+
+		slow@0 {
+			compatible = "test-spi-loopback-slow";
+			reg = <0>;
+			spi-max-frequency = <500000>;
+		};
+
+		fast@0 {
+			compatible = "test-spi-loopback-fast";
+			reg = <0>;
+			spi-max-frequency = <4000000>;
+		};
+	};
+};
+
+&gpioe_l {
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_loopback/tests.yaml
+++ b/tests/drivers/spi/spi_loopback/tests.yaml
@@ -274,6 +274,7 @@ tests:
       - platform:mimxrt1040_evk:DTC_OVERLAY_FILE="boards/mimxrt1040_evk_flexio_spi.overlay"
       - platform:frdm_imxrt1186/mimxrt1186/cm33:DTC_OVERLAY_FILE="boards/frdm_imxrt1186_flexio_spi.overlay"
       - platform:frdm_imxrt1186/mimxrt1186/cm7:DTC_OVERLAY_FILE="boards/frdm_imxrt1186_flexio_spi.overlay"
+      - platform:frdm_mcxe31b/mcxe31b:DTC_OVERLAY_FILE="boards/frdm_mcxe31b_flexio_spi.overlay"
     filter: CONFIG_DT_HAS_NXP_FLEXIO_ENABLED and
             CONFIG_DT_HAS_NXP_FLEXIO_SPI_ENABLED
     platform_allow:
@@ -285,6 +286,7 @@ tests:
       - mimxrt1040_evk
       - frdm_imxrt1186/mimxrt1186/cm33
       - frdm_imxrt1186/mimxrt1186/cm7
+      - frdm_mcxe31b
   drivers.spi.nrf54h_fast_2mhz:
     extra_args:
       - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"


### PR DESCRIPTION
Enable FlexIO-based PWM and SPI on FRDM-MCXE31B.

- boards: add FlexIO PWM/SPI pinctrl groups (PWM on FXIO_D2/J4-4; SPI SCK/SDO/SDI on FXIO_D9/D10/D11, J5 header) and list pwm as supported
- tests: hook the board into the `drivers.pwm.pwm_flexio` and `drivers.spi.flexio_spi.loopback` scenarios

Tested on FRDM-MCXE31B hardware: pwm_basic passes 2/2; spi_loopback (SDO J5-5 jumpered to SDI J5-6) passes both SLOW 500 kHz and FAST 4 MHz suites, 24/24 each.
