### PR TITLE
drivers: espi: npcx: optimize TAF packet processing

### DIFF
--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -396,7 +396,7 @@ static uint32_t espi_taf_parse(const struct device *dev)
 	struct espi_reg *const inst = HAL_INSTANCE(dev);
 	struct npcx_taf_head taf_head;
 	uint32_t taf_addr, head_data;
-	uint8_t i, roundsize;
+	uint16_t i, roundsize, max_rxbuf_words;
 
 	/* Get type, length and tag from RX buffer */
 	head_data = inst->FLASHRXBUF[0];
@@ -405,6 +405,7 @@ static uint32_t espi_taf_parse(const struct device *dev)
 	taf_pckt.type = taf_head.type;
 	taf_pckt.len = (((uint16_t)taf_head.tag_hlen & 0xF) << 8) | taf_head.llen;
 	taf_pckt.tag = taf_head.tag_hlen >> 4;
+	taf_pckt.invalid_flag = 0;
 
 	if ((taf_pckt.len == 0) && (taf_pckt.type == NPCX_ESPI_TAF_REQ_READ)) {
 		taf_pckt.len = KB(4);
@@ -419,11 +420,24 @@ static uint32_t espi_taf_parse(const struct device *dev)
 	    (IS_ENABLED(CONFIG_ESPI_TAF_NPCX_RPMC_SUPPORT) &&
 	     (taf_pckt.type == NPCX_ESPI_TAF_REQ_RPMC_OP1))) {
 		roundsize = DIV_ROUND_UP(taf_pckt.len, sizeof(uint32_t));
+
+		max_rxbuf_words = ARRAY_SIZE(((struct espi_reg *)0)->FLASHRXBUF) -
+				  NPCX_ESPI_FLASH_HEADER_ADDRESS_LEN;
+
+		if ((roundsize > max_rxbuf_words) || (roundsize > NPCX_TAF_RX_PAYLOAD_WORDS)) {
+			LOG_ERR("TAF packet length exceeds max payload size");
+			LOG_ERR("Requested length: %d bytes, maximum payload size: %d bytes",
+				taf_pckt.len,
+				NPCX_TAF_RX_PAYLOAD_WORDS * (uint16_t)sizeof(uint32_t));
+			taf_pckt.invalid_flag = 1;
+			goto parse_exit;
+		}
+
 		for (i = 0; i < roundsize; i++) {
-			taf_pckt.src[i] = inst->FLASHRXBUF[2 + i];
+			taf_pckt.src[i] = inst->FLASHRXBUF[NPCX_ESPI_FLASH_HEADER_ADDRESS_LEN + i];
 		}
 	}
-
+parse_exit:
 	return (uint32_t)&taf_pckt;
 }
 #endif /* CONFIG_ESPI_TAF */

--- a/drivers/espi/espi_taf_npcx.c
+++ b/drivers/espi/espi_taf_npcx.c
@@ -53,11 +53,7 @@ struct espi_taf_npcx_config {
 struct espi_taf_npcx_data {
 	sys_slist_t *callbacks;
 	const struct device *host_dev;
-	uint8_t taf_type;
-	uint8_t taf_tag;
-	uint32_t address;
-	uint16_t length;
-	uint32_t src[16];
+	struct espi_taf_pckt pckt;
 	uint8_t read_buf[MAX_TX_PAYLOAD_SIZE];
 	struct k_work work;
 #if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
@@ -78,6 +74,15 @@ static struct espi_callback espi_taf_cb;
 	GET_FIELD(inst->FLASHBASE, NPCX_FLASH_PRTR_BADDR)		\
 	<< GET_FIELD_POS(NPCX_FLASH_PRTR_BADDR))
 
+/* Cycle types with data: 0x09, 0x0B, 0x0D, 0x0F (all odd and >= 0x09) */
+#define CYC_TYPE_HAS_DATA(type) \
+	(((type) >= CYC_SCS_CMP_WITH_DATA_MIDDLE) && ((type) & 0x01))
+
+/* Cycle types that are part of a multi-packet sequence (not last or only) */
+#define CYC_TYPE_IS_CONTINUATION(type) \
+	(((type) == CYC_SCS_CMP_WITH_DATA_FIRST) || \
+	 ((type) == CYC_SCS_CMP_WITH_DATA_MIDDLE))
+
 #define PRTR_BADDR(i) (							\
 	GET_FIELD(inst->FLASH_PRTR_BADDR[i], NPCX_FLASH_PRTR_BADDR)	\
 	<< GET_FIELD_POS(NPCX_FLASH_PRTR_BADDR))
@@ -94,22 +99,10 @@ static struct espi_callback espi_taf_cb;
 #define RPMC_OP2_MAX_RETRY		3U
 #define RPMC_OP2_BUSY_MASK		0x1U
 
-static void espi_taf_get_pckt(const struct device *dev, struct espi_taf_npcx_data *pckt,
+static void espi_taf_get_pckt(const struct device *dev, struct espi_taf_npcx_data *data,
 			      struct espi_event event)
 {
-	struct espi_taf_pckt *data_ptr;
-
-	data_ptr = (struct espi_taf_pckt *)event.evt_data;
-
-	pckt->taf_type = data_ptr->type;
-	pckt->length = data_ptr->len;
-	pckt->taf_tag = data_ptr->tag;
-	pckt->address = data_ptr->addr;
-	if ((data_ptr->type == NPCX_ESPI_TAF_REQ_WRITE) ||
-	    (IS_ENABLED(CONFIG_ESPI_TAF_NPCX_RPMC_SUPPORT) &&
-	     (data_ptr->type == NPCX_ESPI_TAF_REQ_RPMC_OP1))) {
-		memcpy(pckt->src, data_ptr->src, sizeof(pckt->src));
-	}
+	data->pckt = *(struct espi_taf_pckt *)event.evt_data;
 }
 
 #if defined(CONFIG_ESPI_NPCX_NPCKN_V1)
@@ -343,41 +336,41 @@ static int taf_npcx_completion_handler(const struct device *dev, uint8_t type, u
 {
 	struct espi_reg *const inst = HAL_INSTANCE(dev);
 	struct npcx_taf_head taf_head;
-	uint16_t i, size;
-	uint32_t tx_buf[16];
+	uint32_t header;
 
 	taf_head.pkt_len = NPCX_TAF_CMP_HEADER_LEN + len;
 	taf_head.type = type;
-	taf_head.tag_hlen = (tag << 4) | ((len & 0xF00) >> 8);
+	taf_head.tag_hlen = (tag << 4) | ((len >> 8) & 0x0F);
 	taf_head.llen = len & 0xFF;
 
-	memcpy(&tx_buf[0], &taf_head, sizeof(struct npcx_taf_head));
-
-	if (type == CYC_SCS_CMP_WITH_DATA_ONLY || type == CYC_SCS_CMP_WITH_DATA_FIRST ||
-	    type == CYC_SCS_CMP_WITH_DATA_MIDDLE || type == CYC_SCS_CMP_WITH_DATA_LAST) {
-		memcpy(&tx_buf[1], buffer, (uint8_t)(len));
-	}
-
-	/* Check the Flash Access TX Queue is empty by polling
-	 * FLASH_ACC_TX_AVAIL.
-	 */
 	if (WAIT_FOR(!IS_BIT_SET(inst->FLASHCTL, NPCX_FLASHCTL_FLASH_ACC_TX_AVAIL),
 		     CONFIG_ESPI_TAF_TX_AVAIL_CHECK_TIME, NULL) == false) {
 		LOG_ERR("Check TX Queue Is Empty Timeout");
 		return -EBUSY;
 	}
 
-	/* Write packet to FLASHTXBUF */
-	size = DIV_ROUND_UP((uint8_t)(tx_buf[0]) + 1, sizeof(uint32_t));
-	for (i = 0; i < size; i++) {
-		inst->FLASHTXBUF[i] = tx_buf[i];
+	memcpy(&header, &taf_head, sizeof(taf_head));
+	inst->FLASHTXBUF[0] = header;
+
+	if (CYC_TYPE_HAS_DATA(type) && len > 0) {
+		uint16_t words = DIV_ROUND_UP(len, sizeof(uint32_t));
+		uint16_t max_words =
+			ARRAY_SIZE(((struct espi_reg *)0)->FLASHTXBUF) - NPCX_ESPI_FLASH_HEADER_LEN;
+
+		if (words > max_words) {
+			LOG_ERR("FLASHTXBUF overflow len=%u words=%u avail=%u", len, words,
+				max_words);
+			return -EOVERFLOW;
+		}
+
+		for (uint16_t i = 0; i < words; i++) {
+			inst->FLASHTXBUF[i + NPCX_ESPI_FLASH_HEADER_LEN] = buffer[i];
+		}
 	}
 
-	/* Set the FLASHCTL.FLASH_ACC_TX_AVAIL bit to 1 to enqueue the packet */
 	taf_set_flash_c_avail(dev);
 
-	/* Release FLASH_NP_FREE here to ready get next TAF request */
-	if ((type != CYC_SCS_CMP_WITH_DATA_FIRST) && (type != CYC_SCS_CMP_WITH_DATA_MIDDLE)) {
+	if (!CYC_TYPE_IS_CONTINUATION(type)) {
 		taf_release_flash_np_free(dev);
 	}
 
@@ -385,14 +378,13 @@ static int taf_npcx_completion_handler(const struct device *dev, uint8_t type, u
 }
 
 #if defined(CONFIG_ESPI_TAF_MANUAL_MODE)
-static int espi_taf_npcx_flash_read(const struct device *dev, struct espi_saf_packet *pckt)
+static int espi_taf_npcx_flash_read(const struct device *dev, struct espi_taf_npcx_data *taf)
 {
 	struct espi_reg *const inst = HAL_INSTANCE(dev);
-	struct espi_taf_npcx_pckt *taf_data_ptr = (struct espi_taf_npcx_pckt *)pckt->buf;
 	uint8_t cycle_type = CYC_SCS_CMP_WITH_DATA_ONLY;
-	uint32_t total_len = pckt->len;
+	uint32_t total_len = taf->pckt.len;
 	uint32_t len = total_len;
-	uint32_t addr = pckt->flash_addr;
+	uint32_t addr = taf->pckt.addr;
 	uint8_t flash_req_size = GET_FIELD(inst->FLASHCFG, NPCX_FLASHCFG_FLASHREQSIZE);
 	uint8_t target_max_size = GET_FIELD(inst->FLASHCFG, NPCX_FLASHCFG_FLREQSUP);
 	uint16_t max_read_req = 32 << flash_req_size;
@@ -411,7 +403,7 @@ static int espi_taf_npcx_flash_read(const struct device *dev, struct espi_saf_pa
 		return -EINVAL;
 	}
 
-	if (espi_taf_check_read_protect(dev, addr, len, taf_data_ptr->tag)) {
+	if (espi_taf_check_read_protect(dev, addr, len, taf->pckt.tag)) {
 		LOG_ERR("Access protect region");
 		return -EINVAL;
 	}
@@ -426,40 +418,35 @@ static int espi_taf_npcx_flash_read(const struct device *dev, struct espi_saf_pa
 
 	do {
 #if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
-		if ((addr + len) <= npcx_espi_taf_data.low_dev_size) {
-			rc = flash_read(npcx_espi_taf_data.low_dev_ptr, addr,
-					npcx_espi_taf_data.read_buf, len);
-		} else if (addr >= npcx_espi_taf_data.low_dev_size) {
-			rc = flash_read(npcx_espi_taf_data.high_dev_ptr,
-					(addr - npcx_espi_taf_data.low_dev_size),
-					npcx_espi_taf_data.read_buf, len);
+		if ((addr + len) <= taf->low_dev_size) {
+			rc = flash_read(taf->low_dev_ptr, addr, taf->read_buf, len);
+		} else if (addr >= taf->low_dev_size) {
+			rc = flash_read(taf->high_dev_ptr,
+					(addr - taf->low_dev_size), taf->read_buf, len);
 		} else {
-			rc = flash_read(npcx_espi_taf_data.low_dev_ptr, addr,
-					npcx_espi_taf_data.read_buf,
-					(npcx_espi_taf_data.low_dev_size - addr));
+			rc = flash_read(taf->low_dev_ptr, addr, taf->read_buf,
+					(taf->low_dev_size - addr));
 
 			if (rc) {
 				LOG_ERR("flash read fail 0x%x", rc);
 				return -EIO;
 			}
 
-			uint32_t index = npcx_espi_taf_data.low_dev_size - addr;
+			uint32_t index = taf->low_dev_size - addr;
 
-			rc = flash_read(
-				npcx_espi_taf_data.high_dev_ptr, 0x0,
-				&npcx_espi_taf_data.read_buf[index],
-				(addr + len - npcx_espi_taf_data.low_dev_size));
+			rc = flash_read(taf->high_dev_ptr, 0x0, &taf->read_buf[index],
+					(addr + len - taf->low_dev_size));
 		}
 #else
-		rc = flash_read(spi_dev, addr, npcx_espi_taf_data.read_buf, len);
+		rc = flash_read(spi_dev, addr, taf->read_buf, len);
 #endif
 		if (rc) {
 			LOG_ERR("flash read fail 0x%x", rc);
 			return -EIO;
 		}
 
-		rc = taf_npcx_completion_handler(dev, cycle_type, taf_data_ptr->tag, len,
-						 (uint32_t *)npcx_espi_taf_data.read_buf);
+		rc = taf_npcx_completion_handler(dev, cycle_type, taf->pckt.tag, len,
+						 (uint32_t *)taf->read_buf);
 		if (rc) {
 			LOG_ERR("espi taf completion handler fail");
 			return rc;
@@ -480,26 +467,23 @@ static int espi_taf_npcx_flash_read(const struct device *dev, struct espi_saf_pa
 }
 #endif
 
-static int espi_taf_npcx_flash_write(const struct device *dev, struct espi_saf_packet *pckt)
+static int espi_taf_npcx_flash_write(const struct device *dev, struct espi_taf_npcx_data *taf)
 {
-	struct espi_taf_npcx_pckt *taf_data_ptr = (struct espi_taf_npcx_pckt *)pckt->buf;
-	uint8_t *data_ptr = (uint8_t *)(taf_data_ptr->data);
-	uint32_t addr = pckt->flash_addr;
-	uint32_t len = pckt->len;
+	uint8_t *data_ptr = (uint8_t *)taf->pckt.src;
+	uint32_t addr = taf->pckt.addr;
+	uint32_t len = taf->pckt.len;
 	int rc;
 
-	if (espi_taf_check_write_protect(dev, pckt->flash_addr,
-					 pckt->len, taf_data_ptr->tag)) {
+	if (espi_taf_check_write_protect(dev, addr, len, taf->pckt.tag)) {
 		LOG_ERR("Access protection region");
 		return -EINVAL;
 	}
 
 #if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
-	if ((addr + len) <= npcx_espi_taf_data.low_dev_size) {
-		rc = flash_write(npcx_espi_taf_data.low_dev_ptr, addr, data_ptr, len);
-	} else if (addr >= npcx_espi_taf_data.low_dev_size) {
-		rc = flash_write(npcx_espi_taf_data.high_dev_ptr,
-				 (addr - npcx_espi_taf_data.low_dev_size), data_ptr, len);
+	if ((addr + len) <= taf->low_dev_size) {
+		rc = flash_write(taf->low_dev_ptr, addr, data_ptr, len);
+	} else if (addr >= taf->low_dev_size) {
+		rc = flash_write(taf->high_dev_ptr, (addr - taf->low_dev_size), data_ptr, len);
 	} else {
 		LOG_ERR("Write across two flashes");
 		return -EINVAL;
@@ -512,8 +496,7 @@ static int espi_taf_npcx_flash_write(const struct device *dev, struct espi_saf_p
 		return -EIO;
 	}
 
-	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITHOUT_DATA, taf_data_ptr->tag, 0x0,
-					 NULL);
+	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITHOUT_DATA, taf->pckt.tag, 0x0, NULL);
 	if (rc) {
 		LOG_ERR("espi taf completion handler fail");
 		return rc;
@@ -522,32 +505,30 @@ static int espi_taf_npcx_flash_write(const struct device *dev, struct espi_saf_p
 	return 0;
 }
 
-static int espi_taf_npcx_flash_erase(const struct device *dev, struct espi_saf_packet *pckt)
+static int espi_taf_npcx_flash_erase(const struct device *dev, struct espi_taf_npcx_data *taf)
 {
 	int erase_blk[] = {KB(4), KB(32), KB(64), KB(128)};
-	struct espi_taf_npcx_pckt *taf_data_ptr = (struct espi_taf_npcx_pckt *)pckt->buf;
-	uint32_t addr = pckt->flash_addr;
+	uint32_t addr = taf->pckt.addr;
 	uint32_t len;
 	int rc;
 
-	if ((pckt->len < 0) || (pckt->len >= NPCX_ESPI_TAF_ERASE_LEN_MAX)) {
+	if ((taf->pckt.len < 0) || (taf->pckt.len >= NPCX_ESPI_TAF_ERASE_LEN_MAX)) {
 		LOG_ERR("Invalid erase block size");
 		return -EINVAL;
 	}
 
-	len = erase_blk[pckt->len];
+	len = erase_blk[taf->pckt.len];
 
-	if (espi_taf_check_write_protect(dev, addr, len, taf_data_ptr->tag)) {
+	if (espi_taf_check_write_protect(dev, addr, len, taf->pckt.tag)) {
 		LOG_ERR("Access protection region");
 		return -EINVAL;
 	}
 
 #if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
-	if ((addr + len) <= npcx_espi_taf_data.low_dev_size) {
-		rc = flash_erase(npcx_espi_taf_data.low_dev_ptr, addr, len);
-	} else if (addr >= npcx_espi_taf_data.low_dev_size) {
-		rc = flash_erase(npcx_espi_taf_data.high_dev_ptr,
-				 (addr - npcx_espi_taf_data.low_dev_size), len);
+	if ((addr + len) <= taf->low_dev_size) {
+		rc = flash_erase(taf->low_dev_ptr, addr, len);
+	} else if (addr >= taf->low_dev_size) {
+		rc = flash_erase(taf->high_dev_ptr, (addr - taf->low_dev_size), len);
 	} else {
 		LOG_ERR("Erase across two flashes");
 		return -EINVAL;
@@ -560,8 +541,7 @@ static int espi_taf_npcx_flash_erase(const struct device *dev, struct espi_saf_p
 		return -EIO;
 	}
 
-	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITHOUT_DATA, taf_data_ptr->tag, 0x0,
-					 NULL);
+	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITHOUT_DATA, taf->pckt.tag, 0x0, NULL);
 	if (rc) {
 		LOG_ERR("espi taf completion handler fail");
 		return rc;
@@ -571,14 +551,13 @@ static int espi_taf_npcx_flash_erase(const struct device *dev, struct espi_saf_p
 }
 
 #ifdef CONFIG_ESPI_TAF_NPCX_RPMC_SUPPORT
-static int espi_taf_npcx_rpmc_op1(const struct device *dev, struct espi_saf_packet *pckt)
+static int espi_taf_npcx_rpmc_op1(const struct device *dev, struct espi_taf_npcx_data *taf)
 {
-	struct espi_taf_npcx_pckt *taf_data_ptr = (struct espi_taf_npcx_pckt *)pckt->buf;
-	uint8_t *data_ptr = taf_data_ptr->data;
+	uint8_t *data_ptr = (uint8_t *)taf->pckt.src;
 	struct npcx_ex_ops_uma_in op_in = {
 		.opcode = ESPI_TAF_RPMC_OP1_CMD,
 		.tx_buf = data_ptr + 1,
-		.tx_count = (pckt->len) - 1,
+		.tx_count = taf->pckt.len - 1,
 		.rx_count = 0,
 	};
 	int rc;
@@ -589,8 +568,7 @@ static int espi_taf_npcx_rpmc_op1(const struct device *dev, struct espi_saf_pack
 		return -EIO;
 	}
 
-	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITHOUT_DATA, taf_data_ptr->tag, 0x0,
-					 NULL);
+	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITHOUT_DATA, taf->pckt.tag, 0x0, NULL);
 	if (rc) {
 		LOG_ERR("espi taf completion handler fail");
 		return rc;
@@ -599,9 +577,8 @@ static int espi_taf_npcx_rpmc_op1(const struct device *dev, struct espi_saf_pack
 	return 0;
 }
 
-static int espi_taf_npcx_rpmc_op2(const struct device *dev, struct espi_saf_packet *pckt)
+static int espi_taf_npcx_rpmc_op2(const struct device *dev, struct espi_taf_npcx_data *taf)
 {
-	struct espi_taf_npcx_pckt *taf_data_ptr = (struct espi_taf_npcx_pckt *)pckt->buf;
 	uint8_t dummy_byte = 0;
 	uint8_t retry = RPMC_OP2_MAX_RETRY;
 	uint8_t status;
@@ -616,7 +593,7 @@ static int espi_taf_npcx_rpmc_op2(const struct device *dev, struct espi_saf_pack
 	};
 	int rc;
 
-	if (pckt->len > MAX_TX_PAYLOAD_SIZE) {
+	if (taf->pckt.len > MAX_TX_PAYLOAD_SIZE) {
 		LOG_ERR("Invalid size");
 		return -EINVAL;
 	}
@@ -628,8 +605,9 @@ static int espi_taf_npcx_rpmc_op2(const struct device *dev, struct espi_saf_pack
 			return -EIO;
 		}
 
+		status = taf->read_buf[0];
+
 		if (status & RPMC_OP2_BUSY_MASK) {
-			/* Retry if device reports busy status (bit 0 set) */
 			LOG_DBG("RPMC OP2 status code: %x, in attempt %d", status,
 				(RPMC_OP2_MAX_RETRY - retry + 1));
 			retry--;
@@ -645,16 +623,16 @@ static int espi_taf_npcx_rpmc_op2(const struct device *dev, struct espi_saf_pack
 		return -EBUSY;
 	}
 
-	op_in.rx_count = pckt->len;
-	op_out.rx_buf = npcx_espi_taf_data.read_buf;
+	op_in.rx_count = taf->pckt.len;
+	op_out.rx_buf = taf->read_buf;
 	rc = flash_ex_op(spi_dev, FLASH_NPCX_EX_OP_EXEC_UMA, (uintptr_t)&op_in, &op_out);
 	if (rc) {
 		LOG_ERR("flash RPMC OP2 data read fail");
 		return -EIO;
 	}
 
-	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITH_DATA_ONLY, taf_data_ptr->tag,
-					 pckt->len, (uint32_t *)npcx_espi_taf_data.read_buf);
+	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITH_DATA_ONLY, taf->pckt.tag,
+					 taf->pckt.len, (uint32_t *)taf->read_buf);
 	if (rc) {
 		LOG_ERR("espi taf completion handler fail");
 		return rc;
@@ -664,12 +642,11 @@ static int espi_taf_npcx_rpmc_op2(const struct device *dev, struct espi_saf_pack
 }
 #endif
 
-static int espi_taf_npcx_flash_unsuccess(const struct device *dev, struct espi_saf_packet *pckt)
+static int espi_taf_npcx_flash_unsuccess(const struct device *dev, struct espi_taf_npcx_data *taf)
 {
-	struct espi_taf_npcx_pckt *taf_data_ptr = (struct espi_taf_npcx_pckt *)pckt->buf;
 	int rc;
 
-	rc = taf_npcx_completion_handler(dev, CYC_UNSCS_CMP_WITHOUT_DATA_ONLY, taf_data_ptr->tag,
+	rc = taf_npcx_completion_handler(dev, CYC_UNSCS_CMP_WITHOUT_DATA_ONLY, taf->pckt.tag,
 					 0x0, NULL);
 	if (rc) {
 		LOG_ERR("espi taf completion handler fail");
@@ -684,45 +661,42 @@ static void espi_taf_work(struct k_work *item)
 	struct espi_taf_npcx_data *info = CONTAINER_OF(item, struct espi_taf_npcx_data, work);
 	int ret = 0;
 
-	struct espi_taf_npcx_pckt taf_data;
-	struct espi_saf_packet pckt_taf;
+	if (info->pckt.invalid_flag == 1) {
+		LOG_ERR("Invalid TAF packet");
 
-	pckt_taf.flash_addr = info->address;
-	pckt_taf.len = info->length;
-	taf_data.tag = info->taf_tag;
-	if ((info->taf_type == NPCX_ESPI_TAF_REQ_WRITE) ||
-	    (IS_ENABLED(CONFIG_ESPI_TAF_NPCX_RPMC_SUPPORT) &&
-	     (info->taf_type == NPCX_ESPI_TAF_REQ_RPMC_OP1))) {
-		taf_data.data = (uint8_t *)info->src;
-	} else {
-		taf_data.data = NULL;
+		ret = espi_taf_npcx_flash_unsuccess(info->host_dev, info);
+
+		return;
 	}
-	pckt_taf.buf = (uint8_t *)&taf_data;
 
-	switch (info->taf_type) {
+	switch (info->pckt.type) {
 #if defined(CONFIG_ESPI_TAF_MANUAL_MODE)
 	case NPCX_ESPI_TAF_REQ_READ:
-		ret = espi_taf_npcx_flash_read(info->host_dev, &pckt_taf);
+		ret = espi_taf_npcx_flash_read(info->host_dev, info);
 		break;
 #endif
 	case NPCX_ESPI_TAF_REQ_ERASE:
-		ret = espi_taf_npcx_flash_erase(info->host_dev, &pckt_taf);
+		ret = espi_taf_npcx_flash_erase(info->host_dev, info);
 		break;
 	case NPCX_ESPI_TAF_REQ_WRITE:
-		ret = espi_taf_npcx_flash_write(info->host_dev, &pckt_taf);
+		ret = espi_taf_npcx_flash_write(info->host_dev, info);
 		break;
 #ifdef CONFIG_ESPI_TAF_NPCX_RPMC_SUPPORT
 	case NPCX_ESPI_TAF_REQ_RPMC_OP1:
-		ret = espi_taf_npcx_rpmc_op1(info->host_dev, &pckt_taf);
+		ret = espi_taf_npcx_rpmc_op1(info->host_dev, info);
 		break;
 	case NPCX_ESPI_TAF_REQ_RPMC_OP2:
-		ret = espi_taf_npcx_rpmc_op2(info->host_dev, &pckt_taf);
+		ret = espi_taf_npcx_rpmc_op2(info->host_dev, info);
 		break;
 #endif
+	default:
+		LOG_ERR("Unsupported TAF cycle type %u", info->pckt.type);
+		ret = -EINVAL;
+		break;
 	}
 
 	if (ret != 0) {
-		ret = espi_taf_npcx_flash_unsuccess(info->host_dev, &pckt_taf);
+		ret = espi_taf_npcx_flash_unsuccess(info->host_dev, info);
 	}
 }
 

--- a/drivers/espi/espi_taf_npcx.c
+++ b/drivers/espi/espi_taf_npcx.c
@@ -53,11 +53,7 @@ struct espi_taf_npcx_config {
 struct espi_taf_npcx_data {
 	sys_slist_t *callbacks;
 	const struct device *host_dev;
-	uint8_t taf_type;
-	uint8_t taf_tag;
-	uint32_t address;
-	uint16_t length;
-	uint32_t src[16];
+	struct espi_taf_pckt pckt;
 	uint8_t read_buf[MAX_TX_PAYLOAD_SIZE];
 	struct k_work work;
 #if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
@@ -78,6 +74,15 @@ static struct espi_callback espi_taf_cb;
 	GET_FIELD(inst->FLASHBASE, NPCX_FLASH_PRTR_BADDR)		\
 	<< GET_FIELD_POS(NPCX_FLASH_PRTR_BADDR))
 
+/* Cycle types with data: 0x09, 0x0B, 0x0D, 0x0F (all odd and >= 0x09) */
+#define CYC_TYPE_HAS_DATA(type) \
+	(((type) >= CYC_SCS_CMP_WITH_DATA_MIDDLE) && ((type) & 0x01))
+
+/* Cycle types that are part of a multi-packet sequence (not last or only) */
+#define CYC_TYPE_IS_CONTINUATION(type) \
+	(((type) == CYC_SCS_CMP_WITH_DATA_FIRST) || \
+	 ((type) == CYC_SCS_CMP_WITH_DATA_MIDDLE))
+
 #define PRTR_BADDR(i) (							\
 	GET_FIELD(inst->FLASH_PRTR_BADDR[i], NPCX_FLASH_PRTR_BADDR)	\
 	<< GET_FIELD_POS(NPCX_FLASH_PRTR_BADDR))
@@ -94,22 +99,10 @@ static struct espi_callback espi_taf_cb;
 #define RPMC_OP2_MAX_RETRY		3U
 #define RPMC_OP2_BUSY_MASK		0x1U
 
-static void espi_taf_get_pckt(const struct device *dev, struct espi_taf_npcx_data *pckt,
+static void espi_taf_get_pckt(const struct device *dev, struct espi_taf_npcx_data *data,
 			      struct espi_event event)
 {
-	struct espi_taf_pckt *data_ptr;
-
-	data_ptr = (struct espi_taf_pckt *)event.evt_data;
-
-	pckt->taf_type = data_ptr->type;
-	pckt->length = data_ptr->len;
-	pckt->taf_tag = data_ptr->tag;
-	pckt->address = data_ptr->addr;
-	if ((data_ptr->type == NPCX_ESPI_TAF_REQ_WRITE) ||
-	    (IS_ENABLED(CONFIG_ESPI_TAF_NPCX_RPMC_SUPPORT) &&
-	     (data_ptr->type == NPCX_ESPI_TAF_REQ_RPMC_OP1))) {
-		memcpy(pckt->src, data_ptr->src, sizeof(pckt->src));
-	}
+	data->pckt = *(struct espi_taf_pckt *)event.evt_data;
 }
 
 #if defined(CONFIG_ESPI_NPCX_NPCKN_V1)
@@ -338,46 +331,49 @@ static void taf_release_flash_np_free(const struct device *dev)
 	inst->FLASHCTL = tmp;
 }
 
+BUILD_ASSERT(sizeof(struct npcx_taf_head) == sizeof(uint32_t),
+	     "struct npcx_taf_head size must be exactly 4 bytes");
+
 static int taf_npcx_completion_handler(const struct device *dev, uint8_t type, uint8_t tag,
 				       uint16_t len, uint32_t *buffer)
 {
 	struct espi_reg *const inst = HAL_INSTANCE(dev);
 	struct npcx_taf_head taf_head;
-	uint16_t i, size;
-	uint32_t tx_buf[16];
+	uint32_t header;
 
 	taf_head.pkt_len = NPCX_TAF_CMP_HEADER_LEN + len;
 	taf_head.type = type;
-	taf_head.tag_hlen = (tag << 4) | ((len & 0xF00) >> 8);
+	taf_head.tag_hlen = (tag << 4) | ((len >> 8) & 0x0F);
 	taf_head.llen = len & 0xFF;
 
-	memcpy(&tx_buf[0], &taf_head, sizeof(struct npcx_taf_head));
-
-	if (type == CYC_SCS_CMP_WITH_DATA_ONLY || type == CYC_SCS_CMP_WITH_DATA_FIRST ||
-	    type == CYC_SCS_CMP_WITH_DATA_MIDDLE || type == CYC_SCS_CMP_WITH_DATA_LAST) {
-		memcpy(&tx_buf[1], buffer, (uint8_t)(len));
-	}
-
-	/* Check the Flash Access TX Queue is empty by polling
-	 * FLASH_ACC_TX_AVAIL.
-	 */
 	if (WAIT_FOR(!IS_BIT_SET(inst->FLASHCTL, NPCX_FLASHCTL_FLASH_ACC_TX_AVAIL),
 		     CONFIG_ESPI_TAF_TX_AVAIL_CHECK_TIME, NULL) == false) {
 		LOG_ERR("Check TX Queue Is Empty Timeout");
 		return -EBUSY;
 	}
 
-	/* Write packet to FLASHTXBUF */
-	size = DIV_ROUND_UP((uint8_t)(tx_buf[0]) + 1, sizeof(uint32_t));
-	for (i = 0; i < size; i++) {
-		inst->FLASHTXBUF[i] = tx_buf[i];
+	memcpy(&header, &taf_head, sizeof(taf_head));
+	inst->FLASHTXBUF[0] = header;
+
+	if (CYC_TYPE_HAS_DATA(type) && len > 0) {
+		uint16_t words = DIV_ROUND_UP(len, sizeof(uint32_t));
+		uint16_t max_words =
+			ARRAY_SIZE(((struct espi_reg *)0)->FLASHTXBUF) - NPCX_ESPI_FLASH_HEADER_LEN;
+
+		if (words > max_words) {
+			LOG_ERR("FLASHTXBUF overflow len=%u words=%u avail=%u", len, words,
+				max_words);
+			return -EOVERFLOW;
+		}
+
+		for (uint16_t i = 0; i < words; i++) {
+			inst->FLASHTXBUF[i + NPCX_ESPI_FLASH_HEADER_LEN] = buffer[i];
+		}
 	}
 
-	/* Set the FLASHCTL.FLASH_ACC_TX_AVAIL bit to 1 to enqueue the packet */
 	taf_set_flash_c_avail(dev);
 
-	/* Release FLASH_NP_FREE here to ready get next TAF request */
-	if ((type != CYC_SCS_CMP_WITH_DATA_FIRST) && (type != CYC_SCS_CMP_WITH_DATA_MIDDLE)) {
+	if (!CYC_TYPE_IS_CONTINUATION(type)) {
 		taf_release_flash_np_free(dev);
 	}
 
@@ -385,14 +381,13 @@ static int taf_npcx_completion_handler(const struct device *dev, uint8_t type, u
 }
 
 #if defined(CONFIG_ESPI_TAF_MANUAL_MODE)
-static int espi_taf_npcx_flash_read(const struct device *dev, struct espi_saf_packet *pckt)
+static int espi_taf_npcx_flash_read(const struct device *dev, struct espi_taf_npcx_data *taf)
 {
 	struct espi_reg *const inst = HAL_INSTANCE(dev);
-	struct espi_taf_npcx_pckt *taf_data_ptr = (struct espi_taf_npcx_pckt *)pckt->buf;
 	uint8_t cycle_type = CYC_SCS_CMP_WITH_DATA_ONLY;
-	uint32_t total_len = pckt->len;
+	uint32_t total_len = taf->pckt.len;
 	uint32_t len = total_len;
-	uint32_t addr = pckt->flash_addr;
+	uint32_t addr = taf->pckt.addr;
 	uint8_t flash_req_size = GET_FIELD(inst->FLASHCFG, NPCX_FLASHCFG_FLASHREQSIZE);
 	uint8_t target_max_size = GET_FIELD(inst->FLASHCFG, NPCX_FLASHCFG_FLREQSUP);
 	uint16_t max_read_req = 32 << flash_req_size;
@@ -411,7 +406,7 @@ static int espi_taf_npcx_flash_read(const struct device *dev, struct espi_saf_pa
 		return -EINVAL;
 	}
 
-	if (espi_taf_check_read_protect(dev, addr, len, taf_data_ptr->tag)) {
+	if (espi_taf_check_read_protect(dev, addr, len, taf->pckt.tag)) {
 		LOG_ERR("Access protect region");
 		return -EINVAL;
 	}
@@ -426,40 +421,35 @@ static int espi_taf_npcx_flash_read(const struct device *dev, struct espi_saf_pa
 
 	do {
 #if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
-		if ((addr + len) <= npcx_espi_taf_data.low_dev_size) {
-			rc = flash_read(npcx_espi_taf_data.low_dev_ptr, addr,
-					npcx_espi_taf_data.read_buf, len);
-		} else if (addr >= npcx_espi_taf_data.low_dev_size) {
-			rc = flash_read(npcx_espi_taf_data.high_dev_ptr,
-					(addr - npcx_espi_taf_data.low_dev_size),
-					npcx_espi_taf_data.read_buf, len);
+		if ((addr + len) <= taf->low_dev_size) {
+			rc = flash_read(taf->low_dev_ptr, addr, taf->read_buf, len);
+		} else if (addr >= taf->low_dev_size) {
+			rc = flash_read(taf->high_dev_ptr,
+					(addr - taf->low_dev_size), taf->read_buf, len);
 		} else {
-			rc = flash_read(npcx_espi_taf_data.low_dev_ptr, addr,
-					npcx_espi_taf_data.read_buf,
-					(npcx_espi_taf_data.low_dev_size - addr));
+			rc = flash_read(taf->low_dev_ptr, addr, taf->read_buf,
+					(taf->low_dev_size - addr));
 
 			if (rc) {
 				LOG_ERR("flash read fail 0x%x", rc);
 				return -EIO;
 			}
 
-			uint32_t index = npcx_espi_taf_data.low_dev_size - addr;
+			uint32_t index = taf->low_dev_size - addr;
 
-			rc = flash_read(
-				npcx_espi_taf_data.high_dev_ptr, 0x0,
-				&npcx_espi_taf_data.read_buf[index],
-				(addr + len - npcx_espi_taf_data.low_dev_size));
+			rc = flash_read(taf->high_dev_ptr, 0x0, &taf->read_buf[index],
+					(addr + len - taf->low_dev_size));
 		}
 #else
-		rc = flash_read(spi_dev, addr, npcx_espi_taf_data.read_buf, len);
+		rc = flash_read(spi_dev, addr, taf->read_buf, len);
 #endif
 		if (rc) {
 			LOG_ERR("flash read fail 0x%x", rc);
 			return -EIO;
 		}
 
-		rc = taf_npcx_completion_handler(dev, cycle_type, taf_data_ptr->tag, len,
-						 (uint32_t *)npcx_espi_taf_data.read_buf);
+		rc = taf_npcx_completion_handler(dev, cycle_type, taf->pckt.tag, len,
+						 (uint32_t *)taf->read_buf);
 		if (rc) {
 			LOG_ERR("espi taf completion handler fail");
 			return rc;
@@ -480,26 +470,23 @@ static int espi_taf_npcx_flash_read(const struct device *dev, struct espi_saf_pa
 }
 #endif
 
-static int espi_taf_npcx_flash_write(const struct device *dev, struct espi_saf_packet *pckt)
+static int espi_taf_npcx_flash_write(const struct device *dev, struct espi_taf_npcx_data *taf)
 {
-	struct espi_taf_npcx_pckt *taf_data_ptr = (struct espi_taf_npcx_pckt *)pckt->buf;
-	uint8_t *data_ptr = (uint8_t *)(taf_data_ptr->data);
-	uint32_t addr = pckt->flash_addr;
-	uint32_t len = pckt->len;
+	uint8_t *data_ptr = (uint8_t *)taf->pckt.src;
+	uint32_t addr = taf->pckt.addr;
+	uint32_t len = taf->pckt.len;
 	int rc;
 
-	if (espi_taf_check_write_protect(dev, pckt->flash_addr,
-					 pckt->len, taf_data_ptr->tag)) {
+	if (espi_taf_check_write_protect(dev, addr, len, taf->pckt.tag)) {
 		LOG_ERR("Access protection region");
 		return -EINVAL;
 	}
 
 #if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
-	if ((addr + len) <= npcx_espi_taf_data.low_dev_size) {
-		rc = flash_write(npcx_espi_taf_data.low_dev_ptr, addr, data_ptr, len);
-	} else if (addr >= npcx_espi_taf_data.low_dev_size) {
-		rc = flash_write(npcx_espi_taf_data.high_dev_ptr,
-				 (addr - npcx_espi_taf_data.low_dev_size), data_ptr, len);
+	if ((addr + len) <= taf->low_dev_size) {
+		rc = flash_write(taf->low_dev_ptr, addr, data_ptr, len);
+	} else if (addr >= taf->low_dev_size) {
+		rc = flash_write(taf->high_dev_ptr, (addr - taf->low_dev_size), data_ptr, len);
 	} else {
 		LOG_ERR("Write across two flashes");
 		return -EINVAL;
@@ -512,8 +499,7 @@ static int espi_taf_npcx_flash_write(const struct device *dev, struct espi_saf_p
 		return -EIO;
 	}
 
-	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITHOUT_DATA, taf_data_ptr->tag, 0x0,
-					 NULL);
+	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITHOUT_DATA, taf->pckt.tag, 0x0, NULL);
 	if (rc) {
 		LOG_ERR("espi taf completion handler fail");
 		return rc;
@@ -522,32 +508,30 @@ static int espi_taf_npcx_flash_write(const struct device *dev, struct espi_saf_p
 	return 0;
 }
 
-static int espi_taf_npcx_flash_erase(const struct device *dev, struct espi_saf_packet *pckt)
+static int espi_taf_npcx_flash_erase(const struct device *dev, struct espi_taf_npcx_data *taf)
 {
 	int erase_blk[] = {KB(4), KB(32), KB(64), KB(128)};
-	struct espi_taf_npcx_pckt *taf_data_ptr = (struct espi_taf_npcx_pckt *)pckt->buf;
-	uint32_t addr = pckt->flash_addr;
+	uint32_t addr = taf->pckt.addr;
 	uint32_t len;
 	int rc;
 
-	if ((pckt->len < 0) || (pckt->len >= NPCX_ESPI_TAF_ERASE_LEN_MAX)) {
+	if ((taf->pckt.len < 0) || (taf->pckt.len >= NPCX_ESPI_TAF_ERASE_LEN_MAX)) {
 		LOG_ERR("Invalid erase block size");
 		return -EINVAL;
 	}
 
-	len = erase_blk[pckt->len];
+	len = erase_blk[taf->pckt.len];
 
-	if (espi_taf_check_write_protect(dev, addr, len, taf_data_ptr->tag)) {
+	if (espi_taf_check_write_protect(dev, addr, len, taf->pckt.tag)) {
 		LOG_ERR("Access protection region");
 		return -EINVAL;
 	}
 
 #if DT_NODE_HAS_STATUS_OKAY(NPCX_TAF_SEC_FLASH_NODE)
-	if ((addr + len) <= npcx_espi_taf_data.low_dev_size) {
-		rc = flash_erase(npcx_espi_taf_data.low_dev_ptr, addr, len);
-	} else if (addr >= npcx_espi_taf_data.low_dev_size) {
-		rc = flash_erase(npcx_espi_taf_data.high_dev_ptr,
-				 (addr - npcx_espi_taf_data.low_dev_size), len);
+	if ((addr + len) <= taf->low_dev_size) {
+		rc = flash_erase(taf->low_dev_ptr, addr, len);
+	} else if (addr >= taf->low_dev_size) {
+		rc = flash_erase(taf->high_dev_ptr, (addr - taf->low_dev_size), len);
 	} else {
 		LOG_ERR("Erase across two flashes");
 		return -EINVAL;
@@ -560,8 +544,7 @@ static int espi_taf_npcx_flash_erase(const struct device *dev, struct espi_saf_p
 		return -EIO;
 	}
 
-	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITHOUT_DATA, taf_data_ptr->tag, 0x0,
-					 NULL);
+	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITHOUT_DATA, taf->pckt.tag, 0x0, NULL);
 	if (rc) {
 		LOG_ERR("espi taf completion handler fail");
 		return rc;
@@ -571,14 +554,13 @@ static int espi_taf_npcx_flash_erase(const struct device *dev, struct espi_saf_p
 }
 
 #ifdef CONFIG_ESPI_TAF_NPCX_RPMC_SUPPORT
-static int espi_taf_npcx_rpmc_op1(const struct device *dev, struct espi_saf_packet *pckt)
+static int espi_taf_npcx_rpmc_op1(const struct device *dev, struct espi_taf_npcx_data *taf)
 {
-	struct espi_taf_npcx_pckt *taf_data_ptr = (struct espi_taf_npcx_pckt *)pckt->buf;
-	uint8_t *data_ptr = taf_data_ptr->data;
+	uint8_t *data_ptr = (uint8_t *)taf->pckt.src;
 	struct npcx_ex_ops_uma_in op_in = {
 		.opcode = ESPI_TAF_RPMC_OP1_CMD,
 		.tx_buf = data_ptr + 1,
-		.tx_count = (pckt->len) - 1,
+		.tx_count = taf->pckt.len - 1,
 		.rx_count = 0,
 	};
 	int rc;
@@ -589,8 +571,7 @@ static int espi_taf_npcx_rpmc_op1(const struct device *dev, struct espi_saf_pack
 		return -EIO;
 	}
 
-	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITHOUT_DATA, taf_data_ptr->tag, 0x0,
-					 NULL);
+	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITHOUT_DATA, taf->pckt.tag, 0x0, NULL);
 	if (rc) {
 		LOG_ERR("espi taf completion handler fail");
 		return rc;
@@ -599,9 +580,8 @@ static int espi_taf_npcx_rpmc_op1(const struct device *dev, struct espi_saf_pack
 	return 0;
 }
 
-static int espi_taf_npcx_rpmc_op2(const struct device *dev, struct espi_saf_packet *pckt)
+static int espi_taf_npcx_rpmc_op2(const struct device *dev, struct espi_taf_npcx_data *taf)
 {
-	struct espi_taf_npcx_pckt *taf_data_ptr = (struct espi_taf_npcx_pckt *)pckt->buf;
 	uint8_t dummy_byte = 0;
 	uint8_t retry = RPMC_OP2_MAX_RETRY;
 	uint8_t status;
@@ -616,7 +596,7 @@ static int espi_taf_npcx_rpmc_op2(const struct device *dev, struct espi_saf_pack
 	};
 	int rc;
 
-	if (pckt->len > MAX_TX_PAYLOAD_SIZE) {
+	if (taf->pckt.len > MAX_TX_PAYLOAD_SIZE) {
 		LOG_ERR("Invalid size");
 		return -EINVAL;
 	}
@@ -628,8 +608,9 @@ static int espi_taf_npcx_rpmc_op2(const struct device *dev, struct espi_saf_pack
 			return -EIO;
 		}
 
+		status = taf->read_buf[0];
+
 		if (status & RPMC_OP2_BUSY_MASK) {
-			/* Retry if device reports busy status (bit 0 set) */
 			LOG_DBG("RPMC OP2 status code: %x, in attempt %d", status,
 				(RPMC_OP2_MAX_RETRY - retry + 1));
 			retry--;
@@ -645,16 +626,16 @@ static int espi_taf_npcx_rpmc_op2(const struct device *dev, struct espi_saf_pack
 		return -EBUSY;
 	}
 
-	op_in.rx_count = pckt->len;
-	op_out.rx_buf = npcx_espi_taf_data.read_buf;
+	op_in.rx_count = taf->pckt.len;
+	op_out.rx_buf = taf->read_buf;
 	rc = flash_ex_op(spi_dev, FLASH_NPCX_EX_OP_EXEC_UMA, (uintptr_t)&op_in, &op_out);
 	if (rc) {
 		LOG_ERR("flash RPMC OP2 data read fail");
 		return -EIO;
 	}
 
-	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITH_DATA_ONLY, taf_data_ptr->tag,
-					 pckt->len, (uint32_t *)npcx_espi_taf_data.read_buf);
+	rc = taf_npcx_completion_handler(dev, CYC_SCS_CMP_WITH_DATA_ONLY, taf->pckt.tag,
+					 taf->pckt.len, (uint32_t *)taf->read_buf);
 	if (rc) {
 		LOG_ERR("espi taf completion handler fail");
 		return rc;
@@ -664,12 +645,11 @@ static int espi_taf_npcx_rpmc_op2(const struct device *dev, struct espi_saf_pack
 }
 #endif
 
-static int espi_taf_npcx_flash_unsuccess(const struct device *dev, struct espi_saf_packet *pckt)
+static int espi_taf_npcx_flash_unsuccess(const struct device *dev, struct espi_taf_npcx_data *taf)
 {
-	struct espi_taf_npcx_pckt *taf_data_ptr = (struct espi_taf_npcx_pckt *)pckt->buf;
 	int rc;
 
-	rc = taf_npcx_completion_handler(dev, CYC_UNSCS_CMP_WITHOUT_DATA_ONLY, taf_data_ptr->tag,
+	rc = taf_npcx_completion_handler(dev, CYC_UNSCS_CMP_WITHOUT_DATA_ONLY, taf->pckt.tag,
 					 0x0, NULL);
 	if (rc) {
 		LOG_ERR("espi taf completion handler fail");
@@ -684,45 +664,42 @@ static void espi_taf_work(struct k_work *item)
 	struct espi_taf_npcx_data *info = CONTAINER_OF(item, struct espi_taf_npcx_data, work);
 	int ret = 0;
 
-	struct espi_taf_npcx_pckt taf_data;
-	struct espi_saf_packet pckt_taf;
+	if (info->pckt.invalid_flag == 1) {
+		LOG_ERR("Invalid TAF packet");
 
-	pckt_taf.flash_addr = info->address;
-	pckt_taf.len = info->length;
-	taf_data.tag = info->taf_tag;
-	if ((info->taf_type == NPCX_ESPI_TAF_REQ_WRITE) ||
-	    (IS_ENABLED(CONFIG_ESPI_TAF_NPCX_RPMC_SUPPORT) &&
-	     (info->taf_type == NPCX_ESPI_TAF_REQ_RPMC_OP1))) {
-		taf_data.data = (uint8_t *)info->src;
-	} else {
-		taf_data.data = NULL;
+		ret = espi_taf_npcx_flash_unsuccess(info->host_dev, info);
+
+		return;
 	}
-	pckt_taf.buf = (uint8_t *)&taf_data;
 
-	switch (info->taf_type) {
+	switch (info->pckt.type) {
 #if defined(CONFIG_ESPI_TAF_MANUAL_MODE)
 	case NPCX_ESPI_TAF_REQ_READ:
-		ret = espi_taf_npcx_flash_read(info->host_dev, &pckt_taf);
+		ret = espi_taf_npcx_flash_read(info->host_dev, info);
 		break;
 #endif
 	case NPCX_ESPI_TAF_REQ_ERASE:
-		ret = espi_taf_npcx_flash_erase(info->host_dev, &pckt_taf);
+		ret = espi_taf_npcx_flash_erase(info->host_dev, info);
 		break;
 	case NPCX_ESPI_TAF_REQ_WRITE:
-		ret = espi_taf_npcx_flash_write(info->host_dev, &pckt_taf);
+		ret = espi_taf_npcx_flash_write(info->host_dev, info);
 		break;
 #ifdef CONFIG_ESPI_TAF_NPCX_RPMC_SUPPORT
 	case NPCX_ESPI_TAF_REQ_RPMC_OP1:
-		ret = espi_taf_npcx_rpmc_op1(info->host_dev, &pckt_taf);
+		ret = espi_taf_npcx_rpmc_op1(info->host_dev, info);
 		break;
 	case NPCX_ESPI_TAF_REQ_RPMC_OP2:
-		ret = espi_taf_npcx_rpmc_op2(info->host_dev, &pckt_taf);
+		ret = espi_taf_npcx_rpmc_op2(info->host_dev, info);
 		break;
 #endif
+	default:
+		LOG_ERR("Unsupported TAF cycle type %u", info->pckt.type);
+		ret = -EINVAL;
+		break;
 	}
 
 	if (ret != 0) {
-		ret = espi_taf_npcx_flash_unsuccess(info->host_dev, &pckt_taf);
+		ret = espi_taf_npcx_flash_unsuccess(info->host_dev, info);
 	}
 }
 

--- a/soc/nuvoton/npcx/common/soc_espi_taf.h
+++ b/soc/nuvoton/npcx/common/soc_espi_taf.h
@@ -8,6 +8,8 @@
 #define _NUVOTON_NPCX_SOC_ESPI_TAF_H_
 
 #include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -70,6 +72,13 @@ extern "C" {
 #define NPCX_FLASH_SHARING_CAP_SUPP_TAF            2
 #define NPCX_FLASH_SHARING_CAP_SUPP_TAF_AND_CAF    3
 
+#define NPCX_ESPI_FLASH_HEADER_LEN                 1
+#define NPCX_ESPI_FLASH_HEADER_ADDRESS_LEN         2
+
+/* Get the eSPI receive payload size from Devicetree. */
+#define NPCX_TAF_RX_PAYLOAD_BYTES DT_PROP(DT_INST(0, nuvoton_npcx_espi), rx_plsize)
+#define NPCX_TAF_RX_PAYLOAD_WORDS DIV_ROUND_UP(NPCX_TAF_RX_PAYLOAD_BYTES, sizeof(uint32_t))
+
 enum NPCX_ESPI_TAF_REQ {
 	NPCX_ESPI_TAF_REQ_READ,
 	NPCX_ESPI_TAF_REQ_WRITE,
@@ -126,17 +135,13 @@ struct espi_saf_protection {
 	const struct espi_saf_pr *pregions;
 };
 
-struct espi_taf_npcx_pckt {
-	uint8_t tag;
-	uint8_t *data;
-};
-
 struct espi_taf_pckt {
 	uint8_t  type;
 	uint8_t  tag;
 	uint32_t addr;
 	uint16_t len;
-	uint32_t src[16];
+	uint32_t src[NPCX_TAF_RX_PAYLOAD_WORDS];
+	uint8_t  invalid_flag;
 };
 
 struct npcx_taf_head {


### PR DESCRIPTION
This changes include:
- Streamline data structures by embedding espi_taf_pckt directly into driver data, eliminating manual field copies and indirection.
- Optimize completion handler to write directly to FLASHTXBUF register.
- Implement defensive RX/TX bounds validation to guard against buffer overflows.
- Add safety fallback for unsupported eSPI cycle type.

Fixes: #117251