### PR TITLE
timer: stop overloading sys_clock_set_timeout() arguments

### DIFF
--- a/doc/kernel/services/timing/clocks.rst
+++ b/doc/kernel/services/timing/clocks.rst
@@ -265,6 +265,54 @@ comparatively simple API.
   :c:func:`sys_clock_announce`, which the kernel needs to test newly
   arriving timeouts for expiration.
 
+* The driver may optionally provide a :c:func:`sys_clock_no_timeout` call.
+  The kernel invokes it in place of :c:func:`sys_clock_set_timeout` when no
+  timeout is pending, that is when the timeout queue is empty, and
+  :kconfig:option:`CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE` is enabled.
+
+  It is a hint that the driver may stop announcing ticks until the next
+  :c:func:`sys_clock_set_timeout`.  The ticks left unannounced are the uptime
+  drift that option explicitly allows.  Unlike :c:func:`sys_clock_disable`,
+  this is a resumable pause and not a teardown.
+
+  The timer *counter* must not be stopped.  :c:func:`sys_clock_cycle_get_32`
+  and :c:func:`sys_clock_cycle_get_64` must keep counting up as if the call had
+  never happened.
+
+  .. note::
+
+     The CPU keeps running with an empty timeout queue, for instance because
+     the ready queue still holds threads, or because an interrupt fires.  Those
+     threads and ISRs may call :c:func:`k_cycle_get_32` or
+     :c:func:`k_busy_wait`.  That limits what an implementation may do: masking
+     the timer interrupt is safe, gating the timer's clock most likely is not.
+     Exactly what is safe is hardware specific.
+
+  The default implementation calls :c:func:`sys_clock_set_timeout` with
+  ``K_TICKS_FOREVER``, the long-standing "no deadline" signal, so a driver that
+  has not been converted keeps working.  That default is a compatibility shim
+  and is removed together with the deprecated ``idle`` argument.
+
+* The driver may optionally provide a :c:func:`sys_clock_idle_enter` call,
+  which the power-management path uses in place of
+  :c:func:`sys_clock_set_timeout` when the CPU is about to enter low-power
+  idle.  It receives the number of ticks until the next expected wakeup, or
+  ``K_TICKS_FOREVER`` when there is none and the uptime may drift.
+
+  A driver that hands off to a low-power wakeup timer, or otherwise
+  reconfigures itself for sleep, does so here.  Told ``K_TICKS_FOREVER`` it may
+  also stop its time base, which :c:func:`sys_clock_no_timeout` does not allow,
+  because the CPU is on its way out and :c:func:`sys_clock_idle_exit` is
+  guaranteed to run on the way back in.  Only the calling CPU goes idle, so a
+  driver whose time base is shared between CPUs must account for the others
+  itself.
+
+  The default implementation calls :c:func:`sys_clock_set_timeout` with its
+  deprecated ``idle`` argument set to ``true``, so a driver still keying its
+  low-power handling on that argument keeps working.  A driver with no
+  low-power handling needs no implementation.  That default is a compatibility
+  shim and is removed together with the argument.
+
 Timer Driver Locking
 --------------------
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -762,6 +762,16 @@ Syscon
 Timer
 =====
 
+* The ``bool idle`` argument of :c:func:`sys_clock_set_timeout` is deprecated. The
+  kernel now calls the new :c:func:`sys_clock_idle_enter` hook instead of
+  :c:func:`sys_clock_set_timeout` with ``idle=true``. For backwards compatibility, the
+  default implementation of :c:func:`sys_clock_idle_enter` emulates the old behavior by
+  calling :c:func:`sys_clock_set_timeout` with ``idle=true``, so timer drivers that
+  still examine ``idle`` keep working unchanged. Such drivers should be updated to
+  implement :c:func:`sys_clock_idle_enter` and move their ``idle``-specific handling
+  there. The argument and that default implementation are both removed in a future
+  release (:github:`114901`).
+
 * :c:func:`sys_clock_set_timeout`, :c:func:`sys_clock_announce` and
   :c:func:`sys_clock_announce_locked` now take their tick count as an unsigned
   ``uint32_t`` rather than a signed ``int32_t``. Out-of-tree system timer drivers must
@@ -771,6 +781,23 @@ Timer
   drivers no longer need to clamp the request against the :c:func:`sys_clock_announce`
   range or special-case ``K_TICKS_FOREVER``; only their own hardware cycle-count limits
   still need enforcing (:github:`111022`).
+
+* When :kconfig:option:`CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE` is enabled, the kernel now
+  calls the new :c:func:`sys_clock_no_timeout` hook when no timeout is pending, instead
+  of :c:func:`sys_clock_set_timeout` with ``ticks=K_TICKS_FOREVER``. For backwards
+  compatibility, the default implementation of :c:func:`sys_clock_no_timeout` emulates
+  the old behavior by calling :c:func:`sys_clock_set_timeout` with that same value, so
+  drivers expecting it as the "no deadline" signal keep working unchanged, whether they
+  stop their clock or program a maximal wait. Such drivers should be updated to
+  implement :c:func:`sys_clock_no_timeout` instead. Every in-tree driver has been.
+
+  Note the split between the two new hooks. Masking the wakeups while the CPU still
+  runs belongs in :c:func:`sys_clock_no_timeout`, which must leave
+  :c:func:`sys_clock_cycle_get_32` working. Stopping the time base belongs in
+  :c:func:`sys_clock_idle_enter` when it is passed ``K_TICKS_FOREVER``. Refer to the
+  :ref:`kernel timing documentation <kernel_timing>` for the precise semantics. The
+  ``ticks=K_TICKS_FOREVER`` signal and the default implementation that still forwards
+  it are both removed in a future release (:github:`114901`).
 
 USB
 ===

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -168,6 +168,14 @@ Deprecated APIs and options
   * Deprecated :kconfig:option:`CONFIG_NET_L2_PTP`.
     Used :kconfig:option:`CONFIG_NET_L2_PTP_TIMESTAMPING` instead.
 
+* Timer
+
+  * New :c:func:`sys_clock_no_timeout` hook for handling of
+    :kconfig:option:`CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE`, replacing the call to
+    :c:func:`sys_clock_set_timeout` with ``ticks=K_TICKS_FOREVER``.
+  * New :c:func:`sys_clock_idle_enter` hook for handling of entry in low-power state,
+    replacing the call to :c:func:`sys_clock_set_timeout` with ``idle=true``.
+
 * Video
 
   * All functions in the video driver API (``<zephyr/drivers/video.h>``) have moved to the video

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -476,6 +476,18 @@ Other notable changes
     failure.  Use :c:func:`k_thread_cpu_pin` to reassign a thread to a
     different CPU.
 
+* Timer
+
+  * When :kconfig:option:`CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE` is enabled, the cycle
+    counter returned by :c:func:`k_cycle_get_32` is now guaranteed to keep
+    incrementing. Drivers used to stop their time base as soon as no timeout was
+    pending, which froze the counter under a running thread and could hang a
+    :c:func:`k_busy_wait`, and in some cases the clock could not be started again at
+    all. The time base is now stopped only on the way into idle, where
+    :c:func:`sys_clock_idle_exit` is guaranteed to follow. The option is only
+    partially fixed, as driver support for it has not been fully audited, and
+    is now marked experimental.
+
 * Wi-Fi
 
   * Removed the ``samples/net/wifi/test_certs/rsa2k`` enterprise test

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -44,8 +44,9 @@ config SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE
 config SYSTEM_CLOCK_SLOPPY_IDLE
 	bool "Timer allowed to skew uptime clock during idle"
 	help
-	  When true, the timer driver is not required to maintain a
-	  correct system uptime count when the system enters idle.
+	  When true, the kernel may let the system uptime count drift while
+	  there are no pending timeouts, rather than keep waking the CPU to
+	  maintain it.
 	  Some platforms may take advantage of this to reduce the
 	  overhead from regular interrupts required to handle counter
 	  wraparound conditions.

--- a/drivers/timer/Kconfig
+++ b/drivers/timer/Kconfig
@@ -43,6 +43,7 @@ config SYSTEM_CLOCK_HW_CYCLES_PER_SEC_RUNTIME_UPDATE
 
 config SYSTEM_CLOCK_SLOPPY_IDLE
 	bool "Timer allowed to skew uptime clock during idle"
+	select EXPERIMENTAL
 	help
 	  When true, the kernel may let the system uptime count drift while
 	  there are no pending timeouts, rather than keep waking the CPU to
@@ -50,6 +51,9 @@ config SYSTEM_CLOCK_SLOPPY_IDLE
 	  Some platforms may take advantage of this to reduce the
 	  overhead from regular interrupts required to handle counter
 	  wraparound conditions.
+
+	  No in-tree board enables this option and driver support for it has
+	  not been fully audited, hence the experimental tag.
 
 config SYSTEM_CLOCK_INIT_PRIORITY
 	int "System clock driver initialization priority"

--- a/drivers/timer/arcv2_timer0.c
+++ b/drivers/timer/arcv2_timer0.c
@@ -44,7 +44,6 @@
  * overflow,e.g, 0xffffffff + any value will cause overflow
  */
 #define COUNTER_MAX 0x7fffffff
-#define TIMER_STOPPED 0x0
 #define CYC_PER_TICK (sys_clock_hw_cycles_per_sec()	\
 		      / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 
@@ -258,24 +257,9 @@ static void timer_int_handler(const void *unused)
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
-	/* If the kernel allows us to miss tick announcements in idle,
-	 * then shut off the counter. (Note: we can assume if idle==true
-	 * that interrupts are already disabled)
-	 */
-#if SMP_TIMER_DRIVER
-	/* as 64-bits GFRC is used as wall clock, it's ok to ignore idle
-	 * systick will not be missed.
-	 * However for single core using 32-bits arc timer, idle cannot
-	 * be ignored, as 32-bits timer will overflow in a not-long time.
-	 */
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
-	    ticks == SYS_CLOCK_MAX_WAIT) {
-		timer0_control_register_set(0);
-		timer0_count_register_set(0);
-		timer0_limit_register_set(0);
-		return;
-	}
+	ARG_UNUSED(idle);
 
+#if SMP_TIMER_DRIVER
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint32_t delay;
 	uint32_t key;
@@ -299,15 +283,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	arch_irq_unlock(key);
 #endif
 #else
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
-	    ticks == SYS_CLOCK_MAX_WAIT) {
-		timer0_control_register_set(0);
-		timer0_count_register_set(0);
-		timer0_limit_register_set(0);
-		last_load = TIMER_STOPPED;
-		return;
-	}
-
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint32_t delay;
 	uint32_t unannounced;

--- a/drivers/timer/cmsdk_apb_timer.c
+++ b/drivers/timer/cmsdk_apb_timer.c
@@ -70,46 +70,30 @@ static uint32_t elapsed(uint32_t *val_out)
 	return data->load - value;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+/* Add the cycles counted down under the current reload to cycle_count and
+ * return the ticks not announced yet. *val_out and *load_out carry the counter
+ * value and the reload it was read against, which cmsdk_apb_program() needs.
+ */
+static uint32_t cmsdk_apb_sync(uint32_t *val_out, uint32_t *load_out)
 {
-	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
 
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
+	*load_out = data->load;
+	data->cycle_count += elapsed(val_out);
 
-	ARG_UNUSED(idle);
+	return data->cycle_count - data->announced_cycles;
+}
 
+/* Install a new reload, picking up the cycles that pass while the registers
+ * are rewritten: val1 and last_load come from the preceding cmsdk_apb_sync().
+ */
+static void cmsdk_apb_program(uint32_t load, uint32_t val1, uint32_t last_load)
+{
 	const struct tmr_cmsdk_apb_cfg *const cfg = &cfg_inst0;
 	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
-	uint32_t last_load = data->load;
-	uint32_t val1;
 	uint32_t val2;
 
-	/* store the current cfg->timer->value in val1 */
-	uint32_t pending_cycles = elapsed(&val1);
-	uint32_t load_to_be_set = 0;
-	uint32_t unannounced_cycles = 0;
-
-	data->cycle_count += pending_cycles;
-	unannounced_cycles = data->cycle_count - data->announced_cycles;
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * No pending timeout and no future timer interrupt required:
-		 * wait as long as the hardware allows.
-		 */
-		load_to_be_set = MAX_CYC;
-	} else if ((int32_t)unannounced_cycles < 0) {
-		load_to_be_set = MIN_DELAY_CYCLES;
-	} else {
-		int64_t want = ((uint64_t)data->last_elapsed + ticks) * CYC_PER_TICK;
-		int64_t delta_cycles = want - unannounced_cycles;
-
-		load_to_be_set = CLAMP(delta_cycles, (int64_t)MIN_DELAY_CYCLES, (int64_t)MAX_CYC);
-	}
-
-	data->load = load_to_be_set;
+	data->load = load;
 
 	val2 = cfg->timer->value;
 
@@ -122,6 +106,59 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	} else {
 		data->cycle_count += (val1 - val2);
 	}
+}
+
+void sys_clock_no_timeout(void)
+{
+	uint32_t val1;
+	uint32_t last_load;
+
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* Program the longest interval. An auto-reload down-counter cannot be
+	 * left alone the way a free-running compare can: it keeps firing at
+	 * whatever interval was programmed last, which may be a short one.
+	 *
+	 * Clearing TIMER_CTRL_EN and re-enabling it from
+	 * sys_clock_set_timeout() would drop the wakeup entirely. That is the
+	 * next step once the accounting tolerates a stopped counter.
+	 */
+	(void)cmsdk_apb_sync(&val1, &last_load);
+	cmsdk_apb_program(MAX_CYC, val1, last_load);
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	struct tmr_cmsdk_apb_dev_data *data = &data_inst0;
+	uint32_t unannounced_cycles;
+	uint32_t load_to_be_set;
+	uint32_t val1;
+	uint32_t last_load;
+
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
+	ARG_UNUSED(idle);
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	unannounced_cycles = cmsdk_apb_sync(&val1, &last_load);
+
+	if ((int32_t)unannounced_cycles < 0) {
+		load_to_be_set = MIN_DELAY_CYCLES;
+	} else {
+		int64_t want = ((uint64_t)data->last_elapsed + ticks) * CYC_PER_TICK;
+		int64_t delta_cycles = want - unannounced_cycles;
+
+		load_to_be_set = CLAMP(delta_cycles, (int64_t)MIN_DELAY_CYCLES, (int64_t)MAX_CYC);
+	}
+
+	cmsdk_apb_program(load_to_be_set, val1, last_load);
 }
 
 uint32_t sys_clock_elapsed(void)

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -372,67 +372,94 @@ __attribute__((interrupt("IRQ"))) void sys_clock_isr(void)
 }
 ARCH_ISR_DIAG_ON
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_no_timeout(void)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
-	/* Fast CPUs and a 24 bit counter mean that even idle systems
-	 * need to wake up multiple times per second.  If the kernel
-	 * allows us to miss tick announcements while nothing is pending
-	 * (sloppy idle), then shut off the counter.
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* Program the longest interval the counter can hold, then mask the
+	 * interrupt. Wraps that happen while it is masked never reach
+	 * elapsed(), so they are never added to overflow_cyc: the longer the
+	 * interval, the fewer of them and the less uptime drift.
+	 *
+	 * The counter keeps running. An empty timeout queue does not mean the
+	 * CPU is idle, and sys_clock_cycle_get_32() must keep advancing for
+	 * k_busy_wait() to work.
 	 */
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
-	    ticks == SYS_CLOCK_MAX_WAIT) {
+	sys_clock_set_timeout(UINT32_MAX, false);
+	SysTick->CTRL &= ~SysTick_CTRL_TICKINT_Msk;
+}
+
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && ticks == (uint32_t)K_TICKS_FOREVER) {
+		/* Nothing to wake up for and the uptime may drift: stop the
+		 * counter. SysTick is per-CPU, so only the CPU going idle is
+		 * affected. sys_clock_idle_exit() restarts it.
+		 */
+		cycle_count += elapsed(NULL);
+		overflow_cyc = 0U;
 		SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
 		last_load = TIMER_STOPPED;
 		return;
 	}
 
 #if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
-	if (idle) {
-		uint64_t timeout_us =
-			((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+	uint64_t timeout_us = k_ticks_to_us_ceil64(ticks);
 
-		timeout_idle = true;
+	timeout_idle = true;
 
-		/**
-		 * Invoke platform-specific layer to configure LPTIM
-		 * such that system wakes up after timeout elapses.
-		 */
-		z_sys_clock_lpm_enter(timeout_us);
+	/**
+	 * Invoke platform-specific layer to configure LPTIM
+	 * such that system wakes up after timeout elapses.
+	 */
+	z_sys_clock_lpm_enter(timeout_us);
 
 #if !defined(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)
-		/* Store current value of SysTick counter to be able to
-		 * calculate a difference in measurements after exiting
-		 * the low-power state.
-		 */
-		cycle_pre_idle = cycle_count + elapsed(NULL);
+	/* Store current value of SysTick counter to be able to
+	 * calculate a difference in measurements after exiting
+	 * the low-power state.
+	 */
+	cycle_pre_idle = cycle_count + elapsed(NULL);
 #else /* CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
-		/**
-		 * SysTick will be placed under reset once we enter
-		 * low-power mode. Turn it off right now then update
-		 * the cycle counter now, since we won't be able to
-		 * to it after waking up.
-		 */
-		sys_clock_disable();
-		/* Ensure the SysTick interrupt is not pending. This is safe
-		 * as we just did the ISR's job, and MUST be done because
-		 * a pending interrupt could inhibit low-power mode entry.
-		 * Note: On Armv8-M, ICSR.STTNS is R/W, so preserve it while
-		 * writing the write-1-to-clear PENDSTCLR bit.
-		 */
+	/**
+	 * SysTick will be placed under reset once we enter
+	 * low-power mode. Turn it off right now then update
+	 * the cycle counter now, since we won't be able to
+	 * to it after waking up.
+	 */
+	sys_clock_disable();
+	/* Ensure the SysTick interrupt is not pending. This is safe
+	 * as we just did the ISR's job, and MUST be done because
+	 * a pending interrupt could inhibit low-power mode entry.
+	 * Note: On Armv8-M, ICSR.STTNS is R/W, so preserve it while
+	 * writing the write-1-to-clear PENDSTCLR bit.
+	 */
 #ifdef SCB_ICSR_STTNS_Msk
-		SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
+	SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
 #else
-		SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
+	SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
 #endif
 
-		cycle_count += elapsed(NULL);
-		overflow_cyc = 0;
+	cycle_count += elapsed(NULL);
+	overflow_cyc = 0;
 #endif /* !CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
-		return;
-	}
+#else
+	sys_clock_set_timeout(ticks, false);
 #endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	ARG_UNUSED(idle);
+
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+	__ASSERT(!idle, "the idle argument is deprecated");
 
 #if defined(CONFIG_TICKLESS_KERNEL)
 	/*
@@ -528,6 +555,9 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 #else
 	SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
 #endif
+
+	/* Re-arm what sys_clock_no_timeout() may have masked. */
+	SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;
 
 	if (val1 < val2) {
 		cycle_count += val1 + (old_load - val2);
@@ -642,7 +672,11 @@ void sys_clock_idle_exit(void)
 		SysTick->LOAD = last_load - 1;
 		SysTick->VAL = 0; /* resets timer to last_load */
 		if (!IS_ENABLED(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)) {
-			SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
+			/* TICKINT too: sys_clock_no_timeout() may have masked it,
+			 * and LOAD is back to one tick so every wrap must be
+			 * announced again.
+			 */
+			SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk | SysTick_CTRL_TICKINT_Msk;
 		} else {
 			NVIC_SetPriority(SysTick_IRQn, _IRQ_PRIO_OFFSET);
 			SysTick->CTRL |= (SysTick_CTRL_ENABLE_Msk |

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -99,6 +99,10 @@ static void IRAM_ATTR sys_timer_isr(void *arg)
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
+	ARG_UNUSED(idle);
+
+	__ASSERT(!idle, "the idle argument is deprecated");
+
 #if defined(CONFIG_TICKLESS_KERNEL)
 	if (systimer_hal.dev == NULL) {
 		return;
@@ -125,22 +129,35 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	set_systimer_alarm(cyc + last_count);
 
-#if defined(CONFIG_PM)
-	if (idle) {
-		uint64_t timeout_us =
-			((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-		lptim_pre_idle = esp32_lptim_hook_on_lpm_entry(timeout_us);
-		systimer_pre_idle = get_systimer_alarm();
-		timeout_idle = true;
-	}
-#else
-	ARG_UNUSED(idle);
-#endif
-
 	k_spin_unlock(&lock, key);
+#else
+	ARG_UNUSED(ticks);
 #endif
 }
+
+#if defined(CONFIG_PM)
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	sys_clock_set_timeout(ticks, false);
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL) || systimer_hal.dev == NULL) {
+		return;
+	}
+
+	/* Same tick count sys_clock_set_timeout() programmed the systimer with
+	 * above, so the low-power timer is armed for the same deadline.
+	 */
+	uint32_t lp_ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
+	uint64_t timeout_us = ((uint64_t)lp_ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	lptim_pre_idle = esp32_lptim_hook_on_lpm_entry(timeout_us);
+	systimer_pre_idle = get_systimer_alarm();
+	timeout_idle = true;
+
+	k_spin_unlock(&lock, key);
+}
+#endif
 
 uint32_t sys_clock_elapsed(void)
 {

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -349,6 +349,57 @@ void smp_timer_init(void)
 	 */
 }
 
+void sys_clock_no_timeout(void)
+{
+	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* Mask the comparator interrupt and leave the main counter alone. An
+	 * empty timeout queue does not mean the CPU is idle, so k_cycle_get_32()
+	 * must keep advancing. Clearing GCONF_ENABLE is not an option either
+	 * way: the HPET counter is shared by every CPU.
+	 */
+	uint32_t reg = hpet_timer_conf_get();
+
+	reg &= ~TIMER_CONF_INT_ENABLE;
+	hpet_timer_conf_set(reg);
+}
+
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	uint32_t reg;
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL) || ticks != (uint32_t)K_TICKS_FOREVER) {
+		sys_clock_set_timeout(ticks, false);
+		return;
+	}
+
+	if (IS_ENABLED(CONFIG_SMP)) {
+		/* The HPET counter is shared by every CPU and only this one is
+		 * going idle. Stopping it would freeze sys_clock_cycle_get_32()
+		 * for the others, so only mask the comparator interrupt.
+		 */
+		reg = hpet_timer_conf_get();
+		reg &= ~TIMER_CONF_INT_ENABLE;
+		hpet_timer_conf_set(reg);
+		return;
+	}
+
+	/* Nothing to wake up for and the uptime may drift: stop the main
+	 * counter, which saves more than masking the interrupt. There is one
+	 * CPU here, so nothing else can observe it standing still.
+	 * sys_clock_idle_exit() starts it again, and it resumes where it
+	 * stopped: last_count and the comparator stay coherent, only real time
+	 * is lost.
+	 */
+	reg = hpet_gconf_get();
+	reg &= ~GCONF_ENABLE;
+	hpet_gconf_set(reg);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -358,17 +409,15 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 #if defined(CONFIG_TICKLESS_KERNEL)
 	uint32_t reg;
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		reg = hpet_gconf_get();
-		reg &= ~GCONF_ENABLE;
-		hpet_gconf_set(reg);
-		return;
-	}
-
 	/* The comparator is 64-bit, so the requested timeout needs no clamp. */
 	uint64_t cyc = (last_tick + last_elapsed + ticks) * cyc_per_tick;
 
 	hpet_timer_comparator_set_safe(cyc);
+
+	/* Re-arm what sys_clock_no_timeout() may have masked. */
+	reg = hpet_timer_conf_get();
+	reg |= TIMER_CONF_INT_ENABLE;
+	hpet_timer_conf_set(reg);
 #endif
 }
 

--- a/drivers/timer/infineon_lp_timer.c
+++ b/drivers/timer/infineon_lp_timer.c
@@ -66,6 +66,20 @@ static void lptimer_interrupt_handler(void *handler_arg, cyhal_lptimer_event_t e
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? delta_ticks : (delta_ticks > 0));
 }
 
+void sys_clock_no_timeout(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	/* Disable the LPTIMER events */
+	cyhal_lptimer_enable_event(&lptimer_obj, CYHAL_LPTIMER_COMPARE_MATCH,
+				   LPTIMER_INTR_PRIORITY, false);
+	k_spin_unlock(&lock, key);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -73,15 +87,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	k_spinlock_key_t key = {0};
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		key = k_spin_lock(&lock);
-		/* Disable the LPTIMER events */
-		cyhal_lptimer_enable_event(&lptimer_obj, CYHAL_LPTIMER_COMPARE_MATCH,
-					   LPTIMER_INTR_PRIORITY, false);
-		k_spin_unlock(&lock, key);
 		return;
 	}
 

--- a/drivers/timer/ite_it51xxx_timer.c
+++ b/drivers/timer/ite_it51xxx_timer.c
@@ -193,6 +193,18 @@ static void free_run_timer_overflow_isr(const void *unused)
 	/* TODO: to increment 32-bit "top half" here for software 64-bit timer emulation. */
 }
 
+void sys_clock_no_timeout(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	ext_timer_disable(EVENT_TIMER);
+	k_spin_unlock(&lock, key);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -210,18 +222,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	/* Disable event timer */
 	ext_timer_disable(EVENT_TIMER);
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * The kernel has no pending timeout, which it signals with
-		 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle no future
-		 * timer interrupt is required, so leave the event timer
-		 * disabled and stop waking up. Without sloppy idle we fall
-		 * through and still schedule the (capped) timeout so the
-		 * uptime tick count stays correct.
-		 */
-		k_spin_unlock(&lock, key);
-		return;
-	}
 	/*
 	 * If ticks <= 1 means the kernel wants the tick announced as soon as possible,
 	 * ideally no more than one system tick in the future. So set event timer count

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -223,6 +223,18 @@ static void free_run_timer_overflow_isr(const void *unused)
 	 */
 }
 
+void sys_clock_no_timeout(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	IT8XXX2_EXT_CTRLX(EVENT_TIMER) &= ~IT8XXX2_EXT_ETXEN;
+	k_spin_unlock(&lock, key);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	uint32_t hw_cnt;
@@ -240,18 +252,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	/* Disable event timer */
 	IT8XXX2_EXT_CTRLX(EVENT_TIMER) &= ~IT8XXX2_EXT_ETXEN;
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * The kernel has no pending timeout, which it signals with
-		 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle no future
-		 * timer interrupt is required, so leave the event timer
-		 * disabled and stop waking up. Without sloppy idle we fall
-		 * through to the else and still schedule the (capped) timeout
-		 * so the uptime tick count stays correct.
-		 */
-		k_spin_unlock(&lock, key);
-		return;
-	} else {
+	{
 		uint32_t next_cycs;
 		uint32_t now;
 		uint32_t dcycles;

--- a/drivers/timer/max32_rv32_sys_timer.c
+++ b/drivers/timer/max32_rv32_sys_timer.c
@@ -122,9 +122,7 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	uint32_t next_cycle;
 	uint32_t count;
 
-	if (ticks == SYS_CLOCK_MAX_WAIT) {
-		next_cycle = (last_tick * CYC_PER_TICK) + CYCLES_MAX;
-	} else if (ticks == 0) {
+	if (ticks == 0) {
 		next_cycle = MXC_TMR_GetCount(regs) + (CYC_PER_TICK * 3 / 2);
 		next_cycle -= (next_cycle % CYC_PER_TICK);
 	} else {

--- a/drivers/timer/mchp_xec_rtos_timer.c
+++ b/drivers/timer/mchp_xec_rtos_timer.c
@@ -182,6 +182,23 @@ static uint32_t last_announcement; /* last time we called sys_clock_announce() *
  * Writing a new value to preload only takes effect once the count
  * register reaches 0.
  */
+
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	if (ticks != (uint32_t)K_TICKS_FOREVER) {
+		sys_clock_set_timeout(ticks, false);
+		return;
+	}
+
+	/* Nothing to wake up for and the uptime may drift: stop the timer.
+	 * This timer serves a single CPU, so nothing else can observe
+	 * sys_clock_cycle_get_32() standing still. sys_clock_idle_exit()
+	 * starts it again.
+	 */
+	sys_write32(0, TIMER_BASE + TIMER_CR_OFS);
+	cached_icr = TIMER_STOPPED;
+}
+
 void sys_clock_set_timeout(uint32_t n, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -190,16 +207,6 @@ void sys_clock_set_timeout(uint32_t n, bool idle)
 	int full_ticks;          /* number of complete ticks we'll wait */
 	uint32_t full_cycles;    /* full_ticks represented as cycles */
 	uint32_t partial_cycles; /* number of cycles to first tick boundary */
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && (n == SYS_CLOCK_MAX_WAIT)) {
-		/*
-		 * We are not in a locked section. Are writes to two
-		 * global objects safe from pre-emption?
-		 */
-		sys_write32(0, TIMER_BASE + TIMER_CR_OFS); /* stop timer */
-		cached_icr = TIMER_STOPPED;
-		return;
-	}
 
 	if (n < 1) {
 		full_ticks = 0;

--- a/drivers/timer/mcux_lptmr_timer.c
+++ b/drivers/timer/mcux_lptmr_timer.c
@@ -66,14 +66,21 @@ static inline uint32_t counter_delta(uint32_t now, uint32_t then)
 	return (now - then) & COUNTER_MAX;
 }
 
+void sys_clock_no_timeout(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/* The interrupt masked below is the periodic tick there, and
+		 * sys_clock_set_timeout() would not bring it back.
+		 */
+		return;
+	}
+
+	LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		LPTMR_DisableInterrupts(LPTMR_BASE, kLPTMR_TimerInterruptEnable);
-		return;
-	}
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -244,28 +244,68 @@ bool z_nxp_os_timer_ignore_timer_wakeup(void)
 	return (wait_forever || counter_remaining_ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_no_timeout(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		/* Only for tickless kernel system */
 		return;
 	}
 
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	/* Program the longest wait the hardware can hold, the same value
+	 * sys_clock_set_timeout() would compute with no deadline. wait_forever
+	 * records the state for the counter-overflow wakeup path.
+	 */
+	OSTIMER_SetMatchValue(base, MAX_TICKS * CYC_PER_TICK + last_count - cyc_sys_compensated,
+			      NULL);
+	counter_remaining_ticks = 0;
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
-	/* We intercept calls from idle with a 0 tick count when PM=y */
-	if (idle && (ticks == 0)) {
+	wait_forever = true;
+#endif
+
+	k_spin_unlock(&lock, key);
+}
+
+void sys_clock_idle_enter(uint32_t ticks)
+{
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
+	/* We intercept idle entry with a 0 tick count when PM=y */
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && (ticks == 0)) {
 		mcux_os_timer_set_lp_counter_timeout();
 		/* A low power counter has been started. No need to
 		 * go further, simply return
 		 */
 		return;
 	}
-	/* When using a counter for certain low power modes, set this flag when the requested
-	 * delay is forever. This is to keep track of wakeup sources in case of counter overflows.
-	 */
-	wait_forever = (ticks == SYS_CLOCK_MAX_WAIT);
-#else
+#endif
+	if (ticks == (uint32_t)K_TICKS_FOREVER) {
+		/* Nothing to wake up for: same handling as on the running path,
+		 * which also keeps the wait_forever bookkeeping set rather than
+		 * having sys_clock_set_timeout() clear it below.
+		 */
+		sys_clock_no_timeout();
+		return;
+	}
+
+	sys_clock_set_timeout(ticks, false);
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
 	ARG_UNUSED(idle);
+
+	__ASSERT(!idle, "the idle argument is deprecated");
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/* Only for tickless kernel system */
+		return;
+	}
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
+	/* A real deadline is being scheduled; the "no deadline" case is
+	 * handled by sys_clock_no_timeout() instead.
+	 */
+	wait_forever = false;
 #endif
 	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 

--- a/drivers/timer/mcux_rtc_jdp_timer.c
+++ b/drivers/timer/mcux_rtc_jdp_timer.c
@@ -128,20 +128,9 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	uint32_t cycles;
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * No pending timeout and no future timer interrupt required:
-		 * wait as long as the hardware allows.
-		 */
-		cycles = cycles_max;
-	} else {
-		uint64_t wait_ticks = (uint64_t)last_elapsed + (uint64_t)ticks;
-		uint64_t wait_cycles = wait_ticks * (uint64_t)cycles_per_tick;
-
-		cycles = (wait_cycles > cycles_max) ? cycles_max : (uint32_t)wait_cycles;
-	}
+	uint64_t wait_ticks = (uint64_t)last_elapsed + (uint64_t)ticks;
+	uint64_t wait_cycles = wait_ticks * (uint64_t)cycles_per_tick;
+	uint32_t cycles = (wait_cycles > cycles_max) ? cycles_max : (uint32_t)wait_cycles;
 
 	rtc_jdp_set_compare(last_count + cycles);
 }

--- a/drivers/timer/mcux_sysctr_timer.c
+++ b/drivers/timer/mcux_sysctr_timer.c
@@ -154,6 +154,20 @@ static void sysctr_timer_isr(const void *arg)
 	sys_clock_announce(delta_ticks);
 }
 
+void sys_clock_no_timeout(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* No timeout pending: mask the compare interrupt. The CPU keeps
+	 * running, so the recovery is the next sys_clock_set_timeout():
+	 * sysctr_set_compare() re-enables both the interrupt and the compare.
+	 */
+	SYSCTR_EnableCompare(CMP_BASE, TIMER_CMP_FRAME, false);
+	SYSCTR_DisableInterrupts(CMP_BASE, TIMER_CMP_INT_MASK);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	uint64_t next_cycle;
@@ -163,17 +177,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	ARG_UNUSED(idle);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/*
-		 * No near deadline to schedule: under sloppy idle, disable the
-		 * compare interrupt entirely. sys_clock_idle_exit() will
-		 * re-enable it when the CPU wakes from an external source.
-		 */
-		SYSCTR_EnableCompare(CMP_BASE, TIMER_CMP_FRAME, false);
-		SYSCTR_DisableInterrupts(CMP_BASE, TIMER_CMP_INT_MASK);
 		return;
 	}
 

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -144,7 +144,7 @@ static inline void npcx_itim_evt_disable(void)
 }
 
 /* ITIM local functions */
-static int npcx_itim_start_evt_tmr_by_tick(int32_t ticks)
+static int npcx_itim_start_evt_tmr_by_tick(uint32_t ticks)
 {
 	/*
 	 * Get desired cycles of event timer from the requested ticks which

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -667,6 +667,25 @@ bail:
 	return err;
 }
 
+void sys_clock_no_timeout(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* No timeout pending: push the compare as far out as the counter
+	 * allows and drop the busy flag consumed by the overflow-trigger
+	 * path.
+	 *
+	 * Not reprogramming at all would be the natural improvement: the
+	 * compare already in place covers the counter wrap, so this wakeup
+	 * is redundant.
+	 */
+	sys_busy = false;
+	compare_set(SYS_CLOCK_CH, last_count + MAX_CYCLES,
+		    sys_clock_timeout_handler, NULL, false);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -676,22 +695,17 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
+	target_time = last_count +
+		      ((uint64_t)last_elapsed + (uint64_t)ticks) * CYC_PER_TICK;
+	/* Clamp to fit the 24-bit compare register and keep the
+	 * anchor in its valid range (see anchor_update). A resulting
+	 * target in the past is fine: compare_set forces an immediate
+	 * IRQ and the handler catches up in one shot.
+	 */
+	if ((target_time - last_count) > MAX_CYCLES) {
 		target_time = last_count + MAX_CYCLES;
-		sys_busy = false;
-	} else {
-		target_time = last_count +
-			      ((uint64_t)last_elapsed + (uint64_t)ticks) * CYC_PER_TICK;
-		/* Clamp to fit the 24-bit compare register and keep the
-		 * anchor in its valid range (see anchor_update). A resulting
-		 * target in the past is fine: compare_set forces an immediate
-		 * IRQ and the handler catches up in one shot.
-		 */
-		if ((target_time - last_count) > MAX_CYCLES) {
-			target_time = last_count + MAX_CYCLES;
-		}
-		sys_busy = true;
 	}
+	sys_busy = true;
 
 	compare_set(SYS_CLOCK_CH, target_time, sys_clock_timeout_handler, NULL, false);
 }

--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -98,6 +98,22 @@ static void rtmr_isr(const void *arg)
 	sys_clock_announce(ticks);
 }
 
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	if (ticks != (uint32_t)K_TICKS_FOREVER) {
+		sys_clock_set_timeout(ticks, false);
+		return;
+	}
+
+	/* Nothing to wake up for and the uptime may drift: stop the timer.
+	 * This timer serves a single CPU, so nothing else can observe
+	 * sys_clock_cycle_get_32() standing still. sys_clock_idle_exit()
+	 * starts it again.
+	 */
+	RTMR_REG->CTRL = 0U;
+	previous_cnt = RTMR_TIMER_STOPPED;
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -106,7 +122,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	int full_ticks;
 	uint32_t full_cycles;
 	uint32_t partial_cycles;
-
 
 	if (ticks < 1) {
 		full_ticks = 0;

--- a/drivers/timer/realtek_rts5912_rtmr.c
+++ b/drivers/timer/realtek_rts5912_rtmr.c
@@ -107,11 +107,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	uint32_t full_cycles;
 	uint32_t partial_cycles;
 
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && (ticks == SYS_CLOCK_MAX_WAIT)) {
-		RTMR_REG->CTRL = 0U;
-		previous_cnt = RTMR_TIMER_STOPPED;
-		return;
-	}
 
 	if (ticks < 1) {
 		full_ticks = 0;

--- a/drivers/timer/renesas_ra_ulpt_timer.c
+++ b/drivers/timer/renesas_ra_ulpt_timer.c
@@ -82,17 +82,25 @@ static void ra_ulpt_timer_isr(void)
 	}
 }
 
+void sys_clock_no_timeout(void)
+{
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		return;
+	}
+
+	/* The counter reloads and fires again on every underflow, so leaving
+	 * it alone would keep waking the CPU at whatever rate the last deadline
+	 * set. Ask for the longest interval instead, which clamps to MAX_TICKS.
+	 */
+	sys_clock_set_timeout(UINT32_MAX, false);
+}
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
 
 	/* Timeout configuration is unsupported in tickful mode. */
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		return;
-	}
-
-	/* No timeout change when the kernel has no near deadline to schedule. */
-	if (ticks == SYS_CLOCK_MAX_WAIT) {
 		return;
 	}
 

--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -207,14 +207,26 @@ static int sys_clock_driver_init(void)
 	return 0;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_no_timeout(void)
 {
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
 
-	/* Nothing to do when the kernel has no near deadline to schedule. */
-	if (ticks == SYS_CLOCK_MAX_WAIT) {
+	/* CMCOR is a period, not a deadline: a compare match clears CMCNT, so
+	 * whatever is programmed keeps firing at that rate. Stretch it to the
+	 * longest the register can hold, which is all this hardware can do to
+	 * slow the wakeups down. The cycle count comes from CMT1, so lengthening
+	 * this one leaves sys_clock_cycle_get_32() untouched.
+	 */
+	*tick_timer_cfg.cmcor = (uint16_t)COUNTER_MAX;
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	ARG_UNUSED(idle);
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
 

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -181,6 +181,20 @@ static void rtc_isr(const void *arg)
 #endif /* CONFIG_TICKLESS_KERNEL */
 }
 
+#ifndef CONFIG_TICKLESS_KERNEL
+void sys_clock_no_timeout(void)
+{
+	/* Disable the comparator. Nothing is pending and sloppy idle lets the
+	 * uptime drift, so the periodic tick can stop.
+	 *
+	 * Only the ticking configuration needs this hook. The tickless one is
+	 * left with the default, which forwards K_TICKS_FOREVER to
+	 * sys_clock_set_timeout() and gets clamped to MAX_TICKS there.
+	 */
+	rtc_timeout = rtc_counter;
+}
+#endif /* !CONFIG_TICKLESS_KERNEL */
+
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
 	ARG_UNUSED(idle);
@@ -204,12 +218,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	RTC0->COMP[0].reg = count + timeout;
 
 #else /* !CONFIG_TICKLESS_KERNEL */
-
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		/* Disable comparator when the kernel has no pending timeout. */
-		rtc_timeout = rtc_counter;
-		return;
-	}
 
 	if (ticks < 1) {
 		ticks = 1;

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -315,86 +315,18 @@ static inline uint32_t z_clock_lptim_getcounter(void)
 	return lp_time;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+static void lptim_set_timeout(uint32_t ticks)
 {
 	/* new LPTIM AutoReload value to set (aligned on Kernel ticks) */
 	uint32_t next_arr = 0;
 	int err;
 
-	ARG_UNUSED(idle);
-
-#ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
-	const struct pm_state_info *next;
-
-	next = pm_policy_next_state(_current_cpu->id, ticks);
-
-	/* Check if STANBY or STOP3 is requested */
-	timeout_stdby = false;
-	if ((next != NULL) && idle) {
-#ifdef CONFIG_PM_S2RAM
-		if (next->state == PM_STATE_SUSPEND_TO_RAM) {
-			timeout_stdby = true;
-		}
-#endif
-#ifdef CONFIG_STM32_STOP3_LP_MODE
-		if ((next->state == PM_STATE_SUSPEND_TO_IDLE) && (next->substate_id == 4)) {
-			timeout_stdby = true;
-		}
-#endif
-	}
-
-	if (timeout_stdby) {
-		uint64_t timeout_us =
-			((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-		struct counter_alarm_cfg cfg = {
-			.callback = NULL,
-			.ticks = counter_us_to_ticks(stdby_timer, timeout_us),
-			.user_data = NULL,
-			.flags = 0,
-		};
-
-		/* Set the alarm using timer that runs the standby.
-		 * Needed rump-up/setting time, lower accurency etc. should be
-		 * included in the exit-latency in the power state definition.
-		 */
-		counter_cancel_channel_alarm(stdby_timer, 0);
-		counter_set_channel_alarm(stdby_timer, 0, &cfg);
-
-		/* Store current values to calculate a difference in
-		 * measurements after exiting the standby state.
-		 */
-		counter_get_value(stdby_timer, &stdby_timer_pre_stdby);
-		lptim_cnt_pre_stdby = z_clock_lptim_getcounter();
-
-		LL_LPTIM_DisableIT_ARROK(LPTIM);
-		LL_LPTIM_ClearFlag_ARROK(LPTIM);
-		NVIC_ClearPendingIRQ(DT_IRQN(LPTIM_SYSTIMER_NODE));
-		/* Stop clocks for LPTIM, since RTC is used instead */
-		clock_control_off(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
-
-		return;
-	}
-#endif /* CONFIG_STM32_LPTIM_STDBY_TIMER */
-
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
 
-	/*
-	 * The kernel has no pending timeout, which it signals with
-	 * ticks == SYS_CLOCK_MAX_WAIT. Under sloppy idle the LPTIM can be
-	 * turned off entirely (never waking up, not clocked anymore).
-	 * Without sloppy idle we fall through and schedule the (capped)
-	 * timeout so the uptime tick count stays correct.
-	 */
-	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) && ticks == SYS_CLOCK_MAX_WAIT) {
-		clock_control_off(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
-		return;
-	}
-	/*
-	 * When CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE = n, ticks equals to INT_MAX
-	 * is treated as a maximum possible value LPTIM_MAX_TIMEBASE (16bit counter)
+	/* A request beyond what the 16 bit counter can hold is clamped to
+	 * LPTIM_MAX_TIMEBASE below, so the longest wait needs no special case.
 	 */
 
 	/* if LPTIM clock was previously stopped, it must now be restored */
@@ -456,6 +388,92 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	lptim_set_autoreload(next_arr);
 
 	k_spin_unlock(&lock, key);
+}
+
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	if (ticks == (uint32_t)K_TICKS_FOREVER) {
+		/* Nothing to wake up for and the uptime may drift: gate the
+		 * LPTIM off. It is unclocked from here and cannot wake the CPU.
+		 * This timer serves a single CPU, so nothing else can observe
+		 * sys_clock_cycle_get_32() standing still. The
+		 * clock_control_on() in lptim_set_timeout() restores it on the
+		 * next deadline.
+		 */
+		clock_control_off(clk_ctrl, (clock_control_subsys_t)&lptim_clk[0]);
+		return;
+	}
+
+#ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
+	const struct pm_state_info *next;
+
+	next = pm_policy_next_state(_current_cpu->id, ticks);
+
+	/* Check if STANBY or STOP3 is requested */
+	timeout_stdby = false;
+	if (next != NULL) {
+#ifdef CONFIG_PM_S2RAM
+		if (next->state == PM_STATE_SUSPEND_TO_RAM) {
+			timeout_stdby = true;
+		}
+#endif
+#ifdef CONFIG_STM32_STOP3_LP_MODE
+		if ((next->state == PM_STATE_SUSPEND_TO_IDLE) && (next->substate_id == 4)) {
+			timeout_stdby = true;
+		}
+#endif
+	}
+
+	if (timeout_stdby) {
+		uint64_t timeout_us = k_ticks_to_us_ceil64(ticks);
+
+		struct counter_alarm_cfg cfg = {
+			.callback = NULL,
+			.ticks = counter_us_to_ticks(stdby_timer, timeout_us),
+			.user_data = NULL,
+			.flags = 0,
+		};
+
+		/* Set the alarm using timer that runs the standby.
+		 * Needed rump-up/setting time, lower accurency etc. should be
+		 * included in the exit-latency in the power state definition.
+		 */
+		counter_cancel_channel_alarm(stdby_timer, 0);
+		counter_set_channel_alarm(stdby_timer, 0, &cfg);
+
+		/* Store current values to calculate a difference in
+		 * measurements after exiting the standby state.
+		 */
+		counter_get_value(stdby_timer, &stdby_timer_pre_stdby);
+		lptim_cnt_pre_stdby = z_clock_lptim_getcounter();
+
+		LL_LPTIM_DisableIT_ARROK(LPTIM);
+		LL_LPTIM_ClearFlag_ARROK(LPTIM);
+		NVIC_ClearPendingIRQ(DT_IRQN(LPTIM_SYSTIMER_NODE));
+		/* Stop clocks for LPTIM, since RTC is used instead */
+		clock_control_off(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
+
+		return;
+	}
+#endif /* CONFIG_STM32_LPTIM_STDBY_TIMER */
+
+	lptim_set_timeout(ticks);
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	ARG_UNUSED(idle);
+
+	/* Idle entry comes through sys_clock_idle_enter(), so this deprecated
+	 * argument is never set here. Catch a stale caller until it goes away.
+	 */
+	__ASSERT(!idle, "the idle argument is deprecated");
+
+#ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
+	timeout_stdby = false;
+#endif
+
+	lptim_set_timeout(ticks);
 }
 
 static uint32_t sys_clock_lp_time_get(void)

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -25,3 +25,14 @@ void __weak sys_clock_set_timeout(uint32_t ticks, bool idle)
 void __weak sys_clock_idle_exit(void)
 {
 }
+
+void __weak sys_clock_no_timeout(void)
+{
+	/* A driver that does not implement this hook may recognise
+	 * K_TICKS_FOREVER as the request to stop its clock and act on it;
+	 * one that does not reads it as a maximal wait, which is equally
+	 * acceptable here since timekeeping accuracy is already forfeit.
+	 * That tick value is deprecated in favour of implementing this hook.
+	 */
+	sys_clock_set_timeout((uint32_t)K_TICKS_FOREVER, false);
+}

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -36,3 +36,14 @@ void __weak sys_clock_no_timeout(void)
 	 */
 	sys_clock_set_timeout((uint32_t)K_TICKS_FOREVER, false);
 }
+
+void __weak sys_clock_idle_enter(uint32_t ticks)
+{
+	/* A driver that does not implement this hook may still key its
+	 * low-power handling on sys_clock_set_timeout()'s idle argument, so
+	 * pass true here. That argument is deprecated in favour of
+	 * implementing this hook, and carries no information for a driver
+	 * that does.
+	 */
+	sys_clock_set_timeout(ticks, true);
+}

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -85,7 +85,7 @@ static void ccompare_isr(const void *arg)
 	sys_clock_announce_locked(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+static void set_timeout(uint32_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -125,6 +125,19 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	}
 
 #endif
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	ARG_UNUSED(idle);
+
+	__ASSERT(!idle, "the idle argument is deprecated");
+	set_timeout(ticks, false);
+}
+
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	set_timeout(ticks, true);
 }
 
 uint32_t sys_clock_elapsed(void)

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -147,20 +147,19 @@ bool sys_clock_is_locked(void);
  * Similarly a ticks value of zero is legal: it simply indicates the
  * kernel would like the next tick announcement as soon as possible.
  *
- * Note that ticks can also be passed the special value K_TICKS_FOREVER,
- * indicating that no future timer interrupts are expected or required
- * and that the system is permitted to enter an indefinite sleep even
- * if this could cause rollover of the internal counter (i.e. the
- * system uptime counter is allowed to be wrong
+ * The kernel never asks for more than SYS_CLOCK_MAX_WAIT ticks.  That is a
+ * plain upper bound and not a signal: it is indistinguishable from any other
+ * tick count, and the driver must not read a meaning into it.  A driver whose
+ * hardware cannot hold a wait that long clamps to what it can and announces
+ * the ticks that did elapse.
  *
- * Note also that it is conventional for the kernel to pass INT_MAX
- * for ticks if it wants to preserve the uptime tick count but doesn't
- * have a specific event to await.  The intent here is that the driver
- * will schedule any needed timeout as far into the future as
- * possible.  For the specific case of INT_MAX, the next call to
- * sys_clock_announce() may occur at any point in the future, not just
- * at INT_MAX ticks.  But the correspondence between the announced
- * ticks and real-world time must be correct.
+ * The two conditions a driver used to infer from the tick value now have
+ * their own entry points: sys_clock_no_timeout() for "no timeout is pending"
+ * and sys_clock_idle_enter() for "the CPU is going to sleep".  The special
+ * value K_TICKS_FOREVER is deprecated as an argument to this function.  It
+ * reaches a driver only through the default sys_clock_no_timeout(), on behalf
+ * of drivers that do not implement that hook, and that is the one place a
+ * value above SYS_CLOCK_MAX_WAIT is still passed.
  *
  * A final note about SMP: note that the call to sys_clock_set_timeout()
  * is made on any CPU, and reflects the next timeout desired globally.

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -253,6 +253,34 @@ uint32_t sys_clock_elapsed(void);
 void sys_clock_disable(void);
 
 /**
+ * @brief Notify the timer driver that no timeout is pending.
+ *
+ * Called by the kernel in place of sys_clock_set_timeout() when the timeout
+ * queue is empty and @kconfig{CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE} is enabled.
+ * The kernel is not asking for a deadline here: the driver may stop
+ * announcing ticks until the next sys_clock_set_timeout(). The ticks missed
+ * in the meantime are the uptime drift that option permits. Mask the wakeup,
+ * program the longest interval the hardware can hold, or both.
+ *
+ * The CPU keeps running, so sys_clock_cycle_get_32() and
+ * sys_clock_cycle_get_64() must keep counting: a thread can still call
+ * k_cycle_get_32() or k_busy_wait(). A driver whose cycle counter is driven by
+ * the timer it would stop can therefore only mask the interrupt. One whose
+ * cycle counter lives in a different clock or power domain may stop more.
+ * Stopping the time base belongs in sys_clock_idle_enter().
+ *
+ * Unlike sys_clock_disable(), this is a resumable pause and not a teardown.
+ * The next sys_clock_set_timeout() resumes normal operation.
+ *
+ * The default implementation calls sys_clock_set_timeout() with
+ * K_TICKS_FOREVER, which a driver that has not been converted still reads as
+ * the request to stop. That default is a compatibility shim: it goes away
+ * together with the deprecated @p idle argument of sys_clock_set_timeout(),
+ * and a driver implementing this hook must not rely on the tick value.
+ */
+void sys_clock_no_timeout(void);
+
+/**
  * @brief Hardware cycle counter
  *
  * Timer drivers are generally responsible for the system cycle

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -174,8 +174,12 @@ bool sys_clock_is_locked(void);
  * lock held.
  *
  * @param ticks Timeout in tick units
- * @param idle Hint to the driver that the system is about to enter
- *        the idle state immediately after setting the timeout
+ * @param idle Deprecated, and always false when the kernel calls this
+ *        function: idle entry is notified through sys_clock_idle_enter(),
+ *        whose default implementation passes true here so that a driver
+ *        keying its low-power handling on this argument still works. Retained
+ *        for source compatibility and scheduled for removal in a future
+ *        release; new code must ignore it.
  */
 void sys_clock_set_timeout(uint32_t ticks, bool idle);
 
@@ -279,6 +283,28 @@ void sys_clock_disable(void);
  * and a driver implementing this hook must not rely on the tick value.
  */
 void sys_clock_no_timeout(void);
+
+/**
+ * @brief Notify the timer driver that the CPU is entering low-power idle.
+ *
+ * Called from the power-management idle path when the CPU is about to sleep.
+ * A driver that hands off to a low-power wakeup timer, or otherwise
+ * reconfigures itself for sleep, does so here. sys_clock_idle_exit() undoes
+ * it on the way out. A driver with no low-power handling does not need to
+ * implement this hook.
+ *
+ * The default implementation calls sys_clock_set_timeout() with the
+ * deprecated @p idle argument set to true, which keeps a driver keying its
+ * low-power handling on that argument working. That default is a
+ * compatibility shim and goes away together with the argument.
+ *
+ * @param ticks Ticks until the next expected wakeup, or K_TICKS_FOREVER when
+ *        nothing needs to wake the CPU and the uptime is allowed to drift, in
+ *        which case the driver may stop its time base. Only the calling CPU is
+ *        going idle: a driver whose time base is shared between CPUs must
+ *        account for the others itself.
+ */
+void sys_clock_idle_enter(uint32_t ticks);
 
 /**
  * @brief Hardware cycle counter

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -54,7 +54,13 @@ void idle(void *unused1, void *unused2, void *unused3)
 		bool system_suspended = false;
 
 		if (!k_is_pre_kernel()) {
-			_kernel.idle = z_get_next_timeout_expiry();
+			/* _kernel.idle is int32_t and the helper is uint32_t.
+			 * Every value it returns is either at most
+			 * SYS_CLOCK_MAX_WAIT (== INT32_MAX) or the
+			 * K_TICKS_FOREVER bit pattern, which converts back
+			 * to -1, so nothing is lost here.
+			 */
+			_kernel.idle = (int32_t)z_get_next_timeout_expiry();
 
 			/*
 			 * Call the suspend hook function of the soc interface

--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -125,7 +125,7 @@ static inline int z_try_abort_thread_timeout(struct k_thread *thread)
 	return z_try_abort_timeout(&thread->base.timeout);
 }
 
-int32_t z_get_next_timeout_expiry(void);
+uint32_t z_get_next_timeout_expiry(void);
 
 k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 
@@ -135,7 +135,7 @@ k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 #define z_init_thread_timeout(thread_base) do {} while (false)
 #define z_try_abort_thread_timeout(to) 0
 #define z_is_inactive_timeout(to) 1
-#define z_get_next_timeout_expiry() ((int32_t) K_TICKS_FOREVER)
+#define z_get_next_timeout_expiry() ((uint32_t) K_TICKS_FOREVER)
 #define z_set_timeout_expiry(ticks, is_idle) do {} while (false)
 
 static inline k_ticks_t z_add_thread_timeout(struct k_thread *thread, k_timeout_t ticks)

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -312,20 +312,23 @@ k_ticks_t z_timeout_expires(const struct _timeout *timeout)
 }
 EXPORT_SYMBOL(z_timeout_expires);
 
-int32_t z_get_next_timeout_expiry(void)
+uint32_t z_get_next_timeout_expiry(void)
 {
-	int32_t ret = (int32_t) K_TICKS_FOREVER;
+	uint32_t ret = (uint32_t)K_TICKS_FOREVER;
 
 	K_SPINLOCK(&timeout_lock) {
-		uint32_t t = next_timeout(elapsed());
-
 		/*
-		 * next_timeout() is unsigned; only fold it into the signed
-		 * result when it fits, otherwise leave the K_TICKS_FOREVER
-		 * default.
+		 * Same decision as reprogram_next(). Sloppy idle lets the
+		 * uptime drift, so an empty list means nothing to wake up for
+		 * and that is reported as K_TICKS_FOREVER. Otherwise the
+		 * answer is a wait: either a real deadline, or the synthetic
+		 * one that keeps the announce range covered.
 		 */
-		if (t <= INT32_MAX) {
-			ret = (int32_t)t;
+		if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
+		    z_timeout_q_next_expiry() == K_TICKS_FOREVER) {
+			ret = (uint32_t)K_TICKS_FOREVER;
+		} else {
+			ret = next_timeout(elapsed());
 		}
 	}
 	return ret;

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -138,35 +138,37 @@ static uint32_t next_timeout(uint32_t ticks_elapsed)
 	}
 
 	/*
-	 * With nothing pending under sloppy idle, report SYS_CLOCK_MAX_WAIT
-	 * verbatim (not the budget): it is the "no deadline" value a driver
-	 * looks for to stop the clock entirely, and a skewed uptime is
-	 * acceptable. Without sloppy idle the uptime must stay correct, so
-	 * respect the budget and keep waking up.
+	 * No deadline, or one further out than can be scheduled in a single
+	 * step: wait the capped budget and re-evaluate at the next announce.
+	 * Testing next (which may be 64-bit) against the cap keeps the
+	 * remaining arithmetic in 32 bits. The empty case still returns the
+	 * budget so a driver keeps waking to maintain uptime.
 	 */
-	if (next == K_TICKS_FOREVER) {
-		if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE)) {
-			return SYS_CLOCK_MAX_WAIT;
-		}
+	if (next == K_TICKS_FOREVER || next >= SYS_CLOCK_MAX_WAIT) {
 		return SYS_CLOCK_MAX_WAIT - ticks_elapsed;
-	}
-
-	/*
-	 * A timeout further out than can be scheduled in one step: wait nearly
-	 * the whole budget, but stop one short of SYS_CLOCK_MAX_WAIT so it is
-	 * never mistaken for the "no deadline" value above (which would drop
-	 * the timeout under sloppy idle); an intermediate announce re-evaluates.
-	 * Testing next (which may be 64-bit) against the cap also keeps the
-	 * remaining arithmetic in 32 bits.
-	 */
-	if (next >= SYS_CLOCK_MAX_WAIT) {
-		return SYS_CLOCK_MAX_WAIT - 1 - ticks_elapsed;
 	}
 
 	/* Otherwise wait until the timeout, relative to now (0 if due). */
 	dticks = (uint32_t)next;
 
 	return (dticks > ticks_elapsed) ? (dticks - ticks_elapsed) : 0;
+}
+
+/*
+ * Reprogram the timer for the next pending timeout, or, when nothing is
+ * pending and CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE tolerates a drifting uptime, tell
+ * the driver its clock is unused so it may stop. Only meaningful where the
+ * timeout queue may have just drained (abort, end of announce); the add path
+ * always has a pending timeout and calls sys_clock_set_timeout() directly.
+ */
+static void reprogram_next(uint32_t ticks_elapsed)
+{
+	if (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) &&
+	    z_timeout_q_next_expiry() == K_TICKS_FOREVER) {
+		sys_clock_no_timeout();
+	} else {
+		sys_clock_set_timeout(next_timeout(ticks_elapsed), false);
+	}
 }
 
 k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t timeout)
@@ -242,7 +244,7 @@ int z_try_abort_timeout(struct _timeout *to)
 
 			ret = 0;
 			if (was_first) {
-				sys_clock_set_timeout(next_timeout(elapsed()), false);
+				reprogram_next(elapsed());
 			}
 		} else if (IS_ENABLED(CONFIG_SMP) && inflight_ptr() == to &&
 			   !this_cpu_announcing()) {
@@ -396,7 +398,7 @@ void sys_clock_announce_locked(uint32_t ticks, k_spinlock_key_t key)
 
 	announcing_cpu = -1;
 
-	sys_clock_set_timeout(next_timeout(0), false);
+	reprogram_next(0);
 
 	k_spin_unlock(&timeout_lock, key);
 

--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -218,7 +218,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		{
 			k_spinlock_key_t key = sys_clock_lock();
 
-			sys_clock_set_timeout(0, true);
+			sys_clock_idle_enter(0);
 			sys_clock_unlock(key);
 		}
 
@@ -239,7 +239,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 				{
 					k_spinlock_key_t key = sys_clock_lock();
 
-					sys_clock_set_timeout(0, true);
+					sys_clock_idle_enter(0);
 					sys_clock_unlock(key);
 				}
 				/* GDET got enabled when exiting PM3, disable it

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -201,18 +201,19 @@ bool pm_system_suspend(int32_t kernel_ticks)
 #endif
 
 	exit_latency_ticks = EXIT_LATENCY_US_TO_TICKS(z_cpus_pm_state[id]->exit_latency_us);
-	if ((exit_latency_ticks > 0) && (ticks != K_TICKS_FOREVER)) {
+	if ((ticks == K_TICKS_FOREVER) || (exit_latency_ticks > 0)) {
 		/*
-		 * We need to set the timer to interrupt a little bit early to
-		 * accommodate the time required by the CPU to fully wake up.
-		 *
-		 * Since K_TICKS_FOREVER is defined as -1, ensure that -1
-		 * is not passed as the next timeout.
-		 *
+		 * Nothing to wake up for is handed over as is, so a driver able
+		 * to stop its clock outright can do so; recovery is
+		 * sys_clock_idle_exit(). A real deadline is brought forward to
+		 * accommodate the time the CPU needs to fully wake up.
 		 */
+		uint32_t idle_ticks = (ticks == K_TICKS_FOREVER)
+			? (uint32_t)K_TICKS_FOREVER
+			: (uint32_t)MAX(0, (int64_t)ticks - (int64_t)exit_latency_ticks);
 		k_spinlock_key_t key = sys_clock_lock();
 
-		sys_clock_set_timeout(MAX(0, (int64_t)ticks - (int64_t)exit_latency_ticks), true);
+		sys_clock_idle_enter(idle_ticks);
 		sys_clock_unlock(key);
 	}
 

--- a/tests/kernel/timer/timer_api/Kconfig
+++ b/tests/kernel/timer/timer_api/Kconfig
@@ -4,4 +4,13 @@
 config SYS_CLOCK_TICKS_PER_SEC
 	default 16384 if NRF_RTC_TIMER && TICKLESS_KERNEL
 
+config TEST_PROVIDE_PM_HOOKS
+	bool "Provide the PM hooks this test needs"
+	select HAS_PM
+	select PM_STATE_SET_IRQ_UNLOCKED
+	help
+	  CONFIG_PM needs HAS_PM, which only SoCs implementing low-power states
+	  select. src/pm_hooks.c supplies the two required hooks so the PM idle
+	  path can be exercised anywhere.
+
 source "Kconfig.zephyr"

--- a/tests/kernel/timer/timer_api/pm.overlay
+++ b/tests/kernel/timer/timer_api/pm.overlay
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Minimal power state so CONFIG_PM has something to enter. The point is to
+ * reach sys_clock_idle_enter() and sys_clock_idle_exit(), not to emulate a
+ * real low-power mode.
+ */
+
+/ {
+	cpus {
+		power-states {
+			idle_state: idle-state {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				min-residency-us = <0>;
+			};
+		};
+	};
+};
+
+&{/cpus/cpu@0} {
+	cpu-power-states = <&idle_state>;
+};

--- a/tests/kernel/timer/timer_api/src/pm_hooks.c
+++ b/tests/kernel/timer/timer_api/src/pm_hooks.c
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#ifdef CONFIG_PM
+
+#include <zephyr/pm/pm.h>
+
+/*
+ * CONFIG_PM needs an SoC to implement these two hooks, and only SoCs with real
+ * low-power states do. This test wants the PM idle path, not a low-power mode,
+ * so pm_state_set() just waits for the next interrupt the way an ordinary idle
+ * would. That is enough to reach sys_clock_idle_enter() and, on the way out,
+ * sys_clock_idle_exit().
+ *
+ * k_cpu_idle() returns with interrupts unlocked, hence
+ * CONFIG_PM_STATE_SET_IRQ_UNLOCKED in the test configuration.
+ */
+void pm_state_set(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+
+	k_cpu_idle();
+}
+
+void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+}
+
+#endif /* CONFIG_PM */

--- a/tests/kernel/timer/timer_api/tests.yaml
+++ b/tests/kernel/timer/timer_api/tests.yaml
@@ -4,6 +4,41 @@ tests:
       - kernel
       - timer
       - userspace
+  kernel.timer.sloppy_idle:
+    tags:
+      - kernel
+      - timer
+    # No board enables CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE, so this variant is
+    # what exercises sys_clock_no_timeout(). The platforms below cover both a
+    # driver implementing the hook and one leaving it to the default.
+    platform_allow:
+      - native_sim
+      - qemu_cortex_m3
+      - qemu_x86
+      - qemu_arc/qemu_arc_em
+      - qemu_riscv32
+    integration_platforms:
+      - native_sim
+    extra_configs:
+      - CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE=y
+  kernel.timer.sloppy_idle_pm:
+    tags:
+      - kernel
+      - timer
+    # sys_clock_idle_enter() is only reached from the PM idle path, so this is
+    # the variant that covers the driver stopping its clock there and
+    # sys_clock_idle_exit() bringing it back.
+    platform_allow:
+      - qemu_cortex_m3
+      - native_sim
+    integration_platforms:
+      - qemu_cortex_m3
+    extra_args:
+      - DTC_OVERLAY_FILE=pm.overlay
+    extra_configs:
+      - CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE=y
+      - CONFIG_TEST_PROVIDE_PM_HOOKS=y
+      - CONFIG_PM=y
   kernel.timer.no_multitheading:
     tags:
       - kernel


### PR DESCRIPTION
Two different conditions are signalled to a timer driver today by overloading the arguments of `sys_clock_set_timeout()`: a magic tick value meaning "no timeout is pending", and a `bool idle` meaning "the CPU is about to sleep". Every driver has to recognise both in the middle of programming a deadline. This series gives each condition its own entry point.

It is one step in a wider cleanup of tick handling. Every tickless driver reimplements the same tick and cycle accounting by hand, and each copy carries its own subtle bugs: deadlines that round the wrong way, compare values that are never corrected once the kernel stops asking, counters stopped in states their author never anticipated. Several such bugs surfaced while preparing this series and are fixed by it. The goal is to factor that accounting into shared code, and that is only possible once the tick contract carries no special values left for a driver to reinterpret, and once "nothing is pending" and "we are going to sleep" are decisions the core makes rather than each driver inferring them from a tick count.

There are four states, and they call for different answers:

|  | nothing pending | something pending |
|---|---|---|
| **running** | `sys_clock_unused()` | `sys_clock_set_timeout(ticks)` |
| **idle** | `sys_clock_idle_enter(K_TICKS_FOREVER)` | `sys_clock_idle_enter(ticks)` |

Without `CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE` the left column never arises: the kernel keeps a synthetic deadline armed so the uptime stays exact, and a driver only ever sees the right one.

The constraint on `sys_clock_unused()` is not what may be stopped, but what must keep answering. The CPU is still running there, so `sys_clock_cycle_get_32()` has to go on working, since a thread can reach it through `k_busy_wait()`. A driver whose cycle counter shares that clock is limited to masking its wakeups or stretching its interval to the longest the hardware holds; one whose counter lives in another clock or power domain may stop more. Stopping outright belongs to `sys_clock_idle_enter()`, where nothing remains to read the counter and `sys_clock_idle_exit()` is guaranteed to follow.

That distinction is what was missing, and six drivers stopped their time base as soon as the timeout queue drained, which is not the same as going idle. `k_cycle_get_32()` and `k_busy_wait()` could then be left standing still under a running thread, and on four of them nothing restarted the clock at all, so a timeout scheduled afterwards could never fire. With the option enabled, `kernel.timer` hangs on its first test case on qemu_cortex_m3, qemu_x86 and qemu_arc on current main.

The kernel keeps both decisions in the same shape: `reprogram_next()` chooses between `sys_clock_unused()` and a wait for a running system, and `pm_system_suspend()` makes the same choice for a sleeping one. `z_get_next_timeout_expiry()`, which is internal and has a single caller, now carries that logic and reports `K_TICKS_FOREVER` only when there is genuinely nothing to wake for, so a far future deadline can never be mistaken for it.

A driver that has not migrated keeps working unchanged, since the two hooks' default implementations forward the old signals, the magic tick value and the `idle` argument respectively. Both are deprecated with the usual notice. Every in-tree driver is converted here.

Independent evidence: the driver contract tests proposed in #115147, written without this series in view, fail 0 of 4 on qemu_x86 and qemu_cortex_m3 on main with sloppy idle enabled, and pass 12 of 12 on this branch. Since no board enables the option, which is how this went unnoticed, a `kernel.timer` variant that turns it on closes the series.

This supersedes #114908, whose idle-entry work is folded in. Keeping the two apart forced every affected driver to carry a flag remembering which condition it had last been told about, which is precisely the per-driver cleverness the series exists to remove.

Three of the converted drivers, the Microchip XEC and Realtek RTS5912 RTOS timers and the STM32 LPTIM, have no emulated platform and are build-tested only.
