### PR TITLE
boards: heltec: fix T114 V2 button polarity

### DIFF
--- a/boards/heltec/heltec_t114_v2/heltec_t114_v2_nrf52840_common.dts
+++ b/boards/heltec/heltec_t114_v2/heltec_t114_v2_nrf52840_common.dts
@@ -71,7 +71,7 @@
 		compatible = "gpio-keys";
 
 		button0: button_0 {
-			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 			label = "Button 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};


### PR DESCRIPTION
## Summary

- describe the Heltec T114 V2 user button on P1.10 as active low
- make the logical button state match the electrical behavior

The button is pulled high when released and reads low when pressed. With
`GPIO_ACTIVE_HIGH`, Zephyr therefore reports both states inverted.

## Validation

Tested on real `heltec_t114_v2/nrf52840/uf2` hardware with a
display-assisted GPIO diagnostic application.

| Released | Pressed |
|:---:|:---:|
| <img width="960" height="540" alt="heltec-t114-button-released-simulated" src="https://github.com/user-attachments/assets/39592828-061f-464b-a0cd-998425353035" /> | <img width="960" height="540" alt="heltec-t114-button-pressed-simulated" src="https://github.com/user-attachments/assets/deeb485e-0db8-447a-ab55-f56947fdb9c2" /> |
| `raw = 1`, logical released | `raw = 0`, logical pressed |

The same UI was built for `native_sim/native/64` with the SDL display
driver at the panel's 240 × 135 resolution.

<details>
<summary>Real hardware validation</summary>

### Released

<img width="1600" height="1066" alt="heltec-t114-button-released-clean" src="https://github.com/user-attachments/assets/fd7a94fa-00e5-4a4c-9fd9-27ac58c03aa6" />

### Pressed

<img width="1600" height="1066" alt="heltec-t114-button-pressed-clean" src="https://github.com/user-attachments/assets/a5b5d825-520b-4d35-94da-941ac1028ce4" />

The diagnostic compares the current `GPIO_ACTIVE_HIGH` description
against `GPIO_ACTIVE_LOW` while showing the physical and raw GPIO
states.

</details>
