### PR TITLE
drivers: display: hx8353e: make GRAM bounds check rotation-aware

### DIFF
--- a/drivers/display/display_hx8353e.c
+++ b/drivers/display/display_hx8353e.c
@@ -500,10 +500,16 @@ static int hx8353e_init(const struct device *dev)
 }
 
 #define HX8353E_INIT(n)								\
-	BUILD_ASSERT(DT_INST_PROP(n, width)  <= 132,				\
-		     "HX8353E width must be <= 132 (chip limit)");		\
-	BUILD_ASSERT(DT_INST_PROP(n, height) <= 162,				\
-		     "HX8353E height must be <= 162 (chip limit)");		\
+	BUILD_ASSERT((DT_INST_PROP(n, rotation) == 90 ||			\
+		      DT_INST_PROP(n, rotation) == 270)			\
+			     ? DT_INST_PROP(n, width) <= 162			\
+			     : DT_INST_PROP(n, width) <= 132,			\
+		     "HX8353E width exceeds the 132x162 GRAM (chip limit)");	\
+	BUILD_ASSERT((DT_INST_PROP(n, rotation) == 90 ||			\
+		      DT_INST_PROP(n, rotation) == 270)			\
+			     ? DT_INST_PROP(n, height) <= 132			\
+			     : DT_INST_PROP(n, height) <= 162,			\
+		     "HX8353E height exceeds the 132x162 GRAM (chip limit)");	\
 	static const struct hx8353e_config hx8353e_config_##n = {		\
 		.mipi_dbi      = DEVICE_DT_GET(DT_INST_PARENT(n)),		\
 		.dbi_config    = {						\


### PR DESCRIPTION
## Summary

Follow-up to #108055 (the original HX8353E driver). The `HX8353E_INIT` macro's `BUILD_ASSERT`s unconditionally check `width <= 132` and `height <= 162`, regardless of the `rotation` devicetree property.

The HX8353E's GRAM is 132x162 (columns x rows). Setting `rotation = <90>;` or `<270>;` sets the MADCTL row/column-exchange (MV) bit, which swaps which GRAM axis the `width`/`height` devicetree properties address. A panel wired at 90 degrees with `width = <160>; height = <128>;` is a perfectly valid 132x162 GRAM configuration once the swap is accounted for (128 <= 132, 160 <= 162), but the unconditional assert rejects it at compile time because it never accounts for rotation.

This fix makes the two `BUILD_ASSERT`s check against the rotated bound when `rotation` is 90 or 270, and the normal bound otherwise.

## Reproduction

I provided example code to reproduce this at https://github.com/ndoo/hx8353e-rotation-repro with a minimal `mps2/an385` app and an `hx8353e` node with a dummy `zephyr,mipi-dbi-bitbang` bus. Pointing that repro's manifest at this branch confirms the build now succeeds for a 160x128@90 panel, and still correctly fails for a genuinely oversized panel (`width = <200>;`) in both `rotation = <0>;` and `rotation = <90>;`.

## Additional note

I'm already using this fix on a TYT MD-UV390 PLUS radio, 160x128 panel at `rotation = <90>;`) in a downstream out-of-tree board using this driver.
