### PR TITLE
usb: device: class: rndis: keep trailing byte of unaligned frame

### DIFF
--- a/subsys/usb/device/class/netusb/function_rndis.c
+++ b/subsys/usb/device/class/netusb/function_rndis.c
@@ -305,10 +305,13 @@ static void rndis_bulk_out(uint8_t ep, enum usb_dc_ep_cb_status_code ep_status)
 		return;
 	}
 
-	/* We already use frame keeping with len, warn here about
-	 * receiving frame delimiter
+	/* A single 0x00 byte is only a frame delimiter when no packet is
+	 * currently being assembled. When a packet is in progress, the same
+	 * byte can be the genuine trailing byte of a frame whose length is
+	 * not a multiple of the bulk endpoint size, so it must be kept and
+	 * written to complete the frame instead of being skipped.
 	 */
-	if (len == 1U && !rx_buf[0]) {
+	if (len == 1U && !rx_buf[0] && rndis.in_pkt == NULL) {
 		LOG_DBG("Got frame delimiter, skip");
 		return;
 	}


### PR DESCRIPTION
### Problem
`rndis_bulk_out()` treats any single `0x00` byte received on the bulk-OUT endpoint as an RNDIS frame delimiter and skips it unconditionally. When an RNDIS data frame's total length is not a multiple of the bulk endpoint packet size and its final USB packet carries a single `0x00` payload byte, that genuine payload byte is dropped.

### Root cause
The delimiter check `if (len == 1U && !rx_buf[0])` does not consider whether a packet is currently being assembled, so a legitimate trailing payload byte of an in-progress frame is discarded. The frame is never completed, the next transfer is written into the still-open packet, and the following RNDIS header is misparsed ΓÇö desynchronising the receive stream (observed as repeated `Error parsing RNDIS header` / `Too small packet len` errors).

### Fix
Only treat a single `0x00` byte as a frame delimiter when no packet is currently being assembled (`rndis.in_pkt == NULL`). While a frame is in progress the byte is written normally, completing the frame and keeping the stream in sync.

### Why the change is generic
Protocol-correctness fix in Zephyr's RNDIS receive handling, independent of any board, vendor, or downstream product logic. RNDIS exists only in the legacy USB device stack; the newer `device_next` stack has no RNDIS equivalent.

### Tests performed
- Hardware: verified on an STM32U575 target over a USB RNDIS link that an unaligned RNDIS data frame whose final packet is a single `0x00` payload byte now completes correctly; the pre-fix RX errors (`Error parsing RNDIS header` / `Too small packet len`) and stream desync no longer occur.
- Compliance: `check_compliance.py` (Gitlint, Identity, Checkpatch) ΓÇö no failures.

### Documentation impact
None.

### Related
#63820

### Risks / limitations
- The legacy USB device stack is deprecated upstream; maintainers may prefer this land on `v3.7-branch`. Happy to retarget.
- No automated regression test: `rndis_bulk_out()` is `static` and the legacy stack has no `native_sim` harness. Can add one if an acceptable seam is identified.


Fixes #117264
