### PR TITLE
boards: adi: max32657/8: Migrate to mapped partitions

### DIFF
--- a/boards/adi/max32657evkit/Kconfig.defconfig
+++ b/boards/adi/max32657evkit/Kconfig.defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_MAX32657EVKIT
@@ -16,16 +16,7 @@ if BOARD_MAX32657EVKIT
 # Apply this configuration below by setting the Kconfig symbols used by
 # the linker according to the information extracted from DT partitions.
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
 if BOARD_MAX32657EVKIT_MAX32657_NS
-
-config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
 
 # MAX32657 has one UART interface,
 # It can be used either on TFM or Zephyr

--- a/boards/adi/max32657evkit/max32657evkit_max32657.dts
+++ b/boards/adi/max32657evkit/max32657evkit_max32657.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -30,17 +30,19 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0 DT_SIZE_K(960)>;
 			read-only;
 		};
 
 		storage_partition: partition@f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xf0000 DT_SIZE_K(64)>;
 		};

--- a/boards/adi/max32657evkit/max32657evkit_max32657_defconfig
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Enable MPU
@@ -17,3 +17,5 @@ CONFIG_UART_INTERRUPT_DRIVEN=y
 
 # It is secure fw, enable flags
 CONFIG_TRUSTED_EXECUTION_SECURE=y
+
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/adi/max32657evkit/max32657evkit_max32657_ns.dts
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_ns.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -36,22 +36,25 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x10000 DT_SIZE_K(320)>;
 		};
 
 		slot0_ns_partition: partition@60000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-nonsecure";
 			reg = <0x60000 DT_SIZE_K(576)>;
 		};
@@ -68,6 +71,7 @@
 		 */
 
 		tfm_storage_partition: partition@f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "tfm-storage";
 			reg = <0xf0000 DT_SIZE_K(64)>;
 		};

--- a/boards/adi/max32657evkit/max32657evkit_max32657_ns_defconfig
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_ns_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Enable MPU
@@ -20,3 +20,5 @@ CONFIG_TRUSTED_EXECUTION_NONSECURE=y
 
 # Set TFM and Zephyr sign key
 CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE="RSA-3072"
+
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/adi/max32658evkit/Kconfig.defconfig
+++ b/boards/adi/max32658evkit/Kconfig.defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_MAX32658EVKIT
@@ -16,16 +16,7 @@ if BOARD_MAX32658EVKIT
 # Apply this configuration below by setting the Kconfig symbols used by
 # the linker according to the information extracted from DT partitions.
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
 if BOARD_MAX32658EVKIT_MAX32658_NS
-
-config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
 
 # MAX32658 has one UART interface,
 # It can be used either on TFM or Zephyr

--- a/boards/adi/max32658evkit/max32658evkit_max32658.dts
+++ b/boards/adi/max32658evkit/max32658evkit_max32658.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -30,17 +30,19 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		slot0_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x0 DT_SIZE_K(960)>;
 			read-only;
 		};
 
 		storage_partition: partition@f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xf0000 DT_SIZE_K(64)>;
 		};

--- a/boards/adi/max32658evkit/max32658evkit_max32658_defconfig
+++ b/boards/adi/max32658evkit/max32658evkit_max32658_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Enable GPIO
@@ -14,3 +14,5 @@ CONFIG_UART_INTERRUPT_DRIVEN=y
 
 # It is secure fw, enable flags
 CONFIG_TRUSTED_EXECUTION_SECURE=y
+
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/boards/adi/max32658evkit/max32658evkit_max32658_ns.dts
+++ b/boards/adi/max32658evkit/max32658evkit_max32658_ns.dts
@@ -70,9 +70,9 @@
 		 * };
 		 */
 
-		storage_partition: partition@f0000 {
+		tfm_storage_partition: partition@f0000 {
 			compatible = "zephyr,mapped-partition";
-			label = "storage";
+			label = "tfm-storage";
 			reg = <0xf0000 DT_SIZE_K(64)>;
 		};
 	};

--- a/boards/adi/max32658evkit/max32658evkit_max32658_ns.dts
+++ b/boards/adi/max32658evkit/max32658evkit_max32658_ns.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -36,22 +36,25 @@
 
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges;
 
 		boot_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0";
 			reg = <0x10000 DT_SIZE_K(320)>;
 		};
 
 		slot0_ns_partition: partition@60000 {
+			compatible = "zephyr,mapped-partition";
 			label = "image-0-nonsecure";
 			reg = <0x60000 DT_SIZE_K(576)>;
 		};
@@ -68,6 +71,7 @@
 		 */
 
 		storage_partition: partition@f0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0xf0000 DT_SIZE_K(64)>;
 		};

--- a/boards/adi/max32658evkit/max32658evkit_max32658_ns_defconfig
+++ b/boards/adi/max32658evkit/max32658evkit_max32658_ns_defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Analog Devices, Inc.
+# Copyright (c) 2024-2026 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Enable GPIO
@@ -17,3 +17,5 @@ CONFIG_TRUSTED_EXECUTION_NONSECURE=y
 
 # Set TFM and Zephyr sign key
 CONFIG_TFM_MCUBOOT_SIGNATURE_TYPE="RSA-3072"
+
+CONFIG_USE_DT_CODE_PARTITION=y

--- a/dts/arm/adi/max32/max32657.dtsi
+++ b/dts/arm/adi/max32/max32657.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  * Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -23,22 +23,6 @@
 				ranges = <0x8000 0x50008000 0x1000>;
 			};
 
-			flc0: flash_controller@29000 {
-				compatible = "adi,max32-flash-controller";
-				reg = <0x29000 0x400>;
-
-				#address-cells = <1>;
-				#size-cells = <1>;
-				status = "okay";
-
-				flash0: flash@1000000 {
-					compatible = "soc-nv-flash";
-					reg = <0x01000000 DT_SIZE_K(1024)>;
-					write-block-size = <16>;
-					erase-block-size = <8192>;
-				};
-			};
-
 			dma1: dma@35000 {
 				compatible = "adi,max32-dma";
 				reg = <0x35000 0x1000>;
@@ -47,6 +31,25 @@
 				dma-channels = <4>;
 				status = "disabled";
 				#dma-cells = <2>;
+			};
+		};
+
+		flc0: flash_controller@50029000 {
+			compatible = "adi,max32-flash-controller";
+			reg = <0x50029000 0x400>;
+			ranges;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			status = "okay";
+
+			flash0: flash@1000000 {
+				compatible = "soc-nv-flash";
+				reg = <0x01000000 DT_SIZE_K(1024)>;
+				write-block-size = <16>;
+				erase-block-size = <8192>;
+				ranges = <0x0 0x1000000 DT_SIZE_K(1024)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 	};

--- a/dts/arm/adi/max32/max32657_ns.dtsi
+++ b/dts/arm/adi/max32/max32657_ns.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Analog Devices, Inc.
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -35,7 +35,7 @@
 		flc0: flash_controller@50029000 {
 			compatible = "adi,max32-flash-controller";
 			reg = <0x50029000 0x400>;
-
+			ranges;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "disabled";
@@ -45,6 +45,9 @@
 				reg = <0x01000000 DT_SIZE_K(1024)>;
 				write-block-size = <16>;
 				erase-block-size = <8192>;
+				ranges = <0x0 0x1000000 DT_SIZE_K(1024)>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 			};
 		};
 	};


### PR DESCRIPTION
Migrate MAX32657 and MAX32658 boards to use `zephyr,mapped-partitions` as part of https://github.com/zephyrproject-rtos/zephyr/issues/107737.