### PR TITLE
tests: drivers: uart: uart_async_api: modify kit_psc3m5_evk.overlay

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/kit_psc3m5_evk.overlay
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,7 +14,7 @@ dut: &scb4 {
 	status = "okay";
 	current-speed = <115200>;
 
-	clocks = <&peri0_group4_8bit_1>;
+	clocks = <&peri0_group4_16bit_0>;
 
 	pinctrl-0 = <&p4_3_scb4_uart_tx &p4_2_scb4_uart_rx>;
 	pinctrl-names = "default";
@@ -31,7 +31,7 @@ dut: &scb4 {
 	input-enable;
 };
 
-&peri0_group4_8bit_1 {
+&peri0_group4_16bit_0 {
 	status = "okay";
-	clock-div = <109>;
+	clock-div = <103>;
 };


### PR DESCRIPTION
The test_read_abort case drops the baud rate to 9600. At a 96 MHz HF clock, this requires a clock divider of ~1250, which exceeds the 8-bit divider limit (max 255). Switch to peri0_group4_16bit_0 (16-bit) to support the full baud rate sweep required by the test.

Also adjust default clock-div to 103 (divider 104) to achieve 115200 baud with ~0.16% error, correcting the previous 109 value (~5.3% error).