### PR TITLE
kernel: initialize swap_data if CONFIG_SPIN_VALIDATE

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -1111,7 +1111,10 @@ void z_init_thread_base(struct _thread_base *thread_base, int priority,
 	thread_base->slice_expired = NULL;
 #endif /* CONFIG_TIMESLICE_PER_THREAD */
 
-	/* swap_data does not need to be initialized */
+#ifdef CONFIG_SPIN_VALIDATE
+	thread_base->swap_data = NULL;
+	/* otherwise swap_data does not need to be initialized */
+#endif
 
 	z_init_thread_timeout(thread_base);
 }


### PR DESCRIPTION
With CONFIG_SPIN_VALIDATE, z_assert_can_swap() & halt_thread() check if the value set in base.swap_data corresponds to &z_spinlock_abort_sentinel (it will be set to this value in subsys/testsuite/ztest/src/ztest_error_hook.c if there is a fatal error or assert).
But nobody is initializing this (struct k_thread).base.swap_data to anything.
So when there is no failures (or no ztest code), we are checking a random value and potentially doing weird things.

Let's initialize it to NULL to avoid this.

This check was added in d844a4a861c7708a96e9d1d74383aa5362b374cb
* https://github.com/zephyrproject-rtos/zephyr/pull/109744