### PR TITLE
scripts/build: allow whitespace between function name and parenthesis

### DIFF
--- a/scripts/build/parse_syscalls.py
+++ b/scripts/build/parse_syscalls.py
@@ -36,7 +36,7 @@ regex_flags = re.MULTILINE | re.VERBOSE
 syscall_regex = re.compile(
     r'''
 (?:__syscall|__syscall_always_inline)\s+   # __syscall attribute, must be first
-([^(]+)                                    # type and name of system call (split later)
+([^(]+?)\s*                                # type and name of system call (split later)
 [(]                                        # Function opening parenthesis
 ([^)]*)                                    # Arg list (split later)
 [)]                                        # Closing parenthesis

--- a/tests/cmake/syscalls/main.h
+++ b/tests/cmake/syscalls/main.h
@@ -13,4 +13,9 @@ __syscall void
 test_wrapped(int foo);
 /* clang-format on */
 
+/* Whitespace between symbol name and arguments */
+/* clang-format off */
+__syscall void test_arguments (void);
+/* clang-format on */
+
 #include <zephyr/syscalls/main.h>


### PR DESCRIPTION
This commit changes the syscall regex to allow whitespace between a syscall's function name and the opening parenthesis of the argument list.