### PR TITLE
dts: bindings: add timebase-frequency to cpu.yaml

### DIFF
--- a/dts/bindings/cpu/cpu.yaml
+++ b/dts/bindings/cpu/cpu.yaml
@@ -16,6 +16,11 @@ properties:
   clock-frequency:
     type: int
     description: Clock frequency in Hz
+  timebase-frequency:
+    type: int
+    description: |
+      Specifies the current frequency in Hertz at which the
+      timebase and decrementer registers are updated
   cpu-power-states:
     type: phandles
     description: List of power management states supported by this cpu

--- a/dts/bindings/cpu/openhwgroup,cva6.yaml
+++ b/dts/bindings/cpu/openhwgroup,cva6.yaml
@@ -10,5 +10,4 @@ include: riscv-common.yaml
 properties:
   timebase-frequency:
     required: true
-    type: int
     description: Clock speed at which the core-local machine timer operates.


### PR DESCRIPTION
timebase-frequency is a optional prop for
/cpus/cpu* nodes according to the devicetree spec, so add it to cpu.yaml.