### PR TITLE
drivers: wifi: nxp: fix NET_BUF_ALIGNMENT for platforms without DCACHE

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -1485,9 +1485,11 @@ if NXP_WIFI_TX_RX_ZERO_COPY && !NXP_RW610
 configdefault NET_BUF_DATA_SIZE
 	default 2048
 
-# For SDHC zero copy, net buf should be aligned by cache line size
+# For SDHC zero copy, net buf should be aligned by cache line size.
+# On platforms without DCACHE, align to SDHC DMA transfer requirement.
 configdefault NET_BUF_ALIGNMENT
-	default DCACHE_LINE_SIZE
+	default DCACHE_LINE_SIZE if DCACHE
+	default SDHC_BUFFER_ALIGNMENT
 
 endif # NXP_WIFI_TX_RX_ZERO_COPY && !NXP_RW610
 


### PR DESCRIPTION
The configdefault for NET_BUF_ALIGNMENT references DCACHE_LINE_SIZE unconditionally. On platforms where CACHE_MANAGEMENT is enabled but CACHE_TYPE is not DCACHE (e.g., EXTERNAL_CACHE for instruction-only caches), the DCACHE_LINE_SIZE symbol is hidden inside `if DCACHE` and resolves to 0. Kconfig stores int 0 as an empty string, which breaks GEN_ABSOLUTE_SYM_KCONFIG and produces an assembler error: "missing expression".

Add an `if DCACHE` guard and use SDHC_BUFFER_ALIGNMENT for platforms without DCACHE, which reflects the actual USDHC ADMA2 DMA transfer alignment requirement.