### PR TITLE
dts: bindings: base: add standard `ranges` property

### DIFF
--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -79,6 +79,27 @@ properties:
         - one with base address 0x1000, size 0x2000, and name "foo"
         - another with base address 0x3000, size 0x4000, and name "bar"
 
+  # Does not follow the 'type: array' scheme, but gets type-checked
+  # by the code. Declare it here just so that other bindings can make it
+  # 'required: true' easily if they want to.
+  ranges:
+    type: compound
+    description: |
+      Information used to define a mapping (or translation) between the address
+      space of a bus (the "child address space") and the address space of the
+      bus node's parent (the "parent address space").
+
+      The "ranges" property is typically empty, or a sequence of triplets
+      (child bus address, parent bus address, length).
+
+      If the "ranges" property is empty, it specifies that the parent and child
+      address spaces are identical and no address translation is required.
+
+      If the "ranges" property is not present in a bus node, it is assumed that
+      no mapping exists between children of the node and the parent address space.
+
+      For details, see "2.3.8 ranges" in Devicetree Specification v0.4.
+
   interrupts:
     type: array
     description: |

--- a/dts/bindings/gpio/sifli,sf32lb-gpio-parent.yaml
+++ b/dts/bindings/gpio/sifli,sf32lb-gpio-parent.yaml
@@ -12,7 +12,6 @@ properties:
     required: true
 
   ranges:
-    type: array
     required: true
 
   "#address-cells":

--- a/dts/bindings/i2s/st,stm32-sai.yaml
+++ b/dts/bindings/i2s/st,stm32-sai.yaml
@@ -12,7 +12,6 @@ properties:
     required: true
 
   ranges:
-    type: compound
     required: true
 
   "#address-cells":

--- a/dts/bindings/pcie/host/pci-host-ecam-generic.yaml
+++ b/dts/bindings/pcie/host/pci-host-ecam-generic.yaml
@@ -15,7 +15,6 @@ properties:
     type: phandle
 
   ranges:
-    type: array
     required: true
     description: |
       As described in IEEE Std 1275-1994, but must provide at least a


### PR DESCRIPTION
Define the standard `ranges` property in the `base.yaml` binding so that other bindings can easily set it as `required: true`. The property follows the pattern of `interrupts-extended`: type `compound` is used to disable type-checking at DTLib level but the type is validated at EDTLib level:

https://github.com/zephyrproject-rtos/zephyr/blob/066f18113dc4cee8d29331f082705ecf4425e5c3/scripts/dts/python-devicetree/src/devicetree/edtlib.py#L3812-L3816