### PR TITLE
tee: add @since and @version to tee_interface

### DIFF
--- a/include/zephyr/drivers/tee.h
+++ b/include/zephyr/drivers/tee.h
@@ -46,6 +46,8 @@
 /**
  * @brief Interfaces to work with Trusted Execution Environment (TEE).
  * @defgroup tee_interface TEE
+ * @since 3.7
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  *


### PR DESCRIPTION
The tee_interface group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 6 releases since 3.7
  - 1 in-tree implementation
  - 0 in-tree users outside include/

Experimental states that the API may still change or be removed without
a deprecation period.

A single implementation over six releases.

The API landed on 2024-06-26 ("drivers: tee: Add Tee driver generic
API"), first released in v3.7.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
