### PR TITLE
net: sockets: Store async socket error in net_context

### DIFF
--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -280,6 +280,12 @@ __net_socket struct net_context {
 	/** BSD socket private data */
 	void *socket_data;
 
+	/** Pending socket error (positive errno) reported asynchronously by
+	 *  the network stack. Valid only while the SOCK_ERROR flag is set;
+	 *  consumed via SO_ERROR or by the next blocking socket call.
+	 */
+	int sock_error;
+
 	/** Per-socket packet or connection queues */
 	union {
 		struct k_fifo recv_q;

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -173,8 +173,7 @@ int zsock_close_ctx(struct net_context *ctx, int sock)
 		(void)net_context_recv(ctx, NULL, K_NO_WAIT, NULL);
 	}
 
-	ctx->user_data = INT_TO_POINTER(EINTR);
-	sock_set_error(ctx);
+	sock_set_error(ctx, EINTR);
 
 	zsock_flush_queue(ctx);
 
@@ -221,8 +220,7 @@ static void zsock_accepted_cb(struct net_context *new_ctx,
 
 		(void)k_condvar_signal(&parent->cond.recv);
 	} else if (status < 0) {
-		parent->user_data = INT_TO_POINTER(-status);
-		sock_set_error(parent);
+		sock_set_error(parent, -status);
 
 		k_fifo_cancel_wait(&parent->recv_q);
 		(void)k_condvar_signal(&parent->cond.recv);
@@ -254,8 +252,7 @@ static void zsock_received_cb(struct net_context *ctx,
 		user_data);
 
 	if (status < 0) {
-		ctx->user_data = INT_TO_POINTER(-status);
-		sock_set_error(ctx);
+		sock_set_error(ctx, -status);
 	}
 
 	/* if pkt is NULL, EOF */
@@ -360,8 +357,7 @@ int zsock_bind_ctx(struct net_context *ctx, const struct net_sockaddr *addr,
 static void zsock_connected_cb(struct net_context *ctx, int status, void *user_data)
 {
 	if (status < 0) {
-		ctx->user_data = INT_TO_POINTER(-status);
-		sock_set_error(ctx);
+		sock_set_error(ctx, -status);
 
 		/* Wake pending threads, if any. */
 		k_fifo_cancel_wait(&ctx->recv_q);
@@ -407,7 +403,7 @@ int zsock_connect_ctx(struct net_context *ctx, const struct net_sockaddr *addr,
 
 	if (net_context_get_state(ctx) == NET_CONTEXT_CONNECTING) {
 		if (sock_is_error(ctx)) {
-			errno = POINTER_TO_INT(ctx->user_data);
+			errno = sock_get_error(ctx);
 			return -1;
 		}
 
@@ -520,7 +516,7 @@ int zsock_accept_ctx(struct net_context *parent, struct net_sockaddr *addr,
 	}
 
 	if (sock_is_error(parent)) {
-		errno = POINTER_TO_INT(parent->user_data);
+		errno = sock_get_error(parent);
 		return -1;
 	}
 
@@ -984,7 +980,7 @@ int zsock_wait_data(struct net_context *ctx, k_timeout_t *timeout)
 		}
 
 		if (sock_is_error(ctx)) {
-			return -POINTER_TO_INT(ctx->user_data);
+			return -sock_get_error(ctx);
 		}
 	}
 
@@ -1585,7 +1581,7 @@ static ssize_t zsock_recv_stream_timed(struct net_context *ctx, struct net_msghd
 					break;
 				}
 
-				return -POINTER_TO_INT(ctx->user_data);
+				return -sock_get_error(ctx);
 			}
 
 			if (sock_is_eof(ctx)) {
@@ -2018,7 +2014,7 @@ int zsock_getsockopt_ctx(struct net_context *ctx, int level, int optname,
 				return -1;
 			}
 
-			*(int *)optval = POINTER_TO_INT(ctx->user_data);
+			*(int *)optval = sock_get_error(ctx);
 
 			return 0;
 		}

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -51,7 +51,25 @@ static inline bool net_socket_is_tls(void *obj)
 #define sock_set_eof(ctx) sock_set_flag(ctx, SOCK_EOF, SOCK_EOF)
 #define sock_is_nonblock(ctx) sock_get_flag(ctx, SOCK_NONBLOCK)
 #define sock_is_error(ctx) sock_get_flag(ctx, SOCK_ERROR)
-#define sock_set_error(ctx) sock_set_flag(ctx, SOCK_ERROR, SOCK_ERROR)
+
+/* Record a pending socket error (positive errno) and flag the context.
+ * The value is stored in a dedicated net_context field rather than being
+ * stashed in user_data, which the stack also uses to carry the parent
+ * context pointer for accept callbacks.
+ */
+static inline void sock_set_error(struct net_context *ctx, int err)
+{
+	ctx->sock_error = err;
+	sock_set_flag(ctx, SOCK_ERROR, SOCK_ERROR);
+}
+
+/* Retrieve the pending socket error (positive errno) previously recorded
+ * by sock_set_error(). Only meaningful while sock_is_error() is true.
+ */
+static inline int sock_get_error(struct net_context *ctx)
+{
+	return ctx->sock_error;
+}
 
 size_t msghdr_non_empty_iov_count(const struct net_msghdr *msg);
 


### PR DESCRIPTION
zsock_*_cb() stashed the asynchronous error code in net_context.user_data via INT_TO_POINTER() and read it back with POINTER_TO_INT(). That field is also used by the stack to carry the parent context pointer passed to the accept callback, so a failed accept left a small integer where a pointer was expected. A subsequent interface-down forwarded that stale integer to zsock_accepted_cb(), which dereferenced it as the parent context, causing a wild pointer access and kernel fatal error.

Store the pending error in a dedicated net_context.sock_error field instead, leaving user_data untouched. sock_set_error() now takes the errno value and sock_get_error() retrieves it, replacing the user_data punning at all read and write sites.

Assisted-by: Claude:opus-4-8

This is an alternative fix that closes #114678
