### PR TITLE
drivers: xen: add sysctl trace buffer op and domctl unbind pt irq op

### DIFF
--- a/drivers/xen/dom0/domctl.c
+++ b/drivers/xen/dom0/domctl.c
@@ -280,6 +280,30 @@ int xen_domctl_bind_pt_irq(int domid, uint32_t machine_irq, uint8_t irq_type,
 	return do_domctl(&domctl);
 }
 
+int xen_domctl_unbind_pt_irq(int domid, const struct xen_domctl_pt_irq *irq)
+{
+	xen_domctl_t domctl = {
+		.domain = domid,
+		.cmd = XEN_DOMCTL_unbind_pt_irq,
+	};
+	struct xen_domctl_bind_pt_irq *bind = &(domctl.u.bind_pt_irq);
+
+	if (irq == NULL) {
+		return -EINVAL;
+	}
+
+	if (irq->irq_type != PT_IRQ_TYPE_SPI) {
+		/* TODO: implement other types */
+		return -ENOTSUP;
+	}
+
+	bind->irq_type = irq->irq_type;
+	bind->machine_irq = irq->machine_irq;
+	bind->u.spi.spi = irq->spi;
+
+	return do_domctl(&domctl);
+}
+
 int xen_domctl_max_vcpus(int domid, int max_vcpus)
 {
 	xen_domctl_t domctl = {

--- a/drivers/xen/dom0/sysctl.c
+++ b/drivers/xen/dom0/sysctl.c
@@ -38,6 +38,28 @@ int xen_sysctl_physinfo(struct xen_sysctl_physinfo *info)
 	return ret;
 }
 
+int xen_sysctl_tbuf_op(struct xen_sysctl_tbuf_op *tbuf_op)
+{
+	int ret;
+	xen_sysctl_t sysctl = {
+		.cmd = XEN_SYSCTL_tbuf_op,
+	};
+
+	if (!tbuf_op) {
+		return -EINVAL;
+	}
+
+	sysctl.u.tbuf_op = *tbuf_op;
+
+	ret = do_sysctl(&sysctl);
+	if (ret < 0) {
+		return ret;
+	}
+	*tbuf_op = sysctl.u.tbuf_op;
+
+	return ret;
+}
+
 int xen_sysctl_getdomaininfo(struct xen_domctl_getdomaininfo *domaininfo,
 			     uint16_t first, uint16_t num)
 {

--- a/include/zephyr/xen/dom0/domctl.h
+++ b/include/zephyr/xen/dom0/domctl.h
@@ -225,6 +225,26 @@ int xen_domctl_assign_dt_device(int domid, char *dtdev_path);
 int xen_domctl_deassign_dt_device(int domid, char *dtdev_path);
 
 /**
+ * @brief Physical interrupt passthrough descriptor.
+ */
+struct xen_domctl_pt_irq {
+	/** Machine IRQ number to bind or unbind. */
+	uint32_t machine_irq;
+	/** Xen passthrough IRQ type. */
+	uint8_t irq_type;
+	/** PCI bus number for PCI passthrough modes. */
+	uint8_t bus;
+	/** PCI device number for PCI passthrough modes. */
+	uint8_t device;
+	/** PCI INTx line for PCI passthrough modes. */
+	uint8_t intx;
+	/** ISA IRQ number for ISA passthrough modes. */
+	uint8_t isa_irq;
+	/** SPI number used with ``PT_IRQ_TYPE_SPI``. */
+	uint16_t spi;
+};
+
+/**
  * @brief Bind a physical interrupt to a guest domain.
  *
  * Only ``PT_IRQ_TYPE_SPI`` is currently supported.
@@ -245,6 +265,22 @@ int xen_domctl_deassign_dt_device(int domid, char *dtdev_path);
  */
 int xen_domctl_bind_pt_irq(int domid, uint32_t machine_irq, uint8_t irq_type, uint8_t bus,
 			   uint8_t device, uint8_t intx, uint8_t isa_irq, uint16_t spi);
+
+/**
+ * @brief Unbind a physical interrupt from a guest domain.
+ *
+ * Only ``PT_IRQ_TYPE_SPI`` is currently supported.
+ *
+ * @kconfig_dep{CONFIG_XEN_DOM0}
+ *
+ * @param domid Target domain identifier.
+ * @param irq Physical interrupt passthrough descriptor.
+ *
+ * @return 0 on success, negative errno value on failure.
+ * @retval -EINVAL @p irq is NULL.
+ * @retval -ENOTSUP @p irq->irq_type is not supported by the current implementation.
+ */
+int xen_domctl_unbind_pt_irq(int domid, const struct xen_domctl_pt_irq *irq);
 
 /**
  * @brief Set the maximum number of vCPUs available to a domain.

--- a/include/zephyr/xen/dom0/sysctl.h
+++ b/include/zephyr/xen/dom0/sysctl.h
@@ -44,6 +44,17 @@
 int xen_sysctl_physinfo(struct xen_sysctl_physinfo *info);
 
 /**
+ * @brief Performs a Xen trace buffer sysctl operation.
+ *
+ * @param[in,out] tbuf_op A pointer to a `struct xen_sysctl_tbuf_op` object
+ *                        that defines the trace buffer operation and receives
+ *                        any output values returned by Xen.
+ * @retval 0 on success.
+ * @retval -errno on failure.
+ */
+int xen_sysctl_tbuf_op(struct xen_sysctl_tbuf_op *tbuf_op);
+
+/**
  * @brief Retrieves information about Xen domains.
  *
  * @param[out] domaininfo A pointer to the `xen_domctl_getdomaininfo` structure


### PR DESCRIPTION
drivers: xen: add sysctl trace buffer op
Expose a Dom0 wrapper for XEN_SYSCTL_tbuf_op using the Xen public
headers provided by zephyr-xenlib.

The wrapper follows the existing sysctl helper pattern: validate the
caller-provided request, copy it into xen_sysctl, issue
HYPERVISOR_sysctl(), and copy Xen-updated fields back on success.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>

----

drivers: xen: add domctl unbind pt irq op
Add a Dom0 wrapper for XEN_DOMCTL_unbind_pt_irq.

Use SPI-only argument handling, matching the existing bind_pt_irq wrapper.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>

----

Commits are independent and can be reviewed separately