### PR TITLE
sys: add @since and @version to sys_poweroff

### DIFF
--- a/include/zephyr/sys/poweroff.h
+++ b/include/zephyr/sys/poweroff.h
@@ -21,6 +21,8 @@ extern "C" {
 
 /**
  * @defgroup sys_poweroff System power off
+ * @since 3.5
+ * @version 1.0.0
  * @ingroup os_services
  * @{
  */


### PR DESCRIPTION
The sys_poweroff group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 8 releases since 3.5
  - 51 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

Younger than most entries here at 8 releases, but the header has taken
only 4 commits in its lifetime and 1 since v4.2.0: the interface has
not moved since it was introduced.

sys_poweroff() landed on 2023-07-20 ("lib: os: add support for system
power off"), first released in v3.5.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
