### PR TITLE
soc: realtek: rtl8752h: support sys_reboot()

### DIFF
--- a/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
+++ b/soc/realtek/bee/rtl8752h/Kconfig.defconfig.series
@@ -15,6 +15,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default 1000
 
+config ARCH_HAS_CUSTOM_BUSY_WAIT
+	default y
+
 config TIMESLICE_SIZE
 	default 10
 

--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/linker/linker-defs.h>
+#include <zephyr/sys/reboot.h>
 #include <zephyr/logging/log.h>
 #include <soc.h>
 
@@ -17,13 +18,12 @@
 #include <system_rtl876x.h>
 #include <vector_table.h>
 #include <rtl876x_aon_reg.h>
+#include <sys_reset.h>
 
 extern void _isr_wrapper(void);
 
 #define RAM_VECTOR_ADDR   (0x200000)
 #define STACK_ROM_ADDRESS DT_REG_ADDR(DT_NODELABEL(bee_bt_controller))
-
-typedef bool (*BOOL_PATCH_FUNC)(void);
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
@@ -173,4 +173,16 @@ void soc_late_init_hook(void)
 	rtl8752h_isr_register();
 
 	rtl_boot_stage_record(PON_BOOT_DONE);
+}
+
+/* Overrides the weak ARM implementation */
+void sys_arch_reboot(int type)
+{
+	/* Convert SYS_REBOOT_WARM (0) to RESET_ALL_EXCEPT_AON (1).
+	 * Convert SYS_REBOOT_COLD (1) to RESET_ALL (0).
+	 */
+	int wdt_mode = (type == SYS_REBOOT_WARM) ? RESET_ALL_EXCEPT_AON : RESET_ALL;
+
+	/* Call the watchdog system reset with the converted mode and reset reason. */
+	WDG_SystemReset(wdt_mode, RESET_REASON_ZEPHYR);
 }

--- a/soc/realtek/bee/rtl8752h/soc.c
+++ b/soc/realtek/bee/rtl8752h/soc.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/linker/linker-defs.h>
+#include <zephyr/sys/reboot.h>
 #include <zephyr/logging/log.h>
 #include <soc.h>
 
@@ -17,13 +18,12 @@
 #include "system_rtl876x.h"
 #include "vector_table.h"
 #include "rtl876x_aon_reg.h"
+#include "sys_reset.h"
 
 extern void _isr_wrapper(void);
 
 #define RAM_VECTOR_ADDR   (0x200000)
 #define STACK_ROM_ADDRESS DT_REG_ADDR(DT_NODELABEL(bee_bt_controller))
-
-typedef bool (*BOOL_PATCH_FUNC)(void);
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
@@ -173,4 +173,16 @@ void soc_late_init_hook(void)
 	rtl8752h_isr_register();
 
 	rtl_boot_stage_record(PON_BOOT_DONE);
+}
+
+/* Overrides the weak ARM implementation */
+void sys_arch_reboot(int type)
+{
+	/* Convert SYS_REBOOT_WARM (0) to RESET_ALL_EXCEPT_AON (1).
+	 * Convert SYS_REBOOT_COLD (1) to RESET_ALL (0).
+	 */
+	int wdt_mode = (type == SYS_REBOOT_WARM) ? RESET_ALL_EXCEPT_AON : RESET_ALL;
+
+	/* Call the watchdog system reset with the converted mode and reset reason. */
+	WDG_SystemReset(wdt_mode, RESET_REASON_ZEPHYR);
 }

--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
         - hal
     - name: hal_realtek
       path: modules/hal/realtek
-      revision: c20e7ee9744a1b9b5f05b99260930a7f196b9b12
+      revision: 29d365ccfbceb9f42ce666d75463fbe2c83b8e29
       groups:
         - hal
     - name: hal_renesas

--- a/west.yml
+++ b/west.yml
@@ -229,7 +229,7 @@ manifest:
         - hal
     - name: hal_realtek
       path: modules/hal/realtek
-      revision: ba5032a9e47b6ad9e9488665c1e990ed0f434734
+      revision: pull/43/head
       groups:
         - hal
     - name: hal_renesas


### PR DESCRIPTION
This PR enables Zephyr `sys_reboot()` support for the Realtek Bee
series reset flow.

The change updates the HAL Realtek revision to include the RTL8752H ROM
system reset APIs, then wires the RTL8752H SoC reset implementation to
Zephyr's reboot path.

The `samples/subsys/task_wdt` sample was used to validate the reboot path
because it exercises the `sys_reboot()` API. Both currently supported Bee
series SoCs passed: `rtl8752h_evb/rtl8752hjl` and
`rtl87x2g_evb_a/rtl8762gku`.

Detailed result:

```json
{
    "environment":{
        "os":"Linux",
        "zephyr_version":"v4.4.0-9928-g577e42ad1878",
        "toolchain":"zephyr/gnu",
        "commit_date":"2026-07-29T16:56:04-07:00",
        "run_date":"2026-07-30T07:58:05+00:00",
        "options":{
            "help":null,
            "zephyr_base":null,
            "quiet":0,
            "command":"twister",
            "testsuite_root":[
                "samples/subsys/task_wdt"
            ],
            "device_testing":true,
            "hardware_map":"./hw.yaml",
            "platform":[
                "rtl87x2g_evb_a/rtl8762gku",
                "rtl8752h_evb/rtl8752hjl"
            ]
        }
    },
    "testsuites":[
        {
            "name":"sample.task_wdt",
            "arch":"arm",
            "platform":"rtl8752h_evb/rtl8752hjl",
            "path":"samples/subsys/task_wdt",
            "run_id":"7b55bab8d5b09dc9e3d870d82a8b8395",
            "runnable":true,
            "retries":0,
            "toolchain":"zephyr/gnu",
            "dut":"H Series",
            "status":"passed",
            "execution_time":"12.75",
            "build_time":"36.52",
            "testcases":[
                {
                    "identifier":"sample.task_wdt",
                    "execution_time":"12.75",
                    "status":"passed"
                }
            ]
        },
        {
            "name":"sample.task_wdt",
            "arch":"arm",
            "platform":"rtl87x2g_evb_a/rtl8762gku",
            "path":"samples/subsys/task_wdt",
            "run_id":"eaa9c8903265e6b181ae98d00f8a35a0",
            "runnable":true,
            "retries":0,
            "toolchain":"zephyr/gnu",
            "dut":"G Series",
            "status":"passed",
            "execution_time":"15.03",
            "build_time":"37.35",
            "testcases":[
                {
                    "identifier":"sample.task_wdt",
                    "execution_time":"15.03",
                    "status":"passed"
                }
            ]
        }
    ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
