### PR TITLE
drivers: i2c: infineon_pdl: fix stale data on write-read NACK

### DIFF
--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -230,11 +230,30 @@ static void ifx_cat1_i2c_event_handler(void *callback_arg, uint32_t event)
 {
 	const struct device *dev = (const struct device *)callback_arg;
 	struct ifx_cat1_i2c_data *data = dev->data;
+	const struct ifx_cat1_i2c_config *const config = dev->config;
 
 	if (((CY_SCB_I2C_MASTER_ERR_EVENT | CY_SCB_I2C_SLAVE_ERR_EVENT) & event) != 0) {
 		(void)_i2c_abort_async(dev);
+		/*
+		 * Abort does not confirm the master went idle when it times out,
+		 * so clear the async state unconditionally. This stops the
+		 * interrupt handler from starting a spurious read after a failed
+		 * write and leaving a stale completion for the next transfer.
+		 */
+		data->pending = CAT1_I2C_PENDING_NONE;
 		data->error = true;
 		k_sem_give(&data->transfer_sem);
+	} else if ((data->async_pending == CAT1_I2C_PENDING_TX_RX) &&
+		   ((CY_SCB_I2C_MASTER_WR_CMPLT_EVENT & event) != 0) &&
+		   (data->pending == CAT1_I2C_PENDING_TX_RX)) {
+		/*
+		 * Chain the read phase only after the write phase completes. A
+		 * write to an absent target reports its address NACK through the
+		 * error event above, so the read is never issued and cannot
+		 * return stale data.
+		 */
+		data->pending = CAT1_I2C_PENDING_RX;
+		Cy_SCB_I2C_MasterRead(config->base, &data->rx_config, &data->context);
 	} else if (((data->async_pending == CAT1_I2C_PENDING_TX_RX) &&
 		    ((CY_SCB_I2C_MASTER_RD_CMPLT_EVENT & event) != 0)) ||
 		   (data->async_pending != CAT1_I2C_PENDING_TX_RX)) {
@@ -824,21 +843,13 @@ static void i2c_isr_handler(const struct device *dev)
 	Cy_SCB_I2C_Interrupt(config->base, &data->context);
 
 	if (data->pending != CAT1_I2C_PENDING_NONE) {
-		/* This code is part of _i2c_master_transfer_async() API functionality */
-		/* _i2c_master_transfer_async() API uses this interrupt handler for RX transfer
+		/* The write-read read phase is chained from the master
+		 * WR_CMPLT event, so only the single TX or RX phase needs to be
+		 * cleared once the master goes idle.
 		 */
 		if (0 == (Cy_SCB_I2C_MasterGetStatus(config->base, &data->context) &
 			  CY_SCB_I2C_MASTER_BUSY)) {
-			/* Check if TX is completed and run RX in case when TX and RX are enabled */
-			if (data->pending == CAT1_I2C_PENDING_TX_RX) {
-				/* Start RX transfer */
-				data->pending = CAT1_I2C_PENDING_RX;
-				Cy_SCB_I2C_MasterRead(config->base, &data->rx_config,
-						      &data->context);
-			} else {
-				/* Finish async TX or RX separate transfer */
-				data->pending = CAT1_I2C_PENDING_NONE;
-			}
+			data->pending = CAT1_I2C_PENDING_NONE;
 		}
 	}
 }


### PR DESCRIPTION
A write-read transfer to a target that NACKs it's address will return stale data on alternating attempts rather than returning the NACK condition.  When a write is aborted, the interrupt handler still chains the read because it checks pending without gating on the IRQ cause.  This produces a spurious completion that gets picked up by the following transfer, causing it to erroneously report success.  

This PR fixes this behavior by initiating the read phase from the write complete event rather than from the ISR's idle.  This change also clears pending unconditionally on the error path so stray interrupts after a failed write won't be acted on. 