### PR TITLE
  arch: arm64: fix SMP hang when CONFIG_PRINTK_SYNC is enabled

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -1076,6 +1076,22 @@ static void enable_mmu_el1(struct arm_mmu_ptables *ptables, unsigned int flags)
 	MMU_DEBUG("MMU enabled with dcache\n");
 }
 
+/*
+ * Before the MMU is enabled (i.e. during setup_page_tables(), which per
+ * z_arm64_mm_init() only ever runs single-threaded on the primary core
+ * before any other CPU is released from reset), LSE atomic instructions
+ * such as the one used by printk's CONFIG_PRINTK_SYNC spinlock cannot
+ * execute correctly: they require the MMU to already be active with
+ * proper (shareable) memory attributes, and will instead take a
+ * Synchronous External Abort. No other CPU can be printing at the same
+ * time in that window either, so it is safe for printk() to skip
+ * locking entirely until the MMU comes up.
+ */
+bool arch_printk_sync_safe(void)
+{
+	return (read_sctlr_el1() & SCTLR_M_BIT) != 0U;
+}
+
 /* ARM MMU Driver Initial Setup */
 
 static struct arm_mmu_ptables kernel_ptables;

--- a/arch/arm64/core/thread.c
+++ b/arch/arm64/core/thread.c
@@ -148,8 +148,19 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	thread->callee_saved.lr = (uint64_t)z_arm64_exit_exc;
 
 	thread->switch_handle = thread;
-#if defined(CONFIG_ARM64_STACK_PROTECTION)
+#if defined(CONFIG_ARM64_SAFE_EXCEPTION_STACK)
+	/*
+	 * Needed by z_arm64_quick_stack_check() so it can tell a real stack
+	 * overflow from a healthy SP_EL1 and switch to the safe exception
+	 * stack. On targets without CONFIG_ARM64_STACK_PROTECTION (no
+	 * ARM_MPU, e.g. plain MMU-based Cortex-A), Z_ARM64_STACK_GUARD_SIZE
+	 * is 0, so this is just the stack's base address with no guard
+	 * region -- still enough to catch SP running past the whole
+	 * allocated stack instead of silently corrupting adjacent memory.
+	 */
 	thread->arch.stack_limit = (uint64_t)stack + Z_ARM64_STACK_GUARD_SIZE;
+#endif
+#if defined(CONFIG_ARM64_STACK_PROTECTION)
 	z_arm64_thread_mem_domains_init(thread);
 #endif
 

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -618,6 +618,25 @@ uintptr_t arch_page_info_get(void *addr, uintptr_t *location,
  */
 int arch_printk_char_out(int c);
 
+/**
+ * Report whether it is currently safe to synchronize printk() output
+ * with a spinlock
+ *
+ * Definition of this function is optional. Some architectures cannot
+ * safely execute the atomic instructions used by the CONFIG_PRINTK_SYNC
+ * spinlock during certain early-boot windows -- for example arm64, where
+ * LSE atomics require the MMU to already be enabled. Returning false here
+ * during such a window lets printk() skip locking instead of faulting;
+ * since no other CPU is capable of racing during that window either, this
+ * is provably still safe.
+ *
+ * The default __weak implementation always returns true.
+ *
+ * @return true if printk() may take its internal spinlock, false if it
+ *         must skip synchronization entirely for this call
+ */
+bool arch_printk_sync_safe(void);
+
 #ifdef CONFIG_ARCH_HAS_THREAD_NAME_HOOK
 /**
  * Set thread name hook

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -31,6 +31,11 @@
 #if defined(CONFIG_PRINTK_SYNC)
 static struct k_spinlock lock;
 
+__attribute__((weak)) bool arch_printk_sync_safe(void)
+{
+	return true;
+}
+
 static ALWAYS_INLINE bool printk_lock(k_spinlock_key_t *key)
 {
 #ifdef CONFIG_SPIN_VALIDATE
@@ -61,6 +66,18 @@ static ALWAYS_INLINE bool printk_lock(k_spinlock_key_t *key)
 		return false;
 	}
 #endif /* CONFIG_SPIN_VALIDATE */
+
+	if (!arch_printk_sync_safe()) {
+		/*
+		 * Some architectures cannot safely execute the lock's atomic
+		 * instructions this early (see arch_printk_sync_safe()). No
+		 * other CPU can be printing at the same time in that window
+		 * either, so skipping the lock here is safe, not just
+		 * expedient.
+		 */
+		return false;
+	}
+
 	*key = k_spin_lock(&lock);
 	return true;
 }

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -30,7 +30,48 @@
 
 #if defined(CONFIG_PRINTK_SYNC)
 static struct k_spinlock lock;
-#endif
+
+static ALWAYS_INLINE bool printk_lock(k_spinlock_key_t *key)
+{
+#ifdef CONFIG_SPIN_VALIDATE
+	/*
+	 * vprintk()/z_impl_k_str_out() can be re-entered on the same CPU
+	 * when an assertion fires while a message is still being printed
+	 * (for example a spinlock validation failure on this very `lock`,
+	 * reported through assert_print()). Re-acquiring `lock` in that
+	 * case would fail validation again and recurse through
+	 * assert_print() -> vprintk() -> k_spin_lock() forever, until the
+	 * stack overflows. If this CPU already owns the lock, skip taking
+	 * it again and print directly instead.
+	 *
+	 * Reading the current CPU id must be done with local interrupts
+	 * masked: _current_cpu asserts the calling thread is not migratable
+	 * (!z_smp_cpu_mobile()), which is only guaranteed while interrupts
+	 * are locked. printk() is routinely called from preemptible thread
+	 * context, so dereferencing _current_cpu directly would trip that
+	 * assertion.
+	 */
+	unsigned int irq_key = arch_irq_lock();
+	bool self_owned = (lock.thread_cpu != 0U) &&
+			  ((lock.thread_cpu & 3U) == _current_cpu->id);
+
+	arch_irq_unlock(irq_key);
+
+	if (self_owned) {
+		return false;
+	}
+#endif /* CONFIG_SPIN_VALIDATE */
+	*key = k_spin_lock(&lock);
+	return true;
+}
+
+static ALWAYS_INLINE void printk_unlock(bool locked, k_spinlock_key_t key)
+{
+	if (locked) {
+		k_spin_unlock(&lock, key);
+	}
+}
+#endif /* CONFIG_PRINTK_SYNC */
 
 #ifdef CONFIG_PRINTK
 /**
@@ -125,7 +166,8 @@ void vprintk(const char *fmt, va_list ap)
 	} else {
 		compiler_barrier();
 #ifdef CONFIG_PRINTK_SYNC
-		k_spinlock_key_t key = k_spin_lock(&lock);
+		k_spinlock_key_t key;
+		bool locked = printk_lock(&key);
 #endif
 
 #ifdef CONFIG_PICOLIBC
@@ -137,7 +179,7 @@ void vprintk(const char *fmt, va_list ap)
 #endif
 
 #ifdef CONFIG_PRINTK_SYNC
-		k_spin_unlock(&lock, key);
+		printk_unlock(locked, key);
 #endif
 	}
 }
@@ -147,7 +189,8 @@ void z_impl_k_str_out(char *c, size_t n)
 {
 	size_t i;
 #ifdef CONFIG_PRINTK_SYNC
-	k_spinlock_key_t key = k_spin_lock(&lock);
+	k_spinlock_key_t key;
+	bool locked = printk_lock(&key);
 #endif
 
 	for (i = 0; i < n; i++) {
@@ -155,7 +198,7 @@ void z_impl_k_str_out(char *c, size_t n)
 	}
 
 #ifdef CONFIG_PRINTK_SYNC
-	k_spin_unlock(&lock, key);
+	printk_unlock(locked, key);
 #endif
 }
 


### PR DESCRIPTION
  ## Problem

  On an arm64 SMP target (AMD Versal Gen 2 APU, 2 cores), enabling
  `CONFIG_PRINTK_SYNC` together with `CONFIG_SMP` produced an early-boot
  hang with **no console output at all** — not even a partial crash dump —
  and the secondary CPU never left reset. `CONFIG_PRINTK_SYNC=n` masked
  the problem entirely, which made it look printk-specific at first, but
  the actual trigger turned out to be architectural: any `printk()`/
  `LOG_ERR()` call reachable from arm64 code that runs before the MMU is
  enabled will fault, because `CONFIG_PRINTK_SYNC`'s spinlock executes an
  atomic instruction that requires the MMU to already be active with
  proper (shareable) memory attributes.

  In this case the trigger was `set_mapping()` (arch/arm64/core/mmu.c)
  logging a conflicting MMU region during `setup_page_tables()`, which
  runs single-threaded on the primary core before the MMU comes up and
  before any secondary CPU is released from reset. That first faulting
  `LOG_ERR()` call recursed into `z_arm64_fatal_error()` trying to report
  itself the same way, faulting again, until the stack overflowed — all
  silently, since the printk hook is still a no-op stub this early
  regardless.

  Three separate, independently valid issues surfaced while chasing this
  down:

  1. **`lib: os: printk: avoid self-relock recursion when re-entered on
     same CPU`** — with `CONFIG_SPIN_VALIDATE` enabled, if an assertion
     fires while `vprintk()` already holds its own lock, reporting that
     assertion re-enters `vprintk()`, which fails the same lock-ownership
     check, asserts again, and recurses with no possible exit until the
     stack overflows. Skip re-locking when the current CPU already owns
     the lock.

  2. **`arch: arm64: thread: populate stack_limit under
     SAFE_EXCEPTION_STACK`** — `thread->arch.stack_limit` was only ever
     initialized under `CONFIG_ARM64_STACK_PROTECTION`, which requires
     `ARM_MPU`. On MMU-only Cortex-A targets that can never be selected,
     so `current_stack_limit` stays zero forever and
     `z_arm64_quick_stack_check()`'s overflow detection is silently dead
     code — `CONFIG_ARM64_SAFE_EXCEPTION_STACK` allocates the safety net
     but nothing was wiring it up. Populate the field whenever
     `CONFIG_ARM64_SAFE_EXCEPTION_STACK` is enabled instead.

  3. **`arch: arm64: mmu: let printk skip its lock before the MMU is
     enabled`** — the actual fix for the hang. Adds
     `arch_printk_sync_safe()`, a weak hook (default: always safe, no
     behavior change on any other architecture) that `vprintk()` checks
     before taking its lock. The arm64 implementation returns false
     exactly when `SCTLR_EL1.M` is clear. Since no other CPU can be
     running yet in that window either, skipping the lock is provably
     safe — this covers *any* pre-MMU-enable printk/LOG call, not just
     the specific one that exposed the bug.

  ## Testing

  - Reproduced the hang reliably on AMD Versal Gen 2 APU (2-core, SMP)
    hardware with `CONFIG_SMP=y` + `CONFIG_PRINTK_SYNC=y`.
  - Confirmed root cause via JTAG (XSDB): a breakpoint at
    `z_arm64_fatal_error()` caught the first fault with
    `ESR_EL1 = 0x96000410` (Data Abort, Synchronous External Abort) at
    the `ldaddal` instruction inside `atomic_inc()`, called from
    `k_spin_lock()`, called from a `LOG_ERR()` in `set_mapping()` during
    `setup_page_tables()` — i.e. before `SCTLR_EL1.M` is set.
  - With all three commits applied, the board boots cleanly with
    `CONFIG_PRINTK_SYNC=y`, the secondary CPU comes up, and the full
    `tests/kernel/smp` suite runs to completion, including
    `test_fatal_on_smp`, which deliberately triggers a real kernel oops
    on each CPU and now reports it correctly instead of hanging.
