### PR TITLE
drivers: rtc: pcf8523: fix calibration offset encode/decode

### DIFF
--- a/drivers/rtc/rtc_pcf8523.c
+++ b/drivers/rtc/rtc_pcf8523.c
@@ -739,7 +739,7 @@ static int pcf8523_set_calibration(const struct device *dev, int32_t freq_ppb)
 static int pcf8523_get_calibration(const struct device *dev, int32_t *freq_ppb)
 {
 	int32_t period_ppb;
-	int8_t offset;
+	uint8_t offset;
 	int err;
 
 	err = pcf8523_read_reg8(dev, PCF8523_OFFSET, &offset);
@@ -747,8 +747,8 @@ static int pcf8523_get_calibration(const struct device *dev, int32_t *freq_ppb)
 		return err;
 	}
 
-	/* Clear mode bit and sign extend the offset */
-	period_ppb = (offset << 1U) >> 1U;
+	/* Clear the mode bit and sign extend the signed 7-bit offset field */
+	period_ppb = sign_extend(offset & PCF8523_OFFSET_MASK, 6);
 
 	period_ppb = period_ppb * PCF8523_OFFSET_PPB_PER_LSB;
 	*freq_ppb = period_ppb * -1;

--- a/drivers/rtc/rtc_pcf8523.c
+++ b/drivers/rtc/rtc_pcf8523.c
@@ -718,14 +718,14 @@ unlock:
 static int pcf8523_set_calibration(const struct device *dev, int32_t freq_ppb)
 {
 	int32_t period_ppb = freq_ppb * -1;
-	int8_t offset;
+	uint8_t offset;
 
 	if (period_ppb < PCF8523_OFFSET_PPB_MIN || period_ppb > PCF8523_OFFSET_PPB_MAX) {
 		LOG_WRN("calibration value (%d ppb) out of range", freq_ppb);
 		return -EINVAL;
 	}
 
-	offset = period_ppb / PCF8523_OFFSET_PPB_PER_LSB;
+	offset = (period_ppb / PCF8523_OFFSET_PPB_PER_LSB) & PCF8523_OFFSET_MASK;
 
 	if (IS_ENABLED(CONFIG_RTC_PCF8523_OFFSET_MODE_FAST)) {
 		offset |= PCF8523_OFFSET_MODE;


### PR DESCRIPTION
Two fixes for the PCF8523 offset register (0x0E) handling:

- **set**: the period offset was written unmasked, so the sign bit of a negative offset (i.e. every positive calibration request) landed in the MODE bit — with the default slow offset mode the device silently switched into fast mode, where the hardware applies a 4069 ppb step while the driver computed the value with 4340 ppb (~6.7% scale error and a different correction cadence). Now masked with the previously unused `PCF8523_OFFSET_MASK`.
- **get**: `(offset << 1U) >> 1U` was intended to clear the mode bit and sign extend the 7-bit field, but under C integer promotion it is a no-op, so the MODE bit acted as the sign bit. In fast mode a stored offset of +9 read back as -119 steps. Now masked and decoded with `sign_extend()`.

The two fixes belong together: with set() properly masking the field, the old decode would misread slow-mode negative offsets (stored -9 → +119).

These are conformance fixes against the existing `rtc.h` contract and don't depend on the outcome of #114938, where this driver is listed among the divergence examples.

Testing: build-only (`tests/drivers/build_all/rtc` with `CONFIG_RTC_CALIBRATION=y`, qemu_cortex_m3), based on register-level analysis of the PCF8523 data sheet. Hardware verification with `tests/drivers/rtc/rtc_api` is welcome — the in-tree `adafruit_data_logger` shield (e.g. on frdm_k64f) carries this chip.