### PR TITLE
drivers: cmake: remove redunant conditions

### DIFF
--- a/drivers/disk/CMakeLists.txt
+++ b/drivers/disk/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_DISK_DRIVERS)
-
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_SDMMC_SUBSYS sdmmc_subsys.c)
@@ -16,5 +14,3 @@ zephyr_library_sources_ifdef(CONFIG_DISK_DRIVER_LOOPBACK loopback_disk.c)
 zephyr_library_sources_ifdef(CONFIG_DISK_DRIVER_RAM ramdisk.c)
 zephyr_library_sources_ifdef(CONFIG_SDMMC_STM32 sdmmc_stm32.c)
 # zephyr-keep-sorted-stop
-
-endif()

--- a/drivers/sdhc/CMakeLists.txt
+++ b/drivers/sdhc/CMakeLists.txt
@@ -1,6 +1,5 @@
 # Copyright 2022 NXP
 # SPDX-License-Identifier: Apache-2.0
-if(CONFIG_SDHC)
 
 zephyr_library()
 
@@ -27,5 +26,3 @@ zephyr_library_sources_ifdef(CONFIG_SDHC_TI_AM654 sdhc_ti_am654.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_SDHC sdhc_spi.c)
 zephyr_library_sources_ifdef(CONFIG_XLNX_SDHC xlnx_sdhc.c)
 # zephyr-keep-sorted-stop
-
-endif()

--- a/drivers/tee/CMakeLists.txt
+++ b/drivers/tee/CMakeLists.txt
@@ -2,7 +2,5 @@
 
 add_subdirectory_ifdef(CONFIG_OPTEE optee)
 
-if(CONFIG_TEE)
 zephyr_library()
 zephyr_library_sources(tee.c)
-endif()


### PR DESCRIPTION
these drivers are already conditionally
included/added in drivers/CMakeLists.txt
so we dont' need another if.