### PR TITLE
drivers: peci_espi: Fix address error and incomplete header definition

### DIFF
--- a/drivers/peci/espi_peci.c
+++ b/drivers/peci/espi_peci.c
@@ -303,7 +303,7 @@ static int espi_peci_send(const struct device *dev, struct peci_msg *msg)
 	oob_hdr->byte_cnt = OOB_PACKET_HEADER_SIZE + oob_peci_req.wr_len;
 
 	oob_peci_req.cmd_code = msg->cmd_code;
-	oob_peci_req.addr = msg->oob_addr;
+	oob_peci_req.addr = msg->addr;
 	/* Tx length includes peci cmd code. So copy len-1 byte as data */
 	if (msg->tx_buffer.len > 1) {
 		memcpy(oob_peci_req.data, msg->tx_buffer.buf, msg->tx_buffer.len);

--- a/include/zephyr/drivers/peci.h
+++ b/include/zephyr/drivers/peci.h
@@ -53,7 +53,7 @@ enum peci_command_code {
 	PECI_CMD_WR_PCI_CFG0         = 0x65,
 	PECI_CMD_WR_PCI_CFG1         = 0x66,
 	PECI_CMD_RD_PKG_CFG0         = 0xA1,
-	PECI_CMD_RD_PKG_CFG1         = 0xA,
+	PECI_CMD_RD_PKG_CFG1         = 0xA2,
 	PECI_CMD_WR_PKG_CFG0         = 0xA5,
 	PECI_CMD_WR_PKG_CFG1         = 0xA6,
 	PECI_CMD_RD_IAMSR0           = 0xB1,


### PR DESCRIPTION
The driver was incorrectly using 'oob_addr' instead of 'addr' as the PECI index during transactions. Update the assignment to use the correct target address.

Additionally, add the missing definitions in the header file to complete the PECI over eSPI implementation.