### PR TITLE
crc: add @since and @version to crc_interface

### DIFF
--- a/include/zephyr/drivers/crc.h
+++ b/include/zephyr/drivers/crc.h
@@ -25,6 +25,8 @@ extern "C" {
 /**
  * @brief Interfaces for Cyclic Redundancy Check (CRC) devices.
  * @defgroup crc_interface CRC driver APIs
+ * @since 4.3
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
The crc_interface group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 2 releases since 4.3
  - 6 in-tree implementations
  - 4 in-tree users outside include/

Experimental states that the API may still change or be removed without
a deprecation period.

Experimental rather than unstable, which is what release count and
implementation count alone would suggest. The API is two releases old,
every one of its five commits landed since v4.2.0, and it is still
gaining algorithms. A new API starts experimental.

The API landed on 2025-09-10 ("drivers: crc: initial support for CRC
driver"), first released in v4.3.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
