### PR TITLE
cellular: add @since and @version to cellular_interface

### DIFF
--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -17,6 +17,8 @@
 /**
  * @brief Interfaces for cellular modems.
  * @defgroup cellular_interface Cellular
+ * @since 3.6
+ * @version 0.8.0
  * @ingroup io_interfaces
  * @{
  *


### PR DESCRIPTION
The cellular_interface group declared no @version, so neither tooling
nor readers could tell what stability guarantees the API offers. Groups
with no version are assumed stable by scripts/ci/check_api_compat.py so
that it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 7 releases since 3.6
  - 3 in-tree implementations
  - 2 in-tree users outside include/

Unstable states that the API is settling but not yet proven across the
field, and that changes to it are not announced.

16 of the header's 22 lifetime commits landed since v4.2.0. The API is
actively changing shape.

cellular_interface_ext inherits this state.

The API landed on 2023-12-12 ("drivers: Add cellular API for network
configuration"), first released in v3.6.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
