### PR TITLE
net: coap: bound Uri-Query comparison loop in match_path_uri

### DIFF
--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -81,6 +81,10 @@ static bool match_path_uri(const char * const *path,
 			k = i;
 
 			for (j = 0; j < plen; j++) {
+				if (k >= len) {
+					goto next;
+				}
+
 				if (uri[k] == '*') {
 					if ((k + 1) == len) {
 						return true;

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -451,6 +451,8 @@ ZTEST(coap, test_match_path_uri)
 		"devnull",
 		NULL
 	};
+	/* Deliberately not NUL terminated, see below. */
+	const char unterminated[] = { '/', 'f', 'o', 'o', 'b' };
 	const char *uri;
 	int r;
 
@@ -481,6 +483,17 @@ ZTEST(coap, test_match_path_uri)
 	uri = "/devnull*";
 	r = _coap_match_path_uri(resource_path, uri, strlen(uri));
 	zassert_false(r, "Matching %s failed", uri);
+
+	r = _coap_match_path_uri(resource_path, unterminated,
+				 sizeof(unterminated));
+	zassert_false(r, "Matching a non-terminated URI failed");
+
+	/* The same length guard is crossed by a URI that does match: with
+	 * len 8, "foobar3a" runs past the end while "foobar3" still matches.
+	 */
+	uri = "/foobar3a";
+	r = _coap_match_path_uri(resource_path, uri, strlen(uri) - 1);
+	zassert_true(r, "Matching %s truncated to 8 bytes failed", uri);
 }
 
 #define BLOCK_WISE_TRANSFER_SIZE_GET 150


### PR DESCRIPTION
match_path_uri() compares a resource path against the URI carried in a
Uri-Query option. That URI points straight into the received packet
buffer and is not NUL terminated, but the inner path character loop
advanced k for every path character without ever checking it against
len. A query such as "?href=/foob", aimed at an application that
registers a "foobar" resource, therefore walked past the end of the
option value, and past the end of the packet buffer when the option is
the last thing in the packet.

The over-read cannot change the result: returning true requires either
k == len or k + 1 == len, both in bounds, so bytes beyond the option
only ever steer the loop towards the next candidate path. The impact is
the undefined behaviour and the fault it may cause, not a matching
error or an information leak back to the requester.

Add a "k >= len" guard at the top of the inner loop. The check has to
stay inside the loop: hoisting it into a "plen > len - i" test in front
of the loop would also reject a trailing wildcard, so that "/ab*" would
stop matching a path such as "abcdefgh".

Extend test_match_path_uri with a URI built without a NUL terminator,
so that the over-read is trapped when the suite is run under a
sanitizer, and with a URI whose length is shorter than its buffer to
cover the guard on a path that does match.

Fixes: #114902