### PR TITLE
mdio: add @since and @version to mdio_interface

### DIFF
--- a/include/zephyr/drivers/mdio.h
+++ b/include/zephyr/drivers/mdio.h
@@ -17,6 +17,8 @@
 /**
  * @brief Interfaces for Management Data Input/Output (MDIO) controllers.
  * @defgroup mdio_interface MDIO
+ * @since 2.7
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
The mdio_interface group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 14 releases since 2.7
  - 26 in-tree implementations
  - 1 in-tree users outside include/

Unstable states that the API is settling but not yet proven across the
field, and that changes to it are not announced.

26 implementations, the most of any API in this batch, but one in-tree
user: MDIO is consumed almost entirely by Ethernet drivers that live
alongside its own implementations rather than by application code.

The API landed on 2021-08-27 ("drivers: Add mdio API"), first released
in v2.7.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
