### PR TITLE
tests Bluetooth l2cap: Pass correct struct type in accept callback

### DIFF
--- a/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
+++ b/tests/bsim/bluetooth/host/l2cap/send_on_connect/src/main_l2cap_send_on_connect.c
@@ -123,7 +123,7 @@ static const struct bt_l2cap_chan_ops l2cap_ops = {
 };
 
 static struct bt_l2cap_le_chan dyn_chan;
-static struct bt_l2cap_chan fixed_chan;
+static struct bt_l2cap_le_chan fixed_chan;
 
 static int accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 		  struct bt_l2cap_chan **l2cap_chan)
@@ -142,7 +142,7 @@ static struct bt_l2cap_server server = {
 
 static int l2cap_fixed_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
-	*chan = &fixed_chan;
+	*chan = &fixed_chan.chan;
 
 	**chan = (struct bt_l2cap_chan){
 		.ops = &l2cap_ops,


### PR DESCRIPTION
Even though a fixed channel l2cap accept callback has the signature
  `int (*accept)(struct bt_conn *conn, struct bt_l2cap_chan **chan);`
in reality it needs a chan parameter that is part of a `bt_l2cap_le_chan` structure, as the host `bt_l2cap_connected()` will attempt to access members from the `bt_l2cap_le_chan` parent which are beyond the end of the `bt_l2cap_chan` struct.

Let's fix the issue in this test accordingly, and in that way avoid `bt_l2cap_connected()` writing memory beyond that structure end which is likely to result in corruption of other data, or a fault.

------------

I created a bug to track the overall issue #114692
Unless an overall fix can be found right away, I think it makes sense to get this fix for this test, as it is quite small)
