### PR TITLE
ci: update docker images to v0.29.3.20260727

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -43,7 +43,7 @@ jobs:
       group: zephyr-runner-v2-linux-x64-4xlarge
     timeout-minutes: 120
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -21,7 +21,7 @@ jobs:
       group: zephyr-runner-v2-linux-x64-4xlarge
     timeout-minutes: 360
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/coding_guidelines_full.yml
+++ b/.github/workflows/coding_guidelines_full.yml
@@ -16,7 +16,7 @@ jobs:
       group: zephyr-runner-v2-linux-x64-4xlarge
     timeout-minutes: 300
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
       options: '--entrypoint /bin/bash'
     permissions:
       contents: read

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
       options: '--entrypoint /bin/bash'
     timeout-minutes: 60
     concurrency:

--- a/.github/workflows/doxygen-checks.yml
+++ b/.github/workflows/doxygen-checks.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
       options: '--entrypoint /bin/bash'
     timeout-minutes: 60
     env:

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 120
     if: github.repository_owner == 'zephyrproject-rtos'
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
       options: '--entrypoint /bin/bash'
     defaults:
       run:

--- a/.github/workflows/push_artifacts.yml
+++ b/.github/workflows/push_artifacts.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on:
       group: zephyr-runner-v2-linux-x64-4xlarge
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
       options: '--entrypoint /bin/bash'
     timeout-minutes: 360
     env:

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -29,7 +29,7 @@ jobs:
       group: zephyr-runner-v2-linux-x64-4xlarge
     timeout-minutes: 60
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
       options: '--entrypoint /bin/bash'
     outputs:
       subset: ${{ steps.output-services.outputs.subset }}
@@ -156,7 +156,7 @@ jobs:
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
-      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.2.20260422
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false


### PR DESCRIPTION
Primary changes pulled as part of this tag are,
- TriCore GCC compilation permission fix
- BSIM to v3.1
- Hexagon LLVM toolchain
- ARM Corstone-1000 FVP version to 11.31

Docker Cache tag: https://github.com/zephyrproject-rtos/docker-ci-repo-cache/releases/tag/v0.29.3.20260727
Docker image tag: https://github.com/zephyrproject-rtos/docker-image/releases/tag/v0.29.3

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>