### PR TITLE
soc: renesas: ra: add missing endif

### DIFF
--- a/soc/renesas/ra/ra8p1/sections.ld
+++ b/soc/renesas/ra/ra8p1/sections.ld
@@ -71,3 +71,5 @@ SECTION_DATA_PROLOGUE(.option_setting_otp_pbps_sec, DT_REG_ADDR(DT_NODELABEL(opt
 	KEEP(*(.option_setting_otp_pbps_sec))
 } GROUP_LINK_IN(OFS_OTP_PBPS_SEC_MEMORY)
 #endif
+
+#endif

--- a/soc/renesas/ra/ra8t1/sections.ld
+++ b/soc/renesas/ra/ra8t1/sections.ld
@@ -78,3 +78,5 @@ SECTION_DATA_PROLOGUE(.option_setting_bps_sel, DT_REG_ADDR(DT_NODELABEL(option_s
 	KEEP(*(.option_setting_bps_sel))
 } GROUP_LINK_IN(OFS_BPS_SEL_MEMORY)
 #endif
+
+#endif


### PR DESCRIPTION
add missing endif, forgotten in
fbd79da3b66b22b5afbc04a62a12367d5d36533b #114429