### PR TITLE
cache: add @since and @version to cache_external_interface

### DIFF
--- a/include/zephyr/drivers/cache.h
+++ b/include/zephyr/drivers/cache.h
@@ -18,6 +18,8 @@
 /**
  * @brief Interfaces for external cache controllers.
  * @defgroup cache_external_interface External Cache Controller
+ * @since 2.6
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
The cache_external_interface group declared no @version, so neither
tooling nor readers could tell what stability guarantees the API offers.
Groups with no version are assumed stable by
scripts/ci/check_api_compat.py so that it fails closed, but assuming is
not the same as stating.

Evidence from the tree:
  - shipped in 15 releases since 2.6
  - 13 in-tree users outside include/

That clears the bar doc/develop/api/overview.rst sets for stable: in use
and available in at least two development releases.

This is the external cache controller driver API, distinct from the
sys_cache_*() API in include/zephyr/cache.h.

The API landed on 2021-05-08 ("cache: Introduce external cache
controller system support"), first released in v2.6.0.

Note that stable does not mean frozen: it means backwards
compatibility is maintained where reasonable, and that removals go
through a deprecation period of at least two releases.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
