### PR TITLE
Bluetooth: TBS: Use MUTEX_TIMEOUT instead of K_FOREVER

### DIFF
--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -1436,7 +1436,7 @@ static void current_calls_cfg_changed(const struct bt_gatt_attr *attr, uint16_t 
 	LOG_DBG("Index %u: value 0x%04x", inst_index(inst), value);
 
 	if (value == 0U) {
-		int err = k_mutex_lock(&tbs_mutex, K_FOREVER);
+		int err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 
 		if (err != 0) {
 			LOG_DBG("Failed to lock mutex: %d", err);
@@ -1631,7 +1631,7 @@ static void call_state_cfg_changed(const struct bt_gatt_attr *attr, uint16_t val
 	LOG_DBG("Index %u: value 0x%04x", inst_index(inst), value);
 
 	if (value == 0U) {
-		int err = k_mutex_lock(&tbs_mutex, K_FOREVER);
+		int err = k_mutex_lock(&tbs_mutex, MUTEX_TIMEOUT);
 
 		if (err != 0) {
 			LOG_DBG("Failed to lock mutex: %d", err);


### PR DESCRIPTION
Two CCC callbacks used K_FOREVER instead of MUTEX_TIMEOUT as the mutex timeout. Change to be consistent and to avoid blocking everything in case that it could not lock the mutex.