### PR TITLE
samples: display: add MCX-N5XX-EVK to shield test

### DIFF
--- a/samples/drivers/display/tests.yaml
+++ b/samples/drivers/display/tests.yaml
@@ -107,6 +107,7 @@ tests:
       - platform:mimxrt1040_evk/mimxrt1042:SHIELD=rk043fn66hs_ctg
       - platform:frdm_mcxn947/mcxn947/cpu0:SHIELD=lcd_par_s035_8080
       - platform:mcx_n9xx_evk/mcxn947/cpu0:SHIELD=lcd_par_s035_8080
+      - platform:mcx_n5xx_evk/mcxn547/cpu0:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxn236/mcxn236:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxa156/mcxa156:SHIELD=lcd_par_s035_8080
       - platform:frdm_rw612/rw612:SHIELD=lcd_par_s035_spi

--- a/tests/drivers/display/display_check/tests.yaml
+++ b/tests/drivers/display/display_check/tests.yaml
@@ -95,6 +95,7 @@ tests:
       - platform:mimxrt1040_evk/mimxrt1042:SHIELD=rk043fn66hs_ctg
       - platform:frdm_mcxn947/mcxn947/cpu0:SHIELD=lcd_par_s035_8080
       - platform:mcx_n9xx_evk/mcxn947/cpu0:SHIELD=lcd_par_s035_8080
+      - platform:mcx_n5xx_evk/mcxn547/cpu0:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxn236/mcxn236:SHIELD=lcd_par_s035_8080
       - platform:frdm_mcxa156/mcxa156:SHIELD=lcd_par_s035_8080
       - platform:frdm_rw612/rw612:SHIELD=lcd_par_s035_spi


### PR DESCRIPTION
Add mcx_n5xx_evk/mcxn547/cpu0 with lcd_par_s035_8080 shield to the display sample test matrix. The board shares the same FlexIO LCD 8080 interface as mcx_n9xx_evk via the common mcx_nx4x_evk base.