### PR TITLE
drivers: gpio: reset PCA polarity inversion registers

### DIFF
--- a/drivers/gpio/gpio_pca_series.c
+++ b/drivers/gpio/gpio_pca_series.c
@@ -88,7 +88,7 @@ const char *const gpio_pca_series_part_name[] = {
 enum gpio_pca_series_reg_type {			/** Type0 Type1 Type2 Type3 */
 	PCA_REG_TYPE_1B_INPUT_PORT = 0U,	/**   x     x     x     x   */
 	PCA_REG_TYPE_1B_OUTPUT_PORT,		/**   x     x     x     x   */
-/*  PCA_REG_TYPE_1B_POLARITY_INVERSION,		      x     x     x     x   * (unused, omitted) */
+	PCA_REG_TYPE_1B_POLARITY_INVERSION,	/**   x     x     x     x   */
 	PCA_REG_TYPE_1B_CONFIGURATION,		/**   x     x     x     x   */
 	PCA_REG_TYPE_2B_OUTPUT_DRIVE_STRENGTH,	/**         x           x   */
 	PCA_REG_TYPE_1B_INPUT_LATCH,		/**         x           x   */
@@ -118,7 +118,7 @@ enum gpio_pca_series_reg_type {			/** Type0 Type1 Type2 Type3 */
 const char *const gpio_pca_series_reg_name[] = {
 	"1b_input_port",
 	"1b_output_port",
-/*  "1b_polarity_inversion," */
+	"1b_polarity_inversion",
 	"1b_configuration",
 	"2b_output_drive_strength",
 	"1b_input_latch",
@@ -256,7 +256,7 @@ static inline uint32_t gpio_pca_series_reg_size_per_port(const struct device *de
 	switch (reg_type) {
 	case PCA_REG_TYPE_1B_INPUT_PORT:
 	case PCA_REG_TYPE_1B_OUTPUT_PORT:
-/*  case PCA_REG_TYPE_1B_POLARITY_INVERSION: */
+	case PCA_REG_TYPE_1B_POLARITY_INVERSION:
 	case PCA_REG_TYPE_1B_CONFIGURATION:
 	case PCA_REG_TYPE_1B_INPUT_LATCH:
 	case PCA_REG_TYPE_1B_PULL_ENABLE:
@@ -708,6 +708,11 @@ static inline int gpio_pca_series_reset_write_reg(const struct device *dev)
 	 * write reset value to registers
 	 */
 	ret = gpio_pca_series_reg_write(dev, PCA_REG_TYPE_1B_OUTPUT_PORT, reset_value_1);
+	if (ret) {
+		return ret;
+	}
+	ret = gpio_pca_series_reg_write(dev, PCA_REG_TYPE_1B_POLARITY_INVERSION,
+					reset_value_0);
 	if (ret) {
 		return ret;
 	}
@@ -2079,7 +2084,7 @@ out_bus:
 static const uint8_t gpio_pca_series_cache_map_pca953x[] = {
 	PCA_REG_INVALID, /** input_port if not PCA_HAS_OUT_CONFIG, non-cacheable */
 	0x00, /** output_port */
-/*	0x02,     polarity_inversion  (unused, omitted) */
+	PCA_REG_INVALID, /** polarity_inversion */
 	0x01, /** configuration */
 	PCA_REG_INVALID, /** 2b_output_drive_strength if PCA_HAS_LATCH*/
 	PCA_REG_INVALID, /** input_latch if PCA_HAS_LATCH*/
@@ -2106,7 +2111,7 @@ static const uint8_t gpio_pca_series_cache_map_pca953x[] = {
 static const uint8_t gpio_pca_series_reg_pca9538[] = {
 	0x00, /** input_port if not PCA_HAS_OUT_CONFIG, non-cacheable */
 	0x01, /** output_port */
-/*	0x02,     polarity_inversion  (unused, omitted) */
+	0x02, /** polarity_inversion */
 	0x03, /** configuration */
 	PCA_REG_INVALID, /** 2b_output_drive_strength if PCA_HAS_LATCH*/
 	PCA_REG_INVALID, /** input_latch if PCA_HAS_LATCH*/
@@ -2193,7 +2198,7 @@ const struct gpio_pca_series_part_config gpio_pca_series_part_cfg_pca6408 = {
 static const uint8_t gpio_pca_series_reg_pca9539[] = {
 	0x00, /** input_port if not PCA_HAS_OUT_CONFIG, non-cacheable */
 	0x02, /** output_port */
-/*	0x04,     polarity_inversion  (unused, omitted) */
+	0x04, /** polarity_inversion */
 	0x06, /** configuration */
 	PCA_REG_INVALID, /** 2b_output_drive_strength if PCA_HAS_LATCH*/
 	PCA_REG_INVALID, /** input_latch if PCA_HAS_LATCH*/
@@ -2300,7 +2305,7 @@ const struct gpio_pca_series_part_config gpio_pca_series_part_cfg_pca6416 = {
 static const uint8_t gpio_pca_series_cache_map_pcal953x[] = {
 	PCA_REG_INVALID, /** input_port if not PCA_HAS_OUT_CONFIG, non-cacheable */
 	0x00, /** output_port */
-/*	0x02,     polarity_inversion  (unused, omitted) */
+	PCA_REG_INVALID, /** polarity_inversion */
 	0x01, /** configuration */
 	0x02, /** 2b_output_drive_strength if PCA_HAS_LATCH*/
 	0x04, /** input_latch if PCA_HAS_LATCH*/
@@ -2327,7 +2332,7 @@ static const uint8_t gpio_pca_series_cache_map_pcal953x[] = {
 static const uint8_t gpio_pca_series_reg_pcal9538[] = {
 	0x00, /** input_port if not PCA_HAS_OUT_CONFIG, non-cacheable */
 	0x01, /** output_port */
-/*	0x02,     polarity_inversion  (unused, omitted) */
+	0x02, /** polarity_inversion */
 	0x03, /** configuration */
 	0x40, /** 2b_output_drive_strength if PCA_HAS_LATCH*/
 	0x42, /** input_latch if PCA_HAS_LATCH*/
@@ -2391,7 +2396,7 @@ const struct gpio_pca_series_part_config gpio_pca_series_part_cfg_pcal6408 = {
 static const uint8_t gpio_pca_series_reg_pcal9539[] = {
 	0x00, /** input_port if not PCA_HAS_OUT_CONFIG, non-cacheable */
 	0x02, /** output_port */
-/*	0x04,     polarity_inversion  (unused, omitted) */
+	0x04, /** polarity_inversion */
 	0x06, /** configuration */
 	0x40, /** 2b_output_drive_strength if PCA_HAS_LATCH*/
 	0x44, /** input_latch if PCA_HAS_LATCH*/
@@ -2479,7 +2484,7 @@ const struct gpio_pca_series_part_config gpio_pca_series_part_cfg_pcal6416 = {
 static const uint8_t gpio_pca_series_cache_map_pcal65xx[] = {
 	PCA_REG_INVALID, /** input_port if not PCA_HAS_OUT_CONFIG, non-cacheable */
 	0x00, /** output_port */
-/*	0x02,     polarity_inversion  (unused, omitted) */
+	PCA_REG_INVALID, /** polarity_inversion */
 	0x01, /** configuration */
 	0x02, /** 2b_output_drive_strength if PCA_HAS_LATCH*/
 	0x04, /** input_latch if PCA_HAS_LATCH*/
@@ -2506,7 +2511,7 @@ static const uint8_t gpio_pca_series_cache_map_pcal65xx[] = {
 static const uint8_t gpio_pca_series_reg_pcal6524[] = {
 	PCA_REG_INVALID, /** input_port if not PCA_HAS_OUT_CONFIG, non-cacheable */
 	0x04, /** output_port */
-/*	0x08,     polarity_inversion  (unused, omitted) */
+	0x08, /** polarity_inversion */
 	0x0c, /** configuration */
 	0x40, /** 2b_output_drive_strength if PCA_HAS_LATCH*/
 	0x48, /** input_latch if PCA_HAS_LATCH*/
@@ -2548,7 +2553,7 @@ const struct gpio_pca_series_part_config gpio_pca_series_part_cfg_pcal6524 = {
 static const uint8_t gpio_pca_series_reg_pcal6534[] = {
 	PCA_REG_INVALID, /** input_port if not PCA_HAS_OUT_CONFIG, non-cacheable */
 	0x05, /** output_port */
-/*	0x0a,     polarity_inversion  (unused, omitted) */
+	0x0a, /** polarity_inversion */
 	0x0f, /** configuration */
 	0x30, /** 2b_output_drive_strength if PCA_HAS_LATCH*/
 	0x3a, /** input_latch if PCA_HAS_LATCH*/

--- a/tests/drivers/gpio/gpio_pca_series/CMakeLists.txt
+++ b/tests/drivers/gpio/gpio_pca_series/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 The Zephyr Project Contributors
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(gpio_pca_series)
+
+target_sources(app PRIVATE
+	src/main.c
+	src/pca9555_emul.c
+)

--- a/tests/drivers/gpio/gpio_pca_series/boards/native_sim.overlay
+++ b/tests/drivers/gpio/gpio_pca_series/boards/native_sim.overlay
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 The Zephyr Project Contributors
+
+&i2c0 {
+	pca9555_auto_reset: gpio@20 {
+		compatible = "nxp,pca9555";
+		reg = <0x20>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <16>;
+	};
+
+	pca9555_no_auto_reset: gpio@21 {
+		compatible = "nxp,pca9555";
+		reg = <0x21>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <16>;
+		no-auto-reset;
+	};
+};

--- a/tests/drivers/gpio/gpio_pca_series/boards/native_sim_native_64.overlay
+++ b/tests/drivers/gpio/gpio_pca_series/boards/native_sim_native_64.overlay
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 The Zephyr Project Contributors
+
+#include "native_sim.overlay"

--- a/tests/drivers/gpio/gpio_pca_series/prj.conf
+++ b/tests/drivers/gpio/gpio_pca_series/prj.conf
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 The Zephyr Project Contributors
+
+CONFIG_ZTEST=y
+CONFIG_GPIO=y
+CONFIG_GPIO_PCA_SERIES=y
+CONFIG_GPIO_PCA_SERIES_INTERRUPT=n
+CONFIG_EMUL=y

--- a/tests/drivers/gpio/gpio_pca_series/src/main.c
+++ b/tests/drivers/gpio/gpio_pca_series/src/main.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/emul.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/ztest.h>
+
+#include "pca9555_emul.h"
+
+#define PCA9555_REG_INPUT_PORT0              0x00
+#define PCA9555_REG_OUTPUT_PORT0             0x02
+#define PCA9555_REG_POLARITY_INVERSION_PORT0 0x04
+#define PCA9555_REG_CONFIGURATION_PORT0      0x06
+
+static const struct device *const auto_reset_dev = DEVICE_DT_GET(DT_NODELABEL(pca9555_auto_reset));
+static const struct emul *const auto_reset_emul = EMUL_DT_GET(DT_NODELABEL(pca9555_auto_reset));
+static const struct device *const no_auto_reset_dev =
+	DEVICE_DT_GET(DT_NODELABEL(pca9555_no_auto_reset));
+static const struct emul *const no_auto_reset_emul =
+	EMUL_DT_GET(DT_NODELABEL(pca9555_no_auto_reset));
+
+ZTEST(gpio_pca_series, test_automatic_reset_restores_all_basic_registers)
+{
+	zassert_true(device_is_ready(auto_reset_dev));
+
+	zexpect_equal(pca9555_emul_get_word(auto_reset_emul, PCA9555_REG_OUTPUT_PORT0), UINT16_MAX);
+	zexpect_equal(pca9555_emul_get_word(auto_reset_emul, PCA9555_REG_POLARITY_INVERSION_PORT0),
+		      0);
+	zexpect_equal(pca9555_emul_get_word(auto_reset_emul, PCA9555_REG_CONFIGURATION_PORT0),
+		      UINT16_MAX);
+}
+
+ZTEST(gpio_pca_series, test_no_auto_reset_preserves_polarity_inversion)
+{
+	zassert_true(device_is_ready(no_auto_reset_dev));
+	zexpect_equal(
+		pca9555_emul_get_word(no_auto_reset_emul, PCA9555_REG_POLARITY_INVERSION_PORT0),
+		PCA9555_EMUL_INITIAL_POLARITY);
+}
+
+ZTEST(gpio_pca_series, test_port_get_returns_both_input_ports)
+{
+	gpio_port_value_t value = 0;
+
+	pca9555_emul_set_word(auto_reset_emul, PCA9555_REG_INPUT_PORT0, 0xa55a);
+
+	zassert_ok(gpio_port_get_raw(auto_reset_dev, &value));
+	zexpect_equal(value, 0xa55a);
+}
+
+ZTEST_SUITE(gpio_pca_series, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/gpio/gpio_pca_series/src/pca9555_emul.c
+++ b/tests/drivers/gpio/gpio_pca_series/src/pca9555_emul.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_pca9555
+
+#include <zephyr/drivers/emul.h>
+#include <zephyr/drivers/i2c_emul.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
+
+#include "pca9555_emul.h"
+
+#define PCA9555_REGISTER_COUNT 8
+
+struct pca9555_emul_data {
+	uint8_t registers[PCA9555_REGISTER_COUNT];
+};
+
+static int pca9555_emul_transfer(const struct emul *target, struct i2c_msg *msgs, int num_msgs,
+				 int addr)
+{
+	struct pca9555_emul_data *data = target->data;
+	uint8_t reg;
+
+	ARG_UNUSED(addr);
+
+	if (num_msgs != 2 || msgs[0].len != 1 || (msgs[0].flags & I2C_MSG_READ) != 0) {
+		return -EIO;
+	}
+
+	reg = msgs[0].buf[0];
+	if (reg >= PCA9555_REGISTER_COUNT || msgs[1].len > PCA9555_REGISTER_COUNT - reg) {
+		return -EIO;
+	}
+
+	if ((msgs[1].flags & I2C_MSG_READ) != 0) {
+		memcpy(msgs[1].buf, &data->registers[reg], msgs[1].len);
+	} else {
+		memcpy(&data->registers[reg], msgs[1].buf, msgs[1].len);
+	}
+
+	return 0;
+}
+
+uint16_t pca9555_emul_get_word(const struct emul *target, uint8_t reg)
+{
+	struct pca9555_emul_data *data = target->data;
+
+	return sys_get_le16(&data->registers[reg]);
+}
+
+void pca9555_emul_set_word(const struct emul *target, uint8_t reg, uint16_t value)
+{
+	struct pca9555_emul_data *data = target->data;
+
+	sys_put_le16(value, &data->registers[reg]);
+}
+
+static int pca9555_emul_init(const struct emul *target, const struct device *parent)
+{
+	ARG_UNUSED(target);
+	ARG_UNUSED(parent);
+
+	return 0;
+}
+
+static const struct i2c_emul_api pca9555_emul_api = {
+	.transfer = pca9555_emul_transfer,
+};
+
+#define PCA9555_EMUL(inst)                                                                         \
+	static struct pca9555_emul_data pca9555_emul_data_##inst = {                               \
+		.registers =                                                                       \
+			{                                                                          \
+				[0x00] = 0x5a,                                                     \
+				[0x01] = 0xa5,                                                     \
+				[0x02] = 0x34,                                                     \
+				[0x03] = 0x12,                                                     \
+				[0x04] = (PCA9555_EMUL_INITIAL_POLARITY & 0xff),                   \
+				[0x05] = (PCA9555_EMUL_INITIAL_POLARITY >> 8),                     \
+				[0x06] = 0x0f,                                                     \
+				[0x07] = 0xf0,                                                     \
+			},                                                                         \
+	};                                                                                         \
+	EMUL_DT_INST_DEFINE(inst, pca9555_emul_init, &pca9555_emul_data_##inst, NULL,              \
+			    &pca9555_emul_api, NULL)
+
+DT_INST_FOREACH_STATUS_OKAY(PCA9555_EMUL)

--- a/tests/drivers/gpio/gpio_pca_series/src/pca9555_emul.h
+++ b/tests/drivers/gpio/gpio_pca_series/src/pca9555_emul.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2026 The Zephyr Project Contributors */
+
+#ifndef ZEPHYR_TESTS_DRIVERS_GPIO_GPIO_PCA_SERIES_PCA9555_EMUL_H_
+#define ZEPHYR_TESTS_DRIVERS_GPIO_GPIO_PCA_SERIES_PCA9555_EMUL_H_
+
+#include <stdint.h>
+
+struct emul;
+
+#define PCA9555_EMUL_INITIAL_POLARITY 0x9669
+
+uint16_t pca9555_emul_get_word(const struct emul *target, uint8_t reg);
+void pca9555_emul_set_word(const struct emul *target, uint8_t reg, uint16_t value);
+
+#endif /* ZEPHYR_TESTS_DRIVERS_GPIO_GPIO_PCA_SERIES_PCA9555_EMUL_H_ */

--- a/tests/drivers/gpio/gpio_pca_series/tests.yaml
+++ b/tests/drivers/gpio/gpio_pca_series/tests.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 The Zephyr Project Contributors
+
+tests:
+  drivers.gpio.pca_series:
+    tags:
+      - drivers
+      - gpio
+    platform_allow:
+      - native_sim
+      - native_sim/native/64


### PR DESCRIPTION
## Summary

- restore polarity-inversion entries in the generic PCA and PCAL register maps
- reset polarity-inversion registers to their documented zero value during automatic software reset
- add a native I2C emulator test for automatic reset, `no-auto-reset`, and multi-byte port reads

## Motivation

The generic PCA-series software-reset path restores output and configuration
registers but leaves polarity inversion untouched. A PCA9555 that starts with
non-zero polarity bits therefore remains inverted even though the driver has
requested an automatic reset.

## Testing

- `twister -T tests/drivers/gpio/gpio_pca_series -p native_sim/native/64 --inline-logs --integration`
  - 1 configuration passed
  - 3 of 3 test cases passed
- `scripts/checkpatch/maintainer-checkpatch.bash -n 1`
  - 0 errors, 0 warnings

The related multi-byte port-read correction is already covered separately by
#89785; its regression is included here to keep this driver's basic PCA9555
behavior under one emulated test suite.
