### PR TITLE
soc: st: stm32n6: add backup SRAM support

### DIFF
--- a/boards/st/nucleo_n657x0_q/twister.yaml
+++ b/boards/st/nucleo_n657x0_q/twister.yaml
@@ -8,6 +8,7 @@ supported:
   - arduino_serial
   - arduino_spi
   - adc
+  - backup_sram
   - can
   - dma
   - i2c

--- a/boards/st/stm32n6570_dk/twister.yaml
+++ b/boards/st/stm32n6570_dk/twister.yaml
@@ -9,6 +9,7 @@ supported:
   - arduino_serial
   - arduino_spi
   - adc
+  - backup_sram
   - can
   - counter
   - crc

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -62,6 +62,18 @@
 		};
 	};
 
+	backup_sram: memory@3c000000 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "zephyr,memory-region", "st,stm32-backup-sram";
+		reg = <0x3c000000 DT_SIZE_K(8)>;
+		ranges = <0x3c000000 0x3c000000 DT_SIZE_K(8)>;
+		clocks = <&rcc STM32_CLOCK(MEM, 6)>;
+		zephyr,memory-region = "BACKUP_SRAM";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
+		status = "disabled";
+	};
+
 	clocks {
 		clk_hse: clk-hse {
 			#clock-cells = <0>;

--- a/dts/arm/st/n6/stm32n657X0_ns.dtsi
+++ b/dts/arm/st/n6/stm32n657X0_ns.dtsi
@@ -16,6 +16,10 @@
 		ranges = <0x34000000 0x24000000 DT_SIZE_M(2)>;
 	};
 
+	memory@3c000000 {
+		ranges = <0x3c000000 0x2c000000 DT_SIZE_K(8)>;
+	};
+
 	soc {
 		peripherals@40000000 {
 			ranges = <0x50000000 0x40000000 DT_SIZE_M(256)>,

--- a/samples/boards/st/backup_sram/boards/nucleo_n657x0_q_sb.overlay
+++ b/samples/boards/st/backup_sram/boards/nucleo_n657x0_q_sb.overlay
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Tobias Meyer <tobias.meyer@hula.earth>
+ */
+
+&backup_sram {
+	status = "okay";
+};

--- a/samples/boards/st/backup_sram/boards/stm32n6570_dk_stm32n657xx_sb.overlay
+++ b/samples/boards/st/backup_sram/boards/stm32n6570_dk_stm32n657xx_sb.overlay
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Tobias Meyer <tobias.meyer@hula.earth>
+ */
+
+&backup_sram {
+	status = "okay";
+};

--- a/samples/boards/st/backup_sram/tests.yaml
+++ b/samples/boards/st/backup_sram/tests.yaml
@@ -10,3 +10,4 @@ tests:
       - st
     integration_platforms:
       - nucleo_f207zg/stm32f207xx
+      - stm32n6570_dk/stm32n657xx/sb

--- a/soc/st/stm32/common/stm32_backup_sram.c
+++ b/soc/st/stm32/common/stm32_backup_sram.c
@@ -43,24 +43,28 @@ static int stm32_backup_sram_init(const struct device *dev)
 	/* Add a refcount to backup domain access and never remove it */
 	stm32_backup_domain_enable_access();
 
-	if (IS_ENABLED(CONFIG_SOC_SERIES_STM32U5X)) {
-		/*
-		 * On STM32U5 series, backup RAM retention can only be enabled
-		 * when the LDO is selected as voltage regulator. However, the
-		 * SMPS regulator may have been selected by the time this code
-		 * executes, which results in a deadlock. To avoid this, the
-		 * SoC initialization code is modified to enable the regulator
-		 * on our behalf, before switching regulators - don't try to
-		 * enable the regulator again.
-		 */
-	} else {
-		/* enable backup sram regulator (required to retain backup SRAM content
-		 * while in standby or VBAT modes).
-		 */
-		LL_PWR_EnableBkUpRegulator();
-		while (!LL_PWR_IsEnabledBkUpRegulator()) {
-		}
+#if defined(CONFIG_SOC_SERIES_STM32U5X)
+	/*
+	 * On STM32U5 series, backup RAM retention can only be enabled
+	 * when the LDO is selected as voltage regulator. However, the
+	 * SMPS regulator may have been selected by the time this code
+	 * executes, which results in a deadlock. To avoid this, the
+	 * SoC initialization code is modified to enable the regulator
+	 * on our behalf, before switching regulators - don't try to
+	 * enable the regulator again.
+	 */
+#elif defined(CONFIG_SOC_SERIES_STM32N6X)
+	LL_PWR_EnableBkpSRAMSBRetention();
+	while (!LL_PWR_IsEnabledBkpSRAMSBRetention()) {
 	}
+#else
+	/* enable backup sram regulator (required to retain backup SRAM content
+	 * while in standby or VBAT modes).
+	 */
+	LL_PWR_EnableBkUpRegulator();
+	while (!LL_PWR_IsEnabledBkUpRegulator()) {
+	}
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Adds backup SRAM support for the STM32N6 series. Describes the 8 KiB
backup SRAM node, selects STM32_BACKUP_PROTECTION, and adds a
platform-specific retention-enable path that waits for standby
retention acknowledgement.

Enables the existing backup SRAM sample for STM32N6570-DK and
Nucleo N657X0-Q secure-boot board variants.

Tested on nuclea board and a custom stm32n6board