### PR TITLE
ci: manifest: use special token for manifest action

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@ce3405bd7039ea968a2821cef3b88150e9415555
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ZB_MANIFEST_GITHUB_TOKEN }}
           manifest-path: 'west.yml'
           checkout-path: 'zephyrproject/zephyr'
           use-tree-checkout: 'true'


### PR DESCRIPTION
Use project token with limited access for the manifest action to resolve
issues with backports.

Partially fixes #113403

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
