### PR TITLE
MAINTAINERS: include doc/package*.json in documentation infrastructure

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1453,6 +1453,7 @@ Documentation Infrastructure:
     - doc/Makefile
     - doc/_*/
     - doc/conf.py
+    - doc/package*.json
     - doc/requirements.in
     - doc/requirements.txt
     - doc/zephyr.doxyfile.in

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1449,12 +1449,12 @@ Documentation Infrastructure:
     - nashif
   files:
     - doc/404.rst
+    - doc/CMakeLists.txt
+    - doc/Makefile
+    - doc/_*/
+    - doc/conf.py
     - doc/requirements.in
     - doc/requirements.txt
-    - doc/_*/
-    - doc/CMakeLists.txt
-    - doc/conf.py
-    - doc/Makefile
     - doc/zephyr.doxyfile.in
   labels:
     - "area: Documentation Infrastructure"


### PR DESCRIPTION
Include the doc/package*.json files the list of Documentation Infrastructure files.