### PR TITLE
counter: ace_v1x: fix header include issue

### DIFF
--- a/drivers/counter/counter_ace_v1x_art.c
+++ b/drivers/counter/counter_ace_v1x_art.c
@@ -10,7 +10,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/spinlock.h>
 #include <soc.h>
-#include <counter/counter_ace_v1x_art_regs.h>
+#include "counter_ace_v1x_art_regs.h"
 
 static struct k_spinlock lock;
 

--- a/drivers/counter/counter_ace_v1x_rtc.c
+++ b/drivers/counter/counter_ace_v1x_rtc.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/counter.h>
 #include <zephyr/kernel.h>
 #include <soc.h>
-#include <counter/counter_ace_v1x_rtc_regs.h>
+#include "counter_ace_v1x_rtc_regs.h"
 
 static int counter_ace_v1x_rtc_get_value_32(const struct device *dev,
 		uint32_t *value)


### PR DESCRIPTION
Fix build error on the ace_v1x_{art,rtc} drivers where compiler cannot find the register header files. Since those header files reside at the same directory, convert it to local include.