### PR TITLE
soc: renesas: ra: don't emit option settings when chain-loaded by MCUboot

### DIFF
--- a/soc/renesas/ra/ra0e1/rom_start.ld
+++ b/soc/renesas/ra/ra0e1/rom_start.ld
@@ -6,8 +6,13 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0));
 KEEP(*(.option_setting_ofs0))
 
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_ofs1));
 KEEP(*(.option_setting_ofs1))
+
+#endif

--- a/soc/renesas/ra/ra0e1/sections.ld
+++ b/soc/renesas/ra/ra0e1/sections.ld
@@ -6,9 +6,14 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
 } GROUP_LINK_IN(OFS_OSIS_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra2a1/rom_start.ld
+++ b/soc/renesas/ra/ra2a1/rom_start.ld
@@ -7,6 +7,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0));
 KEEP(*(.option_setting_ofs0))
 
@@ -15,3 +18,5 @@ KEEP(*(.option_setting_ofs1))
 
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_secmpu));
 KEEP(*(.option_setting_secmpu))
+
+#endif

--- a/soc/renesas/ra/ra2a1/sections.ld
+++ b/soc/renesas/ra/ra2a1/sections.ld
@@ -7,9 +7,14 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
 } GROUP_LINK_IN(OFS_OSIS_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra2l1/rom_start.ld
+++ b/soc/renesas/ra/ra2l1/rom_start.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0));
 KEEP(*(.option_setting_ofs0))
 
@@ -14,3 +17,5 @@ KEEP(*(.option_setting_ofs1))
 
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_secmpu));
 KEEP(*(.option_setting_secmpu))
+
+#endif

--- a/soc/renesas/ra/ra2l1/sections.ld
+++ b/soc/renesas/ra/ra2l1/sections.ld
@@ -6,9 +6,14 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
 } GROUP_LINK_IN(OFS_OSIS_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra4c1/sections.ld
+++ b/soc/renesas/ra/ra4c1/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -67,4 +70,6 @@ SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_s
 {
 	KEEP(*(.option_setting_bps_sel))
 } GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra4e1/sections.ld
+++ b/soc/renesas/ra/ra4e1/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -46,4 +49,6 @@ SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_s
 {
 	KEEP(*(.option_setting_bps_sel))
 } GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra4e2/sections.ld
+++ b/soc/renesas/ra/ra4e2/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -39,4 +42,6 @@ SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_
 {
 	KEEP(*(.option_setting_pbps_sec))
 } GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra4l1/sections.ld
+++ b/soc/renesas/ra/ra4l1/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -67,4 +70,6 @@ SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_s
 {
 	KEEP(*(.option_setting_bps_sel))
 } GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra4m1/rom_start.ld
+++ b/soc/renesas/ra/ra4m1/rom_start.ld
@@ -7,6 +7,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0));
 KEEP(*(.option_setting_ofs0))
 
@@ -15,3 +18,5 @@ KEEP(*(.option_setting_ofs1))
 
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_secmpu));
 KEEP(*(.option_setting_secmpu))
+
+#endif

--- a/soc/renesas/ra/ra4m1/sections.ld
+++ b/soc/renesas/ra/ra4m1/sections.ld
@@ -7,9 +7,14 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
 } GROUP_LINK_IN(OFS_OSIS_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra4m2/sections.ld
+++ b/soc/renesas/ra/ra4m2/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -46,4 +49,6 @@ SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_s
 {
 	KEEP(*(.option_setting_bps_sel))
 } GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra4m3/sections.ld
+++ b/soc/renesas/ra/ra4m3/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -60,4 +63,6 @@ SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_s
 {
 	KEEP(*(.option_setting_bps_sel))
 } GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra4t1/sections.ld
+++ b/soc/renesas/ra/ra4t1/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -39,4 +42,6 @@ SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_
 {
 	KEEP(*(.option_setting_pbps_sec))
 } GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra4w1/rom_start.ld
+++ b/soc/renesas/ra/ra4w1/rom_start.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0));
 KEEP(*(.option_setting_ofs0))
 
@@ -14,3 +17,5 @@ KEEP(*(.option_setting_ofs1))
 
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_secmpu));
 KEEP(*(.option_setting_secmpu))
+
+#endif

--- a/soc/renesas/ra/ra4w1/sections.ld
+++ b/soc/renesas/ra/ra4w1/sections.ld
@@ -6,9 +6,14 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
 } GROUP_LINK_IN(OFS_OSIS_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra6e1/sections.ld
+++ b/soc/renesas/ra/ra6e1/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -67,4 +70,6 @@ SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_s
 {
 	KEEP(*(.option_setting_bps_sel))
 } GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra6e2/sections.ld
+++ b/soc/renesas/ra/ra6e2/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -39,4 +42,6 @@ SECTION_DATA_PROLOGUE(.option_setting_pbps_sec, DT_REG_ADDR(DT_NODELABEL(option_
 {
 	KEEP(*(.option_setting_pbps_sec))
 } GROUP_LINK_IN(OFS_PBPS_SEC_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra6m1/rom_start.ld
+++ b/soc/renesas/ra/ra6m1/rom_start.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0));
 KEEP(*(.option_setting_ofs0))
 
@@ -14,3 +17,5 @@ KEEP(*(.option_setting_ofs1))
 
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_secmpu));
 KEEP(*(.option_setting_secmpu))
+
+#endif

--- a/soc/renesas/ra/ra6m1/sections.ld
+++ b/soc/renesas/ra/ra6m1/sections.ld
@@ -6,9 +6,14 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
 } GROUP_LINK_IN(OFS_OSIS_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra6m2/rom_start.ld
+++ b/soc/renesas/ra/ra6m2/rom_start.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0));
 KEEP(*(.option_setting_ofs0))
 
@@ -14,3 +17,5 @@ KEEP(*(.option_setting_ofs1))
 
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_secmpu));
 KEEP(*(.option_setting_secmpu))
+
+#endif

--- a/soc/renesas/ra/ra6m2/sections.ld
+++ b/soc/renesas/ra/ra6m2/sections.ld
@@ -6,9 +6,14 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
 } GROUP_LINK_IN(OFS_OSIS_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra6m3/rom_start.ld
+++ b/soc/renesas/ra/ra6m3/rom_start.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0));
 KEEP(*(.option_setting_ofs0))
 
@@ -14,3 +17,5 @@ KEEP(*(.option_setting_ofs1))
 
 . = DT_REG_ADDR(DT_NODELABEL(option_setting_secmpu));
 KEEP(*(.option_setting_secmpu))
+
+#endif

--- a/soc/renesas/ra/ra6m3/sections.ld
+++ b/soc/renesas/ra/ra6m3/sections.ld
@@ -6,9 +6,14 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_osis))
 SECTION_DATA_PROLOGUE(.option_setting_osis, DT_REG_ADDR(DT_NODELABEL(option_setting_osis)),)
 {
 	KEEP(*(.option_setting_osis))
 } GROUP_LINK_IN(OFS_OSIS_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra6m4/sections.ld
+++ b/soc/renesas/ra/ra6m4/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -67,4 +70,6 @@ SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_s
 {
 	KEEP(*(.option_setting_bps_sel))
 } GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra6m5/sections.ld
+++ b/soc/renesas/ra/ra6m5/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -67,4 +70,6 @@ SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_s
 {
 	KEEP(*(.option_setting_bps_sel))
 } GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra8d1/sections.ld
+++ b/soc/renesas/ra/ra8d1/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -74,4 +77,6 @@ SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_s
 {
 	KEEP(*(.option_setting_bps_sel))
 } GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra8d2/sections.ld
+++ b/soc/renesas/ra/ra8d2/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -67,4 +70,6 @@ SECTION_DATA_PROLOGUE(.option_setting_otp_pbps_sec, DT_REG_ADDR(DT_NODELABEL(opt
 {
 	KEEP(*(.option_setting_otp_pbps_sec))
 } GROUP_LINK_IN(OFS_OTP_PBPS_SEC_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra8e1/sections.ld
+++ b/soc/renesas/ra/ra8e1/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -74,4 +77,6 @@ SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_s
 {
 	KEEP(*(.option_setting_bps_sel))
 } GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra8m1/sections.ld
+++ b/soc/renesas/ra/ra8m1/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -74,4 +77,6 @@ SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_s
 {
 	KEEP(*(.option_setting_bps_sel))
 } GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra8m2/sections.ld
+++ b/soc/renesas/ra/ra8m2/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -67,4 +70,6 @@ SECTION_DATA_PROLOGUE(.option_setting_otp_pbps_sec, DT_REG_ADDR(DT_NODELABEL(opt
 {
 	KEEP(*(.option_setting_otp_pbps_sec))
 } GROUP_LINK_IN(OFS_OTP_PBPS_SEC_MEMORY)
+#endif
+
 #endif

--- a/soc/renesas/ra/ra8p1/sections.ld
+++ b/soc/renesas/ra/ra8p1/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {

--- a/soc/renesas/ra/ra8t1/sections.ld
+++ b/soc/renesas/ra/ra8t1/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {

--- a/soc/renesas/ra/ra8t2/sections.ld
+++ b/soc/renesas/ra/ra8t2/sections.ld
@@ -6,6 +6,9 @@
 
 #include <zephyr/devicetree.h>
 
+/* Emit option setting sections only when standalone app OR MCUboot itself */
+#if !defined(CONFIG_BOOTLOADER_MCUBOOT) || defined(CONFIG_MCUBOOT)
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs0))
 SECTION_DATA_PROLOGUE(.option_setting_ofs0, DT_REG_ADDR(DT_NODELABEL(option_setting_ofs0)),)
 {
@@ -67,4 +70,6 @@ SECTION_DATA_PROLOGUE(.option_setting_otp_pbps_sec, DT_REG_ADDR(DT_NODELABEL(opt
 {
 	KEEP(*(.option_setting_otp_pbps_sec))
 } GROUP_LINK_IN(OFS_OTP_PBPS_SEC_MEMORY)
+#endif
+
 #endif


### PR DESCRIPTION
Emit the option settings sections only when the image is a standalone app or MCUboot. Don't emit the option settings when the image is an app being chain-loaded by MCUboot.

This avoids populating addresses outside of the code-partition area in the app image, allowing app images to be signed correctly.

Enabling MCUboot for renesas ra-series is also dependent on:
https://github.com/zephyrproject-rtos/zephyr/pull/109125
https://github.com/mcu-tools/mcuboot/pull/2797