### PR TITLE
twister: harness: handle missing robot executable

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -245,8 +245,18 @@ class Robot(Harness):
         else:
             command.append(os.path.join(handler.sourcedir, self.path))
 
-        with subprocess.Popen(command, stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT, cwd=self.instance.build_dir, env=env) as renode_test_proc:
+        try:
+            renode_test_proc = subprocess.Popen(command, stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT, cwd=self.instance.build_dir, env=env)
+        except FileNotFoundError as err:
+            reason = f"Robot test executable '{command[0]}' not found: {err.strerror}"
+            logger.warning(reason)
+            self.instance.status = TwisterStatus.SKIP
+            self.instance.reason = reason
+            self.instance.add_missing_case_status(TwisterStatus.SKIP)
+            return
+
+        with renode_test_proc:
             out, _ = renode_test_proc.communicate()
 
             self.instance.execution_time = time.time() - start_time

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -384,13 +384,12 @@ def test_robot_run_robot_test(tmp_path, caplog, exp_out, returncode, expected_st
     robot.option = option
     robot.instance = instance
     proc_mock = mock.Mock(
-        returncode=returncode, communicate=mock.Mock(return_value=(b"output", None))
+        returncode=returncode,
+        communicate=mock.Mock(return_value=(b"output", None)),
     )
-    popen_mock = mock.Mock(
-        return_value=mock.Mock(
-            __enter__=mock.Mock(return_value=proc_mock), __exit__=mock.Mock()
-        )
-    )
+    proc_mock.__enter__ = mock.Mock(return_value=proc_mock)
+    proc_mock.__exit__ = mock.Mock()
+    popen_mock = mock.Mock(return_value=proc_mock)
 
     # Act
     with mock.patch("subprocess.Popen", popen_mock) as mock.mock_popen, mock.patch(


### PR DESCRIPTION
When the Robot Framework executable is not found, subprocess raised an unhandled FileNotFoundError that aborted the entire Twister run instead of just the affected test.

Catch the exception in the Robot harness, mark the instance as skipped with a descriptive reason, and continue so remaining tests still execute.

---
Before this change, if you run Twister without the Robot framework installed, Twister aborts execution.
Reproduce with:
`west twister --no-clean -vv -ll debug -T samples/subsys/shell/shell_module -s sample.shell.shell_module.robot -p qemu_x86 -p native_sim`
Then received:
```
ERROR   - General exception: [Errno 2] No such file or directory: 'robot'
Traceback (most recent call last):
  File "/home/grch/zephyrproject/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 2060, in pipeline_mgr
    return self.process_tasks(processing_queue, processing_ready, lock, results)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/grch/zephyrproject/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 2043, in process_tasks
    pb.process(processing_queue, processing_ready, task, lock, results)
  File "/home/grch/zephyrproject/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 927, in process
    self.run()
  File "/home/grch/zephyrproject/zephyr/scripts/pylib/twister/twisterlib/runner.py", line 1693, in run
    instance.handler.handle(harness)
  File "/home/grch/zephyrproject/zephyr/scripts/pylib/twister/twisterlib/handlers.py", line 1160, in handle
    harness.run_robot_test(robot_command, self)
  File "/home/grch/zephyrproject/zephyr/scripts/pylib/twister/twisterlib/harness.py", line 248, in run_robot_test
    with subprocess.Popen(command, stdout=subprocess.PIPE,
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.12/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'robot'

ERROR   - Process 1385009 failed, aborting execution
```

With this change:
```
DEBUG   - run status: qemu_x86/atom/zephyr/gnu/sample.shell.shell_module.robot skipped
INFO    - 2/2 qemu_x86/atom             sample.shell.shell_module.robot                    SKIPPED (Robot test executable 'robot' not found: No such file or directory)
```

