### PR TITLE
sys: add @since and @version to ring_buffer_apis

### DIFF
--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -20,6 +20,8 @@ extern "C" {
  * @ingroup ring_buffer_apis
  *
  * @defgroup ring_buffer_apis Ring Buffer APIs
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup datastructure_apis
  *
  * @brief Simple ring buffer implementation.


### PR DESCRIPTION
The ring_buffer_apis group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 36 releases since 1.0
  - 52 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

The API landed on 2015-08-27 ("nanokernel: add optional ring buffer
data type"), which predates v1.0.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
