### PR TITLE
drivers: fuel_gauge: sbs_gauge: Cast average current to signed int16

### DIFF
--- a/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
+++ b/drivers/fuel_gauge/sbs_gauge/sbs_gauge.c
@@ -92,7 +92,7 @@ static int sbs_gauge_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 	switch (prop) {
 	case FUEL_GAUGE_AVG_CURRENT_UA:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_AVG_CURRENT, &tmp_val);
-		val->avg_current_ua = tmp_val * 1000;
+		val->avg_current_ua = (int16_t)tmp_val * 1000;
 		break;
 	case FUEL_GAUGE_CYCLE_COUNT:
 		rc = sbs_cmd_reg_read(dev, SBS_GAUGE_CMD_CYCLE_COUNT, &tmp_val);


### PR DESCRIPTION
SBS_GAUGE_CMD_AVG_CURRENT returns a 16-bit signed integer (in mA, negative when discharging). Cast tmp_val to int16_t before multiplying by 1000 so negative values are properly extended to int32_t instead of producing large positive uA values.