### PR TITLE
drivers: usb: udc_stm32: fix bulk IN ZLP busy-flag race

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -686,19 +686,29 @@ static void handle_msg_data_in(struct udc_stm32_data *priv, uint8_t epnum)
 	const struct device *dev = priv->dev;
 	struct udc_ep_config *ep_cfg;
 	uint8_t ep = epnum | USB_EP_DIR_IN;
+	unsigned int lock_key;
 	struct net_buf *buf;
 	stm32_status_t status;
 
 	LOG_DBG("DataIn ep 0x%02x",  ep);
 
 	ep_cfg = udc_get_ep_cfg(dev, ep);
-	udc_ep_set_busy(ep_cfg, false);
 
 	buf = udc_buf_peek(ep_cfg);
 	if (unlikely(buf == NULL)) {
+		udc_ep_set_busy(ep_cfg, false);
 		return;
 	}
 
+	/*
+	 * When a control data stage continuation or a trailing ZLP still
+	 * has to go out, the transfer is not complete: the endpoint must
+	 * stay marked busy, otherwise a concurrent udc_stm32_ep_enqueue()
+	 * passes the busy check in udc_stm32_tx() and starts a second
+	 * transfer on an endpoint the hardware still owns, shearing the
+	 * HAL transfer state and leaving a partial packet stuck in the
+	 * TxFIFO (endpoint NAKs forever).
+	 */
 	if (ep == USB_CONTROL_EP_IN && buf->len > 0U) {
 		uint32_t len = MIN(UDC_STM32_EP0_MAX_PACKET_SIZE, buf->len);
 
@@ -730,11 +740,23 @@ static void handle_msg_data_in(struct udc_stm32_data *priv, uint8_t epnum)
 	buf = udc_buf_get(ep_cfg);
 	udc_submit_ep_event(dev, buf, 0);
 
-	/* enqueue */
+	/*
+	 * The busy-flag hand-off and the start of the next queued
+	 * transfer must be atomic against udc_stm32_ep_enqueue() (which
+	 * runs under irq_lock in another context), otherwise both
+	 * contexts can pass the busy check in udc_stm32_tx() and
+	 * double-start the endpoint.
+	 */
+	lock_key = irq_lock();
+
+	udc_ep_set_busy(ep_cfg, false);
+
 	buf = udc_buf_peek(ep_cfg);
 	if (buf != NULL) {
 		udc_stm32_tx(dev, ep_cfg, buf);
 	}
+
+	irq_unlock(lock_key);
 }
 
 void HAL_PCD_SetupStageCallback(stm32_pcd_handle_t *hpcd)


### PR DESCRIPTION
## Summary

`handle_msg_data_in()` clears the endpoint busy flag before checking whether the completed data stage still needs a control data stage continuation or a trailing ZLP. In the ZLP case, the endpoint is marked idle while the hardware still owns an active transfer:

1. A bulk IN transfer whose length is an exact multiple of MPS completes its data stage; the driver clears `busy`, arms the ZLP and returns.
2. Until the ZLP completes, a concurrent `udc_stm32_ep_enqueue()` passes the `udc_ep_is_busy()` check in `udc_stm32_tx()` and starts a second transfer on the same endpoint: the HAL endpoint state (`xfer_buff`/`xfer_len`/`xfer_count`, DIEPTSIZ, TXFE mask) is overwritten mid-flight.
3. The TXFE ISR fills the TxFIFO under the sheared state, leaving a partial packet in the FIFO. The OTG core never transmits a partial packet and TXFE never fires again above the half-empty threshold, so the endpoint NAKs forever. No error is reported anywhere; the endpoint just stops.

State captured on a wedged endpoint (STM32N6, OTG HS, slave mode): `DIEPCTL1.EPENA=1`, `DIEPTSIZ1 PKTCNT=1 XFERSIZE=512`, `DTXFSTS1=0x31` (79/128 words occupied), HAL `IN_ep[1].xfer_len=512, xfer_count=0`, bus active.

Any class that sets the ZLP flag on bulk IN transfers while enqueueing from a context not synchronized with USB completion events can hit this. Found with UVC H.264 streaming at ~60 Mbit/s on STM32N6570-DK (UVC flags a ZLP whenever a payload is an exact multiple of 512; the stream wedged within seconds).

The fix keeps the endpoint marked busy through the control-continuation and ZLP branches (the transfer is not finished yet), and makes the busy-flag clear plus next-transfer start atomic against the `irq_lock`'d enqueue path so two contexts cannot both pass the busy check.

## Reproduction / test

Minimal standalone PoC (west workspace app + pyusb host reader), with the wedge analysis and captured register state: https://github.com/PepperoniPingu/UDC-STM32-ZLP-Race

Every transfer is an exact multiple of MPS with the ZLP flag set, enqueued from a jittered producer thread. Measured on STM32N6570-DK (high speed, Zephyr v4.4.0, same code paths as main):

- unpatched: `WEDGED: no data for 2000 ms after 319 transfers (325120 bytes) at t=2.1s`
- patched: ~5100 ZLP-terminated transfers/s sustained, zero stalls (65 s test window, ~330k transfers)

Related: #93924 tracks general STM32 UDC compliance; the merged EP0 fixes (#97729) do not cover this bulk IN race.