### PR TITLE
Update WIFI 1.4.0 FW and add CYW55513_MOD_PSE84_SOM CLM/NVM 

### DIFF
--- a/boards/infineon/kit_pse84_eval/Kconfig.defconfig
+++ b/boards/infineon/kit_pse84_eval/Kconfig.defconfig
@@ -11,7 +11,7 @@ choice AIROC_PART
 endchoice
 
 choice CYW55500_MODULE
-	default CYW55513IUBG_SM
+	default CYW55513_MOD_PSE84_SOM
 endchoice
 
 # Heap Pool Size

--- a/drivers/wifi/infineon/Kconfig.airoc
+++ b/drivers/wifi/infineon/Kconfig.airoc
@@ -260,6 +260,11 @@ config CYW55513_MURATA_2FY_SM
 	help
 	  Infineon CYW55513 in Murata LBEE5HY2FY (Type 2FY) module (SM)
 
+config CYW55513_MOD_PSE84_SOM
+	bool "CYW55513_MOD_PSE84_SOM"
+	help
+	  Infineon CYW55513_MOD_PSE84_SOM (SM) module
+
 endchoice
 
 choice CYW55572_MODULE

--- a/modules/hal_infineon/whd-expansion/CMakeLists.txt
+++ b/modules/hal_infineon/whd-expansion/CMakeLists.txt
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_AIROC_WIFI6)
-    set(whd_wifi_ver COMPONENT_WIFI6)
+  set(whd_wifi_ver COMPONENT_WIFI6)
 else()
-    set(whd_wifi_ver COMPONENT_WIFI5)
+  set(whd_wifi_ver COMPONENT_WIFI5)
 endif()
 
 set(hal_dir                  ${ZEPHYR_HAL_INFINEON_MODULE_DIR})
@@ -300,6 +300,18 @@ if(CONFIG_CYW55513_MURATA_2FY_SM AND NOT CONFIG_AIROC_WIFI_CUSTOM)
   endif()
   # nvram
   set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_55500/COMPONENT_MURATA-2FY/cyw55500-sdio-mur-2FY.txt)
+endif()
+
+# CYW55513_MOD_PSE84_SOM clm, nvram
+if(CONFIG_CYW55513_MOD_PSE84_SOM AND NOT CONFIG_AIROC_WIFI_CUSTOM)
+  # clm
+  if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_55500/COMPONENT_CYW55513_MOD_PSE84_SOM/55500A1-mfgtest.clm_blob)
+  else()
+    set(CLM_IMAGE_NAME ${hal_blobs_dir}/clm/COMPONENT_55500/COMPONENT_CYW55513_MOD_PSE84_SOM/55500A1.clm_blob)
+  endif()
+  # nvram
+  set(NVRAM_IMAGE_NAME ${hal_wifi_dir_resources}/nvram/COMPONENT_55500/COMPONENT_CYW55513_MOD_PSE84_SOM/cyw55513modpse84som_rev3.txt)
 endif()
 
 # CYW955573M2IPA1_SM

--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,7 @@ manifest:
       groups:
         - hal
     - name: hal_infineon
-      revision: c73313ab49840fee98cb347034526aaab62122a6
+      revision: 13e4b3cd70fb2d862a37e55665f03af09fe74201
       path: modules/hal/infineon
       groups:
         - hal


### PR DESCRIPTION
1. update 1.4.0 FW from https://github.com/Infineon/whd-expansion/tree/release-v1.4.0/WHD/COMPONENT_WIFI6/resources
2. Add CYW55513_MOD_PSE84_SOM's CLM/NVM https://github.com/Infineon/wifi-resources

It depends on https://github.com/zephyrproject-rtos/hal_infineon/pull/70.

Verifed wifi_shell on m33/ns and m55.