### PR TITLE
FRDM-MCXL255: LPUART support for CM33

### DIFF
--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255-pinctrl.dtsi
@@ -16,6 +16,16 @@
 		};
 	};
 
+	pinmux_lpuart1: pinmux_lpuart1 {
+		group0 {
+			pinmux = <LPUART1_RXD_P3_4>,
+				 <LPUART1_TXD_P2_6>;
+			drive-strength = "low";
+			slew-rate = "fast";
+			input-enable;
+		};
+	};
+
 	pinmux_aon_lpuart0: pinmux_aon_lpuart0 {
 		group0 {
 			pinmux = <AON_LPUART0_TX_P0_6>,

--- a/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
+++ b/boards/nxp/frdm_mcxl255/frdm_mcxl255_mcxl255_cpu0.dtsi
@@ -92,6 +92,13 @@
 	pinctrl-names = "default";
 };
 
+&lpuart1 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&pinmux_lpuart1>;
+	pinctrl-names = "default";
+};
+
 &aon_lpuart0 {
 	status = "disabled";
 	current-speed = <115200>;


### PR DESCRIPTION
Add LPUART1 support for the FRDM-MCXL255 CM33.

This PR enables the existing MCXL255 LPUART1 devicetree node and configures
the required pinctrl. LPUART0 was already implemented during the board
enablement and remains the default console.

Tested with:
- samples/hello_world on frdm_mcxl255/mcxl255/cpu0