### PR TITLE
boards: adi: max32690fthr: Enable ARM MPU on M4 core

### DIFF
--- a/boards/adi/max32690fthr/max32690fthr_max32690_m4_defconfig
+++ b/boards/adi/max32690fthr/max32690fthr_max32690_m4_defconfig
@@ -1,5 +1,8 @@
-# Copyright (c) 2023-2024 Analog Devices, Inc.
+# Copyright (c) 2023-2026 Analog Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
+
+# Enable MPU
+CONFIG_ARM_MPU=y
 
 # Enable GPIO
 CONFIG_GPIO=y


### PR DESCRIPTION
Enable ARM MPU support on the MAX32690FTHR/M4 board to align it with other ARM-based ADI boards that already have MPU support enabled.

```
west build -p -b max32690fthr/max32690/m4 .\tests\kernel\mem_protect\userspace -T kernel.memory_protection.userspace \
-t flash
```

```
*** Booting Zephyr OS build v4.4.0-10049-ged09a9db9af5 ***
Running TESTSUITE userspace
===================================================================
START - test_access_after_revoke
...

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [userspace]: pass = 32, fail = 0, skip = 2, total = 34 duration = 1.512 seconds
 - PASS - [userspace.test_access_after_revoke] duration = 0.050 seconds
 - PASS - [userspace.test_bad_syscall] duration = 0.036 seconds
 - PASS - [userspace.test_disable_mmu_mpu] duration = 0.041 seconds
 - PASS - [userspace.test_is_post_kernel] duration = 0.001 seconds
 - PASS - [userspace.test_is_usermode] duration = 0.001 seconds
 - PASS - [userspace.test_kernel_only_thread] duration = 0.501 seconds
 - PASS - [userspace.test_object_recycle] duration = 0.001 seconds
 - PASS - [userspace.test_oops_exception] duration = 0.033 seconds
 - PASS - [userspace.test_oops_maxint] duration = 0.033 seconds
 - PASS - [userspace.test_oops_oops] duration = 0.032 seconds
 - PASS - [userspace.test_oops_panic] duration = 0.033 seconds
 - PASS - [userspace.test_oops_stackcheck] duration = 0.033 seconds
 - PASS - [userspace.test_pass_noperms_object] duration = 0.050 seconds
 - PASS - [userspace.test_pass_user_object] duration = 0.045 seconds
 - PASS - [userspace.test_read_kernel_data] duration = 0.041 seconds
 - PASS - [userspace.test_read_kernram] duration = 0.040 seconds
 - PASS - [userspace.test_read_kobject_user_pipe] duration = 0.042 seconds
 - PASS - [userspace.test_read_other_stack] duration = 0.040 seconds
 - PASS - [userspace.test_read_priv_stack] duration = 0.041 seconds
 - PASS - [userspace.test_revoke_noperms_object] duration = 0.052 seconds
 - PASS - [userspace.test_start_kernel_thread] duration = 0.039 seconds
 - PASS - [userspace.test_syscall_context] duration = 0.001 seconds
 - SKIP - [userspace.test_tls_leakage] duration = 0.001 seconds
 - SKIP - [userspace.test_tls_pointer] duration = 0.001 seconds
 - PASS - [userspace.test_unimplemented_syscall] duration = 0.036 seconds
 - PASS - [userspace.test_user_mode_enter] duration = 0.001 seconds
 - PASS - [userspace.test_write_control] duration = 0.001 seconds
 - PASS - [userspace.test_write_kernel_data] duration = 0.041 seconds
 - PASS - [userspace.test_write_kernram] duration = 0.041 seconds
 - PASS - [userspace.test_write_kernro] duration = 0.040 seconds
 - PASS - [userspace.test_write_kerntext] duration = 0.041 seconds
 - PASS - [userspace.test_write_kobject_user_pipe] duration = 0.042 seconds
 - PASS - [userspace.test_write_other_stack] duration = 0.040 seconds
 - PASS - [userspace.test_write_priv_stack] duration = 0.041 seconds

SUITE PASS - 100.00% [userspace_domain]: pass = 4, fail = 0, skip = 0, total = 4 duration = 0.086 seconds
 - PASS - [userspace_domain.test_1st_init_and_access_other_memdomain] duration = 0.040 seconds
 - PASS - [userspace_domain.test_domain_add_part_drop_to_user] duration = 0.002 seconds
 - PASS - [userspace_domain.test_domain_add_thread_drop_to_user] duration = 0.002 seconds
 - PASS - [userspace_domain.test_domain_remove_part_drop_to_user] duration = 0.042 seconds

SUITE PASS - 100.00% [userspace_domain_ctx]: pass = 3, fail = 0, skip = 0, total = 3 duration = 0.042 seconds
 - PASS - [userspace_domain_ctx.test_domain_add_part_context_switch] duration = 0.001 seconds
 - PASS - [userspace_domain_ctx.test_domain_add_thread_context_switch] duration = 0.001 seconds
 - PASS - [userspace_domain_ctx.test_domain_remove_part_context_switch] duration = 0.040 seconds

SUITE SKIP -   0.00% [userspace_domain_switching]: pass = 0, fail = 0, skip = 3, total = 3 duration = 0.003 seconds
 - SKIP - [userspace_domain_switching.test_kernel_only_switching] duration = 0.001 seconds
 - SKIP - [userspace_domain_switching.test_kernel_user_mix_switching] duration = 0.001 seconds
 - SKIP - [userspace_domain_switching.test_user_only_switching] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```