### PR TITLE
net: dhcpv4: fix slow INIT-REBOOT fallback on a network change

### DIFF
--- a/subsys/net/lib/dhcpv4/Kconfig
+++ b/subsys/net/lib/dhcpv4/Kconfig
@@ -121,6 +121,24 @@ config NET_DHCPV4_INIT_REBOOT
 	  been assigned an address before, it begins in INIT-REBOOT state and
 	  sends a DHCPREQUEST message.
 
+config NET_DHCPV4_INIT_REBOOT_ATTEMPTS
+	int "Number of INIT-REBOOT REQUEST attempts before falling back to DISCOVER"
+	depends on NET_DHCPV4_INIT_REBOOT
+	range 1 $(UINT8_MAX)
+	default 1
+	help
+	  Number of times the DHCPv4 client sends the INIT-REBOOT DHCPREQUEST for
+	  a remembered address before giving up and restarting the configuration
+	  with a full DHCPDISCOVER. INIT-REBOOT is meant as an optimistic fast probe:
+	  on a network change many access points silently drop the foreign-subnet
+	  REQUEST instead of NAKing it, so a low value keeps the resulting
+	  fall-back to DISCOVER quick. Per RFC 2131 4.1 the retransmit backoff is
+	  exponential (4 s, 8 s, 16 s, ...), so each extra attempt roughly doubles
+	  the worst-case delay before DISCOVER: 1 falls back fastest (~4 s), while a
+	  higher value tolerates lost packets on the same network at the cost of a
+	  slower fall-back. To disable INIT-REBOOT entirely, disable
+	  CONFIG_NET_DHCPV4_INIT_REBOOT instead.
+
 config NET_DHCPV4_RESTART_ON_IF_UP
 	bool
 	default n if WIFI_NM_WPA_SUPPLICANT

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1848,6 +1848,13 @@ static void dhcpv4_start_internal(struct net_if *iface, bool first_start)
 		NET_DBG("iface %p state=%s", iface,
 			net_dhcpv4_state_name(iface->config.dhcpv4.state));
 
+		/* A fresh (re)start must not inherit a retransmit count left
+		 * over from a previous binding or an aborted cycle, otherwise
+		 * the backoff starts too high or the client falls straight
+		 * through to DISCOVER.
+		 */
+		iface->config.dhcpv4.attempts = 0U;
+
 		/* We need entropy for both an XID and a random delay
 		 * before sending the initial discover message.
 		 */

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1867,12 +1867,14 @@ static void dhcpv4_start_internal(struct net_if *iface, bool first_start)
 		 */
 		iface->config.dhcpv4.xid = entropy;
 
-		/* Use default */
-		if (first_start) {
-			/* RFC2131 4.4.1 requires we wait a random period
-			 * between 1 and 10 seconds before sending the initial
-			 * discover.
-			 */
+		/* RFC2131 4.4.1 requires we wait a random period between 1 and
+		 * 10 seconds before sending the initial discover. This desync
+		 * delay applies to the initial DISCOVER only; an INIT-REBOOT
+		 * re-REQUEST of a known address is an optimistic fast probe
+		 * (RFC2131 3.2), so skip the delay in that state.
+		 */
+		if (first_start &&
+		    iface->config.dhcpv4.state == NET_DHCPV4_INIT) {
 			timeout = entropy % (CONFIG_NET_DHCPV4_INITIAL_DELAY_MAX -
 					DHCPV4_INITIAL_DELAY_MIN) + DHCPV4_INITIAL_DELAY_MIN;
 		}

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -811,6 +811,20 @@ static uint32_t dhcpv4_manage_timers(struct net_if *iface, int64_t now)
 		/* Failed to get OFFER message, send DISCOVER again */
 		return dhcpv4_send_discover(iface);
 	case NET_DHCPV4_INIT_REBOOT:
+		/* INIT-REBOOT is an optimistic fast probe (RFC2131 3.2). If the
+		 * remembered address is not confirmed within a tight retransmit
+		 * budget (e.g. the interface moved to a different network whose
+		 * server silently drops the foreign-subnet REQUEST), fall back
+		 * to a full DISCOVER instead of burning the whole schedule.
+		 */
+		if (iface->config.dhcpv4.attempts >=
+					DHCPV4_INIT_REBOOT_MAX_ATTEMPTS) {
+			NET_DBG("INIT-REBOOT unanswered, restart with discover");
+			dhcpv4_enter_selecting(iface);
+			return dhcpv4_send_discover(iface);
+		}
+
+		return dhcpv4_send_request(iface);
 	case NET_DHCPV4_REQUESTING:
 		/* Maximum number of renewal attempts failed, so start
 		 * from the beginning.

--- a/subsys/net/lib/dhcpv4/dhcpv4_internal.h
+++ b/subsys/net/lib/dhcpv4/dhcpv4_internal.h
@@ -93,6 +93,14 @@ struct dhcp_msg {
 /* Maximum number of REQUEST retransmits before reverting to DISCOVER. */
 #define DHCPV4_MAX_NUMBER_OF_ATTEMPTS	3
 
+/* Maximum number of INIT-REBOOT REQUEST retransmits before reverting to DISCOVER */
+#ifdef CONFIG_NET_DHCPV4_INIT_REBOOT_ATTEMPTS
+#define DHCPV4_INIT_REBOOT_MAX_ATTEMPTS	CONFIG_NET_DHCPV4_INIT_REBOOT_ATTEMPTS
+#else
+/* INIT-REBOOT support is disabled; the state is never entered. */
+#define DHCPV4_INIT_REBOOT_MAX_ATTEMPTS	0
+#endif
+
 /* Initial message retry timeout (s).  This timeout increases
  * exponentially on each retransmit.
  * RFC2131 4.1

--- a/tests/net/dhcpv4/client/src/main.c
+++ b/tests/net/dhcpv4/client/src/main.c
@@ -341,6 +341,8 @@ static bool discover_req_included_dns;
 static bool init_reboot_req_included_dns;
 static bool init_reboot_request_seen;
 static bool reject_init_reboot;
+static bool drop_init_reboot;
+static uint8_t init_reboot_request_count;
 
 #define EVT_ADDR_ADD        BIT(0)
 #define EVT_ADDR_DEL        BIT(1)
@@ -376,6 +378,8 @@ static void dhcp_test_reset_iface(struct net_if *iface)
 	init_reboot_req_included_dns = false;
 	init_reboot_request_seen = false;
 	reject_init_reboot = false;
+	drop_init_reboot = false;
+	init_reboot_request_count = 0U;
 }
 
 static void dhcpv4_tests_before(void *fixture)
@@ -696,6 +700,18 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 		dns_requested = dhcp_msg_req_list_contains(&msg, OPTION_DNS_SERVER);
 		is_init_reboot = msg.has_requested_ip && !msg.has_server_id;
 		init_reboot_request_seen |= is_init_reboot;
+		if (is_init_reboot) {
+			init_reboot_request_count++;
+		}
+
+		if (drop_init_reboot && is_init_reboot) {
+			/* Emulate a server (e.g. on a different network) that
+			 * silently ignores the foreign-subnet REQUEST instead of
+			 * NAKing it, forcing the client to time out and fall back
+			 * to DISCOVER.
+			 */
+			return 0;
+		}
 
 		if (strict_dhcp_server && is_init_reboot) {
 			init_reboot_req_included_dns = dns_requested;
@@ -1102,6 +1118,49 @@ ZTEST(dhcpv4_tests, test_init_reboot_nak_restarts_discovery)
 	evt = k_event_wait_all(&events, EVT_DHCP_OFFER | EVT_DHCP_ACK, false, WAIT_TIME);
 	zassert_equal(evt, EVT_DHCP_OFFER | EVT_DHCP_ACK,
 		      "INIT-REBOOT NAK did not restart discovery %08x", evt);
+
+	net_dhcpv4_stop(iface);
+}
+
+ZTEST(dhcpv4_tests, test_init_reboot_unanswered_falls_back_to_discover)
+{
+	/* Worst-case INIT-REBOOT backoff is 4 + 8 + ... = 4 * (2^N - 1) seconds
+	 * for N attempts, plus per-attempt randomisation and the follow-up
+	 * DISCOVER round. native_sim fast-forwards idle time, so this large
+	 * timeout costs no wall-clock.
+	 */
+	const struct net_in_addr requested_ip = {{{10, 237, 72, 158}}};
+	const k_timeout_t fallback_wait = K_SECONDS(
+		4 * (BIT(DHCPV4_INIT_REBOOT_MAX_ATTEMPTS) - 1) +
+		DHCPV4_INIT_REBOOT_MAX_ATTEMPTS + 5);
+	struct net_if *iface;
+	uint32_t evt;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_DHCPV4_INIT_REBOOT);
+
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY));
+	zassert_not_null(iface, "Interface not available");
+
+	/* Emulate a network change: a stale lease drives INIT-REBOOT, but the
+	 * new network's server silently drops the foreign-subnet REQUEST.
+	 */
+	zassert_ok(net_dhcpv4_set_reboot_hint(iface, &requested_ip));
+	drop_init_reboot = true;
+
+	net_dhcpv4_start(iface);
+
+	/* An OFFER is only produced in response to a DISCOVER, so its arrival
+	 * proves the client abandoned INIT-REBOOT and restarted configuration
+	 * rather than retransmitting the REQUEST for the full attempt budget.
+	 */
+	evt = k_event_wait_all(&events, EVT_DHCP_OFFER | EVT_DHCP_ACK, false,
+			       fallback_wait);
+	zassert_equal(evt, EVT_DHCP_OFFER | EVT_DHCP_ACK,
+		      "Unanswered INIT-REBOOT did not fall back to DISCOVER %08x", evt);
+	zassert_true(init_reboot_request_seen, "INIT-REBOOT REQUEST was not sent");
+	zassert_equal(init_reboot_request_count, DHCPV4_INIT_REBOOT_MAX_ATTEMPTS,
+		      "Expected %d INIT-REBOOT attempt(s) before fallback, got %d",
+		      DHCPV4_INIT_REBOOT_MAX_ATTEMPTS, init_reboot_request_count);
 
 	net_dhcpv4_stop(iface);
 }

--- a/tests/net/dhcpv4/client/tests.yaml
+++ b/tests/net/dhcpv4/client/tests.yaml
@@ -1,5 +1,7 @@
 common:
   depends_on: netif
+  platform_allow:
+    - native_sim
   tags:
     - net
     - dhcpv4


### PR DESCRIPTION
With `CONFIG_NET_DHCPV4_INIT_REBOOT=y` (default enabled), a DHCPv4 client that moves to a different network (the common Wi-Fi flow where the driver calls `net_dhcpv4_stop()` on disconnect and `net_dhcpv4_start()` on the new association) re-enters `INIT-REBOOT` for the previous lease and can burn 25–35 s before it finally falls back to `DISCOVER` and binds on the new network. Many consumer APs silently drop the foreign-subnet REQUEST instead of NAKing it, so the client only recovers after exhausting the full retransmission schedule.

This series bounds `INIT-REBOOT` to a short, RFC-aligned probe so a network change recovers in a few seconds, while preserving the same-network fast path.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/114794