### PR TITLE
boards: shields: Better ST Nucleo board support for X-NUCLEO-67W61M1

### DIFF
--- a/boards/shields/x_nucleo_67w61m1/boards/nucleo_c562re.overlay
+++ b/boards/shields/x_nucleo_67w61m1/boards/nucleo_c562re.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_spi {
+	dmas = <&lpdma1 0 5 STM32_DMA_PERIPH_TX>,
+	       <&lpdma1 1 4 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};
+
+&lpdma1 {
+	status = "okay";
+};

--- a/boards/shields/x_nucleo_67w61m1/boards/nucleo_c5a3zg.conf
+++ b/boards/shields/x_nucleo_67w61m1/boards/nucleo_c5a3zg.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_NET_IF_MAX_IPV4_COUNT=2
+CONFIG_NET_IF_MAX_IPV6_COUNT=2

--- a/boards/shields/x_nucleo_67w61m1/boards/nucleo_c5a3zg.overlay
+++ b/boards/shields/x_nucleo_67w61m1/boards/nucleo_c5a3zg.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_spi {
+	dmas = <&lpdma1 0 5 STM32_DMA_PERIPH_TX>,
+	       <&lpdma1 1 4 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};

--- a/boards/shields/x_nucleo_67w61m1/boards/nucleo_h563zi.conf
+++ b/boards/shields/x_nucleo_67w61m1/boards/nucleo_h563zi.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_NET_IF_MAX_IPV4_COUNT=2
+CONFIG_NET_IF_MAX_IPV6_COUNT=2

--- a/boards/shields/x_nucleo_67w61m1/boards/nucleo_h563zi.overlay
+++ b/boards/shields/x_nucleo_67w61m1/boards/nucleo_h563zi.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_spi {
+	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};

--- a/boards/shields/x_nucleo_67w61m1/boards/nucleo_l476rg.overlay
+++ b/boards/shields/x_nucleo_67w61m1/boards/nucleo_l476rg.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&arduino_spi {
+	dmas = <&dma1 3 1 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dma1 2 1 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+
+	st67w611m1: st67w611m1@0 {
+		spi-max-frequency = <DT_FREQ_M(20)>;
+	};
+};
+
+&dma1 {
+	status = "okay";
+};


### PR DESCRIPTION
Improve out of the box support for some Nucleo boards to be used with the X-NUCLEO-67W61M1 Wi-Fi shield. It is mainly about configuring DMA for SPI.
Boards are the following:
- Nucleo H563ZI
- Nucleo C562RE
- Nucleo C5A3ZG
- Nucleo L476RG