### PR TITLE
drivers: regulator: fake: Add get_voltage custom fake

### DIFF
--- a/drivers/regulator/regulator_fake.c
+++ b/drivers/regulator/regulator_fake.c
@@ -50,6 +50,15 @@ DEFINE_FAKE_VALUE_FUNC(int, regulator_fake_get_active_discharge, const struct de
 DEFINE_FAKE_VALUE_FUNC(int, regulator_fake_get_error_flags,
 		       const struct device *, regulator_error_flags_t *);
 
+static int regulator_fake_get_voltage_delegate(const struct device *dev, int32_t *volt_uv)
+{
+	ARG_UNUSED(dev);
+
+	*volt_uv = 1e6; /* 1V */
+
+	return 0;
+};
+
 static DEVICE_API(regulator, api) = {
 	.enable = regulator_fake_enable,
 	.disable = regulator_fake_disable,
@@ -71,6 +80,8 @@ static DEVICE_API(regulator, api) = {
 static int regulator_fake_init(const struct device *dev)
 {
 	const struct regulator_fake_config *config = dev->config;
+
+	regulator_fake_get_voltage_fake.custom_fake = regulator_fake_get_voltage_delegate;
 
 	regulator_common_data_init(dev);
 


### PR DESCRIPTION
regulator_common_init() calls the .get_voltage() API. So instead of not doing anything in the fake (not updating the voltage) and therefore having regulator_common_init() continue with a random value, let's update it to a relatively sensible constant (1V).

You can see the issue by running the regulator tests with valgrind:
`twister -p native_sim  --enable-valgrind   -T tests/drivers/regulator/`