### PR TITLE
tests: drivers: clock_control: Added pic32cxsg test support files

### DIFF
--- a/tests/drivers/clock_control/clock_control_api/boards/pic32cx_sg41_cult.conf
+++ b/tests/drivers/clock_control/clock_control_api/boards/pic32cx_sg41_cult.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CLOCK_CONTROL_MCHP_ASYNC_ON=y

--- a/tests/drivers/clock_control/clock_control_api/boards/pic32cx_sg41_cult.overlay
+++ b/tests/drivers/clock_control/clock_control_api/boards/pic32cx_sg41_cult.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&clock {
+	mclkperiph: mclkperiph {
+		compatible = "microchip,sam-d5x-e5x-mclkperiph";
+		#clock-cells = <1>;
+
+		sercom3 {
+			subsystem = <CLOCK_MCHP_MCLKPERIPH_ID_APBB_SERCOM3>;
+			mclk-en = <1>;
+		};
+	};
+
+	gclkperiph: gclkperiph {
+		compatible = "microchip,sam-d5x-e5x-gclkperiph";
+		#clock-cells = <1>;
+
+		sercom4 {
+			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_SERCOM3_CORE>;
+			gclkperiph-src = "gclk0";
+			gclkperiph-en = <1>;
+		};
+	};
+};

--- a/tests/drivers/clock_control/clock_control_api/boards/pic32cx_sg61_cult.conf
+++ b/tests/drivers/clock_control/clock_control_api/boards/pic32cx_sg61_cult.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Microchip Technology Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CLOCK_CONTROL_MCHP_ASYNC_ON=y

--- a/tests/drivers/clock_control/clock_control_api/boards/pic32cx_sg61_cult.overlay
+++ b/tests/drivers/clock_control/clock_control_api/boards/pic32cx_sg61_cult.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&clock {
+	mclkperiph: mclkperiph {
+		compatible = "microchip,sam-d5x-e5x-mclkperiph";
+		#clock-cells = <1>;
+
+		sercom3 {
+			subsystem = <CLOCK_MCHP_MCLKPERIPH_ID_APBB_SERCOM3>;
+			mclk-en = <1>;
+		};
+	};
+
+	gclkperiph: gclkperiph {
+		compatible = "microchip,sam-d5x-e5x-gclkperiph";
+		#clock-cells = <1>;
+
+		sercom4 {
+			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_SERCOM3_CORE>;
+			gclkperiph-src = "gclk0";
+			gclkperiph-en = <1>;
+		};
+	};
+};

--- a/tests/drivers/clock_control/clock_control_api/boards/sam_e54_xpro.overlay
+++ b/tests/drivers/clock_control/clock_control_api/boards/sam_e54_xpro.overlay
@@ -20,7 +20,7 @@
 		#clock-cells = <1>;
 
 		sercom4 {
-			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_SERCOM4_CORE>;
+			subsystem = <CLOCK_MCHP_GCLKPERIPH_ID_SERCOM3_CORE>;
 			gclkperiph-src = "gclk0";
 			gclkperiph-en = <1>;
 		};

--- a/tests/drivers/clock_control/clock_control_api/src/mchp_device_subsys.h
+++ b/tests/drivers/clock_control/clock_control_api/src/mchp_device_subsys.h
@@ -20,7 +20,7 @@
 static const struct device_subsys_data subsys_data[] = {
 #if defined CONFIG_SOC_FAMILY_MICROCHIP_SAM_D5X_E5X
 	{.subsys = (void *)CLOCK_MCHP_MCLKPERIPH_ID_APBB_SERCOM3},
-	{.subsys = (void *)CLOCK_MCHP_GCLKPERIPH_ID_SERCOM4_CORE},
+	{.subsys = (void *)CLOCK_MCHP_GCLKPERIPH_ID_SERCOM3_CORE},
 	{
 		.subsys = (void *)CLOCK_MCHP_XOSC_ID_XOSC1,
 		.startup_us = XOSC_STARTUP_US,

--- a/tests/drivers/clock_control/clock_control_api/src/mchp_device_subsys.h
+++ b/tests/drivers/clock_control/clock_control_api/src/mchp_device_subsys.h
@@ -5,7 +5,8 @@
  */
 
 #include "device_subsys.h"
-#if defined CONFIG_SOC_FAMILY_MICROCHIP_SAM_D5X_E5X
+#if defined(CONFIG_SOC_FAMILY_MICROCHIP_SAM_D5X_E5X) || \
+	defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CX_SG)
 #include <zephyr/drivers/clock_control/mchp_clock_sam_d5x_e5x.h>
 #include <zephyr/dt-bindings/clock/mchp_sam_d5x_e5x_clock.h>
 #endif /* CONFIG_SOC_FAMILY_MICROCHIP_SAM_D5X_E5X */
@@ -18,7 +19,8 @@
 #define XOSC_STARTUP_US 500
 
 static const struct device_subsys_data subsys_data[] = {
-#if defined CONFIG_SOC_FAMILY_MICROCHIP_SAM_D5X_E5X
+#if defined(CONFIG_SOC_FAMILY_MICROCHIP_SAM_D5X_E5X) || \
+	defined(CONFIG_SOC_FAMILY_MICROCHIP_PIC32CX_SG)
 	{.subsys = (void *)CLOCK_MCHP_MCLKPERIPH_ID_APBB_SERCOM3},
 	{.subsys = (void *)CLOCK_MCHP_GCLKPERIPH_ID_SERCOM3_CORE},
 	{

--- a/tests/drivers/clock_control/clock_control_api/tests.yaml
+++ b/tests/drivers/clock_control/clock_control_api/tests.yaml
@@ -16,6 +16,8 @@ tests:
       - bg29_rb4420a
       - sam_e54_xpro
       - pic32cm_jh01_cpro
+      - pic32cx_sg41_cult
+      - pic32cx_sg61_cult
     integration_platforms:
       - esp32_devkitc/esp32/procpu
   drivers.clock.clock_control_nrf5:


### PR DESCRIPTION
Updated mchp_device_subsys.h for the PIC32CX SG family.
Added PIC32CX SG overlay files and .conf files.
Added pic32cx_sg41 and pic32cx_sg61 to the platform_allow list in tests.yaml.