### PR TITLE
drivers: udc: dwc2: select the fsls phy for esp32p4 otg-fs

### DIFF
--- a/drivers/usb/udc/udc_dwc2_esp32_usb_otg_fs.h
+++ b/drivers/usb/udc/udc_dwc2_esp32_usb_otg_fs.h
@@ -20,6 +20,10 @@
 #include <hal/gpio_ll.h>
 #include <soc/gpio_sig_map.h>
 
+#if defined(CONFIG_SOC_SERIES_ESP32P4)
+#include <hal/usb_serial_jtag_ll.h>
+#endif
+
 struct phy_context_t {
 	usb_phy_target_t target;
 	usb_phy_controller_t controller;
@@ -99,6 +103,12 @@ static inline int esp32_usb_otg_init(const struct device *dev,
 
 static inline int esp32_usb_otg_enable_clk(struct phy_context_t *phy_ctx)
 {
+#if defined(CONFIG_SOC_SERIES_ESP32P4)
+	/* The FSLS phy pads default to usb-serial-jtag; hand them to the
+	 * otg-fs controller while the device stack is enabled.
+	 */
+	usb_serial_jtag_ll_phy_select(1);
+#endif
 	usb_wrap_hal_init(&phy_ctx->wrap_hal);
 
 #if USB_WRAP_LL_EXT_PHY_SUPPORTED
@@ -117,6 +127,10 @@ static inline int esp32_usb_otg_enable_phy(struct phy_context_t *phy_ctx, bool e
 		LOG_DBG("PHY enabled");
 	} else {
 		usb_wrap_ll_phy_enable_pad(phy_ctx->wrap_hal.dev, false);
+#if defined(CONFIG_SOC_SERIES_ESP32P4)
+		/* Return the FSLS phy pads to usb-serial-jtag */
+		usb_serial_jtag_ll_phy_select(0);
+#endif
 		LOG_DBG("PHY disabled");
 	}
 
@@ -127,6 +141,9 @@ static inline int esp32_usb_otg_shutdown(const struct esp32_usb_otg_fs_config *c
 					 struct esp32_usb_otg_fs_data *data)
 {
 	usb_wrap_hal_disable();
+#if defined(CONFIG_SOC_SERIES_ESP32P4)
+	usb_serial_jtag_ll_phy_select(0);
+#endif
 	esp_intr_free(data->int_handle);
 
 	return clock_control_off(cfg->clock_dev, cfg->clock_subsys);

--- a/drivers/usb/udc/udc_dwc2_esp32_usb_otg_fs.h
+++ b/drivers/usb/udc/udc_dwc2_esp32_usb_otg_fs.h
@@ -20,6 +20,10 @@
 #include <hal/gpio_ll.h>
 #include <soc/gpio_sig_map.h>
 
+#if defined(CONFIG_SOC_SERIES_ESP32P4)
+#include <hal/usb_serial_jtag_ll.h>
+#endif
+
 struct phy_context_t {
 	usb_phy_target_t target;
 	usb_phy_controller_t controller;
@@ -113,10 +117,20 @@ static inline int esp32_usb_otg_enable_phy(struct phy_context_t *phy_ctx, bool e
 	LOG_MODULE_DECLARE(udc_dwc2, CONFIG_UDC_DRIVER_LOG_LEVEL);
 
 	if (enable) {
+#if defined(CONFIG_SOC_SERIES_ESP32P4)
+		/* The FSLS phy pads default to usb-serial-jtag; hand them to the
+		 * otg-fs controller while the device stack is enabled.
+		 */
+		usb_serial_jtag_ll_phy_select(1);
+#endif
 		usb_wrap_ll_phy_enable_pad(phy_ctx->wrap_hal.dev, true);
 		LOG_DBG("PHY enabled");
 	} else {
 		usb_wrap_ll_phy_enable_pad(phy_ctx->wrap_hal.dev, false);
+#if defined(CONFIG_SOC_SERIES_ESP32P4)
+		/* Return the FSLS phy pads to usb-serial-jtag */
+		usb_serial_jtag_ll_phy_select(0);
+#endif
 		LOG_DBG("PHY disabled");
 	}
 


### PR DESCRIPTION
The esp32p4 fsls phy pads are shared between usb-serial-jtag and
the otg-fs controller through an lp_sys mux that defaults to the
usj. This PR hands the pads to the otg-fs controller when the
device stack is enabled, so a devicetree enabled fs controller
enumerates without application code, and returns them to
usb-serial-jtag when the stack is disabled. The usj console and
flashing keep working until usbd_enable() and are restored at
runtime after usbd_disable(), without a chip reset.
