### PR TITLE
drivers: rtc: sam: Avoid unusued variables warnings

### DIFF
--- a/drivers/rtc/rtc_sam.c
+++ b/drivers/rtc/rtc_sam.c
@@ -188,11 +188,15 @@ static int rtc_sam_get_time(const struct device *dev, struct rtc_time *timeptr)
 
 static void rtc_sam_isr(const struct device *dev)
 {
+#if defined(CONFIG_RTC_ALARM) || defined(CONFIG_RTC_UPDATE)
 	struct rtc_sam_data *data = dev->data;
 	const struct rtc_sam_config *config = dev->config;
 	Rtc *regs = config->regs;
 
 	uint32_t sr = regs->RTC_SR;
+#else
+	ARG_UNUSED(dev);
+#endif
 
 #ifdef CONFIG_RTC_ALARM
 	if (sr & RTC_SR_ALARM) {


### PR DESCRIPTION
Let's ifdef the common variables, so we avoid unused variables warnings when neither RTC_ALARM or RTC_UPDATE are set.

This can be reproduced for examples building
tests/drivers/rtc/rtc_api_helpers for sam_v71_xult/samv71q21