### PR TITLE
kernel: mm: fix always-true VM base check when base is 0

### DIFF
--- a/include/zephyr/kernel/internal/mm.h
+++ b/include/zephyr/kernel/internal/mm.h
@@ -120,7 +120,12 @@ static inline uintptr_t k_mem_phys_addr(void *virt)
 	__ASSERT(sys_mm_is_virt_addr_in_range(virt),
 		 "address %p not in permanent mappings", virt);
 #elif defined(CONFIG_MMU)
+#if CONFIG_KERNEL_VM_BASE != 0
+	/* Skipped when the VM base is 0, where the comparison is always true and
+	 * some compilers warn about it (-Wtype-limits).
+	 */
 	__ASSERT(addr >= (uintptr_t)CONFIG_KERNEL_VM_BASE, "address %p below VM base", virt);
+#endif /* CONFIG_KERNEL_VM_BASE != 0 */
 	__ASSERT((addr - (uintptr_t)CONFIG_KERNEL_VM_BASE) < (uintptr_t)CONFIG_KERNEL_VM_SIZE,
 		 "address %p above VM limit", virt);
 #else


### PR DESCRIPTION
Commit 0f8f4b534451 ("kernel: mm: fix address bounds check in
k_mem_phys_addr()") replaced the preprocessor-guarded bounds check
with two plain __ASSERT() statements. That dropped the
CONFIG_KERNEL_VM_BASE != 0 guard around the lower-bound check, so on
platforms where the VM base is 0 the comparison

	addr >= (uintptr_t)CONFIG_KERNEL_VM_BASE

is always true. Most of the tree does not build with -Wtype-limits,
but modules that add -Wextra -Werror (mbedtls) and pull in kernel.h
through <zephyr/posix/sys/socket.h> fail to compile:

  error: comparison of unsigned expression in '>= 0' is always true
         [-Werror=type-limits]

Restore the guard, but around the whole statement rather than inside
the macro argument list, so the C11 6.10.3 undefined behavior that
0f8f4b534451 removed does not come back. Nothing is lost when the
base is 0: no address can be below it, and the unsigned-subtraction
upper-bound check is exact. The 64-bit overflow fix is untouched.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
