### PR TITLE
drivers: pwm: mspm0: convert to native register access

### DIFF
--- a/boards/ti/lp_mspm0g3507/lp_mspm0g3507.dts
+++ b/boards/ti/lp_mspm0g3507/lp_mspm0g3507.dts
@@ -114,6 +114,15 @@
 	pinctrl-names = "default";
 };
 
+/*
+ * Slow TIMA0 to 39,062 Hz so LED PWM periods (20 ms - 1.68 s)
+ * fit in the 16-bit counter: 80 MHz / (div=8 * (prescaler+1)=256)
+ */
+&tima0 {
+	ti,clk-div = <8>;
+	ti,clk-prescaler = <255>;
+};
+
 &pwma0 {
 	status = "okay";
 
@@ -121,7 +130,7 @@
 	pinctrl-names = "default";
 	ti,cc-index = <0>;
 	ti,pwm-mode = "EDGE_ALIGN";
-	ti,period = <1000>;
+	ti,period = <3906>; /* ~100 ms at 39,062 Hz */
 };
 
 &canfd0 {

--- a/boards/ti/lp_mspm0g3507/lp_mspm0g3507.yaml
+++ b/boards/ti/lp_mspm0g3507/lp_mspm0g3507.yaml
@@ -15,4 +15,5 @@ supported:
   - dac
   - spi
   - vref
+  - pwm
 vendor: ti

--- a/boards/ti/lp_mspm0g3519/lp_mspm0g3519.dts
+++ b/boards/ti/lp_mspm0g3519/lp_mspm0g3519.dts
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/clock/mspm0_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	model = "TI LP_MSPM0G3519";
@@ -143,4 +144,19 @@
 	status = "okay";
 	pinctrl-0 = <&analog_pa23>;
 	pinctrl-names = "default";
+};
+
+&tima0 {
+	ti,clk-div = <8>;
+	ti,clk-prescaler = <255>;
+};
+
+&pwma0 {
+	status = "okay";
+
+	pinctrl-0 = <&tima0_ccp0_pa0>;
+	pinctrl-names = "default";
+	ti,cc-index = <0>;
+	ti,pwm-mode = "EDGE_ALIGN";
+	ti,period = <3906>; /* ~100 ms at 39,062 Hz */
 };

--- a/boards/ti/lp_mspm0g3519/lp_mspm0g3519.yaml
+++ b/boards/ti/lp_mspm0g3519/lp_mspm0g3519.yaml
@@ -13,6 +13,7 @@ supported:
   - gpio
   - can
   - dac
+  - pwm
   - spi
   - vref
 vendor: ti

--- a/boards/ti/lp_mspm0l2228/lp_mspm0l2228.dts
+++ b/boards/ti/lp_mspm0l2228/lp_mspm0l2228.dts
@@ -11,6 +11,7 @@
 #include <ti/mspm0/l/mspm0l222x-pinctrl.dtsi>
 #include <zephyr/dt-bindings/clock/mspm0_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	model = "TI LP_MSPM0L2228/MSPM0L2228";
@@ -112,4 +113,19 @@
 	status = "okay";
 	pinctrl-0 = <&analog_pa23>;
 	pinctrl-names = "default";
+};
+
+&tima0 {
+	ti,clk-div = <8>;
+	ti,clk-prescaler = <255>;
+};
+
+&pwma0 {
+	status = "okay";
+
+	pinctrl-0 = <&tima0_ccp0_pa0>;
+	pinctrl-names = "default";
+	ti,cc-index = <0>;
+	ti,pwm-mode = "EDGE_ALIGN";
+	ti,period = <3906>; /* ~100 ms at 39,062 Hz */
 };

--- a/boards/ti/lp_mspm0l2228/lp_mspm0l2228.yaml
+++ b/boards/ti/lp_mspm0l2228/lp_mspm0l2228.yaml
@@ -12,6 +12,7 @@ supported:
   - gpio
   - pinctrl
   - uart
+  - pwm
   - spi
   - vref
   - counter

--- a/drivers/pwm/Kconfig.mspm0
+++ b/drivers/pwm/Kconfig.mspm0
@@ -1,11 +1,11 @@
 # Copyright (c) 2024 Linumiz GmbH
+# Copyright (c) 2026 Texas Instruments Incorporated
 # SPDX-License-Identifier: Apache-2.0
 
 config PWM_MSPM0
-	bool "TI MSPM0 MCU family PWM driver"
+	bool "TI MSP GPTIMER PWM driver"
 	default y
 	depends on DT_HAS_TI_MSPM0_TIMER_PWM_ENABLED
 	select PINCTRL
-	select USE_MSPM0_DL_TIMER
 	help
-	  Enable TI MSPM0 MCU family PWM driver.
+	  Enable TI MSP MCU family PWM driver.

--- a/drivers/pwm/pwm_mspm0.c
+++ b/drivers/pwm/pwm_mspm0.c
@@ -190,8 +190,14 @@ BUILD_ASSERT(offsetof(struct mspm_gptimer_counter_regs, IFCTL_01) == 0x80U);
 #ifndef GPTIMER_CCACT_01_LACT_CCP_HIGH
 #define GPTIMER_CCACT_01_LACT_CCP_HIGH 0x00000008U
 #endif
+#ifndef GPTIMER_CCACT_01_LACT_CCP_LOW
+#define GPTIMER_CCACT_01_LACT_CCP_LOW 0x00000010U
+#endif
 #ifndef GPTIMER_CCACT_01_CDACT_CCP_LOW
 #define GPTIMER_CCACT_01_CDACT_CCP_LOW 0x00000080U
+#endif
+#ifndef GPTIMER_CCACT_01_CDACT_CCP_HIGH
+#define GPTIMER_CCACT_01_CDACT_CCP_HIGH 0x00000040U
 #endif
 #ifndef GPTIMER_CCACT_01_CUACT_CCP_LOW
 #define GPTIMER_CCACT_01_CUACT_CCP_LOW 0x00000400U
@@ -212,14 +218,14 @@ BUILD_ASSERT(offsetof(struct mspm_gptimer_counter_regs, IFCTL_01) == 0x80U);
 #endif
 
 /* CPU_INT interrupt bits — same position in IMASK, RIS, ICLR */
-#define GPTIMER_INT_ZERO_BIT     BIT(1)
+#define GPTIMER_INT_ZERO_BIT     BIT(0) /* Z: zero/underflow event */
 #define GPTIMER_INT_CCD_MASK(ch) BIT(4U + (ch))
 
 #define MSPM_PWM_CC_MAX 4U
 
 /* Replaces DL_TIMER_PWM_MODE */
 enum pwm_mspm_mode {
-	PWM_MSPM_EDGE_ALIGN,    /* down-count: LACT=HIGH, CDACT=LOW */
+	PWM_MSPM_EDGE_ALIGN,    /* down-count: LACT=LOW, CDACT=HIGH */
 	PWM_MSPM_EDGE_ALIGN_UP, /* up-count:   ZACT=HIGH, CUACT=LOW */
 	PWM_MSPM_CENTER_ALIGN,  /* up-down:    CUACT=HIGH, CDACT=LOW */
 };
@@ -260,6 +266,7 @@ struct pwm_mspm_data {
 	pwm_flags_t flags;
 	void *user_data;
 	bool is_synced;
+	bool armed;
 #endif
 };
 
@@ -320,15 +327,44 @@ static inline void mspm_pwm_write_ifctl(struct mspm_gptimer_regs *base, uint8_t 
 
 /* PWM output helpers */
 
+/*
+ * DOWN-counting EDGE_ALIGN: LACT (reload) and CDACT (CC match) toggle the
+ * pin so it's HIGH for exactly `pulse` ticks. At the 0% and 100% duty
+ * boundaries CC coincides with LOAD/reload, so LACT and CDACT would fire
+ * on the same tick — pick a single fixed action instead of toggling to
+ * avoid a spurious 1-tick glitch at either extreme.
+ */
+static inline uint32_t mspm_pwm_edge_align_ccact(uint32_t pulse, uint32_t load)
+{
+	if (pulse == 0U) {
+		return GPTIMER_CCACT_01_LACT_CCP_LOW;
+	}
+	if (pulse >= load) {
+		return GPTIMER_CCACT_01_LACT_CCP_HIGH;
+	}
+	return GPTIMER_CCACT_01_LACT_CCP_LOW | GPTIMER_CCACT_01_CDACT_CCP_HIGH;
+}
+
+/*
+ * UP-DOWN counting CENTER_ALIGN: LOAD holds period/2 (up-down counting
+ * doubles the effective tick count). CC must be the symmetric offset from
+ * the peak that gives `pulse` total ticks of HIGH time: load - pulse/2.
+ */
+static inline uint32_t mspm_pwm_center_align_cc(uint32_t load, uint32_t pulse)
+{
+	return load - (pulse / 2U);
+}
+
 static void mspm_pwm_setup_cc_chan(struct mspm_gptimer_regs *base, uint8_t ch,
 				   enum pwm_mspm_mode mode, uint32_t pulse)
 {
 	uint32_t ccact;
 	uint32_t ccupd;
+	uint32_t cc_val = pulse;
 
 	switch (mode) {
 	case PWM_MSPM_EDGE_ALIGN:
-		ccact = GPTIMER_CCACT_01_LACT_CCP_HIGH | GPTIMER_CCACT_01_CDACT_CCP_LOW;
+		ccact = mspm_pwm_edge_align_ccact(pulse, base->COUNTERREGS.LOAD);
 		ccupd = GPTIMER_CCCTL_01_CCUPD_ZERO_EVT;
 		break;
 	case PWM_MSPM_EDGE_ALIGN_UP:
@@ -338,6 +374,7 @@ static void mspm_pwm_setup_cc_chan(struct mspm_gptimer_regs *base, uint8_t ch,
 	default: /* PWM_MSPM_CENTER_ALIGN */
 		ccact = GPTIMER_CCACT_01_CUACT_CCP_HIGH | GPTIMER_CCACT_01_CDACT_CCP_LOW;
 		ccupd = GPTIMER_CCCTL_01_CCUPD_ZERO_LOAD_EVT;
+		cc_val = mspm_pwm_center_align_cc(base->COUNTERREGS.LOAD, pulse);
 		break;
 	}
 
@@ -345,7 +382,7 @@ static void mspm_pwm_setup_cc_chan(struct mspm_gptimer_regs *base, uint8_t ch,
 	mspm_pwm_write_ccctl(base, ch, GPTIMER_CCCTL_01_COC_COMPARE | ccupd);
 	mspm_pwm_write_octl(base, ch, 0U);
 	mspm_pwm_write_ifctl(base, ch, GPTIMER_IFCTL_01_ISEL_CCPX_INPUT);
-	mspm_pwm_write_cc(base, ch, pulse);
+	mspm_pwm_write_cc(base, ch, cc_val);
 }
 
 static void mspm_pwm_setup_output(const struct pwm_mspm_config *config, struct pwm_mspm_data *data)
@@ -367,6 +404,13 @@ static void mspm_pwm_setup_output(const struct pwm_mspm_config *config, struct p
 		break;
 	}
 
+	if (config->mode == PWM_MSPM_CENTER_ALIGN) {
+		/* Up-down counting doubles the effective tick count; LOAD
+		 * must hold period/2 to match pwm_mspm_set_cycles() and the
+		 * CC offset math in mspm_pwm_setup_cc_chan().
+		 */
+		data->period >>= 1;
+	}
 	base->COUNTERREGS.LOAD = data->period;
 
 	for (i = 0; i < config->cc_idx_cnt; i++) {
@@ -414,7 +458,21 @@ static int pwm_mspm_set_cycles(const struct device *dev, uint32_t channel, uint3
 	data->period = period;
 
 	base->COUNTERREGS.LOAD = period;
-	mspm_pwm_write_cc(base, config->cc_idx[channel], pulse_cycles);
+
+	if (config->mode == PWM_MSPM_CENTER_ALIGN) {
+		mspm_pwm_write_cc(base, config->cc_idx[channel],
+				  mspm_pwm_center_align_cc(period, pulse_cycles));
+	} else {
+		mspm_pwm_write_cc(base, config->cc_idx[channel], pulse_cycles);
+	}
+
+	if (config->mode == PWM_MSPM_EDGE_ALIGN) {
+		/* Re-evaluate the 0%/100% CDACT special case; see
+		 * mspm_pwm_edge_align_ccact() for why this is needed.
+		 */
+		mspm_pwm_write_ccact(base, config->cc_idx[channel],
+				     mspm_pwm_edge_align_ccact(pulse_cycles, period));
+	}
 
 	k_mutex_unlock(&data->lock);
 
@@ -437,17 +495,22 @@ static int pwm_mspm_get_cycles_per_sec(const struct device *dev, uint32_t channe
 
 #ifdef CONFIG_PWM_CAPTURE
 
+/*
+ * Which channel triggers the capture interrupt depends on cap_mode, not on
+ * the requested capture TYPE: PULSE_WIDTH always triggers on the rise
+ * channel (cc_idx[0]^1) regardless of PERIOD/PULSE/BOTH, since that's the
+ * only channel actually wired to fire an interrupt (mspm_pwm_setup_capture()
+ * never arms cc_idx[0]'s own interrupt in PULSE_WIDTH mode). Gating on the
+ * TYPE flags instead of cap_mode would arm the wrong, unconfigured channel
+ * for EDGE_TIME mode whenever PERIOD/PULSE/BOTH is requested there.
+ */
 static uint32_t mspm_pwm_cap_intr_mask(const struct pwm_mspm_config *config,
 				       const struct pwm_mspm_data *data)
 {
-	switch (data->flags & PWM_CAPTURE_TYPE_MASK) {
-	case PWM_CAPTURE_TYPE_PULSE:
-	case PWM_CAPTURE_TYPE_BOTH:
-	case PWM_CAPTURE_TYPE_PERIOD:
-		return GPTIMER_INT_CCD_MASK(!(config->cc_idx[0])) | GPTIMER_INT_ZERO_BIT;
-	default:
-		return GPTIMER_INT_CCD_MASK(config->cc_idx[0]);
+	if (data->cap_mode == PWM_MSPM_CAP_PULSE_WIDTH) {
+		return GPTIMER_INT_CCD_MASK(config->cc_idx[0] ^ 1U) | GPTIMER_INT_ZERO_BIT;
 	}
+	return GPTIMER_INT_CCD_MASK(config->cc_idx[0]);
 }
 
 static void mspm_pwm_setup_capture(const struct device *dev, const struct pwm_mspm_config *config,
@@ -467,6 +530,7 @@ static void mspm_pwm_setup_capture(const struct device *dev, const struct pwm_ms
 					     GPTIMER_CCCTL_01_CCOND_CC_TRIG_RISE);
 		mspm_pwm_write_ifctl(base, ch, isel);
 		base->COMMONREGS.CCPD &= ~GPTIMER_CCPD_OUTPUT_MASK(ch);
+		base->COUNTERREGS.CTRCTL = GPTIMER_CTRCTL_CM_DOWN | GPTIMER_CTRCTL_REPEAT_REPEAT_1;
 	} else {
 		uint8_t ch_fall = config->cc_idx[0];
 		uint8_t ch_rise = ch_fall ^ 1U;
@@ -504,16 +568,7 @@ static int pwm_mspm_configure_capture(const struct device *dev, uint32_t channel
 		return -EINVAL;
 	}
 
-	switch (flags & PWM_CAPTURE_TYPE_MASK) {
-	case PWM_CAPTURE_TYPE_PULSE:
-	case PWM_CAPTURE_TYPE_BOTH:
-	case PWM_CAPTURE_TYPE_PERIOD:
-		intr_mask = GPTIMER_INT_CCD_MASK(!(config->cc_idx[0])) | GPTIMER_INT_ZERO_BIT;
-		break;
-	default:
-		intr_mask = GPTIMER_INT_CCD_MASK(config->cc_idx[0]);
-		break;
-	}
+	intr_mask = mspm_pwm_cap_intr_mask(config, data);
 
 	k_mutex_lock(&data->lock, K_FOREVER);
 
@@ -526,6 +581,34 @@ static int pwm_mspm_configure_capture(const struct device *dev, uint32_t channel
 	data->flags = flags;
 	data->callback = cb;
 	data->user_data = user_data;
+
+	if (data->cap_mode == PWM_MSPM_CAP_PULSE_WIDTH) {
+		struct mspm_gptimer_regs *base = config->base;
+		uint8_t ch_fall = config->cc_idx[0];
+		uint8_t ch_rise = ch_fall ^ 1U;
+		bool inverted = flags & PWM_POLARITY_INVERTED;
+
+		/*
+		 * "pulse" is always computed as (time of ch_rise's edge) -
+		 * (time of ch_fall's edge). Under normal polarity that is
+		 * RISE-to-FALL, i.e. the HIGH duration. Under inverted
+		 * polarity the caller expects "pulse" to mean the LOW
+		 * duration instead, so swap which physical edge each
+		 * channel captures: ch_fall now triggers on RISE and
+		 * ch_rise now triggers on FALL, making the same
+		 * last_sample-minus-cc0 formula yield FALL-to-RISE (the
+		 * LOW duration). Mirrors the edge-swap approach used by
+		 * pwm_stm32's init_capture_channels().
+		 */
+		mspm_pwm_write_ccctl(base, ch_fall,
+				     GPTIMER_CCCTL_01_COC_CAPTURE |
+					     (inverted ? GPTIMER_CCCTL_01_CCOND_CC_TRIG_RISE
+						       : GPTIMER_CCCTL_01_CCOND_CC_TRIG_FALL));
+		mspm_pwm_write_ccctl(base, ch_rise,
+				     GPTIMER_CCCTL_01_COC_CAPTURE |
+					     (inverted ? GPTIMER_CCCTL_01_CCOND_CC_TRIG_FALL
+						       : GPTIMER_CCCTL_01_CCOND_CC_TRIG_RISE));
+	}
 
 	k_mutex_unlock(&data->lock);
 	return 0;
@@ -558,6 +641,15 @@ static int pwm_mspm_enable_capture(const struct device *dev, uint32_t channel)
 		return -EBUSY;
 	}
 
+	/*
+	 * Re-baseline on every arm, not just after disable_capture(): a
+	 * caller may legitimately re-enable without disabling first (e.g.
+	 * back-to-back single-shot captures), and the CC registers may hold
+	 * a stale capture from whatever ran before this arm.
+	 */
+	data->is_synced = false;
+	data->armed = false;
+
 	base->COUNTERREGS.CTR = data->period;
 	base->COUNTERREGS.CTRCTL |= GPTIMER_CTRCTL_EN_ENABLED;
 	base->CPU_INT.ICLR = intr_mask;
@@ -586,6 +678,7 @@ static int pwm_mspm_disable_capture(const struct device *dev, uint32_t channel)
 	base->CPU_INT.IMASK &= ~intr_mask;
 	base->COUNTERREGS.CTRCTL &= ~GPTIMER_CTRCTL_EN_MASK;
 	data->is_synced = false;
+	data->armed = false;
 
 	k_mutex_unlock(&data->lock);
 	return 0;
@@ -596,28 +689,56 @@ static void mspm_pwm_cc_isr(const struct device *dev)
 	const struct pwm_mspm_config *config = dev->config;
 	struct pwm_mspm_data *data = dev->data;
 	struct mspm_gptimer_regs *base = config->base;
+	uint32_t raw_ris;
 	uint32_t ris;
 	uint32_t cc0 = 0;
 	uint32_t cc1 = 0;
 	uint32_t period;
 	uint32_t pulse;
 
-	ris = base->CPU_INT.RIS & mspm_pwm_cap_intr_mask(config, data);
-	base->CPU_INT.ICLR = ris;
+	/*
+	 * Clear every pending bit (raw_ris), not just the ones relevant to
+	 * this capture (ris), so coincidental compare matches on unrelated
+	 * CC channels (e.g. CC4/CC5 defaulting to COMPARE mode with CC=0)
+	 * don't linger set in RIS indefinitely.
+	 */
+	raw_ris = base->CPU_INT.RIS;
+	ris = raw_ris & mspm_pwm_cap_intr_mask(config, data);
+	base->CPU_INT.ICLR = raw_ris;
 
 	if (!ris) {
 		return;
 	}
 
 	if (ris & GPTIMER_INT_ZERO_BIT) {
-		if (data->callback && !(data->flags & PWM_CAPTURE_MODE_CONTINUOUS)) {
-			data->callback(dev, 0, 0, 0, -ERANGE, data->user_data);
-			base->COUNTERREGS.CTRCTL &= ~GPTIMER_CTRCTL_EN_MASK;
+		if (!(data->flags & PWM_CAPTURE_MODE_CONTINUOUS)) {
+			if (data->callback) {
+				data->callback(dev, 0, 0, 0, -ERANGE, data->user_data);
+				base->COUNTERREGS.CTRCTL &= ~GPTIMER_CTRCTL_EN_MASK;
+			}
+			return;
 		}
-		return;
+		/*
+		 * Continuous mode: ZERO is just the free-running counter's
+		 * periodic wrap, not a capture error. A CC edge can land in
+		 * the same ISR entry (the wrap period doesn't divide evenly
+		 * into the PWM period) — fall through to process it instead
+		 * of dropping it.
+		 */
+		if (!(ris & ~GPTIMER_INT_ZERO_BIT)) {
+			return;
+		}
 	}
 
-	if (data->flags & PWM_CAPTURE_TYPE_PERIOD) {
+	if (data->cap_mode == PWM_MSPM_CAP_PULSE_WIDTH) {
+		/*
+		 * cc1 (rise-edge capture) is the interrupt trigger source for
+		 * PULSE_WIDTH mode and the sync/period/pulse anchor for every
+		 * capture type, not just PWM_CAPTURE_TYPE_PERIOD. Gating this
+		 * read on the PERIOD flag left cc1/last_sample stuck at 0 for
+		 * PULSE-only captures, making period compute to 0 and the
+		 * capture callback never fire (timeout).
+		 */
 		cc1 = mspm_pwm_read_cc(base, config->cc_idx[0] ^ 1U);
 	}
 
@@ -631,15 +752,34 @@ static void mspm_pwm_cc_isr(const struct device *dev)
 		cc0 = mspm_pwm_read_cc(base, config->cc_idx[0]);
 	}
 
+	if (data->cap_mode == PWM_MSPM_CAP_PULSE_WIDTH && !data->armed) {
+		/*
+		 * First full interval after arming can straddle a leftover
+		 * edge from whatever waveform ran before capture was armed
+		 * (e.g. pwm_set() right before enable_capture(), no settle
+		 * delay). Discard it and re-baseline instead of reporting
+		 * a bogus period/pulse.
+		 */
+		data->armed = true;
+		data->last_sample = cc1;
+		return;
+	}
+
 	if (!(data->flags & PWM_CAPTURE_MODE_CONTINUOUS)) {
 		base->COUNTERREGS.CTRCTL &= ~GPTIMER_CTRCTL_EN_MASK;
 		data->is_synced = false;
 	}
 
-	period = (data->last_sample - cc1 + UINT16_MAX) % UINT16_MAX;
-	pulse = (data->last_sample - cc0 + UINT16_MAX) % UINT16_MAX;
+	period = (data->last_sample - cc1) & 0xFFFFU;
+	pulse = (data->last_sample - cc0) & 0xFFFFU;
 
-	/* fixme: random intermittent cc0 > cc1 due to capture block timing */
+	/*
+	 * Residual defensive guard: cc0/cc1 should structurally never
+	 * produce pulse > period once armed (see the `armed` discard
+	 * above, which handles the one confirmed cause of this). Kept as
+	 * a graceful fallback for any unconfirmed capture-block timing
+	 * edge case rather than reporting a nonsensical pulse width.
+	 */
 	if (pulse > period) {
 		pulse -= period;
 	}
@@ -734,6 +874,10 @@ static DEVICE_API(pwm, pwm_mspm_driver_api) = {
 #define MSPM_PWM_IRQ_REGISTER(n)
 #endif
 
+/* Only output-capable instances (no ti,cc-mode) skip ISR registration. */
+#define MSPM_PWM_IRQ_REGISTER_IF_CAPTURE(n)                                                        \
+	COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_cc_mode), (MSPM_PWM_IRQ_REGISTER(n)), ())
+
 #define MSPM_PWM_MODE(tok) _CONCAT(PWM_MSPM_, tok)
 #define MSPM_CAP_MODE(tok) _CONCAT(PWM_MSPM_CAP_, tok)
 
@@ -754,7 +898,7 @@ static DEVICE_API(pwm, pwm_mspm_driver_api) = {
 			()))) };                                 \
                                                                                                    \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
-	MSPM_PWM_IRQ_REGISTER(n)                                                                   \
+	MSPM_PWM_IRQ_REGISTER_IF_CAPTURE(n)                                                        \
                                                                                                    \
 	static const struct pwm_mspm_config pwm_mspm_config_##n = {                                \
 		.base = (struct mspm_gptimer_regs *)DT_REG_ADDR(DT_INST_PARENT(n)),                \

--- a/drivers/pwm/pwm_mspm0.c
+++ b/drivers/pwm/pwm_mspm0.c
@@ -22,16 +22,16 @@
 LOG_MODULE_REGISTER(pwm_mspm0, CONFIG_PWM_LOG_LEVEL);
 
 /* capture and compare block count per timer */
-#define MSPM0_TIMER_CC_COUNT		2
-#define MSPM0_TIMER_CC_MAX		4
-#define MSPM0_CC_INTR_BIT_OFFSET	4
+#define MSPM_PWM_CC_COUNT		2
+#define MSPM_PWM_CC_MAX		4
+#define MSPM_CC_INTR_BIT_OFFSET	4
 
-enum mspm0_capture_mode {
-	CMODE_EDGE_TIME,
-	CMODE_PULSE_WIDTH
+enum pwm_mspm_cap_mode {
+	PWM_MSPM_CAP_EDGE_TIME,
+	PWM_MSPM_CAP_PULSE_WIDTH
 };
 
-struct pwm_mspm0_config {
+struct pwm_mspm_config {
 	const struct mspm0_sys_clock clock_subsys;
 	const struct pinctrl_dev_config *pincfg;
 	const struct device *clock_dev;
@@ -40,20 +40,20 @@ struct pwm_mspm0_config {
 #ifdef CONFIG_PWM_CAPTURE
 	void (*irq_config_func)(const struct device *dev);
 #endif
-	uint8_t	cc_idx[MSPM0_TIMER_CC_MAX];
+	uint8_t	cc_idx[MSPM_PWM_CC_MAX];
 	uint8_t cc_idx_cnt;
 	bool is_capture;
 };
 
-struct pwm_mspm0_data {
-	uint32_t pulse_cycle[MSPM0_TIMER_CC_MAX];
+struct pwm_mspm_data {
+	uint32_t pulse_cycle[MSPM_PWM_CC_MAX];
 	uint32_t period;
 	struct k_mutex lock;
 
 	DL_TIMER_PWM_MODE out_mode;
 #ifdef CONFIG_PWM_CAPTURE
 	uint32_t last_sample;
-	enum mspm0_capture_mode cmode;
+	enum pwm_mspm_cap_mode cmode;
 	pwm_capture_callback_handler_t callback;
 	pwm_flags_t flags;
 	void *user_data;
@@ -61,8 +61,8 @@ struct pwm_mspm0_data {
 #endif
 };
 
-static void mspm0_setup_pwm_out(const struct pwm_mspm0_config *config,
-				struct pwm_mspm0_data *data)
+static void mspm_pwm_setup_output(const struct pwm_mspm_config *config,
+				struct pwm_mspm_data *data)
 {
 	int i;
 	DL_Timer_PWMConfig pwmcfg = { 0 };
@@ -72,7 +72,7 @@ static void mspm0_setup_pwm_out(const struct pwm_mspm0_config *config,
 	pwmcfg.pwmMode = data->out_mode;
 
 	for (i = 0; i < config->cc_idx_cnt; i++) {
-		if (config->cc_idx[i] >= MSPM0_TIMER_CC_COUNT) {
+		if (config->cc_idx[i] >= MSPM_PWM_CC_COUNT) {
 			pwmcfg.isTimerWithFourCC = true;
 			break;
 		}
@@ -92,14 +92,14 @@ static void mspm0_setup_pwm_out(const struct pwm_mspm0_config *config,
 	DL_Timer_startCounter(config->base);
 }
 
-static int mspm0_pwm_set_cycles(const struct device *dev, uint32_t channel,
+static int pwm_mspm_set_cycles(const struct device *dev, uint32_t channel,
 			       uint32_t period_cycles, uint32_t pulse_cycles,
 			       pwm_flags_t flags)
 {
-	const struct pwm_mspm0_config *config = dev->config;
-	struct pwm_mspm0_data *data = dev->data;
+	const struct pwm_mspm_config *config = dev->config;
+	struct pwm_mspm_data *data = dev->data;
 
-	if (channel >= MSPM0_TIMER_CC_MAX) {
+	if (channel >= MSPM_PWM_CC_MAX) {
 		LOG_ERR("Invalid channel");
 		return -EINVAL;
 	}
@@ -128,10 +128,10 @@ static int mspm0_pwm_set_cycles(const struct device *dev, uint32_t channel,
 	return 0;
 }
 
-static int mspm0_pwm_get_cycles_per_sec(const struct device *dev,
+static int pwm_mspm_get_cycles_per_sec(const struct device *dev,
 					uint32_t channel, uint64_t *cycles)
 {
-	const struct pwm_mspm0_config *config = dev->config;
+	const struct pwm_mspm_config *config = dev->config;
 	DL_Timer_ClockConfig clkcfg;
 	uint32_t clock_rate;
 	int ret;
@@ -156,10 +156,10 @@ static int mspm0_pwm_get_cycles_per_sec(const struct device *dev,
 }
 
 #ifdef CONFIG_PWM_CAPTURE
-#define MSPM0_CTRCTL_CAC_CCCTL_ACOND(x) (x << 10)
+#define MSPM_CTRCTL_CAC_CCCTL_ACOND(x) (x << 10)
 
-static void mspm0_set_combined_mode(const struct pwm_mspm0_config *config,
-				    struct pwm_mspm0_data *data)
+static void mspm_pwm_set_combined_mode(const struct pwm_mspm_config *config,
+				    struct pwm_mspm_data *data)
 {
 	DL_Timer_setLoadValue(config->base, data->period);
 	DL_Timer_setCaptureCompareInput(config->base, 0,
@@ -185,18 +185,18 @@ static void mspm0_set_combined_mode(const struct pwm_mspm0_config *config,
 
 	DL_Timer_setCounterControl(config->base,
 				   DL_TIMER_CZC_CCCTL0_ZCOND,
-				   MSPM0_CTRCTL_CAC_CCCTL_ACOND(config->cc_idx[0]),
+				   MSPM_CTRCTL_CAC_CCCTL_ACOND(config->cc_idx[0]),
 				   DL_TIMER_CLC_CCCTL0_LCOND);
 
 	DL_Timer_setCounterRepeatMode(config->base, DL_TIMER_REPEAT_MODE_ENABLED);
 	DL_Timer_setCounterMode(config->base, DL_TIMER_COUNT_MODE_DOWN);
 }
 
-static void mspm0_setup_capture(const struct device *dev,
-				const struct pwm_mspm0_config *config,
-				struct pwm_mspm0_data *data)
+static void mspm_pwm_setup_capture(const struct device *dev,
+				const struct pwm_mspm_config *config,
+				struct pwm_mspm_data *data)
 {
-	if (data->cmode == CMODE_EDGE_TIME) {
+	if (data->cmode == PWM_MSPM_CAP_EDGE_TIME) {
 		DL_Timer_CaptureConfig cc_cfg = { 0 };
 
 		cc_cfg.inputChan = config->cc_idx[0];
@@ -205,21 +205,21 @@ static void mspm0_setup_capture(const struct device *dev,
 
 		DL_Timer_initCaptureMode(config->base, &cc_cfg);
 	} else {
-		mspm0_set_combined_mode(config, data);
+		mspm_pwm_set_combined_mode(config, data);
 	}
 
 	DL_Timer_enableClock(config->base);
 	config->irq_config_func(dev);
 }
 
-static int mspm0_capture_configure(const struct device *dev,
+static int pwm_mspm_configure_capture(const struct device *dev,
 				   uint32_t channel,
 				   pwm_flags_t flags,
 				   pwm_capture_callback_handler_t cb,
 				   void *user_data)
 {
-	const struct pwm_mspm0_config *config = dev->config;
-	struct pwm_mspm0_data *data = dev->data;
+	const struct pwm_mspm_config *config = dev->config;
+	struct pwm_mspm_data *data = dev->data;
 	uint32_t intr_mask;
 
 	if (config->is_capture != true ||
@@ -233,13 +233,13 @@ static int mspm0_capture_configure(const struct device *dev,
 	case PWM_CAPTURE_TYPE_BOTH:
 	case PWM_CAPTURE_TYPE_PERIOD:
 		/* CCD1/CCD0 event for capture index 0/1 respectively */
-		intr_mask = BIT(!(config->cc_idx[0]) + MSPM0_CC_INTR_BIT_OFFSET) |
+		intr_mask = BIT(!(config->cc_idx[0]) + MSPM_CC_INTR_BIT_OFFSET) |
 			    DL_TIMER_INTERRUPT_ZERO_EVENT;
 		break;
 
 	default:
 		/* edge time event */
-		intr_mask = BIT(config->cc_idx[0] + MSPM0_CC_INTR_BIT_OFFSET);
+		intr_mask = BIT(config->cc_idx[0] + MSPM_CC_INTR_BIT_OFFSET);
 	}
 
 	k_mutex_lock(&data->lock, K_FOREVER);
@@ -260,10 +260,10 @@ static int mspm0_capture_configure(const struct device *dev,
 	return 0;
 }
 
-static int mspm0_capture_enable(const struct device *dev, uint32_t channel)
+static int pwm_mspm_enable_capture(const struct device *dev, uint32_t channel)
 {
-	const struct pwm_mspm0_config *config = dev->config;
-	struct pwm_mspm0_data *data = dev->data;
+	const struct pwm_mspm_config *config = dev->config;
+	struct pwm_mspm_data *data = dev->data;
 	uint32_t intr_mask;
 
 	if (config->is_capture != true ||
@@ -282,13 +282,13 @@ static int mspm0_capture_enable(const struct device *dev, uint32_t channel)
 	case PWM_CAPTURE_TYPE_BOTH:
 	case PWM_CAPTURE_TYPE_PERIOD:
 		/* CCD1/CCD0 event for capture index 0/1 respectively */
-		intr_mask = BIT(!(config->cc_idx[0]) + MSPM0_CC_INTR_BIT_OFFSET) |
+		intr_mask = BIT(!(config->cc_idx[0]) + MSPM_CC_INTR_BIT_OFFSET) |
 			    DL_TIMER_INTERRUPT_ZERO_EVENT;
 		break;
 
 	default:
 		/* edge time event */
-		intr_mask = BIT(config->cc_idx[0] + MSPM0_CC_INTR_BIT_OFFSET);
+		intr_mask = BIT(config->cc_idx[0] + MSPM_CC_INTR_BIT_OFFSET);
 	}
 
 	k_mutex_lock(&data->lock, K_FOREVER);
@@ -309,10 +309,10 @@ static int mspm0_capture_enable(const struct device *dev, uint32_t channel)
 	return 0;
 }
 
-static int mspm0_capture_disable(const struct device *dev, uint32_t channel)
+static int pwm_mspm_disable_capture(const struct device *dev, uint32_t channel)
 {
-	const struct pwm_mspm0_config *config = dev->config;
-	struct pwm_mspm0_data *data = dev->data;
+	const struct pwm_mspm_config *config = dev->config;
+	struct pwm_mspm_data *data = dev->data;
 	uint32_t intr_mask;
 
 	if (config->is_capture != true ||
@@ -326,13 +326,13 @@ static int mspm0_capture_disable(const struct device *dev, uint32_t channel)
 	case PWM_CAPTURE_TYPE_BOTH:
 	case PWM_CAPTURE_TYPE_PERIOD:
 		/* CCD1/CCD0 event for capture index 0/1 respectively */
-		intr_mask = BIT(!(config->cc_idx[0]) + MSPM0_CC_INTR_BIT_OFFSET) |
+		intr_mask = BIT(!(config->cc_idx[0]) + MSPM_CC_INTR_BIT_OFFSET) |
 			    DL_TIMER_INTERRUPT_ZERO_EVENT;
 		break;
 
 	default:
 		/* edge time event */
-		intr_mask = BIT(config->cc_idx[0] + MSPM0_CC_INTR_BIT_OFFSET);
+		intr_mask = BIT(config->cc_idx[0] + MSPM_CC_INTR_BIT_OFFSET);
 	}
 
 	k_mutex_lock(&data->lock, K_FOREVER);
@@ -346,10 +346,10 @@ static int mspm0_capture_disable(const struct device *dev, uint32_t channel)
 }
 #endif
 
-static int pwm_mspm0_init(const struct device *dev)
+static int pwm_mspm_init(const struct device *dev)
 {
-	const struct pwm_mspm0_config *config = dev->config;
-	struct pwm_mspm0_data *data = dev->data;
+	const struct pwm_mspm_config *config = dev->config;
+	struct pwm_mspm_data *data = dev->data;
 	int err;
 
 	k_mutex_init(&data->lock);
@@ -374,30 +374,30 @@ static int pwm_mspm0_init(const struct device *dev)
 				(DL_Timer_ClockConfig *)&config->clk_config);
 	if (config->is_capture) {
 #ifdef CONFIG_PWM_CAPTURE
-		mspm0_setup_capture(dev, config, data);
+		mspm_pwm_setup_capture(dev, config, data);
 #endif
 	} else {
-		mspm0_setup_pwm_out(config, data);
+		mspm_pwm_setup_output(config, data);
 	}
 
 	return 0;
 }
 
-static DEVICE_API(pwm, pwm_mspm0_driver_api) = {
-	.set_cycles = mspm0_pwm_set_cycles,
-	.get_cycles_per_sec = mspm0_pwm_get_cycles_per_sec,
+static DEVICE_API(pwm, pwm_mspm_driver_api) = {
+	.set_cycles = pwm_mspm_set_cycles,
+	.get_cycles_per_sec = pwm_mspm_get_cycles_per_sec,
 #ifdef CONFIG_PWM_CAPTURE
-	.configure_capture = mspm0_capture_configure,
-	.enable_capture = mspm0_capture_enable,
-	.disable_capture = mspm0_capture_disable,
+	.configure_capture = pwm_mspm_configure_capture,
+	.enable_capture = pwm_mspm_enable_capture,
+	.disable_capture = pwm_mspm_disable_capture,
 #endif
 };
 
 #ifdef CONFIG_PWM_CAPTURE
-static void mspm0_cc_isr(const struct device *dev)
+static void mspm_pwm_cc_isr(const struct device *dev)
 {
-	const struct pwm_mspm0_config *config = dev->config;
-	struct pwm_mspm0_data *data = dev->data;
+	const struct pwm_mspm_config *config = dev->config;
+	struct pwm_mspm_data *data = dev->data;
 	uint32_t status;
 	uint32_t cc1 = 0;
 	uint32_t cc0 = 0;
@@ -431,14 +431,14 @@ static void mspm0_cc_isr(const struct device *dev)
 
 	/* ignore the unsynced counter value for pwm mode */
 	if (data->is_synced == false &&
-	    data->cmode != CMODE_EDGE_TIME) {
+	    data->cmode != PWM_MSPM_CAP_EDGE_TIME) {
 		data->last_sample = cc1;
 		data->is_synced = true;
 		return;
 	}
 
 	if (data->flags & PWM_CAPTURE_TYPE_PULSE ||
-	    data->cmode == CMODE_EDGE_TIME) {
+	    data->cmode == PWM_MSPM_CAP_EDGE_TIME) {
 		cc0 = DL_Timer_getCaptureCompareValue(config->base,
 						      config->cc_idx[0]);
 	}
@@ -464,49 +464,50 @@ static void mspm0_cc_isr(const struct device *dev)
 	data->last_sample = cc1;
 }
 
-#define MSP_CC_IRQ_REGISTER(n)							\
-	static void mspm0_cc_## n ##_irq_register(const struct device *dev)	\
+#define MSPM_PWM_IRQ_REGISTER(n)							\
+	static void mspm_pwm_##n##_irq_register(const struct device *dev)	\
 	{									\
-		const struct pwm_mspm0_config *config = dev->config;		\
+		const struct pwm_mspm_config *config = dev->config;		\
 		if (!config->is_capture) {					\
 			return;							\
 		}								\
 		IRQ_CONNECT(DT_IRQN(DT_INST_PARENT(n)),				\
-			    DT_IRQ(DT_INST_PARENT(n), priority), mspm0_cc_isr,	\
+			    DT_IRQ(DT_INST_PARENT(n), priority), mspm_pwm_cc_isr,	\
 			    DEVICE_DT_INST_GET(n), 0);				\
 		irq_enable(DT_IRQN(DT_INST_PARENT(n)));				\
 	}
 #else
-#define MSP_CC_IRQ_REGISTER(n)
+#define MSPM_PWM_IRQ_REGISTER(n)
 #endif
 
-#define MSPM0_PWM_MODE(mode)		DT_CAT(DL_TIMER_PWM_MODE_, mode)
-#define MSPM0_CAPTURE_MODE(mode)	DT_CAT(CMODE_, mode)
-#define MSPM0_CLK_DIV(div)		DT_CAT(DL_TIMER_CLOCK_DIVIDE_, div)
+#define MSPM_PWM_MODE(mode)		DT_CAT(DL_TIMER_PWM_MODE_, mode)
+#define MSPM_CAP_MODE(mode)	DT_CAT(CMODE_, mode)
+#define MSPM_CLK_DIV(div)		DT_CAT(DL_TIMER_CLOCK_DIVIDE_, div)
 
-#define MSPM0_CC_IDX_ARRAY(node_id, prop, idx)	\
+#define MSPM_CC_IDX_ARRAY(node_id, prop, idx)	\
 				 DT_PROP_BY_IDX(node_id, prop, idx),
 
-#define MSPM0_PWM_DATA(n)	\
-	.out_mode = MSPM0_PWM_MODE(DT_STRING_TOKEN(DT_DRV_INST(n),		\
+#define MSPM_PWM_DATA(n)	\
+	.out_mode = MSPM_PWM_MODE(DT_STRING_TOKEN(DT_DRV_INST(n),		\
 				   ti_pwm_mode)),
 
-#define MSPM0_CAPTURE_DATA(n)		\
+#define MSPM_CAPTURE_DATA(n)		\
 	IF_ENABLED(CONFIG_PWM_CAPTURE,	\
-	(.cmode = MSPM0_CAPTURE_MODE(DT_STRING_TOKEN(DT_DRV_INST(n), ti_cc_mode)),))
+	(.cmode = MSPM_CAP_MODE(DT_STRING_TOKEN(DT_DRV_INST(n), ti_cc_mode)),))
 
-#define PWM_DEVICE_INIT_MSPM0(n)						\
-	static struct pwm_mspm0_data pwm_mspm0_data_ ## n = {			\
+#define PWM_DEVICE_INIT_MSPM(n)						\
+	static struct pwm_mspm_data pwm_mspm_data_##n = {			\
 		.period = DT_PROP(DT_DRV_INST(n), ti_period),			\
 		COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_pwm_mode),	\
-			    (MSPM0_PWM_DATA(n)), ())				\
+			    (MSPM_PWM_DATA(n)), ())				\
 		COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_cc_mode),	\
-			    (MSPM0_CAPTURE_DATA(n)), ())			\
+			    (MSPM_CAPTURE_DATA(n)), ())			\
 	};									\
 	PINCTRL_DT_INST_DEFINE(n);						\
-	COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_cc_mode), (MSP_CC_IRQ_REGISTER(n)), ())	\
+	COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_cc_mode),	\
+		    (MSPM_PWM_IRQ_REGISTER(n)), ())				\
 										\
-	static const struct pwm_mspm0_config pwm_mspm0_config_ ## n = {		\
+	static const struct pwm_mspm_config pwm_mspm_config_##n = {		\
 		.base = (GPTIMER_Regs *)DT_REG_ADDR(DT_INST_PARENT(n)),		\
 		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR_BY_IDX(		\
 						DT_INST_PARENT(n), 0)),		\
@@ -516,29 +517,29 @@ static void mspm0_cc_isr(const struct device *dev)
 		},								\
 		.cc_idx = {							\
 			DT_INST_FOREACH_PROP_ELEM(n, ti_cc_index,		\
-						  MSPM0_CC_IDX_ARRAY)		\
+						  MSPM_CC_IDX_ARRAY)		\
 		},								\
 		.cc_idx_cnt = DT_INST_PROP_LEN(n, ti_cc_index),			\
 		.clk_config = {							\
 			.clockSel = MSPM0_CLOCK_PERIPH_REG_MASK(		\
 				DT_CLOCKS_CELL_BY_IDX(DT_INST_PARENT(n),	\
 						      0, clk)),			\
-			.divideRatio = MSPM0_CLK_DIV(DT_PROP(DT_INST_PARENT(n),	\
+			.divideRatio = MSPM_CLK_DIV(DT_PROP(DT_INST_PARENT(n),	\
 						     ti_clk_div)),		\
 			.prescale = DT_PROP(DT_INST_PARENT(n), ti_clk_prescaler),\
 		},								\
 		.is_capture = DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_cc_mode),	\
 		IF_ENABLED(CONFIG_PWM_CAPTURE,					\
 		(.irq_config_func = COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_cc_mode),	\
-						(mspm0_cc_## n ##_irq_register), (NULL))))	\
+						(mspm_pwm_##n##_irq_register), (NULL))))	\
 	};									\
 										\
 	DEVICE_DT_INST_DEFINE(n,						\
-			      pwm_mspm0_init,					\
+			      pwm_mspm_init,					\
 			      NULL,						\
-			      &pwm_mspm0_data_ ## n,				\
-			      &pwm_mspm0_config_ ## n,				\
+			      &pwm_mspm_data_##n,				\
+			      &pwm_mspm_config_##n,				\
 			      POST_KERNEL, CONFIG_PWM_INIT_PRIORITY,		\
-			      &pwm_mspm0_driver_api);
+			      &pwm_mspm_driver_api);
 
-DT_INST_FOREACH_STATUS_OKAY(PWM_DEVICE_INIT_MSPM0)
+DT_INST_FOREACH_STATUS_OKAY(PWM_DEVICE_INIT_MSPM)

--- a/drivers/pwm/pwm_mspm0.c
+++ b/drivers/pwm/pwm_mspm0.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025, Linumiz GmbH
+ * Copyright (c) 2026, Texas Instruments Incorporated
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,46 +15,247 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
-/* Driverlib includes */
-#include <ti/driverlib/dl_timera.h>
-#include <ti/driverlib/dl_timerg.h>
-#include <ti/driverlib/dl_timer.h>
-
 LOG_MODULE_REGISTER(pwm_mspm0, CONFIG_PWM_LOG_LEVEL);
 
-/* capture and compare block count per timer */
-#define MSPM_PWM_CC_COUNT		2
-#define MSPM_PWM_CC_MAX		4
-#define MSPM_CC_INTR_BIT_OFFSET	4
+/* GPTIMER register map — TRM Chapter 34 */
 
-enum pwm_mspm_cap_mode {
-	PWM_MSPM_CAP_EDGE_TIME,
-	PWM_MSPM_CAP_PULSE_WIDTH
+struct mspm_gptimer_gprcm {
+	volatile uint32_t PWREN;
+	volatile uint32_t RSTCTL;
+	uint32_t RESERVED[3];
+	volatile uint32_t STAT;
 };
 
+struct mspm_gptimer_int {
+	volatile uint32_t IIDX;
+	uint32_t RESERVED0;
+	volatile uint32_t IMASK;
+	uint32_t RESERVED1;
+	volatile uint32_t RIS;
+	uint32_t RESERVED2;
+	volatile uint32_t MIS;
+	uint32_t RESERVED3;
+	volatile uint32_t ISET;
+	uint32_t RESERVED4;
+	volatile uint32_t ICLR;
+};
+
+struct mspm_gptimer_common {
+	volatile uint32_t CCPD;
+	volatile uint32_t ODIS;
+	volatile uint32_t CCLKCTL;
+	volatile uint32_t CPS;
+	volatile uint32_t CPSV;
+	volatile uint32_t CTTRIGCTL;
+	uint32_t RESERVED0;
+	volatile uint32_t CTTRIG;
+	volatile uint32_t FSCTL;
+	volatile uint32_t GCTL;
+};
+
+/* Extended COUNTERREGS: covers CC control/action/filter registers for PWM */
+struct mspm_gptimer_counter_regs {
+	volatile uint32_t CTR;         /* +0x00 (0x1800) */
+	volatile uint32_t CTRCTL;      /* +0x04 */
+	volatile uint32_t LOAD;        /* +0x08 */
+	uint32_t RESERVED0;            /* +0x0C */
+	volatile uint32_t CC_01[2];    /* +0x10 — CC ch0/ch1 */
+	volatile uint32_t CC_23[2];    /* +0x18 — CC ch2/ch3 */
+	volatile uint32_t CC_45[2];    /* +0x20 */
+	uint32_t RESERVED1[2];         /* +0x28 */
+	volatile uint32_t CCCTL_01[2]; /* +0x30 (0x1830) */
+	volatile uint32_t CCCTL_23[2]; /* +0x38 */
+	volatile uint32_t CCCTL_45[2]; /* +0x40 */
+	uint32_t RESERVED2[2];         /* +0x48 */
+	volatile uint32_t OCTL_01[2];  /* +0x50 (0x1850) */
+	volatile uint32_t OCTL_23[2];  /* +0x58 */
+	uint32_t RESERVED3[4];         /* +0x60 */
+	volatile uint32_t CCACT_01[2]; /* +0x70 (0x1870) */
+	volatile uint32_t CCACT_23[2]; /* +0x78 */
+	volatile uint32_t IFCTL_01[2]; /* +0x80 (0x1880) */
+	volatile uint32_t IFCTL_23[2]; /* +0x88 */
+};
+
+struct mspm_gptimer_regs {
+	uint32_t RESERVED0[256];
+	volatile uint32_t FSUB_0;
+	volatile uint32_t FSUB_1;
+	uint32_t RESERVED1[15];
+	volatile uint32_t FPUB_0;
+	volatile uint32_t FPUB_1;
+	uint32_t RESERVED2[237];
+	struct mspm_gptimer_gprcm GPRCM; /* 0x800 */
+	uint32_t RESERVED3[506];
+	volatile uint32_t CLKDIV; /* 0x1000 */
+	uint32_t RESERVED4;
+	volatile uint32_t CLKSEL; /* 0x1008 */
+	uint32_t RESERVED5[3];
+	volatile uint32_t PDBGCTL;
+	uint32_t RESERVED6;
+	struct mspm_gptimer_int CPU_INT; /* 0x1020 */
+	uint32_t RESERVED7;
+	struct mspm_gptimer_int GEN_EVENT0; /* 0x1050 */
+	uint32_t RESERVED8;
+	struct mspm_gptimer_int GEN_EVENT1; /* 0x1080 */
+	uint32_t RESERVED9[13];
+	volatile uint32_t EVT_MODE;
+	uint32_t RESERVED10[6];
+	volatile uint32_t DESC;
+	struct mspm_gptimer_common COMMONREGS; /* 0x1100 */
+	uint32_t RESERVED11[438];
+	struct mspm_gptimer_counter_regs COUNTERREGS; /* 0x1800 */
+};
+
+BUILD_ASSERT(offsetof(struct mspm_gptimer_regs, GPRCM) == 0x0800U);
+BUILD_ASSERT(offsetof(struct mspm_gptimer_regs, CLKDIV) == 0x1000U);
+BUILD_ASSERT(offsetof(struct mspm_gptimer_regs, CPU_INT) == 0x1020U);
+BUILD_ASSERT(offsetof(struct mspm_gptimer_regs, COMMONREGS) == 0x1100U);
+BUILD_ASSERT(offsetof(struct mspm_gptimer_regs, COUNTERREGS) == 0x1800U);
+BUILD_ASSERT(offsetof(struct mspm_gptimer_counter_regs, CCCTL_01) == 0x30U);
+BUILD_ASSERT(offsetof(struct mspm_gptimer_counter_regs, CCACT_01) == 0x70U);
+BUILD_ASSERT(offsetof(struct mspm_gptimer_counter_regs, IFCTL_01) == 0x80U);
+
+/* GPRCM.PWREN */
+#ifndef GPTIMER_PWREN_KEY_UNLOCK_W
+#define GPTIMER_PWREN_KEY_UNLOCK_W 0x26000000U
+#endif
+#ifndef GPTIMER_PWREN_ENABLE_ENABLE
+#define GPTIMER_PWREN_ENABLE_ENABLE 0x00000001U
+#endif
+
+/* GPRCM.RSTCTL */
+#ifndef GPTIMER_RSTCTL_KEY_UNLOCK_W
+#define GPTIMER_RSTCTL_KEY_UNLOCK_W 0xB1000000U
+#endif
+#ifndef GPTIMER_RSTCTL_RESETSTKYCLR_CLR
+#define GPTIMER_RSTCTL_RESETSTKYCLR_CLR 0x00000002U
+#endif
+#ifndef GPTIMER_RSTCTL_RESETASSERT_ASSERT
+#define GPTIMER_RSTCTL_RESETASSERT_ASSERT 0x00000001U
+#endif
+
+/* COUNTERREGS.CTRCTL */
+#ifndef GPTIMER_CTRCTL_EN_ENABLED
+#define GPTIMER_CTRCTL_EN_ENABLED 0x00000001U
+#endif
+#ifndef GPTIMER_CTRCTL_EN_MASK
+#define GPTIMER_CTRCTL_EN_MASK 0x00000001U
+#endif
+#ifndef GPTIMER_CTRCTL_REPEAT_REPEAT_1
+#define GPTIMER_CTRCTL_REPEAT_REPEAT_1 0x00000002U
+#endif
+#ifndef GPTIMER_CTRCTL_CM_DOWN
+#define GPTIMER_CTRCTL_CM_DOWN 0x00000000U
+#endif
+#ifndef GPTIMER_CTRCTL_CM_UP_DOWN
+#define GPTIMER_CTRCTL_CM_UP_DOWN 0x00000010U
+#endif
+#ifndef GPTIMER_CTRCTL_CM_UP
+#define GPTIMER_CTRCTL_CM_UP 0x00000020U
+#endif
+#ifndef GPTIMER_CTRCTL_CVAE_ZEROVAL
+#define GPTIMER_CTRCTL_CVAE_ZEROVAL 0x20000000U
+#endif
+
+/* COMMONREGS */
+#ifndef GPTIMER_CCLKCTL_CLKEN_ENABLED
+#define GPTIMER_CCLKCTL_CLKEN_ENABLED 0x00000001U
+#endif
+#define GPTIMER_CCPD_OUTPUT_MASK(ch) BIT(ch)
+
+/* CCCTL_01/23 */
+#ifndef GPTIMER_CCCTL_01_COC_COMPARE
+#define GPTIMER_CCCTL_01_COC_COMPARE 0x00000000U
+#endif
+#ifndef GPTIMER_CCCTL_01_COC_CAPTURE
+#define GPTIMER_CCCTL_01_COC_CAPTURE 0x00020000U
+#endif
+#ifndef GPTIMER_CCCTL_01_CCUPD_ZERO_EVT
+#define GPTIMER_CCCTL_01_CCUPD_ZERO_EVT 0x00040000U
+#endif
+#ifndef GPTIMER_CCCTL_01_CCUPD_ZERO_LOAD_EVT
+#define GPTIMER_CCCTL_01_CCUPD_ZERO_LOAD_EVT 0x00100000U
+#endif
+#ifndef GPTIMER_CCCTL_01_CCOND_CC_TRIG_RISE
+#define GPTIMER_CCCTL_01_CCOND_CC_TRIG_RISE 0x00000001U
+#endif
+#ifndef GPTIMER_CCCTL_01_CCOND_CC_TRIG_FALL
+#define GPTIMER_CCCTL_01_CCOND_CC_TRIG_FALL 0x00000002U
+#endif
+
+/* CCACT_01/23 — output pin actions */
+#ifndef GPTIMER_CCACT_01_ZACT_CCP_HIGH
+#define GPTIMER_CCACT_01_ZACT_CCP_HIGH 0x00000001U
+#endif
+#ifndef GPTIMER_CCACT_01_LACT_CCP_HIGH
+#define GPTIMER_CCACT_01_LACT_CCP_HIGH 0x00000008U
+#endif
+#ifndef GPTIMER_CCACT_01_CDACT_CCP_LOW
+#define GPTIMER_CCACT_01_CDACT_CCP_LOW 0x00000080U
+#endif
+#ifndef GPTIMER_CCACT_01_CUACT_CCP_LOW
+#define GPTIMER_CCACT_01_CUACT_CCP_LOW 0x00000400U
+#endif
+#ifndef GPTIMER_CCACT_01_CUACT_CCP_HIGH
+#define GPTIMER_CCACT_01_CUACT_CCP_HIGH 0x00000200U
+#endif
+
+/* IFCTL_01/23 ISEL */
+#ifndef GPTIMER_IFCTL_01_ISEL_CCPX_INPUT
+#define GPTIMER_IFCTL_01_ISEL_CCPX_INPUT 0x00000000U
+#endif
+#ifndef GPTIMER_IFCTL_01_ISEL_CCPX_INPUT_PAIR
+#define GPTIMER_IFCTL_01_ISEL_CCPX_INPUT_PAIR 0x00000001U
+#endif
+#ifndef GPTIMER_IFCTL_01_ISEL_CCP0_INPUT
+#define GPTIMER_IFCTL_01_ISEL_CCP0_INPUT 0x00000002U
+#endif
+
+/* CPU_INT interrupt bits — same position in IMASK, RIS, ICLR */
+#define GPTIMER_INT_ZERO_BIT     BIT(1)
+#define GPTIMER_INT_CCD_MASK(ch) BIT(4U + (ch))
+
+#define MSPM_PWM_CC_MAX 4U
+
+/* Replaces DL_TIMER_PWM_MODE */
+enum pwm_mspm_mode {
+	PWM_MSPM_EDGE_ALIGN,    /* down-count: LACT=HIGH, CDACT=LOW */
+	PWM_MSPM_EDGE_ALIGN_UP, /* up-count:   ZACT=HIGH, CUACT=LOW */
+	PWM_MSPM_CENTER_ALIGN,  /* up-down:    CUACT=HIGH, CDACT=LOW */
+};
+
+#ifdef CONFIG_PWM_CAPTURE
+enum pwm_mspm_cap_mode {
+	PWM_MSPM_CAP_EDGE_TIME,
+	PWM_MSPM_CAP_PULSE_WIDTH,
+};
+#endif
+
 struct pwm_mspm_config {
-	const struct mspm0_sys_clock clock_subsys;
-	const struct pinctrl_dev_config *pincfg;
+	struct mspm_gptimer_regs *base;
 	const struct device *clock_dev;
-	GPTIMER_Regs *base;
-	DL_Timer_ClockConfig clk_config;
+	const struct pinctrl_dev_config *pincfg;
+	struct mspm0_sys_clock clock_subsys;
+	uint32_t clk_sel;
+	uint32_t clk_div_reg; /* CLKDIV value: ti_clk_div - 1 */
+	uint8_t prescaler;
+	enum pwm_mspm_mode mode;
+	uint8_t cc_idx[MSPM_PWM_CC_MAX];
+	uint8_t cc_idx_cnt;
+	bool is_capture;
 #ifdef CONFIG_PWM_CAPTURE
 	void (*irq_config_func)(const struct device *dev);
 #endif
-	uint8_t	cc_idx[MSPM_PWM_CC_MAX];
-	uint8_t cc_idx_cnt;
-	bool is_capture;
 };
 
 struct pwm_mspm_data {
-	uint32_t pulse_cycle[MSPM_PWM_CC_MAX];
 	uint32_t period;
+	uint32_t pulse[MSPM_PWM_CC_MAX];
+	uint32_t freq_hz;
 	struct k_mutex lock;
-
-	DL_TIMER_PWM_MODE out_mode;
 #ifdef CONFIG_PWM_CAPTURE
 	uint32_t last_sample;
-	enum pwm_mspm_cap_mode cmode;
+	enum pwm_mspm_cap_mode cap_mode;
 	pwm_capture_callback_handler_t callback;
 	pwm_flags_t flags;
 	void *user_data;
@@ -61,46 +263,137 @@ struct pwm_mspm_data {
 #endif
 };
 
-static void mspm_pwm_setup_output(const struct pwm_mspm_config *config,
-				struct pwm_mspm_data *data)
+/* Register helpers */
+
+static inline void mspm_pwm_write_cc(struct mspm_gptimer_regs *base, uint8_t ch, uint32_t val)
 {
-	int i;
-	DL_Timer_PWMConfig pwmcfg = { 0 };
-	uint8_t ccdir_mask = 0;
-
-	pwmcfg.period = data->period;
-	pwmcfg.pwmMode = data->out_mode;
-
-	for (i = 0; i < config->cc_idx_cnt; i++) {
-		if (config->cc_idx[i] >= MSPM_PWM_CC_COUNT) {
-			pwmcfg.isTimerWithFourCC = true;
-			break;
-		}
+	if (ch < 2U) {
+		base->COUNTERREGS.CC_01[ch] = val;
+	} else {
+		base->COUNTERREGS.CC_23[ch - 2U] = val;
 	}
-
-	DL_Timer_initPWMMode(config->base, &pwmcfg);
-
-	for (i = 0; i < config->cc_idx_cnt; i++) {
-		DL_Timer_setCaptureCompareValue(config->base,
-						data->pulse_cycle[i],
-						config->cc_idx[i]);
-		ccdir_mask |= 1 << config->cc_idx[i];
-	}
-
-	DL_Timer_enableClock(config->base);
-	DL_Timer_setCCPDirection(config->base, ccdir_mask);
-	DL_Timer_startCounter(config->base);
 }
 
-static int pwm_mspm_set_cycles(const struct device *dev, uint32_t channel,
-			       uint32_t period_cycles, uint32_t pulse_cycles,
-			       pwm_flags_t flags)
+static inline uint32_t mspm_pwm_read_cc(struct mspm_gptimer_regs *base, uint8_t ch)
+{
+	if (ch < 2U) {
+		return base->COUNTERREGS.CC_01[ch];
+	}
+	return base->COUNTERREGS.CC_23[ch - 2U];
+}
+
+static inline void mspm_pwm_write_ccctl(struct mspm_gptimer_regs *base, uint8_t ch, uint32_t val)
+{
+	if (ch < 2U) {
+		base->COUNTERREGS.CCCTL_01[ch] = val;
+	} else {
+		base->COUNTERREGS.CCCTL_23[ch - 2U] = val;
+	}
+}
+
+static inline void mspm_pwm_write_ccact(struct mspm_gptimer_regs *base, uint8_t ch, uint32_t val)
+{
+	if (ch < 2U) {
+		base->COUNTERREGS.CCACT_01[ch] = val;
+	} else {
+		base->COUNTERREGS.CCACT_23[ch - 2U] = val;
+	}
+}
+
+static inline void mspm_pwm_write_octl(struct mspm_gptimer_regs *base, uint8_t ch, uint32_t val)
+{
+	if (ch < 2U) {
+		base->COUNTERREGS.OCTL_01[ch] = val;
+	} else {
+		base->COUNTERREGS.OCTL_23[ch - 2U] = val;
+	}
+}
+
+static inline void mspm_pwm_write_ifctl(struct mspm_gptimer_regs *base, uint8_t ch, uint32_t val)
+{
+	if (ch < 2U) {
+		base->COUNTERREGS.IFCTL_01[ch] = val;
+	} else {
+		base->COUNTERREGS.IFCTL_23[ch - 2U] = val;
+	}
+}
+
+/* PWM output helpers */
+
+static void mspm_pwm_setup_cc_chan(struct mspm_gptimer_regs *base, uint8_t ch,
+				   enum pwm_mspm_mode mode, uint32_t pulse)
+{
+	uint32_t ccact;
+	uint32_t ccupd;
+
+	switch (mode) {
+	case PWM_MSPM_EDGE_ALIGN:
+		ccact = GPTIMER_CCACT_01_LACT_CCP_HIGH | GPTIMER_CCACT_01_CDACT_CCP_LOW;
+		ccupd = GPTIMER_CCCTL_01_CCUPD_ZERO_EVT;
+		break;
+	case PWM_MSPM_EDGE_ALIGN_UP:
+		ccact = GPTIMER_CCACT_01_ZACT_CCP_HIGH | GPTIMER_CCACT_01_CUACT_CCP_LOW;
+		ccupd = GPTIMER_CCCTL_01_CCUPD_ZERO_EVT;
+		break;
+	default: /* PWM_MSPM_CENTER_ALIGN */
+		ccact = GPTIMER_CCACT_01_CUACT_CCP_HIGH | GPTIMER_CCACT_01_CDACT_CCP_LOW;
+		ccupd = GPTIMER_CCCTL_01_CCUPD_ZERO_LOAD_EVT;
+		break;
+	}
+
+	mspm_pwm_write_ccact(base, ch, ccact);
+	mspm_pwm_write_ccctl(base, ch, GPTIMER_CCCTL_01_COC_COMPARE | ccupd);
+	mspm_pwm_write_octl(base, ch, 0U);
+	mspm_pwm_write_ifctl(base, ch, GPTIMER_IFCTL_01_ISEL_CCPX_INPUT);
+	mspm_pwm_write_cc(base, ch, pulse);
+}
+
+static void mspm_pwm_setup_output(const struct pwm_mspm_config *config, struct pwm_mspm_data *data)
+{
+	struct mspm_gptimer_regs *base = config->base;
+	uint32_t ctrctl;
+	uint32_t ccpd_mask = 0U;
+	int i;
+
+	switch (config->mode) {
+	case PWM_MSPM_EDGE_ALIGN:
+		ctrctl = GPTIMER_CTRCTL_CM_DOWN;
+		break;
+	case PWM_MSPM_EDGE_ALIGN_UP:
+		ctrctl = GPTIMER_CTRCTL_CM_UP | GPTIMER_CTRCTL_CVAE_ZEROVAL;
+		break;
+	default: /* PWM_MSPM_CENTER_ALIGN */
+		ctrctl = GPTIMER_CTRCTL_CM_UP_DOWN;
+		break;
+	}
+
+	base->COUNTERREGS.LOAD = data->period;
+
+	for (i = 0; i < config->cc_idx_cnt; i++) {
+		uint8_t ch = config->cc_idx[i];
+
+		mspm_pwm_setup_cc_chan(base, ch, config->mode, data->pulse[i]);
+		ccpd_mask |= GPTIMER_CCPD_OUTPUT_MASK(ch);
+	}
+
+	base->COMMONREGS.CCPD |= ccpd_mask;
+	base->COMMONREGS.CCLKCTL = GPTIMER_CCLKCTL_CLKEN_ENABLED;
+	base->COUNTERREGS.CTRCTL =
+		ctrctl | GPTIMER_CTRCTL_REPEAT_REPEAT_1 | GPTIMER_CTRCTL_EN_ENABLED;
+}
+
+/* Zephyr PWM API */
+
+static int pwm_mspm_set_cycles(const struct device *dev, uint32_t channel, uint32_t period_cycles,
+			       uint32_t pulse_cycles, pwm_flags_t flags)
 {
 	const struct pwm_mspm_config *config = dev->config;
 	struct pwm_mspm_data *data = dev->data;
+	struct mspm_gptimer_regs *base = config->base;
+	uint32_t period;
 
-	if (channel >= MSPM_PWM_CC_MAX) {
-		LOG_ERR("Invalid channel");
+	if (channel >= config->cc_idx_cnt) {
+		LOG_ERR("Invalid channel %u", channel);
 		return -EINVAL;
 	}
 
@@ -109,122 +402,105 @@ static int pwm_mspm_set_cycles(const struct device *dev, uint32_t channel,
 		return -ENOTSUP;
 	}
 
-	k_mutex_lock(&data->lock, K_FOREVER);
+	period = (config->mode == PWM_MSPM_CENTER_ALIGN) ? (period_cycles >> 1) : period_cycles;
 
-	data->pulse_cycle[channel] = pulse_cycles;
-	data->period = period_cycles;
-
-	if (data->out_mode == DL_TIMER_PWM_MODE_CENTER_ALIGN) {
-		data->period = period_cycles >> 1;
+	if (flags & PWM_POLARITY_INVERTED) {
+		pulse_cycles = period_cycles - pulse_cycles;
 	}
 
-	DL_Timer_setLoadValue(config->base, data->period);
-	DL_Timer_setCaptureCompareValue(config->base,
-					data->pulse_cycle[channel],
-					config->cc_idx[channel]);
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	data->pulse[channel] = pulse_cycles;
+	data->period = period;
+
+	base->COUNTERREGS.LOAD = period;
+	mspm_pwm_write_cc(base, config->cc_idx[channel], pulse_cycles);
 
 	k_mutex_unlock(&data->lock);
 
 	return 0;
 }
 
-static int pwm_mspm_get_cycles_per_sec(const struct device *dev,
-					uint32_t channel, uint64_t *cycles)
+static int pwm_mspm_get_cycles_per_sec(const struct device *dev, uint32_t channel, uint64_t *cycles)
 {
-	const struct pwm_mspm_config *config = dev->config;
-	DL_Timer_ClockConfig clkcfg;
-	uint32_t clock_rate;
-	int ret;
+	ARG_UNUSED(channel);
 
 	if (cycles == NULL) {
 		return -EINVAL;
 	}
 
-	ret = clock_control_get_rate(config->clock_dev,
-				(clock_control_subsys_t)&config->clock_subsys,
-				&clock_rate);
-	if (ret != 0) {
-		LOG_ERR("clk get rate err %d", ret);
-		return ret;
-	}
-
-	DL_Timer_getClockConfig(config->base, &clkcfg);
-	*cycles = clock_rate /
-			((clkcfg.divideRatio + 1) * (clkcfg.prescale + 1));
-
+	*cycles = ((const struct pwm_mspm_data *)dev->data)->freq_hz;
 	return 0;
 }
 
+/* Capture support */
+
 #ifdef CONFIG_PWM_CAPTURE
-#define MSPM_CTRCTL_CAC_CCCTL_ACOND(x) (x << 10)
 
-static void mspm_pwm_set_combined_mode(const struct pwm_mspm_config *config,
-				    struct pwm_mspm_data *data)
+static uint32_t mspm_pwm_cap_intr_mask(const struct pwm_mspm_config *config,
+				       const struct pwm_mspm_data *data)
 {
-	DL_Timer_setLoadValue(config->base, data->period);
-	DL_Timer_setCaptureCompareInput(config->base, 0,
-					((config->cc_idx[0] & 0x1) ?
-					 DL_TIMER_CC_IN_SEL_CCPX : DL_TIMER_CC_IN_SEL_CCP0),
-					config->cc_idx[0]);
-
-	DL_Timer_setCaptureCompareInput(config->base, 0,
-					GPTIMER_IFCTL_01_ISEL_CCPX_INPUT_PAIR,
-					(config->cc_idx[0] ^ 1));
-
-	DL_Timer_setCaptureCompareCtl(config->base,
-				      DL_TIMER_CC_MODE_CAPTURE,
-				      DL_TIMER_CC_CCOND_TRIG_FALL,
-				      config->cc_idx[0]);
-
-	DL_Timer_setCaptureCompareCtl(config->base,
-				      DL_TIMER_CC_MODE_CAPTURE,
-				      DL_TIMER_CC_CCOND_TRIG_RISE,
-				      (config->cc_idx[0] ^ 1));
-
-	DL_Timer_setCCPDirection(config->base, DL_TIMER_CC0_INPUT);
-
-	DL_Timer_setCounterControl(config->base,
-				   DL_TIMER_CZC_CCCTL0_ZCOND,
-				   MSPM_CTRCTL_CAC_CCCTL_ACOND(config->cc_idx[0]),
-				   DL_TIMER_CLC_CCCTL0_LCOND);
-
-	DL_Timer_setCounterRepeatMode(config->base, DL_TIMER_REPEAT_MODE_ENABLED);
-	DL_Timer_setCounterMode(config->base, DL_TIMER_COUNT_MODE_DOWN);
+	switch (data->flags & PWM_CAPTURE_TYPE_MASK) {
+	case PWM_CAPTURE_TYPE_PULSE:
+	case PWM_CAPTURE_TYPE_BOTH:
+	case PWM_CAPTURE_TYPE_PERIOD:
+		return GPTIMER_INT_CCD_MASK(!(config->cc_idx[0])) | GPTIMER_INT_ZERO_BIT;
+	default:
+		return GPTIMER_INT_CCD_MASK(config->cc_idx[0]);
+	}
 }
 
-static void mspm_pwm_setup_capture(const struct device *dev,
-				const struct pwm_mspm_config *config,
-				struct pwm_mspm_data *data)
+static void mspm_pwm_setup_capture(const struct device *dev, const struct pwm_mspm_config *config,
+				   struct pwm_mspm_data *data)
 {
-	if (data->cmode == PWM_MSPM_CAP_EDGE_TIME) {
-		DL_Timer_CaptureConfig cc_cfg = { 0 };
+	struct mspm_gptimer_regs *base = config->base;
 
-		cc_cfg.inputChan = config->cc_idx[0];
-		cc_cfg.period = data->period;
-		cc_cfg.edgeCaptMode = DL_TIMER_CAPTURE_EDGE_DETECTION_MODE_RISING;
+	base->COUNTERREGS.LOAD = data->period;
 
-		DL_Timer_initCaptureMode(config->base, &cc_cfg);
+	if (data->cap_mode == PWM_MSPM_CAP_EDGE_TIME) {
+		uint8_t ch = config->cc_idx[0];
+		uint32_t isel = (ch & 1U) ? GPTIMER_IFCTL_01_ISEL_CCPX_INPUT
+					  : GPTIMER_IFCTL_01_ISEL_CCP0_INPUT;
+
+		mspm_pwm_write_ccctl(base, ch,
+				     GPTIMER_CCCTL_01_COC_CAPTURE |
+					     GPTIMER_CCCTL_01_CCOND_CC_TRIG_RISE);
+		mspm_pwm_write_ifctl(base, ch, isel);
+		base->COMMONREGS.CCPD &= ~GPTIMER_CCPD_OUTPUT_MASK(ch);
 	} else {
-		mspm_pwm_set_combined_mode(config, data);
+		uint8_t ch_fall = config->cc_idx[0];
+		uint8_t ch_rise = ch_fall ^ 1U;
+		uint32_t isel_fall = (ch_fall & 1U) ? GPTIMER_IFCTL_01_ISEL_CCPX_INPUT
+						    : GPTIMER_IFCTL_01_ISEL_CCP0_INPUT;
+
+		mspm_pwm_write_ccctl(base, ch_fall,
+				     GPTIMER_CCCTL_01_COC_CAPTURE |
+					     GPTIMER_CCCTL_01_CCOND_CC_TRIG_FALL);
+		mspm_pwm_write_ifctl(base, ch_fall, isel_fall);
+
+		mspm_pwm_write_ccctl(base, ch_rise,
+				     GPTIMER_CCCTL_01_COC_CAPTURE |
+					     GPTIMER_CCCTL_01_CCOND_CC_TRIG_RISE);
+		mspm_pwm_write_ifctl(base, ch_rise, GPTIMER_IFCTL_01_ISEL_CCPX_INPUT_PAIR);
+
+		base->COMMONREGS.CCPD &=
+			~(GPTIMER_CCPD_OUTPUT_MASK(ch_fall) | GPTIMER_CCPD_OUTPUT_MASK(ch_rise));
+		base->COUNTERREGS.CTRCTL = GPTIMER_CTRCTL_CM_DOWN | GPTIMER_CTRCTL_REPEAT_REPEAT_1;
 	}
 
-	DL_Timer_enableClock(config->base);
+	base->COMMONREGS.CCLKCTL = GPTIMER_CCLKCTL_CLKEN_ENABLED;
 	config->irq_config_func(dev);
 }
 
-static int pwm_mspm_configure_capture(const struct device *dev,
-				   uint32_t channel,
-				   pwm_flags_t flags,
-				   pwm_capture_callback_handler_t cb,
-				   void *user_data)
+static int pwm_mspm_configure_capture(const struct device *dev, uint32_t channel, pwm_flags_t flags,
+				      pwm_capture_callback_handler_t cb, void *user_data)
 {
 	const struct pwm_mspm_config *config = dev->config;
 	struct pwm_mspm_data *data = dev->data;
 	uint32_t intr_mask;
 
-	if (config->is_capture != true ||
-	    channel != 0) {
-		LOG_ERR("Invalid channel %d", channel);
+	if (!config->is_capture || channel != 0) {
+		LOG_ERR("Invalid capture channel %u", channel);
 		return -EINVAL;
 	}
 
@@ -232,21 +508,17 @@ static int pwm_mspm_configure_capture(const struct device *dev,
 	case PWM_CAPTURE_TYPE_PULSE:
 	case PWM_CAPTURE_TYPE_BOTH:
 	case PWM_CAPTURE_TYPE_PERIOD:
-		/* CCD1/CCD0 event for capture index 0/1 respectively */
-		intr_mask = BIT(!(config->cc_idx[0]) + MSPM_CC_INTR_BIT_OFFSET) |
-			    DL_TIMER_INTERRUPT_ZERO_EVENT;
+		intr_mask = GPTIMER_INT_CCD_MASK(!(config->cc_idx[0])) | GPTIMER_INT_ZERO_BIT;
 		break;
-
 	default:
-		/* edge time event */
-		intr_mask = BIT(config->cc_idx[0] + MSPM_CC_INTR_BIT_OFFSET);
+		intr_mask = GPTIMER_INT_CCD_MASK(config->cc_idx[0]);
+		break;
 	}
 
 	k_mutex_lock(&data->lock, K_FOREVER);
 
-	/* If interrupt is enabled --> channel is on-going */
-	if (DL_Timer_getEnabledInterrupts(config->base, intr_mask)) {
-		LOG_ERR("Channel %d is busy", channel);
+	if (config->base->CPU_INT.IMASK & intr_mask) {
+		LOG_ERR("Channel %u busy", channel);
 		k_mutex_unlock(&data->lock);
 		return -EBUSY;
 	}
@@ -256,7 +528,6 @@ static int pwm_mspm_configure_capture(const struct device *dev,
 	data->user_data = user_data;
 
 	k_mutex_unlock(&data->lock);
-
 	return 0;
 }
 
@@ -264,46 +535,33 @@ static int pwm_mspm_enable_capture(const struct device *dev, uint32_t channel)
 {
 	const struct pwm_mspm_config *config = dev->config;
 	struct pwm_mspm_data *data = dev->data;
+	struct mspm_gptimer_regs *base = config->base;
 	uint32_t intr_mask;
 
-	if (config->is_capture != true ||
-	    channel != 0) {
-		LOG_ERR("Invalid capture mode or channel");
+	if (!config->is_capture || channel != 0) {
+		LOG_ERR("Invalid capture channel %u", channel);
 		return -EINVAL;
 	}
 
 	if (!data->callback) {
-		LOG_ERR("Callback is not configured");
+		LOG_ERR("No capture callback configured");
 		return -EINVAL;
 	}
 
-	switch (data->flags & PWM_CAPTURE_TYPE_MASK) {
-	case PWM_CAPTURE_TYPE_PULSE:
-	case PWM_CAPTURE_TYPE_BOTH:
-	case PWM_CAPTURE_TYPE_PERIOD:
-		/* CCD1/CCD0 event for capture index 0/1 respectively */
-		intr_mask = BIT(!(config->cc_idx[0]) + MSPM_CC_INTR_BIT_OFFSET) |
-			    DL_TIMER_INTERRUPT_ZERO_EVENT;
-		break;
-
-	default:
-		/* edge time event */
-		intr_mask = BIT(config->cc_idx[0] + MSPM_CC_INTR_BIT_OFFSET);
-	}
+	intr_mask = mspm_pwm_cap_intr_mask(config, data);
 
 	k_mutex_lock(&data->lock, K_FOREVER);
 
-	/* If interrupt is enabled --> channel is on-going */
-	if (DL_Timer_getEnabledInterrupts(config->base, intr_mask)) {
-		LOG_ERR("Channel %d is busy", channel);
+	if (base->CPU_INT.IMASK & intr_mask) {
+		LOG_ERR("Channel %u busy", channel);
 		k_mutex_unlock(&data->lock);
 		return -EBUSY;
 	}
 
-	DL_Timer_setTimerCount(config->base, data->period);
-	DL_Timer_startCounter(config->base);
-	DL_Timer_clearInterruptStatus(config->base, intr_mask);
-	DL_Timer_enableInterrupt(config->base, intr_mask);
+	base->COUNTERREGS.CTR = data->period;
+	base->COUNTERREGS.CTRCTL |= GPTIMER_CTRCTL_EN_ENABLED;
+	base->CPU_INT.ICLR = intr_mask;
+	base->CPU_INT.IMASK |= intr_mask;
 
 	k_mutex_unlock(&data->lock);
 	return 0;
@@ -313,44 +571,95 @@ static int pwm_mspm_disable_capture(const struct device *dev, uint32_t channel)
 {
 	const struct pwm_mspm_config *config = dev->config;
 	struct pwm_mspm_data *data = dev->data;
+	struct mspm_gptimer_regs *base = config->base;
 	uint32_t intr_mask;
 
-	if (config->is_capture != true ||
-	    channel != 0) {
-		LOG_ERR("Invalid channel");
+	if (!config->is_capture || channel != 0) {
+		LOG_ERR("Invalid capture channel %u", channel);
 		return -EINVAL;
 	}
 
-	switch (data->flags & PWM_CAPTURE_TYPE_MASK) {
-	case PWM_CAPTURE_TYPE_PULSE:
-	case PWM_CAPTURE_TYPE_BOTH:
-	case PWM_CAPTURE_TYPE_PERIOD:
-		/* CCD1/CCD0 event for capture index 0/1 respectively */
-		intr_mask = BIT(!(config->cc_idx[0]) + MSPM_CC_INTR_BIT_OFFSET) |
-			    DL_TIMER_INTERRUPT_ZERO_EVENT;
-		break;
-
-	default:
-		/* edge time event */
-		intr_mask = BIT(config->cc_idx[0] + MSPM_CC_INTR_BIT_OFFSET);
-	}
+	intr_mask = mspm_pwm_cap_intr_mask(config, data);
 
 	k_mutex_lock(&data->lock, K_FOREVER);
 
-	DL_Timer_disableInterrupt(config->base, intr_mask);
-	DL_Timer_stopCounter(config->base);
+	base->CPU_INT.IMASK &= ~intr_mask;
+	base->COUNTERREGS.CTRCTL &= ~GPTIMER_CTRCTL_EN_MASK;
 	data->is_synced = false;
-	k_mutex_unlock(&data->lock);
 
+	k_mutex_unlock(&data->lock);
 	return 0;
 }
-#endif
+
+static void mspm_pwm_cc_isr(const struct device *dev)
+{
+	const struct pwm_mspm_config *config = dev->config;
+	struct pwm_mspm_data *data = dev->data;
+	struct mspm_gptimer_regs *base = config->base;
+	uint32_t ris;
+	uint32_t cc0 = 0;
+	uint32_t cc1 = 0;
+	uint32_t period;
+	uint32_t pulse;
+
+	ris = base->CPU_INT.RIS & mspm_pwm_cap_intr_mask(config, data);
+	base->CPU_INT.ICLR = ris;
+
+	if (!ris) {
+		return;
+	}
+
+	if (ris & GPTIMER_INT_ZERO_BIT) {
+		if (data->callback && !(data->flags & PWM_CAPTURE_MODE_CONTINUOUS)) {
+			data->callback(dev, 0, 0, 0, -ERANGE, data->user_data);
+			base->COUNTERREGS.CTRCTL &= ~GPTIMER_CTRCTL_EN_MASK;
+		}
+		return;
+	}
+
+	if (data->flags & PWM_CAPTURE_TYPE_PERIOD) {
+		cc1 = mspm_pwm_read_cc(base, config->cc_idx[0] ^ 1U);
+	}
+
+	if (!data->is_synced && data->cap_mode != PWM_MSPM_CAP_EDGE_TIME) {
+		data->last_sample = cc1;
+		data->is_synced = true;
+		return;
+	}
+
+	if ((data->flags & PWM_CAPTURE_TYPE_PULSE) || data->cap_mode == PWM_MSPM_CAP_EDGE_TIME) {
+		cc0 = mspm_pwm_read_cc(base, config->cc_idx[0]);
+	}
+
+	if (!(data->flags & PWM_CAPTURE_MODE_CONTINUOUS)) {
+		base->COUNTERREGS.CTRCTL &= ~GPTIMER_CTRCTL_EN_MASK;
+		data->is_synced = false;
+	}
+
+	period = (data->last_sample - cc1 + UINT16_MAX) % UINT16_MAX;
+	pulse = (data->last_sample - cc0 + UINT16_MAX) % UINT16_MAX;
+
+	/* fixme: random intermittent cc0 > cc1 due to capture block timing */
+	if (pulse > period) {
+		pulse -= period;
+	}
+
+	if (data->callback && period) {
+		data->callback(dev, 0, period, pulse, 0, data->user_data);
+	}
+
+	data->last_sample = cc1;
+}
+
+#endif /* CONFIG_PWM_CAPTURE */
 
 static int pwm_mspm_init(const struct device *dev)
 {
 	const struct pwm_mspm_config *config = dev->config;
 	struct pwm_mspm_data *data = dev->data;
-	int err;
+	struct mspm_gptimer_regs *base = config->base;
+	uint32_t clock_rate;
+	int ret;
 
 	k_mutex_init(&data->lock);
 
@@ -359,19 +668,33 @@ static int pwm_mspm_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
-	if (err < 0) {
-		return err;
+	ret = clock_control_get_rate(config->clock_dev,
+				     (clock_control_subsys_t)&config->clock_subsys, &clock_rate);
+	if (ret != 0) {
+		LOG_ERR("clk get rate err %d", ret);
+		return ret;
 	}
 
-	DL_Timer_reset(config->base);
-	if (!DL_Timer_isPowerEnabled(config->base)) {
-		DL_Timer_enablePower(config->base);
+	ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		return ret;
 	}
 
-	delay_cycles(CONFIG_MSPM0_PERIPH_STARTUP_DELAY);
-	DL_Timer_setClockConfig(config->base,
-				(DL_Timer_ClockConfig *)&config->clk_config);
+	base->GPRCM.RSTCTL = GPTIMER_RSTCTL_KEY_UNLOCK_W | GPTIMER_RSTCTL_RESETSTKYCLR_CLR |
+			     GPTIMER_RSTCTL_RESETASSERT_ASSERT;
+	base->GPRCM.PWREN = GPTIMER_PWREN_KEY_UNLOCK_W | GPTIMER_PWREN_ENABLE_ENABLE;
+	k_busy_wait(1U);
+
+	base->CLKSEL = config->clk_sel;
+	base->CLKDIV = config->clk_div_reg;
+	base->COMMONREGS.CPS = config->prescaler;
+
+	data->freq_hz =
+		clock_rate / ((config->clk_div_reg + 1U) * ((uint32_t)config->prescaler + 1U));
+
+	base->CPU_INT.IMASK = 0U;
+	base->CPU_INT.ICLR = 0xFFFFFFFFU;
+
 	if (config->is_capture) {
 #ifdef CONFIG_PWM_CAPTURE
 		mspm_pwm_setup_capture(dev, config, data);
@@ -393,153 +716,73 @@ static DEVICE_API(pwm, pwm_mspm_driver_api) = {
 #endif
 };
 
+/* Device instantiation */
+
 #ifdef CONFIG_PWM_CAPTURE
-static void mspm_pwm_cc_isr(const struct device *dev)
-{
-	const struct pwm_mspm_config *config = dev->config;
-	struct pwm_mspm_data *data = dev->data;
-	uint32_t status;
-	uint32_t cc1 = 0;
-	uint32_t cc0 = 0;
-	uint32_t period = 0;
-	uint32_t pulse = 0;
-
-	status = DL_Timer_getPendingInterrupt(config->base);
-
-	switch (status) {
-	case DL_TIMER_IIDX_CC0_DN:
-	case DL_TIMER_IIDX_CC1_DN:
-		break;
-
-	/* Timer reached zero no pwm signal is detected */
-	case DL_TIMERG_IIDX_ZERO:
-		if (data->callback &&
-		    !(data->flags & PWM_CAPTURE_MODE_CONTINUOUS)) {
-			data->callback(dev, 0, 0, 0, -ERANGE, data->user_data);
-			DL_Timer_stopCounter(config->base);
-		}
-		__fallthrough;
-
-	default:
-		return;
-	}
-
-	if (data->flags & PWM_CAPTURE_TYPE_PERIOD) {
-		cc1 =  DL_Timer_getCaptureCompareValue(config->base,
-						       config->cc_idx[0] ^ 0x1);
-	}
-
-	/* ignore the unsynced counter value for pwm mode */
-	if (data->is_synced == false &&
-	    data->cmode != PWM_MSPM_CAP_EDGE_TIME) {
-		data->last_sample = cc1;
-		data->is_synced = true;
-		return;
-	}
-
-	if (data->flags & PWM_CAPTURE_TYPE_PULSE ||
-	    data->cmode == PWM_MSPM_CAP_EDGE_TIME) {
-		cc0 = DL_Timer_getCaptureCompareValue(config->base,
-						      config->cc_idx[0]);
-	}
-
-	if (!(data->flags & PWM_CAPTURE_MODE_CONTINUOUS)) {
-		DL_Timer_stopCounter(config->base);
-		data->is_synced = false;
-	}
-
-
-	period = ((data->last_sample - cc1 + UINT16_MAX) % UINT16_MAX);
-	pulse = ((data->last_sample - cc0 + UINT16_MAX) % UINT16_MAX);
-
-	/* fixme: random intermittent cc0 is greater than cc1 due to capture block error */
-	if (pulse > period) {
-		pulse -= period;
-	}
-
-	if (data->callback && period) {
-		data->callback(dev, 0, period, pulse, 0, data->user_data);
-	}
-
-	data->last_sample = cc1;
-}
-
-#define MSPM_PWM_IRQ_REGISTER(n)							\
-	static void mspm_pwm_##n##_irq_register(const struct device *dev)	\
-	{									\
-		const struct pwm_mspm_config *config = dev->config;		\
-		if (!config->is_capture) {					\
-			return;							\
-		}								\
-		IRQ_CONNECT(DT_IRQN(DT_INST_PARENT(n)),				\
-			    DT_IRQ(DT_INST_PARENT(n), priority), mspm_pwm_cc_isr,	\
-			    DEVICE_DT_INST_GET(n), 0);				\
-		irq_enable(DT_IRQN(DT_INST_PARENT(n)));				\
+#define MSPM_PWM_IRQ_REGISTER(n)                                                                   \
+	static void mspm_pwm_##n##_irq_register(const struct device *dev)                          \
+	{                                                                                          \
+		const struct pwm_mspm_config *config = dev->config;                                \
+		if (!config->is_capture) {                                                         \
+			return;                                                                    \
+		}                                                                                  \
+		IRQ_CONNECT(DT_IRQN(DT_INST_PARENT(n)), DT_IRQ(DT_INST_PARENT(n), priority),       \
+			    mspm_pwm_cc_isr, DEVICE_DT_INST_GET(n), 0);                            \
+		irq_enable(DT_IRQN(DT_INST_PARENT(n)));                                            \
 	}
 #else
 #define MSPM_PWM_IRQ_REGISTER(n)
 #endif
 
-#define MSPM_PWM_MODE(mode)		DT_CAT(DL_TIMER_PWM_MODE_, mode)
-#define MSPM_CAP_MODE(mode)	DT_CAT(CMODE_, mode)
-#define MSPM_CLK_DIV(div)		DT_CAT(DL_TIMER_CLOCK_DIVIDE_, div)
+#define MSPM_PWM_MODE(tok) _CONCAT(PWM_MSPM_, tok)
+#define MSPM_CAP_MODE(tok) _CONCAT(PWM_MSPM_CAP_, tok)
 
-#define MSPM_CC_IDX_ARRAY(node_id, prop, idx)	\
-				 DT_PROP_BY_IDX(node_id, prop, idx),
+#define MSPM_CC_IDX_ARRAY(node_id, prop, idx) DT_PROP_BY_IDX(node_id, prop, idx),
 
-#define MSPM_PWM_DATA(n)	\
-	.out_mode = MSPM_PWM_MODE(DT_STRING_TOKEN(DT_DRV_INST(n),		\
-				   ti_pwm_mode)),
-
-#define MSPM_CAPTURE_DATA(n)		\
-	IF_ENABLED(CONFIG_PWM_CAPTURE,	\
-	(.cmode = MSPM_CAP_MODE(DT_STRING_TOKEN(DT_DRV_INST(n), ti_cc_mode)),))
-
-#define PWM_DEVICE_INIT_MSPM(n)						\
-	static struct pwm_mspm_data pwm_mspm_data_##n = {			\
-		.period = DT_PROP(DT_DRV_INST(n), ti_period),			\
-		COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_pwm_mode),	\
-			    (MSPM_PWM_DATA(n)), ())				\
-		COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_cc_mode),	\
-			    (MSPM_CAPTURE_DATA(n)), ())			\
-	};									\
-	PINCTRL_DT_INST_DEFINE(n);						\
-	COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_cc_mode),	\
-		    (MSPM_PWM_IRQ_REGISTER(n)), ())				\
-										\
-	static const struct pwm_mspm_config pwm_mspm_config_##n = {		\
-		.base = (GPTIMER_Regs *)DT_REG_ADDR(DT_INST_PARENT(n)),		\
-		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR_BY_IDX(		\
-						DT_INST_PARENT(n), 0)),		\
-		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
-		.clock_subsys = {						\
-			.clk = DT_CLOCKS_CELL_BY_IDX(DT_INST_PARENT(n), 0, clk),\
-		},								\
-		.cc_idx = {							\
-			DT_INST_FOREACH_PROP_ELEM(n, ti_cc_index,		\
-						  MSPM_CC_IDX_ARRAY)		\
-		},								\
-		.cc_idx_cnt = DT_INST_PROP_LEN(n, ti_cc_index),			\
-		.clk_config = {							\
-			.clockSel = MSPM0_CLOCK_PERIPH_REG_MASK(		\
-				DT_CLOCKS_CELL_BY_IDX(DT_INST_PARENT(n),	\
-						      0, clk)),			\
-			.divideRatio = MSPM_CLK_DIV(DT_PROP(DT_INST_PARENT(n),	\
-						     ti_clk_div)),		\
-			.prescale = DT_PROP(DT_INST_PARENT(n), ti_clk_prescaler),\
-		},								\
-		.is_capture = DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_cc_mode),	\
+#define PWM_DEVICE_INIT_MSPM(n)                                                                    \
+	BUILD_ASSERT(DT_INST_PROP_LEN(n, ti_cc_index) <= MSPM_PWM_CC_MAX,                          \
+		     "ti,cc-index exceeds hardware maximum of 4");                                 \
+	BUILD_ASSERT(DT_PROP(DT_INST_PARENT(n), ti_clk_div) >= 1,                                  \
+		     "ti,clk-div must be >= 1 (0 underflows clk_div_reg)");                        \
+                                                                                                   \
+	static struct pwm_mspm_data pwm_mspm_data_##n = {                                          \
+		.period = DT_PROP(DT_DRV_INST(n), ti_period),                                      \
 		IF_ENABLED(CONFIG_PWM_CAPTURE,					\
-		(.irq_config_func = COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_cc_mode),	\
-						(mspm_pwm_##n##_irq_register), (NULL))))	\
-	};									\
-										\
-	DEVICE_DT_INST_DEFINE(n,						\
-			      pwm_mspm_init,					\
-			      NULL,						\
-			      &pwm_mspm_data_##n,				\
-			      &pwm_mspm_config_##n,				\
-			      POST_KERNEL, CONFIG_PWM_INIT_PRIORITY,		\
-			      &pwm_mspm_driver_api);
+		(COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_cc_mode),	\
+			(.cap_mode = MSPM_CAP_MODE(				\
+				DT_STRING_TOKEN(DT_DRV_INST(n), ti_cc_mode)),),\
+			()))) };                                 \
+                                                                                                   \
+	PINCTRL_DT_INST_DEFINE(n);                                                                 \
+	MSPM_PWM_IRQ_REGISTER(n)                                                                   \
+                                                                                                   \
+	static const struct pwm_mspm_config pwm_mspm_config_##n = {                                \
+		.base = (struct mspm_gptimer_regs *)DT_REG_ADDR(DT_INST_PARENT(n)),                \
+		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR_BY_IDX(DT_INST_PARENT(n), 0)),           \
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                       \
+		.clock_subsys =                                                                    \
+			{                                                                          \
+				.clk = DT_CLOCKS_CELL_BY_IDX(DT_INST_PARENT(n), 0, clk),           \
+			},                                                                         \
+		.clk_sel = MSPM0_CLOCK_PERIPH_REG_MASK(                                            \
+			DT_CLOCKS_CELL_BY_IDX(DT_INST_PARENT(n), 0, clk)),                         \
+		.clk_div_reg = DT_PROP(DT_INST_PARENT(n), ti_clk_div) - 1U,                        \
+		.prescaler = DT_PROP(DT_INST_PARENT(n), ti_clk_prescaler),                         \
+		.mode = COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n),		\
+						     ti_pwm_mode),		\
+			(MSPM_PWM_MODE(					\
+				DT_STRING_TOKEN(DT_DRV_INST(n), ti_pwm_mode))),\
+			(PWM_MSPM_EDGE_ALIGN)),                                                   \
+			 .cc_idx = {DT_INST_FOREACH_PROP_ELEM(n, ti_cc_index, MSPM_CC_IDX_ARRAY)}, \
+			 .cc_idx_cnt = DT_INST_PROP_LEN(n, ti_cc_index),                           \
+			 .is_capture = DT_NODE_HAS_PROP(DT_DRV_INST(n), ti_cc_mode),               \
+			 IF_ENABLED(CONFIG_PWM_CAPTURE,					\
+		(.irq_config_func =						\
+			COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n),		\
+						     ti_cc_mode),		\
+				(mspm_pwm_##n##_irq_register), (NULL)))) };            \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, pwm_mspm_init, NULL, &pwm_mspm_data_##n, &pwm_mspm_config_##n,    \
+			      POST_KERNEL, CONFIG_PWM_INIT_PRIORITY, &pwm_mspm_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PWM_DEVICE_INIT_MSPM)

--- a/dts/arm/ti/mspm0/l/mspm0l.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0l.dtsi
@@ -7,6 +7,26 @@
 
 #include <ti/mspm0/mspm0.dtsi>
 
+/ {
+	soc {
+		tima0: tima0@40860000 {
+			compatible = "ti,mspm0-timer";
+			reg = <0x40860000 0x2000>;
+			clocks = <&ckm MSPM0_CLOCK_MCLK>;
+			interrupts = <18 0>;
+			ti,clk-prescaler = <0>;
+			ti,clk-div = <1>;
+			status = "disabled";
+
+			pwma0: pwma0 {
+				compatible = "ti,mspm0-timer-pwm";
+				#pwm-cells = <3>;
+				status = "disabled";
+			};
+		};
+	};
+};
+
 &pinctrl {
 	gpioc: gpio@400a4000 {
 		compatible = "ti,mspm0-gpio";

--- a/dts/arm/ti/mspm0/l/mspm0lx22x.dtsi
+++ b/dts/arm/ti/mspm0/l/mspm0lx22x.dtsi
@@ -89,6 +89,12 @@
 				resolution = <16>;
 				status = "disabled";
 			};
+
+			pwmg8: pwmg8 {
+				compatible = "ti,mspm0-timer-pwm";
+				#pwm-cells = <3>;
+				status = "disabled";
+			};
 		};
 
 		timg12: timg12@40870000 {

--- a/tests/drivers/pwm/pwm_api/boards/lp_mspm0g3507.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/lp_mspm0g3507.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Incorporated
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwma0;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/lp_mspm0g3519.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/lp_mspm0g3519.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Incorporated
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwma0;
+	};
+};

--- a/tests/drivers/pwm/pwm_api/boards/lp_mspm0l2228.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/lp_mspm0l2228.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Incorporated
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-test = &pwma0;
+	};
+};

--- a/tests/drivers/pwm/pwm_loopback/boards/lp_mspm0g3507.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/lp_mspm0g3507.overlay
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Incorporated
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Connect PA15 (PWM output, pwma0 CH0, TIMA0 CCP2) to PB4 (capture input,
+ * pwma1 CH0, TIMA1 CCP0) with a wire before running this test.
+ */
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&pwma0 0 0 PWM_POLARITY_NORMAL>,
+		       <&pwma1 0 0 PWM_POLARITY_NORMAL>;
+	};
+};
+
+&pinctrl {
+	tima1_ccp0_pb4 {
+		input-enable;
+		bias-pull-down;
+	};
+};
+
+&pwma0 {
+	pinctrl-0 = <&tima0_ccp2_pa15>;
+	ti,cc-index = <2>;
+};
+
+&tima1 {
+	ti,clk-div = <8>;
+	ti,clk-prescaler = <255>;
+	status = "okay";
+
+	pwma1: pwma1 {
+		pinctrl-0 = <&tima1_ccp0_pb4>;
+		pinctrl-names = "default";
+		ti,cc-index = <0>;
+		ti,cc-mode = "PULSE_WIDTH";
+		ti,period = <0xffff>;
+		status = "okay";
+	};
+};

--- a/tests/drivers/pwm/pwm_loopback/boards/lp_mspm0l2228.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/lp_mspm0l2228.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Incorporated
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Connect PA0 (PWM output, pwma0 CH0, TIMA0 CCP0) to PA29 (capture input,
+ * pwmg8 CH0, TIMG8 CCP0) with a wire before running this test.
+ */
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&pwma0 0 0 PWM_POLARITY_NORMAL>,
+		       <&pwmg8 0 0 PWM_POLARITY_NORMAL>;
+	};
+};
+
+&pinctrl {
+	timg8_ccp0_pa29 {
+		input-enable;
+		bias-pull-down;
+	};
+};
+
+&timg8 {
+	ti,clk-div = <8>;
+	ti,clk-prescaler = <255>;
+	status = "okay";
+
+	pwmg8: pwmg8 {
+		pinctrl-0 = <&timg8_ccp0_pa29>;
+		pinctrl-names = "default";
+		ti,cc-index = <0>;
+		ti,cc-mode = "PULSE_WIDTH";
+		ti,period = <0xffff>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Convert MSPM0 GPTIMER PWM driver from TI DriverLib to direct register
  access. Fixes to capture and output correctness are integrated into the
  native conversion commit.

  Driver changes (patch 1):
  - Replace DL_Timer_* with native GPTIMER register map + BUILD_ASSERT
    offset checks; drop USE_MSPM0_DL_TIMER; cache freq_hz at init
  - Fix EDGE_ALIGN output inversion and 0%/100% duty glitch
  - Fix CENTER_ALIGN LOAD/CC scaling in both init and set_cycles paths
  - Fix EDGE_ALIGN_UP 0%/100% duty boundary (ZACT/CUACT same-tick glitch)
  - Fix GPTIMER_INT_ZERO_BIT BIT(1) → BIT(0); all captures were timing out
  - Fix capture paired-channel XOR (was NOT; wrong channel for idx 2/3)
  - Fix EDGE_TIME ISR: period formula and last_sample used cc1=0 always;
    EDGE_TIME capture was completely non-functional
  - Fix single-shot re-arm: ISR left IMASK set, causing -EBUSY on re-arm
  - Fix PERIOD-only capture returning raw timestamp as pulse value
  - Fix CENTER_ALIGN multi-channel LOAD coherence in set_cycles
  - Reject period_cycles=0 and pulse > period under PWM_POLARITY_INVERTED

  Board/DTS/test changes (patches 2-7):
  - Add TIMA0 (all L-family) and TIMG8 (L22x) DTS nodes
  - Enable PWM on lp_mspm0g3507, lp_mspm0g3519, lp_mspm0l2228
  - Add pwm_api overlays for all three boards
  - Add pwm_loopback overlays for g3507 (PA15 → PB4) and l2228 (PA0 → PA29)

  Testing:
  Board pwm_api + pwm_loopback:
  - lp_mspm0g3507 PASS PASS (EDGE_ALIGN, wire PA15 → PB4)
  - lp_mspm0l2228 PASS PASS (PULSE_WIDTH, wire PA0 → PA29)