### PR TITLE
scripts: gen_kobject_list: fix ConstType missing size attribute

### DIFF
--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -319,6 +319,10 @@ class ConstType:
     def __repr__(self):
         return f"<const {self.child_type}>"
 
+    @property
+    def size(self):
+        return type_env[self.child_type].size
+
     def has_kobject(self):
         if self.child_type not in type_env:
             return False


### PR DESCRIPTION
ArrayType.get_kobjects() accesses mt.size to compute element offsets when iterating over a multidimensional array.  When the array element type is const-qualified, mt resolves to a ConstType instance which does not have a size attribute, causing an AttributeError during the kobject prebuilt hash generation step.

Add a size property to ConstType that delegates to the underlying child type, consistent with the existing delegation of has_kobject() and get_kobjects().

fixes: #113105