### PR TITLE
Bluetooth: add @since and @version to bt_addr

### DIFF
--- a/include/zephyr/bluetooth/addr.h
+++ b/include/zephyr/bluetooth/addr.h
@@ -22,6 +22,8 @@ extern "C" {
 /**
  * @brief Bluetooth device address definitions and utilities.
  * @defgroup bt_addr Device Address
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup bluetooth
  * @{
  */


### PR DESCRIPTION
The bt_addr group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups
with no version are assumed stable by scripts/ci/check_api_compat.py
so that it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 36 releases since 1.0
  - 229 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

bt_addr_le_t has been public since 2015-05-25 ("Bluetooth: Introduce
dedicated Bluetooth address types"), which predates v1.0.0. addr.h
itself was only split out in 2019; the types it holds are far older.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
