### PR TITLE
samples: net sockets coap_upload: Be explicit about offsetting pointer

### DIFF
--- a/samples/net/sockets/coap_upload/src/main.c
+++ b/samples/net/sockets/coap_upload/src/main.c
@@ -85,7 +85,8 @@ static int block_payload_cb(size_t offset, const uint8_t **payload, size_t *len,
 		return -EINVAL;
 	}
 
-	*payload = LOREM_IPSUM_SHORT + offset;
+	*payload = LOREM_IPSUM_SHORT;
+	*payload += (intptr_t)offset;
 
 	data_left = LOREM_IPSUM_SHORT_STRLEN - offset;
 	if (data_left <= *len) {


### PR DESCRIPTION
Let's be explicit about offsetting the pointer into the string, to avoid a warning by the compiler in code it considers may be a programming bug:
`error: adding 'size_t' (aka 'unsigned int') to a string does not append to the string`

Can be reproduced w
```
ZEPHYR_TOOLCHAIN_VARIANT=host/llvm cmake -GNinja -DBOARD=native_sim ../samples/net/sockets/coap_upload/
ninja
```

can be seen failing in main's CI:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/29970525128/job/89145988629#step:12:1254

Note that since 
* https://github.com/zephyrproject-rtos/zephyr/pull/114093

we build and run both with clang and gcc by default in the normal twister workflow