### PR TITLE
pcie: host: shell: fix radix base parsing in get_bdf

### DIFF
--- a/drivers/pcie/host/shell.c
+++ b/drivers/pcie/host/shell.c
@@ -266,7 +266,7 @@ static pcie_bdf_t get_bdf(char *str)
 		return PCIE_BDF_NONE;
 	}
 
-	bus = strtoul(tok, NULL, 16);
+	bus = strtoul(tok, NULL, 10);
 
 	tok = strtok_r(NULL, ".", &state);
 	if (tok == NULL) {
@@ -280,7 +280,7 @@ static pcie_bdf_t get_bdf(char *str)
 		return PCIE_BDF_NONE;
 	}
 
-	func = strtoul(tok, NULL, 16);
+	func = strtoul(tok, NULL, 10);
 
 	return PCIE_BDF(bus, dev, func);
 }


### PR DESCRIPTION
Fix a string parsing radix bug in get_bdf where the Bus and Function parameters were decoded using base-16 (hexadecimal) instead of base-10 (decimal). Standard PCI notation dictates that bus and function strings are written as decimal values, whereas only the device slot uses hexadecimal syntax. This correction prevents valid base-10 console input strings from being translated incorrectly into higher hex positions during shell command executions.

## Zephyr PCIe ls dump 
 
```text 
uart:~$ pcie ls dump 16:0.0 
dont print anything 
```
## After applying the patch (fix)

```text
pcie ls dump 16:0.0 
16:0.0 ID 8086:10d3 class 2 subclass 0 prog i/f 0 rev 0
    bar 0: MEM addr 0x10080000
    bar 1: MEM addr 0x100a0000
    bar 2: I/O addr 0x00001020
    bar 3: MEM addr 0x100c0000
    wired interrupt on IRQ 0
    PCI capabilities:
        Power Management
        Message Signalled Interrupts
        PCI Express
        MSI-X
    PCIe capabilities:
        Advanced Error Reporting
        Device Serial Number
86 80 d3 10 00 00 10 00 00 00 00 02 00 00 00 00 
00 00 08 10 00 00 0a 10 21 10 00 00 00 00 0c 10 
00 00 00 00 00 00 00 00 00 00 00 00 86 80 00 00 
00 00 00 00 c8 00 00 00 00 00 00 00 00 01 00 00 
```