### PR TITLE
modules: hostap: handle the default MFP setting in get_mfp()

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1518,6 +1518,17 @@ int supplicant_disconnect(const struct device *dev __unused, struct net_if *ifac
 
 enum wifi_mfp_options get_mfp(enum mfp_options supp_mfp_option)
 {
+	/*
+	 * MGMT_FRAME_PROTECTION_DEFAULT is not an enum mfp_options member, so
+	 * it has to be checked before the switch. It marks a network with no
+	 * explicit ieee80211w setting, whose effective value is only known
+	 * after resolving it against the global "pmf" setting, the key
+	 * management and the driver capabilities (see wpas_get_ssid_pmf()).
+	 */
+	if (supp_mfp_option == MGMT_FRAME_PROTECTION_DEFAULT) {
+		return WIFI_MFP_UNKNOWN;
+	}
+
 	switch (supp_mfp_option) {
 	case NO_MGMT_FRAME_PROTECTION:
 		return WIFI_MFP_DISABLE;
@@ -1622,7 +1633,12 @@ int supplicant_status(const struct device *dev __unused, struct net_if *iface,
 			}
 		}
 #endif
-		status->mfp = get_mfp(ssid->ieee80211w);
+		/*
+		 * Resolve a network without an explicit ieee80211w setting
+		 * (MGMT_FRAME_PROTECTION_DEFAULT) the same way the supplicant
+		 * does when associating.
+		 */
+		status->mfp = get_mfp(wpas_get_ssid_pmf(wpa_s, ssid));
 		ieee80211_freq_to_chan(wpa_s->assoc_freq, &channel);
 		status->channel = channel;
 


### PR DESCRIPTION
`wpa_ssid::ieee80211w` is initialized to `MGMT_FRAME_PROTECTION_DEFAULT` (3),
which is a `#define` rather than an `enum mfp_options` member, and it keeps
that value whenever the network has no explicit `ieee80211w` setting.
`supplicant_connect()` only issues `set_network <id> ieee80211w` when a
non-zero MFP level is requested, so a plain open or WPA2-PSK connection
leaves the default in place.

`get_mfp()` had no handling for that value, so every status query on such a
connection took the switch default: it logged a bogus
`Invalid mfp mapping 3` error and reported `WIFI_MFP_DISABLE`.

Changes:

* Handle the value explicitly in `get_mfp()` and map it to
  `WIFI_MFP_UNKNOWN`, since the effective level cannot be derived from the
  network block alone. The check sits before the `switch` because a `case`
  label outside `enum mfp_options` triggers
  `-Wswitch` (`case value '3' not in enumerated type 'enum mfp_options'`).
* Resolve the value in `supplicant_status()` via `wpas_get_ssid_pmf()`,
  which applies the same global `pmf`, key-management and driver-capability
  (BIP) rules the supplicant uses when associating. `WIFI_MFP_UNKNOWN`
  therefore stays a fallback rather than the normal answer: an open
  connection now reports `Disable`, and a PSK connection under `pmf=1`
  reports `Optional`.

The AP-side caller (`hapd_api.c`, `bss->ieee80211w`) needs no change,
as hostapd's config path never leaves 3 there.

Testing:

* `samples/net/wifi/shell` builds clean for `native_sim/native/64`, with no
  new warnings from `supp_api.c`.
* Runtime coverage was not run locally (`mac80211_hwsim` is not available in
  this environment); `tests/drivers/wifi/hwsim` exercises the affected path,
  as its open-AP case connects with `mfp = WIFI_MFP_DISABLE`, i.e. exactly
  the connect that leaves `ieee80211w` at the default.
