### PR TITLE
soc: espressif: include devicetree.h in start.S

### DIFF
--- a/soc/espressif/common/start.S
+++ b/soc/espressif/common/start.S
@@ -11,6 +11,7 @@
  */
 
 #include <zephyr/toolchain.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/arch/riscv/csr.h>
 #include <soc/soc_caps.h>
 #include "memory.h"


### PR DESCRIPTION
DRAM_STACK_START resolves to a devicetree-derived expression when CONFIG_NOCACHE_MEMORY is enabled. Without devicetree.h the DT_REG_SIZE and DT_NODELABEL macros reach the assembler unexpanded and fail. Add the include so the early stack pointer resolves in all configurations.

ref: https://github.com/zephyrproject-rtos/zephyr/actions/runs/30121477262/job/89575231624