### PR TITLE
boards: non-ST: update to "zephyr,mapped-partition" compatible

### DIFF
--- a/boards/fanke/fk7b0m1_vbt6/fk7b0m1_vbt6.dts
+++ b/boards/fanke/fk7b0m1_vbt6/fk7b0m1_vbt6.dts
@@ -97,15 +97,33 @@
 		spi-bus-width = <OSPI_QUAD_MODE>;
 		data-rate = <OSPI_STR_TRANSFER>;
 		writeoc = "PP_1_1_4";
+
+		/* QSPI external flash mapping */
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x90000000 DT_SIZE_M(8)>;
+
 		status = "okay";
 
-		partitions {
-			compatible = "fixed-partitions";
+		ext_flash: ext-flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(8)>;
+			write-block-size = <1>;
+			erase-block-size = <DT_SIZE_K(4)>;
+
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
-			slot0_partition: partition@0 {
-				reg = <0x00000000 DT_SIZE_M(8)>; /* 64 Mbits */
+			partitions {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
+
+				slot0_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
+					reg = <0x00000000 DT_SIZE_M(8)>; /* 64 Mbits */
+				};
 			};
 		};
 	};

--- a/boards/fanke/fk7b0m1_vbt6/fk7b0m1_vbt6.yaml
+++ b/boards/fanke/fk7b0m1_vbt6/fk7b0m1_vbt6.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 1376
-flash: 128
+flash: 8192
 supported:
   - uart
   - gpio

--- a/boards/ruiside/art_pi/art_pi.dts
+++ b/boards/ruiside/art_pi/art_pi.dts
@@ -252,24 +252,42 @@
 		reset-cmd;
 		reset-cmd-wait = <2000>;
 
-		partitions {
-			compatible = "fixed-partitions";
+		/* QSPI external flash mapping */
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x90000000 DT_SIZE_M(8)>;
+
+		ext_flash: ext-flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(8)>;
+			write-block-size = <1>;
+			erase-block-size = <DT_SIZE_K(4)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
-			slot0_partition: partition@0 {
-				label = "image-0";
-				reg = <0x00000000 DT_SIZE_K(2048)>; /* 2MB */
-			};
+			partitions {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
 
-			slot1_partition: partition@200000 {
-				label = "image-1";
-				reg = <0x00200000 DT_SIZE_K(2048)>; /* 2MB */
-			};
+				slot0_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
+					label = "image-0";
+					reg = <0x00000000 DT_SIZE_K(2048)>; /* 2MB */
+				};
 
-			storage_partition: partition@400000 {
-				label = "storage";
-				reg = <0x00400000 DT_SIZE_K(4096)>; /* 4MB */
+				slot1_partition: partition@200000 {
+					compatible = "zephyr,mapped-partition";
+					label = "image-1";
+					reg = <0x00200000 DT_SIZE_K(2048)>; /* 2MB */
+				};
+
+				storage_partition: partition@400000 {
+					compatible = "zephyr,mapped-partition";
+					label = "storage";
+					reg = <0x00400000 DT_SIZE_K(4096)>; /* 4MB */
+				};
 			};
 		};
 	};

--- a/boards/weact/mini_stm32h743/mini_stm32h743.dts
+++ b/boards/weact/mini_stm32h743/mini_stm32h743.dts
@@ -182,13 +182,30 @@ zephyr_udc0: &usbotg_fs {
 		spi-bus-width = <4>;
 		writeoc = "PP_1_1_4";
 
-		partitions {
-			compatible = "fixed-partitions";
+		/* QSPI external flash mapping */
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x90000000 DT_SIZE_M(8)>;
+
+		ext_flash: ext-flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(8)>;
+			write-block-size = <1>;
+			erase-block-size = <DT_SIZE_K(4)>;
+
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
-			slot0_partition: partition@0 {
-				reg = <0x00000000 DT_SIZE_M(8)>;
+			partitions {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
+
+				slot0_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
+					reg = <0x00000000 DT_SIZE_M(8)>;
+				};
 			};
 		};
 	};

--- a/boards/weact/mini_stm32h743/mini_stm32h743.yaml
+++ b/boards/weact/mini_stm32h743/mini_stm32h743.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 512
-flash: 2048
+flash: 8192
 supported:
   - gpio
   - counter

--- a/boards/weact/mini_stm32h7b0/mini_stm32h7b0.dts
+++ b/boards/weact/mini_stm32h7b0/mini_stm32h7b0.dts
@@ -158,13 +158,30 @@ zephyr_udc0: &usbotg_hs {
 		data-rate = <OSPI_STR_TRANSFER>;
 		writeoc = "PP_1_1_4";
 
-		partitions {
-			compatible = "fixed-partitions";
+		/* OSPI external flash mapping */
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x90000000 DT_SIZE_M(8)>;
+
+		ext_flash: ext-flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(8)>;
+			write-block-size = <1>;
+			erase-block-size = <DT_SIZE_K(4)>;
+
 			#address-cells = <1>;
 			#size-cells = <1>;
+			ranges;
 
-			slot0_partition: partition@0 {
-				reg = <0x00000000 DT_SIZE_M(8)>;
+			partitions {
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges;
+
+				slot0_partition: partition@0 {
+					compatible = "zephyr,mapped-partition";
+					reg = <0x00000000 DT_SIZE_M(8)>;
+				};
 			};
 		};
 	};

--- a/boards/weact/mini_stm32h7b0/mini_stm32h7b0.yaml
+++ b/boards/weact/mini_stm32h7b0/mini_stm32h7b0.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 ram: 512
-flash: 2048
+flash: 8192
 supported:
   - gpio
   - counter


### PR DESCRIPTION
Update memory mapped external flash partitions descriptions of non-ST boards embedding a STM32 MCU from deprecated "fixed-partitions" compatible to "zephyr,mapped-partition" compatible.

