### PR TITLE
pm: add @since and @version to subsys_pm_sys_policy

### DIFF
--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -28,6 +28,8 @@ extern "C" {
 /**
  * @brief System Power Management Policy API
  * @defgroup subsys_pm_sys_policy Policy
+ * @since 2.7
+ * @version 1.0.0
  * @ingroup subsys_pm_sys
  * @{
  */


### PR DESCRIPTION
The subsys_pm_sys_policy group declared no @version, so neither tooling
nor readers could tell what stability guarantees the API offers. Groups
with no version are assumed stable by scripts/ci/check_api_compat.py so
that it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 14 releases since 2.7
  - 136 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

105 of its users are drivers.

The current pm_policy_*() header was created on 2021-06-11 ("pm: Fix
policy manager header"), first released in v2.7.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
