### PR TITLE
drivers: sensor: adxl345: RTIO stream fix

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345_stream.c
+++ b/drivers/sensor/adi/adxl345/adxl345_stream.c
@@ -271,6 +271,7 @@ static void adxl345_process_status1_cb(struct rtio *r, const struct rtio_sqe *sq
 	uint8_t status1 = data->status1;
 
 	if (data->sqe == NULL) {
+		data->fifo_watermark_irq = 0;
 		return;
 	}
 
@@ -390,6 +391,7 @@ void adxl345_stream_irq_handler(const struct device *dev)
 	int rc;
 
 	if (data->sqe == NULL) {
+		data->fifo_watermark_irq = 0;
 		return;
 	}
 


### PR DESCRIPTION
Fix for RTIO streaming. When stream is canceled with rtio_sqe_cancel before IRQ or when sequence for getting data from FIFO, data->sqe is set to NULL. This will result with early exit from some functions. Because data->fifo_watermark_irq remain set, it was not possible to start new stream.

Signed-off-by: Vladislav Pejic [vladislav.pejic@orioninc.com](mailto:vladislav.pejic@orioninc.com)