### PR TITLE
drivers: input: *: select CONFIG_INPUT_TOUCH where needed

### DIFF
--- a/drivers/input/Kconfig.cst8xx
+++ b/drivers/input/Kconfig.cst8xx
@@ -6,6 +6,7 @@ menuconfig INPUT_CST8XX
 	default y
 	depends on DT_HAS_HYNITRON_CST8XX_ENABLED
 	select I2C
+	select INPUT_TOUCH
 	help
 	  Enable driver for hynitron cst8xx touch panel.
 

--- a/drivers/input/Kconfig.ili2132a
+++ b/drivers/input/Kconfig.ili2132a
@@ -6,5 +6,6 @@ config INPUT_ILI2132A
 	default y
 	depends on DT_HAS_ILITEK_ILI2132A_ENABLED
 	select I2C
+	select INPUT_TOUCH
 	help
 	  Enable driver for ilitek ili2132a touch controller

--- a/drivers/input/Kconfig.xpt2046
+++ b/drivers/input/Kconfig.xpt2046
@@ -6,6 +6,7 @@ config INPUT_XPT2046
 	default y
 	depends on DT_HAS_XPTEK_XPT2046_ENABLED
 	select SPI
+	select INPUT_TOUCH
 	help
 	  Enable driver for Xptek XPT2046 resistive touch panel.
 	  This driver is very similar to ADS7843, but differs on channel numbering.


### PR DESCRIPTION
Select CONFIG_INPUT_TOUCH for drivers that now depends on the APIs implemented there.

Fixes the CI issue seen in https://github.com/zephyrproject-rtos/zephyr/actions/runs/30092175096/job/89478168771