### PR TITLE
boards: nxp: add crc to supported lists

### DIFF
--- a/boards/nxp/frdm_k22f/frdm_k22f.yaml
+++ b/boards/nxp/frdm_k22f/frdm_k22f.yaml
@@ -20,4 +20,5 @@ supported:
   - spi
   - usb_device
   - watchdog
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_ke15z/frdm_ke15z.yaml
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z.yaml
@@ -14,3 +14,4 @@ supported:
   - hwinfo
   - uart
   - watchdog
+  - crc

--- a/boards/nxp/frdm_ke16z/frdm_ke16z.yaml
+++ b/boards/nxp/frdm_ke16z/frdm_ke16z.yaml
@@ -12,3 +12,4 @@ supported:
   - gpio
   - hwinfo
   - uart
+  - crc

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
@@ -19,4 +19,5 @@ supported:
   - spi
   - uart
   - watchdog
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.yaml
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.yaml
@@ -25,4 +25,5 @@ supported:
   - spi
   - dma
   - watchdog
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153.yaml
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153.yaml
@@ -30,4 +30,5 @@ supported:
   - usb_device
   - watchdog
   - edac
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156.yaml
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156.yaml
@@ -30,4 +30,5 @@ supported:
   - usbd
   - watchdog
   - edac
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxa344/frdm_mcxa344.yaml
+++ b/boards/nxp/frdm_mcxa344/frdm_mcxa344.yaml
@@ -27,4 +27,5 @@ supported:
   - edac
   - pwm
   - opamp
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
@@ -30,4 +30,5 @@ supported:
   - can
   - dac
   - rtc
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577_mcxa577_t1s.yaml
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577_mcxa577_t1s.yaml
@@ -15,4 +15,5 @@ toolchain:
   - gnuarmemb
 supported:
   - netif:eth
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.yaml
@@ -32,4 +32,5 @@ supported:
   - edac
   - pwm
   - rtc
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa346.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa346.yaml
@@ -30,4 +30,5 @@ supported:
   - edac
   - pwm
   - rtc
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.yaml
@@ -33,4 +33,5 @@ supported:
   - edac
   - pwm
   - rtc
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242.yaml
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242.yaml
@@ -24,6 +24,7 @@ supported:
   - usb_device
   - usbd
   - dma
+  - crc
 testing:
   ignore_tags:
     - net

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
@@ -30,4 +30,5 @@ supported:
   - usbd
   - video
   - watchdog
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -41,4 +41,5 @@ supported:
   - video
   - watchdog
   - edac
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
@@ -35,4 +35,5 @@ supported:
   - usb_device
   - usbd
   - watchdog
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu1.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu1.yaml
@@ -16,4 +16,5 @@ toolchain:
 supported:
   - dma
   - gpio
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxw70/frdm_mcxw70.yaml
+++ b/boards/nxp/frdm_mcxw70/frdm_mcxw70.yaml
@@ -19,4 +19,5 @@ supported:
   - pinctrl
   - uart
   - trng
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.yaml
@@ -31,4 +31,5 @@ supported:
   - watchdog
   - netif:openthread
   - rtc
+  - crc
 vendor: nxp

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72.yaml
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72.yaml
@@ -21,4 +21,5 @@ supported:
   - uart
   - watchdog
   - netif:openthread
+  - crc
 vendor: nxp

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
@@ -27,4 +27,5 @@ supported:
   - usb_device
   - usbd
   - watchdog
+  - crc
 vendor: nxp

--- a/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0.yaml
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0.yaml
@@ -34,4 +34,5 @@ supported:
   - usb_device
   - watchdog
   - edac
+  - crc
 vendor: nxp

--- a/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0_qspi.yaml
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu0_qspi.yaml
@@ -29,4 +29,5 @@ supported:
   - spi
   - usb_device
   - watchdog
+  - crc
 vendor: nxp

--- a/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu1.yaml
+++ b/boards/nxp/mcx_nx4x_evk/mcx_n9xx_evk_mcxn947_cpu1.yaml
@@ -16,4 +16,5 @@ toolchain:
 supported:
   - dma
   - gpio
+  - crc
 vendor: nxp

--- a/boards/nxp/mcxw72_evk/mcxw72_evk.yaml
+++ b/boards/nxp/mcxw72_evk/mcxw72_evk.yaml
@@ -17,3 +17,4 @@ supported:
   - pwm
   - spi
   - uart
+  - crc

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.yaml
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.yaml
@@ -27,4 +27,5 @@ supported:
   - hwinfo
   - flash
   - memc
+  - crc
 vendor: nxp

--- a/boards/nxp/twr_ke18f/twr_ke18f.yaml
+++ b/boards/nxp/twr_ke18f/twr_ke18f.yaml
@@ -19,4 +19,5 @@ supported:
   - pwm
   - spi
   - watchdog
+  - crc
 vendor: nxp


### PR DESCRIPTION
## Summary

Add `crc` to the board metadata for the NXP platforms enabled by
#109331.

That PR added CRC enablement for these platforms, but the corresponding
board YAML metadata still omits `crc` from `supported`. Update the
affected board files so tests such as
`tests/drivers/crc/tests.yaml`, which use `depends_on: crc`, can select
these platforms.

This change only updates board metadata. It does not change the CRC
implementation.
