### PR TITLE
drivers: bluetooth: esp32: raise bt rx stack for settings

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.esp32
+++ b/drivers/bluetooth/hci/Kconfig.esp32
@@ -10,6 +10,9 @@ config HEAP_MEM_POOL_ADD_SIZE_ESP_BT
 	help
 	  Additional heap size reserved for Bluetooth driver usage.
 
+configdefault BT_RX_STACK_SIZE
+	default 2048 if BT_SETTINGS
+
 choice ESP_BT_HEAP
 	prompt "Bluetooth heap type"
 	default ESP_BT_HEAP_SYSTEM


### PR DESCRIPTION
The BLE receive thread runs the connect-time settings store (CCC, keys, GATT database hash), which on Espressif SoCs goes through the flash driver and PSA crypto and overflows the 1200 byte host default. Raise BT_RX_STACK_SIZE to 2048 when BT_SETTINGS is enabled.

Fixes #114394
Fixes #114487