### PR TITLE
[DRAFT]: AMP remote core API

### DIFF
--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(usb)
 add_subdirectory(usb_c)
 
 add_subdirectory_ifdef(CONFIG_ADC adc)
+add_subdirectory_ifdef(CONFIG_AMP amp)
 add_subdirectory_ifdef(CONFIG_ARM_SIP_SVC_DRIVER sip_svc)
 add_subdirectory_ifdef(CONFIG_AUDIO audio)
 add_subdirectory_ifdef(CONFIG_AUXDISPLAY auxdisplay)

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -7,6 +7,7 @@ menu "Device Drivers"
 
 # zephyr-keep-sorted-start
 source "drivers/adc/Kconfig"
+source "drivers/amp/Kconfig"
 source "drivers/audio/Kconfig"
 source "drivers/audio/mic_privacy/intel/Kconfig.mic_privacy"
 source "drivers/auxdisplay/Kconfig"

--- a/drivers/amp/CMakeLists.txt
+++ b/drivers/amp/CMakeLists.txt
@@ -9,3 +9,8 @@ zephyr_library()
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_USERSPACE amp_handlers.c)
 # zephyr-keep-sorted-stop
+
+# AMP driver implementations
+# zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_AMP_TI_K3 amp_ti_k3.c)
+# zephyr-keep-sorted-stop

--- a/drivers/amp/CMakeLists.txt
+++ b/drivers/amp/CMakeLists.txt
@@ -6,6 +6,12 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/amp.h)
 
 zephyr_library()
 
+# OpenAMP *_ops implementations
+zephyr_library_sources_ifdef(CONFIG_AMP_OPENAMP_OPS_PROVIDE_REMOTEPROC amp_openamp_rproc_ops.c)
+# zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_AMP_OPENAMP_OPS_PROVIDE_STORAGE_OPS_MEMCPY amp_openamp_storage_ops_memcpy.c)
+# zephyr-keep-sorted-stop
+
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_USERSPACE amp_handlers.c)
 # zephyr-keep-sorted-stop

--- a/drivers/amp/CMakeLists.txt
+++ b/drivers/amp/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/amp.h)
+
+zephyr_library()
+
+# zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_USERSPACE amp_handlers.c)
+# zephyr-keep-sorted-stop

--- a/drivers/amp/Kconfig
+++ b/drivers/amp/Kconfig
@@ -29,6 +29,8 @@ config AMP_IDENTIFICATION_INCLUDES_CLUSTER_TYPE
 	bool "AMP core identificaiton includes a cluster type"
 	default n
 
+source "drivers/amp/Kconfig.openamp_ops"
+
 # zephyr-keep-sorted-start
 source "drivers/amp/Kconfig.ti_k3"
 # zephyr-keep-sorted-stop

--- a/drivers/amp/Kconfig
+++ b/drivers/amp/Kconfig
@@ -29,4 +29,8 @@ config AMP_IDENTIFICATION_INCLUDES_CLUSTER_TYPE
 	bool "AMP core identificaiton includes a cluster type"
 	default n
 
+# zephyr-keep-sorted-start
+source "drivers/amp/Kconfig.ti_k3"
+# zephyr-keep-sorted-stop
+
 endif # AMP

--- a/drivers/amp/Kconfig
+++ b/drivers/amp/Kconfig
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# AMP options
+#
+menuconfig AMP
+	bool "Asynchronous Multiprocessing drivers"
+
+if AMP
+
+module = AMP
+module-str = AMP
+source "subsys/logging/Kconfig.template.log_config"
+
+# TODO: Find a good default init priority
+config AMP_INIT_PRIORITY
+	int "AMP init priority"
+	default KERNEL_INIT_PRIORITY_DEFAULT
+	help
+	  AMP driver device initialization priority.
+
+config AMP_IDENTIFICATION_INCLUDES_CLUSTER_NUMBER
+	bool "AMP core identification includes a cluster number"
+	default n
+
+config AMP_IDENTIFICATION_INCLUDES_CLUSTER_TYPE
+	bool "AMP core identificaiton includes a cluster type"
+	default n
+
+endif # AMP

--- a/drivers/amp/Kconfig.openamp_ops
+++ b/drivers/amp/Kconfig.openamp_ops
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# AMP options
+#
+menuconfig AMP_OPENAMP_OPS
+	bool "Provide OpenAMP operations"
+
+if AMP_OPENAMP_OPS
+
+module = AMP_OPENAMP_OPS
+module-str = AMP_OPENAMP_OPS
+source "subsys/logging/Kconfig.template.log_config"
+
+config AMP_OPENAMP_OPS_PROVIDE_REMOTEPROC
+	bool "Provide a OpenAMP remoteproc_ops struct that use the Zephyr API"
+	depends on OPENAMP
+	default n
+
+# All storage_ops are to be used from remoteproc_load which needs remoteproc_ops
+if AMP_OPENAMP_OPS_PROVIDE_REMOTEPROC
+
+config AMP_OPENAMP_OPS_PROVIDE_STORAGE_OPS_LOCK_TIMEOUT
+	int "Maximum amount to wait to acquire the Mutex for global storage option data (ms)"
+	default 1000
+	help
+	  The memory operations require a small amount of global data that is
+	  protected by a mutex. It is acquired in open and released in close. This
+	  options says how long it is allowed to wait to wait to acquire it in open
+	  in milliseconds
+
+config AMP_OPENAMP_OPS_PROVIDE_STORAGE_OPS_MEMCPY
+	bool "Provide a OpenAMP storage_ops struct that uses memcpy for an ELF in addressable memory"
+	default n
+
+endif # AMP_OPENAMP_OPS_PROVIDE_REMOTEPROC
+
+config HEAP_MEM_POOL_ADD_SIZE_AMPO_PENAMP_OPS
+	int "Heap memory pool size for provided OpenAMP operations"
+	default 2048
+	depends on AMP_OPENAMP_OPS_PROVIDE_STORAGE_OPS_MEMCPY
+	help
+	  Used inside of upstream OpenAMP to hold data while parsing ELF files
+
+# zephyr-keep-sorted-start
+source "drivers/amp/Kconfig.ti_k3"
+# zephyr-keep-sorted-stop
+
+endif # AMP

--- a/drivers/amp/Kconfig.ti_k3
+++ b/drivers/amp/Kconfig.ti_k3
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+config AMP_TI_K3
+	bool "TI K3 AMP Driver"
+	default y
+	depends on DT_HAS_TI_AMP_K3_ENABLED
+	depends on TISCI
+	imply POWER_DOMAIN
+	imply PM_DEVICE
+	imply PM_DEVICE_RUNTIME
+	select AMP_IDENTIFICATION_INCLUDES_CLUSTER_NUMBER
+	select AMP_IDENTIFICATION_INCLUDES_CLUSTER_TYPE

--- a/drivers/amp/amp_handlers.c
+++ b/drivers/amp/amp_handlers.c
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// TODO: This needs to be tested
+
+#include <zephyr/drivers/amp.h>
+#include <zephyr/internal/syscall_handler.h>
+
+static inline size_t z_vrfy_amp_get_core_option_size(const struct device *dev,
+			       const struct amp_core_identification *core_identification)
+{
+	K_OOPS(K_SYSCALL_DRIVER_AMP(dev, amp_get_core_option_size));
+
+	struct amp_core_identification core_identification_local;
+	K_OOPS(k_usermode_from_copy(&core_identification_local, core_identification, sizeof(struct amp_core_identification)));
+
+	return z_impl_amp_get_core_option_size(dev, &core_identification_local);
+}
+#include <zephyr/syscalls/amp_get_core_option_size_mrsh.c>
+
+static inline int z_vrfy_amp_prepare_core(const struct device *dev,
+			       const struct amp_core_identification *core_identification,
+			       const void *core_options)
+{
+	K_OOPS(K_SYSCALL_DRIVER_AMP(dev, amp_get_core_option_size));
+
+	struct amp_core_identification core_identification_local;
+	K_OOPS(k_usermode_from_copy(&core_identification_local, core_identification, sizeof(struct amp_core_identification)));
+
+	const size_t core_options_size = z_impl_amp_get_core_option_size(dev, &core_identification_local);
+
+	uint8_t core_options_local[core_options_size];
+
+	K_OOPS(k_usermode_from_copy(&core_options_local, core_options, core_options_size));
+
+	return z_impl_amp_prepare_core(dev, &core_identification_local, core_options_local);
+}
+#include <zephyr/syscalls/amp_prepare_core_mrsh.c>
+
+static inline int z_vrfy_amp_start_core(const struct device *dev,
+			     const struct amp_core_identification *core_identification)
+{
+	K_OOPS(K_SYSCALL_DRIVER_AMP(dev, amp_get_core_option_size));
+
+	struct amp_core_identification core_identification_local;
+	K_OOPS(k_usermode_from_copy(&core_identification_local, core_identification, sizeof(struct amp_core_identification)));
+
+	return z_impl_amp_start_core(dev, &core_identification_local);
+}
+#include <zephyr/syscalls/amp_start_core_mrsh.c>
+
+static inline int z_vrfy_amp_stop_core(const struct device *dev,
+			    const struct amp_core_identification *core_identification)
+{
+	K_OOPS(K_SYSCALL_DRIVER_AMP(dev, amp_get_core_option_size));
+
+	struct amp_core_identification core_identification_local;
+	K_OOPS(k_usermode_from_copy(&core_identification_local, core_identification, sizeof(struct amp_core_identification)));
+
+	return z_impl_amp_stop_core(dev, &core_identification_local);
+}
+#include <zephyr/syscalls/amp_stop_core_mrsh.c>
+
+static inline size_t z_vrfy_amp_get_dt_core_options(const struct device *dev,
+			       const struct amp_core_identification *core_identification)
+{
+	K_OOPS(K_SYSCALL_DRIVER_AMP(dev, amp_get_core_option_size));
+
+	struct amp_core_identification core_identification_local;
+	K_OOPS(k_usermode_from_copy(&core_identification_local, core_identification, sizeof(struct amp_core_identification)));
+
+	return z_impl_amp_get_dt_core_config(dev, &core_identification_local);
+}
+#include <zephyr/syscalls/amp_get_dt_core_options_mrsh.c>
+
+static inline int z_vrfy_amp_get_virtual_address(const struct device *dev,
+				      const struct amp_core_identification *core_identification,
+				      struct amp_memory_mapping *mapping)
+{
+	K_OOPS(K_SYSCALL_DRIVER_AMP(dev, amp_get_core_option_size));
+
+	struct amp_core_identification core_identification_local;
+	K_OOPS(k_usermode_from_copy(&core_identification_local, core_identification, sizeof(struct amp_core_identification)));
+
+	struct amp_memory_mapping mapping_local;
+	K_OOPS(k_usermode_from_copy(&mapping_local, mapping, sizeof(struct amp_memory_mapping)));
+
+	int ret;
+
+	ret = z_impl_amp_get_virtual_address(dev, &core_identification_local, &mapping_local);
+
+	K_OOPS(k_usermode_to_copy(mapping, &mapping_local, sizeof(struct amp_memory_mapping)));
+
+	return ret;
+}
+#include <zephyr/syscalls/amp_get_virtual_address_mrsh.c>

--- a/drivers/amp/amp_openamp_rproc_ops.c
+++ b/drivers/amp/amp_openamp_rproc_ops.c
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/drivers/amp/amp_openamp_ops_rproc.h>
+
+struct remoteproc *zephyr_openamp_init(struct remoteproc *rproc,
+					const struct remoteproc_ops *ops, void *arg)
+{
+	rproc->priv = arg;
+	return rproc;
+}
+
+int zephyr_openamp_config(struct remoteproc *rproc, void *data)
+{
+	const struct amp_full_identification *full_id = rproc->priv;
+	return amp_prepare_core(full_id->dev, &full_id->core_id, data);
+}
+
+int zephyr_openamp_start(struct remoteproc *rproc)
+{
+	const struct amp_full_identification *full_id = rproc->priv;
+	return amp_start_core(full_id->dev, &full_id->core_id);
+}
+
+int zephyr_openamp_stop(struct remoteproc *rproc)
+{
+	const struct amp_full_identification *full_id = rproc->priv;
+	return amp_stop_core(full_id->dev, &full_id->core_id);
+}

--- a/drivers/amp/amp_openamp_storage_ops_memcpy.c
+++ b/drivers/amp/amp_openamp_storage_ops_memcpy.c
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/drivers/amp/amp_openamp_ops_storage.h>
+
+#include <zephyr/arch/cache.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(amp_openamp_memcpy_mapping, CONFIG_AMP_OPENAMP_OPS_LOG_LEVEL);
+
+static K_MUTEX_DEFINE(loading_mutex);
+static struct metal_io_region io_region;
+static metal_phys_addr_t phys_base_address;
+
+/*
+ * Emulate get_mem so the address where a section needs to be loaded is provided
+ * as "virtual" address from the own processor view.
+ * This assumes a flat memory map as of now.
+ */
+struct remoteproc_mem *zephyr_openamp_get_mem(struct remoteproc *rproc, const char *name,
+						     metal_phys_addr_t pa, metal_phys_addr_t da,
+						     void *va, size_t size,
+						     struct remoteproc_mem *buf)
+{
+	const struct amp_full_identification *full_id = rproc->priv;
+	struct amp_memory_mapping map = {
+		.target_device_address = da,
+		.target_area_size = size,
+	};
+
+	int ret = amp_get_virtual_address(full_id->dev, &full_id->core_id, &map);
+	if (ret < 0) {
+		LOG_ERR("Error getting device address mapping");
+		return NULL;
+	}
+
+	metal_io_init(&io_region, (void*) map.own_virtual_address_start, &phys_base_address, map.mapped_region_size, -1, 0, NULL);
+	phys_base_address = map.target_device_area_start;
+
+	buf->pa = map.target_device_address;
+	buf->da = map.target_device_address;
+
+	buf->size = map.mapped_region_size;
+
+	buf->io = &io_region;
+
+	return buf;
+}
+
+int zephyr_openamp_load_memcpy_open(void *store, const char *path, const void **img_data) {
+	struct amp_memcpy_options *options = store;
+	int ret;
+
+	LOG_DBG("Storage open called");
+
+	ret = k_mutex_lock(&loading_mutex, K_MSEC(CONFIG_AMP_OPENAMP_OPS_PROVIDE_STORAGE_OPS_LOCK_TIMEOUT));
+	if (ret < 0) {
+		LOG_ERR("Timeout while waiting for OpenAMP memcpy mutex %d", ret);
+		return NULL;
+	}
+	*img_data = (void*) options->start_address;
+	return options->image_size;
+}
+
+void zephyr_openamp_load_memcpy_close(void *store) {
+	LOG_DBG("Storage close called");
+	int ret = k_mutex_unlock(&loading_mutex);
+	if (ret < 0) {
+		LOG_ERR("Error unlocking OpenAMP memcpy mutex %d", ret);
+	}
+}
+
+int zephyr_openamp_load_memcpy_load(void *store, size_t offset, size_t size,
+		const void **data,
+		metal_phys_addr_t pa,
+		struct metal_io_region *io, char is_blocking)
+{
+	struct amp_memcpy_options *options = store;
+
+	LOG_DBG("Storage load called");
+
+	uintptr_t in_elf_start = options->start_address + offset;
+
+	if (pa == METAL_BAD_PHYS) {
+		*data = (void*) in_elf_start;
+	} else {
+		void *dest = metal_io_phys_to_virt(io, pa);
+		LOG_DBG("Doing memcpy to %p from %p with size 0x%zx", dest, (void*) in_elf_start, size);
+		memcpy(dest, (void*) in_elf_start, size);
+		sys_cache_data_flush_range(dest, size);
+	}
+	return (int)size;
+}

--- a/drivers/amp/amp_ti_k3.c
+++ b/drivers/amp/amp_ti_k3.c
@@ -1,0 +1,328 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "zephyr/dt-bindings/amp/ti-k3-amp.h"
+#define DT_DRV_COMPAT ti_amp_k3
+
+#include <zephyr/drivers/amp.h>
+#include <zephyr/drivers/amp/amp_ti_k3.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/drivers/firmware/tisci/tisci.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util.h>
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(amp_ti_k3, LOG_LEVEL_INF);
+
+// TODO: Get from DT or Kconfig
+#define NUM_CORTEX_R_CLUSTERS 2
+#define NUM_CORTEX_M_CLUSTERS 1
+
+#define NUM_CORTEX_R_CORES_PER_CLUSTER 2
+#define NUM_CORTEX_M_CORES_PER_CLUSTER 1
+
+// TODO: Size is depending on the core config!
+#define CORTEX_R_ATCM_START_ADDRESS 0x0
+#define CORTEX_R_ATCM_SIZE          KB(32)
+#define CORTEX_R_BTCM_START_ADDRESS 0x41010000
+#define CORTEX_R_BTCM_SIZE          KB(32)
+
+// TODO: This is mostly belonging in the config and *not* the data
+struct amp_ti_k3_generic_core_config {
+	const uint8_t tisci_core_id;
+	const struct device *power_domain;
+	const bool is_allowed_to_change; // status = "okay" check; not used *yet*
+};
+
+struct amp_ti_k3_cortex_r_core {
+	struct amp_ti_k3_generic_core_config generic;
+	// TODO: Indicate, if core got flags from devicetree
+	struct amp_ti_k3_boot_options dt_core_options;
+	const uintptr_t atcm_external_address;
+	const uintptr_t btcm_external_address;
+};
+
+struct amp_ti_k3_cortex_r_cluster {
+	struct amp_ti_k3_cortex_r_core cores[NUM_CORTEX_R_CORES_PER_CLUSTER];
+};
+
+// NOTE: The Cortex-M isn't implemented yet
+struct amp_ti_k3_cortex_m_core {
+	struct amp_ti_k3_generic_core_config generic;
+	const uintptr_t iram_external_address; /* This is 0x00000..0x30000 (internal) @ 0x5000000
+						  (external) */
+	const uintptr_t dram_external_address; /* This is 0x30000..0x40000 (internal) @ 0x5040000
+						  (external) */
+};
+
+struct amp_ti_k3_cortex_m_cluster {
+	struct amp_ti_k3_cortex_m_core cores[NUM_CORTEX_M_CORES_PER_CLUSTER];
+};
+
+struct amp_ti_k3_config {
+	DEVICE_MMIO_ROM;
+	const struct device *dmsc;
+};
+
+struct amp_ti_k3_data {
+	DEVICE_MMIO_RAM;
+	struct amp_ti_k3_cortex_r_cluster cortex_r_clusters[NUM_CORTEX_R_CLUSTERS];
+	struct amp_ti_k3_cortex_m_cluster cortex_m_clusters[NUM_CORTEX_M_CLUSTERS];
+};
+
+static int amp_ti_k3_init(const struct device *dev)
+{
+	// TODO: Get state of all cores (unsure for now)
+
+	// Power Management + Reset state (Maybe also not?)
+
+	return 0;
+}
+
+void *amp_ti_k3_get_core_data(const struct device *root_device,
+			      const struct amp_core_identification *core_identification)
+{
+	struct amp_ti_k3_data *data = root_device->data;
+	switch (core_identification->cluster_type) {
+	case AMP_TI_K3_CLUSTER_TYPE_CORTEX_R:
+		if (core_identification->cluster_id >= NUM_CORTEX_R_CLUSTERS || core_identification->core_id >= NUM_CORTEX_R_CORES_PER_CLUSTER) {
+			return NULL;;
+		}
+		return &data->cortex_r_clusters[core_identification->cluster_id]
+				.cores[core_identification->core_id];
+	case AMP_TI_K3_CLUSTER_TYPE_CORTEX_M:
+		if (core_identification->cluster_id >= NUM_CORTEX_M_CLUSTERS || core_identification->core_id >= NUM_CORTEX_M_CORES_PER_CLUSTER) {
+			return NULL;;
+		}
+		return &data->cortex_m_clusters[core_identification->cluster_id]
+				.cores[core_identification->core_id];
+	}
+	__ASSERT(false, "Asked for a Cluster type that doesn't exist");
+	return NULL;
+}
+
+static int amp_ti_k3_prepare_core(const struct device *root_device,
+				  const struct amp_core_identification *core_identification,
+				  const void *core_options)
+{
+	const struct amp_ti_k3_config *cfg = root_device->config;
+	uint8_t tisci_core_id = 0;
+	int ret;
+	if (core_identification->cluster_type == AMP_TI_K3_CLUSTER_TYPE_CORTEX_R) {
+		struct amp_ti_k3_cortex_r_core *core =
+			amp_ti_k3_get_core_data(root_device, core_identification);
+		tisci_core_id = core->generic.tisci_core_id;
+
+		ret = tisci_cmd_proc_request(cfg->dmsc, tisci_core_id);
+		if (ret < 0) {
+			LOG_ERR("Error while requesting processor control: %d", ret);
+			goto err;
+		}
+
+		const struct amp_ti_k3_boot_options *boot_options = core_options;
+		uint32_t set_xor_clear = boot_options->config_flags_set ^ boot_options->config_flags_clear;
+		if (set_xor_clear != CORTEX_R_ALL_BITS) {
+			uint32_t bitdiff = set_xor_clear ^ CORTEX_R_ALL_BITS;
+			LOG_ERR("Cortex-R had some config options specified neither in set or clear. Missing bits: 0x%08llX", (unsigned long long) bitdiff);
+			ret = -EINVAL;
+			goto err;
+		}
+
+		ret = tisci_cmd_set_proc_boot_cfg(cfg->dmsc, tisci_core_id, boot_options->boot_vec,
+						  boot_options->config_flags_set,
+						  boot_options->config_flags_clear);
+		if (ret < 0) {
+			LOG_ERR("Error setting processor boot config: %d", ret);
+			goto err;
+		}
+
+		/* Assert reset */
+		ret = tisci_cmd_set_proc_boot_ctrl(cfg->dmsc, tisci_core_id, BIT(0), 0);
+		if (ret < 0) {
+			LOG_ERR("Error asserting reset signal on processor: %d", ret);
+			goto err;
+		}
+
+		ret = pm_device_runtime_get(core->generic.power_domain);
+		if (ret < 0) {
+			LOG_ERR("Error enabling core power domain: %d", ret);
+			goto err;
+		}
+	} else {
+		// TODO: Cortex-M and Cortex-A
+	}
+
+	return 0;
+
+err:
+	if (tisci_cmd_proc_release(cfg->dmsc, tisci_core_id) < 0) {
+		LOG_ERR("Error releasing processor after previous error: %d", ret);
+	}
+	return ret;
+}
+
+static int amp_ti_k3_start_core(const struct device *root_device,
+				const struct amp_core_identification *core_identification)
+{
+	const struct amp_ti_k3_config *cfg = root_device->config;
+	uint8_t tisci_core_id = 0;
+	int ret = 0;
+	if (core_identification->cluster_type == AMP_TI_K3_CLUSTER_TYPE_CORTEX_R) {
+		struct amp_ti_k3_cortex_r_core *core =
+			amp_ti_k3_get_core_data(root_device, core_identification);
+		tisci_core_id = core->generic.tisci_core_id;
+
+		// Deassert reset
+		ret = tisci_cmd_set_proc_boot_ctrl(cfg->dmsc, tisci_core_id, 0, BIT(0));
+		if (ret < 0) {
+			LOG_ERR("Error deasserting reset signal: %d", ret);
+			goto exit;
+		}
+	} else {
+		// TODO: Cortex-M
+	}
+
+exit:
+	if (tisci_cmd_proc_release(cfg->dmsc, tisci_core_id) < 0) {
+		LOG_ERR("Error releasing processor control: %d", ret);
+	}
+	return ret;
+}
+
+static int amp_ti_k3_stop_core(const struct device *root_device,
+			       const struct amp_core_identification *core_identification)
+{
+	int ret = 0;
+	if (core_identification->cluster_type == AMP_TI_K3_CLUSTER_TYPE_CORTEX_R) {
+		struct amp_ti_k3_cortex_r_core *core =
+			amp_ti_k3_get_core_data(root_device, core_identification);
+
+		// TODO: Track if the core is actually having a clock signal to avoid
+		// removing the clock signal twice
+		ret = pm_device_runtime_put(core->generic.power_domain);
+		if (ret < 0) {
+			LOG_ERR("Error removing power from processor core: %d", ret);
+		}
+	}
+	return ret;
+}
+
+static void *amp_ti_k3_get_dt_core_config(const struct device *root_device,
+					  const struct amp_core_identification *core_identification)
+{
+	/* This cast works since the generic options are the first element */
+	if (core_identification->cluster_type == AMP_TI_K3_CLUSTER_TYPE_CORTEX_R) {
+		struct amp_ti_k3_cortex_r_core *core =
+			amp_ti_k3_get_core_data(root_device, core_identification);
+		return &core->dt_core_options;
+	}
+	return NULL;
+}
+
+static int amp_ti_k3_get_virtual_address(const struct device *root_device,
+					 const struct amp_core_identification *core_identification,
+					 struct amp_memory_mapping *mapping)
+{
+	// TODO: xTCM size check based on dualcore check
+	// TODO: Length checks
+	// TODO: Get whether ATCM or BTCM is considered at 0x0 via devicetree option
+	// or previous core startup
+	if (core_identification->cluster_type == AMP_TI_K3_CLUSTER_TYPE_CORTEX_R) {
+		struct amp_ti_k3_cortex_r_core *core =
+			amp_ti_k3_get_core_data(root_device, core_identification);
+		if (IN_RANGE(mapping->target_device_address, CORTEX_R_ATCM_START_ADDRESS,
+			     CORTEX_R_ATCM_START_ADDRESS + CORTEX_R_ATCM_SIZE)) {
+			mapping->own_virtual_address_start = core->atcm_external_address;
+			mapping->mapped_region_size = CORTEX_R_ATCM_SIZE;
+			mapping->target_device_area_start = CORTEX_R_ATCM_START_ADDRESS;
+			return 0;
+		}
+
+		if (IN_RANGE(mapping->target_device_address, CORTEX_R_BTCM_START_ADDRESS,
+			     CORTEX_R_BTCM_START_ADDRESS + CORTEX_R_BTCM_SIZE)) {
+			mapping->own_virtual_address_start = core->btcm_external_address;
+			mapping->mapped_region_size = CORTEX_R_BTCM_SIZE;
+			mapping->target_device_area_start = CORTEX_R_BTCM_START_ADDRESS;
+			return 0;
+		}
+		// TODO: Get from DT; this should be a generic node
+		if (IN_RANGE(mapping->target_device_address, 0x70000000, 0x70000000 + MB(2))) {
+			mapping->own_virtual_address_start = 0x70000000;
+			mapping->target_device_area_start = 0x70000000;
+			mapping->mapped_region_size = MB(2);
+		}
+		return 0;
+	}
+
+	LOG_ERR("Tried to request invalid mapping for address %" PRIuPTR " with size %zx",
+		mapping->target_device_address, mapping->target_area_size);
+
+	return -EINVAL;
+}
+
+static DEVICE_API(amp, amp_ti_k3_driver_api) = {
+	.amp_prepare_core = amp_ti_k3_prepare_core,
+	.amp_start_core = amp_ti_k3_start_core,
+	.amp_stop_core = amp_ti_k3_stop_core,
+	.amp_get_dt_core_config = amp_ti_k3_get_dt_core_config,
+	.amp_get_virtual_address = amp_ti_k3_get_virtual_address,
+};
+
+/* Generic field that every core type has; node_id = core */
+#define AMP_TI_K3_GENERIC_CORE_OPTIONS(node_id)                                                    \
+	{                                                                                          \
+		.is_allowed_to_change = DT_NODE_HAS_STATUS_OKAY(node_id),                          \
+		.power_domain = DEVICE_DT_GET(DT_PHANDLE(node_id, power_domains)),                 \
+		.tisci_core_id = DT_PROP(node_id, ti_tisci_core_id),                               \
+	}
+
+/* Single Cortex-R core; node_id = core */
+/* No trailing comma at the end due to the necesssity of DT_FOREACH_CHILD_SEP mixing! */
+#define AMP_TI_K3_CORTEX_R_CORE_OPTIONS(node_id)                                                   \
+	[DT_REG_ADDR(node_id)] = {                                                                 \
+		.atcm_external_address = DT_PROP(node_id, atcm_address),                           \
+		.btcm_external_address = DT_PROP(node_id, btcm_address),                           \
+		.generic = AMP_TI_K3_GENERIC_CORE_OPTIONS(node_id),                                \
+		.dt_core_options = {                                                               \
+			.config_flags_set = DT_PROP_OR(node_id, config_set_flags, 0),              \
+			.config_flags_clear = DT_PROP_OR(node_id, config_clear_flags, 0),          \
+			.boot_vec = DT_PROP_OR(node_id, boot_vec, 0),                       \
+		},                                                                                 \
+	}
+
+/* Full Cortex-R cluster; node_id = cluster */
+#define AMP_TI_K3_CORTEX_R_SINGLE_CLUSTER(node_id)                                                 \
+	[DT_REG_ADDR(node_id)] = {                                                                 \
+		.cores = {DT_FOREACH_CHILD_SEP(node_id, AMP_TI_K3_CORTEX_R_CORE_OPTIONS, (, ))}},
+
+/*
+ * It's necessary to use DT_FOREACH_CHILD_SEP and DT_FOREACH_CHILD (without _SEP)
+ * since for some reason using the same inside themself leads to compiler errors
+ */
+
+/* All Cortex-R clusters; node_id = cortex_r_clusters */
+#define AMP_TI_K3_CORTEX_R_CLUSTERS(node_id)                                                       \
+	{DT_FOREACH_CHILD(node_id, AMP_TI_K3_CORTEX_R_SINGLE_CLUSTER)}
+
+#define AMP_TI_K3_INIT(n)                                                                          \
+	static const struct amp_ti_k3_config amp_ti_k3_##n##_config = {                            \
+		.dmsc = DEVICE_DT_GET(DT_PHANDLE(DT_DRV_INST(n), dmsc)),                           \
+	};                                                                                         \
+                                                                                                   \
+	static struct amp_ti_k3_data amp_ti_k3_##n##_data = {                                      \
+		.cortex_r_clusters =                                                               \
+			AMP_TI_K3_CORTEX_R_CLUSTERS(DT_CHILD(DT_DRV_INST(n), r5f_clusters_0)),     \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, amp_ti_k3_init, NULL, &amp_ti_k3_##n##_data,                      \
+			      &amp_ti_k3_##n##_config, PRE_KERNEL_2, CONFIG_AMP_INIT_PRIORITY,     \
+			      &amp_ti_k3_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(AMP_TI_K3_INIT)

--- a/dts/arm/ti/am64x_r5f0_0.dtsi
+++ b/dts/arm/ti/am64x_r5f0_0.dtsi
@@ -27,3 +27,7 @@
 		     <0 65 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
 	interrupt-parent = <&vim>;
 };
+
+&r5fss_0_0 {
+	self-cpu;
+};

--- a/dts/arm/ti/am64x_r5f0_1.dtsi
+++ b/dts/arm/ti/am64x_r5f0_1.dtsi
@@ -27,3 +27,7 @@
 		     <0 67 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
 	interrupt-parent = <&vim>;
 };
+
+&r5fss_0_1 {
+	self-cpu;
+};

--- a/dts/arm/ti/am64x_r5f1_0.dtsi
+++ b/dts/arm/ti/am64x_r5f1_0.dtsi
@@ -27,3 +27,7 @@
 		     <0 65 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
 	interrupt-parent = <&vim>;
 };
+
+&r5fss_1_0 {
+	self-cpu;
+};

--- a/dts/arm/ti/am64x_r5f1_1.dtsi
+++ b/dts/arm/ti/am64x_r5f1_1.dtsi
@@ -27,3 +27,7 @@
 		     <0 67 IRQ_TYPE_EDGE IRQ_DEFAULT_PRIORITY>;
 	interrupt-parent = <&vim>;
 };
+
+&r5fss_1_1 {
+	self-cpu;
+};

--- a/dts/bindings/amp/amp-cluster-group.yaml
+++ b/dts/bindings/amp/amp-cluster-group.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+title: Generic cluster group
+
+description: |
+  An optional node to put multiple clusters of the same type in, e.g. all
+  Cortex-R clusters, if there are also Cortex-M clusters. In such cases the reg
+  property of this node needs to match the SoC specific enum that identifies the
+  cluster type for the struct core_identification
+
+compatible: "amp-cluster-group"
+
+include: base.yaml

--- a/dts/bindings/amp/amp-cluster-instance.yaml
+++ b/dts/bindings/amp/amp-cluster-instance.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+title: Generic AMP cluster instance
+
+description: |
+  A cluster consistent of one or multiple CPU cores, e.g. two Cortex-R cores. A
+  cluster can have a single core, if there are multiple cluster types inside the
+  SoC.
+
+compatible: "amp-cluster-instance"
+
+include: base.yaml

--- a/dts/bindings/amp/amp-core.yaml
+++ b/dts/bindings/amp/amp-core.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+title: Generic CPU core
+
+description: |
+  A single CPU core
+
+include: base.yaml
+
+properties:
+  self-cpu:
+    type: boolean
+    required: false
+    description: |
+      Set this, if this is the core the currently built Zephyr firmware will run
+      on. As of now this doesn't do anything.
+
+  stop-on-init:
+    type: boolean
+    description: |
+      Add this property in case the driver should ensure the core is powered off
+      during startup.

--- a/dts/bindings/amp/ti,amp-k3-cortex-m-core.yaml
+++ b/dts/bindings/amp/ti,amp-k3-cortex-m-core.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+description: Texas Instruments Keystone 3 Cortex-M core
+
+compatible: "ti,amp-k3-cortex-m-core"
+
+include: ti,amp-k3-tisci-controlled-core.yaml
+
+properties:
+  ti,tisci-core-id:
+    type: int
+    required: true
+    description: |
+      Core ID according to the TISCI documentation (see the "Processor
+      Descriptions" for your SoC under
+      https://software-dl.ti.com/tisci/esd/latest/5_soc_doc/index.html)

--- a/dts/bindings/amp/ti,amp-k3-cortex-r-core.yaml
+++ b/dts/bindings/amp/ti,amp-k3-cortex-r-core.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+description: Texas Instruments Keystone 3 Cortex-R core
+
+compatible: "ti,amp-k3-cortex-r-core"
+
+include: ti,amp-k3-tisci-controlled-core.yaml
+
+properties:
+  atcm-address:
+    type: int
+    required: true
+    description: |
+      External address of the ATCM interface so other cores can load into the ATCM memory
+
+  btcm-address:
+    type: int
+    required: true
+    description: |
+      External address of the BTCM interface so other cores can load into the ATCM memory
+
+  config-set-flags:
+    type: int
+    required: false
+    description: |
+      Config flags that should be set. When combined with config_clear_flags
+      must contain all possible flags for the target core
+
+  config-clear-flags:
+    type: int
+    required: false
+    description: |
+      Config flags that should be set. When combined with config_set_flags
+      must contain all possible flags for the target core
+
+  boot-vec:
+    type: int
+    required: false
+    description: |
+      Boot address where the core starts to boot. Can be omitted and will default to 0.

--- a/dts/bindings/amp/ti,amp-k3-tisci-controlled-core.yaml
+++ b/dts/bindings/amp/ti,amp-k3-tisci-controlled-core.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+description: Texas Instruments Keystone 3 core controlled by TISCI
+
+include: amp-core.yaml
+
+properties:
+  ti,tisci-core-id:
+    type: int
+    required: true
+    description: |
+      Core ID according to the TISCI documentation (see the "Processor
+      Descriptions" for your SoC under
+      https://software-dl.ti.com/tisci/esd/latest/5_soc_doc/index.html)

--- a/dts/bindings/amp/ti,amp-k3.yaml
+++ b/dts/bindings/amp/ti,amp-k3.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+description: Texas Instruments Keystone 3 AMP root node
+
+compatible: "ti,amp-k3"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: false
+
+  dmsc:
+    type: phandle
+    required: true
+    description: Phandle to the device DMSC-L node

--- a/dts/vendor/ti/am64x_main.dtsi
+++ b/dts/vendor/ti/am64x_main.dtsi
@@ -28,6 +28,105 @@
 		status = "disabled";
 	};
 
+	amp: amp-controller {
+		compatible = "ti,amp-k3";
+		dmsc = <&dmsc>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		r5f_clusters: r5f-clusters@0 {
+			compatible = "amp-cluster-group";
+			reg = <0x0>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			r5fss@0 {
+				compatible = "amp-cluster-instance";
+				reg = <0x0>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				r5fss_0_0: cpu@0 {
+					compatible = "ti,amp-k3-cortex-r-core";
+					reg = <0x0>;
+					ti,tisci-core-id = <0x01>;
+					power-domains = <&r5fss0_core0_pd>;
+					atcm-address = <0x78000000>;
+					btcm-address = <0x78100000>;
+					self-cpu;
+					status = "disabled";
+				};
+
+				r5fss_0_1: cpu@1 {
+					compatible = "ti,amp-k3-cortex-r-core";
+					reg = <0x1>;
+					ti,tisci-core-id = <0x02>;
+					power-domains = <&r5fss0_core1_pd>;
+					atcm-address = <0x78200000>;
+					btcm-address = <0x78300000>;
+					status = "disabled";
+				};
+			};
+
+			r5fss@1 {
+				compatible = "amp-cluster-instance";
+				reg = <0x1>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+
+				r5fss_1_0: cpu@0 {
+					compatible = "ti,amp-k3-cortex-r-core";
+					reg = <0x0>;
+					ti,tisci-core-id = <0x06>;
+					power-domains = <&r5fss1_core0_pd>;
+					atcm-address = <0x78400000>;
+					btcm-address = <0x78500000>;
+					status = "disabled";
+				};
+
+				r5fss_1_1: cpu@1 {
+					compatible = "ti,amp-k3-cortex-r-core";
+					reg = <0x1>;
+					ti,tisci-core-id = <0x07>;
+					power-domains = <&r5fss1_core1_pd>;
+					atcm-address = <0x78600000>;
+					btcm-address = <0x78700000>;
+					status = "disabled";
+				};
+			};
+		};
+
+		m4f_clusters: m4f-clusters@1 {
+			compatible = "amp-cluster-group";
+			reg = <0x1>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			m4fss@0 {
+				compatible = "amp-cluster-instance";
+				reg = <0x0>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				/* TODO: Actual name */
+				m4fss_0: cpu@0 {
+					reg = <0x0>;
+					compatible = "ti,amp-k3-cortex-m-core";
+					ti,tisci-core-id = <0x18>;
+					power-domains = <&mcu_m4fss0_pd>;
+					status = "disabled";
+				};
+			};
+		};
+	};
+
+
 	main_padcfg0: syscon@f0000 {
 		compatible = "ti,control-module";
 		reg = <0xf0000 DT_SIZE_K(32)>;

--- a/include/zephyr/drivers/amp.h
+++ b/include/zephyr/drivers/amp.h
@@ -1,0 +1,297 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for the Asynchronous Multiprocessing (AMP) driver API
+ * @ingroup amp_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_AMP_H_
+#define ZEPHYR_INCLUDE_DRIVERS_AMP_H_
+
+#include <sys/types.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/toolchain.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief
+ * @defgroup amp_interface AMP
+ * @version 0.0.1
+ * @{
+ */
+
+/** @brief Core identification */
+struct amp_core_identification {
+#if defined(CONFIG_AMP_IDENTIFICATION_INCLUDES_CLUSTER_TYPE) || defined(__DOXYGEN__)
+	const uint32_t cluster_type; /**< Cluster type */
+#endif
+#if defined(CONFIG_AMP_IDENTIFICATION_INCLUDES_CLUSTER_NUMBER) || defined(__DOXYGEN__)
+	const uint32_t cluster_id; /**< Cluster number */
+#endif
+	const uint32_t core_id; /**< Core number */
+};
+
+
+/**
+ * @brief Get amp_core_identification from a node_id
+ *
+ * TODO: Use Kconfig (or something similar) to check whether the cluster_type /
+ * cluster_id needs to be set!
+ */
+#define AMP_DT_GET_CORE_IDENTIFICATION(node_id)			       \
+	{\
+		.core_id = DT_REG_ADDR(node_id),\
+		.cluster_id = DT_REG_ADDR(DT_PARENT(node_id)),\
+		.cluster_type = DT_REG_ADDR(DT_PARENT(DT_PARENT(node_id))),\
+	}
+
+/**
+ * @brief Get memory mapping to load data into other cores memory
+ */
+struct amp_memory_mapping {
+	/** Device address from the perspective of the target core */
+	const uintptr_t target_device_address;
+
+	/** Size of the data that should be written */
+	const size_t target_area_size;
+
+	/** Start of the memory region from the own virtual memory view */
+	uintptr_t own_virtual_address_start;
+
+	/** Start of the memory region on the view from the target code */
+	uintptr_t target_device_area_start;
+
+	/** Size of the mapped region */
+	size_t mapped_region_size;
+};
+
+/**
+ * @cond INTERNAL_HIDDEN
+ *
+ * Internal typedefs for readability and the subsystem that shouldn't appear in
+ * the documentation
+ */
+typedef ssize_t (*amp_get_core_option_size_t)(const struct device *dev,
+			       const struct amp_core_identification *core_identification);
+typedef int (*amp_prepare_core_t)(const struct device *dev,
+				  const struct amp_core_identification *core_identification,
+				  const void *core_options);
+typedef int (*amp_start_core_t)(const struct device *dev,
+				const struct amp_core_identification *core_identification);
+typedef int (*amp_stop_core_t)(const struct device *dev,
+			       const struct amp_core_identification *core_identification);
+
+typedef int (*amp_get_virtual_address_t)(const struct device *dev,
+					 const struct amp_core_identification *core_identification,
+					 struct amp_memory_mapping *mapping);
+
+typedef void *(*amp_get_dt_core_config_t)(const struct device *dev,
+					 const struct amp_core_identification *core_identification);
+
+__subsystem struct amp_driver_api {
+	amp_get_core_option_size_t amp_get_core_option_size;
+	amp_prepare_core_t amp_prepare_core;
+	amp_start_core_t amp_start_core;
+	amp_stop_core_t amp_stop_core;
+	amp_get_dt_core_config_t amp_get_dt_core_config;
+
+	amp_get_virtual_address_t amp_get_virtual_address;
+};
+
+/** @endcond */
+
+/**
+ * @brief Get the size of core_options parameter used in amp_prepare_core.
+ *
+ * Get the required size in bytes for the core_options for a given core so a
+ * copy from userspace can be done in the syscall helper, if necessary, to avoid
+ * TOCTOU vulnerabilities. The size should be limited since the data will be
+ * stored on the stack.
+ *
+ * @param dev Root device node for AMP
+ * @param core_identification Core for which the option size should be returned
+ *
+ * @retval number of bytes in size or 0, if not used
+ */
+__syscall ssize_t amp_get_core_option_size(const struct device *dev,
+			       const struct amp_core_identification *core_identification);
+
+static inline ssize_t z_impl_amp_get_core_option_size(const struct device *dev,
+					  const struct amp_core_identification *core_identification)
+{
+	const struct amp_driver_api *api = (const struct amp_driver_api *)dev->api;
+	if (api->amp_get_core_option_size) {
+		return api->amp_get_core_option_size(dev, core_identification);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Configure a core and make memory loadable
+ *
+ * This applies configuration to a core (or saves it in the driver, if it is
+ * needed later) and puts there core into a state where it doesn't execute code
+ * but it's possible to load data into core specific memory (usually TCM).
+ *
+ * @param dev Root device node for AMP
+ * @param core_identification Core which should be configured and made loadable
+ * @param core_options Driver and Core specific options for the core
+ *
+ * @retval 0 if successful (or not needed)
+ * @retval -ENODEV core_identification refers to a core that doesn't exist (or is disabled)
+ * @retval -EINVAL invalid core_options configuration
+ * @retval -EIO generic error while trying to configure other core
+ */
+__syscall int amp_prepare_core(const struct device *dev,
+			       const struct amp_core_identification *core_identification,
+			       const void *core_options);
+
+static inline int z_impl_amp_prepare_core(const struct device *dev,
+					  const struct amp_core_identification *core_identification,
+					  const void *core_options)
+{
+	const struct amp_driver_api *api = (const struct amp_driver_api *)dev->api;
+
+	if (api->amp_prepare_core) {
+		return api->amp_prepare_core(dev, core_identification, core_options);
+	}
+
+	/*
+	 * Some cores might not need preperation (they have no configuration options
+	 * and are always loadable). For these no -ENOSYS should be returned due to
+	 * not implementing it but instead show that there were no errors
+	 */
+	return 0;
+}
+
+/**
+ * @brief Start executing code on another core
+ *
+ * Start executing code on a core that is configured and has code loaded
+ *
+ * @param dev Root device node for AMP
+ * @param core_identification Core which should start executing code
+ *
+ * @retval 0 if successful (or not needed)
+ * @retval -ENODEV core_identification refers to a core that doesn't exist (or is disabled)
+ * @retval -EIO generic error while trying to start the core
+ */
+__syscall int amp_start_core(const struct device *dev,
+			     const struct amp_core_identification *core_identification);
+
+static inline int z_impl_amp_start_core(const struct device *dev,
+					const struct amp_core_identification *core_identification)
+{
+	const struct amp_driver_api *api = (const struct amp_driver_api *)dev->api;
+
+	if (api->amp_start_core) {
+		return api->amp_start_core(dev, core_identification);
+	}
+
+	return -ENOSYS;
+}
+
+/**
+ * @brief Stop executing code on another core
+ *
+ * @param dev Root device node for AMP
+ * @param core_identification Core which should start executing code
+ *
+ * @retval 0 if successful (or not needed)
+ * @retval -ENODEV core_identification refers to a core that doesn't exist (or is disabled)
+ * @retval -EIO generic error while trying to stop the core
+ */
+__syscall int amp_stop_core(const struct device *dev,
+			    const struct amp_core_identification *core_identification);
+
+static inline int z_impl_amp_stop_core(const struct device *dev,
+				       const struct amp_core_identification *core_identification)
+{
+	const struct amp_driver_api *api = (const struct amp_driver_api *)dev->api;
+
+	if (api->amp_stop_core) {
+		return api->amp_stop_core(dev, core_identification);
+	}
+
+	return -ENOSYS;
+}
+
+/**
+ * @brief Get the core_options specified in the devicetree for a given core
+ *
+ * Get the core_options specified in the devicetree for a given CPU node to be
+ * used in core_start.
+ *
+ * @param dev Root device node for AMP
+ * @param core_identification Core for which the options should be returned
+ *
+ * @retval Pointer ot the core options or NULL
+ */
+__syscall void *amp_get_dt_core_config(const struct device *dev,
+			       const struct amp_core_identification *core_identification);
+
+static inline void *z_impl_amp_get_dt_core_config(const struct device *dev,
+					  const struct amp_core_identification *core_identification)
+{
+	const struct amp_driver_api *api = (const struct amp_driver_api *)dev->api;
+	if (api->amp_get_dt_core_config) {
+		return api->amp_get_dt_core_config(dev, core_identification);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get virtual address mapping
+ *
+ * @param dev Root device node for AMP
+ * @param core_identification Core which should start executing code
+ * @param[in,out] mapping memory mapping. Refer to amp_memory_mapping for more info
+ *
+ * @see amp_memory_mapping
+ *
+ * @retval 0 if successful (or not needed)
+ * @retval -ENODEV core_identification refers to a core that doesn't exist (or is disabled)
+ * @retval -EFAULT requested area is not mappable
+ *
+ * TODO: It would probably be useful to have more/other return codes
+ */
+__syscall int amp_get_virtual_address(const struct device *dev,
+				      const struct amp_core_identification *core_identification,
+				      struct amp_memory_mapping *mapping);
+
+static inline int
+z_impl_amp_get_virtual_address(const struct device *dev,
+			       const struct amp_core_identification *core_identification,
+			       struct amp_memory_mapping *mapping)
+{
+	const struct amp_driver_api *api = (const struct amp_driver_api *)dev->api;
+
+	/*
+	 * TODO: Handle fully linear memory so that no implementation is needed for
+	 * those SoCs
+	 */
+	const int ret = api->amp_get_virtual_address(dev, core_identification, mapping);
+
+	return ret;
+}
+
+#include <zephyr/syscalls/amp.h>
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_AMP_H_ */

--- a/include/zephyr/drivers/amp/amp_openamp_ops_rproc.h
+++ b/include/zephyr/drivers/amp/amp_openamp_ops_rproc.h
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief AMP OpenAMP remoteproc_ops implementation
+ * @ingroup amp_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_AMP_OPENAMP_OPS_RPROC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_AMP_OPENAMP_OPS_RPROC_H_
+
+#include <zephyr/drivers/amp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <openamp/open_amp.h>
+#include <openamp/remoteproc.h>
+
+/**
+ * @brief Full identification of an AMP core
+ */
+struct amp_full_identification {
+	/** AMP root node */
+	const struct device *dev;
+	/** Core identification for which OpenAMP rproc is used */
+	const struct amp_core_identification core_id;
+};
+
+/**
+ * @cond INTERNAL_HIDDEN
+ *
+ * Internal implementaiton details that shouldn't be used by the user
+ */
+struct remoteproc *zephyr_openamp_init(struct remoteproc *rproc, const struct remoteproc_ops *ops,
+				       void *arg);
+int zephyr_openamp_config(struct remoteproc *rproc, void *data);
+int zephyr_openamp_start(struct remoteproc *rproc);
+int zephyr_openamp_stop(struct remoteproc *rproc);
+struct remoteproc_mem *zephyr_openamp_get_mem(struct remoteproc *rproc, const char *name,
+					      metal_phys_addr_t pa, metal_phys_addr_t da, void *va,
+					      size_t size, struct remoteproc_mem *buf);
+/** @endcond */
+
+/**
+ * @brief remoteproc_ops based on Zephyr drivers
+ *
+ * This provides remoteproc_ops that are based on top of Zephyr drivers. For
+ * rproc_init it is neccessary to pass a pointer to amp_full_identification into
+ * the priv argument which lives as long as the rproc argument itself.
+ *
+ * @see amp_full_identification
+ *
+ * TODO: Put into a group
+ */
+static const struct remoteproc_ops zephyr_openamp_ops = {
+	.init = zephyr_openamp_init,
+	.start = zephyr_openamp_start,
+	.stop = zephyr_openamp_stop,
+	.config = zephyr_openamp_config,
+	.get_mem = zephyr_openamp_get_mem,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_AMP_OPENAMP_OPS_RPROC_H_ */

--- a/include/zephyr/drivers/amp/amp_openamp_ops_storage.h
+++ b/include/zephyr/drivers/amp/amp_openamp_ops_storage.h
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief AMP OpenAMP storage_ops implementations
+ * @ingroup amp_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_AMP_OPENAMP_OPS_MEMORY_H_
+#define ZEPHYR_INCLUDE_DRIVERS_AMP_OPENAMP_OPS_MEMORY_H_
+
+#include <zephyr/drivers/amp/amp_openamp_ops_rproc.h>
+#include <openamp/remoteproc_loader.h>
+
+#if defined(CONFIG_AMP_OPENAMP_OPS_PROVIDE_STORAGE_OPS_MEMCPY) || defined(__DOXYGEN__)
+
+/**
+ * @brief Location and size of an ELF in readable memory
+ */
+struct amp_memcpy_options {
+	/** Start of the ELF */
+	const uintptr_t start_address;
+	/** Size of the ELF */
+	const size_t image_size;
+};
+
+/**
+ * @cond INTERNAL_HIDDEN
+ *
+ * Internal implementaiton details that shouldn't be used by the user
+ */
+int zephyr_openamp_load_memcpy_open(void *store, const char *path, const void **img_data);
+void zephyr_openamp_load_memcpy_close(void *store);
+int zephyr_openamp_load_memcpy_load(void *store, size_t offset, size_t size, const void **data,
+				    metal_phys_addr_t pa, struct metal_io_region *io,
+				    char is_blocking);
+/** @endcond */
+
+/**
+ * @brief image_store_ops based on an ELF being in readable memory
+ *
+ * This provides image_store_ops that only require the ELF for another processor
+ * being in readable memory. The store argument needs to be of the type
+ * amp_memcpy_options.
+ *
+ * @see amp_memcpy_options
+ *
+ * TODO: Put into a group
+ */
+static const struct image_store_ops zephyr_openamp_load_memcpy_ops = {
+	.open = zephyr_openamp_load_memcpy_open,
+	.close = zephyr_openamp_load_memcpy_close,
+	.load = zephyr_openamp_load_memcpy_load,
+	.features = SUPPORT_SEEK,
+};
+
+#endif /* CONFIG_AMP_OPENAMP_OPS_PROVIDE_STORAGE_OPS_MEMCPY */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_AMP_OPENAMP_OPS_MEMORY_H_ */

--- a/include/zephyr/drivers/amp/amp_ti_k3.h
+++ b/include/zephyr/drivers/amp/amp_ti_k3.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef AMP_TI_K3_H
+#define AMP_TI_K3_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <zephyr/dt-bindings/amp/ti-k3-amp.h>
+
+/**
+ * @brief Cluster type
+ */
+enum amp_ti_k3_cluster_type {
+	/** A Cortex-R cluster */
+	AMP_TI_K3_CLUSTER_TYPE_CORTEX_R = 0,
+	/** A Cortex-M cluster */
+	AMP_TI_K3_CLUSTER_TYPE_CORTEX_M = 1,
+};
+
+/**
+ * @brief Boot options for K3 boot cores
+ */
+struct amp_ti_k3_boot_options {
+	/* Config flags that should be enabled on processor boot */
+	uint32_t config_flags_set;
+	/* Config flags that should be disabled on processor boot */
+	uint32_t config_flags_clear;
+	/* Location of the boot vector */
+	uint64_t boot_vec;
+};
+
+#endif /* AMP_TI_K3_H */

--- a/include/zephyr/dt-bindings/amp/ti-k3-amp.h
+++ b/include/zephyr/dt-bindings/amp/ti-k3-amp.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_AMP_TI_K3_AMP_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_AMP_TI_K3_AMP_H_
+
+#include <zephyr/dt-bindings/dt-util.h>
+
+// TODO: "Unique" TI K3 Prefix or similar!
+
+#define CORTEX_R_INVASIVE_DBG_BIT                BIT(0)
+#define CORTEX_R_NON_INVASIVE_DBG_BIT            BIT(1)
+#define CORTEX_R_THUMB_EXCEPTION_HANDLING_BIT    BIT(9)
+#define CORTEX_R_NON_MASKABLE_FAST_INTERRUPT_BIT BIT(10)
+#define CORTEX_R_ATCM_AT_ZERO_BIT                BIT(11)
+#define CORTEX_R_BTCM_ENABLE_BIT                 BIT(12)
+#define CORTEX_R_ATCM_ENABLE_BIT                 BIT(13)
+#define CORTEX_R_DISABLE_MEMORY_INIT_BIT         BIT(14)
+#define CORTEX_R_USE_SINGLECORE                  BIT(15)
+
+#define CORTEX_X_IGNORE_BOOTVECTOR               BIT(28)
+
+#define CORTEX_R_ALL_BITS \
+	(BIT(0) | BIT(1) | GENMASK(15, 9) | BIT(28))
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_AMP_TI_K3_AMP_H_ */

--- a/samples/drivers/amp/openamp-memcpy/CMakeLists.txt
+++ b/samples/drivers/amp/openamp-memcpy/CMakeLists.txt
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(openamp_memcpy)
+
+set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
+
+generate_inc_file_for_target(
+    app
+    remote_firmware.elf
+    ${gen_dir}/remote_firmware.elf.inc
+)
+
+target_include_directories(app PRIVATE include)
+target_sources(app PRIVATE src/main.c)

--- a/samples/drivers/amp/openamp-memcpy/boards/lp_am243_am2434_r5f0_0.overlay
+++ b/samples/drivers/amp/openamp-memcpy/boards/lp_am243_am2434_r5f0_0.overlay
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/amp/ti-k3-amp.h>
+
+&dmsc {
+	status = "okay";
+};
+
+&secure_proxy_main {
+	status = "okay";
+};
+
+&r5fss_1_0 {
+	status = "okay";
+	config-set-flags = <(CORTEX_R_INVASIVE_DBG_BIT | CORTEX_R_NON_INVASIVE_DBG_BIT | CORTEX_R_ATCM_AT_ZERO_BIT | CORTEX_R_ATCM_ENABLE_BIT | CORTEX_R_BTCM_ENABLE_BIT)>;
+	config-clear-flags = <(CORTEX_R_THUMB_EXCEPTION_HANDLING_BIT | CORTEX_R_NON_MASKABLE_FAST_INTERRUPT_BIT | CORTEX_R_DISABLE_MEMORY_INIT_BIT | CORTEX_R_USE_SINGLECORE | CORTEX_X_IGNORE_BOOTVECTOR)>;
+	boot-vec = <0x0>;
+};
+

--- a/samples/drivers/amp/openamp-memcpy/prj.conf
+++ b/samples/drivers/amp/openamp-memcpy/prj.conf
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_AMP=y
+CONFIG_OPENAMP=y
+
+CONFIG_LOG=y
+
+CONFIG_AMP_OPENAMP_OPS=y
+CONFIG_AMP_OPENAMP_OPS_PROVIDE_REMOTEPROC=y
+CONFIG_AMP_OPENAMP_OPS_PROVIDE_STORAGE_OPS_MEMCPY=y

--- a/samples/drivers/amp/openamp-memcpy/sample.yaml
+++ b/samples/drivers/amp/openamp-memcpy/sample.yaml
@@ -1,0 +1,3 @@
+sample:
+  name: OpenAMP memcpy sample
+# TODO: Rest of this file and a sample description (README.rst)

--- a/samples/drivers/amp/openamp-memcpy/src/main.c
+++ b/samples/drivers/amp/openamp-memcpy/src/main.c
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Siemens Mobility GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/amp.h>
+#include <zephyr/drivers/amp/amp_openamp_ops_rproc.h>
+#include <zephyr/drivers/amp/amp_openamp_ops_storage.h>
+
+#include <openamp/open_amp.h>
+#include <openamp/remoteproc.h>
+#include <openamp/remoteproc_loader.h>
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(openamp_sample, LOG_LEVEL_DBG);
+
+#define DT_SAMPLE_CORE DT_NODELABEL(r5fss_1_0)
+
+static struct remoteproc rproc_inst;
+static struct amp_full_identification full_core_id = {
+	.core_id = AMP_DT_GET_CORE_IDENTIFICATION(DT_SAMPLE_CORE),
+	.dev = DEVICE_DT_GET(DT_NODELABEL(amp)),
+};
+
+static const uint8_t remote_firmware_elf[] = {
+#include "remote_firmware.elf.inc"
+};
+
+static struct amp_memcpy_options store_data = {
+	.start_address = (uintptr_t) remote_firmware_elf,
+	.image_size = ARRAY_SIZE(remote_firmware_elf),
+};
+
+int main(void)
+{
+	int ret;
+	struct metal_init_params metal_param = METAL_INIT_DEFAULTS;
+	metal_init(&metal_param);
+
+	LOG_INF("Initializing remoteproc instance");
+	struct remoteproc *rproc = remoteproc_init(&rproc_inst, &zephyr_openamp_ops, &full_core_id);
+	if (rproc == NULL) {
+		LOG_ERR("Error initializing rproc");
+		ret = -EIO;
+		goto end;
+	}
+
+	LOG_INF("Getting remote core config pointer from devicetree");
+	void *core_options = amp_get_dt_core_config(full_core_id.dev, &full_core_id.core_id);
+	if (!core_options) {
+		LOG_ERR("Couldn't get core options from devicetree");
+		ret = -EINVAL;
+		goto end;
+	}
+
+	LOG_INF("Configuring remote core");
+	ret = remoteproc_config(rproc, core_options);
+	if (ret) {
+		LOG_ERR("Error configuring remote core %d", ret);
+		goto end;
+	}
+
+	LOG_INF("Loading remoteproc ELF into correct memory");
+	ret = remoteproc_load(rproc, NULL, &store_data, &zephyr_openamp_load_memcpy_ops, NULL);
+	if (ret < 0) {
+		LOG_ERR("Error in ELF Loading %d", ret);
+		goto end;
+	}
+
+	LOG_INF("Starting executing code on remote processor");
+	ret = remoteproc_start(rproc);
+	if (ret < 0) {
+		LOG_ERR("Error starting remote core %d", ret);
+		goto end;
+	}
+
+	LOG_INF("Waiting 10 seconds before stopping the other core again");
+	k_sleep(K_SECONDS(10));
+
+	LOG_INF("Stopping remotecore");
+	ret = remoteproc_stop(rproc);
+	if (ret < 0) {
+		LOG_ERR("Error stopping other core %d", ret);
+		goto end;
+	}
+
+end:
+	LOG_INF("Reached end of sample %s", ret < 0 ? "with errors" : "successfully");
+
+	return 0;
+}


### PR DESCRIPTION
This is an example how a remote core control API could look like and which impliciations it would have. It will be opened once a decision was made on the RFC. Until then it will be closed to avoid adding/removing the Stale labels over and over again.

The commit especially include:
- Initial API definition
- An implementation for the TI AM243 (which also requires messages to a core that runs a firmware from TI)
- Code that allows easy usage via OpenAMP remoteproc functions
- A sample that builds an ELF into the firmware, loads it onto another core and then runs it for 10 seconds (to show a simple API usage)

**Please do not comment on this PR. There are known Code style issues (and similar) that will be resolved once the RFC is accepted. Please comment thoughts on the RFC Issue #114707**

Changes:
- 2026-07-28: Add single commit description in PR summary for clarity