### PR TITLE
drivers: mspi: small fixes for Ambiq Apollo3 Blue MCU

### DIFF
--- a/drivers/mspi/mspi_ambiq.h
+++ b/drivers/mspi/mspi_ambiq.h
@@ -100,9 +100,12 @@ struct mspi_ambiq_timing_scan {
 
 #define MSPI_AMBIQ_TIMING_CONFIG_MASK(n) DT_INST_PROP(n, ambiq_timing_config_mask)
 
+#if defined(CONFIG_SOC_APOLLO3_BLUE)
+#define MSPI_AMBIQ_PORT(n) ((DT_REG_ADDR(DT_INST_BUS(n)) - MSPI_BASE) / 0x1000UL)
+#else
 #define MSPI_AMBIQ_PORT(n) ((DT_REG_ADDR(DT_INST_BUS(n)) - MSPI0_BASE) /                          \
 				(MSPI1_BASE - MSPI0_BASE))
-
+#endif
 
 int mspi_ambiq_timing_scan(const struct device           *dev,
 			   const struct device           *bus,

--- a/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
@@ -440,9 +440,9 @@
 			#io-channel-cells = <1>;
 		};
 
-		mspi0: mspi@40020000 {
+		mspi0: mspi@50014000 {
 			compatible = "ambiq,mspi-controller";
-			reg = <0x40020000 0x400>;
+			reg = <0x50014000 0x400>, <0x51000000 0x0100000>;
 			clock-frequency = <48000000>;
 			interrupts = <20 0>;
 			#address-cells = <1>;

--- a/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3_blue.dtsi
@@ -440,9 +440,9 @@
 			#io-channel-cells = <1>;
 		};
 
-		mspi0: mspi@40020000 {
+		mspi0: mspi@50014000 {
 			compatible = "ambiq,mspi-controller";
-			reg = <0x40020000 0x400>;
+			reg = <0x50014000 0x400>, <0x51000000 0x00ffffff>;
 			clock-frequency = <48000000>;
 			interrupts = <20 0>;
 			#address-cells = <1>;


### PR DESCRIPTION
Three small fixes for MSPI driver of Apollo3 Blue:
- ~~the MSPI controller does not support memory mapping of devices~~
- specialized definition of `MSPI_AMBIQ_PORT(n)` macro
- apollo3_blue dts enumerated a wrong register address for the controller