### PR TITLE
treewide: use autogenerated Kconfig variables for compatibles

### DIFF
--- a/drivers/ethernet/nxp_imx_netc/Kconfig
+++ b/drivers/ethernet/nxp_imx_netc/Kconfig
@@ -12,10 +12,9 @@ menuconfig ETH_NXP_IMX_NETC
 
 if ETH_NXP_IMX_NETC
 
-DT_GIC_ITS_COMPAT := arm,gic-v3-its
 DT_NETC_PATH := $(dt_nodelabel_path,netc)
 DT_NETC_INT_PARENT_PATH := $(dt_node_ph_prop_path,$(DT_NETC_PATH),msi-parent)
-DT_NETC_INT_IS_GIC := $(dt_node_has_compat,$(DT_NETC_INT_PARENT_PATH),$(DT_GIC_ITS_COMPAT))
+DT_NETC_INT_IS_GIC := $(dt_node_has_compat,$(DT_NETC_INT_PARENT_PATH),$(DT_COMPAT_ARM_GIC_V3_ITS))
 
 config ETH_NXP_IMX_NETC_MSI_GIC
 	bool

--- a/drivers/timer/Kconfig.cmsdk_apb_timer
+++ b/drivers/timer/Kconfig.cmsdk_apb_timer
@@ -3,12 +3,11 @@
 
 DT_CHOSEN_ZEPHYR_SYSTEM_TIMER := zephyr,system-timer
 DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
-DT_COMPAT_CMSDK_TIMER := arm,cmsdk-timer
 
 config CMSDK_APB_TIMER
 	bool "CMSDK APB Timer as system clock"
 	depends on $(dt_chosen_enabled,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
-	depends on $(dt_node_has_compat,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH),$(DT_COMPAT_CMSDK_TIMER))
+	depends on $(dt_node_has_compat,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH),$(DT_COMPAT_ARM_CMSDK_TIMER))
 	select TICKLESS_CAPABLE
 	default y if SYS_CLOCK_EXISTS
 	help

--- a/drivers/timer/Kconfig.mcux_lptmr
+++ b/drivers/timer/Kconfig.mcux_lptmr
@@ -6,7 +6,6 @@
 
 DT_CHOSEN_ZEPHYR_SYSTEM_TIMER := zephyr,system-timer
 DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
-DT_COMPAT_NXP_LPTMR := nxp,lptmr
 
 config MCUX_LPTMR_TIMER
 	bool "MCUX LPTMR timer"

--- a/drivers/timer/Kconfig.mcux_rtc_jdp
+++ b/drivers/timer/Kconfig.mcux_rtc_jdp
@@ -3,7 +3,6 @@
 
 DT_CHOSEN_ZEPHYR_SYSTEM_TIMER := zephyr,system-timer
 DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
-DT_COMPAT_NXP_RTC_JDP := nxp,rtc-jdp
 
 config MCUX_RTC_JDP_TIMER
 	bool "MCUX RTC JDP system timer"

--- a/drivers/timer/Kconfig.mcux_stm
+++ b/drivers/timer/Kconfig.mcux_stm
@@ -3,7 +3,6 @@
 
 DT_CHOSEN_ZEPHYR_SYSTEM_TIMER := zephyr,system-timer
 DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
-DT_COMPAT_NXP_STM := nxp,stm
 
 config MCUX_STM_TIMER
 	bool "MCUX STM system timer"

--- a/drivers/timer/Kconfig.mcux_sysctr
+++ b/drivers/timer/Kconfig.mcux_sysctr
@@ -3,7 +3,6 @@
 
 DT_CHOSEN_ZEPHYR_SYSTEM_TIMER := zephyr,system-timer
 DT_CHOSEN_ZEPHYR_SYSTEM_TIMER_PATH := $(dt_chosen_path,$(DT_CHOSEN_ZEPHYR_SYSTEM_TIMER))
-DT_COMPAT_NXP_SYSCTR := nxp,sysctr
 
 config MCUX_SYSCTR_TIMER
 	bool "MCUX System Counter (SYS_CTR) timer"

--- a/subsys/secure_storage/Kconfig.its_store
+++ b/subsys/secure_storage/Kconfig.its_store
@@ -8,14 +8,13 @@ DT_ITS_PARTITION := $(dt_chosen_path,secure_storage_its_partition)
 DT_CHOSEN_Z_SETTINGS_PARTITION := zephyr,settings-partition
 DT_SETTINGS_PARTITIION := $(dt_chosen_path,$(DT_CHOSEN_Z_SETTINGS_PARTITION))
 DT_STORAGE_PARTITION := $(dt_nodelabel_path,storage_partition)
-DT_COMPAT_Z_MAPPED_PARTITION := zephyr,mapped-partition
 
 config SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_ZMS
 	bool "ITS store module implementation using ZMS for storage"
 	depends on FLASH_HAS_DRIVER_ENABLED \
 		&& $(dt_path_enabled,$(DT_ITS_PARTITION)) \
 		&& ($(dt_node_has_compat,$(dt_node_parent,$(DT_ITS_PARTITION)),fixed-partitions) \
-		|| $(dt_node_has_compat,$(DT_ITS_PARTITION),$(DT_COMPAT_Z_MAPPED_PARTITION)))
+		|| $(dt_node_has_compat,$(DT_ITS_PARTITION),$(DT_COMPAT_ZEPHYR_MAPPED_PARTITION)))
 	depends on ZMS
 	help
 	  This implementation of the ITS store module makes direct use of ZMS for storage.
@@ -31,10 +30,10 @@ config SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_SETTINGS
 	depends on FLASH_HAS_DRIVER_ENABLED \
 		&& ($(dt_path_enabled,$(DT_SETTINGS_PARTITIION)) \
 		&& ($(dt_node_has_compat,$(dt_node_parent,$(DT_SETTINGS_PARTITIION)),fixed-partitions) \
-		|| $(dt_node_has_compat,$(DT_SETTINGS_PARTITIION),$(DT_COMPAT_Z_MAPPED_PARTITION))) \
+		|| $(dt_node_has_compat,$(DT_SETTINGS_PARTITIION),$(DT_COMPAT_ZEPHYR_MAPPED_PARTITION))) \
 		|| ($(dt_path_enabled,$(DT_STORAGE_PARTITION)) \
 		&& ($(dt_node_has_compat,$(dt_node_parent,$(DT_STORAGE_PARTITION)),fixed-partitions) \
-		|| $(dt_node_has_compat,$(DT_STORAGE_PARTITION),$(DT_COMPAT_Z_MAPPED_PARTITION)))))
+		|| $(dt_node_has_compat,$(DT_STORAGE_PARTITION),$(DT_COMPAT_ZEPHYR_MAPPED_PARTITION)))))
 	depends on SETTINGS && !SETTINGS_NONE
 
 config SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_NONE

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -50,11 +50,10 @@ config SETTINGS_ENCODE_LEN
 	bool
 
 DT_CHOSEN_ZEPHYR_SETTINGS_PARTITION := zephyr,settings-partition
-DT_ZEPHYR_RETENTION := zephyr,retention
 
 config SETTINGS_SUPPORTED_RETENTION
 	bool
-	default y if RETENTION && $(dt_chosen_has_compat,$(DT_CHOSEN_ZEPHYR_SETTINGS_PARTITION),$(DT_ZEPHYR_RETENTION))
+	default y if RETENTION && $(dt_chosen_has_compat,$(DT_CHOSEN_ZEPHYR_SETTINGS_PARTITION),$(DT_COMPAT_ZEPHYR_RETENTION))
 
 choice SETTINGS_BACKEND
 	prompt "Storage back-end"


### PR DESCRIPTION
Replace manual definitions of variables wrapping compatible names in Kconfig all around tree with use of the variables that get generated automatically by the build system (as `<build dir>/Kconfig/Kconfig.dts`).