### PR TITLE
drivers: espi: it8xxx2: clear PMC2 processing flag at init

### DIFF
--- a/drivers/espi/espi_it8xxx2.c
+++ b/drivers/espi/espi_it8xxx2.c
@@ -1314,10 +1314,16 @@ static void pmc2_it8xxx2_init(const struct device *dev)
 	const struct espi_it8xxx2_config *const config = dev->config;
 	struct pmc_regs *const pmc_reg = (struct pmc_regs *)config->base_pmc;
 
+	/* Clear processing flag before enabling host's interrupts
+	 * in case it's set by the other command during sysjump.
+	 */
+	pmc_reg->PM2STS &= ~PMC_PM2STS_GPF;
+
 	/* Dedicated interrupt for PMC2 */
 	pmc_reg->MBXCTRL |= PMC_MBXCTRL_DINT;
 	/* Enable pmc2 input buffer full interrupt */
 	pmc_reg->PM2CTL |= PMC_PM2CTL_IBFIE;
+
 	IRQ_CONNECT(IT8XXX2_PMC2_IBF_IRQ, 0, pmc2_it8xxx2_ibf_isr,
 			DEVICE_DT_INST_GET(0), 0);
 	if (!IS_ENABLED(CONFIG_ESPI_PERIPHERAL_CUSTOM_OPCODE)) {


### PR DESCRIPTION
PM2STS.GPF (host-command BUSY) is set in the PMC2 IBF ISR and cleared on the response path. If a sysjump happens in between, the response never runs and GPF is left set. The new image re-enables the PMC2 interrupt but doesn't clear the BUSY bit, so the host sees a permanently BUSY interface and every subsequent host command times out.

Clear PM2STS.GPF in pmc2_it8xxx2_init() before enabling the IBF interrupt, matching the equivalent fix in the Nuvoton NPCX driver (host_hcmd_init() in drivers/espi/host_subs_npcx.c clears HIPMST.F0 for the same reason)