### PR TITLE
Sysbuild: application cmake preset selection

### DIFF
--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -942,7 +942,7 @@ Running sysbuild with preset.
 
       .. code-block:: shell
 
-         APP_DIR=samples/hello_world cmake -Bbuild -GNinja -DBOARD=reel_board share/sysbuild
+         APP_DIR=samples/hello_world cmake -Bbuild -GNinja -DBOARD=reel_board --preset=release share/sysbuild
          ninja -Cbuild
 
       When using CMake presets with sysbuild then ``APP_DIR`` must be set in environment in order

--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -937,7 +937,28 @@ Example snippet sysbuild preset file:
 
 The application preset file is located in the application's source folder ``<application>/CMakePresets.json``
 and is only used for the build process of the application itself. This is the CMake default behaviour.
-Selecting a preset for a specific application is currently not possible `#111494 <https://github.com/zephyrproject-rtos/zephyr/issues/111494>`_.
+
+Selecting presets
+=================
+
+When using sysbuild with CMake presets, the preset selection is done at the sysbuild level.
+This means that the preset selection you pass on the commandline is only applied to the high-level sysbuild process.
+
+To select a preset for the image build process, you can use the ``CMAKE_PRESET`` variable.
+This will be applied to all builds of all images in the sysbuild project.
+To select a preset for a specific image, you can use name spacing as described in :ref:`sysbuild_cmake_namespace`.
+
+A good place to set the preset selection for a specific image is in the sysbuild preset file, as described above.
+Tip: By defining the selection in a (high level) preset you can define combinations for specific scenarios.
+
+Example snippet selecting a preset for a specific domain:
+
+.. code-block:: json
+
+   "cacheVariables": {
+         "<domain>_CMAKE_PRESET": "PresetName",
+         "<domain2>_CMAKE_PRESET": "PresetName2"
+   },
 
 Running sysbuild with a preset selection
 ========================================

--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -915,17 +915,39 @@ Sysbuild but not all preset macros will work as expected.
 
    Using CMake presets with sysbuild requires CMake version 3.27 or higher.
 
-As described in :ref:`sysbuild` then sysbuild is a higher-level build system which means that when
-CMake presets are used together with sysbuild, then the preset is consumed and processed by sysbuild
-itself and result is passed to the application.
+As described in :ref:`sysbuild` sysbuild is a higher-level build system overseeing
+the build of multiple applications. This means for the build process two preset files apply:
+one for the high level sysbuild CMake process and one for the individual application build process.
 
-Running sysbuild with preset.
+The high level sysbuild preset file is located in the application's sysbuild
+configuration folder ``<application>/sysbuild/CMakePresets.json``. See :ref:`sysbuild_application_configuration`.
+You can set variables that apply to sysbuild itself and to all images that are part of the sysbuild project.
+Or use domain specific variables to set variables for a specific image, see :ref:`sysbuild_cmake_namespace`
+
+Example snippet sysbuild preset file:
+
+.. code-block:: json
+
+   "cacheVariables": {
+      "CMAKE_MESSAGE_LOG_LEVEL": "STATUS",
+      "BOARD": "Board name of project",
+      "BOARD_QUALIFIERS": "Qualifier for all applications in the sysbuild project",
+      "<domain>_BOARD_QUALIFIERS": "Board qualifier for a specific domain"
+   }
+
+The application preset file is located in the application's source folder ``<application>/CMakePresets.json``
+and is only used for the build process of the application itself. This is the CMake default behaviour.
+Selecting a preset for a specific application is currently not possible `#111494 <https://github.com/zephyrproject-rtos/zephyr/issues/111494>`_.
+
+Running sysbuild with a preset selection
+========================================
+
+Here is an example of how to run sysbuild with the ``release`` preset:
 
 .. tabs::
 
    .. group-tab:: ``west build``
 
-      Here is an example where preset ``release`` should be used.
       For details, see :ref:`west-multi-domain-builds` in the ``west build documentation``.
 
       .. zephyr-app-commands::
@@ -938,15 +960,13 @@ Running sysbuild with preset.
 
    .. group-tab:: ``cmake``
 
-      Here is an example using CMake and Ninja.
-
       .. code-block:: shell
 
          APP_DIR=samples/hello_world cmake -Bbuild -GNinja -DBOARD=reel_board --preset=release share/sysbuild
          ninja -Cbuild
 
-      When using CMake presets with sysbuild then ``APP_DIR`` must be set in environment in order
-      for Sysbuild CMake to be able to include the ``CMakePresets.json`` from the main Zephyr
+      When using CMake presets with sysbuild, ``APP_DIR`` must be set as an environment variable
+      in order for sysbuild's CMake process to be able to include the ``CMakePresets.json`` from the
       application's source directory.
 
 .. note::

--- a/share/sysbuild/CMakePresets.json
+++ b/share/sysbuild/CMakePresets.json
@@ -6,6 +6,6 @@
     "patch": 0
   },
   "include": [
-    "$penv{APP_DIR}/CMakePresets.json"
+    "$penv{APP_DIR}/sysbuild/CMakePresets.json"
   ]
 }

--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -345,6 +345,17 @@ function(ExternalZephyrProject_Add)
     endif()
   endforeach()
 
+  # Pass selected CMake preset to CMake commandline argument
+  if(DEFINED CACHE{${ZBUILD_APPLICATION}_CMAKE_PRESET})
+    list(APPEND shared_cmake_vars_argument
+         "--preset=$CACHE{${ZBUILD_APPLICATION}_CMAKE_PRESET}"
+    )
+  elseif(DEFINED CACHE{CMAKE_PRESET})
+    list(APPEND shared_cmake_vars_argument
+         "--preset=$CACHE{CMAKE_PRESET}"
+    )
+  endif()
+
   set(list_separator ",")
   set(image_extra_kconfig_targets "-DEXTRA_KCONFIG_TARGETS=$CACHE{EXTRA_KCONFIG_TARGETS}")
   string(REPLACE ";" "${list_separator}" image_extra_kconfig_targets "${image_extra_kconfig_targets}")
@@ -544,6 +555,17 @@ function(ExternalZephyrVariantProject_Add)
       )
     endif()
   endforeach()
+
+  # Pass selected CMake preset to CMake commandline argument
+  if(DEFINED CACHE{${ZBUILD_APPLICATION}_CMAKE_PRESET})
+    list(APPEND shared_cmake_vars_argument
+         "--preset=$CACHE{${ZBUILD_APPLICATION}_CMAKE_PRESET}"
+    )
+  elseif(DEFINED CACHE{CMAKE_PRESET})
+    list(APPEND shared_cmake_vars_argument
+         "--preset=$CACHE{CMAKE_PRESET}"
+    )
+  endif()
 
   # Add the variant image CMake module path to replace the normal Zephyr module path
   list(APPEND shared_cmake_vars_argument


### PR DESCRIPTION
**Introduction**
This PR implements/fixes https://github.com/zephyrproject-rtos/zephyr/issues/111494

**Proposed change**
It adds a `CMAKE_PRESET` variable to sysbuild to select a preset name for the image build process.
The variable can be name-spaced to select a preset for an individual application.

For preset selection the name must be passed on the CMake command-line when starting an image build process. 
`--preset=<preset name to use>`
If the  `CMAKE_PRESET` variable is set, this CLI option will be added to the CMake invocation with the set value.

**Implementation notes**
- The name  `CMAKE_PRESET`  was chosen by me, it can be any other name.
- I re-used the existing `shared_cmake_vars_argument` variable to add the commandline parameter, as the functionality of that is identical to my proposed change, apart from adding `--preset` instead of `-D` I can of course split it to a separate variable.

**Documentation update**
- Described the new variable and its usage.
- Removed the previously noted limitation