### PR TITLE
Bluetooth: Audio: Rename bt_bap_stream_ops fields to align with ASE states

### DIFF
--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -840,6 +840,13 @@ Bluetooth Audio
     :zephyr:code-sample:`bluetooth_bap_unicast_client` and
     :zephyr:code-sample:`bluetooth_bap_unicast_server` have been moved from
     :zephyr_file:`samples/bluetooth/` to :zephyr_file:`samples/bluetooth/audio`.
+  * ``bt_bap_stream_ops.configured`` has been renamed to
+    :c:member:`bt_bap_stream_ops.codec_configured` and ``bt_bap_stream_ops.qos_set`` has been
+    renamed to :c:member:`bt_bap_stream_ops.qos_configured`, to align the names with the ASE states
+    defined by the ASCS specification. The callback signatures and the conditions where they are
+    called are unchanged, so applications only need to do a search-and-replace from ``configured``
+    to ``codec_configured`` and from ``qos_set`` to ``qos_configured`` where the callbacks are
+    assigned. (:github:`114835`)
 
 * CAP
 

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -753,24 +753,26 @@ struct bt_bap_stream {
 struct bt_bap_stream_ops {
 #if defined(CONFIG_BT_BAP_UNICAST) || defined(__DOXYGEN__)
 	/**
-	 * @brief Stream configured callback
+	 * @brief Stream codec configured callback
 	 *
-	 * Configured callback is called whenever an Audio Stream has been configured.
+	 * Codec configured callback is called whenever an Audio Stream has been configured with a
+	 * codec configuration.
 	 *
 	 * @param stream Stream object that has been configured.
 	 * @param pref   Remote QoS preferences.
 	 */
-	void (*configured)(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg_pref *pref);
+	void (*codec_configured)(struct bt_bap_stream *stream,
+				 const struct bt_bap_qos_cfg_pref *pref);
 
 	/**
-	 * @brief Stream QoS set callback
+	 * @brief Stream QoS configured callback
 	 *
-	 * QoS set callback is called whenever an Audio Stream Quality of Service has been set or
-	 * updated.
+	 * QoS configured callback is called whenever an Audio Stream Quality of Service has been
+	 * set or updated.
 	 *
 	 * @param stream Stream object that had its QoS updated.
 	 */
-	void (*qos_set)(struct bt_bap_stream *stream);
+	void (*qos_configured)(struct bt_bap_stream *stream);
 
 	/**
 	 * @brief Stream enabled callback

--- a/samples/bluetooth/audio/bap_unicast_client/src/main.c
+++ b/samples/bluetooth/audio/bap_unicast_client/src/main.c
@@ -217,7 +217,8 @@ static void start_scan(void)
 	printk("Scanning successfully started\n");
 }
 
-static void stream_configured(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg_pref *pref)
+static void stream_codec_configured(struct bt_bap_stream *stream,
+				    const struct bt_bap_qos_cfg_pref *pref)
 {
 	ARG_UNUSED(pref);
 
@@ -226,7 +227,7 @@ static void stream_configured(struct bt_bap_stream *stream, const struct bt_bap_
 	k_sem_give(&sem_stream_configured);
 }
 
-static void stream_qos_set(struct bt_bap_stream *stream)
+static void stream_qos_configured(struct bt_bap_stream *stream)
 {
 	struct bt_iso_info info;
 	int err;
@@ -341,8 +342,8 @@ static void stream_recv(struct bt_bap_stream *stream,
 }
 
 static struct bt_bap_stream_ops stream_ops = {
-	.configured = stream_configured,
-	.qos_set = stream_qos_set,
+	.codec_configured = stream_codec_configured,
+	.qos_configured = stream_qos_configured,
 	.enabled = stream_enabled,
 	.started = stream_started,
 	.metadata_updated = stream_metadata_updated,

--- a/samples/bluetooth/audio/cap_acceptor/src/cap_acceptor_unicast.c
+++ b/samples/bluetooth/audio/cap_acceptor/src/cap_acceptor_unicast.c
@@ -267,8 +267,8 @@ static const struct bt_bap_unicast_server_cb unicast_server_cb = {
 	.release = unicast_server_release_cb,
 };
 
-static void unicast_stream_configured_cb(struct bt_bap_stream *bap_stream,
-					 const struct bt_bap_qos_cfg_pref *pref)
+static void unicast_stream_codec_configured_cb(struct bt_bap_stream *bap_stream,
+					       const struct bt_bap_qos_cfg_pref *pref)
 {
 	LOG_INF("Configured bap_stream %p", bap_stream);
 
@@ -282,7 +282,7 @@ static void unicast_stream_configured_cb(struct bt_bap_stream *bap_stream,
 		pref->latency, pref->pd_min, pref->pd_max, pref->pref_pd_min, pref->pref_pd_max);
 }
 
-static void unicast_stream_qos_set_cb(struct bt_bap_stream *bap_stream)
+static void unicast_stream_qos_configured_cb(struct bt_bap_stream *bap_stream)
 {
 	LOG_INF("QoS set bap_stream %p", bap_stream);
 }
@@ -427,8 +427,8 @@ static void tx_thread_func(void *arg1, void *arg2, void *arg3)
 int init_cap_acceptor_unicast(struct peer_config *peer)
 {
 	static struct bt_bap_stream_ops unicast_stream_ops = {
-		.configured = unicast_stream_configured_cb,
-		.qos_set = unicast_stream_qos_set_cb,
+		.codec_configured = unicast_stream_codec_configured_cb,
+		.qos_configured = unicast_stream_qos_configured_cb,
 		.enabled = unicast_stream_enabled_cb,
 		.started = unicast_stream_started_cb,
 		.metadata_updated = unicast_stream_metadata_updated_cb,

--- a/samples/bluetooth/audio/cap_handover/src/main.c
+++ b/samples/bluetooth/audio/cap_handover/src/main.c
@@ -101,8 +101,8 @@ static K_SEM_DEFINE(sem_broadcast_stopped, 1U, 1U);
 static K_SEM_DEFINE(sem_receive_state_updated, 0U, 1U);
 static K_SEM_DEFINE(sem_streams, 0U, CAP_STREAM_TX_MAX);
 
-static void stream_configured_cb(struct bt_bap_stream *stream,
-				 const struct bt_bap_qos_cfg_pref *pref)
+static void stream_codec_configured_cb(struct bt_bap_stream *stream,
+				       const struct bt_bap_qos_cfg_pref *pref)
 {
 	LOG_INF("Configured stream %p", stream);
 
@@ -112,7 +112,7 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 		pref->latency, pref->pd_min, pref->pd_max, pref->pref_pd_min, pref->pref_pd_max);
 }
 
-static void stream_qos_set_cb(struct bt_bap_stream *stream)
+static void stream_qos_configured_cb(struct bt_bap_stream *stream)
 {
 	LOG_INF("QoS set stream %p", stream);
 }
@@ -1071,8 +1071,8 @@ static int init_cap_handover(void)
 		.recv = scan_recv_cb,
 	};
 	static struct bt_bap_stream_ops stream_ops = {
-		.configured = stream_configured_cb,
-		.qos_set = stream_qos_set_cb,
+		.codec_configured = stream_codec_configured_cb,
+		.qos_configured = stream_qos_configured_cb,
 		.enabled = stream_enabled_cb,
 		.started = stream_started_cb,
 		.metadata_updated = stream_metadata_updated_cb,

--- a/samples/bluetooth/audio/cap_initiator/src/cap_initiator_unicast.c
+++ b/samples/bluetooth/audio/cap_initiator/src/cap_initiator_unicast.c
@@ -93,8 +93,8 @@ static bool is_tx_stream(struct bt_bap_stream *stream)
 	return ep_info.dir == BT_AUDIO_DIR_SINK;
 }
 
-static void unicast_stream_configured_cb(struct bt_bap_stream *stream,
-					 const struct bt_bap_qos_cfg_pref *pref)
+static void unicast_stream_codec_configured_cb(struct bt_bap_stream *stream,
+					       const struct bt_bap_qos_cfg_pref *pref)
 {
 	LOG_INF("Configured stream %p", stream);
 
@@ -108,7 +108,7 @@ static void unicast_stream_configured_cb(struct bt_bap_stream *stream,
 		pref->latency, pref->pd_min, pref->pd_max, pref->pref_pd_min, pref->pref_pd_max);
 }
 
-static void unicast_stream_qos_set_cb(struct bt_bap_stream *stream)
+static void unicast_stream_qos_configured_cb(struct bt_bap_stream *stream)
 {
 	LOG_INF("QoS set stream %p", stream);
 }
@@ -204,8 +204,8 @@ static void unicast_stream_sent_cb(struct bt_bap_stream *stream)
 }
 
 static struct bt_bap_stream_ops unicast_stream_ops = {
-	.configured = unicast_stream_configured_cb,
-	.qos_set = unicast_stream_qos_set_cb,
+	.codec_configured = unicast_stream_codec_configured_cb,
+	.qos_configured = unicast_stream_qos_configured_cb,
 	.enabled = unicast_stream_enabled_cb,
 	.started = unicast_stream_started_cb,
 	.metadata_updated = unicast_stream_metadata_updated_cb,

--- a/samples/bluetooth/audio/tmap_central/src/cap_initiator.c
+++ b/samples/bluetooth/audio/tmap_central/src/cap_initiator.c
@@ -47,8 +47,8 @@ static K_SEM_DEFINE(sem_discover_sink, 0U, 1U);
 static K_SEM_DEFINE(sem_discover_source, 0U, 1U);
 static K_SEM_DEFINE(sem_audio_start, 0U, 1U);
 
-static void unicast_stream_configured(struct bt_bap_stream *stream,
-				      const struct bt_bap_qos_cfg_pref *pref)
+static void unicast_stream_codec_configured(struct bt_bap_stream *stream,
+					    const struct bt_bap_qos_cfg_pref *pref)
 {
 	ARG_UNUSED(pref);
 
@@ -59,7 +59,7 @@ static void unicast_stream_configured(struct bt_bap_stream *stream,
 	 */
 }
 
-static void unicast_stream_qos_set(struct bt_bap_stream *stream)
+static void unicast_stream_qos_configured(struct bt_bap_stream *stream)
 {
 	printk("QoS set stream %p\n", stream);
 }
@@ -100,8 +100,8 @@ static void unicast_stream_released(struct bt_bap_stream *stream)
 }
 
 static struct bt_bap_stream_ops unicast_stream_ops = {
-	.configured = unicast_stream_configured,
-	.qos_set = unicast_stream_qos_set,
+	.codec_configured = unicast_stream_codec_configured,
+	.qos_configured = unicast_stream_qos_configured,
 	.enabled = unicast_stream_enabled,
 	.started = unicast_stream_started,
 	.metadata_updated = unicast_stream_metadata_updated,

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -334,8 +334,8 @@ static void ase_enter_state_codec_configured(struct bt_ascs_ase *ase)
 	stream->iso = NULL;
 
 	ops = stream->ops;
-	if (ops != NULL && ops->configured != NULL) {
-		ops->configured(stream, &ase->ep.qos_pref);
+	if (ops != NULL && ops->codec_configured != NULL) {
+		ops->codec_configured(stream, &ase->ep.qos_pref);
 	}
 }
 
@@ -349,8 +349,8 @@ static void ase_enter_state_qos_configured(struct bt_ascs_ase *ase)
 	ase->ep.receiver_ready = false;
 
 	ops = stream->ops;
-	if (ops != NULL && ops->qos_set != NULL) {
-		ops->qos_set(stream);
+	if (ops != NULL && ops->qos_configured != NULL) {
+		ops->qos_configured(stream);
 	}
 }
 

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -1239,10 +1239,10 @@ static void unicast_client_ep_notify_app(struct bt_bap_stream *stream, bool stat
 	case BT_BAP_EP_STATE_CODEC_CONFIGURED:
 
 		/* Notify upper layer */
-		if (ops->configured != NULL) {
-			ops->configured(stream, &stream->ep->qos_pref);
+		if (ops->codec_configured != NULL) {
+			ops->codec_configured(stream, &stream->ep->qos_pref);
 		} else {
-			LOG_WRN("No callback for configured set");
+			LOG_WRN("No callback for codec_configured set");
 		}
 		break;
 	case BT_BAP_EP_STATE_QOS_CONFIGURED:
@@ -1271,10 +1271,10 @@ static void unicast_client_ep_notify_app(struct bt_bap_stream *stream, bool stat
 			__ASSERT(false, "Invalid dir: %d", dir);
 		}
 
-		if (ops->qos_set != NULL) {
-			ops->qos_set(stream);
+		if (ops->qos_configured != NULL) {
+			ops->qos_configured(stream);
 		} else {
-			LOG_WRN("No callback for qos_set set");
+			LOG_WRN("No callback for qos_configured set");
 		}
 		break;
 	case BT_BAP_EP_STATE_ENABLING:

--- a/subsys/bluetooth/audio/cap_stream.c
+++ b/subsys/bluetooth/audio/cap_stream.c
@@ -47,8 +47,8 @@ static bool stream_is_central(struct bt_bap_stream *bap_stream)
 }
 
 #if defined(CONFIG_BT_BAP_UNICAST)
-static void cap_stream_configured_cb(struct bt_bap_stream *bap_stream,
-				     const struct bt_bap_qos_cfg_pref *pref)
+static void cap_stream_codec_configured_cb(struct bt_bap_stream *bap_stream,
+					   const struct bt_bap_qos_cfg_pref *pref)
 {
 	struct bt_cap_stream *cap_stream = CONTAINER_OF(bap_stream,
 							struct bt_cap_stream,
@@ -57,8 +57,8 @@ static void cap_stream_configured_cb(struct bt_bap_stream *bap_stream,
 
 	LOG_DBG("%p", cap_stream);
 
-	if (ops != NULL && ops->configured != NULL) {
-		ops->configured(bap_stream, pref);
+	if (ops != NULL && ops->codec_configured != NULL) {
+		ops->codec_configured(bap_stream, pref);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
@@ -67,7 +67,7 @@ static void cap_stream_configured_cb(struct bt_bap_stream *bap_stream,
 	}
 }
 
-static void cap_stream_qos_set_cb(struct bt_bap_stream *bap_stream)
+static void cap_stream_qos_configured_cb(struct bt_bap_stream *bap_stream)
 {
 	struct bt_cap_stream *cap_stream = CONTAINER_OF(bap_stream,
 							struct bt_cap_stream,
@@ -76,8 +76,8 @@ static void cap_stream_qos_set_cb(struct bt_bap_stream *bap_stream)
 
 	LOG_DBG("%p", cap_stream);
 
-	if (ops != NULL && ops->qos_set != NULL) {
-		ops->qos_set(bap_stream);
+	if (ops != NULL && ops->qos_configured != NULL) {
+		ops->qos_configured(bap_stream);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CAP_INITIATOR) && IS_ENABLED(CONFIG_BT_BAP_UNICAST_CLIENT) &&
@@ -262,8 +262,8 @@ static void cap_stream_disconnected_cb(struct bt_bap_stream *bap_stream, uint8_t
 
 static struct bt_bap_stream_ops bap_stream_ops = {
 #if defined(CONFIG_BT_BAP_UNICAST)
-	.configured = cap_stream_configured_cb,
-	.qos_set = cap_stream_qos_set_cb,
+	.codec_configured = cap_stream_codec_configured_cb,
+	.qos_configured = cap_stream_qos_configured_cb,
 	.enabled = cap_stream_enabled_cb,
 	.metadata_updated = cap_stream_metadata_updated_cb,
 	.disabled = cap_stream_disabled_cb,

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3142,8 +3142,8 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 }
 
 #if defined(CONFIG_BT_BAP_UNICAST)
-static void stream_configured_cb(struct bt_bap_stream *stream,
-				 const struct bt_bap_qos_cfg_pref *pref)
+static void stream_codec_configured_cb(struct bt_bap_stream *stream,
+				       const struct bt_bap_qos_cfg_pref *pref)
 {
 	ARG_UNUSED(pref);
 
@@ -3213,7 +3213,7 @@ static struct bt_bap_stream_ops stream_ops = {
 	.recv = audio_recv,
 #endif /* CONFIG_BT_AUDIO_RX */
 #if defined(CONFIG_BT_BAP_UNICAST)
-	.configured = stream_configured_cb,
+	.codec_configured = stream_codec_configured_cb,
 	.released = stream_released_cb,
 	.enabled = stream_enabled_cb,
 	.metadata_updated = stream_metadata_updated_cb,

--- a/tests/bluetooth/audio/ascs/src/main.c
+++ b/tests/bluetooth/audio/ascs/src/main.c
@@ -415,7 +415,7 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_streaming_state)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Expected to notify the upper layers */
-	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_configured_called(1, &stream);
 	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 	expect_bt_bap_stream_ops_released_called(0, NULL);
 	expect_bt_bap_stream_ops_disconnected_called(1, (const struct bt_bap_stream **)&stream);
@@ -458,7 +458,7 @@ static void test_cis_link_loss_in_disabling_state(struct ascs_test_suite_fixture
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Expected to notify the upper layers */
-	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_configured_called(1, &stream);
 	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 	expect_bt_bap_stream_ops_released_called(0, NULL);
 	expect_bt_bap_stream_ops_disconnected_called(1, (const struct bt_bap_stream **)&stream);
@@ -505,7 +505,7 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Expected no change in ASE state */
-	expect_bt_bap_stream_ops_qos_set_called(0, NULL);
+	expect_bt_bap_stream_ops_qos_configured_called(0, NULL);
 	expect_bt_bap_stream_ops_released_called(0, NULL);
 	expect_bt_bap_stream_ops_disconnected_called(1, (const struct bt_bap_stream **)&stream);
 
@@ -515,11 +515,11 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	if (IS_ENABLED(CONFIG_BT_ASCS_ASE_SNK)) {
-		expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+		expect_bt_bap_stream_ops_qos_configured_called(1, &stream);
 		expect_bt_bap_stream_ops_disabled_called(1, &stream);
 	} else {
 		/* Server-initiated disable operation that shall not cause transition to QoS */
-		expect_bt_bap_stream_ops_qos_set_called(0, NULL);
+		expect_bt_bap_stream_ops_qos_configured_called(0, NULL);
 	}
 }
 
@@ -553,7 +553,7 @@ ZTEST_F(ascs_test_suite, test_cis_link_loss_in_enabling_state_client_retries)
 	test_drain_syswq(); /* Ensure that state transitions are completed */
 
 	/* Expected to not notify the upper layers */
-	expect_bt_bap_stream_ops_qos_set_called(0, NULL);
+	expect_bt_bap_stream_ops_qos_configured_called(0, NULL);
 	expect_bt_bap_stream_ops_released_called(0, NULL);
 	expect_bt_bap_stream_ops_disconnected_called(1, (const struct bt_bap_stream **)&stream);
 
@@ -644,7 +644,7 @@ ZTEST_F(ascs_test_suite, test_ase_state_notification_retry)
 	cp->write(conn, cp, (void *)buf, sizeof(buf), 0, 0);
 
 	/* Verification */
-	expect_bt_bap_stream_ops_configured_called(0, NULL, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(0, NULL, NULL);
 
 	mock_bt_gatt_notify_cb_fake.return_val = 0;
 
@@ -654,5 +654,5 @@ ZTEST_F(ascs_test_suite, test_ase_state_notification_retry)
 	/* Wait for ASE state notification retry */
 	k_sleep(K_USEC(info.le.interval_us));
 
-	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(1, &stream, NULL);
 }

--- a/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
+++ b/tests/bluetooth/audio/ascs/src/test_ase_state_transition.c
@@ -149,7 +149,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_idle_to_codec_configured)
 	enum bt_audio_dir dir = BT_AUDIO_DIR_SINK;
 
 	expect_bt_ascs_cb_config_called(1, &conn, NULL, &dir, NULL);
-	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_qos_configured)
@@ -166,7 +166,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_qos_conf
 
 	/* Verification */
 	expect_bt_ascs_cb_qos_called(1, &stream, NULL);
-	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_configured_called(1, &stream);
 	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
@@ -201,7 +201,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_enabling_to_qos_configured)
 
 	/* Verification */
 	expect_bt_ascs_cb_disable_called(1, &stream);
-	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_configured_called(1, &stream);
 	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 }
 
@@ -239,7 +239,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_codec_co
 
 	expect_bt_ascs_cb_config_called(0, NULL, NULL, NULL, NULL);
 	expect_bt_ascs_cb_reconfig_called(1, &stream, &dir, NULL);
-	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_qos_configured)
@@ -256,7 +256,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_qos_config
 
 	/* Verification */
 	expect_bt_ascs_cb_qos_called(1, &stream, NULL);
-	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_configured_called(1, &stream);
 	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
@@ -276,7 +276,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_qos_configured_to_codec_conf
 	const enum bt_audio_dir dir = BT_AUDIO_DIR_SINK;
 
 	expect_bt_ascs_cb_reconfig_called(1, &stream, &dir, NULL);
-	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_client_codec_configured_to_releasing)
@@ -397,7 +397,7 @@ ZTEST_F(test_sink_ase_state_transition, test_client_streaming_to_qos_configured)
 
 	expect_bt_ascs_cb_disable_called(1, &stream);
 	expect_bt_bap_stream_ops_stopped_called(1, &stream, &reason);
-	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_configured_called(1, &stream);
 	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 }
 
@@ -419,7 +419,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_idle_to_codec_configured)
 
 	/* Verification */
 	expect_bt_ascs_cb_config_called(0, NULL, NULL, NULL, NULL);
-	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_codec_configured_to_codec_configured)
@@ -445,7 +445,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_codec_configured_to_codec_co
 	const enum bt_audio_dir dir = BT_AUDIO_DIR_SINK;
 
 	expect_bt_ascs_cb_reconfig_called(1, &stream, &dir, NULL);
-	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_codec_configured_to_releasing)
@@ -492,7 +492,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_qos_configured_to_codec_conf
 	const enum bt_audio_dir dir = BT_AUDIO_DIR_SINK;
 
 	expect_bt_ascs_cb_reconfig_called(1, &stream, &dir, NULL);
-	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_sink_ase_state_transition, test_server_qos_configured_to_releasing)
@@ -582,7 +582,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_enabling_to_qos_configured)
 
 	/* Verification */
 	expect_bt_ascs_cb_disable_called(1, &stream);
-	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_configured_called(1, &stream);
 	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 }
 
@@ -662,7 +662,7 @@ ZTEST_F(test_sink_ase_state_transition, test_server_streaming_to_qos_configured)
 
 	expect_bt_ascs_cb_disable_called(1, &stream);
 	expect_bt_bap_stream_ops_stopped_called(1, &stream, &reason);
-	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_configured_called(1, &stream);
 	expect_bt_bap_stream_ops_disabled_called(1, &stream);
 }
 
@@ -733,7 +733,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_idle_to_codec_configured)
 	enum bt_audio_dir dir = BT_AUDIO_DIR_SOURCE;
 
 	expect_bt_ascs_cb_config_called(1, &conn, NULL, &dir, NULL);
-	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_qos_configured)
@@ -750,7 +750,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_qos_co
 
 	/* Verification */
 	expect_bt_ascs_cb_qos_called(1, &stream, NULL);
-	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_configured_called(1, &stream);
 	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
@@ -845,7 +845,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_codec_
 	const enum bt_audio_dir dir = BT_AUDIO_DIR_SOURCE;
 
 	expect_bt_ascs_cb_reconfig_called(1, &stream, &dir, NULL);
-	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_qos_configured)
@@ -862,7 +862,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_qos_conf
 
 	/* Verification */
 	expect_bt_ascs_cb_qos_called(1, &stream, NULL);
-	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_configured_called(1, &stream);
 	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
@@ -882,7 +882,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_qos_configured_to_codec_co
 	const enum bt_audio_dir dir = BT_AUDIO_DIR_SOURCE;
 
 	expect_bt_ascs_cb_reconfig_called(1, &stream, &dir, NULL);
-	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_client_codec_configured_to_releasing)
@@ -1024,7 +1024,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_enabling_to_disabling_to_q
 
 	/* Verification */
 	expect_bt_ascs_cb_stop_called(1, &stream);
-	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_configured_called(1, &stream);
 	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
@@ -1053,7 +1053,7 @@ ZTEST_F(test_source_ase_state_transition, test_client_streaming_to_disabling_to_
 
 	/* Verification */
 	expect_bt_ascs_cb_stop_called(1, &stream);
-	expect_bt_bap_stream_ops_qos_set_called(1, &stream);
+	expect_bt_bap_stream_ops_qos_configured_called(1, &stream);
 	expect_bt_bap_stream_ops_disabled_called(0, NULL);
 }
 
@@ -1075,7 +1075,7 @@ ZTEST_F(test_source_ase_state_transition, test_server_idle_to_codec_configured)
 
 	/* Verification */
 	expect_bt_ascs_cb_config_called(0, NULL, NULL, NULL, NULL);
-	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_codec_configured_to_codec_configured)
@@ -1101,7 +1101,7 @@ ZTEST_F(test_source_ase_state_transition, test_server_codec_configured_to_codec_
 	const enum bt_audio_dir dir = BT_AUDIO_DIR_SOURCE;
 
 	expect_bt_ascs_cb_reconfig_called(1, &stream, &dir, NULL);
-	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_codec_configured_to_releasing)
@@ -1148,7 +1148,7 @@ ZTEST_F(test_source_ase_state_transition, test_server_qos_configured_to_codec_co
 	const enum bt_audio_dir dir = BT_AUDIO_DIR_SOURCE;
 
 	expect_bt_ascs_cb_reconfig_called(1, &stream, &dir, NULL);
-	expect_bt_bap_stream_ops_configured_called(1, &stream, NULL);
+	expect_bt_bap_stream_ops_codec_configured_called(1, &stream, NULL);
 }
 
 ZTEST_F(test_source_ase_state_transition, test_server_qos_configured_to_releasing)

--- a/tests/bluetooth/audio/mocks/include/bap_stream.h
+++ b/tests/bluetooth/audio/mocks/include/bap_stream.h
@@ -19,9 +19,9 @@ extern struct bt_bap_stream_ops mock_bap_stream_ops;
 void mock_bap_stream_init(void);
 void mock_bap_stream_cleanup(void);
 
-DECLARE_FAKE_VOID_FUNC(mock_bap_stream_configured_cb, struct bt_bap_stream *,
+DECLARE_FAKE_VOID_FUNC(mock_bap_stream_codec_configured_cb, struct bt_bap_stream *,
 		       const struct bt_bap_qos_cfg_pref *);
-DECLARE_FAKE_VOID_FUNC(mock_bap_stream_qos_set_cb, struct bt_bap_stream *);
+DECLARE_FAKE_VOID_FUNC(mock_bap_stream_qos_configured_cb, struct bt_bap_stream *);
 DECLARE_FAKE_VOID_FUNC(mock_bap_stream_enabled_cb, struct bt_bap_stream *);
 DECLARE_FAKE_VOID_FUNC(mock_bap_stream_metadata_updated_cb, struct bt_bap_stream *);
 DECLARE_FAKE_VOID_FUNC(mock_bap_stream_disabled_cb, struct bt_bap_stream *);

--- a/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
+++ b/tests/bluetooth/audio/mocks/include/bap_stream_expects.h
@@ -19,19 +19,19 @@
 #include "bap_stream.h"
 #include "expects_util.h"
 
-static inline void expect_bt_bap_stream_ops_configured_called(
+static inline void expect_bt_bap_stream_ops_codec_configured_called(
 	unsigned int expected_count,
 	struct bt_bap_stream *streams[],
 	void *pref[])
 {
-	const char *func_name = "bt_bap_stream_ops.configured";
+	const char *func_name = "bt_bap_stream_ops.codec_configured";
 
 	zexpect_call_count(func_name,
-		expected_count, mock_bap_stream_configured_cb_fake.call_count);
+		expected_count, mock_bap_stream_codec_configured_cb_fake.call_count);
 
-	for (unsigned int i = 0; i < mock_bap_stream_configured_cb_fake.call_count; i++) {
+	for (unsigned int i = 0; i < mock_bap_stream_codec_configured_cb_fake.call_count; i++) {
 		zexpect_equal_ptr(streams[i],
-			mock_bap_stream_configured_cb_fake.arg0_history[i],
+			mock_bap_stream_codec_configured_cb_fake.arg0_history[i],
 			"'%s()' was called with incorrect 'stream[%i]' value",
 			func_name, i);
 	}
@@ -42,18 +42,18 @@ static inline void expect_bt_bap_stream_ops_configured_called(
 	}
 }
 
-static inline void expect_bt_bap_stream_ops_qos_set_called(
+static inline void expect_bt_bap_stream_ops_qos_configured_called(
 	unsigned int expected_count,
 	struct bt_bap_stream *streams[])
 {
-	const char *func_name = "bt_bap_stream_ops.qos_set";
+	const char *func_name = "bt_bap_stream_ops.qos_configured";
 
 	zexpect_call_count(func_name,
-		expected_count, mock_bap_stream_qos_set_cb_fake.call_count);
+		expected_count, mock_bap_stream_qos_configured_cb_fake.call_count);
 
-	for (unsigned int i = 0; i < mock_bap_stream_qos_set_cb_fake.call_count; i++) {
+	for (unsigned int i = 0; i < mock_bap_stream_qos_configured_cb_fake.call_count; i++) {
 		zexpect_equal_ptr(streams[i],
-			mock_bap_stream_qos_set_cb_fake.arg0_history[i],
+			mock_bap_stream_qos_configured_cb_fake.arg0_history[i],
 			"'%s()' was called with incorrect '%s[%i]'", func_name, "stream", i);
 	}
 }

--- a/tests/bluetooth/audio/mocks/src/bap_stream.c
+++ b/tests/bluetooth/audio/mocks/src/bap_stream.c
@@ -15,8 +15,8 @@
 
 /* List of fakes used by this unit tester */
 #define FFF_FAKES_LIST(FAKE)                                                                       \
-	FAKE(mock_bap_stream_configured_cb)                                                        \
-	FAKE(mock_bap_stream_qos_set_cb)                                                           \
+	FAKE(mock_bap_stream_codec_configured_cb)                                                  \
+	FAKE(mock_bap_stream_qos_configured_cb)                                                    \
 	FAKE(mock_bap_stream_enabled_cb)                                                           \
 	FAKE(mock_bap_stream_metadata_updated_cb)                                                  \
 	FAKE(mock_bap_stream_disabled_cb)                                                          \
@@ -30,9 +30,9 @@
 
 struct bt_bap_stream_ops mock_bap_stream_ops;
 
-DEFINE_FAKE_VOID_FUNC(mock_bap_stream_configured_cb, struct bt_bap_stream *,
+DEFINE_FAKE_VOID_FUNC(mock_bap_stream_codec_configured_cb, struct bt_bap_stream *,
 		      const struct bt_bap_qos_cfg_pref *);
-DEFINE_FAKE_VOID_FUNC(mock_bap_stream_qos_set_cb, struct bt_bap_stream *);
+DEFINE_FAKE_VOID_FUNC(mock_bap_stream_qos_configured_cb, struct bt_bap_stream *);
 DEFINE_FAKE_VOID_FUNC(mock_bap_stream_enabled_cb, struct bt_bap_stream *);
 DEFINE_FAKE_VOID_FUNC(mock_bap_stream_metadata_updated_cb, struct bt_bap_stream *);
 DEFINE_FAKE_VOID_FUNC(mock_bap_stream_disabled_cb, struct bt_bap_stream *);
@@ -50,8 +50,8 @@ void mock_bap_stream_init(void)
 	FFF_FAKES_LIST(RESET_FAKE);
 
 #if defined(CONFIG_BT_BAP_UNICAST)
-	mock_bap_stream_ops.configured = mock_bap_stream_configured_cb;
-	mock_bap_stream_ops.qos_set = mock_bap_stream_qos_set_cb;
+	mock_bap_stream_ops.codec_configured = mock_bap_stream_codec_configured_cb;
+	mock_bap_stream_ops.qos_configured = mock_bap_stream_qos_configured_cb;
 	mock_bap_stream_ops.enabled = mock_bap_stream_enabled_cb;
 	mock_bap_stream_ops.metadata_updated = mock_bap_stream_metadata_updated_cb;
 	mock_bap_stream_ops.disabled = mock_bap_stream_disabled_cb;

--- a/tests/bluetooth/audio/mocks/src/bap_unicast_client.c
+++ b/tests/bluetooth/audio/mocks/src/bap_unicast_client.c
@@ -175,10 +175,10 @@ int bt_bap_unicast_client_config(struct bt_bap_stream *stream,
 
 	stream->ep->state = BT_BAP_EP_STATE_CODEC_CONFIGURED;
 
-	if (stream->ops != NULL && stream->ops->configured != NULL) {
+	if (stream->ops != NULL && stream->ops->codec_configured != NULL) {
 		const struct bt_bap_qos_cfg_pref pref = {0};
 
-		stream->ops->configured(stream, &pref);
+		stream->ops->codec_configured(stream, &pref);
 	}
 
 	return 0;
@@ -223,8 +223,8 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 
 			stream->ep->state = BT_BAP_EP_STATE_QOS_CONFIGURED;
 
-			if (stream->ops != NULL && stream->ops->qos_set != NULL) {
-				stream->ops->qos_set(stream);
+			if (stream->ops != NULL && stream->ops->qos_configured != NULL) {
+				stream->ops->qos_configured(stream);
 			}
 		}
 	}
@@ -416,8 +416,8 @@ int bt_bap_unicast_client_disable(struct bt_bap_stream *stream)
 			stream->ops->stopped(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
 		}
 
-		if (stream->ops != NULL && stream->ops->qos_set != NULL) {
-			stream->ops->qos_set(stream);
+		if (stream->ops != NULL && stream->ops->qos_configured != NULL) {
+			stream->ops->qos_configured(stream);
 		}
 	} else if (stream->ep->dir == BT_AUDIO_DIR_SOURCE) {
 		stream->ep->state = BT_BAP_EP_STATE_DISABLING;
@@ -462,8 +462,8 @@ int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
 		stream->ops->stopped(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
 	}
 
-	if (stream->ops != NULL && stream->ops->qos_set != NULL) {
-		stream->ops->qos_set(stream);
+	if (stream->ops != NULL && stream->ops->qos_configured != NULL) {
+		stream->ops->qos_configured(stream);
 	}
 
 	/* If the stream can be disconnected, BAP will disconnect the stream once it reaches the
@@ -494,8 +494,8 @@ int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
 							  BT_HCI_ERR_LOCALHOST_TERM_CONN);
 			}
 
-			if (pair_stream->ops != NULL && pair_stream->ops->qos_set != NULL) {
-				pair_stream->ops->qos_set(pair_stream);
+			if (pair_stream->ops != NULL && pair_stream->ops->qos_configured != NULL) {
+				pair_stream->ops->qos_configured(pair_stream);
 			}
 		}
 	}

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -563,8 +563,8 @@ static void stream_state_changed(struct bt_bap_stream *stream)
 	btp_send_ascs_ase_state_changed_ev(stream->conn, u_stream->ase_id, info.state);
 }
 
-static void stream_configured_cb(struct bt_bap_stream *stream,
-				 const struct bt_bap_qos_cfg_pref *pref)
+static void stream_codec_configured_cb(struct bt_bap_stream *stream,
+				       const struct bt_bap_qos_cfg_pref *pref)
 {
 	struct bt_bap_ep_info info;
 	struct btp_bap_unicast_connection *u_conn;
@@ -582,7 +582,7 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 	stream_state_changed(stream);
 }
 
-static void stream_qos_set_cb(struct bt_bap_stream *stream)
+static void stream_qos_configured_cb(struct bt_bap_stream *stream)
 {
 	LOG_DBG("QoS set stream %p", stream);
 
@@ -850,8 +850,8 @@ static void stream_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 }
 
 static struct bt_bap_stream_ops stream_ops = {
-	.configured = stream_configured_cb,
-	.qos_set = stream_qos_set_cb,
+	.codec_configured = stream_codec_configured_cb,
+	.qos_configured = stream_qos_configured_cb,
 	.enabled = stream_enabled_cb,
 	.metadata_updated = stream_metadata_updated_cb,
 	.disabled = stream_disabled_cb,

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -78,7 +78,8 @@ CREATE_FLAG(flag_sink_supp_ctx_changed);
 CREATE_FLAG(flag_source_avail_ctx_changed);
 CREATE_FLAG(flag_source_supp_ctx_changed);
 
-static void stream_configured(struct bt_bap_stream *stream, const struct bt_bap_qos_cfg_pref *pref)
+static void stream_codec_configured(struct bt_bap_stream *stream,
+				    const struct bt_bap_qos_cfg_pref *pref)
 {
 	struct bt_conn *ep_conn;
 
@@ -100,7 +101,7 @@ static void stream_configured(struct bt_bap_stream *stream, const struct bt_bap_
 	SET_FLAG(flag_stream_codec_configured);
 }
 
-static void stream_qos_set(struct bt_bap_stream *stream)
+static void stream_qos_configured(struct bt_bap_stream *stream)
 {
 	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
 
@@ -188,8 +189,8 @@ static void stream_released(struct bt_bap_stream *stream)
 }
 
 static struct bt_bap_stream_ops stream_ops = {
-	.configured = stream_configured,
-	.qos_set = stream_qos_set,
+	.codec_configured = stream_codec_configured,
+	.qos_configured = stream_qos_configured,
 	.enabled = stream_enabled,
 	.started = stream_started,
 	.metadata_updated = stream_metadata_updated,

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -252,8 +252,8 @@ static const struct bt_bap_unicast_server_cb unicast_server_cb = {
 	.release = lc3_release,
 };
 
-static void stream_configured_cb(struct bt_bap_stream *stream,
-				 const struct bt_bap_qos_cfg_pref *pref)
+static void stream_codec_configured_cb(struct bt_bap_stream *stream,
+				       const struct bt_bap_qos_cfg_pref *pref)
 {
 	struct bt_conn *ep_conn;
 
@@ -328,7 +328,7 @@ static void stream_stopped_cb(struct bt_bap_stream *stream, uint8_t reason)
 }
 
 static struct bt_bap_stream_ops stream_ops = {
-	.configured = stream_configured_cb,
+	.codec_configured = stream_codec_configured_cb,
 	.enabled = stream_enabled_cb,
 	.started = stream_started_cb,
 	.stopped = stream_stopped_cb,

--- a/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_unicast_test.c
@@ -136,8 +136,8 @@ static const struct named_lc3_preset lc3_unicast_presets[] = {
 	{"48_6_2", BT_BAP_LC3_UNICAST_PRESET_48_6_2(LOCATION, CONTEXT)},
 };
 
-static void unicast_stream_configured(struct bt_bap_stream *stream,
-				      const struct bt_bap_qos_cfg_pref *pref)
+static void unicast_stream_codec_configured(struct bt_bap_stream *stream,
+					    const struct bt_bap_qos_cfg_pref *pref)
 {
 	struct bt_cap_stream *cap_stream = cap_stream_from_bap_stream(stream);
 
@@ -160,7 +160,7 @@ static void unicast_stream_configured(struct bt_bap_stream *stream,
 	 */
 }
 
-static void unicast_stream_qos_set(struct bt_bap_stream *stream)
+static void unicast_stream_qos_configured(struct bt_bap_stream *stream)
 {
 	printk("QoS set stream %p\n", stream);
 }
@@ -237,8 +237,8 @@ static void unicast_stream_released(struct bt_bap_stream *stream)
 }
 
 static struct bt_bap_stream_ops unicast_stream_ops = {
-	.configured = unicast_stream_configured,
-	.qos_set = unicast_stream_qos_set,
+	.codec_configured = unicast_stream_codec_configured,
+	.qos_configured = unicast_stream_qos_configured,
 	.enabled = unicast_stream_enabled,
 	.started = unicast_stream_started,
 	.metadata_updated = unicast_stream_metadata_updated,

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -161,8 +161,8 @@ const struct named_lc3_preset *gmap_get_named_preset(bool is_unicast, enum bt_au
 	return NULL;
 }
 
-static void stream_configured_cb(struct bt_bap_stream *stream,
-				 const struct bt_bap_qos_cfg_pref *pref)
+static void stream_codec_configured_cb(struct bt_bap_stream *stream,
+				       const struct bt_bap_qos_cfg_pref *pref)
 {
 	ARG_UNUSED(pref);
 
@@ -173,7 +173,7 @@ static void stream_configured_cb(struct bt_bap_stream *stream,
 	 */
 }
 
-static void stream_qos_set_cb(struct bt_bap_stream *stream)
+static void stream_qos_configured_cb(struct bt_bap_stream *stream)
 {
 	printk("QoS set stream %p\n", stream);
 }
@@ -242,8 +242,8 @@ static void stream_released_cb(struct bt_bap_stream *stream)
 }
 
 static struct bt_bap_stream_ops stream_ops = {
-	.configured = stream_configured_cb,
-	.qos_set = stream_qos_set_cb,
+	.codec_configured = stream_codec_configured_cb,
+	.qos_configured = stream_qos_configured_cb,
 	.enabled = stream_enabled_cb,
 	.started = stream_started_cb,
 	.metadata_updated = stream_metadata_updated_cb,


### PR DESCRIPTION
Rename the `configured` and `qos_set` callbacks of
`struct bt_bap_stream_ops` to `codec_configured` and `qos_configured`
respectively, so that the names align with the ASE state machine names
defined by the ASCS specification.
    
All in-tree users (host implementation, shell, samples and tests) have
been updated accordingly, including the local callback function names
that mirror the operation names.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/114835