### PR TITLE
arch: expose arch_page_phys_get() in public arch_interface.h

### DIFF
--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -719,6 +719,36 @@ static inline unsigned int arch_num_cpus(void);
 
 
 /**
+ * @addtogroup arch-mmu
+ * @{
+ */
+
+/**
+ * Get the mapped physical memory address from virtual address.
+ *
+ * The function only needs to query the current set of page tables as
+ * the information it reports must be common to all of them if multiple
+ * page tables are in use. If multiple page tables are active it is unnecessary
+ * to iterate over all of them.
+ *
+ * Unless otherwise specified, virtual pages have the same mappings
+ * across all page tables. Calling this function on data pages that are
+ * exceptions to this rule (such as the scratch page) is undefined behavior.
+ * Just check the currently installed page tables and return the information
+ * in that.
+ *
+ * @param virt Page-aligned virtual address
+ * @param[out] phys Mapped physical address (can be NULL if only checking
+ *                  if virtual address is mapped)
+ *
+ * @retval 0 if mapping is found and valid
+ * @retval -EFAULT if virtual address is not mapped
+ */
+int arch_page_phys_get(void *virt, uintptr_t *phys);
+
+/** @} */
+
+/**
  * @defgroup arch-userspace Architecture-specific userspace APIs
  * @ingroup arch-interface
  * @{

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -724,18 +724,20 @@ static inline unsigned int arch_num_cpus(void);
  */
 
 /**
- * Get the mapped physical memory address from virtual address.
+ * Get the physical address mapped at a virtual address.
  *
- * The function only needs to query the current set of page tables as
- * the information it reports must be common to all of them if multiple
- * page tables are in use. If multiple page tables are active it is unnecessary
- * to iterate over all of them.
+ * The query is answered from the caller's currently active page tables.
+ * Only mappings that are active in the caller's context are reliably
+ * reported: a virtual address whose mapping is not part of that context
+ * (for example memory belonging to a memory domain that is not currently
+ * active, or per-context data pages such as the scratch page) may be
+ * reported as unmapped or resolve differently. Calling this function on
+ * such addresses is undefined behavior.
  *
- * Unless otherwise specified, virtual pages have the same mappings
- * across all page tables. Calling this function on data pages that are
- * exceptions to this rule (such as the scratch page) is undefined behavior.
- * Just check the currently installed page tables and return the information
- * in that.
+ * From an implementation standpoint, only the currently installed page
+ * tables need to be consulted, without iterating over other page tables
+ * in the system: anything legitimately queried through this API maps
+ * identically in all of them.
  *
  * @param virt Page-aligned virtual address
  * @param[out] phys Mapped physical address (can be NULL if only checking

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -361,29 +361,6 @@ void arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flags);
 void arch_mem_unmap(void *addr, size_t size);
 
 /**
- * Get the mapped physical memory address from virtual address.
- *
- * The function only needs to query the current set of page tables as
- * the information it reports must be common to all of them if multiple
- * page tables are in use. If multiple page tables are active it is unnecessary
- * to iterate over all of them.
- *
- * Unless otherwise specified, virtual pages have the same mappings
- * across all page tables. Calling this function on data pages that are
- * exceptions to this rule (such as the scratch page) is undefined behavior.
- * Just check the currently installed page tables and return the information
- * in that.
- *
- * @param virt Page-aligned virtual address
- * @param[out] phys Mapped physical address (can be NULL if only checking
- *                  if virtual address is mapped)
- *
- * @retval 0 if mapping is found and valid
- * @retval -EFAULT if virtual address is not mapped
- */
-int arch_page_phys_get(void *virt, uintptr_t *phys);
-
-/**
  * Update page frame database with reserved pages
  *
  * Some page frames within system RAM may not be available for use. A good

--- a/subsys/portability/cmsis_rtos_v1/cmsis_thread.c
+++ b/subsys/portability/cmsis_rtos_v1/cmsis_thread.c
@@ -51,7 +51,6 @@ void thread_abort_hook(struct k_thread *thread)
 
 #ifdef CONFIG_THREAD_STACK_MEM_MAPPED
 		/* The offset calculation below requires physical address. */
-		extern int arch_page_phys_get(void *virt, uintptr_t *phys);
 		(void)arch_page_phys_get((void *)thread->stack_info.start, &stack_start);
 #else
 		stack_start = thread->stack_info.start;

--- a/subsys/portability/posix/options/mmap.c
+++ b/subsys/portability/posix/options/mmap.c
@@ -8,7 +8,6 @@
 #include <stddef.h>
 #include <sys/types.h>
 
-#include <kernel_arch_interface.h>
 #include <zephyr/kernel.h>
 #include <zephyr/kernel/mm.h>
 #include <zephyr/sys/fdtable.h>

--- a/subsys/portability/posix/options/shm.c
+++ b/subsys/portability/posix/options/shm.c
@@ -10,7 +10,6 @@
 #include <string.h>
 #include <stdio.h>
 
-#include <kernel_arch_interface.h>
 #include <zephyr/kernel.h>
 #include <zephyr/kernel/mm.h>
 #include <zephyr/posix/fcntl.h>


### PR DESCRIPTION
Move the declaration of arch_page_phys_get() from the internal kernel_arch_interface.h to the public arch_interface.h, under the existing arch-mmu group and guarded by CONFIG_MMU, so that drivers and subsystems can query the physical address of an already-mapped virtual page without depending on private kernel headers.

Clean up the existing users that resorted to including the internal header or to extern declarations:

- subsys/portability/posix/options/mmap.c
- subsys/portability/posix/options/shm.c
- subsys/portability/cmsis_rtos_v1/cmsis_thread.c

Fixes #113314