### PR TITLE
arch: arm: core: mpu: prevent static MPU regions corruption on PMSAv8

### DIFF
--- a/arch/arm/core/mpu/arm_core_mpu.c
+++ b/arch/arm/core/mpu/arm_core_mpu.c
@@ -37,17 +37,6 @@ extern void arm_core_mpu_disable(void);
 	(IS_ENABLED(CONFIG_MPU_STACK_GUARD) ? 1 : 0)
 #endif /* CONFIG_USERSPACE */
 
-/* Convenience macros to denote the start address and the size of the system
- * memory area, where dynamic memory regions may be programmed at run-time.
- */
-#if defined(CONFIG_USERSPACE)
-#define _MPU_DYNAMIC_REGIONS_AREA_START ((uint32_t)&_app_smem_start)
-#else
-#define _MPU_DYNAMIC_REGIONS_AREA_START ((uint32_t)&__kernel_ram_start)
-#endif /* CONFIG_USERSPACE */
-#define _MPU_DYNAMIC_REGIONS_AREA_SIZE ((uint32_t)&__kernel_ram_end - \
-		_MPU_DYNAMIC_REGIONS_AREA_START)
-
 #if !defined(CONFIG_MULTITHREADING) && defined(CONFIG_MPU_STACK_GUARD)
 K_THREAD_STACK_DECLARE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
 #endif
@@ -169,24 +158,6 @@ void z_arm_configure_static_mpu_regions(void)
 #ifdef CONFIG_AARCH32_ARMV8_R
 	arm_core_mpu_enable();
 #endif
-
-#if defined(CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS) && \
-	defined(CONFIG_MULTITHREADING)
-	/* Define a constant array of z_arm_mpu_partition objects that holds the
-	 * boundaries of the areas, inside which dynamic region programming
-	 * is allowed. The information is passed to the underlying driver at
-	 * initialization.
-	 */
-	const struct z_arm_mpu_partition dyn_region_areas[] = {
-		{
-		.start = _MPU_DYNAMIC_REGIONS_AREA_START,
-		.size =  _MPU_DYNAMIC_REGIONS_AREA_SIZE,
-		}
-	};
-
-	arm_core_mpu_mark_areas_for_dynamic_regions(dyn_region_areas,
-		ARRAY_SIZE(dyn_region_areas));
-#endif /* CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS */
 }
 
 /**

--- a/arch/arm/core/mpu/arm_core_mpu_dev.h
+++ b/arch/arm/core/mpu/arm_core_mpu_dev.h
@@ -136,39 +136,6 @@ void arm_core_mpu_configure_static_mpu_regions(
 	const uint8_t regions_num, const uint32_t background_area_start,
 	const uint32_t background_area_end);
 
-#if defined(CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS)
-
-/* Number of memory areas, inside which dynamic regions
- * may be programmed in run-time.
- */
-#define MPU_DYNAMIC_REGION_AREAS_NUM 1
-
-/**
- * @brief mark a set of memory regions as eligible for dynamic configuration
- *
- * Internal API function to configure a set of memory regions, determined
- * by their start address and size, as memory areas eligible for dynamically
- * programming MPU regions (such as a supervisor stack overflow guard) at
- * run-time (for example, thread upon context-switch).
- *
- * The function shall be invoked once, upon system initialization.
- *
- * @param dyn_region_areas an array of z_arm_mpu_partition objects declaring the
- *                             eligible memory areas for dynamic programming
- * @param dyn_region_areas_num the number of eligible areas for dynamic
- *                             programming.
- *
- * The function shall assert if the operation cannot be not performed
- * successfully. Therefore, the requested areas shall correspond to
- * static memory regions, configured earlier by
- * arm_core_mpu_configure_static_mpu_regions().
- */
-void arm_core_mpu_mark_areas_for_dynamic_regions(
-	const struct z_arm_mpu_partition *dyn_region_areas,
-	const uint8_t dyn_region_areas_num);
-
-#endif /* CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS */
-
 /**
  * @brief configure a set of dynamic MPU regions
  *

--- a/arch/arm/core/mpu/arm_core_mpu_dev.h
+++ b/arch/arm/core/mpu/arm_core_mpu_dev.h
@@ -188,27 +188,6 @@ void arm_core_mpu_configure_dynamic_mpu_regions(
 	const struct z_arm_mpu_partition *dynamic_regions,
 	uint8_t regions_num);
 
-#if defined(CONFIG_USERSPACE)
-/**
- * @brief update configuration of an active memory partition
- *
- * Internal API function to re-configure the access permissions of an
- * active memory partition, i.e. a partition that has earlier been
- * configured in the (current) thread context.
- *
- * @param partition Pointer to a structure holding the partition information
- *                  (must be valid).
- * @param new_attr  New access permissions attribute for the partition.
- *
- * The function shall assert if the operation cannot be not performed
- * successfully (e.g. the given partition can not be found).
- */
-void arm_core_mpu_mem_partition_config_update(
-	struct z_arm_mpu_partition *partition,
-	k_mem_partition_attr_t *new_attr);
-
-#endif /* CONFIG_USERSPACE */
-
 /**
  * @brief configure the base address and size for an MPU region
  *

--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -319,47 +319,6 @@ void arm_core_mpu_disable(void)
 
 #if defined(CONFIG_USERSPACE)
 /**
- * @brief update configuration of an active memory partition
- */
-void arm_core_mpu_mem_partition_config_update(
-	struct z_arm_mpu_partition *partition,
-	k_mem_partition_attr_t *new_attr)
-{
-	/* Find the partition. ASSERT if not found. */
-	uint8_t i;
-	uint8_t reg_index = get_num_regions();
-
-	for (i = get_dyn_region_min_index(); i < get_num_regions(); i++) {
-		if (!is_enabled_region(i)) {
-			continue;
-		}
-
-		uint32_t base = mpu_region_get_base(i);
-
-		if (base != partition->start) {
-			continue;
-		}
-
-		uint32_t size = mpu_region_get_size(i);
-
-		if (size != partition->size) {
-			continue;
-		}
-
-		/* Region found */
-		reg_index = i;
-		break;
-	}
-	__ASSERT(reg_index != get_num_regions(),
-		 "Memory domain partition %p size %zu not found\n",
-		 (void *)partition->start, partition->size);
-
-	/* Modify the permissions */
-	partition->attr = *new_attr;
-	mpu_configure_region(reg_index, partition);
-}
-
-/**
  * @brief get the maximum number of available (free) MPU region indices
  *        for configuring dynamic MPU partitions
  */

--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -354,23 +354,6 @@ void arm_core_mpu_configure_static_mpu_regions(const struct z_arm_mpu_partition
 	}
 }
 
-#if defined(CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS)
-/**
- * @brief mark memory areas for dynamic region configuration
- */
-void arm_core_mpu_mark_areas_for_dynamic_regions(
-	const struct z_arm_mpu_partition dyn_region_areas[],
-	const uint8_t dyn_region_areas_num)
-{
-	if (mpu_mark_areas_for_dynamic_regions(dyn_region_areas,
-						 dyn_region_areas_num) == -EINVAL) {
-
-		__ASSERT(0, "Marking %u areas for dynamic regions failed\n",
-			dyn_region_areas_num);
-	}
-}
-#endif /* CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS */
-
 /**
  * @brief configure dynamic MPU regions.
  */

--- a/arch/arm/core/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/mpu/arm_mpu_v8_internal.h
@@ -15,22 +15,16 @@
 #include <zephyr/sys/math_extras.h>
 #include <zephyr/sys/barrier.h>
 
+#if defined(CONFIG_MPU_GAP_FILLING)
 /**
- * @brief internal structure holding information of
- *        memory areas where dynamic MPU programming
- *        is allowed.
+ * Global array holding a backup of the descriptors for static regions.
  */
-struct dynamic_region_info {
-	int index;
-	struct arm_mpu_region region_conf;
-};
+static struct {
+	uint32_t rbar;
+	uint32_t rlar;
+} static_region_descriptors[Z_ARM_MPU_MAX_REGIONS];
+#endif /* CONFIG_MPU_GAP_FILLING */
 
-/**
- * Global array, holding the MPU region index of
- * the memory region inside which dynamic memory
- * regions may be configured.
- */
-static struct dynamic_region_info dyn_reg_info[MPU_DYNAMIC_REGION_AREAS_NUM];
 #if defined(CONFIG_CPU_CORTEX_M23) || defined(CONFIG_CPU_CORTEX_M33) || \
 	defined(CONFIG_CPU_CORTEX_M52) || defined(CONFIG_CPU_CORTEX_M55) || \
 	defined(CONFIG_CPU_CORTEX_M85)
@@ -329,31 +323,6 @@ static inline void get_region_attr_from_mpu_partition_info(
 }
 
 #if defined(CONFIG_USERSPACE)
-
-/**
- * This internal function returns the minimum HW MPU region index
- * that may hold the configuration of a dynamic memory region.
- *
- * Browse through the memory areas marked for dynamic MPU programming,
- * pick the one with the minimum MPU region index. Return that index.
- *
- * The function is optimized for the (most common) use-case of a single
- * marked area for dynamic memory regions.
- */
-static inline int get_dyn_region_min_index(void)
-{
-	int dyn_reg_min_index = dyn_reg_info[0].index;
-#if MPU_DYNAMIC_REGION_AREAS_NUM > 1
-	for (int i = 1; i < MPU_DYNAMIC_REGION_AREAS_NUM; i++) {
-		if ((dyn_reg_info[i].index != -EINVAL) &&
-			(dyn_reg_info[i].index < dyn_reg_min_index)
-		) {
-			dyn_reg_min_index = dyn_reg_info[i].index;
-		}
-	}
-#endif
-	return dyn_reg_min_index;
-}
 
 static inline uint32_t mpu_region_get_size(uint32_t index)
 {
@@ -684,48 +653,26 @@ static int mpu_configure_static_mpu_regions(const struct z_arm_mpu_partition
 
 	static_regions_num = mpu_reg_index;
 
-	return mpu_reg_index;
-}
-
-/* This internal function marks and stores the configuration of memory areas
- * where dynamic region programming is allowed. Return zero on success, or
- * -EINVAL on error.
- */
-static int mpu_mark_areas_for_dynamic_regions(
-		const struct z_arm_mpu_partition dyn_region_areas[],
-		const uint8_t dyn_region_areas_num)
-{
-	/* In ARMv8-M architecture we need to store the index values
-	 * and the default configuration of the MPU regions, inside
-	 * which dynamic memory regions may be programmed at run-time.
+#if defined(CONFIG_MPU_GAP_FILLING)
+	/*
+	 * On PMSAv8 MPUs, the regions cannot overlap so "static" regions
+	 * may actually be modified at runtime; more precisely, they are
+	 * split in smaller pieces to allow creation of dynamic regions.
+	 *
+	 * Save the original descriptors for these static regions so we can
+	 * restore them later on, when the value in MPU registers have been
+	 * modified to create dynamic regions. This is only needed when
+	 * gap filling is enabled as otherwise, the static regions are not
+	 * used at all.
 	 */
-	for (int i = 0; i < dyn_region_areas_num; i++) {
-		if (dyn_region_areas[i].size == 0U) {
-			continue;
-		}
-		/* Non-empty area */
-
-		/* Retrieve HW MPU region index */
-		dyn_reg_info[i].index =
-			get_region_index(dyn_region_areas[i].start,
-					dyn_region_areas[i].size);
-
-		if (dyn_reg_info[i].index == -EINVAL) {
-
-			return -EINVAL;
-		}
-
-		if (dyn_reg_info[i].index >= static_regions_num) {
-
-			return -EINVAL;
-		}
-
-		/* Store default configuration */
-		mpu_region_get_conf(dyn_reg_info[i].index,
-			&dyn_reg_info[i].region_conf);
+	for (int i = 0; i < static_regions_num; i++) {
+		mpu_set_rnr(i);
+		static_region_descriptors[i].rbar = mpu_get_rbar();
+		static_region_descriptors[i].rlar = mpu_get_rlar();
 	}
+#endif /* CONFIG_MPU_GAP_FILLING */
 
-	return 0;
+	return mpu_reg_index;
 }
 
 /**
@@ -747,6 +694,7 @@ static inline uint8_t get_num_regions(void)
 static int mpu_configure_dynamic_mpu_regions(const struct z_arm_mpu_partition
 	dynamic_regions[], uint8_t regions_num)
 {
+#if defined(CONFIG_MPU_GAP_FILLING)
 	int mpu_reg_index = static_regions_num;
 
 	/* Disable all MPU regions except for the static ones. */
@@ -754,13 +702,11 @@ static int mpu_configure_dynamic_mpu_regions(const struct z_arm_mpu_partition
 		mpu_clear_region(i);
 	}
 
-#if defined(CONFIG_MPU_GAP_FILLING)
-	/* Reset MPU regions inside which dynamic memory regions may
-	 * be programmed.
-	 */
-	for (int i = 0; i < MPU_DYNAMIC_REGION_AREAS_NUM; i++) {
-		region_init(dyn_reg_info[i].index,
-			&dyn_reg_info[i].region_conf);
+	/* Restore the configuration of all static regions */
+	for (int i = 0; i < static_regions_num; i++) {
+		mpu_set_rnr(i);
+		mpu_set_rbar(static_region_descriptors[i].rbar);
+		mpu_set_rlar(static_region_descriptors[i].rlar);
 	}
 
 	/* In ARMv8-M architecture the dynamic regions are programmed on SRAM,
@@ -769,23 +715,19 @@ static int mpu_configure_dynamic_mpu_regions(const struct z_arm_mpu_partition
 	 */
 	mpu_reg_index = mpu_configure_regions_and_partition(dynamic_regions,
 		regions_num, mpu_reg_index, true);
-#else
-
-	/* We are going to skip the full partition of the background areas.
-	 * So we can disable MPU regions inside which dynamic memory regions
-	 * may be programmed.
+#else /* CONFIG_MPU_GAP_FILLING */
+	/* When gap filling is disabled, MPU regions are simply programmed
+	 * on top of the background map. Clear all regions before programming.
 	 */
-	for (int i = 0; i < MPU_DYNAMIC_REGION_AREAS_NUM; i++) {
-		mpu_clear_region(dyn_reg_info[i].index);
+	for (int i = 0; i < get_num_regions(); i++) {
+		mpu_clear_region(i);
 	}
 
-	/* The dynamic regions are now programmed on top of
-	 * existing SRAM region configuration.
-	 */
+	/* Then program dynamic regions on top of the background map. */
 	mpu_reg_index = mpu_configure_regions(dynamic_regions,
-		regions_num, mpu_reg_index, true);
-
+		regions_num, 0, true);
 #endif /* CONFIG_MPU_GAP_FILLING */
+
 	return mpu_reg_index;
 }
 

--- a/arch/arm/core/mpu/nxp_mpu.c
+++ b/arch/arm/core/mpu/nxp_mpu.c
@@ -534,46 +534,6 @@ static inline int is_in_region(uint32_t r_index, uint32_t start, uint32_t size)
 }
 
 /**
- * @brief update configuration of an active memory partition
- */
-void arm_core_mpu_mem_partition_config_update(
-	struct z_arm_mpu_partition *partition,
-	k_mem_partition_attr_t *new_attr)
-{
-	/* Find the partition. ASSERT if not found. */
-	uint8_t i;
-	uint8_t reg_index = get_num_regions();
-
-	for (i = static_regions_num; i < get_num_regions(); i++) {
-		if (!is_enabled_region(i)) {
-			continue;
-		}
-
-		uint32_t base = mpu_region_get_base(i);
-
-		if (base != partition->start) {
-			continue;
-		}
-
-		uint32_t size = mpu_region_get_size(i);
-
-		if (size != partition->size) {
-			continue;
-		}
-
-		/* Region found */
-		reg_index = i;
-		break;
-	}
-	__ASSERT(reg_index != get_num_regions(),
-		 "Memory domain partition not found\n");
-
-	/* Modify the permissions */
-	partition->attr = *new_attr;
-	mpu_configure_region(reg_index, partition);
-}
-
-/**
  * @brief get the maximum number of available (free) MPU region indices
  *        for configuring dynamic MPU partitions
  */


### PR DESCRIPTION
The previous implementation for PMSAv8 had a concept of "areas marked for dynamic regions" which allowed to reconfigure "static" MPU regions at runtime. This worked by saving these regions' MPU configuration and restoring it during MPU context switches, ensuring that even if those regions were broken into smaller pieces due to dynamic regions, they would not be corrupted...

...however, the implementation never actually checked if an MPU region was "marked for dynamic regions" or not before breaking it into smaller pieces! As a result, if any dynamic region is created "inside" a static region that was not "marked", this static region's MPU desctiptor will be shrinked but never restored later on and be permanently corrupted.

Completely remove this "areas marked for dynamic regions" concept and instead, save the MPU descriptors for all static regions when they are configured (once, at boot) and restore these descriptors unconditionally where the "marked" regions used to be restored, which is effectively an extension of the existing behavior to all static regions.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/99826

---

The first commit is preliminary cleanup and only tangentially related - the removed function was a caller of stuff that's being removed so I would have had to update it... but it's actually dead code lingering in tree since https://github.com/zephyrproject-rtos/zephyr/pull/27786 (!).

From a look at the linker map on `mps2/an521/cpu0`, it seems the function wasn't even garbage collected by the linker, so this removal should not only make tree, but also *images for all ARM targets* leaner, and simplifies the actual patch itself. I can split it to a separate PR if you prefer though.