### PR TITLE
boards: arduino: nano_33_ble: fix board initialization

### DIFF
--- a/boards/arduino/nano_33_ble/Kconfig
+++ b/boards/arduino/nano_33_ble/Kconfig
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ARDUINO_NANO_33_BLE
-	select BOARD_LATE_INIT_HOOK
+	select BOARD_EARLY_INIT_HOOK

--- a/boards/arduino/nano_33_ble/board.c
+++ b/boards/arduino/nano_33_ble/board.c
@@ -1,31 +1,56 @@
 /*
  * Copyright (c) 2020 Jefferson Lee.
+ * Copyright (c) 2026 The Zephyr Project Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
+#include <hal/nrf_gpio.h>
 
-void board_late_init_hook(void)
+/*
+ * enable internal I2C pull-up and user led
+ *
+ * The associated GPIOs pins are defined in the board's devicetree by
+ * the node "zephyr,user" and alias "led4".
+ *
+ * The original board.c used SYS_INIT() and the Zephyr's GPIO driver to
+ * configure the pins to GPIO_OUTPUT_HIGH.
+ *
+ * We need to guarantee that the I2C pull-ups are enabled before any I2C
+ * sensor drivers. This implies a board early init hook.
+ * As such, we must use the nordic's nrfx HAL to configure the pins.
+ *
+ * The information needed is retrieved from the devicetree, to keep the
+ * spirit of the former board init code and avoid information duplication.
+ *
+ */
+
+/* helper to retrieve the GPIO port number given a node gpios property */
+#define DT_GPIO_PORT(node, gpios) DT_PROP(DT_GPIO_CTLR(node, gpios), port)
+
+/*  internal pull-up -> node:zephyr,user prop:pull-up-gpios */
+#define PULLUP_NODE      DT_PATH(zephyr_user)
+#define PULLUP_GPIO_PORT DT_GPIO_PORT(PULLUP_NODE, pull_up_gpios)
+#define PULLUP_GPIO_PIN  DT_GPIO_PIN(PULLUP_NODE, pull_up_gpios)
+
+/* user led -> alias:led4  prop: gpios */
+#define USERLED_NODE      DT_ALIAS(led4)
+#define USERLED_GPIO_PORT DT_GPIO_PORT(USERLED_NODE, gpios)
+#define USERLED_GPIO_PIN  DT_GPIO_PIN(USERLED_NODE, gpios)
+
+/* maps DT port/pin to absolute pin number as needed by nrfx HAL */
+#define PULLUP_NRF_PIN  NRF_GPIO_PIN_MAP(PULLUP_GPIO_PORT, PULLUP_GPIO_PIN)
+#define USERLED_NRF_PIN NRF_GPIO_PIN_MAP(USERLED_GPIO_PORT, USERLED_GPIO_PIN)
+
+void board_early_init_hook(void)
 {
+	/* set pin high in the output latch first to prevent initial low glitch */
+	nrf_gpio_pin_set(PULLUP_NRF_PIN);
+	nrf_gpio_pin_set(USERLED_NRF_PIN);
 
-	static const struct gpio_dt_spec pull_up =
-		GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), pull_up_gpios);
-	static const struct gpio_dt_spec user_led =
-		GPIO_DT_SPEC_GET(DT_ALIAS(led4), gpios);
-
-	if (!gpio_is_ready_dt(&pull_up)) {
-		return;
-	}
-
-	if (!gpio_is_ready_dt(&user_led)) {
-		return;
-	}
-
-	if (gpio_pin_configure_dt(&pull_up, GPIO_OUTPUT_HIGH)) {
-		return;
-	}
-
-	(void)gpio_pin_configure_dt(&user_led, GPIO_OUTPUT_HIGH);
+	/* configure GPIO pins as output (high) */
+	nrf_gpio_cfg_output(PULLUP_NRF_PIN);
+	nrf_gpio_cfg_output(USERLED_NRF_PIN);
 }


### PR DESCRIPTION
The board init was moved from SYS_INIT to BOARD_LATE_INIT_HOOK, which runs after all POST_KERNEL device init so the GPIO driver is available.

Doing so however cause the I2C sensor drivers init to fail, as the board init is responsible to enable the I2C pull-ups, which must happen before any I2C transfer.

This PR moves the board init hooks to BOARD_EARLY_INIT_HOOK, while retaining the spirit of the original board init code.

fixes: #113955 