### PR TITLE
[Backport v3.7-branch] drivers: ADC buffer size validation improvements

### DIFF
--- a/drivers/adc/adc_common.c
+++ b/drivers/adc/adc_common.c
@@ -48,3 +48,19 @@ int adc_gain_invert(enum adc_gain gain,
 
 	return rv;
 }
+
+int adc_sequence_validate_buffer(const struct adc_sequence *sequence,
+				 uint8_t active_channels, size_t data_size)
+{
+	size_t needed = (size_t)active_channels * data_size;
+
+	if (sequence->options) {
+		needed *= (1 + sequence->options->extra_samplings);
+	}
+
+	if (sequence->buffer_size < needed) {
+		return -ENOMEM;
+	}
+
+	return 0;
+}

--- a/drivers/adc/adc_common.h
+++ b/drivers/adc/adc_common.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_ADC_ADC_COMMON_H_
+#define ZEPHYR_DRIVERS_ADC_ADC_COMMON_H_
+
+#include <zephyr/drivers/adc.h>
+
+#include <stddef.h>
+
+/**
+ * This function will validate the buffer size is large enough to hold
+ * the requested samples. Returns -ENOMEM if the sequence buffer size is too
+ * small, otherwise 0.
+ */
+int adc_sequence_validate_buffer(const struct adc_sequence *sequence,
+				 uint8_t active_channels, size_t data_size);
+
+#endif /* ZEPHYR_DRIVERS_ADC_ADC_COMMON_H_ */

--- a/drivers/adc/adc_mcux_lpadc.c
+++ b/drivers/adc/adc_mcux_lpadc.c
@@ -18,6 +18,8 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 
+#include "adc_common.h"
+
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
@@ -238,6 +240,7 @@ static int mcux_lpadc_start_read(const struct device *dev,
 	struct mcux_lpadc_data *data = dev->data;
 	lpadc_hardware_average_mode_t hardware_average_mode;
 	uint8_t channel, last_enabled;
+	int ret;
 #if defined(FSL_FEATURE_LPADC_HAS_CMDL_MODE) \
 	&& FSL_FEATURE_LPADC_HAS_CMDL_MODE
 	lpadc_conversion_resolution_mode_t resolution_mode;
@@ -292,6 +295,12 @@ static int mcux_lpadc_start_read(const struct device *dev,
 		LOG_ERR("Unsupported oversampling value %d",
 			sequence->oversampling);
 		return -ENOTSUP;
+	}
+
+	ret = adc_sequence_validate_buffer(sequence,
+					   POPCOUNT(sequence->channels), sizeof(uint16_t));
+	if (ret < 0) {
+		return ret;
 	}
 
 	/*

--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -265,7 +265,7 @@ static void adc_npcx_isr(const struct device *dev)
 
 /*
  * Validate the buffer size with adc channels mask. If it is lower than what
- * we need return -ENOSPC.
+ * we need return -ENOMEM.
  */
 static int adc_npcx_validate_buffer_size(const struct device *dev,
 					const struct adc_sequence *sequence)
@@ -287,7 +287,7 @@ static int adc_npcx_validate_buffer_size(const struct device *dev,
 	}
 
 	if (sequence->buffer_size < needed) {
-		return -ENOSPC;
+		return -ENOMEM;
 	}
 
 	return 0;

--- a/drivers/adc/adc_nxp_s32_adc_sar.c
+++ b/drivers/adc/adc_nxp_s32_adc_sar.c
@@ -131,7 +131,7 @@ static int adc_nxp_s32_validate_buffer_size(const struct device *dev,
 	}
 
 	if (sequence->buffer_size < needed_size) {
-		return -ENOSPC;
+		return -ENOMEM;
 	}
 
 	return 0;

--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -144,6 +144,36 @@ ZTEST_USER(adc_basic, test_adc_sample_one_channel)
 }
 
 /*
+ * test_adc_sample_invalid_buffer
+ */
+static int test_task_invalid_buffer(void)
+{
+	int ret;
+	uint8_t small_buffer[2];
+
+	struct adc_sequence sequence = {
+		.buffer = small_buffer,
+		.buffer_size = sizeof(small_buffer) - 1,
+	};
+
+	small_buffer[1] = UINT8_MAX;
+
+	init_adc();
+	(void)adc_sequence_init_dt(&adc_channels[0], &sequence);
+
+	ret = adc_read_dt(&adc_channels[0], &sequence);
+	zassert_equal(ret, -ENOMEM, "adc_read() incorrectly returned with code %d", ret);
+	zassert_equal(small_buffer[1], UINT8_MAX, "adc_read() overwrote beyond the buffer size");
+
+	return TC_PASS;
+}
+
+ZTEST_USER(adc_basic, test_adc_sample_invalid_buffer)
+{
+	zassert_true(test_task_invalid_buffer() == TC_PASS);
+}
+
+/*
  * test_adc_sample_multiple_channels
  */
 static int test_task_multiple_channels(void)


### PR DESCRIPTION
Backport of the fix from #114530 to `v3.7-branch`.

Fixes: #114978