### PR TITLE
serial: mcux_lpuart: Fix UART noise error marked as parity error

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -238,7 +238,7 @@ static int mcux_lpuart_err_check(const struct device *dev)
 	}
 
 	if (flags & kLPUART_NoiseErrorFlag) {
-		err |= UART_ERROR_PARITY;
+		err |= UART_ERROR_NOISE;
 	}
 
 	LPUART_ClearStatusFlags(get_base(dev), kLPUART_RxOverrunFlag |


### PR DESCRIPTION
This PR fixes a small bug where a noise error is misclassified as a parity error.

This appears to be a genuine bug since elsewhere in this file (exact same flag) it is correct:
https://github.com/zephyrproject-rtos/zephyr/blob/0ee5b604af6b842abc977bc5c57e5791a5b9ceb0/drivers/serial/uart_mcux_lpuart.c#L1087-L1095

Eerily similar to #112717... maybe I should look through all of the drivers.