### PR TITLE
drivers: flash: infineon: fix soc-nv-flash node selection

### DIFF
--- a/drivers/flash/flash_infineon.c
+++ b/drivers/flash/flash_infineon.c
@@ -6,10 +6,7 @@
  */
 
 #define DT_DRV_COMPAT	  infineon_flash_controller
-
-#include "flash_priv.h"
-
-#define SOC_NV_FLASH_NODE SOC_NV_FLASH_CHILD_NODE(0)
+#define SOC_NV_FLASH_NODE DT_PARENT(DT_INST(0, fixed_partitions))
 
 #define PAGE_LEN DT_PROP(SOC_NV_FLASH_NODE, erase_block_size)
 


### PR DESCRIPTION
Commit 7acfb6145fd ("drivers: flash: unify SOC_NV_FLASH_NODE logic")
switched `flash_infineon.c` to the shared `SOC_NV_FLASH_CHILD_NODE()`
helper, which is documented to only work for flash controllers with a
single `soc-nv-flash` child node.

The Infineon CAT1A (PSoC 6) `infineon,flash-controller` node exposes two
`soc-nv-flash` children (the main flash and the auxiliary flash), both
`status = "okay"`. `SOC_NV_FLASH_CHILD_NODE(0)` therefore expands to two
node identifiers and `DT_REG_ADDR(SOC_NV_FLASH_NODE)` fails to compile:

```
error: 'DT_N_S_flash_controller_40250000_S_flash_10000000' undeclared
here (not in a function); did you mean
'DT_N_S_flash_controller_40250000_S_flash_10000000_ORD'?
```

This breaks building `tests/drivers/flash/common` (and any application
enabling the CAT1 flash driver with fixed partitions) for boards such as
`cy8cproto_063_ble` and `cy8cproto_062_4343w`.

### Fix

Restore the previous single-node selection, deriving the flash memory
node from its `fixed-partitions` parent, so the correct node is selected
regardless of how many `soc-nv-flash` children the controller exposes.

### Notes

The sibling `flash_infineon_pdl.c` received the same conversion but is
not affected: it is only built for parts whose controller has a single
`soc-nv-flash` child.

### Verification

Built `tests/drivers/flash/common` with the fix:

- `cy8cproto_063_ble` — builds and links (previously failed to compile)
- `cy8cproto_062_4343w` — builds and links (previously failed to compile)

Fixes: 7acfb6145fd ("drivers: flash: unify SOC_NV_FLASH_NODE logic")
