### PR TITLE
ci: manifest: Use zephyrbot token

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@ce3405bd7039ea968a2821cef3b88150e9415555
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ZB_MANIFEST_GITHUB_TOKEN }}
           manifest-path: 'west.yml'
           checkout-path: 'zephyrproject/zephyr'
           use-tree-checkout: 'true'


### PR DESCRIPTION
Use a dedicated zephyrbot token, `ZB_MANIFEST_GITHUB_TOKEN`, for the manifest workflow to better distribute the GitHub API quota usage and thereby reduce the number of workflow failures due to the API rate limit.

---

Tested in https://github.com/zephyrproject-rtos/zephyr-testing/pull/450