### PR TITLE
drivers: fuel_gauge: bq40z50: Read operation status for charge cutoff

### DIFF
--- a/drivers/fuel_gauge/bq40z50/bq40z50.c
+++ b/drivers/fuel_gauge/bq40z50/bq40z50.c
@@ -240,7 +240,7 @@ static int bq40z50_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		break;
 
 	case FUEL_GAUGE_CHARGE_CUTOFF:
-		ret = bq40z50_i2c_read(dev, BQ40Z50_MANUFACTURERACCESS, (uint8_t *)&tmp_val,
+		ret = bq40z50_i2c_read(dev, BQ40Z50_OPERATIONSTATUS, (uint8_t *)&tmp_val,
 				       BQ40Z50_LEN_HALF_WORD);
 		val->cutoff = IS_BIT_SET(tmp_val, BQ40Z50_OPERATION_STATUS_XCHG_BIT);
 		break;


### PR DESCRIPTION
Read BQ40Z50_OPERATIONSTATUS (0x54) instead of BQ40Z50_MANUFACTURERACCESS (0x00) when checking BQ40Z50_OPERATION_STATUS_XCHG_BIT for charge cutoff.

<img width="742" height="400" alt="image" src="https://github.com/user-attachments/assets/8a301d7c-73c5-4a9b-93ef-a328352fc79d" />

<img width="249" height="81" alt="image" src="https://github.com/user-attachments/assets/84d5071f-537f-41a9-a8ae-1477f64b2f4b" />
