### PR TITLE
Missed dmic0 alignement

### DIFF
--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
@@ -23,9 +23,9 @@
 	};
 
 	aliases {
+		dmic0 = &dmic_dev;
 		led0 = &red_led;
 		led1 = &green_led;
-		dmic-dev = &dmic_dev;
 	};
 
 	otghs_ulpi_phy: otghs_ulpis_phy {

--- a/boards/native/native_sim/native_sim.dts
+++ b/boards/native/native_sim/native_sim.dts
@@ -31,7 +31,7 @@
 
 	aliases {
 		codec0 = &audio_codec;
-		dmic-dev = &dmic0;
+		dmic0 = &dmic0;
 		eeprom-0 = &eeprom0;
 		i2c-0 = &i2c0;
 		i2s-node0 = &i2s_rxtx;

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -28,7 +28,7 @@
 		accel0 = &fxos8700;
 		sdhc0 = &usdhc0;
 		pwm-0 = &sc_timer;
-		dmic-dev = &dmic0;
+		dmic0 = &dmic0;
 		mcuboot-button0 = &user_button_1;
 	};
 

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -34,7 +34,7 @@
 		magn0 = &fxos8700;
 		accel0 = &fxos8700;
 		sdhc0 = &usdhc0;
-		dmic-dev = &dmic0;
+		dmic0 = &dmic0;
 		mcuboot-button0 = &user_button_1;
 		mbox = &mbox;
 	};

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -18,7 +18,7 @@
 		sw0 = &sw_4;
 		i2c-0 = &flexcomm2;
 		watchdog0 = &wwdt;
-		dmic-dev = &dmic0;
+		dmic0 = &dmic0;
 		mcuboot-button0 = &sw_4;
 		pwm-0 = &sctimer;
 	};

--- a/tests/drivers/audio/dmic_api/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/audio/dmic_api/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
@@ -7,7 +7,7 @@
 
 / {
 	aliases {
-		dmic-dev = &pdm20;
+		dmic0 = &pdm20;
 	};
 };
 

--- a/tests/drivers/audio/dmic_api/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/audio/dmic_api/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -7,7 +7,7 @@
 
 / {
 	aliases {
-		dmic-dev = &pdm20;
+		dmic0 = &pdm20;
 	};
 };
 

--- a/tests/drivers/audio/dmic_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/tests/drivers/audio/dmic_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -6,7 +6,7 @@
 
 / {
 	aliases {
-		dmic-dev = &micfil;
+		dmic0 = &micfil;
 	};
 };
 

--- a/tests/drivers/audio/dmic_api/boards/frdm_mcxn947_mcxn947_cpu1.overlay
+++ b/tests/drivers/audio/dmic_api/boards/frdm_mcxn947_mcxn947_cpu1.overlay
@@ -6,7 +6,7 @@
 
 / {
 	aliases {
-		dmic-dev = &micfil;
+		dmic0 = &micfil;
 	};
 };
 

--- a/tests/drivers/audio/dmic_api/boards/kit_pse84_common.overlay
+++ b/tests/drivers/audio/dmic_api/boards/kit_pse84_common.overlay
@@ -7,7 +7,7 @@
 
 / {
 	aliases {
-		dmic-dev = &dmic0;
+		dmic0 = &dmic0;
 	};
 };
 

--- a/tests/drivers/audio/dmic_api/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
+++ b/tests/drivers/audio/dmic_api/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
@@ -6,7 +6,7 @@
 
 / {
 	aliases {
-		dmic-dev = &micfil;
+		dmic0 = &micfil;
 	};
 };
 

--- a/tests/drivers/audio/dmic_api/boards/mcx_n9xx_evk_mcxn947_cpu1.overlay
+++ b/tests/drivers/audio/dmic_api/boards/mcx_n9xx_evk_mcxn947_cpu1.overlay
@@ -6,7 +6,7 @@
 
 / {
 	aliases {
-		dmic-dev = &micfil;
+		dmic0 = &micfil;
 	};
 };
 

--- a/tests/drivers/audio/dmic_api/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/tests/drivers/audio/dmic_api/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -6,7 +6,7 @@
 
 / {
 	aliases {
-		dmic-dev = &micfil;
+		dmic0 = &micfil;
 	};
 };
 

--- a/tests/drivers/audio/dmic_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/audio/dmic_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -6,7 +6,7 @@
 
 / {
 	aliases {
-		dmic-dev = &pdm20;
+		dmic0 = &pdm20;
 	};
 };
 

--- a/tests/drivers/audio/dmic_api/boards/nrf54lm20dk_nrf54lm20_common.dtsi
+++ b/tests/drivers/audio/dmic_api/boards/nrf54lm20dk_nrf54lm20_common.dtsi
@@ -10,7 +10,7 @@
 
 / {
 	aliases {
-		dmic-dev = &pdm20;
+		dmic0 = &pdm20;
 	};
 };
 

--- a/tests/drivers/audio/dmic_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
+++ b/tests/drivers/audio/dmic_api/boards/nrf7120dk_nrf7120_cpuapp.overlay
@@ -11,7 +11,7 @@
 
 / {
 	aliases {
-		dmic-dev = &pdm20;
+		dmic0 = &pdm20;
 	};
 };
 

--- a/tests/drivers/audio/dmic_api/boards/ophelia4ev_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/audio/dmic_api/boards/ophelia4ev_nrf54l15_cpuapp.overlay
@@ -6,7 +6,7 @@
 
 / {
 	aliases {
-		dmic-dev = &pdm20;
+		dmic0 = &pdm20;
 	};
 };
 

--- a/tests/drivers/audio/dmic_api/src/main.c
+++ b/tests/drivers/audio/dmic_api/src/main.c
@@ -13,7 +13,7 @@
 #include <zephyr/audio/dmic.h>
 #include <zephyr/ztest.h>
 
-static const struct device *dmic_dev = DEVICE_DT_GET(DT_ALIAS(dmic_dev));
+static const struct device *dmic_dev = DEVICE_DT_GET(DT_ALIAS(dmic0));
 
 #define SAMPLE_BIT_WIDTH CONFIG_SAMPLE_BIT_WIDTH
 #define PDM_CHANNELS     CONFIG_SAMPLE_PDM_CHANNELS

--- a/tests/drivers/audio/dmic_api/tests.yaml
+++ b/tests/drivers/audio/dmic_api/tests.yaml
@@ -3,6 +3,6 @@ tests:
     depends_on: dmic
     tags: dmic
     harness: ztest
-    filter: dt_alias_exists("dmic-dev")
+    filter: dt_alias_exists("dmic0")
     integration_platforms:
       - mimxrt595_evk/mimxrt595s/cm33


### PR DESCRIPTION
Several boards remained under `dmic-dev` alias.  Ditto for `dmic-api` tests and related overlays.

Switch everything to `dmic0` alias.