### PR TITLE
drivers: sensor: sensirion: add SCD30 CO2 sensor driver

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -306,6 +306,10 @@ New Drivers
   * Diodes/Pericom PI4IOE5V6408 8-bit I2C-bus I/O expander
     (:dtcompatible:`diodes,pi4ioe5v6408`).
 
+* Sensors
+
+  * Sensirion SCD30 CO2 sensor (:dtcompatible:`sensirion,scd30`).
+
 * Input
 
   * VIRTIO input device (:dtcompatible:`virtio,input`).

--- a/drivers/sensor/sensirion/CMakeLists.txt
+++ b/drivers/sensor/sensirion/CMakeLists.txt
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # zephyr-keep-sorted-start
+add_subdirectory_ifdef(CONFIG_SCD30 scd30)
 add_subdirectory_ifdef(CONFIG_SCD4X scd4x)
 add_subdirectory_ifdef(CONFIG_SGP40 sgp40)
 add_subdirectory_ifdef(CONFIG_SHT3XD sht3xd)

--- a/drivers/sensor/sensirion/Kconfig
+++ b/drivers/sensor/sensirion/Kconfig
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # zephyr-keep-sorted-start
+source "drivers/sensor/sensirion/scd30/Kconfig"
 source "drivers/sensor/sensirion/scd4x/Kconfig"
 source "drivers/sensor/sensirion/sgp40/Kconfig"
 source "drivers/sensor/sensirion/sht3xd/Kconfig"

--- a/drivers/sensor/sensirion/scd30/CMakeLists.txt
+++ b/drivers/sensor/sensirion/scd30/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 RAKwireless Technology Limited
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(scd30.c)

--- a/drivers/sensor/sensirion/scd30/Kconfig
+++ b/drivers/sensor/sensirion/scd30/Kconfig
@@ -1,0 +1,16 @@
+# SCD30 CO2 sensor configuration options
+
+# Copyright (c) 2026 RAKwireless Technology Limited
+# SPDX-License-Identifier: Apache-2.0
+
+config SCD30
+	bool "Sensirion SCD30 CO2 Sensor"
+	default y
+	depends on DT_HAS_SENSIRION_SCD30_ENABLED
+	select I2C
+	select CRC
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_SENSIRION_SCD30),ready-gpios)
+	help
+	  Enable driver for the Sensirion SCD30 carbon dioxide sensor.
+	  Optional ready-gpios uses GPIO for data-ready; otherwise I2C
+	  get-data-ready polling is used.

--- a/drivers/sensor/sensirion/scd30/scd30.c
+++ b/drivers/sensor/sensirion/scd30/scd30.c
@@ -1,0 +1,575 @@
+/*
+ * Copyright (c) 2026 RAKwireless Technology Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT sensirion_scd30
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/scd30.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/crc.h>
+#include <string.h>
+
+#include "scd30.h"
+
+LOG_MODULE_REGISTER(SCD30, CONFIG_SENSOR_LOG_LEVEL);
+
+static uint8_t scd30_crc(const uint8_t *data, size_t len)
+{
+	return crc8(data, len, SCD30_CRC_POLY, SCD30_CRC_INIT, false);
+}
+
+static int scd30_write_cmd(const struct device *dev, uint16_t cmd)
+{
+	const struct scd30_config *cfg = dev->config;
+	uint8_t buf[2];
+	int ret;
+
+	sys_put_be16(cmd, buf);
+	ret = i2c_write_dt(&cfg->bus, buf, sizeof(buf));
+	if (ret < 0) {
+		return ret;
+	}
+
+	k_msleep(SCD30_CMD_DELAY_MS);
+	return 0;
+}
+
+static int scd30_write_cmd_arg(const struct device *dev, uint16_t cmd, uint16_t arg)
+{
+	const struct scd30_config *cfg = dev->config;
+	uint8_t buf[5];
+	int ret;
+
+	sys_put_be16(cmd, buf);
+	sys_put_be16(arg, &buf[2]);
+	buf[4] = scd30_crc(&buf[2], 2);
+
+	ret = i2c_write_dt(&cfg->bus, buf, sizeof(buf));
+	if (ret < 0) {
+		return ret;
+	}
+
+	k_msleep(SCD30_CMD_DELAY_MS);
+	return 0;
+}
+
+static int scd30_read_words(const struct device *dev, uint8_t *rx_buf, size_t rx_len)
+{
+	const struct scd30_config *cfg = dev->config;
+	int ret;
+
+	/* SCD30 does not support repeated start: separate write then read. */
+	ret = i2c_read_dt(&cfg->bus, rx_buf, rx_len);
+	if (ret < 0) {
+		LOG_ERR("Failed to read I2C data (%d)", ret);
+		return ret;
+	}
+
+	for (size_t i = 0; i < rx_len; i += 3) {
+		if (scd30_crc(&rx_buf[i], 2) != rx_buf[i + 2]) {
+			LOG_ERR("Invalid CRC");
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+static int scd30_cmd_read_words(const struct device *dev, uint16_t cmd, uint8_t *rx_buf,
+				size_t rx_len)
+{
+	int ret;
+
+	ret = scd30_write_cmd(dev, cmd);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return scd30_read_words(dev, rx_buf, rx_len);
+}
+
+static float scd30_be_float(const uint8_t *word_pair)
+{
+	uint8_t raw[4] = {word_pair[0], word_pair[1], word_pair[3], word_pair[4]};
+	uint32_t u32 = sys_get_be32(raw);
+	float value;
+
+	memcpy(&value, &u32, sizeof(value));
+	return value;
+}
+
+static int scd30_stop_measurement(const struct device *dev)
+{
+	struct scd30_data *data = dev->data;
+	int ret;
+
+	ret = scd30_write_cmd(dev, SCD30_CMD_STOP_PERIODIC_MEASUREMENT);
+	if (ret < 0) {
+		return ret;
+	}
+
+	k_msleep(SCD30_STOP_DELAY_MS);
+	data->measuring = false;
+	return 0;
+}
+
+static int scd30_start_measurement(const struct device *dev)
+{
+	struct scd30_data *data = dev->data;
+	int ret;
+
+	ret = scd30_write_cmd_arg(dev, SCD30_CMD_START_PERIODIC_MEASUREMENT,
+				  data->ambient_pressure);
+	if (ret < 0) {
+		return ret;
+	}
+
+	data->measuring = true;
+	return 0;
+}
+
+static int scd30_set_idle(const struct device *dev)
+{
+	struct scd30_data *data = dev->data;
+
+	if (!data->measuring) {
+		return 0;
+	}
+
+	return scd30_stop_measurement(dev);
+}
+
+static int scd30_data_ready_gpio(const struct device *dev, bool *ready)
+{
+	const struct scd30_config *cfg = dev->config;
+	int level;
+
+	*ready = false;
+
+	if (cfg->ready_gpio.port == NULL) {
+		return -ENOTSUP;
+	}
+
+	level = gpio_pin_get_dt(&cfg->ready_gpio);
+	if (level < 0) {
+		return level;
+	}
+
+	*ready = (level != 0);
+	return 0;
+}
+
+static int scd30_data_ready_i2c(const struct device *dev, bool *ready)
+{
+	uint8_t rx[3];
+	int ret;
+
+	*ready = false;
+
+	ret = scd30_cmd_read_words(dev, SCD30_CMD_GET_DATA_READY, rx, sizeof(rx));
+	if (ret < 0) {
+		return ret;
+	}
+
+	*ready = (sys_get_be16(rx) == 1);
+	return 0;
+}
+
+static int scd30_data_ready(const struct device *dev, bool *ready)
+{
+	const struct scd30_config *cfg = dev->config;
+
+	/* Prefer RDY pin when wired; otherwise use I2C get-data-ready. */
+	if (cfg->ready_gpio.port != NULL) {
+		return scd30_data_ready_gpio(dev, ready);
+	}
+
+	return scd30_data_ready_i2c(dev, ready);
+}
+
+static int scd30_read_sample(const struct device *dev)
+{
+	struct scd30_data *data = dev->data;
+	uint8_t rx[18];
+	int ret;
+
+	ret = scd30_cmd_read_words(dev, SCD30_CMD_READ_MEASUREMENT, rx, sizeof(rx));
+	if (ret < 0) {
+		return ret;
+	}
+
+	data->co2_sample = scd30_be_float(&rx[0]);
+	data->temp_sample = scd30_be_float(&rx[6]);
+	data->humi_sample = scd30_be_float(&rx[12]);
+
+	return 0;
+}
+
+static int scd30_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	bool ready;
+	int ret;
+
+	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_CO2 &&
+	    chan != SENSOR_CHAN_AMBIENT_TEMP && chan != SENSOR_CHAN_HUMIDITY) {
+		return -ENOTSUP;
+	}
+
+	ret = scd30_data_ready(dev, &ready);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (!ready) {
+		return 0;
+	}
+
+	return scd30_read_sample(dev);
+}
+
+static int scd30_channel_get(const struct device *dev, enum sensor_channel chan,
+			     struct sensor_value *val)
+{
+	const struct scd30_data *data = dev->data;
+
+	switch (chan) {
+	case SENSOR_CHAN_CO2:
+		return sensor_value_from_float(val, data->co2_sample);
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		return sensor_value_from_float(val, data->temp_sample);
+	case SENSOR_CHAN_HUMIDITY:
+		return sensor_value_from_float(val, data->humi_sample);
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int scd30_attr_set(const struct device *dev, enum sensor_channel chan,
+			  enum sensor_attribute attr, const struct sensor_value *val)
+{
+	struct scd30_data *data = dev->data;
+	int ret;
+
+	ARG_UNUSED(chan);
+
+	if (val->val1 < 0) {
+		return -EINVAL;
+	}
+
+	switch ((enum sensor_attribute_scd30)attr) {
+	case SENSOR_ATTR_SCD30_AMBIENT_PRESSURE: {
+		uint16_t pressure = (uint16_t)val->val1;
+
+		if (pressure != 0 &&
+		    (pressure < SCD30_AMBIENT_PRESSURE_MIN ||
+		     pressure > SCD30_AMBIENT_PRESSURE_MAX)) {
+			return -EINVAL;
+		}
+		data->ambient_pressure = pressure;
+		/* May be written while measuring; restarts continuous mode. */
+		return scd30_start_measurement(dev);
+	}
+	case SENSOR_ATTR_SCD30_TEMPERATURE_OFFSET: {
+		int32_t offset_cdeg;
+
+		ret = scd30_set_idle(dev);
+		if (ret < 0) {
+			return ret;
+		}
+		offset_cdeg = val->val1 * 100 + val->val2 / 10000;
+		if (offset_cdeg < 0 || offset_cdeg > UINT16_MAX) {
+			return -EINVAL;
+		}
+		ret = scd30_write_cmd_arg(dev, SCD30_CMD_SET_TEMPERATURE_OFFSET,
+					  (uint16_t)offset_cdeg);
+		break;
+	}
+	case SENSOR_ATTR_SCD30_SENSOR_ALTITUDE:
+		ret = scd30_set_idle(dev);
+		if (ret < 0) {
+			return ret;
+		}
+		if (val->val1 > UINT16_MAX) {
+			return -EINVAL;
+		}
+		ret = scd30_write_cmd_arg(dev, SCD30_CMD_SET_ALTITUDE, (uint16_t)val->val1);
+		break;
+	case SENSOR_ATTR_SCD30_AUTOMATIC_CALIB_ENABLE:
+		ret = scd30_set_idle(dev);
+		if (ret < 0) {
+			return ret;
+		}
+		if (val->val1 > 1) {
+			return -EINVAL;
+		}
+		ret = scd30_write_cmd_arg(dev, SCD30_CMD_SET_ASC, (uint16_t)val->val1);
+		break;
+	case SENSOR_ATTR_SCD30_MEASUREMENT_INTERVAL:
+		if (val->val1 < SCD30_MEASUREMENT_INTERVAL_MIN_S ||
+		    val->val1 > SCD30_MEASUREMENT_INTERVAL_MAX_S) {
+			return -EINVAL;
+		}
+		ret = scd30_set_idle(dev);
+		if (ret < 0) {
+			return ret;
+		}
+		ret = scd30_write_cmd_arg(dev, SCD30_CMD_SET_MEASUREMENT_INTERVAL,
+					  (uint16_t)val->val1);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	return scd30_start_measurement(dev);
+}
+
+static int scd30_attr_get(const struct device *dev, enum sensor_channel chan,
+			  enum sensor_attribute attr, struct sensor_value *val)
+{
+	uint8_t rx[3];
+	uint16_t word;
+	int ret;
+	bool was_measuring;
+	struct scd30_data *data = dev->data;
+
+	ARG_UNUSED(chan);
+
+	was_measuring = data->measuring;
+
+	switch ((enum sensor_attribute_scd30)attr) {
+	case SENSOR_ATTR_SCD30_AMBIENT_PRESSURE:
+		val->val1 = data->ambient_pressure;
+		val->val2 = 0;
+		return 0;
+	case SENSOR_ATTR_SCD30_TEMPERATURE_OFFSET:
+		ret = scd30_set_idle(dev);
+		if (ret < 0) {
+			return ret;
+		}
+		ret = scd30_cmd_read_words(dev, SCD30_CMD_SET_TEMPERATURE_OFFSET, rx, sizeof(rx));
+		if (ret < 0) {
+			goto out_restart;
+		}
+		word = sys_get_be16(rx);
+		val->val1 = word / 100;
+		val->val2 = (word % 100) * 10000;
+		break;
+	case SENSOR_ATTR_SCD30_SENSOR_ALTITUDE:
+		ret = scd30_set_idle(dev);
+		if (ret < 0) {
+			return ret;
+		}
+		ret = scd30_cmd_read_words(dev, SCD30_CMD_SET_ALTITUDE, rx, sizeof(rx));
+		if (ret < 0) {
+			goto out_restart;
+		}
+		val->val1 = sys_get_be16(rx);
+		val->val2 = 0;
+		break;
+	case SENSOR_ATTR_SCD30_AUTOMATIC_CALIB_ENABLE:
+		ret = scd30_set_idle(dev);
+		if (ret < 0) {
+			return ret;
+		}
+		ret = scd30_cmd_read_words(dev, SCD30_CMD_SET_ASC, rx, sizeof(rx));
+		if (ret < 0) {
+			goto out_restart;
+		}
+		val->val1 = sys_get_be16(rx);
+		val->val2 = 0;
+		break;
+	case SENSOR_ATTR_SCD30_MEASUREMENT_INTERVAL:
+		ret = scd30_set_idle(dev);
+		if (ret < 0) {
+			return ret;
+		}
+		ret = scd30_cmd_read_words(dev, SCD30_CMD_SET_MEASUREMENT_INTERVAL, rx, sizeof(rx));
+		if (ret < 0) {
+			goto out_restart;
+		}
+		val->val1 = sys_get_be16(rx);
+		val->val2 = 0;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+out_restart:
+	if (was_measuring) {
+		int start_ret = scd30_start_measurement(dev);
+
+		if (ret == 0) {
+			ret = start_ret;
+		}
+	}
+
+	return ret;
+}
+
+int scd30_forced_recalibration(const struct device *dev, uint16_t target_concentration)
+{
+	bool was_measuring;
+	struct scd30_data *data = dev->data;
+	int ret;
+
+	if (target_concentration < SCD30_FRC_CONCENTRATION_MIN ||
+	    target_concentration > SCD30_FRC_CONCENTRATION_MAX) {
+		return -EINVAL;
+	}
+
+	was_measuring = data->measuring;
+	ret = scd30_set_idle(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = scd30_write_cmd_arg(dev, SCD30_CMD_SET_FRC, target_concentration);
+	if (ret < 0) {
+		goto out;
+	}
+
+out:
+	if (was_measuring) {
+		int start_ret = scd30_start_measurement(dev);
+
+		if (ret == 0) {
+			ret = start_ret;
+		}
+	}
+
+	return ret;
+}
+
+int scd30_soft_reset(const struct device *dev)
+{
+	struct scd30_data *data = dev->data;
+	const struct scd30_config *cfg = dev->config;
+	int ret;
+
+	ret = scd30_write_cmd(dev, SCD30_CMD_SOFT_RESET);
+	if (ret < 0) {
+		return ret;
+	}
+
+	k_msleep(SCD30_BOOT_TIME_MS);
+	data->measuring = false;
+	data->ambient_pressure = 0;
+
+	ret = scd30_write_cmd_arg(dev, SCD30_CMD_SET_MEASUREMENT_INTERVAL,
+				  cfg->measurement_interval);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return scd30_start_measurement(dev);
+}
+
+static int scd30_probe(const struct device *dev)
+{
+	uint8_t fw[3];
+	int ret;
+
+	ret = scd30_cmd_read_words(dev, SCD30_CMD_GET_FIRMWARE_VERSION, fw, sizeof(fw));
+	if (ret < 0) {
+		return ret;
+	}
+
+	LOG_INF("SCD30 firmware %u.%u", fw[0], fw[1]);
+	return 0;
+}
+
+static int scd30_init(const struct device *dev)
+{
+	const struct scd30_config *cfg = dev->config;
+	struct scd30_data *data = dev->data;
+	int ret;
+
+	if (!i2c_is_ready_dt(&cfg->bus)) {
+		LOG_ERR_DEVICE_NOT_READY(cfg->bus.bus);
+		return -ENODEV;
+	}
+
+	if (cfg->measurement_interval < SCD30_MEASUREMENT_INTERVAL_MIN_S ||
+	    cfg->measurement_interval > SCD30_MEASUREMENT_INTERVAL_MAX_S) {
+		LOG_ERR("Invalid measurement-interval %u", cfg->measurement_interval);
+		return -EINVAL;
+	}
+
+	if (cfg->ready_gpio.port != NULL) {
+		if (!gpio_is_ready_dt(&cfg->ready_gpio)) {
+			LOG_ERR_DEVICE_NOT_READY(cfg->ready_gpio.port);
+			return -ENODEV;
+		}
+
+		ret = gpio_pin_configure_dt(&cfg->ready_gpio, GPIO_INPUT);
+		if (ret < 0) {
+			LOG_ERR("Failed to configure ready GPIO (%d)", ret);
+			return ret;
+		}
+	}
+
+	data->ambient_pressure = 0;
+	data->measuring = false;
+
+	ret = scd30_write_cmd(dev, SCD30_CMD_SOFT_RESET);
+	if (ret < 0) {
+		LOG_ERR("Soft reset failed (%d)", ret);
+		return ret;
+	}
+
+	k_msleep(SCD30_BOOT_TIME_MS);
+
+	ret = scd30_probe(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to read firmware version (%d)", ret);
+		return ret;
+	}
+
+	(void)scd30_stop_measurement(dev);
+
+	ret = scd30_write_cmd_arg(dev, SCD30_CMD_SET_MEASUREMENT_INTERVAL,
+				  cfg->measurement_interval);
+	if (ret < 0) {
+		LOG_ERR("Failed to set measurement interval (%d)", ret);
+		return ret;
+	}
+
+	ret = scd30_start_measurement(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to start measurement (%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static DEVICE_API(sensor, scd30_api_funcs) = {
+	.sample_fetch = scd30_sample_fetch,
+	.channel_get = scd30_channel_get,
+	.attr_set = scd30_attr_set,
+	.attr_get = scd30_attr_get,
+};
+
+#define SCD30_INIT(inst)                                                                           \
+	static struct scd30_data scd30_data_##inst;                                                \
+	static const struct scd30_config scd30_config_##inst = {                                   \
+		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.ready_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, ready_gpios, {0}),                    \
+		.measurement_interval = DT_INST_PROP(inst, measurement_interval),                  \
+	};                                                                                         \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, scd30_init, NULL, &scd30_data_##inst,                   \
+				     &scd30_config_##inst, POST_KERNEL,                            \
+				     CONFIG_SENSOR_INIT_PRIORITY, &scd30_api_funcs);
+
+DT_INST_FOREACH_STATUS_OKAY(SCD30_INIT)

--- a/drivers/sensor/sensirion/scd30/scd30.h
+++ b/drivers/sensor/sensirion/scd30/scd30.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 RAKwireless Technology Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_SCD30_SCD30_H_
+#define ZEPHYR_DRIVERS_SENSOR_SCD30_SCD30_H_
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c.h>
+
+#define SCD30_CMD_START_PERIODIC_MEASUREMENT 0x0010
+#define SCD30_CMD_STOP_PERIODIC_MEASUREMENT  0x0104
+#define SCD30_CMD_SET_MEASUREMENT_INTERVAL   0x4600
+#define SCD30_CMD_GET_DATA_READY             0x0202
+#define SCD30_CMD_READ_MEASUREMENT           0x0300
+#define SCD30_CMD_SET_ASC                    0x5306
+#define SCD30_CMD_SET_FRC                    0x5204
+#define SCD30_CMD_SET_TEMPERATURE_OFFSET     0x5403
+#define SCD30_CMD_SET_ALTITUDE               0x5102
+#define SCD30_CMD_GET_FIRMWARE_VERSION       0xD100
+#define SCD30_CMD_SOFT_RESET                 0xD304
+
+#define SCD30_CRC_POLY 0x31
+#define SCD30_CRC_INIT 0xFF
+
+/* Datasheet: boot-up time < 2 s */
+#define SCD30_BOOT_TIME_MS 2000
+/* Common practice after stop before issuing further commands */
+#define SCD30_STOP_DELAY_MS 500
+/* Datasheet: wait > 3 ms after write before read */
+#define SCD30_CMD_DELAY_MS 10
+
+#define SCD30_MEASUREMENT_INTERVAL_MIN_S 2
+#define SCD30_MEASUREMENT_INTERVAL_MAX_S 1800
+#define SCD30_AMBIENT_PRESSURE_MIN       700
+#define SCD30_AMBIENT_PRESSURE_MAX       1400
+#define SCD30_FRC_CONCENTRATION_MIN      400
+#define SCD30_FRC_CONCENTRATION_MAX      2000
+
+struct scd30_config {
+	struct i2c_dt_spec bus;
+	struct gpio_dt_spec ready_gpio;
+	uint16_t measurement_interval;
+};
+
+struct scd30_data {
+	float co2_sample;
+	float temp_sample;
+	float humi_sample;
+	uint16_t ambient_pressure;
+	bool measuring;
+};
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_SCD30_SCD30_H_ */

--- a/dts/bindings/sensor/sensirion,scd30.yaml
+++ b/dts/bindings/sensor/sensirion,scd30.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 RAKwireless Technology Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Sensirion SCD30 photoelectric NDIR CO2 sensor IC.
+
+  The SCD30 also includes a humidity and temperature sensor.
+
+compatible: "sensirion,scd30"
+
+include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+  measurement-interval:
+    type: int
+    default: 2
+    description: |
+      Continuous measurement interval in seconds. Legal range is 2 to 1800.
+      Power-up / factory default is 2 seconds.
+
+  ready-gpios:
+    type: phandle-array
+    description: |
+      Optional data-ready (RDY) output. Active high when a new measurement is
+      available. When present, sample_fetch uses this pin instead of the I2C
+      get-data-ready command. Without this property, readiness is polled over
+      I2C.

--- a/include/zephyr/drivers/sensor/scd30.h
+++ b/include/zephyr/drivers/sensor/scd30.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 RAKwireless Technology Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for extended sensor API of SCD30 sensor
+ * @ingroup scd30_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_SCD30_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_SCD30_H_
+
+/**
+ * @brief Sensirion SCD30 CO<sub>2</sub> sensor
+ * @defgroup scd30_interface SCD30
+ * @ingroup sensor_interface_ext_sensirion
+ * @{
+ */
+
+#include <zephyr/drivers/sensor.h>
+
+/**
+ * @brief Custom sensor attributes for SCD30
+ */
+enum sensor_attribute_scd30 {
+	/**
+	 * Temperature offset for the onboard RH/T sensor.
+	 *
+	 * Unit: °C. The driver converts to the device format (0.01 °C ticks).
+	 */
+	SENSOR_ATTR_SCD30_TEMPERATURE_OFFSET = SENSOR_ATTR_PRIV_START,
+	/**
+	 * Altitude compensation in metres above sea level.
+	 */
+	SENSOR_ATTR_SCD30_SENSOR_ALTITUDE,
+	/**
+	 * Ambient pressure compensation in mBar.
+	 *
+	 * Range: 0 (disabled) or 700–1400. Writing this restarts continuous
+	 * measurement with the new pressure argument.
+	 */
+	SENSOR_ATTR_SCD30_AMBIENT_PRESSURE,
+	/**
+	 * Automatic self-calibration enable (1) or disable (0).
+	 *
+	 * Default after power-up is disabled.
+	 */
+	SENSOR_ATTR_SCD30_AUTOMATIC_CALIB_ENABLE,
+	/**
+	 * Continuous measurement interval in seconds.
+	 *
+	 * Range: 2–1800. Default: 2.
+	 */
+	SENSOR_ATTR_SCD30_MEASUREMENT_INTERVAL,
+};
+
+/**
+ * @brief Perform a forced recalibration (FRC).
+ *
+ * Operate the sensor in continuous mode at a 2 s interval for at least two
+ * minutes in a stable environment before calling this function.
+ *
+ * @param dev Pointer to the sensor device
+ * @param target_concentration Reference CO2 concentration in ppm (400–2000)
+ *
+ * @return 0 if successful, negative errno code if failure.
+ */
+int scd30_forced_recalibration(const struct device *dev, uint16_t target_concentration);
+
+/**
+ * @brief Soft-reset the SCD30.
+ *
+ * Forces the same state as after power-up. Blocks for the sensor boot time.
+ *
+ * @param dev Pointer to the sensor device
+ *
+ * @return 0 if successful, negative errno code if failure.
+ */
+int scd30_soft_reset(const struct device *dev);
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_SCD30_H_ */

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1652,3 +1652,9 @@ test_i2c_icm40627: icm40627@d6 {
 	accel-fs = <16>;
 	gyro-fs = <2000>;
 };
+
+test_i2c_scd30: scd30@d7 {
+	compatible = "sensirion,scd30";
+	reg = <0xd7>;
+	measurement-interval = <2>;
+};


### PR DESCRIPTION
Add an I2C driver for the Sensirion SCD30, exposing CO2, ambient temperature and humidity channels with configuration attributes and optional ready-gpios support for data-ready signalling.