### PR TITLE
drivers: flash: stm32: Restore full access to bank 1 on dual core H7s

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -34,6 +34,7 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #define STM32H7_FLASH_OPT_TIMEOUT_MS 800
 
 #if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_nv_flash), bank2_flash_size)
+
 #define STM32H7_M4_FLASH_SIZE DT_PROP_OR(DT_INST(0, st_stm32_nv_flash), bank2_flash_size, 0)
 #ifdef CONFIG_CPU_CORTEX_M4
 #if STM32H7_M4_FLASH_SIZE == 0
@@ -44,9 +45,17 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #else
 #define REAL_FLASH_SIZE_KB (DT_REG_SIZE(DT_INST(0, st_stm32_nv_flash)) * 2)
 #endif
+
+#else /* DT_NODE_HAS_PROP(DT_INST(0, st_stm32_nv_flash), bank2_flash_size) */
+
+#if defined(CONFIG_STM32H7_DUAL_CORE)
+/* Dual core STM32H7x products feature two banks of the same size */
+#define REAL_FLASH_SIZE_KB (DT_REG_SIZE(DT_INST(0, st_stm32_nv_flash)) * 2)
 #else
 #define REAL_FLASH_SIZE_KB DT_REG_SIZE(DT_INST(0, st_stm32_nv_flash))
-#endif
+#endif /* CONFIG_STM32H7_DUAL_CORE */
+
+#endif /* DT_NODE_HAS_PROP(DT_INST(0, st_stm32_nv_flash), bank2_flash_size) */
 #define SECTOR_PER_BANK ((REAL_FLASH_SIZE_KB / FLASH_SECTOR_SIZE) / 2)
 #if defined(DUAL_BANK)
 #define STM32H7_SERIES_MAX_FLASH_KB KB(2048)

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -33,21 +33,6 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 /* No information in documentation about that. */
 #define STM32H7_FLASH_OPT_TIMEOUT_MS 800
 
-#if DT_NODE_HAS_PROP(DT_INST(0, st_stm32_nv_flash), bank2_flash_size)
-
-#define STM32H7_M4_FLASH_SIZE DT_PROP_OR(DT_INST(0, st_stm32_nv_flash), bank2_flash_size, 0)
-#ifdef CONFIG_CPU_CORTEX_M4
-#if STM32H7_M4_FLASH_SIZE == 0
-#error Flash driver on M4 requires the DT property bank2-flash-size
-#else
-#define REAL_FLASH_SIZE_KB (KB(STM32H7_M4_FLASH_SIZE * 2))
-#endif
-#else
-#define REAL_FLASH_SIZE_KB (DT_REG_SIZE(DT_INST(0, st_stm32_nv_flash)) * 2)
-#endif
-
-#else /* DT_NODE_HAS_PROP(DT_INST(0, st_stm32_nv_flash), bank2_flash_size) */
-
 #if defined(CONFIG_STM32H7_DUAL_CORE)
 /* Dual core STM32H7x products feature two banks of the same size */
 #define REAL_FLASH_SIZE_KB (DT_REG_SIZE(DT_INST(0, st_stm32_nv_flash)) * 2)
@@ -55,7 +40,6 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #define REAL_FLASH_SIZE_KB DT_REG_SIZE(DT_INST(0, st_stm32_nv_flash))
 #endif /* CONFIG_STM32H7_DUAL_CORE */
 
-#endif /* DT_NODE_HAS_PROP(DT_INST(0, st_stm32_nv_flash), bank2_flash_size) */
 #define SECTOR_PER_BANK ((REAL_FLASH_SIZE_KB / FLASH_SECTOR_SIZE) / 2)
 #if defined(DUAL_BANK)
 #define STM32H7_SERIES_MAX_FLASH_KB KB(2048)

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -26,6 +26,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_DOMAIN);
 
+BUILD_ASSERT(DT_NODE_EXISTS(DT_INST(0, st_stm32_nv_flash)), "st,stm32-nv-flash node missing");
+
 /* Let's wait for double the max erase time to be sure that the operation is
  * completed.
  */

--- a/dts/arm/st/h7/stm32h745Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h745Xi_m4.dtsi
@@ -20,7 +20,6 @@
 			flash1: flash@8100000 {
 				reg = <0x08100000 DT_SIZE_K(1024)>;
 				ranges = <0 0x8100000 DT_SIZE_K(1024)>;
-				bank2-flash-size = <1024>;
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h747Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h747Xi_m4.dtsi
@@ -20,7 +20,6 @@
 			flash1: flash@8100000 {
 				reg = <0x08100000 DT_SIZE_K(1024)>;
 				ranges = <0 0x8100000 DT_SIZE_K(1024)>;
-				bank2-flash-size = <1024>;
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h755Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h755Xi_m4.dtsi
@@ -20,7 +20,6 @@
 			flash1: flash@8100000 {
 				reg = <0x08100000 DT_SIZE_K(1024)>;
 				ranges = <0 0x8100000 DT_SIZE_K(1024)>;
-				bank2-flash-size = <1024>;
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h757Xi_m4.dtsi
+++ b/dts/arm/st/h7/stm32h757Xi_m4.dtsi
@@ -20,7 +20,6 @@
 			flash1: flash@8100000 {
 				reg = <0x08100000 DT_SIZE_K(1024)>;
 				ranges = <0 0x8100000 DT_SIZE_K(1024)>;
-				bank2-flash-size = <1024>;
 			};
 		};
 

--- a/dts/bindings/mtd/st,stm32-nv-flash.yaml
+++ b/dts/bindings/mtd/st,stm32-nv-flash.yaml
@@ -15,7 +15,8 @@ properties:
     required: true
   bank2-flash-size:
     type: int
+    deprecated: true
     description: |
-      Embedded flash memory bank 2 size in KBytes.
-      Used by CM4 CPU because it cannot access flash controller register to read size.
-      Provides a way to configure this size when the flash controller driver runs on CM4 CPU.
+      Deprecated. This property was used to obtain the sizes of flash banks on the Cortex-M4 of
+      dual core MCUs.  Said sizes are now derived from the size cell. It's safe to simply remove
+      this property.


### PR DESCRIPTION
This PR addresses a regression introduced in https://github.com/zephyrproject-rtos/zephyr/pull/88377 which renders sectors 4-7 of memory bank 1 on multicore STM32H7 MCUs inaccessible. 

More specifically, ever since 0e41b07309a893f1f5eafeede9bbeee237ccf8a4, the flash_smt32h7x driver assumes the size of the entire flash can be obtained by reading the size cell of the first node with compatible `st,stm32-nv-flash`. On dual core MCUs, said size cell holds the size of only one of the two banks. As a result, the driver treats the Cortex-M7 as having access to only 512 of its 1024KiB flash. The Cortex-M4 is not affected as it derives `REAL_FLASH_SIZE_KB` from the `bank2-flash-size`property.

The PR leverages the fact that the dual core STM32H7x MCUs supported by Zephyr, that is, STM32H747, STM32H757, STM32H745 and STM32H755, all come with two memory banks of the same size, allowing `REAL_FLASH_SIZE_KB` to be computed by multiplying the value of the size cell of a bank by 2. Furthermore, as said approach works just as well on the Cortex-M4 as it does on the Cortex-M7, the PR leverages it for both CPUs and deprecates the `bank2-flash-size` property.
