### PR TITLE
boards: nxp: frdm_imxrt1186: document Ethernet vs EtherCAT jumpers

### DIFF
--- a/boards/nxp/frdm_imxrt1186/doc/index.rst
+++ b/boards/nxp/frdm_imxrt1186/doc/index.rst
@@ -180,8 +180,8 @@ DSA master port. DSA master port support is TODO work.
 
 For FRDM-iMXRT1186, the following network interfaces present:
 
-- ``swp0`` and ``swp2``: user ports which can be used.
-- ``swp4``: DSA CPU port. Not a user port.
+- ``swp0`` and ``swp1``: user ports which can be used.
+- ``swp2``: DSA CPU port. Not a user port.
 - ``eth0``: DSA conduit port. Not a user port.
 
 On the FRDM-iMXRT1186 board, the two Ethernet connectors are shared between
@@ -194,7 +194,7 @@ network interfaces:
 
 .. note::
 
-   DHCP is expected to work on ``swp0`` and ``swp2``.
+   DHCP is expected to work on ``swp0`` and ``swp1``.
 
 .. code-block:: none
 

--- a/boards/nxp/frdm_imxrt1186/doc/index.rst
+++ b/boards/nxp/frdm_imxrt1186/doc/index.rst
@@ -184,6 +184,14 @@ For FRDM-iMXRT1186, the following network interfaces present:
 - ``swp4``: DSA CPU port. Not a user port.
 - ``eth0``: DSA conduit port. Not a user port.
 
+On the FRDM-iMXRT1186 board, the two Ethernet connectors are shared between
+the NETC (``ETH0``/``ETH2``) and EtherCAT (``ECAT0``/``ECAT1``) interfaces.
+Set the following jumpers to route the connectors to NETC before using the
+network interfaces:
+
+- ``ETH0`` instead of ``ECAT0``: J12 short pins 1-2, J13 short pins 2-3.
+- ``ETH2`` instead of ``ECAT1``: J18 short pins 1-2, J17 short pins 2-3.
+
 .. note::
 
    DHCP is expected to work on ``swp0`` and ``swp2``.


### PR DESCRIPTION
The ETH0 and ETH2 connectors on the FRDM-IMXRT1186 board are shared between the NETC and EtherCAT interfaces, selected by on-board jumpers. The Ethernet documentation added in #104945 did not mention them, so with the default/EtherCAT jumper setting the DSA network interfaces cannot link up and there is no hint in the docs about why.

Add the required jumper settings (J12/J13 for ETH0, J18/J17 for ETH2) to the board Ethernet documentation.

Documentation-only change, follow-up to #104945.