### PR TITLE
net: ip: set checksum to 0 if checksum offloading is used

### DIFF
--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -133,11 +133,11 @@ int net_ipv4_finalize(struct net_pkt *pkt, uint8_t next_header_proto)
 
 	ipv4_hdr->len   = net_htons(net_pkt_get_len(pkt));
 	ipv4_hdr->proto = next_header_proto;
+	ipv4_hdr->chksum = 0U;
 
 	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), NET_IF_CHECKSUM_IPV4_HEADER)) {
 		uint16_t chksum = 0;
 
-		ipv4_hdr->chksum = 0;
 		ret = net_calc_chksum_ipv4(pkt, &chksum);
 		if (ret < 0) {
 			return ret;

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2493,11 +2493,12 @@ static int context_setup_raw_ip_packet(net_sa_family_t family,
 				pkt, hdr_len - sizeof(struct net_ipv4_hdr));
 		}
 
+		ipv4_hdr->chksum = 0U;
+
 		if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt),
 						 NET_IF_CHECKSUM_IPV4_HEADER)) {
 			uint16_t chksum = 0;
 
-			ipv4_hdr->chksum = 0;
 			ret = net_calc_chksum_ipv4(pkt, &chksum);
 			if (ret < 0) {
 				return ret;

--- a/subsys/net/ip/udp.c
+++ b/subsys/net/ip/udp.c
@@ -57,12 +57,12 @@ int net_udp_finalize(struct net_pkt *pkt, bool force_chksum)
 	}
 
 	udp_hdr->len = net_htons(length);
+	udp_hdr->chksum = 0U;
 
 	if (net_if_need_calc_tx_checksum(net_pkt_iface(pkt), type) || force_chksum) {
 		int ret;
 		uint16_t chksum = 0;
 
-		udp_hdr->chksum = 0;
 		ret = net_calc_chksum_udp(pkt, &chksum);
 		if (ret < 0) {
 			return ret;


### PR DESCRIPTION
make sure that the checksum field is set to 0, when checksum offloading is used. In tcp, icmpv4 and icmpv6 it is already done that way.

It is also already done at the openthread border router, if the ethernet iface supports offloading.