### PR TITLE
samples: pico_w_wifi_led: fix event callback type

### DIFF
--- a/samples/boards/raspberrypi/pico_w_wifi_led/src/main.c
+++ b/samples/boards/raspberrypi/pico_w_wifi_led/src/main.c
@@ -14,7 +14,7 @@ static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED_NODE, gpios);
 static struct net_mgmt_event_callback wifi_cb;
 static K_SEM_DEFINE(scan_done, 0, 1);
 
-static void wifi_scan_result(struct net_mgmt_event_callback *cb, uint32_t mgmt_event,
+static void wifi_scan_result(struct net_mgmt_event_callback *cb, uint64_t mgmt_event,
 			     struct net_if *iface)
 {
 	if (mgmt_event == NET_EVENT_WIFI_SCAN_DONE) {


### PR DESCRIPTION
## Summary

Update the `wifi_scan_result()` event parameter from `uint32_t` to
`uint64_t` so that it matches `net_mgmt_event_handler_t`.

This fixes an incompatible pointer type build failure in the
`pico_w_wifi_led` sample.

## Testing

- Built successfully for `rpi_pico2/rp2350a/m33/w`
- Ran `./scripts/ci/check_compliance.py -c upstream/main..HEAD`
- Compliance result: 0 failures and 0 errors
