### PR TITLE
ci: set_assignees: overhaul reviewer selection

### DIFF
--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -71,15 +71,21 @@ weight) and assignee selection.
 
 Reviewer selection
 ------------------
-The ordered reviewer candidate list is built as follows:
+The ordered reviewer candidate list is built in two tiers, maintainers before
+collaborators, so that a PR touching many areas does not spend its limited
+review slots on the collaborators of the highest-weight areas while dropping
+the maintainers of every other touched area:
 
-  1. For each area in descending weight order: add the area's maintainers,
-     then its collaborators.
-  2. Append any path-specific collaborators returned by
-     get_collaborators_for_path() for each matched file.
-  3. Append any extra reviewers identified from MAINTAINERS.yml diff (see
-     Manifest / MAINTAINERS.yml change handling below).
-  4. Deduplicate while preserving insertion order.
+  1. Maintainer tier:
+     a. For each area in descending weight order: the area's maintainers.
+     b. Any extra reviewers identified from the manifest or MAINTAINERS.yml
+        diff (see Manifest / MAINTAINERS.yml change handling below).
+     c. Maintainers of deferred file-group areas (see Deferred file-groups).
+  2. Collaborator tier:
+     a. For each area in descending weight order: the area's collaborators.
+     b. Any path-specific collaborators returned by
+        get_collaborators_for_path() for each matched file.
+  3. Deduplicate while preserving insertion order.
 
 Candidates are then filtered:
   - The PR author is skipped.
@@ -514,6 +520,31 @@ def _pick_assignees(pr, area_counter: dict, all_maintainers: dict, num_files: in
     return assignees
 
 
+def _build_reviewer_candidates(
+    maintainer_file,
+    area_counter: dict,
+    collab_per_path: set,
+    additional_reviews: set,
+    deferred_reviewers: set,
+) -> list:
+    maintainers = []
+    collaborators = []
+    for area in area_counter:
+        maintainers += maintainer_file.areas[area.name].maintainers
+        collaborators += maintainer_file.areas[area.name].collaborators
+
+    candidates = (
+        maintainers
+        + sorted(additional_reviews)
+        + sorted(deferred_reviewers)
+        + collaborators
+        + sorted(collab_per_path)
+    )
+
+    # Deduplicate while preserving insertion order.
+    return list(dict.fromkeys(candidates))
+
+
 def _add_reviewers(
     gh,
     gh_repo,
@@ -855,16 +886,11 @@ def process_pr(gh, args, maintainer_file, number: int):
     logger.info("Area weights: %s", {a.name: c for a, c in area_counter.items()})
     logger.debug("Collected labels: %s", labels)
 
-    # Build the ordered collaborator/reviewer list by area priority.
-    collab = []
-    for area in area_counter:
-        collab += maintainer_file.areas[area.name].maintainers
-        collab += maintainer_file.areas[area.name].collaborators
-    collab += list(collab_per_path)
-    collab += list(additional_reviews)
-    collab += sorted(deferred_reviewers)
-    # Deduplicate while preserving insertion order.
-    collab = list(dict.fromkeys(collab))
+    # Build the ordered collaborator/reviewer list: maintainers of all touched
+    # areas by area priority first, then collaborators.
+    collab = _build_reviewer_candidates(
+        maintainer_file, area_counter, collab_per_path, additional_reviews, deferred_reviewers
+    )
     logger.debug("Reviewer candidates: %s", collab)
 
     all_maintainers = dict(

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -118,18 +118,19 @@ Candidates are then filtered:
   - Users who previously self-removed themselves from the review request list
     are skipped.
 
-If the PR already has MAX_REVIEWERS (15) or more reviewers, the normal
-candidate list is discarded.  Only the maintainers of the *primary*
-(highest-weight) area are used as fallback candidates, plus any
-``additional_reviews`` users identified from manifest or MAINTAINERS.yml
-diff.  This keeps the fallback small and high-signal, and avoids the
-original behaviour of requesting reviews from all area maintainers across
-all touched files (which could push a broad PR even further above the
-reviewer cap).  The same author / existing-reviewer / self-removed /
-collaborator-status filters are applied to the fallback candidates.
+Every candidate that survives those filters is then requested: no cap is
+applied.  GitHub documents no limit on how many reviewers a pull request may
+carry, and PRs holding more than 15 are observable in the wild, so imposing one
+here only meant dropping people who were legitimately responsible for the
+change.  What keeps the request meaningful is the tier ordering above, not a
+count: if a PR is broad enough to need thirty reviewers, all thirty own part of
+it.
 
-Otherwise the candidate list is capped at the remaining vacancy
-(MAX_REVIEWERS - existing reviewer count) before the review request is created.
+Should GitHub refuse the full set anyway (some undocumented limit, or a
+candidate who lost collaborator status between the check and the request), the
+call is retried once with the first REVIEWER_RETRY_BATCH (15) candidates.
+Because the list is ordered highest-signal first, that retry keeps the area
+maintainers and drops only the tail.
 
 Assignee selection
 ------------------
@@ -243,8 +244,12 @@ logger = logging.getLogger(__name__)
 # Maximum number of changed files to process; larger PRs are skipped.
 MAX_FILES = 500
 
-# Maximum number of reviewers on a PR before switching to maintainer-only strategy.
-MAX_REVIEWERS = 15
+# GitHub does not document a cap on how many reviewers a pull request may have,
+# and PRs carrying more than 15 are observable in the wild, so no cap is imposed
+# here: every eligible candidate is requested.  Should GitHub reject the full
+# set anyway, the request is retried with this many of the highest-ranked
+# candidates so that a rejection cannot cost the review request entirely.
+REVIEWER_RETRY_BATCH = 15
 
 # Maximum number of labels to apply; more than this is likely noise from over-broad matches.
 MAX_LABELS = 10
@@ -724,27 +729,17 @@ def _build_reviewer_candidates(
     return list(dict.fromkeys(candidates))
 
 
-def _add_reviewers(
-    gh,
-    gh_repo,
-    pr,
-    args,
-    collab: list,
-    primary_maintainers: list,
-    extra_reviewers: frozenset = frozenset(),
-):
+def _add_reviewers(gh, gh_repo, pr, args, collab: list):
     """Request reviews from eligible collaborators on *pr*.
 
     Skips the PR author, existing reviewers, non-collaborators, and users
     who previously removed themselves from the review request.
 
-    When the PR already has MAX_REVIEWERS or more reviewers, only
-    *primary_maintainers* (the maintainers of the highest-weight area) plus
-    *extra_reviewers* (e.g. maintainers of MAINTAINERS.yml-changed areas) are
-    used as fallback candidates.  This keeps the fallback small and
-    high-signal while ensuring that people specifically responsible for
-    changed areas are never silently dropped.
-    The same filters apply in both the normal and overflow paths.
+    Every remaining candidate is requested; no cap is applied.  *collab* is
+    ordered highest-signal first (area maintainers, then collaborators, then
+    heuristic picks -- see _build_reviewer_candidates), so the ordering, rather
+    than an arbitrary limit, is what protects the review request from being
+    dominated by low-signal reviewers.
     """
     existing_reviewers = set()
     for review in pr.get_reviews():
@@ -764,24 +759,8 @@ def _add_reviewers(
         if event.event == 'review_request_removed' and event.actor == event.requested_reviewer:
             self_removed.add(event.actor)
 
-    if len(existing_reviewers) >= MAX_REVIEWERS:
-        logger.info(
-            "PR #%d already has %d reviewer(s) (limit %d); "
-            "restricting candidates to primary area maintainers",
-            pr.number,
-            len(existing_reviewers),
-            MAX_REVIEWERS,
-        )
-        # Preserve extra_reviewers (e.g. MAINTAINERS.yml-change reviewers)
-        # even in the overflow path so they are never silently dropped.
-        candidates = list(dict.fromkeys(primary_maintainers + sorted(extra_reviewers)))
-        vacancy = None
-    else:
-        candidates = collab  # extra_reviewers already included via process_pr
-        vacancy = MAX_REVIEWERS - len(existing_reviewers)
-
     reviewers = []
-    for collaborator in candidates:
+    for collaborator in collab:
         try:
             gh_user = gh.get_user(collaborator)
         except UnknownObjectException:
@@ -803,16 +782,28 @@ def _add_reviewers(
 
         reviewers.append(collaborator)
 
-    if vacancy is not None:
-        reviewers = reviewers[:vacancy]
+    if not reviewers:
+        return
 
-    if reviewers:
-        logger.info("Requesting reviews from: %s", reviewers)
-        if not args.dry_run:
+    logger.info("Requesting reviews from %d user(s): %s", len(reviewers), reviewers)
+    if args.dry_run:
+        return
+
+    try:
+        pr.create_review_request(reviewers=reviewers)
+    except GithubException as exc:
+        logger.error("Failed to add reviewers %s: %s", reviewers, exc)
+
+        # The full set may have been refused for exceeding an undocumented
+        # per-PR reviewer limit.  Retry with the highest-ranked candidates so
+        # that a rejection does not leave the PR with no reviewers at all.
+        if len(reviewers) > REVIEWER_RETRY_BATCH:
+            retry = reviewers[:REVIEWER_RETRY_BATCH]
+            logger.info("Retrying with the first %d: %s", len(retry), retry)
             try:
-                pr.create_review_request(reviewers=reviewers)
-            except GithubException as exc:
-                logger.error("Failed to add reviewers %s: %s", reviewers, exc)
+                pr.create_review_request(reviewers=retry)
+            except GithubException as retry_exc:
+                logger.error("Retry failed for reviewers %s: %s", retry, retry_exc)
 
 
 def _assign_maintainers(gh, pr, args, assignees: list):
@@ -1154,20 +1145,10 @@ def process_pr(gh, args, maintainer_file, number: int):
             )
 
     # Request reviews.
-    if collab or additional_reviews:
-        primary_area = next(iter(area_counter), None)
-        primary_maintainers = (
-            maintainer_file.areas[primary_area.name].maintainers if primary_area else []
-        )
-        _add_reviewers(
-            gh,
-            gh_repo,
-            pr,
-            args,
-            collab,
-            primary_maintainers,
-            frozenset(additional_reviews),
-        )
+    # additional_reviews is already folded into collab by
+    # _build_reviewer_candidates, so collab alone decides whether to ask.
+    if collab:
+        _add_reviewers(gh, gh_repo, pr, args, collab)
 
     # Set assignees (only when none are set yet, unless doing a dry run).
     if assignees and (not pr.assignee or args.dry_run):

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -113,10 +113,13 @@ Candidates are then filtered:
   - The PR author is skipped.
   - Users who already submitted a review or are already on the review-request
     list are skipped.
-  - Users who are not repository collaborators are skipped (GitHub requires
-    collaborator status to receive a review request).
+  - Users whose login no longer resolves (deleted accounts) are skipped.
   - Users who previously self-removed themselves from the review request list
-    are skipped.
+    are skipped.  This is checked before the collaborator test below, so that
+    someone who opted out is never routed to the mention fallback instead.
+  - Users who are not repository collaborators are set aside: GitHub requires
+    collaborator status to receive a review request, so they are mentioned in a
+    comment instead (see below) rather than dropped.
 
 Every candidate that survives those filters is then requested: no cap is
 applied.  GitHub documents no limit on how many reviewers a pull request may
@@ -131,6 +134,19 @@ candidate who lost collaborator status between the check and the request), the
 call is retried once with the first REVIEWER_RETRY_BATCH (15) candidates.
 Because the list is ordered highest-signal first, that retry keeps the area
 maintainers and drops only the tail.
+
+Mention fallback
+----------------
+A formal review request is not always possible: non-collaborators cannot
+receive one at all, and a request may be refused outright.  Rather than let
+those people fall off the PR silently, they are @mentioned in a comment asking
+for their review, which notifies them regardless of their permissions.
+
+The comment carries a hidden MENTION_MARKER so that repeated runs over the same
+PR find their own previous comment and edit it in place, instead of posting a
+duplicate every time the PR is updated.  Users who removed themselves from the
+review request are never mentioned, since a mention would route around an
+explicit opt-out.
 
 Assignee selection
 ------------------
@@ -250,6 +266,11 @@ MAX_FILES = 500
 # set anyway, the request is retried with this many of the highest-ranked
 # candidates so that a rejection cannot cost the review request entirely.
 REVIEWER_RETRY_BATCH = 15
+
+# Hidden marker identifying the comment used to mention reviewers who could not
+# be added to the review request.  It lets a re-run find and update its own
+# previous comment instead of posting a duplicate.
+MENTION_MARKER = "<!-- set_assignees: reviewer-mention -->"
 
 # Maximum number of labels to apply; more than this is likely noise from over-broad matches.
 MAX_LABELS = 10
@@ -760,10 +781,12 @@ def _add_reviewers(gh, gh_repo, pr, args, collab: list):
             self_removed.add(event.actor)
 
     reviewers = []
+    non_collaborators = []
     for collaborator in collab:
         try:
             gh_user = gh.get_user(collaborator)
         except UnknownObjectException:
+            # The login does not resolve, so there is nobody to mention either.
             logger.warning("User '%s' not found; account may have been deleted", collaborator)
             continue
 
@@ -773,37 +796,103 @@ def _add_reviewers(gh, gh_repo, pr, args, collab: list):
         if gh_user in existing_reviewers:
             logger.debug("Skipping existing reviewer '%s'", collaborator)
             continue
-        if not gh_repo.has_in_collaborators(gh_user):
-            logger.info("Skipping '%s': not a repository collaborator", collaborator)
-            continue
         if gh_user in self_removed:
             logger.info("Skipping '%s': previously self-removed from reviewers", collaborator)
+            continue
+        if not gh_repo.has_in_collaborators(gh_user):
+            # GitHub refuses a review request for non-collaborators, so ask
+            # them by mention instead of dropping them.
+            logger.info("'%s' is not a repository collaborator; will mention", collaborator)
+            non_collaborators.append(collaborator)
             continue
 
         reviewers.append(collaborator)
 
-    if not reviewers:
+    if reviewers:
+        logger.info("Requesting reviews from %d user(s): %s", len(reviewers), reviewers)
+        unrequested = _request_reviews(pr, args, reviewers)
+    else:
+        unrequested = []
+
+    # Anyone the review request could not accommodate still gets asked, by
+    # name, in a comment.  Users who removed themselves are deliberately not
+    # mentioned: they opted out, and a mention would route around that.
+    _mention_reviewers(pr, args, non_collaborators + unrequested)
+
+
+def _request_reviews(pr, args, reviewers: list) -> list:
+    """Request reviews from *reviewers*; return those that could not be added.
+
+    A rejected bulk request is retried once with the highest-ranked
+    REVIEWER_RETRY_BATCH candidates, so that hitting an undocumented per-PR
+    reviewer limit cannot leave the PR with no reviewers at all.  Whoever is
+    left out is returned for the caller to mention instead.
+    """
+    if args.dry_run:
+        return []
+
+    try:
+        pr.create_review_request(reviewers=reviewers)
+        return []
+    except GithubException as exc:
+        logger.error("Failed to add reviewers %s: %s", reviewers, exc)
+
+    if len(reviewers) > REVIEWER_RETRY_BATCH:
+        retry = reviewers[:REVIEWER_RETRY_BATCH]
+        logger.info("Retrying with the first %d: %s", len(retry), retry)
+        try:
+            pr.create_review_request(reviewers=retry)
+            return reviewers[REVIEWER_RETRY_BATCH:]
+        except GithubException as retry_exc:
+            logger.error("Retry failed for reviewers %s: %s", retry, retry_exc)
+
+    return list(reviewers)
+
+
+def _mention_reviewers(pr, args, logins: list):
+    """Ask *logins* for a review in a PR comment.
+
+    Used for people who cannot receive a formal review request: those who are
+    not repository collaborators (GitHub rejects a review request for them),
+    and those the request itself could not accommodate.  An @mention notifies
+    them regardless of their permissions, so the change still reaches the
+    people responsible for it.
+
+    The comment is maintained in place: one is created the first time and
+    edited afterwards, keyed on MENTION_MARKER, so that re-running over the
+    same PR does not spam it with duplicates.
+    """
+    logins = list(dict.fromkeys(logins))
+    if not logins:
         return
 
-    logger.info("Requesting reviews from %d user(s): %s", len(reviewers), reviewers)
+    mentions = " ".join(f"@{login}" for login in logins)
+    body = (
+        f"{MENTION_MARKER}\n"
+        f"{mentions}\n\n"
+        "You have been identified as a likely reviewer for the code this pull "
+        "request changes, but could not be added to its review request "
+        "automatically. Please review it if you are able to."
+    )
+
+    logger.info("Mentioning %d user(s) unable to be requested: %s", len(logins), logins)
     if args.dry_run:
         return
 
     try:
-        pr.create_review_request(reviewers=reviewers)
-    except GithubException as exc:
-        logger.error("Failed to add reviewers %s: %s", reviewers, exc)
+        for comment in pr.get_issue_comments():
+            if MENTION_MARKER in comment.body:
+                # Already asked; refresh only when the set of people changed.
+                if comment.body.strip() != body.strip():
+                    comment.edit(body)
+                    logger.info("Updated existing reviewer-mention comment")
+                else:
+                    logger.debug("Reviewer-mention comment already up to date")
+                return
 
-        # The full set may have been refused for exceeding an undocumented
-        # per-PR reviewer limit.  Retry with the highest-ranked candidates so
-        # that a rejection does not leave the PR with no reviewers at all.
-        if len(reviewers) > REVIEWER_RETRY_BATCH:
-            retry = reviewers[:REVIEWER_RETRY_BATCH]
-            logger.info("Retrying with the first %d: %s", len(retry), retry)
-            try:
-                pr.create_review_request(reviewers=retry)
-            except GithubException as retry_exc:
-                logger.error("Retry failed for reviewers %s: %s", retry, retry_exc)
+        pr.create_issue_comment(body)
+    except GithubException as exc:
+        logger.error("Failed to mention reviewers %s: %s", logins, exc)
 
 
 def _assign_maintainers(gh, pr, args, assignees: list):

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -86,6 +86,22 @@ the maintainers of every other touched area:
      b. Any path-specific collaborators returned by
         get_collaborators_for_path() for each matched file.
   3. Deduplicate while preserving insertion order.
+  4. Heuristic tier (only for under-covered areas): an area that names no
+     maintainers, or at most THIN_AREA_COLLABORATORS (2) collaborators, cannot
+     supply enough reviewers on its own.  For such areas two heuristics are
+     tried in order, and the result is appended after the tiers above (the
+     author and anyone already listed are excluded).  These are
+     lower-confidence picks, so they fill only leftover review slots.
+
+     a. GitHub's own ``suggestedReviewers`` for the PR, which GitHub derives
+        from commit history *and* past review comments.  This is the better
+        signal and costs one query, but it is only available over GraphQL and
+        is empty for most PRs, so it cannot be relied on alone.
+     b. When GitHub suggests nobody, the recent contributors to the changed
+        files the under-covered areas own, read from the commit history.
+        Unlike (a) this is scoped to the files that are actually short of
+        reviewers, rather than to the PR as a whole.  Bounded by
+        HISTORY_COMMITS_PER_FILE, MAX_HISTORY_FILES, and MAX_HISTORY_REVIEWERS.
 
 Candidates are then filtered:
   - The PR author is skipped.
@@ -226,6 +242,39 @@ MAX_REVIEWERS = 15
 
 # Maximum number of labels to apply; more than this is likely noise from over-broad matches.
 MAX_LABELS = 10
+
+# An area is considered under-covered when it names no maintainers, or names at
+# most this many collaborators.  Such areas do not supply enough reviewers on
+# their own, so recent Git contributors to the changed files are added as
+# heuristic reviewer candidates (see _history_reviewers).
+THIN_AREA_COLLABORATORS = 2
+
+# Bounds on the Git-history heuristic, to keep its GitHub API cost predictable:
+#   - sample at most this many recent commits per changed file,
+#   - inspect at most this many under-covered files in total,
+#   - add at most this many heuristic reviewers to the candidate list.
+HISTORY_COMMITS_PER_FILE = 20
+MAX_HISTORY_FILES = 40
+MAX_HISTORY_REVIEWERS = 3
+
+# GitHub's own reviewer suggestions ("based on commit history and past review
+# comments") are exposed only through the GraphQL API, as a plain unpaginated
+# list on the PullRequest object.
+SUGGESTED_REVIEWERS_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      suggestedReviewers {
+        isAuthor
+        isCommenter
+        reviewer {
+          login
+        }
+      }
+    }
+  }
+}
+"""
 
 # Courtesy sleep between consecutive GitHub API calls to avoid secondary rate limits.
 API_SLEEP_SECONDS = 1
@@ -520,6 +569,121 @@ def _pick_assignees(pr, area_counter: dict, all_maintainers: dict, num_files: in
     return assignees
 
 
+def _thin_areas(maintainer_file, area_counter: dict) -> set:
+    """Return the names of areas in *area_counter* that are under-covered.
+
+    An area is under-covered when MAINTAINERS.yml names no maintainers for it,
+    or names at most THIN_AREA_COLLABORATORS collaborators.  These areas cannot
+    supply enough reviewers on their own, so the caller supplements them with
+    recent Git contributors (see _history_reviewers).
+    """
+    thin = set()
+    for area in area_counter:
+        entry = maintainer_file.areas[area.name]
+        if not entry.maintainers or len(entry.collaborators) <= THIN_AREA_COLLABORATORS:
+            thin.add(area.name)
+    return thin
+
+
+def _suggested_reviewers(gh, args, pr, exclude: set) -> list:
+    """Return GitHub's own reviewer suggestions for *pr* as ordered logins.
+
+    GitHub computes these from commit history and past review comments, so
+    they are a strictly better-informed version of the _history_reviewers
+    heuristic when available.  They are only exposed through GraphQL, hence
+    the raw query; PyGithub's requester reuses the same token and session, so
+    this adds no dependency.
+
+    Suggestions where GitHub flagged the person as an author of the changed
+    code rank ahead of comment-only suggestions, and ties break by login for
+    determinism.  Logins in *exclude* are dropped.
+
+    The list is frequently empty (GitHub's heuristic is sparse, and it is not
+    documented when it declines to suggest), and the field is best-effort, so
+    every failure path degrades to an empty list and lets the caller fall back
+    to _history_reviewers.
+    """
+    variables = {"owner": args.org, "name": args.repo, "number": pr.number}
+    try:
+        _headers, response = gh.requester.graphql_query(SUGGESTED_REVIEWERS_QUERY, variables)
+    except GithubException as exc:
+        logger.debug("suggestedReviewers query failed for PR #%d: %s", pr.number, exc)
+        return []
+
+    if response.get("errors"):
+        logger.debug(
+            "suggestedReviewers query returned errors for PR #%d: %s",
+            pr.number,
+            response["errors"],
+        )
+
+    try:
+        suggestions = response["data"]["repository"]["pullRequest"]["suggestedReviewers"]
+    except (KeyError, TypeError):
+        logger.debug("Unexpected suggestedReviewers response for PR #%d", pr.number)
+        return []
+
+    ranked = []
+    for suggestion in suggestions or []:
+        login = (suggestion.get("reviewer") or {}).get("login")
+        if not login or login in exclude:
+            continue
+        # Authorship of the changed code is a stronger signal than having
+        # commented on it, so sort authors first.
+        ranked.append((0 if suggestion.get("isAuthor") else 1, login))
+
+    return [login for _rank, login in sorted(ranked)]
+
+
+def _history_reviewers(gh_repo, filenames, exclude: set) -> list:
+    """Return recent contributors to *filenames* as ordered GitHub logins.
+
+    Walks each file's commit history (newest first) and tallies the commit
+    authors GitHub resolved to a real account, ranking them by how many of the
+    sampled commits they authored (ties broken by login for determinism).
+
+    Commit history is read through the GitHub API rather than a local
+    ``git log``/``git blame`` because the API yields actual GitHub logins
+    (commit-author emails cannot be mapped to logins reliably) and does not
+    depend on the CI checkout having the full history.
+
+    *exclude* holds logins already covered (PR author, existing candidates) so
+    they are not re-proposed.  Sampling is bounded by HISTORY_COMMITS_PER_FILE,
+    MAX_HISTORY_FILES, and MAX_HISTORY_REVIEWERS.
+    """
+    sampled_files = sorted(filenames)
+    if len(sampled_files) > MAX_HISTORY_FILES:
+        logger.info(
+            "Sampling Git history for %d of %d under-covered files (limit %d)",
+            MAX_HISTORY_FILES,
+            len(sampled_files),
+            MAX_HISTORY_FILES,
+        )
+        sampled_files = sampled_files[:MAX_HISTORY_FILES]
+
+    counts = defaultdict(int)
+    for filename in sampled_files:
+        try:
+            commits = gh_repo.get_commits(path=filename)
+        except GithubException as exc:
+            logger.debug("No commit history for '%s': %s", filename, exc)
+            continue
+
+        sampled = 0
+        for commit in commits:
+            if sampled >= HISTORY_COMMITS_PER_FILE:
+                break
+            sampled += 1
+            author = commit.author
+            login = getattr(author, "login", None) if author else None
+            if not login or login in exclude:
+                continue
+            counts[login] += 1
+
+    ranked = sorted(counts, key=lambda login: (-counts[login], login))
+    return ranked[:MAX_HISTORY_REVIEWERS]
+
+
 def _build_reviewer_candidates(
     maintainer_file,
     area_counter: dict,
@@ -527,6 +691,16 @@ def _build_reviewer_candidates(
     additional_reviews: set,
     deferred_reviewers: set,
 ) -> list:
+
+    """Build the ordered reviewer candidate list for a PR.
+
+    Maintainers of every touched area come first (in descending area-weight
+    order), then collaborators.  The caller truncates the filtered result to
+    the reviewer cap, so ordering maintainers ahead of collaborators ensures
+    the highest-signal reviewers are never dropped in favour of lower-signal
+    ones.  Lower-confidence Git-history reviewers (for under-covered areas) are
+    appended after this list by the caller so they fill only leftover slots.
+    """
     maintainers = []
     collaborators = []
     for area in area_counter:
@@ -763,6 +937,9 @@ def process_pr(gh, args, maintainer_file, number: int):
     collab_per_path = set()
     additional_reviews = set()
     deferred_reviewers = set()
+    # Files that mapped to each area, used to sample Git history for areas that
+    # MAINTAINERS.yml under-covers (see _thin_areas / _history_reviewers).
+    area_files = defaultdict(set)
 
     changed_files = list(pr.get_files())
     num_files = len(changed_files)
@@ -867,6 +1044,7 @@ def process_pr(gh, args, maintainer_file, number: int):
                 count = 1 if not is_instance else 0
 
             area_counter[area] += count
+            area_files[area.name].add(filename)
             logger.debug("  area weight update: %s += %d", area.name, count)
             labels.update(area.labels)
 
@@ -891,6 +1069,37 @@ def process_pr(gh, args, maintainer_file, number: int):
     collab = _build_reviewer_candidates(
         maintainer_file, area_counter, collab_per_path, additional_reviews, deferred_reviewers
     )
+
+    # Supplement under-covered areas (no maintainers, or few collaborators)
+    # with heuristic reviewers.  Exclude the author and everyone already listed
+    # so these last-resort slots are not wasted on reviewers we already have.
+    thin = _thin_areas(maintainer_file, area_counter)
+    if thin:
+        exclude = set(collab) | {pr.user.login}
+
+        # Prefer GitHub's own suggestions: they draw on both commit history and
+        # past review comments, and cost a single query.  They are often empty,
+        # in which case fall back to walking the history of the files the
+        # under-covered areas actually own.
+        heuristic = _suggested_reviewers(gh, args, pr, exclude)[:MAX_HISTORY_REVIEWERS]
+        source = "GitHub-suggested"
+
+        if not heuristic:
+            thin_files = set()
+            for name in thin:
+                thin_files.update(area_files.get(name, ()))
+            heuristic = _history_reviewers(gh_repo, thin_files, exclude)
+            source = "Git-history"
+
+        if heuristic:
+            logger.info(
+                "Under-covered areas %s; adding %s reviewers: %s",
+                sorted(thin),
+                source,
+                heuristic,
+            )
+            collab += heuristic
+
     logger.debug("Reviewer candidates: %s", collab)
 
     all_maintainers = dict(

--- a/scripts/ci/set_assignees.py
+++ b/scripts/ci/set_assignees.py
@@ -86,22 +86,28 @@ the maintainers of every other touched area:
      b. Any path-specific collaborators returned by
         get_collaborators_for_path() for each matched file.
   3. Deduplicate while preserving insertion order.
-  4. Heuristic tier (only for under-covered areas): an area that names no
-     maintainers, or at most THIN_AREA_COLLABORATORS (2) collaborators, cannot
-     supply enough reviewers on its own.  For such areas two heuristics are
-     tried in order, and the result is appended after the tiers above (the
-     author and anyone already listed are excluded).  These are
-     lower-confidence picks, so they fill only leftover review slots.
+  4. Heuristic tier, used for changed files MAINTAINERS.yml cannot staff:
+
+       - files in an under-covered area, i.e. one that names no maintainers or
+         at most THIN_AREA_COLLABORATORS (2) collaborators, and so cannot
+         supply enough reviewers on its own, and
+       - orphaned files, which match no area at all.  A PR consisting only of
+         these would otherwise get no reviewer whatsoever, since every tier
+         above is derived from matched areas.
+
+     Two heuristics are tried in order, and the result is appended after the
+     tiers above (the author and anyone already listed are excluded).  These
+     are lower-confidence picks, so they fill only leftover review slots.
 
      a. GitHub's own ``suggestedReviewers`` for the PR, which GitHub derives
         from commit history *and* past review comments.  This is the better
         signal and costs one query, but it is only available over GraphQL and
         is empty for most PRs, so it cannot be relied on alone.
-     b. When GitHub suggests nobody, the recent contributors to the changed
-        files the under-covered areas own, read from the commit history.
-        Unlike (a) this is scoped to the files that are actually short of
-        reviewers, rather than to the PR as a whole.  Bounded by
-        HISTORY_COMMITS_PER_FILE, MAX_HISTORY_FILES, and MAX_HISTORY_REVIEWERS.
+     b. When GitHub suggests nobody, the recent contributors to the unstaffed
+        files, read from the commit history.  Unlike (a) this is scoped to the
+        files that are actually short of reviewers, rather than to the PR as a
+        whole.  Bounded by HISTORY_COMMITS_PER_FILE, MAX_HISTORY_FILES, and
+        MAX_HISTORY_REVIEWERS.
 
 Candidates are then filtered:
   - The PR author is skipped.
@@ -691,7 +697,6 @@ def _build_reviewer_candidates(
     additional_reviews: set,
     deferred_reviewers: set,
 ) -> list:
-
     """Build the ordered reviewer candidate list for a PR.
 
     Maintainers of every touched area come first (in descending area-weight
@@ -940,6 +945,9 @@ def process_pr(gh, args, maintainer_file, number: int):
     # Files that mapped to each area, used to sample Git history for areas that
     # MAINTAINERS.yml under-covers (see _thin_areas / _history_reviewers).
     area_files = defaultdict(set)
+    # Changed files that mapped to no area at all.  MAINTAINERS.yml offers no
+    # reviewer for these, so they feed the same heuristics as thin areas.
+    orphan_files = set()
 
     changed_files = list(pr.get_files())
     num_files = len(changed_files)
@@ -1006,6 +1014,10 @@ def process_pr(gh, args, maintainer_file, number: int):
         logger.debug("  areas for %s: %s", filename, [a.name for a in areas])
 
         if not areas:
+            # Orphaned: no area claims this file, so MAINTAINERS.yml yields no
+            # reviewer for it.  Remember it for the heuristic pass below.
+            logger.debug("  '%s' matches no area", filename)
+            orphan_files.add(filename)
             continue
 
         # Handle deferred file-groups: when a file is matched by both a
@@ -1070,35 +1082,47 @@ def process_pr(gh, args, maintainer_file, number: int):
         maintainer_file, area_counter, collab_per_path, additional_reviews, deferred_reviewers
     )
 
-    # Supplement under-covered areas (no maintainers, or few collaborators)
-    # with heuristic reviewers.  Exclude the author and everyone already listed
+    # Supplement files MAINTAINERS.yml cannot staff with heuristic reviewers:
+    # those in under-covered areas (no maintainers, or few collaborators) and
+    # those in no area at all.  Exclude the author and everyone already listed
     # so these last-resort slots are not wasted on reviewers we already have.
     thin = _thin_areas(maintainer_file, area_counter)
-    if thin:
+    uncovered_files = set(orphan_files)
+    for name in thin:
+        uncovered_files.update(area_files.get(name, ()))
+
+    if uncovered_files:
+        if orphan_files:
+            logger.info(
+                "%d changed file(s) match no area: %s",
+                len(orphan_files),
+                sorted(orphan_files),
+            )
+
         exclude = set(collab) | {pr.user.login}
 
         # Prefer GitHub's own suggestions: they draw on both commit history and
         # past review comments, and cost a single query.  They are often empty,
-        # in which case fall back to walking the history of the files the
-        # under-covered areas actually own.
+        # in which case fall back to walking the history of the files that
+        # MAINTAINERS.yml left unstaffed.
         heuristic = _suggested_reviewers(gh, args, pr, exclude)[:MAX_HISTORY_REVIEWERS]
         source = "GitHub-suggested"
 
         if not heuristic:
-            thin_files = set()
-            for name in thin:
-                thin_files.update(area_files.get(name, ()))
-            heuristic = _history_reviewers(gh_repo, thin_files, exclude)
+            heuristic = _history_reviewers(gh_repo, uncovered_files, exclude)
             source = "Git-history"
 
         if heuristic:
             logger.info(
-                "Under-covered areas %s; adding %s reviewers: %s",
+                "Under-covered areas %s / %d orphaned file(s); adding %s reviewers: %s",
                 sorted(thin),
+                len(orphan_files),
                 source,
                 heuristic,
             )
             collab += heuristic
+        else:
+            logger.info("No heuristic reviewers found for under-covered files")
 
     logger.debug("Reviewer candidates: %s", collab)
 

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -631,3 +631,85 @@ class TestDeferredFileGroups:
         sut.process_pr(gh, args, mf, 99)
 
         assert "net_m" in _assignees_set(pr)
+
+
+# ---------------------------------------------------------------------------
+# _build_reviewer_candidates
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReviewerCandidates:
+    """Reviewer candidates must list every area's maintainers before any
+    collaborator, so that truncation to the reviewer cap never drops a
+    maintainer in favour of a higher-weight area's collaborator."""
+
+    @staticmethod
+    def _mf(*areas):
+        mf = SimpleNamespace(areas={area.name: area for area in areas})
+        return mf
+
+    def test_all_maintainers_precede_all_collaborators(self):
+        net = _make_area("Networking", maintainers=["net_m"], collaborators=["net_c"])
+        usb = _make_area("USB", maintainers=["usb_m"], collaborators=["usb_c"])
+        mf = self._mf(net, usb)
+
+        result = sut._build_reviewer_candidates(mf, {net: 5, usb: 2}, set(), set(), set())
+
+        assert result == ["net_m", "usb_m", "net_c", "usb_c"]
+
+    def test_maintainer_order_follows_area_weight(self):
+        net = _make_area("Networking", maintainers=["net_m"])
+        usb = _make_area("USB", maintainers=["usb_m"])
+        mf = self._mf(net, usb)
+
+        # area_counter is pre-sorted by descending weight by the caller.
+        result = sut._build_reviewer_candidates(mf, {usb: 9, net: 1}, set(), set(), set())
+
+        assert result == ["usb_m", "net_m"]
+
+    def test_extra_and_deferred_reviewers_join_maintainer_tier(self):
+        net = _make_area("Networking", maintainers=["net_m"], collaborators=["net_c"])
+        mf = self._mf(net)
+
+        result = sut._build_reviewer_candidates(
+            mf, {net: 1}, {"path_c"}, {"extra_m"}, {"deferred_m"}
+        )
+
+        assert result == ["net_m", "extra_m", "deferred_m", "net_c", "path_c"]
+
+    def test_duplicates_are_removed_keeping_first_occurrence(self):
+        net = _make_area("Networking", maintainers=["alice"], collaborators=["bob"])
+        usb = _make_area("USB", maintainers=["bob"], collaborators=["alice"])
+        mf = self._mf(net, usb)
+
+        result = sut._build_reviewer_candidates(mf, {net: 3, usb: 1}, set(), set(), set())
+
+        # 'bob' is a maintainer of USB, so he keeps his maintainer-tier slot
+        # rather than the collaborator slot he also holds in Networking.
+        assert result == ["alice", "bob"]
+
+    def test_no_areas_returns_only_extra_reviewers(self):
+        mf = self._mf()
+
+        result = sut._build_reviewer_candidates(mf, {}, set(), {"extra_m"}, set())
+
+        assert result == ["extra_m"]
+
+    def test_broad_pr_keeps_every_maintainer_within_the_cap(self):
+        """A PR touching more areas than the reviewer cap allows must still
+        request every area's maintainer before any collaborator."""
+        areas_per_file = {}
+        for i in range(8):
+            area = _make_area(
+                f"Area{i}",
+                maintainers=[f"m{i}"],
+                collaborators=[f"c{i}a", f"c{i}b", f"c{i}c", f"c{i}d"],
+            )
+            areas_per_file[f"subsys/area{i}/foo.c"] = [area]
+
+        gh, args, mf, pr = _make_process_pr_harness(areas_per_file)
+        sut.process_pr(gh, args, mf, 99)
+
+        requested = _reviewers_requested(pr)
+        assert len(requested) == sut.MAX_REVIEWERS
+        assert requested[:8] == [f"m{i}" for i in range(8)]

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -723,9 +723,9 @@ class TestBuildReviewerCandidates:
 
         assert result == ["extra_m"]
 
-    def test_broad_pr_keeps_every_maintainer_within_the_cap(self):
-        """A PR touching more areas than the reviewer cap allows must still
-        request every area's maintainer before any collaborator."""
+    def test_broad_pr_requests_every_maintainer_then_collaborators(self):
+        """A broad PR requests everyone eligible -- no cap -- with all area
+        maintainers ranked ahead of any collaborator."""
         areas_per_file = {}
         for i in range(8):
             area = _make_area(
@@ -739,7 +739,8 @@ class TestBuildReviewerCandidates:
         sut.process_pr(gh, args, mf, 99)
 
         requested = _reviewers_requested(pr)
-        assert len(requested) == sut.MAX_REVIEWERS
+        # 8 maintainers + 8*4 collaborators, none dropped.
+        assert len(requested) == 40
         assert requested[:8] == [f"m{i}" for i in range(8)]
 
 
@@ -1111,3 +1112,115 @@ class TestUnmatchedFiles:
         sut.process_pr(gh, args, mf, 99)
 
         assert _reviewers_requested(pr) == []
+
+
+# ---------------------------------------------------------------------------
+# Reviewer cap removal  (_add_reviewers)
+# ---------------------------------------------------------------------------
+
+
+def _make_add_reviewers_stubs(author="author"):
+    """Return (gh, gh_repo, pr, args) for a direct _add_reviewers() call."""
+    pr = MagicMock()
+    pr.number = 7
+    pr.get_reviews.return_value = []
+    pr.get_review_requests.return_value = ([], [])
+    pr.get_issue_events.return_value = []
+
+    cache = {}
+
+    def _get_user(login):
+        if login not in cache:
+            user = MagicMock()
+            user.login = login
+            cache[login] = user
+        return cache[login]
+
+    gh = MagicMock()
+    gh.get_user.side_effect = _get_user
+    pr.user = _get_user(author)
+
+    gh_repo = MagicMock()
+    gh_repo.has_in_collaborators.return_value = True
+
+    return gh, gh_repo, pr, SimpleNamespace(dry_run=False)
+
+
+class TestNoReviewerCap:
+    """The old MAX_REVIEWERS cap is gone: every eligible candidate is
+    requested, and GitHub decides what it will accept."""
+
+    def test_all_candidates_are_requested(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        candidates = [f"u{i}" for i in range(40)]
+
+        sut._add_reviewers(gh, gh_repo, pr, args, candidates)
+
+        assert _reviewers_requested(pr) == candidates
+
+    def test_many_existing_reviewers_no_longer_restricts_candidates(self):
+        """Previously, a PR at or over the cap discarded the candidate list and
+        fell back to primary-area maintainers only."""
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        pr.get_reviews.return_value = [
+            SimpleNamespace(user=gh.get_user(f"old{i}")) for i in range(20)
+        ]
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["m1", "m2", "c1"])
+
+        assert _reviewers_requested(pr) == ["m1", "m2", "c1"]
+
+    def test_existing_reviewers_are_still_skipped(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        pr.get_review_requests.return_value = ([gh.get_user("already")], [])
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["already", "fresh"])
+
+        assert _reviewers_requested(pr) == ["fresh"]
+
+    def test_author_is_still_skipped(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs(author="me")
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["me", "someone"])
+
+        assert _reviewers_requested(pr) == ["someone"]
+
+    def test_dry_run_requests_nobody(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        args.dry_run = True
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["a", "b"])
+
+        pr.create_review_request.assert_not_called()
+
+
+class TestReviewRequestRetry:
+    """A rejected bulk request must not cost the PR all of its reviewers."""
+
+    def test_rejection_retries_with_highest_ranked_candidates(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        candidates = [f"u{i}" for i in range(25)]
+        pr.create_review_request.side_effect = [sut.GithubException("too many"), None]
+
+        sut._add_reviewers(gh, gh_repo, pr, args, candidates)
+
+        assert pr.create_review_request.call_count == 2
+        retried = pr.create_review_request.call_args_list[1].kwargs["reviewers"]
+        assert retried == candidates[: sut.REVIEWER_RETRY_BATCH]
+
+    def test_small_request_is_not_retried(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        pr.create_review_request.side_effect = sut.GithubException("nope")
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["a", "b"])
+
+        # Nothing to trim, so a retry would just repeat the failing call.
+        assert pr.create_review_request.call_count == 1
+
+    def test_failing_retry_does_not_raise(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        pr.create_review_request.side_effect = sut.GithubException("nope")
+
+        sut._add_reviewers(gh, gh_repo, pr, args, [f"u{i}" for i in range(25)])
+
+        assert pr.create_review_request.call_count == 2

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -887,17 +887,13 @@ class TestSuggestedReviewers:
         assert result == ["alice", "bob"]
 
     def test_authors_rank_ahead_of_commenters(self):
-        gh = _gh_with_suggestions(
-            _suggested_payload([("commenter", False), ("author", True)])
-        )
+        gh = _gh_with_suggestions(_suggested_payload([("commenter", False), ("author", True)]))
         result = sut._suggested_reviewers(gh, _suggest_args(), _suggest_pr(), exclude=set())
         assert result == ["author", "commenter"]
 
     def test_excluded_logins_are_dropped(self):
         gh = _gh_with_suggestions(_suggested_payload([("alice", True), ("known", True)]))
-        result = sut._suggested_reviewers(
-            gh, _suggest_args(), _suggest_pr(), exclude={"known"}
-        )
+        result = sut._suggested_reviewers(gh, _suggest_args(), _suggest_pr(), exclude={"known"})
         assert result == ["alice"]
 
     def test_empty_suggestion_list(self):
@@ -962,9 +958,7 @@ class TestHistoryReviewersIntegration:
 
     def test_well_covered_area_skips_history_lookup(self):
         """A fully-staffed area must not trigger any commit-history query."""
-        area = _make_area(
-            "Full", maintainers=["m"], collaborators=["c1", "c2", "c3"]
-        )
+        area = _make_area("Full", maintainers=["m"], collaborators=["c1", "c2", "c3"])
         areas = {"subsys/full/foo.c": [area]}
 
         gh, args, mf, _ = _make_process_pr_harness(areas)
@@ -1042,3 +1036,78 @@ class TestHistoryReviewersIntegration:
         sut.process_pr(gh, args, mf, 99)
 
         assert "self" not in _reviewers_requested(pr)
+
+
+class TestUnmatchedFiles:
+    """A file matching no area at all yields no reviewer from MAINTAINERS.yml,
+    so it must still reach the heuristics (see PR #112563, a lone doc change
+    to an orphaned path)."""
+
+    def test_pr_with_no_matching_area_uses_github_suggestion(self):
+        gh, args, mf, pr = _make_process_pr_harness({"doc/orphaned.rst": []})
+        gh.requester.graphql_query.return_value = (
+            {},
+            _suggested_payload([("foouser", False)]),
+        )
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "foouser" in _reviewers_requested(pr)
+
+    def test_pr_with_no_matching_area_falls_back_to_history(self):
+        gh, args, mf, pr = _make_process_pr_harness({"doc/orphaned.rst": []})
+        gh.requester.graphql_query.return_value = ({}, _suggested_payload([]))
+        gh.get_repo.return_value.get_commits.side_effect = lambda path: [
+            SimpleNamespace(author=SimpleNamespace(login="baruser"))
+        ]
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "baruser" in _reviewers_requested(pr)
+
+    def test_history_is_scoped_to_the_orphaned_files(self):
+        """Only the unmatched file is walked, not the well-covered one."""
+        covered = _make_area("Full", maintainers=["m"], collaborators=["c1", "c2", "c3"])
+        areas = {"doc/orphaned.rst": [], "subsys/full/foo.c": [covered]}
+
+        gh, args, mf, _ = _make_process_pr_harness(areas)
+        gh.requester.graphql_query.return_value = ({}, _suggested_payload([]))
+        gh.get_repo.return_value.get_commits.side_effect = lambda path: [
+            SimpleNamespace(author=SimpleNamespace(login="doc_author"))
+        ]
+        sut.process_pr(gh, args, mf, 99)
+
+        walked = [
+            call.kwargs.get("path") for call in gh.get_repo.return_value.get_commits.call_args_list
+        ]
+        assert walked == ["doc/orphaned.rst"]
+
+    def test_maintainers_still_rank_ahead_of_heuristics(self):
+        """A mixed PR keeps real maintainers first; heuristics only top up."""
+        covered = _make_area("Full", maintainers=["real_m"], collaborators=["c1", "c2", "c3"])
+        areas = {"doc/orphaned.rst": [], "subsys/full/foo.c": [covered]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas)
+        gh.requester.graphql_query.return_value = (
+            {},
+            _suggested_payload([("heuristic_r", True)]),
+        )
+        sut.process_pr(gh, args, mf, 99)
+
+        requested = _reviewers_requested(pr)
+        assert requested.index("real_m") < requested.index("heuristic_r")
+
+    def test_fully_matched_pr_triggers_no_heuristic(self):
+        covered = _make_area("Full", maintainers=["m"], collaborators=["c1", "c2", "c3"])
+        gh, args, mf, _ = _make_process_pr_harness({"subsys/full/foo.c": [covered]})
+        sut.process_pr(gh, args, mf, 99)
+
+        gh.requester.graphql_query.assert_not_called()
+        gh.get_repo.return_value.get_commits.assert_not_called()
+
+    def test_no_reviewer_found_at_all_does_not_crash(self):
+        """Orphaned file with no suggestions and no history: nothing requested."""
+        gh, args, mf, pr = _make_process_pr_harness({"doc/orphaned.rst": []})
+        gh.requester.graphql_query.return_value = ({}, _suggested_payload([]))
+        gh.get_repo.return_value.get_commits.side_effect = lambda path: []
+        sut.process_pr(gh, args, mf, 99)
+
+        assert _reviewers_requested(pr) == []

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -496,6 +496,30 @@ class TestSetupLogging:
 # ---------------------------------------------------------------------------
 
 
+def _suggested_payload(suggestions):
+    """Wrap *suggestions* in the GraphQL envelope suggestedReviewers returns.
+
+    Each entry is (login, is_author); the reviewer sub-object mirrors the real
+    schema so the SUT's unwrapping is exercised for real.
+    """
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "suggestedReviewers": [
+                        {
+                            "isAuthor": is_author,
+                            "isCommenter": not is_author,
+                            "reviewer": {"login": login},
+                        }
+                        for login, is_author in suggestions
+                    ]
+                }
+            }
+        }
+    }
+
+
 def _make_process_pr_harness(areas_per_file, pr_user="someone"):
     """Return (gh, args, maintainer_file, pr) ready for sut.process_pr().
 
@@ -541,8 +565,12 @@ def _make_process_pr_harness(areas_per_file, pr_user="someone"):
     gh_repo = MagicMock()
     gh.get_repo.return_value = gh_repo
     gh.get_user.side_effect = _get_user
+    # No GitHub-suggested reviewers by default; tests override as needed.
+    gh.requester.graphql_query.return_value = ({}, _suggested_payload([]))
     gh_repo.get_pull.return_value = pr
     gh_repo.has_in_collaborators.return_value = True
+    # No Git history by default; individual tests override per path as needed.
+    gh_repo.get_commits.return_value = []
 
     args = SimpleNamespace(
         org="testorg",
@@ -713,3 +741,304 @@ class TestBuildReviewerCandidates:
         requested = _reviewers_requested(pr)
         assert len(requested) == sut.MAX_REVIEWERS
         assert requested[:8] == [f"m{i}" for i in range(8)]
+
+
+# ---------------------------------------------------------------------------
+# _thin_areas
+# ---------------------------------------------------------------------------
+
+
+class TestThinAreas:
+    @staticmethod
+    def _mf(*areas):
+        return SimpleNamespace(areas={area.name: area for area in areas})
+
+    def test_area_without_maintainers_is_thin(self):
+        area = _make_area("Orphan", maintainers=[], collaborators=["a", "b", "c", "d"])
+        mf = self._mf(area)
+        assert sut._thin_areas(mf, {area: 1}) == {"Orphan"}
+
+    def test_area_with_few_collaborators_is_thin(self):
+        area = _make_area("Small", maintainers=["m"], collaborators=["a", "b"])
+        mf = self._mf(area)
+        assert sut._thin_areas(mf, {area: 1}) == {"Small"}
+
+    def test_well_covered_area_is_not_thin(self):
+        area = _make_area("Big", maintainers=["m"], collaborators=["a", "b", "c"])
+        mf = self._mf(area)
+        assert sut._thin_areas(mf, {area: 1}) == set()
+
+    def test_threshold_is_inclusive(self):
+        area = _make_area(
+            "AtLimit",
+            maintainers=["m"],
+            collaborators=["a"] * sut.THIN_AREA_COLLABORATORS,
+        )
+        mf = self._mf(area)
+        assert sut._thin_areas(mf, {area: 1}) == {"AtLimit"}
+
+    def test_mixed_areas_reports_only_thin_ones(self):
+        thin = _make_area("Thin", maintainers=[], collaborators=[])
+        full = _make_area("Full", maintainers=["m"], collaborators=["a", "b", "c"])
+        mf = self._mf(thin, full)
+        assert sut._thin_areas(mf, {thin: 2, full: 1}) == {"Thin"}
+
+
+# ---------------------------------------------------------------------------
+# _history_reviewers
+# ---------------------------------------------------------------------------
+
+
+def _commit(login):
+    """A stub commit whose GitHub-resolved author has *login* (None => unmatched)."""
+    author = SimpleNamespace(login=login) if login is not None else None
+    return SimpleNamespace(author=author)
+
+
+def _repo_with_history(history):
+    """gh_repo stub whose get_commits(path=...) returns history[path] (or [])."""
+    repo = MagicMock()
+    repo.get_commits.side_effect = lambda path: list(history.get(path, []))
+    return repo
+
+
+class TestHistoryReviewers:
+    def test_ranks_contributors_by_commit_count(self):
+        history = {
+            "f.c": [_commit("alice"), _commit("bob"), _commit("alice")],
+        }
+        repo = _repo_with_history(history)
+        result = sut._history_reviewers(repo, {"f.c"}, exclude=set())
+        assert result == ["alice", "bob"]
+
+    def test_excluded_logins_are_dropped(self):
+        history = {"f.c": [_commit("author"), _commit("alice")]}
+        repo = _repo_with_history(history)
+        result = sut._history_reviewers(repo, {"f.c"}, exclude={"author"})
+        assert result == ["alice"]
+
+    def test_unmatched_authors_are_ignored(self):
+        history = {"f.c": [_commit(None), _commit("alice"), _commit(None)]}
+        repo = _repo_with_history(history)
+        result = sut._history_reviewers(repo, {"f.c"}, exclude=set())
+        assert result == ["alice"]
+
+    def test_result_is_capped(self):
+        history = {
+            "f.c": [_commit(name) for name in ["a", "a", "b", "b", "c", "c", "d", "d"]],
+        }
+        repo = _repo_with_history(history)
+        result = sut._history_reviewers(repo, {"f.c"}, exclude=set())
+        assert len(result) == sut.MAX_HISTORY_REVIEWERS
+
+    def test_commits_sampled_per_file_are_bounded(self):
+        # More commits than the per-file sample budget; only the first
+        # HISTORY_COMMITS_PER_FILE are counted.
+        commits = [_commit("early")] * sut.HISTORY_COMMITS_PER_FILE + [_commit("late")]
+        repo = _repo_with_history({"f.c": commits})
+        result = sut._history_reviewers(repo, {"f.c"}, exclude=set())
+        assert result == ["early"]
+
+    def test_github_exception_on_a_file_is_skipped(self):
+        def _raise_or_return(path):
+            if path == "bad.c":
+                raise sut.GithubException("no history")
+            return [_commit("alice")]
+
+        repo = MagicMock()
+        repo.get_commits.side_effect = _raise_or_return
+        result = sut._history_reviewers(repo, {"bad.c", "good.c"}, exclude=set())
+        assert result == ["alice"]
+
+    def test_contributions_aggregate_across_files(self):
+        history = {
+            "a.c": [_commit("alice")],
+            "b.c": [_commit("alice"), _commit("bob")],
+        }
+        repo = _repo_with_history(history)
+        result = sut._history_reviewers(repo, {"a.c", "b.c"}, exclude=set())
+        assert result == ["alice", "bob"]
+
+
+# ---------------------------------------------------------------------------
+# _suggested_reviewers
+# ---------------------------------------------------------------------------
+
+
+def _gh_with_suggestions(payload):
+    """Github stub whose requester.graphql_query returns *payload*."""
+    gh = MagicMock()
+    gh.requester.graphql_query.return_value = ({}, payload)
+    return gh
+
+
+def _suggest_args():
+    return SimpleNamespace(org="zephyrproject-rtos", repo="zephyr")
+
+
+def _suggest_pr(number=99):
+    return SimpleNamespace(number=number)
+
+
+class TestSuggestedReviewers:
+    def test_returns_suggested_logins(self):
+        gh = _gh_with_suggestions(_suggested_payload([("alice", True), ("bob", True)]))
+        result = sut._suggested_reviewers(gh, _suggest_args(), _suggest_pr(), exclude=set())
+        assert result == ["alice", "bob"]
+
+    def test_authors_rank_ahead_of_commenters(self):
+        gh = _gh_with_suggestions(
+            _suggested_payload([("commenter", False), ("author", True)])
+        )
+        result = sut._suggested_reviewers(gh, _suggest_args(), _suggest_pr(), exclude=set())
+        assert result == ["author", "commenter"]
+
+    def test_excluded_logins_are_dropped(self):
+        gh = _gh_with_suggestions(_suggested_payload([("alice", True), ("known", True)]))
+        result = sut._suggested_reviewers(
+            gh, _suggest_args(), _suggest_pr(), exclude={"known"}
+        )
+        assert result == ["alice"]
+
+    def test_empty_suggestion_list(self):
+        gh = _gh_with_suggestions(_suggested_payload([]))
+        assert sut._suggested_reviewers(gh, _suggest_args(), _suggest_pr(), set()) == []
+
+    def test_null_suggestion_list_is_tolerated(self):
+        payload = {"data": {"repository": {"pullRequest": {"suggestedReviewers": None}}}}
+        gh = _gh_with_suggestions(payload)
+        assert sut._suggested_reviewers(gh, _suggest_args(), _suggest_pr(), set()) == []
+
+    def test_malformed_response_returns_empty(self):
+        gh = _gh_with_suggestions({"data": {"repository": None}})
+        assert sut._suggested_reviewers(gh, _suggest_args(), _suggest_pr(), set()) == []
+
+    def test_graphql_exception_returns_empty(self):
+        gh = MagicMock()
+        gh.requester.graphql_query.side_effect = sut.GithubException("boom")
+        assert sut._suggested_reviewers(gh, _suggest_args(), _suggest_pr(), set()) == []
+
+    def test_query_is_parameterised_with_pr_coordinates(self):
+        gh = _gh_with_suggestions(_suggested_payload([]))
+        sut._suggested_reviewers(gh, _suggest_args(), _suggest_pr(1234), set())
+        _query, variables = gh.requester.graphql_query.call_args.args
+        assert variables == {
+            "owner": "zephyrproject-rtos",
+            "name": "zephyr",
+            "number": 1234,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Heuristic reviewers  (process_pr integration)
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryReviewersIntegration:
+    def test_orphan_area_gets_history_reviewer(self):
+        """An area with no maintainers pulls a recent contributor as reviewer."""
+        area = _make_area("Orphan", maintainers=[], collaborators=[])
+        areas = {"subsys/orphan/foo.c": [area]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas)
+        gh.get_repo.return_value.get_commits.side_effect = lambda path: [
+            SimpleNamespace(author=SimpleNamespace(login="frequent_contributor"))
+        ]
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "frequent_contributor" in _reviewers_requested(pr)
+
+    def test_history_reviewer_excludes_pr_author(self):
+        area = _make_area("Orphan", maintainers=[], collaborators=[])
+        areas = {"subsys/orphan/foo.c": [area]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas, pr_user="self")
+        gh.get_repo.return_value.get_commits.side_effect = lambda path: [
+            SimpleNamespace(author=SimpleNamespace(login="self"))
+        ]
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "self" not in _reviewers_requested(pr)
+
+    def test_well_covered_area_skips_history_lookup(self):
+        """A fully-staffed area must not trigger any commit-history query."""
+        area = _make_area(
+            "Full", maintainers=["m"], collaborators=["c1", "c2", "c3"]
+        )
+        areas = {"subsys/full/foo.c": [area]}
+
+        gh, args, mf, _ = _make_process_pr_harness(areas)
+        sut.process_pr(gh, args, mf, 99)
+
+        gh.get_repo.return_value.get_commits.assert_not_called()
+
+    def test_well_covered_area_skips_suggestion_query(self):
+        """A fully-staffed area must not trigger the GraphQL query either."""
+        area = _make_area("Full", maintainers=["m"], collaborators=["c1", "c2", "c3"])
+        areas = {"subsys/full/foo.c": [area]}
+
+        gh, args, mf, _ = _make_process_pr_harness(areas)
+        sut.process_pr(gh, args, mf, 99)
+
+        gh.requester.graphql_query.assert_not_called()
+
+    def test_github_suggestion_is_preferred_over_history(self):
+        """When GitHub suggests reviewers, the commit walk is skipped."""
+        area = _make_area("Orphan", maintainers=[], collaborators=[])
+        areas = {"subsys/orphan/foo.c": [area]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas)
+        gh.requester.graphql_query.return_value = (
+            {},
+            _suggested_payload([("suggested_by_github", True)]),
+        )
+        gh.get_repo.return_value.get_commits.side_effect = lambda path: [
+            SimpleNamespace(author=SimpleNamespace(login="from_history"))
+        ]
+        sut.process_pr(gh, args, mf, 99)
+
+        requested = _reviewers_requested(pr)
+        assert "suggested_by_github" in requested
+        assert "from_history" not in requested
+        gh.get_repo.return_value.get_commits.assert_not_called()
+
+    def test_falls_back_to_history_when_github_suggests_nobody(self):
+        """GitHub's suggestions are empty for most PRs; the walk must cover that."""
+        area = _make_area("Orphan", maintainers=[], collaborators=[])
+        areas = {"subsys/orphan/foo.c": [area]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas)
+        gh.requester.graphql_query.return_value = ({}, _suggested_payload([]))
+        gh.get_repo.return_value.get_commits.side_effect = lambda path: [
+            SimpleNamespace(author=SimpleNamespace(login="from_history"))
+        ]
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "from_history" in _reviewers_requested(pr)
+
+    def test_github_suggestions_are_capped(self):
+        area = _make_area("Orphan", maintainers=[], collaborators=[])
+        areas = {"subsys/orphan/foo.c": [area]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas)
+        gh.requester.graphql_query.return_value = (
+            {},
+            _suggested_payload([(f"s{i}", True) for i in range(10)]),
+        )
+        sut.process_pr(gh, args, mf, 99)
+
+        requested = _reviewers_requested(pr)
+        assert len([r for r in requested if r.startswith("s")]) == sut.MAX_HISTORY_REVIEWERS
+
+    def test_github_suggestion_excludes_pr_author(self):
+        area = _make_area("Orphan", maintainers=[], collaborators=[])
+        areas = {"subsys/orphan/foo.c": [area]}
+
+        gh, args, mf, pr = _make_process_pr_harness(areas, pr_user="self")
+        gh.requester.graphql_query.return_value = (
+            {},
+            _suggested_payload([("self", True)]),
+        )
+        sut.process_pr(gh, args, mf, 99)
+
+        assert "self" not in _reviewers_requested(pr)

--- a/scripts/tests/ci/test_set_assignees.py
+++ b/scripts/tests/ci/test_set_assignees.py
@@ -541,6 +541,7 @@ def _make_process_pr_harness(areas_per_file, pr_user="someone"):
     pr.get_reviews.return_value = []
     pr.get_review_requests.return_value = ([], [])
     pr.get_issue_events.return_value = []
+    pr.get_issue_comments.return_value = []
 
     mf = MagicMock()
     mf.path2areas.side_effect = lambda p: areas_per_file.get(p, [])
@@ -1126,6 +1127,7 @@ def _make_add_reviewers_stubs(author="author"):
     pr.get_reviews.return_value = []
     pr.get_review_requests.return_value = ([], [])
     pr.get_issue_events.return_value = []
+    pr.get_issue_comments.return_value = []
 
     cache = {}
 
@@ -1224,3 +1226,167 @@ class TestReviewRequestRetry:
         sut._add_reviewers(gh, gh_repo, pr, args, [f"u{i}" for i in range(25)])
 
         assert pr.create_review_request.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Mention fallback
+# ---------------------------------------------------------------------------
+
+
+def _posted_comments(pr):
+    """Bodies of every comment created on *pr*."""
+    return [call.args[0] for call in pr.create_issue_comment.call_args_list]
+
+
+def _mentioned(pr):
+    """Logins @mentioned in the single comment posted on *pr*."""
+    bodies = _posted_comments(pr)
+    assert len(bodies) == 1, f"expected exactly one comment, got {len(bodies)}"
+    return [word[1:] for word in bodies[0].split() if word.startswith("@")]
+
+
+def _existing_comment(body):
+    comment = MagicMock()
+    comment.body = body
+    return comment
+
+
+class TestMentionFallback:
+    """People who cannot receive a formal review request are asked by name in
+    a comment instead of being dropped."""
+
+    def test_non_collaborator_is_mentioned_not_requested(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        gh_repo.has_in_collaborators.side_effect = lambda user: user.login != "outsider"
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["insider", "outsider"])
+
+        assert _reviewers_requested(pr) == ["insider"]
+        assert _mentioned(pr) == ["outsider"]
+
+    def test_candidates_dropped_by_retry_are_mentioned(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        candidates = [f"u{i}" for i in range(25)]
+        pr.create_review_request.side_effect = [sut.GithubException("too many"), None]
+
+        sut._add_reviewers(gh, gh_repo, pr, args, candidates)
+
+        assert _mentioned(pr) == candidates[sut.REVIEWER_RETRY_BATCH :]
+
+    def test_everyone_is_mentioned_when_the_request_fails_outright(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        pr.create_review_request.side_effect = sut.GithubException("nope")
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["a", "b"])
+
+        assert _mentioned(pr) == ["a", "b"]
+
+    def test_self_removed_user_is_never_mentioned(self):
+        """Opting out must not be routed around by a mention."""
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        quitter = gh.get_user("quitter")
+        pr.get_issue_events.return_value = [
+            SimpleNamespace(
+                event="review_request_removed", actor=quitter, requested_reviewer=quitter
+            )
+        ]
+        # Also a non-collaborator, so only the opt-out can keep them out.
+        gh_repo.has_in_collaborators.side_effect = lambda user: user.login != "quitter"
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["quitter", "keeper"])
+
+        assert _reviewers_requested(pr) == ["keeper"]
+        pr.create_issue_comment.assert_not_called()
+
+    def test_author_and_existing_reviewers_are_not_mentioned(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs(author="me")
+        pr.get_review_requests.return_value = ([gh.get_user("already")], [])
+        gh_repo.has_in_collaborators.return_value = False
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["me", "already", "outsider"])
+
+        assert _mentioned(pr) == ["outsider"]
+
+    def test_nobody_to_mention_posts_no_comment(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["a", "b"])
+
+        pr.create_issue_comment.assert_not_called()
+
+    def test_comment_carries_the_marker(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        gh_repo.has_in_collaborators.return_value = False
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["outsider"])
+
+        assert sut.MENTION_MARKER in _posted_comments(pr)[0]
+
+    def test_dry_run_posts_no_comment(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        args.dry_run = True
+        gh_repo.has_in_collaborators.return_value = False
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["outsider"])
+
+        pr.create_issue_comment.assert_not_called()
+
+    def test_comment_creation_failure_does_not_raise(self):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        gh_repo.has_in_collaborators.return_value = False
+        pr.create_issue_comment.side_effect = sut.GithubException("no write access")
+
+        sut._add_reviewers(gh, gh_repo, pr, args, ["outsider"])
+
+
+class TestMentionCommentIsIdempotent:
+    """Re-running over the same PR must update the existing comment rather
+    than posting another one."""
+
+    def _run(self, existing_body, candidates=("outsider",)):
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        gh_repo.has_in_collaborators.return_value = False
+        existing = _existing_comment(existing_body)
+        pr.get_issue_comments.return_value = [existing]
+        sut._add_reviewers(gh, gh_repo, pr, args, list(candidates))
+        return pr, existing
+
+    def test_existing_comment_is_edited_when_the_set_changes(self):
+        stale = f"{sut.MENTION_MARKER}\n@someone_else\n\nold text"
+        pr, existing = self._run(stale)
+
+        pr.create_issue_comment.assert_not_called()
+        existing.edit.assert_called_once()
+        assert "@outsider" in existing.edit.call_args.args[0]
+
+    def test_unchanged_comment_is_left_alone(self):
+        """A second identical run must not edit, to avoid timeline noise."""
+        gh, gh_repo, pr, args = _make_add_reviewers_stubs()
+        gh_repo.has_in_collaborators.return_value = False
+        sut._add_reviewers(gh, gh_repo, pr, args, ["outsider"])
+        first_body = _posted_comments(pr)[0]
+
+        pr2, existing = self._run(first_body)
+
+        pr2.create_issue_comment.assert_not_called()
+        existing.edit.assert_not_called()
+
+    def test_unrelated_comments_are_ignored(self):
+        pr, _ = self._run("just a normal review comment, no marker")
+
+        assert len(_posted_comments(pr)) == 1
+
+    def test_maintainer_outside_the_org_reaches_the_comment(self):
+        """End-to-end: an area maintainer without push access is still asked."""
+        area = _make_area("Net", maintainers=["outside_m"], collaborators=["inside_c"])
+        gh, args, mf, pr = _make_process_pr_harness({"subsys/net/foo.c": [area]})
+        gh.requester.graphql_query.return_value = ({}, _suggested_payload([]))
+        gh.get_repo.return_value.get_commits.side_effect = lambda path: []
+        gh.get_repo.return_value.has_in_collaborators.side_effect = (
+            lambda user: user.login != "outside_m"
+        )
+
+        sut.process_pr(gh, args, mf, 99)
+
+        assert _reviewers_requested(pr) == ["inside_c"]
+        assert _mentioned(pr) == ["outside_m"]


### PR DESCRIPTION
Reviewer candidates are now ordered maintainers-first, so a PR touching many
areas can no longer spend its review slots on the top areas' collaborators
while the maintainers of every other touched area go unasked.

Areas that MAINTAINERS.yml under-covers — no maintainers, or barely any collaborators,
and files it doesn't cover at all now fall back to GitHub's own suggested
reviewers, and then to the recent contributors to the changed files;

The self-imposed 15-reviewer cap is gone along with the maintainer-only
overflow path it fed, since GitHub documents no such limit, PRs carrying more
than 15 exist in this repo, and the tier ordering now does the job that cap was
reaching for. Anyone who still can't be added — a non-collaborator, or a
request GitHub refuses outright — is @mentioned in a comment asking for review
rather than being silently dropped.
