### PR TITLE
pmci: mctp: Add missing <zephyr/init.h> includes

### DIFF
--- a/subsys/pmci/mctp/mctp_log.c
+++ b/subsys/pmci/mctp/mctp_log.c
@@ -5,6 +5,7 @@
  *
  */
 
+#include <zephyr/init.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/logging/log.h>
 #include <libmctp.h>

--- a/subsys/pmci/mctp/mctp_memory.c
+++ b/subsys/pmci/mctp/mctp_memory.c
@@ -5,6 +5,7 @@
  *
  */
 
+#include <zephyr/init.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/sys/sys_heap.h>
 #include <libmctp.h>


### PR DESCRIPTION
Both mctp_memory.c and mctp_log.c were using SYS_INIT_NAMED without the right include - were working only due transitive includes. Make it explicit so it work on all architectures.