### PR TITLE
soc: intel_adsp: remove deprecated CONFIG_INTEL_ADSP_IPC

### DIFF
--- a/soc/intel/intel_adsp/Kconfig
+++ b/soc/intel/intel_adsp/Kconfig
@@ -30,17 +30,10 @@ config INTEL_ADSP_FWREADY_MSG
 	  Send a firmware ready message to the host once the system is up
 	  and running.
 
-config INTEL_ADSP_IPC
-	bool "Driver for the host IPC interrupt delivery"
-	select DEPRECATED
-	help
-	  Deprecated config for IPC. Will be removed in the future.
-
 config INTEL_ADSP_IPC_OLD_INTERFACE
 	bool "Expose old interface for the IPC"
 	depends on IPC_SERVICE_BACKEND_INTEL_ADSP_HOST_IPC
 	default y
-	select INTEL_ADSP_IPC
 	help
 	  Expose the old IPC interface (intel_adsp_ipc_* functions) to
 	  maintain backward compatibility.


### PR DESCRIPTION
SOF has removed their use of CONFIG_INTEL_ADSP_IPC so we can remove this deprecated kconfig.