### PR TITLE
scripts: zephyr_module: allow to locate `zephyr/` in a arbitrary subdirectory

### DIFF
--- a/doc/develop/modules.rst
+++ b/doc/develop/modules.rst
@@ -71,7 +71,8 @@ Module Repositories
   under the zephyrproject-rtos GitHub organization.
 
 * The module repository codebase shall include a *module.yml* file in a
-  :file:`zephyr/` folder at the root of the repository.
+  :file:`zephyr/` folder at the root of the repository or in the path
+  specified by the ``module-path`` attribute.
 
 * Module repository names should follow the convention of using lowercase
   letters and dashes instead of underscores. This rule will apply to all
@@ -1105,6 +1106,23 @@ build system finds all the modules in your :term:`west installation` and uses
 those. It does this by running :ref:`west list <west-built-in-misc>` to get
 the paths of all the projects in the installation, then filters the results to
 just those projects which have the necessary module metadata files.
+
+Usually, the directory containing the module files is the same as the project
+repository. However, the ``userdata.module-path`` key allows to place the module
+in a subdirectory of the project repository. This is especially used in external
+projects that provide a module for Zephyr but don't want to expose it in
+their root directory:
+
+.. code-block:: yaml
+
+   manifest:
+     projects:
+       - name: external-feature
+         url: https://github.com/acme/external-feature
+         revision: master
+         path: modules/external-feature
+         userdata:
+           module-path: thirdparty-integrations
 
 Each project in the ``west list`` output is tested like this:
 

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -751,12 +751,23 @@ def west_projects(manifest=None):
     return None
 
 
+def project_module_path(project):
+    # Honor userdata.module-path if exist
+    userdata = getattr(project, 'userdata', None)
+    if not isinstance(userdata, dict):
+        return project.posixpath
+    module_path = userdata.get('module-path')
+    if not module_path:
+        return project.posixpath
+    return PurePath(project.posixpath, module_path).as_posix()
+
+
 def parse_modules(zephyr_base, manifest=None, west_projs=None, modules=None,
                   extra_modules=None, require_yaml_validation=True):
 
     if modules is None:
         west_projs = west_projs or west_projects(manifest)
-        modules = ([p.posixpath for p in west_projs['projects']]
+        modules = ([project_module_path(p) for p in west_projs['projects']]
                    if west_projs else [])
 
     if extra_modules is None:

--- a/tests/cmake/module_path/CMakeLists.txt
+++ b/tests/cmake/module_path/CMakeLists.txt
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Silicon Laboratories Inc.
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(module_path_test)
+
+target_sources(app PRIVATE ${ZEPHYR_BASE}/misc/empty_file.c)
+
+# fake_workspace/main_project/west.yml declares a 'module' project whose module
+# metadata (zephyr/module.yml, Kconfig, CMakeLists.txt) lives in 'module/custom'
+# and points at it using the  project's 'userdata.module-path' key. This checks
+# that the build system finds the module there, and not directly under the
+# project's checkout root ('module/').
+
+set(workspace ${CMAKE_CURRENT_SOURCE_DIR}/fake_workspace)
+
+execute_process(
+  COMMAND
+  ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/zephyr_module.py
+  --cmake-out ${CMAKE_CURRENT_BINARY_DIR}/cmake.out
+  --kconfig-out ${CMAKE_CURRENT_BINARY_DIR}/kconfig.out
+  WORKING_DIRECTORY ${workspace}
+  ERROR_VARIABLE error_text
+  RESULT_VARIABLE result
+)
+if(result)
+  message(FATAL_ERROR "zephyr_module.py failed: ${error_text}")
+endif()
+
+file(READ ${CMAKE_CURRENT_BINARY_DIR}/cmake.out cmake_out)
+string(FIND "${cmake_out}" "\"module\":\"${workspace}/module/custom\":" module_path_found)
+string(FIND "${cmake_out}" "\"module\":\"${workspace}/module\":" module_path_wrong_found)
+
+if(NOT module_path_wrong_found EQUAL -1)
+  message(FATAL_ERROR "Test failed, module-path is not honored")
+endif()
+
+if(module_path_found EQUAL -1)
+  message(FATAL_ERROR "Test failed, module is not detected")
+endif()

--- a/tests/cmake/module_path/fake_workspace/.west/config
+++ b/tests/cmake/module_path/fake_workspace/.west/config
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Silicon Laboratories Inc.
+
+# This is a throwaway, self-contained west workspace used only by
+# tests/cmake/module_path/CMakeLists.txt to exercise west's
+# generic project 'userdata' attribute with a 'module-path' key,
+# independently of the real Zephyr workspace this test lives in.
+[manifest]
+path = main_project
+file = west.yml

--- a/tests/cmake/module_path/fake_workspace/main_project/west.yml
+++ b/tests/cmake/module_path/fake_workspace/main_project/west.yml
@@ -1,0 +1,10 @@
+manifest:
+  projects:
+    - name: module
+      url: https://example.com/module
+      revision: master
+      path: module
+      userdata:
+        module-path: custom
+  self:
+    path: main_project

--- a/tests/cmake/module_path/fake_workspace/module/custom/CMakeLists.txt
+++ b/tests/cmake/module_path/fake_workspace/module/custom/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Silicon Laboratories Inc.
+
+zephyr_library()
+zephyr_library_sources(${CMAKE_CURRENT_LIST_DIR}/../module.c)

--- a/tests/cmake/module_path/fake_workspace/module/custom/Kconfig
+++ b/tests/cmake/module_path/fake_workspace/module/custom/Kconfig
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Silicon Laboratories Inc.
+
+config MODULE_PATH_TEST_OPTION
+	bool "Fake option used to test module_path attribute"
+	default y

--- a/tests/cmake/module_path/fake_workspace/module/custom/zephyr/module.yml
+++ b/tests/cmake/module_path/fake_workspace/module/custom/zephyr/module.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Silicon Laboratories Inc.
+#
+# Fake module.yml used only by the tests/cmake/module_path test, to
+# check that the build system resolves 'zephyr/module.yml' relative to
+# the project's 'module-path' userdata entry ('custom'), and not
+# relative to the project's checkout root ('module/').
+
+name: module
+
+build:
+  cmake: .
+  kconfig: Kconfig

--- a/tests/cmake/module_path/fake_workspace/module/module.c
+++ b/tests/cmake/module_path/fake_workspace/module/module.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Silicon Laboratories Inc.
+ */
+
+#include <zephyr/autoconf.h>
+
+#ifndef CONFIG_MODULE_PATH_TEST_OPTION
+#error "Kconfig has been ignored"
+#endif

--- a/tests/cmake/module_path/prj.conf
+++ b/tests/cmake/module_path/prj.conf
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 Silicon Laboratories Inc.
+#
+# Nothing to configure, we are testing the build system.

--- a/tests/cmake/module_path/tests.yaml
+++ b/tests/cmake/module_path/tests.yaml
@@ -1,0 +1,6 @@
+common:
+  tags: cmake
+  build_only: true
+  platform_allow: native_sim
+tests:
+  buildsystem.module_path:


### PR DESCRIPTION
Some upstream projects support Zephyr and have to declare themselves as modules through `zephyr/module.yml`. However, this practice is intrusive and the upstream projects may not want to expose Zephyr support in their root directory.
    
This PR introduces a way to locate the zephyr files in an arbitrary subdirectory.
    
The required attribute has to be located in the west.yml file. We define a new "module-path" attribute located in the "userdata" field already allowed by the west specification.
    
With this change, a module like Matter can be integrated with West/Zephyr using this snippet:
    
      manifest:
        projects:
          - name: matter
            url: https://github.com/project-chip/connectedhomeip
            revision: master
            path: modules/lib/matter
            submodules:
              - path: third_party/editline/repo
              - path: third_party/jsoncpp/repo
              - path: third_party/nlassert/repo
              - path: third_party/nlio/repo
              - path: third_party/uriparser/repo
            userdata:
              module-path: config/zephyr/chip-module
            