### PR TITLE
sys: add @since and @version to sys_io_apis

### DIFF
--- a/include/zephyr/sys/sys_io.h
+++ b/include/zephyr/sys/sys_io.h
@@ -25,6 +25,8 @@ extern "C" {
  * @brief System I/O APIs
  *
  * @defgroup sys_io_apis System I/O APIs
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup utilities
  *
  * Low-level primitives for port I/O, memory-mapped register I/O, and in-memory bit manipulation.


### PR DESCRIPTION
The sys_io_apis group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 36 releases since 1.0
  - 138 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable:
in use and available in at least two development releases.

sys_io_port_apis, sys_io_mmio_apis and sys_io_bits_apis declare
@ingroup sys_io_apis and inherit this state.

The API landed on 2015-08-21 ("API: Add a generic API for port and mem
mapped registers functions"), which predates v1.0.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
