### PR TITLE
sys: add @since and @version to bitarray_apis

### DIFF
--- a/include/zephyr/sys/bitarray.h
+++ b/include/zephyr/sys/bitarray.h
@@ -23,6 +23,8 @@ extern "C" {
  * @ingroup bitarray_apis
  *
  * @defgroup bitarray_apis Bit array
+ * @since 2.6
+ * @version 1.0.0
  * @ingroup datastructure_apis
  *
  * @brief Store and manipulate bits in a bit array.


### PR DESCRIPTION
The bitarray_apis group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 15 releases since 2.6
  - 20 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

The API landed on 2021-04-21 ("sys: introduce bit arrays"), first
released in v2.6.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
