### PR TITLE
drivers: wifi: nrf_wifi: Use API names platform agnostic

### DIFF
--- a/drivers/wifi/nrf_wifi/off_raw_tx/src/off_raw_tx_api.c
+++ b/drivers/wifi/nrf_wifi/off_raw_tx/src/off_raw_tx_api.c
@@ -136,7 +136,7 @@ static enum op_band get_nrf_wifi_op_band(void)
 	return BAND_ALL;
 }
 
-int nrf70_off_raw_tx_init(uint8_t *mac_addr, unsigned char *country_code)
+int nrf_wifi_off_raw_tx_init(uint8_t *mac_addr, unsigned char *country_code)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
@@ -158,7 +158,7 @@ int nrf70_off_raw_tx_init(uint8_t *mac_addr, unsigned char *country_code)
 	off_raw_tx_drv_priv.fmac_priv = nrf_wifi_off_raw_tx_fmac_init();
 
 	if (off_raw_tx_drv_priv.fmac_priv == NULL) {
-		LOG_ERR("%s: Failed to initialize nRF70 driver",
+		LOG_ERR("%s: Failed to initialize nRF Wi-Fi driver",
 			__func__);
 		goto err;
 	}
@@ -170,7 +170,7 @@ int nrf70_off_raw_tx_init(uint8_t *mac_addr, unsigned char *country_code)
 	rpu_ctx = nrf_wifi_off_raw_tx_fmac_dev_add(off_raw_tx_drv_priv.fmac_priv,
 						   rpu_ctx_zep);
 	if (!rpu_ctx) {
-		LOG_ERR("%s: Failed to add nRF70 device", __func__);
+		LOG_ERR("%s: Failed to add nRF Wi-Fi device", __func__);
 		rpu_ctx_zep = NULL;
 		goto err;
 	}
@@ -179,18 +179,18 @@ int nrf70_off_raw_tx_init(uint8_t *mac_addr, unsigned char *country_code)
 
 	status = nrf_wifi_fw_load(rpu_ctx);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: Failed to load the nRF70 firmware patch", __func__);
+		LOG_ERR("%s: Failed to load the nRF Wi-Fi firmware patch", __func__);
 		goto err;
 	}
 
 	status = nrf_wifi_fmac_ver_get(rpu_ctx,
 				       &fw_ver);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: Failed to read the nRF70 firmware version", __func__);
+		LOG_ERR("%s: Failed to read the nRF Wi-Fi firmware version", __func__);
 		goto err;
 	}
 
-	LOG_DBG("nRF70 firmware (v%d.%d.%d.%d) booted successfully",
+	LOG_DBG("nRF Wi-Fi firmware (v%d.%d.%d.%d) booted successfully",
 		NRF_WIFI_UMAC_VER(fw_ver),
 		NRF_WIFI_UMAC_VER_MAJ(fw_ver),
 		NRF_WIFI_UMAC_VER_MIN(fw_ver),
@@ -218,7 +218,7 @@ int nrf70_off_raw_tx_init(uint8_t *mac_addr, unsigned char *country_code)
 						   &board_params,
 						   country_code);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nRF70 firmware initialization failed", __func__);
+		LOG_ERR("%s: nRF Wi-Fi firmware initialization failed", __func__);
 		goto err;
 	}
 
@@ -271,12 +271,12 @@ err:
 	}
 
 	k_spin_unlock(&off_raw_tx_drv_priv.lock, key);
-	nrf70_off_raw_tx_deinit();
+	nrf_wifi_off_raw_tx_deinit();
 	return -1;
 }
 
 
-void nrf70_off_raw_tx_deinit(void)
+void nrf_wifi_off_raw_tx_deinit(void)
 {
 	k_spinlock_key_t key;
 
@@ -308,7 +308,7 @@ static bool validate_rate(enum nrf_wifi_off_raw_tx_tput_mode tput_mode,
 	return true;
 }
 
-int nrf70_off_raw_tx_conf_update(struct nrf_wifi_off_raw_tx_conf *conf)
+int nrf_wifi_off_raw_tx_conf_update(struct nrf_wifi_off_raw_tx_conf *conf)
 {
 	int ret = -1;
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -374,7 +374,7 @@ int nrf70_off_raw_tx_conf_update(struct nrf_wifi_off_raw_tx_conf *conf)
 					       off_ctrl_params,
 					       off_tx_params);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nRF70 offloaded raw TX configuration failed",
+		LOG_ERR("%s: nRF Wi-Fi offloaded raw TX configuration failed",
 				      __func__);
 		goto out;
 	}
@@ -388,15 +388,15 @@ out:
 }
 
 
-int nrf70_off_raw_tx_start(struct nrf_wifi_off_raw_tx_conf *conf)
+int nrf_wifi_off_raw_tx_start(struct nrf_wifi_off_raw_tx_conf *conf)
 {
 	int ret = -1;
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	k_spinlock_key_t key;
 
-	status = nrf70_off_raw_tx_conf_update(conf);
+	status = nrf_wifi_off_raw_tx_conf_update(conf);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nRF70 offloaded raw TX configuration failed",
+		LOG_ERR("%s: nRF Wi-Fi offloaded raw TX configuration failed",
 				      __func__);
 		goto out;
 	}
@@ -409,7 +409,7 @@ int nrf70_off_raw_tx_start(struct nrf_wifi_off_raw_tx_conf *conf)
 
 	status = nrf_wifi_off_raw_tx_fmac_start(off_raw_tx_drv_priv.rpu_ctx_zep.rpu_ctx);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nRF70 offloaded raw TX start failed",
+		LOG_ERR("%s: nRF Wi-Fi offloaded raw TX start failed",
 				      __func__);
 		goto out;
 	}
@@ -421,7 +421,7 @@ out:
 }
 
 
-int nrf70_off_raw_tx_stop(void)
+int nrf_wifi_off_raw_tx_stop(void)
 {
 	int ret = -1;
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -436,7 +436,7 @@ int nrf70_off_raw_tx_stop(void)
 
 	status = nrf_wifi_off_raw_tx_fmac_stop(off_raw_tx_drv_priv.rpu_ctx_zep.rpu_ctx);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nRF70 offloaded raw TX stop failed",
+		LOG_ERR("%s: nRF Wi-Fi offloaded raw TX stop failed",
 				      __func__);
 		goto out;
 	}
@@ -448,7 +448,7 @@ out:
 }
 
 
-int nrf70_off_raw_tx_mac_addr_get(uint8_t *mac_addr)
+int nrf_wifi_off_raw_tx_mac_addr_get(uint8_t *mac_addr)
 {
 	if (!mac_addr) {
 		LOG_ERR("%s: Invalid param", __func__);
@@ -459,7 +459,7 @@ int nrf70_off_raw_tx_mac_addr_get(uint8_t *mac_addr)
 	return 0;
 }
 
-int nrf70_off_raw_tx_stats(struct nrf_wifi_off_raw_tx_stats *off_raw_tx_stats)
+int nrf_wifi_off_raw_tx_stats(struct nrf_wifi_off_raw_tx_stats *off_raw_tx_stats)
 {
 	int ret = -1;
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -479,7 +479,7 @@ int nrf70_off_raw_tx_stats(struct nrf_wifi_off_raw_tx_stats *off_raw_tx_stats)
 						    0,
 						    &stats);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		LOG_ERR("%s: nRF70 offloaded raw TX stats failed",
+		LOG_ERR("%s: nRF Wi-Fi offloaded raw TX stats failed",
 				      __func__);
 		goto out;
 	}

--- a/include/zephyr/drivers/wifi/nrf_wifi/off_raw_tx/off_raw_tx_api.h
+++ b/include/zephyr/drivers/wifi/nrf_wifi/off_raw_tx/off_raw_tx_api.h
@@ -5,7 +5,7 @@
  */
 /** @file
  *
- * @addtogroup nrf70_off_raw_tx_api nRF70 Offloaded raw TX API
+ * @addtogroup nrf_wifi_off_raw_tx_api Offloaded raw TX API
  * @{
  *
  * @brief File containing API's for the Offloaded raw TX feature.
@@ -165,19 +165,19 @@ struct nrf_wifi_off_raw_tx_conf {
 
 
 /**
- * @brief Initialize the nRF70 for operating in the offloaded raw TX mode.
- * @param mac_addr MAC address to be used for the nRF70 device.
+ * @brief Initialize the nRF Wi-Fi for operating in the offloaded raw TX mode.
+ * @param mac_addr MAC address to be used for the nRF Wi-Fi device.
  * @param country_code Country code to be set for regularity domain.
  *
- * This function is initializes the nRF70 device for offloaded raw TX mode by:
+ * This function is initializes the nRF Wi-Fi device for offloaded raw TX mode by:
  *  - Powering it up,
  *  - Downloading a firmware patch (if any).
  *  - Initializing the firmware to accept further commands
  *
- * The mac_addr parameter is used to set the MAC address of the nRF70 device.
+ * The mac_addr parameter is used to set the MAC address of the nRF Wi-Fi device.
  * This address can be used to override the MAC addresses programmed in the OTP and
  * the value configured (if any) in CONFIG_WIFI_FIXED_MAC_ADDRESS.
- * The priority order in which the MAC address values for the nRF70 device are used is:
+ * The priority order in which the MAC address values for the nRF Wi-Fi device are used is:
  * - If mac_addr is provided, the MAC address is set to the value provided.
  * - If CONFIG_WIFI_FIXED_MAC_ADDRESS is enabled, the MAC address uses the Kconfig value.
  * - If none of the above are provided, the MAC address is set to the value programmed in the OTP.
@@ -185,15 +185,15 @@ struct nrf_wifi_off_raw_tx_conf {
  * @retval 0 If the operation was successful.
  * @retval -1 If the operation failed.
  */
-int nrf70_off_raw_tx_init(uint8_t *mac_addr, unsigned char *country_code);
+int nrf_wifi_off_raw_tx_init(uint8_t *mac_addr, unsigned char *country_code);
 
 /**
- * @brief Initialize the nRF70 for operating in the offloaded raw TX mode.
+ * @brief Initialize the nRF Wi-Fi for operating in the offloaded raw TX mode.
  *
- * This function is deinitializes the nRF70 device.
+ * This function is deinitializes the nRF Wi-Fi device.
  *
  */
-void nrf70_off_raw_tx_deinit(void);
+void nrf_wifi_off_raw_tx_deinit(void);
 
 /**
  * @brief Update the configured offloaded raw TX parameters.
@@ -206,55 +206,55 @@ void nrf70_off_raw_tx_deinit(void);
  * @retval 0 If the operation was successful.
  * @retval -1 If the operation failed.
  */
-int nrf70_off_raw_tx_conf_update(struct nrf_wifi_off_raw_tx_conf *conf);
+int nrf_wifi_off_raw_tx_conf_update(struct nrf_wifi_off_raw_tx_conf *conf);
 
 /**
  * @brief Start the offloaded raw TX.
  * @param conf Configuration parameters necessary for the offloaded raw TX operation.
  *
- * This function is used to start offloaded raw TX operation. When this function is invoked
- * the nRF70 device will start transmitting frames as per the configuration specified by @p conf.
+ * This function is used to start offloaded raw TX operation. When this function is invoked the
+ * nRF Wi-Fi device will start transmitting frames as per the configuration specified by @p conf.
  *
  * @retval 0 If the operation was successful.
  * @retval -1 If the operation failed.
  */
-int nrf70_off_raw_tx_start(struct nrf_wifi_off_raw_tx_conf *conf);
+int nrf_wifi_off_raw_tx_start(struct nrf_wifi_off_raw_tx_conf *conf);
 
 /**
  * @brief Stop the offloaded raw TX.
  *
  * This function is used to stop offloaded raw TX operation. When this function is invoked
- * the nRF70 device will stop transmitting frames.
+ * the nRF Wi-Fi device will stop transmitting frames.
  *
  * @retval 0 If the operation was successful.
  * @retval -1 If the operation failed.
  */
-int nrf70_off_raw_tx_stop(void);
+int nrf_wifi_off_raw_tx_stop(void);
 
 /**
- * @brief Get the MAC address of the nRF70 device.
+ * @brief Get the MAC address of the nRF Wi-Fi device.
  * @param mac_addr Buffer to store the MAC address.
  *
- * This function is used to get the MAC address of the nRF70 device.
+ * This function is used to get the MAC address of the nRF Wi-Fi device.
  * The MAC address is stored in the buffer pointed by mac_addr.
  * The MAC address is expected to be a 6 byte value.
  *
  * @retval 0 If the operation was successful.
  * @retval -1 If the operation failed.
  */
-int nrf70_off_raw_tx_mac_addr_get(uint8_t *mac_addr);
+int nrf_wifi_off_raw_tx_mac_addr_get(uint8_t *mac_addr);
 
 /**
  * @brief Get statistics of the offloaded raw TX.
  * @param off_raw_tx_stats Statistics of the offloaded raw TX operation.
  *
  * This function is used to get statistics of offloaded raw TX operation. When this function
- * is invoked the nRF70 device will show statistics.
+ * is invoked the nRF Wi-Fi device will show statistics.
  *
  * @retval 0 If the operation was successful.
  * @retval -1 If the operation failed.
  */
-int nrf70_off_raw_tx_stats(struct nrf_wifi_off_raw_tx_stats *off_raw_tx_stats);
+int nrf_wifi_off_raw_tx_stats(struct nrf_wifi_off_raw_tx_stats *off_raw_tx_stats);
 /**
  * @}
  */


### PR DESCRIPTION
Presently the Offloaded raw TX API names are tied to the nRF70 platform. So make the API names platform agnostic.