### PR TITLE
tests bsim bluetooth: Replace old header include

### DIFF
--- a/tests/bsim/babblekit/src/device.c
+++ b/tests/bsim/babblekit/src/device.c
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "argparse.h"
-#include "bs_types.h"
+#include "bsim_args_runner.h"
 
 unsigned int bk_device_get_number(void)
 {

--- a/tests/bsim/babblekit/src/sync.c
+++ b/tests/bsim/babblekit/src/sync.c
@@ -6,8 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
-#include "argparse.h"
-#include "bs_types.h"
+#include "bsim_args_runner.h"
 #include "bs_tracing.h"
 #include "time_machine.h"
 #include "bs_pc_backchannel.h"

--- a/tests/bsim/bluetooth/host/att/eatt/src/common.c
+++ b/tests/bsim/bluetooth/host/att/eatt/src/common.c
@@ -8,7 +8,7 @@
 
 #include "babblekit/testcase.h"
 #include "common.h"
-#include "argparse.h"
+#include "bsim_args_runner.h"
 
 struct bt_conn *default_conn;
 

--- a/tests/bsim/bluetooth/host/att/long_read/bs_sync.c
+++ b/tests/bsim/bluetooth/host/att/long_read/bs_sync.c
@@ -3,7 +3,7 @@
  */
 
 #include <stdint.h>
-#include <argparse.h>
+#include <bsim_args_runner.h>
 #include <posix_native_task.h>
 #include <bs_pc_backchannel.h>
 

--- a/tests/bsim/bluetooth/host/att/long_read/main.c
+++ b/tests/bsim/bluetooth/host/att/long_read/main.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <argparse.h>
+#include <bsim_args_runner.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>

--- a/tests/bsim/bluetooth/host/att/open_close/src/bs_sync.c
+++ b/tests/bsim/bluetooth/host/att/open_close/src/bs_sync.c
@@ -3,7 +3,7 @@
  */
 
 #include <stdint.h>
-#include <argparse.h>
+#include <bsim_args_runner.h>
 #include <posix_native_task.h>
 #include <bs_pc_backchannel.h>
 

--- a/tests/bsim/bluetooth/host/att/open_close/src/main.c
+++ b/tests/bsim/bluetooth/host/att/open_close/src/main.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <argparse.h>
+#include <bsim_args_runner.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/server/main.c
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/server/main.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <argparse.h>
+#include <bsim_args_runner.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>

--- a/tests/bsim/bluetooth/host/att/retry_on_sec_err/server/main.c
+++ b/tests/bsim/bluetooth/host/att/retry_on_sec_err/server/main.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <argparse.h>
+#include <bsim_args_runner.h>
 
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/logging/log.h>

--- a/tests/bsim/bluetooth/host/att/timeout/main.c
+++ b/tests/bsim/bluetooth/host/att/timeout/main.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <argparse.h>
+#include <bsim_args_runner.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/src/central.c
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/src/central.c
@@ -21,7 +21,7 @@
 #include "common.h"
 #include "settings.h"
 
-#include "argparse.h"
+#include "bsim_args_runner.h"
 
 #include "babblekit/testcase.h"
 #include "babblekit/flags.h"

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/src/peripheral.c
@@ -19,7 +19,7 @@
 #include "common.h"
 #include "settings.h"
 
-#include "argparse.h"
+#include "bsim_args_runner.h"
 #include "babblekit/testcase.h"
 #include "babblekit/flags.h"
 #include "babblekit/sync.h"

--- a/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/gatt_utils.c
@@ -5,7 +5,7 @@
  */
 
 #include "utils.h"
-#include "argparse.h"
+#include "bsim_args_runner.h"
 
 #include <zephyr/kernel.h>
 #include <zephyr/bluetooth/bluetooth.h>

--- a/tests/bsim/bluetooth/host/gatt/settings/src/main.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/main.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include "utils.h"
 #include "main.h"
-#include "argparse.h"
+#include "bsim_args_runner.h"
 #include "bs_pc_backchannel.h"
 #include "bstests.h"
 

--- a/tests/bsim/bluetooth/host/gatt/settings/src/settings.c
+++ b/tests/bsim/bluetooth/host/gatt/settings/src/settings.c
@@ -13,7 +13,7 @@
 #include <zephyr/settings/settings.h>
 #include <zephyr/types.h>
 #include "errno.h"
-#include "argparse.h"
+#include "bsim_args_runner.h"
 #include "posix_native_task.h"
 #include "nsi_host_trampolines.h"
 

--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
@@ -11,7 +11,7 @@
 #include "babblekit/testcase.h"
 #include "babblekit/flags.h"
 #include "bsim_args_runner.h"
-#include "argparse.h"
+#include "bsim_args_runner.h"
 
 extern enum bst_result_t bst_result;
 

--- a/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/src/main.c
@@ -30,7 +30,7 @@ LOG_MODULE_REGISTER(peripheral, LOG_LEVEL_INF);
 #include "bs_types.h"
 #include "bs_tracing.h"
 #include "bs_pc_backchannel.h"
-#include "argparse.h"
+#include "bsim_args_runner.h"
 
 #include "babblekit/testcase.h"
 

--- a/tests/bsim/bluetooth/host/misc/hfc/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/hfc/src/main.c
@@ -18,7 +18,7 @@
 
 #include "testlib/att_read.h"
 
-#include <argparse.h>		/* For get_device_nbr() */
+#include <bsim_args_runner.h>		/* For get_device_nbr() */
 #include "babblekit/testcase.h"
 #include "babblekit/flags.h"
 

--- a/tests/bsim/bluetooth/host/security/ccc_update/src/central.c
+++ b/tests/bsim/bluetooth/host/security/ccc_update/src/central.c
@@ -23,7 +23,7 @@
 #include "common.h"
 #include "settings.h"
 
-#include "argparse.h"
+#include "bsim_args_runner.h"
 #include "bs_pc_backchannel.h"
 
 #define CLIENT_CLIENT_CHAN 0

--- a/tests/bsim/bluetooth/host/security/ccc_update/src/common.c
+++ b/tests/bsim/bluetooth/host/security/ccc_update/src/common.c
@@ -6,7 +6,7 @@
 
 #include "common.h"
 
-#include "argparse.h"
+#include "bsim_args_runner.h"
 #include "bs_pc_backchannel.h"
 
 void backchannel_sync_send(uint channel, uint device_nbr)

--- a/tests/bsim/bluetooth/host/security/ccc_update/src/peripheral.c
+++ b/tests/bsim/bluetooth/host/security/ccc_update/src/peripheral.c
@@ -21,7 +21,7 @@
 #include "common.h"
 #include "settings.h"
 
-#include "argparse.h"
+#include "bsim_args_runner.h"
 #include "bs_pc_backchannel.h"
 
 #define GOOD_CLIENT_CHAN 0

--- a/tests/bsim/bluetooth/mesh/src/mesh_test.c
+++ b/tests/bsim/bluetooth/mesh/src/mesh_test.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "mesh_test.h"
-#include "argparse.h"
+#include "bsim_args_runner.h"
 #include <bs_pc_backchannel.h>
 #include "mesh/crypto.h"
 #include <zephyr/bluetooth/hci.h>

--- a/tests/bsim/bluetooth/mesh/src/test_beacon.c
+++ b/tests/bsim/bluetooth/mesh/src/test_beacon.c
@@ -11,7 +11,7 @@
 #include "mesh/mesh.h"
 #include "mesh/foundation.h"
 #include "mesh/crypto.h"
-#include "argparse.h"
+#include "bsim_args_runner.h"
 #include "mesh/proxy_cli.h"
 #include "mesh/proxy.h"
 

--- a/tests/bsim/bluetooth/mesh/src/test_blob.c
+++ b/tests/bsim/bluetooth/mesh/src/test_blob.c
@@ -8,7 +8,7 @@
 #include "friendship_common.h"
 #include "mesh/adv.h"
 #include "mesh/blob.h"
-#include "argparse.h"
+#include "bsim_args_runner.h"
 
 #define LOG_MODULE_NAME test_blob
 

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -8,7 +8,7 @@
 #include "mesh/dfu_slot.h"
 #include "mesh/dfu.h"
 #include "mesh/blob.h"
-#include "argparse.h"
+#include "bsim_args_runner.h"
 #include "dfu_blob_common.h"
 
 #define LOG_MODULE_NAME test_dfu

--- a/tests/bsim/bluetooth/mesh/src/test_friendship.c
+++ b/tests/bsim/bluetooth/mesh/src/test_friendship.c
@@ -9,7 +9,7 @@
 #include "mesh/transport.h"
 #include "mesh/va.h"
 #include <zephyr/sys/byteorder.h>
-#include "argparse.h"
+#include "bsim_args_runner.h"
 
 #include "friendship_common.h"
 

--- a/tests/bsim/bluetooth/mesh/src/test_heartbeat.c
+++ b/tests/bsim/bluetooth/mesh/src/test_heartbeat.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "mesh_test.h"
-#include "argparse.h"
+#include "bsim_args_runner.h"
 #include "mesh/net.h"
 #include "mesh/heartbeat.h"
 #include "mesh/lpn.h"

--- a/tests/bsim/bluetooth/mesh/src/test_lcd.c
+++ b/tests/bsim/bluetooth/mesh/src/test_lcd.c
@@ -15,7 +15,7 @@
 
 #include <mesh/access.h>
 #include <mesh/net.h>
-#include "argparse.h"
+#include "bsim_args_runner.h"
 
 LOG_MODULE_REGISTER(test_lcd, LOG_LEVEL_INF);
 

--- a/tests/bsim/bluetooth/mesh/src/test_provision.c
+++ b/tests/bsim/bluetooth/mesh/src/test_provision.c
@@ -11,7 +11,7 @@
 #include "mesh/net.h"
 #include "mesh/crypto.h"
 #include "mesh/prov.h"
-#include "argparse.h"
+#include "bsim_args_runner.h"
 #include <bs_pc_backchannel.h>
 #include <time_machine.h>
 

--- a/tests/bsim/bluetooth/samples/battery_service/src/central_test.c
+++ b/tests/bsim/bluetooth/samples/battery_service/src/central_test.c
@@ -10,7 +10,7 @@
 #include "bs_tracing.h"
 #include "time_machine.h"
 #include "bstests.h"
-#include <argparse.h>
+#include <bsim_args_runner.h>
 
 #include <zephyr/types.h>
 #include <stddef.h>


### PR DESCRIPTION
In 3a4bebacb143c036555b8f8c368315690e761c33 `argparse.h` was superseded by `bsim_args_runner.h` 
Let's use the new one instead.

In the babblekit code we also remove another two unnecessary includes. Otherwise this is just a plain search and replace.

(`argparse.h` had been left as a passthru to `bsim_args_runner.h` to retain backwards compatibility)