### PR TITLE
espi: add @since and @version to espi_interface

### DIFF
--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -28,6 +28,8 @@ extern "C" {
  * @brief Interfaces for Enhanced Serial Peripheral Interface (eSPI)
  *        target hardware.
  * @defgroup espi_interface ESPI
+ * @since 2.0
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
The espi_interface group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 21 releases since 2.0
  - 5 in-tree implementations
  - 12 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

5 implementations over 21 releases. The 13 commits since v4.2.0 are a
vendor driver port, documentation fixes and an added interrupt API:
additive work, which a stable API permits.

The API landed on 2019-07-25 ("API: espi: Add API for Enhanced Serial
Peripheral Interface"), first released in v2.0.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
