### PR TITLE
arch: arm: core: mpu: drop arm_core_mpu_mem_partition_config_update()

### DIFF
--- a/arch/arm/core/mpu/arm_core_mpu_dev.h
+++ b/arch/arm/core/mpu/arm_core_mpu_dev.h
@@ -188,27 +188,6 @@ void arm_core_mpu_configure_dynamic_mpu_regions(
 	const struct z_arm_mpu_partition *dynamic_regions,
 	uint8_t regions_num);
 
-#if defined(CONFIG_USERSPACE)
-/**
- * @brief update configuration of an active memory partition
- *
- * Internal API function to re-configure the access permissions of an
- * active memory partition, i.e. a partition that has earlier been
- * configured in the (current) thread context.
- *
- * @param partition Pointer to a structure holding the partition information
- *                  (must be valid).
- * @param new_attr  New access permissions attribute for the partition.
- *
- * The function shall assert if the operation cannot be not performed
- * successfully (e.g. the given partition can not be found).
- */
-void arm_core_mpu_mem_partition_config_update(
-	struct z_arm_mpu_partition *partition,
-	k_mem_partition_attr_t *new_attr);
-
-#endif /* CONFIG_USERSPACE */
-
 /**
  * @brief configure the base address and size for an MPU region
  *

--- a/arch/arm/core/mpu/arm_mpu.c
+++ b/arch/arm/core/mpu/arm_mpu.c
@@ -319,47 +319,6 @@ void arm_core_mpu_disable(void)
 
 #if defined(CONFIG_USERSPACE)
 /**
- * @brief update configuration of an active memory partition
- */
-void arm_core_mpu_mem_partition_config_update(
-	struct z_arm_mpu_partition *partition,
-	k_mem_partition_attr_t *new_attr)
-{
-	/* Find the partition. ASSERT if not found. */
-	uint8_t i;
-	uint8_t reg_index = get_num_regions();
-
-	for (i = get_dyn_region_min_index(); i < get_num_regions(); i++) {
-		if (!is_enabled_region(i)) {
-			continue;
-		}
-
-		uint32_t base = mpu_region_get_base(i);
-
-		if (base != partition->start) {
-			continue;
-		}
-
-		uint32_t size = mpu_region_get_size(i);
-
-		if (size != partition->size) {
-			continue;
-		}
-
-		/* Region found */
-		reg_index = i;
-		break;
-	}
-	__ASSERT(reg_index != get_num_regions(),
-		 "Memory domain partition %p size %zu not found\n",
-		 (void *)partition->start, partition->size);
-
-	/* Modify the permissions */
-	partition->attr = *new_attr;
-	mpu_configure_region(reg_index, partition);
-}
-
-/**
  * @brief get the maximum number of available (free) MPU region indices
  *        for configuring dynamic MPU partitions
  */

--- a/arch/arm/core/mpu/nxp_mpu.c
+++ b/arch/arm/core/mpu/nxp_mpu.c
@@ -534,46 +534,6 @@ static inline int is_in_region(uint32_t r_index, uint32_t start, uint32_t size)
 }
 
 /**
- * @brief update configuration of an active memory partition
- */
-void arm_core_mpu_mem_partition_config_update(
-	struct z_arm_mpu_partition *partition,
-	k_mem_partition_attr_t *new_attr)
-{
-	/* Find the partition. ASSERT if not found. */
-	uint8_t i;
-	uint8_t reg_index = get_num_regions();
-
-	for (i = static_regions_num; i < get_num_regions(); i++) {
-		if (!is_enabled_region(i)) {
-			continue;
-		}
-
-		uint32_t base = mpu_region_get_base(i);
-
-		if (base != partition->start) {
-			continue;
-		}
-
-		uint32_t size = mpu_region_get_size(i);
-
-		if (size != partition->size) {
-			continue;
-		}
-
-		/* Region found */
-		reg_index = i;
-		break;
-	}
-	__ASSERT(reg_index != get_num_regions(),
-		 "Memory domain partition not found\n");
-
-	/* Modify the permissions */
-	partition->attr = *new_attr;
-	mpu_configure_region(reg_index, partition);
-}
-
-/**
  * @brief get the maximum number of available (free) MPU region indices
  *        for configuring dynamic MPU partitions
  */


### PR DESCRIPTION
Commit 2222fa1426a0aa83503e906282591ae7df23c211 removed all callers of the function arm_core_mpu_mem_partition_config_update()... but not the function itself, which became dead code lingering in tree since then...

Get rid of this function - it has served no purpose for long enough.

(this is cherry-picked from #114883; I think that PR will take some time to land whereas this one should be easy to merge)