### PR TITLE
net: lwm2m: Check block context allocation before use

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -2115,15 +2115,18 @@ static int parse_write_op(struct lwm2m_message *msg, uint16_t format)
 			free_block_ctx(block_ctx);
 
 			r = init_block_ctx(&msg->path, &block_ctx);
+		}
+
+		if (block_ctx == NULL) {
+			LOG_ERR("Cannot find block context");
+			return r < 0 ? r : -ENOMEM;
+		}
+
+		if (block_num == 0) {
 			/* If we have already parsed the packet, we can handle the block size
 			 * given by the server.
 			 */
 			block_ctx->ctx.block_size = block_size;
-		}
-
-		if (r < 0) {
-			LOG_ERR("Cannot find block context");
-			return r;
 		}
 
 		msg->in.block_ctx = block_ctx;


### PR DESCRIPTION
parse_write_op() stored the server selected block size into the block1 context right after calling init_block_ctx(), before inspecting its return code. init_block_ctx() leaves the caller's pointer set to NULL and returns -ENOMEM when the block1 context pool (default 3 entries) has no free or timed out slot, so that store dereferences a NULL pointer.

Move the store below the guard, and validate the context pointer itself instead of the return code, so the context is only touched once it is known to be valid regardless of how the helpers report failure.

Fixes: #115223