### PR TITLE
soc: nxp: imxrt: allow spread spectrum configuration

### DIFF
--- a/dts/bindings/clock/nxp,imx-ccm-fnpll.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm-fnpll.yaml
@@ -34,19 +34,16 @@ properties:
 
   ss-step:
     type: int
-    required: false
     description: |
       Step value to get frequency change step
 
   ss-stop:
     type: int
-    required: false
     description: |
-      Stop value to get frequency change 
+      Stop value to get frequency change
 
   ss-enable:
     type: int
-    required: false
     description: |
       Enable spread spectrum modulation
 

--- a/dts/bindings/clock/nxp,imx-ccm-fnpll.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm-fnpll.yaml
@@ -32,6 +32,24 @@ properties:
     description: |
       Denominator of PLL multiplier fraction
 
+  ss-step:
+    type: int
+    required: false
+    description: |
+      Step value to get frequency change step
+
+  ss-stop:
+    type: int
+    required: false
+    description: |
+      Stop value to get frequency change 
+
+  ss-enable:
+    type: int
+    required: false
+    description: |
+      Enable spread spectrum modulation
+
   src:
     type: int
     required: true

--- a/soc/nxp/imxrt/imxrt10xx/soc.c
+++ b/soc/nxp/imxrt/imxrt10xx/soc.c
@@ -146,6 +146,9 @@ __weak void clock_init(void)
 		.numerator = DT_PROP(DT_CHILD(CCM_NODE, sys_pll), numerator),
 		.denominator = DT_PROP(DT_CHILD(CCM_NODE, sys_pll), denominator),
 		.src = DT_PROP(DT_CHILD(CCM_NODE, sys_pll), src),
+		.ss_enable = DT_PROP(DT_CHILD(CCM_NODE, sys_pll), ss_enable),
+		.ss_step = DT_PROP(DT_CHILD(CCM_NODE, sys_pll), ss_step),
+		.ss_stop = DT_PROP(DT_CHILD(CCM_NODE, sys_pll), ss_stop),
 	};
 
 	if (IS_ENABLED(CONFIG_INIT_SYS_PLL)) {


### PR DESCRIPTION
Add binding for spread spectrum, tested with values from Application Note AN12879 (https://www.nxp.com/docs/en/application-note/AN12879.pdf)