### PR TITLE
samples: net: zperf: Add deterministic loopback throughput check

### DIFF
--- a/samples/net/zperf/Kconfig
+++ b/samples/net/zperf/Kconfig
@@ -68,6 +68,17 @@ config ZPERF_LOOPBACK_SELFTEST_PACKET_SIZE
 	  Near-MTU packets also better expose data-touching costs (checksums,
 	  buffer walking) than tiny packets.
 
+config ZPERF_LOOPBACK_SELFTEST_FRAG_PACKET_SIZE
+	int "Loopback selftest fragmented-run payload size (bytes)"
+	default 2000
+	range 1 16384
+	help
+	  Payload size for the extra UDP runs that intentionally exceed
+	  CONFIG_NET_LOOPBACK_MTU to exercise IP fragmentation and reassembly.
+	  These runs are only performed when CONFIG_NET_IPV4_FRAGMENT /
+	  CONFIG_NET_IPV6_FRAGMENT are enabled. Keep it above the MTU (so the
+	  datagram actually fragments) and below CONFIG_NET_ZPERF_MAX_PACKET_SIZE.
+
 config ZPERF_LOOPBACK_SELFTEST_RATE_KBPS
 	int "Loopback selftest target rate (kbps)"
 	default 0

--- a/samples/net/zperf/Kconfig
+++ b/samples/net/zperf/Kconfig
@@ -32,4 +32,53 @@ configdefault NRF_WIFI_DATA_HEAP_SIZE
 	default 30000 if NRF_WIFI_ZERO_COPY_TX
 	default 50000
 
+config ZPERF_LOOPBACK_SELFTEST
+	bool "Self-driven loopback throughput run"
+	depends on NET_ZPERF && NET_ZPERF_SERVER
+	help
+	  When enabled, the sample does not wait for shell input. Instead it
+	  starts an in-guest UDP and TCP receiver on the loopback interface,
+	  runs a client upload against it, and prints machine-parseable
+	  throughput results ("ZPERF-RESULT ...") followed by a "ZPERF-DONE"
+	  marker. Combined with QEMU icount mode this yields a deterministic,
+	  host-speed-independent throughput regression metric.
+
+if ZPERF_LOOPBACK_SELFTEST
+
+config ZPERF_LOOPBACK_SELFTEST_DURATION_MS
+	int "Loopback selftest transfer duration (ms)"
+	default 1000
+	help
+	  Duration of each (UDP and TCP) upload run.
+
+config ZPERF_LOOPBACK_SELFTEST_PACKET_SIZE
+	int "Loopback selftest packet size (bytes)"
+	default 1220
+	range 1 16384
+	help
+	  Payload size used for each upload. Keep it small enough that the IP
+	  packet (payload + IP + UDP headers) fits within CONFIG_NET_LOOPBACK_MTU
+	  unless IP fragmentation is enabled, and below
+	  CONFIG_NET_ZPERF_MAX_PACKET_SIZE. The default of 1220 is the IPv6 TCP
+	  MSS at a 1280 byte MTU (1280 - 40 IPv6 - 20 TCP): with it every write
+	  is one full-sized segment for both IPv4 and IPv6, so TCP throughput is
+	  comparable across families. Larger values (e.g. 1232) still fit the
+	  IPv4 MSS but exceed the IPv6 MSS, which splits each IPv6 write into a
+	  full segment plus a tiny runt and roughly halves IPv6 TCP throughput.
+	  Near-MTU packets also better expose data-touching costs (checksums,
+	  buffer walking) than tiny packets.
+
+config ZPERF_LOOPBACK_SELFTEST_RATE_KBPS
+	int "Loopback selftest target rate (kbps)"
+	default 0
+	help
+	  Target upload rate in kbps. Use 0 to send as fast as possible (best
+	  for measuring the maximum throughput / catching CPU-cost regressions).
+
+config ZPERF_LOOPBACK_SELFTEST_PORT
+	int "Loopback selftest server port"
+	default 5001
+
+endif # ZPERF_LOOPBACK_SELFTEST
+
 source "Kconfig.zephyr"

--- a/samples/net/zperf/README-loopback-icount.rst
+++ b/samples/net/zperf/README-loopback-icount.rst
@@ -150,13 +150,22 @@ Run through twister
 ===================
 
 The :file:`tests.yaml` scenario ``sample.net.zperf.loopback_icount`` uses the
-``console`` harness and records the two throughput values into the twister JSON
+``console`` harness and records the throughput values into the twister JSON
 report:
 
 .. code-block:: console
 
    ./scripts/twister -p qemu_x86 -s sample.net.zperf.loopback_icount \
        --outdir ../build/zperf_run
+
+The scenario is allowed on both ``qemu_x86`` (32-bit) and ``qemu_x86_64``
+(64-bit); run the latter for a 64-bit data point (for example to exercise the
+64-bit checksum fast path):
+
+.. code-block:: console
+
+   ./scripts/twister -p qemu_x86_64 -s sample.net.zperf.loopback_icount \
+       --outdir ../build/zperf_run64
 
 Baseline and regression gate
 ============================

--- a/samples/net/zperf/README-loopback-icount.rst
+++ b/samples/net/zperf/README-loopback-icount.rst
@@ -44,11 +44,27 @@ The runner lives in :file:`src/main.c`, guarded by
 
 #. Brings the network up itself (automatic init is disabled so the transfer does
    not race the bring-up).
-#. Starts a UDP receiver, runs a blocking UDP upload, stops the receiver, and
-   prints ``ZPERF-RESULT udp4_mbps=<value>``.
-#. Repeats the same for TCP and prints ``ZPERF-RESULT tcp4_mbps=<value>``.
-#. Repeats both over IPv6, printing ``ZPERF-RESULT udp6_mbps=<value>`` and
-   ``ZPERF-RESULT tcp6_mbps=<value>``.
+#. For each IP family, runs a sequence of transfers, each bracketed by starting
+   the matching receiver, running a blocking upload, and stopping the receiver,
+   and prints one ``ZPERF-RESULT <marker>_mbps=<value>`` line per transfer:
+
+   .. list-table::
+      :header-rows: 1
+
+      * - Marker
+        - Transfer
+      * - ``udp4`` / ``udp6``
+        - Baseline UDP, near-MTU payload (single, unfragmented datagram).
+      * - ``udp4_frag`` / ``udp6_frag``
+        - UDP with an oversized payload that forces **IP fragmentation** on TX
+          and reassembly on RX. Only run when the matching
+          :kconfig:option:`CONFIG_NET_IPV4_FRAGMENT` /
+          :kconfig:option:`CONFIG_NET_IPV6_FRAGMENT` is enabled.
+      * - ``tcp4`` / ``tcp6``
+        - Baseline TCP (Nagle on).
+      * - ``tcp4_nodelay`` / ``tcp6_nodelay``
+        - TCP with ``TCP_NODELAY`` (Nagle off) to cover the alternate send path.
+
 #. Prints a final ``ZPERF-DONE`` marker.
 
 Both IP families are exercised so a regression in either code path is caught.
@@ -57,6 +73,12 @@ loopback driver assigns both addresses to the loopback interface. For each
 family the receiver is bound to that loopback address (not just the interface's
 default address) so the client can connect to it. The IPv6 runs are skipped
 when :kconfig:option:`CONFIG_NET_IPV6` is disabled (and likewise for IPv4).
+
+Every upload is sent with a non-default socket priority
+(:c:enumerator:`NET_PRIORITY_VI`). Combined with more than one configured
+traffic class (see below) this routes the traffic through the per-traffic-class
+threads in ``net_tc.c`` instead of the caller's context, so that scheduling path
+is exercised on every run.
 
 The whole thing is configured by :file:`overlay-loopback-icount.conf`, which is
 layered on top of the existing :file:`overlay-loopback.conf`.
@@ -76,6 +98,10 @@ Configuration knobs
    * - :kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST_PACKET_SIZE`
      - Payload size (bytes). The default is the IPv6 TCP MSS at a 1280 byte
        MTU so every write is one full-sized segment (see below).
+   * - :kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST_FRAG_PACKET_SIZE`
+     - Payload size (bytes) for the extra fragmenting UDP runs. Must exceed the
+       MTU (so the datagram fragments) and stay below
+       :kconfig:option:`CONFIG_NET_ZPERF_MAX_PACKET_SIZE`.
    * - :kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST_RATE_KBPS`
      - Target rate; ``0`` means send as fast as the (virtual) CPU allows.
    * - :kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST_PORT`
@@ -109,11 +135,27 @@ A few non-obvious points are baked into :file:`overlay-loopback-icount.conf`:
   IPv4 MSS in one segment but exceeds the IPv6 MSS, so every IPv6 write is split
   into a full 1220 byte segment plus a 12 byte runt - roughly doubling the IPv6
   segment/ACK count and nearly halving IPv6 TCP throughput. Using 1220 keeps
-  every write to a single full-sized segment for both families. The payload also
-  stays under the MTU for UDP in both families, so no IP fragmentation is needed
-  (IP fragmentation is disabled in this config). Because the net_buf data size
-  (1100) is below the MTU, each frame still spans two buffer fragments, which
-  deliberately exercises the fragment-chain walk.
+  every write to a single full-sized segment for both families. The baseline UDP
+  payload also stays under the MTU for both families, so those datagrams are not
+  IP-fragmented. Because the net_buf data size (1100) is below the MTU, each
+  frame still spans two buffer fragments, which deliberately exercises the
+  fragment-chain walk.
+- **IP fragmentation coverage.** :kconfig:option:`CONFIG_NET_IPV4_FRAGMENT` and
+  :kconfig:option:`CONFIG_NET_IPV6_FRAGMENT` are enabled and the runner adds an
+  extra UDP run per family whose payload
+  (``CONFIG_ZPERF_LOOPBACK_SELFTEST_FRAG_PACKET_SIZE``, 2000 by default) exceeds
+  the MTU. This drives the fragmentation path in ``ipv4.c`` / ``ipv6.c`` on TX
+  and the reassembly path on RX (the ``*_frag`` markers).
+  :kconfig:option:`CONFIG_NET_ZPERF_MAX_PACKET_SIZE` is raised above this payload.
+- **Traffic classes and priority.** The overlay configures more than one TX/RX
+  traffic class (:kconfig:option:`CONFIG_NET_TC_TX_COUNT` /
+  :kconfig:option:`CONFIG_NET_TC_RX_COUNT` = 2) and enables
+  :kconfig:option:`CONFIG_NET_CONTEXT_PRIORITY` (plus
+  :kconfig:option:`CONFIG_NET_ALLOW_ANY_PRIORITY`). Every upload sets a
+  non-default ``SO_PRIORITY``, so traffic is dispatched through the dedicated
+  per-traffic-class threads rather than the caller's context. This exercises the
+  ``net_tc.c`` scheduling path but adds context switches, which lowers the
+  absolute numbers compared with a single-traffic-class configuration.
 - **Unlimited-rate math.** In unlimited-rate (``rate = 0``) mode the runner
   picks a rate high enough that the per-packet pacing delay rounds down to zero.
   That synthetic rate is computed in 64-bit to avoid an intermediate overflow,
@@ -137,14 +179,21 @@ Expected output (values are deterministic and repeat exactly across runs on a
 given build; the exact numbers depend on the toolchain, packet size, icount
 shift and tick rate, so treat them as an example)::
 
-   ZPERF-RESULT udp4_mbps=13.251
-   ZPERF-RESULT tcp4_mbps=6.003
-   ZPERF-RESULT udp6_mbps=13.463
-   ZPERF-RESULT tcp6_mbps=6.050
+   ZPERF-RESULT udp4_mbps=13.099
+   ZPERF-RESULT udp4_frag_mbps=20.249
+   ZPERF-RESULT tcp4_mbps=5.970
+   ZPERF-RESULT tcp4_nodelay_mbps=5.876
+   ZPERF-RESULT udp6_mbps=13.310
+   ZPERF-RESULT udp6_frag_mbps=20.059
+   ZPERF-RESULT tcp6_mbps=5.979
+   ZPERF-RESULT tcp6_nodelay_mbps=5.910
    ZPERF-DONE
 
 The IPv4 and IPv6 TCP numbers are close because the default payload is the IPv6
-TCP MSS; see the MSS caveat under `Implementation notes / gotchas`_.
+TCP MSS; see the MSS caveat under `Implementation notes / gotchas`_. The
+``*_frag`` (fragmented) UDP runs report a *higher* number than the baseline UDP
+runs because the larger datagram amortizes the fixed per-datagram overhead over
+more payload, even after accounting for the fragmentation work.
 
 Run through twister
 ===================

--- a/samples/net/zperf/README-loopback-icount.rst
+++ b/samples/net/zperf/README-loopback-icount.rst
@@ -251,3 +251,16 @@ tolerance, which makes it suitable as a CI regression check.
    rejected. The examples pass ``--base-dir ..`` because they read the twister
    report from the sibling ``../build`` tree while writing outputs into the
    repository.
+
+Visualize the results
+=====================
+
+Pass ``--plot`` to write a bar chart of the metrics as a self-contained SVG
+(no extra Python dependencies). Without a baseline it plots the current values;
+combined with ``--baseline`` it draws grouped baseline-vs-current bars:
+
+.. code-block:: console
+
+   samples/net/zperf/scripts/zperf_regression.py --base-dir .. \
+       --twister-json ../build/zperf_cur/twister.json \
+       --baseline baseline.json --plot throughput.svg

--- a/samples/net/zperf/README-loopback-icount.rst
+++ b/samples/net/zperf/README-loopback-icount.rst
@@ -1,0 +1,195 @@
+:orphan:
+
+.. _zperf-loopback-icount:
+
+zperf deterministic loopback throughput (qemu_x86 + icount)
+###########################################################
+
+Overview
+********
+
+This describes a self-contained way to use the zperf sample as a **network
+throughput regression check** that is hardware agnostic and, most importantly,
+independent of the speed of the host running the emulator.
+
+The measurement runs entirely inside a ``qemu_x86`` guest:
+
+- All traffic goes over the in-guest loopback interface, so there is no external
+  (real-time) network backend in the measurement path.
+- QEMU is run in **icount mode**, so the guest's notion of time is derived from
+  the number of executed instructions rather than from host wall-clock time.
+- The sample drives itself (no interactive shell): it starts a UDP and a TCP
+  receiver on loopback, uploads to ``127.0.0.1``, and prints the results.
+
+Throughput is ``bytes / elapsed_time``, so the metric is only useful for
+regression detection if ``elapsed_time`` is deterministic and host independent.
+In icount mode the virtual CPU advances virtual time by ``2^shift`` ns per
+executed instruction, so the reported throughput becomes a deterministic
+function of *instructions per byte*: identical across runs and across machines,
+and sensitive to real code regressions (more instructions per byte lowers the
+number). Keeping all traffic on loopback means there is no external real-time
+backend that would otherwise break icount determinism.
+
+.. note::
+
+   The absolute Mbps value is a *virtual-time proxy* (a stand-in for
+   instructions-per-byte), not a real line rate. Only compare values captured
+   with the same icount shift, packet size, and tick rate.
+
+How it works
+************
+
+The runner lives in :file:`src/main.c`, guarded by
+:kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST`. When enabled the sample:
+
+#. Brings the network up itself (automatic init is disabled so the transfer does
+   not race the bring-up).
+#. Starts a UDP receiver, runs a blocking UDP upload, stops the receiver, and
+   prints ``ZPERF-RESULT udp4_mbps=<value>``.
+#. Repeats the same for TCP and prints ``ZPERF-RESULT tcp4_mbps=<value>``.
+#. Repeats both over IPv6, printing ``ZPERF-RESULT udp6_mbps=<value>`` and
+   ``ZPERF-RESULT tcp6_mbps=<value>``.
+#. Prints a final ``ZPERF-DONE`` marker.
+
+Both IP families are exercised so a regression in either code path is caught.
+The IPv4 transfers use ``127.0.0.1`` and the IPv6 transfers use ``::1``; the
+loopback driver assigns both addresses to the loopback interface. For each
+family the receiver is bound to that loopback address (not just the interface's
+default address) so the client can connect to it. The IPv6 runs are skipped
+when :kconfig:option:`CONFIG_NET_IPV6` is disabled (and likewise for IPv4).
+
+The whole thing is configured by :file:`overlay-loopback-icount.conf`, which is
+layered on top of the existing :file:`overlay-loopback.conf`.
+
+Configuration knobs
+===================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Kconfig option
+     - Meaning
+   * - :kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST`
+     - Enable the self-driven loopback runner.
+   * - :kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST_DURATION_MS`
+     - Duration of each (UDP and TCP) upload run.
+   * - :kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST_PACKET_SIZE`
+     - Payload size (bytes). The default is the IPv6 TCP MSS at a 1280 byte
+       MTU so every write is one full-sized segment (see below).
+   * - :kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST_RATE_KBPS`
+     - Target rate; ``0`` means send as fast as the (virtual) CPU allows.
+   * - :kconfig:option:`CONFIG_ZPERF_LOOPBACK_SELFTEST_PORT`
+     - Server port used by both the receiver and the client.
+
+Implementation notes / gotchas
+==============================
+
+A few non-obvious points are baked into :file:`overlay-loopback-icount.conf`:
+
+- **Stack sizes.** The loopback driver delivers every packet synchronously in
+  the sender's context, so the entire receive path (and the blocking client
+  upload) nests on the caller's stack. The main and networking thread stacks are
+  enlarged; otherwise the guest overflows its stack and faults at boot.
+- **Tick rate.** The tick rate is raised to 10 kHz. At the default 100 Hz,
+  ``USECS_PER_TICK >= 1000`` compiles in the UDP uploader's clock-compensation
+  path, which divides by the per-packet duration. With the unlimited rate that
+  duration is zero, so a >1 kHz tick both avoids the division-by-zero and gives
+  fine-grained pacing.
+- **Near-MTU packet size and the MSS caveat.** The overlay raises the loopback
+  MTU (:kconfig:option:`CONFIG_NET_LOOPBACK_MTU`) to 1280 and lifts zperf's own
+  packet ceiling (:kconfig:option:`CONFIG_NET_ZPERF_MAX_PACKET_SIZE`) above the
+  payload, so the default 1220 byte payload produces near-MTU frames. Large
+  frames make the per-byte work (checksums, buffer/fragment walking) dominate
+  the fixed per-call overhead, which is what a throughput regression check
+  should be sensitive to. The exact value 1220 matters for a *fair* TCP
+  comparison across families: the zperf TCP uploader sends the whole payload
+  per ``send()`` and lets TCP segment it at the MSS. At a 1280 byte MTU the
+  IPv4 MSS is ``1280 - 40`` = 1240 but the IPv6 MSS is only ``1280 - 60`` =
+  1220 (the IPv6 header is 20 bytes larger). A payload of, say, 1232 fits the
+  IPv4 MSS in one segment but exceeds the IPv6 MSS, so every IPv6 write is split
+  into a full 1220 byte segment plus a 12 byte runt - roughly doubling the IPv6
+  segment/ACK count and nearly halving IPv6 TCP throughput. Using 1220 keeps
+  every write to a single full-sized segment for both families. The payload also
+  stays under the MTU for UDP in both families, so no IP fragmentation is needed
+  (IP fragmentation is disabled in this config). Because the net_buf data size
+  (1100) is below the MTU, each frame still spans two buffer fragments, which
+  deliberately exercises the fragment-chain walk.
+- **Unlimited-rate math.** In unlimited-rate (``rate = 0``) mode the runner
+  picks a rate high enough that the per-packet pacing delay rounds down to zero.
+  That synthetic rate is computed in 64-bit to avoid an intermediate overflow,
+  so any realistic packet size (up to ~500 kB) is supported.
+- **No SLIP/TAP.** The QEMU SLIP host networking backend is disabled; the run
+  needs no host-side ``slip.sock``.
+
+Usage
+*****
+
+Build and run once
+==================
+
+.. code-block:: console
+
+   west build -p -b qemu_x86 -d ../build/zperf_loop samples/net/zperf -- \
+       -DEXTRA_CONF_FILE="overlay-loopback.conf;overlay-loopback-icount.conf"
+   west build -t run -d ../build/zperf_loop
+
+Expected output (values are deterministic and repeat exactly across runs on a
+given build; the exact numbers depend on the toolchain, packet size, icount
+shift and tick rate, so treat them as an example)::
+
+   ZPERF-RESULT udp4_mbps=13.251
+   ZPERF-RESULT tcp4_mbps=6.003
+   ZPERF-RESULT udp6_mbps=13.463
+   ZPERF-RESULT tcp6_mbps=6.050
+   ZPERF-DONE
+
+The IPv4 and IPv6 TCP numbers are close because the default payload is the IPv6
+TCP MSS; see the MSS caveat under `Implementation notes / gotchas`_.
+
+Run through twister
+===================
+
+The :file:`tests.yaml` scenario ``sample.net.zperf.loopback_icount`` uses the
+``console`` harness and records the two throughput values into the twister JSON
+report:
+
+.. code-block:: console
+
+   ./scripts/twister -p qemu_x86 -s sample.net.zperf.loopback_icount \
+       --outdir ../build/zperf_run
+
+Baseline and regression gate
+============================
+
+The helper :file:`scripts/zperf_regression.py` reads the recordings from a
+twister run. Capture a baseline once on the reference commit:
+
+.. code-block:: console
+
+   ./scripts/twister -p qemu_x86 -s sample.net.zperf.loopback_icount \
+       --outdir ../build/zperf_base
+   samples/net/zperf/scripts/zperf_regression.py --base-dir .. \
+       --twister-json ../build/zperf_base/twister.json \
+       --save baseline.json
+
+On a later commit, re-run and gate on a maximum allowed drop (in percent):
+
+.. code-block:: console
+
+   ./scripts/twister -p qemu_x86 -s sample.net.zperf.loopback_icount \
+       --outdir ../build/zperf_cur
+   samples/net/zperf/scripts/zperf_regression.py --base-dir .. \
+       --twister-json ../build/zperf_cur/twister.json \
+       --baseline baseline.json --tolerance 5
+
+The script exits non-zero if any recorded metric dropped by more than the
+tolerance, which makes it suitable as a CI regression check.
+
+.. note::
+
+   For safety when the script is driven by automation, every file it reads or
+   writes must resolve to a location under ``--base-dir`` (default: the current
+   directory); paths that escape it (via ``..`` or an absolute path) are
+   rejected. The examples pass ``--base-dir ..`` because they read the twister
+   report from the sibling ``../build`` tree while writing outputs into the
+   repository.

--- a/samples/net/zperf/README.rst
+++ b/samples/net/zperf/README.rst
@@ -57,6 +57,13 @@ Usage
 See :ref:`zperf library documentation <zperf>` for more information about
 the library usage.
 
+Deterministic throughput regression testing
+============================================
+
+For a hardware-agnostic, host-speed-independent way to detect network
+throughput regressions (using ``qemu_x86`` with QEMU icount mode over the
+in-guest loopback interface), see :ref:`zperf-loopback-icount`.
+
 Wi-Fi
 =====
 

--- a/samples/net/zperf/overlay-loopback-icount.conf
+++ b/samples/net/zperf/overlay-loopback-icount.conf
@@ -1,0 +1,78 @@
+# Deterministic, host-speed-independent zperf throughput measurement.
+#
+# Layer this on top of overlay-loopback.conf, e.g.:
+#   -DEXTRA_CONF_FILE="overlay-loopback.conf;overlay-loopback-icount.conf"
+#
+# All traffic stays inside the guest (loopback), so QEMU icount mode can be
+# safely enabled. In icount mode the virtual CPU advances virtual time by
+# 2^SHIFT ns per executed instruction, so the reported throughput becomes a
+# deterministic function of instructions-per-byte instead of host wall clock.
+
+# Force QEMU icount on. It is disabled by default when networking + shell are
+# enabled, but with loopback-only traffic there is no real host I/O in the
+# measurement path.
+CONFIG_QEMU_ICOUNT=y
+CONFIG_QEMU_ICOUNT_SHIFT=5
+CONFIG_QEMU_ICOUNT_SLEEP=n
+
+# icount only works with a single CPU.
+CONFIG_MP_MAX_NUM_CPUS=1
+
+# Run the kernel tick at 10 kHz. The default qemu_x86 rate is 100 Hz, which
+# (a) compiles in the UDP uploader's clock-compensation path that divides by
+# the per-packet duration - a division by zero once the unlimited rate drives
+# that duration to 0 - and (b) is far too coarse to pace traffic. A >1 kHz tick
+# removes the compensation path and gives fine-grained timing.
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=10000
+
+# Loopback-only: no QEMU SLIP/TAP host networking. This removes the external,
+# real-time network backend that would otherwise make icount non-deterministic
+# (and require a host-side slip.sock).
+CONFIG_NET_QEMU_SLIP=n
+CONFIG_NET_SLIP_TAP=n
+
+# Self-driven loopback runner (see src/main.c). Avoids the interactive shell,
+# which can stall under icount waiting on real-time stdin.
+CONFIG_ZPERF_LOOPBACK_SELFTEST=y
+
+# The UDP uploader needs a receive timeout to collect the server statistics.
+CONFIG_NET_CONTEXT_RCVTIMEO=y
+
+# The zperf receivers register several sockets with the socket service; give
+# zvfs_poll() enough slots for the TCP listener plus its sessions.
+CONFIG_ZVFS_POLL_MAX=16
+
+# The loopback driver delivers each packet synchronously in the sender's
+# context, so the whole receive path (and, for this sample, the blocking client
+# upload) runs on the caller's stack. Give the involved threads generous stacks
+# to absorb that nesting; otherwise the guest overflows and faults at boot.
+CONFIG_MAIN_STACK_SIZE=3072
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2560
+CONFIG_NET_RX_STACK_SIZE=2560
+CONFIG_NET_TX_STACK_SIZE=2560
+CONFIG_NET_MGMT_EVENT_STACK_SIZE=2560
+CONFIG_NET_SOCKETS_SERVICE_STACK_SIZE=2560
+
+# Do not try to add IPv4/6 address to network interface but let the system
+# use the localhost addresses.
+CONFIG_NET_CONFIG_MY_IPV4_ADDR=""
+CONFIG_NET_CONFIG_MY_IPV6_ADDR=""
+
+# Disable statistics so that the stats collection will not lower the numbers.
+CONFIG_NET_STATISTICS=n
+
+# Push near-MTU-sized frames through the stack so the per-packet cost is
+# dominated by data-touching work (checksums, buffer/fragment walking) rather
+# than fixed per-call overhead. The selftest sends a 1220 byte payload (see the
+# Kconfig default): that is the IPv6 TCP MSS at a 1280 byte MTU (1280 - 40 IPv6
+# - 20 TCP), so every TCP write is a single full-sized segment for both IPv4 and
+# IPv6 (avoiding a tiny trailing segment that would otherwise halve IPv6 TCP),
+# and the UDP datagrams stay under the MTU for both families so no IP
+# fragmentation is needed. Raise the loopback L3 MTU accordingly and lift
+# zperf's own packet ceiling above the payload.
+CONFIG_NET_LOOPBACK_MTU=1280
+CONFIG_NET_ZPERF_MAX_PACKET_SIZE=1300
+
+# Keep the net_buf data size (1100, from overlay-loopback.conf) below the MTU so
+# each 1280 byte packet spans two buffer fragments. This deliberately exercises
+# the fragment-chain walk in net_pkt_get_len() and friends.

--- a/samples/net/zperf/overlay-loopback-icount.conf
+++ b/samples/net/zperf/overlay-loopback-icount.conf
@@ -69,10 +69,25 @@ CONFIG_NET_STATISTICS=n
 # IPv6 (avoiding a tiny trailing segment that would otherwise halve IPv6 TCP),
 # and the UDP datagrams stay under the MTU for both families so no IP
 # fragmentation is needed. Raise the loopback L3 MTU accordingly and lift
-# zperf's own packet ceiling above the payload.
+# zperf's own packet ceiling above the (larger, fragmenting) payload below.
 CONFIG_NET_LOOPBACK_MTU=1280
-CONFIG_NET_ZPERF_MAX_PACKET_SIZE=1300
+CONFIG_NET_ZPERF_MAX_PACKET_SIZE=2100
 
 # Keep the net_buf data size (1100, from overlay-loopback.conf) below the MTU so
 # each 1280 byte packet spans two buffer fragments. This deliberately exercises
 # the fragment-chain walk in net_pkt_get_len() and friends.
+
+# Exercise the IP fragmentation + reassembly subsystem: the runner adds an extra
+# UDP run per family whose payload (see ZPERF_LOOPBACK_SELFTEST_FRAG_PACKET_SIZE)
+# exceeds the MTU, so ipv4.c/ipv6.c must fragment on TX and reassemble on RX.
+CONFIG_NET_IPV4_FRAGMENT=y
+CONFIG_NET_IPV6_FRAGMENT=y
+
+# Exercise traffic classes and SO_PRIORITY: with more than one TX/RX queue the
+# stack routes prioritised traffic through dedicated per-traffic-class threads
+# (net_tc.c) instead of the caller's context. The runner sets a non-default
+# priority on every upload so this path is always taken.
+CONFIG_NET_TC_TX_COUNT=2
+CONFIG_NET_TC_RX_COUNT=2
+CONFIG_NET_CONTEXT_PRIORITY=y
+CONFIG_NET_ALLOW_ANY_PRIORITY=y

--- a/samples/net/zperf/scripts/zperf_regression.py
+++ b/samples/net/zperf/scripts/zperf_regression.py
@@ -103,12 +103,12 @@ def extract_metrics(twister_json: str, suite_name: str) -> dict[str, float]:
 def compare(baseline: dict[str, float], current: dict[str, float], tolerance_pct: float) -> bool:
     """Print a comparison table and return True if no metric regressed."""
     ok = True
-    print(f"{'metric':<12}{'baseline':>12}{'current':>12}{'change':>10}  status")
+    print(f"{'metric':<20}{'baseline':>12}{'current':>12}{'change':>10}  status")
     for metric in sorted(set(baseline) | set(current)):
         base = baseline.get(metric)
         cur = current.get(metric)
         if base is None or cur is None:
-            print(f"{metric:<12}{str(base):>12}{str(cur):>12}{'':>10}  MISSING")
+            print(f"{metric:<20}{str(base):>12}{str(cur):>12}{'':>10}  MISSING")
             ok = False
             continue
 
@@ -117,7 +117,7 @@ def compare(baseline: dict[str, float], current: dict[str, float], tolerance_pct
         status = "OK" if cur >= min_allowed else "REGRESSION"
         if status != "OK":
             ok = False
-        print(f"{metric:<12}{base:>12.3f}{cur:>12.3f}{change_pct:>+9.1f}%  {status}")
+        print(f"{metric:<20}{base:>12.3f}{cur:>12.3f}{change_pct:>+9.1f}%  {status}")
 
     return ok
 

--- a/samples/net/zperf/scripts/zperf_regression.py
+++ b/samples/net/zperf/scripts/zperf_regression.py
@@ -27,10 +27,17 @@ Typical usage::
     samples/net/zperf/scripts/zperf_regression.py --base-dir .. \\
         --twister-json ../build/zperf_cur/twister.json \\
         --baseline baseline.json --tolerance 5
+
+    # Visualize the results as an SVG bar chart (optionally baseline vs
+    # current when --baseline is also given).
+    samples/net/zperf/scripts/zperf_regression.py --base-dir .. \\
+        --twister-json ../build/zperf_cur/twister.json \\
+        --baseline baseline.json --plot throughput.svg
 """
 
 import argparse
 import json
+import math
 import os
 import sys
 
@@ -122,6 +129,124 @@ def compare(baseline: dict[str, float], current: dict[str, float], tolerance_pct
     return ok
 
 
+def _nice_ceil(value: float) -> float:
+    """Round a positive value up to a 1/2/2.5/5/10 * 10^n axis maximum."""
+    if value <= 0:
+        return 1.0
+    exp = math.floor(math.log10(value))
+    base = 10.0**exp
+    for mult in (1.0, 2.0, 2.5, 5.0, 10.0):
+        if value <= mult * base:
+            return mult * base
+    return 10.0 * base
+
+
+def write_plot(
+    path: str, current: dict[str, float], baseline: dict[str, float] | None = None
+) -> None:
+    """Render a bar chart of the metrics as a self-contained SVG file.
+
+    Without a baseline a single bar per metric is drawn; with a baseline the
+    baseline and current values are drawn as grouped bars per metric.
+    """
+    metrics = sorted(set(current) | (set(baseline) if baseline else set()))
+
+    margin_left, margin_right, margin_top, margin_bottom = 70, 30, 60, 110
+    group_w = 70
+    plot_w = group_w * max(len(metrics), 1)
+    height = 460
+    plot_h = height - margin_top - margin_bottom
+    width = margin_left + plot_w + margin_right
+    plot_bottom = margin_top + plot_h
+
+    values = [current.get(m, 0.0) for m in metrics]
+    if baseline:
+        values += [baseline.get(m, 0.0) for m in metrics]
+    axis_max = _nice_ceil(max(values) if values else 1.0)
+
+    def y_of(val: float) -> float:
+        return plot_bottom - (val / axis_max) * plot_h
+
+    color_cur = "#1f77b4"
+    color_base = "#999999"
+    svg: list[str] = []
+    svg.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" '
+        f'height="{height}" font-family="sans-serif" font-size="12">'
+    )
+    svg.append(f'<rect width="{width}" height="{height}" fill="white"/>')
+    svg.append(
+        f'<text x="{width / 2:.1f}" y="24" text-anchor="middle" '
+        f'font-size="16" font-weight="bold">'
+        f'zperf loopback throughput (Mbps)</text>'
+    )
+
+    ticks = 5
+    for i in range(ticks + 1):
+        val = axis_max * i / ticks
+        y = y_of(val)
+        svg.append(
+            f'<line x1="{margin_left}" y1="{y:.1f}" '
+            f'x2="{margin_left + plot_w}" y2="{y:.1f}" stroke="#e0e0e0"/>'
+        )
+        svg.append(
+            f'<text x="{margin_left - 8}" y="{y + 4:.1f}" '
+            f'text-anchor="end" fill="#555">{val:.1f}</text>'
+        )
+
+    svg.append(
+        f'<line x1="{margin_left}" y1="{margin_top}" x2="{margin_left}" '
+        f'y2="{plot_bottom}" stroke="#333"/>'
+    )
+    svg.append(
+        f'<line x1="{margin_left}" y1="{plot_bottom}" '
+        f'x2="{margin_left + plot_w}" y2="{plot_bottom}" stroke="#333"/>'
+    )
+
+    def bar(x: float, val: float, bar_w: float, color: str) -> None:
+        y = y_of(val)
+        svg.append(
+            f'<rect x="{x:.1f}" y="{y:.1f}" width="{bar_w:.1f}" '
+            f'height="{plot_bottom - y:.1f}" fill="{color}"/>'
+        )
+        svg.append(
+            f'<text x="{x + bar_w / 2:.1f}" y="{y - 4:.1f}" '
+            f'text-anchor="middle" font-size="9" fill="{color}">'
+            f'{val:.1f}</text>'
+        )
+
+    for idx, metric in enumerate(metrics):
+        center = margin_left + idx * group_w + group_w / 2
+        if baseline:
+            bar_w = group_w * 0.30
+            if metric in baseline:
+                bar(center - bar_w - 2, baseline[metric], bar_w, color_base)
+            if metric in current:
+                bar(center + 2, current[metric], bar_w, color_cur)
+        else:
+            bar_w = group_w * 0.5
+            bar(center - bar_w / 2, current.get(metric, 0.0), bar_w, color_cur)
+
+        label_y = plot_bottom + 14
+        svg.append(
+            f'<text x="{center:.1f}" y="{label_y:.1f}" '
+            f'transform="rotate(-45 {center:.1f} {label_y:.1f})" '
+            f'text-anchor="end" fill="#333">{metric}</text>'
+        )
+
+    if baseline:
+        lx, ly = margin_left + 10, margin_top + 6
+        svg.append(f'<rect x="{lx}" y="{ly}" width="12" height="12" fill="{color_base}"/>')
+        svg.append(f'<text x="{lx + 18}" y="{ly + 11}">baseline</text>')
+        svg.append(f'<rect x="{lx + 90}" y="{ly}" width="12" height="12" fill="{color_cur}"/>')
+        svg.append(f'<text x="{lx + 108}" y="{ly + 11}">current</text>')
+
+    svg.append("</svg>")
+    with open(path, "w") as fp:
+        fp.write("\n".join(svg) + "\n")
+    print(f"Wrote plot to {path}")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -147,6 +272,13 @@ def main() -> int:
         help="Allowed throughput drop in percent (default: 5.0)",
     )
     parser.add_argument(
+        "--plot",
+        metavar="PATH",
+        help="Write an SVG bar chart of the metrics to PATH "
+        "(grouped baseline vs current when --baseline is "
+        "given)",
+    )
+    parser.add_argument(
         "--base-dir",
         metavar="DIR",
         default=".",
@@ -169,10 +301,17 @@ def main() -> int:
             fp.write("\n")
         print(f"Saved baseline to {save_path}")
 
+    baseline = None
     if args.baseline:
         baseline_path = validate_path(args.baseline, args.base_dir, for_write=False)
         with open(baseline_path) as fp:
             baseline = {k: float(v) for k, v in json.load(fp).items()}
+
+    if args.plot:
+        plot_path = validate_path(args.plot, args.base_dir, for_write=True)
+        write_plot(plot_path, current, baseline)
+
+    if baseline is not None:
         print()
         if not compare(baseline, current, args.tolerance):
             print("\nThroughput regression detected.", file=sys.stderr)

--- a/samples/net/zperf/scripts/zperf_regression.py
+++ b/samples/net/zperf/scripts/zperf_regression.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+
+"""Capture and compare zperf loopback throughput from a twister run.
+
+The ``sample.net.zperf.loopback_icount`` scenario runs a deterministic,
+host-speed-independent throughput test under QEMU icount mode and records the
+UDP and TCP throughput (in Mbps) into the twister JSON report.
+
+By default all files read or written must live under the current directory;
+pass --base-dir to widen that (the examples below read the twister report from
+the sibling ../build tree and write into the repo, so they use --base-dir ..).
+
+Typical usage::
+
+    # Capture a baseline on the reference commit.
+    ./scripts/twister -p qemu_x86 -s sample.net.zperf.loopback_icount \\
+        --outdir ../build/zperf_base
+    samples/net/zperf/scripts/zperf_regression.py --base-dir .. \\
+        --twister-json ../build/zperf_base/twister.json \\
+        --save baseline.json
+
+    # On a later commit, re-run and gate on a maximum allowed drop.
+    ./scripts/twister -p qemu_x86 -s sample.net.zperf.loopback_icount \\
+        --outdir ../build/zperf_cur
+    samples/net/zperf/scripts/zperf_regression.py --base-dir .. \\
+        --twister-json ../build/zperf_cur/twister.json \\
+        --baseline baseline.json --tolerance 5
+"""
+
+import argparse
+import json
+import os
+import sys
+
+DEFAULT_SUITE = "sample.net.zperf.loopback_icount"
+
+
+def validate_path(path: str, base_dir: str, *, for_write: bool) -> str:
+    """Resolve *path* and ensure it stays inside *base_dir*.
+
+    All files this script reads or writes are taken from CLI arguments. To
+    avoid path-traversal or absolute-path escapes when the script is driven
+    with untrusted or faulty arguments, every such path is resolved (following
+    symlinks and ``..``) and rejected unless it lives under the resolved base
+    directory. The validated absolute path is returned for use with ``open()``.
+    """
+    if not path or "\x00" in path:
+        sys.exit(f"Invalid path: {path!r}")
+
+    base_real = os.path.realpath(base_dir)
+    if not os.path.isdir(base_real):
+        sys.exit(f"Base directory '{base_dir}' does not exist.")
+
+    # Resolve the path as the user means it (relative paths against the current
+    # directory, absolute paths as-is, following symlinks and ".."), then
+    # require the result to stay under the resolved base directory.
+    target_real = os.path.realpath(path)
+
+    if os.path.commonpath([base_real, target_real]) != base_real:
+        sys.exit(
+            f"Refusing to access '{path}': resolved path '{target_real}' is "
+            f"outside the permitted base directory '{base_real}'. Use "
+            f"--base-dir to widen the allowed location."
+        )
+
+    if for_write:
+        parent = os.path.dirname(target_real)
+        if not os.path.isdir(parent):
+            sys.exit(f"Cannot write '{path}': '{parent}' is not a directory.")
+        if os.path.isdir(target_real):
+            sys.exit(f"Cannot write '{path}': it is a directory.")
+
+    return target_real
+
+
+def extract_metrics(twister_json: str, suite_name: str) -> dict[str, float]:
+    """Return a {metric: value} mapping from a twister.json recording."""
+    with open(twister_json) as fp:
+        data = json.load(fp)
+
+    metrics: dict[str, float] = {}
+    for suite in data.get("testsuites", []):
+        if suite.get("name") != suite_name:
+            continue
+        for record in suite.get("recording") or []:
+            for key, value in record.items():
+                try:
+                    metrics[key] = float(value)
+                except (TypeError, ValueError):
+                    continue
+
+    if not metrics:
+        sys.exit(
+            f"No throughput recordings for suite '{suite_name}' in "
+            f"{twister_json}. Did the run pass?"
+        )
+
+    return metrics
+
+
+def compare(baseline: dict[str, float], current: dict[str, float], tolerance_pct: float) -> bool:
+    """Print a comparison table and return True if no metric regressed."""
+    ok = True
+    print(f"{'metric':<12}{'baseline':>12}{'current':>12}{'change':>10}  status")
+    for metric in sorted(set(baseline) | set(current)):
+        base = baseline.get(metric)
+        cur = current.get(metric)
+        if base is None or cur is None:
+            print(f"{metric:<12}{str(base):>12}{str(cur):>12}{'':>10}  MISSING")
+            ok = False
+            continue
+
+        change_pct = ((cur - base) / base * 100.0) if base else 0.0
+        min_allowed = base * (1.0 - tolerance_pct / 100.0)
+        status = "OK" if cur >= min_allowed else "REGRESSION"
+        if status != "OK":
+            ok = False
+        print(f"{metric:<12}{base:>12.3f}{cur:>12.3f}{change_pct:>+9.1f}%  {status}")
+
+    return ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "--twister-json", required=True, help="Path to the twister.json of the current run"
+    )
+    parser.add_argument(
+        "--suite", default=DEFAULT_SUITE, help="Test suite name to read recordings from"
+    )
+    parser.add_argument(
+        "--save", metavar="PATH", help="Write the extracted metrics as a baseline file"
+    )
+    parser.add_argument(
+        "--baseline", metavar="PATH", help="Compare against a previously saved baseline file"
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=5.0,
+        help="Allowed throughput drop in percent (default: 5.0)",
+    )
+    parser.add_argument(
+        "--base-dir",
+        metavar="DIR",
+        default=".",
+        help="Restrict all files read or written to this "
+        "directory tree (default: current directory). "
+        "Paths resolving outside it are rejected.",
+    )
+    args = parser.parse_args()
+
+    twister_json = validate_path(args.twister_json, args.base_dir, for_write=False)
+    current = extract_metrics(twister_json, args.suite)
+
+    for metric, value in sorted(current.items()):
+        print(f"{metric} = {value:.3f} Mbps")
+
+    if args.save:
+        save_path = validate_path(args.save, args.base_dir, for_write=True)
+        with open(save_path, "w") as fp:
+            json.dump(current, fp, indent=4, sort_keys=True)
+            fp.write("\n")
+        print(f"Saved baseline to {save_path}")
+
+    if args.baseline:
+        baseline_path = validate_path(args.baseline, args.base_dir, for_write=False)
+        with open(baseline_path) as fp:
+            baseline = {k: float(v) for k, v in json.load(fp).items()}
+        print()
+        if not compare(baseline, current, args.tolerance):
+            print("\nThroughput regression detected.", file=sys.stderr)
+            return 1
+        print("\nNo throughput regression.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/samples/net/zperf/src/main.c
+++ b/samples/net/zperf/src/main.c
@@ -32,6 +32,18 @@ LOG_MODULE_REGISTER(zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 #define SELFTEST_DURATION_MS CONFIG_ZPERF_LOOPBACK_SELFTEST_DURATION_MS
 #define SELFTEST_PACKET_SIZE CONFIG_ZPERF_LOOPBACK_SELFTEST_PACKET_SIZE
 #define SELFTEST_RATE_KBPS   CONFIG_ZPERF_LOOPBACK_SELFTEST_RATE_KBPS
+#define SELFTEST_FRAG_PACKET_SIZE CONFIG_ZPERF_LOOPBACK_SELFTEST_FRAG_PACKET_SIZE
+
+/* Non-default socket priority applied to every upload so that, when more than
+ * one traffic class is configured, traffic is routed through the per-traffic-
+ * class threads (net_tc.c) instead of the caller's context. Set to -1 (i.e. do
+ * not set SO_PRIORITY) when priority support is not compiled in.
+ */
+#if defined(CONFIG_NET_CONTEXT_PRIORITY)
+#define SELFTEST_PRIORITY NET_PRIORITY_VI
+#else
+#define SELFTEST_PRIORITY (-1)
+#endif
 
 /* Loopback addresses used for both the server bind and the client connect.
  * The loopback driver assigns 127.0.0.1 and ::1 to the loopback interface, so
@@ -50,6 +62,9 @@ LOG_MODULE_REGISTER(zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 BUILD_ASSERT(((uint64_t)SELFTEST_PACKET_SIZE * 8U * 1000000U) / 1024U + 1U <=
 		     UINT32_MAX,
 	     "Unlimited-rate loopback selftest packet size overflows rate_kbps");
+BUILD_ASSERT(((uint64_t)SELFTEST_FRAG_PACKET_SIZE * 8U * 1000000U) / 1024U + 1U <=
+		     UINT32_MAX,
+	     "Unlimited-rate loopback selftest frag packet size overflows rate_kbps");
 
 static void selftest_session_cb(enum zperf_status status,
 				struct zperf_results *result,
@@ -82,7 +97,8 @@ static void selftest_fill_addr(struct net_sockaddr *addr, int family)
 	}
 }
 
-static void selftest_fill_upload(struct zperf_upload_params *param, int family)
+static void selftest_fill_upload(struct zperf_upload_params *param, int family,
+				 uint32_t packet_size, bool tcp_nodelay)
 {
 	uint32_t rate_kbps = SELFTEST_RATE_KBPS;
 
@@ -91,17 +107,18 @@ static void selftest_fill_upload(struct zperf_upload_params *param, int family)
 		 * 64-bit to avoid overflowing the intermediate product for
 		 * near-MTU packet sizes, then store the (small enough) result.
 		 */
-		rate_kbps = (uint32_t)(((uint64_t)SELFTEST_PACKET_SIZE * 8U *
+		rate_kbps = (uint32_t)(((uint64_t)packet_size * 8U *
 					1000000U) / 1024U + 1U);
 	}
 
 	memset(param, 0, sizeof(*param));
 	selftest_fill_addr(&param->peer_addr, family);
 	param->duration_ms = SELFTEST_DURATION_MS;
-	param->packet_size = SELFTEST_PACKET_SIZE;
+	param->packet_size = packet_size;
 	param->rate_kbps = rate_kbps;
 	param->unix_offset_us = (uint64_t)k_uptime_get() * USEC_PER_MSEC;
-	param->options.priority = -1;
+	param->options.priority = SELFTEST_PRIORITY;
+	param->options.tcp_nodelay = tcp_nodelay ? 1 : 0;
 }
 
 /* Machine-parseable throughput line for the twister console harness. */
@@ -119,7 +136,7 @@ static void selftest_report(const char *proto, struct zperf_results *res)
 	       (uint32_t)(kbps / 1000U), (uint32_t)(kbps % 1000U));
 }
 
-static int selftest_run_udp(int family, const char *label)
+static int selftest_run_udp(int family, const char *label, uint32_t packet_size)
 {
 	struct zperf_download_params dl = { .port = SELFTEST_PORT };
 	struct zperf_upload_params ul;
@@ -136,7 +153,7 @@ static int selftest_run_udp(int family, const char *label)
 		return ret;
 	}
 
-	selftest_fill_upload(&ul, family);
+	selftest_fill_upload(&ul, family, packet_size, false);
 	ret = zperf_udp_upload(&ul, &res);
 	(void)zperf_udp_download_stop();
 	if (ret < 0) {
@@ -148,7 +165,7 @@ static int selftest_run_udp(int family, const char *label)
 	return 0;
 }
 
-static int selftest_run_tcp(int family, const char *label)
+static int selftest_run_tcp(int family, const char *label, bool tcp_nodelay)
 {
 	struct zperf_download_params dl = { .port = SELFTEST_PORT };
 	struct zperf_upload_params ul;
@@ -162,7 +179,7 @@ static int selftest_run_tcp(int family, const char *label)
 		return ret;
 	}
 
-	selftest_fill_upload(&ul, family);
+	selftest_fill_upload(&ul, family, SELFTEST_PACKET_SIZE, tcp_nodelay);
 	ret = zperf_tcp_upload(&ul, &res);
 	(void)zperf_tcp_download_stop();
 	if (ret < 0) {
@@ -174,30 +191,65 @@ static int selftest_run_tcp(int family, const char *label)
 	return 0;
 }
 
+/* Whether the extra, intentionally-fragmenting UDP run should be performed for
+ * the given family (needs the matching IP fragmentation support compiled in).
+ */
+static bool selftest_frag_enabled(int family)
+{
+	if (family == NET_AF_INET6) {
+		return IS_ENABLED(CONFIG_NET_IPV6_FRAGMENT);
+	}
+
+	return IS_ENABLED(CONFIG_NET_IPV4_FRAGMENT);
+}
+
 static void selftest_run_family(int family, const char *udp_label,
-				const char *tcp_label)
+				const char *udp_frag_label,
+				const char *tcp_label,
+				const char *tcp_nodelay_label)
 {
 	int ret;
 
-	ret = selftest_run_udp(family, udp_label);
+	ret = selftest_run_udp(family, udp_label, SELFTEST_PACKET_SIZE);
 	if (ret < 0) {
 		printk("ZPERF-RESULT %s_mbps=error(%d)\n", udp_label, ret);
 	}
 
-	ret = selftest_run_tcp(family, tcp_label);
+	/* Oversized datagram: forces IP fragmentation on TX and reassembly on
+	 * RX. Only meaningful when fragmentation is compiled in.
+	 */
+	if (selftest_frag_enabled(family)) {
+		ret = selftest_run_udp(family, udp_frag_label,
+				       SELFTEST_FRAG_PACKET_SIZE);
+		if (ret < 0) {
+			printk("ZPERF-RESULT %s_mbps=error(%d)\n",
+			       udp_frag_label, ret);
+		}
+	}
+
+	ret = selftest_run_tcp(family, tcp_label, false);
 	if (ret < 0) {
 		printk("ZPERF-RESULT %s_mbps=error(%d)\n", tcp_label, ret);
+	}
+
+	/* Same transfer with Nagle disabled to cover the TCP_NODELAY send path. */
+	ret = selftest_run_tcp(family, tcp_nodelay_label, true);
+	if (ret < 0) {
+		printk("ZPERF-RESULT %s_mbps=error(%d)\n", tcp_nodelay_label,
+		       ret);
 	}
 }
 
 static void run_loopback_selftest(void)
 {
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
-		selftest_run_family(NET_AF_INET, "udp4", "tcp4");
+		selftest_run_family(NET_AF_INET, "udp4", "udp4_frag", "tcp4",
+				    "tcp4_nodelay");
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV6)) {
-		selftest_run_family(NET_AF_INET6, "udp6", "tcp6");
+		selftest_run_family(NET_AF_INET6, "udp6", "udp6_frag", "tcp6",
+				    "tcp6_nodelay");
 	}
 
 	printk("ZPERF-DONE\n");

--- a/samples/net/zperf/src/main.c
+++ b/samples/net/zperf/src/main.c
@@ -8,6 +8,9 @@
  * @file
  * @brief Zperf sample.
  */
+#include <string.h>
+
+#include <zephyr/kernel.h>
 #include <zephyr/usb/usbd.h>
 #include <zephyr/net/net_config.h>
 
@@ -20,6 +23,186 @@ LOG_MODULE_REGISTER(zperf, CONFIG_NET_ZPERF_LOG_LEVEL);
 #if defined(CONFIG_USB_DEVICE_STACK_NEXT)
 #include <sample_usbd.h>
 #endif
+
+#if defined(CONFIG_ZPERF_LOOPBACK_SELFTEST)
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/zperf.h>
+
+#define SELFTEST_PORT        CONFIG_ZPERF_LOOPBACK_SELFTEST_PORT
+#define SELFTEST_DURATION_MS CONFIG_ZPERF_LOOPBACK_SELFTEST_DURATION_MS
+#define SELFTEST_PACKET_SIZE CONFIG_ZPERF_LOOPBACK_SELFTEST_PACKET_SIZE
+#define SELFTEST_RATE_KBPS   CONFIG_ZPERF_LOOPBACK_SELFTEST_RATE_KBPS
+
+/* Loopback addresses used for both the server bind and the client connect.
+ * The loopback driver assigns 127.0.0.1 and ::1 to the loopback interface, so
+ * both are valid local endpoints.
+ */
+#define SELFTEST_IPV4_ADDR   "127.0.0.1"
+#define SELFTEST_IPV6_ADDR   "::1"
+
+/* When the configured rate is 0 (unlimited), the runner picks a rate high
+ * enough that the per-packet pacing delay in the UDP uploader rounds down to
+ * zero, so the client sends as fast as the (virtual) CPU allows. The computed
+ * rate (in kbps) is stored in a uint32_t field, so it must fit; the math below
+ * is done in 64-bit to avoid an intermediate overflow. This bounds the usable
+ * packet size at roughly 500 kB, far above any realistic MTU.
+ */
+BUILD_ASSERT(((uint64_t)SELFTEST_PACKET_SIZE * 8U * 1000000U) / 1024U + 1U <=
+		     UINT32_MAX,
+	     "Unlimited-rate loopback selftest packet size overflows rate_kbps");
+
+static void selftest_session_cb(enum zperf_status status,
+				struct zperf_results *result,
+				void *user_data)
+{
+	ARG_UNUSED(status);
+	ARG_UNUSED(result);
+	ARG_UNUSED(user_data);
+}
+
+/* Fill a socket address with the loopback endpoint for the given family. */
+static void selftest_fill_addr(struct net_sockaddr *addr, int family)
+{
+	if (family == NET_AF_INET6) {
+		struct net_sockaddr_in6 *a6 = net_sin6(addr);
+
+		memset(a6, 0, sizeof(*a6));
+		a6->sin6_family = NET_AF_INET6;
+		a6->sin6_port = net_htons(SELFTEST_PORT);
+		(void)net_addr_pton(NET_AF_INET6, SELFTEST_IPV6_ADDR,
+				    &a6->sin6_addr);
+	} else {
+		struct net_sockaddr_in *a4 = net_sin(addr);
+
+		memset(a4, 0, sizeof(*a4));
+		a4->sin_family = NET_AF_INET;
+		a4->sin_port = net_htons(SELFTEST_PORT);
+		(void)net_addr_pton(NET_AF_INET, SELFTEST_IPV4_ADDR,
+				    &a4->sin_addr);
+	}
+}
+
+static void selftest_fill_upload(struct zperf_upload_params *param, int family)
+{
+	uint32_t rate_kbps = SELFTEST_RATE_KBPS;
+
+	if (rate_kbps == 0U) {
+		/* Force packet_duration_us == 0, i.e. no pacing. Compute in
+		 * 64-bit to avoid overflowing the intermediate product for
+		 * near-MTU packet sizes, then store the (small enough) result.
+		 */
+		rate_kbps = (uint32_t)(((uint64_t)SELFTEST_PACKET_SIZE * 8U *
+					1000000U) / 1024U + 1U);
+	}
+
+	memset(param, 0, sizeof(*param));
+	selftest_fill_addr(&param->peer_addr, family);
+	param->duration_ms = SELFTEST_DURATION_MS;
+	param->packet_size = SELFTEST_PACKET_SIZE;
+	param->rate_kbps = rate_kbps;
+	param->unix_offset_us = (uint64_t)k_uptime_get() * USEC_PER_MSEC;
+	param->options.priority = -1;
+}
+
+/* Machine-parseable throughput line for the twister console harness. */
+static void selftest_report(const char *proto, struct zperf_results *res)
+{
+	uint64_t kbps = 0U;
+
+	if (res->client_time_in_us != 0U) {
+		kbps = ((uint64_t)res->nb_packets_sent *
+			(uint64_t)res->packet_size * 8U * USEC_PER_SEC) /
+		       ((uint64_t)res->client_time_in_us * 1000U);
+	}
+
+	printk("ZPERF-RESULT %s_mbps=%u.%03u\n", proto,
+	       (uint32_t)(kbps / 1000U), (uint32_t)(kbps % 1000U));
+}
+
+static int selftest_run_udp(int family, const char *label)
+{
+	struct zperf_download_params dl = { .port = SELFTEST_PORT };
+	struct zperf_upload_params ul;
+	struct zperf_results res = { 0 };
+	int ret;
+
+	/* Bind the receiver to the loopback address so the client can reach it
+	 * (in particular ::1, which is not the interface's default address).
+	 */
+	selftest_fill_addr(&dl.addr, family);
+
+	ret = zperf_udp_download(&dl, selftest_session_cb, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+
+	selftest_fill_upload(&ul, family);
+	ret = zperf_udp_upload(&ul, &res);
+	(void)zperf_udp_download_stop();
+	if (ret < 0) {
+		return ret;
+	}
+
+	selftest_report(label, &res);
+
+	return 0;
+}
+
+static int selftest_run_tcp(int family, const char *label)
+{
+	struct zperf_download_params dl = { .port = SELFTEST_PORT };
+	struct zperf_upload_params ul;
+	struct zperf_results res = { 0 };
+	int ret;
+
+	selftest_fill_addr(&dl.addr, family);
+
+	ret = zperf_tcp_download(&dl, selftest_session_cb, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+
+	selftest_fill_upload(&ul, family);
+	ret = zperf_tcp_upload(&ul, &res);
+	(void)zperf_tcp_download_stop();
+	if (ret < 0) {
+		return ret;
+	}
+
+	selftest_report(label, &res);
+
+	return 0;
+}
+
+static void selftest_run_family(int family, const char *udp_label,
+				const char *tcp_label)
+{
+	int ret;
+
+	ret = selftest_run_udp(family, udp_label);
+	if (ret < 0) {
+		printk("ZPERF-RESULT %s_mbps=error(%d)\n", udp_label, ret);
+	}
+
+	ret = selftest_run_tcp(family, tcp_label);
+	if (ret < 0) {
+		printk("ZPERF-RESULT %s_mbps=error(%d)\n", tcp_label, ret);
+	}
+}
+
+static void run_loopback_selftest(void)
+{
+	if (IS_ENABLED(CONFIG_NET_IPV4)) {
+		selftest_run_family(NET_AF_INET, "udp4", "tcp4");
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV6)) {
+		selftest_run_family(NET_AF_INET6, "udp6", "tcp6");
+	}
+
+	printk("ZPERF-DONE\n");
+}
+#endif /* CONFIG_ZPERF_LOOPBACK_SELFTEST */
 
 int main(void)
 {
@@ -47,5 +230,10 @@ int main(void)
 #if defined(CONFIG_NET_DHCPV4) && !defined(CONFIG_NET_CONFIG_SETTINGS)
 	net_dhcpv4_start(net_if_get_default());
 #endif
+
+#if defined(CONFIG_ZPERF_LOOPBACK_SELFTEST)
+	run_loopback_selftest();
+#endif /* CONFIG_ZPERF_LOOPBACK_SELFTEST */
+
 	return 0;
 }

--- a/samples/net/zperf/tests.yaml
+++ b/samples/net/zperf/tests.yaml
@@ -17,6 +17,21 @@ tests:
     platform_allow: qemu_x86
     extra_configs:
       - CONFIG_NET_ZPERF_SERVER=n
+  sample.net.zperf.loopback_icount:
+    harness: console
+    platform_allow: qemu_x86
+    extra_args:
+      - EXTRA_CONF_FILE="overlay-loopback.conf;overlay-loopback-icount.conf"
+    harness_config:
+      type: one_line
+      regex:
+        - "ZPERF-DONE"
+      record:
+        regex:
+          - "ZPERF-RESULT udp4_mbps=(?P<udp4_mbps>[0-9.]+)"
+          - "ZPERF-RESULT tcp4_mbps=(?P<tcp4_mbps>[0-9.]+)"
+          - "ZPERF-RESULT udp6_mbps=(?P<udp6_mbps>[0-9.]+)"
+          - "ZPERF-RESULT tcp6_mbps=(?P<tcp6_mbps>[0-9.]+)"
   sample.net.zperf.async_tx.stm32:
     filter: dt_compat_enabled("st,stm32-ethernet") and CONFIG_ETH_STM32_HAL_API_V2
     harness: console

--- a/samples/net/zperf/tests.yaml
+++ b/samples/net/zperf/tests.yaml
@@ -43,9 +43,13 @@ tests:
       record:
         regex:
           - "ZPERF-RESULT udp4_mbps=(?P<udp4_mbps>[0-9.]+)"
+          - "ZPERF-RESULT udp4_frag_mbps=(?P<udp4_frag_mbps>[0-9.]+)"
           - "ZPERF-RESULT tcp4_mbps=(?P<tcp4_mbps>[0-9.]+)"
+          - "ZPERF-RESULT tcp4_nodelay_mbps=(?P<tcp4_nodelay_mbps>[0-9.]+)"
           - "ZPERF-RESULT udp6_mbps=(?P<udp6_mbps>[0-9.]+)"
+          - "ZPERF-RESULT udp6_frag_mbps=(?P<udp6_frag_mbps>[0-9.]+)"
           - "ZPERF-RESULT tcp6_mbps=(?P<tcp6_mbps>[0-9.]+)"
+          - "ZPERF-RESULT tcp6_nodelay_mbps=(?P<tcp6_nodelay_mbps>[0-9.]+)"
   sample.net.zperf.async_tx.stm32:
     filter: dt_compat_enabled("st,stm32-ethernet") and CONFIG_ETH_STM32_HAL_API_V2
     harness: console

--- a/samples/net/zperf/tests.yaml
+++ b/samples/net/zperf/tests.yaml
@@ -1,6 +1,5 @@
 common:
   tags:
-    - net
     - zperf
   platform_exclude:
     - sam_e70_xplained/same70q21
@@ -12,14 +11,29 @@ tests:
   sample.net.zperf:
     harness: net
     platform_allow: qemu_x86
+    tags:
+      - net
   sample.net.zperf_no_server:
     harness: net
     platform_allow: qemu_x86
+    tags:
+      - net
     extra_configs:
       - CONFIG_NET_ZPERF_SERVER=n
   sample.net.zperf.loopback_icount:
     harness: console
-    platform_allow: qemu_x86
+    platform_allow:
+      - qemu_x86
+      - qemu_x86_64
+    tags:
+      # Unlike the other zperf scenarios, this one is tagged net-perf instead of
+      # net. The qemu_x86_64 board sets ignore_tags: [net, ...] in its
+      # board YAML, so any net tagged suite is statically filtered there. Using a
+      # dedicated net-perf tag lets the performance check run on qemu_x86_64
+      # while the functional net zperf scenarios remain 32-bit only, as intended
+      # upstream. Baselines are per-platform: a 32-bit and a 64-bit run produce
+      # different absolute numbers, so keep separate baseline files for each.
+      - net-perf
     extra_args:
       - EXTRA_CONF_FILE="overlay-loopback.conf;overlay-loopback-icount.conf"
     harness_config:
@@ -35,6 +49,8 @@ tests:
   sample.net.zperf.async_tx.stm32:
     filter: dt_compat_enabled("st,stm32-ethernet") and CONFIG_ETH_STM32_HAL_API_V2
     harness: console
+    tags:
+      - net
     harness_config:
       type: multi_line
       regex:
@@ -45,6 +61,8 @@ tests:
       - CONFIG_ETH_STM32_HAL_TX_ASYNC=y
   sample.net.zperf_st:
     harness: console
+    tags:
+      - net
     harness_config:
       type: multi_line
       regex:
@@ -60,17 +78,23 @@ tests:
       - stm32h573i_dk
   sample.net.zperf_st.otp_mac_addr:
     build_only: true
+    tags:
+      - net
     platform_allow:
       - stm32n6570_dk/stm32n657xx/sb
     extra_args:
       - DTC_OVERLAY_FILE="boards/stm32n6570_dk_stm32n657xx_sb_otp.overlay"
   sample.net.zperf_no_shell:
     harness: net
+    tags:
+      - net
     extra_configs:
       - CONFIG_NET_SHELL=n
     platform_allow: qemu_x86
   sample.net.zperf_concurrent_upload:
     harness: net
+    tags:
+      - net
     extra_configs:
       - CONFIG_ZPERF_SESSION_PER_THREAD=y
     platform_allow: qemu_x86
@@ -120,22 +144,30 @@ tests:
       - mimxrt1170_evk/mimxrt1176/cm7
   sample.net.zperf.802154.subg:
     extra_args: EXTRA_CONF_FILE="overlay-802154-subg.conf"
+    tags:
+      - net
     platform_allow:
       - beagleconnect_freedom@C5/cc1352p
       - beagleconnect_freedom@C7/cc1352p7
   sample.net.zperf.nrf7002dk:
     extra_args: SNIPPET=wifi-ipv4
+    tags:
+      - net
     extra_configs:
       - CONFIG_BUILD_ONLY_NO_BLOBS=y
     platform_allow: nrf7002dk/nrf5340/cpuapp
   sample.net.zperf.raw_tx:
     harness: net
     platform_allow: qemu_x86
+    tags:
+      - net
     extra_configs:
       - CONFIG_NET_SOCKETS_PACKET=y
       - CONFIG_NET_ZPERF_RAW_TX=y
   sample.net.zperf.raw_tx.nrf7002dk:
     extra_args: SNIPPET=wifi-ipv4
+    tags:
+      - net
     extra_configs:
       - CONFIG_BUILD_ONLY_NO_BLOBS=y
       - CONFIG_NET_SOCKETS_PACKET=y


### PR DESCRIPTION
Add a hardware-agnostic, host-speed-independent way to use the zperf sample as a network throughput regression check. The measurement runs entirely inside a qemu_x86 guest over the in-guest loopback interface, with QEMU icount mode enabled so the guest's notion of time is derived from executed instructions rather than host wall-clock time. Throughput then becomes a deterministic function of instructions-per-byte: identical across runs and machines, and sensitive to real code regressions.

native_sim is unsuitable because its simulated clock either tracks host wall time or makes CPU work cost zero simulated time, and plain qemu_x86 disables icount when networking and the shell are enabled.

Changes:
- overlay-loopback-icount.conf: enable QEMU icount, single CPU, disable SLIP/TAP, and set the stack sizes and 10 kHz tick rate needed by the synchronous loopback delivery path.
- Kconfig: add CONFIG_ZPERF_LOOPBACK_SELFTEST and duration/packet-size/ rate/port knobs.
- src/main.c: self-driven runner that, for both IPv4 (127.0.0.1) and IPv6 (::1), binds the receiver to the loopback address and uploads to it, printing ZPERF-RESULT udp4/tcp4/udp6/tcp6 lines and a final ZPERF-DONE marker.
- tests.yaml: sample.net.zperf.loopback_icount console-harness scenario that records udp4_mbps, tcp4_mbps, udp6_mbps and tcp6_mbps.
- scripts/zperf_regression.py: capture a baseline from twister.json and gate on a maximum allowed throughput drop.
- README: document the technical background and usage.

Assisted-by: Claude:claude-opus-4.8