### PR TITLE
samples: amp_audio_loopback: Increase INITIAL_BLOCKS

### DIFF
--- a/samples/boards/nxp/adsp/rtxxx/amp_audio_loopback/remote/src/main.c
+++ b/samples/boards/nxp/adsp/rtxxx/amp_audio_loopback/remote/src/main.c
@@ -20,7 +20,7 @@
 #define NUMBER_OF_CHANNELS  2
 /* Such block length provides an echo with the delay of 100 ms. */
 #define SAMPLES_PER_BLOCK   ((SAMPLE_FREQUENCY / 10) * NUMBER_OF_CHANNELS)
-#define INITIAL_BLOCKS      2
+#define INITIAL_BLOCKS      4
 #define TIMEOUT             1000
 
 #define BLOCK_SIZE  (BYTES_PER_SAMPLE * SAMPLES_PER_BLOCK)


### PR DESCRIPTION
Increase the `INITIAL_BLOCKS` constant in the `amp_audio_loopback` sample from 2 to 4.

This reflects the double buffering approach in the `i2s_mcux_flexcomm` driver's TX path (introduced with https://github.com/zephyrproject-rtos/zephyr/pull/99696), as it now requires more buffers to be enqueued, because it now effectively keeps more buffers in flight.

Manually tested on `mimxrt685_evk/mimxrt688s/hifi4`.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/111047.