### PR TITLE
Bluetooth: add @since and @version to bt_byteorder

### DIFF
--- a/include/zephyr/bluetooth/byteorder.h
+++ b/include/zephyr/bluetooth/byteorder.h
@@ -14,6 +14,8 @@
 /**
  * @brief Byteorder
  * @defgroup bt_byteorder Byteorder
+ * @since 3.4
+ * @version 1.0.0
  * @ingroup bluetooth
  * @{
  */


### PR DESCRIPTION
The bt_byteorder group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 9 releases since 3.4
  - 28 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

The header has taken no commits since v4.2.0 and 3 in its lifetime.

The macros landed on 2022-08-30 ("include: Bluetooth: Add
BT_BYTES_LIST_LEXX macros"), merged 2023-05-08 and first released in
v3.4.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
