### PR TITLE
drivers: uart: mspm0: add fifo threshold properties

### DIFF
--- a/drivers/serial/uart_mspm0.c
+++ b/drivers/serial/uart_mspm0.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/clock_control/mspm0_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/dt-bindings/uart/mspm0_uart.h>
 #include <zephyr/irq.h>
 
 /* Driverlib includes */
@@ -25,6 +26,9 @@ struct uart_mspm0_config {
 	const struct pinctrl_dev_config *pinctrl;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	void (*irq_config_func)(const struct device *dev);
+	/* UART FIFO thresholds */
+	uint8_t rx_fifo_threshold;
+	uint8_t tx_fifo_threshold;
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 };
 
@@ -418,6 +422,23 @@ static void uart_mspm0_isr(const struct device *dev)
 }
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
+#ifdef CONFIG_UART_INTERRUPT_DRIVEN
+static const DL_UART_RX_FIFO_LEVEL uart_mspm0_rx_fifo_level[] = {
+	[MSPM0_UART_RX_FIFO_LEVEL_ONE_ENTRY] = DL_UART_RX_FIFO_LEVEL_ONE_ENTRY,
+	[MSPM0_UART_RX_FIFO_LEVEL_1_4_FULL] = DL_UART_RX_FIFO_LEVEL_1_4_FULL,
+	[MSPM0_UART_RX_FIFO_LEVEL_1_2_FULL] = DL_UART_RX_FIFO_LEVEL_1_2_FULL,
+	[MSPM0_UART_RX_FIFO_LEVEL_3_4_FULL] = DL_UART_RX_FIFO_LEVEL_3_4_FULL,
+	[MSPM0_UART_RX_FIFO_LEVEL_FULL] = DL_UART_RX_FIFO_LEVEL_FULL,
+};
+static const DL_UART_TX_FIFO_LEVEL uart_mspm0_tx_fifo_level[] = {
+	[MSPM0_UART_TX_FIFO_LEVEL_ONE_ENTRY] = DL_UART_TX_FIFO_LEVEL_ONE_ENTRY,
+	[MSPM0_UART_TX_FIFO_LEVEL_1_4_EMPTY] = DL_UART_TX_FIFO_LEVEL_1_4_EMPTY,
+	[MSPM0_UART_TX_FIFO_LEVEL_1_2_EMPTY] = DL_UART_TX_FIFO_LEVEL_1_2_EMPTY,
+	[MSPM0_UART_TX_FIFO_LEVEL_3_4_EMPTY] = DL_UART_TX_FIFO_LEVEL_3_4_EMPTY,
+	[MSPM0_UART_TX_FIFO_LEVEL_EMPTY] = DL_UART_TX_FIFO_LEVEL_EMPTY,
+};
+#endif /* CONFIG_UART_INTERRUPT_DRIVEN */
+
 static int uart_mspm0_init(const struct device *dev)
 {
 	const struct uart_mspm0_config *config = dev->config;
@@ -441,8 +462,10 @@ static int uart_mspm0_init(const struct device *dev)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	DL_UART_Main_enableFIFOs(config->regs);
-	DL_UART_Main_setRXFIFOThreshold(config->regs, DL_UART_RX_FIFO_LEVEL_1_2_FULL);
-	DL_UART_Main_setTXFIFOThreshold(config->regs, DL_UART_TX_FIFO_LEVEL_EMPTY);
+	DL_UART_Main_setRXFIFOThreshold(config->regs,
+					 uart_mspm0_rx_fifo_level[config->rx_fifo_threshold]);
+	DL_UART_Main_setTXFIFOThreshold(config->regs,
+					 uart_mspm0_tx_fifo_level[config->tx_fifo_threshold]);
 	DL_UART_Main_setRXInterruptTimeout(config->regs, 15U);
 	config->irq_config_func(dev);
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
@@ -508,6 +531,10 @@ static DEVICE_API(uart, uart_mspm0_driver_api) = {
 		.clock_subsys = &mspm0_uart_sys_clock##index,					\
 		IF_ENABLED(CONFIG_UART_INTERRUPT_DRIVEN,					\
 			   (.irq_config_func = uart_mspm0_##index##_irq_register,))		\
+		IF_ENABLED(CONFIG_UART_INTERRUPT_DRIVEN,					\
+			   (.rx_fifo_threshold = DT_INST_PROP(index, rx_fifo_threshold),))	\
+		IF_ENABLED(CONFIG_UART_INTERRUPT_DRIVEN,					\
+			   (.tx_fifo_threshold = DT_INST_PROP(index, tx_fifo_threshold),))	\
 		};										\
 												\
 	static struct uart_mspm0_data uart_mspm0_data_##index = {				\

--- a/dts/bindings/serial/ti,mspm0-uart.yaml
+++ b/dts/bindings/serial/ti,mspm0-uart.yaml
@@ -31,3 +31,25 @@ properties:
       - 8
     description: |
       Clock divider selection value.
+
+  rx-fifo-threshold:
+    type: int
+    default: 2
+    enum: [0, 1, 2, 3, 4]
+    description: |
+     0 - MSPM0_UART_RX_FIFO_LEVEL_ONE_ENTRY
+     1 - MSPM0_UART_RX_FIFO_LEVEL_1_4_FULL
+     2 - MSPM0_UART_RX_FIFO_LEVEL_1_2_FULL
+     3 - MSPM0_UART_RX_FIFO_LEVEL_3_4_FULL
+     4 - MSPM0_UART_RX_FIFO_LEVEL_FULL
+
+  tx-fifo-threshold:
+    type: int
+    default: 4
+    enum: [0, 1, 2, 3, 4]
+    description: |
+      0 - MSPM0_UART_TX_FIFO_LEVEL_ONE_ENTRY
+      1 - MSPM0_UART_TX_FIFO_LEVEL_1_4_EMPTY
+      2 - MSPM0_UART_TX_FIFO_LEVEL_1_2_EMPTY
+      3 - MSPM0_UART_TX_FIFO_LEVEL_3_4_EMPTY
+      4 - MSPM0_UART_TX_FIFO_LEVEL_EMPTY

--- a/include/zephyr/dt-bindings/uart/mspm0_uart.h
+++ b/include/zephyr/dt-bindings/uart/mspm0_uart.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Bang & Olufsen A/S, Denmark
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief TI MSPM0 UART FIFO threshold level definitions
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_UART_MSPM0_UART_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_UART_MSPM0_UART_H_
+
+/**
+ * @name MSPM0 UART RX FIFO threshold levels
+ * @{
+ */
+
+/** At least one entry is present */
+#define MSPM0_UART_RX_FIFO_LEVEL_ONE_ENTRY 0
+/** RX FIFO is 1/4 full */
+#define MSPM0_UART_RX_FIFO_LEVEL_1_4_FULL  1
+/** RX FIFO is 1/2 full */
+#define MSPM0_UART_RX_FIFO_LEVEL_1_2_FULL  2
+/** RX FIFO is 3/4 full */
+#define MSPM0_UART_RX_FIFO_LEVEL_3_4_FULL  3
+/** RX FIFO is full */
+#define MSPM0_UART_RX_FIFO_LEVEL_FULL      4
+
+/** @} */
+
+/**
+ * @name MSPM0 UART TX FIFO threshold levels
+ * @{
+ */
+
+/** TX FIFO has at least one entry available */
+#define MSPM0_UART_TX_FIFO_LEVEL_ONE_ENTRY 0
+/** TX FIFO is 1/4 empty */
+#define MSPM0_UART_TX_FIFO_LEVEL_1_4_EMPTY 1
+/** TX FIFO is 1/2 empty */
+#define MSPM0_UART_TX_FIFO_LEVEL_1_2_EMPTY 2
+/** TX FIFO is 3/4 empty */
+#define MSPM0_UART_TX_FIFO_LEVEL_3_4_EMPTY 3
+/** TX FIFO is empty */
+#define MSPM0_UART_TX_FIFO_LEVEL_EMPTY     4
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_UART_MSPM0_UART_H_ */


### PR DESCRIPTION
By default, the UART RX FIFO is configured to trigger an interrupt when it is half full. This end up breaking implementations that assumed a per-byte interrupt delivery. These changes make these
properties adjustable in the DTS for RX and TX FIFOs.