### PR TITLE
drivers: i3c: it51xxx: add enhancements and fixes

### DIFF
--- a/drivers/i3c/Kconfig.it51xxx
+++ b/drivers/i3c/Kconfig.it51xxx
@@ -28,6 +28,16 @@ config I3CM_IT51XXX_DLM_SIZE
 	help
 	  Set i3cm data-local-memory(DLM) size.
 
+config IT51XXX_AUTO_IBI_MAX_TARGETS
+	int
+	depends on I3C_USE_IBI
+	default 0 if SOC_IT51526AW || SOC_IT51526BW
+	default 3
+	range 0 4
+	help
+	  Maximum number of targets supported by the it51xxx
+	  automatic IBI response mechanism.
+
 endif # I3CM_IT51XXX
 
 config I3CS_IT51XXX

--- a/drivers/i3c/i3cm_it51xxx.c
+++ b/drivers/i3c/i3cm_it51xxx.c
@@ -16,6 +16,7 @@ LOG_MODULE_REGISTER(i3cm_it51xxx);
 #include <zephyr/kernel.h>
 #include <zephyr/irq.h>
 #include <zephyr/pm/policy.h>
+#include <zephyr/sys/minmax.h>
 
 #include <soc_common.h>
 
@@ -96,6 +97,29 @@ LOG_MODULE_REGISTER(i3cm_it51xxx);
 #define I3CM52_DLM_BASE_ADDRESS_LB 0x52 /* dlm base address[15:8] */
 #define I3CM53_DLM_BASE_ADDRESS_HB 0x53 /* dlm base address[17:16] */
 
+#define I3CM54_IBI_AUTO_RESP_DLM_BASE_ADDR_0 0x54
+#define I3CM55_IBI_AUTO_RESP_DLM_BASE_ADDR_1 0x55
+#define I3CM56_IBI_AUTO_RESP_DLM_BASE_ADDR_2 0x56
+
+#define IT51XXX_AUTO_IBI_MAX_PAYLOAD_SIZE 16
+
+#if CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS
+static const uint8_t auto_ibi_base[] = {0x60, 0x64, 0x68};
+BUILD_ASSERT(ARRAY_SIZE(auto_ibi_base) >= CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS,
+	     "CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS does not match auto_ibi_base[] size");
+#define I3CM60_IBI_AUTO_RESP_0_CTRL_0 0x0
+#define AUTO_IBI_RESP_ADDR_MASK       GENMASK(7, 1)
+#define AUTO_IBI_RESP_ADDR_PREP(n)    FIELD_PREP(AUTO_IBI_RESP_ADDR_MASK, n)
+#define AUTO_IBI_RESP_ADDR_GET(n)     FIELD_GET(AUTO_IBI_RESP_ADDR_MASK, n)
+
+#define I3CM61_IBI_AUTO_RESP_0_CTRL_1 0x1
+#define AUTO_IBI_RESP_PAYLOAD_SIZE(x) FIELD_PREP(GENMASK(4, 0), x)
+
+#define I3CM62_IBI_AUTO_RESP_0_CTRL_2 0x2
+#define IBI_ONE_SHOT_AUTO_RESP_EN     BIT(7)
+#define IBI_AUTO_RESP_COMPLETION      BIT(0)
+#endif /* CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS */
+
 #define I3C_IBI_HJ_ADDR 0x02
 
 #define I3C_BUS_TLOW_PP_MIN_NS  24  /* T_LOW period in push-pull mode */
@@ -156,6 +180,12 @@ struct it51xxx_i3cm_data {
 		uint8_t addr[4];
 		uint8_t num_addr;
 	} ibi;
+
+#if CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS
+	struct {
+		uint8_t data[IT51XXX_AUTO_IBI_MAX_PAYLOAD_SIZE];
+	} auto_ibi_payload[CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS] __aligned(64);
+#endif /* CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS */
 #endif /* CONFIG_I3C_USE_IBI */
 
 	struct k_sem msg_sem;
@@ -1033,6 +1063,29 @@ static int it51xxx_i3cm_ibi_enable(const struct device *dev, struct i3c_device_d
 		idx = 0;
 	}
 
+#if CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS
+	/* auto ibi supports only 16-byte payloads, including mdb */
+	if (CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE <= IT51XXX_AUTO_IBI_MAX_PAYLOAD_SIZE) {
+		for (uint8_t i = 0; i < CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS; i++) {
+			mem_addr_t auto_ibi_addr = cfg->base + auto_ibi_base[i];
+
+			if (AUTO_IBI_RESP_ADDR_GET(sys_read8(auto_ibi_addr +
+							     I3CM60_IBI_AUTO_RESP_0_CTRL_0)) != 0) {
+				continue;
+			}
+
+			sys_write8(AUTO_IBI_RESP_ADDR_PREP(target->dynamic_addr),
+				   auto_ibi_addr + I3CM60_IBI_AUTO_RESP_0_CTRL_0);
+			sys_write8(AUTO_IBI_RESP_PAYLOAD_SIZE(IT51XXX_AUTO_IBI_MAX_PAYLOAD_SIZE),
+				   auto_ibi_addr + I3CM61_IBI_AUTO_RESP_0_CTRL_1);
+			/* enable auto ibi one-shot mode */
+			sys_write8(IBI_ONE_SHOT_AUTO_RESP_EN,
+				   auto_ibi_addr + I3CM62_IBI_AUTO_RESP_0_CTRL_2);
+			break;
+		}
+	}
+#endif /* CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS */
+
 	LOG_INST_DBG(cfg->log, "ibi enabling for 0x%x (bcr 0x%x)", target->dynamic_addr,
 		     target->bcr);
 
@@ -1084,6 +1137,23 @@ static int it51xxx_i3cm_ibi_disable(const struct device *dev, struct i3c_device_
 	if (data->ibi.num_addr == 0U) {
 		it51xxx_enable_standby_state(dev, true);
 	}
+
+#if CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS
+	if (CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE <= IT51XXX_AUTO_IBI_MAX_PAYLOAD_SIZE) {
+		for (uint8_t i = 0; i < CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS; i++) {
+			mem_addr_t auto_ibi_addr = cfg->base + auto_ibi_base[i];
+
+			if (AUTO_IBI_RESP_ADDR_GET(
+				    sys_read8(auto_ibi_addr + I3CM60_IBI_AUTO_RESP_0_CTRL_0)) !=
+			    target->dynamic_addr) {
+				continue;
+			}
+			sys_write8(AUTO_IBI_RESP_ADDR_PREP(0),
+				   auto_ibi_addr + I3CM60_IBI_AUTO_RESP_0_CTRL_0);
+			sys_write8(0, auto_ibi_addr + I3CM62_IBI_AUTO_RESP_0_CTRL_2);
+		}
+	}
+#endif /* CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS */
 
 	LOG_INST_DBG(cfg->log, "ibi disabling for 0x%x (bcr 0x%x)", target->dynamic_addr,
 		     target->bcr);
@@ -1169,6 +1239,17 @@ static int it51xxx_i3cm_init(const struct device *dev)
 	sys_write8(FIELD_GET(GENMASK(17, 16), (uint32_t)&data->dlm_data),
 		   cfg->base + I3CM53_DLM_BASE_ADDRESS_HB);
 	sys_write8(BYTE_1((uint32_t)&data->dlm_data), cfg->base + I3CM52_DLM_BASE_ADDRESS_LB);
+
+#if CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS
+	LOG_INST_DBG(cfg->log, "auto ibi: dlm base address 0x%x",
+		     (uint32_t)&data->auto_ibi_payload);
+	sys_write8(BYTE_0((uint32_t)&data->auto_ibi_payload),
+		   cfg->base + I3CM54_IBI_AUTO_RESP_DLM_BASE_ADDR_0);
+	sys_write8(BYTE_1((uint32_t)&data->auto_ibi_payload),
+		   cfg->base + I3CM55_IBI_AUTO_RESP_DLM_BASE_ADDR_1);
+	sys_write8(FIELD_GET(GENMASK(17, 16), (uint32_t)&data->auto_ibi_payload),
+		   cfg->base + I3CM56_IBI_AUTO_RESP_DLM_BASE_ADDR_2);
+#endif /* CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS */
 
 	ret = it51xxx_set_frequency(dev);
 	if (ret) {
@@ -1406,34 +1487,72 @@ static void it51xxx_private_xfer_end(const struct device *dev)
 }
 
 #ifdef CONFIG_I3C_USE_IBI
+static int it51xxx_ibi_payload_size(const struct device *dev, struct i3c_device_desc *target,
+				    size_t *payload_sz)
+{
+	const struct it51xxx_i3cm_config *cfg = dev->config;
+
+	*payload_sz = 0;
+
+	if (i3c_ibi_has_payload(target)) {
+		*payload_sz = it51xxx_get_received_data_count(dev);
+		if (*payload_sz == 0) {
+			/* wrong ibi transaction due to missing payload.
+			 * a 100us timeout on the target side may cause this
+			 * situation.
+			 */
+			return -EINVAL;
+		}
+
+		if (*payload_sz > CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE) {
+			LOG_INST_WRN(cfg->log, "ibi payloads(%d) is too much", *payload_sz);
+			*payload_sz = min(*payload_sz, CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE);
+		}
+	}
+
+	return 0;
+}
+
 static void it51xxx_process_ibi_payload(const struct device *dev)
 {
 	const struct it51xxx_i3cm_config *cfg = dev->config;
 	struct it51xxx_i3cm_data *data = dev->data;
-	size_t payload_sz = 0;
+	size_t payload_sz;
 	struct i3c_device_desc *target = i3c_dev_list_i3c_addr_find(dev, data->ibi_target_addr);
 
-	if (i3c_ibi_has_payload(target)) {
-		payload_sz = it51xxx_get_received_data_count(dev);
-		if (payload_sz == 0) {
-			/* wrong ibi transaction due to missing payload.
-			 * a 100us timeout on the targe side may cause this
-			 * situation.
-			 */
-			return;
-		}
-
-		if (payload_sz > CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE) {
-			LOG_INST_WRN(cfg->log, "ibi payloads(%d) is too much", payload_sz);
-		}
+	if (it51xxx_ibi_payload_size(dev, target, &payload_sz)) {
+		return;
 	}
 
-	if (i3c_ibi_work_enqueue_target_irq(target, data->dlm_data.rx_data,
-					    MIN(payload_sz, CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE)) !=
-	    0) {
+	LOG_HEXDUMP_DBG(data->dlm_data.rx_data, payload_sz, "isr: ibi:");
+	if (i3c_ibi_work_enqueue_target_irq(target, data->dlm_data.rx_data, payload_sz) != 0) {
 		LOG_INST_ERR(cfg->log, "failed to enqueue tir work");
 	}
 }
+
+#if CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS
+static void it51xxx_process_auto_ibi_payload(const struct device *dev, const uint8_t index)
+{
+	const struct it51xxx_i3cm_config *cfg = dev->config;
+	struct it51xxx_i3cm_data *data = dev->data;
+	size_t payload_sz;
+	uint8_t address = AUTO_IBI_RESP_ADDR_GET(
+		sys_read8(cfg->base + auto_ibi_base[index] + I3CM60_IBI_AUTO_RESP_0_CTRL_0));
+	struct i3c_device_desc *target = i3c_dev_list_i3c_addr_find(dev, address);
+
+	LOG_INST_DBG(cfg->log, "isr: auto ibi %d: device %#x xfer done", index, address);
+	if (it51xxx_ibi_payload_size(dev, target, &payload_sz)) {
+		return;
+	}
+
+	LOG_HEXDUMP_DBG(data->auto_ibi_payload[index].data, payload_sz, "isr: auto ibi:");
+	if (i3c_ibi_work_enqueue_target_irq(target, data->auto_ibi_payload[index].data,
+					    payload_sz) != 0) {
+		LOG_INST_ERR(cfg->log, "auto_ibi: failed to enqueue tir work");
+		return;
+	}
+}
+#endif /* CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS */
 #endif /* CONFIG_I3C_USE_IBI */
 
 static inline void it51xxx_check_error(const struct device *dev, const uint8_t int_status)
@@ -1565,6 +1684,24 @@ static void it51xxx_i3cm_isr(const struct device *dev)
 			LOG_INST_DBG(cfg->log, "isr: daa finished");
 			break;
 		case IT51XXX_I3CM_MSG_IDLE:
+#if CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS
+			for (uint8_t i = 0; i < ARRAY_SIZE(auto_ibi_base); i++) {
+				uint8_t ctrl2 = sys_read8(cfg->base + auto_ibi_base[i] +
+							  I3CM62_IBI_AUTO_RESP_0_CTRL_2);
+
+				if (!(ctrl2 & IBI_AUTO_RESP_COMPLETION)) {
+					continue;
+				}
+
+				it51xxx_process_auto_ibi_payload(dev, i);
+				/* w1c completion bit and enable one-shot for the next ibi */
+				sys_write8(ctrl2 | IBI_ONE_SHOT_AUTO_RESP_EN |
+						   IBI_AUTO_RESP_COMPLETION,
+					   cfg->base + auto_ibi_base[i] +
+						   I3CM62_IBI_AUTO_RESP_0_CTRL_2);
+				goto out;
+			}
+#endif /* CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS */
 			LOG_INST_WRN(cfg->log, "isr: end transfer occurs but bus is in idle");
 			break;
 		default:
@@ -1576,6 +1713,9 @@ static void it51xxx_i3cm_isr(const struct device *dev)
 			k_sem_give(&data->msg_sem);
 		}
 
+#if CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS
+out:
+#endif /* CONFIG_IT51XXX_AUTO_IBI_MAX_TARGETS */
 		data->msg_state = IT51XXX_I3CM_MSG_IDLE;
 		sys_write8(TARGET_NACK | TRANSFER_END, cfg->base + I3CM01_STATUS);
 	}

--- a/drivers/i3c/i3cm_it51xxx.c
+++ b/drivers/i3c/i3cm_it51xxx.c
@@ -221,6 +221,8 @@ struct it51xxx_i3cm_config {
 		uint32_t i2c_scl_hddat;
 	} clocks;
 
+	bool pull_up_4k_ohm;
+
 	void (*irq_config_func)(const struct device *dev);
 
 	LOG_INSTANCE_PTR_DECLARE(log);
@@ -1231,8 +1233,11 @@ static int it51xxx_i3cm_init(const struct device *dev)
 	LOG_INST_DBG(cfg->log, "channel %d is selected", cfg->io_channel);
 	reg_val |= FIELD_PREP(I3CM_CHANNEL_SELECT_MASK, cfg->io_channel);
 
-	/* select 4k pull-up resistor and enable i3c engine*/
-	reg_val |= (I3CM_PULL_UP_RESISTOR | I3CM_ENABLE);
+	/* select 4k pull-up resistor and enable i3c engine */
+	if (cfg->pull_up_4k_ohm) {
+		reg_val |= I3CM_PULL_UP_RESISTOR;
+	}
+	reg_val |= I3CM_ENABLE;
 	sys_write8(reg_val, cfg->base + I3CM50_CONTROL_3);
 
 	LOG_INST_DBG(cfg->log, "dlm base address 0x%x", (uint32_t)&data->dlm_data);
@@ -1806,6 +1811,7 @@ static DEVICE_API(i3c, it51xxx_i3cm_api) = {
 		.clocks.i3c_scl_tcasr = DT_INST_PROP_OR(n, i3c_scl_tcasr, 1),                      \
 		.clocks.i3c_scl_tcbsr = DT_INST_PROP_OR(n, i3c_scl_tcbsr, 0),                      \
 		.clocks.i2c_scl_hddat = DT_INST_PROP_OR(n, i2c_scl_hddat, 0),                      \
+		.pull_up_4k_ohm = DT_INST_PROP(n, pull_up_4k_ohm),                                 \
 		LOG_INSTANCE_PTR_INIT(log, DT_NODE_FULL_NAME_TOKEN(DT_DRV_INST(n)), n)};           \
 	static struct it51xxx_i3cm_data i3c_data_##n = {                                           \
 		.common.ctrl_config.scl.i3c = DT_INST_PROP_OR(n, i3c_scl_hz, 0),                   \

--- a/drivers/i3c/i3cs_it51xxx.c
+++ b/drivers/i3c/i3cs_it51xxx.c
@@ -113,9 +113,6 @@ LOG_MODULE_REGISTER(i3cs_it51xxx);
 #define I3CS6A_MWL_SET_BY_CTRL_LB 0x6A
 #define I3CS6B_MWL_SET_BY_CTRL_HB 0x6B
 #define I3CS6C_PRAT_NUMBER_0      0x6C
-#define I3CS6D_PRAT_NUMBER_1      0x6D
-#define I3CS6E_PRAT_NUMBER_2      0x6E
-#define I3CS6F_PRAT_NUMBER_3      0x6F
 #define I3CS71_DCR                0x71
 #define I3CS72_BCR                0x72
 #define I3CS76_TX_FIFO_READ_PTR   0x76
@@ -127,6 +124,11 @@ LOG_MODULE_REGISTER(i3cs_it51xxx);
 
 #define IT51XXX_DIRECT_MODE_FIFO_SIZE 4096
 #define IT51XXX_I3CS_MAX_MRL_MWL      0xFFF /* 4095 bytes */
+
+#define MIPI_MID_ITE_TECH_INC    0x02FD
+#define MANUFACTURER_ID_MASK     GENMASK64(47, 33)
+#define GET_MANUFACTURER_ID(pid) FIELD_GET(MANUFACTURER_ID_MASK, (uint64_t)pid)
+#define GET_PART_NUMBER(pid)     FIELD_GET(GENMASK64(31, 0), (uint64_t)pid)
 
 enum it51xxx_i3cs_event_type {
 	EVT_NORMAL_MODE = 0,
@@ -242,6 +244,28 @@ static inline void set_mwl_value(const struct device *dev, const uint16_t value)
 	sys_write8(BYTE_1(mwl), cfg->base + I3CS6B_MWL_SET_BY_CTRL_HB);
 }
 
+static inline void set_pid_part_number(const struct device *dev,
+				       struct i3c_config_target *cfg_target)
+{
+	const struct it51xxx_i3cs_config *cfg = dev->config;
+	uint32_t pid_part_number = GET_PART_NUMBER(cfg_target->pid);
+
+	if (!cfg_target->pid_random) {
+		sys_write8(sys_read8(cfg->base + I3CS05_CONFIG_1) & ~ID_RANDOM,
+			   cfg->base + I3CS05_CONFIG_1);
+		cfg_target->pid =
+			FIELD_PREP(MANUFACTURER_ID_MASK, (uint64_t)MIPI_MID_ITE_TECH_INC) |
+			sys_read32(cfg->base + I3CS6C_PRAT_NUMBER_0);
+	} else {
+		sys_write8(sys_read8(cfg->base + I3CS05_CONFIG_1) | ID_RANDOM,
+			   cfg->base + I3CS05_CONFIG_1);
+		sys_write32(pid_part_number, cfg->base + I3CS6C_PRAT_NUMBER_0);
+	}
+
+	LOG_INST_INF(cfg->log, "pid: (%s) %#llx", cfg_target->pid_random ? "random" : "fixed",
+		     cfg_target->pid);
+}
+
 static int it51xxx_i3cs_prepare_tx_fifo(const struct device *dev, uint8_t *buf, uint16_t len)
 {
 	const struct it51xxx_i3cs_config *cfg = dev->config;
@@ -340,6 +364,83 @@ static int it51xxx_i3cs_target_tx_write(const struct device *dev, uint8_t *buf, 
 	k_mutex_unlock(&data->lock);
 
 	return ret ? ret : len;
+}
+
+static int it51xxx_i3cs_configure(const struct device *dev, enum i3c_config_type type, void *config)
+{
+	const struct it51xxx_i3cs_config *cfg = dev->config;
+	struct it51xxx_i3cs_data *data = dev->data;
+	struct i3c_config_target *cfg_target = config;
+
+	if (config == NULL) {
+		LOG_INST_ERR(cfg->log, "config is null");
+		return -EINVAL;
+	}
+
+	if (type != I3C_CONFIG_TARGET) {
+		LOG_INST_ERR(cfg->log, "support target mode only");
+		return -ENOTSUP;
+	}
+
+	/* manufacturer id should be fixed as 02fd'h (ITE Tech. Inc.) */
+	if (cfg_target->pid == 0 || GET_MANUFACTURER_ID(cfg_target->pid) != MIPI_MID_ITE_TECH_INC) {
+		LOG_INST_ERR(cfg->log, "invalid pid (0x%#llx)", cfg_target->pid);
+		return -EINVAL;
+	}
+
+	if (cfg_target->supported_hdr) {
+		LOG_INST_ERR(cfg->log, "only supported sdr mode");
+		return -EINVAL;
+	}
+
+	if (cfg_target->max_write_len > sizeof(data->fifo.rx_data) ||
+	    cfg_target->max_read_len > sizeof(data->fifo.tx_data)) {
+		LOG_INST_ERR(cfg->log, "mwl or mrl exceeded (mwl=%u/%zu, mrl=%u/%zu)",
+			     cfg_target->max_write_len, sizeof(data->fifo.rx_data),
+			     cfg_target->max_read_len, sizeof(data->fifo.tx_data));
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	set_pid_part_number(dev, cfg_target);
+
+	sys_write8(cfg_target->bcr, cfg->base + I3CS72_BCR);
+	sys_write8(cfg_target->dcr, cfg->base + I3CS71_DCR);
+	LOG_INST_INF(cfg->log, "bcr: %#x, dcr: %#x", cfg_target->bcr, cfg_target->dcr);
+
+	set_mwl_value(dev, cfg_target->max_write_len);
+	set_mrl_value(dev, cfg_target->max_read_len);
+	LOG_INST_INF(cfg->log, "mwl: %#x, mrl: %#x", cfg_target->max_write_len,
+		     cfg_target->max_read_len);
+
+	sys_write8(I3CS_TARGET_ADDRESS(cfg_target->static_addr), cfg->base + I3CS07_CONFIG_2);
+
+	cfg_target->enabled = true;
+
+	(void)memcpy(&data->config_target, cfg_target, sizeof(*cfg_target));
+
+	k_mutex_unlock(&data->lock);
+
+	return 0;
+}
+
+static int it51xxx_i3cs_config_get(const struct device *dev, enum i3c_config_type type,
+				   void *config)
+{
+	struct it51xxx_i3cs_data *data = dev->data;
+
+	if (type != I3C_CONFIG_TARGET) {
+		return -ENOTSUP;
+	}
+
+	if (!config) {
+		return -EINVAL;
+	}
+
+	(void)memcpy(config, &data->config_target, sizeof(data->config_target));
+
+	return 0;
 }
 
 static inline bool it51xxx_i3cs_dynamic_addr_valid(const struct device *dev)
@@ -567,15 +668,8 @@ static int it51xxx_i3cs_init(const struct device *dev)
 	sys_write8(cfg->vendor_info, cfg->base + I3CS0F_CONTROL_3);
 
 	/* set pid, bcr and dcr */
-	if (config_target->pid_random) {
-		sys_write8(sys_read8(cfg->base + I3CS05_CONFIG_1) | ID_RANDOM,
-			   cfg->base + I3CS05_CONFIG_1);
-		sys_write8(BYTE_0(config_target->pid), cfg->base + I3CS6C_PRAT_NUMBER_0);
-		sys_write8(BYTE_1(config_target->pid), cfg->base + I3CS6D_PRAT_NUMBER_1);
-		sys_write8(BYTE_2(config_target->pid), cfg->base + I3CS6E_PRAT_NUMBER_2);
-		sys_write8(BYTE_3(config_target->pid), cfg->base + I3CS6F_PRAT_NUMBER_3);
-		LOG_INST_INF(cfg->log, "set pid random value: %#llx", config_target->pid);
-	}
+	set_pid_part_number(dev, config_target);
+
 	if (I3C_BCR_DEVICE_ROLE(config_target->bcr) == I3C_BCR_DEVICE_ROLE_I3C_CONTROLLER_CAPABLE) {
 		LOG_INST_ERR(cfg->log, "i3cs doesn't support controller capability");
 		return -ENOTSUP;
@@ -650,10 +744,14 @@ static int it51xxx_i3cs_init(const struct device *dev)
 
 	cfg->irq_config_func(dev);
 
+	config_target->enabled = true;
+
 	return 0;
 }
 
 static DEVICE_API(i3c, it51xxx_i3cs_api) = {
+	.configure = it51xxx_i3cs_configure,
+	.config_get = it51xxx_i3cs_config_get,
 	.target_tx_write = it51xxx_i3cs_target_tx_write,
 	.target_register = it51xxx_i3cs_target_register,
 	.target_unregister = it51xxx_i3cs_target_unregister,
@@ -862,6 +960,13 @@ static void it51xxx_i3cs_isr(const struct device *dev)
 		.bit_mask = DT_INST_PROP_BY_IDX(n, extern_enable, 1),                              \
 	}
 
+#define PID_TYPE_RANDOM_VALUE BIT64(32)
+#define IT51XXX_I3CS_PID(n)                                                                        \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, pid_random_value),                                    \
+		(FIELD_PREP(MANUFACTURER_ID_MASK, MIPI_MID_ITE_TECH_INC) |                         \
+		 PID_TYPE_RANDOM_VALUE | DT_INST_PROP(n, pid_random_value)),                       \
+		(FIELD_PREP(MANUFACTURER_ID_MASK, MIPI_MID_ITE_TECH_INC)))
+
 #define IT51XXX_I3CS_INIT(n)                                                                       \
 	LOG_INSTANCE_REGISTER(DT_NODE_FULL_NAME_TOKEN(DT_DRV_INST(n)), n,                          \
 			      CONFIG_I3C_IT51XXX_LOG_LEVEL);                                       \
@@ -882,11 +987,11 @@ static void it51xxx_i3cs_isr(const struct device *dev)
 		LOG_INSTANCE_PTR_INIT(log, DT_NODE_FULL_NAME_TOKEN(DT_DRV_INST(n)), n)};           \
 	static struct it51xxx_i3cs_data i3c_data_##n = {                                           \
 		.config_target.static_addr = DT_INST_PROP_OR(n, static_address, 0),                \
-		.config_target.pid = DT_INST_PROP_OR(n, pid_random_value, 0),                      \
+		.config_target.pid = IT51XXX_I3CS_PID(n),                                          \
 		.config_target.pid_random = DT_INST_NODE_HAS_PROP(n, pid_random_value),            \
 		.config_target.bcr = DT_INST_PROP_OR(n, bcr, 0x0F),                                \
 		.config_target.dcr = DT_INST_PROP_OR(n, dcr, 0),                                   \
-		.config_target.supported_hdr = false,                                              \
+		.config_target.supported_hdr = 0,                                                  \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(n, it51xxx_i3cs_init, NULL, &i3c_data_##n, &i3c_config_##n,          \
 			      POST_KERNEL, CONFIG_I3C_CONTROLLER_INIT_PRIORITY,                    \

--- a/drivers/i3c/i3cs_it51xxx.c
+++ b/drivers/i3c/i3cs_it51xxx.c
@@ -793,13 +793,13 @@ static void it51xxx_i3cs_isr(const struct device *dev)
 	if (int_status_1 & INT_DYN_ADDR_CHANGE) {
 		if (it51xxx_i3cs_dynamic_addr_valid(dev)) {
 			if (data->target_config) {
-				data->target_config->address = DYNAMIC_ADDRESS(
+				data->config_target.dynamic_addr = DYNAMIC_ADDRESS(
 					sys_read8(cfg->base + I3CS64_DYNAMIC_ADDRESS));
 			}
 			LOG_INST_DBG(cfg->log, "dynamic address is assigned");
 		} else {
 			if (data->target_config) {
-				data->target_config->address = 0;
+				data->config_target.dynamic_addr = 0;
 			}
 			LOG_INST_DBG(cfg->log, "dynamic address is reset");
 		}

--- a/dts/bindings/i3c/ite,it51xxx-i3cm.yaml
+++ b/dts/bindings/i3c/ite,it51xxx-i3cm.yaml
@@ -25,6 +25,13 @@ properties:
       that multiple controllers (including the i3cm controller and i3cs
       target engines) are not assigned the same io channel.
 
+  pull-up-4k-ohm:
+    type: boolean
+    description: |
+      Select the 4k-ohm resistor for i3cm. If not set, the 1.3k-ohm pull-up
+      resistor is used. This property can be configured based on the number
+      of devices on the i3c bus. (default: false)
+
   i3c-pp-duty-cycle:
     default: 50
     type: int


### PR DESCRIPTION
This pr adds several enhancements and fixes for the it51xxx i3cm/i3cs drivers.

Changes:
- i3cs: add runtime target device configuration support
- i3cm: add devicetree property to configure the bus pull-up resistor
- i3cm: add automatic ibi response support
- i3cs: fix build error caused by the removal of the `address` member in `struct i3c_target_config`