### PR TITLE
twister harness robot: Handle better missing robot executable

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -248,7 +248,7 @@ class Robot(Harness):
         try:
             renode_test_proc = subprocess.Popen(command, stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT, cwd=self.instance.build_dir, env=env)
-        except FileNotFoundError as err:
+        except (FileNotFoundError, PermissionError) as err:
             reason = f"Robot test executable '{command[0]}' not found: {err.strerror}"
             logger.warning(reason)
             self.instance.status = TwisterStatus.SKIP


### PR DESCRIPTION
Depending on conditions, PermissionError may also be raised if there is no executable to run.
So let's also handle it

This expands on the fix from a18fd195bffa559f0631ac908eceef7d95792693
* https://github.com/zephyrproject-rtos/zephyr/pull/114307

