### PR TITLE
samples: usb: cdc_acm_bridge: add control signals for coprocessor flashing.

### DIFF
--- a/boards/shields/x_nucleo_67w61m1/doc/index.rst
+++ b/boards/shields/x_nucleo_67w61m1/doc/index.rst
@@ -44,6 +44,13 @@ A flashing script is included in the X-CUBE package:
    cd x-cube-st67w61/Projects/ST67W6X_Scripts/Binaries/
    ./NCP_update_mission_profile_t02.sh
 
+Alternatively, the coprocessor can be flashed from the host through the STM32
+with the :zephyr:code-sample:`usb-cdc-acm-bridge` sample: built for
+``nucleo_u575zi_q`` (its board overlay targets this shield) it bridges USB
+CDC-ACM to the module UART and drives the module boot/reset straps from the
+DTR/RTS control lines, so the X-CUBE flashing tool can be run against the
+resulting USB CDC-ACM serial port.
+
 Programming
 ***********
 

--- a/samples/subsys/usb/cdc_acm_bridge/README.rst
+++ b/samples/subsys/usb/cdc_acm_bridge/README.rst
@@ -47,3 +47,31 @@ If the hardware port is connected to an on-board debugger then the output
 should be echoed between the two ports, if it's connected to some pins on the
 boards the pins can be shorted together to test that the driver is working
 correctly.
+
+Flashing a coprocessor
+**********************
+
+Some boards carry a coprocessor (for example a Wi-Fi/BT module) whose own
+firmware is updated over a UART ROM bootloader. Host flashing tools enter
+that bootloader by toggling the serial DTR/RTS control lines.
+
+A board overlay can add ``boot-gpios`` and ``reset-gpios`` to ``/zephyr,user``
+node, to drive the boot pin from DTR and the reset pin from RTS, with polarity
+taken from the ``GPIO_ACTIVE_*`` flag on each property. This allows flashing
+the coprocessor straight through the bridge with the vendor's normal host tool,
+no separate firmware or wiring required.
+
+Two overlays demonstrate this:
+
+* ``nucleo_u575zi_q`` with the ``x_nucleo_67w61m1`` shield bridges to the
+  ST67W611M1 (Qualcomm) module UART; flash it with ST's QConn tool.
+* ``arduino_portenta_c33`` bridges to the onboard ESP32-C3; flash it with
+  ``esptool``:
+
+  .. code-block:: console
+
+     esptool.py --chip esp32c3 -p /dev/ttyACM0 -b 230400 \
+       --before=default_reset --after=hard_reset write_flash 0x0 firmware.bin
+
+  If the USB path drops bytes, add ``--no-stub`` and lower the baud rate
+  (``-b 115200``).

--- a/samples/subsys/usb/cdc_acm_bridge/boards/arduino_portenta_c33.conf
+++ b/samples/subsys/usb/cdc_acm_bridge/boards/arduino_portenta_c33.conf
@@ -1,0 +1,7 @@
+# Drive the ESP32-C3 boot/reset straps from the CDC DTR/RTS lines.
+CONFIG_GPIO=y
+
+# Reliable flashing throughput: large CDC and bridge buffers so
+# bursts from esptool are not dropped.
+CONFIG_USBD_CDC_ACM_BUF_POOL_SIZE=4096
+CONFIG_UART_BRIDGE_BUF_SIZE=4096

--- a/samples/subsys/usb/cdc_acm_bridge/boards/arduino_portenta_c33.overlay
+++ b/samples/subsys/usb/cdc_acm_bridge/boards/arduino_portenta_c33.overlay
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * cdc_acm_bridge on Arduino Portenta C33: flash the onboard ESP32-C3
+ * coprocessor from a host esptool over USB CDC-ACM.
+ *
+ * Bridges USB CDC-ACM <-> SCI8 (the ESP32-C3 UART) and drives the ESP boot
+ * (P803, GPIO0/download strap) and reset/EN (P804) pins from the CDC DTR/RTS
+ * lines, reproducing esptool's auto-download-reset circuit. The normal SPI
+ * esp-hosted WiFi, the BT HCI link, and the download-strap regulator are
+ * disabled so the UART and those pins are free for flashing.
+ *
+ * A boards/<board>.overlay replaces the sample's app.overlay, so the bridge and
+ * CDC-ACM nodes are declared here too (reusing the board's board_cdc_acm_uart).
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	uart-bridge0 {
+		compatible = "zephyr,uart-bridge";
+		peers = <&board_cdc_acm_uart &uart8>;
+	};
+
+	zephyr,user {
+		/* boot <- DTR, reset <- RTS; active-low (esptool default_reset).
+		 *   boot-gpios  : P803 (ESP32-C3 GPIO0 / download strap)
+		 *   reset-gpios : P804 (ESP32-C3 EN / reset)
+		 */
+		boot-gpios = <&ioport8 3 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&ioport8 4 GPIO_ACTIVE_LOW>;
+	};
+
+	/* P803 is also the esp-hosted download-strap regulator; disable it so the
+	 * boot line above is free.
+	 */
+	download-esp32 {
+		status = "disabled";
+	};
+};
+
+/* ESP UART becomes a plain bridge peer: no BT HCI, no hardware flow control. */
+&uart8 {
+	/delete-property/ hw-flow-control;
+};
+
+&bt_hci_uart {
+	status = "disabled";
+};
+
+/* Disable the SPI WiFi so it does not claim the reset/handshake pins. */
+&spi1 {
+	esp_hosted@1 {
+		status = "disabled";
+	};
+};
+
+/* Full-speed is ample for flashing (bulk 64-byte, ~1 MB/s) and avoids a
+ * high-speed bulk-IN device->host stall in the RA USBHS UDC.
+ */
+&usbhs {
+	maximum-speed = "full-speed";
+};

--- a/samples/subsys/usb/cdc_acm_bridge/boards/nucleo_u575zi_q.conf
+++ b/samples/subsys/usb/cdc_acm_bridge/boards/nucleo_u575zi_q.conf
@@ -1,0 +1,8 @@
+# Drive the coprocessor boot/reset straps from the CDC DTR/RTS lines. Without
+# CONFIG_GPIO the STM32 GPIO API is a no-op stub and the pins are never driven.
+CONFIG_GPIO=y
+
+## Reliable flashing throughput: large CDC and bridge buffers so
+# bursts from QConn are not dropped.
+CONFIG_USBD_CDC_ACM_BUF_POOL_SIZE=4096
+CONFIG_UART_BRIDGE_BUF_SIZE=4096

--- a/samples/subsys/usb/cdc_acm_bridge/boards/nucleo_u575zi_q.overlay
+++ b/samples/subsys/usb/cdc_acm_bridge/boards/nucleo_u575zi_q.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) Arduino s.r.l. and/or its affiliated companies
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * cdc_acm_bridge on NUCLEO-U575ZI-Q + X-NUCLEO-67W61M1 (ST67W611M1
+ * coprocessor). Bridges USB CDC-ACM <-> LPUART1 (Arduino D0/D1, the module
+ * firmware-update UART) and drives the module boot/reset straps from the CDC
+ * DTR/RTS lines, so ST's QConn flashing tool can put the coprocessor into UART
+ * ISP without a manual button press.
+ *
+ * A boards/<board>.overlay replaces the sample's app.overlay, so the bridge and
+ * CDC-ACM nodes are declared here too.
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	uart-bridge0 {
+		compatible = "zephyr,uart-bridge";
+		peers = <&cdc_acm_uart0 &arduino_serial>;
+	};
+
+	zephyr,user {
+		/* boot <- DTR, reset <- RTS; active-low matches the classic
+		 * auto-download-reset circuit.
+		 *   boot-gpios  : Arduino D6 = PE9  (module BOOT / GPIO0)
+		 *   reset-gpios : Arduino D5 = PE11 (module CHIP_EN)
+		 */
+		boot-gpios = <&gpioe 9 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&gpioe 11 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&arduino_serial {
+	/* Enable the hardware FIFO for reliable operation at higher baud rates;
+	 * baud itself is set at runtime from the CDC line coding.
+	 */
+	current-speed = <115200>;
+	fifo-enable;
+	status = "okay";
+};
+
+&zephyr_udc0 {
+	cdc_acm_uart0: cdc_acm_uart0 {
+		compatible = "zephyr,cdc-acm-uart";
+		label = "Zephyr USB CDC-ACM";
+	};
+};

--- a/samples/subsys/usb/cdc_acm_bridge/src/main.c
+++ b/samples/subsys/usb/cdc_acm_bridge/src/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2025 Google LLC
+ * Copyright (C) Arduino s.r.l. and/or its affiliated companies
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +10,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/uart/uart_bridge.h>
 #include <zephyr/kernel.h>
 
@@ -26,6 +29,63 @@ static struct usbd_context *sample_usbd;
 const struct device *uart_bridges[] = {
 	DT_FOREACH_STATUS_OKAY(zephyr_uart_bridge, DEVICE_DT_GET_COMMA)
 };
+
+/*
+ * Optional coprocessor control signals.
+ *
+ * When the board overlay adds boot-gpios and reset-gpios to the /zephyr,user
+ * node, the bridge drives them from the CDC-ACM control lines: a USB-serial
+ * flashing tool toggles DTR/RTS to force the coprocessor into its ROM/UART
+ * bootloader, and the bridge mirrors those lines onto the coprocessor boot and
+ * reset pins. The mapping is the convention used by esptool (default_reset)
+ * and other host flashers:
+ *
+ *   DTR -> boot (strap)     RTS -> reset (enable)
+ *
+ * Polarity is expressed with the GPIO_ACTIVE_* flag on each gpios property in
+ * the overlay (typically GPIO_ACTIVE_LOW), so no code change is needed per
+ * target.
+ */
+#define RESET_LINES_NODE DT_PATH(zephyr_user)
+
+#if DT_NODE_HAS_PROP(RESET_LINES_NODE, boot_gpios) && \
+	DT_NODE_HAS_PROP(RESET_LINES_NODE, reset_gpios)
+#define HAS_RESET_LINES 1
+
+static const struct gpio_dt_spec boot_gpio = GPIO_DT_SPEC_GET(RESET_LINES_NODE, boot_gpios);
+static const struct gpio_dt_spec reset_gpio = GPIO_DT_SPEC_GET(RESET_LINES_NODE, reset_gpios);
+
+static void reset_lines_update(const struct device *cdc)
+{
+	uint32_t dtr = 0U;
+	uint32_t rts = 0U;
+
+	(void)uart_line_ctrl_get(cdc, UART_LINE_CTRL_DTR, &dtr);
+	(void)uart_line_ctrl_get(cdc, UART_LINE_CTRL_RTS, &rts);
+
+	/* DTR drives boot, RTS drives reset; the overlay GPIO flags set polarity. */
+	gpio_pin_set_dt(&boot_gpio, (int)dtr);
+	gpio_pin_set_dt(&reset_gpio, (int)rts);
+
+	LOG_DBG("ctrl-lines dtr=%u rts=%u", dtr, rts);
+}
+
+static int reset_lines_init(void)
+{
+	if (!gpio_is_ready_dt(&boot_gpio) || !gpio_is_ready_dt(&reset_gpio)) {
+		LOG_ERR("reset-line GPIOs not ready");
+		return -ENODEV;
+	}
+
+	/* Start both lines deasserted - their idle state, like a USB-serial
+	 * adapter at rest. The flashing tool then drives the boot/reset
+	 * sequence over the control lines.
+	 */
+	gpio_pin_configure_dt(&boot_gpio, GPIO_OUTPUT_INACTIVE);
+	gpio_pin_configure_dt(&reset_gpio, GPIO_OUTPUT_INACTIVE);
+	return 0;
+}
+#endif /* reset lines */
 
 static void sample_msg_cb(struct usbd_context *const ctx, const struct usbd_msg *msg)
 {
@@ -54,11 +114,23 @@ static void sample_msg_cb(struct usbd_context *const ctx, const struct usbd_msg 
 			uart_bridge_settings_update(msg->dev, uart_bridges[i]);
 		}
 	}
+
+#ifdef HAS_RESET_LINES
+	if (msg->type == USBD_MSG_CDC_ACM_CONTROL_LINE_STATE) {
+		reset_lines_update(msg->dev);
+	}
+#endif
 }
 
 int main(void)
 {
 	int err;
+
+#ifdef HAS_RESET_LINES
+	if (reset_lines_init()) {
+		return -ENODEV;
+	}
+#endif
 
 	sample_usbd = sample_usbd_init_device(sample_msg_cb);
 	if (sample_usbd == NULL) {

--- a/samples/subsys/usb/cdc_acm_bridge/tests.yaml
+++ b/samples/subsys/usb/cdc_acm_bridge/tests.yaml
@@ -10,3 +10,9 @@ tests:
     build_only: true
     platform_allow:
       - rpi_pico
+  sample.usb.cdc-acm-bridge.reset_lines:
+    tags: usb
+    build_only: true
+    platform_allow:
+      - nucleo_u575zi_q
+      - arduino_portenta_c33


### PR DESCRIPTION
Many WiFi coprocessors are flashed over a UART ROM bootloader that a vendor PC tool enters by toggling the serial DTR/RTS lines as control signals (BOOT_EN, RESET, ...) wired to the coprocessor. The host microcontroller needs custom firmware to bridge the USB serial port to the coprocessor's UART and to drive those control signals.

Zephyr's `cdc_acm_bridge` sample already provides a transparent USB-CDC <-> UART bridge (via the `zephyr,uart-bridge` driver), which is exactly what's needed here, but it has no control signals.

This PR adds DT-driven control signals to the `cdc_acm_bridge` sample, to enable flashing WiFi coprocessor firmware with Zephyr. A board overlay declares `boot-gpios` and `reset-gpios` under the `/zephyr,user` node; the bridge then drives boot from DTR and reset from RTS, with polarity taken from each `GPIO_ACTIVE_*` flag. No new binding and no per-target code.

Two use cases already exist in the tree:

1. The ESP32-C3 on the Portenta C33, currently flashed with an old Arduino serial-passthrough sketch and esptool.
2. The ST67W611M1 (Qualcomm) module, currently flashed with vendor scripts and the QConn PC tool.

With this feature, cdc_acm_bridge can upload firmware to both coprocessors through the host microcontroller.

## Testing
ESP32-C3 on Portenta C33, flashed with esptool through the bridge:
```bash
esptool.py --chip esp32c3 -p /dev/ttyACM0 -b 230400 \
  --before=default_reset --after=hard_reset write_flash 0x0 \
  portenta_c33-v0.0.5.bin
...
Wrote 989184 bytes at 0x00000000 in 54.3 seconds...
Hash of data verified.
Leaving...
Hard resetting via RTS pin...
```

ST67W611M1 on NUCLEO-U575ZI-Q + X-NUCLEO-67W61M1, flashed with ST's QConn
tool through the bridge:
```bash
QConn_Flash_Cmd-macos --port /dev/tty.usbmodem11201 --baudrate 500000 \
  --config NCP_Binaries/mission_t02_flash_prog_cfg.ini \
  --efuse=NCP_Binaries/efusedata.bin
[19:50:48.885] - Address=0x10000
[19:50:48.885] - Size=1785856
[19:50:48.885] - Program Start
[19:50:49.029] - com speed: 500000
[19:50:49.029] - ========= Interface is uart =========
...
[19:51:41.840] - Finished
[19:51:41.840] - All time cost(ms): 22924.223876953125
[19:51:41.946] - [All Success]
```
Note the module UART only flashed reliably at 500 kbaud here. 2Mbaud and 1Mbaud don't work reliabliy, I guess because it's connected to LPUART.

## Alternatives

I first considered adding a separate sample (e.g. a dedicated "coprocessor flasher") rather than touching cdc_acm_bridge, and went back and forth on it.

Extending cdc_acm_bridge (this PR):
The feature is a small and optional (entirely DT-gated). The same code plus two GPIOs that follow DTR/RTS, so No duplicated bridge logic to keep in sync.  However, it widens the sample's scope a little.

A separate sample instead:
Keeps `cdc_acm_bridge` purely a transparent bridge, and a "flasher" sample is arguably more discoverable by name. However, it would duplicate almost all of `cdc_acm_bridge` sample, just to add two GPIOs.

I leaned toward extending because changes to existing bridge is so small and cleanly optional. But I'm happy to split it out into a dedicated sample instead if maintainers would prefer that separation, just let me know.