### PR TITLE
boards: fix QEMU icount sleep help

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -90,11 +90,11 @@ config QEMU_ICOUNT_SLEEP
 	depends on QEMU_ICOUNT
 	help
 	  When the virtual CPU is sleeping, the virtual time will advance
-	  at default speed unless this option is set. With this option set,
-	  the virtual time will jump to the next timer deadline instantly
-	  whenever the virtual CPU goes to sleep mode and will not advance
-	  if no timer is enabled. This behavior gives deterministic execution
-	  times from the guest point of view.
+	  at default speed when this option is enabled. When disabled, the
+	  virtual time will jump to the next timer deadline instantly whenever
+	  the virtual CPU goes to sleep mode and will not advance if no timer
+	  is enabled. This behavior gives deterministic execution times from
+	  the guest point of view.
 
 config QEMU_IVSHMEM_PLAIN_MEM_SIZE
 	int "QEMU ivshmem-plain shared memory size in mega-bytes"


### PR DESCRIPTION
QEMU advances virtual time to the next timer deadline when icount sleep is disabled. When enabled, virtual time advances at the default speed while the vCPU sleeps. Correct the Kconfig help, which described these behaviors in reverse, probably by following the wrong documentation in the upstream QEMU.

The wrong QEMU documentation was fixed in upstream QEMU commit [e372214e663a](https://github.com/qemu/qemu/commit/e372214e663a) ("qemu-options.hx: Fix reversed description of icount sleep behavior"), and we follow the same fix here.