### PR TITLE
sys: add @since and @version to iterable_section_apis

### DIFF
--- a/include/zephyr/sys/iterable_sections.h
+++ b/include/zephyr/sys/iterable_sections.h
@@ -23,6 +23,8 @@ extern "C" {
 /**
  * @brief Iterable Sections APIs
  * @defgroup iterable_section_apis Iterable Sections APIs
+ * @since 2.7
+ * @version 1.0.0
  * @ingroup os_services
  * @{
  */


### PR DESCRIPTION
The iterable_section_apis group declared no @version, so neither tooling
nor readers could tell what stability guarantees the API offers. Groups
with no version are assumed stable by scripts/ci/check_api_compat.py so
that it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 14 releases since 2.7
  - 82 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

Neither of the two dates a naive lookup would find is right: the
Z_-prefixed internal form dates to v2.0.0, and this header only came
into existence in v3.4.0 when the macros were moved into it.

The macros became public API on 2021-08-03 ("toolchain: redefine
iterable section APIs as non internal"), first released in v2.7.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
