### PR TITLE
debug: add @since and @version to coredump_apis

### DIFF
--- a/include/zephyr/debug/coredump.h
+++ b/include/zephyr/debug/coredump.h
@@ -33,6 +33,8 @@ extern "C" {
  * @file
  *
  * @defgroup coredump_apis Coredump APIs
+ * @since 2.4
+ * @version 1.0.0
  * @ingroup debug
  * @brief Coredump APIs
  * @{


### PR DESCRIPTION
The coredump_apis group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 17 releases since 2.4
  - 20 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

The mechanism landed on 2020-08-07 ("debug/coredump: add a primitive
coredump mechanism"), first released in v2.4.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
