### PR TITLE
dts: arm: st: u3: Fix sai1_{a|b} reg properties

### DIFF
--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -508,7 +508,7 @@
 			status = "disabled";
 
 			sai1_a: sai1a@40015404 {
-				reg = <0x4 0x20>;
+				reg = <0x40015404 0x20>;
 				dmas = <&gpdma1 1 36 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -516,7 +516,7 @@
 			};
 
 			sai1_b: sai1b@40015424 {
-				reg = <0x24 0x20>;
+				reg = <0x40015424 0x20>;
 				dmas = <&gpdma1 0 37 (STM32_DMA_16BITS | STM32_DMA_PRIORITY_HIGH)>;
 				#address-cells = <1>;
 				#size-cells = <0>;


### PR DESCRIPTION
Correct the reg properties of nodes sai1_a and sai1_b that should define the full address value since the empty ranges property in their parent node.