### PR TITLE
drivers: sensor: adxl367: add INT2 interrupt pin support

### DIFF
--- a/drivers/sensor/adi/adxl367/Kconfig
+++ b/drivers/sensor/adi/adxl367/Kconfig
@@ -106,13 +106,15 @@ config ADXL367_TRIGGER_NONE
 config ADXL367_TRIGGER_GLOBAL_THREAD
 	bool "Use global thread"
 	depends on GPIO
-	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADXL367),int1-gpios)
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADXL367),int1-gpios) || \
+		$(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADXL367),int2-gpios)
 	select ADXL367_TRIGGER
 
 config ADXL367_TRIGGER_OWN_THREAD
 	bool "Use own thread"
 	depends on GPIO
-	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADXL367),int1-gpios)
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADXL367),int1-gpios) || \
+		$(dt_compat_any_has_prop,$(DT_COMPAT_ADI_ADXL367),int2-gpios)
 	select ADXL367_TRIGGER
 
 endchoice

--- a/drivers/sensor/adi/adxl367/adxl367.c
+++ b/drivers/sensor/adi/adxl367/adxl367.c
@@ -1108,7 +1108,15 @@ static int adxl367_init(const struct device *dev)
 
 #ifdef CONFIG_ADXL367_TRIGGER
 #define ADXL367_CFG_IRQ(inst) \
-		.interrupt = GPIO_DT_SPEC_INST_GET(inst, int1_gpios),
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, int1_gpios),		\
+		(							\
+			.interrupt = GPIO_DT_SPEC_INST_GET(inst, int1_gpios),	\
+			.int_map_reg = ADXL367_INTMAP1_LOWER,		\
+		),							\
+		(							\
+			.interrupt = GPIO_DT_SPEC_INST_GET(inst, int2_gpios),	\
+			.int_map_reg = ADXL367_INTMAP2_LOWER,		\
+		))
 #else
 #define ADXL367_CFG_IRQ(inst)
 #endif /* CONFIG_ADXL367_TRIGGER */
@@ -1154,7 +1162,8 @@ static int adxl367_init(const struct device *dev)
 		.bus_init = adxl367_spi_init,				\
 		.spi = SPI_DT_SPEC_INST_GET(inst, ADXL367_SPI_CFG),		\
 		ADXL367_CONFIG(inst, chipid)					\
-		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, int1_gpios),	\
+		COND_CODE_1(UTIL_OR(DT_INST_NODE_HAS_PROP(inst, int1_gpios),	\
+				    DT_INST_NODE_HAS_PROP(inst, int2_gpios)),	\
 		(ADXL367_CFG_IRQ(inst)), ())				\
 	}
 
@@ -1177,7 +1186,8 @@ static int adxl367_init(const struct device *dev)
 		.bus_init = adxl367_i2c_init,				\
 		.i2c = I2C_DT_SPEC_INST_GET(inst),			\
 		ADXL367_CONFIG(inst, chipid)					\
-		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, int1_gpios),	\
+		COND_CODE_1(UTIL_OR(DT_INST_NODE_HAS_PROP(inst, int1_gpios),	\
+				    DT_INST_NODE_HAS_PROP(inst, int2_gpios)),	\
 		(ADXL367_CFG_IRQ(inst)), ())				\
 	}
 

--- a/drivers/sensor/adi/adxl367/adxl367.h
+++ b/drivers/sensor/adi/adxl367/adxl367.h
@@ -384,6 +384,7 @@ struct adxl367_dev_config {
 
 #ifdef CONFIG_ADXL367_TRIGGER
 	struct gpio_dt_spec interrupt;
+	uint8_t int_map_reg;
 #endif
 
 	enum adxl367_odr odr;

--- a/drivers/sensor/adi/adxl367/adxl367_stream.c
+++ b/drivers/sensor/adi/adxl367/adxl367_stream.c
@@ -117,7 +117,7 @@ void adxl367_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 		data->fifo_wmark_irq = fifo_wmark_irq;
 		data->fifo_full_irq = fifo_full_irq;
 
-		rc = data->hw_tf->write_reg_mask(dev, ADXL367_INTMAP1_LOWER, int_mask, int_value);
+		rc = data->hw_tf->write_reg_mask(dev, cfg_367->int_map_reg, int_mask, int_value);
 		if (rc < 0) {
 			return;
 		}

--- a/drivers/sensor/adi/adxl367/adxl367_trigger.c
+++ b/drivers/sensor/adi/adxl367/adxl367_trigger.c
@@ -122,7 +122,7 @@ int adxl367_trigger_set(const struct device *dev,
 		int_en = 0U;
 	}
 
-	ret = drv_data->hw_tf->write_reg_mask(dev, ADXL367_INTMAP1_LOWER, int_mask, int_en);
+	ret = drv_data->hw_tf->write_reg_mask(dev, cfg->int_map_reg, int_mask, int_en);
 	if (ret != 0) {
 		return ret;
 	}

--- a/dts/bindings/sensor/adi,adxl367-common.yaml
+++ b/dts/bindings/sensor/adi,adxl367-common.yaml
@@ -36,6 +36,15 @@ properties:
       The INT1 signal defaults to active high as produced by the
       sensor.  The property value should ensure the flags properly
       describe the signal that is presented to the driver.
+      Either this or INT2 will be used to route interrupts. If both
+      are defined, then int1 is prioritized.
+
+  int2-gpios:
+    type: phandle-array
+    description: |
+      The INT2 signal defaults to active high as produced by the
+      sensor.  The property value should ensure the flags properly
+      describe the signal that is presented to the driver.
 
   fifo-mode:
     type: int


### PR DESCRIPTION
drivers: sensor: adxl367: add INT2 interrupt pin support
The driver so far hardcoded INT1 (INTMAP1_LOWER at 0x2A) for all
interrupt mappings, so a board that routes only INT2 to the host could
never receive trigger or FIFO watermark interrupts. INT1 and INT2 have
bit-for-bit identical event mapping registers (INTMAP2_LOWER at 0x2B).

Select the connected pin from the int1-gpios/int2-gpios devicetree
properties and route the interrupt mappings to the matching register,
following the pattern already used by the adxl345 driver. When only
int1-gpios is present the driver keeps using INT1, so existing device
trees continue to work unchanged.