### PR TITLE
drivers: counter: renesas_ra_agt: Add comparison channel B support

### DIFF
--- a/drivers/counter/counter_renesas_ra_agt.c
+++ b/drivers/counter/counter_renesas_ra_agt.c
@@ -17,6 +17,12 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(counter_renesas_ra_agt, CONFIG_COUNTER_LOG_LEVEL);
 
+#define AGT_SUPPORTED_CHANNEL_COUNT 2
+
+#define AGT_NUM_IRQ_ENABLED_CHANNELS(inst) \
+	(DT_IRQ_HAS_NAME(TIMER(inst), agtcmai) + \
+	 DT_IRQ_HAS_NAME(TIMER(inst), agtcmbi))
+
 struct counter_renesas_ra_agt_config {
 	struct counter_config_info info;
 	void (*irq_config_func)(void);
@@ -26,25 +32,26 @@ struct counter_renesas_ra_agt_data {
 	struct st_agt_instance_ctrl agt_ctrl;
 	struct st_timer_cfg agt_cfg;
 	struct st_agt_extended_cfg agt_extend_cfg;
-	IRQn_Type agtcmai_irq;
-	uint8_t agtcmai_ipl;
+	IRQn_Type agt_irq[AGT_SUPPORTED_CHANNEL_COUNT];
+	uint8_t agt_ipl[AGT_SUPPORTED_CHANNEL_COUNT];
 	uint32_t guard_period;
-	counter_alarm_callback_t alarm_cb;
+	counter_alarm_callback_t alarm_cb[AGT_SUPPORTED_CHANNEL_COUNT];
 	counter_top_callback_t top_cb;
-	void *alarm_data;
+	void *alarm_data[AGT_SUPPORTED_CHANNEL_COUNT];
 	void *top_data;
 	struct k_spinlock lock;
 };
 
 extern void agt_int_isr(void);
 extern void agtcmai_isr(void);
+extern void agtcmbi_isr(void);
 
 static inline bool renesas_ra_agt_is_running(const struct device *dev)
 {
 	struct counter_renesas_ra_agt_data *data = dev->data;
 
-	return data->agt_ctrl.is_agtw ? (data->agt_ctrl.p_reg->AGT32.CTRL.AGTCR_b.TCSTF == 1)
-				      : (data->agt_ctrl.p_reg->AGT16.CTRL.AGTCR_b.TCSTF == 1);
+	return data->agt_ctrl.is_agtw ? (data->agt_ctrl.p_reg->AGT32.CTRL.AGTCR_b.TSTART == 1)
+			: (data->agt_ctrl.p_reg->AGT16.CTRL.AGTCR_b.TSTART == 1);
 }
 
 static inline int renesas_ra_agt_period_set(const struct device *dev, uint32_t period)
@@ -75,7 +82,8 @@ static inline int renesas_ra_agt_period_set(const struct device *dev, uint32_t p
 	return 0;
 }
 
-static inline int renesas_ra_agt_compare_match_set(const struct device *dev, uint32_t val)
+static inline int renesas_ra_agt_compare_match_set(const struct device *dev,
+	uint32_t val, timer_compare_match_t channel)
 {
 	struct counter_renesas_ra_agt_data *data = dev->data;
 	const bool counting = renesas_ra_agt_is_running(dev);
@@ -88,7 +96,7 @@ static inline int renesas_ra_agt_compare_match_set(const struct device *dev, uin
 		}
 	}
 
-	err = RP_AGT_CompareMatchSet(&data->agt_ctrl, val, TIMER_COMPARE_MATCH_A);
+	err = RP_AGT_CompareMatchSet(&data->agt_ctrl, val, channel);
 	if (err != FSP_SUCCESS) {
 		return -EIO;
 	}
@@ -179,6 +187,13 @@ static int counter_renesas_ra_agt_set_top_value(const struct device *dev,
 	fsp_err_t err;
 	int ret = 0;
 
+	for (int i = 0; i < AGT_SUPPORTED_CHANNEL_COUNT; i++) {
+		if (data->alarm_cb[i] != NULL) {
+			ret = -EBUSY;
+			goto out;
+		}
+	}
+
 	if (cfg->ticks > config->info.max_top_value) {
 		LOG_DBG("Top value exceed maximum value");
 		ret = -EINVAL;
@@ -244,15 +259,16 @@ static inline uint32_t ticks_sub(uint32_t val, uint32_t old, uint32_t top)
 }
 
 static int renesas_ra_agt_abs_alarm_set(const struct device *dev, uint32_t val, uint32_t top,
-					bool irq_on_late)
+					bool irq_on_late, timer_compare_match_t channel)
 {
 	struct counter_renesas_ra_agt_data *data = dev->data;
 	uint32_t max_val;
 	uint32_t read_again;
 	fsp_err_t err;
+	uint8_t chan = (uint8_t)channel;
 	int ret;
 
-	ret = renesas_ra_agt_compare_match_set(dev, val);
+	ret = renesas_ra_agt_compare_match_set(dev, val, channel);
 	if (ret != 0) {
 		return ret;
 	}
@@ -265,32 +281,35 @@ static int renesas_ra_agt_abs_alarm_set(const struct device *dev, uint32_t val, 
 	max_val = ticks_sub(read_again + top, data->guard_period, top);
 	if (val > max_val) {
 		if (irq_on_late) {
-			NVIC_SetPendingIRQ(data->agtcmai_irq);
+			NVIC_SetPendingIRQ(data->agt_irq[chan]);
 		} else {
-			data->alarm_cb = NULL;
+			data->alarm_cb[chan] = NULL;
 		}
 
 		ret = -ETIME;
 	}
 
-	err = RP_AGT_EventSet(&data->agt_ctrl, TIMER_AGT_AGTCMAI, true);
+	err = RP_AGT_EventSet(&data->agt_ctrl,
+					(channel == TIMER_COMPARE_MATCH_A ? TIMER_AGT_AGTCMAI
+									: TIMER_AGT_AGTCMBI), true);
 	if (err != FSP_SUCCESS) {
 		return -EIO;
 	}
 
-	irq_enable(data->agtcmai_irq);
+	irq_enable(data->agt_irq[chan]);
 
 	return ret;
 }
 
-static int renesas_ra_agt_rel_alarm_set(const struct device *dev, uint32_t val, uint32_t top,
-					bool irq_on_late)
+static int renesas_ra_agt_rel_alarm_set(const struct device *dev,
+	uint32_t val, uint32_t top, bool irq_on_late, timer_compare_match_t channel)
 {
 	struct counter_renesas_ra_agt_data *data = dev->data;
 	uint32_t max_rel_val = irq_on_late ? (top / 2) : top;
 	uint32_t diff;
 	uint32_t now;
 	fsp_err_t err;
+	uint8_t chan = (uint8_t)channel;
 	int ret;
 
 	ret = counter_renesas_ra_agt_get_value(dev, &now);
@@ -300,7 +319,7 @@ static int renesas_ra_agt_rel_alarm_set(const struct device *dev, uint32_t val, 
 
 	val = ticks_sub(now, val, top);
 
-	ret = renesas_ra_agt_compare_match_set(dev, val);
+	ret = renesas_ra_agt_compare_match_set(dev, val, channel);
 	if (ret != 0) {
 		return ret;
 	}
@@ -314,18 +333,21 @@ static int renesas_ra_agt_rel_alarm_set(const struct device *dev, uint32_t val, 
 
 	if (diff > max_rel_val || diff == 0) {
 		if (irq_on_late) {
-			NVIC_SetPendingIRQ(data->agtcmai_irq);
+			NVIC_SetPendingIRQ(data->agt_irq[chan]);
 		} else {
-			data->alarm_cb = NULL;
+			data->alarm_cb[chan] = NULL;
 		}
 	}
 
-	err = RP_AGT_EventSet(&data->agt_ctrl, TIMER_AGT_AGTCMAI, true);
+	err = RP_AGT_EventSet(&data->agt_ctrl,
+					(channel == TIMER_COMPARE_MATCH_A ? TIMER_AGT_AGTCMAI
+									: TIMER_AGT_AGTCMBI), true);
+
 	if (err != FSP_SUCCESS) {
 		return -EIO;
 	}
 
-	irq_enable(data->agtcmai_irq);
+	irq_enable(data->agt_irq[chan]);
 
 	return 0;
 }
@@ -334,14 +356,21 @@ static int counter_renesas_ra_agt_set_alarm(const struct device *dev, uint8_t ch
 					    const struct counter_alarm_cfg *alarm_cfg)
 {
 	struct counter_renesas_ra_agt_data *data = dev->data;
+	k_spinlock_key_t key = counter_renesas_ra_agt_lock(dev);
 	const uint32_t top = counter_renesas_ra_agt_get_top_value(dev);
 	const bool absolute = (alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) != 0;
 	const bool irq_on_late =
 		absolute ? (alarm_cfg->flags & COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE) != 0
 			 : alarm_cfg->ticks < (top / 2);
+	timer_compare_match_t channel = (timer_compare_match_t)chan;
 	int ret = 0;
 
-	if (chan != 0) {
+	if (alarm_cfg->callback == NULL) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	if (chan >= AGT_SUPPORTED_CHANNEL_COUNT) {
 		ret = -EINVAL;
 		goto out;
 	}
@@ -351,24 +380,33 @@ static int counter_renesas_ra_agt_set_alarm(const struct device *dev, uint8_t ch
 		goto out;
 	}
 
-	if (data->alarm_cb != NULL) {
+	if (data->alarm_cb[chan] != NULL) {
 		ret = -EBUSY;
 		goto out;
 	}
 
-	if (data->agtcmai_irq == BSP_IRQ_DISABLED) {
-		return -ENOTSUP;
+	if (data->agt_irq[chan] == BSP_IRQ_DISABLED) {
+		ret = -ENOTSUP;
+		goto out;
 	}
 
-	data->alarm_cb = alarm_cfg->callback;
-	data->alarm_data = alarm_cfg->user_data;
+	data->alarm_cb[chan] = alarm_cfg->callback;
+	data->alarm_data[chan] = alarm_cfg->user_data;
 
 	if (absolute) {
-		ret = renesas_ra_agt_abs_alarm_set(dev, alarm_cfg->ticks, top, irq_on_late);
+		ret = renesas_ra_agt_abs_alarm_set(dev, alarm_cfg->ticks, top,
+						irq_on_late, channel);
 	} else {
-		ret = renesas_ra_agt_rel_alarm_set(dev, alarm_cfg->ticks, top, irq_on_late);
+		ret = renesas_ra_agt_rel_alarm_set(dev, alarm_cfg->ticks, top,
+						irq_on_late, channel);
+	}
+
+	if (ret != 0 && ret != -ETIME) {
+		data->alarm_cb[chan] = NULL;
+		data->alarm_data[chan] = NULL;
 	}
 out:
+	counter_renesas_ra_agt_unlock(dev, key);
 	return ret;
 }
 
@@ -377,23 +415,31 @@ static int counter_renesas_ra_agt_cancel_alarm(const struct device *dev, uint8_t
 	struct counter_renesas_ra_agt_data *data = dev->data;
 	k_spinlock_key_t key = counter_renesas_ra_agt_lock(dev);
 	fsp_err_t err;
+	timer_compare_match_t channel = (timer_compare_match_t)chan;
 	int ret = 0;
 
-	if (data->agtcmai_irq == BSP_IRQ_DISABLED) {
+	if (chan >= AGT_SUPPORTED_CHANNEL_COUNT) {
 		ret = -ENOTSUP;
 		goto out;
 	}
 
-	err = RP_AGT_EventSet(&data->agt_ctrl, TIMER_AGT_AGTCMAI, false);
+	if (data->agt_irq[chan] == BSP_IRQ_DISABLED) {
+		ret = -ENOTSUP;
+		goto out;
+	}
+	err = RP_AGT_EventSet(&data->agt_ctrl,
+				(channel == TIMER_COMPARE_MATCH_A ? TIMER_AGT_AGTCMAI
+								: TIMER_AGT_AGTCMBI), false);
 	if (err != FSP_SUCCESS) {
 		ret = -EIO;
 		goto out;
 	}
 
-	irq_disable(data->agtcmai_irq);
-	NVIC_ClearPendingIRQ(data->agtcmai_irq);
-	data->alarm_cb = NULL;
-	data->alarm_data = NULL;
+	irq_disable(data->agt_irq[chan]);
+	R_BSP_IrqStatusClear(data->agt_irq[chan]);
+	NVIC_ClearPendingIRQ(data->agt_irq[chan]);
+	data->alarm_cb[chan] = NULL;
+	data->alarm_data[chan] = NULL;
 out:
 	counter_renesas_ra_agt_unlock(dev, key);
 	return ret;
@@ -438,7 +484,9 @@ static uint32_t counter_renesas_ra_agt_get_pending_int(const struct device *dev)
 	}
 
 	return (uint32_t)!!(
-		event & (R_AGTX0_AGT16_CTRL_AGTCR_TCMAF_Msk | R_AGTX0_AGT16_CTRL_AGTCR_TUNDF_Msk));
+		event & (R_AGTX0_AGT16_CTRL_AGTCR_TCMAF_Msk |
+			 R_AGTX0_AGT16_CTRL_AGTCR_TUNDF_Msk |
+			  R_AGTX0_AGT16_CTRL_AGTCR_TCMBF_Msk));
 }
 
 static uint32_t counter_renesas_ra_agt_get_freq(const struct device *dev)
@@ -467,8 +515,10 @@ static int counter_renesas_ra_agt_init(const struct device *dev)
 		return -EIO;
 	}
 
-	if (data->agtcmai_irq != BSP_IRQ_DISABLED) {
-		R_FSP_IsrContextSet(data->agtcmai_irq, &data->agt_ctrl);
+	for (int i = 0; i < AGT_SUPPORTED_CHANNEL_COUNT; i++) {
+		if (data->agt_irq[i] != BSP_IRQ_DISABLED) {
+			R_FSP_IsrContextSet(data->agt_irq[i], &data->agt_ctrl);
+		}
 	}
 
 	cfg->irq_config_func();
@@ -489,26 +539,36 @@ static void counter_renesas_ra_agt_agti_isr(const struct device *dev)
 	agt_int_isr();
 }
 
-static void counter_renesas_ra_agt_agtcmai_isr(const struct device *dev)
+static void counter_renesas_ra_agt_alarm_isr(const struct device *dev, uint8_t chan)
 {
 	struct counter_renesas_ra_agt_data *data = dev->data;
-	counter_alarm_callback_t cb = data->alarm_cb;
-	void *usr_data = data->alarm_data;
+	counter_alarm_callback_t cb = data->alarm_cb[chan];
+	void *usr_data = data->alarm_data[chan];
 	uint32_t now;
 
 	if (cb != NULL) {
-		data->alarm_cb = NULL;
-		data->alarm_data = NULL;
+		data->alarm_cb[chan] = NULL;
+		data->alarm_data[chan] = NULL;
 
 		if (counter_renesas_ra_agt_get_value(dev, &now) != 0) {
 			LOG_DBG("Error in counter alarm");
 			return;
 		}
 
-		cb(dev, 0, now, usr_data);
+		cb(dev, chan, now, usr_data);
 	}
+}
 
+static __unused void counter_renesas_ra_agt_channel_a(const struct device *dev)
+{
+	counter_renesas_ra_agt_alarm_isr(dev, (uint8_t)TIMER_COMPARE_MATCH_A);
 	agtcmai_isr();
+}
+
+static __unused void counter_renesas_ra_agt_channel_b(const struct device *dev)
+{
+	counter_renesas_ra_agt_alarm_isr(dev, (uint8_t)TIMER_COMPARE_MATCH_B);
+	agtcmbi_isr();
 }
 
 static DEVICE_API(counter, agt_renesas_ra_driver_api) = {
@@ -529,6 +589,7 @@ static DEVICE_API(counter, agt_renesas_ra_driver_api) = {
 
 #define EVENT_AGT_INT(channel)       BSP_PRV_IELS_ENUM(CONCAT(EVENT_AGT, channel, _INT))
 #define EVENT_AGT_COMPARE_A(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_AGT, channel, _COMPARE_A))
+#define EVENT_AGT_COMPARE_B(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_AGT, channel, _COMPARE_B))
 
 #define AGT_IRQ_GET_BY_NAME(inst, name, cell)                                                      \
 	COND_CODE_1(DT_IRQ_HAS_NAME(TIMER(inst), name), (DT_IRQ_BY_NAME(TIMER(inst), name, cell)), \
@@ -544,12 +605,19 @@ static DEVICE_API(counter, agt_renesas_ra_driver_api) = {
 				irq_disable(DT_IRQ_BY_NAME(TIMER(inst), name, irq));))
 
 #define COUNTER_AGT_DEVICE_INIT(inst)                                                              \
+	BUILD_ASSERT(!DT_IRQ_HAS_NAME(TIMER(inst), agtcmbi) ||                                     \
+		DT_IRQ_HAS_NAME(TIMER(inst), agtcmai),                                             \
+		"AGT instance " STRINGIFY(inst) ": agtcmai must be enabled to use agtcmbi; "       \
+		"counter alarm comparison channels must be contiguous from earliest first");       \
+                                                                                                   \
 	static void counter_renesas_ra_agt##inst##_irq_config_func(void)                           \
 	{                                                                                          \
 		AGT_IRQ_CONFIG(inst, agti, EVENT_AGT_INT(DT_PROP(TIMER(inst), channel)),           \
 			       counter_renesas_ra_agt_agti_isr);                                   \
 		AGT_IRQ_CONFIG(inst, agtcmai, EVENT_AGT_COMPARE_A(DT_PROP(TIMER(inst), channel)),  \
-			       counter_renesas_ra_agt_agtcmai_isr);                                \
+			       counter_renesas_ra_agt_channel_a);                                  \
+		AGT_IRQ_CONFIG(inst, agtcmbi, EVENT_AGT_COMPARE_B(DT_PROP(TIMER(inst), channel)),  \
+			       counter_renesas_ra_agt_channel_b);                                  \
 	}                                                                                          \
                                                                                                    \
 	struct counter_renesas_ra_agt_config counter_renesas_ra_agt_config##inst = {               \
@@ -558,7 +626,7 @@ static DEVICE_API(counter, agt_renesas_ra_driver_api) = {
 				? UINT32_MAX                                                       \
 				: BIT_MASK(DT_PROP(TIMER(inst), renesas_resolution)),              \
 		.info.flags = (uint8_t)0U,                                                         \
-		.info.channels = 1,                                                                \
+		.info.channels = AGT_NUM_IRQ_ENABLED_CHANNELS(inst),                               \
 		.irq_config_func = counter_renesas_ra_agt##inst##_irq_config_func,                 \
 	};                                                                                         \
                                                                                                    \
@@ -588,11 +656,13 @@ static DEVICE_API(counter, agt_renesas_ra_driver_api) = {
 				.enable_pin = AGT_ENABLE_PIN_NOT_USED,                             \
 				.trigger_edge = AGT_TRIGGER_EDGE_RISING,                           \
 			},                                                                         \
-		.agtcmai_irq = AGT_IRQ_GET_BY_NAME(inst, agtcmai, irq),                            \
-		.agtcmai_ipl = AGT_IRQ_GET_BY_NAME(inst, agtcmai, priority),                       \
+		.agt_irq[0] = AGT_IRQ_GET_BY_NAME(inst, agtcmai, irq),                             \
+		.agt_ipl[0] = AGT_IRQ_GET_BY_NAME(inst, agtcmai, priority),                        \
+		.agt_irq[1] = AGT_IRQ_GET_BY_NAME(inst, agtcmbi, irq),                             \
+		.agt_ipl[1] = AGT_IRQ_GET_BY_NAME(inst, agtcmbi, priority),                        \
 		.guard_period = 0,                                                                 \
 	};                                                                                         \
-                                                                                                   \
+												   \
 	DEVICE_DT_INST_DEFINE(inst, counter_renesas_ra_agt_init, NULL,                             \
 			      &counter_renesas_ra_agt_data##inst,                                  \
 			      &counter_renesas_ra_agt_config##inst, POST_KERNEL,                   \


### PR DESCRIPTION
drivers: counter: renesas_ra_agt: Add support for channel B comparison

Added support for the AGT compare match B channel. The hardware has two compare match channels but the driver only exposed channel A.

Comparison channels for period mode on AGT are not default supported with FSP, to comply with Zephyr, channel A had to be enabled. Since AGT is the sole Zephyr counter timer, GPT is tied to PWM, I think the comparison channel functionality should be increased, which makes a great difference to DTC/Sleep mode related tasks. 

A note on Zephyr's implementation of counter is that counters must be enabled lowest first, channel B can not be enabled and used without channel A being active. This is enforced by counter.h and a new guard in counter_renesas_ra_agt.c.


- Device data changed from single variables to arrays so it can hold multiple channels

- Added an AGT_SUPPORTED_CHANNEL_COUNT definition, used for array sizes, for loops and guarding against unsupported channel requests

- The compare match ISR is now a shared function, counter_renesas_ra_agt_alarm_isr, which takes the channel as a
  parameter. Two small wrappers, counter_renesas_ra_agt_channel_a and counter_renesas_ra_agt_channel_b, call it with the right channel. The interrupt
  function call at the end of the old ISR was moved into the wrappers.

- Added AGT_NUM_IRQ_ENABLED_CHANNELS which calculates how many channels are activated by the application. The advertised channel count is calculated with this. The counter API requires alarm channels to be contiguous from 0, so channel B is usable only when channel A is also wired. This is set in counter.h. This is reinforced also in device init.

- renesas_ra_agt_is_running was edited to check if the timer is running with TSTART instead of TCSTF
In a situation where the timer has just been started, TSTART will be 1 and TCSTF could be 0, about to turn 1. And similarly, in a situation where  the timer  is turning off, TSTART is 0 and TCSTF could be 1, about to turn 0. The function will return the state of TCSTF, but TCSTF had not changed it's state yet. However, the AGT can be running from a slower clock than the system clock, so there may be a window where TCSTF may not update to reflect TCSTF in time. This situation is possible, but less likely, and rp_agt.c protects against the edge case of TCSTF lagging by 3 source clock cycles with r_agt_common_preamble. On a side note, this function would now be checking if the peripheral is start enabled, rather than running, the function would need renaming if this change was made.
 
- renesas_ra_agt_compare_match_set altered to take a channel parameter, enabling channel B to be set.

- renesas_ra_agt_abs_alarm_set and renesas_ra_agt_rel_alarm_set altered to:
      - Accept channel parameter and use this in place of hardcoded channel A

- counter_renesas_ra_agt_set_alarm altered to:
      - Activate and deactivate during this function
      - Check if requested channel id  is less than total offered channels, however this is also already checked, even stricter in counter.h
      - Accept channel Id and use it in place of hardcoded Channel A
      - Have a spin lock since two channels will be accessing this function now, here will be a timing trade off.

- counter_renesas_ra_agt_cancel_alarm altered to:
      - Check if requested channel id  is less than total offered channels, however this is also already checked, even stricter in counter.h
      - Include R_BSP_IrqStatusClear call

- counter_renesas_ra_agt_get_pending_intaltered to:
      - include channel B interrupt pending mask
 
- counter_renesas_ra_agt_init to:
      - for loop set interrupts in the Isr
   
- counter_renesas_ra_agt_agtcmai_isr to:
      - renamed to counter_renesas_ra_agt_alarm_isr
      - Accepts channel parameter which is used instead of hardcoded channel A (0)

- counter_renesas_ra_agt_channel_a and counter_renesas_ra_agt_channel_b wrapper functions are created to call counter_renesas_ra_agt_alarm_isr and then their respective isr functions

- Device tree initiation altered to include channel B references and updated hardcoded 1 channel


While looking into this I noticed that current use of RP_AGT_EventSet is out of spec, since the timer is not being stopped before writing to AGTCMSR. I looked into effects of stopping (if running) the counter before writing to AGTCMSR, and if applicable restarting the timer. In situations such as when setting the comparison channel functions, it would be best to enable the the counter in the same AGT stop window as setting the top value to reduce latency. Renesas user manuals (e.g. ra2l1. ra4l1, ra8m1, ra6m5)  request for count operation to be stopped before altering the AGTCMSR. I looked into this and tested writing to AGTCMSR, the instability caused by writing with a enabled clock was minimal. The additional overhead of disabling the timer may cause more issues than the action of writing to the enabled counter. The only issue is that the application is not in spec to the user manuals without stopping the timer before writing to the register. Regardless of the decision, I saw that there was no impact to this PR but, I thought to make a note.

Tested on ek_ra2l1 and ek_ra4l1 hardware with alarms on both dual and single channel.