### PR TITLE
bluetooth: le: audio: add LE connection type checks

### DIFF
--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -689,6 +689,10 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	for (size_t i = 0U; i < ARRAY_SIZE(aics_insts); i++) {
 		if (aics_insts[i].cli.conn == conn) {
 			aics_client_reset(&aics_insts[i]);

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -693,6 +693,10 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	for (size_t i = 0U; i < ARRAY_SIZE(aics_insts); i++) {
 		if (aics_insts[i].cli.conn == conn) {
 			aics_client_reset(&aics_insts[i]);

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1230,6 +1230,10 @@ int bt_ascs_disable_ase(struct bt_bap_ep *ep)
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	for (size_t i = 0U; i < ARRAY_SIZE(ascs.ase_pool); i++) {
 		struct bt_ascs_ase *ase = &ascs.ase_pool[i];
 

--- a/subsys/bluetooth/audio/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/bap_broadcast_assistant.c
@@ -976,10 +976,15 @@ static int broadcast_assistant_reset(struct bap_broadcast_assistant_instance *in
 
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
-	struct bap_broadcast_assistant_instance *inst = inst_by_conn(conn);
+	struct bap_broadcast_assistant_instance *inst;
 
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	inst = inst_by_conn(conn);
 	if (inst) {
 		(void)broadcast_assistant_reset(inst);
 	}

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -341,8 +341,8 @@ static void scan_delegator_security_changed(struct bt_conn *conn,
 					    bt_security_t level,
 					    enum bt_security_err err)
 {
-
-	if (err != 0 || level < BT_SECURITY_L2 || !bt_le_bond_exists(conn->id, &conn->le.dst)) {
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE) || err != 0 || level < BT_SECURITY_L2 ||
+	    !bt_le_bond_exists(conn->id, &conn->le.dst)) {
 		return;
 	}
 

--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -541,6 +541,10 @@ static void security_changed_cb(struct bt_conn *conn, bt_security_t level,
 	struct bt_conn_info conn_info;
 	__maybe_unused int err;
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	/* If there doesn't exist a bond, then this function is a no-op: We either add the bonded
 	 * address or trigger notification work for bonded devices
 	 */
@@ -593,6 +597,10 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 	struct bt_conn_info conn_info;
 	__maybe_unused int err;
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	if (!atomic_test_bit(scan_delegator_flags, SCAN_DELEGATOR_FLAG_REGISTERED)) {
 		/* Not yet registered, ignore callback */
 		return;
@@ -619,6 +627,10 @@ static void pairing_complete_cb(struct bt_conn *conn, bool bonded)
 {
 	struct bass_recv_state_internal *internal_state = &scan_delegator.recv_states[0];
 	__maybe_unused int err;
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
 
 	LOG_DBG("%s paired (%sbonded)", bt_conn_dst_str(conn), bonded ? "" : "not ");
 

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -4707,6 +4707,10 @@ static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn, const struct
 
 static void unicast_client_disconnected(struct bt_conn *conn, uint8_t reason)
 {
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	LOG_DBG("conn %p reason 0x%02x", conn, reason);
 
 	unicast_client_ep_reset(conn, reason);

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -4764,6 +4764,10 @@ static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn, const struct
 
 static void unicast_client_disconnected(struct bt_conn *conn, uint8_t reason)
 {
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	LOG_DBG("conn %p reason 0x%02x", conn, reason);
 
 	unicast_client_ep_reset(conn, reason);

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -266,9 +266,15 @@ bool bt_cap_common_stream_in_active_proc(const struct bt_cap_stream *cap_stream)
 
 void bt_cap_common_disconnected(struct bt_conn *conn, uint8_t reason)
 {
-	struct bt_cap_common_client *client = bt_cap_common_get_client_by_acl(conn);
+	struct bt_cap_common_client *client;
 
 	ARG_UNUSED(reason);
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	client = bt_cap_common_get_client_by_acl(conn);
 
 	LOG_DBG("conn %p disconnected", conn);
 

--- a/subsys/bluetooth/audio/cap_common.c
+++ b/subsys/bluetooth/audio/cap_common.c
@@ -267,9 +267,15 @@ bool bt_cap_common_stream_in_active_proc(const struct bt_cap_stream *cap_stream)
 static void bt_cap_common_disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	struct bt_cap_common_proc *active_proc_ptr = bt_cap_common_get_active_proc();
-	struct bt_cap_common_client *client = bt_cap_common_get_client_by_acl(conn);
+	struct bt_cap_common_client *client;
 
 	ARG_UNUSED(reason);
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	client = bt_cap_common_get_client_by_acl(conn);
 
 	LOG_DBG("conn %p disconnected", conn);
 

--- a/subsys/bluetooth/audio/ccp_call_control_client.c
+++ b/subsys/bluetooth/audio/ccp_call_control_client.c
@@ -91,7 +91,9 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 {
 	static bool cbs_registered;
 
-	ARG_UNUSED(conn);
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
 
 	/* We register the callbacks in the connected callback. That way we ensure that they are
 	 * registered before any procedures are completed or we receive any notifications, while
@@ -109,10 +111,15 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
-	struct bt_ccp_call_control_client *client = get_client_by_conn(conn);
+	struct bt_ccp_call_control_client *client;
 
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	client = get_client_by_conn(conn);
 	/* client->conn may be NULL */
 	if (client->conn == conn) {
 		bt_conn_drop(&client->conn);

--- a/subsys/bluetooth/audio/ccp_call_control_client.c
+++ b/subsys/bluetooth/audio/ccp_call_control_client.c
@@ -501,6 +501,10 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 
 	ARG_UNUSED(conn);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	/* We register the callbacks in the connected callback. That way we ensure that they are
 	 * registered before any procedures are completed or we receive any notifications, while
 	 * registering them as late as possible
@@ -529,9 +533,15 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
-	struct bt_ccp_call_control_client *client = get_client_by_conn(conn);
+	struct bt_ccp_call_control_client *client;
 
 	ARG_UNUSED(reason);
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	client = get_client_by_conn(conn);
 
 	/* client->conn may be NULL */
 	if (client->conn == conn) {

--- a/subsys/bluetooth/audio/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/csip_set_coordinator.c
@@ -1382,10 +1382,15 @@ static void csip_set_coordinator_reset(struct bt_csip_set_coordinator_inst *inst
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
-	struct bt_csip_set_coordinator_inst *inst = &client_insts[bt_conn_index(conn)];
+	struct bt_csip_set_coordinator_inst *inst;
 
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	inst = &client_insts[bt_conn_index(conn)];
 	if (inst->conn == conn) {
 		csip_set_coordinator_reset(inst);
 	}

--- a/subsys/bluetooth/audio/csip_set_member.c
+++ b/subsys/bluetooth/audio/csip_set_member.c
@@ -560,7 +560,7 @@ static void csip_security_changed(struct bt_conn *conn, bt_security_t level,
 
 	ARG_UNUSED(level);
 
-	if (err != 0 || conn->encrypt == 0) {
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE) || err != 0 || conn->encrypt == 0) {
 		return;
 	}
 
@@ -641,6 +641,10 @@ static void handle_csip_disconnect(struct bt_csip_set_member_svc_inst *svc_inst,
 
 static void csip_disconnected(struct bt_conn *conn, uint8_t reason)
 {
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	LOG_DBG("Disconnected: %s (reason %u)", bt_conn_dst_str(conn), reason);
 
 	if (!bt_le_bond_exists(conn->id, &conn->le.dst)) {
@@ -686,6 +690,10 @@ static void handle_csip_auth_complete(struct bt_csip_set_member_svc_inst *svc_in
 
 static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
 {
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	/**
 	 * If a pairing is complete for a bonded device, then we
 	 * 1) Store the connection pointer to later validate SIRK encryption

--- a/subsys/bluetooth/audio/gmap_client.c
+++ b/subsys/bluetooth/audio/gmap_client.c
@@ -88,10 +88,15 @@ static struct bt_gmap_client *client_by_conn(struct bt_conn *conn)
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
-	struct bt_gmap_client *gmap_cli = client_by_conn(conn);
+	struct bt_gmap_client *gmap_cli;
 
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	gmap_cli = client_by_conn(conn);
 	if (gmap_cli != NULL) {
 		bt_conn_drop(&gmap_cli->conn);
 	}

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -364,6 +364,10 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 	struct bt_conn_info info;
 	int ret;
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	LOG_DBG("conn %p level %d err %d", (void *)conn, level, err);
 
 	if (err != BT_SECURITY_ERR_SUCCESS) {
@@ -399,6 +403,10 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	struct has_client *client;
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	LOG_DBG("conn %p reason %d", (void *)conn, reason);
 
 	client = client_find_by_conn(conn);
@@ -411,6 +419,10 @@ static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
 			      const bt_addr_le_t *identity)
 {
 	struct has_client *client;
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
 
 	LOG_DBG("conn %p %s -> %s", (void *)conn, bt_addr_le_str(rpa), bt_addr_le_str(identity));
 

--- a/subsys/bluetooth/audio/has_client.c
+++ b/subsys/bluetooth/audio/has_client.c
@@ -1003,10 +1003,15 @@ int bt_has_client_preset_prev(struct bt_has *has, bool sync)
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
-	struct bt_has_client *inst = inst_by_conn(conn);
+	struct bt_has_client *inst;
 
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	inst = inst_by_conn(conn);
 	if (!inst) {
 		return;
 	}

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -1354,6 +1354,10 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	mcs_inst = lookup_inst_by_conn(conn);
 	if (mcs_inst != NULL) {
 		(void)reset_mcs_inst(mcs_inst);

--- a/subsys/bluetooth/audio/mcs.c
+++ b/subsys/bluetooth/audio/mcs.c
@@ -101,6 +101,10 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	__maybe_unused int err;
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	err = k_mutex_lock(&mcs_inst.mutex, MUTEX_TIMEOUT);
 	__ASSERT(err == 0, "Failed to lock mutex: %d", err);
 

--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -741,6 +741,10 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	if (mprx.remote_player.conn == conn) {
 		bt_conn_drop(&mprx.remote_player.conn);
 	}

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -509,10 +509,15 @@ static void micp_mic_ctlr_reset(struct bt_micp_mic_ctlr *mic_ctlr)
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
-	struct bt_micp_mic_ctlr *mic_ctlr = mic_ctlr_get_by_conn(conn);
+	struct bt_micp_mic_ctlr *mic_ctlr;
 
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	mic_ctlr = mic_ctlr_get_by_conn(conn);
 	if (mic_ctlr->conn == conn) {
 		micp_mic_ctlr_reset(mic_ctlr);
 	}

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -524,10 +524,15 @@ static void micp_mic_ctlr_reset(struct bt_micp_mic_ctlr *mic_ctlr)
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
-	struct bt_micp_mic_ctlr *mic_ctlr = mic_ctlr_get_by_conn(conn);
+	struct bt_micp_mic_ctlr *mic_ctlr;
 
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	mic_ctlr = mic_ctlr_get_by_conn(conn);
 	if (mic_ctlr->conn == conn) {
 		micp_mic_ctlr_reset(mic_ctlr);
 	}

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -1260,6 +1260,10 @@ static void deferred_nfy_work_handler(struct k_work *work)
 
 static void pacs_auth_pairing_complete(struct bt_conn *conn, bool bonded)
 {
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	LOG_DBG("%s paired (%sbonded)", bt_conn_dst_str(conn),
 		bonded ? "" : "not ");
 
@@ -1312,6 +1316,10 @@ static void pacs_security_changed(struct bt_conn *conn, bt_security_t level,
 	struct bt_conn_info info;
 	int err;
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	LOG_DBG("%s changed security level to %d", bt_conn_dst_str(conn), level);
 
 	if (sec_err != BT_SECURITY_ERR_SUCCESS || level <= BT_SECURITY_L1) {
@@ -1348,6 +1356,10 @@ static void pacs_disconnected(struct bt_conn *conn, uint8_t reason)
 	struct pacs_client *client;
 
 	ARG_UNUSED(reason);
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
 
 	client = client_lookup_conn(conn);
 	if (client == NULL) {

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -812,6 +812,10 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 #if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0
 	(void)memset(snks[bt_conn_index(conn)], 0, sizeof(snks[0]));
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0 */

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -811,6 +811,10 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 #if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0
 	(void)memset(snks[bt_conn_index(conn)], 0, sizeof(snks[0]));
 #endif /* CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0 */

--- a/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
+++ b/subsys/bluetooth/audio/shell/bap_broadcast_assistant.c
@@ -65,6 +65,10 @@ static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	(void)memset(&broadcast_assistant_recv_states[bt_conn_index(conn)], 0,
 		     sizeof(broadcast_assistant_recv_states[0]));
 }

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -508,6 +508,10 @@ static struct bt_le_per_adv_sync_cb pa_sync_cb = {
 
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	ARRAY_FOR_EACH_PTR(scan_delegator_sync_states, sync_state) {
 		if (sync_state->conn == conn) {
 			bt_conn_drop(&sync_state->conn);

--- a/subsys/bluetooth/audio/shell/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/shell/bap_scan_delegator.c
@@ -517,6 +517,10 @@ static struct bt_le_per_adv_sync_cb pa_sync_cb = {
 
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	ARRAY_FOR_EACH_PTR(scan_delegator_sync_states, sync_state) {
 		if (sync_state->conn == conn) {
 			bt_conn_drop(&sync_state->conn);

--- a/subsys/bluetooth/audio/shell/csip_set_coordinator.c
+++ b/subsys/bluetooth/audio/shell/csip_set_coordinator.c
@@ -56,6 +56,10 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 {
 	uint8_t conn_index;
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
 	if (err != 0) {
 		bt_shell_error("Failed to connect to %s (%u)", bt_conn_dst_str(conn), err);
 		return;
@@ -73,9 +77,15 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 
 static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
-	uint8_t conn_index = bt_conn_index(conn);
+	uint8_t conn_index;
 
 	ARG_UNUSED(reason);
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	conn_index = bt_conn_index(conn);
 
 	bt_conn_drop(&conns[conn_index]);
 }

--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -370,10 +370,16 @@ static struct tbs_inst *lookup_inst_by_uri_scheme(const uint8_t *uri, uint8_t ur
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
-	const uint8_t conn_index = bt_conn_index(conn);
+	uint8_t conn_index;
 	int err;
 
 	ARG_UNUSED(reason);
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	conn_index = bt_conn_index(conn);
 
 	err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 	if (err != 0) {

--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -369,10 +369,16 @@ static struct tbs_inst *lookup_inst_by_uri_scheme(const uint8_t *uri, uint8_t ur
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
-	const uint8_t conn_index = bt_conn_index(conn);
+	uint8_t conn_index;
 	int err;
 
 	ARG_UNUSED(reason);
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	conn_index = bt_conn_index(conn);
 
 	err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 	if (err != 0) {

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -866,10 +866,15 @@ static void vcp_vol_ctlr_reset(struct bt_vcp_vol_ctlr *vol_ctlr)
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
-	struct bt_vcp_vol_ctlr *vol_ctlr = vol_ctlr_get_by_conn(conn);
+	struct bt_vcp_vol_ctlr *vol_ctlr;
 
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	vol_ctlr = vol_ctlr_get_by_conn(conn);
 	if (vol_ctlr->conn == conn) {
 		vcp_vol_ctlr_reset(vol_ctlr);
 	}

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -896,10 +896,15 @@ static void vcp_vol_ctlr_reset(struct bt_vcp_vol_ctlr *vol_ctlr)
 
 static void disconnected(struct bt_conn *conn, uint8_t reason)
 {
-	struct bt_vcp_vol_ctlr *vol_ctlr = vol_ctlr_get_by_conn(conn);
+	struct bt_vcp_vol_ctlr *vol_ctlr;
 
 	ARG_UNUSED(reason);
 
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		return;
+	}
+
+	vol_ctlr = vol_ctlr_get_by_conn(conn);
 	if (vol_ctlr->conn == conn) {
 		vcp_vol_ctlr_reset(vol_ctlr);
 	}


### PR DESCRIPTION
There is an issue found that when both Bluetooth Classic and LE audio are enabled, the LE audio driver may cause an assertion when a Classic connection notification occurs because it doesn't check the connection type.

Add `bt_conn_is_le()` checks to Bluetooth audio subsystem callback functions to ensure they only process LE connections. This prevents potential issues when BR/EDR or other connection types trigger these callbacks.

The checks are added early in callback functions before accessing LE-specific connection fields or performing LE-specific operations.