### PR TITLE
scripts: ci: fix twisterlib import in test plan scripts

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -37,8 +37,9 @@ args = None
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
 
 sys.path.append(os.path.join(zephyr_base, 'scripts'))
+sys.path.append(os.path.join(zephyr_base, 'scripts', 'pylib', 'twister'))
 import list_boards  # noqa: E402
-from pylib.twister.twisterlib.statuses import TwisterStatus  # noqa: E402
+from twisterlib.statuses import TwisterStatus  # noqa: E402
 
 
 def _get_match_fn(globs, regexes):

--- a/scripts/ci/test_plan_v2.py
+++ b/scripts/ci/test_plan_v2.py
@@ -119,6 +119,7 @@ if "ZEPHYR_BASE" not in os.environ:
 
 ZEPHYR_BASE = Path(os.environ["ZEPHYR_BASE"])
 sys.path.insert(0, str(ZEPHYR_BASE / "scripts"))
+sys.path.insert(0, str(ZEPHYR_BASE / "scripts" / "pylib" / "twister"))
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 log = logging.getLogger(__name__)
@@ -720,10 +721,8 @@ class Orchestrator:
     @staticmethod
     def _count_errors(testsuites):
         errors = 0
-        try:
-            from pylib.twister.twisterlib.statuses import TwisterStatus  # noqa: PLC0415
-        except ImportError:
-            return 0
+        from twisterlib.statuses import TwisterStatus  # noqa: PLC0415
+
         for ts in testsuites:
             if TwisterStatus(ts.get("status")) == TwisterStatus.ERROR:
                 log.warning(


### PR DESCRIPTION
Both test plan scripts imported TwisterStatus through the package path
'pylib.twister.twisterlib.statuses'. Modules inside twisterlib import
each other with absolute 'twisterlib.<module>' names, which only resolve
when scripts/pylib/twister is on sys.path - something only the
scripts/twister launcher did. That spelling worked by accident as long
as statuses.py had no intra-package imports; commit fc599d0e3e55 added
'from twisterlib.error import StatusAttributeError' to it and the import
started raising ModuleNotFoundError.

test_plan.py aborted outright. In test_plan_v2.py the same import sat
inside a bare try/except ImportError that returned 0, so _count_errors()
always reported no errors and the script exited 0 even when test
configurations failed.

Put scripts/pylib/twister on sys.path in both scripts and import
'twisterlib.statuses' directly, matching every other consumer of the
package, then drop the try/except so an unimportable TwisterStatus is a
hard failure rather than a silently miscounted result. Importing via
both spellings would otherwise create two distinct TwisterStatus enum
classes whose members compare unequal under 'is'.

Fixes #114208

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
