### PR TITLE
kernel: add @since and @version to thread_stack_api

### DIFF
--- a/include/zephyr/kernel/thread_stack.h
+++ b/include/zephyr/kernel/thread_stack.h
@@ -14,6 +14,8 @@
  * @brief Thread Stack APIs
  * @ingroup kernel_apis
  * @defgroup thread_stack_api Thread Stack APIs
+ * @since 1.8
+ * @version 1.0.0
  * @{
  * @}
  */


### PR DESCRIPTION
The thread_stack_api group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 18 releases since 1.8
  - 24 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

K_THREAD_STACK_DEFINE() landed on 2017-06-02 ("kernel: introduce stack
definition macros"), merged 2017-06-09 and first released in v1.8.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
