### PR TITLE
bluetooth: classic: bip: Fix disconnect response buffer parameter

### DIFF
--- a/subsys/bluetooth/host/classic/bip.c
+++ b/subsys/bluetooth/host/classic/bip.c
@@ -1651,9 +1651,9 @@ int bt_bip_disconnect_rsp(struct bt_bip_server *server, uint8_t rsp_code, struct
 		return -EINVAL;
 	}
 
-	err = bt_obex_disconnect_rsp(&server->_server, rsp_code, NULL);
+	err = bt_obex_disconnect_rsp(&server->_server, rsp_code, buf);
 	if (err != 0) {
-		LOG_ERR("Failed to send conn rsp %d", err);
+		LOG_ERR("Failed to send disconnect rsp %d", err);
 		return err;
 	}
 


### PR DESCRIPTION
`bt_bip_disconnect_rsp()` was incorrectly passing NULL instead of the `buf` parameter to `bt_obex_disconnect_rsp()`.  This prevented any optional headers in the disconnect response from being sent. And leading a result that the passed `buf` will not be released anymore.

Pass the `buf` parameter through to `bt_obex_disconnect_rsp()` so that optional headers can be included in the disconnect response as intended. And also the passed buffer `buf` will be managed by the underlay if the OBEX disconnect response is sent without any errors via the function `bt_obex_disconnect_rsp()`.