### PR TITLE
Bluetooth: add @since and @version to bt_l2cap

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -14,6 +14,8 @@
 /**
  * @brief L2CAP
  * @defgroup bt_l2cap L2CAP
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup bluetooth
  * @{
  */


### PR DESCRIPTION
The bt_l2cap group declared no @version, so neither tooling nor readers
could tell what stability guarantees the API offers. Groups with no
version are assumed stable by scripts/ci/check_api_compat.py so that it
fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 36 releases since 1.0
  - 93 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

l2cap_cid declares @ingroup bt_l2cap and inherits this state.

bt_l2cap_chan_send() has been public since 2015-11-12 ("Bluetooth:
L2CAP: Add bt_l2cap_chan_send"), which predates v1.0.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
