### PR TITLE
scripts: dts: Loosen type annotation on "val"

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -1262,7 +1262,7 @@ def list2init(values: Iterable[str]) -> str:
 
 def out_dt_define(
     macro: str,
-    val: str,
+    val: str | int,
     width: int | None = None,
     deprecation_msg: str | None = None,
 ) -> str:
@@ -1284,7 +1284,7 @@ def out_dt_define(
 
 def out_define(
     macro: str,
-    val: str,
+    val: str | int,
     width: int | None = None,
     deprecation_msg: str | None = None,
 ) -> None:


### PR DESCRIPTION
Update `out_dt_define` and `out_define` macro to allow integer types as the value parameter. Prevents unneeded / invalid warning when "val" is specified as an integer.

The script uses both string and integer typed values as input to `out_dt_define`. This is valid since this API is used to generate `#define` statements with `val` (see https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/dts/gen_defines.py#L1285-L1302)

**Existing usage of string type**
- https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/dts/gen_defines.py#L85
- https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/dts/gen_defines.py#L280
- https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/dts/gen_defines.py#L304

**Existing usage of int type**
- https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/dts/gen_defines.py#L302
- https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/dts/gen_defines.py#L687
- https://github.com/zephyrproject-rtos/zephyr/blob/main/scripts/dts/gen_defines.py#L1247