### PR TITLE
drivers: audio: set logging level for audio codec drivers where missing

### DIFF
--- a/drivers/audio/cs43l22.c
+++ b/drivers/audio/cs43l22.c
@@ -8,7 +8,7 @@
 #include <zephyr/audio/codec.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(cirrus_cs43l22);
+LOG_MODULE_REGISTER(cirrus_cs43l22, CONFIG_AUDIO_CODEC_LOG_LEVEL);
 
 #define DT_DRV_COMPAT cirrus_cs43l22
 

--- a/drivers/audio/max98091.c
+++ b/drivers/audio/max98091.c
@@ -12,7 +12,7 @@
 #include <zephyr/logging/log.h>
 #include "max98091.h"
 
-LOG_MODULE_REGISTER(maxim_max98091);
+LOG_MODULE_REGISTER(maxim_max98091, CONFIG_AUDIO_CODEC_LOG_LEVEL);
 
 #define DT_DRV_COMPAT maxim_max98091
 

--- a/drivers/audio/pcm1681.c
+++ b/drivers/audio/pcm1681.c
@@ -17,7 +17,7 @@
 
 #include "pcm1681.h"
 
-LOG_MODULE_REGISTER(pcm1681);
+LOG_MODULE_REGISTER(pcm1681, CONFIG_AUDIO_CODEC_LOG_LEVEL);
 
 union pcm1681_bus_spec {
 	struct i2c_dt_spec i2c;

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -12,7 +12,7 @@
 #include <zephyr/devicetree/clocks.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(wolfson_wm8904);
+LOG_MODULE_REGISTER(wolfson_wm8904, CONFIG_AUDIO_CODEC_LOG_LEVEL);
 
 #include "wm8904.h"
 


### PR DESCRIPTION
While debugging with the WM8904 audio codec, I noticed that the logging level was not properly defined for that driver, and therefore debug logging could not be enabled selectively for that driver. Since `CONFIG_AUDIO_CODEC_LOG_LEVEL` is already defined, let's use that one.

While at it, I looked at other audio codec drivers where this was missing, such that all of them now have the same logging behavior.