### PR TITLE
debug: add @since and @version to coredump_device_interface

### DIFF
--- a/include/zephyr/drivers/coredump.h
+++ b/include/zephyr/drivers/coredump.h
@@ -23,6 +23,8 @@ extern "C" {
 /**
  * @brief Interfaces for coredump pseudo-device.
  * @defgroup coredump_device_interface Coredump pseudo-device
+ * @since 3.2
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
The coredump_device_interface group declared no @version, so neither
tooling nor readers could tell what stability guarantees the API offers.
Groups with no version are assumed stable by
scripts/ci/check_api_compat.py so that it fails closed, but assuming is
not the same as stating.

Evidence from the tree:
  - shipped in 11 releases since 3.2
  - 1 in-tree implementation
  - 0 in-tree users outside include/

Experimental states that the API may still change or be removed without
a deprecation period.

A single implementation, which is what keeps this experimental: the
promotion rule asks for at least two on different hardware.

The API landed on 2022-06-05 ("coredump: drivers: Add coredump
device"), 69 minutes after v3.1.0 was tagged, so it first shipped in
v3.2.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
