### PR TITLE
timer: cortex_m_systick: allow configurable SysTick interrupt priority

### DIFF
--- a/drivers/timer/Kconfig.cortex_m_systick
+++ b/drivers/timer/Kconfig.cortex_m_systick
@@ -42,6 +42,39 @@ config CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER
 	  This is set to y by default when the hardware clock is fast enough
 	  to wrap sys_clock_cycle_get_32() in about a minute or less.
 
+config CORTEX_M_SYSTICK_INTERRUPT_PRIORITY
+	int "Cortex-M SYSTICK timer interrupt priority"
+	depends on CORTEX_M_SYSTICK
+	default 0
+	help
+	  This option specifies the interrupt priority used by the Cortex-M
+	  SysTick timer, expressed the same way as any priority passed to
+	  IRQ_CONNECT(): 0 is the most urgent (kernel) level and the kernel
+	  reserved-level offset (_IRQ_PRIO_OFFSET) is applied internally.
+
+	  Valid values range from 0 up to the lowest usable IRQ priority for
+	  the target core (IRQ_PRIO_LOWEST).
+
+	  The default (0) preserves the historical behavior of running
+	  SysTick at the highest maskable/kernel IRQ priority level.
+
+	  WARNING: The timekeeping code in the SysTick driver tolerates at
+	  most one counter wrap between successive updates; the wrap period
+	  is floored at MIN_DELAY (the larger of 1024 cycles or
+	  CYC_PER_TICK/16, unless overridden by zephyr,min-timeout-cycles on
+	  the systick node). If the SysTick interrupt is held off longer than
+	  one wrap period, a full last_load worth of uptime is silently lost
+	  with no diagnostic.
+	  Raising the priority number (lowering SysTick's priority) reduces
+	  the latency impact on higher-priority interrupts, but it also makes
+	  the worst-case SysTick hold-off equal to the total nested run time
+	  of every higher-priority interrupt in the system. It is therefore
+	  safe ONLY while that worst-case hold-off remains below the wrap
+	  period.
+	  IMPORTANT: In practice, any non-default value MUST be paired with a
+	  larger zephyr,min-timeout-cycles on the systick node so that
+	  MIN_DELAY (and thus the wrap period) covers the worst-case hold-off.
+
 if CORTEX_M_SYSTICK
 
 # Deprecated SysTick-specific Kconfig symbols.

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -90,6 +90,18 @@ static inline uint32_t systick_min_delay(void)
 	return MAX(2U, cyc);
 }
 
+/* Validate the configured SysTick timer priority:
+ * Accepted values [0..IRQ_PRIO_LOWEST]
+ * IRQ_PRIO_LOWEST encodes the kernel reserved level offset (_IRQ_PRIO_OFFSET), so that
+ * the final NVIC priority calculated below is valid.
+ */
+BUILD_ASSERT(CONFIG_CORTEX_M_SYSTICK_INTERRUPT_PRIORITY >= 0 &&
+	     CONFIG_CORTEX_M_SYSTICK_INTERRUPT_PRIORITY <= IRQ_PRIO_LOWEST,
+	     "CONFIG_CORTEX_M_SYSTICK_INTERRUPT_PRIORITY out of range");
+
+/* Apply the kernel reserved level offset to deduce the NVIC priority. */
+#define SYSTICK_IRQ_PRIO (CONFIG_CORTEX_M_SYSTICK_INTERRUPT_PRIORITY + _IRQ_PRIO_OFFSET)
+
 static uint32_t last_load;
 
 /* Minimum LOAD value; derived from the cycle rate in sys_clock_driver_init()
@@ -644,7 +656,7 @@ void sys_clock_idle_exit(void)
 		if (!IS_ENABLED(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)) {
 			SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
 		} else {
-			NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
+			NVIC_SetPriority(SysTick_IRQn, SYSTICK_IRQ_PRIO);
 			SysTick->CTRL |= (SysTick_CTRL_ENABLE_Msk |
 					  SysTick_CTRL_TICKINT_Msk |
 					  SYSTICK_CTRL_CLKSOURCE_MSK_GET());
@@ -662,7 +674,7 @@ void sys_clock_disable(void)
 static int sys_clock_driver_init(void)
 {
 
-	NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
+	NVIC_SetPriority(SysTick_IRQn, SYSTICK_IRQ_PRIO);
 	min_delay = systick_min_delay();
 	last_load = CYC_PER_TICK;
 	overflow_cyc = 0U;


### PR DESCRIPTION
Introduce a Kconfig option to let users configure the SysTick interrupt priority like any other hardware interrupt in the system. This allows adjusting the SysTick priority to reduce latency impact on higher-priority interrupts when needed.

The default priority preserves the current behavior of using the highest maskable/kernel IRQ priority (_IRQ_PRIO_OFFSET).