### PR TITLE
modules: lvgl: support multiple displays with LV_Z_FLUSH_THREAD

### DIFF
--- a/modules/lvgl/include/lvgl_display.h
+++ b/modules/lvgl/include/lvgl_display.h
@@ -18,6 +18,9 @@ extern "C" {
 struct lvgl_disp_data {
 	const struct device *display_dev;
 	struct display_capabilities cap;
+#ifdef CONFIG_LV_Z_FLUSH_THREAD
+	struct k_sem flush_complete;
+#endif
 	bool blanking_on;
 };
 

--- a/modules/lvgl/lvgl_display.c
+++ b/modules/lvgl/lvgl_display.c
@@ -12,11 +12,8 @@
 
 #ifdef CONFIG_LV_Z_FLUSH_THREAD
 
-K_SEM_DEFINE(flush_complete, 0, 1);
-/* Needed because the wait callback might be called even if not flush is pending */
-K_SEM_DEFINE(flush_required, 0, 1);
-/* Message queue will only ever need to queue one message */
-K_MSGQ_DEFINE(flush_queue, sizeof(struct lvgl_display_flush), 1, 1);
+/* There can be up to DISPLAY_COUNT flush events at the same time*/
+K_MSGQ_DEFINE(flush_queue, sizeof(struct lvgl_display_flush), DT_ZEPHYR_DISPLAYS_COUNT, 1);
 
 void lvgl_flush_thread_entry(void *arg1, void *arg2, void *arg3)
 {
@@ -30,18 +27,18 @@ void lvgl_flush_thread_entry(void *arg1, void *arg2, void *arg3)
 		flush.desc.frame_incomplete = !lv_display_flush_is_last(flush.display);
 		display_write(data->display_dev, flush.x, flush.y, &flush.desc, flush.buf);
 
-		k_sem_give(&flush_complete);
+		k_sem_give(&data->flush_complete);
 	}
 }
 
 K_THREAD_DEFINE(lvgl_flush_thread, CONFIG_LV_Z_FLUSH_THREAD_STACK_SIZE, lvgl_flush_thread_entry,
 		NULL, NULL, NULL, CONFIG_LV_Z_FLUSH_THREAD_PRIORITY, 0, 0);
 
-void lvgl_wait_cb(lv_display_t *display)
+static void lvgl_wait_cb(lv_display_t *display)
 {
-	if (k_sem_take(&flush_required, K_NO_WAIT) == 0) {
-		k_sem_take(&flush_complete, K_FOREVER);
-	}
+	struct lvgl_disp_data *data = (struct lvgl_disp_data *)lv_display_get_user_data(display);
+
+	k_sem_take(&data->flush_complete, K_FOREVER);
 }
 
 #endif /* CONFIG_LV_Z_FLUSH_THREAD */
@@ -73,6 +70,7 @@ int set_lvgl_rendering_cb(lv_display_t *display)
 	struct lvgl_disp_data *data = (struct lvgl_disp_data *)lv_display_get_user_data(display);
 
 #ifdef CONFIG_LV_Z_FLUSH_THREAD
+	k_sem_init(&data->flush_complete, 0, 1);
 	lv_display_set_flush_wait_cb(display, lvgl_wait_cb);
 #endif
 
@@ -134,21 +132,19 @@ int set_lvgl_rendering_cb(lv_display_t *display)
 
 void lvgl_flush_display(struct lvgl_display_flush *request)
 {
+	struct lvgl_disp_data *data =
+		(struct lvgl_disp_data *)lv_display_get_user_data(request->display);
 #ifdef CONFIG_LV_Z_FLUSH_THREAD
 	/*
 	 * LVGL will only start a flush once the previous one is complete,
 	 * so we can reset the flush state semaphore here.
 	 */
-	k_sem_reset(&flush_complete);
+	k_sem_reset(&data->flush_complete);
 	k_msgq_put(&flush_queue, request, K_FOREVER);
-	k_sem_give(&flush_required);
 	/* Explicitly yield, in case the calling thread is a cooperative one */
 	k_yield();
 #else
 	/* Write directly to the display */
-	struct lvgl_disp_data *data =
-		(struct lvgl_disp_data *)lv_display_get_user_data(request->display);
-
 	request->desc.frame_incomplete = !lv_display_flush_is_last(request->display);
 	display_write(data->display_dev, request->x, request->y, &request->desc, request->buf);
 	lv_display_flush_ready(request->display);


### PR DESCRIPTION
Previously the code claimed that there could only be one flush event at a time which is only true if there's a single display, with mulitple displays LVGL doesn't wait for one display to render another meaning that there can be two display flushing at the same time

Additionally it also claimed that LVGL can call `flush_wait` for a non flushing display which is untrue. Unless a semaphore is used to track the state of multiple displays there's no need for a `flush_request` display semaphore

https://github.com/zephyrproject-rtos/zephyr/pull/111191 went stale as I tried to see if adding an async variant to display_write was a good approach, i'm cherry-picking this fix from there so that this enters the tree even if we end up not using async display writes