### PR TITLE
serial: sam0: Fix discarded byte on zero size fifo_read

### DIFF
--- a/drivers/serial/uart_mchp_sercom_g1.c
+++ b/drivers/serial/uart_mchp_sercom_g1.c
@@ -1544,7 +1544,6 @@ static int uart_mchp_irq_rx_ready(const struct device *dev)
  * @param rx_data Pointer to the buffer to store received data.
  * @param size Size of the buffer.
  * @return Number of bytes read from the FIFO.
- * @retval -EINVAL for invalid argument.
  */
 static int uart_mchp_fifo_read(const struct device *dev, uint8_t *rx_data, const int size)
 {
@@ -1553,18 +1552,19 @@ static int uart_mchp_fifo_read(const struct device *dev, uint8_t *rx_data, const
 	bool is_clock_external = cfg->is_clock_external;
 	int retval = 0;
 
-	if (uart_is_rx_complete(regs, is_clock_external) == true) {
-		uint8_t ch = uart_get_received_char(
-			/* Get the received character */
-			regs, is_clock_external);
+	/*
+	 * Check the requested size before reading the received character:
+	 * reading it pops the byte out of the receiver, so doing so with no
+	 * room to store the byte would discard received data.
+	 */
+	if (size < 1) {
+		return 0;
+	}
 
-		if (size >= 1) {
-			/* Store the received character in the buffer */
-			*rx_data = ch;
-			retval = 1;
-		} else {
-			retval = -EINVAL;
-		}
+	if (uart_is_rx_complete(regs, is_clock_external) == true) {
+		/* Store the received character in the buffer */
+		*rx_data = uart_get_received_char(regs, is_clock_external);
+		retval = 1;
 	}
 
 	return retval;

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -858,16 +858,20 @@ static int uart_sam0_fifo_read(const struct device *dev, uint8_t *rx_data,
 	const struct uart_sam0_dev_cfg *config = dev->config;
 	SercomUsart * const regs = config->regs;
 
-	if (regs->INTFLAG.bit.RXC) {
-		uint8_t ch = regs->DATA.reg;
-
-		if (size >= 1) {
-			*rx_data = ch;
-			return 1;
-		} else {
-			return -EINVAL;
-		}
+	/*
+	 * Check the requested size before touching DATA: reading it pops the
+	 * received byte out of the receiver, so reading it with no room to
+	 * store the byte would discard received data.
+	 */
+	if (size < 1) {
+		return 0;
 	}
+
+	if (regs->INTFLAG.bit.RXC) {
+		*rx_data = regs->DATA.reg;
+		return 1;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
`uart_sam0_fifo_read()` and `uart_mchp_fifo_read()` read the received character before validating the requested size. Reading it pops the byte out of the receiver, so a call with `size < 1` consumed a received byte and then returned `-EINVAL`, losing the data. This PR fixes `fifo_read` to return 0 without discarding data (like other drivers), and it now never returns `-EINVAL` (no other drivers do this).

Most other drivers use a `while` loop (from a FIFO buffer) that avoids this issue.

Assisted-by: Claude:claude-opus-4.8