### PR TITLE
nxp: i.MX93 audio + AArch64 correctness for A2DP sink

### DIFF
--- a/drivers/bluetooth/hci/hci_nxp_setup.c
+++ b/drivers/bluetooth/hci/hci_nxp_setup.c
@@ -925,11 +925,11 @@ static int fw_upload_v1_send_data(uint16_t len)
 		len = fw_upload.fw_length - fw_upload.current_length;
 	}
 
-	__ASSERT(sizeof(fw_upload.send_buffer) >= len, "V1: Out of sending buffer range (%u < %u)",
+	__ASSERT(sizeof(fw_upload.send_buffer) >= len, "V1: Out of sending buffer range (%zu < %u)",
 		 sizeof(fw_upload.send_buffer), len);
 
 	if (sizeof(fw_upload.send_buffer) < len) {
-		LOG_ERR("V1: Out of sending buffer range (%u < %u)", sizeof(fw_upload.send_buffer),
+		LOG_ERR("V1: Out of sending buffer range (%zu < %u)", sizeof(fw_upload.send_buffer),
 			len);
 		return -ENOMEM;
 	}
@@ -985,11 +985,11 @@ static int fw_upload_v3_send_data(void)
 		fw_upload.length = fw_upload.fw_length - start;
 	}
 	__ASSERT(sizeof(fw_upload.send_buffer) >= fw_upload.length,
-		 "V3: Out of sending buffer range (%u < %u)", sizeof(fw_upload.send_buffer),
+		 "V3: Out of sending buffer range (%zu < %u)", sizeof(fw_upload.send_buffer),
 		 fw_upload.length);
 
 	if (sizeof(fw_upload.send_buffer) < fw_upload.length) {
-		LOG_ERR("V3: Out of sending buffer range (%u < %u)", sizeof(fw_upload.send_buffer),
+		LOG_ERR("V3: Out of sending buffer range (%zu < %u)", sizeof(fw_upload.send_buffer),
 			fw_upload.length);
 		return -ENOMEM;
 	}

--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -522,33 +522,58 @@ static int CCM_SET_FUNC_ATTR mcux_ccm_set_subsys_rate(const struct device *dev,
 	defined(CONFIG_SOC_MIMX9111)) && defined(CONFIG_I2S_MCUX_SAI)
 	case IMX_CCM_SAI1_CLK:
 	case IMX_CCM_SAI2_CLK:
-	case IMX_CCM_SAI3_CLK:
+	case IMX_CCM_SAI3_CLK: {
 		uint32_t clock_root, instance;
 		clock_root_config_t saiClkCfg;
 		fracn_pll_init_t g_audioPllCfg;
+		uint32_t audio_pll_freq;
 
 		instance = (clock_name & IMX_CCM_INSTANCE_MASK);
 		clock_root = kCLOCK_Root_Sai1 + instance;
 
-		/* Fixed AUDIO_PLL's frequency at 393216000 Hz */
-#define AUDIO_PLL_CLK_FREQ 393216000
-		g_clockSourceFreq[kCLOCK_AudioPll1Out] = AUDIO_PLL_CLK_FREQ;
-		g_clockSourceFreq[kCLOCK_AudioPll1] = AUDIO_PLL_CLK_FREQ;
-		g_audioPllCfg.rdiv = 1;
-		g_audioPllCfg.mfi = 163;
-		g_audioPllCfg.mfn = 84;
-		g_audioPllCfg.mfd = 100;
-		g_audioPllCfg.odiv = 10;
+		/*
+		 * Select AUDIO_PLL family based on the requested SAI root clock.
+		 * The i.MX93 AUDIO_PLL frequency has to be integer-divided down
+		 * to the SAI MCLK, so a 48kHz-family MCLK (12.288MHz, 24.576MHz,
+		 * ...) requires AUDIO_PLL = 393.216MHz and a 44.1kHz-family MCLK
+		 * (11.2896MHz, 22.5792MHz, ...) requires AUDIO_PLL = 361.2672MHz.
+		 * Detect which family the caller is asking for by checking
+		 * divisibility. Fall back to the 48kHz-family PLL if the rate is
+		 * neither.
+		 */
+#define AUDIO_PLL_FREQ_48K_FAMILY  393216000U   /* 24MHz * (163 + 84/100) / 10 */
+#define AUDIO_PLL_FREQ_44K1_FAMILY 361267200U   /* 24MHz * (150 + 66/125) / 10 */
+
+		if ((clock_rate != 0U) &&
+		    ((AUDIO_PLL_FREQ_44K1_FAMILY % (uint32_t)clock_rate) == 0U)) {
+			audio_pll_freq = AUDIO_PLL_FREQ_44K1_FAMILY;
+			g_audioPllCfg.rdiv = 1;
+			g_audioPllCfg.mfi  = 150;
+			g_audioPllCfg.mfn  = 66;
+			g_audioPllCfg.mfd  = 125;
+			g_audioPllCfg.odiv = 10;
+		} else {
+			audio_pll_freq = AUDIO_PLL_FREQ_48K_FAMILY;
+			g_audioPllCfg.rdiv = 1;
+			g_audioPllCfg.mfi  = 163;
+			g_audioPllCfg.mfn  = 84;
+			g_audioPllCfg.mfd  = 100;
+			g_audioPllCfg.odiv = 10;
+		}
+
+		g_clockSourceFreq[kCLOCK_AudioPll1Out] = audio_pll_freq;
+		g_clockSourceFreq[kCLOCK_AudioPll1] = audio_pll_freq;
 
 		CLOCK_PllInit(AUDIOPLL, &g_audioPllCfg);
 
 		saiClkCfg.clockOff = false;
 		saiClkCfg.mux = 1;
-		saiClkCfg.div = (AUDIO_PLL_CLK_FREQ + (clock_rate - 1)) / clock_rate;
+		saiClkCfg.div = (audio_pll_freq + (clock_rate - 1)) / clock_rate;
 
 		CLOCK_SetRootClock(clock_root, &saiClkCfg);
 
 		return 0;
+	}
 #endif
 
 #if defined(CONFIG_UDC_NXP_EHCI) && defined(CONFIG_SOC_MIMX9352_A55)

--- a/drivers/dma/Kconfig.mcux_edma
+++ b/drivers/dma/Kconfig.mcux_edma
@@ -19,6 +19,7 @@ config DMA_MCUX_EDMA_V3
 	bool "MCUX DMA v3 driver"
 	default y
 	depends on $(dt_compat_any_has_prop,$(EDMA_COMPAT),$(REV_PROP),3)
+	imply NOCACHE_MEMORY if CPU_HAS_DCACHE
 	help
 	  DMA version 3 driver for MCUX series SoCs with DMA3 IP.
 
@@ -27,6 +28,7 @@ config DMA_MCUX_EDMA_V4
 	default y
 	depends on $(dt_compat_any_has_prop,$(EDMA_COMPAT),$(REV_PROP),4) || \
 	           $(dt_compat_any_has_prop,$(EDMA_COMPAT),$(REV_PROP),5)
+	imply NOCACHE_MEMORY if CPU_HAS_DCACHE
 	help
 	  DMA version 4  driver for MCUX Series SoCs Equipped
 	  with Multiple EDMA IPs(EDMA, DMA3, EDMA4, EDMA5).

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -365,8 +365,8 @@ static int dma_mcux_edma_configure_sg_loop(const struct device *dev,
 	data->transfer_settings.empty_tcds = CONFIG_DMA_TCD_QUEUE_SIZE;
 
 	EDMA_PrepareTransfer(
-		&data->transferConfig, (void *)block_config->source_address,
-		config->source_data_size, (void *)block_config->dest_address,
+		&data->transferConfig, (void *)(uintptr_t)block_config->source_address,
+		config->source_data_size, (void *)(uintptr_t)block_config->dest_address,
 		config->dest_data_size, config->source_burst_length,
 		block_config->block_size, transfer_type);
 
@@ -456,9 +456,9 @@ static inline int dma_mcux_edma_configure_sg_dynamic(const struct device *dev,
 		}
 
 		EDMA_PrepareTransfer(&(data->transferConfig),
-				     (void *)block_config->source_address,
+				     (void *)(uintptr_t)block_config->source_address,
 				     config->source_data_size,
-				     (void *)block_config->dest_address,
+				     (void *)(uintptr_t)block_config->dest_address,
 				     config->dest_data_size,
 				     config->source_burst_length,
 				     block_config->block_size, block_transfer_type);
@@ -504,9 +504,9 @@ static int dma_mcux_edma_configure_basic(const struct device *dev,
 	/* block_count shall be 1 */
 	LOG_DBG("block size is: %d", block_config->block_size);
 	EDMA_PrepareTransfer(&(data->transferConfig),
-			     (void *)block_config->source_address,
+			     (void *)(uintptr_t)block_config->source_address,
 			     config->source_data_size,
-			     (void *)block_config->dest_address,
+			     (void *)(uintptr_t)block_config->dest_address,
 			     config->dest_data_size,
 			     xfer_settings->source_burst_length,
 			     block_config->block_size, transfer_type);
@@ -889,7 +889,7 @@ static int edma_reload_loop(const struct device *dev, uint32_t channel,
 			~DMA_CSR_DREQ(1U);
 
 		if (data->transfer_settings.empty_tcds == CONFIG_DMA_TCD_QUEUE_SIZE - 1 ||
-		    hw_id == (uint32_t)tcd) {
+		    hw_id == (uint32_t)(uintptr_t)tcd) {
 			/* DMA is running on last transfer. HW has loaded the last one,
 			 * we need ensure it's DREQ is cleared.
 			 */
@@ -936,8 +936,8 @@ static int edma_reload_dynamic(const struct device *dev, uint32_t channel,
 		return -EBUSY;
 	}
 
-	EDMA_PrepareTransfer(&(data->transferConfig), (void *)src,
-			     data->transfer_settings.source_data_size, (void *)dst,
+	EDMA_PrepareTransfer(&(data->transferConfig), (void *)(uintptr_t)src,
+			     data->transfer_settings.source_data_size, (void *)(uintptr_t)dst,
 			     data->transfer_settings.dest_data_size,
 			     data->transfer_settings.source_burst_length, size,
 			     data->transfer_settings.transfer_type);

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -538,6 +538,30 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 		enable_mclk_direction(dev, dev_cfg->mclk_output);
 	}
 
+#ifndef CONFIG_I2S_HAS_PLL_SETTING
+	/*
+	 * Re-tune the SAI root clock to a value that matches the requested
+	 * sample rate's clock family. The default value programmed at driver
+	 * initialization (12.288MHz, 48kHz-family) cannot generate a valid
+	 * 44.1kHz LRCK via any integer bit-clock divider, so leaving it in
+	 * place for a 44.1kHz stream produces silence at the codec (the SAI
+	 * rounds LRCK to 48kHz and the codec's SYSCLK:LRCK ratio falls out
+	 * of its supported range). Pick the closest MCLK that is an integer
+	 * multiple of 256 * frame_clk_freq; the platform's CCM driver is
+	 * responsible for reconfiguring the underlying audio PLL family.
+	 */
+	{
+		uint32_t desired_mclk;
+
+		if ((i2s_cfg->frame_clk_freq % 11025U) == 0U) {
+			desired_mclk = 11289600U;   /* 44.1kHz family */
+		} else {
+			desired_mclk = 12288000U;   /* 48kHz family (default) */
+		}
+		set_mclk_rate(dev, desired_mclk);
+	}
+#endif
+
 	get_mclk_rate(dev, &mclk);
 	LOG_DBG("mclk is %d", mclk);
 

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -244,8 +244,8 @@ static int i2s_tx_reload_multiple_dma_blocks(const struct device *dev, uint8_t *
 		}
 
 		/* reload the DMA */
-		ret = dma_reload(dev_data->dev_dma, strm->dma_channel, (uint32_t)q_entry.mem_block,
-				 (uint32_t)&base->TDR[strm->start_channel], q_entry.size);
+		ret = dma_reload(dev_data->dev_dma, strm->dma_channel, (uintptr_t)q_entry.mem_block,
+				 (uintptr_t)&base->TDR[strm->start_channel], q_entry.size);
 		if (ret != 0) {
 			LOG_ERR("dma_reload() failed with error 0x%x", ret);
 			break;
@@ -411,7 +411,7 @@ static void i2s_dma_rx_callback(const struct device *dma_dev, void *arg, uint32_
 	uint32_t data_path = strm->start_channel;
 
 	ret = dma_reload(dev_data->dev_dma, strm->dma_channel,
-			 (uint32_t)&base->RDR[data_path], (uint32_t)q_entry.mem_block,
+			 (uintptr_t)&base->RDR[data_path], (uintptr_t)q_entry.mem_block,
 			 q_entry.size);
 	if (ret != 0) {
 		LOG_ERR("dma_reload() failed with error 0x%x", ret);
@@ -436,7 +436,7 @@ static void enable_mclk_direction(const struct device *dev, bool dir)
 	uint32_t control_base = dev_cfg->mclk_control_base;
 	uint32_t offset = dev_cfg->mclk_pin_offset;
 	uint32_t mask = dev_cfg->mclk_pin_mask;
-	uint32_t *base = (uint32_t *)(control_base + offset);
+	uint32_t *base = (uint32_t *)(uintptr_t)(control_base + offset);
 
 	if (control_base == 0 && offset == 0 && mask == 0) {
 		return;
@@ -475,7 +475,7 @@ static void set_mclk_rate(const struct device *dev, uint32_t rate)
 
 	if (device_is_ready(ccm_dev)) {
 		clock_control_set_rate(ccm_dev, clk_sub_sys,
-					(clock_control_subsys_rate_t)rate);
+					(clock_control_subsys_rate_t)(uintptr_t)rate);
 		clock_control_on(ccm_dev, clk_sub_sys);
 	} else {
 		LOG_ERR("CCM driver is not installed");
@@ -677,10 +677,10 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 
 	if (dir == I2S_DIR_TX) {
 		memcpy(&dev_data->tx.cfg, i2s_cfg, sizeof(struct i2s_config));
-		LOG_DBG("tx slab free_list = 0x%x", (uint32_t)i2s_cfg->mem_slab->free_list);
+		LOG_DBG("tx slab free_list = %p", (void *)i2s_cfg->mem_slab->free_list);
 		LOG_DBG("tx slab num_blocks = %d", (uint32_t)i2s_cfg->mem_slab->info.num_blocks);
 		LOG_DBG("tx slab block_size = %d", (uint32_t)i2s_cfg->mem_slab->info.block_size);
-		LOG_DBG("tx slab buffer = 0x%x", (uint32_t)i2s_cfg->mem_slab->buffer);
+		LOG_DBG("tx slab buffer = %p", (void *)i2s_cfg->mem_slab->buffer);
 
 		config.fifo.fifoWatermark = (uint32_t)FSL_FEATURE_SAI_FIFO_COUNTn(base) - 1;
 #if defined(FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE) && FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE
@@ -709,10 +709,10 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 #endif
 
 		memcpy(&dev_data->rx.cfg, i2s_cfg, sizeof(struct i2s_config));
-		LOG_DBG("rx slab free_list = 0x%x", (uint32_t)i2s_cfg->mem_slab->free_list);
+		LOG_DBG("rx slab free_list = %p", (void *)i2s_cfg->mem_slab->free_list);
 		LOG_DBG("rx slab num_blocks = %d", (uint32_t)i2s_cfg->mem_slab->info.num_blocks);
 		LOG_DBG("rx slab block_size = %d", (uint32_t)i2s_cfg->mem_slab->info.block_size);
-		LOG_DBG("rx slab buffer = 0x%x", (uint32_t)i2s_cfg->mem_slab->buffer);
+		LOG_DBG("rx slab buffer = %p", (void *)i2s_cfg->mem_slab->buffer);
 
 		/* set bit clock divider */
 		SAI_RxSetConfig(base, &config);
@@ -780,8 +780,8 @@ static int i2s_tx_stream_start(const struct device *dev)
 
 	uint32_t data_path = strm->start_channel;
 
-	blk_cfg->dest_address = (uint32_t)&base->TDR[data_path];
-	blk_cfg->source_address = (uint32_t)q_entry.mem_block;
+	blk_cfg->dest_address = (uintptr_t)&base->TDR[data_path];
+	blk_cfg->source_address = (uintptr_t)q_entry.mem_block;
 	blk_cfg->block_size = q_entry.size;
 	blk_cfg->dest_scatter_en = 1;
 
@@ -862,8 +862,8 @@ static int i2s_rx_stream_start(const struct device *dev)
 
 	uint32_t data_path = strm->start_channel;
 
-	blk_cfg->dest_address = (uint32_t)q_entry.mem_block;
-	blk_cfg->source_address = (uint32_t)&base->RDR[data_path];
+	blk_cfg->dest_address = (uintptr_t)q_entry.mem_block;
+	blk_cfg->source_address = (uintptr_t)&base->RDR[data_path];
 	blk_cfg->block_size = q_entry.size;
 
 	blk_cfg->source_gather_en = 1;
@@ -892,8 +892,8 @@ static int i2s_rx_stream_start(const struct device *dev)
 		}
 		q_entry.size = blk_cfg->block_size;
 
-		ret = dma_reload(dev_dma, strm->dma_channel, (uint32_t)&base->RDR[data_path],
-				 (uint32_t)q_entry.mem_block, q_entry.size);
+		ret = dma_reload(dev_dma, strm->dma_channel, (uintptr_t)&base->RDR[data_path],
+				 (uintptr_t)q_entry.mem_block, q_entry.size);
 		if (ret != 0) {
 			LOG_ERR("dma_reload() failed with error 0x%x", ret);
 			return ret;

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -496,9 +496,8 @@
 		dma-channels = <4>;
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SPI 128 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-			     <GIC_SPI 128 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
-			     <GIC_SPI 129 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 			     <GIC_SPI 129 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		channels-shared-irq-mask = <0x00000003>, <0x0000000c>;
 		#dma-cells = <2>;
 		status = "disabled";
 	};

--- a/samples/bluetooth/classic/a2dp_sink/src/audio_buf.c
+++ b/samples/bluetooth/classic/a2dp_sink/src/audio_buf.c
@@ -149,9 +149,10 @@ void audio_process_sbc_buf(uint8_t sbc_hdr, uint8_t *data, size_t len, uint16_t 
 {
 	const void *in_data;
 	size_t samples_count;
-	size_t out_size;
+	uint32_t out_size;
 	size_t samples_lost;
 	uint8_t num_frames;
+	uint32_t in_size;
 	int err;
 
 	samples_lost = 0;
@@ -176,6 +177,7 @@ void audio_process_sbc_buf(uint8_t sbc_hdr, uint8_t *data, size_t len, uint16_t 
 
 	samples_count = 0;
 	in_data = (void *)data;
+	in_size = (uint32_t)len;
 	for (uint8_t i = 0; i < num_frames; ++i) {
 		if (audio_pcm_buffer_free_size() == 0) {
 			/* if no enough space, don't need decode. */
@@ -183,7 +185,7 @@ void audio_process_sbc_buf(uint8_t sbc_hdr, uint8_t *data, size_t len, uint16_t 
 		}
 
 		out_size = sizeof(pcm_frame_buffer);
-		err = sbc_decode(&decoder, &in_data, &len, pcm_frame_buffer, &out_size);
+		err = sbc_decode(&decoder, &in_data, &in_size, pcm_frame_buffer, &out_size);
 
 		if (err == 0) {
 			audio_add_pcm_data((uint8_t *)pcm_frame_buffer, out_size);

--- a/samples/bluetooth/classic/a2dp_sink/src/codec_play.c
+++ b/samples/bluetooth/classic/a2dp_sink/src/codec_play.c
@@ -67,9 +67,24 @@ void codec_play_configure(uint32_t sample_rate, uint8_t sample_width, uint8_t ch
 	struct audio_codec_cfg audio_cfg;
 	size_t block_size;
 
+	int ret;
+
 	audio_sample_rate = sample_rate;
 	if (sample_rate == 44100) {
-		block_size = A2DP_SBC_DATA_PLAY_SIZE_44_1K;
+		/*
+		 * A2DP_SBC_DATA_PLAY_SIZE_44_1K (1764 bytes) is not a multiple of
+		 * sizeof(void *). k_mem_slab_init()/create_free_list() require the
+		 * block size to be word aligned (they build an in-place free list by
+		 * linking each block's first pointer-sized word). On 32-bit targets
+		 * 1764 happens to be 4-byte aligned so this went unnoticed, but on
+		 * this AArch64 board (8-byte pointers) it fails the alignment check,
+		 * k_mem_slab_init() returns -EINVAL, and the mem_slab is left with
+		 * an uninitialized wait_q/free_list. The buffer itself is already
+		 * sized using the larger A2DP_SBC_DATA_PLAY_SIZE_48K, so rounding
+		 * the block size up here is safe (the actual data written per
+		 * block, A2DP_SBC_DATA_PLAY_SIZE_44_1K, still fits within it).
+		 */
+		block_size = ROUND_UP(A2DP_SBC_DATA_PLAY_SIZE_44_1K, sizeof(void *));
 	} else {
 		block_size = A2DP_SBC_DATA_PLAY_SIZE_48K;
 	}
@@ -87,8 +102,6 @@ void codec_play_configure(uint32_t sample_rate, uint8_t sample_width, uint8_t ch
 	audio_cfg.dai_cfg.i2s.frame_clk_freq = sample_rate;
 	audio_cfg.dai_cfg.i2s.mem_slab = &mem_slab;
 	audio_cfg.dai_cfg.i2s.block_size = block_size;
-	audio_codec_configure(codec_dev, &audio_cfg);
-	k_msleep(1000);
 
 	config.word_size = sample_width;
 	config.channels = channels;
@@ -102,11 +115,35 @@ void codec_play_configure(uint32_t sample_rate, uint8_t sample_width, uint8_t ch
 	config.mem_slab = &mem_slab;
 	config.block_size = block_size;
 	config.timeout = I2S_TIMEOUT;
+
+	/*
+	 * Configure the SAI (MCLK master) BEFORE the codec. On boards where
+	 * MCLK is derived from a runtime-tunable CCM root clock (i.MX93 SAI3),
+	 * i2s_configure() may need to retune the SAI root clock to a
+	 * sample-rate-aligned frequency (e.g. 11.2896 MHz for the 44.1 kHz
+	 * family vs. 12.288 MHz for the 48 kHz family). If the codec is
+	 * configured first, it reads a stale MCLK rate via
+	 * clock_control_get_rate() and programs its internal FLL for the
+	 * wrong input frequency, producing an out-of-spec SYSCLK once the
+	 * SAI subsequently retunes MCLK.
+	 *
+	 * Reordering is safe on boards whose MCLK is DT-static (e.g. NXP RT
+	 * anatop pll-clocks): configuring the SAI first has no effect on the
+	 * codec beyond a slightly earlier MCLK enable, which the WM8962
+	 * tolerates.
+	 */
 	if (i2s_configure(codec_tx, I2S_DIR_TX, &config)) {
 		printk("failure to config streams\n");
 	}
 
-	k_mem_slab_init(&mem_slab, mem_slab_buffer, block_size, CONFIG_A2DP_BOARD_CODEC_PLAY_COUNT);
+	audio_codec_configure(codec_dev, &audio_cfg);
+	k_msleep(1000);
+
+	ret = k_mem_slab_init(&mem_slab, mem_slab_buffer, block_size,
+			      CONFIG_A2DP_BOARD_CODEC_PLAY_COUNT);
+	if (ret < 0) {
+		printk("failed to init mem slab: %d\n", ret);
+	}
 }
 
 static void codec_play_to_dev(uint8_t *data, uint32_t length)
@@ -176,6 +213,7 @@ void codec_keep_play(void)
 
 	while (true) {
 		if (!audio_start) {
+			k_sleep(K_MSEC(1));
 			continue;
 		}
 

--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -1427,7 +1427,7 @@ static uint16_t sdp_svc_search_att_req(struct bt_sdp *sdp, struct net_buf *buf, 
 	}
 
 	if (max_att_len < sizeof(*seq)) {
-		LOG_WRN("Invalid maximum attribute byte count %u < %u", max_att_len, sizeof(*seq));
+		LOG_WRN("Invalid maximum attribute byte count %u < %zu", max_att_len, sizeof(*seq));
 		return BT_SDP_INVALID_SYNTAX;
 	}
 
@@ -2898,7 +2898,7 @@ static int sdp_pass_value_u16(struct bt_sdp_attr_value *value, uint16_t *param)
 		*param = value->uint.u16;
 		break;
 	default:
-		LOG_WRN("Mismatched size %u != %u", value->uint.size, sizeof(*param));
+		LOG_WRN("Mismatched size %u != %zu", value->uint.size, sizeof(*param));
 		return -EINVAL;
 	}
 
@@ -2969,7 +2969,7 @@ int bt_sdp_get_addl_proto_param(const struct net_buf *buf, uint16_t proto, uint8
 	}
 
 	if (index >= count) {
-		LOG_ERR("Index out of range 0 ~ %d", count - 1);
+		LOG_ERR("Index out of range 0 ~ %zd", count - 1);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
## Group 1 — i.MX93 44.1 kHz audio bring-up (real bugs)

- `drivers: clock_control: mcux_ccm_rev2: support 44.1kHz-family SAI clocks`
- `drivers: i2s: mcux_sai: retune SAI root clock to sample rate family`
- `dts: arm64: imx93: fix edma4_2 shared IRQs`
- `drivers: dma: mcux_edma: imply NOCACHE_MEMORY on cached CPUs`

## Group 2 — a2dp_sink sample fixes for AArch64 / runtime-MCLK boards

- `samples: bluetooth: a2dp_sink: fix sbc_decode length type mismatch`
- `samples: bluetooth: a2dp_sink: fix codec_play for runtime-MCLK boards`

## Group 3 — AArch64 build-warning cleanup (no functional change)

- `Bluetooth: fix format specifiers for size_t/ssize_t`
- `drivers: dma: mcux_edma: fix pointer casts for 64-bit hosts`
- `drivers: i2s: mcux_sai: fix pointer casts for 64-bit hosts`

## Testing

Verified on `nitrogen93_smarc/mimx9352/a55/nx611` + `smarc_car_brd`
shield (WM8962 on SAI3) playing 44.1 kHz stereo SBC over A2DP from a
phone (`samples/bluetooth/classic/a2dp_sink`). Clean tree build: zero warnings, zero errors. Checkpatch clean
on all 9 commits.

## Notes

A companion `hal_nxp` PR (`edma4: fix pointer casts for 64-bit hosts`)
silences the remaining HAL-internal warnings but is not required for
this PR to build or run correctly.
https://github.com/zephyrproject-rtos/hal_nxp/pull/773
https://github.com/zephyrproject-rtos/hal_nxp/pull/773/changes/94e30c6b58f52617b9fb281da9ebd10e7576049c