### PR TITLE
drivers: uart: align async timeout units documentation

### DIFF
--- a/drivers/modem/modem_iface_uart_async.c
+++ b/drivers/modem/modem_iface_uart_async.c
@@ -116,7 +116,7 @@ static int modem_iface_uart_async_write(struct modem_iface *iface,
 	}
 
 	/* Start the transmission */
-	rc = uart_tx(iface->dev, buf, size, SYS_FOREVER_MS);
+	rc = uart_tx(iface->dev, buf, size, SYS_FOREVER_US);
 	if (rc >= 0) {
 		/* Wait until the transmission completes */
 		data = iface->iface_data;

--- a/drivers/serial/serial_test.c
+++ b/drivers/serial/serial_test.c
@@ -419,7 +419,7 @@ static int serial_vnd_rx_enable(const struct device *dev, uint8_t *read_buf, siz
 		return -EINVAL;
 	}
 
-	__ASSERT(timeout == SYS_FOREVER_MS, "Async timeout not implemented.");
+	__ASSERT(timeout == SYS_FOREVER_US, "Async timeout not implemented.");
 
 	data->read_buf = read_buf;
 	data->read_size = read_size;

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -780,8 +780,8 @@ __syscall int uart_tx(const struct device *dev, const uint8_t *buf,
  * @param dev     UART device instance.
  * @param buf     Pointer to wide data transmit buffer.
  * @param len     Length of wide data transmit buffer.
- * @param timeout Timeout in milliseconds. Valid only if flow control is
- *		  enabled. @ref SYS_FOREVER_MS disables timeout.
+ * @param timeout Timeout in microseconds. Valid only if flow control is
+ *		  enabled. @ref SYS_FOREVER_US disables timeout.
  *
  * @return 0 on success, negative errno value on failure.
  * @retval -ENOTSUP API is not enabled.
@@ -837,8 +837,8 @@ __syscall int uart_rx_enable(const struct device *dev, uint8_t *buf,
  * @param buf     Pointer to wide data receive buffer.
  * @param len     Buffer length.
  * @param timeout Inactivity period after receiving at least a byte which
- *		  triggers  #UART_RX_RDY event. Given in milliseconds.
- *		  @ref SYS_FOREVER_MS disables timeout. See
+ *		  triggers  #UART_RX_RDY event. Given in microseconds.
+ *		  @ref SYS_FOREVER_US disables timeout. See
  *		  @ref uart_event_type for details.
  *
  * @return 0 on success, negative errno value on failure.

--- a/modules/openthread/platform/uart.c
+++ b/modules/openthread/platform/uart.c
@@ -279,7 +279,7 @@ otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
 		}
 		return OT_ERROR_NONE;
 #else
-		int ret = uart_tx(ot_uart.dev, aBuf, aBufLength, SYS_FOREVER_MS);
+		int ret = uart_tx(ot_uart.dev, aBuf, aBufLength, SYS_FOREVER_US);
 
 		if (ret == 0) {
 			if (is_panic_mode) {


### PR DESCRIPTION
Align the public UART async API with its microsecond-based implementation. Update the wide-data (u16 variant) TX and RX API documentation to specify microseconds and SYS_FOREVER_US.

Replace millisecond-named forever sentinels in the serial test driver and asynchronous UART callers, while retaining existing microsecond timeout values in drivers, tests, and samples.

Assisted-by: Copilot:GPT-5.6 Terra