### PR TITLE
Bluetooth: CAP: Ini: Allow update metadata with same metadata

### DIFF
--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -895,11 +895,8 @@ get_next_proc_param(struct bt_cap_common_proc *active_proc)
 		case BT_CAP_COMMON_SUBPROC_TYPE_META_UPDATE:
 			__ASSERT_NO_MSG(active_proc->proc_type == BT_CAP_COMMON_PROC_TYPE_UPDATE);
 
-			if ((state == BT_BAP_EP_STATE_ENABLING ||
-			     state == BT_BAP_EP_STATE_STREAMING) &&
-			    !util_eq(bap_stream->codec_cfg->meta, bap_stream->codec_cfg->meta_len,
-				     proc_param->meta_update.meta,
-				     proc_param->meta_update.meta_len)) {
+			if (state == BT_BAP_EP_STATE_ENABLING ||
+			    state == BT_BAP_EP_STATE_STREAMING) {
 				return proc_param;
 			}
 			break;


### PR DESCRIPTION
This relax check introduced in db44a526c9c25471f48f4413 "Bluetooth: CAP: Ini: Compare cfg/qos in get_next_proc_param" for not allowing Update Metadta procedure with same metadata value.

This is fixing assert in bt_cap_initiator_unicast_audio_update() when used from tester application
ASSERTION FAIL [proc_param != ((void *)0)]
   @ WEST_TOPDIR/zephyr/subsys/bluetooth/audio/cap_initiator.c:2309


This is currently affecting CAP/INI/UST/BV-33-C, CAP/INI/UST/BV-35-C and CAP/INI/UST/BV-37-C qualification test cases (due to assertion on tester side).

Note: I'm not sure if this is valid fix, alternative would be to return error in bt_cap_initiator_unicast_audio_update() and require autopts to provided updated metadata although I've not found any requirements in CAP or ASCS spec, nor test spec that would mandate actual change in metadata for this procedure.
