### PR TITLE
usb: add @since and @version to usb_host_core_api

### DIFF
--- a/include/zephyr/usb/usbh.h
+++ b/include/zephyr/usb/usbh.h
@@ -30,6 +30,8 @@ extern "C" {
 /**
  * @brief USB HOST Core Layer API
  * @defgroup usb_host_core_api USB Host Core API
+ * @since 3.3
+ * @version 0.1.0
  * @ingroup usb
  * @{
  */


### PR DESCRIPTION
The usb_host_core_api group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 10 releases since 3.3
  - 20 in-tree users outside include/

Experimental means the API may change or be removed at any time, which
is what its own subsystem already tells users.

Experimental, not stable: the file's own brief calls this the "New
experimental USB device stack APIs and structures", and the header has
taken 6 commits since v4.2.0. The USB host stack is still being built
out.

Initial USB host support landed on 2022-02-17 ("usb: add initial USB
host support"), first released in v3.3.0.

Assisted-by: Claude:claude-opus-4-8
