### PR TITLE
ptp_clock: add @since and @version to ptp_clock_interface

### DIFF
--- a/include/zephyr/drivers/ptp_clock.h
+++ b/include/zephyr/drivers/ptp_clock.h
@@ -16,6 +16,8 @@
 /**
  * @brief Interfaces for Precision Time Protocol (PTP) clocks.
  * @defgroup ptp_clock_interface PTP Clock
+ * @since 1.13
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
The ptp_clock_interface group declared no @version, so neither tooling
nor readers could tell what stability guarantees the API offers. Groups
with no version are assumed stable by scripts/ci/check_api_compat.py so
that it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 23 releases since 1.13
  - 8 in-tree implementations
  - 13 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

8 implementations over 23 releases. Six commits since v4.2.0, all of
them Doxygen and convention work -- @file tags, DEVICE_API_GET, wording
-- with no change to the interface itself.

The API landed on 2018-06-26 ("driver: ptp_clock: PTP clock driver
definition"), first released in v1.13.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
