### PR TITLE
drivers: sensor: bmp581: fix SPI protocol handling

### DIFF
--- a/drivers/sensor/bosch/bmp581/bmp581.c
+++ b/drivers/sensor/bosch/bmp581/bmp581.c
@@ -385,19 +385,34 @@ static int set_odr_config(const struct sensor_value *odr, const struct device *d
 
 static int soft_reset(const struct device *dev)
 {
+	CHECKIF(dev == NULL) {
+		return -EINVAL;
+	}
+
 	struct bmp581_config *conf = (struct bmp581_config *)dev->config;
 	int ret = 0;
 	const uint8_t reset_cmd = BMP5_SOFT_RESET_CMD;
 	uint8_t int_status = 0;
 
-	CHECKIF(dev == NULL) {
-		return -EINVAL;
-	}
-
 	ret = bmp581_reg_write_rtio(&conf->bus, BMP5_REG_CMD, &reset_cmd, 1);
 
 	if (ret == BMP5_OK) {
 		k_usleep(BMP5_DELAY_US_SOFT_RESET);
+
+		/*
+		 * Soft-reset returns the device to its power-up I2C/I3C mode.
+		 * Re-issue the SPI dummy read to switch the interface back to
+		 * SPI before reading the reset status.
+		 */
+		if (conf->bus.rtio.type == BMP581_BUS_TYPE_SPI) {
+			uint8_t dummy = 0;
+
+			ret = bmp581_reg_read_rtio(&conf->bus, BMP5_REG_CHIP_ID, &dummy, 1);
+			if (ret != BMP5_OK) {
+				return ret;
+			}
+		}
+
 		ret = get_interrupt_status(&int_status, dev);
 		if (ret == BMP5_OK) {
 			if ((int_status & BMP5_INT_ASSERTED_POR_SOFTRESET_COMPLETE) != 0) {
@@ -597,17 +612,6 @@ static int bmp581_init(const struct device *dev)
 	if (ret != BMP5_OK) {
 		LOG_ERR("Failed to perform soft-reset: %d", ret);
 		return ret;
-	}
-
-	/*
-	 * Soft-reset returns the device to its power-up I2C/I3C mode. Re-issue the
-	 * SPI dummy read to switch the interface back to SPI before subsequent
-	 * register accesses.
-	 */
-	if (conf->bus.rtio.type == BMP581_BUS_TYPE_SPI) {
-		uint8_t dummy = 0;
-
-		(void)bmp581_reg_read_rtio(&conf->bus, BMP5_REG_CHIP_ID, &dummy, 1);
 	}
 
 	ret = bmp581_reg_read_rtio(&conf->bus, BMP5_REG_CHIP_ID, &drv->chip_id, 1);

--- a/drivers/sensor/bosch/bmp581/bmp581_bus.c
+++ b/drivers/sensor/bosch/bmp581/bmp581_bus.c
@@ -52,6 +52,48 @@ int bmp581_prep_reg_write_rtio_async(const struct bmp581_bus *bus,
 {
 	struct rtio *ctx = bus->rtio.ctx;
 	struct rtio_iodev *iodev = bus->rtio.iodev;
+
+	/** More than 7 won't work with tiny-write */
+	if (size > 7) {
+		return -EINVAL;
+	}
+
+	if (bus->rtio.type == BMP581_BUS_TYPE_SPI) {
+		struct rtio_sqe *last_sqe = NULL;
+
+		/*
+		 * BMP581 SPI burst writes consist of address/data pairs:
+		 *
+		 *   address[0], data[0], address[1], data[1], ...
+		 *
+		 * Chain all pairs into one transaction to keep CSB asserted.
+		 */
+		for (size_t i = 0; i < size; i++) {
+			uint8_t frame[] = {
+				(reg + i) & ~BMP5_SPI_RD_MASK,
+				buf[i],
+			};
+
+			last_sqe = rtio_sqe_acquire(ctx);
+			if (!last_sqe) {
+				rtio_sqe_drop_all(ctx);
+				return -ENOMEM;
+			}
+
+			rtio_sqe_prep_tiny_write(last_sqe, iodev, RTIO_PRIO_NORM, frame,
+						 sizeof(frame), NULL);
+			if (i + 1 < size) {
+				last_sqe->flags |= RTIO_SQE_TRANSACTION;
+			}
+		}
+
+		if (out) {
+			*out = last_sqe;
+		}
+
+		return size;
+	}
+
 	struct rtio_sqe *write_reg_sqe = rtio_sqe_acquire(ctx);
 	struct rtio_sqe *write_buf_sqe = rtio_sqe_acquire(ctx);
 
@@ -60,12 +102,6 @@ int bmp581_prep_reg_write_rtio_async(const struct bmp581_bus *bus,
 		return -ENOMEM;
 	}
 
-	/** More than 7 won't work with tiny-write */
-	if (size > 7) {
-		return -EINVAL;
-	}
-
-	/* SPI writes use the register address with bit 7 cleared (default) */
 	rtio_sqe_prep_tiny_write(write_reg_sqe, iodev, RTIO_PRIO_NORM, &reg, 1, NULL);
 	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
 	rtio_sqe_prep_tiny_write(write_buf_sqe, iodev, RTIO_PRIO_NORM, buf, size, NULL);
@@ -74,7 +110,6 @@ int bmp581_prep_reg_write_rtio_async(const struct bmp581_bus *bus,
 	} else if (bus->rtio.type == BMP581_BUS_TYPE_I3C) {
 		write_buf_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP;
 	}
-	/* SPI does not require setting additional flags to the write-buf SQE */
 
 	/** Send back last SQE so it can be concatenated later. */
 	if (out) {

--- a/drivers/sensor/bosch/bmp581/bmp581_emul.c
+++ b/drivers/sensor/bosch/bmp581/bmp581_emul.c
@@ -146,7 +146,7 @@ static int bmp581_emul_io_spi(const struct emul *target, const struct spi_config
 			      const struct spi_buf_set *tx_bufs, const struct spi_buf_set *rx_bufs)
 {
 	struct bmp581_emul_data *data = target->data;
-	const struct spi_buf *tx, *txd, *rxd;
+	const struct spi_buf *tx;
 	uint8_t regn;
 	int count;
 
@@ -155,28 +155,34 @@ static int bmp581_emul_io_spi(const struct emul *target, const struct spi_config
 	__ASSERT_NO_MSG(!tx_bufs || !rx_bufs || tx_bufs->count == rx_bufs->count);
 
 	count = tx_bufs ? tx_bufs->count : rx_bufs->count;
-	if (count != 2) {
-		LOG_ERR("Unexpected SPI buffer count %d", count);
+	if (count < 1) {
+		LOG_ERR("Invalid SPI buffer count %d", count);
 		return -EIO;
 	}
 
-	/* buffers[0] carries the 1-byte register address, buffers[1] the data. */
 	tx = tx_bufs ? tx_bufs->buffers : NULL;
-	txd = tx_bufs ? &tx_bufs->buffers[1] : NULL;
-	rxd = rx_bufs ? &rx_bufs->buffers[1] : NULL;
 
-	if (tx == NULL || tx->len != 1) {
-		LOG_ERR("Expected a 1-byte register address");
+	if (tx == NULL || tx->buf == NULL || tx->len < 1) {
+		LOG_ERR("Missing SPI register address");
 		return -EIO;
 	}
 
 	regn = *(uint8_t *)tx->buf;
 
 	if (regn & BMP5_SPI_RD_MASK) {
+		const struct spi_buf *rxd;
+
 		/* Read transaction. */
-		if (rxd == NULL) {
+		if (count != 2 || tx->len != 1 || rx_bufs == NULL) {
+			LOG_ERR("Invalid SPI read transaction");
+			return -EIO;
+		}
+
+		rxd = &rx_bufs->buffers[1];
+		if (rxd->buf == NULL) {
 			return -EPERM;
 		}
+
 		regn &= ~BMP5_SPI_RD_MASK;
 		for (uint32_t i = 0; i < rxd->len; i++) {
 			uint8_t a = regn + i;
@@ -184,17 +190,45 @@ static int bmp581_emul_io_spi(const struct emul *target, const struct spi_config
 			((uint8_t *)rxd->buf)[i] = (a < BMP581_EMUL_NUM_REGS) ? data->reg[a] : 0;
 		}
 	} else {
-		/* Write transaction. */
-		if (txd == NULL) {
-			return -EIO;
-		}
-		for (uint32_t i = 0; i < txd->len; i++) {
-			int ret = bmp581_emul_handle_write(target, regn + i,
-							   ((uint8_t *)txd->buf)[i]);
+		bool expect_addr = true;
 
-			if (ret < 0) {
-				return ret;
+		/*
+		 * SPI writes consist of an address/data pair for each register.
+		 * Parse the wire byte stream independently of spi_buf boundaries.
+		 */
+		for (int m = 0; m < count; m++) {
+			const struct spi_buf *msg = &tx_bufs->buffers[m];
+			const uint8_t *buf = msg->buf;
+
+			if (buf == NULL) {
+				LOG_ERR("Missing SPI write data");
+				return -EIO;
 			}
+
+			for (size_t i = 0; i < msg->len; i++) {
+				if (expect_addr) {
+					if (buf[i] & BMP5_SPI_RD_MASK) {
+						LOG_ERR("Invalid SPI write address");
+						return -EIO;
+					}
+
+					regn = buf[i];
+					expect_addr = false;
+				} else {
+					int ret = bmp581_emul_handle_write(target, regn, buf[i]);
+
+					if (ret < 0) {
+						return ret;
+					}
+
+					expect_addr = true;
+				}
+			}
+		}
+
+		if (!expect_addr) {
+			LOG_ERR("SPI write address without data");
+			return -EIO;
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fix two BMP581 SPI protocol handling issues that prevent reliable initialization and measurement:

1. SPI mode must be reselected after a soft reset before reading the reset-complete status.
2. SPI multi-byte writes require an address/data pair for every byte.

The I2C and I3C paths remain unchanged.

## Post-reset SPI activation

After a soft reset, the BMP581 returns to its power-up I2C/I3C mode. The first SPI transaction selects SPI mode, but its returned data is invalid and must be discarded.

`soft_reset()` previously read `INT_STATUS` as the first post-reset SPI transaction. The status read was therefore consumed as the SPI activation transaction, causing initialization to fail with `-EFAULT`.

Observed log:

```
Booting Zephyr OS build v4.4.0-9703-gc25aaee66eae ***
[00:00:00.051,000] <err> bmp581: Failed to perform soft-reset: -14
uart:~$ sensor get bmp581@0
Sensor device unknown (bmp581@0)
```

Move the post-reset dummy SPI read into `soft_reset()`, after the reset delay and before reading `INT_STATUS`.

## SPI multi-byte writes

The BMP581 SPI write protocol requires every data byte to be preceded by its register address while CSB remains asserted.

The previous implementation sent:

```
address, data[0], data[1], ...
```

The sensor expects:

```
address[0], data[0], address[1], data[1], ...
```

Consequently, the second payload byte was interpreted as another register address rather than data.

During initialization, `set_osr_odr_press_config()` writes `OSR_CONFIG` and `ODR_CONFIG` together. Over SPI, `ODR_CONFIG` was not programmed, so the sensor did not enter the configured measurement mode and its data
registers remained at their `0x7f` reset values.

This resulted in continuously reporting:

```
temp 127.50 Cel, pressure 130.557000 kPa
```

Build one two-byte RTIO SQE for each register-address/data pair and chain the SQEs as a single transaction so CSB remains asserted for the complete write.

## Testing

- [x] Built `samples/sensor/sensor_shell` for a custom STM32F407IGH6
- [x] Built `samples/sensor/pressure_polling` for a custom STM32F407IGH6
- [x] Verified on a custom STM32F407IGH6 board that the BMP581 completes initialization after soft reset
- [x] Verified on hardware that pressure and temperature no longer remain at the register reset values

## Additional context

SPI support was introduced by #109240.

The emulator added by #111193 does not currently reproduce these failures:

- It does not model the interface returning to I2C/I3C mode after soft reset.
- Its SPI write path models register auto-increment rather than requiring explicit address/data pairs.

This is distinct from #103361, which reports reset-complete/POR status behavior after resetting the host processor.

PR #111698 also modifies `soft_reset()` for unrelated I2C bring-up changes, so this PR may need to be rebased if it lands first.

Link: https://github.com/zephyrproject-rtos/zephyr/pull/109240
Link: https://github.com/zephyrproject-rtos/zephyr/pull/111193
Link: https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp581-ds004.pdf

Assisted-by: Codex:GPT-5.6 Sol