### PR TITLE
tests: Bluetooth: Audio: Add stopping condition for RX checks

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_common.c
+++ b/tests/bsim/bluetooth/audio/src/bap_common.c
@@ -164,3 +164,12 @@ bool audio_test_stream_is_streaming(const struct audio_test_stream *test_stream)
 {
 	return cap_stream_is_streaming(&test_stream->stream);
 }
+
+void bap_unicast_stream_disconnected_cb(struct bt_bap_stream *stream, uint8_t reason)
+{
+	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
+
+	LOG_INF("Disconnected stream %p with reason %u", stream, reason);
+
+	UNSET_FLAG(test_stream->stopping);
+}

--- a/tests/bsim/bluetooth/audio/src/bap_common.h
+++ b/tests/bsim/bluetooth/audio/src/bap_common.h
@@ -120,4 +120,5 @@ static inline bool valid_metadata_type(uint8_t type, uint8_t len)
 bool bap_stream_is_streaming(const struct bt_bap_stream *bap_stream);
 bool cap_stream_is_streaming(const struct bt_cap_stream *cap_stream);
 bool audio_test_stream_is_streaming(const struct audio_test_stream *test_stream);
+void bap_unicast_stream_disconnected_cb(struct bt_bap_stream *stream, uint8_t reason);
 #endif /* ZEPHYR_TEST_BSIM_BT_AUDIO_TEST_COMMON_ */

--- a/tests/bsim/bluetooth/audio/src/bap_stream_rx.c
+++ b/tests/bsim/bluetooth/audio/src/bap_stream_rx.c
@@ -100,7 +100,7 @@ void bap_stream_rx_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 	if (info->flags & BT_ISO_FLAGS_LOST) {
 		log_stream_err(test_stream, info, buf);
 
-		if (test_stream->valid_rx_cnt > 1U) {
+		if (!TEST_FLAG(test_stream->stopping) && test_stream->valid_rx_cnt > 1U) {
 			FAIL("ISO receive lost\n");
 		}
 	}

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -147,7 +147,7 @@ static void stream_connected(struct bt_bap_stream *stream)
 
 static void stream_disconnected(struct bt_bap_stream *stream, uint8_t reason)
 {
-	LOG_INF("Disconnected stream %p with reason %u", stream, reason);
+	bap_unicast_stream_disconnected_cb(stream, reason);
 
 	SET_FLAG(flag_stream_disconnected);
 }
@@ -967,14 +967,17 @@ static void transceive_streams(void)
 static void disable_streams(size_t stream_cnt)
 {
 	for (size_t i = 0U; i < stream_cnt; i++) {
+		struct audio_test_stream *test_stream = &test_streams[i];
 		int err;
 
 		UNSET_FLAG(flag_operation_success);
 		UNSET_FLAG(flag_stream_disabled);
 
+		/* Mark stream as stopping to not treat lost SDUs as a failure condition */
+		SET_FLAG(test_stream->stopping);
+
 		do {
-			err = bt_bap_stream_disable(
-				bap_stream_from_audio_test_stream(&test_streams[i]));
+			err = bt_bap_stream_disable(bap_stream_from_audio_test_stream(test_stream));
 			if (err == -EBUSY) {
 				k_sleep(BAP_RETRY_WAIT);
 			} else if (err != 0) {

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -212,9 +212,14 @@ static int lc3_metadata(struct bt_bap_stream *stream, const uint8_t meta[], size
 
 static int lc3_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
+
 	ARG_UNUSED(rsp);
 
 	LOG_INF("Disable: stream %p", stream);
+
+	/* Mark stream as stopping to not treat lost SDUs as a failure condition */
+	SET_FLAG(test_stream->stopping);
 
 	return 0;
 }
@@ -230,9 +235,14 @@ static int lc3_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 
 static int lc3_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
+
 	ARG_UNUSED(rsp);
 
 	LOG_INF("Release: stream %p", stream);
+
+	/* Mark stream as stopping to not treat lost SDUs as a failure condition */
+	SET_FLAG(test_stream->stopping);
 
 	return 0;
 }
@@ -336,6 +346,7 @@ static struct bt_bap_stream_ops stream_ops = {
 	.stopped = stream_stopped_cb,
 	.recv = bap_stream_rx_recv_cb,
 	.sent = bap_stream_tx_sent_cb,
+	.disconnected = bap_unicast_stream_disconnected_cb,
 };
 
 static void transceive_test_streams(void)

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -547,6 +547,7 @@ static struct bt_bap_stream_ops unicast_stream_ops = {
 	.stopped = unicast_stream_stopped,
 	.sent = bap_stream_tx_sent_cb,
 	.recv = bap_stream_rx_recv_cb,
+	.disconnected = bap_unicast_stream_disconnected_cb,
 };
 
 static void pa_sync_create(void)
@@ -838,15 +839,21 @@ static int unicast_server_metadata(struct bt_bap_stream *stream, const uint8_t m
 
 static int unicast_server_disable(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
+
 	ARG_UNUSED(rsp);
 
 	LOG_INF("Disable: stream %p", stream);
+
+	/* Mark stream as stopping to not treat lost SDUs as a failure condition */
+	SET_FLAG(test_stream->stopping);
 
 	return 0;
 }
 
 static int unicast_server_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+
 	ARG_UNUSED(rsp);
 
 	LOG_INF("Stop: stream %p", stream);
@@ -856,9 +863,14 @@ static int unicast_server_stop(struct bt_bap_stream *stream, struct bt_bap_ascs_
 
 static int unicast_server_release(struct bt_bap_stream *stream, struct bt_bap_ascs_rsp *rsp)
 {
+	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
+
 	ARG_UNUSED(rsp);
 
 	LOG_INF("Release: stream %p", stream);
+
+	/* Mark stream as stopping to not treat lost SDUs as a failure condition */
+	SET_FLAG(test_stream->stopping);
 
 	return 0;
 }

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -249,6 +249,7 @@ static struct bt_bap_stream_ops unicast_stream_ops = {
 	.released = unicast_stream_released,
 	.sent = bap_stream_tx_sent_cb,
 	.recv = bap_stream_rx_recv_cb,
+	.disconnected = bap_unicast_stream_disconnected_cb,
 };
 
 static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
@@ -845,6 +846,14 @@ static void cap_initiator_unicast_audio_stop(struct bt_cap_unicast_group *unicas
 	/* Stop without release first to verify that we enter the QoS Configured state */
 	UNSET_FLAG(flag_stopped);
 	LOG_INF("Stopping without releasing");
+
+	/* Mark streams as stopping to not treat lost SDUs as a failure condition */
+	for (size_t i = 0U; i < non_idle_streams_cnt; i++) {
+		struct audio_test_stream *test_stream =
+			audio_test_stream_from_cap_stream(non_idle_streams[i]);
+
+		SET_FLAG(test_stream->stopping);
+	}
 
 	err = bt_cap_initiator_unicast_audio_stop(&param);
 	if (err != 0) {

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -145,6 +145,7 @@ struct audio_test_stream {
 	size_t rx_cnt;
 	size_t valid_rx_cnt;
 	atomic_t flag_audio_received;
+	atomic_t stopping;
 	bool last_rx_failed;
 };
 


### PR DESCRIPTION
Add a boolean value in `struct audio_test_stream` to mark when a stream is being stopped. When a stream is being stopped, then there may be a small period of time between the BAP stream leaving the streaming state, and the CIS being disconnected. When we are in that period, we do not want to consider lost data as a failure condition as that can happen by design.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/112496