### PR TITLE
drivers: timer: cortex_m_systick: export raw VAL from elapsed()

### DIFF
--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -186,8 +186,9 @@ static cycle_t cycle_pre_idle;
  * holds the amount of elapsed HW cycles due to (possibly) multiple
  * timer wraps (overflows).
  *
- * @param val_out Optional pointer to store the SysTick->VAL snapshot (val2)
- *                used in the calculation.
+ * @param val_out Optional pointer to store the raw SysTick->VAL snapshot (C)
+ *                taken by this function, for callers that need to chain a
+ *                measurement onto the window this call accounted for.
  *
  * Prerequisites:
  * - reprogramming of SysTick.LOAD must be clearing the SysTick.COUNTER
@@ -203,6 +204,10 @@ static uint32_t elapsed(uint32_t *val_out)
 	uint32_t val1 = SysTick->VAL;	/* A */
 	uint32_t ctrl = SysTick->CTRL;	/* B */
 	uint32_t val2 = SysTick->VAL;	/* C */
+
+	if (val_out != NULL) {
+		*val_out = val2;
+	}
 
 	/* SysTick behavior: The counter wraps after zero automatically.
 	 * The COUNTFLAG field of the CTRL register is set when it
@@ -241,10 +246,6 @@ static uint32_t elapsed(uint32_t *val_out)
 		/* We know there was a wrap, but we might not have
 		 * seen it in CTRL, so clear it. */
 		(void)SysTick->CTRL;
-	}
-
-	if (val_out != NULL) {
-		*val_out = val2;
 	}
 
 	return (last_load - val2) + overflow_cyc;
@@ -393,12 +394,17 @@ void sys_clock_set_timeout(uint32_t ticks, bool idle)
 	 * state here to catch any wrap before writing VAL=0 destroys COUNTFLAG.
 	 */
 
-	/* elapsed() is called passing the address of val1 so that the SysTick->VAL
-	 * snapshot used for computing 'pending' is also returned and stored
-	 * in val1. This eliminates the timing gap that would exist if we read
-	 * SysTick->VAL separately after elapsed(), ensuring perfect precision.
+	/* val1 is taken from elapsed()'s own last VAL sample rather than from a
+	 * separate read afterwards, so the window measured by (val1 - val2) at
+	 * the bottom of this function abuts the window already accounted for by
+	 * elapsed() with no gap in between. Any cycles in such a gap would be
+	 * neither in elapsed()'s return value nor in the drift compensation,
+	 * i.e. systematically lost drift.
+	 *
+	 * Note that val1 and the val2 read further down must both be raw VAL
+	 * samples: mixing a wrap-realigned sample with a raw one would fabricate
+	 * a whole counter period whenever VAL reads 0.
 	 */
-
 	uint32_t val1;
 	uint32_t pending = elapsed(&val1);
 	uint32_t old_load = last_load;


### PR DESCRIPTION
The val_out snapshot exported by elapsed() was written after the
wrap-realignment step, so callers received last_load instead of 0
whenever sample C happened to read VAL == 0.

sys_clock_set_timeout() feeds that snapshot into the drift
compensation as val1 and compares it against a later raw read of
SysTick->VAL as val2. Mixing a realigned operand with a raw one makes
val1 - val2 evaluate to a whole counter period that never elapsed, so
cycle_count jumps forward by up to one full timer period on every
reprogram that lands on a zero VAL sample.

The realignment of 0 to last_load is an internal convention of
elapsed(): it exists only so the wrap-detection below can assume
COUNTFLAG and wrapping occur on the same cycle. It has no meaning for
a caller that measures a window against its own raw register read.
Move the export to immediately after the three register reads so
val_out carries the raw sample, which is what the code did before
elapsed() grew the out-parameter. The out-parameter still removes the
gap between the window elapsed() accounts for and the window the
drift compensation measures.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
