### PR TITLE
sensor: add missing dependencies

### DIFF
--- a/drivers/sensor/tdk/icm45686/Kconfig
+++ b/drivers/sensor/tdk/icm45686/Kconfig
@@ -5,6 +5,7 @@
 menuconfig ICM45686
 	bool "ICM45686 High-precision 6-Axis Motion Tracking Device"
 	default y
+	depends on ZEPHYR_HAL_TDK_MODULE
 	depends on DT_HAS_INVENSENSE_ICM45605_ENABLED || \
 		DT_HAS_INVENSENSE_ICM45605S_ENABLED || \
 		DT_HAS_INVENSENSE_ICM45686_ENABLED || \

--- a/drivers/sensor/tdk/icp101xx/Kconfig
+++ b/drivers/sensor/tdk/icp101xx/Kconfig
@@ -7,6 +7,7 @@ config ICP101XX
 	bool "ICP101XX Barometric Pressure and Temperature Sensor"
 	default y
 	depends on DT_HAS_INVENSENSE_ICP101XX_ENABLED
+	depends on ZEPHYR_HAL_TDK_MODULE
 	select I2C
 	select USE_EMD_ICP101XX
 	help

--- a/drivers/sensor/tdk/icp201xx/Kconfig
+++ b/drivers/sensor/tdk/icp201xx/Kconfig
@@ -8,6 +8,7 @@ menuconfig ICP201XX
 	bool "ICP201xx Barometric Pressure and Temperature Sensor"
 	default y
 	depends on DT_HAS_INVENSENSE_ICP201XX_ENABLED
+	depends on ZEPHYR_HAL_TDK_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICP201XX),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICP201XX),spi)
 	select USE_EMD_ICP201XX

--- a/drivers/sensor/wsen/wsen_hids_2525020210002/Kconfig
+++ b/drivers/sensor/wsen/wsen_hids_2525020210002/Kconfig
@@ -5,6 +5,7 @@ config WSEN_HIDS_2525020210002
 	bool "WSEN-HIDS-2525020210002 humidity sensor"
 	default y
 	depends on DT_HAS_WE_WSEN_HIDS_2525020210002_ENABLED
+	depends on ZEPHYR_HAL_WURTHELEKTRONIK_MODULE
 	select I2C
 	select HAS_WESENSORS
 	help

--- a/drivers/sensor/wsen/wsen_isds_2536030320001/Kconfig
+++ b/drivers/sensor/wsen/wsen_isds_2536030320001/Kconfig
@@ -5,6 +5,7 @@ menuconfig WSEN_ISDS_2536030320001
 	bool "WSEN-ISDS 3D accelerometer and 3D gyroscope sensor"
 	default y
 	depends on DT_HAS_WE_WSEN_ISDS_2536030320001_ENABLED
+	depends on ZEPHYR_HAL_WURTHELEKTRONIK_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_WE_WSEN_ISDS_2536030320001),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_WE_WSEN_ISDS_2536030320001),spi)
 	select HAS_WESENSORS

--- a/drivers/sensor/wsen/wsen_itds_2533020201601/Kconfig
+++ b/drivers/sensor/wsen/wsen_itds_2533020201601/Kconfig
@@ -5,6 +5,7 @@ menuconfig WSEN_ITDS_2533020201601
 	bool "WSEN-ITDS-2533020201601 3-axis acceleration sensor"
 	default y
 	depends on DT_HAS_WE_WSEN_ITDS_2533020201601_ENABLED
+	depends on ZEPHYR_HAL_WURTHELEKTRONIK_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_WE_WSEN_ITDS_2533020201601),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_WE_WSEN_ITDS_2533020201601),spi)
 	select HAS_WESENSORS

--- a/drivers/sensor/wsen/wsen_pads_2511020213301/Kconfig
+++ b/drivers/sensor/wsen/wsen_pads_2511020213301/Kconfig
@@ -5,6 +5,7 @@ menuconfig WSEN_PADS_2511020213301
 	bool "WSEN-PADS-2511020213301 absolute pressure and temperature sensor"
 	default y
 	depends on DT_HAS_WE_WSEN_PADS_2511020213301_ENABLED
+	depends on ZEPHYR_HAL_WURTHELEKTRONIK_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_WE_WSEN_PADS),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_WE_WSEN_PADS),spi)
 	select HAS_WESENSORS

--- a/drivers/sensor/wsen/wsen_pdms_25131308XXX05/Kconfig
+++ b/drivers/sensor/wsen/wsen_pdms_25131308XXX05/Kconfig
@@ -5,6 +5,7 @@ config WSEN_PDMS_25131308XXX05
 	bool "WSEN-PDMS-25131308XXX05 differential pressure sensor"
 	default y
 	depends on DT_HAS_WE_WSEN_PDMS_25131308XXX05_ENABLED
+	depends on ZEPHYR_HAL_WURTHELEKTRONIK_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_WE_WSEN_PDMS_25131308XXX05),i2c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_WE_WSEN_PDMS_25131308XXX05),spi)
 	select HAS_WESENSORS

--- a/drivers/sensor/wsen/wsen_pdus_25131308XXXXX/Kconfig
+++ b/drivers/sensor/wsen/wsen_pdus_25131308XXXXX/Kconfig
@@ -5,6 +5,7 @@ config WSEN_PDUS_25131308XXXXX
 	bool "WSEN-PDUS-25131308XXXXX differential pressure sensor"
 	default y
 	depends on DT_HAS_WE_WSEN_PDUS_25131308XXXXX_ENABLED
+	depends on ZEPHYR_HAL_WURTHELEKTRONIK_MODULE
 	select I2C
 	select HAS_WESENSORS
 	help

--- a/drivers/sensor/wsen/wsen_tids_2521020222501/Kconfig
+++ b/drivers/sensor/wsen/wsen_tids_2521020222501/Kconfig
@@ -5,6 +5,7 @@ menuconfig WSEN_TIDS_2521020222501
 	bool "WSEN-TIDS-2521020222501 temperature sensor"
 	default y
 	depends on DT_HAS_WE_WSEN_TIDS_2521020222501_ENABLED
+	depends on ZEPHYR_HAL_WURTHELEKTRONIK_MODULE
 	select I2C
 	select HAS_WESENSORS
 	help

--- a/modules/hal_wurthelektronik/Kconfig
+++ b/modules/hal_wurthelektronik/Kconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Embeint Inc
+# SPDX-License-Identifier: Apache-2.0
+
+config ZEPHYR_HAL_WURTHELEKTRONIK_MODULE
+	bool


### PR DESCRIPTION
Add missing dependencies on the HAL module for sensors that use the HAL
headers. This fixes compile time errors for `build_all` tests downstream
that don't have the HAL checked out.