### PR TITLE
dts: raspberrypi: Disable core-supply-regulator by default on RP2040/RP2350

### DIFF
--- a/boards/adafruit/feather_adalogger_rp2040/adafruit_feather_adalogger_rp2040.dts
+++ b/boards/adafruit/feather_adalogger_rp2040/adafruit_feather_adalogger_rp2040.dts
@@ -224,8 +224,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/adafruit/feather_canbus_rp2040/adafruit_feather_canbus_rp2040.dts
+++ b/boards/adafruit/feather_canbus_rp2040/adafruit_feather_canbus_rp2040.dts
@@ -224,8 +224,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/adafruit/feather_propmaker_rp2040/adafruit_feather_propmaker_rp2040.dts
+++ b/boards/adafruit/feather_propmaker_rp2040/adafruit_feather_propmaker_rp2040.dts
@@ -245,8 +245,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/adafruit/feather_rfm95_rp2040/adafruit_feather_rfm95_rp2040.dts
+++ b/boards/adafruit/feather_rfm95_rp2040/adafruit_feather_rfm95_rp2040.dts
@@ -218,8 +218,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/adafruit/feather_rp2040/adafruit_feather_rp2040.dts
+++ b/boards/adafruit/feather_rp2040/adafruit_feather_rp2040.dts
@@ -153,8 +153,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/adafruit/feather_scorpio_rp2040/adafruit_feather_scorpio_rp2040.dts
+++ b/boards/adafruit/feather_scorpio_rp2040/adafruit_feather_scorpio_rp2040.dts
@@ -229,8 +229,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/adafruit/itsybitsy_rp2040/adafruit_itsybitsy_rp2040.dts
+++ b/boards/adafruit/itsybitsy_rp2040/adafruit_itsybitsy_rp2040.dts
@@ -199,8 +199,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/adafruit/kb2040/adafruit_kb2040.dts
+++ b/boards/adafruit/kb2040/adafruit_kb2040.dts
@@ -122,8 +122,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040.dts
+++ b/boards/adafruit/macropad_rp2040/adafruit_macropad_rp2040.dts
@@ -224,6 +224,10 @@ zephyr_udc0: &usbd {
 	status = "okay";
 };
 
+&vreg {
+	status = "okay";
+};
+
 &pio1 {
 	status = "okay";
 

--- a/boards/adafruit/metro_rp2040/adafruit_metro_rp2040.dts
+++ b/boards/adafruit/metro_rp2040/adafruit_metro_rp2040.dts
@@ -206,8 +206,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/adafruit/metro_rp2350/adafruit_metro_rp2350_rp2350b_m33.dts
+++ b/boards/adafruit/metro_rp2350/adafruit_metro_rp2350_rp2350b_m33.dts
@@ -158,6 +158,10 @@
 	status = "okay";
 };
 
+&vreg {
+	status = "okay";
+};
+
 zephyr_udc0: &usbd {
 	status = "okay";
 };

--- a/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040.dts
+++ b/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040.dts
@@ -161,8 +161,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/adafruit/trinkey_qt2040/adafruit_trinkey_qt2040.dts
+++ b/boards/adafruit/trinkey_qt2040/adafruit_trinkey_qt2040.dts
@@ -142,8 +142,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/arduino/nano_connect/arduino_nano_connect.dts
+++ b/boards/arduino/nano_connect/arduino_nano_connect.dts
@@ -194,8 +194,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 /* Aliases for Arduino compatibility */

--- a/boards/cytron/maker_nano_rp2040/maker_nano_rp2040.dts
+++ b/boards/cytron/maker_nano_rp2040/maker_nano_rp2040.dts
@@ -215,8 +215,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/cytron/maker_pi_rp2040/maker_pi_rp2040.dts
+++ b/boards/cytron/maker_pi_rp2040/maker_pi_rp2040.dts
@@ -213,8 +213,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/cytron/maker_uno_rp2040/maker_uno_rp2040.dts
+++ b/boards/cytron/maker_uno_rp2040/maker_uno_rp2040.dts
@@ -200,8 +200,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/cytron/motion_2350_pro/motion_2350_pro.dtsi
+++ b/boards/cytron/motion_2350_pro/motion_2350_pro.dtsi
@@ -173,6 +173,10 @@ zephyr_i2c: &i2c0 {
 	status = "okay";
 };
 
+&vreg {
+	status = "okay";
+};
+
 &wdt0 {
 	status = "okay";
 };

--- a/boards/dfrobot/beetle_rp2040/beetle_rp2040.dts
+++ b/boards/dfrobot/beetle_rp2040/beetle_rp2040.dts
@@ -128,8 +128,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/dfrobot/beetle_rp2350/beetle_rp2350.dtsi
+++ b/boards/dfrobot/beetle_rp2350/beetle_rp2350.dtsi
@@ -114,6 +114,10 @@
 	status = "okay";
 };
 
+&vreg {
+	status = "okay";
+};
+
 &wdt0 {
 	status = "okay";
 };

--- a/boards/framework/framework_ledmatrix/framework_ledmatrix.dts
+++ b/boards/framework/framework_ledmatrix/framework_ledmatrix.dts
@@ -106,6 +106,5 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };

--- a/boards/framework/laptop16_keyboard/framework_laptop16_keyboard.dts
+++ b/boards/framework/laptop16_keyboard/framework_laptop16_keyboard.dts
@@ -122,6 +122,5 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };

--- a/boards/kws/pico2_spe/pico2_spe.dtsi
+++ b/boards/kws/pico2_spe/pico2_spe.dtsi
@@ -144,6 +144,10 @@
 	status = "okay";
 };
 
+&vreg {
+	status = "okay";
+};
+
 zephyr_udc0: &usbd {
 	status = "okay";
 };

--- a/boards/kws/pico_spe/pico_spe.dts
+++ b/boards/kws/pico_spe/pico_spe.dts
@@ -206,8 +206,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 pico_spi: &spi1 {};

--- a/boards/longan/canbed_rp2040/canbed_rp2040.dts
+++ b/boards/longan/canbed_rp2040/canbed_rp2040.dts
@@ -180,8 +180,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/pimoroni/pico_plus2/pico_plus2.dtsi
+++ b/boards/pimoroni/pico_plus2/pico_plus2.dtsi
@@ -141,6 +141,10 @@ gpio0_lo: &gpio0 {
 	status = "okay";
 };
 
+&vreg {
+	status = "okay";
+};
+
 zephyr_udc0: &usbd {
 	status = "okay";
 };

--- a/boards/pimoroni/tiny2040/tiny2040.dts
+++ b/boards/pimoroni/tiny2040/tiny2040.dts
@@ -174,8 +174,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/raspberrypi/rpi_debug_probe/rpi_debug_probe.dts
+++ b/boards/raspberrypi/rpi_debug_probe/rpi_debug_probe.dts
@@ -116,8 +116,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
+++ b/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
@@ -152,8 +152,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 pico_spi: &spi0 {};

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_cpu0_common.dtsi
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_cpu0_common.dtsi
@@ -74,6 +74,10 @@
 	status = "okay";
 };
 
+&vreg {
+	status = "okay";
+};
+
 &rng {
 	status = "okay";
 };

--- a/boards/seeed/xiao_rp2040/xiao_rp2040.dts
+++ b/boards/seeed/xiao_rp2040/xiao_rp2040.dts
@@ -180,8 +180,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/seeed/xiao_rp2350/xiao_rp2350.dtsi
+++ b/boards/seeed/xiao_rp2350/xiao_rp2350.dtsi
@@ -117,6 +117,10 @@
 	status = "okay";
 };
 
+&vreg {
+	status = "okay";
+};
+
 &rng {
 	status = "okay";
 };

--- a/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040.dts
+++ b/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040.dts
@@ -130,6 +130,5 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };

--- a/boards/sparkfun/rp2040_mikrobus/sparkfun_rp2040_mikrobus-common.dtsi
+++ b/boards/sparkfun/rp2040_mikrobus/sparkfun_rp2040_mikrobus-common.dtsi
@@ -32,8 +32,7 @@
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &timer {

--- a/boards/vicharak/shrike_lite/shrike_lite.dts
+++ b/boards/vicharak/shrike_lite/shrike_lite.dts
@@ -132,8 +132,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/waveshare/rp2040_geek/rp2040_geek.dts
+++ b/boards/waveshare/rp2040_geek/rp2040_geek.dts
@@ -171,8 +171,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/waveshare/rp2040_keyboard_3/rp2040_keyboard_3.dts
+++ b/boards/waveshare/rp2040_keyboard_3/rp2040_keyboard_3.dts
@@ -141,8 +141,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/waveshare/rp2040_matrix/rp2040_matrix.dts
+++ b/boards/waveshare/rp2040_matrix/rp2040_matrix.dts
@@ -174,8 +174,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 &xosc {

--- a/boards/waveshare/rp2040_plus/rp2040_plus.dts
+++ b/boards/waveshare/rp2040_plus/rp2040_plus.dts
@@ -196,8 +196,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 pico_spi: &spi0 {};

--- a/boards/waveshare/rp2040_zero/rp2040_zero.dts
+++ b/boards/waveshare/rp2040_zero/rp2040_zero.dts
@@ -141,8 +141,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 pico_spi: &spi0 {};

--- a/boards/waveshare/rp2350_zero/rp2350_zero.dtsi
+++ b/boards/waveshare/rp2350_zero/rp2350_zero.dtsi
@@ -146,6 +146,10 @@
 	status = "okay";
 };
 
+&vreg {
+	status = "okay";
+};
+
 zephyr_udc0: &usbd {
 	status = "okay";
 };

--- a/boards/weact/rp2350b_core/rp2350b_core.dtsi
+++ b/boards/weact/rp2350b_core/rp2350b_core.dtsi
@@ -140,6 +140,10 @@ gpio1: &gpio0_hi {
 	status = "okay";
 };
 
+&vreg {
+	status = "okay";
+};
+
 &rng {
 	status = "okay";
 };

--- a/boards/wiznet/w5500_evb_pico/w5500_evb_pico.dts
+++ b/boards/wiznet/w5500_evb_pico/w5500_evb_pico.dts
@@ -182,8 +182,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 pico_spi: &spi0 {};

--- a/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2.dtsi
+++ b/boards/wiznet/w5500_evb_pico2/w5500_evb_pico2.dtsi
@@ -168,6 +168,10 @@
 	status = "okay";
 };
 
+&vreg {
+	status = "okay";
+};
+
 zephyr_udc0: &usbd {
 	status = "okay";
 };

--- a/boards/wiznet/w6100_evb_pico/w6100_evb_pico.dts
+++ b/boards/wiznet/w6100_evb_pico/w6100_evb_pico.dts
@@ -183,8 +183,7 @@ zephyr_udc0: &usbd {
 };
 
 &vreg {
-	regulator-always-on;
-	regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
+	status = "okay";
 };
 
 pico_spi: &spi0 {};

--- a/boards/wiznet/w6100_evb_pico2/w6100_evb_pico2.dtsi
+++ b/boards/wiznet/w6100_evb_pico2/w6100_evb_pico2.dtsi
@@ -169,6 +169,10 @@
 	status = "okay";
 };
 
+&vreg {
+	status = "okay";
+};
+
 zephyr_udc0: &usbd {
 	status = "okay";
 };

--- a/boards/wiznet/w6300_evb_pico2/w6300_evb_pico2.dtsi
+++ b/boards/wiznet/w6300_evb_pico2/w6300_evb_pico2.dtsi
@@ -144,6 +144,10 @@
 	status = "okay";
 };
 
+&vreg {
+	status = "okay";
+};
+
 zephyr_udc0: &usbd {
 	status = "okay";
 };

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -50,6 +50,14 @@ Kernel
 Boards
 ******
 
+* On RP2040 and RP2350, the ``vreg`` node (:dtcompatible:`raspberrypi,core-supply-regulator`) is
+  now ``disabled`` by default instead of ``okay``. Out-of-tree boards that need this regulator
+  must set ``status = "okay"`` on the ``&vreg`` node.
+
+  On RP2040, the ``regulator-always-on`` and ``regulator-allowed-modes =
+  <REGULATOR_RPI_PICO_MODE_NORMAL>`` properties are now set by default in the SoC dtsi. Boards
+  that previously set them explicitly can remove those lines. (:github:`114751`)
+
 * The Kconfig options :kconfig:option:`CONFIG_SRAM_SIZE` and
   :kconfig:option:`CONFIG_SRAM_BASE_ADDRESS` have been deprecated, boards should instead use the
   devicetree ``zephyr.sram`` chosen node to specify the RAM node which will be used (whose values

--- a/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
+++ b/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
@@ -402,7 +402,9 @@
 		vreg: vreg@40064000 {
 			compatible = "raspberrypi,core-supply-regulator";
 			reg = <0x40064000 1>;
-			status = "okay";
+			status = "disabled";
+			regulator-always-on;
+			regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>;
 			raspberrypi,brown-out-detection;
 			raspberrypi,brown-out-threshold = <860000>;
 		};

--- a/dts/vendor/raspberrypi/rpi_pico/rp2350.dtsi
+++ b/dts/vendor/raspberrypi/rpi_pico/rp2350.dtsi
@@ -411,7 +411,7 @@
 		vreg: vreg@40100000 {
 			compatible = "raspberrypi,core-supply-regulator";
 			reg = <0x40100000 0x200>;
-			status = "okay";
+			status = "disabled";
 			raspberrypi,brown-out-detection;
 		};
 


### PR DESCRIPTION
Both the RP2040 and RP2350 core-supply-regulator (vreg) nodes were enabled unconditionally in their shared SoC dtsi files, so every board inherited "okay" status regardless of whether it actually configures the regulator.

This hardware is shared between both cores for the RP2040/RP2350. If enabled unconditionally at the soc-level, both cores would be responsible for initializing the regulator driver.

*Almost* every RP2040 based board adds `regulator-always-on` and `regulator-allowed-modes = <REGULATOR_RPI_PICO_MODE_NORMAL>` to the `&vreg` node. Move those properties to the rp2040 dtsi to reduce duplication.

Motivated by discussion in: https://github.com/zephyrproject-rtos/zephyr/pull/110169#discussion_r3604157459 