### PR TITLE
[Backport v4.3-branch] net: gptp: harden announce/message receive path

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -130,6 +130,11 @@ static bool gptp_handle_critical_msg(struct net_if *iface, struct net_pkt *pkt)
 
 static void gptp_handle_msg(struct net_pkt *pkt)
 {
+	if (GPTP_PACKET_LEN(pkt) < sizeof(struct gptp_hdr)) {
+		NET_DBG("gPTP packet too short (%zu)", GPTP_PACKET_LEN(pkt));
+		return;
+	}
+
 	struct gptp_hdr *hdr = GPTP_HDR(pkt);
 	struct gptp_pdelay_req_state *pdelay_req_state;
 	struct gptp_sync_rcv_state *sync_rcv_state;

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -1241,11 +1241,24 @@ static bool gptp_mi_qualify_announce(int port, struct net_pkt *announce_msg)
 		return false;
 	}
 
-	for (i = 0; i < len + 1; i++) {
-		if (memcmp(announce->tlv.path_sequence[i],
-			   GPTP_DEFAULT_DS()->clk_id,
-			   GPTP_CLOCK_ID_LEN) == 0) {
+	/* The path_sequence array in the announce TLV has (tlv.len /
+	 * GPTP_CLOCK_ID_LEN) entries. Iterating up to steps_removed+1
+	 * without validating against the TLV length reads past the data.
+	 */
+	{
+		uint16_t tlv_entries = ntohs(announce->tlv.len) / GPTP_CLOCK_ID_LEN;
+		uint16_t max_i = (uint16_t)(len + 1U);
+
+		if (max_i > tlv_entries) {
 			return false;
+		}
+
+		for (i = 0; i < max_i; i++) {
+			if (memcmp(announce->tlv.path_sequence[i],
+				   GPTP_DEFAULT_DS()->clk_id,
+				   GPTP_CLOCK_ID_LEN) == 0) {
+				return false;
+			}
 		}
 	}
 


### PR DESCRIPTION
Backport of the fix from #111986 to `v4.3-branch`.

Fixes: #114337