### PR TITLE
drivers: rtc: rtc_emul: Avoid libc dependency

### DIFF
--- a/drivers/rtc/CMakeLists.txt
+++ b/drivers/rtc/CMakeLists.txt
@@ -53,3 +53,7 @@ zephyr_library_sources_ifdef(CONFIG_RTC_TI_MSPM0 rtc_ti_mspm0.c)
 zephyr_library_sources_ifdef(CONFIG_RTC_XEC rtc_mchp_xec.c)
 zephyr_library_sources_ifdef(CONFIG_RTC_XMC4XXX rtc_xmc4xxx.c)
 # zephyr-keep-sorted-stop
+
+if(CONFIG_RTC_EMUL_INIT_DATETIME)
+  target_sources(native_simulator INTERFACE rtc_emul_native.c)
+endif()

--- a/drivers/rtc/Kconfig.emul
+++ b/drivers/rtc/Kconfig.emul
@@ -12,7 +12,7 @@ if RTC_EMUL
 
 config RTC_EMUL_INIT_DATETIME
 	bool "Initialize emulated RTC time from host wall-clock"
-	depends on NATIVE_LIBC
+	depends on ARCH_POSIX
 	help
 	  Seed the emulated RTC with the host's current wall-clock time.
 

--- a/drivers/rtc/rtc_emul.c
+++ b/drivers/rtc/rtc_emul.c
@@ -11,6 +11,7 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include <time.h>
+#include "rtc_emul_native.h"
 #endif /* CONFIG_RTC_EMUL_INIT_DATETIME */
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
@@ -459,13 +460,14 @@ int rtc_emul_init(const struct device *dev)
 	struct rtc_emul_data *data = (struct rtc_emul_data *)dev->data;
 
 #ifdef CONFIG_RTC_EMUL_INIT_DATETIME
+	int64_t host_sec, host_nsec;
 	struct rtc_time *datetime = &data->datetime;
-	struct timespec host_time;
 	struct tm tm_time;
 
-	if (clock_gettime(CLOCK_REALTIME, &host_time) == 0) {
-		localtime_r(&host_time.tv_sec, &tm_time);
+	if (rtc_emul_native_gettime(&host_sec, &host_nsec) == 0) {
+		time_t sec = host_sec;
 
+		localtime_r(&sec, &tm_time);
 		datetime->tm_sec = tm_time.tm_sec;
 		datetime->tm_min = tm_time.tm_min;
 		datetime->tm_hour = tm_time.tm_hour;
@@ -474,7 +476,7 @@ int rtc_emul_init(const struct device *dev)
 		datetime->tm_year = tm_time.tm_year;
 		datetime->tm_wday = tm_time.tm_wday;
 		datetime->tm_yday = tm_time.tm_yday;
-		datetime->tm_nsec = (int)host_time.tv_nsec;
+		datetime->tm_nsec = (int)host_nsec;
 
 		data->datetime_set = true;
 	} else {

--- a/drivers/rtc/rtc_emul_native.c
+++ b/drivers/rtc/rtc_emul_native.c
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+
+#include <time.h>
+#include <stdint.h>
+
+int rtc_emul_native_gettime(int64_t *sec, int64_t *nsec)
+{
+	struct timespec host_time;
+
+	if (clock_gettime(CLOCK_REALTIME, &host_time) == 0) {
+		*sec = host_time.tv_sec;
+		*nsec = host_time.tv_nsec;
+		return 0;
+	} else {
+		return -1;
+	}
+}

--- a/drivers/rtc/rtc_emul_native.h
+++ b/drivers/rtc/rtc_emul_native.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef DRIVERS_RTC_RTC_EMUL_NATIVE_H
+#define DRIVERS_RTC_RTC_EMUL_NATIVE_H
+
+#include <stdint.h>
+
+int rtc_emul_native_gettime(int64_t *sec, int64_t *nsec);
+
+#endif /* DRIVERS_RTC_RTC_EMUL_NATIVE_H */


### PR DESCRIPTION
There is no need to limit this functionality to when we build the embedded code with the host libC.
It is better to just move the host dependent code into its own file that is built in the runner context.

Follow up on 
* https://github.com/zephyrproject-rtos/zephyr/pull/111701