### PR TITLE
Bluetooth: audio: Fix VOCS and AICS client instances on alloc fail

### DIFF
--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -371,6 +371,7 @@ New APIs and options
 
   * Audio
 
+    * :c:func:`bt_aics_client_free_instance`
     * :c:func:`bt_ascs_register`
     * :c:func:`bt_ascs_unregister`
     * :c:func:`bt_bap_unicast_client_qos_from_group`
@@ -385,6 +386,7 @@ New APIs and options
     * :c:member:`bt_bap_unicast_group_info.c_to_p_ft`
     * :c:member:`bt_bap_unicast_group_info.p_to_c_ft`
     * :c:member:`bt_bap_unicast_group_info.iso_interval`
+    * :c:func:`bt_vocs_client_free_instance`
 
   * Host
 

--- a/include/zephyr/bluetooth/audio/aics.h
+++ b/include/zephyr/bluetooth/audio/aics.h
@@ -562,6 +562,18 @@ int bt_aics_description_set(struct bt_aics *inst, const char *description);
 struct bt_aics *bt_aics_client_free_instance_get(void);
 
 /**
+ * @brief Free an instance received from bt_aics_client_free_instance_get()
+ *
+ * @param inst The instance to free
+ *
+ * @retval 0 Success.
+ * @retval -EINVAL @p inst is NULL or not a client instance.
+ * @retval -EALREADY @p inst is already free.
+ * @retval -EBUSY @p inst is busy.
+ */
+int bt_aics_client_free_instance(struct bt_aics *inst);
+
+/**
  * @brief Registers the callbacks for the Audio Input Control Service client.
  *
  * @param inst      The instance pointer.

--- a/include/zephyr/bluetooth/audio/vocs.h
+++ b/include/zephyr/bluetooth/audio/vocs.h
@@ -324,6 +324,18 @@ void bt_vocs_client_cb_register(struct bt_vocs *inst, struct bt_vocs_cb *cb);
 struct bt_vocs *bt_vocs_client_free_instance_get(void);
 
 /**
+ * @brief Free an instance received from bt_vocs_client_free_instance_get()
+ *
+ * @param inst The instance to free
+ *
+ * @retval 0 Success.
+ * @retval -EINVAL @p inst is NULL or not a client instance.
+ * @retval -EALREADY @p inst is already free
+ * @retval -EBUSY @p inst is busy.
+ */
+int bt_vocs_client_free_instance(struct bt_vocs *inst);
+
+/**
  * @brief Discover a Volume Offset Control Service.
  *
  * Attempts to discover a Volume Offset Control Service on a server given the @p param.

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -777,6 +777,34 @@ struct bt_aics *bt_aics_client_free_instance_get(void)
 	return NULL;
 }
 
+int bt_aics_client_free_instance(struct bt_aics *aics)
+{
+	ARRAY_FOR_EACH_PTR(aics_insts, inst) {
+		if (aics == inst) {
+			if (!atomic_test_bit(inst->cli.flags, BT_AICS_CLIENT_FLAG_ACTIVE)) {
+				return -EALREADY;
+			}
+
+			/* Test and set the BT_AICS_CLIENT_FLAG_BUSY flag here to reduce, but not
+			 * eliminate, chance of any operations happening while we are free'ing this
+			 * instance.
+			 */
+			if (atomic_test_and_set_bit(inst->cli.flags, BT_AICS_CLIENT_FLAG_BUSY)) {
+				return -EBUSY;
+			}
+
+			aics_client_reset(inst);
+
+			atomic_clear_bit(inst->cli.flags, BT_AICS_CLIENT_FLAG_BUSY);
+			atomic_clear_bit(inst->cli.flags, BT_AICS_CLIENT_FLAG_ACTIVE);
+
+			return 0;
+		}
+	}
+
+	return -EINVAL;
+}
+
 int bt_aics_client_conn_get(const struct bt_aics *aics, struct bt_conn **conn)
 {
 	if (aics == NULL) {

--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -32,6 +32,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
+#include "aics_internal.h"
 #include "common/bt_str.h"
 #include "micp_internal.h"
 
@@ -42,6 +43,20 @@ static sys_slist_t micp_mic_ctlr_cbs = SYS_SLIST_STATIC_INIT(&micp_mic_ctlr_cbs)
 
 static struct bt_micp_mic_ctlr mic_ctlrs[CONFIG_BT_MAX_CONN];
 static const struct bt_uuid *mics_uuid = BT_UUID_MICS;
+
+#if defined(CONFIG_BT_MICP_MIC_CTLR_AICS)
+static void micp_mic_ctlr_client_free_aics(void)
+{
+	ARRAY_FOR_EACH_PTR(mic_ctlrs, mic_ctlr) {
+		ARRAY_FOR_EACH_PTR(mic_ctlr->aics, aics) {
+			if (*aics != NULL) {
+				bt_aics_client_free_instance(*aics);
+				*aics = NULL;
+			}
+		}
+	}
+}
+#endif /* CONFIG_BT_MICP_MIC_CTLR_AICS */
 
 static struct bt_micp_mic_ctlr *mic_ctlr_get_by_conn(const struct bt_conn *conn)
 {
@@ -583,6 +598,7 @@ int bt_micp_mic_ctlr_discover(struct bt_conn *conn, struct bt_micp_mic_ctlr **mi
 				mic_ctlrs[i].aics[j] = bt_aics_client_free_instance_get();
 
 				if (mic_ctlrs[i].aics[j] == NULL) {
+					micp_mic_ctlr_client_free_aics();
 					bt_conn_unref(ref);
 					err = -ENOMEM;
 					goto cleanup;

--- a/subsys/bluetooth/audio/vcp_vol_ctlr.c
+++ b/subsys/bluetooth/audio/vcp_vol_ctlr.c
@@ -33,7 +33,9 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
+#include "aics_internal.h"
 #include "common/bt_str.h"
+#include "vocs_internal.h"
 #include "vcp_internal.h"
 
 LOG_MODULE_REGISTER(bt_vcp_vol_ctlr, CONFIG_BT_VCP_VOL_CTLR_LOG_LEVEL);
@@ -44,6 +46,34 @@ static sys_slist_t vcp_vol_ctlr_cbs = SYS_SLIST_STATIC_INIT(&vcp_vol_ctlr_cbs);
 static struct bt_vcp_vol_ctlr vol_ctlr_insts[CONFIG_BT_MAX_CONN];
 static int write_common_vcs_cp(struct bt_vcp_vol_ctlr *vol_ctlr);
 static int write_set_vol_cp(struct bt_vcp_vol_ctlr *vol_ctlr);
+
+#if defined(CONFIG_BT_VCP_VOL_CTLR_VOCS)
+static void vcp_vol_ctlr_free_vocs_client(void)
+{
+	ARRAY_FOR_EACH_PTR(vol_ctlr_insts, vol_ctlr) {
+		ARRAY_FOR_EACH_PTR(vol_ctlr->vocs, vocs) {
+			if (*vocs != NULL) {
+				bt_vocs_client_free_instance(*vocs);
+				*vocs = NULL;
+			}
+		}
+	}
+}
+#endif /* CONFIG_BT_VCP_VOL_CTLR_VOCS */
+
+#if defined(CONFIG_BT_VCP_VOL_CTLR_AICS)
+static void vcp_vol_ctlr_free_aics_client(void)
+{
+	ARRAY_FOR_EACH_PTR(vol_ctlr_insts, vol_ctlr) {
+		ARRAY_FOR_EACH_PTR(vol_ctlr->aics, aics) {
+			if (*aics != NULL) {
+				bt_aics_client_free_instance(*aics);
+				*aics = NULL;
+			}
+		}
+	}
+}
+#endif /* CONFIG_BT_VCP_VOL_CTLR_AICS */
 
 static struct bt_vcp_vol_ctlr *vol_ctlr_get_by_conn(const struct bt_conn *conn)
 {
@@ -879,7 +909,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.disconnected = disconnected,
 };
 
-static void bt_vcp_vol_ctlr_init(void)
+static int bt_vcp_vol_ctlr_init(void)
 {
 #if defined(CONFIG_BT_VCP_VOL_CTLR_VOCS)
 	for (size_t i = 0U; i < ARRAY_SIZE(vol_ctlr_insts); i++) {
@@ -894,8 +924,10 @@ static void bt_vcp_vol_ctlr_init(void)
 
 			vol_ctlr_insts[i].vocs[j] = bt_vocs_client_free_instance_get();
 
-			__ASSERT(vol_ctlr_insts[i].vocs[j],
-				 "Could not allocate VOCS client instance");
+			if (vol_ctlr_insts[i].vocs[j] == NULL) {
+				vcp_vol_ctlr_free_vocs_client();
+				return -ENOMEM;
+			}
 
 			bt_vocs_client_cb_register(vol_ctlr_insts[i].vocs[j], &vocs_cb);
 		}
@@ -921,13 +953,20 @@ static void bt_vcp_vol_ctlr_init(void)
 
 			vol_ctlr_insts[i].aics[j] = bt_aics_client_free_instance_get();
 
-			__ASSERT(vol_ctlr_insts[i].aics[j],
-				 "Could not allocate AICS client instance");
+			if (vol_ctlr_insts[i].aics[j] == NULL) {
+				vcp_vol_ctlr_free_aics_client();
+#if defined(CONFIG_BT_VCP_VOL_CTLR_VOCS)
+				vcp_vol_ctlr_free_vocs_client();
+#endif /* CONFIG_BT_VCP_VOL_CTLR_VOCS */
+				return -ENOMEM;
+			}
 
 			bt_aics_client_cb_register(vol_ctlr_insts[i].aics[j], &aics_cb);
 		}
 	}
 #endif /* CONFIG_BT_VCP_VOL_CTLR_AICS */
+
+	return 0;
 }
 
 int bt_vcp_vol_ctlr_discover(struct bt_conn *conn, struct bt_vcp_vol_ctlr **out_vol_ctlr)
@@ -965,7 +1004,11 @@ int bt_vcp_vol_ctlr_discover(struct bt_conn *conn, struct bt_vcp_vol_ctlr **out_
 	}
 
 	if (!initialized) {
-		bt_vcp_vol_ctlr_init();
+		err = bt_vcp_vol_ctlr_init();
+		if (err != 0) {
+			goto cleanup;
+		}
+
 		initialized = true;
 	}
 

--- a/subsys/bluetooth/audio/vocs_client.c
+++ b/subsys/bluetooth/audio/vocs_client.c
@@ -716,6 +716,34 @@ static void vocs_client_reset(struct bt_vocs_client *inst)
 	bt_conn_drop(&inst->conn);
 }
 
+int bt_vocs_client_free_instance(struct bt_vocs *vocs)
+{
+	ARRAY_FOR_EACH_PTR(insts, inst) {
+		if (vocs == &inst->vocs) {
+			if (!atomic_test_bit(inst->flags, BT_VOCS_CLIENT_FLAG_ACTIVE)) {
+				return -EALREADY;
+			}
+
+			/* Test and set the BT_VOCS_CLIENT_FLAG_BUSY flag here to reduce, but not
+			 * eliminate, chance of any operations happening while we are free'ing this
+			 * instance.
+			 */
+			if (atomic_test_and_set_bit(inst->flags, BT_VOCS_CLIENT_FLAG_BUSY)) {
+				return -EBUSY;
+			}
+
+			vocs_client_reset(inst);
+
+			atomic_clear_bit(inst->flags, BT_VOCS_CLIENT_FLAG_BUSY);
+			atomic_clear_bit(inst->flags, BT_VOCS_CLIENT_FLAG_ACTIVE);
+
+			return 0;
+		}
+	}
+
+	return -EINVAL;
+}
+
 int bt_vocs_discover(struct bt_conn *conn, struct bt_vocs *vocs,
 		     const struct bt_vocs_discover_param *param)
 {


### PR DESCRIPTION
Fixes issue with VCP and MICP init failures not cleaning up allocated AICS and VOCS instances.

Assisted-by: copilot-swe-agent

fixes https://github.com/zephyrproject-rtos/zephyr/issues/109776