### PR TITLE
drivers: crypto: add Realtek Bee crypto support

### DIFF
--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjf.yaml
@@ -19,6 +19,7 @@ supported:
   - entropy
   - dma
   - spi
+  - crypto
 testing:
   ignore_tags:
     - pm

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjl.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hjl.yaml
@@ -19,6 +19,7 @@ supported:
   - entropy
   - dma
   - spi
+  - crypto
 testing:
   ignore_tags:
     - pm

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hkf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hkf.yaml
@@ -19,6 +19,7 @@ supported:
   - entropy
   - dma
   - spi
+  - crypto
 testing:
   ignore_tags:
     - pm

--- a/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hmf.yaml
+++ b/boards/realtek/rtl8752h_evb/rtl8752h_evb_rtl8752hmf.yaml
@@ -19,6 +19,7 @@ supported:
   - entropy
   - dma
   - spi
+  - crypto
 testing:
   ignore_tags:
     - pm

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gkh.yaml
@@ -20,6 +20,7 @@ supported:
   - dma
   - spi
   - can
+  - crypto
 testing:
   ignore_tags:
     - pm

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gku.yaml
@@ -20,6 +20,7 @@ supported:
   - dma
   - spi
   - can
+  - crypto
 testing:
   ignore_tags:
     - pm

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762grh.yaml
@@ -19,6 +19,7 @@ supported:
   - entropy
   - dma
   - spi
+  - crypto
 testing:
   ignore_tags:
     - pm

--- a/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.yaml
+++ b/boards/realtek/rtl87x2g_evb_a/rtl87x2g_evb_a_rtl8762gru.yaml
@@ -19,6 +19,7 @@ supported:
   - entropy
   - dma
   - spi
+  - crypto
 testing:
   ignore_tags:
     - pm

--- a/drivers/crypto/CMakeLists.txt
+++ b/drivers/crypto/CMakeLists.txt
@@ -5,6 +5,8 @@ zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedtls_iface)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_CRYPTO_ATAES132A crypto_ataes132a.c)
+zephyr_library_sources_ifdef(CONFIG_CRYPTO_BEE_AES crypto_bee_aes.c)
+zephyr_library_sources_ifdef(CONFIG_CRYPTO_BEE_SHA256 crypto_bee_sha.c)
 zephyr_library_sources_ifdef(CONFIG_CRYPTO_BFLB_SEC_ENG_AES crypto_bflb_sec_eng_aes.c)
 zephyr_library_sources_ifdef(CONFIG_CRYPTO_BFLB_SEC_ENG_SHA crypto_bflb_sec_eng_sha.c)
 zephyr_library_sources_ifdef(CONFIG_CRYPTO_CC23X0 crypto_cc23x0.c)

--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -56,6 +56,7 @@ config CRYPTO_MBEDTLS_SHIM_MAX_SESSION
 
 # zephyr-keep-sorted-start
 source "drivers/crypto/Kconfig.ataes132a"
+source "drivers/crypto/Kconfig.bee"
 source "drivers/crypto/Kconfig.bflb"
 source "drivers/crypto/Kconfig.cc23x0"
 source "drivers/crypto/Kconfig.esp32"

--- a/drivers/crypto/Kconfig.bee
+++ b/drivers/crypto/Kconfig.bee
@@ -1,0 +1,39 @@
+# Copyright (c) 2026, Realtek Semiconductor Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config CRYPTO_BEE_AES
+	bool "Realtek Bee AES hardware accelerator"
+	default y
+	depends on DT_HAS_REALTEK_BEE_AES_ENABLED
+	help
+	  Enable the AES hardware accelerator driver for Realtek Bee family
+	  SoCs (RTL8752H, RTL87x2G). Supports AES-128 and AES-256 in ECB,
+	  CBC, and CTR modes.
+
+if CRYPTO_BEE_AES
+
+config CRYPTO_BEE_AES_SESSIONS_MAX
+	int "Maximum number of concurrent AES sessions"
+	default 4
+	range 1 32
+	help
+	  Maximum number of concurrent AES cipher sessions. Each session
+	  uses approximately 64 bytes of RAM.
+
+config CRYPTO_BEE_AES_SWAP_BUF
+	bool
+	default y if SOC_SERIES_RTL8752H
+	help
+	  Enable byte swapping before and after calling the AES hardware engine.
+	  RTL8752H requires this to match the hardware engine word order, while
+	  RTL87x2G accepts buffers in normal byte order and should leave this off.
+
+endif # CRYPTO_BEE_AES
+
+config CRYPTO_BEE_SHA256
+	bool "Realtek Bee SHA-256 hardware accelerator"
+	default y
+	depends on DT_HAS_REALTEK_BEE_SHA256_ENABLED
+	help
+	  Enable the SHA-256 hardware accelerator driver for Realtek Bee
+	  SoCs (RTL8752H, RTL87x2G). Supports one-shot SHA-256 calculation.

--- a/drivers/crypto/crypto_bee_aes.c
+++ b/drivers/crypto/crypto_bee_aes.c
@@ -1,0 +1,536 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/crypto/crypto.h>
+#include <zephyr/crypto/cipher.h>
+#include <string.h>
+#include <errno.h>
+
+#if defined(CONFIG_SOC_SERIES_RTL87X2G)
+#include <crypto_engine_nsc.h>
+#elif defined(CONFIG_SOC_SERIES_RTL8752H)
+#include <hw_aes.h>
+#endif
+
+LOG_MODULE_REGISTER(crypto_bee_aes, CONFIG_CRYPTO_LOG_LEVEL);
+
+#define DT_DRV_COMPAT realtek_bee_aes
+
+#define BEE_AES_BLOCK_SIZE 16U
+
+struct bee_aes_sessn_state {
+	bool in_use;
+	uint8_t key[32];
+	size_t key_len;
+	enum cipher_mode mode;
+	enum cipher_op op;
+};
+
+static K_MUTEX_DEFINE(bee_aes_lock);
+
+static struct bee_aes_sessn_state bee_aes_sessions[CONFIG_CRYPTO_BEE_AES_SESSIONS_MAX];
+
+static void bee_aes_copy_to_hw(const uint8_t *src, uint32_t *dst, size_t len)
+{
+#if defined(CONFIG_CRYPTO_BEE_AES_SWAP_BUF)
+	swap_buf(src, (uint8_t *)dst, len);
+#else
+	memcpy(dst, src, len);
+#endif
+}
+
+static void bee_aes_copy_from_hw(const uint32_t *src, uint8_t *dst, size_t len)
+{
+#if defined(CONFIG_CRYPTO_BEE_AES_SWAP_BUF)
+	swap_buf((const uint8_t *)src, dst, len);
+#else
+	memcpy(dst, src, len);
+#endif
+}
+
+static struct bee_aes_sessn_state *bee_aes_sessn_alloc(void)
+{
+	struct bee_aes_sessn_state *ret = NULL;
+
+	k_mutex_lock(&bee_aes_lock, K_FOREVER);
+
+	for (int i = 0; i < ARRAY_SIZE(bee_aes_sessions); i++) {
+		if (!bee_aes_sessions[i].in_use) {
+			memset(&bee_aes_sessions[i], 0, sizeof(bee_aes_sessions[i]));
+			bee_aes_sessions[i].in_use = true;
+			ret = &bee_aes_sessions[i];
+			break;
+		}
+	}
+
+	k_mutex_unlock(&bee_aes_lock);
+
+	if (!ret) {
+		LOG_WRN("No free AES sessions (max %d)", CONFIG_CRYPTO_BEE_AES_SESSIONS_MAX);
+	}
+
+	return ret;
+}
+
+static void bee_aes_sessn_free(struct bee_aes_sessn_state *s)
+{
+	if (!s) {
+		return;
+	}
+
+	k_mutex_lock(&bee_aes_lock, K_FOREVER);
+	memset(s, 0, sizeof(*s));
+	k_mutex_unlock(&bee_aes_lock);
+}
+
+static T_HW_AES_MODE bee_aes_hw_mode(enum cipher_mode mode)
+{
+	switch (mode) {
+	case CRYPTO_CIPHER_MODE_ECB:
+		return AES_MODE_ECB;
+	case CRYPTO_CIPHER_MODE_CBC:
+		return AES_MODE_CBC;
+	case CRYPTO_CIPHER_MODE_CFB:
+		return AES_MODE_CFB;
+	case CRYPTO_CIPHER_MODE_OFB:
+		return AES_MODE_OFB;
+	case CRYPTO_CIPHER_MODE_CTR:
+		return AES_MODE_CTR;
+	default:
+		return AES_MODE_NONE;
+	}
+}
+
+static int bee_aes_hw_block(const struct bee_aes_sessn_state *s, T_HW_AES_MODE mode,
+			    const uint8_t *in, uint8_t *out, const uint8_t *iv, bool decrypt)
+{
+	uint32_t in_hw[BEE_AES_BLOCK_SIZE / sizeof(uint32_t)];
+	uint32_t out_hw[BEE_AES_BLOCK_SIZE / sizeof(uint32_t)];
+	uint32_t key_hw[32U / sizeof(uint32_t)];
+	uint32_t iv_hw[BEE_AES_BLOCK_SIZE / sizeof(uint32_t)];
+	uint32_t *iv_arg = NULL;
+	bool ret;
+
+	bee_aes_copy_to_hw(in, in_hw, BEE_AES_BLOCK_SIZE);
+	bee_aes_copy_to_hw(s->key, key_hw, s->key_len);
+
+	if (iv) {
+		bee_aes_copy_to_hw(iv, iv_hw, BEE_AES_BLOCK_SIZE);
+		iv_arg = iv_hw;
+	}
+
+	if (s->key_len == 16U) {
+		if (decrypt) {
+			ret = hw_aes_decrypt128(in_hw, out_hw, 4, key_hw, iv_arg, mode);
+		} else {
+			ret = hw_aes_encrypt128(in_hw, out_hw, 4, key_hw, iv_arg, mode);
+		}
+	} else if (s->key_len == 32U) {
+		if (decrypt) {
+			ret = hw_aes_decrypt256(in_hw, out_hw, 4, key_hw, iv_arg, mode);
+		} else {
+			ret = hw_aes_encrypt256(in_hw, out_hw, 4, key_hw, iv_arg, mode);
+		}
+	} else {
+		return -EINVAL;
+	}
+
+	if (!ret) {
+		return -EIO;
+	}
+
+	bee_aes_copy_from_hw(out_hw, out, BEE_AES_BLOCK_SIZE);
+	return 0;
+}
+
+static void bee_aes_ctr_inc(uint8_t *counter, size_t ctr_offset)
+{
+	for (int i = BEE_AES_BLOCK_SIZE - 1; i >= (int)ctr_offset; i--) {
+		if (++counter[i] != 0) {
+			break;
+		}
+	}
+}
+
+static int bee_aes_block_mode_crypt(const struct bee_aes_sessn_state *s, const uint8_t *in,
+				    uint8_t *out, size_t len, const uint8_t *iv)
+{
+	T_HW_AES_MODE mode = bee_aes_hw_mode(s->mode);
+	bool decrypt = (s->op == CRYPTO_CIPHER_OP_DECRYPT);
+	uint8_t iv_state[BEE_AES_BLOCK_SIZE];
+	int ret;
+
+	if ((len % BEE_AES_BLOCK_SIZE) != 0U) {
+		return -EINVAL;
+	}
+
+	if (iv) {
+		memcpy(iv_state, iv, BEE_AES_BLOCK_SIZE);
+	}
+
+	while (len > 0U) {
+		ret = bee_aes_hw_block(s, mode, in, out, iv ? iv_state : NULL, decrypt);
+		if (ret != 0) {
+			return ret;
+		}
+
+		if (s->mode == CRYPTO_CIPHER_MODE_CBC) {
+			if (decrypt) {
+				memcpy(iv_state, in, BEE_AES_BLOCK_SIZE);
+			} else {
+				memcpy(iv_state, out, BEE_AES_BLOCK_SIZE);
+			}
+		}
+
+		in += BEE_AES_BLOCK_SIZE;
+		out += BEE_AES_BLOCK_SIZE;
+		len -= BEE_AES_BLOCK_SIZE;
+	}
+
+	return 0;
+}
+
+static int bee_aes_cfb_crypt(const struct bee_aes_sessn_state *s, const uint8_t *in, uint8_t *out,
+			     size_t len, const uint8_t *iv)
+{
+	bool decrypt = (s->op == CRYPTO_CIPHER_OP_DECRYPT);
+	uint8_t iv_state[BEE_AES_BLOCK_SIZE];
+	uint8_t zero[BEE_AES_BLOCK_SIZE] = {0};
+	int ret;
+
+	memcpy(iv_state, iv, BEE_AES_BLOCK_SIZE);
+
+	while (len > 0U) {
+		uint8_t stream[BEE_AES_BLOCK_SIZE];
+		size_t chunk = MIN(len, BEE_AES_BLOCK_SIZE);
+
+		ret = bee_aes_hw_block(s, AES_MODE_CFB, zero, stream, iv_state, decrypt);
+		if (ret != 0) {
+			return ret;
+		}
+
+		for (size_t i = 0; i < chunk; i++) {
+			out[i] = in[i] ^ stream[i];
+		}
+
+		if (chunk == BEE_AES_BLOCK_SIZE) {
+			if (decrypt) {
+				memcpy(iv_state, in, BEE_AES_BLOCK_SIZE);
+			} else {
+				memcpy(iv_state, out, BEE_AES_BLOCK_SIZE);
+			}
+		}
+
+		in += chunk;
+		out += chunk;
+		len -= chunk;
+	}
+
+	return 0;
+}
+
+static int bee_aes_ofb_crypt(const struct bee_aes_sessn_state *s, const uint8_t *in, uint8_t *out,
+			     size_t len, const uint8_t *iv)
+{
+	bool decrypt = (s->op == CRYPTO_CIPHER_OP_DECRYPT);
+	uint8_t iv_state[BEE_AES_BLOCK_SIZE];
+	uint8_t zero[BEE_AES_BLOCK_SIZE] = {0};
+	int ret;
+
+	memcpy(iv_state, iv, BEE_AES_BLOCK_SIZE);
+
+	while (len > 0U) {
+		uint8_t stream[BEE_AES_BLOCK_SIZE];
+		size_t chunk = MIN(len, BEE_AES_BLOCK_SIZE);
+
+		ret = bee_aes_hw_block(s, AES_MODE_OFB, zero, stream, iv_state, decrypt);
+		if (ret != 0) {
+			return ret;
+		}
+
+		for (size_t i = 0; i < chunk; i++) {
+			out[i] = in[i] ^ stream[i];
+		}
+
+		memcpy(iv_state, stream, BEE_AES_BLOCK_SIZE);
+		in += chunk;
+		out += chunk;
+		len -= chunk;
+	}
+
+	return 0;
+}
+
+static int bee_aes_ctr_crypt(const struct bee_aes_sessn_state *s, const uint8_t *in, uint8_t *out,
+			     size_t len, const uint8_t *iv, uint32_t ctr_len_bits)
+{
+	size_t ctr_bytes;
+	size_t iv_bytes;
+	uint8_t counter[BEE_AES_BLOCK_SIZE];
+	int ret;
+
+	if (ctr_len_bits == 0U || (ctr_len_bits % 8U) != 0U || ctr_len_bits > 128U) {
+		LOG_ERR("CTR: invalid counter length %u bits", ctr_len_bits);
+		return -EINVAL;
+	}
+
+	ctr_bytes = ctr_len_bits / 8U;
+	iv_bytes = BEE_AES_BLOCK_SIZE - ctr_bytes;
+
+	memset(counter, 0, sizeof(counter));
+	memcpy(counter, iv, iv_bytes);
+
+	while (len > 0U) {
+		uint8_t stream[BEE_AES_BLOCK_SIZE];
+		size_t chunk = MIN(len, BEE_AES_BLOCK_SIZE);
+
+		/* Match the Realtek SDK CTR wrapper: generate the CTR keystream by
+		 * encrypting the counter block with AES-ECB, then XOR in software.
+		 * Do not call the HW AES_MODE_CTR path here; its counter semantics do
+		 * not match Zephyr's split [nonce || counter] CTR test vectors.
+		 */
+		ret = bee_aes_hw_block(s, AES_MODE_ECB, counter, stream, NULL, false);
+		if (ret != 0) {
+			return ret;
+		}
+
+		for (size_t i = 0; i < chunk; i++) {
+			out[i] = in[i] ^ stream[i];
+		}
+
+		bee_aes_ctr_inc(counter, iv_bytes);
+		in += chunk;
+		out += chunk;
+		len -= chunk;
+	}
+
+	return 0;
+}
+
+static int bee_aes_ecb_op(struct cipher_ctx *ctx, struct cipher_pkt *pkt)
+{
+	struct bee_aes_sessn_state *s = ctx->drv_sessn_state;
+	int ret;
+
+	if (!s || pkt->in_len < 0 || !pkt->in_buf || !pkt->out_buf) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&bee_aes_lock, K_FOREVER);
+	ret = bee_aes_block_mode_crypt(s, pkt->in_buf, pkt->out_buf, pkt->in_len, NULL);
+	k_mutex_unlock(&bee_aes_lock);
+
+	if (ret == 0) {
+		pkt->out_len = pkt->in_len;
+	}
+
+	return ret;
+}
+
+static int bee_aes_cbc_op(struct cipher_ctx *ctx, struct cipher_pkt *pkt, uint8_t *iv)
+{
+	struct bee_aes_sessn_state *s = ctx->drv_sessn_state;
+	bool decrypt;
+	bool prefix_iv;
+	const uint8_t *in;
+	uint8_t *out;
+	size_t len;
+	int ret;
+
+	if (!s || pkt->in_len < 0) {
+		return -EINVAL;
+	}
+
+	decrypt = (s->op == CRYPTO_CIPHER_OP_DECRYPT);
+	prefix_iv = (ctx->flags & CAP_NO_IV_PREFIX) == 0U;
+	in = pkt->in_buf;
+	out = pkt->out_buf;
+	len = pkt->in_len;
+
+	if (!iv) {
+		return -EINVAL;
+	}
+
+	if (!decrypt && prefix_iv) {
+		memcpy(out, iv, BEE_AES_BLOCK_SIZE);
+		out += BEE_AES_BLOCK_SIZE;
+	} else if (decrypt && prefix_iv) {
+		if (len < BEE_AES_BLOCK_SIZE) {
+			return -EINVAL;
+		}
+		iv = (uint8_t *)in;
+		in += BEE_AES_BLOCK_SIZE;
+		len -= BEE_AES_BLOCK_SIZE;
+	}
+
+	k_mutex_lock(&bee_aes_lock, K_FOREVER);
+	ret = bee_aes_block_mode_crypt(s, in, out, len, iv);
+	k_mutex_unlock(&bee_aes_lock);
+
+	if (ret == 0) {
+		pkt->out_len = pkt->in_len;
+		if (!decrypt && prefix_iv) {
+			pkt->out_len += BEE_AES_BLOCK_SIZE;
+		} else if (decrypt && prefix_iv) {
+			pkt->out_len -= BEE_AES_BLOCK_SIZE;
+		}
+	}
+
+	return ret;
+}
+
+static int bee_aes_cfb_op(struct cipher_ctx *ctx, struct cipher_pkt *pkt, uint8_t *iv)
+{
+	struct bee_aes_sessn_state *s = ctx->drv_sessn_state;
+	int ret;
+
+	if (!s || pkt->in_len < 0 || !pkt->in_buf || !pkt->out_buf || !iv) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&bee_aes_lock, K_FOREVER);
+	ret = bee_aes_cfb_crypt(s, pkt->in_buf, pkt->out_buf, pkt->in_len, iv);
+	k_mutex_unlock(&bee_aes_lock);
+
+	if (ret == 0) {
+		pkt->out_len = pkt->in_len;
+	}
+
+	return ret;
+}
+
+static int bee_aes_ofb_op(struct cipher_ctx *ctx, struct cipher_pkt *pkt, uint8_t *iv)
+{
+	struct bee_aes_sessn_state *s = ctx->drv_sessn_state;
+	int ret;
+
+	if (!s || pkt->in_len < 0 || !pkt->in_buf || !pkt->out_buf || !iv) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&bee_aes_lock, K_FOREVER);
+	ret = bee_aes_ofb_crypt(s, pkt->in_buf, pkt->out_buf, pkt->in_len, iv);
+	k_mutex_unlock(&bee_aes_lock);
+
+	if (ret == 0) {
+		pkt->out_len = pkt->in_len;
+	}
+
+	return ret;
+}
+
+static int bee_aes_ctr_op(struct cipher_ctx *ctx, struct cipher_pkt *pkt, uint8_t *iv)
+{
+	struct bee_aes_sessn_state *s = ctx->drv_sessn_state;
+	int ret;
+
+	if (!s || pkt->in_len < 0 || !pkt->in_buf || !pkt->out_buf || !iv) {
+		return -EINVAL;
+	}
+
+	k_mutex_lock(&bee_aes_lock, K_FOREVER);
+	ret = bee_aes_ctr_crypt(s, pkt->in_buf, pkt->out_buf, pkt->in_len, iv,
+				ctx->mode_params.ctr_info.ctr_len);
+	k_mutex_unlock(&bee_aes_lock);
+
+	if (ret == 0) {
+		pkt->out_len = pkt->in_len;
+	}
+
+	return ret;
+}
+
+static int bee_aes_query_caps(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return CAP_RAW_KEY | CAP_SEPARATE_IO_BUFS | CAP_SYNC_OPS | CAP_NO_IV_PREFIX;
+}
+
+static int bee_aes_begin_session(const struct device *dev, struct cipher_ctx *ctx,
+				 enum cipher_algo algo, enum cipher_mode mode,
+				 enum cipher_op op_type)
+{
+	struct bee_aes_sessn_state *s;
+
+	ARG_UNUSED(dev);
+
+	if (algo != CRYPTO_CIPHER_ALGO_AES) {
+		LOG_ERR("Unsupported algorithm %d", algo);
+		return -ENOTSUP;
+	}
+
+	if (mode != CRYPTO_CIPHER_MODE_ECB && mode != CRYPTO_CIPHER_MODE_CBC &&
+	    mode != CRYPTO_CIPHER_MODE_CFB && mode != CRYPTO_CIPHER_MODE_OFB &&
+	    mode != CRYPTO_CIPHER_MODE_CTR) {
+		LOG_ERR("Unsupported mode %d", mode);
+		return -ENOTSUP;
+	}
+
+	if (ctx->keylen != 16U && ctx->keylen != 32U) {
+		LOG_ERR("Unsupported key length %zu (must be 16 or 32)", ctx->keylen);
+		return -EINVAL;
+	}
+
+	s = bee_aes_sessn_alloc();
+	if (!s) {
+		return -ENOMEM;
+	}
+
+	s->key_len = ctx->keylen;
+	s->mode = mode;
+	s->op = op_type;
+	memcpy(s->key, ctx->key.bit_stream, ctx->keylen);
+
+	ctx->drv_sessn_state = s;
+	ctx->ops.cipher_mode = mode;
+
+	switch (mode) {
+	case CRYPTO_CIPHER_MODE_ECB:
+		ctx->ops.block_crypt_hndlr = bee_aes_ecb_op;
+		break;
+	case CRYPTO_CIPHER_MODE_CBC:
+		ctx->ops.cbc_crypt_hndlr = bee_aes_cbc_op;
+		break;
+	case CRYPTO_CIPHER_MODE_CFB:
+		ctx->ops.cfb_crypt_hndlr = bee_aes_cfb_op;
+		break;
+	case CRYPTO_CIPHER_MODE_OFB:
+		ctx->ops.ofb_crypt_hndlr = bee_aes_ofb_op;
+		break;
+	case CRYPTO_CIPHER_MODE_CTR:
+		ctx->ops.ctr_crypt_hndlr = bee_aes_ctr_op;
+		break;
+	default:
+		bee_aes_sessn_free(s);
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int bee_aes_free_session(const struct device *dev, struct cipher_ctx *ctx)
+{
+	ARG_UNUSED(dev);
+
+	bee_aes_sessn_free(ctx->drv_sessn_state);
+	ctx->drv_sessn_state = NULL;
+
+	return 0;
+}
+
+static DEVICE_API(crypto, bee_aes_crypto_api) = {
+	.query_hw_caps = bee_aes_query_caps,
+	.cipher_begin_session = bee_aes_begin_session,
+	.cipher_free_session = bee_aes_free_session,
+	.cipher_async_callback_set = NULL,
+};
+
+DEVICE_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY,
+		      &bee_aes_crypto_api);

--- a/drivers/crypto/crypto_bee_sha.c
+++ b/drivers/crypto/crypto_bee_sha.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT realtek_bee_sha256
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/crypto/crypto.h>
+#include <zephyr/logging/log.h>
+#include <string.h>
+#include <errno.h>
+
+#if defined(CONFIG_SOC_SERIES_RTL87X2G)
+#include <crypto_engine_nsc.h>
+#elif defined(CONFIG_SOC_SERIES_RTL8752H)
+#include <rtl876x_hw_sha256.h>
+#endif
+
+LOG_MODULE_REGISTER(crypto_bee_sha, CONFIG_CRYPTO_LOG_LEVEL);
+
+struct bee_sha256_data {
+	struct k_mutex lock;
+};
+
+static int bee_sha256_hash_handler(struct hash_ctx *ctx, struct hash_pkt *pkt, bool finish)
+{
+	struct bee_sha256_data *data = ctx->device->data;
+	uint32_t result[8];
+	uint8_t empty = 0U;
+	uint8_t *input;
+	bool ret;
+
+	if (!finish) {
+		LOG_ERR("Multipart SHA-256 is not supported");
+		return -ENOTSUP;
+	}
+
+	if (!pkt || !pkt->out_buf || (!pkt->in_buf && pkt->in_len != 0U)) {
+		return -EINVAL;
+	}
+
+	input = pkt->in_len == 0U ? &empty : (uint8_t *)pkt->in_buf;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+	ret = hw_sha256(input, pkt->in_len, result, HW_SHA256_CPU_MODE);
+	k_mutex_unlock(&data->lock);
+
+	if (!ret) {
+		return -EIO;
+	}
+
+	memcpy(pkt->out_buf, result, sizeof(result));
+
+	return 0;
+}
+
+static int bee_sha256_query_hw_caps(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return CAP_SEPARATE_IO_BUFS | CAP_SYNC_OPS;
+}
+
+static int bee_sha256_hash_begin_session(const struct device *dev, struct hash_ctx *ctx,
+					 enum hash_algo algo)
+{
+	if (algo != CRYPTO_HASH_ALGO_SHA256) {
+		LOG_ERR("Unsupported hash algorithm %d", algo);
+		return -ENOTSUP;
+	}
+
+	if ((ctx->flags & ~(CAP_SEPARATE_IO_BUFS | CAP_SYNC_OPS)) != 0U) {
+		LOG_ERR("Unsupported hash flags 0x%x", ctx->flags);
+		return -EINVAL;
+	}
+
+	ctx->hash_hndlr = bee_sha256_hash_handler;
+	ctx->device = dev;
+	ctx->drv_sessn_state = NULL;
+	ctx->started = false;
+
+	return 0;
+}
+
+static int bee_sha256_hash_free_session(const struct device *dev, struct hash_ctx *ctx)
+{
+	ARG_UNUSED(dev);
+
+	ctx->hash_hndlr = NULL;
+	ctx->drv_sessn_state = NULL;
+	ctx->started = false;
+
+	return 0;
+}
+
+static int bee_sha256_init(const struct device *dev)
+{
+	struct bee_sha256_data *data = dev->data;
+
+	k_mutex_init(&data->lock);
+
+	return 0;
+}
+
+static DEVICE_API(crypto, bee_sha256_crypto_api) = {
+	.query_hw_caps = bee_sha256_query_hw_caps,
+	.hash_begin_session = bee_sha256_hash_begin_session,
+	.hash_free_session = bee_sha256_hash_free_session,
+	.hash_async_callback_set = NULL,
+};
+
+#define BEE_SHA256_INIT(inst)                                                                      \
+	static struct bee_sha256_data bee_sha256_data_##inst;                                      \
+	DEVICE_DT_INST_DEFINE(inst, bee_sha256_init, NULL, &bee_sha256_data_##inst, NULL,          \
+			      POST_KERNEL, CONFIG_CRYPTO_INIT_PRIORITY, &bee_sha256_crypto_api);
+
+DT_INST_FOREACH_STATUS_OKAY(BEE_SHA256_INIT)

--- a/dts/arm/realtek/bee/rtl8752h.dtsi
+++ b/dts/arm/realtek/bee/rtl8752h.dtsi
@@ -378,6 +378,18 @@
 			status = "disabled";
 		};
 
+		aes: aes@40014000 {
+			compatible = "realtek,bee-aes";
+			reg = <0x40014000 0x7c>;
+			status = "disabled";
+		};
+
+		sha256: sha256@4002b000 {
+			compatible = "realtek,bee-sha256";
+			reg = <0x4002b000 0x220>;
+			status = "disabled";
+		};
+
 		trng: trng@400c2400 {
 			compatible = "realtek,bee-trng";
 			reg = <0x400c2400 0x68>;

--- a/dts/arm/realtek/bee/rtl87x2g.dtsi
+++ b/dts/arm/realtek/bee/rtl87x2g.dtsi
@@ -530,6 +530,18 @@
 			status = "disabled";
 		};
 
+		aes: aes@400c1000 {
+			compatible = "realtek,bee-aes";
+			reg = <0x400c1000 0xd4>;
+			status = "disabled";
+		};
+
+		sha256: sha256@400c2000 {
+			compatible = "realtek,bee-sha256";
+			reg = <0x400c2000 0x220>;
+			status = "disabled";
+		};
+
 		trng: trng@400c2400 {
 			compatible = "realtek,bee-trng";
 			reg = <0x400c2400 0x68>;

--- a/dts/bindings/crypto/realtek,bee-aes.yaml
+++ b/dts/bindings/crypto/realtek,bee-aes.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2026, Realtek Semiconductor Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Realtek Bee family AES hardware accelerator.
+
+  Supports AES-128 and AES-256 in ECB, CBC, CFB, OFB and CTR modes on Realtek Bee family SoCs.
+
+compatible: "realtek,bee-aes"
+
+include: base.yaml

--- a/dts/bindings/crypto/realtek,bee-sha256.yaml
+++ b/dts/bindings/crypto/realtek,bee-sha256.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2026, Realtek Semiconductor Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Realtek Bee family SHA-256 hardware accelerator.
+
+  Supports one-shot SHA-256 calculation on Realtek Bee family SoCs.
+
+compatible: "realtek,bee-sha256"
+
+include: base.yaml

--- a/samples/drivers/crypto/boards/rtl8752h_evb_rtl8752hjl.overlay
+++ b/samples/drivers/crypto/boards/rtl8752h_evb_rtl8752hjl.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&aes {
+	status = "okay";
+};

--- a/samples/drivers/crypto/boards/rtl87x2g_evb_a_rtl8762gku.overlay
+++ b/samples/drivers/crypto/boards/rtl87x2g_evb_a_rtl8762gku.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&aes {
+	status = "okay";
+};

--- a/samples/drivers/crypto/src/main.c
+++ b/samples/drivers/crypto/src/main.c
@@ -43,6 +43,8 @@ LOG_MODULE_REGISTER(main);
 #define CRYPTO_DEV_COMPAT sifli_sf32lb_crypto
 #elif DT_HAS_COMPAT_STATUS_OKAY(bflb_sec_eng_aes)
 #define CRYPTO_DEV_COMPAT bflb_sec_eng_aes
+#elif DT_HAS_COMPAT_STATUS_OKAY(realtek_bee_aes)
+#define CRYPTO_DEV_COMPAT realtek_bee_aes
 #elif CONFIG_CRYPTO_MSPM0_AES
 #define CRYPTO_DEV_COMPAT ti_mspm0_aes
 #else

--- a/samples/drivers/crypto/tests.yaml
+++ b/samples/drivers/crypto/tests.yaml
@@ -23,6 +23,27 @@ tests:
         - ".*: CCM mode DECRYPT - Match"
         - ".*: GCM mode ENCRYPT - Match"
         - ".*: GCM mode DECRYPT - Match"
+  sample.drivers.crypto.bee:
+    tags: crypto
+    filter: dt_compat_enabled("realtek,bee-aes")
+    integration_platforms:
+      - rtl87x2g_evb_a/rtl8762gku
+      - rtl8752h_evb/rtl8752hjl
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*: Cipher Sample"
+        - ".*: ECB mode ENCRYPT - Match"
+        - ".*: ECB mode DECRYPT - Match"
+        - ".*: CBC mode ENCRYPT - Match"
+        - ".*: CBC mode DECRYPT - Match"
+        - ".*: CFB mode ENCRYPT - Match"
+        - ".*: CFB mode DECRYPT - Match"
+        - ".*: OFB mode ENCRYPT - Match"
+        - ".*: OFB mode DECRYPT - Match"
+        - ".*: CTR mode ENCRYPT - Match"
+        - ".*: CTR mode DECRYPT - Match"
   sample.drivers.crypto.microchip:
     tags: crypto
     filter: dt_compat_enabled("microchip,aes-g1")

--- a/tests/crypto/crypto_aes/boards/rtl8752h_evb_rtl8752hjl.overlay
+++ b/tests/crypto/crypto_aes/boards/rtl8752h_evb_rtl8752hjl.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&aes {
+	status = "okay";
+};

--- a/tests/crypto/crypto_aes/boards/rtl87x2g_evb_a_rtl8762gku.overlay
+++ b/tests/crypto/crypto_aes/boards/rtl87x2g_evb_a_rtl8762gku.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&aes {
+	status = "okay";
+};

--- a/tests/crypto/crypto_aes/src/main.c
+++ b/tests/crypto/crypto_aes/src/main.c
@@ -24,6 +24,8 @@
 #define CRYPTO_DEV_COMPAT st_stm32_cryp
 #elif DT_HAS_COMPAT_STATUS_OKAY(bflb_sec_eng_aes)
 #define CRYPTO_DEV_COMPAT bflb_sec_eng_aes
+#elif DT_HAS_COMPAT_STATUS_OKAY(realtek_bee_aes)
+#define CRYPTO_DEV_COMPAT realtek_bee_aes
 #elif CONFIG_CRYPTO_INFINEON_MXCRYPTOLITE
 #define CRYPTO_DEV_COMPAT infineon_mxcryptolite_crypto
 #else

--- a/tests/crypto/crypto_aes/tests.yaml
+++ b/tests/crypto/crypto_aes/tests.yaml
@@ -23,4 +23,6 @@ tests:
       - cyw920829m2evk_02/cyw20829b1340
       - cyw920829m2evk_02/cyw20829b1010
       - cyw920829m2evk_02/cyw20829b0lkml
+      - rtl87x2g_evb_a/rtl8762gku
+      - rtl8752h_evb/rtl8752hjl
     tags: crypto

--- a/tests/crypto/crypto_hash/boards/rtl8752h_evb_rtl8752hjl.overlay
+++ b/tests/crypto/crypto_hash/boards/rtl8752h_evb_rtl8752hjl.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sha256 {
+	status = "okay";
+};

--- a/tests/crypto/crypto_hash/boards/rtl87x2g_evb_a_rtl8762gku.overlay
+++ b/tests/crypto/crypto_hash/boards/rtl87x2g_evb_a_rtl8762gku.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026, Realtek Semiconductor Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sha256 {
+	status = "okay";
+};

--- a/tests/crypto/crypto_hash/src/main.c
+++ b/tests/crypto/crypto_hash/src/main.c
@@ -27,6 +27,8 @@
 #define CRYPTO_DEV_COMPAT sifli_sf32lb_crypto
 #elif DT_HAS_COMPAT_STATUS_OKAY(bflb_sec_eng_sha)
 #define CRYPTO_DEV_COMPAT bflb_sec_eng_sha
+#elif DT_HAS_COMPAT_STATUS_OKAY(realtek_bee_sha256)
+#define CRYPTO_DEV_COMPAT realtek_bee_sha256
 #elif CONFIG_CRYPTO_INFINEON_MXCRYPTOLITE
 #define CRYPTO_DEV_COMPAT infineon_mxcryptolite_crypto
 #else

--- a/tests/crypto/crypto_hash/tests.yaml
+++ b/tests/crypto/crypto_hash/tests.yaml
@@ -26,4 +26,6 @@ tests:
       - cyw920829m2evk_02/cyw20829b1340
       - cyw920829m2evk_02/cyw20829b1010
       - cyw920829m2evk_02/cyw20829b0lkml
+      - rtl8752h_evb/rtl8752hjl
+      - rtl87x2g_evb_a/rtl8762gku
     tags: crypto

--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
         - hal
     - name: hal_realtek
       path: modules/hal/realtek
-      revision: ba5032a9e47b6ad9e9488665c1e990ed0f434734
+      revision: c20e7ee9744a1b9b5f05b99260930a7f196b9b12
       groups:
         - hal
     - name: hal_renesas


### PR DESCRIPTION
Add Realtek Bee AES and SHA-256 crypto driver support, including devicetree bindings and disabled SoC nodes for RTL8752H and RTL87x2G.

Add sample and test coverage for the Bee AES and SHA-256 devices, and update hal_realtek to include the required Bee crypto HAL APIs.

HAL dependency:
- https://github.com/zephyrproject-rtos/hal_realtek/pull/41

Testing:
- tests/crypto/crypto_hash on rtl8752h_evb/rtl8752hjl: passed
  - run_id: dc3cddd2523fabda2e718978f16d0dcd
  - dut: H Series
  - execution_time: 11.47 s
  - build_time: 44.98 s
  - sha256: passed; sha512/sha384/sha224: skipped by ztest
- tests/crypto/crypto_hash on rtl87x2g_evb_a/rtl8762gku: passed
  - run_id: d5bcbfd74fd4a1538f65de17170f923b
  - dut: G Series
  - execution_time: 13.91 s
  - build_time: 45.47 s
  - sha256: passed; sha512/sha384/sha224: skipped by ztest
- samples/drivers/crypto sample.drivers.crypto.bee on rtl8752h_evb/rtl8752hjl: passed
  - run_id: 92e916043f82fe3be861e021f4431718
  - dut: H Series
  - execution_time: 8.96 s
  - build_time: 132.67 s
- samples/drivers/crypto sample.drivers.crypto.bee on rtl87x2g_evb_a/rtl8762gku: passed
  - run_id: 839f94908c429fe7ac2400e7fab290fe
  - dut: G Series
  - execution_time: 11.44 s
  - build_time: 133.99 s
 
🤖 Generated with [Claude Code](https://claude.com/claude-code)
