### PR TITLE
gpio: nrf: implement gpiohspadctrl for nrf54l

### DIFF
--- a/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54l15bsim_nrf54l15_cpuapp.dts
@@ -113,6 +113,7 @@
 
 &gpio2 {
 	status = "okay";
+	/delete-property/ hspadctrl-supported;
 };
 
 &gpiote20 {

--- a/boards/native/nrf_bsim/nrf54lm20bsim_nrf54lm20a_cpuapp.dts
+++ b/boards/native/nrf_bsim/nrf54lm20bsim_nrf54lm20a_cpuapp.dts
@@ -118,6 +118,7 @@
 
 &gpio2 {
 	status = "okay";
+	/delete-property/ hspadctrl-supported;
 };
 
 &gpiote20 {

--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -18,6 +18,14 @@
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
 
+#if DT_ANY_INST_HAS_BOOL_STATUS_OKAY(hspadctrl_supported)
+#define HSPADCTRL_SUPPORTED 1
+#endif
+
+#if HSPADCTRL_SUPPORTED
+#include <hal/nrf_gpiohspadctrl.h>
+#endif
+
 #define GPIOTE_PHANDLE(id) DT_INST_PHANDLE(id, gpiote_instance)
 #define GPIOTE_PROP(idx, prop)     DT_PROP(GPIOTE(idx), prop)
 
@@ -56,6 +64,10 @@ struct gpio_nrfx_cfg {
 #endif
 #if defined(GPIOTE_FEATURE_FLAG)
 	uint32_t flags;
+#endif
+#if HSPADCTRL_SUPPORTED
+	uint8_t has_hs_bias : 1;
+	uint8_t hs_bias : 4;
 #endif
 };
 
@@ -549,6 +561,25 @@ static int gpio_nrfx_port_get_direction(const struct device *port,
 }
 #endif /* CONFIG_GPIO_GET_DIRECTION */
 
+#if HSPADCTRL_SUPPORTED
+static bool has_hs_bias(const struct device *port)
+{
+	const struct gpio_nrfx_cfg *cfg = get_port_cfg(port);
+
+	return cfg->has_hs_bias;
+}
+
+static void set_hs_bias(const struct device *port)
+{
+	const struct gpio_nrfx_cfg *cfg = get_port_cfg(port);
+
+	/* The GPIOHSPADCTRL shares base address with the GPIO port is belongs to */
+	NRF_GPIOHSPADCTRL_Type *reg = (NRF_GPIOHSPADCTRL_Type *)cfg->port;
+
+	nrf_gpiohspadctrl_hs_bias_set(reg, cfg->hs_bias);
+}
+#endif /* HSPADCTRL_SUPPORTED */
+
 #ifdef CONFIG_GPIO_NRFX_INTERRUPT
 /* Get port device from port id. */
 static const struct device *get_dev(uint32_t port_id)
@@ -632,6 +663,12 @@ static int gpio_nrfx_init(const struct device *port)
 	const struct gpio_nrfx_cfg *cfg = get_port_cfg(port);
 	int err;
 
+#if HSPADCTRL_SUPPORTED
+	if (has_hs_bias(port)) {
+		set_hs_bias(port);
+	}
+#endif /* HSPADCTRL_SUPPORTED */
+
 	if (!use_gpiote(cfg)) {
 		goto pm_init;
 	}
@@ -711,6 +748,10 @@ static DEVICE_API(gpio, gpio_nrfx_drv_api_funcs) = {
 			    GPIOTE_FLAG_NO_PORT_EVT : 0) |				\
 			 (DT_PROP_OR(GPIOTE_PHANDLE(id), fixed_channels_supported, 0) ?	\
 			  GPIOTE_FLAG_FIXED_CHAN : 0),)					\
+			)								\
+		IF_ENABLED(HSPADCTRL_SUPPORTED,						\
+			(.has_hs_bias = DT_INST_PROP(id, hspadctrl_supported),		\
+			 .hs_bias = DT_INST_PROP(id, hs_bias),)				\
 			)								\
 	};										\
 											\

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -42,6 +42,21 @@ properties:
     description: |
       Enable latch detect mode for this GPIO port.
 
+  hspadctrl-supported:
+    type: boolean
+    description: |
+      High-Speed pad control supported for GPIO port.
+
+  hs-bias:
+    type: int
+    min: 0
+    max: 3
+    default: 3
+    description: |
+      Slew setting for GPIO port. Default to highest/fastest value as recommended by datasheet.
+      Available if hspadctrl is supported for GPIO port, indicated by the hspadctrl-supported
+      property.
+
 gpio-cells:
   - pin
   - flags

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -198,6 +198,7 @@
 				ngpios = <11>;
 				status = "disabled";
 				port = <2>;
+				hspadctrl-supported;
 			};
 
 			timer00: timer@55000 {

--- a/dts/vendor/nordic/nrf54lm20_a_b.dtsi
+++ b/dts/vendor/nordic/nrf54lm20_a_b.dtsi
@@ -222,6 +222,7 @@
 				ngpios = <11>;
 				status = "disabled";
 				port = <2>;
+				hspadctrl-supported;
 			};
 
 			timer00: timer@55000 {


### PR DESCRIPTION
The nrf54l has high speed pad ctrl (slew rate) of the fast GPIO port (P2), configurable through registers sharing the address space of the GPIO port.

Extend the nordic,nrf-gpio devicetree binding with a property indicating if hspadctrl is available for a port, and add an optional property for setting the optional HSBIAS value of the GPIOHSPADCTRL BIAS register. The datasheet recommends always setting HSBIAS to its highest value: 
<img width="1663" height="288" alt="image" src="https://github.com/user-attachments/assets/564b753a-7184-4f8d-8060-a4aa812fdde4" /> which will now be set by the nrf gpio device driver on init, unless the user specifies otherwise in the devicetree.