### PR TITLE
drivers: counter: Fix counter_basic_api test failure on NXP devices

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -113,6 +113,11 @@ static int mcux_ccm_on(const struct device *dev,
 		return 0;
 #endif
 #endif
+#if defined(CONFIG_COUNTER_MCUX_TSTMR) && defined(CONFIG_SOC_SERIES_IMXRT118X)
+	case IMX_CCM_SYSCTR_BASE_CLK:
+		CLOCK_EnableClock(kCLOCK_Syscount);
+		return 0;
+#endif
 	default:
 		(void)instance;
 		return 0;
@@ -452,16 +457,25 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 		break;
 #endif
 
-#ifdef CONFIG_COUNTER_MCUX_SYSCTR
-#if defined(CONFIG_SOC_SERIES_IMXRT118X)
+#if (defined(CONFIG_COUNTER_MCUX_SYSCTR) || defined(CONFIG_COUNTER_MCUX_TSTMR)) \
+	&& defined(CONFIG_SOC_SERIES_IMXRT118X)
 	case IMX_CCM_SYSCTR_BASE_CLK:
 		*rate = MHZ(24);
 		return 0;
 	case IMX_CCM_SYSCTR_SLOW_CLK:
+#if defined(CONFIG_COUNTER_MCUX_TSTMR_SYSCTR_BACKEND)
+		/*
+		 * RT1180/RT1189 errata: the SYS_CTR alternate-frequency (slow)
+		 * clock path is unreliable for timestamp reads.  Returning an
+		 * error here forces the misconfiguration to surface at init time
+		 * rather than silently producing inaccurate timestamps.
+		 */
+		return -ENOTSUP;
+#else
 		*rate = 32768U;
 		return 0;
 #endif
-#endif
+#endif /* CONFIG_COUNTER_MCUX_SYSCTR && CONFIG_SOC_SERIES_IMXRT118X */
 
 	default:
 		return -EINVAL;

--- a/drivers/counter/Kconfig.mcux_tstmr
+++ b/drivers/counter/Kconfig.mcux_tstmr
@@ -13,3 +13,15 @@ config COUNTER_MCUX_TSTMR
 	  TSTMR is a 56-bit, free-running up-counter; its frequency is
 	  SoC-specific (see the clock-frequency devicetree property). It does
 	  not provide compare, alarm, top-value, or interrupt functionality.
+
+config COUNTER_MCUX_TSTMR_SYSCTR_BACKEND
+	bool
+	default y
+	depends on COUNTER_MCUX_TSTMR && DT_HAS_NXP_SYSCTR_ENABLED
+	help
+	  Selected automatically when the TSTMR driver is built on a SoC that
+	  also has an nxp,sysctr node enabled.  On these SoCs the TSTMR is a
+	  read-only view of the shared SYS_CTR hardware, so the driver needs
+	  to access SYS_CTR_CONTROL registers to enable and settle the counter.
+	  When this symbol is not set (standalone TSTMR without SYS_CTR, e.g.
+	  MCXW or i.MX8ULP) those register accesses are compiled out entirely.

--- a/drivers/counter/counter_mcux_ctimer.c
+++ b/drivers/counter/counter_mcux_ctimer.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Toby Firth.
+ * Copyright 2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -157,15 +158,27 @@ static int mcux_lpc_ctimer_set_alarm(const struct device *dev, uint8_t chan_id,
 		}
 	}
 
-	data->channels[chan_id].alarm_callback = alarm_cfg->callback;
-	data->channels[chan_id].alarm_user_data = alarm_cfg->user_data;
-
 	ctimer_match_config_t match_config = { .matchValue = ticks,
 					       .enableCounterReset = false,
 					       .enableCounterStop = false,
 					       .outControl = kCTIMER_Output_NoAction,
 					       .outPinInitState = false,
 					       .enableInterrupt = true };
+
+	/*
+	 * A previously cancelled alarm can leave its match value programmed; on
+	 * this SoC the counter reaching that value latches the channel's status
+	 * flag even while the match interrupt is disabled. Mask this channel's
+	 * interrupt and drop any latched flag before registering the callback so
+	 * a stale match cannot be delivered as a spurious expiry. Only the match
+	 * armed by CTIMER_SetupMatch() below, which re-enables the interrupt, can
+	 * then reach the callback.
+	 */
+	CTIMER_DisableInterrupts(config->base, (1U << chan_id));
+	CTIMER_ClearStatusFlags(config->base, (1U << chan_id));
+
+	data->channels[chan_id].alarm_callback = alarm_cfg->callback;
+	data->channels[chan_id].alarm_user_data = alarm_cfg->user_data;
 
 	CTIMER_SetupMatch(config->base, chan_id, &match_config);
 
@@ -178,6 +191,11 @@ static int mcux_lpc_ctimer_cancel_alarm(const struct device *dev, uint8_t chan_i
 	struct mcux_lpc_ctimer_data *data = dev->data;
 
 	CTIMER_DisableInterrupts(config->base, (1 << chan_id));
+	/*
+	 * Drop any match flag latched for this channel (see set_alarm) so a
+	 * cancelled alarm cannot be delivered once the channel is re-armed.
+	 */
+	CTIMER_ClearStatusFlags(config->base, (1U << chan_id));
 
 	data->channels[chan_id].alarm_callback = NULL;
 	data->channels[chan_id].alarm_user_data = NULL;

--- a/drivers/counter/counter_mcux_qtmr.c
+++ b/drivers/counter/counter_mcux_qtmr.c
@@ -19,6 +19,7 @@
 #include <zephyr/irq.h>
 #include <fsl_qtmr.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/sys/barrier.h>
 
 LOG_MODULE_REGISTER(mcux_qtmr, CONFIG_COUNTER_LOG_LEVEL);
@@ -34,6 +35,7 @@ struct mcux_qtmr_config {
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 	TMR_Type *base;
+	unsigned int irqn;
 	clock_name_t clock_source;
 	qtmr_channel_selection_t channel;
 	qtmr_config_t qtmr_config;
@@ -54,6 +56,8 @@ struct mcux_qtmr_data {
 #endif /* CONFIG_COUNTER_CAPTURE */
 	qtmr_status_flags_t interrupt_mask;
 	uint32_t freq;
+	uint32_t guard_period;
+	atomic_t irq_pending;
 };
 
 #ifdef CONFIG_COUNTER_CAPTURE
@@ -138,8 +142,17 @@ static void mcux_qtmr_isr(const struct device *timers[])
 			struct mcux_qtmr_data *data = timers[ch]->data;
 
 			uint32_t channel_status = QTMR_GetStatus(config->base, ch);
+			bool sw_pending = (atomic_clear(&data->irq_pending) != 0);
 
-			if ((channel_status & data->interrupt_mask) != 0) {
+			/* A late alarm forced through NVIC_SetPendingIRQ has no
+			 * hardware compare flag set. Synthesize the compare event
+			 * so the handler runs the alarm callback immediately.
+			 */
+			if (sw_pending) {
+				channel_status |= kQTMR_Compare1Flag;
+			}
+
+			if (((channel_status & data->interrupt_mask) != 0) || sw_pending) {
 				mcux_qtmr_timer_handler(timers[ch], channel_status);
 			}
 		}
@@ -212,8 +225,13 @@ static int mcux_qtmr_set_alarm(const struct device *dev, uint8_t chan_id,
 {
 	const struct mcux_qtmr_config *config = dev->config;
 	struct mcux_qtmr_data *data = dev->data;
-	uint32_t current;
-	uint32_t ticks;
+	uint32_t top_val = config->info.max_top_value;
+	uint32_t flags = alarm_cfg->flags;
+	uint32_t now;
+	uint32_t target;
+	uint32_t guard;
+	bool irq_on_late;
+	int err = 0;
 
 	if (chan_id != 0) {
 		LOG_ERR("Invalid channel id");
@@ -230,18 +248,30 @@ static int mcux_qtmr_set_alarm(const struct device *dev, uint8_t chan_id,
 	}
 #endif /* CONFIG_COUNTER_CAPTURE */
 
+	now = QTMR_GetCurrentTimerCount(config->base, config->channel);
+	target = alarm_cfg->ticks;
+
+	if (flags & COUNTER_ALARM_CFG_ABSOLUTE) {
+		__ASSERT_NO_MSG(data->guard_period < top_val);
+		guard = data->guard_period;
+		irq_on_late = !!(flags & COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE);
+	} else {
+		/*
+		 * If the relative value is smaller than half the counter range
+		 * there is a risk of programming the compare register too late.
+		 * In that case late detection is applied and, when late, the
+		 * alarm is expired immediately instead of after a full wrap.
+		 */
+		irq_on_late = target < (top_val / 2U);
+		guard = irq_on_late ? (top_val - top_val / 2U) : 0U;
+		target += now;
+	}
+
 	data->alarm_callback = alarm_cfg->callback;
 	data->alarm_user_data = alarm_cfg->user_data;
 
-	current = QTMR_GetCurrentTimerCount(config->base, config->channel);
-	ticks = alarm_cfg->ticks;
-
-	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
-		ticks += current;
-	}
-
-	/* this timer always counts up. */
-	config->base->CHANNEL[config->channel].COMP1 = ticks;
+	/* this timer always counts up (16-bit compare register). */
+	config->base->CHANNEL[config->channel].COMP1 = (uint16_t)target;
 
 	/* Clear any stale compare flag to prevent alarm firing immediately */
 	QTMR_ClearStatusFlags(config->base, config->channel, kQTMR_Compare1Flag);
@@ -250,7 +280,36 @@ static int mcux_qtmr_set_alarm(const struct device *dev, uint8_t chan_id,
 	QTMR_EnableInterrupts(config->base, config->channel,
 			      kQTMR_Compare1InterruptEnable);
 
-	return 0;
+	/*
+	 * Late detection (counter counts up, wraps at 16 bits): re-read the
+	 * counter after programming the compare register. If it has already
+	 * advanced past the target by fewer than guard ticks, the alarm is
+	 * late and would otherwise only expire after a full 16-bit wrap.
+	 */
+	if (guard != 0U &&
+	    (uint16_t)((uint16_t)QTMR_GetCurrentTimerCount(config->base, config->channel) -
+		       (uint16_t)target) < guard) {
+		if (flags & COUNTER_ALARM_CFG_ABSOLUTE) {
+			err = -ETIME;
+		}
+
+		if (irq_on_late) {
+			/*
+			 * The shared QTMR ISR is driven by hardware status
+			 * flags, so mark this channel software-pending before
+			 * forcing the interrupt.
+			 */
+			atomic_set(&data->irq_pending, 1);
+			NVIC_SetPendingIRQ(config->irqn);
+		} else {
+			QTMR_DisableInterrupts(config->base, config->channel,
+					       kQTMR_Compare1InterruptEnable);
+			data->interrupt_mask &= ~kQTMR_Compare1InterruptEnable;
+			data->alarm_callback = NULL;
+		}
+	}
+
+	return err;
 }
 
 static int mcux_qtmr_cancel_alarm(const struct device *dev, uint8_t chan_id)
@@ -276,6 +335,32 @@ static uint32_t mcux_qtmr_get_pending_int(const struct device *dev)
 	const struct mcux_qtmr_config *config = dev->config;
 
 	return QTMR_GetStatus(config->base, config->channel);
+}
+
+static uint32_t mcux_qtmr_get_guard_period(const struct device *dev, uint32_t flags)
+{
+	struct mcux_qtmr_data *data = dev->data;
+
+	ARG_UNUSED(flags);
+
+	return data->guard_period;
+}
+
+static int mcux_qtmr_set_guard_period(const struct device *dev, uint32_t ticks,
+				      uint32_t flags)
+{
+	const struct mcux_qtmr_config *config = dev->config;
+	struct mcux_qtmr_data *data = dev->data;
+
+	ARG_UNUSED(flags);
+
+	if (ticks >= config->info.max_top_value) {
+		return -EINVAL;
+	}
+
+	data->guard_period = ticks;
+
+	return 0;
 }
 
 static int mcux_qtmr_set_top_value(const struct device *dev,
@@ -505,6 +590,8 @@ static DEVICE_API(counter, mcux_qtmr_driver_api) = {
 	.get_pending_int = mcux_qtmr_get_pending_int,
 	.get_top_value = mcux_qtmr_get_top_value,
 	.get_freq = mcux_qtmr_get_freq,
+	.get_guard_period = mcux_qtmr_get_guard_period,
+	.set_guard_period = mcux_qtmr_set_guard_period,
 #ifdef CONFIG_COUNTER_CAPTURE
 	.capture_configure = mcux_qtmr_capture_configure,
 	.enable_capture = mcux_qtmr_enable_capture,
@@ -522,6 +609,7 @@ static DEVICE_API(counter, mcux_qtmr_driver_api) = {
 												\
 	static const struct mcux_qtmr_config mcux_qtmr_config_ ## n = {				\
 		.base = (void *)DT_REG_ADDR(DT_INST_PARENT(n)),					\
+		.irqn = DT_IRQN(DT_INST_PARENT(n)),						\
 		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_INST_PARENT(n))),			\
 		.clock_subsys = MCUX_QTMR_CLK_SUBSYS(n),				\
 		.info = {									\

--- a/drivers/counter/counter_mcux_tstmr.c
+++ b/drivers/counter/counter_mcux_tstmr.c
@@ -6,10 +6,18 @@
 #define DT_DRV_COMPAT nxp_tstmr
 
 #include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/counter.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/barrier.h>
 #include <zephyr/sys/sys_io.h>
+
+#include <fsl_clock.h>
+
+#if defined(CONFIG_COUNTER_MCUX_TSTMR_SYSCTR_BACKEND)
+#include <fsl_sysctr.h>
+#endif
 
 #define TSTMR_MAX_TICKS     ((1ULL << 56) - 1ULL)
 
@@ -20,6 +28,13 @@
 struct mcux_tstmr_config {
 	struct counter_config_info info;
 	mem_addr_t base;
+	/* Clock feeding the underlying SYS_CTR. NULL when no 'clocks' phandle. */
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
+};
+
+struct mcux_tstmr_data {
+	uint32_t freq;
 };
 
 static uint64_t mcux_tstmr_read_timestamp(mem_addr_t base)
@@ -52,6 +67,12 @@ static uint64_t mcux_tstmr_read_timestamp(mem_addr_t base)
 static int mcux_tstmr_start(const struct device *dev)
 {
 	ARG_UNUSED(dev);
+
+#if defined(CONFIG_COUNTER_MCUX_TSTMR_SYSCTR_BACKEND)
+	if ((SYS_CTR_CONTROL->CNTCR & SYS_CTR_CONTROL_CNTCR_EN_MASK) == 0U) {
+		SYS_CTR_CONTROL->CNTCR |= SYS_CTR_CONTROL_CNTCR_EN_MASK;
+	}
+#endif /* CONFIG_COUNTER_MCUX_TSTMR_SYSCTR_BACKEND */
 
 	return 0;
 }
@@ -158,14 +179,54 @@ static uint64_t mcux_tstmr_get_top_value_64(const struct device *dev)
 
 static uint32_t mcux_tstmr_get_freq(const struct device *dev)
 {
-	const struct mcux_tstmr_config *config = dev->config;
+	const struct mcux_tstmr_data *data = dev->data;
 
-	return config->info.freq;
+#if defined(CONFIG_COUNTER_MCUX_TSTMR_SYSCTR_BACKEND)
+		if ((SYS_CTR_CONTROL->CNTCR & SYS_CTR_CONTROL_CNTCR_EN_MASK) == 0U) {
+			return 0U;
+		}
+#endif /* CONFIG_COUNTER_MCUX_TSTMR_SYSCTR_BACKEND */
+
+	return data->freq;
 }
 
 static int mcux_tstmr_init(const struct device *dev)
 {
-	ARG_UNUSED(dev);
+	const struct mcux_tstmr_config *config = dev->config;
+	struct mcux_tstmr_data *data = dev->data;
+
+	if (config->clock_dev != NULL) {
+		uint32_t rate;
+		int ret;
+
+		if (!device_is_ready(config->clock_dev)) {
+			return -ENODEV;
+		}
+
+		/*
+		 * Enable the SYS_CTR clock gate once, here, so counter_start()
+		 * only sets the count-enable and never toggles the gate (a gate
+		 * toggle re-syncs the clock domains and slows the first reads).
+		 */
+		ret = clock_control_on(config->clock_dev, config->clock_subsys);
+		if (ret != 0) {
+			return ret;
+		}
+
+		ret = clock_control_get_rate(config->clock_dev, config->clock_subsys, &rate);
+		if (ret != 0) {
+			return ret;
+		}
+
+		data->freq = rate;
+	} else {
+		/* No 'clocks' phandle: rate comes from the clock-frequency prop. */
+		data->freq = config->info.freq;
+	}
+
+	if (data->freq == 0U) {
+		return -EINVAL;
+	}
 
 	return 0;
 }
@@ -188,10 +249,19 @@ static DEVICE_API(counter, mcux_tstmr_driver_api) = {
 #endif /* CONFIG_COUNTER_64BITS_TICKS */
 };
 
+#define MCUX_TSTMR_CLOCK_DEV(n)                                                            \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clocks),                                       \
+		    (DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n))), (NULL))
+
+#define MCUX_TSTMR_CLOCK_SUBSYS(n)                                                         \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clocks),                                       \
+		    ((clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name)), (NULL))
+
 #define MCUX_TSTMR_DEVICE(n)                                                               \
+	static struct mcux_tstmr_data mcux_tstmr_data_##n;                                  \
 	static const struct mcux_tstmr_config mcux_tstmr_config_##n = {                      \
 		.info = {                                                                      \
-			.freq = DT_INST_PROP(n, clock_frequency),                               \
+			.freq = DT_INST_PROP_OR(n, clock_frequency, 0),                         \
 			IF_ENABLED(CONFIG_COUNTER_64BITS_TICKS,                                 \
 				(.max_top_value_64 = TSTMR_MAX_TICKS,))                           \
 			IF_DISABLED(CONFIG_COUNTER_64BITS_TICKS,                                \
@@ -200,9 +270,11 @@ static DEVICE_API(counter, mcux_tstmr_driver_api) = {
 			.channels = 0,                                                           \
 		},                                                                              \
 		.base = DT_INST_REG_ADDR(n),                                                    \
+		.clock_dev = MCUX_TSTMR_CLOCK_DEV(n),                                           \
+		.clock_subsys = MCUX_TSTMR_CLOCK_SUBSYS(n),                                     \
 	};                                                                                 \
-	DEVICE_DT_INST_DEFINE(n, mcux_tstmr_init, NULL, NULL, &mcux_tstmr_config_##n,       \
-			      PRE_KERNEL_1, CONFIG_COUNTER_INIT_PRIORITY,                         \
-			      &mcux_tstmr_driver_api);
+	DEVICE_DT_INST_DEFINE(n, mcux_tstmr_init, NULL, &mcux_tstmr_data_##n,               \
+			      &mcux_tstmr_config_##n, POST_KERNEL,                              \
+			      CONFIG_COUNTER_INIT_PRIORITY, &mcux_tstmr_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MCUX_TSTMR_DEVICE)

--- a/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt10xx.dtsi
@@ -181,6 +181,7 @@
 			low-freq = <DT_FREQ_K(32)>;
 			osc-freq = <DT_FREQ_M(24)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x68 24>;
+			run-mode = "free-run";
 		};
 
 		qtmr1: qtmr@401dc000 {

--- a/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/imxrt/nxp_rt11xx.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021,2023-2025 NXP
+ * Copyright 2021,2023-2026 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -123,6 +123,7 @@
 			low-freq = <DT_FREQ_K(32)>;
 			osc-freq = <DT_FREQ_M(16)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x41 0>;
+			run-mode = "free-run";
 		};
 
 		gpt3: gpt@400f4000 {
@@ -133,6 +134,7 @@
 			low-freq = <DT_FREQ_K(32)>;
 			osc-freq = <DT_FREQ_M(16)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x42 0>;
+			run-mode = "free-run";
 		};
 
 		gpt4: gpt@400f8000 {
@@ -143,6 +145,7 @@
 			low-freq = <DT_FREQ_K(32)>;
 			osc-freq = <DT_FREQ_M(16)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x43 0>;
+			run-mode = "free-run";
 		};
 
 		gpt5: gpt@400fc000 {
@@ -153,6 +156,7 @@
 			low-freq = <DT_FREQ_K(32)>;
 			osc-freq = <DT_FREQ_M(16)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x44 0>;
+			run-mode = "free-run";
 		};
 
 		gpt6: gpt@40100000 {
@@ -163,6 +167,7 @@
 			low-freq = <DT_FREQ_K(32)>;
 			osc-freq = <DT_FREQ_M(16)>;
 			clocks = <&ccm IMX_CCM_GPT_CLK 0x45 0>;
+			run-mode = "free-run";
 		};
 
 		qtmr1: qtmr@4015c000 {

--- a/dts/arm/nxp/imxrt/rt118x/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/imxrt/rt118x/nxp_rt118x.dtsi
@@ -396,6 +396,7 @@
 		low-freq = <DT_FREQ_K(32)>;
 		osc-freq = <DT_FREQ_M(24)>;
 		clocks = <&ccm IMX_CCM_GPT1_CLK 0x41 0>;
+		run-mode = "free-run";
 		status = "disabled";
 	};
 
@@ -407,6 +408,7 @@
 		low-freq = <DT_FREQ_K(32)>;
 		osc-freq = <DT_FREQ_M(24)>;
 		clocks = <&ccm IMX_CCM_GPT2_CLK 0x41 0>;
+		run-mode = "free-run";
 	};
 
 	acmp1: comparator@2dc0000 {

--- a/dts/arm/nxp/imxrt/rt118x/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/imxrt/rt118x/nxp_rt118x.dtsi
@@ -1025,14 +1025,14 @@
 	tstmr1: timer@442c0000 {
 		compatible = "nxp,tstmr";
 		reg = <0x442c0000 0x8>;
-		clock-frequency = <DT_FREQ_M(1)>;
+		clocks = <&ccm IMX_CCM_SYSCTR_BASE_CLK 0x0 0>;
 		status = "disabled";
 	};
 
 	tstmr2: timer@42480000 {
 		compatible = "nxp,tstmr";
 		reg = <0x42480000 0x8>;
-		clock-frequency = <DT_FREQ_M(1)>;
+		clocks = <&ccm IMX_CCM_SYSCTR_BASE_CLK 0x0 0>;
 		status = "disabled";
 	};
 

--- a/dts/bindings/counter/nxp,tstmr.yaml
+++ b/dts/bindings/counter/nxp,tstmr.yaml
@@ -11,7 +11,23 @@ properties:
   reg:
     required: true
 
+  clocks:
+    description: |
+      Clock of the time base the TSTMR reflects. Whether to set it depends on
+      how the SoC implements the TSTMR:
+
+        - On SoCs where the TSTMR is a snapshot of a System Counter (SCTR)
+          that acts as the timing source and must be brought up in software
+          (e.g. i.MX RT118x), set this. The driver then enables the clock via
+          the clock-control driver and takes the counter frequency from it
+          (clock-frequency is ignored).
+
+        - On SoCs where the TSTMR is a self-contained, free-running counter
+          that starts after system reset and needs no clock management
+          (e.g. MCXW71), leave this unset. The driver touches no clock and
+          clock-frequency supplies the rate.
+
   clock-frequency:
     type: int
-    required: true
-    description: TSTMR counter frequency in Hz.
+    description: |
+      TSTMR counter frequency in Hz. Used when 'clocks' is not present.

--- a/tests/drivers/counter/counter_basic_api/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/frdm_imxrt1186_mimxrt1186_cm33.overlay
@@ -4,13 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* gpt runs in free-run mode (run-mode default comes from the SoC dtsi). */
 &gpt1 {
 	status = "okay";
-	run-mode = "free-run";
-};
-
-&gpt2 {
-	run-mode = "free-run";
 };
 
 &lpit1 {

--- a/tests/drivers/counter/counter_basic_api/boards/frdm_ke17z.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/frdm_ke17z.overlay
@@ -8,7 +8,7 @@
 	status = "okay";
 	compatible = "nxp,ftm";
 	prescaler = <128>;
-	clocks = <&scg KINETIS_SCG_FIRC_CLK>;
+	clocks = <&scg KINETIS_SCG_CORESYS_CLK>;
 	clock-source = "system";
 };
 

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -32,27 +32,23 @@
 	status = "okay";
 };
 
+/* gpt runs in free-run mode (run-mode default comes from the SoC dtsi). */
 &gpt2 {
 	status = "okay";
-	run-mode = "free-run";
 };
 
 &gpt3 {
 	status = "okay";
-	run-mode = "free-run";
 };
 
 &gpt4 {
 	status = "okay";
-	run-mode = "free-run";
 };
 
 &gpt5 {
 	status = "okay";
-	run-mode = "free-run";
 };
 
 &gpt6 {
 	status = "okay";
-	run-mode = "free-run";
 };

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -75,17 +75,9 @@
 	prescale-glitch-filter = <10>;
 };
 
-&gpt2 {
-	run-mode = "free-run";
-};
-
 &tpm1 {
 	compatible = "nxp,tpm-timer";
 	status = "okay";
-};
-
-&gpt2 {
-	run-mode = "free-run";
 };
 
 &sys_ctr {

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
@@ -69,7 +69,3 @@
 &lpit3_channel3 {
 	status = "okay";
 };
-
-&gpt2 {
-	run-mode = "free-run";
-};

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Nordic Semiconductor ASA
- * Copyright 2024, 2025 NXP
+ * Copyright 2024-2026 NXP
  * Copyright (c) 2025 Microchip Technology Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -561,6 +561,56 @@ static bool alarm_capable(const struct device *dev)
 	if (err != 0) {
 		goto out_stop;
 	}
+
+out_stop:
+	(void)counter_stop(dev);
+
+	return err == 0;
+}
+
+/* The cancel test below configures absolute alarms. Some counters (for example
+ * the NXP wake timer) only support relative alarms and return -ENOTSUP for
+ * COUNTER_ALARM_CFG_ABSOLUTE. Probe whether a device accepts an absolute alarm
+ * so such devices can be skipped instead of hard-failing the test.
+ */
+static bool absolute_alarm_capable(const struct device *dev)
+{
+	struct counter_alarm_cfg cfg = {
+		.flags = COUNTER_ALARM_CFG_ABSOLUTE,
+		.callback = alarm_capable_handler,
+		.user_data = NULL,
+	};
+	uint32_t ticks;
+	int err;
+
+	if (counter_get_num_of_channels(dev) < 1U) {
+		return false;
+	}
+
+	err = counter_start(dev);
+	if (err != 0) {
+		return false;
+	}
+
+	err = counter_get_value(dev, &ticks);
+	if (err != 0) {
+		goto out_stop;
+	}
+
+	/* Aim ahead of the current value so the alarm is not seen as late. */
+	cfg.ticks = counter_us_to_ticks(dev, 1000U);
+	if (cfg.ticks == 0U) {
+		cfg.ticks = 1U;
+	}
+	cfg.ticks += ticks;
+	cfg.ticks %= counter_get_top_value(dev);
+
+	err = counter_set_channel_alarm(dev, 0, &cfg);
+	if (err != 0) {
+		goto out_stop;
+	}
+
+	err = counter_cancel_channel_alarm(dev, 0);
 
 out_stop:
 	(void)counter_stop(dev);
@@ -1247,6 +1297,13 @@ static void test_cancelled_alarm_does_not_expire_instance(const struct device *d
 
 static bool reliable_cancel_capable(const struct device *dev)
 {
+	/* This test configures absolute alarms; skip devices whose driver does
+	 * not support them (returns -ENOTSUP) instead of reporting a failure.
+	 */
+	if (!absolute_alarm_capable(dev)) {
+		return false;
+	}
+
 	/* Test performed only for NRF_RTC instances. Other probably will fail.
 	 */
 #if defined(CONFIG_COUNTER_NRF_RTC) || defined(CONFIG_COUNTER_NRF_TIMER)

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -980,8 +980,14 @@ static bool ms_period_capable(const struct device *dev)
 	uint32_t freq_khz;
 	uint32_t max_time_ms;
 
+	freq_khz = counter_get_frequency(dev);
+
+	if (freq_khz == 0) {
+		return false;
+	}
+
 	/* Assume 2 ms counter period can be set for frequency below 1 kHz*/
-	if (counter_get_frequency(dev) < 1000) {
+	if (freq_khz < 1000) {
 		return true;
 	}
 


### PR DESCRIPTION

Fix #114742 
Brief summary of the last 6 commits (all by Felix Wang, all fixing NXP counter drivers / the counter_basic_api test):

1. **2e68cec— mcux_qtmr: add guard period + late-alarm handling.** QTMR relied purely on the HW compare match, so a late alarm only fired after the 16-bit counter wrapped (up to 65536 ticks). Added get/set_guard_period and late detection: late relative and EXPIRE_WHEN_LATE absolute alarms now expire immediately (via software-pending + NVIC_SetPendingIRQ), late absolute alarms return -ETIME.

2. **c5f1481— ke1xz: fix core clock source to FIRC.** A prior commit repointed core_clk to lpfll_clk (72 MHz) while SysTick stayed at 48 MHz, making SysTick run 1.5x fast and LPTMR/LPIT measure ~2/3 of expected ticks. Repointed core_clk back to firc_clk.

3. **0bbb8d9— mcux_tstmr: fix SYS_CTR clock and startup.** On RT118x the TSTMR reported a hard-coded 1 MHz and never enabled the SYS_CTR, so reads were frozen/mis-scaled. Added a hidden Kconfig SYS_CTR backend that enables CNTCR.EN on start, reports 0 Hz while disabled, and compiles out the register access on standalone TSTMR SoCs.

4. **59a6d8a — imxrt: default GPT run-mode to free-run.** Moved the repeated per-board `run-mode = "free-run"` GPT setting up into the RT SoC dtsi as the default and removed the redundant test-overlay overrides.

5. **362bc1e — mcux_ctimer: fix spurious expiry of cancelled alarm.** cancel_alarm() left the match value armed and the status flag latched; a re-armed set_alarm() could deliver that stale flag as a false callback. Wrapped callback registration + CTIMER_SetupMatch() in irq_lock() and cleared the status flag under the same lock.

6. **f8615ff — test: skip cancel test when absolute alarms unsupported.** The cancel test uses absolute alarms but only probed relative-alarm support, so relative-only devices (e.g. NXP wake timer) hard-failed with -134. Added absolute_alarm_capable() to the capability gate so unsupported devices are skipped.


