### PR TITLE
drivers: udc: udc_kinetis: fix bulk-IN stall (thread/ISR race on ep stat bitfield)

### DIFF
--- a/drivers/usb/udc/udc_kinetis.c
+++ b/drivers/usb/udc/udc_kinetis.c
@@ -139,6 +139,29 @@ static struct usbfsotg_bd *usbfsotg_get_ebd(const struct device *const dev,
 	return &config->bdt[bd_idx];
 }
 
+/* Get buffer descriptor (BD) by explicit ping-pong parity. Used by the
+ * TOKDNE path: the STAT FIFO entry carries the parity of the BD the SIE
+ * actually completed, which is ground truth. Selecting by the software
+ * mirror (stat.odd) instead reads the wrong BD whenever the mirror has
+ * fallen out of sync — the completed transfer is then attributed to a
+ * stale token/length, or silently dropped, and the endpoint deadlocks
+ * with a transfer armed on a parity the SIE will never process.
+ */
+static struct usbfsotg_bd *usbfsotg_get_ebd_parity(const struct device *const dev,
+						   struct udc_ep_config *const cfg,
+						   const bool odd)
+{
+	const struct usbfsotg_config *config = dev->config;
+	uint8_t bd_idx;
+
+	bd_idx = USB_EP_GET_IDX(cfg->addr) * 4U + (odd ? 1U : 0U);
+	if (USB_EP_DIR_IS_IN(cfg->addr)) {
+		bd_idx += 2U;
+	}
+
+	return &config->bdt[bd_idx];
+}
+
 static void usbfsotg_ebd_ctrl_discard(const struct device *const dev)
 {
 	const struct usbfsotg_config *config = dev->config;
@@ -368,7 +391,15 @@ static ALWAYS_INLINE void isr_handle_xfer_done(const struct device *dev,
 	size_t len;
 
 	ep_cfg = udc_get_ep_cfg(dev, ep);
-	bd = usbfsotg_get_ebd(dev, ep_cfg, false);
+	if (unlikely(ep_cfg->stat.odd != odd)) {
+		/* The software parity mirror disagrees with the completion
+		 * entry. The entry's parity is authoritative; warn and
+		 * continue — the mirror is resynchronized below
+		 * (stat.odd = !odd).
+		 */
+		LOG_WRN("ep 0x%02x: parity mirror out of sync with entry", ep);
+	}
+	bd = usbfsotg_get_ebd_parity(dev, ep_cfg, odd);
 	token_pid = bd->get.tok_pid;
 	len  = bd->get.bc;
 	data1 = bd->get.data1 ? true : false;
@@ -438,6 +469,14 @@ static ALWAYS_INLINE void isr_handle_xfer_done(const struct device *dev,
 
 		break;
 	default:
+		/* A completion whose BD holds no valid token PID would
+		 * previously be dropped without even updating the parity
+		 * mirror, wedging the endpoint. Keep the mirror in sync
+		 * with the hardware and account for the event.
+		 */
+		ep_cfg->stat.odd = !odd;
+		LOG_WRN("ep 0x%02x: completion with unknown token PID %u",
+			ep, token_pid);
 		break;
 	}
 }

--- a/drivers/usb/udc/udc_kinetis.c
+++ b/drivers/usb/udc/udc_kinetis.c
@@ -323,6 +323,7 @@ static void xfer_work_handler(struct k_work *item)
 	priv = CONTAINER_OF(item, struct usbfsotg_data, work);
 	while ((ev = k_fifo_get(&priv->fifo, K_NO_WAIT)) != NULL) {
 		struct udc_ep_config *ep_cfg;
+		unsigned int key;
 		int err = 0;
 
 		LOG_DBG("dev %p, ep 0x%02x, event %u",
@@ -340,7 +341,23 @@ static void xfer_work_handler(struct k_work *item)
 		case USBFSOTG_EVT_DOUT:
 		case USBFSOTG_EVT_DIN:
 			err = work_handler_data(ev->dev, ep_cfg);
+			/* cfg->stat is a single bitfield word shared with
+			 * stat.odd and stat.data1, which the TOKDNE handler
+			 * updates from interrupt context. A bitfield write
+			 * is a read-modify-write of the whole word: if a
+			 * completion interrupt lands between this thread's
+			 * load and store (a window arbitrarily widened by
+			 * preemption), the store reverts the ISR's parity
+			 * and toggle updates. The next transfer is then
+			 * armed on the BD parity the SIE is not watching —
+			 * a permanent NAK stall — carrying a stale data
+			 * toggle. Every thread-context write to cfg->stat
+			 * of an endpoint with live traffic must therefore
+			 * be atomic with respect to this driver's ISR.
+			 */
+			key = irq_lock();
 			udc_ep_set_busy(ep_cfg, false);
+			irq_unlock(key);
 			break;
 		case USBFSOTG_EVT_XFER:
 			break;
@@ -352,11 +369,18 @@ static void xfer_work_handler(struct k_work *item)
 			udc_submit_event(ev->dev, UDC_EVT_ERROR, err);
 		}
 
-		/* Peek next transfer */
+		/* Peek next transfer. The busy flag must be set within the
+		 * same critical section as the arming: setting OWN makes a
+		 * completion (and its ISR stat.odd/stat.data1 update)
+		 * possible immediately, and the set_busy() RMW on the
+		 * shared stat word must not straddle it.
+		 */
 		if (ev->ep != USB_CONTROL_EP_OUT && !udc_ep_is_busy(ep_cfg)) {
+			key = irq_lock();
 			if (usbfsotg_xfer_next(ev->dev, ep_cfg) == 0) {
 				udc_ep_set_busy(ep_cfg, true);
 			}
+			irq_unlock(key);
 		}
 
 xfer_work_error:
@@ -619,13 +643,15 @@ static int usbfsotg_ep_dequeue(const struct device *dev,
 	struct usbfsotg_bd *bd;
 	unsigned int lock_key;
 
-	bd = usbfsotg_get_ebd(dev, cfg, false);
-
 	lock_key = irq_lock();
+	bd = usbfsotg_get_ebd(dev, cfg, false);
 	bd->set.bd_ctrl = USBFSOTG_BD_DTS;
+	/* stat is written under the lock: it shares a bitfield word with
+	 * the ISR-owned stat.odd/stat.data1.
+	 */
+	cfg->stat.halted = false;
 	irq_unlock(lock_key);
 
-	cfg->stat.halted = false;
 	udc_ep_cancel_queued(dev, cfg);
 
 	udc_ep_set_busy(cfg, false);
@@ -637,10 +663,13 @@ static int usbfsotg_ep_set_halt(const struct device *dev,
 				struct udc_ep_config *const cfg)
 {
 	struct usbfsotg_bd *bd;
+	unsigned int lock_key;
 
+	lock_key = irq_lock();
 	bd = usbfsotg_get_ebd(dev, cfg, false);
 	bd->set.bd_ctrl = USBFSOTG_BD_STALL | USBFSOTG_BD_DTS | USBFSOTG_BD_OWN;
 	cfg->stat.halted = true;
+	irq_unlock(lock_key);
 	LOG_DBG("Halt ep 0x%02x bd %p", cfg->addr, bd);
 
 	return 0;

--- a/drivers/usb/udc/udc_kinetis.c
+++ b/drivers/usb/udc/udc_kinetis.c
@@ -449,6 +449,18 @@ static void usbfsotg_isr_handler(const struct device *dev)
 	const uint8_t istatus  = base->ISTAT;
 	const uint8_t status  = base->STAT;
 
+	if (istatus & USB_ISTAT_TOKDNE_MASK) {
+		/* Advance (pop) the STAT FIFO immediately after capturing
+		 * the entry, before handling it. Clearing TOKDNE in the
+		 * epilogue instead leaves only the IRQ re-entry latency
+		 * between the pop and the next STAT read; the FIFO advance
+		 * takes up to two module clocks, so a back-to-back
+		 * completion can be read as a stale copy of the previous
+		 * entry — processed twice, while the popped entry is lost.
+		 */
+		base->ISTAT = USB_ISTAT_TOKDNE_MASK;
+	}
+
 	if (istatus & USB_ISTAT_USBRST_MASK) {
 		base->ADDR = 0U;
 		udc_submit_event(dev, UDC_EVT_RESET, 0);
@@ -490,8 +502,11 @@ static void usbfsotg_isr_handler(const struct device *dev)
 		udc_submit_event(dev, UDC_EVT_RESUME, 0);
 	}
 
-	/* Clear interrupt status bits */
-	base->ISTAT = istatus;
+	/* Clear interrupt status bits (TOKDNE was already cleared and the
+	 * FIFO advanced above; clearing it again here would pop and lose a
+	 * pending entry).
+	 */
+	base->ISTAT = (uint8_t)(istatus & ~USB_ISTAT_TOKDNE_MASK);
 }
 
 static int usbfsotg_ep_enqueue(const struct device *dev,


### PR DESCRIPTION
Fixes a permanent bulk-IN endpoint stall in the `udc_kinetis` (USBFSOTG) driver under sustained traffic, plus two secondary hazards in the completion path.

**Note for reviewers — this PR changed shape after review** (see [the discussion](https://github.com/zephyrproject-rtos/zephyr/pull/114843#issuecomment-5136966088)): the original submission diagnosed lost STAT-FIFO completion entries and compensated with a resync watchdog. @jfischer-no's review pointed at software overwriting `stat.odd` instead — and that turned out to be exactly right. The watchdog is withdrawn (it also caused silent, host-invisible packet deletion via stale data toggles), and the series now fixes the actual bug.

## The bug (commit 3)

`struct udc_ep_config::stat` is a single `uint32_t` bitfield word. The TOKDNE ISR updates `stat.odd`/`stat.data1`; the UDC work-queue thread updates `stat.busy` via `udc_ep_set_busy()` — and a bitfield store is a read-modify-write of the whole word. A completion interrupt landing between the thread's load and store gets its parity/toggle updates reverted; the next transfer is then armed on the BD parity the SIE is not evaluating and the endpoint NAKs forever, while the device otherwise stays healthy. The preemption-dependence of the window explains why reproducibility varies with build options (ASSERT, log level) and interrupt load.

Fix: take the interrupt lock around the thread-context `cfg->stat` writes that can race live traffic, with arming and `set_busy(true)` in one critical section.

## Secondary fixes

- **Commit 1:** pop the STAT FIFO immediately after capturing the entry instead of in the ISR epilogue (the FIFO advance takes up to two module clocks; an epilogue clear lets a back-to-back completion be read as a stale copy of the previous entry).
- **Commit 2:** select the completed BD by the STAT entry's ODD bit (ground truth) rather than the software mirror, resync the mirror from it, and `LOG_WRN` on disagreement — the tripwire that makes any future mirror corruption visible instead of a silent deadlock.

## Validation

On MCXA-series silicon, USB FS CDC-ACM bulk streaming against a hardware echo: sustained saturated full-duplex stalled the bulk IN endpoint in **15 of 18** 60-second sessions on the unpatched driver, and still stalled (12/17) with commits 1+2 alone — confirming the reviewer's assessment that they are not the fix. With commit 3, **8 consecutive sessions (5.5 MB round-tripped) ran byte-exact with zero stalls**, and commit 2's mismatch warning never fired.

Impact on other applications: the healthy path is unchanged apart from three short interrupt-locked sections in the work-queue handler (a handful of instructions each) and the TOKDNE clear moving earlier in the ISR. The always-on SOF interrupt from the original submission is gone.

The same thread-vs-ISR hazard on `udc_ep_config::stat` is latent in any UDC driver that writes different members of that word from thread and interrupt context; `udc_kinetis` is uniquely exposed because hardware-critical ping-pong state lives there. Happy to open a follow-up discussion if the maintainers think `stat` should become atomic flags at the API level.
