### PR TITLE
dts: arm: st: stm32h7: add vrefbuf node

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1348,6 +1348,15 @@
 			resets = <&rctl STM32_RESET(AHB4, 19)>;
 			status = "disabled";
 		};
+
+		vrefbuf: vrefbuf@58003c00 {
+			compatible = "st,stm32-vrefbuf";
+			reg = <0x58003c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB4, 15)>;
+			resets = <&rctl STM32_RESET(APB4, 15)>;
+			ref-voltages = <2500000>, <2048000>, <1800000>, <1500000>;
+			status = "disabled";
+		};
 	};
 
 	die_temp: dietemp {


### PR DESCRIPTION
Adds VREFBUF peripheral to STM32H7.

As https://github.com/zephyrproject-rtos/hal_stm32/pull/381 is available, the node can be added. 

Closes https://github.com/zephyrproject-rtos/zephyr/issues/102301.

Specified following RM0455 (_rev 13_), RM0468 (_rev 3_). Functionality tested with a custom board.


