### PR TITLE
tests: drivers: fixes for i2s_api and wdt_basic_api

### DIFF
--- a/tests/drivers/i2s/i2s_api/boards/esp32s3_devkitc_procpu.overlay
+++ b/tests/drivers/i2s/i2s_api/boards/esp32s3_devkitc_procpu.overlay
@@ -12,21 +12,34 @@
 	};
 };
 
+/* GPIO35-37 and GPIO47-48 belong to the octal flash/PSRAM bus on the
+ * devkitc variants with OPI memory; muxing i2s there kills XIP before
+ * the console comes up. Use free header pins instead and keep spi2/3
+ * away from them.
+ */
 &i2s0_default {
 	group1 {
-		pinmux = <I2S0_O_WS_GPIO36>,
-			 <I2S0_O_BCK_GPIO37>;
+		pinmux = <I2S0_O_WS_GPIO2>,
+			 <I2S0_O_BCK_GPIO3>;
 	};
 
 	group2 {
-		pinmux = <I2S0_O_SD_GPIO48>;
+		pinmux = <I2S0_O_SD_GPIO4>;
 		input-enable;
 	};
 
 	group3 {
-		pinmux = <I2S0_I_SD_GPIO48>;
+		pinmux = <I2S0_I_SD_GPIO4>;
 		output-enable;
 	};
+};
+
+&spi2 {
+	status = "disabled";
+};
+
+&spi3 {
+	status = "disabled";
 };
 
 &i2s0 {

--- a/tests/drivers/i2s/i2s_api/src/common.c
+++ b/tests/drivers/i2s/i2s_api/src/common.c
@@ -9,8 +9,17 @@
 #include <zephyr/drivers/i2s.h>
 #include "i2s_api_test.h"
 
-K_MEM_SLAB_DEFINE(rx_mem_slab, BLOCK_SIZE, NUM_RX_BLOCKS, 32);
-K_MEM_SLAB_DEFINE(tx_mem_slab, BLOCK_SIZE, NUM_TX_BLOCKS, 32);
+/* Cache-line align the blocks so cache maintenance on one block cannot
+ * corrupt a neighbouring block
+ */
+#ifdef CONFIG_DCACHE_LINE_SIZE
+#define SLAB_ALIGN MAX(32, CONFIG_DCACHE_LINE_SIZE)
+#else
+#define SLAB_ALIGN 32
+#endif
+
+K_MEM_SLAB_DEFINE(rx_mem_slab, BLOCK_SIZE, NUM_RX_BLOCKS, SLAB_ALIGN);
+K_MEM_SLAB_DEFINE(tx_mem_slab, BLOCK_SIZE, NUM_TX_BLOCKS, SLAB_ALIGN);
 
 /* The data_l represent a sine wave */
 ZTEST_DMEM int16_t data_l[SAMPLE_NO] = {

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -60,6 +60,7 @@
  * @}
  */
 
+#include <zephyr/cache.h>
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
@@ -210,12 +211,24 @@ volatile DATATYPE m_testvalue __attribute__((section(NOINIT_SECTION)));
 /* m_magic is used to detect first boot (random value) vs reset (magic retained) */
 volatile DATATYPE m_magic __attribute__((section(NOINIT_SECTION)));
 
+/* Commit the noinit state to memory: a watchdog reset discards dirty
+ * write-back cache lines
+ */
+static void commit_noinit_state(void)
+{
+	sys_cache_data_flush_range((void *)(uintptr_t)&m_state, sizeof(m_state));
+	sys_cache_data_flush_range((void *)(uintptr_t)&m_testcase_index, sizeof(m_testcase_index));
+	sys_cache_data_flush_range((void *)(uintptr_t)&m_testvalue, sizeof(m_testvalue));
+	sys_cache_data_flush_range((void *)(uintptr_t)&m_magic, sizeof(m_magic));
+}
+
 #if TEST_WDT_CALLBACK_1
 static void wdt_int_cb0(const struct device *wdt_dev, int channel_id)
 {
 	ARG_UNUSED(wdt_dev);
 	ARG_UNUSED(channel_id);
 	m_testvalue += WDT_TEST_CB0_TEST_VALUE;
+	commit_noinit_state();
 }
 #endif
 
@@ -225,6 +238,7 @@ static void wdt_int_cb1(const struct device *wdt_dev, int channel_id)
 	ARG_UNUSED(wdt_dev);
 	ARG_UNUSED(channel_id);
 	m_testvalue += WDT_TEST_CB1_TEST_VALUE;
+	commit_noinit_state();
 }
 #endif
 
@@ -269,6 +283,7 @@ static int test_wdt_no_callback(void)
 	TC_PRINT("Waiting to restart MCU\n");
 	m_testvalue = 0U;
 	m_state = WDT_TEST_STATE_CHECK_RESET;
+	commit_noinit_state();
 	while (1) {
 		k_yield();
 	}
@@ -332,6 +347,7 @@ static int test_wdt_callback_1(void)
 	TC_PRINT("Waiting to restart MCU\n");
 	m_testvalue = 0U;
 	m_state = WDT_TEST_STATE_CHECK_RESET;
+	commit_noinit_state();
 	while (1) {
 		k_yield();
 	}
@@ -401,6 +417,7 @@ static int test_wdt_callback_2(void)
 	TC_PRINT("Waiting to restart MCU\n");
 	m_testvalue = 0U;
 	m_state = WDT_TEST_STATE_CHECK_RESET;
+	commit_noinit_state();
 
 	while (1) {
 		wdt_feed(wdt, 0);
@@ -495,6 +512,7 @@ static int test_wdt_enable_wait_mode(void)
 	TC_PRINT("Waiting to restart MCU\n");
 	m_testvalue = 0U;
 	m_state = WDT_TEST_STATE_CHECK_RESET;
+	commit_noinit_state();
 	while (1) {
 		k_yield();
 	}


### PR DESCRIPTION
Three test fixes found while running the driver suites on
Espressif SoCs with SMP support:

- i2s_api: move the esp32s3_devkitc loopback pins off GPIO36,
  GPIO37 and GPIO48, which belong to the octal flash and PSRAM
  bus. Muxing i2s there killed XIP before the console came up
  and the test appeared to hang at boot.
  
- i2s_api: align the dma mem slab blocks to the data cache line
  size, so cache maintenance on one block cannot corrupt a
  neighbouring block sharing the same line.
  
- wdt_basic_api: flush the noinit state variables before every
  point a watchdog reset can fire. On SoCs with a write-back
  data cache the reset discards dirty lines and the suite looped
  forever in its first reset phase.