### PR TITLE
drivers: fuel_gauge: lc709203f: Propagate error code from temp mode config

### DIFF
--- a/drivers/fuel_gauge/lc709203f/lc709203f.c
+++ b/drivers/fuel_gauge/lc709203f/lc709203f.c
@@ -474,7 +474,7 @@ static int lc709203f_init(const struct device *dev)
 
 	if (config->thermistor) {
 		LOG_DBG("Set temperature mode: %d", config->thermistor_mode);
-		lc709203f_set_temp_mode(dev, config->thermistor_mode);
+		ret = lc709203f_set_temp_mode(dev, config->thermistor_mode);
 		if (ret) {
 			LOG_ERR("Failed to set temperature mode: %d", ret);
 		}


### PR DESCRIPTION
Store the return value of lc709203f_set_temp_mode() in ret so errors during temperature mode configuration are properly logged and detected rather than testing a stale return value.