### PR TITLE
dts: nxp: lpc55s6x: define SRAMX as a memory region

### DIFF
--- a/dts/arm/nxp/lpc/nxp_lpc55S06_ns.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S06_ns.dtsi
@@ -18,12 +18,6 @@
 
 #include "nxp_lpc55S0x_common.dtsi"
 
-&sramx {
-	compatible = "zephyr,memory-region", "mmio-sram";
-	reg = <0x04000000 DT_SIZE_K(16)>;
-	zephyr,memory-region = "SRAMX";
-};
-
 &iap {
 	status = "okay";
 };

--- a/dts/arm/nxp/lpc/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S0x_common.dtsi
@@ -46,8 +46,9 @@
 	 * LPC55x06: RAMX: 16K, SRAM0: 32K, SRAM1: 16K, SRAM2: 16K, SRAM3: 16k
 	 */
 	sramx: memory@4000000 {
-		compatible = "mmio-sram";
+		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x04000000 DT_SIZE_K(16)>;
+		zephyr,memory-region = "SRAMX";
 	};
 
 	sram0: memory@20000000 {

--- a/dts/arm/nxp/lpc/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/lpc/nxp_lpc55S6x_common.dtsi
@@ -62,11 +62,6 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	sramx: memory@4000000 {
-		compatible = "mmio-sram";
-		reg = <0x4000000 DT_SIZE_K(32)>;
-	};
-
 	/* lpc55S6x Memory configurations:
 	 *
 	 * RAM blocks SRAM0 through SRAM4 are contiguous address ranges
@@ -75,6 +70,12 @@
 	 * LPC55S69: 320KB RAM, RAMX: 32K, SRAM0: 64K, SRAM1: 64K,
 	 *                      SRAM2: 64K, SRAM3: 64K, SRAM4: 16K
 	 */
+	sramx: memory@4000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x4000000 DT_SIZE_K(32)>;
+		zephyr,memory-region = "SRAMX";
+	};
+
 	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SIZE_K(64)>;


### PR DESCRIPTION
- Adds the "zephyr,memory-region" compatible property to the SRAMX node on LPC55S6x. This exposes the RAM block as named memory region so it can be referenced from linker sections and application code.
- Fixes the inability to relocate code to SRAMX on LPCXpresso55s69.
- Moves the SRAMX memory-region definition from nxp_lpc55S0x_ns.dtsi to _common.
- It follows the memory-region approach used by nxp_lpc55S1x/2x/3x_common.dtsi