### PR TITLE
samples: bluetooth: peripheral_esp: add overlay for kit_pse84_eval

### DIFF
--- a/samples/bluetooth/peripheral_esp/boards/kit_pse84_eval_m33.overlay
+++ b/samples/bluetooth/peripheral_esp/boards/kit_pse84_eval_m33.overlay
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		die-temp0 = &bosch_bmi270;
+	};
+};


### PR DESCRIPTION
Add a board-specific devicetree overlay for the Infineon kit_pse84_eval to support the Bluetooth Environmental Sensing Profile (ESP) sample.

This overlay aliases the `die-temp0` node to the onboard Bosch BMI270 IMU, which features an integrated temperature sensor.