### PR TITLE
drivers: native_sim*: Add missing dependency

### DIFF
--- a/drivers/audio/Kconfig.dmic_native_sim
+++ b/drivers/audio/Kconfig.dmic_native_sim
@@ -6,6 +6,7 @@ config AUDIO_DMIC_NATIVE_SIM
 	bool "Native simulator DMIC driver"
 	depends on DT_HAS_ZEPHYR_NATIVE_SIM_DMIC_ENABLED
 	default y
+	select NATIVE_USE_NSI_ERRNO
 	help
 	  Enable the native simulator DMIC driver.
 

--- a/drivers/i2s/Kconfig.native_sim
+++ b/drivers/i2s/Kconfig.native_sim
@@ -5,6 +5,7 @@ config I2S_NATIVE_SIM
 	bool "native_sim I2S file backend"
 	depends on DT_HAS_ZEPHYR_NATIVE_SIM_I2S_ENABLED
 	default y
+	select NATIVE_USE_NSI_ERRNO
 	help
 	  Enable a native_sim I2S backend which reads RX PCM samples from a host
 	  file and writes TX PCM samples to a host file.

--- a/drivers/led/Kconfig.linux-leds
+++ b/drivers/led/Kconfig.linux-leds
@@ -6,6 +6,7 @@ config NATIVE_LINUX_LEDS
 	default y
 	depends on DT_HAS_ZEPHYR_NATIVE_LINUX_LEDS_ENABLED
 	depends on ARCH_POSIX
+	select NATIVE_USE_NSI_ERRNO
 	help
 	  Enable a native_sim LED driver backed by Linux sysfs LEDs.
 	  Each DT `native-linux-leds` child node provides a Linux LED name (as

--- a/drivers/serial/Kconfig.native_tty
+++ b/drivers/serial/Kconfig.native_tty
@@ -4,6 +4,7 @@ config UART_NATIVE_TTY
 	bool "UART driver for interacting with host serial ports"
 	default y
 	depends on DT_HAS_ZEPHYR_NATIVE_TTY_UART_ENABLED
+	select NATIVE_USE_NSI_ERRNO
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	select SERIAL_HAS_POST_KERNEL_INIT if UART_INTERRUPT_DRIVEN

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -132,6 +132,7 @@ config FILE_SYSTEM_NATIVE_MOUNT
 	bool "Mount Native Simulator host FS to Zephyr"
 	depends on ARCH_POSIX
 	select NATIVE_USE_NSI_FCNTL
+	select NATIVE_USE_NSI_ERRNO
 	help
 	  Mount a path in the host file system in Zephyr. This allows Zephyr to access, and modify,
 	  host files and folders, like any other embedded mount point.


### PR DESCRIPTION
These drivers need the nsi_errno conversion component.
Let's make sure we build it by selecting it.

(Without enabling it the code still links, but the conversion converts back and forth from/to the host libC values, and not into the embedded ones, as the embedded code links with the runner side version of the functions which are always present. This just results in incorrect errno reporting, which is not really catastrophic)

