### PR TITLE
data: add @since and @version to json

### DIFF
--- a/include/zephyr/data/json.h
+++ b/include/zephyr/data/json.h
@@ -19,6 +19,8 @@ extern "C" {
 
 /**
  * @defgroup json JSON
+ * @since 1.10
+ * @version 1.0.0
  * @ingroup utilities
  * @{
  */


### PR DESCRIPTION
The json group declared no @version, so neither tooling nor readers
could tell what stability guarantees the API offers. Groups with no
version are assumed stable by scripts/ci/check_api_compat.py so that it
fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 29 releases since 1.10
  - 21 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

json.h became a public header on 2017-09-04 ("lib: json: move json.h
to include/"), merged 2017-10-03 and first released in v1.10.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
