### PR TITLE
soc: nordic: nrf71: Fix soc.c non-secure initialisation issue

### DIFF
--- a/soc/nordic/nrf71/soc.c
+++ b/soc/nordic/nrf71/soc.c
@@ -12,17 +12,15 @@
  * for the Nordic Semiconductor nRF71 family processor.
  */
 
-#ifdef __NRF_TFM__
 #include <zephyr/autoconf.h>
-#endif
 
 #include <zephyr/kernel.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
-
-#ifndef __NRF_TFM__
 #include <zephyr/cache.h>
+#ifndef __ZEPHYR__
+#include <hal/nrf_cache.h>
 #endif
 
 #if defined(NRF_APPLICATION)
@@ -122,7 +120,6 @@ static void set_mpc_region_override(NRF_MPC_Type *mpc,
 	nrf_mpc_override_config_set(mpc, index, &override->config);
 }
 
-#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 static void mpc_configuration(void)
 {
 	ARRAY_FOR_EACH(mpc00_region_overrides, i) {
@@ -133,7 +130,6 @@ static void mpc_configuration(void)
 		set_mpc_region_override(NRF_MPC03, i, &mpc03_region_overrides[i]);
 	}
 }
-#endif
 
 /**
  * Return the SPU instance that can be used to configure the
@@ -166,7 +162,8 @@ static void ipct_configuration(void)
 #endif /* CONFIG_TRUSTED_EXECUTION_NONSECURE */
 
 #if defined(CONFIG_SOC_NRF71_WIFI_BOOT)
-#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(__NRF_TFM__)
+#if (defined(NRF_APPLICATION) && !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)) || \
+	!defined(__ZEPHYR__)
 static void wifi_setup(void)
 {
 	/* Kickstart the LMAC processor */
@@ -181,11 +178,9 @@ static void wifi_setup(void)
 void soc_early_init_hook(void)
 {
 	/* Update the SystemCoreClock global variable with current core clock
-	 * retrieved from hardware state.
+	 * retrieved from the DT.
 	 */
-#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(__NRF_TFM__)
-	/* Currently not supported for non-secure */
-	SystemCoreClockUpdate();
+	SystemCoreClock = NRF_PERIPH_GET_FREQUENCY(DT_NODELABEL(cpu));
 
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	/* Skip for tf-m, configuration exist in target_cfg_71.c */
@@ -194,6 +189,8 @@ void soc_early_init_hook(void)
 	ipct_configuration();
 #endif
 
+#if (defined(NRF_APPLICATION) && !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)) || \
+	!defined(__ZEPHYR__)
 #if defined(CONFIG_SOC_NRF7120_WICR_SETUP)
 	int ret = wicr_setup();
 
@@ -215,15 +212,12 @@ void soc_early_init_hook(void)
 	nrf_lfxo_cload_set(NRF_LFXO,
 			(uint8_t)(DT_PROP(LFXO_NODE, load_capacitance_femtofarad) / 1000));
 #endif
-#endif /* !CONFIG_TRUSTED_EXECUTION_NONSECURE || __NRF_TFM__ */
+#endif /* (NRF_APPLICATION && !CONFIG_TRUSTED_EXECUTION_NONSECURE) || !__ZEPHYR__  */
 
-#ifdef __NRF_TFM__
-	/* TF-M enables the instruction cache from target_cfg_71.c, so we
-	 * don't need to enable it here.
-	 */
-#else
-	/* Enable ICACHE */
+#ifdef __ZEPHYR__
 	sys_cache_instr_enable();
+#elif defined(NRF_ICACHE)
+	nrf_cache_enable(NRF_ICACHE);
 #endif
 }
 

--- a/west.yml
+++ b/west.yml
@@ -399,7 +399,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: 79823893d870345e944f9acb59f08b5e3a3c55a8
+      revision: 163bdeb4681ebadf5781a8b8714a709ed77aaf27
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
The soc.c non-secure build initialisation was using __NRF_TFM__, which is meant to be for sdk-nrf only. New ifdef function is updated to replace the secure initialisation condition. So that now power related, wifi, wicr setup is done in secure environment for non secure build.

Also updated SystemCoreClock as global variable with retrival from the DT. SystemCoreClock setting will be done in non secure environment aligning to other nordic soc.

Corresponded tf-m fix:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/52989
https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/216

Signed-off-by: Travis Lam <travis.lam@nordicsemi.no>