### PR TITLE
include: net: net_context: fix doxygen typo

### DIFF
--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -1453,7 +1453,7 @@ static inline void net_context_setup_pools(struct net_context *context,
 	context->data_pool = data_pool;
 }
 #else
-#define net_context_setup_pools(context, tx_pool, data_pool)
+#define net_context_setup_pools(context, tx_slab, data_pool)
 #endif
 
 /**


### PR DESCRIPTION
somehow missed in CI, this reconciles the parameter name for the two signatures of net_context_setup_pools() (the one with an actual inline body when CONFIG_NET_CONTEXT_NET_PKT_POOL=y and the one pure declarative one).