### PR TITLE
Bluetooth: Classic: add @since and @version to bt_rfcomm

### DIFF
--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -13,6 +13,8 @@
 /**
  * @brief RFCOMM
  * @defgroup bt_rfcomm RFCOMM
+ * @since 1.6
+ * @version 0.1.0
  * @ingroup bluetooth
  * @{
  */


### PR DESCRIPTION
The bt_rfcomm group declared no @version, so neither tooling nor readers
could tell what stability guarantees the API offers. Groups with no
version are assumed stable by scripts/ci/check_api_compat.py so that it
fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 30 releases since 1.6
  - 24 in-tree users outside include/

Experimental means the API may change or be removed at any time, which
is what its own subsystem already tells users.

Experimental, not stable, despite 30 releases: BT_RFCOMM is prompted
"Bluetooth RFCOMM protocol support [EXPERIMENTAL]" and selects
EXPERIMENTAL. Longevity is not maturity when the subsystem says
otherwise.

bt_rfcomm_dlc_connect() landed on 2016-10-21 ("Bluetooth: RFCOMM:
Initiate session connection"), first released in v1.6.0.

Assisted-by: Claude:claude-opus-4-8
