### PR TITLE
Bluetooth: add @since and @version to bt_conn

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -14,6 +14,8 @@
 /**
  * @brief Connection management
  * @defgroup bt_conn Connection management
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup bluetooth
  * @{
  */


### PR DESCRIPTION
The bt_conn group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups
with no version are assumed stable by scripts/ci/check_api_compat.py
so that it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 36 releases since 1.0
  - 483 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

Recent work on this header is additive (bt_conn_drop(), bt_conn_take(),
sniff subrating) and the four removals in flight went through the
documented deprecation path, both of which a stable API permits.

bt_conn_ref() has been public since 2015-10-23 ("Bluetooth: Rename
bt_conn_get/put to bt_conn_ref/unref"), which predates v1.0.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
