### PR TITLE
tests rtio_i2c: Initialize stack buffers to be printed

### DIFF
--- a/tests/subsys/rtio/rtio_i2c/src/main.cpp
+++ b/tests/subsys/rtio/rtio_i2c/src/main.cpp
@@ -154,7 +154,7 @@ ZTEST(rtio_i2c, test_fallback_submit_rx)
 
 ZTEST(rtio_i2c, test_fallback_transaction_error)
 {
-	uint8_t buffer[3];
+	uint8_t buffer[3] = {0x01, 0x02, 0x03};
 	struct rtio_sqe *phase1 = rtio_sqe_acquire(&test_rtio_ctx);
 	struct rtio_sqe *phase2 = rtio_sqe_acquire(&test_rtio_ctx);
 
@@ -186,7 +186,7 @@ ZTEST(rtio_i2c, test_fallback_transaction_error)
 
 ZTEST(rtio_i2c, test_fallback_transaction)
 {
-	uint8_t buffer[3];
+	uint8_t buffer[3] = {0x01, 0x02, 0x03};
 	struct rtio_sqe *phase1 = rtio_sqe_acquire(&test_rtio_ctx);
 	struct rtio_sqe *phase2 = rtio_sqe_acquire(&test_rtio_ctx);
 


### PR DESCRIPTION
These buffers will eventually be logged/printed by i2c_dump_msgs_rw(). Let's initialize them to anything, so we do not print garbage stack content.
Printing garbage is not much of a problem in itself, but it trips valgrind, and it is easy to fix.

`twister -p native_sim  --enable-valgrind   -T tests/subsys/rtio/rtio_i2c/`