### PR TITLE
tests: net: socket: tls_configurations: Limit to one toolchain

### DIFF
--- a/tests/net/socket/tls_configurations/tests.yaml
+++ b/tests/net/socket/tls_configurations/tests.yaml
@@ -6,6 +6,9 @@ common:
     - native_sim
   integration_platforms:
     - native_sim
+  integration_toolchains:
+    # Only build/run with gcc so we don't try to run in parallel (in the same port) with clang
+    - host/gnu
   harness: pytest
 tests:
   net.sockets.tls12.psk_kex:


### PR DESCRIPTION
Limit these tests to be built and run with just one toolchain. 

a) more importantly, each sub-test assumes there is no duplicate of itself running at the same time, as the subtest hardcodes the port being used, and another running in parallel will result in a port collision, and the test failing to start the OpenSLL server.
b) there seems to be little practical benefit of re-running all these tests variations with 2 toolchains.

The tests can be seen failing randomly (depending on twister execution order) in CI here:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/29970525128/job/89145988297#step:12:1381

These tests started failing due to:
* #114093