### PR TITLE
boards: adi: mass erase before flashing for max32657/8evkit_ns boards

### DIFF
--- a/boards/adi/max32657evkit/board.cmake
+++ b/boards/adi/max32657evkit/board.cmake
@@ -1,8 +1,10 @@
-# Copyright (c) 2024-2025 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_BOARD_MAX32657EVKIT_MAX32657_NS)
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
+  board_runner_args(openocd "--erase")
+  board_runner_args(jlink "--erase")
 endif()
 
 board_runner_args(jlink "--device=MAX32657" "--reset-after-load")

--- a/boards/adi/max32658evkit/board.cmake
+++ b/boards/adi/max32658evkit/board.cmake
@@ -1,8 +1,10 @@
-# Copyright (c) 2024-2025 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_BOARD_MAX32658EVKIT_MAX32658_NS)
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
+  board_runner_args(openocd "--erase")
+  board_runner_args(jlink "--erase")
 endif()
 
 board_runner_args(jlink "--device=MAX32658" "--reset-after-load")


### PR DESCRIPTION
Erase flash before writing new image on the max32657evkit_ns and max32658evkit_ns boards.