### PR TITLE
modules: tf-m: stop auto-enabling Mbed TLS/PSA Crypto

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -1232,6 +1232,9 @@ Trusted Firmware-M
   :kconfig:option:`TFM_ZEPHYR_4_2_COMPATIBILITY`, which more accurately describes when the symbol
   needs to be set.
 
+* :kconfig:option:`CONFIG_BUILD_WITH_TFM` does not enable :kconfig:option:`CONFIG_MBEDTLS` /
+  :kconfig:option:`CONFIG_PSA_CRYPTO` anymore. Make sure to enable them explicitly in your build as needed. (:github:`114762#`)
+
 Snippets
 ********
 

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -277,11 +277,16 @@ if(CONFIG_BUILD_WITH_TFM)
     )
   endif()
 
-  # By default TF-M installs TF-PSA-Crypto include files in the build directory,
-  # but this will duplicate what's already provided by the TF-PSA-Crypto library
-  # itself. Disable this, unless CONFIG_TFM_USE_NS_APP is set because in that
-  # case the NS app is built in a completely different way than what Zephyr does.
-  if(NOT CONFIG_TFM_USE_NS_APP)
+  if(CONFIG_TFM_INSTALL_TF_PSA_CRYPTO_HEADERS)
+    # The PSA Crypto client headers are the ones installed by TF-M. TF-M
+    # exports the matching configuration through its "psa_crypto_config" CMake
+    # target, but Zephyr does not consume TF-M's CMake targets, so set the same
+    # definitions here.
+    zephyr_compile_definitions(
+      TFM_PSA_CRYPTO_CLIENT_ONLY
+      TF_PSA_CRYPTO_CONFIG_FILE="${TFM_INTERFACE_INCLUDE_DIR}/mbedtls/tf_psa_crypto_config.h"
+    )
+  else()
     list(APPEND TFM_CMAKE_ARGS -DTFM_INSTALL_TF_PSA_CRYPTO_HEADERS=OFF)
   endif()
 

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -53,8 +53,6 @@ menuconfig BUILD_WITH_TFM
 	select BUILD_OUTPUT_HEX
 	imply INIT_ARCH_HW_AT_BOOT
 	imply ARM_NONSECURE_PREEMPTIBLE_SECURE_CALLS
-	imply MBEDTLS if !TFM_USE_NS_APP
-	imply PSA_CRYPTO if !TFM_USE_NS_APP
 	help
 	  When enabled, this option instructs the Zephyr build process to
 	  additionally generate a TF-M image for the Secure Execution
@@ -274,6 +272,15 @@ config TFM_USE_NS_APP
 	  This option is intended for testing purposes only, since this is the
 	  easiest way to integrate and run the TF-M regression tests in the
 	  zephyr build system.
+
+config TFM_INSTALL_TF_PSA_CRYPTO_HEADERS
+	bool
+	depends on TFM_PARTITION_CRYPTO && !MBEDTLS
+	default y
+	help
+	  Hidden symbol signaling that the TF-PSA-Crypto headers (psa/crypto.h and friends)
+	  used by the Zephyr image are the ones installed by TF-M, together with the matching
+	  TF-PSA-Crypto configuration header.
 
 config TFM_CONNECTION_BASED_SERVICE_API
 	bool "TF-M use connection based service APIs"

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -71,7 +71,7 @@ menu "Engine features"
 
 config LWM2M_DTLS_SUPPORT
 	bool "DTLS support in the LwM2M client"
-
+	select MBEDTLS
 
 config LWM2M_DNS_SUPPORT
 	bool "DNS support in the LwM2M client"

--- a/tests/modules/tf-m/regression/prj.conf
+++ b/tests/modules/tf-m/regression/prj.conf
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+CONFIG_PSA_CRYPTO=y
+
 # Regression tests are included if a related secure partition is enabled.
 CONFIG_TFM_PARTITION_PROTECTED_STORAGE=y
 CONFIG_TFM_PARTITION_INTERNAL_TRUSTED_STORAGE=y


### PR DESCRIPTION
It was only needed because TF-M relied on TF-PSA-Crypto to expose its header files.
    
Make TF-M install the TF-PSA-Crypto headers by default instead, and make sure TF-PSA-Crypto doesn't conflict.