### PR TITLE
net: ip: core: do iface autostart last

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -663,27 +663,24 @@ static void init_rx_queues(void)
 	 */
 	net_if_init();
 
-	/* This will take the interface up and start everything. */
-	net_if_post_init();
-
-	/* Things to init after network interface is working */
+	/* Things to init after network interface is initialized */
 	net_post_init();
 }
 
-static inline int services_init(void)
+static inline void services_init(void)
 {
 	int status;
 
 	socket_service_init();
 
 	status = net_dhcpv4_init();
-	if (status) {
-		return status;
+	if (status != 0) {
+		return;
 	}
 
 	status = net_dhcpv6_init();
 	if (status != 0) {
-		return status;
+		return;
 	}
 
 	net_dhcpv4_server_init();
@@ -698,8 +695,6 @@ static inline int services_init(void)
 	net_quic_init();
 
 	net_shell_init();
-
-	return status;
 }
 
 static int net_init(void)
@@ -716,7 +711,12 @@ static int net_init(void)
 
 	init_rx_queues();
 
-	return services_init();
+	services_init();
+
+	/* This will take all interfaces up, that have autostart enabled. */
+	net_if_post_init();
+
+	return 0;
 }
 
 SYS_INIT(net_init, POST_KERNEL, CONFIG_NET_INIT_PRIO);


### PR DESCRIPTION
as the iface is in most cases not operational
at that point and we also have ifaces without
autostart, no net init part should require that
the iface is up and therefore we should do that
at the end.