### PR TITLE
drivers: entropy: mcux_trng: fix silent failure poisoning xoshiro128 seed

### DIFF
--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -1,11 +1,14 @@
 /*
  * Copyright (c) 2017 Linaro Limited.
  * Copyright 2025 NXP
+ * Copyright (c) 2026 Xsight Labs Ltd.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #define DT_DRV_COMPAT nxp_kinetis_trng
+
+#include <errno.h>
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
@@ -27,7 +30,9 @@ static int entropy_mcux_trng_get_entropy(const struct device *dev,
 	status_t status;
 
 	status = TRNG_GetRandomData(config->base, buffer, length);
-	__ASSERT_NO_MSG(!status);
+	if (status != kStatus_Success) {
+		return -EIO;
+	}
 
 	return 0;
 }
@@ -47,10 +52,14 @@ static int entropy_mcux_trng_init(const struct device *dev)
 	status_t status;
 
 	status = TRNG_GetDefaultConfig(&conf);
-	__ASSERT_NO_MSG(!status);
+	if (status != kStatus_Success) {
+		return -EIO;
+	}
 
 	status = TRNG_Init(config->base, &conf);
-	__ASSERT_NO_MSG(!status);
+	if (status != kStatus_Success) {
+		return -EIO;
+	}
 
 	return 0;
 }
@@ -66,8 +75,7 @@ static int entropy_mcux_trng_pm_action(const struct device *dev, enum pm_device_
 	case PM_DEVICE_ACTION_TURN_OFF:
 		break;
 	case PM_DEVICE_ACTION_TURN_ON:
-		entropy_mcux_trng_init(dev);
-		break;
+		return entropy_mcux_trng_init(dev);
 	default:
 		return -ENOTSUP;
 	}

--- a/subsys/random/random_xoshiro128.c
+++ b/subsys/random/random_xoshiro128.c
@@ -48,10 +48,17 @@ static void xoshiro128_init_state(void)
 	 * up with a mix of random bytes from both threads.
 	 */
 	rc = entropy_get_entropy(entropy_driver, (uint8_t *)&state, sizeof(state));
-	if (rc == 0) {
+
+	/* Reject an all-zero seed: xoshiro128++ has a fixed point at
+	 * state = {0,0,0,0}. Leaving initialized=false on rejection lets
+	 * the next sys_rand_get() retry the entropy source.
+	 */
+	if (rc == 0 &&
+	    (state[0] | state[1] | state[2] | state[3]) != 0) {
 		initialized = true;
 	} else {
-		/* Entropy device failed or is not yet ready.
+		/* Entropy device failed, is not yet ready, or returned an
+		 * all-zero buffer.
 		 * Reseed the PRNG state with pseudo-random data until it can
 		 * be properly seeded. This may be needed if random numbers are
 		 * requested before the backing entropy device has been enabled.


### PR DESCRIPTION
The NXP mcux_trng driver returns success even when the underlying
TRNG_GetRandomData() call fails, feeding an all-zero buffer to
xoshiro128++. Since {0,0,0,0} is xoshiro's fixed point, the PRNG
outputs 0 forever, so sys_rand_get() is pinned to 0 for the rest
of boot. This deterministically breaks find_available_port() in
the net stack: sys_rand16_get() | 0x8000 is always 32768, so
every TCP net_context_get() fails with -EADDRINUSE.

Two independent commits:
1. drivers/entropy: mcux_trng returns -EIO on SDK errors instead
   of asserting.
2. random/xoshiro128: reject an all-zero seed (defense in depth).

Fixes [114586](https://github.com/zephyrproject-rtos/zephyr/issues/114586)