### PR TITLE
drivers: i2c: infineon_pdl: add timeout for i2c transfers

### DIFF
--- a/drivers/i2c/Kconfig.infineon
+++ b/drivers/i2c/Kconfig.infineon
@@ -22,6 +22,7 @@ config I2C_INFINEON_CAT1_PDL
 	depends on !USE_INFINEON_LEGACY_HAL
 	select USE_INFINEON_I2C
 	select PINCTRL
+	select I2C_TRANSFER_TIMEOUT_SUPPORTED
 	help
 	  This option enables the PDL based I2C driver for the Infineon CAT1 family.
 

--- a/drivers/i2c/i2c_infineon_pdl.c
+++ b/drivers/i2c/i2c_infineon_pdl.c
@@ -621,6 +621,7 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 	struct i2c_msg *tx_msg;
 	struct i2c_msg *rx_msg;
 	struct ifx_cat1_i2c_data *data = dev->data;
+	const struct ifx_cat1_i2c_config *const config = dev->config;
 	int ret;
 
 	/* Acquire semaphore (block I2C transfer for another thread) */
@@ -672,11 +673,33 @@ static int ifx_cat1_i2c_transfer(const struct device *dev, struct i2c_msg *msg, 
 			return ret;
 		}
 
-		/* Acquire semaphore (block I2C async transfer for another thread) */
-		ret = k_sem_take(&data->transfer_sem, K_FOREVER);
-		if (ret < 0) {
+		/* Wait for the async transfer to complete, bounded by the
+		 * configured transfer timeout.
+		 */
+		ret = k_sem_take(&data->transfer_sem, I2C_TRANSFER_TIMEOUT);
+		if (ret != 0) {
+			cy_rslt_t abort_status;
+
+			/* The transfer did not complete in time, for example a
+			 * target holding the bus low. Abort the async operation,
+			 * then reset the shared async state with the SCB
+			 * interrupt masked so a late completion cannot race the
+			 * teardown or leak into the next transfer.
+			 */
+			abort_status = _i2c_abort_async(dev);
+			if (abort_status != CY_RSLT_SUCCESS) {
+				LOG_WRN("I2C abort did not confirm master idle "
+					"(0x%x); bus may be stuck", abort_status);
+			}
+
+			irq_disable(config->irq_num);
+			data->pending = CAT1_I2C_PENDING_NONE;
+			k_sem_reset(&data->transfer_sem);
+			data->irq_cause &= ~I2C_CAT1_EVENTS_MASK;
+			irq_enable(config->irq_num);
+
 			k_sem_give(&data->operation_sem);
-			return -EIO;
+			return -ETIMEDOUT;
 		}
 
 		/* Check for an error during the transfer */


### PR DESCRIPTION
The I2C master transfer waited on the transfer semaphore with K_FOREVER, so a target that never completed a transfer would block the calling thread indefinitely with no recovery mechanism.

This PR implements the timeout by adding a timeout to the transfer semaphore using I2C_TRANSFER_TIMEOUT as a timeout value. On a timeout, the driver now aborts the asynchronous operation and resets the shared state with the SCB interrupt masked so a late completion cannot corrupt the teardown, then returns -ETIMEDOUT.