### PR TITLE
Exclude imx952_evk m7/ddr from two incompatible ARM interrupt tests

### DIFF
--- a/tests/arch/arm/arm_custom_interrupt/tests.yaml
+++ b/tests/arch/arm/arm_custom_interrupt/tests.yaml
@@ -14,6 +14,7 @@ tests:
       - imx95_evk/mimx9596/m7/ddr
       - imx95_evk/mimx9596/m7/flash
       - imx952_evk/mimx9529/m7
+      - imx952_evk/mimx9529/m7/ddr
       - imx943_evk/mimx94398/m33
       - imx943_evk/mimx94398/m33/ddr
       - mr_navq95b/mimx9596/m7

--- a/tests/arch/arm/arm_irq_vector_table/tests.yaml
+++ b/tests/arch/arm/arm_irq_vector_table/tests.yaml
@@ -16,6 +16,7 @@ tests:
       - imx95_evk/mimx9596/m7/ddr
       - imx95_evk/mimx9596/m7/flash
       - imx952_evk/mimx9529/m7
+      - imx952_evk/mimx9529/m7/ddr
       - mr_navq95b/mimx9596/m7
       - mr_navq95b/mimx9596/m7/flash
       - mr_navq95b/mimx9596/m7/ddr


### PR DESCRIPTION
Fix two build failures seen when running the ARM architecture interrupt tests on the imx952_evk/mimx9529/m7/ddr board. 

In both cases the failure stems from an inherent conflict between what the test requires and what the i.MX952 m7 SoC forces in its defconfig, making the board/test combination invalid to build.

The corresponding non-ddr imx952_evk/mimx9529/m7 variant was already listed in each test's platform_exclude; these patches simply add the m7/ddr variant that was missed.