### PR TITLE
scripts: list_boards: richer target iteration

### DIFF
--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -153,6 +153,19 @@ class Board:
         return node
 
 
+@dataclass(frozen=True)
+class BoardTarget:
+    board: str
+    qualifiers: str
+    soc: str
+    cpucluster: str | None = None
+    revision: str | None = None
+
+    def name(self) -> str:
+        board = f"{self.board}@{self.revision}" if self.revision else self.board
+        return f"{board}/{self.qualifiers}"
+
+
 def load_v2_boards(board_name, board_yml, systems):
     boards = {}
     board_extensions = []
@@ -299,24 +312,41 @@ def variant_v2_qualifiers(variant, qualifiers = None):
     return qualifiers_list
 
 
-def board_v2_qualifiers(board):
-    qualifiers_list = []
+def board_v2_targets(board: Board, include_revisions: bool = True) -> list[BoardTarget]:
+    targets: list[BoardTarget] = []
+
+    def extend_targets(qualifiers, soc, cpucluster=None):
+        targets.append(BoardTarget(board.name, qualifiers, soc, cpucluster))
+        if not include_revisions:
+            return
+
+        for revision in board.revisions:
+            if not revision.name:
+                continue
+            targets.append(BoardTarget(board.name, qualifiers, soc, cpucluster, revision.name))
 
     for s in board.socs:
         if s.cpuclusters:
             for c in s.cpuclusters:
                 id_str = s.name + '/' + c.name
-                qualifiers_list.append(id_str)
+                extend_targets(id_str, s.name, c.name)
                 for v in c.variants:
-                    qualifiers_list.extend(variant_v2_qualifiers(v, id_str))
+                    for qualifiers in variant_v2_qualifiers(v, id_str):
+                        extend_targets(qualifiers, s.name, c.name)
         else:
-            qualifiers_list.append(s.name)
+            extend_targets(s.name, s.name)
             for v in s.variants:
-                qualifiers_list.extend(variant_v2_qualifiers(v, s.name))
+                for qualifiers in variant_v2_qualifiers(v, s.name):
+                    extend_targets(qualifiers, s.name)
 
     for v in board.variants:
-        qualifiers_list.extend(variant_v2_qualifiers(v))
-    return qualifiers_list
+        for qualifiers in variant_v2_qualifiers(v):
+            extend_targets(qualifiers, "")
+
+    return targets
+
+def board_v2_qualifiers(board: Board) -> list[str]:
+    return [t.qualifiers for t in board_v2_targets(board, include_revisions=False)]
 
 
 def board_v2_qualifiers_csv(board):

--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -99,12 +99,7 @@ class Boards(WestCommand):
                 continue
 
             if args.all_targets:
-                all_targets += [f"{board.name}/{qualifier}"
-                                for qualifier in list_boards.board_v2_qualifiers(board)]
-                if board.revisions:
-                    all_targets += [f"{board.name}@{revision.name}/{qualifier}"
-                                    for qualifier in list_boards.board_v2_qualifiers(board)
-                                    for revision in board.revisions]
+                all_targets += [target.name() for target in list_boards.board_v2_targets(board)]
             else:
                 if board.revisions:
                     revisions_list = ','.join([rev.name for rev in board.revisions])


### PR DESCRIPTION
Add a helper function that returns richer information about board targets, `board_v2_targets`. Update `board_v2_qualifiers` to use this new helper.

Intended as a first step towards adding SoC level filtering to twister, which requires the SoC to be exposed by the iteration functions.