### PR TITLE
boards: ti: lp_am243: add missing board yamls

### DIFF
--- a/boards/ti/lp_am243/lp_am243_m4.yaml
+++ b/boards/ti/lp_am243/lp_am243_m4.yaml
@@ -1,0 +1,8 @@
+identifier: lp_am243/am2434/m4
+name: TI AM243x LaunchPad (M4 Core)
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+ram: 192
+vendor: ti

--- a/boards/ti/lp_am243/lp_am243_r5f0_0.yaml
+++ b/boards/ti/lp_am243/lp_am243_r5f0_0.yaml
@@ -1,0 +1,8 @@
+identifier: lp_am243/am2434/r5f0_0
+name: TI AM243x LaunchPad (R5FSS0 Core 0)
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+ram: 256
+vendor: ti


### PR DESCRIPTION
The lp_am243 board directory is missing the <board>.yaml files for lp_am243_m4 and lp_am243_r5f0_0 metadata. Add these here.