### PR TITLE
subsys: zbus: proxy_agent: fix OOB read logging channel name

### DIFF
--- a/subsys/zbus/proxy_agent/zbus_proxy_agent_ipc.c
+++ b/subsys/zbus/proxy_agent/zbus_proxy_agent_ipc.c
@@ -47,7 +47,13 @@ static void zbus_proxy_agent_ipc_recv_callback(const void *data, size_t len, voi
 	if (ipc_data->recv_cb) {
 		ret = ipc_data->recv_cb(ipc_data->recv_cb_config_ptr, msg);
 		if (ret < 0) {
-			LOG_WRN("Proxy agent receive callback failed for channel '%s': %d",
+			/*
+			 * The frame comes from a peer domain and, on the recv_cb
+			 * error path, channel_name[] is not guaranteed to be
+			 * NUL-terminated within the fixed-size frame.
+			 */
+			LOG_WRN("Proxy agent receive callback failed for channel '%.*s': %d",
+				(int)MIN(msg->channel_name_len, sizeof(msg->channel_name)),
 				msg->channel_name, ret);
 		}
 	}

--- a/tests/subsys/zbus/proxy_agent/ipc_backend/src/main.c
+++ b/tests/subsys/zbus/proxy_agent/ipc_backend/src/main.c
@@ -287,6 +287,51 @@ ZTEST(ipc_backend, test_backend_recv)
 		      "Receive callback should not be called when length is invalid");
 }
 
+/*
+ * Regression test for OOB read when logging the channel name on the recv_cb
+ * error path.
+ *
+ * A frame originating from a peer domain is not guaranteed to have a
+ * NUL-terminated channel_name[]. When the receive callback rejects such a
+ * frame, the backend logs the channel name. Logging it with a plain "%s" reads
+ * past the fixed-size buffer. This test crafts a frame whose channel_name[]
+ * fully occupies the buffer without a terminator and whose channel_name_len is
+ * larger than the buffer, then forces the recv_cb to fail. The logged name must
+ * be bounded to the buffer size (verified by the regex in tests.yaml) and the
+ * read must not run off the end of the buffer.
+ */
+ZTEST(ipc_backend, test_recv_error_unterminated_channel_name)
+{
+	static struct zbus_proxy_agent_ipc_data ipc_data = {0};
+	struct zbus_proxy_agent_ipc_config ipc_config = {
+		.dev = DEVICE_DT_GET(FAKE_IPC_NODE),
+		.ept_name = "test_ept",
+		.data = &ipc_data,
+	};
+	struct zbus_proxy_msg msg = {0};
+
+	struct zbus_proxy_agent agent_config = create_test_proxy_agent(&ipc_config);
+
+	init_backend(&agent_config);
+
+	/* Fill the whole channel name buffer with no NUL terminator and claim a
+	 * length larger than the buffer, mimicking a malformed peer frame.
+	 */
+	memset(msg.channel_name, 'A', sizeof(msg.channel_name));
+	msg.channel_name_len = UINT32_MAX;
+	msg.message_size = 0;
+
+	/* Force the error path that logs the channel name. */
+	fake_recv_callback_fake.return_val = -EINVAL;
+
+	trigger_received_callback(&msg, sizeof(msg));
+
+	zassert_equal(fake_recv_callback_fake.call_count, 1,
+		      "Receive callback should be called once");
+
+	fake_recv_callback_fake.return_val = 0;
+}
+
 ZTEST(ipc_backend, test_ipc_error)
 {
 	static struct zbus_proxy_agent_ipc_data ipc_data = {0};

--- a/tests/subsys/zbus/proxy_agent/ipc_backend/tests.yaml
+++ b/tests/subsys/zbus/proxy_agent/ipc_backend/tests.yaml
@@ -11,3 +11,4 @@ tests:
       ordered: false
       regex:
         - ".* IPC error: Test error message on endpoint test_ept"
+        - ".* Proxy agent receive callback failed for channel 'A{32}': -22"


### PR DESCRIPTION
The IPC backend receive callback logged msg->channel_name with a plain %s on the recv_cb error path. That frame originates from a peer domain and, precisely because recv_cb rejected it, channel_name[] is not guaranteed to be NUL-terminated.

Fixes: #114906