### PR TITLE
tests: drivers: spi: spi_loopback: add kit_pse84_eval m33/ns support

### DIFF
--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns.yaml
@@ -18,3 +18,5 @@ supported:
   - bluetooth
   - wifi
   - flash
+  - dma
+  - spi

--- a/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.conf
+++ b/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_INFINEON_DMA=y

--- a/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"


### PR DESCRIPTION
## tests: drivers: spi: spi_loopback: add kit_pse84_eval m33/ns support

`drivers.spi.loopback` did not run on
`kit_pse84_eval/pse846gps2dbzc4a/m33/ns`: the board's `supported`
peripheral list lacked `spi`, so the test was statically filtered out,
and there was no `spi_loopback` board overlay for the variant.

### Changes

- Add `spi` (and `dma`) to the m33/ns board `supported` list so the test
  is no longer statically filtered.
- Add the `spi_loopback` board overlay and conf for the m33/ns variant,
  mirroring the existing Secure m33 variant. The overlay reuses the
  shared `kit_pse84_eval_common.overlay` (SCB10 SPI master with the
  `test-spi-loopback-slow`/`-fast` nodes and DMA); the conf enables the
  Infineon SPI DMA path (`CONFIG_SPI_INFINEON_DMA=y`).

### Testing

`drivers.spi.loopback` builds and passes on the m33/ns (Non-Secure)
target on hardware (SPI loopback jumper installed): all test cases pass,
0 failed / 0 errored.
