### PR TITLE
Modify the overlay to support mcxn947 bluetooth

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -6,8 +6,10 @@
 
 #include <nxp/mcx/MCXN947VDF-pinctrl.h>
 
-&arduino_serial {
-	status = "disabled";
+/ {
+	chosen {
+		zephyr,uart-pipe = &flexcomm4_lpuart4;
+	};
 };
 
 &m2_hci_bt_uart {


### PR DESCRIPTION
Need remove the disabled arduino_serial for bluetooth, there is the other m2_hci_bt_uart. 
Add the uart-pipe for bt tester app use.