### PR TITLE
ps2: add @since and @version to ps2_interface

### DIFF
--- a/include/zephyr/drivers/ps2.h
+++ b/include/zephyr/drivers/ps2.h
@@ -25,6 +25,8 @@ extern "C" {
 /**
  * @brief Interfaces for PS/2 devices.
  * @defgroup ps2_interface PS/2
+ * @since 2.1
+ * @version 0.8.0
  * @ingroup io_interfaces
  *
  * Callers of this API are responsible for setting the typematic rate


### PR DESCRIPTION
The ps2_interface group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 20 releases since 2.1
  - 3 in-tree implementations
  - 2 in-tree users outside include/

Unstable states that the API is settling but not yet proven across the
field, and that changes to it are not announced.

Three implementations over 20 releases, but only 2 in-tree users.

The API landed on 2019-09-18 ("API: ps2 : Add API for PS/2 devices"),
first released in v2.1.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
