### PR TITLE
soc: espressif: init irq stack with 0xaa on riscv

### DIFF
--- a/soc/espressif/common/start.S
+++ b/soc/espressif/common/start.S
@@ -12,6 +12,7 @@
 
 #include <zephyr/toolchain.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/offsets.h>
 #include <zephyr/arch/riscv/csr.h>
 #include <soc/soc_caps.h>
 #include "memory.h"
@@ -20,6 +21,9 @@
 
 GTEXT(start_riscv)
 GTEXT(_vector_table)
+#ifdef CONFIG_INIT_STACKS
+GDATA(z_interrupt_stacks)
+#endif
 #if SOC_INT_CLIC_SUPPORTED
 GTEXT(_mtvt_table)
 #endif
@@ -43,6 +47,21 @@ __start:
 	li sp, DRAM_STACK_START
 
 	csrci mstatus, MSTATUS_MIE
+
+#ifdef CONFIG_INIT_STACKS
+	/* Pre-populate all bytes in z_interrupt_stacks with 0xAA */
+	la t0, z_interrupt_stacks
+	/* Total size of all cores' IRQ stack */
+	li t1, __z_interrupt_all_stacks_SIZEOF
+	add t1, t1, t0
+
+	/* Populate z_interrupt_stacks with 0xaaaaaaaa */
+	li t2, 0xaaaaaaaa
+aa_loop:
+	sw t2, 0x00(t0)
+	addi t0, t0, 4
+	blt t0, t1, aa_loop
+#endif /* CONFIG_INIT_STACKS */
 
 	la t0, _vector_table
 	csrw mtvec, t0


### PR DESCRIPTION
Espressif RISC-V SoCs enter through their own __start in soc/espressif/common/start.S rather than the common arch/riscv __initialize. That entry exists because the ROM hands over on a stack that can overlap .bss, so gp, the stack and the vector table must be set up before any compiler-generated prologue runs. As a side effect the 0xaa painting of z_interrupt_stacks done by the common reset code was never executed.

Fixes #114970