### PR TITLE
samples: drivers: audio: dmic: fix buffer size type on 64-bit targets

### DIFF
--- a/samples/drivers/audio/dmic/src/main.c
+++ b/samples/drivers/audio/dmic/src/main.c
@@ -54,7 +54,7 @@ static int do_pdm_transfer(const struct device *dmic_dev,
 
 	for (int i = 0; i < block_count; ++i) {
 		void *buffer;
-		uint32_t size;
+		size_t size;
 
 		ret = dmic_read(dmic_dev, 0, &buffer, &size, READ_TIMEOUT);
 		if (ret < 0) {


### PR DESCRIPTION
`dmic_read()` takes a `size_t` pointer for the received buffer size, but the sample passes the address of a `uint32_t`. On 32-bit targets the types happen to coincide; on LP64 targets the driver's 8-byte store tramples the stack slot adjacent to `size` (in practice the `buffer` pointer) and the subsequent `memcpy()` faults on a `NULL` source.

Reproduced on `qemu_cortex_a53` with an out-of-tree DMIC driver: the sample crashes with a data abort on the first read, and completes both its mono and stereo rounds once `size` is declared `size_t`.

Assisted-by: Claude:fable-5