### PR TITLE
soc: silabs: siwx91x: allow WiFi PS without CONFIG_PM

### DIFF
--- a/drivers/bluetooth/hci/hci_silabs_siwx91x.c
+++ b/drivers/bluetooth/hci/hci_silabs_siwx91x.c
@@ -14,6 +14,7 @@ LOG_MODULE_REGISTER(bt_hci_driver_siwg917);
 #include "rsi_ble.h"
 #include "rsi_ble_common_config.h"
 #include "siwx91x_nwp.h"
+#include "sl_si91x_power_manager.h"
 
 #define BLE_RF_POWER_INDEX     0x0006
 #define BT_OP_VS_RF_POWER_MODE BT_OP(BT_OGF_VS, BLE_RF_POWER_INDEX)
@@ -91,6 +92,9 @@ static int siwx91x_bt_setup(const struct device *dev, const struct bt_hci_setup_
 	if (err < 0) {
 		LOG_ERR("Failed to set power profile: %d", err);
 		return err;
+	}
+	if (IS_ENABLED(CONFIG_PM)) {
+		sl_si91x_power_manager_remove_ps_requirement(SL_SI91X_POWER_MANAGER_PS4);
 	}
 
 	return 0;

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
@@ -461,11 +461,6 @@ int siwx91x_nwp_apply_power_profile(const struct device *dev,
 	};
 	int ret;
 
-	if (!IS_ENABLED(CONFIG_PM)) {
-		/* no_op if PM is not enabled*/
-		return 0;
-	}
-
 	/* WiseConnect zeros the BT half of its cached coex profile on every
 	 * sl_wifi_disconnect(). Re-seed it so the combined profile doesn't
 	 * resolve to HIGH_PERFORMANCE and silently drop the PS request.
@@ -486,8 +481,9 @@ int siwx91x_nwp_apply_power_profile(const struct device *dev,
 		return -EINVAL;
 	}
 
-	/* Remove the previously added PS4 power state requirement */
-	sl_si91x_power_manager_remove_ps_requirement(SL_SI91X_POWER_MANAGER_PS4);
+	if (IS_ENABLED(CONFIG_PM)) {
+		sl_si91x_power_manager_remove_ps_requirement(SL_SI91X_POWER_MANAGER_PS4);
+	}
 
 	return 0;
 }
@@ -507,8 +503,8 @@ static int siwx91x_nwp_init(const struct device *dev)
 		LOG_WRN("'ext-gpios' expects some pinctrl configuration");
 	}
 
-	if (IS_ENABLED(CONFIG_BT_SILABS_SIWX91X) || IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X)) {
-		data->power_profile = ASSOCIATED_POWER_SAVE;
+	if (!IS_ENABLED(CONFIG_BT_SILABS_SIWX91X) && !IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X)) {
+		data->power_profile = DEEP_SLEEP_WITH_RAM_RETENTION;
 	}
 
 	siwx91x_get_nwp_config(dev, &network_config, WIFI_STA_MODE, false, 0);
@@ -572,7 +568,7 @@ BUILD_ASSERT(CONFIG_SIWX91X_NWP_INIT_PRIORITY < CONFIG_KERNEL_INIT_PRIORITY_DEFA
 	};                                                                                         \
                                                                                                    \
 	static struct siwx91x_nwp_data siwx91x_nwp_data_##inst = {                                 \
-		.power_profile = DEEP_SLEEP_WITH_RAM_RETENTION,                                    \
+		.power_profile = HIGH_PERFORMANCE,                                                 \
 	};                                                                                         \
                                                                                                    \
 	PINCTRL_DT_INST_DEFINE(inst);                                                              \

--- a/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/siwx91x_nwp.c
@@ -481,10 +481,6 @@ int siwx91x_nwp_apply_power_profile(const struct device *dev,
 		return -EINVAL;
 	}
 
-	if (IS_ENABLED(CONFIG_PM)) {
-		sl_si91x_power_manager_remove_ps_requirement(SL_SI91X_POWER_MANAGER_PS4);
-	}
-
 	return 0;
 }
 
@@ -544,6 +540,9 @@ static int siwx91x_nwp_init(const struct device *dev)
 		ret = siwx91x_nwp_apply_power_profile(dev, NULL);
 		if (ret) {
 			return -EINVAL;
+		}
+		if (IS_ENABLED(CONFIG_PM)) {
+			sl_si91x_power_manager_remove_ps_requirement(SL_SI91X_POWER_MANAGER_PS4);
 		}
 	}
 


### PR DESCRIPTION
Until now, the wifi power save request was discarded if `CONFIG_PM` was not set. It does not make sense since `CONFIG_PM` only impact the main CPU (and devices if we consider `CONFIG_PM_DEVICE`).
    
Probably the condition was only here to avoid call to `sl_si91x_power_manager_remove_ps_requirement()` when `CONFIG_PM` is not set.
    
