### PR TITLE
drivers: usb: common: stm32: fix Kconfig options leak

### DIFF
--- a/drivers/usb/common/stm32/Kconfig
+++ b/drivers/usb/common/stm32/Kconfig
@@ -9,6 +9,8 @@ config STM32_USB_COMMON
 	  Enable compilation of STM32 USB common code.
 	  This option is selected by the USB drivers when appropriate.
 
+if STM32_USB_COMMON
+
 config STM32_HAS_EMBEDDED_FS_ULPI_OFF_QUIRK
 	def_bool y
 	# Hand-maintained list of series affected by the quirk.
@@ -46,4 +48,6 @@ module = STM32_USB_COMMON
 module-str = STM32 USB common code
 source "subsys/logging/Kconfig.template.log_config"
 
-endif  # SOC_FAMILY_STM32
+endif # STM32_USB_COMMON
+
+endif # SOC_FAMILY_STM32


### PR DESCRIPTION
The Kconfig options related to USB common code should be gated by the STM32_USB_COMMON option. Otherwise, they can appear in Kconfig of builds where USB is not enabled at all (notably, the options related to logging configuration were always leaked)

Note that this also reflects the CMake listfile structure where everything is gated by `STM32_USB_COMMON`:
https://github.com/zephyrproject-rtos/zephyr/blob/4269cd60816f0a0f6dc9099247c9f62b359939d9/drivers/usb/common/stm32/CMakeLists.txt#L4-L9