### PR TITLE
boards: nordic: nrf93m1dk: specify revisions on runner config

### DIFF
--- a/boards/nordic/nrf93m1dk/board.yml
+++ b/boards/nordic/nrf93m1dk/board.yml
@@ -24,10 +24,18 @@ runners:
       run: first
       groups:
       - boards:
-        - nrf93m1dk/nrf54l15/cpuapp
-        - nrf93m1dk/nrf54l15/cpuapp/ns
-        - nrf93m1dk/nrf54l15/cpuflpr
-        - nrf93m1dk/nrf54l15/cpuflpr/xip
+        - nrf93m1dk@0.1.0/nrf54l15/cpuapp
+        - nrf93m1dk@0.1.0/nrf54l15/cpuapp/ns
+        - nrf93m1dk@0.1.0/nrf54l15/cpuflpr
+        - nrf93m1dk@0.1.0/nrf54l15/cpuflpr/xip
+        - nrf93m1dk@0.2.0/nrf54l15/cpuapp
+        - nrf93m1dk@0.2.0/nrf54l15/cpuapp/ns
+        - nrf93m1dk@0.2.0/nrf54l15/cpuflpr
+        - nrf93m1dk@0.2.0/nrf54l15/cpuflpr/xip
+        - nrf93m1dk@0.3.0/nrf54l15/cpuapp
+        - nrf93m1dk@0.3.0/nrf54l15/cpuapp/ns
+        - nrf93m1dk@0.3.0/nrf54l15/cpuflpr
+        - nrf93m1dk@0.3.0/nrf54l15/cpuflpr/xip
     '--erase':
     - runners:
       - jlink
@@ -35,10 +43,18 @@ runners:
       run: first
       groups:
       - boards:
-        - nrf93m1dk/nrf54l15/cpuapp
-        - nrf93m1dk/nrf54l15/cpuapp/ns
-        - nrf93m1dk/nrf54l15/cpuflpr
-        - nrf93m1dk/nrf54l15/cpuflpr/xip
+        - nrf93m1dk@0.1.0/nrf54l15/cpuapp
+        - nrf93m1dk@0.1.0/nrf54l15/cpuapp/ns
+        - nrf93m1dk@0.1.0/nrf54l15/cpuflpr
+        - nrf93m1dk@0.1.0/nrf54l15/cpuflpr/xip
+        - nrf93m1dk@0.2.0/nrf54l15/cpuapp
+        - nrf93m1dk@0.2.0/nrf54l15/cpuapp/ns
+        - nrf93m1dk@0.2.0/nrf54l15/cpuflpr
+        - nrf93m1dk@0.2.0/nrf54l15/cpuflpr/xip
+        - nrf93m1dk@0.3.0/nrf54l15/cpuapp
+        - nrf93m1dk@0.3.0/nrf54l15/cpuapp/ns
+        - nrf93m1dk@0.3.0/nrf54l15/cpuflpr
+        - nrf93m1dk@0.3.0/nrf54l15/cpuflpr/xip
     '--reset':
     - runners:
       - jlink
@@ -46,7 +62,15 @@ runners:
       run: last
       groups:
       - boards:
-        - nrf93m1dk/nrf54l15/cpuapp
-        - nrf93m1dk/nrf54l15/cpuapp/ns
-        - nrf93m1dk/nrf54l15/cpuflpr
-        - nrf93m1dk/nrf54l15/cpuflpr/xip
+        - nrf93m1dk@0.1.0/nrf54l15/cpuapp
+        - nrf93m1dk@0.1.0/nrf54l15/cpuapp/ns
+        - nrf93m1dk@0.1.0/nrf54l15/cpuflpr
+        - nrf93m1dk@0.1.0/nrf54l15/cpuflpr/xip
+        - nrf93m1dk@0.2.0/nrf54l15/cpuapp
+        - nrf93m1dk@0.2.0/nrf54l15/cpuapp/ns
+        - nrf93m1dk@0.2.0/nrf54l15/cpuflpr
+        - nrf93m1dk@0.2.0/nrf54l15/cpuflpr/xip
+        - nrf93m1dk@0.3.0/nrf54l15/cpuapp
+        - nrf93m1dk@0.3.0/nrf54l15/cpuapp/ns
+        - nrf93m1dk@0.3.0/nrf54l15/cpuflpr
+        - nrf93m1dk@0.3.0/nrf54l15/cpuflpr/xip


### PR DESCRIPTION
Explicitly specify board revisions on runner config. This is required for "west flash --erase" and
"west flash --recover" to pick up the right configuration.