### PR TITLE
lorawan: frag_flash: Support MCUboot swap-using-offset mode

### DIFF
--- a/subsys/lorawan/services/frag_flash.c
+++ b/subsys/lorawan/services/frag_flash.c
@@ -24,6 +24,7 @@ struct frag_cache_entry {
 
 static struct frag_cache_entry frag_cache[FRAG_MAX_REDUNDANCY];
 static uint32_t frag_size;
+static size_t offset;
 static int cached_frags;
 static bool use_cache;
 
@@ -32,6 +33,8 @@ static const struct flash_area *fa;
 int frag_flash_init(uint32_t fragment_size)
 {
 	int err;
+	struct flash_sector first_sector;
+	uint32_t sector_count = 1;
 
 	if (fragment_size > FRAG_MAX_SIZE) {
 		return -ENOSPC;
@@ -40,6 +43,7 @@ int frag_flash_init(uint32_t fragment_size)
 	frag_size = fragment_size;
 	cached_frags = 0;
 	use_cache = false;
+	offset = 0;
 
 	err = flash_area_open(TARGET_IMAGE_AREA, &fa);
 	if (err) {
@@ -52,6 +56,31 @@ int frag_flash_init(uint32_t fragment_size)
 
 	LOG_DBG("Finished erasing flash area");
 
+#if IS_ENABLED(CONFIG_MCUBOOT_BOOTLOADER_MODE_SWAP_USING_OFFSET) &&                                \
+	defined(SWAP_USING_OFFSET_SECTOR_UPDATE_BEGIN)
+	err = flash_area_sectors(fa, &sector_count, &first_sector);
+	if (err && err != -ENOMEM) {
+		return err;
+	}
+
+	/* We only need the first sector size to calculate the upload offset. */
+	if (sector_count < SWAP_USING_OFFSET_SECTOR_UPDATE_BEGIN) {
+		return -ENOENT;
+	}
+
+	offset = first_sector.fs_size;
+	if (offset == 0) {
+		return -EINVAL;
+	}
+
+	if (offset >= fa->fa_size) {
+		LOG_ERR("Invalid swap offset %zu for area size %zu", offset, fa->fa_size);
+		return -EINVAL;
+	}
+
+	LOG_DBG("Swap-using-offset active, FUOTA write offset: %zu bytes", offset);
+#endif
+
 	return err;
 }
 
@@ -60,9 +89,10 @@ int8_t frag_flash_write(uint32_t addr, uint8_t *data, uint32_t size)
 	int8_t err = 0;
 
 	if (!use_cache) {
-		LOG_DBG("Writing %u bytes to addr 0x%X", size, addr);
+		LOG_DBG("Writing %u bytes to addr 0x%X (effective 0x%zX)", size, addr,
+			offset + addr);
 
-		err = flash_area_write(fa, addr, data, size);
+		err = flash_area_write(fa, offset + addr, data, size);
 	} else {
 		LOG_DBG("Caching %u bytes for addr 0x%X", size, addr);
 
@@ -102,7 +132,7 @@ int8_t frag_flash_read(uint32_t addr, uint8_t *data, uint32_t size)
 		}
 	}
 
-	return flash_area_read(fa, addr, data, size) == 0 ? 0 : -1;
+	return flash_area_read(fa, offset + addr, data, size) == 0 ? 0 : -1;
 }
 
 void frag_flash_use_cache(void)
@@ -116,7 +146,7 @@ void frag_flash_finish(void)
 
 	for (int i = 0; i < cached_frags; i++) {
 		LOG_DBG("Writing %u bytes to addr 0x%x", frag_size, frag_cache[i].addr);
-		flash_area_write(fa, frag_cache[i].addr, frag_cache[i].data, frag_size);
+		flash_area_write(fa, offset + frag_cache[i].addr, frag_cache[i].data, frag_size);
 	}
 
 	flash_area_close(fa);

--- a/subsys/lorawan/services/frag_flash.c
+++ b/subsys/lorawan/services/frag_flash.c
@@ -24,6 +24,7 @@ struct frag_cache_entry {
 
 static struct frag_cache_entry frag_cache[FRAG_MAX_REDUNDANCY];
 static uint32_t frag_size;
+static size_t offset;
 static int cached_frags;
 static bool use_cache;
 
@@ -40,6 +41,7 @@ int frag_flash_init(uint32_t fragment_size)
 	frag_size = fragment_size;
 	cached_frags = 0;
 	use_cache = false;
+	offset = 0;
 
 	err = flash_area_open(TARGET_IMAGE_AREA, &fa);
 	if (err) {
@@ -52,6 +54,35 @@ int frag_flash_init(uint32_t fragment_size)
 
 	LOG_DBG("Finished erasing flash area");
 
+#if IS_ENABLED(CONFIG_MCUBOOT_BOOTLOADER_MODE_SWAP_USING_OFFSET) &&                                \
+	defined(SWAP_USING_OFFSET_SECTOR_UPDATE_BEGIN)
+
+	struct flash_sector first_sector;
+	uint32_t sector_count = 1;
+
+	err = flash_area_sectors(fa, &sector_count, &first_sector);
+	if (err && err != -ENOMEM) {
+		return err;
+	}
+
+	/* We only need the first sector size to calculate the upload offset. */
+	if (sector_count < SWAP_USING_OFFSET_SECTOR_UPDATE_BEGIN) {
+		return -ENOENT;
+	}
+
+	offset = first_sector.fs_size;
+	if (offset == 0) {
+		return -EINVAL;
+	}
+
+	if (offset >= fa->fa_size) {
+		LOG_ERR("Invalid swap offset %zu for area size %zu", offset, fa->fa_size);
+		return -EINVAL;
+	}
+
+	LOG_DBG("Swap-using-offset active, FUOTA write offset: %zu bytes", offset);
+#endif
+
 	return err;
 }
 
@@ -60,9 +91,10 @@ int8_t frag_flash_write(uint32_t addr, uint8_t *data, uint32_t size)
 	int8_t err = 0;
 
 	if (!use_cache) {
-		LOG_DBG("Writing %u bytes to addr 0x%X", size, addr);
+		LOG_DBG("Writing %u bytes to addr 0x%X (effective 0x%zX)", size, addr,
+			offset + addr);
 
-		err = flash_area_write(fa, addr, data, size);
+		err = flash_area_write(fa, offset + addr, data, size);
 	} else {
 		LOG_DBG("Caching %u bytes for addr 0x%X", size, addr);
 
@@ -102,7 +134,7 @@ int8_t frag_flash_read(uint32_t addr, uint8_t *data, uint32_t size)
 		}
 	}
 
-	return flash_area_read(fa, addr, data, size) == 0 ? 0 : -1;
+	return flash_area_read(fa, offset + addr, data, size) == 0 ? 0 : -1;
 }
 
 void frag_flash_use_cache(void)
@@ -116,7 +148,7 @@ void frag_flash_finish(void)
 
 	for (int i = 0; i < cached_frags; i++) {
 		LOG_DBG("Writing %u bytes to addr 0x%x", frag_size, frag_cache[i].addr);
-		flash_area_write(fa, frag_cache[i].addr, frag_cache[i].data, frag_size);
+		flash_area_write(fa, offset + frag_cache[i].addr, frag_cache[i].data, frag_size);
 	}
 
 	flash_area_close(fa);

--- a/subsys/lorawan/services/frag_flash.c
+++ b/subsys/lorawan/services/frag_flash.c
@@ -33,8 +33,6 @@ static const struct flash_area *fa;
 int frag_flash_init(uint32_t fragment_size)
 {
 	int err;
-	struct flash_sector first_sector;
-	uint32_t sector_count = 1;
 
 	if (fragment_size > FRAG_MAX_SIZE) {
 		return -ENOSPC;
@@ -58,6 +56,10 @@ int frag_flash_init(uint32_t fragment_size)
 
 #if IS_ENABLED(CONFIG_MCUBOOT_BOOTLOADER_MODE_SWAP_USING_OFFSET) &&                                \
 	defined(SWAP_USING_OFFSET_SECTOR_UPDATE_BEGIN)
+
+	struct flash_sector first_sector;
+	uint32_t sector_count = 1;
+
 	err = flash_area_sectors(fa, &sector_count, &first_sector);
 	if (err && err != -ENOMEM) {
 		return err;


### PR DESCRIPTION
### Description

When using MCUboot's `CONFIG_MCUBOOT_BOOTLOADER_MODE_SWAP_USING_OFFSET` mode, candidate images stored in the secondary slot (`slot1_partition`) must be written with an offset equal to the size of the first flash sector. This leaves space for the secondary slot header/magic required by MCUboot.

Currently, `subsys/lorawan/services/frag_flash.c` writes incoming LoRaWAN FUOTA fragments starting at address `0x0` of the target flash area (`TARGET_IMAGE_AREA`). When swap-by-offset is active, this causes the binary image to be written directly at the beginning of the slot, destroying the expected header/magic offset alignment and making MCUboot unable to perform the swap after a download.

### Solution

This PR adds support for `CONFIG_MCUBOOT_BOOTLOADER_MODE_SWAP_USING_OFFSET`:
- Dynamically retrieves the size of the first sector of `TARGET_IMAGE_AREA` during `frag_flash_init()` using `flash_area_sectors()`.
- Uses this sector size as a dynamic write/read/cache-flush offset.
- Adds bounds checking to ensure the computed offset is valid and fits within the flash area size.
- Strictly guards the offset logic behind `#if IS_ENABLED(CONFIG_MCUBOOT_BOOTBOOTLOADER_MODE_SWAP_USING_OFFSET)` to maintain zero-overhead behavior when offset mode is disabled.

### Testing Performed

- Verified end-to-end LoRaWAN FUOTA firmware updates on custom STM32WL hardware using Zephyr v4.4.1 + MCUboot v2.4.0 in `swap-using-offset` mode.
- Confirmed that fragments are correctly written with the sector offset, MCUboot recognizes the image header/magic upon reboot, executes the swap via offset algorithm, and correctly handles reverts if an image fails confirmation.