### PR TITLE
tests: samples: counter: add nucode_nu32 board overlays

### DIFF
--- a/samples/drivers/counter/alarm/boards/nucode_nu32_nrf52832.overlay
+++ b/samples/drivers/counter/alarm/boards/nucode_nu32_nrf52832.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026 NUCODE Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&rtc0 {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nucode_nu32_nrf52832.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucode_nu32_nrf52832.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 NUCODE Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timer0 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer1 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer2 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer3 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer4 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&rtc0 {
+	status = "okay";
+	ppi-wrap;
+};
+
+&rtc2 {
+	status = "okay";
+	ppi-wrap;
+};


### PR DESCRIPTION
The two NUCODE boards expose three board targets, and all three declare `counter` in their twister `supported:` list:

```
nucode_nu32/nrf52832
nucode_nu40/nrf52840
nucode_nu40/nrf52840/bare
```

No timer or RTC is enabled anywhere in the SoC or board devicetree though, so `drivers.counter.basic_api` gets selected for them, builds fine, and passes while collecting an empty device list. Nothing is actually exercised, and because it builds, CI never surfaces it.

This adds the missing per-board overlays for `nucode_nu32/nrf52832`, mirroring the existing `nrf52dk_nrf52832` ones.

Verified on a NUCODE NU32 module (nRF52832-QFAA) over SEGGER J-Link. Before the overlay the test build enumerates nothing:

```
nordic_nrf_timer_NUM_OKAY = 0
nordic_nrf_rtc_NUM_OKAY   = 0
```

After, 5 timers and 2 RTCs are picked up and the suite runs for real:

```
SUITE PASS - 100.00% [counter_basic]: pass = 10, fail = 0, skip = 0, total = 10
SUITE PASS - 100.00% [counter_no_callback]: pass = 1, fail = 0, skip = 0, total = 1
PROJECT EXECUTION SUCCESSFUL
```

The alarm sample, which does not build at all for this target today, also runs with correct timing (2/6/14/30 s cumulative).

`nucode_nu40` has the same gap and will follow in a separate PR.
