### PR TITLE
boards: nxp: frdm_imxrt1186: doc: update Ethernet documentation

### DIFF
--- a/boards/nxp/frdm_imxrt1186/doc/index.rst
+++ b/boards/nxp/frdm_imxrt1186/doc/index.rst
@@ -186,6 +186,12 @@ For FRDM-iMXRT1186, the following network interfaces present:
 
 .. note::
 
+   To have the Ethernet operations on ETH0 (``swp0``) and ETH2 (``swp2``), set the
+   jumpers as follows:
+
+   - ETH0: set **J12** to pins 1-2 and **J13** to pins 2-3.
+   - ETH2: set **J18** to pins 1-2 and **J17** to pins 2-3.
+
    DHCP is expected to work on ``swp0`` and ``swp2``.
 
 .. code-block:: none

--- a/boards/nxp/frdm_imxrt1186/doc/index.rst
+++ b/boards/nxp/frdm_imxrt1186/doc/index.rst
@@ -180,19 +180,19 @@ DSA master port. DSA master port support is TODO work.
 
 For FRDM-iMXRT1186, the following network interfaces present:
 
-- ``swp0`` and ``swp2``: user ports which can be used.
-- ``swp4``: DSA CPU port. Not a user port.
+- ``swp0`` and ``swp1``: user ports which can be used.
+- ``swp2``: DSA CPU port. Not a user port.
 - ``eth0``: DSA conduit port. Not a user port.
 
 .. note::
 
-   To have the Ethernet operations on ETH0 (``swp0``) and ETH2 (``swp2``), set the
+   To have the Ethernet operations on ETH0 (``swp0``) and ETH2 (``swp1``), set the
    jumpers as follows:
 
    - ETH0: set **J12** to pins 1-2 and **J13** to pins 2-3.
    - ETH2: set **J18** to pins 1-2 and **J17** to pins 2-3.
 
-   DHCP is expected to work on ``swp0`` and ``swp2``.
+   DHCP is expected to work on ``swp0`` and ``swp1``.
 
 .. code-block:: none
 


### PR DESCRIPTION
boards: nxp: frdm_imxrt1186: doc: add jumper settings for Ethernet ports

Document the jumper configuration required to use the ETH0 and ETH2 ports on the FRDM-iMXRT1186 board:

- ETH0 (swp0): J12 pins 1-2, J13 pins 2-3
- ETH2 (swp2): J18 pins 1-2, J17 pins 2-3

Motivation: Multiple people in my team ran into issues due to a bad jumper configuration. This documents the right configuration so that it is more explicit.

----

And in a second commit:
boards: nxp: frdm_imxrt1186: doc: update ethernet interface names

Commit 81f724c23fe6fad ("ethernet: dsa: Avoid DSA interface name clashes") changed the port numbering. Adapt the doc to match the new interface names.