### PR TITLE
pm: add @version to subsys_pm_sys

### DIFF
--- a/include/zephyr/pm/pm.h
+++ b/include/zephyr/pm/pm.h
@@ -37,6 +37,7 @@ extern "C" {
  * @brief System Power Management API
  * @defgroup subsys_pm_sys System
  * @since 1.2
+ * @version 1.0.0
  * @ingroup subsys_pm
  * @{
  */


### PR DESCRIPTION
The subsys_pm_sys group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 34 releases since 1.2
  - 106 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

subsys_pm is a container with no content of its own, and
subsys_pm_sys_hooks names this group as its parent, so tagging the
group that actually holds the system PM API covers both.

The group already declares @since 1.2, which is left as the tree has
it; only the maturity statement was missing.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
