### PR TITLE
tests kvss zms: Avoid working with garbage data

### DIFF
--- a/tests/subsys/kvss/zms/src/main.c
+++ b/tests/subsys/kvss/zms/src/main.c
@@ -851,6 +851,7 @@ ZTEST_F(zms, test_zms_gc_corrupt_ate)
 	struct zms_ate close_ate;
 	int err;
 
+	memset(&close_ate, 0xff, sizeof(struct zms_ate));
 	close_ate.id = ZMS_HEAD_ID;
 	close_ate.offset = fixture->fs.sector_size / 2;
 	close_ate.len = 0;
@@ -858,6 +859,7 @@ ZTEST_F(zms, test_zms_gc_corrupt_ate)
 		crc8_ccitt(0xff, (uint8_t *)&close_ate + SIZEOF_FIELD(struct zms_ate, crc8),
 			   sizeof(struct zms_ate) - SIZEOF_FIELD(struct zms_ate, crc8));
 
+	memset(&corrupt_ate, 0xff, sizeof(struct zms_ate));
 	corrupt_ate.id = 0xdeadbeef;
 	corrupt_ate.offset = 0;
 	corrupt_ate.len = 20;

--- a/tests/subsys/kvss/zms/src/main.c
+++ b/tests/subsys/kvss/zms/src/main.c
@@ -851,6 +851,7 @@ ZTEST_F(zms, test_zms_gc_corrupt_ate)
 	struct zms_ate close_ate;
 	int err;
 
+	(void)memset(&close_ate, 0xff, sizeof(struct zms_ate));
 	close_ate.id = ZMS_HEAD_ID;
 	close_ate.offset = fixture->fs.sector_size / 2;
 	close_ate.len = 0;
@@ -858,6 +859,7 @@ ZTEST_F(zms, test_zms_gc_corrupt_ate)
 		crc8_ccitt(0xff, (uint8_t *)&close_ate + SIZEOF_FIELD(struct zms_ate, crc8),
 			   sizeof(struct zms_ate) - SIZEOF_FIELD(struct zms_ate, crc8));
 
+	(void)memset(&corrupt_ate, 0xff, sizeof(struct zms_ate));
 	corrupt_ate.id = 0xdeadbeef;
 	corrupt_ate.offset = 0;
 	corrupt_ate.len = 20;


### PR DESCRIPTION
The test_zms_gc_corrupt_ate would CRC and write to flash random/garbage stack content.
Instead of that, let's make sure the data is initialized. This avoids valgrind warning us.
This can be reproduced with
`twister -p native_sim --enable-valgrind -T tests/subsys/kvss/zms`