### PR TITLE
drivers: watchdog: mcux_rtwdog: Add WDT_OPT_PAUSE_IN_SLEEP support

### DIFF
--- a/drivers/watchdog/wdt_mcux_rtwdog.c
+++ b/drivers/watchdog/wdt_mcux_rtwdog.c
@@ -53,10 +53,8 @@ static int mcux_rtwdog_setup(const struct device *dev, uint8_t options)
 		return -EBUSY;
 	}
 
-	if ((options & WDT_OPT_PAUSE_IN_SLEEP) != 0U) {
-		LOG_ERR("Not support WDT_OPT_PAUSE_IN_SLEEP");
-		return -ENOTSUP;
-	}
+	data->wdog_config.workMode.enableWait = ((options & WDT_OPT_PAUSE_IN_SLEEP) == 0U);
+	data->wdog_config.workMode.enableStop = ((options & WDT_OPT_PAUSE_IN_SLEEP) == 0U);
 
 	data->wdog_config.workMode.enableDebug = ((options & WDT_OPT_PAUSE_HALTED_BY_DBG) == 0U);
 


### PR DESCRIPTION
The RTWDOG driver previously rejected WDT_OPT_PAUSE_IN_SLEEP with -ENOTSUP, even though the hardware supports stopping the counter in low-power modes via workMode.enableWait and workMode.enableStop.

Map WDT_OPT_PAUSE_IN_SLEEP to both enableWait and enableStop fields.