### PR TITLE
gitignore: only match target on the root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ Cargo.lock
 
 # Normal west builds will place the Rust target directory under the build directory.  However,
 # sometimes IDEs and such will litter these target directories as well.
-target/
+/target/
 
 # CI output
 compliance.xml


### PR DESCRIPTION
These patterns match full path by default, so this specific one matches drivers/i2c/target too. There's probably more that should be defined with a leading / but this is seems to be the only problematic one right now.