### PR TITLE
virtio: add @since and @version to virtio_interface

### DIFF
--- a/include/zephyr/drivers/virtio.h
+++ b/include/zephyr/drivers/virtio.h
@@ -22,6 +22,8 @@ extern "C" {
 /**
  * @brief Interfaces for Virtual I/O (VIRTIO) devices.
  * @defgroup virtio_interface VIRTIO
+ * @since 4.2
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */


### PR DESCRIPTION
The virtio_interface group declared no @version, so neither tooling nor
readers could tell what stability guarantees the API offers. Groups with
no version are assumed stable by scripts/ci/check_api_compat.py so that
it fails closed, but assuming is not the same as stating.

Evidence from the tree:
  - shipped in 3 releases since 4.2
  - 1 in-tree implementation
  - 0 in-tree users outside include/

Experimental states that the API may still change or be removed without
a deprecation period.

One implementation and three releases.

The API landed on 2025-06-02 ("virtio: add API for VIRTIO devices and
add VIRTIO PCI driver"), first released in v4.2.0.

Assisted-by: Claude:claude-opus-4-8
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
