### PR TITLE
tests: drivers: flash: add nrf54l15dk support to flash common test

### DIFF
--- a/tests/drivers/flash/common/boards/nrf54l15dk_nrf54l15_cpuapp_w25n01gv.overlay
+++ b/tests/drivers/flash/common/boards/nrf54l15dk_nrf54l15_cpuapp_w25n01gv.overlay
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mx25r64 {
+	status = "disabled";
+};
+
+/delete-node/ &storage_partition;
+
+&spi22_default {
+	group1 {
+		psels = <NRF_PSEL(SPIM_SCK, 1, 11)>,
+			<NRF_PSEL(SPIM_MOSI, 1, 12)>,
+			<NRF_PSEL(SPIM_MISO, 1, 13)>;
+	};
+};
+
+&spi22_sleep {
+	group1 {
+		psels = <NRF_PSEL(SPIM_SCK, 1, 11)>,
+			<NRF_PSEL(SPIM_MOSI, 1, 12)>,
+			<NRF_PSEL(SPIM_MISO, 1, 13)>;
+	};
+
+	low-power-enable;
+};
+
+&spi22 {
+	status = "okay";
+	pinctrl-0 = <&spi22_default>;
+	pinctrl-1 = <&spi22_sleep>;
+	pinctrl-names = "default", "sleep";
+	cs-gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+	overrun-character = <0x00>;
+
+	w25n01gv: spi-nand@0 {
+		compatible = "jedec,spi-nand";
+		reg = <0>;
+		status = "okay";
+		spi-max-frequency = <104000000>;
+
+		/* w25n01gv parameters */
+		jedec-id = [ef aa 21];
+		size-bytes = <DT_SIZE_M(128)>;
+		plane-bytes = <DT_SIZE_M(128)>;
+		erase-block-size = <DT_SIZE_K(128)>;
+		write-block-size = <DT_SIZE_K(2)>;
+		block-erase-duration-max = <10000>;
+		page-program-duration-max = <700>;
+		page-read-duration-max = <200>;
+		reset-duration-max = <500>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			storage_partition: partition@0 {
+				label = "storage";
+				reg = <0x0 DT_SIZE_M(2)>;
+			};
+		};
+	};
+};

--- a/tests/drivers/flash/common/tests.yaml
+++ b/tests/drivers/flash/common/tests.yaml
@@ -282,6 +282,14 @@ tests:
       - SHIELD=mikroe_flash_5_click
       - DTC_OVERLAY_FILE="./boards/mikroe_flash_5_click.overlay"
       - EXTRA_CONF_FILE="./boards/mikroe_flash_5_click.conf"
+  drivers.flash.common.spi_nand.w25n01gv:
+    harness_config:
+      fixture: w25n01gv
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+    extra_args:
+      - FILE_SUFFIX="w25n01gv"
+      - EXTRA_CONF_FILE="./boards/mikroe_flash_5_click.conf"
   drivers.flash.common.versalnet:
     build_only: true
     platform_allow:


### PR DESCRIPTION
This commit adds the necessary overlay files and testcases for support for the nrf54l15dk driving a Mikroe Flash 5 Click NAND flash over SPI