### PR TITLE
boards: esp32p4: add missing netif:eth

### DIFF
--- a/boards/espressif/esp32p4_function_ev_board/esp32p4_function_ev_board_hpcore.yaml
+++ b/boards/espressif/esp32p4_function_ev_board/esp32p4_function_ev_board_hpcore.yaml
@@ -13,6 +13,7 @@ supported:
   - entropy
   - gpio
   - hwinfo
+  - netif:eth
   - sdhc
   - spi
   - uart

--- a/boards/espressif/esp32p4x_function_ev_board/esp32p4x_function_ev_board_hpcore.yaml
+++ b/boards/espressif/esp32p4x_function_ev_board/esp32p4x_function_ev_board_hpcore.yaml
@@ -10,6 +10,7 @@ supported:
   - entropy
   - gpio
   - hwinfo
+  - netif:eth
   - sdhc
   - spi
   - uart

--- a/boards/waveshare/esp32p4_wifi6_dev_kit/esp32p4_wifi6_dev_kit_esp32p4_hpcore.yaml
+++ b/boards/waveshare/esp32p4_wifi6_dev_kit/esp32p4_wifi6_dev_kit_esp32p4_hpcore.yaml
@@ -10,11 +10,11 @@ testing:
 supported:
   - counter
   - entropy
-  - ethernet
   - gpio
   - hwinfo
   - i2c
   - input
+  - netif:eth
   - sdhc
   - uart
   - watchdog


### PR DESCRIPTION
add the missing netif:eth for the
esp32p4 boards that support ethernet.