### PR TITLE
tests: dma: chan_blen_transfer: accept dma-test-devs boards in filter

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/tests.yaml
+++ b/tests/drivers/dma/chan_blen_transfer/tests.yaml
@@ -8,14 +8,14 @@ tests:
     integration_platforms:
       - native_sim
       - native_sim/native/64
-    filter: dt_nodelabel_enabled("tst_dma0")
+    filter: dt_nodelabel_enabled("tst_dma0") or dt_node_has_prop("/zephyr,user", "dma-test-devs")
   drivers.dma.chan_blen_transfer.low_footprint:
     tags:
       - dma
     min_ram: 12
     depends_on:
       - dma
-    filter: dt_nodelabel_enabled("tst_dma0")
+    filter: dt_nodelabel_enabled("tst_dma0") or dt_node_has_prop("/zephyr,user", "dma-test-devs")
     platform_allow:
       - nucleo_c031c6
       - sam_e54_xpro


### PR DESCRIPTION
## Description

The `drivers.dma.chan_blen_transfer` test source selects the DMA
controllers to exercise from either a `zephyr,user` `dma-test-devs`
phandle list or the legacy `tst_dmaN` nodelabels. The twister filter,
however, only enabled the test when a `tst_dma0` nodelabel was present.

As a result, a board that provides only the `dma-test-devs` list (and
no `tst_dma0` nodelabel) is filtered out at runtime, even though the
test builds and runs correctly on it.

This extends the filter to also accept boards that expose a
`dma-test-devs` property on `/zephyr,user`, matching how the test
source discovers the controllers. Boards that still use the legacy
`tst_dma0` nodelabel are unaffected.

## Testing

- `tst_dma0`-based boards: filter behaviour unchanged (still selected).
- `dma-test-devs`-based boards: now selected instead of being filtered.