### PR TITLE
boards: nxp: lpcxpresso55s69: use mapped partitions

### DIFF
--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
@@ -115,32 +115,37 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
 		};
 
 		slot0_partition: partition@8000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x00008000 DT_SIZE_K(160)>;
 		};
 
 		slot0_ns_partition: partition@30000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-nonsecure";
 			reg = <0x00030000 DT_SIZE_K(96)>;
 		};
 
 		slot1_partition: partition@48000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1";
 			reg = <0x00048000 DT_SIZE_K(160)>;
 		};
 
 		slot1_ns_partition: partition@70000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-1-nonsecure";
 			reg = <0x00070000 DT_SIZE_K(96)>;
 		};
@@ -150,6 +155,7 @@
 		 * 0x949FF is reserved for the application.
 		 */
 		storage_partition: partition@88000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x00088000 DT_SIZE_K(50)>;
 		};

--- a/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x.dtsi
+++ b/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x.dtsi
@@ -10,6 +10,12 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
+#define LPC55S6X_IAP_BASE 50034000
+#define LPC55S6X_FLASH_BASE 10000000
+#define LPC55S6X_FLASH_RESERVED_BASE 1009d800
+#define LPC55S6X_UUID_BASE 1009fc70
+#define LPC55S6X_BOOT_ROM_BASE 13000000
+
 / {
 	soc {
 		sram: sram@14000000 {
@@ -18,15 +24,17 @@
 
 		peripheral: peripheral@50000000 {
 			ranges = <0x0 0x50000000 0x10000000>;
-
-			iap: flash-controller@34000 {
-				ranges = <0x0 0x10000000 0x3020000>;
-			};
 		};
 	};
 };
 
 #include "nxp_lpc55S6x_common.dtsi"
+
+#undef LPC55S6X_IAP_BASE
+#undef LPC55S6X_FLASH_BASE
+#undef LPC55S6X_FLASH_RESERVED_BASE
+#undef LPC55S6X_UUID_BASE
+#undef LPC55S6X_BOOT_ROM_BASE
 
 /*
  * Explicitly enable IAP after we include the common LPC55S6X dtsi file,

--- a/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x.dtsi
+++ b/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x.dtsi
@@ -10,12 +10,6 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
-#define LPC55S6X_IAP_BASE 50034000
-#define LPC55S6X_FLASH_BASE 10000000
-#define LPC55S6X_FLASH_RESERVED_BASE 1009d800
-#define LPC55S6X_UUID_BASE 1009fc70
-#define LPC55S6X_BOOT_ROM_BASE 13000000
-
 / {
 	soc {
 		sram: sram@14000000 {
@@ -23,18 +17,13 @@
 		};
 
 		peripheral: peripheral@50000000 {
-			ranges = <0x0 0x50000000 0x10000000>;
+			ranges = <0x0 0x50000000 0x10000000>,
+				 <0x10000000 0x10000000 0x3020000>;
 		};
 	};
 };
 
 #include "nxp_lpc55S6x_common.dtsi"
-
-#undef LPC55S6X_IAP_BASE
-#undef LPC55S6X_FLASH_BASE
-#undef LPC55S6X_FLASH_RESERVED_BASE
-#undef LPC55S6X_UUID_BASE
-#undef LPC55S6X_BOOT_ROM_BASE
 
 /*
  * Explicitly enable IAP after we include the common LPC55S6X dtsi file,

--- a/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x_common.dtsi
@@ -25,6 +25,43 @@
 		zephyr,flash-controller = &iap;
 	};
 
+	soc {
+		iap: flash-controller@LPC55S6X_IAP_BASE {
+			compatible = "nxp,iap-fmc55";
+			reg = <DT_ADDR(LPC55S6X_IAP_BASE) 0x1000>;
+			ranges;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			status = "disabled";
+
+			flash0: flash@LPC55S6X_FLASH_BASE {
+				compatible = "soc-nv-flash";
+				reg = <DT_ADDR(LPC55S6X_FLASH_BASE) DT_SIZE_K(630)>;
+				ranges = <0x0 DT_ADDR(LPC55S6X_FLASH_BASE) DT_SIZE_K(630)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				erase-block-size = <512>;
+				write-block-size = <512>;
+			};
+
+			flash_reserved: flash@LPC55S6X_FLASH_RESERVED_BASE {
+				compatible = "soc-nv-flash";
+				reg = <DT_ADDR(LPC55S6X_FLASH_RESERVED_BASE) DT_SIZE_K(9)>;
+				status = "disabled";
+			};
+
+			uuid: flash@LPC55S6X_UUID_BASE {
+				compatible = "nxp,lpc-uid";
+				reg = <DT_ADDR(LPC55S6X_UUID_BASE) 0x10>;
+			};
+
+			boot_rom: flash@LPC55S6X_BOOT_ROM_BASE {
+				compatible = "soc-nv-flash";
+				reg = <DT_ADDR(LPC55S6X_BOOT_ROM_BASE) DT_SIZE_K(128)>;
+			};
+		};
+	};
+
 	cpus: cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -126,37 +163,6 @@
 		reset: reset {
 			compatible = "nxp,lpc-syscon-reset";
 			#reset-cells = <1>;
-		};
-	};
-
-	iap: flash-controller@34000 {
-		compatible = "nxp,iap-fmc55";
-		reg = <0x34000 0x1000>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-		status = "disabled";
-
-		flash0: flash@0 {
-			compatible = "soc-nv-flash";
-			reg = <0x0 DT_SIZE_K(630)>;
-			erase-block-size = <512>;
-			write-block-size = <512>;
-		};
-
-		flash_reserved: flash@9d800 {
-			compatible = "soc-nv-flash";
-			reg = <0x9d800 DT_SIZE_K(9)>;
-			status = "disabled";
-		};
-
-		uuid: flash@9fc70 {
-			compatible = "nxp,lpc-uid";
-			reg = <0x9fc70 0x10>;
-		};
-
-		boot_rom: flash@3000000 {
-			compatible = "soc-nv-flash";
-			reg = <0x3000000 DT_SIZE_K(128)>;
 		};
 	};
 

--- a/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x_common.dtsi
@@ -25,43 +25,6 @@
 		zephyr,flash-controller = &iap;
 	};
 
-	soc {
-		iap: flash-controller@LPC55S6X_IAP_BASE {
-			compatible = "nxp,iap-fmc55";
-			reg = <DT_ADDR(LPC55S6X_IAP_BASE) 0x1000>;
-			ranges;
-			#address-cells = <1>;
-			#size-cells = <1>;
-			status = "disabled";
-
-			flash0: flash@LPC55S6X_FLASH_BASE {
-				compatible = "soc-nv-flash";
-				reg = <DT_ADDR(LPC55S6X_FLASH_BASE) DT_SIZE_K(630)>;
-				ranges = <0x0 DT_ADDR(LPC55S6X_FLASH_BASE) DT_SIZE_K(630)>;
-				#address-cells = <1>;
-				#size-cells = <1>;
-				erase-block-size = <512>;
-				write-block-size = <512>;
-			};
-
-			flash_reserved: flash@LPC55S6X_FLASH_RESERVED_BASE {
-				compatible = "soc-nv-flash";
-				reg = <DT_ADDR(LPC55S6X_FLASH_RESERVED_BASE) DT_SIZE_K(9)>;
-				status = "disabled";
-			};
-
-			uuid: flash@LPC55S6X_UUID_BASE {
-				compatible = "nxp,lpc-uid";
-				reg = <DT_ADDR(LPC55S6X_UUID_BASE) 0x10>;
-			};
-
-			boot_rom: flash@LPC55S6X_BOOT_ROM_BASE {
-				compatible = "soc-nv-flash";
-				reg = <DT_ADDR(LPC55S6X_BOOT_ROM_BASE) DT_SIZE_K(128)>;
-			};
-		};
-	};
-
 	cpus: cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -142,6 +105,41 @@
 &peripheral {
 	#address-cells = <1>;
 	#size-cells = <1>;
+
+	iap: flash-controller@34000 {
+		compatible = "nxp,iap-fmc55";
+		reg = <0x34000 0x1000>;
+		ranges = <0x0 0x10000000 0x3020000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		status = "disabled";
+
+		flash0: flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_K(630)>;
+			ranges = <0x0 0x0 DT_SIZE_K(630)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			erase-block-size = <512>;
+			write-block-size = <512>;
+		};
+
+		flash_reserved: flash@9d800 {
+			compatible = "soc-nv-flash";
+			reg = <0x9d800 DT_SIZE_K(9)>;
+			status = "disabled";
+		};
+
+		uuid: flash@9fc70 {
+			compatible = "nxp,lpc-uid";
+			reg = <0x9fc70 0x10>;
+		};
+
+		boot_rom: flash@3000000 {
+			compatible = "soc-nv-flash";
+			reg = <0x3000000 DT_SIZE_K(128)>;
+		};
+	};
 
 	pmc: pmc@20000 {
 		compatible = "nxp,lpc-pmc-hwinfo";

--- a/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x_ns.dtsi
+++ b/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x_ns.dtsi
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define LPC55S6X_IAP_BASE 40034000
+#define LPC55S6X_FLASH_BASE 0
+#define LPC55S6X_FLASH_RESERVED_BASE 9d800
+#define LPC55S6X_UUID_BASE 9fc70
+#define LPC55S6X_BOOT_ROM_BASE 3000000
+
 / {
 	soc {
 		sram: sram@4000000 {
@@ -17,3 +23,9 @@
 };
 
 #include "nxp_lpc55S6x_common.dtsi"
+
+#undef LPC55S6X_IAP_BASE
+#undef LPC55S6X_FLASH_BASE
+#undef LPC55S6X_FLASH_RESERVED_BASE
+#undef LPC55S6X_UUID_BASE
+#undef LPC55S6X_BOOT_ROM_BASE

--- a/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x_ns.dtsi
+++ b/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x_ns.dtsi
@@ -11,6 +11,10 @@
 		};
 
 		peripheral: peripheral@40000000 {
+			/*
+			 * Map the IAP flash window to the non-secure flash alias at 0x0.
+			 * This only translates addresses; TrustZone attribution is unchanged.
+			 */
 			ranges = <0x0 0x40000000 0x10000000>,
 				 <0x10000000 0x0 0x3020000>;
 		};

--- a/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x_ns.dtsi
+++ b/dts/arm/nxp/lpc/lpc55xxx/nxp_lpc55S6x_ns.dtsi
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LPC55S6X_IAP_BASE 40034000
-#define LPC55S6X_FLASH_BASE 0
-#define LPC55S6X_FLASH_RESERVED_BASE 9d800
-#define LPC55S6X_UUID_BASE 9fc70
-#define LPC55S6X_BOOT_ROM_BASE 3000000
-
 / {
 	soc {
 		sram: sram@4000000 {
@@ -17,15 +11,10 @@
 		};
 
 		peripheral: peripheral@40000000 {
-			ranges = <0x0 0x40000000 0x10000000>;
+			ranges = <0x0 0x40000000 0x10000000>,
+				 <0x10000000 0x0 0x3020000>;
 		};
 	};
 };
 
 #include "nxp_lpc55S6x_common.dtsi"
-
-#undef LPC55S6X_IAP_BASE
-#undef LPC55S6X_FLASH_BASE
-#undef LPC55S6X_FLASH_RESERVED_BASE
-#undef LPC55S6X_UUID_BASE
-#undef LPC55S6X_BOOT_ROM_BASE

--- a/dts/arm/nxp/lpc/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S6x_common.dtsi
@@ -133,6 +133,9 @@
 		flash0: flash@0 {
 			compatible = "soc-nv-flash";
 			reg = <0x0 DT_SIZE_K(630)>;
+			ranges = <0x0 0x0 DT_SIZE_K(630)>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			erase-block-size = <512>;
 			write-block-size = <512>;
 		};


### PR DESCRIPTION
Convert the LPCXpresso55S69 internal flash layout from fixed-partitions to zephyr,mapped-partition and add the required ranges properties.

The existing Kconfig overrides for CPU1 and the TF-M layouts remain unchanged. This addresses the LPCXpresso55S69 entry in #107737.

Tested:
- scripts/checkpatch.pl --git HEAD~1..HEAD
- west build -b lpcxpresso55s69/lpc55s69/cpu0 samples/hello_world
- west build -b lpcxpresso55s69/lpc55s69/cpu1 samples/hello_world
- west build -b lpcxpresso55s69/lpc55s69/cpu0 samples/hello_world -- -DCONFIG_BOOTLOADER_MCUBOOT=y
- west build -b lpcxpresso55s69/lpc55s69/cpu0/ns samples/hello_world
- west build -b lpcxpresso55s69/lpc55s69/cpu0/ns samples/hello_world -- -DCONFIG_TFM_BL2=n
- Confirmed byte-identical application binaries against the parent commit for all five configurations
- Flashed CPU0 hello_world with LPC-Link2/pyOCD, reset through the probe, and verified the UART boot banner and Hello World output