### PR TITLE
tests: counter: make short relative alarm iterations configurable

### DIFF
--- a/tests/drivers/counter/counter_basic_api/Kconfig
+++ b/tests/drivers/counter/counter_basic_api/Kconfig
@@ -30,4 +30,17 @@ config TEST_PROCESSING_LIMIT_US
 	help
 	  Processing limit in us
 
+config TEST_COUNTER_SHORT_RELATIVE_ALARM_ITERATIONS
+	int "Iterations for the short relative alarm test (slow counters)"
+	range 1 1000
+	default 10
+	help
+	  Number of set-alarm/wait iterations performed by
+	  test_short_relative_alarm for low-frequency (< 1000 Hz) counter
+	  instances only; high-frequency counters always use the full 100
+	  iterations. Each iteration busy-waits a few counter ticks, so on a
+	  slow counter (e.g. a 1 Hz RTC) a large value makes the test run for
+	  minutes and risk the test timeout. The default keeps slow-counter
+	  coverage while bounding runtime.
+
 source "Kconfig.zephyr"

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -1095,7 +1095,14 @@ static void test_short_relative_alarm_instance(const struct device *dev)
 
 	alarm_cfg.ticks = 1;
 
-	for (int i = 0; i < 100; ++i) {
+	/* Slow counters busy-wait several ticks per iteration (~3 s on a 1 Hz
+	 * RTC), so cap their iteration count; fast counters keep the full
+	 * count to preserve coverage.
+	 */
+	int iterations = (counter_get_frequency(dev) < 1000) ?
+		CONFIG_TEST_COUNTER_SHORT_RELATIVE_ALARM_ITERATIONS : 100;
+
+	for (int i = 0; i < iterations; ++i) {
 		err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
 		zassert_equal(0, err,
 				"%s: Failed to set an alarm (err: %d)",


### PR DESCRIPTION
test_short_relative_alarm sets an alarm and busy-waits a few counter ticks, repeated in a fixed 100-iteration loop for every counter instance. On low-frequency counters this dominates the runtime: On a 1 Hz RTC, each iteration busy-waits ~3 s (3 ticks), so the default 100 iterations take ~5 minutes. With a 3 s trigger window there is no race left to catch, so extra iterations only waste time.

Replace the hard-coded 100 with a new Kconfig option, CONFIG_TEST_COUNTER_SHORT_RELATIVE_ALARM_ITERATIONS (default 100, so existing behaviour is unchanged).