### PR TITLE
twister: include the handler's stderr in the JSON report

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -348,6 +348,7 @@ class JsonReport:
                 continue
             suite = {}
             handler_log = os.path.join(instance.build_dir, "handler.log")
+            handler_stderr_log = os.path.join(instance.build_dir, "handler_stderr.log")
             script_log = os.path.join(instance.build_dir, "twister_harness.log")
             build_log = os.path.join(instance.build_dir, "build.log")
             device_log = os.path.join(instance.build_dir, "device.log")
@@ -396,6 +397,10 @@ class JsonReport:
                     suite["log"] = self.process_log(device_log)
                 else:
                     suite["log"] = self.process_log(build_log)
+
+                stderr_output = self.process_log(handler_stderr_log)
+                if stderr_output.strip():
+                    suite["log"] = f"{suite['log']}\n{stderr_output}"
 
                 suite["reason"] = self.get_detailed_reason(instance.reason, suite["log"])  # type: ignore
                 # update the reason to get more details also in other reports (e.g. junit)


### PR DESCRIPTION
BinaryHandler captures the test binary's stderr to its own file,
handler_stderr.log, which no report ever reads. Whatever the
binary wrote there is therefore absent from twister.json and from
everything derived from it.

This is most visible with UndefinedBehaviorSanitizer on
native_sim. It writes its diagnostics to stderr rather than
stdout, so a run it aborts is recorded as a bare "rc=1": the
report says the test failed and nothing at all about why, even
though the reason was captured and sits on disk next to the
build. The same applies to any crash or loader failure that
reports on stderr.

Append the captured stderr to the log already selected for a
failing instance, rather than replacing it, so the stdout
transcript that shows how far the test got is preserved and the
stderr diagnostic explaining the failure follows it. Only failing
instances are affected, and only when stderr is non-empty, so
passing runs and reports for handlers that do not capture stderr
are unchanged.
