### PR TITLE
kernel: device: restrict the device_deinit syscall to driver objects

### DIFF
--- a/kernel/device.c
+++ b/kernel/device.c
@@ -226,7 +226,7 @@ int z_impl_device_deinit(const struct device *dev)
 #ifdef CONFIG_USERSPACE
 static inline int z_vrfy_device_deinit(const struct device *dev)
 {
-	K_OOPS(K_SYSCALL_OBJ_INIT(dev, K_OBJ_ANY));
+	K_OOPS(K_SYSCALL_OBJ_INIT(dev, K_OBJ_DRIVER_ANY));
 
 	return z_impl_device_deinit(dev);
 }


### PR DESCRIPTION
z_vrfy_device_deinit() validated its argument with K_OBJ_ANY, so any kernel
object the calling thread has access to could be passed as a struct device.
z_impl_device_deinit() then calls dev->ops.deinit(dev), an indirect call
through a function pointer read out of the confused object, giving user
mode an arbitrary call primitive when CONFIG_DEVICE_DEINIT_SUPPORT=y.

Use K_OBJ_DRIVER_ANY, matching z_vrfy_device_init() and
z_vrfy_device_is_ready().

Signed-off-by: Anas Nashif <anas.nashif@intel.com>

Fixes: #116388