### PR TITLE
boards: nxp: frdm_mcxa577: add USB support

### DIFF
--- a/boards/nxp/frdm_mcxa577/board.c
+++ b/boards/nxp/frdm_mcxa577/board.c
@@ -8,6 +8,10 @@
 #include <fsl_clock.h>
 #include <fsl_spc.h>
 #include <soc.h>
+#if defined(CONFIG_UDC_NXP_EHCI)
+#define SCG_TRIM_UNLOCK_KEY     0x5a5a0001U
+#define BOARD_XTAL_FREQ_HZ      24000000U
+#endif
 
 /* Core clock frequency: 200MHz from PLL */
 #define CLOCK_INIT_CORE_CLOCK 200000000U
@@ -384,6 +388,29 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kFRO_HF_DIV_to_TSI0);
 	CLOCK_SetClockDiv(kCLOCK_DivTSI0, 4);
 	CLOCK_EnableClock(kCLOCK_GateTSI0);
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb0)) && defined(CONFIG_UDC_NXP_EHCI)
+	/* Voltage delay for USB LDO ramp-up */
+	SPC0->ACTIVE_VDELAY = 0x0500;
+	SPC0->ACTIVE_CFG |= SPC_ACTIVE_CFG_CORELDO_VDD_DS_MASK;
+	SPC0->ACTIVE_CFG |= SPC_ACTIVE_CFG_CORELDO_VDD_LVL(0x3);
+	while (SPC0->SC & SPC_SC_BUSY_MASK) {
+	};
+	/* Unlock SCG trim registers and enable LDO for USB PHY */
+	if (0u == (SCG0->LDOCSR & SCG_LDOCSR_LDOEN_MASK)) {
+		SCG0->TRIM_LOCK = SCG_TRIM_UNLOCK_KEY;
+		SCG0->LDOCSR |= SCG_LDOCSR_LDOEN_MASK;
+		while (0U == (SCG0->LDOCSR & SCG_LDOCSR_VOUT_OK_MASK)) {
+		};
+	}
+	CLOCK_AttachClk(kPHY_CLK_XTAL_to_USBHS);
+	CLOCK_AttachClk(kCLK_IN_to_USBHS_PHY);
+	CLOCK_EnableClock(kCLOCK_GateUSBHS);
+	CLOCK_EnableClock(kCLOCK_GateUSBHS_PHY);
+	CLOCK_SetClockDiv(kCLOCK_DivUSBHS_PHY, 1);
+	CLOCK_EnableUsbhsPhyPllClock(BOARD_XTAL_FREQ_HZ);
+	CLOCK_EnableUsbhsClock();
 #endif
 
 	/* Set SystemCoreClock variable. */

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.dtsi
@@ -356,6 +356,18 @@
 	clock-src = <1>;
 };
 
+zephyr_udc0: &usb0 {
+	status = "okay";
+	phy-handle = <&usbphy1>;
+};
+
+&usbphy1 {
+	status = "okay";
+	tx-d-cal = <4>;
+	tx-cal-45-dp-ohms = <7>;
+	tx-cal-45-dm-ohms = <7>;
+};
+
 &i3c0 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_i3c0>;

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577.yaml
@@ -33,4 +33,5 @@ supported:
   - crc
   - pwm
   - tsi
+  - usbd
 vendor: nxp


### PR DESCRIPTION
Enable USB High-Speed EHCI controller and integrated USB PHY on the FRDM-MCXA577 board.

- Enable usb0 (nxp,ehci) and usbphy1 (nxp,usbphy) nodes in the board DTSI with PHY calibration values from the hardware design.
- Add USB clock and power initialization in board_early_init_hook(): SPC/LDO power-up, SOSC-based clock muxing, USBHS/PHY clock gating, and 480 MHz PHY PLL configuration from the 24 MHz board crystal.
- Add usb_device and usbd to the board supported features list.

Test with samples/subsys/usb/cdc_acm and samples/subsys/usb/console