### PR TITLE
doc: releases: release-notes-4.5: normalize Zbus section label

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -371,7 +371,8 @@ Libraries / Subsystems
 
   * Introducing a video subsystem that inherits all the function names previously in
     video drivers.
-* ZBus
+
+* Zbus
 
   * :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION` now works without requiring
     a dedicated pool on every channel (channels fall back to the shared pool until


### PR DESCRIPTION
The 4.5 release notes referred to the subsystem as both "Zbus" and "ZBus". Use "Zbus" consistently, matching release-notes-4.4 and the canonical "Zephyr bus (zbus)" name, and add the missing blank line separating it from the preceding Video entry.