### PR TITLE
drivers: ethernet: nxp_imx_netc: add NETC VSI driver

### DIFF
--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.dts
@@ -101,6 +101,8 @@
 	pinctrl-names = "default";
 	phy-handle = <&phy2>;
 	phy-connection-type = "rgmii";
+	zephyr,random-mac-address;
+	zephyr,mac-address-prefix = [00 04 9f];
 	status = "okay";
 };
 
@@ -109,6 +111,8 @@
 	pinctrl-names = "default";
 	phy-handle = <&phy3>;
 	phy-connection-type = "rgmii";
+	zephyr,random-mac-address;
+	zephyr,mac-address-prefix = [00 04 9f];
 	status = "okay";
 };
 
@@ -117,6 +121,8 @@
 	pinctrl-names = "default";
 	phy-handle = <&phy4>;
 	phy-connection-type = "rgmii";
+	zephyr,random-mac-address;
+	zephyr,mac-address-prefix = [00 04 9f];
 	status = "okay";
 };
 

--- a/boards/nxp/mr_navq95b/doc/index.rst
+++ b/boards/nxp/mr_navq95b/doc/index.rst
@@ -117,6 +117,58 @@ When running the firmware from external flash, the standard boot flow involves:
 4. Firmware executes from flash (XIP)
 
 
+Ethernet: running a NETC VSI alongside Linux
+********************************************
+
+The i.MX95 NETC (ENETC) Ethernet controller is shared between Linux on the
+Cortex-A55 cores and Zephyr on the Cortex-M7. Linux owns the physical port and
+PHY through the Physical Station Interface (PSI), which shows up as the ``end0``
+network interface. Zephyr on the M7 uses a Virtual Station Interface (VSI) - a
+virtual function (VF) of the same controller (``enetc0_vsi1``, ENETC0 VF1) - and
+sends and receives through that shared port.
+
+The VF belongs to the PF, so Linux must create and hand over the VF before the
+M7 can use it. The M7 driver never touches the PHY or the PF; it only brings up
+its own station interface and asks the PSI to set its MAC filter over the NETC
+VSI-to-PSI message channel.
+
+Linux device tree
+=================
+
+No M7-specific change is required in the Linux device tree. The default NavQ95
+Linux image (see `NXP IMX-MANIFEST-NAVQ95`_) already enables the ENETC0 PF as
+``end0`` with SR-IOV support, which is all that is needed. The VF itself is
+created at runtime (below), not described statically in the device tree.
+
+Bringing up the VF from Linux
+=============================
+
+Run the following once on the A55 (as root) after Linux has booted, where
+``end0`` is the ENETC0 PF handed to the M7 as VF1:
+
+.. code-block:: bash
+
+   # Keep Linux's VF driver off the VF so the M7 can own it, then create VF0+VF1.
+   echo 0 > /sys/class/net/end0/device/sriov_drivers_autoprobe
+   echo 2 > /sys/class/net/end0/device/sriov_numvfs
+
+   # Resolve the VF1 PCI address and let it DMA and raise MSI-X interrupts.
+   vf=$(basename "$(readlink -f /sys/class/net/end0/device/virtfn1)")
+   setpci -s "$vf" COMMAND=0x0006          # Bus Master Enable
+   setpci -s "$vf" CAP_MSIX+2.w=0x8000:0x8000
+
+   # Trust the VF so the PSI honours the M7 driver's MAC-filter requests.
+   ip link set end0 vf 1 trust on
+
+After this, the M7 VSI driver sees that the VF is enabled and comes up on the
+network through ``end0``.
+
+.. note::
+
+   The NavQ95 BSP (see `NXP IMX-MANIFEST-NAVQ95`_) ships an
+   ``enetc-vsi-handoff-mcore`` service that runs these steps at boot, so you
+   normally do not run them by hand. They are shown here for custom setups.
+
 .. include:: ../../common/board-footer.rst.inc
 
 References

--- a/boards/nxp/mr_navq95b/mr_navq95b_mimx9596_m7.dts
+++ b/boards/nxp/mr_navq95b/mr_navq95b_mimx9596_m7.dts
@@ -239,3 +239,24 @@
 &tstmr2 {
 	status = "okay";
 };
+
+/*
+ * The NETC block controller (IERB/NETCMIX/PRB) and the ENETC PSIs are owned by
+ * Linux on the Cortex-A55. The M7 only drives ENETC0 VF1 as a VSI, talking to
+ * the Linux PSI over the VSI-to-PSI message channel.
+ */
+&netc_blk_ctrl {
+	status = "disabled";
+};
+
+&enetc0_vsi1 {
+	zephyr,random-mac-address;
+	zephyr,mac-address-prefix = [00 04 9f];
+	status = "okay";
+};
+
+&enetc2_vsi1 {
+	zephyr,random-mac-address;
+	zephyr,mac-address-prefix = [00 04 9f];
+	status = "okay";
+};

--- a/drivers/clock_control/clock_control_arm_scmi.c
+++ b/drivers/clock_control/clock_control_arm_scmi.c
@@ -116,11 +116,37 @@ static int scmi_clock_set_rate(const struct device *dev,
 	return scmi_clock_rate_set(proto, &cfg);
 }
 
+static enum clock_control_status scmi_clock_get_status(const struct device *dev,
+						       clock_control_subsys_t clk)
+{
+	struct scmi_clock_data *data;
+	struct scmi_protocol *proto;
+	uint32_t clk_id, config;
+	int ret;
+
+	proto = dev->data;
+	data = proto->data;
+	clk_id = POINTER_TO_UINT(clk);
+
+	if (clk_id >= data->clk_num) {
+		return CLOCK_CONTROL_STATUS_UNKNOWN;
+	}
+
+	ret = scmi_clock_config_get(proto, clk_id, 0, &config);
+	if (ret < 0) {
+		return CLOCK_CONTROL_STATUS_UNKNOWN;
+	}
+
+	return SCMI_CLK_CONFIG_ENABLE_DISABLE(config) == 1U ? CLOCK_CONTROL_STATUS_ON
+							    : CLOCK_CONTROL_STATUS_OFF;
+}
+
 static DEVICE_API(clock_control, scmi_clock_api) = {
 	.on = scmi_clock_on,
 	.off = scmi_clock_off,
 	.get_rate = scmi_clock_get_rate,
 	.set_rate = scmi_clock_set_rate,
+	.get_status = scmi_clock_get_status,
 };
 
 static int scmi_clock_init(const struct device *dev)

--- a/drivers/ethernet/nxp_imx_netc/CMakeLists.txt
+++ b/drivers/ethernet/nxp_imx_netc/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 if(CONFIG_ETH_NXP_IMX_NETC)
   zephyr_library_sources(eth_nxp_imx_netc.c)
-  zephyr_library_sources(eth_nxp_imx_netc_psi.c)
+  zephyr_library_sources_ifdef(CONFIG_DT_HAS_NXP_IMX_NETC_PSI_ENABLED eth_nxp_imx_netc_psi.c)
+  zephyr_library_sources_ifdef(CONFIG_DT_HAS_NXP_IMX_NETC_VSI_ENABLED eth_nxp_imx_netc_vsi.c)
+  zephyr_library_sources_ifdef(CONFIG_DT_HAS_NXP_IMX_NETC_VSI_ENABLED eth_nxp_imx_netc_msg.c)
   zephyr_library_sources_ifdef(CONFIG_DT_HAS_NXP_IMX_NETC_BLK_CTRL_ENABLED eth_nxp_imx_netc_blk.c)
 endif()

--- a/drivers/ethernet/nxp_imx_netc/Kconfig
+++ b/drivers/ethernet/nxp_imx_netc/Kconfig
@@ -4,11 +4,19 @@
 menuconfig ETH_NXP_IMX_NETC
 	bool "NXP IMX Ethernet and Network Controller (NETC) driver"
 	default y
-	depends on DT_HAS_NXP_IMX_NETC_PSI_ENABLED
+	depends on DT_HAS_NXP_IMX_NETC_PSI_ENABLED || DT_HAS_NXP_IMX_NETC_VSI_ENABLED
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	select NET_CHECKSUM_OFFLOAD_SUPPORTED if NET_L2_ETHERNET
 	help
 	  Enable Ethernet and Network Controller (NETC) driver for NXP IMX SoCs.
+	  Supports both the Physical Station Interface (PSI) and the Virtual
+	  Station Interface (VSI).
+
+	  Note: the VSI support targets the AMP use case where Zephyr owns a VSI
+	  (a VF) while another OS owns the PSI (the PF). The Zephyr PSI driver
+	  implements neither SR-IOV nor the PSI side of the PSI-to-VSI message
+	  channel, so a Zephyr VSI paired with a Zephyr PSI is not supported. Only
+	  a Zephyr VSI paired with a Linux PSI has been tested.
 
 if ETH_NXP_IMX_NETC
 
@@ -69,7 +77,7 @@ config ETH_NXP_IMX_TX_RING_LEN
 
 config ETH_NXP_IMX_TX_RING_BUF_SIZE
 	int "TX ring data buffer size"
-	default 1000
+	default 1518
 	range 64 1536
 	help
 	  Size, in bytes, of the TX data buffer. The size must be big enough to
@@ -97,5 +105,19 @@ config ETH_NXP_IMX_RX_RING_BUF_SIZE
 	help
 	  Size, in bytes, of the RX data buffer. The size must be big enough to
 	  store one complete Ethernet frame, and be a multiple of 8.
+
+if DT_HAS_NXP_IMX_NETC_VSI_ENABLED
+
+config ETH_NXP_IMX_NETC_VSI_READY_POLL_INTERVAL_MS
+	int "VSI readiness-gate poll interval (ms)"
+	default 100
+	range 1 10000
+	help
+	  Interval at which the VSI service thread polls its readiness gates before
+	  the first SI access: the optional SCMI clock-status gate (when the node
+	  has a "clocks" property) and the parent PF's SR-IOV VF-enable bits in
+	  ECAM. Both are fault-free (they never touch the not-yet-decoding SI).
+
+endif # DT_HAS_NXP_IMX_NETC_VSI_ENABLED
 
 endif # ETH_NXP_IMX_NETC

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -394,7 +394,10 @@ int netc_eth_init_common(const struct device *dev)
 	ep_config.rxCacheMaintain = true;
 	ep_config.txCacheMaintain = true;
 
-	config->generate_mac(&data->mac_addr[0]);
+	if (net_eth_mac_load(&config->mac_config, data->mac_addr) == -ENODATA) {
+		LOG_WRN("No MAC address in the device tree; set local-mac-address or "
+			"zephyr,random-mac-address");
+	}
 
 	result = EP_Init(&data->handle, &data->mac_addr[0], &ep_config, &bdr_config);
 	if (result != kStatus_Success) {

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -685,6 +685,30 @@ enum ethernet_hw_caps netc_eth_get_capabilities(const struct device *dev __maybe
 	return caps;
 }
 
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+struct net_stats_eth *netc_eth_get_stats(const struct device *dev, struct net_if *iface __unused)
+{
+	struct netc_eth_data *data = dev->data;
+	const struct netc_eth_config *cfg = dev->config;
+
+#ifdef CONFIG_DT_HAS_NXP_IMX_NETC_VSI_ENABLED
+	/* Stats are only available once the VSI is fully ready. */
+	if (cfg->is_vsi && !data->si_ready) {
+		return &data->stats;
+	}
+#else
+	ARG_UNUSED(cfg);
+#endif
+
+	/* SITDFCR counts frames discarded on this SI's transmit path. */
+#ifdef ENETC_SI_SITDFCR_COUNT_MASK
+	data->stats.tx_dropped = data->handle.hw.si->SITDFCR;
+#endif
+
+	return &data->stats;
+}
+#endif /* CONFIG_NET_STATISTICS_ETHERNET */
+
 int netc_eth_set_config(const struct device *dev, struct net_if *iface __unused,
 			enum ethernet_config_type type, const struct ethernet_config *config)
 {

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -24,7 +24,10 @@ LOG_MODULE_REGISTER(nxp_imx_eth);
 #include "../eth.h"
 #include "eth_nxp_imx_netc_priv.h"
 
+#ifdef CONFIG_ETH_NXP_IMX_MSGINTR
+/* Devices sharing the MSGINTR line; msgintr_isr dispatches Tx/Rx across them. */
 const struct device *netc_dev_list[NETC_DRV_MAX_INST_SUPPORT];
+#endif
 
 #ifdef CONFIG_PTP_CLOCK_NXP_NETC
 static void netc_eth_pkt_get_timestamp(struct net_pkt *pkt, const struct device *ptp_clock,
@@ -113,7 +116,7 @@ static status_t netc_eth_get_tx_response(const struct device *dev, swt_tsr_resp_
 }
 #endif
 
-static int netc_eth_rx(const struct device *dev)
+int netc_eth_rx(const struct device *dev)
 {
 	struct netc_eth_data *data = dev->data;
 	struct net_if *iface_dst = data->iface;
@@ -233,6 +236,14 @@ static void netc_eth_rx_thread(void *arg1, void *unused1, void *unused2)
 	}
 }
 
+void netc_eth_tx_coalesce_init(struct netc_eth_data *data)
+{
+	/* HAL leaves Tx coalescing regs unset: fire after ICPT frames, ICTT timeout. */
+	data->handle.hw.si->BDR[0].TBICR1 = ENETC_SI_TBICR1_ICTT(NETC_TX_COALESCE_TICKS);
+	data->handle.hw.si->BDR[0].TBICR0 =
+		ENETC_SI_TBICR0_ICEN_MASK | ENETC_SI_TBICR0_ICPT(NETC_TX_COALESCE_FRAMES);
+}
+
 #ifdef CONFIG_ETH_NXP_IMX_NETC_MSI_GIC
 
 static void netc_tx_isr_handler(const void *arg)
@@ -240,8 +251,9 @@ static void netc_tx_isr_handler(const void *arg)
 	const struct device *dev = (const struct device *)arg;
 	struct netc_eth_data *data = dev->data;
 
-	EP_CleanTxIntrFlags(&data->handle, 1, 0);
-	data->tx_done = true;
+	/* Clear both Tx flags (per-frame and threshold). */
+	EP_CleanTxIntrFlags(&data->handle, 1, 1);
+	k_sem_give(&data->tx_sem);
 }
 
 static void netc_rx_isr_handler(const void *arg)
@@ -272,17 +284,67 @@ static void msgintr_isr(void)
 		data = dev->data;
 		/* Transmit interrupt */
 		if (irqs & (1 << config->tx_intr_msg_data)) {
-			EP_CleanTxIntrFlags(&data->handle, 1, 0);
-			data->tx_done = true;
+			EP_CleanTxIntrFlags(&data->handle, 1, 1);
+			k_sem_give(&data->tx_sem);
 		}
 		/* Receive interrupt */
 		if (irqs & (1 << config->rx_intr_msg_data)) {
 			EP_CleanRxIntrFlags(&data->handle, 1);
 			k_sem_give(&data->rx_sem);
 		}
+#ifdef CONFIG_DT_HAS_NXP_IMX_NETC_VSI_ENABLED
+		/* VSI PSI->VSI message interrupt (e.g. link-status notify) */
+		if (config->is_vsi && (irqs & (1 << config->msg_intr_msg_data))) {
+			netc_eth_vsi_msg_isr(dev);
+		}
+#endif
 	}
 
 	SDK_ISR_EXIT_BARRIER;
+}
+
+/*
+ * Register the device with the shared MSGINTR, point its SI Tx/Rx MSI-X vectors
+ * at that line, hook the ISR once, and unmask. msgintr_isr dispatches to every
+ * device registered here. The MSI-X function-enable itself lives in the SI
+ * function config (EP_Init for the PSI, the PSI owner for the VSI); this only
+ * owns the SI-side table.
+ */
+void netc_eth_msgintr_arm(const struct device *dev)
+{
+	const struct netc_eth_config *config = dev->config;
+	struct netc_eth_data *data = dev->data;
+	uint32_t msg_addr = MSGINTR_GetIntrSelectAddr(NETC_MSGINTR, NETC_MSGINTR_CHANNEL);
+
+	for (int i = 0; i < NETC_DRV_MAX_INST_SUPPORT; i++) {
+		if (!netc_dev_list[i]) {
+			netc_dev_list[i] = dev;
+			break;
+		}
+	}
+
+	if (!irq_is_enabled(NETC_MSGINTR_IRQ)) {
+		IRQ_CONNECT(NETC_MSGINTR_IRQ, 0, msgintr_isr, 0, 0);
+		irq_enable(NETC_MSGINTR_IRQ);
+	}
+
+	data->handle.hw.msixTable[NETC_TX_MSIX_ENTRY_IDX].msgAddr = msg_addr;
+	data->handle.hw.msixTable[NETC_TX_MSIX_ENTRY_IDX].msgData = config->tx_intr_msg_data;
+	data->handle.hw.msixTable[NETC_RX_MSIX_ENTRY_IDX].msgAddr = msg_addr;
+	data->handle.hw.msixTable[NETC_RX_MSIX_ENTRY_IDX].msgData = config->rx_intr_msg_data;
+
+	EP_MsixSetEntryMask(&data->handle, NETC_TX_MSIX_ENTRY_IDX, false);
+	EP_MsixSetEntryMask(&data->handle, NETC_RX_MSIX_ENTRY_IDX, false);
+
+#ifdef CONFIG_DT_HAS_NXP_IMX_NETC_VSI_ENABLED
+	/* VSI has a third entry for the PSI->VSI message (link-notify) interrupt. */
+	if (config->is_vsi) {
+		data->handle.hw.msixTable[NETC_MSG_MSIX_ENTRY_IDX].msgAddr = msg_addr;
+		data->handle.hw.msixTable[NETC_MSG_MSIX_ENTRY_IDX].msgData =
+			config->msg_intr_msg_data;
+		EP_MsixSetEntryMask(&data->handle, NETC_MSG_MSIX_ENTRY_IDX, false);
+	}
+#endif
 }
 
 #endif
@@ -291,12 +353,11 @@ int netc_eth_init_common(const struct device *dev)
 {
 	const struct netc_eth_config *config = dev->config;
 	struct netc_eth_data *data = dev->data;
-	netc_msix_entry_t msix_entry[NETC_MSIX_ENTRY_NUM];
+	netc_msix_entry_t msix_entry[config->msix_entry_num];
 	netc_rx_bdr_config_t rx_bdr_config = {0};
 	netc_tx_bdr_config_t tx_bdr_config = {0};
 	netc_bdr_config_t bdr_config = {0};
 	ep_config_t ep_config;
-	uint32_t msg_addr;
 	status_t result;
 
 	config->bdr_init(&bdr_config, &rx_bdr_config, &tx_bdr_config);
@@ -320,12 +381,13 @@ int netc_eth_init_common(const struct device *dev)
 	/* MSIX entry configuration */
 #ifdef CONFIG_ETH_NXP_IMX_NETC_MSI_GIC
 	int ret;
+	uint32_t msg_addr;
 
 	if (config->msi_dev == NULL) {
 		LOG_ERR("MSI device is not configured");
 		return -ENODEV;
 	}
-	ret = its_setup_deviceid(config->msi_dev, config->msi_device_id, NETC_MSIX_ENTRY_NUM);
+	ret = its_setup_deviceid(config->msi_dev, config->msi_device_id, config->msix_entry_num);
 	if (ret != 0) {
 		LOG_ERR("Failed to setup device ID for MSI: %d", ret);
 		return ret;
@@ -363,19 +425,8 @@ int netc_eth_init_common(const struct device *dev)
 		irq_enable(data->rx_intid);
 	}
 #else
-	msg_addr = MSGINTR_GetIntrSelectAddr(NETC_MSGINTR, NETC_MSGINTR_CHANNEL);
 	msix_entry[NETC_TX_MSIX_ENTRY_IDX].control = kNETC_MsixIntrMaskBit;
-	msix_entry[NETC_TX_MSIX_ENTRY_IDX].msgAddr = msg_addr;
-	msix_entry[NETC_TX_MSIX_ENTRY_IDX].msgData = config->tx_intr_msg_data;
-
 	msix_entry[NETC_RX_MSIX_ENTRY_IDX].control = kNETC_MsixIntrMaskBit;
-	msix_entry[NETC_RX_MSIX_ENTRY_IDX].msgAddr = msg_addr;
-	msix_entry[NETC_RX_MSIX_ENTRY_IDX].msgData = config->rx_intr_msg_data;
-
-	if (!irq_is_enabled(NETC_MSGINTR_IRQ)) {
-		IRQ_CONNECT(NETC_MSGINTR_IRQ, 0, msgintr_isr, 0, 0);
-		irq_enable(NETC_MSGINTR_IRQ);
-	}
 #endif
 
 	/* Endpoint configuration. */
@@ -387,12 +438,13 @@ int netc_eth_init_common(const struct device *dev)
 	ep_config.userData = data;
 	ep_config.reclaimCallback = NULL;
 	ep_config.msixEntry = &msix_entry[0];
-	ep_config.entryNum = NETC_MSIX_ENTRY_NUM;
+	ep_config.entryNum = config->msix_entry_num;
 	ep_config.port.ethMac.miiMode = config->phy_mode;
 	ep_config.port.ethMac.miiSpeed = kNETC_MiiSpeed100M;
 	ep_config.port.ethMac.miiDuplex = kNETC_MiiFullDuplex;
-	ep_config.rxCacheMaintain = true;
-	ep_config.txCacheMaintain = true;
+	/* Buffers/BD rings are non-cacheable; skip HAL cache ops (DSB still runs). */
+	ep_config.rxCacheMaintain = false;
+	ep_config.txCacheMaintain = false;
 
 	if (net_eth_mac_load(&config->mac_config, data->mac_addr) == -ENODATA) {
 		LOG_WRN("No MAC address in the device tree; set local-mac-address or "
@@ -415,16 +467,18 @@ int netc_eth_init_common(const struct device *dev)
 		}
 	}
 
-	for (int i = 0; i < NETC_DRV_MAX_INST_SUPPORT; i++) {
-		if (!netc_dev_list[i]) {
-			netc_dev_list[i] = dev;
-			break;
-		}
-	}
+	netc_eth_tx_coalesce_init(data);
 
+#ifdef CONFIG_ETH_NXP_IMX_NETC_MSI_GIC
 	/* Unmask MSIX message interrupt. */
 	EP_MsixSetEntryMask(&data->handle, NETC_TX_MSIX_ENTRY_IDX, false);
 	EP_MsixSetEntryMask(&data->handle, NETC_RX_MSIX_ENTRY_IDX, false);
+#else
+	/* Point the SI MSI-X table at the shared MSGINTR, hook the ISR, unmask. */
+	netc_eth_msgintr_arm(dev);
+#endif
+
+	k_sem_init(&data->tx_sem, 0, 1);
 
 	k_sem_init(&data->rx_sem, 0, 1);
 	k_thread_create(&data->rx_thread, data->rx_thread_stack,
@@ -436,14 +490,50 @@ int netc_eth_init_common(const struct device *dev)
 	return 0;
 }
 
+/* Reclaim completed Tx BDs, recycling their ring slots. */
+static void netc_eth_tx_reclaim(const struct device *dev)
+{
+	struct netc_eth_data *data = dev->data;
+	netc_tx_frame_info_t *frame_info;
+
+	do {
+		frame_info = EP_ReclaimTxDescCommon(&data->handle, &data->handle.txBdRing[0], 0,
+						    true);
+		if (frame_info != NULL) {
+			if (frame_info->status != kNETC_EPTxSuccess) {
+				eth_stats_update_errors_tx(data->iface);
+			}
+			memset(frame_info, 0, sizeof(netc_tx_frame_info_t));
+		}
+	} while (frame_info != NULL);
+}
+
+/*
+ * Submit one frame to Tx ring 0. DSA passes a caller-built BD carrying the
+ * egress port (EP_SendFrameCommon); otherwise EP_SendFrame honours ep_tx_opt.
+ */
+static status_t netc_eth_tx_submit(struct netc_eth_data *data, netc_frame_struct_t *frame,
+				   netc_tx_bd_t *txDesc, ep_tx_opt *opt)
+{
+#if defined(NETC_SWITCH_NO_TAG_DRIVER_SUPPORT)
+	if (txDesc != NULL) {
+		return EP_SendFrameCommon(&data->handle, &data->handle.txBdRing[0], 0, frame, NULL,
+					  txDesc, data->handle.cfg.txCacheMaintain);
+	}
+#else
+	ARG_UNUSED(txDesc);
+#endif
+	return EP_SendFrame(&data->handle, 0, frame, NULL, opt);
+}
+
 int netc_eth_tx(const struct device *dev, struct net_pkt *pkt)
 {
 	struct netc_eth_data *data = dev->data;
-	netc_buffer_struct_t buff = {.buffer = data->tx_buff, .length = sizeof(data->tx_buff)};
+	netc_buffer_struct_t buff;
 	netc_frame_struct_t frame = {.buffArray = &buff, .length = 1};
-	netc_tx_frame_info_t *frame_info;
 	struct net_if *iface_dst;
 	size_t pkt_len = net_pkt_get_len(pkt);
+	uint16_t slot;
 #if defined(NETC_SWITCH_NO_TAG_DRIVER_SUPPORT)
 	struct ethernet_context *eth_ctx = net_if_l2_data(data->iface);
 #endif
@@ -458,6 +548,12 @@ int netc_eth_tx(const struct device *dev, struct net_pkt *pkt)
 	__ASSERT(pkt, "Packet pointer is NULL");
 
 	iface_dst = data->iface;
+
+	if (pkt_len > CONFIG_ETH_NXP_IMX_TX_RING_BUF_SIZE) {
+		LOG_ERR("Frame length %zu exceeds tx buffer size", pkt_len);
+		eth_stats_update_errors_tx(iface_dst);
+		return -EMSGSIZE;
+	}
 
 	/*
 	 * Pseudo MAC connects to internal switch port.
@@ -486,7 +582,10 @@ int netc_eth_tx(const struct device *dev, struct net_pkt *pkt)
 		opt.flags |= kEP_TX_OPT_REQ_TS;
 	}
 #endif
-	/* Copy packet to tx buffer */
+
+	/* Copy into the current ring slot's buffer; it stays valid until reclaim. */
+	slot = data->handle.txBdRing[0].producerIndex;
+	buff.buffer = data->tx_buff[slot];
 	buff.length = (uint16_t)pkt_len;
 	ret = net_pkt_read(pkt, buff.buffer, pkt_len);
 	if (ret) {
@@ -495,14 +594,13 @@ int netc_eth_tx(const struct device *dev, struct net_pkt *pkt)
 		goto error;
 	}
 
-	/* Send */
-	data->tx_done = false;
-
 #if defined(NETC_SWITCH_NO_TAG_DRIVER_SUPPORT)
+	netc_tx_bd_t txDesc[2] = {0};
+	netc_tx_bd_t *txbd = NULL;
+
 	if (eth_ctx->dsa_port == DSA_CONDUIT_PORT) {
 		const struct dsa_port_config *port_cfg = net_if_get_device(iface_dst)->config;
 		const int dst_port = port_cfg->port_idx;
-		netc_tx_bd_t txDesc[2] = {0};
 
 		txDesc[0].standard.flags = NETC_SI_TXDESCRIP_RD_FLQ(2) |
 					   NETC_SI_TXDESCRIP_RD_SMSO_MASK |
@@ -512,50 +610,57 @@ int netc_eth_tx(const struct device *dev, struct net_pkt *pkt)
 			txDesc[0].standard.flags |= NETC_SI_TXDESCRIP_RD_TSR_MASK;
 		}
 #endif
-		result = EP_SendFrameCommon(&data->handle, &data->handle.txBdRing[0], 0, &frame,
-					    NULL, &txDesc[0], data->handle.cfg.txCacheMaintain);
-	} else {
-		result = EP_SendFrame(&data->handle, 0, &frame, NULL, &opt);
+		txbd = &txDesc[0];
 	}
 #else
-	result = EP_SendFrame(&data->handle, 0, &frame, NULL, &opt);
+	netc_tx_bd_t *txbd = NULL;
 #endif
+
+	/* Full ring (kStatus_Busy): reclaim and retry, then block on tx_sem, don't drop. */
+	result = netc_eth_tx_submit(data, &frame, txbd, &opt);
+	while (result == kStatus_Busy) {
+		netc_eth_tx_reclaim(dev);
+		result = netc_eth_tx_submit(data, &frame, txbd, &opt);
+		if (result == kStatus_Busy) {
+			k_sem_take(&data->tx_sem, K_FOREVER);
+		}
+	}
 	if (result != kStatus_Success) {
 		LOG_ERR("Failed to tx frame");
 		ret = -EIO;
 		goto error;
 	}
 
-	while (!data->tx_done) {
-	}
-
-	do {
-		frame_info = EP_ReclaimTxDescCommon(&data->handle, &data->handle.txBdRing[0],
-						    0, true);
-		if (frame_info != NULL) {
-			if (frame_info->status != kNETC_EPTxSuccess) {
-				memset(frame_info, 0, sizeof(netc_tx_frame_info_t));
-				LOG_ERR("Failed to tx frame");
-				ret = -EIO;
-				goto error;
-			}
-
 #ifdef CONFIG_PTP_CLOCK_NXP_NETC
-			if (frame_info->isTsAvail) {
-				netc_eth_pkt_get_timestamp(pkt, cfg->ptp_clock,
-							   frame_info->timestamp);
-				net_if_add_tx_timestamp(pkt);
-			}
+	/* Busy-wait for this frame's completion, then read its egress timestamp. */
+	if ((opt.flags & (uint32_t)kEP_TX_OPT_REQ_TS) != 0U) {
+		netc_tx_frame_info_t *frame_info;
+		k_timepoint_t deadline = sys_timepoint_calc(NETC_TIMEOUT);
+		bool stamped = false;
+
+		do {
+			frame_info = EP_ReclaimTxDescCommon(&data->handle,
+							    &data->handle.txBdRing[0], 0, true);
+			if (frame_info != NULL) {
+				if (frame_info->isTsAvail) {
+					netc_eth_pkt_get_timestamp(pkt, cfg->ptp_clock,
+								   frame_info->timestamp);
+					net_if_add_tx_timestamp(pkt);
+					stamped = true;
+				}
 #if defined(NETC_SWITCH_NO_TAG_DRIVER_SUPPORT)
-			if (eth_ctx->dsa_port == DSA_CONDUIT_PORT && frame_info->isTxTsIdAvail) {
-				dsa_netc_port_txtsid(net_if_get_device(iface_dst),
-						     frame_info->txtsid);
+				if (eth_ctx->dsa_port == DSA_CONDUIT_PORT &&
+				    frame_info->isTxTsIdAvail) {
+					dsa_netc_port_txtsid(net_if_get_device(iface_dst),
+							     frame_info->txtsid);
+					stamped = true;
+				}
+#endif
+				memset(frame_info, 0, sizeof(netc_tx_frame_info_t));
 			}
+		} while (!stamped && !sys_timepoint_expired(deadline));
+	}
 #endif
-#endif
-			memset(frame_info, 0, sizeof(netc_tx_frame_info_t));
-		}
-	} while (frame_info != NULL);
 
 	ret = 0;
 error:

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_msg.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_msg.c
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * NXP NETC VSI-to-PSI mailbox messaging.
+ *
+ * A VSI cannot write the PSI's shared MAC/filter/link registers, so it requests
+ * those operations from the PSI owner over the VSI-to-PSI message channel. This
+ * file owns the mailbox transport and the per-operation encoders; the VSI
+ * driver keeps the interface/lifecycle policy.
+ */
+
+#define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(nxp_imx_eth_vsi);
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/sys/crc.h>
+
+#include "eth_nxp_imx_netc_priv.h"
+#include "eth_nxp_imx_netc_msg.h"
+#include "fsl_netc_msg.h"
+
+#define NETC_MSG_RESP_CLASS(r) ((uint16_t)(r) >> 8)
+#define NETC_MSG_RESP_CODE(r)  (((uint16_t)(r) >> 4) & 0x0fU)
+#define NETC_MSG_VSI_ALIGN     32U
+
+/* Time to poll for the PSI to consume a VSI->PSI message before giving up. */
+#define NETC_MSG_VSI_TIMEOUT_MS 100
+
+/* MAC/VLAN filter message fields (match the ENETC VSI->PSI mailbox ABI). */
+#define NETC_MAC_HASH_TABLE_SIZE_64 0U
+#if defined(CONFIG_NET_VLAN)
+#define NETC_VLAN_HASH_TABLE_SIZE_64 0U
+#endif
+
+/*
+ * Send a control message to the PSI and wait for its reply.
+ * Returns 0 if the expected reply is received, otherwise an error.
+ */
+static int netc_vsi_msg_send(const struct device *dev, uint8_t class_id, uint8_t cmd_id,
+			     const void *payload, size_t payload_len, uint8_t want_class,
+			     uint16_t *resp)
+{
+	struct netc_eth_data *data = dev->data;
+	ep_handle_t *handle = &data->handle;
+	netc_msg_header_t *hdr = (netc_msg_header_t *)data->msg_buff;
+	size_t msg_len = ROUND_UP(sizeof(*hdr) + payload_len, NETC_MSG_VSI_ALIGN);
+	netc_vsi_msg_tx_status_t status;
+	k_timepoint_t deadline;
+	uint16_t crc;
+	int ret;
+
+	if (msg_len > NETC_MSG_VSI_BUF_SIZE) {
+		return -EINVAL;
+	}
+
+	/* Serialize access to the shared msg_buff and the single SI mailbox. */
+	k_mutex_lock(&data->msg_lock, K_FOREVER);
+
+	(void)memset(data->msg_buff, 0, msg_len);
+	hdr->classId = class_id;
+	hdr->cmdId = cmd_id;
+	hdr->len = (uint8_t)(msg_len / NETC_MSG_VSI_ALIGN - 1U);
+	if (payload_len != 0U) {
+		(void)memcpy(data->msg_buff + sizeof(*hdr), payload, payload_len);
+	}
+
+	crc = crc16_itu_t(0xFFFFU, data->msg_buff + 2, msg_len - 2U);
+	data->msg_buff[0] = (uint8_t)(crc >> 8);
+	data->msg_buff[1] = (uint8_t)crc;
+
+	if (EP_VsiSendMsg(handle, (uint64_t)(uintptr_t)data->msg_buff, msg_len) !=
+	    kStatus_Success) {
+		ret = -EBUSY;
+		goto out;
+	}
+
+	deadline = sys_timepoint_calc(K_MSEC(NETC_MSG_VSI_TIMEOUT_MS));
+	do {
+		NETC_SIVsiCheckTxStatus(handle->hw.si, &status);
+		if (!status.txBusy) {
+			break;
+		}
+		if (sys_timepoint_expired(deadline)) {
+			LOG_DBG("VSI msg (class 0x%02x) timed out; PSI not servicing messages?",
+				class_id);
+			ret = -ETIMEDOUT;
+			goto out;
+		}
+		k_msleep(1);
+	} while (true);
+
+	if (status.isTxErr) {
+		LOG_DBG("VSI msg (class 0x%02x) send error, status 0x%04x", class_id,
+			status.msgCode);
+		ret = -EIO;
+		goto out;
+	}
+
+	*resp = status.msgCode;
+	ret = (NETC_MSG_RESP_CLASS(*resp) == want_class) ? 0 : -EBADMSG;
+
+out:
+	k_mutex_unlock(&data->msg_lock);
+	return ret;
+}
+
+int netc_vsi_msg_set_primary_mac(const struct device *dev)
+{
+	struct netc_eth_data *data = dev->data;
+	uint16_t resp;
+	int ret;
+	struct {
+		uint8_t count;
+		uint8_t reserved[3];
+		uint8_t mac[6];
+	} req = {0};
+
+	(void)memcpy(req.mac, data->mac_addr, sizeof(req.mac));
+
+	ret = netc_vsi_msg_send(dev, (uint8_t)kNETC_MsgClassMacFilter,
+				(uint8_t)kNETC_MsgMacFilterSetMacAddr, &req, sizeof(req),
+				(uint8_t)kNETC_MsgClassDone, &resp);
+	if (ret == -EBADMSG) {
+		LOG_DBG("VSI MAC-filter request rejected by PSI: code 0x%04x", resp);
+		return -EIO;
+	}
+
+	return ret;
+}
+
+#if defined(CONFIG_NET_PROMISCUOUS_MODE)
+int netc_vsi_msg_set_mac_promisc(const struct device *dev, uint8_t type_mask, bool enable)
+{
+	uint16_t resp;
+	int ret;
+	struct {
+		uint8_t flush_macs: 1;
+		uint8_t promisc_mode: 1;
+		uint8_t reserved: 4;
+		uint8_t type: 2;
+	} req = {
+		.promisc_mode = enable ? 1U : 0U,
+		.type = type_mask,
+	};
+
+	ret = netc_vsi_msg_send(dev, (uint8_t)kNETC_MsgClassMacFilter,
+				(uint8_t)kNETC_MsgMacFilterSetMacPromisc, &req, sizeof(req),
+				(uint8_t)kNETC_MsgClassDone, &resp);
+	if (ret == -EBADMSG) {
+		LOG_DBG("VSI promisc request rejected by PSI: code 0x%04x", resp);
+		return -EIO;
+	}
+
+	return ret;
+}
+#endif /* CONFIG_NET_PROMISCUOUS_MODE */
+
+int netc_vsi_msg_set_mac_hash(const struct device *dev)
+{
+	struct netc_eth_data *data = dev->data;
+	uint16_t resp;
+	int ret;
+	struct {
+		uint8_t size_type;
+		uint8_t reserved[7];
+		uint64_t hash_tbl;
+	} req = {
+		.size_type = (uint8_t)((NETC_MAC_HASH_TABLE_SIZE_64 & 0x3fU) |
+				       (uint8_t)(NETC_MAC_FILTER_TYPE_MC << 6)),
+		.hash_tbl = data->mc_hash,
+	};
+
+	ret = netc_vsi_msg_send(dev, (uint8_t)kNETC_MsgClassMacFilter,
+				(uint8_t)kNETC_MsgMacFilterSet, &req, sizeof(req),
+				(uint8_t)kNETC_MsgClassDone, &resp);
+	if (ret == -EBADMSG) {
+		LOG_DBG("VSI multicast hash update rejected by PSI: code 0x%04x", resp);
+		return -EIO;
+	}
+
+	return ret;
+}
+
+#if defined(CONFIG_NET_VLAN)
+int netc_vsi_msg_set_vlan_hash(const struct device *dev)
+{
+	struct netc_eth_data *data = dev->data;
+	uint16_t resp;
+	int ret;
+	struct {
+		uint8_t size;
+		uint8_t reserved[7];
+		uint64_t hash_tbl;
+	} req = {
+		.size = NETC_VLAN_HASH_TABLE_SIZE_64,
+		.hash_tbl = data->vlan_hash,
+	};
+
+	ret = netc_vsi_msg_send(dev, (uint8_t)kNETC_MsgClassVlanFilter,
+				(uint8_t)kNETC_MsgVlanFilterSet, &req, sizeof(req),
+				(uint8_t)kNETC_MsgClassDone, &resp);
+	if (ret == -EBADMSG) {
+		LOG_DBG("VSI VLAN hash update rejected by PSI: code 0x%04x", resp);
+		return -EIO;
+	}
+
+	return ret;
+}
+#endif /* CONFIG_NET_VLAN */
+
+int netc_vsi_msg_enable_link_notify(const struct device *dev)
+{
+	uint16_t resp;
+	int ret;
+
+	ret = netc_vsi_msg_send(dev, (uint8_t)kNETC_MsgClassLinkStatus,
+				(uint8_t)kNETC_MsgLinkStatusEnableNotify, NULL, 0,
+				(uint8_t)kNETC_MsgClassDone, &resp);
+	if (ret == -EBADMSG) {
+		LOG_WRN("VSI link-notify registration rejected by PSI: code 0x%04x", resp);
+		return -EIO;
+	}
+
+	return ret;
+}
+
+enum netc_msg_link netc_vsi_msg_poll_link(const struct device *dev)
+{
+	struct netc_eth_data *data = dev->data;
+	ep_handle_t *handle = &data->handle;
+	enum netc_msg_link link = NETC_MSG_LINK_NONE;
+	uint16_t msg = 0;
+
+	if ((EP_VsiGetStatus(handle) & (uint32_t)kNETC_VsiMsgRxFlag) == 0U) {
+		return NETC_MSG_LINK_NONE;
+	}
+
+	if (EP_VsiReceiveMsg(handle, &msg) == kStatus_Success &&
+	    NETC_MSG_RESP_CLASS(msg) == (uint16_t)kNETC_MsgClassLinkStatus) {
+		link = (NETC_MSG_RESP_CODE(msg) == (uint16_t)kNETC_MsgLinkStatusUp)
+			       ? NETC_MSG_LINK_UP
+			       : NETC_MSG_LINK_DOWN;
+	}
+
+	EP_VsiClearStatus(handle, (uint32_t)kNETC_VsiMsgRxFlag);
+
+	return link;
+}

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_msg.h
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_msg.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_ETHERNET_ETH_NXP_IMX_NETC_MSG_H_
+#define ZEPHYR_DRIVERS_ETHERNET_ETH_NXP_IMX_NETC_MSG_H_
+
+#include <zephyr/device.h>
+
+/*
+ * NXP NETC VSI-to-PSI mailbox messaging.
+ *
+ * A VSI cannot write the PSI's shared MAC/filter/link registers, so it requests
+ * those operations from the PSI owner over the VSI-to-PSI message channel. This
+ * module owns that transport and the per-operation message encoders; the VSI
+ * driver calls this API and keeps the interface/lifecycle policy.
+ */
+
+/* Size of the DMA-visible VSI->PSI message buffer. */
+#define NETC_MSG_VSI_BUF_SIZE 64U
+
+/* MAC filter type bits (match the ENETC VSI->PSI mailbox ABI). */
+#define NETC_MAC_FILTER_TYPE_UC BIT(0)
+#define NETC_MAC_FILTER_TYPE_MC BIT(1)
+
+/* Link state parsed from a pending PSI->VSI message. */
+enum netc_msg_link {
+	NETC_MSG_LINK_NONE,
+	NETC_MSG_LINK_UP,
+	NETC_MSG_LINK_DOWN,
+};
+
+/* Ask the PSI to route this VSI's primary unicast MAC (data->mac_addr) to it. */
+int netc_vsi_msg_set_primary_mac(const struct device *dev);
+
+/* Program this VSI's 64-bit multicast hash table (data->mc_hash) in the PSI. */
+int netc_vsi_msg_set_mac_hash(const struct device *dev);
+
+#if defined(CONFIG_NET_VLAN)
+/* Program this VSI's 64-bit VLAN hash table (data->vlan_hash) in the PSI. */
+int netc_vsi_msg_set_vlan_hash(const struct device *dev);
+#endif
+
+#if defined(CONFIG_NET_PROMISCUOUS_MODE)
+/* Ask the PSI to set or clear UC/MC promiscuous mode for this VSI. */
+int netc_vsi_msg_set_mac_promisc(const struct device *dev, uint8_t type_mask, bool enable);
+#endif
+
+/* Subscribe to PSI link-status notifications for this VSI. */
+int netc_vsi_msg_enable_link_notify(const struct device *dev);
+
+/* Consume a pending PSI->VSI message and report any link-state change. */
+enum netc_msg_link netc_vsi_msg_poll_link(const struct device *dev);
+
+#endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_NXP_IMX_NETC_MSG_H_ */

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_DRIVERS_ETHERNET_ETH_NXP_IMX_NETC_PRIV_H_
 
 #include "nxp_imx_netc.h"
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/net/ethernet.h>
 #include "fsl_netc_endpoint.h"
 #if defined(NETC_SWITCH_NO_TAG_DRIVER_SUPPORT) && defined(CONFIG_PTP_CLOCK_NXP_NETC)
@@ -23,14 +24,18 @@
 	SDK_SIZEALIGN(CONFIG_ETH_NXP_IMX_RX_RING_BUF_SIZE, NETC_BUFF_ALIGN)
 
 /* MSIX definitions */
-#define NETC_TX_MSIX_ENTRY_IDX 0
-#define NETC_RX_MSIX_ENTRY_IDX 1
-#define NETC_MSIX_ENTRY_NUM    2
+#define NETC_TX_MSIX_ENTRY_IDX  0
+#define NETC_RX_MSIX_ENTRY_IDX  1
+/* VSI only: PSI->VSI communication (message) interrupt, routed via SIMSIVR. */
+#define NETC_MSG_MSIX_ENTRY_IDX 2
 
-#define NETC_MSIX_EVENTS_COUNT      NETC_MSIX_ENTRY_NUM
+#define NETC_MSIX_PSI_EVENTS_COUNT 2
+#define NETC_MSIX_VSI_EVENTS_COUNT 3
+
 #define NETC_TX_INTR_MSG_DATA_START 0
-#define NETC_RX_INTR_MSG_DATA_START 16
-#define NETC_DRV_MAX_INST_SUPPORT   16
+#define NETC_MSG_INTR_MSG_DATA_START 8
+#define NETC_RX_INTR_MSG_DATA_START  16
+#define NETC_DRV_MAX_INST_SUPPORT    16
 
 /* MSGINTR */
 #define NETC_MSGINTR_CHANNEL 0
@@ -39,7 +44,7 @@
 #define NETC_MSGINTR_IRQ DT_IRQN_BY_IDX(DT_NODELABEL(netc), 0)
 #endif
 
-#ifndef CONFIG_ETH_NXP_IMX_NETC_MSI_GIC
+#ifdef CONFIG_ETH_NXP_IMX_MSGINTR
 #if (CONFIG_ETH_NXP_IMX_MSGINTR == 1)
 #define NETC_MSGINTR MSGINTR1
 #ifndef NETC_MSGINTR_IRQ
@@ -53,20 +58,47 @@
 #else
 #error "Current CONFIG_ETH_NXP_IMX_MSGINTR not support"
 #endif
-#endif /* CONFIG_ETH_NXP_IMX_NETC_MSI_GIC */
+#endif /* CONFIG_ETH_NXP_IMX_MSGINTR */
 
 /* Timeout for various operations */
 #define NETC_TIMEOUT K_MSEC(20)
 
+/*
+ * Tx completions are reclaimed inline on the next send, so the ring uses a
+ * coalesced watermark (threshold) interrupt instead of one per frame - it only
+ * needs to wake a sender blocked on a full ring. PTP timestamps ride the Tx
+ * completion writeback and are busy-waited for, so no per-frame interrupt.
+ */
+/* ICPT (4-bit): ~half a ring, capped at field max. */
+#define NETC_TX_COALESCE_FRAMES MIN(CONFIG_ETH_NXP_IMX_TX_RING_LEN / 2U, 15U)
+/* ICTT: timeout in NETC cycles if fewer than ICPT complete. */
+#define NETC_TX_COALESCE_TICKS 1024U
+
 struct netc_eth_config {
 	DEVICE_MMIO_NAMED_ROM(port);
 	DEVICE_MMIO_NAMED_ROM(pfconfig);
+#ifdef CONFIG_DT_HAS_NXP_IMX_NETC_VSI_ENABLED
+	/* VSI only: the VF's own PCIe config space (the PSI uses pfconfig). */
+	DEVICE_MMIO_NAMED_ROM(vfconfig);
+#endif
 	uint16_t si_idx;
 	const struct device *phy_dev;
 	netc_hw_mii_mode_t phy_mode;
 	volatile bool pseudo_mac;
 	/* Standard MAC-address source (device tree); see net_eth_mac_load(). */
 	struct net_eth_mac_config mac_config;
+	/* True for a Virtual Station Interface (VF); the PSI is owned elsewhere. */
+	bool is_vsi;
+	/* Number of MSI-X entries used (2 for PSI, 3 for VSI). */
+	uint8_t msix_entry_num;
+	/*
+	 * VSI only: optional readiness-gate clock. When set, the service thread
+	 * polls this clock's status (via SCMI, which never touches the SI
+	 * registers) before its first SI access. NULL falls back to a fixed
+	 * startup delay.
+	 */
+	const struct device *ready_clock_dev;
+	clock_control_subsys_t ready_clock_subsys;
 	void (*bdr_init)(netc_bdr_config_t *bdr_config, netc_rx_bdr_config_t *rx_bdr_config,
 			 netc_tx_bdr_config_t *tx_bdr_config);
 	const struct pinctrl_dev_config *pincfg;
@@ -76,6 +108,10 @@ struct netc_eth_config {
 #else
 	uint8_t tx_intr_msg_data;
 	uint8_t rx_intr_msg_data;
+#ifdef CONFIG_DT_HAS_NXP_IMX_NETC_VSI_ENABLED
+	/* VSI only: MSGINTR message-data bit for the PSI->VSI message interrupt. */
+	uint8_t msg_intr_msg_data;
+#endif
 #endif
 #ifdef CONFIG_PTP_CLOCK_NXP_NETC
 	const struct device *ptp_clock;
@@ -87,12 +123,16 @@ typedef uint8_t rx_buffer_t[NETC_RX_RING_BUF_SIZE_ALIGN];
 struct netc_eth_data {
 	DEVICE_MMIO_NAMED_RAM(port);
 	DEVICE_MMIO_NAMED_RAM(pfconfig);
+#ifdef CONFIG_DT_HAS_NXP_IMX_NETC_VSI_ENABLED
+	DEVICE_MMIO_NAMED_RAM(vfconfig);
+#endif
 	ep_handle_t handle;
 	struct net_if *iface;
 	uint8_t mac_addr[6];
 	/* TX */
-	uint8_t *tx_buff;
-	volatile bool tx_done;
+	/* One buffer per Tx BD ring slot, indexed by the ring producer index. */
+	uint8_t (*tx_buff)[CONFIG_ETH_NXP_IMX_TX_RING_BUF_SIZE];
+	struct k_sem tx_sem;
 	/* RX */
 	struct k_sem rx_sem;
 	struct k_thread rx_thread;
@@ -103,10 +143,45 @@ struct netc_eth_data {
 	unsigned int tx_intid;
 	unsigned int rx_intid;
 #endif
+#ifdef CONFIG_DT_HAS_NXP_IMX_NETC_VSI_ENABLED
+	/* VSI->PSI control message buffer (DMA-visible). */
+	uint8_t *msg_buff;
+	/* SI is up (BD rings configured, SI enabled); deferred until SR-IOV is on. */
+	volatile bool si_ready;
+	/* Multicast RX hash, mirrored to the PSI; refcnt keeps colliding groups. */
+	uint64_t mc_hash;
+	uint8_t mc_hash_refcnt[64];
+#if defined(CONFIG_NET_VLAN)
+	/* VLAN RX hash, mirrored to the PSI; refcnt keeps colliding VLANs. */
+	uint64_t vlan_hash;
+	uint8_t vlan_hash_refcnt[64];
+#endif
+	/* Serializes VSI->PSI messages from the service thread and set_config(). */
+	struct k_mutex msg_lock;
+	/* PSI link-up seen (ISR); service thread re-sends the steering. */
+	volatile bool link_notify;
+#endif
 };
 
 int netc_eth_init_common(const struct device *dev);
+
+/* Program the SI Tx interrupt-coalescing (watermark) registers TBICR0/TBICR1. */
+void netc_eth_tx_coalesce_init(struct netc_eth_data *data);
+
+#ifdef CONFIG_ETH_NXP_IMX_MSGINTR
+/*
+ * Register a device with the shared MSGINTR, point its SI Tx/Rx MSI-X vectors at
+ * that line, hook the ISR once, and unmask. Used by both the PSI and the VSI.
+ */
+void netc_eth_msgintr_arm(const struct device *dev);
+#endif
+#ifdef CONFIG_DT_HAS_NXP_IMX_NETC_VSI_ENABLED
+/* VSI message interrupt handler: services a PSI->VSI message (e.g. link notify). */
+void netc_eth_vsi_msg_isr(const struct device *dev);
+#endif
 int netc_eth_tx(const struct device *dev, struct net_pkt *pkt);
+/* Drain one Rx frame from the SI ring into the net stack; -ENOBUFS when empty. */
+int netc_eth_rx(const struct device *dev);
 enum ethernet_hw_caps netc_eth_get_capabilities(const struct device *dev, struct net_if *iface);
 int netc_eth_set_config(const struct device *dev, struct net_if *iface,
 			enum ethernet_config_type type, const struct ethernet_config *config);

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_DRIVERS_ETHERNET_ETH_NXP_IMX_NETC_PRIV_H_
 
 #include "nxp_imx_netc.h"
+#include <zephyr/net/ethernet.h>
 #include "fsl_netc_endpoint.h"
 #if defined(NETC_SWITCH_NO_TAG_DRIVER_SUPPORT) && defined(CONFIG_PTP_CLOCK_NXP_NETC)
 #include "fsl_netc_switch.h"
@@ -57,37 +58,6 @@
 /* Timeout for various operations */
 #define NETC_TIMEOUT K_MSEC(20)
 
-/* Helper function to generate an Ethernet MAC address for a given ENETC instance */
-#define FREESCALE_OUI_B0 0x00
-#define FREESCALE_OUI_B1 0x04
-#define FREESCALE_OUI_B2 0x9f
-
-#define _NETC_GENERATE_MAC_ADDRESS_RANDOM                                                          \
-	gen_random_mac(mac_addr, FREESCALE_OUI_B0, FREESCALE_OUI_B1, FREESCALE_OUI_B2)
-
-#define _NETC_GENERATE_MAC_ADDRESS_UNIQUE(n)                                                       \
-	do {                                                                                       \
-		uint32_t id = 0x001100;                                                            \
-                                                                                                   \
-		/* Set MAC address locally administered bit (LAA) */                               \
-		mac_addr[0] = FREESCALE_OUI_B0 | 0x02;                                             \
-		mac_addr[1] = FREESCALE_OUI_B1;                                                    \
-		mac_addr[2] = FREESCALE_OUI_B2;                                                    \
-		mac_addr[3] = (id >> 16) & 0xff;                                                   \
-		mac_addr[4] = (id >> 8) & 0xff;                                                    \
-		mac_addr[5] = (id + n) & 0xff;                                                     \
-	} while (0)
-
-#define NETC_GENERATE_MAC_ADDRESS(n)                                                               \
-	static void netc_eth##n##_generate_mac(uint8_t mac_addr[6])                                \
-	{                                                                                          \
-		COND_CODE_1(DT_INST_PROP(n, zephyr_random_mac_address),                            \
-			    (_NETC_GENERATE_MAC_ADDRESS_RANDOM),                                   \
-			    (COND_CODE_0(DT_INST_NODE_HAS_PROP(n, local_mac_address),              \
-					 (_NETC_GENERATE_MAC_ADDRESS_UNIQUE(n)),                   \
-					 (ARG_UNUSED(mac_addr)))));                      \
-	}
-
 struct netc_eth_config {
 	DEVICE_MMIO_NAMED_ROM(port);
 	DEVICE_MMIO_NAMED_ROM(pfconfig);
@@ -95,7 +65,8 @@ struct netc_eth_config {
 	const struct device *phy_dev;
 	netc_hw_mii_mode_t phy_mode;
 	volatile bool pseudo_mac;
-	void (*generate_mac)(uint8_t *mac_addr);
+	/* Standard MAC-address source (device tree); see net_eth_mac_load(). */
+	struct net_eth_mac_config mac_config;
 	void (*bdr_init)(netc_bdr_config_t *bdr_config, netc_rx_bdr_config_t *rx_bdr_config,
 			 netc_tx_bdr_config_t *tx_bdr_config);
 	const struct pinctrl_dev_config *pincfg;

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
@@ -10,6 +10,9 @@
 #include "nxp_imx_netc.h"
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/net/ethernet.h>
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+#include <zephyr/net/net_stats.h>
+#endif
 #include "fsl_netc_endpoint.h"
 #if defined(NETC_SWITCH_NO_TAG_DRIVER_SUPPORT) && defined(CONFIG_PTP_CLOCK_NXP_NETC)
 #include "fsl_netc_switch.h"
@@ -129,6 +132,10 @@ struct netc_eth_data {
 	ep_handle_t handle;
 	struct net_if *iface;
 	uint8_t mac_addr[6];
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+	/* Snapshot returned by get_stats(), refreshed from the SI HW counters. */
+	struct net_stats_eth stats;
+#endif
 	/* TX */
 	/* One buffer per Tx BD ring slot, indexed by the ring producer index. */
 	uint8_t (*tx_buff)[CONFIG_ETH_NXP_IMX_TX_RING_BUF_SIZE];
@@ -183,6 +190,10 @@ int netc_eth_tx(const struct device *dev, struct net_pkt *pkt);
 /* Drain one Rx frame from the SI ring into the net stack; -ENOBUFS when empty. */
 int netc_eth_rx(const struct device *dev);
 enum ethernet_hw_caps netc_eth_get_capabilities(const struct device *dev, struct net_if *iface);
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+/* Refresh and return the SI hardware counters (shared by the PSI and VSI). */
+struct net_stats_eth *netc_eth_get_stats(const struct device *dev, struct net_if *iface);
+#endif
 int netc_eth_set_config(const struct device *dev, struct net_if *iface,
 			enum ethernet_config_type type, const struct ethernet_config *config);
 #ifdef CONFIG_PTP_CLOCK_NXP_NETC

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
@@ -132,7 +132,6 @@ static const struct ethernet_api netc_eth_api = {.iface_api.init = netc_eth_ifac
 
 #define NETC_PSI_INSTANCE_DEFINE(n)                                                                \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
-	NETC_GENERATE_MAC_ADDRESS(n)                                                               \
 	AT_NONCACHEABLE_SECTION_ALIGN(                                                             \
 		static uint8_t eth##n##_tx_buff[CONFIG_ETH_NXP_IMX_TX_RING_BUF_SIZE],              \
 		NETC_BUFF_ALIGN);                                                                  \
@@ -191,7 +190,7 @@ static const struct ethernet_api netc_eth_api = {.iface_api.init = netc_eth_ifac
 	static const struct netc_eth_config netc_eth##n##_config = {                               \
 		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(port, DT_DRV_INST(n)),                          \
 		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(pfconfig, DT_DRV_INST(n)),                      \
-		.generate_mac = netc_eth##n##_generate_mac,                                        \
+		.mac_config = NET_ETH_MAC_DT_INST_CONFIG_INIT(n),                                  \
 		.bdr_init = netc_eth##n##_bdr_init,                                                \
 		.phy_dev = (COND_CODE_1(DT_INST_NODE_HAS_PROP(n, phy_handle),                      \
 					(DEVICE_DT_GET(DT_INST_PHANDLE(n, phy_handle))), NULL)),   \

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
@@ -121,8 +121,33 @@ static const struct device *netc_eth_get_phy(const struct device *dev,
 	return cfg->phy_dev;
 }
 
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+static struct net_stats_eth *netc_eth_psi_get_stats(const struct device *dev, struct net_if *iface)
+{
+	struct netc_eth_data *data = dev->data;
+	netc_port_discard_statistic_t discard;
+
+	/* SI-level stats, including tx_dropped from SITDFCR. */
+	(void)netc_eth_get_stats(dev, iface);
+
+	/*
+	 * The PSI owns the MAC port, so it can also read the port-level RX
+	 * discard counter that no software path or SI counter tracks. It is
+	 * free-running, so assigning it is idempotent.
+	 */
+	if (EP_GetPortDiscardStatistic(&data->handle, false, &discard) == kStatus_Success) {
+		data->stats.error_details.rx_missed_errors = discard.count;
+	}
+
+	return &data->stats;
+}
+#endif /* CONFIG_NET_STATISTICS_ETHERNET */
+
 static const struct ethernet_api netc_eth_api = {.iface_api.init = netc_eth_iface_init,
 						 .get_capabilities = netc_eth_get_capabilities,
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+						 .get_stats = netc_eth_psi_get_stats,
+#endif
 						 .get_phy = netc_eth_get_phy,
 						 .set_config = netc_eth_set_config,
 #ifdef CONFIG_PTP_CLOCK_NXP_NETC

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
@@ -133,7 +133,8 @@ static const struct ethernet_api netc_eth_api = {.iface_api.init = netc_eth_ifac
 #define NETC_PSI_INSTANCE_DEFINE(n)                                                                \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
 	AT_NONCACHEABLE_SECTION_ALIGN(                                                             \
-		static uint8_t eth##n##_tx_buff[CONFIG_ETH_NXP_IMX_TX_RING_BUF_SIZE],              \
+		static uint8_t eth##n##_tx_buff[CONFIG_ETH_NXP_IMX_TX_RING_LEN]                    \
+					       [CONFIG_ETH_NXP_IMX_TX_RING_BUF_SIZE],             \
 		NETC_BUFF_ALIGN);                                                                  \
 	AT_NONCACHEABLE_SECTION_ALIGN(                                                             \
 		static netc_tx_bd_t eth##n##_txbd_array[CONFIG_ETH_NXP_IMX_TX_RING_NUM]            \
@@ -180,7 +181,8 @@ static const struct ethernet_api netc_eth_api = {.iface_api.init = netc_eth_ifac
 		bdr_config->txBdrConfig[0].len = CONFIG_ETH_NXP_IMX_TX_RING_LEN;                   \
 		bdr_config->txBdrConfig[0].dirtyArray = &eth##n##_txdirty_array[0][0];             \
 		bdr_config->txBdrConfig[0].msixEntryIdx = NETC_TX_MSIX_ENTRY_IDX;                  \
-		bdr_config->txBdrConfig[0].enIntr = true;                                          \
+		bdr_config->txBdrConfig[0].enIntr = false;                                         \
+		bdr_config->txBdrConfig[0].enThresIntr = true;                                     \
 	}                                                                                          \
 	static struct netc_eth_data netc_eth##n##_data = {                                         \
 		.mac_addr = DT_INST_PROP_OR(n, local_mac_address, {0}),                            \
@@ -198,6 +200,7 @@ static const struct ethernet_api netc_eth_api = {.iface_api.init = netc_eth_ifac
 		.pseudo_mac = DT_ENUM_HAS_VALUE(DT_DRV_INST(n), phy_connection_type, internal),    \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                       \
 		.si_idx = (DT_INST_PROP(n, mac_index) << 8) | DT_INST_PROP(n, si_index),           \
+		.msix_entry_num = NETC_MSIX_PSI_EVENTS_COUNT,                                     \
 		IF_ENABLED(CONFIG_ETH_NXP_IMX_NETC_MSI_GIC,                                        \
 			(.msi_device_id = DT_INST_PROP_OR(n, msi_device_id, 0),                    \
 			.msi_dev = (COND_CODE_1(DT_NODE_HAS_PROP(DT_INST_PARENT(n), msi_parent),   \

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_vsi.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_vsi.c
@@ -1,0 +1,676 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * NXP NETC Virtual Station Interface (VSI) Ethernet driver.
+ *
+ * The PSI owner manages the physical function (PF) and enables the VSI.
+ * This driver only uses VSI-specific registers, which are accessible only
+ * after SR-IOV has been enabled by the PSI owner.
+ */
+
+#define DT_DRV_COMPAT nxp_imx_netc_vsi
+
+#define LOG_LEVEL CONFIG_ETHERNET_LOG_LEVEL
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(nxp_imx_eth_vsi);
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_pkt.h>
+#include <ethernet/eth_stats.h>
+
+#include "../eth.h"
+#include "eth_nxp_imx_netc_priv.h"
+#include "eth_nxp_imx_netc_msg.h"
+#include "fsl_netc_msg.h"
+
+/*Retry MAC-filter updates for a short time until the PSI grants access. */
+#define NETC_VSI_MAC_SET_RETRIES  10
+#define NETC_VSI_MAC_SET_RETRY_MS 200
+
+static void netc_eth_vsi_thread(void *arg1, void *unused1, void *unused2);
+
+static void netc_eth_vsi_iface_init(struct net_if *iface)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct netc_eth_data *data = dev->data;
+	const struct netc_eth_config *cfg = dev->config;
+
+	net_if_set_link_addr(iface, data->mac_addr, sizeof(data->mac_addr), NET_LINK_ETHERNET);
+
+	LOG_INF("VSI (SI idx %d) MAC: %02x:%02x:%02x:%02x:%02x:%02x", getSiIdx(cfg->si_idx),
+		data->mac_addr[0], data->mac_addr[1], data->mac_addr[2], data->mac_addr[3],
+		data->mac_addr[4], data->mac_addr[5]);
+
+	ethernet_init(iface);
+
+	/* Stay carrier-off until the service thread brings the SI up; no SI access here. */
+	net_if_carrier_off(iface);
+
+	/* Publish the interface, then start the service thread that drives the SI. */
+	data->iface = iface;
+
+	k_thread_create(&data->rx_thread, data->rx_thread_stack,
+			K_KERNEL_STACK_SIZEOF(data->rx_thread_stack), netc_eth_vsi_thread,
+			(void *)dev, NULL, NULL, K_PRIO_COOP(CONFIG_ETH_NXP_IMX_RX_THREAD_PRIO), 0,
+			K_NO_WAIT);
+	k_thread_name_set(&data->rx_thread, "netc_eth_vsi");
+}
+
+static int netc_eth_vsi_set_config(const struct device *dev, struct net_if *iface __unused,
+				   enum ethernet_config_type type,
+				   const struct ethernet_config *config);
+static int netc_eth_vsi_set_mac_filter(const struct device *dev,
+				       const struct ethernet_filter *filter);
+
+static int netc_eth_vsi_set_config(const struct device *dev, struct net_if *iface __unused,
+				   enum ethernet_config_type type,
+				   const struct ethernet_config *config)
+{
+	struct netc_eth_data *data = dev->data;
+
+	switch (type) {
+	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
+		memcpy(data->mac_addr, config->mac_address.addr, sizeof(data->mac_addr));
+		/* Only update the local MAC address; the PSI owner manages the HW filter. */
+		net_if_set_link_addr(data->iface, data->mac_addr, sizeof(data->mac_addr),
+				     NET_LINK_ETHERNET);
+		break;
+	case ETHERNET_CONFIG_TYPE_FILTER:
+		return netc_eth_vsi_set_mac_filter(dev, &config->filter);
+#if defined(CONFIG_NET_PROMISCUOUS_MODE)
+	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
+		return netc_vsi_msg_set_mac_promisc(dev,
+						NETC_MAC_FILTER_TYPE_UC | NETC_MAC_FILTER_TYPE_MC,
+						config->promisc_mode);
+#endif
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int netc_eth_vsi_si_bringup(const struct device *dev)
+{
+	const struct netc_eth_config *config = dev->config;
+	struct netc_eth_data *data = dev->data;
+	ep_handle_t *handle = &data->handle;
+	netc_rx_bdr_config_t rx_bdr_config = {0};
+	netc_tx_bdr_config_t tx_bdr_config = {0};
+	netc_bdr_config_t bdr_config = {0};
+	uint8_t ring;
+
+	config->bdr_init(&bdr_config, &rx_bdr_config, &tx_bdr_config);
+
+	/* Read the SI capabilities from the PF. */
+	NETC_EnetcGetCapability(handle->hw.base, &handle->capability);
+
+	/* Rx BD ring group configuration (SI-scoped). */
+	NETC_SISetRxBDRGroup(handle->hw.si, 0, 1);
+	NETC_SISetDefaultRxBDRGroup(handle->hw.si, kNETC_SiBDRGroupOne);
+
+	/* Configure the Tx BD ring(s) and record their bases in the handle. */
+	for (ring = 0; ring < handle->cfg.txRingUse; ring++) {
+		if (NETC_SIConfigTxBDR(handle->hw.si, ring, &bdr_config.txBdrConfig[ring]) !=
+		    kStatus_Success) {
+			LOG_ERR("Failed to configure VSI Tx BD ring %u", ring);
+			return -ENOBUFS;
+		}
+		handle->txBdRing[ring].bdBase = bdr_config.txBdrConfig[ring].bdArray;
+		handle->txBdRing[ring].dirtyBase = bdr_config.txBdrConfig[ring].dirtyArray;
+		handle->txBdRing[ring].len = bdr_config.txBdrConfig[ring].len;
+		/* Resync SW indices with the just-reset HW ring (needed on re-bring-up). */
+		handle->txBdRing[ring].producerIndex = 0;
+		handle->txBdRing[ring].cleanIndex = 0;
+	}
+
+	netc_eth_tx_coalesce_init(data);
+
+	/* Configure the Rx BD ring(s) and record their bases in the handle. */
+	for (ring = 0; ring < handle->cfg.rxRingUse; ring++) {
+		if (NETC_SIConfigRxBDR(handle->hw.si, ring, &bdr_config.rxBdrConfig[ring]) !=
+		    kStatus_Success) {
+			LOG_ERR("Failed to configure VSI Rx BD ring %u", ring);
+			return -ENOBUFS;
+		}
+		handle->rxBdRing[ring].extendDesc = bdr_config.rxBdrConfig[ring].extendDescEn;
+		handle->rxBdRing[ring].bdBase = bdr_config.rxBdrConfig[ring].bdArray;
+		handle->rxBdRing[ring].len = bdr_config.rxBdrConfig[ring].len;
+		handle->rxBdRing[ring].buffSize = bdr_config.rxBdrConfig[ring].buffSize;
+		/* Resync the SW read index with the just-reset HW ring. */
+		handle->rxBdRing[ring].index = 0;
+	}
+
+	/* Attach an Rx buffer to each descriptor. */
+	for (ring = 0; ring < handle->cfg.rxRingUse; ring++) {
+		const netc_rx_bdr_config_t *rc = &bdr_config.rxBdrConfig[ring];
+		netc_rx_bd_t *rx_desc = &rc->bdArray[0];
+
+		handle->rxBdRing[ring].buffArray = rc->buffAddrArray;
+		for (uint16_t idx = 0; idx < rc->len; idx++) {
+			(void)memset(rx_desc, 0, sizeof(netc_rx_bd_t));
+			rx_desc->standard.addr = (uint64_t)MEMORY_ConvertMemoryMapAddress(
+				(uintptr_t)handle->rxBdRing[ring].buffArray[idx],
+				kMEMORY_Local2DMA);
+			rx_desc++;
+		}
+	}
+
+	/* Enable the Rx ring(s). */
+	for (ring = 0; ring < handle->cfg.rxRingUse; ring++) {
+		NETC_SIRxRingEnable(handle->hw.si, ring, true);
+	}
+
+	NETC_SIEnableVlanToIpv(handle->hw.si, false);
+
+	/* Enable the SI; the PF-side enable is the PSI owner's. */
+	NETC_SIEnable(handle->hw.si, true);
+
+#ifdef CONFIG_ETH_NXP_IMX_MSGINTR
+	netc_eth_msgintr_arm(dev);
+#endif
+
+    /* Enable PSI-to-VSI message interrupts for asynchronous link updates. */
+	handle->hw.si->SIMSIVR = NETC_MSG_MSIX_ENTRY_IDX & ENETC_SI_SIMSIVR_VECTOR_MASK;
+	EP_VsiEnableInterrupt(handle, kNETC_VsiMsgRxFlag, true);
+
+	return 0;
+}
+
+/* ENETC multicast hash index (0..63). */
+static uint8_t netc_eth_vsi_mac_hash_idx(const uint8_t *addr)
+{
+	uint64_t ether = 0;
+	uint64_t fold;
+	uint64_t mask = 0;
+	uint8_t res = 0;
+
+	for (int i = 0; i < 6; i++) {
+		ether = (ether << 8) | addr[i];
+	}
+	fold = __builtin_bswap64(ether) >> 16;
+	for (int i = 0; i < 8; i++) {
+		mask |= BIT64(i * 6);
+	}
+	for (int i = 0; i < 6; i++) {
+		res |= (uint8_t)(__builtin_popcountll(fold & (mask << i)) & 0x1U) << i;
+	}
+
+	return res;
+}
+
+/*
+ * Add or remove a multicast destination MAC from the VSI hash filter. Called
+ * by the Ethernet L2 multicast monitor on every group join/leave. Reference
+ * counting per hash index keeps a bit set while any group still maps to it.
+ */
+static int netc_eth_vsi_set_mac_filter(const struct device *dev,
+				       const struct ethernet_filter *filter)
+{
+	struct netc_eth_data *data = dev->data;
+	uint8_t idx;
+	int ret = 0;
+
+	if (filter->type != ETHERNET_FILTER_TYPE_DST_MAC_ADDRESS) {
+		return -ENOTSUP;
+	}
+
+	idx = netc_eth_vsi_mac_hash_idx(filter->mac_address.addr);
+
+	k_mutex_lock(&data->msg_lock, K_FOREVER);
+
+	if (filter->set) {
+		if (data->mc_hash_refcnt[idx] == UINT8_MAX) {
+			k_mutex_unlock(&data->msg_lock);
+			return -ENOSPC;
+		}
+		data->mc_hash_refcnt[idx]++;
+	} else if (data->mc_hash_refcnt[idx] > 0U) {
+		data->mc_hash_refcnt[idx]--;
+	}
+
+	if (data->mc_hash_refcnt[idx] > 0U) {
+		data->mc_hash |= BIT64(idx);
+	} else {
+		data->mc_hash &= ~BIT64(idx);
+	}
+
+	/* If the SI is not up yet, the table is programmed at bring-up. */
+	if (data->si_ready) {
+		ret = netc_vsi_msg_set_mac_hash(dev);
+	}
+
+	k_mutex_unlock(&data->msg_lock);
+
+	return ret;
+}
+
+#if defined(CONFIG_NET_VLAN)
+/* ENETC VLAN hash index (0..63): fold the two 6-bit halves of the VID. */
+static uint8_t netc_eth_vsi_vlan_hash_idx(uint16_t tag)
+{
+	return (uint8_t)(((tag >> 6) & 0x3fU) ^ (tag & 0x3fU));
+}
+
+/*
+ * Add or remove a VLAN from the VSI hash filter. Called by the Ethernet L2
+ * on every VLAN enable/disable. Reference counting per hash index keeps a bit
+ * set while any active VLAN still maps to it.
+ */
+static int netc_eth_vsi_vlan_setup(const struct device *dev, struct net_if *iface __unused,
+				   uint16_t tag, bool enable)
+{
+	struct netc_eth_data *data = dev->data;
+	uint8_t idx = netc_eth_vsi_vlan_hash_idx(tag);
+	int ret = 0;
+
+	k_mutex_lock(&data->msg_lock, K_FOREVER);
+
+	if (enable) {
+		if (data->vlan_hash_refcnt[idx] == UINT8_MAX) {
+			k_mutex_unlock(&data->msg_lock);
+			return -ENOSPC;
+		}
+		data->vlan_hash_refcnt[idx]++;
+	} else if (data->vlan_hash_refcnt[idx] > 0U) {
+		data->vlan_hash_refcnt[idx]--;
+	}
+
+	if (data->vlan_hash_refcnt[idx] > 0U) {
+		data->vlan_hash |= BIT64(idx);
+	} else {
+		data->vlan_hash &= ~BIT64(idx);
+	}
+
+	/* If the SI is not up yet, the table is programmed at bring-up. */
+	if (data->si_ready) {
+		ret = netc_vsi_msg_set_vlan_hash(dev);
+	}
+
+	k_mutex_unlock(&data->msg_lock);
+
+	return ret;
+}
+#endif /* CONFIG_NET_VLAN */
+
+/*
+ * Ask the PSI to program this VSI's primary MAC address, retrying briefly
+ * while the SI comes up.
+ */
+static void netc_eth_vsi_program_mac(const struct device *dev)
+{
+	for (int attempt = 0; attempt < NETC_VSI_MAC_SET_RETRIES; attempt++) {
+		if (netc_vsi_msg_set_primary_mac(dev) == 0) {
+			LOG_DBG("VSI primary MAC filter programmed via PSI");
+			return;
+		}
+		k_msleep(NETC_VSI_MAC_SET_RETRY_MS);
+	}
+	LOG_WRN("VSI MAC filter not accepted by PSI; unicast RX needs PSI-side steering");
+}
+
+/* Handle link-status messages from the PSI and update the carrier state. */
+void netc_eth_vsi_msg_isr(const struct device *dev)
+{
+	struct netc_eth_data *data = dev->data;
+
+	if (data->iface == NULL) {
+		return;
+	}
+
+	switch (netc_vsi_msg_poll_link(dev)) {
+	case NETC_MSG_LINK_UP:
+		/* Link-up: wake the service thread to (re)program the PSI. */
+		data->link_notify = true;
+		k_sem_give(&data->rx_sem);
+		break;
+	case NETC_MSG_LINK_DOWN:
+		/* Link-down: gate off Tx and drop the carrier. */
+		data->si_ready = false;
+		net_eth_carrier_off(data->iface);
+		break;
+	default:
+		break;
+	}
+}
+
+/* True once the PSI owner has enabled SR-IOV for our ENETC. */
+static inline bool netc_eth_vsi_vf_ready(const struct netc_eth_config *config)
+{
+	static const uintptr_t pf_pci_base[] = ENETC_PCI_TYPE0_BASE_ADDRS;
+	ENETC_PCI_TYPE0_Type *pf =
+		(ENETC_PCI_TYPE0_Type *)pf_pci_base[1U + getSiInstance(config->si_idx)];
+	const uint16_t vf_ready = ENETC_PCI_TYPE0_PCIE_CFC_SRIOV_CTL_VF_ENABLE_MASK |
+				  ENETC_PCI_TYPE0_PCIE_CFC_SRIOV_CTL_VF_MSE_MASK;
+
+	return (pf->PCIE_CFC_SRIOV_CTL & vf_ready) == vf_ready;
+}
+
+/* Wait until the SI is ready and can be accessed safely.  */
+static void netc_eth_vsi_wait_ready(const struct device *dev)
+{
+	const struct netc_eth_config *config = dev->config;
+
+	if (config->ready_clock_dev != NULL) {
+		if (!device_is_ready(config->ready_clock_dev)) {
+			LOG_DBG("VSI readiness-gate clock not ready; skipping clock gate");
+		} else {
+			while (clock_control_get_status(config->ready_clock_dev,
+							config->ready_clock_subsys) !=
+			       CLOCK_CONTROL_STATUS_ON) {
+				k_msleep(CONFIG_ETH_NXP_IMX_NETC_VSI_READY_POLL_INTERVAL_MS);
+			}
+		}
+	}
+
+	while (!netc_eth_vsi_vf_ready(config)) {
+		k_msleep(CONFIG_ETH_NXP_IMX_NETC_VSI_READY_POLL_INTERVAL_MS);
+	}
+}
+
+/*
+ * Send the VSI traffic settings to the PSI. This includes the main unicast
+ * MAC address, and the multicast and VLAN RX hash filters.
+ */
+static void netc_eth_vsi_program_psi(const struct device *dev)
+{
+	struct netc_eth_data *data = dev->data;
+
+	/* Set our MAC address in the PSI. */
+	netc_eth_vsi_program_mac(dev);
+
+	/*
+	 * Mark the SI as ready and update the multicast/VLAN hash tables together,
+	 * so no joins are missed during the change.
+	 */
+	k_mutex_lock(&data->msg_lock, K_FOREVER);
+	data->si_ready = true;
+	if (netc_vsi_msg_set_mac_hash(dev) != 0) {
+		LOG_WRN("VSI multicast hash not programmed; multicast RX may be limited");
+	}
+#if defined(CONFIG_NET_VLAN)
+	if (netc_vsi_msg_set_vlan_hash(dev) != 0) {
+		LOG_WRN("VSI VLAN hash not programmed; VLAN RX may be limited");
+	}
+#endif
+	k_mutex_unlock(&data->msg_lock);
+}
+
+/*
+ * Full SI bring-up: wait for SR-IOV, bring the SI up, set up PSI steering,
+ * subscribe to link status notifications, and enable the carrier.
+ */
+static void netc_eth_vsi_bring_up(const struct device *dev)
+{
+	struct netc_eth_data *data = dev->data;
+	int ret;
+
+	netc_eth_vsi_wait_ready(dev);
+	do {
+		ret = netc_eth_vsi_si_bringup(dev);
+		if (ret != 0) {
+			LOG_ERR("VSI SI bring-up failed (%d); retrying", ret);
+			k_msleep(CONFIG_ETH_NXP_IMX_NETC_VSI_READY_POLL_INTERVAL_MS);
+		}
+	} while (ret != 0);
+
+	netc_eth_vsi_program_psi(dev);
+
+	/* Subscribe to link-status notifications once per SI */
+	if (netc_vsi_msg_enable_link_notify(dev) == 0) {
+		LOG_INF("VSI ready; carrier follows PSI link status");
+	} else {
+		LOG_WRN("VSI link-status notifications unavailable; forcing carrier up");
+		net_eth_carrier_on(data->iface);
+		LOG_INF("VSI ready");
+	}
+}
+
+/*
+ * Single VSI service thread: manages the SI and handles Rx. It waits on
+ * rx_sem and is woken by an Rx IRQ, a PSI link-up notification
+ * (link_notify), or a timeout. On each wake-up it:
+ *   1. Checks the SR-IOV VF-enable bit. If the VF is disabled, it drops the
+ *      carrier and waits. If the VF is enabled again, it brings the SI up
+ *      and performs the full setup.
+ *   2. Re-sends the PSI steering after a link-up notification, because a
+ *      PSI restart can lose our MAC and filter settings.
+ *   3. Receives data from the Rx ring while the SI is up.
+ */
+static void netc_eth_vsi_thread(void *arg1, void *unused1, void *unused2)
+{
+	const struct device *dev = (const struct device *)arg1;
+	const struct netc_eth_config *config = dev->config;
+	struct netc_eth_data *data = dev->data;
+	bool up = true;
+
+	ARG_UNUSED(unused1);
+	ARG_UNUSED(unused2);
+
+	netc_eth_vsi_bring_up(dev);
+
+	for (;;) {
+		int work;
+		bool ready;
+
+		k_sem_take(&data->rx_sem,
+			   K_MSEC(CONFIG_ETH_NXP_IMX_NETC_VSI_READY_POLL_INTERVAL_MS));
+		ready = netc_eth_vsi_vf_ready(config);
+
+		if (up && !ready) {
+			/* SR-IOV torn down: the SI is gone until it returns. */
+			k_mutex_lock(&data->msg_lock, K_FOREVER);
+			data->si_ready = false;
+			k_mutex_unlock(&data->msg_lock);
+			net_eth_carrier_off(data->iface);
+			LOG_INF("VSI down; awaiting SR-IOV re-enable");
+			up = false;
+		} else if (!up && ready) {
+			/* SR-IOV back: the SI was reset, so redo the full bring-up. */
+			netc_eth_vsi_bring_up(dev);
+			up = true;
+		}
+
+		if (!up) {
+			/* SI torn down (SR-IOV gone): nothing to drive until it returns. */
+			continue;
+		}
+
+		if (data->link_notify) {
+			/*
+			 * Link-up notification: re-send the steering settings to restore si_ready.
+			 */
+			data->link_notify = false;
+			netc_eth_vsi_program_psi(dev);
+			net_eth_carrier_on(data->iface);
+			LOG_INF("VSI link-up; PSI reprogrammed");
+		}
+
+		if (!data->si_ready) {
+			/* Graceful link-down, no link-up yet: idle until it returns. */
+			continue;
+		}
+
+		work = 0;
+		while (netc_eth_rx(dev) != -ENOBUFS) {
+			if (++work == CONFIG_ETH_NXP_IMX_RX_BUDGET) {
+				/* more work to do, reschedule */
+				work = 0;
+				k_yield();
+			}
+		}
+	}
+}
+
+/* Boot-time init: software handle setup only (no MMIO), then spawn the threads. */
+static int netc_eth_vsi_init(const struct device *dev)
+{
+	const struct netc_eth_config *config = dev->config;
+	struct netc_eth_data *data = dev->data;
+	ep_handle_t *handle = &data->handle;
+
+	/* No-op without an MMU, but kept for parity with the PSI driver. */
+	DEVICE_MMIO_NAMED_MAP(dev, port, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
+	DEVICE_MMIO_NAMED_MAP(dev, vfconfig, K_MEM_CACHE_NONE | K_MEM_DIRECT_MAP);
+
+	(void)memset(handle, 0, sizeof(*handle));
+
+	NETC_SocGetBaseResource(&handle->hw, (netc_hw_si_idx_t)config->si_idx);
+
+	/* Fill the handle config the driver needs to drive the SI datapath. */
+	handle->cfg.si = (netc_hw_si_idx_t)config->si_idx;
+	handle->cfg.rxRingUse = 1;
+	handle->cfg.txRingUse = 1;
+	handle->cfg.rxBdrGroupNum = 0;
+	handle->cfg.ringPerBdrGroup = 1;
+	/* Buffers/BD rings are non-cacheable; skip HAL cache ops (DSB still runs). */
+	handle->cfg.rxCacheMaintain = false;
+	handle->cfg.txCacheMaintain = false;
+	handle->cfg.rxZeroCopy = false;
+	handle->cfg.entryNum = config->msix_entry_num;
+	handle->cfg.userData = data;
+	handle->cfg.reclaimCallback = NULL;
+
+	if (net_eth_mac_load(&config->mac_config, data->mac_addr) == -ENODATA) {
+		LOG_WRN("No MAC address in the device tree; set local-mac-address or "
+			"zephyr,random-mac-address");
+	}
+
+	data->si_ready = false;
+	k_mutex_init(&data->msg_lock);
+	k_sem_init(&data->tx_sem, 0, 1);
+	k_sem_init(&data->rx_sem, 0, 1);
+
+	return 0;
+}
+
+static int netc_eth_vsi_tx(const struct device *dev, struct net_pkt *pkt)
+{
+	struct netc_eth_data *data = dev->data;
+	const struct netc_eth_config *config = dev->config;
+
+	/*
+	 * Do not transmit unless the SI is up. If the VF is disabled, wake the
+	 * service thread so it can handle the carrier-down state immediately.
+	 */
+	if (!data->si_ready) {
+		return -ENETDOWN;
+	}
+	if (!netc_eth_vsi_vf_ready(config)) {
+		k_sem_give(&data->rx_sem);
+		return -ENETDOWN;
+	}
+
+	return netc_eth_tx(dev, pkt);
+}
+
+static enum ethernet_hw_caps netc_eth_vsi_get_capabilities(const struct device *dev,
+							   struct net_if *iface)
+{
+	/* The VSI programs a multicast hash filter over the PSI mailbox. */
+	return netc_eth_get_capabilities(dev, iface) | ETHERNET_HW_FILTERING;
+}
+
+static const struct ethernet_api netc_eth_vsi_api = {
+	.iface_api.init = netc_eth_vsi_iface_init,
+	.get_capabilities = netc_eth_vsi_get_capabilities,
+	.set_config = netc_eth_vsi_set_config,
+#if defined(CONFIG_NET_VLAN)
+	.vlan_setup = netc_eth_vsi_vlan_setup,
+#endif
+	.send = netc_eth_vsi_tx,
+};
+
+#define NETC_VSI_INSTANCE_DEFINE(n)                                                                \
+	AT_NONCACHEABLE_SECTION_ALIGN(                                                             \
+		static uint8_t eth_vsi##n##_tx_buff[CONFIG_ETH_NXP_IMX_TX_RING_LEN]                \
+						   [CONFIG_ETH_NXP_IMX_TX_RING_BUF_SIZE],         \
+		NETC_BUFF_ALIGN);                                                                  \
+	AT_NONCACHEABLE_SECTION_ALIGN(                                                             \
+		static uint8_t eth_vsi##n##_msg_buff[NETC_MSG_VSI_BUF_SIZE], NETC_BUFF_ALIGN);     \
+	AT_NONCACHEABLE_SECTION_ALIGN(                                                             \
+		static netc_tx_bd_t eth_vsi##n##_txbd_array[CONFIG_ETH_NXP_IMX_TX_RING_NUM]        \
+							   [CONFIG_ETH_NXP_IMX_TX_RING_LEN],       \
+		NETC_BD_ALIGN);                                                                    \
+	static netc_tx_frame_info_t eth_vsi##n##_txdirty_array[CONFIG_ETH_NXP_IMX_TX_RING_NUM]     \
+							      [CONFIG_ETH_NXP_IMX_TX_RING_LEN];    \
+	AT_NONCACHEABLE_SECTION_ALIGN(                                                             \
+		static rx_buffer_t eth_vsi##n##_rx_buff[CONFIG_ETH_NXP_IMX_RX_RING_NUM]            \
+						       [CONFIG_ETH_NXP_IMX_RX_RING_LEN],           \
+		NETC_BUFF_ALIGN);                                                                  \
+	static uint64_t eth_vsi##n##_rx_buff_addr_array[CONFIG_ETH_NXP_IMX_RX_RING_NUM]            \
+						       [CONFIG_ETH_NXP_IMX_RX_RING_LEN];           \
+	AT_NONCACHEABLE_SECTION(                                                                   \
+		static uint8_t eth_vsi##n##_rx_frame[NETC_RX_RING_BUF_SIZE_ALIGN]);                \
+	AT_NONCACHEABLE_SECTION_ALIGN(                                                             \
+		static netc_rx_bd_t eth_vsi##n##_rxbd_array[CONFIG_ETH_NXP_IMX_RX_RING_NUM]        \
+							   [CONFIG_ETH_NXP_IMX_RX_RING_LEN],       \
+		NETC_BD_ALIGN);                                                                    \
+	static void netc_eth_vsi##n##_bdr_init(netc_bdr_config_t *bdr_config,                      \
+					       netc_rx_bdr_config_t *rx_bdr_config,                \
+					       netc_tx_bdr_config_t *tx_bdr_config)                \
+	{                                                                                          \
+		for (uint8_t ring = 0U; ring < CONFIG_ETH_NXP_IMX_RX_RING_NUM; ring++) {           \
+			for (uint8_t bd = 0U; bd < CONFIG_ETH_NXP_IMX_RX_RING_LEN; bd++) {         \
+				eth_vsi##n##_rx_buff_addr_array[ring][bd] =                        \
+					(uint64_t)(uintptr_t)&eth_vsi##n##_rx_buff[ring][bd];      \
+			}                                                                          \
+		}                                                                                  \
+		bdr_config->rxBdrConfig = rx_bdr_config;                                           \
+		bdr_config->txBdrConfig = tx_bdr_config;                                           \
+		bdr_config->rxBdrConfig[0].bdArray = &eth_vsi##n##_rxbd_array[0][0];               \
+		bdr_config->rxBdrConfig[0].len = CONFIG_ETH_NXP_IMX_RX_RING_LEN;                   \
+		bdr_config->rxBdrConfig[0].buffAddrArray = &eth_vsi##n##_rx_buff_addr_array[0][0]; \
+		bdr_config->rxBdrConfig[0].buffSize = NETC_RX_RING_BUF_SIZE_ALIGN;                 \
+		bdr_config->rxBdrConfig[0].msixEntryIdx = NETC_RX_MSIX_ENTRY_IDX;                  \
+		bdr_config->rxBdrConfig[0].extendDescEn = false;                                   \
+		bdr_config->rxBdrConfig[0].enThresIntr = true;                                     \
+		bdr_config->rxBdrConfig[0].enCoalIntr = true;                                      \
+		bdr_config->rxBdrConfig[0].intrThreshold = 1;                                      \
+		bdr_config->txBdrConfig[0].bdArray = &eth_vsi##n##_txbd_array[0][0];               \
+		bdr_config->txBdrConfig[0].len = CONFIG_ETH_NXP_IMX_TX_RING_LEN;                   \
+		bdr_config->txBdrConfig[0].dirtyArray = &eth_vsi##n##_txdirty_array[0][0];         \
+		bdr_config->txBdrConfig[0].msixEntryIdx = NETC_TX_MSIX_ENTRY_IDX;                  \
+		bdr_config->txBdrConfig[0].enIntr = false;                                         \
+		bdr_config->txBdrConfig[0].enThresIntr = true;                                     \
+	}                                                                                          \
+	static struct netc_eth_data netc_eth_vsi##n##_data = {                                     \
+		.mac_addr = DT_INST_PROP_OR(n, local_mac_address, {0}),                            \
+		.tx_buff = eth_vsi##n##_tx_buff,                                                   \
+		.msg_buff = eth_vsi##n##_msg_buff,                                                 \
+		.rx_frame = eth_vsi##n##_rx_frame,                                                 \
+	};                                                                                         \
+	static const struct netc_eth_config netc_eth_vsi##n##_config = {                           \
+		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(port, DT_DRV_INST(n)),                          \
+		DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(vfconfig, DT_DRV_INST(n)),                      \
+		.mac_config = NET_ETH_MAC_DT_INST_CONFIG_INIT(n),                                  \
+		.bdr_init = netc_eth_vsi##n##_bdr_init,                                            \
+		.si_idx = (DT_INST_PROP(n, mac_index) << 8) | DT_INST_PROP(n, si_index),           \
+		.is_vsi = true,                                                                    \
+		IF_ENABLED(DT_INST_NODE_HAS_PROP(n, clocks),                                       \
+			(.ready_clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                 \
+			.ready_clock_subsys =                                                      \
+				(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),))            \
+		.msix_entry_num = NETC_MSIX_VSI_EVENTS_COUNT,                                     \
+		IF_ENABLED(CONFIG_ETH_NXP_IMX_NETC_MSI_GIC,                                        \
+			(.msi_device_id = DT_INST_PROP_OR(n, msi_device_id, 0),                    \
+			.msi_dev = (COND_CODE_1(DT_NODE_HAS_PROP(DT_INST_PARENT(n), msi_parent),   \
+			       (DEVICE_DT_GET(DT_PHANDLE(DT_INST_PARENT(n), msi_parent))), NULL)), \
+			))                                                                         \
+		IF_DISABLED(CONFIG_ETH_NXP_IMX_NETC_MSI_GIC,                                       \
+			(.tx_intr_msg_data = NETC_TX_INTR_MSG_DATA_START + n,                      \
+			.rx_intr_msg_data = NETC_RX_INTR_MSG_DATA_START + n,                       \
+			.msg_intr_msg_data = NETC_MSG_INTR_MSG_DATA_START + n,))                   \
+	};                                                                                         \
+	ETH_NET_DEVICE_DT_INST_DEFINE(n, netc_eth_vsi_init, NULL, &netc_eth_vsi##n##_data,         \
+				      &netc_eth_vsi##n##_config,                                   \
+				      CONFIG_ETH_INIT_PRIORITY,                                    \
+				      &netc_eth_vsi_api, NET_ETH_MTU);
+DT_INST_FOREACH_STATUS_OKAY(NETC_VSI_INSTANCE_DEFINE)

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_vsi.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_vsi.c
@@ -581,6 +581,9 @@ static enum ethernet_hw_caps netc_eth_vsi_get_capabilities(const struct device *
 static const struct ethernet_api netc_eth_vsi_api = {
 	.iface_api.init = netc_eth_vsi_iface_init,
 	.get_capabilities = netc_eth_vsi_get_capabilities,
+#if defined(CONFIG_NET_STATISTICS_ETHERNET)
+	.get_stats = netc_eth_get_stats,
+#endif
 	.set_config = netc_eth_vsi_set_config,
 #if defined(CONFIG_NET_VLAN)
 	.vlan_setup = netc_eth_vsi_vlan_setup,

--- a/drivers/firmware/scmi/clk.c
+++ b/drivers/firmware/scmi/clk.c
@@ -49,6 +49,18 @@ struct scmi_clock_parent_config {
 	uint32_t parent_id;
 };
 
+struct scmi_clock_config_get_request {
+	uint32_t clk_id;
+	uint32_t flags;
+};
+
+struct scmi_clock_config_get_reply {
+	int32_t status;
+	uint32_t attributes;
+	uint32_t config;
+	uint32_t extended_config_val;
+};
+
 struct scmi_clock_get_permissions_reply {
 	int32_t status;
 	uint32_t permissions;
@@ -256,6 +268,49 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 	}
 
 	return scmi_status_to_errno(status);
+}
+
+int scmi_clock_config_get(struct scmi_protocol *proto, uint32_t clk_id,
+			  uint32_t flags, uint32_t *config)
+{
+	struct scmi_message msg, reply;
+	struct scmi_clock_config_get_request request;
+	struct scmi_clock_config_get_reply reply_buffer;
+	int ret;
+
+	/* input validation */
+	if (!proto || !config) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_CLOCK) {
+		return -EINVAL;
+	}
+
+	request.clk_id = clk_id;
+	request.flags = flags;
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(CLOCK_CONFIG_GET,
+					SCMI_COMMAND, proto->id, 0x0);
+	msg.len = sizeof(request);
+	msg.content = &request;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(reply_buffer);
+	reply.content = &reply_buffer;
+
+	ret = scmi_send_message(proto, &msg, &reply, false);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (reply_buffer.status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(reply_buffer.status);
+	}
+
+	*config = reply_buffer.config;
+
+	return 0;
 }
 
 static int scmi_clock_attributes_v2(struct scmi_protocol *proto, uint32_t clk_id,

--- a/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/imx/nxp_imx95_m7.dtsi
@@ -1052,6 +1052,77 @@
 					status = "disabled";
 				};
 
+				/*
+				 * NETC Virtual Station Interfaces (VFs), ENETC-grouped in pairs:
+				 * ENETC0 -> VSI0/1, ENETC1 -> VSI2/3, ENETC2 -> VSI4/5. All
+				 * disabled here; a board enables the VF assigned to this core.
+				 */
+				enetc0_vsi0: ethernet@4cd20000 {
+					compatible = "nxp,imx-netc-vsi";
+					reg = <0x4cd20000 0x10000>,
+					      <0x4ca10000 0x1000>;
+					reg-names = "port", "vfconfig";
+					mac-index = <0>;
+					si-index = <0x13>;
+					clocks = <&scmi_clk IMX95_CLK_BUSNETCMIX>;
+					status = "disabled";
+				};
+
+				enetc0_vsi1: ethernet@4cd30000 {
+					compatible = "nxp,imx-netc-vsi";
+					reg = <0x4cd30000 0x10000>,
+					      <0x4ca20000 0x1000>;
+					reg-names = "port", "vfconfig";
+					mac-index = <0>;
+					si-index = <0x24>;
+					clocks = <&scmi_clk IMX95_CLK_BUSNETCMIX>;
+					status = "disabled";
+				};
+
+				enetc1_vsi0: ethernet@4cd40000 {
+					compatible = "nxp,imx-netc-vsi";
+					reg = <0x4cd40000 0x10000>,
+					      <0x4ca50000 0x1000>;
+					reg-names = "port", "vfconfig";
+					mac-index = <1>;
+					si-index = <0x15>;
+					clocks = <&scmi_clk IMX95_CLK_BUSNETCMIX>;
+					status = "disabled";
+				};
+
+				enetc1_vsi1: ethernet@4cd50000 {
+					compatible = "nxp,imx-netc-vsi";
+					reg = <0x4cd50000 0x10000>,
+					      <0x4ca60000 0x1000>;
+					reg-names = "port", "vfconfig";
+					mac-index = <1>;
+					si-index = <0x26>;
+					clocks = <&scmi_clk IMX95_CLK_BUSNETCMIX>;
+					status = "disabled";
+				};
+
+				enetc2_vsi0: ethernet@4cd60000 {
+					compatible = "nxp,imx-netc-vsi";
+					reg = <0x4cd60000 0x10000>,
+					      <0x4ca90000 0x1000>;
+					reg-names = "port", "vfconfig";
+					mac-index = <2>;
+					si-index = <0x17>;
+					clocks = <&scmi_clk IMX95_CLK_BUSNETCMIX>;
+					status = "disabled";
+				};
+
+				enetc2_vsi1: ethernet@4cd70000 {
+					compatible = "nxp,imx-netc-vsi";
+					reg = <0x4cd70000 0x10000>,
+					      <0x4caa0000 0x1000>;
+					reg-names = "port", "vfconfig";
+					mac-index = <2>;
+					si-index = <0x28>;
+					clocks = <&scmi_clk IMX95_CLK_BUSNETCMIX>;
+					status = "disabled";
+				};
+
 				emdio: mdio@4cb00000 {
 					compatible = "nxp,imx-netc-emdio";
 					reg = <0x4cb00000 0x100000>,

--- a/dts/bindings/ethernet/nxp,imx-netc-vsi.yaml
+++ b/dts/bindings/ethernet/nxp,imx-netc-vsi.yaml
@@ -1,0 +1,40 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  NXP NETC Virtual Station Interface (VSI).
+
+  A VSI is a virtual function of an ENETC instance. Unlike the Physical Station
+  Interface (PSI) it does not own the physical MAC/PHY or the MDIO bus.
+  Control operations that touch those shared resources (primary MAC, filters,
+  link status) are performed by messaging the PSI over the VSI-to-PSI channel.
+
+compatible: "nxp,imx-netc-vsi"
+
+# Reuse the PSI binding; a VSI only adds VSI-specific reg-names/clocks.
+include: nxp,imx-netc-psi.yaml
+
+properties:
+  reg-names:
+    required: true
+
+  mac-index:
+    required: true
+    type: int
+    description: |
+      ENETC (MAC) instance this VSI belongs to.
+
+  si-index:
+    required: true
+    type: int
+    description: |
+      Low byte of the HAL station-interface index: bits [7:4] = SI number within
+      the ENETC (0=PSI, 1=VSI0, 2=VSI1), bits [3:0] = index into the SI
+      base-address array.
+
+  clocks:
+    type: phandle-array
+    description: |
+      Optional readiness clock: Checks whether the PSI has enabled the clock,
+      so the driver can safely access the VSI. The clock is only observed and
+      not controlled by the driver.

--- a/include/zephyr/drivers/firmware/scmi/clk.h
+++ b/include/zephyr/drivers/firmware/scmi/clk.h
@@ -127,6 +127,24 @@ struct scmi_clock_attributes {
  */
 int scmi_clock_config_set(struct scmi_protocol *proto,
 			  struct scmi_clock_config *cfg);
+
+/**
+ * @brief Send the CLOCK_CONFIG_GET command and get its reply
+ *
+ * Queries the current configuration of a clock, notably whether it is
+ * enabled. This is a read-only query serviced by the SCMI platform.
+ *
+ * @param proto pointer to SCMI clock protocol data
+ * @param clk_id ID of the clock for which the query is done
+ * @param flags command flags (0 for the base query; extended-config bits are
+ * not decoded here)
+ * @param config pointer set to the returned config word on success. Use
+ * SCMI_CLK_CONFIG_ENABLE_DISABLE() to test the enable state.
+ *
+ * @return 0 on success, negative errno value on failure.
+ */
+int scmi_clock_config_get(struct scmi_protocol *proto, uint32_t clk_id,
+			  uint32_t flags, uint32_t *config);
 /**
  * @brief Query the rate of a clock
  *


### PR DESCRIPTION
This PR adds a NETC Virtual Station Interface (VSI) driver for ENETC (Particularly the i.MX95), so Zephyr can drive the ENETC VSI MAC while a separate OS owns the PSI MAC. On the MR-NavQ95B the M7 runs Zephyr as an ENETC VF next to Linux on the A55, which owns the PSI and the physical port.

The driver brings the VSI up off the boot path in a service thread, gating first access on the NETC clock and the PF's SR-IOV VF-enable bit so it can't fault on a not-yet-decoding SI. Once it's up it programs its own unicast MAC and multicast-promiscuous mode through VSI->PSI messages.

To make this work the PR also:

- Implements the SCMI `CLOCK_CONFIG_GET` command ( `scmi_clock_config_get` ) and wires it into the ARM SCMI clock_control driver as a  `.get_status` callback, so a consumer can query a clock's enabled state over SCMI. The VSI driver uses this to know when the shared NETCMIX block is clocked before touching the SI.
- The shared transmit (Tx) data path was improved to handle more traffic. Tx-completion interrupts are grouped together using a frame count limit and a timer, reducing interrupt overhead. Each slot now has its own buffer ring, so frames do not have to wait for a single shared buffer. If a ring becomes full, the system waits until space is available instead of dropping frames. PTP transmit timestamps are still obtained using a busy-wait method.

Note: the current Zephyr NETC PSI driver implements neither SR-IOV nor PSI<->VSI messaging, so only the Zephyr-VSI-to-Linux-PSI path is tested.