### PR TITLE
dts: arm: nxp: kinetis: fix invalid ftfe /delete-node/

### DIFF
--- a/dts/arm/nxp/kinetis/nxp_ke17z.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_ke17z.dtsi
@@ -29,7 +29,7 @@
 
 	soc {
 		/* Remove ftfe, it doesn't exist on KE17Z */
-		/delete-node/ ftfe;
+		/delete-node/ flash-controller@40020000;
 
 		ftfa: flash-controller@40020000 {
 			compatible = "nxp,kinetis-ftfa";

--- a/dts/arm/nxp/kinetis/nxp_ke17z512.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_ke17z512.dtsi
@@ -25,7 +25,7 @@
 
 	soc {
 		/* Fix flash, it has different size on KE17Z512 */
-		/delete-node/ ftfe;
+		/delete-node/ flash-controller@40020000;
 
 		ftfe: flash-controller@40020000 {
 			compatible = "nxp,kinetis-ftfe";

--- a/dts/arm/nxp/kinetis/nxp_ke1xz64.dtsi
+++ b/dts/arm/nxp/kinetis/nxp_ke1xz64.dtsi
@@ -36,7 +36,7 @@
 
 	soc {
 		/* Remove ftfe, it doesn't exist on KE16Z */
-		/delete-node/ ftfe;
+		/delete-node/ flash-controller@40020000;
 
 		ftfa: flash-controller@40020000 {
 			compatible = "nxp,kinetis-ftfa";


### PR DESCRIPTION
The nxp_ke17z.dtsi, nxp_ke17z512.dtsi, and nxp_ke1xz64.dtsi overlays each remove the parent nxp_ke1xz.dtsi's flash-controller node with `/delete-node/ ftfe;` inside the soc {} scope. A `/delete-node/` directive inside a node body can only reference a child by its node name (name[@address]); the label form is silently ignored, so the parent's flash-controller@40020000 was never actually removed.

Replace `/delete-node/ ftfe;` with the full-form
`/delete-node/ flash-controller@40020000;` in all three overlays so the parent node is actually removed before the replacement is added.