### PR TITLE
boards: nucode: document NU32 J-Link connections

### DIFF
--- a/boards/nucode/nucode_nu32/doc/index.rst
+++ b/boards/nucode/nucode_nu32/doc/index.rst
@@ -70,10 +70,13 @@ NUCODE_JTAG Adapter.  The minimum SWD connection is:
    * - SWDIO
      - SWDIO
      - SWD data
+   * - nRESET (nRST)
+     - RESET (P0.21)
+     - Target reset
 
 The target must be powered and VTARGET must be connected before starting a
-debug session.  Keep the SWD leads short.  The RESET signal can optionally be
-connected to P0.21 if reset control from the debug probe is required.
+debug session.  Keep the SWD leads short.  Connect nRESET to P0.21 so the
+debug probe can reliably reset and recover the target.
 
 Programming and Debugging
 *************************

--- a/boards/nucode/nucode_nu32/doc/index.rst
+++ b/boards/nucode/nucode_nu32/doc/index.rst
@@ -46,6 +46,35 @@ SWD
 
 * The SWDCLK and SWDIO debug pads are used for flashing and debugging.
 
+NUCODE_JTAG Adapter
+-------------------
+
+The NU32-B-Dev04 carrier can be connected to an external J-Link through a
+NUCODE_JTAG Adapter.  The minimum SWD connection is:
+
+.. list-table:: SWD connection
+   :header-rows: 1
+
+   * - NUCODE_JTAG Adapter
+     - NU32-B-Dev04
+     - Description
+   * - VTARGET
+     - VCC or VTARGET
+     - Target voltage reference
+   * - GND
+     - GND
+     - Common ground
+   * - SWDCLK
+     - SWDCLK
+     - SWD clock
+   * - SWDIO
+     - SWDIO
+     - SWD data
+
+The target must be powered and VTARGET must be connected before starting a
+debug session.  Keep the SWD leads short.  The RESET signal can optionally be
+connected to P0.21 if reset control from the debug probe is required.
+
 Programming and Debugging
 *************************
 
@@ -68,12 +97,22 @@ to the SWD pads.
       :zephyr-app: samples/hello_world
       :board: nucode_nu32/nrf52832
       :goals: build flash
+      :flash-args: -r jlink
 
 #. Open a serial terminal (115200 8N1) connected to the UART0 pins and
    reset the board to see the output.
 
+If more than one J-Link is connected to the host, select the probe by appending
+``--dev-id <serial-number>`` to the ``west flash`` command.
+
 Debugging
 =========
+
+Start a debug session with J-Link:
+
+.. code-block:: console
+
+   $ west debug -r jlink
 
 Refer to the :ref:`application_run` page for more details on debugging.
 


### PR DESCRIPTION
## Summary

- document the minimum four-wire SWD connection between the NUCODE_JTAG Adapter and NU32-B-Dev04
- make the J-Link runner explicit in the flashing example
- document multi-probe selection and the J-Link debug command

## Why

The existing board page only refers to generic SWD pads. It does not describe the target-voltage reference, signal mapping, or runner selection needed to connect and use the NUCODE_JTAG Adapter with an external J-Link.

## Hardware validation

Validated on an NU32-B-Dev04 with a NUCODE_JTAG Adapter and J-Link EDU Mini V2:

- target detected over the documented four-wire SWD connection
- `west flash -r jlink` completed at 4 MHz
- the `samples/hello_world` boot message was observed over RTT

## Checks

- `sphinx-lint boards/nucode/nucode_nu32/doc/index.rst`
- `git diff --check`
