### PR TITLE
manifest: hal_nxp: update caam driver to 2.4.1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 85d250e97c9319df6c8311f17d6d7eec9e6578e5
+      revision: 6a6303b2b40dcb1885926bbe8371c6327ab222fe
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Sync hal_nxp to update CAAM driver to the latest version.