### PR TITLE
drivers: clock_monitor: Add set_source syscall verifier

### DIFF
--- a/drivers/clock_monitor/clock_monitor_handlers.c
+++ b/drivers/clock_monitor/clock_monitor_handlers.c
@@ -42,3 +42,11 @@ static inline int z_vrfy_clock_monitor_get_rate(const struct device *dev,
 	return z_impl_clock_monitor_get_rate(dev, rate_hz);
 }
 #include <zephyr/syscalls/clock_monitor_get_rate_mrsh.c>
+
+static inline int z_vrfy_clock_monitor_set_source(const struct device *dev, uint32_t reference,
+						  uint32_t target)
+{
+	K_OOPS(K_SYSCALL_DRIVER_CLOCK_MONITOR(dev, set_source));
+	return z_impl_clock_monitor_set_source(dev, reference, target);
+}
+#include <zephyr/syscalls/clock_monitor_set_source_mrsh.c>


### PR DESCRIPTION
clock_monitor_set_source() is declared as a syscall and has a z_impl_ implementation, but clock_monitor_handlers.c never provided the matching z_vrfy_ shim (and its _mrsh.c include) like the other four syscalls do. With CONFIG_USERSPACE=y the generated syscall table falls back to the unimplemented-syscall handler, so a user mode caller of clock_monitor_set_source() faults instead of being dispatched.

Add the verifier mirroring the other optional op (get_rate): check the device via K_SYSCALL_DRIVER_CLOCK_MONITOR() and forward the two scalar cookies to z_impl_clock_monitor_set_source().