### PR TITLE
cache: add @since and @version to cache_interface

### DIFF
--- a/include/zephyr/cache.h
+++ b/include/zephyr/cache.h
@@ -34,6 +34,8 @@ extern "C" {
 
 /**
  * @defgroup cache_interface Cache Interface
+ * @since 3.3
+ * @version 1.0.0
  * @ingroup os_services
  * @{
  */


### PR DESCRIPTION
The cache_interface group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups
with no version are assumed stable by scripts/ci/check_api_compat.py
so that it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 7 releases since 3.3
  - 247 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

Deriving @since from the file would have claimed 1.0: git --follow
traces cache.h back through a rename to an unrelated 2015 ancestor.

The current sys_cache_*() API replaced the previous one on 2022-10-05
("cache: Rework cache API"), first released in v3.3.0. The file itself
is older, but the API it declares today is not.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
