### PR TITLE
Bluetooth: add @since and @version to bt_ots

### DIFF
--- a/include/zephyr/bluetooth/services/ots.h
+++ b/include/zephyr/bluetooth/services/ots.h
@@ -10,6 +10,8 @@
 /**
  * @brief Object Transfer Service (OTS)
  * @defgroup bt_ots Object Transfer Service (OTS)
+ * @since 2.4
+ * @version 0.1.0
  * @ingroup bluetooth
  * @{
  *


### PR DESCRIPTION
The bt_ots group declared no @version, so neither tooling nor readers
could tell what stability guarantees the API offers. Groups with no
version are assumed stable by scripts/ci/check_api_compat.py so that it
fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 17 releases since 2.4
  - 23 in-tree users outside include/

Experimental means the API may change or be removed at any time, which
is what its own subsystem already tells users.

Experimental, not stable: the header itself states "[Experimental]
Users should note that the APIs can change". The declared version now
agrees with that sentence.

The service landed on 2020-07-23 ("bluetooth: services: add Object
Transfer service"), first released in v2.4.0.

Assisted-by: Claude:claude-opus-4-8
