### PR TITLE
PSOC4: Shared WDT between application watchdog and Power management Deep-sleep companion 

### DIFF
--- a/drivers/watchdog/wdt_infineon.c
+++ b/drivers/watchdog/wdt_infineon.c
@@ -312,12 +312,7 @@ __STATIC_INLINE uint32_t ifx_wdt_timeout_to_match(uint32_t timeout_ms, uint32_t 
 
 	uint32_t match_count;
 
-	match_count = (Cy_WDT_GetMatch() + dev_data->ilo_compensated_counts);
-
-	/* Ensure match count is within valid range for 16-bit WDT */
-	if (match_count > UINT16_MAX) {
-		match_count = UINT16_MAX;
-	}
+	match_count = (Cy_WDT_GetMatch() + dev_data->ilo_compensated_counts) & UINT16_MAX;
 
 	return match_count;
 #else

--- a/drivers/watchdog/wdt_infineon.c
+++ b/drivers/watchdog/wdt_infineon.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,6 +17,11 @@
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+
+#if defined(CY_IP_S8SRSSLT) && defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_HOOKS)
+#include "power.h"
+#endif
+
 LOG_MODULE_REGISTER(wdt_infineon, CONFIG_WDT_LOG_LEVEL);
 
 #define IFX_WDT_IS_IRQ_EN DT_NODE_HAS_PROP(DT_DRV_INST(0), interrupts)
@@ -224,10 +229,74 @@ struct ifx_cat1_wdt_data {
 	bool timeout_installed;
 #if defined(CY_IP_S8SRSSLT)
 	uint32_t ilo_compensated_counts;
+	uint64_t pm_budget_cycles;
+	bool pm_ds_locked;
 #endif
 };
 
 static struct ifx_cat1_wdt_data wdt_data;
+
+#if defined(CY_IP_S8SRSSLT)
+#define WDT_PM_BUDGET_FLOOR_CYCLES 32U
+
+static void ifx_wdt_pm_refresh(struct ifx_cat1_wdt_data *data)
+{
+	/*
+	 * This run from wdt_feed() in thread context, while lpm exit hook may touch this
+	 * same budget state form the idle, so handle it here with a lock.
+	 */
+	unsigned int key = irq_lock();
+
+	data->pm_budget_cycles = data->ilo_compensated_counts;
+#if defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_HOOKS)
+	ifx_wdt_pm_unlock_ds(&data->pm_ds_locked);
+#endif
+	irq_unlock(key);
+}
+
+bool ifx_wdt_pm_active(void)
+{
+	return wdt_data.wdt_initialized;
+}
+
+uint64_t ifx_wdt_pm_budget_cycles(void)
+{
+	return wdt_data.pm_budget_cycles;
+}
+
+void ifx_wdt_pm_resume(uint64_t slept_cycles)
+{
+	struct ifx_cat1_wdt_data *data = &wdt_data;
+
+	if (slept_cycles >= data->pm_budget_cycles) {
+		data->pm_budget_cycles = 0U;
+	} else {
+		data->pm_budget_cycles -= slept_cycles;
+	}
+
+	Cy_WDT_SetIgnoreBits(data->wdt_ignore_bits);
+	Cy_WDT_SetMatch((Cy_WDT_GetCount() + data->pm_budget_cycles) & UINT16_MAX);
+	Cy_WDT_ClearInterrupt();
+
+#ifdef IFX_WDT_IS_IRQ_EN
+	if (data->callback) {
+		Cy_WDT_UnmaskInterrupt();
+		irq_enable(DT_INST_IRQN(0));
+	} else {
+		Cy_WDT_MaskInterrupt();
+		irq_disable(DT_INST_IRQN(0));
+	}
+#else
+	Cy_WDT_MaskInterrupt();
+#endif
+
+	if (data->pm_budget_cycles < WDT_PM_BUDGET_FLOOR_CYCLES) {
+#if defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_HOOKS)
+		ifx_wdt_pm_lock_ds(&data->pm_ds_locked);
+#endif
+	}
+}
+#endif /* CY_IP_S8SRSSLT */
 
 #if !defined(CY_IP_S8SRSSLT)
 #define IFX_DETERMINE_MATCH_BITS(bits)      ((IFX_WDT_MAX_IGNORE_BITS) - (bits))
@@ -348,6 +417,9 @@ static int ifx_cat1_wdt_setup(const struct device *dev, uint8_t options)
 
 	Cy_WDT_SetIgnoreBits(dev_data->wdt_ignore_bits);
 	Cy_WDT_SetMatch(dev_data->ilo_compensated_counts);
+
+	dev_data->pm_budget_cycles = dev_data->ilo_compensated_counts;
+	dev_data->pm_ds_locked = false;
 #elif defined(CY_IP_MXS40SRSS) && (CY_IP_MXS40SRSS_VERSION >= 2)
 	Cy_WDT_SetUpperLimit(ifx_wdt_timeout_to_match(dev_data->wdt_initial_timeout_ms,
 						      dev_data->wdt_ignore_bits, dev_data));
@@ -409,6 +481,10 @@ static int ifx_cat1_wdt_disable(const struct device *dev)
 #if defined(CY_IP_S8SRSSLT)
 	Cy_SysClk_IloStopMeasurement();
 	dev_data->ilo_compensated_counts = 0;
+#if defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_HOOKS)
+	ifx_wdt_pm_unlock_ds(&dev_data->pm_ds_locked);
+#endif
+	dev_data->pm_budget_cycles = 0U;
 #endif
 
 	ifx_wdt_unlock();
@@ -468,6 +544,10 @@ static int ifx_cat1_wdt_feed(const struct device *dev, int channel_id)
 
 	ifx_wdt_lock();
 
+#if defined(CY_IP_S8SRSSLT)
+	ifx_wdt_pm_refresh(data);
+#endif
+
 	return 0;
 }
 
@@ -486,6 +566,8 @@ static int ifx_cat1_wdt_init(const struct device *dev)
 
 #if defined(CY_IP_S8SRSSLT)
 	data->ilo_compensated_counts = 0;
+	data->pm_budget_cycles = 0U;
+	data->pm_ds_locked = false;
 #endif
 
 	return 0;

--- a/soc/infineon/psoc4/psoc4100tp/Kconfig.defconfig
+++ b/soc/infineon/psoc4/psoc4100tp/Kconfig.defconfig
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
-# or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+# SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+# SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -14,7 +14,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 if PM
 
 choice SYSTEM_TIMER_LPM_COMPANION
-	default SYSTEM_TIMER_LPM_COMPANION_HOOKS if !WDT_INFINEON_CAT1
+	default SYSTEM_TIMER_LPM_COMPANION_HOOKS
 endchoice
 
 endif # PM

--- a/soc/infineon/psoc4/psoc4100tp/power.c
+++ b/soc/infineon/psoc4/psoc4100tp/power.c
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: <text>Copyright (c) 2026 Infineon Technologies AG,
- * or an affiliate of Infineon Technologies AG. All rights reserved.</text>
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,6 +17,8 @@
 #include <cy_wdt.h>
 
 #include <soc.h>
+
+#include "power.h"
 
 LOG_MODULE_REGISTER(soc_power, CONFIG_SOC_LOG_LEVEL);
 
@@ -86,11 +88,13 @@ static void wdt_lpm_calibrate_ilo(void)
 	}
 }
 
+#if !defined(CONFIG_WDT_INFINEON_CAT1)
 static void wdt_lpm_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 	Cy_WDT_ClearInterrupt();
 }
+#endif
 
 static void wdt_lpm_arm_window(uint32_t from_count, uint64_t remaining_cycles)
 {
@@ -111,9 +115,21 @@ static void wdt_lpm_arm_window(uint32_t from_count, uint64_t remaining_cycles)
 void z_sys_clock_lpm_enter(uint64_t max_lpm_time_us)
 {
 	wdt_target_cycles = (max_lpm_time_us * (uint64_t)ilo_freq_hz) / USEC_PER_SEC;
+
 	if (wdt_target_cycles < MIN_WDT_CYCLES) {
 		wdt_target_cycles = MIN_WDT_CYCLES;
 	}
+
+#if defined(CONFIG_WDT_INFINEON_CAT1)
+	if (ifx_wdt_pm_active()) {
+		uint64_t budget_cycles = ifx_wdt_pm_budget_cycles();
+
+		if (wdt_target_cycles > budget_cycles) {
+			wdt_target_cycles = budget_cycles;
+		}
+	}
+#endif
+
 	wdt_elapsed_cycles = 0U;
 
 	Cy_WDT_ClearInterrupt();
@@ -161,16 +177,22 @@ uint64_t z_sys_clock_lpm_exit(void)
 {
 	uint32_t end_count;
 	uint64_t total_cycles;
+	bool restored = false;
 
 	end_count = Cy_WDT_GetCount();
 
-	Cy_WDT_MaskInterrupt();
-	Cy_WDT_ClearInterrupt();
-
-	irq_disable(WDT_IRQ_NUM);
-	NVIC_ClearPendingIRQ(WDT_IRQ_NUM);
-
 	total_cycles = wdt_elapsed_cycles + ((end_count - wdt_start_count) & UINT16_MAX);
+
+#if defined(CONFIG_WDT_INFINEON_CAT1)
+	if (ifx_wdt_pm_active()) {
+		ifx_wdt_pm_resume(total_cycles);
+		restored = true;
+	}
+#endif
+
+	if (!restored) {
+		irq_disable(WDT_IRQ_NUM);
+	}
 
 	return (total_cycles * USEC_PER_SEC) / ilo_freq_hz;
 }
@@ -200,6 +222,18 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 				break;
 			}
 		} while (wdt_lpm_continue());
+
+#if defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_HOOKS)
+		/*
+		 * Clear it here, before pm_state_exit_post_ops re-enables interrupts;
+		 * otherwise in shared mode, WDT ISR would run and fire the application
+		 * any other timeout callback for what was only a wakeup.
+		 */
+		Cy_WDT_MaskInterrupt();
+		Cy_WDT_ClearInterrupt();
+		NVIC_ClearPendingIRQ(WDT_IRQ_NUM);
+#endif
+
 		SCB_SCR &= (uint32_t)~SCB_SCR_SLEEPDEEP_Msk;
 		break;
 	default:
@@ -221,7 +255,9 @@ int pm_init(void)
 #if defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_HOOKS)
 	wdt_lpm_calibrate_ilo();
 
+#if !defined(CONFIG_WDT_INFINEON_CAT1)
 	IRQ_CONNECT(WDT_IRQ_NUM, WDT_IRQ_PRIO, wdt_lpm_isr, NULL, 0);
+#endif
 #else
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
 #endif

--- a/soc/infineon/psoc4/psoc4100tp/power.h
+++ b/soc/infineon/psoc4/psoc4100tp/power.h
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Infineon Technologies AG,
+ * SPDX-FileCopyrightText: or an affiliate of Infineon Technologies AG. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief Infineon PSoC 4100T Plus power management interface.
+ */
+
+#ifndef ZEPHYR_SOC_INFINEON_PSOC4_PSOC4100TP_POWER_H_
+#define ZEPHYR_SOC_INFINEON_PSOC4_PSOC4100TP_POWER_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/pm/policy.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(CONFIG_WDT_INFINEON_CAT1)
+/**
+ * @brief Check whether the WDT is being used as the LPM companion.
+ *
+ * @return true if the watchdog has been set up and is acting as the Deep
+ *         Sleep wakeup source, false otherwise.
+ */
+bool ifx_wdt_pm_active(void);
+
+/**
+ * @brief Get the WDT's remaining feed budget, in WDT (ILO) cycles.
+ *
+ * Used by the LPM companion hooks to clamp the Deep Sleep window so the
+ * system wakes before the application's configured watchdog timeout would
+ * elapse.
+ *
+ * @return Remaining budget, in ILO cycles, before the watchdog would expire.
+ */
+uint64_t ifx_wdt_pm_budget_cycles(void);
+
+/**
+ * @brief Resume the WDT after a Deep Sleep LPM companion cycle.
+ *
+ * Re-arms the watchdog match window and IRQ state, and consumes
+ * @p slept_cycles from the remaining feed budget.
+ *
+ * @param slept_cycles Number of WDT (ILO) cycles spent asleep.
+ */
+void ifx_wdt_pm_resume(uint64_t slept_cycles);
+#endif /* CONFIG_WDT_INFINEON_CAT1 */
+
+#if defined(CONFIG_SYSTEM_TIMER_LPM_COMPANION_HOOKS)
+/**
+ * @brief Block Deep Sleep entry until the matching unlock call.
+ *
+ * Requests a Zephyr PM-policy lock on PM_STATE_SUSPEND_TO_IDLE so the idle
+ * thread cannot let the system enter Deep Sleep again, used once the WDT's
+ * remaining feed budget is too low to safely cover another Deep Sleep cycle.
+ *
+ * The lock is guarded by @p ds_locked so repeated calls before a matching
+ * ifx_wdt_pm_unlock_ds() are a no-op and the underlying policy lock is only
+ * ever taken once per outstanding lock/unlock pair.
+ *
+ * @param ds_locked Pointer to the caller-owned lock state flag.
+ */
+static inline void ifx_wdt_pm_lock_ds(bool *ds_locked)
+{
+	if (!*ds_locked) {
+		pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+		*ds_locked = true;
+	}
+}
+
+/**
+ * @brief Release the lock taken by ifx_wdt_pm_lock_ds().
+ *
+ * @param ds_locked Pointer to the caller-owned lock state flag.
+ */
+static inline void ifx_wdt_pm_unlock_ds(bool *ds_locked)
+{
+	if (*ds_locked) {
+		pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
+		*ds_locked = false;
+	}
+}
+#endif /* CONFIG_SYSTEM_TIMER_LPM_COMPANION_HOOKS */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_SOC_INFINEON_PSOC4_PSOC4100TP_POWER_H_ */


### PR DESCRIPTION
- Watchdog as wakeup source for Deep-sleep.
- To avoid the conflict between the application WDT and WDT driven by PM used the shared WDT.