### PR TITLE
net: utils: Initialize stack variable to 0 to avoid warning, and ensure net_ip conversion helpers are always inlined

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -1908,7 +1908,7 @@ static inline bool net_ipv6_addr_based_on_ll(const struct net_in6_addr *addr,
  *
  * @return Pointer to socket address (struct sockaddr)
  */
-static inline struct net_sockaddr *net_sad(const struct net_sockaddr_storage *addr)
+static ALWAYS_INLINE struct net_sockaddr *net_sad(const struct net_sockaddr_storage *addr)
 {
 	return (struct net_sockaddr *)addr;
 }
@@ -1921,7 +1921,7 @@ static inline struct net_sockaddr *net_sad(const struct net_sockaddr_storage *ad
  *
  * @return Pointer to socket storage address (struct net_sockaddr_storage)
  */
-static inline struct net_sockaddr_storage *net_sas(const struct net_sockaddr *addr)
+static ALWAYS_INLINE struct net_sockaddr_storage *net_sas(const struct net_sockaddr *addr)
 {
 	return (struct net_sockaddr_storage *)addr;
 }
@@ -1934,7 +1934,7 @@ static inline struct net_sockaddr_storage *net_sas(const struct net_sockaddr *ad
  *
  * @return Pointer to IPv6 socket address
  */
-static inline struct net_sockaddr_in6 *net_sin6(const struct net_sockaddr *addr)
+static ALWAYS_INLINE struct net_sockaddr_in6 *net_sin6(const struct net_sockaddr *addr)
 {
 	return (struct net_sockaddr_in6 *)addr;
 }
@@ -1947,7 +1947,7 @@ static inline struct net_sockaddr_in6 *net_sin6(const struct net_sockaddr *addr)
  *
  * @return Pointer to IPv4 socket address
  */
-static inline struct net_sockaddr_in *net_sin(const struct net_sockaddr *addr)
+static ALWAYS_INLINE struct net_sockaddr_in *net_sin(const struct net_sockaddr *addr)
 {
 	return (struct net_sockaddr_in *)addr;
 }
@@ -1960,7 +1960,7 @@ static inline struct net_sockaddr_in *net_sin(const struct net_sockaddr *addr)
  *
  * @return Pointer to IPv6 socket address
  */
-static inline
+static ALWAYS_INLINE
 struct net_sockaddr_in6_ptr *net_sin6_ptr(const struct net_sockaddr_ptr *addr)
 {
 	return (struct net_sockaddr_in6_ptr *)addr;
@@ -1974,7 +1974,7 @@ struct net_sockaddr_in6_ptr *net_sin6_ptr(const struct net_sockaddr_ptr *addr)
  *
  * @return Pointer to IPv4 socket address
  */
-static inline
+static ALWAYS_INLINE
 struct net_sockaddr_in_ptr *net_sin_ptr(const struct net_sockaddr_ptr *addr)
 {
 	return (struct net_sockaddr_in_ptr *)addr;
@@ -1988,7 +1988,7 @@ struct net_sockaddr_in_ptr *net_sin_ptr(const struct net_sockaddr_ptr *addr)
  *
  * @return Pointer to linklayer socket address
  */
-static inline
+static ALWAYS_INLINE
 struct net_sockaddr_ll_ptr *net_sll_ptr(const struct net_sockaddr_ptr *addr)
 {
 	return (struct net_sockaddr_ll_ptr *)addr;
@@ -2002,7 +2002,7 @@ struct net_sockaddr_ll_ptr *net_sll_ptr(const struct net_sockaddr_ptr *addr)
  *
  * @return Pointer to CAN socket address
  */
-static inline
+static ALWAYS_INLINE
 struct net_sockaddr_can_ptr *net_can_ptr(const struct net_sockaddr_ptr *addr)
 {
 	return (struct net_sockaddr_can_ptr *)addr;

--- a/subsys/shell/backends/shell_telnet.c
+++ b/subsys/shell/backends/shell_telnet.c
@@ -411,7 +411,7 @@ static void telnet_restart_server(void)
 static void telnet_accept(struct zsock_pollfd *pollfd)
 {
 	int sock, ret = 0;
-	struct net_sockaddr_storage addr;
+	struct net_sockaddr_storage addr = {};
 	net_socklen_t addrlen = sizeof(addr);
 
 	sock = zsock_accept(pollfd->fd, net_sad(&addr), &addrlen);

--- a/tests/net/utils/src/main.c
+++ b/tests/net/utils/src/main.c
@@ -1578,7 +1578,7 @@ ZTEST(test_utils_fn, test_linkaddr_handling)
 
 ZTEST(test_utils_fn, test_parse_ipv4_overflow)
 {
-	struct net_sockaddr_storage saddr;
+	struct net_sockaddr_storage saddr = {};
 	struct net_sockaddr *addr = net_sad(&saddr);
 	bool ret;
 
@@ -1732,7 +1732,7 @@ ZTEST(test_utils_fn, test_parse_ipv4_overflow)
 
 ZTEST(test_utils_fn, test_parse_ipv6_overflow)
 {
-	struct net_sockaddr_storage saddr;
+	struct net_sockaddr_storage saddr = {};
 	struct net_sockaddr *addr = net_sad(&saddr);
 	bool ret;
 


### PR DESCRIPTION
When building with no optimizations, the compiler does not inline net_sad(), and does not do a pass to check how inputs may be used by functions (Not realizing the function is nothing more than a cast). In that context it warns about saddr not being initialized and being potentially used. (This will happen even if we forcefully inline the function, as the forceful in-lining does not affect the check of how variables are used)

Let's just initialize them to zero to silence it. With optimizations enabled the compiler should anyhow drop the initialization.

can be repro'd building for a target that disabels optimizations by default,
`cmake -GNinja -DBOARD=nrf52_bsim/native ../tests/net/utils  && ninja`
or disabiling them
`cmake -GNinja -DBOARD=native_sim ../tests/net/utils -DCONFIG_NO_OPTIMIZATIONS=y  && ninja`

----

For the trivial conversion helpers in net_ip.h let's ensure they are always inlined
    
`inline` is just a hint for the compiler. But without optimizations enabled it is ignored. 
Nonetheless, there is no scenario where we would not want these functions actually inlined, so let's use ALWAYS_INLINE instead so we ensure they are inlined.
