### PR TITLE
arch: arm64: cache: fix dc_val type to uint64_t in arm64_dcache_all()

### DIFF
--- a/include/zephyr/arch/arm64/cache.h
+++ b/include/zephyr/arch/arm64/cache.h
@@ -151,7 +151,8 @@ static ALWAYS_INLINE int arm64_dcache_all(int op)
 {
 	uint32_t clidr_el1, csselr_el1, ccsidr_el1;
 	uint8_t loc, ctype, cache_level, line_size, way_pos;
-	uint32_t max_ways, max_sets, dc_val, set, way;
+	uint32_t max_ways, max_sets, set, way;
+	uint64_t dc_val;
 
 	if (op != K_CACHE_INVD && op != K_CACHE_WB && op != K_CACHE_WB_INVD) {
 		return -ENOTSUP;


### PR DESCRIPTION
The dc_val variable in arm64_dcache_all() is used as the operand for the DC set/way instructions (dc isw, dc cisw, dc csw). Per the ARM Architecture Reference Manual (DDI0487), the DC instruction takes a 64-bit general-purpose register (Xt) as its operand:
 
    DC <dc_op>, Xt

Using uint32_t with the "r" inline assembly constraint causes the compiler to select a 32-bit W register, which does not match the
64-bit Xt operand required by the DC instruction. Clang detects this with -Wasm-operand-widths:

  error: value size does not match register size specified by the
         constraint and modifier [-Werror,-Wasm-operand-widths]

Fix by declaring dc_val as uint64_t so the "r" constraint selects a 64-bit X register, matching the DC instruction's requirement.

Fixes: #114808 