### PR TITLE
rtio: fix mempool block count macro expansion

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -288,8 +288,8 @@ extern struct k_mem_partition rtio_partition;
 /* @cond ignore */
 #define Z_RTIO_BLOCK_POOL_DEFINE(name, blk_sz, blk_cnt, blk_align)                                 \
 	RTIO_BMEM uint8_t __aligned(WB_UP(blk_align))                                              \
-	CONCAT(_block_pool_, name)[blk_cnt*WB_UP(blk_sz)];                                         \
-	_SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF(name, WB_UP(blk_sz), blk_cnt,                          \
+	CONCAT(_block_pool_, name)[(blk_cnt) * WB_UP(blk_sz)];                                     \
+	_SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF(name, WB_UP(blk_sz), (blk_cnt),                        \
 					    CONCAT(_block_pool_, name),	RTIO_DMEM)
 
 /* @endcond */

--- a/include/zephyr/sys/mem_blocks.h
+++ b/include/zephyr/sys/mem_blocks.h
@@ -152,7 +152,7 @@ struct sys_multi_mem_blocks {
 	BUILD_ASSERT(IS_POWER_OF_TWO(balign), "balign must be a power of 2"); \
 	mbmod uint8_t __noinit_named(sys_mem_blocks_buf_##name)		\
 		__aligned(WB_UP(balign))				\
-		_sys_mem_blocks_buf_##name[num_blks * WB_UP(blk_sz)];	\
+		_sys_mem_blocks_buf_##name[(num_blks) * WB_UP(blk_sz)];	\
 	_SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF(name, blk_sz, num_blks,	\
 					   _sys_mem_blocks_buf_##name,	\
 					   mbmod);


### PR DESCRIPTION
`Z_RTIO_BLOCK_POOL_DEFINE` sized the backing array with `blk_cnt*WB_UP(blk_sz)`, so a block count passed as an unparenthesized expression such as `N + 2` bound as `N + 2*WB_UP(blk_sz)`. This under-sized the array while the pool still handed out the full block count, letting reads into high blocks corrupt adjacent memory.

Parenthesize the count in both the array size and the backing `sys_mem_blocks` definition.