### PR TITLE
drivers: dai: intel: ssp: Fix aux data size check for DMA transmission

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -1857,6 +1857,7 @@ static int dai_ssp_check_aux_data(struct ssp_intel_aux_tlv *aux_tlv, int aux_len
 	case SSP_DMA_TRANSMISSION_START:
 	case SSP_DMA_TRANSMISSION_STOP:
 		size = sizeof(struct ssp_intel_tr_ctl);
+		break;
 	case SSP_DMA_ALWAYS_RUNNING_MODE:
 		size = sizeof(struct ssp_intel_run_ctl);
 		break;


### PR DESCRIPTION
The SSP_DMA_TRANSMISSION_START/STOP case fell through into SSP_DMA_ALWAYS_RUNNING_MODE, overwriting the expected size with sizeof(struct ssp_intel_run_ctl) (4 bytes) instead of sizeof(struct ssp_intel_tr_ctl) (24 bytes). A well-formed transmission control TLV then failed the size != aux_tlv->size check and aborted the whole config parse. Add the missing break.