### PR TITLE
drivers: ethernet: esp32: add ptp support on esp32p4

### DIFF
--- a/drivers/ethernet/Kconfig.esp32
+++ b/drivers/ethernet/Kconfig.esp32
@@ -5,7 +5,7 @@
 
 menuconfig ETH_ESP32
 	bool "ESP32 Ethernet driver"
-	default y if !PTP_CLOCK
+	default y
 	depends on SOC_SERIES_ESP32 || SOC_SERIES_ESP32P4
 	depends on DT_HAS_ESPRESSIF_ESP32_ETH_ENABLED
 	help
@@ -45,5 +45,16 @@ config ETH_ESP32_DMA_TX_BUFFER_NUM
 	  Number of DMA transmit buffers. Each buffer's size is
 	  ETH_ESP32_DMA_BUFFER_SIZE. Larger number of buffers could
 	  increase throughput somehow.
+
+config PTP_CLOCK_ESP32
+	bool "ESP32 Ethernet PTP clock driver"
+	default y
+	depends on PTP_CLOCK
+	depends on DT_HAS_SNPS_DWMAC_PTP_CLOCK_ENABLED
+	help
+	  Enable the IEEE 1588 PTP clock provided by the Ethernet MAC.
+	  The MAC timestamps transmitted and received frames in
+	  hardware and exposes a free running clock that can be set,
+	  offset and rate adjusted.
 
 endif # ETH_ESP32

--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -76,6 +76,8 @@ struct eth_esp32_dev_data {
 	uint8_t *dma_tx_buf[CONFIG_ETH_ESP32_DMA_TX_BUFFER_NUM];
 #if defined(CONFIG_PTP_CLOCK_ESP32)
 	const struct device *ptp_clock;
+	struct net_ptp_time rx_timestamp;
+	bool rx_timestamp_valid;
 #endif
 	struct k_sem int_sem;
 	struct k_sem tx_sem;
@@ -186,8 +188,13 @@ static void eth_esp32_reset_desc_chain(struct eth_esp32_dev_data *dev_data)
 }
 
 static uint32_t eth_esp32_transmit_frame(struct eth_esp32_dev_data *dev_data, uint8_t *buf,
-					 uint32_t length)
+					 uint32_t length, struct net_pkt *pkt)
 {
+#if defined(CONFIG_PTP_CLOCK_ESP32)
+	const bool timestamp = net_pkt_is_tx_timestamping(pkt);
+#else
+	ARG_UNUSED(pkt);
+#endif
 	uint32_t bufcount = 0;
 	uint32_t lastlen = length;
 	uint32_t sentout = 0;
@@ -205,6 +212,9 @@ static uint32_t eth_esp32_transmit_frame(struct eth_esp32_dev_data *dev_data, ui
 	}
 
 	eth_dma_tx_descriptor_t *desc_iter = dev_data->tx_desc;
+#if defined(CONFIG_PTP_CLOCK_ESP32)
+	eth_dma_tx_descriptor_t *first_desc = dev_data->tx_desc;
+#endif
 
 	/* Fill descriptors */
 	for (size_t i = 0; i < bufcount; i++) {
@@ -217,6 +227,9 @@ static uint32_t eth_esp32_transmit_frame(struct eth_esp32_dev_data *dev_data, ui
 
 		if (i == 0) {
 			desc_iter->TDES0.FirstSegment = 1;
+#if defined(CONFIG_PTP_CLOCK_ESP32)
+			desc_iter->TDES0.TransmitTimestampEnable = timestamp;
+#endif
 		}
 		if (i == (bufcount - 1)) {
 			desc_iter->TDES0.LastSegment = 1;
@@ -240,6 +253,35 @@ static uint32_t eth_esp32_transmit_frame(struct eth_esp32_dev_data *dev_data, ui
 		dev_data->tx_desc = tx_desc_next(dev_data, dev_data->tx_desc);
 	}
 	emac_hal_transmit_poll_demand(&dev_data->hal);
+
+#if defined(CONFIG_PTP_CLOCK_ESP32)
+	/*
+	 * The transmit timestamp is written back into the first descriptor
+	 * of the frame once the DMA has released it. Only wait for it when
+	 * the caller asked for a timestamp, and bound the wait so a stuck
+	 * transmission cannot block the TX path.
+	 */
+	if (timestamp) {
+		k_timepoint_t ts_deadline = sys_timepoint_calc(K_MSEC(20));
+
+		while (first_desc->TDES0.Own == EMAC_LL_DMADESC_OWNER_DMA) {
+			if (sys_timepoint_expired(ts_deadline)) {
+				return sentout;
+			}
+			k_yield();
+		}
+
+		if (first_desc->TDES0.TxTimestampStatus) {
+			struct net_ptp_time ts = {
+				.second = first_desc->TimeStampHigh,
+				.nanosecond = first_desc->TimeStampLow,
+			};
+
+			net_pkt_set_timestamp(pkt, &ts);
+			net_if_add_tx_timestamp(pkt);
+		}
+	}
+#endif
 
 	return sentout;
 }
@@ -381,6 +423,22 @@ static uint32_t eth_esp32_receive_frame(struct eth_esp32_dev_data *dev_data, uin
 		desc_iter->RDES0.Own = EMAC_LL_DMADESC_OWNER_DMA;
 		desc_iter = rx_desc_next(dev_data, desc_iter);
 	}
+
+#if defined(CONFIG_PTP_CLOCK_ESP32)
+	/*
+	 * The capture is reported in the last descriptor of the frame. A
+	 * timestamp is only present when the MAC snapshotted this frame,
+	 * which it does for PTP frames only, so it must be latched here
+	 * before the descriptor is handed back to the DMA.
+	 */
+	dev_data->rx_timestamp_valid = desc_iter->RDES0.TSAvailIPChecksumErrGiantFrame &&
+				       !desc_iter->ExtendedStatus.TimestampDropped;
+	if (dev_data->rx_timestamp_valid) {
+		dev_data->rx_timestamp.second = desc_iter->TimeStampHigh;
+		dev_data->rx_timestamp.nanosecond = desc_iter->TimeStampLow;
+	}
+#endif
+
 	desc_iter->RDES0.Own = EMAC_LL_DMADESC_OWNER_DMA;
 
 	dev_data->rx_desc = rx_desc_next(dev_data, desc_iter);
@@ -433,7 +491,7 @@ static int eth_esp32_send(const struct device *dev, struct net_pkt *pkt)
 	k_timepoint_t deadline = sys_timepoint_calc(K_MSEC(100));
 
 	do {
-		if (eth_esp32_transmit_frame(dev_data, dev_data->txb, len) == len) {
+		if (eth_esp32_transmit_frame(dev_data, dev_data->txb, len, pkt) == len) {
 			return 0;
 		}
 	} while (k_sem_take(&dev_data->tx_sem, sys_timepoint_timeout(deadline)) == 0);
@@ -465,6 +523,13 @@ static struct net_pkt *eth_esp32_rx(
 		net_pkt_unref(pkt);
 		return NULL;
 	}
+
+#if defined(CONFIG_PTP_CLOCK_ESP32)
+	if (dev_data->rx_timestamp_valid) {
+		net_pkt_set_timestamp(pkt, &dev_data->rx_timestamp);
+		net_pkt_set_rx_timestamping(pkt, true);
+	}
+#endif
 
 	return pkt;
 }
@@ -665,6 +730,14 @@ int eth_esp32_initialize(const struct device *dev)
 
 	eth_esp32_reset_desc_chain(dev_data);
 	emac_hal_init_mac_default(&dev_data->hal);
+
+	/*
+	 * The MAC filters out multicast destinations by default, which drops
+	 * IPv4/IPv6 multicast traffic such as PTP, mDNS and neighbour
+	 * discovery before it reaches the DMA. Zephyr performs multicast
+	 * filtering in the network stack, so let all multicast frames pass.
+	 */
+	emac_ll_pass_all_multicast_enable(dev_data->hal.mac_regs, true);
 	emac_hal_init_dma_default(&dev_data->hal, &dma_config);
 
 	/*

--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -14,6 +14,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/net/ethernet.h>
 #include <zephyr/net/phy.h>
+#if defined(CONFIG_PTP_CLOCK_ESP32)
+#include <zephyr/drivers/ptp_clock.h>
+#endif
 
 #include <esp_attr.h>
 #include <esp_mac.h>
@@ -71,6 +74,9 @@ struct eth_esp32_dev_data {
 	uint8_t rxb[NET_ETH_MAX_FRAME_SIZE];
 	uint8_t *dma_rx_buf[CONFIG_ETH_ESP32_DMA_RX_BUFFER_NUM];
 	uint8_t *dma_tx_buf[CONFIG_ETH_ESP32_DMA_TX_BUFFER_NUM];
+#if defined(CONFIG_PTP_CLOCK_ESP32)
+	const struct device *ptp_clock;
+#endif
 	struct k_sem int_sem;
 	struct k_sem tx_sem;
 
@@ -737,12 +743,25 @@ static void eth_esp32_iface_init(struct net_if *iface)
 	}
 }
 
+#if defined(CONFIG_PTP_CLOCK_ESP32)
+static const struct device *eth_esp32_get_ptp_clock(const struct device *dev,
+						   struct net_if *iface __unused)
+{
+	struct eth_esp32_dev_data *const dev_data = dev->data;
+
+	return dev_data->ptp_clock;
+}
+#endif
+
 static const struct ethernet_api eth_esp32_api = {
 	.iface_api.init		= eth_esp32_iface_init,
 	.get_capabilities	= eth_esp32_caps,
 	.set_config		= eth_esp32_set_config,
 	.get_phy		= eth_esp32_phy_get,
 	.send			= eth_esp32_send,
+#if defined(CONFIG_PTP_CLOCK_ESP32)
+	.get_ptp_clock		= eth_esp32_get_ptp_clock,
+#endif
 };
 
 /* DMA data must be in DRAM, descriptors must be aligned to EMAC_HAL_DMA_DESC_SIZE */
@@ -754,3 +773,103 @@ static struct eth_esp32_dev_data eth_esp32_dev = {
 
 ETH_NET_DEVICE_DT_INST_DEFINE(0, eth_esp32_initialize, NULL, &eth_esp32_dev, &eth_esp32_config,
 			      CONFIG_ETH_INIT_PRIORITY, &eth_esp32_api, NET_ETH_MTU);
+
+#if defined(CONFIG_PTP_CLOCK_ESP32)
+
+#define PTP_CLOCK_NODE DT_INST_CHILD(0, ptp_clock)
+
+static int eth_esp32_ptp_clock_set(const struct device *dev, struct net_ptp_time *tm)
+{
+	struct eth_esp32_dev_data *const dev_data = dev->data;
+
+	return emac_hal_ptp_set_sys_time(&dev_data->hal, tm->second, tm->nanosecond) == ESP_OK
+		       ? 0
+		       : -EIO;
+}
+
+static int eth_esp32_ptp_clock_get(const struct device *dev, struct net_ptp_time *tm)
+{
+	struct eth_esp32_dev_data *const dev_data = dev->data;
+	uint32_t seconds;
+	uint32_t nanoseconds;
+
+	if (emac_hal_ptp_get_sys_time(&dev_data->hal, &seconds, &nanoseconds) != ESP_OK) {
+		return -EIO;
+	}
+
+	tm->second = seconds;
+	tm->nanosecond = nanoseconds;
+
+	return 0;
+}
+
+static int eth_esp32_ptp_clock_adjust(const struct device *dev, int increment)
+{
+	struct eth_esp32_dev_data *const dev_data = dev->data;
+	bool sign = increment >= 0;
+	uint32_t offset = sign ? increment : -increment;
+
+	return emac_hal_ptp_time_add(&dev_data->hal, offset / NSEC_PER_SEC,
+				     offset % NSEC_PER_SEC, sign) == ESP_OK
+		       ? 0
+		       : -EIO;
+}
+
+static int eth_esp32_ptp_clock_rate_adjust(const struct device *dev, double ratio)
+{
+	struct eth_esp32_dev_data *const dev_data = dev->data;
+	int32_t adj_ppb = (int32_t)((ratio - 1.0) * 1000000000.0);
+
+	return emac_hal_ptp_adj_freq(&dev_data->hal, adj_ppb) == ESP_OK ? 0 : -EIO;
+}
+
+static DEVICE_API(ptp_clock, eth_esp32_ptp_clock_api) = {
+	.set = eth_esp32_ptp_clock_set,
+	.get = eth_esp32_ptp_clock_get,
+	.adjust = eth_esp32_ptp_clock_adjust,
+	.rate_adjust = eth_esp32_ptp_clock_rate_adjust,
+};
+
+static int eth_esp32_ptp_clock_init(const struct device *dev)
+{
+	struct eth_esp32_dev_data *const dev_data = dev->data;
+	const struct device *clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_NODELABEL(eth)));
+	clock_control_subsys_t ptp_subsys =
+		(clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_NAME(0, ptp, offset);
+	emac_hal_ptp_config_t ptp_config;
+	uint32_t ptp_clk_rate;
+	int ret;
+
+	ret = clock_control_on(clock_dev, ptp_subsys);
+	if (ret < 0 && ret != -EALREADY) {
+		LOG_ERR("Failed to enable PTP reference clock");
+		return ret;
+	}
+
+	ret = clock_control_get_rate(clock_dev, ptp_subsys, &ptp_clk_rate);
+	if (ret < 0 || ptp_clk_rate == 0) {
+		LOG_ERR("Failed to get PTP reference clock rate");
+		return -EIO;
+	}
+
+	ptp_config.upd_method = ETH_PTP_UPDATE_METHOD_FINE;
+	ptp_config.roll = ETH_PTP_DIGITAL_ROLLOVER;
+	ptp_config.ptp_clk_src_period_ns = 1000000000.0f / (float)ptp_clk_rate;
+	ptp_config.ptp_req_accuracy_ns = ptp_config.ptp_clk_src_period_ns;
+
+	if (emac_hal_ptp_start(&dev_data->hal, &ptp_config) != ESP_OK) {
+		LOG_ERR("Failed to start PTP");
+		return -EIO;
+	}
+
+	dev_data->ptp_clock = dev;
+
+	LOG_INF("PTP clock started, reference %u Hz", ptp_clk_rate);
+
+	return 0;
+}
+
+DEVICE_DT_DEFINE(PTP_CLOCK_NODE, eth_esp32_ptp_clock_init, NULL, &eth_esp32_dev, NULL, POST_KERNEL,
+		 CONFIG_PTP_CLOCK_INIT_PRIORITY, &eth_esp32_ptp_clock_api);
+
+#endif /* CONFIG_PTP_CLOCK_ESP32 */

--- a/samples/net/ptp/tests.yaml
+++ b/samples/net/ptp/tests.yaml
@@ -16,6 +16,7 @@ tests:
       - nucleo_h753zi
       - nucleo_h745zi_q/stm32h745xx/m7
       - qemu_x86
+      - esp32p4x_function_ev_board/esp32p4/hpcore
     depends_on: eth
     integration_platforms:
       - nucleo_h563zi


### PR DESCRIPTION
Add IEEE 1588 PTP support to the ESP32 Ethernet driver, using the
timestamping unit built into the ESP32-P4 Ethernet MAC.

The MAC exposes a free running clock that can be read, set, offset
and rate adjusted, and it captures the time at which frames cross
the wire.