### PR TITLE
drivers/smbus: it51xxx: Add SMBus driver support for it51xxx series

### DIFF
--- a/drivers/smbus/CMakeLists.txt
+++ b/drivers/smbus/CMakeLists.txt
@@ -10,5 +10,6 @@ zephyr_library_sources_ifdef(CONFIG_USERSPACE smbus_handlers.c)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_SMBUS_INTEL_PCH intel_pch_smbus.c)
+zephyr_library_sources_ifdef(CONFIG_SMBUS_ITE_IT51XXX smbus_ite_it51xxx.c)
 zephyr_library_sources_ifdef(CONFIG_SMBUS_STM32 smbus_stm32.c)
 # zephyr-keep-sorted-stop

--- a/drivers/smbus/Kconfig
+++ b/drivers/smbus/Kconfig
@@ -105,4 +105,6 @@ config SMBUS_STM32_SMBALERT
 
 endif # SMBUS_STM32
 
+source "drivers/smbus/Kconfig.it51xxx"
+
 endif # SMBUS

--- a/drivers/smbus/Kconfig.it51xxx
+++ b/drivers/smbus/Kconfig.it51xxx
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 ITE Corporation. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+config SMBUS_ITE_IT51XXX
+	bool "ITE SMBus driver"
+	default y
+	depends on DT_HAS_ITE_IT51XXX_SMBUS_ENABLED
+	help
+	  Enable ITE SMBus driver.
+	  Supports nine controllers, performs SMBus messages with packet
+	  error checking (PEC) either enabled or disabled.
+	  Supported speeds: 50kHz, 100kHz, 400kHz and 1MHz.
+	  Supports host notify command.

--- a/drivers/smbus/smbus_ite_it51xxx.c
+++ b/drivers/smbus/smbus_ite_it51xxx.c
@@ -1,0 +1,1113 @@
+/*
+ * Copyright (c) 2026 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ite_it51xxx_smbus
+
+#include <soc.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/drivers/smbus.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
+
+#include "smbus_utils.h"
+
+LOG_MODULE_REGISTER(smbus_ite, CONFIG_SMBUS_LOG_LEVEL);
+
+/* Host Status Register */
+#define SMB_HOSTARn     0x00
+/* Byte Done Status */
+#define SMB_BDS         BIT(7)
+/* Time-out Error */
+#define SMB_TMOE        BIT(6)
+/* Not Response ACK */
+#define SMB_NACK        BIT(5)
+/* Fail (KILL acknowledged) */
+#define SMB_FAIL        BIT(4)
+/* Bus Error (lost arbitration) */
+#define SMB_BSER        BIT(3)
+/* Device Error */
+#define SMB_DVER        BIT(2)
+/* Finish Interrupt (STOP detected) */
+#define SMB_FINTR       BIT(1)
+/* Host Busy */
+#define SMB_HOBY        BIT(0)
+#define HOSTA_ANY_ERROR (SMB_TMOE | SMB_NACK | SMB_FAIL | SMB_BSER | SMB_DVER)
+#define HOSTA_ALL_WC    (SMB_FINTR | HOSTA_ANY_ERROR | SMB_BDS)
+
+/* Host Control Register */
+#define SMB_HOCTLRn     0x01
+#define SMB_PEC_EN      BIT(7)
+#define SMB_SRT         BIT(6)
+#define SMB_LABY        BIT(5)
+/* BIT[4:2]: SMBus command codes for SMCD field */
+#define SMB_SMCD(n)     FIELD_PREP(GENMASK(4, 2), n)
+#define SMCD_QUICK      0
+#define SMCD_BYTE       1
+#define SMCD_BYTE_DATA  2
+#define SMCD_WORD_DATA  3
+#define SMCD_PROC_CALL  4
+#define SMCD_BLOCK      5
+#define SMCD_I2C_BLOCK  6
+#define SMB_KILL        BIT(1)
+#define SMB_INTREN      BIT(0)
+/* Pre-composed HOCTL start values (SRT | SMCD | INTREN) */
+#define START_QUICK_CMD (SMB_SRT | SMB_SMCD(SMCD_QUICK) | SMB_INTREN)
+#define START_BYTE_CMD  (SMB_SRT | SMB_SMCD(SMCD_BYTE) | SMB_INTREN)
+#define START_BYTE_DATA (SMB_SRT | SMB_SMCD(SMCD_BYTE_DATA) | SMB_INTREN)
+#define START_WORD_DATA (SMB_SRT | SMB_SMCD(SMCD_WORD_DATA) | SMB_INTREN)
+#define START_PROC_CALL (SMB_SRT | SMB_SMCD(SMCD_PROC_CALL) | SMB_INTREN)
+#define START_BLOCK_CMD (SMB_SRT | SMB_SMCD(SMCD_BLOCK) | SMB_INTREN)
+
+/* Host Command Register */
+#define SMB_HOCMDRn       0x02
+/* Transmit Slave Address Register */
+#define SMB_TRASLAn       0x03
+/* 0=Write, 1=Read */
+#define SMB_DIR           BIT(0)
+/* Data 0 Register */
+#define SMB_D0REGn        0x04
+/* Data 1 Register */
+#define SMB_D1REGn        0x06
+/* Host Block Data Byte Register */
+#define SMB_HOBDBRn       0x07
+/* Master PIO Packet Error Check Register */
+#define SMB_PECERCRn      0x08
+/* SMBus Pin Control Register */
+#define SMB_SMBPCTLRn     0x09
+/* Host SMDAT Current State */
+#define SMB_HSMBDCS       BIT(1)
+/* Host SMCLK Current State */
+#define SMB_HSMBCS        BIT(0)
+/* Line-idle check */
+#define SMB_LINE_SCL_HIGH SMB_HSMBCS
+#define SMB_LINE_SDA_HIGH SMB_HSMBDCS
+#define SMB_LINE_IDLE     (SMB_LINE_SCL_HIGH | SMB_LINE_SDA_HIGH)
+
+/* Host Nack Source */
+#define SMB_HONACKSRCn   0x0a
+#define SMB_HSMCDTD      BIT(4)
+/* Host Control 2 Register */
+#define SMB_HOCTL2Rn     0x0b
+/* Host Notify Enable (A/B/C only) */
+#define SMB_HTIFYEN      BIT(6)
+/* SMDAT Timeout Enable */
+#define SMB_SMD_TO_EN    BIT(4)
+/* I2C Enable (0=SMBus, 1=I2C mode) */
+#define I2C_EN           BIT(1)
+/* SMBus Host Enable */
+#define SMB_SMH_EN       BIT(0)
+/* SMCLK Timing Setting Register */
+#define SMB_MSCLKTSn     0x0c
+#define MSCLKTS_SCLKS(n) FIELD_PREP(GENMASK(2, 0), n)
+/* BIT[2:0]: SMCLK Setting */
+#define SMB_CLKS_1M      4
+#define SMB_CLKS_400K    3
+#define SMB_CLKS_100K    2
+#define SMB_CLKS_50K     1
+
+#define IT51XXX_SMBUS_BITRATE_50K 50000
+
+/* 25 ms Register */
+#define SMB_25MSREGn 0x11
+/* HW PEC Enable and Status Register */
+#define SMB_SPESRn   0x19
+/* R/WC: Hardwired PEC Check Error */
+#define SMB_MAHPCE   BIT(1)
+/* R/W : Hardwired PEC Function Enable */
+#define SMB_MAHPF    BIT(0)
+/* I2C Wr to Rd FIFO Register */
+#define SMB_I2CW2RFn 0x1b
+/* Host Notify Interrupt Enable */
+#define SMB_HONOIN   BIT(3)
+/* Host Notify registers (A/B/C only) */
+#define SMB_NDADRn   0x1c
+#define SMB_HONOST   BIT(0)
+/* Notify Data Low Byte Register  */
+#define SMB_NDLBn    0x1d
+/* Notify Data High Byte Register */
+#define SMB_NDHBn    0x1e
+
+/* Master FIFO Control Status Register */
+#define SMB_MSTFCSTS    0xf0
+#define SMB_BLKDS2      BIT(6)
+#define SMB_FF2EN       BIT(5)
+#define SMB_BLKDS1      BIT(4)
+#define SMB_FF1EN       BIT(3)
+#define SMB_FFCHSEL2(n) FIELD_PREP(GENMASK(2, 0), n)
+
+/*
+ * Host Notify (HTIFYEN) and the NDADRn/NDLBn/NDHBn capture registers are only
+ * present on host channel A/B/C.
+ */
+#define IT51XXX_SMBUS_HOST_NOTIFY_MAX_PORT 2
+
+/* Transaction timeout */
+#define IT51XXX_SMBUS_TIMEOUT_MS 25
+
+static const uint8_t start_cmd_table[] = {
+	[SMBUS_CMD_QUICK] = START_QUICK_CMD,     [SMBUS_CMD_BYTE] = START_BYTE_CMD,
+	[SMBUS_CMD_BYTE_DATA] = START_BYTE_DATA, [SMBUS_CMD_WORD_DATA] = START_WORD_DATA,
+	[SMBUS_CMD_PROC_CALL] = START_PROC_CALL, [SMBUS_CMD_BLOCK] = START_BLOCK_CMD,
+};
+
+struct smbus_it51xxx_config {
+	/* SMBus alternate configuration */
+	const struct pinctrl_dev_config *pcfg;
+	mm_reg_t host_base;
+	mm_reg_t smbbase;
+	uint32_t bitrate;
+	void (*irq_config_func)(const struct device *dev);
+	uint8_t smbus_irq;
+	uint8_t port;
+	bool fifo_enable;
+};
+
+struct smbus_it51xxx_data {
+	const struct device *dev;
+	struct k_sem bus_lock;
+	struct k_sem xfer_done;
+	/* Configured mode flags */
+	uint32_t dev_config;
+	/* Current transaction error bits captured from HOSTA */
+	int err;
+	uint8_t *blk_rlen;
+	uint8_t *g_w_buf;
+	uint8_t *g_r_buf;
+	uint16_t xfer_addr;
+	uint8_t xfer_protocol;
+	uint8_t blk_idx;
+	uint8_t blk_len;
+	bool blk_is_write;
+	bool blk_active;
+};
+
+static void it51xxx_smb_reset(const struct device *dev)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+
+	irq_disable(cfg->smbus_irq);
+	/* bit1, kill current transaction. */
+	sys_write8(SMB_KILL, cfg->host_base + SMB_HOCTLRn);
+	sys_write8(0, cfg->host_base + SMB_HOCTLRn);
+
+	/* W/C host status register */
+	sys_write8(HOSTA_ALL_WC, cfg->host_base + SMB_HOSTARn);
+	sys_write8(0, cfg->host_base + SMB_HOCTL2Rn);
+	data->blk_active = false;
+}
+
+static inline void it51xxx_smb_xfer_reset(struct smbus_it51xxx_data *data, uint16_t addr,
+					  uint8_t protocol)
+{
+	data->err = 0;
+	data->xfer_addr = addr;
+	data->xfer_protocol = protocol;
+	data->blk_active = false;
+	data->blk_is_write = false;
+	data->g_r_buf = NULL;
+	data->g_w_buf = NULL;
+	data->blk_idx = 0;
+	data->blk_len = 0;
+	data->blk_rlen = NULL;
+	k_sem_reset(&data->xfer_done);
+}
+
+static inline bool it51xxx_smb_bus_idle(const struct device *dev)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+
+	/* Bus is busy */
+	if (sys_read8(cfg->host_base + SMB_HOSTARn) & SMB_HOBY) {
+		return false;
+	}
+
+	/* SCL or SDA is not high */
+	if ((sys_read8(cfg->host_base + SMB_SMBPCTLRn) & SMB_LINE_IDLE) != SMB_LINE_IDLE) {
+		return false;
+	}
+
+	return true;
+}
+
+static int it51xxx_smb_not_available(const struct device *dev)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	uint8_t status;
+
+	status = sys_read8(cfg->host_base + SMB_HOSTARn);
+	if (status & HOSTA_ALL_WC) {
+		LOG_DBG("%s: Clearing HOSTA=0x%02x before transfer", dev->name, status);
+		sys_write8(status & HOSTA_ALL_WC, cfg->host_base + SMB_HOSTARn);
+	}
+
+	if (!it51xxx_smb_bus_idle(dev)) {
+		LOG_ERR("%s: SMBus busy or line not idle", dev->name);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static inline void it51xxx_smb_fifo_enable(const struct device *dev, bool enable)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	uint8_t fifo_en;
+
+	fifo_en = (cfg->port == SMB_CHANNEL_A) ? SMB_FF1EN : SMB_FF2EN;
+
+	if (enable) {
+		sys_write8(sys_read8(cfg->smbbase + SMB_MSTFCSTS) | fifo_en,
+			   cfg->smbbase + SMB_MSTFCSTS);
+	} else {
+		sys_write8(sys_read8(cfg->smbbase + SMB_MSTFCSTS) & ~fifo_en,
+			   cfg->smbbase + SMB_MSTFCSTS);
+	}
+}
+
+static inline void it51xxx_smb_host_enable(const struct device *dev)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+
+	/* Enable SMBus host controller (I2C_EN=0, SMD_EN=1) */
+	sys_write8(sys_read8(cfg->host_base + SMB_HOCTL2Rn) | SMB_SMD_TO_EN | SMB_SMH_EN,
+		   cfg->host_base + SMB_HOCTL2Rn);
+}
+
+static void it51xxx_smb_host_disable(const struct device *dev, uint8_t status)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+
+	irq_disable(cfg->smbus_irq);
+	/* Disable SMBus host controller */
+	sys_write8(0, cfg->host_base + SMB_HOCTL2Rn);
+
+	data->blk_active = false;
+	/* W/C */
+	sys_write8(status, cfg->host_base + SMB_HOSTARn);
+}
+
+static inline void it51xxx_smb_target_addr(const struct device *dev, uint16_t addr,
+					   enum smbus_direction rw)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	uint8_t target_addr;
+
+	target_addr = (uint8_t)((addr << 1) | (rw == SMBUS_MSG_READ ? SMB_DIR : 0));
+	sys_write8(target_addr, cfg->host_base + SMB_TRASLAn);
+}
+
+static void it51xxx_smb_write_cmd(const struct device *dev, enum smbus_direction rw, uint8_t cmd,
+				  uint8_t protocol)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+
+	/* Optional read/write command byte */
+	switch (protocol) {
+	case SMBUS_CMD_QUICK:
+		/* No command byte */
+		break;
+
+	case SMBUS_CMD_BYTE:
+		if (rw == SMBUS_MSG_WRITE) {
+			/* Send Byte has a command byte */
+			sys_write8(cmd, cfg->host_base + SMB_HOCMDRn);
+		}
+		/* Receive byte has not command byte */
+		break;
+	default:
+		/* Byte data / Word data / Block command / Process call have command byte */
+		sys_write8(cmd, cfg->host_base + SMB_HOCMDRn);
+		break;
+	}
+}
+
+static void it51xxx_smb_write_data(const struct device *dev, uint8_t *buf, size_t count)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+
+	LOG_DBG("%s: count=%u buf[0]=0x%02x", dev->name, count, buf[0]);
+
+	sys_write8(buf[0], cfg->host_base + SMB_D0REGn);
+
+	if (count > 1) {
+		LOG_DBG("%s: buf[1]=0x%02x", dev->name, buf[1]);
+		sys_write8(buf[1], cfg->host_base + SMB_D1REGn);
+	}
+}
+
+static void it51xxx_smb_setup_block_xfer(const struct device *dev, enum smbus_direction rw,
+					 uint8_t tx_cnt, uint8_t *tx_buf, uint8_t *rx_cnt,
+					 uint8_t *rx_buf)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+
+	data->blk_is_write = (rw == SMBUS_MSG_WRITE);
+
+	/* FIFO mode */
+	if (cfg->fifo_enable) {
+		if (data->blk_is_write) {
+			/* Byte count field, then the first data byte (HOBDB) */
+			sys_write8(tx_cnt, cfg->host_base + SMB_D0REGn);
+
+			/* Set host block data byte */
+			for (uint8_t i = 0; i < tx_cnt; i++) {
+				sys_write8(tx_buf[i], cfg->host_base + SMB_HOBDBRn);
+			}
+		}
+
+		return;
+	}
+
+	/* PIO mode */
+	data->blk_active = true;
+
+	if (data->blk_is_write) {
+		/* Byte count field, then the first data byte (HOBDB) */
+		sys_write8(tx_cnt, cfg->host_base + SMB_D0REGn);
+
+		sys_write8(tx_buf[0], cfg->host_base + SMB_HOBDBRn);
+
+		/*
+		 * tx_buf[0] is preloaded into HOBDB before START. The ISR pushes
+		 * tx_buf[1..count - 1] on each subsequent BDS.
+		 */
+		data->blk_idx = 1;
+		data->blk_len = tx_cnt;
+		data->g_w_buf = tx_buf;
+	} else {
+		data->blk_idx = 0;
+		data->blk_rlen = rx_cnt;
+		data->g_r_buf = rx_buf;
+	}
+}
+
+static inline int smbus_it51xxx_get_start_cmd(const struct device *dev, uint8_t protocol,
+					      uint8_t *start_cmd)
+{
+	if (protocol >= ARRAY_SIZE(start_cmd_table)) {
+		LOG_ERR("%s: Unsupported SMBus protocol %u", dev->name, protocol);
+		return -EIO;
+	}
+
+	*start_cmd = start_cmd_table[protocol];
+
+	return 0;
+}
+
+static int it51xxx_smb_set_protocol(const struct device *dev, uint8_t protocol)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	int ret;
+	uint8_t start_cmd;
+
+	ret = smbus_it51xxx_get_start_cmd(dev, protocol, &start_cmd);
+	if (ret) {
+		it51xxx_smb_host_disable(dev, 0);
+		return ret;
+	}
+
+	LOG_DBG("%s: IRQ num=%u start_cmd=0x%02x", dev->name, cfg->smbus_irq, start_cmd);
+
+	/* Enable SMBus interrupt */
+	irq_enable(cfg->smbus_irq);
+
+	sys_write8(start_cmd, cfg->host_base + SMB_HOCTLRn);
+
+	return 0;
+}
+
+static int it51xxx_smb_parsing_err(const struct device *dev)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+
+	if (!data->err) {
+		return 0;
+	}
+
+	LOG_ERR("%s: port%u addr=0x%02x HOSTA error=0x%02x", dev->name, cfg->port, data->xfer_addr,
+		data->err);
+
+	if (data->err == ETIMEDOUT) {
+		/* Connection timed out */
+		LOG_ERR("Transaction time out");
+	} else {
+		/* Host error bits message*/
+		if (data->err & SMB_TMOE) {
+			LOG_ERR("Hardware time-out error");
+		}
+		if (data->err & SMB_NACK) {
+			LOG_DBG("NACK received");
+		}
+		if (data->err & SMB_FAIL) {
+			LOG_ERR("Transaction killed");
+		}
+		if (data->err & SMB_BSER) {
+			LOG_ERR("Lost arbitration.");
+		}
+		if (data->err & SMB_DVER) {
+			LOG_ERR("Device error");
+		}
+	}
+
+	return -EIO;
+}
+
+static int it51xxx_smb_wait_finish(const struct device *dev)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+
+	ret = k_sem_take(&data->xfer_done, K_MSEC(IT51XXX_SMBUS_TIMEOUT_MS + 10));
+	if (ret == -EAGAIN) {
+		data->err = ETIMEDOUT;
+		it51xxx_smb_reset(dev);
+		LOG_ERR("%s: Transaction timed out", dev->name);
+
+		return ret;
+	}
+
+	return 0;
+}
+
+static inline uint8_t it51xxx_smb_protocol_data_len(uint8_t protocol)
+{
+	switch (protocol) {
+	case SMBUS_CMD_BYTE:
+	case SMBUS_CMD_BYTE_DATA:
+		return 1;
+	case SMBUS_CMD_WORD_DATA:
+	case SMBUS_CMD_PROC_CALL:
+		return 2;
+	default:
+		return 0;
+	}
+}
+
+static inline void it51xxx_smb_read_data(const struct device *dev, uint8_t *buf, uint8_t count)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+
+	buf[0] = sys_read8(cfg->host_base + SMB_D0REGn);
+
+	if (count > 1) {
+		buf[1] = sys_read8(cfg->host_base + SMB_D1REGn);
+	}
+}
+
+static inline void it51xxx_smb_post_read(const struct device *dev, uint8_t *rx_buf,
+					 uint8_t protocol)
+{
+	uint8_t data_len = it51xxx_smb_protocol_data_len(protocol);
+
+	if (data_len > 0) {
+		it51xxx_smb_read_data(dev, rx_buf, data_len);
+	}
+}
+
+static int it51xxx_smb_fifo_block_read_data(const struct device *dev, uint8_t *rx_buf,
+					    uint8_t *rx_cnt)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+	uint8_t byte_count;
+
+	byte_count = sys_read8(cfg->host_base + SMB_D0REGn);
+
+	if (byte_count == 0 || byte_count > SMBUS_BLOCK_BYTES_MAX) {
+		LOG_ERR("%s: FIFO block read invalid byte count %u", dev->name, byte_count);
+		data->err = SMB_FAIL;
+		return -EIO;
+	}
+
+	*rx_cnt = byte_count;
+
+	/* HOBDB acts as a FIFO output port while dedicated FIFO mode is enabled */
+	for (uint8_t i = 0; i < byte_count; i++) {
+		rx_buf[i] = sys_read8(cfg->host_base + SMB_HOBDBRn);
+	}
+
+	return 0;
+}
+
+static int it51xxx_smbus_xfer(const struct device *dev, uint16_t periph_addr,
+			      enum smbus_direction rw, uint8_t cmd, uint8_t tx_cnt, uint8_t *tx_buf,
+			      uint8_t *rx_cnt, uint8_t *rx_buf, uint8_t protocol)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+
+	it51xxx_smb_xfer_reset(data, periph_addr, protocol);
+
+	/* Ensure bus idle before starting a new transaction */
+	ret = it51xxx_smb_not_available(dev);
+	if (ret) {
+		return ret;
+	}
+
+	/* Enable FIFO mode */
+	if (cfg->fifo_enable && protocol == SMBUS_CMD_BLOCK) {
+		it51xxx_smb_fifo_enable(dev, true);
+	}
+
+	/* Enable SMBus host interface */
+	it51xxx_smb_host_enable(dev);
+
+	/* Target address + R/W bit */
+	it51xxx_smb_target_addr(dev, periph_addr, rw);
+
+	/* Set host command register */
+	it51xxx_smb_write_cmd(dev, rw, cmd, protocol);
+
+	if (protocol == SMBUS_CMD_BLOCK) {
+		/* SMB_BLOCK_CMD */
+		it51xxx_smb_setup_block_xfer(dev, rw, tx_cnt, tx_buf, rx_cnt, rx_buf);
+	} else if (tx_buf != NULL && tx_cnt > 0) {
+		/* Command byte / Byte data / Word data / Process call */
+		it51xxx_smb_write_data(dev, tx_buf, tx_cnt);
+	}
+
+	/* Start transaction with selected protocol */
+	ret = it51xxx_smb_set_protocol(dev, protocol);
+	if (ret) {
+		return ret;
+	}
+
+	/*
+	 * Wait for either FINTR (transaction complete) or any error bit.
+	 * Returns 0 on success, negative errno on error or timeout.
+	 */
+	ret = it51xxx_smb_wait_finish(dev);
+	if (ret) {
+		goto done;
+	}
+
+	LOG_DBG("%s: Complete addr=0x%02x protocol=0x%02x", dev->name, periph_addr, protocol);
+
+	/* Command byte / Byte data / Word data / Process call have read data */
+	if (rx_buf != NULL) {
+		it51xxx_smb_post_read(dev, rx_buf, protocol);
+	}
+
+	if (cfg->fifo_enable && protocol == SMBUS_CMD_BLOCK && rw == SMBUS_MSG_READ) {
+		it51xxx_smb_fifo_block_read_data(dev, rx_buf, rx_cnt);
+	}
+
+done:
+	if (cfg->fifo_enable && protocol == SMBUS_CMD_BLOCK) {
+		it51xxx_smb_fifo_enable(dev, false);
+	}
+
+	return it51xxx_smb_parsing_err(dev);
+}
+
+static int it51xxx_smbus_set_port_frequency(const struct device *dev)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	uint8_t msclkts, freq_set;
+
+	switch (cfg->bitrate) {
+	case IT51XXX_SMBUS_BITRATE_50K:
+		freq_set = MSCLKTS_SCLKS(SMB_CLKS_50K);
+		break;
+
+	case I2C_BITRATE_STANDARD:
+		freq_set = MSCLKTS_SCLKS(SMB_CLKS_100K);
+		break;
+
+	case I2C_BITRATE_FAST:
+		freq_set = MSCLKTS_SCLKS(SMB_CLKS_400K);
+		break;
+
+	case I2C_BITRATE_FAST_PLUS:
+		freq_set = MSCLKTS_SCLKS(SMB_CLKS_1M);
+		break;
+
+	default:
+		LOG_ERR("%s: Unsupported SMBus bitrate: %u", dev->name, cfg->bitrate);
+		return -EIO;
+	}
+
+	msclkts = sys_read8(cfg->host_base + SMB_MSCLKTSn);
+	msclkts &= ~GENMASK(2, 0);
+	sys_write8(msclkts | freq_set, cfg->host_base + SMB_MSCLKTSn);
+
+	return 0;
+}
+
+static int smbus_it51xxx_configure(const struct device *dev, uint32_t config_value)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+
+	LOG_DBG("%s: port%u config=0x%02x", dev->name, cfg->port, config_value);
+
+	if ((config_value & SMBUS_MODE_CONTROLLER) == 0) {
+		LOG_ERR("%s: Only controller mode is supported", dev->name);
+		return -EIO;
+	}
+
+	if (config_value & SMBUS_MODE_SMBALERT) {
+		LOG_ERR("%s: SMBALERT# is not support", dev->name);
+		return -EIO;
+	}
+
+	data->dev_config = config_value;
+
+	ret = it51xxx_smbus_set_port_frequency(dev);
+
+	return ret;
+}
+
+static int smbus_it51xxx_get_config(const struct device *dev, uint32_t *config)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+
+	if (config == NULL) {
+		return -EIO;
+	}
+
+	*config = data->dev_config;
+
+	return 0;
+}
+
+static int smbus_it51xxx_quick(const struct device *dev, uint16_t periph_addr,
+			       enum smbus_direction rw)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+
+	LOG_DBG("%s: addr=0x%02x rw=%d", dev->name, periph_addr, rw);
+
+	k_sem_take(&data->bus_lock, K_FOREVER);
+
+	ret = it51xxx_smbus_xfer(dev, periph_addr, rw, 0, 0, NULL, NULL, NULL, SMBUS_CMD_QUICK);
+
+	k_sem_give(&data->bus_lock);
+
+	return ret;
+}
+
+static int smbus_it51xxx_byte_write(const struct device *dev, uint16_t periph_addr, uint8_t byte)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+
+	LOG_DBG("%s: addr=0x%02x byte=0x%02x", dev->name, periph_addr, byte);
+
+	k_sem_take(&data->bus_lock, K_FOREVER);
+
+	ret = it51xxx_smbus_xfer(dev, periph_addr, SMBUS_MSG_WRITE, byte, 0, NULL, NULL, NULL,
+				 SMBUS_CMD_BYTE);
+
+	k_sem_give(&data->bus_lock);
+
+	return ret;
+}
+
+static int smbus_it51xxx_byte_read(const struct device *dev, uint16_t periph_addr, uint8_t *byte)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+
+	if (byte == NULL) {
+		return -EIO;
+	}
+
+	LOG_DBG("%s: addr=0x%02x", dev->name, periph_addr);
+
+	k_sem_take(&data->bus_lock, K_FOREVER);
+
+	ret = it51xxx_smbus_xfer(dev, periph_addr, SMBUS_MSG_READ, 0, 0, NULL, NULL, byte,
+				 SMBUS_CMD_BYTE);
+
+	k_sem_give(&data->bus_lock);
+
+	return ret;
+}
+
+static int smbus_it51xxx_byte_data_write(const struct device *dev, uint16_t periph_addr,
+					 uint8_t command, uint8_t byte)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+
+	LOG_DBG("%s: addr=0x%02x cmd=0x%02x", dev->name, periph_addr, command);
+
+	k_sem_take(&data->bus_lock, K_FOREVER);
+
+	ret = it51xxx_smbus_xfer(dev, periph_addr, SMBUS_MSG_WRITE, command, sizeof(byte), &byte,
+				 NULL, NULL, SMBUS_CMD_BYTE_DATA);
+
+	k_sem_give(&data->bus_lock);
+
+	return ret;
+}
+
+static int smbus_it51xxx_byte_data_read(const struct device *dev, uint16_t periph_addr,
+					uint8_t command, uint8_t *byte)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+
+	LOG_DBG("%s: addr=0x%02x cmd=0x%02x", dev->name, periph_addr, command);
+
+	if (byte == NULL) {
+		return -EIO;
+	}
+
+	k_sem_take(&data->bus_lock, K_FOREVER);
+
+	ret = it51xxx_smbus_xfer(dev, periph_addr, SMBUS_MSG_READ, command, 0, NULL, NULL, byte,
+				 SMBUS_CMD_BYTE_DATA);
+
+	k_sem_give(&data->bus_lock);
+
+	return ret;
+}
+
+static int smbus_it51xxx_word_data_write(const struct device *dev, uint16_t periph_addr,
+					 uint8_t command, uint16_t word)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+	uint8_t buf[2];
+
+	LOG_DBG("%s: addr=0x%02x cmd=0x%02x", dev->name, periph_addr, command);
+
+	sys_put_le16(word, buf);
+
+	k_sem_take(&data->bus_lock, K_FOREVER);
+
+	ret = it51xxx_smbus_xfer(dev, periph_addr, SMBUS_MSG_WRITE, command, sizeof(buf), buf, NULL,
+				 NULL, SMBUS_CMD_WORD_DATA);
+
+	k_sem_give(&data->bus_lock);
+
+	return ret;
+}
+
+static int smbus_it51xxx_word_data_read(const struct device *dev, uint16_t periph_addr,
+					uint8_t command, uint16_t *word)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+	uint8_t r_buf[2];
+
+	LOG_DBG("%s: addr=0x%02x cmd=0x%02x", dev->name, periph_addr, command);
+
+	if (word == NULL) {
+		return -EIO;
+	}
+
+	k_sem_take(&data->bus_lock, K_FOREVER);
+
+	ret = it51xxx_smbus_xfer(dev, periph_addr, SMBUS_MSG_READ, command, 0, NULL, NULL, r_buf,
+				 SMBUS_CMD_WORD_DATA);
+
+	k_sem_give(&data->bus_lock);
+
+	if (ret) {
+		return ret;
+	}
+
+	*word = sys_get_le16(r_buf);
+
+	return 0;
+}
+
+static int smbus_it51xxx_pcall(const struct device *dev, uint16_t periph_addr, uint8_t command,
+			       uint16_t send_word, uint16_t *recv_word)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+	uint8_t w_buf[2], r_buf[2];
+
+	if (recv_word == NULL) {
+		return -EIO;
+	}
+
+	LOG_DBG("%s: addr=0x%02x cmd=0x%02x", dev->name, periph_addr, command);
+
+	sys_put_le16(send_word, w_buf);
+
+	k_sem_take(&data->bus_lock, K_FOREVER);
+
+	ret = it51xxx_smbus_xfer(dev, periph_addr, SMBUS_MSG_WRITE, command, sizeof(w_buf), w_buf,
+				 NULL, r_buf, SMBUS_CMD_PROC_CALL);
+
+	k_sem_give(&data->bus_lock);
+
+	if (ret) {
+		return ret;
+	}
+
+	*recv_word = sys_get_le16(r_buf);
+
+	return 0;
+}
+
+static int smbus_it51xxx_block_write(const struct device *dev, uint16_t periph_addr,
+				     uint8_t command, uint8_t count, uint8_t *buf)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+
+	LOG_DBG("%s: addr=0x%02x cmd=0x%02x count=%u", dev->name, periph_addr, command, count);
+
+	if (buf == NULL || count == 0 || count > SMBUS_BLOCK_BYTES_MAX) {
+		return -EIO;
+	}
+
+	k_sem_take(&data->bus_lock, K_FOREVER);
+
+	ret = it51xxx_smbus_xfer(dev, periph_addr, SMBUS_MSG_WRITE, command, count, buf, NULL, NULL,
+				 SMBUS_CMD_BLOCK);
+
+	k_sem_give(&data->bus_lock);
+
+	return ret;
+}
+
+static int smbus_it51xxx_block_read(const struct device *dev, uint16_t periph_addr, uint8_t command,
+				    uint8_t *count, uint8_t *buf)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+
+	LOG_DBG("%s: addr=0x%02x cmd=0x%02x", dev->name, periph_addr, command);
+
+	if (count == NULL || buf == NULL) {
+		return -EIO;
+	}
+
+	k_sem_take(&data->bus_lock, K_FOREVER);
+
+	ret = it51xxx_smbus_xfer(dev, periph_addr, SMBUS_MSG_READ, command, 0, NULL, count, buf,
+				 SMBUS_CMD_BLOCK);
+
+	k_sem_give(&data->bus_lock);
+
+	return ret;
+}
+
+static void it51xxx_smb_isr_block_write(const struct device *dev)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+
+	LOG_DBG("%s: Block write byte done idx=%u len=%u", dev->name, data->blk_idx, data->blk_len);
+
+	if (data->blk_idx < data->blk_len) {
+		sys_write8(data->g_w_buf[data->blk_idx], cfg->host_base + SMB_HOBDBRn);
+		data->blk_idx++;
+	}
+
+	/*
+	 * W/C BDS: releases the clock stretch so hardware can send the ACK/NACK and
+	 * clock out the next byte (or stop).
+	 */
+	sys_write8(SMB_BDS, cfg->host_base + SMB_HOSTARn);
+}
+
+static void it51xxx_smb_isr_block_read(const struct device *dev)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+	uint8_t byte_count;
+
+	if (data->blk_idx == 0) {
+		byte_count = sys_read8(cfg->host_base + SMB_D0REGn);
+		*data->blk_rlen = byte_count;
+
+		LOG_DBG("%s: Block read data len=%u", dev->name, *data->blk_rlen);
+		if (byte_count == 0 || byte_count > SMBUS_BLOCK_BYTES_MAX) {
+			LOG_ERR("%s: Block read invalid byte count %u", dev->name, byte_count);
+			data->err = SMB_FAIL;
+			it51xxx_smb_reset(dev);
+			k_sem_give(&data->xfer_done);
+			return;
+		}
+	}
+
+	/*
+	 * LABY bit must be set before the actual last byte arrives, so hardware knows the
+	 * incoming byte is the final one. That means we have to set it one byte early:
+	 * blk_rlen == 1: no need to set the last byte.
+	 * blk_idx == blk_rlen - 2: normal case, we're currently on the second-to-last byte,
+	 * meaning the next one (blk_idx + 1, i.e. blk_rlen - 1) will be the last byte.
+	 */
+	if (*data->blk_rlen > 1 && (data->blk_idx == *data->blk_rlen - 2)) {
+		sys_write8(sys_read8(cfg->host_base + SMB_HOCTLRn) | SMB_LABY,
+			   cfg->host_base + SMB_HOCTLRn);
+	}
+
+	data->g_r_buf[data->blk_idx] = sys_read8(cfg->host_base + SMB_HOBDBRn);
+	data->blk_idx++;
+	/* W/C BDS */
+	sys_write8(SMB_BDS, cfg->host_base + SMB_HOSTARn);
+}
+
+static void it51xxx_smb_isr_byte_done(const struct device *dev)
+{
+	struct smbus_it51xxx_data *data = dev->data;
+
+	if (data->xfer_protocol != SMBUS_CMD_BLOCK) {
+		return;
+	}
+
+	if (data->blk_is_write) {
+		it51xxx_smb_isr_block_write(dev);
+	} else {
+		it51xxx_smb_isr_block_read(dev);
+	}
+}
+
+static void smbus_it51xxx_isr(const struct device *dev)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+	uint8_t status;
+
+	status = sys_read8(cfg->host_base + SMB_HOSTARn);
+
+	/* Any bus/device error ends the transaction */
+	if (status & HOSTA_ANY_ERROR) {
+		data->err = status & HOSTA_ANY_ERROR;
+		goto done;
+	}
+
+	/* Byte done status */
+	if (status & SMB_BDS && data->blk_active) {
+		it51xxx_smb_isr_byte_done(dev);
+		return;
+	}
+
+	if (!(status & SMB_FINTR)) {
+		return;
+	}
+
+	/* Finish Interrupt: stop condition detected, transaction is done */
+done:
+	it51xxx_smb_host_disable(dev, status);
+	/* Wake the waiting thread */
+	k_sem_give(&data->xfer_done);
+}
+
+static int smbus_it51xxx_init(const struct device *dev)
+{
+	const struct smbus_it51xxx_config *cfg = dev->config;
+	struct smbus_it51xxx_data *data = dev->data;
+	int ret;
+
+	it51xxx_smb_reset(dev);
+
+	/* Initialize bus lock (mutex) and transfer-done semaphore */
+	k_sem_init(&data->bus_lock, 1, 1);
+	k_sem_init(&data->xfer_done, 0, 1);
+
+	cfg->irq_config_func(dev);
+
+	ret = smbus_it51xxx_configure(dev, SMBUS_MODE_CONTROLLER);
+	if (ret) {
+		LOG_ERR("%s: Cannot set default configuration", dev->name);
+		return ret;
+	}
+
+	/* This field defines the low timeout for design A-I clocks */
+	sys_write8(IT51XXX_SMBUS_TIMEOUT_MS, cfg->host_base + SMB_25MSREGn);
+
+	/* Set the pin to SMBus alternate function. */
+	ret = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret) {
+		LOG_ERR("%s: Failed to configure SMbus pins", dev->name);
+		return ret;
+	}
+
+	/* Select which port to use FIFO2 except port A */
+	if ((cfg->port != SMB_CHANNEL_A) && cfg->fifo_enable) {
+		sys_write8(sys_read8(cfg->smbbase + SMB_MSTFCSTS) | SMB_FFCHSEL2(cfg->port - 1),
+			   cfg->smbbase + SMB_MSTFCSTS);
+	}
+
+	return 0;
+}
+
+static DEVICE_API(smbus, smbus_it51xxx_api) = {
+	.configure = smbus_it51xxx_configure,
+	.get_config = smbus_it51xxx_get_config,
+	.smbus_quick = smbus_it51xxx_quick,
+	.smbus_byte_write = smbus_it51xxx_byte_write,
+	.smbus_byte_read = smbus_it51xxx_byte_read,
+	.smbus_byte_data_write = smbus_it51xxx_byte_data_write,
+	.smbus_byte_data_read = smbus_it51xxx_byte_data_read,
+	.smbus_word_data_write = smbus_it51xxx_word_data_write,
+	.smbus_word_data_read = smbus_it51xxx_word_data_read,
+	.smbus_pcall = smbus_it51xxx_pcall,
+	.smbus_block_write = smbus_it51xxx_block_write,
+	.smbus_block_read = smbus_it51xxx_block_read,
+};
+
+#define IT51XXX_I2C_COMPAT ite_it51xxx_i2c
+
+/* Ensure no enabled I2C instance uses the same port as this SMBus instance. */
+#define SMBUS_IT51XXX_I2C_PORT_CONFLICT_CHECK(i2c_node_id, smbus_inst)                             \
+	BUILD_ASSERT(DT_REG_ADDR(i2c_node_id) != DT_INST_REG_ADDR(smbus_inst),                     \
+		     "it51xxx: an I2C and SMBus instance cannot use the same port");
+
+#define SMBUS_IT51XXX_CHECK_NOT_ALSO_I2C(smbus_inst)                                               \
+	DT_FOREACH_STATUS_OKAY_VARGS(IT51XXX_I2C_COMPAT, SMBUS_IT51XXX_I2C_PORT_CONFLICT_CHECK,    \
+				     smbus_inst)
+
+#define IT51XXX_FIFO_ENABLE_ADD_NON_A(node_id)                                                     \
+	+((DT_PROP(node_id, port_num) != SMB_CHANNEL_A) ? DT_PROP(node_id, fifo_enable) : 0)
+
+#define IT51XXX_SMBUS_FIFO_ENABLE_COUNT                                                            \
+	(0 DT_FOREACH_STATUS_OKAY(DT_DRV_COMPAT, IT51XXX_FIFO_ENABLE_ADD_NON_A))
+
+#define IT51XXX_I2C_FIFO_ENABLE_COUNT                                                              \
+	(0 DT_FOREACH_STATUS_OKAY(IT51XXX_I2C_COMPAT, IT51XXX_FIFO_ENABLE_ADD_NON_A))
+
+BUILD_ASSERT((IT51XXX_SMBUS_FIFO_ENABLE_COUNT + IT51XXX_I2C_FIFO_ENABLE_COUNT) <= 1,
+	     "it51xxx: at most one SMBus/I2C port (smbus1-8, i2c1-8) may enable fifo mode");
+
+#define SMBUS_IT51XXX_DEVICE_INIT(inst)                                                            \
+	PINCTRL_DT_INST_DEFINE(inst);                                                              \
+	SMBUS_IT51XXX_CHECK_NOT_ALSO_I2C(inst)                                                     \
+	static void smbus_it51xxx_irq_config_##inst(const struct device *dev)                      \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(inst), 0, smbus_it51xxx_isr, DEVICE_DT_INST_GET(inst),    \
+			    0);                                                                    \
+	};                                                                                         \
+	static struct smbus_it51xxx_config smbus_it51xxx_config_##inst = {                         \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                      \
+		.host_base = DT_INST_REG_ADDR(inst),                                               \
+		.smbbase = DT_REG_ADDR_BY_IDX(DT_NODELABEL(i2cbase), 0),                           \
+		.smbus_irq = DT_INST_IRQN(inst),                                                   \
+		.bitrate = DT_INST_PROP(inst, clock_frequency),                                    \
+		.port = DT_INST_PROP(inst, port_num),                                              \
+		.irq_config_func = smbus_it51xxx_irq_config_##inst,                                \
+		.fifo_enable = DT_INST_PROP(inst, fifo_enable),                                    \
+	};                                                                                         \
+                                                                                                   \
+	static struct smbus_it51xxx_data smbus_it51xxx_data_##inst;                                \
+                                                                                                   \
+	SMBUS_DEVICE_DT_INST_DEFINE(inst, smbus_it51xxx_init, NULL, &smbus_it51xxx_data_##inst,    \
+				    &smbus_it51xxx_config_##inst, POST_KERNEL,                     \
+				    CONFIG_SMBUS_INIT_PRIORITY, &smbus_it51xxx_api);
+
+DT_INST_FOREACH_STATUS_OKAY(SMBUS_IT51XXX_DEVICE_INIT)

--- a/drivers/smbus/smbus_shell.c
+++ b/drivers/smbus/smbus_shell.c
@@ -278,6 +278,51 @@ static int cmd_smbus_word_data_write(const struct shell *sh,
 	return 0;
 }
 
+/* smbus process_call <device> <dev_addr> <cmd> <tx_word> */
+static int cmd_smbus_process_call(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	uint8_t addr;
+	uint8_t command;
+	uint16_t tx_word;
+	uint16_t rx_word;
+	int ret = 0;
+
+	dev = shell_device_get_binding(argv[ARGV_DEV]);
+	if (!dev) {
+		shell_error(sh, "SMBus: Device %s not found", argv[ARGV_DEV]);
+		return -ENODEV;
+	}
+
+	addr = shell_strtol(argv[ARGV_ADDR], 16, &ret);
+	if (ret) {
+		shell_error(sh, "Failed to parse addr: %d", ret);
+		return ret;
+	}
+
+	command = shell_strtol(argv[ARGV_CMD], 16, &ret);
+	if (ret) {
+		shell_error(sh, "Failed to parse command: %d", ret);
+		return ret;
+	}
+
+	tx_word = shell_strtol(argv[4], 16, &ret);
+	if (ret) {
+		shell_error(sh, "Failed to parse data: %d", ret);
+		return ret;
+	}
+
+	ret = smbus_pcall(dev, addr, command, tx_word, &rx_word);
+	if (ret < 0) {
+		shell_error(sh, "SMBus: Failed process call to periph: 0x%02x", addr);
+		return ret;
+	}
+
+	shell_print(sh, "Command: 0x%02x TX: 0x%04x RX: 0x%04x", command, tx_word, rx_word);
+
+	return 0;
+}
+
 /* smbus block_write <device> <dev_addr> <cmd> <bytes ... > */
 static int cmd_smbus_block_write(const struct shell *sh,
 				 size_t argc, char **argv)
@@ -367,6 +412,7 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 
 SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
+/* clang-format off */
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_smbus_cmds,
 	SHELL_CMD_ARG(quick, &dsub_device_name,
 		      "SMBus Quick command\n"
@@ -400,6 +446,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_smbus_cmds,
 		      "SMBus: word data write command\n"
 		      "Usage: word_data_write <device> <addr> <cmd> <value>",
 		      cmd_smbus_word_data_write, 5, 0),
+	SHELL_CMD_ARG(process_call, &dsub_device_name,
+		      "SMBus: Process call command\n"
+		      "Usage: process_call <device> <addr> <cmd> <tx_word>",
+		      cmd_smbus_process_call, 5, 0),
 	SHELL_CMD_ARG(block_write, &dsub_device_name,
 		      "SMBus: Block Write command\n"
 		      "Usage: block_write <device> <addr> <cmd> [<byte1>, ...]",
@@ -410,5 +460,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_smbus_cmds,
 		      cmd_smbus_block_read, 4, 0),
 	SHELL_SUBCMD_SET_END     /* Array terminated. */
 );
+/* clang-format off */
 
 SHELL_CMD_REGISTER(smbus, &sub_smbus_cmds, "smbus commands", NULL);

--- a/dts/bindings/smbus/ite,it51xxx-smbus.yaml
+++ b/dts/bindings/smbus/ite,it51xxx-smbus.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 ITE Corporation. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+description: ITE it51xxx SMBus controller
+
+compatible: "ite,it51xxx-smbus"
+
+include: [smbus-controller.yaml, pinctrl-device.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  pinctrl-0:
+    required: true
+
+  pinctrl-names:
+    required: true
+
+  port-num:
+    type: int
+    required: true
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+    description: Ordinal identifying the port
+      0 = SMB_CHANNEL_A,
+      1 = SMB_CHANNEL_B,
+      2 = SMB_CHANNEL_C,
+      3 = SMB_CHANNEL_D,
+      4 = SMB_CHANNEL_E,
+      5 = SMB_CHANNEL_F,
+      6 = SMB_CHANNEL_G,
+      7 = SMB_CHANNEL_H,
+      8 = SMB_CHANNEL_I,
+
+  fifo-enable:
+    type: boolean
+    description: |
+      The SMBus controller supports two 32-bytes FIFOs,
+      FIFO1 supports SMBus port 0. FIFO2 only supports one port among
+      1~8. The default is SMBus port 1.

--- a/dts/riscv/ite/it51xxx.dtsi
+++ b/dts/riscv/ite/it51xxx.dtsi
@@ -1444,5 +1444,113 @@
 			alarms-count = <2>;
 			status = "disabled";
 		};
+
+		smbus0: smbus@f04100 {
+			compatible = "ite,it51xxx-smbus";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+			reg = <0x00f04100 0x0028>;
+			interrupts = <IT51XXX_IRQ_SMB_A IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-parent = <&intc>;
+			port-num = <SMB_CHANNEL_A>;
+			fifo-enable;   /* FIFO1 */
+		};
+
+		smbus1: smbus@f04128 {
+			compatible = "ite,it51xxx-smbus";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+			reg = <0x00f04128 0x0028>;
+			interrupts = <IT51XXX_IRQ_SMB_B IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-parent = <&intc>;
+			port-num = <SMB_CHANNEL_B>;
+			fifo-enable;   /* FIFO2 */
+		};
+
+		smbus2: smbus@f04150 {
+			compatible = "ite,it51xxx-smbus";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+			reg = <0x00f04150 0x0028>;
+			interrupts = <IT51XXX_IRQ_SMB_C IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-parent = <&intc>;
+			port-num = <SMB_CHANNEL_C>;
+			/delete-property/ fifo-enable;   /* FIFO2 */
+		};
+
+		smbus3: smbus@f04178 {
+			compatible = "ite,it51xxx-smbus";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+			reg = <0x00f04178 0x0028>;
+			interrupts = <IT51XXX_IRQ_SMB_D IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-parent = <&intc>;
+			port-num = <SMB_CHANNEL_D>;
+			/delete-property/ fifo-enable;   /* FIFO2 */
+		};
+
+		smbus4: smbus@f041a0 {
+			compatible = "ite,it51xxx-smbus";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+			reg = <0x00f041a0 0x0028>;
+			interrupts = <IT51XXX_IRQ_SMB_E IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-parent = <&intc>;
+			port-num = <SMB_CHANNEL_E>;
+			/delete-property/ fifo-enable;   /* FIFO2 */
+		};
+
+		smbus5: smbus@f041c8 {
+			compatible = "ite,it51xxx-smbus";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+			reg = <0x00f041c8 0x0028>;
+			interrupts = <IT51XXX_IRQ_SMB_F IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-parent = <&intc>;
+			port-num = <SMB_CHANNEL_F>;
+			/delete-property/ fifo-enable;   /* FIFO2 */
+		};
+
+		smbus6: smbus@f04260 {
+			compatible = "ite,it51xxx-smbus";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+			reg = <0x00f04260 0x0028>;
+			interrupts = <IT51XXX_IRQ_SMB_G IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-parent = <&intc>;
+			port-num = <SMB_CHANNEL_G>;
+			/delete-property/ fifo-enable;   /* FIFO2 */
+		};
+
+		smbus7: smbus@f04288 {
+			compatible = "ite,it51xxx-smbus";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+			reg = <0x00f04288 0x0028>;
+			interrupts = <IT51XXX_IRQ_SMB_H IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-parent = <&intc>;
+			port-num = <SMB_CHANNEL_H>;
+			/delete-property/ fifo-enable;   /* FIFO2 */
+		};
+
+		smbus8: smbus@f042b0 {
+			compatible = "ite,it51xxx-smbus";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+			reg = <0x00f042b0 0x0028>;
+			interrupts = <IT51XXX_IRQ_SMB_I IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-parent = <&intc>;
+			port-num = <SMB_CHANNEL_H>;
+			/delete-property/ fifo-enable;   /* FIFO2 */
+		};
 	};
 };

--- a/tests/drivers/smbus/smbus_it51xxx/CMakeLists.txt
+++ b/tests/drivers/smbus/smbus_it51xxx/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 ITE Corporation. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.5)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(smbus_it51xxx_test)
+
+file(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/drivers/smbus/smbus_it51xxx/boards/it51xxx_evb_it51526aw.overlay
+++ b/tests/drivers/smbus/smbus_it51xxx/boards/it51xxx_evb_it51526aw.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		smbus-host = &smbus2;
+		i2c-target = &i2c0;
+	};
+};
+
+&smbus2 {
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+
+	pinctrl-0 = <&i2c2_clk_gpf6_default
+		     &i2c2_data_gpf7_default>;
+	pinctrl-names = "default";
+	fifo-enable;
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	pinctrl-0 = <&i2c0_clk_gpf2_default
+		     &i2c0_data_gpf3_default>;
+	pinctrl-names = "default";
+
+	target-enable;
+	target-shared-fifo-mode;
+
+	i2c_target0: target@52 {
+		reg = <0x52>;
+		size = <256>;
+	};
+};

--- a/tests/drivers/smbus/smbus_it51xxx/prj.conf
+++ b/tests/drivers/smbus/smbus_it51xxx/prj.conf
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+
+# SMBus host controller under test (smbus2 / channel C)
+CONFIG_SMBUS=y
+
+# I2C subsystem + target mode, for the i2c0 test peripheral (channel A)
+CONFIG_I2C=y
+CONFIG_I2C_TARGET=y
+
+CONFIG_LOG=y
+CONFIG_SMBUS_LOG_LEVEL_INF=y
+CONFIG_I2C_LOG_LEVEL_INF=y
+
+CONFIG_ZTEST_ASSERT_VERBOSE=1

--- a/tests/drivers/smbus/smbus_it51xxx/src/i2c_target.c
+++ b/tests/drivers/smbus/smbus_it51xxx/src/i2c_target.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2026 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "i2c_target.h"
+
+#include <errno.h>
+#include <string.h>
+
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+
+LOG_MODULE_REGISTER(smbus_test_target, LOG_LEVEL_INF);
+
+struct test_target_state {
+	struct i2c_target_config cfg;
+	const struct device *bus;
+
+	uint8_t write_buf[CONFIG_I2C_TARGET_IT51XXX_MAX_BUF_SIZE];
+	size_t write_len;
+
+	uint8_t read_buf[CONFIG_I2C_TARGET_IT51XXX_MAX_BUF_SIZE];
+	size_t read_len;
+	size_t read_idx;
+
+	bool registered;
+};
+
+static struct test_target_state state;
+
+static int target_write_requested(struct i2c_target_config *cfg)
+{
+	ARG_UNUSED(cfg);
+
+	state.write_len = 0;
+
+	return 0;
+}
+
+static int target_write_received(struct i2c_target_config *cfg, uint8_t val)
+{
+	ARG_UNUSED(cfg);
+
+	if (state.write_len >= CONFIG_I2C_TARGET_IT51XXX_MAX_BUF_SIZE) {
+		LOG_ERR("write capture buffer full, dropping byte 0x%02x", val);
+		return -ENOMEM;
+	}
+
+	state.write_buf[state.write_len++] = val;
+
+	return 0;
+}
+
+static int target_read_requested(struct i2c_target_config *cfg, uint8_t *val)
+{
+	ARG_UNUSED(cfg);
+
+	state.read_idx = 0;
+
+	if (state.read_len == 0) {
+		/* Nothing preloaded: NACK the read so the test sees a real error. */
+		LOG_WRN("read requested but nothing preloaded");
+		return -EIO;
+	}
+
+	*val = state.read_buf[state.read_idx++];
+
+	return 0;
+}
+
+static int target_read_processed(struct i2c_target_config *cfg, uint8_t *val)
+{
+	ARG_UNUSED(cfg);
+
+	if (state.read_idx >= state.read_len) {
+		/* Host is clocking out more bytes than were preloaded. */
+		LOG_WRN("read past preloaded data (idx=%u len=%u)", (unsigned int)state.read_idx,
+			(unsigned int)state.read_len);
+		*val = 0xFF;
+		return 0;
+	}
+
+	*val = state.read_buf[state.read_idx++];
+
+	return 0;
+}
+
+#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
+static void target_buf_write_received(struct i2c_target_config *config, uint8_t *ptr, uint32_t len)
+{
+	ARG_UNUSED(config);
+
+	if (len > CONFIG_I2C_TARGET_IT51XXX_MAX_BUF_SIZE) {
+		LOG_ERR("buf_write_received: len %u exceeds capture buffer (%d), truncating", len,
+			CONFIG_I2C_TARGET_IT51XXX_MAX_BUF_SIZE);
+		len = CONFIG_I2C_TARGET_IT51XXX_MAX_BUF_SIZE;
+	}
+
+	memcpy(state.write_buf, ptr, len);
+	state.write_len = len;
+}
+
+static int target_buf_read_requested(struct i2c_target_config *cfg, uint8_t **ptr, uint32_t *len)
+{
+	ARG_UNUSED(cfg);
+
+	*ptr = state.read_buf;
+	*len = (uint32_t)state.read_len;
+
+	return 0;
+}
+#endif
+
+static int target_stop(struct i2c_target_config *cfg)
+{
+	ARG_UNUSED(cfg);
+
+	return 0;
+}
+
+static const struct i2c_target_callbacks test_target_callbacks = {
+	.write_requested = target_write_requested,
+	.write_received = target_write_received,
+	.read_requested = target_read_requested,
+	.read_processed = target_read_processed,
+#ifdef CONFIG_I2C_TARGET_BUFFER_MODE
+	.buf_write_received = target_buf_write_received,
+	.buf_read_requested = target_buf_read_requested,
+#endif
+	.stop = target_stop,
+};
+
+int test_target_start(const struct device *bus)
+{
+	int ret;
+
+	if (!device_is_ready(bus)) {
+		LOG_ERR("I2C target bus %s not ready", bus->name);
+		return -ENODEV;
+	}
+
+	memset(&state, 0, sizeof(state));
+	state.bus = bus;
+	state.cfg.address = SMBUS_TEST_TARGET_ADDR;
+	state.cfg.callbacks = &test_target_callbacks;
+
+	ret = i2c_target_register(bus, &state.cfg);
+	if (ret == 0) {
+		state.registered = true;
+	} else {
+		LOG_ERR("i2c_target_register failed: %d", ret);
+	}
+
+	return ret;
+}
+
+int test_target_stop(void)
+{
+	int ret;
+
+	if (!state.registered) {
+		return 0;
+	}
+
+	ret = i2c_target_unregister(state.bus, &state.cfg);
+	if (ret == 0) {
+		state.registered = false;
+	}
+
+	return ret;
+}
+
+void test_target_reset(void)
+{
+	state.write_len = 0;
+	state.read_len = 0;
+}
+
+size_t test_target_write_len(void)
+{
+	return state.write_len;
+}
+
+const uint8_t *test_target_write_buf(void)
+{
+	return state.write_buf;
+}
+
+void test_target_set_read_data(const uint8_t *data, size_t len)
+{
+	size_t copy_len = MIN(len, CONFIG_I2C_TARGET_IT51XXX_MAX_BUF_SIZE);
+
+	if (data != NULL && copy_len > 0) {
+		memcpy(state.read_buf, data, copy_len);
+	}
+
+	state.read_len = copy_len;
+}

--- a/tests/drivers/smbus/smbus_it51xxx/src/i2c_target.h
+++ b/tests/drivers/smbus/smbus_it51xxx/src/i2c_target.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SMBUS_TEST_I2C_TARGET_H_
+#define SMBUS_TEST_I2C_TARGET_H_
+
+#include <zephyr/device.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* 7-bit target address used by the test target on i2c1 */
+#define SMBUS_TEST_TARGET_ADDR 0x52
+
+/* Register the test target on @p bus */
+int test_target_start(const struct device *bus);
+
+/* Unregister the test target. Safe to call even if not registered */
+int test_target_stop(void);
+
+/* Clear captured write data, the preloaded read queue, and all counters */
+void test_target_reset(void);
+
+/* Number of bytes captured during the most recent write-direction phase */
+size_t test_target_write_len(void);
+
+/* Captured write-direction bytes; valid until the next reset/transaction */
+const uint8_t *test_target_write_buf(void);
+
+/* Preload the bytes to hand back on the next read-direction phase */
+void test_target_set_read_data(const uint8_t *data, size_t len);
+
+#endif /* SMBUS_TEST_I2C_TARGET_H_ */

--- a/tests/drivers/smbus/smbus_it51xxx/src/main.c
+++ b/tests/drivers/smbus/smbus_it51xxx/src/main.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/ztest.h>
+
+LOG_MODULE_REGISTER(smbus_it51xxx_test, LOG_LEVEL_INF);
+
+static const struct device *const smbus_host_dev = DEVICE_DT_GET(DT_ALIAS(smbus_host));
+static const struct device *const smbus_target_bus_dev = DEVICE_DT_GET(DT_ALIAS(i2c_target));
+
+/* Pure bring-up checks */
+ZTEST(smbus_device, test_devices_ready)
+{
+	zassert_true(device_is_ready(smbus_host_dev), "SMBus host device %s not ready",
+		     smbus_host_dev->name);
+	zassert_true(device_is_ready(smbus_target_bus_dev), "I2C target bus device %s not ready",
+		     smbus_target_bus_dev->name);
+}
+
+ZTEST_SUITE(smbus_device, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/smbus/smbus_it51xxx/src/smbus_host_test.c
+++ b/tests/drivers/smbus/smbus_it51xxx/src/smbus_host_test.c
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2026 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/smbus.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/ztest.h>
+
+#include "i2c_target.h"
+
+LOG_MODULE_REGISTER(smbus_api_test, LOG_LEVEL_INF);
+
+/*
+ * Functional coverage for smbus_ite_it51xxx.c against a real it51xxx_evb:
+ *   host   = smbus2 (channel C)
+ *   target = i2c0   (channel A), driven directly by i2c_target.c
+ *
+ * Test groups:
+ *   - protocol coverage: one test per SMBus API entry point
+ *   - error paths: address NACK, invalid block params, target NACK
+ */
+
+static const struct device *const host = DEVICE_DT_GET(DT_ALIAS(smbus_host));
+static const struct device *const target_bus = DEVICE_DT_GET(DT_ALIAS(i2c_target));
+
+/* Address with no target registered on the bus, for NACK/error-path tests */
+#define SMBUS_TEST_UNUSED_ADDR 0x70
+
+#define SMBUS_HOST_NOTIFY_MAX_PORT 2
+
+/* Suite setup / before/ after / teardown */
+static void *smbus_api_setup(void)
+{
+	int ret;
+
+	zassert_true(device_is_ready(host), "SMBus host %s not ready", host->name);
+
+	ret = test_target_start(target_bus);
+	zassert_equal(ret, 0, "test_target_start failed: %d", ret);
+
+	ret = smbus_configure(host, SMBUS_MODE_CONTROLLER);
+	zassert_equal(ret, 0, "smbus_configure(CONTROLLER) failed: %d", ret);
+
+	return NULL;
+}
+
+static void smbus_api_before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	test_target_reset();
+}
+
+static void smbus_api_after(void *fixture)
+{
+	ARG_UNUSED(fixture);
+
+	/* Force config back to plain controller mode (no PEC, no Host Notify) after every test */
+	(void)smbus_configure(host, SMBUS_MODE_CONTROLLER);
+}
+
+static void smbus_api_teardown(void *fixture)
+{
+	ARG_UNUSED(fixture);
+	(void)test_target_stop();
+}
+
+ZTEST_SUITE(smbus_api, NULL, smbus_api_setup, smbus_api_before, smbus_api_after,
+	    smbus_api_teardown);
+
+/* Protocol coverage test */
+ZTEST(smbus_api, test_quick_write)
+{
+	int ret = smbus_quick(host, SMBUS_TEST_TARGET_ADDR, SMBUS_MSG_WRITE);
+
+	zassert_equal(ret, 0, "smbus_quick(WRITE) failed: %d", ret);
+	/* Quick has no data */
+	zassert_equal(test_target_write_len(), 0, "unexpected data on Quick command");
+}
+
+ZTEST(smbus_api, test_byte_write)
+{
+	int ret = smbus_byte_write(host, SMBUS_TEST_TARGET_ADDR, 0xa5);
+
+	zassert_equal(ret, 0, "smbus_byte_write failed: %d", ret);
+	zassert_equal(test_target_write_len(), 1, "wrong byte count");
+	zassert_equal(test_target_write_buf()[0], 0xa5, "wrong byte value");
+}
+
+ZTEST(smbus_api, test_byte_read)
+{
+	int ret;
+	uint8_t preload[] = {0x5a};
+	uint8_t val = 0;
+
+	test_target_set_read_data(preload, sizeof(preload));
+
+	ret = smbus_byte_read(host, SMBUS_TEST_TARGET_ADDR, &val);
+
+	zassert_equal(ret, 0, "smbus_byte_read failed: %d", ret);
+	zassert_equal(val, 0x5a, "wrong byte value read back");
+}
+
+ZTEST(smbus_api, test_byte_data_write)
+{
+	int ret = smbus_byte_data_write(host, SMBUS_TEST_TARGET_ADDR, 0x10, 0x77);
+
+	zassert_equal(ret, 0, "smbus_byte_data_write failed: %d", ret);
+	zassert_equal(test_target_write_len(), 2, "wrong byte count");
+	zassert_equal(test_target_write_buf()[0], 0x10, "wrong command byte");
+	zassert_equal(test_target_write_buf()[1], 0x77, "wrong data byte");
+}
+
+ZTEST(smbus_api, test_byte_data_read)
+{
+	int ret;
+	uint8_t preload[] = {0x99};
+	uint8_t val = 0;
+
+	test_target_set_read_data(preload, sizeof(preload));
+
+	ret = smbus_byte_data_read(host, SMBUS_TEST_TARGET_ADDR, 0x20, &val);
+
+	zassert_equal(ret, 0, "smbus_byte_data_read failed: %d", ret);
+	zassert_equal(val, 0x99, "wrong data byte read back");
+	zassert_equal(test_target_write_len(), 1, "wrong command-phase length");
+	zassert_equal(test_target_write_buf()[0], 0x20, "wrong command byte");
+}
+
+ZTEST(smbus_api, test_word_data_write)
+{
+	int ret = smbus_word_data_write(host, SMBUS_TEST_TARGET_ADDR, 0x30, 0x1234);
+
+	zassert_equal(ret, 0, "smbus_word_data_write failed: %d", ret);
+	zassert_equal(test_target_write_len(), 3, "wrong byte count");
+	zassert_equal(test_target_write_buf()[0], 0x30, "wrong command byte");
+	zassert_equal(test_target_write_buf()[1], 0x34, "wrong LSB");
+	zassert_equal(test_target_write_buf()[2], 0x12, "wrong MSB");
+}
+
+ZTEST(smbus_api, test_word_data_read)
+{
+	int ret;
+	uint16_t word = 0;
+	/* LSB, MSB -> 0x5678 */
+	uint8_t preload[] = {0x78, 0x56};
+
+	test_target_set_read_data(preload, sizeof(preload));
+
+	ret = smbus_word_data_read(host, SMBUS_TEST_TARGET_ADDR, 0x40, &word);
+
+	zassert_equal(ret, 0, "smbus_word_data_read failed: %d", ret);
+	zassert_equal(word, 0x5678, "wrong word read back");
+}
+
+ZTEST(smbus_api, test_pcall)
+{
+	int ret;
+	uint16_t recv = 0;
+	/* LSB, MSB -> 0xbeef */
+	uint8_t preload[] = {0xef, 0xbe};
+
+	test_target_set_read_data(preload, sizeof(preload));
+
+	ret = smbus_pcall(host, SMBUS_TEST_TARGET_ADDR, 0x50, 0xcafe, &recv);
+
+	zassert_equal(ret, 0, "smbus_pcall failed: %d", ret);
+	zassert_equal(recv, 0xbeef, "wrong process-call response");
+	zassert_equal(test_target_write_len(), 3, "wrong write-phase length");
+	zassert_equal(test_target_write_buf()[0], 0x50, "wrong command byte");
+	zassert_equal(test_target_write_buf()[1], 0xfe, "wrong sent LSB");
+	zassert_equal(test_target_write_buf()[2], 0xca, "wrong sent MSB");
+}
+
+ZTEST(smbus_api, test_block_write)
+{
+	int ret;
+	uint8_t block[SMBUS_BLOCK_BYTES_MAX - 1];
+
+	for (int i = 0; i < SMBUS_BLOCK_BYTES_MAX - 1; i++) {
+		block[i] = (uint8_t)(0xc0 + i);
+	}
+
+	ret = smbus_block_write(host, SMBUS_TEST_TARGET_ADDR, 0x60, sizeof(block), block);
+
+	zassert_equal(ret, 0, "smbus_block_write failed: %d", ret);
+	/* Wire order: [cmd, count, data...] */
+	zassert_equal(test_target_write_len(), 2 + sizeof(block), "wrong byte count");
+	zassert_equal(test_target_write_buf()[0], 0x60, "wrong command byte");
+	zassert_equal(test_target_write_buf()[1], sizeof(block), "wrong byte-count field");
+	zassert_mem_equal(&test_target_write_buf()[2], block, sizeof(block), "wrong block data");
+}
+
+ZTEST(smbus_api, test_block_read)
+{
+	int ret;
+	/* [count, data...] as the SMBus Block Read wire format expects */
+	uint8_t preload[SMBUS_BLOCK_BYTES_MAX];
+	uint8_t out_buf[SMBUS_BLOCK_BYTES_MAX];
+	uint8_t out_count = 0;
+
+	preload[0] = SMBUS_BLOCK_BYTES_MAX - 1;
+	for (int i = 1; i < SMBUS_BLOCK_BYTES_MAX; i++) {
+		preload[i] = (uint8_t)(0xa0 + i);
+	}
+	test_target_set_read_data(preload, sizeof(preload));
+
+	ret = smbus_block_read(host, SMBUS_TEST_TARGET_ADDR, 0x70, &out_count, out_buf);
+
+	zassert_equal(ret, 0, "smbus_block_read failed: %d", ret);
+	zassert_equal(out_count, SMBUS_BLOCK_BYTES_MAX - 1, "wrong reported byte count");
+	zassert_mem_equal(out_buf, &preload[1], SMBUS_BLOCK_BYTES_MAX - 1,
+			  "wrong block data read back");
+	/* Write phase of Block Read is just the command byte */
+	zassert_equal(test_target_write_len(), 1, "wrong command-phase length");
+	zassert_equal(test_target_write_buf()[0], 0x70, "wrong command byte");
+}
+
+ZTEST(smbus_api, test_block_pcall_not_supported)
+{
+	int ret;
+	uint8_t snd[] = {0x01};
+	uint8_t rcv[SMBUS_BLOCK_BYTES_MAX];
+	uint8_t rcv_count = 0;
+
+	ret = smbus_block_pcall(host, SMBUS_TEST_TARGET_ADDR, 0x80, sizeof(snd), snd, &rcv_count,
+				rcv);
+
+	/* smbus_it51xxx_block_pcall() is not currently supported */
+	zassert_equal(ret, -ENOSYS, "expected -ENOSYS, got %d", ret);
+}
+
+/* Generic API-contract / error paths */
+ZTEST(smbus_api, test_get_config_null)
+{
+	int ret = smbus_get_config(host, NULL);
+
+	zassert_equal(ret, -EIO, "expected -EIO for NULL config pointer, got %d", ret);
+}
+
+ZTEST(smbus_api, test_error_address_nack)
+{
+	/* No target registered at this address: expect a NACK -> -EIO */
+	int ret = smbus_byte_write(host, SMBUS_TEST_UNUSED_ADDR, 0x00);
+
+	zassert_equal(ret, -EIO, "expected -EIO addressing an absent peripheral, got %d", ret);
+}
+
+ZTEST(smbus_api, test_error_block_write_invalid_count)
+{
+	uint8_t buf[1] = {0};
+	int ret;
+
+	/* count == 0 and count > SMBUS_BLOCK_BYTES_MAX */
+	ret = smbus_block_write(host, SMBUS_TEST_TARGET_ADDR, 0x60, 0, buf);
+	zassert_equal(ret, -EINVAL, "expected -EINVAL for count=0, got %d", ret);
+
+	ret = smbus_block_write(host, SMBUS_TEST_TARGET_ADDR, 0x60, SMBUS_BLOCK_BYTES_MAX + 1, buf);
+	zassert_equal(ret, -EINVAL, "expected -EINVAL for count>max, got %d", ret);
+}
+
+ZTEST(smbus_api, test_error_block_write_null_buf)
+{
+	/*
+	 * A valid count with a NULL buffer passes the subsystem-level check
+	 * but is rejected by the driver itself.
+	 */
+	int ret = smbus_block_write(host, SMBUS_TEST_TARGET_ADDR, 0x60, 4, NULL);
+
+	zassert_equal(ret, -EIO, "expected -EIO for NULL buffer, got %d", ret);
+}

--- a/tests/drivers/smbus/smbus_it51xxx/tests.yaml
+++ b/tests/drivers/smbus/smbus_it51xxx/tests.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+common:
+  tags:
+    - drivers
+    - smbus
+    - i2c
+  harness: ztest
+tests:
+  drivers.smbus.it51xxx:
+    platform_allow:
+      - it51xxx_evb/it51526aw


### PR DESCRIPTION
Add SMBus support for the it51xxx series, including:

- The driver supports up to nine SMBus controllers and implements the standard SMBus protocols, except for Block Process Call. An optional FIFO mode using the controller's dedicated 32-byte FIFOs to reduce the interval between transferred bytes and improve clock stretching.
- A shell command for issuing SMBus Process Call transactions.
- A test suite that verifies SMBus transactions using the on-chip I2C target driver.