### PR TITLE
sensor: st: lps22hh: lps22hb compatibility

### DIFF
--- a/drivers/sensor/st/lps22hh/Kconfig
+++ b/drivers/sensor/st/lps22hh/Kconfig
@@ -4,19 +4,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig LPS22HH
-	bool "LPS22HH pressure and temperature"
+	bool "LPS22HH/LPS22HB pressure and temperature"
 	default y
-	depends on DT_HAS_ST_LPS22HH_ENABLED
+	depends on DT_HAS_ST_LPS22HH_ENABLED || DT_HAS_ST_LPS22HX_ENABLED
 	depends on ZEPHYR_HAL_ST_MODULE
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22HH),i2c)
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22HX),i2c)
 	select I3C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22HH),i3c)
 	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22HH),spi)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22HX),spi)
 	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_ST_LPS22HH),drdy-gpios)
 	select HAS_STMEMSC
 	select USE_STDC_LPS22HH
 	help
-	  Enable driver for LPS22HH I2C-based pressure and temperature
-	  sensor.
+	  Enable driver for LPS22HH/LPS22HB I2C-based pressure and
+	  temperature sensor.
 
 if LPS22HH
 

--- a/drivers/sensor/st/lps22hh/lps22hh.c
+++ b/drivers/sensor/st/lps22hh/lps22hh.c
@@ -8,8 +8,6 @@
  * https://www.st.com/resource/en/datasheet/lps22hh.pdf
  */
 
-#define DT_DRV_COMPAT st_lps22hh
-
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
 #include <zephyr/pm/device.h>
@@ -18,6 +16,8 @@
 #include <zephyr/logging/log.h>
 
 #include "lps22hh.h"
+
+#define LPS22HB_ID 0xB1
 
 LOG_MODULE_REGISTER(LPS22HH, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -35,15 +35,22 @@ static const uint16_t lps22hh_map[] = {0, 1, 10, 25, 50, 75, 100, 200};
 
 static int lps22hh_odr_set(const struct device *dev, uint16_t freq)
 {
+	struct lps22hh_data *data = dev->data;
+	uint8_t map_size = ARRAY_SIZE(lps22hh_map);
 	int odr;
 
-	for (odr = 0; odr < ARRAY_SIZE(lps22hh_map); odr++) {
+	if (data->is_lps22hb) {
+		/* LPS22HB does not support 100Hz or 200Hz */
+		map_size -= 2;
+	}
+
+	for (odr = 0; odr < map_size; odr++) {
 		if (freq == lps22hh_map[odr]) {
 			break;
 		}
 	}
 
-	if (odr == ARRAY_SIZE(lps22hh_map)) {
+	if (odr == map_size) {
 		LOG_DBG("bad frequency");
 		return -EINVAL;
 	}
@@ -210,6 +217,7 @@ static DEVICE_API(sensor, lps22hh_driver_api) = {
 static int lps22hh_init_chip(const struct device *dev)
 {
 	const struct lps22hh_config *const cfg = dev->config;
+	struct lps22hh_data *data = dev->data;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	uint8_t chip_id;
 	int ret;
@@ -220,13 +228,17 @@ static int lps22hh_init_chip(const struct device *dev)
 	}
 
 	if (chip_id != LPS22HH_ID) {
-		LOG_ERR("%s: Invalid chip ID 0x%02x", dev->name, chip_id);
-		return -EIO;
+		if (cfg->lps22hb_compat && (chip_id == LPS22HB_ID)) {
+			data->is_lps22hb = true;
+		} else {
+			LOG_ERR("%s: Invalid chip ID 0x%02x", dev->name, chip_id);
+			return -EIO;
+		}
 	}
 
 	LOG_DBG("%s: chip id 0x%x", dev->name, chip_id);
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+#if LPS22H_ANY_INST_ON_BUS(i3c)
 	if (cfg->i3c.bus != NULL) {
 		/*
 		 * Enabling I3C and disabling I2C are required
@@ -319,7 +331,7 @@ static int lps22hh_pm_action(const struct device *dev, enum pm_device_action act
 
 static int lps22hh_init(const struct device *dev)
 {
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+#if LPS22H_ANY_INST_ON_BUS(i3c)
 	const struct lps22hh_config *const cfg = dev->config;
 	struct lps22hh_data *data = dev->data;
 
@@ -345,7 +357,7 @@ static int lps22hh_init(const struct device *dev)
 	return pm_device_driver_init(dev, lps22hh_pm_action);
 }
 
-#if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 0
+#if (DT_NUM_INST_STATUS_OKAY(st_lps22hh) == 0) && (DT_NUM_INST_STATUS_OKAY(st_lps22hx) == 0)
 #warning "LPS22HH driver enabled without any devices"
 #endif
 
@@ -359,72 +371,74 @@ static int lps22hh_init(const struct device *dev)
 #define LPS22HH_CFG_IRQ(inst)
 #endif /* CONFIG_LPS22HH_TRIGGER */
 
-#define LPS22HH_CONFIG_COMMON(inst)                                     \
-	.odr = DT_INST_PROP(inst, odr),                                 \
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, drdy_gpios),		\
-			(LPS22HH_CFG_IRQ(inst)), ())
+#define LPS22HH_CONFIG_COMMON(inst)                                                                \
+	.odr = DT_INST_PROP(inst, odr),                                                            \
+	.lps22hb_compat = DT_NODE_HAS_COMPAT(DT_DRV_INST(inst), st_lps22hx),                       \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, drdy_gpios), (LPS22HH_CFG_IRQ(inst)), ())
 
 #define LPS22HH_SPI_OPERATION (SPI_WORD_SET(8) | SPI_OP_MODE_MASTER | SPI_MODE_CPOL | SPI_MODE_CPHA)
 
-#define LPS22HH_CONFIG_SPI(inst)                                        \
-	{                                                               \
-		STMEMSC_CTX_SPI(&lps22hh_config_##inst.stmemsc_cfg),    \
-		.stmemsc_cfg =  {                                       \
-			.spi = SPI_DT_SPEC_INST_GET(inst,		\
-				LPS22HH_SPI_OPERATION)			\
-		},                                                      \
-		LPS22HH_CONFIG_COMMON(inst)                             \
-	}
+#define LPS22H_CONFIG_SPI(inst, cfg)                                                               \
+	{STMEMSC_CTX_SPI(&cfg.stmemsc_cfg),                                                        \
+	 .stmemsc_cfg = {.spi = SPI_DT_SPEC_INST_GET(inst, LPS22HH_SPI_OPERATION)},                \
+	 LPS22HH_CONFIG_COMMON(inst)}
 
 /*
  * Instantiation macros used when a device is on an I2C bus.
  */
 
-#define LPS22HH_CONFIG_I2C(inst)                                          \
-	{                                                                 \
-		STMEMSC_CTX_I2C(&lps22hh_config_##inst.stmemsc_cfg),      \
-		.stmemsc_cfg =  {                                         \
-			.i2c = I2C_DT_SPEC_INST_GET(inst),                \
-		},                                                        \
-		LPS22HH_CONFIG_COMMON(inst)                               \
-	}
+#define LPS22H_CONFIG_I2C(inst, cfg)                                                               \
+	{STMEMSC_CTX_I2C(&cfg.stmemsc_cfg),                                                        \
+	 .stmemsc_cfg =                                                                            \
+		 {                                                                                 \
+			 .i2c = I2C_DT_SPEC_INST_GET(inst),                                        \
+		 },                                                                                \
+	 LPS22HH_CONFIG_COMMON(inst)}
 
 /*
  * Instantiation macros used when a device is on an I#C bus.
  */
 
-#define LPS22HH_CONFIG_I3C(inst)					\
-	{								\
-		STMEMSC_CTX_I3C(&lps22hh_config_##inst.stmemsc_cfg),	\
-		.stmemsc_cfg = {					\
-			.i3c = &lps22hh_data_##inst.i3c_dev,		\
-		},							\
-		.i3c.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),		\
-		.i3c.dev_id = I3C_DEVICE_ID_DT_INST(inst),		\
-		LPS22HH_CONFIG_COMMON(inst)				\
-	}
+#define LPS22H_CONFIG_I3C(inst, cfg, data)                                                         \
+	{STMEMSC_CTX_I3C(&cfg.stmemsc_cfg),                                                        \
+	 .stmemsc_cfg =                                                                            \
+		 {                                                                                 \
+			 .i3c = &data.i3c_dev,                                                     \
+		 },                                                                                \
+	 .i3c.bus = DEVICE_DT_GET(DT_INST_BUS(inst)), .i3c.dev_id = I3C_DEVICE_ID_DT_INST(inst),   \
+	 LPS22HH_CONFIG_COMMON(inst)}
 
-#define LPS22HH_CONFIG_I3C_OR_I2C(inst)					\
-	COND_CODE_0(DT_INST_PROP_BY_IDX(inst, reg, 1),			\
-		(LPS22HH_CONFIG_I2C(inst)),				\
-		(LPS22HH_CONFIG_I3C(inst)))
+#define LPS22H_CONFIG_I3C_OR_I2C(inst, cfg, data)                                                  \
+	COND_CODE_0(DT_INST_PROP_BY_IDX(inst, reg, 1), (LPS22H_CONFIG_I2C(inst, cfg)),             \
+		    (LPS22H_CONFIG_I3C(inst, cfg, data)))
+
+/* Use of COND_CODE_1() selects the right bus-specific macro at preprocessor time.*/
+#define LPS22H_CONFIG(inst, cfg, data)                                                             \
+	COND_CODE_1(DT_INST_ON_BUS(inst, spi), (LPS22H_CONFIG_SPI(inst, cfg)),                     \
+		    (COND_CODE_1(DT_INST_ON_BUS(inst, i3c),                                        \
+				 (LPS22H_CONFIG_I3C_OR_I2C(inst, cfg, data)),                      \
+				 (LPS22H_CONFIG_I2C(inst, cfg)))))
 
 /*
- * Main instantiation macro. Use of COND_CODE_1() selects the right
- * bus-specific macro at preprocessor time.
+ * Main instantiation macro
  */
-
-#define LPS22HH_DEFINE(inst)							\
-	static struct lps22hh_data lps22hh_data_##inst;				\
-	static const struct lps22hh_config lps22hh_config_##inst =		\
-	COND_CODE_1(DT_INST_ON_BUS(inst, spi),					\
-			(LPS22HH_CONFIG_SPI(inst)),				\
-			(COND_CODE_1(DT_INST_ON_BUS(inst, i3c),			\
-				(LPS22HH_CONFIG_I3C_OR_I2C(inst)),		\
-				(LPS22HH_CONFIG_I2C(inst)))));			\
+#define LPS22H_DEFINE(inst, name)                                                                  \
+	static struct lps22hh_data name##_data_##inst;                                             \
+	static const struct lps22hh_config name##_config_##inst =                                  \
+		LPS22H_CONFIG(inst, name##_config_##inst, name##_data_##inst);                     \
 	PM_DEVICE_DT_INST_DEFINE(inst, lps22hh_pm_action);                                         \
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, lps22hh_init, PM_DEVICE_DT_INST_GET(inst),              \
-				     &lps22hh_data_##inst, &lps22hh_config_##inst, POST_KERNEL,    \
+				     &name##_data_##inst, &name##_config_##inst, POST_KERNEL,      \
 				     CONFIG_SENSOR_INIT_PRIORITY, &lps22hh_driver_api);
 
+#define LPS22HH_DEFINE(inst) LPS22H_DEFINE(inst, lps22hh)
+
+#define LPS22HX_DEFINE(inst) LPS22H_DEFINE(inst, lps22hx)
+
+#define DT_DRV_COMPAT st_lps22hh
 DT_INST_FOREACH_STATUS_OKAY(LPS22HH_DEFINE)
+#undef DT_DRV_COMPAT
+
+#define DT_DRV_COMPAT st_lps22hx
+DT_INST_FOREACH_STATUS_OKAY(LPS22HX_DEFINE)
+#undef DT_DRV_COMPAT

--- a/drivers/sensor/st/lps22hh/lps22hh.c
+++ b/drivers/sensor/st/lps22hh/lps22hh.c
@@ -8,8 +8,6 @@
  * https://www.st.com/resource/en/datasheet/lps22hh.pdf
  */
 
-#define DT_DRV_COMPAT st_lps22hh
-
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/kernel.h>
 #include <zephyr/pm/device.h>
@@ -18,6 +16,8 @@
 #include <zephyr/logging/log.h>
 
 #include "lps22hh.h"
+
+#define LPS22HB_ID 0xB1
 
 LOG_MODULE_REGISTER(LPS22HH, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -35,15 +35,22 @@ static const uint16_t lps22hh_map[] = {0, 1, 10, 25, 50, 75, 100, 200};
 
 static int lps22hh_odr_set(const struct device *dev, uint16_t freq)
 {
+	struct lps22hh_data *data = dev->data;
+	uint8_t map_size = ARRAY_SIZE(lps22hh_map);
 	int odr;
 
-	for (odr = 0; odr < ARRAY_SIZE(lps22hh_map); odr++) {
+	if (data->is_lps22hb) {
+		/* LPS22HB does not support 100Hz or 200Hz */
+		map_size -= 2;
+	}
+
+	for (odr = 0; odr < map_size; odr++) {
 		if (freq == lps22hh_map[odr]) {
 			break;
 		}
 	}
 
-	if (odr == ARRAY_SIZE(lps22hh_map)) {
+	if (odr == map_size) {
 		LOG_DBG("bad frequency");
 		return -EINVAL;
 	}
@@ -210,6 +217,7 @@ static DEVICE_API(sensor, lps22hh_driver_api) = {
 static int lps22hh_init_chip(const struct device *dev)
 {
 	const struct lps22hh_config *const cfg = dev->config;
+	struct lps22hh_data *data = dev->data;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	uint8_t chip_id;
 	int ret;
@@ -220,13 +228,17 @@ static int lps22hh_init_chip(const struct device *dev)
 	}
 
 	if (chip_id != LPS22HH_ID) {
-		LOG_ERR("%s: Invalid chip ID 0x%02x", dev->name, chip_id);
-		return -EIO;
+		if (cfg->lps22hb_compat && (chip_id == LPS22HB_ID)) {
+			data->is_lps22hb = true;
+		} else {
+			LOG_ERR("%s: Invalid chip ID 0x%02x", dev->name, chip_id);
+			return -EIO;
+		}
 	}
 
 	LOG_DBG("%s: chip id 0x%x", dev->name, chip_id);
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+#if LPS22H_ANY_INST_ON_BUS(i3c)
 	if (cfg->i3c.bus != NULL) {
 		/*
 		 * Enabling I3C and disabling I2C are required
@@ -319,7 +331,7 @@ static int lps22hh_pm_action(const struct device *dev, enum pm_device_action act
 
 static int lps22hh_init(const struct device *dev)
 {
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+#if LPS22H_ANY_INST_ON_BUS(i3c)
 	const struct lps22hh_config *const cfg = dev->config;
 	struct lps22hh_data *data = dev->data;
 
@@ -345,7 +357,7 @@ static int lps22hh_init(const struct device *dev)
 	return pm_device_driver_init(dev, lps22hh_pm_action);
 }
 
-#if DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 0
+#if (DT_NUM_INST_STATUS_OKAY(st_lps22hh) == 0) && (DT_NUM_INST_STATUS_OKAY(st_lps22hx) == 0)
 #warning "LPS22HH driver enabled without any devices"
 #endif
 
@@ -359,73 +371,75 @@ static int lps22hh_init(const struct device *dev)
 #define LPS22HH_CFG_IRQ(inst)
 #endif /* CONFIG_LPS22HH_TRIGGER */
 
-#define LPS22HH_CONFIG_COMMON(inst)                                     \
-	.odr = DT_INST_PROP(inst, odr),                                 \
-	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, drdy_gpios),		\
-			(LPS22HH_CFG_IRQ(inst)), ())
+#define LPS22HH_CONFIG_COMMON(inst)                                                                \
+	.odr = DT_INST_PROP(inst, odr),                                                            \
+	.lps22hb_compat = DT_NODE_HAS_COMPAT(DT_DRV_INST(inst), st_lps22hx),                       \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, drdy_gpios), (LPS22HH_CFG_IRQ(inst)), ())
 
 #define LPS22HH_SPI_OPERATION                                           \
 	(SPI_WORD_SET(8) | SPI_OP_MODE_CONTROLLER | SPI_MODE_CPOL | SPI_MODE_CPHA)
 
-#define LPS22HH_CONFIG_SPI(inst)                                        \
-	{                                                               \
-		STMEMSC_CTX_SPI(&lps22hh_config_##inst.stmemsc_cfg),    \
-		.stmemsc_cfg =  {                                       \
-			.spi = SPI_DT_SPEC_INST_GET(inst,		\
-				LPS22HH_SPI_OPERATION)			\
-		},                                                      \
-		LPS22HH_CONFIG_COMMON(inst)                             \
-	}
+#define LPS22H_CONFIG_SPI(inst, cfg)                                                               \
+	{STMEMSC_CTX_SPI(&cfg.stmemsc_cfg),                                                        \
+	 .stmemsc_cfg = {.spi = SPI_DT_SPEC_INST_GET(inst, LPS22HH_SPI_OPERATION)},                \
+	 LPS22HH_CONFIG_COMMON(inst)}
 
 /*
  * Instantiation macros used when a device is on an I2C bus.
  */
 
-#define LPS22HH_CONFIG_I2C(inst)                                          \
-	{                                                                 \
-		STMEMSC_CTX_I2C(&lps22hh_config_##inst.stmemsc_cfg),      \
-		.stmemsc_cfg =  {                                         \
-			.i2c = I2C_DT_SPEC_INST_GET(inst),                \
-		},                                                        \
-		LPS22HH_CONFIG_COMMON(inst)                               \
-	}
+#define LPS22H_CONFIG_I2C(inst, cfg)                                                               \
+	{STMEMSC_CTX_I2C(&cfg.stmemsc_cfg),                                                        \
+	 .stmemsc_cfg =                                                                            \
+		 {                                                                                 \
+			 .i2c = I2C_DT_SPEC_INST_GET(inst),                                        \
+		 },                                                                                \
+	 LPS22HH_CONFIG_COMMON(inst)}
 
 /*
  * Instantiation macros used when a device is on an I#C bus.
  */
 
-#define LPS22HH_CONFIG_I3C(inst)					\
-	{								\
-		STMEMSC_CTX_I3C(&lps22hh_config_##inst.stmemsc_cfg),	\
-		.stmemsc_cfg = {					\
-			.i3c = &lps22hh_data_##inst.i3c_dev,		\
-		},							\
-		.i3c.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),		\
-		.i3c.dev_id = I3C_DEVICE_ID_DT_INST(inst),		\
-		LPS22HH_CONFIG_COMMON(inst)				\
-	}
+#define LPS22H_CONFIG_I3C(inst, cfg, data)                                                         \
+	{STMEMSC_CTX_I3C(&cfg.stmemsc_cfg),                                                        \
+	 .stmemsc_cfg =                                                                            \
+		 {                                                                                 \
+			 .i3c = &data.i3c_dev,                                                     \
+		 },                                                                                \
+	 .i3c.bus = DEVICE_DT_GET(DT_INST_BUS(inst)), .i3c.dev_id = I3C_DEVICE_ID_DT_INST(inst),   \
+	 LPS22HH_CONFIG_COMMON(inst)}
 
-#define LPS22HH_CONFIG_I3C_OR_I2C(inst)					\
-	COND_CODE_0(DT_INST_PROP_BY_IDX(inst, reg, 1),			\
-		(LPS22HH_CONFIG_I2C(inst)),				\
-		(LPS22HH_CONFIG_I3C(inst)))
+#define LPS22H_CONFIG_I3C_OR_I2C(inst, cfg, data)                                                  \
+	COND_CODE_0(DT_INST_PROP_BY_IDX(inst, reg, 1), (LPS22H_CONFIG_I2C(inst, cfg)),             \
+		    (LPS22H_CONFIG_I3C(inst, cfg, data)))
+
+/* Use of COND_CODE_1() selects the right bus-specific macro at preprocessor time.*/
+#define LPS22H_CONFIG(inst, cfg, data)                                                             \
+	COND_CODE_1(DT_INST_ON_BUS(inst, spi), (LPS22H_CONFIG_SPI(inst, cfg)),                     \
+		    (COND_CODE_1(DT_INST_ON_BUS(inst, i3c),                                        \
+				 (LPS22H_CONFIG_I3C_OR_I2C(inst, cfg, data)),                      \
+				 (LPS22H_CONFIG_I2C(inst, cfg)))))
 
 /*
- * Main instantiation macro. Use of COND_CODE_1() selects the right
- * bus-specific macro at preprocessor time.
+ * Main instantiation macro
  */
-
-#define LPS22HH_DEFINE(inst)							\
-	static struct lps22hh_data lps22hh_data_##inst;				\
-	static const struct lps22hh_config lps22hh_config_##inst =		\
-	COND_CODE_1(DT_INST_ON_BUS(inst, spi),					\
-			(LPS22HH_CONFIG_SPI(inst)),				\
-			(COND_CODE_1(DT_INST_ON_BUS(inst, i3c),			\
-				(LPS22HH_CONFIG_I3C_OR_I2C(inst)),		\
-				(LPS22HH_CONFIG_I2C(inst)))));			\
+#define LPS22H_DEFINE(inst, name)                                                                  \
+	static struct lps22hh_data name##_data_##inst;                                             \
+	static const struct lps22hh_config name##_config_##inst =                                  \
+		LPS22H_CONFIG(inst, name##_config_##inst, name##_data_##inst);                     \
 	PM_DEVICE_DT_INST_DEFINE(inst, lps22hh_pm_action);                                         \
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, lps22hh_init, PM_DEVICE_DT_INST_GET(inst),              \
-				     &lps22hh_data_##inst, &lps22hh_config_##inst, POST_KERNEL,    \
+				     &name##_data_##inst, &name##_config_##inst, POST_KERNEL,      \
 				     CONFIG_SENSOR_INIT_PRIORITY, &lps22hh_driver_api);
 
+#define LPS22HH_DEFINE(inst) LPS22H_DEFINE(inst, lps22hh)
+
+#define LPS22HX_DEFINE(inst) LPS22H_DEFINE(inst, lps22hx)
+
+#define DT_DRV_COMPAT st_lps22hh
 DT_INST_FOREACH_STATUS_OKAY(LPS22HH_DEFINE)
+#undef DT_DRV_COMPAT
+
+#define DT_DRV_COMPAT st_lps22hx
+DT_INST_FOREACH_STATUS_OKAY(LPS22HX_DEFINE)
+#undef DT_DRV_COMPAT

--- a/drivers/sensor/st/lps22hh/lps22hh.h
+++ b/drivers/sensor/st/lps22hh/lps22hh.h
@@ -15,28 +15,32 @@
 #include <stmemsc.h>
 #include "lps22hh_reg.h"
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#define LPS22H_ANY_INST_ON_BUS(bus) \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps22hh, bus) || \
+	DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(st_lps22hx, bus)
+
+#if LPS22H_ANY_INST_ON_BUS(spi)
 #include <zephyr/drivers/spi.h>
-#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(spi) */
+#endif /* LPS22H_ANY_INST_ON_BUS(spi) */
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#if LPS22H_ANY_INST_ON_BUS(i2c)
 #include <zephyr/drivers/i2c.h>
-#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c) */
+#endif /* LPS22H_ANY_INST_ON_BUS(i2c) */
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+#if LPS22H_ANY_INST_ON_BUS(i3c)
 #include <zephyr/drivers/i3c.h>
-#endif /* DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c) */
+#endif /* LPS22H_ANY_INST_ON_BUS(i3c) */
 
 struct lps22hh_config {
 	stmdev_ctx_t ctx;
 	union {
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
+#if LPS22H_ANY_INST_ON_BUS(i2c)
 		const struct i2c_dt_spec i2c;
 #endif
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
+#if LPS22H_ANY_INST_ON_BUS(spi)
 		const struct spi_dt_spec spi;
 #endif
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+#if LPS22H_ANY_INST_ON_BUS(i3c)
 		struct i3c_device_desc **i3c;
 #endif
 	} stmemsc_cfg;
@@ -45,17 +49,21 @@ struct lps22hh_config {
 	struct gpio_dt_spec gpio_int;
 #endif
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+#if LPS22H_ANY_INST_ON_BUS(i3c)
 	struct {
 		const struct device *bus;
 		const struct i3c_device_id dev_id;
 	} i3c;
 #endif
+
+	bool lps22hb_compat;
 };
 
 struct lps22hh_data {
 	int32_t sample_press;
 	int16_t sample_temp;
+
+	bool is_lps22hb;
 
 #ifdef CONFIG_LPS22HH_TRIGGER
 	struct gpio_callback gpio_cb;
@@ -74,7 +82,7 @@ struct lps22hh_data {
 
 #endif /* CONFIG_LPS22HH_TRIGGER */
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+#if LPS22H_ANY_INST_ON_BUS(i3c)
 	struct i3c_device_desc *i3c_dev;
 #endif
 };

--- a/drivers/sensor/st/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/st/lps22hh/lps22hh_trigger.c
@@ -78,7 +78,7 @@ static void lps22hh_handle_interrupt(const struct device *dev)
 		lps22hh->handler_drdy(dev, lps22hh->data_ready_trigger);
 	}
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+#if LPS22H_ANY_INST_ON_BUS(i3c)
 	if (cfg->i3c.bus != NULL) {
 		/*
 		 * I3C IBI does not rely on GPIO.
@@ -147,7 +147,7 @@ static void lps22hh_work_cb(struct k_work *work)
 }
 #endif /* CONFIG_LPS22HH_TRIGGER_GLOBAL_THREAD */
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+#if LPS22H_ANY_INST_ON_BUS(i3c)
 static int lps22hh_ibi_cb(struct i3c_device_desc *target,
 			  struct i3c_ibi_payload *payload)
 {
@@ -171,7 +171,7 @@ int lps22hh_init_interrupt(const struct device *dev)
 
 	/* setup data ready gpio interrupt */
 	if (!gpio_is_ready_dt(&cfg->gpio_int)
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+#if LPS22H_ANY_INST_ON_BUS(i3c)
 	    && (cfg->i3c.bus == NULL)
 #endif
 	   ) {
@@ -198,7 +198,7 @@ int lps22hh_init_interrupt(const struct device *dev)
 	lps22hh->work.handler = lps22hh_work_cb;
 #endif /* CONFIG_LPS22HH_TRIGGER_OWN_THREAD */
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+#if LPS22H_ANY_INST_ON_BUS(i3c)
 	if (cfg->i3c.bus == NULL)
 #endif
 	{
@@ -227,7 +227,7 @@ int lps22hh_init_interrupt(const struct device *dev)
 		return -EIO;
 	}
 
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+#if LPS22H_ANY_INST_ON_BUS(i3c)
 	if (cfg->i3c.bus != NULL) {
 		/* I3C IBI does not utilize GPIO interrupt. */
 		lps22hh->i3c_dev->ibi_cb = lps22hh_ibi_cb;

--- a/dts/bindings/sensor/st,lps22hx-i2c.yaml
+++ b/dts/bindings/sensor/st,lps22hx-i2c.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2019 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    STMicroelectronics LPS22HH/LPS22HB pressure and temperature sensor connected
+    to I2C bus
+
+compatible: "st,lps22hx"
+
+include: ["i2c-device.yaml", "st,lps22hh-common.yaml"]

--- a/dts/bindings/sensor/st,lps22hx-spi.yaml
+++ b/dts/bindings/sensor/st,lps22hx-spi.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2019 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    STMicroelectronics LPS22HH/LPS22HB pressure and temperature sensor connected
+    to SPI bus
+
+compatible: "st,lps22hx"
+
+include: ["spi-device.yaml", "st,lps22hh-common.yaml"]

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1652,3 +1652,10 @@ test_i2c_icm40627: icm40627@d6 {
 	accel-fs = <16>;
 	gyro-fs = <2000>;
 };
+
+test_i2c_lps22hx: lps22hx@d7 {
+	compatible = "st,lps22hx";
+	reg = <0xd7>;
+	drdy-gpios = <&test_gpio 0 0>;
+	odr = <LPS22HH_DT_ODR_75HZ>;
+};

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1699,3 +1699,10 @@ test_i2c_pmsa003i: pmsa003i@dc {
 	reset-gpios = <&test_gpio 0 GPIO_ACTIVE_LOW>;
 	set-gpios = <&test_gpio 0 GPIO_ACTIVE_HIGH>;
 };
+
+test_i2c_lps22hx: lps22hx@dd {
+	compatible = "st,lps22hx";
+	reg = <0xdd>;
+	drdy-gpios = <&test_gpio 0 0>;
+	odr = <LPS22HH_DT_ODR_75HZ>;
+};

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -531,3 +531,9 @@ test_spi_adis1647x: adis1647x@40 {
 	drdy-gpios = <&test_gpio 0 0>;
 	reset-gpios = <&test_gpio 0 0>;
 };
+
+test_spi_lps22hx: lps22hx@41 {
+	compatible = "st,lps22hx";
+	reg = <0x41>;
+	spi-max-frequency = <0>;
+};

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -555,3 +555,9 @@ test_spi_icm56686: icm56686@42 {
 	gyro-lpf = <1>;
 	gyro-pwr-mode = <2>;
 };
+
+test_spi_lps22hx: lps22hx@43 {
+	compatible = "st,lps22hx";
+	reg = <0x43>;
+	spi-max-frequency = <0>;
+};


### PR DESCRIPTION
Make the existing lps22hh driver compatible at runtime with the lps22hb
sensor. Opting into this behaviour requires switching the compatible
from `st,lps22hh` to `st,lps22hx`. If done, the driver will accept
either device ID at runtime, limiting the supported ODRs accordingly
depending on which device was found.

While a LPS22HB driver already exists in tree, it does not allow for
the runtime acceptance of either part in a single binary image. The
LPS22HH is currently sold out in all variants for the foreseeable
future, and this change allows the substitution of LPS22HB as available.

The alternative approach would be creating a brand new `lps22hx` driver, but that seems like overkill for what is essentially supporting an additional `WHO_AM_I` register value.