### PR TITLE
include: dt-bindings: pinctrl: fix ESP32-P4 I2S0 GPIO matrix signal

### DIFF
--- a/include/zephyr/dt-bindings/pinctrl/esp32p4-gpio-sigmap.h
+++ b/include/zephyr/dt-bindings/pinctrl/esp32p4-gpio-sigmap.h
@@ -129,19 +129,19 @@
 #define ESP_I2CEXT1_SDA_OUT 71 /**< I2C1 SDA output */
 
 /* I2S0 */
-#define ESP_I2S0_O_BCK_IN  72 /**< I2S0 output BCK input */
-#define ESP_I2S0_O_BCK_OUT 72 /**< I2S0 output BCK output */
-#define ESP_I2S0_MCLK_IN   73 /**< I2S0 MCLK input */
-#define ESP_I2S0_MCLK_OUT  73 /**< I2S0 MCLK output */
-#define ESP_I2S0_O_WS_IN   74 /**< I2S0 output WS input */
-#define ESP_I2S0_O_WS_OUT  74 /**< I2S0 output WS output */
-#define ESP_I2S0_I_SD_IN   75 /**< I2S0 input SD input */
-#define ESP_I2S0_O_SD_OUT  76 /**< I2S0 output SD output */
-#define ESP_I2S0_O_SD1_OUT 77 /**< I2S0 output SD1 output */
-#define ESP_I2S0_I_BCK_IN  78 /**< I2S0 input BCK input */
-#define ESP_I2S0_I_BCK_OUT 78 /**< I2S0 input BCK output */
-#define ESP_I2S0_I_WS_IN   79 /**< I2S0 input WS input */
-#define ESP_I2S0_I_WS_OUT  79 /**< I2S0 input WS output */
+#define ESP_I2S0_O_BCK_IN  25 /**< I2S0 output BCK input */
+#define ESP_I2S0_O_BCK_OUT 25 /**< I2S0 output BCK output */
+#define ESP_I2S0_MCLK_IN   26 /**< I2S0 MCLK input */
+#define ESP_I2S0_MCLK_OUT  26 /**< I2S0 MCLK output */
+#define ESP_I2S0_O_WS_IN   27 /**< I2S0 output WS input */
+#define ESP_I2S0_O_WS_OUT  27 /**< I2S0 output WS output */
+#define ESP_I2S0_I_SD_IN   28 /**< I2S0 input SD input */
+#define ESP_I2S0_O_SD_OUT  28 /**< I2S0 output SD output */
+#define ESP_I2S0_O_SD1_OUT 43 /**< I2S0 output SD1 output */
+#define ESP_I2S0_I_BCK_IN  29 /**< I2S0 input BCK input */
+#define ESP_I2S0_I_BCK_OUT 29 /**< I2S0 input BCK output */
+#define ESP_I2S0_I_WS_IN   30 /**< I2S0 input WS input */
+#define ESP_I2S0_I_WS_OUT  30 /**< I2S0 input WS output */
 
 /* TWAI1 */
 #define ESP_TWAI1_RX 83 /**< TWAI1 RX input */


### PR DESCRIPTION
## Problem

The I2S0 GPIO matrix signal indices in
`include/zephyr/dt-bindings/pinctrl/esp32p4-gpio-sigmap.h` point at signals
72-79, which on ESP32-P4 rev 3.x silicon are GPIO_SD/UART sleep-clock
signals — not I2S0. Signal 79 is even on the hardware reserved-input list
(`func_in_sel_cfg` comment in the HAL's `gpio_struct.h`, both hw_ver1 and
hw_ver3), so routing `ESP_I2S0_I_WS_IN` silently fails at runtime.

Consequences for any ESP32-P4 board using the I2S0 pinctrl macros:

- TX clock/data outputs never reach the pins (pads stay static)
- full-duplex slave RX never sees BCK/WS and captures only zeros

Notably, the I2S1 (31-36) and I2S2 (37-42) entries in the same file already
match the ESP-IDF `gpio_sig_map.h` shipped in `modules/hal/espressif` —
only the I2S0 entries diverge.

## Fix

Align the I2S0 entries with the ESP-IDF/HAL sigmap
(`components/soc/esp32p4/include/soc/gpio_sig_map.h`, unchanged in ESP-IDF
since ESP32-P4 support was introduced, and used by
`esp_hal_i2s/esp32p4/i2s_periph.c` at runtime):

| signal | before | after |
|---|---|---|
| O_BCK | 72 | 25 |
| MCLK | 73 | 26 |
| O_WS | 74 | 27 |
| I_SD | 75 | 28 |
| O_SD | 76 | 28 |
| O_SD1 | 77 | 43 |
| I_BCK | 78 | 29 |
| I_WS | 79 | 30 |

Fixes #114564.
