### PR TITLE
modules: hal_nordic: nrfx: make NRFX_WDT user selectable

### DIFF
--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -64,57 +64,7 @@ config NRFX_CRACEN_BSIM_SUPPORT
 	bool
 
 config NRFX_EGU
-	bool
-
-config NRFX_EGU0
-	bool "EGU0 driver instance"
-	depends on $(dt_nodelabel_exists,egu0)
-	select NRFX_EGU
-
-config NRFX_EGU1
-	bool "EGU1 driver instance"
-	depends on $(dt_nodelabel_exists,egu1)
-	select NRFX_EGU
-
-config NRFX_EGU2
-	bool "EGU2 driver instance"
-	depends on $(dt_nodelabel_exists,egu2)
-	select NRFX_EGU
-
-config NRFX_EGU3
-	bool "EGU3 driver instance"
-	depends on $(dt_nodelabel_exists,egu3)
-	select NRFX_EGU
-
-config NRFX_EGU4
-	bool "EGU4 driver instance"
-	depends on $(dt_nodelabel_exists,egu4)
-	select NRFX_EGU
-
-config NRFX_EGU5
-	bool "EGU5 driver instance"
-	depends on $(dt_nodelabel_exists,egu5)
-	select NRFX_EGU
-
-config NRFX_EGU10
-	bool "EGU10 driver instance"
-	depends on $(dt_nodelabel_exists,egu10)
-	select NRFX_EGU
-
-config NRFX_EGU20
-	bool "EGU20 driver instance"
-	depends on $(dt_nodelabel_exists,egu20)
-	select NRFX_EGU
-
-config NRFX_EGU020
-	bool "EGU020 driver instance"
-	depends on $(dt_nodelabel_exists,egu020)
-	select NRFX_EGU
-
-config NRFX_EGU130
-	bool "EGU130 driver instance"
-	depends on $(dt_nodelabel_exists,egu130)
-	select NRFX_EGU
+	bool "EGU driver"
 
 config NRFX_GPIOTE
 	bool "GPIOTE driver"

--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -288,7 +288,7 @@ config NRFX_USBREG
 	depends on $(dt_nodelabel_exists,usbreg)
 
 config NRFX_WDT
-	bool
+	bool "WDT driver"
 
 menu "Peripheral Resource Sharing module"
 

--- a/modules/hal_nordic/nrfx/nrfx_kconfig.h
+++ b/modules/hal_nordic/nrfx/nrfx_kconfig.h
@@ -101,36 +101,6 @@
 #ifdef CONFIG_NRFX_EGU_LOG
 #define NRFX_EGU_CONFIG_LOG_ENABLED 1
 #endif
-#ifdef CONFIG_NRFX_EGU0
-#define NRFX_EGU0_ENABLED 1
-#endif
-#ifdef CONFIG_NRFX_EGU1
-#define NRFX_EGU1_ENABLED 1
-#endif
-#ifdef CONFIG_NRFX_EGU2
-#define NRFX_EGU2_ENABLED 1
-#endif
-#ifdef CONFIG_NRFX_EGU3
-#define NRFX_EGU3_ENABLED 1
-#endif
-#ifdef CONFIG_NRFX_EGU4
-#define NRFX_EGU4_ENABLED 1
-#endif
-#ifdef CONFIG_NRFX_EGU5
-#define NRFX_EGU5_ENABLED 1
-#endif
-#ifdef CONFIG_NRFX_EGU10
-#define NRFX_EGU10_ENABLED 1
-#endif
-#ifdef CONFIG_NRFX_EGU20
-#define NRFX_EGU20_ENABLED 1
-#endif
-#ifdef CONFIG_NRFX_EGU020
-#define NRFX_EGU020_ENABLED 1
-#endif
-#ifdef CONFIG_NRFX_EGU130
-#define NRFX_EGU130_ENABLED 1
-#endif
 
 #ifdef CONFIG_NRFX_GRTC
 #define NRFX_GRTC_ENABLED 1


### PR DESCRIPTION
Aligned to other nrfx drivers, allows to use nrfx_wdt without Zephyr's watchdog driver.