### PR TITLE
tests/bsim/bluetooth/mesh 2 fixes

### DIFF
--- a/tests/bsim/bluetooth/mesh/src/test_beacon.c
+++ b/tests/bsim/bluetooth/mesh/src/test_beacon.c
@@ -338,7 +338,7 @@ static struct {
 static void beacon_scan_cb(const bt_addr_le_t *addr, int8_t rssi, uint8_t adv_type,
 			   struct net_buf_simple *buf)
 {
-	const uint8_t *net_id;
+	const uint8_t *net_id = NULL;
 	uint8_t ad_data_type, beacon_type, length;
 
 	ASSERT_EQUAL(BT_GAP_ADV_TYPE_ADV_NONCONN_IND, adv_type);
@@ -1073,6 +1073,8 @@ BT_MESH_BEACON_CB_DEFINE(priv_beacon) = {
 
 static bool private_beacon_check(const uint8_t *net_id, void *ctx)
 {
+	ARG_UNUSED(net_id);
+
 	bool ret;
 	bool same_random = *(bool *)ctx;
 

--- a/tests/bsim/bluetooth/mesh/src/test_dfu.c
+++ b/tests/bsim/bluetooth/mesh/src/test_dfu.c
@@ -55,7 +55,13 @@ static int dfu_targets_cnt;
 static bool dfu_fail_confirm;
 static bool recover;
 static bool expect_fail;
+static int expected_stop_phase_param;
 static enum bt_mesh_dfu_phase expected_stop_phase;
+
+static void expected_stop_phase_found(char *argv, int offset)
+{
+	expected_stop_phase = (enum bt_mesh_dfu_phase)expected_stop_phase_param;
+}
 
 static void test_args_parse(int argc, char *argv[])
 {
@@ -75,7 +81,8 @@ static void test_args_parse(int argc, char *argv[])
 			.descript = "Request target to fail confirm step"
 		},
 		{
-			.dest = &expected_stop_phase,
+			.dest = &expected_stop_phase_param,
+			.call_when_found = expected_stop_phase_found,
 			.type = 'i',
 			.name = "{none, start, verify, verify-ok, verify-fail, apply}",
 			.option = "expected-phase",


### PR DESCRIPTION
    tests/bsim/bluetooth/mesh/test_dfu: Fix command line parsing bug
    
    The size of an enum (enum bt_mesh_dfu_phase) depends on compile options.
    It is not the same as the size of int in general.
    
    Depending on memory layout and compile options, expected_stop_phase would
    be just 1 byte, and when setting it from command line it would be
    written like if it was a whole int, smashing the variables around causing
    bizarre failures.
    
    Let's fix the issue by using an intermediate int variable we then copy
    into the enum (so we minimize code changes in the test).
    

----

    tests/bsim/bluetooth/mesh/src/test_beacon: Initialize stack variable
    
    Let's initialize net_id to an invalid value explicitly to avoid a
    build warning, in which the compiler thinks it may be used unitialized
    in line 374.
    
    The case the compiler tries to warn us about does not seem to happen:
    (when this calback is used with `expected_beacon == BEACON_TYPE_PRIVATE`,
    process_cb is set to private_beacon_check() which does not use this input)
