### PR TITLE
pm_cpu_ops: add @since and @version to power_management_cpu_api

### DIFF
--- a/include/zephyr/drivers/pm_cpu_ops.h
+++ b/include/zephyr/drivers/pm_cpu_ops.h
@@ -25,6 +25,8 @@ extern "C" {
 #define SYS_COLD_RESET 1
 /**
  * @defgroup power_management_cpu_api CPU Power Management
+ * @since 2.6
+ * @version 0.8.0
  * @ingroup subsys_pm
  * @{
  */


### PR DESCRIPTION
The power_management_cpu_api group declared no @version, so neither
tooling nor readers could tell what stability guarantees the API offers.
Groups with no version are assumed stable by
scripts/ci/check_api_compat.py so that it fails closed, but assuming is
not the same as stating.

Evidence from the tree:
  - shipped in 15 releases since 2.6
  - 9 in-tree users outside include/

Unstable states that the API is settling but not yet proven across the
field, and that changes to it are not announced.

Unstable rather than stable: this class dispatches without a vtable, so
the number of independent implementations cannot be counted, and 9
in-tree users is thin evidence for a compatibility promise.

The subsystem landed on 2021-03-04 ("aarch64: pm_cpu_ops: Introduce
pm_cpu_ops subsystem"), first released in v2.6.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
