### PR TITLE
logging: frontend: stmesp: Use CONFIG_LOG_FRONTEND_STMESP_TURBO_LOG_BASE

### DIFF
--- a/subsys/logging/frontends/log_frontend_stmesp.c
+++ b/subsys/logging/frontends/log_frontend_stmesp.c
@@ -668,7 +668,7 @@ int log_frontend_stmesp_etr_ready(void)
 void log_frontend_stmesp_log0(const void *source, uint32_t x)
 {
 	STMESP_Type *port;
-	int err = stmesp_get_port((uint32_t)x + 0x8000, &port);
+	int err = stmesp_get_port((uint32_t)x + CONFIG_LOG_FRONTEND_STMESP_TURBO_LOG_BASE, &port);
 	uint16_t source_id = log_source_id(source);
 
 	__ASSERT_NO_MSG(err == 0);
@@ -681,7 +681,7 @@ void log_frontend_stmesp_log0(const void *source, uint32_t x)
 void log_frontend_stmesp_log1(const void *source, uint32_t x, uint32_t arg)
 {
 	STMESP_Type *port;
-	int err = stmesp_get_port((uint32_t)x + 0x8000, &port);
+	int err = stmesp_get_port((uint32_t)x + CONFIG_LOG_FRONTEND_STMESP_TURBO_LOG_BASE, &port);
 	uint16_t source_id = log_source_id(source);
 
 	__ASSERT_NO_MSG(err == 0);


### PR DESCRIPTION
Replace hardcoded 0x8000 base address values with the CONFIG_LOG_FRONTEND_STMESP_TURBO_LOG_BASE configuration parameter. This parameter was previously defined but never used. Using it makes the code more configurable and allows the base address to be adjusted via kconfig without modifying source code.

<img width="1862" height="706" alt="image" src="https://github.com/user-attachments/assets/9cc7396c-faf0-4afb-bbdf-7a884415ddd8" />
