### PR TITLE
drivers: display: nt35510: select GPIO

### DIFF
--- a/drivers/display/Kconfig.nt35510
+++ b/drivers/display/Kconfig.nt35510
@@ -5,6 +5,8 @@ config NT35510
 	bool "NT35510 display driver"
 	default y
 	depends on DT_HAS_FRIDA_NT35510_ENABLED
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_FRIDA_NT35510),bl-gpios) || \
+		$(dt_compat_any_has_prop,$(DT_COMPAT_FRIDA_NT35510),reset-gpios)
 	select MIPI_DSI
 	help
 	  Enable driver for NT35510 display driver.


### PR DESCRIPTION
The NT35510 driver uses GPIOs to control the display reset and backlight.
However, it does not currently enable the GPIO subsystem.

This dependency was previously satisfied by STM32 board defaults, but
PR #109468 removed `CONFIG_GPIO=y` from most STM32 board configurations.
Consequently, the upstream display sample builds but the NT35510
initialization fails at runtime with `-ENOSYS`.

Select `GPIO` from the NT35510 Kconfig option so applications using this
driver do not need to enable it explicitly.