### PR TITLE
west: hal_nxp: Remove large header

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 53946adb08b54449391c1c0c73cdd094d92a3b6e
+      revision: bc22c70f46957b2a8d3855f71a560ac417dc8287
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Remove large TRDC header files, they are
not used, TRDC accessing is done through
system manager for i.MX. TRDC header
is not necessary.