### PR TITLE
sys: add @since and @version to sys_check_apis

### DIFF
--- a/include/zephyr/sys/check.h
+++ b/include/zephyr/sys/check.h
@@ -17,6 +17,8 @@
 
 /**
  * @defgroup sys_check_apis Error checking
+ * @since 2.2
+ * @version 1.0.0
  * @ingroup os_services
  * @{
  */


### PR DESCRIPTION
The sys_check_apis group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 19 releases since 2.2
  - 63 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

Used by 30 drivers and 12 kernel files for argument validation.

CHECKIF() landed on 2019-11-24 ("base: add error checking macros"),
first released in v2.2.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
