### PR TITLE
sys: add @since and @version to doubly-linked-list_apis

### DIFF
--- a/include/zephyr/sys/dlist.h
+++ b/include/zephyr/sys/dlist.h
@@ -10,6 +10,8 @@
  * @ingroup doubly-linked-list_apis
  *
  * @defgroup doubly-linked-list_apis Doubly-linked list
+ * @since 1.0
+ * @version 1.0.0
  * @ingroup datastructure_apis
  *
  * @brief Doubly-linked list implementation


### PR DESCRIPTION
The doubly-linked-list_apis group declared no @version, so neither
tooling nor readers could tell what stability guarantees the API offers.
Groups with no version are assumed stable by
scripts/ci/check_api_compat.py so that it fails closed, but assuming is
not the same as stating.

Evidence from the tree:
  - shipped in 36 releases since 1.0
  - 33 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

The API landed on 2015-06-14 ("dlist: enhance library and make all
functions inline"), which predates v1.0.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
