### PR TITLE
maintainers: add tmedicci as hal_espressif collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -6749,6 +6749,7 @@ West:
     - LucasTambor
     - marekmatej
     - raffarost
+    - tmedicci
     - wmrsouza
   files:
     - modules/Kconfig.esp32


### PR DESCRIPTION
Add tmedicci to the collaborator list of the hal_espressif west project entry.