### PR TITLE
boards: shields: m5stack_cardputer: Fix ST7789V display orientation

### DIFF
--- a/boards/shields/m5stack_cardputer/Kconfig.defconfig
+++ b/boards/shields/m5stack_cardputer/Kconfig.defconfig
@@ -14,9 +14,6 @@ choice LV_COLOR_DEPTH
 	default LV_COLOR_DEPTH_16
 endchoice
 
-configdefault LV_COLOR_16_SWAP
-	default y
-
 endif # LVGL
 
 endif # DISPLAY

--- a/boards/shields/m5stack_cardputer/m5stack_cardputer.overlay
+++ b/boards/shields/m5stack_cardputer/m5stack_cardputer.overlay
@@ -33,18 +33,17 @@
 			reg = <0>;
 			mipi-max-frequency = <20000000>;
 
-			width = <135>;
-			height = <240>;
-			x-offset = <52>;
-			y-offset = <40>;
-
+			width = <240>;
+			height = <135>;
+			x-offset = <40>;
+			y-offset = <53>;
 			vcom = <0x28>;
 			gctrl = <0x35>;
 			vrhs = <0x10>;
 			vdvs = <0x20>;
-			mdac = <0x00>;
+			mdac = <0x60>;
 			gamma = <0x01>;
-			pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+			pixel-format = <PANEL_PIXEL_FORMAT_RGB_565X>;
 			lcm = <0x2c>;
 			porch-param = [0c 0c 00 33 33];
 			cmd2en-param = [5a 69 02 00];


### PR DESCRIPTION
### Description

This pull request updates the ST7789V display configuration for the M5Stack Cardputer shield to properly reflect its landscape layout orientation. 

The display rotation orientation for the M5Stack Cardputer shield was incorrectly mapped, causing the screen to render vertically by default. This portrait alignment directly contradicts the physical design of the hardware shield, which features an integrated keyboard built for horizontal operation. Correct the rotation logic to enforce a landscape layout that matches the physical form factor of the device.

### Impact

Fixes incorrect coordinate tracking, clipping, and wrapping bugs for graphic framebuffers (such as LVGL applications) running on the M5Stack Cardputer shield, ensuring text and assets align cleanly with the physical landscape screen borders.
