### PR TITLE
i2c target register set library and tmp103 target

### DIFF
--- a/drivers/i2c/target/CMakeLists.txt
+++ b/drivers/i2c/target/CMakeLists.txt
@@ -2,4 +2,5 @@
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_I2C_EEPROM_TARGET eeprom_target.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_TARGET_REGSET_LIB regset_target_lib.c)
 # zephyr-keep-sorted-stop

--- a/drivers/i2c/target/CMakeLists.txt
+++ b/drivers/i2c/target/CMakeLists.txt
@@ -3,4 +3,5 @@
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_I2C_EEPROM_TARGET eeprom_target.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_TARGET_REGSET_LIB regset_target_lib.c)
+zephyr_library_sources_ifdef(CONFIG_I2C_TMP103_TARGET tmp103_target.c)
 # zephyr-keep-sorted-stop

--- a/drivers/i2c/target/Kconfig
+++ b/drivers/i2c/target/Kconfig
@@ -13,6 +13,11 @@ menuconfig I2C_TARGET
 
 if I2C_TARGET
 
+config I2C_TARGET_REGSET_LIB
+	bool
+	help
+	  I2C target regset library support.
+
 config I2C_TARGET_INIT_PRIORITY
 	int "Init priority"
 	default 60

--- a/drivers/i2c/target/Kconfig
+++ b/drivers/i2c/target/Kconfig
@@ -32,6 +32,7 @@ config I2C_TARGET_BUFFER_MODE
 
 # zephyr-keep-sorted-start
 source "drivers/i2c/target/Kconfig.eeprom"
+source "drivers/i2c/target/Kconfig.tmp103"
 # zephyr-keep-sorted-stop
 
 endif # I2C_TARGET

--- a/drivers/i2c/target/Kconfig.eeprom
+++ b/drivers/i2c/target/Kconfig.eeprom
@@ -5,6 +5,8 @@
 
 config I2C_EEPROM_TARGET
 	bool "I2C Target EEPROM driver"
+	default y
+	depends on DT_HAS_ZEPHYR_I2C_TARGET_EEPROM_ENABLED
 	select I2C_TARGET_REGSET_LIB
 	help
 	  Enable virtual I2C Target EEPROM driver

--- a/drivers/i2c/target/Kconfig.eeprom
+++ b/drivers/i2c/target/Kconfig.eeprom
@@ -5,6 +5,7 @@
 
 config I2C_EEPROM_TARGET
 	bool "I2C Target EEPROM driver"
+	select I2C_TARGET_REGSET_LIB
 	help
 	  Enable virtual I2C Target EEPROM driver
 

--- a/drivers/i2c/target/Kconfig.tmp103
+++ b/drivers/i2c/target/Kconfig.tmp103
@@ -1,0 +1,12 @@
+# I2C EEPROM Target configuration options
+
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config I2C_TMP103_TARGET
+	bool "I2C Target TMP103 driver"
+	default y
+	depends on DT_HAS_ZEPHYR_I2C_TARGET_TMP103_ENABLED
+	select I2C_TARGET_REGSET_LIB
+	help
+	  Enable virtual I2C Target TMP103 driver

--- a/drivers/i2c/target/eeprom_target.c
+++ b/drivers/i2c/target/eeprom_target.c
@@ -6,324 +6,74 @@
 
 #define DT_DRV_COMPAT zephyr_i2c_target_eeprom
 
-#include <zephyr/sys/util.h>
-#include <zephyr/kernel.h>
-#include <errno.h>
 #include <zephyr/drivers/i2c.h>
-#include <string.h>
 #include <zephyr/drivers/i2c/target/eeprom.h>
-
-#define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
+#include <zephyr/drivers/i2c/target/regset_target_lib.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(i2c_target);
+
+LOG_MODULE_REGISTER(i2c_eeprom, CONFIG_I2C_LOG_LEVEL);
 
 struct i2c_eeprom_target_data {
-	const struct device *dev;
-	struct i2c_target_config config;
-	uint32_t buffer_idx;
-	uint32_t idx_write_cnt;
-	uint8_t address_width;
-	eeprom_target_changed_handler_t changed_handler;
-	void *changed_handler_data;
-	bool changed;
+	struct regset_target_lib_data regset_data;
 };
 
 struct i2c_eeprom_target_config {
-	struct i2c_dt_spec bus;
-	uint32_t buffer_size;
-	uint8_t *buffer;
+	struct regset_target_lib_config regset_cfg;
 };
+
+REGSET_TARGET_LIB_STRUCT_CHECK(struct i2c_eeprom_target_config,
+			       struct i2c_eeprom_target_data);
 
 void eeprom_target_set_changed_callback(const struct device *dev,
 					eeprom_target_changed_handler_t handler,
 					void *user_data)
 {
-	struct i2c_eeprom_target_data *data = dev->data;
-
-	data->changed_handler = handler;
-	data->changed_handler_data = user_data;
+	regset_target_lib_set_changed_callback(dev, handler, user_data);
 }
 
 size_t eeprom_target_get_size(const struct device *dev)
 {
-	const struct i2c_eeprom_target_config *cfg = dev->config;
-
-	return cfg->buffer_size;
+	return regset_target_lib_get_size(dev);
 }
 
 int eeprom_target_read_data(const struct device *dev, off_t offset,
 			    void *data, size_t len)
 {
-	const struct i2c_eeprom_target_config *cfg = dev->config;
-
-	if ((offset + len) > cfg->buffer_size) {
-		LOG_WRN("attempt to read past device boundary");
-		return -EINVAL;
-	}
-
-	memcpy(data, cfg->buffer + offset, len);
-	return 0;
+	return regset_target_lib_read_data(dev, offset, data, len);
 }
 
 int eeprom_target_write_data(const struct device *dev, off_t offset,
 			     const void *data, size_t len)
 {
-	const struct i2c_eeprom_target_config *cfg = dev->config;
-
-	if ((offset + len) > cfg->buffer_size) {
-		LOG_WRN("attempt to write past device boundary");
-		return -EINVAL;
-	}
-
-	memcpy(cfg->buffer + offset, data, len);
-	return 0;
+	return regset_target_lib_write_data(dev, offset, data, len);
 }
 
 #ifdef CONFIG_I2C_EEPROM_TARGET_RUNTIME_ADDR
 int eeprom_target_set_addr(const struct device *dev, uint8_t addr)
 {
-	const struct i2c_eeprom_target_config *cfg = dev->config;
-	struct i2c_eeprom_target_data *data = dev->data;
-	int ret;
-
-	ret = i2c_target_unregister(cfg->bus.bus, &data->config);
-	if (ret) {
-		LOG_DBG("eeprom target failed to unregister");
-		return ret;
-	}
-
-	data->config.address = addr;
-
-	return i2c_target_register(cfg->bus.bus, &data->config);
+	return regset_target_lib_set_addr(dev, addr);
 }
 #endif /* CONFIG_I2C_EEPROM_TARGET_RUNTIME_ADDR */
 
-static int eeprom_target_write_requested(struct i2c_target_config *config)
-{
-	struct i2c_eeprom_target_data *data = CONTAINER_OF(config,
-						struct i2c_eeprom_target_data,
-						config);
-
-	LOG_DBG("eeprom: write req");
-
-	data->idx_write_cnt = 0;
-
-	return 0;
-}
-
-static int eeprom_target_read_requested(struct i2c_target_config *config,
-				       uint8_t *val)
-{
-	struct i2c_eeprom_target_data *data = CONTAINER_OF(config,
-						struct i2c_eeprom_target_data,
-						config);
-	const struct device *dev = data->dev;
-	const struct i2c_eeprom_target_config *cfg = dev->config;
-
-	*val = cfg->buffer[data->buffer_idx];
-
-	LOG_DBG("eeprom: read req, val=0x%x", *val);
-
-	/* Increment will be done in the read_processed callback */
-
-	return 0;
-}
-
-static int eeprom_target_write_received(struct i2c_target_config *config,
-				       uint8_t val)
-{
-	struct i2c_eeprom_target_data *data = CONTAINER_OF(config,
-						struct i2c_eeprom_target_data,
-						config);
-	const struct device *dev = data->dev;
-	const struct i2c_eeprom_target_config *cfg = dev->config;
-
-	LOG_DBG("eeprom: write done, val=0x%x", val);
-
-	/* In case EEPROM wants to be R/O, return !0 here could trigger
-	 * a NACK to the I2C controller, support depends on the
-	 * I2C controller support
-	 */
-
-	if (data->idx_write_cnt < (data->address_width >> 3)) {
-		if (data->idx_write_cnt == 0) {
-			data->buffer_idx = 0;
-		}
-
-		data->buffer_idx = val | (data->buffer_idx << 8);
-		data->idx_write_cnt++;
-	} else {
-		cfg->buffer[data->buffer_idx++] = val;
-		data->changed = true;
-	}
-
-	data->buffer_idx = data->buffer_idx % cfg->buffer_size;
-
-	return 0;
-}
-
-static int eeprom_target_read_processed(struct i2c_target_config *config,
-				       uint8_t *val)
-{
-	struct i2c_eeprom_target_data *data = CONTAINER_OF(config,
-						struct i2c_eeprom_target_data,
-						config);
-	const struct device *dev = data->dev;
-	const struct i2c_eeprom_target_config *cfg = dev->config;
-
-	/* Increment here */
-	data->buffer_idx = (data->buffer_idx + 1) % cfg->buffer_size;
-
-	*val = cfg->buffer[data->buffer_idx];
-
-	LOG_DBG("eeprom: read done, val=0x%x", *val);
-
-	/* Increment will be done in the next read_processed callback
-	 * In case of STOP, the byte won't be taken in account
-	 */
-
-	return 0;
-}
-
-static int eeprom_target_stop(struct i2c_target_config *config)
-{
-	struct i2c_eeprom_target_data *data = CONTAINER_OF(config,
-						struct i2c_eeprom_target_data,
-						config);
-	eeprom_target_changed_handler_t handler = data->changed_handler;
-
-	LOG_DBG("eeprom: stop");
-
-	data->idx_write_cnt = 0;
-
-	if (data->changed && handler != NULL) {
-		handler(data->dev, data->changed_handler_data);
-	}
-	data->changed = false;
-
-	return 0;
-}
-
-#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
-static void eeprom_target_buf_write_received(struct i2c_target_config *config,
-					     uint8_t *ptr, uint32_t len)
-{
-	struct i2c_eeprom_target_data *data = CONTAINER_OF(config,
-						struct i2c_eeprom_target_data,
-						config);
-	const struct device *dev = data->dev;
-	const struct i2c_eeprom_target_config *cfg = dev->config;
-
-	/* The first byte(s) is offset */
-	uint32_t idx_write_cnt = 0;
-
-	data->buffer_idx = 0;
-	while (idx_write_cnt < (data->address_width >> 3)) {
-		data->buffer_idx = (data->buffer_idx << 8) | *ptr++;
-		len--;
-		idx_write_cnt++;
-	}
-
-	if (len > 0) {
-		memcpy(&cfg->buffer[data->buffer_idx], ptr, len);
-		data->changed = true;
-	}
-}
-
-static int eeprom_target_buf_read_requested(struct i2c_target_config *config,
-					    uint8_t **ptr, uint32_t *len)
-{
-	struct i2c_eeprom_target_data *data = CONTAINER_OF(config,
-						struct i2c_eeprom_target_data,
-						config);
-	const struct device *dev = data->dev;
-	const struct i2c_eeprom_target_config *cfg = dev->config;
-
-	*ptr = &cfg->buffer[data->buffer_idx];
-	*len = cfg->buffer_size;
-
-	return 0;
-}
-#endif
-
-static int eeprom_target_register(const struct device *dev)
-{
-	const struct i2c_eeprom_target_config *cfg = dev->config;
-	struct i2c_eeprom_target_data *data = dev->data;
-
-	return i2c_target_register(cfg->bus.bus, &data->config);
-}
-
-static int eeprom_target_unregister(const struct device *dev)
-{
-	const struct i2c_eeprom_target_config *cfg = dev->config;
-	struct i2c_eeprom_target_data *data = dev->data;
-
-	return i2c_target_unregister(cfg->bus.bus, &data->config);
-}
-
-static DEVICE_API(i2c_target, api_funcs) = {
-	.driver_register = eeprom_target_register,
-	.driver_unregister = eeprom_target_unregister,
-};
-
-static const struct i2c_target_callbacks eeprom_callbacks = {
-	.write_requested = eeprom_target_write_requested,
-	.read_requested = eeprom_target_read_requested,
-	.write_received = eeprom_target_write_received,
-	.read_processed = eeprom_target_read_processed,
-#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
-	.buf_write_received = eeprom_target_buf_write_received,
-	.buf_read_requested = eeprom_target_buf_read_requested,
-#endif
-	.stop = eeprom_target_stop,
-};
-
 static int i2c_eeprom_target_init(const struct device *dev)
 {
-	struct i2c_eeprom_target_data *data = dev->data;
-	const struct i2c_eeprom_target_config *cfg = dev->config;
-
-	if (!device_is_ready(cfg->bus.bus)) {
-		LOG_ERR("I2C controller device not ready");
-		return -ENODEV;
-	}
-
-	data->dev = dev;
-	data->config.address = cfg->bus.addr;
-	data->config.callbacks = &eeprom_callbacks;
-
-	return 0;
+	return regset_target_lib_init(dev);
 }
 
-#define I2C_EEPROM_INIT(inst)						\
-	static struct i2c_eeprom_target_data				\
-		i2c_eeprom_target_##inst##_dev_data = {			\
-			.address_width = DT_INST_PROP_OR(inst,		\
-					address_width, 8),		\
-		};							\
-									\
-	static uint8_t							\
-	i2c_eeprom_target_##inst##_buffer[(DT_INST_PROP(inst, size))];	\
-									\
-	BUILD_ASSERT(DT_INST_PROP(inst, size) <=			\
-			(1 << DT_INST_PROP_OR(inst, address_width, 8)), \
-			"size must be <= than 2^address_width");	\
-									\
-	static const struct i2c_eeprom_target_config			\
-		i2c_eeprom_target_##inst##_cfg = {			\
-		.bus = I2C_DT_SPEC_INST_GET(inst),			\
-		.buffer_size = DT_INST_PROP(inst, size),		\
-		.buffer = i2c_eeprom_target_##inst##_buffer		\
-	};								\
-									\
-	DEVICE_DT_INST_DEFINE(inst,					\
-			    &i2c_eeprom_target_init,			\
-			    NULL,			\
-			    &i2c_eeprom_target_##inst##_dev_data,	\
-			    &i2c_eeprom_target_##inst##_cfg,		\
-			    POST_KERNEL,				\
-			    CONFIG_I2C_TARGET_INIT_PRIORITY,		\
-			    &api_funcs);
+#define I2C_EEPROM_INIT(inst)								\
+	REGSET_TARGET_LIB_DT_INST_BUILD_ASSERT(inst)					\
+											\
+	static struct i2c_eeprom_target_data i2c_eeprom_target_##inst##_dev_data;	\
+											\
+	static const struct i2c_eeprom_target_config i2c_eeprom_target_##inst##_cfg = {	\
+		.regset_cfg = REGSET_TARGET_LIB_DT_INST_CONFIG_INIT(inst),		\
+	};										\
+											\
+	DEVICE_DT_INST_DEFINE(inst, &i2c_eeprom_target_init, NULL,			\
+			      &i2c_eeprom_target_##inst##_dev_data,			\
+			      &i2c_eeprom_target_##inst##_cfg,				\
+			      POST_KERNEL, CONFIG_I2C_TARGET_INIT_PRIORITY,		\
+			      &regset_target_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_EEPROM_INIT)

--- a/drivers/i2c/target/regset_target_lib.c
+++ b/drivers/i2c/target/regset_target_lib.c
@@ -1,0 +1,265 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017 BayLibre, SAS
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/i2c/target/regset_target_lib.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(regset, CONFIG_I2C_LOG_LEVEL);
+
+void regset_target_lib_set_changed_callback(const struct device *dev,
+					    regset_target_lib_changed_handler_t handler,
+					    void *user_data)
+{
+	struct regset_target_lib_data *data = dev->data;
+
+	data->changed_handler = handler;
+	data->changed_handler_data = user_data;
+}
+
+size_t regset_target_lib_get_size(const struct device *dev)
+{
+	const struct regset_target_lib_config *cfg = dev->config;
+
+	return cfg->buffer_size;
+}
+
+int regset_target_lib_read_data(const struct device *dev, off_t offset,
+				void *data, size_t len)
+{
+	const struct regset_target_lib_config *cfg = dev->config;
+
+	if ((offset + len) > cfg->buffer_size) {
+		LOG_WRN("attempt to read past device boundary");
+		return -EINVAL;
+	}
+
+	memcpy(data, cfg->buffer + offset, len);
+	return 0;
+}
+
+int regset_target_lib_write_data(const struct device *dev, off_t offset,
+				 const void *data, size_t len)
+{
+	const struct regset_target_lib_config *cfg = dev->config;
+
+	if ((offset + len) > cfg->buffer_size) {
+		LOG_WRN("attempt to write past device boundary");
+		return -EINVAL;
+	}
+
+	memcpy(cfg->buffer + offset, data, len);
+	return 0;
+}
+
+int regset_target_lib_set_addr(const struct device *dev, uint8_t addr)
+{
+	const struct regset_target_lib_config *cfg = dev->config;
+	struct regset_target_lib_data *data = dev->data;
+	int ret;
+
+	ret = i2c_target_unregister(cfg->bus.bus, &data->config);
+	if (ret) {
+		LOG_DBG("i2c target failed to unregister");
+		return ret;
+	}
+
+	data->config.address = addr;
+
+	return i2c_target_register(cfg->bus.bus, &data->config);
+}
+
+static int regset_target_lib_write_requested(struct i2c_target_config *config)
+{
+	struct regset_target_lib_data *data = CONTAINER_OF(
+			config, struct regset_target_lib_data, config);
+
+	LOG_DBG("i2c target: write req");
+
+	data->idx_write_cnt = 0;
+
+	return 0;
+}
+
+static int regset_target_lib_read_requested(struct i2c_target_config *config,
+					     uint8_t *val)
+{
+	struct regset_target_lib_data *data = CONTAINER_OF(
+			config, struct regset_target_lib_data, config);
+	const struct device *dev = data->dev;
+	const struct regset_target_lib_config *cfg = dev->config;
+
+	*val = cfg->buffer[data->buffer_idx];
+
+	LOG_DBG("i2c target: read req, val=0x%x", *val);
+
+	/* Increment will be done in the read_processed callback */
+
+	return 0;
+}
+
+static int regset_target_lib_write_received(struct i2c_target_config *config,
+					    uint8_t val)
+{
+	struct regset_target_lib_data *data = CONTAINER_OF(
+			config, struct regset_target_lib_data, config);
+	const struct device *dev = data->dev;
+	const struct regset_target_lib_config *cfg = dev->config;
+
+	LOG_DBG("i2c target: write done, val=0x%x", val);
+
+	/* In case EEPROM wants to be R/O, return !0 here could trigger
+	 * a NACK to the I2C controller, support depends on the
+	 * I2C controller support
+	 */
+
+	if (data->idx_write_cnt < (cfg->address_width >> 3)) {
+		if (data->idx_write_cnt == 0) {
+			data->buffer_idx = 0;
+		}
+
+		data->buffer_idx = val | (data->buffer_idx << 8);
+		data->idx_write_cnt++;
+	} else {
+		cfg->buffer[data->buffer_idx++] = val;
+		data->changed = true;
+	}
+
+	data->buffer_idx = data->buffer_idx % cfg->buffer_size;
+
+	return 0;
+}
+
+static int regset_target_lib_read_processed(struct i2c_target_config *config,
+					    uint8_t *val)
+{
+	struct regset_target_lib_data *data = CONTAINER_OF(
+			config, struct regset_target_lib_data, config);
+	const struct device *dev = data->dev;
+	const struct regset_target_lib_config *cfg = dev->config;
+
+	/* Increment here */
+	data->buffer_idx = (data->buffer_idx + 1) % cfg->buffer_size;
+
+	*val = cfg->buffer[data->buffer_idx];
+
+	LOG_DBG("i2c target: read done, val=0x%x", *val);
+
+	/* Increment will be done in the next read_processed callback
+	 * In case of STOP, the byte won't be taken in account
+	 */
+
+	return 0;
+}
+
+static int regset_target_lib_stop(struct i2c_target_config *config)
+{
+	struct regset_target_lib_data *data = CONTAINER_OF(
+			config, struct regset_target_lib_data, config);
+	regset_target_lib_changed_handler_t handler = data->changed_handler;
+
+	LOG_DBG("i2c target: stop");
+
+	data->idx_write_cnt = 0;
+
+	if (data->changed && handler != NULL) {
+		handler(data->dev, data->changed_handler_data);
+	}
+	data->changed = false;
+
+	return 0;
+}
+
+#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
+static void regset_target_lib_buf_write_received(struct i2c_target_config *config,
+						 uint8_t *ptr, uint32_t len)
+{
+	struct regset_target_lib_data *data = CONTAINER_OF(
+			config, struct regset_target_lib_data, config);
+	const struct device *dev = data->dev;
+	const struct regset_target_lib_config *cfg = dev->config;
+
+	/* The first byte(s) is offset */
+	uint32_t idx_write_cnt = 0;
+
+	data->buffer_idx = 0;
+	while (idx_write_cnt < (cfg->address_width >> 3)) {
+		data->buffer_idx = (data->buffer_idx << 8) | *ptr++;
+		len--;
+		idx_write_cnt++;
+	}
+
+	if (len > 0) {
+		memcpy(&cfg->buffer[data->buffer_idx], ptr, len);
+		data->changed = true;
+	}
+}
+
+static int regset_target_lib_buf_read_requested(struct i2c_target_config *config,
+						uint8_t **ptr, uint32_t *len)
+{
+	struct regset_target_lib_data *data = CONTAINER_OF(
+			config, struct regset_target_lib_data, config);
+	const struct device *dev = data->dev;
+	const struct regset_target_lib_config *cfg = dev->config;
+
+	*ptr = &cfg->buffer[data->buffer_idx];
+	*len = cfg->buffer_size;
+
+	return 0;
+}
+#endif
+
+static int regset_target_lib_register(const struct device *dev)
+{
+	const struct regset_target_lib_config *cfg = dev->config;
+	struct regset_target_lib_data *data = dev->data;
+
+	return i2c_target_register(cfg->bus.bus, &data->config);
+}
+
+static int regset_target_lib_unregister(const struct device *dev)
+{
+	const struct regset_target_lib_config *cfg = dev->config;
+	struct regset_target_lib_data *data = dev->data;
+
+	return i2c_target_unregister(cfg->bus.bus, &data->config);
+}
+
+static const struct i2c_target_callbacks regset_target_lib_callbacks = {
+	.write_requested = regset_target_lib_write_requested,
+	.read_requested = regset_target_lib_read_requested,
+	.write_received = regset_target_lib_write_received,
+	.read_processed = regset_target_lib_read_processed,
+#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
+	.buf_write_received = regset_target_lib_buf_write_received,
+	.buf_read_requested = regset_target_lib_buf_read_requested,
+#endif
+	.stop = regset_target_lib_stop,
+};
+
+DEVICE_API(i2c_target, regset_target_api) = {
+	.driver_register = regset_target_lib_register,
+	.driver_unregister = regset_target_lib_unregister,
+};
+
+int regset_target_lib_init(const struct device *dev)
+{
+	struct regset_target_lib_data *data = dev->data;
+	const struct regset_target_lib_config *cfg = dev->config;
+
+	if (!device_is_ready(cfg->bus.bus)) {
+		LOG_ERR("I2C controller device not ready");
+		return -ENODEV;
+	}
+
+	data->dev = dev;
+	data->config.address = cfg->bus.addr;
+	data->config.callbacks = &regset_target_lib_callbacks;
+
+	return 0;
+}

--- a/drivers/i2c/target/tmp103_target.c
+++ b/drivers/i2c/target/tmp103_target.c
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT zephyr_i2c_target_tmp103
+
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/i2c/target/regset_target_lib.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/minmax.h>
+
+LOG_MODULE_REGISTER(i2c_tmp103, CONFIG_I2C_LOG_LEVEL);
+
+struct tmp103_target_data {
+	struct regset_target_lib_data regset_data;
+	const struct device *dev;
+	struct k_work_delayable dwork;
+};
+
+struct tmp103_target_config {
+	struct regset_target_lib_config regset_cfg;
+	const struct device *sensor_dev;
+};
+
+REGSET_TARGET_LIB_STRUCT_CHECK(struct tmp103_target_config,
+			       struct tmp103_target_data);
+
+static void tmp103_work_handler(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct tmp103_target_data *data = CONTAINER_OF(dwork, struct tmp103_target_data, dwork);
+	const struct device *dev = data->dev;
+	const struct tmp103_target_config *cfg = dev->config;
+	struct sensor_value val;
+	int ret;
+
+	if (cfg->sensor_dev == NULL) {
+		LOG_ERR("No sensor configured");
+		return;
+	}
+
+	ret = sensor_sample_fetch_chan(cfg->sensor_dev, SENSOR_CHAN_DIE_TEMP);
+	if (ret < 0) {
+		LOG_ERR("sample_fetch error: %d", ret);
+		return;
+	}
+
+	ret = sensor_channel_get(cfg->sensor_dev, SENSOR_CHAN_DIE_TEMP, &val);
+	if (ret < 0) {
+		LOG_ERR("channel_get error: %d", ret);
+		return;
+	}
+
+	LOG_DBG("temp: %d", val.val1);
+
+	int8_t temp_c = clamp(val.val1, 0, UINT8_MAX);
+
+	regset_target_lib_write_data(dev, 0, &temp_c, sizeof(temp_c));
+
+	k_work_schedule(&data->dwork, K_MSEC(500));
+}
+
+static void tmp103_change_cb(const struct device *dev, void *user_data)
+{
+	int8_t regs[4];
+
+	regset_target_lib_read_data(dev, 0, regs, sizeof(regs));
+
+	LOG_INF("Temp: %d Config: 0x%02x Thigh: %d Tlow: %d",
+		regs[0], regs[1], regs[2], regs[3]);
+}
+
+static int tmp103_target_init(const struct device *dev)
+{
+	const struct tmp103_target_config *cfg = dev->config;
+	struct tmp103_target_data *data = dev->data;
+
+	data->dev = dev;
+
+	if (cfg->sensor_dev != NULL && !device_is_ready(cfg->sensor_dev)) {
+		LOG_ERR_DEVICE_NOT_READY(cfg->sensor_dev);
+		return -ENODEV;
+	}
+
+	regset_target_lib_set_changed_callback(dev, tmp103_change_cb, NULL);
+
+	k_work_init_delayable(&data->dwork, tmp103_work_handler);
+
+	if (cfg->sensor_dev != NULL) {
+		k_work_schedule(&data->dwork, K_MSEC(500));
+	}
+
+	return regset_target_lib_init(dev);
+}
+
+#define I2C_TMP103_INIT(inst)								\
+	REGSET_TARGET_LIB_DT_INST_BUILD_ASSERT(inst)					\
+											\
+	static struct tmp103_target_data tmp103_target_##inst##_dev_data;		\
+											\
+	static const struct tmp103_target_config tmp103_target_##inst##_cfg = {		\
+		.regset_cfg = REGSET_TARGET_LIB_DT_INST_CONFIG_INIT(inst),		\
+		.sensor_dev = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(inst, sensor)),	\
+	};										\
+											\
+	DEVICE_DT_INST_DEFINE(inst, &tmp103_target_init, NULL,				\
+			      &tmp103_target_##inst##_dev_data,				\
+			      &tmp103_target_##inst##_cfg,				\
+			      POST_KERNEL, CONFIG_I2C_TARGET_INIT_PRIORITY,		\
+			      &regset_target_api);
+
+DT_INST_FOREACH_STATUS_OKAY(I2C_TMP103_INIT)

--- a/dts/bindings/i2c/regset-target-base.yaml
+++ b/dts/bindings/i2c/regset-target-base.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+include: [base.yaml, i2c-device.yaml]
+
+properties:
+  size:
+    type: int
+    description: Total register size in bytes
+
+  address-width:
+    type: int
+    enum: [8, 16]
+    description: |
+      Number of address bits used to address the EEPROM. If not specified
+      the EEPROM is assumed to have a 8-bit address.

--- a/dts/bindings/i2c/zephyr,i2c-target-tmp103.yaml
+++ b/dts/bindings/i2c/zephyr,i2c-target-tmp103.yaml
@@ -1,0 +1,32 @@
+description: |
+  Zephyr I2C target TMP103
+
+  Creates an I2C target device that mimics a TMP103 temperature sensor,
+  optionally backed by a real temperature sensor implementing the
+  SENSOR_CHAN_DIE_TEMP channel.
+
+  Can be used by a Linux host with the tmp103 driver.
+
+compatible: "zephyr,i2c-target-tmp103"
+
+include: regset-target-base.yaml
+
+properties:
+  size:
+    min: 4
+    max: 4
+    default: 4
+
+  sensor:
+    type: phandle
+    description: Sensor device to use as data source.
+
+examples:
+  - |
+    zephyr_i2c: &i2c2 {
+            tmp103: tmp103@30 {
+                    reg = <0x30>;
+                    compatible = "zephyr,i2c-target-tmp103";
+                    sensor = <&die_temp>;
+            };
+    };

--- a/dts/bindings/mtd/zephyr,i2c-target-eeprom.yaml
+++ b/dts/bindings/mtd/zephyr,i2c-target-eeprom.yaml
@@ -4,12 +4,4 @@ description: Zephyr I2C target EEPROM
 
 compatible: "zephyr,i2c-target-eeprom"
 
-include: ["eeprom-base.yaml", i2c-device.yaml]
-
-properties:
-  address-width:
-    type: int
-    enum: [8, 16]
-    description: |
-      Number of address bits used to address the EEPROM. If not specified
-      the EEPROM is assumed to have a 8-bit address.
+include: regset-target-base.yaml

--- a/include/zephyr/drivers/i2c/target/regset_target_lib.h
+++ b/include/zephyr/drivers/i2c/target/regset_target_lib.h
@@ -1,0 +1,172 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017 BayLibre, SAS
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Public APIs for the I2C target library.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_I2C_TARGET_REGSET_TARGET_LIB_H_
+#define ZEPHYR_INCLUDE_DRIVERS_I2C_TARGET_REGSET_TARGET_LIB_H_
+
+#include <stddef.h>
+#include <sys/types.h>
+
+/**
+ * @brief Define the application callback handler function signature
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param user_data Optional user data provided when callback is set.
+ */
+typedef void (*regset_target_lib_changed_handler_t)(const struct device *dev, void *user_data);
+
+/**
+ * @brief Register set library config
+ *
+ * This structure **must** be placed first in the driver's config structure.
+ */
+struct regset_target_lib_data {
+	/** @cond INTERNAL_HIDDEN */
+	const struct device *dev;
+	struct i2c_target_config config;
+	uint32_t buffer_idx;
+	uint32_t idx_write_cnt;
+	regset_target_lib_changed_handler_t changed_handler;
+	void *changed_handler_data;
+	bool changed;
+	/** @endcond */
+};
+
+/**
+ * @brief Register set library data
+ *
+ * This structure **must** be placed first in the driver's config structure.
+ */
+struct regset_target_lib_config {
+	/** @cond INTERNAL_HIDDEN */
+	struct i2c_dt_spec bus;
+	uint32_t buffer_size;
+	uint8_t *buffer;
+	uint8_t address_width;
+	/** @endcond */
+};
+
+/**
+ * @brief Set the regset changed callback handler
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param handler Handler to call on regset changes
+ * @param user_data Optional user data passed to callback
+ */
+void regset_target_lib_set_changed_callback(const struct device *dev,
+					    regset_target_lib_changed_handler_t handler,
+					    void *user_data);
+
+/**
+ * @brief Get size of the register set
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @return Size of register set in bytes
+ */
+size_t regset_target_lib_get_size(const struct device *dev);
+
+/**
+ * @brief Read data from the register set
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param offset Address offset to read from.
+ * @param data Buffer to store read data.
+ * @param len Number of bytes to read.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int regset_target_lib_read_data(const struct device *dev, off_t offset,
+				void *data, size_t len);
+
+/**
+ * @brief Write data to the register set
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param offset Address offset to write data to.
+ * @param data Buffer with data to write.
+ * @param len Number of bytes to write.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int regset_target_lib_write_data(const struct device *dev, off_t offset,
+				 const void *data, size_t len);
+
+/**
+ * @brief Change the address of register set target at runtime
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param addr New address to assign to the register set target device
+ *
+ * @retval 0 Is successful
+ * @retval -EINVAL If parameters are invalid
+ * @retval -EIO General input / output error during i2c_taget_register
+ * @retval -ENOSYS If target mode is not implemented
+ */
+int regset_target_lib_set_addr(const struct device *dev, uint8_t addr);
+
+/**
+ * @brief Generig register set library i2c target API
+ */
+extern const struct i2c_target_driver_api regset_target_api;
+
+/**
+ * @brief Initialize the register set data structures
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @return 0 on success, negative errno code on failure.
+ */
+int regset_target_lib_init(const struct device *dev);
+
+/**
+ * @brief Validate the offset of the regset data structures.
+ *
+ * @param config Name of the config structure.
+ * @param data Name of the data structure.
+ */
+#define REGSET_TARGET_LIB_STRUCT_CHECK(config, data)				\
+	BUILD_ASSERT(offsetof(config, regset_cfg) == 0,				\
+		     "struct regset_target_lib_config must be placed first");	\
+	BUILD_ASSERT(offsetof(data, regset_data) == 0,				\
+		     "struct regset_target_lib_data must be placed first")
+
+/**
+ * @brief Validate the node properties from devicetree
+ */
+#define REGSET_TARGET_LIB_DT_BUILD_ASSERT(node_id)						\
+	BUILD_ASSERT(DT_PROP(node_id, size) <= (1 << DT_PROP_OR(node_id, address_width, 8)),	\
+		     "size must be <= than 2^address_width");
+
+/**
+ * @brief Validate the node properties from a devicetree instance
+ */
+#define REGSET_TARGET_LIB_DT_INST_BUILD_ASSERT(inst)		\
+	REGSET_TARGET_LIB_DT_BUILD_ASSERT(DT_DRV_INST(inst))
+
+/**
+ * @brief Define the common data structure from devicetree
+ */
+#define REGSET_TARGET_LIB_DT_CONFIG_INIT(node_id)		\
+{								\
+	.bus = I2C_DT_SPEC_GET(node_id),			\
+	.buffer_size = DT_PROP(node_id, size),			\
+	.buffer = (uint8_t[DT_PROP(node_id, size)]) {},		\
+	.address_width = DT_PROP_OR(node_id, address_width, 8),	\
+}
+
+/**
+ * @brief Define the common data structure from a devicetree instance
+ */
+#define REGSET_TARGET_LIB_DT_INST_CONFIG_INIT(inst) \
+	REGSET_TARGET_LIB_DT_CONFIG_INIT(DT_DRV_INST(inst))
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_I2C_TARGET_REGSET_TARGET_LIB_H_ */

--- a/tests/drivers/build_all/i2c/boards/qemu_cortex_m3.overlay
+++ b/tests/drivers/build_all/i2c/boards/qemu_cortex_m3.overlay
@@ -14,6 +14,17 @@
 		reg = <0x88888888 0x10000>;
 		interrupt-parent = <&nvic>;
 		interrupts = <4 1>;
+
+		eeprom@0 {
+			reg = <0x0>;
+			size = <32>;
+			compatible = "zephyr,i2c-target-eeprom";
+		};
+
+		tmp103@1 {
+			reg = <0x1>;
+			compatible = "zephyr,i2c-target-tmp103";
+		};
 	};
 
 	i2c1: i2c@88898888 {


### PR DESCRIPTION
Refactor the core eeprom target code in a reusable library, use in the original eeprom driver (which is seamless for existing users) and add a new tmp103 driver.