### PR TITLE
[Backport v3.7-branch] net: sockets: Store async socket error in net_context

### DIFF
--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -273,6 +273,12 @@ __net_socket struct net_context {
 	/** BSD socket private data */
 	void *socket_data;
 
+	/** Pending socket error (positive errno) reported asynchronously by
+	 *  the network stack. Valid only while the SOCK_ERROR flag is set;
+	 *  consumed via SO_ERROR or by the next blocking socket call.
+	 */
+	int sock_error;
+
 	/** Per-socket packet or connection queues */
 	union {
 		struct k_fifo recv_q;

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -277,8 +277,7 @@ int zsock_close_ctx(struct net_context *ctx)
 		(void)net_context_recv(ctx, NULL, K_NO_WAIT, NULL);
 	}
 
-	ctx->user_data = INT_TO_POINTER(EINTR);
-	sock_set_error(ctx);
+	sock_set_error(ctx, EINTR);
 
 	zsock_flush_queue(ctx);
 
@@ -416,8 +415,7 @@ static void zsock_received_cb(struct net_context *ctx,
 		user_data);
 
 	if (status < 0) {
-		ctx->user_data = INT_TO_POINTER(-status);
-		sock_set_error(ctx);
+		sock_set_error(ctx, -status);
 	}
 
 	/* if pkt is NULL, EOF */
@@ -524,8 +522,7 @@ static inline int z_vrfy_zsock_bind(int sock, const struct sockaddr *addr,
 static void zsock_connected_cb(struct net_context *ctx, int status, void *user_data)
 {
 	if (status < 0) {
-		ctx->user_data = INT_TO_POINTER(-status);
-		sock_set_error(ctx);
+		sock_set_error(ctx, -status);
 	}
 }
 
@@ -545,7 +542,7 @@ int zsock_connect_ctx(struct net_context *ctx, const struct sockaddr *addr,
 		return 0;
 	} else if (net_context_get_state(ctx) == NET_CONTEXT_CONNECTING) {
 		if (sock_is_error(ctx)) {
-			SET_ERRNO(-POINTER_TO_INT(ctx->user_data));
+			SET_ERRNO(sock_get_error(ctx));
 		} else {
 			SET_ERRNO(-EALREADY);
 		}
@@ -1332,7 +1329,7 @@ int zsock_wait_data(struct net_context *ctx, k_timeout_t *timeout)
 		}
 
 		if (sock_is_error(ctx)) {
-			return -POINTER_TO_INT(ctx->user_data);
+			return -sock_get_error(ctx);
 		}
 	}
 
@@ -1765,7 +1762,7 @@ static ssize_t zsock_recv_stream_timed(struct net_context *ctx, struct msghdr *m
 	for (end = sys_timepoint_calc(timeout); max_len > 0; timeout = sys_timepoint_timeout(end)) {
 
 		if (sock_is_error(ctx)) {
-			return -POINTER_TO_INT(ctx->user_data);
+			return -sock_get_error(ctx);
 		}
 
 		if (sock_is_eof(ctx)) {
@@ -2664,7 +2661,7 @@ int zsock_getsockopt_ctx(struct net_context *ctx, int level, int optname,
 				return -1;
 			}
 
-			*(int *)optval = POINTER_TO_INT(ctx->user_data);
+			*(int *)optval = sock_get_error(ctx);
 
 			return 0;
 		}

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -51,7 +51,25 @@ static inline bool net_socket_is_tls(void *obj)
 #define sock_set_eof(ctx) sock_set_flag(ctx, SOCK_EOF, SOCK_EOF)
 #define sock_is_nonblock(ctx) sock_get_flag(ctx, SOCK_NONBLOCK)
 #define sock_is_error(ctx) sock_get_flag(ctx, SOCK_ERROR)
-#define sock_set_error(ctx) sock_set_flag(ctx, SOCK_ERROR, SOCK_ERROR)
+
+/* Record a pending socket error (positive errno) and flag the context.
+ * The value is stored in a dedicated net_context field rather than being
+ * stashed in user_data, which the stack also uses to carry the parent
+ * context pointer for accept callbacks.
+ */
+static inline void sock_set_error(struct net_context *ctx, int err)
+{
+	ctx->sock_error = err;
+	sock_set_flag(ctx, SOCK_ERROR, SOCK_ERROR);
+}
+
+/* Retrieve the pending socket error (positive errno) previously recorded
+ * by sock_set_error(). Only meaningful while sock_is_error() is true.
+ */
+static inline int sock_get_error(struct net_context *ctx)
+{
+	return ctx->sock_error;
+}
 
 struct socket_op_vtable {
 	struct fd_op_vtable fd_vtable;


### PR DESCRIPTION
This is a backport of https://github.com/zephyrproject-rtos/zephyr/pull/114694 to v3.7 branch

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/114678