### PR TITLE
twister: reports: Also report toolchain in synopsis shortlist

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -709,7 +709,7 @@ class Reporting:
                     status = Fore.RED + status.upper() + Fore.RESET
                 logger.info(
                     f"{cnt}) {instance.testsuite.name} on {instance.platform.name}"
-                    f" {status} ({instance.reason})"
+                    f" ({instance.toolchain}) {status} ({instance.reason})"
                 )
                 example_instance = instance
             if cnt == count:

--- a/scripts/tests/twister_blackbox/test_report.py
+++ b/scripts/tests/twister_blackbox/test_report.py
@@ -111,9 +111,9 @@ class TestReport:
         (
             os.path.join(TEST_DATA, 'tests', 'one_fail_two_error_one_pass'),
             ['qemu_x86/atom'],
-            [r'one_fail_two_error_one_pass.agnostic.group1.subgroup2 on qemu_x86/atom FAILED \(.*\)',
-            r'one_fail_two_error_one_pass.agnostic.group1.subgroup3 on qemu_x86/atom ERROR \(Build failure.*\)',
-            r'one_fail_two_error_one_pass.agnostic.group1.subgroup4 on qemu_x86/atom ERROR \(Build failure.*\)'],
+            [r'one_fail_two_error_one_pass.agnostic.group1.subgroup2 on qemu_x86/atom \(.*\) FAILED \(.*\)',
+            r'one_fail_two_error_one_pass.agnostic.group1.subgroup3 on qemu_x86/atom \(.*\) ERROR \(Build failure.*\)',
+            r'one_fail_two_error_one_pass.agnostic.group1.subgroup4 on qemu_x86/atom \(.*\) ERROR \(Build failure.*\)'],
         )
     ]
 

--- a/scripts/tests/twister_blackbox/test_runner.py
+++ b/scripts/tests/twister_blackbox/test_runner.py
@@ -643,7 +643,7 @@ class TestRunner:
 
 
         assert re.search(
-            r'one_fail_one_pass.agnostic.group1.subgroup2 on qemu_x86/atom failed \(.*\)', err)
+            r'one_fail_one_pass.agnostic.group1.subgroup2 on qemu_x86/atom \(.*\) failed \(.*\)', err)
 
 
         select_search = re.search(select_regex, err, re.MULTILINE)


### PR DESCRIPTION
Now that we are building with multiple toolchains some failures will only happen with one toolchain.

So, also print the toolchain used, so it is easier to identify the issue.

And update the twister blackbox tests reference data.

So this error: 
https://github.com/zephyrproject-rtos/zephyr/actions/runs/29970525128/job/89145988629#step:12:2347
will be instead:
sample.net.sockets.coap_upload on native_sim/native **(host/llvm)** error (Build failure - error: adding 'size_t' (aka 'unsigned int') to a string does not append to the string [-Werror,-Wstring-plus-int])