### PR TITLE
sys: add @since and @version to crc

### DIFF
--- a/include/zephyr/sys/crc.h
+++ b/include/zephyr/sys/crc.h
@@ -47,6 +47,8 @@ extern "C" {
 
 /**
  * @defgroup crc CRC
+ * @since 1.8
+ * @version 1.0.0
  * @ingroup checksum
  * @{
  */


### PR DESCRIPTION
The crc group declared no @version, so neither tooling nor readers could
tell what stability guarantees the API offers. Groups with no version
are assumed stable by scripts/ci/check_api_compat.py so that it fails
closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 28 releases since 1.8
  - 85 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

The enclosing checksum group is an empty container that groups this
one under os_services, so the version belongs on crc, which is where
the API actually lives.

The API landed on 2017-03-30 ("crc16: Create function for computing
CRC 16"), first released in v1.8.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
