### PR TITLE
sys: add @since and @version to math_extras

### DIFF
--- a/include/zephyr/sys/math_extras.h
+++ b/include/zephyr/sys/math_extras.h
@@ -13,6 +13,8 @@
 /**
  * @brief Extra arithmetic and bit manipulation functions.
  * @defgroup math_extras Math extras
+ * @since 2.0
+ * @version 1.0.0
  * @ingroup utilities
  *
  * Portable wrapper functions for a number of arithmetic and bit-counting functions that are often


### PR DESCRIPTION
The math_extras group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 21 releases since 2.0
  - 57 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

The portable implementations landed on 2019-05-07 ("misc: Portable
math_extras.h implementations"), first released in v2.0.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
