### PR TITLE
charger: add @since and @version to charger_interface

### DIFF
--- a/include/zephyr/drivers/charger.h
+++ b/include/zephyr/drivers/charger.h
@@ -16,6 +16,8 @@
 /**
  * @brief Interfaces for battery chargers.
  * @defgroup charger_interface Battery Charger
+ * @since 3.5
+ * @version 1.0.0
  * @ingroup io_interfaces
  * @{
  *


### PR DESCRIPTION
The charger_interface group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 8 releases since 3.5
  - 8 in-tree implementations
  - 3 in-tree users outside include/

Unstable states that the API is settling but not yet proven across the
field, and that changes to it are not announced.

8 implementations, but 3 in-tree users and 8 of 25 lifetime commits
since v4.2.0.

charger_interface_ext inherits this state.

The API landed on 2023-09-07 ("charger: Initial charger dedicated
API"), first released in v3.5.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
