### PR TITLE
drivers: dp: use raw line levels for SWJ_Pins, fix sample nRESET polarity

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -196,6 +196,18 @@ Controller Area Network (CAN)
   are processed in the order received on the bus. Out-of-tree users may want to update any
   ``bosch,mram-cfg`` devicetree property overrides to allocate all FIFO elements to RX FIFO0.
 
+Debug
+=====
+
+* The :dtcompatible:`zephyr,swdp-gpio` driver now consistently treats the ``reset-gpios``
+  active-level flags as the reset assertion level: the driver asserts reset by driving the pin to
+  its logical active state, so a directly wired active-low nRESET line must be declared
+  ``GPIO_ACTIVE_LOW``. ``DAP_SWJ_Pins`` requests now operate on raw line levels, as defined by
+  CMSIS-DAP, and are unaffected by the flags. Boards that declared ``reset-gpios`` with
+  ``GPIO_ACTIVE_HIGH`` for a directly wired nRESET (as the ``dap`` sample previously did) must flip
+  the flag to ``GPIO_ACTIVE_LOW``, otherwise the debug port setup holds the target in reset
+  (:github:`114549`).
+
 Devicetree
 ==========
 

--- a/drivers/dp/swdp_bitbang.c
+++ b/drivers/dp/swdp_bitbang.c
@@ -442,26 +442,26 @@ static int sw_set_pins(const struct device *dev,
 
 	if (pins & BIT(SWDP_SWCLK_PIN)) {
 		if (value & BIT(SWDP_SWCLK_PIN)) {
-			gpio_pin_set_dt(&config->clk, 1);
+			(void)gpio_pin_set_raw(config->clk.port, config->clk.pin, 1);
 		} else {
-			gpio_pin_set_dt(&config->clk, 0);
+			(void)gpio_pin_set_raw(config->clk.port, config->clk.pin, 0);
 		}
 	}
 
 	if (config->dout_reg != NULL) {
 		if (pins & BIT(SWDP_SWDIO_PIN)) {
 			if (value & BIT(SWDP_SWDIO_PIN)) {
-				gpio_pin_set_dt(&config->dout, 1);
+				(void)gpio_pin_set_raw(config->dout.port, config->dout.pin, 1);
 			} else {
-				gpio_pin_set_dt(&config->dout, 0);
+				(void)gpio_pin_set_raw(config->dout.port, config->dout.pin, 0);
 			}
 		}
 	} else {
 		if (pins & BIT(SWDP_SWDIO_PIN)) {
 			if (value & BIT(SWDP_SWDIO_PIN)) {
-				gpio_pin_set_dt(&config->dio, 1);
+				(void)gpio_pin_set_raw(config->dio.port, config->dio.pin, 1);
 			} else {
-				gpio_pin_set_dt(&config->dio, 0);
+				(void)gpio_pin_set_raw(config->dio.port, config->dio.pin, 0);
 			}
 		}
 	}
@@ -469,9 +469,9 @@ static int sw_set_pins(const struct device *dev,
 	if (config->reset.port) {
 		if (pins & BIT(SWDP_nRESET_PIN)) {
 			if (value & BIT(SWDP_nRESET_PIN)) {
-				gpio_pin_set_dt(&config->reset, 1);
+				(void)gpio_pin_set_raw(config->reset.port, config->reset.pin, 1);
 			} else {
-				gpio_pin_set_dt(&config->reset, 0);
+				(void)gpio_pin_set_raw(config->reset.port, config->reset.pin, 0);
 			}
 		}
 	}
@@ -482,17 +482,31 @@ static int sw_set_pins(const struct device *dev,
 static int sw_get_pins(const struct device *dev, uint8_t *const state)
 {
 	const struct sw_config *config = dev->config;
-	uint32_t val;
+	int val;
+
+	*state = 0;
 
 	if (config->reset.port) {
-		val = gpio_pin_get_dt(&config->reset);
+		val = gpio_pin_get_raw(config->reset.port, config->reset.pin);
+		if (val < 0) {
+			LOG_ERR("Failed to read reset pin");
+			return val;
+		}
 		*state = val ? BIT(SWDP_nRESET_PIN) : 0;
 	}
 
-	val = gpio_pin_get_dt(&config->dio);
+	val = gpio_pin_get_raw(config->dio.port, config->dio.pin);
+	if (val < 0) {
+		LOG_ERR("Failed to read SWDIO pin");
+		return val;
+	}
 	*state |= val ? BIT(SWDP_SWDIO_PIN) : 0;
 
-	val = gpio_pin_get_dt(&config->clk);
+	val = gpio_pin_get_raw(config->clk.port, config->clk.pin);
+	if (val < 0) {
+		LOG_ERR("Failed to read SWCLK pin");
+		return val;
+	}
 	*state |= val ? BIT(SWDP_SWCLK_PIN) : 0;
 
 	LOG_DBG("pins state 0x%02x", *state);

--- a/dts/bindings/misc/zephyr,swdp-gpio.yaml
+++ b/dts/bindings/misc/zephyr,swdp-gpio.yaml
@@ -92,6 +92,13 @@ properties:
     description: |
       Optional GPIO pin used for RESET output.
 
+      The GPIO flags describe the reset assertion level: the driver
+      asserts reset by driving the pin to its logical active state.
+      For the common directly wired active-low nRESET signal, use
+      GPIO_ACTIVE_LOW. DAP_SWJ_Pins requests are the exception: they
+      operate on raw line levels, as defined by CMSIS-DAP, and are not
+      affected by these flags.
+
   keep-reset-deasserted:
     type: boolean
     description: |

--- a/samples/subsys/dap/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/subsys/dap/boards/nrf52840dk_nrf52840.overlay
@@ -13,7 +13,7 @@
 		dout-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>;	/* D3 */
 		dnoe-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;	/* D6 */
 		noe-gpios = <&arduino_header 11 GPIO_ACTIVE_HIGH>;	/* D5 */
-		reset-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;	/* D7 */
+		reset-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>;	/* D7 */
 		port-write-cycles = <2>;
 	};
 };


### PR DESCRIPTION
### Problem

The bitbang SW-DP driver had two contradictory polarity conventions for `reset-gpios`, so no devicetree flag choice made all paths work:

- `sw_set_pins()`/`sw_get_pins()` (`DAP_SWJ_Pins`) mapped the CMSIS-DAP pin bits — defined as line levels, 1 = high — to *logical* GPIO values, i.e. they behaved only under `GPIO_ACTIVE_HIGH` for a directly wired nRESET.
- `sw_port_on()`/`sw_port_off()` (since 4023ded959a1, #106125) drive reset by *assertion level*, i.e. they behave only under `GPIO_ACTIVE_LOW`.

With the sample's `GPIO_ACTIVE_HIGH`, port-on holds the target in reset for the entire debug session — DP transactions succeed while every AP access returns WAIT forever, invisible unless nRESET is actually wired. With `GPIO_ACTIVE_LOW`, host-driven reset and pin readback via `DAP_SWJ_Pins` invert silently. Full analysis in the discussion below.

### Fix (v2 — reworked per review)

Per @rerickson1's review, this revision standardizes on the **assertion-level** convention for `reset-gpios` and makes `DAP_SWJ_Pins` convention-independent. (v1 of this PR implemented the opposite, line-level convention; superseded.)

- **Commit 1 — authored by @rerickson1**, adopted from his patch attached in the discussion: `sw_set_pins()`/`sw_get_pins()` switch to the raw GPIO accessors, so SWJ_Pins always reflects the physical line levels as CMSIS-DAP defines them, regardless of DT flags. Two minimal edits during adoption, disclosed in the commit trailer: `val` in `sw_get_pins()` declared `int` so the added `< 0` error checks can actually fire (it was `uint32_t`), and an extended commit message.
- **Commit 2**: flip the sample overlay to `GPIO_ACTIVE_LOW` (under the assertion-level convention, the old `GPIO_ACTIVE_HIGH` still makes port-on hold the target in reset), state the contract explicitly in the binding (`reset-gpios` flags = reset assertion level, use `GPIO_ACTIVE_LOW` for a directly wired nRESET; `DAP_SWJ_Pins` operates on raw line levels and ignores the flags), and add a 4.5 migration note for out-of-tree boards written against the old sample.

### Validation

- `samples/subsys/dap` builds for `nrf52840dk/nrf52840` with the flipped overlay.
- During the investigation we bench-verified the assertion-level convention on our probe firmware (FRDM-MCXA153 running this driver + `subsys/dap`) against FRDM-MCXN947 and STM32H503 targets: pyocd connect / halt / memory read (incl. TrustZone secure alias) / flash / resume. We will re-run the matrix, including host-driven SWJ_Pins nRESET pulses and pin readback, on exactly this revision and post the results here.

Fixes the regression introduced by 4023ded959a1 for devicetrees following the sample.
