### PR TITLE
tests drivers gnss_emu: Make constant data static (placed in .rodata)

### DIFF
--- a/tests/drivers/gnss/gnss_emul/src/main.c
+++ b/tests/drivers/gnss/gnss_emul/src/main.c
@@ -90,12 +90,12 @@ ZTEST(gnss_emul, test_config_functions)
 ZTEST(gnss_emul, test_callback_behaviour)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_ALIAS(gnss));
-	const struct navigation_data nav = {
+	static const struct navigation_data nav = {
 		.latitude = 150000000000,
 		.longitude = -15199000000,
 		.altitude = 123456,
 	};
-	const struct gnss_info info = {
+	static const struct gnss_info info = {
 		.satellites_cnt = 7,
 		.hdop = 1999,
 		.geoid_separation = 1000,


### PR DESCRIPTION
struct gnss_info has 2 bytes of padding.
The test is memcmp'aring this struct with a copy in line 136. If we run this test with valgrind as is, it warns us that the padding bytes are not initialized (as nav and info are stack variables, whose fields are filled up by code at runtime, skipping the padding, and therefore the padding content is just stack garbage).

Instead let's just make these 2 variables be just static (constants in .rodata), which makes the padding deterministically 0.

This avoids the valgrind warning.