### PR TITLE
boards: nxp: lpc845brk: fix board name

### DIFF
--- a/boards/nxp/lpc845brk/lpc845brk.yaml
+++ b/boards/nxp/lpc845brk/lpc845brk.yaml
@@ -1,5 +1,5 @@
 identifier: lpc845brk
-name: LPC845 Breakout Board
+name: NXP LPC845-BRK
 type: mcu
 arch: arm
 ram: 16


### PR DESCRIPTION
- Updates the board name to "NXP LPC845-BRK" to include the vendor prefix and match the official board naming.
- No functional change. Just visual fix to unify with other NXP boards how it's shown in MCUx VSCode board list.