### PR TITLE
Sysbuild: Fix cmake warnings "unused variables" due to presets file

### DIFF
--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -942,7 +942,7 @@ Running sysbuild with preset.
 
       .. code-block:: shell
 
-         APP_DIR=samples/hello_world cmake -Bbuild -GNinja -DBOARD=reel_board share/sysbuild
+         APP_DIR=samples/hello_world cmake -Bbuild -GNinja -DBOARD=reel_board --preset=release share/sysbuild
          ninja -Cbuild
 
       When using CMake presets with sysbuild then ``APP_DIR`` must be set in environment in order

--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -915,17 +915,39 @@ Sysbuild but not all preset macros will work as expected.
 
    Using CMake presets with sysbuild requires CMake version 3.27 or higher.
 
-As described in :ref:`sysbuild` then sysbuild is a higher-level build system which means that when
-CMake presets are used together with sysbuild, then the preset is consumed and processed by sysbuild
-itself and result is passed to the application.
+As described in :ref:`sysbuild` sysbuild is a higher-level build system overseeing
+the build of multiple applications. This means for the build process two preset files apply:
+one for the high level sysbuild CMake process and one for the individual application build process.
 
-Running sysbuild with preset.
+The high level sysbuild preset file is located in the application's sysbuild
+configuration folder ``<application>/sysbuild/CMakePresets.json``. See :ref:`sysbuild_application_configuration`.
+You can set variables that apply to sysbuild itself and to all images that are part of the sysbuild project.
+Or use domain specific variables to set variables for a specific image, see :ref:`sysbuild_cmake_namespace`
+
+Example snippet sysbuild preset file:
+
+.. code-block:: json
+
+   "cacheVariables": {
+      "CMAKE_MESSAGE_LOG_LEVEL": "STATUS",
+      "BOARD": "Board name of project",
+      "BOARD_QUALIFIERS": "Qualifier for all applications in the sysbuild project",
+      "<domain>_BOARD_QUALIFIERS": "Board qualifier for a specific domain"
+   }
+
+The application preset file is located in the application's source folder ``<application>/CMakePresets.json``
+and is only used for the build process of the application itself. This is the CMake default behaviour.
+Selecting a preset for a specific application is currently not possible `#111494 <https://github.com/zephyrproject-rtos/zephyr/issues/111494>`_.
+
+Running sysbuild with a preset selection
+========================================
+
+Here is an example of how to run sysbuild with the ``release`` preset:
 
 .. tabs::
 
    .. group-tab:: ``west build``
 
-      Here is an example where preset ``release`` should be used.
       For details, see :ref:`west-multi-domain-builds` in the ``west build documentation``.
 
       .. zephyr-app-commands::
@@ -938,15 +960,13 @@ Running sysbuild with preset.
 
    .. group-tab:: ``cmake``
 
-      Here is an example using CMake and Ninja.
-
       .. code-block:: shell
 
          APP_DIR=samples/hello_world cmake -Bbuild -GNinja -DBOARD=reel_board --preset=release share/sysbuild
          ninja -Cbuild
 
-      When using CMake presets with sysbuild then ``APP_DIR`` must be set in environment in order
-      for Sysbuild CMake to be able to include the ``CMakePresets.json`` from the main Zephyr
+      When using CMake presets with sysbuild, ``APP_DIR`` must be set as an environment variable
+      in order for sysbuild's CMake process to be able to include the ``CMakePresets.json`` from the
       application's source directory.
 
 .. note::

--- a/share/sysbuild/CMakePresets.json
+++ b/share/sysbuild/CMakePresets.json
@@ -6,6 +6,6 @@
     "patch": 0
   },
   "include": [
-    "$penv{APP_DIR}/CMakePresets.json"
+    "$penv{APP_DIR}/sysbuild/CMakePresets.json"
   ]
 }


### PR DESCRIPTION
**Introduction**

The current [CMake presets](https://docs.zephyrproject.org/latest/build/sysbuild/index.html#sysbuild-and-cmake-presets) implementation includes the `CMakePresets.json` file from `APP_DIR`, i.e., the CMake presets file for the application itself.

This works fine at first glance. However, an issue arises when variables are defined for the sysbuild process itself.

When compiling the application located in `APP_DIR`, CMake automatically includes the presets file from that directory. CMake then detects that certain variables are not used during the application build process and issues warnings. These variables are intended for the sysbuild process itself, not for the application.

**Proposed change**

My proposal (and the content of this PR) is to separate the CMake presets used for the sysbuild process from those used for building the application.

The presets file for the sysbuild process is moved to the sysbuild configuration directory, `<application>/sysbuild/CMakePresets.json`, while `<application>/CMakePresets.json` remains available for the application itself, following CMake's default behavior.

**Documentation update**

- Reflect this change.
- Clarify the sysbuild/presets workflow and preset scoping.
- Fix a missing flag in the CMake/Ninja example.
- Add a reference to issue #111494 documenting the current limitation of per-image preset selection (which I am working to resolve in a follow-up PR: https://github.com/zephyrproject-rtos/zephyr/pull/114947).