### PR TITLE
llext: unify xtensa linking (wip)

### DIFF
--- a/doc/services/llext/config.rst
+++ b/doc/services/llext/config.rst
@@ -321,12 +321,6 @@ LLEXT subsystem to optimize memory footprint in this case.
            phase. Once the extension is unloaded, the buffer must be reloaded
            before it can be used again in a call to :c:func:`llext_load`.
 
-        .. note::
-
-           This is currently required by the Xtensa architecture. Further
-           information on this topic is available on GitHub issue `#75341
-           <https://github.com/zephyrproject-rtos/zephyr/issues/75341>`_.
-
 .. _llext_symbol_groups:
 
 Symbol Groups

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -125,9 +125,6 @@ struct llext {
 	/** Lookup table of memory regions */
 	void *mem[LLEXT_MEM_COUNT];
 
-	/** Address of text region in ELF buffer */
-	void *text_in_elf;
-
 	/** Is the memory for this region allocated on heap? */
 	bool mem_on_heap[LLEXT_MEM_COUNT];
 

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -165,7 +165,6 @@ config LLEXT_SHELL_MAX_SIZE
 
 config LLEXT_STORAGE_WRITABLE
 	bool "llext storage is writable"
-	default y if XTENSA
 	help
 	  Select if LLEXT storage is writable, i.e. if extensions are stored in
 	  RAM and can be modified in place

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -356,6 +356,8 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 				   ldr->sects[LLEXT_MEM_TEXT].sh_offset;
 		}
 
+		rel_addr = rel_addr;
+
 		if (tgt) {
 			/* Relocatable / partially linked ELF. */
 			if (rela.r_offset >= tgt->sh_size) {

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -47,6 +47,45 @@ __weak int arch_elf_relocate_global(struct llext_loader *ldr, struct llext *ext,
 }
 
 /*
+ * Resolve addresses within the copied / merged memory regions tracked by
+ * ext->mem[] and ldr->sect_map
+ */
+static uint8_t *llext_file_offset_to_addr(struct llext_loader *ldr, struct llext *ext,
+					  ssize_t offset)
+{
+	for (int i = 0; i < ext->sect_cnt; ++i) {
+		elf_shdr_t *shdr = ext->sect_hdrs + i;
+		enum llext_mem mem_idx = ldr->sect_map[i].mem_idx;
+
+		/*
+		 * Skip anything we cannot address: SHT_NOBITS sections occupy
+		 * no space in the file, so their [sh_offset, sh_offset + sh_size)
+		 * range overlaps that of the following section; and sections that
+		 * were never assigned a mem_idx (e.g. TLS sections) have no address in
+		 * ext->mem[], even though a relocation may still reference them
+		 * and their bytes may still be reachable elsewhere. Returning NULL
+		 * for these is correct: the caller treats it as "not patchable"
+		 * and skips the relocation.
+		 */
+		if (shdr->sh_type == SHT_NOBITS || !(shdr->sh_flags & SHF_ALLOC) ||
+		    mem_idx == LLEXT_MEM_COUNT) {
+			continue;
+		}
+
+		if (offset >= (ssize_t)shdr->sh_offset) {
+			ssize_t sect_offset = offset - (ssize_t)shdr->sh_offset;
+
+			if (sect_offset < (ssize_t)shdr->sh_size) {
+				return (uint8_t *)ext->mem[mem_idx] + ldr->sect_map[i].offset +
+				       sect_offset;
+			}
+		}
+	}
+
+	return NULL;
+}
+
+/*
  * Find the memory region containing the supplied offset and return the
  * corresponding file offset
  */
@@ -326,35 +365,7 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 			continue;
 		}
 
-		/*
-		 * Both r_offset and sh_addr are addresses for which the extension
-		 * has been built.
-		 *
-		 * NOTE: The calculations below assumes offsets from the
-		 * beginning of the .text section in the ELF file can be
-		 * applied to the memory location of mem[LLEXT_MEM_TEXT].
-		 *
-		 * This is valid only for LLEXT_STORAGE_WRITABLE loaders
-		 * since the buffer will be directly modified.
-		 */
-		if (ldr->storage != LLEXT_STORAGE_WRITABLE) {
-			LOG_WRN("PLT: cannot link read-only ELF file");
-			continue;
-		}
-
 		uint8_t *rel_addr = NULL;
-
-		/*
-		 * The only time text will be on the heap with a writable ELF buffer
-		 * is if the ELF is not in instruction memory
-		 */
-		if (ext->mem_on_heap[LLEXT_MEM_TEXT]) {
-			rel_addr =
-				(uint8_t *)ext->text_in_elf - ldr->sects[LLEXT_MEM_TEXT].sh_offset;
-		} else {
-			rel_addr = (uint8_t *)ext->mem[LLEXT_MEM_TEXT] -
-				   ldr->sects[LLEXT_MEM_TEXT].sh_offset;
-		}
 
 		if (tgt) {
 			/* Relocatable / partially linked ELF. */
@@ -364,13 +375,15 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 					(size_t)rela.r_offset, (size_t)tgt->sh_size);
 				continue;
 			}
-			/* Relocation lands in text on heap */
-			if (ext->mem_on_heap[LLEXT_MEM_TEXT] &&
-			    ldr->sect_map[shdr->sh_info].mem_idx == LLEXT_MEM_TEXT) {
-				rel_addr = (uint8_t *)ext->mem[LLEXT_MEM_TEXT] -
-					   ldr->sects[LLEXT_MEM_TEXT].sh_offset;
+
+			const void *sect_ptr = llext_loaded_sect_ptr(ldr, ext, shdr->sh_info);
+
+			if (!sect_ptr) {
+				LOG_WRN("PLT: section %u not loaded, skipping", shdr->sh_info);
+				continue;
 			}
-			rel_addr += rela.r_offset + tgt->sh_offset;
+
+			rel_addr = (uint8_t *)((uintptr_t)sect_ptr + rela.r_offset);
 		} else {
 			/* Shared / dynamically linked ELF */
 			ssize_t offset = llext_file_offset(ldr, rela.r_offset);
@@ -381,17 +394,14 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 				continue;
 			}
 
-			ssize_t text_offset =
-				(ssize_t)ext->text_in_elf - (ssize_t)llext_peek(ldr, 0);
-			/* Relocation lands in text on heap */
-			if (ext->mem_on_heap[LLEXT_MEM_TEXT] &&
-			    (offset >= text_offset &&
-			     offset < text_offset + ext->mem_size[LLEXT_MEM_TEXT])) {
-				rel_addr = (uint8_t *)ext->mem[LLEXT_MEM_TEXT] -
-					   ldr->sects[LLEXT_MEM_TEXT].sh_offset;
-			}
+			rel_addr = llext_file_offset_to_addr(ldr, ext, offset);
 
-			rel_addr += offset;
+			if (rel_addr == NULL) {
+				LOG_WRN("PLT: offset %#zx not mapped to any loaded section, "
+					"skipping",
+					offset);
+				continue;
+			}
 		}
 
 		uint32_t stb = ELF_ST_BIND(sym.st_info);

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -135,10 +135,6 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 			/* Region has data in the file, check if peek() is supported */
 			ext->mem[mem_idx] = llext_peek(ldr, region->sh_offset);
 			if (ext->mem[mem_idx]) {
-				if (mem_idx == LLEXT_MEM_TEXT) {
-					ext->text_in_elf = ext->mem[mem_idx];
-				}
-
 				if ((IS_ALIGNED(ext->mem[mem_idx], region_align) ||
 				     ldr_parm->pre_located) &&
 				    ((mem_idx != LLEXT_MEM_TEXT) ||

--- a/tests/subsys/llext/CMakeLists.txt
+++ b/tests/subsys/llext/CMakeLists.txt
@@ -47,7 +47,8 @@ if(NOT CONFIG_LLEXT_TYPE_ELF_SHAREDLIB)
     list(APPEND ext_names init_fini)
 endif()
 
-if(CONFIG_LLEXT_RODATA_NO_RELOC)
+if(CONFIG_LLEXT_RODATA_NO_RELOC AND NOT CONFIG_XTENSA)
+    # Xtensa linker rejects relocations in .rodata even with -fPIC
     list(APPEND ext_names rodata_no_reloc)
 endif()
 
@@ -107,7 +108,7 @@ get_property(COMPILER_TOPT TARGET compiler PROPERTY linker_script)
 set_ifndef(  TOPT "${COMPILER_TOPT}")
 set_ifndef(  TOPT -Wl,-T) # Use this if the compiler driver doesn't set a value
 
-if(CONFIG_LLEXT_TYPE_ELF_RELOCATABLE AND CONFIG_XTENSA)
+if(CONFIG_LLEXT_TYPE_ELF_RELOCATABLE AND CONFIG_XTENSA AND CONFIG_LLEXT_STORAGE_WRITABLE)
   # Manually fix the pre_located extension's text address at a multiple of 4
   get_target_property(pre_located_target pre_located_ext lib_target)
   get_target_property(pre_located_file pre_located_ext pkg_input)

--- a/tests/subsys/llext/src/test_llext.c
+++ b/tests/subsys/llext/src/test_llext.c
@@ -371,7 +371,7 @@ static LLEXT_CONST uint8_t inspect_ext[] LLEXT_SECT ELF_ALIGN = {
 	#include "inspect.inc"
 };
 
-#if defined(CONFIG_LLEXT_RODATA_NO_RELOC)
+#if defined(CONFIG_LLEXT_RODATA_NO_RELOC) && !defined(CONFIG_XTENSA)
 static LLEXT_CONST uint8_t rodata_no_reloc_ext[] ELF_ALIGN = {
 	#include "rodata_no_reloc.inc"
 };
@@ -529,7 +529,8 @@ ZTEST(llext, test_inter_ext)
 #endif
 
 #if defined(CONFIG_LLEXT_TYPE_ELF_RELOCATABLE) && defined(CONFIG_XTENSA) &&                        \
-	!defined(CONFIG_ARCH_HAS_WORD_GRANULAR_ACCESS_INSTR_MEM)
+	!defined(CONFIG_ARCH_HAS_WORD_GRANULAR_ACCESS_INSTR_MEM) &&                                \
+	defined(CONFIG_LLEXT_STORAGE_WRITABLE)
 static LLEXT_CONST uint8_t pre_located_ext[] LLEXT_SECT ELF_ALIGN = {
 	#include "pre_located.inc"
 };

--- a/tests/subsys/llext/tests.yaml
+++ b/tests/subsys/llext/tests.yaml
@@ -36,8 +36,9 @@ tests:
   # most tests include no_mem_protection.conf, which disables memory protection
   # hardware completely.
   llext.readonly:
-    arch_allow:               # Xtensa needs writable storage
+    arch_allow:
       - arm
+      - xtensa
       - riscv
       - arc
       - x86
@@ -49,8 +50,9 @@ tests:
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
       - CONFIG_LLEXT_RODATA_NO_RELOC=y
   llext.readonly.memblk:
-    arch_allow:               # Xtensa needs writable storage
+    arch_allow:
       - arm
+      - xtensa
       - riscv
       - arc
       - x86
@@ -63,7 +65,8 @@ tests:
       - CONFIG_LLEXT_HEAP_MEMBLK=y
   llext.readonly_mpu:
     arch_allow:
-      - arm # Xtensa needs writable storage, currently not supported on RISC-V
+      - arm # Currently not supported on RISC-V
+      - xtensa
       - arc
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
@@ -72,7 +75,8 @@ tests:
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.readonly_mpu.memblk:
     arch_allow:
-      - arm # Xtensa needs writable storage, currently not supported on RISC-V
+      - arm # Currently not supported on RISC-V
+      - xtensa
       - arc
     filter: CONFIG_ARCH_HAS_USERSPACE and not CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
     extra_configs:
@@ -83,7 +87,8 @@ tests:
       - CONFIG_LLEXT_HEAP_MEMBLK_BLOCK_SIZE=8192
   llext.readonly_mpu.memblk.power_of_two_alignment:
     arch_allow:
-      - arm # Xtensa needs writable storage, currently not supported on RISC-V
+      - arm # Currently not supported on RISC-V
+      - xtensa
       - arc
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
     extra_configs:


### PR DESCRIPTION
A draft PR that will be used for unifying Xtensa linking for LLEXT, but right now, I'm using it to see if there is a particular [failure](https://github.com/zephyrproject-rtos/zephyr/pull/114099#issuecomment-5123349305) on main for LLEXT. This failure doesn't appear locally, only in CI.