### PR TITLE
samples: mpu_test: use word-aligned addresses in shell test

### DIFF
--- a/samples/arch/mpu/mpu_test/test_shell.yml
+++ b/samples/arch/mpu/mpu_test/test_shell.yml
@@ -1,4 +1,4 @@
-- command: "mpu mtest 1"
+- command: "mpu mtest 0"
   expected: "The value is: 0x.*"
-- command: "mpu mtest 2"
+- command: "mpu mtest 4"
   expected: "The value is: 0x.*"


### PR DESCRIPTION
The shell harness test passes addresses `1` and `2` to the
`mpu mtest` command, which interprets its argument as a hex
address and performs a 32-bit (word) read.

Addresses `0x1` and `0x2` are not word-aligned. ARMv6-M
(Cortex-M0+) does not support unaligned word accesses and raises a
HardFault immediately, causing the shell prompt to never return and
the harness to time out:

  AssertionError: Did not find "uart:~$ " within 20.0 seconds

ARMv7-M and ARMv8-M cores handle unaligned accesses transparently
in hardware, so those platforms are not affected.

Replace `0x1`/`0x2` with word-aligned `0x0`/`0x4`, which
fall inside the ROM/Flash region present on all supported ARM
platforms. The expected pattern `"The value is: 0x.*"` does not
constrain the value, so platforms returning different ROM contents
all pass correctly.

Observed on Cortex-M0+ (RTL8752H):
- Before: HardFault + system halt -> test FAILED
- After:  "The value is: 0x..." printed -> test PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)