### PR TITLE
drivers: i2c: i2c_dw: Fix need_setup not being reset on i2c error

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -691,7 +691,11 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 
 #if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
 	if (!dw->need_setup) {
-		return 0;
+		/* If slave address changed setup is still needed */
+		ic_tar.raw = read_tar(reg_base);
+		if (ic_tar.bits.ic_tar == slave_address) {
+			return 0;
+		}
 	}
 #endif
 
@@ -1023,6 +1027,10 @@ error:
 	k_sem_give(&dw->bus_sem);
 
 	pm_device_runtime_put(dev);
+	if (ret != 0) {
+		/* Failed/aborted transaction is no longer active, require setup */
+		dw->need_setup = true;
+	}
 
 	return ret;
 }

--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -691,7 +691,11 @@ static int i2c_dw_setup(const struct device *dev, uint16_t slave_address)
 
 #if CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
 	if (!dw->need_setup) {
-		return 0;
+		/* If slave address changed setup is still needed */
+		ic_tar.raw = read_tar(reg_base);
+		if (ic_tar.bits.ic_tar == slave_address) {
+			return 0;
+		}
 	}
 #endif
 
@@ -1023,6 +1027,7 @@ error:
 	k_sem_give(&dw->bus_sem);
 
 	pm_device_runtime_put(dev);
+	dw->need_setup = true;
 
 	return ret;
 }


### PR DESCRIPTION
If an i2c transaction got past setting the need_setup but didn't complete for some reason the i2c driver would send the next transaction to that address regardless of what was passed into the driver. Add a check to verify that the address still matches if not bypass need_setup.