### PR TITLE
drivers: wifi: esp32: restore STA state on synchronous connect errors

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -1213,6 +1213,7 @@ static int esp32_wifi_connect(const struct device *dev __unused, struct net_if *
 		ret = esp_wifi_sta_enterprise_disable();
 		if (ret != ESP_OK) {
 			LOG_ERR("Failed to disable Enterprise authentication (%d)", ret);
+			data->state = ESP32_STA_STARTED;
 			return -EIO;
 		}
 	}
@@ -1278,6 +1279,7 @@ static int esp32_wifi_connect(const struct device *dev __unused, struct net_if *
 #else
 		LOG_ERR("WPA3 not supported for STA mode. Enable "
 			"CONFIG_ESP32_WIFI_ENABLE_WPA3_SAE");
+		data->state = ESP32_STA_STARTED;
 		return -EINVAL;
 #endif /* CONFIG_ESP32_WIFI_ENABLE_WPA3_SAE */
 	case WIFI_SECURITY_TYPE_EAP_TLS:
@@ -1288,16 +1290,19 @@ static int esp32_wifi_connect(const struct device *dev __unused, struct net_if *
 #if defined(CONFIG_ESP32_WIFI_ENTERPRISE)
 		ret = esp32_wifi_configure_enterprise(data, params, &wifi_config);
 		if (ret) {
+			data->state = ESP32_STA_STARTED;
 			return ret;
 		}
 		break;
 #else
 		LOG_ERR("WPA Enterprise not supported for STA mode. Enable "
 			"CONFIG_ESP32_WIFI_ENTERPRISE");
+		data->state = ESP32_STA_STARTED;
 		return -EINVAL;
 #endif /* CONFIG_ESP32_WIFI_ENTERPRISE */
 	default:
 		LOG_ERR("Authentication method not supported");
+		data->state = ESP32_STA_STARTED;
 		return -EIO;
 	}
 
@@ -1312,12 +1317,14 @@ static int esp32_wifi_connect(const struct device *dev __unused, struct net_if *
 	ret = esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config);
 	if (ret) {
 		LOG_ERR("Failed to set Wi-Fi configuration (%d)", ret);
+		data->state = ESP32_STA_STARTED;
 		return -EINVAL;
 	}
 
 	ret = esp_wifi_connect();
 	if (ret) {
 		LOG_ERR("Failed to connect to Wi-Fi access point (%d)", ret);
+		data->state = ESP32_STA_STARTED;
 		return -EAGAIN;
 	}
 


### PR DESCRIPTION
## Description

`esp32_wifi_connect()` sets `data->state = ESP32_STA_CONNECTING` before validating the security parameters and before the synchronous calls into the ESP Wi-Fi library. Every synchronous error return after that point leaves the state at CONNECTING: the entry gate then rejects all subsequent connect attempts with `-EALREADY`, and since no connection was ever initiated, no Wi-Fi event will arrive to reset the state. One failed connect — unsupported security mode, enterprise configuration failure, `esp_wifi_set_config()` or `esp_wifi_connect()` error — permanently wedges the interface until reboot.

This PR restores `ESP32_STA_STARTED` on all synchronous error paths so the driver is ready for the next attempt.

## Field observation

On ESP32-C6, a provisioning request carrying an SAE security mode on a build without `CONFIG_ESP32_WIFI_ENABLE_WPA3_SAE` returned `-EINVAL` once, after which the interface could never reconnect without a power cycle (every attempt returned `-EALREADY`).

## Testing

The same fix has been carried as a downstream patch on v4.3.1 and v4.4.1 and validated on ESP32-C6 hardware: forcing a synchronous connect error (SAE attempt without WPA3 support) previously wedged Wi-Fi permanently; with the fix, the application's reconnect logic recovers on its next attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)