### PR TITLE
dts: nordic: nrf7120: Add default memory region for vtf monitoring

### DIFF
--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -149,43 +149,58 @@
 		};
 #endif
 
-		cpuapp_sram: memory@20000000 {
+		sram: memory@20000000 {
 			compatible = "mmio-sram";
 			reg = <0x20000000 DT_SIZE_K(1016)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x20000000 0xfe000>;
 
-			ram00_sram: memory@0 {
+			cpuapp_sram: memory@0 {
 				compatible = "mmio-sram";
-				reg = <0x0 DT_SIZE_K(512)>;
+				reg = <0x0 (DT_SIZE_K(1016) - 0x20)>;
 				#address-cells = <1>;
 				#size-cells = <1>;
-				ranges = <0x0 0x0 DT_SIZE_K(512)>;
+				ranges = <0x0 0x0 (DT_SIZE_K(1016) - 0x20)>;
+
+				ram00_sram: memory@0 {
+					compatible = "mmio-sram";
+					reg = <0x0 DT_SIZE_K(512)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+					ranges = <0x0 0x0 DT_SIZE_K(512)>;
+				};
+
+				ram01_sram: memory@80000 {
+					compatible = "mmio-sram";
+					reg = <0x80000 DT_SIZE_K(256)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+					ranges = <0x0 0x80000 DT_SIZE_K(256)>;
+				};
+
+				ram02_sram: memory@c0000 {
+					compatible = "mmio-sram";
+					reg = <0xc0000 DT_SIZE_K(128)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+					ranges = <0x0 0xc0000 DT_SIZE_K(128)>;
+				};
+
+				ram03_sram: memory@e0000 {
+					compatible = "mmio-sram";
+					reg = <0xe0000 (DT_SIZE_K(120) - 0x20)>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+					ranges = <0x0 0xe0000 (DT_SIZE_K(120) - 0x20)>;
+				};
 			};
 
-			ram01_sram: memory@80000 {
-				compatible = "mmio-sram";
-				reg = <0x80000 DT_SIZE_K(256)>;
-				#address-cells = <1>;
-				#size-cells = <1>;
-				ranges = <0x0 0x80000 DT_SIZE_K(256)>;
-			};
-
-			ram02_sram: memory@c0000 {
-				compatible = "mmio-sram";
-				reg = <0xc0000 DT_SIZE_K(128)>;
-				#address-cells = <1>;
-				#size-cells = <1>;
-				ranges = <0x0 0xc0000 DT_SIZE_K(128)>;
-			};
-
-			ram03_sram: memory@e0000 {
-				compatible = "mmio-sram";
-				reg = <0xe0000 DT_SIZE_K(120)>;
-				#address-cells = <1>;
-				#size-cells = <1>;
-				ranges = <0x0 0xe0000 DT_SIZE_K(120)>;
+			vtf_region_default: memory@fdfe0 {
+				compatible = "zephyr,memory-region", "mmio-sram";
+				reg = <0xfdfe0 0x20>;
+				ranges = <0x0 0xfdfe0 0x20>;
+				zephyr,memory-region = "NRF_VTF_REGION";
 			};
 		};
 


### PR DESCRIPTION
vtf monitoring requires a default address that can be accessed from app and wifi cores. vtf_region_default is set to be top unallocated memory in RAM03.