### PR TITLE
drivers: kconfig: drop 'select UART' of nonexistent symbol

### DIFF
--- a/boards/infineon/cy8cproto_062_4343w/Kconfig.defconfig
+++ b/boards/infineon/cy8cproto_062_4343w/Kconfig.defconfig
@@ -26,15 +26,6 @@ configdefault NET_L2_ETHERNET
 
 endif # WIFI
 
-if BT
-
-# Select HCI components
-config UART
-	bool
-	default y
-
-endif # BT
-
 # Heap Pool Size
 config HEAP_MEM_POOL_ADD_SIZE_BOARD
 	int

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -275,7 +275,6 @@ config BT_AIROC
 	bool "AIROC BT connectivity"
 	default y
 	select GPIO                          if BT_H4
-	select UART                          if BT_H4
 	select UART_USE_RUNTIME_CONFIGURE    if BT_H4
 	select BT_HCI_SETUP
 	select BT_HCI_SET_PUBLIC_ADDR

--- a/drivers/input/Kconfig.ch9350l
+++ b/drivers/input/Kconfig.ch9350l
@@ -6,7 +6,6 @@ config INPUT_CH9350L
 	default y
 	depends on DT_HAS_WCH_CH9350L_ENABLED
 	depends on SERIAL_SUPPORT_INTERRUPT
-	select UART
 	select UART_INTERRUPT_DRIVEN
 	help
 	  This option enables the driver for WinChipHead CH9350L USB HID to UART control chips.

--- a/drivers/sensor/explorir_m/Kconfig
+++ b/drivers/sensor/explorir_m/Kconfig
@@ -8,6 +8,5 @@ config EXPLORIR_M
 	default y
 	depends on DT_HAS_GSS_EXPLORIR_M_ENABLED
 	depends on UART_INTERRUPT_DRIVEN
-	select UART
 	help
 	  Enable driver for ExplorIR-M CO2 Sensor.

--- a/drivers/sensor/fcx_mldx5/Kconfig
+++ b/drivers/sensor/fcx_mldx5/Kconfig
@@ -8,6 +8,5 @@ config FCX_MLDX5
 	default y
 	depends on DT_HAS_AP_FCX_MLDX5_ENABLED
 	depends on UART_INTERRUPT_DRIVEN
-	select UART
 	help
 	  Enable driver for FCX-MLD25 or FCX-MLD95 O2 Sensor.

--- a/drivers/sensor/iclegend/s3km1110/Kconfig
+++ b/drivers/sensor/iclegend/s3km1110/Kconfig
@@ -6,7 +6,6 @@ config S3KM1110
 	default y
 	depends on DT_HAS_ICLEGEND_S3KM1110_ENABLED
 	depends on UART_INTERRUPT_DRIVEN
-	select UART
 	help
 	  Enable driver for the Iclegend S3KM1110 UART radar.
 

--- a/drivers/stepper/adi_tmc/bus/Kconfig
+++ b/drivers/stepper/adi_tmc/bus/Kconfig
@@ -9,7 +9,7 @@ config STEPPER_ADI_TMC_SPI
 
 config STEPPER_ADI_TMC_UART
 	bool "Use Trinamic Stepper Controller with single wire UART"
-	select UART
+	select SERIAL
 	help
 	  A Trinamic Stepper Controller with single wire UART is enabled
 


### PR DESCRIPTION
- **drivers: kconfig: drop 'select UART' of nonexistent symbol**
- **boards: infineon: cy8cproto_062_4343w: drop accidental UART symbol**
