### PR TITLE
drivers: fpga: agilex: fix NULL deref and leak in mailbox path

### DIFF
--- a/drivers/fpga/fpga_altera_agilex_bridge.c
+++ b/drivers/fpga/fpga_altera_agilex_bridge.c
@@ -150,6 +150,12 @@ static void smc_callback(uint32_t c_token, struct sip_svc_response *response)
 			response_header = (union mailbox_response_header)resp_data[0];
 			private_data->mbox_response_data =
 				(uint32_t *)k_malloc(sizeof(uint32_t) * resp_len);
+			if (!private_data->mbox_response_data) {
+				LOG_ERR("Failed to allocate memory for mailbox response data");
+				k_free((char *)response->resp_data_addr);
+				k_sem_give(&(private_data->smc_sem));
+				return;
+			}
 			for (mbox_idx = 0; mbox_idx < resp_len; mbox_idx++) {
 				LOG_DBG("\t\t[%4d] %08x", mbox_idx, resp_data[mbox_idx]);
 				private_data->mbox_response_data[mbox_idx] = resp_data[mbox_idx];
@@ -253,6 +259,10 @@ static int32_t smc_send(const struct device *dev, uint32_t cmd_type, uint64_t fu
 
 	if (trans_id == SIP_SVC_ID_INVALID) {
 		LOG_ERR("SiP SVC send request fail");
+		if (cmd_type == SIP_SVC_PROTO_CMD_ASYNC) {
+			k_free(cmd_addr);
+			k_free(resp_addr);
+		}
 		return -EBUSY;
 	}
 
@@ -316,6 +326,11 @@ static int32_t fpga_config_ready_check(const struct device *dev)
 	if (!priv_data.response.resp_data_size &&
 		priv_data.mbox_response_len != FPGA_CONFIG_STATUS_RESPONSE_LEN) {
 		return -EINVAL;
+	}
+
+	if (!priv_data.mbox_response_data) {
+		LOG_ERR("Failed to allocate memory for mailbox response data");
+		return -ENOMEM;
 	}
 
 	/* Verify the FPGA config status response */


### PR DESCRIPTION
Fixes two error-path bugs in the Agilex FPGA bridge driver
(`drivers/fpga/fpga_altera_agilex_bridge.c`):

1. **NULL pointer dereference** in `smc_callback()`: the `k_malloc()`
   result for the mailbox response-data copy was never checked. On heap
   exhaustion the copy loop writes through a NULL pointer, and
   `fpga_config_ready_check()` would then pass the NULL buffer to
   `fpga_reconfig_status_validate()`, which dereferences it again. The fix
   returns `-ENOMEM` after releasing the semaphore so the waiting caller
   does not block forever, and `fpga_config_ready_check()` now rejects a
   NULL response buffer before validation.

2. **Memory leak** in `smc_send()`: `cmd_addr`/`resp_addr` were leaked
   when `sip_svc_send()` failed. They are now freed before returning
   `-EBUSY`.

### Testing

The real driver was compiled against stub Zephyr headers and exercised
with simulated heap exhaustion and send failure:

- Pre-fix: NULL pointer write crash on heap exhaustion; 2 buffers leaked
  on send failure.
- Post-fix: returns `-ENOMEM` gracefully, no leaks, no hang; clean under
  AddressSanitizer. `scripts/checkpatch.pl`: 0 errors, 0 warnings.