### PR TITLE
sys: add @since and @version to linear_range

### DIFF
--- a/include/zephyr/sys/linear_range.h
+++ b/include/zephyr/sys/linear_range.h
@@ -24,6 +24,8 @@ extern "C" {
 
 /**
  * @defgroup linear_range Linear Range
+ * @since 3.3
+ * @version 1.0.0
  * @ingroup utilities
  *
  * The linear range API maps values in a linear range to a range index. A linear


### PR DESCRIPTION
The linear_range group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 10 releases since 3.3
  - 28 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

Mostly consumed by regulator and charger drivers converting between
raw and real values.

The API landed on 2022-11-22 ("sys: linear_range: initial API"), first
released in v3.3.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
