### PR TITLE
drivers: otp: rts5817: depend on SYSCON instead of selecting

### DIFF
--- a/drivers/otp/Kconfig.rts5817
+++ b/drivers/otp/Kconfig.rts5817
@@ -6,6 +6,6 @@ config OTP_RTS5817
 	default y
 	depends on DT_HAS_REALTEK_RTS5817_OCOTP_ENABLED
 	depends on RESET_RTS5817 && CLOCK_CONTROL_RTS5817
-	select SYSCON
+	depends on SYSCON
 	help
 	  Enable support for RTS5817 OCOTP driver.


### PR DESCRIPTION
`select SYSCON` in `OTP_RTS5817` creates a circular Kconfig dependency loop (`SYSCON -> OTP -> ... -> DCACHE -> SYSCON`) that breaks kconfig.py in downstream builds.

Change `select SYSCON` to `depends on SYSCON` to break the loop.