### PR TITLE
soc: infineon: edge: Only --erase once

### DIFF
--- a/soc/infineon/edge/soc.yml
+++ b/soc/infineon/edge/soc.yml
@@ -244,3 +244,18 @@ family:
       cpuclusters:
       - name: m33
       - name: m55
+
+runners:
+  run_once:
+    '--erase':
+    - run: first
+      runners:
+      - all
+      groups:
+      # Qualifiers are matched as regexes, so a single pattern covers every
+      # pse8xx part number. The m33/ns, m33 and m55 cores of a die are flashed together,
+      # so grouping them here makes --erase run once, before the first core.
+      - qualifiers:
+        - pse8[0-9a-z]+/m33/ns
+        - pse8[0-9a-z]+/m33
+        - pse8[0-9a-z]+/m55


### PR DESCRIPTION
When flashing this AMP part and running firmware built for the M55 with
--sysbuild using west flash --erase would erase twice leaving the part
in a non-bootable state.

Add the needed soc.yml runner options to only run --erase once
regardless of how many images were being flashed.

Fixes #114142 for psoc edge

Signed-off-by: Tom Burdick <thomas.burdick@infineon.com>
