### PR TITLE
sys: add @since and @version to timeutil_apis

### DIFF
--- a/include/zephyr/sys/timeutil.h
+++ b/include/zephyr/sys/timeutil.h
@@ -80,6 +80,8 @@ extern "C" {
 
 /**
  * @defgroup timeutil_apis Time Utility APIs
+ * @since 2.0
+ * @version 1.0.0
  * @ingroup utilities
  * @defgroup timeutil_repr_apis Time Representation APIs
  * @ingroup timeutil_apis


### PR DESCRIPTION
The timeutil_apis group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 20 releases since 2.0
  - 29 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

This group is the root of the time utility family. Its four subgroups
-- timeutil_repr_apis, timeutil_sync_apis, timeutil_timespec_apis and
timeutil_unit_apis, the last of which lives in time_units.h -- name it
as their parent and inherit the state, so one statement covers the
whole family.

The module landed on 2019-07-01 ("sys: timeutil: add module"), first
released in v2.0.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
