### PR TITLE
boards: st: Add USB support for nucleo_c562re and nucleo_c542rc

### DIFF
--- a/boards/st/nucleo_c542rc/doc/index.rst
+++ b/boards/st/nucleo_c542rc/doc/index.rst
@@ -68,6 +68,17 @@ use both functions simultaneously.
 
 For more details please refer to `STM32 Nucleo-64 board User Manual`_.
 
+USB
+===
+
+.. warning::
+
+  By default, the dead-battery pull-downs are not present on the connector (self-powered mode).
+  Therefore, the board cannot be powered from the user USB-C connector using a USB-C-to-USB-C cable.
+  A legacy USB-C-to-USB-A cable should still work.
+  Another option is to connect both the user USB and the ST-Link USB.
+  The board can also be modified to support bus-powered mode.
+
 Programming and Debugging
 *************************
 

--- a/boards/st/nucleo_c542rc/nucleo_c542rc.dts
+++ b/boards/st/nucleo_c542rc/nucleo_c542rc.dts
@@ -58,6 +58,11 @@
 	status = "okay";
 };
 
+&clk_psidiv3 {
+	clock-frequency = <DT_FREQ_M(48)>;
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;
@@ -128,5 +133,16 @@
 	pinctrl-0 = <&usart2_tx_pa2 &usart2_rx_pa3>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
+};
+
+&clk48 {
+	clocks = <&rcc STM32_SRC_PSIDIV3 CK48_SEL(1)>;
+	status = "okay";
+};
+
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/st/nucleo_c542rc/nucleo_c542rc.yaml
+++ b/boards/st/nucleo_c542rc/nucleo_c542rc.yaml
@@ -14,6 +14,7 @@ supported:
   - i2c
   - spi
   - uart
+  - usbd
 ram: 64
 flash: 256
 vendor: st

--- a/boards/st/nucleo_c562re/doc/index.rst
+++ b/boards/st/nucleo_c562re/doc/index.rst
@@ -68,6 +68,17 @@ use both functions simultaneously.
 
 For more details please refer to `STM32 Nucleo-64 board User Manual`_.
 
+USB
+===
+
+.. warning::
+
+  By default, the dead-battery pull-downs are not present on the connector (self-powered mode).
+  Therefore, the board cannot be powered from the user USB-C connector using a USB-C-to-USB-C cable.
+  A legacy USB-C-to-USB-A cable should still work.
+  Another option is to connect both the user USB and the ST-Link USB.
+  The board can also be modified to support bus-powered mode.
+
 Programming and Debugging
 *************************
 

--- a/boards/st/nucleo_c562re/nucleo_c562re.dts
+++ b/boards/st/nucleo_c562re/nucleo_c562re.dts
@@ -58,6 +58,11 @@
 	status = "okay";
 };
 
+&clk_psidiv3 {
+	clock-frequency = <DT_FREQ_M(48)>;
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		#address-cells = <1>;
@@ -132,5 +137,16 @@
 };
 
 &hash {
+	status = "okay";
+};
+
+&clk48 {
+	clocks = <&rcc STM32_SRC_PSIDIV3 CK48_SEL(1)>;
+	status = "okay";
+};
+
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/st/nucleo_c562re/nucleo_c562re.yaml
+++ b/boards/st/nucleo_c562re/nucleo_c562re.yaml
@@ -14,6 +14,7 @@ supported:
   - i2c
   - spi
   - uart
+  - usbd
 ram: 128
 flash: 512
 vendor: st

--- a/boards/st/nucleo_c5a3zg/doc/index.rst
+++ b/boards/st/nucleo_c5a3zg/doc/index.rst
@@ -74,6 +74,17 @@ STM32 I/O is in a low state.
 
 For more details please refer to `STM32 Nucleo-144 board User Manual`_.
 
+USB
+===
+
+.. warning::
+
+  By default, the dead-battery pull-downs are not present on the connector (self-powered mode).
+  Therefore, the board cannot be powered from the user USB-C connector using a USB-C-to-USB-C cable.
+  A legacy USB-C-to-USB-A cable should still work.
+  Another option is to connect both the user USB and the ST-Link USB.
+  The board can also be modified to support bus-powered mode.
+
 Programming and Debugging
 *************************
 

--- a/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
+++ b/boards/st/nucleo_c5a3zg/nucleo_c5a3zg.dts
@@ -130,6 +130,11 @@
 	status = "okay";
 };
 
+&clk48 {
+	clocks = <&rcc STM32_SRC_HSE CK48_SEL(3)>;
+	status = "okay";
+};
+
 &fdcan1 {
 	clocks = <&rcc STM32_CLOCK(APB1_2, 9)>,
 		 <&rcc STM32_SRC_PSIK FDCAN_SEL(2)>;
@@ -260,8 +265,6 @@
 };
 
 &rng {
-	clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
-		 <&rcc STM32_SRC_CK48 CK48_SEL(2)>;
 	status = "okay";
 };
 
@@ -287,8 +290,6 @@
 };
 
 zephyr_udc0: &usb {
-	clocks = <&rcc STM32_CLOCK(APB2, 24)>,
-		 <&rcc STM32_SRC_CK48 CK48_SEL(2)>;
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";
 	status = "okay";

--- a/drivers/clock_control/clock_stm32_ll_c5.c
+++ b/drivers/clock_control/clock_stm32_ll_c5.c
@@ -153,7 +153,7 @@ int enabled_clock(uint32_t src_clk)
 	    ((src_clk == STM32_SRC_PSIK) && IS_ENABLED(STM32_PSIK_ENABLED)) ||
 	    ((src_clk == STM32_SRC_LSE) && IS_ENABLED(STM32_LSE_ENABLED)) ||
 	    ((src_clk == STM32_SRC_LSI) && IS_ENABLED(STM32_LSI_ENABLED)) ||
-	    (src_clk == STM32_SRC_CK48)) {
+	    ((src_clk == STM32_SRC_CK48) && IS_ENABLED(STM32_CK48_ENABLED))) {
 		return 0;
 	}
 

--- a/dts/arm/st/c5/stm32c5.dtsi
+++ b/dts/arm/st/c5/stm32c5.dtsi
@@ -122,6 +122,13 @@
 			compatible = "fixed-clock";
 			status = "disabled";
 		};
+
+		clk48: clk48 {
+			#clock-cells = <0>;
+			compatible = "st,stm32-clock-mux";
+			clocks = <&rcc STM32_SRC_HSIDIV3 CK48_SEL(2)>;
+			status = "disabled";
+		};
 	};
 
 	mcos {
@@ -428,7 +435,8 @@
 		rng: rng@420c0800 {
 			compatible = "st,stm32-rng";
 			reg = <0x420c0800 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 18)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
+				 <&rcc STM32_SRC_CK48 NO_SEL>;
 			interrupts = <64 0>;
 			nist-config = <0x8451f00>;
 			health-test-config = <0xaac7>;
@@ -730,7 +738,7 @@
 			ram-size = <2048>;
 			maximum-speed = "full-speed";
 			clocks = <&rcc STM32_CLOCK(APB2, 24)>,
-				 <&rcc STM32_SRC_CK48 CK48_SEL(0)>;
+				 <&rcc STM32_SRC_CK48 NO_SEL>;
 			phys = <&usb_fs_phy>;
 			status = "disabled";
 		};


### PR DESCRIPTION
Adding support to `nucleo_c562re` and `nucleo_c542rc`.
I also added not to all C5 Nucleo documentation on how to use the USB.