### PR TITLE
modem: cellular: on-demand neighbour cells

### DIFF
--- a/drivers/modem/Kconfig.cellular
+++ b/drivers/modem/Kconfig.cellular
@@ -65,6 +65,15 @@ config MODEM_CELLULAR_PERIODIC_SCRIPT_MS
 	default 30000 if DT_HAS_NORDIC_NRF93M1_ENABLED
 	default 2000
 
+config MODEM_CELLULAR_MAX_NEIGHBOR_CELLS
+	int "Maximum number of neighbour cells cached"
+	range 1 255
+	default 6
+	help
+	  Upper bound on the number of neighbour cells retained from a
+	  measurement and returned by cellular_get_neighbor_cells(). Neighbour
+	  cells reported beyond this count are dropped.
+
 config MODEM_CELLULAR_UART_BUFFER_SIZES
 	int "The UART receive and transmit buffer sizes in bytes."
 	default 512

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -239,11 +239,45 @@ void modem_cellular_emit_network_status(struct modem_cellular_data *data,
 	}
 }
 
-static void modem_cellular_invalidate_network_status(struct modem_cellular_data *data)
+static void modem_cellular_invalidate_cell_cache(struct modem_cellular_data *data)
 {
 	k_mutex_lock(&data->api_lock, K_FOREVER);
 	data->network_status_valid = false;
+	data->neighbor_cells_valid = false;
 	k_mutex_unlock(&data->api_lock);
+}
+
+void modem_cellular_add_neighbor_cell(struct modem_cellular_data *data,
+				      const struct cellular_neighbor_cell *cell)
+{
+	/* Stage into a private buffer, never the published cache, so a reader is
+	 * never exposed to a half-parsed measurement. Runs on the modem work queue.
+	 */
+	if (data->neighbor_staging_count >= ARRAY_SIZE(data->neighbor_staging)) {
+		LOG_WRN("neighbour cell staging full (%zu), dropping entry",
+			ARRAY_SIZE(data->neighbor_staging));
+		return;
+	}
+
+	data->neighbor_staging[data->neighbor_staging_count] = *cell;
+	data->neighbor_staging_count++;
+}
+
+void modem_cellular_commit_neighbor_cells(struct modem_cellular_data *data)
+{
+	/* Publish the staged measurement in one locked step, then clear the staging
+	 * buffer so the next measurement starts empty. A measurement that staged no
+	 * cells publishes an empty list, distinct from the -ENODATA no-measurement
+	 * state.
+	 */
+	k_mutex_lock(&data->api_lock, K_FOREVER);
+	memcpy(data->neighbor_cells, data->neighbor_staging,
+	       data->neighbor_staging_count * sizeof(data->neighbor_cells[0]));
+	data->neighbor_cell_count = data->neighbor_staging_count;
+	data->neighbor_cells_valid = true;
+	k_mutex_unlock(&data->api_lock);
+
+	data->neighbor_staging_count = 0;
 }
 
 static void modem_cellular_emit_modem_info(struct modem_cellular_data *data,
@@ -608,15 +642,17 @@ void modem_cellular_chat_on_cxreg(struct modem_chat *chat, char **argv, uint16_t
 		   (modem_cellular_stats_on_reg_transition(data, was_registered,
 							   modem_cellular_is_registered(data))));
 
-	if (modem_cellular_is_registered(data)) {
-		/* Drop any cached serving cell on a registration change; it is stale
-		 * until the next periodic poll, so get_network_status() reports no
-		 * data rather than the previous (deregistered) snapshot.
-		 */
-		if (registration_prev != registration_status) {
-			modem_cellular_invalidate_network_status(data);
-		}
+	/* Drop the cached serving and neighbour cells on any registration change,
+	 * including deregistration; they are stale until the next periodic poll.
+	 * The deregistration branch below re-reports the serving status, while the
+	 * neighbour list stays invalid (get_neighbor_cells() returns -ENODATA) until
+	 * the next scan refreshes it.
+	 */
+	if (registration_prev != registration_status) {
+		modem_cellular_invalidate_cell_cache(data);
+	}
 
+	if (modem_cellular_is_registered(data)) {
 		modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_REGISTERED);
 	} else {
 		modem_cellular_delegate_event(data, MODEM_CELLULAR_EVENT_DEREGISTERED);
@@ -2561,6 +2597,33 @@ static int modem_cellular_get_network_status(const struct device *dev,
 	return ret;
 }
 
+static int modem_cellular_get_neighbor_cells(const struct device *dev,
+					     struct cellular_neighbor_cell *cells, uint8_t *count)
+{
+	struct modem_cellular_data *data = dev->data;
+	int ret = 0;
+
+	if (cells == NULL || count == NULL) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&data->api_lock, K_FOREVER);
+
+	if (!data->neighbor_cells_valid) {
+		ret = -ENODATA;
+	} else if (*count < data->neighbor_cell_count) {
+		*count = data->neighbor_cell_count;
+		ret = -ENOMEM;
+	} else {
+		memcpy(cells, data->neighbor_cells, data->neighbor_cell_count * sizeof(*cells));
+		*count = data->neighbor_cell_count;
+	}
+
+	k_mutex_unlock(&data->api_lock);
+
+	return ret;
+}
+
 static int modem_cellular_set_apn(const struct device *dev, const char *apn)
 {
 	struct modem_cellular_data *data = dev->data;
@@ -2666,6 +2729,7 @@ DEVICE_API(cellular, modem_cellular_api) = {
 	.get_modem_info = modem_cellular_get_modem_info,
 	.get_registration_status = modem_cellular_get_registration_status,
 	.get_network_status = modem_cellular_get_network_status,
+	.get_neighbor_cells = modem_cellular_get_neighbor_cells,
 	.set_apn = modem_cellular_set_apn,
 	.set_callback = modem_cellular_set_callback,
 	IF_ENABLED(CONFIG_MODEM_CELLULAR_STATS, (.get_stats = modem_cellular_get_stats,))

--- a/drivers/modem/vendor_modem_cellular/cellular_quectel_eg25_g.c
+++ b/drivers/modem/vendor_modem_cellular/cellular_quectel_eg25_g.c
@@ -13,11 +13,25 @@
 
 static void quectel_eg25_g_on_qeng(struct modem_chat *chat, char **argv, uint16_t argc,
 				   void *user_data);
+static void quectel_eg25_g_on_qeng_scan_commit(struct modem_chat *chat, char **argv, uint16_t argc,
+					       void *user_data);
 
 MODEM_CELLULAR_COMMON_CHAT_MATCHES();
 
 MODEM_CHAT_MATCHES_DEFINE(quectel_eg25_g_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATCHES,
 			  MODEM_CHAT_MATCH("+QENG: ", ",", quectel_eg25_g_on_qeng));
+
+/*
+ * The neighbourcell report spans several lines terminated by OK, or a bare
+ * ERROR while the modem is not camped (searching / limited service). Both
+ * terminate the step and commit, so the report never aborts the periodic script
+ * and an ERROR while searching publishes an empty list rather than a stale one.
+ * The staging buffer self-clears on commit, so the query is independent of any
+ * other command in the periodic script.
+ */
+MODEM_CHAT_MATCHES_DEFINE(qeng_neighbourcell_match,
+			  MODEM_CHAT_MATCH("OK", "", quectel_eg25_g_on_qeng_scan_commit),
+			  MODEM_CHAT_MATCH("ERROR", "", quectel_eg25_g_on_qeng_scan_commit));
 
 /*
  * AT+CMUX <port_speed> is specified in 3GPP TS 27.007 defining values 1..6 (up to 230400);
@@ -44,6 +58,61 @@ MODEM_CHAT_MATCHES_DEFINE(quectel_eg25_g_unsol, MODEM_CELLULAR_COMMON_UNSOL_MATC
 #else
 #error "CONFIG_MODEM_CELLULAR_NEW_BAUDRATE unsupported for EG25-G CMUX port speed"
 #endif
+
+/*
+ * argv[0] is the "+QENG: " prefix; the comma-separated fields follow, so field N
+ * of the response is argv[N]. The cell-type token at argv[1] selects the report
+ * kind. Non-LTE RATs use a different field layout and are ignored.
+ */
+#define QENG_CELLTYPE_ARGV 1
+
+/*
+ * LTE neighbours are reported as "neighbourcell intra"/"neighbourcell inter"; a
+ * prefix match covers both, plus the bare GSM/WCDMA "neighbourcell" token that
+ * the RAT guard then filters out.
+ */
+#define QENG_NEIGHBOURCELL_PREFIX "\"neighbourcell"
+
+/* RAT token as it appears in argv, i.e. with the QENG surrounding quotes. */
+#define QENG_LTE_RAT_TOKEN "\"LTE\""
+
+/* Placeholder the modem emits for a field it has not measured. */
+#define QENG_UNMEASURED_FIELD "-"
+
+/*
+ * Serving cell (LTE):
+ * +QENG: "servingcell",<state>,"LTE",<is_tdd>,<mcc>,<mnc>,<cellid>,<pcid>,
+ *        <earfcn>,<freq_band_ind>,<ul_bw>,<dl_bw>,<tac>,<rsrp>,<rsrq>,...
+ */
+enum {
+	QENG_LTE_RAT = 3,
+	QENG_LTE_MCC = 5,
+	QENG_LTE_MNC = 6,
+	QENG_LTE_CELLID = 7,
+	QENG_LTE_PCID = 8,
+	QENG_LTE_EARFCN = 9,
+	QENG_LTE_BAND = 10,
+	QENG_LTE_TAC = 13,
+	QENG_LTE_RSRP = 14,
+	QENG_LTE_RSRQ = 15,
+	QENG_LTE_MIN_ARGC = 16,
+};
+
+/*
+ * Neighbour cell (LTE intra/inter):
+ * +QENG: "neighbourcell intra","LTE",<earfcn>,<pcid>,<rsrq>,<rsrp>,<rssi>,...
+ * +QENG: "neighbourcell inter","LTE",<earfcn>,<pcid>,<rsrq>,<rsrp>,<rssi>,...
+ * Both layouts share the leading fields used here (rsrq precedes rsrp, unlike
+ * the serving-cell report).
+ */
+enum {
+	QENG_NBR_LTE_RAT = 2,
+	QENG_NBR_LTE_EARFCN = 3,
+	QENG_NBR_LTE_PCID = 4,
+	QENG_NBR_LTE_RSRQ = 5,
+	QENG_NBR_LTE_RSRP = 6,
+	QENG_NBR_LTE_MIN_ARGC = 7,
+};
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(
 	quectel_eg25_g_init_chat_script_cmds, MODEM_CHAT_SCRIPT_CMD_RESP("ATE0", ok_match),
@@ -98,36 +167,60 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_eg25_g_periodic_chat_script_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG?", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CSQ", csq_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+QENG=\"servingcell\"", ok_match));
+			      MODEM_CHAT_SCRIPT_CMD_RESP_MULT("AT+QENG=\"servingcell\"",
+							      allow_match),
+			      MODEM_CHAT_SCRIPT_CMD_RESP_MULT("AT+QENG=\"neighbourcell\"",
+							      qeng_neighbourcell_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(quectel_eg25_g_periodic_chat_script,
 			 quectel_eg25_g_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
 
-/*
- * Field positions in the LTE serving-cell report:
- * +QENG: "servingcell",<state>,"LTE",<is_tdd>,<mcc>,<mnc>,<cellid>,<pcid>,
- *        <earfcn>,<freq_band_ind>,<ul_bw>,<dl_bw>,<tac>,<rsrp>,<rsrq>,...
- * argv[0] is the "+QENG: " prefix, so field N is argv[N]. Other RATs use a
- * different layout and are ignored (see the RAT guard below).
- */
+static void quectel_eg25_g_parse_neighbourcell(struct modem_cellular_data *data, char **argv,
+					       uint16_t argc)
+{
+	struct cellular_neighbor_cell cell = {0};
 
-/* RAT token as it appears in argv, i.e. with the QENG surrounding quotes. */
-#define QENG_LTE_RAT_TOKEN "\"LTE\""
+	/*
+	 * Only LTE neighbours carry these fields; GSM/WCDMA neighbours reported
+	 * while camped on LTE use a different layout.
+	 */
+	if (argc < QENG_NBR_LTE_MIN_ARGC ||
+	    strcmp(argv[QENG_NBR_LTE_RAT], QENG_LTE_RAT_TOKEN) != 0) {
+		return;
+	}
 
-enum {
-	QENG_LTE_RAT = 3,
-	QENG_LTE_MCC = 5,
-	QENG_LTE_MNC = 6,
-	QENG_LTE_CELLID = 7,
-	QENG_LTE_PCID = 8,
-	QENG_LTE_EARFCN = 9,
-	QENG_LTE_BAND = 10,
-	QENG_LTE_TAC = 13,
-	QENG_LTE_RSRP = 14,
-	QENG_LTE_RSRQ = 15,
-	QENG_LTE_MIN_ARGC = 16,
-};
+	/*
+	 * Inter-frequency rows list a frequency even when no cell was found on it,
+	 * leaving "-" placeholders for the identity and measurement fields. Drop
+	 * those so the list holds only measured neighbours, not empty candidates.
+	 */
+	if (strcmp(argv[QENG_NBR_LTE_PCID], QENG_UNMEASURED_FIELD) == 0 ||
+	    strcmp(argv[QENG_NBR_LTE_RSRP], QENG_UNMEASURED_FIELD) == 0 ||
+	    strcmp(argv[QENG_NBR_LTE_RSRQ], QENG_UNMEASURED_FIELD) == 0) {
+		return;
+	}
+
+	/* All neighbour fields are decimal and unquoted. */
+	cell.cell.lte.earfcn = (uint32_t)strtoul(argv[QENG_NBR_LTE_EARFCN], NULL, 10);
+	cell.cell.lte.phys_cell_id = (uint16_t)strtoul(argv[QENG_NBR_LTE_PCID], NULL, 10);
+	cell.cell.lte.rsrq = (int8_t)strtol(argv[QENG_NBR_LTE_RSRQ], NULL, 10);
+	cell.cell.lte.rsrp = (int16_t)strtol(argv[QENG_NBR_LTE_RSRP], NULL, 10);
+
+	/*
+	 * The intra-frequency report echoes the camped cell as a row. PCI is
+	 * unique per EARFCN, so a row matching the serving (EARFCN, PCI) is the
+	 * serving cell, not a neighbour; drop it. The periodic script polls
+	 * servingcell before neighbourcell, so the cached value is current here.
+	 */
+	if (data->network_status_valid &&
+	    cell.cell.lte.earfcn == data->network_status.cell.lte.earfcn &&
+	    cell.cell.lte.phys_cell_id == data->network_status.cell.lte.phys_cell_id) {
+		return;
+	}
+
+	modem_cellular_add_neighbor_cell(data, &cell);
+}
 
 static void quectel_eg25_g_on_qeng(struct modem_chat *chat, char **argv, uint16_t argc,
 				   void *user_data)
@@ -137,6 +230,17 @@ static void quectel_eg25_g_on_qeng(struct modem_chat *chat, char **argv, uint16_
 		.status = data->registration_status_lte,
 		.access_tech = data->access_tech,
 	};
+
+	/*
+	 * Neighbour cell reports share the "+QENG: " prefix but carry their own
+	 * field layout; handle them separately from the serving-cell report below.
+	 */
+	if (argc > QENG_CELLTYPE_ARGV &&
+	    strncmp(argv[QENG_CELLTYPE_ARGV], QENG_NEIGHBOURCELL_PREFIX,
+		    strlen(QENG_NEIGHBOURCELL_PREFIX)) == 0) {
+		quectel_eg25_g_parse_neighbourcell(data, argv, argc);
+		return;
+	}
 
 	/*
 	 * Only the LTE report carries the fields below; a shorter line (state
@@ -158,6 +262,12 @@ static void quectel_eg25_g_on_qeng(struct modem_chat *chat, char **argv, uint16_
 	evt.cell.lte.rsrq = (int8_t)strtol(argv[QENG_LTE_RSRQ], NULL, 10);
 
 	modem_cellular_emit_network_status(data, &evt);
+}
+
+static void quectel_eg25_g_on_qeng_scan_commit(struct modem_chat *chat, char **argv, uint16_t argc,
+					       void *user_data)
+{
+	modem_cellular_commit_neighbor_cells((struct modem_cellular_data *)user_data);
 }
 
 static const struct modem_cellular_vendor_config quectel_eg25_g_vendor = {

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -192,6 +192,22 @@ struct cellular_evt_network_status {
 };
 
 /**
+ * @brief Neighbour cell measurement.
+ *
+ * One entry of the list returned by @ref cellular_get_neighbor_cells.
+ */
+struct cellular_neighbor_cell {
+	union {
+		struct {
+			uint32_t earfcn; /**< E-UTRAN assigned radio channel */
+			uint16_t phys_cell_id; /**< Physical cell ID */
+			int16_t rsrp; /**< Received signal power (dBm) */
+			int8_t rsrq; /**< Received signal quality (dB) */
+		} lte; /**< LTE neighbour cell information */
+	} cell; /**< Generic neighbour cell information */
+};
+
+/**
  * @brief Cellular link operational statistics.
  *
  * Counters are cumulative since boot.
@@ -262,6 +278,11 @@ typedef int (*cellular_api_get_registration_status)(const struct device *dev,
 typedef int (*cellular_api_get_network_status)(const struct device *dev,
 					       struct cellular_evt_network_status *status);
 
+/** API for getting neighbour cells */
+typedef int (*cellular_api_get_neighbor_cells)(const struct device *dev,
+					       struct cellular_neighbor_cell *cells,
+					       uint8_t *count);
+
 /** API for programming APN */
 typedef int (*cellular_api_set_apn)(const struct device *dev, const char *apn);
 
@@ -288,6 +309,8 @@ __subsystem struct cellular_driver_api {
 	cellular_api_get_registration_status get_registration_status;
 	/** @driver_ops_optional @copybrief cellular_get_network_status */
 	cellular_api_get_network_status get_network_status;
+	/** @driver_ops_optional @copybrief cellular_get_neighbor_cells */
+	cellular_api_get_neighbor_cells get_neighbor_cells;
 	/** @driver_ops_optional @copybrief cellular_set_apn */
 	cellular_api_set_apn set_apn;
 	/** @driver_ops_optional @copybrief cellular_set_callback */
@@ -450,6 +473,35 @@ static inline int cellular_get_network_status(const struct device *dev,
 	}
 
 	return api->get_network_status(dev, status);
+}
+
+/**
+ * @brief Get the last reported neighbour cells
+ *
+ * @details Returns the most recent neighbour cell list the driver has observed.
+ * It does not trigger a fresh measurement.
+ *
+ * @param dev Cellular network device instance
+ * @param cells Destination array for the neighbour cell snapshots
+ * @param count In: capacity of @p cells. Out: number of entries written, or the
+ * number available when the buffer is too small.
+ *
+ * @return 0 on success, negative errno value on failure.
+ * @retval -ENOSYS API is not supported by cellular network device.
+ * @retval -ENODATA No neighbour cells reported yet (before the first
+ * measurement, or after a registration change until the next poll refreshes it).
+ * @retval -ENOMEM @p cells too small; @p count is set to the number available.
+ */
+static inline int cellular_get_neighbor_cells(const struct device *dev,
+					      struct cellular_neighbor_cell *cells, uint8_t *count)
+{
+	const struct cellular_driver_api *api = DEVICE_API_GET(cellular, dev);
+
+	if (api->get_neighbor_cells == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_neighbor_cells(dev, cells, count);
 }
 
 /**

--- a/include/zephyr/drivers/modem/modem_cellular.h
+++ b/include/zephyr/drivers/modem/modem_cellular.h
@@ -158,6 +158,11 @@ struct modem_cellular_data {
 	uint8_t rsrq;
 	struct cellular_evt_network_status network_status;
 	bool network_status_valid;
+	struct cellular_neighbor_cell neighbor_cells[CONFIG_MODEM_CELLULAR_MAX_NEIGHBOR_CELLS];
+	uint8_t neighbor_cell_count;
+	bool neighbor_cells_valid;
+	struct cellular_neighbor_cell neighbor_staging[CONFIG_MODEM_CELLULAR_MAX_NEIGHBOR_CELLS];
+	uint8_t neighbor_staging_count;
 	uint8_t imei[MODEM_CELLULAR_DATA_IMEI_LEN];
 	uint8_t model_id[MODEM_CELLULAR_DATA_MODEL_ID_LEN];
 	uint8_t imsi[MODEM_CELLULAR_DATA_IMSI_LEN];
@@ -342,6 +347,17 @@ void modem_cellular_emit_event(struct modem_cellular_data *data, enum cellular_e
  */
 void modem_cellular_emit_network_status(struct modem_cellular_data *data,
 					const struct cellular_evt_network_status *status);
+
+/*
+ * Accumulate a neighbour cell measurement across the per-line parse of one poll:
+ * add stages a cell (dropping the excess when the staging buffer is full), commit
+ * publishes the staged list to get_neighbor_cells() readers and clears the buffer
+ * for the next measurement. A measurement that stages nothing publishes an empty
+ * list, so the pair needs no external "scan start" signal.
+ */
+void modem_cellular_add_neighbor_cell(struct modem_cellular_data *data,
+				      const struct cellular_neighbor_cell *cell);
+void modem_cellular_commit_neighbor_cells(struct modem_cellular_data *data);
 
 void modem_cellular_chat_on_imei(struct modem_chat *chat, char **argv, uint16_t argc,
 				 void *user_data);

--- a/tests/drivers/modem/cellular_network_status/src/main.c
+++ b/tests/drivers/modem/cellular_network_status/src/main.c
@@ -48,6 +48,19 @@ static struct cellular_evt_network_status make_lte(uint32_t gci, int16_t rsrp)
 	return status;
 }
 
+static struct cellular_neighbor_cell make_neighbor(uint32_t earfcn, uint16_t pci, int16_t rsrp,
+						   int8_t rsrq)
+{
+	struct cellular_neighbor_cell cell = {0};
+
+	cell.cell.lte.earfcn = earfcn;
+	cell.cell.lte.phys_cell_id = pci;
+	cell.cell.lte.rsrp = rsrp;
+	cell.cell.lte.rsrq = rsrq;
+
+	return cell;
+}
+
 /* modem_cellular_emit_network_status() must raise the event on the first report
  * and on any changed field, but suppress a report identical to the last one.
  */
@@ -106,6 +119,150 @@ ZTEST(cellular_network_status, test_getter_states)
 	data.network_status_valid = false;
 	zassert_equal(cellular_get_network_status(&dev, &out), -ENODATA,
 		      "getter must report no data after invalidation");
+}
+
+/* The accumulator publishes the neighbour list only on commit; the getter must
+ * report -ENODATA while a scan is in progress and the full list afterwards.
+ */
+ZTEST(cellular_network_status, test_neighbor_accumulate_and_get)
+{
+	struct modem_cellular_data data;
+	const struct device dev = {
+		.data = &data,
+		.api = &modem_cellular_api,
+	};
+	struct cellular_neighbor_cell a = make_neighbor(100, 10, -90, -10);
+	struct cellular_neighbor_cell b = make_neighbor(200, 20, -95, -12);
+	struct cellular_neighbor_cell out[4];
+	uint8_t count;
+
+	init_data(&data);
+
+	count = ARRAY_SIZE(out);
+	zassert_equal(cellular_get_neighbor_cells(&dev, out, &count), -ENODATA,
+		      "getter must report no data before the first scan");
+
+	modem_cellular_add_neighbor_cell(&data, &a);
+
+	count = ARRAY_SIZE(out);
+	zassert_equal(cellular_get_neighbor_cells(&dev, out, &count), -ENODATA,
+		      "staged cells must not be visible before commit");
+
+	modem_cellular_add_neighbor_cell(&data, &b);
+	modem_cellular_commit_neighbor_cells(&data);
+
+	count = ARRAY_SIZE(out);
+	zassert_ok(cellular_get_neighbor_cells(&dev, out, &count));
+	zassert_equal(count, 2, "both neighbours must be returned");
+	zassert_equal(out[0].cell.lte.earfcn, 100);
+	zassert_equal(out[1].cell.lte.phys_cell_id, 20);
+	zassert_equal(out[1].cell.lte.rsrp, -95);
+}
+
+/* A completed scan with no LTE neighbours is valid, distinct from -ENODATA. */
+ZTEST(cellular_network_status, test_neighbor_empty_scan)
+{
+	struct modem_cellular_data data;
+	const struct device dev = {
+		.data = &data,
+		.api = &modem_cellular_api,
+	};
+	struct cellular_neighbor_cell out[4];
+	uint8_t count;
+
+	init_data(&data);
+
+	modem_cellular_commit_neighbor_cells(&data);
+
+	count = ARRAY_SIZE(out);
+	zassert_ok(cellular_get_neighbor_cells(&dev, out, &count),
+		   "a completed scan with no neighbours must succeed");
+	zassert_equal(count, 0, "no neighbours reported");
+}
+
+/* A caller buffer smaller than the cached list is rejected, and count reports
+ * the number available so the caller can size a second call.
+ */
+ZTEST(cellular_network_status, test_neighbor_buffer_too_small)
+{
+	struct modem_cellular_data data;
+	const struct device dev = {
+		.data = &data,
+		.api = &modem_cellular_api,
+	};
+	struct cellular_neighbor_cell a = make_neighbor(100, 10, -90, -10);
+	struct cellular_neighbor_cell b = make_neighbor(200, 20, -95, -12);
+	struct cellular_neighbor_cell out[1];
+	uint8_t count;
+
+	init_data(&data);
+
+	modem_cellular_add_neighbor_cell(&data, &a);
+	modem_cellular_add_neighbor_cell(&data, &b);
+	modem_cellular_commit_neighbor_cells(&data);
+
+	count = ARRAY_SIZE(out);
+	zassert_equal(cellular_get_neighbor_cells(&dev, out, &count), -ENOMEM,
+		      "a too-small buffer must be rejected");
+	zassert_equal(count, 2, "count must report the number available");
+}
+
+/* Neighbours reported beyond the staging cap are dropped, not overflowed. */
+ZTEST(cellular_network_status, test_neighbor_overflow_dropped)
+{
+	struct modem_cellular_data data;
+	const struct device dev = {
+		.data = &data,
+		.api = &modem_cellular_api,
+	};
+	struct cellular_neighbor_cell c;
+	struct cellular_neighbor_cell out[CONFIG_MODEM_CELLULAR_MAX_NEIGHBOR_CELLS + 4];
+	uint8_t count;
+	int i;
+
+	init_data(&data);
+
+	for (i = 0; i < CONFIG_MODEM_CELLULAR_MAX_NEIGHBOR_CELLS + 2; i++) {
+		c = make_neighbor(i, i, -80, -8);
+		modem_cellular_add_neighbor_cell(&data, &c);
+	}
+	modem_cellular_commit_neighbor_cells(&data);
+
+	count = ARRAY_SIZE(out);
+	zassert_ok(cellular_get_neighbor_cells(&dev, out, &count));
+	zassert_equal(count, CONFIG_MODEM_CELLULAR_MAX_NEIGHBOR_CELLS,
+		      "excess neighbours beyond the cap must be dropped");
+}
+
+/* Each commit fully replaces the previous list; the staging buffer self-clears,
+ * so a later, shorter scan does not leak stale neighbours from an earlier one.
+ */
+ZTEST(cellular_network_status, test_neighbor_rescan_replaces)
+{
+	struct modem_cellular_data data;
+	const struct device dev = {
+		.data = &data,
+		.api = &modem_cellular_api,
+	};
+	struct cellular_neighbor_cell a = make_neighbor(100, 10, -90, -10);
+	struct cellular_neighbor_cell b = make_neighbor(200, 20, -95, -12);
+	struct cellular_neighbor_cell c = make_neighbor(300, 30, -85, -9);
+	struct cellular_neighbor_cell out[4];
+	uint8_t count;
+
+	init_data(&data);
+
+	modem_cellular_add_neighbor_cell(&data, &a);
+	modem_cellular_add_neighbor_cell(&data, &b);
+	modem_cellular_commit_neighbor_cells(&data);
+
+	modem_cellular_add_neighbor_cell(&data, &c);
+	modem_cellular_commit_neighbor_cells(&data);
+
+	count = ARRAY_SIZE(out);
+	zassert_ok(cellular_get_neighbor_cells(&dev, out, &count));
+	zassert_equal(count, 1, "second scan must replace, not append to, the first");
+	zassert_equal(out[0].cell.lte.earfcn, 300);
 }
 
 ZTEST_SUITE(cellular_network_status, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Today the cellular API can report the serving cell on demand, but offers no view of the neighbouring cells the modem measures around it.

This adds a `get_neighbor_cells` driver operation and `cellular_get_neighbor_cells()`, in the same shape as the existing get_* accessors, returning the neighbour cells the driver saw on its most recent measurement: their EARFCN, physical cell ID and RSRP/RSRQ. The driver keeps this list refreshed alongside the serving cell it already tracks.

The Quectel EG25-G drives the feature end to end, decoding its AT+QENG="neighbourcell" report into the list so there is a real in-tree user.
