### PR TITLE
hwspinlock: add @since and @version to hwspinlock_interface

### DIFF
--- a/include/zephyr/drivers/hwspinlock.h
+++ b/include/zephyr/drivers/hwspinlock.h
@@ -16,6 +16,8 @@
 /**
  * @brief Interfaces for hardware spinlocks.
  * @defgroup hwspinlock_interface Hardware Spinlock
+ * @since 3.5
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
The hwspinlock_interface group declared no @version, so neither tooling
nor readers could tell what stability guarantees the API offers. Groups
with no version are assumed stable by scripts/ci/check_api_compat.py so
that it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 8 releases since 3.5
  - 2 in-tree implementations
  - 3 in-tree users outside include/

Unstable states that the API is settling but not yet proven across the
field, and that changes to it are not announced.

Two implementations is the minimum for unstable. 11 of the header's 14
lifetime commits landed since v4.2.0, so the interface is still moving.

The framework landed on 2023-08-16 ("drivers: introduce hardware
spinlock framework"), first released in v3.5.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
