### PR TITLE
kernel: mm: fix 32-bit overflow in k_mem_phys_addr() address bounds check

### DIFF
--- a/include/zephyr/kernel/internal/mm.h
+++ b/include/zephyr/kernel/internal/mm.h
@@ -120,17 +120,9 @@ static inline uintptr_t k_mem_phys_addr(void *virt)
 	__ASSERT(sys_mm_is_virt_addr_in_range(virt),
 		 "address %p not in permanent mappings", virt);
 #elif defined(CONFIG_MMU)
-	__ASSERT(
-#if CONFIG_KERNEL_VM_BASE != 0
-		 (addr >= CONFIG_KERNEL_VM_BASE) &&
-#endif /* CONFIG_KERNEL_VM_BASE != 0 */
-#if (CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_SIZE) != 0
-		 (addr < (CONFIG_KERNEL_VM_BASE +
-			  (CONFIG_KERNEL_VM_SIZE))),
-#else
-		 false,
-#endif /* CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_SIZE != 0 */
-		 "address %p not in permanent mappings", virt);
+	__ASSERT(addr >= (uintptr_t)CONFIG_KERNEL_VM_BASE, "address %p below VM base", virt);
+	__ASSERT((addr - (uintptr_t)CONFIG_KERNEL_VM_BASE) < (uintptr_t)CONFIG_KERNEL_VM_SIZE,
+		 "address %p above VM limit", virt);
 #else
 	/* Should be identity-mapped */
 	__ASSERT(IS_SRAM_ADDRESS(addr),


### PR DESCRIPTION
On 64-bit targets CONFIG_KERNEL_VM_BASE and CONFIG_KERNEL_VM_SIZE are bare hex literals treated as unsigned int (32-bit) by the compiler. The upper-bound check:

      addr < (CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_SIZE)

overflows to 0 when the sum exceeds 4GB, causing the __ASSERT to fire for every valid address and crash the device.

Cast both macros to uintptr_t so the arithmetic is performed at pointer width, matching the type of addr.