### PR TITLE
net: pkt: Streamline the cursor operate loop

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1906,26 +1906,22 @@ static int net_pkt_cursor_operate(struct net_pkt *pkt,
 {
 	/* We use such variable to avoid lengthy lines */
 	struct net_pkt_cursor *c_op = &pkt->cursor;
+	const bool ow = net_pkt_is_being_overwritten(pkt);
+	const bool append = write && !ow;
 
 	while ((c_op->buf != NULL) && (length > 0U)) {
-		size_t d_len, len;
+		size_t limit, d_len, len;
 
-		pkt_cursor_advance(pkt, net_pkt_is_being_overwritten(pkt) ?
-				   false : write);
-		if (c_op->buf == NULL) {
-			break;
-		}
-
-		if (write && !net_pkt_is_being_overwritten(pkt)) {
-			d_len = net_buf_max_len(c_op->buf);
-		} else {
-			d_len = c_op->buf->len;
-		}
-
-		d_len -= c_op->pos - c_op->buf->data;
+		/* Compute the fragment limit only once per fragment */
+		limit = append ? net_buf_max_len(c_op->buf) : c_op->buf->len;
+		d_len = limit - (c_op->pos - c_op->buf->data);
 
 		if (d_len == 0U) {
-			break;
+			/* End of this fragment reached, move to the next
+			 * non-empty one.
+			 */
+			pkt_cursor_jump(pkt, append);
+			continue;
 		}
 
 		len = MIN(length, d_len);
@@ -1940,11 +1936,21 @@ static int net_pkt_cursor_operate(struct net_pkt *pkt,
 			}
 		}
 
-		if (write && !net_pkt_is_being_overwritten(pkt)) {
+		if (append) {
 			net_buf_add(c_op->buf, len);
 		}
 
-		pkt_cursor_update(pkt, len, write);
+		/* Update the cursor: when the end of the fragment has been
+		 * reached, jump to the next non-empty one, except in
+		 * overwrite mode when the fragment still has room for
+		 * subsequent appends.
+		 */
+		if (len == d_len &&
+		    !(ow && c_op->buf->len < net_buf_max_len(c_op->buf))) {
+			pkt_cursor_jump(pkt, append);
+		} else {
+			c_op->pos += len;
+		}
 
 		if (copy && (data != NULL)) {
 			data = (uint8_t *) data + len;


### PR DESCRIPTION
`net_pkt_cursor_operate()` re-derived the overwrite/append state of the operation and the fragment limits several times for every processed fragment, through `pkt_cursor_advance()` and `pkt_cursor_update()` which each recompute them. Since packet payloads are split into many small fragments (`CONFIG_NET_BUF_DATA_SIZE` is 128 bytes by default), this bookkeeping runs a dozen times for a single MTU-sized read or write and is pure overhead on every user-to-packet copy in the stack.

Hoist the loop-invariant overwrite/append state out of the loop, compute the fragment limit once per fragment, and update the cursor inline using the already computed values instead of re-deriving them in `pkt_cursor_update()`.

```
metric          baseline     current    change  status
tcp4_mbps          6.003       6.184     +3.0%  OK
tcp6_mbps          6.050       6.236     +3.1%  OK
udp4_mbps         13.251      13.651     +3.0%  OK
udp6_mbps         13.463      13.877     +3.1%  OK
```