### PR TITLE
ipc: add @since and @version to ipc_service_api

### DIFF
--- a/include/zephyr/ipc/ipc_service.h
+++ b/include/zephyr/ipc/ipc_service.h
@@ -26,6 +26,8 @@ extern "C" {
 /**
  * @brief IPC Service API
  * @defgroup ipc_service_api IPC service APIs
+ * @since 2.7
+ * @version 1.0.0
  * @ingroup ipc
  * @{
  */


### PR DESCRIPTION
The ipc_service_api group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 14 releases since 2.7
  - 33 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

The API landed on 2021-06-09 ("ipc: Added IPC Service to support
different transport backends"), first released in v2.7.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
