### PR TITLE
subsys: dfu: fix for dfu erasing beyond the partition

### DIFF
--- a/subsys/usb/device_next/class/usbd_dfu_flash.c
+++ b/subsys/usb/device_next/class/usbd_dfu_flash.c
@@ -95,7 +95,7 @@ static int dfu_flash_write(void *const priv,
 	int ret;
 
 	if (block == 0) {
-		if (flash_img_init(&data->fi_ctx)) {
+		if (flash_img_init_id(&data->fi_ctx, data->id)) {
 			return -EINVAL;
 		}
 


### PR DESCRIPTION
the dfu write flash function without this fix, when the partition is written, attempts to erase not only the partition to write but also what is following (i.e. next partition in flash)
This has been tested on STM32H5F5