### PR TITLE
net: fix unused parameter warning

### DIFF
--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -524,6 +524,8 @@ static inline void net_pkt_set_udp_opt_surplus_len(struct net_pkt *pkt,
 #else
 static inline uint16_t net_pkt_udp_opt_surplus_len(struct net_pkt *pkt)
 {
+	ARG_UNUSED(pkt);
+
 	return 0;
 }
 


### PR DESCRIPTION
Fix unused parameter warning in `net_pkt_udp_opt_surplus_len()` function, if `CONFIG_NET_UDP_OPTIONS` is not enabled.

```
In file included from /home/user/west_workspace/zephyr/include/zephyr/net/ethernet.h:22:
/home/user/west_workspace/zephyr/include/zephyr/net/net_pkt.h:525:68: error: unused parameter 'pkt' [-Werror,-Wunused-parameter]
  525 | static inline uint16_t net_pkt_udp_opt_surplus_len(struct net_pkt *pkt)
      |          
```