### PR TITLE
STM32MP13 timers introduction

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_mp13.c
+++ b/drivers/clock_control/clock_stm32_ll_mp13.c
@@ -37,7 +37,10 @@ int enabled_clock(uint32_t src_clk)
 	    (src_clk == STM32_SRC_PLL3_R && IS_ENABLED(STM32_PLL3_R_ENABLED)) ||
 	    (src_clk == STM32_SRC_PLL4_P && IS_ENABLED(STM32_PLL4_P_ENABLED)) ||
 	    (src_clk == STM32_SRC_PLL4_Q && IS_ENABLED(STM32_PLL4_Q_ENABLED)) ||
-	    (src_clk == STM32_SRC_PLL4_R && IS_ENABLED(STM32_PLL4_R_ENABLED))) {
+	    (src_clk == STM32_SRC_PLL4_R && IS_ENABLED(STM32_PLL4_R_ENABLED)) ||
+	    (src_clk == STM32_SRC_TIMPCLK1) ||
+	    (src_clk == STM32_SRC_TIMPCLK2) ||
+	    (src_clk == STM32_SRC_TIMPCLK6)) {
 		return 0;
 	}
 
@@ -105,6 +108,11 @@ static int stm32_clock_control_configure(const struct device *dev,
 		return err;
 	}
 
+	if (pclken->enr == NO_SEL) {
+		/* Domain clock is fixed. Nothing to set. Exit */
+		return 0;
+	}
+
 	stm32_reg_modify_bits((uint32_t *)(DT_REG_ADDR(DT_NODELABEL(rcc)) + reg),
 			      STM32_DT_CLKSEL_MASK_GET(enr) << shift,
 			      STM32_DT_CLKSEL_VAL_GET(enr) << shift);
@@ -168,6 +176,15 @@ static int stm32_clock_control_get_subsys_rate(const struct device *dev,
 		default:
 			return -ENOTSUP;
 		}
+		break;
+	case STM32_SRC_TIMPCLK1:
+		*rate = LL_RCC_GetTIMGClockFreq(LL_RCC_TIMG1PRES);
+		break;
+	case STM32_SRC_TIMPCLK2:
+		*rate = LL_RCC_GetTIMGClockFreq(LL_RCC_TIMG2PRES);
+		break;
+	case STM32_SRC_TIMPCLK6:
+		*rate = LL_RCC_GetTIMGClockFreq(LL_RCC_TIMG3PRES);
 		break;
 	default:
 		return -ENOTSUP;

--- a/drivers/counter/counter_stm32_timer.c
+++ b/drivers/counter/counter_stm32_timer.c
@@ -14,7 +14,9 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/drivers/counter/stm32.h>
 #include <zephyr/drivers/pinctrl.h>
-
+#if defined(CONFIG_GIC)
+#include <zephyr/drivers/interrupt_controller/gic.h>
+#endif /* CONFIG_GIC */
 #include <stm32_ll_tim.h>
 #include <stm32_ll_rcc.h>
 
@@ -221,13 +223,22 @@ static uint32_t counter_stm32_ticks_sub(uint32_t val, uint32_t old, uint32_t top
 	return (val >= old) ? (val - old) : val + top + 1U - old;
 }
 
+static void counter_stm32_set_pending(unsigned int irq)
+{
+#if defined(CONFIG_GIC)
+	arm_gic_irq_set_pending(irq);
+#else  /* NVIC */
+	NVIC_SetPendingIRQ(irq);
+#endif /* CONFIG_GIC */
+}
+
 static void counter_stm32_counter_stm32_set_cc_int_pending(const struct device *dev, uint8_t chan)
 {
 	const struct counter_stm32_config *config = dev->config;
 	struct counter_stm32_data *data = dev->data;
 
 	atomic_or(&data->cc_int_pending, BIT(chan));
-	NVIC_SetPendingIRQ(config->irqn);
+	counter_stm32_set_pending(config->irqn);
 }
 
 static int counter_stm32_set_cc(const struct device *dev, uint8_t id,
@@ -860,11 +871,18 @@ static void counter_stm32_irq_handler_global(const struct device *dev)
 /** TIMx instance from DT */
 #define TIM(idx) ((TIM_TypeDef *)DT_REG_ADDR(TIMER(idx)))
 
+#if defined(CONFIG_GIC)
+#define COUNTER_STM32_GET_IRQ_FLAGS(index, name) DT_IRQ_BY_NAME(TIMER(index), name, flags)
+#else /* NVIC */
+#define COUNTER_STM32_GET_IRQ_FLAGS(index, name) 0
+#endif /* CONFIG_GIC */
+
 #define IRQ_CONNECT_AND_ENABLE_BY_NAME(index, name)				\
 {										\
 	IRQ_CONNECT(DT_IRQ_BY_NAME(TIMER(index), name, irq),			\
 		    DT_IRQ_BY_NAME(TIMER(index), name, priority),		\
-		    counter_stm32_irq_handler_##name, DEVICE_DT_INST_GET(index), 0);	\
+		    counter_stm32_irq_handler_##name, DEVICE_DT_INST_GET(index),	\
+		    COUNTER_STM32_GET_IRQ_FLAGS(index, name));			\
 	irq_enable(DT_IRQ_BY_NAME(TIMER(index), name, irq));			\
 }
 

--- a/dts/arm/st/mp13/stm32mp13.dtsi
+++ b/dts/arm/st/mp13/stm32mp13.dtsi
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/reset/stm32mp13_reset.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 
 / {
 	chosen {
@@ -323,6 +324,358 @@
 				     <GIC_SPI 115 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "event", "error";
 			status = "disabled";
+		};
+
+		timers1: timers@44000000 {
+			compatible = "st,stm32-timers";
+			reg = <0x44000000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 0)>,
+				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB2, 0)>;
+			interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 26 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 27 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 28 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "brk", "up", "trgcom", "cc";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
+		timers2: timers@40000000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40000000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 0)>,
+				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1, 0)>;
+			interrupts = <GIC_SPI 29 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
+		timers3: timers@40001000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 1)>,
+				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1, 1)>;
+			interrupts = <GIC_SPI 30 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
+		timers4: timers@40002000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40002000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 2)>,
+				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1, 2)>;
+			interrupts = <GIC_SPI 31 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
+		timers5: timers@40003000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40003000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 3)>,
+				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1, 3)>;
+			interrupts = <GIC_SPI 51 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
+		timers6: timers@40004000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40004000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 4)>,
+				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1, 4)>;
+			interrupts = <GIC_SPI 55 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers7: timers@40005000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40005000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 5)>,
+				 <&rcc STM32_SRC_TIMPCLK1 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB1, 5)>;
+			interrupts = <GIC_SPI 56 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers8: timers@44001000 {
+			compatible = "st,stm32-timers";
+			reg = <0x44001000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 1)>,
+				 <&rcc STM32_SRC_TIMPCLK2 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB2, 1)>;
+			interrupts = <GIC_SPI 44 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 45 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 46 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				     <GIC_SPI 47 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "brk", "up", "trgcom", "cc";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				st,input-filter-level = <NO_FILTER>;
+				status = "disabled";
+			};
+		};
+
+		timers12: timers@4c007000 {
+			compatible = "st,stm32-timers";
+			reg = <0x4c007000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB6, 7)>,
+				 <&rcc STM32_SRC_TIMPCLK6 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB6, 7)>;
+			interrupts = <GIC_SPI 104 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers13: timers@4c008000 {
+			compatible = "st,stm32-timers";
+			reg = <0x4c008000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB6, 8)>,
+				 <&rcc STM32_SRC_TIMPCLK6 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB6, 8)>;
+			interrupts = <GIC_SPI 111 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers14: timers@4c009000 {
+			compatible = "st,stm32-timers";
+			reg = <0x4c009000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB6, 9)>,
+				 <&rcc STM32_SRC_TIMPCLK6 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB6, 9)>;
+			interrupts = <GIC_SPI 112 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers15: timers@4c00a000 {
+			compatible = "st,stm32-timers";
+			reg = <0x4c00a000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB6, 10)>,
+				 <&rcc STM32_SRC_TIMPCLK6 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB6, 10)>;
+			interrupts = <GIC_SPI 101 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers16: timers@4c00b000 {
+			compatible = "st,stm32-timers";
+			reg = <0x4c00b000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB6, 11)>,
+				 <&rcc STM32_SRC_TIMPCLK6 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB6, 11)>;
+			interrupts = <GIC_SPI 102 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
+		};
+
+		timers17: timers@4c00c000 {
+			compatible = "st,stm32-timers";
+			reg = <0x4c00c000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB6, 12)>,
+				 <&rcc STM32_SRC_TIMPCLK6 NO_SEL>;
+			resets = <&rctl STM32_RESET(APB6, 12)>;
+			interrupts = <GIC_SPI 103 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+			};
 		};
 
 		eth0: mac0: ethernet@5800a000 {

--- a/include/zephyr/dt-bindings/clock/stm32mp13_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32mp13_clock.h
@@ -28,6 +28,11 @@
 #define STM32_SRC_PLL4_Q	(STM32_SRC_PLL4_P + 1)
 #define STM32_SRC_PLL4_R	(STM32_SRC_PLL4_Q + 1)
 
+/** Timer group kernel clocks */
+#define STM32_SRC_TIMPCLK1	(STM32_SRC_PLL4_R + 1)
+#define STM32_SRC_TIMPCLK2	(STM32_SRC_TIMPCLK1 + 1)
+#define STM32_SRC_TIMPCLK6	(STM32_SRC_TIMPCLK2 + 1)
+
 /** Bus clocks */
 #define STM32_CLOCK_BUS_APB1    0x700
 #define STM32_CLOCK_BUS_APB2    0x708


### PR DESCRIPTION
The STM32MP13 provides the same timers IP as we can find on some other STM32 MCUs like H7 or F7.
Adapt MP13  clock driver management to handle it properly, and new SoC device tree nodes to add:

- TIM1/8: Advanced-control timers.
- TIM2/3/4/5: 16/32 bits general-purpose timers.
- TIM12/13/14: 16 bits general-purpose timers.
- TIM15/16/17: 16 bits general-purpose timers with break input.
- TIM6/7: Basic timers.