### PR TITLE
scripts: guiconfig: fix missing sys import

### DIFF
--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -61,6 +61,7 @@ $srctree is supported through Kconfiglib.
 import errno
 import os
 import re
+import sys
 
 from tkinter import *
 import tkinter.ttk as ttk


### PR DESCRIPTION
Import the Python sys module before use in guiconfig.py.

Without this change, code paths referencing sys can fail
with a NameError exception.

fail log:

```
[KTraceback (most recent call last):
  File "C:\...\zephyr\scripts\kconfig\guiconfig.py", line 2430, in <module>
    _main()
  File "C:\...\zephyr\scripts\kconfig\guiconfig.py", line 93, in _main
    menuconfig(standard_kconfig(__doc__))
  File "C:\...\zephyr\scripts\kconfig\guiconfig.py", line 171, in menuconfig
    _create_ui()
  File "C:\...\zephyr\scripts\kconfig\guiconfig.py", line 327, in _create_ui
    _init_misc_ui()
  File "C:\...\zephyr\scripts\kconfig\guiconfig.py", line 432, in _init_misc_ui
    _dark_mode = _detect_system_dark_mode()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\...\zephyr\scripts\kconfig\guiconfig.py", line 269, in _detect_system_dark_mode
    if sys.platform == "win32":
       ^^^
NameError: name 'sys' is not defined. Did you forget to import 'sys'?
```