### PR TITLE
Bluetooth: add @since and @version to bt_att

### DIFF
--- a/include/zephyr/bluetooth/att.h
+++ b/include/zephyr/bluetooth/att.h
@@ -13,6 +13,8 @@
 /**
  * @brief Attribute Protocol (ATT)
  * @defgroup bt_att Attribute Protocol (ATT)
+ * @since 1.1
+ * @version 1.0.0
  * @ingroup bluetooth
  * @{
  */


### PR DESCRIPTION
The bt_att group declared no @version, so neither tooling nor readers
could tell what stability guarantees the API offers. Groups with no
version are assumed stable by scripts/ci/check_api_compat.py so that it
fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 35 releases since 1.1
  - 79 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

The public header was added on 2016-02-17 ("Bluetooth: Add public
att.h header file"), first released in v1.1.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
