### PR TITLE
drivers: hwinfo: stm32: Do not read reserved memory

### DIFF
--- a/drivers/hwinfo/hwinfo_stm32.c
+++ b/drivers/hwinfo/hwinfo_stm32.c
@@ -63,6 +63,8 @@ static void ll_rcc_clear_reset_flags(void)
 #endif /* CONFIG_SOC_SERIES_STM32C5X */
 }
 
+/* Cortex-M4 on dual core STM32H7xx MCUs cannot access system memory */
+#if !defined(CONFIG_SOC_SERIES_STM32H7X) || !defined(CONFIG_CPU_CORTEX_M4)
 ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	struct stm32_uid dev_id;
@@ -91,6 +93,7 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 
 	return length;
 }
+#endif /* !CONFIG_SOC_SERIES_STM32H7X || !CONFIG_CPU_CORTEX_M4 */
 
 #if defined(CONFIG_SOC_SERIES_STM32WBAX) || \
 	defined(CONFIG_SOC_SERIES_STM32WBX) || \


### PR DESCRIPTION
I ran into a HardFault while working with networking and USB on the Cortex-M4 CPU of an STM32H755. The issue is caused by the M4 trying to read the device UID from the system memory region, access to which is restricted to the Cortex-M7. See Table 6 on Page 137 of the [reference manual](https://www.st.com/resource/en/reference_manual/rm0399-stm32h745755-and-stm32h747757-advanced-armbased-32bit-mcus-stmicroelectronics.pdf). This PR should have the attempted read fail gracefully instead.

The access restrictions apply to all STM32H7 SoCs.