### PR TITLE
modules: nrf_wifi: Support switching the nRF70 supply rail

### DIFF
--- a/dts/bindings/wifi/nordic,nrf70.yaml
+++ b/dts/bindings/wifi/nordic,nrf70.yaml
@@ -1,6 +1,10 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+# power.yaml provides supply-gpios and vin-supply, which control the
+# VBAT/BUCKVBAT/AFEVBAT supply of the nRF70.
+include: power.yaml
+
 properties:
   iovdd-ctrl-gpios:
     type: phandle-array
@@ -36,3 +40,12 @@ properties:
     description: |
       Duration to wait after enabling IOVDD before attempting communications.
       Default value of 1 comes from the nRF7002 DK/EK switch (TCK106AG): ~600us
+
+  supply-power-up-delay-ms:
+    type: int
+    default: 6
+    description: |
+      Duration to wait after enabling the supply (supply-gpios and/or vin-supply)
+      before asserting BUCKEN.
+      Default value of 6 comes from the nRF7002 datasheet section 14.3.5 Supply
+      sequencing requirements which states Wait >= 6 ms

--- a/modules/nrf_wifi/bus/Kconfig
+++ b/modules/nrf_wifi/bus/Kconfig
@@ -23,6 +23,31 @@ config NRF70_ON_SPI
 			 $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF7000_SPI))
 	select SPI
 
+config NRF70_SUPPLY_GPIO
+	def_bool $(dt_nodelabel_has_prop,nrf70,supply-gpios)
+	help
+	  Selected when the nRF70 supply rail is switched by a GPIO.
+
+config NRF70_VIN_SUPPLY
+	def_bool $(dt_nodelabel_has_prop,nrf70,vin-supply)
+	select REGULATOR
+	help
+	  Selected when the nRF70 supply rail is fed from a regulator, so that
+	  the regulator API the driver calls is built.
+
+config NRF70_SUPPLY
+	def_bool NRF70_SUPPLY_GPIO || NRF70_VIN_SUPPLY
+	help
+	  Selected when this driver switches the nRF70 supply rail, by either
+	  method.
+
+config NRF70_IOVDD_REGULATOR
+	def_bool $(dt_nodelabel_has_prop,nrf70,iovdd-regulator)
+	select REGULATOR
+	help
+	  Selected when IOVDD is fed from a regulator instead of a dedicated
+	  GPIO, so that the regulator API the driver calls is built.
+
 module = WIFI_NRF70_BUSLIB
 module-dep = LOG
 module-str = Log level for Wi-Fi nRF70 bus library

--- a/modules/nrf_wifi/bus/rpu_hw_if.c
+++ b/modules/nrf_wifi/bus/rpu_hw_if.c
@@ -17,6 +17,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/drivers/regulator.h>
 #include <zephyr/drivers/wifi/nrf_wifi/bus/rpu_hw_if.h>
 #include <zephyr/drivers/wifi/nrf_wifi/bus/qspi_if.h>
 
@@ -37,14 +38,29 @@ GPIO_DT_SPEC_GET(NRF7002_NODE, iovdd_ctrl_gpios);
 
 #elif DT_NODE_HAS_PROP(NRF7002_NODE, iovdd_regulator)
 
-#include <zephyr/drivers/regulator.h>
-
 static const struct device *iovdd_regulator =
 DEVICE_DT_GET(DT_PHANDLE(NRF7002_NODE, iovdd_regulator));
 
 #else
 #error "nRF70 device either needs iovdd-ctrl-gpios or iovdd-regulator property"
 #endif
+
+/* Always defined so the code below builds regardless of the devicetree. The
+ * GPIO port and the regulator device are NULL when the matching property is
+ * absent.
+ */
+static const struct gpio_dt_spec supply_spec =
+GPIO_DT_SPEC_GET_OR(NRF7002_NODE, supply_gpios, {0});
+
+static const struct device *vin_supply =
+DEVICE_DT_GET_OR_NULL(DT_PHANDLE(NRF7002_NODE, vin_supply));
+
+/* Tracks whether this driver holds a reference on vin_supply, so a failed
+ * power-up only releases what it actually requested. The regulator may be
+ * shared with other consumers, where regulator_is_enabled() says nothing
+ * about who enabled it.
+ */
+static bool vin_supply_enabled;
 
 static const struct gpio_dt_spec bucken_spec =
 GPIO_DT_SPEC_GET(NRF7002_NODE, bucken_gpios);
@@ -212,6 +228,11 @@ static int rpu_gpio_config_early(void)
 		return -ENODEV;
 	}
 
+	if (IS_ENABLED(CONFIG_NRF70_SUPPLY_GPIO) && !device_is_ready(supply_spec.port)) {
+		LOG_ERR("SUPPLY GPIO %s is not ready", supply_spec.port->name);
+		return -ENODEV;
+	}
+
 	/* Configure BUCKEN as output in inactive (low) state to prevent
 	 * floating pin from accidentally powering the module.
 	 */
@@ -233,6 +254,18 @@ static int rpu_gpio_config_early(void)
 		return ret;
 	}
 #endif
+
+	if (IS_ENABLED(CONFIG_NRF70_SUPPLY_GPIO)) {
+		/* Configure SUPPLY as output in inactive (low) state to prevent
+		 * floating pin from accidentally powering the module.
+		 */
+		ret = gpio_pin_configure_dt(&supply_spec, GPIO_OUTPUT_INACTIVE);
+		if (ret) {
+			LOG_ERR("SUPPLY GPIO configuration failed...");
+			gpio_pin_configure_dt(&supply_spec, GPIO_DISCONNECTED);
+			return ret;
+		}
+	}
 
 	return 0;
 }
@@ -279,6 +312,16 @@ static int rpu_gpio_config(void)
 {
 	int ret;
 
+	if (IS_ENABLED(CONFIG_NRF70_VIN_SUPPLY) && !device_is_ready(vin_supply)) {
+		LOG_ERR("VIN supply regulator is not ready");
+		return -ENODEV;
+	}
+
+	if (IS_ENABLED(CONFIG_NRF70_SUPPLY_GPIO) && !device_is_ready(supply_spec.port)) {
+		LOG_ERR("SUPPLY GPIO %s is not ready", supply_spec.port->name);
+		return -ENODEV;
+	}
+
 #ifdef NRF70_IOVDD_GPIO
 	if (!device_is_ready(iovdd_ctrl_spec.port)) {
 		LOG_ERR("IOVDD GPIO %s is not ready", iovdd_ctrl_spec.port->name);
@@ -289,6 +332,15 @@ static int rpu_gpio_config(void)
 	if (!device_is_ready(bucken_spec.port)) {
 		LOG_ERR("BUCKEN GPIO %s is not ready", bucken_spec.port->name);
 		return -ENODEV;
+	}
+
+	if (IS_ENABLED(CONFIG_NRF70_SUPPLY_GPIO)) {
+		ret = gpio_pin_configure_dt(&supply_spec, GPIO_OUTPUT);
+		if (ret) {
+			LOG_ERR("SUPPLY GPIO configuration failed...");
+			gpio_pin_configure_dt(&supply_spec, GPIO_DISCONNECTED);
+			return ret;
+		}
 	}
 
 	ret = gpio_pin_configure_dt(&bucken_spec, (GPIO_OUTPUT | NRF_GPIO_DRIVE_H0H1));
@@ -329,6 +381,14 @@ static int rpu_gpio_remove(void)
 	}
 #endif
 
+	if (IS_ENABLED(CONFIG_NRF70_SUPPLY_GPIO)) {
+		ret = gpio_pin_configure_dt(&supply_spec, GPIO_DISCONNECTED);
+		if (ret) {
+			LOG_ERR("SUPPLY GPIO remove failed...");
+			return ret;
+		}
+	}
+
 	LOG_DBG("GPIO remove done...\n");
 	return ret;
 }
@@ -336,6 +396,29 @@ static int rpu_gpio_remove(void)
 static int rpu_pwron(void)
 {
 	int ret;
+
+	/* The regulator must be requested before the supply GPIO is activated. */
+	if (IS_ENABLED(CONFIG_NRF70_VIN_SUPPLY)) {
+		ret = regulator_enable(vin_supply);
+		if (ret) {
+			LOG_ERR("VIN supply enable failed...");
+			return ret;
+		}
+		vin_supply_enabled = true;
+	}
+
+	if (IS_ENABLED(CONFIG_NRF70_SUPPLY_GPIO)) {
+		ret = gpio_pin_set_dt(&supply_spec, 1);
+		if (ret) {
+			LOG_ERR("SUPPLY GPIO set failed...");
+			return ret;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_NRF70_SUPPLY)) {
+		/* Settling time for SUPPLY */
+		k_msleep(DT_PROP(NRF7002_NODE, supply_power_up_delay_ms));
+	}
 
 	ret = gpio_pin_set_dt(&bucken_spec, 1);
 	if (ret) {
@@ -357,6 +440,13 @@ static int rpu_pwron(void)
 	}
 	/* Settling time for IOVDD */
 	k_msleep(DT_PROP(NRF7002_NODE, iovdd_power_up_delay_ms));
+
+	if (IS_ENABLED(CONFIG_NRF70_SUPPLY_GPIO)) {
+		LOG_DBG("Supply GPIO = %d", gpio_pin_get_dt(&supply_spec));
+	}
+	if (IS_ENABLED(CONFIG_NRF70_VIN_SUPPLY)) {
+		LOG_DBG("Vin supply = %d", regulator_is_enabled(vin_supply) ? 1 : 0);
+	}
 
 #ifdef NRF70_IOVDD_GPIO
 	if ((bucken_spec.port == iovdd_ctrl_spec.port) &&
@@ -398,7 +488,40 @@ static int rpu_pwroff(void)
 		return ret;
 	}
 
+	/* The supply GPIO must be inactive before releasing the regulator. */
+	if (IS_ENABLED(CONFIG_NRF70_SUPPLY_GPIO)) {
+		ret = gpio_pin_set_dt(&supply_spec, 0); /* SUPPLY = 0 */
+		if (ret) {
+			LOG_ERR("SUPPLY GPIO set failed...");
+			return ret;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_NRF70_VIN_SUPPLY)) {
+		ret = regulator_disable(vin_supply);
+		if (ret) {
+			LOG_ERR("VIN supply disable failed...");
+			return ret;
+		}
+		vin_supply_enabled = false;
+	}
+
 	return ret;
+}
+
+/* Release the supply rail after a failed power-up. Errors are ignored, there is
+ * nothing left to do about them on that path.
+ */
+static void rpu_supply_off(void)
+{
+	if (IS_ENABLED(CONFIG_NRF70_SUPPLY_GPIO)) {
+		gpio_pin_set_dt(&supply_spec, 0);
+	}
+
+	if (IS_ENABLED(CONFIG_NRF70_VIN_SUPPLY) && vin_supply_enabled) {
+		regulator_disable(vin_supply);
+		vin_supply_enabled = false;
+	}
 }
 
 int rpu_read(unsigned int addr, void *data, int len)
@@ -607,6 +730,7 @@ int rpu_init(void)
 #endif
 	ret = rpu_pwron();
 	if (ret) {
+		rpu_supply_off();
 #ifdef CONFIG_NRF70_SR_COEX_RF_SWITCH
 		goto remove_sr_gpio;
 #else

--- a/modules/nrf_wifi/bus/rpu_hw_if.c
+++ b/modules/nrf_wifi/bus/rpu_hw_if.c
@@ -335,7 +335,10 @@ static int rpu_gpio_config(void)
 	}
 
 	if (IS_ENABLED(CONFIG_NRF70_SUPPLY_GPIO)) {
-		ret = gpio_pin_configure_dt(&supply_spec, GPIO_OUTPUT);
+		/* GPIO_INPUT keeps the input buffer connected so the pin state
+		 * can be read back.
+		 */
+		ret = gpio_pin_configure_dt(&supply_spec, (GPIO_OUTPUT | GPIO_INPUT));
 		if (ret) {
 			LOG_ERR("SUPPLY GPIO configuration failed...");
 			gpio_pin_configure_dt(&supply_spec, GPIO_DISCONNECTED);
@@ -343,14 +346,15 @@ static int rpu_gpio_config(void)
 		}
 	}
 
-	ret = gpio_pin_configure_dt(&bucken_spec, (GPIO_OUTPUT | NRF_GPIO_DRIVE_H0H1));
+	ret = gpio_pin_configure_dt(&bucken_spec,
+				     (GPIO_OUTPUT | GPIO_INPUT | NRF_GPIO_DRIVE_H0H1));
 	if (ret) {
 		LOG_ERR("BUCKEN GPIO configuration failed...");
 		return ret;
 	}
 
 #ifdef NRF70_IOVDD_GPIO
-	ret = gpio_pin_configure_dt(&iovdd_ctrl_spec, GPIO_OUTPUT);
+	ret = gpio_pin_configure_dt(&iovdd_ctrl_spec, (GPIO_OUTPUT | GPIO_INPUT));
 	if (ret) {
 		LOG_ERR("IOVDD GPIO configuration failed...");
 		gpio_pin_configure_dt(&bucken_spec, GPIO_DISCONNECTED);


### PR DESCRIPTION
### Summary

Adds a way for boards that gate the nRF70 VBAT/BUCKVBAT/AFEVBAT rail to
describe it in devicetree, so the rail is raised and settled before BUCKEN is
asserted as the nRF7002 datasheet requires. Also fixes the power-up log, which
printed 0 for BUCKEN and IOVDD regardless of the levels actually driven.

### Supply rail control

`nordic,nrf70.yaml` now includes `power.yaml`, so the nRF70 nodes accept the
standard `supply-gpios` and `vin-supply` properties. A new
`supply-power-up-delay-ms` property carries the settling time; its default of
6 ms is the minimum from the nRF7002 datasheet, section 14.3.5 (supply
sequencing requirements). The SPI bindings already inherited `supply-gpios` and
`vin-supply` through `spi-device.yaml`, so in practice only the QSPI bindings
gain them.

`rpu_pwron()` raises the supply and waits before touching BUCKEN;
`rpu_pwroff()` releases it after IOVDD and BUCKEN are down. The two properties
are handled independently rather than as an either/or, so a board with a shared
regulator feeding a per-device load switch works: `power.yaml` requires the
regulator to be requested before the supply GPIO goes active, and the GPIO to
go inactive before the regulator is released, which is the order implemented
here.

`REGULATOR` is now selected when either `vin-supply` or `iovdd-regulator` is
present, since the driver calls `regulator_enable()`/`regulator_disable()`.
Without it such a configuration fails to link with undefined references. The
`iovdd-regulator` path has had this gap since 57baf7cf724 ("modules: nrf_wifi:
Allow using a regulator for IOVDD"); no in-tree board uses it, which is why it
went unnoticed.

### Pin state readback fix

`rpu_pwron()` logs the BUCKEN and IOVDD_CTRL levels with `gpio_pin_get_dt()`,
but `rpu_gpio_config()` configured both pins as `GPIO_OUTPUT` only. The nRF GPIO
driver leaves the input buffer disconnected in that case, and its
`port_get_raw()` reads the IN register, so the log always printed 0. Adding
`GPIO_INPUT` makes the readback reflect reality; drive strength is unaffected
and the input buffer sees an actively driven level, so no pin is left floating.
`rpu_gpio_config_early()` is left alone — it only keeps the pins from floating
before the interface comes up, and reads nothing back.

### Testing

Tested on an out-of-tree nRF5340 + nRF7002 board with `samples/net/wifi/shell`:
with the supply on a GPIO, and with an overlay moving it behind a
`regulator-fixed` node driving the same line. Both configurations power the RPU
up and return results from `wifi scan`. The power-up log now prints
`Bucken = 1, IOVDD = 1` instead of `Bucken = 0, IOVDD = 0`.

No in-tree board sets `supply-gpios`, `vin-supply` or `iovdd-regulator` on an
nRF70 node, so no board files change and existing boards are unaffected.
