### PR TITLE
soc: nxp: lpc55s36: enable CTIMER clock divider

### DIFF
--- a/soc/nxp/lpc/lpc55xxx/soc.c
+++ b/soc/nxp/lpc/lpc55xxx/soc.c
@@ -48,6 +48,13 @@ static uint32_t ExternalClockFrequency;
 #define TO_CLOCK_ATTACH_ID(inst, val) MUX_A(CM_CTIMERCLKSEL##inst, val)
 #define CTIMER_CLOCK_SETUP(node_id) CLOCK_AttachClk(CTIMER_CLOCK_SOURCE(node_id));
 
+#if defined(CONFIG_SOC_LPC55S36)
+#define CTIMER_CLOCK_DIV_NAME(inst) kCLOCK_DivCtimer##inst##Clk
+#define CTIMER_CLOCK_DIV_ID(inst) CTIMER_CLOCK_DIV_NAME(inst)
+#define CTIMER_CLOCK_DIV_SETUP(node_id) \
+	CLOCK_SetClkDiv(CTIMER_CLOCK_DIV_ID(DT_CLOCKS_CELL(node_id, name)), 1U, false);
+#endif /* CONFIG_SOC_LPC55S36 */
+
 #ifdef CONFIG_INIT_PLL0
 const pll_setup_t pll0Setup = {
 	.pllctrl = SYSCON_PLL0CTRL_CLKEN_MASK | SYSCON_PLL0CTRL_SELI(2U) |
@@ -352,6 +359,11 @@ __weak void clock_init(void)
 DT_FOREACH_STATUS_OKAY(nxp_lpc_ctimer, CTIMER_CLOCK_SETUP)
 
 DT_FOREACH_STATUS_OKAY(nxp_ctimer_pwm, CTIMER_CLOCK_SETUP)
+
+#if defined(CONFIG_SOC_LPC55S36)
+	DT_FOREACH_STATUS_OKAY(nxp_lpc_ctimer, CTIMER_CLOCK_DIV_SETUP)
+	DT_FOREACH_STATUS_OKAY(nxp_ctimer_pwm, CTIMER_CLOCK_DIV_SETUP)
+#endif /* CONFIG_SOC_LPC55S36 */
 
 #if (DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(flexcomm6), nxp_lpc_i2s, okay))
 #if defined(CONFIG_SOC_LPC55S36)


### PR DESCRIPTION
Enables CTIMER clock divider that is halted out of reset.
As with the divider halted, the CTIMER receives no functional clock, so the first register access hanged the system during driver initialization.

Tested on LPCXpresso55s36.