### PR TITLE
shell: telnet: document that the backend is unauthenticated

### DIFF
--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -537,6 +537,14 @@ config SHELL_BACKEND_TELNET
 	help
 	  Enable TELNET backend.
 
+	  Security warning: this backend exposes the full Zephyr shell over an
+	  unauthenticated, unencrypted TCP port. Anyone able to reach the device
+	  on the network gets the same control as a local console user, which
+	  typically includes flash erase/write, reboot, settings modification
+	  and secret exfiltration through any shell-exposed subsystem. It is
+	  strongly discouraged in production unless the network path itself is
+	  trusted.
+
 if SHELL_BACKEND_TELNET
 
 config SHELL_TELNET_INIT_PRIORITY


### PR DESCRIPTION
The telnet backend exposes the full Zephyr shell over an unauthenticated,
unencrypted TCP port, which is equivalent to granting full device control
to anyone who can reach the port. There is no in-tree authentication to
switch on, so add the security warning to the Kconfig help, mirroring the
guidance already given for MCUMGR_GRP_SHELL.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
