### PR TITLE
bbram: add @since and @version to bbram_interface

### DIFF
--- a/include/zephyr/drivers/bbram.h
+++ b/include/zephyr/drivers/bbram.h
@@ -20,6 +20,8 @@
 /**
  * @brief Interfaces for Battery-Backed RAM (BBRAM).
  * @defgroup bbram_interface BBRAM
+ * @since 2.7
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
The bbram_interface group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 14 releases since 2.7
  - 8 in-tree implementations
  - 5 in-tree users outside include/

Unstable states that the API is settling but not yet proven across the
field, and that changes to it are not announced.

8 implementations clear the bar for unstable, but 5 in-tree users is
well short of what stable asks for.

The API landed on 2021-08-07 ("nuvoton: battery-backed ram"), first
released in v2.7.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
