### PR TITLE
drivers: virtio: virtqueue fixes and cleanups

### DIFF
--- a/drivers/virtio/virtqueue.c
+++ b/drivers/virtio/virtqueue.c
@@ -103,6 +103,18 @@ static int virtq_add_available(struct virtq *v, uint16_t desc_idx)
 	return 0;
 }
 
+static void virtq_return_desc_chain(struct virtq *v, uint16_t head, uint16_t count)
+{
+	uint16_t curr = head;
+
+	for (uint16_t i = 0; i < count; i++) {
+		uint16_t next = sys_le16_to_cpu(v->desc[curr].next);
+
+		virtq_add_free_desc(v, curr);
+		curr = next;
+	}
+}
+
 int virtq_add_buffer_chain(
 	struct virtq *v, struct virtq_buf *bufs, uint16_t bufs_size,
 	uint16_t device_readable_count, virtq_receive_callback cb, void *cb_opaque,
@@ -123,26 +135,18 @@ int virtq_add_buffer_chain(
 		return -EINVAL;
 	}
 
-	k_spinlock_key_t key = k_spin_lock(&v->lock);
-
-	if (v->free_desc_n < bufs_size && !K_TIMEOUT_EQ(timeout, K_FOREVER)) {
-		/* we don't have enough free descriptors to push all buffers to the queue */
-		k_spin_unlock(&v->lock, key);
-		return -EBUSY;
-	}
-
 	uint16_t prev_desc = VIRTQ_DESC_NEXT_SENTINEL;
 	uint16_t head = VIRTQ_DESC_NEXT_SENTINEL;
 
 	for (uint16_t buf_n = 0; buf_n < bufs_size; buf_n++) {
 		uint16_t desc;
+		/* popped outside the queue lock as k_stack_pop() may block */
+		int ret = virtq_get_free_desc(v, &desc, timeout);
 
-		/*
-		 * we've checked before that we have enough free descriptors
-		 * and the queue is locked, so popping from stack is guaranteed
-		 * to succeed and we don't have to check its return value
-		 */
-		virtq_get_free_desc(v, &desc, timeout);
+		if (ret != 0) {
+			virtq_return_desc_chain(v, head, buf_n);
+			return ret;
+		}
 
 		if (head == VIRTQ_DESC_NEXT_SENTINEL) {
 			head = desc;
@@ -169,8 +173,9 @@ int virtq_add_buffer_chain(
 	v->recv_cbs[head].cb = cb;
 	v->recv_cbs[head].opaque = cb_opaque;
 
-	virtq_add_available(v, head);
+	k_spinlock_key_t key = k_spin_lock(&v->lock);
 
+	virtq_add_available(v, head);
 	k_spin_unlock(&v->lock, key);
 
 	return 0;
@@ -184,7 +189,9 @@ int virtq_get_free_desc(struct virtq *v, uint16_t *desc_idx, k_timeout_t timeout
 
 	if (ret == 0) {
 		*desc_idx = (uint16_t)desc;
-		v->free_desc_n--;
+		K_SPINLOCK(&v->lock) {
+			v->free_desc_n--;
+		}
 	}
 
 	return ret;
@@ -193,5 +200,7 @@ int virtq_get_free_desc(struct virtq *v, uint16_t *desc_idx, k_timeout_t timeout
 void virtq_add_free_desc(struct virtq *v, uint16_t desc_idx)
 {
 	k_stack_push(&v->free_desc_stack, desc_idx);
-	v->free_desc_n++;
+	K_SPINLOCK(&v->lock) {
+		v->free_desc_n++;
+	}
 }

--- a/drivers/virtio/virtqueue.c
+++ b/drivers/virtio/virtqueue.c
@@ -94,15 +94,13 @@ void virtq_free(struct virtq *v)
 	k_free(v->desc);
 }
 
-static int virtq_add_available(struct virtq *v, uint16_t desc_idx)
+static void virtq_add_available(struct virtq *v, uint16_t desc_idx)
 {
-	uint16_t new_idx = sys_le16_to_cpu(v->avail->idx) % v->num;
+	uint16_t idx = sys_le16_to_cpu(v->avail->idx);
 
-	v->avail->ring[new_idx] = sys_cpu_to_le16(desc_idx);
+	v->avail->ring[idx & (v->num - 1)] = sys_cpu_to_le16(desc_idx);
 	barrier_dmem_fence_full();
-	v->avail->idx = sys_cpu_to_le16(sys_le16_to_cpu(v->avail->idx) + 1);
-
-	return 0;
+	v->avail->idx = sys_cpu_to_le16(idx + 1);
 }
 
 static void virtq_return_desc_chain(struct virtq *v, uint16_t head, uint16_t count)

--- a/drivers/virtio/virtqueue.c
+++ b/drivers/virtio/virtqueue.c
@@ -108,6 +108,10 @@ int virtq_add_buffer_chain(
 	uint16_t device_readable_count, virtq_receive_callback cb, void *cb_opaque,
 	k_timeout_t timeout)
 {
+	if (bufs_size == 0) {
+		return -EINVAL;
+	}
+
 	uint64_t total_len = 0;
 
 	for (int i = 0; i < bufs_size; i++) {

--- a/drivers/virtio/virtqueue.c
+++ b/drivers/virtio/virtqueue.c
@@ -94,9 +94,9 @@ void virtq_free(struct virtq *v)
 
 static int virtq_add_available(struct virtq *v, uint16_t desc_idx)
 {
-	uint16_t new_idx_le = sys_cpu_to_le16(sys_le16_to_cpu(v->avail->idx) % v->num);
+	uint16_t new_idx = sys_le16_to_cpu(v->avail->idx) % v->num;
 
-	v->avail->ring[new_idx_le] = sys_cpu_to_le16(desc_idx);
+	v->avail->ring[new_idx] = sys_cpu_to_le16(desc_idx);
 	barrier_dmem_fence_full();
 	v->avail->idx = sys_cpu_to_le16(sys_le16_to_cpu(v->avail->idx) + 1);
 
@@ -140,28 +140,23 @@ int virtq_add_buffer_chain(
 		 */
 		virtq_get_free_desc(v, &desc, timeout);
 
-		uint16_t desc_le = sys_cpu_to_le16(desc);
-
 		if (head == VIRTQ_DESC_NEXT_SENTINEL) {
 			head = desc;
 		}
-		v->desc[desc_le].addr = k_mem_phys_addr(bufs[buf_n].addr);
-		v->desc[desc_le].len = bufs[buf_n].len;
-		if (buf_n < device_readable_count) {
-			v->desc[desc_le].flags = 0;
-		} else {
-			v->desc[desc_le].flags = VIRTQ_DESC_F_WRITE;
-		}
+
+		uint16_t flags = buf_n < device_readable_count ? 0 : VIRTQ_DESC_F_WRITE;
+
 		if (buf_n < bufs_size - 1) {
-			v->desc[desc_le].flags |= VIRTQ_DESC_F_NEXT;
+			flags |= VIRTQ_DESC_F_NEXT;
 		} else {
-			v->desc[desc_le].next = 0;
+			v->desc[desc].next = 0;
 		}
+		v->desc[desc].addr = sys_cpu_to_le64(k_mem_phys_addr(bufs[buf_n].addr));
+		v->desc[desc].len = sys_cpu_to_le32(bufs[buf_n].len);
+		v->desc[desc].flags = sys_cpu_to_le16(flags);
 
 		if (prev_desc != VIRTQ_DESC_NEXT_SENTINEL) {
-			uint16_t prev_desc_le = sys_cpu_to_le16(prev_desc);
-
-			v->desc[prev_desc_le].next = desc_le;
+			v->desc[prev_desc].next = sys_cpu_to_le16(desc);
 		}
 
 		prev_desc = desc;

--- a/drivers/virtio/virtqueue.c
+++ b/drivers/virtio/virtqueue.c
@@ -50,7 +50,7 @@ int virtq_create(struct virtq *v, size_t size)
 		descriptor_table_size + available_ring_size + used_ring_pad + used_ring_size;
 	size_t recv_cbs_pad = WB_UP(shared_size) - shared_size;
 	size_t recv_cbs_size = recv_cbs_pad + sizeof(struct virtq_receive_callback_entry) * size;
-	size_t v_size = shared_size + recv_cbs_size;
+	size_t v_size = shared_size + recv_cbs_size + size * sizeof(stack_data_t);
 
 	uint8_t *v_area = k_aligned_alloc(16, v_size);
 
@@ -77,7 +77,10 @@ int virtq_create(struct virtq *v, size_t size)
 
 	v->last_used_idx = 0;
 
-	k_stack_alloc_init(&v->free_desc_stack, size);
+	/* pointer-aligned as recv_cbs starts WB_UP()-aligned and holds pointer pairs */
+	stack_data_t *stack_buf = (stack_data_t *)(v_area + shared_size + recv_cbs_size);
+
+	k_stack_init(&v->free_desc_stack, stack_buf, size);
 	for (uint16_t i = 0; i < size; i++) {
 		k_stack_push(&v->free_desc_stack, i);
 	}
@@ -89,7 +92,6 @@ int virtq_create(struct virtq *v, size_t size)
 void virtq_free(struct virtq *v)
 {
 	k_free(v->desc);
-	k_stack_cleanup(&v->free_desc_stack);
 }
 
 static int virtq_add_available(struct virtq *v, uint16_t desc_idx)

--- a/drivers/virtio/virtqueue.c
+++ b/drivers/virtio/virtqueue.c
@@ -27,7 +27,7 @@ LOG_MODULE_REGISTER(virtio, CONFIG_VIRTIO_LOG_LEVEL);
 #define VIRTQ_DESC_NEXT_SENTINEL 0xffff
 
 /* According to the spec 2.7.5.2 the maximum size of descriptor chain is 4GB */
-#define MAX_DESCRIPTOR_CHAIN_LENGTH ((uint64_t)1 << 32)
+#define MAX_DESCRIPTOR_CHAIN_LENGTH BIT64(32)
 
 int virtq_create(struct virtq *v, size_t size)
 {
@@ -54,7 +54,7 @@ int virtq_create(struct virtq *v, size_t size)
 
 	uint8_t *v_area = k_aligned_alloc(16, v_size);
 
-	if (!v_area) {
+	if (v_area == NULL) {
 		LOG_ERR("unable to allocate virtqueue");
 		return -ENOMEM;
 	}
@@ -74,8 +74,6 @@ int virtq_create(struct virtq *v, size_t size)
 	 * Zephyr, so we don't have to handle it here
 	 */
 	memset(v_area, 0, v_size);
-
-	v->last_used_idx = 0;
 
 	/* pointer-aligned as recv_cbs starts WB_UP()-aligned and holds pointer pairs */
 	stack_data_t *stack_buf = (stack_data_t *)(v_area + shared_size + recv_cbs_size);


### PR DESCRIPTION
Fixes and cleanups for the split virtqueue implementation:

- fix endianness handling: little-endian converted values were used as
  array indexes and descriptor fields were stored without conversion
  (no functional change on little-endian targets)
- reject empty buffer chains, which would write `recv_cbs[0xffff]` out
  of bounds and publish a bogus descriptor index to the device
- do not block while holding the virtqueue spinlock: with `K_FOREVER`
  and no free descriptors, `virtq_add_buffer_chain()` slept in
  `k_stack_pop()` with the lock held; descriptors are now popped before
  taking the lock, which also shrinks the critical section to the
  available ring update
- use a single allocation per virtqueue instead of a second, hidden
  `k_malloc()` in `k_stack_alloc_init()` whose return value was not
  checked
- streamline the available ring update (read `avail->idx` from shared
  memory once, mask instead of modulo)
- minor cleanups (`BIT64()`, `NULL` comparison, redundant store)