### PR TITLE
drivers: pcie: defer recursive bridge scans for multifunction ports

### DIFF
--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -378,9 +378,12 @@ static bool scan_bus(uint8_t bus, const struct pcie_scan_opt *opt);
 
 static bool scan_dev(uint8_t bus, uint8_t dev, const struct pcie_scan_opt *opt)
 {
+	uint8_t deferred_buses[PCIE_MAX_FUNC + 1];
+	uint8_t deferred_count = 0;
+	uint8_t secondary = 0;
+
 	for (uint8_t func = 0; func <= PCIE_MAX_FUNC; func++) {
 		pcie_bdf_t bdf = PCIE_BDF(bus, dev, func);
-		uint32_t secondary = 0;
 		uint32_t id, type;
 		bool do_cb;
 
@@ -395,12 +398,8 @@ static bool scan_dev(uint8_t bus, uint8_t dev, const struct pcie_scan_opt *opt)
 			do_cb = true;
 			break;
 		case PCIE_CONF_TYPE_PCI_BRIDGE:
-			if (scan_flag(opt, PCIE_SCAN_RECURSIVE)) {
-				uint32_t num = pcie_conf_read(bdf,
-							      PCIE_BUS_NUMBER);
-				secondary = PCIE_BUS_SECONDARY_NUMBER(num);
-			}
-			__fallthrough;
+			do_cb = scan_flag(opt, PCIE_SCAN_CB_ALL);
+			break;
 		default:
 			do_cb = scan_flag(opt, PCIE_SCAN_CB_ALL);
 			break;
@@ -410,15 +409,26 @@ static bool scan_dev(uint8_t bus, uint8_t dev, const struct pcie_scan_opt *opt)
 			return false;
 		}
 
-		if (scan_flag(opt, PCIE_SCAN_RECURSIVE) && secondary != 0) {
-			if (!scan_bus(secondary, opt)) {
-				return false;
+		if (PCIE_CONF_TYPE_GET(type) == PCIE_CONF_TYPE_PCI_BRIDGE &&
+		    scan_flag(opt, PCIE_SCAN_RECURSIVE)) {
+			uint32_t num = pcie_conf_read(bdf, PCIE_BUS_NUMBER);
+
+			secondary = PCIE_BUS_SECONDARY_NUMBER(num);
+
+			if (secondary != 0) {
+				deferred_buses[deferred_count++] = secondary;
 			}
 		}
 
 		/* Only function 0 is valid for non-multifunction devices */
 		if (func == 0 && !PCIE_CONF_MULTIFUNCTION(type)) {
 			break;
+		}
+	}
+
+	for (uint8_t idx = 0; idx < deferred_count; idx++) {
+		if (!scan_bus(deferred_buses[idx], opt)) {
+			return false;
 		}
 	}
 

--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -390,9 +390,12 @@ static inline bool should_skip_masked_bdf(pcie_bdf_t bdf, uint8_t func,
 
 static bool scan_dev(uint8_t bus, uint8_t dev, const struct pcie_scan_opt *opt)
 {
+	uint8_t deferred_buses[PCIE_MAX_FUNC + 1];
+	uint8_t deferred_count = 0;
+	uint8_t secondary = 0;
+
 	for (uint8_t func = 0; func <= PCIE_MAX_FUNC; func++) {
 		pcie_bdf_t bdf = PCIE_BDF(bus, dev, func);
-		uint32_t secondary = 0;
 		uint32_t id, type;
 		bool do_cb;
 
@@ -412,12 +415,8 @@ static bool scan_dev(uint8_t bus, uint8_t dev, const struct pcie_scan_opt *opt)
 			do_cb = true;
 			break;
 		case PCIE_CONF_TYPE_PCI_BRIDGE:
-			if (scan_flag(opt, PCIE_SCAN_RECURSIVE)) {
-				uint32_t num = pcie_conf_read(bdf,
-							      PCIE_BUS_NUMBER);
-				secondary = PCIE_BUS_SECONDARY_NUMBER(num);
-			}
-			__fallthrough;
+			do_cb = scan_flag(opt, PCIE_SCAN_CB_ALL);
+			break;
 		default:
 			do_cb = scan_flag(opt, PCIE_SCAN_CB_ALL);
 			break;
@@ -427,15 +426,26 @@ static bool scan_dev(uint8_t bus, uint8_t dev, const struct pcie_scan_opt *opt)
 			return false;
 		}
 
-		if (scan_flag(opt, PCIE_SCAN_RECURSIVE) && secondary != 0) {
-			if (!scan_bus(secondary, opt)) {
-				return false;
+		if (PCIE_CONF_TYPE_GET(type) == PCIE_CONF_TYPE_PCI_BRIDGE &&
+		    scan_flag(opt, PCIE_SCAN_RECURSIVE)) {
+			uint32_t num = pcie_conf_read(bdf, PCIE_BUS_NUMBER);
+
+			secondary = PCIE_BUS_SECONDARY_NUMBER(num);
+
+			if (secondary != 0 && deferred_count <= PCIE_MAX_FUNC) {
+				deferred_buses[deferred_count++] = secondary;
 			}
 		}
 
 		/* Only function 0 is valid for non-multifunction devices */
 		if (func == 0 && !PCIE_CONF_MULTIFUNCTION(type)) {
 			break;
+		}
+	}
+
+	for (uint8_t idx = 0; idx < deferred_count; idx++) {
+		if (!scan_bus(deferred_buses[idx], opt)) {
+			return false;
 		}
 	}
 


### PR DESCRIPTION
## Description
Fixes an issue where scanning nested multifunction bridges premature-dives down the first bridge function before processing peer functions on the same slot. This can cause missing hardware tracking cells if secondary buses aren't allocated in order.
## Solution
Maintain the core DFS pattern but defer the vertical branch descent until the horizontal function traversal across the parent slot node completes. This queues the target buses into an array buffer to secure parent interfaces before downstream enumeration begins.
## Testing Matrix

* Verified on qemu_cortex_a53 with a multi-root port bridge topology (multifunction=on).
* Low-level pci_cfg tracing confirms the horizontal ports are fully initialized in hardware before child branches are traversed.


### Real-World Topology Verification

Tested against a multi-root port slot hosting a nested downstream switch array layout (forcing dynamic bus expansion under Function 0).

####  Originally (Scrambled/Out-of-Order Enumeration)
The original engine premature-dives down the first branch immediately, executing complete leaf-node discovery on Bus 01, 02, and 03 before ever discovering that peer Bridge B (`0:1.1`) exists on the parent layer. This scrambles the internal device tree topology array layout. 

```text
uart:~$ pcie ls 
0:0.0 ID 1b36:8 class 6 subclass 0 prog i/f 0 rev 0
    wired interrupt on IRQ 0
0:1.0 ID 1b36:c class 6 subclass 4 prog i/f 0 rev 0 [bridge]
1:0.0 ID 104c:8232 class 6 subclass 4 prog i/f 0 rev 2 [bridge]
2:0.0 ID 104c:8233 class 6 subclass 4 prog i/f 0 rev 1 [bridge]
3:0.0 ID 8086:10d3 class 2 subclass 0 prog i/f 0 rev 0
    bar 0: MEM addr 0x10020000
    bar 1: MEM addr 0x10040000
    bar 2: I/O addr 0x00001000
    bar 3: MEM addr 0x10060000
    wired interrupt on IRQ 0
0:1.1 ID 1b36:c class 6 subclass 4 prog i/f 0 rev 0 [bridge]
```

####  Now
With the patch applied, the localized breadth-first barrier safely captures the peer bridge entries across the slot layout first. Sibling bridges (`0:1.0` and `0:1.1`) are discovered and registered sequentially next to each other on the parent bus before the vertical recursive dive safely unwinds:

```text
uart:~\$ pcie ls 
0:0.0 ID 1b36:8 class 6 subclass 0 prog i/f 0 rev 0
    wired interrupt on IRQ 0
0:1.0 ID 1b36:c class 6 subclass 4 prog i/f 0 rev 0 [bridge]
0:1.1 ID 1b36:c class 6 subclass 4 prog i/f 0 rev 0 [bridge]
1:0.0 ID 104c:8232 class 6 subclass 4 prog i/f 0 rev 2 [bridge]
2:0.0 ID 104c:8233 class 6 subclass 4 prog i/f 0 rev 1 [bridge]
3:0.0 ID 8086:10d3 class 2 subclass 0 prog i/f 0 rev 0
    bar 0: MEM addr 0x10020000
    bar 1: MEM addr 0x10040000
    bar 2: I/O addr 0x00001000
    bar 3: MEM addr 0x10060000
    wired interrupt on IRQ 0
```

