### PR TITLE
drivers: dma: stm32: introduce dma_stm32_zcfg_to_halcfg() private helper

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -238,6 +238,11 @@ static void stm32_sdmmc_dma_cb(const struct device *dev, void *arg,
 static int stm32_sdmmc_configure_dma(DMA_HandleTypeDef *handle, struct sdmmc_dma_stream *dma)
 {
 	int ret;
+	struct dma_config hal_dma_cfg = dma->cfg;
+	struct dma_block_config dma_block = {
+		.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE,
+		.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+	};
 
 	if (!device_is_ready(dma->dev)) {
 		LOG_ERR("Failed to get dma dev");
@@ -255,15 +260,19 @@ static int stm32_sdmmc_configure_dma(DMA_HandleTypeDef *handle, struct sdmmc_dma
 		return ret;
 	}
 
+	hal_dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
+	hal_dma_cfg.source_data_size = 4U;
+	hal_dma_cfg.dest_data_size = 4U;
+	hal_dma_cfg.head_block = &dma_block;
+	ret = dma_stm32_zcfg_to_halcfg(&hal_dma_cfg, &handle->Init);
+	if (ret < 0) {
+		return ret;
+	}
+
 	handle->Instance                 = STM32_DMA_GET_INSTANCE(dma->reg, dma->channel_nb);
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v1)
 	handle->Init.Channel             = dma->cfg.dma_slot * DMA_CHANNEL_1;
-	handle->Init.PeriphInc           = DMA_PINC_DISABLE;
-	handle->Init.MemInc              = DMA_MINC_ENABLE;
-	handle->Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
-	handle->Init.MemDataAlignment    = DMA_MDATAALIGN_WORD;
 	handle->Init.Mode                = DMA_PFCTRL;
-	handle->Init.Priority            = table_priority[dma->cfg.channel_priority];
 	handle->Init.FIFOMode            = DMA_FIFOMODE_ENABLE;
 	handle->Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
 	handle->Init.MemBurst            = DMA_MBURST_INC4;
@@ -275,12 +284,6 @@ static int stm32_sdmmc_configure_dma(DMA_HandleTypeDef *handle, struct sdmmc_dma
 	 * configured before each read/write call.
 	 */
 	handle->Init.Request             = dma->cfg.dma_slot;
-	handle->Init.PeriphInc           = DMA_PINC_DISABLE;
-	handle->Init.MemInc              = DMA_MINC_ENABLE;
-	handle->Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
-	handle->Init.MemDataAlignment    = DMA_MDATAALIGN_WORD;
-	handle->Init.Mode                = DMA_NORMAL;
-	handle->Init.Priority            = table_priority[dma->cfg.channel_priority];
 #endif
 
 	return ret;

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -76,14 +76,6 @@ LOG_MODULE_REGISTER(stm32_sdmmc, CONFIG_SDMMC_LOG_LEVEL);
 typedef void (*irq_config_func_t)(const struct device *dev);
 
 #if STM32_SDMMC_USE_DMA
-
-static const uint32_t table_priority[] = {
-	DMA_PRIORITY_LOW,
-	DMA_PRIORITY_MEDIUM,
-	DMA_PRIORITY_HIGH,
-	DMA_PRIORITY_VERY_HIGH
-};
-
 struct sdmmc_dma_stream {
 	const struct device *dev;
 	uint32_t channel;
@@ -238,6 +230,7 @@ static void stm32_sdmmc_dma_cb(const struct device *dev, void *arg,
 static int stm32_sdmmc_configure_dma(DMA_HandleTypeDef *handle, struct sdmmc_dma_stream *dma)
 {
 	int ret;
+	struct dma_config hal_dma_cfg = dma->cfg;
 
 	if (!device_is_ready(dma->dev)) {
 		LOG_ERR("Failed to get dma dev");
@@ -255,15 +248,19 @@ static int stm32_sdmmc_configure_dma(DMA_HandleTypeDef *handle, struct sdmmc_dma
 		return ret;
 	}
 
+	hal_dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
+	hal_dma_cfg.source_data_size = 4U;
+	hal_dma_cfg.dest_data_size = 4U;
+	ret = dma_stm32_zcfg_to_halcfg(dma->dev, &hal_dma_cfg, &handle->Init,
+				       DMA_ADDR_ADJ_NO_CHANGE, DMA_ADDR_ADJ_INCREMENT);
+	if (ret < 0) {
+		return ret;
+	}
+
 	handle->Instance                 = STM32_DMA_GET_INSTANCE(dma->reg, dma->channel_nb);
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v1)
 	handle->Init.Channel             = dma->cfg.dma_slot * DMA_CHANNEL_1;
-	handle->Init.PeriphInc           = DMA_PINC_DISABLE;
-	handle->Init.MemInc              = DMA_MINC_ENABLE;
-	handle->Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
-	handle->Init.MemDataAlignment    = DMA_MDATAALIGN_WORD;
 	handle->Init.Mode                = DMA_PFCTRL;
-	handle->Init.Priority            = table_priority[dma->cfg.channel_priority];
 	handle->Init.FIFOMode            = DMA_FIFOMODE_ENABLE;
 	handle->Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
 	handle->Init.MemBurst            = DMA_MBURST_INC4;
@@ -275,12 +272,6 @@ static int stm32_sdmmc_configure_dma(DMA_HandleTypeDef *handle, struct sdmmc_dma
 	 * configured before each read/write call.
 	 */
 	handle->Init.Request             = dma->cfg.dma_slot;
-	handle->Init.PeriphInc           = DMA_PINC_DISABLE;
-	handle->Init.MemInc              = DMA_MINC_ENABLE;
-	handle->Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
-	handle->Init.MemDataAlignment    = DMA_MDATAALIGN_WORD;
-	handle->Init.Mode                = DMA_NORMAL;
-	handle->Init.Priority            = table_priority[dma->cfg.channel_priority];
 #endif
 
 	return ret;

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -13,12 +13,380 @@
 
 #include "dma_stm32.h"
 
+#include <errno.h>
+#include <string.h>
+
 #include <zephyr/init.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/dma/dma_stm32.h>
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
+
+static int dma_stm32_hal_map_direction(uint32_t z_dir, uint32_t *hal_dir)
+{
+	switch (z_dir) {
+	case MEMORY_TO_MEMORY:
+		*hal_dir = DMA_MEMORY_TO_MEMORY;
+		return 0;
+	case MEMORY_TO_PERIPHERAL:
+		*hal_dir = DMA_MEMORY_TO_PERIPH;
+		return 0;
+	case PERIPHERAL_TO_MEMORY:
+		*hal_dir = DMA_PERIPH_TO_MEMORY;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int dma_stm32_hal_map_priority(uint32_t z_prio, uint32_t *hal_prio)
+{
+	switch (z_prio) {
+	case 0:
+#ifdef DMA_PRIORITY_LOW
+		*hal_prio = DMA_PRIORITY_LOW;
+#else
+		*hal_prio = DMA_LOW_PRIORITY_LOW_WEIGHT;
+#endif
+		return 0;
+	case 1:
+#ifdef DMA_PRIORITY_MEDIUM
+		*hal_prio = DMA_PRIORITY_MEDIUM;
+#else
+		*hal_prio = DMA_LOW_PRIORITY_MID_WEIGHT;
+#endif
+		return 0;
+	case 2:
+#ifdef DMA_PRIORITY_HIGH
+		*hal_prio = DMA_PRIORITY_HIGH;
+#else
+		*hal_prio = DMA_LOW_PRIORITY_HIGH_WEIGHT;
+#endif
+		return 0;
+	case 3:
+#ifdef DMA_PRIORITY_VERY_HIGH
+		*hal_prio = DMA_PRIORITY_VERY_HIGH;
+#else
+		*hal_prio = DMA_HIGH_PRIORITY;
+#endif
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int dma_stm32_hal_map_data_size(uint32_t z_size,
+				       uint32_t *hal_size,
+				       uint32_t hal_byte,
+				       uint32_t hal_halfword,
+				       uint32_t hal_word)
+{
+	switch (z_size) {
+	case 1:
+		*hal_size = hal_byte;
+		return 0;
+	case 2:
+		*hal_size = hal_halfword;
+		return 0;
+	case 4:
+		*hal_size = hal_word;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int dma_stm32_hal_map_mode(const struct dma_config *cfg, uint32_t *hal_mode)
+{
+	if ((cfg == NULL) || (hal_mode == NULL)) {
+		return -EINVAL;
+	}
+
+	if (cfg->cyclic) {
+#ifdef DMA_CIRCULAR
+		*hal_mode = DMA_CIRCULAR;
+#else
+		return -ENOTSUP;
+#endif
+	} else {
+		*hal_mode = DMA_NORMAL;
+	}
+
+	return 0;
+}
+
+static int dma_stm32_hal_map_addr_adj(enum dma_addr_adj z_adj,
+				      uint32_t *hal_inc,
+				      uint32_t hal_inc_val,
+				      uint32_t hal_noinc_val)
+{
+	if (hal_inc == NULL) {
+		return -EINVAL;
+	}
+
+	switch (z_adj) {
+	case DMA_ADDR_ADJ_INCREMENT:
+		*hal_inc = hal_inc_val;
+		return 0;
+	case DMA_ADDR_ADJ_NO_CHANGE:
+		*hal_inc = hal_noinc_val;
+		return 0;
+	case DMA_ADDR_ADJ_DECREMENT:
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int dma_stm32_hal_config_widths(const struct dma_config *cfg,
+				       DMA_InitTypeDef *hal_config)
+{
+	int ret;
+
+	switch (cfg->channel_direction) {
+	case PERIPHERAL_TO_MEMORY:
+#ifdef DMA_SRC_DATAWIDTH_BYTE
+		ret = dma_stm32_hal_map_data_size(cfg->source_data_size,
+						      &hal_config->SrcDataWidth,
+						      DMA_SRC_DATAWIDTH_BYTE,
+						      DMA_SRC_DATAWIDTH_HALFWORD,
+						      DMA_SRC_DATAWIDTH_WORD);
+		if (ret < 0) {
+			return ret;
+		}
+
+		ret = dma_stm32_hal_map_data_size(cfg->dest_data_size,
+						      &hal_config->DestDataWidth,
+						      DMA_DEST_DATAWIDTH_BYTE,
+						      DMA_DEST_DATAWIDTH_HALFWORD,
+						      DMA_DEST_DATAWIDTH_WORD);
+#else
+		ret = dma_stm32_hal_map_data_size(cfg->source_data_size,
+						      &hal_config->PeriphDataAlignment,
+						      DMA_PDATAALIGN_BYTE,
+						      DMA_PDATAALIGN_HALFWORD,
+						      DMA_PDATAALIGN_WORD);
+		if (ret < 0) {
+			return ret;
+		}
+
+		ret = dma_stm32_hal_map_data_size(cfg->dest_data_size,
+						      &hal_config->MemDataAlignment,
+						      DMA_MDATAALIGN_BYTE,
+						      DMA_MDATAALIGN_HALFWORD,
+						      DMA_MDATAALIGN_WORD);
+#endif
+		return ret;
+	case MEMORY_TO_PERIPHERAL:
+#ifdef DMA_SRC_DATAWIDTH_BYTE
+		ret = dma_stm32_hal_map_data_size(cfg->source_data_size,
+						      &hal_config->SrcDataWidth,
+						      DMA_SRC_DATAWIDTH_BYTE,
+						      DMA_SRC_DATAWIDTH_HALFWORD,
+						      DMA_SRC_DATAWIDTH_WORD);
+		if (ret < 0) {
+			return ret;
+		}
+
+		ret = dma_stm32_hal_map_data_size(cfg->dest_data_size,
+						      &hal_config->DestDataWidth,
+						      DMA_DEST_DATAWIDTH_BYTE,
+						      DMA_DEST_DATAWIDTH_HALFWORD,
+						      DMA_DEST_DATAWIDTH_WORD);
+#else
+		ret = dma_stm32_hal_map_data_size(cfg->dest_data_size,
+						      &hal_config->PeriphDataAlignment,
+						      DMA_PDATAALIGN_BYTE,
+						      DMA_PDATAALIGN_HALFWORD,
+						      DMA_PDATAALIGN_WORD);
+		if (ret < 0) {
+			return ret;
+		}
+
+		ret = dma_stm32_hal_map_data_size(cfg->source_data_size,
+						      &hal_config->MemDataAlignment,
+						      DMA_MDATAALIGN_BYTE,
+						      DMA_MDATAALIGN_HALFWORD,
+						      DMA_MDATAALIGN_WORD);
+#endif
+		return ret;
+	case MEMORY_TO_MEMORY:
+		if (cfg->source_data_size != cfg->dest_data_size) {
+			return -ENOTSUP;
+		}
+
+#ifdef DMA_SRC_DATAWIDTH_BYTE
+		ret = dma_stm32_hal_map_data_size(cfg->source_data_size,
+						      &hal_config->SrcDataWidth,
+						      DMA_SRC_DATAWIDTH_BYTE,
+						      DMA_SRC_DATAWIDTH_HALFWORD,
+						      DMA_SRC_DATAWIDTH_WORD);
+		if (ret < 0) {
+			return ret;
+		}
+
+		ret = dma_stm32_hal_map_data_size(cfg->dest_data_size,
+						      &hal_config->DestDataWidth,
+						      DMA_DEST_DATAWIDTH_BYTE,
+						      DMA_DEST_DATAWIDTH_HALFWORD,
+						      DMA_DEST_DATAWIDTH_WORD);
+#else
+		ret = dma_stm32_hal_map_data_size(cfg->source_data_size,
+						      &hal_config->PeriphDataAlignment,
+						      DMA_PDATAALIGN_BYTE,
+						      DMA_PDATAALIGN_HALFWORD,
+						      DMA_PDATAALIGN_WORD);
+		if (ret < 0) {
+			return ret;
+		}
+
+		ret = dma_stm32_hal_map_data_size(cfg->dest_data_size,
+						      &hal_config->MemDataAlignment,
+						      DMA_MDATAALIGN_BYTE,
+						      DMA_MDATAALIGN_HALFWORD,
+						      DMA_MDATAALIGN_WORD);
+#endif
+		return ret;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int dma_stm32_hal_config_increments(const struct dma_config *cfg,
+					  DMA_InitTypeDef *hal_config)
+{
+	int ret;
+	const struct dma_block_config *block = cfg->head_block;
+
+#ifdef DMA_SINC_FIXED
+	ret = dma_stm32_hal_map_addr_adj(block->source_addr_adj,
+					  &hal_config->SrcInc,
+					  DMA_SINC_INCREMENTED,
+					  DMA_SINC_FIXED);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return dma_stm32_hal_map_addr_adj(block->dest_addr_adj,
+					      &hal_config->DestInc,
+					      DMA_DINC_INCREMENTED,
+					      DMA_DINC_FIXED);
+#else
+	switch (cfg->channel_direction) {
+	case MEMORY_TO_PERIPHERAL:
+		ret = dma_stm32_hal_map_addr_adj(block->source_addr_adj,
+					      &hal_config->MemInc,
+					      DMA_MINC_ENABLE,
+					      DMA_MINC_DISABLE);
+		if (ret < 0) {
+			return ret;
+		}
+
+		return dma_stm32_hal_map_addr_adj(block->dest_addr_adj,
+					      &hal_config->PeriphInc,
+					      DMA_PINC_ENABLE,
+					      DMA_PINC_DISABLE);
+	case PERIPHERAL_TO_MEMORY:
+		ret = dma_stm32_hal_map_addr_adj(block->source_addr_adj,
+					      &hal_config->PeriphInc,
+					      DMA_PINC_ENABLE,
+					      DMA_PINC_DISABLE);
+		if (ret < 0) {
+			return ret;
+		}
+
+		return dma_stm32_hal_map_addr_adj(block->dest_addr_adj,
+					      &hal_config->MemInc,
+					      DMA_MINC_ENABLE,
+					      DMA_MINC_DISABLE);
+	case MEMORY_TO_MEMORY:
+		ret = dma_stm32_hal_map_addr_adj(block->source_addr_adj,
+					      &hal_config->PeriphInc,
+					      DMA_PINC_ENABLE,
+					      DMA_PINC_DISABLE);
+		if (ret < 0) {
+			return ret;
+		}
+
+		return dma_stm32_hal_map_addr_adj(block->dest_addr_adj,
+					      &hal_config->MemInc,
+					      DMA_MINC_ENABLE,
+					      DMA_MINC_DISABLE);
+	default:
+		return -ENOTSUP;
+	}
+#endif
+}
+
+int dma_stm32_zcfg_to_halcfg(const struct dma_config *zephyr_config,
+			     DMA_InitTypeDef *hal_config)
+{
+	int ret;
+
+	if ((zephyr_config == NULL) || (zephyr_config->head_block == NULL) ||
+	    (hal_config == NULL)) {
+		return -EINVAL;
+	}
+
+	memset(hal_config, 0, sizeof(*hal_config));
+
+	ret = dma_stm32_hal_map_direction(zephyr_config->channel_direction,
+					   &hal_config->Direction);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_map_priority(zephyr_config->channel_priority,
+					  &hal_config->Priority);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_config_widths(zephyr_config, hal_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_map_mode(zephyr_config, &hal_config->Mode);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_config_increments(zephyr_config, hal_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+#ifdef DMA_BREQ_SINGLE_BURST
+	hal_config->BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+#endif
+
+#ifdef DMA_TCEM_BLOCK_TRANSFER
+	hal_config->TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+#endif
+
+#ifdef DMA_FIFOMODE_DISABLE
+	hal_config->FIFOMode = DMA_FIFOMODE_DISABLE;
+#endif
+
+#ifdef DMA_FIFO_THRESHOLD_FULL
+	hal_config->FIFOThreshold = DMA_FIFO_THRESHOLD_FULL;
+#endif
+
+#ifdef DMA_MBURST_SINGLE
+	hal_config->MemBurst = DMA_MBURST_SINGLE;
+#endif
+
+#ifdef DMA_PBURST_SINGLE
+	hal_config->PeriphBurst = DMA_PBURST_SINGLE;
+#endif
+
+	return 0;
+}
+
+#if defined(CONFIG_DMA_STM32_V1) || defined(CONFIG_DMA_STM32_V2)
+
 LOG_MODULE_REGISTER(dma_stm32, CONFIG_DMA_LOG_LEVEL);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v1)
@@ -898,3 +1266,5 @@ static void dma_stm32_config_irq_1(const struct device *dev)
 DMA_STM32_INIT_DEV(1);
 
 #endif /* DT_NODE_HAS_STATUS_OKAY(DT_DRV_INST(1)) */
+
+#endif /* CONFIG_DMA_STM32_V1 || CONFIG_DMA_STM32_V2 */

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -19,6 +19,232 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
+
+#include <errno.h>
+#include <string.h>
+
+static int dma_stm32_hal_map_direction(uint32_t z_dir, uint32_t *hal_dir)
+{
+	switch (z_dir) {
+	case MEMORY_TO_MEMORY:
+		*hal_dir = DMA_MEMORY_TO_MEMORY;
+		return 0;
+	case MEMORY_TO_PERIPHERAL:
+		*hal_dir = DMA_MEMORY_TO_PERIPH;
+		return 0;
+	case PERIPHERAL_TO_MEMORY:
+		*hal_dir = DMA_PERIPH_TO_MEMORY;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int dma_stm32_hal_map_priority(uint32_t z_prio, uint32_t *hal_prio)
+{
+	switch (z_prio) {
+	case 0:
+		*hal_prio = DMA_PRIORITY_LOW;
+		return 0;
+	case 1:
+		*hal_prio = DMA_PRIORITY_MEDIUM;
+		return 0;
+	case 2:
+		*hal_prio = DMA_PRIORITY_HIGH;
+		return 0;
+	case 3:
+		*hal_prio = DMA_PRIORITY_VERY_HIGH;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int dma_stm32_hal_map_data_size(uint32_t z_size, uint32_t *hal_size, uint32_t hal_byte,
+				       uint32_t hal_halfword, uint32_t hal_word)
+{
+	switch (z_size) {
+	case 1:
+		*hal_size = hal_byte;
+		return 0;
+	case 2:
+		*hal_size = hal_halfword;
+		return 0;
+	case 4:
+		*hal_size = hal_word;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int dma_stm32_hal_map_mode(const struct dma_config *cfg, uint32_t *hal_mode)
+{
+	__ASSERT_NO_MSG(cfg != NULL && hal_mode != NULL);
+
+	if (cfg->cyclic) {
+#ifdef DMA_CIRCULAR
+		*hal_mode = DMA_CIRCULAR;
+#else
+		return -ENOTSUP;
+#endif
+	} else {
+		*hal_mode = DMA_NORMAL;
+	}
+
+	return 0;
+}
+
+static int dma_stm32_hal_map_addr_adj(enum dma_addr_adj z_adj, uint32_t *hal_inc,
+				      uint32_t hal_inc_val, uint32_t hal_noinc_val)
+{
+	__ASSERT_NO_MSG(hal_inc != NULL);
+
+	switch (z_adj) {
+	case DMA_ADDR_ADJ_INCREMENT:
+		*hal_inc = hal_inc_val;
+		return 0;
+	case DMA_ADDR_ADJ_NO_CHANGE:
+		*hal_inc = hal_noinc_val;
+		return 0;
+	case DMA_ADDR_ADJ_DECREMENT:
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int dma_stm32_hal_config_widths(const struct dma_config *cfg, DMA_InitTypeDef *hal_config)
+{
+	uint32_t periph_dsize, mem_dsize;
+	int ret;
+
+	switch (cfg->channel_direction) {
+	case MEMORY_TO_PERIPHERAL:
+		periph_dsize = cfg->dest_data_size;
+		mem_dsize = cfg->source_data_size;
+		break;
+	case MEMORY_TO_MEMORY:
+		if (cfg->source_data_size != cfg->dest_data_size) {
+			return -ENOTSUP;
+		}
+		__fallthrough;
+	case PERIPHERAL_TO_MEMORY:
+		periph_dsize = cfg->source_data_size;
+		mem_dsize = cfg->dest_data_size;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	ret = dma_stm32_hal_map_data_size(periph_dsize, &hal_config->PeriphDataAlignment,
+					  DMA_PDATAALIGN_BYTE, DMA_PDATAALIGN_HALFWORD,
+					  DMA_PDATAALIGN_WORD);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return dma_stm32_hal_map_data_size(mem_dsize, &hal_config->MemDataAlignment,
+					   DMA_MDATAALIGN_BYTE, DMA_MDATAALIGN_HALFWORD,
+					   DMA_MDATAALIGN_WORD);
+}
+
+static int dma_stm32_hal_config_increments(uint16_t source_addr_adj, uint16_t dest_addr_adj,
+					   uint32_t direction, DMA_InitTypeDef *hal_config)
+{
+	int ret;
+	enum dma_addr_adj periph_adj, mem_adj;
+
+	switch (direction) {
+	case MEMORY_TO_PERIPHERAL:
+		mem_adj = source_addr_adj;
+		periph_adj = dest_addr_adj;
+		break;
+	case PERIPHERAL_TO_MEMORY:
+	case MEMORY_TO_MEMORY:
+		mem_adj = dest_addr_adj;
+		periph_adj = source_addr_adj;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	ret = dma_stm32_hal_map_addr_adj(mem_adj, &hal_config->MemInc, DMA_MINC_ENABLE,
+					 DMA_MINC_DISABLE);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return dma_stm32_hal_map_addr_adj(periph_adj, &hal_config->PeriphInc, DMA_PINC_ENABLE,
+					  DMA_PINC_DISABLE);
+}
+
+int dma_stm32_zcfg_to_halcfg(const struct device *dma, const struct dma_config *zephyr_config,
+			     DMA_InitTypeDef *hal_config, uint16_t source_addr_adj,
+			     uint16_t dest_addr_adj)
+{
+	int ret;
+
+	__ASSERT_NO_MSG(dma != NULL && zephyr_config != NULL && hal_config != NULL);
+
+	memset(hal_config, 0, sizeof(*hal_config));
+
+	ret = dma_stm32_hal_map_direction(zephyr_config->channel_direction, &hal_config->Direction);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_map_priority(zephyr_config->channel_priority, &hal_config->Priority);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_config_widths(zephyr_config, hal_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_map_mode(zephyr_config, &hal_config->Mode);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_config_increments(source_addr_adj, dest_addr_adj,
+					      zephyr_config->channel_direction, hal_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+
+#if defined(CONFIG_DMA_STM32_V1) && !defined(CONFIG_SOC_SERIES_STM32H7X)
+	hal_config->Channel = zephyr_config->dma_slot;
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v2bis)
+	/* DMA under "st,stm32-dma-v2bis" compatible do not possess
+	 * DMA_InitTypeDef->Channel or DMA_InitTypeDef->Request.
+	 */
+#else
+	hal_config->Request = zephyr_config->dma_slot;
+#endif /* CONFIG_DMA_STM32_V1 */
+
+#ifdef DMA_FIFOMODE_DISABLE
+	hal_config->FIFOMode = DMA_FIFOMODE_DISABLE;
+#endif
+
+#ifdef DMA_FIFO_THRESHOLD_FULL
+	hal_config->FIFOThreshold = DMA_FIFO_THRESHOLD_FULL;
+#endif
+
+#ifdef DMA_MBURST_SINGLE
+	hal_config->MemBurst = DMA_MBURST_SINGLE;
+#endif
+
+#ifdef DMA_PBURST_SINGLE
+	hal_config->PeriphBurst = DMA_PBURST_SINGLE;
+#endif
+
+	return 0;
+}
+
 LOG_MODULE_REGISTER(dma_stm32, CONFIG_DMA_LOG_LEVEL);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v1)

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -179,6 +179,23 @@ static int dma_stm32_hal_config_increments(uint16_t source_addr_adj, uint16_t de
 					  DMA_PINC_DISABLE);
 }
 
+/*
+ * Default DMA driver configuration relies on these values,
+ * in case the fields have not been initialized in the @p zephyr_config.
+ *
+ * hal_config->Channel			= DMA_CHANNEL_0;
+ * hal_config->Direction		= DMA_PERIPH_TO_MEMORY;
+ * hal_config->PeriphInc		= DMA_PINC_DISABLE;
+ * hal_config->MemInc			= DMA_MINC_DISABLE;
+ * hal_config->PeriphDataAlignment	= DMA_PDATAALIGN_BYTE;
+ * hal_config->MemDataAlignment		= DMA_MDATAALIGN_BYTE;
+ * hal_config->Mode			= DMA_NORMAL;
+ * hal_config->Priority			= DMA_PRIORITY_LOW;
+ * hal_config->FIFOMode			= DMA_FIFOMODE_DISABLE;
+ * hal_config->FIFOThreshold		= DMA_FIFO_THRESHOLD_1QUARTERFULL;
+ * hal_config->MemBurst			= DMA_MBURST_SINGLE;
+ * hal_config->PeriphBurst		= DMA_PBURST_SINGLE;
+ */
 int dma_stm32_zcfg_to_halcfg(const struct device *dma, const struct dma_config *zephyr_config,
 			     DMA_InitTypeDef *hal_config, uint16_t source_addr_adj,
 			     uint16_t dest_addr_adj)

--- a/drivers/dma/dma_stm32_bdma.c
+++ b/drivers/dma/dma_stm32_bdma.c
@@ -10,6 +10,8 @@
 
 #include "dma_stm32_bdma.h"
 
+#include <string.h>
+
 #include <zephyr/init.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/dma/dma_stm32.h>
@@ -439,6 +441,285 @@ static int bdma_stm32_get_periph_increment(enum dma_addr_adj increment,
 
 	return 0;
 }
+
+#if !defined(CONFIG_DMA_STM32_V1) && !defined(CONFIG_DMA_STM32_V2)
+static int bdma_stm32_hal_map_direction(uint32_t z_dir, uint32_t *hal_dir)
+{
+	switch (z_dir) {
+	case MEMORY_TO_MEMORY:
+		*hal_dir = DMA_MEMORY_TO_MEMORY;
+		return 0;
+	case MEMORY_TO_PERIPHERAL:
+		*hal_dir = DMA_MEMORY_TO_PERIPH;
+		return 0;
+	case PERIPHERAL_TO_MEMORY:
+		*hal_dir = DMA_PERIPH_TO_MEMORY;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int bdma_stm32_hal_map_priority(uint32_t z_prio, uint32_t *hal_prio)
+{
+	switch (z_prio) {
+	case 0:
+#ifdef DMA_PRIORITY_LOW
+		*hal_prio = DMA_PRIORITY_LOW;
+#else
+		*hal_prio = DMA_LOW_PRIORITY_LOW_WEIGHT;
+#endif
+		return 0;
+	case 1:
+#ifdef DMA_PRIORITY_MEDIUM
+		*hal_prio = DMA_PRIORITY_MEDIUM;
+#else
+		*hal_prio = DMA_LOW_PRIORITY_MID_WEIGHT;
+#endif
+		return 0;
+	case 2:
+#ifdef DMA_PRIORITY_HIGH
+		*hal_prio = DMA_PRIORITY_HIGH;
+#else
+		*hal_prio = DMA_LOW_PRIORITY_HIGH_WEIGHT;
+#endif
+		return 0;
+	case 3:
+#ifdef DMA_PRIORITY_VERY_HIGH
+		*hal_prio = DMA_PRIORITY_VERY_HIGH;
+#else
+		*hal_prio = DMA_HIGH_PRIORITY;
+#endif
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int bdma_stm32_hal_map_data_size(uint32_t z_size,
+						uint32_t *hal_size,
+						uint32_t hal_byte,
+						uint32_t hal_halfword,
+						uint32_t hal_word)
+{
+	switch (z_size) {
+	case 1:
+		*hal_size = hal_byte;
+		return 0;
+	case 2:
+		*hal_size = hal_halfword;
+		return 0;
+	case 4:
+		*hal_size = hal_word;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int bdma_stm32_hal_map_mode(const struct dma_config *cfg, uint32_t *hal_mode)
+{
+	if (cfg->cyclic) {
+#ifdef DMA_CIRCULAR
+		*hal_mode = DMA_CIRCULAR;
+#else
+		return -ENOTSUP;
+#endif
+	} else {
+		*hal_mode = DMA_NORMAL;
+	}
+
+	return 0;
+}
+
+static int bdma_stm32_hal_map_addr_adj(enum dma_addr_adj z_adj,
+					       uint32_t *hal_inc,
+					       uint32_t hal_inc_val,
+					       uint32_t hal_noinc_val)
+{
+	switch (z_adj) {
+	case DMA_ADDR_ADJ_INCREMENT:
+		*hal_inc = hal_inc_val;
+		return 0;
+	case DMA_ADDR_ADJ_NO_CHANGE:
+		*hal_inc = hal_noinc_val;
+		return 0;
+	case DMA_ADDR_ADJ_DECREMENT:
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int bdma_stm32_hal_config_widths(const struct dma_config *cfg,
+						DMA_InitTypeDef *hal_config)
+{
+	int ret;
+
+	switch (cfg->channel_direction) {
+	case PERIPHERAL_TO_MEMORY:
+		ret = bdma_stm32_hal_map_data_size(cfg->source_data_size,
+						      &hal_config->PeriphDataAlignment,
+						      DMA_PDATAALIGN_BYTE,
+						      DMA_PDATAALIGN_HALFWORD,
+						      DMA_PDATAALIGN_WORD);
+		if (ret < 0) {
+			return ret;
+		}
+
+		return bdma_stm32_hal_map_data_size(cfg->dest_data_size,
+						   &hal_config->MemDataAlignment,
+						   DMA_MDATAALIGN_BYTE,
+						   DMA_MDATAALIGN_HALFWORD,
+						   DMA_MDATAALIGN_WORD);
+	case MEMORY_TO_PERIPHERAL:
+		ret = bdma_stm32_hal_map_data_size(cfg->dest_data_size,
+						      &hal_config->PeriphDataAlignment,
+						      DMA_PDATAALIGN_BYTE,
+						      DMA_PDATAALIGN_HALFWORD,
+						      DMA_PDATAALIGN_WORD);
+		if (ret < 0) {
+			return ret;
+		}
+
+		return bdma_stm32_hal_map_data_size(cfg->source_data_size,
+						   &hal_config->MemDataAlignment,
+						   DMA_MDATAALIGN_BYTE,
+						   DMA_MDATAALIGN_HALFWORD,
+						   DMA_MDATAALIGN_WORD);
+	case MEMORY_TO_MEMORY:
+		if (cfg->source_data_size != cfg->dest_data_size) {
+			return -ENOTSUP;
+		}
+
+		ret = bdma_stm32_hal_map_data_size(cfg->source_data_size,
+						      &hal_config->PeriphDataAlignment,
+						      DMA_PDATAALIGN_BYTE,
+						      DMA_PDATAALIGN_HALFWORD,
+						      DMA_PDATAALIGN_WORD);
+		if (ret < 0) {
+			return ret;
+		}
+
+		return bdma_stm32_hal_map_data_size(cfg->dest_data_size,
+						   &hal_config->MemDataAlignment,
+						   DMA_MDATAALIGN_BYTE,
+						   DMA_MDATAALIGN_HALFWORD,
+						   DMA_MDATAALIGN_WORD);
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int bdma_stm32_hal_config_increments(const struct dma_config *cfg,
+						   DMA_InitTypeDef *hal_config)
+{
+	int ret;
+	const struct dma_block_config *block = cfg->head_block;
+
+	switch (cfg->channel_direction) {
+	case MEMORY_TO_PERIPHERAL:
+		ret = bdma_stm32_hal_map_addr_adj(block->source_addr_adj,
+					       &hal_config->MemInc,
+					       DMA_MINC_ENABLE,
+					       DMA_MINC_DISABLE);
+		if (ret < 0) {
+			return ret;
+		}
+
+		return bdma_stm32_hal_map_addr_adj(block->dest_addr_adj,
+					      &hal_config->PeriphInc,
+					      DMA_PINC_ENABLE,
+					      DMA_PINC_DISABLE);
+	case PERIPHERAL_TO_MEMORY:
+		ret = bdma_stm32_hal_map_addr_adj(block->source_addr_adj,
+					       &hal_config->PeriphInc,
+					       DMA_PINC_ENABLE,
+					       DMA_PINC_DISABLE);
+		if (ret < 0) {
+			return ret;
+		}
+
+		return bdma_stm32_hal_map_addr_adj(block->dest_addr_adj,
+					      &hal_config->MemInc,
+					      DMA_MINC_ENABLE,
+					      DMA_MINC_DISABLE);
+	case MEMORY_TO_MEMORY:
+		ret = bdma_stm32_hal_map_addr_adj(block->source_addr_adj,
+					       &hal_config->PeriphInc,
+					       DMA_PINC_ENABLE,
+					       DMA_PINC_DISABLE);
+		if (ret < 0) {
+			return ret;
+		}
+
+		return bdma_stm32_hal_map_addr_adj(block->dest_addr_adj,
+					      &hal_config->MemInc,
+					      DMA_MINC_ENABLE,
+					      DMA_MINC_DISABLE);
+	default:
+		return -ENOTSUP;
+	}
+}
+
+int dma_stm32_zcfg_to_halcfg(const struct dma_config *zephyr_config,
+				     DMA_InitTypeDef *hal_config)
+{
+	int ret;
+
+	if ((zephyr_config == NULL) || (zephyr_config->head_block == NULL) ||
+	    (hal_config == NULL)) {
+		return -EINVAL;
+	}
+
+	memset(hal_config, 0, sizeof(*hal_config));
+
+	ret = bdma_stm32_hal_map_direction(zephyr_config->channel_direction,
+					    &hal_config->Direction);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = bdma_stm32_hal_map_priority(zephyr_config->channel_priority,
+					   &hal_config->Priority);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = bdma_stm32_hal_config_widths(zephyr_config, hal_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = bdma_stm32_hal_map_mode(zephyr_config, &hal_config->Mode);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = bdma_stm32_hal_config_increments(zephyr_config, hal_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+#ifdef DMA_FIFOMODE_DISABLE
+	hal_config->FIFOMode = DMA_FIFOMODE_DISABLE;
+#endif
+
+#ifdef DMA_FIFO_THRESHOLD_FULL
+	hal_config->FIFOThreshold = DMA_FIFO_THRESHOLD_FULL;
+#endif
+
+#ifdef DMA_MBURST_SINGLE
+	hal_config->MemBurst = DMA_MBURST_SINGLE;
+#endif
+
+#ifdef DMA_PBURST_SINGLE
+	hal_config->PeriphBurst = DMA_PBURST_SINGLE;
+#endif
+
+	return 0;
+}
+#endif /* !CONFIG_DMA_STM32_V1 && !CONFIG_DMA_STM32_V2 */
 
 static int bdma_stm32_disable_channel(BDMA_TypeDef *bdma, uint32_t id)
 {

--- a/drivers/dma/dma_stm32_bdma.c
+++ b/drivers/dma/dma_stm32_bdma.c
@@ -12,11 +12,15 @@
 
 #include <zephyr/init.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/dma/dma_stm32.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
+
+#include <string.h>
+
 LOG_MODULE_REGISTER(dma_stm32_bdma, CONFIG_DMA_LOG_LEVEL);
 
 #define DT_DRV_COMPAT st_stm32_bdma
@@ -439,6 +443,221 @@ static int bdma_stm32_get_periph_increment(enum dma_addr_adj increment,
 
 	return 0;
 }
+
+#if !defined(CONFIG_DMA_STM32_V1) && !defined(CONFIG_DMA_STM32_V2)
+static int bdma_stm32_hal_map_direction(uint32_t z_dir, uint32_t *hal_dir)
+{
+	switch (z_dir) {
+	case MEMORY_TO_MEMORY:
+		*hal_dir = DMA_MEMORY_TO_MEMORY;
+		return 0;
+	case MEMORY_TO_PERIPHERAL:
+		*hal_dir = DMA_MEMORY_TO_PERIPH;
+		return 0;
+	case PERIPHERAL_TO_MEMORY:
+		*hal_dir = DMA_PERIPH_TO_MEMORY;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int bdma_stm32_hal_map_priority(uint32_t z_prio, uint32_t *hal_prio)
+{
+	switch (z_prio) {
+	case 0:
+		*hal_prio = DMA_PRIORITY_LOW;
+		return 0;
+	case 1:
+		*hal_prio = DMA_PRIORITY_MEDIUM;
+		return 0;
+	case 2:
+		*hal_prio = DMA_PRIORITY_HIGH;
+		return 0;
+	case 3:
+		*hal_prio = DMA_PRIORITY_VERY_HIGH;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int bdma_stm32_hal_map_data_size(uint32_t z_size, uint32_t *hal_size, uint32_t hal_byte,
+					uint32_t hal_halfword, uint32_t hal_word)
+{
+	switch (z_size) {
+	case 1:
+		*hal_size = hal_byte;
+		return 0;
+	case 2:
+		*hal_size = hal_halfword;
+		return 0;
+	case 4:
+		*hal_size = hal_word;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int bdma_stm32_hal_map_mode(const struct dma_config *cfg, uint32_t *hal_mode)
+{
+	if (cfg->cyclic) {
+#ifdef DMA_CIRCULAR
+		*hal_mode = DMA_CIRCULAR;
+#else
+		return -ENOTSUP;
+#endif
+	} else {
+		*hal_mode = DMA_NORMAL;
+	}
+
+	return 0;
+}
+
+static int bdma_stm32_hal_map_addr_adj(enum dma_addr_adj z_adj, uint32_t *hal_inc,
+				       uint32_t hal_inc_val, uint32_t hal_noinc_val)
+{
+	switch (z_adj) {
+	case DMA_ADDR_ADJ_INCREMENT:
+		*hal_inc = hal_inc_val;
+		return 0;
+	case DMA_ADDR_ADJ_NO_CHANGE:
+		*hal_inc = hal_noinc_val;
+		return 0;
+	case DMA_ADDR_ADJ_DECREMENT:
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int bdma_stm32_hal_config_widths(const struct dma_config *cfg, DMA_InitTypeDef *hal_config)
+{
+	uint32_t periph_dsize, mem_dsize;
+	int ret;
+
+	switch (cfg->channel_direction) {
+	case PERIPHERAL_TO_MEMORY:
+		periph_dsize = cfg->source_data_size;
+		mem_dsize = cfg->dest_data_size;
+		break;
+	case MEMORY_TO_MEMORY:
+		if (cfg->source_data_size != cfg->dest_data_size) {
+			return -ENOTSUP;
+		}
+		__fallthrough;
+	case MEMORY_TO_PERIPHERAL:
+		periph_dsize = cfg->dest_data_size;
+		mem_dsize = cfg->source_data_size;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	ret = bdma_stm32_hal_map_data_size(periph_dsize, &hal_config->PeriphDataAlignment,
+					   DMA_PDATAALIGN_BYTE, DMA_PDATAALIGN_HALFWORD,
+					   DMA_PDATAALIGN_WORD);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return bdma_stm32_hal_map_data_size(mem_dsize, &hal_config->MemDataAlignment,
+					    DMA_MDATAALIGN_BYTE, DMA_MDATAALIGN_HALFWORD,
+					    DMA_MDATAALIGN_WORD);
+}
+
+static int bdma_stm32_hal_config_increments(uint32_t direction, DMA_InitTypeDef *hal_config,
+					    uint16_t source_addr_adj, uint16_t dest_addr_adj)
+{
+	enum dma_addr_adj periph_adj, mem_adj;
+	int ret;
+
+	switch (direction) {
+	case MEMORY_TO_PERIPHERAL:
+		mem_adj = source_addr_adj;
+		periph_adj = dest_addr_adj;
+		break;
+	case PERIPHERAL_TO_MEMORY:
+	case MEMORY_TO_MEMORY:
+		mem_adj = dest_addr_adj;
+		periph_adj = source_addr_adj;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	ret = bdma_stm32_hal_map_addr_adj(periph_adj, &hal_config->PeriphInc, DMA_PINC_ENABLE,
+					  DMA_PINC_DISABLE);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return bdma_stm32_hal_map_addr_adj(mem_adj, &hal_config->MemInc, DMA_MINC_ENABLE,
+					   DMA_MINC_DISABLE);
+}
+
+int dma_stm32_zcfg_to_halcfg(const struct device *dma, const struct dma_config *zephyr_config,
+			     DMA_InitTypeDef *hal_config, uint16_t source_addr_adj,
+			     uint16_t dest_addr_adj)
+{
+	int ret;
+
+	__ASSERT_NO_MSG(dma != NULL && zephyr_config != NULL && hal_config != NULL);
+
+	memset(hal_config, 0, sizeof(*hal_config));
+
+	ret = bdma_stm32_hal_map_direction(zephyr_config->channel_direction,
+					   &hal_config->Direction);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = bdma_stm32_hal_map_priority(zephyr_config->channel_priority, &hal_config->Priority);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = bdma_stm32_hal_config_widths(zephyr_config, hal_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = bdma_stm32_hal_map_mode(zephyr_config, &hal_config->Mode);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = bdma_stm32_hal_config_increments(zephyr_config->channel_direction, hal_config,
+					       uint16_t source_addr_adj, uint16_t dest_addr_adj);
+	if (ret < 0) {
+		return ret;
+	}
+
+	hal_config->SrcBurstLength = zephyr_config->source_burst_length;
+	hal_config->DestBurstLength = zephyr_config->dest_burst_length;
+
+	hal_config->Request = zephyr_config->dma_slot;
+
+#ifdef DMA_FIFOMODE_DISABLE
+	hal_config->FIFOMode = DMA_FIFOMODE_DISABLE;
+#endif
+
+#ifdef DMA_FIFO_THRESHOLD_FULL
+	hal_config->FIFOThreshold = DMA_FIFO_THRESHOLD_FULL;
+#endif
+
+#ifdef DMA_MBURST_SINGLE
+	hal_config->MemBurst = DMA_MBURST_SINGLE;
+#endif
+
+#ifdef DMA_PBURST_SINGLE
+	hal_config->PeriphBurst = DMA_PBURST_SINGLE;
+#endif
+
+	return 0;
+}
+#endif /* !CONFIG_DMA_STM32_V1 && !CONFIG_DMA_STM32_V2 */
 
 static int bdma_stm32_disable_channel(BDMA_TypeDef *bdma, uint32_t id)
 {

--- a/drivers/dma/dma_stm32_bdma.c
+++ b/drivers/dma/dma_stm32_bdma.c
@@ -597,6 +597,23 @@ static int bdma_stm32_hal_config_increments(uint32_t direction, DMA_InitTypeDef 
 					   DMA_MINC_DISABLE);
 }
 
+/*
+ * Default BDMA driver configuration relies on these values,
+ * in case the fields have not been initialized in the @p zephyr_config.
+ *
+ * hal_config->Request			= DMA_REQUEST_MEM2MEM;
+ * hal_config->Direction		= DMA_PERIPH_TO_MEMORY;
+ * hal_config->PeriphInc		= DMA_PINC_DISABLE;
+ * hal_config->MemInc			= DMA_MINC_DISABLE;
+ * hal_config->PeriphDataAlignment	= DMA_PDATAALIGN_BYTE;
+ * hal_config->MemDataAlignment		= DMA_MDATAALIGN_BYTE;
+ * hal_config->Mode			= DMA_NORMAL;
+ * hal_config->Priority			= DMA_PRIORITY_LOW;
+ * hal_config->FIFOMode			= DMA_FIFOMODE_DISABLE;
+ * hal_config->FIFOThreshold		= DMA_FIFO_THRESHOLD_1QUARTERFULL;
+ * hal_config->MemBurst			= DMA_MBURST_SINGLE;
+ * hal_config->PeriphBurst		= DMA_PBURST_SINGLE;
+ */
 int dma_stm32_zcfg_to_halcfg(const struct device *dma, const struct dma_config *zephyr_config,
 			     DMA_InitTypeDef *hal_config, uint16_t source_addr_adj,
 			     uint16_t dest_addr_adj)
@@ -629,14 +646,13 @@ int dma_stm32_zcfg_to_halcfg(const struct device *dma, const struct dma_config *
 	}
 
 	ret = bdma_stm32_hal_config_increments(zephyr_config->channel_direction, hal_config,
-					       uint16_t source_addr_adj, uint16_t dest_addr_adj);
+					       source_addr_adj, dest_addr_adj);
 	if (ret < 0) {
 		return ret;
 	}
 
 	hal_config->SrcBurstLength = zephyr_config->source_burst_length;
 	hal_config->DestBurstLength = zephyr_config->dest_burst_length;
-
 	hal_config->Request = zephyr_config->dma_slot;
 
 #ifdef DMA_FIFOMODE_DISABLE

--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -14,6 +14,8 @@
 
 #include "dma_stm32.h"
 
+#include <string.h>
+
 #include <zephyr/init.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/dma/dma_stm32.h>
@@ -362,6 +364,152 @@ static int dma_stm32_get_direction(enum dma_channel_direction direction,
 		LOG_ERR("Direction error. %d", direction);
 		return -EINVAL;
 	}
+
+	return 0;
+}
+
+static int dma_stm32_hal_map_data_size(uint32_t z_size,
+					       uint32_t *hal_size,
+					       uint32_t hal_byte,
+					       uint32_t hal_halfword,
+					       uint32_t hal_word)
+{
+	switch (z_size) {
+	case 1:
+		*hal_size = hal_byte;
+		return 0;
+	case 2:
+		*hal_size = hal_halfword;
+		return 0;
+	case 4:
+		*hal_size = hal_word;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int dma_stm32_hal_map_mode(const struct dma_config *cfg, uint32_t *hal_mode)
+{
+	if (cfg->cyclic) {
+#ifdef DMA_CIRCULAR
+		*hal_mode = DMA_CIRCULAR;
+#else
+		return -ENOTSUP;
+#endif
+	} else {
+		*hal_mode = DMA_NORMAL;
+	}
+
+	return 0;
+}
+
+static int dma_stm32_hal_map_addr_adj(enum dma_addr_adj z_adj,
+					      uint32_t *hal_inc,
+					      uint32_t hal_inc_val,
+					      uint32_t hal_noinc_val)
+{
+	switch (z_adj) {
+	case DMA_ADDR_ADJ_INCREMENT:
+		*hal_inc = hal_inc_val;
+		return 0;
+	case DMA_ADDR_ADJ_NO_CHANGE:
+		*hal_inc = hal_noinc_val;
+		return 0;
+	case DMA_ADDR_ADJ_DECREMENT:
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int dma_stm32_hal_config_widths(const struct dma_config *cfg,
+					       DMA_InitTypeDef *hal_config)
+{
+	int ret;
+
+	ret = dma_stm32_hal_map_data_size(cfg->source_data_size,
+					      &hal_config->SrcDataWidth,
+					      DMA_SRC_DATAWIDTH_BYTE,
+					      DMA_SRC_DATAWIDTH_HALFWORD,
+					      DMA_SRC_DATAWIDTH_WORD);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return dma_stm32_hal_map_data_size(cfg->dest_data_size,
+					   &hal_config->DestDataWidth,
+					   DMA_DEST_DATAWIDTH_BYTE,
+					   DMA_DEST_DATAWIDTH_HALFWORD,
+					   DMA_DEST_DATAWIDTH_WORD);
+}
+
+static int dma_stm32_hal_config_increments(const struct dma_config *cfg,
+						  DMA_InitTypeDef *hal_config)
+{
+	int ret;
+	const struct dma_block_config *block = cfg->head_block;
+
+	ret = dma_stm32_hal_map_addr_adj(block->source_addr_adj,
+					  &hal_config->SrcInc,
+					  DMA_SINC_INCREMENTED,
+					  DMA_SINC_FIXED);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return dma_stm32_hal_map_addr_adj(block->dest_addr_adj,
+					   &hal_config->DestInc,
+					   DMA_DINC_INCREMENTED,
+					   DMA_DINC_FIXED);
+}
+
+int dma_stm32_zcfg_to_halcfg(const struct dma_config *zephyr_config,
+				     DMA_InitTypeDef *hal_config)
+{
+	int ret;
+
+	if ((zephyr_config == NULL) || (zephyr_config->head_block == NULL) ||
+	    (hal_config == NULL)) {
+		return -EINVAL;
+	}
+
+	memset(hal_config, 0, sizeof(*hal_config));
+
+	ret = dma_stm32_get_direction(zephyr_config->channel_direction,
+				       &hal_config->Direction);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_get_priority(zephyr_config->channel_priority,
+				      &hal_config->Priority);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_config_widths(zephyr_config, hal_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_map_mode(zephyr_config, &hal_config->Mode);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_config_increments(zephyr_config, hal_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+#ifdef DMA_BREQ_SINGLE_BURST
+	hal_config->BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+#endif
+
+#ifdef DMA_TCEM_BLOCK_TRANSFER
+	hal_config->TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+#endif
 
 	return 0;
 }

--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -20,6 +20,9 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
+
+#include <string.h>
+
 LOG_MODULE_REGISTER(dma_stm32, CONFIG_DMA_LOG_LEVEL);
 
 #define DT_DRV_COMPAT st_stm32u5_dma
@@ -365,6 +368,140 @@ static int dma_stm32_get_direction(enum dma_channel_direction direction,
 
 	return 0;
 }
+
+#ifndef CONFIG_STM32_HAL2
+static int dma_stm32_hal_map_data_size(uint32_t z_size, uint32_t *hal_size, uint32_t hal_byte,
+				       uint32_t hal_halfword, uint32_t hal_word)
+{
+	switch (z_size) {
+	case 1:
+		*hal_size = hal_byte;
+		return 0;
+	case 2:
+		*hal_size = hal_halfword;
+		return 0;
+	case 4:
+		*hal_size = hal_word;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int dma_stm32_hal_map_mode(const struct dma_config *cfg, uint32_t *hal_mode)
+{
+	if (cfg->cyclic) {
+#ifdef DMA_CIRCULAR
+		*hal_mode = DMA_CIRCULAR;
+#else
+		return -ENOTSUP;
+#endif
+	} else {
+		*hal_mode = DMA_NORMAL;
+	}
+
+	return 0;
+}
+
+static int dma_stm32_hal_map_addr_adj(enum dma_addr_adj z_adj, uint32_t *hal_inc,
+				      uint32_t hal_inc_val, uint32_t hal_noinc_val)
+{
+	switch (z_adj) {
+	case DMA_ADDR_ADJ_INCREMENT:
+		*hal_inc = hal_inc_val;
+		return 0;
+	case DMA_ADDR_ADJ_NO_CHANGE:
+		*hal_inc = hal_noinc_val;
+		return 0;
+	case DMA_ADDR_ADJ_DECREMENT:
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+}
+
+static int dma_stm32_hal_config_widths(const struct dma_config *cfg, DMA_InitTypeDef *hal_config)
+{
+	int ret;
+
+	ret = dma_stm32_hal_map_data_size(cfg->source_data_size, &hal_config->SrcDataWidth,
+					  DMA_SRC_DATAWIDTH_BYTE, DMA_SRC_DATAWIDTH_HALFWORD,
+					  DMA_SRC_DATAWIDTH_WORD);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return dma_stm32_hal_map_data_size(cfg->dest_data_size, &hal_config->DestDataWidth,
+					   DMA_DEST_DATAWIDTH_BYTE, DMA_DEST_DATAWIDTH_HALFWORD,
+					   DMA_DEST_DATAWIDTH_WORD);
+}
+
+static int dma_stm32_hal_config_increments(uint16_t source_addr_adj, uint16_t dest_addr_adj,
+					   DMA_InitTypeDef *hal_config)
+{
+	int ret;
+
+	ret = dma_stm32_hal_map_addr_adj(source_addr_adj, &hal_config->SrcInc,
+					 DMA_SINC_INCREMENTED, DMA_SINC_FIXED);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return dma_stm32_hal_map_addr_adj(dest_addr_adj, &hal_config->DestInc,
+					  DMA_DINC_INCREMENTED, DMA_DINC_FIXED);
+}
+
+int dma_stm32_zcfg_to_halcfg(const struct device *dma, const struct dma_config *zephyr_config,
+			     DMA_InitTypeDef *hal_config, uint16_t source_addr_adj,
+			     uint16_t dest_addr_adj)
+{
+	int ret;
+
+	__ASSERT_NO_MSG(dma != NULL && zephyr_config != NULL && hal_config != NULL);
+
+	memset(hal_config, 0, sizeof(*hal_config));
+
+	ret = dma_stm32_get_direction(zephyr_config->channel_direction, &hal_config->Direction);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_get_priority(zephyr_config->channel_priority, &hal_config->Priority);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_config_widths(zephyr_config, hal_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_map_mode(zephyr_config, &hal_config->Mode);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = dma_stm32_hal_config_increments(source_addr_adj, dest_addr_adj, hal_config);
+	if (ret < 0) {
+		return ret;
+	}
+
+	hal_config->SrcBurstLength = zephyr_config->source_burst_length;
+	hal_config->DestBurstLength = zephyr_config->dest_burst_length;
+
+	hal_config->Request = zephyr_config->dma_slot;
+
+#ifdef DMA_BREQ_SINGLE_BURST
+	hal_config->BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+#endif
+
+#ifdef DMA_TCEM_BLOCK_TRANSFER
+	hal_config->TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+#endif
+
+	return 0;
+}
+#endif /* CONFIG_STM32_HAL2 */
 
 static int dma_stm32_disable_stream(DMA_TypeDef *dma, uint32_t id)
 {

--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -451,6 +451,24 @@ static int dma_stm32_hal_config_increments(uint16_t source_addr_adj, uint16_t de
 					  DMA_DINC_INCREMENTED, DMA_DINC_FIXED);
 }
 
+/*
+ * Default DMA driver configuration relies on these values,
+ * in case the fields have not been initialized in the @p zephyr_config.
+ *
+ * hal_config->Request			= GPDMA1_REQUEST_ADC1;
+ * hal_config->BlkHWRequest		= DMA_BREQ_SINGLE_BURST;
+ * hal_config->Direction		= DMA_PERIPH_TO_MEMORY;
+ * hal_config->SrcInc			= DMA_SINC_FIXED;
+ * hal_config->DestInc			= DMA_DINC_FIXED;
+ * hal_config->SrcDataWidth		= DMA_SRC_DATAWIDTH_BYTE;
+ * hal_config->DestDataWidth		= DMA_DEST_DATAWIDTH_BYTE;
+ * hal_config->Priority			= DMA_LOW_PRIORITY_LOW_WEIGHT;
+ * hal_config->SrcBurstLength		= 0;
+ * hal_config->DestBurstLength		= 0;
+ * hal_config->TransferAllocatedPort	= DMA_SRC_ALLOCATED_PORT0;
+ * hal_config->TransferEventMode	= DMA_TCEM_BLOCK_TRANSFER;
+ * hal_config->Mode			= DMA_NORMAL;
+ */
 int dma_stm32_zcfg_to_halcfg(const struct device *dma, const struct dma_config *zephyr_config,
 			     DMA_InitTypeDef *hal_config, uint16_t source_addr_adj,
 			     uint16_t dest_addr_adj)

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -2252,6 +2252,10 @@ static int flash_stm32_ospi_init(const struct device *dev)
 	 * how to route callbacks.
 	 */
 	struct dma_config *dma_cfg = &dev_data->dma.cfg;
+	struct dma_block_config dma_block = {
+		.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE,
+		.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+	};
 	static DMA_HandleTypeDef hdma;
 
 	if (!device_is_ready(dev_data->dma.dev)) {
@@ -2261,6 +2265,8 @@ static int flash_stm32_ospi_init(const struct device *dev)
 
 	/* Proceed to the minimum Zephyr DMA driver init */
 	dma_cfg->user_data = &hdma;
+	dma_cfg->channel_direction = PERIPHERAL_TO_MEMORY;
+	dma_cfg->head_block = &dma_block;
 	/* HACK: This field is used to inform driver that it is overridden */
 	dma_cfg->linked_channel = STM32_DMA_HAL_OVERRIDE;
 	ret = dma_config(dev_data->dma.dev, dev_data->dma.channel, dma_cfg);
@@ -2269,34 +2275,16 @@ static int flash_stm32_ospi_init(const struct device *dev)
 		return ret;
 	}
 
-	/* Proceed to the HAL DMA driver init */
-	if (dma_cfg->source_data_size != dma_cfg->dest_data_size) {
-		LOG_ERR("Source and destination data sizes not aligned");
-		return -EINVAL;
+	ret = dma_stm32_zcfg_to_halcfg(dma_cfg, &hdma.Init);
+	if (ret < 0) {
+		return ret;
 	}
 
-	int index = find_lsb_set(dma_cfg->source_data_size) - 1;
-
 #if CONFIG_DMA_STM32U5
-	/* Fill the structure for dma init */
-	hdma.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-	hdma.Init.SrcInc = DMA_SINC_FIXED;
-	hdma.Init.DestInc = DMA_DINC_INCREMENTED;
-	hdma.Init.SrcDataWidth = table_src_size[index];
-	hdma.Init.DestDataWidth = table_dest_size[index];
 	hdma.Init.SrcBurstLength = 4;
 	hdma.Init.DestBurstLength = 4;
 	hdma.Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT1;
-	hdma.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-#else
-	hdma.Init.PeriphDataAlignment = table_p_size[index];
-	hdma.Init.MemDataAlignment = table_m_size[index];
-	hdma.Init.PeriphInc = DMA_PINC_DISABLE;
-	hdma.Init.MemInc = DMA_MINC_ENABLE;
 #endif /* CONFIG_DMA_STM32U5 */
-	hdma.Init.Mode = DMA_NORMAL;
-	hdma.Init.Priority = table_priority[dma_cfg->channel_priority];
-	hdma.Init.Direction = DMA_PERIPH_TO_MEMORY;
 	hdma.Instance = STM32_DMA_GET_INSTANCE(dev_data->dma.reg, dev_data->dma.channel);
 #ifdef CONFIG_DMA_STM32_V1
 	/* TODO: Not tested in this configuration */

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -77,48 +77,6 @@ LOG_MODULE_REGISTER(flash_stm32_ospi, CONFIG_FLASH_LOG_LEVEL);
 #define SPI_NOR_WRITEOC_NONE 0xFF
 
 #if STM32_OSPI_USE_DMA
-#if CONFIG_DMA_STM32U5
-static const uint32_t table_src_size[] = {
-	LL_DMA_SRC_DATAWIDTH_BYTE,
-	LL_DMA_SRC_DATAWIDTH_HALFWORD,
-	LL_DMA_SRC_DATAWIDTH_WORD,
-};
-
-static const uint32_t table_dest_size[] = {
-	LL_DMA_DEST_DATAWIDTH_BYTE,
-	LL_DMA_DEST_DATAWIDTH_HALFWORD,
-	LL_DMA_DEST_DATAWIDTH_WORD,
-};
-
-/* Lookup table to set dma priority from the DTS */
-static const uint32_t table_priority[] = {
-	LL_DMA_LOW_PRIORITY_LOW_WEIGHT,
-	LL_DMA_LOW_PRIORITY_MID_WEIGHT,
-	LL_DMA_LOW_PRIORITY_HIGH_WEIGHT,
-	LL_DMA_HIGH_PRIORITY,
-};
-#else
-static const uint32_t table_m_size[] = {
-	LL_DMA_MDATAALIGN_BYTE,
-	LL_DMA_MDATAALIGN_HALFWORD,
-	LL_DMA_MDATAALIGN_WORD,
-};
-
-static const uint32_t table_p_size[] = {
-	LL_DMA_PDATAALIGN_BYTE,
-	LL_DMA_PDATAALIGN_HALFWORD,
-	LL_DMA_PDATAALIGN_WORD,
-};
-
-/* Lookup table to set dma priority from the DTS */
-static const uint32_t table_priority[] = {
-	DMA_PRIORITY_LOW,
-	DMA_PRIORITY_MEDIUM,
-	DMA_PRIORITY_HIGH,
-	DMA_PRIORITY_VERY_HIGH,
-};
-#endif /* CONFIG_DMA_STM32U5 */
-
 struct stream {
 	DMA_TypeDef *reg;
 	const struct device *dev;
@@ -2261,49 +2219,28 @@ static int flash_stm32_ospi_init(const struct device *dev)
 
 	/* Proceed to the minimum Zephyr DMA driver init */
 	dma_cfg->user_data = &hdma;
+	dma_cfg->channel_direction = PERIPHERAL_TO_MEMORY;
 	/* HACK: This field is used to inform driver that it is overridden */
 	dma_cfg->linked_channel = STM32_DMA_HAL_OVERRIDE;
+	dma_cfg->source_burst_length = 4;
+	dma_cfg->dest_burst_length = 4;
 	ret = dma_config(dev_data->dma.dev, dev_data->dma.channel, dma_cfg);
 	if (ret != 0) {
 		LOG_ERR("Failed to configure DMA channel %d", dev_data->dma.channel);
 		return ret;
 	}
 
-	/* Proceed to the HAL DMA driver init */
-	if (dma_cfg->source_data_size != dma_cfg->dest_data_size) {
-		LOG_ERR("Source and destination data sizes not aligned");
-		return -EINVAL;
+	ret = dma_stm32_zcfg_to_halcfg(dev_data->dma.dev, dma_cfg, &hdma.Init,
+				       DMA_ADDR_ADJ_NO_CHANGE, DMA_ADDR_ADJ_INCREMENT);
+	if (ret < 0) {
+		return ret;
 	}
 
-	int index = find_lsb_set(dma_cfg->source_data_size) - 1;
-
 #if CONFIG_DMA_STM32U5
-	/* Fill the structure for dma init */
-	hdma.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-	hdma.Init.SrcInc = DMA_SINC_FIXED;
-	hdma.Init.DestInc = DMA_DINC_INCREMENTED;
-	hdma.Init.SrcDataWidth = table_src_size[index];
-	hdma.Init.DestDataWidth = table_dest_size[index];
-	hdma.Init.SrcBurstLength = 4;
-	hdma.Init.DestBurstLength = 4;
 	hdma.Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT1;
-	hdma.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-#else
-	hdma.Init.PeriphDataAlignment = table_p_size[index];
-	hdma.Init.MemDataAlignment = table_m_size[index];
-	hdma.Init.PeriphInc = DMA_PINC_DISABLE;
-	hdma.Init.MemInc = DMA_MINC_ENABLE;
 #endif /* CONFIG_DMA_STM32U5 */
-	hdma.Init.Mode = DMA_NORMAL;
-	hdma.Init.Priority = table_priority[dma_cfg->channel_priority];
-	hdma.Init.Direction = DMA_PERIPH_TO_MEMORY;
+
 	hdma.Instance = STM32_DMA_GET_INSTANCE(dev_data->dma.reg, dev_data->dma.channel);
-#ifdef CONFIG_DMA_STM32_V1
-	/* TODO: Not tested in this configuration */
-	hdma.Init.Channel = dma_cfg->dma_slot;
-#else
-	hdma.Init.Request = dma_cfg->dma_slot;
-#endif /* CONFIG_DMA_STM32_V1 */
 
 	/* Initialize DMA HAL */
 	__HAL_LINKDMA(&dev_data->hospi, hdma, hdma);

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -2237,6 +2237,7 @@ static int flash_stm32_ospi_init(const struct device *dev)
 	}
 
 #if CONFIG_DMA_STM32U5
+	hdma.Init.DestInc = DMA_DINC_INCREMENTED;
 	hdma.Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT1;
 #endif /* CONFIG_DMA_STM32U5 */
 

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1549,6 +1549,10 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	 * how to route callbacks.
 	 */
 	struct dma_config *dma_cfg = &dev_data->dma.cfg;
+	struct dma_block_config dma_block = {
+		.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE,
+		.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+	};
 	static DMA_HandleTypeDef hdma;
 
 	if (!device_is_ready(dev_data->dma.dev)) {
@@ -1558,6 +1562,8 @@ static int flash_stm32_qspi_init(const struct device *dev)
 
 	/* Proceed to the minimum Zephyr DMA driver init */
 	dma_cfg->user_data = &hdma;
+	dma_cfg->channel_direction = PERIPHERAL_TO_MEMORY;
+	dma_cfg->head_block = &dma_block;
 	/* HACK: This field is used to inform driver that it is overridden */
 	dma_cfg->linked_channel = STM32_DMA_HAL_OVERRIDE;
 	ret = dma_config(dev_data->dma.dev, dev_data->dma.channel, dma_cfg);
@@ -1565,20 +1571,11 @@ static int flash_stm32_qspi_init(const struct device *dev)
 		return ret;
 	}
 
-	/* Proceed to the HAL DMA driver init */
-	if (dma_cfg->source_data_size != dma_cfg->dest_data_size) {
-		LOG_ERR("Source and destination data sizes not aligned");
-		return -EINVAL;
+	ret = dma_stm32_zcfg_to_halcfg(dma_cfg, &hdma.Init);
+	if (ret < 0) {
+		return ret;
 	}
 
-	int index = find_lsb_set(dma_cfg->source_data_size) - 1;
-
-	hdma.Init.PeriphDataAlignment = table_p_size[index];
-	hdma.Init.MemDataAlignment = table_m_size[index];
-	hdma.Init.PeriphInc = DMA_PINC_DISABLE;
-	hdma.Init.MemInc = DMA_MINC_ENABLE;
-	hdma.Init.Mode = DMA_NORMAL;
-	hdma.Init.Priority = table_priority[dma_cfg->channel_priority];
 	hdma.Instance = STM32_DMA_GET_INSTANCE(dev_data->dma.reg, dev_data->dma.channel);
 #ifdef CONFIG_DMA_STM32_V1
 	/* TODO: Not tested in this configuration */

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -152,28 +152,6 @@ static inline uint16_t flash_reg_to_raw(const struct flash_reg *reg)
 	return raw;
 }
 
-#if STM32_QSPI_USE_DMA
-static const uint32_t table_m_size[] = {
-	LL_DMA_MDATAALIGN_BYTE,
-	LL_DMA_MDATAALIGN_HALFWORD,
-	LL_DMA_MDATAALIGN_WORD,
-};
-
-static const uint32_t table_p_size[] = {
-	LL_DMA_PDATAALIGN_BYTE,
-	LL_DMA_PDATAALIGN_HALFWORD,
-	LL_DMA_PDATAALIGN_WORD,
-};
-
-/* Lookup table to set dma priority from the DTS */
-static const uint32_t table_priority[] = {
-	DMA_PRIORITY_LOW,
-	DMA_PRIORITY_MEDIUM,
-	DMA_PRIORITY_HIGH,
-	DMA_PRIORITY_VERY_HIGH,
-};
-#endif /* STM32_QSPI_USE_DMA */
-
 typedef void (*irq_config_func_t)(const struct device *dev);
 
 struct stream {
@@ -1558,6 +1536,7 @@ static int flash_stm32_qspi_init(const struct device *dev)
 
 	/* Proceed to the minimum Zephyr DMA driver init */
 	dma_cfg->user_data = &hdma;
+	dma_cfg->channel_direction = PERIPHERAL_TO_MEMORY;
 	/* HACK: This field is used to inform driver that it is overridden */
 	dma_cfg->linked_channel = STM32_DMA_HAL_OVERRIDE;
 	ret = dma_config(dev_data->dma.dev, dev_data->dma.channel, dma_cfg);
@@ -1565,27 +1544,13 @@ static int flash_stm32_qspi_init(const struct device *dev)
 		return ret;
 	}
 
-	/* Proceed to the HAL DMA driver init */
-	if (dma_cfg->source_data_size != dma_cfg->dest_data_size) {
-		LOG_ERR("Source and destination data sizes not aligned");
-		return -EINVAL;
+	ret = dma_stm32_zcfg_to_halcfg(dev_data->dma.dev, dma_cfg, &hdma.Init,
+				       DMA_ADDR_ADJ_NO_CHANGE, DMA_ADDR_ADJ_INCREMENT);
+	if (ret < 0) {
+		return ret;
 	}
 
-	int index = find_lsb_set(dma_cfg->source_data_size) - 1;
-
-	hdma.Init.PeriphDataAlignment = table_p_size[index];
-	hdma.Init.MemDataAlignment = table_m_size[index];
-	hdma.Init.PeriphInc = DMA_PINC_DISABLE;
-	hdma.Init.MemInc = DMA_MINC_ENABLE;
-	hdma.Init.Mode = DMA_NORMAL;
-	hdma.Init.Priority = table_priority[dma_cfg->channel_priority];
 	hdma.Instance = STM32_DMA_GET_INSTANCE(dev_data->dma.reg, dev_data->dma.channel);
-#ifdef CONFIG_DMA_STM32_V1
-	/* TODO: Not tested in this configuration */
-	hdma.Init.Channel = dma_cfg->dma_slot;
-#else
-	hdma.Init.Request = dma_cfg->dma_slot;
-#endif /* CONFIG_DMA_STM32_V1 */
 
 	/* Initialize DMA HAL */
 	__HAL_LINKDMA(&dev_data->hqspi, hdma, hdma);

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -1994,6 +1994,13 @@ static int spi_nor_process_bfp(const struct device *dev,
 static int flash_stm32_xspi_dma_init(DMA_HandleTypeDef *hdma, struct stream *dma_stream)
 {
 	int ret;
+	struct dma_config hal_dma_cfg;
+	struct dma_block_config dma_block = {
+		.source_addr_adj = dma_stream->src_addr_increment ?
+			DMA_ADDR_ADJ_INCREMENT : DMA_ADDR_ADJ_NO_CHANGE,
+		.dest_addr_adj = dma_stream->dst_addr_increment ?
+			DMA_ADDR_ADJ_INCREMENT : DMA_ADDR_ADJ_NO_CHANGE,
+	};
 	/*
 	 * DMA configuration
 	 * Due to use of XSPI HAL API in current driver,
@@ -2017,10 +2024,14 @@ static int flash_stm32_xspi_dma_init(DMA_HandleTypeDef *hdma, struct stream *dma
 		return ret;
 	}
 
-	/* Proceed to the HAL DMA driver init */
-	if (dma_stream->cfg.source_data_size != dma_stream->cfg.dest_data_size) {
-		LOG_ERR("DMA Source and destination data sizes not aligned");
-		return -EINVAL;
+	hal_dma_cfg = dma_stream->cfg;
+	hal_dma_cfg.source_data_size = 4U;
+	hal_dma_cfg.dest_data_size = 4U;
+	hal_dma_cfg.head_block = &dma_block;
+
+	ret = dma_stm32_zcfg_to_halcfg(&hal_dma_cfg, &hdma->Init);
+	if (ret < 0) {
+		return ret;
 	}
 
 #if defined(CONFIG_SOC_SERIES_STM32H7RSX)
@@ -2045,23 +2056,8 @@ static int flash_stm32_xspi_dma_init(DMA_HandleTypeDef *hdma, struct stream *dma
 	hdma->Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 |
 		DMA_DEST_ALLOCATED_PORT0;
 #endif /* CONFIG_SOC_SERIES_STM32H7RSX */
-	hdma->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_WORD; /* Fixed value */
-	hdma->Init.DestDataWidth = DMA_DEST_DATAWIDTH_WORD; /* Fixed value */
-
-	hdma->Init.SrcInc = (dma_stream->src_addr_increment)
-		? DMA_SINC_INCREMENTED
-		: DMA_SINC_FIXED;
-	hdma->Init.DestInc = (dma_stream->dst_addr_increment)
-		? DMA_DINC_INCREMENTED
-		: DMA_DINC_FIXED;
 	hdma->Init.SrcBurstLength = 4;
 	hdma->Init.DestBurstLength = 4;
-
-	hdma->Init.Priority = table_priority[dma_stream->cfg.channel_priority];
-	hdma->Init.Direction = table_direction[dma_stream->cfg.channel_direction];
-	hdma->Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-	hdma->Init.Mode = DMA_NORMAL;
-	hdma->Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
 	hdma->Init.Request = dma_stream->cfg.dma_slot;
 
 	/*

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2024,6 +2024,9 @@ static int spi_nor_process_bfp(const struct device *dev,
 static int flash_stm32_xspi_dma_init(DMA_HandleTypeDef *hdma, struct stream *dma_stream)
 {
 	int ret;
+	struct dma_config hal_dma_cfg;
+	uint16_t source_addr_adj, dest_addr_adj;
+
 	/*
 	 * DMA configuration
 	 * Due to use of XSPI HAL API in current driver,
@@ -2047,10 +2050,21 @@ static int flash_stm32_xspi_dma_init(DMA_HandleTypeDef *hdma, struct stream *dma
 		return ret;
 	}
 
-	/* Proceed to the HAL DMA driver init */
-	if (dma_stream->cfg.source_data_size != dma_stream->cfg.dest_data_size) {
-		LOG_ERR("DMA Source and destination data sizes not aligned");
-		return -EINVAL;
+	hal_dma_cfg = dma_stream->cfg;
+	hal_dma_cfg.source_data_size = 4U;
+	hal_dma_cfg.dest_data_size = 4U;
+	hal_dma_cfg.source_burst_length = 4;
+	hal_dma_cfg.dest_burst_length = 4;
+
+	source_addr_adj = dma_stream->src_addr_increment ?
+		DMA_ADDR_ADJ_INCREMENT : DMA_ADDR_ADJ_NO_CHANGE;
+	dest_addr_adj = dma_stream->dst_addr_increment ?
+		DMA_ADDR_ADJ_INCREMENT : DMA_ADDR_ADJ_NO_CHANGE;
+
+	ret = dma_stm32_zcfg_to_halcfg(dma_stream->dev, &hal_dma_cfg, &hdma->Init,
+				       source_addr_adj, dest_addr_adj);
+	if (ret < 0) {
+		return ret;
 	}
 
 #if defined(CONFIG_SOC_SERIES_STM32H7RSX)
@@ -2075,24 +2089,6 @@ static int flash_stm32_xspi_dma_init(DMA_HandleTypeDef *hdma, struct stream *dma
 	hdma->Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 |
 		DMA_DEST_ALLOCATED_PORT0;
 #endif /* CONFIG_SOC_SERIES_STM32H7RSX */
-	hdma->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_WORD; /* Fixed value */
-	hdma->Init.DestDataWidth = DMA_DEST_DATAWIDTH_WORD; /* Fixed value */
-
-	hdma->Init.SrcInc = (dma_stream->src_addr_increment)
-		? DMA_SINC_INCREMENTED
-		: DMA_SINC_FIXED;
-	hdma->Init.DestInc = (dma_stream->dst_addr_increment)
-		? DMA_DINC_INCREMENTED
-		: DMA_DINC_FIXED;
-	hdma->Init.SrcBurstLength = 4;
-	hdma->Init.DestBurstLength = 4;
-
-	hdma->Init.Priority = table_priority[dma_stream->cfg.channel_priority];
-	hdma->Init.Direction = table_direction[dma_stream->cfg.channel_direction];
-	hdma->Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-	hdma->Init.Mode = DMA_NORMAL;
-	hdma->Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-	hdma->Init.Request = dma_stream->cfg.dma_slot;
 
 	/*
 	 * HAL expects a valid DMA channel (not DMAMUX).

--- a/drivers/flash/flash_stm32_xspi.h
+++ b/drivers/flash/flash_stm32_xspi.h
@@ -50,21 +50,6 @@
 #define SPI_NOR_WRITEOC_NONE 0xFF
 
 #ifdef CONFIG_FLASH_STM32_XSPI_DMA
-/* Lookup table to set dma priority from the DTS */
-static const uint32_t table_priority[] = {
-	DMA_LOW_PRIORITY_LOW_WEIGHT,
-	DMA_LOW_PRIORITY_MID_WEIGHT,
-	DMA_LOW_PRIORITY_HIGH_WEIGHT,
-	DMA_HIGH_PRIORITY,
-};
-
-/* Lookup table to set dma channel direction from the DTS */
-static const uint32_t table_direction[] = {
-	DMA_MEMORY_TO_MEMORY,
-	DMA_MEMORY_TO_PERIPH,
-	DMA_PERIPH_TO_MEMORY,
-};
-
 struct stream {
 	DMA_TypeDef *reg;
 	const struct device *dev;

--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -29,44 +29,6 @@ enum mclk_divider {
 	MCLK_DIV_512
 };
 
-static const uint32_t dma_priority[] = {
-#if defined(CONFIG_DMA_STM32U5)
-	DMA_LOW_PRIORITY_LOW_WEIGHT,
-	DMA_LOW_PRIORITY_MID_WEIGHT,
-	DMA_LOW_PRIORITY_HIGH_WEIGHT,
-	DMA_HIGH_PRIORITY,
-#else
-	DMA_PRIORITY_LOW,
-	DMA_PRIORITY_MEDIUM,
-	DMA_PRIORITY_HIGH,
-	DMA_PRIORITY_VERY_HIGH,
-#endif
-};
-
-#if defined(CONFIG_DMA_STM32U5)
-static const uint32_t dma_src_size[] = {
-	DMA_SRC_DATAWIDTH_BYTE,
-	DMA_SRC_DATAWIDTH_HALFWORD,
-	DMA_SRC_DATAWIDTH_WORD,
-};
-static const uint32_t dma_dest_size[] = {
-	DMA_DEST_DATAWIDTH_BYTE,
-	DMA_DEST_DATAWIDTH_HALFWORD,
-	DMA_DEST_DATAWIDTH_WORD,
-};
-#else
-static const uint32_t dma_p_size[] = {
-	DMA_PDATAALIGN_BYTE,
-	DMA_PDATAALIGN_HALFWORD,
-	DMA_PDATAALIGN_WORD,
-};
-static const uint32_t dma_m_size[] = {
-	DMA_MDATAALIGN_BYTE,
-	DMA_MDATAALIGN_HALFWORD,
-	DMA_MDATAALIGN_WORD,
-};
-#endif
-
 static const uint32_t sai_fifo_threshold[] = {
 	SAI_FIFOTHRESHOLD_EMPTY,
 	SAI_FIFOTHRESHOLD_1QF,
@@ -307,6 +269,7 @@ static int sai_sub_dma_init(const struct device *dev)
 	struct stm32_sai_sub_data *sub_data = dev->data;
 	struct stream *stream = &sub_data->stream;
 	struct dma_config *dma_cfg = &sub_data->stream.dma_cfg;
+	struct dma_block_config dma_block;
 	int ret;
 
 	SAI_HandleTypeDef *hsai = &sub_data->hsai;
@@ -319,6 +282,14 @@ static int sai_sub_dma_init(const struct device *dev)
 
 	/* Proceed to the minimum Zephyr DMA driver init */
 	dma_cfg->user_data = hdma;
+	if (dma_cfg->channel_direction == (enum dma_channel_direction)MEMORY_TO_PERIPHERAL) {
+		dma_block.source_addr_adj = DMA_ADDR_ADJ_INCREMENT;
+		dma_block.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+	} else {
+		dma_block.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+		dma_block.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT;
+	}
+	dma_cfg->head_block = &dma_block;
 
 	/* HACK: This field is used to inform driver that it is overridden */
 	dma_cfg->linked_channel = STM32_DMA_HAL_OVERRIDE;
@@ -329,14 +300,12 @@ static int sai_sub_dma_init(const struct device *dev)
 		return ret;
 	}
 
-	hdma->Instance = STM32_DMA_GET_INSTANCE(stream->reg, stream->dma_channel);
-	hdma->Init.Mode = DMA_NORMAL;
-
-	if (dma_cfg->channel_priority >= ARRAY_SIZE(dma_priority)) {
-		LOG_ERR("Invalid DMA channel priority");
-		return -EINVAL;
+	ret = dma_stm32_zcfg_to_halcfg(dma_cfg, &hdma->Init);
+	if (ret < 0) {
+		return ret;
 	}
-	hdma->Init.Priority = dma_priority[dma_cfg->channel_priority];
+
+	hdma->Instance = STM32_DMA_GET_INSTANCE(stream->reg, stream->dma_channel);
 
 #if defined(DMA_CHANNEL_1)
 	hdma->Init.Channel = dma_cfg->dma_slot * DMA_CHANNEL_1;
@@ -344,59 +313,15 @@ static int sai_sub_dma_init(const struct device *dev)
 	hdma->Init.Request = dma_cfg->dma_slot;
 #endif
 
-	if (dma_cfg->source_data_size != dma_cfg->dest_data_size) {
-		LOG_ERR("Source and destination data sizes are not aligned");
-		return -EINVAL;
-	}
-
-	int idx = find_lsb_set(dma_cfg->source_data_size) - 1;
-
 #if defined(CONFIG_DMA_STM32U5)
-	if (idx >= ARRAY_SIZE(dma_src_size)) {
-		LOG_ERR("Invalid source and destination DMA data size");
-		return -EINVAL;
-	}
-
-	hdma->Init.SrcDataWidth = dma_src_size[idx];
-	hdma->Init.DestDataWidth = dma_dest_size[idx];
-	hdma->Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
 	hdma->Init.SrcBurstLength = 1;
 	hdma->Init.DestBurstLength = 1;
 	hdma->Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0;
-	hdma->Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-#else
-	if (idx >= ARRAY_SIZE(dma_m_size)) {
-		LOG_ERR("Invalid peripheral and memory DMA data size");
-		return -EINVAL;
-	}
-
-	hdma->Init.PeriphDataAlignment = dma_p_size[idx];
-	hdma->Init.MemDataAlignment = dma_m_size[idx];
-	hdma->Init.PeriphInc = DMA_PINC_DISABLE;
-	hdma->Init.MemInc = DMA_MINC_ENABLE;
-#endif
-
-#if defined(DMA_FIFOMODE_DISABLE)
-	hdma->Init.FIFOMode = DMA_FIFOMODE_DISABLE;
 #endif
 
 	if (dma_cfg->channel_direction == (enum dma_channel_direction)MEMORY_TO_PERIPHERAL) {
-		hdma->Init.Direction = DMA_MEMORY_TO_PERIPH;
-
-#if defined(CONFIG_DMA_STM32U5)
-		hdma->Init.SrcInc = DMA_SINC_INCREMENTED;
-		hdma->Init.DestInc = DMA_DINC_FIXED;
-#endif
-
 		__HAL_LINKDMA(hsai, hdmatx, sub_data->hdma);
 	} else {
-		hdma->Init.Direction = DMA_PERIPH_TO_MEMORY;
-
-#if defined(CONFIG_DMA_STM32U5)
-		hdma->Init.SrcInc = DMA_SINC_FIXED;
-		hdma->Init.DestInc = DMA_DINC_INCREMENTED;
-#endif
-
 		__HAL_LINKDMA(hsai, hdmarx, sub_data->hdma);
 	}
 

--- a/drivers/i2s/i2s_stm32_sai.c
+++ b/drivers/i2s/i2s_stm32_sai.c
@@ -30,44 +30,6 @@ enum mclk_divider {
 	MCLK_DIV_512
 };
 
-static const uint32_t dma_priority[] = {
-#if defined(CONFIG_DMA_STM32U5)
-	DMA_LOW_PRIORITY_LOW_WEIGHT,
-	DMA_LOW_PRIORITY_MID_WEIGHT,
-	DMA_LOW_PRIORITY_HIGH_WEIGHT,
-	DMA_HIGH_PRIORITY,
-#else
-	DMA_PRIORITY_LOW,
-	DMA_PRIORITY_MEDIUM,
-	DMA_PRIORITY_HIGH,
-	DMA_PRIORITY_VERY_HIGH,
-#endif
-};
-
-#if defined(CONFIG_DMA_STM32U5)
-static const uint32_t dma_src_size[] = {
-	DMA_SRC_DATAWIDTH_BYTE,
-	DMA_SRC_DATAWIDTH_HALFWORD,
-	DMA_SRC_DATAWIDTH_WORD,
-};
-static const uint32_t dma_dest_size[] = {
-	DMA_DEST_DATAWIDTH_BYTE,
-	DMA_DEST_DATAWIDTH_HALFWORD,
-	DMA_DEST_DATAWIDTH_WORD,
-};
-#else
-static const uint32_t dma_p_size[] = {
-	DMA_PDATAALIGN_BYTE,
-	DMA_PDATAALIGN_HALFWORD,
-	DMA_PDATAALIGN_WORD,
-};
-static const uint32_t dma_m_size[] = {
-	DMA_MDATAALIGN_BYTE,
-	DMA_MDATAALIGN_HALFWORD,
-	DMA_MDATAALIGN_WORD,
-};
-#endif
-
 static const uint32_t sai_fifo_threshold[] = {
 	SAI_FIFOTHRESHOLD_EMPTY,
 	SAI_FIFOTHRESHOLD_1QF,
@@ -338,6 +300,7 @@ static int sai_sub_dma_init(const struct device *dev)
 	struct stm32_sai_sub_data *sub_data = dev->data;
 	struct stream *stream = &sub_data->stream;
 	struct dma_config *dma_cfg = &sub_data->stream.dma_cfg;
+	uint16_t source_addr_adj, dest_addr_adj;
 	int ret;
 
 	SAI_HandleTypeDef *hsai = &sub_data->hsai;
@@ -350,6 +313,13 @@ static int sai_sub_dma_init(const struct device *dev)
 
 	/* Proceed to the minimum Zephyr DMA driver init */
 	dma_cfg->user_data = hdma;
+	if (dma_cfg->channel_direction == (enum dma_channel_direction)MEMORY_TO_PERIPHERAL) {
+		source_addr_adj = DMA_ADDR_ADJ_INCREMENT;
+		dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+	} else {
+		source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+		dest_addr_adj = DMA_ADDR_ADJ_INCREMENT;
+	}
 
 	/* HACK: This field is used to inform driver that it is overridden */
 	dma_cfg->linked_channel = STM32_DMA_HAL_OVERRIDE;
@@ -360,74 +330,21 @@ static int sai_sub_dma_init(const struct device *dev)
 		return ret;
 	}
 
-	hdma->Instance = STM32_DMA_GET_INSTANCE(stream->reg, stream->dma_channel);
-	hdma->Init.Mode = DMA_NORMAL;
-
-	if (dma_cfg->channel_priority >= ARRAY_SIZE(dma_priority)) {
-		LOG_ERR("Invalid DMA channel priority");
-		return -EINVAL;
+	ret = dma_stm32_zcfg_to_halcfg(stream->dma_dev, dma_cfg, &hdma->Init,
+				       source_addr_adj, dest_addr_adj);
+	if (ret < 0) {
+		return ret;
 	}
-	hdma->Init.Priority = dma_priority[dma_cfg->channel_priority];
-
-#if defined(DMA_CHANNEL_1)
-	hdma->Init.Channel = dma_cfg->dma_slot * DMA_CHANNEL_1;
-#else
-	hdma->Init.Request = dma_cfg->dma_slot;
-#endif
-
-	if (dma_cfg->source_data_size != dma_cfg->dest_data_size) {
-		LOG_ERR("Source and destination data sizes are not aligned");
-		return -EINVAL;
-	}
-
-	int idx = find_lsb_set(dma_cfg->source_data_size) - 1;
 
 #if defined(CONFIG_DMA_STM32U5)
-	if (idx >= ARRAY_SIZE(dma_src_size)) {
-		LOG_ERR("Invalid source and destination DMA data size");
-		return -EINVAL;
-	}
-
-	hdma->Init.SrcDataWidth = dma_src_size[idx];
-	hdma->Init.DestDataWidth = dma_dest_size[idx];
-	hdma->Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-	hdma->Init.SrcBurstLength = 1;
-	hdma->Init.DestBurstLength = 1;
 	hdma->Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0;
-	hdma->Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-#else
-	if (idx >= ARRAY_SIZE(dma_m_size)) {
-		LOG_ERR("Invalid peripheral and memory DMA data size");
-		return -EINVAL;
-	}
-
-	hdma->Init.PeriphDataAlignment = dma_p_size[idx];
-	hdma->Init.MemDataAlignment = dma_m_size[idx];
-	hdma->Init.PeriphInc = DMA_PINC_DISABLE;
-	hdma->Init.MemInc = DMA_MINC_ENABLE;
 #endif
 
-#if defined(DMA_FIFOMODE_DISABLE)
-	hdma->Init.FIFOMode = DMA_FIFOMODE_DISABLE;
-#endif
+	hdma->Instance = STM32_DMA_GET_INSTANCE(stream->reg, stream->dma_channel);
 
 	if (dma_cfg->channel_direction == (enum dma_channel_direction)MEMORY_TO_PERIPHERAL) {
-		hdma->Init.Direction = DMA_MEMORY_TO_PERIPH;
-
-#if defined(CONFIG_DMA_STM32U5)
-		hdma->Init.SrcInc = DMA_SINC_INCREMENTED;
-		hdma->Init.DestInc = DMA_DINC_FIXED;
-#endif
-
 		__HAL_LINKDMA(hsai, hdmatx, sub_data->hdma);
 	} else {
-		hdma->Init.Direction = DMA_PERIPH_TO_MEMORY;
-
-#if defined(CONFIG_DMA_STM32U5)
-		hdma->Init.SrcInc = DMA_SINC_FIXED;
-		hdma->Init.DestInc = DMA_DINC_INCREMENTED;
-#endif
-
 		__HAL_LINKDMA(hsai, hdmarx, sub_data->hdma);
 	}
 

--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -986,6 +986,10 @@ static int mspi_stm32_ospi_dma_setup(const struct mspi_stm32_conf *dev_cfg,
 	int ret = 0;
 
 	struct dma_config dma_cfg = dev_data->dma.cfg;
+	struct dma_block_config dma_block = {
+		.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE,
+		.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+	};
 	DMA_HandleTypeDef *hdma = &dev_data->hdma;
 
 	dev_data->dma.reg = (DMA_TypeDef *)dev_data->dma.phys_addr;
@@ -996,6 +1000,8 @@ static int mspi_stm32_ospi_dma_setup(const struct mspi_stm32_conf *dev_cfg,
 	}
 
 	dma_cfg.user_data = hdma;
+	dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
+	dma_cfg.head_block = &dma_block;
 	dma_cfg.linked_channel = STM32_DMA_HAL_OVERRIDE;
 
 	ret = dma_config(dev_data->dma.dev, dev_data->dma.channel, &dma_cfg);
@@ -1004,34 +1010,17 @@ static int mspi_stm32_ospi_dma_setup(const struct mspi_stm32_conf *dev_cfg,
 		return ret;
 	}
 
-	if (dma_cfg.source_data_size != dma_cfg.dest_data_size) {
-		LOG_ERR("Source and Destination data sizes are not aligned");
-		return -EINVAL;
+	ret = dma_stm32_zcfg_to_halcfg(&dma_cfg, &hdma->Init);
+	if (ret < 0) {
+		return ret;
 	}
 
-	int index = find_lsb_set(dma_cfg.source_data_size) - 1;
-
 #ifdef CONFIG_DMA_STM32U5
-	/* Fill the structure for dma init */
-	hdma->Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-	hdma->Init.SrcInc = DMA_SINC_FIXED;
-	hdma->Init.DestInc = DMA_DINC_INCREMENTED;
-	hdma->Init.SrcDataWidth = mspi_stm32_table_src_size[index];
-	hdma->Init.DestDataWidth = mspi_stm32_table_dest_size[index];
 	hdma->Init.SrcBurstLength = 4;
 	hdma->Init.DestBurstLength = 4;
 	hdma->Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT1;
-	hdma->Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-#else
-	hdma->Init.PeriphDataAlignment = mspi_stm32_table_dest_size[index];
-	hdma->Init.MemDataAlignment = mspi_stm32_table_src_size[index];
-	hdma->Init.PeriphInc = DMA_PINC_DISABLE;
-	hdma->Init.MemInc = DMA_MINC_ENABLE;
 #endif /* CONFIG_DMA_STM32U5 */
 
-	hdma->Init.Mode = DMA_NORMAL;
-	hdma->Init.Priority = mspi_stm32_table_priority[dma_cfg.channel_priority];
-	hdma->Init.Direction = DMA_PERIPH_TO_MEMORY;
 	hdma->Instance = STM32_DMA_GET_INSTANCE(dev_data->dma.reg, dev_data->dma.channel);
 	hdma->Init.Request = dma_cfg.dma_slot;
 	__HAL_LINKDMA(&dev_data->hmspi.ospi, hdma, *hdma);

--- a/drivers/mspi/mspi_stm32_ospi.c
+++ b/drivers/mspi/mspi_stm32_ospi.c
@@ -1017,6 +1017,7 @@ static int mspi_stm32_ospi_dma_setup(const struct mspi_stm32_conf *dev_cfg,
 	}
 
 	dma_cfg.user_data = hdma;
+	dma_cfg.channel_direction = PERIPHERAL_TO_MEMORY;
 	dma_cfg.linked_channel = STM32_DMA_HAL_OVERRIDE;
 
 	ret = dma_config(dev_data->dma.dev, dev_data->dma.channel, &dma_cfg);
@@ -1025,36 +1026,17 @@ static int mspi_stm32_ospi_dma_setup(const struct mspi_stm32_conf *dev_cfg,
 		return ret;
 	}
 
-	if (dma_cfg.source_data_size != dma_cfg.dest_data_size) {
-		LOG_ERR("Source and Destination data sizes are not aligned");
-		return -EINVAL;
+	ret = dma_stm32_zcfg_to_halcfg(dev_data->dma.dev, &dma_cfg, &hdma->Init,
+				       DMA_ADDR_ADJ_NO_CHANGE, DMA_ADDR_ADJ_INCREMENT);
+	if (ret < 0) {
+		return ret;
 	}
 
-	int index = find_lsb_set(dma_cfg.source_data_size) - 1;
-
 #ifdef CONFIG_DMA_STM32U5
-	/* Fill the structure for dma init */
-	hdma->Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-	hdma->Init.SrcInc = DMA_SINC_FIXED;
-	hdma->Init.DestInc = DMA_DINC_INCREMENTED;
-	hdma->Init.SrcDataWidth = mspi_stm32_table_src_size[index];
-	hdma->Init.DestDataWidth = mspi_stm32_table_dest_size[index];
-	hdma->Init.SrcBurstLength = 4;
-	hdma->Init.DestBurstLength = 4;
 	hdma->Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT1;
-	hdma->Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-#else
-	hdma->Init.PeriphDataAlignment = mspi_stm32_table_dest_size[index];
-	hdma->Init.MemDataAlignment = mspi_stm32_table_src_size[index];
-	hdma->Init.PeriphInc = DMA_PINC_DISABLE;
-	hdma->Init.MemInc = DMA_MINC_ENABLE;
-#endif /* CONFIG_DMA_STM32U5 */
+#endif
 
-	hdma->Init.Mode = DMA_NORMAL;
-	hdma->Init.Priority = mspi_stm32_table_priority[dma_cfg.channel_priority];
-	hdma->Init.Direction = DMA_PERIPH_TO_MEMORY;
 	hdma->Instance = STM32_DMA_GET_INSTANCE(dev_data->dma.reg, dev_data->dma.channel);
-	hdma->Init.Request = dma_cfg.dma_slot;
 	__HAL_LINKDMA(&dev_data->hmspi.ospi, hdma, *hdma);
 	if (HAL_DMA_Init(hdma) != HAL_OK) {
 		LOG_ERR("OSPI DMA Init failed");

--- a/drivers/mspi/mspi_stm32_qspi.c
+++ b/drivers/mspi/mspi_stm32_qspi.c
@@ -141,6 +141,10 @@ static uint32_t mspi_stm32_qspi_hal_address_size(uint8_t address_length)
 static int mspi_stm32_qspi_dma_init(DMA_HandleTypeDef *hdma, struct stm32_stream *dma_stream)
 {
 	int ret;
+	struct dma_block_config dma_block = {
+		.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE,
+		.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+	};
 
 	/* Check if DMA device is ready */
 	if (!device_is_ready(dma_stream->dev)) {
@@ -150,6 +154,8 @@ static int mspi_stm32_qspi_dma_init(DMA_HandleTypeDef *hdma, struct stm32_stream
 
 	/* Configure Zephyr DMA driver */
 	dma_stream->cfg.user_data = hdma;
+	dma_stream->cfg.channel_direction = PERIPHERAL_TO_MEMORY;
+	dma_stream->cfg.head_block = &dma_block;
 	/* This field is used to inform driver that it is overridden */
 	dma_stream->cfg.linked_channel = STM32_DMA_HAL_OVERRIDE;
 
@@ -159,21 +165,11 @@ static int mspi_stm32_qspi_dma_init(DMA_HandleTypeDef *hdma, struct stm32_stream
 		return ret;
 	}
 
-	/* Validate data size alignment */
-	if (dma_stream->cfg.source_data_size != dma_stream->cfg.dest_data_size) {
-		LOG_ERR("DMA Source and destination data sizes not aligned");
-		return -EINVAL;
+	ret = dma_stm32_zcfg_to_halcfg(&dma_stream->cfg, &hdma->Init);
+	if (ret < 0) {
+		return ret;
 	}
 
-	/* Configure HAL DMA driver for QSPI */
-	int index = find_lsb_set(dma_stream->cfg.source_data_size) - 1;
-
-	hdma->Init.PeriphDataAlignment = mspi_stm32_table_dest_size[index];
-	hdma->Init.MemDataAlignment = mspi_stm32_table_src_size[index];
-	hdma->Init.PeriphInc = DMA_PINC_DISABLE;
-	hdma->Init.MemInc = DMA_MINC_ENABLE;
-	hdma->Init.Mode = DMA_NORMAL;
-	hdma->Init.Priority = mspi_stm32_table_priority[dma_stream->cfg.channel_priority];
 #ifdef CONFIG_DMA_STM32_V1
 	/* TODO: Not tested in this configuration */
 	hdma->Init.Channel = dma_stream->cfg.dma_slot;

--- a/drivers/mspi/mspi_stm32_qspi.c
+++ b/drivers/mspi/mspi_stm32_qspi.c
@@ -150,6 +150,7 @@ static int mspi_stm32_qspi_dma_init(DMA_HandleTypeDef *hdma, struct stm32_stream
 
 	/* Configure Zephyr DMA driver */
 	dma_stream->cfg.user_data = hdma;
+	dma_stream->cfg.channel_direction = PERIPHERAL_TO_MEMORY;
 	/* This field is used to inform driver that it is overridden */
 	dma_stream->cfg.linked_channel = STM32_DMA_HAL_OVERRIDE;
 
@@ -159,27 +160,11 @@ static int mspi_stm32_qspi_dma_init(DMA_HandleTypeDef *hdma, struct stm32_stream
 		return ret;
 	}
 
-	/* Validate data size alignment */
-	if (dma_stream->cfg.source_data_size != dma_stream->cfg.dest_data_size) {
-		LOG_ERR("DMA Source and destination data sizes not aligned");
-		return -EINVAL;
+	ret = dma_stm32_zcfg_to_halcfg(dma_stream->dev, &dma_stream->cfg, &hdma->Init,
+				       DMA_ADDR_ADJ_NO_CHANGE, DMA_ADDR_ADJ_INCREMENT);
+	if (ret < 0) {
+		return ret;
 	}
-
-	/* Configure HAL DMA driver for QSPI */
-	int index = find_lsb_set(dma_stream->cfg.source_data_size) - 1;
-
-	hdma->Init.PeriphDataAlignment = mspi_stm32_table_dest_size[index];
-	hdma->Init.MemDataAlignment = mspi_stm32_table_src_size[index];
-	hdma->Init.PeriphInc = DMA_PINC_DISABLE;
-	hdma->Init.MemInc = DMA_MINC_ENABLE;
-	hdma->Init.Mode = DMA_NORMAL;
-	hdma->Init.Priority = mspi_stm32_table_priority[dma_stream->cfg.channel_priority];
-#ifdef CONFIG_DMA_STM32_V1
-	/* TODO: Not tested in this configuration */
-	hdma->Init.Channel = dma_stream->cfg.dma_slot;
-#else
-	hdma->Init.Request = dma_stream->cfg.dma_slot;
-#endif /* CONFIG_DMA_STM32_V1 */
 
 	/* Get DMA channel instance */
 	hdma->Instance = STM32_DMA_GET_CHANNEL_INSTANCE(dma_stream->reg, dma_stream->channel);

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -1035,6 +1035,13 @@ static int mspi_stm32_xspi_transceive(const struct device *controller,
 static int mspi_stm32_xspi_dma_init(DMA_HandleTypeDef *hdma, struct stm32_stream *dma_stream)
 {
 	int ret;
+	struct dma_config hal_dma_cfg;
+	struct dma_block_config dma_block = {
+		.source_addr_adj = dma_stream->src_addr_increment ?
+			DMA_ADDR_ADJ_INCREMENT : DMA_ADDR_ADJ_NO_CHANGE,
+		.dest_addr_adj = dma_stream->dst_addr_increment ?
+			DMA_ADDR_ADJ_INCREMENT : DMA_ADDR_ADJ_NO_CHANGE,
+	};
 	/*
 	 * DMA configuration
 	 * Due to use of XSPI HAL API in current driver,
@@ -1058,26 +1065,19 @@ static int mspi_stm32_xspi_dma_init(DMA_HandleTypeDef *hdma, struct stm32_stream
 		return ret;
 	}
 
-	/* Proceed to the HAL DMA driver init */
-	if (dma_stream->cfg.source_data_size != dma_stream->cfg.dest_data_size) {
-		LOG_ERR("DMA Source and destination data sizes not aligned");
-		return -EINVAL;
+	hal_dma_cfg = dma_stream->cfg;
+	hal_dma_cfg.source_data_size = 1U;
+	hal_dma_cfg.dest_data_size = 1U;
+	hal_dma_cfg.head_block = &dma_block;
+
+	ret = dma_stm32_zcfg_to_halcfg(&hal_dma_cfg, &hdma->Init);
+	if (ret < 0) {
+		return ret;
 	}
 
-	hdma->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
-	hdma->Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
-	hdma->Init.SrcInc =
-		(dma_stream->src_addr_increment) ? DMA_SINC_INCREMENTED : DMA_SINC_FIXED;
-	hdma->Init.DestInc =
-		(dma_stream->dst_addr_increment) ? DMA_DINC_INCREMENTED : DMA_DINC_FIXED;
 	hdma->Init.SrcBurstLength = 4;
 	hdma->Init.DestBurstLength = 4;
-	hdma->Init.Priority = mspi_stm32_table_priority[dma_stream->cfg.channel_priority];
-	hdma->Init.Direction = mspi_stm32_table_direction[dma_stream->cfg.channel_direction];
 	hdma->Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 | DMA_SRC_ALLOCATED_PORT1;
-	hdma->Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-	hdma->Init.Mode = DMA_NORMAL;
-	hdma->Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
 	hdma->Init.Request = dma_stream->cfg.dma_slot;
 
 	/*

--- a/drivers/mspi/mspi_stm32_xspi.c
+++ b/drivers/mspi/mspi_stm32_xspi.c
@@ -784,6 +784,8 @@ static int mspi_configure_delay_block(struct mspi_stm32_data *dev_data)
 static int mspi_stm32_xspi_dma_init(DMA_HandleTypeDef *hdma, struct stm32_stream *dma_stream)
 {
 	int ret;
+	struct dma_config hal_dma_cfg;
+	uint16_t source_addr_adj, dest_addr_adj;
 
 	/*
 	 * DMA configuration
@@ -798,22 +800,20 @@ static int mspi_stm32_xspi_dma_init(DMA_HandleTypeDef *hdma, struct stm32_stream
 		return ret;
 	}
 
-	/* Proceed to the HAL DMA driver init */
-	hdma->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
-	hdma->Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
-	hdma->Init.SrcInc =
-		(dma_stream->src_addr_increment) ? DMA_SINC_INCREMENTED : DMA_SINC_FIXED;
-	hdma->Init.DestInc =
-		(dma_stream->dst_addr_increment) ? DMA_DINC_INCREMENTED : DMA_DINC_FIXED;
-	hdma->Init.SrcBurstLength = 4;
-	hdma->Init.DestBurstLength = 4;
-	hdma->Init.Priority = mspi_stm32_table_priority[dma_stream->cfg.channel_priority];
-	hdma->Init.Direction = mspi_stm32_table_direction[dma_stream->cfg.channel_direction];
-	hdma->Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 | DMA_SRC_ALLOCATED_PORT1;
-	hdma->Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-	hdma->Init.Mode = DMA_NORMAL;
-	hdma->Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-	hdma->Init.Request = dma_stream->cfg.dma_slot;
+	hal_dma_cfg = dma_stream->cfg;
+	hal_dma_cfg.source_data_size = 1U;
+	hal_dma_cfg.dest_data_size = 1U;
+
+	source_addr_adj = dma_stream->src_addr_increment ?
+		DMA_ADDR_ADJ_INCREMENT : DMA_ADDR_ADJ_NO_CHANGE;
+	dest_addr_adj = dma_stream->dst_addr_increment ?
+		DMA_ADDR_ADJ_INCREMENT : DMA_ADDR_ADJ_NO_CHANGE;
+
+	ret = dma_stm32_zcfg_to_halcfg(dma_stream->dev, &hal_dma_cfg, &hdma->Init,
+				       source_addr_adj, dest_addr_adj);
+	if (ret < 0) {
+		return ret;
+	}
 
 	/*
 	 * HAL expects a valid DMA channel.

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -164,10 +164,16 @@ static int stm32_dma_init(const struct device *dev)
 	 * how to route callbacks.
 	 */
 	struct dma_config *dma_cfg = &dma->cfg;
+	struct dma_block_config dma_block = {
+		.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE,
+		.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT,
+	};
 	static DMA_HandleTypeDef hdma;
 
 	/* Proceed to the minimum Zephyr DMA driver init */
 	dma_cfg->user_data = &hdma;
+	dma_cfg->cyclic = 1;
+	dma_cfg->head_block = &dma_block;
 	/* HACK: This field is used to inform driver that it is overridden */
 	dma_cfg->linked_channel = STM32_DMA_HAL_OVERRIDE;
 	ret = dma_config(dma->dma_dev, dma->channel, dma_cfg);
@@ -176,20 +182,13 @@ static int stm32_dma_init(const struct device *dev)
 		return ret;
 	}
 
-	/*** Configure the DMA ***/
-	/* Set the parameters to be configured */
+	ret = dma_stm32_zcfg_to_halcfg(dma_cfg, &hdma.Init);
+	if (ret < 0) {
+		return ret;
+	}
+
 	hdma.Init.Request		= DMA_REQUEST_DCMI;
-	hdma.Init.Direction		= DMA_PERIPH_TO_MEMORY;
-	hdma.Init.PeriphInc		= DMA_PINC_DISABLE;
-	hdma.Init.MemInc		= DMA_MINC_ENABLE;
-	hdma.Init.PeriphDataAlignment	= DMA_PDATAALIGN_WORD;
-	hdma.Init.MemDataAlignment	= DMA_MDATAALIGN_WORD;
-	hdma.Init.Mode			= DMA_CIRCULAR;
-	hdma.Init.Priority		= DMA_PRIORITY_HIGH;
 	hdma.Instance			= STM32_DMA_GET_INSTANCE(dma->reg, dma->channel);
-#if defined(CONFIG_SOC_SERIES_STM32F7X) || defined(CONFIG_SOC_SERIES_STM32H7X)
-	hdma.Init.FIFOMode		= DMA_FIFOMODE_DISABLE;
-#endif
 
 	/* Initialize DMA HAL */
 	__HAL_LINKDMA(&data->hdcmi, DMA_Handle, hdma);

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -168,6 +168,7 @@ static int stm32_dma_init(const struct device *dev)
 
 	/* Proceed to the minimum Zephyr DMA driver init */
 	dma_cfg->user_data = &hdma;
+	dma_cfg->cyclic = 1;
 	/* HACK: This field is used to inform driver that it is overridden */
 	dma_cfg->linked_channel = STM32_DMA_HAL_OVERRIDE;
 	ret = dma_config(dma->dma_dev, dma->channel, dma_cfg);
@@ -176,20 +177,15 @@ static int stm32_dma_init(const struct device *dev)
 		return ret;
 	}
 
-	/*** Configure the DMA ***/
-	/* Set the parameters to be configured */
+	ret = dma_stm32_zcfg_to_halcfg(dma->dma_dev, dma_cfg, &hdma.Init,
+				       DMA_ADDR_ADJ_NO_CHANGE, DMA_ADDR_ADJ_INCREMENT);
+	if (ret < 0) {
+		return ret;
+	}
+
 	hdma.Init.Request		= DMA_REQUEST_DCMI;
 	hdma.Init.Direction		= DMA_PERIPH_TO_MEMORY;
-	hdma.Init.PeriphInc		= DMA_PINC_DISABLE;
-	hdma.Init.MemInc		= DMA_MINC_ENABLE;
-	hdma.Init.PeriphDataAlignment	= DMA_PDATAALIGN_WORD;
-	hdma.Init.MemDataAlignment	= DMA_MDATAALIGN_WORD;
-	hdma.Init.Mode			= DMA_CIRCULAR;
-	hdma.Init.Priority		= DMA_PRIORITY_HIGH;
 	hdma.Instance			= STM32_DMA_GET_INSTANCE(dma->reg, dma->channel);
-#if defined(CONFIG_SOC_SERIES_STM32F7X) || defined(CONFIG_SOC_SERIES_STM32H7X)
-	hdma.Init.FIFOMode		= DMA_FIFOMODE_DISABLE;
-#endif
 
 	/* Initialize DMA HAL */
 	__HAL_LINKDMA(&data->hdcmi, DMA_Handle, hdma);

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -177,15 +177,16 @@ static int stm32_dma_init(const struct device *dev)
 		return ret;
 	}
 
+	dma_cfg->dma_slot = DMA_REQUEST_DCMI;
+	dma_cfg->channel_direction = PERIPHERAL_TO_MEMORY;
+
 	ret = dma_stm32_zcfg_to_halcfg(dma->dma_dev, dma_cfg, &hdma.Init,
 				       DMA_ADDR_ADJ_NO_CHANGE, DMA_ADDR_ADJ_INCREMENT);
 	if (ret < 0) {
 		return ret;
 	}
 
-	hdma.Init.Request		= DMA_REQUEST_DCMI;
-	hdma.Init.Direction		= DMA_PERIPH_TO_MEMORY;
-	hdma.Instance			= STM32_DMA_GET_INSTANCE(dma->reg, dma->channel);
+	hdma.Instance = STM32_DMA_GET_INSTANCE(dma->reg, dma->channel);
 
 	/* Initialize DMA HAL */
 	__HAL_LINKDMA(&data->hdcmi, DMA_Handle, hdma);

--- a/include/zephyr/drivers/dma/dma_stm32.h
+++ b/include/zephyr/drivers/dma/dma_stm32.h
@@ -9,6 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/devicetree/dma.h>
+#include <zephyr/drivers/dma.h>
 
 /* @brief linked_channel value to inform zephyr dma driver that
  * DMA channel will be handled by HAL
@@ -104,5 +105,30 @@
 #define STM32_DMA_GET_INSTANCE(reg, channel)				\
 		STM32_DMA_GET_CHANNEL_INSTANCE((reg), (channel) - STM32_DMA_STREAM_OFFSET);
 #endif
+
+/** @cond INTERNAL_HIDDEN */
+/**
+ * @brief Convert Zephyr DMA configuration to STM32 HAL DMA init structure.
+ *
+ * This is a private STM32 DMA helper intended for direct-DMA users which
+ * prepare DMA_InitTypeDef manually, typically when using HAL override.
+ *
+ * The function initializes all common DMA_InitTypeDef fields that can be
+ * derived from @p zephyr_config. Callers may still override or fill additional
+ * STM32-specific fields afterward if required by the peripheral.
+ *
+ * @warning This function is PRIVATE and intended for STM32 drivers only.  No
+ * guarantee is provided to any external caller.
+ *
+ * @param zephyr_config Pointer to Zephyr DMA configuration
+ * @param hal_config Pointer to HAL DMA init structure to initialize
+ *
+ * @retval 0 on success
+ * @retval -EINVAL if parameters are invalid or the configuration is inconsistent
+ * @retval -ENOTSUP if the configuration cannot be represented with STM32 HAL DMA
+ */
+int dma_stm32_zcfg_to_halcfg(const struct dma_config *zephyr_config,
+			     DMA_InitTypeDef *hal_config);
+/** @endcond */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_DMA_DMA_STM32_H_ */

--- a/include/zephyr/drivers/dma/dma_stm32.h
+++ b/include/zephyr/drivers/dma/dma_stm32.h
@@ -9,6 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/devicetree/dma.h>
+#include <zephyr/drivers/dma.h>
 
 /* @brief linked_channel value to inform zephyr dma driver that
  * DMA channel will be handled by HAL
@@ -104,5 +105,36 @@
 #define STM32_DMA_GET_INSTANCE(reg, channel)				\
 		STM32_DMA_GET_CHANNEL_INSTANCE((reg), (channel) - STM32_DMA_STREAM_OFFSET);
 #endif
+
+#ifndef CONFIG_STM32_HAL2
+/** @cond INTERNAL_HIDDEN */
+/**
+ * @brief Convert Zephyr DMA configuration to STM32 HAL DMA init structure.
+ *
+ * This is a private STM32 DMA helper intended for direct-DMA users which
+ * prepare DMA_InitTypeDef manually, typically when using HAL override.
+ *
+ * The function initializes all common DMA_InitTypeDef fields that can be
+ * derived from @p zephyr_config. Callers may still override or fill additional
+ * STM32-specific fields afterward if required by the peripheral.
+ *
+ * @warning This function is PRIVATE and intended for STM32 drivers only.  No
+ * guarantee is provided to any external caller.
+ *
+ * @param dma Pointer to the DMA device structure
+ * @param zephyr_config Pointer to Zephyr DMA configuration
+ * @param hal_config Pointer to HAL DMA init structure to initialize
+ * @param source_addr_adj Source address adjustment option
+ * @param dest_addr_adj Destination address adjustment option
+ *
+ * @retval 0 on success
+ * @retval -EINVAL if parameters are invalid or the configuration is inconsistent
+ * @retval -ENOTSUP if the configuration cannot be represented with STM32 HAL DMA
+ */
+int dma_stm32_zcfg_to_halcfg(const struct device *dma, const struct dma_config *zephyr_config,
+			     DMA_InitTypeDef *hal_config, uint16_t source_addr_adj,
+			     uint16_t dest_addr_adj);
+/** @endcond */
+#endif /* CONFIG_STM32_HAL2 */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_DMA_DMA_STM32_H_ */


### PR DESCRIPTION
Several drivers have no other way than to go with the STM32 HAL DMA implementation.  This translates to the `STM32_DMA_HAL_OVERRIDE` linked_channel magic number and its specific instantiation.

The aim of this PR is to have a unified DMA structure initialization whether drivers use Zephyr or STM32 HAL DMA.

This brings to the introduction of the following private helper:
`int dma_stm32_zcfg_to_halcfg(const struct dma_config *zephyr_config, DMA_InitTypeDef *hal_config);`

where every STM32 DMA driver should provide the above call, and consumers needing it can fill a Zephyr DMA structure which is then translated to `DMA_InitTypeDef`.  In case where quirks need to be instantiated, the consumer can do so after the zephyr-to-stm32 conversion.

NB: In an attempt to modernize myself, the code of this PR has been heavily helped with generative AI.  Although it has been understood and tested, my confidence within this code is mediocre.  (At least this absolves of responsibilities my poor coding skills... or not !)