### PR TITLE
drivers: wifi: st67w611m1: set station mode during init

### DIFF
--- a/drivers/wifi/st67w611m1/Kconfig.st67w611m1
+++ b/drivers/wifi/st67w611m1/Kconfig.st67w611m1
@@ -68,6 +68,15 @@ config ST67W611M1_SPI_PKT_MEM_SLAB_COUNT
 	int "Max number of SPI pkts"
 	default 12
 
+config ST67W611M1_WIFI_AUTO_CONNECT
+	bool "Auto-connect to a stored access point at boot"
+	help
+	  Controls the module's power-on auto-connect (AT+CWAUTOCONN). When
+	  enabled, the module reconnects to the last provisioned access point
+	  automatically at startup. Disable to leave connection management to
+	  the Wi-Fi management API. The setting is only written when it differs
+	  from the module's current value, as the module persists it to flash.
+
 configdefault NET_MGMT_EVENT_STACK_SIZE
 	default 2048
 

--- a/drivers/wifi/st67w611m1/st67w611m1_drv.c
+++ b/drivers/wifi/st67w611m1/st67w611m1_drv.c
@@ -405,6 +405,21 @@ MODEM_CMD_DEFINE(on_cmd_cwnetmode)
 	}
 }
 
+MODEM_CMD_DEFINE(on_cmd_cwautoconn)
+{
+	struct st67_driver_data *st67_data =
+		CONTAINER_OF(data, struct st67_driver_data, cmd_handler_data);
+
+	if (argc < 1) {
+		LOG_ERR("Cannot read auto-connect state");
+		return -EINVAL;
+	}
+
+	st67_data->is_auto_connect_enabled = strtol(argv[0], NULL, 10) != 0;
+
+	return 0;
+}
+
 MODEM_CMD_DEFINE(on_cmd_wifi_scan_done)
 {
 	struct st67_driver_data *st67_data =
@@ -765,6 +780,7 @@ static void st67_init_work(struct k_work *work)
 		SETUP_CMD("AT+CIPSTAMAC?\r\n", "+CIPSTAMAC:", on_cmd_cipstamac, 1U, ""),
 		SETUP_CMD_NOHANDLE(ST67W611M1_CWLAPOPT_CMD),
 		SETUP_CMD("AT+CWNETMODE?\r\n", "+CWNETMODE:", on_cmd_cwnetmode, 1U, ""),
+		SETUP_CMD("AT+CWAUTOCONN?\r\n", "+CWAUTOCONN:", on_cmd_cwautoconn, 1U, ""),
 	};
 	ret = modem_cmd_handler_setup_cmds(
 		&st67_data->mctx.iface, &st67_data->mctx.cmd_handler, cmds, ARRAY_SIZE(cmds),
@@ -772,6 +788,16 @@ static void st67_init_work(struct k_work *work)
 	if (ret < 0) {
 		LOG_ERR("Init failed: %d", ret);
 		return;
+	}
+
+	/* Only write auto-connect when it differs as the module persists it to flash. */
+	if (st67_data->is_auto_connect_enabled != IS_ENABLED(CONFIG_ST67W611M1_WIFI_AUTO_CONNECT)) {
+		ret = st67_send_at_cmd(st67_data, NULL, 0, ST67W611M1_CWAUTOCONN_SET_CMD,
+				       ST67W611M1_AT_CMD_TIMEOUT);
+		if (ret < 0) {
+			LOG_ERR("Failed to set auto-connect: %d", ret);
+			return;
+		}
 	}
 
 	k_sem_give(&st67_data->sem_st67_init_over);

--- a/drivers/wifi/st67w611m1/st67w611m1_drv.c
+++ b/drivers/wifi/st67w611m1/st67w611m1_drv.c
@@ -761,6 +761,7 @@ static void st67_init_work(struct k_work *work)
 	struct st67_driver_data *st67_data = CONTAINER_OF(work, struct st67_driver_data, init_work);
 
 	static const struct setup_cmd cmds[] = {
+		SETUP_CMD_NOHANDLE("AT+CWMODE=1,1\r\n"),
 		SETUP_CMD("AT+CIPSTAMAC?\r\n", "+CIPSTAMAC:", on_cmd_cipstamac, 1U, ""),
 		SETUP_CMD_NOHANDLE(ST67W611M1_CWLAPOPT_CMD),
 		SETUP_CMD("AT+CWNETMODE?\r\n", "+CWNETMODE:", on_cmd_cwnetmode, 1U, ""),

--- a/drivers/wifi/st67w611m1/st67w611m1_drv.h
+++ b/drivers/wifi/st67w611m1/st67w611m1_drv.h
@@ -40,6 +40,13 @@ extern "C" {
 #define ST67W611M1_CWLAPOPT_CMD                                                                    \
 	"AT+CWLAPOPT=1,31,-100,255," STRINGIFY(CONFIG_ST67W611M1_SCAN_RESULT_MAX_NUMBER) "\r\n"
 
+/*
+ * AT+CWAUTOCONN=<enable>: persistent power-on auto-connect, saved to flash by the
+ * module. The value follows CONFIG_ST67W611M1_WIFI_AUTO_CONNECT.
+ */
+#define ST67W611M1_CWAUTOCONN_SET_CMD                                                              \
+	"AT+CWAUTOCONN=" STRINGIFY(IS_ENABLED(CONFIG_ST67W611M1_WIFI_AUTO_CONNECT)) "\r\n"
+
 #define CONN_CMD_MAX_LEN                                                                           \
 	(sizeof("AT+CWJAP=\"\",\"\"\r\n") + WIFI_SSID_MAX_LEN * 2 + WIFI_PSK_MAX_LEN * 2)
 
@@ -97,6 +104,9 @@ struct st67_driver_data {
 	enum st67_sta_current_state sta_current_state;
 
 	bool is_supported_st67_firmware_detected;
+
+	/* Module's current AT+CWAUTOCONN value, read back during init. */
+	bool is_auto_connect_enabled;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
The ST67W611M1 driver never puts the coprocessor into station mode during initialization. On a freshly flashed module the first `AT+CWJAP` is therefore rejected with `ERROR`, and `wifi connect` always fails:

```
uart:~$ wifi connect -s "xxx" -k 1 -p "xxx"
Connection requested
[00:00:02.988,000] <dbg> net_wifi_mgmt.wifi_connect: ssid xxx|xxx
[00:00:02.988,000] <dbg> net_wifi_mgmt.wifi_connect: psk xxx|xxxx
[00:00:02.988,000] <dbg> net_wifi_mgmt.wifi_connect: (shell_uart): ch 255 sec 1
[00:00:02.988,000] <dbg> st67w611m1_spi.spi_ready_cb: Got ready
[00:00:02.988,000] <dbg> st67w611m1_spi.spi_ready_cb: Got ready
[00:00:02.989,000] <dbg> st67w611m1_spi.spi_ready_cb: Got ready
[00:00:02.989,000] <dbg> st67w611m1_spi.spi_ready_cb: Got ready
[00:00:02.989,000] <err> st67w611m1: Failed to send connect cmd
```

ST's ST67W6X SDK sets station mode (`AT+CWMODE=1,0`) in `W61_WiFi_Station_Start()`, which is called early in `W6X_WiFi_Init()` (before auto-connect, country code and DTIM). Add the equivalent to the driver's init setup sequence.

Reproduced on NUCLEO-U575ZI-Q + X-NUCLEO-67W61M1, mission T02 firmware
v2.0.106.

Note: To reproduce this you need to reflash the module as this setting seems persistent in some NVM that gets erased on flash.