### PR TITLE
scripts: west_commands: patch: Add ability to reverse patches

### DIFF
--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -407,6 +407,7 @@ There are several sub-commands available to manage patches for Zephyr or other m
 workspace:
 
 * ``apply``: apply patches listed in ``patches.yml``
+* ``reverse``: reverse patches listed in ``patches.yml`` that have been previously applied
 * ``clean``: remove all patches that have been applied, and reset to the manifest checkout state
 * ``list``: list all patches in ``patches.yml``
 * ``gh-fetch``: fetch patches from a GitHub pull request
@@ -481,6 +482,15 @@ the external application repository, and then the following commands can be run.
     west patch clean
     west update
     west patch apply --roll-back # roll-back all patches if one does not apply cleanly
+
+Optionally, patches can be reversed rather than cleaning all modules. This leaves non-conflicting,
+unrelated edits to modules in place, but removes only the changes made by patches. This is useful
+when developing patches and testing them in an application, but not wanting to clean all patches
+and lose any manual edits made to the module.
+
+.. code-block:: bash
+
+    west patch reverse
 
 If a patch needs to be reworked, remember to update the ``patches.yml`` file with the new SHA256
 checksum.

--- a/scripts/schemas/patch-schema.yml
+++ b/scripts/schemas/patch-schema.yml
@@ -84,6 +84,23 @@ schema;patch-schema:
           type: str
           default: "git apply"
 
+        # This command is used to guess whether the patch was already applied.
+        # This may also be replaced with a no-op command if so desired to skip the check.
+        reverse-test-command:
+          type: str
+          default: "git apply --reverse --check"
+
+        # The command used to reverse the change represented by the patch
+        reverse-command:
+          type: str
+          default: "git apply --reverse"
+
+        # This command is used to guess whether the patch was already reversed (or never applied).
+        # This may also be replaced with a no-op command if so desired to skip the check.
+        apply-test-command:
+          type: str
+          default: "git apply --check"
+
         # Comments useful to other developers about the patch,
         # e.g. "This is a workaround for xyz and probably should not go upstream"
         comments:

--- a/scripts/west_commands/patch.py
+++ b/scripts/west_commands/patch.py
@@ -56,6 +56,11 @@ class Patch(WestCommand):
                 Run "west patch apply" to apply patches.
                 See "west patch apply --help" for details.
 
+            Reversing Patches:
+
+                Run "west patch reverse" to reverse patches.
+                See "west patch reverse --help" for details.
+
             Cleaning Patches:
 
                 Run "west patch clean" to clean patches.
@@ -170,9 +175,27 @@ class Patch(WestCommand):
         apply_arg_parser.add_argument(
             "-r",
             "--roll-back",
-            help="Roll back if any patch fails to apply",
             action="store_true",
             default=False,
+            help="""
+                clean all changes from patched modules if a patch fails to apply.
+                All changes in the module will be lost, including changes that
+                are not part of any patch.""",
+        )
+
+        subparsers.add_parser(
+            "reverse",
+            help="Reverse patches",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=textwrap.dedent(
+                """
+            Reversing Patches:
+
+                Run "west patch reverse" to reverse patches. Changes in the module
+                that are not part of a patch will be left in place. Patches are
+                processed in reverse order of apply.
+            """
+            ),
         )
 
         subparsers.add_parser(
@@ -183,7 +206,9 @@ class Patch(WestCommand):
                 """
             Cleaning Patches:
 
-                Run "west patch clean" to clean patches.
+                Run "west patch clean" to clean patches. All changes in the
+                module will be lost, including changes that are not part of
+                a patch.
             """
             ),
         )
@@ -334,6 +359,7 @@ class Patch(WestCommand):
 
         method = {
             "apply": self.apply,
+            "reverse": self.reverse,
             "clean": self.clean,
             "list": self.list,
             "gh-fetch": self.gh_fetch,
@@ -341,16 +367,87 @@ class Patch(WestCommand):
 
         method[args.subcommand](args, yml, args.dst_modules)
 
-    def apply(self, args, yml, dst_mods=None):
+    def execute_on_patch(self, args, patch_info, command, squelch_errors=False):
+        """
+        Execute an arbitrary command given the patch information.
+
+        Arguments:
+            - args: Patch command arguments
+            - patch_info: Patch information from the patches.yml file
+            - command: Command to execute (e.g. "git apply")
+
+        Returns:
+            - True: The command executed successfully
+            - False: The command failed to execute, or the hash check failed
+        """
+        mod = self.get_module_path(patch_info["module"])
+        if mod is None:
+            return False
+
+        mod_path = Path(args.west_workspace) / mod
+
+        pth = patch_info["path"]
+        patch_path = Path(args.patch_base / pth).resolve()
+
+        self.dbg(f"reading patch file {pth}")
+        expect_sha256 = patch_info["sha256sum"]
+        try:
+            actual_sha256 = self.get_file_sha256sum(patch_path)
+        except OSError as e:
+            self.die(f"failed to read {pth}: {e}")
+
+        if actual_sha256 != expect_sha256:
+            self.dbg("FAIL")
+            self.err(
+                f"sha256 mismatch for {pth}:\n"
+                f"expect: {expect_sha256}\n"
+                f"actual: {actual_sha256}"
+            )
+            return False
+        self.dbg("OK")
+
+        self.dbg(f"executing '{command}' for patch {pth} in module {mod}... ")
+        command_list = shlex.split(command)
+        command_list.append(patch_path)
+        proc = subprocess.run(
+            command_list, capture_output=True, cwd=mod_path, encoding="utf-8"
+        )
+        if proc.returncode:
+            if not squelch_errors:
+                self.err(f"Unable to execute '{command}' for patch {pth} in module {mod}")
+                self.err(proc.stderr)
+            return False
+
+        self.dbg("OK")
+        return True
+
+    def patch(self, args, yml, patch_cmd, test_cmd,
+              reverse_order=False, dst_mods=None):
+        """
+        Execute a patching command for all patches in the patches.yml file.
+
+        Arguments:
+            - args: Patch command arguments
+            - yml: Parsed patches.yml file
+            - patch_cmd: Command tag in the yml file to execute for patching (e.g. "apply-command")
+            - test_cmd: Command tag in the yml file to execute for checking if the patch
+                         has already been applied (e.g. "reverse-test-command")
+            - reverse_order: If True, apply patches in reverse order
+            - dst_mods: List of modules to apply the patch command to. If None, apply to all
+
+        Returns:
+            - True: All patches were processed successfully
+            - False: A patch failed to process
+        """
         patches = yml.get("patches", [])
         if not patches:
-            return
+            return True
 
         patch_count = 0
         failed_patch = None
         patched_mods = set()
 
-        for patch_info in patches:
+        for patch_info in (reversed(patches) if reverse_order else patches):
             mod = self.get_module_path(patch_info["module"])
             if mod is None:
                 continue
@@ -358,57 +455,62 @@ class Patch(WestCommand):
             if dst_mods and mod not in dst_mods:
                 continue
 
-            pth = patch_info["path"]
-            patch_path = os.path.realpath(Path(args.patch_base) / pth)
-
-            apply_cmd = patch_info["apply-command"]
-            apply_cmd_list = shlex.split(apply_cmd)
-
-            self.dbg(f"reading patch file {pth}")
-            expect_sha256 = patch_info["sha256sum"]
-            try:
-                actual_sha256 = self.get_file_sha256sum(patch_path)
-            except Exception as e:
-                self.err(f"failed to read {pth}: {e}")
-                failed_patch = pth
-                break
-
-            if actual_sha256 != expect_sha256:
-                self.dbg("FAIL")
-                self.err(
-                    f"sha256 mismatch for {pth}:\n"
-                    f"expect: {expect_sha256}\n"
-                    f"actual: {actual_sha256}"
-                )
-                failed_patch = pth
-                break
-            self.dbg("OK")
-            patch_count += 1
-
-            mod_path = Path(args.west_workspace) / mod
             patched_mods.add(mod)
 
-            self.dbg(f"patching {mod}... ", end="")
-            apply_cmd += patch_path
-            apply_cmd_list.extend([patch_path])
-            proc = subprocess.run(
-                apply_cmd_list, capture_output=True, cwd=mod_path, encoding="utf-8"
-            )
-            if proc.returncode:
-                self.dbg("FAIL")
-                self.err(proc.stderr)
-                failed_patch = pth
+            # Do our best to see if the working directory is in an appropriate
+            # state before trying to apply or reverse the patch. This is a best
+            # effort check and may not be totally accurate. Errors are squelched
+            # because we expect to fail if the directory is in the correct state.
+            if self.execute_on_patch(
+                args, patch_info, patch_info[test_cmd], squelch_errors=True
+            ):
+                self.inf(f"Skipping {patch_info['path']}: "
+                         f"{'patch already reversed, or never applied' if reverse_order
+                         else 'patch already applied'}")
+                continue
+
+            if not self.execute_on_patch(
+                args, patch_info, patch_info[patch_cmd], squelch_errors=False
+            ):
+                failed_patch = patch_info["path"]
                 break
-            self.dbg("OK")
+
+            patch_count += 1
 
         if not failed_patch:
-            self.inf(f"{patch_count} patches applied successfully \\o/")
-            return
+            self.inf(f"{patch_count} patches processed successfully \\o/")
+            return True
 
-        if args.roll_back:
+        # Only the apply subcommand has the --roll-back option, so we need to check for it first
+        if hasattr(args, "roll_back") and args.roll_back:
             self.clean(args, yml, patched_mods)
 
-        self.die(f"failed to apply patch {failed_patch}")
+        self.err(f"failed to process patch {failed_patch}, is there a conflict?")
+        return False
+
+    def apply(self, args, yml, dst_mods=None):
+        success = self.patch(
+            args, yml,
+            patch_cmd="apply-command",
+            test_cmd="reverse-test-command",
+            reverse_order=False,
+            dst_mods=dst_mods
+        )
+
+        if not success:
+            self.die("failed to apply patches")
+
+    def reverse(self, args, yml, dst_mods=None):
+        success = self.patch(
+            args, yml,
+            patch_cmd="reverse-command",
+            test_cmd="apply-test-command",
+            reverse_order=True,
+            dst_mods=dst_mods
+        )
+
+        if not success:
+            self.die("failed to reverse patches")
 
     def clean(self, args, yml, dst_mods=None):
         clean_cmd = yml["clean-command"]


### PR DESCRIPTION
 The reverse command is distinct from clean in that it only removes changes that have been applied by a patch. Other changes are left in place. By contrast, clean removes all changes in the module. Patches are removed in reverse order of apply, so that if a patch depends on a previous patch, it will be reversed first.

Additionally, if a patch to be applied/reversed has already been applied/reversed, skip it rather than fail. This makes it possible to run apply or reverse multiple times without causing issues. Apply and reverse are now idempotent like other commands. But, this check only works in the absence of conflicts. It's up to patch authors to ensure patches are conflict free.

The logic between the apply and reverse methods are pretty similar so a minor refactor was done to move the common parts into separate functions.