### PR TITLE
drivers: reset: mchp_mss: Fix bit index in reset_status()

### DIFF
--- a/drivers/reset/reset_mchp_mss.c
+++ b/drivers/reset/reset_mchp_mss.c
@@ -29,7 +29,7 @@ static int reset_mss_status(const struct device *dev, uint32_t id, uint8_t *stat
 
 	/* Device is in reset if the clock is turned off or held in soft reset */
 	*status = sys_test_bit(config->base + SUBBLK_CLOCK_CR_OFFSET, RESET_MSS_REG_BIT(id)) == 0 ||
-		  sys_test_bit(config->base + SOFT_RESET_CR_OFFSET, RESET_MSS_REG_BIT(id) != 0);
+		  sys_test_bit(config->base + SOFT_RESET_CR_OFFSET, RESET_MSS_REG_BIT(id)) != 0;
 
 	return 0;
 }

--- a/drivers/reset/reset_mchp_mss.c
+++ b/drivers/reset/reset_mchp_mss.c
@@ -28,8 +28,9 @@ static int reset_mss_status(const struct device *dev, uint32_t id, uint8_t *stat
 	const struct reset_mss_config *config = dev->config;
 
 	/* Device is in reset if the clock is turned off or held in soft reset */
-	*status = sys_test_bit(config->base + SUBBLK_CLOCK_CR_OFFSET, RESET_MSS_REG_BIT(id)) == 0 ||
-		  sys_test_bit(config->base + SOFT_RESET_CR_OFFSET, RESET_MSS_REG_BIT(id) != 0);
+	*status =
+		(sys_test_bit(config->base + SUBBLK_CLOCK_CR_OFFSET, RESET_MSS_REG_BIT(id)) == 0) ||
+		(sys_test_bit(config->base + SOFT_RESET_CR_OFFSET, RESET_MSS_REG_BIT(id)) != 0);
 
 	return 0;
 }


### PR DESCRIPTION
The soft-reset half of reset_status() placed the "!= 0" comparison inside the sys_test_bit() call, so it was evaluated as the bit index argument instead of testing the returned bit. For any reset line whose bit index is >= 2 this read the wrong bit of SOFT_RESET_CR and misreported the reset state.