### PR TITLE
Update i2c0 pin to avoid conflicting with on board i3c sensor

### DIFF
--- a/boards/nxp/frdm_mcxa577/board.cmake
+++ b/boards/nxp/frdm_mcxa577/board.cmake
@@ -7,13 +7,6 @@
 board_runner_args(jlink "--device=MCXA577")
 board_runner_args(linkserver "--device=MCXA577:FRDM-MCXA577")
 
-# Linkserver v25.12.xx and earlier do not include the secure regions in the
-# MCXA577 memory map, so we add them here
-board_runner_args(linkserver  "--override=/device/memory/-=\{\"location\":\"0x10000000\",\
-                              \"size\":\"0x00200000\",\"type\":\"Flash\",\"flash-driver\":\"MCXA2TS_S.cfx\"\}")
-board_runner_args(linkserver "--override=/device/memory/-=\{\"location\":\"0x30000000\",\
-                             \"size\":\"0x0001C000\",\"type\":\"RAM\"\}")
-
 board_runner_args(pyocd "--target=MCXA577")
 
 include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)

--- a/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa577/frdm_mcxa577-pinctrl.dtsi
@@ -58,8 +58,8 @@
 
 	pinmux_lpi2c0: pinmux_lpi2c0 {
 		group0 {
-			pinmux = <LPI2C0_SDA_P0_20>,
-				 <LPI2C0_SCL_P0_21>;
+			pinmux = <LPI2C0_SDA_P0_16>,
+				 <LPI2C0_SCL_P0_17>;
 			slew-rate = "fast";
 			drive-strength = "low";
 			input-enable;

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxa266.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxa266.overlay
@@ -10,6 +10,10 @@
  */
 
 &lpi2c1 {
+	scl-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio1 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -18,6 +22,10 @@
 };
 
 &lpi2c3 {
+	scl-gpios = <&gpio3 27 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio3 28 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxa344.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxa344.overlay
@@ -10,6 +10,10 @@
  */
 
 &lpi2c0 {
+	scl-gpios = <&gpio1 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio1 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -18,6 +22,10 @@
 };
 
 &lpi2c1 {
+	scl-gpios = <&gpio3 27 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio3 28 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxa346.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxa346.overlay
@@ -10,6 +10,10 @@
  */
 
 &lpi2c1 {
+	scl-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio1 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -18,6 +22,10 @@
 };
 
 &lpi2c3 {
+	scl-gpios = <&gpio3 27 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio3 28 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxa366.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxa366.overlay
@@ -10,6 +10,10 @@
  */
 
 &lpi2c1 {
+	scl-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio1 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -18,6 +22,10 @@
 };
 
 &lpi2c3 {
+	scl-gpios = <&gpio3 27 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio3 28 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxa577.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxa577.overlay
@@ -5,11 +5,15 @@
  */
 
 /* To test this sample, connect
- * LPI2C0 SCL(J2-20)  -->  LPI2C3 SCL(J5-5)
- * LPI2C0 SDA(J2-18)  -->  LPI2C3 SDA(J5-6)
+ * LPI2C0 SCL(J9-9)  -->  LPI2C3 SCL(J5-5)
+ * LPI2C0 SDA(J9-10)  -->  LPI2C3 SDA(J5-6)
  */
 
 &lpi2c0 {
+	scl-gpios = <&gpio0 17 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio0 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
+
 	eeprom0: eeprom@54 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x54>;
@@ -18,6 +22,10 @@
 };
 
 &lpi2c3 {
+	scl-gpios = <&gpio3 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio3 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxn236.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxn236.overlay
@@ -34,6 +34,9 @@
 	pinctrl-0 = <&pinmux_flexcomm3_lpi2c>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	scl-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio1 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
 	status = "okay";
 
 	eeprom0: eeprom@54 {
@@ -45,6 +48,10 @@
 };
 
 &flexcomm5_lpi2c5 {
+	scl-gpios = <&gpio1 17 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio1 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;

--- a/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -3,37 +3,22 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-&pinctrl {
-	pinmux_flexcomm1_lpi2c: pinmux_flexcomm1_lpi2c {
-		group0 {
-			pinmux = <FC1_P0_PIO0_24>,
-				 <FC1_P1_PIO0_25>;
-			slew-rate = "fast";
-			drive-strength = "low";
-			input-enable;
-			bias-pull-up;
-			drive-open-drain;
-		};
-	};
-};
-
-&flexcomm1 {
+&flexcomm3 {
 	status = "okay";
 };
 
-/* We cannot enable SPI and I2C on the same flexcomm */
-&flexcomm1_lpspi1 {
-	status = "disabled";
+&flexcomm3_lpi2c3 {
+	status = "okay";
 };
 
 /* To test this sample, connect
- * LPI2C1 SCL(J2-12, P0_25/FC1_P1)    -->        LPI2C2 SCL(J2-20, P4_1/FC2_P1)
- * LPI2C1 SDA(J2-8, P0_24/FC1_P0)     -->        LPI2C2 SDA(J2-18, P4_0/FC2_P0)
+ * LPI2C3 SCL(J5-5, P1_1/FC3_P1)    -->        LPI2C2 SCL(J2-20, P4_1/FC2_P1)
+ * LPI2C3 SDA(J5-6, P1_0/FC3_P0)     -->        LPI2C2 SDA(J2-18, P4_0/FC2_P0)
  */
-&flexcomm1_lpi2c1 {
-	pinctrl-0 = <&pinmux_flexcomm1_lpi2c>;
-	pinctrl-names = "default";
-	clock-frequency = <I2C_BITRATE_STANDARD>;
+&flexcomm3_lpi2c3 {
+	scl-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio1 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
 	status = "okay";
 
 	eeprom0: eeprom@54 {
@@ -44,6 +29,10 @@
 };
 
 &flexcomm2_lpi2c2 {
+	scl-gpios = <&gpio4 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	sda-gpios = <&gpio4 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	recover-bus-on-init;
+
 	eeprom1: eeprom@56 {
 		compatible = "zephyr,i2c-target-eeprom";
 		reg = <0x56>;


### PR DESCRIPTION
tested with `west flash`, the tests/drivers/i2c/i2c_target_api/ works fine for frdm_mcxa577 

this is to fix the issue: https://github.com/zephyrproject-rtos/zephyr/issues/106043