### PR TITLE
boards: adi: max32658evkit: Enable mpu by default

### DIFF
--- a/boards/adi/max32658evkit/max32658evkit_max32658_defconfig
+++ b/boards/adi/max32658evkit/max32658evkit_max32658_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/boards/adi/max32658evkit/max32658evkit_max32658_ns_defconfig
+++ b/boards/adi/max32658evkit/max32658evkit_max32658_ns_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024-2025 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable MPU
+CONFIG_ARM_MPU=y
+
 # Enable GPIO
 CONFIG_GPIO=y
 

--- a/tests/subsys/logging/log_core_additional/tests.yaml
+++ b/tests/subsys/logging/log_core_additional/tests.yaml
@@ -24,3 +24,4 @@ tests:
       - qemu_x86
     platform_exclude:
       - max32657evkit/max32657
+      - max32658evkit/max32658


### PR DESCRIPTION
MPU is supported on MAX32658EVKIT boards. Enable it by default in defconfig files.