### PR TITLE
Add frdm mcxa577 flexio support

### DIFF
--- a/boards/nxp/frdm_mcxa577/board.c
+++ b/boards/nxp/frdm_mcxa577/board.c
@@ -347,6 +347,11 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kFRO_HF_to_FLEXCAN0);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexio0))
+	CLOCK_SetClockDiv(kCLOCK_DivFLEXIO0, 1u);
+	CLOCK_AttachClk(kFRO_HF_to_FLEXIO0);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ewm0))
 	RESET_ReleasePeripheralReset(kEWM0_RST_SHIFT_RSTn);
 	CLOCK_SetupFRO16KClocking(kCLKE_16K_SYSTEM | kCLKE_16K_COREMAIN | kCLKE_16K_VBAT);

--- a/boards/nxp/frdm_mcxa577/doc/index.rst
+++ b/boards/nxp/frdm_mcxa577/doc/index.rst
@@ -38,6 +38,25 @@ are tested on this board:
 - :ref:`lcd_par_s035` - supports the Display interface.  This board uses the
   MIPI_DBI interface of the shield, connected to the FlexIO on-chip peripheral.
 
+Display Support
+***************
+
+The frdm_mcxa577 board supports the following in-tree display module(s).
+
+NXP LCD_PAR_S035
+================
+
+The :ref:`lcd_par_s035` connects to the board's LCD socket, and is driven over
+the MIPI_DBI 8080 parallel interface using the FlexIO on-chip peripheral. The
+display sample can be built for this module like so:
+
+.. zephyr-app-commands::
+   :board: frdm_mcxa577
+   :shield: lcd_par_s035_8080
+   :zephyr-app: samples/drivers/display
+   :goals: build
+   :compact:
+
 Connections and IOs
 ===================
 

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
@@ -5,6 +5,16 @@
 
 #include <nxp/mcx/MCXA577VPN-pinctrl.h>
 
+/* P2_30 and P2_31 exist on the MCXA577VPN 169-ball BGA (balls L7 and L8)
+ * but are not yet present in the upstream hal/nxp pinctrl header.
+ */
+#ifndef P2_30
+#define P2_30 A15X_MUX('2', 30, 0)
+#endif
+#ifndef P2_31
+#define P2_31 A15X_MUX('2', 31, 0)
+#endif
+
 &pinctrl {
 	pinmux_lpuart0: pinmux_lpuart0 {
 		group0 {
@@ -155,6 +165,49 @@
 			slew-rate = "fast";
 			drive-strength = "low";
 			input-enable;
+		};
+	};
+
+	pinmux_flexio_lcd: pinmux_flexio_lcd {
+		group0 {
+			pinmux = <FLEXIO0_D0_P0_8>,
+				 <FLEXIO0_D1_P0_9>,
+				 <FLEXIO0_D2_P0_10>,
+				 <FLEXIO0_D3_P0_11>,
+				 <FLEXIO0_D4_P0_12>,
+				 <FLEXIO0_D5_P0_13>,
+				 <FLEXIO0_D6_P0_22>,
+				 <FLEXIO0_D7_P0_23>,
+				 <FLEXIO0_D8_P2_0>,
+				 <FLEXIO0_D9_P2_1>,
+				 <FLEXIO0_D10_P2_2>,
+				 <FLEXIO0_D11_P3_3>,
+				 <FLEXIO0_D12_P3_4>,
+				 <FLEXIO0_D13_P2_5>,
+				 <FLEXIO0_D14_P2_6>,
+				 <FLEXIO0_D15_P4_7>,
+				 <P2_24>,
+				 <P2_30>,
+				 <P2_31>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+		};
+
+		group1 {
+			pinmux = <FLEXIO0_D26_P2_18>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+			bias-pull-up;
+		};
+
+		group2 {
+			pinmux = <FLEXIO0_D27_P2_19>;
+			slew-rate = "slow";
+			drive-strength = "low";
+			input-enable;
+			bias-pull-up;
 		};
 	};
 };

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
@@ -210,4 +210,12 @@
 			bias-pull-up;
 		};
 	};
+
+	pinmux_flexio_pwm: pinmux_flexio_pwm {
+		group0 {
+			pinmux = <FLEXIO0_D14_P2_6>;
+			drive-strength = "low";
+			slew-rate = "slow";
+		};
+	};
 };

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
@@ -63,6 +63,19 @@
 		};
 	};
 
+	/*
+	 * This node describes the GPIO pins of the LCD-PAR-S035 panel 8080 interface.
+	 */
+	nxp_lcd_8080_connector: lcd-8080-connector {
+		compatible = "nxp,lcd-8080";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <9 0 &gpio2 8 0>,	/* Pin 9, LCD touch INT */
+			   <10 0 &gpio2 4 0>,	/* Pin 10, LCD backlight control */
+			   <11 0 &gpio2 30 0>;	/* Pin 11, LCD and touch reset */
+	};
+
 	arduino_header: arduino-connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
@@ -282,4 +295,26 @@
 		reg = <0x48 0x0236 0x152a0090>;
 		status = "okay";
 	};
+};
+
+&flexio0 {
+	status = "okay";
+};
+
+nxp_8080_touch_panel_i2c: &lpi2c3 {};
+
+zephyr_mipi_dbi_parallel: &flexio0_lcd {
+	/* DMA channel 0, muxed to FlexIO TX */
+	dmas = <&edma0 0 71>;
+	dma-names = "tx";
+	shifters-count = <4>;
+	timers-count = <1>;
+	enwr-pin = <27>;
+	rd-pin = <26>;
+	data-pin-start = <0>;
+	reset-gpios = <&gpio2 30 GPIO_ACTIVE_HIGH>;
+	cs-gpios = <&gpio2 24 GPIO_ACTIVE_HIGH>;
+	rs-gpios = <&gpio2 31 GPIO_ACTIVE_HIGH>;
+	pinctrl-0 = <&pinmux_flexio_lcd>;
+	pinctrl-names = "default";
 };

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
@@ -31,4 +31,5 @@ supported:
   - dac
   - rtc
   - crc
+  - pwm
 vendor: nxp

--- a/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa5x_common.dtsi
@@ -636,6 +636,12 @@
 			compatible = "nxp,mipi-dbi-flexio-lcdif";
 			status = "disabled";
 		};
+
+		flexio0_pwm: flexio0-pwm {
+			compatible = "nxp,flexio-pwm";
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
 	};
 
 	rtc: rtc@ee000 {

--- a/samples/drivers/display/tests.yaml
+++ b/samples/drivers/display/tests.yaml
@@ -110,6 +110,7 @@ tests:
       - platform:mcx_n5xx_evk/mcxn547/cpu0:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxn236/mcxn236:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxa156/mcxa156:SHIELD=lcd_par_s035_8080
+      - platform:frdm_mcxa577:SHIELD=lcd_par_s035_8080
       - platform:frdm_rw612/rw612:SHIELD=lcd_par_s035_spi
       - platform:ek_ra8d1:SHIELD=rtkmipilcdb00000be
       - platform:ek_ra8d1:SHIELD=rtk7eka6m3b00001bu

--- a/tests/drivers/display/display_check/tests.yaml
+++ b/tests/drivers/display/display_check/tests.yaml
@@ -98,6 +98,7 @@ tests:
       - platform:mcx_n5xx_evk/mcxn547/cpu0:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxn236/mcxn236:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxa156/mcxa156:SHIELD=lcd_par_s035_8080
+      - platform:frdm_mcxa577:SHIELD=lcd_par_s035_8080
       - platform:frdm_rw612/rw612:SHIELD=lcd_par_s035_spi
       - platform:ek_ra8d1:SHIELD=rtkmipilcdb00000be
       - platform:ek_ra8d1:SHIELD=rtk7eka6m3b00001bu

--- a/tests/drivers/pwm/pwm_api/boards/frdm_mcxa577_flexio_pwm.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/frdm_mcxa577_flexio_pwm.overlay
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* PWM output in P2_6(J8-27). */
+/ {
+	aliases {
+		pwm-test = &flexio0_pwm;
+	};
+};
+
+&flexio0_pwm {
+	status = "okay";
+	pinctrl-0 = <&pinmux_flexio_pwm>;
+	pinctrl-names = "default";
+
+	pwm_0 {
+		pin-id = <14>;
+		prescaler = <1>;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/tests.yaml
+++ b/tests/drivers/pwm/pwm_api/tests.yaml
@@ -20,6 +20,7 @@ tests:
       - platform:mimxrt1180_evk/mimxrt1189/cm7:DTC_OVERLAY_FILE="boards/mimxrt1180_evk_flexio_pwm.overlay"
       - platform:frdm_mcxa366/mcxa366:DTC_OVERLAY_FILE="boards/frdm_mcxa366_flexio_pwm.overlay"
       - platform:frdm_mcxa266/mcxa266:DTC_OVERLAY_FILE="boards/frdm_mcxa266_flexio_pwm.overlay"
+      - platform:frdm_mcxa577:DTC_OVERLAY_FILE="boards/frdm_mcxa577_flexio_pwm.overlay"
       - platform:frdm_mcxe247/mcxe247:DTC_OVERLAY_FILE="boards/frdm_mcxe247_flexio_pwm.overlay"
       - platform:frdm_mcxe31b/mcxe31b:DTC_OVERLAY_FILE="boards/frdm_mcxe31b_flexio_pwm.overlay"
       - platform:frdm_imxrt1186/mimxrt1186/cm33:DTC_OVERLAY_FILE="boards/frdm_imxrt1186_flexio_pwm.overlay"
@@ -32,6 +33,7 @@ tests:
       - mimxrt1180_evk/mimxrt1189/cm7
       - frdm_mcxa366/mcxa366
       - frdm_mcxa266/mcxa266
+      - frdm_mcxa577
       - frdm_mcxe247
       - frdm_mcxe31b
       - frdm_imxrt1186/mimxrt1186/cm33

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 85d250e97c9319df6c8311f17d6d7eec9e6578e5
+      revision: 2e21c1747cb79933f6e28298cfcc397cdd785e85
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
enable flexio support: lcd and pwm.
tested below examples:
flexio lcd: samples/drivers/display
pwm: tests/drivers/pwm/pwm_api

