### PR TITLE
drivers: display: advertise support for callback events via capabilities

### DIFF
--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -344,6 +344,8 @@ static void mcux_elcdif_get_capabilities(const struct device *dev,
 	capabilities->supported_pixel_formats = supported_fmts;
 	capabilities->current_pixel_format = ((struct mcux_elcdif_data *)dev->data)->pixel_format;
 	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+	capabilities->supported_events =
+		DISPLAY_EVENT_FRAME_DONE | DISPLAY_EVENT_VSYNC | DISPLAY_EVENT_FIFO_UNDERFLOW;
 }
 
 static int mcux_elcdif_register_event_cb(const struct device *dev, display_event_cb_t cb,
@@ -351,8 +353,6 @@ static int mcux_elcdif_register_event_cb(const struct device *dev, display_event
 					 uint32_t *out_reg_handle)
 {
 	struct mcux_elcdif_data *dev_data = dev->data;
-	const uint32_t supported_events =
-		DISPLAY_EVENT_FRAME_DONE | DISPLAY_EVENT_VSYNC | DISPLAY_EVENT_FIFO_UNDERFLOW;
 
 	k_sem_take(&dev_data->cb_sem, K_FOREVER);
 
@@ -368,11 +368,6 @@ static int mcux_elcdif_register_event_cb(const struct device *dev, display_event
 	}
 	if (!in_isr) {
 		LOG_ERR("Registration failed: only ISR context is supported for this driver");
-		k_sem_give(&dev_data->cb_sem);
-		return -ENOTSUP;
-	}
-	if (event_mask & ~supported_events) {
-		LOG_ERR("Registration failed: unsupported event supplied");
 		k_sem_give(&dev_data->cb_sem);
 		return -ENOTSUP;
 	}

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -238,6 +238,7 @@ static void stm32_ltdc_get_capabilities(const struct device *dev,
 
 	capabilities->current_pixel_format = data->current_pixel_format;
 	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+	capabilities->supported_events = DISPLAY_EVENT_VSYNC | DISPLAY_EVENT_LINE_INT;
 }
 
 static void stm32_ltdc_partial_write(const struct device *dev,
@@ -466,10 +467,6 @@ static int stm32_ltdc_display_register_event_cb(const struct device *dev, displa
 	}
 	if (!in_isr) {
 		LOG_ERR("Registration failed: only ISR context is supported for this driver");
-		return -ENOSYS;
-	}
-	if (event_mask & ~(DISPLAY_EVENT_VSYNC | DISPLAY_EVENT_LINE_INT)) {
-		LOG_ERR("Registration failed: Unsupported event requested");
 		return -ENOSYS;
 	}
 

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -340,6 +340,8 @@ struct display_capabilities {
 	enum display_pixel_format current_pixel_format;
 	/** Current display orientation */
 	enum display_orientation current_orientation;
+	/** Supported callback events mask, 0 when event callback unsupported */
+	uint32_t supported_events;
 #if defined(CONFIG_DISPLAY_COLOR_PALETTE) || defined(__DOXYGEN__)
 	/** Color palette supported by the display, indexed by pixel value */
 	struct display_palette_color color_palette[CONFIG_DISPLAY_COLOR_PALETTE_MAX_SIZE];
@@ -774,6 +776,8 @@ static inline void display_get_capabilities(const struct device *dev,
 					    struct display_capabilities *
 					    capabilities)
 {
+	__ASSERT(capabilities != NULL, "display_capabilities struct is NULL");
+	memset(capabilities, 0, sizeof(struct display_capabilities));
 	DEVICE_API_GET(display, dev)->get_capabilities(dev, capabilities);
 }
 
@@ -841,8 +845,7 @@ static inline int display_set_orientation(const struct device *dev,
  *
  * @return 0 and a non-zero out_reg_handle value on success, otherwise a negative errno code.
  * @retval -EBUSY A callback is already registered.
- * @retval -ENOTSUP One of the events is not supported,
- * or the requested invocation context is not supported.
+ * @retval -ENOTSUP The requested callback invocation context is not supported.
  * @retval -ENOSYS Not implemented.
  * @retval -EINVAL Invalid argument.
  */
@@ -854,9 +857,18 @@ static inline int display_register_event_cb(const struct device *dev,
 	__ASSERT(cb != NULL, "Registration failed: callback function pointer is NULL");
 
 	const struct display_driver_api *api = DEVICE_API_GET(display, dev);
+	struct display_capabilities caps;
 
 	if (api->register_event_cb == NULL) {
 		return -ENOSYS;
+	}
+
+	api->get_capabilities(dev, &caps);
+	if (!caps.supported_events) {
+		return -ENOSYS;
+	}
+	if (event_mask == 0 || (~caps.supported_events & event_mask)) {
+		return -EINVAL;
 	}
 
 	return api->register_event_cb(dev, cb, user_data, event_mask, in_isr, out_reg_handle);

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -340,6 +340,8 @@ struct display_capabilities {
 	enum display_pixel_format current_pixel_format;
 	/** Current display orientation */
 	enum display_orientation current_orientation;
+	/** Supported callback events mask, 0 when callbacks are unsupported */
+	uint32_t supported_events;
 #if defined(CONFIG_DISPLAY_COLOR_PALETTE) || defined(__DOXYGEN__)
 	/** Color palette supported by the display, indexed by pixel value */
 	struct display_palette_color color_palette[CONFIG_DISPLAY_COLOR_PALETTE_MAX_SIZE];
@@ -850,9 +852,15 @@ static inline int display_register_event_cb(const struct device *dev,
 	__ASSERT(cb != NULL, "Registration failed: callback function pointer is NULL");
 
 	const struct display_driver_api *api = DEVICE_API_GET(display, dev);
+	struct display_capabilities capas;
 
 	if (api->register_event_cb == NULL) {
 		return -ENOSYS;
+	}
+
+	api->get_capabilities(dev, &capas);
+	if (~capas.supported_events & event_mask) {
+		return -ENOTSUP;
 	}
 
 	return api->register_event_cb(dev, cb, user_data, event_mask, in_isr, out_reg_handle);


### PR DESCRIPTION
Advertise support for callback events via capabilities->supported_events returned by display_get_capabilities() API.
Also consider a wrong events mask as an invalid argument and return `-EINVAL`.
Now `-ENOTSUP` is only returned upon unsupported callback invocation context.

The new `capabilities->supported_events` field is used to enhance the `tests/drivers/display/display_callbacks` test in #117257 and better test the callback API.