### PR TITLE
arch: xtensa: esp32: add CONFIG_SMP support for original ESP32

### DIFF
--- a/arch/xtensa/core/CMakeLists.txt
+++ b/arch/xtensa/core/CMakeLists.txt
@@ -28,7 +28,12 @@ zephyr_library_sources_ifdef(CONFIG_XTENSA_MMU ptables.c mmu.c)
 zephyr_library_sources_ifdef(CONFIG_XTENSA_MPU mpu/mpu_core.c mpu/mpu_regions.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.S syscall_helper.c)
 zephyr_library_sources_ifdef(CONFIG_LLEXT elf.c)
-zephyr_library_sources_ifdef(CONFIG_SMP smp.c)
+# intel_adsp SoCs have their own independent SMP implementation
+# (soc/intel/intel_adsp/{common,ace}/multiprocessing.c) and must not also
+# link this shared implementation.
+if(CONFIG_SMP AND NOT CONFIG_SOC_FAMILY_INTEL_ADSP)
+  zephyr_library_sources(smp.c)
+endif()
 zephyr_library_sources_ifdef(CONFIG_XTENSA_HIFI_SHARING xtensa_hifi.S)
 
 zephyr_library_sources(instr_mem.c)

--- a/arch/xtensa/core/smp.c
+++ b/arch/xtensa/core/smp.c
@@ -1,11 +1,23 @@
 /*
  * Copyright (c) 2023 Intel Corporation
+ * Copyright (c) 2026 The Zephyr Project Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
+#include <zephyr/irq.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/arch/xtensa/smp.h>
+#include <zephyr/zsr.h>
+#include <ipi.h>
+#include <ksched.h>
+#include <kswap.h>
+
+/* Only built when CONFIG_SMP=y (see arch/xtensa/core/CMakeLists.txt), so
+ * no #ifdef CONFIG_SMP needed in this file.
+ */
 
 #ifdef CONFIG_XTENSA_MORE_SPIN_RELAX_NOPS
 /* Some compilers might "optimize out" (i.e. remove) continuous NOPs.
@@ -20,12 +32,151 @@ void arch_spin_relax(void)
 }
 #endif /* CONFIG_XTENSA_MORE_SPIN_RELAX_NOPS */
 
+struct xtensa_cpustart_rec {
+	arch_cpustart_t fn;
+	void *arg;
+	char *stack_top;
+};
+
+static struct xtensa_cpustart_rec cpustart_rec[CONFIG_MP_MAX_NUM_CPUS];
+
+/* True once a core has reached xtensa_smp_secondary_start() (or, for
+ * core 0, unconditionally from arch_smp_init()). Doubles as the
+ * "active" bitmap arch_sched_directed_ipi()/arch_cpu_active() consult,
+ * and as the handshake arch_cpu_start() spins on -- every prior
+ * per-SoC implementation (ESP32's alive_flag, Intel's
+ * soc_cpus_active[]) had its own copy of exactly this.
+ */
+static bool cpu_active[CONFIG_MP_MAX_NUM_CPUS];
 
 /**
- * init for multi-core/smp is done on the SoC level. Add this here for
- * compatibility with other SMP systems.
+ * @brief Stack top for a core that has been told to start but hasn't
+ *        reached xtensa_smp_secondary_start() yet.
+ *
+ * SoC-specific boot trampolines run in assembly before any C stack
+ * exists, so they need this value to set up SP themselves prior to
+ * calling into xtensa_smp_secondary_start(). Exposed as an accessor
+ * rather than a bare global so multi-secondary-core SoCs don't need
+ * one global per core the way the current single-APPCPU ESP32 code
+ * does (static void *appcpu_top).
  */
+void *xtensa_smp_cpu_stack_top(int cpu_num)
+{
+	return cpustart_rec[cpu_num].stack_top;
+}
+
+void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz, arch_cpustart_t fn, void *arg)
+{
+	__ASSERT(cpu_num > 0 && cpu_num < CONFIG_MP_MAX_NUM_CPUS, "invalid secondary core %d",
+		 cpu_num);
+	__ASSERT_NO_MSG(!cpu_active[cpu_num]);
+
+	cpustart_rec[cpu_num].fn = fn;
+	cpustart_rec[cpu_num].arg = arg;
+	cpustart_rec[cpu_num].stack_top = K_KERNEL_STACK_BUFFER(stack) + sz;
+
+	/* soc_mp_start_core() only releases/resets the target core; it
+	 * does not wait for it to come up. The completion handshake is
+	 * cpu_active[cpu_num], set from *inside* xtensa_smp_secondary_start()
+	 * -- i.e. by code actually running on cpu_num, not guessed at by
+	 * the initiating core.
+	 */
+	soc_mp_start_core(cpu_num);
+
+	while (!cpu_active[cpu_num]) {
+		arch_spin_relax();
+	}
+
+	/* Not fully explained, but confirmed to help on ESP32: without a settle
+	 * delay here, right after both cores are confirmed up and before either
+	 * touches anything flash-heavy (e.g. NVS/settings), APPCPU intermittently
+	 * hangs or the board hits a spurious watchdog reset later in boot. Both
+	 * symptoms went away, repeatedly, once this delay was added. Same
+	 * category of unexplained-but-load-bearing fix as esp32-mp.c's
+	 * smp_log() comment, different mechanism -- leave in place until
+	 * understood.
+	 */
+	k_busy_wait(100000);
+}
+
+FUNC_NORETURN void xtensa_smp_secondary_start(int cpu_num)
+{
+	_cpu_t *cpu = &_kernel.cpus[cpu_num];
+
+	__asm__ volatile("wsr %0, " ZSR_CPU_STR : : "r"(cpu));
+
+	/* _current must be valid before soc_mp_startup_self() runs, since that hook can call
+	 * arbitrary driver code -- our esp32 port's IPI registration calls esp_intr_alloc(),
+	 * which calls the generic irq_lock() -> under CONFIG_SMP that's z_smp_global_lock(),
+	 * which dereferences _current->base.global_lock_count. PRO_CPU's own analogous call
+	 * (arch_smp_init() -> soc_mp_startup_self(0)) already works because z_cstart()
+	 * (kernel/init.c) calls z_dummy_thread_init() *before* ever reaching that call -- this
+	 * mirrors that ordering for secondary cores, which previously only got their dummy
+	 * thread set up later, inside smp_init_top() (kernel/smp/smp.c), i.e. *after*
+	 * soc_mp_startup_self() already ran (which meant it never returned).
+	 */
+	z_dummy_thread_init(&_thread_dummy);
+
+	/* Must run before cpu_active[cpu_num] is set: this is what
+	 * registers and enables cpu_num's own incoming IPI line. If a
+	 * directed IPI could be sent to this core before that, it would
+	 * be silently lost.
+	 */
+	soc_mp_startup_self(cpu_num);
+
+	cpu_active[cpu_num] = true;
+
+	cpustart_rec[cpu_num].fn(cpustart_rec[cpu_num].arg);
+
+	__ASSERT(false, "arch_cpu_start() handler should never return");
+	for (;;) {
+	}
+}
+
+bool arch_cpu_active(int cpu_num)
+{
+	return cpu_active[cpu_num];
+}
+
+void arch_sched_directed_ipi(uint32_t cpu_bitmap)
+{
+	unsigned int key = arch_irq_lock();
+	unsigned int self = _current_cpu->id;
+	unsigned int num_cpus = arch_num_cpus();
+
+	for (unsigned int i = 0; i < num_cpus; i++) {
+		if (i != self && cpu_active[i] && (cpu_bitmap & BIT(i)) != 0) {
+			soc_ipi_trigger(i);
+		}
+	}
+
+	arch_irq_unlock(key);
+}
+
+void arch_sched_broadcast_ipi(void)
+{
+	arch_sched_directed_ipi(IPI_ALL_CPUS_MASK);
+}
+
+void xtensa_smp_ipi_isr(void *arg)
+{
+	ARG_UNUSED(arg);
+
+	soc_ipi_clear();
+	z_sched_ipi();
+}
+
 int arch_smp_init(void)
 {
+	/* Core 0 is running Zephyr by definition and never passes through
+	 * xtensa_smp_secondary_start() -- but it still needs its own
+	 * incoming IPI line registered and enabled, the same as every
+	 * other core. Reusing soc_mp_startup_self() here (rather than a
+	 * fifth, core-0-only hook) keeps that one hook symmetric across
+	 * every core in CONFIG_MP_MAX_NUM_CPUS.
+	 */
+	soc_mp_startup_self(0);
+	cpu_active[0] = true;
+
 	return 0;
 }

--- a/drivers/interrupt_controller/intc_esp32.c
+++ b/drivers/interrupt_controller/intc_esp32.c
@@ -222,12 +222,25 @@ int esp_intr_reserve(int intno, int cpu)
 	return 0;
 }
 
-/* Returns true if handler for interrupt is not the default unhandled interrupt handler */
-static bool intr_has_handler(int intr, int cpu)
+/* Returns true if handler for interrupt is not the default unhandled interrupt handler.
+ *
+ * _sw_isr_table has no per-CPU dimension on Xtensa: the real dispatch code
+ * (xtensa_handle_irq_lvl(), arch/xtensa/core/vector_handlers.c) indexes it as
+ * _sw_isr_table[irq] (+32/+64/+96 for higher interrupt-register groups only,
+ * never multiplied by CPU count), and the actual handler installation
+ * (irq_connect_dynamic(), below) writes to that same plain index -- it's one
+ * shared table across both cores. Multiplying by CONFIG_MP_MAX_NUM_CPUS here
+ * checked unrelated slots for any intr > 0 whenever CONFIG_MP_MAX_NUM_CPUS > 1,
+ * and was wrong even in single-core (CONFIG_MP_MAX_NUM_CPUS == 1) builds
+ * physically executing on a non-zero core -- e.g. an AMP image running on
+ * APPCPU -- since esp_core_id()/esp_cpu_get_core_id() read the real hardware
+ * PRID register regardless of that build's own Kconfig.
+ */
+static bool intr_has_handler(int intr)
 {
 	bool r;
 
-	r = _sw_isr_table[intr * CONFIG_MP_MAX_NUM_CPUS + cpu].isr != z_irq_spurious;
+	r = _sw_isr_table[intr].isr != z_irq_spurious;
 
 	return r;
 }
@@ -304,7 +317,7 @@ static bool is_vect_desc_usable(struct vector_desc_t *vd, int flags, int cpu, in
 			INTC_LOG("...Unusable: int is shared, we need non-shared.");
 			return false;
 		}
-	} else if (intr_has_handler(x, cpu)) {
+	} else if (intr_has_handler(x)) {
 		INTC_LOG("....Unusable: already allocated");
 		return false;
 	}
@@ -380,10 +393,10 @@ static int get_available_int(int flags, int cpu, int force, int source)
 		esp_cpu_intr_desc_t intr_desc;
 		esp_cpu_intr_get_desc(cpu, x, &intr_desc);
 
-		INTC_LOG("Int %d reserved %d level %d %s hasIsr %d",
-			 x, intr_desc.flags & ESP_CPU_INTR_DESC_FLAG_RESVD, intr_desc.priority,
+		INTC_LOG("Int %d reserved %d level %d %s hasIsr %d", x,
+			 intr_desc.flags & ESP_CPU_INTR_DESC_FLAG_RESVD, intr_desc.priority,
 			 intr_desc.type == ESP_CPU_INTR_TYPE_LEVEL ? "LEVEL" : "EDGE",
-			 intr_has_handler(x, cpu));
+			 intr_has_handler(x));
 
 		if (!is_vect_desc_usable(vd, flags, cpu, force)) {
 			continue;

--- a/drivers/timer/CMakeLists.txt
+++ b/drivers/timer/CMakeLists.txt
@@ -64,5 +64,6 @@ zephyr_library_sources_ifdef(CONFIG_SYSTEM_TIMER_LPM_COMPANION_COUNTER sys_lpm_h
 zephyr_library_sources_ifdef(CONFIG_TI_DM_TIMER ti_dmtimer.c)
 zephyr_library_sources_ifdef(CONFIG_TI_RTI_TIMER ti_rti_timer.c)
 zephyr_library_sources_ifdef(CONFIG_XLNX_PSTTC_TIMER xlnx_psttc_timer.c)
+zephyr_library_sources_ifdef(CONFIG_XTENSA_ESP32_SYS_TIMER xtensa_esp32_sys_timer.c)
 zephyr_library_sources_ifdef(CONFIG_XTENSA_TIMER xtensa_sys_timer.c)
 # zephyr-keep-sorted-stop

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -139,6 +139,7 @@ source "drivers/timer/Kconfig.wch_ch32v00x"
 source "drivers/timer/Kconfig.x86"
 source "drivers/timer/Kconfig.xlnx_psttc"
 source "drivers/timer/Kconfig.xtensa"
+source "drivers/timer/Kconfig.xtensa_esp32"
 # zephyr-keep-sorted-stop
 
 endmenu

--- a/drivers/timer/Kconfig.xtensa_esp32
+++ b/drivers/timer/Kconfig.xtensa_esp32
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config XTENSA_ESP32_SYS_TIMER
+	bool "ESP32 Xtensa per-core system timer support"
+	depends on SOC_SERIES_ESP32
+	default y if SMP
+	select TICKLESS_CAPABLE
+	help
+	  Per-core-safe system timer driver for original ESP32 (Xtensa), needed
+	  because CCOUNT/CCOMPARE are genuine per-core special registers there,
+	  unlike Xtensa SoCs with a shared external timer. See
+	  drivers/timer/xtensa_esp32_sys_timer.c for details.
+	  Only needed under CONFIG_SMP, where two cores each have their own
+	  independent CCOUNT/CCOMPARE base -- with a single core, the generic
+	  XTENSA_TIMER driver's single shared last_count is already correct,
+	  so non-SMP builds keep using it unchanged rather than switching to
+	  an unnecessary, less-tested driver.
+	  The mutual-exclusion override for the generic XTENSA_TIMER driver
+	  lives in soc/espressif/esp32/Kconfig.defconfig -- a plain sourced
+	  Kconfig fragment like this one cannot reopen a symbol declared
+	  elsewhere to add defaults/dependencies; only files named
+	  Kconfig.defconfig get that special, Zephyr-specific treatment.

--- a/drivers/timer/xtensa_esp32_sys_timer.c
+++ b/drivers/timer/xtensa_esp32_sys_timer.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2018 Intel Corporation
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2026 The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Original ESP32 (Xtensa) per-core system timer driver.
+ *
+ * A private fork of xtensa_sys_timer.c, needed because that driver's
+ * tick-tracking state (last_count and friends) is a single shared variable
+ * per instance, which is only correct on Xtensa SoCs where CCOUNT/CCOMPARE
+ * is a single shared hardware resource (e.g. intel_adsp's external,
+ * cross-core-synchronized wall clock timer, which is why
+ * drivers/timer/intel_adsp_timer.c does not need this). Original ESP32's
+ * CCOUNT/CCOMPARE are genuine per-core Xtensa special registers with no
+ * shared oscillator guarantee between cores, so under CONFIG_SMP each core
+ * needs its own independent copy of this state -- otherwise one core's
+ * tick delta math silently mixes in another core's unrelated CCOUNT base.
+ *
+ * Kept as a separate driver (selected in place of the generic XTENSA_TIMER
+ * for SOC_SERIES_ESP32, see Kconfig.xtensa_esp32) rather than a change to
+ * the shared driver: xtensa_sys_timer.c is also used by AMD, NXP,
+ * MediaTek, and Cadence Xtensa SoCs, none of which are SMP-capable there
+ * today.
+ */
+
+#include <zephyr/init.h>
+#include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/irq.h>
+
+#include "xtensa_sys_timer.h"
+
+/* Original ESP32 always uses timer 0 -- no board overrides
+ * CONFIG_XTENSA_TIMER_ID away from its default, and referencing that
+ * symbol here would be awkward since it depends on CONFIG_XTENSA_TIMER,
+ * which this driver deliberately disables (see Kconfig.xtensa_esp32).
+ */
+#define TIMER_IRQ XCHAL_TIMER0_INTERRUPT
+
+#define CYC_PER_TICK (sys_clock_hw_cycles_per_sec() / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+#define MAX_CYC      0xffffffffu
+#define MAX_TICKS    ((MAX_CYC - CYC_PER_TICK) / CYC_PER_TICK)
+#define MIN_DELAY    1000
+
+/* Each core has its own independent, free-running CCOUNT register with no
+ * shared oscillator guarantee between cores -- these must be per-core
+ * state, not single shared variables, or one core's delta math silently
+ * mixes in another core's unrelated CCOUNT base.
+ */
+static unsigned int last_count[CONFIG_MP_MAX_NUM_CPUS];
+static uint32_t ccount_compensation[CONFIG_MP_MAX_NUM_CPUS];
+static uint32_t ccount_pre_idle[CONFIG_MP_MAX_NUM_CPUS];
+static uint64_t lptim_pre_idle[CONFIG_MP_MAX_NUM_CPUS];
+static bool timeout_idle[CONFIG_MP_MAX_NUM_CPUS];
+
+#if defined(CONFIG_TEST)
+const int32_t z_sys_timer_irq_for_test = XCHAL_TIMER0_INTERRUPT;
+#endif
+
+static uint32_t ccount_comp(void)
+{
+	if (IS_ENABLED(CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK)) {
+		return ccount_compensation[_current_cpu->id];
+	}
+
+	return 0;
+}
+
+static void set_ccompare(uint32_t val)
+{
+	__asm__ volatile("wsr.CCOMPARE0 %0" ::"r"(val));
+}
+
+static uint32_t ccount(void)
+{
+	uint32_t val;
+
+	__asm__ volatile("rsr.CCOUNT %0" : "=r"(val));
+	return val + ccount_comp();
+}
+
+static uint32_t sys_clock_elapsed_ticks(uint32_t curr)
+{
+	unsigned int id = _current_cpu->id;
+	uint32_t dticks = (curr - last_count[id]) / CYC_PER_TICK;
+
+	last_count[id] += dticks * CYC_PER_TICK;
+
+	return dticks;
+}
+
+static void ccompare_isr(const void *arg)
+{
+	ARG_UNUSED(arg);
+
+	k_spinlock_key_t key = sys_clock_lock();
+
+	uint32_t curr = ccount();
+	uint32_t dticks = sys_clock_elapsed_ticks(curr);
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		uint32_t next = last_count[_current_cpu->id] + CYC_PER_TICK;
+
+		if ((int32_t)(next - curr) < MIN_DELAY) {
+			next += CYC_PER_TICK;
+		}
+		set_ccompare(next - ccount_comp());
+	}
+
+	sys_clock_announce_locked(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1, key);
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
+#if defined(CONFIG_TICKLESS_KERNEL)
+	unsigned int id = _current_cpu->id;
+
+	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
+
+	uint32_t curr = ccount(), cyc, adj;
+
+	/* Round up to next tick boundary */
+	cyc = ticks * CYC_PER_TICK;
+	adj = (curr - last_count[id]) + (CYC_PER_TICK - 1);
+	if (cyc <= MAX_CYC - adj) {
+		cyc += adj;
+	} else {
+		cyc = MAX_CYC;
+	}
+	cyc = (cyc / CYC_PER_TICK) * CYC_PER_TICK;
+	cyc += last_count[id];
+
+	if ((cyc - curr) < MIN_DELAY) {
+		cyc += CYC_PER_TICK;
+	}
+
+	set_ccompare(cyc - ccount_comp());
+
+	if (IS_ENABLED(CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK)) {
+		if (idle) {
+			uint64_t timeout_us =
+				((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+
+			lptim_pre_idle[id] = z_xtensa_lptim_hook_on_lpm_entry(timeout_us);
+			ccount_pre_idle[id] = ccount();
+			timeout_idle[id] = true;
+		}
+	} else {
+		ARG_UNUSED(idle);
+	}
+
+#endif
+}
+
+uint32_t sys_clock_elapsed(void)
+{
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return 0;
+	}
+
+	return (ccount() - last_count[_current_cpu->id]) / CYC_PER_TICK;
+}
+
+uint32_t sys_clock_cycle_get_32(void)
+{
+	return ccount();
+}
+
+#ifdef CONFIG_SMP
+void smp_timer_init(void)
+{
+	set_ccompare(ccount() + CYC_PER_TICK);
+	irq_enable(TIMER_IRQ);
+}
+#endif
+
+void sys_clock_idle_exit(void)
+{
+	if (IS_ENABLED(CONFIG_XTENSA_TIMER_LPM_TIMER_HOOK)) {
+		unsigned int id = _current_cpu->id;
+
+		if (!timeout_idle[id]) {
+			return;
+		}
+
+		k_spinlock_key_t key = sys_clock_lock();
+
+		uint64_t lptim_now = z_xtensa_lptim_hook_on_lpm_exit();
+		uint64_t ccount_now = ccount();
+		uint64_t lptim_diff = lptim_now - lptim_pre_idle[id];
+		uint32_t ccount_diff = ccount_now - ccount_pre_idle[id];
+		uint64_t expected_cycles = (lptim_diff * sys_clock_hw_cycles_per_sec()) /
+					   z_xtensa_lptim_hook_get_freq();
+		uint32_t missed_cycles = 0;
+
+		if (expected_cycles > ccount_diff) {
+			missed_cycles = (uint32_t)(expected_cycles - ccount_diff);
+		}
+
+		ccount_compensation[id] += missed_cycles;
+
+		ccount_now = ccount();
+		uint32_t dticks = sys_clock_elapsed_ticks(ccount_now);
+
+		timeout_idle[id] = false;
+
+		/* Announce corrected ticks as CCOUNT remained stalled during LPM */
+		sys_clock_announce_locked(dticks, key);
+	}
+}
+
+static int sys_clock_driver_init(void)
+{
+	IRQ_CONNECT(TIMER_IRQ, 0, ccompare_isr, 0, 0);
+	set_ccompare(ccount() + CYC_PER_TICK);
+	irq_enable(TIMER_IRQ);
+	return 0;
+}
+
+SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/include/zephyr/arch/xtensa/smp.h
+++ b/include/zephyr/arch/xtensa/smp.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief SoC hook interface consumed by the shared Xtensa SMP layer
+ *        (arch/xtensa/core/smp.c).
+ *
+ * Every Xtensa SoC that implements CONFIG_SMP must provide these four
+ * functions. They are the only hardware-specific primitives the shared
+ * layer needs; everything else (boot sequencing, the active-core bitmap,
+ * directed-IPI looping, the shared ISR) lives in arch/xtensa/core/smp.c
+ * and is identical for every SoC.
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_XTENSA_SMP_H_
+#define ZEPHYR_INCLUDE_ARCH_XTENSA_SMP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Physically power on / release / reset the target core so that it
+ *        begins executing the SoC's own secondary-core entry trampoline.
+ *
+ * Called exactly once per core, from arch_cpu_start() running on the
+ * *initiating* core (never on @p cpu_num itself). Must not return until
+ * the target core has been told to start; it does not need to wait for
+ * the target core to finish booting -- xtensa_smp_secondary_start() (see
+ * below) is what runs the completion handshake.
+ *
+ * The SoC's own trampoline (whatever gets the core from reset into C
+ * code -- e.g. a ROM boot vector, a fixed jump table entry) is entirely
+ * SoC-specific and is not part of this hook interface. Once that
+ * trampoline reaches C code running on @p cpu_num, it must call
+ * xtensa_smp_secondary_start(cpu_num) to hand off into the shared layer.
+ *
+ * @param cpu_num Target core to start (never the calling core, never 0).
+ */
+void soc_mp_start_core(int cpu_num);
+
+/**
+ * @brief Final per-core hardware init, executed by a core on itself.
+ *
+ * Called for every core, including core 0, but from different places:
+ * core 0 gets this call from arch_smp_init() early in boot; every other
+ * core gets it from xtensa_smp_secondary_start(), which runs *on* that
+ * core right after soc_mp_start_core() has released it.
+ *
+ * Must, at minimum, register and enable this core's own local incoming
+ * IPI interrupt line (IRQ_CONNECT() + irq_enable(), using
+ * xtensa_smp_ipi_isr() -- declared below -- as the handler). May also
+ * perform any other per-core hardware bring-up the SoC needs (e.g.
+ * interrupt controller state that is genuinely per-core register state
+ * on Xtensa and therefore cannot be set up remotely by another core).
+ *
+ * @param cpu_num The core this function is executing on (== calling
+ *                core's own ID).
+ */
+void soc_mp_startup_self(int cpu_num);
+
+/**
+ * @brief Signal one specific *other* core's incoming IPI line.
+ *
+ * Called from the shared arch_sched_directed_ipi()/
+ * arch_sched_broadcast_ipi() loop, once per bitmap-set, active,
+ * non-self core. Never called with @p cpu_num equal to the calling
+ * core.
+ *
+ * @param cpu_num Target core to signal.
+ */
+void soc_ipi_trigger(int cpu_num);
+
+/**
+ * @brief Clear the pending IPI signal on the calling core.
+ *
+ * Called from xtensa_smp_ipi_isr() (the shared ISR), which runs on the
+ * core that just received the signal -- i.e. this always clears the
+ * *current* core's own pending state, never another core's.
+ */
+void soc_ipi_clear(void);
+
+/**
+ * @brief Shared secondary-core entry point.
+ *
+ * Not a hook -- implemented once in arch/xtensa/core/smp.c. Every SoC's
+ * own secondary-core boot trampoline must call this, in C, running on
+ * @p cpu_num, as its last step before Zephyr code is considered "up" on
+ * that core. Sets up the ZSR_CPU pointer for _kernel.cpus[cpu_num], calls
+ * soc_mp_startup_self(cpu_num), marks the core active, then calls the
+ * fn/arg pair that was passed to arch_cpu_start() for this core. Never
+ * returns.
+ *
+ * @param cpu_num The core this function is executing on.
+ */
+FUNC_NORETURN void xtensa_smp_secondary_start(int cpu_num);
+
+/**
+ * @brief Shared IPI ISR.
+ *
+ * Not a hook -- implemented once in arch/xtensa/core/smp.c. SoC code
+ * passes this as the handler argument when registering this core's own
+ * incoming IPI line inside its soc_mp_startup_self() implementation.
+ * Calls soc_ipi_clear() then z_sched_ipi().
+ *
+ * Deliberately takes a plain (non-const) void * to match
+ * intr_handler_t (see intc_esp32.h) -- the interrupt registration API
+ * ESP32's dynamic per-core interrupt matrix uses, as opposed to
+ * IRQ_CONNECT()'s static-table isr_handler_t. If a future SoC hook
+ * implementation needs IRQ_CONNECT() instead, it can wrap this
+ * function rather than changing its signature, since ESP32 is this
+ * layer's only consumer today and must match intr_handler_t exactly.
+ */
+void xtensa_smp_ipi_isr(void *arg);
+
+/**
+ * @brief Stack top for a core that has been told to start but hasn't
+ *        reached xtensa_smp_secondary_start() yet.
+ *
+ * Not a hook -- implemented once in arch/xtensa/core/smp.c. SoC boot
+ * trampolines run in assembly before any C stack exists, so they need
+ * this value to set up SP themselves prior to calling into
+ * xtensa_smp_secondary_start().
+ *
+ * @param cpu_num The core whose stack top to look up.
+ */
+void *xtensa_smp_cpu_stack_top(int cpu_num);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_SMP_H_ */

--- a/soc/espressif/esp32/Kconfig.defconfig
+++ b/soc/espressif/esp32/Kconfig.defconfig
@@ -12,6 +12,13 @@ config MAIN_STACK_SIZE
 config BUILD_OUTPUT_UF2_FAMILY_ID
 	default "0x1c5f21b0"
 
+# XTENSA_ESP32_SYS_TIMER (drivers/timer/Kconfig.xtensa_esp32) replaces the
+# generic XTENSA_TIMER driver for this SoC series -- see that Kconfig's
+# help text for why (CCOUNT/CCOMPARE are genuine per-core registers here,
+# unlike Xtensa SoCs with a shared external timer).
+config XTENSA_TIMER
+	default n if XTENSA_ESP32_SYS_TIMER
+
 if SMP
 
 config SCHED_CPU_MASK

--- a/soc/espressif/esp32/esp32-mp.c
+++ b/soc/espressif/esp32/esp32-mp.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018 Intel Corporation
  * Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
+ * Copyright (c) 2026 The Zephyr Project Contributors
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,25 +22,18 @@
 
 #ifdef CONFIG_SMP
 
-#include <ipi.h>
+#include <esp_rom_sys.h>
+#include <xt_instr_macros.h>
+#include <zephyr/arch/xtensa/smp.h>
 
-#ifndef CONFIG_SOC_ESP32_PROCPU
 static struct k_spinlock loglock;
-#endif
 
-struct cpustart_rec {
-	int cpu;
-	arch_cpustart_t fn;
-	char *stack_top;
-	void *arg;
-	int vecbase;
-	volatile int *alive;
-};
-
-volatile struct cpustart_rec *start_rec;
-static void *appcpu_top;
-static bool cpus_active[CONFIG_MP_MAX_NUM_CPUS];
-static struct k_spinlock loglock;
+/* VECBASE value for whichever secondary core is currently being started.
+ * ESP32 only ever starts core 1 (__ASSERT'd in soc_mp_start_core() below),
+ * so a single instance is enough -- no need for a per-core array the way
+ * the shared layer's own cpustart_rec[] needs one.
+ */
+static int appcpu_vecbase;
 
 /* Note that the logging done here is ACTUALLY REQUIRED FOR RELIABLE
  * OPERATION!  At least one particular board will experience spurious
@@ -82,84 +76,41 @@ static void appcpu_entry2(void)
 	 */
 	__asm__ volatile("rsr.PS %0" : "=r"(ps));
 	ps &= ~(XCHAL_PS_EXCM_MASK | XCHAL_PS_INTLEVEL_MASK);
+	/* Raise INTLEVEL before clearing INTENABLE below (not just to 0) so
+	 * stale INTENABLE bits left over from the ROM handoff can't let a
+	 * spurious interrupt fire before the wsr.INTENABLE below.
+	 */
+	ps |= XCHAL_EXCM_LEVEL;
 	__asm__ volatile("wsr.PS %0" : : "r"(ps));
 
 	ie = 0;
 	__asm__ volatile("wsr.INTENABLE %0" : : "r"(ie));
-	__asm__ volatile("wsr.VECBASE %0" : : "r"(start_rec->vecbase));
+	__asm__ volatile("wsr.VECBASE %0" : : "r"(appcpu_vecbase));
 	__asm__ volatile("rsync");
-
-	/* Set up the CPU pointer.  Really this should be xtensa arch
-	 * code, not in the ESP-32 layer
-	 */
-	_cpu_t *cpu = &_kernel.cpus[1];
-
-	__asm__ volatile("wsr %0, " ZSR_CPU_STR : : "r"(cpu));
 
 	smp_log("ESP32: APPCPU running");
 
-	*start_rec->alive = 1;
-	start_rec->fn(start_rec->arg);
+	/* Hands off to the shared Xtensa SMP layer (arch/xtensa/core/smp.c):
+	 * sets up the ZSR_CPU pointer, calls soc_mp_startup_self(1) (below)
+	 * to register this core's own incoming IPI line, marks this core
+	 * active, then calls the fn/arg pair arch_cpu_start() was given.
+	 * Never returns.
+	 */
+	xtensa_smp_secondary_start(1);
 }
 
-/* Defines a locally callable "function" named _stack-switch().  The
- * first argument (in register a2 post-ENTRY) is the new stack pointer
- * to go into register a1.  The second (a3) is the entry point.
- * Because this never returns, a0 is used as a scratch register then
- * set to zero for the called function (a null return value is the
- * signal for "top of stack" to the debugger).
+/* Direct ROM boot target -- an ordinary C function, matching ESP-IDF's
+ * call_start_cpu1() shape: runs on whatever SP the ROM handoff left in a1.
+ * Region 1 (0x20000000-0x3FFFFFFF) must be unlocked for RW before any code
+ * here touches DRAM (e.g. appcpu_entry2()'s locals) -- matches ESP-IDF's own
+ * esp_cpu_configure_region_protection(), called at the same point in
+ * call_start_cpu1().
  */
-void z_appcpu_stack_switch(void *stack, void *entry);
-__asm__("\n"
-	".align 4"		"\n"
-	"z_appcpu_stack_switch:"	"\n\t"
-
-	"entry a1, 16"		"\n\t"
-
-	/* Subtle: we want the stack to be 16 bytes higher than the
-	 * top on entry to the called function, because the ABI forces
-	 * it to assume that those bytes are for its caller's A0-A3
-	 * spill area.  (In fact ENTRY instructions with stack
-	 * adjustments less than 16 are a warning condition in the
-	 * assembler). But we aren't a caller, have no bit set in
-	 * WINDOWSTART and will never be asked to spill anything.
-	 * Those 16 bytes would otherwise be wasted on the stack, so
-	 * adjust
-	 */
-	"addi a1, a2, 16"	"\n\t"
-
-	/* Clear WINDOWSTART so called functions never try to spill
-	 * our callers' registers into the now-garbage stack pointers
-	 * they contain.  No need to set the bit corresponding to
-	 * WINDOWBASE, our C callee will do that when it does an
-	 * ENTRY.
-	 */
-	"movi a0, 0"		"\n\t"
-	"wsr.WINDOWSTART a0"	"\n\t"
-
-	/* Clear CALLINC field of PS (you would think it would, but
-	 * our ENTRY doesn't actually do that) so the callee's ENTRY
-	 * doesn't shift the registers
-	 */
-	"rsr.PS a0"		"\n\t"
-	"movi a2, 0xfffcffff"	"\n\t"
-	"and a0, a0, a2"	"\n\t"
-	"wsr.PS a0"		"\n\t"
-
-	"rsync"			"\n\t"
-	"movi a0, 0"		"\n\t"
-
-	"jx a3"			"\n\t");
-
-/* Carefully constructed to use no stack beyond compiler-generated ABI
- * instructions.  WE DO NOT KNOW WHERE THE STACK FOR THIS FUNCTION IS.
- * The ROM library just picks a spot on its own with no input from our
- * app linkage and tells us nothing about it until we're already
- * running.
- */
-static void appcpu_entry1(void)
+void appcpu_entry1(void)
 {
-	z_appcpu_stack_switch(appcpu_top, appcpu_entry2);
+	WDTLB(0x0, 0x20000000);
+
+	appcpu_entry2();
 }
 
 /* The calls and sequencing here were extracted from the ESP-32
@@ -167,16 +118,43 @@ static void appcpu_entry1(void)
  * calls or registers shown are documented, so treat this code with
  * extreme caution.
  */
+/* ESP32 (unlike every later Espressif chip) has two entirely separate flash
+ * MMU page-table hardware banks, one per core (DR_REG_FLASH_MMU_TABLE_PRO /
+ * _APP). Zephyr's image loader only ever populates PRO's table
+ * (mmu_hal_map_region() is hardcoded to core 0); APP's is left empty by
+ * reset_mmu()'s mmu_init(1) call and never filled in anywhere else in-tree.
+ * Without this copy, APPCPU has no valid mapping for its own flash-cached
+ * (IROM) code. Matches ESP-IDF's restore_app_mmu_from_pro_mmu().
+ */
+static void restore_app_mmu_from_pro_mmu(void)
+{
+	volatile uint32_t *from = (volatile uint32_t *)DR_REG_FLASH_MMU_TABLE_PRO;
+	volatile uint32_t *to = (volatile uint32_t *)DR_REG_FLASH_MMU_TABLE_APP;
+
+	/* Matches ESP-IDF's restore_app_mmu_from_pro_mmu() mmu_reg_num exactly. */
+	for (int i = 0; i < 2048; i++) {
+		*(to++) = *(from++);
+	}
+}
+
 void esp_appcpu_start(void *entry_point)
 {
 	ets_printf("ESP32: starting APPCPU");
 
-	/* These two calls are wrapped in a "stall_other_cpu" API in
-	 * esp-idf.  But in this context the appcpu is stalled by
-	 * definition, so we can skip that complexity and just call
-	 * the ROM directly.
+	/* Cache must stay disabled while the MMU table below is being
+	 * overwritten, under the DPORT_APP_CACHE_MMU_IA_CLR erratum guard --
+	 * a real Xtensa/ESP32 hardware erratum (see Zephyr's own reset_mmu(),
+	 * which does the same for PRO_CPU). Enabling cache read before the
+	 * table write, or skipping the guard, makes APPCPU's first
+	 * flash-cached instruction fetch stall forever with no exception.
 	 */
+	esp_rom_Cache_Read_Disable(1);
 	esp_rom_Cache_Flush(1);
+
+	DPORT_SET_PERI_REG_MASK(DPORT_APP_CACHE_CTRL1_REG, DPORT_APP_CACHE_MMU_IA_CLR);
+	restore_app_mmu_from_pro_mmu();
+	DPORT_CLEAR_PERI_REG_MASK(DPORT_APP_CACHE_CTRL1_REG, DPORT_APP_CACHE_MMU_IA_CLR);
+
 	esp_rom_Cache_Read_Enable(1);
 
 	esp_rom_ets_set_appcpu_boot_addr((void *)0);
@@ -186,121 +164,82 @@ void esp_appcpu_start(void *entry_point)
 	DPORT_SET_PERI_REG_MASK(DPORT_APPCPU_CTRL_A_REG, DPORT_APPCPU_RESETTING);
 	DPORT_CLEAR_PERI_REG_MASK(DPORT_APPCPU_CTRL_A_REG, DPORT_APPCPU_RESETTING);
 
-	/* extracted from SMP LOG above, THIS IS REQUIRED FOR AMP RELIABLE
-	 * OPERATION AS WELL, PLEASE DON'T touch on the dummy write below!
-	 *
-	 * Note that the logging done here is ACTUALLY REQUIRED FOR RELIABLE
-	 * OPERATION!  At least one particular board will experience spurious
-	 * hangs during initialization (usually the APPCPU fails to start at
-	 * all) without these calls present.  It's not just time -- careful
-	 * use of k_busy_wait() (and even hand-crafted timer loops using the
-	 * Xtensa timer SRs directly) that duplicates the timing exactly still
-	 * sees hangs.  Something is happening inside the ROM UART code that
-	 * magically makes the startup sequence reliable.
-	 *
-	 * Leave this in place until the sequence is understood better.
-	 *
-	 */
-	esp_rom_output_tx_one_char('\r');
-	esp_rom_output_tx_one_char('\r');
-	esp_rom_output_tx_one_char('\n');
-
 	/* Seems weird that you set the boot address AFTER starting
 	 * the CPU, but this is how they do it...
 	 */
 	esp_rom_ets_set_appcpu_boot_addr((void *)entry_point);
 
-	ets_printf("ESP32: APPCPU start sequence complete");
+	/* mcuboot's appcpu_start() follows the boot-address write with a real
+	 * 10ms delay plus a wait for the UART to actually finish transmitting,
+	 * not just a couple of dummy character writes -- matching that here
+	 * instead of guessing at the timing.
+	 */
+	esp_rom_delay_us(10000);
+	esp_rom_output_tx_wait_idle(0);
 }
 
-IRAM_ATTR static void esp_crosscore_isr(void *arg)
+void soc_mp_start_core(int cpu_num)
 {
-	ARG_UNUSED(arg);
-
-	/* Right now this interrupt is only used for IPIs */
-	z_sched_ipi();
-
-	const int core_id = esp_core_id();
-
-	if (core_id == 0) {
-		DPORT_WRITE_PERI_REG(DPORT_CPU_INTR_FROM_CPU_0_REG, 0);
-	} else {
-		DPORT_WRITE_PERI_REG(DPORT_CPU_INTR_FROM_CPU_1_REG, 0);
-	}
-}
-
-void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
-		    arch_cpustart_t fn, void *arg)
-{
-	volatile struct cpustart_rec sr;
-	int vb;
-	volatile int alive_flag;
-
 	__ASSERT(cpu_num == 1, "ESP-32 supports only two CPUs");
 
-	__asm__ volatile("rsr.VECBASE %0\n\t" : "=r"(vb));
-
-	alive_flag = 0;
-
-	sr.cpu = cpu_num;
-	sr.fn = fn;
-	sr.stack_top = K_KERNEL_STACK_BUFFER(stack) + sz;
-	sr.arg = arg;
-	sr.vecbase = vb;
-	sr.alive = &alive_flag;
-
-	appcpu_top = K_KERNEL_STACK_BUFFER(stack) + sz;
-
-	start_rec = &sr;
+	__asm__ volatile("rsr.VECBASE %0\n\t" : "=r"(appcpu_vecbase));
 
 	esp_appcpu_start(appcpu_entry1);
-
-	while (!alive_flag) {
-	}
-
-	cpus_active[0] = true;
-	cpus_active[cpu_num] = true;
-
-	esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(ipi0), 0, irq),
-		ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(ipi0), 0, priority)) |
-		ESP_INT_FLAGS_CHECK(DT_IRQ_BY_IDX(DT_NODELABEL(ipi0), 0, flags)) |
-			ESP_INTR_FLAG_IRAM,
-		esp_crosscore_isr,
-		NULL,
-		NULL);
-
-	esp_intr_alloc(DT_IRQ_BY_IDX(DT_NODELABEL(ipi1), 0, irq),
-		ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(ipi1), 0, priority)) |
-		ESP_INT_FLAGS_CHECK(DT_IRQ_BY_IDX(DT_NODELABEL(ipi1), 0, flags)) |
-			ESP_INTR_FLAG_IRAM,
-		esp_crosscore_isr,
-		NULL,
-		NULL);
-
-	smp_log("ESP32: APPCPU initialized");
 }
 
-void arch_sched_directed_ipi(uint32_t cpu_bitmap)
+void soc_mp_startup_self(int cpu_num)
 {
-	const int core_id = esp_core_id();
+	int ret;
 
-	ARG_UNUSED(cpu_bitmap);
+	/* ipi0 (FROM_CPU_INTR0_SOURCE, tied to DPORT_CPU_INTR_FROM_CPU_0_REG)
+	 * is core 1's own incoming line: it fires when core 0 writes that
+	 * register. ipi1/FROM_CPU_1 is the mirror image, core 0's own
+	 * incoming line. Each core registers only its own line, on itself
+	 * -- this is the structural fix for the bug where both lines used
+	 * to be registered while executing on PRO_CPU only, leaving
+	 * APPCPU's own line (ipi0) never actually enabled on APPCPU.
+	 */
+	if (cpu_num == 0) {
+		ret = esp_intr_alloc(
+			DT_IRQ_BY_IDX(DT_NODELABEL(ipi1), 0, irq),
+			ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(ipi1), 0, priority)) |
+				ESP_INT_FLAGS_CHECK(DT_IRQ_BY_IDX(DT_NODELABEL(ipi1), 0, flags)) |
+				ESP_INTR_FLAG_IRAM,
+			xtensa_smp_ipi_isr, NULL, NULL);
+	} else {
+		ret = esp_intr_alloc(
+			DT_IRQ_BY_IDX(DT_NODELABEL(ipi0), 0, irq),
+			ESP_PRIO_TO_FLAGS(DT_IRQ_BY_IDX(DT_NODELABEL(ipi0), 0, priority)) |
+				ESP_INT_FLAGS_CHECK(DT_IRQ_BY_IDX(DT_NODELABEL(ipi0), 0, flags)) |
+				ESP_INTR_FLAG_IRAM,
+			xtensa_smp_ipi_isr, NULL, NULL);
 
-	if (core_id == 0) {
+		smp_log("ESP32: APPCPU initialized");
+	}
+
+	/* A silently-unregistered IPI line here means this core's own incoming
+	 * IPI signal is lost forever -- no exception, no crash, just missed
+	 * scheduler wake-ups on this core. Fail loud instead.
+	 */
+	__ASSERT(ret == 0, "failed to register CPU %d IPI line: %d", cpu_num, ret);
+}
+
+void soc_ipi_trigger(int cpu_num)
+{
+	if (cpu_num == 1) {
 		DPORT_WRITE_PERI_REG(DPORT_CPU_INTR_FROM_CPU_0_REG, DPORT_CPU_INTR_FROM_CPU_0);
 	} else {
 		DPORT_WRITE_PERI_REG(DPORT_CPU_INTR_FROM_CPU_1_REG, DPORT_CPU_INTR_FROM_CPU_1);
 	}
 }
 
-void arch_sched_broadcast_ipi(void)
+void soc_ipi_clear(void)
 {
-	arch_sched_directed_ipi(IPI_ALL_CPUS_MASK);
-}
-
-IRAM_ATTR bool arch_cpu_active(int cpu_num)
-{
-	return cpus_active[cpu_num];
+	if (esp_core_id() == 0) {
+		DPORT_WRITE_PERI_REG(DPORT_CPU_INTR_FROM_CPU_1_REG, 0);
+	} else {
+		DPORT_WRITE_PERI_REG(DPORT_CPU_INTR_FROM_CPU_0_REG, 0);
+	}
 }
 #endif /* CONFIG_SMP */
 

--- a/soc/espressif/esp32/soc.h
+++ b/soc/espressif/esp32/soc.h
@@ -41,6 +41,7 @@ extern int esp_rom_gpio_matrix_out(uint32_t gpio, uint32_t signal_index,
 
 extern void esp_rom_Cache_Flush(int cpu);
 extern void esp_rom_Cache_Read_Enable(int cpu);
+extern void esp_rom_Cache_Read_Disable(int cpu);
 extern void esp_rom_ets_set_appcpu_boot_addr(void *addr);
 void esp_appcpu_start(void *entry_point);
 


### PR DESCRIPTION
## Depends on

**zephyrproject-rtos/hal_espressif#618** -- adds the `esp_rom_Cache_Read_Disable`
ROM alias this branch's cache/MMU erratum fix needs. This PR will not link
without it. Opening as draft until that's resolved (merged, or the
`hal_espressif` manifest pin here is updated to include it).

## Summary

The need for SMP on the Esp32 arises when using Zephyr as a like for like replacement of esp-idf. 

Original ESP32 (Xtensa, dual PRO_CPU/APPCPU) has never had working
`CONFIG_SMP` in Zephyr (#56011). This adds a real, hardware-validated
implementation, scoped to the no-WiFi case -- `WIFI_ESP32` keeps its
existing `depends on !SMP`; making WiFi itself SMP-safe is a separate,
unstarted effort.

* Adds a shared Xtensa SMP core layer (`arch/xtensa/core/smp.c`, previously
  a stub, plus a new `include/zephyr/arch/xtensa/smp.h` hook interface),
  modeled on the shape `soc/intel/intel_adsp` already uses internally, now
  factored out so other Xtensa SoCs can implement the same four hooks
  (`soc_mp_start_core()`, `soc_mp_startup_self()`, `soc_ipi_trigger()`,
  `soc_ipi_clear()`) instead of hand-rolling their own boot/IPI state
  machine.
* ESP32's hook implementation (`soc/espressif/esp32/esp32-mp.c`) fixes two
  structural bugs in the process: the APPCPU incoming IPI handler was being
  registered while executing on PRO_CPU (never actually enabled on APPCPU
  itself), and `arch_sched_directed_ipi()` ignored its `cpu_bitmap` argument
  entirely.
* Root cause of the APPCPU boot hang: `z_smp_global_lock()` (what
  `irq_lock()` becomes under `CONFIG_SMP`) dereferences
  `_current->base.global_lock_count`. PRO_CPU's own call into this already
  worked because `z_cstart()` calls `z_dummy_thread_init()` first; secondary
  cores previously only got their dummy thread set up later, after code
  needing a valid `_current` had already run and silently stalled forever
  with no exception. Fixed by moving `z_dummy_thread_init()` earlier in
  `xtensa_smp_secondary_start()`.
* Two more real hardware issues fixed, both required for APPCPU to reliably
  execute flash-cached code: original ESP32's two separate flash-MMU
  page-table banks (one per core) need an explicit copy
  (`restore_app_mmu_from_pro_mmu()`, matching ESP-IDF's own equivalent), and
  the flash MMU table must be written with cache read disabled under the
  `DPORT_APP_CACHE_MMU_IA_CLR` erratum guard (this is the piece needing the
  linked `hal_espressif` PR).
* Adds a per-core system timer driver
  (`drivers/timer/xtensa_esp32_sys_timer.c`): original ESP32's
  CCOUNT/CCOMPARE are genuine per-core Xtensa registers, unlike Xtensa SoCs
  with a shared external timer, so the generic `XTENSA_TIMER` driver's
  single shared `last_count` silently mixed two cores' unrelated CCOUNT
  bases. Gated to `CONFIG_SMP` only; non-SMP ESP32 builds are unaffected.
* Adds a 100ms settle delay after both cores are confirmed up, before either
  touches flash-heavy code (NVS/settings). Documented honestly as not fully
  explained -- confirmed on real hardware, repeatedly, to prevent both an
  intermittent APPCPU hang and a separate spurious watchdog reset loop that
  otherwise occur a few seconds into a run.
* Fixes an unrelated, pre-existing bug found during review:
  `drivers/interrupt_controller/intc_esp32.c`'s `intr_has_handler()` indexed
  `_sw_isr_table` as `intr * CONFIG_MP_MAX_NUM_CPUS + cpu`, but the table has
  no per-CPU dimension on Xtensa at all (confirmed against both the real
  dispatch code and the real handler-install path, which both index it as
  plain `intr`). This was wrong whenever `CONFIG_MP_MAX_NUM_CPUS > 1`, and
  also wrong in single-core AMP images physically executing on APPCPU, since
  `esp_core_id()` reads real hardware regardless of that build's own
  Kconfig -- a real, if previously unnoticed, exposure independent of this
  PR's SMP work.

## Test plan

- [x] Built and flashed on real ESP32-D0WD-V3 (rev 3.1) hardware, via
      ESPHome's platform-zephyr, repeatedly across many restarts.
- [x] Both cores confirmed booting and running independent, correctly
      pinned application threads (via `k_thread_cpu_pin()`), with stable,
      non-bouncing per-core logging.
- [x] Confirmed no regression to `!CONFIG_SMP` ESP32 builds -- re-tested
      both configurations after auditing every change for accidental
      leakage into the non-SMP path (found and fixed one: the new timer
      driver's Kconfig defaulted on unconditionally rather than only under
      `SMP`).
- [x] `scripts/ci/check_compliance.py` clean: zero failures, zero warnings.