### PR TITLE
Bluetooth: add @since and @version to bt_buf

### DIFF
--- a/include/zephyr/bluetooth/buf.h
+++ b/include/zephyr/bluetooth/buf.h
@@ -14,6 +14,8 @@
 /**
  * @brief Data buffers
  * @defgroup bt_buf Data buffers
+ * @since 1.7
+ * @version 1.0.0
  * @ingroup bluetooth
  * @{
  */


### PR DESCRIPTION
The bt_buf group declared no @version, so neither tooling nor readers
could tell what stability guarantees the API offers. Groups with no
version are assumed stable by scripts/ci/check_api_compat.py so that it
fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 33 releases since 1.7
  - 62 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

bt_buf_get_rx() has been public since 2016-12-25 ("Bluetooth: Add
bt_buf_get_rx() helper API"), first released in v1.7.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
