### PR TITLE
drivers: sensor: sensirion: add STC31 CO2 sensor driver

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -309,6 +309,10 @@ New Drivers
   * Diodes/Pericom PI4IOE5V6408 8-bit I2C-bus I/O expander
     (:dtcompatible:`diodes,pi4ioe5v6408`).
 
+* Sensors
+
+  * Sensirion STC31 CO2 sensor (:dtcompatible:`sensirion,stc31`).
+
 * Input
 
   * VIRTIO input device (:dtcompatible:`virtio,input`).

--- a/drivers/sensor/sensirion/CMakeLists.txt
+++ b/drivers/sensor/sensirion/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory_ifdef(CONFIG_SGP40 sgp40)
 add_subdirectory_ifdef(CONFIG_SHT3XD sht3xd)
 add_subdirectory_ifdef(CONFIG_SHT4X sht4x)
 add_subdirectory_ifdef(CONFIG_SHTCX shtcx)
+add_subdirectory_ifdef(CONFIG_STC31 stc31)
 add_subdirectory_ifdef(CONFIG_STCC4 stcc4)
 add_subdirectory_ifdef(CONFIG_STS4X sts4x)
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/sensirion/Kconfig
+++ b/drivers/sensor/sensirion/Kconfig
@@ -7,6 +7,7 @@ source "drivers/sensor/sensirion/sgp40/Kconfig"
 source "drivers/sensor/sensirion/sht3xd/Kconfig"
 source "drivers/sensor/sensirion/sht4x/Kconfig"
 source "drivers/sensor/sensirion/shtcx/Kconfig"
+source "drivers/sensor/sensirion/stc31/Kconfig"
 source "drivers/sensor/sensirion/stcc4/Kconfig"
 source "drivers/sensor/sensirion/sts4x/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/sensor/sensirion/stc31/CMakeLists.txt
+++ b/drivers/sensor/sensirion/stc31/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 RAKwireless Technology Limited
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(stc31.c)

--- a/drivers/sensor/sensirion/stc31/Kconfig
+++ b/drivers/sensor/sensirion/stc31/Kconfig
@@ -1,0 +1,14 @@
+# STC31 CO2 sensor configuration options
+
+# Copyright (c) 2026 RAKwireless Technology Limited
+# SPDX-License-Identifier: Apache-2.0
+
+config STC31
+	bool "Sensirion STC31 CO2 Sensor"
+	default y
+	depends on DT_HAS_SENSIRION_STC31_ENABLED
+	select I2C
+	select CRC
+	help
+	  Enable driver for the Sensirion STC31 thermal conductivity
+	  carbon dioxide sensor.

--- a/drivers/sensor/sensirion/stc31/stc31.c
+++ b/drivers/sensor/sensirion/stc31/stc31.c
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2026 RAKwireless Technology Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT sensirion_stc31
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/stc31.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/crc.h>
+
+#include "stc31.h"
+
+LOG_MODULE_REGISTER(STC31, CONFIG_SENSOR_LOG_LEVEL);
+
+static uint8_t stc31_crc(const uint8_t *data, size_t len)
+{
+	return crc8(data, len, STC31_CRC_POLY, STC31_CRC_INIT, false);
+}
+
+static int stc31_write_cmd(const struct device *dev, uint16_t cmd)
+{
+	const struct stc31_config *cfg = dev->config;
+	uint8_t buf[2];
+
+	sys_put_be16(cmd, buf);
+	return i2c_write_dt(&cfg->bus, buf, sizeof(buf));
+}
+
+static int stc31_write_cmd_arg(const struct device *dev, uint16_t cmd, uint16_t arg)
+{
+	const struct stc31_config *cfg = dev->config;
+	uint8_t buf[5];
+
+	sys_put_be16(cmd, buf);
+	sys_put_be16(arg, &buf[2]);
+	buf[4] = stc31_crc(&buf[2], 2);
+
+	return i2c_write_dt(&cfg->bus, buf, sizeof(buf));
+}
+
+static int stc31_read_words(const struct device *dev, uint8_t *rx_buf, size_t rx_len)
+{
+	const struct stc31_config *cfg = dev->config;
+	int ret;
+
+	ret = i2c_read_dt(&cfg->bus, rx_buf, rx_len);
+	if (ret < 0) {
+		LOG_ERR("Failed to read I2C data (%d)", ret);
+		return ret;
+	}
+
+	for (size_t i = 0; i < rx_len; i += STC31_WORD_SIZE) {
+		if (stc31_crc(&rx_buf[i], 2) != rx_buf[i + 2]) {
+			LOG_ERR("Invalid CRC");
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+static uint16_t stc31_measure_delay_ms(uint16_t binary_gas)
+{
+	/* Low-cross-sensitivity modes use arguments 0x0010-0x0013 */
+	if (binary_gas >= STC31_DT_BINARY_GAS_CO2_IN_N2_100) {
+		return STC31_MEASURE_DURATION_LOW_XSENS_MS;
+	}
+
+	return STC31_MEASURE_DURATION_LN_MS;
+}
+
+/* C[vol%] = 100 * (raw - 2^14) / 2^15 */
+static float stc31_raw_to_vol_percent(uint16_t raw)
+{
+	return (100.0f * ((float)raw - 16384.0f)) / 32768.0f;
+}
+
+static uint16_t stc31_vol_percent_to_raw(float vol_percent)
+{
+	float raw = (vol_percent / 100.0f) * 32768.0f + 16384.0f;
+
+	if (raw < 0.0f) {
+		return 0;
+	}
+	if (raw > (float)UINT16_MAX) {
+		return UINT16_MAX;
+	}
+
+	return (uint16_t)(raw + 0.5f);
+}
+
+static uint16_t stc31_rh_to_raw(const struct sensor_value *val)
+{
+	float rh = sensor_value_to_float(val);
+
+	if (rh < 0.0f) {
+		rh = 0.0f;
+	} else if (rh > 100.0f) {
+		rh = 100.0f;
+	}
+
+	return (uint16_t)((rh * 65535.0f) / 100.0f + 0.5f);
+}
+
+static int16_t stc31_temp_to_raw(const struct sensor_value *val)
+{
+	float t_c = sensor_value_to_float(val);
+
+	return (int16_t)(t_c * 200.0f);
+}
+
+static int stc31_set_binary_gas(const struct device *dev, uint16_t binary_gas)
+{
+	struct stc31_data *data = dev->data;
+	int ret;
+
+	ret = stc31_write_cmd_arg(dev, STC31_CMD_SET_BINARY_GAS, binary_gas);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Sensirion embedded driver waits 1 ms after set_binary_gas */
+	k_msleep(1);
+	data->binary_gas = binary_gas;
+	return 0;
+}
+
+static int stc31_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct stc31_data *data = dev->data;
+	uint8_t rx[6];
+	int16_t temp_raw;
+	uint16_t conc_raw;
+	int ret;
+
+	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_CO2 &&
+	    chan != SENSOR_CHAN_AMBIENT_TEMP) {
+		return -ENOTSUP;
+	}
+
+	ret = stc31_write_cmd(dev, STC31_CMD_MEASURE_GAS_CONCENTRATION);
+	if (ret < 0) {
+		LOG_ERR("Measure command failed (%d)", ret);
+		return ret;
+	}
+
+	k_msleep(stc31_measure_delay_ms(data->binary_gas));
+
+	/* Concentration + temperature (2 words); reserved word is optional */
+	ret = stc31_read_words(dev, rx, sizeof(rx));
+	if (ret < 0) {
+		return ret;
+	}
+
+	conc_raw = sys_get_be16(&rx[0]);
+	temp_raw = (int16_t)sys_get_be16(&rx[3]);
+
+	/* SENSOR_CHAN_CO2 is ppm; 1 vol% = 10000 ppm */
+	data->co2_ppm = stc31_raw_to_vol_percent(conc_raw) * 10000.0f;
+	data->temp_c = (float)temp_raw / 200.0f;
+
+	return 0;
+}
+
+static int stc31_channel_get(const struct device *dev, enum sensor_channel chan,
+			     struct sensor_value *val)
+{
+	const struct stc31_data *data = dev->data;
+
+	switch (chan) {
+	case SENSOR_CHAN_CO2:
+		return sensor_value_from_float(val, data->co2_ppm);
+	case SENSOR_CHAN_AMBIENT_TEMP:
+		return sensor_value_from_float(val, data->temp_c);
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int stc31_attr_set(const struct device *dev, enum sensor_channel chan,
+			  enum sensor_attribute attr, const struct sensor_value *val)
+{
+	ARG_UNUSED(chan);
+
+	switch ((enum sensor_attribute_stc31)attr) {
+	case SENSOR_ATTR_STC31_REL_HUMIDITY:
+		return stc31_write_cmd_arg(dev, STC31_CMD_SET_RELATIVE_HUMIDITY,
+					   stc31_rh_to_raw(val));
+	case SENSOR_ATTR_STC31_TEMPERATURE:
+		return stc31_write_cmd_arg(dev, STC31_CMD_SET_TEMPERATURE,
+					   (uint16_t)stc31_temp_to_raw(val));
+	case SENSOR_ATTR_STC31_PRESSURE:
+		if (val->val1 < 0 || val->val1 > UINT16_MAX) {
+			return -EINVAL;
+		}
+		return stc31_write_cmd_arg(dev, STC31_CMD_SET_PRESSURE, (uint16_t)val->val1);
+	case SENSOR_ATTR_STC31_BINARY_GAS:
+		if (val->val1 < 0 || val->val1 > UINT16_MAX) {
+			return -EINVAL;
+		}
+		return stc31_set_binary_gas(dev, (uint16_t)val->val1);
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static int stc31_attr_get(const struct device *dev, enum sensor_channel chan,
+			  enum sensor_attribute attr, struct sensor_value *val)
+{
+	const struct stc31_data *data = dev->data;
+
+	ARG_UNUSED(chan);
+
+	switch ((enum sensor_attribute_stc31)attr) {
+	case SENSOR_ATTR_STC31_BINARY_GAS:
+		val->val1 = data->binary_gas;
+		val->val2 = 0;
+		return 0;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+int stc31_forced_recalibration(const struct device *dev, uint16_t reference_ppm)
+{
+	struct stc31_data *data = dev->data;
+	float vol_percent = (float)reference_ppm / 10000.0f;
+	uint16_t raw = stc31_vol_percent_to_raw(vol_percent);
+	int ret;
+
+	ret = stc31_write_cmd_arg(dev, STC31_CMD_FORCED_RECALIBRATION, raw);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* FRC takes the same time as a concentration measurement */
+	k_msleep(stc31_measure_delay_ms(data->binary_gas));
+	return 0;
+}
+
+static int stc31_soft_reset_hw(const struct device *dev)
+{
+	const struct stc31_config *cfg = dev->config;
+	uint8_t cmd = STC31_SOFT_RESET_CMD;
+	int ret;
+
+	ret = i2c_write(cfg->bus.bus, &cmd, sizeof(cmd), STC31_GENERAL_CALL_ADDR);
+	if (ret < 0) {
+		return ret;
+	}
+
+	k_msleep(STC31_SOFT_RESET_TIME_MS);
+	return 0;
+}
+
+int stc31_soft_reset(const struct device *dev)
+{
+	struct stc31_data *data = dev->data;
+	int ret;
+
+	ret = stc31_soft_reset_hw(dev);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Soft reset clears binary gas selection */
+	return stc31_set_binary_gas(dev, data->binary_gas);
+}
+
+static int stc31_read_product_id(const struct device *dev, uint32_t *product)
+{
+	uint8_t rx[18];
+	int ret;
+
+	ret = stc31_write_cmd(dev, STC31_CMD_READ_PRODUCT_ID_1);
+	if (ret < 0) {
+		LOG_ERR("Product ID prepare failed (%d)", ret);
+		return ret;
+	}
+
+	ret = stc31_write_cmd(dev, STC31_CMD_READ_PRODUCT_ID_2);
+	if (ret < 0) {
+		LOG_ERR("Product ID read cmd failed (%d)", ret);
+		return ret;
+	}
+
+	/* Sensirion embedded driver waits 10 ms before reading the response */
+	k_msleep(10);
+
+	/* 6 words: 32-bit product + 64-bit serial (with CRC bytes) */
+	ret = stc31_read_words(dev, rx, sizeof(rx));
+	if (ret < 0) {
+		LOG_ERR("Product ID data read failed (%d)", ret);
+		return ret;
+	}
+
+	*product = ((uint32_t)sys_get_be16(&rx[0]) << 16) | sys_get_be16(&rx[3]);
+	return 0;
+}
+
+static int stc31_init(const struct device *dev)
+{
+	const struct stc31_config *cfg = dev->config;
+	uint32_t product;
+	int ret;
+
+	if (!i2c_is_ready_dt(&cfg->bus)) {
+		LOG_ERR("I2C bus not ready");
+		return -ENODEV;
+	}
+
+	k_msleep(STC31_POWER_UP_TIME_MS);
+
+	/* General-call reset; ignore error if bus has no listeners yet */
+	(void)stc31_soft_reset_hw(dev);
+
+	ret = stc31_read_product_id(dev, &product);
+	if (ret < 0) {
+		LOG_ERR("Failed to read product ID (%d)", ret);
+		return ret;
+	}
+
+	if ((product & STC31_PRODUCT_MASK) != STC31_PRODUCT_NUMBER) {
+		LOG_ERR("Unexpected product ID 0x%08x", product);
+		return -ENODEV;
+	}
+
+	LOG_DBG("Product ID: 0x%08x", product);
+
+	ret = stc31_set_binary_gas(dev, cfg->binary_gas);
+	if (ret < 0) {
+		LOG_ERR("Failed to set binary gas 0x%04x (%d)", cfg->binary_gas, ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static DEVICE_API(sensor, stc31_api) = {
+	.sample_fetch = stc31_sample_fetch,
+	.channel_get = stc31_channel_get,
+	.attr_set = stc31_attr_set,
+	.attr_get = stc31_attr_get,
+};
+
+#define STC31_INIT(inst)                                                                           \
+	static struct stc31_data stc31_data_##inst;                                                \
+	static const struct stc31_config stc31_config_##inst = {                                   \
+		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.binary_gas = DT_INST_PROP(inst, binary_gas),                                      \
+	};                                                                                         \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, stc31_init, NULL, &stc31_data_##inst,                   \
+				     &stc31_config_##inst, POST_KERNEL,                            \
+				     CONFIG_SENSOR_INIT_PRIORITY, &stc31_api);
+
+DT_INST_FOREACH_STATUS_OKAY(STC31_INIT)

--- a/drivers/sensor/sensirion/stc31/stc31.h
+++ b/drivers/sensor/sensirion/stc31/stc31.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 RAKwireless Technology Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_STC31_STC31_H_
+#define ZEPHYR_DRIVERS_SENSOR_STC31_STC31_H_
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/dt-bindings/sensor/stc31.h>
+
+#define STC31_CMD_SET_BINARY_GAS            0x3615
+#define STC31_CMD_SET_RELATIVE_HUMIDITY     0x3624
+#define STC31_CMD_SET_TEMPERATURE           0x361E
+#define STC31_CMD_SET_PRESSURE              0x362F
+#define STC31_CMD_MEASURE_GAS_CONCENTRATION 0x3639
+#define STC31_CMD_FORCED_RECALIBRATION      0x3661
+#define STC31_CMD_READ_PRODUCT_ID_1         0x367C
+#define STC31_CMD_READ_PRODUCT_ID_2         0xE102
+
+/* I2C general call soft reset (address 0x00, 8-bit command) */
+#define STC31_GENERAL_CALL_ADDR 0x00
+#define STC31_SOFT_RESET_CMD    0x06
+
+#define STC31_CRC_POLY 0x31
+#define STC31_CRC_INIT 0xFF
+
+#define STC31_WORD_SIZE 3
+
+/* Datasheet timings */
+#define STC31_POWER_UP_TIME_MS              14
+#define STC31_SOFT_RESET_TIME_MS            12
+#define STC31_MEASURE_DURATION_LN_MS        66
+#define STC31_MEASURE_DURATION_LOW_XSENS_MS 110
+
+/* Product number STC31 (revision nibble ignored in check) */
+#define STC31_PRODUCT_NUMBER 0x08010300
+#define STC31_PRODUCT_MASK   0xFFFFFF00
+
+struct stc31_config {
+	struct i2c_dt_spec bus;
+	uint16_t binary_gas;
+};
+
+struct stc31_data {
+	float co2_ppm;
+	float temp_c;
+	uint16_t binary_gas;
+};
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_STC31_STC31_H_ */

--- a/dts/bindings/sensor/sensirion,stc31.yaml
+++ b/dts/bindings/sensor/sensirion,stc31.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 RAKwireless Technology Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Sensirion STC31 thermal conductivity CO2 sensor IC.
+
+  Measures high-range CO2 concentration (vol%) and temperature over I2C.
+  A binary gas model must be selected before measurements.
+
+compatible: "sensirion,stc31"
+
+include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+  binary-gas:
+    type: int
+    default: 0x0001
+    description: |
+      Measurement mode and binary gas argument for command 0x3615.
+      See include/zephyr/dt-bindings/sensor/stc31.h. Default is CO2 in air,
+      0...100 vol%, low-noise mode (0x0001), compatible with STC31 and STC31-C.
+    enum:
+      - 0x0000 # STC31_DT_BINARY_GAS_CO2_IN_N2_100_LN
+      - 0x0001 # STC31_DT_BINARY_GAS_CO2_IN_AIR_100_LN
+      - 0x0002 # STC31_DT_BINARY_GAS_CO2_IN_N2_25_LN
+      - 0x0003 # STC31_DT_BINARY_GAS_CO2_IN_AIR_25_LN
+      - 0x0010 # STC31_DT_BINARY_GAS_CO2_IN_N2_100
+      - 0x0011 # STC31_DT_BINARY_GAS_CO2_IN_AIR_100
+      - 0x0012 # STC31_DT_BINARY_GAS_CO2_IN_N2_40
+      - 0x0013 # STC31_DT_BINARY_GAS_CO2_IN_AIR_40
+
+examples:
+  - |
+    #include <zephyr/dt-bindings/sensor/stc31.h>
+
+    stc31@29 {
+      compatible = "sensirion,stc31";
+      reg = <0x29>;
+      binary-gas = <STC31_DT_BINARY_GAS_CO2_IN_AIR_100_LN>;
+    };

--- a/include/zephyr/drivers/sensor/stc31.h
+++ b/include/zephyr/drivers/sensor/stc31.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 RAKwireless Technology Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for extended sensor API of STC31 sensor
+ * @ingroup stc31_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_STC31_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_STC31_H_
+
+/**
+ * @brief Sensirion STC31 CO<sub>2</sub> sensor
+ * @defgroup stc31_interface STC31
+ * @ingroup sensor_interface_ext_sensirion
+ * @{
+ */
+
+#include <zephyr/drivers/sensor.h>
+
+/**
+ * @brief Custom sensor attributes for STC31
+ */
+enum sensor_attribute_stc31 {
+	/**
+	 * Relative humidity compensation input.
+	 *
+	 * Unit: %RH. Written to the sensor for concentration compensation.
+	 * When never set after power-up/reset, the sensor assumes 0 %RH.
+	 */
+	SENSOR_ATTR_STC31_REL_HUMIDITY = SENSOR_ATTR_PRIV_START,
+	/**
+	 * External temperature compensation input.
+	 *
+	 * Unit: deg C. Prefer a more accurate external sensor (e.g. SHT4x).
+	 * When never set, the sensor uses its internal temperature signal.
+	 */
+	SENSOR_ATTR_STC31_TEMPERATURE,
+	/**
+	 * Ambient pressure compensation input.
+	 *
+	 * Unit: mBar. When never set after power-up/reset, 1013 mBar is assumed.
+	 */
+	SENSOR_ATTR_STC31_PRESSURE,
+	/**
+	 * Binary gas / measurement mode argument for command 0x3615.
+	 *
+	 * See :c:macro:`STC31_DT_BINARY_GAS_*` in
+	 * :file:`zephyr/dt-bindings/sensor/stc31.h`.
+	 */
+	SENSOR_ATTR_STC31_BINARY_GAS,
+};
+
+/**
+ * @brief Perform a forced recalibration (FRC).
+ *
+ * @param dev Pointer to the sensor device
+ * @param reference_ppm Reference CO2 concentration in ppm
+ *        (converted internally to the sensor vol% encoding)
+ *
+ * @return 0 if successful, negative errno code if failure.
+ */
+int stc31_forced_recalibration(const struct device *dev, uint16_t reference_ppm);
+
+/**
+ * @brief Soft-reset the STC31 via I2C general call.
+ *
+ * Blocks for the sensor soft-reset time, then restores the last configured
+ * binary gas selection.
+ *
+ * @param dev Pointer to the sensor device
+ *
+ * @return 0 if successful, negative errno code if failure.
+ */
+int stc31_soft_reset(const struct device *dev);
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_STC31_H_ */

--- a/include/zephyr/dt-bindings/sensor/stc31.h
+++ b/include/zephyr/dt-bindings/sensor/stc31.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 RAKwireless Technology Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Devicetree binding constants for the Sensirion STC31 CO2 sensor.
+ * @ingroup stc31_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_STC31_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_STC31_H_
+
+/**
+ * @defgroup stc31_interface STC31
+ * @ingroup sensor_interface_ext_sensirion
+ * @brief Sensirion STC31 CO2 sensor
+ * @{
+ */
+
+/**
+ * @name Binary gas / measurement mode
+ *
+ * Values for the `binary-gas` devicetree property (STC31-C datasheet §3.3.2).
+ * @{
+ */
+
+/* Low-noise modes */
+#define STC31_DT_BINARY_GAS_CO2_IN_N2_100_LN  0x0000 /**< CO2 in N2, 0...100 vol% (low-noise) */
+#define STC31_DT_BINARY_GAS_CO2_IN_AIR_100_LN 0x0001 /**< CO2 in air, 0...100 vol% (low-noise) */
+#define STC31_DT_BINARY_GAS_CO2_IN_N2_25_LN   0x0002 /**< CO2 in N2, 0...25 vol% (low-noise) */
+#define STC31_DT_BINARY_GAS_CO2_IN_AIR_25_LN  0x0003 /**< CO2 in air, 0...25 vol% (low-noise) */
+
+/* Low-cross-sensitivity modes (recommended for STC31-C) */
+#define STC31_DT_BINARY_GAS_CO2_IN_N2_100  0x0010 /**< CO2 in N2, 0...100 vol% */
+#define STC31_DT_BINARY_GAS_CO2_IN_AIR_100 0x0011 /**< CO2 in air, 0...100 vol% */
+#define STC31_DT_BINARY_GAS_CO2_IN_N2_40   0x0012 /**< CO2 in N2, 0...40 vol% */
+#define STC31_DT_BINARY_GAS_CO2_IN_AIR_40  0x0013 /**< CO2 in air, 0...40 vol% */
+
+/** @} */
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_STC31_H_ */

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1652,3 +1652,9 @@ test_i2c_icm40627: icm40627@d6 {
 	accel-fs = <16>;
 	gyro-fs = <2000>;
 };
+
+test_i2c_stc31: stc31@d7 {
+	compatible = "sensirion,stc31";
+	reg = <0xd7>;
+	binary-gas = <0x0001>;
+};


### PR DESCRIPTION
## Summary
- Add Sensirion STC31 I2C driver under `drivers/sensor/sensirion/stc31/`
- Expose `SENSOR_CHAN_CO2` (ppm from vol%) and ambient temperature
- Support binary-gas selection via DT/`SENSOR_ATTR_STC31_BINARY_GAS`, RH/T/P compensation attributes, and FRC/soft-reset helpers
- Wire into Sensirion Kconfig/CMake, `build_all` I2C coverage (`stc31@d7`), and release notes 4.5

## Test plan
- [x] Hardware validation on RAK3112 + RAK19007 + RAK12008 (STC31 @0x2c, low-noise binary gas): measure path OK