### PR TITLE
drivers: mipi_dsi: stm32: Allow data lanes on host node

### DIFF
--- a/drivers/mipi_dsi/dsi_stm32.c
+++ b/drivers/mipi_dsi/dsi_stm32.c
@@ -501,8 +501,9 @@ static int mipi_dsi_stm32_init(const struct device *dev)
 		};))										\
 	/* Only child data-lanes property at index 0 is taken into account */			\
 	static const uint32_t data_lanes_##inst[] = {						\
-		DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(inst, DT_PROP_BY_IDX, (,),		\
-							    data_lanes, 0)			\
+		DT_INST_PROP_OR(inst, data_lanes,						\
+				DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(			\
+					inst, DT_PROP_BY_IDX, (,), data_lanes, 0))		\
 	};											\
 	static const struct mipi_dsi_stm32_config stm32_dsi_config_##inst = {			\
 		.rcc = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),					\

--- a/dts/bindings/mipi-dsi/st,stm32-mipi-dsi.yaml
+++ b/dts/bindings/mipi-dsi/st,stm32-mipi-dsi.yaml
@@ -103,6 +103,11 @@ properties:
     description: |
       DSI HOST PHY timing parameters.
 
+  data-lanes:
+    type: int
+    description: |
+      Number of MIPI DSI data lanes connected to the host.
+
   test-pattern:
     type: int
     enum:


### PR DESCRIPTION
Some MIPI DSI devices, such as the Waveshare DSI-to-DPI bridge, must be
represented on an I2C bus because they are configured over I2C.
As a result, they cannot be placed under the DSI host node solely to
provide the `data-lanes` property.

Add an optional `data-lanes` property to the STM32 MIPI DSI host binding
and use it when configuring the host. Preserve the existing behavior by
falling back to the `data-lanes` property of the first enabled DSI child
when the host property is not specified.