### PR TITLE
kernel: fix race in cpu_mask_mod()

### DIFF
--- a/kernel/smp/cpu_mask.c
+++ b/kernel/smp/cpu_mask.c
@@ -29,17 +29,18 @@ static int cpu_mask_mod(k_tid_t thread, uint32_t enable_mask, uint32_t disable_m
 		if (z_is_thread_prevented_from_running(thread)) {
 			thread->base.cpu_mask |= enable_mask;
 			thread->base.cpu_mask  &= ~disable_mask;
+
+#if defined(CONFIG_ASSERT) && defined(CONFIG_SCHED_CPU_MASK_PIN_ONLY)
+			uint32_t m = thread->base.cpu_mask;
+
+			__ASSERT(m != 0 && (m & (m - 1)) == 0,
+				 "PIN_ONLY requires exactly one CPU in mask");
+#endif /* defined(CONFIG_ASSERT) && defined(CONFIG_SCHED_CPU_MASK_PIN_ONLY) */
+
 		} else {
 			ret = -EINVAL;
 		}
 	}
-
-#if defined(CONFIG_ASSERT) && defined(CONFIG_SCHED_CPU_MASK_PIN_ONLY)
-		uint32_t m = thread->base.cpu_mask;
-
-		__ASSERT(m != 0 && (m & (m - 1)) == 0,
-			 "PIN_ONLY requires exactly one CPU in mask");
-#endif /* defined(CONFIG_ASSERT) && defined(CONFIG_SCHED_CPU_MASK_PIN_ONLY) */
 
 	return ret;
 }


### PR DESCRIPTION
Moves the assert checking that exactly one CPU in the mask is set to be inside the locked section. This closes a hole where another CPU could have called cpu_mask_mod() and performed an OR operation setting more bits just before the current CPU read the cpu_mask field leading to an incorrect assert evaulation.