### PR TITLE
drivers: *: espressif: use diamond include for non-local headers

### DIFF
--- a/drivers/clock_control/clock_control_esp32_priv.h
+++ b/drivers/clock_control/clock_control_esp32_priv.h
@@ -104,7 +104,7 @@
 #include <hal/uart_ll.h>
 #include <soc/periph_defs.h>
 #include <soc/rtc.h>
-#include "esp_clk_internal.h"
+#include <esp_clk_internal.h>
 
 /*
  * Per-family clock implementations. The RTC_CNTL variant covers the SoCs

--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -35,7 +35,7 @@
 #endif
 
 #if COUNTER_SLEEP_RETENTION_ENABLED
-#include "gptimer_priv.h"
+#include <gptimer_priv.h>
 #include <esp_private/sleep_retention.h>
 #endif
 

--- a/drivers/crypto/crypto_esp32_aes.c
+++ b/drivers/crypto/crypto_esp32_aes.c
@@ -15,8 +15,8 @@
 #include <errno.h>
 #include <stdlib.h>
 
-#include "hal/aes_hal.h"
-#include "hal/aes_ll.h"
+#include <hal/aes_hal.h>
+#include <hal/aes_ll.h>
 
 LOG_MODULE_REGISTER(esp32_aes, CONFIG_CRYPTO_LOG_LEVEL);
 

--- a/drivers/crypto/crypto_esp32_sha.c
+++ b/drivers/crypto/crypto_esp32_sha.c
@@ -15,13 +15,13 @@
 #include <string.h>
 #include <errno.h>
 
-#include "hal/sha_hal.h"
-#include "hal/sha_ll.h"
-#include "hal/sha_types.h"
-#include "soc/soc_caps.h"
+#include <hal/sha_hal.h>
+#include <hal/sha_ll.h>
+#include <hal/sha_types.h>
+#include <soc/soc_caps.h>
 
 #if !SOC_SHA_SUPPORT_RESUME
-#include "soc/hwcrypto_reg.h"
+#include <soc/hwcrypto_reg.h>
 #endif
 
 LOG_MODULE_REGISTER(esp32_sha, CONFIG_CRYPTO_LOG_LEVEL);

--- a/drivers/dma/dma_esp32_gdma.c
+++ b/drivers/dma/dma_esp32_gdma.c
@@ -39,7 +39,7 @@ LOG_MODULE_REGISTER(dma_esp32_gdma, CONFIG_DMA_LOG_LEVEL);
 #endif
 
 #if GDMA_SLEEP_RETENTION_ENABLED
-#include "gdma_priv.h"
+#include <gdma_priv.h>
 #include <esp_private/sleep_retention.h>
 
 static esp_err_t gdma_create_sleep_retention_cb(void *arg)

--- a/drivers/entropy/entropy_esp32.c
+++ b/drivers/entropy/entropy_esp32.c
@@ -18,7 +18,7 @@
 
 LOG_MODULE_REGISTER(entropy, CONFIG_ENTROPY_LOG_LEVEL);
 
-#include "hal/rtc_timer_hal.h"
+#include <hal/rtc_timer_hal.h>
 
 #if defined CONFIG_SOC_SERIES_ESP32S3
 /* If APB clock is 80 MHz, the maximum sampling frequency is around 45 KHz */

--- a/drivers/hwinfo/hwinfo_esp32.c
+++ b/drivers/hwinfo/hwinfo_esp32.c
@@ -7,7 +7,7 @@
 
 #include <soc/efuse_reg.h>
 #include <soc/reset_reasons.h>
-#include "esp_system.h"
+#include <esp_system.h>
 #include <soc/rtc.h>
 
 #include <zephyr/drivers/hwinfo.h>

--- a/drivers/ipm/ipm_esp32.c
+++ b/drivers/ipm/ipm_esp32.c
@@ -5,8 +5,8 @@
  */
 
 #define DT_DRV_COMPAT espressif_esp32_ipm
-#include "soc/dport_reg.h"
-#include "soc/gpio_periph.h"
+#include <soc/dport_reg.h>
+#include <soc/gpio_periph.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/drivers/mbox/mbox_esp32.c
+++ b/drivers/mbox/mbox_esp32.c
@@ -22,7 +22,7 @@
 #endif
 
 #if !defined(MBOX_ESP32_HPCORE) && !defined(MBOX_ESP32_LPCORE)
-#include "soc/dport_reg.h"
+#include <soc/dport_reg.h>
 #else
 #include <ulp_lp_core.h>
 #include <soc/pmu_reg.h>
@@ -34,7 +34,7 @@
 #endif
 #endif
 
-#include "soc/gpio_periph.h"
+#include <soc/gpio_periph.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/drivers/pwm/pwm_mc_esp32.c
+++ b/drivers/pwm/pwm_mc_esp32.c
@@ -29,7 +29,7 @@
 #endif
 
 #if MCPWM_SLEEP_RETENTION_ENABLED
-#include "mcpwm_private.h"
+#include <mcpwm_private.h>
 #include <esp_private/sleep_retention.h>
 #endif
 

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -21,18 +21,18 @@ LOG_MODULE_REGISTER(esp32_wifi, CONFIG_WIFI_LOG_LEVEL);
 #endif
 #include <zephyr/device.h>
 #include <soc.h>
-#include "esp_private/wifi.h"
-#include "esp_event.h"
-#include "esp_rom_sys.h"
-#include "esp_timer.h"
-#include "esp_system.h"
-#include "esp_wifi.h"
-#include "esp_wpa.h"
+#include <esp_private/wifi.h>
+#include <esp_event.h>
+#include <esp_rom_sys.h>
+#include <esp_timer.h>
+#include <esp_system.h>
+#include <esp_wifi.h>
+#include <esp_wpa.h>
 #if defined(CONFIG_ESP32_WIFI_ENTERPRISE)
-#include "esp_eap_client.h"
+#include <esp_eap_client.h>
 #endif
 #include <esp_mac.h>
-#include "wifi/wifi_event.h"
+#include <wifi/wifi_event.h>
 
 #if CONFIG_SOC_SERIES_ESP32S2 || CONFIG_SOC_SERIES_ESP32C3
 #include <esp_private/adc_share_hw_ctrl.h>

--- a/drivers/wifi/esp_at/esp.h
+++ b/drivers/wifi/esp_at/esp.h
@@ -15,9 +15,9 @@
 #include <zephyr/net/net_pkt.h>
 #include <zephyr/net/wifi_mgmt.h>
 
-#include "modem_context.h"
-#include "modem_cmd_handler.h"
-#include "modem_iface_uart.h"
+#include <modem_context.h>
+#include <modem_cmd_handler.h>
+#include <modem_iface_uart.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Use `#include <>` instead of `#include ""` to include a header file which path is not relative to the directory path of the file emitting the `#include` directive.

This change was made running `scripts/check_quoted_includes.py` script proposed in https://github.com/zephyrproject-rtos/zephyr/pull/112135 with Linux shell commands like the one below and manually selecting the applicable changes: only those located in `drivers/` since `soc/`, `boards/`, `samples/` and `tests/` content related to Espressif is addressed in pull request https://github.com/zephyrproject-rtos/zephyr/pull/112190.
```
$ ./scripts/check_quoted_includes.py -w \
    `./scripts/get_maintainer.py list "Espressif Platforms"`