### PR TITLE
sys_io: define 64-bit MMIO access semantics on 32-bit targets

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -201,7 +201,9 @@ config RISCV_SOC_HAS_CUSTOM_SYS_IO
 
 	  Enable this hidden option and specialize the z_soc_* functions when
 	  the RISC-V SoC needs to do something different and more than reading and
-	  writing the registers.
+	  writing the registers. On 32-bit targets, a SoC may provide
+	  z_soc_sys_read64() or z_soc_sys_write64() only when it defines the access
+	  semantics; drivers must not assume these functions are available.
 
 config RISCV_SOC_HAS_GP_RELATIVE_ADDRESSING
 	bool

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -201,7 +201,10 @@ config RISCV_SOC_HAS_CUSTOM_SYS_IO
 
 	  Enable this hidden option and specialize the z_soc_* functions when
 	  the RISC-V SoC needs to do something different and more than reading and
-	  writing the registers.
+	  writing the registers. On 32-bit targets, custom z_soc_sys_read64() and
+	  z_soc_sys_write64() implementations remain supported when they guarantee one
+	  atomic 64-bit memory-mapped I/O access; unlike the generic fallback, they are
+	  not deprecated.
 
 config RISCV_SOC_HAS_GP_RELATIVE_ADDRESSING
 	bool

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1223,6 +1223,15 @@ Snippets
 Architectures
 *************
 
+* The generic implementations of :c:func:`sys_read64` and :c:func:`sys_write64` are no longer
+  available on 32-bit targets. An architecture can still provide either accessor when it defines
+  the access semantics. Out-of-tree drivers that used the generic accessors on a 32-bit target must
+  include ``<zephyr/sys/sys_io_non_atomic.h>`` and migrate to :c:func:`sys_read64_lo_hi`,
+  :c:func:`sys_read64_hi_lo`, :c:func:`sys_write64_lo_hi`, or :c:func:`sys_write64_hi_lo` when the
+  addressed register supports non-atomic 32-bit accesses in the selected order. Use
+  :c:func:`sys_read32` and :c:func:`sys_write32` directly for register-specific sequences such as
+  latched or stability-checked reads.
+
 * A new architecture primitive, ``arch_cpu_irqs_are_enabled()``, has been added.
   It returns the current interrupt-enable state of the calling CPU without
   modifying it, complementing ``arch_irq_unlocked()`` which inspects a saved

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1915,6 +1915,19 @@ Snippets
 Architectures
 *************
 
+* Implementations of :c:func:`sys_read64` and :c:func:`sys_write64` that cannot guarantee one atomic
+  64-bit memory-mapped I/O access are deprecated. This includes the generic implementations on
+  32-bit targets and the AArch32 :c:func:`sys_read64` implementation. Existing out-of-tree callers
+  continue to build with a deprecation warning. Implementations that guarantee one atomic 64-bit
+  access remain supported. The deprecated implementations may be removed in Zephyr 5.0 or later.
+  Drivers using a deprecated 32-bit implementation should include
+  ``<zephyr/sys/sys_io_non_atomic.h>`` and migrate to :c:func:`sys_read64_lo_hi`,
+  :c:func:`sys_read64_hi_lo`, :c:func:`sys_write64_lo_hi`, or :c:func:`sys_write64_hi_lo` when the
+  addressed register supports non-atomic 32-bit accesses in the selected order. The helpers place
+  the low and high words according to the target endianness. Use :c:func:`sys_read32` and
+  :c:func:`sys_write32` directly for register-specific sequences such as latched or
+  stability-checked reads, or when the peripheral does not use the target's native endianness.
+
 * A new architecture primitive, ``arch_cpu_irqs_are_enabled()``, has been added.
   It returns the current interrupt-enable state of the calling CPU without
   modifying it, complementing ``arch_irq_unlocked()`` which inspects a saved

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -260,6 +260,13 @@ New APIs and options
 
   * :c:struct:`sys_ringq` (see :ref:`fixed_size_ringq_api`)
 
+* System I/O
+
+  * :c:func:`sys_read64_lo_hi`
+  * :c:func:`sys_read64_hi_lo`
+  * :c:func:`sys_write64_lo_hi`
+  * :c:func:`sys_write64_hi_lo`
+
 * Zbus
 
   * :kconfig:option:`CONFIG_ZBUS_RUNTIME_CHANNEL_REGISTRATION`

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -102,6 +102,11 @@ Removed APIs and options
     * ``CONFIG_CTR_DRBG_CSPRNG_GENERATOR``
     * ``CONFIG_CS_CTR_DRBG_PERSONALIZATION``
 
+* System I/O
+
+    * Generic implementations of :c:func:`sys_read64` and :c:func:`sys_write64` on 32-bit targets.
+      Architectures can continue to provide explicit implementations.
+
 * West sign support for imgtool, which was deprecated in Zephyr 4.0, has been removed.
 
 Deprecated APIs and options

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -304,6 +304,12 @@ Deprecated APIs and options
   * The Nordic SoC headers :file:`<haltium_power.h>` and :file:`<haltium_pm_s2ram.h>`
     have been renamed to :file:`<soc_power.h>` and :file:`<soc_pm_s2ram.h>` respectively.
 
+* System I/O
+
+  * Implementations of :c:func:`sys_read64` and :c:func:`sys_write64` that cannot guarantee one
+    atomic 64-bit memory-mapped I/O access. This includes the generic implementations on 32-bit
+    targets and the AArch32 :c:func:`sys_read64` implementation.
+
 * Ring buffer
 
   * The ring buffer item API (:c:func:`ring_buf_item_init`, :c:func:`ring_buf_item_put`,

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -574,6 +574,13 @@ New APIs and options
 
   * :c:struct:`sys_ringq` (see :ref:`fixed_size_ringq_api`)
 
+* System I/O
+
+  * :c:func:`sys_read64_lo_hi`
+  * :c:func:`sys_read64_hi_lo`
+  * :c:func:`sys_write64_lo_hi`
+  * :c:func:`sys_write64_hi_lo`
+
 * Zbus
 
   * :kconfig:option:`CONFIG_ZBUS_RUNTIME_CHANNEL_REGISTRATION`

--- a/drivers/audio/mic_privacy/intel/mic_privacy_registers.h
+++ b/drivers/audio/mic_privacy/intel/mic_privacy_registers.h
@@ -9,7 +9,6 @@
 
 #include <stdint.h>
 #include <zephyr/arch/cpu.h>
-#include <zephyr/arch/common/sys_io.h>
 
 /**
  * DFMICPVCP

--- a/drivers/clock_control/clock_control_rts5817.c
+++ b/drivers/clock_control/clock_control_rts5817.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/rts5817_clock.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 #include <zephyr/device.h>
 #include <errno.h>
 #include <stdint.h>

--- a/drivers/clock_control/clock_control_syna_sr100.c
+++ b/drivers/clock_control/clock_control_syna_sr100.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/syna_sr100_clock.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 
 #define DT_DRV_COMPAT syna_sr100_clock
 

--- a/drivers/clock_control/clock_stm32_ll_wb0.c
+++ b/drivers/clock_control/clock_stm32_ll_wb0.c
@@ -18,7 +18,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/sys/__assert.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 #include <zephyr/arch/common/sys_bitops.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 

--- a/drivers/clock_control/clock_stm32_ll_wl3.c
+++ b/drivers/clock_control/clock_stm32_ll_wl3.c
@@ -15,7 +15,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 #include <zephyr/arch/common/sys_bitops.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <stdint.h>
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
+#include <zephyr/sys/sys_io_non_atomic.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
@@ -29,10 +30,6 @@ static const uint32_t dmic_base[4] = {PDM0, PDM1, PDM2, PDM3};
 
 /* global data shared between all dmic instances */
 struct dai_dmic_global_shared dai_dmic_global;
-
-/* Helper macro to read 64-bit data using two 32-bit data read */
-#define sys_read64(addr)    (((uint64_t)(sys_read32(addr + 4)) << 32) | \
-			     sys_read32(addr))
 
 int dai_dmic_set_config_nhlt(struct dai_intel_dmic *dmic, const void *spec_config);
 
@@ -419,10 +416,10 @@ static int dai_timestamp_dmic_get(const struct device *dev, struct dai_ts_cfg *c
 	}
 
 	/* NTK was set, get wall clock */
-	tsd->walclk = sys_read64(TS_DMIC_LOCAL_WALCLK);
+	tsd->walclk = sys_read64_hi_lo(TS_DMIC_LOCAL_WALCLK);
 
 	/* Sample */
-	tsd->sample = sys_read64(TS_DMIC_LOCAL_SAMPLE);
+	tsd->sample = sys_read64_hi_lo(TS_DMIC_LOCAL_SAMPLE);
 
 	/* Clear NTK to enable successive timestamps */
 	sys_write32(TS_LOCAL_TSCTRL_NTK, tsctrl);

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -5,6 +5,7 @@
  */
 
 #include <errno.h>
+#include <zephyr/sys/sys_io_non_atomic.h>
 #include <zephyr/sys/util_macro.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -1728,11 +1729,11 @@ static int dai_ssp_set_config_tplg(struct dai_intel_ssp *dp, const struct dai_co
 
 #if SSP_IP_VER > SSP_IP_VER_2_0
 	for (uint32_t idx = 0; idx < I2SIPCMC; ++idx) {
-		sys_write64(sstsa, dai_base(dp) + SSMODyTSA(idx));
+		sys_write64_lo_hi(sstsa, dai_base(dp) + SSMODyTSA(idx));
 	}
 
 	for (uint32_t idx = 0; idx < I2SOPCMC; ++idx) {
-		sys_write64(ssrsa, dai_base(dp) + SSMIDyTSA(idx));
+		sys_write64_lo_hi(ssrsa, dai_base(dp) + SSMIDyTSA(idx));
 	}
 #else
 	sys_write32(sstsa, dai_base(dp) + SSTSA);
@@ -2098,11 +2099,11 @@ static void dai_ssp_set_reg_config(struct dai_intel_ssp *dp, const struct dai_co
 	sys_write32(regs->sscto, dai_base(dp) + SSTO);
 
 	for (uint32_t idx = 0; idx < I2SIPCMC; ++idx) {
-		sys_write64(regs->ssmidytsa[idx], dai_base(dp) + SSMIDyTSA(idx));
+		sys_write64_lo_hi(regs->ssmidytsa[idx], dai_base(dp) + SSMIDyTSA(idx));
 	}
 
 	for (uint32_t idx = 0; idx < I2SOPCMC; ++idx) {
-		sys_write64(regs->ssmodytsa[idx], dai_base(dp) + SSMODyTSA(idx));
+		sys_write64_lo_hi(regs->ssmodytsa[idx], dai_base(dp) + SSMODyTSA(idx));
 	}
 
 	LOG_INF(" sscr0 = 0x%08x, sscr1 = 0x%08x, ssto = 0x%08x, sspsp = 0x%0x",

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -5,6 +5,7 @@
  */
 
 #include <errno.h>
+#include <zephyr/sys/sys_io_non_atomic.h>
 #include <zephyr/sys/util_macro.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -1728,11 +1729,11 @@ static int dai_ssp_set_config_tplg(struct dai_intel_ssp *dp, const struct dai_co
 
 #if SSP_IP_VER > SSP_IP_VER_2_0
 	for (uint32_t idx = 0; idx < I2SIPCMC; ++idx) {
-		sys_write64(sstsa, dai_base(dp) + SSMODyTSA(idx));
+		sys_write64_lo_hi(sstsa, dai_base(dp) + SSMODyTSA(idx));
 	}
 
 	for (uint32_t idx = 0; idx < I2SOPCMC; ++idx) {
-		sys_write64(ssrsa, dai_base(dp) + SSMIDyTSA(idx));
+		sys_write64_lo_hi(ssrsa, dai_base(dp) + SSMIDyTSA(idx));
 	}
 #else
 	sys_write32(sstsa, dai_base(dp) + SSTSA);
@@ -2099,11 +2100,11 @@ static void dai_ssp_set_reg_config(struct dai_intel_ssp *dp, const struct dai_co
 	sys_write32(regs->sscto, dai_base(dp) + SSTO);
 
 	for (uint32_t idx = 0; idx < I2SIPCMC; ++idx) {
-		sys_write64(regs->ssmidytsa[idx], dai_base(dp) + SSMIDyTSA(idx));
+		sys_write64_lo_hi(regs->ssmidytsa[idx], dai_base(dp) + SSMIDyTSA(idx));
 	}
 
 	for (uint32_t idx = 0; idx < I2SOPCMC; ++idx) {
-		sys_write64(regs->ssmodytsa[idx], dai_base(dp) + SSMODyTSA(idx));
+		sys_write64_lo_hi(regs->ssmodytsa[idx], dai_base(dp) + SSMODyTSA(idx));
 	}
 
 	LOG_INF(" sscr0 = 0x%08x, sscr1 = 0x%08x, ssto = 0x%08x, sspsp = 0x%0x",

--- a/drivers/flash/flash_bflb.c
+++ b/drivers/flash/flash_bflb.c
@@ -31,7 +31,7 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/sys/barrier.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 #include <zephyr/cache.h>
 #include <zephyr/sys/byteorder.h>
 

--- a/drivers/gpio/gpio_renesas_rz.c
+++ b/drivers/gpio/gpio_renesas_rz.c
@@ -44,11 +44,6 @@ LOG_MODULE_REGISTER(rz_gpio, CONFIG_GPIO_LOG_LEVEL);
 
 #ifdef CONFIG_GPIO_RENESAS_RZ_TYPE3
 #define NONSAFETY_PORT_START            13
-#define REG_PFC_READ(base, port)        sys_read64((base) + regs.pfc + (port) * 8)
-#define REG_PFC_WRITE(base, port, v)    sys_write64((v), (base) + regs.pfc + (port) * 8)
-#else /* CONFIG_GPIO_RENESAS_RZ_TYPE1 || CONFIG_GPIO_RENESAS_RZ_TYPE2 */
-#define REG_PFC_READ(base, port)        sys_read32((base) + regs.pfc + (port) * 4)
-#define REG_PFC_WRITE(base, port, v)    sys_write32((v), (base) + regs.pfc + (port) * 4)
 #endif /* CONFIG_GPIO_RENESAS_RZ_TYPE3 */
 
 #define PORT(port_pin) FIELD_GET(BIT_MASK(8) << 8, port_pin)
@@ -145,9 +140,13 @@ static inline uint32_t gpio_rz_get_mode(mem_addr_t base, uint8_t port, gpio_pin_
 static inline uint32_t gpio_rz_get_func(mem_addr_t base, uint8_t port, gpio_pin_t pin)
 {
 #ifdef CONFIG_GPIO_RENESAS_RZ_TYPE3
-	return FIELD_GET(BIT_MASK(6) << (pin * 8), REG_PFC_READ(base, port));
+	uint32_t pfc = sys_read32(base + regs.pfc + (port * 8U) + ROUND_DOWN(pin, 4U));
+
+	return FIELD_GET(BIT_MASK(6), pfc >> ((pin % 4U) * 8U));
 #else
-	return FIELD_GET(BIT_MASK(4) << (pin * 4), REG_PFC_READ(base, port));
+	uint32_t pfc = sys_read32(base + regs.pfc + (port * 4U));
+
+	return FIELD_GET(BIT_MASK(4) << (pin * 4), pfc);
 #endif
 }
 

--- a/drivers/pcie/endpoint/pcie_ep_iproc_msi.c
+++ b/drivers/pcie/endpoint/pcie_ep_iproc_msi.c
@@ -7,15 +7,13 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/pcie/endpoint/pcie_ep.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/sys_io_non_atomic.h>
 
 #define DT_DRV_COMPAT brcm_iproc_pcie_ep
 
 #include "pcie_ep_iproc.h"
 
 LOG_MODULE_DECLARE(iproc_pcie, CONFIG_PCIE_EP_LOG_LEVEL);
-
-/* Helper macro to read 64-bit data using two 32-bit data read */
-#define sys_read64(addr) (((uint64_t)(sys_read32(addr + 4)) << 32) | sys_read32(addr))
 
 #ifdef PCIE_EP_IPROC_INIT_CFG
 void iproc_pcie_msix_config(const struct device *dev)
@@ -83,7 +81,7 @@ static int generate_msix(const struct device *dev, const uint32_t msix_num)
 	uint64_t addr;
 	uint32_t data;
 
-	addr = sys_read64(MSIX_VECTOR_OFF(msix_num) + MSIX_TBL_ADDR_OFF);
+	addr = sys_read64_hi_lo(MSIX_VECTOR_OFF(msix_num) + MSIX_TBL_ADDR_OFF);
 
 	if (addr == 0) {
 		/*

--- a/drivers/pinctrl/pinctrl_sy1xx.c
+++ b/drivers/pinctrl/pinctrl_sy1xx.c
@@ -8,8 +8,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
-
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/arch/cpu.h>
 
 static uint32_t pinctrl0_base_addr = DT_REG_ADDR(DT_NODELABEL(pinctrl));
 static uint32_t pinctrl0_base_mask = DT_REG_SIZE(DT_NODELABEL(pinctrl)) - 1;

--- a/drivers/pinctrl/pinctrl_syna_sr100.c
+++ b/drivers/pinctrl/pinctrl_syna_sr100.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/dt-bindings/pinctrl/syna-sr100-pinctrl.h>
 #include <zephyr/drivers/pinctrl.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 
 struct pinctrl_syna_controller {
 	uint32_t mux;

--- a/drivers/reset/reset_syna_sr100.c
+++ b/drivers/reset/reset_syna_sr100.c
@@ -6,7 +6,7 @@
 
 #define DT_DRV_COMPAT syna_sr100_reset
 
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/reset.h>

--- a/drivers/serial/uart_bflb.c
+++ b/drivers/serial/uart_bflb.c
@@ -14,7 +14,7 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/pm/device.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/irq.h>

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -9,7 +9,7 @@
 #include <zephyr/init.h>
 #include <zephyr/devicetree.h>
 #include <soc.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys/clock.h>
 #include <zephyr/spinlock.h>

--- a/drivers/uaol/uaol_intel_adsp.c
+++ b/drivers/uaol/uaol_intel_adsp.c
@@ -20,6 +20,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/uaol.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/sys_io_non_atomic.h>
 #include <zephyr/sys/time_units.h>
 #include <zephyr/arch/common/sys_io.h>
 #include <zephyr/pm/device.h>
@@ -385,14 +386,14 @@ static void uaol_intel_adsp_program_format(const struct device *dev, int stream,
 	sample_block_size = sample_size * channels;
 	payload_size = sample_block_size * ((sample_rate * service_interval_usec) / USEC_PER_SEC);
 
-	pcms_ctl.full = sys_read64(UAOLxPCMSyCTL_ADDR(dp, stream));
+	pcms_ctl.full = sys_read64_lo_hi(UAOLxPCMSyCTL_ADDR(dp, stream));
 	pcms_ctl.part.si = uaol_intel_adsp_encode_service_interval(service_interval_usec);
 	pcms_ctl.part.ass = sample_size - 1;
 	pcms_ctl.part.asbs = sample_block_size;
 	pcms_ctl.part.aps = payload_size;
 	pcms_ctl.part.mps = sio_credit_size;
 	pcms_ctl.part.pm = DIV_ROUND_UP(payload_size, sio_credit_size);
-	sys_write64(pcms_ctl.full, UAOLxPCMSyCTL_ADDR(dp, stream));
+	sys_write64_lo_hi(pcms_ctl.full, UAOLxPCMSyCTL_ADDR(dp, stream));
 }
 
 /*
@@ -439,13 +440,13 @@ static int uaol_intel_adsp_set_stream_state(const struct device *dev, int stream
 	union UAOLxPCMSyCTL pcms_ctl;
 	uint32_t timeout = UAOL_STREAM_STATE_CHANGE_TIMEOUT_USEC;
 
-	pcms_ctl.full = sys_read64(UAOLxPCMSyCTL_ADDR(dp, stream));
+	pcms_ctl.full = sys_read64_lo_hi(UAOLxPCMSyCTL_ADDR(dp, stream));
 	if (pcms_ctl.part.sen != uaol_intel_adsp_get_sbusy(dev, stream)) {
 		LOG_ERR("Unexpected stream state; SEN %d", pcms_ctl.part.sen);
 		return -EBUSY;
 	}
 	pcms_ctl.part.sen = start;
-	sys_write64(pcms_ctl.full, UAOLxPCMSyCTL_ADDR(dp, stream));
+	sys_write64_lo_hi(pcms_ctl.full, UAOLxPCMSyCTL_ADDR(dp, stream));
 
 	if (!WAIT_FOR(uaol_intel_adsp_get_sbusy(dev, stream) == start, timeout, k_busy_wait(1))) {
 		LOG_ERR("Stream start/stop timeout; start %d", start);
@@ -463,9 +464,9 @@ static void uaol_intel_adsp_reset_stream(const struct device *dev, int stream, b
 	struct uaol_intel_adsp_data *dp = dev->data;
 	union UAOLxPCMSyCTL pcms_ctl;
 
-	pcms_ctl.full = sys_read64(UAOLxPCMSyCTL_ADDR(dp, stream));
+	pcms_ctl.full = sys_read64_lo_hi(UAOLxPCMSyCTL_ADDR(dp, stream));
 	pcms_ctl.part.srst = reset;
-	sys_write64(pcms_ctl.full, UAOLxPCMSyCTL_ADDR(dp, stream));
+	sys_write64_lo_hi(pcms_ctl.full, UAOLxPCMSyCTL_ADDR(dp, stream));
 }
 
 static bool uaol_intel_adsp_frame_adjust_idle(const struct device *dev)

--- a/drivers/uaol/uaol_intel_adsp.c
+++ b/drivers/uaol/uaol_intel_adsp.c
@@ -21,7 +21,7 @@
 #include <zephyr/drivers/uaol.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/time_units.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/logging/log.h>

--- a/drivers/uaol/uaol_intel_adsp.c
+++ b/drivers/uaol/uaol_intel_adsp.c
@@ -20,6 +20,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/uaol.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/sys_io_non_atomic.h>
 #include <zephyr/sys/time_units.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/pm/device.h>
@@ -390,14 +391,14 @@ static void uaol_intel_adsp_program_format(const struct device *dev, int stream,
 	sample_block_size = sample_size * channels;
 	payload_size = sample_block_size * ((sample_rate * service_interval_usec) / USEC_PER_SEC);
 
-	pcms_ctl.full = sys_read64(UAOLxPCMSyCTL_ADDR(dp, stream));
+	pcms_ctl.full = sys_read64_lo_hi(UAOLxPCMSyCTL_ADDR(dp, stream));
 	pcms_ctl.part.si = uaol_intel_adsp_encode_service_interval(service_interval_usec);
 	pcms_ctl.part.ass = sample_size - 1;
 	pcms_ctl.part.asbs = sample_block_size;
 	pcms_ctl.part.aps = payload_size;
 	pcms_ctl.part.mps = sio_credit_size;
 	pcms_ctl.part.pm = DIV_ROUND_UP(payload_size, sio_credit_size);
-	sys_write64(pcms_ctl.full, UAOLxPCMSyCTL_ADDR(dp, stream));
+	sys_write64_lo_hi(pcms_ctl.full, UAOLxPCMSyCTL_ADDR(dp, stream));
 }
 
 /*
@@ -444,13 +445,13 @@ static int uaol_intel_adsp_set_stream_state(const struct device *dev, int stream
 	union UAOLxPCMSyCTL pcms_ctl;
 	uint32_t timeout = UAOL_STREAM_STATE_CHANGE_TIMEOUT_USEC;
 
-	pcms_ctl.full = sys_read64(UAOLxPCMSyCTL_ADDR(dp, stream));
+	pcms_ctl.full = sys_read64_lo_hi(UAOLxPCMSyCTL_ADDR(dp, stream));
 	if (pcms_ctl.part.sen != uaol_intel_adsp_get_sbusy(dev, stream)) {
 		LOG_ERR("Unexpected stream state; SEN %d", pcms_ctl.part.sen);
 		return -EBUSY;
 	}
 	pcms_ctl.part.sen = start;
-	sys_write64(pcms_ctl.full, UAOLxPCMSyCTL_ADDR(dp, stream));
+	sys_write64_lo_hi(pcms_ctl.full, UAOLxPCMSyCTL_ADDR(dp, stream));
 
 	if (!WAIT_FOR(uaol_intel_adsp_get_sbusy(dev, stream) == start, timeout, k_busy_wait(1))) {
 		LOG_ERR("Stream start/stop timeout; start %d", start);
@@ -468,9 +469,9 @@ static void uaol_intel_adsp_reset_stream(const struct device *dev, int stream, b
 	struct uaol_intel_adsp_data *dp = dev->data;
 	union UAOLxPCMSyCTL pcms_ctl;
 
-	pcms_ctl.full = sys_read64(UAOLxPCMSyCTL_ADDR(dp, stream));
+	pcms_ctl.full = sys_read64_lo_hi(UAOLxPCMSyCTL_ADDR(dp, stream));
 	pcms_ctl.part.srst = reset;
-	sys_write64(pcms_ctl.full, UAOLxPCMSyCTL_ADDR(dp, stream));
+	sys_write64_lo_hi(pcms_ctl.full, UAOLxPCMSyCTL_ADDR(dp, stream));
 }
 
 static bool uaol_intel_adsp_frame_adjust_idle(const struct device *dev)

--- a/include/zephyr/arch/arm/cortex_a_r/sys_io.h
+++ b/include/zephyr/arch/arm/cortex_a_r/sys_io.h
@@ -72,7 +72,8 @@ static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 	__asm__ volatile("str %0, [%1]" : : "r" (data), "r" (addr));
 }
 
-static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
+#ifndef RUST_BINDGEN
+__deprecated static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
 {
 	uint64_t val;
 
@@ -81,6 +82,7 @@ static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
 	barrier_dmem_fence_full();
 	return val;
 }
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/arch/common/sys_io.h
+++ b/include/zephyr/arch/common/sys_io.h
@@ -55,6 +55,7 @@ static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 	*(volatile uint32_t *)addr = data;
 }
 
+#ifdef CONFIG_64BIT
 static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
 {
 	return *(volatile uint64_t *)addr;
@@ -64,6 +65,7 @@ static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
 {
 	*(volatile uint64_t *)addr = data;
 }
+#endif /* CONFIG_64BIT */
 
 /**
  * @endcond

--- a/include/zephyr/arch/common/sys_io.h
+++ b/include/zephyr/arch/common/sys_io.h
@@ -55,15 +55,23 @@ static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 	*(volatile uint32_t *)addr = data;
 }
 
+#if defined(CONFIG_64BIT) || !defined(RUST_BINDGEN)
+#ifndef CONFIG_64BIT
+__deprecated
+#endif
 static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
 {
 	return *(volatile uint64_t *)addr;
 }
 
+#ifndef CONFIG_64BIT
+__deprecated
+#endif
 static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
 {
 	*(volatile uint64_t *)addr = data;
 }
+#endif /* CONFIG_64BIT || !RUST_BINDGEN */
 
 /**
  * @endcond

--- a/include/zephyr/arch/riscv/sys_io.h
+++ b/include/zephyr/arch/riscv/sys_io.h
@@ -15,10 +15,6 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/sys_io.h>
 
-#ifndef CONFIG_RISCV_SOC_HAS_CUSTOM_SYS_IO
-#include <zephyr/arch/common/sys_io.h>
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -73,6 +69,62 @@ static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
 {
 	z_soc_sys_write64(data, addr);
 }
+
+#else
+
+static ALWAYS_INLINE uint8_t sys_read8(mem_addr_t addr)
+{
+	uint8_t val;
+
+	__asm__ volatile("lb %0, 0(%1)" : "=r"(val) : "r"(addr));
+	return val;
+}
+
+static ALWAYS_INLINE void sys_write8(uint8_t data, mem_addr_t addr)
+{
+	__asm__ volatile("sb %0, 0(%1)" : : "r"(data), "r"(addr));
+}
+
+static ALWAYS_INLINE uint16_t sys_read16(mem_addr_t addr)
+{
+	uint16_t val;
+
+	__asm__ volatile("lh %0, 0(%1)" : "=r"(val) : "r"(addr));
+	return val;
+}
+
+static ALWAYS_INLINE void sys_write16(uint16_t data, mem_addr_t addr)
+{
+	__asm__ volatile("sh %0, 0(%1)" : : "r"(data), "r"(addr));
+}
+
+static ALWAYS_INLINE uint32_t sys_read32(mem_addr_t addr)
+{
+	uint32_t val;
+
+	__asm__ volatile("lw %0, 0(%1)" : "=r"(val) : "r"(addr));
+	return val;
+}
+
+static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
+{
+	__asm__ volatile("sw %0, 0(%1)" : : "r"(data), "r"(addr));
+}
+
+#ifdef CONFIG_64BIT
+static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
+{
+	uint64_t val;
+
+	__asm__ volatile("ld %0, 0(%1)" : "=r"(val) : "r"(addr));
+	return val;
+}
+
+static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
+{
+	__asm__ volatile("sd %0, 0(%1)" : : "r"(data), "r"(addr));
+}
+#endif /* CONFIG_64BIT */
 
 #endif /* CONFIG_RISCV_SOC_HAS_CUSTOM_SYS_IO */
 

--- a/include/zephyr/arch/riscv/sys_io.h
+++ b/include/zephyr/arch/riscv/sys_io.h
@@ -15,10 +15,6 @@
 #include <zephyr/types.h>
 #include <zephyr/sys/sys_io.h>
 
-#ifndef CONFIG_RISCV_SOC_HAS_CUSTOM_SYS_IO
-#include <zephyr/arch/common/sys_io.h>
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -73,6 +69,72 @@ static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
 {
 	z_soc_sys_write64(data, addr);
 }
+
+#else
+
+static ALWAYS_INLINE uint8_t sys_read8(mem_addr_t addr)
+{
+	uint8_t val;
+
+	__asm__ volatile("lb %0, 0(%1)" : "=r"(val) : "r"(addr));
+	return val;
+}
+
+static ALWAYS_INLINE void sys_write8(uint8_t data, mem_addr_t addr)
+{
+	__asm__ volatile("sb %0, 0(%1)" : : "r"(data), "r"(addr));
+}
+
+static ALWAYS_INLINE uint16_t sys_read16(mem_addr_t addr)
+{
+	uint16_t val;
+
+	__asm__ volatile("lh %0, 0(%1)" : "=r"(val) : "r"(addr));
+	return val;
+}
+
+static ALWAYS_INLINE void sys_write16(uint16_t data, mem_addr_t addr)
+{
+	__asm__ volatile("sh %0, 0(%1)" : : "r"(data), "r"(addr));
+}
+
+static ALWAYS_INLINE uint32_t sys_read32(mem_addr_t addr)
+{
+	uint32_t val;
+
+	__asm__ volatile("lw %0, 0(%1)" : "=r"(val) : "r"(addr));
+	return val;
+}
+
+static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
+{
+	__asm__ volatile("sw %0, 0(%1)" : : "r"(data), "r"(addr));
+}
+
+#ifdef CONFIG_64BIT
+static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
+{
+	uint64_t val;
+
+	__asm__ volatile("ld %0, 0(%1)" : "=r"(val) : "r"(addr));
+	return val;
+}
+
+static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
+{
+	__asm__ volatile("sd %0, 0(%1)" : : "r"(data), "r"(addr));
+}
+#elif !defined(RUST_BINDGEN)
+__deprecated static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
+{
+	return *(volatile uint64_t *)addr;
+}
+
+__deprecated static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
+{
+	*(volatile uint64_t *)addr = data;
+}
+#endif /* CONFIG_64BIT */
 
 #endif /* CONFIG_RISCV_SOC_HAS_CUSTOM_SYS_IO */
 

--- a/include/zephyr/sys/sys_io.h
+++ b/include/zephyr/sys/sys_io.h
@@ -25,6 +25,8 @@ extern "C" {
  * @brief System I/O APIs
  *
  * @defgroup sys_io_apis System I/O APIs
+ * @since 1.0
+ * @version 2.0.0
  * @ingroup utilities
  *
  * Low-level primitives for port I/O, memory-mapped register I/O, and in-memory bit manipulation.
@@ -264,6 +266,11 @@ static inline uint32_t sys_read32(mm_reg_t addr);
  *
  * @param data the 64 bits to write
  * @param addr the memory mapped register address where to write the 64 bits
+ *
+ * @note The generic implementation is only available when CONFIG_64BIT is enabled. An architecture
+ *       may provide this function on a 32-bit target when it can define the access semantics. Use
+ *       one of the non-atomic ordered helpers when the addressed register supports two non-atomic
+ *       32-bit writes.
  */
 static inline void sys_write64(uint64_t data, mm_reg_t addr);
 
@@ -276,6 +283,11 @@ static inline void sys_write64(uint64_t data, mm_reg_t addr);
  *        the 64 bits
  *
  * @return the 64 bits read
+ *
+ * @note The generic implementation is only available when CONFIG_64BIT is enabled. An architecture
+ *       may provide this function on a 32-bit target when it can define the access semantics. Use
+ *       one of the non-atomic ordered helpers when the addressed register supports two non-atomic
+ *       32-bit reads.
  */
 static inline uint64_t sys_read64(mm_reg_t addr);
 

--- a/include/zephyr/sys/sys_io.h
+++ b/include/zephyr/sys/sys_io.h
@@ -26,7 +26,7 @@ extern "C" {
  *
  * @defgroup sys_io_apis System I/O APIs
  * @since 1.0
- * @version 1.0.0
+ * @version 1.1.0
  * @ingroup utilities
  *
  * Low-level primitives for port I/O, memory-mapped register I/O, and in-memory bit manipulation.
@@ -185,6 +185,11 @@ static inline int sys_io_test_and_clear_bit(io_port_t port, unsigned int bit);
  * @defgroup sys_io_mmio_apis Memory-mapped register I/O APIs
  * @ingroup sys_io_apis
  *
+ * Supported standard accessors guarantee one atomic memory-mapped I/O access of the indicated
+ * width and must not be implemented as multiple narrower accesses. Deprecated compatibility
+ * implementations that cannot provide this guarantee remain temporarily available on some
+ * 32-bit targets. The ordered 64-bit helpers explicitly document their non-atomic behavior.
+ *
  * @internal
  * Memory mapped registers I/O is optional and only implemented by a few architectures (e.g. x86),
  * in their architecture-specific headers. Those headers are excluded from the Doxygen build, so the
@@ -266,6 +271,11 @@ static inline uint32_t sys_read32(mm_reg_t addr);
  *
  * @param data the 64 bits to write
  * @param addr the memory mapped register address where to write the 64 bits
+ *
+ * @note This API requires one atomic 64-bit memory-mapped I/O write. Deprecated compatibility
+ *       implementations on some 32-bit targets may split the operation into two 32-bit writes.
+ *       Use one of the ordered non-atomic helpers when the addressed register supports such
+ *       accesses.
  */
 static inline void sys_write64(uint64_t data, mm_reg_t addr);
 
@@ -278,6 +288,11 @@ static inline void sys_write64(uint64_t data, mm_reg_t addr);
  *        the 64 bits
  *
  * @return the 64 bits read
+ *
+ * @note This API requires one atomic 64-bit memory-mapped I/O read. Deprecated compatibility
+ *       implementations on some 32-bit targets may split the operation into two 32-bit reads.
+ *       Use one of the ordered non-atomic helpers when the addressed register supports such
+ *       accesses.
  */
 static inline uint64_t sys_read64(mm_reg_t addr);
 

--- a/include/zephyr/sys/sys_io_non_atomic.h
+++ b/include/zephyr/sys/sys_io_non_atomic.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Non-atomic ordered native-endian 64-bit memory-mapped I/O accessors.
+ * @ingroup sys_io_apis
+ *
+ * The low and high words are placed according to the target endianness, consistent with the
+ * native-endian :c:func:`sys_read32` and :c:func:`sys_write32` accessors.
+ */
+
+#ifndef ZEPHYR_INCLUDE_SYS_SYS_IO_NON_ATOMIC_H_
+#define ZEPHYR_INCLUDE_SYS_SYS_IO_NON_ATOMIC_H_
+
+#include <zephyr/sys/sys_io.h>
+
+#ifdef __DOXYGEN__
+
+/**
+ * @brief Read a 64-bit value using low-word then high-word accesses
+ *
+ * This function performs two 32-bit reads. It first reads the low word, then reads the high word.
+ * The low word is at @p addr on little-endian targets and at @p addr + 4 on big-endian targets.
+ *
+ * @param addr the base address of the memory mapped register
+ *
+ * @return the 64-bit value assembled from the two words
+ *
+ * @warning The two reads are not atomic. The caller must ensure that the addressed register
+ *          supports non-atomic reads in this order.
+ */
+static inline uint64_t sys_read64_lo_hi(mm_reg_t addr);
+
+/**
+ * @brief Read a 64-bit value using high-word then low-word accesses
+ *
+ * This function performs two 32-bit reads. It first reads the high word, then reads the low word.
+ * The high word is at @p addr + 4 on little-endian targets and at @p addr on big-endian targets.
+ *
+ * @param addr the base address of the memory mapped register
+ *
+ * @return the 64-bit value assembled from the two words
+ *
+ * @warning The two reads are not atomic. The caller must ensure that the addressed register
+ *          supports non-atomic reads in this order.
+ */
+static inline uint64_t sys_read64_hi_lo(mm_reg_t addr);
+
+/**
+ * @brief Write a 64-bit value using low-word then high-word accesses
+ *
+ * This function performs two 32-bit writes. It first writes the low word, then writes the high
+ * word. The low word is at @p addr on little-endian targets and at @p addr + 4 on big-endian
+ * targets.
+ *
+ * @param data the 64-bit value to write
+ * @param addr the base address of the memory mapped register
+ *
+ * @warning The two writes are not atomic. The caller must ensure that the addressed register
+ *          supports non-atomic writes in this order.
+ */
+static inline void sys_write64_lo_hi(uint64_t data, mm_reg_t addr);
+
+/**
+ * @brief Write a 64-bit value using high-word then low-word accesses
+ *
+ * This function performs two 32-bit writes. It first writes the high word, then writes the low
+ * word. The high word is at @p addr + 4 on little-endian targets and at @p addr on big-endian
+ * targets.
+ *
+ * @param data the 64-bit value to write
+ * @param addr the base address of the memory mapped register
+ *
+ * @warning The two writes are not atomic. The caller must ensure that the addressed register
+ *          supports non-atomic writes in this order.
+ */
+static inline void sys_write64_hi_lo(uint64_t data, mm_reg_t addr);
+
+#else
+
+#include <zephyr/arch/cpu.h>
+
+static ALWAYS_INLINE mem_addr_t z_sys_io64_lo_addr(mem_addr_t addr)
+{
+#ifdef CONFIG_BIG_ENDIAN
+	return addr + sizeof(uint32_t);
+#else
+	return addr;
+#endif
+}
+
+static ALWAYS_INLINE mem_addr_t z_sys_io64_hi_addr(mem_addr_t addr)
+{
+#ifdef CONFIG_BIG_ENDIAN
+	return addr;
+#else
+	return addr + sizeof(uint32_t);
+#endif
+}
+
+static ALWAYS_INLINE uint64_t sys_read64_lo_hi(mem_addr_t addr)
+{
+	uint32_t lo = sys_read32(z_sys_io64_lo_addr(addr));
+	uint32_t hi = sys_read32(z_sys_io64_hi_addr(addr));
+
+	return ((uint64_t)hi << 32) | lo;
+}
+
+static ALWAYS_INLINE uint64_t sys_read64_hi_lo(mem_addr_t addr)
+{
+	uint32_t hi = sys_read32(z_sys_io64_hi_addr(addr));
+	uint32_t lo = sys_read32(z_sys_io64_lo_addr(addr));
+
+	return ((uint64_t)hi << 32) | lo;
+}
+
+static ALWAYS_INLINE void sys_write64_lo_hi(uint64_t data, mem_addr_t addr)
+{
+	sys_write32((uint32_t)data, z_sys_io64_lo_addr(addr));
+	sys_write32((uint32_t)(data >> 32), z_sys_io64_hi_addr(addr));
+}
+
+static ALWAYS_INLINE void sys_write64_hi_lo(uint64_t data, mem_addr_t addr)
+{
+	sys_write32((uint32_t)(data >> 32), z_sys_io64_hi_addr(addr));
+	sys_write32((uint32_t)data, z_sys_io64_lo_addr(addr));
+}
+
+#endif /* __DOXYGEN__ */
+
+#endif /* ZEPHYR_INCLUDE_SYS_SYS_IO_NON_ATOMIC_H_ */

--- a/include/zephyr/sys/sys_io_non_atomic.h
+++ b/include/zephyr/sys/sys_io_non_atomic.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Meta
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Non-atomic ordered 64-bit memory-mapped I/O accessors.
+ * @ingroup sys_io_apis
+ */
+
+#ifndef ZEPHYR_INCLUDE_SYS_SYS_IO_NON_ATOMIC_H_
+#define ZEPHYR_INCLUDE_SYS_SYS_IO_NON_ATOMIC_H_
+
+#include <zephyr/sys/sys_io.h>
+
+#ifdef __DOXYGEN__
+
+/**
+ * @brief Read a 64-bit value using low-word then high-word accesses
+ *
+ * This function performs two 32-bit reads. It first reads the low word from @p addr, then reads the
+ * high word from @p addr + 4.
+ *
+ * @param addr the address of the low word of the memory mapped register
+ *
+ * @return the 64-bit value assembled from the two words
+ *
+ * @warning The two reads are not atomic. The caller must ensure that the addressed register
+ *          supports non-atomic reads in this order.
+ */
+static inline uint64_t sys_read64_lo_hi(mm_reg_t addr);
+
+/**
+ * @brief Read a 64-bit value using high-word then low-word accesses
+ *
+ * This function performs two 32-bit reads. It first reads the high word from @p addr + 4, then
+ * reads the low word from @p addr.
+ *
+ * @param addr the address of the low word of the memory mapped register
+ *
+ * @return the 64-bit value assembled from the two words
+ *
+ * @warning The two reads are not atomic. The caller must ensure that the addressed register
+ *          supports non-atomic reads in this order.
+ */
+static inline uint64_t sys_read64_hi_lo(mm_reg_t addr);
+
+/**
+ * @brief Write a 64-bit value using low-word then high-word accesses
+ *
+ * This function performs two 32-bit writes. It first writes the low word to @p addr, then writes
+ * the high word to @p addr + 4.
+ *
+ * @param data the 64-bit value to write
+ * @param addr the address of the low word of the memory mapped register
+ *
+ * @warning The two writes are not atomic. The caller must ensure that the addressed register
+ *          supports non-atomic writes in this order.
+ */
+static inline void sys_write64_lo_hi(uint64_t data, mm_reg_t addr);
+
+/**
+ * @brief Write a 64-bit value using high-word then low-word accesses
+ *
+ * This function performs two 32-bit writes. It first writes the high word to @p addr + 4, then
+ * writes the low word to @p addr.
+ *
+ * @param data the 64-bit value to write
+ * @param addr the address of the low word of the memory mapped register
+ *
+ * @warning The two writes are not atomic. The caller must ensure that the addressed register
+ *          supports non-atomic writes in this order.
+ */
+static inline void sys_write64_hi_lo(uint64_t data, mm_reg_t addr);
+
+#else
+
+#include <zephyr/arch/cpu.h>
+
+static ALWAYS_INLINE uint64_t sys_read64_lo_hi(mem_addr_t addr)
+{
+	uint32_t low = sys_read32(addr);
+	uint32_t high = sys_read32(addr + sizeof(uint32_t));
+
+	return ((uint64_t)high << 32) | low;
+}
+
+static ALWAYS_INLINE uint64_t sys_read64_hi_lo(mem_addr_t addr)
+{
+	uint32_t high = sys_read32(addr + sizeof(uint32_t));
+	uint32_t low = sys_read32(addr);
+
+	return ((uint64_t)high << 32) | low;
+}
+
+static ALWAYS_INLINE void sys_write64_lo_hi(uint64_t data, mem_addr_t addr)
+{
+	sys_write32((uint32_t)data, addr);
+	sys_write32((uint32_t)(data >> 32), addr + sizeof(uint32_t));
+}
+
+static ALWAYS_INLINE void sys_write64_hi_lo(uint64_t data, mem_addr_t addr)
+{
+	sys_write32((uint32_t)(data >> 32), addr + sizeof(uint32_t));
+	sys_write32((uint32_t)data, addr);
+}
+
+#endif /* __DOXYGEN__ */
+
+#endif /* ZEPHYR_INCLUDE_SYS_SYS_IO_NON_ATOMIC_H_ */

--- a/soc/focaltech/ft9001/xip.c
+++ b/soc/focaltech/ft9001/xip.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/sys/barrier.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/arch/cpu.h>
 
 /* clocks (soc-specific) */
 #define FT9001_CLK_CFG_ADDR    0x40004008u

--- a/soc/intel/intel_adsp/ace/timestamp.c
+++ b/soc/intel/intel_adsp/ace/timestamp.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <zephyr/spinlock.h>
+#include <zephyr/sys/sys_io_non_atomic.h>
 #include <zephyr/devicetree.h>
 #include <adsp_shim.h>
 #include <adsp_timestamp.h>
@@ -81,9 +82,9 @@ int intel_adsp_get_timestamp(uint32_t tsctrl, struct intel_adsp_timestamp *times
 	 * data in HW is guaranteed to be valid and static.
 	 */
 	timestamp->iscs = sys_read32(ISCS_ADDR);
-	timestamp->lscs = sys_read64(LSCS_ADDR);
-	timestamp->dwccs = sys_read64(DWCCS_ADDR);
-	timestamp->artcs = sys_read64(ARTCS_ADDR);
+	timestamp->lscs = sys_read64_hi_lo(LSCS_ADDR);
+	timestamp->dwccs = sys_read64_hi_lo(DWCCS_ADDR);
+	timestamp->artcs = sys_read64_hi_lo(ARTCS_ADDR);
 	timestamp->lwccs = sys_read32(LWCCS_ADDR);
 
 	/* Clear NTK (RW/1C) bit */

--- a/soc/litex/common/soc.h
+++ b/soc/litex/common/soc.h
@@ -10,6 +10,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/arch/riscv/sys_io.h>
+#include <zephyr/sys/sys_io_non_atomic.h>
 
 #ifndef _ASMLANGUAGE
 /* CSR access helpers */
@@ -88,9 +89,12 @@ static inline uint64_t litex_read64(mem_addr_t addr)
 #endif
 #else /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 #ifdef CONFIG_LITEX_CSR_ORDERING_BIG
-	return ((uint64_t)sys_read32(addr) << 32) | (uint64_t)sys_read32(addr + 0x4);
+	uint32_t high = sys_read32(addr);
+	uint32_t low = sys_read32(addr + 0x4);
+
+	return ((uint64_t)high << 32) | low;
 #else
-	return sys_read64(addr);
+	return sys_read64_hi_lo(addr);
 #endif
 #endif
 }
@@ -161,7 +165,7 @@ static inline void litex_write64(uint64_t value, mem_addr_t addr)
 	sys_write32(value >> 32, addr);
 	sys_write32(value, addr + 0x4);
 #else
-	sys_write64(value, addr);
+	sys_write64_lo_hi(value, addr);
 #endif
 #endif /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 }

--- a/soc/microchip/mec/common/soc_ecia.c
+++ b/soc/microchip/mec/common/soc_ecia.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/arch/common/sys_bitops.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 #include <soc.h>
 #include "soc_ecia.h"
 

--- a/soc/microchip/mec/common/soc_misc.c
+++ b/soc/microchip/mec/common/soc_misc.c
@@ -9,7 +9,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/arch/common/sys_bitops.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 
 #include "soc_misc.h"
 

--- a/soc/microchip/mec/common/soc_pcr.c
+++ b/soc/microchip/mec/common/soc_pcr.c
@@ -8,7 +8,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/arch/common/sys_bitops.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 
 #include "soc_pcr.h"
 

--- a/soc/nxp/imx/imx8/adsp/include/adsp/io.h
+++ b/soc/nxp/imx/imx8/adsp/include/adsp/io.h
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <soc/memory.h>
 #include <zephyr/sys/sys_io.h>
-#include <zephyr/arch/common/sys_io.h>
 
 static inline uint32_t io_reg_read(uint32_t reg)
 {

--- a/soc/nxp/imx/imx8m/adsp/include/adsp/io.h
+++ b/soc/nxp/imx/imx8m/adsp/include/adsp/io.h
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <soc/memory.h>
 #include <zephyr/sys/sys_io.h>
-#include <zephyr/arch/common/sys_io.h>
 
 static inline uint32_t io_reg_read(uint32_t reg)
 {

--- a/soc/nxp/imx/imx8ulp/adsp/include/adsp/io.h
+++ b/soc/nxp/imx/imx8ulp/adsp/include/adsp/io.h
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <soc/memory.h>
 #include <zephyr/sys/sys_io.h>
-#include <zephyr/arch/common/sys_io.h>
 
 static inline uint32_t io_reg_read(uint32_t reg)
 {

--- a/soc/nxp/imx/imx8x/adsp/include/adsp/io.h
+++ b/soc/nxp/imx/imx8x/adsp/include/adsp/io.h
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <soc/memory.h>
 #include <zephyr/sys/sys_io.h>
-#include <zephyr/arch/common/sys_io.h>
 
 static inline uint32_t io_reg_read(uint32_t reg)
 {

--- a/soc/nxp/imxrt/imxrt5xx/f1/include/adsp/io.h
+++ b/soc/nxp/imxrt/imxrt5xx/f1/include/adsp/io.h
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <soc/memory.h>
 #include <zephyr/sys/sys_io.h>
-#include <zephyr/arch/common/sys_io.h>
 
 static inline uint32_t io_reg_read(uint32_t reg)
 {

--- a/soc/nxp/imxrt/imxrt6xx/hifi4/include/adsp/io.h
+++ b/soc/nxp/imxrt/imxrt6xx/hifi4/include/adsp/io.h
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <soc/memory.h>
 #include <zephyr/sys/sys_io.h>
-#include <zephyr/arch/common/sys_io.h>
 
 static inline uint32_t io_reg_read(uint32_t reg)
 {

--- a/soc/nxp/imxrt/imxrt7xx/hifi1/include/dsp/io.h
+++ b/soc/nxp/imxrt/imxrt7xx/hifi1/include/dsp/io.h
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <soc/memory.h>
 #include <zephyr/sys/sys_io.h>
-#include <zephyr/arch/common/sys_io.h>
 
 static inline uint32_t io_reg_read(uint32_t reg)
 {

--- a/soc/nxp/imxrt/imxrt7xx/hifi4/include/dsp/io.h
+++ b/soc/nxp/imxrt/imxrt7xx/hifi4/include/dsp/io.h
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <soc/memory.h>
 #include <zephyr/sys/sys_io.h>
-#include <zephyr/arch/common/sys_io.h>
 
 static inline uint32_t io_reg_read(uint32_t reg)
 {

--- a/soc/sensry/ganymed/sy1xx/common/udma.h
+++ b/soc/sensry/ganymed/sy1xx/common/udma.h
@@ -7,7 +7,7 @@
 #define GANYMED_SY1XX_UDMA_H
 
 #include <stdint.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/arch/cpu.h>
 #include <soc.h>
 
 /* UDMA */

--- a/soc/ti/k3/common/peripherals/ctrl_partitions.c
+++ b/soc/ti/k3/common/peripherals/ctrl_partitions.c
@@ -7,7 +7,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/device_mmio.h>
-#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/arch/cpu.h>
 
 #define KICK0_UNLOCK_VAL (0x68EF3490U)
 #define KICK1_UNLOCK_VAL (0xD172BC5AU)


### PR DESCRIPTION
The generic `sys_read64()` and `sys_write64()` implementations use volatile
`uint64_t` accesses. On 32-bit architectures the compiler may split these into
two 32-bit MMIO transactions, and C does not define their order or preserve
their nominal access width.

Add explicit non-atomic helpers for 64-bit registers that support ordered
32-bit accesses:

* `sys_read64_lo_hi()`
* `sys_read64_hi_lo()`
* `sys_write64_lo_hi()`
* `sys_write64_hi_lo()`

Migrate the in-tree 32-bit callers using the transaction order emitted by the
current toolchain. Preserve the explicit AArch32 `sys_read64()` implementation,
which emits `ldrd`, and allow architectures or SoCs to continue providing
native accessors when they define the semantics.

Keep the generic 64-bit accessors available to 32-bit callers, but mark those
implementations deprecated because their MMIO transaction order is undefined.
This preserves source compatibility for out-of-tree callers while guiding them
to an ordered helper. Architecture- or SoC-specific accessors with defined
semantics are not deprecated.

For standard RISC-V accessors, use width-specific inline assembly on RV64 and
retain a deprecated generic fallback on RV32. Custom RISC-V SoCs may continue
to provide 64-bit accessors explicitly without a deprecation warning.

Update the System I/O API documentation, release notes, and migration guide for
out-of-tree callers.

Testing:

* Zephyr SDK 1.0.1 / GCC 14.3.0
* Architecture builds: `qemu_cortex_m3`, `qemu_cortex_a9`, `qemu_cortex_r5`,
  `qemu_xtensa/sample_controller32/mpu`, `qemu_or1k`, `qemu_malta` (LE and BE),
  `qemu_leon3`, `qemu_rx`, `qemu_riscv32`, `qemu_riscv32e`,
  `qemu_riscv32_xip`, `qemu_riscv64`, `litex_vexriscv`, and
  `native_sim/native/64`
* Full `bcm958402m2/bcm58402/m7` build, including the PCI endpoint MSI-X
  driver
* Full `intel_adsp/ace30/ptl` build with DAI and UAOL enabled, including SSP,
  DMIC, timestamp, and UAOL objects
* Full `rzt2h_evb/r9a09g077m44gbg/cr52_0` build
* Accessor probes verified that generic RV32, Cortex-M, and 32-bit POSIX
  callers retain build compatibility and receive deprecation warnings
* Accessor probes with deprecation warnings promoted to errors passed for
  RV64, custom RV32 accessors, and the native AArch32 accessor
* Pre/post objdump verified access widths, word order, and Xtensa `memw`
  barriers
* Helper names, address layout, and transaction order verified against Linux's
  `io-64-nonatomic-{lo-hi,hi-lo}.h`
* Focused `check_compliance.py` suite and full patch checkpatch audit
