### PR TITLE
Bluetooth: add @since and @version to hci_raw

### DIFF
--- a/include/zephyr/bluetooth/hci_raw.h
+++ b/include/zephyr/bluetooth/hci_raw.h
@@ -13,6 +13,8 @@
 /**
  * @brief HCI RAW channel
  * @defgroup hci_raw HCI RAW channel
+ * @since 2.3
+ * @version 1.0.0
  * @ingroup bluetooth
  * @{
  */


### PR DESCRIPTION
The hci_raw group declared no @version, so neither tooling nor readers
could tell what stability guarantees the API offers. Groups with no
version are assumed stable by scripts/ci/check_api_compat.py so that it
fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 20 releases since 2.3
  - 18 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

The header has taken no commits since v4.2.0 and 5 in its lifetime.

bt_hci_raw landed on 2020-03-18 ("Bluetooth: hci_raw: Add support for
using H:4 transport"), merged 2020-04-20 and first released in v2.3.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
