### PR TITLE
dts: arm: sifli: sf32lb52x: add missing interrupt for lcdc

### DIFF
--- a/dts/arm/sifli/sf32lb52x.dtsi
+++ b/dts/arm/sifli/sf32lb52x.dtsi
@@ -124,6 +124,7 @@
 			compatible = "sifli,sf32lb-lcdc";
 			reg = <0x50008000 0x1000>;
 			clocks = <&rcc_clk SF32LB52X_CLOCK_LCDC1>;
+			interrupts = <63 0>;
 			status = "disabled";
 
 			mipi-dbi {


### PR DESCRIPTION
Add missing interrupt number for lcd controller