### PR TITLE
samples: bluetooth: classic: Add and update no_blobs test variants

### DIFF
--- a/samples/bluetooth/classic/a2dp_sink/tests.yaml
+++ b/samples/bluetooth/classic/a2dp_sink/tests.yaml
@@ -14,8 +14,19 @@ tests:
       - mimxrt1170_evk@B/mimxrt1176/cm7
     tags:
       - bluetooth
-      - gap
+      - i2s
+      - codec
     extra_args:
       - CONFIG_BUILD_ONLY_NO_BLOBS=y
-    timeout: 600
+    build_only: true
+  sample.bluetooth.a2dp.sink.nxp_m2_2el_wifi_bt.no_blobs:
+    platform_allow:
+      - mimxrt1060_evk@C/mimxrt1062/qspi
+    tags:
+      - bluetooth
+      - i2s
+      - codec
+    extra_args:
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+      - SHIELD=nxp_m2_2el_wifi_bt
     build_only: true

--- a/samples/bluetooth/classic/a2dp_source/tests.yaml
+++ b/samples/bluetooth/classic/a2dp_source/tests.yaml
@@ -14,8 +14,19 @@ tests:
       - mimxrt1170_evk@B/mimxrt1176/cm7
     tags:
       - bluetooth
-      - gap
+      - i2s
+      - codec
     extra_args:
       - CONFIG_BUILD_ONLY_NO_BLOBS=y
-    timeout: 600
+    build_only: true
+  sample.bluetooth.a2dp.sink.nxp_m2_2el_wifi_bt.no_blobs:
+    platform_allow:
+      - mimxrt1060_evk@C/mimxrt1062/qspi
+    tags:
+      - bluetooth
+      - i2s
+      - codec
+    extra_args:
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+      - SHIELD=nxp_m2_2el_wifi_bt
     build_only: true

--- a/samples/bluetooth/classic/handsfree/tests.yaml
+++ b/samples/bluetooth/classic/handsfree/tests.yaml
@@ -9,3 +9,24 @@ tests:
     tags: bluetooth
     integration_platforms:
       - qemu_cortex_m3
+  sample.bluetooth.handsfree.no_blobs:
+    platform_allow:
+      - mimxrt1170_evk@B/mimxrt1176/cm7
+    tags:
+      - bluetooth
+      - i2s
+      - codec
+    extra_args:
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+    build_only: true
+  sample.bluetooth.a2dp.sink.nxp_m2_2el_wifi_bt.no_blobs:
+    platform_allow:
+      - mimxrt1060_evk@C/mimxrt1062/qspi
+    tags:
+      - bluetooth
+      - i2s
+      - codec
+    extra_args:
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+      - SHIELD=nxp_m2_2el_wifi_bt
+    build_only: true

--- a/samples/bluetooth/classic/handsfree_ag/tests.yaml
+++ b/samples/bluetooth/classic/handsfree_ag/tests.yaml
@@ -11,3 +11,13 @@ tests:
       - qemu_cortex_m3
     extra_configs:
       - CONFIG_BT_HFP_AG_CALL_OUTGOING=y
+  sample.bluetooth.handsfree.ag.no_blobs:
+    platform_allow:
+      - mimxrt1170_evk@B/mimxrt1176/cm7
+    tags:
+      - bluetooth
+      - i2s
+      - codec
+    extra_args:
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+    build_only: true


### PR DESCRIPTION
Add no_blobs test variants for handsfree and handsfree_ag samples to verify build compatibility without binary blobs on mimxrt platforms.

Also add mimxrt1060_evk@C/mimxrt1062/qspi platform support to existing a2dp_source and a2dp_sink no_blobs tests, and also update the timeout from 600 to 60 seconds.