### PR TITLE
boards: nxp: imx95_evk: sync DDR variant ram size with DTS

### DIFF
--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7_ddr.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7_ddr.yaml
@@ -8,7 +8,7 @@ identifier: imx95_evk/mimx9596/m7/ddr
 name: NXP i.MX95 EVK DDR variant
 type: mcu
 arch: arm
-ram: 256
+ram: 43008
 toolchain:
   - zephyr
   - gnuarmemb


### PR DESCRIPTION
The DDR memory region of imx95_evk/mimx9596/m7/ddr was enlarged to 42 MB in the board DTS, but the ram size in the board YAML was left at 256 KB. Update ram to 43008 (42 MB) so twister/build metadata matches the actual DDR memory region defined in the DTS.