### PR TITLE
sys: add @since and @version to low_level_heap_allocator

### DIFF
--- a/include/zephyr/sys/sys_heap.h
+++ b/include/zephyr/sys/sys_heap.h
@@ -75,6 +75,8 @@ struct z_heap_stress_result {
 
 /**
  * @defgroup low_level_heap_allocator Low Level Heap Allocator
+ * @since 2.3
+ * @version 1.0.0
  * @ingroup heaps
  * @{
  */


### PR DESCRIPTION
The low_level_heap_allocator group declared no @version, so neither
tooling nor readers could tell what stability guarantees the API offers.
Groups with no version are assumed stable by
scripts/ci/check_api_compat.py so that it fails closed, but assuming is
not the same as stating.

Evidence from the tree:
  - shipped in 18 releases since 2.3
  - 23 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

sys_heap landed on 2019-07-17 ("lib/os: Add sys_heap, a new/simpler/
faster memory allocator"), first released in v2.3.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
