### PR TITLE
net: ethernet: remove wrong description from header

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -1,7 +1,6 @@
-/** @file
- @brief Ethernet
-
- This is not to be included by the application.
+/**
+ * @file
+ * @brief Ethernet
  */
 
 /*


### PR DESCRIPTION
remove wrong description from the
Ethernet header: