### PR TITLE
drivers: sensor: ina219: Add support for shunt voltage readouts

### DIFF
--- a/drivers/sensor/ti/ina219/ina219.c
+++ b/drivers/sensor/ti/ina219/ina219.c
@@ -110,6 +110,7 @@ static int ina219_sample_fetch(const struct device *dev,
 
 	if (chan != SENSOR_CHAN_ALL &&
 		chan != SENSOR_CHAN_VOLTAGE &&
+		chan != SENSOR_CHAN_VSHUNT &&
 		chan != SENSOR_CHAN_POWER &&
 		chan != SENSOR_CHAN_CURRENT) {
 		return -ENOTSUP;
@@ -159,6 +160,17 @@ static int ina219_sample_fetch(const struct device *dev,
 	}
 
 	if (chan == SENSOR_CHAN_ALL ||
+		chan == SENSOR_CHAN_VSHUNT) {
+
+		rc = ina219_reg_read(dev, INA219_REG_V_SHUNT, &tmp);
+		if (rc) {
+			LOG_ERR("Error reading shunt voltage.");
+			return rc;
+		}
+		data->v_shunt = tmp;
+	}
+
+	if (chan == SENSOR_CHAN_ALL ||
 		chan == SENSOR_CHAN_POWER)	{
 
 		rc = ina219_reg_read(dev, INA219_REG_POWER, &tmp);
@@ -190,21 +202,19 @@ static int ina219_channel_get(const struct device *dev,
 	const struct ina219_config *cfg = dev->config;
 	struct ina219_data *data = dev->data;
 	double tmp;
-	int8_t sign = 1;
 
 	switch (chan) {
 	case SENSOR_CHAN_VOLTAGE:
 		tmp = data->v_bus * INA219_V_BUS_MUL;
 		break;
+	case SENSOR_CHAN_VSHUNT:
+		tmp = (int16_t)data->v_shunt * INA219_V_SHUNT_MUL;
+		break;
 	case SENSOR_CHAN_POWER:
 		tmp = data->power * cfg->current_lsb * INA219_POWER_MUL * INA219_SI_MUL;
 		break;
 	case SENSOR_CHAN_CURRENT:
-		if (INA219_SIGN_BIT(data->current)) {
-			data->current = ~data->current + 1;
-			sign = -1;
-		}
-		tmp = sign * data->current * cfg->current_lsb * INA219_SI_MUL;
+		tmp = (int16_t)data->current * cfg->current_lsb * INA219_SI_MUL;
 		break;
 	default:
 		LOG_DBG("Channel not supported by device!");

--- a/drivers/sensor/ti/ina219/ina219.c
+++ b/drivers/sensor/ti/ina219/ina219.c
@@ -110,6 +110,7 @@ static int ina219_sample_fetch(const struct device *dev,
 
 	if (chan != SENSOR_CHAN_ALL &&
 		chan != SENSOR_CHAN_VOLTAGE &&
+		chan != SENSOR_CHAN_VSHUNT &&
 		chan != SENSOR_CHAN_POWER &&
 		chan != SENSOR_CHAN_CURRENT) {
 		return -ENOTSUP;
@@ -159,6 +160,17 @@ static int ina219_sample_fetch(const struct device *dev,
 	}
 
 	if (chan == SENSOR_CHAN_ALL ||
+		chan == SENSOR_CHAN_VSHUNT) {
+
+		rc = ina219_reg_read(dev, INA219_REG_V_SHUNT, &tmp);
+		if (rc) {
+			LOG_ERR("Error reading shunt voltage.");
+			return rc;
+		}
+		data->v_shunt = tmp;
+	}
+
+	if (chan == SENSOR_CHAN_ALL ||
 		chan == SENSOR_CHAN_POWER)	{
 
 		rc = ina219_reg_read(dev, INA219_REG_POWER, &tmp);
@@ -195,6 +207,9 @@ static int ina219_channel_get(const struct device *dev,
 	switch (chan) {
 	case SENSOR_CHAN_VOLTAGE:
 		tmp = data->v_bus * INA219_V_BUS_MUL;
+		break;
+	case SENSOR_CHAN_VSHUNT:
+		tmp = (int16_t)data->v_shunt * INA219_V_SHUNT_MUL;
 		break;
 	case SENSOR_CHAN_POWER:
 		tmp = data->power * cfg->current_lsb * INA219_POWER_MUL * INA219_SI_MUL;

--- a/drivers/sensor/ti/ina219/ina219.c
+++ b/drivers/sensor/ti/ina219/ina219.c
@@ -202,7 +202,6 @@ static int ina219_channel_get(const struct device *dev,
 	const struct ina219_config *cfg = dev->config;
 	struct ina219_data *data = dev->data;
 	double tmp;
-	int8_t sign = 1;
 
 	switch (chan) {
 	case SENSOR_CHAN_VOLTAGE:
@@ -212,14 +211,10 @@ static int ina219_channel_get(const struct device *dev,
 		tmp = (int16_t)data->v_shunt * INA219_V_SHUNT_MUL;
 		break;
 	case SENSOR_CHAN_POWER:
-		tmp = data->power * cfg->current_lsb * INA219_POWER_MUL * INA219_SI_MUL;
+		tmp = data->power * (cfg->current_lsb * INA219_POWER_MUL * INA219_SI_MUL);
 		break;
 	case SENSOR_CHAN_CURRENT:
-		if (INA219_SIGN_BIT(data->current)) {
-			data->current = ~data->current + 1;
-			sign = -1;
-		}
-		tmp = sign * data->current * cfg->current_lsb * INA219_SI_MUL;
+		tmp = (int16_t)data->current * (cfg->current_lsb * INA219_SI_MUL);
 		break;
 	default:
 		LOG_DBG("Channel not supported by device!");

--- a/drivers/sensor/ti/ina219/ina219.h
+++ b/drivers/sensor/ti/ina219/ina219.h
@@ -37,8 +37,7 @@
 #define INA219_MODE_OFF		0x0 /* Power off */
 
 /* Others */
-#define INA219_SIGN_BIT(x)	((x) >> 15) & 0x1
-#define INA219_V_BUS_MUL	0.004
+#define INA219_V_BUS_MUL	0.004    /* 4 mV */
 #define INA219_V_SHUNT_MUL	0.00001  /* 10 uV */
 #define INA219_SI_MUL		0.00001
 #define INA219_POWER_MUL	20

--- a/drivers/sensor/ti/ina219/ina219.h
+++ b/drivers/sensor/ti/ina219/ina219.h
@@ -39,6 +39,7 @@
 /* Others */
 #define INA219_SIGN_BIT(x)	((x) >> 15) & 0x1
 #define INA219_V_BUS_MUL	0.004
+#define INA219_V_SHUNT_MUL	0.00001  /* 10 uV */
 #define INA219_SI_MUL		0.00001
 #define INA219_POWER_MUL	20
 #define INA219_WAIT_STARTUP	40
@@ -59,6 +60,7 @@ struct ina219_config {
 struct ina219_data {
 	uint16_t config;
 	uint16_t v_bus;
+	uint16_t v_shunt;
 	uint16_t power;
 	uint16_t current;
 	uint16_t calib;

--- a/drivers/sensor/ti/ina219/ina219.h
+++ b/drivers/sensor/ti/ina219/ina219.h
@@ -38,7 +38,8 @@
 
 /* Others */
 #define INA219_SIGN_BIT(x)	((x) >> 15) & 0x1
-#define INA219_V_BUS_MUL	0.004
+#define INA219_V_BUS_MUL	0.004    /* 4 mV */
+#define INA219_V_SHUNT_MUL	0.00001  /* 10 uV */
 #define INA219_SI_MUL		0.00001
 #define INA219_POWER_MUL	20
 #define INA219_WAIT_STARTUP	40
@@ -59,6 +60,7 @@ struct ina219_config {
 struct ina219_data {
 	uint16_t config;
 	uint16_t v_bus;
+	uint16_t v_shunt;
 	uint16_t power;
 	uint16_t current;
 	uint16_t calib;


### PR DESCRIPTION
Implementation of ina219 was missing support for
shunt voltage readouts (SENSOR_CHAN_VSHUNT).
This commit fixes that issue.