### PR TITLE
drivers: rtc: sam0: Fix int32 overflow in get_calibration

### DIFF
--- a/drivers/rtc/rtc_sam0.c
+++ b/drivers/rtc/rtc_sam0.c
@@ -485,7 +485,7 @@ static int rtc_sam0_get_calibration(const struct device *dev, int32_t *calibrati
 	if (correction == 0) {
 		*calibration = 0;
 	} else {
-		*calibration = (correction * 1000000000) / cfg->cal_constant;
+		*calibration = ((int64_t)correction * 1000000000) / cfg->cal_constant;
 	}
 
 	if (regs->FREQCORR.bit.SIGN) {


### PR DESCRIPTION
The ppb conversion in rtc_sam0_get_calibration() multiplies the FREQCORR correction value by 1000000000 in a 32-bit expression. Any correction value of 3 or more overflows int32_t (3e9 > INT32_MAX), so the reported calibration is garbage for most of the register range (VALUE goes up to 127).

Do the multiplication in 64 bits, matching the equivalent conversion in the Microchip G1 RTC driver. The result fits comfortably in int32_t: with the smallest in-tree cal-constant (983040), the maximum magnitude is 127 * 1e9 / 983040, about 129186 ppb.

Built tests/drivers/rtc/rtc_api for samc21n_xpro with CONFIG_RTC_CALIBRATION=y.