### PR TITLE
drivers: watchdog: MSPM0 WWDT native register access + interval-timer

### DIFF
--- a/boards/ti/lp_mspm0g3507/lp_mspm0g3507.dts
+++ b/boards/ti/lp_mspm0g3507/lp_mspm0g3507.dts
@@ -20,6 +20,8 @@
 	aliases {
 		led0 = &led0;
 		pwm-led0 = &pwm_led0;
+		watchdog0 = &wdt0;
+		watchdog1 = &wdt1;
 	};
 
 	chosen {

--- a/boards/ti/lp_mspm0g3507/lp_mspm0g3507.yaml
+++ b/boards/ti/lp_mspm0g3507/lp_mspm0g3507.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 32
 flash: 128
 supported:
+  - watchdog
   - uart
   - gpio
   - can

--- a/boards/ti/lp_mspm0g3519/lp_mspm0g3519.dts
+++ b/boards/ti/lp_mspm0g3519/lp_mspm0g3519.dts
@@ -23,6 +23,8 @@
 		led2 = &led2;
 		sw0 = &btn0;
 		sw1 = &btn1;
+		watchdog0 = &wdt0;
+		watchdog1 = &wdt1;
 	};
 
 	chosen {

--- a/boards/ti/lp_mspm0g3519/lp_mspm0g3519.yaml
+++ b/boards/ti/lp_mspm0g3519/lp_mspm0g3519.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 128
 flash: 512
 supported:
+  - watchdog
   - uart
   - gpio
   - can

--- a/boards/ti/lp_mspm0l2228/lp_mspm0l2228.dts
+++ b/boards/ti/lp_mspm0l2228/lp_mspm0l2228.dts
@@ -19,6 +19,7 @@
 	aliases {
 		led0 = &led0;
 		led1 = &led1;
+		watchdog0 = &wdt0;
 	};
 
 	chosen {

--- a/boards/ti/lp_mspm0l2228/lp_mspm0l2228.yaml
+++ b/boards/ti/lp_mspm0l2228/lp_mspm0l2228.yaml
@@ -9,6 +9,7 @@ toolchain:
 ram: 32
 flash: 256
 supported:
+  - watchdog
   - gpio
   - pinctrl
   - uart

--- a/drivers/watchdog/wdt_mspm0.c
+++ b/drivers/watchdog/wdt_mspm0.c
@@ -9,15 +9,95 @@
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/logging/log.h>
 
-/* Driverlib includes */
-#include <ti/driverlib/dl_wwdt.h>
-
 #define DT_DRV_COMPAT ti_mspm0_watchdog
 
 LOG_MODULE_REGISTER(wdt_mspm0, CONFIG_WDT_LOG_LEVEL);
 
+/* WWDT register map — TRM "Windowed Watchdog Timer" chapter */
+
+struct wwdt_mspm0_gprcm {
+	volatile uint32_t PWREN;
+	volatile uint32_t RSTCTL;
+	uint32_t RESERVED[3];
+	volatile uint32_t STAT;
+};
+
+struct wwdt_mspm0_regs {
+	uint32_t RESERVED0[512];      /* 0x000–0x7FF */
+	struct wwdt_mspm0_gprcm GPRCM; /* 0x800       */
+	uint32_t RESERVED1[512];
+	volatile uint32_t PDBGCTL; /* 0x1018 — debug halt control      */
+	uint32_t RESERVED2;
+	volatile uint32_t IIDX; /* 0x1020 */
+	uint32_t RESERVED3;
+	volatile uint32_t IMASK; /* 0x1028 */
+	uint32_t RESERVED4;
+	volatile uint32_t RIS; /* 0x1030 */
+	uint32_t RESERVED5;
+	volatile uint32_t MIS; /* 0x1038 */
+	uint32_t RESERVED6;
+	volatile uint32_t ISET; /* 0x1040 */
+	uint32_t RESERVED7;
+	volatile uint32_t ICLR; /* 0x1048 */
+	uint32_t RESERVED8[37];
+	volatile uint32_t EVT_MODE; /* 0x10E0 */
+	uint32_t RESERVED9[6];
+	volatile uint32_t DESC;       /* 0x10FC */
+	volatile uint32_t WWDTCTL0;   /* 0x1100 — starts watchdog on write */
+	volatile uint32_t WWDTCTL1;   /* 0x1104 — window slot select       */
+	volatile uint32_t WWDTCNTRST; /* 0x1108 — feed: write 0x00A7       */
+	volatile uint32_t WWDTSTAT;   /* 0x110C — RUN bit (read-only)      */
+};
+
+BUILD_ASSERT(offsetof(struct wwdt_mspm0_regs, GPRCM) == 0x0800U);
+BUILD_ASSERT(offsetof(struct wwdt_mspm0_regs, PDBGCTL) == 0x1018U);
+BUILD_ASSERT(offsetof(struct wwdt_mspm0_regs, IMASK) == 0x1028U);
+BUILD_ASSERT(offsetof(struct wwdt_mspm0_regs, ICLR) == 0x1048U);
+BUILD_ASSERT(offsetof(struct wwdt_mspm0_regs, WWDTCTL0) == 0x1100U);
+BUILD_ASSERT(offsetof(struct wwdt_mspm0_regs, WWDTSTAT) == 0x110CU);
+
+/* GPRCM.PWREN */
+#define WWDT_PWREN_KEY    0x26000000U
+#define WWDT_PWREN_ENABLE 0x00000001U
+
+/* GPRCM.RSTCTL */
+#define WWDT_RSTCTL_KEY     0xB1000000U
+#define WWDT_RSTCTL_STKYCLR 0x00000002U
+#define WWDT_RSTCTL_ASSERT  0x00000001U
+
+/* WWDTCTL0 — key required on every write; wrong key -> ESM error */
+#define WWDT_CTL0_KEY         0xC9000000U
+/* PER field [6:4] */
+#define WWDT_CTL0_PER_25      0x00000000U
+#define WWDT_CTL0_PER_21      0x00000010U
+#define WWDT_CTL0_PER_18      0x00000020U
+#define WWDT_CTL0_PER_15      0x00000030U
+#define WWDT_CTL0_PER_12      0x00000040U
+#define WWDT_CTL0_PER_10      0x00000050U
+#define WWDT_CTL0_PER_8       0x00000060U
+#define WWDT_CTL0_PER_6       0x00000070U
+/* WINDOW0 [10:8] and WINDOW1 [14:12] field offsets */
+#define WWDT_CTL0_WINDOW0_OFS 8U
+#define WWDT_CTL0_WINDOW1_OFS 12U
+/* STISM [17] — stop-in-sleep */
+#define WWDT_CTL0_STISM_CONT  0x00000000U
+#define WWDT_CTL0_STISM_STOP  0x00020000U
+
+/* WWDTCTL1 */
+#define WWDT_CTL1_KEY 0xBE000000U
+
+/* WWDTCNTRST — write exactly this magic; anything else -> ESM error */
+#define WWDT_CNTRST_KEY 0x00A7U
+
+/* WWDTSTAT */
+#define WWDT_STAT_RUN 0x00000001U
+
+/* PDBGCTL — debug halt behavior */
+#define WWDT_PDBGCTL_STOP 0x00000000U /* halt with core */
+#define WWDT_PDBGCTL_FREE 0x00000001U /* keep counting under debugger */
+
 struct wwdt_mspm0_config {
-	WWDT_Regs *base;
+	struct wwdt_mspm0_regs *base;
 	uint8_t reset_action;
 	uint8_t closed_window;
 };
@@ -29,73 +109,76 @@ struct wwdt_mspm0_data {
 };
 
 struct wwdt_period_lut {
-	uint8_t period_count;
-	uint32_t max_msec;
-	uint32_t interval;
+	uint32_t period_count; /* WWDTCTL0.PER raw value */
+	uint32_t per_counts;   /* 2^n counter counts      */
 };
 
 static int wwdt_mspm0_calculate_timeout_periods(const struct device *dev,
 						const struct wdt_timeout_cfg *cfg)
 {
+	/* PER field values and their corresponding counter bit-widths */
+	static const struct wwdt_period_lut period_lut[] = {
+		{WWDT_CTL0_PER_6,  64},
+		{WWDT_CTL0_PER_8,  256},
+		{WWDT_CTL0_PER_10, 1024},
+		{WWDT_CTL0_PER_12, 4096},
+		{WWDT_CTL0_PER_15, 32768},
+		{WWDT_CTL0_PER_18, 262144},
+		{WWDT_CTL0_PER_21, 2097152},
+		{WWDT_CTL0_PER_25, 33554432},
+	};
+	static const uint8_t window_sixteenths[] = {0, 2, 3, 4, 8, 12, 13, 14};
 	struct wwdt_mspm0_data *data = dev->data;
-	struct wwdt_period_lut *lut_entry = NULL;
 	uint32_t max_ms = cfg->window.max;
 	uint32_t min_ms = cfg->window.min;
 	uint32_t actual_timeout;
 	uint8_t window_idx;
+	uint32_t lut_idx;
 
-	struct wwdt_period_lut period_lut[] = {
-		/* Timer_max_period_count,	 max_timeout(ms),   interval(ms) */
-		{DL_WWDT_TIMER_PERIOD_6_BITS,	       16,		2},
-		{DL_WWDT_TIMER_PERIOD_8_BITS,	       64,		8},
-		{DL_WWDT_TIMER_PERIOD_10_BITS,	       256,		32},
-		{DL_WWDT_TIMER_PERIOD_12_BITS,	       1000,		125},
-		{DL_WWDT_TIMER_PERIOD_15_BITS,	       8000,		1000},
-		{DL_WWDT_TIMER_PERIOD_18_BITS,	       64000,		8000},
-		{DL_WWDT_TIMER_PERIOD_21_BITS,	       512000,		64000},
-		{DL_WWDT_TIMER_PERIOD_25_BITS,	       8192000,		1024000}
-	};
+	/* Compute max achievable timeout at CLKDIV=7: 8 * 2^25 * 1000 / 32768 ms */
+	uint32_t abs_max_ms =
+		(uint32_t)(((uint64_t)8 * period_lut[7].per_counts * 1000U) / 32768U);
 
-	uint8_t window_sixteenths[] = {0, 2, 3, 4, 8, 12, 13, 14};
-
-	if (max_ms > period_lut[7].max_msec || min_ms >= max_ms) {
+	if (max_ms > abs_max_ms || min_ms >= max_ms) {
 		LOG_ERR("Install timeout failed. Invalid window timing");
 		return -EINVAL;
 	}
 
-	/* Find appropriate period count (PER_count) */
-	for (uint8_t i = 0; i < 8; i++) {
-		if (max_ms <= period_lut[i].max_msec) {
-			lut_entry = &period_lut[i];
+	/* Find smallest PER where max_timeout_ms (at CLKDIV=7) >= max_ms */
+	for (lut_idx = 0; lut_idx < ARRAY_SIZE(period_lut); lut_idx++) {
+		uint32_t max_timeout_ms = (uint32_t)(
+			((uint64_t)8 * period_lut[lut_idx].per_counts * 1000U) / 32768U);
+
+		if (max_ms <= max_timeout_ms) {
 			break;
 		}
 	}
 
-	data->period_count = lut_entry->period_count;
+	data->period_count = (uint8_t)period_lut[lut_idx].period_count;
 
-	/*
-	 * Determine clock divider based on the period count. Since rounding up
-	 * is the defined behavior, walking up and checking for when the value is
-	 * equal or underneath will yield the rounded up value
-	 */
-	actual_timeout = lut_entry->interval;
+	/* Walk CLKDIV 0->7 to find smallest divider where timeout >= max_ms */
 	for (data->clock_divider = 0; data->clock_divider < 8; data->clock_divider++) {
+		actual_timeout = (uint32_t)(((uint64_t)(data->clock_divider + 1U) *
+					     period_lut[lut_idx].per_counts * 1000U) / 32768U);
 		if (max_ms <= actual_timeout) {
 			break;
 		}
-		actual_timeout += lut_entry->interval;
 	}
+	data->clock_divider = MIN(data->clock_divider, 7U);
 
-	/* Determine closed window as per the requested lower limit of watchdog feed timeout */
-	for (window_idx = 0; window_idx < 7; window_idx++) {
+	/* Find smallest closed-window fraction that enforces min_ms */
+	for (window_idx = 0; window_idx < ARRAY_SIZE(window_sixteenths); window_idx++) {
 		if (min_ms <= (actual_timeout * window_sixteenths[window_idx] / 16)) {
-			/* Use the chosen window size by window_idx */
 			break;
 		}
-		/* If no match, the largest window available is chosen (87.5%) */
 	}
 
-	data->window_count = (window_idx << WWDT_WWDTCTL0_WINDOW0_OFS);
+	if (window_idx >= ARRAY_SIZE(window_sixteenths)) {
+		LOG_ERR("Install timeout failed. min_ms %u cannot be enforced", min_ms);
+		return -EINVAL;
+	}
+
+	data->window_count = (window_idx << WWDT_CTL0_WINDOW0_OFS);
 
 	return 0;
 }
@@ -104,23 +187,35 @@ static int wwdt_mspm0_setup(const struct device *dev, uint8_t options)
 {
 	const struct wwdt_mspm0_config *config = dev->config;
 	struct wwdt_mspm0_data *data = dev->data;
-	DL_WWDT_SLEEP_MODE sleep_mode = DL_WWDT_RUN_IN_SLEEP;
+	struct wwdt_mspm0_regs *base = config->base;
+	uint32_t stism = WWDT_CTL0_STISM_CONT;
+	uint32_t window0_closed;
+	uint32_t window1_closed;
 
 	if ((options & WDT_OPT_PAUSE_IN_SLEEP) == WDT_OPT_PAUSE_IN_SLEEP) {
-		sleep_mode = DL_WWDT_STOP_IN_SLEEP;
+		stism = WWDT_CTL0_STISM_STOP;
 	}
 
 	if ((options & WDT_OPT_PAUSE_HALTED_BY_DBG) != WDT_OPT_PAUSE_HALTED_BY_DBG) {
 		/* On reset the MSPM0 is set to halt with the core halting */
-		DL_WWDT_setCoreHaltBehavior(config->base, DL_WWDT_CORE_HALT_FREE_RUN);
+		base->PDBGCTL = WWDT_PDBGCTL_FREE;
 	}
 
 	/* This call enables the Watchdog */
-	DL_WWDT_setActiveWindow(config->base, config->closed_window);
-	DL_WWDT_initWatchdogMode(config->base, data->clock_divider,
-				 data->period_count, sleep_mode,
-				 config->closed_window ? 0 : data->window_count,
-				 config->closed_window ? data->window_count : 0);
+	base->WWDTCTL1 = WWDT_CTL1_KEY | (config->closed_window & 1U);
+
+	if (config->closed_window) {
+		window0_closed = 0;
+		window1_closed = data->window_count;
+	} else {
+		window0_closed = data->window_count;
+		window1_closed = 0;
+	}
+
+	base->WWDTCTL0 = WWDT_CTL0_KEY | data->clock_divider | data->period_count | stism |
+			 window0_closed |
+			 (window1_closed << (WWDT_CTL0_WINDOW1_OFS - WWDT_CTL0_WINDOW0_OFS));
+
 	return 0;
 }
 
@@ -136,7 +231,7 @@ static int wwdt_mspm0_install_timeout(const struct device *dev, const struct wdt
 	const struct wwdt_mspm0_config *config = dev->config;
 
 	/* Cannot install timeout if the WWDT is already running */
-	if (DL_WWDT_isRunning(config->base)) {
+	if (config->base->WWDTSTAT & WWDT_STAT_RUN) {
 		LOG_ERR("Install timeout failed. WWDT is already running");
 		return -EBUSY;
 	}
@@ -160,15 +255,23 @@ static int wwdt_mspm0_install_timeout(const struct device *dev, const struct wdt
 
 static int wwdt_mspm0_feed(const struct device *dev, int channel_id)
 {
+	const struct wwdt_mspm0_config *config = dev->config;
+
 	ARG_UNUSED(channel_id);
-	DL_WWDT_restart(((const struct wwdt_mspm0_config *)dev->config)->base);
+	config->base->WWDTCNTRST = WWDT_CNTRST_KEY;
 
 	return 0;
 }
 
 static int wwdt_mspm0_init(const struct device *dev)
 {
-	DL_WWDT_enablePower(((const struct wwdt_mspm0_config *)dev->config)->base);
+	const struct wwdt_mspm0_config *config = dev->config;
+	struct wwdt_mspm0_regs *base = config->base;
+
+	/* Reset peripheral and enable power — matches counter/PWM init sequence. */
+	base->GPRCM.RSTCTL = WWDT_RSTCTL_KEY | WWDT_RSTCTL_STKYCLR | WWDT_RSTCTL_ASSERT;
+	base->GPRCM.PWREN = WWDT_PWREN_KEY | WWDT_PWREN_ENABLE;
+	k_busy_wait(1U);
 
 	return 0;
 }
@@ -180,9 +283,10 @@ static DEVICE_API(wdt, wwdt_mspm0_driver_api) = {
 	.feed = wwdt_mspm0_feed
 };
 
-#define MSP_WDT_INIT_FN(index)								\
+#define WWDT_MSPM0_INIT(index)								\
+
 static const struct wwdt_mspm0_config wwdt_mspm0_cfg_##index = {			\
-	.base =  (WWDT_Regs *)DT_INST_REG_ADDR(index),					\
+	.base = (struct wwdt_mspm0_regs *)DT_INST_REG_ADDR(index),			\
 	.reset_action = COND_CODE_1(DT_INST_PROP(index, ti_watchdog_reset_action),	\
 				    (WDT_FLAG_RESET_SOC), (WDT_FLAG_RESET_CPU_CORE)),	\
 	.closed_window = DT_INST_PROP(index, closed_window),				\
@@ -195,4 +299,4 @@ DEVICE_DT_INST_DEFINE(index, wwdt_mspm0_init, NULL, &wwdt_mspm0_data_##index,		\
 		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,				\
 		      &wwdt_mspm0_driver_api);						\
 
-DT_INST_FOREACH_STATUS_OKAY(MSP_WDT_INIT_FN)
+DT_INST_FOREACH_STATUS_OKAY(WWDT_MSPM0_INIT)

--- a/drivers/watchdog/wdt_mspm0.c
+++ b/drivers/watchdog/wdt_mspm0.c
@@ -79,9 +79,6 @@ BUILD_ASSERT(offsetof(struct wwdt_mspm0_regs, WWDTSTAT) == 0x110CU);
 /* WINDOW0 [10:8] and WINDOW1 [14:12] field offsets */
 #define WWDT_CTL0_WINDOW0_OFS 8U
 #define WWDT_CTL0_WINDOW1_OFS 12U
-/* STISM [17] — stop-in-sleep */
-#define WWDT_CTL0_STISM_CONT  0x00000000U
-#define WWDT_CTL0_STISM_STOP  0x00020000U
 
 /* WWDTCTL1 */
 #define WWDT_CTL1_KEY 0xBE000000U
@@ -166,7 +163,7 @@ static int wwdt_mspm0_calculate_timeout_periods(const struct device *dev,
 	}
 	data->clock_divider = MIN(data->clock_divider, 7U);
 
-	/* Find smallest closed-window fraction that enforces min_ms */
+	/* Determine closed window as per the requested lower limit of watchdog feed timeout */
 	for (window_idx = 0; window_idx < ARRAY_SIZE(window_sixteenths); window_idx++) {
 		if (min_ms <= (actual_timeout * window_sixteenths[window_idx] / 16)) {
 			break;
@@ -188,12 +185,12 @@ static int wwdt_mspm0_setup(const struct device *dev, uint8_t options)
 	const struct wwdt_mspm0_config *config = dev->config;
 	struct wwdt_mspm0_data *data = dev->data;
 	struct wwdt_mspm0_regs *base = config->base;
-	uint32_t stism = WWDT_CTL0_STISM_CONT;
 	uint32_t window0_closed;
 	uint32_t window1_closed;
 
-	if ((options & WDT_OPT_PAUSE_IN_SLEEP) == WDT_OPT_PAUSE_IN_SLEEP) {
-		stism = WWDT_CTL0_STISM_STOP;
+	if (options & WDT_OPT_PAUSE_IN_SLEEP) {
+		/* hw_wwdt.h: STISM has no effect for the global Window Watchdog. */
+		return -ENOTSUP;
 	}
 
 	if ((options & WDT_OPT_PAUSE_HALTED_BY_DBG) != WDT_OPT_PAUSE_HALTED_BY_DBG) {
@@ -212,7 +209,7 @@ static int wwdt_mspm0_setup(const struct device *dev, uint8_t options)
 		window1_closed = 0;
 	}
 
-	base->WWDTCTL0 = WWDT_CTL0_KEY | data->clock_divider | data->period_count | stism |
+	base->WWDTCTL0 = WWDT_CTL0_KEY | data->clock_divider | data->period_count |
 			 window0_closed |
 			 (window1_closed << (WWDT_CTL0_WINDOW1_OFS - WWDT_CTL0_WINDOW0_OFS));
 

--- a/drivers/watchdog/wdt_mspm0.c
+++ b/drivers/watchdog/wdt_mspm0.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/mspm0_clock_control.h>
 #include <zephyr/drivers/watchdog.h>
+#include <zephyr/irq.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
@@ -81,6 +82,9 @@ BUILD_ASSERT(offsetof(struct wwdt_mspm0_regs, WWDTSTAT) == 0x110CU);
 /* WINDOW0 [10:8] and WINDOW1 [14:12] field offsets */
 #define WWDT_CTL0_WINDOW0_OFS 8U
 #define WWDT_CTL0_WINDOW1_OFS 12U
+/* MODE [16] */
+#define WWDT_CTL0_MODE_WINDOW   0x00000000U
+#define WWDT_CTL0_MODE_INTERVAL 0x00010000U
 
 /* WWDTCTL1 */
 #define WWDT_CTL1_KEY 0xBE000000U
@@ -95,20 +99,42 @@ BUILD_ASSERT(offsetof(struct wwdt_mspm0_regs, WWDTSTAT) == 0x110CU);
 #define WWDT_PDBGCTL_STOP 0x00000000U /* halt with core */
 #define WWDT_PDBGCTL_FREE 0x00000001U /* keep counting under debugger */
 
+/*
+ * CPU_INT — single source: INTTIM (bit 0).
+ * Fires only in interval-timer mode (WWDTCTL0.MODE = MODE_INTERVAL).
+ * In window-watchdog mode violations go to the ESM, not this interrupt.
+ */
+#define WWDT_INT_INTTIM 0x00000001U
+
+/* True when the DT node has an interrupts property (interval mode capable) */
+#define WWDT_MSPM0_HAS_IRQ(n) DT_INST_NODE_HAS_PROP(n, interrupts)
+
 struct wwdt_mspm0_config {
 	struct wwdt_mspm0_regs *base;
-	uint8_t reset_action;
 	uint8_t closed_window;
+	/* Zephyr flag expected by install_timeout() — WWDT always does SYSRST. */
+	uint8_t reset_action;
 	const struct device *clock_dev;
 	struct mspm0_sys_clock clock_subsys;
+	/* NULL on instances without an interrupts DT property (window-mode only). */
+	void (*irq_config_func)(const struct device *dev);
+	int irq_num;
 };
 
 struct wwdt_mspm0_data {
-	uint8_t period_count;
-	uint8_t clock_divider;
-	uint16_t window_count;
-	bool timeout_valid; /* true after install_timeout(), false after disable() */
-	bool is_setup;      /* true after setup(), false after disable() */
+	uint8_t period_count;  /* WWDTCTL0.PER field raw bits */
+	uint8_t clock_divider; /* WWDTCTL0.CLKDIV raw 0–7 */
+	uint16_t window_count; /* WINDOW0 field raw bits (shifted to [10:8]) */
+	bool timeout_valid;    /* true after install_timeout(), false after disable() */
+	bool is_interval_mode; /* true when WDT_FLAG_RESET_NONE path selected */
+	/*
+	 * Authoritative "driver active" flag — set by setup(), cleared by disable().
+	 * Cannot use WWDTSTAT.RUN: it stays 1 after interval-mode disable() since
+	 * the hardware counter cannot be stopped. volatile: written by thread
+	 * (disable()), read by INTTIM ISR.
+	 */
+	volatile bool is_setup;
+	volatile wdt_callback_t callback; /* volatile: written by thread, read by ISR */
 	struct k_mutex lock;
 };
 
@@ -207,6 +233,11 @@ static int wwdt_mspm0_calculate_timeout_periods(const struct device *dev,
 		}
 	}
 
+	/*
+	 * If no available fraction enforces the requested min_ms, the hardware
+	 * cannot satisfy the constraint — return an error rather than silently
+	 * programming a wider window than requested.
+	 */
 	if (window_idx >= ARRAY_SIZE(window_sixteenths)) {
 		LOG_ERR("min_ms %u cannot be enforced; max available closed "
 			"window is %u ms",
@@ -221,13 +252,41 @@ static int wwdt_mspm0_calculate_timeout_periods(const struct device *dev,
 	return 0;
 }
 
+static void wwdt_mspm0_isr(const struct device *dev)
+{
+	const struct wwdt_mspm0_config *config = dev->config;
+	struct wwdt_mspm0_data *data = dev->data;
+	struct wwdt_mspm0_regs *base = config->base;
+
+	/*
+	 * z_shared_isr calls every handler registered on this IRQ line.
+	 * Check RIS first so we only act when this instance actually fired.
+	 */
+	if (!(base->RIS & WWDT_INT_INTTIM)) {
+		return;
+	}
+
+	base->ICLR = WWDT_INT_INTTIM;
+
+	/*
+	 * The hardware counter keeps running after disable() — no stop register
+	 * exists. is_setup=false (set by disable() before any IRQ operations)
+	 * is the software gate against spurious fires.
+	 */
+	if (!data->is_setup) {
+		return;
+	}
+
+	if (data->callback) {
+		data->callback(dev, 0);
+	}
+}
+
 static int wwdt_mspm0_setup(const struct device *dev, uint8_t options)
 {
 	const struct wwdt_mspm0_config *config = dev->config;
 	struct wwdt_mspm0_data *data = dev->data;
 	struct wwdt_mspm0_regs *base = config->base;
-	uint32_t window0_closed;
-	uint32_t window1_closed;
 
 	k_mutex_lock(&data->lock, K_FOREVER);
 
@@ -242,30 +301,75 @@ static int wwdt_mspm0_setup(const struct device *dev, uint8_t options)
 		return -EBUSY;
 	}
 
+	/*
+	 * hw_wwdt.h: STISM "has no effect for the global Window Watchdog as
+	 * Sleep Mode is not supported." Return -ENOTSUP rather than silently
+	 * ignoring the request.
+	 */
 	if (options & WDT_OPT_PAUSE_IN_SLEEP) {
-		/* hw_wwdt.h: STISM has no effect for the global Window Watchdog. */
 		k_mutex_unlock(&data->lock);
 		return -ENOTSUP;
 	}
 
-	if ((options & WDT_OPT_PAUSE_HALTED_BY_DBG) != WDT_OPT_PAUSE_HALTED_BY_DBG) {
-		/* On reset the MSPM0 is set to halt with the core halting */
-		base->PDBGCTL = WWDT_PDBGCTL_FREE;
+	/* STOP halts with core; FREE keeps counting under debugger (default). */
+	base->PDBGCTL =
+		(options & WDT_OPT_PAUSE_HALTED_BY_DBG) ? WWDT_PDBGCTL_STOP : WWDT_PDBGCTL_FREE;
+
+	if (data->is_interval_mode) {
+		/* Interval-timer mode: INTTIM fires on each expiry, auto-reloads, no reset.
+		 */
+		uint32_t ctl0 = WWDT_CTL0_KEY | (uint32_t)data->clock_divider |
+				(uint32_t)data->period_count | WWDT_CTL0_MODE_INTERVAL;
+
+		base->WWDTCTL0 = ctl0;
+		/*
+		 * WWDTCNTRST restarts the counter. WWDTCTL0 updates config but
+		 * does not reset a running counter — hardware keeps counting across
+		 * disable() calls (no stop register on MSPM0 WWDT). Without this
+		 * the interval fires at the inherited counter position.
+		 * No closed-window constraint in interval mode so write is safe.
+		 */
+		base->WWDTCNTRST = WWDT_CNTRST_KEY;
+		/* Clear stale RIS before enabling IMASK to prevent immediate ISR. */
+		base->ICLR = WWDT_INT_INTTIM;
+		base->IMASK = WWDT_INT_INTTIM;
+
+		/*
+		 * Release mutex before irq_enable(): avoids holding the lock
+		 * across IRQ_CONNECT/irq_enable(). feed() itself skips the
+		 * lock entirely when called from ISR context (see
+		 * wwdt_mspm0_feed()), so this isn't required for that reason,
+		 * but keeping the critical section short is still good
+		 * practice.
+		 */
+		data->is_setup = true;
+		k_mutex_unlock(&data->lock);
+		config->irq_config_func(dev);
+		return 0;
 	}
 
-	/* This call enables the Watchdog */
+	/* Window-watchdog mode */
+	uint32_t window0_closed;
+	uint32_t window1_closed;
+
+	/* Select active window slot — must write WWDTCTL1 before WWDTCTL0 */
 	base->WWDTCTL1 = WWDT_CTL1_KEY | (config->closed_window & 1U);
 
 	if (config->closed_window) {
-		window0_closed = 0;
+		window0_closed = 0U;
 		window1_closed = data->window_count;
 	} else {
 		window0_closed = data->window_count;
-		window1_closed = 0;
+		window1_closed = 0U;
 	}
 
-	base->WWDTCTL0 = WWDT_CTL0_KEY | data->clock_divider | data->period_count |
-			 window0_closed |
+	/*
+	 * Writing WWDTCTL0 starts the watchdog immediately.
+	 * WINDOW0 encoding is at bits [10:8]; WINDOW1 uses the same encoding
+	 * but at bits [14:12] — shift left by (12 - 8) = 4.
+	 */
+	base->WWDTCTL0 = WWDT_CTL0_KEY | (uint32_t)data->clock_divider |
+			 (uint32_t)data->period_count | window0_closed |
 			 (window1_closed << (WWDT_CTL0_WINDOW1_OFS - WWDT_CTL0_WINDOW0_OFS));
 
 	data->is_setup = true;
@@ -275,72 +379,121 @@ static int wwdt_mspm0_setup(const struct device *dev, uint8_t options)
 
 static int wwdt_mspm0_disable(const struct device *dev)
 {
+	const struct wwdt_mspm0_config *config = dev->config;
 	struct wwdt_mspm0_data *data = dev->data;
-	int ret;
+	struct wwdt_mspm0_regs *base = config->base;
+	bool is_interval;
 
 	k_mutex_lock(&data->lock, K_FOREVER);
+	is_interval = data->is_interval_mode;
 
-	/*
-	 * hw_wwdt.h: "For safety devices a watchdog reset by software is not
-	 * possible." Once started, the WDT runs until SoC reset. -EFAULT if
-	 * never started (also frees the install slot), -EPERM if started.
-	 */
-	if (data->is_setup) {
-		ret = -EPERM;
-	} else {
+	if (is_interval) {
+		/*
+		 * Hardware counter cannot be stopped (no stop register). Mask the
+		 * interrupt and gate the ISR via is_setup — that is the only reliable
+		 * "logically stopped" indicator.
+		 * is_setup cleared FIRST so any pending ISR sees it before irq_disable.
+		 */
+		int ret = data->is_setup ? 0 : -EFAULT;
+
+		data->is_setup = false;
+		data->is_interval_mode = false;
+		data->callback = NULL;
 		data->timeout_valid = false;
-		ret = -EFAULT;
+
+		base->IMASK = 0U;
+		base->ICLR = WWDT_INT_INTTIM;
+
+		if (config->irq_num >= 0) {
+			irq_disable(config->irq_num);
+			NVIC_ClearPendingIRQ(config->irq_num);
+		}
+		k_mutex_unlock(&data->lock);
+		return ret;
 	}
 
+	/*
+	 * Window-watchdog mode: hw_wwdt.h: "For safety devices a watchdog reset
+	 * by software is not possible." Once started, the WDT runs until SoC
+	 * reset. -EFAULT if never started (also frees the install slot),
+	 * -EPERM if started.
+	 */
+	if (data->is_setup) {
+		k_mutex_unlock(&data->lock);
+		return -EPERM;
+	}
+
+	data->timeout_valid = false;
 	k_mutex_unlock(&data->lock);
-	return ret;
+	return -EFAULT;
 }
 
 static int wwdt_mspm0_install_timeout(const struct device *dev, const struct wdt_timeout_cfg *cfg)
 {
 	const struct wwdt_mspm0_config *config = dev->config;
 	struct wwdt_mspm0_data *data = dev->data;
+	wdt_callback_t cb = NULL;
+	bool interval_mode = false;
 	int ret;
 
 	k_mutex_lock(&data->lock, K_FOREVER);
 
-	/* Cannot install timeout if the WWDT is already running */
 	if (data->is_setup) {
 		LOG_ERR("Install timeout failed. WWDT is already running");
 		k_mutex_unlock(&data->lock);
 		return -EBUSY;
 	}
 
-	/* Single channel: slot freed by disable(). Second install before disable -> -ENOMEM. */
+	/* Single channel: slot freed by disable(). Second install before disable ->
+	 * -ENOMEM.
+	 */
 	if (data->timeout_valid) {
 		k_mutex_unlock(&data->lock);
 		return -ENOMEM;
 	}
 
-	if (cfg->callback) {
-		LOG_ERR("Install timeout failed. Callback not supported");
+	if ((cfg->flags & WDT_FLAG_RESET_MASK) == WDT_FLAG_RESET_NONE) {
+		/* Interval-timer mode: INTTIM fires on expiry, auto-reloads, no reset. */
+		if (!config->irq_config_func) {
+			LOG_ERR("Instance has no interrupt line (missing DT interrupts property)");
+			k_mutex_unlock(&data->lock);
+			return -ENOTSUP;
+		}
+		cb = cfg->callback;
+		interval_mode = true;
+	} else if (cfg->callback) {
+		/* Window-watchdog violations route to ESM, not NVIC — no pre-reset
+		 * callback.
+		 */
+		LOG_ERR("Callback requires WDT_FLAG_RESET_NONE");
 		k_mutex_unlock(&data->lock);
 		return -ENOTSUP;
+	} else {
+		/*
+		 * Window-watchdog mode. WWDT always generates SYSRST on violation
+		 * regardless of ti,watchdog-reset-action; the DT property is used
+		 * only to validate that the requested flag matches this instance.
+		 */
+		if ((cfg->flags & WDT_FLAG_RESET_MASK) > WDT_FLAG_RESET_SOC) {
+			LOG_ERR("Unsupported reset flags 0x%x", cfg->flags);
+			k_mutex_unlock(&data->lock);
+			return -ENOTSUP;
+		}
+		if ((cfg->flags & WDT_FLAG_RESET_MASK) != config->reset_action) {
+			LOG_ERR("Unsupported reset flag %u on this instance "
+				"(ti,watchdog-reset-action configures %u)",
+				cfg->flags & WDT_FLAG_RESET_MASK, config->reset_action);
+			k_mutex_unlock(&data->lock);
+			return -ENOTSUP;
+		}
+		interval_mode = false;
 	}
 
-	if ((cfg->flags & WDT_FLAG_RESET_MASK) > WDT_FLAG_RESET_SOC) {
-		LOG_ERR("Install timeout failed. Unsupported reset flags 0x%x", cfg->flags);
-		k_mutex_unlock(&data->lock);
-		return -ENOTSUP;
-	}
-
-	if ((cfg->flags & WDT_FLAG_RESET_MASK) != config->reset_action) {
-		LOG_ERR("Install timeout failed. Reset action mismatch");
-		k_mutex_unlock(&data->lock);
-		return -EINVAL;
-	}
-
-	/*
-	 * To calculate the timeout period as per :
-	 * TIMEOUT = (CLKDIV + 1) * PER_count / LFCLK Frequency
-	 */
+	/* Calculate periods before committing — leave state intact on failure. */
 	ret = wwdt_mspm0_calculate_timeout_periods(dev, cfg);
 	if (ret == 0) {
+		data->callback = cb;
+		data->is_interval_mode = interval_mode;
 		data->timeout_valid = true;
 	}
 
@@ -352,8 +505,24 @@ static int wwdt_mspm0_feed(const struct device *dev, int channel_id)
 {
 	const struct wwdt_mspm0_config *config = dev->config;
 	struct wwdt_mspm0_data *data = dev->data;
+	struct wwdt_mspm0_regs *base = config->base;
 
 	ARG_UNUSED(channel_id);
+
+	/*
+	 * May be called from the interval-timer ISR's callback (wwdt_mspm0_isr()).
+	 * k_mutex_lock() is illegal in ISR context, so skip the lock there — the
+	 * register write is safe unsynchronized; worst case is racing a
+	 * concurrent disable(), which is harmless since WWDTCNTRST can be
+	 * written regardless of software state.
+	 */
+	if (k_is_in_isr()) {
+		if (!data->is_setup) {
+			return -EINVAL;
+		}
+		base->WWDTCNTRST = WWDT_CNTRST_KEY;
+		return 0;
+	}
 
 	k_mutex_lock(&data->lock, K_FOREVER);
 
@@ -362,7 +531,8 @@ static int wwdt_mspm0_feed(const struct device *dev, int channel_id)
 		return -EINVAL;
 	}
 
-	config->base->WWDTCNTRST = WWDT_CNTRST_KEY;
+	/* Any value other than 0x00A7 triggers an ESM error. */
+	base->WWDTCNTRST = WWDT_CNTRST_KEY;
 
 	k_mutex_unlock(&data->lock);
 	return 0;
@@ -371,8 +541,8 @@ static int wwdt_mspm0_feed(const struct device *dev, int channel_id)
 static int wwdt_mspm0_init(const struct device *dev)
 {
 	const struct wwdt_mspm0_config *config = dev->config;
-	struct wwdt_mspm0_regs *base = config->base;
 	struct wwdt_mspm0_data *data = dev->data;
+	struct wwdt_mspm0_regs *base = config->base;
 
 	k_mutex_init(&data->lock);
 
@@ -391,22 +561,69 @@ static DEVICE_API(wdt, wwdt_mspm0_driver_api) = {
 	.feed = wwdt_mspm0_feed
 };
 
-#define WWDT_MSPM0_INIT(index)									\
-static const struct wwdt_mspm0_config wwdt_mspm0_cfg_##index = {					\
-	.base = (struct wwdt_mspm0_regs *)DT_INST_REG_ADDR(index),				\
-	.reset_action = COND_CODE_1(DT_INST_PROP(index, ti_watchdog_reset_action),	\
-				    (WDT_FLAG_RESET_SOC), (WDT_FLAG_RESET_CPU_CORE)),		\
-	.closed_window = DT_INST_PROP(index, closed_window),					\
-	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_IDX(index, 0)),			\
-	.clock_subsys = {									\
-		.clk = DT_INST_CLOCKS_CELL_BY_IDX(index, 0, clk),				\
-	},											\
-};												\
-												\
-static struct wwdt_mspm0_data wwdt_mspm0_data_##index;						\
-												\
-DEVICE_DT_INST_DEFINE(index, wwdt_mspm0_init, NULL, &wwdt_mspm0_data_##index,			\
-		      &wwdt_mspm0_cfg_##index, POST_KERNEL,					\
-		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,					\
-		      &wwdt_mspm0_driver_api);							\
+/* clang-format off */
+/*
+ * Detect at build time if multiple enabled instances share the same IRQ.
+ * When sharing is detected, CONFIG_SHARED_INTERRUPTS must be enabled so
+ * gen_isr_tables wires z_shared_isr to dispatch to each instance's ISR.
+ */
+#define WWDT_MSPM0_COUNT_MATCHING_IRQ(inst, irq_num)				\
+	+ (COND_CODE_1(WWDT_MSPM0_HAS_IRQ(inst),				\
+		((DT_INST_IRQN(inst) == (irq_num)) ? 1 : 0), (0)))
+
+#define WWDT_MSPM0_CHECK_SHARED_IRQ(index)					\
+	COND_CODE_1(WWDT_MSPM0_HAS_IRQ(index), (				\
+	BUILD_ASSERT(								\
+		(0 DT_INST_FOREACH_STATUS_OKAY_VARGS(				\
+			WWDT_MSPM0_COUNT_MATCHING_IRQ,				\
+			DT_INST_IRQN(index))) <= 1 ||				\
+		IS_ENABLED(CONFIG_SHARED_INTERRUPTS),				\
+		"Node " DT_NODE_PATH(DT_DRV_INST(index))			\
+		" shares its interrupt line with another "			\
+		"ti,mspm0-watchdog instance: "					\
+		"enable CONFIG_SHARED_INTERRUPTS");				\
+	), ())
+
+#define WWDT_MSPM0_IRQ_DEFINE(n)                                                                   \
+	static void wwdt_mspm0_##n##_irq_config(const struct device *dev)                          \
+	{                                                                                          \
+		ARG_UNUSED(dev);                                                                   \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), wwdt_mspm0_isr,             \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+		/* Belt-and-suspenders: clear any pending NVIC bit before enable. */               \
+		NVIC_ClearPendingIRQ(DT_INST_IRQN(n));                                            \
+		irq_enable(DT_INST_IRQN(n));                                                       \
+	}
+
+/* Gate IRQ definition per instance on whether the DT node has interrupts */
+#define WWDT_MSPM0_IRQ_DEFINE_IF_PRESENT(n)                                                        \
+	COND_CODE_1(WWDT_MSPM0_HAS_IRQ(n), (WWDT_MSPM0_IRQ_DEFINE(n)), ())
+
+#define WWDT_MSPM0_INIT(index)                                                                     \
+	WWDT_MSPM0_CHECK_SHARED_IRQ(index)                                                         \
+	WWDT_MSPM0_IRQ_DEFINE_IF_PRESENT(index)                                                    \
+                                                                                                   \
+	static struct wwdt_mspm0_data wwdt_mspm0_data_##index;                                     \
+                                                                                                   \
+	static const struct wwdt_mspm0_config wwdt_mspm0_cfg_##index = {                           \
+		.base = (struct wwdt_mspm0_regs *)DT_INST_REG_ADDR(index),                         \
+		.closed_window = DT_INST_PROP(index, closed_window),                               \
+		.reset_action = COND_CODE_1(                                                       \
+			DT_INST_PROP(index, ti_watchdog_reset_action),                             \
+			(WDT_FLAG_RESET_SOC), (WDT_FLAG_RESET_CPU_CORE)),                         \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_IDX(index, 0)),                  \
+		.clock_subsys = {                                                                  \
+			.clk = DT_INST_CLOCKS_CELL_BY_IDX(index, 0, clk),                         \
+		},                                                                                 \
+		.irq_config_func = COND_CODE_1(WWDT_MSPM0_HAS_IRQ(index),\
+			(wwdt_mspm0_##index##_irq_config), (NULL)),                           \
+		.irq_num = COND_CODE_1(WWDT_MSPM0_HAS_IRQ(index),                                  \
+			(DT_INST_IRQN(index)), (-1)),                                              \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(index, wwdt_mspm0_init, NULL, &wwdt_mspm0_data_##index,              \
+			      &wwdt_mspm0_cfg_##index, POST_KERNEL,                                \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &wwdt_mspm0_driver_api);
+
 DT_INST_FOREACH_STATUS_OKAY(WWDT_MSPM0_INIT)
+/* clang-format on */

--- a/drivers/watchdog/wdt_mspm0.c
+++ b/drivers/watchdog/wdt_mspm0.c
@@ -323,7 +323,13 @@ static int wwdt_mspm0_install_timeout(const struct device *dev, const struct wdt
 		return -ENOTSUP;
 	}
 
-	if (cfg->flags != config->reset_action) {
+	if ((cfg->flags & WDT_FLAG_RESET_MASK) > WDT_FLAG_RESET_SOC) {
+		LOG_ERR("Install timeout failed. Unsupported reset flags 0x%x", cfg->flags);
+		k_mutex_unlock(&data->lock);
+		return -ENOTSUP;
+	}
+
+	if ((cfg->flags & WDT_FLAG_RESET_MASK) != config->reset_action) {
 		LOG_ERR("Install timeout failed. Reset action mismatch");
 		k_mutex_unlock(&data->lock);
 		return -EINVAL;

--- a/drivers/watchdog/wdt_mspm0.c
+++ b/drivers/watchdog/wdt_mspm0.c
@@ -103,6 +103,9 @@ struct wwdt_mspm0_data {
 	uint8_t period_count;
 	uint8_t clock_divider;
 	uint16_t window_count;
+	bool timeout_valid; /* true after install_timeout(), false after disable() */
+	bool is_setup;      /* true after setup(), false after disable() */
+	struct k_mutex lock;
 };
 
 struct wwdt_period_lut {
@@ -188,8 +191,22 @@ static int wwdt_mspm0_setup(const struct device *dev, uint8_t options)
 	uint32_t window0_closed;
 	uint32_t window1_closed;
 
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	if (!data->timeout_valid) {
+		k_mutex_unlock(&data->lock);
+		return -EINVAL;
+	}
+
+	if (data->is_setup) {
+		LOG_ERR("WWDT already running — call wdt_disable() first");
+		k_mutex_unlock(&data->lock);
+		return -EBUSY;
+	}
+
 	if (options & WDT_OPT_PAUSE_IN_SLEEP) {
 		/* hw_wwdt.h: STISM has no effect for the global Window Watchdog. */
+		k_mutex_unlock(&data->lock);
 		return -ENOTSUP;
 	}
 
@@ -213,33 +230,64 @@ static int wwdt_mspm0_setup(const struct device *dev, uint8_t options)
 			 window0_closed |
 			 (window1_closed << (WWDT_CTL0_WINDOW1_OFS - WWDT_CTL0_WINDOW0_OFS));
 
+	data->is_setup = true;
+	k_mutex_unlock(&data->lock);
 	return 0;
 }
 
 static int wwdt_mspm0_disable(const struct device *dev)
 {
-	/* Disabling a watchdog that is configured is not possible */
-	ARG_UNUSED(dev);
-	return -EPERM;
+	struct wwdt_mspm0_data *data = dev->data;
+	int ret;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	/*
+	 * hw_wwdt.h: "For safety devices a watchdog reset by software is not
+	 * possible." Once started, the WDT runs until SoC reset. -EFAULT if
+	 * never started (also frees the install slot), -EPERM if started.
+	 */
+	if (data->is_setup) {
+		ret = -EPERM;
+	} else {
+		data->timeout_valid = false;
+		ret = -EFAULT;
+	}
+
+	k_mutex_unlock(&data->lock);
+	return ret;
 }
 
 static int wwdt_mspm0_install_timeout(const struct device *dev, const struct wdt_timeout_cfg *cfg)
 {
 	const struct wwdt_mspm0_config *config = dev->config;
+	struct wwdt_mspm0_data *data = dev->data;
+	int ret;
+
+	k_mutex_lock(&data->lock, K_FOREVER);
 
 	/* Cannot install timeout if the WWDT is already running */
-	if (config->base->WWDTSTAT & WWDT_STAT_RUN) {
+	if (data->is_setup) {
 		LOG_ERR("Install timeout failed. WWDT is already running");
+		k_mutex_unlock(&data->lock);
 		return -EBUSY;
+	}
+
+	/* Single channel: slot freed by disable(). Second install before disable -> -ENOMEM. */
+	if (data->timeout_valid) {
+		k_mutex_unlock(&data->lock);
+		return -ENOMEM;
 	}
 
 	if (cfg->callback) {
 		LOG_ERR("Install timeout failed. Callback not supported");
+		k_mutex_unlock(&data->lock);
 		return -ENOTSUP;
 	}
 
 	if (cfg->flags != config->reset_action) {
 		LOG_ERR("Install timeout failed. Reset action mismatch");
+		k_mutex_unlock(&data->lock);
 		return -EINVAL;
 	}
 
@@ -247,16 +295,32 @@ static int wwdt_mspm0_install_timeout(const struct device *dev, const struct wdt
 	 * To calculate the timeout period as per :
 	 * TIMEOUT = (CLKDIV + 1) * PER_count / 32768 (LFCLK Frequency)
 	 */
-	return wwdt_mspm0_calculate_timeout_periods(dev, cfg);
+	ret = wwdt_mspm0_calculate_timeout_periods(dev, cfg);
+	if (ret == 0) {
+		data->timeout_valid = true;
+	}
+
+	k_mutex_unlock(&data->lock);
+	return ret;
 }
 
 static int wwdt_mspm0_feed(const struct device *dev, int channel_id)
 {
 	const struct wwdt_mspm0_config *config = dev->config;
+	struct wwdt_mspm0_data *data = dev->data;
 
 	ARG_UNUSED(channel_id);
+
+	k_mutex_lock(&data->lock, K_FOREVER);
+
+	if (!data->is_setup) {
+		k_mutex_unlock(&data->lock);
+		return -EINVAL;
+	}
+
 	config->base->WWDTCNTRST = WWDT_CNTRST_KEY;
 
+	k_mutex_unlock(&data->lock);
 	return 0;
 }
 
@@ -264,6 +328,9 @@ static int wwdt_mspm0_init(const struct device *dev)
 {
 	const struct wwdt_mspm0_config *config = dev->config;
 	struct wwdt_mspm0_regs *base = config->base;
+	struct wwdt_mspm0_data *data = dev->data;
+
+	k_mutex_init(&data->lock);
 
 	/* Reset peripheral and enable power — matches counter/PWM init sequence. */
 	base->GPRCM.RSTCTL = WWDT_RSTCTL_KEY | WWDT_RSTCTL_STKYCLR | WWDT_RSTCTL_ASSERT;

--- a/drivers/watchdog/wdt_mspm0.c
+++ b/drivers/watchdog/wdt_mspm0.c
@@ -5,8 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/mspm0_clock_control.h>
 #include <zephyr/drivers/watchdog.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
 #define DT_DRV_COMPAT ti_mspm0_watchdog
@@ -97,6 +99,8 @@ struct wwdt_mspm0_config {
 	struct wwdt_mspm0_regs *base;
 	uint8_t reset_action;
 	uint8_t closed_window;
+	const struct device *clock_dev;
+	struct mspm0_sys_clock clock_subsys;
 };
 
 struct wwdt_mspm0_data {
@@ -127,54 +131,88 @@ static int wwdt_mspm0_calculate_timeout_periods(const struct device *dev,
 		{WWDT_CTL0_PER_21, 2097152},
 		{WWDT_CTL0_PER_25, 33554432},
 	};
-	static const uint8_t window_sixteenths[] = {0, 2, 3, 4, 8, 12, 13, 14};
+	const struct wwdt_mspm0_config *config = dev->config;
 	struct wwdt_mspm0_data *data = dev->data;
+	struct mspm0_sys_clock clock_subsys = config->clock_subsys;
 	uint32_t max_ms = cfg->window.max;
 	uint32_t min_ms = cfg->window.min;
-	uint32_t actual_timeout;
+	uint32_t clock_freq;
 	uint8_t window_idx;
-	uint32_t lut_idx;
+	int ret;
 
-	/* Compute max achievable timeout at CLKDIV=7: 8 * 2^25 * 1000 / 32768 ms */
-	uint32_t abs_max_ms =
-		(uint32_t)(((uint64_t)8 * period_lut[7].per_counts * 1000U) / 32768U);
+	ret = clock_control_get_rate(config->clock_dev, (clock_control_subsys_t)&clock_subsys,
+				     &clock_freq);
+	if (ret != 0) {
+		LOG_ERR("Failed to get LFCLK rate: %d", ret);
+		return ret;
+	}
 
-	if (max_ms > abs_max_ms || min_ms >= max_ms) {
-		LOG_ERR("Install timeout failed. Invalid window timing");
+	if (clock_freq == 0U) {
+		LOG_ERR("LFCLK rate is zero");
 		return -EINVAL;
 	}
 
-	/* Find smallest PER where max_timeout_ms (at CLKDIV=7) >= max_ms */
-	for (lut_idx = 0; lut_idx < ARRAY_SIZE(period_lut); lut_idx++) {
-		uint32_t max_timeout_ms = (uint32_t)(
-			((uint64_t)8 * period_lut[lut_idx].per_counts * 1000U) / 32768U);
+	/*
+	 * Closed-window fractions as n/16 of the timeout period.
+	 * Maps to: 0%, 12.5%, 18.75%, 25%, 50%, 75%, 81.25%, 87.5%.
+	 */
+	static const uint8_t window_sixteenths[] = {0, 2, 3, 4, 8, 12, 13, 14};
+
+	/* Compute max achievable timeout: 8 * 2^25 / clock_freq * 1000 ms */
+	uint32_t abs_max_ms =
+		(uint32_t)(((uint64_t)8 * period_lut[7].per_counts * 1000U) / clock_freq);
+
+	if (max_ms > abs_max_ms || min_ms >= max_ms) {
+		LOG_ERR("Invalid window timing (max=%u ms, abs_max=%u ms)", max_ms, abs_max_ms);
+		return -EINVAL;
+	}
+
+	/* Find the smallest PER where max_timeout_ms (at CLKDIV=7) >= max_ms */
+	uint32_t lut_idx = 0;
+
+	for (uint32_t i = 0; i < ARRAY_SIZE(period_lut); i++) {
+		uint32_t max_timeout_ms =
+			(uint32_t)(((uint64_t)8 * period_lut[i].per_counts * 1000U) / clock_freq);
 
 		if (max_ms <= max_timeout_ms) {
+			lut_idx = i;
 			break;
 		}
 	}
 
 	data->period_count = (uint8_t)period_lut[lut_idx].period_count;
 
-	/* Walk CLKDIV 0->7 to find smallest divider where timeout >= max_ms */
+	/*
+	 * Walk CLKDIV 0->7 to find the smallest divider where the timeout
+	 * is >= max_ms (always rounds up, never under-programs the watchdog).
+	 */
+	uint32_t actual_timeout = 0;
+
 	for (data->clock_divider = 0; data->clock_divider < 8; data->clock_divider++) {
 		actual_timeout = (uint32_t)(((uint64_t)(data->clock_divider + 1U) *
-					     period_lut[lut_idx].per_counts * 1000U) / 32768U);
+					     period_lut[lut_idx].per_counts * 1000U) /
+					    clock_freq);
 		if (max_ms <= actual_timeout) {
 			break;
 		}
 	}
 	data->clock_divider = MIN(data->clock_divider, 7U);
 
-	/* Determine closed window as per the requested lower limit of watchdog feed timeout */
+	/* Find the smallest closed-window fraction that enforces min_ms */
 	for (window_idx = 0; window_idx < ARRAY_SIZE(window_sixteenths); window_idx++) {
-		if (min_ms <= (actual_timeout * window_sixteenths[window_idx] / 16)) {
+		uint32_t window_ms = actual_timeout * window_sixteenths[window_idx] / 16U;
+
+		if (min_ms <= window_ms) {
 			break;
 		}
 	}
 
 	if (window_idx >= ARRAY_SIZE(window_sixteenths)) {
-		LOG_ERR("Install timeout failed. min_ms %u cannot be enforced", min_ms);
+		LOG_ERR("min_ms %u cannot be enforced; max available closed "
+			"window is %u ms",
+			min_ms,
+			actual_timeout * window_sixteenths[ARRAY_SIZE(window_sixteenths) - 1] /
+				16U);
 		return -EINVAL;
 	}
 
@@ -293,7 +331,7 @@ static int wwdt_mspm0_install_timeout(const struct device *dev, const struct wdt
 
 	/*
 	 * To calculate the timeout period as per :
-	 * TIMEOUT = (CLKDIV + 1) * PER_count / 32768 (LFCLK Frequency)
+	 * TIMEOUT = (CLKDIV + 1) * PER_count / LFCLK Frequency
 	 */
 	ret = wwdt_mspm0_calculate_timeout_periods(dev, cfg);
 	if (ret == 0) {
@@ -347,20 +385,22 @@ static DEVICE_API(wdt, wwdt_mspm0_driver_api) = {
 	.feed = wwdt_mspm0_feed
 };
 
-#define WWDT_MSPM0_INIT(index)								\
-
-static const struct wwdt_mspm0_config wwdt_mspm0_cfg_##index = {			\
-	.base = (struct wwdt_mspm0_regs *)DT_INST_REG_ADDR(index),			\
+#define WWDT_MSPM0_INIT(index)									\
+static const struct wwdt_mspm0_config wwdt_mspm0_cfg_##index = {					\
+	.base = (struct wwdt_mspm0_regs *)DT_INST_REG_ADDR(index),				\
 	.reset_action = COND_CODE_1(DT_INST_PROP(index, ti_watchdog_reset_action),	\
-				    (WDT_FLAG_RESET_SOC), (WDT_FLAG_RESET_CPU_CORE)),	\
-	.closed_window = DT_INST_PROP(index, closed_window),				\
-};											\
-											\
-static struct wwdt_mspm0_data wwdt_mspm0_data_##index;					\
-											\
-DEVICE_DT_INST_DEFINE(index, wwdt_mspm0_init, NULL, &wwdt_mspm0_data_##index,		\
-		      &wwdt_mspm0_cfg_##index, POST_KERNEL,				\
-		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,				\
-		      &wwdt_mspm0_driver_api);						\
-
+				    (WDT_FLAG_RESET_SOC), (WDT_FLAG_RESET_CPU_CORE)),		\
+	.closed_window = DT_INST_PROP(index, closed_window),					\
+	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_IDX(index, 0)),			\
+	.clock_subsys = {									\
+		.clk = DT_INST_CLOCKS_CELL_BY_IDX(index, 0, clk),				\
+	},											\
+};												\
+												\
+static struct wwdt_mspm0_data wwdt_mspm0_data_##index;						\
+												\
+DEVICE_DT_INST_DEFINE(index, wwdt_mspm0_init, NULL, &wwdt_mspm0_data_##index,			\
+		      &wwdt_mspm0_cfg_##index, POST_KERNEL,					\
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,					\
+		      &wwdt_mspm0_driver_api);							\
 DT_INST_FOREACH_STATUS_OKAY(WWDT_MSPM0_INIT)

--- a/dts/arm/ti/mspm0/g/mspm0g.dtsi
+++ b/dts/arm/ti/mspm0/g/mspm0g.dtsi
@@ -41,6 +41,8 @@
 		wdt1: wdt1@40082000 {
 			compatible = "ti,mspm0-watchdog";
 			reg = <0x40082000 0x2000>;
+			interrupts = <0 0>;
+			clocks = <&ckm MSPM0_CLOCK_LFCLK>;
 			ti,watchdog-reset-action = <0>;
 			closed-window = <0>;
 			status = "disabled";

--- a/dts/arm/ti/mspm0/mspm0.dtsi
+++ b/dts/arm/ti/mspm0/mspm0.dtsi
@@ -163,6 +163,8 @@
 		wdt0: wdt0@40080000 {
 			compatible = "ti,mspm0-watchdog";
 			reg = <0x40080000 0x2000>;
+			interrupts = <0 0>;
+			clocks = <&ckm MSPM0_CLOCK_LFCLK>;
 			ti,watchdog-reset-action = <1>;
 			closed-window = <0>;
 			status = "disabled";

--- a/dts/bindings/watchdog/ti,mspm0-watchdog.yaml
+++ b/dts/bindings/watchdog/ti,mspm0-watchdog.yaml
@@ -16,9 +16,23 @@ properties:
     type: int
     required: true
     description: |
-      The specific reset action associated with a given peripheral. 1 is BOOTRST, 0 is SYSRST
+      Reset type delivered by this WWDT instance on a violation.
+      1 = SYSRST (WDT_FLAG_RESET_SOC), 0 = BOOTRST (WDT_FLAG_RESET_CPU_CORE).
+      Note: the hardware always generates SYSRST regardless of this value;
+      it is used only to validate the flags passed to wdt_install_timeout().
 
   closed-window:
     type: int
     required: true
     description: Watchdog has two closed windows. 0 is WINDOW0, 1 is WINDOW1
+
+  clocks:
+    required: true
+    description: |
+      Reference to the clock controller providing LFCLK.
+      Typically <&ckm MSPM0_CLOCK_LFCLK>.
+
+  interrupts:
+    description: |
+      INTTIM interrupt line. Only fires in interval-timer mode
+      (WDT_FLAG_RESET_NONE). Not used in window-watchdog mode.

--- a/samples/drivers/watchdog/boards/lp_mspm0g3519.overlay
+++ b/samples/drivers/watchdog/boards/lp_mspm0g3519.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &wdt0;
+	};
+};
+
+&wdt0 {
+	status = "okay";
+};

--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -54,6 +54,11 @@
 #define WDT_OPT            0
 #elif DT_HAS_COMPAT_STATUS_OKAY(andestech_atcwdt200)
 #define WDT_MAX_WINDOW 500U
+#elif DT_HAS_COMPAT_STATUS_OKAY(ti_mspm0_watchdog)
+/* MSPM0 WWDT: window-watchdog violations route to the ESM safety block,
+ * not the NVIC. A pre-reset callback is architecturally impossible.
+ */
+#define WDT_ALLOW_CALLBACK 0
 #endif
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_gswdt)
 #if !defined(CONFIG_NRFS_GSWDT_SERVICE_ENABLED)

--- a/tests/drivers/watchdog/wdt_basic_api/boards/lp_mspm0g3507.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/lp_mspm0g3507.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &wdt0;
+	};
+};
+
+&wdt0 {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_basic_api/boards/lp_mspm0g3519.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/lp_mspm0g3519.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &wdt0;
+	};
+};
+
+&wdt0 {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_basic_api/boards/lp_mspm0l2228.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/lp_mspm0l2228.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &wdt0;
+	};
+};
+
+&wdt0 {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_basic_reset_none/boards/lp_mspm0g3507.overlay
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/boards/lp_mspm0g3507.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &wdt0;
+	};
+};
+
+&wdt0 {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_basic_reset_none/boards/lp_mspm0g3519.overlay
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/boards/lp_mspm0g3519.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &wdt0;
+	};
+};
+
+&wdt0 {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_basic_reset_none/boards/lp_mspm0l2228.overlay
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/boards/lp_mspm0l2228.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &wdt0;
+	};
+};
+
+&wdt0 {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_basic_reset_none/tests.yaml
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/tests.yaml
@@ -80,3 +80,12 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/realtek_bee_core_wdt.overlay"
     extra_configs:
       - CONFIG_TEST_WDT_SETUP_FLAGS=0
+  drivers.watchdog.reset_none.ti_mspm0:
+    platform_allow:
+      - lp_mspm0g3507/mspm0g3507
+      - lp_mspm0g3519/mspm0g3519
+      - lp_mspm0l2228/mspm0l2228
+    integration_platforms:
+      - lp_mspm0g3507/mspm0g3507
+    extra_configs:
+      - CONFIG_TEST_WDT_SETUP_FLAGS=2

--- a/tests/drivers/watchdog/wdt_error_cases/Kconfig
+++ b/tests/drivers/watchdog/wdt_error_cases/Kconfig
@@ -14,7 +14,7 @@ config TEST_WDT_DISABLE_SUPPORTED
 
 config TEST_WDT_FLAG_RESET_NONE_SUPPORTED
 	bool "Watchdog flag WDT_FLAG_RESET_NONE is supported"
-	default y if SOC_FAMILY_SILABS_S2 || SOC_SERIES_M48X
+	default y if SOC_FAMILY_SILABS_S2 || SOC_SERIES_M48X || DT_HAS_TI_MSPM0_WATCHDOG_ENABLED
 	help
 	  Set this Kconfig to 'y' if wdt_install_timeout() can be called with
 	  cfg.flags=WDT_FLAG_RESET_NONE.
@@ -51,7 +51,7 @@ config TEST_WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED
 
 config TEST_WDT_WINDOW_MIN_SUPPORTED
 	bool "Watchdog supports lower limit of watchdog feed timeout"
-	default y if SOC_FAMILY_SILABS_S2
+	default y if SOC_FAMILY_SILABS_S2 || DT_HAS_TI_MSPM0_WATCHDOG_ENABLED
 	help
 	  Set this Kconfig to 'y' if wdt_install_timeout() can be called with
 	  cfg.window.min value higher than 0.
@@ -64,6 +64,7 @@ config TEST_WDT_WINDOW_MAX_ALLOWED
 					  SOC_FAMILY_MICROCHIP_PIC32CM_JH
 	default 0xFFFFFFFF if SOC_IT51XXX
 	default 0x6667 if SOC_SERIES_M48X
+	default 0x7D0000 if DT_HAS_TI_MSPM0_WATCHDOG_ENABLED
 	default 0xFFFFFFF
 	help
 	  Maximal value of the Watchdog timeout passed in the

--- a/tests/drivers/watchdog/wdt_error_cases/boards/lp_mspm0g3507.overlay
+++ b/tests/drivers/watchdog/wdt_error_cases/boards/lp_mspm0g3507.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &wdt0;
+	};
+};
+
+&wdt0 {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_error_cases/boards/lp_mspm0l2228.overlay
+++ b/tests/drivers/watchdog/wdt_error_cases/boards/lp_mspm0l2228.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Texas Instruments Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		watchdog0 = &wdt0;
+	};
+};
+
+&wdt0 {
+	status = "okay";
+};

--- a/tests/drivers/watchdog/wdt_error_cases/tests.yaml
+++ b/tests/drivers/watchdog/wdt_error_cases/tests.yaml
@@ -28,11 +28,14 @@ tests:
       - numaker_pfm_m487
       - pic32cm_jh01_cpro
       - raytac_an54lv_db_15/nrf54l15/cpuapp
+      - lp_mspm0g3507/mspm0g3507
+      - lp_mspm0l2228/mspm0l2228
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
       - raytac_an54lq_db_15/nrf54l15/cpuapp
       - raytac_an54lv_db_15/nrf54l15/cpuapp
+      - lp_mspm0l2228/mspm0l2228
   drivers.watchdog.wdt_error_cases_pm:
     platform_allow:
       - xg24_rb4187c


### PR DESCRIPTION
Convert the MSPM0 Windowed Watchdog Timer driver from TI DriverLib HAL calls to native register access, add WDT_FLAG_RESET_NONE interval-timer callback support, and enable the driver on three MSPM0 LaunchPad boards.


### Window-watchdog improvements over the HAL version:

  - Dynamic LFCLK rate via clock_control_get_rate() (ti,mspm0-watchdog
    now requires a clocks property); no longer assumes 32768 Hz
  - reset_action DT property maps to a Zephyr WDT_FLAG_RESET_* for
    install_timeout() flag validation; hardware always does SYSRST
  - -ENOMEM on second install_timeout() before disable() (single channel)
  - channel_id validated in wdt_feed(); -EINVAL for non-zero channel
  - WDT_OPT_PAUSE_IN_SLEEP returns -ENOTSUP (hw_wwdt.h: no effect for
    global Window Watchdog)
  - -EFAULT from disable() when watchdog was never started



### Hardware notes

  - MSPM0 WWDT is a safety peripheral; in window-watchdog mode violations
    route to the ESM block, not the NVIC — no pre-reset CPU callback is
    possible. WDT_FLAG_RESET_NONE uses the separate interval-timer mode
    for callback delivery.
  - Window-watchdog mode cannot be stopped once started (hardware
    limitation); disable() returns -EPERM for that mode.
  - IRQ 0 (Group0) on MSPM0G is shared by WWDT0/WWDT1/SYSCTL/FLASHCTL;
    only wdt0 registers a static IRQ handler.


### Testing (Runtime logs attached in a PR comment https://github.com/zephyrproject-rtos/zephyr/pull/114858#issuecomment-5130134079) 

- samples/driver/watchdog                                                   (lp_mspm0l2228)
- tests/drivers/watchdog/wdt_basic_api/                            (lp_mspm0l2228)
- tests/drivers/watchdog/wdt_basic_reset_none/             (lp_mspm0l2228)
- tests/drivers/watchdog/wdt_basic_reset_none/             (lp_mspm0l2228)


