### PR TITLE
init: add @since and @version to sys_init

### DIFF
--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -19,6 +19,8 @@ extern "C" {
 
 /**
  * @defgroup sys_init System Initialization
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup os_services
  *
  * Zephyr offers an infrastructure to call initialization code before `main`.


### PR DESCRIPTION
The sys_init group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups
with no version are assumed stable by scripts/ci/check_api_compat.py
so that it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 36 releases since 1.0
  - 1068 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

Most included public API in the tree: 449 drivers, 260 SoCs, 183
subsystem files and 75 boards depend on it.

SYS_INIT() has been available from a public header since 2015-10-14
("init: Support fine-grained device initialization"), which predates
v1.0.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
