### PR TITLE
dts: arm: st: *: sai: use empty ranges

### DIFF
--- a/dts/arm/st/f4/stm32f413.dtsi
+++ b/dts/arm/st/f4/stm32f413.dtsi
@@ -87,20 +87,20 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015800 0x400>;
-			ranges = <0x0 0x40015800 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015804 {
+				reg = <0x40015804 0x20>;
 				dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015824 {
+				reg = <0x40015824 0x20>;
 				dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -121,20 +121,20 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015800 0x400>;
-			ranges = <0x0 0x40015800 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015804 {
+				reg = <0x40015804 0x20>;
 				dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015824 {
+				reg = <0x40015824 0x20>;
 				dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -177,20 +177,20 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015800 0x400>;
-			ranges = <0x0 0x40015800 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015804 {
+				reg = <0x40015804 0x20>;
 				dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015824 {
+				reg = <0x40015824 0x20>;
 				dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -1077,20 +1077,20 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 		reg = <0x40015800 0x400>;
-		ranges = <0x0 0x40015800 0x400>;
+		ranges;
 		clocks = <&rcc STM32_CLOCK(APB2, 22)>;
 		status = "disabled";
 
-		sai1_a: sai1a@4 {
-			reg = <0x4 0x20>;
+		sai1_a: sai1a@40015804 {
+			reg = <0x40015804 0x20>;
 			dmas = <&dma2 1 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
 		};
 
-		sai1_b: sai1b@24 {
-			reg = <0x24 0x20>;
+		sai1_b: sai1b@40015824 {
+			reg = <0x40015824 0x20>;
 			dmas = <&dma2 5 0 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -782,20 +782,20 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
-			ranges = <0x0 0x40015400 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015404 {
+				reg = <0x40015404 0x20>;
 				dmas = <&dma1 1 108 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015424 {
+				reg = <0x40015424 0x20>;
 				dmas = <&dma1 2 109 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -130,21 +130,21 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
-			ranges = <0x0 0x40015400 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL1_Q SAI1_SEL(0)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015404 {
+				reg = <0x40015404 0x20>;
 				dmas = <&gpdma1 1 53 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015424 {
+				reg = <0x40015424 0x20>;
 				dmas = <&gpdma1 0 54 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -157,21 +157,21 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015800 0x400>;
-			ranges = <0x0 0x40015800 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 				 <&rcc STM32_SRC_PLL1_Q SAI2_SEL(0)>;
 			status = "disabled";
 
-			sai2_a: sai2a@4 {
-				reg = <0x4 0x20>;
+			sai2_a: sai2a@40015804 {
+				reg = <0x40015804 0x20>;
 				dmas = <&gpdma1 1 55 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai2_b: sai2b@24 {
-				reg = <0x24 0x20>;
+			sai2_b: sai2b@40015824 {
+				reg = <0x40015824 0x20>;
 				dmas = <&gpdma1 0 56 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1297,21 +1297,21 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015800 0x400>;
-			ranges = <0x0 0x40015800 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015804 {
+				reg = <0x40015804 0x20>;
 				dmas = <&dma1 2 87 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015824 {
+				reg = <0x40015824 0x20>;
 				dmas = <&dma1 3 88 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH) 0>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -1064,21 +1064,21 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x42005800 0x400>;
-			ranges = <0x0 0x42005800 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 22)>,
 				 <&rcc STM32_SRC_PLL3_P SAI1_SEL(0)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@42005804 {
+				reg = <0x42005804 0x20>;
 				dmas = <&gpdma1 1 63 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@42005824 {
+				reg = <0x42005824 0x20>;
 				dmas = <&gpdma1 0 64 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -126,21 +126,21 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
-			ranges = <0x0 0x40015400 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015404 {
+				reg = <0x40015404 0x20>;
 				dmas = <&dma2 1 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015424 {
+				reg = <0x40015424 0x20>;
 				dmas = <&dma2 2 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -96,21 +96,21 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
-			ranges = <0x0 0x40015400 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015404 {
+				reg = <0x40015404 0x20>;
 				dmas = <&dma2 1 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015424 {
+				reg = <0x40015424 0x20>;
 				dmas = <&dma2 2 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/l4/stm32l451.dtsi
+++ b/dts/arm/st/l4/stm32l451.dtsi
@@ -176,21 +176,21 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
-			ranges = <0x0 0x40015400 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015404 {
+				reg = <0x40015404 0x20>;
 				dmas = <&dma2 1 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015424 {
+				reg = <0x40015424 0x20>;
 				dmas = <&dma2 2 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -333,21 +333,21 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
-			ranges = <0x0 0x40015400 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015404 {
+				reg = <0x40015404 0x20>;
 				dmas = <&dma2 1 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015424 {
+				reg = <0x40015424 0x20>;
 				dmas = <&dma2 2 1 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -476,21 +476,21 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
-			ranges = <0x0 0x40015400 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015404 {
+				reg = <0x40015404 0x20>;
 				dmas = <&dma2 1 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015424 {
+				reg = <0x40015424 0x20>;
 				dmas = <&dma2 2 38 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -75,11 +75,11 @@
 
 		sai1: sai1@40015400 {
 			/* L4R/S SAI DMA Request differs from L4P/Q */
-			sai1_a: sai1a@4 {
+			sai1_a: sai1a@40015404 {
 				dmas = <&dma2 1 36 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 			};
 
-			sai1_b: sai1b@24 {
+			sai1_b: sai1b@40015424 {
 				dmas = <&dma2 2 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 			};
 		};

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -848,21 +848,21 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
-			ranges = <0x0 0x40015400 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLLSAI1_P SAI1_SEL(0)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015404 {
+				reg = <0x40015404 0x20>;
 				dmas = <&dma1 1 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015424 {
+				reg = <0x40015424 0x20>;
 				dmas = <&dma1 2 38 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -1478,12 +1478,12 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 				reg = <0x52005800 0x400>;
-				ranges = <0x0 0x52005800 0x400>;
+				ranges;
 				clocks = <&rcc STM32_CLOCK(APB2, 21)>;
 				status = "disabled";
 
-				sai1_a: sai1a@4 {
-					reg = <0x4 0x20>;
+				sai1_a: sai1a@52005804 {
+					reg = <0x52005804 0x20>;
 					dmas = <&gpdma1 1 91
 						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 					#address-cells = <1>;
@@ -1491,8 +1491,8 @@
 					status = "disabled";
 				};
 
-				sai1_b: sai1b@24 {
-					reg = <0x24 0x20>;
+				sai1_b: sai1b@52005824 {
+					reg = <0x52005824 0x20>;
 					dmas = <&gpdma1 0 92
 						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 					#address-cells = <1>;
@@ -1506,12 +1506,12 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 				reg = <0x52005c00 0x400>;
-				ranges = <0x0 0x52005c00 0x400>;
+				ranges;
 				clocks = <&rcc STM32_CLOCK(APB2, 22)>;
 				status = "disabled";
 
-				sai2_a: sai2a@4 {
-					reg = <0x4 0x20>;
+				sai2_a: sai2a@52005c04 {
+					reg = <0x52005c04 0x20>;
 					dmas = <&gpdma1 3 93
 						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 					#address-cells = <1>;
@@ -1519,8 +1519,8 @@
 					status = "disabled";
 				};
 
-				sai2_b: sai2b@24 {
-					reg = <0x24 0x20>;
+				sai2_b: sai2b@52005c24 {
+					reg = <0x52005c24 0x20>;
 					dmas = <&gpdma1 2 94
 						(STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 					#address-cells = <1>;

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -503,11 +503,11 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
-			ranges = <0x0 0x40015400 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
+			sai1_a: sai1a@40015404 {
 				reg = <0x4 0x20>;
 				dmas = <&gpdma1 1 36 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
@@ -515,7 +515,7 @@
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
+			sai1_b: sai1b@40015424 {
 				reg = <0x24 0x20>;
 				dmas = <&gpdma1 0 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -544,21 +544,21 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
-			ranges = <0x0 0x40015400 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015404 {
+				reg = <0x40015404 0x20>;
 				dmas = <&gpdma1 1 36 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015424 {
+				reg = <0x40015424 0x20>;
 				dmas = <&gpdma1 0 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/arm/st/wba/stm32wba55.dtsi
+++ b/dts/arm/st/wba/stm32wba55.dtsi
@@ -15,21 +15,21 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40015400 0x400>;
-			ranges = <0x0 0x40015400 0x400>;
+			ranges;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL1_P SAI1_SEL(0)>;
 			status = "disabled";
 
-			sai1_a: sai1a@4 {
-				reg = <0x4 0x20>;
+			sai1_a: sai1a@40015404 {
+				reg = <0x40015404 0x20>;
 				dmas = <&gpdma1 1 17 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				status = "disabled";
 			};
 
-			sai1_b: sai1b@24 {
-				reg = <0x24 0x20>;
+			sai1_b: sai1b@40015424 {
+				reg = <0x40015424 0x20>;
 				dmas = <&gpdma1 0 18 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;

--- a/dts/bindings/i2s/st,stm32-sai.yaml
+++ b/dts/bindings/i2s/st,stm32-sai.yaml
@@ -12,7 +12,7 @@ properties:
     required: true
 
   ranges:
-    type: array
+    type: compound
     required: true
 
   "#address-cells":


### PR DESCRIPTION
Map 1:1 using empty 'ranges;' property. Specific range property should only be use when devices are not on the same bus interface.  This also prevents from redefining Secure/Non-Secure addresses.