### PR TITLE
stm32: drivers: flash: stm32_xspi: invalidate d-cache on memory-mapped read 

### DIFF
--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -17,6 +17,7 @@
 #include <zephyr/kernel.h>
 #include <soc.h>
 #include <stm32_bitops.h>
+#include <zephyr/cache.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
@@ -1009,6 +1010,21 @@ static bool stm32_xspi_is_memorymap(const struct device *dev)
 	return stm32_reg_read_bits(&dev_data->hxspi.Instance->CR, XSPI_CR_FMODE) == XSPI_CR_FMODE;
 }
 
+static void stm32_xspi_invalidate_mmap_cache(const struct device *dev, off_t addr, size_t size)
+{
+	const struct flash_stm32_xspi_config *dev_cfg = dev->config;
+	size_t line_size = sys_cache_data_line_size_get();
+
+	if (line_size != 0 && IS_ENABLED(CONFIG_DCACHE) &&
+	    IS_ENABLED(CONFIG_FLASH_STM32_NOR_MEMMAP) &&
+	    IS_ENABLED(CONFIG_CACHE_MANAGEMENT)) {
+		uintptr_t start = ROUND_DOWN(dev_cfg->mem_map_based_address + addr, line_size);
+		uintptr_t end = ROUND_UP(dev_cfg->mem_map_based_address + addr + size, line_size);
+
+		sys_cache_data_invd_range((void *)start, end - start);
+	}
+}
+
 /*
  * Function to erase the flash : chip or sector with possible OCTO/SPI and STR/DTR
  * to erase the complete chip (using dedicated command) :
@@ -1042,6 +1058,9 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 		LOG_ERR("Error: wrong sector size 0x%x", size);
 		return -ENOTSUP;
 	}
+
+	const off_t erase_addr = addr;
+	const size_t erase_size = size;
 
 	xspi_lock_thread(dev);
 
@@ -1181,6 +1200,8 @@ static int flash_stm32_xspi_erase(const struct device *dev, off_t addr,
 	/* Ends the erase operation */
 
 erase_end:
+	stm32_xspi_invalidate_mmap_cache(dev, erase_addr, erase_size);
+
 	xspi_unlock_thread(dev);
 
 	return ret;
@@ -1325,6 +1346,9 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 		return 0;
 	}
 
+	const off_t write_addr = addr;
+	const size_t write_size = size;
+
 	xspi_lock_thread(dev);
 
 #ifdef CONFIG_FLASH_STM32_NOR_MEMMAP
@@ -1436,6 +1460,8 @@ static int flash_stm32_xspi_write(const struct device *dev, off_t addr,
 	/* Ends the write operation */
 
 write_end:
+	stm32_xspi_invalidate_mmap_cache(dev, write_addr, write_size);
+
 	xspi_unlock_thread(dev);
 
 	return ret;


### PR DESCRIPTION
This PR fixes regression introduced after this https://github.com/zephyrproject-rtos/zephyr/commit/a489894e9ae38bf345d82fa63a7df2b6c424e669 . It affects the samples/drivers/spi_flash sample on the `stm32h573i_dk` platform.



