### PR TITLE
dts: arm: st: stm32u3: add uart5 node

### DIFF
--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -272,6 +272,15 @@
 			status = "disabled";
 		};
 
+		uart5: serial@40005000 {
+			compatible = "st,stm32-uart";
+			reg = <0x40005000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
+			resets = <&rctl STM32_RESET(APB1L, 20)>;
+			interrupts = <65 0>;
+			status = "disabled";
+		};
+
 		lpuart1: serial@40042400 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40042400 0x400>;


### PR DESCRIPTION
Add UART5 peripheral node to STM32U3 series DTSI.

Source: [RM0487 Reference manual](https://www.st.com/resource/en/reference_manual/rm0487-stm32u3-series-armbased-32bit-mcus-stmicroelectronics.pdf)
UART5 Information
Base address `0x40005000`: p. 115, Section 2.3.2
RCTL`APB1L` bit 20: p. 437, Section 10.5.16
RCC `APB1` bit 20: p. 445, Section 10.5.24
IRQ 65: p. 630, Section 16.3

Verified with `checkpatch.pl` and `west build -p -b nucleo_u385rg_q samples/hello_world`.