### PR TITLE
checkpatch: Add support for Assisted-by tag

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -508,6 +508,7 @@ our $signature_tags = qr{(?xi:
 	Reviewed-by:|
 	Reported-by:|
 	Suggested-by:|
+	Assisted-by:|
 	To:|
 	Cc:
 )};
@@ -2731,6 +2732,15 @@ sub process {
 					$fixed[$fixlinenr] =
 					    "$ucfirst_sign_off $email";
 				}
+			}
+
+			# Assisted-by uses AGENT_NAME:MODEL_VERSION format, not email
+			if ($sign_off =~ /^Assisted-by:/i) {
+				if ($email !~ /^\S+:\S+/) {
+					WARN("BAD_SIGN_OFF",
+					     "Assisted-by expects 'AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]' format\n" . $herecurr);
+				}
+				next;
 			}
 
 			my ($email_name, $email_address, $comment) = parse_email($email);


### PR DESCRIPTION
Assisted-by tag was introduced in doc/contibute/guidelines.rst for attributing AI tool contributions.

checkpatch.pl doesn't recognise this tag and throws BAD_SIGN_OFF issues for missing email address.

This fix imports linux kernel support for Assisted-by tag to zephyr (https://github.com/torvalds/linux/commit/d1db411).

It adds Assisted-by to the recognised $signature_tags list, skips email validation since Assisted-by uses the
[Agent Name]:[Model Version] format and throws a warning if the value doesn't match the expected format.