### PR TITLE
boards: nxp: mimxrt1180_evk: rename board specific MPU settings option

### DIFF
--- a/boards/nxp/mimxrt1180_evk/CMakeLists.txt
+++ b/boards/nxp/mimxrt1180_evk/CMakeLists.txt
@@ -11,7 +11,7 @@ if(CONFIG_SOC_MIMXRT1189_CM33)
 zephyr_linker_sources(DTCM_SECTION cm33/dtcm.ld)
 endif()
 
-if(CONFIG_NXP_BOARD_SPECIFIC_MPU_SETTINGS)
+if(CONFIG_BOARD_NXP_SPECIFIC_MPU_SETTINGS)
   if(CONFIG_SOC_MIMXRT1189_CM7)
     zephyr_sources(cm7/mpu_regions.c)
     # The DTCM_SECTION snippet only applies when a dedicated DTCM region is

--- a/boards/nxp/mimxrt1180_evk/Kconfig
+++ b/boards/nxp/mimxrt1180_evk/Kconfig
@@ -21,7 +21,7 @@ config CM7_FLEXSPI_OFFSET
 	help
 	  This is the FlexSPI offset for CM7.
 
-config NXP_BOARD_SPECIFIC_MPU_SETTINGS
+config BOARD_NXP_SPECIFIC_MPU_SETTINGS
 	bool "Use default MPU settings for NXP boards"
 	default y if CPU_HAS_CUSTOM_FIXED_SOC_MPU_REGIONS
 	help

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -130,6 +130,11 @@ Boards
   must move their serial terminal from VCOM0 back to VCOM1. The nRF54L15 DK is unaffected: its
   expansion header genuinely conflicts with UART20, so it keeps rerouting the console to UART30.
 
+* The mimxrt1180_evk Kconfig option ``NXP_BOARD_SPECIFIC_MPU_SETTINGS`` has been renamed to
+  :kconfig:option:`CONFIG_BOARD_NXP_SPECIFIC_MPU_SETTINGS`, matching the ``BOARD_NXP_*`` naming
+  used by the other NXP board options and by frdm_imxrt1186. Configurations setting
+  ``CONFIG_NXP_BOARD_SPECIFIC_MPU_SETTINGS`` must be updated to the new name.
+
 Device Drivers and Devicetree
 *****************************
 


### PR DESCRIPTION
Rename the mimxrt1180_evk Kconfig option `NXP_BOARD_SPECIFIC_MPU_SETTINGS` to
`BOARD_NXP_SPECIFIC_MPU_SETTINGS`, to keep it consistent with frdm_imxrt1186,
which already defines the identical option under that name, and with the
`BOARD_NXP_*` namespace used by the other NXP board Kconfig options.

The option is promptable and shipped in v4.3.0, so the rename is documented in
the 4.5 migration guide.

No functional change.