### PR TITLE
net: dns: Fix dispatcher forwarding with context when socket is shared

### DIFF
--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -68,7 +68,7 @@ static int dns_dispatch(struct dns_socket_dispatcher *dispatcher,
 					     addr, addrlen,
 					     dns_data, data_len);
 		} else if (dispatcher->pair) {
-			ret = dispatcher->pair->cb(dispatcher, sock,
+			ret = dispatcher->pair->cb(dispatcher->pair, sock,
 						   addr, addrlen,
 						   dns_data, data_len);
 		} else {
@@ -86,7 +86,7 @@ static int dns_dispatch(struct dns_socket_dispatcher *dispatcher,
 					     addr, addrlen,
 					     dns_data, data_len);
 		} else if (dispatcher->pair) {
-			ret = dispatcher->pair->cb(dispatcher, sock,
+			ret = dispatcher->pair->cb(dispatcher->pair, sock,
 						   addr, addrlen,
 						   dns_data, data_len);
 		} else {


### PR DESCRIPTION
When the mDNS responder and DNS resolver are attached to the same port, i.e., 5353, the socket is supposed to be shared, and it seems this is achieved by pairing dispatchers and forwarding the message to the correct handler depending if the received message is a query or response. The 'pairing' was done by attaching the second handler (either resolver or responder, whichever was paired second) to the 'pair' field of the dispatcher.
But then when the callback from the pair field, a.ka. the `dispatcher->pair->cb()` function is called, it is passing `dispatcher` as the context and not the `dispatcher-pair`. This caused the responses or requests to be silently dropped.

The fix was to pass `dispatcher-pair` as `ctx` when `dispatcher->pair->cb()` was called.