### PR TITLE
MAINTAINERS: defer vendor-owned sensor drivers from generic area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2773,6 +2773,12 @@ Documentation Infrastructure:
     - doc/hardware/peripherals/sensor/
     - tests/drivers/build_all/sensor/
     - include/zephyr/drivers/sensor_*
+  file-groups:
+    - name: Vendor-owned sensor drivers
+      defer-to-other-areas: true
+      files:
+        - drivers/sensor/tdk/
+        - drivers/sensor/wsen/
   labels:
     - "area: Sensors"
   tests:

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2777,6 +2777,7 @@ Documentation Infrastructure:
     - name: Vendor-owned sensor drivers
       defer-to-other-areas: true
       files:
+        - drivers/sensor/st/
         - drivers/sensor/tdk/
         - drivers/sensor/wsen/
   labels:
@@ -5529,6 +5530,15 @@ SPDX Tooling:
     - "area: SPDX Tooling"
   tests:
     - buildsystem.sbom.spdx
+
+ST Sensors:
+  status: maintained
+  maintainers:
+    - avisconti
+  files:
+    - drivers/sensor/st/
+  tests:
+    - drivers.sensor
 
 STM32 Platforms:
   status: maintained


### PR DESCRIPTION
drivers/sensor/tdk/ and drivers/sensor/wsen/ already have their own
maintainer areas, but "Drivers: Sensors" has no files-exclude or
file-groups entry for those paths, so files there tie in weight
between both areas. The tie is broken by insertion order, which
favors the alphabetically-first "Drivers: Sensors" as assignee
instead of the vendor area's actual maintainers.

Add a file-groups entry with defer-to-other-areas: true, mirroring
the existing "Drivers: Clock control" pattern, so the vendor areas
win the assignee tie while "Drivers: Sensors" maintainers remain
reviewers and the "area: Sensors" label still applies.

Assisted-by: Claude:claude-sonnet-5
Signed-off-by: Maureen Helm <maureen.helm@analog.com>