### PR TITLE
drivers: clock_control: esp32: fix ESP32-C6 boot hang after SW reset

### DIFF
--- a/drivers/clock_control/clock_control_esp32_pmu.c
+++ b/drivers/clock_control/clock_control_esp32_pmu.c
@@ -276,12 +276,20 @@ int esp32_cpu_clock_configure(const struct esp32_cpu_clock_config *cpu_cfg)
 	if (cpu_cfg->clk_src == SOC_CPU_CLK_SRC_PLL) {
 		clk_ll_mspi_fast_set_hs_divider(6);
 		/*
-		 * The I2C analog master may be clocked from 160MHz PLL.
-		 * If PLL was disabled, that clock is dead and REGI2C
-		 * writes will hang. Switch to XTAL-based clock before
-		 * re-enabling PLL, then restore 160MHz after PLL is up.
+		 * Use the PLL-derived I2C analog master clock, like the IDF
+		 * bootloader (bootloader_hardware_init()): on the C6 the
+		 * BBPLL is alive on every boot path, since the ROM needs it
+		 * for USB-Serial-JTAG and esp_restart() deliberately keeps
+		 * it running. The XTAL-side source (sel_160m = 0) is routed
+		 * through modem_lpcon state that
+		 * esp_system_reset_modules_on_exit() resets at shutdown and
+		 * the ROM's soft-boot path does not restore, so after a
+		 * software reset the BBPLL calibration in
+		 * rtc_clk_bbpll_configure() polls a clockless status
+		 * register forever (pre-console boot hang until power
+		 * cycle).
 		 */
-		MODEM_LPCON.i2c_mst_clk_conf.clk_i2c_mst_sel_160m = 0;
+		regi2c_ctrl_ll_master_configure_clock();
 	}
 #endif
 


### PR DESCRIPTION
## Description

On ESP32-C6, `esp32_cpu_clock_configure()` switches the analog I2C master to the `sel_160m = 0` clock source before enabling the BBPLL. That source is routed through modem_lpcon state which `esp_system_reset_modules_on_exit()` resets at shutdown and which the ROM's soft-boot path does not restore (the full power-on path does). After any **software reset** — including the reboot every MCUboot-based application performs to install a firmware update — the BBPLL calibration in `rtc_clk_bbpll_configure()` then spins forever on `regi2c_ctrl_ll_bbpll_calibration_is_done()`, reading a clockless register: the chip hangs pre-console until power is cycled, while its USB device stays enumerated. **Power-on boots are unaffected**, which makes this easy to miss in bring-up testing but devastating in the field (a fleet OTA bricks every device until manual power cycle).

The fix selects the PLL-derived I2C master clock instead, exactly like the IDF second-stage bootloader does on every boot (`bootloader_esp32c6.c`, `bootloader_hardware_init()`: *"keep ana i2c mst clock always enabled in bootloader"* + `regi2c_ctrl_ll_master_configure_clock()`). On the C6 the BBPLL is alive on every boot path: the ROM requires it for USB-Serial-JTAG, and `esp_restart()` deliberately keeps it running (see the comment in `esp_restart_noos()`).

## How it was found

Field devices (MCUboot + Zephyr application, USB-Serial-JTAG console) hung on every OTA install reboot. Early-boot breadcrumb instrumentation localized the hang to the exact call sequence:

```
hardware_init() done → clock_control_esp32_init → esp_rtc_init done
→ esp32_cpu_clock_configure: old config XTAL/40 → switching to PLL/160
→ rtc_clk_cpu_freq_set_config → rtc_clk_bbpll_configure → (spins forever)
```

## Testing

Validated on ESP32-C6 hardware (v4.4.1 code base; the affected code is identical on main): before the fix, every `kernel reboot cold` and every OTA install reboot hung in the MCUboot image right after bootloader flash init. With the fix, consecutive software resets and a complete OTA install cycle (download → verify → request upgrade → SW reset → MCUboot install → boot) run cleanly, and power-on behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)