### PR TITLE
ci: twister: increase number of runners to 30

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -38,7 +38,7 @@ jobs:
       testplan: ${{ steps.test-plan.outputs.has_testplan }}
     env:
       MATRIX_SIZE: 10
-      PUSH_MATRIX_SIZE: 25
+      PUSH_MATRIX_SIZE: 30
       WEEKLY_MATRIX_SIZE: 200
       TESTS_PER_BUILDER: 900
       BASE_REF: ${{ github.base_ref }}


### PR DESCRIPTION
As we move clang into the main twister workflow, we need some more
runners to handle the increase in number of tests.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
