### PR TITLE
net_buf: Add optional runtime integrity checks

### DIFF
--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -950,6 +950,39 @@ static inline uint16_t net_buf_simple_max_len(const struct net_buf_simple *buf)
 }
 
 /**
+ * @brief Check that a buffer's length and pointers are self-consistent.
+ *
+ * Validates the invariant that must always hold for a well-formed buffer:
+ * @c data points within the backing storage and @c len does not extend past
+ * the end of that storage. A buffer whose #net_buf_simple::len has been
+ * corrupted (for example wrapped to a large value) or whose #net_buf_simple::data
+ * has been moved outside @c __buf..__buf+size fails this check.
+ *
+ * This does not (and cannot) detect a @c len that was changed to a different
+ * but still in-bounds value; it detects only out-of-bounds corruption, which is
+ * what turns into an out-of-bounds read or write when the buffer is used.
+ *
+ * @param buf Buffer to validate.
+ *
+ * @return true if the buffer is self-consistent, false otherwise.
+ */
+static inline bool net_buf_simple_is_valid(const struct net_buf_simple *buf)
+{
+	size_t headroom;
+
+	if (buf == NULL || buf->__buf == NULL || buf->data < buf->__buf) {
+		return false;
+	}
+
+	headroom = (size_t)(buf->data - buf->__buf);
+	if (headroom > buf->size) {
+		return false;
+	}
+
+	return (size_t)buf->len <= (size_t)(buf->size - headroom);
+}
+
+/**
  * @brief Parsing state of a buffer.
  *
  * This is used for temporarily storing the parsing state of a buffer
@@ -2665,6 +2698,23 @@ static inline size_t net_buf_headroom(const struct net_buf *buf)
 static inline uint16_t net_buf_max_len(const struct net_buf *buf)
 {
 	return net_buf_simple_max_len(&buf->b);
+}
+
+/**
+ * @brief Check that a buffer's length and pointers are self-consistent.
+ *
+ * Equivalent to net_buf_simple_is_valid() applied to the buffer's underlying
+ * net_buf_simple. Useful as a guard at "use" boundaries (e.g. before
+ * transmitting or copying out @c len bytes) to drop a buffer whose metadata
+ * has been corrupted instead of accessing memory out of bounds.
+ *
+ * @param buf Buffer to validate.
+ *
+ * @return true if the buffer is self-consistent, false otherwise.
+ */
+static inline bool net_buf_is_valid(const struct net_buf *buf)
+{
+	return buf != NULL && net_buf_simple_is_valid(&buf->b);
 }
 
 /**

--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -950,6 +950,39 @@ static inline uint16_t net_buf_simple_max_len(const struct net_buf_simple *buf)
 }
 
 /**
+ * @brief Check that a buffer's length and pointers are self-consistent.
+ *
+ * Validates the invariant that must always hold for a well-formed buffer:
+ * @c data points within the backing storage and @c len does not extend past
+ * the end of that storage. A buffer whose #net_buf_simple::len has been
+ * corrupted (for example wrapped to a large value) or whose #net_buf_simple::data
+ * has been moved outside @c __buf..__buf+size fails this check.
+ *
+ * This does not (and cannot) detect a @c len that was changed to a different
+ * but still in-bounds value; it detects only out-of-bounds corruption, which is
+ * what turns into an out-of-bounds read or write when the buffer is used.
+ *
+ * @param buf Buffer to validate.
+ *
+ * @return true if the buffer is self-consistent, false otherwise.
+ */
+static inline bool net_buf_simple_is_valid(const struct net_buf_simple *buf)
+{
+	size_t headroom;
+
+	if (buf == NULL || buf->__buf == NULL || buf->data < buf->__buf) {
+		return false;
+	}
+
+	headroom = net_buf_simple_headroom(buf);
+	if (headroom > buf->size) {
+		return false;
+	}
+
+	return (size_t)buf->len <= (size_t)(buf->size - headroom);
+}
+
+/**
  * @brief Parsing state of a buffer.
  *
  * This is used for temporarily storing the parsing state of a buffer
@@ -2665,6 +2698,26 @@ static inline size_t net_buf_headroom(const struct net_buf *buf)
 static inline uint16_t net_buf_max_len(const struct net_buf *buf)
 {
 	return net_buf_simple_max_len(&buf->b);
+}
+
+/**
+ * @brief Check that a buffer's length and pointers are self-consistent.
+ *
+ * Checks that the buffer is still referenced (net_buf::ref is non-zero, so
+ * the buffer has not been returned to its pool) and that its underlying
+ * net_buf_simple passes net_buf_simple_is_valid(). Useful as a guard at
+ * "use" boundaries (e.g. before transmitting or copying out @c len bytes)
+ * to drop a freed or corrupted buffer instead of accessing memory out of
+ * bounds.
+ *
+ * @param buf Buffer to validate.
+ *
+ * @return true if the buffer is referenced and self-consistent, false
+ *         otherwise.
+ */
+static inline bool net_buf_is_valid(const struct net_buf *buf)
+{
+	return buf != NULL && buf->ref > 0 && net_buf_simple_is_valid(&buf->b);
 }
 
 /**

--- a/lib/net_buf/Kconfig
+++ b/lib/net_buf/Kconfig
@@ -49,6 +49,22 @@ config NET_BUF_POOL_USAGE
 	  * total size of the pool is calculated
 	  * pool name is stored and can be shown in debugging prints
 
+config NET_BUF_HARDENING
+	bool "Network buffer runtime integrity checks"
+	help
+	  Enable always-on (not assert-gated) integrity checks on the network
+	  buffer length/pointer fields before mutating a buffer. A buffer whose
+	  len/data have been corrupted so that they no longer fit within the
+	  buffer's own storage (e.g. len wrapped to a large value, or data moved
+	  outside __buf..__buf+size) is rejected fail-closed: the mutating
+	  operation returns NULL instead of reading or writing out of bounds.
+
+	  This turns a would-be out-of-bounds access (in particular the
+	  tailroom-underflow -> net_buf_add() overflow) into a controlled
+	  failure. It adds a small runtime cost to net_buf_simple_add()/push()/
+	  pull()/remove() and is intended for security-sensitive builds; leave
+	  disabled to keep the fast path assert-only.
+
 config NET_BUF_ALIGNMENT
 	int "Network buffer alignment restriction"
 	default 0

--- a/lib/net_buf/buf_simple.c
+++ b/lib/net_buf/buf_simple.c
@@ -29,6 +29,36 @@ LOG_MODULE_REGISTER(net_buf_simple, CONFIG_NET_BUF_LOG_LEVEL);
 #define NET_BUF_SIMPLE_INFO(fmt, ...)
 #endif /* CONFIG_NET_BUF_SIMPLE_LOG */
 
+#if defined(CONFIG_NET_BUF_HARDENING)
+/* Fail-closed check for the mutating primitives. If the buffer's metadata is
+ * out-of-bounds (net_buf_simple_is_valid()) or the requested operation would
+ * exceed the buffer, log and return false so the caller rejects the operation
+ * (returns NULL) instead of reading/writing out of bounds. is_valid() is
+ * checked first and short-circuits, so a corrupted len is caught before it is
+ * used in @p ok (e.g. in a tailroom calculation that would otherwise
+ * underflow).
+ */
+static bool net_buf_simple_ok(const struct net_buf_simple *buf, bool ok)
+{
+	if (!net_buf_simple_is_valid(buf) || !ok) {
+		NET_BUF_SIMPLE_ERR("net_buf %p integrity check failed", (void *)buf);
+		return false;
+	}
+
+	return true;
+}
+#else
+static inline bool net_buf_simple_ok(const struct net_buf_simple *buf, bool ok)
+{
+	ARG_UNUSED(buf);
+	ARG_UNUSED(ok);
+
+	__ASSERT_NO_MSG(ok);
+
+	return true;
+}
+#endif /* CONFIG_NET_BUF_HARDENING */
+
 void net_buf_simple_init_with_data(struct net_buf_simple *buf,
 				   void *data, size_t size)
 {
@@ -55,12 +85,15 @@ void net_buf_simple_clone(const struct net_buf_simple *original,
 
 void *net_buf_simple_add(struct net_buf_simple *buf, size_t len)
 {
-	uint8_t *tail = net_buf_simple_tail(buf);
+	uint8_t *tail;
 
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	__ASSERT_NO_MSG(net_buf_simple_tailroom(buf) >= len);
+	if (!net_buf_simple_ok(buf, net_buf_simple_tailroom(buf) >= len)) {
+		return NULL;
+	}
 
+	tail = net_buf_simple_tail(buf);
 	buf->len += len;
 	return tail;
 }
@@ -68,9 +101,16 @@ void *net_buf_simple_add(struct net_buf_simple *buf, size_t len)
 void *net_buf_simple_add_mem(struct net_buf_simple *buf, const void *mem,
 			     size_t len)
 {
+	void *tail;
+
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	return memcpy(net_buf_simple_add(buf, len), mem, len);
+	tail = net_buf_simple_add(buf, len);
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && tail == NULL) {
+		return NULL;
+	}
+
+	return memcpy(tail, mem, len);
 }
 
 uint8_t *net_buf_simple_add_u8(struct net_buf_simple *buf, uint8_t val)
@@ -173,7 +213,9 @@ void *net_buf_simple_remove_mem(struct net_buf_simple *buf, size_t len)
 {
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	__ASSERT_NO_MSG(buf->len >= len);
+	if (!net_buf_simple_ok(buf, buf->len >= len)) {
+		return NULL;
+	}
 
 	buf->len -= len;
 	return buf->data + buf->len;
@@ -338,7 +380,9 @@ void *net_buf_simple_push(struct net_buf_simple *buf, size_t len)
 {
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	__ASSERT_NO_MSG(net_buf_simple_headroom(buf) >= len);
+	if (!net_buf_simple_ok(buf, net_buf_simple_headroom(buf) >= len)) {
+		return NULL;
+	}
 
 	buf->data -= len;
 	buf->len += len;
@@ -348,9 +392,16 @@ void *net_buf_simple_push(struct net_buf_simple *buf, size_t len)
 void *net_buf_simple_push_mem(struct net_buf_simple *buf, const void *mem,
 			      size_t len)
 {
+	void *data;
+
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	return memcpy(net_buf_simple_push(buf, len), mem, len);
+	data = net_buf_simple_push(buf, len);
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && data == NULL) {
+		return NULL;
+	}
+
+	return memcpy(data, mem, len);
 }
 
 void net_buf_simple_push_le16(struct net_buf_simple *buf, uint16_t val)
@@ -448,7 +499,9 @@ void *net_buf_simple_pull(struct net_buf_simple *buf, size_t len)
 {
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	__ASSERT_NO_MSG(buf->len >= len);
+	if (!net_buf_simple_ok(buf, buf->len >= len)) {
+		return NULL;
+	}
 
 	buf->len -= len;
 	return buf->data += len;
@@ -460,7 +513,9 @@ void *net_buf_simple_pull_mem(struct net_buf_simple *buf, size_t len)
 
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	__ASSERT_NO_MSG(buf->len >= len);
+	if (!net_buf_simple_ok(buf, buf->len >= len)) {
+		return NULL;
+	}
 
 	buf->len -= len;
 	buf->data += len;

--- a/lib/net_buf/buf_simple.c
+++ b/lib/net_buf/buf_simple.c
@@ -47,6 +47,19 @@ static bool net_buf_simple_ok(const struct net_buf_simple *buf, bool ok)
 
 	return true;
 }
+
+/* Store a value via sys_put_*() into the location returned by add()/push(),
+ * skipping the store (rather than dereferencing NULL) when hardening rejected
+ * the request. Contains no flow-control statements.
+ */
+#define NET_BUF_SIMPLE_PUT(_put_fn, _val, _ptr)  \
+	do {                                     \
+		void *_dst = (_ptr);             \
+						 \
+		if (_dst != NULL) {              \
+			_put_fn((_val), _dst);   \
+		}                                \
+	} while (0)
 #else
 static inline bool net_buf_simple_ok(const struct net_buf_simple *buf, bool ok)
 {
@@ -57,6 +70,8 @@ static inline bool net_buf_simple_ok(const struct net_buf_simple *buf, bool ok)
 
 	return true;
 }
+
+#define NET_BUF_SIMPLE_PUT(_put_fn, _val, _ptr) _put_fn((_val), (_ptr))
 #endif /* CONFIG_NET_BUF_HARDENING */
 
 void net_buf_simple_init_with_data(struct net_buf_simple *buf,
@@ -120,6 +135,9 @@ uint8_t *net_buf_simple_add_u8(struct net_buf_simple *buf, uint8_t val)
 	NET_BUF_SIMPLE_DBG("buf %p val 0x%02x", buf, val);
 
 	u8 = net_buf_simple_add(buf, 1);
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && u8 == NULL) {
+		return NULL;
+	}
 	*u8 = val;
 
 	return u8;
@@ -129,84 +147,84 @@ void net_buf_simple_add_le16(struct net_buf_simple *buf, uint16_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_le16(val, net_buf_simple_add(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_le16, val, net_buf_simple_add(buf, sizeof(val)));
 }
 
 void net_buf_simple_add_be16(struct net_buf_simple *buf, uint16_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_be16(val, net_buf_simple_add(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_be16, val, net_buf_simple_add(buf, sizeof(val)));
 }
 
 void net_buf_simple_add_le24(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_le24(val, net_buf_simple_add(buf, 3));
+	NET_BUF_SIMPLE_PUT(sys_put_le24, val, net_buf_simple_add(buf, 3));
 }
 
 void net_buf_simple_add_be24(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_be24(val, net_buf_simple_add(buf, 3));
+	NET_BUF_SIMPLE_PUT(sys_put_be24, val, net_buf_simple_add(buf, 3));
 }
 
 void net_buf_simple_add_le32(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_le32(val, net_buf_simple_add(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_le32, val, net_buf_simple_add(buf, sizeof(val)));
 }
 
 void net_buf_simple_add_be32(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_be32(val, net_buf_simple_add(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_be32, val, net_buf_simple_add(buf, sizeof(val)));
 }
 
 void net_buf_simple_add_le40(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_le40(val, net_buf_simple_add(buf, 5));
+	NET_BUF_SIMPLE_PUT(sys_put_le40, val, net_buf_simple_add(buf, 5));
 }
 
 void net_buf_simple_add_be40(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_be40(val, net_buf_simple_add(buf, 5));
+	NET_BUF_SIMPLE_PUT(sys_put_be40, val, net_buf_simple_add(buf, 5));
 }
 
 void net_buf_simple_add_le48(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_le48(val, net_buf_simple_add(buf, 6));
+	NET_BUF_SIMPLE_PUT(sys_put_le48, val, net_buf_simple_add(buf, 6));
 }
 
 void net_buf_simple_add_be48(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_be48(val, net_buf_simple_add(buf, 6));
+	NET_BUF_SIMPLE_PUT(sys_put_be48, val, net_buf_simple_add(buf, 6));
 }
 
 void net_buf_simple_add_le64(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_le64(val, net_buf_simple_add(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_le64, val, net_buf_simple_add(buf, sizeof(val)));
 }
 
 void net_buf_simple_add_be64(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_be64(val, net_buf_simple_add(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_be64, val, net_buf_simple_add(buf, sizeof(val)));
 }
 
 void *net_buf_simple_remove_mem(struct net_buf_simple *buf, size_t len)
@@ -227,6 +245,9 @@ uint8_t net_buf_simple_remove_u8(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = *(uint8_t *)ptr;
 
 	return val;
@@ -238,6 +259,9 @@ uint16_t net_buf_simple_remove_le16(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((uint16_t *)ptr);
 
 	return sys_le16_to_cpu(val);
@@ -249,6 +273,9 @@ uint16_t net_buf_simple_remove_be16(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((uint16_t *)ptr);
 
 	return sys_be16_to_cpu(val);
@@ -262,6 +289,9 @@ uint32_t net_buf_simple_remove_le24(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((struct uint24 *)ptr);
 
 	return sys_le24_to_cpu(val.u24);
@@ -275,6 +305,9 @@ uint32_t net_buf_simple_remove_be24(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((struct uint24 *)ptr);
 
 	return sys_be24_to_cpu(val.u24);
@@ -286,6 +319,9 @@ uint32_t net_buf_simple_remove_le32(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((uint32_t *)ptr);
 
 	return sys_le32_to_cpu(val);
@@ -297,6 +333,9 @@ uint32_t net_buf_simple_remove_be32(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((uint32_t *)ptr);
 
 	return sys_be32_to_cpu(val);
@@ -310,6 +349,9 @@ uint64_t net_buf_simple_remove_le40(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((struct uint40 *)ptr);
 
 	return sys_le40_to_cpu(val.u40);
@@ -323,6 +365,9 @@ uint64_t net_buf_simple_remove_be40(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((struct uint40 *)ptr);
 
 	return sys_be40_to_cpu(val.u40);
@@ -336,6 +381,9 @@ uint64_t net_buf_simple_remove_le48(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((struct uint48 *)ptr);
 
 	return sys_le48_to_cpu(val.u48);
@@ -349,6 +397,9 @@ uint64_t net_buf_simple_remove_be48(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((struct uint48 *)ptr);
 
 	return sys_be48_to_cpu(val.u48);
@@ -360,6 +411,9 @@ uint64_t net_buf_simple_remove_le64(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((uint64_t *)ptr);
 
 	return sys_le64_to_cpu(val);
@@ -371,6 +425,9 @@ uint64_t net_buf_simple_remove_be64(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((uint64_t *)ptr);
 
 	return sys_be64_to_cpu(val);
@@ -408,19 +465,23 @@ void net_buf_simple_push_le16(struct net_buf_simple *buf, uint16_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_le16(val, net_buf_simple_push(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_le16, val, net_buf_simple_push(buf, sizeof(val)));
 }
 
 void net_buf_simple_push_be16(struct net_buf_simple *buf, uint16_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_be16(val, net_buf_simple_push(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_be16, val, net_buf_simple_push(buf, sizeof(val)));
 }
 
 void net_buf_simple_push_u8(struct net_buf_simple *buf, uint8_t val)
 {
 	uint8_t *data = net_buf_simple_push(buf, 1);
+
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && data == NULL) {
+		return;
+	}
 
 	*data = val;
 }
@@ -429,70 +490,70 @@ void net_buf_simple_push_le24(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_le24(val, net_buf_simple_push(buf, 3));
+	NET_BUF_SIMPLE_PUT(sys_put_le24, val, net_buf_simple_push(buf, 3));
 }
 
 void net_buf_simple_push_be24(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_be24(val, net_buf_simple_push(buf, 3));
+	NET_BUF_SIMPLE_PUT(sys_put_be24, val, net_buf_simple_push(buf, 3));
 }
 
 void net_buf_simple_push_le32(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_le32(val, net_buf_simple_push(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_le32, val, net_buf_simple_push(buf, sizeof(val)));
 }
 
 void net_buf_simple_push_be32(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_be32(val, net_buf_simple_push(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_be32, val, net_buf_simple_push(buf, sizeof(val)));
 }
 
 void net_buf_simple_push_le40(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_le40(val, net_buf_simple_push(buf, 5));
+	NET_BUF_SIMPLE_PUT(sys_put_le40, val, net_buf_simple_push(buf, 5));
 }
 
 void net_buf_simple_push_be40(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_be40(val, net_buf_simple_push(buf, 5));
+	NET_BUF_SIMPLE_PUT(sys_put_be40, val, net_buf_simple_push(buf, 5));
 }
 
 void net_buf_simple_push_le48(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_le48(val, net_buf_simple_push(buf, 6));
+	NET_BUF_SIMPLE_PUT(sys_put_le48, val, net_buf_simple_push(buf, 6));
 }
 
 void net_buf_simple_push_be48(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_be48(val, net_buf_simple_push(buf, 6));
+	NET_BUF_SIMPLE_PUT(sys_put_be48, val, net_buf_simple_push(buf, 6));
 }
 
 void net_buf_simple_push_le64(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_le64(val, net_buf_simple_push(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_le64, val, net_buf_simple_push(buf, sizeof(val)));
 }
 
 void net_buf_simple_push_be64(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_be64(val, net_buf_simple_push(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_be64, val, net_buf_simple_push(buf, sizeof(val)));
 }
 
 void *net_buf_simple_pull(struct net_buf_simple *buf, size_t len)
@@ -526,9 +587,13 @@ void *net_buf_simple_pull_mem(struct net_buf_simple *buf, size_t len)
 uint8_t net_buf_simple_pull_u8(struct net_buf_simple *buf)
 {
 	uint8_t val;
+	void *ptr;
 
-	val = buf->data[0];
-	net_buf_simple_pull(buf, 1);
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = *(uint8_t *)ptr;
 
 	return val;
 }
@@ -536,9 +601,13 @@ uint8_t net_buf_simple_pull_u8(struct net_buf_simple *buf)
 uint16_t net_buf_simple_pull_le16(struct net_buf_simple *buf)
 {
 	uint16_t val;
+	void *ptr;
 
-	val = UNALIGNED_GET((uint16_t *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((uint16_t *)ptr);
 
 	return sys_le16_to_cpu(val);
 }
@@ -546,9 +615,13 @@ uint16_t net_buf_simple_pull_le16(struct net_buf_simple *buf)
 uint16_t net_buf_simple_pull_be16(struct net_buf_simple *buf)
 {
 	uint16_t val;
+	void *ptr;
 
-	val = UNALIGNED_GET((uint16_t *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((uint16_t *)ptr);
 
 	return sys_be16_to_cpu(val);
 }
@@ -558,9 +631,13 @@ uint32_t net_buf_simple_pull_le24(struct net_buf_simple *buf)
 	struct uint24 {
 		uint32_t u24:24;
 	} __packed val;
+	void *ptr;
 
-	val = UNALIGNED_GET((struct uint24 *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((struct uint24 *)ptr);
 
 	return sys_le24_to_cpu(val.u24);
 }
@@ -570,9 +647,13 @@ uint32_t net_buf_simple_pull_be24(struct net_buf_simple *buf)
 	struct uint24 {
 		uint32_t u24:24;
 	} __packed val;
+	void *ptr;
 
-	val = UNALIGNED_GET((struct uint24 *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((struct uint24 *)ptr);
 
 	return sys_be24_to_cpu(val.u24);
 }
@@ -580,9 +661,13 @@ uint32_t net_buf_simple_pull_be24(struct net_buf_simple *buf)
 uint32_t net_buf_simple_pull_le32(struct net_buf_simple *buf)
 {
 	uint32_t val;
+	void *ptr;
 
-	val = UNALIGNED_GET((uint32_t *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((uint32_t *)ptr);
 
 	return sys_le32_to_cpu(val);
 }
@@ -590,9 +675,13 @@ uint32_t net_buf_simple_pull_le32(struct net_buf_simple *buf)
 uint32_t net_buf_simple_pull_be32(struct net_buf_simple *buf)
 {
 	uint32_t val;
+	void *ptr;
 
-	val = UNALIGNED_GET((uint32_t *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((uint32_t *)ptr);
 
 	return sys_be32_to_cpu(val);
 }
@@ -602,9 +691,13 @@ uint64_t net_buf_simple_pull_le40(struct net_buf_simple *buf)
 	struct uint40 {
 		uint64_t u40: 40;
 	} __packed val;
+	void *ptr;
 
-	val = UNALIGNED_GET((struct uint40 *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((struct uint40 *)ptr);
 
 	return sys_le40_to_cpu(val.u40);
 }
@@ -614,9 +707,13 @@ uint64_t net_buf_simple_pull_be40(struct net_buf_simple *buf)
 	struct uint40 {
 		uint64_t u40: 40;
 	} __packed val;
+	void *ptr;
 
-	val = UNALIGNED_GET((struct uint40 *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((struct uint40 *)ptr);
 
 	return sys_be40_to_cpu(val.u40);
 }
@@ -626,9 +723,13 @@ uint64_t net_buf_simple_pull_le48(struct net_buf_simple *buf)
 	struct uint48 {
 		uint64_t u48:48;
 	} __packed val;
+	void *ptr;
 
-	val = UNALIGNED_GET((struct uint48 *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((struct uint48 *)ptr);
 
 	return sys_le48_to_cpu(val.u48);
 }
@@ -638,9 +739,13 @@ uint64_t net_buf_simple_pull_be48(struct net_buf_simple *buf)
 	struct uint48 {
 		uint64_t u48:48;
 	} __packed val;
+	void *ptr;
 
-	val = UNALIGNED_GET((struct uint48 *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((struct uint48 *)ptr);
 
 	return sys_be48_to_cpu(val.u48);
 }
@@ -648,9 +753,13 @@ uint64_t net_buf_simple_pull_be48(struct net_buf_simple *buf)
 uint64_t net_buf_simple_pull_le64(struct net_buf_simple *buf)
 {
 	uint64_t val;
+	void *ptr;
 
-	val = UNALIGNED_GET((uint64_t *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((uint64_t *)ptr);
 
 	return sys_le64_to_cpu(val);
 }
@@ -658,9 +767,13 @@ uint64_t net_buf_simple_pull_le64(struct net_buf_simple *buf)
 uint64_t net_buf_simple_pull_be64(struct net_buf_simple *buf)
 {
 	uint64_t val;
+	void *ptr;
 
-	val = UNALIGNED_GET((uint64_t *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((uint64_t *)ptr);
 
 	return sys_be64_to_cpu(val);
 }

--- a/lib/net_buf/buf_simple.c
+++ b/lib/net_buf/buf_simple.c
@@ -29,6 +29,44 @@ LOG_MODULE_REGISTER(net_buf_simple, CONFIG_NET_BUF_LOG_LEVEL);
 #define NET_BUF_SIMPLE_INFO(fmt, ...)
 #endif /* CONFIG_NET_BUF_SIMPLE_LOG */
 
+#if defined(CONFIG_NET_BUF_HARDENING)
+/* Fail-closed check for the mutating primitives. If the buffer's metadata is
+ * out-of-bounds (net_buf_simple_is_valid()) or the requested operation would
+ * exceed the buffer, log and return false so the caller rejects the operation
+ * (returns NULL) instead of reading/writing out of bounds. is_valid() is
+ * checked first and short-circuits, so a corrupted len is caught before it is
+ * used in @p ok (e.g. in a tailroom calculation that would otherwise
+ * underflow).
+ */
+static bool net_buf_simple_ok_check(const struct net_buf_simple *buf, bool ok, const char *func)
+{
+	ARG_UNUSED(func);
+
+	if (!ok || !net_buf_simple_is_valid(buf)) {
+		NET_BUF_SIMPLE_ERR("%s: net_buf %p integrity check failed", func, (void *)buf);
+		return false;
+	}
+
+	return true;
+}
+
+/* Wrapped in a macro so the failure log names the net_buf operation that
+ * rejected the request rather than this helper.
+ */
+#define net_buf_simple_ok(_buf, _ok) net_buf_simple_ok_check((_buf), (_ok), __func__)
+#else
+/* A macro (rather than a helper function) so that the assert reports the
+ * file:line of the net_buf operation that failed, as it did before the
+ * hardening checks were added.
+ */
+#define net_buf_simple_ok(_buf, _ok)             \
+	({                                       \
+		ARG_UNUSED(_buf);                \
+		__ASSERT_NO_MSG(_ok);            \
+		true;                            \
+	})
+#endif /* CONFIG_NET_BUF_HARDENING */
+
 void net_buf_simple_init_with_data(struct net_buf_simple *buf,
 				   void *data, size_t size)
 {
@@ -55,12 +93,15 @@ void net_buf_simple_clone(const struct net_buf_simple *original,
 
 void *net_buf_simple_add(struct net_buf_simple *buf, size_t len)
 {
-	uint8_t *tail = net_buf_simple_tail(buf);
+	uint8_t *tail;
 
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	__ASSERT_NO_MSG(net_buf_simple_tailroom(buf) >= len);
+	if (!net_buf_simple_ok(buf, net_buf_simple_tailroom(buf) >= len)) {
+		return NULL;
+	}
 
+	tail = net_buf_simple_tail(buf);
 	buf->len += len;
 	return tail;
 }
@@ -68,9 +109,16 @@ void *net_buf_simple_add(struct net_buf_simple *buf, size_t len)
 void *net_buf_simple_add_mem(struct net_buf_simple *buf, const void *mem,
 			     size_t len)
 {
+	void *tail;
+
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	return memcpy(net_buf_simple_add(buf, len), mem, len);
+	tail = net_buf_simple_add(buf, len);
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && tail == NULL) {
+		return NULL;
+	}
+
+	return memcpy(tail, mem, len);
 }
 
 uint8_t *net_buf_simple_add_u8(struct net_buf_simple *buf, uint8_t val)
@@ -173,7 +221,9 @@ void *net_buf_simple_remove_mem(struct net_buf_simple *buf, size_t len)
 {
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	__ASSERT_NO_MSG(buf->len >= len);
+	if (!net_buf_simple_ok(buf, buf->len >= len)) {
+		return NULL;
+	}
 
 	buf->len -= len;
 	return buf->data + buf->len;
@@ -338,7 +388,9 @@ void *net_buf_simple_push(struct net_buf_simple *buf, size_t len)
 {
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	__ASSERT_NO_MSG(net_buf_simple_headroom(buf) >= len);
+	if (!net_buf_simple_ok(buf, net_buf_simple_headroom(buf) >= len)) {
+		return NULL;
+	}
 
 	buf->data -= len;
 	buf->len += len;
@@ -348,9 +400,16 @@ void *net_buf_simple_push(struct net_buf_simple *buf, size_t len)
 void *net_buf_simple_push_mem(struct net_buf_simple *buf, const void *mem,
 			      size_t len)
 {
+	void *data;
+
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	return memcpy(net_buf_simple_push(buf, len), mem, len);
+	data = net_buf_simple_push(buf, len);
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && data == NULL) {
+		return NULL;
+	}
+
+	return memcpy(data, mem, len);
 }
 
 void net_buf_simple_push_le16(struct net_buf_simple *buf, uint16_t val)
@@ -448,7 +507,9 @@ void *net_buf_simple_pull(struct net_buf_simple *buf, size_t len)
 {
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	__ASSERT_NO_MSG(buf->len >= len);
+	if (!net_buf_simple_ok(buf, buf->len >= len)) {
+		return NULL;
+	}
 
 	buf->len -= len;
 	return buf->data += len;
@@ -460,7 +521,9 @@ void *net_buf_simple_pull_mem(struct net_buf_simple *buf, size_t len)
 
 	NET_BUF_SIMPLE_DBG("buf %p len %zu", buf, len);
 
-	__ASSERT_NO_MSG(buf->len >= len);
+	if (!net_buf_simple_ok(buf, buf->len >= len)) {
+		return NULL;
+	}
 
 	buf->len -= len;
 	buf->data += len;

--- a/lib/net_buf/buf_simple.c
+++ b/lib/net_buf/buf_simple.c
@@ -54,6 +54,19 @@ static bool net_buf_simple_ok_check(const struct net_buf_simple *buf, bool ok, c
  * rejected the request rather than this helper.
  */
 #define net_buf_simple_ok(_buf, _ok) net_buf_simple_ok_check((_buf), (_ok), __func__)
+
+/* Store a value via sys_put_*() into the location returned by add()/push(),
+ * skipping the store (rather than dereferencing NULL) when hardening rejected
+ * the request. Contains no flow-control statements.
+ */
+#define NET_BUF_SIMPLE_PUT(_put_fn, _val, _ptr)  \
+	do {                                     \
+		void *_dst = (_ptr);             \
+						 \
+		if (_dst != NULL) {              \
+			_put_fn((_val), _dst);   \
+		}                                \
+	} while (0)
 #else
 /* A macro (rather than a helper function) so that the assert reports the
  * file:line of the net_buf operation that failed, as it did before the
@@ -65,6 +78,8 @@ static bool net_buf_simple_ok_check(const struct net_buf_simple *buf, bool ok, c
 		__ASSERT_NO_MSG(_ok);            \
 		true;                            \
 	})
+
+#define NET_BUF_SIMPLE_PUT(_put_fn, _val, _ptr) _put_fn((_val), (_ptr))
 #endif /* CONFIG_NET_BUF_HARDENING */
 
 void net_buf_simple_init_with_data(struct net_buf_simple *buf,
@@ -128,6 +143,9 @@ uint8_t *net_buf_simple_add_u8(struct net_buf_simple *buf, uint8_t val)
 	NET_BUF_SIMPLE_DBG("buf %p val 0x%02x", buf, val);
 
 	u8 = net_buf_simple_add(buf, 1);
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && u8 == NULL) {
+		return NULL;
+	}
 	*u8 = val;
 
 	return u8;
@@ -137,84 +155,84 @@ void net_buf_simple_add_le16(struct net_buf_simple *buf, uint16_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_le16(val, net_buf_simple_add(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_le16, val, net_buf_simple_add(buf, sizeof(val)));
 }
 
 void net_buf_simple_add_be16(struct net_buf_simple *buf, uint16_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_be16(val, net_buf_simple_add(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_be16, val, net_buf_simple_add(buf, sizeof(val)));
 }
 
 void net_buf_simple_add_le24(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_le24(val, net_buf_simple_add(buf, 3));
+	NET_BUF_SIMPLE_PUT(sys_put_le24, val, net_buf_simple_add(buf, 3));
 }
 
 void net_buf_simple_add_be24(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_be24(val, net_buf_simple_add(buf, 3));
+	NET_BUF_SIMPLE_PUT(sys_put_be24, val, net_buf_simple_add(buf, 3));
 }
 
 void net_buf_simple_add_le32(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_le32(val, net_buf_simple_add(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_le32, val, net_buf_simple_add(buf, sizeof(val)));
 }
 
 void net_buf_simple_add_be32(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_be32(val, net_buf_simple_add(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_be32, val, net_buf_simple_add(buf, sizeof(val)));
 }
 
 void net_buf_simple_add_le40(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_le40(val, net_buf_simple_add(buf, 5));
+	NET_BUF_SIMPLE_PUT(sys_put_le40, val, net_buf_simple_add(buf, 5));
 }
 
 void net_buf_simple_add_be40(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_be40(val, net_buf_simple_add(buf, 5));
+	NET_BUF_SIMPLE_PUT(sys_put_be40, val, net_buf_simple_add(buf, 5));
 }
 
 void net_buf_simple_add_le48(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_le48(val, net_buf_simple_add(buf, 6));
+	NET_BUF_SIMPLE_PUT(sys_put_le48, val, net_buf_simple_add(buf, 6));
 }
 
 void net_buf_simple_add_be48(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_be48(val, net_buf_simple_add(buf, 6));
+	NET_BUF_SIMPLE_PUT(sys_put_be48, val, net_buf_simple_add(buf, 6));
 }
 
 void net_buf_simple_add_le64(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_le64(val, net_buf_simple_add(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_le64, val, net_buf_simple_add(buf, sizeof(val)));
 }
 
 void net_buf_simple_add_be64(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_be64(val, net_buf_simple_add(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_be64, val, net_buf_simple_add(buf, sizeof(val)));
 }
 
 void *net_buf_simple_remove_mem(struct net_buf_simple *buf, size_t len)
@@ -235,6 +253,9 @@ uint8_t net_buf_simple_remove_u8(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = *(uint8_t *)ptr;
 
 	return val;
@@ -246,6 +267,9 @@ uint16_t net_buf_simple_remove_le16(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((uint16_t *)ptr);
 
 	return sys_le16_to_cpu(val);
@@ -257,6 +281,9 @@ uint16_t net_buf_simple_remove_be16(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((uint16_t *)ptr);
 
 	return sys_be16_to_cpu(val);
@@ -270,6 +297,9 @@ uint32_t net_buf_simple_remove_le24(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((struct uint24 *)ptr);
 
 	return sys_le24_to_cpu(val.u24);
@@ -283,6 +313,9 @@ uint32_t net_buf_simple_remove_be24(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((struct uint24 *)ptr);
 
 	return sys_be24_to_cpu(val.u24);
@@ -294,6 +327,9 @@ uint32_t net_buf_simple_remove_le32(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((uint32_t *)ptr);
 
 	return sys_le32_to_cpu(val);
@@ -305,6 +341,9 @@ uint32_t net_buf_simple_remove_be32(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((uint32_t *)ptr);
 
 	return sys_be32_to_cpu(val);
@@ -318,6 +357,9 @@ uint64_t net_buf_simple_remove_le40(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((struct uint40 *)ptr);
 
 	return sys_le40_to_cpu(val.u40);
@@ -331,6 +373,9 @@ uint64_t net_buf_simple_remove_be40(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((struct uint40 *)ptr);
 
 	return sys_be40_to_cpu(val.u40);
@@ -344,6 +389,9 @@ uint64_t net_buf_simple_remove_le48(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((struct uint48 *)ptr);
 
 	return sys_le48_to_cpu(val.u48);
@@ -357,6 +405,9 @@ uint64_t net_buf_simple_remove_be48(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((struct uint48 *)ptr);
 
 	return sys_be48_to_cpu(val.u48);
@@ -368,6 +419,9 @@ uint64_t net_buf_simple_remove_le64(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((uint64_t *)ptr);
 
 	return sys_le64_to_cpu(val);
@@ -379,6 +433,9 @@ uint64_t net_buf_simple_remove_be64(struct net_buf_simple *buf)
 	void *ptr;
 
 	ptr = net_buf_simple_remove_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
 	val = UNALIGNED_GET((uint64_t *)ptr);
 
 	return sys_be64_to_cpu(val);
@@ -416,19 +473,23 @@ void net_buf_simple_push_le16(struct net_buf_simple *buf, uint16_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_le16(val, net_buf_simple_push(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_le16, val, net_buf_simple_push(buf, sizeof(val)));
 }
 
 void net_buf_simple_push_be16(struct net_buf_simple *buf, uint16_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_be16(val, net_buf_simple_push(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_be16, val, net_buf_simple_push(buf, sizeof(val)));
 }
 
 void net_buf_simple_push_u8(struct net_buf_simple *buf, uint8_t val)
 {
 	uint8_t *data = net_buf_simple_push(buf, 1);
+
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && data == NULL) {
+		return;
+	}
 
 	*data = val;
 }
@@ -437,70 +498,70 @@ void net_buf_simple_push_le24(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_le24(val, net_buf_simple_push(buf, 3));
+	NET_BUF_SIMPLE_PUT(sys_put_le24, val, net_buf_simple_push(buf, 3));
 }
 
 void net_buf_simple_push_be24(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_be24(val, net_buf_simple_push(buf, 3));
+	NET_BUF_SIMPLE_PUT(sys_put_be24, val, net_buf_simple_push(buf, 3));
 }
 
 void net_buf_simple_push_le32(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_le32(val, net_buf_simple_push(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_le32, val, net_buf_simple_push(buf, sizeof(val)));
 }
 
 void net_buf_simple_push_be32(struct net_buf_simple *buf, uint32_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %u", buf, val);
 
-	sys_put_be32(val, net_buf_simple_push(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_be32, val, net_buf_simple_push(buf, sizeof(val)));
 }
 
 void net_buf_simple_push_le40(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_le40(val, net_buf_simple_push(buf, 5));
+	NET_BUF_SIMPLE_PUT(sys_put_le40, val, net_buf_simple_push(buf, 5));
 }
 
 void net_buf_simple_push_be40(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_be40(val, net_buf_simple_push(buf, 5));
+	NET_BUF_SIMPLE_PUT(sys_put_be40, val, net_buf_simple_push(buf, 5));
 }
 
 void net_buf_simple_push_le48(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_le48(val, net_buf_simple_push(buf, 6));
+	NET_BUF_SIMPLE_PUT(sys_put_le48, val, net_buf_simple_push(buf, 6));
 }
 
 void net_buf_simple_push_be48(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_be48(val, net_buf_simple_push(buf, 6));
+	NET_BUF_SIMPLE_PUT(sys_put_be48, val, net_buf_simple_push(buf, 6));
 }
 
 void net_buf_simple_push_le64(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_le64(val, net_buf_simple_push(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_le64, val, net_buf_simple_push(buf, sizeof(val)));
 }
 
 void net_buf_simple_push_be64(struct net_buf_simple *buf, uint64_t val)
 {
 	NET_BUF_SIMPLE_DBG("buf %p val %" PRIu64, buf, val);
 
-	sys_put_be64(val, net_buf_simple_push(buf, sizeof(val)));
+	NET_BUF_SIMPLE_PUT(sys_put_be64, val, net_buf_simple_push(buf, sizeof(val)));
 }
 
 void *net_buf_simple_pull(struct net_buf_simple *buf, size_t len)
@@ -534,9 +595,13 @@ void *net_buf_simple_pull_mem(struct net_buf_simple *buf, size_t len)
 uint8_t net_buf_simple_pull_u8(struct net_buf_simple *buf)
 {
 	uint8_t val;
+	void *ptr;
 
-	val = buf->data[0];
-	net_buf_simple_pull(buf, 1);
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = *(uint8_t *)ptr;
 
 	return val;
 }
@@ -544,9 +609,13 @@ uint8_t net_buf_simple_pull_u8(struct net_buf_simple *buf)
 uint16_t net_buf_simple_pull_le16(struct net_buf_simple *buf)
 {
 	uint16_t val;
+	void *ptr;
 
-	val = UNALIGNED_GET((uint16_t *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((uint16_t *)ptr);
 
 	return sys_le16_to_cpu(val);
 }
@@ -554,9 +623,13 @@ uint16_t net_buf_simple_pull_le16(struct net_buf_simple *buf)
 uint16_t net_buf_simple_pull_be16(struct net_buf_simple *buf)
 {
 	uint16_t val;
+	void *ptr;
 
-	val = UNALIGNED_GET((uint16_t *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((uint16_t *)ptr);
 
 	return sys_be16_to_cpu(val);
 }
@@ -566,9 +639,13 @@ uint32_t net_buf_simple_pull_le24(struct net_buf_simple *buf)
 	struct uint24 {
 		uint32_t u24:24;
 	} __packed val;
+	void *ptr;
 
-	val = UNALIGNED_GET((struct uint24 *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((struct uint24 *)ptr);
 
 	return sys_le24_to_cpu(val.u24);
 }
@@ -578,9 +655,13 @@ uint32_t net_buf_simple_pull_be24(struct net_buf_simple *buf)
 	struct uint24 {
 		uint32_t u24:24;
 	} __packed val;
+	void *ptr;
 
-	val = UNALIGNED_GET((struct uint24 *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((struct uint24 *)ptr);
 
 	return sys_be24_to_cpu(val.u24);
 }
@@ -588,9 +669,13 @@ uint32_t net_buf_simple_pull_be24(struct net_buf_simple *buf)
 uint32_t net_buf_simple_pull_le32(struct net_buf_simple *buf)
 {
 	uint32_t val;
+	void *ptr;
 
-	val = UNALIGNED_GET((uint32_t *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((uint32_t *)ptr);
 
 	return sys_le32_to_cpu(val);
 }
@@ -598,9 +683,13 @@ uint32_t net_buf_simple_pull_le32(struct net_buf_simple *buf)
 uint32_t net_buf_simple_pull_be32(struct net_buf_simple *buf)
 {
 	uint32_t val;
+	void *ptr;
 
-	val = UNALIGNED_GET((uint32_t *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((uint32_t *)ptr);
 
 	return sys_be32_to_cpu(val);
 }
@@ -610,9 +699,13 @@ uint64_t net_buf_simple_pull_le40(struct net_buf_simple *buf)
 	struct uint40 {
 		uint64_t u40: 40;
 	} __packed val;
+	void *ptr;
 
-	val = UNALIGNED_GET((struct uint40 *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((struct uint40 *)ptr);
 
 	return sys_le40_to_cpu(val.u40);
 }
@@ -622,9 +715,13 @@ uint64_t net_buf_simple_pull_be40(struct net_buf_simple *buf)
 	struct uint40 {
 		uint64_t u40: 40;
 	} __packed val;
+	void *ptr;
 
-	val = UNALIGNED_GET((struct uint40 *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((struct uint40 *)ptr);
 
 	return sys_be40_to_cpu(val.u40);
 }
@@ -634,9 +731,13 @@ uint64_t net_buf_simple_pull_le48(struct net_buf_simple *buf)
 	struct uint48 {
 		uint64_t u48:48;
 	} __packed val;
+	void *ptr;
 
-	val = UNALIGNED_GET((struct uint48 *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((struct uint48 *)ptr);
 
 	return sys_le48_to_cpu(val.u48);
 }
@@ -646,9 +747,13 @@ uint64_t net_buf_simple_pull_be48(struct net_buf_simple *buf)
 	struct uint48 {
 		uint64_t u48:48;
 	} __packed val;
+	void *ptr;
 
-	val = UNALIGNED_GET((struct uint48 *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((struct uint48 *)ptr);
 
 	return sys_be48_to_cpu(val.u48);
 }
@@ -656,9 +761,13 @@ uint64_t net_buf_simple_pull_be48(struct net_buf_simple *buf)
 uint64_t net_buf_simple_pull_le64(struct net_buf_simple *buf)
 {
 	uint64_t val;
+	void *ptr;
 
-	val = UNALIGNED_GET((uint64_t *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((uint64_t *)ptr);
 
 	return sys_le64_to_cpu(val);
 }
@@ -666,9 +775,13 @@ uint64_t net_buf_simple_pull_le64(struct net_buf_simple *buf)
 uint64_t net_buf_simple_pull_be64(struct net_buf_simple *buf)
 {
 	uint64_t val;
+	void *ptr;
 
-	val = UNALIGNED_GET((uint64_t *)buf->data);
-	net_buf_simple_pull(buf, sizeof(val));
+	ptr = net_buf_simple_pull_mem(buf, sizeof(val));
+	if (IS_ENABLED(CONFIG_NET_BUF_HARDENING) && ptr == NULL) {
+		return 0;
+	}
+	val = UNALIGNED_GET((uint64_t *)ptr);
 
 	return sys_be64_to_cpu(val);
 }

--- a/subsys/net/lib/mqtt_sn/mqtt_sn_decoder.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn_decoder.c
@@ -83,10 +83,23 @@ static void decode_flags(struct net_buf_simple *buf, struct mqtt_sn_flags *flags
 						      MQTT_SN_FLAGS_SHIFT_TOPICID_TYPE);
 }
 
-static void decode_data(struct net_buf_simple *buf, struct mqtt_sn_data *dest)
+static int decode_data(struct net_buf_simple *buf, struct mqtt_sn_data *dest)
 {
-	dest->size = buf->len;
-	dest->data = net_buf_simple_pull_mem(buf, buf->len);
+	size_t size = buf->len;
+	const uint8_t *data = net_buf_simple_pull_mem(buf, size);
+
+	if (data == NULL) {
+		/* The pull only fails with CONFIG_NET_BUF_HARDENING, when the
+		 * buffer metadata is corrupt: fail closed rather than exposing
+		 * a NULL pointer with a non-zero size to the caller.
+		 */
+		return -EINVAL;
+	}
+
+	dest->data = data;
+	dest->size = size;
+
+	return 0;
 }
 
 static int decode_empty_message(struct net_buf_simple *buf)
@@ -124,6 +137,8 @@ static int decode_msg_searchgw(struct net_buf_simple *buf, struct mqtt_sn_param_
 
 static int decode_msg_gwinfo(struct net_buf_simple *buf, struct mqtt_sn_param_gwinfo *params)
 {
+	int ret;
+
 	if (buf->len < 1) {
 		return -EPROTO;
 	}
@@ -131,7 +146,10 @@ static int decode_msg_gwinfo(struct net_buf_simple *buf, struct mqtt_sn_param_gw
 	params->gw_id = net_buf_simple_pull_u8(buf);
 
 	if (buf->len) {
-		decode_data(buf, &params->gw_add);
+		ret = decode_data(buf, &params->gw_add);
+		if (ret) {
+			return ret;
+		}
 	} else {
 		params->gw_add.size = 0;
 	}
@@ -168,9 +186,8 @@ static int decode_msg_register(struct net_buf_simple *buf, struct mqtt_sn_param_
 
 	params->topic_id = net_buf_simple_pull_be16(buf);
 	params->msg_id = net_buf_simple_pull_be16(buf);
-	decode_data(buf, &params->topic);
 
-	return 0;
+	return decode_data(buf, &params->topic);
 }
 
 static int decode_msg_regack(struct net_buf_simple *buf, struct mqtt_sn_param_regack *params)
@@ -201,9 +218,8 @@ static int decode_msg_publish(struct net_buf_simple *buf, struct mqtt_sn_param_p
 	params->topic_type = flags.topic_type;
 	params->topic_id = net_buf_simple_pull_be16(buf);
 	params->msg_id = net_buf_simple_pull_be16(buf);
-	decode_data(buf, &params->data);
 
-	return 0;
+	return decode_data(buf, &params->data);
 }
 
 static int decode_msg_puback(struct net_buf_simple *buf, struct mqtt_sn_param_puback *params)

--- a/subsys/net/lib/mqtt_sn/mqtt_sn_decoder.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn_decoder.c
@@ -83,10 +83,20 @@ static void decode_flags(struct net_buf_simple *buf, struct mqtt_sn_flags *flags
 						      MQTT_SN_FLAGS_SHIFT_TOPICID_TYPE);
 }
 
-static void decode_data(struct net_buf_simple *buf, struct mqtt_sn_data *dest)
+static int decode_data(struct net_buf_simple *buf, struct mqtt_sn_data *dest)
 {
 	dest->size = buf->len;
 	dest->data = net_buf_simple_pull_mem(buf, buf->len);
+	if (dest->data == NULL) {
+		/* Only reachable with CONFIG_NET_BUF_HARDENING, when the buffer
+		 * metadata is corrupt: fail closed rather than exposing a NULL
+		 * pointer with a non-zero size to the caller.
+		 */
+		dest->size = 0;
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
 static int decode_empty_message(struct net_buf_simple *buf)
@@ -124,6 +134,8 @@ static int decode_msg_searchgw(struct net_buf_simple *buf, struct mqtt_sn_param_
 
 static int decode_msg_gwinfo(struct net_buf_simple *buf, struct mqtt_sn_param_gwinfo *params)
 {
+	int ret;
+
 	if (buf->len < 1) {
 		return -EPROTO;
 	}
@@ -131,7 +143,10 @@ static int decode_msg_gwinfo(struct net_buf_simple *buf, struct mqtt_sn_param_gw
 	params->gw_id = net_buf_simple_pull_u8(buf);
 
 	if (buf->len) {
-		decode_data(buf, &params->gw_add);
+		ret = decode_data(buf, &params->gw_add);
+		if (ret) {
+			return ret;
+		}
 	} else {
 		params->gw_add.size = 0;
 	}
@@ -168,9 +183,8 @@ static int decode_msg_register(struct net_buf_simple *buf, struct mqtt_sn_param_
 
 	params->topic_id = net_buf_simple_pull_be16(buf);
 	params->msg_id = net_buf_simple_pull_be16(buf);
-	decode_data(buf, &params->topic);
 
-	return 0;
+	return decode_data(buf, &params->topic);
 }
 
 static int decode_msg_regack(struct net_buf_simple *buf, struct mqtt_sn_param_regack *params)
@@ -201,9 +215,8 @@ static int decode_msg_publish(struct net_buf_simple *buf, struct mqtt_sn_param_p
 	params->topic_type = flags.topic_type;
 	params->topic_id = net_buf_simple_pull_be16(buf);
 	params->msg_id = net_buf_simple_pull_be16(buf);
-	decode_data(buf, &params->data);
 
-	return 0;
+	return decode_data(buf, &params->data);
 }
 
 static int decode_msg_puback(struct net_buf_simple *buf, struct mqtt_sn_param_puback *params)

--- a/tests/lib/net_buf/buf/src/main.c
+++ b/tests/lib/net_buf/buf/src/main.c
@@ -1232,4 +1232,33 @@ ZTEST(net_buf_tests, test_net_buf_drop)
 	zassert_equal(destroy_called, 1, "Incorrect destroy callback count");
 }
 
+ZTEST(net_buf_tests, test_net_buf_is_valid)
+{
+	struct net_buf *buf;
+
+	destroy_called = 0;
+
+	zassert_false(net_buf_is_valid(NULL), "NULL buffer reported valid");
+
+	buf = net_buf_alloc_len(&bufs_pool, 74, K_NO_WAIT);
+	zassert_not_null(buf, "Failed to get buffer");
+	zassert_true(net_buf_is_valid(buf), "Freshly allocated buffer not valid");
+
+	/* A zero reference count means the buffer has been handed back to
+	 * its pool and must no longer be considered valid.
+	 */
+	buf->ref = 0U;
+	zassert_false(net_buf_is_valid(buf), "Unreferenced buffer reported valid");
+	buf->ref = 1U;
+
+	/* Metadata corruption is caught via net_buf_simple_is_valid() */
+	buf->len = buf->size + 1U;
+	zassert_false(net_buf_is_valid(buf), "Corrupted buffer reported valid");
+	buf->len = 0U;
+	zassert_true(net_buf_is_valid(buf), "Restored buffer not valid");
+
+	net_buf_unref(buf);
+	zassert_equal(destroy_called, 1, "Incorrect destroy callback count");
+}
+
 ZTEST_SUITE(net_buf_tests, NULL, NULL, NULL, NULL, NULL);

--- a/tests/lib/net_buf/buf_simple/src/main.c
+++ b/tests/lib/net_buf/buf_simple/src/main.c
@@ -598,3 +598,57 @@ ZTEST(net_buf_simple_test_suite, test_net_buf_simple_hardening_pull_corrupt_len)
 	ptr = net_buf_simple_pull(&buf, 1);
 	zassert_is_null(ptr, "pull() on corrupted buffer must return NULL");
 }
+
+/*
+ * Typed scalar accessors dereference the pointer returned by the raw
+ * add/push/pull/remove primitives. Under hardening a corrupted buffer must
+ * make them fail closed (add_* returns NULL / skips the store, pull_* and
+ * remove_* return 0) instead of writing to or reading from a NULL pointer.
+ */
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_hardening_add_u8_corrupt_len)
+{
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_BUF_HARDENING);
+
+	buf.len = 0xFFFF;
+
+	zassert_is_null(net_buf_simple_add_u8(&buf, 0x42),
+			"add_u8() on corrupted buffer must return NULL");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_hardening_add_scalar_corrupt_len)
+{
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_BUF_HARDENING);
+
+	buf.len = 0xFFFF;
+
+	/* Void helper: must skip the store rather than dereferencing NULL. The
+	 * buffer must be left untouched (len not advanced).
+	 */
+	net_buf_simple_add_le32(&buf, 0xdeadbeef);
+	zassert_equal(buf.len, 0xFFFF, "add_le32() must not mutate a rejected buffer");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_hardening_pull_scalar_corrupt_len)
+{
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_BUF_HARDENING);
+
+	buf.len = 0xFFFF;
+
+	zassert_equal(net_buf_simple_pull_u8(&buf), 0,
+		      "pull_u8() on corrupted buffer must return 0");
+	zassert_equal(net_buf_simple_pull_le16(&buf), 0,
+		      "pull_le16() on corrupted buffer must return 0");
+	zassert_equal(net_buf_simple_pull_be32(&buf), 0,
+		      "pull_be32() on corrupted buffer must return 0");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_hardening_remove_scalar_corrupt_len)
+{
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_BUF_HARDENING);
+
+	buf.len = 0xFFFF;
+
+	zassert_equal(net_buf_simple_remove_le16(&buf), 0,
+		      "remove_le16() on corrupted buffer must return 0");
+}

--- a/tests/lib/net_buf/buf_simple/src/main.c
+++ b/tests/lib/net_buf/buf_simple/src/main.c
@@ -477,3 +477,124 @@ ZTEST(net_buf_simple_test_suite, test_net_buf_simple_push_be64)
 	zassert_mem_equal(be64, net_buf_simple_remove_mem(&buf, sizeof(be64)),
 			  sizeof(be64), "Invalid 64 bits byte order");
 }
+
+/*
+ * Integrity validation and CONFIG_NET_BUF_HARDENING fail-closed behaviour.
+ *
+ * net_buf_simple_is_valid() is always compiled and checks the invariant that
+ * data stays within [__buf, __buf+size] and len does not extend past the
+ * storage. The hardening tests additionally verify that, when
+ * CONFIG_NET_BUF_HARDENING is enabled, the mutating primitives refuse a
+ * corrupted or overflowing buffer (returning NULL) instead of reading or
+ * writing out of bounds; they are skipped when the option is disabled.
+ */
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_is_valid_fresh)
+{
+	zassert_true(net_buf_simple_is_valid(&buf), "Freshly reset buffer must be valid");
+
+	net_buf_simple_add(&buf, 4);
+	zassert_true(net_buf_simple_is_valid(&buf), "Buffer with in-bounds data must be valid");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_is_valid_len_boundary)
+{
+	buf.len = net_buf_simple_max_len(&buf);
+	zassert_true(net_buf_simple_is_valid(&buf), "len == max_len must be valid");
+
+	buf.len = net_buf_simple_max_len(&buf) + 1U;
+	zassert_false(net_buf_simple_is_valid(&buf), "len past capacity must be invalid");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_is_valid_corrupt_len)
+{
+	/* Simulate the corruption: len overwritten with a wrapped/huge value. */
+	buf.len = 0xFFFF;
+	zassert_false(net_buf_simple_is_valid(&buf),
+		      "Corrupted (wrapped) len must be detected as invalid");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_is_valid_bad_data_ptr)
+{
+	uint8_t *saved = buf.data;
+
+	/* data moved before the storage start */
+	buf.data = buf.__buf - 1;
+	zassert_false(net_buf_simple_is_valid(&buf), "data before __buf must be invalid");
+	buf.data = saved;
+
+	/* headroom larger than the whole buffer */
+	buf.data = buf.__buf + buf.size + 1U;
+	zassert_false(net_buf_simple_is_valid(&buf), "data past end of storage must be invalid");
+	buf.data = saved;
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_hardening_add_corrupt_len)
+{
+	void *ptr;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_BUF_HARDENING);
+
+	net_buf_simple_add(&buf, 4);
+
+	/* Corrupt len as a heap overflow / attacker might. */
+	buf.len = 0xFFFF;
+
+	/* add() must refuse rather than advancing len and returning a tail
+	 * pointer past the storage.
+	 */
+	ptr = net_buf_simple_add(&buf, 1);
+	zassert_is_null(ptr, "add() on corrupted buffer must return NULL");
+	zassert_equal(buf.len, 0xFFFF, "add() must not mutate a rejected buffer");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_hardening_add_mem_corrupt_len)
+{
+	uint8_t payload[2] = {0xAA, 0xBB};
+	void *ptr;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_BUF_HARDENING);
+
+	buf.len = 0xFFFF;
+
+	ptr = net_buf_simple_add_mem(&buf, payload, sizeof(payload));
+	zassert_is_null(ptr, "add_mem() on corrupted buffer must return NULL (no memcpy)");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_hardening_add_overflow)
+{
+	void *ptr;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_BUF_HARDENING);
+
+	/* Valid buffer, but request more than the tailroom. */
+	ptr = net_buf_simple_add(&buf, net_buf_simple_max_len(&buf) + 1U);
+	zassert_is_null(ptr, "add() beyond tailroom must return NULL");
+	zassert_equal(buf.len, 0, "rejected add() must not change len");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_hardening_pull_underflow)
+{
+	void *ptr;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_BUF_HARDENING);
+
+	net_buf_simple_add(&buf, 2);
+
+	/* Pulling more than present would underflow len. */
+	ptr = net_buf_simple_pull(&buf, 5);
+	zassert_is_null(ptr, "pull() beyond len must return NULL");
+	zassert_equal(buf.len, 2, "rejected pull() must not change len");
+}
+
+ZTEST(net_buf_simple_test_suite, test_net_buf_simple_hardening_pull_corrupt_len)
+{
+	void *ptr;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_BUF_HARDENING);
+
+	buf.len = 0xFFFF;
+
+	ptr = net_buf_simple_pull(&buf, 1);
+	zassert_is_null(ptr, "pull() on corrupted buffer must return NULL");
+}

--- a/tests/lib/net_buf/buf_simple/tests.yaml
+++ b/tests/lib/net_buf/buf_simple/tests.yaml
@@ -4,3 +4,7 @@ common:
 tests:
   libraries.net_buf.buf_simple:
     type: unit
+  libraries.net_buf.buf_simple.hardening:
+    type: unit
+    extra_configs:
+      - CONFIG_NET_BUF_HARDENING=y


### PR DESCRIPTION
Add CONFIG_NET_BUF_HARDENING, an opt-in (default off) set of always-on integrity checks on the net_buf_simple length/pointer fields, evaluated before a buffer is mutated. If a buffer's metadata has been corrupted so that it no longer fits within its own storage -- for example len wrapped to a large value, or data moved outside __buf..__buf+size -- the mutating primitive is rejected fail-closed and returns NULL instead of reading or writing out of bounds.

Add hardening support to mqtt-sn which was trusting that the net_buf was ok, but as now the net_buf is checked whether it is ok, the checks can fail.
