### PR TITLE
cmake: honor an explicitly selected Zephyr SDK

### DIFF
--- a/cmake/modules/FindZephyr-sdk.cmake
+++ b/cmake/modules/FindZephyr-sdk.cmake
@@ -78,8 +78,13 @@ if((${ZEPHYR_TOOLCHAIN_VARIANT} MATCHES "^zephyr/?") OR
     # To support Zephyr SDK tools (DTC, and other tools) with 3rd party toolchains
     # then we keep track of current toolchain variant.
     set(ZEPHYR_CURRENT_TOOLCHAIN_VARIANT ${ZEPHYR_TOOLCHAIN_VARIANT})
+    # When ZEPHYR_SDK_INSTALL_DIR is set, the Zephyr SDK must be located there.
+    # Restrict the search to this location with NO_DEFAULT_PATH so that an
+    # explicitly selected, but incompatible, SDK results in a clear error
+    # instead of silently falling back to another SDK found elsewhere (for
+    # example in the CMake package registry).
     find_package(Zephyr-sdk ${Zephyr-sdk_FIND_VERSION_COMPLETE}
-                 REQUIRED QUIET CONFIG HINTS ${ZEPHYR_SDK_INSTALL_DIR}
+                 REQUIRED QUIET CONFIG HINTS ${ZEPHYR_SDK_INSTALL_DIR} NO_DEFAULT_PATH
     )
     if(DEFINED ZEPHYR_CURRENT_TOOLCHAIN_VARIANT)
       set(ZEPHYR_TOOLCHAIN_VARIANT ${ZEPHYR_CURRENT_TOOLCHAIN_VARIANT})


### PR DESCRIPTION
When `ZEPHYR_SDK_INSTALL_DIR` is set, the Zephyr SDK is looked up with `find_package()` using `HINTS`. Since `HINTS` does not prevent the other default search locations from being used, an explicitly selected but incompatible SDK was silently ignored: `find_package()` fell through to another SDK found elsewhere (for example in the CMake package registry), while `ZEPHYR_SDK_INSTALL_DIR` kept pointing at the selected directory. This produced confusing output such as a version being reported that did not match the selected directory.

Restrict the lookup to `ZEPHYR_SDK_INSTALL_DIR` with `NO_DEFAULT_PATH` so that an explicitly selected SDK is used exactly, and an incompatible one results in a clear error instead of a silent fallback. Pointing `ZEPHYR_SDK_INSTALL_DIR` at a directory containing multiple SDKs keeps working, as `HINTS` still selects the best compatible SDK below it.

---

Before:
```shell
$ west build -p -b mimxrt1064_evk samples/hello_world -- -DZEPHYR_SDK_INSTALL_DIR=/home/pdgendt/.local/opt/zephyr-sdk-0.17.4
...
-- Found host-tools: zephyr 1.0.1 (/home/pdgendt/.local/opt/zephyr-sdk-0.17.4)
-- Found toolchain: zephyr 1.0.1 (/home/pdgendt/.local/opt/zephyr-sdk-0.17.4)
-- Found Dtc: /home/pdgendt/.local/opt/zephyr-sdk-0.17.4/sysroots/x86_64-pokysdk-linux/usr/bin/dtc (found suitable version "1.7.0", minimum required is "1.4.6")
...
```

After:
```shell
$ west build -p -b mimxrt1064_evk samples/hello_world -- -DZEPHYR_SDK_INSTALL_DIR=/home/pdgendt/.local/opt/zephyr-sdk-0.17.4
...
CMake Error at /home/pdgendt/zephyrproject/zephyr/cmake/modules/FindZephyr-sdk.cmake:86 (find_package):
  Could not find a configuration file for package "Zephyr-sdk" that is
  compatible with requested version "1.0".

  The following configuration files were considered but not accepted:

    /home/pdgendt/.local/opt/zephyr-sdk-0.17.4/cmake/Zephyr-sdkConfig.cmake, version: 0.17.4
      The version found is not compatible with the version requested.
...
```