### PR TITLE
Bluetooth: Classic: add @since and @version to bt_sdp

### DIFF
--- a/include/zephyr/bluetooth/classic/sdp.h
+++ b/include/zephyr/bluetooth/classic/sdp.h
@@ -14,6 +14,8 @@
  * @file
  * @brief Service Discovery Protocol (SDP)
  * @defgroup bt_sdp Service Discovery Protocol (SDP)
+ * @since 1.6
+ * @version 0.1.0
  * @ingroup bluetooth
  * @{
  */


### PR DESCRIPTION
The bt_sdp group declared no @version, so neither tooling nor readers
could tell what stability guarantees the API offers. Groups with no
version are assumed stable by scripts/ci/check_api_compat.py so that it
fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 30 releases since 1.6
  - 34 in-tree users outside include/

Experimental means the API may change or be removed at any time, which
is what its own subsystem already tells users.

Experimental, not stable: BT_CLASSIC is prompted "Bluetooth BR/EDR
support [EXPERIMENTAL]", and 12 of this header's 15 lifetime commits
landed since v4.2.0, adding BIP, AVDTP and a record-storage rework.
Age and adoption alone would have proposed stable, which would
contradict what the subsystem tells users.

bt_sdp_register_service() landed on 2016-10-17 ("Bluetooth: SDP:
Server: Support service record registration"), first released in
v1.6.0.

Assisted-by: Claude:claude-opus-4-8
