### PR TITLE
boards: bluepillplus_ch32v203: enable the on-board button

### DIFF
--- a/boards/weact/bluepillplus_ch32v203/bluepillplus_ch32v203.dts
+++ b/boards/weact/bluepillplus_ch32v203/bluepillplus_ch32v203.dts
@@ -30,18 +30,18 @@
 		};
 	};
 
-	buttons {
+	gpio_keys {
 		compatible = "gpio-keys";
 
-		mode: sw0 {
-			gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;
+		user_button: button {
+			gpios = <&gpioa 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};
 
 	aliases {
 		led0 = &blue_led;
-		sw0 = &mode;
+		sw0 = &user_button;
 	};
 };
 
@@ -68,6 +68,10 @@
 };
 
 &gpioc {
+	status = "okay";
+};
+
+&exti {
 	status = "okay";
 };
 


### PR DESCRIPTION
Fix up the user button by enabling the pull down and the GPIO interrupt controller. Also rename to match the schematic

With this, `samples/basic/button` and `samples/drivers/gpio/button_interrupt` now work.