### PR TITLE
boards: adi: apard32690: Add missing CONFIG_USE_DT_CODE_PARTITION config

### DIFF
--- a/boards/adi/apard32690/apard32690_max32690_m4_defconfig
+++ b/boards/adi/apard32690/apard32690_max32690_m4_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Enable MPU
@@ -14,3 +14,5 @@ CONFIG_UART_CONSOLE=y
 # Enable UART
 CONFIG_SERIAL=y
 CONFIG_UART_INTERRUPT_DRIVEN=y
+
+CONFIG_USE_DT_CODE_PARTITION=y


### PR DESCRIPTION
Added missing CONFIG_USE_DT_CODE_PARTITION config to the apard32690_max32690_m4_defconfig file. This config is required for the M4 core to use the code partition defined in the device tree.