### PR TITLE
arch: riscv: add Zicfilp support

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -450,6 +450,15 @@ config PMP_UNLOCK_ROM_FOR_DEBUG
 
 endif #RISCV_PMP
 
+config RISCV_LANDING_PADS
+	bool "Landing Pad Enforcement (Zicfilp)"
+	depends on RISCV_ISA_EXT_ZICFILP
+	default y
+	help
+	  Enables forward-edge control-flow integrity by configuring
+	  environment registers to enforce landing pad (lpad) instructions at
+	  indirect branch targets.
+
 config PMP_STACK_GUARD
 	bool
 	depends on HW_STACK_PROTECTION

--- a/arch/riscv/Kconfig.isa
+++ b/arch/riscv/Kconfig.isa
@@ -183,7 +183,7 @@ config RISCV_ISA_EXT_ZCA
 	bool
 	default y if $(dt_compat_all_has_prop,riscv,$(RISCV_ISA_EXT_PROP),zca)
 	help
-	  (Zca) - Zba Extension for Compressed Instructions
+	  (Zca) - Zca Extension for Compressed Instructions
 
 	  The Zca extension is a subset of the C extension that does not include
 	  the floating-point load and store instructions.
@@ -353,3 +353,13 @@ config RISCV_ISA_EXT_ZKS
 	  standards. It includes sub-extensions Zbkb, Zbkc, Zbkx
 	  (shared with Zk), Zksed (SM4 block cipher), and Zksh
 	  (SM3 hash function).
+
+config RISCV_ISA_EXT_ZICFILP
+	bool
+	default y if $(dt_compat_all_has_prop,riscv,$(RISCV_ISA_EXT_PROP),zicfilp)
+	help
+	  (Zicfilp) - Zicfilp Extensions for Landing Pads
+
+	  The Zicfilp extension introduces landing pad (lpad) instructions to enforce
+	  forward-edge control-flow integrity, ensuring indirect calls and jumps target
+	  valid, predefined locations.

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -53,7 +53,7 @@ uintptr_t z_riscv_get_sp_before_exc(const struct arch_esf *esf)
 
 const char *z_riscv_mcause_str(unsigned long cause)
 {
-	static const char *const mcause_str[17] = {
+	static const char *const mcause_str[20] = {
 		[0] = "Instruction address misaligned",
 		[1] = "Instruction Access fault",
 		[2] = "Illegal instruction",
@@ -70,7 +70,10 @@ const char *z_riscv_mcause_str(unsigned long cause)
 		[13] = "Load page fault",
 		[14] = "unknown",
 		[15] = "Store/AMO page fault",
-		[16] = "unknown",
+		[16] = "Double Trap",
+		[17] = "unknown",
+		[18] = "Software Check Exception",
+		[19] = "unknown",
 	};
 
 	return mcause_str[MIN(cause, ARRAY_SIZE(mcause_str) - 1)];

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -75,6 +75,9 @@ void arch_secondary_cpu_init(int hartid)
 #ifdef CONFIG_RISCV_PMP
 	z_riscv_pmp_init();
 #endif
+#ifdef CONFIG_RISCV_LANDING_PADS
+	csr_set(mseccfg, MSECCFG_MLPE);
+#endif
 #ifdef CONFIG_CUSTOM_STACK_GUARD
 	z_riscv_custom_stack_guard_init();
 #endif /* CONFIG_CUSTOM_STACK_GUARD */

--- a/arch/riscv/include/kernel_arch_func.h
+++ b/arch/riscv/include/kernel_arch_func.h
@@ -66,6 +66,9 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 #if defined(CONFIG_RISCV_PMP) && !defined(CONFIG_RISCV_S_MODE)
 	z_riscv_pmp_init();
 #endif
+#if defined(CONFIG_RISCV_LANDING_PADS) && !defined(CONFIG_RISCV_S_MODE)
+	csr_set(mseccfg, MSECCFG_MLPE);
+#endif
 #ifdef CONFIG_CUSTOM_STACK_GUARD
 	z_riscv_custom_stack_guard_init();
 #endif /* CONFIG_CUSTOM_STACK_GUARD */

--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -137,6 +137,10 @@ if(CONFIG_RISCV_ISA_EXT_ZBS)
   string(APPEND riscv_march "_zbs")
 endif()
 
+if(CONFIG_RISCV_ISA_EXT_ZICFILP)
+  string(APPEND riscv_march "_zicfilp")
+endif()
+
 # Check whether we already imply Zmmul by selecting the M extension; if not - enable it
 if(NOT CONFIG_RISCV_ISA_EXT_M AND
    CONFIG_RISCV_ISA_EXT_ZMMUL AND
@@ -201,6 +205,10 @@ list(APPEND RISCV_C_FLAGS
      -march=${riscv_march}
      -mcmodel=${riscv_mcmodel}
      )
+if(CONFIG_RISCV_LANDING_PADS)
+  list(APPEND RISCV_C_FLAGS -fcf-protection=branch)
+endif()
+
 list(APPEND TOOLCHAIN_C_FLAGS ${RISCV_C_FLAGS})
 list(APPEND TOOLCHAIN_GROUPED_LD_FLAGS RISCV_C_FLAGS)
 

--- a/include/zephyr/arch/riscv/csr.h
+++ b/include/zephyr/arch/riscv/csr.h
@@ -133,6 +133,8 @@
 #define SATP_MODE_SV57	10
 #define SATP_MODE_SV64	11
 
+#define MSECCFG_MLPE	0x400
+
 /**
  * PMPCFG CSR base address
  */

--- a/tests/arch/riscv/cfi/missing_landing_pad/CMakeLists.txt
+++ b/tests/arch/riscv/cfi/missing_landing_pad/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(riscv_cfi_missing_landing_pad)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/arch/riscv/cfi/missing_landing_pad/prj.conf
+++ b/tests/arch/riscv/cfi/missing_landing_pad/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/arch/riscv/cfi/missing_landing_pad/qemu_riscv32.overlay
+++ b/tests/arch/riscv/cfi/missing_landing_pad/qemu_riscv32.overlay
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Zephyr Project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	cpus {
+		cpu@0 {
+			riscv,isa-extensions = "i", "m", "a", "c", "s",
+					       "zicsr", "zifencei",
+					       "zicfilp";
+		};
+
+		cpu@1 {
+			riscv,isa-extensions = "i", "m", "a", "c", "s",
+					       "zicsr", "zifencei",
+					       "zicfilp";
+		};
+
+		cpu@2 {
+			riscv,isa-extensions = "i", "m", "a", "c", "s",
+					       "zicsr", "zifencei",
+					       "zicfilp";
+		};
+
+		cpu@3 {
+			riscv,isa-extensions = "i", "m", "a", "c", "s",
+					       "zicsr", "zifencei",
+					       "zicfilp";
+		};
+
+		cpu@4 {
+			riscv,isa-extensions = "i", "m", "a", "c", "s",
+					       "zicsr", "zifencei",
+					       "zicfilp";
+		};
+
+		cpu@5 {
+			riscv,isa-extensions = "i", "m", "a", "c", "s",
+					       "zicsr", "zifencei",
+					       "zicfilp";
+		};
+
+		cpu@6 {
+			riscv,isa-extensions = "i", "m", "a", "c", "s",
+					       "zicsr", "zifencei",
+					       "zicfilp";
+		};
+
+		cpu@7 {
+			riscv,isa-extensions = "i", "m", "a", "c", "s",
+					       "zicsr", "zifencei",
+					       "zicfilp";
+		};
+	};
+};

--- a/tests/arch/riscv/cfi/missing_landing_pad/src/main.c
+++ b/tests/arch/riscv/cfi/missing_landing_pad/src/main.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Zephyr Project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+#include <zephyr/arch/riscv/csr.h>
+
+#define STACK_SIZE  1024
+#define THREAD_PRIO 5
+
+K_THREAD_STACK_DEFINE(worker_stack, STACK_SIZE);
+struct k_thread worker_thread;
+K_SEM_DEFINE(fault_sem, 0, 1);
+
+static volatile bool valid_fault;
+
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
+{
+#ifdef CONFIG_RISCV_S_MODE
+	unsigned long cause = csr_read(scause);
+#else
+	unsigned long cause = csr_read(mcause);
+#endif
+	cause &= CONFIG_RISCV_MCAUSE_EXCEPTION_MASK;
+
+	if (valid_fault && cause == 18) {
+		valid_fault = false;
+		k_sem_give(&fault_sem);
+		/* Abort only the faulting thread so ZTest thread can continue */
+		k_thread_abort(k_current_get());
+	} else {
+		/* Unexpected fault */
+		TC_END_REPORT(TC_FAIL);
+		k_fatal_halt(reason);
+	}
+}
+
+/*
+ * Top-level assembly defining bad_target_function.
+ * Written directly in global assembly so the compiler cannot insert 'lpad'.
+ */
+__asm__(".section .text\n"
+	".globl bad_target_function\n"
+	".type bad_target_function, @function\n"
+	"bad_target_function:\n"
+	"    nop\n"
+	"    ret\n"
+	".size bad_target_function, .-bad_target_function\n");
+
+/* C prototype for the assembly target function above */
+extern void bad_target_function(void);
+
+static void worker_entry(void *p1, void *p2, void *p3)
+{
+	/*
+	 * Load address of bad_target_function into x6 (t1) — a register other than x1, x5, x7.
+	 * Execute indirect call (jalr x1, x6, 0).
+	 * If CONFIG_RISCV_LANDING_PADS (Zicfilp) is enabled, jumping to a function lacking an
+	 * 'lpad' instruction triggers a landing pad fault (cause 18).
+	 */
+	__asm__ volatile("la x6, bad_target_function\n\t"
+			 "jalr x1, x6, 0\n\t"
+			 :
+			 :
+			 : "x6", "x1", "memory");
+}
+
+ZTEST(riscv_cfi_missing_landing_pad, test_missing_landing_pad_trap)
+{
+	valid_fault = true;
+
+	/* Create worker thread to execute the faulting call */
+	k_thread_create(&worker_thread, worker_stack, STACK_SIZE, worker_entry, NULL, NULL, NULL,
+			THREAD_PRIO, 0, K_NO_WAIT);
+
+	/* Wait for the fatal error handler to catch the trap */
+	zassert_equal(k_sem_take(&fault_sem, K_MSEC(1000)), 0,
+		      "Landing pad trap was not triggered within timeout");
+}
+
+ZTEST_SUITE(riscv_cfi_missing_landing_pad, NULL, NULL, NULL, NULL, NULL);

--- a/tests/arch/riscv/cfi/missing_landing_pad/tests.yaml
+++ b/tests/arch/riscv/cfi/missing_landing_pad/tests.yaml
@@ -1,0 +1,14 @@
+common:
+  platform_allow:
+    - qemu_riscv32
+    - qemu_riscv32e
+    - qemu_riscv64
+  toolchain_allow:
+    - cross-compile
+  filter: CONFIG_RISCV_LANDING_PADS
+  ignore_faults: true
+
+tests:
+  arch.riscv.cfi.missing_landing_pad:
+    extra_configs:
+      - CONFIG_RISCV_LANDING_PADS=y


### PR DESCRIPTION
Based on the documentation, Zephyr currently supports architectural CFI for Intel and ARM. The RISC-V Zicfilp extension was ratified in 2024 and provides forward-edge CFI using landing pad instructions (while backward-edge CFI is handled separately by Zicfiss using shadow stacks). Toolchain support continues to mature. This PR adds initial Zicfilp support to Zephyr.

The current implementation enables Zicfilp for M mode. I have verified the implementation with a PoC test that writes the address of an assembly function missing an lpad 0 instruction into register x6 and performs an indirect jump, which correctly causes the CPU to trap.

Additionally, the standard sample codes boot and run normally on qemu32 with CONFIG_RISCV_LANDING_PADS=y set in prj.conf and the target extension enabled via app.overlay. I also tested arch/riscv and kernel tests with EXTRA_CONF_FILE and EXTRA_DTC_OVERLAY_FILE to enable Landing pads in code and qemu to check for functions maybe without a valid lpad entry. All ran tests pass.

This does require GCC Toolchain to be compiled with Zicfilp enabled. I compiled my own for testing (Not using SDK Toolchain).

This initial PR focuses cleanly on M-mode.  