### PR TITLE
sys: add @since and @version to single-linked-list_apis

### DIFF
--- a/include/zephyr/sys/slist.h
+++ b/include/zephyr/sys/slist.h
@@ -10,6 +10,8 @@
   * @ingroup single-linked-list_apis
   *
   * @defgroup single-linked-list_apis Single-linked list
+  * @since 1.2
+  * @version 1.0.0
   * @ingroup datastructure_apis
   *
   * @brief Single-linked list implementation.


### PR DESCRIPTION
The single-linked-list_apis group declared no @version, so neither
tooling nor readers could tell what stability guarantees the API offers.
Groups with no version are assumed stable by
scripts/ci/check_api_compat.py so that it fails closed, but assuming is
not the same as stating.

Evidence from the tree:
  - shipped in 34 releases since 1.2
  - 148 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

The header has seen 8 commits in its lifetime and 1 since v4.2.0, so
the interface has long since settled.

The API landed on 2016-03-22 ("include: misc: Add a generic single
linked list API"), first released in v1.2.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
