### PR TITLE
[Backport v4.3-branch] net: pkt: Optimize front pulls without exposing fragment layout

### DIFF
--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -476,17 +476,40 @@ static enum net_verdict ieee802154_recv(struct net_if *iface, struct net_pkt *pk
 /**
  * Implements (part of) the MCPS-DATA.request/confirm primitives, see sections 8.3.2/3.
  */
+static int copy_pkt_to_frame(struct net_buf *frame_buf, const struct net_buf *pkt_buf,
+			     size_t pkt_len, uint8_t authtag_len)
+{
+	size_t tailroom = net_buf_tailroom(frame_buf);
+	size_t copied;
+
+	if (authtag_len > tailroom || pkt_len > tailroom - authtag_len) {
+		return -EMSGSIZE;
+	}
+
+	copied = net_buf_linearize(net_buf_tail(frame_buf), tailroom - authtag_len, pkt_buf, 0,
+				   pkt_len);
+	if (copied != pkt_len) {
+		NET_ERR("Failed to copy packet to frame (%zu/%zu)", copied, pkt_len);
+		return -EINVAL;
+	}
+
+	net_buf_add(frame_buf, copied);
+
+	return 0;
+}
+
 static int ieee802154_send(struct net_if *iface, struct net_pkt *pkt)
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
+	struct net_buf *pkt_buf;
 	uint8_t ll_hdr_len = 0, authtag_len = 0;
 	static struct net_buf *frame_buf;
-	static struct net_buf *pkt_buf;
+	size_t pkt_len;
 	bool send_raw = false;
+	bool requires_fragmentation = false;
 	int len;
 #ifdef CONFIG_NET_L2_IEEE802154_FRAGMENT
 	struct ieee802154_6lo_fragment_ctx frag_ctx;
-	int requires_fragmentation = 0;
 #endif
 
 	if (frame_buf == NULL) {
@@ -530,15 +553,24 @@ static int ieee802154_send(struct net_if *iface, struct net_pkt *pkt)
 
 #ifdef CONFIG_NET_6LO
 #ifdef CONFIG_NET_L2_IEEE802154_FRAGMENT
-		requires_fragmentation =
-			ieee802154_6lo_encode_pkt(iface, pkt, &frag_ctx, ll_hdr_len, authtag_len);
-		if (requires_fragmentation < 0) {
-			return requires_fragmentation;
+		int ret;
+
+		ret = ieee802154_6lo_encode_pkt(iface, pkt, &frag_ctx, ll_hdr_len, authtag_len);
+		if (ret < 0) {
+			return ret;
 		}
+
+		requires_fragmentation = (ret != 0);
 #else
 		ieee802154_6lo_encode_pkt(iface, pkt, NULL, ll_hdr_len, authtag_len);
 #endif /* CONFIG_NET_L2_IEEE802154_FRAGMENT */
 #endif /* CONFIG_NET_6LO */
+	}
+
+	pkt_len = net_pkt_get_len(pkt);
+	if (!requires_fragmentation && ll_hdr_len + pkt_len + authtag_len > IEEE802154_MTU) {
+		NET_ERR("Frame too long: %zu", ll_hdr_len + pkt_len + authtag_len);
+		return -EMSGSIZE;
 	}
 
 	net_capture_pkt(iface, pkt);
@@ -556,16 +588,20 @@ static int ieee802154_send(struct net_if *iface, struct net_pkt *pkt)
 		if (requires_fragmentation) {
 			pkt_buf = ieee802154_6lo_fragment(&frag_ctx, frame_buf, true);
 		} else {
-			net_buf_add_mem(frame_buf, pkt_buf->data, pkt_buf->len);
-			pkt_buf = pkt_buf->frags;
+			ret = copy_pkt_to_frame(frame_buf, pkt->buffer, pkt_len, authtag_len);
+			if (ret < 0) {
+				return ret;
+			}
+
+			pkt_buf = NULL;
 		}
 #else
-		if (ll_hdr_len + pkt_buf->len + authtag_len > IEEE802154_MTU) {
-			NET_ERR("Frame too long: %d", pkt_buf->len);
-			return -EINVAL;
+		ret = copy_pkt_to_frame(frame_buf, pkt->buffer, pkt_len, authtag_len);
+		if (ret < 0) {
+			return ret;
 		}
-		net_buf_add_mem(frame_buf, pkt_buf->data, pkt_buf->len);
-		pkt_buf = pkt_buf->frags;
+
+		pkt_buf = NULL;
 #endif /* CONFIG_NET_L2_IEEE802154_FRAGMENT */
 
 		__ASSERT_NO_MSG(authtag_len <= net_buf_tailroom(frame_buf));

--- a/tests/net/ieee802154/6lo_fragment/src/main.c
+++ b/tests/net/ieee802154/6lo_fragment/src/main.c
@@ -493,7 +493,29 @@ static bool test_fragment(struct net_fragment_data *data)
 	}
 
 	if (!ieee802154_6lo_requires_fragmentation(pkt, 0, 0)) {
-		f_pkt = pkt;
+		size_t pkt_len = net_pkt_get_len(pkt);
+		size_t copied;
+
+		f_pkt = net_pkt_alloc(K_FOREVER);
+		if (f_pkt == NULL) {
+			goto end;
+		}
+
+		dfrag = net_pkt_get_frag(f_pkt, pkt_len, K_FOREVER);
+		if (dfrag == NULL) {
+			goto end;
+		}
+
+		net_pkt_frag_add(f_pkt, dfrag);
+
+		copied = net_buf_linearize(dfrag->data, net_buf_tailroom(dfrag), pkt->buffer, 0,
+					   pkt_len);
+		if (copied != pkt_len) {
+			goto end;
+		}
+
+		net_buf_add(dfrag, copied);
+		net_pkt_unref(pkt);
 		pkt = NULL;
 
 		goto reassemble;

--- a/tests/net/ieee802154/l2/src/ieee802154_test.c
+++ b/tests/net/ieee802154/l2/src/ieee802154_test.c
@@ -520,6 +520,89 @@ out:
 	return result;
 }
 
+static bool test_partitioned_pkt_sending(const uint8_t *payload, size_t payload_len,
+					 const size_t *frag_sizes, size_t frag_count)
+{
+	static const uint8_t broadcast_addr[IEEE802154_SHORT_ADDR_LENGTH] = {0xff, 0xff};
+	struct ieee802154_mpdu mpdu;
+	struct net_pkt *pkt;
+	size_t offset = 0;
+	bool result = false;
+
+	k_sem_reset(&driver_lock);
+
+	pkt = net_pkt_alloc_on_iface(net_iface, K_FOREVER);
+	if (pkt == NULL) {
+		NET_ERR("*** Failed to allocate partitioned packet");
+		return false;
+	}
+
+	net_pkt_lladdr_src(pkt)->type = NET_LINK_IEEE802154;
+	net_pkt_lladdr_dst(pkt)->type = NET_LINK_IEEE802154;
+	if (net_linkaddr_set(net_pkt_lladdr_dst(pkt), broadcast_addr, sizeof(broadcast_addr)) < 0) {
+		NET_ERR("*** Failed to set destination address");
+		goto release_pkt;
+	}
+
+	for (size_t i = 0; i < frag_count; i++) {
+		struct net_buf *frag;
+
+		frag = net_pkt_get_frag(pkt, frag_sizes[i], K_FOREVER);
+		if (frag == NULL) {
+			NET_ERR("*** Failed to allocate packet fragment");
+			goto release_pkt;
+		}
+
+		net_buf_add_mem(frag, payload + offset, frag_sizes[i]);
+		net_pkt_frag_add(pkt, frag);
+		offset += frag_sizes[i];
+	}
+
+	if (offset != payload_len) {
+		NET_ERR("*** Fragment sizes do not match payload length");
+		goto release_pkt;
+	}
+
+	if (net_if_send_data(net_iface, pkt) != NET_OK) {
+		NET_ERR("*** Failed to send partitioned packet");
+		goto release_pkt;
+	}
+
+	pkt = NULL;
+	k_yield();
+	if (k_sem_take(&driver_lock, K_SECONDS(1)) < 0) {
+		NET_ERR("*** Timed out waiting for partitioned packet");
+		goto out;
+	}
+
+	if (current_pkt->frags == NULL || current_pkt->frags->frags != NULL) {
+		NET_ERR("*** Packet storage fragments became MAC frame boundaries");
+		goto release_frame;
+	}
+
+	if (!ieee802154_validate_frame(current_pkt->frags->data, current_pkt->frags->len, &mpdu)) {
+		NET_ERR("*** Sent partitioned packet is not valid");
+		goto release_frame;
+	}
+
+	if (mpdu.payload_length != payload_len || memcmp(mpdu.payload, payload, payload_len)) {
+		NET_ERR("*** Sent partitioned payload differs from source");
+		goto release_frame;
+	}
+
+	result = true;
+
+release_frame:
+	net_pkt_frag_unref(current_pkt->frags);
+	current_pkt->frags = NULL;
+out:
+	return result;
+
+release_pkt:
+	net_pkt_unref(pkt);
+	goto out;
+}
+
 static bool test_wait_for_ack(struct ieee802154_pkt_test *t)
 {
 	struct ieee802154_mpdu mpdu;
@@ -1303,6 +1386,25 @@ ZTEST(ieee802154_l2, test_sending_ns_pkt_with_short_addr)
 	ret = test_ns_sending(&test_ns_pkt, true);
 
 	zassert_true(ret, "NS sent");
+}
+
+ZTEST(ieee802154_l2, test_sending_partitioned_pkt)
+{
+	static const uint8_t payload[] = {
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+		0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+		0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+	};
+	static const size_t one_frag[] = {sizeof(payload)};
+	static const size_t two_frags[] = {1, sizeof(payload) - 1};
+	static const size_t three_frags[] = {7, 5, sizeof(payload) - 12};
+
+	zassert_true(test_partitioned_pkt_sending(payload, sizeof(payload), one_frag,
+						  ARRAY_SIZE(one_frag)));
+	zassert_true(test_partitioned_pkt_sending(payload, sizeof(payload), two_frags,
+						  ARRAY_SIZE(two_frags)));
+	zassert_true(test_partitioned_pkt_sending(payload, sizeof(payload), three_frags,
+						  ARRAY_SIZE(three_frags)));
 }
 
 ZTEST(ieee802154_l2, test_parsing_ack_pkt)


### PR DESCRIPTION
Backport of the fix from #114067 to `v4.3-branch`.

Fixes: #114895