### PR TITLE
dts: bindings: mmc: move host controller bindings to sdhc

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1378,7 +1378,6 @@ Disk:
     - tests/drivers/build_all/disk/
     - include/zephyr/sd/
     - dts/bindings/sd/
-    - dts/bindings/mmc/
     - dts/bindings/disk/
   file-groups:
     - name: eMMC

--- a/dts/bindings/mmc/mmc.yaml
+++ b/dts/bindings/mmc/mmc.yaml
@@ -1,6 +1,0 @@
-# Copyright (c) 2019, NXP
-# SPDX-License-Identifier: Apache-2.0
-
-# Specifies the MMC/SDHC module
-
-include: base.yaml

--- a/dts/bindings/sdhc/renesas,rcar-mmc.yaml
+++ b/dts/bindings/sdhc/renesas,rcar-mmc.yaml
@@ -2,7 +2,7 @@ description: Renesas R-Car eMMC
 
 compatible: "renesas,rcar-mmc"
 
-include: [sdhc.yaml, mmc.yaml, pinctrl-device.yaml, reset-device.yaml]
+include: [sdhc.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   clocks:

--- a/dts/bindings/sdhc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/sdhc/st,stm32-sdmmc.yaml
@@ -2,7 +2,7 @@ description: STM32 SDMMC Host Controller
 
 compatible: "st,stm32-sdmmc"
 
-include: [sdhc.yaml, mmc.yaml, pinctrl-device.yaml, reset-device.yaml]
+include: [sdhc.yaml, pinctrl-device.yaml, reset-device.yaml]
 
 properties:
   disk-name:


### PR DESCRIPTION
The binding files in mmc directory were nothing specifc but for SDHC host controllers. Let's move them to sdhc directory.