### PR TITLE
drivers: uart_mchp_sercom_g1: fix RX error forwarding

### DIFF
--- a/drivers/serial/uart_mchp_sercom_g1.c
+++ b/drivers/serial/uart_mchp_sercom_g1.c
@@ -893,14 +893,16 @@ static bool uart_mchp_handle_rx_error(const struct device *dev, sercom_registers
 				      bool is_clock_external)
 {
 	uart_mchp_dev_data_t *const dev_data = dev->data;
+	uint32_t uart_err = uart_get_err(dev);
 
-	if (uart_get_err(dev) == 0) {
+	if (uart_err == 0) {
 		return false;
 	}
 
 	if (dev_data->async_cb != NULL) {
 		struct uart_event evt = {
 			.type = UART_RX_STOPPED,
+			.data.rx_stop.reason = uart_err,
 		};
 		dev_data->async_cb(dev, &evt, dev_data->async_cb_data);
 	}


### PR DESCRIPTION
Fix RX error not getting forwarded as reason to the UART_RX_STOPPED event.