### PR TITLE
net: shell: Remove hard dependency on IPv4 IGMP

### DIFF
--- a/subsys/net/lib/shell/Kconfig
+++ b/subsys/net/lib/shell/Kconfig
@@ -6,7 +6,6 @@
 menuconfig NET_SHELL
 	bool "Network shell utilities"
 	select SHELL
-	select NET_IPV4_IGMP if NET_NATIVE_IPV4
 	select REQUIRES_FLOAT_PRINTF
 	help
 	  Activate shell module that provides network commands like

--- a/subsys/net/lib/shell/ipv4.c
+++ b/subsys/net/lib/shell/ipv4.c
@@ -146,6 +146,10 @@ static int cmd_net_ip_add(const struct shell *sh, size_t argc, char *argv[])
 		if (ret < 0) {
 			PR_ERROR("Cannot %s multicast group %s for interface %d (%d)\n",
 				 "join", net_sprint_ipv4_addr(&addr), idx, ret);
+			if (ret == -ENOSYS) {
+				PR_INFO("Enable CONFIG_NET_IPV4_IGMP for %s multicast "
+					"group\n", "joining");
+			}
 			return ret;
 		}
 	} else {
@@ -213,6 +217,10 @@ static int cmd_net_ip_del(const struct shell *sh, size_t argc, char *argv[])
 		if (ret < 0) {
 			PR_ERROR("Cannot %s multicast group %s for interface %d (%d)\n",
 				 "leave", net_sprint_ipv4_addr(&addr), idx, ret);
+			if (ret == -ENOSYS) {
+				PR_INFO("Enable CONFIG_NET_IPV4_IGMP for %s multicast "
+					"group\n", "leaving");
+			}
 			return ret;
 		}
 	} else {


### PR DESCRIPTION
The network shell has no mandatory support for IPv4 IGMP. Remove the hard dependency on IPv4 IGMP when CONFIG_NET_SHELL is enabled.

Applications that use IPv4 multicast group join/leave from the network shell must now enable CONFIG_NET_IPV4_IGMP explicitly.

This change is similar to the fix in [366402a0c7b21 net/shell: Net shell has no mandatory support for IPv6 MLD](https://github.com/zephyrproject-rtos/zephyr/commit/366402a0c7b21)
And was even suggested by a [review comment](https://github.com/zephyrproject-rtos/zephyr/pull/66643#discussion_r1431248918)