### PR TITLE
boards: shields: seed_xiao_logger_hat: Adding support for seeed studio logger hat

### DIFF
--- a/boards/shields/seeed_xiao_logger_hat/Kconfig.defconfig
+++ b/boards/shields/seeed_xiao_logger_hat/Kconfig.defconfig
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_SEEED_XIAO_LOGGER_HAT
+
+config SENSOR
+	default y
+
+config SHT4X
+	default y
+
+config RTC
+	default y
+
+config RTC_PCF8563
+	default y
+
+config GPIO
+	default y
+
+config BH1750
+	default y
+
+config ADC
+	default y
+
+config VOLTAGE_DIVIDER
+	default y
+
+endif # SHIELD_SEEED_XIAO_LOGGER_HAT

--- a/boards/shields/seeed_xiao_logger_hat/Kconfig.shield
+++ b/boards/shields/seeed_xiao_logger_hat/Kconfig.shield
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_SEEED_XIAO_LOGGER_HAT
+	def_bool $(shields_list_contains,seeed_xiao_logger_hat)

--- a/boards/shields/seeed_xiao_logger_hat/boards/xiao_esp32c3_esp32c3_hpcore.overlay
+++ b/boards/shields/seeed_xiao_logger_hat/boards/xiao_esp32c3_esp32c3_hpcore.overlay
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		battery = &vbatt;
+	};
+
+	vbatt: vbatt {
+		compatible = "voltage-divider";
+		io-channels = <&adc0 0>;
+		output-ohms = <100000>;
+		full-ohms = <(100000 + 100000)>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/boards/shields/seeed_xiao_logger_hat/boards/xiao_esp32c6_esp32c6_hpcore.overlay
+++ b/boards/shields/seeed_xiao_logger_hat/boards/xiao_esp32c6_esp32c6_hpcore.overlay
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		battery = &vbatt;
+	};
+
+	vbatt: vbatt {
+		compatible = "voltage-divider";
+		io-channels = <&adc0 0>;
+		output-ohms = <100000>;
+		full-ohms = <(100000 + 100000)>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/boards/shields/seeed_xiao_logger_hat/boards/xiao_mg24.overlay
+++ b/boards/shields/seeed_xiao_logger_hat/boards/xiao_mg24.overlay
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		battery = &vbatt;
+	};
+
+	vbatt: vbatt {
+		compatible = "voltage-divider";
+		io-channels = <&adc0 0>;
+		output-ohms = <100000>;
+		full-ohms = <(100000 + 100000)>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/boards/shields/seeed_xiao_logger_hat/boards/xiao_rp2350_hazard.overlay
+++ b/boards/shields/seeed_xiao_logger_hat/boards/xiao_rp2350_hazard.overlay
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		battery = &vbatt;
+	};
+
+	vbatt: vbatt {
+		compatible = "voltage-divider";
+		io-channels = <&adc 0>;
+		output-ohms = <100000>;
+		full-ohms = <(100000 + 100000)>;
+	};
+};
+
+&adc {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/boards/shields/seeed_xiao_logger_hat/boards/xiao_rp2350_m33.overlay
+++ b/boards/shields/seeed_xiao_logger_hat/boards/xiao_rp2350_m33.overlay
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		battery = &vbatt;
+	};
+
+	vbatt: vbatt {
+		compatible = "voltage-divider";
+		io-channels = <&adc 0>;
+		output-ohms = <100000>;
+		full-ohms = <(100000 + 100000)>;
+	};
+};
+
+&adc {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/boards/shields/seeed_xiao_logger_hat/doc/index.rst
+++ b/boards/shields/seeed_xiao_logger_hat/doc/index.rst
@@ -1,0 +1,95 @@
+.. _seeed_xiao_logger_hat:
+
+Seeed XIAO Logger Hat
+#####################
+
+Overview
+********
+
+The Seeed XIAO Logger Hat is an expansion board designed for
+Seeed Studio XIAO boards. It provides additional peripherals connected
+through the I2C interface.
+
+The shield includes:
+
+* Sensirion SHT4x temperature and humidity sensor
+* NXP PCF8563 real-time clock (RTC)
+* ROHM BH1750 light sensor
+* voltage divider for battery voltage measurement
+* sensor power control GPIO
+
+Supported boards
+****************
+
+This shield is compatible with Seeed Studio XIAO boards supported by
+Zephyr.
+
+Currently supported:
+
+   +----------------------+-----------------------------+
+   | All features         | No battery monitoring       |
+   +======================+=============================+
+   | seed_xiao_esp32c6    | seeed_xiao_samd21           |
+   +----------------------+-----------------------------+
+   | seed_xiao_esp32c3    | seeed_xiao_rp2040           |
+   +----------------------+-----------------------------+
+   | seeed_xiao_rp2350    |                             |
+   +----------------------+-----------------------------+
+   | seeed_xiao_mg24      |                             |
+   +----------------------+-----------------------------+
+
+Hardware configuration
+**********************
+
+The shield uses the following peripherals:
+
+I2C
+===
+
+The following devices are connected to the I2C bus:
+
++----------------------+----------------+
+| Device               | Address        |
++======================+================+
+| Sensirion SHT4x      | 0x44           |
++----------------------+----------------+
+| NXP PCF8563 RTC      | 0x51           |
++----------------------+----------------+
+| ROHM BH1750          | 0x23           |
++----------------------+----------------+
+
+Sensor power control
+====================
+
+The sensors power supply can be controlled using a GPIO pin.
+
+The shield defines a ``enable-sensors`` alias in the device tree.
+The GPIO assignment is done with xiao_d nexus node
+
+Configuration
+*************
+
+Enable the shield when building an application:
+
+.. code-block:: console
+
+   west build -b <board> --shield seeed_xiao_logger_hat
+
+Dependencies
+************
+
+Kconfig options has been added to enable the following features:
+
+* I2C support
+* Sensor subsystem
+* Sensirion SHT4x driver
+* RTC subsystem
+* NXP PCF8563 RTC driver
+* ROHM BH1750 driver
+* ADC support (for battery voltage measurement)
+* Voltage divider
+
+References
+**********
+
+* Seeed Studio XIAO Logger documentation - https://github.com/potblitd/XIAO-log/tree/main

--- a/boards/shields/seeed_xiao_logger_hat/dts/bindings/seeed,xiao-logger-hat.yaml
+++ b/boards/shields/seeed_xiao_logger_hat/dts/bindings/seeed,xiao-logger-hat.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, Dawid Zadlo
+# SPDX-License-Identifier: Apache-2.0
+
+description: seeed logger hat GPIO Controller
+
+compatible: "seeed,xiao-logger-hat"
+
+properties:
+  gpios:
+    type: phandle-array
+    required: true

--- a/boards/shields/seeed_xiao_logger_hat/seeed_xiao_logger_hat.overlay
+++ b/boards/shields/seeed_xiao_logger_hat/seeed_xiao_logger_hat.overlay
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		rtc = &bh1750;
+		enable-sensors = &sensors;
+	}
+
+	sensors: sensors {
+		compatible = "seeed,xiao-logger-hat";
+		gpios = <&xiao_d 10 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+
+	sht40: sht40@44 {
+		compatible = "sensirion,sht4x";
+		repeatability = <1>;
+		reg = <0x44>;
+	};
+
+	pcf8563: pcf8563@51 {
+		compatible = "nxp,pcf8563";
+		reg = <0x51>;
+	};
+
+	bh1750: bh1750@23 {
+		compatible = "rohm,bh1750";
+		reg = <0x23>;
+	};
+};

--- a/boards/shields/seeed_xiao_logger_hat/seeed_xiao_logger_hat.yaml
+++ b/boards/shields/seeed_xiao_logger_hat/seeed_xiao_logger_hat.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+shield:
+  name: seeed_xiao_logger_hat
+  full_name: Logger Hat shield for XIAO
+  vendor: seeed
+  supported_features:
+    - sensor
+    - i2c
+    - rtc
+    - adc


### PR DESCRIPTION
Summary

Adds support for the seeed_xiao_logger_hat shield.

Changes
Added shield definition.
Added devicetree overlay(s).
Added Kconfig
Added documentation for the shield.
Built the sample/application with the shield enabled.
Verified that the shield is detected and works as expected.