### PR TITLE
tests: lib: cmsis_dsp: Add missing free()

### DIFF
--- a/tests/lib/cmsis_dsp/bayes/src/f32.c
+++ b/tests/lib/cmsis_dsp/bayes/src/f32.c
@@ -81,4 +81,5 @@ ZTEST(bayes_f32, test_gaussian_naive_bayes_predict_f32)
 	/* Free output buffers */
 	free(output_probs_buf);
 	free(output_preds_buf);
+	free(temp);
 }


### PR DESCRIPTION
Avoid a memory leak in the test by adding a missing free() (malloc in line 55)