### PR TITLE
timer: introduce a generic tickless system-timer core

### DIFF
--- a/doc/kernel/services/timing/clocks.rst
+++ b/doc/kernel/services/timing/clocks.rst
@@ -265,6 +265,31 @@ comparatively simple API.
   :c:func:`sys_clock_announce`, which the kernel needs to test newly
   arriving timeouts for expiration.
 
+* The driver may optionally provide a :c:func:`sys_clock_unused` call.  The
+  kernel invokes it, in place of :c:func:`sys_clock_set_timeout`, when no
+  timeout is pending and :kconfig:option:`CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE`
+  allows the system uptime to drift.  A driver may use it to halt its counter
+  and stop taking interrupts until the next :c:func:`sys_clock_set_timeout`
+  resumes it.  Unlike :c:func:`sys_clock_disable`, this is a resumable pause,
+  not a teardown.  The default implementation preserves the legacy contract by
+  passing ``K_TICKS_FOREVER`` to :c:func:`sys_clock_set_timeout`, the
+  long-standing "no deadline" signal, so a driver that has not migrated to
+  this hook keeps working, whether it stops its clock on that signal or just
+  programs a maximal wait; the signal is deprecated together with that
+  default.
+
+* The driver may optionally provide a :c:func:`sys_clock_idle_enter` call,
+  which the power-management path uses in place of
+  :c:func:`sys_clock_set_timeout` when the CPU is about to enter low-power
+  idle, passing the number of ticks until the next expected wakeup.  A driver
+  that can hand off to a low-power wakeup timer (or otherwise reconfigure for
+  sleep) does so here; recovery happens in :c:func:`sys_clock_idle_exit`.  The
+  default implementation programs the wakeup through
+  :c:func:`sys_clock_set_timeout` with its deprecated ``idle`` argument set to
+  ``true``, so a driver that still keys its low-power handling on that argument
+  keeps working, and a driver with no low-power handling needs no
+  implementation.
+
 Timer Driver Locking
 --------------------
 

--- a/doc/kernel/services/timing/clocks.rst
+++ b/doc/kernel/services/timing/clocks.rst
@@ -334,6 +334,27 @@ counter driver can be trivially implemented also:
   as no more than one tick can be detected as having elapsed (because
   otherwise an interrupt would have been received).
 
+Generic Tickless Core
+---------------------
+
+The per-driver work described above -- the cycle-to-tick conversion, the
+announce baseline, the tick-aligned deadline computation and the counter wrap
+and range handling -- is nearly identical across tickless drivers, and its
+small hand-rolled divergences are a recurring source of timer bugs.
+:zephyr_file:`drivers/timer/system_timer_generic.h` provides that logic once,
+as an implementation header a driver includes after defining a few cycle-domain
+primitives: a counter read plus either an absolute-compare or a relative-reload
+arming function. The header then emits :c:func:`sys_clock_set_timeout`,
+:c:func:`sys_clock_elapsed` and :c:func:`sys_clock_cycle_get_32` /
+:c:func:`sys_clock_cycle_get_64` on the driver's behalf and owns the announce
+baseline, so the driver stays in the cycle domain and never manipulates ticks
+directly. It states its counter width and, only when the counter does not run
+at the system clock rate, its frequency.
+
+New timer drivers that support tickless operation should build on this header
+rather than reimplement the tick accounting.  The header itself documents the
+exact set of feature macros and primitives a driver provides.
+
 
 SMP Details
 -----------

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -666,6 +666,23 @@ Syscon
 Timer
 =====
 
+* Tickless system-timer drivers should no longer carry their own tick handling.
+  The implementation header :file:`drivers/timer/system_timer_generic.h` now
+  owns the accounting that each driver used to reimplement by hand, and got
+  subtly wrong: the cycle-to-tick conversion, the announce baseline, the
+  tick-aligned deadline computation and the counter range clamp (including the
+  wrap handling of a narrow counter). A driver reduces to a few cycle-domain
+  primitives (a cycle-counter read plus an absolute-compare or relative-reload
+  arm) and includes the header once, which emits
+  :c:func:`sys_clock_set_timeout`, :c:func:`sys_clock_elapsed` and
+  :c:func:`sys_clock_cycle_get_32` / :c:func:`sys_clock_cycle_get_64`. In-tree
+  tickless drivers are being converted to it, one driver at a time;
+  out-of-tree drivers, new or existing, are strongly encouraged to do the same
+  rather than track the kernel interface by hand. A driver built on the core
+  needs no action for the interface changes below, as it no longer defines
+  those entry points itself; those notes apply only to the residual cases
+  where the hardware genuinely cannot be expressed through the core.
+
 * :c:func:`sys_clock_set_timeout`, :c:func:`sys_clock_announce` and
   :c:func:`sys_clock_announce_locked` now take their tick count as an unsigned
   ``uint32_t`` rather than a signed ``int32_t``. Out-of-tree system timer drivers must

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -670,11 +670,30 @@ Timer
   :c:func:`sys_clock_announce_locked` now take their tick count as an unsigned
   ``uint32_t`` rather than a signed ``int32_t``. Out-of-tree system timer drivers must
   update their :c:func:`sys_clock_set_timeout` definition accordingly, otherwise the build
-  fails with a conflicting-types error. The kernel now also caps the requested timeout at
-  ``SYS_CLOCK_MAX_WAIT`` and no longer passes ``K_TICKS_FOREVER`` to the driver, so such
-  drivers no longer need to clamp the request against the :c:func:`sys_clock_announce`
-  range or special-case ``K_TICKS_FOREVER``; only their own hardware cycle-count limits
-  still need enforcing (:github:`111022`).
+  fails with a conflicting-types error. The kernel now also caps a requested wait at
+  ``SYS_CLOCK_MAX_WAIT``, so such drivers no longer need to clamp it against the
+  :c:func:`sys_clock_announce` range; only their own hardware cycle-count limits still
+  need enforcing. ``K_TICKS_FOREVER`` is only ever passed as the sloppy-idle
+  "no deadline" signal described below (:github:`111022`).
+
+* Under ``CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE``, the kernel now calls the new weak
+  :c:func:`sys_clock_unused` hook when no timeout is pending, rather than deciding in
+  :c:func:`sys_clock_set_timeout` itself. The default :c:func:`sys_clock_unused` passes
+  ``K_TICKS_FOREVER`` (``UINT32_MAX`` as the unsigned tick argument) to
+  :c:func:`sys_clock_set_timeout`, the long-standing "no deadline" signal, so an
+  out-of-tree timer driver keying on ``ticks == K_TICKS_FOREVER`` keeps stopping its
+  clock as before, and one without that branch programs a maximal wait, which sloppy
+  idle tolerates by definition. The signal is deprecated: the clock-stop ultimately
+  belongs in a :c:func:`sys_clock_unused` implementation, to which drivers will
+  migrate one at a time (:github:`114342`).
+
+* The ``bool idle`` argument of :c:func:`sys_clock_set_timeout` is deprecated; the
+  low-power idle hint moved to the new weak :c:func:`sys_clock_idle_enter` hook. The
+  kernel now always passes ``false``, except that the default
+  :c:func:`sys_clock_idle_enter` forwards the idle entry as ``true``, so an out-of-tree
+  timer driver keying on the argument keeps working unchanged. Such drivers should move
+  their ``idle``-specific handling to :c:func:`sys_clock_idle_enter`; the argument will
+  be removed in a future release (:github:`114342`).
 
 USB
 ===

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -162,6 +162,17 @@ Deprecated APIs and options
   * Deprecated :kconfig:option:`CONFIG_NET_L2_PTP`.
     Used :kconfig:option:`CONFIG_NET_L2_PTP_TIMESTAMPING` instead.
 
+* Timer
+
+  * The ``bool idle`` argument of :c:func:`sys_clock_set_timeout` is deprecated: the
+    low-power idle hint moved to the new weak :c:func:`sys_clock_idle_enter` hook and the
+    kernel now always passes ``false`` (the default :c:func:`sys_clock_idle_enter`
+    forwards ``true`` for drivers that have not migrated). The ``K_TICKS_FOREVER``
+    "no deadline" clock-stop signal under
+    :kconfig:option:`CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE` is likewise deprecated in favour
+    of the new weak :c:func:`sys_clock_unused` hook, whose default still forwards it
+    for drivers that have not migrated.
+
 * Video
 
   * All functions in the video driver API (``<zephyr/drivers/video.h>``) have moved to the video

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -407,6 +407,17 @@ Other notable changes
     failure.  Use :c:func:`k_thread_cpu_pin` to reassign a thread to a
     different CPU.
 
+* Timer
+
+  * Tickless system-timer drivers can now be built on a shared implementation
+    header, :file:`drivers/timer/system_timer_generic.h`, which owns the tick
+    accounting each driver previously open-coded (and occasionally got wrong):
+    the cycle-to-tick conversion, the announce baseline, the tick-aligned
+    deadline and the counter wrap and range handling. A driver reduces to a few
+    cycle-domain primitives, a cycle-counter read plus an absolute-compare or
+    relative-reload arm. In-tree drivers are being converted one at a time; see
+    the :ref:`migration guide <migration_4.5>` for how to use it.
+
 * Wi-Fi
 
   * Removed the ``samples/net/wifi/test_certs/rsa2k`` enterprise test

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -44,8 +44,9 @@ config SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE
 config SYSTEM_CLOCK_SLOPPY_IDLE
 	bool "Timer allowed to skew uptime clock during idle"
 	help
-	  When true, the timer driver is not required to maintain a
-	  correct system uptime count when the system enters idle.
+	  When true, the kernel may let the system uptime count drift while
+	  there are no pending timeouts, rather than keep waking the CPU to
+	  maintain it.
 	  Some platforms may take advantage of this to reduce the
 	  overhead from regular interrupts required to handle counter
 	  wraparound conditions.

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -269,7 +269,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	 * be ignored, as 32-bits timer will overflow in a not-long time.
 	 */
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
-	    ticks == SYS_CLOCK_MAX_WAIT) {
+	    ticks == (uint32_t)K_TICKS_FOREVER) {
 		timer0_control_register_set(0);
 		timer0_count_register_set(0);
 		timer0_limit_register_set(0);
@@ -300,7 +300,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 #endif
 #else
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
-	    ticks == SYS_CLOCK_MAX_WAIT) {
+	    ticks == (uint32_t)K_TICKS_FOREVER) {
 		timer0_control_register_set(0);
 		timer0_count_register_set(0);
 		timer0_limit_register_set(0);

--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -94,7 +94,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	data->cycle_count += pending_cycles;
 	unannounced_cycles = data->cycle_count - data->announced_cycles;
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == (uint32_t)K_TICKS_FOREVER) {
 		/*
 		 * No pending timeout and no future timer interrupt required:
 		 * wait as long as the hardware allows.

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -325,7 +325,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	 * (sloppy idle), then shut off the counter.
 	 */
 	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
-	    ticks == SYS_CLOCK_MAX_WAIT) {
+	    ticks == (uint32_t)K_TICKS_FOREVER) {
 		SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
 		last_load = TIMER_STOPPED;
 		return;

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -358,7 +358,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint32_t reg;
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == (uint32_t)K_TICKS_FOREVER) {
 		reg = hpet_gconf_get();
 		reg &= ~GCONF_ENABLE;
 		hpet_gconf_set(reg);

--- a/drivers/timer/infineon_lp_timer.c
+++ b/drivers/timer/infineon_lp_timer.c
@@ -76,7 +76,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == (uint32_t)K_TICKS_FOREVER) {
 		key = k_spin_lock(&lock);
 		/* Disable the LPTIMER events */
 		cyhal_lptimer_enable_event(&lptimer_obj, CYHAL_LPTIMER_COMPARE_MATCH,

--- a/drivers/timer/ite_it51xxx_timer.c
+++ b/drivers/timer/ite_it51xxx_timer.c
@@ -210,10 +210,10 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	/* Disable event timer */
 	ext_timer_disable(EVENT_TIMER);
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == (uint32_t)K_TICKS_FOREVER) {
 		/*
 		 * The kernel has no pending timeout, which it signals with
-		 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle no future
+		 * ticks == (uint32_t)K_TICKS_FOREVER. Under sloppy idle no future
 		 * timer interrupt is required, so leave the event timer
 		 * disabled and stop waking up. Without sloppy idle we fall
 		 * through and still schedule the (capped) timeout so the

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -240,10 +240,10 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	/* Disable event timer */
 	IT8XXX2_EXT_CTRLX(EVENT_TIMER) &= ~IT8XXX2_EXT_ETXEN;
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == (uint32_t)K_TICKS_FOREVER) {
 		/*
 		 * The kernel has no pending timeout, which it signals with
-		 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle no future
+		 * ticks == (uint32_t)K_TICKS_FOREVER. Under sloppy idle no future
 		 * timer interrupt is required, so leave the event timer
 		 * disabled and stop waking up. Without sloppy idle we fall
 		 * through to the else and still schedule the (capped) timeout

--- a/drivers/timer/max32_rv32_sys_timer.c
+++ b/drivers/timer/max32_rv32_sys_timer.c
@@ -122,7 +122,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	uint32_t next_cycle;
 	uint32_t count;
 
-	if (ticks == SYS_CLOCK_MAX_WAIT) {
+	if (ticks == (uint32_t)K_TICKS_FOREVER) {
 		next_cycle = (last_tick * CYC_PER_TICK) + CYCLES_MAX;
 	} else if (ticks == 0) {
 		next_cycle = MXC_TMR_GetCount(regs) + (CYC_PER_TICK * 3 / 2);

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -191,7 +191,7 @@ void sys_clock_set_timeout(uint32_t n, bool idle)
 	uint32_t full_cycles;    /* full_ticks represented as cycles */
 	uint32_t partial_cycles; /* number of cycles to first tick boundary */
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && (n == SYS_CLOCK_MAX_WAIT)) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && (n == (uint32_t)K_TICKS_FOREVER)) {
 		/*
 		 * We are not in a locked section. Are writes to two
 		 * global objects safe from pre-emption?

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -70,7 +70,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == (uint32_t)K_TICKS_FOREVER) {
 		LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
 		return;
 	}

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -263,7 +263,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	/* When using a counter for certain low power modes, set this flag when the requested
 	 * delay is forever. This is to keep track of wakeup sources in case of counter overflows.
 	 */
-	wait_forever = (ticks == SYS_CLOCK_MAX_WAIT);
+	wait_forever = (ticks == (uint32_t)K_TICKS_FOREVER);
 #else
 	ARG_UNUSED(idle);
 #endif

--- a/drivers/timer/mcux_rtc_jdp_timer.c
+++ b/drivers/timer/mcux_rtc_jdp_timer.c
@@ -130,7 +130,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	uint32_t cycles;
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == (uint32_t)K_TICKS_FOREVER) {
 		/*
 		 * No pending timeout and no future timer interrupt required:
 		 * wait as long as the hardware allows.

--- a/drivers/timer/mcux_sysctr_timer.c
+++ b/drivers/timer/mcux_sysctr_timer.c
@@ -166,7 +166,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == (uint32_t)K_TICKS_FOREVER) {
 		/*
 		 * No near deadline to schedule: under sloppy idle, disable the
 		 * compare interrupt entirely. sys_clock_idle_exit() will

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -676,7 +676,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == (uint32_t)K_TICKS_FOREVER) {
 		target_time = last_count + MAX_CYCLES;
 		sys_busy = false;
 	} else {

--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -107,7 +107,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	uint32_t full_cycles;
 	uint32_t partial_cycles;
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && (ticks == SYS_CLOCK_MAX_WAIT)) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && (ticks == (uint32_t)K_TICKS_FOREVER)) {
 		RTMR_REG->CTRL = 0U;
 		previous_cnt = RTMR_TIMER_STOPPED;
 		return;

--- a/drivers/timer/renesas_ra_ulpt_timer.c
+++ b/drivers/timer/renesas_ra_ulpt_timer.c
@@ -92,7 +92,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	}
 
 	/* No timeout change when the kernel has no near deadline to schedule. */
-	if (ticks == SYS_CLOCK_MAX_WAIT) {
+	if (ticks == (uint32_t)K_TICKS_FOREVER) {
 		return;
 	}
 

--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -214,7 +214,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	}
 
 	/* Nothing to do when the kernel has no near deadline to schedule. */
-	if (ticks == SYS_CLOCK_MAX_WAIT) {
+	if (ticks == (uint32_t)K_TICKS_FOREVER) {
 		return;
 	}
 

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <limits.h>
-
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/timer/system_timer.h>
@@ -18,27 +16,6 @@
 #define MTIME_REG    DT_INST_REG_ADDR_BY_NAME(0, mtime)
 #define MTIMECMP_REG DT_INST_REG_ADDR_BY_NAME(0, mtimecmp)
 #define TIMER_IRQN   DT_INST_IRQN(0)
-
-#define CYC_PER_TICK (uint32_t)(sys_clock_hw_cycles_per_sec() / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
-
-/* the unsigned long cast limits divisions to native CPU register width */
-#define cycle_diff_t   unsigned long
-#define CYCLE_DIFF_MAX (~(cycle_diff_t)0)
-
-/*
- * Maximum number of cycles to wait between two sys_clock_announce() reports:
- * the elapsed cycle count must fit in a cycle_diff_t before it is divided down
- * to ticks. Reserve 1/4 of the range as headroom for the unavoidable IRQ
- * servicing latency so a late report still fits, then add the LSB so the value
- * clears a run of low set bits for a nicer literal in the generated assembly.
- */
-#define CYCLES_MAX_1 ((uint64_t)CYCLE_DIFF_MAX)
-#define CYCLES_MAX_2 (CYCLES_MAX_1 / 2 + CYCLES_MAX_1 / 4)
-#define CYCLES_MAX   (CYCLES_MAX_2 + LSB_GET(CYCLES_MAX_2))
-
-static uint64_t last_count;
-static uint64_t last_ticks;
-static uint32_t last_elapsed;
 
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = TIMER_IRQN;
@@ -86,62 +63,35 @@ static uint64_t mtime(void)
 #endif
 }
 
+/*
+ * Free-running mtime counter plus an absolute mtimecmp compare: a COMPARE
+ * backend. mtime is 64 bits wide. The generic core owns the tick accounting;
+ * this driver only reads the counter and arms the comparator. The public
+ * cycle counter is the raw mtime scaled by the DT divider, so it overrides
+ * the core's default.
+ */
+#define TIMER_CORE_BACKEND_COMPARE
+#define TIMER_CORE_HAVE_CYCLE_GET_32
+#define TIMER_CORE_HAVE_CYCLE_GET_64
+#define TIMER_CORE_CYCLES_WIDTH 64
+
+static inline uint64_t timer_driver_cycle_get(void)
+{
+	return mtime();
+}
+
+static inline void timer_driver_set_compare(uint64_t cycles)
+{
+	set_mtimecmp(cycles);
+}
+
+#include "system_timer_generic.h"
+
 static void timer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 
-	k_spinlock_key_t key = sys_clock_lock();
-
-	uint64_t now = mtime();
-	uint64_t dcycles = now - last_count;
-	uint32_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
-
-	last_count += (cycle_diff_t)dticks * CYC_PER_TICK;
-	last_ticks += dticks;
-	last_elapsed = 0;
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		uint64_t next = last_count + CYC_PER_TICK;
-
-		set_mtimecmp(next);
-	}
-
-	sys_clock_announce_locked(dticks, key);
-}
-
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
-{
-	ARG_UNUSED(idle);
-
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	uint64_t cyc;
-
-	cyc = (last_ticks + last_elapsed + ticks) * CYC_PER_TICK;
-	if ((cyc - last_count) > CYCLES_MAX) {
-		cyc = last_count + CYCLES_MAX;
-	}
-	set_mtimecmp(cyc);
-}
-
-uint32_t sys_clock_elapsed(void)
-{
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
-
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return 0;
-	}
-
-	uint64_t now = mtime();
-	uint64_t dcycles = now - last_count;
-	uint32_t dticks = (cycle_diff_t)dcycles / CYC_PER_TICK;
-
-	last_elapsed = dticks;
-	return dticks;
+	timer_core_announce();
 }
 
 uint32_t sys_clock_cycle_get_32(void)
@@ -157,9 +107,7 @@ uint64_t sys_clock_cycle_get_64(void)
 static int sys_clock_driver_init(void)
 {
 	IRQ_CONNECT(TIMER_IRQN, 0, timer_isr, NULL, 0);
-	last_ticks = mtime() / CYC_PER_TICK;
-	last_count = last_ticks * CYC_PER_TICK;
-	set_mtimecmp(last_count + CYC_PER_TICK);
+	timer_core_init();
 	irq_enable(TIMER_IRQN);
 	return 0;
 }
@@ -167,7 +115,7 @@ static int sys_clock_driver_init(void)
 #ifdef CONFIG_SMP
 void smp_timer_init(void)
 {
-	set_mtimecmp(last_count + CYC_PER_TICK);
+	timer_core_smp_prime();
 	irq_enable(TIMER_IRQN);
 }
 #endif

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -205,7 +205,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 #else /* !CONFIG_TICKLESS_KERNEL */
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == (uint32_t)K_TICKS_FOREVER) {
 		/* Disable comparator when the kernel has no pending timeout. */
 		rtc_timeout = rtc_counter;
 		return;

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -383,12 +383,12 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	/*
 	 * The kernel has no pending timeout, which it signals with
-	 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle the LPTIM can be
+	 * ticks == (uint32_t)K_TICKS_FOREVER. Under sloppy idle the LPTIM can be
 	 * turned off entirely (never waking up, not clocked anymore).
 	 * Without sloppy idle we fall through and schedule the (capped)
 	 * timeout so the uptime tick count stays correct.
 	 */
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == (uint32_t)K_TICKS_FOREVER) {
 		clock_control_off(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
 		return;
 	}

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -25,3 +25,16 @@ void __weak sys_clock_set_timeout(uint32_t ticks, bool idle)
 void __weak sys_clock_idle_exit(void)
 {
 }
+
+void __weak sys_clock_unused(void)
+{
+	/* Forward the legacy contract: a driver that has not migrated to this
+	 * hook stops its clock when it sees K_TICKS_FOREVER (UINT32_MAX once
+	 * converted to the unsigned tick argument), the long-standing
+	 * "no deadline" signal under CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE. A driver
+	 * without that branch reads it as a maximal wait, which is just as
+	 * good: timekeeping accuracy is already forfeit here, so it does not
+	 * matter when or whether the next announce comes.
+	 */
+	sys_clock_set_timeout((uint32_t)K_TICKS_FOREVER, false);
+}

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -38,3 +38,14 @@ void __weak sys_clock_unused(void)
 	 */
 	sys_clock_set_timeout((uint32_t)K_TICKS_FOREVER, false);
 }
+
+void __weak sys_clock_idle_enter(uint32_t ticks)
+{
+	/* The idle hint used to travel as sys_clock_set_timeout()'s second
+	 * argument. Passing true here keeps a driver that has not migrated to
+	 * this hook behaving exactly as before; the argument is deprecated and
+	 * carries no information for migrated drivers, which learn about idle
+	 * entry by overriding this hook.
+	 */
+	sys_clock_set_timeout(ticks, true);
+}

--- a/drivers/timer/system_timer_generic.h
+++ b/drivers/timer/system_timer_generic.h
@@ -1,0 +1,554 @@
+/*
+ * Copyright (c) 2026 BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Generic tickless system-timer core
+ *
+ * This header carries the tick accounting that every tickless system-timer
+ * driver would otherwise reimplement by hand: the cycle-to-tick conversion, the
+ * announce baseline (last_cycle / last_tick / last_elapsed), the deadline
+ * computation and the range clamp. A driver reduces to a few cycle-domain
+ * primitives; the tick contract the kernel calls (sys_clock_set_timeout(),
+ * sys_clock_elapsed(), sys_clock_cycle_get_32/64()) is emitted here.
+ *
+ * The file is an implementation header, not a normal declaration header: it
+ * *defines* the global sys_clock_* entry points, so it must be included exactly
+ * once, by the one chosen system-timer driver, after that driver has provided
+ * its constants and primitives.
+ *
+ * A driver, before the include, provides:
+ *
+ *   - Exactly one backend feature macro:
+ *       TIMER_CORE_BACKEND_COMPARE  free-running counter plus an absolute compare
+ *                                register (arm_arch, riscv, hpet, ...)
+ *       TIMER_CORE_BACKEND_RELOAD   a counter that fires after a relative delay
+ *                                (down-counters, compare-match-reset periodics).
+ *                                Assumed to auto-reload: on a non-tickless
+ *                                kernel it free-runs from the LOAD set at init
+ *                                and is not reprogrammed per tick.
+ *
+ *   - static inline uint64_t timer_driver_cycle_get(void): the hardware cycle count.
+ *     Its rate is TIMER_CORE_CYCLES_PER_SEC (see the knobs below), by default the kernel
+ *     system clock rate. It may wrap at the counter width declared by
+ *     TIMER_CORE_CYCLES_WIDTH (the core masks deltas to that width), so a narrow
+ *     free-running counter is used as-is, without software extension.
+ *
+ *   - the arming primitive for the chosen backend:
+ *       COMPARE: static inline void timer_driver_set_compare(uint32_t/uint64_t cycles)
+ *                Fire an interrupt when the counter reaches @p cycles, a
+ *                full-width cycle count. The argument width is the driver's: a
+ *                64-bit comparator takes uint64_t; a 32-bit one may take uint32_t
+ *                (or mask a uint64_t argument) to drop the value to its
+ *                comparator width. Must not lose the interrupt for an
+ *                already-past target.
+ *       RELOAD:  static inline void timer_driver_set_reload(uint32_t/uint64_t cycles)
+ *                Fire an interrupt after @p cycles more cycles. The core has
+ *                already clamped @p cycles to [TIMER_CORE_MIN_DELAY,
+ *                TIMER_CORE_CYCLES_MAX]. The argument width is the driver's:
+ *                uint32_t suits a counter whose TIMER_CORE_CYCLES_MAX fits 32
+ *                bits (the usual case); a wider counter may take uint64_t and
+ *                raise TIMER_CORE_CYCLES_MAX to match. The core does not narrow
+ *                the value, so the two must be kept coherent.
+ *
+ * Optional knobs (sensible defaults provided):
+ *
+ *   - TIMER_CORE_CYCLES_PER_SEC: rate, in Hz, of the counter timer_driver_cycle_get() reads,
+ *     from which the core derives the cycles per tick. Defaults to the kernel
+ *     system clock rate; a driver whose counter runs at another rate (prescaled,
+ *     or a fixed frequency) overrides it. With a build-time-constant rate the
+ *     derived cycles-per-tick is a constant (the tick math divides by it on the
+ *     announce path); with a run-time rate
+ *     (CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME) the core precomputes it once
+ *     in timer_core_init(), so that path never divides the rate twice. A driver
+ *     that needs cycles-per-tick as a compile-time constant elsewhere may
+ *     instead define TIMER_CORE_CYC_PER_TICK directly.
+ *   - TIMER_CORE_CYCLES_WIDTH: width, in bits, of the cycle counter (1..64). Defaults to
+ *     64 when TIMER_CORE_64BIT_CYCLES is declared, else to the native register
+ *     width, which suits any counter at least that wide; a narrower counter,
+ *     or a wide counter to be treated as narrower, sets its own value. The
+ *     core masks every delta to this width and never arms a deadline more than
+ *     TIMER_CORE_CYCLES_MAX ahead.
+ *   - TIMER_CORE_CYCLES_MAX: furthest deadline armed ahead of the last announce. Defaults
+ *     to half the counter span (the upper half is IRQ-latency headroom), or a
+ *     quarter span when TIMER_CORE_COUNTER_NONMONOTONIC is set.
+ *   - TIMER_CORE_64BIT_CYCLES: define to also emit sys_clock_cycle_get_64() (and,
+ *     as above, default the counter width to 64).
+ *   - TIMER_CORE_HAVE_CYCLE_GET_32 / _64: define (and provide your own
+ *     sys_clock_cycle_get_32 / _64 before the include) to suppress the core's,
+ *     e.g. when the raw counter needs scaling.
+ *   - TIMER_CORE_CYCLE_GET_NONATOMIC: define when timer_driver_cycle_get() is not a
+ *     single atomic read but a synthesized count (built from a shared software
+ *     accumulator the ISR and reprogram paths also touch). The core then reads
+ *     it under the clock lock in sys_clock_cycle_get_32/64() instead of raw.
+ *   - TIMER_CORE_MIN_DELAY (RELOAD): reload floor, in cycles.
+ *   - TIMER_CORE_COUNTER_NONMONOTONIC: define if the counter may momentarily read
+ *     behind a value already observed (e.g. a global timer under QEMU SMP); the
+ *     core then treats a backwards read as no elapse instead of a huge jump.
+ *
+ * The driver completes with its IRQ handler (a hardware acknowledge, then
+ * timer_core_announce()), its init (connect the IRQ, then timer_core_init()) and,
+ * on SMP, an smp_timer_init() that primes the per-CPU timer via
+ * timer_core_smp_prime().
+ */
+
+#ifndef ZEPHYR_DRIVERS_TIMER_SYSTEM_TIMER_GENERIC_H_
+#define ZEPHYR_DRIVERS_TIMER_SYSTEM_TIMER_GENERIC_H_
+
+#include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/sys/util.h>
+
+#if defined(TIMER_CORE_BACKEND_COMPARE) == defined(TIMER_CORE_BACKEND_RELOAD)
+#error "define exactly one of TIMER_CORE_BACKEND_COMPARE / TIMER_CORE_BACKEND_RELOAD"
+#endif
+
+/*
+ * Cycles per second of the counter that timer_driver_cycle_get() reads. Defaults to
+ * the kernel system clock rate; a driver whose counter runs at another rate (a
+ * prescaled or fixed-frequency source) overrides it.
+ */
+#if !defined(TIMER_CORE_CYCLES_PER_SEC)
+#define TIMER_CORE_CYCLES_PER_SEC sys_clock_hw_cycles_per_sec()
+#endif
+
+/*
+ * Cycles per kernel tick, derived from the rate so a driver normally does not
+ * define it. With a build-time-constant rate the division folds, which matters
+ * because the tick math divides by it on the announce path. When the rate is
+ * only known at run time (CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME) it is
+ * precomputed once in timer_core_init() into a variable, so that path never
+ * divides the rate twice. A driver that needs cycles-per-tick as a compile-time
+ * constant elsewhere (e.g. a preprocessor test) may define it directly instead.
+ */
+#if !defined(TIMER_CORE_CYC_PER_TICK)
+#if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
+static uint32_t timer_core_cyc_per_tick;
+#define TIMER_CORE_CYC_PER_TICK timer_core_cyc_per_tick
+#define TIMER_CORE_PRECOMPUTE_CYC_PER_TICK
+#else
+#define TIMER_CORE_CYC_PER_TICK \
+	((uint32_t)(TIMER_CORE_CYCLES_PER_SEC / CONFIG_SYS_CLOCK_TICKS_PER_SEC))
+/*
+ * The whole tick math divides by this, so a counter rate below the tick rate
+ * (or a mis-set TIMER_CORE_CYCLES_PER_SEC) that rounds it to zero must be caught. When the
+ * default TIMER_CORE_CYCLES_PER_SEC is a build constant, catch it at build time. It is not
+ * a constant with CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE (a runtime
+ * variable that can even change later), so that case, like the runtime-frequency
+ * case above, is checked once in timer_core_init() where the value is known. A
+ * driver that defines its own TIMER_CORE_CYC_PER_TICK owns that check.
+ */
+#if defined(CONFIG_SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE)
+#define TIMER_CORE_CHECK_CYC_PER_TICK_AT_INIT
+#else
+BUILD_ASSERT(TIMER_CORE_CYC_PER_TICK != 0, "timer counter rate is below the tick rate");
+#endif
+#endif
+#endif
+
+/*
+ * Default to the native register width: the masked delta then divides in a
+ * single register, and a counter at least this wide never wraps within the
+ * scheduling range. A narrower counter overrides TIMER_CORE_CYCLES_WIDTH with its width.
+ *
+ * A driver declaring TIMER_CORE_64BIT_CYCLES states its counter is a genuine
+ * 64-bit one, so default its width to 64 no matter the register width: the
+ * native default on a 32-bit CPU would silently mask deltas at 2^32, losing
+ * any span beyond it (e.g. across a long debugger halt or low-power sleep). A
+ * counter narrower than what it is read back as (say a 52-bit counter read as
+ * 64 bits) still overrides this with its true width. The width must never be
+ * forced wider than the counter really is: a 64-bit mask on a 32-bit counter
+ * underflows once the baseline passes 2^32.
+ */
+#if !defined(TIMER_CORE_CYCLES_WIDTH)
+#if defined(TIMER_CORE_64BIT_CYCLES)
+#define TIMER_CORE_CYCLES_WIDTH 64
+#else
+#define TIMER_CORE_CYCLES_WIDTH __LONG_WIDTH__
+#endif
+#endif
+
+/* Wrap mask for the counter. */
+#define TIMER_CORE_CYCLES_MASK (UINT64_MAX >> (64 - TIMER_CORE_CYCLES_WIDTH))
+
+/*
+ * Furthest deadline that may be armed ahead of the last announce.
+ *
+ * Half the span by default: the upper half is headroom so a late announce
+ * (IRQ latency on a maximum-length arm) still yields an in-range delta rather
+ * than wrapping.
+ *
+ * With backwards-read detection (TIMER_CORE_COUNTER_NONMONOTONIC) the upper half
+ * is instead the range that flags a backwards read, so it can no longer double
+ * as latency headroom. Arming then reaches only a quarter span ahead, leaving
+ * the second quarter as the headroom: a late announce of a maximum arm stays
+ * below the half-span backwards threshold, while a genuine backwards read still
+ * lands in the upper half. A driver may override TIMER_CORE_CYCLES_MAX.
+ */
+#ifndef TIMER_CORE_CYCLES_MAX
+#ifdef TIMER_CORE_COUNTER_NONMONOTONIC
+#define TIMER_CORE_CYCLES_MAX (TIMER_CORE_CYCLES_MASK >> 2)
+#else
+#define TIMER_CORE_CYCLES_MAX (TIMER_CORE_CYCLES_MASK >> 1)
+#endif
+#endif
+
+/* Reload floor, in cycles (RELOAD only). A driver whose hardware needs a larger
+ * minimum programmable delay overrides it.
+ */
+#ifndef TIMER_CORE_MIN_DELAY
+#define TIMER_CORE_MIN_DELAY 1
+#endif
+
+/*
+ * Announce baseline, private to this translation unit.
+ *
+ * last_cycle is the cycle count of the most recent announce, held tick-aligned
+ * (an exact multiple of TIMER_CORE_CYC_PER_TICK above the init baseline). Its low
+ * TIMER_CORE_CYCLES_WIDTH bits track the hardware counter, so masking a delta against it is
+ * wrap-correct even for a counter narrower than 64 bits. last_elapsed is the
+ * tick count most recently reported to the kernel via sys_clock_elapsed().
+ */
+static uint64_t timer_core_last_cycle;
+static uint64_t timer_core_last_tick;
+static uint32_t timer_core_last_elapsed;
+
+#if defined(TIMER_CORE_BACKEND_RELOAD)
+/* A catch-up reload (floored at TIMER_CORE_MIN_DELAY because the deadline is
+ * already due, or because the un-announced span is about to overrun
+ * TIMER_CORE_CYCLES_MAX) is in flight. Programming a reload restarts the
+ * counter, so a stream of set_timeout() calls arriving faster than the floor
+ * would rewrite the reload before it can expire and postpone the announce
+ * indefinitely; while this is set, timer_core_arm() leaves the hardware alone
+ * so the pending fire gets through. Cleared by the announce.
+ */
+static bool timer_core_catchup;
+#endif
+
+/* Tick-aligned deadline currently armed in the hardware, or UINT64_MAX when
+ * nothing is known to be armed (initially, and after each announce, which
+ * consumes the programmed deadline). timer_core_arm() programs the hardware
+ * only when the deadline actually moves: the kernel re-evaluates its earliest
+ * timeout on every add and abort (a timeslice reset is one of each), so
+ * back-to-back calls usually land on the same tick boundary, and rewriting
+ * the timer for those is pure churn. For a RELOAD backend the rewrite is
+ * worse than churn: it restarts the counter, so a sustained stream of
+ * rewrites (e.g. timeslice resets from a syscall-heavy thread) keeps any
+ * period from ever completing and postpones the announce for the duration of
+ * the stream.
+ */
+static uint64_t timer_core_armed_deadline = UINT64_MAX;
+
+/* Whole ticks elapsed since the last announce, from the current counter. */
+static inline uint32_t timer_core_delta_ticks(void)
+{
+	uint64_t delta =
+		(timer_driver_cycle_get() - timer_core_last_cycle) & TIMER_CORE_CYCLES_MASK;
+
+#ifdef TIMER_CORE_COUNTER_NONMONOTONIC
+	/*
+	 * A counter that can momentarily read behind a value already observed
+	 * (e.g. a global timer seen from another CPU under QEMU SMP) produces a
+	 * near-full-span masked delta. Arming is capped at TIMER_CORE_CYCLES_MAX (a quarter
+	 * span here), so a legitimate delta, even a late one, stays in the lower
+	 * half; a delta in the upper half is therefore a backwards read and is
+	 * reported as no elapse rather than a spurious huge jump.
+	 */
+	if (delta > (TIMER_CORE_CYCLES_MASK >> 1)) {
+		return 0;
+	}
+#endif
+
+#if TIMER_CORE_CYCLES_WIDTH <= 32
+	/* The masked delta fits in a 32-bit register: divide cheaply. */
+	return (uint32_t)delta / TIMER_CORE_CYC_PER_TICK;
+#else
+	return delta / TIMER_CORE_CYC_PER_TICK;
+#endif
+}
+
+/* Program the timer for a tick-aligned deadline `ticks` out from the last
+ * reported elapsed. Called with the system clock lock held.
+ */
+static void timer_core_arm(uint32_t ticks)
+{
+	uint64_t deadline_tick = timer_core_last_tick + timer_core_last_elapsed + ticks;
+
+	if (deadline_tick == timer_core_armed_deadline) {
+		return;
+	}
+	timer_core_armed_deadline = deadline_tick;
+
+#if defined(TIMER_CORE_BACKEND_COMPARE)
+	/*
+	 * Absolute, tick-aligned deadline. last_cycle is linear (its low
+	 * TIMER_CORE_CYCLES_WIDTH bits track the counter), and a narrow-register driver
+	 * truncates the value to its comparator width when it writes it, so a
+	 * linear deadline is correct for both wide and narrow counters.
+	 */
+	uint64_t deadline = deadline_tick * TIMER_CORE_CYC_PER_TICK;
+
+	if ((deadline - timer_core_last_cycle) > TIMER_CORE_CYCLES_MAX) {
+		deadline = timer_core_last_cycle + TIMER_CORE_CYCLES_MAX;
+	}
+	timer_driver_set_compare(deadline);
+#else /* TIMER_CORE_BACKEND_RELOAD */
+	/*
+	 * Relative reload: the cycles from the last announce to the tick-aligned
+	 * deadline, minus what has already elapsed since then. Both terms are in
+	 * the counter's cycle domain (the elapsed part masked to TIMER_CORE_CYCLES_WIDTH),
+	 * so this stays correct across a counter wrap, and a starved ISR (elapsed
+	 * past the deadline) yields a non-positive value pulled up to the floor.
+	 */
+	uint64_t want = ((uint64_t)timer_core_last_elapsed + ticks) * TIMER_CORE_CYC_PER_TICK;
+	uint64_t done = (timer_driver_cycle_get() - timer_core_last_cycle) & TIMER_CORE_CYCLES_MASK;
+	int64_t rel = (int64_t)(want - done);
+
+	/*
+	 * Clamp against the budget left before the baseline would be TIMER_CORE_CYCLES_MAX
+	 * behind, not against TIMER_CORE_CYCLES_MAX alone. Re-arming restarts the counter, so
+	 * without accounting `done` a stream of set_timeout() calls with no
+	 * intervening announce would push the fire point out indefinitely and let
+	 * `done` grow past TIMER_CORE_CYCLES_MASK, wrapping the masked delta and silently
+	 * losing the elapsed span. Once `done` reaches TIMER_CORE_CYCLES_MAX the budget goes
+	 * non-positive and the MIN_DELAY floor forces a near-immediate fire, hence
+	 * an announce that resets the baseline. This keeps the same invariant the
+	 * COMPARE path gets from clamping its absolute deadline.
+	 */
+	if (rel > (int64_t)TIMER_CORE_CYCLES_MAX - (int64_t)done) {
+		rel = (int64_t)TIMER_CORE_CYCLES_MAX - (int64_t)done;
+	}
+	if (rel < (int64_t)TIMER_CORE_MIN_DELAY) {
+		/*
+		 * The announce is due (or overdue): fire as soon as the floor
+		 * allows. If a floored reload is already in flight, leave it
+		 * to expire rather than restart the counter, or a set_timeout()
+		 * stream arriving faster than the floor (e.g. timeslice resets
+		 * from a syscall-heavy thread) would push the fire point out
+		 * forever and freeze announced time for the storm's duration.
+		 * No incoming deadline can need to fire sooner than the floor
+		 * anyway.
+		 */
+		if (timer_core_catchup) {
+			return;
+		}
+		timer_core_catchup = true;
+		rel = TIMER_CORE_MIN_DELAY;
+	}
+	timer_driver_set_reload((uint64_t)rel);
+#endif
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	/* Deprecated; the idle-entry hint travels via sys_clock_idle_enter(). */
+	ARG_UNUSED(idle);
+
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+	timer_core_arm(ticks);
+}
+
+uint32_t sys_clock_elapsed(void)
+{
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return 0;
+	}
+
+	timer_core_last_elapsed = timer_core_delta_ticks();
+	return timer_core_last_elapsed;
+}
+
+/* Account the whole ticks elapsed since the last announce, rearm (tickful only;
+ * tickless rearms from the kernel's reprogram after the announce) and announce,
+ * with the clock lock already held. @p key is the key returned by the driver's
+ * sys_clock_lock() and is consumed here. Use this when the driver must do work
+ * that has to be atomic with the announce (e.g. committing a wrap into its cycle
+ * counter) before handing off.
+ */
+static void timer_core_announce_from(k_spinlock_key_t key)
+{
+	uint32_t dticks = timer_core_delta_ticks();
+
+	timer_core_last_cycle += (uint64_t)dticks * TIMER_CORE_CYC_PER_TICK;
+	timer_core_last_tick += dticks;
+	timer_core_last_elapsed = 0;
+	/* The programmed deadline is consumed (or obsolete): the kernel decides
+	 * the next one after the announce, and it must reach the hardware even
+	 * if it lands on the same tick.
+	 */
+	timer_core_armed_deadline = UINT64_MAX;
+#if defined(TIMER_CORE_BACKEND_RELOAD)
+	timer_core_catchup = false;
+#endif
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+#if defined(TIMER_CORE_BACKEND_COMPARE)
+		/* Re-arm the comparator one tick out. A RELOAD counter reloads
+		 * itself from the LOAD set at init, so it needs nothing here.
+		 */
+		timer_core_arm(1);
+#endif
+	}
+
+	sys_clock_announce_locked(dticks, key);
+}
+
+/* Read the counter, account the whole ticks elapsed since the last announce,
+ * rearm and announce. The driver ISR body reduces to a hardware acknowledge
+ * followed by this call. inline so a driver that instead uses
+ * timer_core_announce_from() directly does not trip -Wunused-function.
+ */
+static inline void timer_core_announce(void)
+{
+	timer_core_announce_from(sys_clock_lock());
+}
+
+/*
+ * Full-width cycle count reconstructed from the announce baseline (which carries
+ * the extended upper bits) plus the masked forward delta, taken under the clock
+ * lock. The lock is needed when either the read cannot be trusted atomically:
+ *
+ *   - timer_driver_cycle_get() is a synthesized count, not a single register read
+ *     (TIMER_CORE_CYCLE_GET_NONATOMIC): the lock serialises it against the ISR and
+ *     reprogram paths that update the same software state; or
+ *   - the full 64-bit baseline is read on a narrower counter (the getter below
+ *     needs all 64 bits, which is not a single load on a 32-bit CPU).
+ *
+ * A narrow counter feeding only the 32-bit getter does NOT need this: that path
+ * reconstructs from the baseline's low word, a single atomic load, so it stays
+ * lock-free (see sys_clock_cycle_get_32()). Keeping the lock out of the 32-bit
+ * getter matters because it is on the thread-usage timestamp hot path.
+ */
+#if defined(TIMER_CORE_CYCLE_GET_NONATOMIC) || \
+	(defined(TIMER_CORE_64BIT_CYCLES) && TIMER_CORE_CYCLES_WIDTH < 64)
+static inline uint64_t timer_core_cycle_extend_locked(void)
+{
+	k_spinlock_key_t key = sys_clock_lock();
+	uint64_t delta =
+		(timer_driver_cycle_get() - timer_core_last_cycle) & TIMER_CORE_CYCLES_MASK;
+	uint64_t ret = timer_core_last_cycle + delta;
+
+	sys_clock_unlock(key);
+	return ret;
+}
+#endif
+
+#if !defined(TIMER_CORE_HAVE_CYCLE_GET_32)
+uint32_t sys_clock_cycle_get_32(void)
+{
+#if defined(TIMER_CORE_CYCLE_GET_NONATOMIC)
+	/* Synthesized read: serialise the get and baseline under the lock. */
+	return (uint32_t)timer_core_cycle_extend_locked();
+#elif TIMER_CORE_CYCLES_WIDTH < 32
+	/* Narrow atomic counter: extend from the baseline's low word. Both reads
+	 * are single loads, and pairing one baseline read with one counter read
+	 * yields the true position regardless of an announce in between, so this
+	 * needs no lock.
+	 */
+	uint32_t base = (uint32_t)timer_core_last_cycle;
+	uint32_t delta = ((uint32_t)timer_driver_cycle_get() - base) &
+			 (uint32_t)TIMER_CORE_CYCLES_MASK;
+
+	return base + delta;
+#else
+	return (uint32_t)timer_driver_cycle_get();
+#endif
+}
+#endif
+
+#if defined(TIMER_CORE_64BIT_CYCLES) && !defined(TIMER_CORE_HAVE_CYCLE_GET_64)
+uint64_t sys_clock_cycle_get_64(void)
+{
+#if defined(TIMER_CORE_CYCLE_GET_NONATOMIC) || TIMER_CORE_CYCLES_WIDTH < 64
+	return timer_core_cycle_extend_locked();
+#else
+	return timer_driver_cycle_get();
+#endif
+}
+#endif
+
+/* Rescale the announce baseline from one cycle rate to another. A driver that
+ * changes the timer frequency at runtime calls this (after rescaling its own
+ * cycle counter) so the tick accounting stays continuous, without touching the
+ * core's private baseline directly. last_tick is a tick count and so is
+ * frequency-independent; only the cycle-domain baseline scales.
+ */
+static inline void timer_core_rescale(uint32_t to_hz, uint32_t from_hz)
+{
+	ARG_UNUSED(from_hz);
+#ifdef TIMER_CORE_PRECOMPUTE_CYC_PER_TICK
+	/* The rate just changed, so the precomputed cycles-per-tick is stale. */
+	timer_core_cyc_per_tick = to_hz / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+#else
+	ARG_UNUSED(to_hz);
+#endif
+	/*
+	 * Re-express the announce baseline in the new cycle domain. Deriving it
+	 * from last_tick (a frequency-independent tick count) keeps it an exact
+	 * multiple of TIMER_CORE_CYC_PER_TICK, the invariant the arm and announce paths rely
+	 * on. Scaling the old cycle value directly would leave it a fraction of a
+	 * tick off and, on the COMPARE arm, could make (deadline - last_cycle)
+	 * underflow. The caller has already rescaled its own cycle counter.
+	 */
+	timer_core_last_cycle = timer_core_last_tick * (uint64_t)TIMER_CORE_CYC_PER_TICK;
+}
+
+/* Prime the calling CPU's timer one tick ahead of the shared baseline. An SMP
+ * driver calls this from smp_timer_init() so it need not touch the core's
+ * private baseline.
+ */
+static inline void timer_core_smp_prime(void)
+{
+#if defined(TIMER_CORE_BACKEND_COMPARE)
+	timer_driver_set_compare(timer_core_last_cycle + TIMER_CORE_CYC_PER_TICK);
+#else
+	timer_driver_set_reload(TIMER_CORE_CYC_PER_TICK);
+#endif
+}
+
+/* Seed the announce baseline from the current counter and arm the first tick.
+ * The driver calls this from its init after connecting the IRQ (and, for a
+ * runtime frequency, after setting TIMER_CORE_CYC_PER_TICK).
+ */
+static inline void timer_core_init(void)
+{
+#ifdef TIMER_CORE_PRECOMPUTE_CYC_PER_TICK
+	/* Rate is known only now (the driver has brought the counter up), so
+	 * fix the cycles-per-tick the tick math will divide by.
+	 */
+	timer_core_cyc_per_tick = TIMER_CORE_CYCLES_PER_SEC / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+#endif
+#if defined(TIMER_CORE_PRECOMPUTE_CYC_PER_TICK) || defined(TIMER_CORE_CHECK_CYC_PER_TICK_AT_INIT)
+	/* Runtime-rate cases: TIMER_CORE_CYC_PER_TICK is not a constant expression, so the
+	 * non-zero check the constant case gets at build time happens here instead.
+	 */
+	__ASSERT(TIMER_CORE_CYC_PER_TICK != 0, "timer counter rate is below the tick rate");
+#endif
+	timer_core_last_tick = timer_driver_cycle_get() / TIMER_CORE_CYC_PER_TICK;
+	timer_core_last_cycle = timer_core_last_tick * TIMER_CORE_CYC_PER_TICK;
+	timer_core_last_elapsed = 0;
+
+#if defined(TIMER_CORE_BACKEND_RELOAD)
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/* A tickful RELOAD driver configures its hardware to auto-reload one
+		 * tick and is never reprogrammed (see timer_core_announce_from()), so the
+		 * driver owns the period. Arming here would instead program it to the
+		 * sub-tick remainder left after seeding the baseline, and that short
+		 * value would stick as the permanent period.
+		 */
+		return;
+	}
+#endif
+	timer_core_arm(1);
+}
+
+#endif /* ZEPHYR_DRIVERS_TIMER_SYSTEM_TIMER_GENERIC_H_ */

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -253,6 +253,25 @@ uint32_t sys_clock_elapsed(void);
 void sys_clock_disable(void);
 
 /**
+ * @brief Notify the timer driver that the system clock is currently unused.
+ *
+ * Called by the kernel when no timeout is pending and
+ * @kconfig{CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE} allows the system uptime to drift.
+ * A driver may use this to halt the counter and stop generating interrupts
+ * until the next sys_clock_set_timeout(), which resumes normal operation.
+ *
+ * Unlike sys_clock_disable(), this is a resumable pause, not a teardown. The
+ * default implementation preserves the legacy contract by calling
+ * sys_clock_set_timeout() with K_TICKS_FOREVER (UINT32_MAX once converted to
+ * the unsigned tick argument), the long-standing "no deadline" signal a
+ * driver that has not migrated to this hook either recognises and stops its
+ * clock on, or treats as a maximal wait, which is equally acceptable once
+ * timekeeping accuracy has been given up. That signal is deprecated together
+ * with the default, and a driver overriding this hook must not rely on it.
+ */
+void sys_clock_unused(void);
+
+/**
  * @brief Hardware cycle counter
  *
  * Timer drivers are generally responsible for the system cycle

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -272,6 +272,23 @@ void sys_clock_disable(void);
 void sys_clock_unused(void);
 
 /**
+ * @brief Notify the timer driver that the CPU is entering low-power idle.
+ *
+ * Called by the power-management / idle path when the CPU is about to be put
+ * to sleep, with @p ticks until the next expected wakeup. A driver that can
+ * hand off to a low-power wakeup timer (or otherwise reconfigure for sleep)
+ * does so here. The default implementation programs the wakeup through
+ * sys_clock_set_timeout() with its deprecated idle argument set to true, so a
+ * driver that has not migrated to this hook (and still keys its low-power
+ * handling on that argument) behaves exactly as before, and a driver with no
+ * low-power handling needs no implementation. Recovery happens in
+ * sys_clock_idle_exit().
+ *
+ * @param ticks Ticks until the next expected wakeup.
+ */
+void sys_clock_idle_enter(uint32_t ticks);
+
+/**
  * @brief Hardware cycle counter
  *
  * Timer drivers are generally responsible for the system cycle

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -174,8 +174,12 @@ bool sys_clock_is_locked(void);
  * lock held.
  *
  * @param ticks Timeout in tick units
- * @param idle Hint to the driver that the system is about to enter
- *        the idle state immediately after setting the timeout
+ * @param idle Deprecated. The kernel always passes false: the idle-entry
+ *        hint this argument used to carry moved to sys_clock_idle_enter(),
+ *        whose default implementation calls this function with true so a
+ *        driver still keying on the argument keeps working. Retained for
+ *        source compatibility and scheduled for removal in a future
+ *        release; new code must ignore it.
  */
 void sys_clock_set_timeout(uint32_t ticks, bool idle);
 

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -138,35 +138,37 @@ static uint32_t next_timeout(uint32_t ticks_elapsed)
 	}
 
 	/*
-	 * With nothing pending under sloppy idle, report SYS_CLOCK_MAX_WAIT
-	 * verbatim (not the budget): it is the "no deadline" value a driver
-	 * looks for to stop the clock entirely, and a skewed uptime is
-	 * acceptable. Without sloppy idle the uptime must stay correct, so
-	 * respect the budget and keep waking up.
+	 * No deadline, or one further out than can be scheduled in a single
+	 * step: wait the capped budget and re-evaluate at the next announce.
+	 * Testing next (which may be 64-bit) against the cap keeps the
+	 * remaining arithmetic in 32 bits. The empty case still returns the
+	 * budget so a driver keeps waking to maintain uptime.
 	 */
-	if (next == K_TICKS_FOREVER) {
-		if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE)) {
-			return SYS_CLOCK_MAX_WAIT;
-		}
+	if (next == K_TICKS_FOREVER || next >= SYS_CLOCK_MAX_WAIT) {
 		return SYS_CLOCK_MAX_WAIT - ticks_elapsed;
-	}
-
-	/*
-	 * A timeout further out than can be scheduled in one step: wait nearly
-	 * the whole budget, but stop one short of SYS_CLOCK_MAX_WAIT so it is
-	 * never mistaken for the "no deadline" value above (which would drop
-	 * the timeout under sloppy idle); an intermediate announce re-evaluates.
-	 * Testing next (which may be 64-bit) against the cap also keeps the
-	 * remaining arithmetic in 32 bits.
-	 */
-	if (next >= SYS_CLOCK_MAX_WAIT) {
-		return SYS_CLOCK_MAX_WAIT - 1 - ticks_elapsed;
 	}
 
 	/* Otherwise wait until the timeout, relative to now (0 if due). */
 	dticks = (uint32_t)next;
 
 	return (dticks > ticks_elapsed) ? (dticks - ticks_elapsed) : 0;
+}
+
+/*
+ * Reprogram the timer for the next pending timeout, or, when nothing is
+ * pending and CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE tolerates a drifting uptime, tell
+ * the driver its clock is unused so it may stop. Only meaningful where the
+ * timeout queue may have just drained (abort, end of announce); the add path
+ * always has a pending timeout and calls sys_clock_set_timeout() directly.
+ */
+static void reprogram_next(uint32_t ticks_elapsed)
+{
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
+	    z_timeout_q_next_expiry() == K_TICKS_FOREVER) {
+		sys_clock_unused();
+	} else {
+		sys_clock_set_timeout(next_timeout(ticks_elapsed), false);
+	}
 }
 
 k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t timeout)
@@ -242,7 +244,7 @@ int z_try_abort_timeout(struct _timeout *to)
 
 			ret = 0;
 			if (was_first) {
-				sys_clock_set_timeout(next_timeout(elapsed()), false);
+				reprogram_next(elapsed());
 			}
 		} else if (IS_ENABLED(CONFIG_SMP) && inflight_ptr() == to &&
 			   !this_cpu_announcing()) {
@@ -396,7 +398,7 @@ void sys_clock_announce_locked(uint32_t ticks, k_spinlock_key_t key)
 
 	announcing_cpu = -1;
 
-	sys_clock_set_timeout(next_timeout(0), false);
+	reprogram_next(0);
 
 	k_spin_unlock(&timeout_lock, key);
 

--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -216,7 +216,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		{
 			k_spinlock_key_t key = sys_clock_lock();
 
-			sys_clock_set_timeout(0, true);
+			sys_clock_idle_enter(0);
 			sys_clock_unlock(key);
 		}
 
@@ -237,7 +237,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 				{
 					k_spinlock_key_t key = sys_clock_lock();
 
-					sys_clock_set_timeout(0, true);
+					sys_clock_idle_enter(0);
 					sys_clock_unlock(key);
 				}
 				/* GDET got enabled when exiting PM3, disable it

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -212,7 +212,7 @@ bool pm_system_suspend(int32_t kernel_ticks)
 		 */
 		k_spinlock_key_t key = sys_clock_lock();
 
-		sys_clock_set_timeout(MAX(0, (int64_t)ticks - (int64_t)exit_latency_ticks), true);
+		sys_clock_idle_enter(MAX(0, (int64_t)ticks - (int64_t)exit_latency_ticks));
 		sys_clock_unlock(key);
 	}
 


### PR DESCRIPTION
Every tickless system-timer driver reimplements the same tick accounting by hand: the cycle-to-tick conversion, the announce baseline, the tick-aligned deadline computation and the counter wrap and range handling. The small divergences between those hand-rolled copies are a recurring source of timer bugs. This PR introduces `drivers/timer/system_timer_generic.h`, an implementation header that owns this logic once so a driver reduces to a few cycle-domain primitives: read the counter, arm the comparator or reload, acknowledge the interrupt.

This is the reworked resubmission of the core infrastructure from #112959, which was reverted in #114308 over its `sys_clock_set_timeout()` signature change. This time the driver-facing API stays fully intact: an out-of-tree driver compiles and behaves exactly as before, including the `bool idle` argument and the `K_TICKS_FOREVER` sloppy-idle contract. The header also incorporates everything learned from the first round's fallout: the equality-comparator catch-up handling, redundant-rearm suppression, the catch-up reload latch, and 64-bit counter width defaulting.

Getting there requires two cleanups along the way, each giving a special situation currently signalled through `sys_clock_set_timeout()` its own explicit interface, with a weak default preserving the legacy behaviour for drivers that have not migrated:

- `sys_clock_unused()`: called when no timeout is pending and `CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE` allows uptime to drift, so a driver may stop its clock. The default forwards `K_TICKS_FOREVER`, the signal drivers have keyed on for most of this interface's history; the in-tree drivers whose check had recently drifted to an exact `SYS_CLOCK_MAX_WAIT` comparison are switched back, as that value is a legitimate wait and was standing in the way.
- `sys_clock_idle_enter(ticks)`: called by the PM idle path in place of `sys_clock_set_timeout(ticks, true)`. The default forwards exactly that call, so a driver keying its low-power handoff on the `idle` argument behaves as before.

With both hooks in place, the `idle` argument and the `K_TICKS_FOREVER` signal no longer serve the kernel and are formally deprecated (documentation, migration guide and release notes entries included); they keep working through the defaults until removal after the usual deprecation period.

A single conversion (riscv_machine) closes the series, included for two reasons: it shows what a converted driver looks like in practice, and it is a simple conversion whose equivalence with the previous code is easily verifiable, the driver reducing to a counter read and a comparator write around the same arithmetic the core now owns. The remaining conversions deliberately stay out of this PR and will follow as separate per-driver PRs so the respective driver maintainers can review them individually. Every commit builds and passes tests on its own; validated across converted and unconverted platforms, including the sloppy-idle stop behaviour, on qemu_riscv32/64, qemu_cortex_m3, mps2/an385, qemu_malta, qemu_or1k, nrf52840dk and others.