### PR TITLE
tracing: add @since and @version to subsys_tracing

### DIFF
--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -56,6 +56,8 @@
  * running on a host to visualize the inner-working of the kernel and various other subsystems.
  *
  * @defgroup subsys_tracing Tracing
+ * @since 1.13
+ * @version 0.8.0
  * @ingroup os_services
  * @{
  */


### PR DESCRIPTION
The subsys_tracing group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 23 releases since 1.13
  - 37 in-tree users outside include/

Unstable means the API is settling but not yet proven in the field, and
that changes are not announced.

Unstable rather than stable despite 23 releases and 37 users: the
header has taken 13 commits since v4.2.0, among them a canonical hook
header and out-of-tree format support, and the tracing API is under
active rework. Unstable states that plainly without freezing it.

The generic hooks landed on 2018-07-04 ("tracing: support generic
tracing hooks"), first released in v1.13.0.

Assisted-by: Claude:claude-opus-4-8
