### PR TITLE
dts: arm: st: h5: fix clocks of UCPD1 peripheral

### DIFF
--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -701,7 +701,7 @@
 		ucpd1: ucpd@4000dc00 {
 			compatible = "st,stm32-ucpd";
 			reg = <0x4000dc00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 23)>;
 			interrupts = <76 0>;
 			status = "disabled";
 		};


### PR DESCRIPTION
The UCPD1 clock enable bit is in
RCC_APB1HENR, which should be represented as `STM32_CLOCK(APB1_2, 23)`, but the SoC DTSI used `APB1` (no `_2`) instead. As a result, the UCPD clock could not really be enabled.

Reference Manual extract:
<img width="1101" height="573" alt="Screenshot from 2026-07-24 16-54-26" src="https://github.com/user-attachments/assets/90a1cdac-88c0-4320-8074-a4bec59a0a8d" />
