### PR TITLE
tests logging log_immediate: Initialize stack buffer to something and remove unnecessary platform_exclude

### DIFF
--- a/tests/subsys/logging/log_immediate/src/log_immediate_test.c
+++ b/tests/subsys/logging/log_immediate/src/log_immediate_test.c
@@ -41,6 +41,10 @@ static void thread_func(void *p1, void *p2, void *p3)
 	int buf_len = 8*id + 8;
 	uint8_t *buf = alloca(buf_len);
 
+	for (int i = 0; i < buf_len; i++) {
+		buf[i] = (uint8_t)id*16 + i; /* Initialize to anything */
+	}
+
 	while (1) {
 		LOG_INF("test string printed %d %d %p", 1, 2, k_current_get());
 		LOG_HEXDUMP_INF(buf, buf_len, "data:");

--- a/tests/subsys/logging/log_immediate/tests.yaml
+++ b/tests/subsys/logging/log_immediate/tests.yaml
@@ -12,7 +12,6 @@ tests:
       - nucleo_l053r8
       - nucleo_f030r8
       - stm32f0_disco
-      - nrf52_bsim
   logging.immediate.clean_output:
     extra_args: CONFIG_LOG_IMMEDIATE_CLEAN_OUTPUT=y
     tags:
@@ -23,4 +22,3 @@ tests:
       - nucleo_l053r8
       - nucleo_f030r8
       - stm32f0_disco
-      - nrf52_bsim


### PR DESCRIPTION
    tests logging log_immediate: Remove unnecessary platform_exclude
    
    This test works just fine in the nrf52_bsim.
    There is no need to exclude it.
    
    The exclusion was there since the begining
    b29d141dab3db644017a5325ca889e7d9979136f
    but whatever may have been the reason, it does not seem to apply now.
  
-----
  
    tests logging log_immediate: Initialize stack buffer to something
    
    Let's initialize the stack buffer we print out to something,
    otherwise valgrind warns us that the execution takes random paths
    which it does. Neither the warning nor the random behaviour are
    desirable.
    
