### PR TITLE
arch: common: make early init header self-contained

### DIFF
--- a/include/zephyr/arch/common/init.h
+++ b/include/zephyr/arch/common/init.h
@@ -6,6 +6,9 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_COMMON_INIT_H_
 #define ZEPHYR_INCLUDE_ARCH_COMMON_INIT_H_
 
+#include <zephyr/toolchain.h>
+#include <stddef.h>
+
 FUNC_NORETURN void z_cstart(void);
 
 /* Early boot functions */


### PR DESCRIPTION
arch/common/init.h declares early boot helpers using FUNC_NORETURN and
size_t, but it does not include the headers that define them. Include
zephyr/toolchain.h and stddef.h directly so the header does not depend
on callers including zephyr/kernel.h first.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>