### PR TITLE
scripts: build: fix relocation region and metadata parsing

### DIFF
--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -81,11 +81,19 @@ class SectionKind(Enum):
         """
         Return the kind of section that includes a section with the given name.
 
-        >>> SectionKind.for_section_with_name(".rodata.str1.4")
+        >>> SectionKind.for_section_named(".rodata.str1.4")
         <SectionKind.RODATA: 'rodata'>
-        >>> SectionKind.for_section_with_name(".device_deps")
-        None
+        >>> SectionKind.for_section_named(".device_deps") is None
+        True
+        >>> SectionKind.for_section_named(".rel.text.foo") is None
+        True
+        >>> SectionKind.for_section_named(".ARM.exidx.text.foo") is None
+        True
         """
+        if name in (".rel", ".rela") or name.startswith((".rel.", ".rela.")):
+            return None
+        if name.startswith((".ARM.exidx", ".ARM.extab")):
+            return None
         if ".text." in name:
             return cls.TEXT
         elif ".rodata." in name:

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -293,14 +293,13 @@ def assign_to_correct_mem_region(
     """
     use_section_kinds, memory_region = section_kinds_from_memory_region(memory_region)
 
-    # Split |COPY/|NOKEEP flags before the numeric align suffix, else a region
-    # like "SRAM_4|COPY" makes int("4|COPY") throw.
-    memory_region, sep, flags = memory_region.partition('|')
-    flags = sep + flags
-    memory_region, _, align_size = memory_region.partition('_')
+    memory_region, *flags = memory_region.split('|')
+    memory_region, align_size = split_alignment_suffix(memory_region)
     if align_size:
         mpu_align[memory_region] = int(align_size)
-    memory_region = memory_region + flags
+
+    if flags:
+        memory_region = '|'.join((memory_region, *flags))
 
     keep_sections = '|NOKEEP' not in memory_region
     memory_region = memory_region.replace('|NOKEEP', '')
@@ -313,6 +312,24 @@ def assign_to_correct_mem_region(
         ]
 
     return {MemoryRegion(memory_region): output_sections}
+
+
+def split_alignment_suffix(memory_region: str) -> 'tuple[str, str]':
+    """
+    Split a final numeric alignment suffix from a memory region name.
+
+    >>> split_alignment_suffix('SRAM_FAST')
+    ('SRAM_FAST', '')
+    >>> split_alignment_suffix('SRAM_FAST_32')
+    ('SRAM_FAST', '32')
+    >>> split_alignment_suffix('SRAM_FAST_TEXT')
+    ('SRAM_FAST_TEXT', '')
+    """
+    memory_region_base, sep, align_size = memory_region.rpartition('_')
+    if sep and align_size.isdecimal():
+        return memory_region_base, align_size
+
+    return memory_region, ''
 
 
 def section_kinds_from_memory_region(memory_region: str) -> 'tuple[set[SectionKind], str]':

--- a/scripts/tests/build/test_gen_relocate_app.py
+++ b/scripts/tests/build/test_gen_relocate_app.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections import defaultdict
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[2] / "build" / "gen_relocate_app.py"
+SPEC = importlib.util.spec_from_file_location("gen_relocate_app", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+gen_relocate_app = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(gen_relocate_app)
+
+
+def test_numeric_alignment_suffix_follows_region_name():
+    gen_relocate_app.mpu_align = {}
+    sections = defaultdict(list)
+    sections[gen_relocate_app.SectionKind.TEXT].append(
+        gen_relocate_app.OutputSection("file.c.obj", ".text.function")
+    )
+
+    result = gen_relocate_app.assign_to_correct_mem_region(
+        "SRAM_FAST_TEXT_32|COPY|NOKEEP", sections
+    )
+
+    assert list(result) == ["SRAM_FAST|COPY"]
+    assert gen_relocate_app.mpu_align == {"SRAM_FAST": 32}
+    assert result["SRAM_FAST|COPY"][gen_relocate_app.SectionKind.TEXT] == [
+        gen_relocate_app.OutputSection("file.c.obj", ".text.function", keep=False)
+    ]
+
+
+def test_non_numeric_suffix_remains_part_of_region_name():
+    assert gen_relocate_app.split_alignment_suffix("SRAM_FAST") == ("SRAM_FAST", "")

--- a/scripts/tests/build/test_gen_relocate_app.py
+++ b/scripts/tests/build/test_gen_relocate_app.py
@@ -34,3 +34,20 @@ def test_numeric_alignment_suffix_follows_region_name():
 
 def test_non_numeric_suffix_remains_part_of_region_name():
     assert gen_relocate_app.split_alignment_suffix("SRAM_FAST") == ("SRAM_FAST", "")
+
+
+def test_relocation_metadata_is_not_classified_as_code():
+    for name in (".rel.text.function", ".rela.text.function"):
+        assert gen_relocate_app.SectionKind.for_section_named(name) is None
+
+
+def test_arm_unwind_metadata_is_not_classified_as_code():
+    for name in (".ARM.exidx.text.function", ".ARM.extab.text.function"):
+        assert gen_relocate_app.SectionKind.for_section_named(name) is None
+
+
+def test_regular_code_section_is_still_classified():
+    assert (
+        gen_relocate_app.SectionKind.for_section_named(".text.function")
+        is gen_relocate_app.SectionKind.TEXT
+    )


### PR DESCRIPTION
## Summary

Fix `gen_relocate_app.py` handling of underscored relocation-region names
and ELF metadata sections.

## Problem

Relocation locations can refer to Devicetree memory regions whose names
contain underscores. For example:

```dts
/ {
	axisram_safe: memory@34010000 {
		compatible = "zephyr,memory-region", "mmio-sram";
		reg = <0x34010000 0x00008000>;
		zephyr,memory-region = "AXISRAM_SAFE";
		zephyr,memory-region-flags = "rxw";
		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
		status = "okay";
	};
};
```

Application code can then be relocated into the text sections of this
region:

```
zephyr_code_relocate(
  FILES ${ZEPHYR_BASE}/arch/arm/core/cortex_m/cache.c
  LOCATION AXISRAM_SAFE_TEXT
)
```

Previously, gen_relocate_app.py removed _TEXT, then split the remaining
AXISRAM_SAFE name at its first underscore. It interpreted SAFE as a
numeric alignment suffix and failed while generating the relocation linker
script.
The same problem affects names such as AXISRAM_APP, PSRAM_EXEC, and
PSRAM_DATA.

## Changes
- Parse only a final numeric component as an alignment suffix.
- Preserve underscores in the actual memory-region name.
- Preserve COPY, NOCOPY, and NOKEEP relocation flags.
- Ignore ELF relocation sections before section classification.
- Ignore ARM exception and unwind metadata sections that contain .text.
in their names.

For example:
AXISRAM_SAFE_TEXT     -> region AXISRAM_SAFE, select TEXT sections
AXISRAM_SAFE_TEXT_32  -> region AXISRAM_SAFE, select TEXT, suffix 32
AXISRAM_APP            -> region AXISRAM_APP, no alignment suffix
The generated relocation section for the first example is based on the
AXISRAM_SAFE region and contains only the selected text sections.
The following metadata sections are now excluded instead of being treated
as executable code:
.rel.text.cache
.rela.text.cache
.ARM.exidx.text.cache
.ARM.extab.text.cache