### PR TITLE
net: context: Validate bind address against the bound interface 

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2514,6 +2514,22 @@ bool net_if_ipv4_addr_onlink(struct net_if **iface, const struct net_in_addr *ad
 struct net_if_addr *net_if_ipv4_addr_lookup(const struct net_in_addr *addr,
 					    struct net_if **iface);
 
+/** @cond INTERNAL_HIDDEN */
+struct net_if_addr *net_if_ipv4_addr_lookup_by_iface_raw(struct net_if *iface,
+							 const uint8_t *addr);
+/** @endcond */
+
+/**
+ * @brief Check if this IPv4 address belongs to this specific interfaces.
+ *
+ * @param iface Network interface
+ * @param addr IPv4 address
+ *
+ * @return Pointer to interface address, NULL if not found.
+ */
+struct net_if_addr *net_if_ipv4_addr_lookup_by_iface(struct net_if *iface,
+						     const struct net_in_addr *addr);
+
 /**
  * @brief Add a IPv4 address to an interface
  *

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -975,9 +975,14 @@ int net_context_bind(struct net_context *context, const struct net_sockaddr *add
 				}
 			}
 
-			ifaddr = net_if_ipv6_addr_lookup(
-					&addr6->sin6_addr,
-					iface == NULL ? &iface : NULL);
+			if (iface != NULL) {
+				ifaddr = net_if_ipv6_addr_lookup_by_iface(iface,
+									  &addr6->sin6_addr);
+			} else {
+				ifaddr = net_if_ipv6_addr_lookup(&addr6->sin6_addr,
+								 &iface);
+			}
+
 			if (!ifaddr) {
 				return -ENOENT;
 			}
@@ -1083,9 +1088,14 @@ int net_context_bind(struct net_context *context, const struct net_sockaddr *add
 
 			ptr = (struct net_in_addr *)net_ipv4_unspecified_address();
 		} else {
-			ifaddr = net_if_ipv4_addr_lookup(
-					&addr4->sin_addr,
-					iface == NULL ? &iface : NULL);
+			if (iface != NULL) {
+				ifaddr = net_if_ipv4_addr_lookup_by_iface(iface,
+									  &addr4->sin_addr);
+			} else {
+				ifaddr = net_if_ipv4_addr_lookup(&addr4->sin_addr,
+								 &iface);
+			}
+
 			if (!ifaddr) {
 				return -ENOENT;
 			}

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4428,6 +4428,44 @@ struct net_if_addr *net_if_ipv4_addr_lookup(const struct net_in_addr *addr,
 	return net_if_ipv4_addr_lookup_raw(addr->s4_addr, ret);
 }
 
+struct net_if_addr *net_if_ipv4_addr_lookup_by_iface_raw(struct net_if *iface,
+							 const uint8_t *addr)
+{
+	struct net_if_addr *ifaddr = NULL;
+	struct net_if_ipv4 *ipv4;
+
+	net_if_lock(iface);
+
+	ipv4 = iface->config.ip.ipv4;
+	if (ipv4 == NULL) {
+		goto out;
+	}
+
+	ARRAY_FOR_EACH(ipv4->unicast, i) {
+		if (!ipv4->unicast[i].ipv4.is_used ||
+		    ipv4->unicast[i].ipv4.address.family != NET_AF_INET) {
+			continue;
+		}
+
+		if (UNALIGNED_GET((uint32_t *)addr) ==
+		    ipv4->unicast[i].ipv4.address.in_addr.s_addr) {
+			ifaddr = &ipv4->unicast[i].ipv4;
+			goto out;
+		}
+	}
+
+out:
+	net_if_unlock(iface);
+
+	return ifaddr;
+}
+
+struct net_if_addr *net_if_ipv4_addr_lookup_by_iface(struct net_if *iface,
+						     const struct net_in_addr *addr)
+{
+	return net_if_ipv4_addr_lookup_by_iface_raw(iface, addr->s4_addr);
+}
+
 int z_impl_net_if_ipv4_addr_lookup_by_index(const struct net_in_addr *addr)
 {
 	struct net_if_addr *if_addr;

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -869,6 +869,24 @@ ZTEST(net_iface, test_v4_addr_add_rm)
 	v4_addr_rm();
 }
 
+ZTEST(net_iface, test_v4_addr_lookup_by_iface)
+{
+	struct net_if_addr *ifaddr;
+
+	ifaddr = net_if_ipv4_addr_lookup_by_iface(iface1, &my_ipv4_addr1);
+	zassert_not_null(ifaddr, "IPv4 address not found");
+	zassert_mem_equal(&ifaddr->address.in_addr, &my_ipv4_addr1,
+			  sizeof(struct net_in_addr),
+			  "Wrong IPv4 address returned");
+
+	ifaddr = net_if_ipv4_addr_lookup_by_iface(iface2, &my_ipv4_addr1);
+	zassert_is_null(ifaddr, "IPv4 address found from a wrong interface");
+
+	ifaddr = net_if_ipv4_addr_lookup_by_iface(iface1,
+						  &my_ipv4_addr_not_found);
+	zassert_is_null(ifaddr, "Unknown IPv4 address found");
+}
+
 #define MY_ADDR_V4_USER      { { { 10, 0, 0, 2 } } }
 #define UNKNOWN_ADDR_V4_USER { { { 5, 6, 7, 8 } } }
 

--- a/tests/net/socket/misc/src/main.c
+++ b/tests/net/socket/misc/src/main.c
@@ -386,6 +386,76 @@ void test_ipv6_so_bindtodevice(void)
 			     (struct net_sockaddr *)&bind_addr, sizeof(bind_addr));
 }
 
+/* A socket bound to a given interface can only be bound to an address that is
+ * assigned to that interface.
+ */
+static void test_so_bindtodevice_addr(int family, struct net_sockaddr *own_addr,
+				      struct net_sockaddr *other_addr,
+				      net_socklen_t addrlen)
+{
+	struct net_ifreq ifreq = { 0 };
+	int sock;
+	int ret;
+
+	sock = zsock_socket(family, NET_SOCK_DGRAM, NET_IPPROTO_UDP);
+	zassert_true(sock >= 0, "socket open failed");
+
+	strcpy(ifreq.ifr_name, DEV1_NAME);
+	ret = zsock_setsockopt(sock, ZSOCK_SOL_SOCKET, ZSOCK_SO_BINDTODEVICE,
+			       &ifreq, sizeof(ifreq));
+	zassert_equal(ret, 0, "SO_BINDTODEVICE failed, %d", errno);
+
+	ret = zsock_bind(sock, other_addr, addrlen);
+	zassert_equal(ret, -1, "bind to an address of another interface passed");
+	zassert_equal(errno, ENOENT, "bind failed with invalid errno, %d", errno);
+
+	ret = zsock_bind(sock, own_addr, addrlen);
+	zassert_equal(ret, 0, "bind failed, %d", errno);
+
+	ret = zsock_close(sock);
+	zassert_equal(ret, 0, "close failed, %d", errno);
+}
+
+void test_ipv4_so_bindtodevice_addr(void)
+{
+	struct net_sockaddr_in own_addr = {
+		.sin_family = NET_AF_INET,
+		.sin_port = net_htons(BIND_PORT),
+		.sin_addr = { { { 192, 0, 1, 1 } } },
+	};
+	struct net_sockaddr_in other_addr = {
+		.sin_family = NET_AF_INET,
+		.sin_port = net_htons(BIND_PORT),
+		.sin_addr = { { { 192, 0, 2, 2 } } },
+	};
+
+	test_so_bindtodevice_addr(NET_AF_INET,
+				  (struct net_sockaddr *)&own_addr,
+				  (struct net_sockaddr *)&other_addr,
+				  sizeof(own_addr));
+}
+
+void test_ipv6_so_bindtodevice_addr(void)
+{
+	struct net_sockaddr_in6 own_addr = {
+		.sin6_family = NET_AF_INET6,
+		.sin6_port = net_htons(BIND_PORT),
+		.sin6_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+					0, 0, 0, 0, 0, 0, 0, 0x1 } } },
+	};
+	struct net_sockaddr_in6 other_addr = {
+		.sin6_family = NET_AF_INET6,
+		.sin6_port = net_htons(BIND_PORT),
+		.sin6_addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+					0, 0, 0, 0, 0, 0, 0, 0x2 } } },
+	};
+
+	test_so_bindtodevice_addr(NET_AF_INET6,
+				  (struct net_sockaddr *)&own_addr,
+				  (struct net_sockaddr *)&other_addr,
+				  sizeof(own_addr));
+}
+
 #define ADDR_SIZE(family) ((family == NET_AF_INET) ? \
 			   sizeof(struct net_sockaddr_in) : \
 			   sizeof(struct net_sockaddr_in6))
@@ -900,12 +970,14 @@ static void *setup(void)
 ZTEST_USER(socket_misc_test_suite, test_ipv4)
 {
 	test_ipv4_so_bindtodevice();
+	test_ipv4_so_bindtodevice_addr();
 	test_ipv4_getpeername();
 }
 
 ZTEST_USER(socket_misc_test_suite, test_ipv6)
 {
 	test_ipv6_so_bindtodevice();
+	test_ipv6_so_bindtodevice_addr();
 	test_ipv6_getpeername();
 }
 


### PR DESCRIPTION
When a context was bound to a specific interface (SO_BINDTODEVICE), net_context_bind() still searched all interfaces for the requested local address, so a bind could succeed with an address owned by a different interface — leaving the socket transmitting with an off-subnet source address. 

Changes:
* net: if: add net_if_ipv4_addr_lookup_by_iface() and its _raw() variant, mirroring the existing IPv6 helpers.
* net: context: in net_context_bind(), restrict the unicast lookup to the bound interface for both IPv4 and IPv6; fall back to the all-interfaces lookup only when no interface is known yet.
* Tests: unit coverage for the new helper in tests/net/iface, and a SO_BINDTODEVICE regression test in tests/net/socket/misc for both families.