### PR TITLE
wifi samples|tests: Do not build for 64bits

### DIFF
--- a/samples/net/wifi/shell/tests.yaml
+++ b/samples/net/wifi/shell/tests.yaml
@@ -133,6 +133,5 @@ tests:
   sample.net.wifi.hwsim:
     platform_allow:
       - native_sim
-      - native_sim/native/64
     integration_platforms:
       - native_sim

--- a/tests/drivers/wifi/hwsim/tests.yaml
+++ b/tests/drivers/wifi/hwsim/tests.yaml
@@ -5,7 +5,6 @@ tests:
   drivers.wifi.hwsim:
     platform_allow:
       - native_sim
-      - native_sim/native/64
     tags:
       - wifi
       - hwsim


### PR DESCRIPTION
The hostap module does not build cleanly for 64bits targets, so
allowing this sample for native_sim//64 results in a failure in CI
where warnings are treated as errors.

Introduced in 
* https://github.com/zephyrproject-rtos/zephyr/pull/111236

Related to 
* https://github.com/zephyrproject-rtos/hostap/pull/62