### PR TITLE
drivers: sdhc: esp32: add sdio host support and two-slot operation

### DIFF
--- a/drivers/sdhc/Kconfig.esp32
+++ b/drivers/sdhc/Kconfig.esp32
@@ -17,4 +17,13 @@ config SDHC_BUFFER_ALIGNMENT
 	default DCACHE_LINE_SIZE if DCACHE
 	default 4
 
+config SDHC_ESP32_SDIO
+	bool "SDIO host support (CMD53 data path and card interrupt)"
+	default y if SDIO_STACK
+	help
+	  Enable CMD53 data-phase handling and asynchronous SDIO card
+	  interrupt delivery so the Zephyr SDIO stack can drive an SDIO
+	  peripheral attached to the ESP32 SDMMC controller. CMD52 works
+	  without this option.
+
 endif

--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -113,11 +113,17 @@ struct sdhc_esp32_data {
 	uint8_t bus_width;  /* Bus width used by the slot (can change during execution) */
 	uint32_t bus_clock; /* Value in Hz; the low-level helpers use kHz */
 
+	/*
+	 * The host clock divider is a controller register but each slot may
+	 * need a different value, so the slot's own divider is kept here and
+	 * re-applied whenever the bus changes hands.
+	 */
+	int host_div;
+
 	enum sdhc_power power_mode;
 	enum sdhc_timing_mode timing;
 
 	struct host_ctx s_host_ctx;
-	struct k_mutex s_request_mutex;
 	bool s_is_app_cmd;
 	sdmmc_desc_t s_dma_desc[SDMMC_DMA_DESC_CNT] __aligned(SDMMC_DESC_ALIGN);
 	struct sdmmc_transfer_state s_cur_transfer;
@@ -127,6 +133,27 @@ struct sdhc_esp32_data {
 	int sdio_int_sources;
 #endif
 };
+
+/*
+ * Both slots are served by a single SDMMC controller: one register block, one
+ * command engine, one DMA channel and one interrupt line. The controller-wide
+ * bring-up (clock, reset, global registers, ISR and DMA) therefore runs once,
+ * on whichever slot initialises first, and the slots share the state below.
+ *
+ * The command engine can only carry one transaction at a time, so bus_mutex
+ * serialises transactions across slots. The slot that holds it is recorded in
+ * owner so the ISR can route completion events to the right event queue; the
+ * per-slot SDIO card interrupt is routed by its own slot bit instead.
+ */
+struct sdhc_esp32_ctrl_data {
+	struct k_mutex bus_mutex;
+	const struct device *owner;
+	const struct device *slot_dev[SOC_SDMMC_NUM_SLOTS];
+	intr_handle_t intr_handle;
+	bool initialized;
+};
+
+static struct sdhc_esp32_ctrl_data sdhc_esp32_ctrl;
 
 /**********************************************************************
  * ESP32 low level functions
@@ -156,6 +183,8 @@ struct sdhc_esp32_data {
  * Of the second stage dividers, div0 is used for card 0, and div1 is used
  * for card 1.
  */
+static int sdmmc_host_clock_update_command(sdmmc_dev_t *sdio_hw, int slot);
+
 static int sdmmc_host_set_clk_div(sdmmc_dev_t *sdio_hw, int div)
 {
 	if (!((div > 1) && (div <= 16))) {
@@ -197,8 +226,6 @@ static void sdmmc_host_dma_stop(sdmmc_dev_t *sdio_hw)
 
 static int sdmmc_host_transaction_handler_init(struct sdhc_esp32_data *data)
 {
-	k_mutex_init(&data->s_request_mutex);
-
 	data->s_is_app_cmd = false;
 
 	return 0;
@@ -656,8 +683,43 @@ static int sdmmc_host_do_transaction(const struct device *dev, int slot,
 	sdmmc_dev_t *sdio_hw = (sdmmc_dev_t *)cfg->sdio_hw;
 	int ret;
 
-	if (k_mutex_lock(&data->s_request_mutex, K_FOREVER) != 0) {
+	/*
+	 * The controller runs a single command engine, so a transaction on one
+	 * slot excludes the other. Claim the bus and record this slot as the
+	 * owner so the ISR routes completion events to its queue.
+	 */
+	if (k_mutex_lock(&sdhc_esp32_ctrl.bus_mutex, K_FOREVER) != 0) {
 		return ESP_ERR_NO_MEM;
+	}
+
+	/*
+	 * The host clock divider is a controller register shared by both slots,
+	 * so a slot taking the bus from the other one has to restore its own
+	 * divider before issuing a command. The per-slot card divider lives in
+	 * its own register field and survives the handover. A clock update
+	 * command is what pushes the new divider into the CIU, so it has to run
+	 * with the card clock stopped and the shared interrupt mask parked.
+	 */
+	if (sdhc_esp32_ctrl.owner != dev) {
+		if (sdhc_esp32_ctrl.owner != NULL && data->host_div != 0) {
+			uint32_t saved_intmask = sdio_hw->intmask.val;
+
+			sdio_hw->intmask.val = 0;
+
+			sdmmc_ll_enable_card_clock(sdio_hw, slot, false);
+			(void)sdmmc_host_clock_update_command(sdio_hw, slot);
+
+			(void)sdmmc_host_set_clk_div(sdio_hw, data->host_div);
+			(void)sdmmc_host_clock_update_command(sdio_hw, slot);
+
+			sdmmc_ll_enable_card_clock(sdio_hw, slot, true);
+			(void)sdmmc_host_clock_update_command(sdio_hw, slot);
+
+			sdmmc_ll_clear_interrupt(sdio_hw, 0xFFFF);
+			sdio_hw->intmask.val = saved_intmask;
+			k_msgq_purge(data->s_host_ctx.event_queue);
+		}
+		sdhc_esp32_ctrl.owner = dev;
 	}
 
 	/* dispose of any events which happened asynchronously */
@@ -749,7 +811,12 @@ static int sdmmc_host_do_transaction(const struct device *dev, int slot,
 
 out:
 
-	k_mutex_unlock(&data->s_request_mutex);
+	/*
+	 * Keep owner set: it records which slot's clock divider is currently
+	 * programmed, so the next transaction knows whether it has to restore
+	 * its own. The ISR uses it the same way while a transaction runs.
+	 */
+	k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
 
 	return ret;
 }
@@ -852,7 +919,7 @@ static int sdmmc_host_calc_freq(const int host_div, const int card_div)
 	return clk_src_freq_hz / host_div / ((card_div == 0) ? 1 : card_div * 2) / 1000;
 }
 
-int sdmmc_host_set_card_clk(sdmmc_dev_t *sdio_hw, int slot, uint32_t freq_khz)
+int sdmmc_host_set_card_clk(sdmmc_dev_t *sdio_hw, int slot, uint32_t freq_khz, int *out_host_div)
 {
 	if (!(slot == 0 || slot == 1)) {
 		return ESP_ERR_INVALID_ARG;
@@ -872,7 +939,7 @@ int sdmmc_host_set_card_clk(sdmmc_dev_t *sdio_hw, int slot, uint32_t freq_khz)
 	if (err != 0) {
 		LOG_ERR("disabling clk failed");
 		LOG_ERR("%s: sdmmc_host_clock_update_command returned 0x%x", __func__, err);
-		return err;
+		goto restore;
 	}
 
 	int host_div = 0; /* clock divider of the host (sdio_hw->clock) */
@@ -889,8 +956,12 @@ int sdmmc_host_set_card_clk(sdmmc_dev_t *sdio_hw, int slot, uint32_t freq_khz)
 	sdmmc_ll_set_card_clock_div(sdio_hw, slot, card_div);
 	err = sdmmc_host_set_clk_div(sdio_hw, host_div);
 
+	if (out_host_div != NULL) {
+		*out_host_div = host_div;
+	}
+
 	if (err != 0) {
-		return err;
+		goto restore;
 	}
 
 	err = sdmmc_host_clock_update_command(sdio_hw, slot);
@@ -898,7 +969,7 @@ int sdmmc_host_set_card_clk(sdmmc_dev_t *sdio_hw, int slot, uint32_t freq_khz)
 	if (err != 0) {
 		LOG_ERR("setting clk div failed");
 		LOG_ERR("%s: sdmmc_host_clock_update_command returned 0x%x", __func__, err);
-		return err;
+		goto restore;
 	}
 
 	/* Re-enable clocks */
@@ -910,7 +981,7 @@ int sdmmc_host_set_card_clk(sdmmc_dev_t *sdio_hw, int slot, uint32_t freq_khz)
 	if (err != 0) {
 		LOG_ERR("re-enabling clk failed");
 		LOG_ERR("%s: sdmmc_host_clock_update_command returned 0x%x", __func__, err);
-		return err;
+		goto restore;
 	}
 
 	/* set data timeout */
@@ -922,9 +993,16 @@ int sdmmc_host_set_card_clk(sdmmc_dev_t *sdio_hw, int slot, uint32_t freq_khz)
 	sdmmc_ll_set_response_timeout(sdio_hw, 255);
 
 	sdio_hw->rintsts.val = 0xFFFFFFFFU;
+
+restore:
+	/*
+	 * Always put the interrupt mask back. Leaving it cleared on an error
+	 * path would silently disable the other slot's interrupts too, since
+	 * the register is shared by the whole controller.
+	 */
 	sdio_hw->intmask.val = saved_intmask;
 
-	return 0;
+	return err;
 }
 
 int sdmmc_host_set_bus_width(sdmmc_dev_t *sdio_hw, int slot, size_t width)
@@ -1042,7 +1120,7 @@ static void configure_slot_pins(const struct sdhc_esp32_config *cfg)
 /*
  * Reset USDHC controller
  */
-static int sdhc_esp32_reset(const struct device *dev)
+static int sdhc_esp32_reset_ctrl(const struct device *dev)
 {
 	const struct sdhc_esp32_config *cfg = dev->config;
 	sdmmc_dev_t *sdio_hw = (sdmmc_dev_t *)cfg->sdio_hw;
@@ -1076,6 +1154,94 @@ static int sdhc_esp32_reset(const struct device *dev)
 }
 
 /*
+ * Restore the controller registers cleared by a reset. The interrupt mask is
+ * shared, so the other slot's card-interrupt bit is preserved. That bit is
+ * armed under an interrupt lock, so the scan and the write take the same lock.
+ */
+static void sdhc_esp32_restore_after_reset(const struct device *dev)
+{
+	const struct sdhc_esp32_config *cfg = dev->config;
+	sdmmc_dev_t *sdio_hw = (sdmmc_dev_t *)cfg->sdio_hw;
+	uint32_t keep_io = 0;
+	unsigned int io_key;
+
+	sdio_hw->tmout.val = 0xFFFFFFFFU;
+	sdio_hw->rintsts.val = 0xFFFFFFFFU;
+
+	io_key = irq_lock();
+
+#ifdef CONFIG_SDHC_ESP32_SDIO
+	for (int s = 0; s < SOC_SDMMC_NUM_SLOTS; s++) {
+		const struct device *other = sdhc_esp32_ctrl.slot_dev[s];
+		struct sdhc_esp32_data *other_data;
+
+		if (other == NULL || other == dev) {
+			continue;
+		}
+
+		other_data = other->data;
+		if (other_data->sdio_int_sources != 0) {
+			keep_io |= (s == 0) ? SDMMC_LL_EVENT_IO_SLOT0 : SDMMC_LL_EVENT_IO_SLOT1;
+		}
+	}
+#endif
+
+	sdio_hw->intmask.val = SDMMC_INTMASK_CD | SDMMC_INTMASK_CMD_DONE |
+			       SDMMC_INTMASK_DATA_OVER | SDMMC_INTMASK_RCRC |
+			       SDMMC_INTMASK_DCRC | SDMMC_INTMASK_RTO | SDMMC_INTMASK_DTO |
+			       SDMMC_INTMASK_HTO | SDMMC_INTMASK_SBE | SDMMC_INTMASK_EBE |
+			       SDMMC_INTMASK_RESP_ERR | SDMMC_INTMASK_HLE | keep_io;
+	irq_unlock(io_key);
+
+	sdio_hw->ctrl.int_enable = 1;
+	sdio_hw->cardthrctl.busy_clr_int_en = 0;
+	sdmmc_host_dma_init(sdio_hw);
+}
+
+/*
+ * The reset is controller wide, so it must not run while the other slot owns
+ * the bus, and it clears the shared divider, interrupt mask and timeouts,
+ * which are restored here.
+ */
+static int sdhc_esp32_reset(const struct device *dev)
+{
+	const struct sdhc_esp32_config *cfg = dev->config;
+	sdmmc_dev_t *sdio_hw = (sdmmc_dev_t *)cfg->sdio_hw;
+	struct sdhc_esp32_data *data = dev->data;
+	int ret;
+
+	if (k_mutex_lock(&sdhc_esp32_ctrl.bus_mutex, K_FOREVER) != 0) {
+		return -EIO;
+	}
+
+	ret = sdhc_esp32_reset_ctrl(dev);
+	if (ret != 0) {
+		k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
+		return ret;
+	}
+
+	sdhc_esp32_restore_after_reset(dev);
+	k_msgq_purge(data->s_host_ctx.event_queue);
+
+	if (data->bus_clock != 0) {
+		ret = sdmmc_host_set_card_clk(sdio_hw, cfg->slot, data->bus_clock / 1000,
+					      &data->host_div);
+		if (ret != 0) {
+			LOG_ERR("Failed to re-apply card clock after reset");
+			k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
+			return err_esp2zep(ret);
+		}
+		k_msgq_purge(data->s_host_ctx.event_queue);
+	}
+
+	sdhc_esp32_ctrl.owner = dev;
+
+	k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
+
+	return 0;
+}
+
+/*
  * Set SDHC io properties
  */
 static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
@@ -1101,8 +1267,20 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 		}
 
 		if (data->bus_clock != (uint32_t)ios->clock) {
+			/*
+			 * Setting the card clock masks the shared interrupt
+			 * register and issues clock-update commands on the single
+			 * command engine, so it must not run while the other slot
+			 * owns the bus.
+			 */
+			k_mutex_lock(&sdhc_esp32_ctrl.bus_mutex, K_FOREVER);
+
 			/* Try setting new clock */
-			ret = sdmmc_host_set_card_clk(sdio_hw, cfg->slot, (ios->clock / 1000));
+			ret = sdmmc_host_set_card_clk(sdio_hw, cfg->slot, (ios->clock / 1000),
+						      &data->host_div);
+
+			/* The host divider now holds this slot's value. */
+			sdhc_esp32_ctrl.owner = dev;
 
 			if (ret == 0) {
 				/* Purge stale CMD_DONE events from clock update commands */
@@ -1110,10 +1288,13 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 				LOG_INF("Bus clock successfully set to %d kHz", ios->clock / 1000);
 			} else {
 				LOG_ERR("Error configuring card clock");
+				k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
 				return err_esp2zep(ret);
 			}
 
 			data->bus_clock = (uint32_t)ios->clock;
+
+			k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
 		}
 	}
 
@@ -1131,7 +1312,9 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 		}
 
 		if (data->bus_width != bus_width) {
+			k_mutex_lock(&sdhc_esp32_ctrl.bus_mutex, K_FOREVER);
 			ret = sdmmc_host_set_bus_width(sdio_hw, cfg->slot, bus_width);
+			k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
 
 			if (ret == 0) {
 				LOG_INF("Bus width set successfully to %d bit", bus_width);
@@ -1150,24 +1333,23 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 			if (cfg->pwr_gpio.port) {
 				gpio_pin_set_dt(&cfg->pwr_gpio, 0);
 			}
+			k_mutex_lock(&sdhc_esp32_ctrl.bus_mutex, K_FOREVER);
 			sdmmc_ll_enable_card_clock(sdio_hw, cfg->slot, false);
 			sdmmc_host_clock_update_command(sdio_hw, cfg->slot);
+			k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
 		} else if (ios->power_mode == SDHC_POWER_ON) {
 			if (cfg->pwr_gpio.port) {
 				gpio_pin_set_dt(&cfg->pwr_gpio, 1);
 			}
-			sdhc_esp32_reset(dev);
-			sdio_hw->tmout.val = 0xFFFFFFFFU;
-			sdio_hw->rintsts.val = 0xFFFFFFFFU;
-			sdio_hw->intmask.val = SDMMC_INTMASK_CD | SDMMC_INTMASK_CMD_DONE |
-					       SDMMC_INTMASK_DATA_OVER | SDMMC_INTMASK_RCRC |
-					       SDMMC_INTMASK_DCRC | SDMMC_INTMASK_RTO |
-					       SDMMC_INTMASK_DTO | SDMMC_INTMASK_HTO |
-					       SDMMC_INTMASK_SBE | SDMMC_INTMASK_EBE |
-					       SDMMC_INTMASK_RESP_ERR | SDMMC_INTMASK_HLE;
-			sdio_hw->ctrl.int_enable = 1;
-			sdio_hw->cardthrctl.busy_clr_int_en = 0;
-			sdmmc_host_dma_init(sdio_hw);
+			/*
+			 * Claim the bus: the reset and the register writes below
+			 * are controller wide and must not land in the middle of
+			 * a transaction running on the other slot.
+			 */
+			k_mutex_lock(&sdhc_esp32_ctrl.bus_mutex, K_FOREVER);
+
+			sdhc_esp32_reset_ctrl(dev);
+			sdhc_esp32_restore_after_reset(dev);
 			k_msgq_purge(data->s_host_ctx.event_queue);
 			/* Reset wiped the clock dividers. Re-apply the previously
 			 * configured bus clock so commands issued before the next
@@ -1175,13 +1357,24 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 			 */
 			if (data->bus_clock != 0) {
 				ret = sdmmc_host_set_card_clk(sdio_hw, cfg->slot,
-							      data->bus_clock / 1000);
+							      data->bus_clock / 1000,
+							      &data->host_div);
 				if (ret != 0) {
 					LOG_ERR("Failed to re-apply card clock after power-on");
+					k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
 					return err_esp2zep(ret);
 				}
 				k_msgq_purge(data->s_host_ctx.event_queue);
 			}
+
+			/*
+			 * The reset wiped the shared clock divider, so this slot
+			 * now owns it and the other one must reprogram before its
+			 * next command.
+			 */
+			sdhc_esp32_ctrl.owner = dev;
+
+			k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
 		}
 		data->power_mode = ios->power_mode;
 	}
@@ -1189,6 +1382,8 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 	if (ios->timing > 0) {
 		/* Set I/O timing */
 		if (data->timing != ios->timing) {
+			k_mutex_lock(&sdhc_esp32_ctrl.bus_mutex, K_FOREVER);
+
 			switch (ios->timing) {
 			case SDHC_TIMING_LEGACY:
 			case SDHC_TIMING_HS:
@@ -1213,6 +1408,8 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 				ret = -ENOTSUP;
 				break;
 			}
+
+			k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
 
 			LOG_INF("Bus timing successfully changed to %s", timingStr[ios->timing]);
 			data->timing = ios->timing;
@@ -1464,11 +1661,9 @@ static void IRAM_ATTR sdio_esp32_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	const struct sdhc_esp32_config *cfg = dev->config;
-	struct sdhc_esp32_data *data = dev->data;
 	sdmmc_dev_t *sdio_hw = (sdmmc_dev_t *)cfg->sdio_hw;
 
 	struct sdmmc_event event;
-	struct k_msgq *queue = data->s_host_ctx.event_queue;
 	/*
 	 * The card interrupt bits live at 16 and 17 and are dispatched
 	 * separately below, so the event queue only ever carries the low
@@ -1478,9 +1673,19 @@ static void IRAM_ATTR sdio_esp32_isr(void *arg)
 	uint32_t pending = raw & 0xFFFF;
 
 #ifdef CONFIG_SDHC_ESP32_SDIO
-	uint32_t io_bit = (cfg->slot == 0) ? SDMMC_LL_EVENT_IO_SLOT0 : SDMMC_LL_EVENT_IO_SLOT1;
+	/*
+	 * The card interrupt is the only per-slot source, so dispatch it to the
+	 * slot that owns the asserted bit rather than to the transaction owner.
+	 */
+	for (int slot = 0; slot < SOC_SDMMC_NUM_SLOTS; slot++) {
+		const struct device *slot_dev = sdhc_esp32_ctrl.slot_dev[slot];
+		uint32_t io_bit = (slot == 0) ? SDMMC_LL_EVENT_IO_SLOT0 : SDMMC_LL_EVENT_IO_SLOT1;
+		struct sdhc_esp32_data *slot_data;
 
-	if (raw & io_bit) {
+		if (slot_dev == NULL || !(raw & io_bit)) {
+			continue;
+		}
+
 		/*
 		 * Mask the source so it does not re-trigger before the consumer
 		 * has handled it, and clear the latched status: the bit is
@@ -1491,8 +1696,9 @@ static void IRAM_ATTR sdio_esp32_isr(void *arg)
 		sdmmc_ll_enable_interrupt(sdio_hw, io_bit, false);
 		sdmmc_ll_clear_interrupt(sdio_hw, io_bit);
 
-		if (data->sdio_cb) {
-			data->sdio_cb(dev, SDHC_INT_SDIO, data->sdio_cb_user_data);
+		slot_data = slot_dev->data;
+		if (slot_data->sdio_cb) {
+			slot_data->sdio_cb(slot_dev, SDHC_INT_SDIO, slot_data->sdio_cb_user_data);
 		}
 	}
 #endif
@@ -1506,8 +1712,94 @@ static void IRAM_ATTR sdio_esp32_isr(void *arg)
 	event.dma_status = dma_pending & 0x1f;
 
 	if ((pending != 0) || (dma_pending != 0)) {
-		k_msgq_put(queue, &event, K_NO_WAIT);
+		/*
+		 * Command and data events are not slot tagged; the controller
+		 * runs one transaction at a time, so they belong to the slot
+		 * currently holding the bus. Fall back to the slot the ISR was
+		 * registered with when no transaction is in flight.
+		 */
+		const struct device *owner = sdhc_esp32_ctrl.owner;
+		struct sdhc_esp32_data *owner_data = (owner != NULL) ? owner->data : dev->data;
+
+		k_msgq_put(owner_data->s_host_ctx.event_queue, &event, K_NO_WAIT);
 	}
+}
+
+/*
+ * Bring up the parts of the controller that are shared by both slots. This
+ * runs once: a second slot initialising later reuses the clock, the interrupt
+ * and the DMA set up here, and resetting or re-allocating them would disturb
+ * a slot that is already running.
+ */
+static int sdhc_esp32_controller_init(const struct device *dev)
+{
+	const struct sdhc_esp32_config *cfg = dev->config;
+	struct sdhc_esp32_data *data = dev->data;
+	sdmmc_dev_t *sdio_hw = (sdmmc_dev_t *)cfg->sdio_hw;
+	int ret;
+
+	if (sdhc_esp32_ctrl.initialized) {
+		return 0;
+	}
+
+	ret = clock_control_on(cfg->clock_dev, cfg->clock_subsys);
+
+	if (ret != 0) {
+		LOG_ERR("Error enabling SDHC clock");
+		sdhc_esp32_ctrl.slot_dev[cfg->slot] = NULL;
+		return ret;
+	}
+
+	/* Enable clock to peripheral. Use smallest divider first */
+	ret = sdmmc_host_set_clk_div(sdio_hw, 2);
+
+	if (ret != 0) {
+		sdhc_esp32_ctrl.slot_dev[cfg->slot] = NULL;
+		return err_esp2zep(ret);
+	}
+
+	/* Reset controller */
+	sdhc_esp32_reset_ctrl(dev);
+
+	sdio_hw->tmout.val = 0xFFFFFFFFU;
+
+	/* Clear interrupt status and set interrupt mask to known state */
+	sdio_hw->rintsts.val = 0xffffffff;
+	sdio_hw->intmask.val = 0;
+	sdio_hw->ctrl.int_enable = 0;
+
+	/* Attach interrupt handler */
+	ret = esp_intr_alloc(cfg->irq_source,
+			     ESP_PRIO_TO_FLAGS(cfg->irq_priority) |
+				     ESP_INT_FLAGS_CHECK(cfg->irq_flags) | ESP_INTR_FLAG_IRAM,
+			     &sdio_esp32_isr, (void *)dev, &sdhc_esp32_ctrl.intr_handle);
+
+	if (ret != 0) {
+		k_msgq_purge(data->s_host_ctx.event_queue);
+		sdhc_esp32_ctrl.slot_dev[cfg->slot] = NULL;
+		return -EFAULT;
+	}
+
+	/* Enable interrupts, sdio interrupt is enabled only when in use */
+	sdmmc_ll_enable_interrupt(
+		sdio_hw,
+		SDMMC_INTMASK_CD | SDMMC_INTMASK_CMD_DONE | SDMMC_INTMASK_DATA_OVER |
+			SDMMC_INTMASK_RCRC | SDMMC_INTMASK_DCRC | SDMMC_INTMASK_RTO |
+			SDMMC_INTMASK_DTO | SDMMC_INTMASK_HTO | SDMMC_INTMASK_SBE |
+			SDMMC_INTMASK_EBE | SDMMC_INTMASK_RESP_ERR | SDMMC_INTMASK_HLE,
+		true);
+
+	sdio_hw->ctrl.int_enable = 1;
+
+	/* Disable generation of Busy Clear Interrupt */
+	sdio_hw->cardthrctl.busy_clr_int_en = 0;
+
+	/* Enable DMA */
+	sdmmc_host_dma_init(sdio_hw);
+
+	sdhc_esp32_ctrl.initialized = true;
+
+	return 0;
 }
 
 /*
@@ -1517,7 +1809,6 @@ static int sdhc_esp32_init(const struct device *dev)
 {
 	const struct sdhc_esp32_config *cfg = dev->config;
 	struct sdhc_esp32_data *data = dev->data;
-	sdmmc_dev_t *sdio_hw = (sdmmc_dev_t *)cfg->sdio_hw;
 	int ret;
 
 	/* Pin configuration */
@@ -1547,65 +1838,35 @@ static int sdhc_esp32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(cfg->clock_dev, cfg->clock_subsys);
-
-	if (ret != 0) {
-		LOG_ERR("Error enabling SDHC clock");
-		return ret;
-	}
-
-	/* Enable clock to peripheral. Use smallest divider first */
-	ret = sdmmc_host_set_clk_div(sdio_hw, 2);
-
-	if (ret != 0) {
-		return err_esp2zep(ret);
-	}
-
-	/* Reset controller */
-	sdhc_esp32_reset(dev);
-
-	sdio_hw->tmout.val = 0xFFFFFFFFU;
-
-	/* Clear interrupt status and set interrupt mask to known state */
-	sdio_hw->rintsts.val = 0xffffffff;
-	sdio_hw->intmask.val = 0;
-	sdio_hw->ctrl.int_enable = 0;
-
-	/* Attach interrupt handler */
-	ret = esp_intr_alloc(cfg->irq_source,
-				ESP_PRIO_TO_FLAGS(cfg->irq_priority) |
-				ESP_INT_FLAGS_CHECK(cfg->irq_flags) | ESP_INTR_FLAG_IRAM,
-				&sdio_esp32_isr, (void *)dev,
-				&data->s_host_ctx.intr_handle);
-
-	if (ret != 0) {
-		k_msgq_purge(data->s_host_ctx.event_queue);
-		return -EFAULT;
-	}
-
-	/* Enable interrupts */
-	sdio_hw->intmask.val = SDMMC_INTMASK_CD | SDMMC_INTMASK_CMD_DONE | SDMMC_INTMASK_DATA_OVER |
-			       SDMMC_INTMASK_RCRC | SDMMC_INTMASK_DCRC | SDMMC_INTMASK_RTO |
-			       SDMMC_INTMASK_DTO | SDMMC_INTMASK_HTO | SDMMC_INTMASK_SBE |
-			       SDMMC_INTMASK_EBE | SDMMC_INTMASK_RESP_ERR |
-			       SDMMC_INTMASK_HLE; /* sdio is enabled only when use */
-
-	sdio_hw->ctrl.int_enable = 1;
-
-	/* Disable generation of Busy Clear Interrupt */
-	sdio_hw->cardthrctl.busy_clr_int_en = 0;
-
-	/* Enable DMA */
-	sdmmc_host_dma_init(sdio_hw);
-
 	/* Initialize transaction handler */
 	ret = sdmmc_host_transaction_handler_init(data);
 
 	if (ret != 0) {
-		k_msgq_purge(data->s_host_ctx.event_queue);
-		esp_intr_free(data->s_host_ctx.intr_handle);
-		data->s_host_ctx.intr_handle = NULL;
+		return ret;
+	}
 
+	if (cfg->slot >= SOC_SDMMC_NUM_SLOTS) {
+		return -EINVAL;
+	}
+
+	/*
+	 * Initialise the bus mutex before publishing the slot, so it is valid
+	 * no matter which slot runs first and whether the controller bring-up
+	 * below is skipped.
+	 */
+	if (!sdhc_esp32_ctrl.initialized) {
+		k_mutex_init(&sdhc_esp32_ctrl.bus_mutex);
+	}
+
+	/*
+	 * Publish the slot before the controller is brought up so the shared
+	 * ISR can already route a card interrupt to it.
+	 */
+	sdhc_esp32_ctrl.slot_dev[cfg->slot] = dev;
+
+	ret = sdhc_esp32_controller_init(dev);
+
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -1770,5 +2031,5 @@ static DEVICE_API(sdhc, sdhc_api) = {
 
 DT_INST_FOREACH_STATUS_OKAY(SDHC_ESP32_INIT)
 
-BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
-	     "Currently, only one espressif,esp32-sdhc-slot compatible node is supported");
+BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) <= SOC_SDMMC_NUM_SLOTS,
+	     "More espressif,esp32-sdhc-slot nodes enabled than the controller has slots");

--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -23,12 +23,27 @@
 #include <esp_intr_alloc.h>
 #include <esp_timer.h>
 #include <hal/gpio_hal.h>
+
+/*
+ * SoCs whose SDMMC slots have no dedicated IO_MUX pins must route the
+ * bus through the GPIO matrix. ESP32-P4 uses it for slot 1 only;
+ * ESP32-S3 uses it for every slot.
+ */
+#if defined(CONFIG_SOC_SERIES_ESP32P4) || defined(CONFIG_SOC_SERIES_ESP32S3)
+#define SDHC_ESP32_USE_GPIO_MATRIX 1
+#endif
+
 #if defined(CONFIG_SOC_SERIES_ESP32P4)
 #include <hal/gpio_ll.h>
 #include <soc/io_mux_struct.h>
 #include <soc/gpio_struct.h>
 #else
 #include <hal/rtc_io_hal.h>
+#endif
+#if defined(SDHC_ESP32_USE_GPIO_MATRIX)
+#include <hal/gpio_ll.h>
+#include <hal/sdmmc_periph.h>
+#include <esp_rom_gpio.h>
 #endif
 #include <soc/io_mux_reg.h>
 #include <soc/sdmmc_reg.h>
@@ -96,7 +111,7 @@ struct sdhc_esp32_config {
 struct sdhc_esp32_data {
 
 	uint8_t bus_width;  /* Bus width used by the slot (can change during execution) */
-	uint32_t bus_clock; /* Value in Hz. ESP-IDF functions use kHz instead */
+	uint32_t bus_clock; /* Value in Hz; the low-level helpers use kHz */
 
 	enum sdhc_power power_mode;
 	enum sdhc_timing_mode timing;
@@ -106,6 +121,11 @@ struct sdhc_esp32_data {
 	bool s_is_app_cmd;
 	sdmmc_desc_t s_dma_desc[SDMMC_DMA_DESC_CNT] __aligned(SDMMC_DESC_ALIGN);
 	struct sdmmc_transfer_state s_cur_transfer;
+#ifdef CONFIG_SDHC_ESP32_SDIO
+	sdhc_interrupt_cb_t sdio_cb;
+	void *sdio_cb_user_data;
+	int sdio_int_sources;
+#endif
 };
 
 /**********************************************************************
@@ -203,8 +223,8 @@ static int sdmmc_host_wait_for_event(struct sdhc_esp32_data *data, int timeout_m
 static int handle_idle_state_events(struct sdhc_esp32_data *data)
 {
 	/* Handle any events which have happened in between transfers.
-	 * Under current assumptions (no SDIO support) only card detect events
-	 * can happen in the idle state.
+	 * SDIO card interrupts are delivered through the registered callback,
+	 * not this queue, so only card detect events surface in the idle state.
 	 */
 	struct sdmmc_event evt;
 
@@ -654,6 +674,18 @@ static int sdmmc_host_do_transaction(const struct device *dev, int slot,
 			goto out;
 		}
 
+		/*
+		 * make_hw_cmd() cannot describe a transfer that is not a whole
+		 * number of blocks, so reject it here instead of letting it
+		 * build a descriptor the controller would misinterpret.
+		 */
+		if ((cmdinfo->blklen == 0) || ((cmdinfo->datalen % cmdinfo->blklen) != 0)) {
+			LOG_DBG("%s: invalid block length: total=%d blklen=%d", __func__,
+				cmdinfo->datalen, cmdinfo->blklen);
+			ret = ESP_ERR_INVALID_SIZE;
+			goto out;
+		}
+
 		if ((((intptr_t)cmdinfo->data % 4) != 0) || !esp_ptr_dma_capable(cmdinfo->data)) {
 			LOG_DBG("%s: buffer %p can not be used for DMA", __func__, cmdinfo->data);
 			ret = ESP_ERR_INVALID_ARG;
@@ -946,6 +978,63 @@ static void configure_pin_iomux(int gpio_num)
 #endif
 }
 
+#if defined(SDHC_ESP32_USE_GPIO_MATRIX)
+/*
+ * Route a pin to the SDMMC peripheral through the GPIO matrix. Slots that
+ * have no dedicated IO_MUX pins (SDMMC_LL_SLOT_SUPPORT_GPIO_MATRIX) can only
+ * reach the controller this way. The same signal index feeds both the input
+ * and output connections; for the clock pin only the output path is wired.
+ */
+static void configure_pin_gpio_matrix(int gpio_num, uint32_t signal_idx, bool is_output_only)
+{
+	if (gpio_num == GPIO_NUM_NC) {
+		return;
+	}
+
+	gpio_ll_func_sel(GPIO_LL_GET_HW(0), gpio_num, PIN_FUNC_GPIO);
+	gpio_ll_pulldown_dis(GPIO_LL_GET_HW(0), gpio_num);
+	gpio_ll_pullup_en(GPIO_LL_GET_HW(0), gpio_num);
+	gpio_ll_set_drive_capability(GPIO_LL_GET_HW(0), gpio_num, GPIO_DRIVE_CAP_3);
+
+	if (!is_output_only) {
+		gpio_ll_input_enable(GPIO_LL_GET_HW(0), gpio_num);
+		esp_rom_gpio_connect_in_signal(gpio_num, signal_idx, false);
+	}
+
+	gpio_ll_output_enable(GPIO_LL_GET_HW(0), gpio_num);
+	esp_rom_gpio_connect_out_signal(gpio_num, signal_idx, false, false);
+}
+#endif
+
+/*
+ * Slots wired to dedicated IO_MUX pins are configured through the fixed IO_MUX
+ * function. Slots with no IO_MUX pins (ESP32-P4 slot 1, every ESP32-S3 slot)
+ * must be routed through the GPIO matrix using the per-slot signal indices.
+ */
+static void configure_slot_pins(const struct sdhc_esp32_config *cfg)
+{
+#if defined(SDHC_ESP32_USE_GPIO_MATRIX)
+	if (SDMMC_LL_SLOT_SUPPORT_GPIO_MATRIX(cfg->slot)) {
+		const sdmmc_slot_io_info_t *sig = &sdmmc_slot_gpio_sig[cfg->slot];
+
+		configure_pin_gpio_matrix(cfg->clk_pin, sig->clk, true);
+		configure_pin_gpio_matrix(cfg->cmd_pin, sig->cmd, false);
+		configure_pin_gpio_matrix(cfg->d0_pin, sig->d0, false);
+		configure_pin_gpio_matrix(cfg->d1_pin, sig->d1, false);
+		configure_pin_gpio_matrix(cfg->d2_pin, sig->d2, false);
+		configure_pin_gpio_matrix(cfg->d3_pin, sig->d3, false);
+		return;
+	}
+#endif
+
+	configure_pin_iomux(cfg->clk_pin);
+	configure_pin_iomux(cfg->cmd_pin);
+	configure_pin_iomux(cfg->d0_pin);
+	configure_pin_iomux(cfg->d1_pin);
+	configure_pin_iomux(cfg->d2_pin);
+	configure_pin_iomux(cfg->d3_pin);
+}
+
 /**********************************************************************
  * Zephyr API
  **********************************************************************/
@@ -1220,6 +1309,18 @@ static int sdhc_esp32_request(const struct device *dev, struct sdhc_command *cmd
 		esp_cmd.flags = SCF_CMD_AC | SCF_RSP_R5;
 		break;
 
+#if defined(CONFIG_SDHC_ESP32_SDIO)
+	case SDIO_RW_EXTENDED:
+		if (!data || data->block_size == 0 || data->blocks == 0) {
+			return -EINVAL;
+		}
+		esp_cmd.flags = SCF_CMD_ADTC | SCF_RSP_R5;
+		if (!(cmd->arg & BIT(SDIO_CMD_ARG_RW_SHIFT))) {
+			esp_cmd.flags |= SCF_CMD_READ;
+		}
+		break;
+#endif
+
 	case SDIO_SEND_OP_COND:
 		esp_cmd.flags = SCF_CMD_BCR | SCF_RSP_R4;
 		break;
@@ -1368,7 +1469,33 @@ static void IRAM_ATTR sdio_esp32_isr(void *arg)
 
 	struct sdmmc_event event;
 	struct k_msgq *queue = data->s_host_ctx.event_queue;
-	uint32_t pending = sdmmc_ll_get_intr_status(sdio_hw) & 0xFFFF;
+	/*
+	 * The card interrupt bits live at 16 and 17 and are dispatched
+	 * separately below, so the event queue only ever carries the low
+	 * 16 command and data sources.
+	 */
+	uint32_t raw = sdmmc_ll_get_intr_status(sdio_hw);
+	uint32_t pending = raw & 0xFFFF;
+
+#ifdef CONFIG_SDHC_ESP32_SDIO
+	uint32_t io_bit = (cfg->slot == 0) ? SDMMC_LL_EVENT_IO_SLOT0 : SDMMC_LL_EVENT_IO_SLOT1;
+
+	if (raw & io_bit) {
+		/*
+		 * Mask the source so it does not re-trigger before the consumer
+		 * has handled it, and clear the latched status: the bit is
+		 * write-1-to-clear and never self-clears, so leaving it set
+		 * would re-enter this handler as soon as the source is
+		 * unmasked. A card still asserting DAT1 re-latches it at once.
+		 */
+		sdmmc_ll_enable_interrupt(sdio_hw, io_bit, false);
+		sdmmc_ll_clear_interrupt(sdio_hw, io_bit);
+
+		if (data->sdio_cb) {
+			data->sdio_cb(dev, SDHC_INT_SDIO, data->sdio_cb_user_data);
+		}
+	}
+#endif
 
 	sdio_hw->rintsts.val = pending;
 	event.sdmmc_status = pending;
@@ -1404,16 +1531,7 @@ static int sdhc_esp32_init(const struct device *dev)
 		}
 	}
 
-	/*
-	 * Pins below are only defined for ESP32. For SoC's with GPIO matrix feature
-	 * please use pinctrl for pin configuration.
-	 */
-	configure_pin_iomux(cfg->clk_pin);
-	configure_pin_iomux(cfg->cmd_pin);
-	configure_pin_iomux(cfg->d0_pin);
-	configure_pin_iomux(cfg->d1_pin);
-	configure_pin_iomux(cfg->d2_pin);
-	configure_pin_iomux(cfg->d3_pin);
+	configure_slot_pins(cfg);
 
 	/* GPIO matrix routed pins */
 	if (cfg->pcfg != NULL) {
@@ -1500,6 +1618,83 @@ static int sdhc_esp32_init(const struct device *dev)
 	return 0;
 }
 
+#ifdef CONFIG_SDHC_ESP32_SDIO
+static int sdhc_esp32_enable_interrupt(const struct device *dev, sdhc_interrupt_cb_t callback,
+				       int sources, void *user_data)
+{
+	const struct sdhc_esp32_config *cfg = dev->config;
+	struct sdhc_esp32_data *data = dev->data;
+	sdmmc_dev_t *sdio_hw = (sdmmc_dev_t *)cfg->sdio_hw;
+	uint32_t io_bit;
+
+	if (sources & ~SDHC_INT_SDIO) {
+		return -ENOTSUP;
+	}
+
+	io_bit = (cfg->slot == 0) ? SDMMC_LL_EVENT_IO_SLOT0 : SDMMC_LL_EVENT_IO_SLOT1;
+
+	/*
+	 * The card interrupt callback runs from the ISR and the consumer
+	 * re-arms from there, so this must stay callable with interrupts
+	 * locked. intmask is shared with the ISR, so an interrupt lock is
+	 * what guards the read-modify-write; a mutex would neither help
+	 * against the ISR nor be usable from it.
+	 */
+	unsigned int key = irq_lock();
+
+	data->sdio_cb = callback;
+	data->sdio_cb_user_data = user_data;
+	/* The API replaces the enabled set rather than adding to it. */
+	data->sdio_int_sources = sources;
+
+	/*
+	 * Clear any status latched while the source was masked before
+	 * unmasking, so a stale bit does not fire the handler immediately.
+	 * The card interrupt is level driven, so a card that is still
+	 * asserting DAT1 sets the bit again right away and nothing is lost.
+	 */
+	if (sources & SDHC_INT_SDIO) {
+		sdmmc_ll_clear_interrupt(sdio_hw, io_bit);
+		sdmmc_ll_enable_interrupt(sdio_hw, io_bit, true);
+	} else {
+		sdmmc_ll_enable_interrupt(sdio_hw, io_bit, false);
+	}
+
+	irq_unlock(key);
+
+	return 0;
+}
+
+static int sdhc_esp32_disable_interrupt(const struct device *dev, int sources)
+{
+	const struct sdhc_esp32_config *cfg = dev->config;
+	struct sdhc_esp32_data *data = dev->data;
+	sdmmc_dev_t *sdio_hw = (sdmmc_dev_t *)cfg->sdio_hw;
+	uint32_t io_bit;
+
+	if (sources & ~SDHC_INT_SDIO) {
+		return -ENOTSUP;
+	}
+
+	io_bit = (cfg->slot == 0) ? SDMMC_LL_EVENT_IO_SLOT0 : SDMMC_LL_EVENT_IO_SLOT1;
+
+	/* Callable from the card interrupt callback, so no mutex here. */
+	unsigned int key = irq_lock();
+
+	sdmmc_ll_enable_interrupt(sdio_hw, io_bit, false);
+
+	data->sdio_int_sources &= ~sources;
+	if (data->sdio_int_sources == 0) {
+		data->sdio_cb = NULL;
+		data->sdio_cb_user_data = NULL;
+	}
+
+	irq_unlock(key);
+
+	return 0;
+}
+#endif /* CONFIG_SDHC_ESP32_SDIO */
+
 static DEVICE_API(sdhc, sdhc_api) = {
 	.reset = sdhc_esp32_reset,
 	.request = sdhc_esp32_request,
@@ -1507,6 +1702,10 @@ static DEVICE_API(sdhc, sdhc_api) = {
 	.get_card_present = sdhc_esp32_get_card_present,
 	.card_busy = sdhc_esp32_card_busy,
 	.get_host_props = sdhc_esp32_get_host_props,
+#ifdef CONFIG_SDHC_ESP32_SDIO
+	.enable_interrupt = sdhc_esp32_enable_interrupt,
+	.disable_interrupt = sdhc_esp32_disable_interrupt,
+#endif
 };
 
 #define SDHC_ESP32_INIT(n)                                                                         \
@@ -1551,7 +1750,9 @@ static DEVICE_API(sdhc, sdhc_api) = {
 					.ddr50_support = false,                                    \
 					.sdr104_support = false,                                   \
 					.sdr50_support = false,                                    \
-					.bus_8_bit_support = false},                               \
+					.bus_8_bit_support = false,                                \
+					.sdio_async_interrupt_support =                            \
+						IS_ENABLED(CONFIG_SDHC_ESP32_SDIO)},               \
 			  .bus_4_bit_support = DT_INST_PROP(n, bus_width) == 4,                    \
 			  .hs200_support = false,                                                  \
 			  .hs400_support = false}};                                                \

--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -1252,7 +1252,7 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 	uint8_t bus_width;
 	int ret = 0;
 
-	LOG_INF("SDHC I/O: slot: %d, bus width %d, clock %dHz, card power %s, "
+	LOG_DBG("SDHC I/O: slot: %d, bus width %d, clock %dHz, card power %s, "
 		"timing %s, voltage %s",
 		cfg->slot, ios->bus_width, ios->clock,
 		ios->power_mode == SDHC_POWER_ON ? "ON" : "OFF",
@@ -1285,7 +1285,7 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 			if (ret == 0) {
 				/* Purge stale CMD_DONE events from clock update commands */
 				k_msgq_purge(data->s_host_ctx.event_queue);
-				LOG_INF("Bus clock successfully set to %d kHz", ios->clock / 1000);
+				LOG_DBG("Bus clock successfully set to %d kHz", ios->clock / 1000);
 			} else {
 				LOG_ERR("Error configuring card clock");
 				k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
@@ -1317,7 +1317,7 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 			k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
 
 			if (ret == 0) {
-				LOG_INF("Bus width set successfully to %d bit", bus_width);
+				LOG_DBG("Bus width set successfully to %d bit", bus_width);
 			} else {
 				LOG_ERR("Error configuring bus width");
 				return err_esp2zep(ret);
@@ -1393,7 +1393,7 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 			case SDHC_TIMING_DDR52:
 				/* Enable DDR mode */
 				sdmmc_ll_enable_ddr_mode(sdio_hw, cfg->slot, true);
-				LOG_INF("DDR mode enabled");
+				LOG_DBG("DDR mode enabled");
 				break;
 			case SDHC_TIMING_SDR12:
 			case SDHC_TIMING_SDR25:
@@ -1411,7 +1411,7 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 
 			k_mutex_unlock(&sdhc_esp32_ctrl.bus_mutex);
 
-			LOG_INF("Bus timing successfully changed to %s", timingStr[ios->timing]);
+			LOG_DBG("Bus timing successfully changed to %s", timingStr[ios->timing]);
 			data->timing = ios->timing;
 		}
 	}
@@ -1579,7 +1579,7 @@ static int sdhc_esp32_request(const struct device *dev, struct sdhc_command *cmd
 		break;
 
 	default:
-		LOG_INF("SDHC driver: command %u not supported", cmd->opcode);
+		LOG_DBG("SDHC driver: command %u not supported", cmd->opcode);
 		return -ENOTSUP;
 	}
 

--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -206,24 +206,6 @@ static int sdmmc_host_set_clk_div(sdmmc_dev_t *sdio_hw, int div)
 	return 0;
 }
 
-static void sdmmc_host_dma_init(sdmmc_dev_t *sdio_hw)
-{
-	sdio_hw->ctrl.dma_enable = 1;
-	sdio_hw->bmod.val = 0;
-	sdio_hw->bmod.sw_reset = 1;
-	sdio_hw->idinten.ni = 1;
-	sdio_hw->idinten.ri = 1;
-	sdio_hw->idinten.ti = 1;
-}
-
-static void sdmmc_host_dma_stop(sdmmc_dev_t *sdio_hw)
-{
-	sdio_hw->ctrl.use_internal_dma = 0;
-	sdio_hw->ctrl.dma_reset = 1;
-	sdio_hw->bmod.fb = 0;
-	sdio_hw->bmod.enable = 0;
-}
-
 static int sdmmc_host_transaction_handler_init(struct sdhc_esp32_data *data)
 {
 	data->s_is_app_cmd = false;
@@ -353,7 +335,7 @@ static int sdmmc_host_start_command(sdmmc_dev_t *sdio_hw, int slot, sdmmc_hw_cmd
 	int64_t t0 = esp_timer_get_time();
 	int64_t t1 = 0;
 
-	while (sdio_hw->cmd.start_command == 1) {
+	while (!sdmmc_ll_is_command_taken(sdio_hw)) {
 		t1 = esp_timer_get_time();
 
 		if (t1 - t0 > SDMMC_HOST_START_CMD_TIMEOUT_US) {
@@ -365,10 +347,10 @@ static int sdmmc_host_start_command(sdmmc_dev_t *sdio_hw, int slot, sdmmc_hw_cmd
 		}
 	}
 
-	sdio_hw->cmdarg = arg;
+	sdmmc_ll_set_command_arg(sdio_hw, arg);
 	cmd.card_num = slot;
 	cmd.start_command = 1;
-	sdio_hw->cmd = cmd;
+	sdmmc_ll_set_command(sdio_hw, cmd);
 
 	return ESP_OK;
 }
@@ -406,7 +388,7 @@ static void process_command_response(sdmmc_dev_t *sdio_hw, uint32_t status,
 	if (err != ESP_OK) {
 		cmd->error = err;
 		if (cmd->data) {
-			sdmmc_host_dma_stop(sdio_hw);
+			sdmmc_ll_stop_dma(sdio_hw);
 		}
 		LOG_DBG("%s: error 0x%x  (status=%08" PRIx32 ")", __func__, err, status);
 	}
@@ -424,12 +406,12 @@ static void process_data_status(sdmmc_dev_t *sdio_hw, uint32_t status, struct sd
 		} else {
 			cmd->error = ESP_FAIL;
 		}
-		sdio_hw->ctrl.fifo_reset = 1;
+		sdmmc_ll_reset_fifo(sdio_hw);
 	}
 
 	if (cmd->error != 0) {
 		if (cmd->data) {
-			sdmmc_host_dma_stop(sdio_hw);
+			sdmmc_ll_stop_dma(sdio_hw);
 		}
 		LOG_DBG("%s: error 0x%x (status=%08" PRIx32 ")", __func__, cmd->error, status);
 	}
@@ -526,7 +508,7 @@ static int process_events(const struct device *dev, struct sdmmc_event evt,
 		case SDMMC_SENDING_DATA:
 			if (mask_check_and_clear(&evt.sdmmc_status, SDMMC_DATA_ERR_MASK)) {
 				process_data_status(sdio_hw, orig_evt.sdmmc_status, cmd);
-				sdmmc_host_dma_stop(sdio_hw);
+				sdmmc_ll_stop_dma(sdio_hw);
 			}
 			if (mask_check_and_clear(&evt.dma_status, SDMMC_DMA_DONE_MASK)) {
 
@@ -583,7 +565,7 @@ static int handle_event(const struct device *dev, struct sdmmc_command *cmd,
 			"ms",
 			err, cmd->timeout_ms);
 		if (err == -EAGAIN) {
-			sdmmc_host_dma_stop(sdio_hw);
+			sdmmc_ll_stop_dma(sdio_hw);
 		}
 		return err;
 	}
@@ -606,7 +588,7 @@ static int handle_event(const struct device *dev, struct sdmmc_command *cmd,
 static bool wait_for_busy_cleared(const sdmmc_dev_t *sdio_hw, uint32_t timeout_ms)
 {
 	if (timeout_ms == 0) {
-		return !(sdio_hw->status.data_busy == 1);
+		return !sdmmc_ll_is_card_data_busy((sdmmc_dev_t *)sdio_hw);
 	}
 
 	/* It would have been nice to do this without polling, however the peripheral
@@ -616,7 +598,7 @@ static bool wait_for_busy_cleared(const sdmmc_dev_t *sdio_hw, uint32_t timeout_m
 	uint32_t timeout_ticks = k_ms_to_ticks_ceil32(timeout_ms);
 
 	while (timeout_ticks-- > 0) {
-		if (!(sdio_hw->status.data_busy == 1)) {
+		if (!sdmmc_ll_is_card_data_busy((sdmmc_dev_t *)sdio_hw)) {
 			return true;
 		}
 		k_sleep(K_MSEC(1));
@@ -849,14 +831,14 @@ static int sdmmc_host_clock_update_command(sdmmc_dev_t *sdio_hw, int slot)
 			}
 			/* Sending clock update command to the CIU can generate HLE error */
 			/* According to the manual, this is okay and we must retry the command */
-			if (sdio_hw->rintsts.val & SDMMC_HLE_BIT) {
-				sdio_hw->rintsts.val = SDMMC_HLE_BIT;
+			if (sdmmc_ll_get_interrupt_raw(sdio_hw) & SDMMC_HLE_BIT) {
+				sdmmc_ll_clear_interrupt(sdio_hw, SDMMC_HLE_BIT);
 				repeat = true;
 				break;
 			}
 			/* When the command is accepted by CIU, start_command bit will be */
-			/* cleared in sdio_hw->cmd register */
-			if (sdio_hw->cmd.start_command == 0) {
+			/* cleared in the cmd register */
+			if (sdmmc_ll_is_command_taken(sdio_hw)) {
 				repeat = false;
 				break;
 			}
@@ -992,7 +974,7 @@ int sdmmc_host_set_card_clk(sdmmc_dev_t *sdio_hw, int slot, uint32_t freq_khz, i
 	/* always set response timeout to highest value, it's small enough anyway */
 	sdmmc_ll_set_response_timeout(sdio_hw, 255);
 
-	sdio_hw->rintsts.val = 0xFFFFFFFFU;
+	sdmmc_ll_clear_interrupt(sdio_hw, 0xFFFFFFFFU);
 
 restore:
 	/*
@@ -1011,17 +993,11 @@ int sdmmc_host_set_bus_width(sdmmc_dev_t *sdio_hw, int slot, size_t width)
 		return ESP_ERR_INVALID_ARG;
 	}
 
-	const uint16_t mask = BIT(slot);
-
-	if (width == 1) {
-		sdio_hw->ctype.card_width_8 &= ~mask;
-		sdio_hw->ctype.card_width &= ~mask;
-	} else if (width == 4) {
-		sdio_hw->ctype.card_width_8 &= ~mask;
-		sdio_hw->ctype.card_width |= mask;
-	} else {
+	if (width != 1 && width != 4) {
 		return ESP_ERR_INVALID_ARG;
 	}
+
+	sdmmc_ll_set_card_width(sdio_hw, slot, (sd_bus_width_t)width);
 
 	LOG_DBG("slot=%d width=%d", slot, width);
 	return ESP_OK;
@@ -1126,17 +1102,17 @@ static int sdhc_esp32_reset_ctrl(const struct device *dev)
 	sdmmc_dev_t *sdio_hw = (sdmmc_dev_t *)cfg->sdio_hw;
 
 	/* Set reset bits */
-	sdio_hw->ctrl.controller_reset = 1;
-	sdio_hw->ctrl.dma_reset = 1;
-	sdio_hw->ctrl.fifo_reset = 1;
+	sdmmc_ll_reset_controller(sdio_hw);
+	sdmmc_ll_reset_dma(sdio_hw);
+	sdmmc_ll_reset_fifo(sdio_hw);
 
 	/* Wait for the reset bits to be cleared by hardware */
 	int64_t yield_delay_us = 100 * 1000; /* initially 100ms */
 	int64_t t0 = esp_timer_get_time();
 	int64_t t1 = 0;
 
-	while (sdio_hw->ctrl.controller_reset || sdio_hw->ctrl.fifo_reset ||
-	       sdio_hw->ctrl.dma_reset) {
+	while (!sdmmc_ll_is_controller_reset_done(sdio_hw) ||
+	       !sdmmc_ll_is_fifo_reset_done(sdio_hw) || !sdmmc_ll_is_dma_reset_done(sdio_hw)) {
 		t1 = esp_timer_get_time();
 
 		if (t1 - t0 > SDMMC_HOST_RESET_TIMEOUT_US) {
@@ -1165,8 +1141,9 @@ static void sdhc_esp32_restore_after_reset(const struct device *dev)
 	uint32_t keep_io = 0;
 	unsigned int io_key;
 
-	sdio_hw->tmout.val = 0xFFFFFFFFU;
-	sdio_hw->rintsts.val = 0xFFFFFFFFU;
+	sdmmc_ll_set_data_timeout(sdio_hw, 0xFFFFFFU);
+	sdmmc_ll_set_response_timeout(sdio_hw, 0xFFU);
+	sdmmc_ll_clear_interrupt(sdio_hw, 0xFFFFFFFFU);
 
 	io_key = irq_lock();
 
@@ -1186,16 +1163,19 @@ static void sdhc_esp32_restore_after_reset(const struct device *dev)
 	}
 #endif
 
-	sdio_hw->intmask.val = SDMMC_INTMASK_CD | SDMMC_INTMASK_CMD_DONE |
-			       SDMMC_INTMASK_DATA_OVER | SDMMC_INTMASK_RCRC |
-			       SDMMC_INTMASK_DCRC | SDMMC_INTMASK_RTO | SDMMC_INTMASK_DTO |
-			       SDMMC_INTMASK_HTO | SDMMC_INTMASK_SBE | SDMMC_INTMASK_EBE |
-			       SDMMC_INTMASK_RESP_ERR | SDMMC_INTMASK_HLE | keep_io;
+	sdmmc_ll_enable_interrupt(sdio_hw,
+				  SDMMC_INTMASK_CD | SDMMC_INTMASK_CMD_DONE |
+					  SDMMC_INTMASK_DATA_OVER | SDMMC_INTMASK_RCRC |
+					  SDMMC_INTMASK_DCRC | SDMMC_INTMASK_RTO |
+					  SDMMC_INTMASK_DTO | SDMMC_INTMASK_HTO |
+					  SDMMC_INTMASK_SBE | SDMMC_INTMASK_EBE |
+					  SDMMC_INTMASK_RESP_ERR | SDMMC_INTMASK_HLE | keep_io,
+				  true);
 	irq_unlock(io_key);
 
-	sdio_hw->ctrl.int_enable = 1;
-	sdio_hw->cardthrctl.busy_clr_int_en = 0;
-	sdmmc_host_dma_init(sdio_hw);
+	sdmmc_ll_enable_global_interrupt(sdio_hw, true);
+	sdmmc_ll_enable_busy_clear_interrupt(sdio_hw, false);
+	sdmmc_ll_init_dma(sdio_hw);
 }
 
 /*
@@ -1255,8 +1235,7 @@ static int sdhc_esp32_set_io(const struct device *dev, struct sdhc_io *ios)
 	LOG_DBG("SDHC I/O: slot: %d, bus width %d, clock %dHz, card power %s, "
 		"timing %s, voltage %s",
 		cfg->slot, ios->bus_width, ios->clock,
-		ios->power_mode == SDHC_POWER_ON ? "ON" : "OFF",
-		sdhc_timing_mode_str(ios->timing),
+		ios->power_mode == SDHC_POWER_ON ? "ON" : "OFF", sdhc_timing_mode_str(ios->timing),
 		sd_voltage_str(ios->signal_voltage));
 
 	if (ios->clock) {
@@ -1427,7 +1406,7 @@ static int sdhc_esp32_card_busy(const struct device *dev)
 	const struct sdhc_esp32_config *cfg = dev->config;
 	const sdmmc_dev_t *sdio_hw = cfg->sdio_hw;
 
-	return (sdio_hw->status.data_busy == 1);
+	return sdmmc_ll_is_card_data_busy((sdmmc_dev_t *)sdio_hw);
 }
 
 /*
@@ -1703,12 +1682,12 @@ static void IRAM_ATTR sdio_esp32_isr(void *arg)
 	}
 #endif
 
-	sdio_hw->rintsts.val = pending;
+	sdmmc_ll_clear_interrupt(sdio_hw, pending);
 	event.sdmmc_status = pending;
 
-	uint32_t dma_pending = sdio_hw->idsts.val;
+	uint32_t dma_pending = sdmmc_ll_get_idsts_interrupt_raw(sdio_hw);
 
-	sdio_hw->idsts.val = dma_pending;
+	sdmmc_ll_clear_idsts_interrupt(sdio_hw, dma_pending);
 	event.dma_status = dma_pending & 0x1f;
 
 	if ((pending != 0) || (dma_pending != 0)) {
@@ -1761,12 +1740,13 @@ static int sdhc_esp32_controller_init(const struct device *dev)
 	/* Reset controller */
 	sdhc_esp32_reset_ctrl(dev);
 
-	sdio_hw->tmout.val = 0xFFFFFFFFU;
+	sdmmc_ll_set_data_timeout(sdio_hw, 0xFFFFFFU);
+	sdmmc_ll_set_response_timeout(sdio_hw, 0xFFU);
 
 	/* Clear interrupt status and set interrupt mask to known state */
-	sdio_hw->rintsts.val = 0xffffffff;
+	sdmmc_ll_clear_interrupt(sdio_hw, 0xffffffff);
 	sdio_hw->intmask.val = 0;
-	sdio_hw->ctrl.int_enable = 0;
+	sdmmc_ll_enable_global_interrupt(sdio_hw, false);
 
 	/* Attach interrupt handler */
 	ret = esp_intr_alloc(cfg->irq_source,
@@ -1789,13 +1769,13 @@ static int sdhc_esp32_controller_init(const struct device *dev)
 			SDMMC_INTMASK_EBE | SDMMC_INTMASK_RESP_ERR | SDMMC_INTMASK_HLE,
 		true);
 
-	sdio_hw->ctrl.int_enable = 1;
+	sdmmc_ll_enable_global_interrupt(sdio_hw, true);
 
 	/* Disable generation of Busy Clear Interrupt */
-	sdio_hw->cardthrctl.busy_clr_int_en = 0;
+	sdmmc_ll_enable_busy_clear_interrupt(sdio_hw, false);
 
 	/* Enable DMA */
-	sdmmc_host_dma_init(sdio_hw);
+	sdmmc_ll_init_dma(sdio_hw);
 
 	sdhc_esp32_ctrl.initialized = true;
 


### PR DESCRIPTION
Adds SDIO host support to the esp32 sdhc driver and allows both
controller slots to be enabled at the same time.

- Adds the CMD53 data path (block and byte transfers) and card
  interrupt delivery, so the Zephyr SDIO stack can drive an SDIO
  peripheral. Guarded by CONFIG_SDHC_ESP32_SDIO, default y when the
  SDIO stack is enabled. CMD52 is unaffected.
- Moves the controller-wide state (clock, reset, DMA, interrupt) into
  a shared struct initialised once, and serialises transactions across
  slots with a controller mutex that tracks the owning slot and
  reprograms the clock divider on handover.