### PR TITLE
dts: arm: ti: mspm33c: add GPIO/pinctrl nodes and LED wiring for lp_mspm33c321a

### DIFF
--- a/boards/ti/lp_mspm33c321a/lp_mspm33c321a.dts
+++ b/boards/ti/lp_mspm33c321a/lp_mspm33c321a.dts
@@ -6,15 +6,41 @@
 /dts-v1/;
 
 #include <ti/mspm33c/mspm33c321a.dtsi>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	model = "TI LP_MSPM33C321A/MSPM33C321A";
 	compatible = "ti,lp-mspm33c321a";
 
+	aliases {
+		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
+	};
+
 	chosen {
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,flash-controller = &flash_controller;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led0: led_0 {
+			gpios = <&gpioc 26 GPIO_ACTIVE_HIGH>;
+			label = "Red LED";
+		};
+
+		led1: led_1 {
+			gpios = <&gpioc 27 GPIO_ACTIVE_HIGH>;
+			label = "Green LED";
+		};
+
+		led2: led_2 {
+			gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
+			label = "Blue LED";
+		};
 	};
 };
 
@@ -23,5 +49,13 @@
 };
 
 &sram0 {
+	status = "okay";
+};
+
+&gpioa {
+	status = "okay";
+};
+
+&gpioc {
 	status = "okay";
 };

--- a/dts/arm/ti/mspm33c/mspm33c.dtsi
+++ b/dts/arm/ti/mspm33c/mspm33c.dtsi
@@ -39,6 +39,40 @@
 				#size-cells = <1>;
 			};
 		};
+
+		pinctrl: pin-controller@400f0000 {
+			compatible = "ti,mspm0-pinctrl";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x400f0000 0x6000>;
+
+			gpioa: gpio@400f0000 {
+				compatible = "ti,mspm0-gpio";
+				reg = <0x400f0000 0x2000>;
+				interrupts = <6 0>;
+				status = "disabled";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
+
+			gpiob: gpio@400f2000 {
+				compatible = "ti,mspm0-gpio";
+				reg = <0x400f2000 0x2000>;
+				interrupts = <7 0>;
+				status = "disabled";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
+
+			gpioc: gpio@400f4000 {
+				compatible = "ti,mspm0-gpio";
+				reg = <0x400f4000 0x2000>;
+				interrupts = <8 0>;
+				status = "disabled";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
+		};
 	};
 };
 


### PR DESCRIPTION
Add gpioa/gpiob/gpioc and their pin-controller parent to mspm33c.dtsi, and wire up the LP-MSPM33C321A LaunchPad's three LEDs via a gpio-leds node with matching aliases.

Register offsets and IRQs are taken from the MSPM33C321A TRM memory map and NVIC interrupt vector table. GPIO's register layout (DOUT/DOE/DIN/POLARITY/CPU_INT) is identical to MSPM0's GPIO_Regs, so the existing "ti,mspm0-gpio" and "ti,mspm0-pinctrl" compatibles are reused instead of introducing new bindings. It's the same GPIO IP block reused across the MSPM0 and MSPM33 family