### PR TITLE
MAINTAINERS: Fix and update bflb boards matching

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -899,14 +899,17 @@ Bouffalolab Platforms:
     - josuah
     - will-tm
   files:
+    - boards/bflb/
     - boards/**/*bflb*
     - boards/**/*bflb*/
     - boards/aithinker/ai_*/
+    - boards/aithinker/aipi_eyes_s2/
     - boards/doiting/
-    - boards/thirdreality/
+    - boards/qcom/qcc74*/
     - boards/sipeed/m0sense/
     - boards/sipeed/m1s_dock/
     - boards/sipeed/maix_m0s_dock/
+    - boards/thirdreality/
     - drivers/**/*bflb*
     - drivers/**/*bflb*/
     - dts/riscv/bflb/


### PR DESCRIPTION
It misses some boards maintained as part of the BFLB port