### PR TITLE
scripts: kconfig: make blank-line rules continuation-aware

### DIFF
--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -10,6 +10,8 @@ on:
       - v*-branch
     paths:
       - 'scripts/build/**'
+      - 'scripts/cmake/**'
+      - 'scripts/kconfig/**'
       - '.github/workflows/scripts_tests.yml'
   pull_request:
     branches:
@@ -17,6 +19,8 @@ on:
       - v*-branch
     paths:
       - 'scripts/build/**'
+      - 'scripts/cmake/**'
+      - 'scripts/kconfig/**'
       - '.github/workflows/scripts_tests.yml'
 
 permissions:
@@ -73,4 +77,4 @@ jobs:
           ZEPHYR_BASE: ./
         run: |
           echo "Run script tests"
-          pytest ./scripts/build
+          pytest ./scripts/build ./scripts/cmake ./scripts/kconfig

--- a/scripts/cmake/cmake_style_test.py
+++ b/scripts/cmake/cmake_style_test.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for cmake_style.py.
+"""
+
+import pytest
+
+# cmake_style needs tree-sitter; skip the whole module if it is not installed.
+cmake_style = pytest.importorskip("cmake_style")
+
+
+def _rules(text):
+    """The set of rule ids reported for 'text'."""
+    return {issue.rule for issue in cmake_style.check_text(text)}
+
+
+# Rule 1: indentation (2 spaces per block level, no tabs).
+def test_indent_wrong_depth_flagged():
+    assert _rules("""\
+if(A)
+foo()
+endif()
+""") == {"indent"}
+
+
+def test_indent_correct_depth_clean():
+    assert not _rules("""\
+if(A)
+  foo()
+endif()
+""")
+
+
+def test_indent_else_endif_use_outer_depth():
+    assert not _rules("""\
+if(A)
+  a()
+else()
+  b()
+endif()
+""")
+
+
+def test_tab_indent_flagged():
+    assert _rules("""\
+if(A)
+\tfoo()
+endif()
+""") == {"tab-indent"}
+
+
+# Rule 2: lowercase commands, with the mixed-case module exception.
+def test_command_case_uppercase_builtin_flagged():
+    assert _rules("FILE(GLOB x)\n") == {"command-case"}
+
+
+def test_command_case_lowercase_clean():
+    assert not _rules("file(GLOB x)\n")
+
+
+def test_command_case_module_canonical_clean():
+    assert not _rules("ExternalProject_Add(foo)\n")
+
+
+def test_command_case_module_non_canonical_flagged():
+    # A module command must use its canonical mixed case, not all-lowercase.
+    assert _rules("externalproject_add(foo)\n") == {"command-case"}
+
+
+# Rule 3: no space before the opening parenthesis.
+def test_paren_space_flagged():
+    assert _rules("""\
+if (A)
+endif()
+""") == {"paren-space"}
+
+
+def test_paren_space_clean():
+    assert not _rules("""\
+if(A)
+endif()
+""")
+
+
+# Rule 4: cache/option variables use UPPERCASE names.
+def test_cache_var_lowercase_flagged():
+    assert _rules('set(foo 1 CACHE STRING "d")\n') == {"cache-var-case"}
+
+
+def test_cache_var_uppercase_clean():
+    assert not _rules('set(FOO 1 CACHE STRING "d")\n')
+
+
+def test_cache_var_option_flagged():
+    assert _rules('option(bar "desc" ON)\n') == {"cache-var-case"}
+
+
+def test_cache_var_mixed_case_clean():
+    # Mixed-case names (e.g. Python3_EXECUTABLE) are dictated by convention.
+    assert not _rules('set(Foo_BAR 1 CACHE STRING "d")\n')
+
+
+def test_cache_var_local_set_ignored():
+    assert not _rules('set(output_dir "x")\n')
+
+
+# Rule 5: booleans are not quoted in option()/set(... CACHE BOOL ...) values.
+def test_quoted_bool_option_flagged():
+    assert _rules('option(X "desc" "OFF")\n') == {"quoted-bool"}
+
+
+def test_quoted_bool_cache_bool_flagged():
+    assert _rules('set(X "ON" CACHE BOOL "d")\n') == {"quoted-bool"}
+
+
+def test_quoted_bool_string_operand_clean():
+    # A quoted boolean elsewhere is a legitimate string, not a boolean value.
+    assert not _rules('string(REPLACE "ON" "off" out "${in}")\n')
+
+
+def test_quoted_bool_cache_string_clean():
+    assert not _rules('set(X "ON" CACHE STRING "d")\n')
+
+
+def test_quoted_bool_plain_string_clean():
+    assert not _rules('set(log_level "OFF")\n')
+
+
+# Line length is intentionally not enforced for CMake.
+def test_line_length_not_enforced():
+    assert not _rules("set(x " + "a" * 200 + ")\n")
+
+
+def test_clean_file_has_no_issues():
+    assert not _rules("""\
+if(ENABLE_TESTS)
+  add_subdirectory(tests)
+endif()
+""")

--- a/scripts/kconfig/kconfig_style.py
+++ b/scripts/kconfig/kconfig_style.py
@@ -91,9 +91,40 @@ def _columns(line: str) -> int:
     return len(line.expandtabs(TAB_WIDTH))
 
 
+def _continues(line: str) -> bool:
+    """
+    True if 'line' continues onto the next one via a trailing backslash. The
+    backslash must be the final character: a backslash before trailing
+    whitespace escapes that whitespace rather than continuing the line.
+    """
+    return line.endswith("\\")
+
+
 def _is_continuation(lines: list[str], i: int) -> bool:
     """True if line 'i' continues the previous line via a trailing backslash."""
-    return i > 0 and lines[i - 1].rstrip().endswith("\\")
+    return i > 0 and _continues(lines[i - 1])
+
+
+def _stmt_start(lines: list[str], i: int) -> int:
+    """
+    First line index of the statement that line 'i' belongs to, walking back over
+    backslash continuations (the inverse of _stmt_end).
+    """
+    j = i
+    while j > 0 and _continues(lines[j - 1]):
+        j -= 1
+    return j
+
+
+def _stmt_end(lines: list[str], i: int) -> int:
+    """
+    Last line index of the statement starting at line 'i', following trailing
+    backslash continuations (e.g. a multi-line 'if' condition).
+    """
+    j = i
+    while j < len(lines) - 1 and _continues(lines[j]):
+        j += 1
+    return j
 
 
 def _comment_start(line: str) -> int:
@@ -292,11 +323,17 @@ def _blank_requirements(
             start = _decl_unit_start(lines, i) if kw == "if" else i
             if start > 0:
                 before[start] = ("if-blank", f"add a blank line before '{kw}'")
-            if i < n - 1:
-                after[i] = ("if-blank", f"add a blank line after '{kw}'")
+            # The blank line goes after the whole statement: an 'if' condition
+            # may span several lines via backslash continuations.
+            end = _stmt_end(lines, i)
+            if end < n - 1:
+                after[end] = ("if-blank", f"add a blank line after '{kw}'")
         elif i not in help_body and _is_entry(line):
             start = _decl_unit_start(lines, i)
-            if start > 0 and not OPENERS_RE.match(lines[start - 1]):
+            # No blank line is needed right after a block opener. The preceding
+            # line may be a continuation, so test the opener at the start of that
+            # statement, not the (possibly continued) line directly above.
+            if start > 0 and not OPENERS_RE.match(lines[_stmt_start(lines, start - 1)]):
                 before.setdefault(start, ("decl-blank", "add a blank line before this declaration"))
     return before, after
 

--- a/scripts/kconfig/kconfig_style_test.py
+++ b/scripts/kconfig/kconfig_style_test.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for kconfig_style.py.
+"""
+
+import kconfig_style
+
+
+def _rules(text):
+    """The set of rule ids reported for 'text' (line-based rules)."""
+    lines = text[:-1].split("\n") if text.endswith("\n") else text.split("\n")
+    return {issue.rule for issue in kconfig_style.lint(lines)}
+
+
+def _file_rules(tmp_path, text):
+    """The set of rule ids reported for 'text' written to a real file."""
+    path = tmp_path / "Kconfig"
+    path.write_text(text)
+    return {issue.rule for issue in kconfig_style.check_file(path)}
+
+
+# Rule 1: line length, with the $(...) macro exemption.
+def test_line_too_long_flagged():
+    assert _rules("config " + "A" * 110 + "\n") == {"line-too-long"}
+
+
+def test_line_too_long_macro_exempt():
+    assert not _rules('config X\n\tdefault "$(' + "y" * 110 + ')"\n')
+
+
+# Rule 2: indentation (tabs, flat layout, help body, continuations).
+def test_space_indentation_flagged():
+    assert _rules("""\
+config X
+    default y
+""") == {"tab-indent"}
+
+
+def test_property_single_tab_clean():
+    assert not _rules("""\
+config X
+\tdefault y
+""")
+
+
+def test_property_over_indent_flagged():
+    assert _rules("""\
+config X
+\t\tdefault y
+""") == {"over-indent"}
+
+
+def test_help_body_indent_clean():
+    assert not _rules("""\
+config X
+\thelp
+\t  Help text.
+""")
+
+
+def test_help_body_indent_flagged():
+    # Help body must be one tab plus two spaces; two tabs is wrong.
+    assert _rules("""\
+config X
+\thelp
+\t\tHelp text.
+""") == {"help-indent"}
+
+
+def test_continuation_tabs_clean():
+    assert not _rules("""\
+config X
+\tdepends on A \\
+\t\t|| B
+""")
+
+
+def test_continuation_spaces_flagged():
+    assert _rules("""\
+config X
+\tdepends on A \\
+\t  || B
+""") == {"cont-indent"}
+
+
+# Rule 3: single blank line between declarations, no consecutive blanks.
+def test_consecutive_blank_lines_flagged():
+    assert _rules("""\
+config A
+\tbool
+
+
+config B
+\tbool
+""") == {"blank-lines"}
+
+
+def test_decl_blank_missing_flagged():
+    assert _rules("""\
+config A
+\tbool
+config B
+\tbool
+""") == {"decl-blank"}
+
+
+def test_decl_blank_present_clean():
+    assert not _rules("""\
+config A
+\tbool
+
+config B
+\tbool
+""")
+
+
+def test_decl_after_multiline_opener_no_decl_blank():
+    # A declaration right after a backslash-continued opener needs no decl-blank;
+    # the 'if' still legitimately needs a blank line after it (if-blank).
+    assert _rules("""\
+if B \\
+\t|| C
+config D
+\tbool
+
+endif
+""") == {"if-blank"}
+
+
+# Rule 4: comment spacing.
+def test_comment_space_flagged():
+    assert _rules("#comment\n") == {"comment-space"}
+
+
+def test_comment_space_clean():
+    assert not _rules("# comment\n")
+
+
+# Rule 5: blank lines around top-level if/endif, incl. multi-line conditions.
+def test_if_blank_missing_flagged():
+    assert _rules("""\
+config A
+\tbool
+
+if B
+config C
+\tbool
+
+endif
+""") == {"if-blank"}
+
+
+def test_if_blank_multiline_condition_clean():
+    assert not _rules("""\
+config A
+\tbool
+
+if B \\
+\t|| C
+
+config D
+\tbool
+
+endif
+""")
+
+
+# Rule 6: exactly one trailing newline (whole-file rule).
+def test_final_newline_missing_flagged(tmp_path):
+    assert _file_rules(tmp_path, "config A\n\tbool") == {"final-newline"}
+
+
+def test_final_newline_extra_flagged(tmp_path):
+    assert _file_rules(tmp_path, "config A\n\tbool\n\n") == {"final-newline"}
+
+
+def test_final_newline_single_clean(tmp_path):
+    assert not _file_rules(tmp_path, "config A\n\tbool\n")


### PR DESCRIPTION
The `if-blank` and `decl-blank` checks assumed single-line statements, so a backslash-continued 'if' condition produced false positives: the blank required after 'if' was checked at the keyword line (a continuation line), and the block-opener exemption for declarations tested that continuation line instead of the opener keyword.

Follow continuations to the statement's start and end in both checks. Also require the continuation backslash to be the final character, since a backslash before trailing whitespace escapes it rather than continuing the line.