### PR TITLE
logging: frontend_stmesp: Fix keeping logging strings

### DIFF
--- a/include/zephyr/logging/log_frontend_stmesp.h
+++ b/include/zephyr/logging/log_frontend_stmesp.h
@@ -126,9 +126,11 @@ TYPE_SECTION_START_EXTERN(const char *, log_stmesp_ptr);
 #define LOG_FRONTEND_STMESP_LOG0(_source, ...)                                                     \
 	do {                                                                                       \
 		static const char _str[] __in_section(_log_stmesp_str, static, __COUNTER__)        \
-			__used __noasan __aligned(sizeof(uint32_t)) = GET_ARG_N(1, __VA_ARGS__);   \
+			IF_ENABLED(CONFIG_LOG_FRONTEND_STMESP_DICT, (__used))                      \
+			__noasan __aligned(sizeof(uint32_t)) = GET_ARG_N(1, __VA_ARGS__);          \
 		static const char *str_ptr __in_section(_log_stmesp_ptr, static, __COUNTER__)      \
-			__used __noasan = _str;                                                    \
+			IF_ENABLED(CONFIG_LOG_FRONTEND_STMESP_DICT, (__used))                      \
+			__noasan = _str;                                                           \
 		uint32_t _idx =                                                                    \
 			((uintptr_t)&str_ptr - (uintptr_t)TYPE_SECTION_START(log_stmesp_ptr)) /    \
 			sizeof(void *);                                                            \
@@ -143,9 +145,11 @@ TYPE_SECTION_START_EXTERN(const char *, log_stmesp_ptr);
 #define LOG_FRONTEND_STMESP_LOG1(_source, ...)                                                     \
 	do {                                                                                       \
 		static const char _str[] __in_section(_log_stmesp_str, static, __COUNTER__)        \
-			__used __noasan __aligned(sizeof(uint32_t)) = GET_ARG_N(1, __VA_ARGS__);   \
+			IF_ENABLED(CONFIG_LOG_FRONTEND_STMESP_DICT, (__used))                      \
+			__noasan __aligned(sizeof(uint32_t)) = GET_ARG_N(1, __VA_ARGS__);          \
 		static const char *str_ptr __in_section(_log_stmesp_ptr, static, __COUNTER__)      \
-			__used __noasan = _str;                                                    \
+			IF_ENABLED(CONFIG_LOG_FRONTEND_STMESP_DICT, (__used))                      \
+			__noasan = _str;                                                           \
 		uint32_t _idx =                                                                    \
 			((uintptr_t)&str_ptr - (uintptr_t)TYPE_SECTION_START(log_stmesp_ptr)) /    \
 			sizeof(void *);                                                            \


### PR DESCRIPTION
Even when module had disabled logs it was kept in the binary increasing the memory footprint. Removing __used keyword unless dictionary logging is used where string section anyway lands in elf but not in the binary.