### PR TITLE
kernel: userspace: reject size overflow in dynamic object allocation

### DIFF
--- a/kernel/userspace/userspace.c
+++ b/kernel/userspace/userspace.c
@@ -365,6 +365,14 @@ static struct k_object *dynamic_object_create(enum k_objects otype, size_t align
 		}
 
 		adjusted_size = STACK_ELEMENT_DATA_SIZE(size);
+		if (adjusted_size < size) {
+			/* The size adjustment above overflowed, which would
+			 * hand out an allocation smaller than requested.
+			 */
+			k_free(dyn);
+			return NULL;
+		}
+
 		dyn->data = z_thread_aligned_alloc(DYN_OBJ_DATA_ALIGN_K_THREAD_STACK,
 						     adjusted_size);
 		if (dyn->data == NULL) {
@@ -402,7 +410,14 @@ static struct k_object *dynamic_object_create(enum k_objects otype, size_t align
 		dyn->kobj.data.stack_size = adjusted_size;
 #endif /* CONFIG_GEN_PRIV_STACKS */
 	} else {
-		dyn->data = z_thread_aligned_alloc(align, obj_size_get(otype) + size);
+		size_t total_size = obj_size_get(otype) + size;
+
+		if (total_size < size) {
+			k_free(dyn);
+			return NULL;
+		}
+
+		dyn->data = z_thread_aligned_alloc(align, total_size);
 		if (dyn->data == NULL) {
 			k_free(dyn);
 			return NULL;


### PR DESCRIPTION
dynamic_object_create() computed the allocation size as
obj_size_get(otype) + size, where size comes straight from user mode via
the k_object_alloc_size() syscall - the verifier is a bare pass-through and
z_object_alloc() only range-checks otype. A size close to SIZE_MAX wraps,
so the allocation is small while the object is tagged with the requested
type; the matching init syscall then writes a full object over it. The
K_OBJ_THREAD_STACK_ELEMENT branch has the same problem through
STACK_ELEMENT_DATA_SIZE(), which rounds up and adds overhead.

Reject both overflows and free the descriptor.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>

Fixes: #116387