### PR TITLE
drivers: ethernet: dwc_mac: add ptp support

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -98,6 +98,15 @@ static int clock_control_esp32_get_rate(const struct device *dev, clock_control_
 	case ESP32_CLOCK_CONTROL_SUBSYS_RTC_SLOW_NOMINAL:
 		*rate = esp_clk_tree_lp_slow_get_freq_hz(ESP_CLK_TREE_SRC_FREQ_PRECISION_APPROX);
 		break;
+#if defined(ESP32_EMAC_PTP_MODULE)
+	case ESP32_EMAC_PTP_MODULE:
+		if (esp_clk_tree_src_get_freq_hz(EMAC_PTP_CLK_SRC_DEFAULT,
+						 ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED,
+						 rate) != ESP_OK) {
+			return -EINVAL;
+		}
+		break;
+#endif
 	default:
 		*rate = clk_hal_cpu_get_freq_hz();
 	}

--- a/drivers/ethernet/Kconfig.esp32
+++ b/drivers/ethernet/Kconfig.esp32
@@ -5,7 +5,7 @@
 
 menuconfig ETH_ESP32
 	bool "ESP32 Ethernet driver"
-	default y
+	default y if !PTP_CLOCK
 	depends on SOC_SERIES_ESP32 || SOC_SERIES_ESP32P4
 	depends on DT_HAS_ESPRESSIF_ESP32_ETH_ENABLED
 	help

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -6,7 +6,8 @@
 
 menuconfig ETH_STM32_HAL
 	bool "STM32 HAL Ethernet driver"
-	default y
+	default y if !(PTP_CLOCK && \
+			(SOC_SERIES_STM32F1X || SOC_SERIES_STM32F2X || SOC_SERIES_STM32F4X))
 	depends on DT_HAS_ST_STM32_ETHERNET_ENABLED
 	select USE_STM32_HAL_ETH
 	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT

--- a/drivers/ethernet/dwc_mac/CMakeLists.txt
+++ b/drivers/ethernet/dwc_mac/CMakeLists.txt
@@ -13,3 +13,5 @@ zephyr_library_sources_ifdef(CONFIG_ETH_ESP32_DWC_ETHER_1000 eth_esp32_dwc_ether
 zephyr_library_sources_ifdef(CONFIG_ETH_STM32_DWC_ETHER_1000 eth_stm32_dwc_ether_1000.c)
 zephyr_library_sources_ifdef(CONFIG_ETH_STM32_DWC_ETHER_QOS eth_stm32_dwc_ether_qos.c)
 # zephyr-keep-sorted-stop
+
+zephyr_library_sources_ifdef(CONFIG_PTP_CLOCK_DWC_MAC eth_dwmac_ptp.c)

--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -85,6 +85,8 @@ config ETH_DWMAC_MMU
 config ETH_DWC_ETHER_1000_CORE_EDFE
 	bool
 	depends on ETH_DWC_ETHER_1000_CORE
+	depends on !SOC_SERIES_STM32F1X
+	default y if PTP_CLOCK_DWC_MAC
 	help
 	  Increases the descriptor size to 32 bytes.
 

--- a/drivers/ethernet/dwc_mac/Kconfig
+++ b/drivers/ethernet/dwc_mac/Kconfig
@@ -165,6 +165,8 @@ config ETH_DWC_ETHER_RX_HW_CHECKSUM_EN
 	depends on NET_CHECKSUM_OFFLOAD
 	default y
 
+rsource "Kconfig.ptp"
+
 endif # ETH_DWC_ETHER_QOS_CORE || ETH_DWC_ETHER_1000_CORE
 
 endmenu

--- a/drivers/ethernet/dwc_mac/Kconfig.ptp
+++ b/drivers/ethernet/dwc_mac/Kconfig.ptp
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config PTP_CLOCK_DWC_MAC
+	bool "DWC MAC PTP clock driver support"
+	default y
+	depends on PTP_CLOCK
+	depends on DT_HAS_SNPS_DWMAC_PTP_CLOCK_ENABLED
+	select NET_L2_PTP_TIMESTAMPING
+	help
+	  Enable PTP clock support for the Synopsys DesignWare MAC cores.

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -34,6 +34,8 @@ LOG_MODULE_REGISTER(dwmac_core, CONFIG_ETHERNET_LOG_LEVEL);
 #define TDES0_FS  BIT(28)
 #define TDES0_TER BIT(21)
 #define TDES0_TCH BIT(20)
+#define TDES0_TTSE BIT(25)
+#define TDES0_TTSS BIT(17)
 #define TDES0_ES  BIT(15)
 #define TDES0_CIC GENMASK(23, 22)
 
@@ -43,6 +45,7 @@ LOG_MODULE_REGISTER(dwmac_core, CONFIG_ETHERNET_LOG_LEVEL);
 #define RDES0_OWN BIT(31)
 #define RDES0_FL  GENMASK(29, 16)
 #define RDES0_ES  BIT(15)
+#define RDES0_TSV BIT(7)
 #define RDES0_FS  BIT(9)
 #define RDES0_LS  BIT(8)
 
@@ -159,6 +162,13 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 		}
 	}
 
+	des0_flags = TDES0_OWN | TDES0_FS;
+
+	if (IS_ENABLED(CONFIG_PTP_CLOCK_DWC_MAC) &&
+		net_pkt_is_tx_timestamping(pkt)) {
+		des0_flags |= TDES0_TTSE;
+	}
+
 	K_SPINLOCK(&p->spinlock) {
 		net_pkt_ref(pkt);
 		k_fifo_put(&p->tx_queue, pkt);
@@ -168,7 +178,7 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 		barrier_dmem_fence_full();
 
 		d = &p->tx_descs[first_d_idx];
-		d->des0 |= TDES0_OWN | TDES0_FS;
+		d->des0 |= des0_flags;
 
 		barrier_dmem_fence_full();
 		DWMAC_REG_WRITE(DWMAC_DMATPDR, 0);
@@ -198,6 +208,19 @@ static void dwmac_tx_release(const struct device *dev)
 			if (pkt != NULL) {
 				LOG_DBG("pkt len/frags=%zu/%u", net_pkt_get_len(pkt),
 					net_pkt_get_nbfrags(pkt));
+
+#if defined(CONFIG_PTP_CLOCK_DWC_MAC)
+				if ((des0 & TDES0_TTSS) != 0U) {
+#if defined(CONFIG_ETH_DWC_ETHER_1000_CORE_EDFE)
+					pkt->timestamp.second = d->des7;
+					pkt->timestamp.nanosecond = d->des6;
+#else /* CONFIG_ETH_DWC_ETHER_1000_CORE_EDFE */
+					pkt->timestamp.second = d->des3;
+					pkt->timestamp.nanosecond = d->des2;
+#endif /* CONFIG_ETH_DWC_ETHER_1000_CORE_EDFE */
+					net_if_add_tx_timestamp(pkt);
+				}
+#endif /* CONFIG_PTP_CLOCK_DWC_MAC */
 			}
 
 			net_pkt_unref(pkt);
@@ -213,6 +236,31 @@ static void dwmac_tx_release(const struct device *dev)
 
 	p->tx_desc_tail = d_idx;
 }
+
+#if defined(CONFIG_PTP_CLOCK_DWC_MAC)
+static void dwmac_receive_timestamp(struct net_pkt *pkt, struct dwmac_dma_desc *d)
+{
+#if defined(CONFIG_ETH_DWC_ETHER_1000_CORE_EDFE)
+	if ((d->des0 & RDES0_TSV) == 0U) {
+		return;
+	}
+	pkt->timestamp.second = d->des7;
+	pkt->timestamp.nanosecond = d->des6;
+#else
+	if (d->des2 == UINT32_MAX && d->des3 == UINT32_MAX) {
+		return;
+	}
+
+	pkt->timestamp.second = d->des3;
+	pkt->timestamp.nanosecond = d->des2;
+#endif /* CONFIG_ETH_DWC_ETHER_1000_CORE_EDFE */
+	net_pkt_set_rx_timestamping(pkt, true);
+}
+#else
+static void dwmac_receive_timestamp(struct net_pkt *pkt __unused, struct dwmac_dma_desc *d __unused)
+{
+}
+#endif /* CONFIG_PTP_CLOCK_DWC_MAC */
 
 static void dwmac_receive(const struct device *dev)
 {
@@ -271,6 +319,8 @@ static void dwmac_receive(const struct device *dev)
 
 		if ((des0 & RDES0_LS) != 0U) {
 			if ((des0 & RDES0_ES) == 0U) {
+				dwmac_receive_timestamp(p->rx_pkt, d);
+
 				if (net_recv_data(p->iface, p->rx_pkt) < 0) {
 					net_pkt_unref(p->rx_pkt);
 				}

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_1000_core.c
@@ -598,6 +598,9 @@ const struct ethernet_api dwmac_api = {
 	.set_config = dwmac_set_config,
 	.get_phy = dwmac_get_phy,
 	.send = dwmac_send,
+#if defined(CONFIG_PTP_CLOCK_DWC_MAC)
+	.get_ptp_clock = dwmac_get_ptp_clock,
+#endif
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	.get_stats = dwmac_stats,
 #endif

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -190,6 +190,11 @@ static int dwmac_send(const struct device *dev, struct net_pkt *pkt)
 	des2_flags = TDES2_IOC;
 	des3_flags = TDES3_FD | TDES3_OWN;
 
+	if (IS_ENABLED(CONFIG_PTP_CLOCK_DWC_MAC) &&
+		net_pkt_is_tx_timestamping(pkt)) {
+		des2_flags |= TDES2_TTSE;
+	}
+
 	if (IS_ENABLED(CONFIG_ETH_DWC_ETHER_TX_HW_CHECKSUM_EN)) {
 		des3_flags |= TDES3_CIC;
 	}
@@ -279,6 +284,14 @@ static void dwmac_tx_release(const struct device *dev)
 			if (pkt != NULL) {
 				LOG_DBG("pkt len/frags=%zu/%u", net_pkt_get_len(pkt),
 					net_pkt_get_nbfrags(pkt));
+
+#ifdef CONFIG_PTP_CLOCK_DWC_MAC
+				if ((des3_val & TDES3_TTSS) != 0U) {
+					pkt->timestamp.second = d->des1;
+					pkt->timestamp.nanosecond = d->des0;
+					net_if_add_tx_timestamp(pkt);
+				}
+#endif /* CONFIG_PTP_CLOCK_DWC_MAC */
 			}
 
 			net_pkt_unref(pkt);
@@ -325,9 +338,23 @@ static void dwmac_receive(const struct device *dev)
 		frag = p->rx_frags[d_idx];
 		p->rx_frags[d_idx] = NULL;
 
-		/* we ignore those for now */
+		/* a context descriptor, it contains the packet's timestamp */
 		if (des3_val & RDES3_CTXT) {
 			net_pkt_frag_unref(frag);
+#ifdef CONFIG_PTP_CLOCK_DWC_MAC
+			if (p->rx_pkt != NULL) {
+				if (d->des0 != UINT32_MAX && d->des1 != UINT32_MAX) {
+					p->rx_pkt->timestamp.second = d->des1;
+					p->rx_pkt->timestamp.nanosecond = d->des0;
+					net_pkt_set_rx_timestamping(p->rx_pkt, true);
+				}
+
+				if (net_recv_data(p->iface, p->rx_pkt) < 0) {
+					net_pkt_unref(p->rx_pkt);
+				}
+				p->rx_pkt = NULL;
+			}
+#endif
 			continue;
 		}
 
@@ -363,6 +390,17 @@ static void dwmac_receive(const struct device *dev)
 				LOG_DBG("pkt len/frags=%zd/%d",
 					net_pkt_get_len(p->rx_pkt),
 					net_pkt_get_nbfrags(p->rx_pkt));
+#ifdef CONFIG_PTP_CLOCK_DWC_MAC
+				/*
+				 * The next descriptor is a context descriptor with a timestamp
+				 * for this packet, so skip here to the next descriptor, so we
+				 * can add the timestamp to this packet, before submitting it.
+				 */
+				if (((des3_val & RDES3_RS1V) != 0) &&
+				    ((d->des1 & RDES1_TSA) != 0)) {
+					continue;
+				}
+#endif
 				if (net_recv_data(p->iface, p->rx_pkt) < 0) {
 					net_pkt_unref(p->rx_pkt);
 				}

--- a/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
+++ b/drivers/ethernet/dwc_mac/eth_dwc_ether_qos_core.c
@@ -792,6 +792,9 @@ const struct ethernet_api dwmac_api = {
 	.set_config		= dwmac_set_config,
 	.get_phy		= dwmac_get_phy,
 	.send			= dwmac_send,
+#if defined(CONFIG_PTP_CLOCK_DWC_MAC)
+	.get_ptp_clock		= dwmac_get_ptp_clock,
+#endif
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	.get_stats		= dwmac_stats,
 #endif

--- a/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_priv.h
@@ -15,6 +15,7 @@
 #define ZEPHYR_DRIVERS_ETHERNET_ETH_DWMAC_PRIV_H_
 
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/net/ethernet.h>
 #include <zephyr/sys/device_mmio.h>
 
 /*
@@ -100,6 +101,10 @@ struct dwmac_config {
 	const struct device *phy_dev;
 	const struct device *clock;
 	const clock_control_subsys_t mac_clk;
+#if defined(CONFIG_PTP_CLOCK_DWC_MAC)
+	const struct device *ptp_clock;
+	const clock_control_subsys_t ptp_clk;
+#endif
 };
 
 struct dwmac_priv {
@@ -149,6 +154,57 @@ struct dwmac_priv {
 #define DWMAC_REG_WRITE(r, v) sys_write32((v), DEVICE_MMIO_GET(dev) + (r))
 
 /*
+ * PTP register definitions shared between the DWMAC core drivers and the
+ * dedicated PTP clock child device.
+ */
+#if defined(CONFIG_ETH_DWC_ETHER_QOS_CORE)
+#define DWMAC_PTP_MACTSCR  0x0b00
+#define DWMAC_PTP_MACSSIR  0x0b04
+#define DWMAC_PTP_MACSTSR  0x0b08
+#define DWMAC_PTP_MACSTNR  0x0b0c
+#define DWMAC_PTP_MACSTSUR 0x0b10
+#define DWMAC_PTP_MACSTNUR 0x0b14
+#define DWMAC_PTP_MACTSAR  0x0b18
+
+#define DWMAC_PTP_CTRL_REG        DWMAC_PTP_MACTSCR
+#define DWMAC_PTP_SSINC_REG       DWMAC_PTP_MACSSIR
+#define DWMAC_PTP_SEC_UPDATE_REG  DWMAC_PTP_MACSTSUR
+#define DWMAC_PTP_NSEC_UPDATE_REG DWMAC_PTP_MACSTNUR
+#define DWMAC_PTP_SEC_REG         DWMAC_PTP_MACSTSR
+#define DWMAC_PTP_NSEC_REG        DWMAC_PTP_MACSTNR
+#define DWMAC_PTP_ADDEND_REG      DWMAC_PTP_MACTSAR
+
+#define DWMAC_PTP_SSINC_SHIFT 16
+#else
+#define DWMAC_PTP_PTPTSCR  0x0700
+#define DWMAC_PTP_PTPSSIR  0x0704
+#define DWMAC_PTP_PTPTSHR  0x0708
+#define DWMAC_PTP_PTPTSLR  0x070c
+#define DWMAC_PTP_PTPTSHUR 0x0710
+#define DWMAC_PTP_PTPTSLUR 0x0714
+#define DWMAC_PTP_PTPTSAR  0x0718
+
+#define DWMAC_PTP_CTRL_REG        DWMAC_PTP_PTPTSCR
+#define DWMAC_PTP_SSINC_REG       DWMAC_PTP_PTPSSIR
+#define DWMAC_PTP_SEC_UPDATE_REG  DWMAC_PTP_PTPTSHUR
+#define DWMAC_PTP_NSEC_UPDATE_REG DWMAC_PTP_PTPTSLUR
+#define DWMAC_PTP_SEC_REG         DWMAC_PTP_PTPTSHR
+#define DWMAC_PTP_NSEC_REG        DWMAC_PTP_PTPTSLR
+#define DWMAC_PTP_ADDEND_REG      DWMAC_PTP_PTPTSAR
+
+#define DWMAC_PTP_SSINC_SHIFT 0
+#endif
+
+#define DWMAC_PTP_CTRL_ENABLE			BIT(0)
+#define DWMAC_PTP_CTRL_FINE_UPDATE		BIT(1)
+#define DWMAC_PTP_CTRL_TIME_INIT		BIT(2)
+#define DWMAC_PTP_CTRL_TIME_UPDATE		BIT(3)
+#define DWMAC_PTP_CTRL_ADDEND_UPDATE		BIT(5)
+#define DWMAC_PTP_CTRL_ALL_RX			BIT(8)
+#define DWMAC_PTP_CTRL_ROLLOVER			BIT(9)
+#define DWMAC_PTP_NSEC_UPDATE_ADDSUB		BIT(31)
+
+/*
  * Shared declarations between core and platform glue code
  */
 
@@ -156,6 +212,9 @@ int dwmac_probe(const struct device *dev);
 int dwmac_bus_init(const struct device *dev);
 int dwmac_platform_init(const struct device *dev);
 void dwmac_isr(const struct device *ddev);
+#if defined(CONFIG_PTP_CLOCK_DWC_MAC)
+const struct device *dwmac_get_ptp_clock(const struct device *dev, struct net_if *iface);
+#endif
 extern const struct ethernet_api dwmac_api;
 
 /*

--- a/drivers/ethernet/dwc_mac/eth_dwmac_ptp.c
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_ptp.c
@@ -1,0 +1,209 @@
+/*
+ * Driver for Synopsys DesignWare MAC PTP clock
+ *
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT snps_dwmac_ptp_clock
+
+#include <errno.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/ptp_clock.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+#include "eth_dwmac_priv.h"
+
+LOG_MODULE_REGISTER(dwmac_ptp_clock, CONFIG_ETHERNET_LOG_LEVEL);
+
+struct dwmac_ptp_data {
+	uint32_t default_addend;
+};
+
+static void dwmac_ptp_wait_for_clear(mm_reg_t base, uint32_t reg, uint32_t mask)
+{
+	while (sys_read32(base + reg) & mask) {
+		k_yield();
+	}
+}
+
+static int dwmac_ptp_set(const struct device *dev, struct net_ptp_time *tm)
+{
+	const struct device *eth_dev = dev->config;
+	struct dwmac_priv *p = eth_dev->data;
+	mm_reg_t base = DEVICE_MMIO_GET(eth_dev);
+
+	K_SPINLOCK(&p->spinlock) {
+		sys_write32(tm->second, base + DWMAC_PTP_SEC_UPDATE_REG);
+		sys_write32(tm->nanosecond, base + DWMAC_PTP_NSEC_UPDATE_REG);
+		sys_write32(sys_read32(base + DWMAC_PTP_CTRL_REG) | DWMAC_PTP_CTRL_TIME_INIT,
+			    base + DWMAC_PTP_CTRL_REG);
+		while (sys_read32(base + DWMAC_PTP_CTRL_REG) & DWMAC_PTP_CTRL_TIME_INIT) {
+			/* spin lock */
+		}
+	}
+
+	return 0;
+}
+
+static int dwmac_ptp_get(const struct device *dev, struct net_ptp_time *tm)
+{
+	const struct device *eth_dev = dev->config;
+	struct dwmac_priv *p = eth_dev->data;
+	mm_reg_t base = DEVICE_MMIO_GET(eth_dev);
+	uint32_t second_2;
+
+	K_SPINLOCK(&p->spinlock) {
+		tm->second = sys_read32(base + DWMAC_PTP_SEC_REG);
+		tm->nanosecond = sys_read32(base + DWMAC_PTP_NSEC_REG);
+		second_2 = sys_read32(base + DWMAC_PTP_SEC_REG);
+	}
+
+	if (tm->second != second_2 && tm->nanosecond < NSEC_PER_SEC / 2) {
+		/* Second rollover happened between the two reads. */
+		tm->second = second_2;
+	}
+
+	return 0;
+}
+
+static int dwmac_ptp_adjust(const struct device *dev, int increment)
+{
+	const struct device *eth_dev = dev->config;
+	struct dwmac_priv *p = eth_dev->data;
+	mm_reg_t base = DEVICE_MMIO_GET(eth_dev);
+
+	if ((increment <= (int32_t)(-NSEC_PER_SEC)) || (increment >= (int32_t)NSEC_PER_SEC)) {
+		return -EINVAL;
+	}
+
+	K_SPINLOCK(&p->spinlock) {
+		sys_write32(0, base + DWMAC_PTP_SEC_UPDATE_REG);
+		if (increment >= 0) {
+			sys_write32((uint32_t)increment, base + DWMAC_PTP_NSEC_UPDATE_REG);
+		} else {
+#if defined(CONFIG_ETH_DWC_ETHER_QOS_CORE)
+			sys_write32(DWMAC_PTP_NSEC_UPDATE_ADDSUB | (NSEC_PER_SEC + increment),
+				    base + DWMAC_PTP_NSEC_UPDATE_REG);
+#else
+			sys_write32(DWMAC_PTP_NSEC_UPDATE_ADDSUB | (-increment),
+				    base + DWMAC_PTP_NSEC_UPDATE_REG);
+#endif
+		}
+		sys_write32(sys_read32(base + DWMAC_PTP_CTRL_REG) | DWMAC_PTP_CTRL_TIME_UPDATE,
+			    base + DWMAC_PTP_CTRL_REG);
+		while (sys_read32(base + DWMAC_PTP_CTRL_REG) & DWMAC_PTP_CTRL_TIME_UPDATE) {
+			/* spin lock */
+		}
+	}
+
+	return 0;
+}
+
+static int dwmac_ptp_rate_adjust(const struct device *dev, double ratio)
+{
+	const struct device *eth_dev = dev->config;
+	struct dwmac_priv *p = eth_dev->data;
+	const struct dwmac_ptp_data *data = dev->data;
+	mm_reg_t base = DEVICE_MMIO_GET(eth_dev);
+	uint32_t addend_val;
+
+	if (ratio <= 0.0 || ratio > 2.0) {
+		return -EINVAL;
+	}
+
+	addend_val = (uint32_t)((double)data->default_addend * ratio);
+
+	K_SPINLOCK(&p->spinlock) {
+		sys_write32(addend_val, base + DWMAC_PTP_ADDEND_REG);
+		sys_write32(sys_read32(base + DWMAC_PTP_CTRL_REG) | DWMAC_PTP_CTRL_ADDEND_UPDATE,
+			    base + DWMAC_PTP_CTRL_REG);
+		while (sys_read32(base + DWMAC_PTP_CTRL_REG) & DWMAC_PTP_CTRL_ADDEND_UPDATE) {
+			/* spin lock */
+		}
+	}
+
+	return 0;
+}
+
+static int dwmac_ptp_init(const struct device *dev)
+{
+	const struct device *eth_dev = dev->config;
+	const struct dwmac_config *eth_cfg = eth_dev->config;
+	struct dwmac_ptp_data *data = dev->data;
+	mm_reg_t base = DEVICE_MMIO_GET(eth_dev);
+	uint32_t ptp_clk_rate;
+	uint32_t ss_incr_ns;
+	uint32_t addend_val;
+	uint64_t temp;
+	int ret;
+
+	ret = clock_control_get_rate(eth_cfg->clock, eth_cfg->ptp_clk, &ptp_clk_rate);
+	if (ret < 0) {
+		return -EIO;
+	}
+
+	ss_incr_ns = 2000000000ULL / ptp_clk_rate;
+
+	sys_write32(ss_incr_ns << DWMAC_PTP_SSINC_SHIFT, base + DWMAC_PTP_SSINC_REG);
+
+	sys_write32(sys_read32(base + DWMAC_PTP_CTRL_REG) | DWMAC_PTP_CTRL_ENABLE,
+		    base + DWMAC_PTP_CTRL_REG);
+
+	temp = 1000000000ULL / ss_incr_ns;
+
+	temp = (uint64_t)(temp << 32);
+
+	addend_val = temp / ptp_clk_rate;
+
+	data->default_addend = addend_val;
+
+	sys_write32(addend_val, base + DWMAC_PTP_ADDEND_REG);
+	sys_write32(sys_read32(base + DWMAC_PTP_CTRL_REG) | DWMAC_PTP_CTRL_ADDEND_UPDATE,
+		    base + DWMAC_PTP_CTRL_REG);
+	dwmac_ptp_wait_for_clear(base, DWMAC_PTP_CTRL_REG, DWMAC_PTP_CTRL_ADDEND_UPDATE);
+
+	sys_write32(sys_read32(base + DWMAC_PTP_CTRL_REG) | DWMAC_PTP_CTRL_FINE_UPDATE,
+		    base + DWMAC_PTP_CTRL_REG);
+	sys_write32(sys_read32(base + DWMAC_PTP_CTRL_REG) | DWMAC_PTP_CTRL_ROLLOVER,
+		    base + DWMAC_PTP_CTRL_REG);
+
+	sys_write32(0, base + DWMAC_PTP_SEC_UPDATE_REG);
+	sys_write32(0, base + DWMAC_PTP_NSEC_UPDATE_REG);
+	sys_write32(sys_read32(base + DWMAC_PTP_CTRL_REG) | DWMAC_PTP_CTRL_TIME_INIT,
+		    base + DWMAC_PTP_CTRL_REG);
+	dwmac_ptp_wait_for_clear(base, DWMAC_PTP_CTRL_REG, DWMAC_PTP_CTRL_TIME_INIT);
+
+	/* Enable timestamping for all received packets */
+	sys_write32(sys_read32(base + DWMAC_PTP_CTRL_REG) | DWMAC_PTP_CTRL_ALL_RX,
+		    base + DWMAC_PTP_CTRL_REG);
+
+	return 0;
+}
+
+static DEVICE_API(ptp_clock, dwmac_ptp_api) = {
+	.set = dwmac_ptp_set,
+	.get = dwmac_ptp_get,
+	.adjust = dwmac_ptp_adjust,
+	.rate_adjust = dwmac_ptp_rate_adjust,
+};
+
+const struct device *dwmac_get_ptp_clock(const struct device *dev, struct net_if *iface __unused)
+{
+	const struct dwmac_config *config = dev->config;
+
+	return config->ptp_clock;
+}
+
+#define PTP_CLOCK_DWMAC_INIT(n)                                                                    \
+	static struct dwmac_ptp_data dwmac_ptp_data_##n;                                           \
+	DEVICE_DT_INST_DEFINE(n, dwmac_ptp_init, NULL, &dwmac_ptp_data_##n,                        \
+			      DEVICE_DT_GET(DT_INST_PARENT(n)), POST_KERNEL,                       \
+			      CONFIG_PTP_CLOCK_INIT_PRIORITY, &dwmac_ptp_api);
+
+DT_INST_FOREACH_STATUS_OKAY(PTP_CLOCK_DWMAC_INIT)

--- a/drivers/ethernet/dwc_mac/eth_dwmac_ptp.c
+++ b/drivers/ethernet/dwc_mac/eth_dwmac_ptp.c
@@ -179,9 +179,29 @@ static int dwmac_ptp_init(const struct device *dev)
 		    base + DWMAC_PTP_CTRL_REG);
 	dwmac_ptp_wait_for_clear(base, DWMAC_PTP_CTRL_REG, DWMAC_PTP_CTRL_TIME_INIT);
 
-	/* Enable timestamping for all received packets */
-	sys_write32(sys_read32(base + DWMAC_PTP_CTRL_REG) | DWMAC_PTP_CTRL_ALL_RX,
-		    base + DWMAC_PTP_CTRL_REG);
+	uint32_t ctrl = sys_read32(base + DWMAC_PTP_CTRL_REG);
+
+	if (IS_ENABLED(CONFIG_PTP)) {
+		/* Use PTPv2 */
+		ctrl |= BIT(10);
+		/* enable timestamping for L2 PTP packets */
+		if (IS_ENABLED(CONFIG_PTP_IEEE_802_3_PROTOCOL)) {
+			ctrl |= BIT(11);
+		}
+		/* enable timestamping for IPv4 PTP packets */
+		if (IS_ENABLED(CONFIG_PTP_UDP_IPV4_PROTOCOL)) {
+			ctrl |= BIT(13);
+		}
+		/* enable timestamping for IPv6 PTP packets */
+		if (IS_ENABLED(CONFIG_PTP_UDP_IPV6_PROTOCOL)) {
+			ctrl |= BIT(12);
+		}
+	} else {
+		/* Enable timestamping for all received packets */
+		ctrl |= DWMAC_PTP_CTRL_ALL_RX;
+	}
+
+	sys_write32(ctrl, base + DWMAC_PTP_CTRL_REG);
 
 	return 0;
 }

--- a/drivers/ethernet/dwc_mac/eth_esp32_dwc_ether_1000.c
+++ b/drivers/ethernet/dwc_mac/eth_esp32_dwc_ether_1000.c
@@ -92,6 +92,14 @@ int dwmac_bus_init(const struct device *dev)
 		emac_ll_clock_enable_mii(EMAC_EXT_ADDR);
 	}
 
+#if defined(CONFIG_PTP_CLOCK_DWC_MAC)
+	ret = clock_control_on(cfg->clock, cfg->ptp_clk);
+	if (ret < 0 && ret != -EALREADY) {
+		LOG_ERR("Failed to setup PTP reference clock");
+		return ret;
+	}
+#endif
+
 	return 0;
 }
 
@@ -155,6 +163,10 @@ static const struct dwmac_config dwmac_config = {
 	.phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, phy_handle)),
 	.clock = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
 	.mac_clk = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(0, offset),
+#if defined(CONFIG_PTP_CLOCK_DWC_MAC)
+	.ptp_clock = DEVICE_DT_GET(DT_INST_CHILD(0, ptp_clock)),
+	.ptp_clk = (clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(0, ptp, offset),
+#endif
 };
 
 static struct dwmac_priv dwmac_instance;

--- a/drivers/ethernet/dwc_mac/eth_stm32_dwc.h
+++ b/drivers/ethernet/dwc_mac/eth_stm32_dwc.h
@@ -11,6 +11,11 @@
 #include <zephyr/net/ethernet.h>
 #include <zephyr/sys/crc.h>
 
+#define ETH_STM32_PTP_CLK_IDX(n)                                                                   \
+	DT_PHA_ELEM_IDX_BY_NAME(                                                                   \
+		DT_DRV_INST(n), clocks,                                                            \
+		COND_CODE_1(DT_INST_CLOCKS_HAS_NAME(n, mac_clk_ptp), (mac_clk_ptp), (stm_eth)))
+
 #define ST_OUI_B0 0x00
 #define ST_OUI_B1 0x80
 #define ST_OUI_B2 0xE1

--- a/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_1000.c
+++ b/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_1000.c
@@ -118,6 +118,10 @@ static const struct dwmac_config dwmac_config = {
 	.phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, phy_handle)),
 	.clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 	.mac_clk = (clock_control_subsys_t)&pclken[0],
+#if defined(CONFIG_PTP_CLOCK_DWC_MAC)
+	.ptp_clock = DEVICE_DT_GET(DT_INST_CHILD(0, ptp_clock)),
+	.ptp_clk = (clock_control_subsys_t)&pclken[ETH_STM32_PTP_CLK_IDX(0)],
+#endif
 };
 
 static struct dwmac_priv dwmac_instance;

--- a/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_qos.c
+++ b/drivers/ethernet/dwc_mac/eth_stm32_dwc_ether_qos.c
@@ -158,6 +158,10 @@ static const struct dwmac_config dwmac_config = {
 	.phy_dev = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(0, phy_handle)),
 	.clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 	.mac_clk = (clock_control_subsys_t)&pclken[0],
+#if defined(CONFIG_PTP_CLOCK_DWC_MAC)
+	.ptp_clock = DEVICE_DT_GET(DT_INST_CHILD(0, ptp_clock)),
+	.ptp_clk = (clock_control_subsys_t)&pclken[ETH_STM32_PTP_CLK_IDX(0)],
+#endif
 };
 
 static struct dwmac_priv dwmac_instance;

--- a/dts/riscv/espressif/esp32p4/esp32p4_common.dtsi
+++ b/dts/riscv/espressif/esp32p4/esp32p4_common.dtsi
@@ -679,7 +679,9 @@
 			reg = <0x50098000 0x4000>;
 			interrupts = <ETH_MAC_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&clock ESP32_EMAC_MODULE>;
+			clocks = <&clock ESP32_EMAC_MODULE>,
+				 <&clock ESP32_EMAC_PTP_MODULE>;
+			clock-names = "mac", "ptp";
 			status = "disabled";
 
 			mdio: mdio {
@@ -687,6 +689,10 @@
 				status = "disabled";
 				#address-cells = <1>;
 				#size-cells = <0>;
+			};
+
+			ptp_clock: ptp-clock {
+				compatible = "snps,dwmac-ptp-clock";
 			};
 		};
 	};

--- a/include/zephyr/dt-bindings/clock/esp32p4_clock.h
+++ b/include/zephyr/dt-bindings/clock/esp32p4_clock.h
@@ -97,5 +97,6 @@
 /* LP peripherals */
 #define ESP32_LP_I2C0_MODULE      137 /**< LP I2C0 module */
 #define ESP32_LP_UART0_MODULE     138 /**< LP UART0 module */
+#define ESP32_EMAC_PTP_MODULE     139 /**< Ethernet MAC PTP reference clock */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_ESP32P4_H_ */

--- a/samples/net/ptp/tests.yaml
+++ b/samples/net/ptp/tests.yaml
@@ -23,6 +23,7 @@ tests:
   sample.net.ptp.dwmac:
     extra_configs:
       - CONFIG_ETH_STM32_HAL=n
+      - CONFIG_ETH_ESP32=n
     depends_on: eth
     platform_allow:
       - stm32h735g_disco
@@ -31,3 +32,4 @@ tests:
       - nucleo_f767zi
       - stm32h7s78_dk/stm32h7s7xx/ext_flash_app
       - stm32h573i_dk
+      - esp32p4x_function_ev_board/esp32p4/hpcore

--- a/samples/net/ptp/tests.yaml
+++ b/samples/net/ptp/tests.yaml
@@ -19,3 +19,15 @@ tests:
     depends_on: eth
     integration_platforms:
       - nucleo_h563zi
+
+  sample.net.ptp.dwmac:
+    extra_configs:
+      - CONFIG_ETH_STM32_HAL=n
+    depends_on: eth
+    platform_allow:
+      - stm32h735g_disco
+      - nucleo_h753zi
+      - nucleo_f429zi
+      - nucleo_f767zi
+      - stm32h7s78_dk/stm32h7s7xx/ext_flash_app
+      - stm32h573i_dk

--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 150e0c1bd24fd568864ae50fa690e9ec526022a4
+      revision: aff3c2c094b32bd2d87fe9211a1b0d0a1d7aa198
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
add support for ptp in the dwc mac driver.

with this and https://github.com/zephyrproject-rtos/zephyr/pull/113235 the dwc mac 1000 driver exceeds the capabilities of the hal based stm32 ethernet driver for the f series. the hal driver only supports ptp on the f7
