### PR TITLE
drivers: gpio: mcux_rgpio: fix unprotected register writes

### DIFF
--- a/drivers/gpio/gpio_mcux_rgpio.c
+++ b/drivers/gpio/gpio_mcux_rgpio.c
@@ -56,6 +56,7 @@ static int mcux_rgpio_configure(const struct device *dev,
 
 	struct pinctrl_soc_pin pin_cfg;
 	int cfg_idx = pin, i;
+	unsigned int key;
 
 	if (flags == GPIO_DISCONNECTED) {
 		return -ENOTSUP;
@@ -173,7 +174,9 @@ static int mcux_rgpio_configure(const struct device *dev,
 		RGPIO_WritePinOutput(base, pin, 0);
 	}
 
+	key = irq_lock();
 	WRITE_BIT(base->PDDR, pin, flags & GPIO_OUTPUT);
+	irq_unlock(key);
 
 	return 0;
 }
@@ -193,8 +196,11 @@ static int mcux_rgpio_port_set_masked_raw(const struct device *dev,
 					  uint32_t value)
 {
 	RGPIO_Type *base = (RGPIO_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
+	uint32_t set_mask = mask & value;
+	uint32_t clear_mask = mask & ~value;
 
-	base->PDOR = (base->PDOR & ~mask) | (mask & value);
+	RGPIO_PortSet(base, set_mask);
+	RGPIO_PortClear(base, clear_mask);
 
 	return 0;
 }


### PR DESCRIPTION
`mcux_rgpio_port_set_masked_raw()` and the pin direction update in
`mcux_rgpio_configure()` both perform a read-modify-write of a
port-wide register (`PDOR`, `PDDR`) without any protection. If a
second thread or an ISR touches the same port concurrently, the
write can land between the read and the write-back, and its effect
is silently lost: bits outside the caller's own mask/pin can be
reverted to a stale value.

- `mcux_rgpio_port_set_masked_raw()` is fixed by using the RGPIO
  peripheral's dedicated set/clear registers (`PSOR`/`PCOR`) instead
  of a read-modify-write on `PDOR`. These registers only ever affect
  bits explicitly set in their argument, so the operation is atomic
  without needing to disable interrupts.
- `PDDR` has no equivalent set/clear alias, so the pin direction
  update in `mcux_rgpio_configure()` is protected with
  `irq_lock()`/`irq_unlock()` instead, matching the locking already
  used elsewhere in this driver for interrupt configuration.