### PR TITLE
testsuite: ztest: cpuhold threads need to join

### DIFF
--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -309,7 +309,10 @@ void z_impl_z_test_1cpu_stop(void)
 
 	for (int i = 0; i <= MAX_NUM_CPUHOLD; i++) {
 		if (cpuhold_pool_items[i].used) {
-			k_thread_abort(&cpuhold_pool_items[i].thread);
+			/* Must join the cpuhold threads before z_test_1cpu_start()
+			 * reuses the thread objects.
+			 */
+			k_thread_join(&cpuhold_pool_items[i].thread, K_FOREVER);
 			cpuhold_pool_items[i].used = false;
 		}
 	}


### PR DESCRIPTION
Since we are reusing the cpuhold thread objects, we must join those threads to make sure the spawned threads have actually stopped. The situation is further compliacted due to those cpuhold threads are running with interrupt disabled inside cpu_hold(). This means the IPI sent by k_thread_abort() is not being processed to abort the thread. And there is no thread swapping where the scheduler checks if a thread is going away. Since k_thread_abort() is rather meaningless here and we must do k_thread_join(), simply replace abort with join.