### PR TITLE
led_strip: add @since and @version to led_strip_interface

### DIFF
--- a/include/zephyr/drivers/led_strip.h
+++ b/include/zephyr/drivers/led_strip.h
@@ -20,6 +20,8 @@
 /**
  * @brief Interfaces for LED strips.
  * @defgroup led_strip_interface LED Strip
+ * @since 1.10
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  *


### PR DESCRIPTION
The led_strip_interface group declared no @version, so neither tooling
nor readers could tell what stability guarantees the API offers. Groups
with no version are assumed stable by scripts/ci/check_api_compat.py so
that it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 26 releases since 1.10
  - 5 in-tree implementations
  - 3 in-tree users outside include/

Unstable states that the API is settling but not yet proven across the
field, and that changes to it are not announced.

Long-lived at 26 releases and 5 implementations, but only 3 in-tree
users outside its own drivers. Longevity alone is not adoption.

led_strip_interface_ext inherits this state.

The API landed on 2017-10-28 ("drivers: led_strip: add public API for
addressable LED strips"), first released in v1.10.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
