### PR TITLE
net: ethernet: remove is_init

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -654,10 +654,7 @@ struct ethernet_context {
 #endif
 
 	/** Is network carrier up */
-	bool is_net_carrier_up : 1;
-
-	/** Is this context already initialized */
-	bool is_init : 1;
+	bool is_net_carrier_up;
 
 	/** Types of Ethernet network interfaces */
 	enum ethernet_if_types eth_if_type;

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -1064,6 +1064,4 @@ void ethernet_init(struct net_if *iface)
 		net_if_mcast_mon_register(&mcast_monitor, NULL, ethernet_mcast_monitor_cb);
 	}
 #endif
-
-	ctx->is_init = true;
 }

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -348,7 +348,6 @@ static void setup_link_address(struct vlan_context *ctx)
 
 int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
 {
-	struct ethernet_context *ctx = net_if_l2_data(iface);
 	const struct ethernet_api *eth = net_if_get_device(iface)->api;
 	struct vlan_context *vlan;
 	int ret;
@@ -365,10 +364,6 @@ int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
 		NET_DBG("Interface %d does not support VLAN",
 			net_if_get_by_iface(iface));
 		return -ENOTSUP;
-	}
-
-	if (!ctx->is_init) {
-		return -EPERM;
 	}
 
 	if (tag >= NET_VLAN_TAG_UNSPEC) {


### PR DESCRIPTION
is_init from struct ethernet_context is
never read, so remove it as it is not needed
anymore, it is a leftover from the time when
vlans were ethernet ifaces instead of virtual ones.