### PR TITLE
net: tcp: Validate th_off for established connections in tcp_in()

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2985,6 +2985,11 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt)
 		return NET_DROP;
 	}
 
+	if (th_off(th) < 5) {
+		NET_DBG("[%p] DROP: invalid th_off %u", conn, (unsigned int)th_off(th));
+		return NET_DROP;
+	}
+
 	tcp_options_len = (th_off(th) - 5) * 4;
 
 	/* Currently we ignore ECN and CWR flags */


### PR DESCRIPTION
tcp_recv() checks that the TCP data offset is at least 5 only when no matching connection is found. If tcp_conn_search() succeeds, processing jumps directly to tcp_in() and skips this validation.