### PR TITLE
soc: ti: cc23x0: always compile power.c regardless of CONFIG_PM

### DIFF
--- a/soc/ti/simplelink/cc23x0/CMakeLists.txt
+++ b/soc/ti/simplelink/cc23x0/CMakeLists.txt
@@ -6,9 +6,8 @@
 
 zephyr_sources(soc.c)
 zephyr_sources(ccfg.c)
+zephyr_sources(power.c)
 zephyr_include_directories(.)
-
-zephyr_sources_ifdef(CONFIG_PM power.c)
 
 zephyr_linker_sources_ifdef(CONFIG_HAS_TI_CCFG SECTIONS ccfg.ld)
 


### PR DESCRIPTION
power.c calls PMCTLSetVoltageRegulator() from a SYS_INIT() hook that is meant to always run, but CMakeLists.txt only compiled the file when CONFIG_PM was enabled. With CONFIG_PM=n, the file was skipped entirely.

Compile power.c unconditionally. Its own "#ifdef CONFIG_PM" guard already excludes the PM-only code when CONFIG_PM is disabled.

Verified by checking that power_initialize is run with CONFIG_PM=n.



Assisted-by: Claude:claude-sonnet-5