### PR TITLE
shell: log_backend: fix queue size macro expansion

### DIFF
--- a/include/zephyr/shell/shell_log_backend.h
+++ b/include/zephyr/shell/shell_log_backend.h
@@ -81,7 +81,7 @@ int z_shell_log_backend_output_func(uint8_t *data, size_t length, void *ctx);
 			  _buf, _size); \
 	static struct shell_log_backend_control_block _name##_control_block; \
 	static uint32_t __aligned(Z_LOG_MSG_ALIGNMENT) \
-			_name##_buf[_queue_size / sizeof(uint32_t)]; \
+			_name##_buf[(_queue_size) / sizeof(uint32_t)]; \
 	const struct mpsc_pbuf_buffer_config _name##_mpsc_buffer_config = { \
 		.buf = _name##_buf, \
 		.size = ARRAY_SIZE(_name##_buf), \


### PR DESCRIPTION
`Z_SHELL_LOG_BACKEND_DEFINE` sized its buffer with `_queue_size / sizeof(uint32_t)`, so a queue size passed as an unparenthesized expression such as `A + B` bound as `A + B / sizeof(uint32_t)`, undersizing the buffer.

Parenthesize the queue size in the buffer array size.