### PR TITLE
drivers: counter: Enable PM support for MAX32 timer counter

### DIFF
--- a/drivers/counter/counter_max32_timer.c
+++ b/drivers/counter/counter_max32_timer.c
@@ -10,6 +10,8 @@
 #include <zephyr/drivers/clock_control/adi_max32_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/policy.h>
 
 #include <wrap_max32_tmr.h>
 
@@ -20,6 +22,7 @@ struct max32_tmr_data {
 	counter_top_callback_t top_callback;
 	void *top_user_data;
 	uint32_t guard_period;
+	bool pm_policy_state_lock;
 };
 
 struct max32_tmr_ch_data {
@@ -40,9 +43,35 @@ struct max32_tmr_config {
 	bool wakeup_source;
 };
 
+static void counter_max32_pm_policy_state_lock_get(const struct device *dev)
+{
+	if (IS_ENABLED(CONFIG_PM_POLICY_DEVICE_CONSTRAINTS)) {
+		struct max32_tmr_data *data = dev->data;
+
+		if (!data->pm_policy_state_lock) {
+			data->pm_policy_state_lock = true;
+			pm_policy_device_power_lock_get(dev);
+		}
+	}
+}
+
+static void counter_max32_pm_policy_state_lock_put(const struct device *dev)
+{
+	if (IS_ENABLED(CONFIG_PM_POLICY_DEVICE_CONSTRAINTS)) {
+		struct max32_tmr_data *data = dev->data;
+
+		if (data->pm_policy_state_lock) {
+			data->pm_policy_state_lock = false;
+			pm_policy_device_power_lock_put(dev);
+		}
+	}
+}
+
 static int api_start(const struct device *dev)
 {
 	const struct max32_tmr_config *cfg = dev->config;
+
+	counter_max32_pm_policy_state_lock_get(dev);
 
 	Wrap_MXC_TMR_EnableInt(cfg->regs);
 	MXC_TMR_Start(cfg->regs);
@@ -56,6 +85,8 @@ static int api_stop(const struct device *dev)
 
 	Wrap_MXC_TMR_DisableInt(cfg->regs);
 	MXC_TMR_Stop(cfg->regs);
+
+	counter_max32_pm_policy_state_lock_put(dev);
 
 	return 0;
 }
@@ -258,6 +289,84 @@ static void counter_max32_isr(const struct device *dev)
 	}
 }
 
+static int counter_max32_pm_resume(const struct device *dev)
+{
+	const struct max32_tmr_config *const cfg = dev->config;
+	wrap_mxc_tmr_cfg_t tmr_cfg;
+	int ret;
+
+	ret = clock_control_on(cfg->clock, (clock_control_subsys_t)&cfg->perclk);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (MXC_TMR_GetCompare(cfg->regs) == 0) {
+		tmr_cfg.pres = LOG2(cfg->prescaler) * TMR_PRES_2;
+		tmr_cfg.mode = TMR_MODE_COMPARE;
+		tmr_cfg.cmp_cnt = cfg->info.max_top_value;
+		tmr_cfg.bitMode = 0; /* Timer Mode 32 bit */
+		tmr_cfg.pol = 0;
+		tmr_cfg.clock = Wrap_MXC_TMR_GetClockIndex(cfg->clock_source);
+
+		ret = Wrap_MXC_TMR_Init(cfg->regs, &tmr_cfg);
+		if (ret != E_NO_ERROR) {
+			return ret;
+		}
+
+		/* Set preload and actually pre-load the counter */
+		MXC_TMR_SetCompare(cfg->regs, cfg->info.max_top_value);
+
+		if (cfg->wakeup_source) {
+			/* Clear Wakeup status */
+			MXC_LP_ClearWakeStatus();
+			/* Enable Timer wake-up source */
+			Wrap_MXC_TMR_EnableWakeup(cfg->regs, &tmr_cfg);
+		}
+	}
+
+	return 0;
+}
+
+static int counter_max32_pm_suspend(const struct max32_tmr_config *const cfg)
+{
+	int ret;
+
+	/* Disable clock */
+	ret = clock_control_off(cfg->clock, (clock_control_subsys_t)&cfg->perclk);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+static int counter_max32_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	int ret;
+	const struct max32_tmr_config *const cfg = dev->config;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		ret = counter_max32_pm_resume(dev);
+		if (ret) {
+			return ret;
+		}
+
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		ret = counter_max32_pm_suspend(cfg);
+		if (ret) {
+			return ret;
+		}
+
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
 static int max32_counter_init(const struct device *dev)
 {
 	int ret = 0;
@@ -308,7 +417,7 @@ static int max32_counter_init(const struct device *dev)
 		Wrap_MXC_TMR_EnableWakeup(regs, &tmr_cfg);
 	}
 
-	return 0;
+	return pm_device_driver_init(dev, counter_max32_pm_action);
 }
 
 static DEVICE_API(counter, counter_max32_driver_api) = {
@@ -378,8 +487,9 @@ static DEVICE_API(counter, counter_max32_driver_api) = {
 		.wakeup_source = DT_PROP(TIMER(_num), wakeup_source),                              \
 	};                                                                                         \
 	static struct max32_tmr_data max32_tmr_data##_num;                                         \
-	DEVICE_DT_INST_DEFINE(_num, &max32_counter_init, NULL, &max32_tmr_data##_num,              \
-			      &max32_tmr_config_##_num, PRE_KERNEL_1,                              \
+	PM_DEVICE_DT_INST_DEFINE(_num, counter_max32_pm_action);                                   \
+	DEVICE_DT_INST_DEFINE(_num, &max32_counter_init, PM_DEVICE_DT_INST_GET(_num),              \
+			      &max32_tmr_data##_num, &max32_tmr_config_##_num, PRE_KERNEL_1,       \
 			      CONFIG_COUNTER_INIT_PRIORITY, &counter_max32_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(COUNTER_MAX32_DEFINE)

--- a/dts/arm/adi/max32/max32657_common.dtsi
+++ b/dts/arm/adi/max32/max32657_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -220,6 +220,8 @@
 
 		counter {
 			compatible = "adi,max32-counter";
+			zephyr,pm-device-runtime-auto;
+			zephyr,disabling-power-states = <&standby &backup>;
 			status = "disabled";
 		};
 	};
@@ -241,6 +243,8 @@
 
 		counter {
 			compatible = "adi,max32-counter";
+			zephyr,pm-device-runtime-auto;
+			zephyr,disabling-power-states = <&standby &backup>;
 			status = "disabled";
 		};
 	};
@@ -262,6 +266,8 @@
 
 		counter {
 			compatible = "adi,max32-counter";
+			zephyr,pm-device-runtime-auto;
+			zephyr,disabling-power-states = <&standby &backup>;
 			status = "disabled";
 		};
 	};
@@ -283,6 +289,8 @@
 
 		counter {
 			compatible = "adi,max32-counter";
+			zephyr,pm-device-runtime-auto;
+			zephyr,disabling-power-states = <&standby &backup>;
 			status = "disabled";
 		};
 	};
@@ -304,6 +312,8 @@
 
 		counter {
 			compatible = "adi,max32-counter";
+			zephyr,pm-device-runtime-auto;
+			zephyr,disabling-power-states = <&standby &backup>;
 			status = "disabled";
 		};
 	};
@@ -325,6 +335,8 @@
 
 		counter {
 			compatible = "adi,max32-counter";
+			zephyr,pm-device-runtime-auto;
+			zephyr,disabling-power-states = <&standby &backup>;
 			status = "disabled";
 		};
 	};

--- a/tests/drivers/counter/counter_basic_api/boards/max32657evkit_max32657.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/max32657evkit_max32657.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -63,4 +63,13 @@
 	counter {
 		status = "okay";
 	};
+};
+
+/*
+ * SRAM banks marked with the following property are retained in backup mode
+ *
+ * SRAM banks are listed in max32657_common.dtsi
+ */
+&sram0 {
+	adi,ram-bank-retained;
 };

--- a/tests/drivers/counter/counter_basic_api/boards/max32658evkit_max32658.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/max32658evkit_max32658.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2026 Analog Devices, Inc.
+ * Copyright (c) 2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -56,20 +56,11 @@
 	};
 };
 
-&wut0 {
-	status = "okay";
-	prescaler = <2>;
-
-	counter {
-		status = "okay";
-	};
-};
-
 /*
  * SRAM banks marked with the following property are retained in backup mode
  *
  * SRAM banks are listed in max32657_common.dtsi
  */
-&sram2 {
+&sram0 {
 	adi,ram-bank-retained;
 };

--- a/tests/drivers/counter/counter_basic_api/boards/max32658evkit_max32658_ns.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/max32658evkit_max32658_ns.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2026 Analog Devices, Inc.
+ * Copyright (c) 2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -50,15 +50,6 @@
 
 &timer5 {
 	status = "okay";
-
-	counter {
-		status = "okay";
-	};
-};
-
-&wut0 {
-	status = "okay";
-	prescaler = <2>;
 
 	counter {
 		status = "okay";

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -10,6 +10,8 @@
 #include <zephyr/ztest.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/pm/policy.h>
 LOG_MODULE_REGISTER(test);
 
 static struct k_sem top_cnt_sem;
@@ -274,6 +276,8 @@ static void counter_setup_instance(const struct device *dev)
 	if (!k_is_user_context()) {
 		compiler_barrier();
 		alarm_cnt = 0;
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+		zassert_ok(pm_device_runtime_get(dev));
 	}
 }
 
@@ -301,6 +305,10 @@ static void counter_tear_down_instance(const struct device *dev)
 	zassert_true((err == 0) || (err == -ENOTSUP),
 			"%s: Counter failed to stop (err: %d)", dev->name, err);
 
+	if (!k_is_user_context()) {
+		zassert_ok(pm_device_runtime_put(dev));
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
+	}
 }
 
 static void test_all_instances(counter_test_func_t func,

--- a/tests/drivers/counter/counter_basic_api/tests.yaml
+++ b/tests/drivers/counter/counter_basic_api/tests.yaml
@@ -147,3 +147,20 @@ tests:
       - xg24_rb4187c/efr32mg24b220f1536im48
     extra_args:
       - CONFIG_BUILD_ONLY_NO_BLOBS=y
+  drivers.counter.basic_api.pm_device_runtime:
+    tags:
+      - drivers
+      - counter
+    depends_on: counter
+    platform_allow:
+      - max32657evkit/max32657
+      - max32657evkit/max32657/ns
+      - max32658evkit/max32658
+      - max32658evkit/max32658/ns
+    min_ram: 16
+    timeout: 600
+    extra_configs:
+      - CONFIG_PM=y
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
+      - CONFIG_PM_POLICY_DEVICE_CONSTRAINTS=y


### PR DESCRIPTION
This PR enables power management (PM) support for the MAX32 timer counter driver, allowing it to enter low-power states when idle to improve energy efficiency.

Changes included:
- Added PM support and a new test case to the counter_basic_api test suite.
- Added overlay for max32658evkit and updated the existing overlay for max32657evkit to enable test execution on both boards.