### PR TITLE
boards: st: nucleo_u3c5zi_q: Fix non-secure SRAM range in ns variant

### DIFF
--- a/boards/st/nucleo_u3c5zi_q/nucleo_u3c5zi_q_stm32u3c5xx_ns.dts
+++ b/boards/st/nucleo_u3c5zi_q/nucleo_u3c5zi_q_stm32u3c5xx_ns.dts
@@ -20,13 +20,14 @@
 	};
 };
 
-/* Node label sram0 initialy cover SRAM1 (192kB), SRAM2 (64kB),
- * SRAM3 (320kB) and SRAM4 (64kB). SRAM2 is owned by secure world
- * (TF-M). SRAM3 and SRAM4 are not supported as non-secure memory region.
- * So, we need to limit the sram0 node to cover only SRAM1 (192kB).
+/* Node label sram0 initialy cover SRAM1 (192kB), SRAM2 (64kB), SRAM3 (320kB) and SRAM4 (64kB).
+ * In current implementation of TF-M (v2.3.0) for U3C5x devices:
+ * - SRAM1 last 64 kbytes are secure;
+ * - SRAM2, SRAM3 and SRAM4 are fully secure.
+ * Therefore we need to limit the sram0 node to cover only the first 128kByte of SRAM1.
  */
 &sram0 {
-	reg = <0x20000000 DT_SIZE_K(192)>;
+	reg = <0x20000000 DT_SIZE_K(128)>;
 };
 
 &flash0 {


### PR DESCRIPTION
Current implementation of TF-M (v2.3.0) for STM32U3C5x devices only opens the first 128kB of SRAM1 to non-secure world (aside a 1kB area at the end of SRAM2 dedicated to shared boot info).

Correct the Zephyr SRAM address range accordingly in ns variant for nucleo_u3c5zi_q board.