### PR TITLE
twister: add --load-filter to reuse a precomputed filter map

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -134,6 +134,20 @@ Artificially long but functional example:
     )
 
     case_select.add_argument(
+        "--load-filter",
+        metavar="FILENAME",
+        action="store",
+        help="Load a precomputed set of filtered test instances from a prior "
+             "'twister.json'/'testplan.json' ('%(metavar)s'). Any (testsuite, "
+             "platform) pair marked 'filtered' there is treated as filtered "
+             "immediately, skipping its CMake configure filter step. This trades "
+             "a small staleness risk for a large reduction in configure time on "
+             "boards where most configurations filter out. Regenerate the file "
+             "(e.g. from a prior run's 'twister.json') whenever Kconfig or "
+             "devicetree that affects filtering changes."
+    )
+
+    case_select.add_argument(
         "-T", "--testsuite-root", action="append", default=[], type = norm_path,
         help="Base directory to recursively search for test cases. All "
              "testcase.yaml files under here will be processed. May be "

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -67,6 +67,9 @@ class Filters:
     MODULE = 'Module filter'
     # in case of missing env. variable required for a platform
     ENVIRONMENT = 'Environment filter'
+    # instance marked filtered from a precomputed --load-filter map, so its
+    # CMake configure filter step is skipped this run.
+    CACHED = 'cached filter'
 
 
 class TestLevel:
@@ -186,6 +189,11 @@ class TestPlan:
         self.instance_fail_count = 0
         self.warnings = 0
 
+        # (testsuite_name, platform_name) -> reason, populated from --load-filter.
+        # Any pair in here is marked filtered in apply_filters() so its CMake
+        # configure filter step is skipped.
+        self.load_filter_map: dict[tuple[str, str], str] = {}
+
         self.scenarios = []
 
         self.hwm: HardwareMap = env.hwm
@@ -244,6 +252,11 @@ class TestPlan:
 
         self.report_duplicates()
         self.levels = self.test_config.get_levels(self.scenarios)
+
+        # Load a precomputed filter map so apply_filters() can short-circuit
+        # CMake configure for known-filtered (testsuite, platform) pairs.
+        if self.options.load_filter:
+            self.load_filter_from_file(self.options.load_filter)
 
         # handle quarantine
         ql = self.options.quarantine_list
@@ -750,6 +763,33 @@ class TestPlan:
             if not matched_quarantine and self.options.quarantine_verify:
                 instance.add_filter("Not under quarantine", Filters.CMD_LINE)
 
+    def load_filter_from_file(self, file):
+        """Populate self.load_filter_map from a prior twister.json/testplan.json.
+
+        Every testsuite entry whose status is 'filtered' is recorded as a
+        (testsuite_name, platform_name) -> reason pair. apply_filters() then
+        marks the matching instances filtered up front, so their CMake configure
+        filter step is skipped this run.
+        """
+        try:
+            with open(file) as json_filter:
+                jf = json.load(json_filter)
+        except FileNotFoundError as e:
+            logger.error(f"{e}")
+            return 1
+        count = 0
+        for ts in jf.get("testsuites", []):
+            if TwisterStatus(ts.get("status")) != TwisterStatus.FILTER:
+                continue
+            name = ts.get("name")
+            platform = ts.get("platform")
+            if not name or not platform:
+                continue
+            self.load_filter_map[(name, platform)] = ts.get("reason") or Filters.CACHED
+            count += 1
+        logger.info(f"Loaded {count} cached filter entries from {file}")
+        return 0
+
     def load_from_file(self, file, filter_platform=None):
         if filter_platform is None:
             filter_platform = []
@@ -1028,6 +1068,14 @@ class TestPlan:
                     self.options,
                     self.hwm
                 )
+
+                # --load-filter: if a prior run recorded this (testsuite,
+                # platform) pair as filtered, mark it filtered now so it skips
+                # the CMake configure filter step below.
+                if self.load_filter_map:
+                    cached_reason = self.load_filter_map.get((ts.name, plat.name))
+                    if cached_reason is not None:
+                        instance.add_filter(cached_reason, Filters.CACHED)
 
                 if not force_platform and self.check_platform(plat,exclude_platform):
                     instance.add_filter("Platform is excluded on command line.", Filters.CMD_LINE)

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -19,7 +19,12 @@ from twisterlib.platform import Platform
 from twisterlib.quarantine import Quarantine
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testinstance import TestInstance
-from twisterlib.testplan import TestConfiguration, TestPlan, change_skip_to_error_if_integration
+from twisterlib.testplan import (
+    Filters,
+    TestConfiguration,
+    TestPlan,
+    change_skip_to_error_if_integration,
+)
 from twisterlib.testsuite import TestSuite
 from twisterlib.testsuitedata import RequiredApplication
 
@@ -789,7 +794,8 @@ def test_testplan_discover(
         test_pattern=[],
         test='ts1',
         quarantine_list=[tmp_path / qf for qf in ql],
-        quarantine_verify=qv
+        quarantine_verify=qv,
+        load_filter=None
     )
     testplan.testsuites = {
         'ts1': mock.Mock(id=1),
@@ -1957,6 +1963,53 @@ def test_testplan_load_from_file_unknown_platform():
         testplan.load_from_file('dummy.yaml')
 
     assert 'unknown platform Unknown Platform' in str(exc.value)
+
+
+def test_testplan_load_filter_from_file():
+    testplan = TestPlan(env=mock_twister_env())
+
+    filter_data = """\
+{
+    "testsuites": [
+        {
+            "name": "tests/foo/filtered",
+            "platform": "plat_a",
+            "status": "filtered",
+            "reason": "runtime filter"
+        },
+        {
+            "name": "tests/foo/no_reason",
+            "platform": "plat_b",
+            "status": "filtered"
+        },
+        {
+            "name": "tests/foo/passed",
+            "platform": "plat_a",
+            "status": "passed"
+        }
+    ]
+}
+"""
+
+    with mock.patch('builtins.open', mock.mock_open(read_data=filter_data)):
+        ret = testplan.load_filter_from_file('dummy.json')
+
+    assert ret == 0
+    # Only 'filtered' entries are recorded, keyed by (name, platform).
+    assert testplan.load_filter_map == {
+        ('tests/foo/filtered', 'plat_a'): 'runtime filter',
+        ('tests/foo/no_reason', 'plat_b'): Filters.CACHED,
+    }
+
+
+def test_testplan_load_filter_from_file_missing():
+    testplan = TestPlan(env=mock_twister_env())
+
+    with mock.patch('builtins.open', side_effect=FileNotFoundError):
+        ret = testplan.load_filter_from_file('missing.json')
+
+    assert ret == 1
+    assert testplan.load_filter_map == {}
 
 
 def test_testplan_add_instances():


### PR DESCRIPTION
On boards where most `(testsuite, platform)` configurations filter out at
CMake-configure time (runtime `filter:` expressions, missing devicetree
nodes, etc.), twister still performs a full CMake configure per instance
only to discard the result. Those filter decisions are stable between runs
as long as the underlying Kconfig/devicetree does not change.

This PR adds a `--load-filter FILENAME` option that loads a precomputed set
of filtered instances from a prior `twister.json`/`testplan.json`. During
`apply_filters()`, any `(testsuite, platform)` pair recorded as `filtered`
in that file is marked filtered up front (new `Filters.CACHED` type), so its
CMake configure filter step is skipped for the run.

### Motivation

On platforms where a large fraction of configurations filter out only after
CMake configure runs, that configure time dominates a build-stage run. Since
those decisions rarely change, reusing a previously-computed filter set
avoids repeating the work.

### Behavior / safety

- **Opt-in.** No behavior change unless `--load-filter` is passed.
- Trades a small staleness risk for a large reduction in configure time.
  Regenerate the map (e.g. from a prior run's `twister.json`) whenever
  Kconfig or devicetree that affects filtering changes.
- Only entries whose status is `filtered` are consumed; the recorded reason
  is preserved (falling back to a generic `cached filter` reason).

### Tests

Adds unit tests for `load_filter_from_file()` covering filtered-only
selection, the default reason, and missing-file handling.
