### PR TITLE
espi: add @since and @version to espi_saf_interface

### DIFF
--- a/include/zephyr/drivers/espi_saf.h
+++ b/include/zephyr/drivers/espi_saf.h
@@ -24,6 +24,8 @@ extern "C" {
  * @brief Interfaces for eSPI SAF (Serial Attached Flash)
  *        controllers.
  * @defgroup espi_saf_interface eSPI SAF
+ * @since 2.6
+ * @version 0.8.0
  * @ingroup espi_interface
  * @{
  */


### PR DESCRIPTION
The espi_saf_interface group declared no @version, so neither tooling
nor readers could tell what stability guarantees the API offers. Groups
with no version are assumed stable by scripts/ci/check_api_compat.py so
that it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 15 releases since 2.6
  - 3 in-tree implementations
  - 1 in-tree users outside include/

Unstable states that the API is settling but not yet proven across the
field, and that changes to it are not announced.

Three implementations over 15 releases, but a single in-tree user.
This is a sub-API of eSPI and is not covered by espi_interface, which
it does not name as a parent.

The API landed on 2021-02-15 ("drivers: espi: Microchip eSPI add SAF
support"), first released in v2.6.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
