### PR TITLE
drivers/pwm/it51xxx: support HW dimming mode for pwm driver

### DIFF
--- a/boards/ite/it51xxx_evb/it51xxx_evb_it51526aw.dts
+++ b/boards/ite/it51xxx_evb/it51xxx_evb_it51526aw.dts
@@ -110,6 +110,17 @@
 	pinctrl-names = "default";
 };
 
+/* test pwm dimming mode */
+&pwm1 {
+	status = "okay";
+	prescaler-cx = <PWM_PRESCALER_C7>;
+	max-dimming-duty = <PWM_DIMMING_DC_FFH>;
+	dimming-duty-increase = <PWM_DIMMING_DC_STEP_8H>;
+	dimming-duty-decrease = <PWM_DIMMING_DC_STEP_8H>;
+	pinctrl-0 = <&pwm1_gpa1_default>;
+	pinctrl-names = "default";
+};
+
 /* test fan */
 &pwm7 {
 	status = "okay";

--- a/drivers/pwm/pwm_ite_it51xxx.c
+++ b/drivers/pwm/pwm_ite_it51xxx.c
@@ -23,6 +23,8 @@ LOG_MODULE_REGISTER(pwm_ite_it51xxx, CONFIG_PWM_LOG_LEVEL);
 #define PWM_CTX_MIN     100
 #define PWM_FREQ        IT51XXX_EC_FREQ
 #define PWM_CH_SPS_MASK GENMASK(1, 0)
+#define IT51XXX_DIMMING_CH_MASK     (BIT(PWM_CHANNEL_0) | BIT(PWM_CHANNEL_1) | BIT(PWM_CHANNEL_7))
+#define IS_DIMMING_SUPPORTED_CH(ch) (BIT(ch) & IT51XXX_DIMMING_CH_MASK)
 
 /* 0x00/0x10/0x20/0x30/0x40/0x50/0x60/0x70: PWM channel 0~7 duty cycle low byte */
 #define REG_PWM_CH_DC_L  0x00
@@ -35,6 +37,14 @@ LOG_MODULE_REGISTER(pwm_ite_it51xxx, CONFIG_PWM_LOG_LEVEL);
 #define PWM_CH_INVP      BIT(0)
 /* 0x05/0x15/0x25/0x35/0x45/0x55/0x65/0x75: PWM channel 0~7 select prescaler source */
 #define REG_PWM_CH_SPS   0x05
+/* 0x08/0x18/0x78: PWM channel 0/1/7 dimming control 0 */
+#define REG_PWM_CH_DIM_CONTROL_0 0x08
+#define PWM_CH_DIMMING_EN        BIT(0)
+/* 0x09/0x19/0x79: PWM channel 0/1/7 dimming control 1 */
+#define REG_PWM_CH_DIM_CONTROL_1 0x09
+#define PWM_CH_DIM_MAX_DC        (BIT(4) | BIT(5))
+#define PWM_CH_DIM_DC_DECREASE   (BIT(2) | BIT(3))
+#define PWM_CH_DIM_DC_INCREASE   (BIT(0) | BIT(1))
 
 /* 0x84/0x88/0x8C: PWM prescaler 4/6/7 clock low byte */
 #define REG_PWM_PXC_L(prs_sel)   (0x04 * (prs_sel))
@@ -58,6 +68,14 @@ struct pwm_it51xxx_cfg {
 	uintptr_t base_prs;
 	/* Select PWM prescaler that output to PWM channel */
 	int prs_sel;
+	/* Dimming mode enabled flag */
+	bool enable_dimming;
+	/* Setting pwm max duty cycle of dimming mode (only support pwm0/1/7) */
+	int max_dimming_duty;
+	/* Setting pwm duty cycle increase step of dimming mode (only support pwm0/1/7) */
+	int dimming_duty_increase;
+	/* Setting pwm duty cycle decrease step of dimming mode (only support pwm0/1/7) */
+	int dimming_duty_decrease;
 	/* PWM alternate configuration */
 	const struct pinctrl_dev_config *pcfg;
 };
@@ -110,6 +128,53 @@ static int pwm_it51xxx_get_cycles_per_sec(const struct device *dev, uint32_t cha
 	return 0;
 }
 
+static int pwm_it51xxx_set_dimming_mode(const struct device *dev)
+{
+	const struct pwm_it51xxx_cfg *config = dev->config;
+	const uintptr_t base_ch = config->base_ch;
+	const uintptr_t base_prs = config->base_prs;
+	int prs_sel = config->prs_sel;
+	uint8_t reg_val;
+
+	reg_val = sys_read8(base_ch + REG_PWM_CH_DIM_CONTROL_0);
+	if (reg_val & PWM_CH_DIMMING_EN) {
+		/*
+		 * To avoid flicker in dimming mode,
+		 * if registers are already setup then return.
+		 */
+		return 0;
+	}
+
+	/* PWM channel clock source gating before configuring */
+	pwm_enable(dev, 0);
+
+	/* Select clock source from 32768Hz to prescaler */
+	reg_val = sys_read8(base_prs + REG_PWM_PXCSS_L(prs_sel));
+	sys_write8(reg_val & ~PWM_PCFS_EC, base_prs + REG_PWM_PXCSS_L(prs_sel));
+
+	/* Set PxC[15:0] value 0000h results in a divisor 1 */
+	sys_write8(0x0, base_prs + REG_PWM_PXC_L(prs_sel));
+	sys_write8(0x0, base_prs + REG_PWM_PXC_H(prs_sel));
+
+	/* Set dimming mode duty cycle and duty-steps */
+	reg_val = sys_read8(base_ch + REG_PWM_CH_DIM_CONTROL_1);
+	reg_val &= ~(PWM_CH_DIM_MAX_DC | PWM_CH_DIM_DC_DECREASE |
+		     PWM_CH_DIM_DC_INCREASE);
+	reg_val |= (uint8_t)((config->max_dimming_duty << 4) |
+			     (config->dimming_duty_decrease << 2) |
+			     (config->dimming_duty_increase));
+	sys_write8(reg_val, base_ch + REG_PWM_CH_DIM_CONTROL_1);
+
+	/* Enable PWM channel dimming mode */
+	reg_val = sys_read8(base_ch + REG_PWM_CH_DIM_CONTROL_0);
+	sys_write8(reg_val | PWM_CH_DIMMING_EN, base_ch + REG_PWM_CH_DIM_CONTROL_0);
+
+	/* PWM channel clock source not gating */
+	pwm_enable(dev, 1);
+
+	return 0;
+}
+
 static int pwm_it51xxx_set_cycles(const struct device *dev, uint32_t channel,
 				  uint32_t period_cycles, uint32_t pulse_cycles, pwm_flags_t flags)
 {
@@ -121,6 +186,28 @@ static int pwm_it51xxx_set_cycles(const struct device *dev, uint32_t channel,
 	uint32_t actual_freq = 0xffffffff, target_freq, deviation, dc_val;
 	uint64_t pwm_clk_src;
 	uint8_t reg_val;
+
+	/* If the dimming mode is enabled on this PWM channel */
+	if (config->enable_dimming) {
+		/* Run dimming mode */
+		if (flags & PWM_IT51XXX_DIMMING_MODE) {
+			return pwm_it51xxx_set_dimming_mode(dev);
+		}
+
+		/* Or run pwm mode */
+		reg_val = sys_read8(base_ch + REG_PWM_CH_DIM_CONTROL_0);
+		if (reg_val & PWM_CH_DIMMING_EN) {
+			/*
+			 * To avoid flicker in pwm mode, disable clock
+			 * source only during mode switch from dimming.
+			 */
+			pwm_enable(dev, 0);
+
+			/* Disable PWM channel dimming mode */
+			sys_write8(reg_val & ~PWM_CH_DIMMING_EN,
+				   base_ch + REG_PWM_CH_DIM_CONTROL_0);
+		}
+	}
 
 	/* Select PWM inverted polarity (ex. active-low pulse) */
 	if (flags & PWM_POLARITY_INVERTED) {
@@ -295,12 +382,20 @@ static DEVICE_API(pwm, pwm_it51xxx_api) = {
 
 /* Device Instance */
 #define PWM_IT51XXX_INIT(inst)                                                                     \
+	BUILD_ASSERT(!DT_INST_NODE_HAS_PROP(inst, max_dimming_duty) ||                             \
+			     IS_DIMMING_SUPPORTED_CH(DT_INST_PROP(inst, channel)),                 \
+		     "PWM dimming mode properties only support on PWM 0, 1, or 7!");               \
+                                                                                                   \
 	PINCTRL_DT_INST_DEFINE(inst);                                                              \
                                                                                                    \
 	static const struct pwm_it51xxx_cfg pwm_it51xxx_cfg_##inst = {                             \
 		.base_ch = DT_INST_REG_ADDR_BY_IDX(inst, 0),                                       \
 		.base_prs = DT_INST_REG_ADDR_BY_IDX(inst, 1),                                      \
 		.prs_sel = DT_PROP(DT_INST(inst, ite_it51xxx_pwm), prescaler_cx),                  \
+		.enable_dimming = DT_INST_NODE_HAS_PROP(inst, max_dimming_duty),                   \
+		.max_dimming_duty = DT_INST_PROP_OR(inst, max_dimming_duty, 0),                    \
+		.dimming_duty_increase = DT_INST_PROP_OR(inst, dimming_duty_increase, 0),          \
+		.dimming_duty_decrease = DT_INST_PROP_OR(inst, dimming_duty_decrease, 0),          \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                      \
 	};                                                                                         \
                                                                                                    \

--- a/dts/bindings/pwm/ite,it51xxx-pwm.yaml
+++ b/dts/bindings/pwm/ite,it51xxx-pwm.yaml
@@ -11,14 +11,41 @@ properties:
   reg:
     required: true
 
+  channel:
+    type: int
+    required: true
+    enum: [0, 1, 2, 3, 4, 5, 6, 7]
+    description: pwm output channel
+
   prescaler-cx:
     type: int
     required: true
-    enum:
-      - 1
-      - 2
-      - 3
+    enum: [1, 2, 3]
     description: 1 = PWM_PRESCALER_C4, 2 = PWM_PRESCALER_C6, 3 = PWM_PRESCALER_C7
+
+  max-dimming-duty:
+    type: int
+    enum: [0, 1, 2, 3]
+    description: |
+     Setting pwm max duty cycle of dimming mode (only pwm0/1/7 support),
+     0 = PWM_DIMMING_DC_40H, 1 = PWM_DIMMING_DC_80H, 2 = PWM_DIMMING_DC_C0H,
+     3 = PWM_DIMMING_DC_FFH
+
+  dimming-duty-increase:
+    type: int
+    enum: [0, 1, 2, 3]
+    description: |
+     Setting pwm duty cycle increase step of dimming mode (only pwm0/1/7 support),
+     0 = PWM_DIMMING_DC_STEP_1H, 1 = PWM_DIMMING_DC_STEP_2H, 2 = PWM_DIMMING_DC_STEP_4H,
+     3 = PWM_DIMMING_DC_STEP_8H
+
+  dimming-duty-decrease:
+    type: int
+    enum: [0, 1, 2, 3]
+    description: |
+     Setting pwm duty cycle decrease step of dimming mode (only pwm0/1/7 support),
+     0 = PWM_DIMMING_DC_STEP_1H, 1 = PWM_DIMMING_DC_STEP_2H, 2 = PWM_DIMMING_DC_STEP_4H,
+     3 = PWM_DIMMING_DC_STEP_8H
 
   pinctrl-0:
     required: true

--- a/dts/riscv/ite/it51xxx.dtsi
+++ b/dts/riscv/ite/it51xxx.dtsi
@@ -1283,6 +1283,7 @@
 			compatible = "ite,it51xxx-pwm";
 			reg = <0x00f04600 0xf
 			       0x00f04680 0x80>;
+			channel = <0>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -1291,6 +1292,7 @@
 			compatible = "ite,it51xxx-pwm";
 			reg = <0x00f04610 0xf
 			       0x00f04680 0x80>;
+			channel = <1>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -1299,6 +1301,7 @@
 			compatible = "ite,it51xxx-pwm";
 			reg = <0x00f04620 0xf
 			       0x00f04680 0x80>;
+			channel = <2>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -1307,6 +1310,7 @@
 			compatible = "ite,it51xxx-pwm";
 			reg = <0x00f04630 0xf
 			       0x00f04680 0x80>;
+			channel = <3>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -1315,6 +1319,7 @@
 			compatible = "ite,it51xxx-pwm";
 			reg = <0x00f04640 0xf
 			       0x00f04680 0x80>;
+			channel = <4>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -1323,6 +1328,7 @@
 			compatible = "ite,it51xxx-pwm";
 			reg = <0x00f04650 0xf
 			       0x00f04680 0x80>;
+			channel = <5>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -1331,6 +1337,7 @@
 			compatible = "ite,it51xxx-pwm";
 			reg = <0x00f04660 0xf
 			       0x00f04680 0x80>;
+			channel = <6>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -1339,6 +1346,7 @@
 			compatible = "ite,it51xxx-pwm";
 			reg = <0x00f04670 0xf
 			       0x00f04680 0x80>;
+			channel = <7>;
 			status = "disabled";
 			#pwm-cells = <3>;
 		};

--- a/include/zephyr/dt-bindings/pwm/it51xxx_pwm.h
+++ b/include/zephyr/dt-bindings/pwm/it51xxx_pwm.h
@@ -23,12 +23,46 @@
 #define PWM_CHANNEL_6		6
 #define PWM_CHANNEL_7		7
 
-/*
- * Provides a type to hold PWM configuration flags.
+/**
+ * @name PWM Dimming Duty Cycle Values
+ * @{
+ */
+/** PWM dimming maximum duty cycle 25% */
+#define PWM_DIMMING_DC_40H 0
+/** PWM dimming maximum duty cycle 50% */
+#define PWM_DIMMING_DC_80H 1
+/** PWM dimming maximum duty cycle 75% */
+#define PWM_DIMMING_DC_C0H 2
+/** PWM dimming maximum duty cycle 100% */
+#define PWM_DIMMING_DC_FFH 3
+/**@}*/
+
+/**
+ * @name PWM Dimming Duty Increase/Decrease Step Values
+ * @{
+ */
+/** PWM dimming duty change step: 1 */
+#define PWM_DIMMING_DC_STEP_1H 0
+/** PWM dimming duty change step: 2 */
+#define PWM_DIMMING_DC_STEP_2H 1
+/** PWM dimming duty change step: 4 */
+#define PWM_DIMMING_DC_STEP_4H 2
+/** PWM dimming duty change step: 8 */
+#define PWM_DIMMING_DC_STEP_8H 3
+/**@}*/
+
+/**
+ * @brief Provides a type to hold PWM configuration flags.
  *
  * The upper 8 bits are reserved for SoC specific flags.
  *    Output open-drain flag    [ 8 ]
+ *    Output dimming mode flag  [ 9 ]
+ * @{
  */
-#define PWM_IT51XXX_OPEN_DRAIN	BIT(8)
+/** PWM open drain flag */
+#define PWM_IT51XXX_OPEN_DRAIN   BIT(8)
+/** Enable PWM dimming mode flag */
+#define PWM_IT51XXX_DIMMING_MODE BIT(9)
+/**@}*/
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PWM_IT51XXX_PWM_H_ */


### PR DESCRIPTION
Support HW dimming mode for pwm driver, our HW dimming mode only supports pwm channel 0, 1, 7.

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>