### PR TITLE
boards: seeed: xiao_nrf54lm20a: fix nPM1300 gpio-i2c pins

### DIFF
--- a/boards/seeed/xiao_nrf54lm20a/doc/index.rst
+++ b/boards/seeed/xiao_nrf54lm20a/doc/index.rst
@@ -115,9 +115,9 @@ means Pin number 0 on PORT1, as used in the board's datasheets and manuals.
 +-------+-------------+--------------------------+
 | P1_12 | GPIO        | Power Enable             |
 +-------+-------------+--------------------------+
-| P1_15 | GPIO        | PMIC I2C SDA             |
+| P1_18 | GPIO        | PMIC I2C SDA             |
 +-------+-------------+--------------------------+
-| P1_16 | GPIO        | PMIC I2C SCL             |
+| P1_17 | GPIO        | PMIC I2C SCL             |
 +-------+-------------+--------------------------+
 | P1_13 | PDM20_CLK   | DMIC Clock               |
 +-------+-------------+--------------------------+

--- a/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a-common.dtsi
+++ b/boards/seeed/xiao_nrf54lm20a/xiao_nrf54lm20a_nrf54lm20a-common.dtsi
@@ -56,8 +56,8 @@
 		compatible = "gpio-i2c";
 		#address-cells = <1>;
 		#size-cells = <0>;
-		sda-gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
-		scl-gpios = <&gpio1 16 GPIO_ACTIVE_HIGH>;
+		sda-gpios = <&gpio1 18 GPIO_ACTIVE_HIGH>;
+		scl-gpios = <&gpio1 17 GPIO_ACTIVE_HIGH>;
 		clock-frequency = <100000>;
 		status = "okay";
 


### PR DESCRIPTION
Fixes #114567.

The bit-banged I2C bus to the on-board nPM1300 was wired to P1.15 (SDA) and
P1.16 (SCL). The Seeed XIAO nRF54LM20A V1.0 schematic (sheets 4 and 6) shows
those pins as not connected to the PMIC; the actual nets are `PMIC_SDA` on
P1.18 and `PMIC_SCL` on P1.17, with 4.7 kOhm pull-ups to VSYS_3V3. The I2C
address (0x6b) was already correct.

Verified on five boards: every PMIC read returns 0 mV with the current
definition, and all five report plausible values (4165-4174 mV, USB powered
with no battery attached) after the change.

Third-party confirmation: Seeed's own `platform-seeedboards` battery example
ships an overlay carrying exactly this change (`sda=18` / `scl=17`), so the
hardware side is not in dispute.

The pin table in the board documentation is updated to match.

One pitfall for anyone reproducing this: do not swap SDA and SCL. A test
overlay using `sda=17` / `scl=18` also yields 0 mV and looks like the pins
were disproven.
