### PR TITLE
toolchain: fix deprecation warning for iar

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -680,6 +680,7 @@ do {                                                                    \
 #define TOOLCHAIN_WARNING_ARRAY_BOUNDS             "-Warray-bounds"
 #define TOOLCHAIN_WARNING_ATTRIBUTES               "-Wattributes"
 #define TOOLCHAIN_WARNING_DELETE_NON_VIRTUAL_DTOR  "-Wdelete-non-virtual-dtor"
+#define TOOLCHAIN_WARNING_DEPRECATED_DECLARATIONS  "-Wdeprecated-declarations"
 #define TOOLCHAIN_WARNING_EXTRA                    "-Wextra"
 #define TOOLCHAIN_WARNING_NONNULL                  "-Wnonnull"
 #define TOOLCHAIN_WARNING_SHADOW                   "-Wshadow"

--- a/include/zephyr/toolchain/iar.h
+++ b/include/zephyr/toolchain/iar.h
@@ -67,6 +67,17 @@
 #endif
 
 /**
+ * @def TOOLCHAIN_WARNING_DEPRECATED_DECLARATIONS
+ * @brief Toolchain-specific warning for deprecated declarations
+ *
+ * Use this as an argument to the @ref TOOLCHAIN_DISABLE_WARNING and
+ * @ref TOOLCHAIN_ENABLE_WARNING family of macros.
+ */
+#ifndef TOOLCHAIN_WARNING_DEPRECATED_DECLARATIONS
+#define TOOLCHAIN_WARNING_DEPRECATED_DECLARATIONS Pe1215
+#endif
+
+/**
  * @def TOOLCHAIN_WARNING_EXTRA
  * @brief Toolchain-specific warning for extra warnings.
  *

--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -58,6 +58,7 @@
 #define TOOLCHAIN_WARNING_USED_BUT_MARKED_UNUSED        "-Wused-but-marked-unused"
 #define TOOLCHAIN_WARNING_UNALIGNED_ACCESS              "-Wunaligned-access"
 #define TOOLCHAIN_WARNING_ARM_INTERRUPT_VFP_CLOBBER     "-Warm-interrupt-vfp-clobber"
+#define TOOLCHAIN_WARNING_DEPRECATED_DECLARATIONS       "-Wdeprecated-declarations"
 /** @endcond */
 
 #define TOOLCHAIN_DISABLE_CLANG_WARNING(warning) _TOOLCHAIN_DISABLE_WARNING(clang, warning)

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -856,7 +856,7 @@ void k_work_queue_start(struct k_work_q *queue,
 	/* In future, this whole function will be deprecated, but for now, we
 	 * have to use the `thread` field to create a new thread in it.
 	 */
-	TOOLCHAIN_DISABLE_WARNING("-Wdeprecated-declarations");
+	TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_DEPRECATED_DECLARATIONS);
 
 	uint32_t flags = K_WORK_QUEUE_STARTED;
 
@@ -901,7 +901,7 @@ void k_work_queue_start(struct k_work_q *queue,
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work_queue, start, queue);
 
-	TOOLCHAIN_ENABLE_WARNING("-Wdeprecated-declarations");
+	TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_DEPRECATED_DECLARATIONS);
 }
 
 int k_work_queue_drain(struct k_work_q *queue,


### PR DESCRIPTION
In commit 4f9df472fc1d06a6deeb7dddf6ab167c7cba984f TOOLCHAIN_DISABLE_WARNING with a hard coded argument in work.c. This created warnings when using the iar toolchain. Fix it by using a preprocessor macro.