### PR TITLE
west.yml: MCUboot synchronization from v3.7-branch

### DIFF
--- a/tests/boot/mcuboot_data_sharing/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/boot/mcuboot_data_sharing/boards/nrf52840dk_nrf52840.overlay
@@ -48,11 +48,11 @@
 		};
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x00022000>;
+			reg = <0x00020000 0x00023000>;
 		};
-		slot1_partition: partition@42000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x00042000 0x00024000>;
+			reg = <0x00043000 0x00022000>;
 		};
 	};
 };

--- a/tests/boot/mcuboot_recovery_retention/testcase.yaml
+++ b/tests/boot/mcuboot_recovery_retention/testcase.yaml
@@ -11,11 +11,9 @@ common:
     type: multi_line
     regex:
       - "mcuboot_status: 0"
-      - "mcuboot_status: 1"
       - "mcuboot_status: 2"
       - "Waiting..."
       - "mcuboot_status: 0"
-      - "mcuboot_status: 1"
       - "mcuboot_status: 8"
       - "Starting bootloader"
       - "Secondary image: magic"

--- a/west.yml
+++ b/west.yml
@@ -287,7 +287,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 6127fc06a54d7a364626a96a33ae652703b505e4
+      revision: 34be198cb34e324bf92319dd47fdddcb77f197dc
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  34be198cb34e324bf92319dd47fdddcb77f197dc

Brings following Zephyr relevant fixes:

  - 34be198c boot_serial: check flash_area_get_sector() return in decrypt_image_inplace()
  - 65e67e27 boot: bootutil: loader: Fix bootstrap with swap modes
  - 13751f8c boot: bootutil: clear AES key schedule in the Tinycrypt aes_ctr_drop
  - 5e2d5db3 boot: boot_serial: clear decrypted plaintext from in-place decrypt buffer
  - 4c3df4ff boot: boot_serial: clear AES key material from stack after in-place decrypt
  - 010eaf64 boot: bootutil: add bootutil_wipe_memory secure-zero helper
  - 37b7f133 boot: bootutil: loader: Fix bootstrap copying in swap move mode
  - 969355bc boot_serial: Fix double boot_loader_state init
  - ef63e09c bootutil: Refactor boot_read_enc_key
  - 8950ce3c boot: bootutil: fix image_index definition
  - 30558d6b boot: zephyr: Fix IO-based entrance method
  - cd7ee9f8 boot: bootutil: write_sz fix
  - 399d897a boot: boot_serial/bootutil: Fix missing changes

Fixes #114928