### PR TITLE
net: loopback: skip checksums and avoid packet cloning on TX

### DIFF
--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -208,6 +208,20 @@ config NET_LOOPBACK_MTU
 	help
 	  This option sets the MTU for loopback interface.
 
+config NET_LOOPBACK_SKIP_CHECKSUM
+	bool "Skip IP/UDP/TCP checksums for loopback traffic"
+	default y if !NET_TEST
+	help
+	  Loopback traffic never leaves the device, so computing the
+	  IPv4/ICMP/UDP/TCP checksums on transmit and verifying them
+	  again on receive only burns CPU cycles: the data cannot get
+	  corrupted in transit. Enabling this option skips the checksum
+	  calculation and verification for packets that are sent to and
+	  received from a loopback interface, which removes two full
+	  passes over the payload for every packet. Disable this if the
+	  checksums are needed, for example in protocol tests that
+	  inject deliberately corrupted packets.
+
 module = NET_LOOPBACK
 module-dep = LOG
 module-str = Log level for network loopback driver

--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -50,6 +50,8 @@ static void loopback_init(struct net_if *iface)
 	net_if_set_link_addr(iface, "\x00\x00\x5e\x00\x53\xff", 6,
 			     NET_LINK_DUMMY);
 
+	net_if_flag_set(iface, NET_IF_LOOPBACK);
+
 	if (IS_ENABLED(CONFIG_NET_IPV4)) {
 		struct net_in_addr ipv4_loopback = NET_INADDR_LOOPBACK_INIT;
 		struct net_in_addr netmask = { { { 255, 0, 0, 0 } } };
@@ -104,6 +106,46 @@ int loopback_get_num_dropped_packets(void)
 
 #endif
 
+/* The packet can be handed over to the RX path without copying it if
+ * nobody else holds a reference to it or to its buffers. Otherwise the
+ * original data must be preserved, e.g. TCP keeps a reference to the
+ * packet data for a possible retransmission.
+ */
+static bool loopback_can_reuse_pkt(struct net_pkt *pkt)
+{
+	struct net_buf *buf;
+
+	/* TCP segments can sit in the peer's receive queue for an
+	 * arbitrarily long time. Reusing the original packet would tie
+	 * up the TX packet/buffer pools there, starving the sender.
+	 * Keep the copy for TCP so that the receive window keeps being
+	 * backed by the RX pools.
+	 */
+	if (IS_ENABLED(CONFIG_NET_TCP)) {
+		if (net_pkt_family(pkt) == NET_AF_INET &&
+		    NET_IPV4_HDR(pkt)->proto == NET_IPPROTO_TCP) {
+			return false;
+		}
+
+		if (net_pkt_family(pkt) == NET_AF_INET6 &&
+		    NET_IPV6_HDR(pkt)->nexthdr == NET_IPPROTO_TCP) {
+			return false;
+		}
+	}
+
+	if (atomic_get(&pkt->atomic_ref) != 1) {
+		return false;
+	}
+
+	for (buf = pkt->buffer; buf != NULL; buf = buf->frags) {
+		if (buf->ref > 1U) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 static int loopback_send(const struct device *dev, struct net_pkt *pkt)
 {
 	struct net_pkt *cloned;
@@ -129,15 +171,25 @@ static int loopback_send(const struct device *dev, struct net_pkt *pkt)
 		return -ENODATA;
 	}
 
-	/* We should simulate normal driver meaning that if the packet is
-	 * properly sent (which is always in this driver), then the packet
-	 * must be dropped. This is very much needed for TCP packets where
-	 * the packet is reference counted in various stages of sending.
-	 */
-	cloned = net_pkt_rx_clone(pkt, K_MSEC(100));
-	if (!cloned) {
-		res = -ENOMEM;
-		goto out;
+	if (loopback_can_reuse_pkt(pkt)) {
+		/* Nobody else holds a reference to the packet or its
+		 * buffers, so it can be handed over to the RX path as is,
+		 * without paying for a full copy. The reference taken here
+		 * is released by the RX path, the TX reference is released
+		 * by the L2 when this function returns.
+		 */
+		cloned = net_pkt_ref(pkt);
+	} else {
+		/* We should simulate normal driver meaning that if the packet is
+		 * properly sent (which is always in this driver), then the packet
+		 * must be dropped. This is very much needed for TCP packets where
+		 * the packet is reference counted in various stages of sending.
+		 */
+		cloned = net_pkt_rx_clone(pkt, K_MSEC(100));
+		if (!cloned) {
+			res = -ENOMEM;
+			goto out;
+		}
 	}
 
 	/* We need to swap the IP addresses because otherwise
@@ -145,23 +197,33 @@ static int loopback_send(const struct device *dev, struct net_pkt *pkt)
 	 *
 	 * Some of the network tests require that addresses are not swapped so allow
 	 * the test to control this remotely.
+	 *
+	 * Note that "cloned" and "pkt" may be the same packet, so the swap
+	 * must go through a temporary copy of the source address.
 	 */
 	if (!COND_CODE_1(CONFIG_NET_TEST, (loopback_dont_swap_addresses), (false))) {
 		if (net_pkt_family(pkt) == NET_AF_INET6) {
+			uint8_t addr[NET_IPV6_ADDR_SIZE];
+
+			net_ipv6_addr_copy_raw(addr, NET_IPV6_HDR(pkt)->src);
 			net_ipv6_addr_copy_raw(NET_IPV6_HDR(cloned)->src,
 					       NET_IPV6_HDR(pkt)->dst);
 			net_ipv6_addr_copy_raw(NET_IPV6_HDR(cloned)->dst,
-					       NET_IPV6_HDR(pkt)->src);
+					       addr);
 		} else {
+			uint8_t addr[NET_IPV4_ADDR_SIZE];
+
+			net_ipv4_addr_copy_raw(addr, NET_IPV4_HDR(pkt)->src);
 			net_ipv4_addr_copy_raw(NET_IPV4_HDR(cloned)->src,
 					       NET_IPV4_HDR(pkt)->dst);
 			net_ipv4_addr_copy_raw(NET_IPV4_HDR(cloned)->dst,
-					       NET_IPV4_HDR(pkt)->src);
+					       addr);
 		}
 	}
 
 	res = net_recv_data(net_pkt_iface(cloned), cloned);
 	if (res < 0) {
+		net_pkt_unref(cloned);
 		LOG_ERR("Data receive failed.");
 	}
 

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -300,6 +300,11 @@ enum net_if_flag {
 	/** Mutex locking on TX data path disabled on the interface. */
 	NET_IF_NO_TX_LOCK,
 
+	/** Interface is a loopback interface, all traffic sent to it is
+	 * looped back to the same device without leaving it.
+	 */
+	NET_IF_LOOPBACK,
+
 /** @cond INTERNAL_HIDDEN */
 	/* Total number of flags - must be at the end of the enum */
 	NET_IF_NUM_FLAGS
@@ -3063,8 +3068,13 @@ bool net_if_need_calc_rx_checksum(struct net_if *iface,
 static inline bool net_if_need_calc_rx_checksum(struct net_if *iface,
 						enum net_if_checksum_type chksum_type)
 {
-	ARG_UNUSED(iface);
 	ARG_UNUSED(chksum_type);
+
+	if (IS_ENABLED(CONFIG_NET_LOOPBACK_SKIP_CHECKSUM) &&
+	    net_if_flag_is_set(iface, NET_IF_LOOPBACK)) {
+		return false;
+	}
+
 	return true;
 }
 #endif /* CONFIG_NET_CHECKSUM_OFFLOAD */
@@ -3087,8 +3097,13 @@ bool net_if_need_calc_tx_checksum(struct net_if *iface,
 static inline bool net_if_need_calc_tx_checksum(struct net_if *iface,
 						enum net_if_checksum_type chksum_type)
 {
-	ARG_UNUSED(iface);
 	ARG_UNUSED(chksum_type);
+
+	if (IS_ENABLED(CONFIG_NET_LOOPBACK_SKIP_CHECKSUM) &&
+	    net_if_flag_is_set(iface, NET_IF_LOOPBACK)) {
+		return false;
+	}
+
 	return true;
 }
 #endif /* CONFIG_NET_CHECKSUM_OFFLOAD */

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -5979,6 +5979,11 @@ static bool need_calc_checksum(struct net_if *iface, enum ethernet_hw_caps caps,
 	struct ethernet_config config;
 	enum ethernet_config_type config_type;
 
+	if (IS_ENABLED(CONFIG_NET_LOOPBACK_SKIP_CHECKSUM) &&
+	    net_if_flag_is_set(iface, NET_IF_LOOPBACK)) {
+		return false;
+	}
+
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(ETHERNET)) {
 		/* For VLANs, figure out the main Ethernet interface and
 		 * get the offloading capabilities from it.


### PR DESCRIPTION
Loopback traffic never leaves the device, so per-packet checksum computation/verification and deep-cloning into the RX pool are pure overhead.

This adds a `NET_IF_LOOPBACK` interface flag that lets `net_if_need_calc_tx_checksum()` / `net_if_need_calc_rx_checksum()` skip checksums (guarded by `CONFIG_NET_LOOPBACK_SKIP_CHECKSUM`, off for `NET_TEST` builds).

Also updates the loopback driver to set the flag and forward packets by reference instead of cloning them when it holds the only reference, falling back to cloning for TCP segments, which can sit in a peer's receive queue indefinitely. Also fixes a packet leak on `net_recv_data()` failure.

```
metric          baseline     current    change  status
tcp4_mbps          6.003       6.703    +11.7%  OK
tcp6_mbps          6.050       6.684    +10.5%  OK
udp4_mbps         13.251      18.958    +43.1%  OK
udp6_mbps         13.463      19.102    +41.9%  OK
```