### PR TITLE
scripts: runner blackmagic: Allow confirmed image uploading

### DIFF
--- a/scripts/west_commands/runners/blackmagicprobe.py
+++ b/scripts/west_commands/runners/blackmagicprobe.py
@@ -155,9 +155,7 @@ class BlackMagicProbeRunner(ZephyrBinaryRunner):
     def bmp_flash(self, command, **kwargs):
         # if hex file is present and signed, use it else use elf file
         if self.hex_file:
-            split = self.hex_file.split('.')
-            # eg zephyr.signed.hex
-            if len(split) >= 3 and split[-2] == 'signed':
+            if self.hex_file.endswith((".signed.hex", ".signed.confirmed.hex")):
                 flash_file = self.hex_file
             else:
                 flash_file = self.elf_file


### PR DESCRIPTION
When using sysbuild, `west flash` uploads the user application `zephyr.signed.hex`.
If `CONFIG_MCUBOOT_GENERATE_CONFIRMED_IMAGE` is set, the user application is `zephyr.signed.confirmed.hex` instead of `zephyr.signed.hex`.

In this case, the blackmagic runner detects `zephyr.signed.confirmed.hex` as the hex file (`self.hex_file`) but in `bmp_flash()`, it only checks if `self.hex_file` ends with ".signed.hex". This leads the runner to flash the user application `zephyr.elf` instead of a signed hex, and it fails to boot.

This patch checks if the selected hex file ends with ".signed.hex" or ".signed.confirmed.hex", allowing `zephyr.signed.confirmed.hex` to be flashed.
