### PR TITLE
driver: modem: add targeted script recovery framework

### DIFF
--- a/drivers/modem/vendor_standalone/hl78xx/Kconfig.hl78xx
+++ b/drivers/modem/vendor_standalone/hl78xx/Kconfig.hl78xx
@@ -75,6 +75,14 @@ config MODEM_HL78XX_12_FW_R6
 
 endif # MODEM_HL78XX_12
 
+config MODEM_HL78XX_DESIRED_FW_VERSION
+	string "Desired firmware version"
+	default ""
+	help
+	  Specify the desired firmware version for the HL78xx modem.
+	  The driver will check the modem's current firmware version and
+	  log a warning if it does not match this desired version.
+
 config MODEM_HL78XX_AT_SHELL
 	bool "AT command shell"
 	depends on SHELL

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx.c
@@ -25,7 +25,6 @@
 #ifdef CONFIG_HL78XX_GNSS
 #include "hl78xx_gnss.h"
 #endif /* CONFIG_HL78XX_GNSS */
-#define MAX_SCRIPT_AT_CMD_RETRY 3
 
 #define MDM_NODE                         DT_ALIAS(modem)
 /* Check phandle target status for a specific phandle index */
@@ -102,8 +101,8 @@ static const char *hl78xx_state_str(enum hl78xx_state state)
 		return "set baudrate";
 	case MODEM_HL78XX_STATE_RUN_INIT_SCRIPT:
 		return "run init script";
-	case MODEM_HL78XX_STATE_RUN_INIT_FAIL_DIAGNOSTIC_SCRIPT:
-		return "init fail diagnostic script ";
+	case MODEM_HL78XX_STATE_RECOVERY:
+		return "recovery";
 	case MODEM_HL78XX_STATE_RUN_RAT_CONFIG_SCRIPT:
 		return "run rat cfg script";
 	case MODEM_HL78XX_STATE_RUN_PMC_CONFIG_SCRIPT:
@@ -1858,6 +1857,53 @@ static void hl78xx_resume_uart(const struct hl78xx_config *config)
 #endif /* CONFIG_PM_DEVICE */
 }
 
+static void hl78xx_clear_script_failure(struct hl78xx_data *data)
+{
+	data->script_failure.recovery_rule = NULL;
+	data->script_failure.result = MODEM_CHAT_SCRIPT_RESULT_SUCCESS;
+	data->script_failure.origin_state = MODEM_HL78XX_STATE_IDLE;
+	data->script_failure.script_chat_index = 0U;
+	data->script_failure.valid = false;
+}
+
+static void hl78xx_clear_recovery(struct hl78xx_data *data)
+{
+	data->script_recovery.attempted_rule = NULL;
+	data->script_recovery.attempts = 0U;
+	hl78xx_clear_script_failure(data);
+}
+
+static void hl78xx_confirm_recovery(struct hl78xx_data *data, enum hl78xx_state state,
+				    enum hl78xx_event event)
+{
+	const struct hl78xx_script_recovery_rule *rule = data->script_recovery.attempted_rule;
+
+	if ((rule == NULL) || (rule->success_state != state) || (rule->success_event != event)) {
+		return;
+	}
+
+	LOG_INF("Script recovery successful after %u attempt(s)", data->script_recovery.attempts);
+
+	hl78xx_clear_recovery(data);
+}
+
+static void hl78xx_handle_recovery_unavailable(struct hl78xx_data *data)
+{
+	if (!data->script_failure.valid) {
+		hl78xx_clear_recovery(data);
+		hl78xx_enter_restart_fallback_state(data);
+		return;
+	}
+
+	/*
+	 * Clear the active failure context, but retain attempted_rule and
+	 * attempts until recovery is confirmed, idle is entered, or a new
+	 * lifecycle is explicitly started.
+	 */
+	hl78xx_clear_script_failure(data);
+	hl78xx_enter_restart_fallback_state(data);
+}
+
 /* -------------------------------------------------------------------------
  * State machine handlers
  * - state enter/leave and per-state event handlers
@@ -2041,7 +2087,6 @@ static void hl78xx_await_power_on_event_handler(struct hl78xx_data *data, enum h
 		/* Reset per-cycle flag so AT_CMD_READY is dispatched exactly once. */
 		data->status.at_cmd_ready_sent = false;
 		data->status.boot.init_sequence_completed = false;
-
 		LOG_DBG("Current baudrate after post-restart script: %d",
 			data->status.uart.current_baudrate);
 #if defined(CONFIG_MODEM_HL78XX_AUTOBAUD_ONLY_IF_COMMS_FAIL) ||                                    \
@@ -2061,10 +2106,11 @@ static void hl78xx_await_power_on_event_handler(struct hl78xx_data *data, enum h
 #ifdef CONFIG_MODEM_HL78XX_AUTO_BAUDRATE
 		hl78xx_enter_state(data, MODEM_HL78XX_STATE_SET_BAUDRATE);
 #else
-		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_INIT_FAIL_DIAGNOSTIC_SCRIPT);
+		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RECOVERY);
 #endif /* CONFIG_MODEM_HL78XX_AUTO_BAUDRATE */
+		break;
 	case MODEM_HL78XX_EVENT_AT_CMD_TIMEOUT:
-		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_INIT_FAIL_DIAGNOSTIC_SCRIPT);
+		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RECOVERY);
 		break;
 
 	default:
@@ -2121,8 +2167,7 @@ static void hl78xx_set_baudrate_event_handler(struct hl78xx_data *data, enum hl7
 		} else {
 			LOG_ERR("Baud rate configuration failed after %d attempts",
 				data->status.uart.baudrate_detection_retry);
-			hl78xx_enter_state(data,
-					   MODEM_HL78XX_STATE_RUN_INIT_FAIL_DIAGNOSTIC_SCRIPT);
+			hl78xx_enter_state(data, MODEM_HL78XX_STATE_RECOVERY);
 		}
 		break;
 
@@ -2152,6 +2197,8 @@ static void hl78xx_run_init_script_event_handler(struct hl78xx_data *data, enum 
 {
 	switch (evt) {
 	case MODEM_HL78XX_EVENT_SCRIPT_SUCCESS:
+		hl78xx_confirm_recovery(data, MODEM_HL78XX_STATE_RUN_INIT_SCRIPT, evt);
+
 		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_RAT_CONFIG_SCRIPT);
 		break;
 
@@ -2162,88 +2209,76 @@ static void hl78xx_run_init_script_event_handler(struct hl78xx_data *data, enum 
 		hl78xx_enter_state(data, MODEM_HL78XX_STATE_IDLE);
 		break;
 
-	case MODEM_HL78XX_EVENT_SCRIPT_FAILED:
-		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_INIT_FAIL_DIAGNOSTIC_SCRIPT);
-		break;
-
-	default:
-		break;
-	}
-}
-
-static int hl78xx_on_run_init_diagnose_script_state_enter(struct hl78xx_data *data)
-{
-	hl78xx_run_init_fail_script_async(data);
-	return 0;
-}
-
-static void hl78xx_run_init_fail_script_event_handler(struct hl78xx_data *data,
-						      enum hl78xx_event evt)
-{
-	const struct hl78xx_config *config = data->devices.hl78xx->config;
-
-	switch (evt) {
-	case MODEM_HL78XX_EVENT_SCRIPT_SUCCESS:
-		if (data->status.ksrep == 0) {
-			hl78xx_run_enable_ksup_urc_script_async(data);
-			hl78xx_start_timer(data, K_MSEC(config->shutdown_time_ms));
-		} else {
-			if (hl78xx_gpio_is_enabled(&config->mdm_gpio_reset)) {
-				hl78xx_enter_state(data, MODEM_HL78XX_STATE_RESET_PULSE);
-			}
-		}
-		break;
-	case MODEM_HL78XX_EVENT_TIMEOUT:
-		LOG_ERR("Modem initialization failed after diagnostic script");
-		hl78xx_enter_state(data, MODEM_HL78XX_STATE_IDLE);
-		break;
 	case MODEM_HL78XX_EVENT_AT_CMD_TIMEOUT:
-#ifdef CONFIG_MODEM_HL78XX_AUTO_BAUDRATE
-		hl78xx_enter_state(data, MODEM_HL78XX_STATE_SET_BAUDRATE);
-#else
-		if (hl78xx_gpio_is_enabled(&config->mdm_gpio_pwr_on)) {
-			hl78xx_enter_state(data, MODEM_HL78XX_STATE_POWER_ON_PULSE);
-			break;
-		}
-
-		if (hl78xx_gpio_is_enabled(&config->mdm_gpio_reset)) {
-			hl78xx_enter_state(data, MODEM_HL78XX_STATE_RESET_PULSE);
-			break;
-		}
-
-		hl78xx_enter_state(data, MODEM_HL78XX_STATE_IDLE);
-#endif /* CONFIG_MODEM_HL78XX_AUTO_BAUDRATE */
-		break;
-	case MODEM_HL78XX_EVENT_BUS_CLOSED:
-		break;
-
-	case MODEM_HL78XX_EVENT_SUSPEND:
-		hl78xx_enter_state(data, MODEM_HL78XX_STATE_IDLE);
-		break;
-
 	case MODEM_HL78XX_EVENT_SCRIPT_FAILED:
-		if (!hl78xx_gpio_is_enabled(&config->mdm_gpio_wake) &&
-		    IS_ENABLED(CONFIG_MODEM_HL78XX_LOW_POWER_MODE)) {
-			LOG_ERR("The modem wake pin is not enabled. Make sure that modem low-power "
-				"mode is disabled. If you’re unsure, enable it by adding the "
-				"corresponding DTS configuration entry.");
-		}
-
-		if (data->status.script_fail_counter++ < MAX_SCRIPT_AT_CMD_RETRY) {
-			if (hl78xx_gpio_is_enabled(&config->mdm_gpio_pwr_on)) {
-				hl78xx_enter_state(data, MODEM_HL78XX_STATE_POWER_ON_PULSE);
-				break;
-			}
-			if (hl78xx_gpio_is_enabled(&config->mdm_gpio_reset)) {
-				hl78xx_enter_state(data, MODEM_HL78XX_STATE_RESET_PULSE);
-				break;
-			}
-		}
-		hl78xx_enter_state(data, MODEM_HL78XX_STATE_IDLE);
+		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RECOVERY);
 		break;
+
 	default:
 		break;
 	}
+}
+
+static int hl78xx_on_recovery_state_enter(struct hl78xx_data *data)
+{
+	struct hl78xx_script_failure *script_failure = &data->script_failure;
+	const struct hl78xx_script_recovery_rule *rule;
+
+	enum hl78xx_state resume_state;
+	int ret;
+
+	if (!script_failure->valid) {
+		LOG_WRN("Recovery entered without script failure context");
+
+		hl78xx_handle_recovery_unavailable(data);
+		return 0;
+	}
+
+	rule = script_failure->recovery_rule;
+
+	if (rule == NULL) {
+		LOG_WRN("No recovery rule for failed script command");
+
+		hl78xx_clear_recovery(data);
+		hl78xx_enter_restart_fallback_state(data);
+		return 0;
+	}
+
+	if (rule->action == NULL) {
+		LOG_ERR("Recovery rule has no action");
+
+		hl78xx_clear_recovery(data);
+		hl78xx_enter_restart_fallback_state(data);
+		return 0;
+	}
+
+	if (data->script_recovery.attempted_rule != rule) {
+		data->script_recovery.attempted_rule = rule;
+		data->script_recovery.attempts = 0U;
+	}
+
+	if (data->script_recovery.attempts >= rule->max_attempts) {
+		LOG_ERR("Script recovery attempts exhausted");
+
+		hl78xx_handle_recovery_unavailable(data);
+		return 0;
+	}
+
+	data->script_recovery.attempts++;
+
+	ret = rule->action(data, script_failure);
+	if (ret < 0) {
+		LOG_ERR("Script recovery action failed: %d", ret);
+
+		hl78xx_handle_recovery_unavailable(data);
+		return 0;
+	}
+
+	resume_state = rule->resume_state;
+	hl78xx_clear_script_failure(data);
+	hl78xx_enter_state(data, resume_state);
+
+	return 0;
 }
 
 static int hl78xx_on_rat_cfg_script_state_enter(struct hl78xx_data *data)
@@ -2413,8 +2448,6 @@ error:
 
 static void hl78xx_run_pmc_cfg_script_event_handler(struct hl78xx_data *data, enum hl78xx_event evt)
 {
-	const struct hl78xx_config *config = data->devices.hl78xx->config;
-
 	switch (evt) {
 	case MODEM_HL78XX_EVENT_TIMEOUT:
 		if (hl78xx_is_config_restart_pending(data)) {
@@ -2438,16 +2471,7 @@ static void hl78xx_run_pmc_cfg_script_event_handler(struct hl78xx_data *data, en
 		hl78xx_enter_state(data, MODEM_HL78XX_STATE_INIT_POWER_OFF);
 		break;
 	case MODEM_HL78XX_EVENT_SCRIPT_REQUIRE_RESTART:
-		if (hl78xx_gpio_is_enabled(&config->mdm_gpio_pwr_on)) {
-			hl78xx_enter_state(data, MODEM_HL78XX_STATE_POWER_ON_PULSE);
-			break;
-		}
-
-		if (hl78xx_gpio_is_enabled(&config->mdm_gpio_reset)) {
-			hl78xx_enter_state(data, MODEM_HL78XX_STATE_RESET_PULSE);
-			break;
-		}
-		hl78xx_enter_state(data, MODEM_HL78XX_STATE_IDLE);
+		hl78xx_enter_restart_fallback_state(data);
 		break;
 	default:
 		break;
@@ -3471,6 +3495,8 @@ static int hl78xx_on_idle_state_enter(struct hl78xx_data *data)
 #ifdef CONFIG_MODEM_HL78XX_POWER_DOWN
 	}
 #endif /* CONFIG_MODEM_HL78XX_POWER_DOWN */
+	hl78xx_clear_recovery(data);
+
 	modem_chat_release(&data->chat);
 	modem_pipe_attach(data->uart_pipe, hl78xx_bus_pipe_handler, data);
 	modem_pipe_close_async(data->uart_pipe);
@@ -3502,7 +3528,6 @@ static void hl78xx_idle_event_handler(struct hl78xx_data *data, enum hl78xx_even
 			hl78xx_enter_state(data, MODEM_HL78XX_STATE_AWAIT_POWER_ON);
 			break;
 		}
-		hl78xx_enter_state(data, MODEM_HL78XX_STATE_RUN_INIT_FAIL_DIAGNOSTIC_SCRIPT);
 		break;
 
 	case MODEM_HL78XX_EVENT_SUSPEND:
@@ -3914,10 +3939,10 @@ const static struct hl78xx_state_handlers hl78xx_state_table[] = {
 		NULL,
 		hl78xx_run_init_script_event_handler
 	},
-	[MODEM_HL78XX_STATE_RUN_INIT_FAIL_DIAGNOSTIC_SCRIPT] = {
-		hl78xx_on_run_init_diagnose_script_state_enter,
+	[MODEM_HL78XX_STATE_RECOVERY] = {
+		hl78xx_on_recovery_state_enter,
 		NULL,
-		hl78xx_run_init_fail_script_event_handler
+		NULL
 	},
 	[MODEM_HL78XX_STATE_RUN_RAT_CONFIG_SCRIPT] = {
 		hl78xx_on_rat_cfg_script_state_enter,

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx.c
@@ -2454,7 +2454,7 @@ static void hl78xx_run_pmc_cfg_script_event_handler(struct hl78xx_data *data, en
 	}
 }
 
-static int hl78xx_on_run_pmc_cfg_script_state_leave(struct hl78xx_data *data)
+static int hl78xx_on_pmc_cfg_script_state_leave(struct hl78xx_data *data)
 {
 	data->status.restart.config_pending = false;
 	return 0;
@@ -3926,7 +3926,7 @@ const static struct hl78xx_state_handlers hl78xx_state_table[] = {
 	},
 	[MODEM_HL78XX_STATE_RUN_PMC_CONFIG_SCRIPT] = {
 		hl78xx_on_pmc_cfg_script_state_enter,
-		hl78xx_on_run_pmc_cfg_script_state_leave,
+		hl78xx_on_pmc_cfg_script_state_leave,
 		hl78xx_run_pmc_cfg_script_event_handler
 	},
 	[MODEM_HL78XX_STATE_RUN_ENABLE_GPRS_SCRIPT] = {

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx.h
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx.h
@@ -164,7 +164,7 @@ enum hl78xx_state {
 	MODEM_HL78XX_STATE_AWAIT_POWER_ON,
 	MODEM_HL78XX_STATE_SET_BAUDRATE,
 	MODEM_HL78XX_STATE_RUN_INIT_SCRIPT,
-	MODEM_HL78XX_STATE_RUN_INIT_FAIL_DIAGNOSTIC_SCRIPT,
+	MODEM_HL78XX_STATE_RECOVERY,
 	MODEM_HL78XX_STATE_RUN_RAT_CONFIG_SCRIPT,
 	MODEM_HL78XX_STATE_RUN_PMC_CONFIG_SCRIPT,
 	MODEM_HL78XX_STATE_RUN_ENABLE_GPRS_SCRIPT,
@@ -520,6 +520,41 @@ struct hl78xx_low_power_status {
 };
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
 
+#define HL78XX_SCRIPT_RESULT_BIT(_result) BIT(_result)
+
+struct hl78xx_data;
+struct hl78xx_script_recovery_rule;
+
+struct hl78xx_script_failure {
+	const struct hl78xx_script_recovery_rule *recovery_rule;
+	enum modem_chat_script_result result;
+	enum hl78xx_state origin_state;
+	uint16_t script_chat_index;
+	bool valid;
+};
+
+typedef int (*hl78xx_script_recovery_action_t)(struct hl78xx_data *data,
+					       const struct hl78xx_script_failure *failure);
+
+struct hl78xx_script_recovery_rule {
+	enum hl78xx_state failed_state;
+	const char *failed_request;
+	uint16_t failed_script_chat_index;
+	uint32_t result_mask;
+	hl78xx_script_recovery_action_t action;
+	/* State whose specified event confirms full recovery. */
+	enum hl78xx_state success_state;
+	enum hl78xx_event success_event;
+	/* State to resume after recovery action is completed */
+	enum hl78xx_state resume_state;
+	uint8_t max_attempts;
+};
+
+struct hl78xx_script_recovery {
+	const struct hl78xx_script_recovery_rule *attempted_rule;
+	uint8_t attempts;
+};
+
 struct modem_status {
 	struct registration_status registration;
 	struct hl78xx_network_info network_info;
@@ -531,7 +566,6 @@ struct modem_status {
 #endif /* CONFIG_MODEM_HL78XX_12 */
 
 	uint8_t ksrep;
-	uint16_t script_fail_counter;
 	int variant;
 	enum hl78xx_state state;
 
@@ -678,6 +712,9 @@ struct hl78xx_data {
 	struct kselacq_syntax kselacq_data;
 	struct hl78xx_runtime_band runtime_band;
 	struct hl78xx_at_cmd_capture_ctx at_cmd_capture;
+
+	struct hl78xx_script_failure script_failure;
+	struct hl78xx_script_recovery script_recovery;
 };
 
 struct hl78xx_config {

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_apis.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_apis.c
@@ -995,6 +995,16 @@ int hl78xx_api_func_get_modem_info(const struct device *dev, enum hl78xx_modem_i
 		*(uint32_t *)info = data->status.uart.current_baudrate;
 		k_mutex_unlock(&data->api_lock);
 		return 0;
+
+	case HL78XX_MODEM_INFO_FW_VERSION:
+		if (size < sizeof(data->identity.fw_version)) {
+			return -EINVAL;
+		}
+
+		k_mutex_lock(&data->api_lock, K_FOREVER);
+		safe_strncpy((char *)info, (const char *)data->identity.fw_version, size);
+		k_mutex_unlock(&data->api_lock);
+		return 0;
 	default:
 		return -ENOTSUP;
 	}

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.c
@@ -326,6 +326,7 @@ int hl78xx_band_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 	if (rat_config_request == HL78XX_RAT_MODE_NONE) {
 		return -EINVAL;
 	}
+	/* Skip band configuration for variants that do not require it. */
 	if (config->variant->cfg_skip_band_for_rat &&
 	    config->variant->cfg_skip_band_for_rat(data, rat_config_request)) {
 		return 0;
@@ -368,7 +369,9 @@ int hl78xx_band_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 error:
 	return ret;
 }
+
 #ifdef CONFIG_MODEM_HL78XX_RAT_NBNTN
+
 int hl78xx_rat_ntn_cfg(struct hl78xx_data *data, bool *modem_require_restart,
 		       enum hl78xx_cell_rat_mode rat_config_request)
 {
@@ -2017,4 +2020,97 @@ void byte_to_binary_str(uint8_t byte, char *output)
 		output[7 - i] = (byte & (1 << i)) ? '1' : '0';
 	}
 	output[8] = '\0';
+}
+
+int hl78xx_recover_kbndcfg(struct hl78xx_data *data, const struct hl78xx_script_failure *failure)
+{
+	const struct hl78xx_config *config = data->devices.hl78xx->config;
+	char hex_bndcfg[MDM_BAND_HEX_STR_LEN] = {0};
+	char cmd_bnd[80] = {0};
+	bool band_config_written = false;
+	int ret;
+
+	ARG_UNUSED(failure);
+
+#ifdef CONFIG_MODEM_HL78XX_AUTORAT
+	for (int rat = HL78XX_RAT_CAT_M1; rat <= HL78XX_RAT_NB1; rat++) {
+#else
+	/*
+	 * Without AUTORAT, use the selected RAT when available. Fall back to
+	 * CAT-M1 if the stored RAT cannot be used with KBNDCFG.
+	 */
+	int rat = data->status.registration.rat_mode;
+
+	if (rat != HL78XX_RAT_CAT_M1 && rat != HL78XX_RAT_NB1) {
+		LOG_WRN("Unsupported RAT mode %d, using CAT-M1 for recovery", rat);
+		rat = HL78XX_RAT_CAT_M1;
+	}
+#endif /* CONFIG_MODEM_HL78XX_AUTORAT */
+		if (config->variant->cfg_skip_band_for_rat &&
+		    config->variant->cfg_skip_band_for_rat(data, rat)) {
+#ifdef CONFIG_MODEM_HL78XX_AUTORAT
+			continue;
+#else
+		return -ENOTSUP;
+#endif
+		}
+
+		memset(hex_bndcfg, 0, sizeof(hex_bndcfg));
+		memset(cmd_bnd, 0, sizeof(cmd_bnd));
+
+		ret = hl78xx_get_expected_band_config_for_rat(data, rat, hex_bndcfg,
+							      sizeof(hex_bndcfg));
+		if (ret < 0) {
+			LOG_ERR("Failed to get band configuration for RAT %d: %d", rat, ret);
+			return ret;
+		}
+
+		ret = snprintf(cmd_bnd, sizeof(cmd_bnd), "AT+KBNDCFG=%d,%s", rat, hex_bndcfg);
+		if ((ret < 0) || ((size_t)ret >= sizeof(cmd_bnd))) {
+			LOG_ERR("Failed to construct KBNDCFG command for RAT %d", rat);
+			return -ENOMEM;
+		}
+
+		ret = modem_dynamic_cmd_send(data, NULL, cmd_bnd, strlen(cmd_bnd),
+					     hl78xx_get_ok_match(), hl78xx_get_ok_match_size(),
+					     MDM_CMD_TIMEOUT, false);
+		if (ret < 0) {
+			LOG_ERR("Failed to restore band configuration for RAT %d: %d", rat, ret);
+			return ret;
+		}
+		band_config_written = true;
+
+#ifdef CONFIG_MODEM_HL78XX_AUTORAT
+	}
+#endif
+	if (!band_config_written) {
+		LOG_WRN("No band configuration was written during recovery");
+		return -ENOTSUP;
+	}
+	return 0;
+}
+
+int hl78xx_recover_post_restart_timeout(struct hl78xx_data *data,
+					const struct hl78xx_script_failure *failure)
+{
+	int ret;
+
+	ARG_UNUSED(failure);
+
+	ret = hl78xx_run_init_fail_script(data);
+	if (ret < 0) {
+		LOG_ERR("Failed to query KSREP configuration: %d", ret);
+		return ret;
+	}
+
+	if (data->status.ksrep == 0) {
+		ret = hl78xx_run_enable_ksup_urc_script(data);
+		if (ret < 0) {
+			LOG_ERR("Failed to enable KSUP URC: %d", ret);
+			return ret;
+		}
+		data->status.boot.is_booted_previously = true;
+	}
+
+	return 0;
 }

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.h
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_cfg.h
@@ -102,8 +102,9 @@ int hl78xx_set_network_operator_format(struct hl78xx_data *data,
  * @param mnc Pointer to store the Mobile Network Code.
  * @return true if parsing was successful, false otherwise.
  */
+/* clang-format off */
 bool hl78xx_parse_plmn(const char *operator, uint16_t *mcc, uint16_t *mnc);
-
+/* clang-format on */
 /**
  * @brief Convert an active band hex bitmap string to a band number.
  *
@@ -201,5 +202,28 @@ bool hl78xx_is_rsrp_value_valid(int16_t rsrp);
 bool hl78xx_is_rsrq_value_valid(int16_t rsrq);
 bool hl78xx_is_sinr_value_valid(int16_t sinr);
 bool hl78xx_is_rsrp_valid(struct hl78xx_data *data);
+
+/**
+ * @brief Recover the modem NB-IoT/ LTE band configuration.
+ *
+ * @param data HL78xx driver data.
+ * @param failure Original script failure context.
+ *
+ * @retval 0 on success.
+ * @retval negative errno value on failure.
+ */
+int hl78xx_recover_kbndcfg(struct hl78xx_data *data, const struct hl78xx_script_failure *failure);
+
+/**
+ * @brief Recover the modem KSUP configuration.
+ *
+ * @param data HL78xx driver data.
+ * @param failure Original script failure context.
+ *
+ * @retval 0 on success.
+ * @retval negative errno value on failure.
+ */
+int hl78xx_recover_post_restart_timeout(struct hl78xx_data *data,
+					const struct hl78xx_script_failure *failure);
 
 #endif /* ZEPHYR_DRIVERS_MODEM_HL78XX_HL78XX_CFG_H_ */

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_chat.c
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_chat.c
@@ -23,6 +23,7 @@
 #include "hl78xx.h"
 #include "hl78xx_at_monitor/hl78xx_at_monitor.h"
 #include "hl78xx_chat.h"
+#include "hl78xx_cfg.h"
 #include <zephyr/modem/chat.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util_macro.h>
@@ -35,6 +36,8 @@ void hl78xx_gnss_on_gnssev(struct modem_chat *chat, char **argv, uint16_t argc, 
 #endif /* CONFIG_HL78XX_GNSS */
 
 LOG_MODULE_DECLARE(hl78xx_dev, CONFIG_MODEM_LOG_LEVEL);
+
+#define HL78XX_SCRIPT_CHAT_INDEX_ANY UINT16_MAX
 
 /* Forward declarations of handlers implemented in hl78xx.c (extern linkage) */
 #ifdef CONFIG_MODEM_HL78XX_HAS_CTZEU_URC
@@ -152,6 +155,10 @@ void hl78xx_on_gnssad(struct modem_chat *chat, char **argv, uint16_t argc, void 
 
 static void hl78xx_on_unsol_monitored(struct modem_chat *chat, char **argv, uint16_t argc,
 				      void *user_data);
+static const struct hl78xx_script_recovery_rule *
+hl78xx_find_script_recovery_rule(enum hl78xx_state state,
+				 const struct modem_chat_script_chat *script_chat,
+				 uint16_t script_chat_index, enum modem_chat_script_result result);
 
 MODEM_CHAT_MATCH_DEFINE(hl78xx_ok_match, "OK", "", NULL);
 MODEM_CHAT_MATCHES_DEFINE(hl78xx_allow_match, MODEM_CHAT_MATCH(MDM_HL78XX_OK_STRING, "", NULL),
@@ -453,16 +460,15 @@ MODEM_CHAT_SCRIPT_DEFINE(hl78xx_post_restart_chat_script, hl78xx_post_restart_ch
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(init_fail_script_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KSREP?", hl78xx_ksrep_match));
 
-MODEM_CHAT_SCRIPT_DEFINE(init_fail_script, init_fail_script_cmds, hl78xx_abort_matches,
-			 hl78xx_chat_callback_handler, HL78XX_CMD_TIMEOUT_SHORT);
+MODEM_CHAT_SCRIPT_DEFINE(init_fail_script, init_fail_script_cmds, hl78xx_abort_matches, NULL,
+			 HL78XX_CMD_TIMEOUT_SHORT);
 
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(hl78xx_enable_ksup_urc_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KSREP=1", hl78xx_ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+KSREP?", hl78xx_ksrep_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(hl78xx_enable_ksup_urc_script, hl78xx_enable_ksup_urc_cmds,
-			 hl78xx_abort_matches, hl78xx_chat_callback_handler,
-			 HL78XX_CMD_TIMEOUT_SHORT);
+			 hl78xx_abort_matches, NULL, HL78XX_CMD_TIMEOUT_SHORT);
 
 /* power-off script moved from hl78xx.c */
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(hl78xx_pwroff_cmds,
@@ -673,6 +679,33 @@ size_t hl78xx_get_ktcp_state_matches_size(void)
 	return (size_t)ARRAY_SIZE(ktcp_state_matches);
 }
 
+/* Capture script failure information */
+static void hl78xx_capture_script_failure(struct hl78xx_data *data, struct modem_chat *chat,
+					  enum modem_chat_script_result result)
+{
+	const struct modem_chat_script_chat *script_chat;
+	uint16_t script_chat_index;
+	enum hl78xx_state origin_state;
+
+	origin_state = data->status.state;
+
+	script_chat = modem_chat_callback_script_chat(chat);
+	script_chat_index = modem_chat_callback_script_chat_index(chat);
+
+	data->script_failure.recovery_rule = hl78xx_find_script_recovery_rule(
+		origin_state, script_chat, script_chat_index, result);
+
+	data->script_failure.script_chat_index = script_chat_index;
+	data->script_failure.result = result;
+	data->script_failure.origin_state = origin_state;
+
+	/*
+	 * A failure callback was received. A NULL recovery_rule means that
+	 * no command-specific recovery rule matched the failure.
+	 */
+	data->script_failure.valid = true;
+}
+
 /* modem_init_chat is implemented in hl78xx.c so it can construct the
  * modem_chat_config with device-local buffer sizes (argv_size) without
  * relying on ARRAY_SIZE at file scope inside this translation unit.
@@ -684,11 +717,17 @@ void hl78xx_chat_callback_handler(struct modem_chat *chat, enum modem_chat_scrip
 {
 	struct hl78xx_data *data = (struct hl78xx_data *)user_data;
 
+	if (data->status.state == MODEM_HL78XX_STATE_RECOVERY) {
+		return;
+	}
+
 	if (result == MODEM_CHAT_SCRIPT_RESULT_SUCCESS) {
 		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_SCRIPT_SUCCESS);
 	} else if (result == MODEM_CHAT_SCRIPT_RESULT_TIMEOUT) {
+		hl78xx_capture_script_failure(data, chat, result);
 		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_AT_CMD_TIMEOUT);
 	} else {
+		hl78xx_capture_script_failure(data, chat, result);
 		hl78xx_delegate_event(data, MODEM_HL78XX_EVENT_SCRIPT_FAILED);
 	}
 }
@@ -817,20 +856,20 @@ int hl78xx_run_post_restart_script_async(struct hl78xx_data *data)
 	return modem_chat_run_script_async(&data->chat, &hl78xx_post_restart_chat_script);
 }
 
-int hl78xx_run_init_fail_script_async(struct hl78xx_data *data)
+int hl78xx_run_init_fail_script(struct hl78xx_data *data)
 {
 	if (!data) {
 		return -EINVAL;
 	}
-	return modem_chat_run_script_async(&data->chat, &init_fail_script);
+	return modem_chat_run_script(&data->chat, &init_fail_script);
 }
 
-int hl78xx_run_enable_ksup_urc_script_async(struct hl78xx_data *data)
+int hl78xx_run_enable_ksup_urc_script(struct hl78xx_data *data)
 {
 	if (!data) {
 		return -EINVAL;
 	}
-	return modem_chat_run_script_async(&data->chat, &hl78xx_enable_ksup_urc_script);
+	return modem_chat_run_script(&data->chat, &hl78xx_enable_ksup_urc_script);
 }
 
 int hl78xx_run_pwroff_script_async(struct hl78xx_data *data)
@@ -975,3 +1014,62 @@ int hl78xx_disable_pmc(struct hl78xx_data *data)
 	return modem_chat_run_script_async(&data->chat, &hl78xx_disable_pmc_chat_script);
 }
 #endif /* CONFIG_MODEM_HL78XX_LOW_POWER_MODE */
+
+/* Don't forget if a restart is required after the recovery, the resume state has to be
+ * MODEM_HL78XX_STATE_SOFT_RESET
+ */
+static const struct hl78xx_script_recovery_rule hl78xx_script_recovery_rules[] = {
+	{
+		.failed_state = MODEM_HL78XX_STATE_RUN_INIT_SCRIPT,
+		.failed_request = "AT+KBNDCFG?",
+		.failed_script_chat_index = HL78XX_SCRIPT_CHAT_INDEX_ANY,
+		.result_mask = HL78XX_SCRIPT_RESULT_BIT(MODEM_CHAT_SCRIPT_RESULT_ABORT),
+		.action = hl78xx_recover_kbndcfg,
+		.success_state = MODEM_HL78XX_STATE_RUN_INIT_SCRIPT,
+		.success_event = MODEM_HL78XX_EVENT_SCRIPT_SUCCESS,
+		.resume_state = MODEM_HL78XX_STATE_SOFT_RESET,
+		.max_attempts = 1U,
+	},
+	{
+		.failed_state = MODEM_HL78XX_STATE_AWAIT_POWER_ON,
+		.failed_request = "",
+		.failed_script_chat_index = 0U,
+		.result_mask = HL78XX_SCRIPT_RESULT_BIT(MODEM_CHAT_SCRIPT_RESULT_TIMEOUT),
+		.action = hl78xx_recover_post_restart_timeout,
+		.success_state = MODEM_HL78XX_STATE_RUN_INIT_SCRIPT,
+		.success_event = MODEM_HL78XX_EVENT_SCRIPT_SUCCESS,
+		.resume_state = MODEM_HL78XX_STATE_SOFT_RESET,
+		.max_attempts = 1U,
+	},
+};
+
+static const struct hl78xx_script_recovery_rule *
+hl78xx_find_script_recovery_rule(enum hl78xx_state state,
+				 const struct modem_chat_script_chat *script_chat,
+				 uint16_t script_chat_index, enum modem_chat_script_result result)
+{
+	const char *request;
+
+	if (script_chat == NULL) {
+		return NULL;
+	}
+
+	request = script_chat->request;
+	if (request == NULL) {
+		return NULL;
+	}
+
+	for (size_t i = 0U; i < ARRAY_SIZE(hl78xx_script_recovery_rules); i++) {
+		const struct hl78xx_script_recovery_rule *rule = &hl78xx_script_recovery_rules[i];
+
+		if ((rule->failed_state == state) &&
+		    ((rule->result_mask & HL78XX_SCRIPT_RESULT_BIT(result)) != 0U) &&
+		    (strcmp(rule->failed_request, request) == 0) &&
+		    ((rule->failed_script_chat_index == HL78XX_SCRIPT_CHAT_INDEX_ANY) ||
+		     (rule->failed_script_chat_index == script_chat_index))) {
+			return rule;
+		}
+	}
+
+	return NULL;
+}

--- a/drivers/modem/vendor_standalone/hl78xx/hl78xx_chat.h
+++ b/drivers/modem/vendor_standalone/hl78xx/hl78xx_chat.h
@@ -153,8 +153,8 @@ size_t hl78xx_get_allow_match_size(void);
 int hl78xx_run_init_script(struct hl78xx_data *data);
 int hl78xx_run_periodic_script(struct hl78xx_data *data);
 int hl78xx_run_post_restart_script(struct hl78xx_data *data);
-int hl78xx_run_init_fail_script_async(struct hl78xx_data *data);
-int hl78xx_run_enable_ksup_urc_script_async(struct hl78xx_data *data);
+int hl78xx_run_init_fail_script(struct hl78xx_data *data);
+int hl78xx_run_enable_ksup_urc_script(struct hl78xx_data *data);
 int hl78xx_run_pwroff_script_async(struct hl78xx_data *data);
 int hl78xx_run_post_restart_script_async(struct hl78xx_data *data);
 /* Run the LTE disable GSM enable registration status script */

--- a/include/zephyr/drivers/modem/hl78xx_apis.h
+++ b/include/zephyr/drivers/modem/hl78xx_apis.h
@@ -118,7 +118,11 @@ extern "C" {
 #define MDM_HL78XX_ERROR_STRING        "ERROR"
 /** Standard response string indicating successful execution of an AT command */
 #define MDM_HL78XX_OK_STRING           "OK"
-
+/** Desired firmware version string */
+#define MDM_HL78XX_DESIRED_VERSION_STRING                                                          \
+	(sizeof(CONFIG_MODEM_HL78XX_DESIRED_FW_VERSION) > 1                                        \
+		 ? CONFIG_MODEM_HL78XX_DESIRED_FW_VERSION                                          \
+		 : "HL7812.5.7.4.0")
 /**
  * @brief Initial active state for HL78xx monitors.
  *
@@ -360,6 +364,8 @@ enum hl78xx_modem_info_type {
 	HL78XX_MODEM_INFO_SERIAL_NUMBER,
 	/** Current Baud Rate */
 	HL78XX_MODEM_INFO_CURRENT_BAUD_RATE,
+	/** Firmware version */
+	HL78XX_MODEM_INFO_FW_VERSION
 };
 
 /**


### PR DESCRIPTION
Replace the generic initialization-failure handling path with a rule-based recovery framework for HL78xx modem chat scripts.

The new recovery mechanism captures script failure context, including the failed script, command index, request, and result, and uses this information to select a targeted recovery action. Successful recovery is tracked and verified before the failure
state is fully cleared.

this pr depends on https://github.com/zephyrproject-rtos/zephyr/pull/113764