### PR TITLE
drivers: clock_control: preserve STM32N6 boot clocks

### DIFF
--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -119,4 +119,23 @@ config CLOCK_STM32_MCO_HAS_ENABLE_BIT
 	help
 	  Hidden option indicating the series has a dedicated bit to enable MCO output
 
+config CLOCK_STM32_N6_PRESERVE_BOOT_CONFIG
+	bool "Preserve STM32N6 boot clock configuration"
+	depends on SOC_SERIES_STM32N6X
+	depends on BOOTLOADER_MCUBOOT
+	depends on DT_HAS_ST_STM32_XSPI_NOR_ENABLED || \
+		DT_HAS_ST_STM32_XSPI_PSRAM_ENABLED
+	help
+	  Preserve the retained clock configuration for STM32N6 applications
+	  chain-loaded by MCUboot. The application may execute from external XSPI
+	  NOR or PSRAM initialized by the bootloader.
+
+	  The bootloader is expected to have initialized the retained clock tree and
+	  external-memory controller. Application-domain oscillator, PLL,
+	  interconnect, prescaler, IC, and SYSCLK configuration is intentionally not
+	  repeated.
+
+	  The application's devicetree must describe the retained clock and
+	  external-memory hardware state.
+
 endif # CLOCK_CONTROL_STM32_CUBE

--- a/drivers/clock_control/clock_stm32_ll_n6.c
+++ b/drivers/clock_control/clock_stm32_ll_n6.c
@@ -958,6 +958,21 @@ int stm32_clock_control_init(const struct device *dev)
 	LL_MEM_EnableClock(misc_ram);
 	LL_MEM_EnableClockLowPower(misc_ram);
 
+	/*
+	 * A chain-loading bootloader is expected to have initialized the clock tree
+	 * and external XSPI memory used by the application. Reinitializing the
+	 * application-domain RCC can make that memory inaccessible while code or
+	 * data is being fetched. Keep the SRAM gate setup above, preserve the
+	 * retained clock configuration, and refresh the CMSIS clock value.
+	 *
+	 * The application's devicetree must describe the retained clock and
+	 * external-memory configuration.
+	 */
+	if (IS_ENABLED(CONFIG_CLOCK_STM32_N6_PRESERVE_BOOT_CONFIG)) {
+		SystemCoreClockUpdate();
+		return 0;
+	}
+
 	/* Set up individual enabled clocks */
 	set_up_fixed_clock_sources();
 


### PR DESCRIPTION
Chain-loaded STM32N6 applications can execute from external memory whose controller depends on the bootloader clock tree. Add an opt-in mode that enables the SRAM clocks but leaves oscillator, PLL, interconnect, prescaler, and system-clock configuration unchanged.

Assisted-by: OpenCode:gpt-5.6-sol