### PR TITLE
drivers: usb: udc: stm32: fix bulk IN ZLP busy-flag race

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -686,16 +686,17 @@ static void handle_msg_data_in(struct udc_stm32_data *priv, uint8_t epnum)
 	const struct device *dev = priv->dev;
 	struct udc_ep_config *ep_cfg;
 	uint8_t ep = epnum | USB_EP_DIR_IN;
+	unsigned int lock_key;
 	struct net_buf *buf;
 	stm32_status_t status;
 
 	LOG_DBG("DataIn ep 0x%02x",  ep);
 
 	ep_cfg = udc_get_ep_cfg(dev, ep);
-	udc_ep_set_busy(ep_cfg, false);
 
 	buf = udc_buf_peek(ep_cfg);
 	if (unlikely(buf == NULL)) {
+		udc_ep_set_busy(ep_cfg, false);
 		return;
 	}
 
@@ -730,11 +731,21 @@ static void handle_msg_data_in(struct udc_stm32_data *priv, uint8_t epnum)
 	buf = udc_buf_get(ep_cfg);
 	udc_submit_ep_event(dev, buf, 0);
 
-	/* enqueue */
+	/*
+	 * Keep the busy-flag clear and the restart of the queue head atomic
+	 * against udc_stm32_ep_enqueue(), which runs under irq_lock in
+	 * another context.
+	 */
+	lock_key = irq_lock();
+
+	udc_ep_set_busy(ep_cfg, false);
+
 	buf = udc_buf_peek(ep_cfg);
 	if (buf != NULL) {
 		udc_stm32_tx(dev, ep_cfg, buf);
 	}
+
+	irq_unlock(lock_key);
 }
 
 void HAL_PCD_SetupStageCallback(stm32_pcd_handle_t *hpcd)


### PR DESCRIPTION
## Bug

A race condition in `drivers/usb/udc/udc_stm32.c` permanently wedges a bulk IN endpoint on STM32 OTG controllers.

Found on an STM32N6570-DK streaming UVC/H.264 (stream froze after ~2 s), but the bug should be generic to any
usbd-next class that enqueues IN transfers from a context that is not synchronized with USB completion events. Present
in the v4.4.0 release and in upstream `main` as of ae55454cc.

PoC: https://github.com/PepperoniPingu/UDC-STM32-ZLP-Race

### Root cause

The driver serializes hardware access per endpoint with a software busy flag. `udc_stm32_tx()` refuses to call `hal_udc_set_endpoint_transmit()` while it is set. The flag itself is undocumented, `udc_common.h` says only "Checks if the endpoint is busy", but the HAL supports one transfer at a time per endpoint and this flag is the only thing gating concurrent transmit calls.

`handle_msg_data_in()` runs on every IN stage completion. But it clears the flag unconditionally at function entry. Before it knows whether the transfer is actually finished. In most cases this works since the packet is actually completed. But it becomes a problem when sending the ZLP. The ZLP is a zero length packet that terminates a bulk transfer whose length is an exact multiple of the packet size. Without it the host keeps waiting for more data. The OTG core cannot know a terminator is needed. So the driver sends the ZLP manually as a second `hal_udc_set_endpoint_transmit()`. That second arming step creates a window when a concurrent thread will think packet transmission is done, while it is in fact not. So this concurrent thread can submit a packet through `udc_stm32_tx()` and not be blocked from arming the hardware again. After this I don't understand the exact workings except it freezes the endpoint.

## Fix

Clear busy only when the hardware is provably idle, i.e. keep the endpoint marked busy through the ZLP branch, and
through the control data stage continuation which follows the same pattern. The busy-flag clear and the restart of the
queue head are also made atomic against the irq_lock'd enqueue path.
