### PR TITLE
tests: drivers: spi: spi_loopback: add kit_pse84_eval m33/ns support

### DIFF
--- a/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns.yaml
+++ b/boards/infineon/kit_pse84_eval/kit_pse84_eval_m33_ns.yaml
@@ -18,3 +18,4 @@ supported:
   - bluetooth
   - wifi
   - flash
+  - spi

--- a/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.conf
+++ b/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.conf
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_INFINEON_DMA=y

--- a/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/kit_pse84_eval_pse846gps2dbzc4a_m33_ns.overlay
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
+ * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kit_pse84_eval_common.overlay"


### PR DESCRIPTION
The non-secure (m33/ns) variant of `kit_pse84_eval` was missing the per-board
devicetree overlay and Kconfig fragment for the SPI loopback test, so the
`scb10` loopback nodes (`test-spi-loopback-slow`/`-fast`) were absent and
`drivers.spi.loopback` was filtered out at runtime. The ns board's
`supported:` list also omitted `spi`, statically filtering the test via its
`spi` dependency.

This adds the m33/ns overlay and conf (mirroring the existing m33 secure and m55
variants) and lists `spi` in the board's supported features so
`drivers.spi.loopback` builds and runs on `kit_pse84_eval/pse846gps2dbzc4a/m33/ns`.

Validated with a full `west build` for `kit_pse84_eval/pse846gps2dbzc4a/m33/ns`:
the overlay applies (generated DT contains the slow@0/fast@0 loopback nodes),
the conf merges (`CONFIG_SPI_INFINEON_DMA=y`), and `zephyr.elf` links.