### PR TITLE
Bluetooth: ASCS: Rename ase->ase_id where appropriate

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1067,13 +1067,13 @@ static void ascs_cp_rsp_init(uint8_t op)
 }
 
 /* Add response to an opcode/ASE ID */
-static void ascs_cp_rsp_add(uint8_t id, uint8_t code, uint8_t reason)
+static void ascs_cp_rsp_add(uint8_t ase_id, uint8_t code, uint8_t reason)
 {
 	struct bt_ascs_cp_rsp *rsp = (void *)cp_rsp_buf.__buf;
 	struct bt_ascs_cp_ase_rsp *ase_rsp;
 
-	LOG_DBG("id 0x%02x code %s (0x%02x) reason %s (0x%02x)", id,
-		bt_ascs_rsp_str(code), code, bt_ascs_reason_str(reason), reason);
+	LOG_DBG("id 0x%02x code %s (0x%02x) reason %s (0x%02x)", ase_id, bt_ascs_rsp_str(code),
+		code, bt_ascs_reason_str(reason), reason);
 
 	if (rsp->num_ase == BT_ASCS_UNSUPP_OR_LENGTH_ERR_NUM_ASE) {
 		return;
@@ -1093,14 +1093,14 @@ static void ascs_cp_rsp_add(uint8_t id, uint8_t code, uint8_t reason)
 	}
 
 	ase_rsp = net_buf_simple_add(&cp_rsp_buf, sizeof(*ase_rsp));
-	ase_rsp->id = id;
+	ase_rsp->ase_id = ase_id;
 	ase_rsp->code = code;
 	ase_rsp->reason = reason;
 }
 
-static void ascs_cp_rsp_success(uint8_t id)
+static void ascs_cp_rsp_success(uint8_t ase_id)
 {
-	ascs_cp_rsp_add(id, BT_BAP_ASCS_RSP_CODE_SUCCESS, BT_BAP_ASCS_REASON_NONE);
+	ascs_cp_rsp_add(ase_id, BT_BAP_ASCS_RSP_CODE_SUCCESS, BT_BAP_ASCS_REASON_NONE);
 }
 
 static int ase_release(struct bt_ascs_ase *ase, uint8_t reason, struct bt_bap_ascs_rsp *rsp)
@@ -1944,26 +1944,26 @@ static ssize_t ascs_config(struct bt_conn *conn, struct net_buf_simple *buf)
 		cfg = net_buf_simple_pull_mem(buf, sizeof(*cfg));
 		(void)net_buf_simple_pull(buf, cfg->cc_len);
 
-		LOG_DBG("ase 0x%02x cc_len %u", cfg->ase, cfg->cc_len);
+		LOG_DBG("ase_id 0x%02x cc_len %u", cfg->ase_id, cfg->cc_len);
 
-		if (!cfg->ase || cfg->ase > ASE_COUNT) {
-			LOG_WRN("Invalid ASE ID: %u", cfg->ase);
-			ascs_cp_rsp_add(cfg->ase, BT_BAP_ASCS_RSP_CODE_INVALID_ASE,
+		if (cfg->ase_id == 0U || cfg->ase_id > ASE_COUNT) {
+			LOG_WRN("Invalid ASE ID: %u", cfg->ase_id);
+			ascs_cp_rsp_add(cfg->ase_id, BT_BAP_ASCS_RSP_CODE_INVALID_ASE,
 					BT_BAP_ASCS_REASON_NONE);
 			continue;
 		}
 
-		ase = ase_find(conn, cfg->ase);
+		ase = ase_find(conn, cfg->ase_id);
 		if (ase != NULL) {
 			ase_config(ase, cfg);
 			continue;
 		}
 
-		ase = ase_new(conn, cfg->ase);
+		ase = ase_new(conn, cfg->ase_id);
 		if (!ase) {
-			ascs_cp_rsp_add(cfg->ase, BT_BAP_ASCS_RSP_CODE_NO_MEM,
+			ascs_cp_rsp_add(cfg->ase_id, BT_BAP_ASCS_RSP_CODE_NO_MEM,
 					BT_BAP_ASCS_REASON_NONE);
-			LOG_WRN("No free ASE found for config ASE ID 0x%02x", cfg->ase);
+			LOG_WRN("No free ASE found for config ASE ID 0x%02x", cfg->ase_id);
 			continue;
 		}
 
@@ -2164,19 +2164,19 @@ static ssize_t ascs_qos(struct bt_conn *conn, struct net_buf_simple *buf)
 
 		qos = net_buf_simple_pull_mem(buf, sizeof(*qos));
 
-		LOG_DBG("ase 0x%02x", qos->ase);
+		LOG_DBG("ase_id 0x%02x", qos->ase_id);
 
-		if (!is_valid_ase_id(qos->ase)) {
-			ascs_cp_rsp_add(qos->ase, BT_BAP_ASCS_RSP_CODE_INVALID_ASE,
+		if (!is_valid_ase_id(qos->ase_id)) {
+			ascs_cp_rsp_add(qos->ase_id, BT_BAP_ASCS_RSP_CODE_INVALID_ASE,
 					BT_BAP_ASCS_REASON_NONE);
-			LOG_WRN("Unknown ase 0x%02x", qos->ase);
+			LOG_WRN("Unknown ase_id 0x%02x", qos->ase_id);
 			continue;
 		}
 
-		ase = ase_find(conn, qos->ase);
+		ase = ase_find(conn, qos->ase_id);
 		if (!ase) {
 			LOG_DBG("Invalid operation for idle ASE");
-			ascs_cp_rsp_add(qos->ase, BT_BAP_ASCS_RSP_CODE_INVALID_ASE_STATE,
+			ascs_cp_rsp_add(qos->ase_id, BT_BAP_ASCS_RSP_CODE_INVALID_ASE_STATE,
 					BT_BAP_ASCS_REASON_NONE);
 			continue;
 		}
@@ -2190,7 +2190,7 @@ static ssize_t ascs_qos(struct bt_conn *conn, struct net_buf_simple *buf)
 		cqos.pd = sys_get_le24(qos->pd);
 
 		ase_qos(ase, qos->cig, qos->cis, &cqos, &rsp);
-		ascs_cp_rsp_add(qos->ase, rsp.code, rsp.reason);
+		ascs_cp_rsp_add(qos->ase_id, rsp.code, rsp.reason);
 	}
 
 	return buf->size;
@@ -2534,17 +2534,17 @@ static ssize_t ascs_enable(struct bt_conn *conn, struct net_buf_simple *buf)
 		meta = net_buf_simple_pull_mem(buf, sizeof(*meta));
 		(void)net_buf_simple_pull(buf, meta->len);
 
-		if (!is_valid_ase_id(meta->ase)) {
-			ascs_cp_rsp_add(meta->ase, BT_BAP_ASCS_RSP_CODE_INVALID_ASE,
+		if (!is_valid_ase_id(meta->ase_id)) {
+			ascs_cp_rsp_add(meta->ase_id, BT_BAP_ASCS_RSP_CODE_INVALID_ASE,
 					BT_BAP_ASCS_REASON_NONE);
-			LOG_WRN("Unknown ase 0x%02x", meta->ase);
+			LOG_WRN("Unknown ase_id 0x%02x", meta->ase_id);
 			continue;
 		}
 
-		ase = ase_find(conn, meta->ase);
+		ase = ase_find(conn, meta->ase_id);
 		if (!ase) {
-			LOG_DBG("Invalid operation for idle ase 0x%02x", meta->ase);
-			ascs_cp_rsp_add(meta->ase, BT_BAP_ASCS_RSP_CODE_INVALID_ASE_STATE,
+			LOG_DBG("Invalid operation for idle ase_id 0x%02x", meta->ase_id);
+			ascs_cp_rsp_add(meta->ase_id, BT_BAP_ASCS_RSP_CODE_INVALID_ASE_STATE,
 					BT_BAP_ASCS_REASON_NONE);
 			continue;
 		}
@@ -2659,12 +2659,12 @@ static ssize_t ascs_start(struct bt_conn *conn, struct net_buf_simple *buf)
 
 		id = net_buf_simple_pull_u8(buf);
 
-		LOG_DBG("ase 0x%02x", id);
+		LOG_DBG("ase_id 0x%02x", id);
 
 		if (!is_valid_ase_id(id)) {
 			ascs_cp_rsp_add(id, BT_BAP_ASCS_RSP_CODE_INVALID_ASE,
 					BT_BAP_ASCS_REASON_NONE);
-			LOG_WRN("Unknown ase 0x%02x", id);
+			LOG_WRN("Unknown ase_id 0x%02x", id);
 			continue;
 		}
 
@@ -2742,12 +2742,12 @@ static ssize_t ascs_disable(struct bt_conn *conn, struct net_buf_simple *buf)
 
 		id = net_buf_simple_pull_u8(buf);
 
-		LOG_DBG("ase 0x%02x", id);
+		LOG_DBG("ase_id 0x%02x", id);
 
 		if (!is_valid_ase_id(id)) {
 			ascs_cp_rsp_add(id, BT_BAP_ASCS_RSP_CODE_INVALID_ASE,
 					BT_BAP_ASCS_REASON_NONE);
-			LOG_WRN("Unknown ase 0x%02x", id);
+			LOG_WRN("Unknown ase_id 0x%02x", id);
 			continue;
 		}
 
@@ -2869,12 +2869,12 @@ static ssize_t ascs_stop(struct bt_conn *conn, struct net_buf_simple *buf)
 
 		id = net_buf_simple_pull_u8(buf);
 
-		LOG_DBG("ase 0x%02x", id);
+		LOG_DBG("ase_id 0x%02x", id);
 
 		if (!is_valid_ase_id(id)) {
 			ascs_cp_rsp_add(id, BT_BAP_ASCS_RSP_CODE_INVALID_ASE,
 					BT_BAP_ASCS_REASON_NONE);
-			LOG_WRN("Unknown ase 0x%02x", id);
+			LOG_WRN("Unknown ase_id 0x%02x", id);
 			continue;
 		}
 
@@ -2971,22 +2971,22 @@ static ssize_t ascs_metadata(struct bt_conn *conn, struct net_buf_simple *buf)
 		if (meta->len > CONFIG_BT_AUDIO_CODEC_CFG_MAX_METADATA_SIZE) {
 			LOG_DBG("Cannot store %u octets of metadata", meta->len);
 
-			ascs_cp_rsp_add(meta->ase, BT_BAP_ASCS_RSP_CODE_NO_MEM,
+			ascs_cp_rsp_add(meta->ase_id, BT_BAP_ASCS_RSP_CODE_NO_MEM,
 					BT_BAP_ASCS_REASON_NONE);
 			continue;
 		}
 
-		if (!is_valid_ase_id(meta->ase)) {
-			ascs_cp_rsp_add(meta->ase, BT_BAP_ASCS_RSP_CODE_INVALID_ASE,
+		if (!is_valid_ase_id(meta->ase_id)) {
+			ascs_cp_rsp_add(meta->ase_id, BT_BAP_ASCS_RSP_CODE_INVALID_ASE,
 					BT_BAP_ASCS_REASON_NONE);
-			LOG_WRN("Unknown ase 0x%02x", meta->ase);
+			LOG_WRN("Unknown ase_id 0x%02x", meta->ase_id);
 			continue;
 		}
 
-		ase = ase_find(conn, meta->ase);
+		ase = ase_find(conn, meta->ase_id);
 		if (!ase) {
-			LOG_DBG("Invalid operation for idle ase 0x%02x", meta->ase);
-			ascs_cp_rsp_add(meta->ase, BT_BAP_ASCS_RSP_CODE_INVALID_ASE_STATE,
+			LOG_DBG("Invalid operation for idle ase_id 0x%02x", meta->ase_id);
+			ascs_cp_rsp_add(meta->ase_id, BT_BAP_ASCS_RSP_CODE_INVALID_ASE_STATE,
 					BT_BAP_ASCS_REASON_NONE);
 			continue;
 		}
@@ -3044,12 +3044,12 @@ static ssize_t ascs_release(struct bt_conn *conn, struct net_buf_simple *buf)
 
 		id = net_buf_simple_pull_u8(buf);
 
-		LOG_DBG("ase 0x%02x", id);
+		LOG_DBG("ase_id 0x%02x", id);
 
 		if (!is_valid_ase_id(id)) {
 			ascs_cp_rsp_add(id, BT_BAP_ASCS_RSP_CODE_INVALID_ASE,
 					BT_BAP_ASCS_REASON_NONE);
-			LOG_WRN("Unknown ase 0x%02x", id);
+			LOG_WRN("Unknown ase_id 0x%02x", id);
 			continue;
 		}
 

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -132,7 +132,7 @@ struct bt_ascs_ase_cp {
 
 struct bt_ascs_config {
 	/* ASE ID */
-	uint8_t  ase;
+	uint8_t ase_id;
 	/* Target latency */
 	uint8_t  latency;
 	/* Target PHY */
@@ -155,7 +155,7 @@ struct bt_ascs_config_op {
 #define BT_ASCS_QOS_OP                   0x02U
 struct bt_ascs_qos {
 	/* ASE ID */
-	uint8_t  ase;
+	uint8_t ase_id;
 	/* CIG ID*/
 	uint8_t  cig;
 	/* CIG ID*/
@@ -186,7 +186,7 @@ struct bt_ascs_qos_op {
 #define BT_ASCS_ENABLE_OP                0x03U
 struct bt_ascs_metadata {
 	/* ASE ID */
-	uint8_t  ase;
+	uint8_t ase_id;
 	/* Metadata length */
 	uint8_t  len;
 	/* LTV-formatted Metadata */
@@ -205,7 +205,7 @@ struct bt_ascs_start_op {
 	/* Number of ASEs */
 	uint8_t  num_ases;
 	/* ASE IDs */
-	uint8_t  ase[];
+	uint8_t ase_ids[];
 } __packed;
 
 #define BT_ASCS_DISABLE_OP               0x05U
@@ -213,7 +213,7 @@ struct bt_ascs_disable_op {
 	/* Number of ASEs */
 	uint8_t  num_ases;
 	/* ASE IDs */
-	uint8_t  ase[];
+	uint8_t ase_ids[];
 } __packed;
 
 #define BT_ASCS_STOP_OP                  0x06U
@@ -221,7 +221,7 @@ struct bt_ascs_stop_op {
 	/* Number of ASEs */
 	uint8_t  num_ases;
 	/* ASE IDs */
-	uint8_t  ase[];
+	uint8_t ase_ids[];
 } __packed;
 
 #define BT_ASCS_METADATA_OP              0x07U
@@ -236,13 +236,13 @@ struct bt_ascs_metadata_op {
 struct bt_ascs_release_op {
 	/* Number of ASEs */
 	uint8_t  num_ases;
-	/* Ase IDs */
-	uint8_t  ase[];
+	/* ASE IDs */
+	uint8_t ase_ids[];
 } __packed;
 
 struct bt_ascs_cp_ase_rsp {
 	/* ASE ID */
-	uint8_t  id;
+	uint8_t ase_id;
 	/* Response code */
 	uint8_t  code;
 	/* Response reason */

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -1622,13 +1622,13 @@ static uint8_t unicast_client_cp_notify(struct bt_conn *conn,
 
 		LOG_DBG("op %s (0x%02x) id 0x%02x code %s (0x%02x) "
 			"reason %s (0x%02x)",
-			bt_ascs_op_str(rsp->op), rsp->op, ase_rsp->id,
+			bt_ascs_op_str(rsp->op), rsp->op, ase_rsp->ase_id,
 			bt_ascs_rsp_str(ase_rsp->code), ase_rsp->code,
 			bt_ascs_reason_str(ase_rsp->reason), ase_rsp->reason);
 
-		stream = audio_stream_by_ep_id(conn, ase_rsp->id);
+		stream = audio_stream_by_ep_id(conn, ase_rsp->ase_id);
 		if (stream == NULL) {
-			LOG_DBG("Could not find stream by id %u", ase_rsp->id);
+			LOG_DBG("Could not find stream by id %u", ase_rsp->ase_id);
 
 			continue;
 		} else {
@@ -1979,7 +1979,7 @@ static int unicast_client_ep_config(struct bt_bap_ep *ep, struct net_buf_simple 
 	LOG_DBG("id 0x%02x dir %s codec 0x%02x", ep->id, bt_audio_dir_str(ep->dir), codec_cfg->id);
 
 	req = net_buf_simple_add(buf, sizeof(*req));
-	req->ase = ep->id;
+	req->ase_id = ep->id;
 	req->latency = codec_cfg->target_latency;
 	req->phy = codec_cfg->target_phy;
 	req->codec.id = codec_cfg->id;
@@ -2018,7 +2018,7 @@ static int unicast_client_add_qos(struct bt_bap_ep *ep, struct net_buf_simple *b
 	}
 
 	req = net_buf_simple_add(buf, sizeof(*req));
-	req->ase = ep->id;
+	req->ase_id = ep->id;
 	req->cig = conn_iso->info.unicast.cig_id;
 	req->cis = conn_iso->info.unicast.cis_id;
 	sys_put_le24(qos->interval, req->interval);
@@ -2046,7 +2046,7 @@ static int unicast_client_ep_enable(struct bt_bap_ep *ep, struct net_buf_simple 
 	LOG_DBG("id 0x%02x", ep->id);
 
 	req = net_buf_simple_add(buf, sizeof(*req));
-	req->ase = ep->id;
+	req->ase_id = ep->id;
 
 	req->len = meta_len;
 	net_buf_simple_add_mem(buf, meta, meta_len);
@@ -2068,7 +2068,7 @@ static int unicast_client_ep_metadata(struct bt_bap_ep *ep, struct net_buf_simpl
 	LOG_DBG("id 0x%02x", ep->id);
 
 	req = net_buf_simple_add(buf, sizeof(*req));
-	req->ase = ep->id;
+	req->ase_id = ep->id;
 
 	req->len = meta_len;
 	net_buf_simple_add_mem(buf, meta, meta_len);


### PR DESCRIPTION
Rename some struct fields from ase to ase_id[s] where the value reflect an ASE ID. This is to avoid any confusion with `struct bt_ascs_ase *ase` variables.