### PR TITLE
Bluetooth: Audio: add @since and @version to bt_audio

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -15,6 +15,8 @@
 /**
  * @brief Bluetooth Audio
  * @defgroup bt_audio Bluetooth Audio
+ * @since 3.1
+ * @version 0.8.0
  * @ingroup bluetooth
  * @{
  */


### PR DESCRIPTION
The bt_audio group declared no @version, so neither tooling nor readers
could tell what stability guarantees the API offers. Groups with no
version are assumed stable by scripts/ci/check_api_compat.py so that it
fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 10 releases since 3.1
  - 144 in-tree users outside include/

Unstable rather than stable despite clearing the release and adoption
bars: bt_audio_codec_cfg took a breaking change in 4.3, which now
requires target latency and target PHY to be set explicitly, and the
header has 129 lifetime commits. LE Audio is still moving.

bt_audio_codec_cfg, bt_audio_codec_cap and bt_audio_to_str are nested
inside this group and inherit the same state.

bt_audio_codec_cfg appeared on 2022-03-29 ("Bluetooth: Stream: Add
functions to parse codec config"), first released in v3.1.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
