### PR TITLE
timer: introduce sys_clock_idle_enter() for the low-power idle handoff

### DIFF
--- a/doc/kernel/services/timing/clocks.rst
+++ b/doc/kernel/services/timing/clocks.rst
@@ -265,6 +265,18 @@ comparatively simple API.
   :c:func:`sys_clock_announce`, which the kernel needs to test newly
   arriving timeouts for expiration.
 
+* The driver may optionally provide a :c:func:`sys_clock_idle_enter` call,
+  which the power-management path uses in place of
+  :c:func:`sys_clock_set_timeout` when the CPU is about to enter low-power
+  idle, passing the number of ticks until the next expected wakeup.  A driver
+  that can hand off to a low-power wakeup timer (or otherwise reconfigure for
+  sleep) does so here; recovery happens in :c:func:`sys_clock_idle_exit`.  The
+  default implementation programs the wakeup through
+  :c:func:`sys_clock_set_timeout` with its deprecated ``idle`` argument set to
+  ``true``, so a driver that still keys its low-power handling on that argument
+  keeps working, and a driver with no low-power handling needs no
+  implementation.
+
 Timer Driver Locking
 --------------------
 

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -713,6 +713,14 @@ Syscon
 Timer
 =====
 
+* The ``bool idle`` argument of :c:func:`sys_clock_set_timeout` is deprecated; the
+  low-power idle hint moved to the new weak :c:func:`sys_clock_idle_enter` hook. The
+  kernel now always passes ``false``, except that the default
+  :c:func:`sys_clock_idle_enter` forwards the idle entry as ``true``, so an out-of-tree
+  timer driver keying on the argument keeps working unchanged. Such drivers should move
+  their ``idle``-specific handling to :c:func:`sys_clock_idle_enter`; the argument will
+  be removed in a future release (:github:`114908`).
+
 * :c:func:`sys_clock_set_timeout`, :c:func:`sys_clock_announce` and
   :c:func:`sys_clock_announce_locked` now take their tick count as an unsigned
   ``uint32_t`` rather than a signed ``int32_t``. Out-of-tree system timer drivers must

--- a/doc/releases/release-notes-4.5.rst
+++ b/doc/releases/release-notes-4.5.rst
@@ -163,6 +163,14 @@ Deprecated APIs and options
   * Deprecated :kconfig:option:`CONFIG_NET_L2_PTP`.
     Used :kconfig:option:`CONFIG_NET_L2_PTP_TIMESTAMPING` instead.
 
+* Timer
+
+  * The ``bool idle`` argument of :c:func:`sys_clock_set_timeout` is deprecated: the
+    low-power idle hint moved to the new weak :c:func:`sys_clock_idle_enter` hook and
+    the kernel now always passes ``false`` (the default
+    :c:func:`sys_clock_idle_enter` forwards ``true`` for drivers that have not
+    migrated).
+
 * Video
 
   * All functions in the video driver API (``<zephyr/drivers/video.h>``) have moved to the video

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -325,6 +325,15 @@ ARCH_ISR_DIAG_ON
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
+#if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
+	/* Idle entry comes through sys_clock_idle_enter(), so this deprecated
+	 * argument must never be set here. Catch a stale caller until it goes.
+	 */
+	__ASSERT_NO_MSG(!idle);
+#else
+	ARG_UNUSED(idle);
+#endif
+
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
 	/* Fast CPUs and a 24 bit counter mean that even idle systems
@@ -338,52 +347,6 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 		last_load = TIMER_STOPPED;
 		return;
 	}
-
-#if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
-	if (idle) {
-		uint64_t timeout_us =
-			((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-		timeout_idle = true;
-
-		/**
-		 * Invoke platform-specific layer to configure LPTIM
-		 * such that system wakes up after timeout elapses.
-		 */
-		z_sys_clock_lpm_enter(timeout_us);
-
-#if !defined(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)
-		/* Store current value of SysTick counter to be able to
-		 * calculate a difference in measurements after exiting
-		 * the low-power state.
-		 */
-		cycle_pre_idle = cycle_count + elapsed(NULL);
-#else /* CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
-		/**
-		 * SysTick will be placed under reset once we enter
-		 * low-power mode. Turn it off right now then update
-		 * the cycle counter now, since we won't be able to
-		 * to it after waking up.
-		 */
-		sys_clock_disable();
-		/* Ensure the SysTick interrupt is not pending. This is safe
-		 * as we just did the ISR's job, and MUST be done because
-		 * a pending interrupt could inhibit low-power mode entry.
-		 * Note: On Armv8-M, ICSR.STTNS is R/W, so preserve it while
-		 * writing the write-1-to-clear PENDSTCLR bit.
-		 */
-#ifdef SCB_ICSR_STTNS_Msk
-		SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
-#else
-		SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
-#endif
-
-		cycle_count += elapsed(NULL);
-		overflow_cyc = 0;
-#endif /* !CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
-		return;
-	}
-#endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 
 #if defined(CONFIG_TICKLESS_KERNEL)
 	/*
@@ -524,6 +487,52 @@ uint64_t sys_clock_cycle_get_64(void)
 	return ret;
 }
 #endif
+
+#if !defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE)
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	uint64_t timeout_us =
+		((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+
+	timeout_idle = true;
+
+	/**
+	 * Invoke platform-specific layer to configure LPTIM
+	 * such that system wakes up after timeout elapses.
+	 */
+	z_sys_clock_lpm_enter(timeout_us);
+
+#if !defined(CONFIG_SYSTEM_TIMER_RESET_BY_LPM)
+	/* Store current value of SysTick counter to be able to
+	 * calculate a difference in measurements after exiting
+	 * the low-power state.
+	 */
+	cycle_pre_idle = cycle_count + elapsed(NULL);
+#else /* CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
+	/**
+	 * SysTick will be placed under reset once we enter
+	 * low-power mode. Turn it off right now then update
+	 * the cycle counter now, since we won't be able to
+	 * to it after waking up.
+	 */
+	sys_clock_disable();
+	/* Ensure the SysTick interrupt is not pending. This is safe
+	 * as we just did the ISR's job, and MUST be done because
+	 * a pending interrupt could inhibit low-power mode entry.
+	 * Note: On Armv8-M, ICSR.STTNS is R/W, so preserve it while
+	 * writing the write-1-to-clear PENDSTCLR bit.
+	 */
+#ifdef SCB_ICSR_STTNS_Msk
+	SCB->ICSR = (SCB->ICSR & SCB_ICSR_STTNS_Msk) | SCB_ICSR_PENDSTCLR_Msk;
+#else
+	SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
+#endif
+
+	cycle_count += elapsed(NULL);
+	overflow_cyc = 0;
+#endif /* !CONFIG_SYSTEM_TIMER_RESET_BY_LPM */
+}
+#endif /* !CONFIG_SYSTEM_TIMER_LPM_COMPANION_NONE */
 
 void sys_clock_idle_exit(void)
 {

--- a/drivers/timer/esp32_sys_timer.c
+++ b/drivers/timer/esp32_sys_timer.c
@@ -99,6 +99,15 @@ static void IRAM_ATTR sys_timer_isr(void *arg)
 
 void sys_clock_set_timeout(uint32_t ticks, bool idle)
 {
+#if defined(CONFIG_PM)
+	/* Idle entry comes through sys_clock_idle_enter(), so this deprecated
+	 * argument must never be set here. Catch a stale caller until it goes.
+	 */
+	__ASSERT_NO_MSG(!idle);
+#else
+	ARG_UNUSED(idle);
+#endif
+
 #if defined(CONFIG_TICKLESS_KERNEL)
 	if (systimer_hal.dev == NULL) {
 		return;
@@ -125,22 +134,32 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 
 	set_systimer_alarm(cyc + last_count);
 
-#if defined(CONFIG_PM)
-	if (idle) {
-		uint64_t timeout_us =
-			((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-		lptim_pre_idle = esp32_lptim_hook_on_lpm_entry(timeout_us);
-		systimer_pre_idle = get_systimer_alarm();
-		timeout_idle = true;
-	}
-#else
-	ARG_UNUSED(idle);
-#endif
-
 	k_spin_unlock(&lock, key);
+#else
+	ARG_UNUSED(ticks);
 #endif
 }
+
+#if defined(CONFIG_PM)
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	sys_clock_set_timeout(ticks, false);
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL) || systimer_hal.dev == NULL) {
+		return;
+	}
+
+	/* Same tick count sys_clock_set_timeout() programmed the systimer with
+	 * above, so the low-power timer is armed for the same deadline.
+	 */
+	uint32_t lp_ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
+	uint64_t timeout_us = ((uint64_t)lp_ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+
+	lptim_pre_idle = esp32_lptim_hook_on_lpm_entry(timeout_us);
+	systimer_pre_idle = get_systimer_alarm();
+	timeout_idle = true;
+}
+#endif
 
 uint32_t sys_clock_elapsed(void)
 {

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -244,28 +244,38 @@ bool z_nxp_os_timer_ignore_timer_wakeup(void)
 	return (wait_forever || counter_remaining_ticks);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+void sys_clock_idle_enter(uint32_t ticks)
 {
-	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
-		/* Only for tickless kernel system */
-		return;
-	}
-
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
-	/* We intercept calls from idle with a 0 tick count when PM=y */
-	if (idle && (ticks == 0)) {
+	/* We intercept idle entry with a 0 tick count when PM=y */
+	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && (ticks == 0)) {
 		mcux_os_timer_set_lp_counter_timeout();
 		/* A low power counter has been started. No need to
 		 * go further, simply return
 		 */
 		return;
 	}
+#endif
+	sys_clock_set_timeout(ticks, false);
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	/* Idle entry comes through sys_clock_idle_enter(), so this deprecated
+	 * argument must never be set here. Catch a stale caller until it goes.
+	 */
+	__ASSERT_NO_MSG(!idle);
+
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
+		/* Only for tickless kernel system */
+		return;
+	}
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(standby)) && CONFIG_PM
 	/* When using a counter for certain low power modes, set this flag when the requested
 	 * delay is forever. This is to keep track of wakeup sources in case of counter overflows.
 	 */
 	wait_forever = (ticks == SYS_CLOCK_MAX_WAIT);
-#else
-	ARG_UNUSED(idle);
 #endif
 	ticks = CLAMP(ticks, 1, MAX_TICKS) - 1;
 

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -315,67 +315,11 @@ static inline uint32_t z_clock_lptim_getcounter(void)
 	return lp_time;
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+static void lptim_set_timeout(uint32_t ticks)
 {
 	/* new LPTIM AutoReload value to set (aligned on Kernel ticks) */
 	uint32_t next_arr = 0;
 	int err;
-
-	ARG_UNUSED(idle);
-
-#ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
-	const struct pm_state_info *next;
-
-	next = pm_policy_next_state(_current_cpu->id, ticks);
-
-	/* Check if STANBY or STOP3 is requested */
-	timeout_stdby = false;
-	if ((next != NULL) && idle) {
-#ifdef CONFIG_PM_S2RAM
-		if (next->state == PM_STATE_SUSPEND_TO_RAM) {
-			timeout_stdby = true;
-		}
-#endif
-#ifdef CONFIG_STM32_STOP3_LP_MODE
-		if ((next->state == PM_STATE_SUSPEND_TO_IDLE) && (next->substate_id == 4)) {
-			timeout_stdby = true;
-		}
-#endif
-	}
-
-	if (timeout_stdby) {
-		uint64_t timeout_us =
-			((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
-
-		struct counter_alarm_cfg cfg = {
-			.callback = NULL,
-			.ticks = counter_us_to_ticks(stdby_timer, timeout_us),
-			.user_data = NULL,
-			.flags = 0,
-		};
-
-		/* Set the alarm using timer that runs the standby.
-		 * Needed rump-up/setting time, lower accurency etc. should be
-		 * included in the exit-latency in the power state definition.
-		 */
-		counter_cancel_channel_alarm(stdby_timer, 0);
-		counter_set_channel_alarm(stdby_timer, 0, &cfg);
-
-		/* Store current values to calculate a difference in
-		 * measurements after exiting the standby state.
-		 */
-		counter_get_value(stdby_timer, &stdby_timer_pre_stdby);
-		lptim_cnt_pre_stdby = z_clock_lptim_getcounter();
-
-		LL_LPTIM_DisableIT_ARROK(LPTIM);
-		LL_LPTIM_ClearFlag_ARROK(LPTIM);
-		NVIC_ClearPendingIRQ(DT_IRQN(LPTIM_SYSTIMER_NODE));
-		/* Stop clocks for LPTIM, since RTC is used instead */
-		clock_control_off(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
-
-		return;
-	}
-#endif /* CONFIG_STM32_LPTIM_STDBY_TIMER */
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
@@ -456,6 +400,79 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	lptim_set_autoreload(next_arr);
 
 	k_spin_unlock(&lock, key);
+}
+
+void sys_clock_idle_enter(uint32_t ticks)
+{
+#ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
+	const struct pm_state_info *next;
+
+	next = pm_policy_next_state(_current_cpu->id, ticks);
+
+	/* Check if STANBY or STOP3 is requested */
+	timeout_stdby = false;
+	if (next != NULL) {
+#ifdef CONFIG_PM_S2RAM
+		if (next->state == PM_STATE_SUSPEND_TO_RAM) {
+			timeout_stdby = true;
+		}
+#endif
+#ifdef CONFIG_STM32_STOP3_LP_MODE
+		if ((next->state == PM_STATE_SUSPEND_TO_IDLE) && (next->substate_id == 4)) {
+			timeout_stdby = true;
+		}
+#endif
+	}
+
+	if (timeout_stdby) {
+		uint64_t timeout_us =
+			((uint64_t)ticks * USEC_PER_SEC) / CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+
+		struct counter_alarm_cfg cfg = {
+			.callback = NULL,
+			.ticks = counter_us_to_ticks(stdby_timer, timeout_us),
+			.user_data = NULL,
+			.flags = 0,
+		};
+
+		/* Set the alarm using timer that runs the standby.
+		 * Needed rump-up/setting time, lower accurency etc. should be
+		 * included in the exit-latency in the power state definition.
+		 */
+		counter_cancel_channel_alarm(stdby_timer, 0);
+		counter_set_channel_alarm(stdby_timer, 0, &cfg);
+
+		/* Store current values to calculate a difference in
+		 * measurements after exiting the standby state.
+		 */
+		counter_get_value(stdby_timer, &stdby_timer_pre_stdby);
+		lptim_cnt_pre_stdby = z_clock_lptim_getcounter();
+
+		LL_LPTIM_DisableIT_ARROK(LPTIM);
+		LL_LPTIM_ClearFlag_ARROK(LPTIM);
+		NVIC_ClearPendingIRQ(DT_IRQN(LPTIM_SYSTIMER_NODE));
+		/* Stop clocks for LPTIM, since RTC is used instead */
+		clock_control_off(clk_ctrl, (clock_control_subsys_t) &lptim_clk[0]);
+
+		return;
+	}
+#endif /* CONFIG_STM32_LPTIM_STDBY_TIMER */
+
+	lptim_set_timeout(ticks);
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	/* Idle entry comes through sys_clock_idle_enter(), so this deprecated
+	 * argument must never be set here. Catch a stale caller until it goes.
+	 */
+	__ASSERT_NO_MSG(!idle);
+
+#ifdef CONFIG_STM32_LPTIM_STDBY_TIMER
+	timeout_stdby = false;
+#endif
+
+	lptim_set_timeout(ticks);
 }
 
 static uint32_t sys_clock_lp_time_get(void)

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -25,3 +25,14 @@ void __weak sys_clock_set_timeout(uint32_t ticks, bool idle)
 void __weak sys_clock_idle_exit(void)
 {
 }
+
+void __weak sys_clock_idle_enter(uint32_t ticks)
+{
+	/* A driver that does not implement this hook may still key its
+	 * low-power handling on sys_clock_set_timeout()'s idle argument, so
+	 * pass true here. That argument is deprecated in favour of
+	 * implementing this hook, and carries no information for a driver
+	 * that does.
+	 */
+	sys_clock_set_timeout(ticks, true);
+}

--- a/drivers/timer/xtensa_sys_timer.c
+++ b/drivers/timer/xtensa_sys_timer.c
@@ -85,7 +85,7 @@ static void ccompare_isr(const void *arg)
 	sys_clock_announce_locked(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ? dticks : 1, key);
 }
 
-void sys_clock_set_timeout(uint32_t ticks, bool idle)
+static void set_timeout(uint32_t ticks, bool idle)
 {
 	__ASSERT(sys_clock_is_locked(), "system clock lock not held");
 
@@ -125,6 +125,20 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	}
 
 #endif
+}
+
+void sys_clock_set_timeout(uint32_t ticks, bool idle)
+{
+	/* Idle entry comes through sys_clock_idle_enter(), so this deprecated
+	 * argument must never be set here. Catch a stale caller until it goes.
+	 */
+	__ASSERT_NO_MSG(!idle);
+	set_timeout(ticks, false);
+}
+
+void sys_clock_idle_enter(uint32_t ticks)
+{
+	set_timeout(ticks, true);
 }
 
 uint32_t sys_clock_elapsed(void)

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -174,8 +174,12 @@ bool sys_clock_is_locked(void);
  * lock held.
  *
  * @param ticks Timeout in tick units
- * @param idle Hint to the driver that the system is about to enter
- *        the idle state immediately after setting the timeout
+ * @param idle Deprecated, and always false when the kernel calls this
+ *        function: idle entry is notified through sys_clock_idle_enter(),
+ *        whose default implementation passes true here so that a driver
+ *        keying its low-power handling on this argument still works. Retained
+ *        for source compatibility and scheduled for removal in a future
+ *        release; new code must ignore it.
  */
 void sys_clock_set_timeout(uint32_t ticks, bool idle);
 
@@ -251,6 +255,22 @@ uint32_t sys_clock_elapsed(void);
  * check if the system timer has the capability of being disabled.
  */
 void sys_clock_disable(void);
+
+/**
+ * @brief Notify the timer driver that the CPU is entering low-power idle.
+ *
+ * Called by the power-management / idle path when the CPU is about to be put
+ * to sleep, with @p ticks until the next expected wakeup. A driver that can
+ * hand off to a low-power wakeup timer (or otherwise reconfigure for sleep)
+ * does so here. The default implementation programs the wakeup through
+ * sys_clock_set_timeout() with its deprecated idle argument set to true, which
+ * keeps a driver that keys its low-power handling on that argument working; a
+ * driver with no low-power handling needs no implementation at all. Recovery
+ * happens in sys_clock_idle_exit().
+ *
+ * @param ticks Ticks until the next expected wakeup.
+ */
+void sys_clock_idle_enter(uint32_t ticks);
 
 /**
  * @brief Hardware cycle counter

--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -216,7 +216,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		{
 			k_spinlock_key_t key = sys_clock_lock();
 
-			sys_clock_set_timeout(0, true);
+			sys_clock_idle_enter(0);
 			sys_clock_unlock(key);
 		}
 
@@ -237,7 +237,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 				{
 					k_spinlock_key_t key = sys_clock_lock();
 
-					sys_clock_set_timeout(0, true);
+					sys_clock_idle_enter(0);
 					sys_clock_unlock(key);
 				}
 				/* GDET got enabled when exiting PM3, disable it

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -212,7 +212,7 @@ bool pm_system_suspend(int32_t kernel_ticks)
 		 */
 		k_spinlock_key_t key = sys_clock_lock();
 
-		sys_clock_set_timeout(MAX(0, (int64_t)ticks - (int64_t)exit_latency_ticks), true);
+		sys_clock_idle_enter(MAX(0, (int64_t)ticks - (int64_t)exit_latency_ticks));
 		sys_clock_unlock(key);
 	}
 


### PR DESCRIPTION
The power-management idle path tells the timer driver that the CPU is about to be put to sleep by setting the `bool idle` argument of `sys_clock_set_timeout()`. The argument is part of every driver's signature, but only the few that can hand off to a low-power wakeup timer ever look at it, and those have to overload their ordinary timeout programming with sleep preparation. This series gives that notification its own interface: a weak `sys_clock_idle_enter(ticks)` hook the power-management path calls instead, so the drivers that care get a proper entry point and the kernel's own timeout programming carries no hint at all.

It is also a prerequisite for the wider refactoring to come where the tick accounting that tickless drivers reimplement by hand is factored into shared code, which requires a tick contract whose arguments no driver reinterprets.

Out-of-tree drivers keep working unchanged: the default `sys_clock_idle_enter()` forwards to `sys_clock_set_timeout()` with the argument set, so a driver that keys its low-power handling on it behaves exactly as before, and one with no low-power handling needs no implementation at all. The argument is deprecated in favour of the hook, and the kernel itself now always passes false; that is spelled out in its doxygen and recorded in the migration guide and release notes.

The in-tree drivers that acted on it are converted here, one commit each, so nothing in tree reads the argument any more. Each conversion is behaviour-preserving and deliberately mechanical; the commit messages carry the per-driver reasoning. The converted drivers now assert the argument is clear, which documents the invariant and catches any straggler until the argument is removed.