### PR TITLE
linker: map __lcxx_override section to ROM

### DIFF
--- a/include/zephyr/linker/cplusplus-rom.ld
+++ b/include/zephyr/linker/cplusplus-rom.ld
@@ -10,6 +10,17 @@
 	*(.gcc_except_table .gcc_except_table.*)
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
+#if defined(CONFIG_LIBCXX_LIBCPP)
+	/*
+	 * LLVM libc++ places operator new/delete in a dedicated section
+	 * named __lcxx_override to support interposing.
+	 */
+	SECTION_PROLOGUE(__lcxx_override,,)
+	{
+	KEEP(*(__lcxx_override))
+	} GROUP_LINK_IN(ROMABLE_REGION)
+#endif /* CONFIG_LIBCXX_LIBCPP */
+
 #if defined (CONFIG_CPP_EXCEPTIONS)
 	SECTION_PROLOGUE(.eh_frame_hdr,,)
 	{


### PR DESCRIPTION
LLVM libc++ (since [this commit][1]) places operator new/delete and their aligned variants in a dedicated ELF section named `__lcxx_override` instead of `.text`. This design allows the dynamic linker to interpose these functions at runtime on hosted platforms:

    $ objdump -h /opt/zephyr-sdk-1.0.1/llvm/.../libc++abi.a
    [...]
    stdlib_new_delete.cpp.obj:     file format elf32-littlearm

    Sections:
    Idx Name          Size      VMA       LMA       File off  Algn
      0 .text         00000000  00000000  00000000  00000034  2**2
                      CONTENTS, ALLOC, LOAD, READONLY, CODE
      1 __lcxx_override 00000038  00000000  00000000  00000034  2**1
                      CONTENTS, ALLOC, LOAD, RELOC, READONLY, CODE
    [...]

On Zephyr's linker scripts, this section is not explicitly captured by any output section. LLD treats it as an orphan section and places it based on its flags. In practice, it ends up in SRAM and an Invalid Instruction or and Instruction Access Violation.

Note, GCC/libstdc++ is not affected because it keeps operator new in .text.

The patch explicitly maps `__lcxx_override` to `ROMABLE_REGION` when `CONFIG_LIBCXX_LIBCPP` is selected, ensuring the operator new/delete implementations land in flash.

`KEEP()` is used as a defensive measure against `--gc-sections` pruning the section before the linker resolves the references from call sites. In practice operator new is always referenced and would survive GC, but `KEEP()` makes the intent explicit and avoids any edge-case removal (e.g. when the section is not directly reachable from entry at GC time).

[1]: https://github.com/llvm/llvm-project/commit/314526557ec66ee627ae8a1c03f6ccc610668fdb