### PR TITLE
doc: wifi: siwx91x: Document that BG scan ignores channel

### DIFF
--- a/boards/silabs/radio_boards/siwx917/doc/wifi.rst
+++ b/boards/silabs/radio_boards/siwx917/doc/wifi.rst
@@ -196,7 +196,9 @@ The device support **Legacy Roaming**, which comprises the following procedures:
 
 **Current Design**:
 
-   - **BG Scan**: Performed using the Scan API.
+   - **BG Scan**: Performed using the Scan API. The channel parameter in the
+     Scan API is ignored during BG Scan. Channels used for BG Scan are derived
+     from the first foreground scan.
 
    - **Roaming Configuration**: Configured during the first BG Scan. Roaming
      parameters are managed through **Kconfig** options.


### PR DESCRIPTION
The channel parameter in the Scan API is ignored during background scan while connected. Channels for BG scan come from the first foreground scan.