### PR TITLE
Off t fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,17 @@ add_link_options(${LINKER_OPTIMIZATION_FLAG})
 compiler_simple_options(simple_options)
 toolchain_linker_add_compiler_options(${simple_options})
 
+set(cmake_c_compiler_command ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS})
+
+list(APPEND cmake_c_compiler_command ${simple_options})
+list(APPEND cmake_c_compiler_command -I$<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>, -I>)
+list(APPEND cmake_c_compiler_command -isystem $<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>, -isystem >)
+list(APPEND cmake_c_compiler_command -D$<JOIN:$<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>, -D> ${C_compile_options})
+
+if(CMAKE_HOST_UNIX)
+  set(cmake_c_compiler_command "'${cmake_c_compiler_command}'")
+endif()
+
 if(CONFIG_LTO)
   if(CONFIG_LTO_SINGLE_THREADED)
     zephyr_compile_options($<TARGET_PROPERTY:compiler,optimization_lto_st>)
@@ -974,6 +985,7 @@ add_custom_command(
   --syscall-exports-llext  include/generated/zephyr/syscall_exports_llext.c
   --syscall-weakdefs-llext syscall_weakdefs_llext.c # compiled in CMake library 'syscall_weakdefs'
   --syscall-list     ${syscall_list_h}
+  --c-compiler       "${cmake_c_compiler_command}"
   $<$<BOOL:${CONFIG_USERSPACE}>:--gen-mrsh-files>
   ${SYSCALL_LONG_REGISTERS_ARG}
   ${SYSCALL_SPLIT_TIMEOUT_ARG}
@@ -2423,6 +2435,7 @@ if(CONFIG_LLEXT_EDK)
       --base-output      edk/include/generated/zephyr/syscalls           # Write to this dir
       --syscall-dispatch edk/include/generated/zephyr/syscall_dispatch.c # Write this file
       --syscall-list     ${edk_syscall_list_h}
+      --c-compiler       "${cmake_c_compiler_command}"
       $<$<BOOL:${CONFIG_LLEXT_EDK_USERSPACE_ONLY}>:--userspace-only>
       ${SYSCALL_LONG_REGISTERS_ARG}
       ${SYSCALL_SPLIT_TIMEOUT_ARG}

--- a/doc/releases/migration-guide-4.5.rst
+++ b/doc/releases/migration-guide-4.5.rst
@@ -728,6 +728,15 @@ STM32
   and will trigger a build error. Use the :ref:`generic chosen <devicetree-zephyr-chosen-nodes>`
   ``zephyr,system-timer`` instead. (:github:`112999`)
 
+Storage
+=======
+
+* The ``fs_off`` element of :c:struct:`flash_sector` has been changed from type ``off_t`` to
+  ``size_t``. This should make all platforms and toolchains use the native machine register size and
+  not vary based on the POSIX ``off_t`` type inherited from the C library. Picolibc 1.8.12 always
+  defines ``off_t`` as a 64-bit integer, even on 32-bit platforms; this change effectively returns
+  the struct to the previous layout when using this C library.
+
 Syscon
 ======
 

--- a/drivers/disk/flashdisk.c
+++ b/drivers/disk/flashdisk.c
@@ -126,7 +126,8 @@ static int flashdisk_init_runtime(struct flashdisk_data *ctx,
 		while (offset < ctx->offset + ctx->size) {
 			rc = flash_get_page_info_by_offs(ctx->info.dev, offset, &page);
 			if (rc < 0) {
-				LOG_ERR("Error %d getting page info at offset %lx", rc, offset);
+				LOG_ERR("Error %d getting page info at offset %lx", rc,
+					(long)offset);
 				return rc;
 			}
 			if (page.size != ctx->page_size) {

--- a/drivers/disk/ftl_dhara.c
+++ b/drivers/disk/ftl_dhara.c
@@ -271,8 +271,8 @@ int disk_ftl_access_init(struct disk_info *disk)
 	ret = flash_get_page_info_by_offs(disk->dev, ctx->area->fa_off, &page);
 	if (ret != 0) {
 		release_disk(disk);
-		LOG_ERR("Getting flash page info at 0x%lX failed with error %d", ctx->area->fa_off,
-			ret);
+		LOG_ERR("Getting flash page info at 0x%llx failed with error %d",
+			(long long)ctx->area->fa_off, ret);
 		return ret;
 	}
 

--- a/drivers/flash/flash_ambiq.c
+++ b/drivers/flash/flash_ambiq.c
@@ -164,7 +164,7 @@ static int flash_ambiq_read(const struct device *dev, off_t offset, void *data, 
 		return 0;
 	}
 
-	memcpy(data, (uint8_t *)(SOC_NV_FLASH_ADDR + offset), len);
+	memcpy(data, (uint8_t *)(SOC_NV_FLASH_ADDR + (uintptr_t)offset), len);
 
 	return 0;
 }
@@ -294,7 +294,7 @@ static int flash_ambiq_write(const struct device *dev, off_t offset, const void 
 
 static bool flash_ambiq_is_erased(off_t offset, size_t len)
 {
-	const uint8_t *flash_ptr = (const uint8_t *)(SOC_NV_FLASH_ADDR + offset);
+	const uint8_t *flash_ptr = (const uint8_t *)(SOC_NV_FLASH_ADDR + (uintptr_t)offset);
 
 	for (size_t i = 0; i < len; i++) {
 		if (flash_ptr[i] != FLASH_ERASE_BYTE) {
@@ -395,7 +395,7 @@ static int flash_ambiq_erase(const struct device *dev, off_t offset, size_t len)
 
 	for (retry_count = 0; retry_count < FLASH_OPERATION_MAX_RETRIES; retry_count++) {
 		ret = am_hal_mram_main_fill(AM_HAL_MRAM_PROGRAM_KEY, FLASH_ERASE_WORD,
-					    (uint32_t *)(SOC_NV_FLASH_ADDR + offset),
+					    (uint32_t *)(SOC_NV_FLASH_ADDR + (uintptr_t)offset),
 					    (len / sizeof(uint32_t)));
 
 		/*
@@ -409,8 +409,10 @@ static int flash_ambiq_erase(const struct device *dev, off_t offset, size_t len)
 		}
 #else
 		if (ret == AM_HAL_STATUS_SUCCESS) {
-			sys_cache_data_invd_range((void *)(SOC_NV_FLASH_ADDR + offset), len);
-			sys_cache_instr_flush_range((void *)(SOC_NV_FLASH_ADDR + offset), len);
+			sys_cache_data_invd_range((void *)(SOC_NV_FLASH_ADDR +
+							   (uintptr_t)offset), len);
+			sys_cache_instr_flush_range((void *)(SOC_NV_FLASH_ADDR +
+							     (uintptr_t)offset), len);
 		}
 #endif
 

--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -143,10 +143,10 @@ static int flash_esp32_read_check_enc(off_t address, void *buffer, size_t length
 	int ret = 0;
 
 	if (esp_efuse_is_flash_encryption_enabled()) {
-		LOG_DBG("Flash read ENCRYPTED - address 0x%lx size 0x%x", address, length);
+		LOG_DBG("Flash read ENCRYPTED - address 0x%lx size 0x%x", (long)address, length);
 		ret = esp_flash_read_encrypted(NULL, address, buffer, length);
 	} else {
-		LOG_DBG("Flash read RAW - address 0x%lx size 0x%x", address, length);
+		LOG_DBG("Flash read RAW - address 0x%lx size 0x%x", (long)address, length);
 		ret = esp_flash_read(NULL, buffer, address, length);
 	}
 
@@ -163,10 +163,10 @@ static int flash_esp32_write_check_enc(off_t address, const void *buffer, size_t
 	int ret = 0;
 
 	if (esp_efuse_is_flash_encryption_enabled() && !ENCRYPTION_IS_VIRTUAL) {
-		LOG_DBG("Flash write ENCRYPTED - address 0x%lx size 0x%x", address, length);
+		LOG_DBG("Flash write ENCRYPTED - address 0x%lx size 0x%x", (long)address, length);
 		ret = esp_flash_write_encrypted(NULL, address, buffer, length);
 	} else {
-		LOG_DBG("Flash write RAW - address 0x%lx size 0x%x", address, length);
+		LOG_DBG("Flash write RAW - address 0x%lx size 0x%x", (long)address, length);
 		ret = esp_flash_write(NULL, buffer, address, length);
 	}
 

--- a/drivers/flash/flash_infineon_serial_memory_qspi.c
+++ b/drivers/flash/flash_infineon_serial_memory_qspi.c
@@ -121,7 +121,7 @@ static int ifx_serial_memory_flash_read(const struct device *dev, off_t offset, 
 
 	rslt = mtb_serial_memory_read(&serial_memory_obj, offset, data_len, data);
 	if (rslt != CY_RSLT_SUCCESS) {
-		LOG_ERR("Error reading @ %lu (Err:0x%x)", offset, rslt);
+		LOG_ERR("Error reading @ %lu (Err:0x%x)", (long)offset, rslt);
 		ret = -EIO;
 	}
 
@@ -148,7 +148,7 @@ static int ifx_serial_memory_flash_write(const struct device *dev, off_t offset,
 
 	rslt = mtb_serial_memory_write(&serial_memory_obj, offset, data_len, data);
 	if (rslt != CY_RSLT_SUCCESS) {
-		LOG_ERR("Error in writing @ %lu (Err:0x%x)", offset, rslt);
+		LOG_ERR("Error in writing @ %lu (Err:0x%x)", (long)offset, rslt);
 		ret = -EIO;
 	}
 

--- a/drivers/flash/flash_intel_pflash_cfi01.c
+++ b/drivers/flash/flash_intel_pflash_cfi01.c
@@ -164,7 +164,7 @@ static int pflash_write(const struct device *dev, off_t offset, const void *data
 		/* Wait for operation to complete */
 		ret = pflash_wait_ready(addr + i, cfg->bank_width, cfg->device_width);
 		if (ret != 0) {
-			LOG_ERR("Write failed at offset 0x%lx", offset + i);
+			LOG_ERR("Write failed at offset 0x%lx", (long)(offset + i));
 			pflash_read_array(base_addr, cfg->bank_width);
 			return ret;
 		}
@@ -206,7 +206,7 @@ static int pflash_erase(const struct device *dev, off_t offset, size_t size)
 		/* Wait for erase to complete */
 		ret = pflash_wait_ready(addr, cfg->bank_width, cfg->device_width);
 		if (ret != 0) {
-			LOG_ERR("Erase failed at offset 0x%lx", offset + erased);
+			LOG_ERR("Erase failed at offset 0x%lx", (long)(offset + erased));
 			pflash_read_array(base_addr, cfg->bank_width);
 			return ret;
 		}

--- a/drivers/flash/flash_ite_it51xxx_m1k.c
+++ b/drivers/flash/flash_ite_it51xxx_m1k.c
@@ -593,7 +593,8 @@ static int flash_it51xxx_read(const struct device *dev, off_t offset, void *dst_
 	int ret;
 	uint8_t *dst = (uint8_t *)dst_data;
 
-	LOG_DBG("%s: offset=%lx, data addr=%p, len=%u", __func__, offset, (uint8_t *)dst_data, len);
+	LOG_DBG("%s: offset=%lx, data addr=%p, len=%u", __func__,
+		(long)offset, (uint8_t *)dst_data, len);
 
 	if (len == 0) {
 		return 0;
@@ -642,8 +643,8 @@ static int flash_it51xxx_write(const struct device *dev, off_t offset, const voi
 	int ret;
 	const uint8_t *src = (const uint8_t *)src_data;
 
-	LOG_DBG("%s: offset=%lx, data addr=%p, len=%u", __func__, offset, (const uint8_t *)src_data,
-		len);
+	LOG_DBG("%s: offset=%lx, data addr=%p, len=%u", __func__,
+		(long)offset, (const uint8_t *)src_data, len);
 
 	if (len == 0) {
 		return 0;
@@ -686,7 +687,7 @@ static int flash_it51xxx_erase(const struct device *dev, off_t offset, size_t le
 	struct flash_it51xxx_dev_data *data = dev->data;
 	int ret;
 
-	LOG_DBG("%s: offset=%lx, len=%u", __func__, offset, len);
+	LOG_DBG("%s: offset=%lx, len=%u", __func__, (long)offset, len);
 
 	if (len == 0) {
 		return 0;

--- a/drivers/flash/flash_mcux_flexspi_hyperflash.c
+++ b/drivers/flash/flash_mcux_flexspi_hyperflash.c
@@ -402,7 +402,7 @@ static int flash_flexspi_hyperflash_page_program(const struct flash_flexspi_hype
 		.dataSize = len,
 	};
 
-	LOG_DBG("Page programming %d bytes to 0x%08lx", len, offset);
+	LOG_DBG("Page programming %d bytes to 0x%08lx", len, (unsigned long)offset);
 
 	return memc_flexspi_transfer(&data->controller, &transfer);
 }
@@ -570,7 +570,7 @@ static int flash_flexspi_hyperflash_erase(const struct device *dev, off_t offset
 			break;
 		}
 
-		LOG_DBG("Erasing sector at 0x%08lx", offset);
+		LOG_DBG("Erasing sector at 0x%08lx", (unsigned long)offset);
 
 		transfer.deviceAddress = offset;
 		transfer.port = data->port;

--- a/drivers/flash/flash_nxp_s32_qspi.c
+++ b/drivers/flash/flash_nxp_s32_qspi.c
@@ -77,7 +77,8 @@ int nxp_s32_qspi_read(const struct device *dev, off_t offset, void *dest, size_t
 		status = Qspi_Ip_Read(data->instance, (uint32_t)offset, (uint8_t *)dest,
 				      (uint32_t)size);
 		if (status != STATUS_QSPI_IP_SUCCESS) {
-			LOG_ERR("Failed to read %zu bytes at 0x%lx (%d)", size, offset, status);
+			LOG_ERR("Failed to read %zu bytes at 0x%lx (%d)", size,
+				(long)offset, status);
 			ret = -EIO;
 		}
 
@@ -118,7 +119,8 @@ int nxp_s32_qspi_write(const struct device *dev, off_t offset, const void *src, 
 		status = Qspi_Ip_Program(data->instance, (uint32_t)offset, (const uint8_t *)src,
 					 (uint32_t)len);
 		if (status != STATUS_QSPI_IP_SUCCESS) {
-			LOG_ERR("Failed to write %zu bytes at 0x%lx (%d)", len, offset, status);
+			LOG_ERR("Failed to write %zu bytes at 0x%lx (%d)",
+				len, (long)offset, status);
 			ret = -EIO;
 			break;
 		}
@@ -132,7 +134,8 @@ int nxp_s32_qspi_write(const struct device *dev, off_t offset, const void *src, 
 			status = Qspi_Ip_ProgramVerify(data->instance, (uint32_t)offset,
 						       (const uint8_t *)src, (uint32_t)len);
 			if (status != STATUS_QSPI_IP_SUCCESS) {
-				LOG_ERR("Write verification failed at 0x%lx (%d)", offset, status);
+				LOG_ERR("Write verification failed at 0x%lx (%d)",
+					(long)offset, status);
 				ret = -EIO;
 				break;
 			}
@@ -176,7 +179,7 @@ static int nxp_s32_qspi_erase_block(const struct device *dev, off_t offset, size
 		status = Qspi_Ip_EraseBlock(data->instance, (uint32_t)offset, *erase_size);
 		if (status != STATUS_QSPI_IP_SUCCESS) {
 			LOG_ERR("Failed to erase %zu bytes at 0x%lx (%d)", *erase_size,
-				(long)offset, status);
+				(unsigned long)offset, status);
 			ret = -EIO;
 		}
 	} else {
@@ -229,8 +232,8 @@ int nxp_s32_qspi_erase(const struct device *dev, off_t offset, size_t size)
 				status = Qspi_Ip_EraseVerify(data->instance, (uint32_t)offset,
 							     erase_size);
 				if (status != STATUS_QSPI_IP_SUCCESS) {
-					LOG_ERR("Erase verification failed at 0x%lx (%d)", offset,
-						status);
+					LOG_ERR("Erase verification failed at 0x%lx (%d)",
+						(long)offset, status);
 					ret = -EIO;
 					break;
 				}

--- a/drivers/flash/flash_nxp_s32_qspi_nor.c
+++ b/drivers/flash/flash_nxp_s32_qspi_nor.c
@@ -473,7 +473,7 @@ static int nxp_s32_qspi_sfdp_read(const struct device *dev, off_t offset, void *
 	status = Qspi_Ip_RunReadCommand(data->instance, data->read_sfdp_lut_idx,
 					(uint32_t)offset, (uint8_t *)buf, NULL, (uint32_t)len);
 	if (status != STATUS_QSPI_IP_SUCCESS) {
-		LOG_ERR("Failed to read SFDP at 0x%lx (%d)", offset, status);
+		LOG_ERR("Failed to read SFDP at 0x%lx (%d)", (long)offset, status);
 		ret = -EIO;
 	}
 

--- a/drivers/flash/flash_realtek_rts5912.c
+++ b/drivers/flash/flash_realtek_rts5912.c
@@ -672,7 +672,7 @@ static int flash_rts5912_erase(const struct device *dev, off_t offset, size_t le
 	for (; len > 0; len -= FLASH_ERASE_BLK_SZ) {
 		ret = flash_erase_sector(dev, offset);
 		if (ret < 0) {
-			LOG_ERR("erase @0x%08lx fail", offset);
+			LOG_ERR("erase @0x%08lx fail", (long)offset);
 		}
 		offset += FLASH_ERASE_BLK_SZ;
 	}

--- a/drivers/flash/flash_renesas_ra_ospi_b.c
+++ b/drivers/flash/flash_renesas_ra_ospi_b.c
@@ -518,10 +518,11 @@ static int flash_renesas_ra_ospi_b_erase(const struct device *dev, off_t offset,
 
 		err = R_OSPI_B_Erase(
 			&ospi_b_data->ospi_b_ctrl,
-			(uint8_t *)(BSP_FEATURE_OSPI_B_DEVICE_1_START_ADDRESS + offset),
+			(uint8_t *)(BSP_FEATURE_OSPI_B_DEVICE_1_START_ADDRESS + (uintptr_t)offset),
 			erase_size);
 		if (err != FSP_SUCCESS) {
-			LOG_ERR("Erase at address 0x%lx, size %zu Failed", offset, erase_size);
+			LOG_ERR("Erase at address 0x%lx, size %zu Failed",
+				(long)offset, erase_size);
 			ret = -EIO;
 			break;
 		}
@@ -598,9 +599,10 @@ static int flash_renesas_ra_ospi_b_write(const struct device *dev, off_t offset,
 
 		err = R_OSPI_B_Write(
 			&ospi_b_data->ospi_b_ctrl, p_src,
-			(uint8_t *)(BSP_FEATURE_OSPI_B_DEVICE_1_START_ADDRESS + offset), size);
+			(uint8_t *)(BSP_FEATURE_OSPI_B_DEVICE_1_START_ADDRESS +
+				    (uintptr_t)offset), size);
 		if (err != FSP_SUCCESS) {
-			LOG_ERR("Write at address 0x%lx, size %zu", offset, size);
+			LOG_ERR("Write at address 0x%lx, size %zu", (long)offset, size);
 			ret = -EIO;
 			break;
 		}

--- a/drivers/flash/flash_renesas_ra_qspi.c
+++ b/drivers/flash/flash_renesas_ra_qspi.c
@@ -368,7 +368,8 @@ static int qspi_flash_ra_erase(const struct device *dev, off_t offset, size_t le
 			erase_size = BLOCK_SIZE_64K;
 		}
 		err = R_QSPI_Erase(&qspi_data->qspi_ctrl,
-				   (uint8_t *)(QSPI_DEVICE_START_ADDRESS + offset), erase_size);
+				   (uint8_t *)(QSPI_DEVICE_START_ADDRESS +
+					       (uintptr_t)offset), erase_size);
 		if (err) {
 			LOG_ERR("Erase failed");
 			err = -EIO;
@@ -402,7 +403,7 @@ static int qspi_flash_ra_read(const struct device *dev, off_t offset, void *data
 
 	acquire_device(dev);
 
-	memcpy(data, (uint8_t *)(QSPI_DEVICE_START_ADDRESS + offset), len);
+	memcpy(data, (uint8_t *)(QSPI_DEVICE_START_ADDRESS + (uintptr_t)offset), len);
 	release_device(dev);
 
 	return 0;
@@ -428,7 +429,8 @@ static int qspi_flash_ra_write(const struct device *dev, off_t offset, const voi
 	while (remaining_bytes > 0) {
 		size = remaining_bytes > PAGE_SIZE_BYTE ? PAGE_SIZE_BYTE : remaining_bytes;
 		err = R_QSPI_Write(&qspi_data->qspi_ctrl, p_data,
-				   (uint8_t *)(QSPI_DEVICE_START_ADDRESS + offset), size);
+				   (uint8_t *)(QSPI_DEVICE_START_ADDRESS +
+					       (uintptr_t)offset), size);
 		if (err) {
 			LOG_ERR("Direct write failed");
 			err = -EIO;

--- a/drivers/flash/flash_rpi_pico.c
+++ b/drivers/flash/flash_rpi_pico.c
@@ -56,7 +56,7 @@ static int flash_rpi_read(const struct device *dev, off_t offset, void *data, si
 		return -EINVAL;
 	}
 
-	memcpy(data, (uint8_t *)(PICO_FLASH_READ_BASE + offset), size);
+	memcpy(data, (uint8_t *)(PICO_FLASH_READ_BASE + (uintptr_t)offset), size);
 
 	return 0;
 }
@@ -74,8 +74,8 @@ static int flash_rpi_write(const struct device *dev, off_t offset, const void *d
 	}
 
 	if (!is_valid_range(offset, size)) {
-		LOG_ERR("Write range exceeds the flash boundaries. Offset=%#lx, Size=%u", offset,
-			size);
+		LOG_ERR("Write range exceeds the flash boundaries. Offset=%#lx, Size=%u",
+			(unsigned long)offset, size);
 		return -EINVAL;
 	}
 
@@ -118,14 +118,14 @@ static int flash_rpi_erase(const struct device *dev, off_t offset, size_t size)
 	}
 
 	if (!is_valid_range(offset, size)) {
-		LOG_ERR("Erase range exceeds the flash boundaries. Offset=%#lx, Size=%u", offset,
-			size);
+		LOG_ERR("Erase range exceeds the flash boundaries. Offset=%#lx, Size=%u",
+			(unsigned long)offset, size);
 		return -EINVAL;
 	}
 
 	if ((offset % SECTOR_SIZE) || (size % SECTOR_SIZE)) {
 		LOG_ERR("Erase range is not a multiple of the sector size. Offset=%#lx, Size=%u",
-			offset, size);
+			(unsigned long)offset, size);
 		return -EINVAL;
 	}
 

--- a/drivers/flash/flash_sam.c
+++ b/drivers/flash/flash_sam.c
@@ -221,7 +221,7 @@ static int sam_flash_read(const struct device *dev, off_t offset, void *data, si
 	}
 
 	key = k_spin_lock(&sam_data->lock);
-	memcpy(data, (uint8_t *)(sam_config->area_address + offset), len);
+	memcpy(data, (uint8_t *)(uintptr_t)(sam_config->area_address + offset), len);
 	k_spin_unlock(&sam_data->lock, key);
 	return 0;
 }
@@ -244,7 +244,7 @@ static int sam_flash_write_latch_buffer_to_previous_page(const struct device *de
 
 static void sam_flash_write_dword_to_latch_buffer(off_t offset, uint32_t dword)
 {
-	*((uint32_t *)offset) = dword;
+	*((uint32_t *)(uintptr_t)offset) = dword;
 	barrier_dsync_fence_full();
 }
 

--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -49,7 +49,7 @@ BUILD_ASSERT((FLASH_WRITE_BLK_SZ % sizeof(uint32_t)) == 0, "unsupported write-bl
 
 #define PAGES_PER_ROW (ROW_SIZE / FLASH_PAGE_SIZE)
 
-#define FLASH_MEM(_a) ((uint32_t *)((uint8_t *)((_a) + CONFIG_FLASH_BASE_ADDRESS)))
+#define FLASH_MEM(_a) ((uint32_t *)((uint8_t *)((uintptr_t)(_a) + CONFIG_FLASH_BASE_ADDRESS)))
 
 struct flash_sam0_data {
 #if CONFIG_SOC_FLASH_SAM0_EMULATE_BYTE_PAGES

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -799,7 +799,7 @@ static int cmd_page_info(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	shell_print(sh, "Page for address 0x%x:\nstart offset: 0x%lx\nsize: %zu\nindex: %d", addr,
-		    info.start_offset, info.size, info.index);
+		    (long)info.start_offset, info.size, info.index);
 	return 0;
 }
 

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -140,7 +140,8 @@ static void flash_stm32_flush_caches(const struct device *dev, off_t offset, siz
 		regs->ACR |= FLASH_ACR_DCEN;
 	}
 #elif defined(CONFIG_SOC_SERIES_STM32F7X)
-	SCB_InvalidateDCache_by_Addr((uint32_t *)(FLASH_STM32_BASE_ADDRESS + offset), len);
+	SCB_InvalidateDCache_by_Addr((uint32_t *)(FLASH_STM32_BASE_ADDRESS +
+						  (uintptr_t)offset), len);
 #endif
 }
 

--- a/drivers/flash/flash_stm32c5x.c
+++ b/drivers/flash/flash_stm32c5x.c
@@ -39,7 +39,7 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 static int write_nwords(const struct device *dev, off_t offset, const uint32_t *buff, size_t n)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
-	volatile uint32_t *flash = (uint32_t *)(offset + FLASH_STM32_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS);
 	int rc;
 	int i;
 

--- a/drivers/flash/flash_stm32f1x.c
+++ b/drivers/flash/flash_stm32f1x.c
@@ -125,7 +125,7 @@ static int write_value(const struct device *dev, off_t offset,
 		       flash_prg_t val)
 {
 	volatile flash_prg_t *flash = (flash_prg_t *)(
-		offset + FLASH_STM32_BASE_ADDRESS);
+		(uintptr_t)offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	int rc;
 

--- a/drivers/flash/flash_stm32f2x.c
+++ b/drivers/flash/flash_stm32f2x.c
@@ -76,7 +76,7 @@ static int write_byte(const struct device *dev, off_t offset, uint8_t val)
 	/* flush the register write */
 	tmp = regs->CR;
 
-	*((uint8_t *) offset + FLASH_STM32_BASE_ADDRESS) = val;
+	*((uint8_t *) (uintptr_t)offset + FLASH_STM32_BASE_ADDRESS) = val;
 
 	/* Wait until the BSY bit is cleared */
 	rc = flash_stm32_wait_flash_idle(dev);

--- a/drivers/flash/flash_stm32f4x.c
+++ b/drivers/flash/flash_stm32f4x.c
@@ -117,7 +117,7 @@ static int write_value(const struct device *dev, off_t offset, flash_prg_t val)
 	/* flush the register write */
 	tmp = regs->CR;
 
-	*((flash_prg_t *)(offset + FLASH_STM32_BASE_ADDRESS)) = val;
+	*((flash_prg_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS)) = val;
 
 	rc = flash_stm32_wait_flash_idle(dev);
 	regs->CR &= (~FLASH_CR_PG);

--- a/drivers/flash/flash_stm32f7x.c
+++ b/drivers/flash/flash_stm32f7x.c
@@ -60,7 +60,7 @@ static int write_byte(const struct device *dev, off_t offset, uint8_t val)
 	barrier_dsync_fence_full();
 
 	/* write the data */
-	*((uint8_t *) offset + FLASH_STM32_BASE_ADDRESS) = val;
+	*((uint8_t *)(uintptr_t)offset + FLASH_STM32_BASE_ADDRESS) = val;
 	/* flush the register write */
 	barrier_dsync_fence_full();
 

--- a/drivers/flash/flash_stm32g0x.c
+++ b/drivers/flash/flash_stm32g0x.c
@@ -57,7 +57,7 @@ static inline void flush_cache(FLASH_TypeDef *regs)
 
 static int write_dword(const struct device *dev, off_t offset, uint64_t val)
 {
-	volatile uint32_t *flash = (uint32_t *)(offset + FLASH_STM32_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	uint32_t tmp;
 	int rc;

--- a/drivers/flash/flash_stm32g4x.c
+++ b/drivers/flash/flash_stm32g4x.c
@@ -82,7 +82,7 @@ static inline void flush_cache(FLASH_TypeDef *regs)
 
 static int write_dword(const struct device *dev, off_t offset, uint64_t val)
 {
-	volatile uint32_t *flash = (uint32_t *)(offset + FLASH_STM32_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	bool dcache_enabled = false;
 	uint32_t tmp;

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -329,7 +329,7 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset, uint32_t le
 		if ((offset % (FLASH_NB_32BITWORD_IN_FLASHWORD * 4)) != 0) {
 			LOG_ERR("Write offset not aligned on flashword length. "
 				"Offset: 0x%lx, flashword length: %d",
-				(unsigned long)offset, FLASH_NB_32BITWORD_IN_FLASHWORD * 4);
+				(long)offset, FLASH_NB_32BITWORD_IN_FLASHWORD * 4);
 			return false;
 		}
 	}
@@ -570,7 +570,7 @@ static int wait_write_queue(const struct flash_stm32_sector_t *sector)
 
 static int write_ndwords(const struct device *dev, off_t offset, const uint64_t *data, uint8_t n)
 {
-	volatile uint64_t *flash = (uint64_t *)(offset + FLASH_STM32_BASE_ADDRESS);
+	volatile uint64_t *flash = (uint64_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS);
 	int rc;
 	int i;
 	struct flash_stm32_sector_t sector = get_sector(dev, offset);
@@ -709,7 +709,8 @@ static void flash_stm32h7_flush_caches(const struct device *dev, off_t offset, s
 		return; /* Cache not enabled */
 	}
 
-	SCB_InvalidateDCache_by_Addr((uint32_t *)(FLASH_STM32_BASE_ADDRESS + offset), len);
+	SCB_InvalidateDCache_by_Addr((uint32_t *)(uintptr_t)(FLASH_STM32_BASE_ADDRESS +
+							     offset), len);
 }
 #endif /* CONFIG_CPU_CORTEX_M7 */
 

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -69,7 +69,7 @@ static unsigned int get_page(off_t offset)
 
 static int write_dword(const struct device *dev, off_t offset, uint64_t val)
 {
-	volatile uint32_t *flash = (uint32_t *)(offset + FLASH_STM32_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)((uintptr_t)offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 #ifdef CONTROL_DCACHE
 	bool dcache_enabled = false;

--- a/drivers/flash/flash_stm32l5x.c
+++ b/drivers/flash/flash_stm32l5x.c
@@ -77,7 +77,7 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 static int write_nwords(const struct device *dev, off_t offset, const uint32_t *buff, size_t n)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
-	volatile uint32_t *flash = (uint32_t *)(offset
+	volatile uint32_t *flash = (uint32_t *)((uintptr_t)offset
 						+ FLASH_STM32_BASE_ADDRESS);
 	bool full_zero = true;
 	uint32_t tmp;

--- a/drivers/flash/flash_stm32u3x.c
+++ b/drivers/flash/flash_stm32u3x.c
@@ -47,7 +47,7 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 static int write_nwords(const struct device *dev, off_t offset, const uint32_t *buff, size_t n)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
-	volatile uint32_t *flash = (uint32_t *)(offset
+	volatile uint32_t *flash = (uint32_t *)((uintptr_t)offset
 						+ FLASH_STM32_BASE_ADDRESS);
 	bool full_zero = true;
 	uint32_t tmp;

--- a/drivers/flash/flash_stm32wbax.c
+++ b/drivers/flash/flash_stm32wbax.c
@@ -67,7 +67,7 @@ bool flash_stm32_valid_range(const struct device *dev, off_t offset,
 static int write_qword(const struct device *dev, off_t offset, const uint32_t *buff)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
-	volatile uint32_t *flash = (uint32_t *)(offset
+	volatile uint32_t *flash = (uint32_t *)((uintptr_t)offset
 						+ FLASH_STM32_BASE_ADDRESS);
 	uint32_t tmp;
 	int rc;

--- a/drivers/flash/flash_stm32wbx.c
+++ b/drivers/flash/flash_stm32wbx.c
@@ -60,7 +60,7 @@ static inline void flush_cache(FLASH_TypeDef *regs)
 
 static int write_dword(const struct device *dev, off_t offset, uint64_t val)
 {
-	volatile uint32_t *flash = (uint32_t *)(offset + FLASH_STM32_BASE_ADDRESS);
+	volatile uint32_t *flash = (uint32_t *)(uintptr_t)(offset + FLASH_STM32_BASE_ADDRESS);
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 	uint32_t tmp;
 	int ret, rc;

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -819,7 +819,7 @@ static inline int read_non_aligned(const struct device *dev,
 		flash_prefix = size;
 	}
 
-	off_t dest_prefix = (WORD_SIZE - (off_t)dptr % WORD_SIZE) % WORD_SIZE;
+	off_t dest_prefix = (WORD_SIZE - (off_t)(uintptr_t)dptr % WORD_SIZE) % WORD_SIZE;
 
 	if (dest_prefix > size) {
 		dest_prefix = size;

--- a/drivers/flash/soc_flash_bee_nor.c
+++ b/drivers/flash/soc_flash_bee_nor.c
@@ -71,7 +71,7 @@ static const struct flash_parameters flash_bee_nor_parameters = {
 static int flash_bee_nor_check_bounds(off_t offset, size_t len)
 {
 	if (offset < 0 || offset >= FLASH_SIZE || (FLASH_SIZE - offset) < len) {
-		LOG_DBG("offset(%ld) or len(%zu) out of bounds", offset, len);
+		LOG_DBG("offset(%ld) or len(%zu) out of bounds", (long)offset, len);
 		return -EINVAL;
 	}
 
@@ -142,7 +142,7 @@ static int flash_bee_nor_erase(const struct device *dev, off_t offset, size_t le
 	}
 
 	if ((offset % FLASH_ERASE_BLK_SZ) != 0) {
-		LOG_ERR("offset %ld: not aligned to erase block size %d", offset,
+		LOG_ERR("offset %ld: not aligned to erase block size %d", (long)offset,
 			FLASH_ERASE_BLK_SZ);
 		return -EINVAL;
 	}

--- a/drivers/flash/soc_flash_cc13xx_cc26xx.c
+++ b/drivers/flash/soc_flash_cc13xx_cc26xx.c
@@ -263,7 +263,7 @@ static int flash_cc13xx_cc26xx_read(const struct device *dev, off_t offs,
 		return -EINVAL;
 	}
 
-	memcpy(data, (void *)offs, size);
+	memcpy(data, (void *)(uintptr_t)offs, size);
 
 	return 0;
 }

--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -169,7 +169,7 @@ static int flash_nrf_read(const struct device *dev, off_t addr,
 #endif
 
 	if (soc_secure_flash_range_is_secure((uintptr_t)addr, len)) {
-		return soc_secure_mem_read(data, (void *)addr, len);
+		return soc_secure_mem_read(data, (void *)(uintptr_t)addr, len);
 	}
 
 	nrf_nvmc_buffer_read(data, (uint32_t)addr, len);

--- a/drivers/flash/soc_flash_nrf_mram.c
+++ b/drivers/flash/soc_flash_nrf_mram.c
@@ -210,7 +210,7 @@ static inline bool nrf_mram_ready(uint32_t addr, uint32_t ironside_se_ver)
 static uintptr_t validate_and_map_addr(off_t offset, size_t len, bool must_align)
 {
 	if (unlikely(offset < 0 || offset >= MRAM_SIZE || len > MRAM_SIZE - offset)) {
-		LOG_ERR("invalid offset: %ld:%zu", offset, len);
+		LOG_ERR("invalid offset: %ld:%zu", (long)offset, len);
 		return 0;
 	}
 

--- a/drivers/flash/soc_flash_nrf_mramc.c
+++ b/drivers/flash/soc_flash_nrf_mramc.c
@@ -94,7 +94,7 @@ static bool validate_action(uint32_t addr, size_t len, bool must_align)
  */
 static int nrf_mramc_verify_data(off_t offset, const void *data, size_t size, bool is_erase)
 {
-	uint32_t *mram_start = (uint32_t *) MAP_TO_ADDR(offset);
+	uint32_t *mram_start = (uint32_t *) MAP_TO_ADDR((uintptr_t)offset);
 	uint32_t *mram_end = mram_start + size / sizeof(uint32_t);
 
 	if (is_erase) {

--- a/drivers/flash/soc_flash_nrf_rram.c
+++ b/drivers/flash/soc_flash_nrf_rram.c
@@ -144,7 +144,7 @@ static void commit_changes(off_t addr, size_t len)
 	 * write-only memory, then one would have to rely on
 	 * READYNEXTTIMEOUT to eventually commit the write.
 	 */
-	volatile uint8_t dummy_read = *(volatile uint8_t *)(addr + len - 1);
+	volatile uint8_t dummy_read = *(volatile uint8_t *)(uintptr_t)(addr + len - 1);
 	ARG_UNUSED(dummy_read);
 #endif
 
@@ -166,9 +166,9 @@ static void rram_write(off_t addr, const void *data, uint8_t fill_val, size_t le
 		chunk_len = MIN(len, CONFIG_NRF_RRAM_THROTTLING_DATA_BLOCK * WRITE_LINE_SIZE);
 #endif /* CONFIG_SOC_FLASH_NRF_THROTTLING */
 		if (data) {
-			memcpy((void *)addr, data, chunk_len);
+			memcpy((void *)(uintptr_t)addr, data, chunk_len);
 		} else {
-			memset((void *)addr, fill_val, chunk_len);
+			memset((void *)(uintptr_t)addr, fill_val, chunk_len);
 		}
 #ifdef CONFIG_SOC_FLASH_NRF_THROTTLING
 		addr += chunk_len;
@@ -282,7 +282,7 @@ static int nrf_write(off_t addr, const void *data, uint8_t fill_val, size_t len)
 		return 0;
 	}
 
-	LOG_DBG("Write: %p:%zu", (void *)addr, len);
+	LOG_DBG("Write: %p:%zu", (void *)(uintptr_t)addr, len);
 
 	SYNC_LOCK();
 
@@ -352,7 +352,7 @@ static int nrf_rram_fill_impl(off_t addr, uint8_t val, size_t len)
 
 	while (cur < end) {
 		while (cur < end &&
-			rram_line_holds((const uint8_t *)(cur + RRAM_START), pat)) {
+		       rram_line_holds((const uint8_t *)((uintptr_t)cur + RRAM_START), pat)) {
 			cur += WRITE_LINE_SIZE;
 		}
 		if (cur >= end) {
@@ -362,7 +362,7 @@ static int nrf_rram_fill_impl(off_t addr, uint8_t val, size_t len)
 		const off_t dirty_start = cur;
 
 		while (cur < end &&
-			!rram_line_holds((const uint8_t *)(cur + RRAM_START), pat)) {
+		       !rram_line_holds((const uint8_t *)((uintptr_t)cur + RRAM_START), pat)) {
 			cur += WRITE_LINE_SIZE;
 		}
 
@@ -388,10 +388,10 @@ static int nrf_rram_read(const struct device *dev, off_t addr, void *data, size_
 	addr += RRAM_START;
 
 	if (soc_secure_flash_range_is_secure((uintptr_t)addr, len)) {
-		return soc_secure_mem_read(data, (void *)addr, len);
+		return soc_secure_mem_read(data, (void *)(uintptr_t)addr, len);
 	}
 
-	memcpy(data, (void *)addr, len);
+	memcpy(data, (void *)(uintptr_t)addr, len);
 	return 0;
 }
 

--- a/drivers/flash/soc_flash_renesas_ra_hp.c
+++ b/drivers/flash/soc_flash_renesas_ra_hp.c
@@ -93,7 +93,7 @@ static int is_area_readable(const struct device *dev, off_t offset, size_t len)
 		}
 		if (dev_ctrl->flags & FLASH_FLAG_BLANK) {
 			LOG_DBG("read request on erased offset:0x%lx size:%d",
-				offset, len);
+				(long)offset, len);
 			result = FLASH_RESULT_BLANK;
 		}
 		atomic_and(&dev_ctrl->flags, ~(FLASH_FLAG_BLANK | FLASH_FLAG_NOT_BLANK));
@@ -132,7 +132,7 @@ static int flash_ra_read(const struct device *dev, off_t offset, void *data, siz
 #endif /* CONFIG_FLASH_RENESAS_RA_HP_CHECK_BEFORE_READING */
 
 	if (!rc) {
-		memcpy(data, (uint8_t *)(offset + flash_data->area_address), len);
+		memcpy(data, (uint8_t *)((uintptr_t)offset + flash_data->area_address), len);
 #if defined(CONFIG_FLASH_RENESAS_RA_HP_CHECK_BEFORE_READING)
 	} else if (rc == -ENODATA) {
 		/* Erased area, return dummy data as an erased page. */

--- a/drivers/otp/otp_bsec_stm32.c
+++ b/drivers/otp/otp_bsec_stm32.c
@@ -98,7 +98,7 @@ static int otp_bsec_stm32_program(const struct device *dev, off_t offset, const 
 	for (i = 0; i < nb_fuse; i++) {
 		uint32_t prog_data = 0;
 
-		LOG_DBG("Programming Fuse %lu", (offset / BSEC_WORD_SIZE) + i);
+		LOG_DBG("Programming Fuse %lu", ((unsigned long)offset / BSEC_WORD_SIZE) + i);
 
 		prog_data = UNALIGNED_GET((uint32_t *)((uint8_t *)buf + i * BSEC_WORD_SIZE));
 
@@ -142,7 +142,7 @@ static int otp_bsec_stm32_read(const struct device *dev, off_t offset, void *buf
 		size_t read_sz = MIN(BSEC_WORD_SIZE - first_offset, bytes_left);
 		uint32_t fuse_data = 0;
 
-		LOG_DBG("Reading Fuse %lu", (offset / BSEC_WORD_SIZE) + i);
+		LOG_DBG("Reading Fuse %lu", ((unsigned long)offset / BSEC_WORD_SIZE) + i);
 
 		hal_ret = HAL_BSEC_OTP_Read(&handle, (offset / BSEC_WORD_SIZE) + i, &fuse_data);
 		if (hal_ret != HAL_OK) {

--- a/include/zephyr/drivers/retained_mem.h
+++ b/include/zephyr/drivers/retained_mem.h
@@ -25,11 +25,6 @@
 extern "C" {
 #endif
 
-/** @cond INTERNAL_HIDDEN */
-BUILD_ASSERT(!(sizeof(off_t) > sizeof(size_t)),
-	     "Size of off_t must be equal or less than size of size_t");
-/** @endcond */
-
 /**
  * @brief Interfaces for retained memory.
  * @defgroup retained_mem_interface Retained memory

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -74,11 +74,15 @@ struct flash_area {
  * @brief Structure for transfer flash sector boundaries
  *
  * This template is used for presentation of flash memory structure. It
- * consumes much less RAM than @ref flash_area
+ * consumes much less RAM than @ref flash_area.
+ *
+ * This uses size_t for both offset and size, which limits flash devices
+ * to no larger than the address space of the target as a way to constrain
+ * the size of this struct.
  */
 struct flash_sector {
 	/** Sector offset from the beginning of the flash device */
-	off_t fs_off;
+	size_t fs_off;
 	/** Sector size in bytes */
 	size_t fs_size;
 };

--- a/scripts/build/gen_syscalls.py
+++ b/scripts/build/gen_syscalls.py
@@ -27,7 +27,9 @@ import argparse
 import json
 import os
 import re
+import subprocess
 import sys
+import tempfile
 
 # Some kernel headers cannot include automated tracing without causing unintended recursion or
 # other serious issues.
@@ -36,6 +38,20 @@ import sys
 notracing = ["kernel.h", "zephyr/kernel.h", "errno_private.h", "zephyr/errno_private.h"]
 
 types64 = ["int64_t", "uint64_t"]
+
+typessmall = [
+    "char",
+    "short",
+    "int",
+    "long",
+    "uint8_t",
+    "int8_t",
+    "uint16_t",
+    "int16_t",
+    "int32_t",
+    "uint32_t",
+    "size_t",
+]
 
 # The kernel linkage is complicated.  These functions from
 # userspace_handlers.c are present in the kernel .a library after
@@ -214,8 +230,96 @@ def typename_split(item):
     return (m[0].strip(), m[1])
 
 
+def compiler_type_wide(argtype):
+    # Include most of the standard C headers to try and define as many
+    # compiler types as possible
+    program = f'''
+#define _POSIX_C_SOURCE 200809L
+#define _GNU_SOURCE
+#include <sys/types.h>
+#include <ctype.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <locale.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <wchar.h>
+_Static_assert(sizeof({argtype}) > sizeof(uintptr_t));
+'''
+
+    # Write the above program to a temporary file, deleting when
+    # we're done, but not on close as we need to close it before the
+    # compiler will be able to read it on Windows
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.c', delete_on_close=False) as source_file:
+        print(program, file=source_file)
+        source_file.close()
+
+        # The c_compiler parameter is a cmake-style list with elements
+        # separated by semicolons. Split it apart, elide any empty
+        # items and then append our arguments
+        compiler = list(filter(None, args.c_compiler.split(';'))) + [
+            '-S',
+            source_file.name,
+            '-o',
+            '/dev/null',
+        ]
+
+        if not os.path.isfile(compiler[0]):
+            raise SyscallParseException(f"Cannot find compiler {compiler[0]}")
+
+        proc = subprocess.run(compiler, capture_output=True)
+
+    if proc.returncode == 0:
+        print(f"C compiler detects wide type {argtype}")
+
+    return proc.returncode == 0
+
+
+type_wide = {}
+
+typetrim = ["const", "volatile", "unsigned", "signed", "ZRESTRICT"]
+
+
+# Detect whether an argument must be split across two registers
 def need_split(argtype):
-    return (not args.long_registers) and (argtype in types64)
+    # targets with 64-bit registers can pass all params in a single register
+    if args.long_registers:
+        return False
+
+    # elide type modifiers from the type
+    while True:
+        for trim in typetrim:
+            match = re.search(f"\\b{trim}\\b", argtype)
+            if match:
+                argtype = (argtype[: match.start(0)] + argtype[match.end(0) :]).strip()
+                break
+        else:
+            break
+
+    # pointers always fit in one register
+    if argtype.endswith('*'):
+        return False
+
+    # known 64-bit types always take two registers
+    if argtype in types64:
+        return True
+
+    # known non-64-bit types always take a single register
+    if argtype in typessmall:
+        return False
+
+    # ask the compiler for help (memoizing the result)
+    if argtype not in type_wide:
+        type_wide[argtype] = compiler_type_wide(argtype)
+    return type_wide[argtype]
 
 
 # Note: "lo" and "hi" are named in little endian conventions,
@@ -494,6 +598,11 @@ def parse_args():
         "--userspace-only",
         action="store_true",
         help="Only generate the userpace path of wrappers",
+    )
+    parser.add_argument(
+        "-c",
+        "--c-compiler",
+        help="C compiler command line",
     )
     args = parser.parse_args()
 

--- a/subsys/bluetooth/services/ots/ots_client.c
+++ b/subsys/bluetooth/services/ots/ots_client.c
@@ -1421,12 +1421,13 @@ int bt_ots_client_write_object_data(struct bt_ots_client *otc_inst,
 	}
 
 	if ((sizeof(offset) > sizeof(uint32_t) && (offset > UINT32_MAX)) || (offset < 0)) {
-		LOG_ERR("offset %ld exceeds UINT32 and must be >= 0", offset);
+		LOG_ERR("offset %ld exceeds UINT32 and must be >= 0", (long)offset);
 		return -EINVAL;
 	}
 
 	if (offset > otc_inst->cur_object.size.cur) {
-		LOG_ERR("offset %ld exceeds cur size %zu", offset, otc_inst->cur_object.size.cur);
+		LOG_ERR("offset %ld exceeds cur size %zu",
+			(long)offset, otc_inst->cur_object.size.cur);
 		return -EINVAL;
 	}
 
@@ -1438,8 +1439,8 @@ int bt_ots_client_write_object_data(struct bt_ots_client *otc_inst,
 
 	if (((len + offset) > otc_inst->cur_object.size.alloc) &&
 	    !BT_OTS_OBJ_GET_PROP_APPEND(otc_inst->cur_object.props)) {
-		LOG_ERR("APPEND is not supported. Invalid new end of object %lu alloc %zu."
-		, (len + offset), otc_inst->cur_object.size.alloc);
+		LOG_ERR("APPEND is not supported. Invalid new end of object %lu alloc %zu.",
+			(len + (long)offset), otc_inst->cur_object.size.alloc);
 		return -EINVAL;
 	}
 
@@ -1482,13 +1483,14 @@ int bt_ots_client_get_object_checksum(struct bt_ots_client *otc_inst, struct bt_
 	}
 
 	if ((sizeof(offset) > sizeof(uint32_t) && (offset > UINT32_MAX)) || (offset < 0)) {
-		LOG_DBG("offset exceeds %ld UINT32 and must be >= 0", offset);
+		LOG_DBG("offset exceeds %ld UINT32 and must be >= 0", (long)offset);
 		return -EINVAL;
 	}
 
 	if ((len + offset) > otc_inst->cur_object.size.cur) {
 		LOG_DBG("The sum of offset (%ld) and length (%zu) exceed the Current Size %lu "
-			"alloc %zu.", offset, len, (len + offset), otc_inst->cur_object.size.cur);
+			"alloc %zu.", (long)offset, len, (len + (long)offset),
+			otc_inst->cur_object.size.cur);
 		return -EINVAL;
 	}
 

--- a/subsys/debug/coredump/coredump_backend_in_memory.c
+++ b/subsys/debug/coredump/coredump_backend_in_memory.c
@@ -69,7 +69,7 @@ static int in_memory_is_valid(void)
 static int in_memory_copy_to(struct coredump_cmd_copy_arg *copy_arg)
 {
 	LOG_DBG("Copy to: %p offset: %lu length: %lu",
-		(void *)copy_arg->buffer, copy_arg->offset,
+		(void *)copy_arg->buffer, (unsigned long)copy_arg->offset,
 		(unsigned long)copy_arg->length);
 
 	if (copy_arg->buffer == NULL ||

--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -445,7 +445,7 @@ ZTEST(flash_driver, test_flash_page_layout)
 	/* Get page info with flash_get_page_info_by_offs() */
 	rc = flash_get_page_info_by_offs(flash_dev, TEST_AREA_OFFSET, &page_info_off);
 	zassert_true(rc == 0, "flash_get_page_info_by_offs returned %d", rc);
-	TC_PRINT("start_offset=0x%lx\tsize=%d\tindex=%d\n", page_info_off.start_offset,
+	TC_PRINT("start_offset=0x%lx\tsize=%d\tindex=%d\n", (long)page_info_off.start_offset,
 		 (int)page_info_off.size, page_info_off.index);
 	zassert_true(page_info_off.start_offset >= 0, "start_offset is %d", rc);
 	zassert_true(page_info_off.size > 0, "size is %d", rc);
@@ -497,8 +497,8 @@ static void test_flash_copy_inner(const struct device *src_dev, off_t src_offset
 	actual_result = flash_copy(src_dev, src_offset, dst_dev, dst_offset, size, buf, buf_size);
 	zassert_equal(actual_result, expected_result,
 		      "flash_copy(%p, %lx, %p, %lx, %zu, %p, %zu) failed: expected: %d actual: %d",
-		      src_dev, src_offset, dst_dev, dst_offset, (size_t)size, buf, buf_size,
-		      expected_result, actual_result);
+		      src_dev, (long)src_offset, dst_dev, (long)dst_offset, (size_t)size,
+		      buf, buf_size, expected_result, actual_result);
 
 	if ((expected_result == 0) && (size != 0) && (src_offset != dst_offset)) {
 		/* verify a successful copy */

--- a/tests/subsys/portability/posix/multi_process/src/times.c
+++ b/tests/subsys/portability/posix/multi_process/src/times.c
@@ -43,12 +43,14 @@ ZTEST(posix_multi_process, test_times)
 	zexpect_not_equal(rtime[0], -1);
 	zexpect_not_equal(rtime[1], -1);
 
-	printk("t0: rtime: %ld utime: %ld stime: %ld cutime: %ld cstime: %ld\n", rtime[0],
-	       test_tms[0].tms_utime, test_tms[0].tms_stime, test_tms[0].tms_cutime,
-	       test_tms[0].tms_cstime);
-	printk("t1: rtime: %ld utime: %ld stime: %ld cutime: %ld cstime: %ld\n", rtime[1],
-	       test_tms[1].tms_utime, test_tms[1].tms_stime, test_tms[1].tms_cutime,
-	       test_tms[1].tms_cstime);
+	printk("t0: rtime: %lld utime: %lld stime: %lld cutime: %lld cstime: %lld\n",
+	       (long long)rtime[0],
+	       (long long)test_tms[0].tms_utime, (long long)test_tms[0].tms_stime,
+	       (long long)test_tms[0].tms_cutime, (long long)test_tms[0].tms_cstime);
+	printk("t1: rtime: %lld utime: %lld stime: %lld cutime: %lld cstime: %lld\n",
+	       (long long)rtime[1],
+	       (long long)test_tms[1].tms_utime, (long long)test_tms[1].tms_stime,
+	       (long long)test_tms[1].tms_cutime, (long long)test_tms[1].tms_cstime);
 
 	ARRAY_FOR_EACH(fields, i) {
 		const char *name = fields[i].name;
@@ -57,7 +59,7 @@ ZTEST(posix_multi_process, test_times)
 		clock_t t0 = *(clock_t *)((uint8_t *)&test_tms[0] + offset);
 		clock_t t1 = *(clock_t *)((uint8_t *)&test_tms[1] + offset);
 
-		zexpect_true(t1 >= t0, "time moved backward for tms_%s: t0: %ld t1: %ld", name, t0,
-			     t1);
+		zexpect_true(t1 >= t0, "time moved backward for tms_%s: t0: %lld t1: %lld",
+			     name, (long long)t0, (long long)t1);
 	}
 }


### PR DESCRIPTION
Picolibc 1.8.12 uses a 64-bit type for 'off_t' on all targets to avoid having file size constrained by the processor register size.

Zephyr assumes that off_t is 'long' in some places and that it is the same size as a pointer in other places.

Add explicit casts to either long or uintptr_t as appropriate so that the compiler doesn't complain about mis-matching pointer/integer sizes and so that printf format directives work correctly. For systems where off_t *is* long, these should all be no-ops.