### PR TITLE
ptp: announce messages must advertise logAnnounceInterval

### DIFF
--- a/subsys/net/lib/ptp/port.c
+++ b/subsys/net/lib/ptp/port.c
@@ -590,7 +590,7 @@ static int port_announce_msg_transmit(struct ptp_port *port)
 	msg->header.flags[1]	      = tpds->flags;
 	msg->header.src_port_id	      = port->port_ds.id;
 	msg->header.sequence_id	      = port->seq_id.announce++;
-	msg->header.log_msg_interval  = port->port_ds.log_sync_interval;
+	msg->header.log_msg_interval  = port->port_ds.log_announce_interval;
 
 	msg->announce.current_utc_offset = tpds->current_utc_offset;
 	msg->announce.gm_priority1	 = pds->gm_priority1;


### PR DESCRIPTION
port_announce_msg_transmit() filled the announce headers logMessageInterval with logSyncInterval. Receivers size their foreign-time-transmitter qualification window from the advertised announce interval (IEEE 1588-2019 9.3.2.4.4: 4 * announceInterval), so any clock whose sync interval is shorter than its announce interval (e.g. AES67: sync -3, announce 1) could never qualify. Verified against ptp4l.