### PR TITLE
tests: shell: limit which platforms use the robot harness

### DIFF
--- a/samples/subsys/shell/shell_module/tests.yaml
+++ b/samples/subsys/shell/shell_module/tests.yaml
@@ -74,8 +74,11 @@ tests:
     harness: robot
     arch_exclude:
       - xtensa
-    platform_exclude:
-      - qemu_rx/r5f562n8
+    # Some QEMUs are getting stuck on termination, so keep this only for
+    # working platforms for now.
+    platform_allow:
+      - qemu_x86
+      - native_sim
     extra_configs:
       - arch:posix:CONFIG_UART_NATIVE_PTY_0_ON_STDINOUT=y
     harness_config:


### PR DESCRIPTION
Some platforms get stuck on termination hogging the runner and causing
test execution to timeout. Enable only on a few working platforms while
we provide a long term solution.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
