### PR TITLE
drivers: auxdisplay: jhd1313: Report settable backlight maximum

### DIFF
--- a/drivers/auxdisplay/auxdisplay_jhd1313.c
+++ b/drivers/auxdisplay/auxdisplay_jhd1313.c
@@ -357,7 +357,7 @@ static DEVICE_API(auxdisplay, auxdisplay_jhd1313_auxdisplay_api) = {
 				.brightness.minimum = AUXDISPLAY_LIGHT_NOT_SUPPORTED,              \
 				.brightness.maximum = AUXDISPLAY_LIGHT_NOT_SUPPORTED,              \
 				.backlight.minimum = 0,                                            \
-				.backlight.maximum = ARRAY_SIZE(colour_define),                    \
+				.backlight.maximum = ARRAY_SIZE(colour_define) - 1,                \
 				.custom_characters = 0,                                            \
 			},                                                                         \
 		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \


### PR DESCRIPTION
backlight_set() rejects a colour index >= ARRAY_SIZE(colour_define), so the largest valid index is ARRAY_SIZE - 1, but capabilities reported backlight.maximum = ARRAY_SIZE(colour_define). A client that selected the advertised maximum got -EINVAL. Report ARRAY_SIZE - 1.