### PR TITLE
net: context: store the local endpoint address inline 

### DIFF
--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -71,6 +71,9 @@ enum net_context_state {
 /** Context is bound to a specific interface */
 #define NET_CONTEXT_BOUND_TO_IFACE BIT(9)
 
+/** A local address has been bound to this context */
+#define NET_CONTEXT_LOCAL_ADDR_SET BIT(10)
+
 struct net_context;
 
 /**
@@ -525,6 +528,21 @@ static inline bool net_context_is_bound_to_iface(struct net_context *context)
 	NET_ASSERT(context);
 
 	return context->flags & NET_CONTEXT_BOUND_TO_IFACE;
+}
+
+/**
+ * @brief Has a local address been bound to this context.
+ *
+ * @param context Network context.
+ *
+ * @return True if a local address has been assigned to @ref net_context.local,
+ * False otherwise.
+ */
+static inline bool net_context_is_local_addr_set(struct net_context *context)
+{
+	NET_ASSERT(context);
+
+	return context->flags & NET_CONTEXT_LOCAL_ADDR_SET;
 }
 
 /** @cond INTERNAL_HIDDEN */

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -234,7 +234,12 @@ __net_socket struct net_context {
 	/** Remote endpoint address. Note that the values are in network byte
 	 * order.
 	 */
-	struct net_sockaddr remote;
+	union {
+		/** Remote endpoint address. */
+		struct net_sockaddr remote;
+		/** Storage-typed alias of the remote endpoint address. */
+		struct net_sockaddr_storage remote_storage;
+	};
 
 	/** Connection handle */
 	struct net_conn_handle *conn_handler;

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -224,7 +224,12 @@ __net_socket struct net_context {
 	/** Local endpoint address. Note that the values are in network byte
 	 * order.
 	 */
-	struct net_sockaddr_ptr local;
+	union {
+		/** Local endpoint address. */
+		struct net_sockaddr local;
+		/** Storage-typed alias of the local endpoint address. */
+		struct net_sockaddr_storage local_storage;
+	};
 
 	/** Remote endpoint address. Note that the values are in network byte
 	 * order.

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -203,8 +203,7 @@ static int check_used_port(struct net_context *context,
 		}
 
 		if (!(net_context_get_proto(&contexts[i]) == proto &&
-		      net_sin((struct net_sockaddr *)&
-			      contexts[i].local)->sin_port == local_port)) {
+		      net_sin(&contexts[i].local)->sin_port == local_port)) {
 			continue;
 		}
 
@@ -217,12 +216,12 @@ static int check_used_port(struct net_context *context,
 		if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		    local_addr->sa_family == NET_AF_INET6) {
 			if (!net_context_is_local_addr_set(&contexts[i]) ||
-			    net_sin6_ptr(&contexts[i].local)->sin6_family != NET_AF_INET6) {
+			    contexts[i].local.sa_family != NET_AF_INET6) {
 				continue;
 			}
 
 			if ((net_ipv6_is_addr_unspecified(
-					net_sin6_ptr(&contexts[i].local)->sin6_addr) ||
+					&net_sin6(&contexts[i].local)->sin6_addr) ||
 			     net_ipv6_is_addr_unspecified(
 					&net_sin6(local_addr)->sin6_addr))) {
 				if (reuseport_set &&
@@ -234,7 +233,7 @@ static int check_used_port(struct net_context *context,
 				} else if (reuseaddr_set &&
 					   !is_in_tcp_listen_state(&contexts[i]) &&
 					   !(net_ipv6_is_addr_unspecified(
-						net_sin6_ptr(&contexts[i].local)->sin6_addr) &&
+						&net_sin6(&contexts[i].local)->sin6_addr) &&
 					     net_ipv6_is_addr_unspecified(
 						&net_sin6(local_addr)->sin6_addr))) {
 					/* In case of REUSEADDR, only one context may be
@@ -250,8 +249,7 @@ static int check_used_port(struct net_context *context,
 			}
 
 			if (net_ipv6_addr_cmp(
-				    net_sin6_ptr(&contexts[i].local)->
-							     sin6_addr,
+				    &net_sin6(&contexts[i].local)->sin6_addr,
 				    &((struct net_sockaddr_in6 *)
 				      local_addr)->sin6_addr)) {
 				if (reuseport_set &&
@@ -279,12 +277,12 @@ static int check_used_port(struct net_context *context,
 			if (!net_context_is_local_addr_set(&contexts[i]) ||
 			    ((IS_ENABLED(CONFIG_NET_IPV4_MAPPING_TO_IPV6) ?
 			      net_context_is_v6only_set(&contexts[i]) : true) &&
-			     net_sin_ptr(&contexts[i].local)->sin_family != NET_AF_INET)) {
+			     contexts[i].local.sa_family != NET_AF_INET)) {
 				continue;
 			}
 
 			if ((net_ipv4_is_addr_unspecified(
-					net_sin_ptr(&contexts[i].local)->sin_addr) ||
+					&net_sin(&contexts[i].local)->sin_addr) ||
 			     net_ipv4_is_addr_unspecified(
 					&net_sin(local_addr)->sin_addr))) {
 				if (reuseport_set &&
@@ -296,7 +294,7 @@ static int check_used_port(struct net_context *context,
 				} else if (reuseaddr_set &&
 					   !is_in_tcp_listen_state(&contexts[i]) &&
 					   !(net_ipv4_is_addr_unspecified(
-						net_sin_ptr(&contexts[i].local)->sin_addr) &&
+						&net_sin(&contexts[i].local)->sin_addr) &&
 					     net_ipv4_is_addr_unspecified(
 						&net_sin(local_addr)->sin_addr))) {
 					/* In case of REUSEADDR, only one context may be
@@ -312,8 +310,7 @@ static int check_used_port(struct net_context *context,
 			}
 
 			if (net_ipv4_addr_cmp(
-				    net_sin_ptr(&contexts[i].local)->
-							      sin_addr,
+				    &net_sin(&contexts[i].local)->sin_addr,
 				    &((struct net_sockaddr_in *)
 				      local_addr)->sin_addr)) {
 				if (reuseport_set &&
@@ -591,7 +588,7 @@ int net_context_get(net_sa_family_t family, enum net_sock_type type, uint16_t pr
 #endif
 		if (IS_ENABLED(CONFIG_NET_IP)) {
 			(void)memset(&contexts[i].remote, 0, sizeof(struct net_sockaddr));
-			(void)memset(&contexts[i].local, 0, sizeof(struct net_sockaddr_ptr));
+			(void)memset(&contexts[i].local, 0, sizeof(struct net_sockaddr));
 
 			if (IS_ENABLED(CONFIG_NET_IPV6) && family == NET_AF_INET6) {
 				struct net_sockaddr_in6 *addr6 =
@@ -892,7 +889,7 @@ static int recheck_port(struct net_context *context,
 				return -EADDRINUSE;
 			}
 
-			net_sin_ptr(&context->local)->sin_port = re_port;
+			net_sin(&context->local)->sin_port = re_port;
 			net_sin(addr)->sin_port = re_port;
 		} else {
 			NET_ERR("Port %d is in use!", net_ntohs(net_sin(addr)->sin_port));
@@ -901,7 +898,7 @@ static int recheck_port(struct net_context *context,
 			return -EADDRINUSE;
 		}
 	} else {
-		net_sin_ptr(&context->local)->sin_port = net_sin(addr)->sin_port;
+		net_sin(&context->local)->sin_port = net_sin(addr)->sin_port;
 	}
 
 	return 0;
@@ -999,8 +996,8 @@ int net_context_bind(struct net_context *context, const struct net_sockaddr *add
 
 		net_context_set_iface(context, iface);
 
-		net_sin6_ptr(&context->local)->sin6_family = NET_AF_INET6;
-		net_sin6_ptr(&context->local)->sin6_addr = ptr;
+		net_sin6(&context->local)->sin6_family = NET_AF_INET6;
+		net_ipaddr_copy(&net_sin6(&context->local)->sin6_addr, ptr);
 		context->flags |= NET_CONTEXT_LOCAL_ADDR_SET;
 
 		if (IS_ENABLED(CONFIG_NET_OFFLOAD) && net_if_is_ip_offloaded(iface)) {
@@ -1017,7 +1014,7 @@ int net_context_bind(struct net_context *context, const struct net_sockaddr *add
 			}
 		} else {
 			addr6->sin6_port =
-				net_sin6_ptr(&context->local)->sin6_port;
+				net_sin6(&context->local)->sin6_port;
 
 			if (IS_ENABLED(CONFIG_NET_CONTEXT_CLAMP_PORT_RANGE)) {
 				ret = recheck_port(context, iface, context->proto,
@@ -1107,8 +1104,8 @@ int net_context_bind(struct net_context *context, const struct net_sockaddr *add
 
 		net_context_set_iface(context, iface);
 
-		net_sin_ptr(&context->local)->sin_family = NET_AF_INET;
-		net_sin_ptr(&context->local)->sin_addr = ptr;
+		net_sin(&context->local)->sin_family = NET_AF_INET;
+		net_ipaddr_copy(&net_sin(&context->local)->sin_addr, ptr);
 		context->flags |= NET_CONTEXT_LOCAL_ADDR_SET;
 
 		if (IS_ENABLED(CONFIG_NET_OFFLOAD) && net_if_is_ip_offloaded(iface)) {
@@ -1125,7 +1122,7 @@ int net_context_bind(struct net_context *context, const struct net_sockaddr *add
 			}
 		} else {
 			addr4->sin_port =
-				net_sin_ptr(&context->local)->sin_port;
+				net_sin(&context->local)->sin_port;
 
 			if (IS_ENABLED(CONFIG_NET_CONTEXT_CLAMP_PORT_RANGE)) {
 				ret = recheck_port(context, iface, context->proto,
@@ -1177,30 +1174,31 @@ int net_context_bind(struct net_context *context, const struct net_sockaddr *add
 
 		k_mutex_lock(&context->lock, K_FOREVER);
 
-		net_sll_ptr(&context->local)->sll_family = NET_AF_PACKET;
-		net_sll_ptr(&context->local)->sll_ifindex =
-			ll_addr->sll_ifindex;
-		net_sll_ptr(&context->local)->sll_protocol =
-			ll_addr->sll_protocol;
+		struct net_sockaddr_ll *local_ll =
+			(struct net_sockaddr_ll *)&context->local;
+
+		local_ll->sll_family = NET_AF_PACKET;
+		local_ll->sll_ifindex = ll_addr->sll_ifindex;
+		local_ll->sll_protocol = ll_addr->sll_protocol;
 		context->flags |= NET_CONTEXT_LOCAL_ADDR_SET;
 
 		if (iface != NULL) {
+			struct net_linkaddr *lladdr;
+
 			net_context_set_iface(context, iface);
 
 			net_if_lock(iface);
-			net_sll_ptr(&context->local)->sll_addr =
-				net_if_get_link_addr(iface)->addr;
-			net_sll_ptr(&context->local)->sll_halen =
-				net_if_get_link_addr(iface)->len;
+			lladdr = net_if_get_link_addr(iface);
+			local_ll->sll_halen = MIN(lladdr->len,
+						  sizeof(local_ll->sll_addr));
+			memcpy(local_ll->sll_addr, lladdr->addr, local_ll->sll_halen);
 			net_if_unlock(iface);
 		}
 
 		NET_DBG("Context %p bind to type 0x%04x iface[%d] %p addr %s",
 			context, net_htons(net_context_get_proto(context)),
 			ll_addr->sll_ifindex, iface,
-			net_sprint_ll_addr(
-				net_sll_ptr(&context->local)->sll_addr,
-				net_sll_ptr(&context->local)->sll_halen));
+			net_sprint_ll_addr(local_ll->sll_addr, local_ll->sll_halen));
 
 		k_mutex_unlock(&context->lock);
 
@@ -1241,8 +1239,8 @@ int net_context_bind(struct net_context *context, const struct net_sockaddr *add
 		net_context_set_iface(context, iface);
 		net_context_set_family(context, NET_AF_CAN);
 
-		net_can_ptr(&context->local)->can_family = NET_AF_CAN;
-		net_can_ptr(&context->local)->can_ifindex =
+		((struct net_sockaddr_can *)&context->local)->can_family = NET_AF_CAN;
+		((struct net_sockaddr_can *)&context->local)->can_ifindex =
 			can_addr->can_ifindex;
 		context->flags |= NET_CONTEXT_LOCAL_ADDR_SET;
 
@@ -1310,7 +1308,7 @@ static int context_create_ipv4_new(struct net_context *context,
 	if (!src) {
 		NET_ASSERT(net_context_is_local_addr_set(context));
 
-		src = ((struct net_sockaddr_in_ptr *)&context->local)->sin_addr;
+		src = &net_sin(&context->local)->sin_addr;
 	}
 
 	if (net_ipv4_is_addr_unspecified(src)
@@ -1364,7 +1362,7 @@ static int context_create_ipv6_new(struct net_context *context,
 	if (!src) {
 		NET_ASSERT(net_context_is_local_addr_set(context));
 
-		src = ((struct net_sockaddr_in6_ptr *)&context->local)->sin6_addr;
+		src = &net_sin6(&context->local)->sin6_addr;
 	}
 
 	if (net_ipv6_is_addr_unspecified(src) || net_ipv6_is_addr_mcast(src)) {
@@ -1511,14 +1509,14 @@ int net_context_connect(struct net_context *context,
 			goto unlock;
 		}
 
-		net_sin6_ptr(&context->local)->sin6_family = NET_AF_INET6;
+		net_sin6(&context->local)->sin6_family = NET_AF_INET6;
 		net_sin6(&local_addr)->sin6_family = NET_AF_INET6;
 		net_sin6(&local_addr)->sin6_port = lport =
-			net_sin6((struct net_sockaddr *)&context->local)->sin6_port;
+			net_sin6(&context->local)->sin6_port;
 
 		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
-				     net_sin6_ptr(&context->local)->sin6_addr);
+				     &net_sin6(&context->local)->sin6_addr);
 
 			laddr = &local_addr;
 		}
@@ -1559,14 +1557,14 @@ int net_context_connect(struct net_context *context,
 			goto unlock;
 		}
 
-		net_sin_ptr(&context->local)->sin_family = NET_AF_INET;
+		net_sin(&context->local)->sin_family = NET_AF_INET;
 		net_sin(&local_addr)->sin_family = NET_AF_INET;
 		net_sin(&local_addr)->sin_port = lport =
-			net_sin((struct net_sockaddr *)&context->local)->sin_port;
+			net_sin(&context->local)->sin_port;
 
 		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
-				       net_sin_ptr(&context->local)->sin_addr);
+				       &net_sin(&context->local)->sin_addr);
 
 			laddr = &local_addr;
 		}
@@ -3115,7 +3113,7 @@ static int context_sendto(struct net_context *context,
 		if (can_addr->can_ifindex < 0) {
 			/* The index should have been set in bind */
 			can_addr->can_ifindex =
-				net_can_ptr(&context->local)->can_ifindex;
+				((struct net_sockaddr_can *)&context->local)->can_ifindex;
 		}
 
 		if (can_addr->can_ifindex < 0) {
@@ -3289,14 +3287,14 @@ skip_alloc:
 
 		net_pkt_cursor_init(pkt);
 
-		struct net_sockaddr_ll_ptr *ll_src_addr;
+		struct net_sockaddr_ll *ll_src_addr;
 		struct net_sockaddr_ll *ll_dst_addr;
 
 		/* The destination address is set in remote for this
 		 * socket type.
 		 */
 		ll_dst_addr = (struct net_sockaddr_ll *)&context->remote;
-		ll_src_addr = (struct net_sockaddr_ll_ptr *)&context->local;
+		ll_src_addr = (struct net_sockaddr_ll *)&context->local;
 
 		(void)net_linkaddr_set(net_pkt_lladdr_dst(pkt),
 				       ll_dst_addr->sll_addr,
@@ -3583,7 +3581,7 @@ static int udp_dplpmtud_send_probe(struct net_context *context, uint16_t size,
 	}
 
 	ret = net_udp_create(pkt,
-			     net_sin((struct net_sockaddr *)&context->local)->sin_port,
+			     net_sin(&context->local)->sin_port,
 			     net_sin(&context->remote)->sin_port);
 	if (ret < 0) {
 		goto fail;
@@ -3984,24 +3982,24 @@ static int recv_dgram(struct net_context *context,
 	    net_context_get_family(context) == NET_AF_INET6) {
 		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
-				     net_sin6_ptr(&context->local)->sin6_addr);
+				     &net_sin6(&context->local)->sin6_addr);
 
 			laddr = &local_addr;
 		}
 
 		net_sin6(&local_addr)->sin6_port =
-			net_sin6((struct net_sockaddr *)&context->local)->sin6_port;
-		lport = net_sin6((struct net_sockaddr *)&context->local)->sin6_port;
+			net_sin6(&context->local)->sin6_port;
+		lport = net_sin6(&context->local)->sin6_port;
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		   net_context_get_family(context) == NET_AF_INET) {
 		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
-				      net_sin_ptr(&context->local)->sin_addr);
+				      &net_sin(&context->local)->sin_addr);
 
 			laddr = &local_addr;
 		}
 
-		lport = net_sin((struct net_sockaddr *)&context->local)->sin_port;
+		lport = net_sin(&context->local)->sin_port;
 	}
 
 	context->recv_cb = cb;
@@ -4160,41 +4158,37 @@ int net_context_recv(struct net_context *context,
 		if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&
 		    family == NET_AF_PACKET) {
 			struct net_sockaddr_ll addr = { 0 };
+			struct net_sockaddr_ll *local_ll =
+				(struct net_sockaddr_ll *)&context->local;
+			struct net_if *pkt_iface;
 
 			ret = bind_default(context);
 			if (ret < 0) {
 				goto unlock;
 			}
 
+			pkt_iface = net_context_get_iface(context);
+
 			addr.sll_family = NET_AF_PACKET;
-			addr.sll_ifindex =
-				net_sll_ptr(&context->local)->sll_ifindex;
-			addr.sll_protocol =
-				net_sll_ptr(&context->local)->sll_protocol;
-			addr.sll_halen =
-				net_sll_ptr(&context->local)->sll_halen;
+			addr.sll_ifindex = local_ll->sll_ifindex;
+			addr.sll_protocol = local_ll->sll_protocol;
+			addr.sll_halen = local_ll->sll_halen;
 
-			if (net_sll_ptr(&context->local)->sll_addr != NULL) {
-				/* NET_AF_PACKET socket is bound to an iface as
-				 * context->local->sll_addr is valid.  Although the sll_addr
-				 * pointer correctly links to the iface net_linkaddr, the
-				 * sll_halen is a copy and doesn't track properly the iface
-				 * linkaddr len. For example, the linkaddr len can change
-				 * depending on the link address format with 802.15.4, between
-				 * extended (8 bytes) or short (2 bytes).
-				 *
-				 * Instead, use the iface link_addr directly. The socket is
-				 * bound to an interface as context->local->sll_addr is valid.
+			if (pkt_iface != NULL) {
+				/* The NET_AF_PACKET socket is bound to an
+				 * interface. Read the link address directly from
+				 * it rather than from the copy stored at bind
+				 * time: the link address length can change at
+				 * runtime (e.g. 802.15.4 switching between short
+				 * (2 bytes) and extended (8 bytes) addressing).
 				 */
-				struct net_linkaddr *link_addr = CONTAINER_OF(
-						(uint8_t(*)[NET_LINK_ADDR_MAX_LENGTH])
-						net_sll_ptr(&context->local)->sll_addr,
-						struct net_linkaddr, addr);
+				struct net_linkaddr *link_addr =
+					net_if_get_link_addr(pkt_iface);
 
-				addr.sll_halen = link_addr->len;
-				memcpy(addr.sll_addr,
-				       net_sll_ptr(&context->local)->sll_addr,
-				       MIN(addr.sll_halen, sizeof(addr.sll_addr)));
+				addr.sll_halen = MIN(link_addr->len,
+						     sizeof(addr.sll_addr));
+				memcpy(addr.sll_addr, link_addr->addr,
+				       addr.sll_halen);
 			}
 
 			ret = recv_raw(context, cb, timeout,
@@ -5438,22 +5432,22 @@ int net_context_get_local_addr(struct net_context *ctx,
 	if (IS_ENABLED(CONFIG_NET_UDP) && net_context_get_type(ctx) == NET_SOCK_DGRAM) {
 		net_socklen_t newlen;
 
-		if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.family == NET_AF_INET) {
+		if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.sa_family == NET_AF_INET) {
 			newlen = MIN(*addrlen, sizeof(struct net_sockaddr_in));
 
 			net_sin(addr)->sin_family = NET_AF_INET;
-			net_sin(addr)->sin_port = net_sin_ptr(&ctx->local)->sin_port;
+			net_sin(addr)->sin_port = net_sin(&ctx->local)->sin_port;
 			memcpy(&net_sin(addr)->sin_addr,
-			       net_sin_ptr(&ctx->local)->sin_addr,
+			       &net_sin(&ctx->local)->sin_addr,
 			       sizeof(struct net_in_addr));
 
-		} else if (IS_ENABLED(CONFIG_NET_IPV6) && ctx->local.family == NET_AF_INET6) {
+		} else if (IS_ENABLED(CONFIG_NET_IPV6) && ctx->local.sa_family == NET_AF_INET6) {
 			newlen = MIN(*addrlen, sizeof(struct net_sockaddr_in6));
 
 			net_sin6(addr)->sin6_family = NET_AF_INET6;
-			net_sin6(addr)->sin6_port = net_sin6_ptr(&ctx->local)->sin6_port;
+			net_sin6(addr)->sin6_port = net_sin6(&ctx->local)->sin6_port;
 			memcpy(&net_sin6(addr)->sin6_addr,
-			       net_sin6_ptr(&ctx->local)->sin6_addr,
+			       &net_sin6(&ctx->local)->sin6_addr,
 			       sizeof(struct net_in6_addr));
 		} else {
 			return -EAFNOSUPPORT;

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -216,7 +216,7 @@ static int check_used_port(struct net_context *context,
 
 		if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		    local_addr->sa_family == NET_AF_INET6) {
-			if (net_sin6_ptr(&contexts[i].local)->sin6_addr == NULL ||
+			if (!net_context_is_local_addr_set(&contexts[i]) ||
 			    net_sin6_ptr(&contexts[i].local)->sin6_family != NET_AF_INET6) {
 				continue;
 			}
@@ -276,7 +276,7 @@ static int check_used_port(struct net_context *context,
 			 * if v6only option is enabled, then it is possible to
 			 * bind IPv4 address to it.
 			 */
-			if (net_sin_ptr(&contexts[i].local)->sin_addr == NULL ||
+			if (!net_context_is_local_addr_set(&contexts[i]) ||
 			    ((IS_ENABLED(CONFIG_NET_IPV4_MAPPING_TO_IPV6) ?
 			      net_context_is_v6only_set(&contexts[i]) : true) &&
 			     net_sin_ptr(&contexts[i].local)->sin_family != NET_AF_INET)) {
@@ -789,12 +789,13 @@ static int bind_default(struct net_context *context)
 {
 	net_sa_family_t family = net_context_get_family(context);
 
+	/* Already bound to a local address, nothing to do. */
+	if (net_context_is_local_addr_set(context)) {
+		return 0;
+	}
+
 	if (IS_ENABLED(CONFIG_NET_IPV6) && family == NET_AF_INET6) {
 		struct net_sockaddr_in6 addr6;
-
-		if (net_sin6_ptr(&context->local)->sin6_addr) {
-			return 0;
-		}
 
 		addr6.sin6_family = NET_AF_INET6;
 		memcpy(&addr6.sin6_addr, net_ipv6_unspecified_address(),
@@ -810,10 +811,6 @@ static int bind_default(struct net_context *context)
 	if (IS_ENABLED(CONFIG_NET_IPV4) && family == NET_AF_INET) {
 		struct net_sockaddr_in addr4;
 
-		if (net_sin_ptr(&context->local)->sin_addr) {
-			return 0;
-		}
-
 		addr4.sin_family = NET_AF_INET;
 		addr4.sin_addr.s_addr = NET_INADDR_ANY;
 		addr4.sin_port = net_context_get_type(context) == NET_SOCK_RAW ?
@@ -827,10 +824,6 @@ static int bind_default(struct net_context *context)
 	if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) && family == NET_AF_PACKET) {
 		struct net_sockaddr_ll ll_addr;
 		struct net_if *iface = net_context_get_iface(context);
-
-		if (net_sll_ptr(&context->local)->sll_addr) {
-			return 0;
-		}
 
 		ll_addr.sll_family = NET_AF_PACKET;
 		ll_addr.sll_protocol = net_htons(net_context_get_proto(context));
@@ -1008,6 +1001,7 @@ int net_context_bind(struct net_context *context, const struct net_sockaddr *add
 
 		net_sin6_ptr(&context->local)->sin6_family = NET_AF_INET6;
 		net_sin6_ptr(&context->local)->sin6_addr = ptr;
+		context->flags |= NET_CONTEXT_LOCAL_ADDR_SET;
 
 		if (IS_ENABLED(CONFIG_NET_OFFLOAD) && net_if_is_ip_offloaded(iface)) {
 			k_mutex_unlock(&context->lock);
@@ -1115,6 +1109,7 @@ int net_context_bind(struct net_context *context, const struct net_sockaddr *add
 
 		net_sin_ptr(&context->local)->sin_family = NET_AF_INET;
 		net_sin_ptr(&context->local)->sin_addr = ptr;
+		context->flags |= NET_CONTEXT_LOCAL_ADDR_SET;
 
 		if (IS_ENABLED(CONFIG_NET_OFFLOAD) && net_if_is_ip_offloaded(iface)) {
 			k_mutex_unlock(&context->lock);
@@ -1187,6 +1182,7 @@ int net_context_bind(struct net_context *context, const struct net_sockaddr *add
 			ll_addr->sll_ifindex;
 		net_sll_ptr(&context->local)->sll_protocol =
 			ll_addr->sll_protocol;
+		context->flags |= NET_CONTEXT_LOCAL_ADDR_SET;
 
 		if (iface != NULL) {
 			net_context_set_iface(context, iface);
@@ -1248,6 +1244,7 @@ int net_context_bind(struct net_context *context, const struct net_sockaddr *add
 		net_can_ptr(&context->local)->can_family = NET_AF_CAN;
 		net_can_ptr(&context->local)->can_ifindex =
 			can_addr->can_ifindex;
+		context->flags |= NET_CONTEXT_LOCAL_ADDR_SET;
 
 		NET_DBG("Context %p binding to %d iface[%d] %p",
 			context, net_context_get_proto(context),
@@ -1311,8 +1308,7 @@ static int context_create_ipv4_new(struct net_context *context,
 				   bool dont_fragment)
 {
 	if (!src) {
-		NET_ASSERT(((
-			struct net_sockaddr_in_ptr *)&context->local)->sin_addr);
+		NET_ASSERT(net_context_is_local_addr_set(context));
 
 		src = ((struct net_sockaddr_in_ptr *)&context->local)->sin_addr;
 	}
@@ -1366,8 +1362,7 @@ static int context_create_ipv6_new(struct net_context *context,
 				   bool dont_fragment)
 {
 	if (!src) {
-		NET_ASSERT(((
-			struct net_sockaddr_in6_ptr *)&context->local)->sin6_addr);
+		NET_ASSERT(net_context_is_local_addr_set(context));
 
 		src = ((struct net_sockaddr_in6_ptr *)&context->local)->sin6_addr;
 	}
@@ -1521,7 +1516,7 @@ int net_context_connect(struct net_context *context,
 		net_sin6(&local_addr)->sin6_port = lport =
 			net_sin6((struct net_sockaddr *)&context->local)->sin6_port;
 
-		if (net_sin6_ptr(&context->local)->sin6_addr) {
+		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
 				     net_sin6_ptr(&context->local)->sin6_addr);
 
@@ -1569,7 +1564,7 @@ int net_context_connect(struct net_context *context,
 		net_sin(&local_addr)->sin_port = lport =
 			net_sin((struct net_sockaddr *)&context->local)->sin_port;
 
-		if (net_sin_ptr(&context->local)->sin_addr) {
+		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
 				       net_sin_ptr(&context->local)->sin_addr);
 
@@ -3987,7 +3982,7 @@ static int recv_dgram(struct net_context *context,
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
 	    net_context_get_family(context) == NET_AF_INET6) {
-		if (net_sin6_ptr(&context->local)->sin6_addr) {
+		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&net_sin6(&local_addr)->sin6_addr,
 				     net_sin6_ptr(&context->local)->sin6_addr);
 
@@ -3999,7 +3994,7 @@ static int recv_dgram(struct net_context *context,
 		lport = net_sin6((struct net_sockaddr *)&context->local)->sin6_port;
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		   net_context_get_family(context) == NET_AF_INET) {
-		if (net_sin_ptr(&context->local)->sin_addr) {
+		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&net_sin(&local_addr)->sin_addr,
 				      net_sin_ptr(&context->local)->sin_addr);
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -281,7 +281,7 @@ int net_tcp_endpoint_copy(struct net_context *ctx,
 			  net_socklen_t *addrlen)
 {
 	const struct tcp *conn = ctx->tcp;
-	net_socklen_t newlen = ctx->local.family == NET_AF_INET ?
+	net_socklen_t newlen = ctx->local.sa_family == NET_AF_INET ?
 		sizeof(struct net_sockaddr_in) :
 		sizeof(struct net_sockaddr_in6);
 
@@ -291,21 +291,22 @@ int net_tcp_endpoint_copy(struct net_context *ctx,
 		 * be different if we are bound to any address.
 		 */
 		if (conn->state < TCP_ESTABLISHED) {
-			if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.family == NET_AF_INET) {
+			if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.sa_family == NET_AF_INET) {
 				memcpy(&net_sin(local)->sin_addr,
-				       net_sin_ptr(&ctx->local)->sin_addr,
+				       &net_sin(&ctx->local)->sin_addr,
 				       sizeof(struct net_in_addr));
-				net_sin(local)->sin_port = net_sin_ptr(&ctx->local)->sin_port;
+				net_sin(local)->sin_port = net_sin(&ctx->local)->sin_port;
 				net_sin(local)->sin_family = NET_AF_INET;
 			} else if (IS_ENABLED(CONFIG_NET_IPV6) &&
-				   ctx->local.family == NET_AF_INET6) {
+				   ctx->local.sa_family == NET_AF_INET6) {
 				memcpy(&net_sin6(local)->sin6_addr,
-				       net_sin6_ptr(&ctx->local)->sin6_addr,
+				       &net_sin6(&ctx->local)->sin6_addr,
 				       sizeof(struct net_in6_addr));
-				net_sin6(local)->sin6_port = net_sin6_ptr(&ctx->local)->sin6_port;
+				net_sin6(local)->sin6_port =
+					net_sin6(&ctx->local)->sin6_port;
 				net_sin6(local)->sin6_family = NET_AF_INET6;
 				net_sin6(local)->sin6_scope_id =
-					net_sin6_ptr(&ctx->local)->sin6_scope_id;
+					net_sin6(&ctx->local)->sin6_scope_id;
 			} else {
 				return -EINVAL;
 			}
@@ -2554,7 +2555,7 @@ static struct tcp *tcp_conn_new(struct net_pkt *pkt)
 	memcpy(&context->remote, &conn->dst, sizeof(context->remote));
 	context->flags |= NET_CONTEXT_REMOTE_ADDR_SET;
 
-	net_sin_ptr(&context->local)->sin_family = af;
+	net_sin(&context->local)->sin_family = af;
 
 	local_addr.sa_family = net_context_get_family(context);
 
@@ -2590,10 +2591,10 @@ static struct tcp *tcp_conn_new(struct net_pkt *pkt)
 	 */
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
 	    net_context_get_family(context) == NET_AF_INET6) {
-		net_sin6_ptr(&context->local)->sin6_port = conn->src.sin6.sin6_port;
+		net_sin6(&context->local)->sin6_port = conn->src.sin6.sin6_port;
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		   net_context_get_family(context) == NET_AF_INET) {
-		net_sin_ptr(&context->local)->sin_port = conn->src.sin.sin_port;
+		net_sin(&context->local)->sin_port = conn->src.sin.sin_port;
 	}
 
 	if (!(IS_ENABLED(CONFIG_NET_TEST_PROTOCOL) ||
@@ -4229,11 +4230,11 @@ int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,
 
 		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&in->sin_addr,
-					net_sin_ptr(&context->local)->sin_addr);
+					&net_sin(&context->local)->sin_addr);
 		}
 
 		in->sin_port =
-			net_sin((struct net_sockaddr *)&context->local)->sin_port;
+			net_sin(&context->local)->sin_port;
 		local_port = net_ntohs(in->sin_port);
 		remote_port = net_ntohs(net_sin(&context->remote)->sin_port);
 
@@ -4248,11 +4249,11 @@ int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,
 
 		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&in6->sin6_addr,
-				net_sin6_ptr(&context->local)->sin6_addr);
+				&net_sin6(&context->local)->sin6_addr);
 		}
 
 		in6->sin6_port =
-			net_sin6((struct net_sockaddr *)&context->local)->sin6_port;
+			net_sin6(&context->local)->sin6_port;
 		local_port = net_ntohs(in6->sin6_port);
 		remote_port = net_ntohs(net_sin6(&context->remote)->sin6_port);
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -4227,7 +4227,7 @@ int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,
 
 		in = (struct net_sockaddr_in *)&local_addr;
 
-		if (net_sin_ptr(&context->local)->sin_addr) {
+		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&in->sin_addr,
 					net_sin_ptr(&context->local)->sin_addr);
 		}
@@ -4246,7 +4246,7 @@ int net_tcp_accept(struct net_context *context, net_tcp_accept_cb_t cb,
 
 		in6 = (struct net_sockaddr_in6 *)&local_addr;
 
-		if (net_sin6_ptr(&context->local)->sin6_addr) {
+		if (net_context_is_local_addr_set(context)) {
 			net_ipaddr_copy(&in6->sin6_addr,
 				net_sin6_ptr(&context->local)->sin6_addr);
 		}

--- a/subsys/net/lib/shell/conn.c
+++ b/subsys/net/lib/shell/conn.c
@@ -125,7 +125,7 @@ static void tcp_cb(struct tcp *conn, void *user_data)
 
 	PR("%p %p   %5u    %5u %10u %10u %5u   %s\n",
 	   conn, conn->context,
-	   net_ntohs(net_sin6_ptr(&conn->context->local)->sin6_port),
+	   net_ntohs(net_sin6(&conn->context->local)->sin6_port),
 	   net_ntohs(net_sin6(&conn->context->remote)->sin6_port),
 	   conn->seq, conn->ack, recv_mss,
 	   net_tcp_state_str(net_tcp_get_state(conn)));

--- a/subsys/net/lib/shell/net_shell.c
+++ b/subsys/net/lib/shell/net_shell.c
@@ -87,7 +87,7 @@ void get_addresses(struct net_context *context,
 		   char addr_remote[], int remote_len)
 {
 	if (IS_ENABLED(CONFIG_NET_IPV6) && context->local.family == NET_AF_INET6) {
-		if (net_sin6_ptr(&context->local)->sin6_addr != NULL) {
+		if (net_context_is_local_addr_set(context)) {
 			snprintk(addr_local, local_len, "[%s]:%u",
 				 net_sprint_ipv6_addr(
 					 net_sin6_ptr(&context->local)->sin6_addr),
@@ -102,7 +102,7 @@ void get_addresses(struct net_context *context,
 			 net_ntohs(net_sin6(&context->remote)->sin6_port));
 
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) && context->local.family == NET_AF_INET) {
-		if (net_sin_ptr(&context->local)->sin_addr != NULL) {
+		if (net_context_is_local_addr_set(context)) {
 			snprintk(addr_local, local_len, "%s:%d",
 				 net_sprint_ipv4_addr(
 					 net_sin_ptr(&context->local)->sin_addr),

--- a/subsys/net/lib/shell/net_shell.c
+++ b/subsys/net/lib/shell/net_shell.c
@@ -86,12 +86,12 @@ void get_addresses(struct net_context *context,
 		   char addr_local[], int local_len,
 		   char addr_remote[], int remote_len)
 {
-	if (IS_ENABLED(CONFIG_NET_IPV6) && context->local.family == NET_AF_INET6) {
+	if (IS_ENABLED(CONFIG_NET_IPV6) && context->local.sa_family == NET_AF_INET6) {
 		if (net_context_is_local_addr_set(context)) {
 			snprintk(addr_local, local_len, "[%s]:%u",
 				 net_sprint_ipv6_addr(
-					 net_sin6_ptr(&context->local)->sin6_addr),
-				 net_ntohs(net_sin6_ptr(&context->local)->sin6_port));
+					 &net_sin6(&context->local)->sin6_addr),
+				 net_ntohs(net_sin6(&context->local)->sin6_port));
 		} else {
 			snprintk(addr_local, local_len, "<not bound>");
 		}
@@ -101,12 +101,12 @@ void get_addresses(struct net_context *context,
 				 &net_sin6(&context->remote)->sin6_addr),
 			 net_ntohs(net_sin6(&context->remote)->sin6_port));
 
-	} else if (IS_ENABLED(CONFIG_NET_IPV4) && context->local.family == NET_AF_INET) {
+	} else if (IS_ENABLED(CONFIG_NET_IPV4) && context->local.sa_family == NET_AF_INET) {
 		if (net_context_is_local_addr_set(context)) {
 			snprintk(addr_local, local_len, "%s:%d",
 				 net_sprint_ipv4_addr(
-					 net_sin_ptr(&context->local)->sin_addr),
-				 net_ntohs(net_sin_ptr(&context->local)->sin_port));
+					 &net_sin(&context->local)->sin_addr),
+				 net_ntohs(net_sin(&context->local)->sin_port));
 		} else {
 			snprintk(addr_local, local_len, "<not bound>");
 		}
@@ -126,15 +126,15 @@ void get_addresses(struct net_context *context,
 				 net_ntohs(net_sin(&context->remote)->sin_port));
 		}
 
-	} else if (context->local.family == NET_AF_UNSPEC) {
+	} else if (context->local.sa_family == NET_AF_UNSPEC) {
 		snprintk(addr_local, local_len, "AF_UNSPEC");
-	} else if (context->local.family == NET_AF_PACKET) {
+	} else if (context->local.sa_family == NET_AF_PACKET) {
 		snprintk(addr_local, local_len, "AF_PACKET");
-	} else if (context->local.family == NET_AF_CAN) {
+	} else if (context->local.sa_family == NET_AF_CAN) {
 		snprintk(addr_local, local_len, "AF_CAN");
 	} else {
 		snprintk(addr_local, local_len, "AF_UNK(%d)",
-			 context->local.family);
+			 context->local.sa_family);
 	}
 }
 #endif /* CONFIG_NET_OFFLOAD || CONFIG_NET_NATIVE */

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -3354,7 +3354,7 @@ int zsock_getsockname_ctx(struct net_context *ctx, struct net_sockaddr *addr,
 	if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.family == NET_AF_INET) {
 		struct net_sockaddr_in addr4 = { 0 };
 
-		if (net_sin_ptr(&ctx->local)->sin_addr == NULL) {
+		if (!net_context_is_local_addr_set(ctx)) {
 			errno = EINVAL;
 			return -1;
 		}
@@ -3374,7 +3374,7 @@ int zsock_getsockname_ctx(struct net_context *ctx, struct net_sockaddr *addr,
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) && ctx->local.family == NET_AF_INET6) {
 		struct net_sockaddr_in6 addr6 = { 0 };
 
-		if (net_sin6_ptr(&ctx->local)->sin6_addr == NULL) {
+		if (!net_context_is_local_addr_set(ctx)) {
 			errno = EINVAL;
 			return -1;
 		}

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1069,7 +1069,7 @@ static int add_pktinfo(struct net_context *ctx,
 
 		net_ipv4_addr_copy_raw((uint8_t *)&info.ipi_addr, ipv4_hdr->dst);
 		net_ipv4_addr_copy_raw((uint8_t *)&info.ipi_spec_dst,
-				       (uint8_t *)net_sin_ptr(&ctx->local)->sin_addr);
+				       (uint8_t *)&net_sin(&ctx->local)->sin_addr);
 		info.ipi_ifindex = ctx->iface;
 
 		ret = insert_pktinfo(msg, NET_IPPROTO_IP, ZSOCK_IP_PKTINFO,
@@ -3351,7 +3351,7 @@ int zsock_getsockname_ctx(struct net_context *ctx, struct net_sockaddr *addr,
 	net_socklen_t newlen = 0;
 	int ret;
 
-	if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.family == NET_AF_INET) {
+	if (IS_ENABLED(CONFIG_NET_IPV4) && ctx->local.sa_family == NET_AF_INET) {
 		struct net_sockaddr_in addr4 = { 0 };
 
 		if (!net_context_is_local_addr_set(ctx)) {
@@ -3371,7 +3371,7 @@ int zsock_getsockname_ctx(struct net_context *ctx, struct net_sockaddr *addr,
 
 		memcpy(addr, &addr4, MIN(*addrlen, newlen));
 
-	} else if (IS_ENABLED(CONFIG_NET_IPV6) && ctx->local.family == NET_AF_INET6) {
+	} else if (IS_ENABLED(CONFIG_NET_IPV6) && ctx->local.sa_family == NET_AF_INET6) {
 		struct net_sockaddr_in6 addr6 = { 0 };
 
 		if (!net_context_is_local_addr_set(ctx)) {


### PR DESCRIPTION
Keeping the local address in the `net_context` struct as a pointer to the address configured in at the interface level had a nasty design flaw - if the interface address table was modified (which could take place for example when the interface state toggled) and the address slot pointed by `net_context` local pointer was updated with a different address, as a consequence the `net_context` would silently "rebind" itself to a different address, which is clearly wrong and unexpected.

Fix this be storing the address copy instead of a pointer at the `net_context` level.

Fixes #114417