### PR TITLE
boards: arm: fvp_corstone1000: build against current main and re-enable in CI

### DIFF
--- a/boards/arm/fvp_corstone1000/fvp_corstone1000_a320.yaml
+++ b/boards/arm/fvp_corstone1000/fvp_corstone1000_a320.yaml
@@ -15,4 +15,3 @@ ram: 128
 flash: 64
 vendor: arm
 sysbuild: true
-twister: false

--- a/boards/arm/fvp_corstone1000/fvp_corstone1000_a320_smp.yaml
+++ b/boards/arm/fvp_corstone1000/fvp_corstone1000_a320_smp.yaml
@@ -15,7 +15,6 @@ ram: 128
 flash: 64
 vendor: arm
 sysbuild: true
-twister: false
 testing:
   # Skip test execution until FVP SMP TLB coherency bug is resolved.
   # Using a non-existent tag effectively makes this build-only.

--- a/boards/arm/fvp_corstone1000/sysbuild.cmake
+++ b/boards/arm/fvp_corstone1000/sysbuild.cmake
@@ -204,6 +204,32 @@ set(tfm_cmake_args
   -DMCUBOOT_BUILTIN_KEY=OFF
 )
 
+# TF-M's corstone1000 platform builds the CryptoCell (cc3xx) PSA crypto driver
+# unconditionally: BL1 links it to verify boot images, so it is a hard
+# dependency rather than an optional accelerator.  TF-M fetches it from
+# git.trustedfirmware.org at configure time, which Zephyr does not allow in CI
+# (and its post-build checks reject a repository appearing under the build
+# directory).  Point TF-M at a pre-installed copy when one is available, the
+# same way this board relies on sgdisk being installed.  Without it, TF-M falls
+# back to its own fetch, which keeps local builds working out of the box.
+set(c1000_psa_crypto_drivers "$ENV{TFM_PSA_CRYPTO_DRIVERS_PATH}")
+if(NOT c1000_psa_crypto_drivers AND EXISTS /opt/tf-psa-crypto-drivers)
+  set(c1000_psa_crypto_drivers /opt/tf-psa-crypto-drivers)
+endif()
+if(c1000_psa_crypto_drivers)
+  if(NOT EXISTS "${c1000_psa_crypto_drivers}")
+    message(FATAL_ERROR
+      "Corstone-1000: TFM_PSA_CRYPTO_DRIVERS_PATH is set to "
+      "'${c1000_psa_crypto_drivers}' but that path does not exist.")
+  endif()
+  message(STATUS
+    "Corstone-1000: PSA crypto drivers: ${c1000_psa_crypto_drivers}")
+  list(APPEND tfm_cmake_args
+    -DPSA_CRYPTO_DRIVER_PATH=${c1000_psa_crypto_drivers})
+else()
+  message(STATUS "Corstone-1000: PSA crypto drivers: fetched by TF-M")
+endif()
+
 # Multi-core support: boot all 4 host CPUs (secondaries enter holding pen)
 if("${BOARD_QUALIFIERS}" MATCHES "/smp$")
   list(APPEND tfm_cmake_args -DENABLE_MULTICORE=TRUE)

--- a/boards/arm/fvp_corstone1000/sysbuild.cmake
+++ b/boards/arm/fvp_corstone1000/sysbuild.cmake
@@ -199,6 +199,9 @@ set(tfm_cmake_args
   # Cortex-A320 variant with DSU-120T PPU power management
   -DCORSTONE1000_CORTEX_A320=TRUE
   -DCORSTONE1000_DSU_120T=TRUE
+  # Verify boot images with MCUboot's default key model (public-key hash), not
+  # the builtin-key/key-id model (which would need an out-of-tree mcuboot patch).
+  -DMCUBOOT_BUILTIN_KEY=OFF
 )
 
 # Multi-core support: boot all 4 host CPUs (secondaries enter holding pen)

--- a/boards/arm/fvp_corstone1000/sysbuild.cmake
+++ b/boards/arm/fvp_corstone1000/sysbuild.cmake
@@ -417,14 +417,10 @@ endif()
 # =============================================================================
 # Sign TF-A BL2 with MCUboot-compatible format for TF-M verification
 # =============================================================================
-# TF-M Corstone1000 uses MCUBOOT_BUILTIN_KEY mode with EC-P256 signatures.
-# Key mapping with BUILTIN_KEY (ecdsa.h bootutil_ecdsa_init increments key_id):
-#   image_index -> key_id (in image_validate.c: key_id = image_index)
-#   bootutil_ecdsa_init: key_id++ (to avoid PSA_KEY_ID_NULL=0)
-#   So for Image 1: key_id = 1 + 1 = 2
-#   PSA looks for key_id=2 -> desc_table[1] (key_id=idx+1=2)
-#   desc_table[1] -> OTP KIND_1 (image_idx = key_id - 1 = 1)
-# Therefore Image 1 (TF-A BL2) uses KIND_1 key (root-EC-P256_1.pem).
+# TF-M Corstone1000 uses MCUboot's default key model (MCUBOOT_BUILTIN_KEY=OFF,
+# EC-P256): each image carries a public-key-hash TLV, and BL2 verifies it against
+# the ROTPK it was built with. Sign the TF-A BL2 (image 1) with the same root key
+# TF-M's BL2 embeds, root-EC-P256_1.pem.
 #
 # Parameters from TF-M Corstone1000 config:
 # - Header size: 0x1000 (4KB)
@@ -434,9 +430,9 @@ endif()
 
 set(imgtool ${ZEPHYR_MCUBOOT_MODULE_DIR}/scripts/imgtool.py)
 # The signing key ships as a static asset in the TF-M tree (bl2/ext/mcuboot/);
-# it is the pre-shared root EC key matched against the OTP KIND_1 slot when
-# verifying image 1 (TF-A BL2).  TF-M does not fetch any external mcuboot
-# submodule.
+# it is the root EC key whose public half TF-M's BL2 embeds as its ROTPK, so
+# BL2 verifies image 1 (TF-A BL2) against it.  TF-M does not fetch any external
+# mcuboot submodule.
 set(signing_key ${tfm_source_dir}/bl2/ext/mcuboot/root-EC-P256_1.pem)
 
 # TF-A BL2 slot size from flash_layout.h: SE_BL2_IMAGE_MAX_SIZE = 0x100000
@@ -463,6 +459,9 @@ add_custom_command(
     --slot-size ${tfa_slot_size}
     --load-addr ${tfa_load_addr}
     --boot-record NSPE
+    # Default key model: embed the public-key hash TLV; BL2 verifies it against
+    # the ROTPK it was built with (root-EC-P256_1.pem). No builtin key-id.
+    --public-key-format hash
     ${tfa_output_dir}/bl2.bin
     ${CORSTONE1000_FIRMWARE_DIR}/bl2_signed.bin
   DEPENDS tfa_host

--- a/boards/arm/fvp_corstone1000/sysbuild.cmake
+++ b/boards/arm/fvp_corstone1000/sysbuild.cmake
@@ -255,11 +255,28 @@ ExternalProject_Add(
 
 # Post-build: Create bl1.bin from TF-M outputs
 # bl1.bin = bl1_1.bin + bl1_provisioning_bundle.bin
-# Offset must match BL1_1_CODE_SIZE from region_defs.h (0xE800 = 59392)
+# The provisioning bundle lives at PROVISIONING_DATA_START, i.e. right after
+# BL1_1's code region (BL1_1_CODE_START is 0).  Derive the offset from
+# BL1_1_CODE_SIZE in region_defs.h rather than hardcoding it, so it stays
+# correct if TF-M changes the BL1_1 layout (it shrank from 0xE800 to 0xE748
+# between TF-M v2.2 and v2.3).
+set(c1000_region_defs
+  ${tfm_source_dir}/platform/ext/target/arm/corstone1000/partition/region_defs.h)
+file(STRINGS ${c1000_region_defs} c1000_bl1_1_code_size_line
+     REGEX "^[ \t]*#define[ \t]+BL1_1_CODE_SIZE[ \t]")
+string(REGEX MATCH "0x[0-9A-Fa-f]+" c1000_bl1_1_code_size "${c1000_bl1_1_code_size_line}")
+if(NOT c1000_bl1_1_code_size)
+  message(FATAL_ERROR
+    "Corstone-1000: could not parse BL1_1_CODE_SIZE from ${c1000_region_defs}")
+endif()
+math(EXPR c1000_prov_bundle_offset "${c1000_bl1_1_code_size}")
+message(STATUS "Corstone-1000: provisioning bundle offset in bl1.bin: "
+  "${c1000_prov_bundle_offset} (BL1_1_CODE_SIZE=${c1000_bl1_1_code_size})")
+
 add_custom_command(
   OUTPUT ${CORSTONE1000_FIRMWARE_DIR}/bl1.bin
   COMMAND ${CMAKE_COMMAND} -E copy ${tfm_binary_dir}/bin/bl1_1.bin ${CORSTONE1000_FIRMWARE_DIR}/bl1.bin
-  COMMAND dd conv=notrunc bs=1 if=${tfm_binary_dir}/bin/bl1_provisioning_bundle.bin of=${CORSTONE1000_FIRMWARE_DIR}/bl1.bin seek=59392 2>/dev/null
+  COMMAND dd conv=notrunc bs=1 if=${tfm_binary_dir}/bin/bl1_provisioning_bundle.bin of=${CORSTONE1000_FIRMWARE_DIR}/bl1.bin seek=${c1000_prov_bundle_offset} 2>/dev/null
   DEPENDS tfm_secure_enclave
   COMMENT "Creating Secure Enclave ROM image (bl1.bin)"
 )

--- a/boards/arm/fvp_corstone1000/sysbuild.cmake
+++ b/boards/arm/fvp_corstone1000/sysbuild.cmake
@@ -48,75 +48,32 @@ if(NOT SGDISK)
     "'dnf install gdisk') and re-run cmake.")
 endif()
 
-# Get west topdir for calculating module paths
-# This allows us to find modules even if module.yml is missing
-execute_process(
-  COMMAND west topdir
-  OUTPUT_VARIABLE west_topdir
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  RESULT_VARIABLE west_result
-)
+# Resolve the dependency module locations from the Zephyr module system.
+# These ZEPHYR_<MODULE>_MODULE_DIR variables are populated for every module
+# in the build, regardless of whether the workspace is maintained with west
+# or the modules are provided via ZEPHYR_MODULES/EXTRA_ZEPHYR_MODULES.  TF-M
+# and its crypto/CMSIS dependencies are passed as explicit paths below so the
+# TF-M build never falls back to fetching them from the network.
+foreach(dep
+    TRUSTED_FIRMWARE_M TRUSTED_FIRMWARE_A TF_PSA_CRYPTO CMSIS_6)
+  if(NOT DEFINED ZEPHYR_${dep}_MODULE_DIR)
+    string(TOLOWER "${dep}" dep_lower)
+    message(FATAL_ERROR
+      "Corstone-1000 requires the ${dep_lower} module, but "
+      "ZEPHYR_${dep}_MODULE_DIR is not set.  Ensure the module is part of "
+      "your manifest (west) or provided via ZEPHYR_MODULES / "
+      "EXTRA_ZEPHYR_MODULES.")
+  endif()
+endforeach()
 
-if(NOT west_result EQUAL 0)
-  # Fallback: assume standard west workspace layout
-  get_filename_component(west_topdir "${ZEPHYR_BASE}/.." ABSOLUTE)
-endif()
-
-# Get module paths
-# Try module variables first, fall back to west workspace layout
-if(DEFINED ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR AND EXISTS "${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR}")
-  set(tfm_source_dir ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR})
-else()
-  set(tfm_source_dir ${west_topdir}/modules/tee/tf-m/trusted-firmware-m)
-endif()
-
-if(DEFINED ZEPHYR_TRUSTED_FIRMWARE_A_MODULE_DIR AND EXISTS "${ZEPHYR_TRUSTED_FIRMWARE_A_MODULE_DIR}")
-  set(tfa_source_dir ${ZEPHYR_TRUSTED_FIRMWARE_A_MODULE_DIR})
-else()
-  set(tfa_source_dir ${west_topdir}/modules/tee/tf-a/trusted-firmware-a)
-endif()
-
-# mbedtls module path (used as MBEDCRYPTO_PATH for TF-M)
-# TF-M requires mbedtls-3.6 because mbedtls 4.x split the crypto code into a
-# separate tf-psa-crypto module that TF-M does not support yet.
-# See west.yml: "Required for TF-M build until we bump it to v2.3"
-if(DEFINED ZEPHYR_MBEDTLS_3_6_MODULE_DIR AND EXISTS "${ZEPHYR_MBEDTLS_3_6_MODULE_DIR}")
-  set(mbedtls_module_dir ${ZEPHYR_MBEDTLS_3_6_MODULE_DIR})
-else()
-  set(mbedtls_module_dir ${west_topdir}/modules/crypto/mbedtls-3.6)
-endif()
-
-# CMSIS_6 module path
-if(DEFINED ZEPHYR_CMSIS_6_MODULE_DIR AND EXISTS "${ZEPHYR_CMSIS_6_MODULE_DIR}")
-  set(cmsis_6_module_dir ${ZEPHYR_CMSIS_6_MODULE_DIR})
-else()
-  set(cmsis_6_module_dir ${west_topdir}/modules/hal/cmsis_6)
-endif()
-
-# Verify the source directories exist
-if(NOT EXISTS "${tfm_source_dir}")
-  message(FATAL_ERROR "TF-M source directory not found: ${tfm_source_dir}\n"
-    "Run 'west update' to fetch the module.")
-endif()
-
-if(NOT EXISTS "${tfa_source_dir}")
-  message(FATAL_ERROR "TF-A source directory not found: ${tfa_source_dir}\n"
-    "Run 'west update' to fetch the module.")
-endif()
-
-if(NOT EXISTS "${mbedtls_module_dir}")
-  message(FATAL_ERROR "mbedtls module directory not found: ${mbedtls_module_dir}\n"
-    "Run 'west update' to fetch the module.")
-endif()
-
-if(NOT EXISTS "${cmsis_6_module_dir}")
-  message(FATAL_ERROR "CMSIS_6 module directory not found: ${cmsis_6_module_dir}\n"
-    "Run 'west update' to fetch the module.")
-endif()
+set(tfm_source_dir ${ZEPHYR_TRUSTED_FIRMWARE_M_MODULE_DIR})
+set(tfa_source_dir ${ZEPHYR_TRUSTED_FIRMWARE_A_MODULE_DIR})
+set(tf_psa_crypto_dir ${ZEPHYR_TF_PSA_CRYPTO_MODULE_DIR})
+set(cmsis_6_module_dir ${ZEPHYR_CMSIS_6_MODULE_DIR})
 
 message(STATUS "Corstone-1000: TF-M source: ${tfm_source_dir}")
 message(STATUS "Corstone-1000: TF-A source: ${tfa_source_dir}")
-message(STATUS "Corstone-1000: mbedtls: ${mbedtls_module_dir}")
+message(STATUS "Corstone-1000: TF-PSA-Crypto: ${tf_psa_crypto_dir}")
 message(STATUS "Corstone-1000: CMSIS_6: ${cmsis_6_module_dir}")
 
 # Output directories
@@ -157,9 +114,10 @@ else()
 endif()
 
 # TF-M CMake arguments
-# Note: We must provide MBEDCRYPTO_PATH and CMSIS_PATH because TF-M's CMakeLists.txt
-# processes bl2/ before lib/ext/mbedcrypto/, so the default "DOWNLOAD" value doesn't
-# work on initial configure. Providing paths from Zephyr modules avoids the fetch.
+# Provide TF_PSA_CRYPTO_PATH and CMSIS_PATH from the in-tree Zephyr modules.
+# These default to "DOWNLOAD" in TF-M, which would clone the dependencies from
+# the network; pointing them at the modules already present in the workspace
+# keeps the build self-contained (Zephyr does not allow build-time fetches).
 # Map Kconfig log level to the three different TF-M log level systems:
 # - TF-M BL1: LOG_LEVEL_{NONE,ERROR,WARNING,INFO,DEBUG}
 # - MCUboot:  {OFF,ERROR,WARNING,INFO,DEBUG}
@@ -198,7 +156,7 @@ set(tfm_cmake_args
   -DBL1=ON
   -DBL2=ON
   -DMCUBOOT_PATH=${ZEPHYR_MCUBOOT_MODULE_DIR}
-  -DMBEDCRYPTO_PATH=${mbedtls_module_dir}
+  -DTF_PSA_CRYPTO_PATH=${tf_psa_crypto_dir}
   -DCMSIS_PATH=${cmsis_6_module_dir}
   -DTFM_BL1_LOG_LEVEL=${tfm_log_level_str}
   -DMCUBOOT_LOG_LEVEL=${mcuboot_log_level_str}
@@ -228,6 +186,7 @@ set(tfm_toolchain_wrapper ${CMAKE_CURRENT_BINARY_DIR}/toolchain_corstone1000.cma
 file(WRITE ${tfm_toolchain_wrapper}
   "include(${tfm_toolchain_file})\n"
   "string(APPEND CMAKE_C_FLAGS \" -Wno-int-conversion -Wno-implicit-function-declaration -Wno-incompatible-pointer-types\")\n"
+  "string(APPEND CMAKE_C_FLAGS \" -isystem ${tf_psa_crypto_dir}/drivers/builtin/include\")\n"
 )
 list(REMOVE_ITEM tfm_cmake_args "-DTFM_TOOLCHAIN_FILE=${tfm_toolchain_file}")
 list(APPEND tfm_cmake_args "-DTFM_TOOLCHAIN_FILE=${tfm_toolchain_wrapper}")

--- a/boards/arm/fvp_corstone1000/sysbuild.cmake
+++ b/boards/arm/fvp_corstone1000/sysbuild.cmake
@@ -76,6 +76,36 @@ message(STATUS "Corstone-1000: TF-A source: ${tfa_source_dir}")
 message(STATUS "Corstone-1000: TF-PSA-Crypto: ${tf_psa_crypto_dir}")
 message(STATUS "Corstone-1000: CMSIS_6: ${cmsis_6_module_dir}")
 
+# TF-M's build invokes its Python tools both as console scripts (by bare name)
+# and as plain scripts importing its packages, which normally requires TF-M's
+# Python package to be installed.  Nothing is installed here: the helper below
+# provides both from the build directory, driven by TF-M's own pyproject.toml so
+# it does not drift.  See boards/arm/fvp_corstone1000/tfm_python_env.py.
+find_package(Python3 COMPONENTS Interpreter QUIET)
+if(NOT Python3_EXECUTABLE)
+  set(Python3_EXECUTABLE python3)
+endif()
+
+set(tfm_pythonpath ${CMAKE_CURRENT_BINARY_DIR}/tfm-pythonpath)
+set(tfm_scripts_dir ${CMAKE_CURRENT_BINARY_DIR}/tfm-scripts)
+set(tfm_python_wrapper ${tfm_scripts_dir}/python3-tfm)
+
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/tfm_python_env.py
+    --tfm-dir ${tfm_source_dir}
+    --pythonpath-dir ${tfm_pythonpath}
+    --scripts-dir ${tfm_scripts_dir}
+    --python ${Python3_EXECUTABLE}
+  RESULT_VARIABLE tfm_pyenv_rc
+  OUTPUT_VARIABLE tfm_pyenv_out
+  ERROR_VARIABLE tfm_pyenv_err
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(NOT tfm_pyenv_rc EQUAL 0)
+  message(FATAL_ERROR
+    "Corstone-1000: could not provide TF-M's Python tools: ${tfm_pyenv_err}")
+endif()
+message(STATUS "Corstone-1000: ${tfm_pyenv_out}")
+
 # Output directories
 set(tfm_binary_dir ${CMAKE_BINARY_DIR}/tfm)
 set(tfa_binary_dir ${CMAKE_BINARY_DIR}/tfa)
@@ -191,12 +221,30 @@ file(WRITE ${tfm_toolchain_wrapper}
 list(REMOVE_ITEM tfm_cmake_args "-DTFM_TOOLCHAIN_FILE=${tfm_toolchain_file}")
 list(APPEND tfm_cmake_args "-DTFM_TOOLCHAIN_FILE=${tfm_toolchain_wrapper}")
 
+# Use the interpreter wrapper generated above so TF-M's python helpers can
+# import tfm_tools without the package being installed.
+list(APPEND tfm_cmake_args -DPython3_EXECUTABLE=${tfm_python_wrapper})
+
+# Run the TF-M build with the console scripts on PATH and the package mapping on
+# PYTHONPATH, so its image generation works without anything being installed
+# system-wide.  PYTHONPATH is needed for the whole build, not just the two
+# scripts above: TF-M also runs plain python scripts that import tfm_tools.
+if(DEFINED ENV{PYTHONPATH})
+  set(tfm_pythonpath_env "${tfm_pythonpath}:$ENV{PYTHONPATH}")
+else()
+  set(tfm_pythonpath_env "${tfm_pythonpath}")
+endif()
+set(tfm_env ${CMAKE_COMMAND} -E env
+  "PATH=${tfm_scripts_dir}:$ENV{PATH}"
+  "PYTHONPATH=${tfm_pythonpath_env}")
+
 ExternalProject_Add(
   tfm_secure_enclave
   SOURCE_DIR ${tfm_source_dir}
   BINARY_DIR ${tfm_binary_dir}
-  CMAKE_ARGS ${tfm_cmake_args}
-  BUILD_COMMAND ${CMAKE_COMMAND} --build . -- install
+  CONFIGURE_COMMAND ${tfm_env} ${CMAKE_COMMAND} -G ${CMAKE_GENERATOR}
+    -S ${tfm_source_dir} -B ${tfm_binary_dir} ${tfm_cmake_args}
+  BUILD_COMMAND ${tfm_env} ${CMAKE_COMMAND} --build . -- install
   INSTALL_COMMAND ""
   BUILD_ALWAYS True
   USES_TERMINAL_BUILD True

--- a/boards/arm/fvp_corstone1000/tfm_python_env.py
+++ b/boards/arm/fvp_corstone1000/tfm_python_env.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 BayLibre SAS
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provide TF-M's Python tools to a TF-M build without installing them.
+
+TF-M's build invokes its Python helpers in two ways: as console scripts by bare
+name (mcuboot_imagesign_wrapper, hex_generation, ...) and as plain scripts that
+import its packages (tfm_tools, bl1, bl2, ...).  Both normally require TF-M's
+Python package to be installed, which a Zephyr board build must not do.
+
+Both are satisfied here from the build directory instead, driven by TF-M's own
+pyproject.toml so this does not drift when TF-M changes:
+
+  - the packages are made importable through a directory of links, needed
+    because [tool.setuptools.package-dir] maps package names onto directories
+    with different names (tfm_tools -> tools/modules);
+  - every entry in [project.scripts] gets a small wrapper that sets PYTHONPATH
+    to that directory and calls the entry point.
+
+The tools' own runtime dependencies (imgtool, click, cbor2) still come from the
+environment, exactly as they do for any other board that builds TF-M.
+"""
+
+import argparse
+import os
+import stat
+import sys
+import tomllib
+
+WRAPPER = """#!/bin/sh
+# Generated for the Corstone-1000 TF-M build: do not edit.
+PYTHONPATH="{pythonpath}${{PYTHONPATH:+:$PYTHONPATH}}" \\
+  exec "{python}" {args} "$@"
+"""
+
+
+def write_script(path, text):
+    with open(path, "w") as f:
+        f.write(text)
+    os.chmod(path, os.stat(path).st_mode | stat.S_IXUSR | stat.S_IXGRP |
+             stat.S_IXOTH)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--tfm-dir", required=True)
+    p.add_argument("--pythonpath-dir", required=True)
+    p.add_argument("--scripts-dir", required=True)
+    p.add_argument("--python", required=True)
+    args = p.parse_args()
+
+    pyproject = os.path.join(args.tfm_dir, "pyproject.toml")
+    if not os.path.exists(pyproject):
+        sys.exit(f"{pyproject} not found; cannot determine TF-M's Python tools")
+    with open(pyproject, "rb") as f:
+        cfg = tomllib.load(f)
+
+    package_dir = cfg["tool"]["setuptools"]["package-dir"]
+    scripts = cfg["project"]["scripts"]
+
+    os.makedirs(args.pythonpath_dir, exist_ok=True)
+    os.makedirs(args.scripts_dir, exist_ok=True)
+
+    for package, subdir in package_dir.items():
+        target = os.path.join(args.tfm_dir, subdir)
+        if not os.path.isdir(target):
+            sys.exit(f"TF-M package directory '{subdir}' is missing")
+        link = os.path.join(args.pythonpath_dir, package)
+        if os.path.islink(link) or os.path.exists(link):
+            os.remove(link)
+        os.symlink(target, link)
+
+    for script, entry in scripts.items():
+        module, _, func = entry.partition(":")
+        code = (f"import sys; from {module} import {func}; "
+                f"sys.exit({func}())")
+        write_script(
+            os.path.join(args.scripts_dir, script),
+            WRAPPER.format(pythonpath=args.pythonpath_dir,
+                           python=args.python,
+                           args=f"-c '{code}'"))
+
+    # Interpreter wrapper.  TF-M's own rules run some helpers as
+    #   cmake -E env PYTHONPATH=<tfm>/tools/modules python3 <script>
+    # which points PYTHONPATH inside the tfm_tools package rather than at its
+    # parent, so their "import tfm_tools.foo" only resolves from an installed
+    # copy.  Prepending our directory to whatever PYTHONPATH TF-M sets fixes
+    # those imports too.
+    write_script(
+        os.path.join(args.scripts_dir, "python3-tfm"),
+        WRAPPER.format(pythonpath=args.pythonpath_dir,
+                       python=args.python, args=""))
+
+    print(f"TF-M Python tools: {len(scripts)} entry points, "
+          f"{len(package_dir)} packages, no installation")
+
+
+if __name__ == "__main__":
+    main()

--- a/west.yml
+++ b/west.yml
@@ -399,7 +399,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: f2f7a8edd109825de35b0c239c8fbb77b06f24a2
+      revision: pull/215/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION

## Goal

`fvp_corstone1000/a320` was merged in #104035 and disabled one day later by
c2fabf140d0d ("boards: fvp_corstone1000: disable platform for now") because it
no longer built against the manifest. This series fixes the build and re-enables
the platform.

The board was developed against a workspace that had drifted from the manifest:
TF-M was pinned at v2.2.2 and a `modules/crypto/mbedtls-3.6` checkout was
present that the manifest never carried. Main has TF-M v2.3.0, and `mbedtls-3.6`
was removed when TF-M v2.3 moved to Mbed TLS 4.x / tf-psa-crypto. So the board
built for its author and for nobody else, which is exactly what CI reported.

## What was broken

Corstone-1000 is the only Zephyr board that builds TF-M's native BL1 and BL2 and
a standalone secure image, so it is the only one that reaches these paths:

1. **Deleted module.** `sysbuild.cmake` referenced `mbedtls-3.6` by workspace
   path. It now resolves every dependency through the module system
   (`ZEPHYR_<MODULE>_MODULE_DIR`) and passes `TF_PSA_CRYPTO_PATH` and
   `CMSIS_PATH` explicitly, so nothing is fetched at build time and no `west`
   layout is assumed.

2. **TF-M did not support the Zephyr SDK toolchain.** The SDK's
   `arm-zephyr-eabi` uses picolibc. TF-M's GNU path was wired for newlib, and
   its picolibc paths were only reachable with Arm Clang / ATfE, so the BL1, BL2
   and secure image linker scripts did not emit the crt0 and heap symbols
   picolibc's startup needs, `uart_stdout.c` gated its picolibc stdio hook on
   `__clang_major__`, and there was no `_exit`. Separately, Zephyr's `cmsis_6`
   defines `__PROGRAM_START` as picolibc's `_start` for a picolibc build, which
   bypasses `__cmsis_start()`; upstream relies on that function both to
   initialise `.data`/`.bss` and to walk the CMSIS scatter copy/zero tables.
   Without the walk, each secure partition's RW data (its own section, LMA
   different from VMA at isolation level 2) stays uninitialised, the Internal
   Trusted Storage driver pointer is NULL and the secure enclave faults into a
   reboot loop.

   These fixes live in the TF-M module, not here. See the dependency below.

3. **Two smaller version assumptions.** The provisioning bundle offset in
   `bl1.bin` was hardcoded to `0xE800`, which is `BL1_1_CODE_SIZE` in TF-M v2.2
   but `0xE748` in v2.3, so provisioning failed at runtime. It is now derived
   from `region_defs.h`. And the platform defaulted to MCUboot's builtin-key
   model, which needs a TF-M-authored mcuboot patch that mcuboot upstream
   declined on design grounds (mcu-tools/mcuboot#2305), so the board now selects
   MCUboot's default key model instead. Secure boot is unchanged in substance:
   BL1 still verifies BL2 through OTP, and BL2 verifies the secure image and
   TF-A BL2 against the ROTPK it embeds.

## Dependency

The picolibc work is in the TF-M module and must land first:
zephyrproject-rtos/trusted-firmware-m#215.

`west.yml` currently points at `pull/215/head` so this can be built and tested
in CI. It has to be replaced with the merge commit SHA on `zephyr_tf-m_v2.3.0`
before this is merged, and I will push that update once #215 lands.
