### PR TITLE
drivers: spi: nxp_lpspi: release native CS on spi_release()

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -94,6 +94,18 @@ int lpspi_wait_tx_fifo_empty(const struct device *dev)
 int spi_lpspi_release(const struct device *dev, const struct spi_config *spi_cfg)
 {
 	struct lpspi_data *data = dev->data;
+	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
+
+	/*
+	 * lpspi_end_xfer() only clears TCR CONT/CONTC when SPI_HOLD_ON_CS is
+	 * absent from the transfer's config, so that transfers within a
+	 * HOLD_ON_CS transaction keep native (non-GPIO) CS asserted between
+	 * spi_transceive() calls. But once the caller is done with the whole
+	 * transaction and explicitly calls spi_release(), CS must actually be
+	 * released - clear them here so native CS doesn't stay asserted
+	 * indefinitely after a HOLD_ON_CS transaction.
+	 */
+	base->TCR &= ~(LPSPI_TCR_CONT_MASK | LPSPI_TCR_CONTC_MASK);
 
 	spi_context_unlock_unconditionally(&data->ctx);
 


### PR DESCRIPTION
## Description

`lpspi_end_xfer()` only clears TCR `CONT`/`CONTC` when `SPI_HOLD_ON_CS`
is absent from the transfer's config, so that consecutive
`spi_transceive()` calls within a `SPI_HOLD_ON_CS` transaction keep
native (non-GPIO) CS asserted between transfers, as intended.

However, once the caller finishes the whole transaction and calls
`spi_release()`, those bits were never cleared, leaving native CS
asserted indefinitely. `spi_context_unlock_unconditionally()` already
force-releases GPIO-based CS via `_spi_context_cs_control(ctx, false,
true)`, but has no way to know about the LPSPI-specific TCR bits used
for native CS.

This clears TCR `CONT`/`CONTC` directly in `spi_lpspi_release()` so
that `spi_release()` actually deasserts native CS as its API contract
implies, matching the existing GPIO CS release behavior.

## Testing

Confirmed on real hardware (FRDM-MCXN947, LPSPI1 native PCS0, via a
logic analyzer): CS previously stayed low indefinitely after the
first `SPI_HOLD_ON_CS` transaction; with this fix CS correctly returns
high after each `spi_release()`.

This surfaced through the Arduino Zephyr core's SPI API
(arduino/ArduinoCore-zephyr), which always sets `SPI_HOLD_ON_CS` to
support multiple `transfer()` calls per transaction.