### PR TITLE
kconfig: fix example in help text of BUILD_OUTPUT_ADJUST_LMA

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -922,7 +922,7 @@ config BUILD_OUTPUT_ADJUST_LMA
 	  DT_CHOSEN_IMAGE_<name> := <name>,<name>-partition
 	  DT_CHOSEN_Z_FLASH := zephyr,flash
 	  config BUILD_OUTPUT_ADJUST_LMA
-	    default "$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_M4))-\
+	    default "$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_<name>))-\
 	             $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))"
 
 config BUILD_OUTPUT_ADJUST_LMA_SECTIONS


### PR DESCRIPTION
The help text for BUILD_OUTPUT_ADJUST_LMA used `<name>` as placeholder in the example, but one part of the example used an actual name instead of the placeholder.

Fix example by using the `<name>` placeholder everywhere.