### PR TITLE
scripts/kconfig/guiconfig: fix missing import statement

### DIFF
--- a/scripts/kconfig/guiconfig.py
+++ b/scripts/kconfig/guiconfig.py
@@ -61,6 +61,7 @@ $srctree is supported through Kconfiglib.
 import errno
 import os
 import re
+import sys
 
 from tkinter import *
 import tkinter.ttk as ttk


### PR DESCRIPTION
Without 'sys' being imported, guiconfig fails as
'_detect_system_dark_mode' uses the unit.

Fixes #114682