### PR TITLE
drivers: gnss: add start/stop API

### DIFF
--- a/doc/hardware/peripherals/gnss.rst
+++ b/doc/hardware/peripherals/gnss.rst
@@ -30,6 +30,39 @@ Adding support for GNSS modems which use other protocols and/or
 buses than the usual NMEA0183 over UART is possible, but will
 require a bit more work from the driver developer.
 
+Power management
+*****************
+
+GNSS receivers typically begin acquiring and tracking GNSS signals as
+soon as they are powered on, unless configured otherwise. In order to
+preserve power, an application can either remove power from the GNSS
+receiver or stop the internal GNSS engine from actively acquiring and
+tracking signals. The latter option halts position computation while
+keeping the receiver powered with reduced power consumption and the
+communication link to the host application available for other operations
+or for resuming the GNSS engine.
+
+In the GNSS subsystem, this can be done using the :c:func:`gnss_stop`
+API call. This is distinct from Zephyr's device power management
+(suspend/resume): the receiver remains powered and able to communicate
+with the host application, but GNSS tracking is stopped.
+
+GNSS tracking can be resumed using :c:func:`gnss_start`. The application
+can specify a :c:enum:`gnss_start_mode`, which affects time-to-first-fix.
+A hot start preserves navigation data and allows the receiver to reacquire
+signals quickly, while warm and cold starts discard some or all navigation
+data, respectively, resulting in longer acquisition times.
+
+GNSS device drivers must ensure the GNSS modem starts tracking when
+resumed from a suspended or powered-off state, without requiring the
+application to call :c:func:`gnss_start` explicitly. Most receivers will
+end up performing a cold start in this situation, simply because they
+lost their tracking data while unpowered, but a driver may instead
+attempt a warm or hot start if the modem retained enough state to do so
+faster. The requirement is that tracking resumes automatically on power
+up; clearing navigation data is only a side effect of the modem having
+been unpowered, not an intended part of resuming from suspend.
+
 Configuration Options
 *********************
 

--- a/drivers/gnss/gnss_emul.c
+++ b/drivers/gnss/gnss_emul.c
@@ -8,6 +8,7 @@
 #define _POSIX_C_SOURCE 200809L /* Required for gmtime_r */
 
 #include <zephyr/drivers/gnss.h>
+#include <zephyr/drivers/gnss/gnss_emul.h>
 #include <zephyr/drivers/gnss/gnss_publish.h>
 #include <zephyr/kernel.h>
 #include <zephyr/pm/device.h>
@@ -41,6 +42,7 @@ struct gnss_emul_data {
 	gnss_systems_t enabled_systems;
 	struct gnss_data data;
 	bool active;
+	bool started;
 
 #ifdef CONFIG_GNSS_SATELLITES
 	struct gnss_satellite satellites[GNSS_EMUL_SUPPORTED_SYSTEMS_COUNT];
@@ -97,6 +99,13 @@ static bool gnss_emul_is_resumed(const struct device *dev)
 	return data->active;
 }
 
+static bool gnss_emul_is_started(const struct device *dev)
+{
+	struct gnss_emul_data *data = dev->data;
+
+	return data->started;
+}
+
 static void gnss_emul_lock(const struct device *dev)
 {
 	gnss_emul_lock_sem(dev);
@@ -105,11 +114,37 @@ static void gnss_emul_lock(const struct device *dev)
 
 static void gnss_emul_unlock(const struct device *dev)
 {
-	if (gnss_emul_is_resumed(dev)) {
+	if (gnss_emul_is_resumed(dev) && gnss_emul_is_started(dev)) {
 		gnss_emul_schedule_work(dev);
 	}
 
 	gnss_emul_unlock_sem(dev);
+}
+
+static int gnss_emul_start(const struct device *dev, enum gnss_start_mode mode)
+{
+	struct gnss_emul_data *data = dev->data;
+
+	if (mode > GNSS_COLD_START) {
+		return -EINVAL;
+	}
+
+	if (!data->started) {
+		gnss_emul_update_fix_timestamp(dev, true);
+	}
+	data->started = true;
+
+	return 0;
+}
+
+static int gnss_emul_stop(const struct device *dev)
+{
+	struct gnss_emul_data *data = dev->data;
+
+	data->started = false;
+	gnss_emul_clear_data(dev);
+
+	return 0;
 }
 
 static int gnss_emul_set_fix_rate(const struct device *dev, uint32_t fix_interval_ms)
@@ -171,6 +206,40 @@ int gnss_emul_get_enabled_systems(const struct device *dev, gnss_systems_t *syst
 
 	*systems = data->enabled_systems;
 	return 0;
+}
+
+static int gnss_emul_api_start(const struct device *dev, enum gnss_start_mode mode)
+{
+	int ret = -ENODEV;
+
+	gnss_emul_lock(dev);
+
+	if (!gnss_emul_is_resumed(dev)) {
+		goto unlock_return;
+	}
+
+	ret = gnss_emul_start(dev, mode);
+
+unlock_return:
+	gnss_emul_unlock(dev);
+	return ret;
+}
+
+static int gnss_emul_api_stop(const struct device *dev)
+{
+	int ret = -ENODEV;
+
+	gnss_emul_lock(dev);
+
+	if (!gnss_emul_is_resumed(dev)) {
+		goto unlock_return;
+	}
+
+	ret = gnss_emul_stop(dev);
+
+unlock_return:
+	gnss_emul_unlock(dev);
+	return ret;
 }
 
 static int gnss_emul_api_set_fix_rate(const struct device *dev, uint32_t fix_interval_ms)
@@ -284,6 +353,8 @@ static int gnss_emul_api_get_supported_systems(const struct device *dev, gnss_sy
 }
 
 static DEVICE_API(gnss, api) = {
+	.start = gnss_emul_api_start,
+	.stop = gnss_emul_api_stop,
 	.set_fix_rate = gnss_emul_api_set_fix_rate,
 	.get_fix_rate = gnss_emul_api_get_fix_rate,
 	.set_navigation_mode = gnss_emul_api_set_navigation_mode,
@@ -503,6 +574,7 @@ static int gnss_emul_init(const struct device *dev)
 		.fix_interval_ms = GNSS_EMUL_DEFAULT_FIX_INTERVAL_MS,			\
 		.nav_mode = GNSS_EMUL_DEFAULT_NAV_MODE,					\
 		.enabled_systems = GNSS_EMUL_DEFAULT_ENABLED_SYSTEMS_MASK,		\
+		.started = true,							\
 	};										\
 											\
 	PM_DEVICE_DT_INST_DEFINE(inst, gnss_emul_pm_action);				\

--- a/drivers/gnss/u_blox/gnss_u_blox_f9p.c
+++ b/drivers/gnss/u_blox/gnss_u_blox_f9p.c
@@ -135,6 +135,62 @@ static int u_blox_f9p_init(const struct device *dev)
 	return f9p_send_init_config(dev);
 }
 
+static int ubx_f9p_start(const struct device *dev, enum gnss_start_mode mode)
+{
+	struct ubx_cfg_rst rst = { .reserved = 0 };
+
+	switch (mode) {
+	case GNSS_HOT_START:
+		rst.nav_bbr_mask = (uint16_t)UBX_CFG_RST_HOT_START;
+		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_GNSS_START;
+		break;
+
+	case GNSS_WARM_START:
+		rst.nav_bbr_mask = (uint16_t)UBX_CFG_RST_WARM_START;
+		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_SW;
+		break;
+
+	case GNSS_COLD_START:
+		rst.nav_bbr_mask = (uint16_t)UBX_CFG_RST_COLD_START;
+		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_SW;
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	/* CFG-RST never ACKs — send fire-and-forget, then let the engine settle. */
+	u_blox_iface_msg_payload_send(dev, UBX_CLASS_ID_CFG, UBX_MSG_ID_CFG_RST,
+				       (const uint8_t *)&rst, sizeof(rst), false);
+
+	k_sleep(K_MSEC(100));
+
+	if (mode == GNSS_HOT_START) {
+		/* GNSS-only restart: RAM config is retained, nothing to reapply. */
+		return 0;
+	}
+
+	/* SW reset (warm/cold): RAM config is lost and must be reapplied. */
+	return f9p_send_init_config(dev);
+}
+
+static int ubx_f9p_stop(const struct device *dev)
+{
+	struct ubx_cfg_rst rst = {
+		.nav_bbr_mask = 0,
+		.reset_mode = UBX_CFG_RST_MODE_GNSS_STOP,
+		.reserved = 0,
+	};
+
+	/* CFG-RST never ACKs — send fire-and-forget, then let the engine settle. */
+	u_blox_iface_msg_payload_send(dev, UBX_CLASS_ID_CFG, UBX_MSG_ID_CFG_RST,
+				       (const uint8_t *)&rst, sizeof(rst), false);
+
+	k_sleep(K_MSEC(100));
+
+	return 0;
+}
+
 static int ubx_f9p_set_fix_rate(const struct device *dev, uint32_t fix_interval_ms)
 {
 	struct ubx_cfg_val_u16 rate = {
@@ -327,6 +383,8 @@ static int ubx_f9p_get_supported_systems(const struct device *dev, gnss_systems_
 
 
 static DEVICE_API(gnss, ublox_f9p_driver_api) = {
+	.start = ubx_f9p_start,
+	.stop = ubx_f9p_stop,
 	.set_fix_rate = ubx_f9p_set_fix_rate,
 	.get_fix_rate = ubx_f9p_get_fix_rate,
 	.set_navigation_mode = ubx_f9p_set_navigation_mode,

--- a/drivers/gnss/u_blox/gnss_u_blox_f9p.c
+++ b/drivers/gnss/u_blox/gnss_u_blox_f9p.c
@@ -83,10 +83,34 @@ static void f9p_rtk_data_cb(const struct device *dev, const struct gnss_rtk_data
 
 #endif /* CONFIG_GNSS_U_BLOX_F9P_RTK */
 
+static int f9p_send_init_config(const struct device *dev)
+{
+	const struct u_blox_iface_config *cfg = dev->config;
+	int err;
+
+	err = gnss_set_fix_rate(dev, cfg->fix_rate_ms);
+	if (err != 0) {
+		LOG_ERR("Failed to set fix-rate: %d", err);
+		return err;
+	}
+
+	for (size_t i = 0 ; i < ARRAY_SIZE(u_blox_f9p_init_seq) ; i++) {
+		err = u_blox_iface_msg_send(dev,
+				       u_blox_f9p_init_seq[i],
+				       UBX_FRAME_SZ(u_blox_f9p_init_seq[i]->payload_size),
+				       true);
+		if (err < 0) {
+			LOG_ERR("Failed to send init sequence - idx: %d, result: %d", i, err);
+			return err;
+		}
+	}
+
+	return 0;
+}
+
 static int u_blox_f9p_init(const struct device *dev)
 {
 	int err = 0;
-	const struct u_blox_iface_config *cfg = dev->config;
 
 	const static struct ubx_frame version_get = UBX_FRAME_GET_INITIALIZER(
 						UBX_CLASS_ID_MON,
@@ -108,24 +132,7 @@ static int u_blox_f9p_init(const struct device *dev)
 	}
 	LOG_INF("SW Version: %s, HW Version: %s", ver.sw_ver, ver.hw_ver);
 
-	err = gnss_set_fix_rate(dev, cfg->fix_rate_ms);
-	if (err != 0) {
-		LOG_ERR("Failed to set fix-rate: %d", err);
-		return err;
-	}
-
-	for (size_t i = 0 ; i < ARRAY_SIZE(u_blox_f9p_init_seq) ; i++) {
-		err = u_blox_iface_msg_send(dev,
-				       u_blox_f9p_init_seq[i],
-				       UBX_FRAME_SZ(u_blox_f9p_init_seq[i]->payload_size),
-				       true);
-		if (err < 0) {
-			LOG_ERR("Failed to send init sequence - idx: %d, result: %d", i, err);
-			return err;
-		}
-	}
-
-	return 0;
+	return f9p_send_init_config(dev);
 }
 
 static int ubx_f9p_set_fix_rate(const struct device *dev, uint32_t fix_interval_ms)

--- a/drivers/gnss/u_blox/gnss_u_blox_m10.c
+++ b/drivers/gnss/u_blox/gnss_u_blox_m10.c
@@ -104,6 +104,62 @@ static int u_blox_m10_init(const struct device *dev)
 	return ubx_m10_send_init_config(dev);
 }
 
+static int ubx_m10_start(const struct device *dev, enum gnss_start_mode mode)
+{
+	struct ubx_cfg_rst rst = { .reserved = 0 };
+
+	switch (mode) {
+	case GNSS_HOT_START:
+		rst.nav_bbr_mask = (uint16_t)UBX_CFG_RST_HOT_START;
+		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_GNSS_START;
+		break;
+
+	case GNSS_WARM_START:
+		rst.nav_bbr_mask = (uint16_t)UBX_CFG_RST_WARM_START;
+		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_SW;
+		break;
+
+	case GNSS_COLD_START:
+		rst.nav_bbr_mask = (uint16_t)UBX_CFG_RST_COLD_START;
+		rst.reset_mode = (uint8_t)UBX_CFG_RST_MODE_SW;
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	/* CFG-RST never ACKs — send fire-and-forget, then let the engine settle. */
+	u_blox_iface_msg_payload_send(dev, UBX_CLASS_ID_CFG, UBX_MSG_ID_CFG_RST,
+				       (const uint8_t *)&rst, sizeof(rst), false);
+
+	k_sleep(K_MSEC(100));
+
+	if (mode == GNSS_HOT_START) {
+		/* GNSS-only restart: RAM config is retained, nothing to reapply. */
+		return 0;
+	}
+
+	/* SW reset (warm/cold): RAM config is lost and must be reapplied. */
+	return ubx_m10_send_init_config(dev);
+}
+
+static int ubx_m10_stop(const struct device *dev)
+{
+	struct ubx_cfg_rst rst = {
+		.nav_bbr_mask = 0,
+		.reset_mode = UBX_CFG_RST_MODE_GNSS_STOP,
+		.reserved = 0,
+	};
+
+	/* CFG-RST never ACKs — send fire-and-forget, then let the engine settle. */
+	u_blox_iface_msg_payload_send(dev, UBX_CLASS_ID_CFG, UBX_MSG_ID_CFG_RST,
+				       (const uint8_t *)&rst, sizeof(rst), false);
+
+	k_sleep(K_MSEC(100));
+
+	return 0;
+}
+
 static int ubx_m10_set_fix_rate(const struct device *dev, uint32_t fix_interval_ms)
 {
 	if (fix_interval_ms < 50 || fix_interval_ms > 65535) {
@@ -302,6 +358,8 @@ static int ubx_m10_get_supported_systems(const struct device *dev, gnss_systems_
 }
 
 static DEVICE_API(gnss, ublox_m10_driver_api) = {
+	.start = ubx_m10_start,
+	.stop = ubx_m10_stop,
 	.set_fix_rate = ubx_m10_set_fix_rate,
 	.get_fix_rate = ubx_m10_get_fix_rate,
 	.set_navigation_mode = ubx_m10_set_navigation_mode,

--- a/drivers/gnss/u_blox/gnss_u_blox_m10.c
+++ b/drivers/gnss/u_blox/gnss_u_blox_m10.c
@@ -53,10 +53,34 @@ MODEM_UBX_MATCH_ARRAY_DEFINE(u_blox_m10_unsol_messages,
 #endif
 );
 
+static int ubx_m10_send_init_config(const struct device *dev)
+{
+	const struct u_blox_iface_config *cfg = dev->config;
+	int err;
+
+	err = gnss_set_fix_rate(dev, cfg->fix_rate_ms);
+	if (err != 0) {
+		LOG_ERR("Failed to set fix-rate: %d", err);
+		return err;
+	}
+
+	for (size_t i = 0 ; i < ARRAY_SIZE(u_blox_m10_init_seq) ; i++) {
+		err = u_blox_iface_msg_send(dev,
+				       u_blox_m10_init_seq[i],
+				       UBX_FRAME_SZ(u_blox_m10_init_seq[i]->payload_size),
+				       true);
+		if (err < 0) {
+			LOG_ERR("Failed to send init sequence - idx: %d, result: %d", i, err);
+			return err;
+		}
+	}
+
+	return 0;
+}
+
 static int u_blox_m10_init(const struct device *dev)
 {
 	int err;
-	const struct u_blox_iface_config *cfg = dev->config;
 
 	const static struct ubx_frame version_get = UBX_FRAME_GET_INITIALIZER(
 						UBX_CLASS_ID_MON, UBX_MSG_ID_MON_VER);
@@ -77,24 +101,7 @@ static int u_blox_m10_init(const struct device *dev)
 	}
 	LOG_INF("SW Version %s, HW Version: %s", ver.sw_ver, ver.hw_ver);
 
-	err = gnss_set_fix_rate(dev, cfg->fix_rate_ms);
-	if (err != 0) {
-		LOG_ERR("Failed to set GNSS fix-rate: %d", err);
-		return err;
-	}
-
-	for (size_t i = 0; i < ARRAY_SIZE(u_blox_m10_init_seq); i++) {
-		err = u_blox_iface_msg_send(dev,
-					u_blox_m10_init_seq[i],
-					UBX_FRAME_SZ(u_blox_m10_init_seq[i]->payload_size),
-					true);
-		if (err < 0) {
-			LOG_ERR("Failed to send init sequence. idx: %d, result %d", i, err);
-			return err;
-		}
-	}
-
-	return 0;
+	return ubx_m10_send_init_config(dev);
 }
 
 static int ubx_m10_set_fix_rate(const struct device *dev, uint32_t fix_interval_ms)

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -32,6 +32,16 @@
 extern "C" {
 #endif
 
+/** GNSS receiver start modes */
+enum gnss_start_mode {
+	/** Restart with all navigation data preserved (fastest TTFF) */
+	GNSS_HOT_START = 0,
+	/** Restart clearing ephemeris; almanac and position are retained */
+	GNSS_WARM_START = 1,
+	/** Restart clearing all navigation data (longest TTFF) */
+	GNSS_COLD_START = 2,
+};
+
 /** GNSS PPS modes */
 enum gnss_pps_mode {
 	/** PPS output disabled */
@@ -162,6 +172,12 @@ struct gnss_time {
  * @{
  */
 
+/** API for starting the GNSS receiver engine */
+typedef int (*gnss_start_t)(const struct device *dev, enum gnss_start_mode mode);
+
+/** API for stopping the GNSS receiver engine */
+typedef int (*gnss_stop_t)(const struct device *dev);
+
 /** API for setting fix rate */
 typedef int (*gnss_set_fix_rate_t)(const struct device *dev, uint32_t fix_interval_ms);
 
@@ -192,6 +208,14 @@ typedef int (*gnss_get_latest_timepulse_t)(const struct device *dev, k_ticks_t *
  * @driver_ops{GNSS}
  */
 __subsystem struct gnss_driver_api {
+	/**
+	 * @driver_ops_optional @copybrief gnss_start
+	 */
+	gnss_start_t start;
+	/**
+	 * @driver_ops_optional @copybrief gnss_stop
+	 */
+	gnss_stop_t stop;
 	/**
 	 * @driver_ops_optional @copybrief gnss_set_fix_rate
 	 */
@@ -280,6 +304,61 @@ struct gnss_satellites_callback {
 	/** Callback called when GNSS satellites is published */
 	gnss_satellites_callback_t callback;
 };
+
+/**
+ * @brief Start the GNSS receiver engine.
+ *
+ * Starts (or resumes) GNSS receiver engine.  @p mode controls which
+ * navigation data is preserved across the restart, trading time-to-first-fix
+ * against accuracy of the first few fixes.
+ *
+ * @param dev  Device instance
+ * @param mode Start mode: GNSS_HOT_START, GNSS_WARM_START, or GNSS_COLD_START
+ *
+ * @retval 0        Success
+ * @retval -ENOSYS  Driver does not support this function
+ * @retval -ENODEV  Device is not yet started (PM not resumed)
+ * @retval -EINVAL  Invalid mode
+ * @retval -errno   Other driver-specific error
+ */
+__syscall int gnss_start(const struct device *dev, enum gnss_start_mode mode);
+
+static inline int z_impl_gnss_start(const struct device *dev, enum gnss_start_mode mode)
+{
+	const struct gnss_driver_api *api = DEVICE_API_GET(gnss, dev);
+
+	if (api->start == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->start(dev, mode);
+}
+
+/**
+ * @brief Stop the GNSS receiver engine.
+ *
+ * Instructs the receiver to halt position computation while keeping the
+ * communication link open.  Call gnss_start() to resume.
+ *
+ * @param dev Device instance
+ *
+ * @retval 0        Success
+ * @retval -ENOSYS  Driver does not support this function
+ * @retval -ENODEV  Device is not yet started (PM not resumed)
+ * @retval -errno   Other driver-specific error
+ */
+__syscall int gnss_stop(const struct device *dev);
+
+static inline int z_impl_gnss_stop(const struct device *dev)
+{
+	const struct gnss_driver_api *api = DEVICE_API_GET(gnss, dev);
+
+	if (api->stop == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->stop(dev);
+}
 
 /**
  * @brief Set the GNSS fix rate

--- a/tests/drivers/gnss/gnss_api/CMakeLists.txt
+++ b/tests/drivers/gnss/gnss_api/CMakeLists.txt
@@ -11,5 +11,6 @@ target_sources(app PRIVATE
   src/test_enabled_systems.c
   src/test_fix_rate.c
   src/test_navigation_mode.c
+  src/test_start_stop.c
   src/test_suite.c
 )

--- a/tests/drivers/gnss/gnss_api/src/test_start_stop.c
+++ b/tests/drivers/gnss/gnss_api/src/test_start_stop.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 CampOS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/gnss.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/ztest.h>
+
+#define TEST_FIX_INTERVAL_MS    200
+#define TEST_VALIDATE_PERIOD    K_MSEC(2500)
+
+static const struct device *dev = DEVICE_DT_GET(DT_ALIAS(gnss));
+
+static atomic_t callback_count_atom = ATOMIC_INIT(0);
+
+static void gnss_data_cb(const struct device *dev, const struct gnss_data *data)
+{
+	atomic_inc(&callback_count_atom);
+}
+
+GNSS_DATA_CALLBACK_DEFINE(DEVICE_DT_GET(DT_ALIAS(gnss)), gnss_data_cb);
+
+ZTEST(gnss_api, test_start_stop)
+{
+	int ret;
+	uint32_t callback_count;
+
+	ret = gnss_set_fix_rate(dev, TEST_FIX_INTERVAL_MS);
+	zassert_true(ret == 0 || ret == -ENOSYS, "failed to set fix rate");
+
+	ret = gnss_stop(dev);
+	if (ret == -ENOSYS) {
+		ztest_test_skip();
+	}
+	zassert_ok(ret, "failed to stop GNSS");
+
+	atomic_set(&callback_count_atom, 0);
+	k_sleep(TEST_VALIDATE_PERIOD);
+	callback_count = atomic_get(&callback_count_atom);
+	zassert_equal(callback_count, 0, "received %u GNSS updates while stopped",
+		     callback_count);
+
+	ret = gnss_start(dev, GNSS_HOT_START);
+	zassert_ok(ret, "failed to start GNSS");
+
+	atomic_set(&callback_count_atom, 0);
+	k_sleep(TEST_VALIDATE_PERIOD);
+	callback_count = atomic_get(&callback_count_atom);
+	zassert_true(callback_count > 0, "received no GNSS updates after start");
+}


### PR DESCRIPTION
  Add `gnss_start()` / `gnss_stop()` to the GNSS driver API, letting applications
  explicitly resume or halt receiver position computation without power-cycling
  the device.

  `gnss_start()` takes an `enum gnss_start_mode` (`GNSS_HOT_START` /
  `GNSS_WARM_START` / `GNSS_COLD_START`) controlling how much navigation data
  (ephemeris, almanac, last known position) is preserved across the restart,
  trading time-to-first-fix against fix accuracy for the first few fixes after
  starting. `gnss_stop()` halts position computation while keeping the
  communication link open, so `gnss_start()` can resume it later.

  Both ops are added as `gnss_driver_api::start` / `::stop` and marked
  `@driver_ops_optional`: drivers that don't implement them return `-ENOSYS`
  from the new `gnss_start()`/`gnss_stop()` wrappers, so this is backward
  compatible with every existing in-tree GNSS driver. The two functions follow
  the same `__syscall` / `z_impl_` pattern as the rest of the GNSS API
  (`gnss_set_fix_rate`, `gnss_get_navigation_mode`, etc.), so they're usable
  from user-mode threads under `CONFIG_USERSPACE`.

  No in-tree driver implements `.start`/`.stop` yet in this PR — this lays down
  the API surface for drivers (e.g. u-blox) that support commanding the
  receiver engine directly, rather than only via device PM suspend/resume.
