### PR TITLE
pm: add @since and @version to subsys_pm_device_runtime

### DIFF
--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -24,6 +24,8 @@ extern "C" {
 /**
  * @brief Device Runtime Power Management API
  * @defgroup subsys_pm_device_runtime Device Runtime
+ * @since 3.0
+ * @version 1.0.0
  * @ingroup subsys_pm
  * @{
  */


### PR DESCRIPTION
The subsys_pm_device_runtime group declared no @version, so neither
tooling nor readers could tell what stability guarantees the API offers.
Groups with no version are assumed stable by
scripts/ci/check_api_compat.py so that it fails closed, but assuming is
not the same as stating.

Evidence from the tree:
  - shipped in 12 releases since 3.0
  - 175 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

124 drivers use runtime PM directly.

pm_device_runtime_get() landed on 2021-11-02 ("pm: device: runtime: use
pm_device_runtime* namespace"), first released in v3.0.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
