### PR TITLE
Add arm cortex-M backend for Perf

### DIFF
--- a/arch/arm/core/cortex_m/CMakeLists.txt
+++ b/arch/arm/core/cortex_m/CMakeLists.txt
@@ -38,6 +38,9 @@ zephyr_library_sources_ifndef(CONFIG_USE_SWITCH exc_exit.c thread_abort.c swap_h
 
 zephyr_library_sources_ifndef(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER irq_init.c)
 zephyr_library_sources_ifdef(CONFIG_GEN_SW_ISR_TABLE isr_wrapper.c)
+if(CONFIG_PROFILING_PERF AND CONFIG_PROFILING_PERF_BACKEND_ARM_CORTEX_M)
+  zephyr_library_sources(perf_sys_clock_isr.S)
+endif()
 zephyr_library_sources_ifdef(CONFIG_DEBUG_COREDUMP coredump.c)
 zephyr_library_sources_ifdef(CONFIG_THREAD_LOCAL_STORAGE __aeabi_read_tp.S)
 zephyr_library_sources_ifdef(CONFIG_SEMIHOST semihost.c)

--- a/arch/arm/core/cortex_m/perf_sys_clock_isr.S
+++ b/arch/arm/core/cortex_m/perf_sys_clock_isr.S
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Cortex-M SysTick wrapper for perf stack sampling
+ *
+ * The normal SysTick handler is a C function, so its compiler-generated
+ * prologue may change the handler stack before perf can inspect the
+ * exception-entry state. This wrapper runs directly from the SysTick vector
+ * and captures the interrupted stack pointer, EXC_RETURN, and r7
+ * before calling sys_clock_isr().
+ */
+
+#include <zephyr/toolchain.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/linker/sections.h>
+
+_ASM_FILE_PROLOGUE
+
+GTEXT(z_arm_perf_sys_clock_isr)
+GTEXT(sys_clock_isr)
+GTEXT(z_arm_perf_sample_enter)
+GTEXT(z_arm_perf_sample_exit)
+
+SECTION_FUNC(TEXT, z_arm_perf_sys_clock_isr)
+	/* Use EXC_RETURN to find the hardware exception frame before
+	 * modifying the handler stack. The C timer ISR runs after exception
+	 * entry, so the wrapper must capture the interrupted stack pointer,
+	 * EXC_RETURN, and r7 before calling into sys_clock_isr().
+	 */
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+	movs r0, #_EXC_RETURN_SPSEL_Msk
+	mov r1, lr
+	tst r1, r0
+	beq .L_stack_frame_msp
+	mrs r0, PSP
+	b .L_stack_frame_endif
+.L_stack_frame_msp:
+	mrs r0, MSP
+.L_stack_frame_endif:
+#elif defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	tst lr, #_EXC_RETURN_SPSEL_Msk
+	ite eq
+	mrseq r0, MSP
+	mrsne r0, PSP
+#else
+#error Unknown ARM architecture
+#endif
+
+	mov r1, lr
+	mov r2, r7
+	/* Keep the original EXC_RETURN live across the profiling hooks and
+	 * the real SysTick handler so the exception returns exactly as it
+	 * would without perf sampling enabled.
+	 */
+	push {r3, lr}
+	bl z_arm_perf_sample_enter
+	bl sys_clock_isr
+	bl z_arm_perf_sample_exit
+	pop {r2, r3}
+	mov lr, r3
+	bx lr

--- a/arch/arm/core/cortex_m/vector_table.S
+++ b/arch/arm/core/cortex_m/vector_table.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013-2015 Wind River Systems, Inc.
  * Copyright (c) 2020 Nordic Semiconductor ASA.
+ * Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -82,11 +83,14 @@ SECTION_SUBSEC_FUNC(exc_vector_table,_vector_table_section,_vector_table)
 #if defined(CONFIG_CPU_CORTEX_M_HAS_SYSTICK)
 #if defined(CONFIG_SYS_CLOCK_EXISTS) && \
     defined(CONFIG_CORTEX_M_SYSTICK_INSTALL_ISR)
+#if defined(CONFIG_PROFILING_PERF) && defined(CONFIG_PROFILING_PERF_BACKEND_ARM_CORTEX_M)
+    .word z_arm_perf_sys_clock_isr
+#else
     .word sys_clock_isr
+#endif /* CONFIG_PROFILING_PERF && CONFIG_PROFILING_PERF_BACKEND_ARM_CORTEX_M */
 #else
     .word z_arm_exc_spurious
 #endif /* CONFIG_SYS_CLOCK_EXISTS && CONFIG_CORTEX_M_SYSTICK_INSTALL_ISR */
 #else
     .word 0
 #endif /* CONFIG_CPU_CORTEX_M_HAS_SYSTICK */
-

--- a/arch/arm/core/cortex_m/vector_table.h
+++ b/arch/arm/core/cortex_m/vector_table.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2015 Wind River Systems, Inc.
+ * Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -56,6 +57,9 @@ GTEXT(z_prep_c)
 #if defined(CONFIG_GEN_ISR_TABLES)
 GTEXT(_isr_wrapper)
 #endif /* CONFIG_GEN_ISR_TABLES */
+#if defined(CONFIG_PROFILING_PERF) && defined(CONFIG_PROFILING_PERF_BACKEND_ARM_CORTEX_M)
+GTEXT(z_arm_perf_sys_clock_isr)
+#endif /* CONFIG_PROFILING_PERF && CONFIG_PROFILING_PERF_BACKEND_ARM_CORTEX_M */
 
 #else /* _ASMLANGUAGE */
 

--- a/arch/arm/core/stacktrace.c
+++ b/arch/arm/core/stacktrace.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2025 Synaptics Incorporated
+ * Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ *
  * Author: Jisheng Zhang <jszhang@kernel.org>
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -452,6 +454,17 @@ static bool unwind_one_frame(struct unwind_control_block *ucb)
 	return true;
 }
 
+static uint32_t esf_stack_pointer(const struct arch_esf *esf)
+{
+#if defined(CONFIG_CPU_CORTEX_M)
+	if ((esf->extra_info.exc_return & EXC_RETURN_SPSEL_Msk) == EXC_RETURN_SPSEL_MAIN) {
+		return esf->extra_info.msp;
+	}
+#endif
+
+	return esf->extra_info.callee->psp;
+}
+
 static bool seed_from_esf(struct unwind_control_block *ucb, const struct arch_esf *esf)
 {
 	if (esf == NULL || esf->extra_info.callee == NULL) {
@@ -459,7 +472,13 @@ static bool seed_from_esf(struct unwind_control_block *ucb, const struct arch_es
 	}
 
 	ucb->vrs[7] = esf->extra_info.callee->v4;
-	ucb->vrs[13] = esf->extra_info.callee->psp + sizeof(esf->basic);
+	ucb->vrs[13] = esf_stack_pointer(esf) + sizeof(esf->basic);
+
+#if defined(CONFIG_CPU_CORTEX_M)
+	if ((esf->basic.xpsr & BIT(9)) != 0) {
+		ucb->vrs[13] += sizeof(uint32_t);
+	}
+#endif
 
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	if ((esf->extra_info.exc_return & EXC_RETURN_STACK_FRAME_TYPE_Msk) ==

--- a/doc/services/profiling/perf.rst
+++ b/doc/services/profiling/perf.rst
@@ -11,9 +11,18 @@ Work Principle
 
 The ``perf record`` shell command starts a timer with the perf tracer function.
 Timers are driven by interrupts, so the perf tracer function is called during an interruption.
-The Zephyr core saves the return address and frame pointer in the interrupt stack or ``callee_saved``
-structure before calling the interrupt handler. Thus, the perf trace function makes stack traces by
-using the return address and frame pointer.
+The Zephyr core saves the return address and frame pointer in the interrupt stack,
+``callee_saved`` structure, or architecture-specific exception frame before calling the
+interrupt handler. Thus, the perf trace function makes stack traces by using the return
+address and frame pointer.
+
+On Cortex-M, perf wraps the SysTick handler so it can sample the interrupted
+Thread-mode Process Stack Pointer (PSP) frame before the normal timer ISR uses the
+handler stack. The backend validates that frame before passing it to the Arm stack
+walker.
+
+The Cortex-M backend is unavailable for Non-secure Trusted Execution images because
+Secure exception frames are inaccessible to Non-secure firmware.
 
 The :zephyr_file:`scripts/profiling/stackcollapse.py` script can be used to convert return addresses
 in the stack trace to function names using symbols from the ELF file, and to prints them in the
@@ -29,6 +38,10 @@ You can configure this module using the following options:
 
 * :kconfig:option:`CONFIG_PROFILING_PERF_BUFFER_SIZE`: Sets the size of the perf buffer
   where samples are saved before printing.
+
+Architecture backends may require additional stack-unwind support. The Cortex-M backend
+requires SysTick, thread stack information, extra exception information, Arm stack
+walking support, and a uniprocessor configuration.
 
 Usage
 *****

--- a/samples/subsys/profiling/perf/Kconfig
+++ b/samples/subsys/profiling/perf/Kconfig
@@ -1,0 +1,11 @@
+# Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+configdefault EXTRA_EXCEPTION_INFO
+	default y if CPU_CORTEX_M && CORTEX_M_SYSTICK
+
+configdefault ARCH_STACKWALK
+	default y if CPU_CORTEX_M && CORTEX_M_SYSTICK
+
+source "Kconfig.zephyr"

--- a/samples/subsys/profiling/perf/README.rst
+++ b/samples/subsys/profiling/perf/README.rst
@@ -9,7 +9,11 @@ tool.
 Requirements
 ************
 
-The Perf tool is currently implemented only for RISC-V and x86_64 architectures.
+The Perf tool is currently implemented for RISC-V, x86, x86_64, and Cortex-M
+architectures. Cortex-M support requires SysTick, thread stack information,
+extra exception information, Arm stack walking support, and a uniprocessor
+configuration.
+The Cortex-M backend is unavailable for Non-secure Trusted Execution images.
 
 Usage example
 *************

--- a/samples/subsys/profiling/perf/src/main.c
+++ b/samples/subsys/profiling/perf/src/main.c
@@ -1,5 +1,6 @@
 /*
  *  Copyright (c) 2023 KNS Group LLC (YADRO)
+ *  Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  *  SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +8,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/toolchain.h>
 #include <stdio.h>
+
+BUILD_ASSERT(IS_ENABLED(CONFIG_PROFILING_PERF),
+	     "The perf sample requires CONFIG_PROFILING_PERF");
 
 #define WAIT_KOEF 10000
 

--- a/samples/subsys/profiling/perf/tests.yaml
+++ b/samples/subsys/profiling/perf/tests.yaml
@@ -9,8 +9,9 @@ tests:
       - profiling
     extra_configs:
       - CONFIG_PROFILING_PERF_BUFFER_SIZE=128
-    filter: CONFIG_RISCV or CONFIG_X86
+    filter: CONFIG_PROFILING_PERF_HAS_BACKEND
     integration_platforms:
+      - qemu_cortex_m3
       - qemu_riscv64
       - qemu_riscv32
       - qemu_x86_64

--- a/subsys/profiling/perf/CMakeLists.txt
+++ b/subsys/profiling/perf/CMakeLists.txt
@@ -2,7 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(backends)
+if(CONFIG_PROFILING_PERF)
+  add_subdirectory(backends)
+endif()
 
 zephyr_library()
 

--- a/subsys/profiling/perf/backends/CMakeLists.txt
+++ b/subsys/profiling/perf/backends/CMakeLists.txt
@@ -1,9 +1,14 @@
 # Copyright (c) 2024 Meta Platforms
+# Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_sources_ifdef(CONFIG_PROFILING_PERF_BACKEND_RISCV
   perf_riscv.c
+)
+
+zephyr_sources_ifdef(CONFIG_PROFILING_PERF_BACKEND_ARM_CORTEX_M
+  perf_arm_cortex_m.c
 )
 
 zephyr_sources_ifdef(CONFIG_PROFILING_PERF_BACKEND_X86

--- a/subsys/profiling/perf/backends/Kconfig
+++ b/subsys/profiling/perf/backends/Kconfig
@@ -1,4 +1,5 @@
 # Copyright (c) 2024 Meta Platforms
+# Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -13,6 +14,17 @@ config PROFILING_PERF_BACKEND_RISCV
 	default y
 	depends on RISCV
 	depends on ARCH_STACKWALK
+	select PROFILING_PERF_HAS_BACKEND
+
+config PROFILING_PERF_BACKEND_ARM_CORTEX_M
+	bool
+	default y
+	depends on CPU_CORTEX_M
+	depends on CORTEX_M_SYSTICK
+	depends on THREAD_STACK_INFO
+	depends on ARCH_STACKWALK
+	depends on !TRUSTED_EXECUTION_NONSECURE
+	depends on !SMP
 	select PROFILING_PERF_HAS_BACKEND
 
 config PROFILING_PERF_BACKEND_X86

--- a/subsys/profiling/perf/backends/perf_arm64.c
+++ b/subsys/profiling/perf/backends/perf_arm64.c
@@ -26,7 +26,7 @@ static bool perf_trace_cb(void *cookie, unsigned long addr)
 	return true;
 }
 
-size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
+int arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 {
 	if (size < 2U) {
 		return 0;
@@ -57,5 +57,5 @@ size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 
 	arch_stack_walk(perf_trace_cb, &ctx, _current, esf);
 
-	return ctx.idx;
+	return (int)ctx.idx;
 }

--- a/subsys/profiling/perf/backends/perf_arm_cortex_m.c
+++ b/subsys/profiling/perf/backends/perf_arm_cortex_m.c
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/arch/arch_interface.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/sys/util.h>
+#include <cortex_m/exception.h>
+#include <cortex_m/stack.h>
+
+#define PERF_CORTEX_M_XPSR_STACK_ALIGN_Msk BIT(9)
+#define PERF_CORTEX_M_XPSR_T_Msk BIT(24)
+
+struct perf_cortex_m_sample {
+	const struct arch_esf *esf;
+	uint32_t exc_return;
+	uint32_t r7;
+	bool active;
+};
+
+struct perf_cortex_m_trace {
+	uintptr_t *buf;
+	size_t size;
+	size_t count;
+	bool overflow;
+};
+
+static volatile struct perf_cortex_m_sample perf_sample;
+
+static bool in_text_region(uintptr_t addr)
+{
+	return (addr >= (uintptr_t)__text_region_start) && (addr < (uintptr_t)__text_region_end);
+}
+
+static bool range_contains(uintptr_t start, uintptr_t end, uintptr_t addr, size_t size)
+{
+	return (addr >= start) && (addr <= end) && (size <= (end - addr));
+}
+
+static bool thread_stack_range_contains(k_tid_t thread, uintptr_t addr, size_t size)
+{
+	uintptr_t start = thread->stack_info.start;
+	uintptr_t end = start + thread->stack_info.size;
+
+	return range_contains(start, end, addr, size);
+}
+
+static bool interrupt_stack_range_contains(uintptr_t addr, size_t size)
+{
+	unsigned int cpu = arch_curr_cpu()->id;
+	uintptr_t start = (uintptr_t)K_KERNEL_STACK_BUFFER(z_interrupt_stacks[cpu]);
+	uintptr_t end = start + K_KERNEL_STACK_SIZEOF(z_interrupt_stacks[cpu]);
+
+	return range_contains(start, end, addr, size);
+}
+
+static bool valid_basic_frame(const struct arch_esf *esf)
+{
+	/* The hardware-stacked PC must be executable code, and xPSR.T must
+	 * be set for a valid Cortex-M return state.
+	 */
+	return in_text_region((uintptr_t)esf->basic.pc) &&
+	       ((esf->basic.xpsr & PERF_CORTEX_M_XPSR_T_Msk) != 0U);
+}
+
+void z_arm_perf_sample_enter(const struct arch_esf *esf, uint32_t exc_return, uint32_t r7)
+{
+	/* The SysTick wrapper records the interrupted context before the
+	 * normal timer ISR uses the handler stack.
+	 */
+	perf_sample.esf = esf;
+	perf_sample.exc_return = exc_return;
+	perf_sample.r7 = r7;
+	perf_sample.active = true;
+}
+
+void z_arm_perf_sample_exit(void)
+{
+	perf_sample.active = false;
+	perf_sample.esf = NULL;
+	perf_sample.exc_return = 0U;
+	perf_sample.r7 = 0U;
+}
+
+static bool add_trace_addr(void *arg, unsigned long addr)
+{
+	struct perf_cortex_m_trace *trace = arg;
+
+	if (trace->count >= trace->size) {
+		/* perf.c treats a zero-length trace as a full buffer, so report
+		 * overflow by discarding this partial sample.
+		 */
+		trace->overflow = true;
+		return false;
+	}
+
+	if (!in_text_region((uintptr_t)addr)) {
+		return false;
+	}
+
+	trace->buf[trace->count++] = (uintptr_t)addr;
+
+	return true;
+}
+
+static int unwind_stack(const struct arch_esf *esf, uint32_t exc_return, uint32_t r7,
+			uintptr_t *buf, size_t size)
+{
+	struct perf_cortex_m_trace trace = {
+		.buf = buf,
+		.size = size,
+	};
+	struct arch_esf unwind_esf = {
+		.basic = esf->basic,
+	};
+	/* EHABI recipes may use r7 to recover VSP even when frame pointers are
+	 * not enabled globally.
+	 */
+	_callee_saved_t callee = {
+		.v4 = r7,
+		.psp = POINTER_TO_UINT(esf),
+	};
+
+	/* arch_stack_walk() expects the same extra ESF metadata used by the
+	 * fault path. Recreate only the fields needed to unwind from the
+	 * hardware exception frame captured on SysTick entry.
+	 */
+	unwind_esf.extra_info.callee = &callee;
+	unwind_esf.extra_info.exc_return = exc_return;
+	unwind_esf.extra_info.msp = POINTER_TO_UINT(esf);
+
+	arch_stack_walk(add_trace_addr, &trace, _current, &unwind_esf);
+
+	return trace.overflow ? 0 : (int)trace.count;
+}
+
+static bool valid_sample_stack(const struct arch_esf *esf, uint32_t exc_return)
+{
+	bool process_stack =
+		(exc_return & EXC_RETURN_SPSEL_Msk) == EXC_RETURN_SPSEL_PROCESS;
+	size_t frame_size = sizeof(esf->basic);
+	uint32_t xpsr;
+
+	/* The captured stack pointer is not trusted yet. Validate the fixed-size
+	 * basic frame before dereferencing xPSR to derive any optional state.
+	 */
+	if (process_stack) {
+		if (((exc_return & EXC_RETURN_MODE_Msk) != EXC_RETURN_MODE_THREAD) ||
+		    !thread_stack_range_contains(_current, (uintptr_t)esf, frame_size)) {
+			return false;
+		}
+	} else {
+		if (((exc_return & EXC_RETURN_MODE_Msk) != EXC_RETURN_MODE_HANDLER) ||
+		    !interrupt_stack_range_contains((uintptr_t)esf, frame_size)) {
+			return false;
+		}
+	}
+
+	xpsr = esf->basic.xpsr;
+	/* EXC_RETURN's mode and stack selection must agree with the exception
+	 * number recorded in the stacked xPSR.
+	 */
+	if ((process_stack && ((xpsr & IPSR_ISR_Msk) != 0U)) ||
+	    (!process_stack && ((xpsr & IPSR_ISR_Msk) == 0U))) {
+		return false;
+	}
+
+	/* Account for the alignment word inserted by exception entry and any
+	 * extended floating-point state described by EXC_RETURN.
+	 */
+	if ((xpsr & PERF_CORTEX_M_XPSR_STACK_ALIGN_Msk) != 0U) {
+		frame_size += sizeof(uint32_t);
+	}
+
+#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
+	if ((exc_return & EXC_RETURN_STACK_FRAME_TYPE_Msk) ==
+	    EXC_RETURN_STACK_FRAME_TYPE_EXTENDED) {
+		frame_size += sizeof(esf->fpu);
+	}
+#endif
+
+	/* Ensure the complete hardware-stacked frame fits before the unwinder
+	 * advances its virtual stack pointer past it.
+	 */
+	if (process_stack) {
+		return thread_stack_range_contains(_current, (uintptr_t)esf, frame_size);
+	}
+
+	return interrupt_stack_range_contains((uintptr_t)esf, frame_size);
+}
+
+static int stack_trace_from_sample(uintptr_t *buf, size_t size)
+{
+	const struct arch_esf *esf = (const struct arch_esf *)perf_sample.esf;
+	uint32_t exc_return = perf_sample.exc_return;
+	uint32_t r7 = perf_sample.r7;
+
+	if (!perf_sample.active || esf == NULL ||
+	    ((exc_return & EXC_RETURN_INDICATOR_PREFIX) != EXC_RETURN_INDICATOR_PREFIX) ||
+	    !IS_ALIGNED((uintptr_t)esf, sizeof(uint32_t)) ||
+	    !valid_sample_stack(esf, exc_return) ||
+	    !valid_basic_frame(esf)) {
+		return -EAGAIN;
+	}
+
+	return unwind_stack(esf, exc_return, r7, buf, size);
+}
+
+int arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
+{
+	if (size < 1U) {
+		return 0;
+	}
+
+	return stack_trace_from_sample(buf, size);
+}

--- a/subsys/profiling/perf/backends/perf_riscv.c
+++ b/subsys/profiling/perf/backends/perf_riscv.c
@@ -25,7 +25,7 @@ static bool perf_trace_cb(void *cookie, unsigned long addr)
 	return true;
 }
 
-size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
+int arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 {
 	if (size < 2U) {
 		return 0;
@@ -51,5 +51,5 @@ size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 
 	arch_stack_walk(perf_trace_cb, &ctx, _current, esf);
 
-	return ctx.idx;
+	return (int)ctx.idx;
 }

--- a/subsys/profiling/perf/backends/perf_x86.c
+++ b/subsys/profiling/perf/backends/perf_x86.c
@@ -33,7 +33,7 @@ struct isf {
  * Return addresses are translated in corresponding function's names using .elf file.
  * So we get function call trace
  */
-size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
+int arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 {
 	if (size < 1U) {
 		return 0;
@@ -89,5 +89,5 @@ size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 		fp = new_fp;
 	}
 
-	return idx;
+	return (int)idx;
 }

--- a/subsys/profiling/perf/backends/perf_x86_64.c
+++ b/subsys/profiling/perf/backends/perf_x86_64.c
@@ -24,7 +24,7 @@ static inline bool in_text_region(uintptr_t addr)
  * Return addresses are translated in corresponding function's names using .elf file.
  * So we get function call trace
  */
-size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
+int arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 {
 	if (size < 1U) {
 		return 0;
@@ -75,5 +75,5 @@ size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size)
 		fp = new_fp;
 	}
 
-	return idx;
+	return (int)idx;
 }

--- a/subsys/profiling/perf/perf.c
+++ b/subsys/profiling/perf/perf.c
@@ -1,6 +1,7 @@
 /*
  *  Copyright (c) 2023 KNS Group LLC (YADRO)
  *  Copyright (c) 2020 Yonatan Goldschmidt <yon.goldschmidt@gmail.com>
+ *  Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  *  SPDX-License-Identifier: Apache-2.0
  */
@@ -13,7 +14,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-size_t arch_perf_current_stack_trace(uintptr_t *buf, size_t size);
+/*
+ * Return the number of captured frames, zero when the buffer is too small,
+ * or a negative errno when the current sample should be skipped.
+ */
+int arch_perf_current_stack_trace(uintptr_t *buf, size_t size);
 
 struct perf_data_t {
 	struct k_timer timer;
@@ -53,7 +58,7 @@ static struct perf_data_t perf_data = {
 /* Common sampling function called from timer on each CPU */
 static void perf_do_sample(void)
 {
-	size_t trace_length = 0;
+	int trace_length = 0;
 	k_tid_t current_thread;
 #ifdef CONFIG_SMP
 	unsigned int cpu_id = arch_curr_cpu()->id;
@@ -92,13 +97,15 @@ static void perf_do_sample(void)
 								     perf_data.idx);
 	}
 
-	if (trace_length != 0) {
-		perf_data.buf[perf_data.idx - 1] = trace_length;
-		perf_data.idx += trace_length;
+	if (trace_length > 0) {
+		perf_data.buf[perf_data.idx - 1] = (uintptr_t)trace_length;
+		perf_data.idx += (size_t)trace_length;
 	} else {
 		--perf_data.idx;
-		perf_data.buf_full = true;
-		k_work_reschedule(&perf_data.dwork, K_NO_WAIT);
+		if (trace_length == 0) {
+			perf_data.buf_full = true;
+			k_work_reschedule(&perf_data.dwork, K_NO_WAIT);
+		}
 	}
 
 #ifdef CONFIG_SMP


### PR DESCRIPTION
This adds Cortex-M support to Zephyr’s perf stack-sampling backend.

The change wraps SysTick to capture and validate interrupted PSP/MSP exception frames before unwinding them with the Arm stack walker. It also adds Cortex-M sample coverage, build gating, and documentation. Cross-security-state sampling remains unsupported and can be covered later if needed.