### PR TITLE
doc: kernel: services: threads: workqueue: remove old note

### DIFF
--- a/doc/kernel/services/threads/workqueue.rst
+++ b/doc/kernel/services/threads/workqueue.rst
@@ -32,31 +32,6 @@ A workqueue must be initialized before it can be used. This sets its queue to
 empty and spawns the workqueue's thread.  The thread runs forever, but sleeps
 when no work items are available.
 
-.. note::
-   The behavior described here is changed from the Zephyr workqueue
-   implementation used prior to release 2.6.  Among the changes are:
-
-   * Precise tracking of the status of cancelled work items, so that the
-     caller need not be concerned that an item may be processing when the
-     cancellation returns.  Checking of return values on cancellation is still
-     required.
-   * Direct submission of delayable work items to the queue with
-     :c:macro:`K_NO_WAIT` rather than always going through the timeout API,
-     which could introduce delays.
-   * The ability to wait until a work item has completed or a queue has been
-     drained.
-   * Finer control of behavior when scheduling a delayable work item,
-     specifically allowing a previous deadline to remain unchanged when a work
-     item is scheduled again.
-   * Safe handling of work item resubmission when the item is being processed
-     on another workqueue.
-
-   Using the return values of :c:func:`k_work_busy_get()` or
-   :c:func:`k_work_is_pending()`, or measurements of remaining time until
-   delayable work is scheduled, should be avoided to prevent race conditions
-   of the type observed with the previous implementation.  See also `Workqueue
-   Best Practices`_.
-
 Work Item Lifecycle
 ********************
 


### PR DESCRIPTION
Remove note comparing current behavior to pre-v2.6.0 behavior. As Zephyr v2.6.0 was released 5 years ago, this note is no longer relevant.

The last parapgraph is already covered by the best practices section.