### PR TITLE
boards: beagle: beagleplay: fix SoC model typo and build target in doc

### DIFF
--- a/boards/beagle/beagleplay/doc/index.rst
+++ b/boards/beagle/beagleplay/doc/index.rst
@@ -12,7 +12,7 @@ Hardware
 
 * Processors
 
-  * TI Sitara AM6252 SoC
+  * TI Sitara AM6254 SoC
 
     * 4x ARM Cortex-A53
     * ARM Cortex-R5
@@ -165,7 +165,7 @@ The testing requires the binary to be copied to the SD card to allow the A53 cor
 To test the M4F core, we build the :zephyr:code-sample:`hello_world` sample with the following command.
 
 .. zephyr-app-commands::
-   :board: pocketbeagle_2/am6254/m4
+   :board: beagleplay/am6254/m4
    :zephyr-app: samples/hello_world
    :goals: build
 
@@ -211,7 +211,7 @@ superuser privilege, OpenOCD needs to be launched separately for now:
 Start debugging
 
 .. zephyr-app-commands::
-   :board: pocketbeagle_2/am6254/m4
+   :board: beagleplay/am6254/m4
    :goals: debug
 
 References


### PR DESCRIPTION
### Description
Fixes several typos and copy-paste errors in the BeaglePlay board documentation (`boards/beagle/beagleplay/doc/index.rst`).

- **SoC Model Typo**: Corrected `AM6252` to `AM6254` under the Processors section to align with the actual onboard SoC and the Overview section.
- **Build Target Path Fix**: Replaced leftover `pocketbeagle_2/am6254/m4` board references in the sample build and debug commands with `beagleplay/am6254/m4`.

### Impact
- Ensures correct build instructions for developer workflow on BeaglePlay's M4F core.
- Fixes SoC model inconsistency in official documentation.

### Testing
- Verified that the target board `beagleplay/am6254/m4` matches the current board tree structure in Zephyr.