### PR TITLE
boards: microchip: fix FDPLL reference clock

### DIFF
--- a/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg41_cult/pic32cx_sg41_cult.dts
@@ -140,10 +140,11 @@
 
 		fdpll0 {
 			subsystem = <CLOCK_MCHP_FDPLL_ID_FDPLL0>;
-			fdpll-divider-ratio-int = <19>;
+			fdpll-divider-ratio-int = <119>;
 			fdpll-lock-bypass-en = <1>;
 			fdpll-wakeup-fast-en = <1>;
 			fdpll-src = "xosc1";
+			fdpll-xosc-clock-divider = <5>;
 			fdpll-en = <1>;
 		};
 	};

--- a/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
+++ b/boards/microchip/pic32c/pic32cx_sg61_cult/pic32cx_sg61_cult.dts
@@ -140,10 +140,11 @@
 
 		fdpll0 {
 			subsystem = <CLOCK_MCHP_FDPLL_ID_FDPLL0>;
-			fdpll-divider-ratio-int = <19>;
+			fdpll-divider-ratio-int = <119>;
 			fdpll-lock-bypass-en = <1>;
 			fdpll-wakeup-fast-en = <1>;
 			fdpll-src = "xosc1";
+			fdpll-xosc-clock-divider = <5>;
 			fdpll-en = <1>;
 		};
 	};

--- a/boards/microchip/sam/sam_e54_xpro/sam_e54_xpro.dts
+++ b/boards/microchip/sam/sam_e54_xpro/sam_e54_xpro.dts
@@ -217,10 +217,11 @@
 
 		fdpll0 {
 			subsystem = <CLOCK_MCHP_FDPLL_ID_FDPLL0>;
-			fdpll-divider-ratio-int = <19>;
+			fdpll-divider-ratio-int = <119>;
 			fdpll-lock-bypass-en = <1>;
 			fdpll-wakeup-fast-en = <1>;
 			fdpll-src = "xosc1";
+			fdpll-xosc-clock-divider = <5>;
 			fdpll-en = <1>;
 		};
 	};


### PR DESCRIPTION
Reference clock for FDPLL configured to 1 MHz. It should be between 32 KHz and 3.2 MHz for SAM D5x/E5x and PIC32CX SG41/SG61