### PR TITLE
runners: pyocd: add reset

### DIFF
--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -78,7 +78,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach', 'rtt'},
+        return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach', 'rtt', 'reset'},
                           dev_id=True, flash_addr=True, erase=True, skip_load=True,
                           tool_opt=True, rtt=True)
 
@@ -145,10 +145,25 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
         self.require(self.pyocd)
         if command == 'rtt':
             self.rtt(**kwargs)
+        elif command == 'reset':
+            self.reset(**kwargs)
         elif command == 'flash':
             self.flash(**kwargs)
         else:
             self.debug_debugserver(command, **kwargs)
+
+    def reset(self, **kwargs):
+        cmd = ([self.pyocd] +
+               ['reset'] +
+               self.pyocd_config_args +
+               self.daparg_args +
+               self.target_args +
+               self.board_args +
+               self.frequency_args +
+               self.tool_opt_args +
+               self.flash_extra)
+
+        self.check_call(cmd)
 
     def flash(self, **kwargs):
         # Use hex, bin or elf file provided by the buildsystem.

--- a/scripts/west_commands/tests/test_pyocd.py
+++ b/scripts/west_commands/tests/test_pyocd.py
@@ -121,6 +121,17 @@ DEBUGSERVER_DEF_EXPECTED_CALL = ['pyocd',
                                  '-t', TEST_TARGET]
 
 
+RESET_ALL_EXPECTED_CALL = [TEST_PYOCD,
+                           'reset',
+                           '-da', TEST_DAPARG,
+                           '-t', TEST_TARGET,
+                           '-u', TEST_DEV_ID,
+                           '-f', TEST_FREQUENCY] + TEST_TOOL_OPTS + TEST_FLASH_OPTS
+RESET_DEF_EXPECTED_CALL = ['pyocd',
+                           'reset',
+                           '-t', TEST_TARGET]
+
+
 #
 # Fixtures
 #
@@ -196,6 +207,18 @@ def test_debugserver(require, cc, pyocd_args, expected, pyocd):
     cc.assert_called_once_with(expected)
 
 
+@pytest.mark.parametrize('pyocd_args,expected', [
+    (TEST_ALL_KWARGS, RESET_ALL_EXPECTED_CALL),
+    (TEST_DEF_KWARGS, RESET_DEF_EXPECTED_CALL)
+])
+@patch('runners.pyocd.PyOcdBinaryRunner.check_call')
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
+def test_reset(require, cc, pyocd_args, expected, pyocd):
+    pyocd(pyocd_args).run('reset')
+    assert require.called
+    cc.assert_called_once_with(expected)
+
+
 #
 # Test cases for runners created via command line arguments.
 #
@@ -242,6 +265,20 @@ def test_debug_args(require, rsc, bc, pyocd_args, expectedv, pyocd):
 @patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
 def test_debugserver_args(require, cc, bc, pyocd_args, expected, pyocd):
     pyocd(pyocd_args).run('debugserver')
+    assert require.called
+    bc.assert_called_once_with(RC_BUILD_DIR)
+    cc.assert_called_once_with(expected)
+
+
+@pytest.mark.parametrize('pyocd_args, expected', [
+    (TEST_ALL_PARAMS, RESET_ALL_EXPECTED_CALL),
+    (TEST_DEF_PARAMS, RESET_DEF_EXPECTED_CALL),
+])
+@patch('runners.pyocd.BuildConfiguration')
+@patch('runners.pyocd.PyOcdBinaryRunner.check_call')
+@patch('runners.core.ZephyrBinaryRunner.require', side_effect=require_patch)
+def test_reset_args(require, cc, bc, pyocd_args, expected, pyocd):
+    pyocd(pyocd_args).run('reset')
     assert require.called
     bc.assert_called_once_with(RC_BUILD_DIR)
     cc.assert_called_once_with(expected)


### PR DESCRIPTION
Add the ability for the pyocd runner to reset the device. Add pytest to cover use case.

tests:

`west reset -r pycod` on the nucleo u385rg_q 

```
pytest -q scripts/west_commands/tests/test_pyocd.py 
................                                           [100%]
16 passed in 0.04s
```