### PR TITLE
boards: native_sim: doc: Simplify driver vs libC table

### DIFF
--- a/boards/native/native_sim/doc/index.rst
+++ b/boards/native/native_sim/doc/index.rst
@@ -178,9 +178,21 @@ When building with either :ref:`minimal <c_library_minimal>` or :ref:`Picolibc<c
 you will build your code in a more similar way as when building for the embedded target,
 you will be able to test your code interacting with that C library,
 and there will be no conflicts with the :ref:`POSIX OS abstraction<posix_support>` shim,
-but, accessing the host for test purposes from your embedded code will be more
-difficult, and you will have a limited choice of
-:ref:`drivers and backends to chose from<native_sim_peripherals_c_compat>`.
+but, accessing the host for test purposes from your embedded code will be more difficult.
+
+.. _native_sim_peripherals_c_compat:
+
+Peripherals and backends C library compatibility
+================================================
+
+While most native_sim drivers and backends support any C library, the drivers listed below have
+limited compatibility:
+
+.. csv-table:: Drivers/backends limited to some libCs
+   :header: "Driver class", "Driver name", "Driver Kconfig", "libC choices"
+
+   "Bluetooth", ":ref:`Userchan <nsim_bt_host_cont>`", ":kconfig:option:`CONFIG_BT_USERCHAN`", "Host and pico libC"
+   "USB", ":ref:`USB native posix <nsim_per_usb>`", ":kconfig:option:`CONFIG_USB_NATIVE_POSIX`", "Host libC"
 
 Cross-compiling native_sim
 **************************
@@ -772,42 +784,3 @@ To mount a host directory, pass the ``-volume`` option to the executable on the 
 The option follows Docker volume mount syntax: ``HOST-DIR:ZEPHYR-DIR[:ro]``. An optional ``:ro``
 suffix mounts the volume as read-only. The option can be provided multiple times to mount several
 host directories.
-
-.. _native_sim_peripherals_c_compat:
-
-Peripherals and backends C library compatibility
-************************************************
-
-Today, some native_sim peripherals and backends are, so far, only available when compiling with the
-host libC (:kconfig:option:`CONFIG_EXTERNAL_LIBC`):
-
-.. csv-table:: Drivers/backends vs libC choice
-   :header: Driver class, driver name, driver kconfig, libC choices
-
-     ADC, ADC emul, :kconfig:option:`CONFIG_ADC_EMUL`, All
-     Bluetooth, :ref:`Userchan <nsim_bt_host_cont>`, :kconfig:option:`CONFIG_BT_USERCHAN`, Host and pico libC
-     CAN, CAN native Linux, :kconfig:option:`CONFIG_CAN_NATIVE_LINUX`, All
-     Console backend, :ref:`POSIX arch console <nsim_back_console>`, :kconfig:option:`CONFIG_POSIX_ARCH_CONSOLE`, All
-     Display, :ref:`Display SDL <nsim_per_disp_sdl>`, :kconfig:option:`CONFIG_SDL_DISPLAY`, All
-     Entropy, :ref:`Native simulator entropy <nsim_per_entr>`, :kconfig:option:`CONFIG_FAKE_ENTROPY_NATIVE_SIM`, All
-     EEPROM, EEPROM simulator, :kconfig:option:`CONFIG_EEPROM_SIMULATOR`, All
-     EEPROM, EEPROM emulator, :kconfig:option:`CONFIG_EEPROM_EMULATOR`, All
-     Ethernet, :ref:`Eth native_tap <nsim_per_ethe>`, :kconfig:option:`CONFIG_ETH_NATIVE_TAP`, All
-     Flash, :ref:`Flash simulator <nsim_per_flash_simu>`, :kconfig:option:`CONFIG_FLASH_SIMULATOR`, All
-     File System, :ref:`Host filesystem mount <native_mount_fs>`, :kconfig:option:`CONFIG_FILE_SYSTEM_NATIVE_MOUNT`, All
-     FUSE, :ref:`Host based filesystem access <native_fuse_flash>`, :kconfig:option:`CONFIG_FUSE_FS_ACCESS`, All
-     GPIO, GPIO emulator, :kconfig:option:`CONFIG_GPIO_EMUL`, All
-     GPIO, SDL GPIO emulator, :kconfig:option:`CONFIG_GPIO_EMUL_SDL`, All
-     HWINFO, HWINFO native, :kconfig:option:`CONFIG_HWINFO_NATIVE`, All
-     I2C, I2C emulator, :kconfig:option:`CONFIG_I2C_EMUL`, All
-     Input, Input SDL touch, :kconfig:option:`CONFIG_INPUT_SDL_TOUCH`, All
-     Input, Linux evdev, :kconfig:option:`CONFIG_NATIVE_LINUX_EVDEV`, All
-     Logger backend, :ref:`Native backend <nsim_back_logger>`, :kconfig:option:`CONFIG_LOG_BACKEND_NATIVE_POSIX`, All
-     Offloaded sockets, :ref:`nsim_per_offloaded_sockets`, :kconfig:option:`CONFIG_NET_NATIVE_OFFLOADED_SOCKETS`, All
-     RTC, RTC emul, :kconfig:option:`CONFIG_RTC_EMUL`, All
-     Serial, :ref:`UART native PTY <native_ptty_uart>`, :kconfig:option:`CONFIG_UART_NATIVE_PTY`, All
-     Serial, :ref:`UART native TTY <native_tty_uart>`, :kconfig:option:`CONFIG_UART_NATIVE_TTY`, All
-     SPI, SPI emul, :kconfig:option:`CONFIG_SPI_EMUL`, All
-     System tick, Native_sim timer, :kconfig:option:`CONFIG_NATIVE_SIM_TIMER`, All
-     Tracing, :ref:`Posix tracing backend <nsim_back_trace>`, :kconfig:option:`CONFIG_TRACING_BACKEND_POSIX`, All
-     USB, :ref:`USB native posix <nsim_per_usb>`, :kconfig:option:`CONFIG_USB_NATIVE_POSIX`, Host libC


### PR DESCRIPTION
This table has quite many missing entries.
Anyhow, since the majority of drivers support any libC there is no need to list all explicitly. Let's just list the exceptions.
Let's also move that as a subsection of the C library choice section.