### PR TITLE
arch: arm: cleanup in MPU API interface

### DIFF
--- a/arch/arm/core/cortex_a_r/prep_c.c
+++ b/arch/arm/core/cortex_a_r/prep_c.c
@@ -32,7 +32,7 @@
 #endif
 
 #ifdef CONFIG_ARM_MPU
-extern void z_arm_mpu_init(void);
+extern int z_arm_mpu_init(void);
 extern void z_arm_configure_static_mpu_regions(void);
 #elif defined(CONFIG_ARM_AARCH32_MMU)
 extern int z_arm_mmu_init(void);

--- a/arch/arm/core/cortex_a_r/smp.c
+++ b/arch/arm/core/cortex_a_r/smp.c
@@ -92,7 +92,7 @@ static uint32_t cpu_map[CONFIG_MP_MAX_NUM_CPUS] = {
 };
 
 #ifdef CONFIG_ARM_MPU
-extern void z_arm_mpu_init(void);
+extern int z_arm_mpu_init(void);
 extern void z_arm_configure_static_mpu_regions(void);
 #elif defined(CONFIG_ARM_AARCH32_MMU)
 extern int z_arm_mmu_init(void);

--- a/arch/arm/core/mpu/arm_core_mpu.c
+++ b/arch/arm/core/mpu/arm_core_mpu.c
@@ -16,9 +16,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mpu);
 
-extern void arm_core_mpu_enable(void);
-extern void arm_core_mpu_disable(void);
-
 /*
  * Maximum number of dynamic memory partitions that may be supplied to the MPU
  * driver for programming during run-time. Note that the actual number of the

--- a/arch/arm/core/mpu/arm_core_mpu_dev.h
+++ b/arch/arm/core/mpu/arm_core_mpu_dev.h
@@ -109,6 +109,23 @@ struct k_thread;
  */
 
 /**
+ * @brief initialize the MPU
+ *
+ * On SMP, this is called by each core and must initialize the local MPU.
+ */
+int z_arm_mpu_init(void);
+
+/**
+ * @brief enable the MPU
+ */
+void arm_core_mpu_enable(void);
+
+/**
+ * @brief disable the MPU
+ */
+void arm_core_mpu_disable(void);
+
+/**
  * @brief configure a set of fixed (static) MPU regions
  *
  * Internal API function to configure a set of static MPU memory regions,

--- a/arch/arm/core/mpu/arm_core_mpu_dev.h
+++ b/arch/arm/core/mpu/arm_core_mpu_dev.h
@@ -13,7 +13,6 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_ARM_MPU)
 struct k_thread;
 
 #if defined(CONFIG_USERSPACE)
@@ -99,7 +98,6 @@ struct k_thread;
 #endif /* CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS || CPU_HAS_NXP_SYSMPU */
 
 #endif /* CONFIG_USERSPACE */
-
 
 /* ARM Core MPU Driver API */
 
@@ -279,8 +277,6 @@ int arm_core_mpu_get_max_available_dyn_regions(void);
  *       permit user access).
  */
 int arm_core_mpu_buffer_validate(const void *addr, size_t size, int write);
-
-#endif /* CONFIG_ARM_MPU */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Clean up slightly the ARM MPU Core --> MPU Driver API header. While at it, also fix a small and insignificant mistake in the Cortex-A/R init code.