### PR TITLE
Bluetooth: Controller: Generate lost ISO data for CIS Rx

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -36,6 +36,8 @@
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
+#include "isoal.h"
+
 #include "ll_feat.h"
 
 #include "hal/debug.h"
@@ -50,6 +52,7 @@ static void isr_done(void *param);
 static void payload_count_flush(struct lll_conn_iso_stream *cis_lll);
 static void payload_count_flush_or_inc_on_close(struct lll_conn_iso_stream *cis_lll);
 static void payload_count_lazy_update(struct lll_conn_iso_stream *cis_lll, uint16_t lazy);
+static void iso_rx_data_lost(struct lll_conn_iso_stream *cis_lll);
 
 static uint16_t next_cis_chan_remap_idx;
 static uint16_t next_cis_chan_prn_s;
@@ -1216,6 +1219,54 @@ static void isr_done(void *param)
 	lll_isr_cleanup(param);
 }
 
+static void iso_rx_data_lost(struct lll_conn_iso_stream *cis_lll)
+{
+	struct lll_conn_iso_group *cig_lll;
+	struct node_rx_iso_meta *iso_meta;
+	struct node_rx_pdu *node_rx;
+	struct pdu_cis *pdu_rx;
+
+	/* Only report lost ISO data when an Rx data path is set up to consume
+	 * it, e.g. to drive Packet Loss Concealment (PLC) in the LC3 codec.
+	 */
+	if (!cis_lll->datapath_ready_rx) {
+		return;
+	}
+
+	/* Two free Rx buffers are required: one is consumed to report the lost
+	 * ISO data and the other ensures a buffer remains available for the
+	 * radio DMA to receive in subsequent subevents/events.
+	 */
+	node_rx = ull_iso_pdu_rx_alloc_peek(2U);
+	if (!node_rx) {
+		return;
+	}
+
+	ull_iso_pdu_rx_alloc();
+
+	pdu_rx = (void *)node_rx->pdu;
+	pdu_rx->ll_id = PDU_CIS_LLID_START_CONTINUE;
+	pdu_rx->len = 0U;
+
+	node_rx->hdr.type = NODE_RX_TYPE_ISO_PDU;
+	node_rx->hdr.handle = cis_lll->handle;
+
+	iso_meta = &node_rx->rx_iso_meta;
+	iso_meta->payload_number = cis_lll->rx.payload_count + cis_lll->rx.bn_curr - 1U;
+	iso_meta->timestamp = HAL_TICKER_TICKS_TO_US(radio_tmr_start_get()) +
+			      radio_tmr_ready_restore();
+	cig_lll = ull_conn_iso_lll_group_get_by_stream(cis_lll);
+	iso_meta->timestamp -= (cis_lll->event_count -
+				(cis_lll->rx.payload_count / cis_lll->rx.bn)) *
+			       cig_lll->iso_interval_us;
+	iso_meta->timestamp %=
+		HAL_TICKER_TICKS_TO_US_64BIT(BIT64(HAL_TICKER_CNTR_MSBIT + 1U));
+	iso_meta->status = ISOAL_PDU_STATUS_LOST_DATA;
+
+	iso_rx_put(node_rx->hdr.link, node_rx);
+	iso_rx_sched();
+}
+
 static void payload_count_flush(struct lll_conn_iso_stream *cis_lll)
 {
 	if (cis_lll->tx.bn) {
@@ -1256,6 +1307,12 @@ static void payload_count_flush(struct lll_conn_iso_stream *cis_lll)
 		      ((cis_lll->rx.payload_count / cis_lll->rx.bn) <= cis_lll->event_count)) ||
 		     ((cis_lll->rx.bn_curr == cis_lll->rx.bn) &&
 		      ((cis_lll->rx.payload_count / cis_lll->rx.bn) < cis_lll->event_count)))) {
+			/* Generate HCI ISO data with lost status for the Rx
+			 * payload whose flush timeout has elapsed without a
+			 * successful reception.
+			 */
+			iso_rx_data_lost(cis_lll);
+
 			/* sn and nesn are 1-bit, only Least Significant bit is needed */
 			cis_lll->nesn++;
 			cis_lll->rx.bn_curr++;
@@ -1325,6 +1382,12 @@ payload_count_flush_or_inc_on_close_rx:
 			(cis_lll->event_count + 1U)) ||
 		       ((((cis_lll->rx.payload_count / cis_lll->rx.bn) + cis_lll->rx.ft) ==
 			 (cis_lll->event_count + 1U)) && (u <= (cis_lll->nse + 1U)))) {
+			/* Generate HCI ISO data with lost status for the Rx
+			 * payload that is being flushed without a successful
+			 * reception when closing the isochronous event.
+			 */
+			iso_rx_data_lost(cis_lll);
+
 			/* sn and nesn are 1-bit, only Least Significant bit is needed */
 			cis_lll->nesn++;
 			cis_lll->rx.bn_curr++;
@@ -1389,6 +1452,12 @@ static void payload_count_lazy_update(struct lll_conn_iso_stream *cis_lll, uint1
 				cis_lll->event_count) ||
 			       ((((cis_lll->rx.payload_count / cis_lll->rx.bn) + cis_lll->rx.ft) ==
 				 cis_lll->event_count) && (u <= cis_lll->nse))) {
+				/* Generate HCI ISO data with lost status for the
+				 * Rx payload of a CIG event that was skipped due
+				 * to overlapping other events (laziness).
+				 */
+				iso_rx_data_lost(cis_lll);
+
 				/* sn and nesn are 1-bit, only Least Significant bit is needed */
 				cis_lll->nesn++;
 				cis_lll->rx.bn_curr++;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -36,6 +36,8 @@
 #include "lll_tim_internal.h"
 #include "lll_prof_internal.h"
 
+#include "isoal.h"
+
 #include "ll_feat.h"
 
 #include "hal/debug.h"
@@ -53,6 +55,7 @@ static void isr_done(void *param);
 static void payload_count_flush(struct lll_conn_iso_stream *cis_lll);
 static void payload_count_rx_flush_or_txrx_inc(struct lll_conn_iso_stream *cis_lll);
 static void payload_count_lazy(struct lll_conn_iso_stream *cis_lll, uint16_t lazy);
+static void iso_rx_data_lost(struct lll_conn_iso_stream *cis_lll);
 
 static uint8_t next_chan_use;
 static uint16_t data_chan_id;
@@ -1331,6 +1334,56 @@ static void isr_done(void *param)
 	lll_isr_cleanup(param);
 }
 
+static void iso_rx_data_lost(struct lll_conn_iso_stream *cis_lll)
+{
+	struct lll_conn_iso_group *cig_lll;
+	struct node_rx_iso_meta *iso_meta;
+	struct node_rx_pdu *node_rx;
+	struct pdu_cis *pdu_rx;
+
+	/* Only report lost ISO data when an Rx data path is set up to consume
+	 * it, e.g. to drive Packet Loss Concealment (PLC) in the LC3 codec.
+	 */
+	if (!cis_lll->datapath_ready_rx) {
+		return;
+	}
+
+	/* Two free Rx buffers are required: one is consumed to report the lost
+	 * ISO data and the other ensures a buffer remains available for the
+	 * radio DMA to receive in subsequent subevents/events.
+	 */
+	node_rx = ull_iso_pdu_rx_alloc_peek(2U);
+	if (!node_rx) {
+		return;
+	}
+
+	ull_iso_pdu_rx_alloc();
+
+	pdu_rx = (void *)node_rx->pdu;
+	pdu_rx->ll_id = PDU_CIS_LLID_START_CONTINUE;
+	pdu_rx->len = 0U;
+
+	node_rx->hdr.type = NODE_RX_TYPE_ISO_PDU;
+	node_rx->hdr.handle = cis_lll->handle;
+
+	iso_meta = &node_rx->rx_iso_meta;
+	iso_meta->payload_number = cis_lll->rx.payload_count + cis_lll->rx.bn_curr - 1U;
+	iso_meta->timestamp = cis_lll->offset +
+		HAL_TICKER_TICKS_TO_US(radio_tmr_start_get()) +
+		radio_tmr_aa_restore() - cis_offset_first -
+		addr_us_get(cis_lll->rx.phy);
+	cig_lll = ull_conn_iso_lll_group_get_by_stream(cis_lll);
+	iso_meta->timestamp -= (cis_lll->event_count -
+				(cis_lll->rx.payload_count / cis_lll->rx.bn)) *
+			       cig_lll->iso_interval_us;
+	iso_meta->timestamp %=
+		HAL_TICKER_TICKS_TO_US_64BIT(BIT64(HAL_TICKER_CNTR_MSBIT + 1U));
+	iso_meta->status = ISOAL_PDU_STATUS_LOST_DATA;
+
+	iso_rx_put(node_rx->hdr.link, node_rx);
+	iso_rx_sched();
+}
+
 static void payload_count_flush(struct lll_conn_iso_stream *cis_lll)
 {
 	if (cis_lll->tx.bn) {
@@ -1378,6 +1431,12 @@ static void payload_count_flush(struct lll_conn_iso_stream *cis_lll)
 		      ((cis_lll->rx.payload_count / cis_lll->rx.bn) <= cis_lll->event_count)) ||
 		     ((cis_lll->rx.bn_curr == cis_lll->rx.bn) &&
 		      ((cis_lll->rx.payload_count / cis_lll->rx.bn) < cis_lll->event_count)))) {
+			/* Generate HCI ISO data with lost status for the Rx
+			 * payload whose flush timeout has elapsed without a
+			 * successful reception.
+			 */
+			iso_rx_data_lost(cis_lll);
+
 			/* sn and nesn are 1-bit, only Least Significant bit is needed */
 			cis_lll->nesn++;
 			cis_lll->rx.bn_curr++;
@@ -1419,6 +1478,12 @@ static void payload_count_rx_flush_or_txrx_inc(struct lll_conn_iso_stream *cis_l
 			(cis_lll->event_count + 1U)) ||
 		       ((((cis_lll->rx.payload_count / cis_lll->rx.bn) + cis_lll->rx.ft) ==
 			 (cis_lll->event_count + 1U)) && (u <= (cis_lll->nse + 1U)))) {
+			/* Generate HCI ISO data with lost status for the Rx
+			 * payload that is being flushed without a successful
+			 * reception when closing the isochronous event.
+			 */
+			iso_rx_data_lost(cis_lll);
+
 			/* sn and nesn are 1-bit, only Least Significant bit is needed */
 			cis_lll->nesn++;
 			cis_lll->rx.bn_curr++;
@@ -1483,6 +1548,12 @@ static void payload_count_lazy(struct lll_conn_iso_stream *cis_lll, uint16_t laz
 				cis_lll->event_count) ||
 			       ((((cis_lll->rx.payload_count / cis_lll->rx.bn) + cis_lll->rx.ft) ==
 				 cis_lll->event_count) && (u <= cis_lll->nse))) {
+				/* Generate HCI ISO data with lost status for the
+				 * Rx payload of a CIG event that was skipped due
+				 * to overlapping other events (laziness).
+				 */
+				iso_rx_data_lost(cis_lll);
+
 				/* sn and nesn are 1-bit, only Least Significant bit is needed */
 				cis_lll->nesn++;
 				cis_lll->rx.bn_curr++;

--- a/tests/bsim/bluetooth/ll/cis/src/main.c
+++ b/tests/bsim/bluetooth/ll/cis/src/main.c
@@ -256,6 +256,7 @@ static void iso_print_data(uint8_t *data, size_t data_len)
 	printk("\t %s\n", data_str);
 }
 
+static uint16_t offset_seq_num[CONFIG_BT_ISO_MAX_CHAN];
 static uint16_t expected_seq_num[CONFIG_BT_ISO_MAX_CHAN];
 
 static void iso_recv(struct bt_iso_chan *chan, const struct bt_iso_recv_info *info,
@@ -273,11 +274,14 @@ static void iso_recv(struct bt_iso_chan *chan, const struct bt_iso_recv_info *in
 	seq_num = sys_get_le32(buf->data);
 	if (info->flags & BT_ISO_FLAGS_VALID) {
 		if (seq_num != expected_seq_num[index]) {
+			printk("%s: info seq_num %u incoming seq_sum %u\n", __func__, info->seq_num,
+			       seq_num);
 			if (expected_seq_num[index]) {
 				FAIL("ISO data miss match, expected %u actual %u\n",
 				     expected_seq_num[index], seq_num);
 			}
 			expected_seq_num[index] = seq_num;
+			offset_seq_num[index] = info->seq_num - seq_num;
 		}
 
 		expected_seq_num[index] += 1U;
@@ -287,10 +291,26 @@ static void iso_recv(struct bt_iso_chan *chan, const struct bt_iso_recv_info *in
 #elif defined(CONFIG_TEST_FT_CEN_SKIP_SUBEVENTS)
 		expected_seq_num[index] += ((CONFIG_TEST_FT_CEN_SKIP_EVENTS_COUNT - 1U) * 2U);
 #endif
+
+#if defined(CONFIG_TEST_FT_PER_SKIP_SUBEVENTS)
+	} else if ((info->seq_num - offset_seq_num[index]) >=
+		   (expected_seq_num[index] - ((CONFIG_TEST_FT_PER_SKIP_EVENTS_COUNT - 1U) * 2U)) &&
+		   (info->seq_num - offset_seq_num[index]) < expected_seq_num[index]) {
+		/* Accepted lost data due to skipped subevents */
+#endif
+
+#if defined(CONFIG_TEST_FT_CEN_SKIP_SUBEVENTS)
+	} else if ((info->seq_num - offset_seq_num[index]) >=
+		   (expected_seq_num[index] - ((CONFIG_TEST_FT_CEN_SKIP_EVENTS_COUNT - 1U) * 2U)) &&
+		   (info->seq_num - offset_seq_num[index]) < expected_seq_num[index]) {
+		/* Accepted lost data due to skipped subevents */
+#endif
+
 	} else if (expected_seq_num[index] &&
 		   expected_seq_num[index] < SEQ_NUM_MAX) {
 		FAIL("%s: Invalid ISO data after valid ISO data reception.\n"
-		     "Expected %u\n", __func__, expected_seq_num[index]);
+		     "Chan %u, Expected %u Actual %u info %u.\n", __func__, index,
+		     expected_seq_num[index], seq_num, info->seq_num);
 	}
 }
 


### PR DESCRIPTION
The Nordic LLL implementation for Connected Isochronous Streams advanced the Rx payload counters (nesn and payload_count) for payloads that were not received, but did not generate any HCI ISO data towards the Host for them. As a result, when a whole SDU's worth of payloads was missing, the ISO-AL never advanced and never emitted a lost SDU, so the Host received no indication of the gap.

Add generation of HCI ISO data with status set to
ISOAL_PDU_STATUS_LOST_DATA whenever an Rx payload is skipped:

- when CIS subevents are not scheduled/received and the payload's flush timeout elapses (payload_count_flush and payload_count_(rx_)flush_or_(inc/txrx_inc) on close), and
- when a whole CIG event is skipped due to overlapping other events (laziness) in payload_count_lazy(_update).

The new node carries the lost payload number and an approximate reference anchor timestamp, mirroring the existing valid Rx data and the BIS (sync ISO) lost data generation. The ISO-AL turns the lost PDU into a lost SDU (HCI Packet_Status_Flag 0b10), which the Host can use to drive Packet Loss Concealment (PLC) in the LC3 codec. Generation is gated on a configured Rx data path.

Assisted-by: GitHub Copilot: Claude Opus 4.8