### PR TITLE
Bluetooth: add @since and @version to bt_crypto

### DIFF
--- a/include/zephyr/bluetooth/crypto.h
+++ b/include/zephyr/bluetooth/crypto.h
@@ -14,6 +14,8 @@
 /**
  * @brief Cryptography
  * @defgroup bt_crypto Cryptography
+ * @since 1.8
+ * @version 1.0.0
  * @ingroup bluetooth
  * @{
  */


### PR DESCRIPTION
The bt_crypto group declared no @version, so neither tooling nor readers
could tell what stability guarantees the API offers. Groups with no
version are assumed stable by scripts/ci/check_api_compat.py so that it
fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 28 releases since 1.8
  - 33 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

The header has taken no commits at all since v4.2.0 and 4 in its
lifetime.

bt_encrypt_le() landed on 2017-03-16 ("Bluetooth: Introduce public
big-endian AES API"), first released in v1.8.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
