### PR TITLE
tests: ipc_service_api: add nucleo_h755zi_q

### DIFF
--- a/tests/subsys/ipc/ipc_service_api/Kconfig.sysbuild
+++ b/tests/subsys/ipc/ipc_service_api/Kconfig.sysbuild
@@ -18,4 +18,5 @@ config REMOTE_BOARD
 	default "nrf54h20dk/nrf54h20/cpuflpr" if REMOTE_NRF54H20_CPUFLPR_CORE
 	default "nrf54h20dk/nrf54h20/cpuppr" if REMOTE_NRF54H20_CPUPPR_CORE
 	default "nrf54h20dk/nrf54h20/cpurad" if BOARD_NRF54H20DK_NRF54H20_CPUAPP
+	default "nucleo_h755zi_q/stm32h755xx/m4" if $(BOARD) = "nucleo_h755zi_q"
 	default "none"

--- a/tests/subsys/ipc/ipc_service_api/boards/nucleo_h755zi_q_stm32h755xx_m7_icbmsg.overlay
+++ b/tests/subsys/ipc/ipc_service_api/boards/nucleo_h755zi_q_stm32h755xx_m7_icbmsg.overlay
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		sram_tx: memory@38000000 {
+			reg = <0x38000000 DT_SIZE_K(32)>;
+		};
+
+		sram_rx: memory@38008000 {
+			reg = <0x38008000 DT_SIZE_K(32)>;
+		};
+	};
+
+	ipc0: ipc0 {
+		compatible = "zephyr,ipc-icbmsg";
+		tx-region = <&sram_tx>;
+		rx-region = <&sram_rx>;
+		tx-blocks = <20>;
+		rx-blocks = <20>;
+		mboxes = <&mailbox 11>, <&mailbox 10>;
+		mbox-names = "tx", "rx";
+		status = "okay";
+	};
+
+	aliases {
+		dut-ipc = &ipc0;
+	};
+};

--- a/tests/subsys/ipc/ipc_service_api/boards/nucleo_h755zi_q_stm32h755xx_m7_icmsg.overlay
+++ b/tests/subsys/ipc/ipc_service_api/boards/nucleo_h755zi_q_stm32h755xx_m7_icmsg.overlay
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		sram_tx: memory@38000000 {
+			reg = <0x38000000 DT_SIZE_K(32)>;
+		};
+
+		sram_rx: memory@38008000 {
+			reg = <0x38008000 DT_SIZE_K(32)>;
+		};
+	};
+
+	ipc0: ipc0 {
+		compatible = "zephyr,ipc-icmsg";
+		tx-region = <&sram_tx>;
+		rx-region = <&sram_rx>;
+		mboxes = <&mailbox 11>, <&mailbox 10>;
+		mbox-names = "tx", "rx";
+		status = "okay";
+	};
+
+	aliases {
+		dut-ipc = &ipc0;
+	};
+};

--- a/tests/subsys/ipc/ipc_service_api/remote/boards/nucleo_h755zi_q_stm32h755xx_m4_icbmsg.overlay
+++ b/tests/subsys/ipc/ipc_service_api/remote/boards/nucleo_h755zi_q_stm32h755xx_m4_icbmsg.overlay
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		sram_rx: memory@38000000 {
+			reg = <0x38000000 DT_SIZE_K(32)>;
+		};
+
+		sram_tx: memory@38008000 {
+			reg = <0x38008000 DT_SIZE_K(32)>;
+		};
+	};
+
+	ipc0: ipc0 {
+		compatible = "zephyr,ipc-icbmsg";
+		tx-region = <&sram_tx>;
+		rx-region = <&sram_rx>;
+		tx-blocks = <20>;
+		rx-blocks = <20>;
+		mboxes = <&mailbox 10>, <&mailbox 11>;
+		mbox-names = "tx", "rx";
+		status = "okay";
+	};
+
+	aliases {
+		dut-ipc = &ipc0;
+	};
+};

--- a/tests/subsys/ipc/ipc_service_api/remote/boards/nucleo_h755zi_q_stm32h755xx_m4_icmsg.overlay
+++ b/tests/subsys/ipc/ipc_service_api/remote/boards/nucleo_h755zi_q_stm32h755xx_m4_icmsg.overlay
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		sram_rx: memory@38000000 {
+			reg = <0x38000000 DT_SIZE_K(32)>;
+		};
+
+		sram_tx: memory@38008000 {
+			reg = <0x38008000 DT_SIZE_K(32)>;
+		};
+	};
+
+	ipc0: ipc0 {
+		compatible = "zephyr,ipc-icmsg";
+		tx-region = <&sram_tx>;
+		rx-region = <&sram_rx>;
+		mboxes = <&mailbox 10>, <&mailbox 11>;
+		mbox-names = "tx", "rx";
+		status = "okay";
+	};
+
+	aliases {
+		dut-ipc = &ipc0;
+	};
+};

--- a/tests/subsys/ipc/ipc_service_api/tests.yaml
+++ b/tests/subsys/ipc/ipc_service_api/tests.yaml
@@ -11,6 +11,7 @@ tests:
       - nrf5340bsim/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nucleo_h755zi_q/stm32h755xx/m7
     integration_platforms:
       - nrf5340bsim/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
@@ -30,6 +31,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nucleo_h755zi_q/stm32h755xx/m7
     integration_platforms:
       - nrf5340bsim/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
@@ -107,6 +109,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340bsim/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nucleo_h755zi_q/stm32h755xx/m7
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340bsim/nrf5340/cpuapp


### PR DESCRIPTION
Add the Nucleo H755ZI-Q board to the test.

# Testing

```sh
west twister -p nucleo_h755zi_q/stm32h755xx/m7 -T tests\subsys\ipc\ipc_service_api --short-build-path --device-testing --device-serial COM7
```

```sh
west twister -p nucleo_h755zi_q/stm32h755xx/m7 -T tests\subsys\ipc\ipc_service_api --short-build-path --device-testing --device-serial COM7
[...]
INFO    - Total complete:    3/   3  100%  built (not run):    0, filtered:    6, failed:    0, error:    0
INFO    - 9 test scenarios (9 configurations) selected, 6 configurations filtered (6 by static filter, 0 at runtime).
INFO    - 3 of 3 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 470.20 seconds.
INFO    - 15 of 15 executed test cases passed (100.00%) on 1 out of total 1640 platforms (0.06%).
INFO    - 17 selected test cases not executed: 17 skipped.
INFO    - 3 test configurations executed on platforms, 0 test configurations were only built.

Hardware distribution summary:

| Board                          | ID   |   Counter |   Failures |
|--------------------------------|------|-----------|------------|
| nucleo_h755zi_q/stm32h755xx/m7 |      |         3 |          0 |
INFO    - Saving reports...
INFO    - Writing JSON report C:\Workspace\rtos-zephyr-ws\zephyr\twister-out\twister.json
INFO    - Writing xunit report C:\Workspace\rtos-zephyr-ws\zephyr\twister-out\twister.xml...
INFO    - Writing xunit report C:\Workspace\rtos-zephyr-ws\zephyr\twister-out\twister_report.xml...
INFO    - Run completed
```