### PR TITLE
net: tcp: Fix stale user_data pointer in close_tcp_conn()

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -4950,7 +4950,8 @@ static void close_tcp_conn(struct tcp *conn, void *user_data)
 		}
 
 		if (conn->accept_cb != NULL) {
-			conn->accept_cb(conn->context, NULL, 0, -ENETDOWN, context->user_data);
+			/* context->user_data may be a stashed errno, not a pointer */
+			conn->accept_cb(conn->context, NULL, 0, -ENETDOWN, context);
 			conn->accept_cb = NULL;
 		}
 


### PR DESCRIPTION
close_tcp_conn() forwards context->user_data as the accept_cb's user_data argument when notifying a listening socket that its interface went down. For BSD sockets, zsock_accepted_cb() reuses this same field to stash an integer errno (INT_TO_POINTER) after a failed accept, and never restores it. If the interface goes down a second time before a successful accept() occurs, close_tcp_conn() forwards this stale integer as if it were the parent net_context pointer, and zsock_accepted_cb() dereferences it, causing a wild pointer access and a kernel fatal error.

Reproduced on real hardware (STM32F401 + WIZnet W5500) by flapping the Ethernet link twice in a row while a Modbus TCP server thread was blocked in accept() on the affected interface.

context is already the value user_data is supposed to hold in the non-error case, so pass it directly instead of trusting a field the sockets layer may have overwritten.

#114678 