### PR TITLE
tests  lib ringq: Initialize whole test data element

### DIFF
--- a/tests/lib/ringq/src/main.c
+++ b/tests/lib/ringq/src/main.c
@@ -23,7 +23,7 @@ SYS_RINGQ_DEFINE(test_macro1, sizeof(struct element), 4);
 
 struct element mkelement(void)
 {
-	struct element e;
+	struct element e = {};
 
 	sys_rand_get(&e.id, sizeof(e.id));
 	e.size = sys_rand8_get() % sizeof(e.data) + 1;


### PR DESCRIPTION
These tests are (at the end, in L55 and L82) comparing the whole input and output element, not just the random size that was filled in with random data in mkelement().
So let's make sure the whole element has something inside, and not just random stack garbage.
Otherwise valgrind warns us that we are comparing garbage (even if with a copy of itself).
The valgrind warning was not detecting an actual problem, but pacifying it with this change does not cost anything in practice (this is a test so initializing a few more bytes is irrelevant).