### PR TITLE
MAINTAINERS: increase coverage for system timer driver

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2837,6 +2837,8 @@ Documentation Infrastructure:
     - "area: Timer"
   tests:
     - drivers.timer
+    - kernel
+    - arch
 
 "Drivers: Time Aware GPIO":
   status: maintained


### PR DESCRIPTION
Need more coverage when system timer driver changes to catch any issues
in timeout and time management in the kernel.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
