### PR TITLE
boards: adafruit_esp32s3: Adding USB OTG device and host controllers

### DIFF
--- a/boards/adafruit/feather_esp32s3/adafruit_feather_esp32s3_procpu.dts
+++ b/boards/adafruit/feather_esp32s3/adafruit_feather_esp32s3_procpu.dts
@@ -203,3 +203,11 @@ zephyr_i2c: &i2c0 {
 &esp32_bt_hci {
 	status = "okay";
 };
+
+zephyr_udc0: &usb_otg {
+	status = "okay";
+};
+
+zephyr_uhc0: &usb_otg {
+	status = "okay";
+};

--- a/boards/adafruit/qt_py_esp32s3/adafruit_qt_py_esp32s3_procpu.dts
+++ b/boards/adafruit/qt_py_esp32s3/adafruit_qt_py_esp32s3_procpu.dts
@@ -157,3 +157,11 @@ zephyr_i2c: &i2c1 {
 &esp32_bt_hci {
 	status = "okay";
 };
+
+zephyr_udc0: &usb_otg {
+	status = "okay";
+};
+
+zephyr_uhc0: &usb_otg {
+	status = "okay";
+};


### PR DESCRIPTION
Adding and enabling the USB OTG host and device controllers for the following boards:
- adafruit_qt_py_esp32s3
- adafruit_feather_esp32s3