### PR TITLE
haptics: add @since and @version to haptics_interface

### DIFF
--- a/include/zephyr/drivers/haptics.h
+++ b/include/zephyr/drivers/haptics.h
@@ -16,6 +16,8 @@
 /**
  * @brief Interfaces for haptic drivers.
  * @defgroup haptics_interface Haptics
+ * @since 4.0
+ * @version 0.3.0
  * @ingroup io_interfaces
  * @{
  *


### PR DESCRIPTION
The haptics_interface group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 5 releases since 4.0
  - 3 in-tree implementations
  - 5 in-tree users outside include/

Unstable states that the API is settling but not yet proven across the
field, and that changes to it are not announced.

Three implementations over five releases clears experimental. Stable is
some way off: 8 of the header's 9 lifetime commits landed since v4.2.0.

haptics_interface_ext inherits this state.

The API landed on 2024-08-08 ("haptics: Introduces a haptics API"),
first released in v4.0.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
