### PR TITLE
timing: add @since and @version to timing_api

### DIFF
--- a/include/zephyr/timing/timing.h
+++ b/include/zephyr/timing/timing.h
@@ -17,6 +17,8 @@ extern "C" {
 /**
  * @brief Timing Measurement APIs
  * @defgroup timing_api Timing Measurement APIs
+ * @since 2.4
+ * @version 1.0.0
  * @ingroup os_services
  *
  * The timing measurement APIs can be used to obtain execution


### PR DESCRIPTION
The timing_api group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 17 releases since 2.4
  - 41 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

timing_api_soc and timing_api_board name this group as their parent
and inherit the state.

timing_init() landed on 2020-08-05 ("timing: introduce timing functions
as a generic feature"), first released in v2.4.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
