### PR TITLE
Add to scheduled scanners: gcc analyzer + lsan/asan/ubsan with twister

### DIFF
--- a/.github/workflows/gcc-analyzer.yml
+++ b/.github/workflows/gcc-analyzer.yml
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# GCC static analyzer (-fanalyzer) scan, reported to the Security dashboard.
+#
+
+name: GCC Static Analyzer
+
+on:
+  schedule:
+    # Run at 04:00 UTC on every day.
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.profile }})
+    if: github.repository_owner == 'zephyrproject-rtos'
+    runs-on:
+      group: zephyr-runner-v2-linux-x64-4xlarge
+    container:
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      options: '--entrypoint /bin/bash'
+    timeout-minutes: 720
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - profile: kernel
+            twister-args: >-
+              -p qemu_x86 -p qemu_cortex_m3
+              -T tests/kernel -T tests/lib -T tests/arch
+
+          - profile: connectivity
+            twister-args: >-
+              -p qemu_x86
+              -T tests/net -T tests/bluetooth
+
+          - profile: subsys
+            twister-args: >-
+              -p qemu_x86
+              -T tests/subsys -T tests/drivers
+
+    env:
+      ZEPHYR_TOOLCHAIN_VARIANT: zephyr
+      USE_CCACHE: "0"
+
+    steps:
+      - name: Apply container owner mismatch workaround
+        run: |
+          # FIXME: The owner UID of the GITHUB_WORKSPACE directory may not
+          #        match the container user UID because of the way GitHub
+          #        Actions runner is implemented. Remove this workaround when
+          #        GitHub comes up with a fundamental fix for this problem.
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+      - name: Clone cached Zephyr repository
+        continue-on-error: true
+        run: |
+          git clone --shared /repo-cache/zephyrproject/zephyr .
+          git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Zephyr environment
+        uses: ./.github/actions/zephyr-ci-env
+        with:
+          group-filter: '+ci,+optional,+testing'
+          run-checks: 'true'
+
+      - name: Install Python packages
+        run: |
+          pip install -r scripts/requirements-actions.txt --require-hashes
+
+      - name: Build with the GCC analyzer
+        run: |
+          export ZEPHYR_BASE=${PWD}
+
+          # As with the CodeQL scan, a partially built tree is still worth
+          # reporting on: a board that fails to configure must not cost us the
+          # findings from everything that did compile.
+          set +e
+          ./scripts/twister \
+            --build-only \
+            --inline-logs --force-color -v \
+            --outdir twister-out-gcc-sca \
+            -j 16 \
+            -xZEPHYR_SCA_VARIANT=gcc \
+            -xUSE_CCACHE=0 \
+            "-xGCC_SCA_OPTS=-fdiagnostics-format=sarif-file;-Wno-error;-Wno-analyzer-too-complex" \
+            ${{ matrix.twister-args }}
+          status=$?
+          set -e
+
+          if [ ${status} -ne 0 ]; then
+            echo "::warning title=Incomplete analyzer build::twister exited ${status} for" \
+                 "profile '${{ matrix.profile }}'; reporting on the translation units that" \
+                 "did compile. Coverage for this profile is incomplete."
+          fi
+
+      - name: Merge analyzer output
+        run: |
+          # GCC leaves one SARIF file per translation unit in each build
+          # directory, so this collapses thousands of files -- most of them
+          # empty -- into one report with repository-relative paths.
+          python3 scripts/ci/gcc_sca_sarif.py twister-out-gcc-sca \
+            --source-root "${PWD}" \
+            -o results-${{ matrix.profile }}.sarif
+
+      - name: Upload profile SARIF
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gcc-sca-sarif-${{ matrix.profile }}
+          if-no-files-found: error
+          retention-days: 7
+          path: results-${{ matrix.profile }}.sarif
+
+  upload:
+    name: Upload to code scanning
+    needs: analyze
+    # Report whatever finished. One profile timing out should not cost the
+    # findings from the others.
+    if: always() && github.repository_owner == 'zephyrproject-rtos'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download profile SARIF
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: gcc-sca-sarif-*
+          merge-multiple: true
+          path: sarif-in
+
+      - name: Merge profiles into one report
+        id: merge
+        run: |
+          set -eu
+          if ! ls sarif-in/*.sarif >/dev/null 2>&1; then
+            echo "::warning title=No analyzer results::every profile failed before" \
+                 "producing a report; nothing to upload"
+            echo "found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          # The merge is idempotent, so the same script folds the per-profile
+          # reports together and drops findings duplicated across profiles --
+          # shared code is recompiled by each one.
+          python3 scripts/ci/gcc_sca_sarif.py sarif-in \
+            --source-root "${PWD}" \
+            -o results.sarif
+          echo "found=true" >> $GITHUB_OUTPUT
+
+      - name: Write job summary
+        if: steps.merge.outputs.found == 'true'
+        run: python3 scripts/ci/sarif_summary.py results.sarif
+
+      - name: Upload SARIF to code scanning
+        if: steps.merge.outputs.found == 'true'
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: results.sarif
+          # Keeps these alerts in their own lane in the dashboard, so they
+          # neither collide with nor get closed by the CodeQL and Eclair runs.
+          category: gcc-static-analyzer
+
+      - name: Upload SARIF as artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gcc-sca-sarif
+          if-no-files-found: ignore
+          retention-days: 30
+          path: results.sarif

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Sanitizer run on native_sim, reported to the Security dashboard.
+#
+name: Sanitizers
+
+on:
+  schedule:
+    # Run at 06:00 UTC on every day.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sanitize:
+    name: Run under ${{ matrix.name }}
+    if: github.repository_owner == 'zephyrproject-rtos'
+    runs-on:
+      group: zephyr-runner-v2-linux-x64-4xlarge
+    container:
+      image: ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.29.3.20260727
+      options: '--entrypoint /bin/bash'
+    timeout-minutes: 600
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: AddressSanitizer
+            sanitizer: asan
+            # LSan only reports at exit and needs ASan, so they pair.
+            twister-args: '--enable-asan --enable-lsan'
+
+          - name: UndefinedBehaviorSanitizer
+            sanitizer: ubsan
+            twister-args: '--enable-ubsan'
+
+    env:
+      ZEPHYR_TOOLCHAIN_VARIANT: zephyr
+      # The subsystems worth the runtime cost: the parsers and state machines
+      # that process attacker-controlled input, plus the libraries under them.
+      TEST_ROOTS: '-T tests/net -T tests/bluetooth -T tests/subsys -T tests/lib'
+
+    steps:
+      - name: Apply container owner mismatch workaround
+        run: |
+          # FIXME: The owner UID of the GITHUB_WORKSPACE directory may not
+          #        match the container user UID because of the way GitHub
+          #        Actions runner is implemented. Remove this workaround when
+          #        GitHub comes up with a fundamental fix for this problem.
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
+      - name: Clone cached Zephyr repository
+        continue-on-error: true
+        run: |
+          git clone --shared /repo-cache/zephyrproject/zephyr .
+          git remote set-url origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Zephyr environment
+        uses: ./.github/actions/zephyr-ci-env
+        with:
+          group-filter: '+ci,+optional,+testing'
+          run-checks: 'true'
+
+      - name: Install Python packages
+        run: |
+          pip install -r scripts/requirements-actions.txt --require-hashes
+
+      - name: Run tests under ${{ matrix.name }}
+        run: |
+          export ZEPHYR_BASE=${PWD}
+
+          # A sanitizer finding fails its test, so a non-zero exit is the
+          # expected outcome of a productive run and must not fail the job --
+          # the findings are the point. twister.yaml remains the gate.
+          set +e
+          ./scripts/twister \
+            -p native_sim \
+            --inline-logs --force-color -v \
+            --outdir twister-out-${{ matrix.sanitizer }} \
+            -j 16 \
+            ${{ matrix.twister-args }} \
+            ${TEST_ROOTS}
+          status=$?
+          set -e
+
+          if [ ${status} -ne 0 ]; then
+            echo "::notice title=${{ matrix.name }} run had failures::twister exited" \
+                 "${status}; this is expected when the sanitizer reports. See the" \
+                 "uploaded SARIF for the findings."
+          fi
+
+      - name: Convert findings to SARIF
+        run: |
+          python3 scripts/ci/sanitizer_sarif.py twister-out-${{ matrix.sanitizer }} \
+            --source-root "${PWD}" \
+            -o results-${{ matrix.sanitizer }}.sarif
+
+      - name: Write job summary
+        run: python3 scripts/ci/sarif_summary.py results-${{ matrix.sanitizer }}.sarif
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: results-${{ matrix.sanitizer }}.sarif
+          # One category per sanitizer. They report disjoint rule sets, and a
+          # shared category would let whichever job finished last close the
+          # other's alerts.
+          category: sanitizers-${{ matrix.sanitizer }}
+
+      - name: Upload SARIF as artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sanitizer-sarif-${{ matrix.sanitizer }}
+          if-no-files-found: ignore
+          retention-days: 30
+          path: results-${{ matrix.sanitizer }}.sarif
+
+      - name: Upload sanitizer logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sanitizer-logs-${{ matrix.sanitizer }}
+          if-no-files-found: ignore
+          retention-days: 7
+          path: |
+            twister-out-${{ matrix.sanitizer }}/twister.log
+            twister-out-${{ matrix.sanitizer }}/twister.json

--- a/scripts/ci/gcc_sca_sarif.py
+++ b/scripts/ci/gcc_sca_sarif.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Merge the SARIF files produced by the GCC static analyzer into one upload.
+
+``-fdiagnostics-format=sarif-file`` makes GCC write one SARIF file per
+translation unit, named after the input file and dropped in the compiler's
+working directory (the CMake build directory).  A twister run therefore leaves
+thousands of these scattered across the output tree, the vast majority holding
+no results at all.  GitHub wants a single file, so they have to be merged.
+
+The merge is not just concatenation; four things have to be fixed up before
+code scanning will take the result:
+
+* GCC records **absolute** paths.  GitHub resolves result locations against the
+  repository root and silently drops anything it cannot map, so paths are
+  rewritten relative to the source root and results outside it (SDK headers,
+  west modules) are discarded rather than uploaded as unmappable noise.
+* Each run embeds the full text of every artifact it touched under
+  ``artifacts[].contents``, which is where nearly all of the file size comes
+  from -- a single translation unit reporting two leaks weighs 66 KB.  GitHub
+  rejects oversized uploads, so the embedded contents are dropped.
+* The tool name varies with the input language (``GNU C17``, ``GNU C++17``).
+  Code scanning keys alert identity partly on the tool, so the driver name is
+  normalised to keep alerts stable across the tree and across runs.
+* Shared code is recompiled by every build in the matrix, so the same finding
+  reappears once per build.  Results are deduplicated on
+  (rule, file, line, column, message).
+
+The CWE taxonomy GCC already emits is preserved and merged: it is what makes
+the alerts land in the dashboard with a CWE attached.
+
+Usage:
+    python3 scripts/ci/gcc_sca_sarif.py twister-out-gcc-sca -o results.sarif
+"""
+
+import argparse
+import collections
+import json
+import os
+import pathlib
+import sys
+
+import sarif_utils
+
+# Conservative ceiling. GitHub imposes its own per-upload limits and rejects
+# the whole file when they are exceeded; losing every result to a hard reject
+# is worse than uploading the first N and saying so. Truncation is always
+# reported, never silent.
+DEFAULT_MAX_RESULTS = 5000
+
+DRIVER_NAME = "GCC Static Analyzer"
+DRIVER_URI = "https://gcc.gnu.org/onlinedocs/gcc/Static-Analyzer-Options.html"
+
+# GCC's rule metadata is just an id and a help URI. GitHub files an alert as a
+# security alert only when its rule carries the "security" tag, and ranks it by
+# "security-severity", so forwarding GCC's rules verbatim would land a
+# use-after-free here as an ordinary quality alert while the identical finding
+# from the sanitizer scan lands as a critical security one. The severities
+# below match sanitizer_sarif.py so that the two scans rank the same defect
+# classes the same way.
+SEVERITY = {"corruption": "9.0", "undefined": "7.0", "leak": "5.0"}
+
+# Memory corruption: a reachable write or read outside the object's lifetime
+# or bounds.
+_CORRUPTION = (
+    "-Wanalyzer-allocation-size",
+    "-Wanalyzer-double-free",
+    "-Wanalyzer-free-of-non-heap",
+    "-Wanalyzer-mismatching-deallocation",
+    "-Wanalyzer-out-of-bounds",
+    "-Wanalyzer-overlapping-buffers",
+    "-Wanalyzer-putenv-of-auto-var",
+    "-Wanalyzer-stale-setjmp-buffer",
+    "-Wanalyzer-tainted-allocation-size",
+    "-Wanalyzer-tainted-array-index",
+    "-Wanalyzer-tainted-offset",
+    "-Wanalyzer-tainted-size",
+    "-Wanalyzer-use-after-free",
+    "-Wanalyzer-use-of-pointer-in-stale-stack-frame",
+    "-Wanalyzer-write-to-const",
+    "-Wanalyzer-write-to-string-literal",
+    # The front end finds the same defect classes without the analyzer, and
+    # ships them through the same SARIF file.
+    "-Warray-bounds",
+    "-Wdangling-pointer",
+    "-Wfree-nonheap-object",
+    "-Wreturn-local-addr",
+    "-Wstringop-overflow",
+    "-Wstringop-overread",
+    "-Wuse-after-free",
+)
+
+# Undefined behaviour, and untrusted input reaching an operation that trusts it.
+_UNDEFINED = (
+    "-Wanalyzer-deref-before-check",
+    "-Wanalyzer-double-fclose",
+    "-Wanalyzer-exposure-through-output-file",
+    "-Wanalyzer-exposure-through-uninit-copy",
+    "-Wanalyzer-fd-access-mode-mismatch",
+    "-Wanalyzer-fd-double-close",
+    "-Wanalyzer-fd-phase-mismatch",
+    "-Wanalyzer-fd-type-mismatch",
+    "-Wanalyzer-fd-use-after-close",
+    "-Wanalyzer-fd-use-without-check",
+    "-Wanalyzer-infinite-recursion",
+    "-Wanalyzer-jump-through-null",
+    "-Wanalyzer-null-argument",
+    "-Wanalyzer-null-dereference",
+    "-Wanalyzer-possible-null-argument",
+    "-Wanalyzer-possible-null-dereference",
+    "-Wanalyzer-shift-count-negative",
+    "-Wanalyzer-shift-count-overflow",
+    "-Wanalyzer-tainted-assertion",
+    "-Wanalyzer-tainted-divisor",
+    "-Wanalyzer-undefined-behavior-strtok",
+    "-Wanalyzer-unsafe-call-within-signal-handler",
+    "-Wanalyzer-use-of-uninitialized-value",
+    "-Wanalyzer-va-arg-type-mismatch",
+    "-Wanalyzer-va-list-exhausted",
+    "-Wanalyzer-va-list-use-after-va-end",
+    "-Wmaybe-uninitialized",
+    "-Wnonnull",
+    "-Wuninitialized",
+)
+
+# Resources the code allocates and never gives back.
+_LEAK = (
+    "-Wanalyzer-fd-leak",
+    "-Wanalyzer-file-leak",
+    "-Wanalyzer-malloc-leak",
+    "-Wanalyzer-va-list-leak",
+)
+
+RULE_CLASS = {
+    rule: severity_class
+    for severity_class, rules in (
+        ("corruption", _CORRUPTION),
+        ("undefined", _UNDEFINED),
+        ("leak", _LEAK),
+    )
+    for rule in rules
+}
+
+
+def annotate_rule(rule):
+    """Tag *rule* as a security rule when it describes a security defect.
+
+    Anything not in the table keeps GCC's metadata untouched and surfaces as an
+    ordinary alert: -Wanalyzer-too-complex and friends report on the analyzer
+    giving up, not on a defect in the code, and tagging those as security would
+    only dilute the dashboard.
+    """
+    # Warnings that take a level spell their rule id with the trailing "=",
+    # as in "-Warray-bounds=".
+    severity_class = RULE_CLASS.get(rule["id"].rstrip("="))
+    if severity_class is None:
+        return rule
+
+    properties = dict(rule.get("properties", {}))
+    properties["tags"] = sorted({*properties.get("tags", []), "security"})
+    properties["security-severity"] = SEVERITY[severity_class]
+    return dict(rule, properties=properties)
+
+
+def result_key(result):
+    """Identity used for deduplication across builds, and for sorting.
+
+    Every field here is optional in SARIF -- GCC emits diagnostics with no
+    ruleId, and regions without a column -- so the key is stringified to stay
+    totally ordered. Comparing a missing ruleId against a present one would
+    otherwise raise partway through the sort.
+    """
+    location = (result.get("locations") or [{}])[0]
+    physical = location.get("physicalLocation", {})
+    region = physical.get("region", {})
+    return sarif_utils.stable_key(
+        result.get("ruleId"),
+        physical.get("artifactLocation", {}).get("uri"),
+        region.get("startLine"),
+        region.get("startColumn"),
+        result.get("message", {}).get("text"),
+    )
+
+
+def collect(paths, source_root):
+    """Merge every SARIF file under *paths*.
+
+    Returns (results, rules, taxonomies, stats).
+    """
+    results = {}
+    rules = {}
+    taxonomies = {}
+    stats = collections.Counter()
+
+    for sarif_path in sorted(paths):
+        stats["files"] += 1
+        try:
+            with open(sarif_path, encoding="utf-8") as handle:
+                document = json.load(handle)
+        except (OSError, json.JSONDecodeError) as err:
+            # A build killed mid-write leaves a truncated file. One unreadable
+            # translation unit must not sink the whole report.
+            print(f"warning: skipping {sarif_path}: {err}", file=sys.stderr)
+            stats["unreadable"] += 1
+            continue
+
+        for run in document.get("runs", []):
+            driver = run.get("tool", {}).get("driver", {})
+            for rule in driver.get("rules", []):
+                rules.setdefault(rule["id"], rule)
+
+            for taxonomy in run.get("taxonomies", []):
+                merged = taxonomies.setdefault(taxonomy.get("name"), dict(taxonomy, taxa=[]))
+                known = {taxon["id"] for taxon in merged["taxa"]}
+                merged["taxa"].extend(
+                    taxon for taxon in taxonomy.get("taxa", []) if taxon["id"] not in known
+                )
+
+            for result in run.get("results", []):
+                stats["raw"] += 1
+
+                locations = result.get("locations") or []
+                if not locations:
+                    stats["unlocated"] += 1
+                    continue
+                if not sarif_utils.rewrite_location(locations[0], source_root):
+                    stats["external"] += 1
+                    continue
+
+                # Secondary locations are kept only when they survive the
+                # rewrite. Dropping them is not cosmetic: a related location
+                # with no physical location of its own, which GCC emits for
+                # notes like "argument 1 of 'x' must be non-null", makes code
+                # scanning reject the entire upload.
+                result["locations"] = [locations[0]] + [
+                    extra
+                    for extra in locations[1:]
+                    if sarif_utils.rewrite_location(extra, source_root)
+                ]
+                related = [
+                    extra
+                    for extra in (result.get("relatedLocations") or [])
+                    if sarif_utils.rewrite_location(extra, source_root)
+                ]
+                if related:
+                    result["relatedLocations"] = related
+                else:
+                    result.pop("relatedLocations", None)
+
+                sarif_utils.prune_code_flows(result, source_root)
+
+                key = result_key(result)
+                if key in results:
+                    stats["duplicate"] += 1
+                    continue
+                results[key] = result
+
+    return list(results.values()), rules, taxonomies, stats
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    parser.add_argument("search_root", help="directory to scan for *.sarif files")
+    parser.add_argument("-o", "--output", default="results.sarif")
+    parser.add_argument(
+        "--source-root",
+        default=os.environ.get("ZEPHYR_BASE", os.getcwd()),
+        help="repository root that result paths are made relative to",
+    )
+    parser.add_argument("--max-results", type=int, default=DEFAULT_MAX_RESULTS)
+    args = parser.parse_args()
+
+    source_root = pathlib.Path(args.source_root).resolve()
+    sarif_files = list(pathlib.Path(args.search_root).rglob("*.sarif"))
+
+    results, rules, taxonomies, stats = collect(sarif_files, source_root)
+
+    # Report the worst first so that truncation, if it happens, keeps the
+    # findings most likely to matter.
+    severity = {"error": 0, "warning": 1, "note": 2}
+    results.sort(key=lambda r: (severity.get(r.get("level"), 3), result_key(r)))
+
+    results, dropped = sarif_utils.cap_results(results, args.max_results)
+
+    document = sarif_utils.build_document(
+        DRIVER_NAME,
+        DRIVER_URI,
+        [annotate_rule(rule) for rule in sorted(rules.values(), key=lambda r: r["id"])],
+        results,
+        list(taxonomies.values()),
+    )
+
+    sarif_utils.write_report(
+        document,
+        args.output,
+        dropped,
+        args.max_results,
+        f"scanned {stats['files']} SARIF files: {stats['raw']} raw results, "
+        f"{stats['duplicate']} duplicates, {stats['external']} outside the source root, "
+        f"{stats['unlocated']} without a location, {stats['unreadable']} unreadable files",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/sanitizer_sarif.py
+++ b/scripts/ci/sanitizer_sarif.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Turn sanitizer findings from a twister run into a SARIF report.
+
+Twister has no SARIF writer, and sanitizer output is not part of its report
+model: a run that trips AddressSanitizer is recorded as ``rc=1`` and nothing
+more.  The diagnostics themselves survive only in the per-instance logs, so
+this walks the twister output tree and reconstructs them.
+
+Two logs matter, because the sanitizers do not agree on where to write:
+
+    handler.log         ASan and LSan (twister sets ASAN_OPTIONS=log_path=stdout)
+    handler_stderr.log  UBSan, which ignores that and writes to stderr
+
+Three report formats are parsed:
+
+    ASan   ==PID==ERROR: AddressSanitizer: <type> on address 0x...
+           followed by one or more "    #N 0xaddr in <func> <file>:<line>"
+           stacks and a SUMMARY line.
+    LSan   ==PID==ERROR: LeakSanitizer: detected memory leaks
+           followed by one "Direct leak"/"Indirect leak" block per leak, each
+           with its own allocation stack.
+    UBSan  <file>:<line>:<col>: runtime error: <description>
+           a single line, with no stack unless print_stacktrace is enabled.
+
+Unlike a static analyzer, these findings are proven reachable -- the code
+actually executed and misbehaved -- so they are reported at "error" level.
+Coverage is bounded by what the tests exercise, which is the opposite
+trade-off to the static scans.
+
+Usage:
+    python3 scripts/ci/sanitizer_sarif.py twister-out-asan -o results.sarif
+"""
+
+import argparse
+import collections
+import os
+import pathlib
+import re
+import sys
+
+import sarif_utils
+
+DRIVER_NAME = "Sanitizers"
+DRIVER_URI = "https://github.com/google/sanitizers"
+
+DEFAULT_MAX_RESULTS = 5000
+
+# A stack frame with source information, e.g.
+#     #1 0x8049a1f in sanleak_test_leak /path/to/main.c:8
+# Frames without a resolved source file (bare addresses into libc) are left
+# unmatched on purpose: they carry nothing GitHub could render.
+FRAME_RE = re.compile(
+    r"^\s*#(?P<depth>\d+)\s+0x[0-9a-fA-F]+\s+in\s+(?P<func>\S+)\s+"
+    r"(?P<file>[^\s]+?):(?P<line>\d+)(?::(?P<col>\d+))?\s*$"
+)
+
+ASAN_ERROR_RE = re.compile(r"^==\d+==ERROR:\s+AddressSanitizer:\s+(?P<kind>[a-zA-Z0-9_-]+)")
+LSAN_ERROR_RE = re.compile(r"^==\d+==ERROR:\s+LeakSanitizer:\s+(?P<desc>.+?)\s*$")
+LEAK_BLOCK_RE = re.compile(
+    r"^(?P<kind>Direct|Indirect) leak of (?P<bytes>\d+) byte\(s\) in "
+    r"(?P<objects>\d+) object\(s\) allocated from:"
+)
+UBSAN_RE = re.compile(
+    r"^(?P<file>[^\s]+?):(?P<line>\d+):(?P<col>\d+):\s+runtime error:\s+(?P<desc>.+?)\s*$"
+)
+
+# Hex addresses differ between runs, so they are masked out of the text used
+# for deduplication. Without this the same defect looks new on every run and
+# the dashboard fills with duplicates that never close.
+ADDR_RE = re.compile(r"0x[0-9a-fA-F]+")
+
+# Only mappings that are unambiguous. A wrong CWE is worse than none, so
+# checks whose classification is arguable are left untagged.
+ASAN_CWE = {
+    "heap-buffer-overflow": "122",
+    "stack-buffer-overflow": "121",
+    "stack-buffer-underflow": "124",
+    "global-buffer-overflow": "787",
+    "heap-use-after-free": "416",
+    "stack-use-after-return": "562",
+    "stack-use-after-scope": "562",
+    "double-free": "415",
+    "alloc-dealloc-mismatch": "762",
+    "SEGV": "476",
+}
+
+LSAN_CWE = "401"
+
+UBSAN_CWE = (
+    ("signed integer overflow", "190"),
+    ("unsigned integer overflow", "190"),
+    ("division by zero", "369"),
+    ("null pointer", "476"),
+    ("out of bounds", "125"),
+    ("shift exponent", "1335"),
+)
+
+# GitHub ranks alerts by security-severity and only files them as security
+# alerts when the rule is tagged as such. Memory corruption outranks a leak.
+SEVERITY = {"corruption": "9.0", "leak": "5.0", "undefined": "7.0"}
+
+
+def classify_ubsan(description):
+    """Return (rule suffix, cwe) for a UBSan description."""
+    lowered = description.lower()
+    for needle, cwe in UBSAN_CWE:
+        if needle in lowered:
+            return needle.replace(" ", "-"), cwe
+    return "runtime-error", None
+
+
+def _frame_location(match, message=None):
+    """Build a SARIF location from a stack frame match."""
+    region = {"startLine": int(match.group("line"))}
+    if match.group("col"):
+        region["startColumn"] = int(match.group("col"))
+
+    location = {
+        "physicalLocation": {
+            "artifactLocation": {"uri": match.group("file")},
+            "region": region,
+        }
+    }
+    if message:
+        location["message"] = {"text": message}
+    return location
+
+
+def parse_stack(lines, start):
+    """Collect consecutive stack frames beginning at *start*.
+
+    Returns (frames, next_index). Frames that carry no source location end the
+    run of interest but do not stop collection, so a stack that dips through
+    libc and comes back is not truncated.
+    """
+    frames = []
+    index = start
+    while index < len(lines):
+        line = lines[index]
+        match = FRAME_RE.match(line)
+        if match:
+            frames.append(match)
+            index += 1
+            continue
+        # A bare "#N 0xaddr (...)" frame has no source info; skip it but stay
+        # in the stack.
+        if re.match(r"^\s*#\d+\s+0x[0-9a-fA-F]+", line):
+            index += 1
+            continue
+        break
+    return frames, index
+
+
+def _make_result(rule_id, level, text, frames, cwe, properties, source_root):
+    """Build a SARIF result from a message and its stack frames.
+
+    The primary location is the shallowest frame that lies inside the
+    repository, not simply the shallowest frame: an ASan or LSan stack almost
+    always begins inside the sanitizer runtime's own interceptor (malloc,
+    free, memcpy), and anchoring an alert there would point every leak at
+    libsanitizer instead of at the code that leaked. The full stack is kept as
+    a code flow; sarif_utils.prune_code_flows strips the external frames from
+    it afterwards.
+
+    Returns None when no frame is in the repository, which is how findings
+    entirely inside the toolchain get dropped.
+    """
+    primary = next(
+        (
+            frame
+            for frame in frames
+            if sarif_utils.relativize(frame.group("file"), source_root) is not None
+        ),
+        None,
+    )
+    if primary is None:
+        return None
+
+    result = {
+        "ruleId": rule_id,
+        "level": level,
+        "message": {"text": text},
+        "locations": [_frame_location(primary)],
+        "properties": properties,
+    }
+
+    if len(frames) > 1:
+        result["codeFlows"] = [
+            {
+                "threadFlows": [
+                    {
+                        "locations": [
+                            {
+                                "location": _frame_location(
+                                    frame, f"#{frame.group('depth')} {frame.group('func')}"
+                                )
+                            }
+                            for frame in frames
+                        ]
+                    }
+                ]
+            }
+        ]
+
+    if cwe:
+        result["taxa"] = [{"id": cwe, "toolComponent": {"name": "CWE"}}]
+
+    return result
+
+
+def parse_log(text, instance, source_root):
+    """Yield (result, cwe, severity_class) for every finding in *text*."""
+    lines = text.splitlines()
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+
+        asan = ASAN_ERROR_RE.match(line)
+        if asan:
+            kind = asan.group("kind")
+            # The access line ("WRITE of size 1 at ...") sits between the
+            # error banner and the stack; skip ahead to the frames.
+            frames, index = parse_stack(lines, index + 1)
+            if not frames:
+                frames, index = parse_stack(lines, index + 1)
+            cwe = ASAN_CWE.get(kind)
+            result = _make_result(
+                f"asan-{kind}",
+                "error",
+                f"AddressSanitizer: {kind}",
+                frames,
+                cwe,
+                {"sanitizer": "address", "testInstance": instance},
+                source_root,
+            )
+            if result:
+                yield result, cwe, "corruption"
+            continue
+
+        if LSAN_ERROR_RE.match(line):
+            index += 1
+            continue
+
+        leak = LEAK_BLOCK_RE.match(line)
+        if leak:
+            frames, index = parse_stack(lines, index + 1)
+            kind = leak.group("kind").lower()
+            result = _make_result(
+                f"lsan-{kind}-leak",
+                "error",
+                f"LeakSanitizer: {leak.group('kind').lower()} leak of "
+                f"{leak.group('bytes')} byte(s) in {leak.group('objects')} object(s)",
+                frames,
+                LSAN_CWE,
+                {"sanitizer": "leak", "testInstance": instance},
+                source_root,
+            )
+            if result:
+                yield result, LSAN_CWE, "leak"
+            continue
+
+        ubsan = UBSAN_RE.match(line)
+        if ubsan:
+            suffix, cwe = classify_ubsan(ubsan.group("desc"))
+            frames, index = parse_stack(lines, index + 1)
+            result = {
+                "ruleId": f"ubsan-{suffix}",
+                "level": "error",
+                "message": {"text": f"UndefinedBehaviorSanitizer: {ubsan.group('desc')}"},
+                "locations": [_frame_location(ubsan)],
+                "properties": {"sanitizer": "undefined", "testInstance": instance},
+            }
+            if cwe:
+                result["taxa"] = [{"id": cwe, "toolComponent": {"name": "CWE"}}]
+            if frames:
+                result["codeFlows"] = [
+                    {
+                        "threadFlows": [
+                            {
+                                "locations": [
+                                    {"location": _frame_location(frame)} for frame in frames
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            yield result, cwe, "undefined"
+            continue
+
+        index += 1
+
+
+def result_key(result):
+    """Identity used for deduplication across test instances.
+
+    Deliberately excludes the test instance and any hex address: the same
+    defect reached by twenty tests is one defect, and its addresses differ on
+    every run.
+    """
+    physical = result["locations"][0]["physicalLocation"]
+    region = physical.get("region", {})
+    return (
+        result["ruleId"],
+        physical["artifactLocation"]["uri"],
+        region.get("startLine"),
+        ADDR_RE.sub("0xADDR", result["message"]["text"]),
+    )
+
+
+def collect(outdir, source_root):
+    """Parse every sanitizer log under *outdir*."""
+    results = {}
+    cwes = set()
+    rule_class = {}
+    stats = collections.Counter()
+
+    logs = sorted(pathlib.Path(outdir).rglob("handler.log")) + sorted(
+        pathlib.Path(outdir).rglob("handler_stderr.log")
+    )
+
+    for log_path in logs:
+        stats["logs"] += 1
+        try:
+            text = log_path.read_text(encoding="utf-8", errors="replace")
+        except OSError as err:
+            print(f"warning: skipping {log_path}: {err}", file=sys.stderr)
+            stats["unreadable"] += 1
+            continue
+
+        if not text:
+            continue
+
+        # The build directory name is the twister instance name, which is what
+        # tells a maintainer how to reproduce the finding.
+        instance = log_path.parent.name
+
+        for result, cwe, severity_class in parse_log(text, instance, source_root):
+            stats["raw"] += 1
+
+            if not sarif_utils.rewrite_location(result["locations"][0], source_root):
+                stats["external"] += 1
+                continue
+            sarif_utils.prune_code_flows(result, source_root)
+
+            key = result_key(result)
+            if key in results:
+                stats["duplicate"] += 1
+                continue
+
+            results[key] = result
+            rule_class[result["ruleId"]] = severity_class
+            if cwe:
+                cwes.add(cwe)
+
+    return list(results.values()), cwes, rule_class, stats
+
+
+def build_rules(rule_class):
+    """Build rule metadata, tagged so GitHub files these as security alerts."""
+    return [
+        {
+            "id": rule_id,
+            "name": rule_id,
+            "shortDescription": {"text": rule_id},
+            "properties": {
+                "tags": ["security"],
+                "security-severity": SEVERITY.get(severity_class, "5.0"),
+            },
+        }
+        for rule_id, severity_class in sorted(rule_class.items())
+    ]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    parser.add_argument("outdir", help="twister output directory to scan")
+    parser.add_argument("-o", "--output", default="results.sarif")
+    parser.add_argument(
+        "--source-root",
+        default=os.environ.get("ZEPHYR_BASE", os.getcwd()),
+        help="repository root that result paths are made relative to",
+    )
+    parser.add_argument("--max-results", type=int, default=DEFAULT_MAX_RESULTS)
+    args = parser.parse_args()
+
+    source_root = pathlib.Path(args.source_root).resolve()
+    results, cwes, rule_class, stats = collect(args.outdir, source_root)
+
+    results.sort(key=result_key)
+    results, dropped = sarif_utils.cap_results(results, args.max_results)
+
+    document = sarif_utils.build_document(
+        DRIVER_NAME,
+        DRIVER_URI,
+        build_rules(rule_class),
+        results,
+        sarif_utils.make_cwe_taxonomy(cwes),
+    )
+
+    sarif_utils.write_report(
+        document,
+        args.output,
+        dropped,
+        args.max_results,
+        f"scanned {stats['logs']} logs: {stats['raw']} raw findings, "
+        f"{stats['duplicate']} duplicates, {stats['external']} outside the source root, "
+        f"{stats['unreadable']} unreadable logs",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/sarif_utils.py
+++ b/scripts/ci/sarif_utils.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for turning scanner output into a SARIF upload.
+
+Every scanner wired into the code scanning dashboard hits the same handful of
+problems, so they are solved once here rather than per tool:
+
+* Findings carry absolute paths. GitHub resolves result locations against the
+  repository root and silently drops what it cannot map, so paths have to be
+  made relative and results outside the checkout discarded.
+* Stack traces and analyzer execution paths run through code that is not in
+  this repository (toolchain headers, sanitizer runtimes, libc). Those steps
+  have to go, without throwing away the frames that are in the tree.
+* The same finding is reported once per build, because a matrix recompiles or
+  re-executes shared code many times.
+
+Used by gcc_sca_sarif.py and sanitizer_sarif.py.
+"""
+
+import json
+import os
+import pathlib
+import sys
+
+CWE_HELP = "https://cwe.mitre.org/data/definitions/{}.html"
+
+
+def relativize(uri, source_root):
+    """Return *uri* relative to *source_root*, or None if it falls outside.
+
+    Handles the plain absolute paths scanners emit as well as ``file://``
+    URIs. Symlinks are resolved on both sides so a build under a symlinked
+    path still maps onto the checkout. A path that is already relative is
+    assumed to be relative to the source root and returned unchanged, which
+    is what makes a second merge pass over already-processed files a no-op.
+    """
+    if not uri:
+        return None
+
+    path = uri[len("file://") :] if uri.startswith("file://") else uri
+    if not os.path.isabs(path):
+        # Sanitizer runtimes report their own frames with paths relative to
+        # wherever the toolchain was built, e.g.
+        # "../../../../../src/libsanitizer/asan/asan_malloc_linux.cpp".
+        # Those escape the source root and must not be mistaken for in-tree
+        # paths just because they are not absolute.
+        if os.path.normpath(path).startswith(".."):
+            return None
+        return path
+
+    try:
+        resolved = pathlib.Path(path).resolve()
+    except OSError:
+        return None
+
+    try:
+        return resolved.relative_to(source_root).as_posix()
+    except ValueError:
+        return None
+
+
+def rewrite_location(location, source_root):
+    """Rewrite one SARIF location in place.
+
+    Returns False when the location cannot be reported, either because it
+    lies outside the source root or because it has no physical location at
+    all. Callers must drop what this rejects.
+
+    The second case is not hypothetical: GCC annotates a diagnostic with
+    message-only related locations ("argument 1 of '__builtin_strlen' must be
+    non-null") and with code flow steps carrying nothing but a logical
+    location ("looping back..." against a function name). Both are valid
+    SARIF, and both make code scanning reject the entire upload with
+    "expected physical location".
+    """
+    artifact = location.get("physicalLocation", {}).get("artifactLocation")
+    if artifact is None:
+        return False
+
+    rel = relativize(artifact.get("uri"), source_root)
+    if rel is None:
+        return False
+
+    artifact["uri"] = rel
+    # An absolute uriBaseId would send GitHub looking outside the repository.
+    artifact.pop("uriBaseId", None)
+    return True
+
+
+def prune_code_flows(result, source_root):
+    """Rewrite code flow steps, dropping those outside the source root.
+
+    The execution path is the most useful part of both an analyzer report and
+    a sanitizer stack trace, so it is kept, but steps through code GitHub
+    cannot render are removed. A flow left with no steps is dropped rather
+    than uploaded empty, which SARIF forbids.
+    """
+    kept_flows = []
+    for flow in result.get("codeFlows", []):
+        kept_threads = []
+        for thread in flow.get("threadFlows", []):
+            steps = [
+                step
+                for step in thread.get("locations", [])
+                if rewrite_location(step.get("location", {}), source_root)
+            ]
+            if steps:
+                thread["locations"] = steps
+                kept_threads.append(thread)
+        if kept_threads:
+            flow["threadFlows"] = kept_threads
+            kept_flows.append(flow)
+
+    if kept_flows:
+        result["codeFlows"] = kept_flows
+    else:
+        result.pop("codeFlows", None)
+
+
+def stable_key(*values):
+    """Build a totally ordered key from optional SARIF fields.
+
+    Almost everything in SARIF is optional, so a key assembled from raw field
+    values can mix strings with None and blow up the moment two results are
+    compared -- a rule without a ruleId next to one with it, for instance.
+    Stringifying everything keeps the key usable both for sorting and as a
+    deduplication identity.
+    """
+    return tuple("" if value is None else str(value) for value in values)
+
+
+def count_unreportable(document):
+    """Return how many locations in *document* lack a physical location.
+
+    Code scanning rejects the whole upload when it finds one, so this is
+    checked before writing rather than discovered after a job has already
+    spent an hour building.
+    """
+    bad = 0
+
+    def check(location):
+        nonlocal bad
+        if "physicalLocation" not in location:
+            bad += 1
+
+    for run in document.get("runs", []):
+        for result in run.get("results", []):
+            for location in result.get("locations", []):
+                check(location)
+            for location in result.get("relatedLocations", []):
+                check(location)
+            for flow in result.get("codeFlows", []):
+                for thread in flow.get("threadFlows", []):
+                    for step in thread.get("locations", []):
+                        check(step.get("location", {}))
+    return bad
+
+
+def make_cwe_taxonomy(cwe_ids):
+    """Build the CWE taxonomy block for the given set of CWE ids."""
+    if not cwe_ids:
+        return []
+    return [
+        {
+            "name": "CWE",
+            "organization": "MITRE",
+            "shortDescription": {"text": "The MITRE Common Weakness Enumeration"},
+            "taxa": [{"id": cwe, "helpUri": CWE_HELP.format(cwe)} for cwe in sorted(cwe_ids)],
+        }
+    ]
+
+
+def build_document(driver_name, driver_uri, rules, results, taxonomies):
+    """Assemble a single-run SARIF 2.1.0 document."""
+    return {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": driver_name,
+                        "informationUri": driver_uri,
+                        "rules": rules,
+                    }
+                },
+                "taxonomies": taxonomies,
+                "results": results,
+            }
+        ],
+    }
+
+
+def cap_results(results, max_results):
+    """Trim *results* to *max_results*, returning (results, dropped).
+
+    Callers sort by severity first so that what survives is what matters most.
+    """
+    if len(results) <= max_results:
+        return results, 0
+    return results[:max_results], len(results) - max_results
+
+
+def write_report(document, output, dropped, max_results, stats_line):
+    """Write *document* to *output* and report what happened."""
+    unreportable = count_unreportable(document)
+    if unreportable:
+        # Fail here rather than let the upload be rejected wholesale later.
+        print(
+            f"::error title=Malformed SARIF::{unreportable} locations have no "
+            "physicalLocation; code scanning would reject this upload",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    with open(output, "w", encoding="utf-8") as handle:
+        json.dump(document, handle)
+
+    run = document["runs"][0]
+    print(stats_line)
+    print(
+        f"wrote {len(run['results'])} results and "
+        f"{len(run['tool']['driver']['rules'])} rules to {output}"
+    )
+
+    if dropped:
+        # Surface truncation in the Actions log; a capped report that looks
+        # complete is worse than one that says what it dropped.
+        print(
+            f"::warning title=Results truncated::dropped {dropped} results over the "
+            f"{max_results} cap; the uploaded report is incomplete",
+            file=sys.stderr,
+        )


### PR DESCRIPTION

Scan the codebase using both gcc built-in analyzer and using lsan/asan/ubsan
sanitizers (native_sim), and report the findings to GitHub code scanning.

- **ci: gcc: add static analyzer scan with SARIF upload**
- **ci: sanitizers: report native_sim findings to code scanning**
- **twister: include the handler's stderr in the JSON report**
