### PR TITLE
net: sockets: Avoid busy wait looping at end of timeout

### DIFF
--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -609,7 +609,7 @@ static int send_check_and_wait(struct net_context *ctx, int status,
 	}
 
 	if (status == -ENOBUFS) {
-		/* We can monitor net_pkt/net_buf availability, so just wait. */
+		/* We can't monitor net_pkt/net_buf availability, so just wait. */
 		k_sleep(K_MSEC(*retry_timeout));
 	}
 

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -601,7 +601,7 @@ static int send_check_and_wait(struct net_context *ctx, int status,
 
 	if (!K_TIMEOUT_EQ(timeout, K_FOREVER)) {
 		*retry_timeout =
-			MIN(*retry_timeout, k_ticks_to_ms_floor32(timeout.ticks));
+			MIN(*retry_timeout, k_ticks_to_ms_ceil32(timeout.ticks));
 	}
 
 	if (ctx->cond.lock) {

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1094,7 +1094,7 @@ static int timeout_to_ms(k_timeout_t *timeout)
 	} else if (K_TIMEOUT_EQ(*timeout, K_FOREVER)) {
 		return SYS_FOREVER_MS;
 	} else {
-		return k_ticks_to_ms_floor32(timeout->ticks);
+		return k_ticks_to_ms_ceil32(timeout->ticks);
 	}
 }
 


### PR DESCRIPTION
With timeouts that do not divide evenly by the tick, because of flooring when converting to ticks, there is a left over time in which the send/recv functions would poll with a 0 timeout, which would return immediately, and result in poll being called right again. Effectively busy wait looping until the timeout is indeed 0.

Let's avoid this busy waiting by rounding up/ceiling the numberof ms to wait.

(+ fix a missing not in a comment next to one of those fixes)
