### PR TITLE
boards: ti: lp_am13e230: add missing board yaml

### DIFF
--- a/boards/ti/lp_am13e230/lp_am13e230.yaml
+++ b/boards/ti/lp_am13e230/lp_am13e230.yaml
@@ -1,0 +1,9 @@
+identifier: lp_am13e230
+name: TI AM13E230X Launchpad
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+ram: 96
+flash: 512
+vendor: ti


### PR DESCRIPTION
The lp_am13e230 board directory had no board yaml, unlike its sibling TI LaunchPad boards.