### PR TITLE
drivers: gpio: gpio_mcux: exclude disconnected pins from direction query

### DIFF
--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -489,6 +489,32 @@ static int gpio_mcux_port_get_direction(const struct device *dev, gpio_port_pins
 
 	map &= config->common.port_pin_mask;
 
+#if !defined(CONFIG_PINCTRL_NXP_IOCON)
+	/*
+	 * When PORT is used, check whether GPIO is disconnected, if
+	 * 1. PORT PCR MUX is 0, and
+	 * 2. both IBE cleared (no input buffer), and
+	 * 3. PDDR cleared (no output drive)
+	 * Then the pin is disconnected, and should not be reported as input or output.
+	 */
+	PORT_Type * port_base = config->port_base;
+	gpio_port_pins_t connected = 0;
+
+	for (int i = 0; i < ARRAY_SIZE(port_base->PCR); i++) {
+		if (!(map & BIT(i))) {
+			continue;
+		}
+		if (!(((port_base->PCR[i] & PORT_PCR_MUX_MASK) == 0U) &&
+#if defined(FSL_FEATURE_PORT_HAS_INPUT_BUFFER) && FSL_FEATURE_PORT_HAS_INPUT_BUFFER
+		      ((port_base->PCR[i] & PORT_PCR_IBE_MASK) == 0U) &&
+#endif
+		      ((gpio_base->PDDR & BIT(i)) == 0U))) {
+			connected |= BIT(i);
+		}
+	}
+	map = connected;
+#endif /* !CONFIG_PINCTRL_NXP_IOCON */
+
 	if (inputs != NULL) {
 		*inputs = map & (~gpio_base->PDDR);
 	}


### PR DESCRIPTION
The patch ad42613252e31219 added GPIO_DISCONNECTED support for gpio_mcux_port_configure, but port_get_direction was not updated accordingly.

port_get_direction() only checks PDDR to determine pin direction, so a disconnected pin (PDDR cleared) is incorrectly reported as an input. This causes the gpio_get_direction.test_disconnect test to fail on boards using the PORT-based gpio_mcux driver.

Check PORT PCR and PDDR state to identify disconnected pins and exclude them from direction results, so they are reported as neither input nor output per the Zephyr GPIO API contract.

Fixes: #114432

test result on frdmmcxn947:
```
*** Booting Zephyr OS build v4.4.0-8785-g7f7880e01f2b ***
Running TESTSUITE gpio_get_direction
===================================================================
START - test_disconnect
 PASS - test_disconnect in 0.001 seconds
===================================================================
START - test_input
 PASS - test_input in 0.001 seconds
===================================================================
START - test_input_output
 SKIP - test_input_output in 0.001 seconds
===================================================================
START - test_output
 PASS - test_output in 0.001 seconds
===================================================================
TESTSUITE gpio_get_direction succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [gpio_get_direction]: pass = 3, fail = 0, skip = 1, total = 4 duration = 0.004 seconds
 - PASS - [gpio_get_direction.test_disconnect] duration = 0.001 seconds
 - PASS - [gpio_get_direction.test_input] duration = 0.001 seconds
 - SKIP - [gpio_get_direction.test_input_output] duration = 0.001 seconds
 - PASS - [gpio_get_direction.test_output] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```