### PR TITLE
boards: st: stm32h7s78_dk: add audio output

### DIFF
--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -135,6 +135,14 @@
 	status = "okay";
 };
 
+&pll2 {
+	div-m = <5>;
+	mul-n = <294>;
+	div-q = <25>;  /* Tuned for 44.1kHz 16b stereo w/ MCK on I2S6 */
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
 &pll3 {
 	div-m = <12>;
 	mul-n = <25>;
@@ -257,6 +265,15 @@ st_cam_i2c: &i2c1 {
 		irq-gpios = <&gpioe 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		status = "okay";
 	};
+};
+
+&i2s6 {
+	clocks = <&rcc STM32_CLOCK(APB4, 5)>,
+		 <&rcc STM32_SRC_PLL2_Q SPI6_SEL(1)>;
+	pinctrl-0 = <&i2s6_mck_pa3 &i2s6_ws_pa4 &i2s6_ck_pa5 &i2s6_sdo_pb5 &i2s6_sdi_pg12>;
+	pinctrl-names = "default";
+	mck-enabled;
+	status = "okay";
 };
 
 &fdcan1 {

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -265,6 +265,12 @@ st_cam_i2c: &i2c1 {
 		irq-gpios = <&gpioe 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		status = "okay";
 	};
+
+	audio_codec: wm8904g@1a {
+		compatible = "wolfson,wm8904";
+		reg = <0x1a>;
+		status = "okay";
+	};
 };
 
 &i2s6 {

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -272,6 +272,14 @@ st_cam_i2c: &i2c1 {
 		irq-gpios = <&gpioe 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		status = "okay";
 	};
+
+	audio_codec: wm8904@1a {
+		compatible = "wolfson,wm8904";
+		reg = <0x1a>;
+		wolfson,mic-bias-voltage = "avdd-9-10";
+		input-pga-select = <1>;
+		status = "okay";
+	};
 };
 
 &i2s6 {

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk-common.dtsi
@@ -135,6 +135,21 @@
 	status = "okay";
 };
 
+&pll2 {
+	/* PLL2.Q is tuned to minimize bit clock errors on I2S6 providing
+	 * MCK in stereo 16b at the following rates:
+	 * - 8kHz / 16kHz / 32kHz / 48kHz / 96kHz ~ 0.25% err
+	 * - 11.025kHz / 22.05kHz / 44.1KHz / 88.2kHz ~ 0.02% err
+	 * ie. there exists valid I2S prescaler values such that:
+	 * 271MHz x prescaler =~ sample_rate x16(bits) x2(chans) x8(MCK)
+	 */
+	div-m = <12>;
+	mul-n = <271>;
+	div-q = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
 &pll3 {
 	div-m = <12>;
 	mul-n = <25>;
@@ -257,6 +272,15 @@ st_cam_i2c: &i2c1 {
 		irq-gpios = <&gpioe 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		status = "okay";
 	};
+};
+
+&i2s6 {
+	clocks = <&rcc STM32_CLOCK(APB4, 5)>,
+		 <&rcc STM32_SRC_PLL2_Q SPI6_SEL(1)>;
+	pinctrl-0 = <&i2s6_mck_pa3 &i2s6_ws_pa4 &i2s6_ck_pa5 &i2s6_sdo_pb5 &i2s6_sdi_pg12>;
+	pinctrl-names = "default";
+	mck-enabled;
+	status = "okay";
 };
 
 &fdcan1 {

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -584,6 +584,21 @@
 			status = "disabled";
 		};
 
+		i2s6: i2s@58001400 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x58001400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB4, 5)>;
+			interrupts = <63 0>;
+			dmas = <&gpdma1 1 61
+				(STM32_DMA_PERIPH_RX | STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)
+				&gpdma1 0 62
+				(STM32_DMA_PERIPH_TX | STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+			dma-names = "rx", "tx";
+			status = "disabled";
+		};
+
 		fdcan1: can@4000a000 {
 			compatible = "st,stm32-fdcan";
 			reg = <0x4000a000 0x400>, <0x4000ac00 0x350>;

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -520,6 +520,22 @@
 			status = "disabled";
 		};
 
+		i2s1: i2s@42003000 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x42003000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>,
+				 <&rcc STM32_SRC_PLL1_Q SPI1_SEL(0)>;
+			interrupts = <58 0>;
+			dmas = <&gpdma1 1 51
+				(STM32_DMA_PERIPH_RX | STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)
+				&gpdma1 0 52
+				(STM32_DMA_PERIPH_TX | STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+			dma-names = "rx", "tx";
+			status = "disabled";
+		};
+
 		spi2: spi@40003800 {
 			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
@@ -534,6 +550,22 @@
 			status = "disabled";
 		};
 
+		i2s2: i2s@40003800 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>,
+				 <&rcc STM32_SRC_PLL1_Q SPI23_SEL(0)>;
+			interrupts = <59 0>;
+			dmas = <&gpdma1 1 53
+				(STM32_DMA_PERIPH_RX | STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)
+				&gpdma1 0 54
+				(STM32_DMA_PERIPH_TX | STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+			dma-names = "rx", "tx";
+			status = "disabled";
+		};
+
 		spi3: spi@40003c00 {
 			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
@@ -545,6 +577,22 @@
 			st,spi-data-width = "full-4-to-32-bit";
 			fifo-size = <16>;
 			fifo-max-transfer-size = <65535>;
+			status = "disabled";
+		};
+
+		i2s3: i2s@40003c00 {
+			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>,
+				 <&rcc STM32_SRC_PLL1_Q SPI23_SEL(0)>;
+			interrupts = <60 0>;
+			dmas = <&gpdma1 1 55
+				(STM32_DMA_PERIPH_RX | STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)
+				&gpdma1 0 56
+				(STM32_DMA_PERIPH_TX | STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+			dma-names = "rx", "tx";
 			status = "disabled";
 		};
 
@@ -574,14 +622,31 @@
 			fifo-max-transfer-size = <65535>;
 		};
 
-		i2s1: i2s@42003000 {
+		spi6: spi@58001400 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x58001400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB4, 5)>;
+			interrupts = <63 0>;
+			st,spi-data-width = "full-4-to-16-bit";
+			status = "disabled";
+			fifo-size = <8>;
+			fifo-max-transfer-size = <65535>;
+		};
+
+		i2s6: i2s@58001400 {
 			compatible = "st,stm32h7-i2s", "st,stm32-i2s";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0x42003000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12)>,
-				 <&rcc STM32_SRC_PLL1_Q SPI1_SEL(0)>;
-			interrupts = <58 0>;
+			reg = <0x58001400 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB4, 5)>;
+			interrupts = <63 0>;
+			dmas = <&gpdma1 1 61
+				(STM32_DMA_PERIPH_RX | STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)
+				&gpdma1 0 62
+				(STM32_DMA_PERIPH_TX | STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
+			dma-names = "rx", "tx";
 			status = "disabled";
 		};
 

--- a/samples/drivers/i2s/i2s_codec/boards/stm32h7s78_dk_stm32h7s7xx_ext_flash_app.overlay
+++ b/samples/drivers/i2s/i2s_codec/boards/stm32h7s78_dk_stm32h7s7xx_ext_flash_app.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Titouan Christophe
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		i2s-codec-tx = &i2s6;
+	};
+};


### PR DESCRIPTION
Setup audio output on the STM32H7S78-DK:
* Update SPI peripherals on the STM32H7R/S series
    * Add SPI6 which was missing
    * Add I2S nodes for all SPI that support I2S mode (`SPI{1,2,3,6}`)
    * Always put the I2S node below its corresponding SPI, so `i2s1` was moved upwards
* Configure and enable I2S6 and related peripherals for the STM32H7S78-DK, and add the on-board audio codec to the device tree
* Add an overlay for that board in the sample i2s_codec to exercise newly added peripherals