### PR TITLE
net: sockets: Clear pending socket error once delivered

### DIFF
--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -63,12 +63,28 @@ static inline void sock_set_error(struct net_context *ctx, int err)
 	sock_set_flag(ctx, SOCK_ERROR, SOCK_ERROR);
 }
 
-/* Retrieve the pending socket error (positive errno) previously recorded
- * by sock_set_error(). Only meaningful while sock_is_error() is true.
+/* Clear a pending socket error, so the context is not left permanently
+ * flagged after a transient error (e.g. a listening socket surviving an
+ * interface bounce).
+ */
+static inline void sock_clear_error(struct net_context *ctx)
+{
+	sock_set_flag(ctx, SOCK_ERROR, 0);
+}
+
+/* Retrieve and consume the pending socket error (positive errno) previously
+ * recorded by sock_set_error(). Only meaningful while sock_is_error() is
+ * true. The error is one-shot: reading it clears the SOCK_ERROR flag, both
+ * so the context can recover once the error has been delivered to the
+ * application, and so callers cannot forget to clear it.
  */
 static inline int sock_get_error(struct net_context *ctx)
 {
-	return ctx->sock_error;
+	int err = ctx->sock_error;
+
+	sock_clear_error(ctx);
+
+	return err;
 }
 
 size_t msghdr_non_empty_iov_count(const struct net_msghdr *msg);


### PR DESCRIPTION
Follow-up to #114694 (merged as ef370a57d076), requested by @jukkar in
https://github.com/zephyrproject-rtos/zephyr/pull/114679#issuecomment-5092687553:

> Thanks, please propose a PR for that after the errno PR is merged.

### Background

While debugging the crash in #114678 (listening TCP socket dereferencing a stale `user_data` integer as a pointer after a second interface-down), two distinct problems came out of the same root cause — `net_context.user_data` being used
both as the accept-callback parent pointer and as int-punned errno storage:

1. **The wild pointer crash** — fixed by #114694, which moved the pending error into a dedicated `net_context.sock_error` field.
2. **The pending error is never cleared** — noted in https://github.com/zephyrproject-rtos/zephyr/pull/114679#issuecomment-5092199150 and left out of scope there. That is what this PR addresses.

### The problem

`sock_set_error()`/`sock_get_error()` record a one-shot async error, but nothing ever clears the `SOCK_ERROR` flag or the stored value. Once a context hits a single async error — e.g. `accept()` on a listening socket whose interface bounced — every subsequent `accept()`/`connect()`/`recv()`/`getsockopt(SO_ERROR)` call on that context keeps returning the same stale errno for the rest of the socket's lifetime, even after the underlying condition clears. A listening socket is permanently unusable after one transient failure.

This also diverges from POSIX, which specifies that reading `SO_ERROR` clears the pending error.

### The change

Adds `sock_clear_error()` and calls it at each site that actually *delivers* the error to the application:

- `zsock_connect_ctx()`
- `zsock_accept_ctx()`
- `zsock_wait_data()`
- `zsock_recv_stream_timed()`
- `getsockopt(SO_ERROR)`

`poll()`'s `POLLERR`/`sock_is_error()` checks are deliberately left untouched — they only observe the flag, they don't consume it, so level-triggered `poll()` semantics are preserved.

No double-consumption: in `zsock_accept_ctx()` the `sock_is_error()` check runs before `zsock_wait_data()` and returns early, so exactly one site clears per call; the next `accept()` then blocks normally as expected.

### Testing

`checkpatch.pl`: 0 errors, 0 warnings.

Twister on `native_sim`, suites covering the touched code paths:

```
./scripts/twister -p native_sim -T tests/net/socket/tcp -T tests/net/socket/misc \
                                -T tests/net/socket/poll -T tests/net/socket/select
```

> 10 of 10 executed test configurations passed (100.00%), 0 failed, 0 errored
> 249 of 249 executed test cases passed (100.00%)

Running the full `tests/net/socket` tree, `net.socket.service` fails — but it fails identically on unpatched `origin/main` (same assertion, `tests/net/socket/service/src/main.c:97` `bind failed`), so it is pre-existing and unrelated to this change. The TLS/websocket/offload suites error out at CMake in my setup for lack of an mbedtls module, also unrelated.

The original crash from #114678 was reproduced and verified fixed on real hardware (STM32F401RE + WIZnet W5500, link flapped repeatedly with a GDB breakpoint on `z_fatal_error`), but that was against the earlier narrow fix in #114679, not this patch — this one changes error *recovery* behaviour, not the crash path.

### Note on backporting

#114694 was flagged for backport
(https://github.com/zephyrproject-rtos/zephyr/pull/114694#issuecomment-5100986334,
https://github.com/zephyrproject-rtos/zephyr/pull/114694#issuecomment-5101239329).

If it gets backported, this follow-up probably belongs with it, since together they form the complete fix — happy to add the label if you agree.
